### PR TITLE
feat(desktop): update and disconnect actions on the workspace launcher

### DIFF
--- a/apps/desktop/src/features/workspace/components/WorkspaceLauncher/index.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspaceLauncher/index.test.tsx
@@ -12,7 +12,11 @@ const { state } = vi.hoisted(() => ({
     shown: new Set<WorkspaceId>(),
     openWorkspace: vi.fn(async () => undefined),
     saveSetting: vi.fn(async () => undefined),
+    deleteWorkspace: vi.fn(async () => undefined),
+    installUpdate: vi.fn(async () => undefined),
     settings: {} as Record<string, string>,
+    updaterStatus: 'idle' as string,
+    updateVersion: null as string | null,
   },
 }));
 
@@ -23,13 +27,21 @@ vi.mock('../../../../store', () => ({
     selector: (s: {
       openWorkspace: typeof state.openWorkspace;
       saveSetting: typeof state.saveSetting;
+      deleteWorkspace: typeof state.deleteWorkspace;
+      installUpdate: typeof state.installUpdate;
       settings: Record<string, string>;
+      updaterStatus: string;
+      updateVersion: string | null;
     }) => unknown,
   ) =>
     selector({
       openWorkspace: state.openWorkspace,
       saveSetting: state.saveSetting,
+      deleteWorkspace: state.deleteWorkspace,
+      installUpdate: state.installUpdate,
       settings: state.settings,
+      updaterStatus: state.updaterStatus,
+      updateVersion: state.updateVersion,
     }),
 }));
 
@@ -44,7 +56,11 @@ beforeEach(() => {
   state.shown = new Set();
   state.openWorkspace = vi.fn(async () => undefined);
   state.saveSetting = vi.fn(async () => undefined);
+  state.deleteWorkspace = vi.fn(async () => undefined);
+  state.installUpdate = vi.fn(async () => undefined);
   state.settings = {};
+  state.updaterStatus = 'idle';
+  state.updateVersion = null;
 });
 afterEach(cleanup);
 
@@ -59,5 +75,35 @@ describe('WorkspaceLauncher', () => {
     render(<WorkspaceLauncher />);
     fireEvent.click(screen.getByLabelText(/reopen last workspace/i));
     expect(state.saveSetting).toHaveBeenCalledWith(SETTING_REOPEN_LAST, '1');
+  });
+
+  it('disconnects a workspace after an explicit confirmation', async () => {
+    render(<WorkspaceLauncher />);
+    fireEvent.click(screen.getByLabelText('Disconnect alpha'));
+    expect(state.deleteWorkspace).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: 'Disconnect' }));
+    expect(state.deleteWorkspace).toHaveBeenCalledWith('ws-a');
+    expect(state.openWorkspace).not.toHaveBeenCalled();
+  });
+
+  it('keeps the workspace when the confirmation is cancelled', () => {
+    render(<WorkspaceLauncher />);
+    fireEvent.click(screen.getByLabelText('Disconnect bravo'));
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(state.deleteWorkspace).not.toHaveBeenCalled();
+  });
+
+  it('shows the update action when an update is available', () => {
+    state.updaterStatus = 'available';
+    state.updateVersion = '0.1.99';
+    render(<WorkspaceLauncher />);
+    fireEvent.click(screen.getByRole('button', { name: 'Update' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Update and restart' }));
+    expect(state.installUpdate).toHaveBeenCalled();
+  });
+
+  it('hides the update action when the app is current', () => {
+    render(<WorkspaceLauncher />);
+    expect(screen.queryByRole('button', { name: 'Update' })).toBeNull();
   });
 });

--- a/apps/desktop/src/features/workspace/components/WorkspaceLauncher/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspaceLauncher/index.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { Plus, Search } from 'lucide-react';
-import { cn } from '@goodboy/ui';
+import { Plus, Search, Unplug } from 'lucide-react';
+import { Button, Dialog, cn } from '@goodboy/ui';
 import type { Workspace } from '@goodboy/types';
 import { useAppStore, useWorkspaces } from '../../../../store';
 import { DogMascot } from '../../../../shared/components/DogMascot';
 import { SETTING_REOPEN_LAST } from '../../../settings/settings';
+import { UpdateIndicator } from '../../../updater/components/UpdateIndicator';
 import { WorkspaceRow } from '../WorkspaceRow';
 import { filterWorkspaces, sortWorkspacesByRecent } from '../../recent';
 
@@ -12,10 +13,13 @@ export const WorkspaceLauncher = () => {
   const workspaces = useWorkspaces();
   const openWorkspace = useAppStore((s) => s.openWorkspace);
   const saveSetting = useAppStore((s) => s.saveSetting);
+  const deleteWorkspace = useAppStore((s) => s.deleteWorkspace);
   const reopenLast = useAppStore((s) => s.settings[SETTING_REOPEN_LAST] === '1');
   const inputRef = useRef<HTMLInputElement>(null);
   const [query, setQuery] = useState('');
   const [activeIndex, setActiveIndex] = useState(0);
+  const [disconnectTarget, setDisconnectTarget] = useState<Workspace | null>(null);
+  const [disconnecting, setDisconnecting] = useState(false);
 
   useEffect(() => {
     inputRef.current?.focus();
@@ -36,6 +40,19 @@ export const WorkspaceLauncher = () => {
 
   const addWorkspace = () => window.dispatchEvent(new CustomEvent('goodboy:add-workspace'));
 
+  const confirmDisconnect = async () => {
+    if (!disconnectTarget) {
+      return;
+    }
+    setDisconnecting(true);
+    try {
+      await deleteWorkspace(disconnectTarget.id);
+      setDisconnectTarget(null);
+    } finally {
+      setDisconnecting(false);
+    }
+  };
+
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'ArrowDown') {
       e.preventDefault();
@@ -53,7 +70,10 @@ export const WorkspaceLauncher = () => {
   };
 
   return (
-    <div className="flex h-full w-full items-center justify-center overflow-y-auto bg-background px-6 py-10">
+    <div className="relative flex h-full w-full items-center justify-center overflow-y-auto bg-background px-6 py-10">
+      <div data-tauri-drag-region="false" className="absolute right-4 top-3">
+        <UpdateIndicator variant="bar" />
+      </div>
       <div className="w-full max-w-xl motion-safe:animate-fade-in">
         <div className="mb-8 flex flex-col items-center text-center">
           <DogMascot size={56} className="mb-4 text-primary" />
@@ -86,13 +106,23 @@ export const WorkspaceLauncher = () => {
             </li>
           ) : (
             filtered.map((w, i) => (
-              <li key={w.id}>
+              <li key={w.id} className="group/launcher relative">
                 <WorkspaceRow
                   workspace={w}
                   density="card"
                   highlighted={i === activeIndex}
                   onOpen={() => select(w)}
                 />
+                <button
+                  type="button"
+                  data-tauri-drag-region="false"
+                  aria-label={`Disconnect ${w.name}`}
+                  title={`Disconnect ${w.name}`}
+                  onClick={() => setDisconnectTarget(w)}
+                  className="absolute right-2 top-1/2 -translate-y-1/2 rounded-md border border-border-soft bg-background p-1.5 text-muted-foreground opacity-0 transition-opacity hover:text-danger focus-visible:opacity-100 group-hover/launcher:opacity-100"
+                >
+                  <Unplug size={13} aria-hidden />
+                </button>
               </li>
             ))
           )}
@@ -117,6 +147,38 @@ export const WorkspaceLauncher = () => {
           Reopen last workspace on launch
         </label>
       </div>
+      <Dialog
+        open={disconnectTarget !== null}
+        onClose={() => setDisconnectTarget(null)}
+        size="sm"
+        title="Disconnect workspace?"
+        description={disconnectTarget?.name ?? ''}
+        footer={
+          <>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setDisconnectTarget(null)}
+              disabled={disconnecting}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="danger"
+              size="sm"
+              onClick={() => void confirmDisconnect()}
+              disabled={disconnecting}
+            >
+              Disconnect
+            </Button>
+          </>
+        }
+      >
+        <p className="leading-relaxed text-muted-foreground">
+          Hides it from this list. Nothing on disk is deleted, re-add the same path to bring it back
+          with all its sessions.
+        </p>
+      </Dialog>
     </div>
   );
 };


### PR DESCRIPTION
## What

The workspace launcher was a dead end for two recovery paths:

- **Updating the app.** The update check already runs at boot, before any workspace opens, but the only place its result surfaced was the top bar inside a workspace. A user whose workspace crashes on open (the v0.1.36 scenario, #1038) could never reach the fix from the launcher.
- **Removing a workspace.** Disconnect only exists in Settings inside an open workspace, so a workspace that cannot open cannot be removed either: the broken entry stays in the recents list forever.

## How

- the launcher mounts the existing `UpdateIndicator` absolutely in the top-right corner. It renders nothing when the app is current, and it carries its own confirm dialog, so the view is untouched in the normal case (benchmark: VS Code's update badge on the launcher-adjacent gear)
- each recent row reveals a disconnect action on hover or keyboard focus, in the same position VS Code puts "remove from recent workspaces". It asks for confirmation and calls the existing soft `deleteWorkspace`: nothing on disk is deleted, re-adding the same path brings the workspace back with all its sessions

## Tests

- disconnect requires the confirmation, calls `deleteWorkspace` with the right id, and never opens the workspace
- cancelling the dialog leaves everything untouched
- the update action appears when an update is available, installs through the existing confirm flow, and is absent when the app is current
- full suite: 341 files, 2809 tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
