### PR TITLE
UX iteration 7: autorun stall, header status, scripts, lens order, studio width

### DIFF
--- a/apps/desktop/src/features/impact/components/ImpactStudio/DelegationSection.tsx
+++ b/apps/desktop/src/features/impact/components/ImpactStudio/DelegationSection.tsx
@@ -25,7 +25,7 @@ export const DelegationSection = ({ delegation, windowId }: Props) => {
     return (
       <section className="flex flex-col gap-3">
         <SectionHeader label="Delegation and flow" hint="How work gets handed off and closed out" />
-        <div className="grid grid-cols-4 gap-3">
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-4">
           <Skeleton className="h-24 rounded-lg" />
           <Skeleton className="h-24 rounded-lg" />
           <Skeleton className="h-24 rounded-lg" />
@@ -54,7 +54,7 @@ export const DelegationSection = ({ delegation, windowId }: Props) => {
       {isWindowEmpty ? (
         <WindowEmptyState what="delegated work" />
       ) : (
-        <div className="grid grid-cols-4 gap-3">
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-4">
           <MetricCard
             label="workflow-driven"
             measure="Sessions with a workflow run that was not discarded, over every session active in the window"

--- a/apps/desktop/src/features/impact/components/ImpactStudio/PlanSection.tsx
+++ b/apps/desktop/src/features/impact/components/ImpactStudio/PlanSection.tsx
@@ -44,14 +44,14 @@ export const PlanSection = ({ plan, context, windowId }: Props) => {
         hint="How much shared brief every agent starts from"
       />
       {plan === null ? (
-        <div className="grid grid-cols-2 gap-3">
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
           <Skeleton className="h-24 rounded-lg" />
           <Skeleton className="h-24 rounded-lg" />
         </div>
       ) : plan.sessionCount === 0 && windowId === 'last30' ? (
         <WindowEmptyState what="planning activity" />
       ) : (
-        <div className="grid grid-cols-2 gap-3">
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
           <MetricCard
             label="planned sessions"
             measure="Sessions where an agent consumed a plan, over every session active in the window"

--- a/apps/desktop/src/features/impact/components/ImpactStudio/index.tsx
+++ b/apps/desktop/src/features/impact/components/ImpactStudio/index.tsx
@@ -46,7 +46,7 @@ export const ImpactStudio = ({ workspaceId, workspaceName, onClose }: Props) => 
     >
       {() => (
         <ScrollFade className="min-h-0 flex-1">
-          <div className="flex flex-col gap-5 px-6 py-5">
+          <div className="mx-auto flex w-full max-w-5xl flex-col gap-5 px-6 py-5">
             <HeroBand overview={overview} allTimeOverview={allTimeOverview} />
             {isWorkspaceEmpty ? (
               <EmptyState

--- a/apps/desktop/src/features/scripts/components/ScriptsPanel/DiscardDraftDialog.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsPanel/DiscardDraftDialog.tsx
@@ -1,0 +1,39 @@
+import { Button, Dialog } from '@goodboy/ui';
+
+type DiscardDraftDialogProps = {
+  readonly open: boolean;
+  readonly onSave: () => void;
+  readonly onDiscard: () => void;
+  readonly onCancel: () => void;
+};
+
+export const DiscardDraftDialog = ({
+  open,
+  onSave,
+  onDiscard,
+  onCancel,
+}: DiscardDraftDialogProps) => {
+  return (
+    <Dialog
+      open={open}
+      onClose={onCancel}
+      title="Unsaved changes"
+      size="sm"
+      footer={
+        <>
+          <Button variant="ghost" onClick={onCancel}>
+            Keep editing
+          </Button>
+          <Button variant="danger" onClick={onDiscard}>
+            Discard
+          </Button>
+          <Button onClick={onSave}>Save</Button>
+        </>
+      }
+    >
+      <p className="text-xs text-muted-foreground">
+        This script has unsaved edits. Save them or discard to continue.
+      </p>
+    </Dialog>
+  );
+};

--- a/apps/desktop/src/features/scripts/components/ScriptsPanel/DiscardDraftDialog.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsPanel/DiscardDraftDialog.tsx
@@ -1,18 +1,13 @@
 import { Button, Dialog } from '@goodboy/ui';
 
-type DiscardDraftDialogProps = {
+type Props = {
   readonly open: boolean;
   readonly onSave: () => void;
   readonly onDiscard: () => void;
   readonly onCancel: () => void;
 };
 
-export const DiscardDraftDialog = ({
-  open,
-  onSave,
-  onDiscard,
-  onCancel,
-}: DiscardDraftDialogProps) => {
+export const DiscardDraftDialog = ({ open, onSave, onDiscard, onCancel }: Props) => {
   return (
     <Dialog
       open={open}

--- a/apps/desktop/src/features/scripts/components/ScriptsPanel/ScriptEditor.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsPanel/ScriptEditor.tsx
@@ -1,0 +1,76 @@
+import { useEffect } from 'react';
+import { Button, Divider, Input, Textarea } from '@goodboy/ui';
+import { Check } from 'lucide-react';
+import type { ScriptRunRecord } from '../../scripts';
+import { ScriptRunOutput } from './ScriptRunOutput';
+import type { Draft } from './types';
+
+type ScriptEditorProps = {
+  readonly draft: Draft;
+  readonly dirty: boolean;
+  readonly error: string | null;
+  readonly run: ScriptRunRecord | null;
+  readonly completedAt: number | undefined;
+  readonly onNameChange: (value: string) => void;
+  readonly onBodyChange: (value: string) => void;
+  readonly onSave: () => void;
+  readonly onCancel: () => void;
+};
+
+export const ScriptEditor = ({
+  draft,
+  dirty,
+  error,
+  run,
+  completedAt,
+  onNameChange,
+  onBodyChange,
+  onSave,
+  onCancel,
+}: ScriptEditorProps) => {
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onCancel();
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [onCancel]);
+
+  return (
+    <div className="flex h-full min-h-0 flex-col gap-3 p-3">
+      <Input
+        value={draft.name}
+        onChange={(e) => onNameChange(e.target.value)}
+        placeholder="Script name (e.g. copy environments)"
+        autoFocus
+      />
+      <Textarea
+        value={draft.body}
+        onChange={(e) => onBodyChange(e.target.value)}
+        placeholder={'#!/bin/bash\ncp ../main/.env .env'}
+        className="min-h-[200px] flex-1 resize-none font-mono text-xs"
+        spellCheck={false}
+        autoCorrect="off"
+        autoCapitalize="off"
+      />
+      {error !== null ? <p className="text-xs text-danger">{error}</p> : null}
+      <div className="flex items-center justify-end gap-1.5">
+        <Button variant="ghost" size="sm" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button size="sm" onClick={onSave} disabled={!dirty}>
+          <Check size={13} aria-hidden />
+          Save
+        </Button>
+      </div>
+      {run !== null ? (
+        <>
+          <Divider />
+          <ScriptRunOutput run={run} completedAt={completedAt} />
+        </>
+      ) : null}
+    </div>
+  );
+};

--- a/apps/desktop/src/features/scripts/components/ScriptsPanel/ScriptEditor.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsPanel/ScriptEditor.tsx
@@ -5,7 +5,7 @@ import type { ScriptRunRecord } from '../../scripts';
 import { ScriptRunOutput } from './ScriptRunOutput';
 import type { Draft } from './types';
 
-type ScriptEditorProps = {
+type Props = {
   readonly draft: Draft;
   readonly dirty: boolean;
   readonly error: string | null;
@@ -27,7 +27,7 @@ export const ScriptEditor = ({
   onBodyChange,
   onSave,
   onCancel,
-}: ScriptEditorProps) => {
+}: Props) => {
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {

--- a/apps/desktop/src/features/scripts/components/ScriptsPanel/ScriptRow.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsPanel/ScriptRow.tsx
@@ -4,7 +4,7 @@ import type { WorkspaceScript } from '@goodboy/types';
 import { OverflowMenu } from '../../../../shared/components/OverflowMenu';
 import type { ScriptRunStatus } from '../../scripts';
 
-type ScriptRowProps = {
+type Props = {
   readonly script: WorkspaceScript;
   readonly status: ScriptRunStatus;
   readonly selected: boolean;
@@ -18,7 +18,11 @@ type ScriptRowProps = {
   readonly onDelete: () => void;
 };
 
-const extractPreviewLine = ({ body }: { body: string }): string => {
+type Params = {
+  readonly body: string;
+};
+
+const extractPreviewLine = ({ body }: Params): string => {
   const lines = body.split('\n');
   for (const line of lines) {
     const trimmed = line.trim();
@@ -45,7 +49,7 @@ export const ScriptRow = ({
   onCancel,
   onCopy,
   onDelete,
-}: ScriptRowProps) => {
+}: Props) => {
   const preview = extractPreviewLine({ body: script.body });
   const isPending = status === 'pending';
 

--- a/apps/desktop/src/features/scripts/components/ScriptsPanel/ScriptRow.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsPanel/ScriptRow.tsx
@@ -1,0 +1,132 @@
+import { Check, Copy, Play, Square, Trash2 } from 'lucide-react';
+import { StatusDot, cn } from '@goodboy/ui';
+import type { WorkspaceScript } from '@goodboy/types';
+import { OverflowMenu } from '../../../../shared/components/OverflowMenu';
+import type { ScriptRunStatus } from '../../scripts';
+
+type ScriptRowProps = {
+  readonly script: WorkspaceScript;
+  readonly status: ScriptRunStatus;
+  readonly selected: boolean;
+  readonly runnable: boolean;
+  readonly canRun: boolean;
+  readonly copied: boolean;
+  readonly onSelect: () => void;
+  readonly onRun: () => void;
+  readonly onCancel: () => void;
+  readonly onCopy: () => void;
+  readonly onDelete: () => void;
+};
+
+const extractPreviewLine = ({ body }: { body: string }): string => {
+  const lines = body.split('\n');
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed === '') {
+      continue;
+    }
+    if (trimmed.startsWith('#!')) {
+      continue;
+    }
+    return trimmed;
+  }
+  return '';
+};
+
+export const ScriptRow = ({
+  script,
+  status,
+  selected,
+  runnable,
+  canRun,
+  copied,
+  onSelect,
+  onRun,
+  onCancel,
+  onCopy,
+  onDelete,
+}: ScriptRowProps) => {
+  const preview = extractPreviewLine({ body: script.body });
+  const isPending = status === 'pending';
+
+  return (
+    <div
+      className={cn(
+        'group flex items-center gap-2 rounded-lg border border-transparent px-2 py-1.5 transition-colors',
+        selected ? 'border-border bg-muted/50' : 'hover:bg-muted/40',
+      )}
+    >
+      <button
+        type="button"
+        onClick={onSelect}
+        aria-pressed={selected}
+        className="flex min-w-0 flex-1 flex-col items-start gap-0.5 text-left"
+      >
+        <span className="flex min-w-0 items-center gap-1.5">
+          {isPending ? <StatusDot tone="info" pulsing ariaLabel="running" /> : null}
+          <span className="min-w-0 truncate text-sm font-medium text-foreground">
+            {script.name}
+          </span>
+        </span>
+        {preview !== '' ? (
+          <span className="min-w-0 truncate font-mono text-2xs text-muted-foreground">
+            {preview}
+          </span>
+        ) : null}
+      </button>
+
+      {runnable ? (
+        isPending ? (
+          <button
+            type="button"
+            onClick={onCancel}
+            title="stop script"
+            aria-label="stop script"
+            className="flex size-6 shrink-0 items-center justify-center rounded text-danger transition-colors hover:bg-danger/10"
+          >
+            <Square size={11} fill="currentColor" aria-hidden />
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={onRun}
+            disabled={!canRun}
+            title="run script"
+            aria-label="run script"
+            className="flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            <Play size={13} aria-hidden />
+          </button>
+        )
+      ) : null}
+
+      <button
+        type="button"
+        onClick={onCopy}
+        title="copy script"
+        aria-label="copy script"
+        className="flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+      >
+        {copied ? (
+          <Check size={13} aria-hidden className="text-success" />
+        ) : (
+          <Copy size={13} aria-hidden />
+        )}
+      </button>
+
+      <OverflowMenu
+        label="script actions"
+        items={[
+          {
+            kind: 'item',
+            key: 'delete',
+            label: 'Delete',
+            icon: Trash2,
+            destructive: true,
+            onClick: onDelete,
+          },
+        ]}
+      />
+    </div>
+  );
+};

--- a/apps/desktop/src/features/scripts/components/ScriptsPanel/ScriptRow.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsPanel/ScriptRow.tsx
@@ -84,8 +84,8 @@ export const ScriptRow = ({
           <button
             type="button"
             onClick={onCancel}
-            title="stop script"
-            aria-label="stop script"
+            title="Stop script"
+            aria-label="Stop script"
             className="flex size-6 shrink-0 items-center justify-center rounded text-danger transition-colors hover:bg-danger/10"
           >
             <Square size={11} fill="currentColor" aria-hidden />
@@ -95,8 +95,8 @@ export const ScriptRow = ({
             type="button"
             onClick={onRun}
             disabled={!canRun}
-            title="run script"
-            aria-label="run script"
+            title="Run script"
+            aria-label="Run script"
             className="flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40"
           >
             <Play size={13} aria-hidden />
@@ -107,8 +107,8 @@ export const ScriptRow = ({
       <button
         type="button"
         onClick={onCopy}
-        title="copy script"
-        aria-label="copy script"
+        title="Copy script"
+        aria-label="Copy script"
         className="flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
       >
         {copied ? (
@@ -119,7 +119,7 @@ export const ScriptRow = ({
       </button>
 
       <OverflowMenu
-        label="script actions"
+        label="Script actions"
         items={[
           {
             kind: 'item',

--- a/apps/desktop/src/features/scripts/components/ScriptsPanel/ScriptRunOutput.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsPanel/ScriptRunOutput.tsx
@@ -3,7 +3,7 @@ import { ScrollFade, StatusDot, type Tone } from '@goodboy/ui';
 import { ChevronDown, ChevronRight } from 'lucide-react';
 import type { ScriptRunRecord, ScriptRunStatus } from '../../scripts';
 
-type ScriptRunOutputProps = {
+type Props = {
   readonly run: ScriptRunRecord;
   readonly completedAt: number | undefined;
 };
@@ -16,7 +16,7 @@ const STATUS_TONE = {
   cancelled: 'neutral',
 } satisfies Record<ScriptRunStatus, Tone>;
 
-export const ScriptRunOutput = ({ run, completedAt }: ScriptRunOutputProps) => {
+export const ScriptRunOutput = ({ run, completedAt }: Props) => {
   const [open, setOpen] = useState(true);
   const result = run.result;
 

--- a/apps/desktop/src/features/scripts/components/ScriptsPanel/ScriptRunOutput.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsPanel/ScriptRunOutput.tsx
@@ -1,0 +1,61 @@
+import { useState } from 'react';
+import { ScrollFade, StatusDot, type Tone } from '@goodboy/ui';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import type { ScriptRunRecord, ScriptRunStatus } from '../../scripts';
+
+type ScriptRunOutputProps = {
+  readonly run: ScriptRunRecord;
+  readonly completedAt: number | undefined;
+};
+
+const STATUS_TONE = {
+  idle: 'neutral',
+  pending: 'info',
+  ok: 'success',
+  error: 'danger',
+  cancelled: 'neutral',
+} satisfies Record<ScriptRunStatus, Tone>;
+
+export const ScriptRunOutput = ({ run, completedAt }: ScriptRunOutputProps) => {
+  const [open, setOpen] = useState(true);
+  const result = run.result;
+
+  return (
+    <div className="flex min-h-0 flex-col gap-1.5">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        className="flex items-center gap-1.5 text-xs font-medium text-foreground"
+      >
+        {open ? <ChevronDown size={12} aria-hidden /> : <ChevronRight size={12} aria-hidden />}
+        <span>Last run</span>
+        <StatusDot tone={STATUS_TONE[run.status]} pulsing={run.status === 'pending'} />
+        {result !== null ? (
+          <span className="text-2xs font-normal text-muted-foreground">
+            exit {result.exitCode}
+            {completedAt !== undefined ? ` · ${new Date(completedAt).toLocaleTimeString()}` : ''}
+          </span>
+        ) : null}
+      </button>
+      {open && result !== null ? (
+        <ScrollFade
+          className="max-h-56"
+          viewportClassName="whitespace-pre-wrap break-all bg-subtle/40 px-3 py-2 font-mono text-2xs leading-relaxed text-foreground/80"
+        >
+          {result.stdout}
+          {result.stderr !== '' ? (
+            <span className="text-danger">
+              {result.stdout !== '' ? '\n' : ''}
+              {result.stderr}
+            </span>
+          ) : null}
+          {result.stdout === '' && result.stderr === '' ? '(no output)' : null}
+        </ScrollFade>
+      ) : null}
+      {open && result === null ? (
+        <p className="px-1 text-2xs text-muted-foreground">Running…</p>
+      ) : null}
+    </div>
+  );
+};

--- a/apps/desktop/src/features/scripts/components/ScriptsPanel/index.test.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsPanel/index.test.tsx
@@ -9,12 +9,21 @@ type Script = {
   readonly body: string;
 };
 
+type RunRecord = {
+  readonly status: 'idle' | 'pending' | 'ok' | 'error' | 'cancelled';
+  readonly result: { stdout: string; stderr: string; exitCode: number } | null;
+  readonly runId: string;
+};
+
 const { state } = vi.hoisted(() => ({
   state: {
     scripts: [] as ReadonlyArray<Script>,
+    scriptRuns: {} as Record<string, Record<string, RunRecord>>,
     loadScripts: vi.fn(async () => undefined),
     saveScript: vi.fn(async () => undefined),
     deleteScript: vi.fn(async () => undefined),
+    runScript: vi.fn(async () => undefined),
+    cancelScript: vi.fn(async () => undefined),
   },
 }));
 
@@ -22,16 +31,22 @@ vi.mock('../../../../store', () => ({
   useAppStore: <T,>(
     selector: (s: {
       workspaceScripts: Record<string, ReadonlyArray<Script>>;
+      scriptRuns: Record<string, Record<string, RunRecord>>;
       loadScripts: typeof state.loadScripts;
       saveScript: typeof state.saveScript;
       deleteScript: typeof state.deleteScript;
+      runScript: typeof state.runScript;
+      cancelScript: typeof state.cancelScript;
     }) => T,
   ) =>
     selector({
       workspaceScripts: { 'ws-1': state.scripts },
+      scriptRuns: { 'session-1': state.scriptRuns['session-1'] ?? {} },
       loadScripts: state.loadScripts,
       saveScript: state.saveScript,
       deleteScript: state.deleteScript,
+      runScript: state.runScript,
+      cancelScript: state.cancelScript,
     }),
 }));
 
@@ -39,9 +54,12 @@ import { ScriptsPanel } from './index';
 
 beforeEach(() => {
   state.scripts = [];
+  state.scriptRuns = {};
   state.loadScripts = vi.fn(async () => undefined);
   state.saveScript = vi.fn(async () => undefined);
   state.deleteScript = vi.fn(async () => undefined);
+  state.runScript = vi.fn(async () => undefined);
+  state.cancelScript = vi.fn(async () => undefined);
 });
 afterEach(cleanup);
 
@@ -79,5 +97,61 @@ describe('ScriptsPanel', () => {
       name: 'copy env',
       body: 'cp ../main/.env .env',
     });
+  });
+
+  it('opens an existing script and saves an edit to its body', async () => {
+    state.scripts = [{ id: 's1', name: 'setup', body: '#!/bin/bash\necho hi' }];
+    render(<ScriptsPanel workspaceId={'ws-1' as never} />);
+    fireEvent.click(screen.getByRole('button', { name: /setup/i }));
+    const textarea = screen.getByDisplayValue(/echo hi/);
+    fireEvent.change(textarea, { target: { value: 'echo hi again' } });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    });
+    expect(state.saveScript).toHaveBeenCalledWith({
+      workspaceId: 'ws-1',
+      id: 's1',
+      name: 'setup',
+      body: 'echo hi again',
+    });
+  });
+
+  it('deletes a script from its overflow menu', async () => {
+    state.scripts = [{ id: 's1', name: 'setup', body: 'echo hi' }];
+    render(<ScriptsPanel workspaceId={'ws-1' as never} />);
+    fireEvent.click(screen.getByRole('button', { name: 'script actions' }));
+    await act(async () => {
+      fireEvent.click(screen.getByRole('menuitem', { name: 'Delete' }));
+    });
+    expect(state.deleteScript).toHaveBeenCalledWith('s1', 'ws-1');
+  });
+
+  it('prompts before discarding an unsaved edit when switching to another script', () => {
+    state.scripts = [
+      { id: 's1', name: 'setup', body: 'echo one' },
+      { id: 's2', name: 'build', body: 'echo two' },
+    ];
+    render(<ScriptsPanel workspaceId={'ws-1' as never} />);
+    fireEvent.click(screen.getByRole('button', { name: /setup/i }));
+    fireEvent.change(screen.getByDisplayValue(/echo one/), {
+      target: { value: 'echo one changed' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /build/i }));
+    expect(screen.getByText(/unsaved changes/i)).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: 'Discard' }));
+    expect(screen.getByDisplayValue(/echo two/)).toBeDefined();
+  });
+
+  it('runs a script from its row and routes output to the session it runs in', () => {
+    state.scripts = [{ id: 's1', name: 'setup', body: 'echo hi' }];
+    render(
+      <ScriptsPanel
+        workspaceId={'ws-1' as never}
+        sessionId={'session-1' as never}
+        worktreePath="/tmp/work"
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'run script' }));
+    expect(state.runScript).toHaveBeenCalledWith('session-1', 's1', '/tmp/work');
   });
 });

--- a/apps/desktop/src/features/scripts/components/ScriptsPanel/index.test.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsPanel/index.test.tsx
@@ -119,7 +119,7 @@ describe('ScriptsPanel', () => {
   it('deletes a script from its overflow menu', async () => {
     state.scripts = [{ id: 's1', name: 'setup', body: 'echo hi' }];
     render(<ScriptsPanel workspaceId={'ws-1' as never} />);
-    fireEvent.click(screen.getByRole('button', { name: 'script actions' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Script actions' }));
     await act(async () => {
       fireEvent.click(screen.getByRole('menuitem', { name: 'Delete' }));
     });
@@ -151,7 +151,7 @@ describe('ScriptsPanel', () => {
         worktreePath="/tmp/work"
       />,
     );
-    fireEvent.click(screen.getByRole('button', { name: 'run script' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Run script' }));
     expect(state.runScript).toHaveBeenCalledWith('session-1', 's1', '/tmp/work');
   });
 });

--- a/apps/desktop/src/features/scripts/components/ScriptsPanel/index.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsPanel/index.tsx
@@ -1,36 +1,20 @@
-import { useCallback, useEffect, useState, type ReactNode } from 'react';
-import {
-  Button,
-  EmptyState,
-  Input,
-  StatusDot,
-  Textarea,
-  cn,
-  type StatusDotProps,
-} from '@goodboy/ui';
-import type { SessionId, WorkspaceId, WorkspaceScriptId } from '@goodboy/types';
-import {
-  Check,
-  Copy,
-  Pencil,
-  Play,
-  Plus,
-  ScrollText,
-  Square,
-  SquareTerminal,
-  Trash2,
-} from 'lucide-react';
+import { useCallback, useEffect, useState } from 'react';
+import { Button, EmptyState } from '@goodboy/ui';
+import type { SessionId, WorkspaceId, WorkspaceScript, WorkspaceScriptId } from '@goodboy/types';
+import { Plus, SquareTerminal } from 'lucide-react';
+import { InspectorSplit } from '../../../session/components/SessionWorkspace/parts/InspectorSplit';
 import { formatError } from '../../../../shared/lib/errors';
 import { useAppStore } from '../../../../store';
-import type { ScriptRunStatus } from '../../scripts';
+import { DiscardDraftDialog } from './DiscardDraftDialog';
+import { ScriptEditor } from './ScriptEditor';
+import { ScriptRow } from './ScriptRow';
+import type { Draft, PendingAction } from './types';
 
 type Props = {
   readonly workspaceId: WorkspaceId;
   readonly sessionId?: SessionId;
   readonly worktreePath?: string | null;
 };
-
-type Draft = { id: WorkspaceScriptId | null; name: string; body: string };
 
 export const ScriptsPanel = ({ workspaceId, sessionId, worktreePath }: Props) => {
   const scripts = useAppStore((s) => s.workspaceScripts[workspaceId]);
@@ -39,20 +23,165 @@ export const ScriptsPanel = ({ workspaceId, sessionId, worktreePath }: Props) =>
   const deleteScript = useAppStore((s) => s.deleteScript);
   const runScript = useAppStore((s) => s.runScript);
   const cancelScript = useAppStore((s) => s.cancelScript);
-  const runs = useAppStore((s) => (sessionId ? s.scriptRuns[sessionId] : undefined));
+  const runs = useAppStore((s) => (sessionId != null ? s.scriptRuns[sessionId] : undefined));
 
   const [draft, setDraft] = useState<Draft | null>(null);
+  const [original, setOriginal] = useState<{ name: string; body: string } | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [copiedId, setCopiedId] = useState<string | null>(null);
-  const [logId, setLogId] = useState<WorkspaceScriptId | null>(null);
+  const [copiedId, setCopiedId] = useState<WorkspaceScriptId | null>(null);
+  const [pendingAction, setPendingAction] = useState<PendingAction | null>(null);
+  const [completedAt, setCompletedAt] = useState<Record<string, number>>({});
 
   const runnable = sessionId != null;
+  const list = scripts ?? [];
+  const dirty =
+    draft !== null &&
+    original !== null &&
+    (draft.name !== original.name || draft.body !== original.body);
+  const selectedRun = draft?.id != null ? (runs?.[draft.id] ?? null) : null;
 
   useEffect(() => {
     void loadScripts(workspaceId);
   }, [workspaceId, loadScripts]);
 
-  const onCopy = useCallback((id: string, body: string) => {
+  useEffect(() => {
+    if (runs === undefined) {
+      return;
+    }
+    setCompletedAt((prev) => {
+      let next = prev;
+      for (const record of Object.values(runs)) {
+        if (record.result !== null && prev[record.runId] === undefined) {
+          next = next === prev ? { ...prev } : next;
+          next[record.runId] = Date.now();
+        }
+      }
+      return next;
+    });
+  }, [runs]);
+
+  const openNewNow = useCallback(() => {
+    setDraft({ id: null, name: '', body: '' });
+    setOriginal({ name: '', body: '' });
+    setError(null);
+  }, []);
+
+  const openExistingNow = useCallback((script: WorkspaceScript) => {
+    setDraft({ id: script.id, name: script.name, body: script.body });
+    setOriginal({ name: script.name, body: script.body });
+    setError(null);
+  }, []);
+
+  const closeNow = useCallback(() => {
+    setDraft(null);
+    setOriginal(null);
+    setError(null);
+  }, []);
+
+  const applyPendingTransition = useCallback(
+    ({ action }: { action: PendingAction | null }) => {
+      if (action === null) {
+        closeNow();
+        return;
+      }
+      if (action.kind === 'new') {
+        openNewNow();
+        return;
+      }
+      if (action.kind === 'select') {
+        openExistingNow(action.script);
+        return;
+      }
+      closeNow();
+    },
+    [closeNow, openNewNow, openExistingNow],
+  );
+
+  const requestOpenNew = useCallback(() => {
+    if (dirty) {
+      setPendingAction({ kind: 'new' });
+      return;
+    }
+    openNewNow();
+  }, [dirty, openNewNow]);
+
+  const requestSelect = useCallback(
+    (script: WorkspaceScript) => {
+      if (draft?.id === script.id) {
+        return;
+      }
+      if (dirty) {
+        setPendingAction({ kind: 'select', script });
+        return;
+      }
+      openExistingNow(script);
+    },
+    [draft, dirty, openExistingNow],
+  );
+
+  const requestClose = useCallback(() => {
+    if (draft === null) {
+      return;
+    }
+    if (dirty) {
+      setPendingAction({ kind: 'close' });
+      return;
+    }
+    closeNow();
+  }, [draft, dirty, closeNow]);
+
+  const onSaveDraft = useCallback(async (): Promise<boolean> => {
+    if (draft === null) {
+      return false;
+    }
+    const name = draft.name.trim();
+    const body = draft.body.trim();
+    if (name === '' || body === '') {
+      setError('name and script body are required');
+      return false;
+    }
+    setError(null);
+    try {
+      await saveScript({ workspaceId, id: draft.id ?? undefined, name, body });
+      return true;
+    } catch (err) {
+      setError(formatError(err));
+      return false;
+    }
+  }, [draft, saveScript, workspaceId]);
+
+  const onEditorSave = useCallback(() => {
+    void (async () => {
+      const ok = await onSaveDraft();
+      if (ok) {
+        closeNow();
+      }
+    })();
+  }, [onSaveDraft, closeNow]);
+
+  const onDialogCancel = useCallback(() => {
+    setPendingAction(null);
+  }, []);
+
+  const onDialogDiscard = useCallback(() => {
+    const action = pendingAction;
+    setPendingAction(null);
+    applyPendingTransition({ action });
+  }, [pendingAction, applyPendingTransition]);
+
+  const onDialogSave = useCallback(() => {
+    void (async () => {
+      const ok = await onSaveDraft();
+      if (!ok) {
+        return;
+      }
+      const action = pendingAction;
+      setPendingAction(null);
+      applyPendingTransition({ action });
+    })();
+  }, [onSaveDraft, pendingAction, applyPendingTransition]);
+
+  const onCopy = useCallback((id: WorkspaceScriptId, body: string) => {
     void navigator.clipboard
       .writeText(body)
       .then(() => {
@@ -62,49 +191,36 @@ export const ScriptsPanel = ({ workspaceId, sessionId, worktreePath }: Props) =>
       .catch(() => undefined);
   }, []);
 
-  const onSaveDraft = useCallback(async () => {
-    if (!draft) {
-      return;
-    }
-    const name = draft.name.trim();
-    const body = draft.body.trim();
-    if (!name || !body) {
-      setError('name and script body are required');
-      return;
-    }
-    setError(null);
-    try {
-      await saveScript({ workspaceId, id: draft.id ?? undefined, name, body });
-      setDraft(null);
-    } catch (err) {
-      setError(formatError(err));
-    }
-  }, [draft, saveScript, workspaceId]);
-
   const onDelete = useCallback(
     async (id: WorkspaceScriptId) => {
       try {
         await deleteScript(id, workspaceId);
+        if (draft?.id === id) {
+          closeNow();
+        }
       } catch (err) {
         setError(formatError(err));
       }
     },
-    [deleteScript, workspaceId],
+    [deleteScript, workspaceId, draft, closeNow],
   );
 
   const onRun = useCallback(
-    (id: WorkspaceScriptId) => {
-      if (!sessionId || !worktreePath) {
+    (script: WorkspaceScript) => {
+      if (sessionId == null || worktreePath == null) {
         return;
       }
-      void runScript(sessionId, id, worktreePath);
+      if (draft?.id !== script.id) {
+        openExistingNow(script);
+      }
+      void runScript(sessionId, script.id, worktreePath);
     },
-    [runScript, sessionId, worktreePath],
+    [runScript, sessionId, worktreePath, draft, openExistingNow],
   );
 
   const onCancel = useCallback(
     (id: WorkspaceScriptId) => {
-      if (!sessionId) {
+      if (sessionId == null) {
         return;
       }
       void cancelScript(sessionId, id);
@@ -112,239 +228,78 @@ export const ScriptsPanel = ({ workspaceId, sessionId, worktreePath }: Props) =>
     [cancelScript, sessionId],
   );
 
-  const list = scripts ?? [];
-
   return (
-    <div className="flex flex-col gap-3">
-      <div className="flex items-center justify-between">
+    <div className="flex h-full min-h-0 flex-col gap-3">
+      <div className="flex items-center justify-between gap-2">
         <p className="text-xs text-muted-foreground">
           Shell scripts you run by hand from inside a session. cwd is the session worktree. Scripts
           are shared across every session of this workspace.
         </p>
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => setDraft({ id: null, name: '', body: '' })}
-          disabled={draft !== null}
-        >
+        <Button variant="ghost" size="sm" onClick={requestOpenNew}>
           <Plus size={13} aria-hidden />
           New script
         </Button>
       </div>
 
-      {error ? <p className="text-xs text-danger">{error}</p> : null}
+      {error !== null && draft === null ? <p className="text-xs text-danger">{error}</p> : null}
 
-      {list.length === 0 && draft === null && (
-        <EmptyState
-          bordered
-          tone="info"
-          icon={SquareTerminal}
-          title="No scripts yet"
-          description="Create one to run setup or checks from inside this session."
-        />
-      )}
-
-      <ul className="flex flex-col gap-2">
-        {list.map((script) => {
-          const isEditing = draft?.id === script.id;
-          if (isEditing && draft) {
-            return (
-              <li key={script.id}>
-                <ScriptEditor
-                  draft={draft}
-                  setDraft={setDraft}
-                  onSave={() => void onSaveDraft()}
-                  onCancel={() => {
-                    setDraft(null);
-                    setError(null);
-                  }}
-                />
-              </li>
-            );
-          }
-          const run = runs?.[script.id] ?? null;
-          const status: ScriptRunStatus = run?.status ?? 'idle';
-          const isPending = status === 'pending';
-          const result = run?.result ?? null;
-          const logOpen = logId === script.id;
-          return (
-            <li
-              key={script.id}
-              className="overflow-hidden rounded-md border border-border-soft bg-background"
-            >
-              <div className="flex items-center gap-2 px-3 py-2">
-                {runnable ? <RunStatusDot status={status} /> : null}
-                <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
-                  {script.name}
-                </span>
-                {runnable ? (
-                  isPending ? (
-                    <RowAction
-                      icon={<Square size={11} fill="currentColor" aria-hidden />}
-                      label="stop script"
-                      tone="danger"
-                      onClick={() => onCancel(script.id)}
-                    />
-                  ) : (
-                    <RowAction
-                      icon={<Play size={13} aria-hidden />}
-                      label="run script"
-                      disabled={!worktreePath}
-                      onClick={() => onRun(script.id)}
-                    />
-                  )
-                ) : null}
-                {runnable && result ? (
-                  <RowAction
-                    icon={<ScrollText size={13} aria-hidden />}
-                    label={logOpen ? 'hide log' : 'show log'}
-                    onClick={() => setLogId((prev) => (prev === script.id ? null : script.id))}
-                  />
-                ) : null}
-                <RowAction
-                  icon={
-                    copiedId === script.id ? (
-                      <Check size={13} aria-hidden className="text-success" />
-                    ) : (
-                      <Copy size={13} aria-hidden />
-                    )
-                  }
-                  label="copy script"
-                  onClick={() => onCopy(script.id, script.body)}
-                />
-                <RowAction
-                  icon={<Pencil size={13} aria-hidden />}
-                  label="edit script"
-                  disabled={draft !== null}
-                  onClick={() => setDraft({ id: script.id, name: script.name, body: script.body })}
-                />
-                <RowAction
-                  icon={<Trash2 size={13} aria-hidden />}
-                  label="delete script"
-                  tone="danger"
-                  disabled={draft !== null}
-                  onClick={() => void onDelete(script.id)}
-                />
-              </div>
-              {logOpen && result ? (
-                <pre className="m-0 max-h-60 overflow-auto whitespace-pre-wrap break-all bg-subtle/40 px-3 py-2 font-mono text-2xs leading-relaxed text-foreground/80">
-                  {result.stdout}
-                  {result.stderr ? (
-                    <span className="text-danger">
-                      {result.stdout ? '\n' : ''}
-                      {result.stderr}
-                    </span>
-                  ) : null}
-                  {!result.stdout && !result.stderr ? '(no output)' : null}
-                </pre>
-              ) : (
-                <pre className="max-h-40 overflow-auto whitespace-pre-wrap break-all bg-subtle/40 px-3 py-2 font-mono text-2xs leading-relaxed text-foreground/75">
-                  {script.body}
-                </pre>
-              )}
-            </li>
-          );
-        })}
-
-        {draft && draft.id === null ? (
-          <li>
+      <InspectorSplit
+        open={draft !== null}
+        panel={
+          draft !== null ? (
             <ScriptEditor
               draft={draft}
-              setDraft={setDraft}
-              onSave={() => void onSaveDraft()}
-              onCancel={() => {
-                setDraft(null);
-                setError(null);
-              }}
+              dirty={dirty}
+              error={error}
+              run={selectedRun}
+              completedAt={selectedRun !== null ? completedAt[selectedRun.runId] : undefined}
+              onNameChange={(name) => setDraft((d) => (d !== null ? { ...d, name } : d))}
+              onBodyChange={(body) => setDraft((d) => (d !== null ? { ...d, body } : d))}
+              onSave={onEditorSave}
+              onCancel={requestClose}
             />
-          </li>
-        ) : null}
-      </ul>
+          ) : null
+        }
+      >
+        <div className="flex min-h-0 flex-1 flex-col gap-2">
+          {list.length === 0 ? (
+            <EmptyState
+              bordered
+              tone="info"
+              icon={SquareTerminal}
+              title="No scripts yet"
+              description="Create one to run setup or checks from inside this session."
+            />
+          ) : (
+            <ul className="flex flex-col gap-1">
+              {list.map((script) => (
+                <li key={script.id}>
+                  <ScriptRow
+                    script={script}
+                    status={runs?.[script.id]?.status ?? 'idle'}
+                    selected={draft?.id === script.id}
+                    runnable={runnable}
+                    canRun={worktreePath != null}
+                    copied={copiedId === script.id}
+                    onSelect={() => requestSelect(script)}
+                    onRun={() => onRun(script)}
+                    onCancel={() => onCancel(script.id)}
+                    onCopy={() => onCopy(script.id, script.body)}
+                    onDelete={() => void onDelete(script.id)}
+                  />
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </InspectorSplit>
+
+      <DiscardDraftDialog
+        open={pendingAction !== null}
+        onSave={onDialogSave}
+        onDiscard={onDialogDiscard}
+        onCancel={onDialogCancel}
+      />
     </div>
   );
 };
-
-function RowAction({
-  icon,
-  label,
-  onClick,
-  disabled,
-  tone,
-}: {
-  icon: ReactNode;
-  label: string;
-  onClick: () => void;
-  disabled?: boolean;
-  tone?: 'danger';
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      disabled={disabled}
-      aria-label={label}
-      title={label}
-      className={cn(
-        'flex size-6 items-center justify-center rounded text-muted-foreground transition-colors',
-        'hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40',
-        tone === 'danger' && 'hover:bg-danger/10 hover:text-danger',
-      )}
-    >
-      {icon}
-    </button>
-  );
-}
-
-function RunStatusDot({ status }: { readonly status: ScriptRunStatus }) {
-  const tone: StatusDotProps['tone'] =
-    status === 'ok'
-      ? 'success'
-      : status === 'error'
-        ? 'danger'
-        : status === 'pending'
-          ? 'info'
-          : 'neutral';
-  return <StatusDot tone={tone} pulsing={status === 'pending'} />;
-}
-
-function ScriptEditor({
-  draft,
-  setDraft,
-  onSave,
-  onCancel,
-}: {
-  draft: Draft;
-  setDraft: (d: Draft) => void;
-  onSave: () => void;
-  onCancel: () => void;
-}) {
-  return (
-    <div className="flex flex-col gap-2">
-      <Input
-        value={draft.name}
-        onChange={(e) => setDraft({ ...draft, name: e.target.value })}
-        placeholder="script name (e.g. copy environments)"
-        autoFocus
-      />
-      <Textarea
-        value={draft.body}
-        onChange={(e) => setDraft({ ...draft, body: e.target.value })}
-        placeholder={'#!/bin/bash\ncp ../main/.env .env'}
-        className="min-h-[160px] resize-y font-mono text-xs"
-        spellCheck={false}
-        autoCorrect="off"
-        autoCapitalize="off"
-        rows={8}
-      />
-      <div className="flex justify-end gap-1.5">
-        <Button variant="ghost" size="sm" onClick={onCancel}>
-          Cancel
-        </Button>
-        <Button size="sm" onClick={onSave}>
-          <Check size={13} aria-hidden />
-          Save
-        </Button>
-      </div>
-    </div>
-  );
-}

--- a/apps/desktop/src/features/scripts/components/ScriptsPanel/index.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsPanel/index.tsx
@@ -214,12 +214,12 @@ export const ScriptsPanel = ({ workspaceId, sessionId, worktreePath }: Props) =>
       if (sessionId == null || worktreePath == null) {
         return;
       }
-      if (draft?.id !== script.id) {
+      if (draft?.id !== script.id && !dirty) {
         openExistingNow(script);
       }
       void runScript(sessionId, script.id, worktreePath);
     },
-    [runScript, sessionId, worktreePath, draft, openExistingNow],
+    [runScript, sessionId, worktreePath, draft, dirty, openExistingNow],
   );
 
   const onCancel = useCallback(

--- a/apps/desktop/src/features/scripts/components/ScriptsPanel/index.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsPanel/index.tsx
@@ -16,6 +16,10 @@ type Props = {
   readonly worktreePath?: string | null;
 };
 
+type Params = {
+  readonly action: PendingAction | null;
+};
+
 export const ScriptsPanel = ({ workspaceId, sessionId, worktreePath }: Props) => {
   const scripts = useAppStore((s) => s.workspaceScripts[workspaceId]);
   const loadScripts = useAppStore((s) => s.loadScripts);
@@ -79,7 +83,7 @@ export const ScriptsPanel = ({ workspaceId, sessionId, worktreePath }: Props) =>
   }, []);
 
   const applyPendingTransition = useCallback(
-    ({ action }: { action: PendingAction | null }) => {
+    ({ action }: Params) => {
       if (action === null) {
         closeNow();
         return;

--- a/apps/desktop/src/features/scripts/components/ScriptsPanel/types.ts
+++ b/apps/desktop/src/features/scripts/components/ScriptsPanel/types.ts
@@ -1,0 +1,12 @@
+import type { WorkspaceScript, WorkspaceScriptId } from '@goodboy/types';
+
+export type Draft = {
+  readonly id: WorkspaceScriptId | null;
+  readonly name: string;
+  readonly body: string;
+};
+
+export type PendingAction =
+  | { readonly kind: 'new' }
+  | { readonly kind: 'select'; readonly script: WorkspaceScript }
+  | { readonly kind: 'close' };

--- a/apps/desktop/src/features/session/components/CreateAgentPopover/AgentRoutingSections.tsx
+++ b/apps/desktop/src/features/session/components/CreateAgentPopover/AgentRoutingSections.tsx
@@ -99,7 +99,7 @@ export const AgentRoutingSections = ({
           </div>
         )}
         {isProviderConnected && (
-          <ScrollFade fadeFrom="subtle" className="min-h-0 max-h-[13rem]">
+          <ScrollFade fadeFrom="subtle" className="min-h-0 max-h-[15rem]">
             <ModelGrid
               ids={viewedRouting.models}
               value={viewedRouting.model}

--- a/apps/desktop/src/features/session/components/CreateAgentPopover/index.tsx
+++ b/apps/desktop/src/features/session/components/CreateAgentPopover/index.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { getDefaultTurnModel } from '@goodboy/core';
-import { Button, Divider, Popover, ScrollFade, cn } from '@goodboy/ui';
+import { Button, Divider, Popover, cn } from '@goodboy/ui';
 import type { ProviderId, SessionId } from '@goodboy/types';
 import { useAppStore, useCurrentWorkspace } from '../../../../store';
 import { clampEffort } from '../../../chat/utils/chat-constants';
@@ -37,8 +37,8 @@ export const CreateAgentPopover = ({
 }: Props) => {
   const { open, close, toggle, containerRef, popupClassName } = useDropdown({
     align: 'end',
-    expectedHeight: 440,
-    width: 'w-[22rem] max-w-[calc(100vw-2rem)]',
+    expectedHeight: 520,
+    width: 'w-80 max-w-[calc(100vw-2rem)]',
   });
   const [kind, setKind] = useState<AgentKind>('generic');
   const [routing, setRouting] = useState<AgentKindRouting | null>(null);
@@ -99,57 +99,55 @@ export const CreateAgentPopover = ({
           ariaLabel="create agent"
           className={cn(popupClassName, 'flex flex-col bg-subtle')}
         >
-          <ScrollFade fadeFrom="subtle" className="min-h-0 max-h-[26rem]">
-            {agentKinds.length > 1 && (
-              <>
-                <PickerSection label="Agent type" hint="What this agent is allowed to do">
-                  <AgentKindGrid kinds={agentKinds} value={selectedKind} onChange={setKind} />
-                </PickerSection>
-                <Divider />
-              </>
-            )}
-            <SpawnRoutingSummary
-              kind={selectedKind}
-              effective={effective}
-              fallback={spawnDefault}
-              isPinned={routing != null}
-              onReset={() => {
-                setRouting(null);
-                setViewProvider(spawnDefault.provider);
-              }}
-            />
-            <Divider />
-            <AgentRoutingSections
-              connectedProviders={connectedProviders}
-              effective={effective}
-              viewProvider={viewProvider}
-              onViewProvider={setViewProvider}
-              onPickProvider={(provider) => {
-                const model = getDefaultTurnModel(provider);
-                setRouting({
-                  provider,
-                  model,
-                  effort: clampEffort(model, effective.effort),
-                });
-              }}
-              onPickModel={(model) => {
-                setRouting({
-                  provider: viewProvider,
-                  model,
-                  effort: clampEffort(model, effective.effort),
-                });
-              }}
-              onPickEffort={onPickEffort}
-              onConnectProvider={(provider) => {
-                window.dispatchEvent(
-                  new CustomEvent('goodboy:open-provider-studio', {
-                    detail: { providerId: provider },
-                  }),
-                );
-                close();
-              }}
-            />
-          </ScrollFade>
+          {agentKinds.length > 1 && (
+            <>
+              <PickerSection label="Agent type" hint="What this agent is allowed to do">
+                <AgentKindGrid kinds={agentKinds} value={selectedKind} onChange={setKind} />
+              </PickerSection>
+              <Divider />
+            </>
+          )}
+          <SpawnRoutingSummary
+            kind={selectedKind}
+            effective={effective}
+            fallback={spawnDefault}
+            isPinned={routing != null}
+            onReset={() => {
+              setRouting(null);
+              setViewProvider(spawnDefault.provider);
+            }}
+          />
+          <Divider />
+          <AgentRoutingSections
+            connectedProviders={connectedProviders}
+            effective={effective}
+            viewProvider={viewProvider}
+            onViewProvider={setViewProvider}
+            onPickProvider={(provider) => {
+              const model = getDefaultTurnModel(provider);
+              setRouting({
+                provider,
+                model,
+                effort: clampEffort(model, effective.effort),
+              });
+            }}
+            onPickModel={(model) => {
+              setRouting({
+                provider: viewProvider,
+                model,
+                effort: clampEffort(model, effective.effort),
+              });
+            }}
+            onPickEffort={onPickEffort}
+            onConnectProvider={(provider) => {
+              window.dispatchEvent(
+                new CustomEvent('goodboy:open-provider-studio', {
+                  detail: { providerId: provider },
+                }),
+              );
+              close();
+            }}
+          />
           <Divider />
           <div className="flex items-center justify-end px-2.5 py-2">
             <Button size="sm" onClick={() => void onCreate()}>

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ConnectedIntegrationGlyphs.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ConnectedIntegrationGlyphs.test.tsx
@@ -4,21 +4,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import type { Session } from '@goodboy/types';
 
-const { store, remote } = vi.hoisted(() => ({
+const { store } = vi.hoisted(() => ({
   store: {
-    sessionExternalTasks: {} as Record<string, ReadonlyArray<unknown>>,
-    workspaceIntegrations: {} as Record<string, ReadonlyArray<{ provider: string }>>,
+    sessionExternalTasks: {} as Record<string, ReadonlyArray<{ provider: string }>>,
   },
-  remote: { kind: null as 'github' | 'gitlab' | 'other' | null },
 }));
 
 vi.mock('../../../../store', () => ({
   EMPTY_ARRAY: Object.freeze([]),
   useAppStore: <T,>(selector: (s: typeof store) => T) => selector(store),
-}));
-
-vi.mock('../../../worktree/useRemoteHostKind', () => ({
-  useRemoteHostKind: () => remote.kind,
 }));
 
 import { ConnectedIntegrationGlyphs } from './ConnectedIntegrationGlyphs';
@@ -27,26 +21,34 @@ const session = { id: 'sess-1', workspaceId: 'ws-1' } as unknown as Session;
 
 beforeEach(() => {
   store.sessionExternalTasks = {};
-  store.workspaceIntegrations = {};
-  remote.kind = null;
 });
 afterEach(cleanup);
 
 describe('ConnectedIntegrationGlyphs', () => {
-  it('renders nothing when no integration is connected', () => {
+  it('renders nothing when no provider has a linked task', () => {
     const { container } = render(
       <ConnectedIntegrationGlyphs session={session} onSelectLens={vi.fn()} />,
     );
     expect(container.firstChild).toBeNull();
   });
 
-  it('renders only connected providers and routes clicks to their lens', () => {
-    store.workspaceIntegrations = { 'ws-1': [{ provider: 'linear' }] };
-    remote.kind = 'github';
+  it('renders nothing for a connected-but-unlinked provider', () => {
+    const { container } = render(
+      <ConnectedIntegrationGlyphs session={session} onSelectLens={vi.fn()} />,
+    );
+    expect(screen.queryByRole('button', { name: /open github/i })).toBeNull();
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders only providers with a linked task and routes clicks to their lens', () => {
+    store.sessionExternalTasks = {
+      'sess-1': [{ provider: 'linear' }, { provider: 'github' }],
+    };
     const onSelectLens = vi.fn();
     render(<ConnectedIntegrationGlyphs session={session} onSelectLens={onSelectLens} />);
 
     expect(screen.queryByRole('button', { name: /open sentry/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /open gitlab/i })).toBeNull();
     fireEvent.click(screen.getByRole('button', { name: /open github/i }));
     expect(onSelectLens).toHaveBeenCalledWith('pr');
     fireEvent.click(screen.getByRole('button', { name: /open linear/i }));

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ConnectedIntegrationGlyphs.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ConnectedIntegrationGlyphs.tsx
@@ -1,8 +1,6 @@
-import type { Session } from '@goodboy/types';
+import type { Session, SessionExternalTaskProvider } from '@goodboy/types';
 import { EMPTY_ARRAY, useAppStore } from '../../../../store';
 import type { LensKind } from '../../../../store';
-import { useRemoteHostKind } from '../../../worktree/useRemoteHostKind';
-import { resolveIntegrationConnection } from '../../../integrations/connection';
 import {
   IntegrationGlyph,
   type IntegrationGlyphProvider,
@@ -15,42 +13,32 @@ type Props = {
 
 type GlyphSpec = {
   readonly glyph: IntegrationGlyphProvider;
-  readonly connectionProvider: 'github' | 'gitlab' | 'linear' | 'sentry';
+  readonly taskProvider: SessionExternalTaskProvider;
   readonly lens: LensKind;
   readonly label: string;
 };
 
 const GLYPH_SPECS: ReadonlyArray<GlyphSpec> = [
-  { glyph: 'github', connectionProvider: 'github', lens: 'pr', label: 'GitHub' },
-  { glyph: 'gitlab', connectionProvider: 'gitlab', lens: 'gitlab_issues', label: 'GitLab' },
-  { glyph: 'linear', connectionProvider: 'linear', lens: 'linear', label: 'Linear' },
-  { glyph: 'sentry', connectionProvider: 'sentry', lens: 'sentry', label: 'Sentry' },
+  { glyph: 'github', taskProvider: 'github', lens: 'pr', label: 'GitHub' },
+  { glyph: 'gitlab', taskProvider: 'gitlab', lens: 'gitlab_issues', label: 'GitLab' },
+  { glyph: 'linear', taskProvider: 'linear', lens: 'linear', label: 'Linear' },
+  { glyph: 'sentry', taskProvider: 'sentry', lens: 'sentry', label: 'Sentry' },
 ];
 
 export const ConnectedIntegrationGlyphs = ({ session, onSelectLens }: Props) => {
   const externalTasks = useAppStore((s) => s.sessionExternalTasks[session.id] ?? EMPTY_ARRAY);
-  const workspaceIntegrations = useAppStore(
-    (s) => s.workspaceIntegrations[session.workspaceId] ?? EMPTY_ARRAY,
-  );
-  const remoteKind = useRemoteHostKind(session.workspaceId);
 
-  const connected = GLYPH_SPECS.filter(
-    (spec) =>
-      resolveIntegrationConnection({
-        provider: spec.connectionProvider,
-        integrations: workspaceIntegrations,
-        remoteKind,
-        externalTasks,
-      }).isConnected,
+  const linked = GLYPH_SPECS.filter((spec) =>
+    externalTasks.some((task) => task.provider === spec.taskProvider),
   );
 
-  if (connected.length === 0) {
+  if (linked.length === 0) {
     return null;
   }
 
   return (
     <div className="flex items-center gap-1">
-      {connected.map((spec) => (
+      {linked.map((spec) => (
         <button
           key={spec.glyph}
           type="button"

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/PrStatusLine.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/PrStatusLine.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { PullRequestState } from '@goodboy/types';
+
+const { mocks } = vi.hoisted(() => ({
+  mocks: {
+    openUrl: vi.fn(async () => undefined),
+  },
+}));
+
+vi.mock('../../../../shared/lib/editor', () => ({
+  openUrl: mocks.openUrl,
+}));
+
+import { PrStatusLine } from './PrStatusLine';
+
+beforeEach(() => {
+  mocks.openUrl.mockClear();
+});
+afterEach(cleanup);
+
+const basePr = (over: Partial<PullRequestState> = {}): PullRequestState => ({
+  number: 9304,
+  title: 'ship the thing',
+  url: 'https://github.com/acme/repo/pull/9304',
+  state: 'open',
+  mergeable: true,
+  checks: null,
+  baseBranch: 'main',
+  headBranch: 'ak/feat-thing',
+  isDraft: false,
+  reviewDecision: null,
+  body: '',
+  updatedAt: '2026-07-27T10:00:00.000Z',
+  ...over,
+});
+
+describe('PrStatusLine', () => {
+  it('opens the pull request url when the number is clicked', () => {
+    render(<PrStatusLine pr={basePr()} />);
+    fireEvent.click(screen.getByRole('button', { name: '#9304' }));
+    expect(mocks.openUrl).toHaveBeenCalledWith('https://github.com/acme/repo/pull/9304');
+  });
+
+  it('shows failing checks in danger tone and approved review in muted green', () => {
+    render(<PrStatusLine pr={basePr({ checks: 'failure', reviewDecision: 'approved' })} />);
+    expect(screen.getByTitle('checks failing')).toBeDefined();
+    expect(screen.getByText('approved').className).toContain('text-success/80');
+  });
+
+  it('shows changes requested in amber and omits the checks indicator when unknown', () => {
+    render(<PrStatusLine pr={basePr({ reviewDecision: 'changes_requested' })} />);
+    expect(screen.getByText('changes requested').className).toContain('text-warning');
+    expect(screen.queryByTitle('checks failing')).toBeNull();
+    expect(screen.queryByTitle('checks passing')).toBeNull();
+  });
+
+  it('renders the base and head branches', () => {
+    render(<PrStatusLine pr={basePr()} />);
+    expect(screen.getByText('main ← ak/feat-thing')).toBeDefined();
+  });
+});

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/PrStatusLine.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/PrStatusLine.test.tsx
@@ -44,17 +44,24 @@ describe('PrStatusLine', () => {
     expect(mocks.openUrl).toHaveBeenCalledWith('https://github.com/acme/repo/pull/9304');
   });
 
-  it('shows failing checks in danger tone and approved review in muted green', () => {
-    render(<PrStatusLine pr={basePr({ checks: 'failure', reviewDecision: 'approved' })} />);
-    expect(screen.getByTitle('checks failing')).toBeDefined();
-    expect(screen.getByText('approved').className).toContain('text-success/80');
+  it('marks failing checks in the danger tone', () => {
+    render(<PrStatusLine pr={basePr({ checks: 'failure' })} />);
+    expect(screen.getByTitle('Checks failing')).toBeDefined();
   });
 
   it('shows changes requested in amber and omits the checks indicator when unknown', () => {
     render(<PrStatusLine pr={basePr({ reviewDecision: 'changes_requested' })} />);
-    expect(screen.getByText('changes requested').className).toContain('text-warning');
-    expect(screen.queryByTitle('checks failing')).toBeNull();
-    expect(screen.queryByTitle('checks passing')).toBeNull();
+    expect(screen.getByText('Changes requested').className).toContain('text-warning');
+    expect(screen.queryByTitle('Checks failing')).toBeNull();
+    expect(screen.queryByTitle('Checks passing')).toBeNull();
+  });
+
+  it('keeps the approved and queued pill states distinct', () => {
+    render(<PrStatusLine pr={basePr({ state: 'approved' })} />);
+    expect(screen.getByText('Approved')).toBeDefined();
+    cleanup();
+    render(<PrStatusLine pr={basePr({ state: 'queued' })} />);
+    expect(screen.getByText('Queued')).toBeDefined();
   });
 
   it('renders the base and head branches', () => {

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/PrStatusLine.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/PrStatusLine.tsx
@@ -1,0 +1,80 @@
+import { Check, XCircle } from 'lucide-react';
+import type { PullRequestState, PullRequestStateKind } from '@goodboy/types';
+import { cn, StatusDot } from '@goodboy/ui';
+import { openUrl } from '../../../../shared/lib/editor';
+import { PullRequestChip } from '../../../github/components/PullRequestChip';
+
+type Props = {
+  readonly pr: PullRequestState;
+};
+
+const pillStateOf = ({ pr }: Props): PullRequestStateKind => {
+  if (pr.isDraft) {
+    return 'draft';
+  }
+  if (pr.state === 'merged') {
+    return 'merged';
+  }
+  if (pr.state === 'closed') {
+    return 'closed';
+  }
+  return 'open';
+};
+
+const reviewToneOf = ({ pr }: Props): string | null => {
+  if (pr.reviewDecision === 'approved') {
+    return 'text-success/80';
+  }
+  if (pr.reviewDecision === 'changes_requested') {
+    return 'text-warning';
+  }
+  return null;
+};
+
+const reviewLabelOf = ({ pr }: Props): string | null => {
+  if (pr.reviewDecision === 'approved') {
+    return 'approved';
+  }
+  if (pr.reviewDecision === 'changes_requested') {
+    return 'changes requested';
+  }
+  return null;
+};
+
+export const PrStatusLine = ({ pr }: Props) => {
+  const pillState = pillStateOf({ pr });
+  const reviewTone = reviewToneOf({ pr });
+  const reviewLabel = reviewLabelOf({ pr });
+
+  return (
+    <div className="flex min-w-0 items-center gap-2 text-sm leading-relaxed text-muted-foreground">
+      <PullRequestChip state={pillState} variant="badge" iconSize={9} />
+      <button
+        type="button"
+        onClick={() => void openUrl(pr.url)}
+        className="shrink-0 font-mono text-xs font-semibold text-muted-foreground hover:text-foreground hover:underline"
+      >
+        #{pr.number}
+      </button>
+      {pr.checks === 'failure' ? (
+        <span title="checks failing" className="shrink-0 text-danger">
+          <XCircle size={12} aria-hidden />
+        </span>
+      ) : null}
+      {pr.checks === 'success' ? (
+        <span title="checks passing" className="shrink-0 text-success/70">
+          <Check size={12} aria-hidden />
+        </span>
+      ) : null}
+      {pr.checks === 'pending' ? (
+        <StatusDot tone="info" pulsing size="sm" ariaLabel="checks running" role="status" />
+      ) : null}
+      {reviewLabel != null && reviewTone != null ? (
+        <span className={cn('shrink-0', reviewTone)}>{reviewLabel}</span>
+      ) : null}
+      <span className="min-w-0 flex-1 truncate font-mono text-xs">
+        {pr.baseBranch} ← {pr.headBranch}
+      </span>
+    </div>
+  );
+};

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/PrStatusLine.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/PrStatusLine.tsx
@@ -1,6 +1,6 @@
 import { Check, XCircle } from 'lucide-react';
 import type { PullRequestState, PullRequestStateKind } from '@goodboy/types';
-import { cn, StatusDot } from '@goodboy/ui';
+import { StatusDot } from '@goodboy/ui';
 import { openUrl } from '../../../../shared/lib/editor';
 import { PullRequestChip } from '../../../github/components/PullRequestChip';
 
@@ -12,39 +12,12 @@ const pillStateOf = ({ pr }: Props): PullRequestStateKind => {
   if (pr.isDraft) {
     return 'draft';
   }
-  if (pr.state === 'merged') {
-    return 'merged';
-  }
-  if (pr.state === 'closed') {
-    return 'closed';
-  }
-  return 'open';
-};
-
-const reviewToneOf = ({ pr }: Props): string | null => {
-  if (pr.reviewDecision === 'approved') {
-    return 'text-success/80';
-  }
-  if (pr.reviewDecision === 'changes_requested') {
-    return 'text-warning';
-  }
-  return null;
-};
-
-const reviewLabelOf = ({ pr }: Props): string | null => {
-  if (pr.reviewDecision === 'approved') {
-    return 'approved';
-  }
-  if (pr.reviewDecision === 'changes_requested') {
-    return 'changes requested';
-  }
-  return null;
+  return pr.state;
 };
 
 export const PrStatusLine = ({ pr }: Props) => {
   const pillState = pillStateOf({ pr });
-  const reviewTone = reviewToneOf({ pr });
-  const reviewLabel = reviewLabelOf({ pr });
+  const wantsChanges = pr.reviewDecision === 'changes_requested';
 
   return (
     <div className="flex min-w-0 items-center gap-2 text-sm leading-relaxed text-muted-foreground">
@@ -57,21 +30,19 @@ export const PrStatusLine = ({ pr }: Props) => {
         #{pr.number}
       </button>
       {pr.checks === 'failure' ? (
-        <span title="checks failing" className="shrink-0 text-danger">
+        <span title="Checks failing" className="shrink-0 text-danger">
           <XCircle size={12} aria-hidden />
         </span>
       ) : null}
       {pr.checks === 'success' ? (
-        <span title="checks passing" className="shrink-0 text-success/70">
+        <span title="Checks passing" className="shrink-0 text-success/70">
           <Check size={12} aria-hidden />
         </span>
       ) : null}
       {pr.checks === 'pending' ? (
-        <StatusDot tone="info" pulsing size="sm" ariaLabel="checks running" role="status" />
+        <StatusDot tone="info" pulsing size="sm" ariaLabel="Checks running" role="status" />
       ) : null}
-      {reviewLabel != null && reviewTone != null ? (
-        <span className={cn('shrink-0', reviewTone)}>{reviewLabel}</span>
-      ) : null}
+      {wantsChanges && <span className="shrink-0 text-warning">Changes requested</span>}
       <span className="min-w-0 flex-1 truncate font-mono text-xs">
         {pr.baseBranch} ← {pr.headBranch}
       </span>

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/index.tsx
@@ -45,6 +45,7 @@ import { StartTileContent } from './StartTileContent';
 import { SummaryRow } from './SummaryRow';
 import { ConnectedIntegrationGlyphs } from './ConnectedIntegrationGlyphs';
 import { EditorMenu } from './EditorMenu';
+import { PrStatusLine } from './PrStatusLine';
 
 type SessionOverviewPaneProps = {
   readonly session: Session;
@@ -93,6 +94,7 @@ export const SessionOverviewPane = ({ session, onSelectLens }: SessionOverviewPa
   const sessionList = useMemo(() => [session], [session]);
   const runs = useWorkspaceRuns(session.workspaceId, sessionList);
   const branch = useAppStore((s) => s.sessionBranches[session.id as SessionId] ?? null);
+  const pullRequest = useAppStore((s) => s.sessionGithub[session.id as SessionId]?.pr ?? null);
   const attention = selectAttention(stage);
   const openQuestions = selectOpenQuestions(useSessionOpenQuestions(session.id));
   const rawStandalone = selectStandaloneAgents(
@@ -265,7 +267,9 @@ export const SessionOverviewPane = ({ session, onSelectLens }: SessionOverviewPa
               </button>
             </div>
           )}
-          {stage.reason ? (
+          {pullRequest != null ? (
+            <PrStatusLine pr={pullRequest} />
+          ) : stage.reason ? (
             <p className="text-sm leading-relaxed text-muted-foreground">{stage.reason}</p>
           ) : null}
           <div className="flex flex-wrap items-center gap-2">

--- a/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
@@ -366,7 +366,7 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
                   />
                 ) : null}
                 {lens === 'scripts' ? (
-                  <PaneShell title="Scripts" width="3xl">
+                  <PaneShell title="Scripts" width="5xl">
                     <ScriptsPanel
                       workspaceId={session.workspaceId}
                       sessionId={sessionId}

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn.test.tsx
@@ -136,6 +136,21 @@ describe('LensColumn', () => {
     expect(onSelectOverview).toHaveBeenCalledOnce();
   });
 
+  it('marks a disconnected integration and leaves connected ones unmarked', () => {
+    const { container } = render(
+      <LensColumn
+        session={SESSION}
+        activeLens="agents"
+        onSelectOverview={vi.fn()}
+        onSelect={vi.fn()}
+        filesCount={0}
+      />,
+    );
+
+    expect(container.querySelector('[title="GitLab disconnected"]')).not.toBeNull();
+    expect(container.querySelector('[title="Linear disconnected"]')).toBeNull();
+  });
+
   it('orders the regrouped lens sections and rows', () => {
     render(
       <LensColumn
@@ -174,9 +189,9 @@ describe('LensColumn', () => {
       'Decisions',
       'Session summary',
       'GitHub',
-      'GitLab',
       'Linear',
       'Sentry',
+      'GitLab',
       'Terminal',
     ]);
   });

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn.tsx
@@ -13,6 +13,7 @@ import {
   SquareTerminal,
   Target,
   Terminal,
+  Unplug,
 } from 'lucide-react';
 import { Divider, KbdPill, ScrollFade, Skeleton, StatusDot, cn, tintClasses } from '@goodboy/ui';
 import type { Tone } from '@goodboy/ui';
@@ -240,6 +241,15 @@ export const LensColumn = ({
       isConnected: sentryConnection.isConnected,
     },
   ];
+  const sortedIntegrationRows: ReadonlyArray<LensRow> = [...integrationRows].sort((a, b) => {
+    if (a.isConnected === false && b.isConnected !== false) {
+      return 1;
+    }
+    if (b.isConnected === false && a.isConnected !== false) {
+      return -1;
+    }
+    return 0;
+  });
 
   const repoGroups: ReadonlyArray<LensGroup> = [
     {
@@ -336,7 +346,7 @@ export const LensColumn = ({
     },
     {
       label: 'Integrations',
-      rows: integrationRows,
+      rows: sortedIntegrationRows,
     },
     {
       label: 'Infra',
@@ -477,7 +487,8 @@ export const LensColumn = ({
                     row.isCountLoading === true ||
                     (row.count != null && row.count > 0) ||
                     row.dot != null ||
-                    row.secondaryDot === true;
+                    row.secondaryDot === true ||
+                    row.isConnected === false;
                   return (
                     <button
                       key={row.kind}
@@ -531,32 +542,45 @@ export const LensColumn = ({
                             <span data-testid={`lens-count-loading-${row.kind}`}>
                               <Skeleton className="h-4 w-6 rounded-full" />
                             </span>
-                          ) : row.count != null && row.count > 0 ? (
-                            <span className="flex shrink-0 items-center gap-1.5">
-                              {row.secondaryDot ? <StatusDot tone="accent" size="sm" /> : null}
-                              {row.dot === 'running' ? (
-                                <StatusDot tone="info" size="sm" pulsing />
+                          ) : (
+                            <>
+                              {row.count != null && row.count > 0 ? (
+                                <span className="flex shrink-0 items-center gap-1.5">
+                                  {row.secondaryDot ? <StatusDot tone="accent" size="sm" /> : null}
+                                  {row.dot === 'running' ? (
+                                    <StatusDot tone="info" size="sm" pulsing />
+                                  ) : null}
+                                  <span
+                                    className={cn(
+                                      'rounded px-1.5 py-0.5 text-2xs font-medium tabular-nums',
+                                      row.dot === 'attention'
+                                        ? 'bg-warning/15 text-warning'
+                                        : 'bg-muted text-muted-foreground',
+                                    )}
+                                  >
+                                    {row.count}
+                                  </span>
+                                </span>
+                              ) : row.dot ? (
+                                <StatusDot
+                                  tone={row.dot === 'attention' ? 'warning' : 'info'}
+                                  size="sm"
+                                  pulsing={row.dot === 'running'}
+                                />
+                              ) : row.secondaryDot ? (
+                                <StatusDot tone="accent" size="sm" />
                               ) : null}
-                              <span
-                                className={cn(
-                                  'rounded px-1.5 py-0.5 text-2xs font-medium tabular-nums',
-                                  row.dot === 'attention'
-                                    ? 'bg-warning/15 text-warning'
-                                    : 'bg-muted text-muted-foreground',
-                                )}
-                              >
-                                {row.count}
-                              </span>
-                            </span>
-                          ) : row.dot ? (
-                            <StatusDot
-                              tone={row.dot === 'attention' ? 'warning' : 'info'}
-                              size="sm"
-                              pulsing={row.dot === 'running'}
-                            />
-                          ) : row.secondaryDot ? (
-                            <StatusDot tone="accent" size="sm" />
-                          ) : null}
+                              {row.isConnected === false ? (
+                                <span
+                                  aria-hidden
+                                  title={`${row.label} disconnected`}
+                                  className="flex shrink-0 items-center text-muted-foreground"
+                                >
+                                  <Unplug size={12} />
+                                </span>
+                              ) : null}
+                            </>
+                          )}
                         </span>
                       ) : null}
                       {shortcut != null ? (

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/PaneShell.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/PaneShell.tsx
@@ -6,13 +6,14 @@ type Props = {
   readonly description?: string;
   readonly meta?: ReactNode;
   readonly actions?: ReactNode;
-  readonly width?: '2xl' | '3xl';
+  readonly width?: '2xl' | '3xl' | '5xl';
   readonly children: ReactNode;
 };
 
-const WIDTH: Record<'2xl' | '3xl', string> = {
+const WIDTH: Record<'2xl' | '3xl' | '5xl', string> = {
   '2xl': 'max-w-2xl',
   '3xl': 'max-w-3xl',
+  '5xl': 'max-w-5xl',
 };
 
 export const PaneShell = ({

--- a/apps/desktop/src/store/slices/open-questions/dismissOpenQuestion.ts
+++ b/apps/desktop/src/store/slices/open-questions/dismissOpenQuestion.ts
@@ -19,5 +19,6 @@ export const dismissOpenQuestion = (set: SetFn, get: GetFn) => {
     if (slotChanged) {
       await get().loadSessionSlots(sessionId);
     }
+    void get().maybeAutoAdvanceWorkflow(sessionId);
   };
 };

--- a/apps/desktop/src/store/slices/workflows/finalizeWorkflowStep.test.ts
+++ b/apps/desktop/src/store/slices/workflows/finalizeWorkflowStep.test.ts
@@ -83,11 +83,12 @@ const session: Session = {
 
 type Params = {
   readonly sessions?: ReadonlyArray<Session>;
+  readonly agents?: ReadonlyArray<Agent>;
 };
 
-const buildHarness = ({ sessions = [session] }: Params = {}) => {
+const buildHarness = ({ sessions = [session], agents = [agent] }: Params = {}) => {
   const state = {
-    sessionPhaseRuns: { [SESSION_ID]: [agent] },
+    sessionPhaseRuns: { [SESSION_ID]: agents },
     sessions,
     refreshUnreadWorkspaces: vi.fn(),
     emitNotification: vi.fn(),
@@ -214,6 +215,35 @@ describe('finalizeWorkflowStep output summary', () => {
       AGENT_ID,
       expect.objectContaining({ outputSummary: 'timeout output' }),
     );
+  });
+
+  it('ignores a step-done marker that names a different step', async () => {
+    const sibling: Agent = { ...agent, id: 'agent-2' as AgentId, ordinal: 1, name: 'Review' };
+    invokeAgentListSpy.mockResolvedValue([agent, sibling]);
+    const finalize = buildHarness({ agents: [agent, sibling] });
+
+    const result = await finalize(
+      SESSION_ID,
+      AGENT_ID,
+      'done here <<step-done id="agent-2">>',
+      false,
+    );
+
+    expect(result).toEqual({ shouldAutoAdvance: false });
+  });
+
+  it('accepts a step-done marker whose id matches no known agent', async () => {
+    summarizeStepOutputSpy.mockResolvedValue('Did the thing.');
+    const finalize = buildHarness();
+
+    const result = await finalize(
+      SESSION_ID,
+      AGENT_ID,
+      'all done <<step-done id="agent-1-truncated">>',
+      false,
+    );
+
+    expect(result).toEqual({ shouldAutoAdvance: true });
   });
 
   it('does not fail the step when the agent stopped to ask an open question', async () => {

--- a/apps/desktop/src/store/slices/workflows/finalizeWorkflowStep.ts
+++ b/apps/desktop/src/store/slices/workflows/finalizeWorkflowStep.ts
@@ -59,7 +59,10 @@ export const finalizeWorkflowStep = (set: SetFn, get: GetFn) => {
       return { shouldAutoAdvance: false };
     }
 
-    const hasMarker = extractStepDone(assistantText)?.id === agentId;
+    const markerId = extractStepDone(assistantText)?.id ?? null;
+    const claimsAnotherStep =
+      markerId !== null && markerId !== agentId && runs.some((r) => r.id === markerId);
+    const hasMarker = markerId !== null && !claimsAnotherStep;
     const satisfied = !!opts?.force || hasMarker || planCapturedThisTurn;
     if (!satisfied) {
       const askedQuestion = extractMarkers(assistantText).questions.length > 0;

--- a/apps/desktop/src/store/slices/workflows/finalizeWorkflowStep.ts
+++ b/apps/desktop/src/store/slices/workflows/finalizeWorkflowStep.ts
@@ -59,7 +59,7 @@ export const finalizeWorkflowStep = (set: SetFn, get: GetFn) => {
       return { shouldAutoAdvance: false };
     }
 
-    const hasMarker = extractStepDone(assistantText) !== null;
+    const hasMarker = extractStepDone(assistantText)?.id === agentId;
     const satisfied = !!opts?.force || hasMarker || planCapturedThisTurn;
     if (!satisfied) {
       const askedQuestion = extractMarkers(assistantText).questions.length > 0;

--- a/apps/desktop/src/store/slices/workflows/maybeAutoAdvanceWorkflow.test.ts
+++ b/apps/desktop/src/store/slices/workflows/maybeAutoAdvanceWorkflow.test.ts
@@ -159,6 +159,56 @@ describe('maybeAutoAdvanceWorkflow', () => {
     expect(state['activateWorkflowAgent']).toHaveBeenCalledTimes(1);
   });
 
+  it('starts a chained run and activates its first step in the same pass', async () => {
+    const CHAINED_ID = 'run-2' as WorkflowRunId;
+    const predAgent = makeAgent('s0', 'completed', 0);
+    const chainedAgent: Agent = {
+      id: `${CHAINED_ID}-s0` as AgentId,
+      sessionId: SESSION_ID,
+      stepId: 's0' as StepId,
+      workflowRunId: CHAINED_ID,
+      ordinal: 0,
+      name: 'chained step',
+      status: 'pending',
+    };
+    const session = makeSession();
+    const state = baseState(['s0'], [predAgent, chainedAgent]);
+    state['sessions'] = [
+      {
+        ...session,
+        workflowRuns: [
+          ...session.workflowRuns,
+          {
+            id: CHAINED_ID,
+            workflowId: WF_ID,
+            ordinal: 1,
+            currentStep: 0,
+            autoRun: true,
+            triggerMode: 'after_run',
+            chainAfterId: RUN_ID,
+          },
+        ],
+      },
+    ];
+    state['startWorkflowRun'] = vi.fn(async () => {
+      const [current] = state['sessions'] as ReadonlyArray<Session>;
+      state['sessions'] = [
+        {
+          ...(current as Session),
+          workflowRuns: (current as Session).workflowRuns.map((r) =>
+            r.id === CHAINED_ID ? { ...r, triggerMode: 'immediate' as const } : r,
+          ),
+        },
+      ];
+    });
+    const { set, get } = harness(state);
+
+    await maybeAutoAdvanceWorkflow(set, get)(SESSION_ID);
+
+    expect(state['startWorkflowRun']).toHaveBeenCalledWith(SESSION_ID, CHAINED_ID);
+    expect(state['activateWorkflowAgent']).toHaveBeenCalledWith(SESSION_ID, `${CHAINED_ID}-s0`);
+  });
+
   it('holds while the summarizer runs and advances once it finishes', async () => {
     const state = baseState(['s0'], [makeAgent('s0', 'pending', 0)]);
     state['summarizerStatus'] = { [SESSION_ID]: { status: 'running' } };

--- a/apps/desktop/src/store/slices/workflows/maybeAutoAdvanceWorkflow.test.ts
+++ b/apps/desktop/src/store/slices/workflows/maybeAutoAdvanceWorkflow.test.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  Agent,
+  AgentId,
+  AgentStatus,
+  IsoDateTime,
+  Session,
+  SessionId,
+  StepId,
+  Workflow,
+  WorkflowId,
+  WorkflowRun,
+  WorkflowRunId,
+  WorkspaceId,
+} from '@goodboy/types';
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
+vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn() }));
+
+const { listOpenQuestionsSpy } = vi.hoisted(() => ({
+  listOpenQuestionsSpy: vi.fn(async () => []),
+}));
+
+vi.mock('@goodboy/db', () => ({
+  listOpenQuestionsForSession: listOpenQuestionsSpy,
+}));
+
+vi.mock('../../../shared/lib/db', () => ({ tauriDatabase: {} }));
+
+import { maybeAutoAdvanceWorkflow } from './maybeAutoAdvanceWorkflow';
+
+const WS_ID = 'ws-1' as WorkspaceId;
+const WF_ID = 'wf-1' as WorkflowId;
+const SESSION_ID = 'ses-1' as SessionId;
+const RUN_ID = 'run-1' as WorkflowRunId;
+const NOW = '2026-07-27T00:00:00.000Z' as IsoDateTime;
+
+const makeWorkflow = (stepIds: ReadonlyArray<string>): Workflow => ({
+  id: WF_ID,
+  workspaceId: WS_ID,
+  name: 'wf',
+  description: '',
+  steps: stepIds.map((stepId, i) => ({
+    id: stepId as StepId,
+    workflowId: WF_ID,
+    ordinal: i,
+    name: stepId,
+    promptPrefix: '',
+  })),
+  createdAt: NOW,
+  updatedAt: NOW,
+});
+
+const makeAgent = (stepId: string, status: AgentStatus, ordinal: number): Agent => ({
+  id: `${RUN_ID}-${stepId}` as AgentId,
+  sessionId: SESSION_ID,
+  stepId: stepId as StepId,
+  workflowRunId: RUN_ID,
+  ordinal,
+  name: stepId,
+  status,
+});
+
+const makeSession = (): Session => ({
+  id: SESSION_ID,
+  workspaceId: WS_ID,
+  goal: 'g',
+  state: { kind: 'idle', lastActivityAt: NOW },
+  contextSlots: [],
+  providerPreference: {
+    defaultProvider: 'anthropic',
+    allowTurnOverride: true,
+  } as Session['providerPreference'],
+  permissionMode: 'default' as Session['permissionMode'],
+  workflowRuns: [
+    {
+      id: RUN_ID,
+      workflowId: WF_ID,
+      ordinal: 0,
+      currentStep: 0,
+      autoRun: true,
+      triggerMode: 'immediate',
+    },
+  ],
+  autoRun: true,
+  titleUserEdited: false,
+  createdAt: NOW,
+  updatedAt: NOW,
+});
+
+type StoreState = Record<string, unknown>;
+
+const baseState = (stepIds: ReadonlyArray<string>, agents: ReadonlyArray<Agent>): StoreState => ({
+  sessions: [makeSession()],
+  phaseTemplates: { [WS_ID]: [makeWorkflow(stepIds)] },
+  sessionPhaseRuns: { [SESSION_ID]: agents },
+  summarizerStatus: {},
+  budgetAlerts: [],
+  startWorkflowRun: vi.fn(async () => undefined),
+  activateWorkflowAgent: vi.fn(async () => undefined),
+  emitNotification: vi.fn(async () => undefined),
+});
+
+const harness = (state: StoreState) => {
+  const set = vi.fn((updater: unknown) => {
+    if (typeof updater === 'function') {
+      Object.assign(state, (updater as (s: StoreState) => StoreState)(state));
+      return;
+    }
+    Object.assign(state, updater as StoreState);
+  });
+  return { set: set as never, get: (() => state) as never };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('maybeAutoAdvanceWorkflow', () => {
+  it('activates the next pending step once its predecessors are done', async () => {
+    const state = baseState(
+      ['s0', 's1', 's2'],
+      [
+        makeAgent('s0', 'completed', 0),
+        makeAgent('s1', 'pending', 1),
+        makeAgent('s2', 'pending', 2),
+      ],
+    );
+    const { set, get } = harness(state);
+    await maybeAutoAdvanceWorkflow(set, get)(SESSION_ID);
+    expect(state['activateWorkflowAgent']).toHaveBeenCalledWith(SESSION_ID, `${RUN_ID}-s1`);
+  });
+
+  it('does not skip past a step that failed', async () => {
+    const state = baseState(
+      ['s0', 's1'],
+      [makeAgent('s0', 'failed', 0), makeAgent('s1', 'pending', 1)],
+    );
+    const { set, get } = harness(state);
+    await maybeAutoAdvanceWorkflow(set, get)(SESSION_ID);
+    expect(state['activateWorkflowAgent']).not.toHaveBeenCalled();
+  });
+
+  it('spawns a single agent when two advances race', async () => {
+    let release = () => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const state = baseState(['s0'], [makeAgent('s0', 'pending', 0)]);
+    state['activateWorkflowAgent'] = vi.fn(async () => {
+      await gate;
+    });
+    const { set, get } = harness(state);
+    const advance = maybeAutoAdvanceWorkflow(set, get);
+    const first = advance(SESSION_ID);
+    const second = advance(SESSION_ID);
+    release();
+    await Promise.all([first, second]);
+    expect(state['activateWorkflowAgent']).toHaveBeenCalledTimes(1);
+  });
+
+  it('holds while the summarizer runs and advances once it finishes', async () => {
+    const state = baseState(['s0'], [makeAgent('s0', 'pending', 0)]);
+    state['summarizerStatus'] = { [SESSION_ID]: { status: 'running' } };
+    const { set, get } = harness(state);
+    const advance = maybeAutoAdvanceWorkflow(set, get);
+
+    await advance(SESSION_ID);
+    expect(state['activateWorkflowAgent']).not.toHaveBeenCalled();
+
+    state['summarizerStatus'] = { [SESSION_ID]: { status: 'idle' } };
+    await advance(SESSION_ID);
+    expect(state['activateWorkflowAgent']).toHaveBeenCalledWith(SESSION_ID, `${RUN_ID}-s0`);
+  });
+});

--- a/apps/desktop/src/store/slices/workflows/maybeAutoAdvanceWorkflow.ts
+++ b/apps/desktop/src/store/slices/workflows/maybeAutoAdvanceWorkflow.ts
@@ -5,102 +5,125 @@ import { tauriDatabase } from '../../../shared/lib/db';
 import { workflowRunHasOpenQuestions } from '../../../features/context/openQuestionsGate';
 import type { GetFn, SetFn } from './types';
 
+const advanceInFlight = new Set<SessionId>();
+
+type Params = {
+  readonly get: GetFn;
+  readonly sessionId: SessionId;
+};
+
+const startChainedRuns = async ({ get, sessionId }: Params): Promise<void> => {
+  const state = get();
+  const session = state.sessions.find((s) => s.id === sessionId);
+  if (session == null) {
+    return;
+  }
+  const templates = state.phaseTemplates[session.workspaceId] ?? [];
+  const runs = state.sessionPhaseRuns[sessionId] ?? [];
+  for (const candidate of session.workflowRuns) {
+    if (
+      candidate.discardedAt != null ||
+      candidate.triggerMode !== 'after_run' ||
+      candidate.chainAfterId == null
+    ) {
+      continue;
+    }
+    const predecessor = session.workflowRuns.find((r) => r.id === candidate.chainAfterId);
+    if (predecessor == null || predecessor.discardedAt != null) {
+      continue;
+    }
+    const predTemplate = templates.find((t) => t.id === predecessor.workflowId);
+    if (predTemplate == null) {
+      continue;
+    }
+    if (isWorkflowComplete(predTemplate, runsForWorkflowRun(runs, predecessor.id))) {
+      await get().startWorkflowRun(sessionId, candidate.id);
+    }
+  }
+};
+
+const runAdvance = async ({ get, sessionId }: Params): Promise<void> => {
+  await startChainedRuns({ get, sessionId });
+
+  const state = get();
+  const session = state.sessions.find((s) => s.id === sessionId);
+  if (session == null || session.workflowRuns.length === 0) {
+    return;
+  }
+  const activeRuns = session.workflowRuns.filter(
+    (r) => r.autoRun && r.discardedAt == null && r.triggerMode === 'immediate',
+  );
+  if (activeRuns.length === 0) {
+    return;
+  }
+  if (state.summarizerStatus[sessionId]?.status === 'running') {
+    return;
+  }
+  const exceeded = state.budgetAlerts.some(
+    (a) =>
+      a.dismissedAt === undefined &&
+      ((a.kind === 'session-exceeded' && a.sessionId === sessionId) ||
+        a.kind === 'provider-exceeded'),
+  );
+  if (exceeded) {
+    return;
+  }
+  const templates = state.phaseTemplates[session.workspaceId] ?? [];
+  const runs = state.sessionPhaseRuns[sessionId] ?? [];
+  const openQuestions = await listOpenQuestionsForSession(tauriDatabase, sessionId, 'open');
+  const nextPendingAgent = (() => {
+    for (const run of activeRuns) {
+      if (workflowRunHasOpenQuestions(openQuestions, run.id)) {
+        continue;
+      }
+      const template = templates.find((t) => t.id === run.workflowId);
+      if (template == null) {
+        continue;
+      }
+      const runAgents = runsForWorkflowRun(runs, run.id);
+      const sortedSteps = [...template.steps].sort((a, b) => a.ordinal - b.ordinal);
+      for (const step of sortedSteps) {
+        const agent = runAgents.find((r) => r.stepId === step.id);
+        if (agent == null || agent.status !== 'pending') {
+          continue;
+        }
+        const prevSteps = sortedSteps.filter((s) => s.ordinal < step.ordinal);
+        const allDone = prevSteps.every((s) =>
+          runAgents.some(
+            (r) => r.stepId === s.id && (r.status === 'completed' || r.status === 'skipped'),
+          ),
+        );
+        if (allDone) {
+          return agent;
+        }
+        break;
+      }
+    }
+    return null;
+  })();
+  if (nextPendingAgent == null) {
+    return;
+  }
+  await get().activateWorkflowAgent(sessionId, nextPendingAgent.id);
+  void get().emitNotification(
+    'agent-auto-spawn',
+    'info',
+    `agent auto-spawned: ${nextPendingAgent.name}`,
+    undefined,
+    { sessionId },
+  );
+};
+
 export const maybeAutoAdvanceWorkflow = (_set: SetFn, get: GetFn) => {
   return async (sessionId: SessionId) => {
-    const state = get();
-    const session = state.sessions.find((s) => s.id === sessionId);
-    if (!session || session.workflowRuns.length === 0) {
+    if (advanceInFlight.has(sessionId)) {
       return;
     }
-    const templates = state.phaseTemplates[session.workspaceId] ?? [];
-    const runs = state.sessionPhaseRuns[sessionId] ?? [];
-
-    let firedChain = false;
-    for (const candidate of session.workflowRuns) {
-      if (
-        candidate.discardedAt ||
-        candidate.triggerMode !== 'after_run' ||
-        !candidate.chainAfterId
-      ) {
-        continue;
-      }
-      const predecessor = session.workflowRuns.find((r) => r.id === candidate.chainAfterId);
-      if (!predecessor || predecessor.discardedAt) {
-        continue;
-      }
-      const predTemplate = templates.find((t) => t.id === predecessor.workflowId);
-      if (!predTemplate) {
-        continue;
-      }
-      if (isWorkflowComplete(predTemplate, runsForWorkflowRun(runs, predecessor.id))) {
-        await get().startWorkflowRun(sessionId, candidate.id);
-        firedChain = true;
-      }
+    advanceInFlight.add(sessionId);
+    try {
+      await runAdvance({ get, sessionId });
+    } finally {
+      advanceInFlight.delete(sessionId);
     }
-    if (firedChain) {
-      return;
-    }
-
-    const activeRuns = session.workflowRuns.filter(
-      (r) => r.autoRun && !r.discardedAt && r.triggerMode === 'immediate',
-    );
-    if (activeRuns.length === 0) {
-      return;
-    }
-    const summarizerBusy = state.summarizerStatus[sessionId]?.status === 'running';
-    if (summarizerBusy) {
-      return;
-    }
-    const exceeded = state.budgetAlerts.some(
-      (a) =>
-        a.dismissedAt === undefined &&
-        ((a.kind === 'session-exceeded' && a.sessionId === sessionId) ||
-          a.kind === 'provider-exceeded'),
-    );
-    if (exceeded) {
-      return;
-    }
-    const openQuestions = await listOpenQuestionsForSession(tauriDatabase, sessionId, 'open');
-    const nextPendingAgent = (() => {
-      for (const run of activeRuns) {
-        if (workflowRunHasOpenQuestions(openQuestions, run.id)) {
-          continue;
-        }
-        const template = templates.find((t) => t.id === run.workflowId);
-        if (!template) {
-          continue;
-        }
-        const runAgents = runsForWorkflowRun(runs, run.id);
-        const sortedSteps = [...template.steps].sort((a, b) => a.ordinal - b.ordinal);
-        for (const step of sortedSteps) {
-          const agent = runAgents.find((r) => r.stepId === step.id);
-          if (!agent || agent.status !== 'pending') {
-            continue;
-          }
-          const prevSteps = sortedSteps.filter((s) => s.ordinal < step.ordinal);
-          const allDone = prevSteps.every((s) =>
-            runAgents.some(
-              (r) => r.stepId === s.id && (r.status === 'completed' || r.status === 'skipped'),
-            ),
-          );
-          if (allDone) {
-            return agent;
-          }
-          break;
-        }
-      }
-      return null;
-    })();
-    if (!nextPendingAgent) {
-      return;
-    }
-    await get().activateWorkflowAgent(sessionId, nextPendingAgent.id);
-    void get().emitNotification(
-      'agent-auto-spawn',
-      'info',
-      `agent auto-spawned: ${nextPendingAgent.name}`,
-      undefined,
-      { sessionId },
-    );
   };
 };

--- a/apps/desktop/src/store/turn-helpers.ts
+++ b/apps/desktop/src/store/turn-helpers.ts
@@ -135,6 +135,7 @@ const runQueuedSummarizer = ({ set, get, sessionId, entry }: Params): void => {
     const next = queue.queued;
     if (next == null) {
       queue.inFlight = false;
+      void get().maybeAutoAdvanceWorkflow(sessionId);
       return;
     }
     queue.queued = null;

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -171,23 +171,30 @@ does not do.
 
 ### Sibling panels inside a lens
 
-Four surfaces open their detail to the right of the content instead of taking a
+Five surfaces open their detail to the right of the content instead of taking a
 studio rail: `ResolverInspector` (from a resolver row's "Details" action in the
 Resolve lens), `AgentInspector` (from an agent row's "Details" action in the
 Agents lens), `SlotHistoryPanel` in `SlotPane` (the history trigger in the pane
 header of the Goal, Decisions, and Session summary lenses, rendered only when
-that slot has history), and `PlanListPanel` in `PlanStudio` (the "Other plans
-(N)" trigger in the pane header, rendered only when the session holds more than
-one plan).
+that slot has history), `ScriptEditor` in `ScriptsPanel` (opened by clicking any
+script row, and the only way to edit a script since the list rows collapsed to
+one line), and `PlanListPanel` in `PlanStudio` (the "Other plans (N)" trigger in
+the pane header, rendered only when the session holds more than one plan).
 
-`ResolverInspector`, `AgentInspector`, and `SlotHistoryPanel` share one
-primitive, `InspectorSplit` (`SessionWorkspace/parts/InspectorSplit/`): the pane
-is a flex row, the panel is a sibling column resizable via a `ResizeHandle`
-(width persisted at `STORAGE_KEYS.inspectorPanelWidth`), open state is local to
-the pane, the panel loads or refreshes its data when it opens, and it closes
-from its own header. `PlanListPanel` predates this primitive and stays a
-fixed-width column behind a plain `<Divider>`. Reuse `InspectorSplit` for the
-next detail surface rather than adding a rail.
+`ResolverInspector`, `AgentInspector`, `SlotHistoryPanel`, and `ScriptEditor`
+share one primitive, `InspectorSplit`
+(`SessionWorkspace/parts/InspectorSplit/`): the pane is a flex row, the panel is
+a sibling column resizable via a `ResizeHandle` (width persisted at
+`STORAGE_KEYS.inspectorPanelWidth`), open state is local to the pane, the panel
+loads or refreshes its data when it opens, and it closes from its own header.
+`PlanListPanel` predates this primitive and stays a fixed-width column behind a
+plain `<Divider>`. Reuse `InspectorSplit` for the next detail surface rather
+than adding a rail.
+
+`ScriptsPanel` is the one consumer that nests the split _inside_ its
+`PaneShell` rather than wrapping it, because the same component also mounts in
+Workspace settings where there is no `PaneShell`. Its lens therefore runs at
+`width="5xl"` so the list and the editor each keep a usable column.
 
 ## New session form
 


### PR DESCRIPTION
Six areas from the latest UX pass. Five are visible defects, one is a real bug in the workflow engine.

## Workflow autorun stalled and never recovered

`maybeAutoAdvanceWorkflow` was edge-triggered: it ran once at turn end and returned early on three blocking conditions (summarizer running, budget alert, open question) with nothing to re-invoke it once the condition cleared.

The common case was a race. `sendTurn` fire-and-forgets `enqueueSummarizer` (scheduled on `requestIdleCallback`) and then, two awaits later, calls the advance. The summarizer usually flips to `running` in between, so the advance bailed and the run sat there until someone clicked advance by hand. It passed in tests because the test env takes the `queueMicrotask` fallback and orders differently.

- Re-invoke the advance when the summarizer queue drains and when an open question is dismissed.
- Guard the advance with a synchronous in-flight flag per session, so two callers spawn one agent rather than two. `activateWorkflowAgent` starts a paid turn, so double-firing is the expensive failure.
- The guard suppresses the recursive call `startWorkflowRun` makes, so the chain loop no longer returns early and re-reads state instead, activating the chained run in the same pass.
- A step-done marker is now rejected only when it provably names a different agent in the run. Matching the id exactly would have failed a step whenever a model garbled its own marker.

Deliberately not done: the summarizer gate stays. Advancing mid-summarize would launch the next step without the fresh context summary, which is a quieter regression than the stall it hides. Budget-alert dismissal also still stalls; unblocking it needs cross-session fan-out that could spawn several paid agents at once, so it wants its own decision.

## Session overview header

Glyphs were driven by workspace connection state, so on any GitHub-hosted repo the GitHub glyph was always lit regardless of whether the session had anything linked. They now follow the session's linked tasks, and nothing renders when there are none. A PR alone no longer lights the glyph.

The PR instead gets its own status line under the title: state pill, number, checks, review decision, `base <- head`. Colour is confined to the pill and the two indicators. Non-PR sessions keep the existing stage sentence in the same slot.

## Lens column

Integrations sort connected first, disconnected after, stable within each block. Disconnected rows carry an unplug marker on the right, so dimming is no longer the only cue and the empty half of the cell explains itself.

## Scripts

Every row printed its whole body, which made a handful of scripts unscannable, and editing swapped the row into a form under the cursor. Rows are now one line with a first-command preview; the editor and the last run live in a resizable `InspectorSplit` panel. Unsaved edits prompt before being dropped. The lens runs at `width="5xl"` so both columns stay usable.

## Impact Studio and create-agent popover

Impact Studio was the only studio rendering full bleed: it now centres at `max-w-5xl` like the Budget overview, and its plan and delegation grids collapse at `md`/`lg` instead of holding a fixed column count. The create-agent popover had a scroll container around its body and another around its model list, showing two stacked scrollbars; it now scrolls only the model list, matching `RoutingPicker`.

## Verification

- `pnpm typecheck` clean, `pnpm test` 2871 passing across 358 files
- `pnpm knip` unchanged at its 60-entry baseline, so no new dead code
- New tests: concurrent advance spawns one agent, multi-step ordering (previously untested, every existing case used a single-step template), summarizer-blocked-then-released, step-done id ownership, PR status line, glyph linkage, scripts save/delete/discard