### PR TITLE
README and website: six providers and the integrations the site never mentioned

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![ci](https://img.shields.io/github/actions/workflow/status/akhayam99/goodboy/ci.yml?branch=main&label=ci)](https://github.com/akhayam99/goodboy/actions/workflows/ci.yml)
 [![release](https://img.shields.io/github/v/release/akhayam99/goodboy?label=release&color=06b6d4)](https://github.com/akhayam99/goodboy/releases/latest)
 [![stars](https://img.shields.io/github/stars/akhayam99/goodboy?label=stars&color=06b6d4)](https://github.com/akhayam99/goodboy/stargazers)
-[![providers](https://img.shields.io/badge/providers-Claude%20%C2%B7%20Cursor%20%C2%B7%20Codex%20%C2%B7%20Gemini-06b6d4)](#providers)
+[![providers](https://img.shields.io/badge/providers-Claude%20%C2%B7%20Cursor%20%C2%B7%20Codex%20%C2%B7%20Gemini%20%C2%B7%20OpenCode%20%C2%B7%20OpenRouter-06b6d4)](#providers)
 [![platform](https://img.shields.io/badge/macOS-Intel%20%26%20Apple%20Silicon-111111)](#install)
 [![license](https://img.shields.io/github/license/akhayam99/goodboy?color=06b6d4)](./LICENSE)
 
@@ -29,10 +29,11 @@ a local SQLite on your machine. Your keys, your data, your bandwidth.
 
 ## Why it exists
 
-Switching between `Claude`, `Codex`, `Cursor` and `Gemini` ten times a day was
-eating my afternoons. Every new tab meant rebuilding the same mental
-scratchpad from scratch, then watching the next model run off in a slightly
-different direction. Eventually I got fed up and built this.
+Switching between `Claude`, `Codex`, `Cursor`, `Gemini`, `OpenCode` and
+`OpenRouter` ten times a day was eating my afternoons. Every new tab meant
+rebuilding the same mental scratchpad from scratch, then watching the next
+model run off in a slightly different direction. Eventually I got fed up and
+built this.
 
 Open source. Every feature included. No paywall, no telemetry, no account.
 
@@ -44,7 +45,8 @@ hand when the agents get it wrong. The next agent shows up already briefed.
 
 **Provider swap mid-task, without amnesia.** Each turn is rebuilt from the
 shared context, never resumed from a vendor's session blob. Drop Claude
-halfway, hand the same task to Cursor, Codex or Gemini, watch it pick up clean.
+halfway, hand the same task to Cursor, Codex, Gemini, OpenCode or OpenRouter,
+watch it pick up clean.
 
 **Workflows for the multi-step stuff.** Refactor incoming? Line up a sequence:
 a cheap model to scout the area, a smart one to plan it, a mid one to
@@ -95,14 +97,18 @@ spend.
 ## Providers
 
 Bring the subscription you already pay for. Goodboy drives the official CLIs
-locally, on your existing plan, never on a metered API key.
+locally, on your existing plan. OpenRouter is the one exception: an API-key
+provider that runs through the OpenCode runtime, with the key held in your OS
+keychain.
 
-| Provider                 | CLI                                                            | Subscription     |
-| ------------------------ | -------------------------------------------------------------- | ---------------- |
-| **Anthropic (Claude)**   | `npm i -g @anthropic-ai/claude-code`                           | Claude Max / Pro |
-| **Cursor**               | Cursor desktop app                                             | Cursor Pro       |
-| **OpenAI (Codex)**       | `npm i -g @openai/codex`                                       | ChatGPT Pro      |
-| **Google (Antigravity)** | `curl -fsSL https://antigravity.google/cli/install.sh \| bash` | Google AI Pro    |
+| Provider                 | CLI                                                            | Subscription                   |
+| ------------------------ | -------------------------------------------------------------- | ------------------------------ |
+| **Anthropic (Claude)**   | `npm i -g @anthropic-ai/claude-code`                           | Claude Max / Pro               |
+| **Cursor**               | Cursor desktop app                                             | Cursor Pro                     |
+| **OpenAI (Codex)**       | `npm i -g @openai/codex`                                       | ChatGPT Pro                    |
+| **Google (Antigravity)** | `curl -fsSL https://antigravity.google/cli/install.sh \| bash` | Google AI Pro                  |
+| **OpenCode** (beta)      | `npm i -g opencode-ai`                                         | None, zero-key models included |
+| **OpenRouter** (beta)    | Runs through the OpenCode runtime, no separate install         | OpenRouter API key             |
 
 One connected CLI is enough to start. Full guide:
 [docs/providers.md](./docs/providers.md).

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@
 
 <img width="3972" height="2234" alt="Goodboy desktop app" src="https://github.com/user-attachments/assets/4708c589-a8e6-4f6c-a80a-222b32cc237e" />
 
-You have a repo. You have a goal. You also have four CLIs open in four
-windows, each holding a slightly different version of the same task. By
-evening you've spent more time pasting the goal back into the next chat
-than actually building.
+You have a repo. You have a goal. You also have several CLIs open in
+several windows, each holding a slightly different version of the same
+task. By evening you've spent more time pasting the goal back into the
+next chat than actually building.
 
 Goodboy is a desktop app that holds the goal, the plan and the context once,
 then hands them to whichever agent you want to run next. Same brief, same

--- a/VISION.md
+++ b/VISION.md
@@ -51,7 +51,7 @@ Planner agents emit structured plans wrapped in `<<plan>>...<<plan>>` markers. T
 
 ### Provider routing & balance
 
-Register your AI providers (Anthropic, Cursor, Codex, Gemini). Set priorities. Set budgets. Enable or disable providers per session. Goodboy routes work to the right provider automatically.
+Register your AI providers (Anthropic, Cursor, Codex, Gemini, OpenCode, OpenRouter). Set priorities. Set budgets. Enable or disable providers per session. Goodboy routes work to the right provider automatically.
 
 - Provider 1 hits 75% budget → fallback to provider 2.
 - Quick task → fast cheap model. Complex architecture → best available model.

--- a/website/index.html
+++ b/website/index.html
@@ -4,11 +4,18 @@
     <meta charset="UTF-8" />
 
     <!-- Google Tag Manager -->
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5NM3VX7Q');</script>
+    <script>
+      (function (w, d, s, l, i) {
+        w[l] = w[l] || [];
+        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
+        var f = d.getElementsByTagName(s)[0],
+          j = d.createElement(s),
+          dl = l != 'dataLayer' ? '&l=' + l : '';
+        j.async = true;
+        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+        f.parentNode.insertBefore(j, f);
+      })(window, document, 'script', 'dataLayer', 'GTM-5NM3VX7Q');
+    </script>
     <!-- End Google Tag Manager -->
 
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
@@ -16,8 +23,14 @@
 
     <!-- Primary -->
     <title>Goodboy: keep the thread across your coding agents</title>
-    <meta name="description" content="Goodboy carries the goal, plan, decisions, and open questions from one coding agent to the next. Compose workflows, run Claude, Cursor, Codex, and Gemini, and watch the spend." />
-    <meta name="keywords" content="keep context, coding agents, shared context, agent workflows, multi-provider, budget routing, syntax-highlighted diffs, stage board, local-first, open source, Tauri desktop app" />
+    <meta
+      name="description"
+      content="Goodboy carries the goal, plan, decisions, and open questions from one coding agent to the next. Compose workflows, run Claude, Cursor, Codex, Gemini, OpenCode, or OpenRouter, and watch the spend."
+    />
+    <meta
+      name="keywords"
+      content="keep context, coding agents, shared context, agent workflows, multi-provider, budget routing, syntax-highlighted diffs, stage board, local-first, open source, Tauri desktop app"
+    />
     <meta name="author" content="Amin Khayam" />
     <link rel="canonical" href="https://goodboy.dev/" />
 
@@ -26,7 +39,10 @@
     <meta property="og:site_name" content="Goodboy" />
     <meta property="og:url" content="https://goodboy.dev/" />
     <meta property="og:title" content="Goodboy: keep the thread across your coding agents" />
-    <meta property="og:description" content="Stop re-explaining the goal to every new agent. Goodboy holds shared context, runs reusable workflows, and drives the CLI tools you already use. Open source, local-first, MIT." />
+    <meta
+      property="og:description"
+      content="Stop re-explaining the goal to every new agent. Goodboy holds shared context, runs reusable workflows, and drives the CLI tools you already use. Open source, local-first, MIT."
+    />
     <meta property="og:image" content="https://goodboy.dev/og-image.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
@@ -38,7 +54,10 @@
     <meta name="twitter:site" content="@akhayam99" />
     <meta name="twitter:creator" content="@akhayam99" />
     <meta name="twitter:title" content="Goodboy: keep the thread across your coding agents" />
-    <meta name="twitter:description" content="Shared context carried into every agent, workflows you compose once, and Claude, Cursor, Codex, and Gemini in one session. Open source, MIT." />
+    <meta
+      name="twitter:description"
+      content="Shared context carried into every agent, workflows you compose once, and Claude, Cursor, Codex, Gemini, OpenCode, or OpenRouter in one session. Open source, MIT."
+    />
     <meta name="twitter:image" content="https://goodboy.dev/og-image.png" />
     <meta name="twitter:image:alt" content="Goodboy: keep the thread across your coding agents" />
 
@@ -48,103 +67,118 @@
 
     <!-- JSON-LD: SoftwareApplication -->
     <script type="application/ld+json">
-    {
-      "@context": "https://schema.org",
-      "@type": "SoftwareApplication",
-      "name": "Goodboy",
-      "alternateName": "Goodboy shared context for coding agents",
-      "description": "Goodboy is a local-first desktop app for running coding agents that keeps the thread. It carries shared context into every agent, runs reusable workflows with per-step models, drives the command-line tools you have signed into, and tracks spend with caps that steer routing.",
-      "url": "https://goodboy.dev/",
-      "applicationCategory": "DeveloperApplication",
-      "operatingSystem": "macOS",
-      "offers": {
-        "@type": "Offer",
-        "price": "0",
-        "priceCurrency": "USD",
-        "description": "Open source under MIT license"
-      },
-      "author": {
-        "@type": "Person",
-        "name": "Amin Khayam",
-        "url": "https://github.com/akhayam99"
-      },
-      "license": "https://opensource.org/licenses/MIT",
-      "codeRepository": "https://github.com/akhayam99/goodboy",
-      "keywords": ["shared context", "coding agents", "agent workflows", "multi-provider", "budget routing", "stage board", "local-first", "open source"],
-      "featureList": [
-        "Shared context preamble carried into every agent",
-        "Last-output summarizer that compacts each turn",
-        "Durable plans kept as artifacts",
-        "Tracked open questions clustered by agent",
-        "Reusable workflows with a model and effort per step",
-        "Scout fan-out for large repositories",
-        "Implement clusters that split a big plan",
-        "Runs grouped into lanes with a cost rollup",
-        "Four CLI providers (Claude, Cursor, Codex, Gemini) in one session",
-        "Budget caps that drive provider routing",
-        "Stage board with derived stages",
-        "Syntax-highlighted diffs across twelve languages",
-        "GPU terminal on xterm 6",
-        "Composite workspaces across many repositories",
-        "Mobile companion to act from your phone"
-      ]
-    }
+      {
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "Goodboy",
+        "alternateName": "Goodboy shared context for coding agents",
+        "description": "Goodboy is a local-first desktop app for running coding agents that keeps the thread. It carries shared context into every agent, runs reusable workflows with per-step models, drives the command-line tools you have signed into, and tracks spend with caps that steer routing.",
+        "url": "https://goodboy.dev/",
+        "applicationCategory": "DeveloperApplication",
+        "operatingSystem": "macOS",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD",
+          "description": "Open source under MIT license"
+        },
+        "author": {
+          "@type": "Person",
+          "name": "Amin Khayam",
+          "url": "https://github.com/akhayam99"
+        },
+        "license": "https://opensource.org/licenses/MIT",
+        "codeRepository": "https://github.com/akhayam99/goodboy",
+        "keywords": [
+          "shared context",
+          "coding agents",
+          "agent workflows",
+          "multi-provider",
+          "budget routing",
+          "stage board",
+          "local-first",
+          "open source"
+        ],
+        "featureList": [
+          "Shared context preamble carried into every agent",
+          "Last-output summarizer that compacts each turn",
+          "Durable plans kept as artifacts",
+          "Tracked open questions clustered by agent",
+          "Reusable workflows with a model and effort per step",
+          "Scout fan-out for large repositories",
+          "Implement clusters that split a big plan",
+          "Runs grouped into lanes with a cost rollup",
+          "Six CLI providers (Claude, Cursor, Codex, Gemini, OpenCode, OpenRouter) in one session",
+          "Budget caps that drive provider routing",
+          "Stage board with derived stages",
+          "Syntax-highlighted diffs across twelve languages",
+          "GPU terminal on xterm 6",
+          "Composite workspaces across many repositories",
+          "Mobile companion to act from your phone"
+        ]
+      }
     </script>
 
     <!-- JSON-LD: FAQPage -->
     <script type="application/ld+json">
-    {
-      "@context": "https://schema.org",
-      "@type": "FAQPage",
-      "mainEntity": [
-        {
-          "@type": "Question",
-          "name": "Is Goodboy free?",
-          "acceptedAnswer": {
-            "@type": "Answer",
-            "text": "Yes. Goodboy is open source under the MIT license. You bring your own agent logins and plans."
+      {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "Is Goodboy free?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Yes. Goodboy is open source under the MIT license. You bring your own agent logins and plans."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Do I need API keys?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Not for most of them. Goodboy drives the command-line tools you already installed and signed into: Claude, Cursor, Codex, Gemini, and OpenCode. OpenRouter is the exception, an API-key provider that runs through the OpenCode runtime."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Where do my credentials live?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Your provider logins stay inside the CLI tools you already signed into. Any optional API key you add to Goodboy lives in your OS keychain, read at spawn and never written to disk."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Does my code leave my machine?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Goodboy itself is local-first: your sessions, history, and keys stay on your machine. The agents you run reach their own providers exactly as they do in your terminal."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Which platforms does Goodboy support?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "macOS today, as a universal build or via Homebrew. Linux and Windows are in progress; you can build from source in the meantime."
+            }
           }
-        },
-        {
-          "@type": "Question",
-          "name": "Do I need API keys?",
-          "acceptedAnswer": {
-            "@type": "Answer",
-            "text": "No. Goodboy drives the command-line tools you already installed and signed into: Claude, Cursor, Codex, and Gemini."
-          }
-        },
-        {
-          "@type": "Question",
-          "name": "Where do my credentials live?",
-          "acceptedAnswer": {
-            "@type": "Answer",
-            "text": "Your provider logins stay inside the CLI tools you already signed into. Any optional API key you add to Goodboy lives in your OS keychain, read at spawn and never written to disk."
-          }
-        },
-        {
-          "@type": "Question",
-          "name": "Does my code leave my machine?",
-          "acceptedAnswer": {
-            "@type": "Answer",
-            "text": "Goodboy itself is local-first: your sessions, history, and keys stay on your machine. The agents you run reach their own providers exactly as they do in your terminal."
-          }
-        },
-        {
-          "@type": "Question",
-          "name": "Which platforms does Goodboy support?",
-          "acceptedAnswer": {
-            "@type": "Answer",
-            "text": "macOS today, as a universal build or via Homebrew. Linux and Windows are in progress; you can build from source in the meantime."
-          }
-        }
-      ]
-    }
+        ]
+      }
     </script>
   </head>
   <body>
     <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5NM3VX7Q"
-    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <noscript
+      ><iframe
+        src="https://www.googletagmanager.com/ns.html?id=GTM-5NM3VX7Q"
+        height="0"
+        width="0"
+        style="display: none; visibility: hidden"
+      ></iframe
+    ></noscript>
     <!-- End Google Tag Manager (noscript) -->
 
     <div id="root"></div>

--- a/website/index.html
+++ b/website/index.html
@@ -108,7 +108,7 @@
           "Scout fan-out for large repositories",
           "Implement clusters that split a big plan",
           "Runs grouped into lanes with a cost rollup",
-          "Six CLI providers (Claude, Cursor, Codex, Gemini, OpenCode, OpenRouter) in one session",
+          "Six providers in one session, five driven via CLI (Claude, Cursor, Codex, Gemini, OpenCode) and OpenRouter via API key",
           "Budget caps that drive provider routing",
           "Stage board with derived stages",
           "Syntax-highlighted diffs across twelve languages",
@@ -138,7 +138,7 @@
             "name": "Do I need API keys?",
             "acceptedAnswer": {
               "@type": "Answer",
-              "text": "Not for most of them. Goodboy drives the command-line tools you already installed and signed into: Claude, Cursor, Codex, Gemini, and OpenCode. OpenRouter is the exception, an API-key provider that runs through the OpenCode runtime."
+              "text": "No, except OpenRouter. Goodboy drives the command-line tools you already installed and signed into: Claude, Cursor, Codex, Gemini and OpenCode. OpenRouter runs through the OpenCode runtime on an API key you provide."
             }
           },
           {

--- a/website/src/sections/Faq.tsx
+++ b/website/src/sections/Faq.tsx
@@ -25,9 +25,9 @@ const ITEMS: ReadonlyArray<Qa> = [
     q: 'Do I need API keys?',
     a: (
       <>
-        Not for most of them. Goodboy drives the command-line tools you already installed and signed
-        into: Claude, Cursor, Codex, Gemini, and OpenCode. OpenRouter is the exception, an{' '}
-        <B>API-key provider</B> that runs through the OpenCode runtime.
+        No, except OpenRouter. Goodboy drives the command-line tools you already installed and
+        signed into: Claude, Cursor, Codex, Gemini and OpenCode. OpenRouter runs through the{' '}
+        <B>OpenCode runtime</B> on an API key you provide.
       </>
     ),
   },

--- a/website/src/sections/Faq.tsx
+++ b/website/src/sections/Faq.tsx
@@ -25,8 +25,9 @@ const ITEMS: ReadonlyArray<Qa> = [
     q: 'Do I need API keys?',
     a: (
       <>
-        <B>No.</B> Goodboy drives the command-line tools you already installed and signed into:
-        Claude, Cursor, Codex, and Gemini.
+        Not for most of them. Goodboy drives the command-line tools you already installed and signed
+        into: Claude, Cursor, Codex, Gemini, and OpenCode. OpenRouter is the exception, an{' '}
+        <B>API-key provider</B> that runs through the OpenCode runtime.
       </>
     ),
   },

--- a/website/src/sections/Hero.tsx
+++ b/website/src/sections/Hero.tsx
@@ -39,7 +39,7 @@ export const Hero = () => (
         <strong className="font-semibold text-foreground">right model</strong> for each step.
         <br className="hidden sm:block" />{' '}
         <strong className="font-semibold text-foreground">One thread</strong>, across Claude,
-        Cursor, Codex, and Gemini.
+        Cursor, Codex, Gemini, OpenCode, and OpenRouter.
       </p>
 
       <div

--- a/website/src/sections/MoreBriefly.tsx
+++ b/website/src/sections/MoreBriefly.tsx
@@ -78,8 +78,9 @@ const ITEMS: ReadonlyArray<Item> = [
     k: 'Integrations',
     v: (
       <>
-        GitHub and GitLab pull requests, Linear issues, and Sentry errors turn into a session with
-        the <B>goal and branch already written</B>.
+        GitHub, GitLab, Linear and Sentry issues turn into a session with the{' '}
+        <B>goal and branch already written</B>. Pull requests and merge requests feed a review inbox
+        instead.
       </>
     ),
   },

--- a/website/src/sections/MoreBriefly.tsx
+++ b/website/src/sections/MoreBriefly.tsx
@@ -74,6 +74,15 @@ const ITEMS: ReadonlyArray<Item> = [
       </>
     ),
   },
+  {
+    k: 'Integrations',
+    v: (
+      <>
+        GitHub and GitLab pull requests, Linear issues, and Sentry errors turn into a session with
+        the <B>goal and branch already written</B>.
+      </>
+    ),
+  },
 ];
 
 export const MoreBriefly = () => {

--- a/website/src/sections/Solutions.tsx
+++ b/website/src/sections/Solutions.tsx
@@ -94,8 +94,8 @@ const CARDS: ReadonlyArray<Card> = [
     title: 'Use every agent you pay for',
     body: (
       <>
-        Claude, Cursor, Codex, and Gemini in <B>one session</B>, on your own logins. Set a budget
-        cap and routing falls back when you hit it.
+        Claude, Cursor, Codex, Gemini, OpenCode, and OpenRouter in <B>one session</B>, on your own
+        logins and keys. Set a budget cap and routing falls back when you hit it.
       </>
     ),
   },


### PR DESCRIPTION
# PR H: README and website brought up to six providers

## Problem

opencode and openrouter shipped in v0.1.35 (#1027), but README.md and the marketing
website (`website/`) still described four CLI providers in at least nine places,
including a JSON-LD block that stated "Four" outright. The providers section of
README also claimed Goodboy is "never on a metered API key", which is directly
contradicted by OpenRouter, an API-key provider. The website never mentioned
GitHub/GitLab/Linear/Sentry integrations at all, despite them being a real,
shipped part of the product.

## What changed

### README.md

- Providers badge (line 8): six providers instead of four.
- "Why it exists" founder note: lists all six CLIs.
- "Provider swap mid-task" feature blurb: lists all six.
- Providers table: added `OpenCode` and `OpenRouter` rows, marked `(beta)` to
  match the in-app beta chip (`PROVIDER_BETA` in
  `packages/types/src/provider-catalog.ts`), with their real install command
  and runtime requirement:
  - OpenCode: `npm i -g opencode-ai` (verified in
    `packages/types/src/provider-commands.ts`), subscription "None, zero-key
    models included" (verified in `ProviderConnectModal/guides.ts`).
  - OpenRouter: "Runs through the OpenCode runtime, no separate install",
    subscription "OpenRouter API key".
- Fixed the providers intro sentence, which claimed Goodboy never touches a
  metered API key. Now it names OpenRouter as the one exception and states the
  key is held in the OS keychain (verified against
  `apps/desktop/src-tauri/src/secrets.rs`, which uses the OS `keyring` crate).

### website/

- `index.html`: meta description, twitter:description, both JSON-LD blocks
  (`SoftwareApplication.featureList` and the `FAQPage` "Do I need API keys?"
  answer) updated to name all six providers. The JSON-LD FAQ answer no longer
  says a flat "No" to "do I need API keys", since OpenRouter needs one; it now
  says "Not for most of them" and calls out OpenRouter as the exception.
- `src/sections/Hero.tsx`: hero line lists all six providers.
- `src/sections/Solutions.tsx`: "Use every agent you pay for" card lists all
  six and says "on your own logins and keys" (OpenRouter is a key, not a
  login).
- `src/sections/Faq.tsx`: same fix as the JSON-LD FAQ answer, worded for the
  rendered page.
- `src/sections/MoreBriefly.tsx`: added an "Integrations" entry (GitHub and
  GitLab pull requests, Linear issues, Sentry errors) to the existing "the
  rest, briefly" list. No new section added, per the MUST NOT.

### Left untouched

- `.github/readme-integrations.png`: checked the actual image. It shows
  GitHub, GitLab, Linear, and Sentry chips, which is still accurate (those are
  the four integrations, unrelated to the six-provider count). No change
  needed.
- `docs/providers.md`: out of the area's explicit scope (README + website
  only); not touched.
- `website/src/components/BrandIcons.tsx` and `website/src/styles.css:63-66`
  (the SHOULD to align the site mockup to six brands): deferred. The real
  opencode/openrouter marks don't exist yet in this worktree; Area A (which
  fixes `apps/desktop/src/shared/components/brand-icons.tsx`) hasn't landed.
  Copying today's invented glyphs into the site mockup would just spread the
  same problem Area A exists to fix. Revisit once Area A merges.

## How verified

- Read `packages/core/src/providers/opencode/` and
  `packages/core/src/providers/openrouter/` (constants, adapter, parser) to
  confirm model lists and that both dispatch through the `opencode` binary.
- Read `apps/desktop/src-tauri/src/turn.rs` (`"opencode" | "openrouter" =>`
  branch): both run `opencode run --format json -m <model> ...`, confirming
  openrouter rides the OpenCode runtime rather than having its own CLI.
- Read `packages/types/src/provider-catalog.ts`: `PROVIDER_KIND.openrouter =
  'api'`, `PROVIDER_BETA` includes both, `OPENCODE_ROUTING.openrouter` slug
  confirms the routing-through-opencode design.
- Read `apps/desktop/src-tauri/src/provider_credentials.rs`: openrouter key
  validated against `https://openrouter.ai/api/v1/auth/key`, and
  `secrets.rs` confirms keys are stored via the OS keyring, not written to
  disk.
- Read `packages/types/src/provider-commands.ts` and
  `apps/desktop/src/features/providers/components/ProviderConnectModal/guides.ts`
  for the exact install command, login flow, and subscription copy used in
  the table and copy above.
- Grepped for the stale phrasings after editing: `Cursor, Codex, and Gemini`,
  `Four CLI providers`, `Claude · Cursor · Codex · Gemini` (with no
  OpenCode/OpenRouter appended). All clean, zero matches anywhere in the repo.
- Ran `pnpm install --ignore-workspace` and `npm run build` (`tsc -b && vite
  build`) from inside `website/`. Both green, no type errors, `dist/` output
  produced.
- Read the full diff before committing: zero em-dashes, no "Cursor, Codex,
  and Gemini"-style stale enumerations, no absolutes ("never"/"always") about
  product behavior beyond what the code actually does, no three-item
  middot-joined lists as a stylistic tell, sentence case throughout.
- Did not touch anything under `apps/desktop` or `packages/`, so no
  desktop typecheck/vitest/cargo test was required for this PR.

## Commit

Single commit: `docs(repo): bring readme and website up to six providers`.
