### PR TITLE
refactor(desktop): quiet routing picker

### DIFF
--- a/apps/desktop/src/shared/components/RoutingPicker/VariantChip.tsx
+++ b/apps/desktop/src/shared/components/RoutingPicker/VariantChip.tsx
@@ -17,12 +17,6 @@ const TIER_NOTE: Record<CostTier, string> = {
   expensive: 'premium',
 };
 
-const TIER_DOT: Record<CostTier, string> = {
-  cheap: 'bg-success',
-  mid: 'bg-warning',
-  expensive: 'bg-danger',
-};
-
 export const VariantChip = ({ id, active, onSelect }: Props) => {
   const tier = modelTier(id);
   return (
@@ -36,8 +30,8 @@ export const VariantChip = ({ id, active, onSelect }: Props) => {
         active && 'bg-background font-medium text-foreground shadow-sm',
       )}
     >
-      <span className={cn('size-1.5 shrink-0 rounded-full', TIER_DOT[tier])} aria-hidden />
       {parseModelId(id).variantLabel}
+      {tier === 'expensive' && <span className="text-muted-foreground/50">$$</span>}
     </button>
   );
 };

--- a/apps/desktop/src/shared/components/RoutingPicker/index.test.tsx
+++ b/apps/desktop/src/shared/components/RoutingPicker/index.test.tsx
@@ -138,11 +138,7 @@ describe('RoutingPicker', () => {
     window.removeEventListener('goodboy:open-provider-studio', onOpenProviderStudio);
   });
 
-  it('filters cursor models and omits the filter for anthropic', () => {
-    const cursorModel = PROVIDER_CAPABILITIES.cursor.models.at(-1);
-    if (cursorModel == null) {
-      throw new Error('cursor model registry is empty');
-    }
+  it('does not show a model filter for providers with large or small model registries', () => {
     const view = render(
       <RoutingPicker
         {...baseProps}
@@ -151,17 +147,28 @@ describe('RoutingPicker', () => {
       />,
     );
     fireEvent.click(screen.getByRole('button', { name: /routing/i }));
-    const filter = screen.getByPlaceholderText('Filter models');
-    fireEvent.change(filter, { target: { value: cursorModel.label } });
-    const modelChips = screen
-      .getAllByRole('button')
-      .filter((button) => button.title.includes(' ('));
-    expect(modelChips).toHaveLength(1);
-    expect(modelChips[0]?.title).toContain(cursorModel.id);
+    expect(screen.queryByPlaceholderText('Filter models')).toBeNull();
     view.unmount();
 
     render(<RoutingPicker {...baseProps} />);
     fireEvent.click(screen.getByRole('button', { name: /routing/i }));
     expect(screen.queryByPlaceholderText('Filter models')).toBeNull();
+  });
+
+  it('marks expensive variants with text and renders no tier dots in the model grid', () => {
+    render(<RoutingPicker {...baseProps} />);
+    fireEvent.click(screen.getByRole('button', { name: /routing/i }));
+    const expensiveChip = screen.getByTitle(/^claude-opus-5 \(/);
+    const cheapChip = screen.getByTitle(/^claude-haiku-4-5 \(/);
+    const modelGrid = expensiveChip.closest('div.flex.flex-col.gap-1');
+    expect(expensiveChip.textContent).toContain('$$');
+    expect(expensiveChip.querySelector('span')?.className).toContain('text-muted-foreground/50');
+    expect(cheapChip.textContent).not.toContain('$$');
+    expect(modelGrid).not.toBeNull();
+    expect(
+      modelGrid?.querySelector(
+        '[class*="bg-success"], [class*="bg-warning"], [class*="bg-danger"]',
+      ),
+    ).toBeNull();
   });
 });

--- a/apps/desktop/src/shared/components/RoutingPicker/index.tsx
+++ b/apps/desktop/src/shared/components/RoutingPicker/index.tsx
@@ -1,17 +1,15 @@
 import { useEffect, useState } from 'react';
 import { ChevronDown, RotateCcw } from 'lucide-react';
 import { PROVIDER_CAPABILITIES } from '@goodboy/core';
-import { Button, Divider, Input, Popover, ScrollFade, cn } from '@goodboy/ui';
+import { Button, Divider, Popover, ScrollFade, cn } from '@goodboy/ui';
 import type { ProviderId } from '@goodboy/types';
 import {
-  EFFORT_DOT,
   EFFORT_LABEL,
   PROVIDER_LABEL,
   modelLabel,
   type EffortLevel,
 } from '../../../features/chat/utils/chat-constants';
 import {
-  VERBOSITY_DOT,
   VERBOSITY_LABEL,
   VERBOSITY_LEVELS,
   type VerbosityLevel,
@@ -96,7 +94,6 @@ export const RoutingPicker = ({
   });
   const [viewProvider, setViewProvider] = useState(routing.provider);
   const [isViewingAuto, setIsViewingAuto] = useState(routing.isProviderRecommended);
-  const [modelFilter, setModelFilter] = useState('');
   const isViewingRoutingProvider = viewProvider === routing.provider;
   const viewedRouting = resolveRouting({
     providers: PROVIDERS,
@@ -107,13 +104,6 @@ export const RoutingPicker = ({
     recommendedModel: isViewingRoutingProvider ? recommendedModel : undefined,
   });
   const viewedRecommendedModel = isViewingRoutingProvider ? recommendedModel : undefined;
-  const normalizedFilter = modelFilter.trim().toLowerCase();
-  const filteredModels = viewedRouting.models.filter(
-    (id) =>
-      normalizedFilter === '' ||
-      id.toLowerCase().includes(normalizedFilter) ||
-      modelLabel(id).toLowerCase().includes(normalizedFilter),
-  );
   const isViewProviderConnected = connectedProviders.includes(viewProvider);
   const showEffort = onEffort != null && routing.effortLevels != null;
   const showViewedEffort = onEffort != null && viewedRouting.effortLevels != null;
@@ -129,14 +119,12 @@ export const RoutingPicker = ({
     }
     setViewProvider(routing.provider);
     setIsViewingAuto(routing.isProviderRecommended);
-    setModelFilter('');
   }, [open, routing.isProviderRecommended, routing.provider]);
 
   const onPickProvider = ({ next, viewedProvider }: PickProviderParams) => {
     onProvider(next);
     setViewProvider(viewedProvider);
     setIsViewingAuto(next === '');
-    setModelFilter('');
   };
 
   return (
@@ -272,7 +260,6 @@ export const RoutingPicker = ({
                     onClick={() => {
                       setViewProvider(id);
                       setIsViewingAuto(false);
-                      setModelFilter('');
                       if (!isConnected) {
                         return;
                       }
@@ -298,7 +285,7 @@ export const RoutingPicker = ({
             </div>
           </PickerSection>
           <Divider />
-          <PickerSection label="Model" hint="Cost tier shown next to each variant">
+          <PickerSection label="Model" hint="Premium variants marked with $$">
             {!isViewProviderConnected && (
               <div className="flex items-center gap-2 px-2.5 py-1">
                 <p className="flex-1 text-xs text-muted-foreground">
@@ -320,32 +307,15 @@ export const RoutingPicker = ({
               </div>
             )}
             {isViewProviderConnected && (
-              <>
-                {viewedRouting.models.length > 8 && (
-                  <div className="px-2.5">
-                    <Input
-                      value={modelFilter}
-                      onChange={(event) => setModelFilter(event.target.value)}
-                      placeholder="Filter models"
-                      aria-label="Filter models"
-                      className="h-7 text-xs"
-                    />
-                  </div>
-                )}
-                <ScrollFade fadeFrom="subtle" className="min-h-0 max-h-[15rem]">
-                  {filteredModels.length === 0 ? (
-                    <p className="px-2.5 py-1 text-xs text-muted-foreground">No matching models</p>
-                  ) : (
-                    <ModelGrid
-                      ids={filteredModels}
-                      value={viewedRouting.model}
-                      recommendedModel={viewedRecommendedModel}
-                      isRecommended={isModelRecommended}
-                      onSelect={onModel}
-                    />
-                  )}
-                </ScrollFade>
-              </>
+              <ScrollFade fadeFrom="subtle" className="min-h-0 max-h-[15rem]">
+                <ModelGrid
+                  ids={viewedRouting.models}
+                  value={viewedRouting.model}
+                  recommendedModel={viewedRecommendedModel}
+                  isRecommended={isModelRecommended}
+                  onSelect={onModel}
+                />
+              </ScrollFade>
             )}
           </PickerSection>
           {isViewProviderConnected && (
@@ -371,12 +341,6 @@ export const RoutingPicker = ({
                         label={EFFORT_LABEL[level]}
                         active={viewedRouting.effort === level}
                         onSelect={() => onEffort(level)}
-                        glyph={
-                          <span
-                            className={cn('size-1.5 shrink-0 rounded-full', EFFORT_DOT[level])}
-                            aria-hidden
-                          />
-                        }
                       />
                     ))}
                   </div>
@@ -393,12 +357,6 @@ export const RoutingPicker = ({
                           label={VERBOSITY_LABEL[level]}
                           active={verbosity === level}
                           onSelect={() => onVerbosity(level)}
-                          glyph={
-                            <span
-                              className={cn('size-1.5 shrink-0 rounded-full', VERBOSITY_DOT[level])}
-                              aria-hidden
-                            />
-                          }
                         />
                       ))}
                     </div>


### PR DESCRIPTION
## What

- Model variant chips lose the colored cost-tier dot; cost stays in the tooltip and premium variants get a muted `$$` marker. Effort and Replies chips are text-only too: three different meanings no longer share the same dot shape.
- Model filter field removed (only cursor crossed the 8-model threshold; the family grid plus scroll is enough at current catalog sizes).
- MODEL section hint updated accordingly.
- Regression fences kept: popover stays open on every selection, unconnected provider tabs keep their warning dot, useDropdown untouched.

Precedent: Cursor's model dropdown is plain text with pricing relegated to hover detail.

## Tests

- `tsc --noEmit` clean; 48 files / 376 tests green (picker + VerbositySelect + WorkflowStepCard + chat consumers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)