### PR TITLE
fix(desktop): routing picker v4

### DIFF
--- a/apps/desktop/src/features/session/components/WorkflowBuilderView/index.test.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowBuilderView/index.test.tsx
@@ -98,6 +98,9 @@ vi.mock('../../../../shared/components/RoutingPicker', () => ({
       >
         model:{model === '' ? 'auto' : model}
       </button>
+      <button type="button" onClick={() => onModel('claude-sonnet-4-6')}>
+        model:sonnet
+      </button>
     </>
   ),
 }));
@@ -285,6 +288,33 @@ describe('WorkflowBuilderView (custom mode, no presets)', () => {
     const saved = mockSavePhaseTemplate.mock.calls[0]![0];
     expect(saved.steps[0]!.modelOverride).toBe('claude-opus-4-6');
     expect(saved.steps[1]!.modelOverride).toBeUndefined();
+  });
+
+  it('clamps persisted effort when switching from opus to sonnet', async () => {
+    const baseWorkflow = presetWorkflow('wf-preset-1', 'Ship It');
+    const workflow: Workflow = {
+      ...baseWorkflow,
+      steps: baseWorkflow.steps.map((step, index) =>
+        index === 0
+          ? {
+              ...step,
+              modelOverride: 'claude-opus-4-6',
+              effort: 'max',
+            }
+          : step,
+      ),
+    };
+    storeState.phaseTemplates = { 'ws-1': [workflow] };
+    render(<WorkflowBuilderView session={session} onClose={vi.fn()} />);
+    goToApproach();
+    fireEvent.click(screen.getByRole('radio', { name: /ship it/i }));
+    expandStep(0);
+    fireEvent.click(screen.getAllByRole('button', { name: 'model:sonnet' })[0]!);
+    fireEvent.click(startBtn());
+    await waitFor(() => expect(mockSavePhaseTemplate).toHaveBeenCalledOnce());
+    const saved = mockSavePhaseTemplate.mock.calls[0]![0];
+    expect(saved.steps[0]!.modelOverride).toBe('claude-sonnet-4-6');
+    expect(saved.steps[0]!.effort).toBe('high');
   });
 
   it('respects the preset and auto-run toggles', async () => {

--- a/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
@@ -1093,7 +1093,10 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
                                 onPrompt={(v) => patchStep(st.key, { promptPrefix: v })}
                                 onExpectedOutput={(v) => patchStep(st.key, { expectedOutput: v })}
                                 onModel={(v) =>
-                                  patchStep(st.key, { modelOverride: v || undefined })
+                                  patchStep(st.key, {
+                                    modelOverride: v || undefined,
+                                    effort: clampEffort(v, st.effort ?? roleEffort(st.role)),
+                                  })
                                 }
                                 onProvider={(v) =>
                                   patchStep(st.key, { providerOverride: v || undefined })

--- a/apps/desktop/src/features/session/components/WorkflowStepCard/index.test.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowStepCard/index.test.tsx
@@ -69,6 +69,12 @@ describe('WorkflowStepCard (collapsed)', () => {
     expect(screen.getByText('Claude')).toBeDefined();
   });
 
+  it('shows the clamped effort for the resolved model', () => {
+    render(<WorkflowStepCard {...baseProps} resolvedModel="claude-sonnet-4-6" effort="max" />);
+    expect(screen.getByText('High')).toBeDefined();
+    expect(screen.queryByText('Max')).toBeNull();
+  });
+
   it('clicking the card button calls onExpand', () => {
     const onExpand = vi.fn();
     render(<WorkflowStepCard {...baseProps} onExpand={onExpand} />);

--- a/apps/desktop/src/features/session/components/WorkflowStepCard/index.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowStepCard/index.tsx
@@ -10,6 +10,7 @@ import {
   EFFORT_DOT,
   EFFORT_LABEL,
   PROVIDER_LABEL,
+  clampEffort,
   modelLabel,
 } from '../../../chat/utils/chat-constants';
 import { PROVIDER_BRAND, brandColor } from '../../../providers/components/provider-brand';
@@ -68,6 +69,7 @@ const StepMetaRow = ({
   readonly effort: EffortLevel;
 }) => {
   const ProviderGlyph = PROVIDER_BRAND[provider].icon;
+  const resolvedEffort = clampEffort(resolvedModel, effort);
   return (
     <span className="flex flex-wrap items-center gap-1.5">
       <span className={CHIP_CLS}>
@@ -90,8 +92,11 @@ const StepMetaRow = ({
         {modelLabel(resolvedModel)}
       </span>
       <span className={CHIP_CLS}>
-        <span className={cn('size-1.5 shrink-0 rounded-full', EFFORT_DOT[effort])} aria-hidden />
-        {EFFORT_LABEL[effort]}
+        <span
+          className={cn('size-1.5 shrink-0 rounded-full', EFFORT_DOT[resolvedEffort])}
+          aria-hidden
+        />
+        {EFFORT_LABEL[resolvedEffort]}
       </span>
     </span>
   );

--- a/apps/desktop/src/features/workflows/components/LibraryStepForm/index.tsx
+++ b/apps/desktop/src/features/workflows/components/LibraryStepForm/index.tsx
@@ -11,7 +11,7 @@ import type {
   WorkspaceId,
 } from '@goodboy/types';
 import type { StepDefUpsertArgs } from '../../workflows';
-import { modelEffortLevels, type EffortLevel } from '../../../chat/utils/chat-constants';
+import { clampEffort, type EffortLevel } from '../../../chat/utils/chat-constants';
 import { RoleSelect } from '../../../session/components/RoleSelect';
 import { InlineField } from '../../../session/components/InlineField';
 import { RoutingPicker } from '../../../../shared/components/RoutingPicker';
@@ -170,12 +170,12 @@ export const LibraryStepForm = ({
                 commit({ providerOverride: p });
               }}
               onModel={(m) => {
-                const levels = modelEffortLevels(m === '' ? recommendedMod : m);
+                const clamped = clampEffort(m === '' ? recommendedMod : m, effort);
                 setModelOverride(m);
                 const over: Partial<FormState> = { modelOverride: m };
-                if (levels && !levels.includes(effort)) {
-                  setEffort(levels[0]!);
-                  over.effort = levels[0]!;
+                if (clamped !== effort) {
+                  setEffort(clamped);
+                  over.effort = clamped;
                 }
                 commit(over);
               }}

--- a/apps/desktop/src/features/workflows/components/WorkflowStudio/WorkflowComposer/index.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowStudio/WorkflowComposer/index.tsx
@@ -5,6 +5,7 @@ import { recommendedModelForRole } from '@goodboy/core';
 import type { ProviderId, StepDef, StepDefId, WorkspaceId } from '@goodboy/types';
 import type { StepDefUpsertArgs } from '../../../workflows';
 import type { DefinitionForm, TemplateForm } from '../../../form';
+import { clampEffort } from '../../../../chat/utils/chat-constants';
 import { ROLE_TO_KIND } from '../../../../session/agent-kind';
 import { WorkflowStepCard } from '../../../../session/components/WorkflowStepCard';
 import { StepFlowConnector } from '../StepFlowConnector';
@@ -256,7 +257,12 @@ export const WorkflowComposer = ({
                     onPrompt={(v) => onUpdateStep(idx, { promptPrefix: v })}
                     onExpectedOutput={(v) => onUpdateStep(idx, { expectedOutput: v })}
                     onProvider={(v) => onUpdateStep(idx, { providerOverride: v })}
-                    onModel={(v) => onUpdateStep(idx, { modelOverride: v })}
+                    onModel={(v) =>
+                      onUpdateStep(idx, {
+                        modelOverride: v,
+                        effort: clampEffort(v, def.effort),
+                      })
+                    }
                     onEffort={(v) => onUpdateStep(idx, { effort: v })}
                     onRole={(v) => onUpdateStep(idx, { role: v })}
                     onVerbosity={(v) => onUpdateStep(idx, { verbosity: v })}

--- a/apps/desktop/src/shared/components/RoutingPicker/ModelGrid.tsx
+++ b/apps/desktop/src/shared/components/RoutingPicker/ModelGrid.tsx
@@ -8,70 +8,88 @@ type Props = {
   readonly ids: ReadonlyArray<string>;
   readonly value: string;
   readonly recommendedModel?: string;
+  readonly literalAutoModel?: string;
   readonly isRecommended: boolean;
   readonly onSelect: (model: string) => void;
 };
 
-export const ModelGrid = ({ ids, value, recommendedModel, isRecommended, onSelect }: Props) => (
-  <div className="flex flex-col gap-1">
-    {recommendedModel != null && (
-      <div className="flex flex-wrap gap-1 px-2.5">
-        <button
-          type="button"
-          onClick={() => onSelect('')}
-          title={`auto (${modelLabel(recommendedModel)})`}
-          aria-pressed={isRecommended}
-          className={cn(
-            'inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-2xs text-muted-foreground transition-colors hover:bg-background/60 hover:text-foreground',
-            isRecommended && 'bg-background font-medium text-foreground shadow-sm',
-          )}
-        >
-          <Sparkles size={10} className="shrink-0 text-primary" aria-hidden />
-          auto
-        </button>
-      </div>
-    )}
-    {groupModels({ ids }).map((group) => {
-      const hasSubgroups = group.subgroups.some((subgroup) => subgroup.label != null);
-      return (
-        <div key={group.family} className="flex flex-col gap-0.5">
-          <span className="px-2.5 pt-1 text-2xs font-medium uppercase tracking-wide text-muted-foreground/50">
-            {group.label}
-          </span>
-          {!hasSubgroups && (
-            <div className="flex flex-wrap gap-1 px-2.5">
-              {group.subgroups.flatMap((subgroup) =>
-                subgroup.ids.map((id) => (
-                  <VariantChip
-                    key={id}
-                    id={id}
-                    active={!isRecommended && value === id}
-                    onSelect={() => onSelect(id)}
-                  />
-                )),
-              )}
-            </div>
-          )}
-          {hasSubgroups &&
-            group.subgroups.map((subgroup) => (
-              <div key={subgroup.key} className="flex items-center gap-2 px-2.5 py-0.5">
-                <span className="flex-1 text-2xs text-muted-foreground/70">
-                  {subgroup.label ?? group.label}
-                </span>
-                <div className="flex flex-wrap justify-end gap-1">
-                  {subgroup.ids.map((id) => (
+export const ModelGrid = ({
+  ids,
+  value,
+  recommendedModel,
+  literalAutoModel,
+  isRecommended,
+  onSelect,
+}: Props) => {
+  const autoModel = literalAutoModel ?? (recommendedModel != null ? '' : undefined);
+  const isAutoActive = literalAutoModel != null ? value === literalAutoModel : isRecommended;
+  const groupedIds = ids.filter((id) => id !== 'auto');
+
+  return (
+    <div className="flex flex-col gap-1">
+      {autoModel != null && (
+        <div className="flex flex-wrap gap-1 px-2.5">
+          <button
+            type="button"
+            onClick={() => onSelect(autoModel)}
+            title={
+              recommendedModel != null && literalAutoModel == null
+                ? `auto (${modelLabel(recommendedModel)})`
+                : 'auto'
+            }
+            aria-pressed={isAutoActive}
+            className={cn(
+              'inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-2xs text-muted-foreground transition-colors hover:bg-background/60 hover:text-foreground',
+              isAutoActive && 'bg-background font-medium text-foreground shadow-sm',
+            )}
+          >
+            <Sparkles size={10} className="shrink-0 text-primary" aria-hidden />
+            auto
+          </button>
+        </div>
+      )}
+      {groupModels({ ids: groupedIds }).map((group) => {
+        const hasSubgroups = group.subgroups.some((subgroup) => subgroup.label != null);
+        return (
+          <div key={group.family} className="flex flex-col gap-0.5">
+            <span className="px-2.5 pt-1 text-2xs font-medium uppercase tracking-wide text-muted-foreground/50">
+              {group.label}
+            </span>
+            {!hasSubgroups && (
+              <div className="flex flex-wrap gap-1 px-2.5">
+                {group.subgroups.flatMap((subgroup) =>
+                  subgroup.ids.map((id) => (
                     <VariantChip
                       key={id}
                       id={id}
                       active={!isRecommended && value === id}
                       onSelect={() => onSelect(id)}
                     />
-                  ))}
-                </div>
+                  )),
+                )}
               </div>
-            ))}
-        </div>
-      );
-    })}
-  </div>
-);
+            )}
+            {hasSubgroups &&
+              group.subgroups.map((subgroup) => (
+                <div key={subgroup.key} className="flex items-center gap-2 px-2.5 py-0.5">
+                  <span className="flex-1 text-2xs text-muted-foreground/70">
+                    {subgroup.label ?? group.label}
+                  </span>
+                  <div className="flex flex-wrap justify-end gap-1">
+                    {subgroup.ids.map((id) => (
+                      <VariantChip
+                        key={id}
+                        id={id}
+                        active={!isRecommended && value === id}
+                        onSelect={() => onSelect(id)}
+                      />
+                    ))}
+                  </div>
+                </div>
+              ))}
+          </div>
+        );
+      })}
+    </div>
+  );
+};

--- a/apps/desktop/src/shared/components/RoutingPicker/VariantChip.tsx
+++ b/apps/desktop/src/shared/components/RoutingPicker/VariantChip.tsx
@@ -11,10 +11,30 @@ type Props = {
   readonly onSelect: () => void;
 };
 
+type TierClassName = {
+  readonly active: string;
+  readonly inactive: string;
+};
+
 const TIER_NOTE: Record<CostTier, string> = {
   cheap: 'cheap',
   mid: 'standard',
   expensive: 'premium',
+};
+
+const TIER_CLASS_NAME: Record<CostTier, TierClassName> = {
+  cheap: {
+    active: 'bg-success/20 text-success ring-1 ring-success/40',
+    inactive: 'bg-success/10 text-success/70 hover:bg-success/15 hover:text-success',
+  },
+  mid: {
+    active: 'bg-warning/20 text-warning ring-1 ring-warning/40',
+    inactive: 'bg-warning/10 text-warning/70 hover:bg-warning/15 hover:text-warning',
+  },
+  expensive: {
+    active: 'bg-danger/20 text-danger ring-1 ring-danger/40',
+    inactive: 'bg-danger/10 text-danger/70 hover:bg-danger/15 hover:text-danger',
+  },
 };
 
 export const VariantChip = ({ id, active, onSelect }: Props) => {
@@ -26,12 +46,12 @@ export const VariantChip = ({ id, active, onSelect }: Props) => {
       title={`${id} (${TIER_NOTE[tier]})`}
       aria-pressed={active}
       className={cn(
-        'inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 font-mono text-2xs text-muted-foreground transition-colors hover:bg-background/60 hover:text-foreground',
-        active && 'bg-background font-medium text-foreground shadow-sm',
+        'inline-flex items-center rounded-md px-1.5 py-0.5 font-mono text-2xs transition-colors',
+        active ? TIER_CLASS_NAME[tier].active : TIER_CLASS_NAME[tier].inactive,
+        active && 'font-medium',
       )}
     >
       {parseModelId(id).variantLabel}
-      {tier === 'expensive' && <span className="text-muted-foreground/50">$$</span>}
     </button>
   );
 };

--- a/apps/desktop/src/shared/components/RoutingPicker/index.test.tsx
+++ b/apps/desktop/src/shared/components/RoutingPicker/index.test.tsx
@@ -73,6 +73,35 @@ describe('RoutingPicker', () => {
     expect(screen.getByRole('dialog')).toBeDefined();
   });
 
+  it('hides auto when the recommendation does not apply to the viewed provider', () => {
+    render(<RoutingPicker {...baseProps} model="" recommendedModel="claude-sonnet-4-6" />);
+    fireEvent.click(screen.getByRole('button', { name: /routing/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Codex' }));
+    expect(screen.queryByRole('button', { name: 'auto' })).toBeNull();
+  });
+
+  it('hides provider auto when no provider recommendation exists', () => {
+    render(<RoutingPicker {...baseProps} provider="" />);
+    fireEvent.click(screen.getByRole('button', { name: /routing/i }));
+    expect(screen.queryByRole('button', { name: 'auto' })).toBeNull();
+  });
+
+  it('always offers Cursor literal auto and selects its model id', () => {
+    const onModel = vi.fn();
+    render(
+      <RoutingPicker
+        {...baseProps}
+        model=""
+        recommendedModel="claude-sonnet-4-6"
+        onModel={onModel}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /routing/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Cursor' }));
+    fireEvent.click(screen.getByRole('button', { name: 'auto' }));
+    expect(onModel).toHaveBeenCalledWith('auto');
+  });
+
   it('reports the picked effort and keeps the popover open', () => {
     const onEffort = vi.fn();
     render(<RoutingPicker {...baseProps} onEffort={onEffort} />);
@@ -155,20 +184,27 @@ describe('RoutingPicker', () => {
     expect(screen.queryByPlaceholderText('Filter models')).toBeNull();
   });
 
-  it('marks expensive variants with text and renders no tier dots in the model grid', () => {
+  it('tints model variants by cost tier and intensifies the active chip', () => {
     render(<RoutingPicker {...baseProps} />);
     fireEvent.click(screen.getByRole('button', { name: /routing/i }));
     const expensiveChip = screen.getByTitle(/^claude-opus-5 \(/);
     const cheapChip = screen.getByTitle(/^claude-haiku-4-5 \(/);
-    const modelGrid = expensiveChip.closest('div.flex.flex-col.gap-1');
-    expect(expensiveChip.textContent).toContain('$$');
-    expect(expensiveChip.querySelector('span')?.className).toContain('text-muted-foreground/50');
-    expect(cheapChip.textContent).not.toContain('$$');
-    expect(modelGrid).not.toBeNull();
-    expect(
-      modelGrid?.querySelector(
-        '[class*="bg-success"], [class*="bg-warning"], [class*="bg-danger"]',
-      ),
-    ).toBeNull();
+    expect(expensiveChip.textContent).not.toContain('$$');
+    expect(expensiveChip.className).toContain('bg-danger/20');
+    expect(expensiveChip.className).toContain('text-danger');
+    expect(expensiveChip.className).toContain('ring-danger/40');
+    expect(cheapChip.className).toContain('bg-success/10');
+    expect(cheapChip.className).toContain('text-success/70');
+    expect(cheapChip.className).not.toContain('ring-success/40');
+  });
+
+  it('distributes provider tabs evenly across the row', () => {
+    render(<RoutingPicker {...baseProps} />);
+    fireEvent.click(screen.getByRole('button', { name: /routing/i }));
+    const providerButton = screen.getByRole('button', { name: 'Cursor' });
+    const providerRow = providerButton.parentElement;
+    expect(providerRow?.className).toContain('gap-1.5');
+    expect(providerRow?.className).toContain('[&>button]:flex-1');
+    expect(providerButton.className).toContain('min-w-0');
   });
 });

--- a/apps/desktop/src/shared/components/RoutingPicker/index.tsx
+++ b/apps/desktop/src/shared/components/RoutingPicker/index.tsx
@@ -23,6 +23,8 @@ import { TriggerLabel } from './TriggerLabel';
 import { resolveRouting } from './resolveRouting';
 
 const CHIP_GROUP_CLASS_NAME = 'flex flex-wrap gap-1 bg-subtle px-2.5';
+const PROVIDER_CHIP_GROUP_CLASS_NAME =
+  'flex gap-1.5 bg-subtle px-2.5 [&>button]:h-7 [&>button]:flex-1';
 const PROVIDERS = Object.keys(PROVIDER_CAPABILITIES).filter(
   (id): id is ProviderId => id in PROVIDER_CAPABILITIES,
 );
@@ -95,20 +97,28 @@ export const RoutingPicker = ({
   const [viewProvider, setViewProvider] = useState(routing.provider);
   const [isViewingAuto, setIsViewingAuto] = useState(routing.isProviderRecommended);
   const isViewingRoutingProvider = viewProvider === routing.provider;
+  const viewedRecommendedModel =
+    isViewingRoutingProvider &&
+    recommendedModel != null &&
+    PROVIDER_CAPABILITIES[viewProvider].models.some((entry) => entry.id === recommendedModel)
+      ? recommendedModel
+      : undefined;
+  const viewedLiteralAutoModel = PROVIDER_CAPABILITIES[viewProvider].models.find(
+    (entry) => entry.id === 'auto',
+  )?.id;
   const viewedRouting = resolveRouting({
     providers: PROVIDERS,
     provider: viewProvider,
     model: isViewingRoutingProvider ? model : '',
     effort,
     recommendedProvider: isViewingRoutingProvider ? recommendedProvider : undefined,
-    recommendedModel: isViewingRoutingProvider ? recommendedModel : undefined,
+    recommendedModel: viewedRecommendedModel,
   });
-  const viewedRecommendedModel = isViewingRoutingProvider ? recommendedModel : undefined;
   const isViewProviderConnected = connectedProviders.includes(viewProvider);
   const showEffort = onEffort != null && routing.effortLevels != null;
   const showViewedEffort = onEffort != null && viewedRouting.effortLevels != null;
   const isModelRecommended =
-    isViewingRoutingProvider && routing.isModelRecommended && recommendedModel != null;
+    isViewingRoutingProvider && routing.isModelRecommended && viewedRecommendedModel != null;
   const summary = `${PROVIDER_LABEL[routing.provider]} · ${modelLabel(routing.model)}${
     showEffort ? ` · ${EFFORT_LABEL[routing.effort]} effort` : ''
   }`;
@@ -221,8 +231,8 @@ export const RoutingPicker = ({
             </div>
           )}
           <PickerSection label="Provider" hint="Which CLI agent runs the turn">
-            <div className={CHIP_GROUP_CLASS_NAME}>
-              {(recommendedProvider != null || provider === '') && (
+            <div className={PROVIDER_CHIP_GROUP_CLASS_NAME}>
+              {recommendedProvider != null && (
                 <PickerChip
                   label="auto"
                   active={isViewingAuto}
@@ -232,19 +242,8 @@ export const RoutingPicker = ({
                       viewedProvider: routing.provider,
                     })
                   }
-                  glyph={
-                    recommendedProvider != null ? (
-                      <ProviderGlyph id={recommendedProvider} size={15} />
-                    ) : (
-                      <span
-                        className="size-1.5 shrink-0 rounded-full bg-muted-foreground/40"
-                        aria-hidden
-                      />
-                    )
-                  }
-                  note={
-                    recommendedProvider != null ? PROVIDER_LABEL[recommendedProvider] : undefined
-                  }
+                  glyph={<ProviderGlyph id={recommendedProvider} size={15} />}
+                  note={PROVIDER_LABEL[recommendedProvider]}
                 />
               )}
               {PROVIDERS.map((id) => {
@@ -266,7 +265,7 @@ export const RoutingPicker = ({
                       onProvider(id);
                     }}
                     className={cn(
-                      'relative inline-flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-background/60 hover:text-foreground',
+                      'relative inline-flex min-w-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-background/60 hover:text-foreground',
                       isActive && 'bg-background text-foreground shadow-sm',
                     )}
                   >
@@ -285,7 +284,7 @@ export const RoutingPicker = ({
             </div>
           </PickerSection>
           <Divider />
-          <PickerSection label="Model" hint="Premium variants marked with $$">
+          <PickerSection label="Model" hint="Color shows the cost tier">
             {!isViewProviderConnected && (
               <div className="flex items-center gap-2 px-2.5 py-1">
                 <p className="flex-1 text-xs text-muted-foreground">
@@ -312,6 +311,7 @@ export const RoutingPicker = ({
                   ids={viewedRouting.models}
                   value={viewedRouting.model}
                   recommendedModel={viewedRecommendedModel}
+                  literalAutoModel={viewedLiteralAutoModel}
                   isRecommended={isModelRecommended}
                   onSelect={onModel}
                 />


### PR DESCRIPTION
## Problem

Three picker complaints from daily use:
- Switching a workflow step to a different model kept the old effort. Two state owners (`WorkflowBuilderView.patchStep`, `WorkflowComposer.onUpdateStep`) shallow-merged the model without re-clamping effort, so the collapsed badge showed an effort the model cannot run. The spawn path clamps late (`sendTurn`), so the run was right but the UI lied.
- Premium models were marked with a text `$$`, the only cost signal in the grid.
- Provider tabs sat crammed at flex-start, and an `auto` chip could render where no provider handles it.

## Change

- Model changes persist a clamped effort in both workflow editors; the collapsed step badge renders the clamped value.
- Model variant chips are tinted by cost tier (success/warning/danger), muted when inactive, intense with a ring when active. `$$` is gone.
- Provider tabs distribute across the full popover row with a 6px gap.
- The `auto` model entry renders only when a role recommendation applies to the viewed provider, or the provider has a literal auto model (Cursor).

## Testing

- `pnpm --filter @goodboy/desktop typecheck`
- vitest: RoutingPicker, WorkflowStepCard, WorkflowBuilderView (65 tests green), including a regression test for the opus→sonnet effort clamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)