### PR TITLE
fix(desktop): post-merge hardening for opencode and simple relink

### DIFF
--- a/apps/desktop/src-tauri/src/planner.rs
+++ b/apps/desktop/src-tauri/src/planner.rs
@@ -122,7 +122,9 @@ fn build_cli_args(args: &PlannerArgs) -> Result<Vec<String>, PlannerError> {
                 cli_args.push("--dir".to_string());
                 cli_args.push(working_dir.to_string());
             }
-            cli_args.push("--dangerously-skip-permissions".to_string());
+            cli_args.push("--agent".to_string());
+            cli_args.push("plan".to_string());
+            cli_args.push("--".to_string());
             cli_args.push(format!("{}\n\n{}", args.system_prompt, args.user_message));
             Ok(cli_args)
         }
@@ -171,7 +173,9 @@ mod tests {
                 "cheap-model",
                 "--dir",
                 "/tmp/project",
-                "--dangerously-skip-permissions",
+                "--agent",
+                "plan",
+                "--",
                 "you plan\n\nplan this",
             ]
         );

--- a/apps/desktop/src-tauri/src/session_dir.rs
+++ b/apps/desktop/src-tauri/src/session_dir.rs
@@ -63,6 +63,8 @@ struct SessionMarker {
 pub struct SimpleSessionScanEntry {
     #[serde(rename = "sessionId")]
     pub session_id: String,
+    #[serde(rename = "workspaceId")]
+    pub workspace_id: String,
     pub path: String,
 }
 
@@ -109,26 +111,31 @@ fn marker_write(
     Ok(())
 }
 
-fn scan_directory(path: &Path) -> Option<SimpleSessionScanEntry> {
-    if !path.is_dir() {
+fn scan_directory(path: &Path, root: &Path) -> Option<SimpleSessionScanEntry> {
+    let metadata = std::fs::symlink_metadata(path).ok()?;
+    if !metadata.file_type().is_dir() {
+        return None;
+    }
+    let resolved = std::fs::canonicalize(path).ok()?;
+    if !resolved.starts_with(root) {
         return None;
     }
     let marker = std::fs::read(path.join(".goodboy")).ok()?;
     let marker = serde_json::from_slice::<SessionMarker>(&marker).ok()?;
-    let resolved = std::fs::canonicalize(path).ok()?;
     Some(SimpleSessionScanEntry {
         session_id: marker.session_id,
+        workspace_id: marker.workspace_id,
         path: resolved.to_string_lossy().into_owned(),
     })
 }
 
-fn scan_children(path: &Path) -> Vec<SimpleSessionScanEntry> {
+fn scan_children(path: &Path, root: &Path) -> Vec<SimpleSessionScanEntry> {
     let Ok(entries) = std::fs::read_dir(path) else {
         return Vec::new();
     };
     entries
         .filter_map(Result::ok)
-        .filter_map(|entry| scan_directory(&entry.path()))
+        .filter_map(|entry| scan_directory(&entry.path(), root))
         .collect()
 }
 
@@ -171,8 +178,11 @@ pub fn simple_sessions_scan(
     root_path: String,
 ) -> Result<Vec<SimpleSessionScanEntry>, SessionDirError> {
     let root = absolute_path(expand_home(&root_path)?)?;
-    let mut entries = scan_children(&root.join("sessions"));
-    entries.extend(scan_children(&root));
+    let Ok(root) = std::fs::canonicalize(root) else {
+        return Ok(Vec::new());
+    };
+    let mut entries = scan_children(&root.join("sessions"), &root);
+    entries.extend(scan_children(&root, &root));
     Ok(entries)
 }
 
@@ -265,6 +275,47 @@ mod tests {
         assert!(scanned
             .iter()
             .any(|entry| entry.session_id == "session-2" && entry.path == second.worktree_path));
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn skips_symlinked_session_directories() {
+        let root = test_root("simple-session-symlink");
+        let outside = test_root("simple-session-outside");
+        let created = session_dir_create(CreateArgs {
+            base_path: outside.to_string_lossy().into_owned(),
+            slug: "Outside Plan".to_string(),
+            session_id: "session-outside".to_string(),
+            workspace_id: "workspace-1".to_string(),
+        })
+        .unwrap();
+        let sessions = root.join("sessions");
+        std::fs::create_dir_all(&sessions).unwrap();
+        std::os::unix::fs::symlink(&created.worktree_path, sessions.join("linked-plan")).unwrap();
+
+        let scanned = simple_sessions_scan(root.to_string_lossy().into_owned()).unwrap();
+
+        assert!(scanned.is_empty());
+        std::fs::remove_dir_all(root).unwrap();
+        std::fs::remove_dir_all(outside).unwrap();
+    }
+
+    #[test]
+    fn scan_entries_include_marker_workspace_id() {
+        let root = test_root("simple-session-workspace-id");
+        session_dir_create(CreateArgs {
+            base_path: root.to_string_lossy().into_owned(),
+            slug: "Study Plan".to_string(),
+            session_id: "session-1".to_string(),
+            workspace_id: "workspace-marker".to_string(),
+        })
+        .unwrap();
+
+        let scanned = simple_sessions_scan(root.to_string_lossy().into_owned()).unwrap();
+
+        assert_eq!(scanned.len(), 1);
+        assert_eq!(scanned[0].workspace_id, "workspace-marker");
         std::fs::remove_dir_all(root).unwrap();
     }
 }

--- a/apps/desktop/src-tauri/src/summarize.rs
+++ b/apps/desktop/src-tauri/src/summarize.rs
@@ -124,7 +124,9 @@ fn build_cli_args(args: &SummarizeArgs) -> Result<Vec<String>, SummarizeError> {
                 cli_args.push("--dir".to_string());
                 cli_args.push(working_dir.to_string());
             }
-            cli_args.push("--dangerously-skip-permissions".to_string());
+            cli_args.push("--agent".to_string());
+            cli_args.push("plan".to_string());
+            cli_args.push("--".to_string());
             cli_args.push(format!("{}\n\n{}", args.system_prompt, args.user_message));
             Ok(cli_args)
         }
@@ -181,7 +183,9 @@ mod tests {
                 "cheap-model",
                 "--dir",
                 "/tmp/project",
-                "--dangerously-skip-permissions",
+                "--agent",
+                "plan",
+                "--",
                 "you summarize\n\nsummarize this",
             ]
         );

--- a/apps/desktop/src-tauri/src/turn.rs
+++ b/apps/desktop/src-tauri/src/turn.rs
@@ -202,6 +202,7 @@ fn build_provider_cli_args(binary: &str, args: &SpawnOneArgs<'_>) -> Vec<String>
                 v.push("--session".to_string());
                 v.push(session_id.to_string());
             }
+            v.push("--".to_string());
             v.push(args.prompt.to_string());
             v
         }
@@ -676,6 +677,7 @@ mod tests {
                 "high",
                 "--session",
                 "ses_123",
+                "--",
                 "hi",
             ]
         );
@@ -698,6 +700,7 @@ mod tests {
                 "--dir",
                 "/tmp",
                 "--dangerously-skip-permissions",
+                "--",
                 "hi",
             ]
         );

--- a/apps/desktop/src/app/components/AppTopBar/NeedsYouPopover.tsx
+++ b/apps/desktop/src/app/components/AppTopBar/NeedsYouPopover.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useRef, useState } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { Divider, Popover, ScrollFade, StatusDot } from '@goodboy/ui';
 import type { Session, SessionId } from '@goodboy/types';
@@ -32,6 +32,19 @@ export const NeedsYouPopover = ({ sessions, count }: Props) => {
   const [isOpen, setIsOpen] = useState(false);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const [coordinates, setCoordinates] = useState<PopoverCoordinates | null>(null);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setIsOpen(false);
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [isOpen]);
 
   useLayoutEffect(() => {
     if (!isOpen) {
@@ -92,6 +105,8 @@ export const NeedsYouPopover = ({ sessions, count }: Props) => {
             <>
               <div className="fixed inset-0 z-30" onClick={() => setIsOpen(false)} aria-hidden />
               <Popover
+                role="dialog"
+                ariaLabel="Sessions needing attention"
                 className="fixed z-40 w-80"
                 style={{
                   top: coordinates.top,

--- a/apps/desktop/src/app/components/AppTopBar/index.test.tsx
+++ b/apps/desktop/src/app/components/AppTopBar/index.test.tsx
@@ -130,4 +130,18 @@ describe('AppTopBar', () => {
     expect(store.setCurrentSession).toHaveBeenCalledWith(ATTENTION_SESSION_ID);
     expect(screen.queryByText('PR #42: CI failed')).toBeNull();
   });
+
+  it('closes the needs-you dialog on Escape', () => {
+    hooks.sessions = [ATTENTION_SESSION];
+    hooks.groups = [{ key: 'attention', sessions: [ATTENTION_SESSION] }];
+    hooks.rollup = { attentionCount: 1, runningCount: 0, todaySpend: 0 };
+    render(<AppTopBar onOpenSettings={vi.fn()} onOpenBudget={vi.fn()} activeStudio={null} />);
+
+    fireEvent.click(screen.getByRole('button', { name: '1 session needs you' }));
+    expect(screen.getByRole('dialog', { name: 'Sessions needing attention' })).toBeDefined();
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+
+    expect(screen.queryByRole('dialog', { name: 'Sessions needing attention' })).toBeNull();
+  });
 });

--- a/apps/desktop/src/features/integrations/components/IntegrationConnectPanel/index.tsx
+++ b/apps/desktop/src/features/integrations/components/IntegrationConnectPanel/index.tsx
@@ -11,7 +11,7 @@ export const IntegrationConnectPanel = ({ provider, description, children }: Pro
   <div className="w-full max-w-md rounded-lg border border-border-soft bg-background p-5 shadow-sm">
     <div className="flex flex-col gap-5">
       <div className="flex flex-col items-center gap-2 text-center">
-        <IntegrationGlyph provider={provider} />
+        <IntegrationGlyph provider={provider} size={24} />
         <p className="text-sm text-muted-foreground">{description}</p>
       </div>
       {children}

--- a/apps/desktop/src/features/providers/components/ProviderStudio/ApiProviderDetail.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/ApiProviderDetail.tsx
@@ -63,7 +63,7 @@ export const ApiProviderDetail = ({ info }: Props) => {
           <section className="flex flex-col gap-2">
             <SectionHeader
               label="Runtime"
-              hint="OpenRouter runs through the OpenCode CLI installed on this machine."
+              hint={`Sessions for ${info.label} execute through this locally installed runtime.`}
             />
             <div className="flex items-center gap-3 rounded-lg border border-border-soft bg-muted/20 p-4">
               <span

--- a/apps/desktop/src/features/providers/components/ProviderStudio/ProvidersRail.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/ProvidersRail.tsx
@@ -83,7 +83,7 @@ export const ProvidersRail = ({ providers, focusedId, onSelect, onSelectDefaults
                   <span className="flex items-center gap-1.5">
                     <span className="truncate text-sm font-medium text-foreground">{p.label}</span>
                     {PROVIDER_BETA.has(id) ? (
-                      <span className="rounded-md bg-muted px-1 py-0.5 text-[9px] font-medium text-muted-foreground">
+                      <span className="rounded-md bg-warning/15 px-1 py-0.5 text-[9px] font-medium text-warning">
                         beta
                       </span>
                     ) : null}

--- a/apps/desktop/src/features/worktree/worktree.ts
+++ b/apps/desktop/src/features/worktree/worktree.ts
@@ -49,6 +49,7 @@ export const createSessionDir = async ({
 
 export type SimpleSessionScanEntry = {
   readonly sessionId: SessionId;
+  readonly workspaceId: WorkspaceId;
   readonly path: string;
 };
 

--- a/apps/desktop/src/store/slices/workspaces/index.test.ts
+++ b/apps/desktop/src/store/slices/workspaces/index.test.ts
@@ -263,7 +263,12 @@ const createWorktreeSpy = vi.fn();
 const removeWorktreeSpy = vi.fn(async () => undefined);
 const changeWorktreeBranchSpy = vi.fn(async () => undefined);
 const scanSimpleSessionsSpy = vi.fn(
-  async () => [] as ReadonlyArray<{ readonly sessionId: SessionId; readonly path: string }>,
+  async () =>
+    [] as ReadonlyArray<{
+      readonly sessionId: SessionId;
+      readonly workspaceId: WorkspaceId;
+      readonly path: string;
+    }>,
 );
 const simpleSessionDirExistsSpy = vi.fn(async () => true);
 const writeSimpleSessionMarkerSpy = vi.fn(async () => undefined);
@@ -707,7 +712,9 @@ describe('store contract', () => {
       vi.mocked(db.listWorktreesForSessions).mockResolvedValueOnce(
         new Map([[SESSION_ID, [buildWorktree(SESSION_ID, storedPath, '')]]]),
       );
-      scanSimpleSessionsSpy.mockResolvedValueOnce([{ sessionId: SESSION_ID, path: movedPath }]);
+      scanSimpleSessionsSpy.mockResolvedValueOnce([
+        { sessionId: SESSION_ID, workspaceId: WS_ID, path: movedPath },
+      ]);
       simpleSessionDirExistsSpy.mockResolvedValueOnce(false);
       store.setState({
         workspaces: [
@@ -727,6 +734,37 @@ describe('store contract', () => {
         worktreePath: movedPath,
       });
       expect(store.getState().sessionWorktrees[SESSION_ID]).toEqual([movedPath]);
+    });
+
+    it('ignores a moved simple session directory from another workspace', async () => {
+      const store = await getStore();
+      const db = await import('@goodboy/db');
+      const storedPath = '/tmp/study-space/sessions/study-plan';
+      const movedPath = '/tmp/study-space/study-plan';
+      vi.mocked(db.listSessionsForWorkspace).mockResolvedValueOnce([
+        buildSession(),
+        buildSession({ id: SESSION_ID_2 }),
+      ]);
+      vi.mocked(db.listWorktreesForSessions).mockResolvedValueOnce(
+        new Map([[SESSION_ID, [buildWorktree(SESSION_ID, storedPath, '')]]]),
+      );
+      scanSimpleSessionsSpy.mockResolvedValueOnce([
+        { sessionId: SESSION_ID, workspaceId: WS_ID_2, path: movedPath },
+      ]);
+      simpleSessionDirExistsSpy.mockResolvedValueOnce(false);
+      store.setState({
+        workspaces: [
+          buildWorkspace({
+            rootPath: '/tmp/study-space',
+            kind: 'simple',
+          }),
+        ],
+      });
+
+      await store.getState().setCurrentWorkspace(WS_ID);
+
+      expect(db.updateSessionWorktreePath).not.toHaveBeenCalled();
+      expect(store.getState().sessionWorktrees[SESSION_ID]).toEqual([storedPath]);
     });
 
     it('backfills a marker for an existing unmarked simple session directory', async () => {
@@ -758,6 +796,37 @@ describe('store contract', () => {
         sessionId: SESSION_ID,
         workspaceId: WS_ID,
       });
+      expect(db.updateSessionWorktreePath).not.toHaveBeenCalled();
+      expect(store.getState().sessionWorktrees[SESSION_ID]).toEqual([storedPath]);
+    });
+
+    it('does not overwrite another session marker during backfill', async () => {
+      const store = await getStore();
+      const db = await import('@goodboy/db');
+      const storedPath = '/tmp/study-space/sessions/study-plan';
+      vi.mocked(db.listSessionsForWorkspace).mockResolvedValueOnce([
+        buildSession(),
+        buildSession({ id: SESSION_ID_2 }),
+      ]);
+      vi.mocked(db.listWorktreesForSessions).mockResolvedValueOnce(
+        new Map([[SESSION_ID, [buildWorktree(SESSION_ID, storedPath, '')]]]),
+      );
+      scanSimpleSessionsSpy.mockResolvedValueOnce([
+        { sessionId: SESSION_ID_2, workspaceId: WS_ID, path: storedPath },
+      ]);
+      simpleSessionDirExistsSpy.mockResolvedValueOnce(true);
+      store.setState({
+        workspaces: [
+          buildWorkspace({
+            rootPath: '/tmp/study-space',
+            kind: 'simple',
+          }),
+        ],
+      });
+
+      await store.getState().setCurrentWorkspace(WS_ID);
+
+      expect(writeSimpleSessionMarkerSpy).not.toHaveBeenCalled();
       expect(db.updateSessionWorktreePath).not.toHaveBeenCalled();
       expect(store.getState().sessionWorktrees[SESSION_ID]).toEqual([storedPath]);
     });

--- a/apps/desktop/src/store/slices/workspaces/relinkSimpleSessionDirectories.ts
+++ b/apps/desktop/src/store/slices/workspaces/relinkSimpleSessionDirectories.ts
@@ -27,7 +27,8 @@ export const relinkSimpleSessionDirectories = async ({
     return new Map(worktreesBySession);
   }
 
-  const scannedBySession = new Map(scanned.map((entry) => [entry.sessionId, entry.path]));
+  const workspaceScanned = scanned.filter((entry) => entry.workspaceId === workspaceId);
+  const scannedBySession = new Map(workspaceScanned.map((entry) => [entry.sessionId, entry.path]));
   const resolved = new Map<SessionId, ReadonlyArray<SessionWorktree>>();
 
   await Promise.all(
@@ -43,10 +44,16 @@ export const relinkSimpleSessionDirectories = async ({
           }
 
           if (exists) {
-            const hasMarker = scanned.some(
+            const hasMarker = workspaceScanned.some(
               (entry) => entry.sessionId === sessionId && entry.path === worktree.worktreePath,
             );
             if (!hasMarker) {
+              const hasForeignMarker = scanned.some(
+                (entry) => entry.path === worktree.worktreePath && entry.sessionId !== sessionId,
+              );
+              if (hasForeignMarker) {
+                return worktree;
+              }
               await writeSimpleSessionMarker({
                 path: worktree.worktreePath,
                 sessionId,


### PR DESCRIPTION
## Context

Post-merge security, performance and UX review of #1020-#1027 (three independent reviewers on the full range). Verdict: 0 blockers, 2 security majors, 6 minors. This PR applies all accepted findings.

## Security

- **Planner and summarizer ran opencode with `--dangerously-skip-permissions`** while every other provider constrains these auxiliary flows (codex `-s read-only`, gemini `--sandbox`). Both arms now use the read-only `--agent plan` built-in. Verified on the real CLI: same JSON event envelope.
- **Simple-session relink could be hijacked across sessions.** The `.goodboy` scan followed symlinks, never checked the canonicalized path stayed under the workspace root, and dropped the marker's `workspaceId`. A crafted symlink plus copied marker could relink another session's working directory to an arbitrary external path. The scan now rejects symlinks, enforces root containment, and returns `workspaceId`; the store slice filters scan entries by workspace and skips marker backfill when the path holds another session's marker.
- `--` guard before the positional prompt in all three opencode spawn paths, matching the codex arm.

## UX polish

- Needs-you popover closes on Escape and declares `role="dialog"` with a label
- Beta chip on the providers rail uses the same warning tint as the detail headers
- IntegrationConnectPanel glyph gets an explicit 24px size (was falling back to 14px)
- ApiProviderDetail runtime hint no longer duplicates the subtitle nor hardcodes the provider name

## Verification

- desktop typecheck green
- desktop vitest 2734 green (full run), targeted relink + topbar suites re-run green
- `cargo test --locked` 119 green, includes two new session_dir tests (symlink escape skipped, workspaceId in scan entries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)