### PR TITLE
fix(desktop): stop the stage selectors crashing on partial state

### DIFF
--- a/apps/desktop/src/store/selectors.test.ts
+++ b/apps/desktop/src/store/selectors.test.ts
@@ -3,11 +3,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type {
   Agent,
   AgentId,
+  Session,
   SessionId,
   StepId,
   TelemetryKind,
   TelemetryRecord,
   WorkflowRunId,
+  Workspace,
+  WorkspaceId,
 } from '@goodboy/types';
 
 type StoreState = Record<string, unknown>;
@@ -21,7 +24,13 @@ vi.mock('./store', () => ({
   useAppStore: (selector: (state: StoreState) => unknown) => selector(store.state),
 }));
 
-import { sumSessionCost, useLiveTerminalCount, useSessionUnreadLens } from './selectors';
+import {
+  sumSessionCost,
+  useLiveTerminalCount,
+  useSessionUnreadLens,
+  useSortedGroupedSessions,
+  useStageGroupedSessions,
+} from './selectors';
 
 type Params = {
   readonly kind: TelemetryKind;
@@ -64,6 +73,21 @@ const createAgent = ({
 
 const SESSION_ID = 'session-1' as SessionId;
 const AGENT_ID = 'agent-1' as AgentId;
+const WORKSPACE_ID = 'workspace-1' as WorkspaceId;
+
+const createSession = (id: SessionId): Session =>
+  ({
+    id,
+    workspaceId: WORKSPACE_ID,
+    goal: 'ship the fix',
+    state: { kind: 'idle', lastActivityAt: '2026-07-27T10:00:00.000Z' },
+    createdAt: '2026-07-27T10:00:00.000Z',
+    updatedAt: '2026-07-27T10:00:00.000Z',
+    workflowRuns: [],
+  }) as unknown as Session;
+
+const createWorkspace = (kind: string): Workspace =>
+  ({ id: WORKSPACE_ID, kind, rootPath: '/tmp/ws' }) as unknown as Workspace;
 
 beforeEach(() => {
   store.state = {
@@ -73,6 +97,12 @@ beforeEach(() => {
     agentKindOverride: {},
     terminalTabs: {},
     terminalSessions: {},
+    sessionGithub: {},
+    sessionOpenQuestions: {},
+    sessionViewPrefs: {},
+    getSessionViewPrefs: vi.fn(),
+    workspaces: [],
+    sessionBranches: {},
   };
 });
 
@@ -213,5 +243,45 @@ describe('useSessionUnreadLens', () => {
     const { result } = renderHook(() => useSessionUnreadLens(SESSION_ID));
 
     expect(result.current).toBe('workflows');
+  });
+});
+
+describe('useSortedGroupedSessions', () => {
+  it('derives stages with the default stage grouping', () => {
+    store.state.workspaces = [createWorkspace('repo')];
+    store.state.sessionBranches = { [SESSION_ID]: 'ak/feat-thing' };
+    const sessions = [createSession(SESSION_ID)];
+
+    const { result } = renderHook(() => useSortedGroupedSessions(WORKSPACE_ID, sessions));
+
+    expect(result.current).toEqual([{ key: 'building', sessions }]);
+  });
+});
+
+describe('useStageGroupedSessions', () => {
+  it('groups a repo session by its pull request stage', () => {
+    store.state.workspaces = [createWorkspace('repo')];
+    store.state.sessionBranches = { [SESSION_ID]: 'ak/feat-thing' };
+    store.state.sessionGithub = {
+      [SESSION_ID]: { pr: { number: 12, state: 'merged', isDraft: false } },
+    };
+    const sessions = [createSession(SESSION_ID)];
+
+    const { result } = renderHook(() => useStageGroupedSessions(WORKSPACE_ID, sessions));
+
+    expect(result.current).toEqual([{ key: 'done', sessions }]);
+  });
+
+  it('keeps a branchless simple-workspace session out of the pull request stages', () => {
+    store.state.workspaces = [createWorkspace('simple')];
+    store.state.sessionBranches = { [SESSION_ID]: '' };
+    store.state.sessionGithub = {
+      [SESSION_ID]: { pr: { number: 12, state: 'merged', isDraft: false } },
+    };
+    const sessions = [createSession(SESSION_ID)];
+
+    const { result } = renderHook(() => useStageGroupedSessions(WORKSPACE_ID, sessions));
+
+    expect(result.current).toEqual([{ key: 'building', sessions }]);
   });
 });

--- a/apps/desktop/src/store/selectors.ts
+++ b/apps/desktop/src/store/selectors.ts
@@ -71,8 +71,20 @@ export const useSessionViewPrefs = (workspaceId: WorkspaceId | null): SessionVie
 };
 
 const EMPTY_GITHUB_STATE: Readonly<Record<string, never>> = Object.freeze({});
+const EMPTY_WORKSPACES: ReadonlyArray<Workspace> = [];
 
-function countOpenQuestions(state: AppState, sessionId: SessionId): number {
+type StageInfoState = Pick<
+  AppState,
+  | 'workspaces'
+  | 'sessionBranches'
+  | 'sessionGithub'
+  | 'sessionOpenQuestions'
+  | 'sessionPhaseRuns'
+  | 'selectedAgentId'
+  | 'currentSessionId'
+>;
+
+function countOpenQuestions(state: StageInfoState, sessionId: SessionId): number {
   const questions = state.sessionOpenQuestions[sessionId];
   if (!questions) {
     return 0;
@@ -80,7 +92,7 @@ function countOpenQuestions(state: AppState, sessionId: SessionId): number {
   return questions.filter((q) => q.status === 'open').length;
 }
 
-function sessionHasUnreadIn(state: AppState, sessionId: SessionId): boolean {
+function sessionHasUnreadIn(state: StageInfoState, sessionId: SessionId): boolean {
   const runs = state.sessionPhaseRuns[sessionId];
   if (!runs) {
     return false;
@@ -90,16 +102,15 @@ function sessionHasUnreadIn(state: AppState, sessionId: SessionId): boolean {
   return runs.some((r) => agentHasUnread(r, isCurrent && r.id === selected));
 }
 
-function sessionHasRunningAgentIn(state: AppState, sessionId: SessionId): boolean {
+function sessionHasRunningAgentIn(state: StageInfoState, sessionId: SessionId): boolean {
   const runs = state.sessionPhaseRuns[sessionId];
   return runs ? runs.some((r) => r.status === 'running') : false;
 }
 
-function stageInfoOf(state: AppState, session: Session): SessionStageInfo {
+function stageInfoOf(state: StageInfoState, session: Session): SessionStageInfo {
   const sessionId = session.id as SessionId;
   const isBranchless = isBranchlessSession({
-    workspaceKind: state.workspaces?.find((workspace) => workspace.id === session.workspaceId)
-      ?.kind,
+    workspaceKind: state.workspaces.find((workspace) => workspace.id === session.workspaceId)?.kind,
     branch: state.sessionBranches[sessionId],
   });
   return deriveSessionStage({
@@ -139,8 +150,14 @@ export const useSortedGroupedSessions = (
     needsStage ? s.selectedAgentId : (EMPTY_GITHUB_STATE as typeof s.selectedAgentId),
   );
   const currentSessionId = useAppStore((s) => (needsStage ? s.currentSessionId : null));
+  const workspaces = useAppStore((s) => (needsStage ? s.workspaces : EMPTY_WORKSPACES));
+  const sessionBranches = useAppStore((s) =>
+    needsStage ? s.sessionBranches : (EMPTY_GITHUB_STATE as typeof s.sessionBranches),
+  );
   return useMemo(() => {
-    const partial = {
+    const partial: StageInfoState = {
+      workspaces,
+      sessionBranches,
       sessionGithub,
       sessionOpenQuestions,
       sessionPhaseRuns,
@@ -150,7 +167,7 @@ export const useSortedGroupedSessions = (
     const stages: Record<SessionId, SessionStage> = {};
     if (needsStage) {
       for (const session of sessions) {
-        stages[session.id as SessionId] = stageInfoOf(partial as AppState, session).stage;
+        stages[session.id as SessionId] = stageInfoOf(partial, session).stage;
       }
     }
     return sortAndGroupSessions(sessions, prefs, sessionGithub, stages);
@@ -158,6 +175,8 @@ export const useSortedGroupedSessions = (
     sessions,
     prefs,
     needsStage,
+    workspaces,
+    sessionBranches,
     sessionGithub,
     sessionOpenQuestions,
     sessionPhaseRuns,
@@ -176,8 +195,12 @@ export const useStageGroupedSessions = (
   const sessionPhaseRuns = useAppStore((s) => s.sessionPhaseRuns);
   const selectedAgentId = useAppStore((s) => s.selectedAgentId);
   const currentSessionId = useAppStore((s) => s.currentSessionId);
+  const workspaces = useAppStore((s) => s.workspaces);
+  const sessionBranches = useAppStore((s) => s.sessionBranches);
   return useMemo(() => {
-    const partial = {
+    const partial: StageInfoState = {
+      workspaces,
+      sessionBranches,
       sessionGithub,
       sessionOpenQuestions,
       sessionPhaseRuns,
@@ -186,7 +209,7 @@ export const useStageGroupedSessions = (
     };
     const stages: Record<SessionId, SessionStage> = {};
     for (const session of sessions) {
-      stages[session.id as SessionId] = stageInfoOf(partial as AppState, session).stage;
+      stages[session.id as SessionId] = stageInfoOf(partial, session).stage;
     }
     return sortAndGroupSessions(
       sessions,
@@ -197,6 +220,8 @@ export const useStageGroupedSessions = (
   }, [
     sessions,
     prefs.sort,
+    workspaces,
+    sessionBranches,
     sessionGithub,
     sessionOpenQuestions,
     sessionPhaseRuns,


### PR DESCRIPTION
## What

Opening any workspace in v0.1.36 crashed the renderer with `undefined is not an object (evaluating 'e.sessionBranches[s]')`.

#1035 taught `stageInfoOf` to read `workspaces` and `sessionBranches` so a branchless session could be staged correctly, but the two sidebar grouping hooks (`useSortedGroupedSessions`, `useStageGroupedSessions`) feed it a hand-built partial state object cast to `AppState`, and that partial carried neither field. The default sidebar grouping is `stage`, so the first render of any workspace with sessions hit the missing map and threw.

## How

- the partial is now typed as `Pick<AppState, ...>` and the `as AppState` casts are gone, so a future field added to `stageInfoOf` without updating the callers fails typecheck instead of crashing at runtime
- both hooks subscribe to `workspaces` and `sessionBranches` and pass them through
- the helper functions (`countOpenQuestions`, `sessionHasUnreadIn`, `sessionHasRunningAgentIn`) take the same narrowed type

## Why no test caught it

Every consumer of these hooks mocks them away in its own tests (`useStageGroupedSessions: () => []` in the StageBoard test), and `selectors.test.ts` never exercised the grouping hooks. Three regression tests now render both hooks against a store with only the sidebar slices loaded: they fail with the exact production error on the previous code and pass on this branch.

## Verification

- `npx vitest run src/store/selectors.test.ts` against the pre-fix `selectors.ts`: 3 failed on `state.sessionBranches[sessionId]`
- full suite: 341 files, 2805 tests green
- typecheck green
