### PR TITLE
feat(desktop): integrations always visible with connect CTA

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -63,6 +63,7 @@ import {
 import { refreshPricingTable } from './features/providers/provider-pricing';
 import { useGithubPolling } from './features/github/hooks/useGithubPolling';
 import { useUpdaterPolling } from './features/updater/hooks/useUpdaterPolling';
+import { useRemoteHostKind } from './features/worktree/useRemoteHostKind';
 
 const KEEP_ALIVE_CAP = 5;
 
@@ -77,6 +78,7 @@ export const App = () => {
   const hasWorkspaces = workspaces.length > 0;
   const currentWorkspace = useCurrentWorkspace();
   const currentSession = useCurrentSession();
+  const remoteKind = useRemoteHostKind(currentWorkspace?.id ?? null);
   const sessionsSidebarCollapsed = useAppStore((s) => s.sessionsSidebarCollapsed);
   const toggleSessionsSidebar = useAppStore((s) => s.toggleSessionsSidebar);
   const hasLinear = useAppStore((s) =>
@@ -793,6 +795,7 @@ export const App = () => {
           currentWorkspace ? (
             <AppFooter
               activeStudio={activeStudio}
+              githubEnabled={remoteKind === 'github'}
               linearEnabled={hasLinear}
               sentryEnabled={hasSentry}
               gitlabEnabled={hasGitlab}

--- a/apps/desktop/src/__tests__/keyboard/lens-shortcuts.test.tsx
+++ b/apps/desktop/src/__tests__/keyboard/lens-shortcuts.test.tsx
@@ -17,6 +17,7 @@ const { setActiveLens, shortcutHandlers, state } = vi.hoisted(() => {
       sessionsSidebarCollapsed: false,
       toggleSessionsSidebar: vi.fn(),
       workspaceIntegrations: {},
+      workspaces: [],
       setSessionStudio: vi.fn(),
       openWorkspace: vi.fn(),
       setCurrentSession: vi.fn(),

--- a/apps/desktop/src/app/components/AppFooter/index.test.tsx
+++ b/apps/desktop/src/app/components/AppFooter/index.test.tsx
@@ -1,6 +1,14 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+const { integrationGlyph } = vi.hoisted(() => ({
+  integrationGlyph: vi.fn(),
+}));
+
+type MockGlyphProps = {
+  provider: string;
+};
+
 vi.mock('../../../store', () => ({
   useAppStore: (
     selector: (state: { providers: ReadonlyArray<{ connection: string }> }) => unknown,
@@ -8,10 +16,16 @@ vi.mock('../../../store', () => ({
 }));
 
 vi.mock('../../../features/integrations/components/IntegrationGlyph', () => ({
-  IntegrationGlyph: () => null,
+  IntegrationGlyph: ({ provider }: MockGlyphProps) => {
+    integrationGlyph(provider);
+    return null;
+  },
 }));
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
 
 import { AppFooter } from './index';
 
@@ -30,6 +44,7 @@ describe('AppFooter', () => {
         onOpenLinear={vi.fn()}
         onOpenSentry={vi.fn()}
         onOpenGitlab={vi.fn()}
+        githubEnabled={false}
         linearEnabled={false}
         sentryEnabled={false}
         gitlabEnabled={false}
@@ -53,5 +68,69 @@ describe('AppFooter', () => {
     expect(onOpenWorkflows).toHaveBeenCalledOnce();
     expect(onOpenProviders).toHaveBeenCalledOnce();
     expect(onOpenBudget).toHaveBeenCalledOnce();
+  });
+
+  it('renders every disconnected integration and opens integration settings', () => {
+    const workspaceSettingsListener = vi.fn();
+    window.addEventListener('goodboy:open-workspace-settings', workspaceSettingsListener);
+
+    render(
+      <AppFooter
+        activeStudio={null}
+        onOpenWorkflows={vi.fn()}
+        onOpenProviders={vi.fn()}
+        onOpenBudget={vi.fn()}
+        onOpenGithub={vi.fn()}
+        onOpenLinear={vi.fn()}
+        onOpenSentry={vi.fn()}
+        onOpenGitlab={vi.fn()}
+        githubEnabled={false}
+        linearEnabled={false}
+        sentryEnabled={false}
+        gitlabEnabled={false}
+      />,
+    );
+
+    expect(integrationGlyph.mock.calls.map(([provider]) => provider)).toEqual([
+      'github',
+      'gitlab',
+      'linear',
+      'sentry',
+    ]);
+    expect(screen.getByRole('button', { name: 'Connect GitHub' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Connect GitLab' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Connect Linear' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Connect Sentry' })).toBeDefined();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Connect GitLab' }));
+
+    expect(workspaceSettingsListener).toHaveBeenCalledWith(
+      expect.objectContaining({ detail: { section: 'integrations' } }),
+    );
+    window.removeEventListener('goodboy:open-workspace-settings', workspaceSettingsListener);
+  });
+
+  it('opens the GitLab studio when GitLab is connected', () => {
+    const onOpenGitlab = vi.fn();
+    render(
+      <AppFooter
+        activeStudio={null}
+        onOpenWorkflows={vi.fn()}
+        onOpenProviders={vi.fn()}
+        onOpenBudget={vi.fn()}
+        onOpenGithub={vi.fn()}
+        onOpenLinear={vi.fn()}
+        onOpenSentry={vi.fn()}
+        onOpenGitlab={onOpenGitlab}
+        githubEnabled={false}
+        linearEnabled={false}
+        sentryEnabled={false}
+        gitlabEnabled
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'launch a session from a GitLab issue' }));
+
+    expect(onOpenGitlab).toHaveBeenCalledOnce();
   });
 });

--- a/apps/desktop/src/app/components/AppFooter/index.tsx
+++ b/apps/desktop/src/app/components/AppFooter/index.tsx
@@ -11,25 +11,41 @@ type FooterButtonProps = {
   onClick: () => void;
   pulse?: boolean;
   active?: boolean;
+  connected?: boolean;
 };
 
-const FooterButton = ({ icon, label, title, onClick, pulse, active }: FooterButtonProps) => (
+const FooterButton = ({
+  icon,
+  label,
+  title,
+  onClick,
+  pulse,
+  active,
+  connected,
+}: FooterButtonProps) => (
   <button
     type="button"
     onClick={onClick}
     title={title ?? label}
     aria-label={title ?? label}
     className={cn(
-      'flex items-center gap-1.5 rounded px-2 py-1 text-2xs font-medium transition-colors',
+      'relative flex items-center gap-1.5 rounded px-2 py-1 text-2xs font-medium transition-colors',
       active
         ? 'bg-foreground text-background'
         : pulse
           ? 'animate-soft-pulse text-info hover:bg-info/10'
           : 'text-muted-foreground hover:bg-muted/50 hover:text-foreground',
+      connected === false && 'opacity-40',
     )}
   >
     {icon}
     <span>{label}</span>
+    {connected === false ? (
+      <span
+        aria-hidden
+        className="absolute right-0 top-0 size-1.5 rounded-full bg-warning ring-1 ring-subtle"
+      />
+    ) : null}
   </button>
 );
 
@@ -42,6 +58,7 @@ type Props = {
   onOpenLinear: () => void;
   onOpenSentry: () => void;
   onOpenGitlab: () => void;
+  githubEnabled: boolean;
   linearEnabled: boolean;
   sentryEnabled: boolean;
   gitlabEnabled: boolean;
@@ -56,6 +73,7 @@ export const AppFooter = ({
   onOpenLinear,
   onOpenSentry,
   onOpenGitlab,
+  githubEnabled,
   linearEnabled,
   sentryEnabled,
   gitlabEnabled,
@@ -69,42 +87,78 @@ export const AppFooter = ({
       <Divider />
       <div className="relative flex h-9 items-center justify-between bg-background px-2">
         <div className="flex items-center gap-0.5">
-          {!gitlabEnabled ? (
-            <FooterButton
-              icon={<IntegrationGlyph provider="github" size="xs" />}
-              label="GitHub"
-              title="review and act on pull requests across this workspace"
-              onClick={onOpenGithub}
-              active={activeStudio === 'github'}
-            />
-          ) : null}
-          {gitlabEnabled ? (
-            <FooterButton
-              icon={<IntegrationGlyph provider="gitlab" size="xs" />}
-              label="GitLab"
-              title="launch a session from a GitLab issue"
-              onClick={onOpenGitlab}
-              active={activeStudio === 'gitlab'}
-            />
-          ) : null}
-          {linearEnabled ? (
-            <FooterButton
-              icon={<IntegrationGlyph provider="linear" size="xs" />}
-              label="Linear"
-              title="launch a session from a Linear issue"
-              onClick={onOpenLinear}
-              active={activeStudio === 'linear'}
-            />
-          ) : null}
-          {sentryEnabled ? (
-            <FooterButton
-              icon={<IntegrationGlyph provider="sentry" size="xs" />}
-              label="Sentry"
-              title="launch a session from a Sentry issue"
-              onClick={onOpenSentry}
-              active={activeStudio === 'sentry'}
-            />
-          ) : null}
+          <FooterButton
+            icon={<IntegrationGlyph provider="github" size="xs" />}
+            label="GitHub"
+            title={
+              githubEnabled
+                ? 'review and act on pull requests across this workspace'
+                : 'Connect GitHub'
+            }
+            onClick={
+              githubEnabled
+                ? onOpenGithub
+                : () =>
+                    window.dispatchEvent(
+                      new CustomEvent('goodboy:open-workspace-settings', {
+                        detail: { section: 'integrations' },
+                      }),
+                    )
+            }
+            active={activeStudio === 'github'}
+            connected={githubEnabled}
+          />
+          <FooterButton
+            icon={<IntegrationGlyph provider="gitlab" size="xs" />}
+            label="GitLab"
+            title={gitlabEnabled ? 'launch a session from a GitLab issue' : 'Connect GitLab'}
+            onClick={
+              gitlabEnabled
+                ? onOpenGitlab
+                : () =>
+                    window.dispatchEvent(
+                      new CustomEvent('goodboy:open-workspace-settings', {
+                        detail: { section: 'integrations' },
+                      }),
+                    )
+            }
+            active={activeStudio === 'gitlab'}
+            connected={gitlabEnabled}
+          />
+          <FooterButton
+            icon={<IntegrationGlyph provider="linear" size="xs" />}
+            label="Linear"
+            title={linearEnabled ? 'launch a session from a Linear issue' : 'Connect Linear'}
+            onClick={
+              linearEnabled
+                ? onOpenLinear
+                : () =>
+                    window.dispatchEvent(
+                      new CustomEvent('goodboy:open-workspace-settings', {
+                        detail: { section: 'integrations' },
+                      }),
+                    )
+            }
+            active={activeStudio === 'linear'}
+            connected={linearEnabled}
+          />
+          <FooterButton
+            icon={<IntegrationGlyph provider="sentry" size="xs" />}
+            label="Sentry"
+            title={sentryEnabled ? 'launch a session from a Sentry issue' : 'Connect Sentry'}
+            onClick={
+              sentryEnabled
+                ? onOpenSentry
+                : () =>
+                    window.dispatchEvent(
+                      new CustomEvent('goodboy:open-workspace-settings', {
+                        detail: { section: 'integrations' },
+                      }),
+                    )
+            }
+            active={activeStudio === 'sentry'}
+            connected={sentryEnabled}
+          />
         </div>
 
         <span className="pointer-events-none absolute inset-x-0 mx-auto w-fit rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-primary ring-1 ring-primary/15">

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn.test.tsx
@@ -468,9 +468,11 @@ describe('LensColumn', () => {
     expect(container.querySelectorAll('[class*="animate-pulse"]')).toHaveLength(0);
   });
 
-  it('hides disconnected integration rows without linked tasks', () => {
+  it('offers integration settings when no integration rows are available', () => {
     remote.kind = 'other';
     store.workspaceIntegrations = {};
+    const workspaceSettingsListener = vi.fn();
+    window.addEventListener('goodboy:open-workspace-settings', workspaceSettingsListener);
 
     render(
       <LensColumn
@@ -486,5 +488,18 @@ describe('LensColumn', () => {
     expect(screen.queryByRole('button', { name: 'Sentry' })).toBeNull();
     expect(screen.queryByRole('button', { name: /GitLab issues/ })).toBeNull();
     expect(screen.queryByRole('button', { name: 'GitHub' })).toBeNull();
+    const connect = screen.getByRole('button', { name: 'Connect an integration' });
+    expect(connect).toBeDefined();
+
+    for (const heading of screen.getAllByText(/^(Work|Artifacts|Context|Integrations|Infra)$/)) {
+      expect(heading.parentElement?.querySelector('button')).not.toBeNull();
+    }
+
+    fireEvent.click(connect);
+
+    expect(workspaceSettingsListener).toHaveBeenCalledWith(
+      expect.objectContaining({ detail: { section: 'integrations' } }),
+    );
+    window.removeEventListener('goodboy:open-workspace-settings', workspaceSettingsListener);
   });
 });

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn.tsx
@@ -10,6 +10,7 @@ import {
   FileText,
   LayoutDashboard,
   MessageSquareReply,
+  Plug,
   SquareTerminal,
   Target,
   Terminal,
@@ -435,6 +436,9 @@ export const LensColumn = ({
     },
   ];
   const groups = workspaceKind === 'simple' ? simpleGroups : repoGroups;
+  const visibleGroups = groups.filter(
+    (group) => group.rows.length > 0 || group.label === 'Integrations',
+  );
 
   return (
     <ScrollFade className="min-h-0 flex-1">
@@ -469,109 +473,132 @@ export const LensColumn = ({
             ⌘⇧O
           </KbdPill>
         </button>
-        {groups.map((group) => (
+        {visibleGroups.map((group) => (
           <div key={group.label} className="flex flex-col gap-0.5">
             <span className="px-2 pb-1 text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground/60">
               {group.label}
             </span>
-            {group.rows.map((row) => {
-              const active = activeLens === row.kind;
-              const shortcut = LENS_SHORTCUTS[row.kind];
-              const hasBadge =
-                row.isCountLoading === true ||
-                (row.count != null && row.count > 0) ||
-                row.dot != null ||
-                row.secondaryDot === true;
-              return (
-                <button
-                  key={row.kind}
-                  type="button"
-                  onClick={() => onSelect(row.kind)}
-                  aria-current={active ? 'page' : undefined}
-                  className={cn(
-                    'group relative flex items-center gap-2.5 rounded-md px-2 py-1.5 text-left transition-colors',
-                    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]',
-                    active
-                      ? 'bg-foreground/[0.06] text-foreground'
-                      : 'text-muted-foreground hover:bg-foreground/[0.03] hover:text-foreground',
-                  )}
-                >
-                  {row.glyph ? (
-                    <IconTile
-                      size="xs"
-                      color={`var(--color-provider-${row.glyph})`}
-                      ring
-                      className="transition-colors"
-                    >
-                      <span aria-hidden>
-                        <IntegrationGlyph provider={row.glyph} />
-                      </span>
-                    </IconTile>
-                  ) : row.icon ? (
-                    <IconTile size="xs" tone={row.tone} className="transition-colors">
-                      <row.icon size={12} aria-hidden />
-                    </IconTile>
-                  ) : null}
-                  <span
+            {group.rows.length === 0 ? (
+              <button
+                type="button"
+                onClick={() =>
+                  window.dispatchEvent(
+                    new CustomEvent('goodboy:open-workspace-settings', {
+                      detail: { section: 'integrations' },
+                    }),
+                  )
+                }
+                className={cn(
+                  'group relative flex items-center gap-2.5 rounded-md px-2 py-1.5 text-left text-muted-foreground transition-colors',
+                  'hover:bg-foreground/[0.03] hover:text-foreground',
+                  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]',
+                )}
+              >
+                <IconTile size="xs" tone="neutral" className="transition-colors">
+                  <Plug size={12} aria-hidden />
+                </IconTile>
+                <span className="min-w-0 flex-1 truncate text-[13px]">Connect an integration</span>
+              </button>
+            ) : (
+              group.rows.map((row) => {
+                const active = activeLens === row.kind;
+                const shortcut = LENS_SHORTCUTS[row.kind];
+                const hasBadge =
+                  row.isCountLoading === true ||
+                  (row.count != null && row.count > 0) ||
+                  row.dot != null ||
+                  row.secondaryDot === true;
+                return (
+                  <button
+                    key={row.kind}
+                    type="button"
+                    onClick={() => onSelect(row.kind)}
+                    aria-current={active ? 'page' : undefined}
                     className={cn(
-                      'min-w-0 flex-1 truncate text-[13px]',
-                      shortcut != null && !hasBadge && 'pr-12',
-                      active && 'font-medium',
+                      'group relative flex items-center gap-2.5 rounded-md px-2 py-1.5 text-left transition-colors',
+                      'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]',
+                      active
+                        ? 'bg-foreground/[0.06] text-foreground'
+                        : 'text-muted-foreground hover:bg-foreground/[0.03] hover:text-foreground',
                     )}
                   >
-                    {row.label}
-                  </span>
-                  {hasBadge ? (
+                    {row.glyph ? (
+                      <IconTile
+                        size="xs"
+                        color={`var(--color-provider-${row.glyph})`}
+                        ring
+                        className="transition-colors"
+                      >
+                        <span aria-hidden>
+                          <IntegrationGlyph provider={row.glyph} />
+                        </span>
+                      </IconTile>
+                    ) : row.icon ? (
+                      <IconTile size="xs" tone={row.tone} className="transition-colors">
+                        <row.icon size={12} aria-hidden />
+                      </IconTile>
+                    ) : null}
                     <span
                       className={cn(
-                        'flex shrink-0 items-center gap-1.5 transition-opacity',
-                        shortcut != null &&
-                          'min-w-10 justify-end group-hover:opacity-0 group-focus-visible:opacity-0',
+                        'min-w-0 flex-1 truncate text-[13px]',
+                        shortcut != null && !hasBadge && 'pr-12',
+                        active && 'font-medium',
                       )}
                     >
-                      {row.isCountLoading === true ? (
-                        <span data-testid={`lens-count-loading-${row.kind}`}>
-                          <Skeleton className="h-4 w-6 rounded-full" />
-                        </span>
-                      ) : row.count != null && row.count > 0 ? (
-                        <span className="flex shrink-0 items-center gap-1.5">
-                          {row.secondaryDot ? <StatusDot tone="accent" size="sm" /> : null}
-                          {row.dot === 'running' ? (
-                            <StatusDot tone="info" size="sm" pulsing />
-                          ) : null}
-                          <span
-                            className={cn(
-                              'rounded px-1.5 py-0.5 text-2xs font-medium tabular-nums',
-                              row.dot === 'attention'
-                                ? 'bg-warning/15 text-warning'
-                                : 'bg-muted text-muted-foreground',
-                            )}
-                          >
-                            {row.count}
-                          </span>
-                        </span>
-                      ) : row.dot ? (
-                        <StatusDot
-                          tone={row.dot === 'attention' ? 'warning' : 'info'}
-                          size="sm"
-                          pulsing={row.dot === 'running'}
-                        />
-                      ) : row.secondaryDot ? (
-                        <StatusDot tone="accent" size="sm" />
-                      ) : null}
+                      {row.label}
                     </span>
-                  ) : null}
-                  {shortcut != null ? (
-                    <KbdPill
-                      aria-hidden
-                      className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[10px] opacity-0 transition-opacity group-hover:opacity-60 group-focus-visible:opacity-60"
-                    >
-                      {shortcut}
-                    </KbdPill>
-                  ) : null}
-                </button>
-              );
-            })}
+                    {hasBadge ? (
+                      <span
+                        className={cn(
+                          'flex shrink-0 items-center gap-1.5 transition-opacity',
+                          shortcut != null &&
+                            'min-w-10 justify-end group-hover:opacity-0 group-focus-visible:opacity-0',
+                        )}
+                      >
+                        {row.isCountLoading === true ? (
+                          <span data-testid={`lens-count-loading-${row.kind}`}>
+                            <Skeleton className="h-4 w-6 rounded-full" />
+                          </span>
+                        ) : row.count != null && row.count > 0 ? (
+                          <span className="flex shrink-0 items-center gap-1.5">
+                            {row.secondaryDot ? <StatusDot tone="accent" size="sm" /> : null}
+                            {row.dot === 'running' ? (
+                              <StatusDot tone="info" size="sm" pulsing />
+                            ) : null}
+                            <span
+                              className={cn(
+                                'rounded px-1.5 py-0.5 text-2xs font-medium tabular-nums',
+                                row.dot === 'attention'
+                                  ? 'bg-warning/15 text-warning'
+                                  : 'bg-muted text-muted-foreground',
+                              )}
+                            >
+                              {row.count}
+                            </span>
+                          </span>
+                        ) : row.dot ? (
+                          <StatusDot
+                            tone={row.dot === 'attention' ? 'warning' : 'info'}
+                            size="sm"
+                            pulsing={row.dot === 'running'}
+                          />
+                        ) : row.secondaryDot ? (
+                          <StatusDot tone="accent" size="sm" />
+                        ) : null}
+                      </span>
+                    ) : null}
+                    {shortcut != null ? (
+                      <KbdPill
+                        aria-hidden
+                        className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[10px] opacity-0 transition-opacity group-hover:opacity-60 group-focus-visible:opacity-60"
+                      >
+                        {shortcut}
+                      </KbdPill>
+                    ) : null}
+                  </button>
+                );
+              })
+            )}
           </div>
         ))}
       </nav>


### PR DESCRIPTION
## What

- Footer bottom-left now always renders all four integration glyphs (GitHub, GitLab, Linear, Sentry). Connected ones open their studio as before; unconnected ones render dimmed with a warning dot and a `Connect X` tooltip, and clicking them opens Workspace settings on the Integrations section.
- LensColumn integrations group is never a bare header anymore: with zero available integrations it shows a `Connect an integration` row wired to the same flow, and empty groups no longer render orphan labels.
- Same semantics the routing picker v3 established for unconnected providers, applied to the integrations surface.

Stacked on #1011 (shares AppFooter).

## Tests

- `tsc --noEmit` clean; 18 files / 147 tests green (app + SessionWorkspace).

🤖 Generated with [Claude Code](https://claude.com/claude-code)