### PR TITLE
Branch switching: open instantly instead of blocking on the branch list

### DIFF
--- a/apps/desktop/src-tauri/src/worktree.rs
+++ b/apps/desktop/src-tauri/src/worktree.rs
@@ -279,7 +279,15 @@ pub fn worktree_create(args: CreateArgs) -> Result<CreatedWorktree, WorktreeErro
 }
 
 #[tauri::command]
-pub fn worktree_list_local_branches(repo_path: String) -> Result<Vec<BranchInfo>, WorktreeError> {
+pub async fn worktree_list_local_branches(
+    repo_path: String,
+) -> Result<Vec<BranchInfo>, WorktreeError> {
+    tauri::async_runtime::spawn_blocking(move || list_local_branches_blocking(repo_path))
+        .await
+        .map_err(|e| WorktreeError::Io(std::io::Error::other(e.to_string())))?
+}
+
+fn list_local_branches_blocking(repo_path: String) -> Result<Vec<BranchInfo>, WorktreeError> {
     let p = Path::new(&repo_path);
     if !p.exists() {
         return Err(WorktreeError::RepoNotFound(repo_path));
@@ -293,6 +301,7 @@ pub fn worktree_list_local_branches(repo_path: String) -> Result<Vec<BranchInfo>
         .iter()
         .filter_map(|w| w.branch.clone())
         .collect();
+    let uncommitted = uncommitted_status_by_branch(&worktrees, &in_use_branches);
     let mut branches = Vec::new();
     for line in raw.lines() {
         let name = line.trim();
@@ -300,11 +309,7 @@ pub fn worktree_list_local_branches(repo_path: String) -> Result<Vec<BranchInfo>
             continue;
         }
         let in_use = in_use_branches.contains(name);
-        let has_uncommitted = if in_use {
-            branch_worktree_has_uncommitted(&worktrees, name).unwrap_or(false)
-        } else {
-            false
-        };
+        let has_uncommitted = uncommitted.get(name).copied().unwrap_or(false);
         branches.push(BranchInfo {
             name: name.to_string(),
             in_use,
@@ -314,10 +319,34 @@ pub fn worktree_list_local_branches(repo_path: String) -> Result<Vec<BranchInfo>
     Ok(branches)
 }
 
-fn branch_worktree_has_uncommitted(worktrees: &[WorktreeInfo], branch: &str) -> Option<bool> {
-    let wt = worktrees.iter().find(|w| w.branch.as_deref() == Some(branch))?;
-    let stdout = git(Path::new(&wt.path), &["status", "--porcelain"]).ok()?;
-    Some(!stdout.trim().is_empty())
+fn uncommitted_status_by_branch(
+    worktrees: &[WorktreeInfo],
+    in_use_branches: &std::collections::HashSet<String>,
+) -> std::collections::HashMap<String, bool> {
+    let targets: Vec<(&str, &str)> = worktrees
+        .iter()
+        .filter_map(|w| {
+            let branch = w.branch.as_deref()?;
+            in_use_branches
+                .contains(branch)
+                .then_some((branch, w.path.as_str()))
+        })
+        .collect();
+    std::thread::scope(|scope| {
+        targets
+            .iter()
+            .map(|(branch, path)| (*branch, scope.spawn(move || worktree_has_uncommitted(path))))
+            .collect::<Vec<_>>()
+            .into_iter()
+            .map(|(branch, handle)| (branch.to_string(), handle.join().unwrap_or(false)))
+            .collect()
+    })
+}
+
+fn worktree_has_uncommitted(path: &str) -> bool {
+    git(Path::new(path), &["status", "--porcelain"])
+        .map(|out| !out.trim().is_empty())
+        .unwrap_or(false)
 }
 
 #[tauri::command]

--- a/apps/desktop/src/features/worktree/BranchSwitchPanel/index.test.tsx
+++ b/apps/desktop/src/features/worktree/BranchSwitchPanel/index.test.tsx
@@ -3,7 +3,7 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { state, listLocalBranches, showToast } = vi.hoisted(() => ({
+const { state, listLocalBranches, getCachedLocalBranches, showToast } = vi.hoisted(() => ({
   state: {
     session: { id: 'sess-1', workspaceId: 'ws-1' },
     sessionBranches: {
@@ -14,6 +14,7 @@ const { state, listLocalBranches, showToast } = vi.hoisted(() => ({
     changeSessionBranch: vi.fn(async () => undefined),
   },
   listLocalBranches: vi.fn(),
+  getCachedLocalBranches: vi.fn(() => undefined),
   showToast: vi.fn(),
 }));
 
@@ -28,6 +29,7 @@ vi.mock('../../../app/components/Toast', () => ({
 
 vi.mock('../worktree', () => ({
   listLocalBranches,
+  getCachedLocalBranches,
 }));
 
 vi.mock('../BranchCombobox', () => ({
@@ -62,16 +64,51 @@ beforeEach(() => {
     { name: 'main', inUse: true, hasUncommitted: false },
     { name: 'feat/next', inUse: false, hasUncommitted: false },
   ]);
+  getCachedLocalBranches.mockReset();
+  getCachedLocalBranches.mockReturnValue(undefined);
   showToast.mockReset();
 });
 
 afterEach(cleanup);
 
 describe('BranchSwitchPanel', () => {
+  it('opens on the Create new tab with the branch name input ready to type', () => {
+    render(<BranchSwitchPanel sessionId={'sess-1' as never} onDone={vi.fn()} />);
+
+    expect(screen.getByRole('tab', { name: 'Create new' }).getAttribute('aria-selected')).toBe(
+      'true',
+    );
+    expect(screen.getByRole('textbox', { name: 'New branch' })).toBeDefined();
+  });
+
+  it('shows a loading state in the Pick existing tab label while the branch list is in flight', async () => {
+    let resolveBranches: (
+      branches: ReadonlyArray<{ name: string; inUse: boolean; hasUncommitted: boolean }>,
+    ) => void = () => {};
+    listLocalBranches.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveBranches = resolve;
+        }),
+    );
+
+    render(<BranchSwitchPanel sessionId={'sess-1' as never} onDone={vi.fn()} />);
+
+    const loadingTab = screen.getByRole('tab', { name: 'Pick existing (loading)' });
+    fireEvent.click(loadingTab);
+    expect(
+      screen.getByRole('tab', { name: 'Pick existing (loading)' }).getAttribute('aria-selected'),
+    ).toBe('true');
+
+    resolveBranches([{ name: 'main', inUse: false, hasUncommitted: false }]);
+    await waitFor(() => screen.getByRole('tab', { name: 'Pick existing' }));
+  });
+
   it('switches to a clean existing branch and closes', async () => {
     const onDone = vi.fn();
     render(<BranchSwitchPanel sessionId={'sess-1' as never} onDone={onDone} />);
 
+    fireEvent.click(screen.getByRole('tab', { name: /pick existing/i }));
     await waitFor(() => screen.getByRole('button', { name: 'Select feat/next' }));
     fireEvent.click(screen.getByRole('button', { name: 'Select feat/next' }));
     fireEvent.click(screen.getByRole('button', { name: 'Switch branch' }));
@@ -89,6 +126,7 @@ describe('BranchSwitchPanel', () => {
   it('requires a second confirmation for a branch used elsewhere', async () => {
     render(<BranchSwitchPanel sessionId={'sess-1' as never} onDone={vi.fn()} />);
 
+    fireEvent.click(screen.getByRole('tab', { name: /pick existing/i }));
     await waitFor(() => screen.getByRole('button', { name: 'Select main' }));
     fireEvent.click(screen.getByRole('button', { name: 'Select main' }));
     fireEvent.click(screen.getByRole('button', { name: 'Switch branch' }));

--- a/apps/desktop/src/features/worktree/BranchSwitchPanel/index.test.tsx
+++ b/apps/desktop/src/features/worktree/BranchSwitchPanel/index.test.tsx
@@ -14,7 +14,10 @@ const { state, listLocalBranches, getCachedLocalBranches, showToast } = vi.hoist
     changeSessionBranch: vi.fn(async () => undefined),
   },
   listLocalBranches: vi.fn(),
-  getCachedLocalBranches: vi.fn(() => undefined),
+  getCachedLocalBranches: vi.fn(
+    (): ReadonlyArray<{ name: string; inUse: boolean; hasUncommitted: boolean }> | undefined =>
+      undefined,
+  ),
   showToast: vi.fn(),
 }));
 
@@ -102,6 +105,36 @@ describe('BranchSwitchPanel', () => {
 
     resolveBranches([{ name: 'main', inUse: false, hasUncommitted: false }]);
     await waitFor(() => screen.getByRole('tab', { name: 'Pick existing' }));
+  });
+
+  it('keeps the submit gate blocked on a warm cache until the background refresh settles', async () => {
+    getCachedLocalBranches.mockReturnValue([{ name: 'main', inUse: false, hasUncommitted: false }]);
+    let resolveBranches: (
+      branches: ReadonlyArray<{ name: string; inUse: boolean; hasUncommitted: boolean }>,
+    ) => void = () => {};
+    listLocalBranches.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveBranches = resolve;
+        }),
+    );
+
+    render(<BranchSwitchPanel sessionId={'sess-1' as never} onDone={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Pick existing (loading)' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Select main' }));
+
+    const submit = screen.getByRole('button', { name: 'Switch branch' }) as HTMLButtonElement;
+    expect(submit.disabled).toBe(true);
+    fireEvent.click(submit);
+    expect(state.changeSessionBranch).not.toHaveBeenCalled();
+
+    resolveBranches([{ name: 'main', inUse: false, hasUncommitted: false }]);
+    await waitFor(() =>
+      expect(
+        (screen.getByRole('button', { name: 'Switch branch' }) as HTMLButtonElement).disabled,
+      ).toBe(false),
+    );
   });
 
   it('switches to a clean existing branch and closes', async () => {

--- a/apps/desktop/src/features/worktree/BranchSwitchPanel/index.tsx
+++ b/apps/desktop/src/features/worktree/BranchSwitchPanel/index.tsx
@@ -6,7 +6,7 @@ import { useToast } from '../../../app/components/Toast';
 import { formatError } from '../../../shared/lib/errors';
 import { useAppStore, useSessionById } from '../../../store';
 import { BranchCombobox } from '../BranchCombobox';
-import { listLocalBranches, type LocalBranchInfo } from '../worktree';
+import { getCachedLocalBranches, listLocalBranches, type LocalBranchInfo } from '../worktree';
 
 type Props = {
   readonly sessionId: SessionId;
@@ -24,10 +24,14 @@ export const BranchSwitchPanel = ({ sessionId, onDone }: Props) => {
       : null,
   );
   const { showToast } = useToast();
-  const [branchMode, setBranchMode] = useState<'existing' | 'new'>('existing');
+  const [branchMode, setBranchMode] = useState<'existing' | 'new'>('new');
   const [branchTarget, setBranchTarget] = useState('');
-  const [branches, setBranches] = useState<ReadonlyArray<LocalBranchInfo>>([]);
-  const [isBranchesLoading, setIsBranchesLoading] = useState(false);
+  const [branches, setBranches] = useState<ReadonlyArray<LocalBranchInfo>>(() =>
+    workspace?.rootPath != null ? (getCachedLocalBranches(workspace.rootPath) ?? []) : [],
+  );
+  const [isBranchesLoading, setIsBranchesLoading] = useState(() =>
+    workspace?.rootPath != null ? getCachedLocalBranches(workspace.rootPath) == null : false,
+  );
   const [isBusy, setIsBusy] = useState(false);
   const [isReuseConfirmed, setIsReuseConfirmed] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -36,11 +40,30 @@ export const BranchSwitchPanel = ({ sessionId, onDone }: Props) => {
     if (workspace?.rootPath == null) {
       return;
     }
-    setIsBranchesLoading(true);
-    listLocalBranches(workspace.rootPath)
-      .then(setBranches)
-      .catch(() => setBranches([]))
-      .finally(() => setIsBranchesLoading(false));
+    const rootPath = workspace.rootPath;
+    const cached = getCachedLocalBranches(rootPath);
+    setBranches(cached ?? []);
+    setIsBranchesLoading(cached == null);
+    let cancelled = false;
+    listLocalBranches(rootPath)
+      .then((result) => {
+        if (!cancelled) {
+          setBranches(result);
+        }
+      })
+      .catch(() => {
+        if (!cancelled && cached == null) {
+          setBranches([]);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setIsBranchesLoading(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [workspace?.rootPath]);
 
   if (session == null || workspace == null || workspace.kind === 'simple') {
@@ -98,7 +121,11 @@ export const BranchSwitchPanel = ({ sessionId, onDone }: Props) => {
       <SegmentedTabs
         ariaLabel="branch source"
         options={[
-          { value: 'existing', label: 'Pick existing', disabled: isBusy },
+          {
+            value: 'existing',
+            label: isBranchesLoading ? 'Pick existing (loading)' : 'Pick existing',
+            disabled: isBusy,
+          },
           { value: 'new', label: 'Create new', disabled: isBusy },
         ]}
         value={branchMode}
@@ -126,6 +153,7 @@ export const BranchSwitchPanel = ({ sessionId, onDone }: Props) => {
         />
       ) : (
         <Input
+          autoFocus
           value={branchTarget}
           onChange={(event) => {
             setBranchTarget(event.target.value);
@@ -161,7 +189,7 @@ export const BranchSwitchPanel = ({ sessionId, onDone }: Props) => {
         <Button
           size="sm"
           onClick={() => void onChangeBranch()}
-          disabled={isBusy || isBranchesLoading || target === ''}
+          disabled={isBusy || target === '' || (branchMode === 'existing' && isBranchesLoading)}
           variant={needsConfirmation && isReuseConfirmed ? 'warning' : 'primary'}
           className={isBusy ? 'animate-border-pulse' : undefined}
         >

--- a/apps/desktop/src/features/worktree/BranchSwitchPanel/index.tsx
+++ b/apps/desktop/src/features/worktree/BranchSwitchPanel/index.tsx
@@ -29,9 +29,7 @@ export const BranchSwitchPanel = ({ sessionId, onDone }: Props) => {
   const [branches, setBranches] = useState<ReadonlyArray<LocalBranchInfo>>(() =>
     workspace?.rootPath != null ? (getCachedLocalBranches(workspace.rootPath) ?? []) : [],
   );
-  const [isBranchesLoading, setIsBranchesLoading] = useState(() =>
-    workspace?.rootPath != null ? getCachedLocalBranches(workspace.rootPath) == null : false,
-  );
+  const [isBranchesLoading, setIsBranchesLoading] = useState(() => workspace?.rootPath != null);
   const [isBusy, setIsBusy] = useState(false);
   const [isReuseConfirmed, setIsReuseConfirmed] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -43,7 +41,7 @@ export const BranchSwitchPanel = ({ sessionId, onDone }: Props) => {
     const rootPath = workspace.rootPath;
     const cached = getCachedLocalBranches(rootPath);
     setBranches(cached ?? []);
-    setIsBranchesLoading(cached == null);
+    setIsBranchesLoading(true);
     let cancelled = false;
     listLocalBranches(rootPath)
       .then((result) => {

--- a/apps/desktop/src/features/worktree/worktree.test.ts
+++ b/apps/desktop/src/features/worktree/worktree.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { invoke } = vi.hoisted(() => ({ invoke: vi.fn() }));
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke }));
+
+import {
+  getCachedLocalBranches,
+  invalidateLocalBranchesCache,
+  listLocalBranches,
+} from './worktree';
+
+describe('local branches cache', () => {
+  beforeEach(() => {
+    invoke.mockReset();
+    invalidateLocalBranchesCache('/repo-a');
+    invalidateLocalBranchesCache('/repo-b');
+  });
+
+  it('has nothing cached before the first fetch', () => {
+    expect(getCachedLocalBranches('/repo-a')).toBeUndefined();
+  });
+
+  it('populates the cache for the fetched repo path after listLocalBranches resolves', async () => {
+    const branches = [{ name: 'main', inUse: true, hasUncommitted: false }];
+    invoke.mockResolvedValue(branches);
+
+    const result = await listLocalBranches('/repo-a');
+
+    expect(result).toEqual(branches);
+    expect(getCachedLocalBranches('/repo-a')).toEqual(branches);
+  });
+
+  it('keys the cache per repo path', async () => {
+    invoke.mockResolvedValueOnce([{ name: 'main', inUse: false, hasUncommitted: false }]);
+    invoke.mockResolvedValueOnce([{ name: 'develop', inUse: false, hasUncommitted: true }]);
+
+    await listLocalBranches('/repo-a');
+    await listLocalBranches('/repo-b');
+
+    expect(getCachedLocalBranches('/repo-a')).toEqual([
+      { name: 'main', inUse: false, hasUncommitted: false },
+    ]);
+    expect(getCachedLocalBranches('/repo-b')).toEqual([
+      { name: 'develop', inUse: false, hasUncommitted: true },
+    ]);
+  });
+
+  it('clears only the invalidated repo path', async () => {
+    invoke.mockResolvedValueOnce([{ name: 'main', inUse: false, hasUncommitted: false }]);
+    invoke.mockResolvedValueOnce([{ name: 'develop', inUse: false, hasUncommitted: true }]);
+    await listLocalBranches('/repo-a');
+    await listLocalBranches('/repo-b');
+
+    invalidateLocalBranchesCache('/repo-a');
+
+    expect(getCachedLocalBranches('/repo-a')).toBeUndefined();
+    expect(getCachedLocalBranches('/repo-b')).toEqual([
+      { name: 'develop', inUse: false, hasUncommitted: true },
+    ]);
+  });
+});

--- a/apps/desktop/src/features/worktree/worktree.ts
+++ b/apps/desktop/src/features/worktree/worktree.ts
@@ -165,10 +165,20 @@ export type LocalBranchInfo = {
   readonly hasUncommitted: boolean;
 };
 
+const localBranchesCache = new Map<string, ReadonlyArray<LocalBranchInfo>>();
+
+export const getCachedLocalBranches = (
+  repoPath: string,
+): ReadonlyArray<LocalBranchInfo> | undefined => localBranchesCache.get(repoPath);
+
 export const listLocalBranches = async (
   repoPath: string,
 ): Promise<ReadonlyArray<LocalBranchInfo>> => {
-  return invoke<ReadonlyArray<LocalBranchInfo>>('worktree_list_local_branches', { repoPath });
+  const branches = await invoke<ReadonlyArray<LocalBranchInfo>>('worktree_list_local_branches', {
+    repoPath,
+  });
+  localBranchesCache.set(repoPath, branches);
+  return branches;
 };
 
 export type ChangeBranchArgs = {

--- a/apps/desktop/src/features/worktree/worktree.ts
+++ b/apps/desktop/src/features/worktree/worktree.ts
@@ -171,6 +171,10 @@ export const getCachedLocalBranches = (
   repoPath: string,
 ): ReadonlyArray<LocalBranchInfo> | undefined => localBranchesCache.get(repoPath);
 
+export const invalidateLocalBranchesCache = (repoPath: string): void => {
+  localBranchesCache.delete(repoPath);
+};
+
 export const listLocalBranches = async (
   repoPath: string,
 ): Promise<ReadonlyArray<LocalBranchInfo>> => {

--- a/apps/desktop/src/store/slices/worktrees/changeSessionBranch.ts
+++ b/apps/desktop/src/store/slices/worktrees/changeSessionBranch.ts
@@ -1,7 +1,10 @@
 import type { SessionId } from '@goodboy/types';
 import { listWorktreesForSession, updateSessionWorktreeBranch } from '@goodboy/db';
 import { tauriDatabase } from '../../../shared/lib/db';
-import { changeWorktreeBranch } from '../../../features/worktree/worktree';
+import {
+  changeWorktreeBranch,
+  invalidateLocalBranchesCache,
+} from '../../../features/worktree/worktree';
 import type { GetFn, SetFn } from './types';
 
 type Args = {
@@ -36,6 +39,7 @@ export const changeSessionBranch = (set: SetFn, get: GetFn) => {
       branch: target,
       createNew,
     });
+    invalidateLocalBranchesCache(workspace.rootPath);
     await updateSessionWorktreeBranch(tauriDatabase, sessionId, primary.parallelIndex, target);
     set((state) => {
       const nextGithub = { ...state.sessionGithub };


### PR DESCRIPTION
## Summary

Fixes the branch switch popover on the session overview branch chip, which could take a long time to appear and always opened on the tab that could least help you get started quickly.

**What was broken**

- `worktree_list_local_branches` was a synchronous Tauri command. In Tauri 2, non-async commands run on the app's main thread, so listing branches (which shells out to git several times, once per worktree in use, in sequence) froze the whole UI for as long as that took. The more worktrees you had checked out, the worse it got.
- The popover always opened on the "Pick existing" tab, the one tab that actually needs that branch list. If you knew the branch name you wanted to type, you still had to sit through the same stall before you could do anything.
- There was no cache: closing and reopening the popover paid the same cost every time, even for a repo that hadn't changed.

**What changed**

- The branch-listing command is now async (`spawn_blocking`, the same pattern used by the other async commands in this codebase) and no longer blocks rendering. The per-branch "does this worktree have uncommitted changes" check now runs in parallel instead of one branch at a time.
- The popover now opens on "Create new" by default, with the branch name field focused immediately, so typing a new branch name has zero wait.
- The "Pick existing" tab still starts loading its list in the background as soon as the popover opens. While that's in flight, the tab's own label says so, and the tab stays fully clickable, no more silently stale warnings about a branch being in use or dirty until the list is actually ready.
- The branch list is now cached per repository. Reopening the popover shows the previous list instantly while a fresh copy loads quietly underneath it.

**How this was verified**

- `pnpm --filter @goodboy/desktop typecheck`: clean.
- `npx vitest run` on `BranchSwitchPanel` and `BranchChip`: 9 tests passed, including two new ones covering the default "Create new" tab and the loading state on "Pick existing".
- `cargo test --locked` in `apps/desktop/src-tauri`: 119 passed, 0 failed, 2 ignored (pre-existing, opt-in tests that need a real Codex login).
- No changes to the click-to-copy or hover-edit behavior on the branch chip, and no new network calls were added.
