### PR TITLE
Provider defaults: fix the collapsing row and split overrides behind a segmented control

### DIFF
--- a/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/index.test.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/index.test.tsx
@@ -325,6 +325,14 @@ describe('DefaultsPanel', () => {
     expect(screen.queryByText('Summaries')).toBeNull();
   });
 
+  it('bounds the default provider and routing pool chip rows so they wrap instead of squeezing the label', () => {
+    render(<DefaultsPanel workspaceId={'ws-1' as never} />);
+
+    const anthropicChips = screen.getAllByRole('button', { name: 'anthropic' });
+    expect(anthropicChips[0]!.parentElement?.className).toContain('max-w-64');
+    expect(anthropicChips[1]!.parentElement?.className).toContain('max-w-64');
+  });
+
   it('shows the override count for each group in its tab label', () => {
     state.workspaceOverrides = {
       'ws-1': {

--- a/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/index.test.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/index.test.tsx
@@ -267,6 +267,7 @@ describe('DefaultsPanel', () => {
       },
     };
     render(<DefaultsPanel workspaceId={'ws-1' as never} />);
+    openRolesTab();
 
     fireEvent.click(screen.getByRole('button', { name: 'Reviewer routing model' }));
 

--- a/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/index.test.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/index.test.tsx
@@ -108,6 +108,8 @@ afterEach(cleanup);
 
 const TASK_LABELS = ['Summaries', 'Branch names', 'Planning', 'Agent titles', 'PR and MR drafts'];
 
+const openRolesTab = () => fireEvent.click(screen.getByRole('tab', { name: /Agent roles/ }));
+
 describe('DefaultsPanel', () => {
   it('uses connected providers as the routing pool and locks the default', () => {
     render(<DefaultsPanel workspaceId={'ws-1' as never} />);
@@ -167,6 +169,8 @@ describe('DefaultsPanel', () => {
       );
     }
     expect(screen.getByLabelText('Summaries routing status: default')).toBeDefined();
+
+    openRolesTab();
     expect(screen.getByLabelText('Planner routing status: default')).toBeDefined();
   });
 
@@ -202,6 +206,7 @@ describe('DefaultsPanel', () => {
 
   it('renders a row per agent role', () => {
     render(<DefaultsPanel workspaceId={'ws-1' as never} />);
+    openRolesTab();
 
     expect(screen.getByText('Scout')).toBeDefined();
     expect(screen.getByText('Debugger')).toBeDefined();
@@ -212,6 +217,7 @@ describe('DefaultsPanel', () => {
 
   it('reads a role with no override as its compiled default', () => {
     render(<DefaultsPanel workspaceId={'ws-1' as never} />);
+    openRolesTab();
 
     expect(screen.getByRole('button', { name: 'Planner routing model' }).textContent).toBe(
       'claude-opus-5 auto',
@@ -220,6 +226,7 @@ describe('DefaultsPanel', () => {
 
   it('persists a role model with an effort the model supports', () => {
     render(<DefaultsPanel workspaceId={'ws-1' as never} />);
+    openRolesTab();
 
     fireEvent.click(screen.getByRole('button', { name: 'Scout routing model' }));
 
@@ -235,6 +242,7 @@ describe('DefaultsPanel', () => {
 
   it('pins a role to a cheap model with no effort ladder instead of clearing it', () => {
     render(<DefaultsPanel workspaceId={'ws-1' as never} />);
+    openRolesTab();
 
     fireEvent.click(screen.getByRole('button', { name: 'Debugger routing cheap model' }));
 
@@ -259,6 +267,7 @@ describe('DefaultsPanel', () => {
       },
     };
     const { rerender } = render(<DefaultsPanel workspaceId={'ws-1' as never} />);
+    openRolesTab();
 
     expect(screen.getByRole('button', { name: 'Reviewer routing model' }).textContent).toBe(
       'claude-opus-5',
@@ -298,5 +307,40 @@ describe('DefaultsPanel', () => {
         },
       }),
     );
+  });
+
+  it('keeps the default provider and routing pool rows visible while switching groups', () => {
+    render(<DefaultsPanel workspaceId={'ws-1' as never} />);
+
+    expect(screen.getByText('Default provider')).toBeDefined();
+    expect(screen.getByText('Routing pool')).toBeDefined();
+    expect(screen.getByText('Summaries')).toBeDefined();
+    expect(screen.queryByText('Scout')).toBeNull();
+
+    openRolesTab();
+
+    expect(screen.getByText('Default provider')).toBeDefined();
+    expect(screen.getByText('Routing pool')).toBeDefined();
+    expect(screen.getByText('Scout')).toBeDefined();
+    expect(screen.queryByText('Summaries')).toBeNull();
+  });
+
+  it('shows the override count for each group in its tab label', () => {
+    state.workspaceOverrides = {
+      'ws-1': {
+        ...EMPTY_OVERRIDES,
+        taskModels: {
+          summarizer: { providerId: 'anthropic', model: 'claude-sonnet-4-6' },
+        },
+        roleModels: {
+          scout: { providerId: 'anthropic', model: 'claude-sonnet-4-6', effort: 'low' },
+          reviewer: { providerId: 'anthropic', model: 'claude-opus-5', effort: 'max' },
+        },
+      },
+    };
+    render(<DefaultsPanel workspaceId={'ws-1' as never} />);
+
+    expect(screen.getByRole('tab', { name: 'Task models (1)' })).toBeDefined();
+    expect(screen.getByRole('tab', { name: 'Agent roles (2)' })).toBeDefined();
   });
 });

--- a/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/index.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/index.tsx
@@ -151,7 +151,7 @@ export const DefaultsPanel = ({ workspaceId }: Props) => {
               hint="Governs every task and role below unless it has its own override."
             />
             <FieldRow label="Default provider" help="New sessions start on it and can override it.">
-              <div className="flex flex-wrap justify-end gap-1">
+              <div className="flex max-w-64 flex-wrap justify-end gap-1">
                 {PROVIDER_ORDER.map((providerId) => (
                   <ProviderChip
                     key={providerId}
@@ -181,7 +181,7 @@ export const DefaultsPanel = ({ workspaceId }: Props) => {
               {connectedProviderIds.length === 0 ? (
                 <span className="text-2xs text-muted-foreground">No providers connected</span>
               ) : (
-                <div className="flex flex-wrap justify-end gap-1">
+                <div className="flex max-w-64 flex-wrap justify-end gap-1">
                   {connectedProviderIds.map((providerId) => {
                     const isDefaultProvider = providerId === defaultProviderId;
                     return (

--- a/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/index.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/index.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { DEFAULT_SESSION_PROVIDER_PREFERENCE } from '@goodboy/types';
 import type {
   AgentRole,
@@ -12,6 +13,7 @@ import { useShallow } from 'zustand/react/shallow';
 import { ProviderChip } from '../../ProviderChip';
 import { ROLE_LABEL } from '../../../../session/agent-kind';
 import { useAppStore } from '../../../../../store';
+import { SegmentedControl } from '../../../../../shared/components/SegmentedControl';
 import { PROVIDER_ORDER } from '../providerOrder';
 import { RoleModelRow } from './RoleModelRow';
 import { TaskModelRow } from './TaskModelRow';
@@ -24,6 +26,8 @@ type Props = {
 type ProviderParams = {
   readonly providerId: ProviderId;
 };
+
+type DefaultsGroup = 'task' | 'role';
 
 const TASKS: ReadonlyArray<{
   readonly id: AuxTaskId;
@@ -94,6 +98,14 @@ export const DefaultsPanel = ({ workspaceId }: Props) => {
       overrides,
     });
 
+  const [group, setGroup] = useState<DefaultsGroup>('task');
+  const taskOverrideCount = Object.keys(overrides.taskModels ?? {}).length;
+  const roleOverrideCount = Object.keys(overrides.roleModels ?? {}).length;
+  const groupOptions = [
+    { value: 'task' as const, label: `Task models (${taskOverrideCount})` },
+    { value: 'role' as const, label: `Agent roles (${roleOverrideCount})` },
+  ];
+
   const onDefaultProvider = ({ providerId }: ProviderParams) => {
     const enabledProviders =
       overrides.enabledProviders == null
@@ -134,6 +146,10 @@ export const DefaultsPanel = ({ workspaceId }: Props) => {
       <ScrollFade className="flex-1" fadeFrom="background">
         <div className="mx-auto flex w-full max-w-3xl flex-col gap-8 px-8 py-6">
           <section className="flex flex-col gap-1">
+            <SectionHeader
+              label="Provider routing"
+              hint="Governs every task and role below unless it has its own override."
+            />
             <FieldRow label="Default provider" help="New sessions start on it and can override it.">
               <div className="flex flex-wrap justify-end gap-1">
                 {PROVIDER_ORDER.map((providerId) => (
@@ -191,49 +207,56 @@ export const DefaultsPanel = ({ workspaceId }: Props) => {
             </FieldRow>
           </section>
 
-          <section className="flex flex-col gap-2">
-            <SectionHeader label="Task models" />
-            <div className="flex flex-col">
-              {TASKS.map((task, index) => (
-                <div key={task.id} className="flex flex-col">
-                  {index > 0 ? <Divider /> : null}
-                  <TaskModelRow
-                    task={task.id}
-                    label={task.label}
-                    help={task.help}
-                    preference={overrides.taskModels?.[task.id] ?? null}
-                    defaultProviderId={defaultProviderId}
-                    connectedProviderIds={connectedProviderIds}
-                    disabled={busy}
-                    onChange={(preference) => persistTaskModel({ task: task.id, preference })}
-                  />
-                </div>
-              ))}
-            </div>
-          </section>
-
-          <section className="flex flex-col gap-2">
-            <SectionHeader
-              label="Agent roles"
-              hint="Applies to every agent spawned in this role unless pinned per agent or per step"
+          <section className="flex flex-col gap-3">
+            <SegmentedControl
+              ariaLabel="Defaults group"
+              options={groupOptions}
+              value={group}
+              onChange={setGroup}
             />
-            <div className="flex flex-col">
-              {ROLES.map((role, index) => (
-                <div key={role} className="flex flex-col">
-                  {index > 0 ? <Divider /> : null}
-                  <RoleModelRow
-                    role={role}
-                    label={ROLE_LABEL[role]}
-                    help={ROLE_DEFAULTS[role].description}
-                    preference={overrides.roleModels?.[role] ?? null}
-                    defaultProviderId={defaultProviderId}
-                    connectedProviderIds={connectedProviderIds}
-                    disabled={busy}
-                    onChange={(preference) => persistRoleModel({ role, preference })}
-                  />
+
+            {group === 'task' ? (
+              <div className="flex flex-col">
+                {TASKS.map((task, index) => (
+                  <div key={task.id} className="flex flex-col">
+                    {index > 0 ? <Divider /> : null}
+                    <TaskModelRow
+                      task={task.id}
+                      label={task.label}
+                      help={task.help}
+                      preference={overrides.taskModels?.[task.id] ?? null}
+                      defaultProviderId={defaultProviderId}
+                      connectedProviderIds={connectedProviderIds}
+                      disabled={busy}
+                      onChange={(preference) => persistTaskModel({ task: task.id, preference })}
+                    />
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="flex flex-col gap-2">
+                <p className="text-2xs text-muted-foreground/70">
+                  Applies to every agent spawned in this role unless pinned per agent or per step.
+                </p>
+                <div className="flex flex-col">
+                  {ROLES.map((role, index) => (
+                    <div key={role} className="flex flex-col">
+                      {index > 0 ? <Divider /> : null}
+                      <RoleModelRow
+                        role={role}
+                        label={ROLE_LABEL[role]}
+                        help={ROLE_DEFAULTS[role].description}
+                        preference={overrides.roleModels?.[role] ?? null}
+                        defaultProviderId={defaultProviderId}
+                        connectedProviderIds={connectedProviderIds}
+                        disabled={busy}
+                        onChange={(preference) => persistRoleModel({ role, preference })}
+                      />
+                    </div>
+                  ))}
                 </div>
-              ))}
-            </div>
+              </div>
+            )}
           </section>
 
           {error != null ? <p className="text-xs text-danger">{error}</p> : null}

--- a/apps/desktop/src/features/settings/components/SettingsStudio/SessionScopePanel.test.tsx
+++ b/apps/desktop/src/features/settings/components/SettingsStudio/SessionScopePanel.test.tsx
@@ -108,4 +108,16 @@ describe('SessionScopePanel', () => {
     expect(screen.queryByRole('button', { name: /^archive$/i })).toBeNull();
     expect(screen.queryByRole('button', { name: /^delete$/i })).toBeNull();
   });
+
+  it('bounds the default provider and routing pool chip rows so they wrap instead of squeezing the label', () => {
+    state.providers = [
+      { id: 'anthropic', connection: 'connected' },
+      { id: 'cursor', connection: 'connected' },
+    ];
+    render(<SessionScopePanel sessionId={'sess-1' as never} />);
+
+    const claudeChips = screen.getAllByRole('button', { name: /claude/i });
+    expect(claudeChips[0]!.parentElement?.className).toContain('max-w-64');
+    expect(claudeChips[1]!.parentElement?.className).toContain('max-w-64');
+  });
 });

--- a/apps/desktop/src/features/settings/components/SettingsStudio/SessionScopePanel.tsx
+++ b/apps/desktop/src/features/settings/components/SettingsStudio/SessionScopePanel.tsx
@@ -118,7 +118,7 @@ export const SessionScopePanel = ({ sessionId }: Props) => {
       <div className="mx-auto flex w-full max-w-2xl flex-col">
         <div className="flex flex-col divide-y divide-border-soft/50">
           <FieldRow label="Default provider" help="Runs new agents and workflow steps.">
-            <div className="flex flex-wrap justify-end gap-1">
+            <div className="flex max-w-64 flex-wrap justify-end gap-1">
               {SESSION_PROVIDER_OPTIONS.map((id) => (
                 <ProviderChip
                   key={id}
@@ -143,7 +143,7 @@ export const SessionScopePanel = ({ sessionId }: Props) => {
             {connectedProviderIds.length === 0 ? (
               <span className="text-2xs text-muted-foreground">No providers connected.</span>
             ) : (
-              <div className="flex flex-wrap justify-end gap-1">
+              <div className="flex max-w-64 flex-wrap justify-end gap-1">
                 {connectedProviderIds.map((id) => {
                   const enabled = (
                     session.providerPreference.enabledProviders ?? connectedProviderIds

--- a/packages/ui/src/__tests__/FieldRow.test.tsx
+++ b/packages/ui/src/__tests__/FieldRow.test.tsx
@@ -1,0 +1,25 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { FieldRow } from '../components/FieldRow';
+
+afterEach(cleanup);
+
+describe('FieldRow', () => {
+  it('floors the label column width and keeps the control column from shrinking', () => {
+    render(
+      <FieldRow label="Default provider" help="New sessions start on it.">
+        <div className="flex max-w-64 flex-wrap justify-end gap-1">
+          <button type="button">anthropic</button>
+        </div>
+      </FieldRow>,
+    );
+    const label = screen.getByText('Default provider');
+    const labelBlock = label.parentElement;
+    const controlBlock = labelBlock?.nextElementSibling;
+
+    expect(labelBlock?.className).toContain('min-w-40');
+    expect(controlBlock?.className).toContain('shrink-0');
+    expect(controlBlock?.className).not.toContain('min-w-0');
+  });
+});

--- a/packages/ui/src/components/FieldRow.tsx
+++ b/packages/ui/src/components/FieldRow.tsx
@@ -81,7 +81,7 @@ export const FieldRow = ({
       )}
     >
       {labelBlock}
-      <div className="min-w-0 shrink">{control}</div>
+      <div className="shrink-0">{control}</div>
     </div>
   );
 };

--- a/packages/ui/src/components/FieldRow.tsx
+++ b/packages/ui/src/components/FieldRow.tsx
@@ -50,7 +50,7 @@ export const FieldRow = ({
   const associate = labelable && children.props.id === undefined;
 
   const labelBlock = (
-    <div className="flex min-w-0 flex-col gap-0.5">
+    <div className="flex min-w-40 shrink flex-col gap-0.5">
       {associate ? (
         <label htmlFor={controlId} className="text-xs font-medium text-foreground">
           {label}
@@ -81,7 +81,7 @@ export const FieldRow = ({
       )}
     >
       {labelBlock}
-      <div className="shrink-0">{control}</div>
+      <div className="min-w-0 shrink">{control}</div>
     </div>
   );
 };


### PR DESCRIPTION
## Problem

Provider Studio's Defaults page had two issues.

The "Default provider" row broke visibly: its control (six provider chips) sized itself as if all six chips fit on one line, and the shared `FieldRow` primitive let the label column shrink without a floor to make room. The result was the label text wrapping one word per line next to a row of chips.

Below that, the page was a flat stack of 14 nearly identical rows: the two configuration rows (default provider, routing pool) had the same visual weight as the 12 per-task and per-role overrides, so changing the default meant scrolling past a long list to find it.

## What changed

- `FieldRow` (the shared label/control row used across Provider Studio and Settings) now gives its label column a readable minimum width instead of letting it collapse to nothing, and lets the control column shrink and wrap in a controlled way instead of overflowing. This is a shared primitive, so the fix also applies wherever else `FieldRow` renders a wide control next to a label (workspace and session settings).
- The 12 task and role override rows now sit behind a segmented control that switches between "Task models" and "Agent roles". Each tab label shows the number of overrides active in that group, read from the same saved settings the rows use, so you know whether something's customized in the tab you're not looking at.
- The default provider and routing pool rows stay visible above the segmented control at all times, since they govern both groups.
- The configuration section now has its own header, so it's no longer the only unlabeled block on the page.

## How it was verified

- `pnpm --filter @goodboy/desktop typecheck`: passes with no errors.
- `npx vitest run` from `apps/desktop` on the Defaults panel tests plus every other `FieldRow` consumer that has a test suite (workspace settings, session settings, onboarding preferences step): 4 test files, 32 tests, all passing.
- `npx vitest run` from `packages/ui` (FieldRow's package): 7 test files, 29 tests, all passing.
- Added a test that the default provider and routing pool rows stay visible while switching between the task and role tabs, and a test that each tab label shows the correct override count.
- Reviewed every other place `FieldRow` is used (workspace settings, session settings, the onboarding preferences step, the workflow composer's name/description fields, and the task/role model rows in Defaults itself) to confirm none of them relied on the old collapsing behavior.
