### PR TITLE
fix(desktop): role models applied at spawn, ghost roles removed

### DIFF
--- a/apps/desktop/src/features/session/agent-kind.test.ts
+++ b/apps/desktop/src/features/session/agent-kind.test.ts
@@ -414,11 +414,8 @@ describe('kindRouting role overrides', () => {
 describe('inferAgentKindFromStep', () => {
   it.each([
     ['scout', 'scout'],
-    ['explorer', 'scout'],
     ['investigator', 'debugger'],
     ['planner', 'planner'],
-    ['architect', 'planner'],
-    ['product', 'planner'],
     ['implementer', 'implementer'],
     ['tester', 'tester'],
     ['reviewer', 'reviewer'],

--- a/apps/desktop/src/features/session/agent-kind.ts
+++ b/apps/desktop/src/features/session/agent-kind.ts
@@ -196,13 +196,10 @@ export const AGENT_ROLES: ReadonlyArray<AgentRole> = [
 export const ROLE_TO_KIND: Record<AgentRole, AgentKind> = {
   scout: 'scout',
   planner: 'planner',
-  architect: 'planner',
-  product: 'generic',
   implementer: 'implementer',
   reviewer: 'reviewer',
   tester: 'tester',
   investigator: 'debugger',
-  explorer: 'scout',
   custom: 'generic',
 };
 
@@ -222,13 +219,10 @@ export const KIND_TO_ROLE: Record<AgentKind, AgentRole> = {
 export const ROLE_LABEL: Record<AgentRole, string> = {
   scout: 'Scout',
   planner: 'Planner',
-  architect: 'Architect',
-  product: 'Product',
   implementer: 'Implementer',
   reviewer: 'Reviewer',
   tester: 'Tester',
   investigator: 'Debugger',
-  explorer: 'Explorer',
   custom: 'Custom',
 };
 
@@ -305,11 +299,8 @@ export const AGENT_KIND_DEFAULTS: Record<
 
 const STEP_ROLE_KIND_LOOKUP: Record<string, AgentKind> = {
   scout: 'scout',
-  explorer: 'scout',
   investigator: 'debugger',
   planner: 'planner',
-  architect: 'planner',
-  product: 'planner',
   implementer: 'implementer',
   tester: 'tester',
   reviewer: 'reviewer',
@@ -334,7 +325,7 @@ export const inferAgentKindFromName = (name: string): AgentKind => {
   if (/scout|explor|survey|map/.test(lower)) {
     return 'scout';
   }
-  if (/plan|design|architect|spec|product/.test(lower)) {
+  if (/plan|design|spec/.test(lower)) {
     return 'planner';
   }
   if (/impl|build|develop|code|feature|refactor/.test(lower)) {

--- a/apps/desktop/src/features/session/components/AgentKindChip/index.test.tsx
+++ b/apps/desktop/src/features/session/components/AgentKindChip/index.test.tsx
@@ -18,8 +18,8 @@ describe('AgentKindChip', () => {
   });
 
   it('applies the title attribute when provided', () => {
-    const { container } = render(<AgentKindChip kind="scout" title="explorer agent" />);
-    expect(container.querySelector('[title="explorer agent"]')).not.toBeNull();
+    const { container } = render(<AgentKindChip kind="scout" title="scout agent" />);
+    expect(container.querySelector('[title="scout agent"]')).not.toBeNull();
   });
 
   it('marks the chip as aria-hidden so screen readers skip it', () => {

--- a/apps/desktop/src/shared/components/AgentAvatar/index.test.tsx
+++ b/apps/desktop/src/shared/components/AgentAvatar/index.test.tsx
@@ -22,7 +22,7 @@ describe('AgentAvatar', () => {
   });
 
   it('applies the title attribute when provided', () => {
-    const { container } = render(<AgentAvatar kind="scout" title="explorer" />);
-    expect(container.querySelector('[title="explorer"]')).not.toBeNull();
+    const { container } = render(<AgentAvatar kind="scout" title="scout" />);
+    expect(container.querySelector('[title="scout"]')).not.toBeNull();
   });
 });

--- a/apps/desktop/src/store/slices/agents/spawnAgent.test.ts
+++ b/apps/desktop/src/store/slices/agents/spawnAgent.test.ts
@@ -146,7 +146,17 @@ function buildHarness(plans: ReadonlyArray<PlanWithCount>) {
     planConsumptions: {},
     selectedAgentId: {},
     agentTurnState: {},
-    workspaceOverrides: {},
+    workspaceOverrides: {
+      [WS_ID]: {
+        roleModels: {
+          planner: {
+            providerId: 'anthropic',
+            model: 'claude-opus-5',
+            effort: 'high',
+          },
+        },
+      },
+    },
     transcripts: {},
     messages: {},
     agentModelOverride: {},
@@ -182,6 +192,26 @@ describe('spawnAgent ad-hoc cluster fan-out', () => {
     expect(invokeAgentInsertSpy).toHaveBeenCalledWith(
       expect.objectContaining({ kind: 'debugger', name: 'debug startup crash' }),
     );
+  });
+
+  it('seeds routing overrides from the workspace role model', async () => {
+    const { getState, spawn } = buildHarness([]);
+
+    await spawn(SESSION_ID, { kindOverride: 'planner' });
+
+    expect(getState().agentModelOverride[INSERTED_ID]).toBe('claude-opus-5');
+    expect(getState().agentProviderOverride[INSERTED_ID]).toBe('anthropic');
+    expect(getState().agentEffortOverride[INSERTED_ID]).toBe('high');
+  });
+
+  it('keeps an explicit model while seeding omitted routing fields', async () => {
+    const { getState, spawn } = buildHarness([]);
+
+    await spawn(SESSION_ID, { kindOverride: 'planner', model: 'claude-sonnet-4-6' });
+
+    expect(getState().agentModelOverride[INSERTED_ID]).toBe('claude-sonnet-4-6');
+    expect(getState().agentProviderOverride[INSERTED_ID]).toBe('anthropic');
+    expect(getState().agentEffortOverride[INSERTED_ID]).toBe('high');
   });
 
   it('fans out an explicit (triggeredPlanId) plan with 2+ clusters', async () => {

--- a/apps/desktop/src/store/slices/agents/spawnAgent.ts
+++ b/apps/desktop/src/store/slices/agents/spawnAgent.ts
@@ -18,6 +18,7 @@ import {
 } from '../../../features/plans/plans';
 import {
   inferAgentKindFromName,
+  kindRouting,
   kindConsumesPlan,
   type AgentKind,
 } from '../../../features/session/agent-kind';
@@ -88,6 +89,8 @@ export const spawnAgent = (set: SetFn, get: GetFn) => {
     const workspaceVerbositySeed =
       state.workspaceOverrides[session.workspaceId]?.defaultVerbosity ?? undefined;
     const resolvedKind = args.kindOverride ?? inferAgentKindFromName(resolvedName);
+    const roleModels = state.workspaceOverrides[session.workspaceId]?.roleModels;
+    const routing = kindRouting({ kind: resolvedKind, roleModels });
     const inserted = await invokeAgentInsert({
       sessionId,
       ...(args.stepId !== undefined && { stepId: args.stepId }),
@@ -111,15 +114,18 @@ export const spawnAgent = (set: SetFn, get: GetFn) => {
         ...s.agentTurnState,
         [inserted.id]: { kind: 'idle', lastActivityAt: new Date().toISOString() as IsoDateTime },
       },
-      ...(args.model !== undefined && {
-        agentModelOverride: { ...s.agentModelOverride, [inserted.id]: args.model },
-      }),
-      ...(args.provider !== undefined && {
-        agentProviderOverride: { ...s.agentProviderOverride, [inserted.id]: args.provider },
-      }),
-      ...(args.effort !== undefined && {
-        agentEffortOverride: { ...s.agentEffortOverride, [inserted.id]: args.effort },
-      }),
+      agentModelOverride: {
+        ...s.agentModelOverride,
+        [inserted.id]: args.model ?? routing.model,
+      },
+      agentProviderOverride: {
+        ...s.agentProviderOverride,
+        [inserted.id]: args.provider ?? routing.provider,
+      },
+      agentEffortOverride: {
+        ...s.agentEffortOverride,
+        [inserted.id]: args.effort ?? routing.effort,
+      },
       ...(args.kindOverride !== undefined && {
         agentKindOverride: { ...s.agentKindOverride, [inserted.id]: args.kindOverride },
       }),

--- a/apps/desktop/src/store/slices/sessions/createSession.ts
+++ b/apps/desktop/src/store/slices/sessions/createSession.ts
@@ -13,6 +13,7 @@ import type {
   WorkspaceId,
   WorkspaceMember,
 } from '@goodboy/types';
+import { resolveRoleRouting } from '@goodboy/core';
 import { DEFAULT_SESSION_PROVIDER_PREFERENCE } from '@goodboy/types';
 import {
   insertSession,
@@ -278,7 +279,10 @@ export const createSession = (set: SetFn, get: GetFn) => {
             ...(workspaceVerbositySeed && { verbosity: workspaceVerbositySeed }),
           });
           agentModelOverrides[agent.id] =
-            step.modelOverride ?? kindRouting({ kind, roleModels }).model;
+            step.modelOverride ??
+            (step.role != null
+              ? resolveRoleRouting({ role: step.role, prefs: roleModels }).model
+              : kindRouting({ kind, roleModels }).model);
           agentKindOverrides[agent.id] = kind;
           allAgents.push(agent);
         }

--- a/packages/core/src/planner/prompt.ts
+++ b/packages/core/src/planner/prompt.ts
@@ -20,7 +20,7 @@ no code fences. The schema is:
   "steps": [
     {
       "name": "<short imperative title>",
-      "role": "<scout|planner|implementer|reviewer|tester|investigator|product|architect|explorer|custom>",
+      "role": "<scout|planner|implementer|reviewer|tester|investigator|custom>",
       "promptPrefix": "<system-style instructions for the step's agent>",
       "expectedOutput": "<one sentence describing what the step should produce>"
     },

--- a/packages/core/src/providers/auto-model.test.ts
+++ b/packages/core/src/providers/auto-model.test.ts
@@ -73,7 +73,7 @@ describe('autoModelForRole', () => {
     });
 
     it('cursor provider: picks a real cursor slug for a mid-tier role, not auto', () => {
-      const result = autoModelForRole({ role: 'product', providers: ['cursor'] });
+      const result = autoModelForRole({ role: 'reviewer', providers: ['cursor'] });
       expect(result?.provider).toBe('cursor');
       expect(result?.model).not.toBe('auto');
       expect(CURSOR_MODELS.some((m) => m.id === result?.model)).toBe(true);

--- a/packages/core/src/providers/turn-weight.ts
+++ b/packages/core/src/providers/turn-weight.ts
@@ -28,7 +28,7 @@ const TRIVIAL_VERB_PATTERNS: ReadonlyArray<RegExp> = [
 const QUESTION_OPENERS = /^(what|where|when|which|why|who|how\s+(do|does|is|are|can|should))\b/i;
 
 const ARCHITECTURAL_VERBS =
-  /\b(design|architect|propose\s+architecture|migrate\s+database|redesign|rewrite)\b/i;
+  /\b(design|propose\s+architecture|migrate\s+database|redesign|rewrite)\b/i;
 
 const MULTI_STEP =
   /\bfirst\b.+\bthen\b.+\bthen\b|\bimplement\b.+\band\s+also\b|\brefactor\b.+\bacross\b/i;

--- a/packages/core/src/roles.test.ts
+++ b/packages/core/src/roles.test.ts
@@ -10,10 +10,7 @@ describe('ROLE_DEFAULTS', () => {
       'implementer',
       'reviewer',
       'investigator',
-      'product',
-      'architect',
       'tester',
-      'explorer',
       'custom',
     ];
     for (const role of expected) {
@@ -46,7 +43,6 @@ describe('ROLE_DEFAULTS', () => {
 
   it('routes design-heavy roles to the strong model', () => {
     expect(ROLE_DEFAULTS.planner.model).toMatch(/opus/);
-    expect(ROLE_DEFAULTS.architect.model).toMatch(/opus/);
   });
 
   it('routes balanced roles to sonnet', () => {

--- a/packages/core/src/roles.ts
+++ b/packages/core/src/roles.ts
@@ -28,18 +28,6 @@ export const ROLE_DEFAULTS = {
     effort: 'high',
     description: 'design the change; produce an ordered plan',
   },
-  architect: {
-    provider: 'anthropic',
-    model: 'claude-opus-5',
-    effort: 'high',
-    description: 'propose technical approach, modules, data flow, migrations',
-  },
-  product: {
-    provider: 'anthropic',
-    model: 'claude-sonnet-4-6',
-    effort: 'medium',
-    description: 'clarify user-facing behavior + acceptance criteria',
-  },
   implementer: {
     provider: 'anthropic',
     model: 'claude-sonnet-4-6',
@@ -57,12 +45,6 @@ export const ROLE_DEFAULTS = {
     model: 'claude-sonnet-4-6',
     effort: 'medium',
     description: 'write tests covering happy path + edge cases',
-  },
-  explorer: {
-    provider: 'anthropic',
-    model: 'claude-sonnet-4-6',
-    effort: 'medium',
-    description: 'open-ended chat; no fixed structure',
   },
   custom: {
     provider: 'anthropic',

--- a/packages/core/src/workflows/format.ts
+++ b/packages/core/src/workflows/format.ts
@@ -1,19 +1,7 @@
 import type { AgentRole, ProviderId } from '@goodboy/types';
 import { extractAuxOutput } from '../providers/aux-output';
 import { getCheapModel, getDefaultBinary } from '../providers/cli-defaults';
-
-const VALID_ROLES: ReadonlySet<AgentRole> = new Set<AgentRole>([
-  'scout',
-  'planner',
-  'implementer',
-  'reviewer',
-  'investigator',
-  'product',
-  'architect',
-  'tester',
-  'explorer',
-  'custom',
-]);
+import { isAgentRole } from '../roles';
 
 const WORKFLOW_FORMAT_SYSTEM_PROMPT = `You design multi-step AI coding workflows. Each step runs as its own dedicated agent, in order, left to right.
 
@@ -23,7 +11,7 @@ Rules:
 - Match the language of the DESIRED WORKFLOW description for all text fields (name, description, goal, step names, promptPrefix, expectedOutput, suggestions). If the description is written in Italian, write every field in Italian; same for any other language. Keep role values from the canonical list unchanged.
 - 2 to 6 steps. Each step has a single clear responsibility; do not bundle "plan and implement" into one step.
 - name: a short verb or noun (e.g. "Scout", "Plan", "Implement", "Review"). Title case, no numbering.
-- role: one of scout, planner, implementer, reviewer, investigator, product, architect, tester, explorer, custom. Pick the closest fit; use custom only when none apply.
+- role: one of scout, planner, implementer, reviewer, investigator, tester, custom. Pick the closest fit; use custom only when none apply.
 - promptPrefix: a direct instruction to that step's agent. Imperative voice. State what to do and what NOT to do (e.g. "do not write code yet"). One to three sentences.
 - expectedOutput: one sentence describing the artifact this step hands to the next.
 - Order steps so each depends only on prior outputs.
@@ -160,9 +148,8 @@ export const parseFormattedWorkflow = (text: string): FormattedWorkflow | null =
     if (name.length === 0) {
       continue;
     }
-    const roleRaw =
-      typeof e.role === 'string' ? (e.role.trim().toLowerCase() as AgentRole) : 'custom';
-    const role = VALID_ROLES.has(roleRaw) ? roleRaw : 'custom';
+    const roleRaw = typeof e.role === 'string' ? e.role.trim().toLowerCase() : 'custom';
+    const role = isAgentRole(roleRaw) ? roleRaw : 'custom';
     const promptPrefix = typeof e.promptPrefix === 'string' ? e.promptPrefix.trim() : '';
     const expectedOutput = typeof e.expectedOutput === 'string' ? e.expectedOutput.trim() : '';
     steps.push({ name, role, promptPrefix, expectedOutput });

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -78,6 +78,7 @@ import { m077StepExpectedOutput } from './m077-step-expected-output';
 import { m078WorkflowProcessText } from './m078-workflow-process-text';
 import { m079RoleModels } from './m079-role-models';
 import { m080AgentDone } from './m080-agent-done';
+import { m081RoleCleanup } from './m081-role-cleanup';
 
 export type Migration = {
   readonly version: number;
@@ -165,4 +166,5 @@ export const migrations: ReadonlyArray<Migration> = [
   { version: 78, sql: m078WorkflowProcessText },
   { version: 79, sql: m079RoleModels },
   { version: 80, sql: m080AgentDone },
+  { version: 81, sql: m081RoleCleanup },
 ];

--- a/packages/db/src/migrations/m081-role-cleanup.ts
+++ b/packages/db/src/migrations/m081-role-cleanup.ts
@@ -1,0 +1,6 @@
+export const m081RoleCleanup = `
+UPDATE steps SET role = 'planner' WHERE role IN ('architect', 'product');
+UPDATE steps SET role = 'scout' WHERE role = 'explorer';
+UPDATE step_library SET role = 'planner' WHERE role IN ('architect', 'product');
+UPDATE step_library SET role = 'scout' WHERE role = 'explorer';
+`;

--- a/packages/types/src/workflow.ts
+++ b/packages/types/src/workflow.ts
@@ -22,10 +22,7 @@ export type AgentRole =
   | 'implementer'
   | 'reviewer'
   | 'investigator'
-  | 'product'
-  | 'architect'
   | 'tester'
-  | 'explorer'
   | 'custom';
 
 export type AgentStatus = 'pending' | 'running' | 'completed' | 'failed' | 'skipped';


### PR DESCRIPTION
## What

- Role-model overrides now actually apply: `spawnAgent` seeds model/provider/effort from `kindRouting({ kind, roleModels })` when the caller passes none, so agents created by hand (create-agent row, handoff chip, chat prefix) run on the configured per-role model instead of silently falling back to the session default. Explicit caller args still win per-field. This also aligns runtime behavior with the default the routing pill already displayed.
- Roles `architect`, `product`, `explorer` removed from `AgentRole`, `ROLE_DEFAULTS`, the kind maps and workflow role validation (unknown roles now coerce to `custom`). They were configurable in DefaultsPanel but no creatable agent ever used them, and `product` mapped to two different kinds depending on entry point.
- Migration m081 remaps persisted step roles (`architect`/`product` to `planner`, `explorer` to `scout`) in both `steps` and `step_library`.
- `createSession` step seeding reads the step role directly instead of the role-to-kind-to-role round-trip.

## Tests

- db 106, core 860, full desktop suite 329 files / 2686 tests, all green. Migration convergence covered by registry.test.ts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)