### PR TITLE
feat(desktop): simple workspaces without a repository

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -20,6 +20,7 @@ mod providers;
 mod repo;
 mod scripts;
 mod secrets;
+mod session_dir;
 mod sentry;
 mod settings_overrides;
 mod skills;
@@ -114,6 +115,9 @@ pub fn run() {
       bridge::bridge_status,
       bridge::bridge_command_result,
       bridge::bridge_revoke,
+      session_dir::simple_workspace_default_path,
+      session_dir::simple_workspace_prepare,
+      session_dir::session_dir_create,
       worktree::worktree_create,
       worktree::worktree_remove,
       worktree::worktree_list,

--- a/apps/desktop/src-tauri/src/session_dir.rs
+++ b/apps/desktop/src-tauri/src/session_dir.rs
@@ -1,0 +1,136 @@
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum SessionDirError {
+    #[error("home directory is unavailable")]
+    HomeUnavailable,
+    #[error("directory path cannot be empty")]
+    EmptyPath,
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+crate::util::impl_error_serialize!(SessionDirError);
+
+impl SessionDirError {
+    fn kind(&self) -> &'static str {
+        match self {
+            SessionDirError::HomeUnavailable => "home_unavailable",
+            SessionDirError::EmptyPath => "empty_path",
+            SessionDirError::Io(_) => "io",
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateArgs {
+    #[serde(rename = "basePath")]
+    pub base_path: String,
+    pub slug: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CreatedSessionDir {
+    #[serde(rename = "worktreePath")]
+    pub worktree_path: String,
+    #[serde(rename = "branchName")]
+    pub branch_name: String,
+    pub slug: String,
+    pub reused: bool,
+}
+
+fn expand_home(path: &str) -> Result<PathBuf, SessionDirError> {
+    let trimmed = path.trim();
+    if trimmed.is_empty() {
+        return Err(SessionDirError::EmptyPath);
+    }
+    if trimmed == "~" {
+        return dirs::home_dir().ok_or(SessionDirError::HomeUnavailable);
+    }
+    if let Some(rest) = trimmed.strip_prefix("~/") {
+        return Ok(dirs::home_dir()
+            .ok_or(SessionDirError::HomeUnavailable)?
+            .join(rest));
+    }
+    Ok(PathBuf::from(trimmed))
+}
+
+fn absolute_path(path: PathBuf) -> Result<PathBuf, SessionDirError> {
+    if path.is_absolute() {
+        return Ok(path);
+    }
+    Ok(std::env::current_dir()?.join(path))
+}
+
+fn create_absolute_dir(path: PathBuf) -> Result<PathBuf, SessionDirError> {
+    let absolute = absolute_path(path)?;
+    std::fs::create_dir_all(&absolute)?;
+    Ok(std::fs::canonicalize(absolute)?)
+}
+
+#[tauri::command]
+pub fn simple_workspace_default_path(name: String) -> Result<String, SessionDirError> {
+    let home = dirs::home_dir().ok_or(SessionDirError::HomeUnavailable)?;
+    let slug = crate::worktree::sanitize_slug(&name);
+    Ok(home
+        .join("Documents")
+        .join("Goodboy")
+        .join(slug)
+        .to_string_lossy()
+        .into_owned())
+}
+
+#[tauri::command]
+pub fn simple_workspace_prepare(path: String) -> Result<String, SessionDirError> {
+    let resolved = create_absolute_dir(expand_home(&path)?)?;
+    Ok(resolved.to_string_lossy().into_owned())
+}
+
+#[tauri::command]
+pub fn session_dir_create(args: CreateArgs) -> Result<CreatedSessionDir, SessionDirError> {
+    let base = expand_home(&args.base_path)?;
+    let slug = crate::worktree::sanitize_slug(&args.slug);
+    let target = absolute_path(base)?.join("sessions").join(&slug);
+    let reused = target.exists();
+    let resolved = create_absolute_dir(target)?;
+    Ok(CreatedSessionDir {
+        worktree_path: resolved.to_string_lossy().into_owned(),
+        branch_name: String::new(),
+        slug,
+        reused,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::{session_dir_create, CreateArgs};
+
+    #[test]
+    fn creates_and_reuses_a_plain_session_directory() {
+        let root = std::env::temp_dir().join(format!(
+            "goodboy-simple-session-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let args = || CreateArgs {
+            base_path: root.to_string_lossy().into_owned(),
+            slug: "Study Plan".to_string(),
+        };
+        let created = session_dir_create(args()).unwrap();
+        assert_eq!(created.branch_name, "");
+        assert_eq!(created.slug, "study-plan");
+        assert!(!created.reused);
+        assert!(Path::new(&created.worktree_path).is_dir());
+        let reused = session_dir_create(args()).unwrap();
+        assert!(reused.reused);
+        std::fs::remove_dir_all(root).unwrap();
+    }
+}

--- a/apps/desktop/src/features/chat/components/ChatView/index.tsx
+++ b/apps/desktop/src/features/chat/components/ChatView/index.tsx
@@ -112,6 +112,10 @@ export const ChatView = ({ session, isActive = true, header }: Props) => {
   ]);
 
   const worktreePath = useAppStore((s) => (s.sessionWorktrees[session.id] ?? [])[0] ?? null);
+  const isSimple = useAppStore(
+    (s) =>
+      s.workspaces?.find((workspace) => workspace.id === session.workspaceId)?.kind === 'simple',
+  );
   const authResults = useAppStore((s) => s.authResults);
   const refreshProviders = useAppStore((s) => s.refreshProviders);
   const flagOn = useAppStore((s) => s.settings['experimental.enable_parallel_agents'] === 'true');
@@ -197,8 +201,8 @@ export const ChatView = ({ session, isActive = true, header }: Props) => {
   const [mergeDialogOpen, setMergeDialogOpen] = useState(false);
   const [diffJumpFile, setDiffJumpFile] = useState<string | null>(null);
   const diffLoader = useMemo(
-    () => (worktreePath ? () => worktreeDiff(worktreePath) : undefined),
-    [worktreePath],
+    () => (worktreePath && !isSimple ? () => worktreeDiff(worktreePath) : undefined),
+    [isSimple, worktreePath],
   );
 
   const handleOpenDiff = useCallback((filePath: string) => {

--- a/apps/desktop/src/features/onboarding/OnboardingCard/index.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingCard/index.tsx
@@ -37,6 +37,9 @@ export const OnboardingCard = () => {
 };
 
 function ChecklistBody({ progress }: { progress: OnboardingProgress }) {
+  const visibleSteps = progress.isSimple
+    ? ONBOARDING_STEPS.filter((step) => step.id !== 'codeHost' && step.id !== 'tools')
+    : ONBOARDING_STEPS;
   return (
     <>
       <div className="flex items-center justify-between">
@@ -53,7 +56,7 @@ function ChecklistBody({ progress }: { progress: OnboardingProgress }) {
       </div>
       <div className="flex flex-col gap-2.5">
         {GROUP_ORDER.map((group) => {
-          const steps = ONBOARDING_STEPS.filter((s) => s.group === group);
+          const steps = visibleSteps.filter((s) => s.group === group);
           if (steps.length === 0) {
             return null;
           }
@@ -145,6 +148,10 @@ export const OnboardingChip = () => {
     return null;
   }
 
+  const visibleSteps = progress.isSimple
+    ? ONBOARDING_STEPS.filter((step) => step.id !== 'codeHost' && step.id !== 'tools')
+    : ONBOARDING_STEPS;
+
   return (
     <button
       type="button"
@@ -153,7 +160,7 @@ export const OnboardingChip = () => {
       aria-label="open onboarding checklist"
       className="inline-flex shrink-0 items-center gap-1 rounded-md border border-border-soft bg-subtle/60 px-1.5 py-1 motion-safe:transition-colors hover:border-border"
     >
-      {ONBOARDING_STEPS.map((step, i) => (
+      {visibleSteps.map((step, i) => (
         <span
           key={step.id}
           aria-hidden

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/index.test.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/index.test.tsx
@@ -44,6 +44,7 @@ const baseState: OnboardingWizardState = {
   providersConnected: 0,
   hasWorkspace: false,
   workspaceId: null,
+  workspaceKind: null,
   githubConnected: false,
   gitlabConnected: false,
   hasCodeHost: false,
@@ -145,6 +146,22 @@ describe('OnboardingWizard', () => {
       expect(screen.getByTestId('PreferencesStep')).toBeDefined();
       expect(screen.queryByRole('button', { name: /^back$/i })).toBeNull();
       expect(screen.queryByTestId('stepper')).toBeNull();
+    });
+
+    it('jumps from preferences to ready for a simple workspace', () => {
+      setHook({
+        mode: 'setup',
+        hasWorkspace: true,
+        workspaceId: 'simple-workspace' as never,
+        workspaceKind: 'simple',
+      });
+      render(<OnboardingWizard />);
+      expect(screen.getByTestId('PreferencesStep')).toBeDefined();
+      fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+      expect(screen.getByTestId('ReadyStep')).toBeDefined();
+      expect(screen.queryByTestId('CodeHostStep')).toBeNull();
+      expect(screen.queryByTestId('TrackerStep')).toBeNull();
+      expect(screen.queryByTestId('SentryStep')).toBeNull();
     });
   });
 

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/index.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/index.tsx
@@ -15,6 +15,8 @@ import { ReadyStep } from './steps/ReadyStep';
 const STEP_COUNT = 8;
 const SETUP_START_STEP = 3;
 const EXIT_MS = 200;
+const ALL_STEPS = Array.from({ length: STEP_COUNT }, (_, index) => index);
+const SIMPLE_STEPS = [0, 1, 2, 3, 7];
 
 type Cta = {
   readonly label: string;
@@ -30,6 +32,7 @@ export const OnboardingWizard = () => {
     providersConnected,
     hasWorkspace,
     workspaceId,
+    workspaceKind,
     githubConnected,
     gitlabConnected,
     hasCodeHost,
@@ -41,7 +44,12 @@ export const OnboardingWizard = () => {
   const [closing, setClosing] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  const minStep = mode === 'setup' ? SETUP_START_STEP : 0;
+  const isSimple = workspaceKind === 'simple';
+  const availableSteps = isSimple ? SIMPLE_STEPS : ALL_STEPS;
+  const steps = availableSteps.filter((candidate) =>
+    mode === 'setup' ? candidate >= SETUP_START_STEP : true,
+  );
+  const minStep = steps[0] ?? 0;
   const last = STEP_COUNT - 1;
 
   useEffect(() => {
@@ -57,8 +65,16 @@ export const OnboardingWizard = () => {
     return null;
   }
 
-  const goNext = () => setStep((s) => Math.min(s + 1, last));
-  const goBack = () => setStep((s) => Math.max(s - 1, minStep));
+  const goNext = () =>
+    setStep((current) => {
+      const index = steps.indexOf(current);
+      return steps[index + 1] ?? last;
+    });
+  const goBack = () =>
+    setStep((current) => {
+      const index = steps.indexOf(current);
+      return steps[index - 1] ?? minStep;
+    });
   const canSkipSetup = hasWorkspace;
   const dismiss = () => {
     setClosing(true);
@@ -80,7 +96,7 @@ export const OnboardingWizard = () => {
     body = <WorkspaceStep hasWorkspace={hasWorkspace} />;
     cta = { label: 'Continue', onClick: goNext, variant: 'primary', disabled: !hasWorkspace };
   } else if (step === 3) {
-    body = <PreferencesStep workspaceId={workspaceId} />;
+    body = <PreferencesStep workspaceId={workspaceId} workspaceKind={workspaceKind} />;
     cta = { label: 'Continue', onClick: goNext, variant: 'primary' };
   } else if (step === 4) {
     body = (
@@ -133,7 +149,9 @@ export const OnboardingWizard = () => {
       <header className="relative grid min-h-[3.25rem] shrink-0 grid-cols-3 items-center px-6 pt-5">
         <span aria-hidden />
         <div className="flex justify-center">
-          {step > minStep && <Stepper current={step - minStep} total={last - minStep} />}
+          {step > minStep && (
+            <Stepper current={steps.indexOf(step)} total={Math.max(steps.length - 1, 0)} />
+          )}
         </div>
         <div className="flex justify-end">
           {step < last && canSkipSetup && (

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/steps/PreferencesStep.test.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/steps/PreferencesStep.test.tsx
@@ -129,6 +129,13 @@ describe('PreferencesStep', () => {
       fireEvent.blur(input);
       await waitFor(() => expect(input.value).toBe(DEFAULT_BRANCH_PREFIX));
     });
+
+    it('is hidden with repository-specific defaults for simple workspaces', () => {
+      render(<PreferencesStep workspaceId={WS_ID} workspaceKind="simple" />);
+      expect(screen.queryByLabelText(/branch prefix/i)).toBeNull();
+      expect(screen.queryByRole('switch')).toBeNull();
+      expect(state.loadSetting).not.toHaveBeenCalled();
+    });
   });
 
   describe('parallel scouts toggle', () => {

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/steps/PreferencesStep.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/steps/PreferencesStep.tsx
@@ -1,6 +1,12 @@
 import { useEffect, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
-import type { OverrideSettings, ProviderId, VerbosityLevel, WorkspaceId } from '@goodboy/types';
+import type {
+  OverrideSettings,
+  ProviderId,
+  VerbosityLevel,
+  WorkspaceId,
+  WorkspaceKind,
+} from '@goodboy/types';
 import { DEFAULT_SESSION_PROVIDER_PREFERENCE } from '@goodboy/types';
 import { Button, FieldRow, cn } from '@goodboy/ui';
 import { FolderGit2, GitBranch, SlidersHorizontal, Sparkles } from 'lucide-react';
@@ -13,6 +19,7 @@ import { useAppStore } from '../../../../store';
 
 type Props = {
   readonly workspaceId: WorkspaceId | null;
+  readonly workspaceKind?: WorkspaceKind | null;
 };
 
 const PROVIDER_OPTIONS: ReadonlyArray<ProviderId> = ['anthropic', 'cursor', 'codex', 'gemini'];
@@ -24,7 +31,7 @@ const sanitizePrefix = (input: string): string =>
     .replace(/^-+/, '')
     .slice(0, 16);
 
-export const PreferencesStep = ({ workspaceId }: Props) => {
+export const PreferencesStep = ({ workspaceId, workspaceKind = 'repo' }: Props) => {
   return (
     <div className="flex flex-col items-center gap-6 text-center">
       <span className="flex size-14 items-center justify-center rounded-lg border border-border-soft/40 bg-subtle/40 text-primary">
@@ -39,7 +46,11 @@ export const PreferencesStep = ({ workspaceId }: Props) => {
         </p>
       </div>
 
-      {workspaceId === null ? <EmptyState /> : <PreferencesForm workspaceId={workspaceId} />}
+      {workspaceId === null ? (
+        <EmptyState />
+      ) : (
+        <PreferencesForm workspaceId={workspaceId} isSimple={workspaceKind === 'simple'} />
+      )}
     </div>
   );
 };
@@ -62,7 +73,12 @@ const EmptyState = () => (
   </div>
 );
 
-const PreferencesForm = ({ workspaceId }: { workspaceId: WorkspaceId }) => {
+type FormProps = {
+  readonly workspaceId: WorkspaceId;
+  readonly isSimple: boolean;
+};
+
+const PreferencesForm = ({ workspaceId, isSimple }: FormProps) => {
   const loadSetting = useAppStore((s) => s.loadSetting);
   const saveSetting = useAppStore((s) => s.saveSetting);
   const wsOverrides = useAppStore((s) => s.workspaceOverrides[workspaceId] ?? null);
@@ -82,12 +98,15 @@ const PreferencesForm = ({ workspaceId }: { workspaceId: WorkspaceId }) => {
   const scoutFanout = wsOverrides?.scoutFanout ?? false;
 
   useEffect(() => {
+    if (isSimple) {
+      return;
+    }
     void loadSetting(settingBranchPrefix(workspaceId)).then((v) => {
       const value = v ?? DEFAULT_BRANCH_PREFIX;
       setBranchPrefix(value);
       setSavedBranchPrefix(value);
     });
-  }, [workspaceId, loadSetting]);
+  }, [isSimple, workspaceId, loadSetting]);
 
   const persistOverrides = async (
     partial: Partial<
@@ -137,37 +156,39 @@ const PreferencesForm = ({ workspaceId }: { workspaceId: WorkspaceId }) => {
   return (
     <div className="flex w-full flex-col gap-4 text-left">
       <div className="flex flex-col divide-y divide-border-soft/50 rounded-lg border border-border-soft/40 bg-subtle/20 px-4">
-        <FieldRow
-          label="Branch prefix"
-          help="Prefixes every new session branch, e.g. your initials."
-        >
-          <div className="flex items-center gap-1.5">
-            <GitBranch size={13} aria-hidden className="shrink-0 text-muted-foreground" />
-            <input
-              type="text"
-              value={branchPrefix}
-              onChange={(e) => setBranchPrefix(sanitizePrefix(e.target.value))}
-              onBlur={() => void commitBranchPrefix()}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') {
-                  void commitBranchPrefix();
-                }
-              }}
-              placeholder={DEFAULT_BRANCH_PREFIX}
-              disabled={busy}
-              maxLength={16}
-              size={12}
-              aria-label="branch prefix"
-              className={cn(
-                'h-8 rounded-md border border-border bg-background px-2 font-mono text-sm text-foreground motion-safe:transition-colors',
-                'placeholder:text-muted-foreground/40',
-                'hover:border-border-strong focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary',
-                busy && 'cursor-not-allowed opacity-50',
-              )}
-            />
-            <span className="font-mono text-sm text-muted-foreground/40">/&lt;slug&gt;</span>
-          </div>
-        </FieldRow>
+        {!isSimple ? (
+          <FieldRow
+            label="Branch prefix"
+            help="Prefixes every new session branch, e.g. your initials."
+          >
+            <div className="flex items-center gap-1.5">
+              <GitBranch size={13} aria-hidden className="shrink-0 text-muted-foreground" />
+              <input
+                type="text"
+                value={branchPrefix}
+                onChange={(e) => setBranchPrefix(sanitizePrefix(e.target.value))}
+                onBlur={() => void commitBranchPrefix()}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    void commitBranchPrefix();
+                  }
+                }}
+                placeholder={DEFAULT_BRANCH_PREFIX}
+                disabled={busy}
+                maxLength={16}
+                size={12}
+                aria-label="branch prefix"
+                className={cn(
+                  'h-8 rounded-md border border-border bg-background px-2 font-mono text-sm text-foreground motion-safe:transition-colors',
+                  'placeholder:text-muted-foreground/40',
+                  'hover:border-border-strong focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary',
+                  busy && 'cursor-not-allowed opacity-50',
+                )}
+              />
+              <span className="font-mono text-sm text-muted-foreground/40">/&lt;slug&gt;</span>
+            </div>
+          </FieldRow>
+        ) : null}
 
         <FieldRow
           label="Default provider"
@@ -210,17 +231,19 @@ const PreferencesForm = ({ workspaceId }: { workspaceId: WorkspaceId }) => {
           </div>
         </FieldRow>
 
-        <FieldRow
-          label="Parallel scouts"
-          help="Split broad searches across parallel sub-scouts. Much faster on large codebases."
-        >
-          <ToggleSwitch
-            label={scoutFanout ? 'On' : 'Off'}
-            checked={scoutFanout}
-            disabled={busy}
-            onChange={(next) => void persistOverrides({ scoutFanout: next })}
-          />
-        </FieldRow>
+        {!isSimple ? (
+          <FieldRow
+            label="Parallel scouts"
+            help="Split broad searches across parallel sub-scouts. Much faster on large codebases."
+          >
+            <ToggleSwitch
+              label={scoutFanout ? 'On' : 'Off'}
+              checked={scoutFanout}
+              disabled={busy}
+              onChange={(next) => void persistOverrides({ scoutFanout: next })}
+            />
+          </FieldRow>
+        ) : null}
       </div>
 
       {error ? <p className="text-xs text-danger">{error}</p> : null}

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/steps/WelcomeStep.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/steps/WelcomeStep.tsx
@@ -29,7 +29,7 @@ export const WelcomeStep = () => {
         <SetupRow
           icon={<FolderGit2 size={15} className="text-primary" aria-hidden />}
           title="Connect a workspace"
-          detail="A git repo. Every session gets its own worktree and branch."
+          detail="A project space for sessions, agents, workflows, and shared context."
         />
       </div>
     </div>

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/steps/WorkspaceStep.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/steps/WorkspaceStep.tsx
@@ -1,7 +1,11 @@
 import { Check, FolderGit2 } from 'lucide-react';
 import { Button } from '@goodboy/ui';
 
-export const WorkspaceStep = ({ hasWorkspace }: { hasWorkspace: boolean }) => {
+type Props = {
+  readonly hasWorkspace: boolean;
+};
+
+export const WorkspaceStep = ({ hasWorkspace }: Props) => {
   return (
     <div className="flex flex-col items-center gap-6 text-center">
       <span className="flex size-14 items-center justify-center rounded-lg border border-border-soft/40 bg-subtle/40 text-primary">
@@ -13,8 +17,8 @@ export const WorkspaceStep = ({ hasWorkspace }: { hasWorkspace: boolean }) => {
           Connect a workspace
         </h2>
         <p className="mx-auto max-w-md text-sm leading-relaxed text-muted-foreground">
-          Point at a git repo to create your first workspace. Every session gets its own worktree
-          and branch, so your checkout stays clean.
+          Add a repository-backed project, or create a simple project for agents, workflows, and
+          shared context.
         </p>
       </div>
 

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/useOnboardingWizard/index.test.ts
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/useOnboardingWizard/index.test.ts
@@ -7,7 +7,8 @@ import { useOnboardingWizard } from './index';
 let wizardDone = false;
 let hydrated = true;
 const providers: Array<{ connection: ProviderConnectionState }> = [];
-const workspaces: Array<{ id: string }> = [];
+const workspaces: Array<{ id: string; kind?: 'repo' | 'simple' }> = [];
+let currentWorkspaceId: string | null = null;
 let workspaceIntegrations: Record<string, Array<{ provider: string }>> = {};
 
 const { ghStatusMock } = vi.hoisted(() => ({
@@ -28,9 +29,10 @@ vi.mock('../../../../store', () => ({
     selector: (s: {
       providers: typeof providers;
       hydrated: boolean;
+      currentWorkspaceId: string | null;
       workspaceIntegrations: typeof workspaceIntegrations;
     }) => unknown,
-  ) => selector({ providers, hydrated, workspaceIntegrations }),
+  ) => selector({ providers, hydrated, currentWorkspaceId, workspaceIntegrations }),
   useWorkspaces: () => workspaces,
 }));
 
@@ -39,6 +41,7 @@ function reset() {
   hydrated = true;
   providers.length = 0;
   workspaces.length = 0;
+  currentWorkspaceId = null;
   workspaceIntegrations = {};
   ghStatusMock.mockReset();
   ghStatusMock.mockResolvedValue({ scoped: false });
@@ -188,6 +191,14 @@ describe('useOnboardingWizard', () => {
       const { result } = renderHook(() => useOnboardingWizard());
       expect(result.current.workspaceId).toBe('w1');
     });
+
+    it('prefers the active workspace and exposes its kind', () => {
+      workspaces.push({ id: 'w1', kind: 'repo' }, { id: 'w2', kind: 'simple' });
+      currentWorkspaceId = 'w2';
+      const { result } = renderHook(() => useOnboardingWizard());
+      expect(result.current.workspaceId).toBe('w2');
+      expect(result.current.workspaceKind).toBe('simple');
+    });
   });
 
   describe('hasCodeHost', () => {
@@ -221,6 +232,14 @@ describe('useOnboardingWizard', () => {
       const { result } = renderHook(() => useOnboardingWizard());
       await waitFor(() => expect(ghStatusMock).toHaveBeenCalledWith('w1'));
       expect(result.current.hasCodeHost).toBe(false);
+    });
+
+    it('does not query gh status for a simple workspace', () => {
+      workspaces.push({ id: 'w1', kind: 'simple' });
+      const { result } = renderHook(() => useOnboardingWizard());
+      expect(result.current.workspaceKind).toBe('simple');
+      expect(result.current.hasCodeHost).toBe(false);
+      expect(ghStatusMock).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/useOnboardingWizard/index.ts
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/useOnboardingWizard/index.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import type { WorkspaceId } from '@goodboy/types';
+import type { WorkspaceId, WorkspaceKind } from '@goodboy/types';
 import { useAppStore, useWorkspaces } from '../../../../store';
 import { ghStatus } from '../../../github/github';
 import { isWizardDone, OPEN_WIZARD_EVENT, type WizardMode } from '../../onboarding-store';
@@ -10,6 +10,7 @@ export type OnboardingWizardState = {
   readonly providersConnected: number;
   readonly hasWorkspace: boolean;
   readonly workspaceId: WorkspaceId | null;
+  readonly workspaceKind: WorkspaceKind | null;
   readonly githubConnected: boolean;
   readonly gitlabConnected: boolean;
   readonly hasCodeHost: boolean;
@@ -22,8 +23,13 @@ export const useOnboardingWizard = (): OnboardingWizardState => {
   const providersConnected = useAppStore(
     (s) => s.providers.filter((p) => p.connection === 'connected').length,
   );
-  const workspaceId = useWorkspaces()[0]?.id ?? null;
-  const hasWorkspace = useWorkspaces().length > 0;
+  const workspaces = useWorkspaces();
+  const currentWorkspaceId = useAppStore((s) => s.currentWorkspaceId);
+  const workspace =
+    workspaces.find((candidate) => candidate.id === currentWorkspaceId) ?? workspaces[0] ?? null;
+  const workspaceId = workspace?.id ?? null;
+  const workspaceKind = workspace?.kind ?? null;
+  const hasWorkspace = workspaces.length > 0;
   const hydrated = useAppStore((s) => s.hydrated);
 
   const gitlabConnected = useAppStore((s) =>
@@ -44,14 +50,14 @@ export const useOnboardingWizard = (): OnboardingWizardState => {
 
   const [githubScoped, setGithubScoped] = useState(false);
   const refreshGithubStatus = useCallback(() => {
-    if (!workspaceId) {
+    if (!workspaceId || workspaceKind === 'simple') {
       setGithubScoped(false);
       return;
     }
     void ghStatus(workspaceId)
       .then((status) => setGithubScoped(status.scoped ?? false))
       .catch(() => setGithubScoped(false));
-  }, [workspaceId]);
+  }, [workspaceId, workspaceKind]);
 
   useEffect(() => {
     refreshGithubStatus();
@@ -107,6 +113,7 @@ export const useOnboardingWizard = (): OnboardingWizardState => {
     providersConnected,
     hasWorkspace,
     workspaceId,
+    workspaceKind,
     githubConnected: githubScoped,
     gitlabConnected,
     hasCodeHost,

--- a/apps/desktop/src/features/onboarding/hooks/useOnboardingProgress/index.test.ts
+++ b/apps/desktop/src/features/onboarding/hooks/useOnboardingProgress/index.test.ts
@@ -3,7 +3,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { OnboardingStepId } from '../../onboarding-store';
 
 let completed: Array<OnboardingStepId> = [];
-const workspaces: Array<{ id: string }> = [];
+const workspaces: Array<{ id: string; kind?: 'repo' | 'simple' }> = [];
+let currentWorkspaceId: string | null = null;
 let workspaceIntegrations: Record<string, Array<{ provider: string }>> = {};
 let sessions: Array<unknown> = [];
 
@@ -13,7 +14,15 @@ const { markStepCompleteMock, ghStatusMock } = vi.hoisted(() => ({
 }));
 
 vi.mock('../../onboarding-store', () => ({
-  ONBOARDING_STEPS: new Array(7).fill({ id: 'x', title: 'x', why: 'x' }),
+  ONBOARDING_STEPS: [
+    { id: 'workspace', title: 'x', why: 'x' },
+    { id: 'codeHost', title: 'x', why: 'x' },
+    { id: 'tools', title: 'x', why: 'x' },
+    { id: 'session', title: 'x', why: 'x' },
+    { id: 'agent', title: 'x', why: 'x' },
+    { id: 'plan', title: 'x', why: 'x' },
+    { id: 'palette', title: 'x', why: 'x' },
+  ],
   getCompleted: () => completed,
   isCollapsed: () => false,
   isFinished: () => false,
@@ -30,6 +39,7 @@ vi.mock('../../../../store', () => ({
       sessions: typeof sessions;
       sessionPhaseRuns: Record<string, unknown[]>;
       sessionPlans: Record<string, unknown[]>;
+      currentWorkspaceId: string | null;
       workspaceIntegrations: typeof workspaceIntegrations;
     }) => unknown,
   ) =>
@@ -37,6 +47,7 @@ vi.mock('../../../../store', () => ({
       sessions,
       sessionPhaseRuns: {},
       sessionPlans: {},
+      currentWorkspaceId,
       workspaceIntegrations,
     }),
   useCurrentSession: () => null,
@@ -46,6 +57,7 @@ vi.mock('../../../../store', () => ({
 function reset() {
   completed = [];
   workspaces.length = 0;
+  currentWorkspaceId = null;
   workspaceIntegrations = {};
   sessions = [];
   markStepCompleteMock.mockReset();
@@ -109,5 +121,16 @@ describe('useOnboardingProgress auto-mark', () => {
     expect(result.current.completedCount).toBe(2);
     expect(result.current.totalCount).toBe(7);
     expect(result.current.isDone).toBe(false);
+  });
+
+  it('removes integration steps from progress for a simple workspace', () => {
+    completed = ['workspace', 'session', 'agent', 'plan', 'palette'];
+    workspaces.push({ id: 'w1', kind: 'simple' });
+    const { result } = renderHook(() => useOnboardingProgress());
+    expect(result.current.isSimple).toBe(true);
+    expect(result.current.completedCount).toBe(5);
+    expect(result.current.totalCount).toBe(5);
+    expect(result.current.isDone).toBe(true);
+    expect(ghStatusMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/features/onboarding/hooks/useOnboardingProgress/index.ts
+++ b/apps/desktop/src/features/onboarding/hooks/useOnboardingProgress/index.ts
@@ -17,6 +17,7 @@ export type OnboardingProgress = {
   readonly collapsed: boolean;
   readonly finished: boolean;
   readonly isDone: boolean;
+  readonly isSimple: boolean;
 };
 
 export const useOnboardingProgress = (): OnboardingProgress => {
@@ -32,6 +33,10 @@ export const useOnboardingProgress = (): OnboardingProgress => {
   const finished = useMemo(() => isFinished(), [tick]);
 
   const workspaces = useWorkspaces();
+  const currentWorkspaceId = useAppStore((s) => s.currentWorkspaceId);
+  const workspace =
+    workspaces.find((candidate) => candidate.id === currentWorkspaceId) ?? workspaces[0] ?? null;
+  const isSimple = workspace?.kind === 'simple';
   const sessionCount = useAppStore((s) => s.sessions.length);
   const needsAgentDetect = !persistedCompleted.has('agent');
   const needsPlanDetect = !persistedCompleted.has('plan');
@@ -59,9 +64,8 @@ export const useOnboardingProgress = (): OnboardingProgress => {
   });
   const currentSession = useCurrentSession();
 
-  const workspaceId = workspaces[0]?.id ?? null;
-  const needsCodeHostDetect = !persistedCompleted.has('codeHost');
-  const needsToolsDetect = !persistedCompleted.has('tools');
+  const workspaceId = workspace?.id ?? null;
+  const needsCodeHostDetect = !isSimple && !persistedCompleted.has('codeHost');
   const gitlabConnected = useAppStore((s) =>
     workspaceId
       ? (s.workspaceIntegrations[workspaceId] ?? []).some((i) => i.provider === 'gitlab')
@@ -92,10 +96,10 @@ export const useOnboardingProgress = (): OnboardingProgress => {
     if (workspaces.length > 0 && !persistedCompleted.has('workspace')) {
       markStepComplete('workspace');
     }
-    if ((gitlabConnected || githubScoped) && !persistedCompleted.has('codeHost')) {
+    if (!isSimple && (gitlabConnected || githubScoped) && !persistedCompleted.has('codeHost')) {
       markStepComplete('codeHost');
     }
-    if (hasTools && !persistedCompleted.has('tools')) {
+    if (!isSimple && hasTools && !persistedCompleted.has('tools')) {
       markStepComplete('tools');
     }
     if (sessionCount > 0 && !persistedCompleted.has('session')) {
@@ -115,12 +119,16 @@ export const useOnboardingProgress = (): OnboardingProgress => {
     gitlabConnected,
     githubScoped,
     hasTools,
+    isSimple,
     persistedCompleted,
     currentSession,
   ]);
 
-  const totalCount = ONBOARDING_STEPS.length;
-  const completedCount = persistedCompleted.size;
+  const visibleSteps = isSimple
+    ? ONBOARDING_STEPS.filter((step) => step.id !== 'codeHost' && step.id !== 'tools')
+    : ONBOARDING_STEPS;
+  const totalCount = visibleSteps.length;
+  const completedCount = visibleSteps.filter((step) => persistedCompleted.has(step.id)).length;
 
   return {
     completedCount,
@@ -129,5 +137,6 @@ export const useOnboardingProgress = (): OnboardingProgress => {
     collapsed,
     finished,
     isDone: completedCount >= totalCount,
+    isSimple,
   };
 };

--- a/apps/desktop/src/features/onboarding/onboarding-store.ts
+++ b/apps/desktop/src/features/onboarding/onboarding-store.ts
@@ -21,7 +21,7 @@ export const ONBOARDING_STEPS: ReadonlyArray<{
   {
     id: 'workspace',
     title: 'Connect a workspace',
-    why: 'Point Goodboy at a git repo, every session worktree lives off it.',
+    why: 'Create a project space for sessions, agents, workflows, and shared context.',
     group: 'setup',
   },
   {
@@ -39,7 +39,7 @@ export const ONBOARDING_STEPS: ReadonlyArray<{
   {
     id: 'session',
     title: 'Create your first session',
-    why: 'A session = one goal on its own worktree + branch. Pick something concrete.',
+    why: 'A session focuses agents and shared context on one concrete goal.',
     group: 'build',
   },
   {

--- a/apps/desktop/src/features/orchestration/hooks/useWorkspaceRuns/index.ts
+++ b/apps/desktop/src/features/orchestration/hooks/useWorkspaceRuns/index.ts
@@ -196,6 +196,8 @@ export const useWorkspaceRuns = (
   const stageBySession = useAppStore(
     useShallow((s) => {
       const out: Record<string, SessionStage> = {};
+      const workspaceKind =
+        s.workspaces?.find((workspace) => workspace.id === workspaceId)?.kind ?? 'repo';
       for (const session of sessions) {
         if (session.workspaceId !== workspaceId) {
           continue;
@@ -218,6 +220,7 @@ export const useWorkspaceRuns = (
           openQuestionCount,
           hasRunningAgent,
           isPrReview: isPrReviewSession({ agents: runs ?? [] }),
+          workspaceKind,
         }).stage;
       }
       return out;

--- a/apps/desktop/src/features/session/components/NewSessionView/index.test.tsx
+++ b/apps/desktop/src/features/session/components/NewSessionView/index.test.tsx
@@ -1,12 +1,19 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { WorkspaceId, WorkspaceIntegration } from '@goodboy/types';
 
 const h = vi.hoisted(() => ({
   remoteKind: 'github' as string | null,
+  listLocalBranches: vi.fn(async () => []),
   store: {
     providers: [{ id: 'anthropic', connection: 'connected' }],
-    workspaces: [{ id: 'workspace-1', rootPath: '/repo' }],
+    workspaces: [
+      {
+        id: 'workspace-1',
+        rootPath: '/repo',
+        kind: 'repo' as 'repo' | 'simple',
+      },
+    ],
     workspaceOverrides: {},
     workspaceIntegrations: {} as Record<string, ReadonlyArray<WorkspaceIntegration>>,
     sessionBranches: {},
@@ -34,7 +41,7 @@ vi.mock('../../../../features/worktree/useBranchConflict', () => ({
 }));
 
 vi.mock('../../../../features/worktree/worktree', () => ({
-  listLocalBranches: vi.fn(async () => []),
+  listLocalBranches: h.listLocalBranches,
   removeWorktree: vi.fn(),
 }));
 
@@ -58,7 +65,10 @@ const integration = (provider: 'linear' | 'sentry' | 'gitlab'): WorkspaceIntegra
 
 beforeEach(() => {
   h.remoteKind = 'github';
+  h.store.workspaces[0]!.kind = 'repo';
   h.store.workspaceIntegrations = {};
+  h.store.createSession.mockReset();
+  h.listLocalBranches.mockClear();
 });
 
 afterEach(cleanup);
@@ -88,5 +98,30 @@ describe('NewSessionView issue sources', () => {
     );
 
     expect(screen.queryByText('Start from an issue')).toBeNull();
+  });
+
+  it('hides issue and branch controls and creates without branch fields for simple workspaces', async () => {
+    h.store.workspaces[0]!.kind = 'simple';
+    h.store.workspaceIntegrations = {
+      [WORKSPACE_ID]: [integration('linear'), integration('sentry')],
+    };
+    render(
+      <NewSessionView onClose={vi.fn()} workspaceId={WORKSPACE_ID} onOpenSettings={vi.fn()} />,
+    );
+
+    expect(screen.queryByText('Start from an issue')).toBeNull();
+    expect(screen.queryByText('Branch')).toBeNull();
+    expect(screen.queryByLabelText('Branch slug')).toBeNull();
+    expect(h.listLocalBranches).not.toHaveBeenCalled();
+
+    fireEvent.change(screen.getByPlaceholderText(/prepare a study plan/i), {
+      target: { value: 'Prepare for the exam' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Create session' }));
+    await waitFor(() => expect(h.store.createSession).toHaveBeenCalledOnce());
+    const input = h.store.createSession.mock.calls[0]?.[0];
+    expect(input).not.toHaveProperty('branchPrefix');
+    expect(input).not.toHaveProperty('branchSlug');
+    expect(input).not.toHaveProperty('existingBranch');
   });
 });

--- a/apps/desktop/src/features/session/components/NewSessionView/index.tsx
+++ b/apps/desktop/src/features/session/components/NewSessionView/index.tsx
@@ -103,6 +103,7 @@ export const NewSessionView = ({ onClose, workspaceId, onOpenSettings }: Props) 
   const { showToast } = useToast();
   const settingKey = settingBranchPrefix(workspaceId);
   const workspace = useAppStore((s) => s.workspaces.find((w) => w.id === workspaceId));
+  const isSimple = workspace?.kind === 'simple';
   const workspaceOverrides = useAppStore((s) => s.workspaceOverrides?.[workspaceId] ?? null);
 
   const [goal, setGoal] = useState('');
@@ -133,10 +134,12 @@ export const NewSessionView = ({ onClose, workspaceId, onOpenSettings }: Props) 
     useShallow((s) => s.workspaceIntegrations?.[workspaceId] ?? EMPTY_INTEGRATIONS),
   );
   const remoteKind = useRemoteHostKind(workspaceId);
-  const issueSources = resolveIssueSources({
-    integrations: workspaceIntegrations,
-    remoteKind,
-  });
+  const issueSources = isSimple
+    ? []
+    : resolveIssueSources({
+        integrations: workspaceIntegrations,
+        remoteKind,
+      });
 
   const connectedProviders = providers.filter((p) => p.connection === 'connected');
   const noProviderConnected = providers.length > 0 && connectedProviders.length === 0;
@@ -148,10 +151,13 @@ export const NewSessionView = ({ onClose, workspaceId, onOpenSettings }: Props) 
       : pickDefaultProvider(connectedProviderIds);
 
   useEffect(() => {
+    if (isSimple) {
+      return;
+    }
     void loadSetting(settingKey).then((value) => {
       setBranchPrefix(value ?? DEFAULT_BRANCH_PREFIX);
     });
-  }, [settingKey, loadSetting]);
+  }, [isSimple, settingKey, loadSetting]);
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -177,7 +183,7 @@ export const NewSessionView = ({ onClose, workspaceId, onOpenSettings }: Props) 
   }, [workspaceId]);
 
   useEffect(() => {
-    if (branchMode !== 'existing' || branchesLoaded || !workspace?.rootPath) {
+    if (isSimple || branchMode !== 'existing' || branchesLoaded || !workspace?.rootPath) {
       return;
     }
     setBranchesLoading(true);
@@ -188,7 +194,7 @@ export const NewSessionView = ({ onClose, workspaceId, onOpenSettings }: Props) 
         setBranchesLoading(false);
         setBranchesLoaded(true);
       });
-  }, [branchMode, branchesLoaded, workspace?.rootPath]);
+  }, [branchMode, branchesLoaded, isSimple, workspace?.rootPath]);
 
   useEffect(() => {
     if (slugTouched) {
@@ -234,14 +240,15 @@ export const NewSessionView = ({ onClose, workspaceId, onOpenSettings }: Props) 
   };
 
   const conflict = useBranchConflict(
-    branchMode === 'existing' ? existingBranch.trim() || null : null,
+    !isSimple && branchMode === 'existing' ? existingBranch.trim() || null : null,
     workspace?.rootPath ?? null,
   );
   const conflictSessionId = conflict?.kind === 'session' ? conflict.sessionId : null;
   const conflictWorktreePath = conflict?.kind === 'worktree' ? conflict.path : null;
 
   const branchReady =
-    branchMode === 'new' ? isValidBranchSlug(branchSlug) : existingBranch.trim().length > 0;
+    isSimple ||
+    (branchMode === 'new' ? isValidBranchSlug(branchSlug) : existingBranch.trim().length > 0);
   const goalReady = goal.trim().length > 0;
   const canCreate =
     goalReady &&
@@ -260,15 +267,20 @@ export const NewSessionView = ({ onClose, workspaceId, onOpenSettings }: Props) 
     setError(null);
     setBusy(true);
     try {
-      if (eraseWorktreePath && workspace?.rootPath) {
+      if (!isSimple && eraseWorktreePath && workspace?.rootPath) {
         await removeWorktree(workspace.rootPath, eraseWorktreePath);
       }
-      const useExisting = branchMode === 'existing' && existingBranch.trim().length > 0;
+      const useExisting =
+        !isSimple && branchMode === 'existing' && existingBranch.trim().length > 0;
       await createSession({
         workspaceId,
         goal,
-        branchPrefix: sanitizePrefix(branchPrefix).trim() || DEFAULT_BRANCH_PREFIX,
-        branchSlug: branchSlug.trim() || undefined,
+        ...(!isSimple
+          ? {
+              branchPrefix: sanitizePrefix(branchPrefix).trim() || DEFAULT_BRANCH_PREFIX,
+              branchSlug: branchSlug.trim() || undefined,
+            }
+          : {}),
         ...(useExisting ? { existingBranch: existingBranch.trim() } : {}),
         ...(issue
           ? {
@@ -327,7 +339,7 @@ export const NewSessionView = ({ onClose, workspaceId, onOpenSettings }: Props) 
                 </div>
               </div>
             ) : null}
-            {issueSources.length > 0 ? (
+            {!isSimple && issueSources.length > 0 ? (
               <Section
                 icon={<Inbox size={14} aria-hidden className="text-primary" />}
                 tone="primary"
@@ -353,7 +365,11 @@ export const NewSessionView = ({ onClose, workspaceId, onOpenSettings }: Props) 
             >
               <Textarea
                 value={goal}
-                placeholder="Refactor auth domain to extract token validation into a shared module…"
+                placeholder={
+                  isSimple
+                    ? 'Prepare a study plan for next week’s exam…'
+                    : 'Refactor auth domain to extract token validation into a shared module…'
+                }
                 onChange={(e) => setGoal(e.target.value)}
                 autoGrow
                 minRows={4}
@@ -411,85 +427,87 @@ export const NewSessionView = ({ onClose, workspaceId, onOpenSettings }: Props) 
               </div>
             </Section>
 
-            <Section
-              icon={<GitBranch size={14} aria-hidden className="text-success" />}
-              tone="success"
-              title="Branch"
-              subtitle="Each session lives on its own git worktree. Pick a fresh branch or attach to an existing one."
-            >
-              <div className="flex flex-col gap-2">
-                <BranchModeToggle mode={branchMode} onChange={setBranchMode} disabled={busy} />
-                {branchMode === 'new' ? (
-                  <div className="flex items-center gap-1.5">
-                    <span className="shrink-0 text-xs text-muted-foreground font-mono">
-                      {(sanitizePrefix(branchPrefix) || DEFAULT_BRANCH_PREFIX) + '/'}
-                    </span>
-                    {slugGenerating ? (
-                      <Skeleton className="h-8 flex-1 rounded border border-border" />
-                    ) : (
-                      <Input
-                        value={branchSlug}
-                        onChange={(e) => {
-                          setBranchSlug(sanitizeBranchSlug(e.target.value));
-                          setSlugTouched(true);
-                        }}
-                        placeholder="branch-slug"
-                        className="h-8 flex-1 font-mono text-sm"
-                        disabled={busy}
-                        autoCapitalize="off"
-                        autoCorrect="off"
-                        spellCheck={false}
-                        aria-label="Branch slug"
-                      />
-                    )}
-                    <button
-                      type="button"
-                      onClick={handleGenerateSlug}
-                      disabled={!goal.trim() || slugGenerating || busy}
-                      title="Generate from goal"
-                      aria-label="Generate branch name"
-                      className={cn(
-                        'shrink-0 rounded-md border border-border px-2 py-1.5 text-xs transition-colors',
-                        goal.trim() && !slugGenerating && !busy
-                          ? 'text-muted-foreground hover:bg-muted hover:text-foreground'
-                          : 'cursor-not-allowed text-muted-foreground/30',
+            {!isSimple ? (
+              <Section
+                icon={<GitBranch size={14} aria-hidden className="text-success" />}
+                tone="success"
+                title="Branch"
+                subtitle="Each session lives on its own git worktree. Pick a fresh branch or attach to an existing one."
+              >
+                <div className="flex flex-col gap-2">
+                  <BranchModeToggle mode={branchMode} onChange={setBranchMode} disabled={busy} />
+                  {branchMode === 'new' ? (
+                    <div className="flex items-center gap-1.5">
+                      <span className="shrink-0 text-xs text-muted-foreground font-mono">
+                        {(sanitizePrefix(branchPrefix) || DEFAULT_BRANCH_PREFIX) + '/'}
+                      </span>
+                      {slugGenerating ? (
+                        <Skeleton className="h-8 flex-1 rounded border border-border" />
+                      ) : (
+                        <Input
+                          value={branchSlug}
+                          onChange={(e) => {
+                            setBranchSlug(sanitizeBranchSlug(e.target.value));
+                            setSlugTouched(true);
+                          }}
+                          placeholder="branch-slug"
+                          className="h-8 flex-1 font-mono text-sm"
+                          disabled={busy}
+                          autoCapitalize="off"
+                          autoCorrect="off"
+                          spellCheck={false}
+                          aria-label="Branch slug"
+                        />
                       )}
-                    >
-                      <Wand2 size={13} aria-hidden />
-                    </button>
-                  </div>
-                ) : (
-                  <div className="flex flex-col gap-1.5">
-                    <BranchCombobox
-                      branches={existingBranches}
-                      value={existingBranch}
-                      onChange={setExistingBranch}
-                      disabled={busy || branchesLoading}
-                      loading={branchesLoading}
-                    />
-                    {conflictSessionId ? (
-                      <p className="text-2xs leading-relaxed text-muted-foreground">
-                        This branch is already used by an open session. Open it instead of creating
-                        a duplicate.
-                      </p>
-                    ) : conflictWorktreePath ? (
-                      <p className="flex items-start gap-1.5 text-2xs leading-relaxed text-warning">
-                        <AlertTriangle size={12} aria-hidden className="mt-0.5 shrink-0" />
-                        <span>
-                          Checked out in another worktree (
-                          <span className="break-all font-mono">{conflictWorktreePath}</span>).
-                          Creating erases that worktree and recreates it here.
-                        </span>
-                      </p>
-                    ) : null}
-                  </div>
-                )}
-              </div>
-            </Section>
+                      <button
+                        type="button"
+                        onClick={handleGenerateSlug}
+                        disabled={!goal.trim() || slugGenerating || busy}
+                        title="Generate from goal"
+                        aria-label="Generate branch name"
+                        className={cn(
+                          'shrink-0 rounded-md border border-border px-2 py-1.5 text-xs transition-colors',
+                          goal.trim() && !slugGenerating && !busy
+                            ? 'text-muted-foreground hover:bg-muted hover:text-foreground'
+                            : 'cursor-not-allowed text-muted-foreground/30',
+                        )}
+                      >
+                        <Wand2 size={13} aria-hidden />
+                      </button>
+                    </div>
+                  ) : (
+                    <div className="flex flex-col gap-1.5">
+                      <BranchCombobox
+                        branches={existingBranches}
+                        value={existingBranch}
+                        onChange={setExistingBranch}
+                        disabled={busy || branchesLoading}
+                        loading={branchesLoading}
+                      />
+                      {conflictSessionId ? (
+                        <p className="text-2xs leading-relaxed text-muted-foreground">
+                          This branch is already used by an open session. Open it instead of
+                          creating a duplicate.
+                        </p>
+                      ) : conflictWorktreePath ? (
+                        <p className="flex items-start gap-1.5 text-2xs leading-relaxed text-warning">
+                          <AlertTriangle size={12} aria-hidden className="mt-0.5 shrink-0" />
+                          <span>
+                            Checked out in another worktree (
+                            <span className="break-all font-mono">{conflictWorktreePath}</span>).
+                            Creating erases that worktree and recreates it here.
+                          </span>
+                        </p>
+                      ) : null}
+                    </div>
+                  )}
+                </div>
+              </Section>
+            ) : null}
           </div>
         </ScrollFade>
 
-        {error && isMissingBaseRefError(error) ? (
+        {!isSimple && error && isMissingBaseRefError(error) ? (
           <div className="px-6 pb-2">
             <BaseBranchGuide />
           </div>

--- a/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
@@ -58,6 +58,16 @@ const LENS_LABEL: Record<LensKind, string> = {
   gitlab_issues: 'GitLab issues',
 };
 
+const SIMPLE_LENSES = new Set<LensKind>([
+  'workflows',
+  'agents',
+  'questions',
+  'plans',
+  'goal',
+  'decisions',
+  'last_output_summary',
+]);
+
 type SessionWorkspaceProps = {
   readonly session: Session;
   readonly isActive: boolean;
@@ -68,7 +78,15 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
   const [inspectedResolverId, setInspectedResolverId] = useState<AgentId | null>(null);
   const [inspectedAgentId, setInspectedAgentId] = useState<AgentId | null>(null);
   const hasInitializedResolverInspector = useRef(false);
-  const activeLens = useAppStore((s) => s.activeLens[sessionId]);
+  const storedActiveLens = useAppStore((s) => s.activeLens[sessionId]);
+  const workspaceKind = useAppStore(
+    (s) => s.workspaces?.find((workspace) => workspace.id === session.workspaceId)?.kind ?? 'repo',
+  );
+  const isSimple = workspaceKind === 'simple';
+  const activeLens =
+    isSimple && storedActiveLens != null && !SIMPLE_LENSES.has(storedActiveLens)
+      ? null
+      : storedActiveLens;
   const setActiveLens = useAppStore((s) => s.setActiveLens);
   const focusedPlanId = useAppStore((s) => s.focusedPlanId[sessionId] ?? null);
   const selectedAgentId = useAppStore(
@@ -81,7 +99,7 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
   const setFocusedWorkflowRun = useAppStore((s) => s.setFocusedWorkflowRun);
   const setFocusedPlanId = useAppStore((s) => s.setFocusedPlanId);
   const reconcileSessionBranch = useAppStore((s) => s.reconcileSessionBranch);
-  const filesTouched = useFilesTouched(sessionId, isActive);
+  const filesTouched = useFilesTouched(sessionId, isActive && !isSimple);
   const phaseRuns = useAppStore(
     (s) => s.sessionPhaseRuns[sessionId] ?? (EMPTY_ARRAY as ReadonlyArray<Agent>),
   );
@@ -97,7 +115,7 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
   }, [activeLens, sessionId, setActiveLens]);
 
   useEffect(() => {
-    if (!isActive || !workingDir) return;
+    if (!isActive || !workingDir || isSimple) return;
     let cancelled = false;
     worktreeStatus(workingDir)
       .then((status) => {
@@ -109,7 +127,7 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
     return () => {
       cancelled = true;
     };
-  }, [isActive, workingDir, sessionId, filesTouched.count, reconcileSessionBranch]);
+  }, [isActive, workingDir, sessionId, filesTouched.count, isSimple, reconcileSessionBranch]);
 
   const lens: LensKind | null = activeLens ?? null;
   const isOverviewLoading = sessionLoading?.agents === true || sessionLoading?.plans === true;
@@ -278,6 +296,7 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
             onSelectOverview={onSelectOverview}
             onSelect={onSelectLens}
             filesCount={filesTouched.count}
+            workspaceKind={workspaceKind}
           />
         </div>
         <Divider orientation="vertical" />
@@ -381,18 +400,20 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
               />
             ) : null}
 
-            <div
-              className={cn(
-                'absolute inset-0 z-10 flex flex-col',
-                !(lens === 'terminal' && showLens) && 'invisible pointer-events-none',
-              )}
-            >
-              <TerminalDock
-                sessionId={sessionId}
-                isActive={isActive && lens === 'terminal' && showLens}
-                cwd={workingDir}
-              />
-            </div>
+            {!isSimple ? (
+              <div
+                className={cn(
+                  'absolute inset-0 z-10 flex flex-col',
+                  !(lens === 'terminal' && showLens) && 'invisible pointer-events-none',
+                )}
+              >
+                <TerminalDock
+                  sessionId={sessionId}
+                  isActive={isActive && lens === 'terminal' && showLens}
+                  cwd={workingDir}
+                />
+              </div>
+            ) : null}
 
             {studio != null ? (
               <div className="absolute inset-0 z-30">

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn.test.tsx
@@ -168,6 +168,43 @@ describe('LensColumn', () => {
     ]);
   });
 
+  it('renders only shared-context lenses for a simple workspace', () => {
+    render(
+      <LensColumn
+        session={SESSION}
+        activeLens={null}
+        onSelectOverview={vi.fn()}
+        onSelect={vi.fn()}
+        filesCount={3}
+        workspaceKind="simple"
+      />,
+    );
+
+    expect(
+      screen.getAllByText(/^(Work|Artifacts|Context)$/).map((heading) => heading.textContent),
+    ).toEqual(['Work', 'Artifacts', 'Context']);
+    expect(
+      screen.getAllByRole('button').map((button) => {
+        const clone = button.cloneNode(true) as HTMLElement;
+        clone.querySelectorAll('[aria-hidden="true"]').forEach((node) => node.remove());
+        const shortcut = clone.querySelector('kbd')?.textContent ?? '';
+        return clone.textContent?.replace(shortcut, '').trim();
+      }),
+    ).toEqual([
+      'Overview',
+      'Workflows',
+      'Agents',
+      'Questions',
+      'Plans',
+      'Goal',
+      'Decisions',
+      'Session summary',
+    ]);
+    expect(screen.queryByText('Integrations')).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Diff 3' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Terminal' })).toBeNull();
+  });
+
   it('shows shortcuts on bound rows only', () => {
     render(
       <LensColumn

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn.tsx
@@ -17,7 +17,7 @@ import {
 } from 'lucide-react';
 import { IconTile, KbdPill, ScrollFade, Skeleton, StatusDot, cn } from '@goodboy/ui';
 import type { Tone } from '@goodboy/ui';
-import type { Agent, Session, SessionId } from '@goodboy/types';
+import type { Agent, Session, SessionId, WorkspaceKind } from '@goodboy/types';
 import { classifyAgent, isStandaloneAgent } from '../../../../session/agent-kind';
 import { isPrReviewSession } from '../../../../../store/slices/session-view';
 import {
@@ -46,6 +46,7 @@ type LensColumnProps = {
   readonly onSelectOverview: () => void;
   readonly onSelect: (lens: LensKind) => void;
   readonly filesCount: number;
+  readonly workspaceKind?: WorkspaceKind;
 };
 
 type LensRow = {
@@ -90,6 +91,7 @@ export const LensColumn = ({
   onSelectOverview,
   onSelect,
   filesCount,
+  workspaceKind = 'repo',
 }: LensColumnProps) => {
   const sessionId = session.id as SessionId;
   const loading = useAppStore((s) => s.sessionLoading[sessionId]);
@@ -250,7 +252,7 @@ export const LensColumn = ({
       : []),
   ];
 
-  const groups: ReadonlyArray<LensGroup> = [
+  const repoGroups: ReadonlyArray<LensGroup> = [
     {
       label: 'Work',
       rows: [
@@ -361,6 +363,78 @@ export const LensColumn = ({
       ],
     },
   ];
+  const simpleGroups: ReadonlyArray<LensGroup> = [
+    {
+      label: 'Work',
+      rows: [
+        {
+          kind: 'workflows',
+          label: 'Workflows',
+          icon: Layers,
+          tone: 'accent',
+          count: activeWorkflows,
+          dot:
+            attentionLens === 'workflows' || unreadLens === 'workflows' ? 'attention' : undefined,
+        },
+        {
+          kind: 'agents',
+          label: 'Agents',
+          icon: Bot,
+          tone: 'primary',
+          count: activeNonResolverStandalone.length,
+          isCountLoading: areAgentsLoading,
+          dot:
+            attentionLens === 'agents' || unreadLens === 'agents'
+              ? 'attention'
+              : hasRunningAgent
+                ? 'running'
+                : undefined,
+        },
+        {
+          kind: 'questions',
+          label: 'Questions',
+          icon: CircleHelp,
+          tone: 'warning',
+          count: openCount,
+          isCountLoading: areQuestionsLoading,
+        },
+      ],
+    },
+    {
+      label: 'Artifacts',
+      rows: [
+        {
+          kind: 'plans',
+          label: 'Plans',
+          icon: FileText,
+          tone: 'success',
+          count: activePlans,
+          isCountLoading: arePlansLoading,
+        },
+      ],
+    },
+    {
+      label: 'Context',
+      rows: [
+        { kind: 'goal', label: 'Goal', icon: Target, tone: 'primary', dot: summarizerDot },
+        {
+          kind: 'decisions',
+          label: 'Decisions',
+          icon: CheckCheck,
+          tone: 'success',
+          dot: summarizerDot,
+        },
+        {
+          kind: 'last_output_summary',
+          label: 'Session summary',
+          icon: Activity,
+          tone: 'info',
+          dot: summarizerDot,
+        },
+      ],
+    },
+  ];
+  const groups = workspaceKind === 'simple' ? simpleGroups : repoGroups;
 
   return (
     <ScrollFade className="min-h-0 flex-1">

--- a/apps/desktop/src/features/workspace/components/WorkspaceLinkDialog/index.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspaceLinkDialog/index.test.tsx
@@ -6,6 +6,8 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 const { state, validateMock } = vi.hoisted(() => ({
   state: {
     addWorkspace: vi.fn(async () => ({ id: 'ws-new' })),
+    addCompositeWorkspace: vi.fn(async () => ({ id: 'ws-composite' })),
+    addSimpleWorkspace: vi.fn(async () => ({ id: 'ws-simple' })),
     setCurrentWorkspace: vi.fn(async () => undefined),
     workspaces: [] as ReadonlyArray<{ id: string }>,
   },
@@ -16,11 +18,15 @@ vi.mock('../../../../store', () => ({
   useAppStore: <T,>(
     selector: (s: {
       addWorkspace: typeof state.addWorkspace;
+      addCompositeWorkspace: typeof state.addCompositeWorkspace;
+      addSimpleWorkspace: typeof state.addSimpleWorkspace;
       setCurrentWorkspace: typeof state.setCurrentWorkspace;
     }) => T,
   ) =>
     selector({
       addWorkspace: state.addWorkspace,
+      addCompositeWorkspace: state.addCompositeWorkspace,
+      addSimpleWorkspace: state.addSimpleWorkspace,
       setCurrentWorkspace: state.setCurrentWorkspace,
     }),
   useWorkspaces: () => state.workspaces,
@@ -34,12 +40,19 @@ vi.mock('@tauri-apps/plugin-dialog', () => ({
   open: vi.fn(async () => '/picked/path'),
 }));
 
+vi.mock('../../defaultSimpleWorkspacePath', () => ({
+  defaultSimpleWorkspacePath: vi.fn(async () => '/home/test/Documents/Goodboy/my-workspace'),
+}));
+
 import { WorkspaceLinkDialog } from './index';
 
 beforeEach(() => {
   state.addWorkspace = vi.fn(async () => ({ id: 'ws-new' }));
+  state.addCompositeWorkspace = vi.fn(async () => ({ id: 'ws-composite' }));
+  state.addSimpleWorkspace = vi.fn(async () => ({ id: 'ws-simple' }));
   state.setCurrentWorkspace = vi.fn(async () => undefined);
   state.workspaces = [];
+  validateMock.mockClear();
   validateMock.mockResolvedValue({ isRepo: true });
 });
 afterEach(cleanup);
@@ -47,7 +60,9 @@ afterEach(cleanup);
 describe('WorkspaceLinkDialog', () => {
   it('renders the dialog title and the repository helper hint', () => {
     render(<WorkspaceLinkDialog open onClose={vi.fn()} />);
-    expect(screen.getByText(/point goodboy at a local git repo/i)).toBeDefined();
+    expect(
+      screen.getByText(/add a project, link projects, or create a simple workspace/i),
+    ).toBeDefined();
   });
 
   it('renders a Cancel button that closes the dialog', () => {
@@ -64,5 +79,25 @@ describe('WorkspaceLinkDialog', () => {
     });
     await waitFor(() => screen.getByText(/valid git repository/i), { timeout: 2000 });
     expect(validateMock).toHaveBeenCalledWith('/some/repo');
+  });
+
+  it('creates a simple workspace from a prefilled editable directory', async () => {
+    render(<WorkspaceLinkDialog open onClose={vi.fn()} />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Simple' }));
+    const directory = await screen.findByDisplayValue('/home/test/Documents/Goodboy/my-workspace');
+    fireEvent.change(screen.getByDisplayValue('My workspace'), {
+      target: { value: 'History notes' },
+    });
+    fireEvent.change(directory, { target: { value: '/tmp/history-notes' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Create workspace' }));
+
+    await waitFor(() =>
+      expect(state.addSimpleWorkspace).toHaveBeenCalledWith({
+        name: 'History notes',
+        path: '/tmp/history-notes',
+      }),
+    );
+    expect(validateMock).not.toHaveBeenCalled();
+    expect(state.setCurrentWorkspace).toHaveBeenCalledWith('ws-simple');
   });
 });

--- a/apps/desktop/src/features/workspace/components/WorkspaceLinkDialog/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspaceLinkDialog/index.tsx
@@ -2,20 +2,23 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { open as openDialog } from '@tauri-apps/plugin-dialog';
 import { Button, Dialog, Input, SegmentedTabs, StatusDot, cn } from '@goodboy/ui';
 import type { Workspace, WorkspaceId } from '@goodboy/types';
-import { Boxes, Check, FolderGit2, FolderPlus } from 'lucide-react';
+import { Boxes, Check, Folder, FolderGit2, FolderPlus } from 'lucide-react';
 import { useAppStore, useWorkspaces } from '../../../../store';
 import { formatError } from '../../../../shared/lib/errors';
 import { validateGitRepo } from '../../../../shared/lib/repo';
 import { AppBreadcrumb } from '../../../../app/components/AppBreadcrumb';
 import { buildBreadcrumb } from '../../../../app/components/AppBreadcrumb/buildBreadcrumb';
 import { isWizardDone, reopenWizard } from '../../../onboarding/onboarding-store';
+import { defaultSimpleWorkspacePath } from '../../defaultSimpleWorkspacePath';
 
 type Props = {
   open: boolean;
   onClose: () => void;
 };
 
-type Mode = 'single' | 'multi';
+type Mode = 'single' | 'multi' | 'simple';
+
+const DEFAULT_SIMPLE_NAME = 'My workspace';
 
 const lastSegment = (p: string): string => p.split('/').filter(Boolean).at(-1) ?? p;
 
@@ -40,9 +43,13 @@ const commonParentDir = (paths: ReadonlyArray<string>): string => {
 export const WorkspaceLinkDialog = ({ open, onClose }: Props) => {
   const addWorkspace = useAppStore((s) => s.addWorkspace);
   const addCompositeWorkspace = useAppStore((s) => s.addCompositeWorkspace);
+  const addSimpleWorkspace = useAppStore((s) => s.addSimpleWorkspace);
   const setCurrentWorkspace = useAppStore((s) => s.setCurrentWorkspace);
   const workspaces = useWorkspaces();
-  const linkable = useMemo(() => workspaces.filter((w) => w.kind !== 'composite'), [workspaces]);
+  const linkable = useMemo(
+    () => workspaces.filter((w) => w.kind !== 'composite' && w.kind !== 'simple'),
+    [workspaces],
+  );
 
   const [mode, setMode] = useState<Mode>('single');
 
@@ -58,6 +65,9 @@ export const WorkspaceLinkDialog = ({ open, onClose }: Props) => {
   const [containerPath, setContainerPath] = useState('');
   const [containerEdited, setContainerEdited] = useState(false);
   const [compositeName, setCompositeName] = useState('');
+  const [simpleName, setSimpleName] = useState(DEFAULT_SIMPLE_NAME);
+  const [simplePath, setSimplePath] = useState('');
+  const [simplePathEdited, setSimplePathEdited] = useState(false);
 
   const pathInputRef = useRef<HTMLInputElement>(null);
 
@@ -77,7 +87,31 @@ export const WorkspaceLinkDialog = ({ open, onClose }: Props) => {
     setContainerPath('');
     setContainerEdited(false);
     setCompositeName('');
+    setSimpleName(DEFAULT_SIMPLE_NAME);
+    setSimplePath('');
+    setSimplePathEdited(false);
   }, [open]);
+
+  useEffect(() => {
+    if (!open || mode !== 'simple' || simplePathEdited) {
+      return;
+    }
+    let cancelled = false;
+    void defaultSimpleWorkspacePath({ name: simpleName })
+      .then((suggestedPath) => {
+        if (!cancelled) {
+          setSimplePath(suggestedPath);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setSimplePath('');
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [mode, open, simpleName, simplePathEdited]);
 
   useEffect(() => {
     if (path.length === 0) {
@@ -159,6 +193,14 @@ export const WorkspaceLinkDialog = ({ open, onClose }: Props) => {
     }
   }, []);
 
+  const onPickSimple = useCallback(async () => {
+    const picked = await openDialog({ directory: true, multiple: false });
+    if (typeof picked === 'string') {
+      setSimplePathEdited(true);
+      setSimplePath(picked);
+    }
+  }, []);
+
   const onSubmitSingle = useCallback(async () => {
     setBusy(true);
     setSubmitError(null);
@@ -209,6 +251,26 @@ export const WorkspaceLinkDialog = ({ open, onClose }: Props) => {
     onClose,
   ]);
 
+  const onSubmitSimple = useCallback(async () => {
+    setBusy(true);
+    setSubmitError(null);
+    try {
+      const ws = await addSimpleWorkspace({
+        name: simpleName.trim(),
+        path: simplePath.trim(),
+      });
+      await setCurrentWorkspace(ws.id);
+      onClose();
+      if (!isWizardDone()) {
+        reopenWizard('setup');
+      }
+    } catch (err) {
+      setSubmitError(formatError(err));
+    } finally {
+      setBusy(false);
+    }
+  }, [addSimpleWorkspace, onClose, setCurrentWorkspace, simpleName, simplePath]);
+
   const mountValues = selectedWorkspaces.map((w) =>
     (mountNames[w.id] ?? lastSegment(w.rootPath)).trim(),
   );
@@ -216,7 +278,9 @@ export const WorkspaceLinkDialog = ({ open, onClose }: Props) => {
     mountValues.every((m) => m.length > 0) && new Set(mountValues).size === mountValues.length;
   const multiDisabled =
     busy || selectedWorkspaces.length < 2 || containerPath.trim().length === 0 || !mountsValid;
-  const primaryDisabled = mode === 'single' ? busy || !validPath : multiDisabled;
+  const simpleDisabled = busy || simpleName.trim().length === 0 || simplePath.trim().length === 0;
+  const primaryDisabled =
+    mode === 'single' ? busy || !validPath : mode === 'multi' ? multiDisabled : simpleDisabled;
 
   const previewMounts = selectedWorkspaces.map((w) => mountNames[w.id] ?? lastSegment(w.rootPath));
 
@@ -240,7 +304,7 @@ export const WorkspaceLinkDialog = ({ open, onClose }: Props) => {
       onClose={onClose}
       size="md"
       title="Add workspace"
-      description="Point Goodboy at a local git repo, or link several into one."
+      description="Add a project, link projects, or create a simple workspace."
       footer={
         <>
           {submitError ? <span className="mr-auto text-xs text-danger">{submitError}</span> : null}
@@ -248,12 +312,22 @@ export const WorkspaceLinkDialog = ({ open, onClose }: Props) => {
             Cancel
           </Button>
           <Button
-            onClick={() => void (mode === 'single' ? onSubmitSingle() : onSubmitMulti())}
+            onClick={() =>
+              void (mode === 'single'
+                ? onSubmitSingle()
+                : mode === 'multi'
+                  ? onSubmitMulti()
+                  : onSubmitSimple())
+            }
             disabled={primaryDisabled}
             aria-busy={busy}
             className={busy ? 'animate-border-pulse' : undefined}
           >
-            {mode === 'single' ? 'Add workspace' : 'Link projects'}
+            {mode === 'single'
+              ? 'Add workspace'
+              : mode === 'multi'
+                ? 'Link projects'
+                : 'Create workspace'}
           </Button>
         </>
       }
@@ -265,6 +339,7 @@ export const WorkspaceLinkDialog = ({ open, onClose }: Props) => {
           options={[
             { value: 'single', label: 'Single project', icon: FolderGit2 },
             { value: 'multi', label: 'Multi project', icon: Boxes, badge: 'beta' },
+            { value: 'simple', label: 'Simple', icon: Folder },
           ]}
           value={mode}
           onChange={setMode}
@@ -274,7 +349,9 @@ export const WorkspaceLinkDialog = ({ open, onClose }: Props) => {
         <p className="text-xs leading-relaxed text-muted-foreground">
           {mode === 'single'
             ? 'Work in one git repository.'
-            : 'Working on both a frontend and a backend? Link them into one workspace so a single chat can work across all of them.'}
+            : mode === 'multi'
+              ? 'Working on both a frontend and a backend? Link them into one workspace so a single chat can work across all of them.'
+              : 'Use agents, workflows, and shared context in a standalone project space.'}
         </p>
 
         {mode === 'single' ? (
@@ -317,7 +394,7 @@ export const WorkspaceLinkDialog = ({ open, onClose }: Props) => {
               )}
             </div>
           </div>
-        ) : (
+        ) : mode === 'multi' ? (
           <div className="flex flex-col gap-4">
             {linkable.length < 2 ? (
               <div className="rounded-md border border-border bg-muted/30 px-3 py-2 text-xs leading-relaxed text-muted-foreground">
@@ -433,6 +510,40 @@ export const WorkspaceLinkDialog = ({ open, onClose }: Props) => {
                 </div>
               </>
             )}
+          </div>
+        ) : (
+          <div className="flex flex-col gap-4">
+            <div className="flex flex-col gap-1.5">
+              <span className="text-xs font-semibold text-foreground">name</span>
+              <Input
+                autoFocus
+                value={simpleName}
+                placeholder="My workspace"
+                onChange={(event) => setSimpleName(event.target.value)}
+                disabled={busy}
+              />
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <span className="text-xs font-semibold text-foreground">directory</span>
+              <div className="flex gap-2">
+                <Input
+                  value={simplePath}
+                  placeholder="/path/to/workspace"
+                  onChange={(event) => {
+                    setSimplePathEdited(true);
+                    setSimplePath(event.target.value);
+                  }}
+                  disabled={busy}
+                  className="flex-1"
+                />
+                <Button variant="secondary" onClick={() => void onPickSimple()} disabled={busy}>
+                  Browse
+                </Button>
+              </div>
+              <p className="text-xs leading-relaxed text-muted-foreground">
+                The directory is created when it does not exist.
+              </p>
+            </div>
           </div>
         )}
       </div>

--- a/apps/desktop/src/features/workspace/components/WorkspaceRow/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspaceRow/index.tsx
@@ -37,6 +37,11 @@ export const WorkspaceRow = ({ workspace, density, highlighted, onOpen }: Props)
       <span className="min-w-0 flex-1">
         <span className="flex items-center gap-2">
           <span className="truncate text-sm font-medium text-foreground">{workspace.name}</span>
+          {workspace.kind === 'simple' ? (
+            <span className="shrink-0 rounded-full bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+              simple
+            </span>
+          ) : null}
           {hasUnread ? (
             <span className="shrink-0 rounded-full bg-warning/15 px-1.5 py-0.5 text-[10px] font-medium text-warning">
               unread

--- a/apps/desktop/src/features/workspace/defaultSimpleWorkspacePath.ts
+++ b/apps/desktop/src/features/workspace/defaultSimpleWorkspacePath.ts
@@ -1,0 +1,9 @@
+import { invoke } from '@tauri-apps/api/core';
+
+type Params = {
+  name: string;
+};
+
+export const defaultSimpleWorkspacePath = async ({ name }: Params): Promise<string> => {
+  return invoke<string>('simple_workspace_default_path', { name });
+};

--- a/apps/desktop/src/features/workspace/prepareSimpleWorkspace.ts
+++ b/apps/desktop/src/features/workspace/prepareSimpleWorkspace.ts
@@ -1,0 +1,9 @@
+import { invoke } from '@tauri-apps/api/core';
+
+type Params = {
+  path: string;
+};
+
+export const prepareSimpleWorkspace = async ({ path }: Params): Promise<string> => {
+  return invoke<string>('simple_workspace_prepare', { path });
+};

--- a/apps/desktop/src/features/worktree/useRemoteHostKind.ts
+++ b/apps/desktop/src/features/worktree/useRemoteHostKind.ts
@@ -11,6 +11,9 @@ export const useRemoteHostKind = (workspaceId: WorkspaceId | null): RemoteHostKi
   const rootPath = useAppStore(
     (s) => s.workspaces.find((w) => w.id === workspaceId)?.rootPath ?? null,
   );
+  const isSimple = useAppStore(
+    (s) => s.workspaces.find((w) => w.id === workspaceId)?.kind === 'simple',
+  );
   const gitlabHosts = useAppStore(
     useShallow((s) =>
       (s.workspaceIntegrations[workspaceId as WorkspaceId] ?? [])
@@ -19,13 +22,13 @@ export const useRemoteHostKind = (workspaceId: WorkspaceId | null): RemoteHostKi
     ),
   );
   const [kind, setKind] = useState<RemoteHostKind | null>(() =>
-    rootPath ? (cache.get(rootPath) ?? null) : null,
+    rootPath && !isSimple ? (cache.get(rootPath) ?? null) : null,
   );
 
   const hostsKey = gitlabHosts.join('|');
 
   useEffect(() => {
-    if (!rootPath) {
+    if (!rootPath || isSimple) {
       setKind(null);
       return;
     }
@@ -52,7 +55,7 @@ export const useRemoteHostKind = (workspaceId: WorkspaceId | null): RemoteHostKi
       cancelled = true;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [rootPath, hostsKey]);
+  }, [rootPath, hostsKey, isSimple]);
 
   return kind;
 };

--- a/apps/desktop/src/features/worktree/worktree.ts
+++ b/apps/desktop/src/features/worktree/worktree.ts
@@ -23,6 +23,18 @@ export const createWorktree = async (args: CreateWorktreeArgs): Promise<CreatedW
   return invoke<CreatedWorktree>('worktree_create', { args });
 };
 
+export type CreateSessionDirArgs = {
+  readonly basePath: string;
+  readonly slug: string;
+};
+
+export const createSessionDir = async ({
+  basePath,
+  slug,
+}: CreateSessionDirArgs): Promise<CreatedWorktree> => {
+  return invoke<CreatedWorktree>('session_dir_create', { args: { basePath, slug } });
+};
+
 export const removeWorktree = async (repoPath: string, worktreePath: string): Promise<void> => {
   await invoke('worktree_remove', { repoPath, worktreePath });
 };

--- a/apps/desktop/src/store/selectors.ts
+++ b/apps/desktop/src/store/selectors.ts
@@ -96,6 +96,8 @@ function sessionHasRunningAgentIn(state: AppState, sessionId: SessionId): boolea
 
 function stageInfoOf(state: AppState, session: Session): SessionStageInfo {
   const sessionId = session.id as SessionId;
+  const workspaceKind =
+    state.workspaces?.find((workspace) => workspace.id === session.workspaceId)?.kind ?? 'repo';
   return deriveSessionStage({
     session,
     pr: state.sessionGithub[sessionId]?.pr ?? null,
@@ -103,6 +105,7 @@ function stageInfoOf(state: AppState, session: Session): SessionStageInfo {
     openQuestionCount: countOpenQuestions(state, sessionId),
     hasRunningAgent: sessionHasRunningAgentIn(state, sessionId),
     isPrReview: isPrReviewSession({ agents: state.sessionPhaseRuns[sessionId] ?? [] }),
+    workspaceKind,
   });
 }
 

--- a/apps/desktop/src/store/slices/github/index.test.ts
+++ b/apps/desktop/src/store/slices/github/index.test.ts
@@ -568,6 +568,17 @@ describe('store contract', () => {
       expect(store.getState().sessionGithub[SESSION_ID]).toBeUndefined();
     });
 
+    it('refreshSessionPr noops for a simple workspace even with a branch', async () => {
+      const store = await getStore();
+      store.setState({
+        workspaces: [{ ...buildWorkspace(), kind: 'simple' } as never],
+        sessions: [buildSession()],
+        sessionBranches: { [SESSION_ID]: 'goodboy/topic' },
+      });
+      await store.getState().refreshSessionPr(SESSION_ID);
+      expect(store.getState().sessionGithub[SESSION_ID]).toBeUndefined();
+    });
+
     it('sweepGithub is a no-op when github is unavailable', async () => {
       const store = await getStore();
       store.setState({

--- a/apps/desktop/src/store/slices/github/refreshSessionPr.ts
+++ b/apps/desktop/src/store/slices/github/refreshSessionPr.ts
@@ -25,7 +25,7 @@ export const refreshSessionPr = (set: SetFn, get: GetFn) => {
       return;
     }
     const workspace = get().workspaces.find((w) => w.id === session.workspaceId);
-    if (!workspace) {
+    if (!workspace || workspace.kind === 'simple') {
       return;
     }
     set((state) => ({

--- a/apps/desktop/src/store/slices/review-prs/index.test.ts
+++ b/apps/desktop/src/store/slices/review-prs/index.test.ts
@@ -161,7 +161,11 @@ describe('review-prs slice', () => {
         author: { username: 'nbro', name: 'N', avatarUrl: 'https://gitlab.com/n.png' },
       }),
       buildMr({ iid: 3, state: 'merged' }),
-      buildMr({ iid: 4, state: 'closed', reviewers: [{ username: 'nbro', name: 'N', avatarUrl: null }] }),
+      buildMr({
+        iid: 4,
+        state: 'closed',
+        reviewers: [{ username: 'nbro', name: 'N', avatarUrl: null }],
+      }),
     ]);
     const { slice, getState } = buildHarness({
       workspaceIntegrations: { [WS_ID]: [buildGitlabIntegration()] },
@@ -209,6 +213,23 @@ describe('review-prs slice', () => {
     const result = selectReviewPrs(WS_ID)(getState());
     expect(result.items.map((p) => p.id)).toEqual(['gitlab:2', 'github:1']);
     expect(result.fetchedAt).not.toBeNull();
+  });
+
+  it('skips fetching entirely for a simple workspace', async () => {
+    detectRepoSlugSpy.mockResolvedValue('org/repo');
+    const { slice, getState } = buildHarness({
+      workspaces: [{ ...buildWorkspace(), kind: 'simple' }],
+      workspaceIntegrations: { [WS_ID]: [buildGitlabIntegration()] },
+    });
+    await slice.refreshReviewPrs(WS_ID);
+    expect(detectRepoSlugSpy).not.toHaveBeenCalled();
+    expect(gitlabFetchProjectMrsSpy).not.toHaveBeenCalled();
+    expect(selectReviewPrs(WS_ID)(getState())).toEqual({
+      items: [],
+      loading: false,
+      error: null,
+      fetchedAt: null,
+    });
   });
 
   it('selectReviewPrs falls back to an empty idle state', () => {

--- a/apps/desktop/src/store/slices/review-prs/refreshReviewPrs.ts
+++ b/apps/desktop/src/store/slices/review-prs/refreshReviewPrs.ts
@@ -18,6 +18,9 @@ export const refreshReviewPrs = (set: SetFn, get: GetFn) => {
     if (workspace == null) {
       return;
     }
+    if (workspace.kind === 'simple') {
+      return;
+    }
     set((state) => ({
       reviewPrs: {
         ...state.reviewPrs,

--- a/apps/desktop/src/store/slices/session-view/deriveSessionStage.ts
+++ b/apps/desktop/src/store/slices/session-view/deriveSessionStage.ts
@@ -1,4 +1,4 @@
-import type { PullRequestState, Session, SessionStageInfo } from '@goodboy/types';
+import type { PullRequestState, Session, SessionStageInfo, WorkspaceKind } from '@goodboy/types';
 
 type Params = {
   session: Session;
@@ -7,6 +7,7 @@ type Params = {
   openQuestionCount: number;
   hasRunningAgent?: boolean;
   isPrReview?: boolean;
+  workspaceKind?: WorkspaceKind;
 };
 
 const isPrLive = (pr: PullRequestState | null): pr is PullRequestState =>
@@ -22,7 +23,26 @@ export const deriveSessionStage = ({
   openQuestionCount,
   hasRunningAgent = false,
   isPrReview = false,
+  workspaceKind = 'repo',
 }: Params): SessionStageInfo => {
+  if (workspaceKind === 'simple') {
+    if (session.state.kind === 'running' || session.state.kind === 'starting' || hasRunningAgent) {
+      return { stage: 'running', reason: 'agent running' };
+    }
+    if (session.state.kind === 'error') {
+      return { stage: 'attention', reason: 'agent errored' };
+    }
+    if (openQuestionCount === 1) {
+      return { stage: 'attention', reason: '1 open question' };
+    }
+    if (openQuestionCount > 1) {
+      return { stage: 'attention', reason: `${openQuestionCount} open questions` };
+    }
+    if (hasUnread) {
+      return { stage: 'attention', reason: 'unread agent reply' };
+    }
+    return { stage: 'building', reason: 'ready for work' };
+  }
   if (session.state.kind === 'error') {
     return { stage: 'attention', reason: 'agent errored' };
   }

--- a/apps/desktop/src/store/slices/sessions/createSession.ts
+++ b/apps/desktop/src/store/slices/sessions/createSession.ts
@@ -23,7 +23,11 @@ import {
   upsertContextSlot,
 } from '@goodboy/db';
 import { tauriDatabase } from '../../../shared/lib/db';
-import { createWorktree, type CreatedWorktree } from '../../../features/worktree/worktree';
+import {
+  createSessionDir,
+  createWorktree,
+  type CreatedWorktree,
+} from '../../../features/worktree/worktree';
 import { invokeAgentInsert } from '../../../features/workflows/workflows';
 import {
   kindRouting,
@@ -111,6 +115,7 @@ export const createSession = (set: SetFn, get: GetFn) => {
       markSessionMobileShared(sessionId);
     }
     const isComposite = workspace.kind === 'composite';
+    const isSimple = workspace.kind === 'simple';
     const members = isComposite ? (workspace.members ?? []) : [];
     if (isComposite && members.length < 2) {
       throw new Error(`multi-project workspace has no linked repos: ${workspaceId}`);
@@ -118,7 +123,13 @@ export const createSession = (set: SetFn, get: GetFn) => {
 
     let worktree: CreatedWorktree;
     const memberWorktrees: Array<{ member: WorkspaceMember; worktree: CreatedWorktree }> = [];
-    if (isComposite) {
+    if (isSimple) {
+      const dirSlug = `${slugifyDir(slugSeed)}-${sessionId.slice(0, 8)}`;
+      worktree = await createSessionDir({
+        basePath: workspace.rootPath,
+        slug: dirSlug,
+      });
+    } else if (isComposite) {
       const dirSlug = `${slugifyDir(slugSeed)}-${sessionId.slice(0, 8)}`;
       const compositeDir = `${workspace.rootPath}/${dirSlug}`;
       for (const member of members) {

--- a/apps/desktop/src/store/slices/sessions/deleteTask.ts
+++ b/apps/desktop/src/store/slices/sessions/deleteTask.ts
@@ -32,7 +32,7 @@ export const deleteTask = (set: SetFn, get: GetFn) => {
       }
     }
     const workspace = get().workspaces.find((w) => w.id === session.workspaceId);
-    if (workspace) {
+    if (workspace && workspace.kind !== 'simple') {
       for (const worktreePath of paths) {
         try {
           await removeWorktree(workspace.rootPath, worktreePath);

--- a/apps/desktop/src/store/slices/sessions/index.test.ts
+++ b/apps/desktop/src/store/slices/sessions/index.test.ts
@@ -252,11 +252,13 @@ vi.mock('../../../features/workflows/workflows', () => ({
 }));
 
 const createWorktreeSpy = vi.fn();
+const createSessionDirSpy = vi.fn();
 const removeWorktreeSpy = vi.fn(async () => undefined);
 const changeWorktreeBranchSpy = vi.fn(async () => undefined);
 
 vi.mock('../../../features/worktree/worktree', () => ({
   createWorktree: createWorktreeSpy,
+  createSessionDir: createSessionDirSpy,
   removeWorktree: removeWorktreeSpy,
   changeWorktreeBranch: changeWorktreeBranchSpy,
   worktreeChangedFiles: vi.fn(async () => []),
@@ -778,6 +780,47 @@ describe('store contract', () => {
         );
         expect(summary?.[2]).toBe('failed to restore 2 of 2 sessions');
       });
+    });
+  });
+
+  describe('createSession simple workspace', () => {
+    it('registers a plain session directory with an empty branch', async () => {
+      const store = await getStore();
+      const db = await import('@goodboy/db');
+      vi.mocked(db.listWorkspaces).mockResolvedValueOnce([
+        buildWorkspace({
+          rootPath: '/tmp/study-space',
+          kind: 'simple',
+        }),
+      ]);
+      createSessionDirSpy.mockResolvedValueOnce({
+        worktreePath: '/tmp/study-space/sessions/study-plan-12345678',
+        branchName: '',
+        slug: 'study-plan-12345678',
+        reused: false,
+      });
+      store.setState({ currentWorkspaceId: WS_ID });
+
+      const { session, worktree } = await store
+        .getState()
+        .createSession({ workspaceId: WS_ID, goal: 'Study plan' });
+
+      expect(createSessionDirSpy).toHaveBeenCalledWith({
+        basePath: '/tmp/study-space',
+        slug: expect.stringMatching(/^study-plan-[a-f0-9]{8}$/),
+      });
+      expect(createWorktreeSpy).not.toHaveBeenCalled();
+      expect(worktree.branchName).toBe('');
+      expect(vi.mocked(db.insertSessionWorktree)).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          sessionId: session.id,
+          worktreePath: worktree.worktreePath,
+          branch: '',
+          parallelIndex: 0,
+        }),
+      );
+      expect(store.getState().sessionBranches[session.id]).toBe('');
     });
   });
 

--- a/apps/desktop/src/store/slices/turn/sendTurn.ts
+++ b/apps/desktop/src/store/slices/turn/sendTurn.ts
@@ -646,25 +646,35 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
     const kindSystemPrompt = AGENT_KIND_DEFAULTS[earlyAgentKind].systemPrompt;
 
     const scopeWorkspace = get().workspaces.find((w) => w.id === session.workspaceId);
+    const isSimpleWorkspace = scopeWorkspace?.kind === 'simple';
     const scopeMembers = scopeWorkspace?.kind === 'composite' ? (scopeWorkspace.members ?? []) : [];
     const scopeGuard = (
-      scopeMembers.length > 0
+      isSimpleWorkspace
         ? [
-            '[multi-repo-scope]',
-            `You are operating across ${scopeMembers.length} linked git repositories mounted under: ${workingDir}`,
-            `Each repo lives in its own subfolder: ${scopeMembers.map((m) => m.mountName).join(', ')}.`,
-            'Each subfolder is a separate git repository with its own branch. Run git commands inside the relevant subfolder, never at the container root.',
-            'ALL file operations MUST resolve inside one of these subfolders. Do NOT create files at the container root or outside it.',
-            '[/multi-repo-scope]',
+            '[session-directory-scope]',
+            `You are operating inside this session directory: ${workingDir}`,
+            'ALL file operations (Read/Write/Edit/Bash file paths) MUST resolve inside this directory.',
+            'NEVER write to absolute paths that exit this directory.',
+            'Prefer paths relative to your current working directory. If a request implies editing files outside this directory, stop and ask for explicit confirmation before touching them.',
+            '[/session-directory-scope]',
           ]
-        : [
-            '[worktree-scope]',
-            `You are operating inside an isolated git worktree at: ${workingDir}`,
-            'ALL file operations (Read/Write/Edit/Bash file paths) MUST resolve inside this worktree.',
-            'NEVER write to absolute paths that exit this directory, especially not to the parent project checkout.',
-            'Prefer paths relative to your current working directory. If a user request implies editing files outside the worktree, stop and ask for explicit confirmation before touching them.',
-            '[/worktree-scope]',
-          ]
+        : scopeMembers.length > 0
+          ? [
+              '[multi-repo-scope]',
+              `You are operating across ${scopeMembers.length} linked git repositories mounted under: ${workingDir}`,
+              `Each repo lives in its own subfolder: ${scopeMembers.map((m) => m.mountName).join(', ')}.`,
+              'Each subfolder is a separate git repository with its own branch. Run git commands inside the relevant subfolder, never at the container root.',
+              'ALL file operations MUST resolve inside one of these subfolders. Do NOT create files at the container root or outside it.',
+              '[/multi-repo-scope]',
+            ]
+          : [
+              '[worktree-scope]',
+              `You are operating inside an isolated git worktree at: ${workingDir}`,
+              'ALL file operations (Read/Write/Edit/Bash file paths) MUST resolve inside this worktree.',
+              'NEVER write to absolute paths that exit this directory, especially not to the parent project checkout.',
+              'Prefer paths relative to your current working directory. If a user request implies editing files outside the worktree, stop and ask for explicit confirmation before touching them.',
+              '[/worktree-scope]',
+            ]
     ).join('\n');
     const fullSystemPrompt = kindSystemPrompt ? `${scopeGuard}\n\n${kindSystemPrompt}` : scopeGuard;
 
@@ -839,20 +849,22 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
         // The existing `files_touched` slot is left untouched (mobile falls back
         // to it, paths-only, when this slot is absent). Best-effort: a git failure
         // must not fail the turn.
-        try {
-          const changed = await worktreeChangedFiles(workingDir);
-          await upsertContextSlot(
-            tauriDatabase,
-            sessionId,
-            { key: FILES_TOUCHED_NUMSTAT_SLOT, value: changed.numstat, enabled: true },
-            'summarizer',
-          );
-          const refreshedSlots = await listContextSlotsForSession(tauriDatabase, sessionId);
-          set((state) => ({
-            sessionSlots: { ...state.sessionSlots, [sessionId]: refreshedSlots },
-          }));
-        } catch (e) {
-          console.error('files_touched_numstat slot write failed', e);
+        if (!isSimpleWorkspace) {
+          try {
+            const changed = await worktreeChangedFiles(workingDir);
+            await upsertContextSlot(
+              tauriDatabase,
+              sessionId,
+              { key: FILES_TOUCHED_NUMSTAT_SLOT, value: changed.numstat, enabled: true },
+              'summarizer',
+            );
+            const refreshedSlots = await listContextSlotsForSession(tauriDatabase, sessionId);
+            set((state) => ({
+              sessionSlots: { ...state.sessionSlots, [sessionId]: refreshedSlots },
+            }));
+          } catch (e) {
+            console.error('files_touched_numstat slot write failed', e);
+          }
         }
       } catch (e) {
         console.error('autoPopulateContext failed', e);

--- a/apps/desktop/src/store/slices/workspaces/addCompositeWorkspace.ts
+++ b/apps/desktop/src/store/slices/workspaces/addCompositeWorkspace.ts
@@ -37,6 +37,9 @@ export const addCompositeWorkspace = (set: SetFn, get: GetFn) => {
       if (ws.kind === 'composite') {
         throw new Error('cannot nest a multi-project workspace inside another');
       }
+      if (ws.kind === 'simple') {
+        throw new Error('a simple workspace cannot be linked as a repository');
+      }
       return { workspaceId: m.workspaceId, rootPath: ws.rootPath, mountName: m.mountName.trim() };
     });
 

--- a/apps/desktop/src/store/slices/workspaces/addSimpleWorkspace.ts
+++ b/apps/desktop/src/store/slices/workspaces/addSimpleWorkspace.ts
@@ -1,0 +1,57 @@
+import type { IsoDateTime, Workspace, WorkspaceId } from '@goodboy/types';
+import { seedWorkflowLibrary } from '@goodboy/core';
+import { findWorkspaceByRootPath, insertWorkspace } from '@goodboy/db';
+import { invokeSkillRescan } from '../../../features/skills/skills';
+import { prepareSimpleWorkspace } from '../../../features/workspace/prepareSimpleWorkspace';
+import { invokeWorkflowList } from '../../../features/workflows/workflows';
+import { tauriDatabase } from '../../../shared/lib/db';
+import type { GetFn, SetFn } from './types';
+
+type Input = {
+  name: string;
+  path: string;
+};
+
+export const addSimpleWorkspace = (set: SetFn, get: GetFn) => {
+  return async ({ name, path }: Input): Promise<Workspace> => {
+    const trimmedName = name.trim();
+    const trimmedPath = path.trim();
+    if (trimmedName.length === 0) {
+      throw new Error('workspace name cannot be empty');
+    }
+    if (trimmedPath.length === 0) {
+      throw new Error('workspace directory cannot be empty');
+    }
+    const resolvedRoot = await prepareSimpleWorkspace({ path: trimmedPath });
+    const existingInState = get().workspaces.find(
+      (workspace) => workspace.rootPath === resolvedRoot,
+    );
+    if (existingInState != null) {
+      throw new Error(`workspace already exists: ${existingInState.name}`);
+    }
+    const existing = await findWorkspaceByRootPath(tauriDatabase, resolvedRoot);
+    if (existing != null) {
+      throw new Error(`workspace already exists: ${existing.name}`);
+    }
+    const now = new Date().toISOString() as IsoDateTime;
+    const workspace: Workspace = {
+      id: crypto.randomUUID() as WorkspaceId,
+      name: trimmedName,
+      rootPath: resolvedRoot,
+      kind: 'simple',
+      createdAt: now,
+      updatedAt: now,
+      lastAccessedAt: now,
+    };
+    await insertWorkspace(tauriDatabase, workspace);
+    set((state) => ({ workspaces: [workspace, ...state.workspaces] }));
+
+    await seedWorkflowLibrary({ db: tauriDatabase }, workspace.id).catch(() => undefined);
+    const templates = await invokeWorkflowList(workspace.id).catch(() => []);
+    set((state) => ({ phaseTemplates: { ...state.phaseTemplates, [workspace.id]: templates } }));
+    const skills = await invokeSkillRescan(workspace.id).catch(() => []);
+    set((state) => ({ skills: { ...state.skills, [workspace.id]: skills } }));
+
+    return workspace;
+  };
+};

--- a/apps/desktop/src/store/slices/workspaces/index.test.ts
+++ b/apps/desktop/src/store/slices/workspaces/index.test.ts
@@ -273,6 +273,12 @@ vi.mock('../../../shared/lib/repo', () => ({
   validateGitRepo: vi.fn(async () => ({ isRepo: true, rootPath: '/tmp/repo' })),
 }));
 
+const prepareSimpleWorkspaceSpy = vi.fn(async ({ path }: { path: string }) => path);
+
+vi.mock('../../../features/workspace/prepareSimpleWorkspace', () => ({
+  prepareSimpleWorkspace: prepareSimpleWorkspaceSpy,
+}));
+
 vi.mock('../../../shared/lib/editor', () => ({
   detectEditors: vi.fn(async () => []),
 }));
@@ -551,6 +557,25 @@ describe('store contract', () => {
       expect(wsList[0]?.id).toBe(created.id);
       expect(wsList[0]?.name).toBe('app');
       expect(wsList[0]?.rootPath).toBe('/tmp/repo');
+    });
+
+    it('addSimpleWorkspace accepts a non-repository directory and persists its kind', async () => {
+      const store = await getStore();
+      const repo = await import('../../../shared/lib/repo');
+      vi.mocked(repo.validateGitRepo).mockRejectedValueOnce(new Error('not a repository'));
+      prepareSimpleWorkspaceSpy.mockResolvedValueOnce('/tmp/study-space');
+
+      const created = await store
+        .getState()
+        .addSimpleWorkspace({ name: 'Study space', path: '/tmp/study-space' });
+
+      expect(created).toMatchObject({
+        name: 'Study space',
+        rootPath: '/tmp/study-space',
+        kind: 'simple',
+      });
+      expect(store.getState().workspaces[0]).toEqual(created);
+      expect(repo.validateGitRepo).not.toHaveBeenCalled();
     });
 
     it('deleteWorkspace drops it from state and clears workspace-scoped caches when current', async () => {

--- a/apps/desktop/src/store/slices/workspaces/index.ts
+++ b/apps/desktop/src/store/slices/workspaces/index.ts
@@ -1,5 +1,6 @@
 import { addWorkspace } from './addWorkspace';
 import { addCompositeWorkspace } from './addCompositeWorkspace';
+import { addSimpleWorkspace } from './addSimpleWorkspace';
 import { deleteWorkspace } from './deleteWorkspace';
 import { setCurrentWorkspace } from './setCurrentWorkspace';
 import { wipeLocalDatabase } from './wipeLocalDatabase';
@@ -9,6 +10,7 @@ export const createWorkspacesSlice = (set: SetFn, get: GetFn) => {
   return {
     addWorkspace: addWorkspace(set, get),
     addCompositeWorkspace: addCompositeWorkspace(set, get),
+    addSimpleWorkspace: addSimpleWorkspace(set, get),
     deleteWorkspace: deleteWorkspace(set, get),
     setCurrentWorkspace: setCurrentWorkspace(set, get),
     wipeLocalDatabase: wipeLocalDatabase(set, get),

--- a/apps/desktop/src/store/slices/worktrees/changeSessionBranch.ts
+++ b/apps/desktop/src/store/slices/worktrees/changeSessionBranch.ts
@@ -11,6 +11,13 @@ type Args = {
 
 export const changeSessionBranch = (set: SetFn, get: GetFn) => {
   return async (sessionId: SessionId, { branch, createNew }: Args) => {
+    const session = get().sessions.find((candidate) => candidate.id === sessionId);
+    const workspace = session
+      ? get().workspaces.find((candidate) => candidate.id === session.workspaceId)
+      : null;
+    if (workspace?.kind === 'simple') {
+      return;
+    }
     const target = branch.trim();
     if (!target) {
       throw new Error('branch name cannot be empty');
@@ -20,8 +27,6 @@ export const changeSessionBranch = (set: SetFn, get: GetFn) => {
     if (!primary) {
       throw new Error(`no worktree found for session ${sessionId}`);
     }
-    const session = get().sessions.find((s) => s.id === sessionId);
-    const workspace = session ? get().workspaces.find((w) => w.id === session.workspaceId) : null;
     if (!workspace) {
       throw new Error('workspace not found for session');
     }

--- a/apps/desktop/src/store/slices/worktrees/reconcileSessionBranch.ts
+++ b/apps/desktop/src/store/slices/worktrees/reconcileSessionBranch.ts
@@ -5,6 +5,13 @@ import type { GetFn, SetFn } from './types';
 
 export const reconcileSessionBranch = (set: SetFn, get: GetFn) => {
   return async (sessionId: SessionId, observedBranch: string) => {
+    const session = get().sessions.find((candidate) => candidate.id === sessionId);
+    const workspace = session
+      ? get().workspaces.find((candidate) => candidate.id === session.workspaceId)
+      : null;
+    if (workspace?.kind === 'simple') {
+      return;
+    }
     const trimmed = observedBranch.trim();
     if (!trimmed) {
       return;

--- a/apps/desktop/src/store/store.session-view.test.ts
+++ b/apps/desktop/src/store/store.session-view.test.ts
@@ -379,6 +379,46 @@ describe('deriveSessionStage', () => {
     const info = deriveSessionStage({ session: base(1), pr: null, ...signals });
     expect(info.stage).toBe('building');
   });
+
+  it('simple sessions derive running from any active agent signal', () => {
+    const info = deriveSessionStage({
+      session: base(1),
+      pr: null,
+      ...signals,
+      hasRunningAgent: true,
+      workspaceKind: 'simple',
+    });
+    expect(info).toEqual({ stage: 'running', reason: 'agent running' });
+  });
+
+  it('simple sessions derive attention from questions or unread replies', () => {
+    const questions = deriveSessionStage({
+      session: base(1),
+      pr: null,
+      hasUnread: false,
+      openQuestionCount: 2,
+      workspaceKind: 'simple',
+    });
+    const unread = deriveSessionStage({
+      session: base(1),
+      pr: null,
+      hasUnread: true,
+      openQuestionCount: 0,
+      workspaceKind: 'simple',
+    });
+    expect(questions).toEqual({ stage: 'attention', reason: '2 open questions' });
+    expect(unread).toEqual({ stage: 'attention', reason: 'unread agent reply' });
+  });
+
+  it('simple sessions stay building when agent signals are quiet', () => {
+    const info = deriveSessionStage({
+      session: base(1),
+      pr: makePr({ state: 'merged' }),
+      ...signals,
+      workspaceKind: 'simple',
+    });
+    expect(info).toEqual({ stage: 'building', reason: 'ready for work' });
+  });
 });
 
 describe('sortAndGroupSessions, pr grouping', () => {

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -160,6 +160,7 @@ export type AppActions = {
     containerPath: string;
     members: ReadonlyArray<{ workspaceId: WorkspaceId; mountName: string }>;
   }): Promise<Workspace>;
+  addSimpleWorkspace(input: { name: string; path: string }): Promise<Workspace>;
   deleteWorkspace(id: WorkspaceId): Promise<void>;
   loadIntegrations(workspaceId: WorkspaceId): Promise<void>;
   connectLinear(workspaceId: WorkspaceId, token: string): Promise<LinearViewer>;

--- a/packages/db/src/queries/workspace.test.ts
+++ b/packages/db/src/queries/workspace.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { IsoDateTime, WorkspaceId } from '@goodboy/types';
+import type { IsoDateTime, WorkspaceId, WorkspaceKind } from '@goodboy/types';
 import { makeTestDatabase } from '../test-helpers/test-db';
 import { migrate } from '../migrations/runner';
 import {
@@ -26,6 +26,7 @@ function makeWorkspace(
     id: string;
     name: string;
     rootPath: string;
+    kind: WorkspaceKind;
     lastAccessedAt?: IsoDateTime;
   }> = {},
 ) {
@@ -34,6 +35,7 @@ function makeWorkspace(
     id: (overrides.id ?? 'w1') as WorkspaceId,
     name: overrides.name ?? 'my-repo',
     rootPath: overrides.rootPath ?? '/tmp/my-repo',
+    ...(overrides.kind != null ? { kind: overrides.kind } : {}),
     createdAt: now,
     updatedAt: now,
     ...(overrides.lastAccessedAt != null ? { lastAccessedAt: overrides.lastAccessedAt } : {}),
@@ -69,6 +71,19 @@ describe('insertWorkspace', () => {
     const row = await getWorkspaceById(db, ws.id);
     expect(row?.lastAccessedAt).toBeDefined();
     expect(Date.parse(row!.lastAccessedAt!)).toBeCloseTo(Date.parse(ws.updatedAt), -2);
+  });
+
+  it('keeps simple kinds and coerces unknown kinds to repo', async () => {
+    const db = await makeDb();
+    const simple = makeWorkspace({ id: 'simple', rootPath: '/tmp/simple', kind: 'simple' });
+    await insertWorkspace(db, simple);
+    await db.execute(
+      'INSERT INTO workspaces (id, name, root_path, kind, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)',
+      ['unknown', 'unknown', '/tmp/unknown', 'future-kind', Date.now(), Date.now()],
+    );
+
+    expect((await getWorkspaceById(db, simple.id))?.kind).toBe('simple');
+    expect((await getWorkspaceById(db, 'unknown' as WorkspaceId))?.kind).toBe('repo');
   });
 });
 

--- a/packages/db/src/queries/workspace.ts
+++ b/packages/db/src/queries/workspace.ts
@@ -13,12 +13,23 @@ type WorkspaceRow = {
   last_accessed_at: number | null;
 };
 
+type Params = {
+  kind: string | null;
+};
+
+const coerceWorkspaceKind = ({ kind }: Params): WorkspaceKind => {
+  if (kind === 'composite' || kind === 'simple') {
+    return kind;
+  }
+  return 'repo';
+};
+
 function toDomain(row: WorkspaceRow): Workspace {
   return {
     id: row.id as WorkspaceId,
     name: row.name,
     rootPath: row.root_path,
-    kind: (row.kind === 'composite' ? 'composite' : 'repo') as WorkspaceKind,
+    kind: coerceWorkspaceKind({ kind: row.kind }),
     createdAt: new Date(row.created_at).toISOString() as IsoDateTime,
     updatedAt: new Date(row.updated_at).toISOString() as IsoDateTime,
     ...(row.disconnected_at != null

--- a/packages/types/src/workspace.ts
+++ b/packages/types/src/workspace.ts
@@ -12,7 +12,7 @@ import type { SessionProviderPreference } from './provider-preference';
 import type { ModelEffort } from './provider-registry';
 import type { ClaudePermissionMode } from './permission';
 
-export type WorkspaceKind = 'repo' | 'composite';
+export type WorkspaceKind = 'repo' | 'composite' | 'simple';
 
 export type WorkspaceMember = Readonly<{
   workspaceId: WorkspaceId;


### PR DESCRIPTION
## Problema

Il prodotto era inutilizzabile senza un repo git: `addWorkspace` rifiutava directory senza `.git`, `createSession` creava sempre un worktree, `sendTurn` throwava senza. Il contesto condiviso (la feature core) era inaccessibile a chi non sviluppa.

## Meccanica

- **Kind `simple`** nel union (`repo | composite | simple`); coercion DB estesa (unknown → `repo` invariato); NESSUNA migration (la colonna kind esiste da m056).
- **`addSimpleWorkspace`**: nome + directory non git-validata (precedente composite), default proposto `~/Documents/Goodboy/<slug>`, creata se assente.
- **Sessioni senza git**: comando Tauri `session_dir_create` (mkdir ricorsivo, shape di ritorno compatibile con `worktree_create`); la dir si registra in `session_worktrees` con `branch=''` → turn engine, terminal cwd e transcript INVARIATI.
- **Scope prompt neutro** `[session-directory-scope]` al posto del worktree guard.
- **Lens gating per kind**: Work = workflows/agents/questions, Artifacts = plans, Context completo. Spariscono diff, resolve, review, pr, integrations, scripts, terminal.
- **NewSessionView** senza sezioni branch/issue per simple; **stage** derivato dai segnali agent (running/attention/building); **onboarding** salta code-host/tracker/sentry; badge `simple` nel launcher; guard no-op su reconcile branch, remote-host detection, review refresh.

## Verifica

typecheck, 329 file / 2684 test JS, `cargo test --locked` (112) verdi in locale. Un test del dialog era stale dopo il nuovo copy: allineato. Test nuovi su coercion, addSimpleWorkspace, createSession senza worktree, lens gating, stage matrix, onboarding skip, `session_dir_create`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)