### PR TITLE
feat(desktop): richer workflow step cards

### DIFF
--- a/apps/desktop/src-tauri/src/workflows.rs
+++ b/apps/desktop/src-tauri/src/workflows.rs
@@ -185,6 +185,8 @@ pub struct SessionRow {
     pub source_comment_url: Option<String>,
     #[serde(rename = "sourceKind")]
     pub source_kind: Option<String>,
+    #[serde(rename = "domainsJson")]
+    pub domains_json: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -219,6 +221,8 @@ pub struct PhaseRunInsertInput {
     pub source_comment_url: Option<String>,
     #[serde(rename = "sourceKind")]
     pub source_kind: Option<String>,
+    #[serde(rename = "domainsJson")]
+    pub domains_json: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -866,7 +870,7 @@ pub fn agent_list_for_session(
                 provider_run_id, output_summary, started_at, completed_at,
                 provider_session_id, last_finished_at, last_viewed_at, done_at, kind, verbosity,
                 parent_agent_id, workflow_run_id, source_thread_id, source_thread_ids, source_comment_url,
-                source_kind
+                source_kind, domains_json
          FROM agents
          WHERE session_id = ?1
          ORDER BY ordinal ASC",
@@ -895,6 +899,7 @@ pub fn agent_list_for_session(
             source_thread_ids: row.get(19)?,
             source_comment_url: row.get(20)?,
             source_kind: row.get(21)?,
+            domains_json: row.get(22)?,
         })
     })?;
     rows.collect::<Result<Vec<_>, _>>().map_err(PhaseError::Db)
@@ -912,8 +917,9 @@ pub fn agent_insert(
         "INSERT INTO agents
            (id, session_id, step_id, ordinal, name, status,
             provider_run_id, output_summary, started_at, completed_at, kind, verbosity,
-            parent_agent_id, workflow_run_id, source_thread_id, source_thread_ids, source_comment_url, source_kind)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18)",
+            parent_agent_id, workflow_run_id, source_thread_id, source_thread_ids, source_comment_url, source_kind,
+            domains_json)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19)",
         rusqlite::params![
             id,
             input.session_id,
@@ -933,6 +939,7 @@ pub fn agent_insert(
             input.source_thread_ids,
             input.source_comment_url,
             input.source_kind,
+            input.domains_json,
         ],
     )?;
 
@@ -959,6 +966,7 @@ pub fn agent_insert(
         source_thread_ids: input.source_thread_ids,
         source_comment_url: input.source_comment_url,
         source_kind: input.source_kind,
+        domains_json: input.domains_json,
     })
 }
 
@@ -1001,7 +1009,7 @@ pub fn agent_update_status(
                 provider_run_id, output_summary, started_at, completed_at,
                 provider_session_id, last_finished_at, last_viewed_at, done_at, kind, verbosity,
                 parent_agent_id, workflow_run_id, source_thread_id, source_thread_ids, source_comment_url,
-                source_kind
+                source_kind, domains_json
          FROM agents
          WHERE id = ?1
          LIMIT 1",
@@ -1030,6 +1038,7 @@ pub fn agent_update_status(
             source_thread_ids: row.get(19)?,
             source_comment_url: row.get(20)?,
             source_kind: row.get(21)?,
+            domains_json: row.get(22)?,
         })
     })?;
     match rows.next() {

--- a/apps/desktop/src/features/workflows/workflows.ts
+++ b/apps/desktop/src/features/workflows/workflows.ts
@@ -92,6 +92,11 @@ type RawAgentRow = {
   readonly sourceThreadIds: string | null;
   readonly sourceCommentUrl: string | null;
   readonly sourceKind: string | null;
+  readonly domainsJson: string | null;
+};
+
+type ParseStringArrayParams = {
+  readonly value: string | null;
 };
 
 function rowToStep(row: RawWorkflowStepRow): Step {
@@ -150,11 +155,7 @@ function rowToWorkflow(row: RawWorkflowRow): Workflow {
   };
 }
 
-const parseSourceThreadIds = ({
-  value,
-}: {
-  readonly value: string | null;
-}): ReadonlyArray<string> => {
+const parseStringArray = ({ value }: ParseStringArrayParams): ReadonlyArray<string> => {
   if (value === null) {
     return [];
   }
@@ -170,7 +171,8 @@ const parseSourceThreadIds = ({
 };
 
 function rowToAgent(row: RawAgentRow): Agent {
-  const sourceThreadIds = parseSourceThreadIds({ value: row.sourceThreadIds });
+  const sourceThreadIds = parseStringArray({ value: row.sourceThreadIds });
+  const domains = parseStringArray({ value: row.domainsJson });
   return {
     id: row.id as AgentId,
     sessionId: row.sessionId as SessionId,
@@ -194,6 +196,7 @@ function rowToAgent(row: RawAgentRow): Agent {
     ...(sourceThreadIds.length > 0 && { sourceThreadIds }),
     ...(row.sourceCommentUrl != null && { sourceCommentUrl: row.sourceCommentUrl }),
     ...(row.sourceKind != null && { sourceKind: row.sourceKind as AgentSourceKind }),
+    ...(domains.length > 0 && { domains }),
   };
 }
 
@@ -330,6 +333,7 @@ export type AgentInsertArgs = {
   readonly sourceThreadIds?: ReadonlyArray<string>;
   readonly sourceCommentUrl?: string;
   readonly sourceKind?: AgentSourceKind;
+  readonly domains?: ReadonlyArray<string>;
 };
 
 export const invokeAgentInsert = async (run: AgentInsertArgs): Promise<Agent> => {
@@ -354,6 +358,7 @@ export const invokeAgentInsert = async (run: AgentInsertArgs): Promise<Agent> =>
         run.sourceThreadIds !== undefined ? JSON.stringify(run.sourceThreadIds) : null,
       sourceCommentUrl: run.sourceCommentUrl ?? null,
       sourceKind: run.sourceKind ?? null,
+      domainsJson: run.domains !== undefined ? JSON.stringify(run.domains) : null,
     },
   });
   return rowToAgent(row);

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/ClusterChildRow.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/ClusterChildRow.test.tsx
@@ -103,4 +103,19 @@ describe('ClusterChildRow unread border', () => {
     fireEvent.click(button);
     expect(onSelect).toHaveBeenCalledOnce();
   });
+
+  it('shows three scout domains and an overflow chip', () => {
+    renderRow(
+      buildAgent({
+        id: 'c1' as AgentId,
+        domains: ['auth', 'db', 'routing', 'sessions', 'api'],
+      }),
+    );
+
+    expect(screen.getByText('auth')).toBeTruthy();
+    expect(screen.getByText('db')).toBeTruthy();
+    expect(screen.getByText('routing')).toBeTruthy();
+    expect(screen.getByText('+2')).toBeTruthy();
+    expect(screen.queryByText('sessions')).toBeNull();
+  });
 });

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/ClusterChildRow.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/ClusterChildRow.tsx
@@ -3,7 +3,7 @@ import { Check, Clock } from 'lucide-react';
 import type { Agent } from '@goodboy/types';
 import { agentHasUnread } from '../../../../../store';
 
-type ClusterChildRowProps = {
+type Props = {
   readonly child: Agent;
   readonly index: number;
   readonly total: number;
@@ -13,7 +13,7 @@ type ClusterChildRowProps = {
   readonly onSelect: () => void;
 };
 
-export function ClusterChildRow({
+export const ClusterChildRow = ({
   child,
   index,
   total,
@@ -21,8 +21,11 @@ export function ClusterChildRow({
   isSelected,
   isTaskActive,
   onSelect,
-}: ClusterChildRowProps) {
+}: Props) => {
   const hasUnread = agentHasUnread(child, isSelected && isTaskActive);
+  const domains = child.domains ?? [];
+  const visibleDomains = domains.slice(0, 3);
+  const hiddenDomainCount = domains.length - visibleDomains.length;
   const icon =
     child.status === 'running' ? (
       <StatusDot tone="info" size="sm" pulsing />
@@ -52,14 +55,27 @@ export function ClusterChildRow({
       </span>
       {icon}
       <span className="min-w-0 flex-1 truncate text-left">{child.name}</span>
-      {costUsd > 0 && (
+      {visibleDomains.map((domain, domainIndex) => (
+        <span
+          key={`${domain}-${domainIndex}`}
+          className="shrink-0 rounded bg-muted px-1 py-0.5 text-2xs font-normal text-muted-foreground"
+        >
+          {domain}
+        </span>
+      ))}
+      {hiddenDomainCount > 0 ? (
+        <span className="shrink-0 rounded bg-muted px-1 py-0.5 text-2xs font-normal text-muted-foreground">
+          +{hiddenDomainCount}
+        </span>
+      ) : null}
+      {costUsd > 0 ? (
         <span
           className="shrink-0 tabular-nums text-muted-foreground/60"
           title={`$${costUsd.toFixed(4)}`}
         >
           ${costUsd.toFixed(2)}
         </span>
-      )}
+      ) : null}
     </button>
   );
-}
+};

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.test.tsx
@@ -24,7 +24,7 @@ vi.mock('../../../../../store', () => ({
 vi.mock(
   '../../../../../features/context/components/ContextPanel/strips/GoalAttachmentsStrip',
   () => ({
-    GoalAttachmentsStrip: () => null,
+    GoalAttachmentsStrip: () => <div data-testid="goal-attachments" />,
   }),
 );
 
@@ -219,6 +219,17 @@ describe('WorkflowRow detail dashboard', () => {
     expect(screen.getByTestId('workflow-next-step-cta')).toBeDefined();
   });
 
+  it('places workflow attachments between the goal and the steps', () => {
+    renderDetail();
+
+    const goal = screen.getByRole('region', { name: 'what you asked for' });
+    const attachments = screen.getByTestId('goal-attachments');
+    const firstStep = screen.getByTestId(`step-${agents[0]!.id}`);
+
+    expect(goal.compareDocumentPosition(attachments)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    expect(attachments.compareDocumentPosition(firstStep)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+  });
+
   it('places non-scout runs inside the owning step without an indented rail', () => {
     const child = {
       ...agents[1]!,
@@ -232,8 +243,10 @@ describe('WorkflowRow detail dashboard', () => {
     });
 
     const stepRow = screen.getByTestId(`step-${agents[1]!.id}`);
-    expect(within(stepRow).getByRole('button', { name: 'expand runs for Plan' })).toBeDefined();
+    const runs = within(stepRow).getByRole('button', { name: 'expand runs for Plan' });
+    expect(runs).toBeDefined();
     expect(within(stepRow).getByText('Runs (1/1)')).toBeDefined();
+    expect(stepRow.contains(runs)).toBe(true);
     expect(stepRow.querySelector('.ml-3')).toBeNull();
     expect(stepRow.querySelector('.border-l')).toBeNull();
   });

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.tsx
@@ -307,10 +307,13 @@ export const WorkflowRow = ({
         )}
       </div>
       {isDetail && expanded ? (
-        <WorkflowRunAsk
-          goal={(run.goal ?? workflow.goal ?? '').trim()}
-          processText={(workflow.processText ?? '').trim()}
-        />
+        <div className="flex flex-col gap-2">
+          <WorkflowRunAsk
+            goal={(run.goal ?? workflow.goal ?? '').trim()}
+            processText={(workflow.processText ?? '').trim()}
+          />
+          <GoalAttachmentsStrip owner={{ type: 'workflow_run', id: run.id }} />
+        </div>
       ) : null}
       {expanded ? (
         wfAgents.length > 0 ? (
@@ -473,7 +476,7 @@ export const WorkflowRow = ({
           />
         </div>
       ) : null}
-      {expanded ? (
+      {expanded && !isDetail ? (
         <div className={cn('pb-1', !isDetail && 'pl-3')}>
           <GoalAttachmentsStrip owner={{ type: 'workflow_run', id: run.id }} />
         </div>

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowStepPlanBadge.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowStepPlanBadge.tsx
@@ -1,0 +1,69 @@
+import { FileText } from 'lucide-react';
+import type { Agent } from '@goodboy/types';
+import { useAppStore, useSessionPlans } from '../../../../../store';
+import { kindConsumesPlan, type AgentKind } from '../../../../session/agent-kind';
+
+type Props = {
+  readonly run: Agent;
+  readonly kind: AgentKind;
+};
+
+export const WorkflowStepPlanBadge = ({ run, kind }: Props) => {
+  const plans = useSessionPlans(run.sessionId);
+  const planConsumptions = useAppStore((state) => state.planConsumptions);
+  const plannerPlan =
+    kind === 'planner' ? [...plans].reverse().find((plan) => plan.agentId === run.id) : undefined;
+  const consumedPlan = kindConsumesPlan(kind)
+    ? [...plans]
+        .reverse()
+        .find((plan) =>
+          (planConsumptions[plan.id] ?? []).some((consumption) => consumption.agentId === run.id),
+        )
+    : undefined;
+  const runPlans =
+    run.workflowRunId != null
+      ? plans.filter((plan) => plan.workflowRunId === run.workflowRunId)
+      : [];
+  const hasRunConsumptions = runPlans.some((plan) => (planConsumptions[plan.id]?.length ?? 0) > 0);
+  const fallbackPlan =
+    kindConsumesPlan(kind) &&
+    consumedPlan == null &&
+    !hasRunConsumptions &&
+    (run.status === 'running' || run.status === 'completed') &&
+    run.workflowRunId != null
+      ? runPlans[runPlans.length - 1]
+      : undefined;
+  const plan = plannerPlan ?? consumedPlan ?? fallbackPlan;
+
+  if (plan == null) {
+    return null;
+  }
+
+  const label = kind === 'planner' ? 'Plan' : 'From plan';
+  const onOpen = () => {
+    window.dispatchEvent(
+      new CustomEvent('goodboy:open-plan-studio', {
+        detail: { sessionId: run.sessionId, planId: plan.id },
+      }),
+    );
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={(event) => {
+        event.stopPropagation();
+        onOpen();
+      }}
+      onDoubleClick={(event) => event.stopPropagation()}
+      onKeyDown={(event) => event.stopPropagation()}
+      title={plan.title}
+      aria-label={`open ${label.toLowerCase()}: ${plan.title}`}
+      className="flex max-w-full shrink-0 items-center gap-1 rounded-md bg-muted/60 px-1.5 py-0.5 text-2xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+    >
+      <FileText size={12} aria-hidden className="shrink-0" />
+      <span className="shrink-0 font-medium">{label}</span>
+      <span className="max-w-[24ch] truncate">{plan.title}</span>
+    </button>
+  );
+};

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowStepRow.details.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowStepRow.details.test.tsx
@@ -7,6 +7,9 @@ import type { Agent, AgentId, SessionId, Step, StepId, WorkflowId } from '@goodb
 
 vi.mock('../../../../../store', () => ({
   agentHasUnread: () => false,
+  useAppStore: <T,>(selector: (state: { planConsumptions: Record<string, never[]> }) => T) =>
+    selector({ planConsumptions: {} }),
+  useSessionPlans: () => [],
 }));
 
 vi.mock('../../../../session/components/AgentMetricsBlock', () => ({
@@ -119,6 +122,10 @@ describe('WorkflowStepRow details', () => {
 
     const brief = screen.getByText('Instructions').parentElement?.parentElement;
     const runs = screen.getByTestId('step-runs');
+    const card = screen.getByTestId('workflow-step-card');
     expect(brief?.compareDocumentPosition(runs) ?? 0).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    expect(card.contains(brief ?? null)).toBe(true);
+    expect(card.contains(runs)).toBe(true);
+    expect(card.querySelectorAll('[role="separator"]')).toHaveLength(2);
   });
 });

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowStepRow.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowStepRow.test.tsx
@@ -1,11 +1,32 @@
 // @vitest-environment happy-dom
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, render, screen } from '@testing-library/react';
-import type { Agent, AgentId, SessionId, TelemetryRecord } from '@goodboy/types';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type {
+  Agent,
+  AgentId,
+  IsoDateTime,
+  PlanConsumption,
+  PlanConsumptionId,
+  PlanId,
+  PlanWithCount,
+  SessionId,
+  TelemetryRecord,
+  WorkflowRunId,
+} from '@goodboy/types';
+import type { AgentKind } from '../../../../../features/session/agent-kind';
+
+const storeState = vi.hoisted(() => ({
+  plans: [] as ReadonlyArray<PlanWithCount>,
+  planConsumptions: {} as Record<PlanId, ReadonlyArray<PlanConsumption>>,
+}));
 
 vi.mock('../../../../../store', () => ({
   agentHasUnread: () => false,
+  useAppStore: <T,>(
+    selector: (state: { planConsumptions: Record<PlanId, ReadonlyArray<PlanConsumption>> }) => T,
+  ) => selector(storeState),
+  useSessionPlans: () => storeState.plans,
 }));
 
 import { WorkflowStepRow } from './WorkflowStepRow';
@@ -36,17 +57,25 @@ const telemetry = {
 type Overrides = {
   readonly ranAlready?: boolean;
   readonly isPendingFuture?: boolean;
+  readonly kind?: AgentKind;
+  readonly runOverride?: Agent;
 };
 
-const renderRow = ({ ranAlready = true, isPendingFuture = false }: Overrides = {}) =>
+const renderRow = ({
+  ranAlready = true,
+  isPendingFuture = false,
+  kind = 'implementer',
+  runOverride,
+}: Overrides = {}) =>
   render(
     <WorkflowStepRow
       run={
-        isPendingFuture
+        runOverride ??
+        (isPendingFuture
           ? ({ ...run, status: 'pending', startedAt: undefined, completedAt: undefined } as Agent)
-          : run
+          : run)
       }
-      kind="implementer"
+      kind={kind}
       index={0}
       resolvedModel="claude-opus-4-5"
       isActionable={false}
@@ -80,7 +109,11 @@ const renderRow = ({ ranAlready = true, isPendingFuture = false }: Overrides = {
     />,
   );
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  storeState.plans = [];
+  storeState.planConsumptions = {};
+});
 
 describe('WorkflowStepRow', () => {
   it('shows the full metric picture without being selected', () => {
@@ -105,5 +138,95 @@ describe('WorkflowStepRow', () => {
     expect(screen.getByText('opus 4.5')).toBeTruthy();
     expect(screen.getByTestId('agent-metrics-inline').className).toContain('opacity-60');
     expect(screen.queryByTestId('agent-metrics-block')).toBeNull();
+  });
+
+  it('opens the plan created by a planner step', () => {
+    const plan = {
+      id: 'plan-1' as PlanId,
+      sessionId: SID,
+      agentId: run.id,
+      title: 'Authentication migration strategy',
+      bodyMd: 'body',
+      status: 'active',
+      createdAt: '2026-07-27T00:00:00.000Z' as IsoDateTime,
+      updatedAt: '2026-07-27T00:00:00.000Z' as IsoDateTime,
+      consumptionCount: 0,
+    } satisfies PlanWithCount;
+    storeState.plans = [plan];
+    const onOpen = vi.fn();
+    window.addEventListener('goodboy:open-plan-studio', onOpen);
+
+    renderRow({ kind: 'planner' });
+    fireEvent.click(screen.getByRole('button', { name: /open plan:/i }));
+
+    expect(screen.getByTitle(plan.title).textContent).toContain('Plan');
+    const event = onOpen.mock.calls[0]?.[0];
+    if (!(event instanceof CustomEvent)) {
+      throw new Error('expected a plan studio event');
+    }
+    expect(event.detail).toEqual({
+      sessionId: SID,
+      planId: plan.id,
+    });
+    window.removeEventListener('goodboy:open-plan-studio', onOpen);
+  });
+
+  it('shows the plan consumed by an implementation step', () => {
+    const workflowRunId = 'workflow-run-1' as WorkflowRunId;
+    const consumer = { ...run, workflowRunId } satisfies Agent;
+    const plan = {
+      id: 'plan-2' as PlanId,
+      sessionId: SID,
+      agentId: 'planner-1' as AgentId,
+      workflowRunId,
+      title: 'Database routing plan',
+      bodyMd: 'body',
+      status: 'active',
+      createdAt: '2026-07-27T00:00:00.000Z' as IsoDateTime,
+      updatedAt: '2026-07-27T00:00:00.000Z' as IsoDateTime,
+      consumptionCount: 1,
+    } satisfies PlanWithCount;
+    storeState.plans = [plan];
+    storeState.planConsumptions = {
+      [plan.id]: [
+        {
+          id: 'consumption-1' as PlanConsumptionId,
+          planId: plan.id,
+          agentId: consumer.id,
+          agentName: consumer.name,
+          consumedAt: '2026-07-27T00:01:00.000Z' as IsoDateTime,
+        },
+      ],
+    };
+
+    renderRow({ kind: 'implementer', runOverride: consumer });
+
+    expect(screen.getByRole('button', { name: /open from plan:/i }).textContent).toContain(
+      'From plan',
+    );
+    expect(screen.getByTitle(plan.title)).toBeTruthy();
+  });
+
+  it('falls back to the latest run plan for a completed consumer without consumptions', () => {
+    const workflowRunId = 'workflow-run-1' as WorkflowRunId;
+    const consumer = { ...run, workflowRunId } satisfies Agent;
+    const plan = {
+      id: 'plan-3' as PlanId,
+      sessionId: SID,
+      agentId: 'planner-1' as AgentId,
+      workflowRunId,
+      title: 'Latest run plan',
+      bodyMd: 'body',
+      status: 'active',
+      createdAt: '2026-07-27T00:00:00.000Z' as IsoDateTime,
+      updatedAt: '2026-07-27T00:00:00.000Z' as IsoDateTime,
+      consumptionCount: 0,
+    } satisfies PlanWithCount;
+    storeState.plans = [plan];
+
+    renderRow({ kind: 'generic', runOverride: consumer });
+
+    expect(screen.getByRole('button', { name: /open from plan:/i })).toBeTruthy();
+    expect(screen.getByTitle(plan.title)).toBeTruthy();
   });
 });

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowStepRow.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowStepRow.tsx
@@ -1,8 +1,7 @@
 import { useEffect, useState, type ReactNode } from 'react';
-import { StatusDot, cn } from '@goodboy/ui';
+import { Divider, StatusDot, cn } from '@goodboy/ui';
 import { AlertTriangle, Check, ChevronDown, ChevronRight, Clock, Play } from 'lucide-react';
 import type { Agent, Step, TelemetryRecord } from '@goodboy/types';
-import { getModelProvider } from '@goodboy/core';
 import { agentHasUnread } from '../../../../../store';
 import type { AgentKind } from '../../../../../features/session/agent-kind';
 import { AgentKindChip } from '../../../../../features/session/components/AgentKindChip';
@@ -13,6 +12,7 @@ import {
 import { AgentMetricsInline } from '../../../../../features/session/components/AgentMetricsInline';
 import { ContextWindowBar, type ProviderContextUsage } from './ContextWindowBar';
 import { WorkflowStepBrief } from './WorkflowStepBrief';
+import { WorkflowStepPlanBadge } from './WorkflowStepPlanBadge';
 import type { WorkflowBlockReason } from '../../../../workflows/advanceGate';
 import { WORKFLOW_BLOCK_COPY } from '../../../../workflows/blockCopy';
 
@@ -106,21 +106,20 @@ export const WorkflowStepRow = ({
   };
 
   const containerClass = cn(
-    'group rounded border transition-colors',
-    isEditing || isPendingFuture ? '' : 'cursor-pointer',
+    'group overflow-hidden rounded-lg border transition-colors',
     isPendingFuture
       ? 'border-transparent'
       : isStartable
-        ? 'border-primary/45 bg-primary/[0.06] hover:bg-primary/[0.1]'
+        ? 'border-primary/45 bg-primary/[0.06]'
         : isActionable && isBlocked
-          ? 'border-warning/60 bg-warning/[0.06] hover:bg-warning/[0.1]'
+          ? 'border-warning/60 bg-warning/[0.06]'
           : isRunning
             ? cn('border-info/60', isSelected ? 'bg-elevated' : 'bg-muted/40')
             : hasUnread
-              ? 'border-warning/70 bg-muted/40 hover:bg-muted/60'
+              ? 'border-warning/70 bg-muted/40'
               : isSelected
                 ? 'border-border bg-elevated'
-                : 'border-transparent bg-muted/40 hover:bg-muted/60',
+                : 'border-transparent bg-muted/40',
   );
 
   const renderStatusIcon = () => {
@@ -168,25 +167,28 @@ export const WorkflowStepRow = ({
 
   return (
     <div className="flex flex-col gap-1">
-      <div
-        role={isPendingFuture ? undefined : 'button'}
-        tabIndex={isEditing || isPendingFuture ? -1 : 0}
-        aria-pressed={isPendingFuture ? undefined : isSelected}
-        title={stableTitle}
-        onClick={isEditing || isPendingFuture ? undefined : handleRowClick}
-        onDoubleClick={isEditing || isPendingFuture ? undefined : onRenameStart}
-        onKeyDown={(e) => {
-          if (isEditing) {
-            return;
-          }
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault();
-            handleRowClick();
-          }
-        }}
-        className={containerClass}
-      >
-        <div className="flex items-center gap-2 px-2 py-1.5">
+      <div className={containerClass} data-testid="workflow-step-card">
+        <div
+          role={isPendingFuture ? undefined : 'button'}
+          tabIndex={isEditing || isPendingFuture ? -1 : 0}
+          aria-pressed={isPendingFuture ? undefined : isSelected}
+          title={stableTitle}
+          onClick={isEditing || isPendingFuture ? undefined : handleRowClick}
+          onDoubleClick={isEditing || isPendingFuture ? undefined : onRenameStart}
+          onKeyDown={(e) => {
+            if (isEditing) {
+              return;
+            }
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              handleRowClick();
+            }
+          }}
+          className={cn(
+            'flex items-center gap-2 px-2 py-1.5 transition-colors',
+            !isEditing && !isPendingFuture && 'cursor-pointer hover:bg-foreground/[0.04]',
+          )}
+        >
           <span
             aria-hidden
             className={cn(
@@ -235,6 +237,7 @@ export const WorkflowStepRow = ({
               {run.name}
             </span>
           )}
+          <WorkflowStepPlanBadge run={run} kind={kind} />
         </div>
         <div className="flex flex-col gap-0.5 px-2 pb-1.5">
           <AgentMetricsInline
@@ -249,33 +252,41 @@ export const WorkflowStepRow = ({
           <AgentMetricsBlock run={run} aggregate={aggregate} />
           <ContextWindowBar usage={contextUsage} />
         </div>
+        {hasBrief ? (
+          <>
+            <Divider />
+            <div className="flex flex-col gap-1 px-2 py-1.5">
+              <button
+                type="button"
+                onClick={() => setBriefOpen((open) => !open)}
+                aria-expanded={briefOpen}
+                aria-label={`${briefOpen ? 'hide' : 'show'} details for ${run.name}`}
+                className="flex items-center gap-1 self-start rounded text-2xs text-muted-foreground transition-colors hover:text-foreground"
+              >
+                {briefOpen ? (
+                  <ChevronDown size={11} aria-hidden className="shrink-0" />
+                ) : (
+                  <ChevronRight size={11} aria-hidden className="shrink-0" />
+                )}
+                Details
+              </button>
+              {briefOpen ? (
+                <WorkflowStepBrief
+                  promptPrefix={promptPrefix}
+                  expectedOutput={expectedOutput}
+                  outputSummary={outputSummary}
+                />
+              ) : null}
+            </div>
+          </>
+        ) : null}
+        {detailContent != null ? (
+          <>
+            <Divider />
+            <div className="px-2 py-1.5">{detailContent}</div>
+          </>
+        ) : null}
       </div>
-      {hasBrief ? (
-        <div className="flex flex-col gap-1">
-          <button
-            type="button"
-            onClick={() => setBriefOpen((open) => !open)}
-            aria-expanded={briefOpen}
-            aria-label={`${briefOpen ? 'hide' : 'show'} details for ${run.name}`}
-            className="flex items-center gap-1 self-start rounded text-2xs text-muted-foreground transition-colors hover:text-foreground"
-          >
-            {briefOpen ? (
-              <ChevronDown size={11} aria-hidden className="shrink-0" />
-            ) : (
-              <ChevronRight size={11} aria-hidden className="shrink-0" />
-            )}
-            Details
-          </button>
-          {briefOpen ? (
-            <WorkflowStepBrief
-              promptPrefix={promptPrefix}
-              expectedOutput={expectedOutput}
-              outputSummary={outputSummary}
-            />
-          ) : null}
-        </div>
-      ) : null}
-      {detailContent ?? null}
       {pendingConfirm && blockReason !== null ? (
         <div className="flex items-center gap-2 rounded-md bg-warning/5 px-2.5 py-1.5 text-[11px]">
           <AlertTriangle size={12} aria-hidden className="shrink-0 text-warning" />

--- a/apps/desktop/src/store/slices/turn/sendTurn.ts
+++ b/apps/desktop/src/store/slices/turn/sendTurn.ts
@@ -64,6 +64,7 @@ import { applyAgentTurnState, cancelledRunIds } from '../../session-mutators';
 import {
   buildGoalAttachmentsBlock,
   capturePlanFromTurn,
+  captureScoutDomainsFromTurn,
   emitTurnNudges,
   enqueueSummarizer,
   toRelPath,
@@ -931,6 +932,13 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
         assistantText,
         phaseWorkflowRunId ?? undefined,
       );
+      await captureScoutDomainsFromTurn({
+        set,
+        sessionId,
+        agentId: activeAgentId,
+        agentKind: earlyAgentKind,
+        assistantText,
+      });
       void emitTurnNudges(set, get, sessionId, activeAgentId, assistantText, capturedPlan);
       const driftViolations = detectDrift({
         agentKind: earlyAgentKind,

--- a/apps/desktop/src/store/slices/workflows/scoutTree.fanout.test.ts
+++ b/apps/desktop/src/store/slices/workflows/scoutTree.fanout.test.ts
@@ -39,7 +39,7 @@ const areas = (n: number) =>
   Array.from({ length: n }, (_, i) => ({ area: `area-${i}`, query: `q-${i}` }));
 
 function makeStore(c: Agent) {
-  const sendTurn = vi.fn(async () => undefined);
+  const sendTurn = vi.fn(async (_args: { content: string }) => undefined);
   const emitNotification = vi.fn(async () => undefined);
   const state: Record<string, unknown> = {
     sessionPhaseRuns: { [SID]: [c] },
@@ -112,6 +112,10 @@ describe('fanOutScouts workflowRunId propagation', () => {
     await fanOutScouts(set, get, SID, c, areas(3));
 
     expect(sendTurn).toHaveBeenCalledTimes(3);
+    for (const [args] of sendTurn.mock.calls) {
+      expect(args.content).toContain('<<scout-domains keywords="auth,db,routing">>');
+      expect(args.content).toContain('2 to 4 bare single-word domain keywords');
+    }
   });
 
   it('does not fan out (no inserts, no status flip) for fewer than 2 areas', async () => {

--- a/apps/desktop/src/store/slices/workflows/scoutTree.ts
+++ b/apps/desktop/src/store/slices/workflows/scoutTree.ts
@@ -68,6 +68,7 @@ function composeScoutKickoff(area: ExtractedScoutArea, depth: number): string {
     canSplit
       ? 'If this area is itself too broad, you MAY fan out further: emit on its own line <<scout-split>> followed by a JSON array of {"area","query"} (2 to 6 entries), then <</scout-split>>.'
       : 'You are at maximum split depth. Do not fan out further: read your scope and summarize directly.',
+    'End your exploration reply with <<scout-domains keywords="auth,db,routing">>, listing 2 to 4 bare single-word domain keywords and no prose inside the attribute.',
   ].join('\n');
 }
 

--- a/apps/desktop/src/store/turn-helpers.ts
+++ b/apps/desktop/src/store/turn-helpers.ts
@@ -4,6 +4,7 @@ import {
   extractClustersFromMarker,
   extractHandoff,
   extractPlanFromMarker,
+  extractScoutDomains,
   SLOT_BUDGETS,
   Summarizer,
   SummarizerParseError,
@@ -22,6 +23,7 @@ import {
   summarizeWorkspaceProviderTelemetry,
   summarizeWorkspaceTelemetry,
   updateProviderRunStatus,
+  updateAgentDomains,
   upsertContextSlot,
   type NudgeEvent,
   type NudgeKind,
@@ -457,6 +459,47 @@ export const capturePlanFromTurn = async (
   } catch (err) {
     if (import.meta.env.DEV) {
       console.warn(`[plan-capture] failed for session ${sessionId}: ${formatError(err)}`);
+    }
+    return null;
+  }
+};
+
+type CaptureScoutDomainsParams = {
+  readonly set: SetFn;
+  readonly sessionId: SessionId;
+  readonly agentId: AgentId;
+  readonly agentKind: AgentKind;
+  readonly assistantText: string;
+};
+
+export const captureScoutDomainsFromTurn = async ({
+  set,
+  sessionId,
+  agentId,
+  agentKind,
+  assistantText,
+}: CaptureScoutDomainsParams): Promise<ReadonlyArray<string> | null> => {
+  if (agentKind !== 'scout') {
+    return null;
+  }
+  const domains = extractScoutDomains(assistantText);
+  if (domains === null) {
+    return null;
+  }
+  try {
+    await updateAgentDomains({ db: tauriDatabase, id: agentId, domains });
+    set((state) => ({
+      sessionPhaseRuns: {
+        ...state.sessionPhaseRuns,
+        [sessionId]: (state.sessionPhaseRuns[sessionId] ?? []).map((agent) =>
+          agent.id === agentId ? { ...agent, domains } : agent,
+        ),
+      },
+    }));
+    return domains;
+  } catch (err) {
+    if (import.meta.env.DEV) {
+      console.warn(`[scout-domains] failed for agent ${agentId}: ${formatError(err)}`);
     }
     return null;
   }

--- a/packages/core/src/context/extractors.test.ts
+++ b/packages/core/src/context/extractors.test.ts
@@ -15,6 +15,7 @@ import {
   extractMarkers,
   extractPlanFromMarker,
   extractReviewComments,
+  extractScoutDomains,
   extractScoutSplit,
   extractStepDone,
   isOpenQuestionAnswerText,
@@ -607,6 +608,28 @@ describe('extractScoutSplit', () => {
     const text =
       '<<scout-split>>[{"area":"old","query":"x"}]<</scout-split>> later <<scout-split>>[{"area":"new","query":"y"}]<</scout-split>>';
     expect(extractScoutSplit(text)).toEqual([{ area: 'new', query: 'y' }]);
+  });
+});
+
+describe('extractScoutDomains', () => {
+  it('normalizes a well-formed marker and caps it at six keywords', () => {
+    const text = 'done\n<<scout-domains keywords=" Auth,db, Routing,API,cache,tests,ignored ">>';
+    expect(extractScoutDomains(text)).toEqual(['auth', 'db', 'routing', 'api', 'cache', 'tests']);
+    expect(stripControlMarkers(text)).toBe('done');
+  });
+
+  it('returns null for empty keywords', () => {
+    expect(extractScoutDomains('<<scout-domains keywords=" , , ">>')).toBeNull();
+  });
+
+  it('returns null when keywords are missing', () => {
+    expect(extractScoutDomains('<<scout-domains reason="done">>')).toBeNull();
+  });
+
+  it('drops prose and malformed keyword junk', () => {
+    expect(
+      extractScoutDomains('<<scout-domains keywords="auth, two words, @db, routing">>'),
+    ).toEqual(['auth', 'routing']);
   });
 });
 

--- a/packages/core/src/context/extractors.ts
+++ b/packages/core/src/context/extractors.ts
@@ -13,6 +13,7 @@ export {
   extractMarkers,
   extractPlanFromMarker,
   extractReviewComments,
+  extractScoutDomains,
   extractScoutSplit,
   extractStepDone,
   isReviewThreadId,

--- a/packages/core/src/context/index.ts
+++ b/packages/core/src/context/index.ts
@@ -25,6 +25,7 @@ export {
   extractMarkers,
   extractPlanFromMarker,
   extractReviewComments,
+  extractScoutDomains,
   extractScoutSplit,
   extractStepDone,
   isOpenQuestionAnswerText,

--- a/packages/core/src/context/marker-parsing.ts
+++ b/packages/core/src/context/marker-parsing.ts
@@ -35,7 +35,9 @@ const COMMENT_ANALYSIS_OPEN = '<<comment-analysis';
 const COMMENT_RESOLVED_OPEN = '<<comment-resolved';
 const COMMENT_WONTFIX_OPEN = '<<comment-wontfix';
 const CLUSTER_DONE_OPEN = '<<cluster-done';
+const SCOUT_DOMAINS_OPEN = '<<scout-domains';
 const REVIEW_COMMENT_OPEN = '<<review-comment';
+const SCOUT_DOMAIN_RE = /^[a-z0-9][a-z0-9_-]*$/;
 
 const extractSelfClosingInner = (text: string, open: string): ReadonlyArray<string> => {
   const out: string[] = [];
@@ -569,6 +571,22 @@ export const extractClusterDone = (assistantText: string): { readonly id: string
   return last;
 };
 
+export const extractScoutDomains = (text: string): ReadonlyArray<string> | null => {
+  let last: ReadonlyArray<string> | null = null;
+  for (const inner of extractSelfClosingInner(text, SCOUT_DOMAINS_OPEN)) {
+    const attrs = parseHandoffAttrs(inner);
+    const domains = (attrs.keywords ?? '')
+      .split(',')
+      .map((keyword) => keyword.trim().toLowerCase())
+      .filter((keyword) => keyword.length > 0 && SCOUT_DOMAIN_RE.test(keyword))
+      .slice(0, 6);
+    if (domains.length > 0) {
+      last = domains;
+    }
+  }
+  return last;
+};
+
 export const extractStepDone = (assistantText: string): { readonly id: string } | null => {
   STEP_DONE_RE.lastIndex = 0;
   let last: { id: string } | null = null;
@@ -687,7 +705,7 @@ export const assessPlanReadiness = (input: PlanReadinessInput): PlanReadinessRes
 const BLOCK_MARKER_ALT =
   'plan|clusters|scout-split|workflow|goal|ctx-decision|ctx-resolved|ctx-question';
 const SELF_MARKER_ALT =
-  'handoff|comment-analysis|comment-resolved|comment-wontfix|review-comment|cluster-done|step-done';
+  'handoff|comment-analysis|comment-resolved|comment-wontfix|review-comment|cluster-done|step-done|scout-domains';
 
 const CONTROL_BLOCK_STRIP_RE = new RegExp(
   `<<(?:${BLOCK_MARKER_ALT})(?:\\s[^>]*)?>>[\\s\\S]*?<<\\/(?:${BLOCK_MARKER_ALT})>>`,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -39,6 +39,7 @@ export {
   extractMarkers,
   extractPlanFromMarker,
   extractReviewComments,
+  extractScoutDomains,
   extractScoutSplit,
   extractStepDone,
   isOpenQuestionAnswerText,

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -121,6 +121,7 @@ export {
   softDeleteAgent,
   restoreAgent,
   updateAgentConfig,
+  updateAgentDomains,
   getAgentById,
   type AgentConfigUpdate,
 } from './queries/agent';

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -80,6 +80,7 @@ import { m079RoleModels } from './m079-role-models';
 import { m080AgentDone } from './m080-agent-done';
 import { m081RoleCleanup } from './m081-role-cleanup';
 import { m082AgentSourceThreads } from './m082-agent-source-threads';
+import { m083AgentDomains } from './m083-agent-domains';
 
 export type Migration = {
   readonly version: number;
@@ -169,4 +170,5 @@ export const migrations: ReadonlyArray<Migration> = [
   { version: 80, sql: m080AgentDone },
   { version: 81, sql: m081RoleCleanup },
   { version: 82, sql: m082AgentSourceThreads },
+  { version: 83, sql: m083AgentDomains },
 ];

--- a/packages/db/src/migrations/m083-agent-domains.ts
+++ b/packages/db/src/migrations/m083-agent-domains.ts
@@ -1,0 +1,3 @@
+export const m083AgentDomains = `
+ALTER TABLE agents ADD COLUMN domains_json TEXT;
+`;

--- a/packages/db/src/migrations/runner.test.ts
+++ b/packages/db/src/migrations/runner.test.ts
@@ -553,6 +553,7 @@ describe('migrate', () => {
       ordinal: 0,
       name: 'Discovery',
       status: 'pending',
+      domains: ['auth', 'db'],
     };
 
     await insertAgent(db, agent);
@@ -563,6 +564,7 @@ describe('migrate', () => {
       throw new Error('agents[0] should exist');
     }
     expect(agents[0].status).toBe('pending');
+    expect(agents[0].domains).toEqual(['auth', 'db']);
 
     await updateAgentStatus(db, agent.id, {
       status: 'completed',

--- a/packages/db/src/queries/agent.ts
+++ b/packages/db/src/queries/agent.ts
@@ -36,9 +36,40 @@ type AgentRow = {
   model_override: string | null;
   provider_override: string | null;
   kind: string | null;
+  domains_json: string | null;
 };
 
-function toAgent(row: AgentRow): Agent {
+type ParseDomainsParams = {
+  readonly value: string | null;
+};
+
+type ToAgentParams = {
+  readonly row: AgentRow;
+};
+
+type UpdateAgentDomainsParams = {
+  readonly db: Database;
+  readonly id: AgentId;
+  readonly domains: ReadonlyArray<string> | null;
+};
+
+const parseDomains = ({ value }: ParseDomainsParams): ReadonlyArray<string> => {
+  if (value === null) {
+    return [];
+  }
+  try {
+    const parsed: unknown = JSON.parse(value);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed.filter((domain): domain is string => typeof domain === 'string');
+  } catch {
+    return [];
+  }
+};
+
+const toAgent = ({ row }: ToAgentParams): Agent => {
+  const domains = parseDomains({ value: row.domains_json });
   return {
     id: row.id as AgentId,
     sessionId: row.session_id as SessionId,
@@ -66,8 +97,9 @@ function toAgent(row: AgentRow): Agent {
     ...(row.model_override && { modelOverride: row.model_override }),
     ...(row.provider_override && { providerOverride: row.provider_override }),
     ...(row.kind && { kind: row.kind }),
+    ...(domains.length > 0 && { domains }),
   };
-}
+};
 
 export const listAgentsForSession = async (
   db: Database,
@@ -77,7 +109,7 @@ export const listAgentsForSession = async (
     'SELECT * FROM agents WHERE session_id = ? ORDER BY ordinal ASC',
     [sessionId],
   );
-  return rows.map(toAgent);
+  return rows.map((row) => toAgent({ row }));
 };
 
 export const listAgentsForSessions = async (
@@ -94,7 +126,7 @@ export const listAgentsForSessions = async (
     sessionIds,
   );
   for (const row of rows) {
-    const agent = toAgent(row);
+    const agent = toAgent({ row });
     const bucket = out.get(agent.sessionId) ?? [];
     bucket.push(agent);
     out.set(agent.sessionId, bucket);
@@ -105,14 +137,14 @@ export const listAgentsForSessions = async (
 export const getAgentById = async (db: Database, id: AgentId): Promise<Agent | null> => {
   const rows = await db.select<AgentRow>('SELECT * FROM agents WHERE id = ?', [id]);
   const row = rows[0];
-  return row ? toAgent(row) : null;
+  return row ? toAgent({ row }) : null;
 };
 
 export const insertAgent = async (db: Database, agent: Agent): Promise<void> => {
   await db.execute(
     `INSERT INTO agents
-      (id, session_id, step_id, workflow_run_id, parent_agent_id, ordinal, name, status, provider_run_id, output_summary, started_at, completed_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      (id, session_id, step_id, workflow_run_id, parent_agent_id, ordinal, name, status, provider_run_id, output_summary, started_at, completed_at, domains_json)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     [
       agent.id,
       agent.sessionId,
@@ -126,8 +158,20 @@ export const insertAgent = async (db: Database, agent: Agent): Promise<void> => 
       agent.outputSummary ?? null,
       agent.startedAt ?? null,
       agent.completedAt ?? null,
+      agent.domains !== undefined ? JSON.stringify(agent.domains) : null,
     ],
   );
+};
+
+export const updateAgentDomains = async ({
+  db,
+  id,
+  domains,
+}: UpdateAgentDomainsParams): Promise<void> => {
+  await db.execute('UPDATE agents SET domains_json = ? WHERE id = ?', [
+    domains !== null ? JSON.stringify(domains) : null,
+    id,
+  ]);
 };
 
 export const updateAgentStatus = async (

--- a/packages/types/src/workflow.ts
+++ b/packages/types/src/workflow.ts
@@ -105,6 +105,7 @@ export type Agent = Readonly<{
   sourceThreadIds?: ReadonlyArray<string>;
   sourceCommentUrl?: string;
   sourceKind?: AgentSourceKind;
+  domains?: ReadonlyArray<string>;
 }>;
 
 export type ParallelGroup = {


### PR DESCRIPTION
## Problem

- The step card border wrapped only the clickable header, so the Details accordion and the Runs block floated below the card with no clear owner.
- A planner step gave no hint of the plan it produced; an implementer showed neither the plan it consumed nor its clusters at a glance.
- Sub-scouts were anonymous rows: no signal of the domain each one explored.
- The attachments strip sat below all steps even though it is global to the run.

## Change

- One bordered container per step: header, metrics, brief and runs are sections inside the card, separated by soft top borders. Only the header stays clickable.
- Plan badges: planner steps carry a chip for the plan they created; implementer/debugger/generic steps carry the plan they consumed (from `plan_consumptions`, falling back to the run's latest plan). Clicking opens Plan Studio.
- New `<<scout-domains keywords="a,b,c">>` marker: scouts are prompted to end with 2-4 bare keywords, parsed in core, stripped from transcripts, persisted to `agents.domains_json` (m083) and rendered as chips on sub-scout rows (max 3 + overflow).
- Attachments render right under the goal in detail mode, above the steps.

## Testing

- core context suite (140), db suite incl. migration convergence and domains round-trip (106), desktop touched tests (37)
- `cargo test --locked` (112 passed)
- typechecks: types, core, db, desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)