### PR TITLE
refactor(desktop): unified brand glyph primitive

### DIFF
--- a/apps/desktop/src/app/components/AppTopBar/index.test.tsx
+++ b/apps/desktop/src/app/components/AppTopBar/index.test.tsx
@@ -62,7 +62,7 @@ describe('AppTopBar', () => {
   it('opens budget from the workspace rollup and omits the beta chip', () => {
     const onOpenBudget = vi.fn();
     render(<AppTopBar onOpenSettings={vi.fn()} onOpenBudget={onOpenBudget} activeStudio={null} />);
-    fireEvent.click(screen.getByTitle('Open budget'));
+    fireEvent.click(screen.getByTitle("Today's spend across providers, open budget"));
     expect(onOpenBudget).toHaveBeenCalledOnce();
     expect(screen.queryByText('Beta')).toBeNull();
   });

--- a/apps/desktop/src/app/components/AppTopBar/index.tsx
+++ b/apps/desktop/src/app/components/AppTopBar/index.tsx
@@ -40,7 +40,7 @@ export const AppTopBar = ({ onOpenSettings, onOpenBudget, activeStudio }: AppTop
         <button
           type="button"
           onClick={onOpenBudget}
-          title="Open budget"
+          title="Today's spend across providers, open budget"
           className="rounded px-1.5 py-1 transition-colors hover:bg-muted/50"
         >
           <WorkspaceRollupStrip />

--- a/apps/desktop/src/features/integrations/components/IntegrationGlyph/index.tsx
+++ b/apps/desktop/src/features/integrations/components/IntegrationGlyph/index.tsx
@@ -1,5 +1,5 @@
-import { cn, IconTile } from '@goodboy/ui';
 import type { LucideIcon } from 'lucide-react';
+import { BrandGlyph } from '../../../../shared/components/BrandGlyph';
 import {
   GithubIcon,
   GitlabIcon,
@@ -22,13 +22,6 @@ const INTEGRATION_BRAND: Record<IntegrationGlyphProvider, IntegrationBrand> = {
   sentry: { icon: SentryIcon, label: 'Sentry', cssVar: '--color-provider-sentry' },
 };
 
-const MARK_SIZE: Record<'xs' | 'sm', number> = {
-  xs: 12,
-  sm: 14,
-};
-
-const FRAMED_MARK_SIZE = 16;
-
 type Props = {
   readonly provider: IntegrationGlyphProvider;
   readonly size?: 'xs' | 'sm';
@@ -37,24 +30,15 @@ type Props = {
 };
 
 export const IntegrationGlyph = ({ provider, size = 'sm', framed = false, className }: Props) => {
-  const { icon: Icon, label, cssVar } = INTEGRATION_BRAND[provider];
-  const color = `var(${cssVar})`;
-
-  if (!framed) {
-    return (
-      <Icon
-        size={MARK_SIZE[size]}
-        role="img"
-        aria-label={label}
-        className={cn('shrink-0', className)}
-        style={{ color }}
-      />
-    );
-  }
-
+  const brand = INTEGRATION_BRAND[provider];
   return (
-    <IconTile size="sm" color={color} className={className}>
-      <Icon size={FRAMED_MARK_SIZE} role="img" aria-label={label} style={{ color }} />
-    </IconTile>
+    <BrandGlyph
+      icon={brand.icon}
+      cssVar={brand.cssVar}
+      size={size}
+      framed={framed}
+      className={className}
+      label={brand.label}
+    />
   );
 };

--- a/apps/desktop/src/features/providers/components/ProviderIcon.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderIcon.tsx
@@ -1,6 +1,6 @@
-import { cn, IconTile } from '@goodboy/ui';
-import type { ProviderId } from '@goodboy/types';
-import { PROVIDER_BRAND, brandColor } from './provider-brand';
+import { PROVIDER_IDS } from '@goodboy/types';
+import { BrandGlyph } from '../../../shared/components/BrandGlyph';
+import { PROVIDER_BRAND } from './provider-brand';
 
 type Props = {
   readonly provider: string | null | undefined;
@@ -10,8 +10,6 @@ type Props = {
   readonly variant?: 'glyph' | 'icon';
 };
 
-const PROVIDER_IDS: ReadonlyArray<ProviderId> = ['anthropic', 'cursor', 'codex', 'gemini'];
-
 export const ProviderIcon = ({
   provider,
   size = 14,
@@ -19,48 +17,33 @@ export const ProviderIcon = ({
   muted,
   variant = 'icon',
 }: Props) => {
+  const id = PROVIDER_IDS.find((candidate) => candidate === provider);
+  if (id == null && variant === 'glyph') {
+    return null;
+  }
+  if (id == null) {
+    return <span className="text-2xs text-muted-foreground">{provider}</span>;
+  }
+
+  const brand = PROVIDER_BRAND[id];
   if (variant === 'glyph') {
-    if (provider == null || provider === '' || !(provider in PROVIDER_BRAND)) {
-      return null;
-    }
-    const id = provider as ProviderId;
-    const Icon = PROVIDER_BRAND[id].icon;
     return (
-      <Icon
+      <BrandGlyph
+        icon={brand.icon}
+        cssVar={brand.cssVar}
         size={11}
-        aria-hidden
-        className={cn('shrink-0', muted && 'opacity-40')}
-        style={{ color: brandColor(id) }}
+        className={muted === true ? 'opacity-40' : undefined}
       />
     );
   }
 
-  const id = PROVIDER_IDS.includes(provider as ProviderId) ? (provider as ProviderId) : null;
-  if (id === null) {
-    return <span className="text-2xs text-muted-foreground">{provider}</span>;
-  }
-  const Icon = PROVIDER_BRAND[id].icon;
-  const color = brandColor(id);
-  const label = id === 'anthropic' ? 'claude' : id;
-
-  if (!withChip) {
-    return <Icon size={size} aria-label={label} style={{ color }} />;
-  }
-
-  let tileSize: 'xs' | 'sm' | 'md' | 'lg' = 'md';
-  if (size <= 16) {
-    tileSize = 'xs';
-  }
-  if (size > 16 && size <= 22) {
-    tileSize = 'sm';
-  }
-  if (size > 30) {
-    tileSize = 'lg';
-  }
-
   return (
-    <IconTile size={tileSize} color={color}>
-      <Icon size={size} aria-label={label} />
-    </IconTile>
+    <BrandGlyph
+      icon={brand.icon}
+      cssVar={brand.cssVar}
+      size={size}
+      framed={withChip}
+      label={id === 'anthropic' ? 'claude' : id}
+    />
   );
 };

--- a/apps/desktop/src/shared/components/BrandGlyph/index.test.tsx
+++ b/apps/desktop/src/shared/components/BrandGlyph/index.test.tsx
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { GithubIcon } from '../brand-icons';
+import { BrandGlyph } from './index';
+
+afterEach(cleanup);
+
+describe('BrandGlyph', () => {
+  it('renders an unframed glyph with its size and color', () => {
+    render(
+      <BrandGlyph icon={GithubIcon} cssVar="--color-provider-github" size="xs" label="GitHub" />,
+    );
+
+    const glyph = screen.getByRole('img', { name: 'GitHub' });
+    expect(glyph.getAttribute('width')).toBe('12');
+    expect(glyph.style.color).toBe('var(--color-provider-github)');
+    expect(glyph.getAttribute('class')).toContain('shrink-0');
+  });
+
+  it('renders a framed glyph with a tinted tile', () => {
+    render(
+      <BrandGlyph
+        icon={GithubIcon}
+        cssVar="--color-provider-github"
+        size={26}
+        framed
+        label="GitHub"
+      />,
+    );
+
+    const glyph = screen.getByRole('img', { name: 'GitHub' });
+    const tile = glyph.parentElement;
+    expect(glyph.getAttribute('width')).toBe('26');
+    expect(tile?.className).toContain('size-9 rounded-lg');
+    expect(tile?.style.color).toBe('var(--color-provider-github)');
+  });
+
+  it('hides an unlabeled glyph from assistive technology', () => {
+    const { container } = render(<BrandGlyph icon={GithubIcon} cssVar="--color-provider-github" />);
+
+    const glyph = container.querySelector('svg');
+    expect(glyph?.getAttribute('aria-hidden')).toBe('true');
+    expect(screen.queryByRole('img')).toBeNull();
+  });
+});

--- a/apps/desktop/src/shared/components/BrandGlyph/index.tsx
+++ b/apps/desktop/src/shared/components/BrandGlyph/index.tsx
@@ -1,0 +1,70 @@
+import { cn, IconTile } from '@goodboy/ui';
+import type { LucideIcon } from 'lucide-react';
+
+const MARK_SIZE = {
+  xs: 12,
+  sm: 14,
+} satisfies Record<'xs' | 'sm', number>;
+
+type Size = number | keyof typeof MARK_SIZE;
+
+type Props = {
+  readonly icon: LucideIcon;
+  readonly cssVar: string;
+  readonly size?: Size;
+  readonly framed?: boolean;
+  readonly className?: string;
+  readonly label?: string;
+};
+
+export const BrandGlyph = ({
+  icon: Icon,
+  cssVar,
+  size = 'sm',
+  framed = false,
+  className,
+  label,
+}: Props) => {
+  const color = `var(${cssVar})`;
+  const isSemanticSize = typeof size === 'string';
+  const glyphSize = isSemanticSize ? (framed ? 16 : MARK_SIZE[size]) : size;
+
+  if (!framed) {
+    return (
+      <Icon
+        size={glyphSize}
+        role={label != null ? 'img' : undefined}
+        aria-label={label}
+        aria-hidden={label == null ? true : undefined}
+        className={cn('shrink-0', className)}
+        style={{ color }}
+      />
+    );
+  }
+
+  let tileSize: 'xs' | 'sm' | 'md' | 'lg' = 'sm';
+  if (!isSemanticSize) {
+    tileSize = 'md';
+  }
+  if (!isSemanticSize && size <= 16) {
+    tileSize = 'xs';
+  }
+  if (!isSemanticSize && size > 16 && size <= 22) {
+    tileSize = 'sm';
+  }
+  if (!isSemanticSize && size > 30) {
+    tileSize = 'lg';
+  }
+
+  return (
+    <IconTile size={tileSize} color={color} className={className}>
+      <Icon
+        size={glyphSize}
+        role={label != null ? 'img' : undefined}
+        aria-label={label}
+        aria-hidden={label == null ? true : undefined}
+        style={{ color }}
+      />
+    </IconTile>
+  );
+};


### PR DESCRIPTION
## What

- `IntegrationGlyph` and `ProviderIcon` were near-duplicate components (both wrapping a brand icon in `IconTile` with a `cssVar` color, in two different feature folders). Both are now thin wrappers over one shared `BrandGlyph` primitive; their public props are unchanged.
- Dropped the redundant local `PROVIDER_IDS` array in `ProviderIcon` in favor of the registry export from `@goodboy/types`.
- The topbar spend rollup title now says what the number is instead of only where it goes: "Today's spend across providers, open budget".

Closes the two SHOULDs left open by #1011.

## Tests

- `tsc --noEmit` clean; full desktop suite 334 files / 2707 tests green (new BrandGlyph coverage for framed, unframed and labelled rendering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)