### PR TITLE
Picker: model-first trigger, one meaning per word, real OpenCode and OpenRouter marks

### DIFF
--- a/apps/desktop/src/features/chat/components/ChatInput/hooks/useTurnRouting.ts
+++ b/apps/desktop/src/features/chat/components/ChatInput/hooks/useTurnRouting.ts
@@ -157,6 +157,17 @@ export const useTurnRouting = ({ session, isRunning }: Params) => {
     [storeSetSessionConfig, storeSetAgentConfig, session.id, selectedAgentId],
   );
 
+  const realignEffort = useCallback(
+    (model: string) => {
+      const clamped = clampEffort(model, effort);
+      if (clamped === effort) {
+        return;
+      }
+      setEffort(clamped);
+    },
+    [effort, setEffort],
+  );
+
   const onSelectProvider = useCallback(
     (id: ProviderId) => {
       if (!allowOverride || isRunning) return;
@@ -169,6 +180,7 @@ export const useTurnRouting = ({ session, isRunning }: Params) => {
           modelOverride: null,
         });
       }
+      realignEffort(id === defaultProvider ? defaultModel : getDefaultTurnModel(id));
     },
     [
       allowOverride,
@@ -177,6 +189,9 @@ export const useTurnRouting = ({ session, isRunning }: Params) => {
       storeSetAgentConfig,
       session.id,
       selectedAgentId,
+      realignEffort,
+      defaultProvider,
+      defaultModel,
     ],
   );
 
@@ -184,8 +199,9 @@ export const useTurnRouting = ({ session, isRunning }: Params) => {
     (id: string) => {
       if (!allowOverride || isRunning) return;
       setSelectedModel(id);
+      realignEffort(id);
     },
-    [allowOverride, isRunning, setSelectedModel],
+    [allowOverride, isRunning, setSelectedModel, realignEffort],
   );
 
   const onResetTurnOverride = useCallback(() => {

--- a/apps/desktop/src/features/chat/components/ChatInput/index.test.tsx
+++ b/apps/desktop/src/features/chat/components/ChatInput/index.test.tsx
@@ -373,7 +373,7 @@ describe('ChatInput, input wiring', () => {
       />,
     );
 
-    await user.click(screen.getByRole('button', { name: 'model routing' }));
+    await user.click(screen.getByRole('button', { name: /^model routing:/ }));
     await user.click(
       within(screen.getByRole('dialog', { name: 'model routing' })).getByRole('button', {
         name: 'Claude',

--- a/apps/desktop/src/features/chat/components/ChatInput/index.tsx
+++ b/apps/desktop/src/features/chat/components/ChatInput/index.tsx
@@ -450,7 +450,11 @@ export const ChatInput = ({ session, providerDisconnected = false }: Props) => {
                 openEvent="goodboy:open-model-picker"
                 provider={routing.effectiveProvider}
                 model={routing.effectiveModel}
-                effort={routing.effectiveEffort}
+                effort={{
+                  editable: true,
+                  value: routing.effectiveEffort,
+                  onChange: routing.setEffort,
+                }}
                 verbosity={routing.verbosity}
                 connectedProviders={routing.connectedProviderIds}
                 disabled={!routing.allowOverride || isRunning}
@@ -469,7 +473,6 @@ export const ChatInput = ({ session, providerDisconnected = false }: Props) => {
                   routing.onSelectProvider(next);
                 }}
                 onModel={routing.onSelectModel}
-                onEffort={routing.setEffort}
                 onVerbosity={routing.setVerbosity}
                 onReset={routing.onResetTurnOverride}
               />

--- a/apps/desktop/src/features/chat/utils/chat-constants.ts
+++ b/apps/desktop/src/features/chat/utils/chat-constants.ts
@@ -11,15 +11,6 @@ export const PROVIDER_LABEL: Record<ProviderId, string> = {
   openrouter: 'OpenRouter',
 };
 
-export const PROVIDER_DOT: Record<ProviderId, string> = {
-  anthropic: 'bg-[var(--color-provider-anthropic)]',
-  cursor: 'bg-[var(--color-provider-cursor)]',
-  codex: 'bg-[var(--color-provider-codex)]',
-  gemini: 'bg-[var(--color-provider-gemini)]',
-  opencode: 'bg-[var(--color-provider-opencode)]',
-  openrouter: 'bg-[var(--color-provider-openrouter)]',
-};
-
 export const EFFORT_LEVELS = ['minimal', 'low', 'medium', 'high', 'extra-high', 'max'] as const;
 export type EffortLevel = ModelEffort;
 

--- a/apps/desktop/src/features/chat/utils/chat-constants.ts
+++ b/apps/desktop/src/features/chat/utils/chat-constants.ts
@@ -11,15 +11,6 @@ export const PROVIDER_LABEL: Record<ProviderId, string> = {
   openrouter: 'OpenRouter',
 };
 
-export const PROVIDER_TEXT: Record<ProviderId, string> = {
-  anthropic: 'text-[var(--color-provider-anthropic)]',
-  cursor: 'text-[var(--color-provider-cursor)]',
-  codex: 'text-[var(--color-provider-codex)]',
-  gemini: 'text-[var(--color-provider-gemini)]',
-  opencode: 'text-[var(--color-provider-opencode)]',
-  openrouter: 'text-[var(--color-provider-openrouter)]',
-};
-
 export const PROVIDER_DOT: Record<ProviderId, string> = {
   anthropic: 'bg-[var(--color-provider-anthropic)]',
   cursor: 'bg-[var(--color-provider-cursor)]',

--- a/apps/desktop/src/features/github/components/GitHubStudio/ResolveBoard/index.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/ResolveBoard/index.tsx
@@ -462,11 +462,10 @@ function ConfigPanel({
         connectedProviders={connectedProviders}
         provider={config.provider}
         model={config.model}
-        effort={config.effort}
+        effort={{ editable: true, value: config.effort, onChange: onEffort }}
         disabled={false}
         onProvider={onProvider}
         onModel={onModel}
-        onEffort={onEffort}
       />
       <SegmentedControl
         ariaLabel="Resolver mode"

--- a/apps/desktop/src/features/notifications/components/NotificationCenter/index.tsx
+++ b/apps/desktop/src/features/notifications/components/NotificationCenter/index.tsx
@@ -308,7 +308,8 @@ function RetryWithPicker({ action, onDone }: RetryWithPickerProps) {
           connectedProviders={availableProviderIds}
           provider={providerId}
           model={model}
-          recommendedModel={recommendedModel}
+          effort={{ editable: false }}
+          recommendation={{ model: recommendedModel }}
           disabled={false}
           onProvider={(next) => {
             if (next === '') {

--- a/apps/desktop/src/features/permissions/components/DiffViewerDialog/DiffViewerContent.tsx
+++ b/apps/desktop/src/features/permissions/components/DiffViewerDialog/DiffViewerContent.tsx
@@ -828,7 +828,11 @@ export const DiffViewerContent = ({
               connectedProviders={connectedProviderIds}
               provider={resolverRouting.provider}
               model={resolverRouting.model}
-              effort={resolverRouting.effort}
+              effort={{
+                editable: true,
+                value: resolverRouting.effort,
+                onChange: (effort) => setResolverRouting({ ...resolverRouting, effort }),
+              }}
               disabled={spawning}
               onProvider={(next) => {
                 if (next === '') {
@@ -848,7 +852,6 @@ export const DiffViewerContent = ({
                   effort: clampEffort(model, resolverRouting.effort),
                 })
               }
-              onEffort={(effort) => setResolverRouting({ ...resolverRouting, effort })}
             />
           }
         />

--- a/apps/desktop/src/features/permissions/components/DiffViewerDialog/index.test.tsx
+++ b/apps/desktop/src/features/permissions/components/DiffViewerDialog/index.test.tsx
@@ -260,8 +260,8 @@ describe('line comment add (single + multi-line drag)', () => {
         onClose={vi.fn()}
       />,
     );
-    const picker = await screen.findByRole('button', { name: 'resolver routing' });
-    expect(picker.textContent).toContain('Claude');
+    const picker = await screen.findByRole('button', { name: /^resolver routing:/ });
+    expect(picker.getAttribute('aria-label')).toContain('Claude');
     expect(picker.textContent).toContain('Medium');
   });
 });

--- a/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/RoleModelRow.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/RoleModelRow.tsx
@@ -15,6 +15,7 @@ import { FieldRow } from '@goodboy/ui';
 import {
   EFFORT_LABEL,
   PROVIDER_LABEL,
+  clampEffort,
   modelEffortLevels,
   modelLabel,
 } from '../../../../chat/utils/chat-constants';
@@ -93,9 +94,17 @@ export const RoleModelRow = ({
             connectedProviders={availableProviderIds}
             provider={providerId}
             model={resolved.isOverride ? resolved.model : ''}
-            effort={resolved.effort}
-            recommendedProvider={defaultProviderId}
-            recommendedModel={recommendedModel}
+            effort={{
+              editable: true,
+              value: resolved.effort,
+              onChange: (effort) =>
+                commit({
+                  providerId,
+                  model: resolved.isOverride ? resolved.model : recommendedModel,
+                  effort,
+                }),
+            }}
+            recommendation={{ provider: defaultProviderId, model: recommendedModel }}
             defaultSummary={defaultSummary}
             overridden={resolved.isOverride}
             disabled={disabled}
@@ -108,10 +117,11 @@ export const RoleModelRow = ({
               if (!resolved.isOverride) {
                 return;
               }
+              const nextModel = recommendedModelForRole({ role, provider: next });
               commit({
                 providerId: next,
-                model: recommendedModelForRole({ role, provider: next }),
-                effort: resolved.effort,
+                model: nextModel,
+                effort: clampEffort(nextModel, resolved.effort),
               });
             }}
             onModel={(nextModel) => {
@@ -119,15 +129,12 @@ export const RoleModelRow = ({
                 onChange(null);
                 return;
               }
-              commit({ providerId, model: nextModel, effort: resolved.effort });
-            }}
-            onEffort={(effort) =>
               commit({
                 providerId,
-                model: resolved.isOverride ? resolved.model : recommendedModel,
-                effort,
-              })
-            }
+                model: nextModel,
+                effort: clampEffort(nextModel, resolved.effort),
+              });
+            }}
           />
         </div>
       </div>

--- a/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/TaskModelRow.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/TaskModelRow.tsx
@@ -54,7 +54,8 @@ export const TaskModelRow = ({
             connectedProviders={availableProviderIds}
             provider={providerId}
             model={model}
-            recommendedModel={recommendedModel}
+            effort={{ editable: false }}
+            recommendation={{ model: recommendedModel }}
             disabled={disabled}
             onProvider={(next) => {
               if (next === '') {

--- a/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/index.test.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/index.test.tsx
@@ -67,7 +67,7 @@ vi.mock('../../../../../shared/components/RoutingPicker', () => ({
         aria-label={`${ariaLabel} model`}
         onClick={() => onModel('claude-sonnet-4-6')}
       >
-        {model === '' ? `${recommendation?.model} auto` : model}
+        {model === '' ? (recommendation?.model ?? '') : model}
       </button>
       <button
         type="button"
@@ -158,14 +158,15 @@ describe('DefaultsPanel', () => {
     expect(screen.getByText('PR and MR drafts')).toBeDefined();
   });
 
-  it('shows the resolved model for automatic task preferences', () => {
+  it('shows the resolved model for automatic task preferences, never the word auto', () => {
     render(<DefaultsPanel workspaceId={'ws-1' as never} />);
 
     for (const label of TASK_LABELS) {
       expect(screen.getByRole('button', { name: `${label} routing model` }).textContent).toBe(
-        'claude-haiku-4-5 auto',
+        'claude-haiku-4-5',
       );
     }
+    expect(screen.queryByText(/auto/)).toBeNull();
     expect(screen.getByLabelText('Summaries routing status: default')).toBeDefined();
     expect(screen.getByLabelText('Planner routing status: default')).toBeDefined();
   });
@@ -174,7 +175,7 @@ describe('DefaultsPanel', () => {
     const { rerender } = render(<DefaultsPanel workspaceId={'ws-1' as never} />);
 
     expect(screen.getByLabelText('Summaries routing status: default')).toBeDefined();
-    fireEvent.click(screen.getAllByText('claude-haiku-4-5 auto')[0]!);
+    fireEvent.click(screen.getByRole('button', { name: 'Summaries routing model' }));
 
     expect(state.setWorkspaceOverrides).toHaveBeenCalledWith(
       'ws-1',
@@ -214,7 +215,7 @@ describe('DefaultsPanel', () => {
     render(<DefaultsPanel workspaceId={'ws-1' as never} />);
 
     expect(screen.getByRole('button', { name: 'Planner routing model' }).textContent).toBe(
-      'claude-opus-5 auto',
+      'claude-opus-5',
     );
   });
 

--- a/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/index.test.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/index.test.tsx
@@ -43,14 +43,14 @@ vi.mock('../../../../../shared/components/RoutingPicker', () => ({
     ariaLabel,
     provider,
     model,
-    recommendedModel,
+    recommendation,
     onProvider,
     onModel,
   }: {
     ariaLabel: string;
     provider: string;
     model: string;
-    recommendedModel: string;
+    recommendation?: { provider?: string; model?: string };
     onProvider: (provider: string) => void;
     onModel: (model: string) => void;
   }) => (
@@ -67,7 +67,7 @@ vi.mock('../../../../../shared/components/RoutingPicker', () => ({
         aria-label={`${ariaLabel} model`}
         onClick={() => onModel('claude-sonnet-4-6')}
       >
-        {model === '' ? `${recommendedModel} auto` : model}
+        {model === '' ? `${recommendation?.model} auto` : model}
       </button>
       <button
         type="button"
@@ -243,6 +243,29 @@ describe('DefaultsPanel', () => {
       expect.objectContaining({
         roleModels: {
           investigator: { providerId: 'anthropic', model: 'claude-haiku-4-5', effort: 'medium' },
+        },
+      }),
+    );
+  });
+
+  it('drops an effort the newly picked model cannot reach', () => {
+    state.workspaceOverrides = {
+      'ws-1': {
+        ...EMPTY_OVERRIDES,
+        roleModels: {
+          reviewer: { providerId: 'anthropic', model: 'claude-opus-5', effort: 'max' },
+        },
+      },
+    };
+    render(<DefaultsPanel workspaceId={'ws-1' as never} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reviewer routing model' }));
+
+    expect(state.setWorkspaceOverrides).toHaveBeenCalledWith(
+      'ws-1',
+      expect.objectContaining({
+        roleModels: {
+          reviewer: { providerId: 'anthropic', model: 'claude-sonnet-4-6', effort: 'high' },
         },
       }),
     );

--- a/apps/desktop/src/features/session/components/AgentSpawnConfig/index.test.tsx
+++ b/apps/desktop/src/features/session/components/AgentSpawnConfig/index.test.tsx
@@ -33,7 +33,7 @@ describe('AgentSpawnConfig', () => {
       <AgentSpawnConfig value={DEFAULT_AGENT_SPAWN_CONFIG} onChange={onChange} disabled={false} />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Agent settings' }));
+    fireEvent.click(screen.getByRole('button', { name: /^Agent settings:/ }));
     fireEvent.click(screen.getByRole('button', { name: /^Codex/ }));
     const providerValue = onChange.mock.calls[0]![0];
     expect(providerValue.provider).toBe('codex');
@@ -56,6 +56,6 @@ describe('AgentSpawnConfig', () => {
         disabled={false}
       />,
     );
-    expect(screen.getByRole('button', { name: 'Agent settings' }).textContent).toContain('High');
+    expect(screen.getByRole('button', { name: /^Agent settings:/ }).textContent).toContain('High');
   });
 });

--- a/apps/desktop/src/features/session/components/AgentSpawnConfig/index.tsx
+++ b/apps/desktop/src/features/session/components/AgentSpawnConfig/index.tsx
@@ -47,11 +47,14 @@ export const AgentSpawnConfig = ({ value, onChange, disabled, className }: Props
         connectedProviders={connectedProviders}
         provider={value.provider}
         model={value.model}
-        effort={value.effort}
+        effort={{
+          editable: true,
+          value: value.effort,
+          onChange: (effort) => onChange({ ...value, effort }),
+        }}
         disabled={disabled}
         onProvider={onProvider}
         onModel={(model) => onChange({ ...value, model, effort: clampEffort(model, value.effort) })}
-        onEffort={(effort) => onChange({ ...value, effort })}
       />
       <textarea
         aria-label="Agent hint"

--- a/apps/desktop/src/features/session/components/WorkflowBuilderView/index.test.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowBuilderView/index.test.tsx
@@ -76,13 +76,13 @@ vi.mock('../../../../shared/components/RoutingPicker', () => ({
   RoutingPicker: ({
     provider,
     model,
-    recommendedModel,
+    recommendation,
     onProvider,
     onModel,
   }: {
     provider: string;
     model: string;
-    recommendedModel?: string;
+    recommendation?: { provider?: string; model?: string };
     onProvider: (v: string) => void;
     onModel: (v: string) => void;
   }) => (
@@ -93,7 +93,7 @@ vi.mock('../../../../shared/components/RoutingPicker', () => ({
       <button
         type="button"
         data-provider={provider === '' ? 'default' : provider}
-        data-recommended-model={recommendedModel}
+        data-recommended-model={recommendation?.model}
         onClick={() => onModel('claude-opus-4-6')}
       >
         model:{model === '' ? 'auto' : model}

--- a/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
@@ -988,9 +988,11 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
                               connectedProviders={connectedProviders}
                               provider={plannerProviderOverride}
                               model={plannerModelOverride}
-                              effort={PLANNER_EFFORT}
-                              recommendedProvider={resolvedPlanTaskModel.providerId}
-                              recommendedModel={plannerRecommendedModel}
+                              effort={{ editable: false, value: PLANNER_EFFORT }}
+                              recommendation={{
+                                provider: resolvedPlanTaskModel.providerId,
+                                model: plannerRecommendedModel,
+                              }}
                               disabled={blocked}
                               onProvider={(next) => {
                                 setPlannerProviderOverride(next);

--- a/apps/desktop/src/features/session/components/WorkflowStepCard/index.test.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowStepCard/index.test.tsx
@@ -112,7 +112,7 @@ describe('WorkflowStepCard (expanded)', () => {
   it('changes verbosity through the routing picker', () => {
     const onVerbosity = vi.fn();
     render(<WorkflowStepCard {...baseProps} expanded={true} onVerbosity={onVerbosity} />);
-    fireEvent.click(screen.getByRole('button', { name: 'routing for step 1' }));
+    fireEvent.click(screen.getByRole('button', { name: /^routing for step 1:/ }));
     fireEvent.click(screen.getByRole('button', { name: 'Verbose' }));
     expect(onVerbosity).toHaveBeenCalledWith('verbose');
   });

--- a/apps/desktop/src/features/session/components/WorkflowStepCard/index.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowStepCard/index.tsx
@@ -324,14 +324,12 @@ export const WorkflowStepCard = ({
                   connectedProviders={connectedProviders}
                   provider={providerValue}
                   model={model}
-                  effort={effort}
-                  recommendedProvider={recommendedProvider}
-                  recommendedModel={recommendedModel}
+                  effort={{ editable: true, value: effort, onChange: onEffort }}
+                  recommendation={{ provider: recommendedProvider, model: recommendedModel }}
                   verbosity={verbosity}
                   disabled={disabled}
                   onProvider={onProvider}
                   onModel={onModel}
-                  onEffort={onEffort}
                   onVerbosity={onVerbosity}
                 />
               </div>

--- a/apps/desktop/src/features/workflows/components/LibraryStepForm/index.test.tsx
+++ b/apps/desktop/src/features/workflows/components/LibraryStepForm/index.test.tsx
@@ -35,7 +35,7 @@ describe('LibraryStepForm', () => {
     fireEvent.change(screen.getByPlaceholderText('step name'), {
       target: { value: 'Summarize changes' },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'step routing' }));
+    fireEvent.click(screen.getByRole('button', { name: /^step routing:/ }));
     fireEvent.click(screen.getByRole('button', { name: 'Verbose' }));
     expect(onCommit).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/apps/desktop/src/features/workflows/components/LibraryStepForm/index.tsx
+++ b/apps/desktop/src/features/workflows/components/LibraryStepForm/index.tsx
@@ -160,9 +160,15 @@ export const LibraryStepForm = ({
               connectedProviders={connectedProviders}
               provider={providerOverride}
               model={modelOverride}
-              effort={effort}
-              recommendedProvider={recommendedProv}
-              recommendedModel={recommendedMod}
+              effort={{
+                editable: true,
+                value: effort,
+                onChange: (eff) => {
+                  setEffort(eff);
+                  commit({ effort: eff });
+                },
+              }}
+              recommendation={{ provider: recommendedProv, model: recommendedMod }}
               verbosity={verbosity}
               disabled={false}
               onProvider={(p) => {
@@ -178,10 +184,6 @@ export const LibraryStepForm = ({
                   over.effort = clamped;
                 }
                 commit(over);
-              }}
-              onEffort={(eff) => {
-                setEffort(eff);
-                commit({ effort: eff });
               }}
               onVerbosity={(next) => {
                 setVerbosity(next);

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/SpawnAgentControl.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/SpawnAgentControl.test.tsx
@@ -53,7 +53,7 @@ describe('SpawnAgentControl', () => {
     renderControl();
     const create = screen.getByRole('button', { name: 'Create agent' });
     const role = screen.getByRole('combobox', { name: 'agent role' });
-    const routing = screen.getByRole('button', { name: 'new agent routing' });
+    const routing = screen.getByRole('button', { name: /^new agent routing:/ });
     const row = create.parentElement;
 
     expect(row?.className).toContain('border-dashed');
@@ -86,7 +86,7 @@ describe('SpawnAgentControl', () => {
 
   it('passes a pinned model, provider and effort to the spawn', () => {
     renderControl();
-    fireEvent.click(screen.getByRole('button', { name: 'new agent routing' }));
+    fireEvent.click(screen.getByRole('button', { name: /^new agent routing:/ }));
     fireEvent.click(screen.getByTitle(/^claude-opus-5 \(/));
     createAgent();
     expect(h.spawnAgent).toHaveBeenCalledWith(SID, {

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/SpawnAgentControl.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/SpawnAgentControl.tsx
@@ -116,9 +116,20 @@ export const SpawnAgentControl = ({ sessionId, className, onSpawned }: Props) =>
             connectedProviders={connectedProviders}
             provider={routing?.provider ?? ''}
             model={routing?.model ?? ''}
-            effort={routing?.effort ?? recommendedRouting.effort}
-            recommendedProvider={recommendedRouting.provider}
-            recommendedModel={recommendedRouting.model}
+            effort={{
+              editable: true,
+              value: routing?.effort ?? recommendedRouting.effort,
+              onChange: (effort) =>
+                setRouting({
+                  provider: routing?.provider ?? recommendedRouting.provider,
+                  model: routing?.model ?? recommendedRouting.model,
+                  effort,
+                }),
+            }}
+            recommendation={{
+              provider: recommendedRouting.provider,
+              model: recommendedRouting.model,
+            }}
             disabled={false}
             overridden={routing != null}
             onProvider={onProvider}
@@ -133,13 +144,6 @@ export const SpawnAgentControl = ({ sessionId, className, onSpawned }: Props) =>
                 effort: clampEffort(model, routing?.effort ?? recommendedRouting.effort),
               });
             }}
-            onEffort={(effort) =>
-              setRouting({
-                provider: routing?.provider ?? recommendedRouting.provider,
-                model: routing?.model ?? recommendedRouting.model,
-                effort,
-              })
-            }
           />
         </div>
       </div>

--- a/apps/desktop/src/shared/components/RoutingPicker/ModelGrid.tsx
+++ b/apps/desktop/src/shared/components/RoutingPicker/ModelGrid.tsx
@@ -8,88 +8,71 @@ type Props = {
   readonly ids: ReadonlyArray<string>;
   readonly value: string;
   readonly recommendedModel?: string;
-  readonly literalAutoModel?: string;
   readonly isRecommended: boolean;
   readonly onSelect: (model: string) => void;
 };
 
-export const ModelGrid = ({
-  ids,
-  value,
-  recommendedModel,
-  literalAutoModel,
-  isRecommended,
-  onSelect,
-}: Props) => {
-  const autoModel = literalAutoModel ?? (recommendedModel != null ? '' : undefined);
-  const isAutoActive = literalAutoModel != null ? value === literalAutoModel : isRecommended;
-  const groupedIds = ids.filter((id) => id !== 'auto');
-
-  return (
-    <div className="flex flex-col gap-1">
-      {autoModel != null && (
-        <div className="flex flex-wrap gap-1 px-2.5">
-          <button
-            type="button"
-            onClick={() => onSelect(autoModel)}
-            title={
-              recommendedModel != null && literalAutoModel == null
-                ? `auto (${modelLabel(recommendedModel)})`
-                : 'auto'
-            }
-            aria-pressed={isAutoActive}
-            className={cn(
-              'inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-2xs text-muted-foreground transition-colors hover:bg-background/60 hover:text-foreground',
-              isAutoActive && 'bg-background font-medium text-foreground shadow-sm',
-            )}
-          >
-            <Sparkles size={10} className="shrink-0 text-primary" aria-hidden />
-            auto
-          </button>
-        </div>
-      )}
-      {groupModels({ ids: groupedIds }).map((group) => {
-        const hasSubgroups = group.subgroups.some((subgroup) => subgroup.label != null);
-        return (
-          <div key={group.family} className="flex flex-col gap-0.5">
-            <span className="px-2.5 pt-1 text-2xs font-medium uppercase tracking-wide text-muted-foreground/50">
-              {group.label}
-            </span>
-            {!hasSubgroups && (
-              <div className="flex flex-wrap gap-1 px-2.5">
-                {group.subgroups.flatMap((subgroup) =>
-                  subgroup.ids.map((id) => (
+export const ModelGrid = ({ ids, value, recommendedModel, isRecommended, onSelect }: Props) => (
+  <div className="flex flex-col gap-1">
+    {recommendedModel != null && (
+      <div className="flex flex-wrap gap-1 px-2.5">
+        <button
+          type="button"
+          onClick={() => onSelect('')}
+          title={`Recommended (${modelLabel(recommendedModel)})`}
+          aria-pressed={isRecommended}
+          className={cn(
+            'inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-2xs text-muted-foreground transition-colors hover:bg-background/60 hover:text-foreground',
+            isRecommended && 'bg-background font-medium text-foreground shadow-sm',
+          )}
+        >
+          <Sparkles size={10} className="shrink-0 text-primary" aria-hidden />
+          Recommended
+          <span className="font-mono text-muted-foreground/60">{modelLabel(recommendedModel)}</span>
+        </button>
+      </div>
+    )}
+    {groupModels({ ids }).map((group) => {
+      const hasSubgroups = group.subgroups.some((subgroup) => subgroup.label != null);
+      return (
+        <div key={group.family} className="flex flex-col gap-0.5">
+          <span className="px-2.5 pt-1 text-2xs font-medium uppercase tracking-wide text-muted-foreground/50">
+            {group.label}
+          </span>
+          {!hasSubgroups && (
+            <div className="flex flex-wrap gap-1 px-2.5">
+              {group.subgroups.flatMap((subgroup) =>
+                subgroup.ids.map((id) => (
+                  <VariantChip
+                    key={id}
+                    id={id}
+                    active={!isRecommended && value === id}
+                    onSelect={() => onSelect(id)}
+                  />
+                )),
+              )}
+            </div>
+          )}
+          {hasSubgroups &&
+            group.subgroups.map((subgroup) => (
+              <div key={subgroup.key} className="flex items-center gap-2 px-2.5 py-0.5">
+                <span className="flex-1 text-2xs text-muted-foreground/70">
+                  {subgroup.label ?? group.label}
+                </span>
+                <div className="flex flex-wrap justify-end gap-1">
+                  {subgroup.ids.map((id) => (
                     <VariantChip
                       key={id}
                       id={id}
                       active={!isRecommended && value === id}
                       onSelect={() => onSelect(id)}
                     />
-                  )),
-                )}
-              </div>
-            )}
-            {hasSubgroups &&
-              group.subgroups.map((subgroup) => (
-                <div key={subgroup.key} className="flex items-center gap-2 px-2.5 py-0.5">
-                  <span className="flex-1 text-2xs text-muted-foreground/70">
-                    {subgroup.label ?? group.label}
-                  </span>
-                  <div className="flex flex-wrap justify-end gap-1">
-                    {subgroup.ids.map((id) => (
-                      <VariantChip
-                        key={id}
-                        id={id}
-                        active={!isRecommended && value === id}
-                        onSelect={() => onSelect(id)}
-                      />
-                    ))}
-                  </div>
+                  ))}
                 </div>
-              ))}
-          </div>
-        );
-      })}
-    </div>
-  );
-};
+              </div>
+            ))}
+        </div>
+      );
+    })}
+  </div>
+);

--- a/apps/desktop/src/shared/components/RoutingPicker/PickerChip.tsx
+++ b/apps/desktop/src/shared/components/RoutingPicker/PickerChip.tsx
@@ -1,20 +1,15 @@
-import type { ReactNode } from 'react';
 import { cn } from '@goodboy/ui';
 
 type Props = {
   readonly label: string;
   readonly active: boolean;
   readonly onSelect: () => void;
-  readonly glyph?: ReactNode;
-  readonly note?: string;
-  readonly title?: string;
 };
 
-export const PickerChip = ({ label, active, onSelect, glyph, note, title }: Props) => (
+export const PickerChip = ({ label, active, onSelect }: Props) => (
   <button
     type="button"
     onClick={onSelect}
-    title={title}
     aria-pressed={active}
     className={cn(
       'inline-flex min-w-0 items-center gap-1.5 rounded-md px-2 py-1 text-xs transition-colors',
@@ -23,8 +18,6 @@ export const PickerChip = ({ label, active, onSelect, glyph, note, title }: Prop
         : 'text-muted-foreground hover:bg-background/60 hover:text-foreground',
     )}
   >
-    {glyph}
     <span className="truncate">{label}</span>
-    {note != null && <span className="text-2xs text-muted-foreground/60">{note}</span>}
   </button>
 );

--- a/apps/desktop/src/shared/components/RoutingPicker/RecommendationRow.tsx
+++ b/apps/desktop/src/shared/components/RoutingPicker/RecommendationRow.tsx
@@ -1,0 +1,24 @@
+import { cn } from '@goodboy/ui';
+
+type Props = {
+  readonly summary: string;
+  readonly active: boolean;
+  readonly onSelect: () => void;
+};
+
+export const RecommendationRow = ({ summary, active, onSelect }: Props) => (
+  <button
+    type="button"
+    onClick={onSelect}
+    aria-pressed={active}
+    className={cn(
+      'flex w-full items-center justify-between gap-2 px-2.5 py-1.5 text-xs transition-colors',
+      active
+        ? 'bg-background font-medium text-foreground'
+        : 'text-muted-foreground hover:bg-background/60 hover:text-foreground',
+    )}
+  >
+    <span>Recommended</span>
+    <span className="truncate text-2xs text-muted-foreground/70">{summary}</span>
+  </button>
+);

--- a/apps/desktop/src/shared/components/RoutingPicker/TriggerLabel.tsx
+++ b/apps/desktop/src/shared/components/RoutingPicker/TriggerLabel.tsx
@@ -4,8 +4,6 @@ import { PROVIDER_BRAND, brandColor } from '../../../features/providers/componen
 import {
   EFFORT_LABEL,
   EFFORT_TEXT,
-  PROVIDER_LABEL,
-  PROVIDER_TEXT,
   TIER_TEXT,
   VERBOSITY_TEXT,
   modelLabel,
@@ -33,10 +31,6 @@ export const TriggerLabel = ({ provider, model, effort, showEffort, verbosity }:
         style={{ color: brandColor(provider) }}
         aria-hidden
       />
-      <span className={cn('shrink-0 font-medium', PROVIDER_TEXT[provider])}>
-        {PROVIDER_LABEL[provider]}
-      </span>
-      <TriggerSeparator />
       <span className={cn('min-w-0 truncate font-mono font-medium', TIER_TEXT[modelTier(model)])}>
         {modelLabel(model)}
       </span>

--- a/apps/desktop/src/shared/components/RoutingPicker/index.test.tsx
+++ b/apps/desktop/src/shared/components/RoutingPicker/index.test.tsx
@@ -18,12 +18,11 @@ const baseProps = {
   ] as ReadonlyArray<ProviderId>,
   provider: 'anthropic' as ProviderId,
   model: 'claude-opus-5',
-  effort: 'high' as const,
+  effort: { editable: true, value: 'high', onChange: vi.fn() } as const,
   disabled: false,
   ariaLabel: 'routing',
   onProvider: vi.fn(),
   onModel: vi.fn(),
-  onEffort: vi.fn(),
 };
 const providers = Object.keys(PROVIDER_CAPABILITIES).filter(
   (id): id is ProviderId => id in PROVIDER_CAPABILITIES,
@@ -35,31 +34,101 @@ afterEach(() => {
 });
 
 describe('RoutingPicker', () => {
-  it('reads provider, model and effort in the closed trigger', () => {
+  it('reads model and effort in the closed trigger, never the provider name', () => {
     render(<RoutingPicker {...baseProps} />);
     const trigger = screen.getByRole('button', { name: /routing/i });
-    expect(trigger.textContent).toContain('Claude');
     expect(trigger.textContent).toContain('Opus 5');
     expect(trigger.textContent).toContain('High');
+    expect(trigger.textContent).not.toContain('Claude');
+  });
+
+  it('keeps the full routing in the accessible name and the tooltip', () => {
+    render(<RoutingPicker {...baseProps} />);
+    const trigger = screen.getByRole('button', { name: /routing/i });
+    expect(trigger.getAttribute('aria-label')).toBe('routing: Claude · Opus 5 · High');
+    expect(trigger.getAttribute('title')).toContain('Claude · Opus 5 · High');
   });
 
   it('drops the effort segment and explains why for a model without thinking levels', () => {
     render(<RoutingPicker {...baseProps} model="claude-haiku-4-5" ariaLabel="routing" />);
-    const trigger = screen.getByRole('button', { name: 'routing' });
+    const trigger = screen.getByRole('button', { name: /^routing:/ });
     expect(trigger.textContent).toContain('Haiku 4.5');
     expect(trigger.textContent).not.toContain('High');
     fireEvent.click(trigger);
-    expect(screen.getByRole('dialog').textContent).toContain('no thinking levels');
+    expect(screen.getByRole('dialog').textContent).toContain('runs at a fixed effort');
   });
 
-  it('resolves the recommended state to a concrete model', () => {
-    render(<RoutingPicker {...baseProps} model="" recommendedModel="claude-sonnet-4-6" />);
+  it('drops the whole effort section when the caller cannot edit effort', () => {
+    render(<RoutingPicker {...baseProps} effort={{ editable: false }} />);
+    fireEvent.click(screen.getByRole('button', { name: /routing/i }));
+    const dialog = screen.getByRole('dialog');
+    expect(dialog.textContent).not.toContain('Effort');
+    expect(dialog.textContent).not.toContain('fixed effort');
+  });
+
+  it('resolves a model recommendation to a concrete model without saying auto', () => {
+    render(
+      <RoutingPicker {...baseProps} model="" recommendation={{ model: 'claude-sonnet-4-6' }} />,
+    );
     const trigger = screen.getByRole('button', { name: /routing/i });
     expect(trigger.textContent).toContain('Sonnet 4.6');
-    expect(trigger.textContent).not.toContain('recommended');
     fireEvent.click(trigger);
-    expect(screen.getByRole('dialog').textContent).toContain('auto');
-    expect(screen.getByRole('dialog').textContent).not.toContain('recommended');
+    const dialog = screen.getByRole('dialog');
+    expect(dialog.textContent).toContain('Recommended');
+    expect(dialog.textContent).not.toContain('auto');
+  });
+
+  it('offers no recommendation chip when the caller passes no recommendation', () => {
+    render(<RoutingPicker {...baseProps} />);
+    fireEvent.click(screen.getByRole('button', { name: /routing/i }));
+    expect(screen.queryByRole('button', { name: /^Recommended/ })).toBeNull();
+  });
+
+  it('puts a provider recommendation in its own row above the provider tabs', () => {
+    const onProvider = vi.fn();
+    render(
+      <RoutingPicker
+        {...baseProps}
+        provider=""
+        model=""
+        onProvider={onProvider}
+        recommendation={{ provider: 'anthropic', model: 'claude-sonnet-4-6' }}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /routing/i }));
+    const row = screen.getByRole('button', { name: 'Recommended Claude · Sonnet 4.6' });
+    expect(row.querySelector('svg')).toBeNull();
+    fireEvent.click(row);
+    expect(onProvider).toHaveBeenCalledWith('');
+  });
+
+  it('marks the recommended provider tab as secondary, never as selected', () => {
+    render(
+      <RoutingPicker
+        {...baseProps}
+        provider=""
+        model=""
+        recommendation={{ provider: 'anthropic', model: 'claude-sonnet-4-6' }}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /routing/i }));
+    const tab = screen.getByRole('button', { name: 'Claude' });
+    expect(tab.getAttribute('aria-pressed')).toBe('false');
+    expect(tab.className).toContain('ring-border-soft');
+    expect(tab.className).not.toContain('shadow-sm');
+  });
+
+  it('renders each provider mark once in the provider row', () => {
+    render(
+      <RoutingPicker
+        {...baseProps}
+        provider=""
+        recommendation={{ provider: 'anthropic', model: 'claude-sonnet-4-6' }}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /routing/i }));
+    const providerRow = screen.getByRole('button', { name: 'Cursor' }).parentElement;
+    expect(providerRow?.querySelectorAll('svg')).toHaveLength(providers.length);
   });
 
   it('reports the picked model and keeps the popover open', () => {
@@ -80,26 +149,22 @@ describe('RoutingPicker', () => {
     expect(screen.getByRole('dialog')).toBeDefined();
   });
 
-  it('hides auto when the recommendation does not apply to the viewed provider', () => {
-    render(<RoutingPicker {...baseProps} model="" recommendedModel="claude-sonnet-4-6" />);
+  it('hides the recommendation chip when it does not apply to the viewed provider', () => {
+    render(
+      <RoutingPicker {...baseProps} model="" recommendation={{ model: 'claude-sonnet-4-6' }} />,
+    );
     fireEvent.click(screen.getByRole('button', { name: /routing/i }));
     fireEvent.click(screen.getByRole('button', { name: 'Codex' }));
-    expect(screen.queryByRole('button', { name: 'auto' })).toBeNull();
+    expect(screen.queryByRole('button', { name: /^Recommended/ })).toBeNull();
   });
 
-  it('hides provider auto when no provider recommendation exists', () => {
-    render(<RoutingPicker {...baseProps} provider="" />);
-    fireEvent.click(screen.getByRole('button', { name: /routing/i }));
-    expect(screen.queryByRole('button', { name: 'auto' })).toBeNull();
-  });
-
-  it('always offers Cursor literal auto and selects its model id', () => {
+  it('offers Cursor literal auto as a plain model chip', () => {
     const onModel = vi.fn();
     render(
       <RoutingPicker
         {...baseProps}
         model=""
-        recommendedModel="claude-sonnet-4-6"
+        recommendation={{ model: 'claude-sonnet-4-6' }}
         onModel={onModel}
       />,
     );
@@ -110,11 +175,11 @@ describe('RoutingPicker', () => {
   });
 
   it('reports the picked effort and keeps the popover open', () => {
-    const onEffort = vi.fn();
-    render(<RoutingPicker {...baseProps} onEffort={onEffort} />);
+    const onChange = vi.fn();
+    render(<RoutingPicker {...baseProps} effort={{ editable: true, value: 'high', onChange }} />);
     fireEvent.click(screen.getByRole('button', { name: /routing/i }));
     fireEvent.click(screen.getByRole('button', { name: 'Medium' }));
-    expect(onEffort).toHaveBeenCalledWith('medium');
+    expect(onChange).toHaveBeenCalledWith('medium');
     expect(screen.getByRole('dialog')).toBeDefined();
   });
 

--- a/apps/desktop/src/shared/components/RoutingPicker/index.test.tsx
+++ b/apps/desktop/src/shared/components/RoutingPicker/index.test.tsx
@@ -43,10 +43,26 @@ describe('RoutingPicker', () => {
   });
 
   it('keeps the full routing in the accessible name and the tooltip', () => {
-    render(<RoutingPicker {...baseProps} />);
+    render(<RoutingPicker {...baseProps} verbosity="brief" onVerbosity={vi.fn()} />);
     const trigger = screen.getByRole('button', { name: /routing/i });
-    expect(trigger.getAttribute('aria-label')).toBe('routing: Claude · Opus 5 · High');
-    expect(trigger.getAttribute('title')).toContain('Claude · Opus 5 · High');
+    expect(trigger.getAttribute('aria-label')).toBe('routing: Claude · Opus 5 · High · Brief');
+    expect(trigger.getAttribute('title')).toContain('Claude · Opus 5 · High · Brief');
+  });
+
+  it('still explains a disabled trigger when the caller gives no reason', () => {
+    render(
+      <RoutingPicker {...baseProps} disabled={true} verbosity="brief" onVerbosity={vi.fn()} />,
+    );
+    expect(screen.getByRole('button', { name: /routing/i }).getAttribute('title')).toBe(
+      'Claude · Opus 5 · High · Brief',
+    );
+  });
+
+  it('prefers the caller reason over the summary on a disabled trigger', () => {
+    render(<RoutingPicker {...baseProps} disabled={true} disabledTitle="the turn is running" />);
+    expect(screen.getByRole('button', { name: /routing/i }).getAttribute('title')).toBe(
+      'the turn is running',
+    );
   });
 
   it('drops the effort segment and explains why for a model without thinking levels', () => {
@@ -116,6 +132,67 @@ describe('RoutingPicker', () => {
     expect(tab.getAttribute('aria-pressed')).toBe('false');
     expect(tab.className).toContain('ring-border-soft');
     expect(tab.className).not.toContain('shadow-sm');
+  });
+
+  it('marks the recommendation row active while a concrete provider still inherits the default', () => {
+    render(
+      <RoutingPicker
+        {...baseProps}
+        provider="anthropic"
+        model=""
+        overridden={false}
+        recommendation={{ provider: 'anthropic', model: 'claude-sonnet-4-6' }}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /routing/i }));
+    expect(
+      screen
+        .getByRole('button', { name: 'Recommended Claude · Sonnet 4.6' })
+        .getAttribute('aria-pressed'),
+    ).toBe('true');
+    const tab = screen.getByRole('button', { name: 'Claude' });
+    expect(tab.getAttribute('aria-pressed')).toBe('false');
+    expect(tab.className).toContain('ring-border-soft');
+  });
+
+  it('drops the recommendation row highlight as soon as a concrete model is picked', () => {
+    render(
+      <RoutingPicker
+        {...baseProps}
+        provider="anthropic"
+        model=""
+        overridden={false}
+        recommendation={{ provider: 'anthropic', model: 'claude-sonnet-4-6' }}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /routing/i }));
+    const row = screen.getByRole('button', { name: 'Recommended Claude · Sonnet 4.6' });
+    fireEvent.click(screen.getByTitle(/^claude-opus-5 \(/));
+    expect(row.getAttribute('aria-pressed')).toBe('false');
+    expect(screen.getByRole('button', { name: 'Claude' }).getAttribute('aria-pressed')).toBe(
+      'true',
+    );
+  });
+
+  it('keeps the model grid recommendation chip when the recommendation names no provider', () => {
+    render(
+      <RoutingPicker {...baseProps} model="" recommendation={{ model: 'claude-sonnet-4-6' }} />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /routing/i }));
+    expect(screen.getByTitle('Recommended (Sonnet 4.6)')).toBeDefined();
+  });
+
+  it('suppresses the model grid recommendation chip when the recommendation names a provider', () => {
+    render(
+      <RoutingPicker
+        {...baseProps}
+        model=""
+        recommendation={{ provider: 'anthropic', model: 'claude-sonnet-4-6' }}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /routing/i }));
+    expect(screen.queryByTitle('Recommended (Sonnet 4.6)')).toBeNull();
+    expect(screen.getByRole('button', { name: 'Recommended Claude · Sonnet 4.6' })).toBeDefined();
   });
 
   it('renders each provider mark once in the provider row', () => {

--- a/apps/desktop/src/shared/components/RoutingPicker/index.tsx
+++ b/apps/desktop/src/shared/components/RoutingPicker/index.tsx
@@ -37,7 +37,7 @@ type PickProviderParams = {
   readonly viewedProvider: ProviderId;
 };
 
-export type EffortSetting =
+type EffortSetting =
   | { readonly editable: false; readonly value?: EffortLevel }
   | {
       readonly editable: true;
@@ -78,7 +78,7 @@ export const RoutingPicker = ({
   verbosity,
   onVerbosity,
   onReset,
-  overridden = false,
+  overridden,
   defaultSummary,
   variant = 'field',
   align = 'start',
@@ -104,8 +104,11 @@ export const RoutingPicker = ({
     effort: effortValue,
     recommendation,
   });
+  const isOverridden = overridden === true;
+  const isInheritingRecommendation =
+    recommendedProvider != null && (routing.isProviderRecommended || overridden === false);
   const [viewProvider, setViewProvider] = useState(routing.provider);
-  const [isViewingAuto, setIsViewingAuto] = useState(routing.isProviderRecommended);
+  const [isViewingAuto, setIsViewingAuto] = useState(isInheritingRecommendation);
   const isViewingRoutingProvider = viewProvider === routing.provider;
   const viewedRecommendedModel =
     isViewingRoutingProvider &&
@@ -127,15 +130,15 @@ export const RoutingPicker = ({
     isViewingRoutingProvider && routing.isModelRecommended && gridRecommendedModel != null;
   const summary = `${PROVIDER_LABEL[routing.provider]} · ${modelLabel(routing.model)}${
     showEffort ? ` · ${EFFORT_LABEL[routing.effort]}` : ''
-  }`;
+  }${verbosity != null ? ` · ${VERBOSITY_LABEL[verbosity]}` : ''}`;
 
   useEffect(() => {
     if (open) {
       return;
     }
     setViewProvider(routing.provider);
-    setIsViewingAuto(routing.isProviderRecommended);
-  }, [open, routing.isProviderRecommended, routing.provider]);
+    setIsViewingAuto(isInheritingRecommendation);
+  }, [open, isInheritingRecommendation, routing.provider]);
 
   const onPickProvider = ({ next, viewedProvider }: PickProviderParams) => {
     onProvider(next);
@@ -143,12 +146,17 @@ export const RoutingPicker = ({
     setIsViewingAuto(next === '');
   };
 
+  const onPickModel = (next: string) => {
+    setIsViewingAuto(false);
+    onModel(next);
+  };
+
   return (
     <div
       ref={containerRef}
       className={cn('relative flex items-center gap-1', variant === 'field' && 'w-full')}
     >
-      {onReset != null && overridden && !disabled && (
+      {onReset != null && isOverridden && !disabled && (
         <button
           type="button"
           onClick={onReset}
@@ -165,7 +173,7 @@ export const RoutingPicker = ({
         type="button"
         onClick={toggle}
         disabled={disabled}
-        title={disabled ? disabledTitle : `${summary}. Click to change.`}
+        title={disabled ? (disabledTitle ?? summary) : `${summary}. Click to change.`}
         aria-haspopup="dialog"
         aria-expanded={open}
         aria-label={ariaLabel != null ? `${ariaLabel}: ${summary}` : summary}
@@ -179,7 +187,7 @@ export const RoutingPicker = ({
               ? 'border-primary bg-primary/5'
               : 'border-border-soft bg-subtle hover:border-border hover:bg-muted/50'),
           variant === 'pill' &&
-            (overridden
+            (isOverridden
               ? 'bg-warning/10 ring-1 ring-warning/30 hover:bg-warning/15'
               : 'bg-subtle hover:bg-muted'),
           disabled && 'cursor-not-allowed opacity-60',
@@ -211,11 +219,13 @@ export const RoutingPicker = ({
         >
           {defaultSummary != null && (
             <div className="flex items-start gap-1.5 px-2.5 py-2 text-2xs leading-relaxed">
-              <span className={cn('flex-1', overridden ? 'text-warning' : 'text-muted-foreground')}>
-                {overridden ? 'Overriding default' : 'Using default'} ·{' '}
-                {overridden ? summary : defaultSummary}
+              <span
+                className={cn('flex-1', isOverridden ? 'text-warning' : 'text-muted-foreground')}
+              >
+                {isOverridden ? 'Overriding default' : 'Using default'} ·{' '}
+                {isOverridden ? summary : defaultSummary}
               </span>
-              {onReset != null && overridden && (
+              {onReset != null && isOverridden && (
                 <button
                   type="button"
                   onClick={() => {
@@ -312,7 +322,7 @@ export const RoutingPicker = ({
                   value={viewedRouting.model}
                   recommendedModel={gridRecommendedModel}
                   isRecommended={isModelRecommended}
-                  onSelect={onModel}
+                  onSelect={onPickModel}
                 />
               </ScrollFade>
             )}

--- a/apps/desktop/src/shared/components/RoutingPicker/index.tsx
+++ b/apps/desktop/src/shared/components/RoutingPicker/index.tsx
@@ -19,8 +19,11 @@ import { ModelGrid } from './ModelGrid';
 import { PickerChip } from './PickerChip';
 import { PickerSection } from './PickerSection';
 import { ProviderGlyph } from './ProviderGlyph';
+import { RecommendationRow } from './RecommendationRow';
 import { TriggerLabel } from './TriggerLabel';
-import { resolveRouting } from './resolveRouting';
+import { orderedEffortLevels } from './orderedEffortLevels';
+import { recommendationSummary } from './recommendationSummary';
+import { resolveRouting, type Recommendation } from './resolveRouting';
 
 const CHIP_GROUP_CLASS_NAME = 'flex flex-wrap gap-1 bg-subtle px-2.5';
 const PROVIDER_CHIP_GROUP_CLASS_NAME =
@@ -34,17 +37,23 @@ type PickProviderParams = {
   readonly viewedProvider: ProviderId;
 };
 
+export type EffortSetting =
+  | { readonly editable: false; readonly value?: EffortLevel }
+  | {
+      readonly editable: true;
+      readonly value: EffortLevel;
+      readonly onChange: (effort: EffortLevel) => void;
+    };
+
 export type Props = {
   readonly connectedProviders: ReadonlyArray<ProviderId>;
   readonly provider: ProviderId | '';
   readonly model: string;
-  readonly effort?: EffortLevel;
+  readonly effort: EffortSetting;
   readonly disabled: boolean;
   readonly onProvider: (provider: ProviderId | '') => void;
   readonly onModel: (model: string) => void;
-  readonly onEffort?: (effort: EffortLevel) => void;
-  readonly recommendedProvider?: ProviderId;
-  readonly recommendedModel?: string;
+  readonly recommendation?: Recommendation;
   readonly verbosity?: VerbosityLevel;
   readonly onVerbosity?: (verbosity: VerbosityLevel) => void;
   readonly onReset?: () => void;
@@ -61,13 +70,11 @@ export const RoutingPicker = ({
   connectedProviders,
   provider,
   model,
-  effort = 'medium',
+  effort,
   disabled,
   onProvider,
   onModel,
-  onEffort,
-  recommendedProvider,
-  recommendedModel,
+  recommendation,
   verbosity,
   onVerbosity,
   onReset,
@@ -86,13 +93,16 @@ export const RoutingPicker = ({
     expectedHeight: 320,
     width: 'w-80 max-w-[calc(100vw-2rem)]',
   });
+  const editableEffort = effort.editable ? effort : null;
+  const effortValue = effort.value ?? 'medium';
+  const recommendedProvider = recommendation?.provider;
+  const recommendedModel = recommendation?.model;
   const routing = resolveRouting({
     providers: PROVIDERS,
     provider,
     model,
-    effort,
-    recommendedProvider,
-    recommendedModel,
+    effort: effortValue,
+    recommendation,
   });
   const [viewProvider, setViewProvider] = useState(routing.provider);
   const [isViewingAuto, setIsViewingAuto] = useState(routing.isProviderRecommended);
@@ -103,24 +113,20 @@ export const RoutingPicker = ({
     PROVIDER_CAPABILITIES[viewProvider].models.some((entry) => entry.id === recommendedModel)
       ? recommendedModel
       : undefined;
-  const viewedLiteralAutoModel = PROVIDER_CAPABILITIES[viewProvider].models.find(
-    (entry) => entry.id === 'auto',
-  )?.id;
   const viewedRouting = resolveRouting({
     providers: PROVIDERS,
     provider: viewProvider,
     model: isViewingRoutingProvider ? model : '',
-    effort,
-    recommendedProvider: isViewingRoutingProvider ? recommendedProvider : undefined,
-    recommendedModel: viewedRecommendedModel,
+    effort: effortValue,
+    recommendation: viewedRecommendedModel != null ? { model: viewedRecommendedModel } : undefined,
   });
+  const gridRecommendedModel = recommendedProvider == null ? viewedRecommendedModel : undefined;
   const isViewProviderConnected = connectedProviders.includes(viewProvider);
-  const showEffort = onEffort != null && routing.effortLevels != null;
-  const showViewedEffort = onEffort != null && viewedRouting.effortLevels != null;
+  const showEffort = editableEffort != null && routing.effortLevels != null;
   const isModelRecommended =
-    isViewingRoutingProvider && routing.isModelRecommended && viewedRecommendedModel != null;
+    isViewingRoutingProvider && routing.isModelRecommended && gridRecommendedModel != null;
   const summary = `${PROVIDER_LABEL[routing.provider]} · ${modelLabel(routing.model)}${
-    showEffort ? ` · ${EFFORT_LABEL[routing.effort]} effort` : ''
+    showEffort ? ` · ${EFFORT_LABEL[routing.effort]}` : ''
   }`;
 
   useEffect(() => {
@@ -162,7 +168,7 @@ export const RoutingPicker = ({
         title={disabled ? disabledTitle : `${summary}. Click to change.`}
         aria-haspopup="dialog"
         aria-expanded={open}
-        aria-label={ariaLabel}
+        aria-label={ariaLabel != null ? `${ariaLabel}: ${summary}` : summary}
         className={cn(
           'items-center gap-1.5 text-xs transition-colors',
           variant === 'pill'
@@ -205,15 +211,8 @@ export const RoutingPicker = ({
         >
           {defaultSummary != null && (
             <div className="flex items-start gap-1.5 px-2.5 py-2 text-2xs leading-relaxed">
-              <span
-                className={cn(
-                  'font-semibold uppercase tracking-wide',
-                  overridden ? 'text-warning' : 'text-muted-foreground/70',
-                )}
-              >
-                {overridden ? 'override' : 'default'}
-              </span>
-              <span className="flex-1 text-muted-foreground">
+              <span className={cn('flex-1', overridden ? 'text-warning' : 'text-muted-foreground')}>
+                {overridden ? 'Overriding default' : 'Using default'} ·{' '}
                 {overridden ? summary : defaultSummary}
               </span>
               {onReset != null && overridden && (
@@ -230,25 +229,25 @@ export const RoutingPicker = ({
               )}
             </div>
           )}
+          {recommendedProvider != null && (
+            <>
+              <RecommendationRow
+                summary={recommendationSummary({
+                  provider: recommendedProvider,
+                  model: recommendedModel,
+                })}
+                active={isViewingAuto}
+                onSelect={() => onPickProvider({ next: '', viewedProvider: routing.provider })}
+              />
+              <Divider />
+            </>
+          )}
           <PickerSection label="Provider" hint="Which CLI agent runs the turn">
             <div className={PROVIDER_CHIP_GROUP_CLASS_NAME}>
-              {recommendedProvider != null && (
-                <PickerChip
-                  label="auto"
-                  active={isViewingAuto}
-                  onSelect={() =>
-                    onPickProvider({
-                      next: '',
-                      viewedProvider: routing.provider,
-                    })
-                  }
-                  glyph={<ProviderGlyph id={recommendedProvider} size={15} />}
-                  note={PROVIDER_LABEL[recommendedProvider]}
-                />
-              )}
               {PROVIDERS.map((id) => {
                 const isConnected = connectedProviders.includes(id);
                 const isActive = !isViewingAuto && viewProvider === id;
+                const isRecommendedTab = isViewingAuto && recommendedProvider === id;
                 return (
                   <button
                     key={id}
@@ -267,6 +266,7 @@ export const RoutingPicker = ({
                     className={cn(
                       'relative inline-flex min-w-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-background/60 hover:text-foreground',
                       isActive && 'bg-background text-foreground shadow-sm',
+                      isRecommendedTab && 'text-foreground ring-1 ring-inset ring-border-soft',
                     )}
                   >
                     <span className={cn(!isConnected && 'opacity-35')}>
@@ -310,59 +310,52 @@ export const RoutingPicker = ({
                 <ModelGrid
                   ids={viewedRouting.models}
                   value={viewedRouting.model}
-                  recommendedModel={viewedRecommendedModel}
-                  literalAutoModel={viewedLiteralAutoModel}
+                  recommendedModel={gridRecommendedModel}
                   isRecommended={isModelRecommended}
                   onSelect={onModel}
                 />
               </ScrollFade>
             )}
           </PickerSection>
-          {isViewProviderConnected && (
+          {isViewProviderConnected && editableEffort != null && (
             <>
               <Divider />
               <PickerSection label="Effort" hint="How hard the model thinks before answering">
-                {onEffort == null && (
+                {viewedRouting.effortLevels == null && (
                   <p className="px-2.5 text-2xs leading-relaxed text-muted-foreground/60">
-                    This task always runs at the model default effort.
+                    {modelLabel(viewedRouting.model)} runs at a fixed effort.
                   </p>
                 )}
-                {onEffort != null && viewedRouting.effortLevels == null && (
-                  <p className="px-2.5 text-2xs leading-relaxed text-muted-foreground/60">
-                    {modelLabel(viewedRouting.model)} answers in a single pass, so it has no
-                    thinking levels to set.
-                  </p>
-                )}
-                {showViewedEffort && viewedRouting.effortLevels != null && (
+                {viewedRouting.effortLevels != null && (
                   <div className={CHIP_GROUP_CLASS_NAME}>
-                    {viewedRouting.effortLevels.map((level) => (
+                    {orderedEffortLevels({ levels: viewedRouting.effortLevels }).map((level) => (
                       <PickerChip
                         key={level}
                         label={EFFORT_LABEL[level]}
                         active={viewedRouting.effort === level}
-                        onSelect={() => onEffort(level)}
+                        onSelect={() => editableEffort.onChange(level)}
                       />
                     ))}
                   </div>
                 )}
               </PickerSection>
-              {verbosity != null && onVerbosity != null && (
-                <>
-                  <Divider />
-                  <PickerSection label="Replies" hint="How detailed the answers should be">
-                    <div className={CHIP_GROUP_CLASS_NAME}>
-                      {VERBOSITY_LEVELS.map((level) => (
-                        <PickerChip
-                          key={level}
-                          label={VERBOSITY_LABEL[level]}
-                          active={verbosity === level}
-                          onSelect={() => onVerbosity(level)}
-                        />
-                      ))}
-                    </div>
-                  </PickerSection>
-                </>
-              )}
+            </>
+          )}
+          {isViewProviderConnected && verbosity != null && onVerbosity != null && (
+            <>
+              <Divider />
+              <PickerSection label="Replies" hint="How detailed the answers should be">
+                <div className={CHIP_GROUP_CLASS_NAME}>
+                  {VERBOSITY_LEVELS.map((level) => (
+                    <PickerChip
+                      key={level}
+                      label={VERBOSITY_LABEL[level]}
+                      active={verbosity === level}
+                      onSelect={() => onVerbosity(level)}
+                    />
+                  ))}
+                </div>
+              </PickerSection>
             </>
           )}
         </Popover>

--- a/apps/desktop/src/shared/components/RoutingPicker/orderedEffortLevels.ts
+++ b/apps/desktop/src/shared/components/RoutingPicker/orderedEffortLevels.ts
@@ -1,0 +1,8 @@
+import { EFFORT_LEVELS, type EffortLevel } from '../../../features/chat/utils/chat-constants';
+
+type Params = {
+  readonly levels: ReadonlyArray<EffortLevel>;
+};
+
+export const orderedEffortLevels = ({ levels }: Params): ReadonlyArray<EffortLevel> =>
+  EFFORT_LEVELS.filter((level) => levels.includes(level));

--- a/apps/desktop/src/shared/components/RoutingPicker/recommendationSummary.test.ts
+++ b/apps/desktop/src/shared/components/RoutingPicker/recommendationSummary.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { recommendationSummary } from './recommendationSummary';
+
+describe('recommendationSummary', () => {
+  it('names the recommended provider and its model', () => {
+    expect(recommendationSummary({ provider: 'anthropic', model: 'claude-sonnet-4-6' })).toBe(
+      'Claude · Sonnet 4.6',
+    );
+  });
+
+  it('names the provider alone when the model belongs to another provider', () => {
+    expect(recommendationSummary({ provider: 'anthropic', model: 'gpt-5.5' })).toBe('Claude');
+  });
+
+  it('names the provider alone when no model is recommended', () => {
+    expect(recommendationSummary({ provider: 'codex' })).toBe('Codex');
+  });
+});

--- a/apps/desktop/src/shared/components/RoutingPicker/recommendationSummary.ts
+++ b/apps/desktop/src/shared/components/RoutingPicker/recommendationSummary.ts
@@ -1,5 +1,5 @@
 import type { ProviderId } from '@goodboy/types';
-import { PROVIDER_CAPABILITIES, getDefaultTurnModel } from '@goodboy/core';
+import { PROVIDER_CAPABILITIES } from '@goodboy/core';
 import { PROVIDER_LABEL, modelLabel } from '../../../features/chat/utils/chat-constants';
 
 type Params = {
@@ -8,9 +8,12 @@ type Params = {
 };
 
 export const recommendationSummary = ({ provider, model }: Params): string => {
-  const resolved =
-    model != null && PROVIDER_CAPABILITIES[provider].models.some((entry) => entry.id === model)
-      ? model
-      : getDefaultTurnModel(provider);
-  return `${PROVIDER_LABEL[provider]} · ${modelLabel(resolved)}`;
+  const label = PROVIDER_LABEL[provider];
+  if (model == null) {
+    return label;
+  }
+  if (!PROVIDER_CAPABILITIES[provider].models.some((entry) => entry.id === model)) {
+    return label;
+  }
+  return `${label} · ${modelLabel(model)}`;
 };

--- a/apps/desktop/src/shared/components/RoutingPicker/recommendationSummary.ts
+++ b/apps/desktop/src/shared/components/RoutingPicker/recommendationSummary.ts
@@ -1,0 +1,16 @@
+import type { ProviderId } from '@goodboy/types';
+import { PROVIDER_CAPABILITIES, getDefaultTurnModel } from '@goodboy/core';
+import { PROVIDER_LABEL, modelLabel } from '../../../features/chat/utils/chat-constants';
+
+type Params = {
+  readonly provider: ProviderId;
+  readonly model?: string;
+};
+
+export const recommendationSummary = ({ provider, model }: Params): string => {
+  const resolved =
+    model != null && PROVIDER_CAPABILITIES[provider].models.some((entry) => entry.id === model)
+      ? model
+      : getDefaultTurnModel(provider);
+  return `${PROVIDER_LABEL[provider]} · ${modelLabel(resolved)}`;
+};

--- a/apps/desktop/src/shared/components/RoutingPicker/resolveRouting.ts
+++ b/apps/desktop/src/shared/components/RoutingPicker/resolveRouting.ts
@@ -6,13 +6,17 @@ import {
   type EffortLevel,
 } from '../../../features/chat/utils/chat-constants';
 
+export type Recommendation = {
+  readonly provider?: ProviderId;
+  readonly model?: string;
+};
+
 type Params = {
   readonly providers: ReadonlyArray<ProviderId>;
   readonly provider: ProviderId | '';
   readonly model: string;
   readonly effort: EffortLevel;
-  readonly recommendedProvider?: ProviderId;
-  readonly recommendedModel?: string;
+  readonly recommendation?: Recommendation;
 };
 
 export type ResolvedRouting = {
@@ -30,15 +34,14 @@ export const resolveRouting = ({
   provider,
   model,
   effort,
-  recommendedProvider,
-  recommendedModel,
+  recommendation,
 }: Params): ResolvedRouting => {
   const resolvedProvider =
     provider !== ''
       ? provider
-      : (recommendedProvider ?? getModelProvider(model) ?? providers[0] ?? 'anthropic');
+      : (recommendation?.provider ?? getModelProvider(model) ?? providers[0] ?? 'anthropic');
   const resolvedModel =
-    model !== '' ? model : (recommendedModel ?? getDefaultTurnModel(resolvedProvider));
+    model !== '' ? model : (recommendation?.model ?? getDefaultTurnModel(resolvedProvider));
   const ids = PROVIDER_CAPABILITIES[resolvedProvider].models.map((entry) => entry.id);
   return {
     provider: resolvedProvider,

--- a/apps/desktop/src/shared/components/brand-icons.tsx
+++ b/apps/desktop/src/shared/components/brand-icons.tsx
@@ -46,14 +46,14 @@ CursorIcon.displayName = 'CursorIcon';
 
 export const OpencodeIcon: LucideIcon = forwardRef<SVGSVGElement, LucideProps>((props, ref) => (
   <svg ref={ref} {...svgProps(props)}>
-    <path d="M2 3h9v5H7v8h4v5H2V3Zm5 4h4v10H7V7Zm6-4h9v18h-9V3Zm5 5h-1v8h1V8Z" />
+    <path d="M22 24H2V0h20zM17 4.8H7v14.4h10z" />
   </svg>
 ));
 OpencodeIcon.displayName = 'OpencodeIcon';
 
 export const OpenrouterIcon: LucideIcon = forwardRef<SVGSVGElement, LucideProps>((props, ref) => (
   <svg ref={ref} {...svgProps(props)}>
-    <path d="M3 4h11l-3-3 2-1 7 6-7 6-2-2 3-3H3V4Zm0 8h18v3H3v-3Zm0 5h11l-3-3 2-2 7 6-7 6-2-2 3-2H3v-3Z" />
+    <path d="M16.778 1.844v1.919q-.569-.026-1.138-.032-.708-.008-1.415.037c-1.93.126-4.023.728-6.149 2.237-2.911 2.066-2.731 1.95-4.14 2.75-.396.223-1.342.574-2.185.798-.841.225-1.753.333-1.751.333v4.229s.768.108 1.61.333c.842.224 1.789.575 2.185.799 1.41.798 1.228.683 4.14 2.75 2.126 1.509 4.22 2.11 6.148 2.236.88.058 1.716.041 2.555.005v1.918l7.222-4.168-7.222-4.17v2.176c-.86.038-1.611.065-2.278.021-1.364-.09-2.417-.357-3.979-1.465-2.244-1.593-2.866-2.027-3.68-2.508.889-.518 1.449-.906 3.822-2.59 1.56-1.109 2.614-1.377 3.978-1.466.667-.044 1.418-.017 2.278.02v2.176L24 6.014Z" />
   </svg>
 ));
 OpenrouterIcon.displayName = 'OpenrouterIcon';


### PR DESCRIPTION
# Picker v5 and the real opencode and openrouter marks

## What was broken

The provider and model picker printed the provider name in its own button, and that name never gave up space. In the narrow places (the sessions sidebar, the Provider Studio rows, the session start row) the text ran past the border of the button, so the dashboard looked visibly broken.

Inside the picker, the word "auto" meant three different things at once: a suggested provider, a suggested model, and the Cursor model that is genuinely called auto. On the Provider Studio task rows (Summaries, Branch names, Planning, Agent titles, PR drafts) that produced an "auto" chip in the model list with nothing to pair it with, so it read as a stray control. When the suggestion was Claude, the Claude mark appeared twice in a row inside the provider tabs, which looked like a rendering bug.

The same task rows always showed an Effort section whose only content was a sentence saying that effort does not apply there. Two adjacent rows in Provider Studio therefore looked inconsistent for no reason the user could see.

Finally, opencode and openrouter were drawn by hand and matched no real product. Next to four authentic marks, the two newest providers looked like unfinished placeholders.

## What changes

The picker button now shows the provider mark, the model, and (when the model has thinking levels you can set) the effort and reply length. The provider name is gone from the button, so nothing overflows at any width. The full routing, for example `Claude · Fable 5 · Very high`, stays in the tooltip and in the accessible name at all times, not only when the text is cut.

Each word in the picker now means exactly one thing:

- `Recommended` is the suggestion that comes with the role. When a suggestion covers the provider, it is a single row at the top of the popover with the resolved routing shown quietly on the right. It carries no provider mark, so no logo appears twice, and the suggested provider tab gets a light outline instead of looking selected.
- When only a model is suggested, `Recommended` is a chip in the model list with the resolved model next to it.
- `Auto` now only ever refers to the Cursor model actually named auto, listed as an ordinary chip in its own group.
- With no suggestion, no suggestion chip appears anywhere.

The Effort section is now absent whenever the setting cannot be changed, instead of showing a sentence explaining that it cannot be changed. Task model rows in Provider Studio are clean as a result. Models without thinking levels say `Runs at a fixed effort` in one short line. The effort chips keep a stable Low to Max order across models with different ladders.

Picking a model that does not support the current effort now saves an effort that model can actually reach, instead of carrying a level forward that would be silently discarded later.

The recap line at the top of the popover reads in plain sentence case: `Using default · Claude · Sonnet 4.6`, or `Overriding default · ...` with a reset link when you have changed something.

Under the hood, callers now hand the picker a single `recommendation` object and say explicitly whether effort is editable, instead of the picker guessing from which optional props happened to be passed. That guessing is what produced the duplicated mark, the stray "auto" chip, and the empty Effort section.

The opencode and openrouter marks are now the real ones, drawn as single monochrome paths in the same style as the Claude, OpenAI, Cursor, GitHub, GitLab, Sentry and Linear marks already in the app. They were checked at 12, 14 and 15 pixels, the sizes the app actually uses.

## How it was verified

- TypeScript compiles clean across the desktop app.
- The full desktop test suite passes: 336 files, 2740 tests.
- The picker suite was rewritten around the new behavior and grew to 21 tests, including new ones proving that the button no longer prints the provider name, that no suggestion chip renders when no suggestion is passed, that each provider mark appears exactly once in the provider row, that the Effort section disappears when effort is not editable, and that the suggested provider tab reads as secondary rather than selected.
- A new Provider Studio test proves that switching a role from a model with five thinking levels to a model with three saves the highest level the new model supports rather than the old one.
- The two new marks were rendered off-app at 12, 14, 15 and 96 pixels and compared against the official artwork before being committed.
