### PR TITLE
feat(desktop): agents lens with persistent inspector and newest-first lists

### DIFF
--- a/apps/desktop/src/features/session/components/SessionWorkspace/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/index.test.tsx
@@ -55,16 +55,24 @@ const { store, hooks } = vi.hoisted(() => ({
     setFocusedPlanId: vi.fn(),
     reconcileSessionBranch: vi.fn(async () => undefined),
   } as Store,
-  hooks: { agentHome: 'workflows' as LensKind },
+  hooks: {
+    agentHome: 'workflows' as LensKind,
+    openQuestions: [] as ReadonlyArray<{ readonly createdByAgentId?: string }>,
+  },
 }));
 
 vi.mock('../../../../store', () => ({
   EMPTY_ARRAY: Object.freeze([]),
+  agentHasUnread: (agent: Agent, isCurrentlyViewed: boolean) =>
+    !isCurrentlyViewed &&
+    agent.status !== 'skipped' &&
+    agent.lastFinishedAt != null &&
+    (agent.lastViewedAt == null || agent.lastFinishedAt > agent.lastViewedAt),
   readPersistedLens: () => null,
   useAppStore: <T,>(selector: (state: Store) => T) => selector(store),
   useFilesTouched: () => ({ count: 0 }),
   useSessionPlans: () => [],
-  useSessionOpenQuestions: () => [],
+  useSessionOpenQuestions: () => hooks.openQuestions,
 }));
 
 vi.mock('@goodboy/ui', async (importOriginal) => {
@@ -88,8 +96,27 @@ vi.mock('../../../plans/components/PlanStudio', () => ({ PlanStudio: () => null 
 vi.mock('../../../scripts', () => ({ ScriptsPanel: () => null }));
 vi.mock('../../../worktree/worktree', () => ({ worktreeStatus: vi.fn() }));
 vi.mock('../../../workspace/components/WorkspacesSidebar/parts/AgentsSection', () => ({
-  AgentsSection: ({ only }: { only: string }) => (
-    <div data-testid="agents-section" data-home={only} />
+  AgentsSection: ({
+    only,
+    task,
+    onInspectAgent,
+  }: {
+    only: string;
+    task: Session;
+    onInspectAgent?: (agentId: string) => void;
+  }) => (
+    <div data-testid="agents-section" data-home={only}>
+      {only === 'agents'
+        ? (store.sessionPhaseRuns[task.id] ?? []).map((agent) => (
+            <button
+              key={agent.id}
+              type="button"
+              onClick={() => onInspectAgent?.(agent.id)}
+              aria-label={`inspect ${agent.id}`}
+            />
+          ))
+        : null}
+    </div>
   ),
 }));
 vi.mock('../../../../app/components/AppBreadcrumb', () => ({
@@ -180,6 +207,7 @@ beforeEach(() => {
   store.sessionLoading = {};
   store.setActiveLens.mockReset();
   hooks.agentHome = 'workflows';
+  hooks.openQuestions = [];
 });
 
 afterEach(cleanup);
@@ -354,6 +382,88 @@ describe('SessionWorkspace agent overlay', () => {
     render(<SessionWorkspace session={session} isActive />);
 
     expect(screen.getByTestId('resolver-inspector').textContent).toBe(running.id);
+  });
+});
+
+describe('SessionWorkspace agents inspector', () => {
+  it('opens the running standalone agent before newer attention and pending agents', () => {
+    const running = {
+      ...selectedAgent,
+      id: 'agent-running',
+      ordinal: 0,
+      stepId: undefined,
+      workflowRunId: undefined,
+    } as Agent;
+    const attention = {
+      ...running,
+      id: 'agent-attention',
+      ordinal: 1,
+      status: 'failed',
+    } as Agent;
+    const newest = {
+      ...running,
+      id: 'agent-newest',
+      ordinal: 2,
+      status: 'pending',
+    } as Agent;
+    store.selectedAgentId = {};
+    store.sessionPhaseRuns = { [SESSION_ID]: [running, attention, newest] };
+
+    render(<SessionWorkspace session={session} isActive />);
+
+    expect(screen.getByTestId('agent-inspector').textContent).toBe(running.id);
+  });
+
+  it('prioritizes an agent awaiting attention over the newest pending agent', () => {
+    const attention = {
+      ...selectedAgent,
+      id: 'agent-attention',
+      ordinal: 0,
+      status: 'completed',
+      stepId: undefined,
+      workflowRunId: undefined,
+    } as Agent;
+    const newest = {
+      ...attention,
+      id: 'agent-newest',
+      ordinal: 1,
+      status: 'pending',
+    } as Agent;
+    store.selectedAgentId = {};
+    store.sessionPhaseRuns = { [SESSION_ID]: [attention, newest] };
+    hooks.openQuestions = [{ createdByAgentId: attention.id }];
+
+    render(<SessionWorkspace session={session} isActive />);
+
+    expect(screen.getByTestId('agent-inspector').textContent).toBe(attention.id);
+  });
+
+  it('keeps manual details selections and re-picks after the inspected agent is deleted', () => {
+    const older = {
+      ...selectedAgent,
+      id: 'agent-older',
+      ordinal: 0,
+      status: 'pending',
+      stepId: undefined,
+      workflowRunId: undefined,
+    } as Agent;
+    const newer = {
+      ...older,
+      id: 'agent-newer',
+      ordinal: 1,
+    } as Agent;
+    store.selectedAgentId = {};
+    store.sessionPhaseRuns = { [SESSION_ID]: [older, newer] };
+    const view = render(<SessionWorkspace session={session} isActive />);
+
+    expect(screen.getByTestId('agent-inspector').textContent).toBe(newer.id);
+
+    fireEvent.click(screen.getByRole('button', { name: `inspect ${older.id}` }));
+    expect(screen.getByTestId('agent-inspector').textContent).toBe(older.id);
+
+    store.sessionPhaseRuns = { [SESSION_ID]: [newer] };
+    view.rerender(<SessionWorkspace session={session} isActive />);
+    expect(screen.getByTestId('agent-inspector').textContent).toBe(newer.id);
   });
 });
 

--- a/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
@@ -6,9 +6,11 @@ import { PlanStudio } from '../../../plans/components/PlanStudio';
 import { ScriptsPanel } from '../../../scripts';
 import {
   EMPTY_ARRAY,
+  agentHasUnread,
   readPersistedLens,
   useAppStore,
   useFilesTouched,
+  useSessionOpenQuestions,
   useSessionPlans,
 } from '../../../../store';
 import type { LensKind } from '../../../../store';
@@ -81,6 +83,7 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
   const [inspectedResolverId, setInspectedResolverId] = useState<AgentId | null>(null);
   const [inspectedAgentId, setInspectedAgentId] = useState<AgentId | null>(null);
   const hasInitializedResolverInspector = useRef(false);
+  const hasInitializedAgentInspector = useRef(false);
   const storedActiveLens = useAppStore((s) => s.activeLens[sessionId]);
   const workspaceKind = useAppStore(
     (s) => s.workspaces?.find((workspace) => workspace.id === session.workspaceId)?.kind ?? 'repo',
@@ -109,6 +112,7 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
   const focusedWorkflowRunId = useAppStore((s) => s.focusedWorkflowRunId[sessionId] ?? null);
   const attachedWorkflowRuns = useAttachedWorkflowRuns({ session });
   const plans = useSessionPlans(sessionId);
+  const openQuestions = useSessionOpenQuestions(sessionId);
   const sessionLoading = useAppStore((s) => s.sessionLoading[sessionId]);
 
   useEffect(() => {
@@ -190,6 +194,31 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
     resolverCounts.queued === 0 && resolverCounts.resolved === 0
       ? undefined
       : `${resolverCounts.queued} queued, ${resolverCounts.resolved} resolved`;
+  useEffect(() => {
+    if (lens !== 'agents' || standaloneAgents.length === 0) {
+      return;
+    }
+    const isInspectedAgentPresent =
+      inspectedAgentId !== null && standaloneAgents.some((agent) => agent.id === inspectedAgentId);
+    if (isInspectedAgentPresent) {
+      hasInitializedAgentInspector.current = true;
+      return;
+    }
+    if (inspectedAgentId === null && hasInitializedAgentInspector.current) {
+      return;
+    }
+    const newestAgents = [...standaloneAgents].sort((a, b) => b.ordinal - a.ordinal);
+    const running = newestAgents.find((agent) => agent.status === 'running');
+    const attention = newestAgents.find(
+      (agent) =>
+        agent.status === 'failed' ||
+        agentHasUnread(agent, false) ||
+        openQuestions.some((question) => question.createdByAgentId === agent.id),
+    );
+    hasInitializedAgentInspector.current = true;
+    setInspectedAgentId((running ?? attention ?? newestAgents[0])?.id ?? null);
+  }, [inspectedAgentId, lens, openQuestions, standaloneAgents]);
+
   useEffect(() => {
     if (hasInitializedResolverInspector.current || resolverIndex.links.length === 0) {
       return;

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentRow.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentRow.tsx
@@ -231,7 +231,7 @@ export const AgentRow = ({
             </div>
           ))}
       </div>
-      <div className="flex flex-col gap-0.5 px-2 pb-1.5">
+      <div className="flex flex-col gap-0.5 px-2 pb-1.5 pt-0.5">
         <AgentMetricsInline
           telemetry={telemetry}
           aggregate={aggregate}

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.test.tsx
@@ -277,6 +277,27 @@ describe('AgentsSection collapse defaults', () => {
     );
   });
 
+  it('renders active and done standalone agents newest-first', () => {
+    h.state.sessionPhaseRuns = {
+      [SESSION_ID]: [
+        buildAgent({ id: 'active-old' as AgentId, name: 'active old', ordinal: 0 }),
+        buildAgent({ id: 'done-old' as AgentId, name: 'done old', ordinal: 1, doneAt: NOW }),
+        buildAgent({ id: 'active-new' as AgentId, name: 'active new', ordinal: 2 }),
+        buildAgent({ id: 'done-new' as AgentId, name: 'done new', ordinal: 3, doneAt: NOW }),
+      ],
+    };
+
+    render(<AgentsSection task={buildSession()} only="agents" />);
+    fireEvent.click(screen.getByRole('button', { name: 'Done (2)' }));
+
+    expect(screen.getAllByTestId('agent-row').map((row) => row.textContent)).toEqual([
+      'active new',
+      'active old',
+      'done new',
+      'done old',
+    ]);
+  });
+
   it('workflow unread badge counts step agents and their cluster children', () => {
     const RUN_ID = 'run-1' as WorkflowRunId;
     const workflow = {

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.tsx
@@ -43,6 +43,10 @@ import { AdHocRow } from './AdHocRow';
 import { WorkflowRow } from './WorkflowRow';
 import { pluralize, workflowKindName, type ResolverState } from '../lib';
 
+const LIST_CLASS = 'flex flex-col gap-1 pl-2';
+const FIRST_HEADER_CLASS = 'pb-1.5';
+const SUBSEQUENT_HEADER_CLASS = 'mt-6 pb-1.5';
+
 type Props = {
   task: Session;
   only?: 'workflows' | 'agents' | 'scripts' | 'resolve';
@@ -348,17 +352,22 @@ export const AgentsSection = ({
 
   const resolverAgents = useMemo(
     () =>
-      sorted.filter(
-        (r) =>
-          r.parentAgentId == null &&
-          r.stepId == null &&
-          classifyAgent(r, agentKindOverride[r.id] ?? null) === 'resolver',
-      ),
+      sorted
+        .filter(
+          (r) =>
+            r.parentAgentId == null &&
+            r.stepId == null &&
+            classifyAgent(r, agentKindOverride[r.id] ?? null) === 'resolver',
+        )
+        .sort((a, b) => b.ordinal - a.ordinal),
     [sorted, agentKindOverride],
   );
   const resolverIds = useMemo(() => new Set(resolverAgents.map((r) => r.id)), [resolverAgents]);
   const standaloneAgents = useMemo(
-    () => adHocAgents.filter((agent) => !resolverIds.has(agent.id)),
+    () =>
+      adHocAgents
+        .filter((agent) => !resolverIds.has(agent.id))
+        .sort((a, b) => b.ordinal - a.ordinal),
     [adHocAgents, resolverIds],
   );
   const activeStandaloneAgents = useMemo(
@@ -490,7 +499,7 @@ export const AgentsSection = ({
         <>
           {forceExpanded ? null : (
             <SectionHeader
-              className="pb-1.5"
+              className={FIRST_HEADER_CLASS}
               icon={<SECTION_ICONS.workflows size={11} aria-hidden className="text-primary" />}
               label="Workflow"
               action={
@@ -573,7 +582,7 @@ export const AgentsSection = ({
         <>
           {forceExpanded ? null : (
             <SectionHeader
-              className="mt-6 pb-1.5"
+              className={SUBSEQUENT_HEADER_CLASS}
               icon={<DogMascot size={14} className="shrink-0 text-success" />}
               label="Agents"
               action={
@@ -589,7 +598,7 @@ export const AgentsSection = ({
             <>
               {hasAnyWorkflow ? (
                 activeStandaloneAgents.length > 0 ? (
-                  <ul className="flex flex-col gap-1 pl-2">
+                  <ul className={LIST_CLASS}>
                     {activeStandaloneAgents.map((run, index) => (
                       <AdHocRow
                         key={run.id}
@@ -621,11 +630,7 @@ export const AgentsSection = ({
                 ) : null
               ) : standaloneAgents.length === 0 ? (
                 loading.agents ? (
-                  <ul
-                    role="status"
-                    aria-label="loading agents"
-                    className="flex flex-col gap-1 pl-2"
-                  >
+                  <ul role="status" aria-label="loading agents" className={LIST_CLASS}>
                     {[0, 1].map((i) => (
                       <li key={i} className="flex items-center gap-2 rounded px-2 py-1.5">
                         <span className="h-3 w-3 motion-safe:animate-pulse rounded-full bg-muted" />
@@ -657,7 +662,7 @@ export const AgentsSection = ({
                   )
                 ) : null
               ) : (
-                <ul className="flex flex-col gap-1 pl-2">
+                <ul className={LIST_CLASS}>
                   {activeStandaloneAgents.map((run, index) => (
                     <AdHocRow
                       key={run.id}
@@ -703,7 +708,7 @@ export const AgentsSection = ({
                 </button>
               ) : null}
               {doneExpanded ? (
-                <ul className="flex flex-col gap-1 pl-2">
+                <ul className={LIST_CLASS}>
                   {doneStandaloneAgents.map((run, index) => (
                     <AdHocRow
                       key={run.id}
@@ -765,7 +770,7 @@ export const AgentsSection = ({
           <>
             {forceExpanded ? null : (
               <SectionHeader
-                className="mt-6 pb-1.5"
+                className={SUBSEQUENT_HEADER_CLASS}
                 icon={<CheckCheck size={11} aria-hidden className="text-success" />}
                 label="Resolve"
               />

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/ResolveCluster.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/ResolveCluster.test.tsx
@@ -34,6 +34,20 @@ const completed = {
   status: 'completed',
   sourceThreadId: 'PRRT_1',
 } satisfies Agent;
+const newerActive = {
+  ...active,
+  id: 'newer-active' as AgentId,
+  ordinal: 2,
+  name: 'Newer active resolver',
+  status: 'pending',
+} satisfies Agent;
+const newestCompleted = {
+  ...completed,
+  id: 'newest-completed' as AgentId,
+  ordinal: 3,
+  name: 'Newest completed resolver',
+  sourceThreadId: 'PRRT_2',
+} satisfies Agent;
 
 describe('ResolveCluster', () => {
   afterEach(cleanup);
@@ -41,11 +55,11 @@ describe('ResolveCluster', () => {
   it('keeps active resolvers visible and completed resolvers collapsed', () => {
     render(
       <ResolveCluster
-        agents={[active, completed]}
+        agents={[active, completed, newerActive, newestCompleted]}
         sessionId={SESSION_ID}
         isTaskActive
         prNumber={null}
-        resolvedThreadIds={new Set(['PRRT_1'])}
+        resolvedThreadIds={new Set(['PRRT_1', 'PRRT_2'])}
         pendingThreadIds={new Set()}
         resolverState={{}}
         commentByThreadId={new Map()}
@@ -67,11 +81,17 @@ describe('ResolveCluster', () => {
       />,
     );
 
+    expect(screen.getByText('Newer active resolver:pending')).toBeDefined();
     expect(screen.getByText('Active resolver:running')).toBeDefined();
     expect(screen.queryByText('Completed resolver:resolved')).toBeNull();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Completed (1)' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Completed (2)' }));
 
-    expect(screen.getByText('Completed resolver:resolved')).toBeDefined();
+    expect(screen.getAllByText(/resolver:/).map((row) => row.textContent)).toEqual([
+      'Newer active resolver:pending',
+      'Active resolver:running',
+      'Newest completed resolver:resolved',
+      'Completed resolver:resolved',
+    ]);
   });
 });

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/ResolveCluster.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/ResolveCluster.tsx
@@ -55,7 +55,9 @@ export const ResolveCluster = ({
   const [isCompletedExpanded, setIsCompletedExpanded] = useState(false);
   const statusOf = (a: Agent): ResolverStatus =>
     resolverStatus(a, resolvedThreadIds, pendingThreadIds, resolverState[a.id]);
-  const entries = agents.map((agent, index) => ({ agent, index, status: statusOf(agent) }));
+  const entries = [...agents]
+    .sort((a, b) => b.ordinal - a.ordinal)
+    .map((agent, index) => ({ agent, index, status: statusOf(agent) }));
   const completedEntries = entries.filter(({ status }) =>
     ['resolved', 'wontfix', 'stopped', 'done'].includes(status),
   );
@@ -89,8 +91,8 @@ export const ResolveCluster = ({
     );
   };
   return (
-    <div className="flex flex-col gap-0.5 pl-2">
-      <div className="flex items-center gap-1 pr-1">
+    <div className="flex flex-col gap-1 pl-2">
+      <div className="flex items-center gap-1">
         <button
           type="button"
           onClick={onToggle}

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/SpawnAgentControl.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/SpawnAgentControl.test.tsx
@@ -49,6 +49,19 @@ afterEach(() => {
 });
 
 describe('SpawnAgentControl', () => {
+  it('groups the action and quiet configuration controls in one bordered row', () => {
+    renderControl();
+    const create = screen.getByRole('button', { name: 'Create agent' });
+    const role = screen.getByRole('combobox', { name: 'agent role' });
+    const routing = screen.getByRole('button', { name: 'new agent routing' });
+    const row = create.parentElement;
+
+    expect(row?.className).toContain('border-dashed');
+    expect(role.closest('.border-dashed')).toBe(row);
+    expect(routing.closest('.border-dashed')).toBe(row);
+    expect(create.className).not.toContain('border-dashed');
+  });
+
   it('spawns a generic agent with untouched defaults', () => {
     renderControl();
     createAgent();

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/SpawnAgentControl.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/SpawnAgentControl.tsx
@@ -1,7 +1,7 @@
 import { useState, type ChangeEventHandler, type MouseEventHandler } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { getDefaultTurnModel } from '@goodboy/core';
-import { Select, cn } from '@goodboy/ui';
+import { Divider, Select, cn } from '@goodboy/ui';
 import { Plus } from 'lucide-react';
 import type { ProviderId, SessionId } from '@goodboy/types';
 import { useAppStore, useCurrentWorkspace } from '../../../../../store';
@@ -79,62 +79,70 @@ export const SpawnAgentControl = ({ sessionId, className, onSpawned }: Props) =>
   };
 
   return (
-    <div className={cn('relative flex flex-wrap items-center gap-2 overflow-visible', className)}>
-      <button
-        type="button"
-        onClick={onCreate}
-        className="inline-flex h-7 shrink-0 items-center gap-1.5 rounded-md border border-dashed border-border-soft px-2 text-xs text-muted-foreground transition-colors hover:border-border hover:bg-muted/50 hover:text-foreground"
-      >
-        <Plus size={13} aria-hidden />
-        Create agent
-      </button>
-      {agentKinds.length > 1 && (
-        <Select
-          size="sm"
-          value={selectedRole}
-          onChange={onRoleChange}
-          aria-label="agent role"
-          className="h-7 text-xs"
+    <div className={cn('relative overflow-visible pl-2', className)}>
+      <div className="flex h-8 items-center gap-1 rounded-md border border-dashed border-border-soft bg-muted/20">
+        <button
+          type="button"
+          onClick={onCreate}
+          className="inline-flex h-7 shrink-0 items-center gap-1.5 rounded-md px-2 text-xs font-medium text-foreground transition-colors hover:bg-primary hover:text-primary-foreground"
         >
-          {agentKinds.map((kind) => (
-            <option key={kind} value={kind} title={AGENT_KIND_META[kind].hint}>
-              {AGENT_KIND_META[kind].label}
-            </option>
-          ))}
-        </Select>
-      )}
-      <RoutingPicker
-        variant="pill"
-        align="end"
-        ariaLabel="new agent routing"
-        connectedProviders={connectedProviders}
-        provider={routing?.provider ?? ''}
-        model={routing?.model ?? ''}
-        effort={routing?.effort ?? recommendedRouting.effort}
-        recommendedProvider={recommendedRouting.provider}
-        recommendedModel={recommendedRouting.model}
-        disabled={false}
-        overridden={routing != null}
-        onProvider={onProvider}
-        onModel={(model) => {
-          if (model === '') {
-            setRouting(null);
-            return;
-          }
-          setRouting({
-            provider: routing?.provider ?? recommendedRouting.provider,
-            model,
-            effort: clampEffort(model, routing?.effort ?? recommendedRouting.effort),
-          });
-        }}
-        onEffort={(effort) =>
-          setRouting({
-            provider: routing?.provider ?? recommendedRouting.provider,
-            model: routing?.model ?? recommendedRouting.model,
-            effort,
-          })
-        }
-      />
+          <Plus size={13} aria-hidden />
+          Create agent
+        </button>
+        {agentKinds.length > 1 && (
+          <>
+            <Divider orientation="vertical" className="h-4 self-auto" />
+            <Select
+              size="sm"
+              value={selectedRole}
+              onChange={onRoleChange}
+              aria-label="agent role"
+              className="h-7 border-0 bg-transparent text-xs text-muted-foreground shadow-none hover:border-transparent hover:bg-muted/50 hover:text-foreground"
+            >
+              {agentKinds.map((kind) => (
+                <option key={kind} value={kind} title={AGENT_KIND_META[kind].hint}>
+                  {AGENT_KIND_META[kind].label}
+                </option>
+              ))}
+            </Select>
+          </>
+        )}
+        <Divider orientation="vertical" className="h-4 self-auto" />
+        <div className="[&>div>button]:bg-transparent [&>div>button]:ring-0 [&>div>button]:hover:bg-muted/50">
+          <RoutingPicker
+            variant="pill"
+            align="end"
+            ariaLabel="new agent routing"
+            connectedProviders={connectedProviders}
+            provider={routing?.provider ?? ''}
+            model={routing?.model ?? ''}
+            effort={routing?.effort ?? recommendedRouting.effort}
+            recommendedProvider={recommendedRouting.provider}
+            recommendedModel={recommendedRouting.model}
+            disabled={false}
+            overridden={routing != null}
+            onProvider={onProvider}
+            onModel={(model) => {
+              if (model === '') {
+                setRouting(null);
+                return;
+              }
+              setRouting({
+                provider: routing?.provider ?? recommendedRouting.provider,
+                model,
+                effort: clampEffort(model, routing?.effort ?? recommendedRouting.effort),
+              });
+            }}
+            onEffort={(effort) =>
+              setRouting({
+                provider: routing?.provider ?? recommendedRouting.provider,
+                model: routing?.model ?? recommendedRouting.model,
+                effort,
+              })
+            }
+          />
+        </div>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Problem

- The Agents lens shipped with an inspector split (#1007) but it opens only from the row's Details button, so the lens lands on a list with an empty right side. Resolve (#1006) already auto-picks its most relevant resolver.
- Agents and resolvers render oldest-first, so the agent you just spawned lands at the bottom (the Claude app does the opposite).
- The create-agent row was three unrelated controls, and the section mixed four different spacing vocabularies.

## Change

- The Agents lens auto-opens the inspector on the most relevant agent (running, then attention: failed, unread, open question, then newest), initialized once per session, re-picked when the inspected agent is deleted. Manual Details clicks still win.
- Standalone agents and resolvers render newest-first, at the view layer only: DB order, `ordinal` assignment, workflow steps, workflows and plans are untouched.
- Create agent is one cohesive dashed row: primary action, then quiet role and routing controls, aligned with the list rows.
- One spacing vocabulary across AgentsSection, AgentRow, ResolveCluster and the create row.

## Testing

- `pnpm --filter @goodboy/desktop typecheck`
- vitest: SessionWorkspace, AgentsSection, ResolveCluster, SpawnAgentControl, AgentRow (49 tests green), including explicit newest-first assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)