### PR TITLE
fix(desktop): dropped files, expired tokens and the model a new agent gets

### DIFF
--- a/apps/desktop/src-tauri/src/workflows.rs
+++ b/apps/desktop/src-tauri/src/workflows.rs
@@ -173,6 +173,11 @@ pub struct SessionRow {
     pub done_at: Option<String>,
     pub kind: Option<String>,
     pub verbosity: Option<String>,
+    pub effort: Option<String>,
+    #[serde(rename = "modelOverride")]
+    pub model_override: Option<String>,
+    #[serde(rename = "providerOverride")]
+    pub provider_override: Option<String>,
     #[serde(rename = "parentAgentId")]
     pub parent_agent_id: Option<String>,
     #[serde(rename = "workflowRunId")]
@@ -859,49 +864,57 @@ pub fn step_def_delete(state: State<'_, Db>, id: String) -> Result<(), PhaseErro
 // Commands — agent (= session row) lifecycle
 // ---------------------------------------------------------------------------
 
+const AGENT_SESSION_COLS: &str =
+    "id, session_id, step_id, ordinal, name, status, \
+     provider_run_id, output_summary, started_at, completed_at, \
+     provider_session_id, last_finished_at, last_viewed_at, done_at, kind, verbosity, \
+     effort, model_override, provider_override, \
+     parent_agent_id, workflow_run_id, source_thread_id, source_thread_ids, source_comment_url, \
+     source_kind, domains_json";
+
+fn session_row_from_row(row: &rusqlite::Row<'_>) -> Result<SessionRow, rusqlite::Error> {
+    Ok(SessionRow {
+        id: row.get(0)?,
+        session_id: row.get(1)?,
+        step_id: row.get(2)?,
+        ordinal: row.get(3)?,
+        name: row.get(4)?,
+        status: row.get(5)?,
+        provider_run_id: row.get(6)?,
+        output_summary: row.get(7)?,
+        started_at: row.get(8)?,
+        completed_at: row.get(9)?,
+        provider_session_id: row.get(10)?,
+        last_finished_at: row.get(11)?,
+        last_viewed_at: row.get(12)?,
+        done_at: row.get(13)?,
+        kind: row.get(14)?,
+        verbosity: row.get(15)?,
+        effort: row.get(16)?,
+        model_override: row.get(17)?,
+        provider_override: row.get(18)?,
+        parent_agent_id: row.get(19)?,
+        workflow_run_id: row.get(20)?,
+        source_thread_id: row.get(21)?,
+        source_thread_ids: row.get(22)?,
+        source_comment_url: row.get(23)?,
+        source_kind: row.get(24)?,
+        domains_json: row.get(25)?,
+    })
+}
+
 #[tauri::command]
 pub fn agent_list_for_session(
     state: State<'_, Db>,
     session_id: String,
 ) -> Result<Vec<SessionRow>, PhaseError> {
     let conn = state.0.lock().map_err(|_| PhaseError::Poisoned)?;
-    let mut stmt = conn.prepare(
-        "SELECT id, session_id, step_id, ordinal, name, status,
-                provider_run_id, output_summary, started_at, completed_at,
-                provider_session_id, last_finished_at, last_viewed_at, done_at, kind, verbosity,
-                parent_agent_id, workflow_run_id, source_thread_id, source_thread_ids, source_comment_url,
-                source_kind, domains_json
-         FROM agents
-         WHERE session_id = ?1
-         ORDER BY ordinal ASC",
-    )?;
-    let rows = stmt.query_map(rusqlite::params![session_id], |row| {
-        Ok(SessionRow {
-            id: row.get(0)?,
-            session_id: row.get(1)?,
-            step_id: row.get(2)?,
-            ordinal: row.get(3)?,
-            name: row.get(4)?,
-            status: row.get(5)?,
-            provider_run_id: row.get(6)?,
-            output_summary: row.get(7)?,
-            started_at: row.get(8)?,
-            completed_at: row.get(9)?,
-            provider_session_id: row.get(10)?,
-            last_finished_at: row.get(11)?,
-            last_viewed_at: row.get(12)?,
-            done_at: row.get(13)?,
-            kind: row.get(14)?,
-            verbosity: row.get(15)?,
-            parent_agent_id: row.get(16)?,
-            workflow_run_id: row.get(17)?,
-            source_thread_id: row.get(18)?,
-            source_thread_ids: row.get(19)?,
-            source_comment_url: row.get(20)?,
-            source_kind: row.get(21)?,
-            domains_json: row.get(22)?,
-        })
-    })?;
+    let sql = format!(
+        "SELECT {cols} FROM agents WHERE session_id = ?1 ORDER BY ordinal ASC",
+        cols = AGENT_SESSION_COLS
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(rusqlite::params![session_id], session_row_from_row)?;
     rows.collect::<Result<Vec<_>, _>>().map_err(PhaseError::Db)
 }
 
@@ -960,6 +973,9 @@ pub fn agent_insert(
         done_at: None,
         kind: input.kind,
         verbosity: input.verbosity,
+        effort: None,
+        model_override: None,
+        provider_override: None,
         parent_agent_id: input.parent_agent_id,
         workflow_run_id: input.workflow_run_id,
         source_thread_id: input.source_thread_id,
@@ -1004,43 +1020,12 @@ pub fn agent_update_status(
     )?;
 
     // Fetch updated row.
-    let mut stmt = conn.prepare(
-        "SELECT id, session_id, step_id, ordinal, name, status,
-                provider_run_id, output_summary, started_at, completed_at,
-                provider_session_id, last_finished_at, last_viewed_at, done_at, kind, verbosity,
-                parent_agent_id, workflow_run_id, source_thread_id, source_thread_ids, source_comment_url,
-                source_kind, domains_json
-         FROM agents
-         WHERE id = ?1
-         LIMIT 1",
-    )?;
-    let mut rows = stmt.query_map(rusqlite::params![input.id], |row| {
-        Ok(SessionRow {
-            id: row.get(0)?,
-            session_id: row.get(1)?,
-            step_id: row.get(2)?,
-            ordinal: row.get(3)?,
-            name: row.get(4)?,
-            status: row.get(5)?,
-            provider_run_id: row.get(6)?,
-            output_summary: row.get(7)?,
-            started_at: row.get(8)?,
-            completed_at: row.get(9)?,
-            provider_session_id: row.get(10)?,
-            last_finished_at: row.get(11)?,
-            last_viewed_at: row.get(12)?,
-            done_at: row.get(13)?,
-            kind: row.get(14)?,
-            verbosity: row.get(15)?,
-            parent_agent_id: row.get(16)?,
-            workflow_run_id: row.get(17)?,
-            source_thread_id: row.get(18)?,
-            source_thread_ids: row.get(19)?,
-            source_comment_url: row.get(20)?,
-            source_kind: row.get(21)?,
-            domains_json: row.get(22)?,
-        })
-    })?;
+    let sql = format!(
+        "SELECT {cols} FROM agents WHERE id = ?1 LIMIT 1",
+        cols = AGENT_SESSION_COLS
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let mut rows = stmt.query_map(rusqlite::params![input.id], session_row_from_row)?;
     match rows.next() {
         Some(r) => Ok(r.map_err(PhaseError::Db)?),
         None => Err(PhaseError::RunNotFound(input.id)),
@@ -1162,4 +1147,67 @@ pub fn workspaces_with_unread(state: State<'_, Db>) -> Result<Vec<String>, Phase
     )?;
     let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
     rows.collect::<Result<Vec<_>, _>>().map_err(PhaseError::Db)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn agents_table_conn() -> rusqlite::Connection {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE agents (
+                id TEXT, session_id TEXT, step_id TEXT, ordinal INTEGER, name TEXT, status TEXT,
+                provider_run_id TEXT, output_summary TEXT, started_at TEXT, completed_at TEXT,
+                provider_session_id TEXT, last_finished_at TEXT, last_viewed_at TEXT, done_at TEXT,
+                kind TEXT, verbosity TEXT, effort TEXT, model_override TEXT, provider_override TEXT,
+                parent_agent_id TEXT, workflow_run_id TEXT, source_thread_id TEXT,
+                source_thread_ids TEXT, source_comment_url TEXT, source_kind TEXT, domains_json TEXT
+            )",
+        )
+        .unwrap();
+        conn
+    }
+
+    #[test]
+    fn agent_session_cols_round_trips_routing_fields() {
+        let conn = agents_table_conn();
+        conn.execute(
+            "INSERT INTO agents (id, session_id, ordinal, name, status, effort, model_override, provider_override)
+             VALUES ('a1', 's1', 0, 'scout', 'pending', 'high', 'claude-opus-4-8', 'anthropic')",
+            [],
+        )
+        .unwrap();
+
+        let sql = format!("SELECT {cols} FROM agents WHERE id = ?1", cols = AGENT_SESSION_COLS);
+        let mut stmt = conn.prepare(&sql).unwrap();
+        let row = stmt
+            .query_row(rusqlite::params!["a1"], session_row_from_row)
+            .unwrap();
+
+        assert_eq!(row.effort.as_deref(), Some("high"));
+        assert_eq!(row.model_override.as_deref(), Some("claude-opus-4-8"));
+        assert_eq!(row.provider_override.as_deref(), Some("anthropic"));
+    }
+
+    #[test]
+    fn agent_session_cols_default_routing_fields_to_none() {
+        let conn = agents_table_conn();
+        conn.execute(
+            "INSERT INTO agents (id, session_id, ordinal, name, status)
+             VALUES ('a2', 's1', 1, 'planner', 'pending')",
+            [],
+        )
+        .unwrap();
+
+        let sql = format!("SELECT {cols} FROM agents WHERE id = ?1", cols = AGENT_SESSION_COLS);
+        let mut stmt = conn.prepare(&sql).unwrap();
+        let row = stmt
+            .query_row(rusqlite::params!["a2"], session_row_from_row)
+            .unwrap();
+
+        assert!(row.effort.is_none());
+        assert!(row.model_override.is_none());
+        assert!(row.provider_override.is_none());
+    }
 }

--- a/apps/desktop/src/__tests__/parallel-e2e.test.ts
+++ b/apps/desktop/src/__tests__/parallel-e2e.test.ts
@@ -173,6 +173,7 @@ function makeDeps(effects: ParallelBranchEffects) {
     provider: 'anthropic' as ProviderId,
     providerBinary: 'claude',
     model: 'claude-sonnet-4-6',
+    authIdentity: null,
     effects,
   };
 }

--- a/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
+++ b/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
@@ -217,6 +217,7 @@ exports[`snapshot, empty states > NewSessionView: no workflows 1`] = `
             </header>
             <div
               class="flex flex-col gap-2 rounded-lg border border-dashed px-3 py-3 transition-colors border-border-soft"
+              data-drop-composer="true"
             >
               <input
                 accept="image/*,.pdf,.csv,.tsv,.txt,.log,.md,.markdown,.json,.xml,.yaml,.yml,.docx,.xlsx"
@@ -1088,6 +1089,7 @@ exports[`snapshot, error states > NewSessionView: form error 1`] = `
             </header>
             <div
               class="flex flex-col gap-2 rounded-lg border border-dashed px-3 py-3 transition-colors border-border-soft"
+              data-drop-composer="true"
             >
               <input
                 accept="image/*,.pdf,.csv,.tsv,.txt,.log,.md,.markdown,.json,.xml,.yaml,.yml,.docx,.xlsx"

--- a/apps/desktop/src/features/chat/components/ChatInput/hooks/resolveDropTarget.ts
+++ b/apps/desktop/src/features/chat/components/ChatInput/hooks/resolveDropTarget.ts
@@ -1,0 +1,70 @@
+import { currentZoom } from '../../../../../shared/lib/zoom';
+
+type Point = {
+  readonly x: number;
+  readonly y: number;
+};
+
+export type DropTargetResult = {
+  readonly hit: boolean;
+  readonly ambiguousMiss: boolean;
+};
+
+const isVisible = (el: HTMLElement): boolean => el.offsetParent !== null;
+
+const getVisibleComposers = (): HTMLElement[] =>
+  Array.from(document.querySelectorAll<HTMLElement>('[data-drop-composer]')).filter(isVisible);
+
+const isInsideRect = ({
+  x,
+  y,
+  el,
+}: {
+  readonly x: number;
+  readonly y: number;
+  readonly el: HTMLElement;
+}): boolean => {
+  const rect = el.getBoundingClientRect();
+  return x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom;
+};
+
+const findHit = ({
+  point,
+  elements,
+}: {
+  readonly point: Point;
+  readonly elements: ReadonlyArray<HTMLElement>;
+}): HTMLElement | null =>
+  elements.find((el) => isInsideRect({ x: point.x, y: point.y, el })) ?? null;
+
+export const resolveDropTarget = ({
+  px,
+  py,
+  composer,
+}: {
+  readonly px: number;
+  readonly py: number;
+  readonly composer: HTMLElement;
+}): DropTargetResult => {
+  const visible = getVisibleComposers();
+  if (visible.length <= 1) {
+    return { hit: visible.length === 1 && visible[0] === composer, ambiguousMiss: false };
+  }
+
+  const zoom = currentZoom();
+  const dpr = window.devicePixelRatio || 1;
+  const logical: Point = { x: px / zoom, y: py / zoom };
+  const physical: Point = { x: px / (dpr * zoom), y: py / (dpr * zoom) };
+
+  const logicalHit = findHit({ point: logical, elements: visible });
+  if (logicalHit !== null) {
+    return { hit: logicalHit === composer, ambiguousMiss: false };
+  }
+
+  const physicalHit = findHit({ point: physical, elements: visible });
+  if (physicalHit !== null) {
+    return { hit: physicalHit === composer, ambiguousMiss: false };
+  }
+
+  return { hit: false, ambiguousMiss: true };
+};

--- a/apps/desktop/src/features/chat/components/ChatInput/hooks/usePendingAttachments.test.ts
+++ b/apps/desktop/src/features/chat/components/ChatInput/hooks/usePendingAttachments.test.ts
@@ -6,7 +6,7 @@ type DragHandler = (event: { payload: unknown }) => void;
 
 const { hooks } = vi.hoisted(() => ({
   hooks: {
-    handler: null as DragHandler | null,
+    handlers: [] as DragHandler[],
     zoom: 1,
     read: vi.fn(async (path: string) => ({
       fileName: path.split('/').pop() ?? path,
@@ -19,9 +19,9 @@ const { hooks } = vi.hoisted(() => ({
 vi.mock('@tauri-apps/api/webview', () => ({
   getCurrentWebview: () => ({
     onDragDropEvent: async (cb: DragHandler) => {
-      hooks.handler = cb;
+      hooks.handlers.push(cb);
       return () => {
-        hooks.handler = null;
+        hooks.handlers = hooks.handlers.filter((h) => h !== cb);
       };
     },
   }),
@@ -39,27 +39,45 @@ import { usePendingAttachments } from './usePendingAttachments';
 
 const COMPOSER_RECT = { left: 100, right: 300, top: 400, bottom: 500 };
 
-const mountWithComposer = async (showToast: ReturnType<typeof vi.fn>, enabled = true) => {
+const mountComposer = async (
+  showToast: ReturnType<typeof vi.fn>,
+  rect: { left: number; right: number; top: number; bottom: number },
+  enabled = true,
+) => {
   const rendered = renderHook(() => usePendingAttachments({ showToast, enabled }));
   const el = document.createElement('div');
+  el.setAttribute('data-drop-composer', '');
   document.body.appendChild(el);
   Object.defineProperty(el, 'offsetParent', { value: document.body, configurable: true });
   el.getBoundingClientRect = () =>
-    ({ ...COMPOSER_RECT, width: 200, height: 100, x: 100, y: 400 }) as DOMRect;
+    ({
+      ...rect,
+      width: rect.right - rect.left,
+      height: rect.bottom - rect.top,
+      x: rect.left,
+      y: rect.top,
+    }) as DOMRect;
   await act(async () => {
     (rendered.result.current.composerRef as { current: HTMLDivElement | null }).current = el;
   });
   return rendered;
 };
 
-const drop = async (x: number, y: number, paths: ReadonlyArray<string>) => {
+const mountWithComposer = async (showToast: ReturnType<typeof vi.fn>, enabled = true) =>
+  mountComposer(showToast, COMPOSER_RECT, enabled);
+
+const dispatch = async (payload: unknown) => {
   await act(async () => {
-    hooks.handler?.({ payload: { type: 'drop', position: { x, y }, paths } });
+    hooks.handlers.forEach((h) => h({ payload }));
   });
 };
 
+const drop = async (x: number, y: number, paths: ReadonlyArray<string>) => {
+  await dispatch({ type: 'drop', position: { x, y }, paths });
+};
+
 beforeEach(() => {
-  hooks.handler = null;
+  hooks.handlers = [];
   hooks.zoom = 1;
   hooks.read = vi.fn(async (path: string) => ({
     fileName: path.split('/').pop() ?? path,
@@ -68,30 +86,18 @@ beforeEach(() => {
   }));
   window.devicePixelRatio = 1;
 });
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  document.querySelectorAll('[data-drop-composer]').forEach((el) => el.remove());
+});
 
 describe('usePendingAttachments drop target', () => {
-  it('accepts a drop landing inside the composer', async () => {
-    const showToast = vi.fn();
-    const { result } = await mountWithComposer(showToast);
-    await drop(200, 450, ['/tmp/a.png']);
-    expect(result.current.attachments).toHaveLength(1);
-    expect(result.current.attachments[0]?.fileName).toBe('a.png');
-  });
-
-  it('ignores a drop outside the composer', async () => {
+  it('accepts a drop landing anywhere when it is the sole visible composer', async () => {
     const showToast = vi.fn();
     const { result } = await mountWithComposer(showToast);
     await drop(10, 10, ['/tmp/a.png']);
-    expect(result.current.attachments).toHaveLength(0);
-  });
-
-  it('accounts for the webview zoom factor when hit testing', async () => {
-    hooks.zoom = 2;
-    const showToast = vi.fn();
-    const { result } = await mountWithComposer(showToast);
-    await drop(400, 900, ['/tmp/a.png']);
     expect(result.current.attachments).toHaveLength(1);
+    expect(result.current.attachments[0]?.fileName).toBe('a.png');
   });
 
   it('reports unsupported files instead of dropping them silently', async () => {
@@ -113,16 +119,60 @@ describe('usePendingAttachments drop target', () => {
     );
   });
 
-  it('highlights only while the pointer is over the composer', async () => {
+  it('highlights the sole visible composer no matter where the pointer sits', async () => {
     const showToast = vi.fn();
     const { result } = await mountWithComposer(showToast);
-    await act(async () => {
-      hooks.handler?.({ payload: { type: 'over', position: { x: 10, y: 10 } } });
-    });
-    expect(result.current.isDragging).toBe(false);
-    await act(async () => {
-      hooks.handler?.({ payload: { type: 'over', position: { x: 200, y: 450 } } });
-    });
+    await dispatch({ type: 'over', position: { x: 10, y: 10 } });
     expect(result.current.isDragging).toBe(true);
+  });
+
+  it('accepts a drop at devicePixelRatio 2 using the logical-point candidate', async () => {
+    window.devicePixelRatio = 2;
+    const decoyRect = { left: 600, right: 700, top: 10, bottom: 60 };
+    const showToastA = vi.fn();
+    const showToastB = vi.fn();
+    const target = await mountComposer(showToastA, COMPOSER_RECT);
+    const decoy = await mountComposer(showToastB, decoyRect);
+    await drop(200, 450, ['/tmp/a.png']);
+    expect(target.result.current.attachments).toHaveLength(1);
+    expect(decoy.result.current.attachments).toHaveLength(0);
+  });
+
+  it('accepts a drop at devicePixelRatio 2 with a non-default zoom', async () => {
+    window.devicePixelRatio = 2;
+    hooks.zoom = 1.5;
+    const decoyRect = { left: 500, right: 700, top: 50, bottom: 150 };
+    const showToastA = vi.fn();
+    const showToastB = vi.fn();
+    const target = await mountComposer(showToastA, COMPOSER_RECT);
+    const decoy = await mountComposer(showToastB, decoyRect);
+    await drop(375, 720, ['/tmp/a.png']);
+    expect(target.result.current.attachments).toHaveLength(1);
+    expect(decoy.result.current.attachments).toHaveLength(0);
+  });
+
+  it('routes a multi-composer drop to the composer under the pointer', async () => {
+    const decoyRect = { left: 600, right: 700, top: 10, bottom: 60 };
+    const showToastA = vi.fn();
+    const showToastB = vi.fn();
+    const first = await mountComposer(showToastA, COMPOSER_RECT);
+    const second = await mountComposer(showToastB, decoyRect);
+    await drop(650, 30, ['/tmp/b.png']);
+    expect(first.result.current.attachments).toHaveLength(0);
+    expect(second.result.current.attachments).toHaveLength(1);
+    expect(second.result.current.attachments[0]?.fileName).toBe('b.png');
+  });
+
+  it('warns on an ambiguous miss when several composers are visible but neither candidate hits', async () => {
+    const decoyRect = { left: 600, right: 700, top: 10, bottom: 60 };
+    const showToastA = vi.fn();
+    const showToastB = vi.fn();
+    await mountComposer(showToastA, COMPOSER_RECT);
+    await mountComposer(showToastB, decoyRect);
+    await drop(0, 0, ['/tmp/a.png']);
+    expect(showToastA).toHaveBeenCalledWith(
+      'warning',
+      expect.stringContaining('drop the file on a message box'),
+    );
   });
 });

--- a/apps/desktop/src/features/chat/components/ChatInput/hooks/usePendingAttachments.ts
+++ b/apps/desktop/src/features/chat/components/ChatInput/hooks/usePendingAttachments.ts
@@ -9,7 +9,7 @@ import {
 import { getCurrentWebview } from '@tauri-apps/api/webview';
 import { isAllowedAttachment, resolveAttachmentMime } from '../../../attachment-kinds';
 import { readDroppedAttachment } from '../../../turn';
-import { currentZoom } from '../../../../../shared/lib/zoom';
+import { resolveDropTarget } from './resolveDropTarget';
 import type { ToastKind } from '../../../../../app/components/Toast';
 import {
   ATTACHMENT_LIMIT,
@@ -129,18 +129,6 @@ export const usePendingAttachments = ({ showToast, enabled = true, persistToDisk
     let cancelled = false;
     let unlisten: (() => void) | null = null;
 
-    const isInsideComposer = (px: number, py: number): boolean => {
-      const el = composerRef.current;
-      if (!el || el.offsetParent === null) {
-        return false;
-      }
-      const rect = el.getBoundingClientRect();
-      const scale = (window.devicePixelRatio || 1) * currentZoom();
-      const x = px / scale;
-      const y = py / scale;
-      return x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom;
-    };
-
     const basename = (path: string): string => path.split('/').pop() ?? path;
 
     const ingestDroppedPaths = async (paths: ReadonlyArray<string>) => {
@@ -204,16 +192,35 @@ export const usePendingAttachments = ({ showToast, enabled = true, persistToDisk
         const off = await getCurrentWebview().onDragDropEvent((event) => {
           const p = event.payload;
           switch (p.type) {
-            case 'enter':
-            case 'over':
-              setIsDragging(enabledRef.current && isInsideComposer(p.position.x, p.position.y));
-              break;
             case 'leave':
               setIsDragging(false);
               break;
+            case 'enter':
+            case 'over': {
+              const composer = composerRef.current;
+              if (!composer) {
+                setIsDragging(false);
+                break;
+              }
+              const { hit } = resolveDropTarget({ px: p.position.x, py: p.position.y, composer });
+              setIsDragging(enabledRef.current && hit);
+              break;
+            }
             case 'drop': {
               setIsDragging(false);
-              if (!isInsideComposer(p.position.x, p.position.y)) {
+              const composer = composerRef.current;
+              if (!composer) {
+                return;
+              }
+              const { hit, ambiguousMiss } = resolveDropTarget({
+                px: p.position.x,
+                py: p.position.y,
+                composer,
+              });
+              if (!hit) {
+                if (ambiguousMiss) {
+                  showToastRef.current('warning', 'drop the file on a message box to attach it');
+                }
                 return;
               }
               if (!enabledRef.current) {
@@ -232,6 +239,7 @@ export const usePendingAttachments = ({ showToast, enabled = true, persistToDisk
         }
       } catch (err) {
         console.warn('drag-drop listener registration failed:', err);
+        showToastRef.current('warning', 'file drop is unavailable, use the paperclip instead');
       }
     })();
 

--- a/apps/desktop/src/features/chat/components/ChatInput/index.tsx
+++ b/apps/desktop/src/features/chat/components/ChatInput/index.tsx
@@ -331,6 +331,7 @@ export const ChatInput = ({ session, providerDisconnected = false }: Props) => {
         />
         <div
           ref={composerRef}
+          data-drop-composer
           className={cn(
             'relative flex flex-col rounded-md ring-1 transition-all focus-within:ring-2 focus-within:ring-primary/40',
             isDragging ? 'bg-primary/5 ring-2 ring-primary' : 'bg-subtle/80 ring-border-soft',

--- a/apps/desktop/src/features/chat/turn.test.ts
+++ b/apps/desktop/src/features/chat/turn.test.ts
@@ -25,7 +25,7 @@ vi.mock('@tauri-apps/api/event', () => ({
   }),
 }));
 
-import { runTurn } from './turn';
+import { runTurn, isAuthErrorMessage } from './turn';
 
 afterEach(() => {
   capturedListeners.length = 0;
@@ -52,5 +52,22 @@ describe('runTurn', () => {
 
     await expect(iterator.next()).rejects.toThrow('provider emitted no events');
     expect(unlistenMock).toHaveBeenCalledOnce();
+  });
+});
+
+describe('isAuthErrorMessage', () => {
+  it('matches the real claude CLI expired-OAuth-token 401 message', () => {
+    const message =
+      'Failed to authenticate. API Error: 401 {"type":"error","error":{"type":"authentication_error","message":"OAuth access token has expired. Re-authenticate to continue."},"request_id":null}';
+
+    expect(isAuthErrorMessage(message)).toBe(true);
+  });
+
+  it('does not match an unrelated message that merely contains the digits 401', () => {
+    expect(isAuthErrorMessage('processed 4010 records before the connection dropped')).toBe(false);
+  });
+
+  it('still matches a plain "401" status embedded in other provider error text', () => {
+    expect(isAuthErrorMessage('request failed with status 401')).toBe(true);
   });
 });

--- a/apps/desktop/src/features/chat/turn.ts
+++ b/apps/desktop/src/features/chat/turn.ts
@@ -65,7 +65,7 @@ const AUTH_ERROR_PATTERNS = [
   /please log in/i,
   /please sign in/i,
   /unauthenticated/i,
-  /401/,
+  /\b401\b/,
   /unauthorized/i,
   /login required/i,
   /not signed in/i,

--- a/apps/desktop/src/features/session/agent-kind.ts
+++ b/apps/desktop/src/features/session/agent-kind.ts
@@ -261,6 +261,13 @@ export const kindRouting = ({ kind, roleModels }: KindRoutingParams): AgentKindR
   return { provider: role.provider, model: getCheapModel(role.provider), effort: 'low' };
 };
 
+export const isRightSizedKind = ({ kind, roleModels }: KindRoutingParams): boolean => {
+  if (!CHEAP_TIER_KINDS.has(kind)) {
+    return false;
+  }
+  return !resolveRoleRouting({ role: KIND_TO_ROLE[kind], prefs: roleModels }).isOverride;
+};
+
 export const AGENT_KIND_DEFAULTS: Record<
   AgentKind,
   {

--- a/apps/desktop/src/features/session/components/CreateAgentPopover/AgentRoutingSections.tsx
+++ b/apps/desktop/src/features/session/components/CreateAgentPopover/AgentRoutingSections.tsx
@@ -6,9 +6,7 @@ import { ModelGrid } from '../../../../shared/components/RoutingPicker/ModelGrid
 import { PickerChip } from '../../../../shared/components/RoutingPicker/PickerChip';
 import { PickerSection } from '../../../../shared/components/RoutingPicker/PickerSection';
 import { ProviderGlyph } from '../../../../shared/components/RoutingPicker/ProviderGlyph';
-import { RecommendationRow } from '../../../../shared/components/RoutingPicker/RecommendationRow';
 import { orderedEffortLevels } from '../../../../shared/components/RoutingPicker/orderedEffortLevels';
-import { recommendationSummary } from '../../../../shared/components/RoutingPicker/recommendationSummary';
 import { resolveRouting } from '../../../../shared/components/RoutingPicker/resolveRouting';
 import type { AgentKindRouting } from '../../agent-kind';
 
@@ -20,56 +18,41 @@ const PROVIDERS = Object.keys(PROVIDER_CAPABILITIES).filter(
 
 type Props = {
   readonly connectedProviders: ReadonlyArray<ProviderId>;
-  readonly recommended: AgentKindRouting;
-  readonly routing: AgentKindRouting | null;
+  readonly effective: AgentKindRouting;
   readonly viewProvider: ProviderId;
   readonly onViewProvider: (provider: ProviderId) => void;
   readonly onPickProvider: (provider: ProviderId) => void;
   readonly onPickModel: (model: string) => void;
   readonly onPickEffort: (effort: AgentKindRouting['effort']) => void;
-  readonly onUseRecommended: () => void;
   readonly onConnectProvider: (provider: ProviderId) => void;
 };
 
 export const AgentRoutingSections = ({
   connectedProviders,
-  recommended,
-  routing,
+  effective,
   viewProvider,
   onViewProvider,
   onPickProvider,
   onPickModel,
   onPickEffort,
-  onUseRecommended,
   onConnectProvider,
 }: Props) => {
-  const isAuto = routing == null;
-  const isViewingPicked = !isAuto && routing.provider === viewProvider;
   const viewedRouting = resolveRouting({
     providers: PROVIDERS,
     provider: viewProvider,
-    model: isViewingPicked ? routing.model : '',
-    effort: routing?.effort ?? recommended.effort,
+    model: viewProvider === effective.provider ? effective.model : '',
+    effort: effective.effort,
     recommendation: undefined,
   });
   const isProviderConnected = connectedProviders.includes(viewProvider);
 
   return (
     <>
-      <RecommendationRow
-        summary={recommendationSummary({
-          provider: recommended.provider,
-          model: recommended.model,
-        })}
-        active={isAuto}
-        onSelect={onUseRecommended}
-      />
-      <Divider />
       <PickerSection label="Provider" hint="Which CLI agent runs the turn">
         <div className={PROVIDER_CHIP_GROUP_CLASS}>
           {PROVIDERS.map((id) => {
             const isConnected = connectedProviders.includes(id);
-            const isActive = !isAuto && viewProvider === id;
+            const isActive = viewProvider === id;
             return (
               <button
                 key={id}
@@ -120,7 +103,7 @@ export const AgentRoutingSections = ({
             <ModelGrid
               ids={viewedRouting.models}
               value={viewedRouting.model}
-              isRecommended={isAuto}
+              isRecommended={false}
               onSelect={onPickModel}
             />
           </ScrollFade>

--- a/apps/desktop/src/features/session/components/CreateAgentPopover/SpawnRoutingSummary.tsx
+++ b/apps/desktop/src/features/session/components/CreateAgentPopover/SpawnRoutingSummary.tsx
@@ -1,0 +1,82 @@
+import { cn } from '@goodboy/ui';
+import {
+  EFFORT_LABEL,
+  PROVIDER_LABEL,
+  modelEffortLevels,
+  modelLabel,
+} from '../../../chat/utils/chat-constants';
+import type { AgentKind, AgentKindRouting } from '../../agent-kind';
+import type { SpawnRouting } from '../../spawn-routing';
+
+type Props = {
+  readonly kind: AgentKind;
+  readonly effective: AgentKindRouting;
+  readonly fallback: SpawnRouting;
+  readonly isPinned: boolean;
+  readonly onReset: () => void;
+};
+
+const RIGHT_SIZED_HINT: Partial<Record<AgentKind, string>> = {
+  scout: 'Scouts default to a smaller model, they only read code',
+  docs: 'Docs agents default to a smaller model, they only write prose',
+  generic: 'No model picked in this chat yet, so it starts small',
+};
+
+const ORIGIN_TAG: Record<SpawnRouting['origin'], string> = {
+  chat: 'from this chat',
+  'right-sized': 'recommended',
+  'role-default': 'recommended',
+};
+
+const routingLine = ({ provider, model, effort }: AgentKindRouting): string => {
+  const head = `${PROVIDER_LABEL[provider]} · ${modelLabel(model)}`;
+  if (modelEffortLevels(model) == null) {
+    return head;
+  }
+  return `${head}, ${EFFORT_LABEL[effort].toLowerCase()} effort`;
+};
+
+const modelLine = ({ model, effort }: AgentKindRouting): string => {
+  if (modelEffortLevels(model) == null) {
+    return modelLabel(model);
+  }
+  return `${modelLabel(model)}, ${EFFORT_LABEL[effort].toLowerCase()} effort`;
+};
+
+export const SpawnRoutingSummary = ({ kind, effective, fallback, isPinned, onReset }: Props) => {
+  const hint = RIGHT_SIZED_HINT[kind];
+  const showHint = !isPinned && fallback.origin === 'right-sized' && hint != null;
+  const resetPrefix = fallback.origin === 'chat' ? "Use this chat's model" : 'Use recommended';
+
+  return (
+    <div className="flex flex-col gap-1 px-2.5 py-2">
+      <div className="flex items-center gap-2">
+        <span className="min-w-0 flex-1 truncate text-xs font-medium text-foreground">
+          {routingLine(effective)}
+        </span>
+        {!isPinned && (
+          <span
+            className={cn(
+              'shrink-0 rounded-full px-1.5 py-0.5 text-2xs',
+              fallback.origin === 'chat'
+                ? 'bg-primary/10 text-primary'
+                : 'bg-background text-muted-foreground',
+            )}
+          >
+            {ORIGIN_TAG[fallback.origin]}
+          </span>
+        )}
+      </div>
+      {showHint && <p className="text-2xs leading-tight text-muted-foreground/70">{hint}</p>}
+      {isPinned && (
+        <button
+          type="button"
+          onClick={onReset}
+          className="self-start text-2xs text-muted-foreground underline-offset-2 transition-colors hover:text-foreground hover:underline"
+        >
+          {`${resetPrefix}: ${modelLine(fallback)}`}
+        </button>
+      )}
+    </div>
+  );
+};

--- a/apps/desktop/src/features/session/components/CreateAgentPopover/index.test.tsx
+++ b/apps/desktop/src/features/session/components/CreateAgentPopover/index.test.tsx
@@ -2,17 +2,46 @@
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
-import type { ProviderId, SessionId, WorkspaceId, WorkspaceKind } from '@goodboy/types';
+import type {
+  IsoDateTime,
+  ProviderId,
+  Session,
+  SessionId,
+  WorkspaceId,
+  WorkspaceKind,
+} from '@goodboy/types';
 
 type Store = {
   readonly spawnAgent: ReturnType<typeof vi.fn>;
   readonly providers: ReadonlyArray<{ readonly id: ProviderId; readonly connection: string }>;
+  readonly sessions: ReadonlyArray<Session>;
+  readonly workspaceOverrides: Record<string, unknown>;
 };
+
+const NOW = '2026-07-27T00:00:00.000Z' as IsoDateTime;
+const SID = 'sess-1' as SessionId;
+
+const makeSession = (overrides: Partial<Session> = {}): Session => ({
+  id: SID,
+  workspaceId: 'workspace-1' as WorkspaceId,
+  goal: 'g',
+  state: { kind: 'idle', lastActivityAt: NOW },
+  contextSlots: [],
+  providerPreference: { defaultProvider: 'anthropic', allowTurnOverride: true },
+  permissionMode: 'default',
+  workflowRuns: [],
+  autoRun: false,
+  titleUserEdited: false,
+  createdAt: NOW,
+  updatedAt: NOW,
+  ...overrides,
+});
 
 const h = vi.hoisted(() => ({
   spawnAgent: vi.fn(async () => 'a1'),
   providers: [{ id: 'anthropic' as ProviderId, connection: 'connected' }],
   workspaceKind: 'repo' as WorkspaceKind,
+  sessions: [] as ReadonlyArray<unknown>,
 }));
 
 vi.mock('../../../../store', () => ({
@@ -20,13 +49,13 @@ vi.mock('../../../../store', () => ({
     selector({
       spawnAgent: h.spawnAgent,
       providers: h.providers,
+      sessions: h.sessions as ReadonlyArray<Session>,
+      workspaceOverrides: {},
     }),
   useCurrentWorkspace: () => ({ id: 'workspace-1' as WorkspaceId, kind: h.workspaceKind }),
 }));
 
 import { CreateAgentPopover } from './index';
-
-const SID = 'sess-1' as SessionId;
 
 const renderControl = (variant?: 'tile' | 'compact') => {
   render(<CreateAgentPopover sessionId={SID} variant={variant} onSpawned={vi.fn()} />);
@@ -44,7 +73,10 @@ afterEach(() => {
   cleanup();
   vi.clearAllMocks();
   h.workspaceKind = 'repo';
+  h.sessions = [makeSession()];
 });
+
+h.sessions = [makeSession()];
 
 describe('CreateAgentPopover', () => {
   it('replaces the multi-control row with one tile that opens a single popover', () => {
@@ -52,9 +84,6 @@ describe('CreateAgentPopover', () => {
     const trigger = screen.getByRole('button', { name: 'Create agent' });
 
     expect(trigger.className).toContain('rounded-lg');
-    expect(trigger.className).toContain('border-border-soft');
-    expect(trigger.className).toContain('px-3');
-    expect(trigger.className).toContain('py-2.5');
     expect(screen.queryByRole('dialog', { name: 'create agent' })).toBeNull();
 
     openPopover();
@@ -67,20 +96,93 @@ describe('CreateAgentPopover', () => {
 
     const scout = screen.getByRole('button', { name: /^Scout / });
     expect(scout.getAttribute('title')).toBe('Reads and searches codebase. Never edits files');
-    expect(scout.textContent).toContain('Reads and searches codebase');
 
     fireEvent.click(screen.getByRole('button', { name: /^Docs / }));
     confirm();
 
-    expect(h.spawnAgent).toHaveBeenCalledWith(SID, { kindOverride: 'docs' });
+    expect(h.spawnAgent).toHaveBeenCalledWith(SID, {
+      kindOverride: 'docs',
+      provider: 'anthropic',
+      model: 'claude-haiku-4-5',
+      effort: 'low',
+    });
   });
 
-  it('spawns a generic agent with untouched defaults', () => {
+  it('gives a generic agent the model the chat is on and says where it comes from', () => {
+    h.sessions = [
+      makeSession({
+        providerOverride: 'anthropic',
+        modelOverride: 'claude-opus-5',
+        effort: 'high',
+      }),
+    ];
     renderControl();
     openPopover();
-    confirm();
 
-    expect(h.spawnAgent).toHaveBeenCalledWith(SID, { kindOverride: 'generic' });
+    expect(screen.getByText('Claude · Opus 5, high effort')).toBeTruthy();
+    expect(screen.getByText('from this chat')).toBeTruthy();
+
+    confirm();
+    expect(h.spawnAgent).toHaveBeenCalledWith(SID, {
+      kindOverride: 'generic',
+      provider: 'anthropic',
+      model: 'claude-opus-5',
+      effort: 'high',
+    });
+  });
+
+  it('keeps a scout on its smaller model even when the chat is on opus', () => {
+    h.sessions = [
+      makeSession({
+        providerOverride: 'anthropic',
+        modelOverride: 'claude-opus-5',
+        effort: 'high',
+      }),
+    ];
+    renderControl();
+    openPopover();
+    fireEvent.click(screen.getByRole('button', { name: /^Scout / }));
+
+    expect(screen.getByText('Claude · Haiku 4.5')).toBeTruthy();
+    expect(screen.getByText('recommended')).toBeTruthy();
+    expect(screen.getByText('Scouts default to a smaller model, they only read code')).toBeTruthy();
+
+    confirm();
+    expect(h.spawnAgent).toHaveBeenCalledWith(SID, {
+      kindOverride: 'scout',
+      provider: 'anthropic',
+      model: 'claude-haiku-4-5',
+      effort: 'low',
+    });
+  });
+
+  it('swaps the tag for a reset that names the model it would go back to', () => {
+    renderControl();
+    openPopover();
+    fireEvent.click(screen.getByTitle(/^claude-opus-5 \(/));
+
+    expect(screen.queryByText('recommended')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Use recommended: Haiku 4.5' }));
+
+    expect(screen.getByText('Claude · Haiku 4.5')).toBeTruthy();
+    expect(screen.getByText('recommended')).toBeTruthy();
+  });
+
+  it('spawns exactly the pinned model the picker shows', () => {
+    renderControl();
+    openPopover();
+    fireEvent.click(screen.getByTitle(/^claude-opus-5 \(/));
+
+    expect(screen.getByText('Claude · Opus 5, low effort')).toBeTruthy();
+
+    confirm();
+    expect(h.spawnAgent).toHaveBeenCalledWith(SID, {
+      kindOverride: 'generic',
+      provider: 'anthropic',
+      model: 'claude-opus-5',
+      effort: 'low',
+    });
   });
 
   it('drops the type section entirely in a simple workspace', () => {
@@ -90,19 +192,10 @@ describe('CreateAgentPopover', () => {
 
     expect(screen.queryByText('Agent type')).toBeNull();
     confirm();
-    expect(h.spawnAgent).toHaveBeenCalledWith(SID, { kindOverride: 'generic' });
-  });
-
-  it('passes a pinned model, provider and effort to the spawn', () => {
-    renderControl();
-    openPopover();
-    fireEvent.click(screen.getByTitle(/^claude-opus-5 \(/));
-    confirm();
-
     expect(h.spawnAgent).toHaveBeenCalledWith(SID, {
       kindOverride: 'generic',
       provider: 'anthropic',
-      model: 'claude-opus-5',
+      model: 'claude-haiku-4-5',
       effort: 'low',
     });
   });

--- a/apps/desktop/src/features/session/components/CreateAgentPopover/index.tsx
+++ b/apps/desktop/src/features/session/components/CreateAgentPopover/index.tsx
@@ -10,14 +10,15 @@ import { useDropdown } from '../../../../shared/hooks/useDropdown';
 import { useSessionRoleModels } from '../../../../shared/hooks/useSessionRoleModels';
 import {
   AGENT_KIND_META,
-  kindRouting,
   visibleAgentKinds,
   type AgentKind,
   type AgentKindRouting,
 } from '../../agent-kind';
+import { resolveSpawnRouting } from '../../spawn-routing';
 import { AgentKindGrid } from './AgentKindGrid';
 import { AgentRoutingSections } from './AgentRoutingSections';
 import { CreateAgentTrigger, type CreateAgentTriggerVariant } from './CreateAgentTrigger';
+import { SpawnRoutingSummary } from './SpawnRoutingSummary';
 
 type Props = {
   readonly sessionId: SessionId;
@@ -53,32 +54,25 @@ export const CreateAgentPopover = ({
     ),
   );
   const roleModels = useSessionRoleModels({ sessionId });
-  const recommended = kindRouting({ kind: selectedKind, roleModels });
-  const [viewProvider, setViewProvider] = useState<ProviderId>(recommended.provider);
+  const session = useAppStore((state) => state.sessions?.find((s) => s.id === sessionId) ?? null);
+  const spawnDefault = resolveSpawnRouting({ kind: selectedKind, roleModels, session });
+  const effective: AgentKindRouting = routing ?? spawnDefault;
+  const [viewProvider, setViewProvider] = useState<ProviderId>(spawnDefault.provider);
 
   useEffect(() => {
-    if (open) {
-      return;
-    }
-    setViewProvider(routing?.provider ?? recommended.provider);
-  }, [open, routing, recommended.provider]);
+    setViewProvider(routing?.provider ?? spawnDefault.provider);
+  }, [open, selectedKind, routing, spawnDefault.provider]);
 
   const onPickEffort = (effort: AgentKindRouting['effort']) => {
-    setRouting({
-      provider: routing?.provider ?? recommended.provider,
-      model: routing?.model ?? recommended.model,
-      effort,
-    });
+    setRouting({ provider: effective.provider, model: effective.model, effort });
   };
 
   const onCreate = async () => {
     await spawnAgent(sessionId, {
       kindOverride: selectedKind,
-      ...(routing != null && {
-        provider: routing.provider,
-        model: routing.model,
-        effort: routing.effort,
-      }),
+      provider: effective.provider,
+      model: effective.model,
+      effort: effective.effort,
     });
     setKind('generic');
     setRouting(null);
@@ -114,10 +108,20 @@ export const CreateAgentPopover = ({
                 <Divider />
               </>
             )}
+            <SpawnRoutingSummary
+              kind={selectedKind}
+              effective={effective}
+              fallback={spawnDefault}
+              isPinned={routing != null}
+              onReset={() => {
+                setRouting(null);
+                setViewProvider(spawnDefault.provider);
+              }}
+            />
+            <Divider />
             <AgentRoutingSections
               connectedProviders={connectedProviders}
-              recommended={recommended}
-              routing={routing}
+              effective={effective}
               viewProvider={viewProvider}
               onViewProvider={setViewProvider}
               onPickProvider={(provider) => {
@@ -125,25 +129,17 @@ export const CreateAgentPopover = ({
                 setRouting({
                   provider,
                   model,
-                  effort: clampEffort(model, routing?.effort ?? recommended.effort),
+                  effort: clampEffort(model, effective.effort),
                 });
               }}
               onPickModel={(model) => {
-                if (model === '') {
-                  setRouting(null);
-                  return;
-                }
                 setRouting({
                   provider: viewProvider,
                   model,
-                  effort: clampEffort(model, routing?.effort ?? recommended.effort),
+                  effort: clampEffort(model, effective.effort),
                 });
               }}
               onPickEffort={onPickEffort}
-              onUseRecommended={() => {
-                setRouting(null);
-                setViewProvider(recommended.provider);
-              }}
               onConnectProvider={(provider) => {
                 window.dispatchEvent(
                   new CustomEvent('goodboy:open-provider-studio', {

--- a/apps/desktop/src/features/session/components/NewSessionView/index.tsx
+++ b/apps/desktop/src/features/session/components/NewSessionView/index.tsx
@@ -396,6 +396,7 @@ export const NewSessionView = ({ onClose, workspaceId, onOpenSettings }: Props) 
             >
               <div
                 ref={composerRef}
+                data-drop-composer
                 className={cn(
                   'flex flex-col gap-2 rounded-lg border border-dashed px-3 py-3 transition-colors',
                   isDragging ? 'border-primary bg-primary/5' : 'border-border-soft',

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/index.test.tsx
@@ -307,7 +307,10 @@ describe('SessionOverviewPane start row (cluster B)', () => {
     fireEvent.click(screen.getByRole('button', { name: /^Create agent/ }));
     fireEvent.click(screen.getByRole('button', { name: /^Scout / }));
     fireEvent.click(screen.getByRole('button', { name: 'Spawn Scout' }));
-    expect(store.spawnAgent).toHaveBeenCalledWith('sess-1', { kindOverride: 'scout' });
+    expect(store.spawnAgent).toHaveBeenCalledWith(
+      'sess-1',
+      expect.objectContaining({ kindOverride: 'scout' }),
+    );
   });
 
   it('shows the two aligned start cards once work exists and no resolve start card', () => {
@@ -325,7 +328,10 @@ describe('SessionOverviewPane start row (cluster B)', () => {
     fireEvent.click(screen.getByRole('button', { name: /^Create agent/ }));
     fireEvent.click(screen.getByRole('button', { name: /^Scout / }));
     fireEvent.click(screen.getByRole('button', { name: 'Spawn Scout' }));
-    expect(store.spawnAgent).toHaveBeenCalledWith('sess-1', { kindOverride: 'scout' });
+    expect(store.spawnAgent).toHaveBeenCalledWith(
+      'sess-1',
+      expect.objectContaining({ kindOverride: 'scout' }),
+    );
   });
 
   it('treats discarded workflow runs as not active for freshness', () => {

--- a/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
@@ -782,6 +782,7 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
                     <SectionHeader icon={<Paperclip size={11} aria-hidden />} label="Attachments" />
                     <div
                       ref={composerRef}
+                      data-drop-composer
                       className={cn(
                         'flex flex-wrap items-center gap-2 rounded-lg border px-3 py-2 transition-colors',
                         isDragging

--- a/apps/desktop/src/features/session/spawn-routing.test.ts
+++ b/apps/desktop/src/features/session/spawn-routing.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import type { IsoDateTime, Session, SessionId, WorkspaceId } from '@goodboy/types';
+import { resolveSpawnRouting } from './spawn-routing';
+
+const NOW = '2026-07-27T00:00:00.000Z' as IsoDateTime;
+
+const makeSession = (overrides: Partial<Session> = {}): Session => ({
+  id: 'ses-1' as SessionId,
+  workspaceId: 'ws-1' as WorkspaceId,
+  goal: 'g',
+  state: { kind: 'idle', lastActivityAt: NOW },
+  contextSlots: [],
+  providerPreference: { defaultProvider: 'anthropic', allowTurnOverride: true },
+  permissionMode: 'default',
+  workflowRuns: [],
+  autoRun: false,
+  titleUserEdited: false,
+  createdAt: NOW,
+  updatedAt: NOW,
+  ...overrides,
+});
+
+describe('resolveSpawnRouting', () => {
+  it('gives a generic agent the model the chat is currently on', () => {
+    const routing = resolveSpawnRouting({
+      kind: 'generic',
+      roleModels: null,
+      session: makeSession({
+        providerOverride: 'anthropic',
+        modelOverride: 'claude-opus-5',
+        effort: 'high',
+      }),
+    });
+
+    expect(routing).toEqual({
+      provider: 'anthropic',
+      model: 'claude-opus-5',
+      effort: 'high',
+      origin: 'chat',
+    });
+  });
+
+  it('keeps the right-sized role default for an explicit kind, whatever the chat is on', () => {
+    const routing = resolveSpawnRouting({
+      kind: 'scout',
+      roleModels: null,
+      session: makeSession({
+        providerOverride: 'anthropic',
+        modelOverride: 'claude-opus-5',
+        effort: 'high',
+      }),
+    });
+
+    expect(routing).toEqual({
+      provider: 'anthropic',
+      model: 'claude-haiku-4-5',
+      effort: 'low',
+      origin: 'right-sized',
+    });
+  });
+
+  it('falls back to the cheap default when the chat has no model pinned', () => {
+    const routing = resolveSpawnRouting({
+      kind: 'generic',
+      roleModels: null,
+      session: makeSession(),
+    });
+
+    expect(routing).toEqual({
+      provider: 'anthropic',
+      model: 'claude-haiku-4-5',
+      effort: 'low',
+      origin: 'right-sized',
+    });
+  });
+
+  it('infers the provider from the chat model when the session pins none', () => {
+    const routing = resolveSpawnRouting({
+      kind: 'generic',
+      roleModels: null,
+      session: makeSession({ modelOverride: 'gpt-5.6' }),
+    });
+
+    expect(routing.provider).toBe('codex');
+    expect(routing.origin).toBe('chat');
+  });
+
+  it('reports a workspace role override as a plain role default, not a right-sized one', () => {
+    const routing = resolveSpawnRouting({
+      kind: 'scout',
+      roleModels: { scout: { providerId: 'anthropic', model: 'claude-opus-5', effort: 'high' } },
+      session: makeSession(),
+    });
+
+    expect(routing).toEqual({
+      provider: 'anthropic',
+      model: 'claude-opus-5',
+      effort: 'high',
+      origin: 'role-default',
+    });
+  });
+});

--- a/apps/desktop/src/features/session/spawn-routing.ts
+++ b/apps/desktop/src/features/session/spawn-routing.ts
@@ -1,0 +1,53 @@
+import { PROVIDER_CAPABILITIES, getModelProvider } from '@goodboy/core';
+import type { AgentEffort, ProviderId, RoleModelPreferences, Session } from '@goodboy/types';
+import { clampEffort } from '../chat/utils/chat-constants';
+import { isRightSizedKind, kindRouting, type AgentKind, type AgentKindRouting } from './agent-kind';
+
+export type SpawnRoutingOrigin = 'chat' | 'right-sized' | 'role-default';
+
+export type SpawnRouting = AgentKindRouting & {
+  readonly origin: SpawnRoutingOrigin;
+};
+
+type Params = {
+  readonly kind: AgentKind;
+  readonly roleModels: RoleModelPreferences | null;
+  readonly session: Session | null;
+};
+
+type ChatParams = {
+  readonly session: Session;
+  readonly fallbackEffort: AgentEffort;
+};
+
+const PROVIDER_IDS: ReadonlyArray<ProviderId> = Object.keys(PROVIDER_CAPABILITIES).filter(
+  (id): id is ProviderId => id in PROVIDER_CAPABILITIES,
+);
+
+const chatRouting = ({ session, fallbackEffort }: ChatParams): AgentKindRouting | null => {
+  const model = session.modelOverride;
+  if (model == null || model === '') {
+    return null;
+  }
+  const pinned = PROVIDER_IDS.find((id) => id === session.providerOverride) ?? null;
+  const provider = pinned ?? getModelProvider(model);
+  if (provider == null) {
+    return null;
+  }
+  return { provider, model, effort: clampEffort(model, session.effort ?? fallbackEffort) };
+};
+
+export const resolveSpawnRouting = ({ kind, roleModels, session }: Params): SpawnRouting => {
+  const roleDefault = kindRouting({ kind, roleModels });
+  const origin: SpawnRoutingOrigin = isRightSizedKind({ kind, roleModels })
+    ? 'right-sized'
+    : 'role-default';
+  if (kind !== 'generic' || session == null) {
+    return { ...roleDefault, origin };
+  }
+  const fromChat = chatRouting({ session, fallbackEffort: roleDefault.effort });
+  if (fromChat == null) {
+    return { ...roleDefault, origin };
+  }
+  return { ...fromChat, origin: 'chat' };
+};

--- a/apps/desktop/src/features/workflows/workflows.ts
+++ b/apps/desktop/src/features/workflows/workflows.ts
@@ -88,6 +88,9 @@ type RawAgentRow = {
   readonly doneAt: string | null;
   readonly kind: string | null;
   readonly verbosity: string | null;
+  readonly effort: string | null;
+  readonly modelOverride: string | null;
+  readonly providerOverride: string | null;
   readonly sourceThreadId: string | null;
   readonly sourceThreadIds: string | null;
   readonly sourceCommentUrl: string | null;
@@ -192,6 +195,9 @@ function rowToAgent(row: RawAgentRow): Agent {
     ...(row.doneAt != null && { doneAt: row.doneAt as IsoDateTime }),
     ...(row.kind != null && { kind: row.kind }),
     ...(row.verbosity != null && { verbosity: row.verbosity as VerbosityLevel }),
+    ...(row.effort != null && { effort: row.effort as AgentEffort }),
+    ...(row.modelOverride != null && { modelOverride: row.modelOverride }),
+    ...(row.providerOverride != null && { providerOverride: row.providerOverride }),
     ...(row.sourceThreadId != null && { sourceThreadId: row.sourceThreadId }),
     ...(sourceThreadIds.length > 0 && { sourceThreadIds }),
     ...(row.sourceCommentUrl != null && { sourceCommentUrl: row.sourceCommentUrl }),

--- a/apps/desktop/src/store/parallel-turn.ts
+++ b/apps/desktop/src/store/parallel-turn.ts
@@ -49,6 +49,7 @@ import {
 } from '../features/workflows/workflows';
 import { invokeParallelPhaseRunSpawn, cancelTurn } from '../features/chat/turn';
 import { inferAgentKindFromName } from '../features/session/agent-kind';
+import { resolveErrorTurnMessage } from './slices/turn/resolveErrorTurnMessage';
 
 export type ParallelBranchInputs = {
   readonly session: Session;
@@ -230,6 +231,7 @@ export type RunParallelBranchDeps = {
   readonly disallowedTools?: ReadonlyArray<string>;
   readonly apiKeyEnv?: string;
   readonly credentialId?: string;
+  readonly authIdentity: string | null;
   readonly effects: ParallelBranchEffects;
 };
 
@@ -246,7 +248,7 @@ export const runParallelBranch = async (
     maxParallelism,
     workingDir,
   } = inputs;
-  const { now, effects, provider } = deps;
+  const { now, effects, provider, authIdentity } = deps;
 
   const cappedDefs = groupDefs.slice(0, Math.max(1, maxParallelism));
 
@@ -297,11 +299,22 @@ export const runParallelBranch = async (
     });
     listener.registerRun(runId, {
       onEvent: (e) => {
+        const forwarded: TurnEvent =
+          e.kind === 'error'
+            ? {
+                ...e,
+                message: resolveErrorTurnMessage({
+                  message: e.message,
+                  providerId: provider,
+                  identity: authIdentity,
+                }),
+              }
+            : e;
         const cb = progressCallbacks.get(runId);
         if (cb) {
-          cb(e);
+          cb(forwarded);
         }
-        effects.appendTurnEvent(orchestratingAgentId, session.id, e);
+        effects.appendTurnEvent(orchestratingAgentId, session.id, forwarded);
       },
       onSettle: (status, error) => {
         const r = settleResolvers.get(runId);

--- a/apps/desktop/src/store/slices/agents/spawnAgent.test.ts
+++ b/apps/desktop/src/store/slices/agents/spawnAgent.test.ts
@@ -27,6 +27,7 @@ const {
   listConsumptionsForPlanSpy,
   listPlansForSessionSpy,
   fanOutClustersSpy,
+  updateAgentConfigSpy,
 } = vi.hoisted(() => ({
   invokeAgentInsertSpy: vi.fn(),
   invokeAgentListSpy: vi.fn(async () => [] as ReadonlyArray<Agent>),
@@ -34,6 +35,7 @@ const {
   listConsumptionsForPlanSpy: vi.fn(async () => []),
   listPlansForSessionSpy: vi.fn(async () => [] as ReadonlyArray<PlanWithCount>),
   fanOutClustersSpy: vi.fn(async () => undefined),
+  updateAgentConfigSpy: vi.fn(async () => undefined),
 }));
 
 vi.mock('../../../features/workflows/workflows', () => ({
@@ -46,6 +48,11 @@ vi.mock('../../../features/plans/plans', () => ({
   listConsumptionsForPlan: listConsumptionsForPlanSpy,
   listPlansForSession: listPlansForSessionSpy,
 }));
+
+vi.mock('@goodboy/db', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@goodboy/db')>();
+  return { ...actual, updateAgentConfig: updateAgentConfigSpy };
+});
 
 vi.mock('../workflows/clusterImplementation', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../workflows/clusterImplementation')>();
@@ -109,7 +116,10 @@ function makePlan(overrides: Partial<PlanWithCount> = {}): PlanWithCount {
   };
 }
 
-function buildHarness(plans: ReadonlyArray<PlanWithCount>) {
+function buildHarness(
+  plans: ReadonlyArray<PlanWithCount>,
+  sessionOverrides: Partial<Session> = {},
+) {
   listPlansForSessionSpy.mockResolvedValue(plans);
   invokeAgentInsertSpy.mockResolvedValue({
     id: INSERTED_ID,
@@ -137,6 +147,7 @@ function buildHarness(plans: ReadonlyArray<PlanWithCount>) {
     titleUserEdited: false,
     createdAt: NOW,
     updatedAt: NOW,
+    ...sessionOverrides,
   };
   const sendTurn = vi.fn(
     async (_arg: { sessionId: SessionId; agentId: AgentId; content: string }) => undefined,
@@ -215,6 +226,45 @@ describe('spawnAgent ad-hoc cluster fan-out', () => {
     expect(getState().agentModelOverride[INSERTED_ID]).toBe('claude-sonnet-4-6');
     expect(getState().agentProviderOverride[INSERTED_ID]).toBe('anthropic');
     expect(getState().agentEffortOverride[INSERTED_ID]).toBe('high');
+  });
+
+  it('writes the resolved routing onto the agent row and its db record', async () => {
+    const { getState, spawn } = buildHarness([]);
+    invokeAgentListSpy.mockResolvedValue([
+      {
+        id: INSERTED_ID,
+        sessionId: SESSION_ID,
+        ordinal: 0,
+        name: 'agent 1',
+        status: 'pending',
+      } as Agent,
+    ]);
+
+    await spawn(SESSION_ID, { kindOverride: 'planner' });
+
+    expect(getState().sessionPhaseRuns[SESSION_ID]?.[0]).toMatchObject({
+      providerOverride: 'anthropic',
+      modelOverride: 'claude-opus-5',
+      effort: 'high',
+    });
+    expect(updateAgentConfigSpy).toHaveBeenCalledWith(expect.anything(), INSERTED_ID, {
+      providerOverride: 'anthropic',
+      modelOverride: 'claude-opus-5',
+      effort: 'high',
+    });
+  });
+
+  it('keeps the role default for a programmatic spawn even when the chat pins a model', async () => {
+    const { getState, spawn } = buildHarness([], {
+      providerOverride: 'anthropic',
+      modelOverride: 'claude-opus-5',
+      effort: 'high',
+    });
+
+    await spawn(SESSION_ID, { kindOverride: 'scout' });
+
+    expect(getState().agentModelOverride[INSERTED_ID]).toBe('claude-haiku-4-5');
+    expect(getState().agentEffortOverride[INSERTED_ID]).toBe('low');
   });
 
   it('fans out an explicit (triggeredPlanId) plan with 2+ clusters', async () => {

--- a/apps/desktop/src/store/slices/agents/spawnAgent.ts
+++ b/apps/desktop/src/store/slices/agents/spawnAgent.ts
@@ -10,7 +10,10 @@ import type {
   StepId,
   WorkflowRunId,
 } from '@goodboy/types';
+import { updateAgentConfig } from '@goodboy/db';
 import { invokeAgentInsert, invokeAgentList } from '../../../features/workflows/workflows';
+import { tauriDatabase } from '../../../shared/lib/db';
+import { EFFORT_LEVELS } from '../../../features/chat/utils/chat-constants';
 import {
   addPlanConsumption as invokeAddPlanConsumption,
   listConsumptionsForPlan as invokeListConsumptionsForPlan,
@@ -107,7 +110,25 @@ export const spawnAgent = (set: SetFn, get: GetFn) => {
       ...(args.sourceCommentUrl !== undefined && { sourceCommentUrl: args.sourceCommentUrl }),
       ...(args.sourceKind !== undefined && { sourceKind: args.sourceKind }),
     });
-    const refreshed = await invokeAgentList(sessionId);
+    const resolvedProvider = args.provider ?? routing.provider;
+    const resolvedModel = args.model ?? routing.model;
+    const resolvedEffort = EFFORT_LEVELS.find((level) => level === args.effort) ?? routing.effort;
+    await updateAgentConfig(tauriDatabase, inserted.id, {
+      providerOverride: resolvedProvider,
+      modelOverride: resolvedModel,
+      effort: resolvedEffort,
+    });
+    const listed = await invokeAgentList(sessionId);
+    const refreshed = listed.map((agent) =>
+      agent.id === inserted.id
+        ? {
+            ...agent,
+            providerOverride: resolvedProvider,
+            modelOverride: resolvedModel,
+            effort: resolvedEffort,
+          }
+        : agent,
+    );
     set((s) => ({
       sessionPhaseRuns: { ...s.sessionPhaseRuns, [sessionId]: refreshed },
       selectedAgentId: { ...s.selectedAgentId, [sessionId]: inserted.id },
@@ -119,15 +140,15 @@ export const spawnAgent = (set: SetFn, get: GetFn) => {
       },
       agentModelOverride: {
         ...s.agentModelOverride,
-        [inserted.id]: args.model ?? routing.model,
+        [inserted.id]: resolvedModel,
       },
       agentProviderOverride: {
         ...s.agentProviderOverride,
-        [inserted.id]: args.provider ?? routing.provider,
+        [inserted.id]: resolvedProvider,
       },
       agentEffortOverride: {
         ...s.agentEffortOverride,
-        [inserted.id]: args.effort ?? routing.effort,
+        [inserted.id]: resolvedEffort,
       },
       ...(args.kindOverride !== undefined && {
         agentKindOverride: { ...s.agentKindOverride, [inserted.id]: args.kindOverride },

--- a/apps/desktop/src/store/slices/turn/dispatchParallelTurn.ts
+++ b/apps/desktop/src/store/slices/turn/dispatchParallelTurn.ts
@@ -20,6 +20,7 @@ import { AGENT_FEATURES } from '../../../shared/lib/features';
 import { runParallelBranch, type ParallelBranchEffects } from '../../parallel-turn';
 import { applySessionUpdate } from '../../session-mutators';
 import { invokeAgentList } from '../../../features/workflows/workflows';
+import { resolveErrorTurnMessage } from './resolveErrorTurnMessage';
 import type { GetFn, SetFn } from './types';
 
 type Params = {
@@ -160,6 +161,7 @@ export const dispatchParallelTurn = async (
         provider,
         providerBinary,
         model,
+        authIdentity: get().authResults?.[provider]?.identity ?? null,
         ...(claudeFlags.permissionMode !== undefined && {
           permissionMode: claudeFlags.permissionMode,
         }),
@@ -196,10 +198,15 @@ export const dispatchParallelTurn = async (
     }
   } catch (err) {
     const rawMessage = formatError(err);
+    const message = resolveErrorTurnMessage({
+      message: rawMessage,
+      providerId: provider,
+      identity: get().authResults?.[provider]?.identity ?? null,
+    });
     get().appendTurnEvent(activeAgentId, sessionId, {
       kind: 'error',
       runId: groupSessionRunId,
-      message: rawMessage,
+      message,
       at: now(),
     });
     const errorState: TurnState = {

--- a/apps/desktop/src/store/slices/turn/resolveErrorTurnMessage.test.ts
+++ b/apps/desktop/src/store/slices/turn/resolveErrorTurnMessage.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import type { ProviderId } from '@goodboy/types';
+import { decodeAuthRequiredMessage } from '../../../features/chat/turn';
+import { resolveErrorTurnMessage } from './resolveErrorTurnMessage';
+
+const ANTHROPIC = 'anthropic' as ProviderId;
+
+describe('resolveErrorTurnMessage', () => {
+  it('encodes an OAuth-expired 401 message into an auth_required payload', () => {
+    const message =
+      'Failed to authenticate. API Error: 401 {"type":"error","error":{"type":"authentication_error","message":"OAuth access token has expired. Re-authenticate to continue."},"request_id":null}';
+
+    const resolved = resolveErrorTurnMessage({ message, providerId: ANTHROPIC, identity: 'jane' });
+
+    expect(decodeAuthRequiredMessage(resolved)).toEqual({
+      providerId: ANTHROPIC,
+      identity: 'jane',
+    });
+  });
+
+  it('leaves a non-auth provider error message verbatim', () => {
+    const message = 'connection reset by peer';
+
+    const resolved = resolveErrorTurnMessage({ message, providerId: ANTHROPIC, identity: null });
+
+    expect(resolved).toBe(message);
+    expect(decodeAuthRequiredMessage(resolved)).toBeNull();
+  });
+
+  it('leaves our own static app copy (budget exceeded) verbatim', () => {
+    const message =
+      'All providers have exceeded their budget cap. Adjust budget rules or wait for the next billing period.';
+
+    const resolved = resolveErrorTurnMessage({ message, providerId: ANTHROPIC, identity: null });
+
+    expect(resolved).toBe(message);
+  });
+});

--- a/apps/desktop/src/store/slices/turn/resolveErrorTurnMessage.ts
+++ b/apps/desktop/src/store/slices/turn/resolveErrorTurnMessage.ts
@@ -1,0 +1,14 @@
+import type { ProviderId } from '@goodboy/types';
+import { encodeAuthRequiredMessage, isAuthErrorMessage } from '../../../features/chat/turn';
+
+type Params = {
+  message: string;
+  providerId: ProviderId;
+  identity: string | null;
+};
+
+export const resolveErrorTurnMessage = ({ message, providerId, identity }: Params): string => {
+  return isAuthErrorMessage(message)
+    ? encodeAuthRequiredMessage({ providerId, identity })
+    : message;
+};

--- a/apps/desktop/src/store/slices/turn/sendTurn.ts
+++ b/apps/desktop/src/store/slices/turn/sendTurn.ts
@@ -46,11 +46,7 @@ import { invokePermissionRuleList } from '../../../features/permissions/permissi
 import { invokeAgentList, invokeAgentUpdateStatus } from '../../../features/workflows/workflows';
 import { resolveProviderForTurn } from '../../../features/providers/routing';
 import { simpleSessionDirExists, worktreeChangedFiles } from '../../../features/worktree/worktree';
-import {
-  encodeAuthRequiredMessage,
-  isAuthErrorMessage,
-  runTurn,
-} from '../../../features/chat/turn';
+import { encodeAuthRequiredMessage, runTurn } from '../../../features/chat/turn';
 import { clampEffort, type EffortLevel } from '../../../features/chat/utils/chat-constants';
 import { verbosityDirective } from '../../../features/settings/verbosity';
 import { detectDrift } from '../../../features/session/drift-detection';
@@ -81,6 +77,7 @@ import { resolveSkillPrompt } from './resolveSkillPrompt';
 import { persistAttachments } from './persistAttachments';
 import { dispatchParallelTurn } from './dispatchParallelTurn';
 import { auditToolCall } from './auditToolCall';
+import { resolveErrorTurnMessage } from './resolveErrorTurnMessage';
 import { recordUsageTelemetry } from './recordUsageTelemetry';
 import type { GetFn, SetFn } from './types';
 
@@ -745,7 +742,7 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
         : undefined;
 
     try {
-      for await (const event of runTurn({
+      for await (const rawEvent of runTurn({
         runId,
         provider,
         model,
@@ -758,6 +755,17 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
         ...(apiKeyBinding ?? {}),
         ...claudeFlags,
       })) {
+        const event: TurnEvent =
+          rawEvent.kind === 'error'
+            ? {
+                ...rawEvent,
+                message: resolveErrorTurnMessage({
+                  message: rawEvent.message,
+                  providerId: provider,
+                  identity: get().authResults?.[provider]?.identity ?? null,
+                }),
+              }
+            : rawEvent;
         get().appendTurnEvent(activeAgentId, sessionId, event);
         if (event.kind === 'assistant_text') {
           assistantText += event.delta;
@@ -922,13 +930,11 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
     } catch (err) {
       lastError = err;
       const rawMessage = formatError(err);
-      const isAuthErr = isAuthErrorMessage(rawMessage);
-      const message = isAuthErr
-        ? encodeAuthRequiredMessage({
-            providerId: provider,
-            identity: get().authResults?.[provider]?.identity ?? null,
-          })
-        : rawMessage;
+      const message = resolveErrorTurnMessage({
+        message: rawMessage,
+        providerId: provider,
+        identity: get().authResults?.[provider]?.identity ?? null,
+      });
       const errorState: TurnState = {
         kind: 'error',
         message: rawMessage,

--- a/apps/desktop/src/store/slices/workflows/loadPhaseRunsForSession.test.ts
+++ b/apps/desktop/src/store/slices/workflows/loadPhaseRunsForSession.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { SessionId } from '@goodboy/types';
+import type { AppStore } from '../../store';
+import type { SetFn } from './types';
+
+const invokeSpy = vi.hoisted(() => vi.fn());
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: invokeSpy }));
+
+import { loadPhaseRunsForSession } from './loadPhaseRunsForSession';
+
+const SESSION_ID = 'ses-1' as SessionId;
+
+describe('loadPhaseRunsForSession', () => {
+  it('preserves a spawned agent provider, model and effort after a refresh', async () => {
+    invokeSpy.mockResolvedValueOnce([
+      {
+        id: 'agent-new',
+        sessionId: SESSION_ID,
+        stepId: null,
+        workflowRunId: null,
+        parentAgentId: null,
+        ordinal: 0,
+        name: 'scout',
+        status: 'pending',
+        providerRunId: null,
+        outputSummary: null,
+        startedAt: null,
+        completedAt: null,
+        providerSessionId: null,
+        lastFinishedAt: null,
+        lastViewedAt: null,
+        doneAt: null,
+        kind: 'scout',
+        verbosity: null,
+        effort: 'high',
+        modelOverride: 'claude-opus-5',
+        providerOverride: 'anthropic',
+        sourceThreadId: null,
+        sourceThreadIds: null,
+        sourceCommentUrl: null,
+        sourceKind: null,
+        domainsJson: null,
+      },
+    ]);
+
+    let state: Partial<AppStore> = { sessionPhaseRuns: {} };
+    const set: SetFn = (update) => {
+      const patch = typeof update === 'function' ? update(state as AppStore) : update;
+      state = { ...state, ...patch };
+    };
+
+    await loadPhaseRunsForSession(set)(SESSION_ID);
+
+    expect(state.sessionPhaseRuns?.[SESSION_ID]?.[0]).toMatchObject({
+      providerOverride: 'anthropic',
+      modelOverride: 'claude-opus-5',
+      effort: 'high',
+    });
+  });
+});

--- a/apps/desktop/src/store/store.idle-on-empty-stream.test.ts
+++ b/apps/desktop/src/store/store.idle-on-empty-stream.test.ts
@@ -9,16 +9,22 @@ import type {
   TurnEvent,
   WorkspaceId,
 } from '@goodboy/types';
+import { decodeAuthRequiredMessage } from '../features/chat/turn';
 
-const runTurnSpy = vi.fn();
-const cancelTurnSpy = vi.fn();
-
-vi.mock('../features/chat/turn', () => ({
-  runTurn: (args: unknown) => runTurnSpy(args),
-  cancelTurn: cancelTurnSpy,
-  encodeAuthRequiredMessage: () => '',
-  isAuthErrorMessage: () => false,
+const { runTurnSpy, cancelTurnSpy } = vi.hoisted(() => ({
+  runTurnSpy: vi.fn(),
+  cancelTurnSpy: vi.fn(),
 }));
+
+vi.mock('../features/chat/turn', async () => {
+  const actual =
+    await vi.importActual<typeof import('../features/chat/turn')>('../features/chat/turn');
+  return {
+    ...actual,
+    runTurn: (args: unknown) => runTurnSpy(args),
+    cancelTurn: cancelTurnSpy,
+  };
+});
 
 vi.mock('../features/permissions/permissions', () => ({
   invokePermissionRuleList: vi.fn(async () => []),
@@ -63,6 +69,7 @@ vi.mock('@goodboy/db', () => ({
   summarizeWorkspaceTelemetry: vi.fn(async () => null),
   summarizeWorkspaceProviderTelemetry: vi.fn(async () => []),
   updateProviderRunStatus: vi.fn(),
+  updateAgentConfig: vi.fn(),
   updateSessionState: vi.fn(),
   upsertContextSlot: vi.fn(),
   insertOpenQuestion: vi.fn(async () => undefined),
@@ -181,6 +188,37 @@ async function* throwingStream(runId: ProviderRunId): AsyncIterable<TurnEvent> {
     at: '2026-05-08T00:00:01.000Z' as IsoDateTime,
   };
   throw new Error('provider crashed mid-stream');
+}
+
+const OAUTH_EXPIRED_MESSAGE =
+  'Failed to authenticate. API Error: 401 {"type":"error","error":{"type":"authentication_error","message":"OAuth access token has expired. Re-authenticate to continue."},"request_id":null}';
+
+async function* authErrorEventStream(runId: ProviderRunId): AsyncIterable<TurnEvent> {
+  yield {
+    kind: 'error',
+    runId,
+    message: OAUTH_EXPIRED_MESSAGE,
+    at: '2026-05-08T00:00:01.000Z' as IsoDateTime,
+  };
+}
+
+async function* throwingAuthErrorStream(runId: ProviderRunId): AsyncIterable<TurnEvent> {
+  yield {
+    kind: 'assistant_text',
+    runId,
+    delta: 'partial',
+    at: '2026-05-08T00:00:01.000Z' as IsoDateTime,
+  };
+  throw new Error(OAUTH_EXPIRED_MESSAGE);
+}
+
+async function* nonAuthErrorEventStream(runId: ProviderRunId): AsyncIterable<TurnEvent> {
+  yield {
+    kind: 'error',
+    runId,
+    message: 'connection reset by peer',
+    at: '2026-05-08T00:00:01.000Z' as IsoDateTime,
+  };
 }
 
 describe('sendTurn, terminal state guarantees', () => {
@@ -340,5 +378,62 @@ describe('sendTurn, terminal state guarantees', () => {
       (c) => (c[2] as { kind: string }).kind,
     );
     expect(statuses).toContain('failed');
+  });
+
+  it('encodes a stream error event carrying the OAuth 401 text as auth_required, not a raw error item', async () => {
+    runTurnSpy.mockImplementation((args: { runId: ProviderRunId }) =>
+      authErrorEventStream(args.runId),
+    );
+
+    const useAppStore = await importStore();
+    setupSession(useAppStore);
+
+    await useAppStore.getState().sendTurn({ sessionId: SESSION_ID, content: 'hello' });
+
+    const transcript = useAppStore.getState().transcripts[AGENT_ID] ?? [];
+    const errorEvent = transcript.find((e) => e.kind === 'error');
+    const message = errorEvent && 'message' in errorEvent ? errorEvent.message : '';
+    expect(decodeAuthRequiredMessage(message)).toEqual({
+      providerId: 'anthropic',
+      identity: 'test',
+    });
+  });
+
+  it('encodes a thrown OAuth 401 error the same way as a stream error event', async () => {
+    runTurnSpy.mockImplementation((args: { runId: ProviderRunId }) =>
+      throwingAuthErrorStream(args.runId),
+    );
+
+    const useAppStore = await importStore();
+    setupSession(useAppStore);
+
+    await expect(
+      useAppStore.getState().sendTurn({ sessionId: SESSION_ID, content: 'boom' }),
+    ).rejects.toThrow();
+
+    const transcript = useAppStore.getState().transcripts[AGENT_ID] ?? [];
+    const errorEvent = transcript.find((e) => e.kind === 'error');
+    const message = errorEvent && 'message' in errorEvent ? errorEvent.message : '';
+    expect(decodeAuthRequiredMessage(message)).toEqual({
+      providerId: 'anthropic',
+      identity: 'test',
+    });
+  });
+
+  it('leaves a non-auth provider error event message verbatim', async () => {
+    runTurnSpy.mockImplementation((args: { runId: ProviderRunId }) =>
+      nonAuthErrorEventStream(args.runId),
+    );
+
+    const useAppStore = await importStore();
+    setupSession(useAppStore);
+
+    await useAppStore.getState().sendTurn({ sessionId: SESSION_ID, content: 'hello' });
+
+    const transcript = useAppStore.getState().transcripts[AGENT_ID] ?? [];
+    const errorEvent = transcript.find((e) => e.kind === 'error');
+    expect(errorEvent && 'message' in errorEvent ? errorEvent.message : '').toBe(
+      'connection reset by peer',
+    );
   });
 });

--- a/apps/desktop/src/store/store.parallel.test.ts
+++ b/apps/desktop/src/store/store.parallel.test.ts
@@ -15,23 +15,29 @@ import type {
   ProviderRunId,
   WorkspaceId,
 } from '@goodboy/types';
+import { decodeAuthRequiredMessage } from '../features/chat/turn';
 
 const agentFeaturesMock = { parallelAgents: false, maxParallelism: 4 };
 vi.mock('../shared/lib/features', () => ({
   AGENT_FEATURES: agentFeaturesMock,
 }));
 
-const runTurnSpy = vi.fn();
-const cancelTurnSpy = vi.fn();
-const invokeParallelPhaseRunSpawnSpy = vi.fn();
-
-vi.mock('../features/chat/turn', () => ({
-  runTurn: (args: unknown) => runTurnSpy(args),
-  cancelTurn: cancelTurnSpy,
-  invokeParallelPhaseRunSpawn: (args: unknown) => invokeParallelPhaseRunSpawnSpy(args),
-  encodeAuthRequiredMessage: () => '',
-  isAuthErrorMessage: () => false,
+const { runTurnSpy, cancelTurnSpy, invokeParallelPhaseRunSpawnSpy } = vi.hoisted(() => ({
+  runTurnSpy: vi.fn(),
+  cancelTurnSpy: vi.fn(),
+  invokeParallelPhaseRunSpawnSpy: vi.fn(),
 }));
+
+vi.mock('../features/chat/turn', async () => {
+  const actual =
+    await vi.importActual<typeof import('../features/chat/turn')>('../features/chat/turn');
+  return {
+    ...actual,
+    runTurn: (args: unknown) => runTurnSpy(args),
+    cancelTurn: cancelTurnSpy,
+    invokeParallelPhaseRunSpawn: (args: unknown) => invokeParallelPhaseRunSpawnSpy(args),
+  };
+});
 
 vi.mock('../features/permissions/permissions', () => ({
   invokePermissionRuleList: vi.fn(async () => []),
@@ -80,6 +86,7 @@ vi.mock('@goodboy/db', () => ({
   summarizeWorkspaceTelemetry: vi.fn(async () => null),
   summarizeWorkspaceProviderTelemetry: vi.fn(async () => []),
   updateProviderRunStatus: vi.fn(),
+  updateAgentConfig: vi.fn(),
   updateSessionState: vi.fn(),
   upsertContextSlot: vi.fn(),
   insertOpenQuestion: vi.fn(async () => undefined),
@@ -229,6 +236,12 @@ function buildTemplate(steps: ReadonlyArray<Step>): Workflow {
 function emitEnd(runId: ProviderRunId, exitCode: number = 0): void {
   for (const h of listenHandlers) {
     h({ runId, type: 'end', exit_code: exitCode, stderr: exitCode === 0 ? '' : 'failed' });
+  }
+}
+
+function emitLine(runId: ProviderRunId, line: string): void {
+  for (const h of listenHandlers) {
+    h({ runId, type: 'line', line });
   }
 }
 
@@ -449,5 +462,47 @@ describe('sendTurn, parallel agents branch', () => {
     await turnPromise;
 
     expect(parallelPhaseGroupUpdateCompletedAtSpy).toHaveBeenCalledOnce();
+  });
+
+  it('surfaces a parallel branch stream error carrying the OAuth 401 text as auth_required', async () => {
+    agentFeaturesMock.parallelAgents = true;
+    invokeParallelPhaseRunSpawnSpy.mockImplementation(
+      async (args: { runs: ReadonlyArray<{ runId: string }> }) => args.runs.map((r) => r.runId),
+    );
+
+    const useAppStore = await importStore();
+    setupSession(useAppStore, [
+      buildDef({ id: 'd-a', ordinal: 1, parallelGroup: 5 }),
+      buildDef({ id: 'd-b', ordinal: 2, parallelGroup: 5 }),
+    ]);
+    useAppStore.setState({ transcripts: {} });
+
+    const turnPromise = useAppStore.getState().sendTurn({ sessionId: SESSION_ID, content: 'plan' });
+    await new Promise((r) => setTimeout(r, 5));
+
+    const calls = invokeParallelPhaseRunSpawnSpy.mock.calls as unknown as ReadonlyArray<
+      [{ runs: ReadonlyArray<{ runId: ProviderRunId }> }]
+    >;
+    const runIdA = calls[0]![0].runs[0]!.runId;
+    const runIdB = calls[1]![0].runs[0]!.runId;
+
+    const oauthExpiredMessage =
+      'Failed to authenticate. API Error: 401 {"type":"error","error":{"type":"authentication_error","message":"OAuth access token has expired. Re-authenticate to continue."},"request_id":null}';
+    emitLine(
+      runIdA,
+      JSON.stringify({ type: 'result', subtype: 'error', error: oauthExpiredMessage }),
+    );
+    emitEnd(runIdA, 1);
+    emitEnd(runIdB, 0);
+
+    await turnPromise;
+
+    const transcript = useAppStore.getState().transcripts['agent-1' as AgentId] ?? [];
+    const errorEvent = transcript.find((e) => e.kind === 'error');
+    const message = errorEvent && 'message' in errorEvent ? errorEvent.message : '';
+    expect(decodeAuthRequiredMessage(message)).toEqual({
+      providerId: 'anthropic',
+      identity: 'test',
+    });
   });
 });

--- a/apps/desktop/src/store/store.workflow-stepper.test.ts
+++ b/apps/desktop/src/store/store.workflow-stepper.test.ts
@@ -58,6 +58,7 @@ vi.mock('@goodboy/db', () => ({
   summarizeWorkspaceTelemetry: vi.fn(async () => null),
   summarizeWorkspaceProviderTelemetry: vi.fn(async () => []),
   updateProviderRunStatus: vi.fn(),
+  updateAgentConfig: vi.fn(),
   updateSessionState: vi.fn(),
   upsertContextSlot: vi.fn(),
   insertOpenQuestion: vi.fn(async () => undefined),


### PR DESCRIPTION
Three bugs reported against 0.1.37, all shipping in 0.1.38.

### A dropped file never reached the composer

On macOS `wry` reads the drag position from AppKit's `draggingLocation()`, which
is in logical points, and `tauri-runtime-wry` wraps that tuple verbatim in a
`PhysicalPosition`. The type says physical, the value is not. The hit test
divided by `devicePixelRatio`, so on a retina display the coordinates were
halved and the computed point landed in the upper left of the window while the
composer sits at the bottom. The test missed and the drop returned silently. At
a ratio of 1 nothing is wrong, and every existing test pinned exactly that, which
is how this shipped twice.

Rather than pick a formula that is right on one platform and wrong on the next
(on Windows the position really is physical), the hit test now only runs when it
has to. One composer visible: a drop anywhere in the window attaches, matching
every comparable app. Several visible: both readings are tried and the drop
routes to whichever composer is hit. Ambiguous: a toast, never silence. Same
rule drives the drag highlight, so the highlight and the landing agree. Tests now
cover device pixel ratio 2.

### An expired token showed a raw 401

`AuthRequiredCallout` already exists and offers re-authentication, but the encode
path that produces it only covered thrown errors. Provider parsers emit an auth
failure as an ordinary `error` event in the stream, which `sendTurn` forwarded
verbatim, and the parallel branch path did not encode at all. All three sites now
share one helper. Static app copy stays verbatim. The `401` pattern gained a word
boundary so it cannot match digits inside an unrelated number.

Known limit: `claude auth status` reports an expired token as logged in, so the
app cannot detect this before running a turn. The fix makes the failure
actionable, it does not prevent it.

### A new agent ignored the model picked in chat

Not a regression, the old control did the same. A spawn took the per-role
default, and the popover defaults to the `generic` kind, which the cheap tier
downgrades to a small model at low effort. Picking opus and spawning got you
something else, and the picker rendered nothing selected so there was no way to
see it coming.

Generic now inherits the session's provider, model and effort: it carries no task
signal, so the user's active pick is the strongest one available, and the
right-size nudge still fires on its turns if the model is oversized. Explicit
kinds keep their role default, because the kind is a task-type declaration and a
scout should start small whatever the chat is set to. The popover always shows
the routing it will use, tagged `from this chat` or `recommended`, with a reset
that names the concrete model.

While fixing it: the resolved routing was only ever seeded into memory. The agent
row kept a null model, and `agent_list_for_session` did not even select those
three columns, so any later refresh blanked them and the composer fell back to
the session model. The routing is now written to the row and carried through
that query.

### Verification

`pnpm typecheck` clean, `pnpm test` green (2857 desktop, 896 core, 127 db, 31 ui),
`cargo test --locked` green (132 passed, including two new cases on the agent row
round-trip), knip clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)