### PR TITLE
Resolve and Agents: active and completed filters with honest counts

### DIFF
--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/lib.test.ts
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/lib.test.ts
@@ -9,7 +9,7 @@ import type {
   WorkflowId,
   WorkspaceId,
 } from '@goodboy/types';
-import { pluralize, resolverStatus, workflowKindName } from './lib';
+import { defaultCompletionTab, pluralize, resolverStatus, workflowKindName } from './lib';
 
 const NOW = '2026-05-15T00:00:00.000Z' as IsoDateTime;
 const SESSION = 'sess_1' as SessionId;
@@ -63,6 +63,21 @@ describe('pluralize', () => {
 
   it('pluralizes counts above one', () => {
     expect(pluralize(3, 'agent')).toBe('3 agents');
+  });
+});
+
+describe('defaultCompletionTab', () => {
+  it('defaults to active when there is anything active', () => {
+    expect(defaultCompletionTab({ activeCount: 1, completedCount: 0 })).toBe('active');
+    expect(defaultCompletionTab({ activeCount: 2, completedCount: 3 })).toBe('active');
+  });
+
+  it('opens on completed when active is empty but completed is not', () => {
+    expect(defaultCompletionTab({ activeCount: 0, completedCount: 1 })).toBe('completed');
+  });
+
+  it('defaults to active when both are empty', () => {
+    expect(defaultCompletionTab({ activeCount: 0, completedCount: 0 })).toBe('active');
   });
 });
 

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/lib.test.ts
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/lib.test.ts
@@ -9,7 +9,7 @@ import type {
   WorkflowId,
   WorkspaceId,
 } from '@goodboy/types';
-import { defaultCompletionTab, pluralize, resolverStatus, workflowKindName } from './lib';
+import { pluralize, resolveCompletionTab, resolverStatus, workflowKindName } from './lib';
 
 const NOW = '2026-05-15T00:00:00.000Z' as IsoDateTime;
 const SESSION = 'sess_1' as SessionId;
@@ -66,18 +66,53 @@ describe('pluralize', () => {
   });
 });
 
-describe('defaultCompletionTab', () => {
-  it('defaults to active when there is anything active', () => {
-    expect(defaultCompletionTab({ activeCount: 1, completedCount: 0 })).toBe('active');
-    expect(defaultCompletionTab({ activeCount: 2, completedCount: 3 })).toBe('active');
+describe('resolveCompletionTab', () => {
+  it('defaults to active when there is anything active and nothing selected', () => {
+    expect(resolveCompletionTab({ activeCount: 1, completedCount: 0, selected: null })).toBe(
+      'active',
+    );
+    expect(resolveCompletionTab({ activeCount: 2, completedCount: 3, selected: null })).toBe(
+      'active',
+    );
   });
 
-  it('opens on completed when active is empty but completed is not', () => {
-    expect(defaultCompletionTab({ activeCount: 0, completedCount: 1 })).toBe('completed');
+  it('opens on completed when active is empty but completed is not and nothing selected', () => {
+    expect(resolveCompletionTab({ activeCount: 0, completedCount: 1, selected: null })).toBe(
+      'completed',
+    );
   });
 
-  it('defaults to active when both are empty', () => {
-    expect(defaultCompletionTab({ activeCount: 0, completedCount: 0 })).toBe('active');
+  it('defaults to active when both are empty and nothing selected', () => {
+    expect(resolveCompletionTab({ activeCount: 0, completedCount: 0, selected: null })).toBe(
+      'active',
+    );
+  });
+
+  it('keeps an explicit selection that still has items', () => {
+    expect(resolveCompletionTab({ activeCount: 2, completedCount: 1, selected: 'completed' })).toBe(
+      'completed',
+    );
+    expect(resolveCompletionTab({ activeCount: 2, completedCount: 1, selected: 'active' })).toBe(
+      'active',
+    );
+  });
+
+  it('falls back to completed when the explicitly selected active tab empties out', () => {
+    expect(resolveCompletionTab({ activeCount: 0, completedCount: 1, selected: 'active' })).toBe(
+      'completed',
+    );
+  });
+
+  it('falls back to active when the explicitly selected completed tab empties out', () => {
+    expect(resolveCompletionTab({ activeCount: 1, completedCount: 0, selected: 'completed' })).toBe(
+      'active',
+    );
+  });
+
+  it('keeps the explicit selection when both tabs are empty', () => {
+    expect(resolveCompletionTab({ activeCount: 0, completedCount: 0, selected: 'completed' })).toBe(
+      'completed',
+    );
   });
 });
 

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/lib.ts
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/lib.ts
@@ -29,13 +29,26 @@ export type ResolverStatus =
 
 export type CompletionTab = 'active' | 'completed';
 
-export const defaultCompletionTab = ({
+export const resolveCompletionTab = ({
   activeCount,
   completedCount,
+  selected,
 }: {
   readonly activeCount: number;
   readonly completedCount: number;
-}): CompletionTab => (activeCount === 0 && completedCount > 0 ? 'completed' : 'active');
+  readonly selected: CompletionTab | null;
+}): CompletionTab => {
+  if (selected == null) {
+    return activeCount === 0 && completedCount > 0 ? 'completed' : 'active';
+  }
+  const other: CompletionTab = selected === 'active' ? 'completed' : 'active';
+  const selectedCount = selected === 'active' ? activeCount : completedCount;
+  const otherCount = selected === 'active' ? completedCount : activeCount;
+  if (selectedCount === 0 && otherCount > 0) {
+    return other;
+  }
+  return selected;
+};
 
 export const resolverStatus = (
   agent: Agent,

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/lib.ts
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/lib.ts
@@ -27,6 +27,16 @@ export type ResolverStatus =
   | 'stopped'
   | 'done';
 
+export type CompletionTab = 'active' | 'completed';
+
+export const defaultCompletionTab = ({
+  activeCount,
+  completedCount,
+}: {
+  readonly activeCount: number;
+  readonly completedCount: number;
+}): CompletionTab => (activeCount === 0 && completedCount > 0 ? 'completed' : 'active');
+
 export const resolverStatus = (
   agent: Agent,
   resolvedThreadIds: ReadonlySet<string>,

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.test.tsx
@@ -347,6 +347,54 @@ describe('AgentsSection collapse defaults', () => {
     ]);
   });
 
+  it('moves from an empty Active view to Completed when the only agent is marked done while mounted', () => {
+    h.state.sessionPhaseRuns = {
+      [SESSION_ID]: [buildAgent({ id: 'solo' as AgentId, name: 'solo agent' })],
+    };
+    const { rerender } = render(<AgentsSection task={buildSession()} only="agents" />);
+
+    expect(screen.getByText('solo agent')).toBeDefined();
+    expect(screen.queryByRole('tablist')).toBeNull();
+
+    h.state.sessionPhaseRuns = {
+      [SESSION_ID]: [buildAgent({ id: 'solo' as AgentId, name: 'solo agent', doneAt: NOW })],
+    };
+    rerender(<AgentsSection task={buildSession()} only="agents" />);
+
+    expect(screen.getByRole('tab', { name: 'Completed (1)' }).getAttribute('aria-selected')).toBe(
+      'true',
+    );
+    expect(screen.getByText('solo agent')).toBeDefined();
+  });
+
+  it('keeps the explicitly selected agents tab when it still has items after props change', () => {
+    h.state.sessionPhaseRuns = {
+      [SESSION_ID]: [
+        buildAgent({ id: 'active-1' as AgentId, name: 'active one' }),
+        buildAgent({ id: 'done-1' as AgentId, name: 'done one', doneAt: NOW }),
+      ],
+    };
+    const { rerender } = render(<AgentsSection task={buildSession()} only="agents" />);
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Completed (1)' }));
+    expect(screen.getByText('done one')).toBeDefined();
+
+    h.state.sessionPhaseRuns = {
+      [SESSION_ID]: [
+        buildAgent({ id: 'active-1' as AgentId, name: 'active one' }),
+        buildAgent({ id: 'active-2' as AgentId, name: 'active two' }),
+        buildAgent({ id: 'done-1' as AgentId, name: 'done one', doneAt: NOW }),
+      ],
+    };
+    rerender(<AgentsSection task={buildSession()} only="agents" />);
+
+    expect(screen.getByRole('tab', { name: 'Completed (1)' }).getAttribute('aria-selected')).toBe(
+      'true',
+    );
+    expect(screen.getByText('done one')).toBeDefined();
+    expect(screen.queryByText('active two')).toBeNull();
+  });
+
   it('workflow unread badge counts step agents and their cluster children', () => {
     const RUN_ID = 'run-1' as WorkflowRunId;
     const workflow = {

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.test.tsx
@@ -47,6 +47,31 @@ vi.mock('@goodboy/ui', () => ({
     </div>
   ),
   cn: (...a: unknown[]) => a.filter(Boolean).join(' '),
+  SegmentedTabs: ({
+    options,
+    value,
+    onChange,
+    ariaLabel,
+  }: {
+    options: ReadonlyArray<{ value: string; label: string }>;
+    value: string;
+    onChange: (value: string) => void;
+    ariaLabel: string;
+  }) => (
+    <div role="tablist" aria-label={ariaLabel}>
+      {options.map((option) => (
+        <button
+          key={option.value}
+          type="button"
+          role="tab"
+          aria-selected={option.value === value}
+          onClick={() => onChange(option.value)}
+        >
+          {option.label}
+        </button>
+      ))}
+    </div>
+  ),
 }));
 
 vi.mock('./SectionToggle', () => ({
@@ -259,7 +284,7 @@ describe('AgentsSection collapse defaults', () => {
     expect(screen.getByTestId('collapsed').textContent).toBe('1 agent');
   });
 
-  it('partitions user-completed agents into a collapsed done group', () => {
+  it('filters standalone agents to the active tab by default, hiding completed ones', () => {
     h.state.sessionPhaseRuns = {
       [SESSION_ID]: [
         buildAgent({ id: 'active' as AgentId, name: 'active agent' }),
@@ -271,13 +296,14 @@ describe('AgentsSection collapse defaults', () => {
 
     expect(screen.getByText('active agent')).toBeDefined();
     expect(screen.queryByText('done agent')).toBeNull();
-    fireEvent.click(screen.getByRole('button', { name: 'Done (1)' }));
+    fireEvent.click(screen.getByRole('tab', { name: 'Completed (1)' }));
+    expect(screen.queryByText('active agent')).toBeNull();
     expect(screen.getByText('done agent').closest('[data-muted]')?.getAttribute('data-muted')).toBe(
       'true',
     );
   });
 
-  it('renders active and done standalone agents newest-first', () => {
+  it('renders active and completed standalone agents newest-first within their own tab', () => {
     h.state.sessionPhaseRuns = {
       [SESSION_ID]: [
         buildAgent({ id: 'active-old' as AgentId, name: 'active old', ordinal: 0 }),
@@ -288,11 +314,34 @@ describe('AgentsSection collapse defaults', () => {
     };
 
     render(<AgentsSection task={buildSession()} only="agents" />);
-    fireEvent.click(screen.getByRole('button', { name: 'Done (2)' }));
 
     expect(screen.getAllByTestId('agent-row').map((row) => row.textContent)).toEqual([
       'active new',
       'active old',
+    ]);
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Completed (2)' }));
+
+    expect(screen.getAllByTestId('agent-row').map((row) => row.textContent)).toEqual([
+      'done new',
+      'done old',
+    ]);
+  });
+
+  it('opens on the completed tab by default when there are no active agents', () => {
+    h.state.sessionPhaseRuns = {
+      [SESSION_ID]: [
+        buildAgent({ id: 'done-old' as AgentId, name: 'done old', ordinal: 0, doneAt: NOW }),
+        buildAgent({ id: 'done-new' as AgentId, name: 'done new', ordinal: 1, doneAt: NOW }),
+      ],
+    };
+
+    render(<AgentsSection task={buildSession()} only="agents" />);
+
+    expect(screen.getByRole('tab', { name: 'Completed (2)' }).getAttribute('aria-selected')).toBe(
+      'true',
+    );
+    expect(screen.getAllByTestId('agent-row').map((row) => row.textContent)).toEqual([
       'done new',
       'done old',
     ]);

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.tsx
@@ -1,10 +1,11 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { EmptyState, SectionHeader, cn } from '@goodboy/ui';
-import { ArrowUpRight, CheckCheck, ChevronDown, ChevronRight } from 'lucide-react';
+import { ArrowUpRight, CheckCheck } from 'lucide-react';
 import { ScriptsSection } from '../../../../scripts/components/ScriptsSection';
 import { DogMascot } from '../../../../../shared/components/DogMascot';
 import { SECTION_ICONS } from '../../../../../shared/components/section-icons';
+import { SegmentedControl } from '../../../../../shared/components/SegmentedControl';
 import type {
   Agent,
   AgentId,
@@ -41,7 +42,13 @@ import { WorkflowStartButton } from './WorkflowStartButton';
 import { CollapsedSummary } from './CollapsedSummary';
 import { AdHocRow } from './AdHocRow';
 import { WorkflowRow } from './WorkflowRow';
-import { pluralize, workflowKindName, type ResolverState } from '../lib';
+import {
+  defaultCompletionTab,
+  pluralize,
+  workflowKindName,
+  type CompletionTab,
+  type ResolverState,
+} from '../lib';
 
 const LIST_CLASS = 'flex flex-col gap-1 pl-2';
 const FIRST_HEADER_CLASS = 'pb-1.5';
@@ -183,7 +190,6 @@ export const AgentsSection = ({
   const focusedWorkflowRunId = useAppStore((s) => s.focusedWorkflowRunId?.[task.id] ?? null);
   const toggleWorkflowExpand = useAppStore((s) => s.toggleWorkflowExpand);
   const [resolveExpanded, setResolveExpanded] = useState(true);
-  const [doneExpanded, setDoneExpanded] = useState(false);
   const setPanelSectionExpanded = useAppStore((s) => s.setPanelSectionExpanded);
   const workflowExpanded = useAppStore((s) => s.sessionPanelExpanded[task.id]?.workflow ?? true);
   const [clusterExpand, setClusterExpand] = useState<ReadonlyMap<string, boolean>>(new Map());
@@ -382,6 +388,17 @@ export const AgentsSection = ({
       only === 'agents' ? standaloneAgents.filter((agent) => agent.doneAt != null) : EMPTY_ARRAY,
     [only, standaloneAgents],
   );
+  const showCompletedAgentsTab = only === 'agents' && doneStandaloneAgents.length > 0;
+  const [agentsTab, setAgentsTab] = useState<CompletionTab>(() =>
+    defaultCompletionTab({
+      activeCount: activeStandaloneAgents.length,
+      completedCount: doneStandaloneAgents.length,
+    }),
+  );
+  const visibleStandaloneAgents =
+    showCompletedAgentsTab && agentsTab === 'completed'
+      ? doneStandaloneAgents
+      : activeStandaloneAgents;
   const commentByThreadId = useMemo(() => {
     const map = new Map<string, PrComment>();
     for (const c of prComments) {
@@ -493,6 +510,39 @@ export const AgentsSection = ({
   const wfExpanded = forceExpanded || workflowExpanded;
   const agExpanded = forceExpanded || agentsExpanded;
 
+  const standaloneAgentList = (
+    <ul className={LIST_CLASS}>
+      {visibleStandaloneAgents.map((run, index) => (
+        <AdHocRow
+          key={run.id}
+          run={run}
+          index={index}
+          firstUserTextByAgentId={firstUserTextByAgentId}
+          agentKindOverride={agentKindOverride}
+          childrenByParentId={childrenByParentId}
+          latestTelemetryByAgentId={metrics.latestTelemetryByAgentId}
+          aggregatesByAgentId={metrics.aggregatesByAgentId}
+          providerUsageByAgentId={metrics.providerUsageByAgentId}
+          turnsByAgentId={metrics.turnsByAgentId}
+          selectedAgentId={selectedAgentId}
+          isTranscriptLoading={loading.transcript}
+          isTaskActive={isTaskActive}
+          editingId={editingId}
+          setEditingId={setEditingId}
+          clusterExpand={clusterExpand}
+          toggleClusterExpand={toggleClusterExpand}
+          onPickAgent={onPickAgent}
+          onRenameCommit={onRenameCommit}
+          onDeleteAgent={onDeleteAgent}
+          isInspected={run.id === inspectedAgentId}
+          onInspectAgent={onInspectAgent}
+          onMarkDone={(id) => void setAgentDone(task.id, id)}
+          isMuted={agentsTab === 'completed'}
+        />
+      ))}
+    </ul>
+  );
+
   return (
     <section className="flex flex-col">
       {showWorkflows ? (
@@ -596,37 +646,22 @@ export const AgentsSection = ({
           )}
           {agExpanded ? (
             <>
+              {showCompletedAgentsTab ? (
+                <div className="px-2 pb-1">
+                  <SegmentedControl
+                    ariaLabel="Filter agents by status"
+                    options={[
+                      { value: 'active', label: `Active (${activeStandaloneAgents.length})` },
+                      { value: 'completed', label: `Completed (${doneStandaloneAgents.length})` },
+                    ]}
+                    value={agentsTab}
+                    onChange={setAgentsTab}
+                  />
+                </div>
+              ) : null}
               {hasAnyWorkflow ? (
-                activeStandaloneAgents.length > 0 ? (
-                  <ul className={LIST_CLASS}>
-                    {activeStandaloneAgents.map((run, index) => (
-                      <AdHocRow
-                        key={run.id}
-                        run={run}
-                        index={index}
-                        firstUserTextByAgentId={firstUserTextByAgentId}
-                        agentKindOverride={agentKindOverride}
-                        childrenByParentId={childrenByParentId}
-                        latestTelemetryByAgentId={metrics.latestTelemetryByAgentId}
-                        aggregatesByAgentId={metrics.aggregatesByAgentId}
-                        providerUsageByAgentId={metrics.providerUsageByAgentId}
-                        turnsByAgentId={metrics.turnsByAgentId}
-                        selectedAgentId={selectedAgentId}
-                        isTranscriptLoading={loading.transcript}
-                        isTaskActive={isTaskActive}
-                        editingId={editingId}
-                        setEditingId={setEditingId}
-                        clusterExpand={clusterExpand}
-                        toggleClusterExpand={toggleClusterExpand}
-                        onPickAgent={onPickAgent}
-                        onRenameCommit={onRenameCommit}
-                        onDeleteAgent={onDeleteAgent}
-                        isInspected={run.id === inspectedAgentId}
-                        onInspectAgent={onInspectAgent}
-                        onMarkDone={(id) => void setAgentDone(task.id, id)}
-                      />
-                    ))}
-                  </ul>
+                visibleStandaloneAgents.length > 0 ? (
+                  standaloneAgentList
                 ) : null
               ) : standaloneAgents.length === 0 ? (
                 loading.agents ? (
@@ -661,83 +696,8 @@ export const AgentsSection = ({
                     </p>
                   )
                 ) : null
-              ) : (
-                <ul className={LIST_CLASS}>
-                  {activeStandaloneAgents.map((run, index) => (
-                    <AdHocRow
-                      key={run.id}
-                      run={run}
-                      index={index}
-                      firstUserTextByAgentId={firstUserTextByAgentId}
-                      agentKindOverride={agentKindOverride}
-                      childrenByParentId={childrenByParentId}
-                      latestTelemetryByAgentId={metrics.latestTelemetryByAgentId}
-                      aggregatesByAgentId={metrics.aggregatesByAgentId}
-                      providerUsageByAgentId={metrics.providerUsageByAgentId}
-                      turnsByAgentId={metrics.turnsByAgentId}
-                      selectedAgentId={selectedAgentId}
-                      isTranscriptLoading={loading.transcript}
-                      isTaskActive={isTaskActive}
-                      editingId={editingId}
-                      setEditingId={setEditingId}
-                      clusterExpand={clusterExpand}
-                      toggleClusterExpand={toggleClusterExpand}
-                      onPickAgent={onPickAgent}
-                      onRenameCommit={onRenameCommit}
-                      onDeleteAgent={onDeleteAgent}
-                      isInspected={run.id === inspectedAgentId}
-                      onInspectAgent={onInspectAgent}
-                      onMarkDone={(id) => void setAgentDone(task.id, id)}
-                    />
-                  ))}
-                </ul>
-              )}
-              {doneStandaloneAgents.length > 0 ? (
-                <button
-                  type="button"
-                  onClick={() => setDoneExpanded((current) => !current)}
-                  aria-expanded={doneExpanded}
-                  className="flex items-center gap-1 self-start rounded px-2 py-0.5 text-2xs text-muted-foreground transition-colors hover:text-foreground"
-                >
-                  {doneExpanded ? (
-                    <ChevronDown size={11} aria-hidden className="shrink-0" />
-                  ) : (
-                    <ChevronRight size={11} aria-hidden className="shrink-0" />
-                  )}
-                  Done ({doneStandaloneAgents.length})
-                </button>
-              ) : null}
-              {doneExpanded ? (
-                <ul className={LIST_CLASS}>
-                  {doneStandaloneAgents.map((run, index) => (
-                    <AdHocRow
-                      key={run.id}
-                      run={run}
-                      index={activeStandaloneAgents.length + index}
-                      firstUserTextByAgentId={firstUserTextByAgentId}
-                      agentKindOverride={agentKindOverride}
-                      childrenByParentId={childrenByParentId}
-                      latestTelemetryByAgentId={metrics.latestTelemetryByAgentId}
-                      aggregatesByAgentId={metrics.aggregatesByAgentId}
-                      providerUsageByAgentId={metrics.providerUsageByAgentId}
-                      turnsByAgentId={metrics.turnsByAgentId}
-                      selectedAgentId={selectedAgentId}
-                      isTranscriptLoading={loading.transcript}
-                      isTaskActive={isTaskActive}
-                      editingId={editingId}
-                      setEditingId={setEditingId}
-                      clusterExpand={clusterExpand}
-                      toggleClusterExpand={toggleClusterExpand}
-                      onPickAgent={onPickAgent}
-                      onRenameCommit={onRenameCommit}
-                      onDeleteAgent={onDeleteAgent}
-                      isInspected={run.id === inspectedAgentId}
-                      onInspectAgent={onInspectAgent}
-                      onMarkDone={(id) => void setAgentDone(task.id, id)}
-                      isMuted
-                    />
-                  ))}
-                </ul>
+              ) : visibleStandaloneAgents.length > 0 ? (
+                standaloneAgentList
               ) : null}
               <SpawnAgentControl sessionId={task.id} />
               {spawnError ? <p className="mt-1 px-2 text-2xs text-danger">{spawnError}</p> : null}

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.tsx
@@ -43,8 +43,8 @@ import { CollapsedSummary } from './CollapsedSummary';
 import { AdHocRow } from './AdHocRow';
 import { WorkflowRow } from './WorkflowRow';
 import {
-  defaultCompletionTab,
   pluralize,
+  resolveCompletionTab,
   workflowKindName,
   type CompletionTab,
   type ResolverState,
@@ -389,12 +389,12 @@ export const AgentsSection = ({
     [only, standaloneAgents],
   );
   const showCompletedAgentsTab = only === 'agents' && doneStandaloneAgents.length > 0;
-  const [agentsTab, setAgentsTab] = useState<CompletionTab>(() =>
-    defaultCompletionTab({
-      activeCount: activeStandaloneAgents.length,
-      completedCount: doneStandaloneAgents.length,
-    }),
-  );
+  const [selectedAgentsTab, setSelectedAgentsTab] = useState<CompletionTab | null>(null);
+  const agentsTab = resolveCompletionTab({
+    activeCount: activeStandaloneAgents.length,
+    completedCount: doneStandaloneAgents.length,
+    selected: selectedAgentsTab,
+  });
   const visibleStandaloneAgents =
     showCompletedAgentsTab && agentsTab === 'completed'
       ? doneStandaloneAgents
@@ -655,7 +655,7 @@ export const AgentsSection = ({
                       { value: 'completed', label: `Completed (${doneStandaloneAgents.length})` },
                     ]}
                     value={agentsTab}
-                    onChange={setAgentsTab}
+                    onChange={setSelectedAgentsTab}
                   />
                 </div>
               ) : null}

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/ResolveCluster.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/ResolveCluster.test.tsx
@@ -48,50 +48,93 @@ const newestCompleted = {
   name: 'Newest completed resolver',
   sourceThreadId: 'PRRT_2',
 } satisfies Agent;
+const finishedUnconfirmed = {
+  id: 'finished-unconfirmed' as AgentId,
+  sessionId: SESSION_ID,
+  ordinal: 0,
+  name: 'Solo resolver',
+  status: 'completed',
+} satisfies Agent;
+
+const baseProps = {
+  sessionId: SESSION_ID,
+  isTaskActive: true,
+  prNumber: null,
+  pendingThreadIds: new Set<string>(),
+  resolverState: {},
+  commentByThreadId: new Map(),
+  diffCommentByAgentId: new Map(),
+  metrics: {
+    latestTelemetryByAgentId: new Map(),
+    aggregatesByAgentId: new Map(),
+    providerUsageByAgentId: new Map(),
+    turnsByAgentId: new Map(),
+  },
+  isTranscriptLoading: false,
+  selectedAgentId: null,
+  expanded: true,
+  onToggle: vi.fn(),
+  onSelect: vi.fn(),
+  onForceNext: vi.fn(),
+  onResolveThread: vi.fn(),
+  onResolveAgent: vi.fn(),
+};
 
 describe('ResolveCluster', () => {
   afterEach(cleanup);
 
-  it('keeps active resolvers visible and completed resolvers collapsed', () => {
+  it('shows only the active resolvers by default and filters to completed via the segmented tab', () => {
     render(
       <ResolveCluster
+        {...baseProps}
         agents={[active, completed, newerActive, newestCompleted]}
-        sessionId={SESSION_ID}
-        isTaskActive
-        prNumber={null}
         resolvedThreadIds={new Set(['PRRT_1', 'PRRT_2'])}
-        pendingThreadIds={new Set()}
-        resolverState={{}}
-        commentByThreadId={new Map()}
-        diffCommentByAgentId={new Map()}
-        metrics={{
-          latestTelemetryByAgentId: new Map(),
-          aggregatesByAgentId: new Map(),
-          providerUsageByAgentId: new Map(),
-          turnsByAgentId: new Map(),
-        }}
-        isTranscriptLoading={false}
-        selectedAgentId={null}
-        expanded
-        onToggle={vi.fn()}
-        onSelect={vi.fn()}
-        onForceNext={vi.fn()}
-        onResolveThread={vi.fn()}
-        onResolveAgent={vi.fn()}
       />,
     );
 
     expect(screen.getByText('Newer active resolver:pending')).toBeDefined();
     expect(screen.getByText('Active resolver:running')).toBeDefined();
     expect(screen.queryByText('Completed resolver:resolved')).toBeNull();
+    expect(screen.queryByText('Newest completed resolver:resolved')).toBeNull();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Completed (2)' }));
+    fireEvent.click(screen.getByRole('tab', { name: 'Completed (2)' }));
 
+    expect(screen.queryByText('Newer active resolver:pending')).toBeNull();
+    expect(screen.queryByText('Active resolver:running')).toBeNull();
     expect(screen.getAllByText(/resolver:/).map((row) => row.textContent)).toEqual([
-      'Newer active resolver:pending',
-      'Active resolver:running',
       'Newest completed resolver:resolved',
       'Completed resolver:resolved',
     ]);
+  });
+
+  it('opens on Completed by default when there are no active resolvers', () => {
+    render(
+      <ResolveCluster
+        {...baseProps}
+        agents={[completed, newestCompleted]}
+        resolvedThreadIds={new Set(['PRRT_1', 'PRRT_2'])}
+      />,
+    );
+
+    expect(screen.getByRole('tab', { name: 'Completed (2)' }).getAttribute('aria-selected')).toBe(
+      'true',
+    );
+    expect(screen.getAllByText(/resolver:/).map((row) => row.textContent)).toEqual([
+      'Newest completed resolver:resolved',
+      'Completed resolver:resolved',
+    ]);
+  });
+
+  it('does not show a contradictory ratio for a resolver finished without github confirmation', () => {
+    const { container } = render(
+      <ResolveCluster
+        {...baseProps}
+        agents={[finishedUnconfirmed]}
+        resolvedThreadIds={new Set()}
+      />,
+    );
+
+    expect(container.textContent).not.toMatch(/\d+\/\d+/);
+    expect(screen.getByText('Solo resolver:done')).toBeDefined();
   });
 });

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/ResolveCluster.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/ResolveCluster.test.tsx
@@ -137,4 +137,65 @@ describe('ResolveCluster', () => {
     expect(container.textContent).not.toMatch(/\d+\/\d+/);
     expect(screen.getByText('Solo resolver:done')).toBeDefined();
   });
+
+  it('moves from an empty Active view to Completed when the only resolver finishes while mounted', () => {
+    const solo = {
+      id: 'solo' as AgentId,
+      sessionId: SESSION_ID,
+      ordinal: 0,
+      name: 'Solo resolver',
+      status: 'running',
+    } satisfies Agent;
+
+    const { rerender } = render(
+      <ResolveCluster {...baseProps} agents={[solo]} resolvedThreadIds={new Set()} />,
+    );
+
+    expect(screen.getByText('Solo resolver:running')).toBeDefined();
+    expect(screen.queryByRole('tablist')).toBeNull();
+
+    const soloDone = {
+      ...solo,
+      status: 'completed',
+      sourceThreadId: 'PRRT_9',
+    } satisfies Agent;
+
+    rerender(
+      <ResolveCluster {...baseProps} agents={[soloDone]} resolvedThreadIds={new Set(['PRRT_9'])} />,
+    );
+
+    expect(screen.getByRole('tab', { name: 'Completed (1)' }).getAttribute('aria-selected')).toBe(
+      'true',
+    );
+    expect(screen.getByText('Solo resolver:resolved')).toBeDefined();
+    expect(screen.queryByText('Solo resolver:running')).toBeNull();
+  });
+
+  it('keeps the explicitly selected tab when it still has items after props change', () => {
+    const { rerender } = render(
+      <ResolveCluster
+        {...baseProps}
+        agents={[active, completed]}
+        resolvedThreadIds={new Set(['PRRT_1'])}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Completed (1)' }));
+    expect(screen.getByRole('tab', { name: 'Completed (1)' }).getAttribute('aria-selected')).toBe(
+      'true',
+    );
+
+    rerender(
+      <ResolveCluster
+        {...baseProps}
+        agents={[active, completed, newerActive]}
+        resolvedThreadIds={new Set(['PRRT_1'])}
+      />,
+    );
+
+    expect(screen.getByRole('tab', { name: 'Completed (1)' }).getAttribute('aria-selected')).toBe(
+      'true',
+    );
+    expect(screen.getByText('Completed resolver:resolved')).toBeDefined();
+  });
 });

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/ResolveCluster.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/ResolveCluster.tsx
@@ -5,8 +5,8 @@ import { openUrl } from '../../../../../shared/lib/editor';
 import { SegmentedControl } from '../../../../../shared/components/SegmentedControl';
 import type { AgentMetrics } from '../../../../session/hooks/useAgentMetrics';
 import {
-  defaultCompletionTab,
   pluralize,
+  resolveCompletionTab,
   resolverStatus,
   type CompletionTab,
   type ResolverState,
@@ -74,12 +74,12 @@ export const ResolveCluster = ({
     .map((agent) => ({ agent, status: statusOf(agent) }));
   const completedEntries = entries.filter(({ status }) => COMPLETED_STATUSES.includes(status));
   const activeEntries = entries.filter(({ status }) => !COMPLETED_STATUSES.includes(status));
-  const [tab, setTab] = useState<CompletionTab>(() =>
-    defaultCompletionTab({
-      activeCount: activeEntries.length,
-      completedCount: completedEntries.length,
-    }),
-  );
+  const [selectedTab, setSelectedTab] = useState<CompletionTab | null>(null);
+  const tab = resolveCompletionTab({
+    activeCount: activeEntries.length,
+    completedCount: completedEntries.length,
+    selected: selectedTab,
+  });
   const visibleEntries = tab === 'completed' ? completedEntries : activeEntries;
   const anyRunning = agents.some((a) => a.status === 'running');
   const queuedCount = agents.filter((a) => a.status === 'pending').length;
@@ -157,7 +157,7 @@ export const ResolveCluster = ({
                 { value: 'completed', label: `Completed (${completedEntries.length})` },
               ]}
               value={tab}
-              onChange={setTab}
+              onChange={setSelectedTab}
             />
           ) : null}
           <ResolverRows

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/ResolveCluster.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/ResolveCluster.tsx
@@ -2,10 +2,25 @@ import { useState } from 'react';
 import { ArrowUpRight, ChevronDown, ChevronRight, MessageSquareReply, Play } from 'lucide-react';
 import type { Agent, AgentId, DiffComment, PrComment, SessionId } from '@goodboy/types';
 import { openUrl } from '../../../../../shared/lib/editor';
+import { SegmentedControl } from '../../../../../shared/components/SegmentedControl';
 import type { AgentMetrics } from '../../../../session/hooks/useAgentMetrics';
-import { resolverStatus, type ResolverState, type ResolverStatus } from '../lib';
+import {
+  defaultCompletionTab,
+  pluralize,
+  resolverStatus,
+  type CompletionTab,
+  type ResolverState,
+  type ResolverStatus,
+} from '../lib';
 import { ResolverRows } from './ResolverRows';
 import { agentThreadIds } from '../../../../session/agentThreadIds';
+
+const COMPLETED_STATUSES: ReadonlyArray<ResolverStatus> = [
+  'resolved',
+  'wontfix',
+  'stopped',
+  'done',
+];
 
 type ResolveClusterProps = {
   readonly agents: ReadonlyArray<Agent>;
@@ -52,19 +67,20 @@ export const ResolveCluster = ({
   onResolveThread,
   onResolveAgent,
 }: ResolveClusterProps) => {
-  const [isCompletedExpanded, setIsCompletedExpanded] = useState(false);
   const statusOf = (a: Agent): ResolverStatus =>
     resolverStatus(a, resolvedThreadIds, pendingThreadIds, resolverState[a.id]);
   const entries = [...agents]
     .sort((a, b) => b.ordinal - a.ordinal)
-    .map((agent, index) => ({ agent, index, status: statusOf(agent) }));
-  const completedEntries = entries.filter(({ status }) =>
-    ['resolved', 'wontfix', 'stopped', 'done'].includes(status),
+    .map((agent) => ({ agent, status: statusOf(agent) }));
+  const completedEntries = entries.filter(({ status }) => COMPLETED_STATUSES.includes(status));
+  const activeEntries = entries.filter(({ status }) => !COMPLETED_STATUSES.includes(status));
+  const [tab, setTab] = useState<CompletionTab>(() =>
+    defaultCompletionTab({
+      activeCount: activeEntries.length,
+      completedCount: completedEntries.length,
+    }),
   );
-  const activeEntries = entries.filter(
-    ({ status }) => !['resolved', 'wontfix', 'stopped', 'done'].includes(status),
-  );
-  const resolvedCount = entries.filter(({ status }) => status === 'resolved').length;
+  const visibleEntries = tab === 'completed' ? completedEntries : activeEntries;
   const anyRunning = agents.some((a) => a.status === 'running');
   const queuedCount = agents.filter((a) => a.status === 'pending').length;
   const stalled = !anyRunning && queuedCount > 0;
@@ -105,10 +121,7 @@ export const ResolveCluster = ({
           ) : (
             <ChevronRight size={10} aria-hidden className="shrink-0" />
           )}
-          <span className="tabular-nums">
-            {resolvedCount}/{agents.length}
-          </span>{' '}
-          resolved
+          {pluralize(agents.length, 'resolver')}
         </button>
         {stalled ? (
           <button
@@ -136,9 +149,19 @@ export const ResolveCluster = ({
       </div>
       {expanded ? (
         <>
+          {completedEntries.length > 0 ? (
+            <SegmentedControl
+              ariaLabel="Filter resolvers by status"
+              options={[
+                { value: 'active', label: `Active (${activeEntries.length})` },
+                { value: 'completed', label: `Completed (${completedEntries.length})` },
+              ]}
+              value={tab}
+              onChange={setTab}
+            />
+          ) : null}
           <ResolverRows
-            entries={activeEntries}
-            total={agents.length}
+            entries={visibleEntries}
             isTaskActive={isTaskActive}
             isTranscriptLoading={isTranscriptLoading}
             selectedAgentId={selectedAgentId}
@@ -152,39 +175,6 @@ export const ResolveCluster = ({
             onResolveThread={onResolveThread}
             onResolveAgent={onResolveAgent}
           />
-          {completedEntries.length > 0 ? (
-            <button
-              type="button"
-              onClick={() => setIsCompletedExpanded((current) => !current)}
-              aria-expanded={isCompletedExpanded}
-              className="flex items-center gap-1 self-start rounded px-2 py-0.5 text-2xs text-muted-foreground transition-colors hover:text-foreground"
-            >
-              {isCompletedExpanded ? (
-                <ChevronDown size={11} aria-hidden className="shrink-0" />
-              ) : (
-                <ChevronRight size={11} aria-hidden className="shrink-0" />
-              )}
-              Completed ({completedEntries.length})
-            </button>
-          ) : null}
-          {isCompletedExpanded ? (
-            <ResolverRows
-              entries={completedEntries}
-              total={agents.length}
-              isTaskActive={isTaskActive}
-              isTranscriptLoading={isTranscriptLoading}
-              selectedAgentId={selectedAgentId}
-              inspectedAgentId={inspectedAgentId}
-              commentByThreadId={commentByThreadId}
-              diffCommentByAgentId={diffCommentByAgentId}
-              metrics={metrics}
-              onSelect={onSelect}
-              onInspect={onInspect}
-              onJump={jump}
-              onResolveThread={onResolveThread}
-              onResolveAgent={onResolveAgent}
-            />
-          ) : null}
           <button
             type="button"
             onClick={openResolveBoard}

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/ResolveClusterRow.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/ResolveClusterRow.test.tsx
@@ -51,8 +51,6 @@ const renderRow = ({ onSelect = () => undefined, onInspect }: Params = {}) =>
   render(
     <ResolveClusterRow
       agent={agent}
-      index={0}
-      total={2}
       status="done"
       threadComment={null}
       diffComment={null}
@@ -102,10 +100,10 @@ describe('ResolveClusterRow', () => {
     expect(screen.getAllByTitle(/^started 2026-05-28/)).toHaveLength(1);
   });
 
-  it('keeps the resolver name and position readable alongside the metrics', () => {
+  it('keeps the resolver name readable alongside the metrics, without an ordinal position', () => {
     renderRow();
     expect(screen.getByText('resolve comment 12')).toBeTruthy();
-    expect(screen.getByText('1/2')).toBeTruthy();
+    expect(screen.queryByText(/^\d+\/\d+$/)).toBeNull();
     expect(screen.getByText('Review comment')).toBeTruthy();
   });
 

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/ResolveClusterRow.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/ResolveClusterRow.tsx
@@ -24,8 +24,6 @@ import { agentThreadIds } from '../../../../session/agentThreadIds';
 
 type Props = {
   readonly agent: Agent;
-  readonly index: number;
-  readonly total: number;
   readonly status: ResolverStatus;
   readonly threadComment: PrComment | null;
   readonly diffComment: DiffComment | null;
@@ -47,8 +45,6 @@ type Props = {
 
 export const ResolveClusterRow = ({
   agent,
-  index,
-  total,
   status,
   threadComment,
   diffComment,
@@ -131,9 +127,6 @@ export const ResolveClusterRow = ({
       )}
     >
       <div className="flex w-full items-center gap-2">
-        <span className="tabular-nums text-muted-foreground/50">
-          {index + 1}/{total}
-        </span>
         <span className="min-w-0 flex-1 truncate text-left" title={agent.name}>
           {agent.name}
         </span>

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/ResolverRows.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/ResolverRows.tsx
@@ -8,12 +8,10 @@ import { agentThreadIds } from '../../../../session/agentThreadIds';
 type Entry = {
   readonly agent: Agent;
   readonly status: ResolverStatus;
-  readonly index: number;
 };
 
 type Props = {
   readonly entries: ReadonlyArray<Entry>;
-  readonly total: number;
   readonly isTaskActive: boolean;
   readonly isTranscriptLoading: boolean;
   readonly selectedAgentId: AgentId | null;
@@ -30,7 +28,6 @@ type Props = {
 
 export const ResolverRows = ({
   entries,
-  total,
   isTaskActive,
   isTranscriptLoading,
   selectedAgentId,
@@ -45,7 +42,7 @@ export const ResolverRows = ({
   onResolveAgent,
 }: Props) => (
   <>
-    {entries.map(({ agent, status, index }) => {
+    {entries.map(({ agent, status }) => {
       const threadIds = agentThreadIds(agent);
       const threadId = threadIds[0];
       const diffComment =
@@ -57,8 +54,6 @@ export const ResolverRows = ({
         <ResolveClusterRow
           key={agent.id}
           agent={agent}
-          index={index}
-          total={total}
           status={status}
           threadComment={threadComment}
           diffComment={diffComment}


### PR DESCRIPTION
## Problem

The Resolve section in the sidebar and in the Resolve lens showed a header like `0/1 resolved`. That count only included threads GitHub itself had confirmed resolved. A resolver agent that had finished its work but whose PR thread was not yet marked resolved on GitHub still showed a `DONE` badge on its row, right next to a header that read `0/1`. Users read this as a contradiction: the row says done, the header says none resolved.

A second, related issue: each resolver row showed a `1/2` style number next to its name. That number was never a progress indicator, it was just the row's position in the list, but it used the same `n/m` shape as the header count, so the two numbers looked related when they were not.

Finally, both the Resolve section and the Agents section hid everything that was finished behind a collapsed `Completed (N)` / `Done (N)` toggle at the bottom of the list, with no way to see only what was completed.

## What changed

- The ambiguous `N/M resolved` header is gone. The Resolve section header now just states how many resolvers exist (e.g. `3 resolvers`), with no claim about how many are resolved.
- The per-row position number (`1/2`) is removed from resolver rows. It was never progress and does not come back in a different format.
- Both the Resolve cluster and the Agents lens now use an `Active` / `Completed` segmented control (the same primitive already used elsewhere in the app) that filters the list instead of a collapsed toggle. Each tab shows its own count, e.g. `Active (2)` / `Completed (1)`.
- The filter opens on `Active` by default. If there is nothing active but something is completed, it opens on `Completed` automatically instead of showing a misleading empty list.
- The done/active split for agents still uses the same manual "mark done" state as before; nothing changed in how an agent gets marked done.

## How this was verified

- `pnpm --filter @goodboy/desktop typecheck` passes clean.
- Targeted vitest run from `apps/desktop` (`npx vitest run` on `ResolveCluster.test.tsx`, `ResolveClusterRow.test.tsx`, `AgentsSection.test.tsx`, `lib.test.ts`): 4 files, 45 tests, all passing.
- New tests added: a resolver that finished without GitHub confirming its thread no longer produces a contradictory pair of numbers, the Active/Completed filter correctly splits and hides the other group in both the Resolve cluster and the Agents lens, and both surfaces open on Completed by default when Active is empty and something is completed.
