### PR TITLE
fix(desktop): needs-you triage popover and model row provenance chips

### DIFF
--- a/apps/desktop/src/app/components/AppTopBar/NeedsYouPopover.tsx
+++ b/apps/desktop/src/app/components/AppTopBar/NeedsYouPopover.tsx
@@ -1,0 +1,125 @@
+import { useLayoutEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { Divider, Popover, ScrollFade, StatusDot } from '@goodboy/ui';
+import type { Session, SessionId } from '@goodboy/types';
+import { useAppStore } from '../../../store';
+import { NeedsYouSessionRow } from './NeedsYouSessionRow';
+
+type Props = {
+  readonly sessions: ReadonlyArray<Session>;
+  readonly count: number;
+};
+
+type PopoverCoordinates = {
+  readonly top?: number;
+  readonly bottom?: number;
+  readonly left: number;
+};
+
+type SelectParams = {
+  readonly sessionId: SessionId;
+};
+
+const DROPDOWN_WIDTH = 320;
+const VIEWPORT_MARGIN = 8;
+const LIST_MAX_HEIGHT = 320;
+const HEADER_HEIGHT = 37;
+const DROPDOWN_MAX_HEIGHT = LIST_MAX_HEIGHT + HEADER_HEIGHT;
+
+export const NeedsYouPopover = ({ sessions, count }: Props) => {
+  const setCurrentSession = useAppStore((state) => state.setCurrentSession);
+  const setActiveLens = useAppStore((state) => state.setActiveLens);
+  const [isOpen, setIsOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const [coordinates, setCoordinates] = useState<PopoverCoordinates | null>(null);
+
+  useLayoutEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const updatePosition = () => {
+      const trigger = triggerRef.current;
+      if (trigger == null) {
+        return;
+      }
+
+      const rect = trigger.getBoundingClientRect();
+      const centerX = rect.left + rect.width / 2;
+      const desiredLeft = centerX - DROPDOWN_WIDTH / 2;
+      const maxLeft = window.innerWidth - DROPDOWN_WIDTH - VIEWPORT_MARGIN;
+      const left = Math.min(Math.max(desiredLeft, VIEWPORT_MARGIN), maxLeft);
+      const spaceBelow = window.innerHeight - rect.bottom;
+      const shouldOpenAbove = spaceBelow < DROPDOWN_MAX_HEIGHT + VIEWPORT_MARGIN;
+      const top = shouldOpenAbove ? undefined : rect.bottom + 6;
+      const bottom = shouldOpenAbove ? window.innerHeight - rect.top + 6 : undefined;
+      setCoordinates({ top, bottom, left });
+    };
+
+    updatePosition();
+    window.addEventListener('resize', updatePosition);
+    window.addEventListener('scroll', updatePosition, true);
+    return () => {
+      window.removeEventListener('resize', updatePosition);
+      window.removeEventListener('scroll', updatePosition, true);
+    };
+  }, [isOpen]);
+
+  const selectSession = ({ sessionId }: SelectParams) => {
+    setIsOpen(false);
+    void setCurrentSession(sessionId).then(() => {
+      setActiveLens(sessionId, null);
+    });
+  };
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        onClick={() => setIsOpen((current) => !current)}
+        aria-label={`${count} ${count === 1 ? 'session needs' : 'sessions need'} you`}
+        aria-expanded={isOpen}
+        className="flex items-center gap-1 rounded px-1.5 py-1 transition-colors hover:bg-muted/50"
+      >
+        <StatusDot tone="warning" size="sm" pulsing />
+        <span className="font-medium tabular-nums text-foreground">{count}</span>
+        <span className="text-muted-foreground">need you</span>
+      </button>
+
+      {isOpen && coordinates != null
+        ? createPortal(
+            <>
+              <div className="fixed inset-0 z-30" onClick={() => setIsOpen(false)} aria-hidden />
+              <Popover
+                className="fixed z-40 w-80"
+                style={{
+                  top: coordinates.top,
+                  bottom: coordinates.bottom,
+                  left: coordinates.left,
+                }}
+              >
+                <header className="flex items-center gap-2 px-3 py-2">
+                  <StatusDot tone="warning" size="sm" />
+                  <span className="text-xs font-semibold text-foreground">Needs you</span>
+                </header>
+                <Divider />
+                <ScrollFade className="max-h-80" fadeSize={16}>
+                  <ul aria-label="Sessions needing attention">
+                    {sessions.map((session) => (
+                      <NeedsYouSessionRow
+                        key={session.id}
+                        session={session}
+                        onSelect={selectSession}
+                      />
+                    ))}
+                  </ul>
+                </ScrollFade>
+              </Popover>
+            </>,
+            document.body,
+          )
+        : null}
+    </>
+  );
+};

--- a/apps/desktop/src/app/components/AppTopBar/NeedsYouSessionRow.tsx
+++ b/apps/desktop/src/app/components/AppTopBar/NeedsYouSessionRow.tsx
@@ -1,0 +1,33 @@
+import { StatusDot } from '@goodboy/ui';
+import type { Session, SessionId } from '@goodboy/types';
+import { useSessionStageInfo } from '../../../store';
+
+type Props = {
+  readonly session: Session;
+  readonly onSelect: (params: SelectParams) => void;
+};
+
+type SelectParams = {
+  readonly sessionId: SessionId;
+};
+
+export const NeedsYouSessionRow = ({ session, onSelect }: Props) => {
+  const { reason } = useSessionStageInfo(session);
+
+  return (
+    <li>
+      <button
+        type="button"
+        onClick={() => onSelect({ sessionId: session.id as SessionId })}
+        title={`${session.goal} · ${reason}`}
+        className="flex w-full items-center gap-2 px-3 py-2.5 text-left transition-colors hover:bg-muted/50"
+      >
+        <StatusDot tone="warning" size="sm" />
+        <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+          <span className="truncate text-xs font-medium text-foreground">{session.goal}</span>
+          <span className="truncate text-2xs text-muted-foreground">{reason}</span>
+        </span>
+      </button>
+    </li>
+  );
+};

--- a/apps/desktop/src/app/components/AppTopBar/WorkspaceRollupStrip.tsx
+++ b/apps/desktop/src/app/components/AppTopBar/WorkspaceRollupStrip.tsx
@@ -1,0 +1,53 @@
+import { StatusDot, formatUsd } from '@goodboy/ui';
+import {
+  useCurrentWorkspace,
+  useSessions,
+  useStageGroupedSessions,
+  useWorkspaceRollup,
+} from '../../../store';
+import { NeedsYouPopover } from './NeedsYouPopover';
+
+type Props = {
+  readonly onOpenBudget: () => void;
+};
+
+export const WorkspaceRollupStrip = ({ onOpenBudget }: Props) => {
+  const workspace = useCurrentWorkspace();
+  const sessions = useSessions();
+  const workspaceId = workspace?.id ?? null;
+  const rollup = useWorkspaceRollup(workspaceId, sessions);
+  const groups = useStageGroupedSessions(workspaceId, sessions);
+  const attentionSessions = groups.find((group) => group.key === 'attention')?.sessions ?? [];
+
+  if (workspace == null) {
+    return null;
+  }
+
+  return (
+    <div className="flex shrink-0 items-center gap-1 text-2xs">
+      {rollup.attentionCount > 0 ? (
+        <NeedsYouPopover sessions={attentionSessions} count={rollup.attentionCount} />
+      ) : null}
+      <button
+        type="button"
+        onClick={onOpenBudget}
+        title="Today's spend across providers, open budget"
+        className="flex items-center gap-3 rounded px-1.5 py-1 transition-colors hover:bg-muted/50"
+      >
+        {rollup.runningCount > 0 ? (
+          <span className="flex items-center gap-1">
+            <StatusDot tone="info" size="sm" pulsing />
+            <span className="font-medium tabular-nums text-foreground">{rollup.runningCount}</span>
+            <span className="text-muted-foreground">running</span>
+          </span>
+        ) : null}
+        <span className="flex items-center gap-1 text-muted-foreground">
+          <span className="font-medium tabular-nums text-foreground">
+            {formatUsd(rollup.todaySpend)}
+          </span>
+          today
+        </span>
+      </button>
+    </div>
+  );
+};

--- a/apps/desktop/src/app/components/AppTopBar/index.test.tsx
+++ b/apps/desktop/src/app/components/AppTopBar/index.test.tsx
@@ -1,15 +1,37 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
-import type { Workspace, WorkspaceId } from '@goodboy/types';
+import type { Session, SessionId, Workspace, WorkspaceId } from '@goodboy/types';
 
-const { currentWorkspace } = vi.hoisted(() => ({
-  currentWorkspace: { id: 'ws-1' as WorkspaceId, name: 'Test WS' } as Workspace,
-}));
+const { currentWorkspace, hooks, store } = vi.hoisted(() => {
+  const workspace = { id: 'ws-1' as WorkspaceId, name: 'Test WS' } as Workspace;
+  return {
+    currentWorkspace: workspace,
+    hooks: {
+      sessions: [] as ReadonlyArray<Session>,
+      groups: [] as ReadonlyArray<{
+        readonly key: string;
+        readonly sessions: ReadonlyArray<Session>;
+      }>,
+      rollup: { attentionCount: 0, runningCount: 0, todaySpend: 0 },
+      reasons: {} as Record<string, string>,
+    },
+    store: {
+      setCurrentSession: vi.fn(async () => undefined),
+      setActiveLens: vi.fn(),
+    },
+  };
+});
 
 vi.mock('../../../store', () => ({
   useCurrentWorkspace: () => currentWorkspace,
-  useSessions: () => [],
-  useWorkspaceRollup: () => ({ attentionCount: 0, runningCount: 0, todaySpend: 0 }),
+  useSessions: () => hooks.sessions,
+  useWorkspaceRollup: () => hooks.rollup,
+  useStageGroupedSessions: () => hooks.groups,
+  useSessionStageInfo: (session: Session) => ({
+    stage: 'attention',
+    reason: hooks.reasons[session.id] ?? 'Needs attention',
+  }),
+  useAppStore: <T,>(selector: (state: typeof store) => T) => selector(store),
 }));
 
 vi.mock('../../../shared/lib/theme', () => ({
@@ -37,9 +59,24 @@ vi.mock('../../../shared/components/DogMascot', () => ({
   DogMascot: () => null,
 }));
 
+beforeEach(() => {
+  hooks.sessions = [];
+  hooks.groups = [];
+  hooks.rollup = { attentionCount: 0, runningCount: 0, todaySpend: 0 };
+  hooks.reasons = {};
+  store.setCurrentSession.mockClear();
+  store.setActiveLens.mockClear();
+});
+
 afterEach(cleanup);
 
 import { AppTopBar } from './index';
+
+const ATTENTION_SESSION_ID = 'session-1' as SessionId;
+const ATTENTION_SESSION = {
+  id: ATTENTION_SESSION_ID,
+  goal: 'Review the failing checks',
+} as unknown as Session;
 
 describe('AppTopBar', () => {
   it('renders settings button', () => {
@@ -59,11 +96,38 @@ describe('AppTopBar', () => {
     expect(btn.className).not.toContain('bg-foreground');
   });
 
-  it('opens budget from the workspace rollup and omits the beta chip', () => {
+  it('opens budget only from the spend target and omits the beta chip', () => {
+    hooks.sessions = [ATTENTION_SESSION];
+    hooks.groups = [{ key: 'attention', sessions: [ATTENTION_SESSION] }];
+    hooks.rollup = { attentionCount: 1, runningCount: 0, todaySpend: 2.5 };
     const onOpenBudget = vi.fn();
     render(<AppTopBar onOpenSettings={vi.fn()} onOpenBudget={onOpenBudget} activeStudio={null} />);
+
     fireEvent.click(screen.getByTitle("Today's spend across providers, open budget"));
     expect(onOpenBudget).toHaveBeenCalledOnce();
+
+    fireEvent.click(screen.getByRole('button', { name: '1 session needs you' }));
+    expect(onOpenBudget).toHaveBeenCalledOnce();
     expect(screen.queryByText('Beta')).toBeNull();
+  });
+
+  it('lists attention sessions and navigates from the needs-you popover', () => {
+    hooks.sessions = [ATTENTION_SESSION];
+    hooks.groups = [{ key: 'attention', sessions: [ATTENTION_SESSION] }];
+    hooks.rollup = { attentionCount: 1, runningCount: 0, todaySpend: 0 };
+    hooks.reasons = { [ATTENTION_SESSION_ID]: 'PR #42: CI failed' };
+    render(<AppTopBar onOpenSettings={vi.fn()} onOpenBudget={vi.fn()} activeStudio={null} />);
+
+    fireEvent.click(screen.getByRole('button', { name: '1 session needs you' }));
+
+    expect(screen.getByText('Needs you')).toBeDefined();
+    expect(screen.getByRole('list', { name: 'Sessions needing attention' })).toBeDefined();
+    expect(screen.getByText('Review the failing checks')).toBeDefined();
+    expect(screen.getByText('PR #42: CI failed')).toBeDefined();
+
+    fireEvent.click(screen.getByTitle('Review the failing checks · PR #42: CI failed'));
+
+    expect(store.setCurrentSession).toHaveBeenCalledWith(ATTENTION_SESSION_ID);
+    expect(screen.queryByText('PR #42: CI failed')).toBeNull();
   });
 });

--- a/apps/desktop/src/app/components/AppTopBar/index.tsx
+++ b/apps/desktop/src/app/components/AppTopBar/index.tsx
@@ -1,14 +1,14 @@
 import { useEffect, useState } from 'react';
 import { Moon, Smartphone, Sun } from 'lucide-react';
-import { cn, Divider, StatusDot, Tooltip, formatUsd } from '@goodboy/ui';
+import { cn, Divider, Tooltip } from '@goodboy/ui';
 import { DogMascot } from '../../../shared/components/DogMascot';
 import { SECTION_ICONS } from '../../../shared/components/section-icons';
 import { UpdateIndicator } from '../../../features/updater/components/UpdateIndicator';
 import { bridgeStatus } from '../../../features/companion/bridge';
-import { useCurrentWorkspace, useSessions, useWorkspaceRollup } from '../../../store';
 import { useThemeStore } from '../../../shared/lib/theme';
 import { NotificationCenter } from '../../../features/notifications/components/NotificationCenter';
 import { OnboardingChip } from '../../../features/onboarding/OnboardingCard';
+import { WorkspaceRollupStrip } from './WorkspaceRollupStrip';
 
 const TOPBAR_ICON_BTN =
   'flex items-center justify-center rounded p-1.5 text-muted-foreground transition-colors hover:text-foreground hover:bg-muted/50' as const;
@@ -37,14 +37,7 @@ export const AppTopBar = ({ onOpenSettings, onOpenBudget, activeStudio }: AppTop
 
         <div className="min-w-0 flex-1" />
 
-        <button
-          type="button"
-          onClick={onOpenBudget}
-          title="Today's spend across providers, open budget"
-          className="rounded px-1.5 py-1 transition-colors hover:bg-muted/50"
-        >
-          <WorkspaceRollupStrip />
-        </button>
+        <WorkspaceRollupStrip onOpenBudget={onOpenBudget} />
 
         <Divider orientation="vertical" className="h-4 shrink-0 self-center" />
 
@@ -133,38 +126,5 @@ const PairDeviceCta = () => {
         <span aria-hidden className="ml-0.5 size-1.5 shrink-0 rounded-full bg-success" />
       ) : null}
     </button>
-  );
-};
-
-const WorkspaceRollupStrip = () => {
-  const workspace = useCurrentWorkspace();
-  const sessions = useSessions();
-  const rollup = useWorkspaceRollup(workspace?.id ?? null, sessions);
-  if (!workspace) {
-    return null;
-  }
-  return (
-    <div className="flex shrink-0 items-center gap-3 text-2xs">
-      {rollup.attentionCount > 0 ? (
-        <span className="flex items-center gap-1">
-          <StatusDot tone="warning" size="sm" pulsing />
-          <span className="font-medium tabular-nums text-foreground">{rollup.attentionCount}</span>
-          <span className="text-muted-foreground">need you</span>
-        </span>
-      ) : null}
-      {rollup.runningCount > 0 ? (
-        <span className="flex items-center gap-1">
-          <StatusDot tone="info" size="sm" pulsing />
-          <span className="font-medium tabular-nums text-foreground">{rollup.runningCount}</span>
-          <span className="text-muted-foreground">running</span>
-        </span>
-      ) : null}
-      <span className="flex items-center gap-1 text-muted-foreground">
-        <span className="font-medium tabular-nums text-foreground">
-          {formatUsd(rollup.todaySpend)}
-        </span>
-        today
-      </span>
-    </div>
   );
 };

--- a/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/RoleModelRow.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/RoleModelRow.tsx
@@ -19,12 +19,14 @@ import {
   modelLabel,
 } from '../../../../chat/utils/chat-constants';
 import { RoutingPicker } from '../../../../../shared/components/RoutingPicker';
+import { RoutingStatusControl } from './RoutingStatusControl';
 
 type Props = {
   readonly role: AgentRole;
   readonly label: string;
   readonly help: string;
   readonly preference: RoleModelPreference | null;
+  readonly defaultProviderId: ProviderId;
   readonly connectedProviderIds: ReadonlyArray<ProviderId>;
   readonly disabled: boolean;
   readonly onChange: (preference: RoleModelPreference | null) => void;
@@ -41,6 +43,7 @@ export const RoleModelRow = ({
   label,
   help,
   preference,
+  defaultProviderId,
   connectedProviderIds,
   disabled,
   onChange,
@@ -48,20 +51,22 @@ export const RoleModelRow = ({
   const compiled = defaultsForRole(role);
   const prefs: RoleModelPreferences | null = preference == null ? null : { [role]: preference };
   const resolved = resolveRoleRouting({ role, prefs });
-  const [providerId, setProviderId] = useState(resolved.provider);
+  const resolvedProviderId = resolved.isOverride ? resolved.provider : defaultProviderId;
+  const [providerId, setProviderId] = useState(resolvedProviderId);
   const availableProviderIds = connectedProviderIds.filter(
     (candidate) => PROVIDER_CAPABILITIES[candidate].models.length > 0,
   );
   const recommendedModel = recommendedModelForRole({ role, provider: providerId });
-  const compiledRouting = `${PROVIDER_LABEL[compiled.provider]} · ${modelLabel(compiled.model)}`;
+  const defaultModel = recommendedModelForRole({ role, provider: defaultProviderId });
+  const compiledRouting = `${PROVIDER_LABEL[defaultProviderId]} · ${modelLabel(defaultModel)}`;
   const defaultSummary =
-    modelEffortLevels(compiled.model) == null
+    modelEffortLevels(defaultModel) == null
       ? compiledRouting
       : `${compiledRouting} · ${EFFORT_LABEL[compiled.effort]} effort`;
 
   useEffect(() => {
-    setProviderId(resolved.provider);
-  }, [resolved.provider]);
+    setProviderId(resolvedProviderId);
+  }, [resolvedProviderId]);
 
   const commit = ({ providerId: nextProvider, model, effort }: CommitParams) => {
     const candidate: RoleModelPreference = { providerId: nextProvider, model, effort };
@@ -75,49 +80,56 @@ export const RoleModelRow = ({
 
   return (
     <FieldRow label={label} help={help}>
-      <div className="w-80">
-        <RoutingPicker
-          ariaLabel={`${label} routing`}
-          connectedProviders={availableProviderIds}
-          provider={providerId}
-          model={resolved.isOverride ? resolved.model : ''}
-          effort={resolved.effort}
-          recommendedProvider={compiled.provider}
-          recommendedModel={recommendedModel}
-          defaultSummary={defaultSummary}
-          overridden={resolved.isOverride}
+      <div className="flex items-center gap-2">
+        <RoutingStatusControl
+          label={label}
+          isCustom={resolved.isOverride}
           disabled={disabled}
           onReset={() => onChange(null)}
-          onProvider={(next) => {
-            if (next === '') {
-              onChange(null);
-              return;
-            }
-            setProviderId(next);
-            if (!resolved.isOverride) {
-              return;
-            }
-            commit({
-              providerId: next,
-              model: recommendedModelForRole({ role, provider: next }),
-              effort: resolved.effort,
-            });
-          }}
-          onModel={(nextModel) => {
-            if (nextModel === '') {
-              onChange(null);
-              return;
-            }
-            commit({ providerId, model: nextModel, effort: resolved.effort });
-          }}
-          onEffort={(effort) =>
-            commit({
-              providerId,
-              model: resolved.isOverride ? resolved.model : recommendedModel,
-              effort,
-            })
-          }
         />
+        <div className="w-80">
+          <RoutingPicker
+            ariaLabel={`${label} routing`}
+            connectedProviders={availableProviderIds}
+            provider={providerId}
+            model={resolved.isOverride ? resolved.model : ''}
+            effort={resolved.effort}
+            recommendedProvider={defaultProviderId}
+            recommendedModel={recommendedModel}
+            defaultSummary={defaultSummary}
+            overridden={resolved.isOverride}
+            disabled={disabled}
+            onProvider={(next) => {
+              if (next === '') {
+                onChange(null);
+                return;
+              }
+              setProviderId(next);
+              if (!resolved.isOverride) {
+                return;
+              }
+              commit({
+                providerId: next,
+                model: recommendedModelForRole({ role, provider: next }),
+                effort: resolved.effort,
+              });
+            }}
+            onModel={(nextModel) => {
+              if (nextModel === '') {
+                onChange(null);
+                return;
+              }
+              commit({ providerId, model: nextModel, effort: resolved.effort });
+            }}
+            onEffort={(effort) =>
+              commit({
+                providerId,
+                model: resolved.isOverride ? resolved.model : recommendedModel,
+                effort,
+              })
+            }
+          />
+        </div>
       </div>
     </FieldRow>
   );

--- a/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/RoutingStatusControl.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/RoutingStatusControl.tsx
@@ -1,0 +1,37 @@
+import { RotateCcw } from 'lucide-react';
+import { Chip } from '@goodboy/ui';
+
+type Props = {
+  readonly label: string;
+  readonly isCustom: boolean;
+  readonly disabled: boolean;
+  readonly onReset: () => void;
+};
+
+export const RoutingStatusControl = ({ label, isCustom, disabled, onReset }: Props) => {
+  const status = isCustom ? 'custom' : 'default';
+
+  return (
+    <div className="flex shrink-0 items-center gap-1">
+      <Chip
+        tone={isCustom ? 'primary' : 'neutral'}
+        label={status}
+        ariaLabel={`${label} routing status: ${status}`}
+        bordered={false}
+        className={isCustom ? 'bg-primary/10 text-primary' : 'bg-muted text-muted-foreground'}
+      />
+      {isCustom ? (
+        <button
+          type="button"
+          onClick={onReset}
+          disabled={disabled}
+          aria-label="Reset to default"
+          title="Reset to default"
+          className="inline-flex items-center justify-center rounded-full p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          <RotateCcw size={12} aria-hidden />
+        </button>
+      ) : null}
+    </div>
+  );
+};

--- a/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/TaskModelRow.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/TaskModelRow.tsx
@@ -3,6 +3,7 @@ import { PROVIDER_CAPABILITIES, resolveTaskModel } from '@goodboy/core';
 import type { AuxTaskId, ProviderId, TaskModelPreference } from '@goodboy/types';
 import { FieldRow } from '@goodboy/ui';
 import { RoutingPicker } from '../../../../../shared/components/RoutingPicker';
+import { RoutingStatusControl } from './RoutingStatusControl';
 
 type Props = {
   readonly task: AuxTaskId;
@@ -40,28 +41,36 @@ export const TaskModelRow = ({
 
   return (
     <FieldRow label={label} help={help}>
-      <div className="w-80">
-        <RoutingPicker
-          ariaLabel={`${label} routing`}
-          connectedProviders={availableProviderIds}
-          provider={providerId}
-          model={model}
-          recommendedModel={recommendedModel}
+      <div className="flex items-center gap-2">
+        <RoutingStatusControl
+          label={label}
+          isCustom={preference != null}
           disabled={disabled}
-          onProvider={(next) => {
-            if (next === '') {
-              return;
-            }
-            setProviderId(next);
-            if (preference == null) {
-              return;
-            }
-            onChange(resolveTaskModel(task, null, next));
-          }}
-          onModel={(nextModel) =>
-            onChange(nextModel === '' ? null : { providerId, model: nextModel })
-          }
+          onReset={() => onChange(null)}
         />
+        <div className="w-80">
+          <RoutingPicker
+            ariaLabel={`${label} routing`}
+            connectedProviders={availableProviderIds}
+            provider={providerId}
+            model={model}
+            recommendedModel={recommendedModel}
+            disabled={disabled}
+            onProvider={(next) => {
+              if (next === '') {
+                return;
+              }
+              setProviderId(next);
+              if (preference == null) {
+                return;
+              }
+              onChange(resolveTaskModel(task, null, next));
+            }}
+            onModel={(nextModel) =>
+              onChange(nextModel === '' ? null : { providerId, model: nextModel })
+            }
+          />
+        </div>
       </div>
     </FieldRow>
   );

--- a/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/index.test.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/index.test.tsx
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { OverrideSettings } from '@goodboy/types';
 import { DefaultsPanel } from './index';
+
+type SetWorkspaceOverrides = (workspaceId: string, overrides: OverrideSettings) => Promise<void>;
 
 const { state } = vi.hoisted(() => ({
   state: {
@@ -10,7 +12,7 @@ const { state } = vi.hoisted(() => ({
       { id: 'anthropic', connection: 'connected' },
       { id: 'cursor', connection: 'connected' },
     ],
-    setWorkspaceOverrides: vi.fn(async () => undefined),
+    setWorkspaceOverrides: vi.fn<SetWorkspaceOverrides>(async () => undefined),
   },
 }));
 
@@ -92,7 +94,13 @@ const EMPTY_OVERRIDES: OverrideSettings = {
 
 beforeEach(() => {
   state.workspaceOverrides = { 'ws-1': EMPTY_OVERRIDES };
-  state.setWorkspaceOverrides.mockClear();
+  state.setWorkspaceOverrides.mockReset();
+  state.setWorkspaceOverrides.mockImplementation(async (workspaceId, overrides) => {
+    state.workspaceOverrides = {
+      ...state.workspaceOverrides,
+      [workspaceId]: overrides,
+    };
+  });
 });
 
 afterEach(cleanup);
@@ -118,10 +126,14 @@ describe('DefaultsPanel', () => {
         'claude-haiku-4-5 auto',
       );
     }
+    expect(screen.getByLabelText('Summaries routing status: default')).toBeDefined();
+    expect(screen.getByLabelText('Planner routing status: default')).toBeDefined();
   });
 
-  it('persists a selected task model immediately', () => {
-    render(<DefaultsPanel workspaceId={'ws-1' as never} />);
+  it('marks a task override as custom and resets it to default', async () => {
+    const { rerender } = render(<DefaultsPanel workspaceId={'ws-1' as never} />);
+
+    expect(screen.getByLabelText('Summaries routing status: default')).toBeDefined();
     fireEvent.click(screen.getAllByText('claude-haiku-4-5 auto')[0]!);
 
     expect(state.setWorkspaceOverrides).toHaveBeenCalledWith(
@@ -132,6 +144,20 @@ describe('DefaultsPanel', () => {
         },
       }),
     );
+
+    rerender(<DefaultsPanel workspaceId={'ws-1' as never} />);
+    expect(screen.getByLabelText('Summaries routing status: custom')).toBeDefined();
+    const reset = screen.getByRole('button', { name: 'Reset to default' });
+    await waitFor(() => expect(reset.hasAttribute('disabled')).toBe(false));
+    fireEvent.click(reset);
+
+    expect(state.setWorkspaceOverrides).toHaveBeenLastCalledWith(
+      'ws-1',
+      expect.objectContaining({ taskModels: null }),
+    );
+
+    rerender(<DefaultsPanel workspaceId={'ws-1' as never} />);
+    expect(screen.getByLabelText('Summaries routing status: default')).toBeDefined();
   });
 
   it('renders a row per agent role', () => {
@@ -182,19 +208,35 @@ describe('DefaultsPanel', () => {
     );
   });
 
-  it('shows a stored role override instead of the compiled default', () => {
+  it('resets a stored role override to the selected default provider', async () => {
     state.workspaceOverrides = {
       'ws-1': {
         ...EMPTY_OVERRIDES,
+        defaultProviderId: 'cursor',
         roleModels: {
           reviewer: { providerId: 'anthropic', model: 'claude-opus-5', effort: 'max' },
         },
       },
     };
-    render(<DefaultsPanel workspaceId={'ws-1' as never} />);
+    const { rerender } = render(<DefaultsPanel workspaceId={'ws-1' as never} />);
 
     expect(screen.getByRole('button', { name: 'Reviewer routing model' }).textContent).toBe(
       'claude-opus-5',
+    );
+    expect(screen.getByLabelText('Reviewer routing status: custom')).toBeDefined();
+    const reset = screen.getByRole('button', { name: 'Reset to default' });
+    await waitFor(() => expect(reset.hasAttribute('disabled')).toBe(false));
+    fireEvent.click(reset);
+
+    expect(state.setWorkspaceOverrides).toHaveBeenLastCalledWith(
+      'ws-1',
+      expect.objectContaining({ roleModels: null }),
+    );
+
+    rerender(<DefaultsPanel workspaceId={'ws-1' as never} />);
+    expect(screen.getByLabelText('Reviewer routing status: default')).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Reviewer routing provider' }).textContent).toBe(
+      'cursor',
     );
   });
 

--- a/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/index.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/index.tsx
@@ -93,7 +93,7 @@ export const DefaultsPanel = ({ workspaceId }: Props) => {
       <Divider />
       <ScrollFade className="flex-1" fadeFrom="background">
         <div className="mx-auto flex w-full max-w-3xl flex-col gap-8 px-8 py-6">
-          <section className="flex flex-col">
+          <section className="flex flex-col gap-1">
             <FieldRow label="Default provider" help="New sessions start on it and can override it.">
               <div className="flex flex-wrap justify-end gap-1">
                 {PROVIDER_ORDER.map((providerId) => (
@@ -116,6 +116,9 @@ export const DefaultsPanel = ({ workspaceId }: Props) => {
                 ))}
               </div>
             </FieldRow>
+            <p className="text-2xs text-muted-foreground">
+              Default rows follow the provider you set above
+            </p>
           </section>
 
           <section className="flex flex-col gap-2">
@@ -153,6 +156,7 @@ export const DefaultsPanel = ({ workspaceId }: Props) => {
                     label={ROLE_LABEL[role]}
                     help={ROLE_DEFAULTS[role].description}
                     preference={overrides.roleModels?.[role] ?? null}
+                    defaultProviderId={defaultProviderId}
                     connectedProviderIds={connectedProviderIds}
                     disabled={busy}
                     onChange={(preference) => persistRoleModel({ role, preference })}

--- a/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/index.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/index.tsx
@@ -117,7 +117,7 @@ export const DefaultsPanel = ({ workspaceId }: Props) => {
               </div>
             </FieldRow>
             <p className="text-2xs text-muted-foreground">
-              Default rows follow the provider you set above
+              Default rows follow the provider you set above.
             </p>
           </section>
 


### PR DESCRIPTION
## Problem

- The whole topbar rollup ("N need you · $X today") was one button that opened Budget Studio, so clicking the attention count landed you in spend instead of triage.
- In providers > configurations there was no way to tell which role and task models follow the provider default and which are custom, so changing the default provider silently changed rows underneath.

## Change

- The rollup is split: the spend chip keeps opening Budget Studio; "N need you" opens a portal popover (same positioning pattern as the notification center) listing the attention sessions with goal and reason. Clicking a row navigates to that session.
- Every role and task model row carries a chip: `default` (muted) when it follows the provider default, `custom` (accent) when overridden, with an inline reset control that restores the provider default. One help line explains rows follow the default provider.

## Testing

- `pnpm --filter @goodboy/desktop typecheck`
- vitest: AppTopBar (popover, split targets, navigation), DefaultsPanel (chips + reset), 14 tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)