### PR TITLE
fix(desktop): give agents the github token goodboy already holds

### DIFF
--- a/apps/desktop/src-tauri/src/github.rs
+++ b/apps/desktop/src-tauri/src/github.rs
@@ -134,6 +134,10 @@ fn read_token(workspace_id: Option<&str>) -> Option<String> {
     secrets::read(TOKEN_KEY).ok().flatten()
 }
 
+pub(crate) fn token_for_workspace(workspace_id: Option<&str>) -> Option<String> {
+    read_token(workspace_id).filter(|t| !t.is_empty())
+}
+
 fn status_blocking(workspace_id: Option<String>) -> GhStatus {
     let ws = workspace_id.as_deref();
     if !gh_available() {

--- a/apps/desktop/src-tauri/src/parallel_groups.rs
+++ b/apps/desktop/src-tauri/src/parallel_groups.rs
@@ -328,6 +328,8 @@ pub struct ParallelSpawnArgs {
     pub api_key_env: Option<String>,
     #[serde(default)]
     pub credential_id: Option<String>,
+    #[serde(default)]
+    pub workspace_id: Option<String>,
 }
 
 /// Spawn N child processes concurrently (one per `ParallelRunSpec`).
@@ -369,6 +371,7 @@ pub fn parallel_agent_spawn(
                 effort: None,
                 api_key_env: args.api_key_env.as_deref(),
                 credential_id: args.credential_id.as_deref(),
+                workspace_id: args.workspace_id.as_deref(),
             },
         ) {
             Ok(run_id) => run_ids.push(run_id),

--- a/apps/desktop/src-tauri/src/turn.rs
+++ b/apps/desktop/src-tauri/src/turn.rs
@@ -68,6 +68,8 @@ pub struct SpawnArgs {
     #[serde(default)]
     pub effort: Option<String>,
     #[serde(default)]
+    pub workspace_id: Option<String>,
+    #[serde(default)]
     pub api_key_env: Option<String>,
     #[serde(default)]
     pub credential_id: Option<String>,
@@ -263,6 +265,7 @@ pub struct SpawnOneArgs<'a> {
     pub effort: Option<&'a str>,
     pub api_key_env: Option<&'a str>,
     pub credential_id: Option<&'a str>,
+    pub workspace_id: Option<&'a str>,
 }
 
 /// Spawns one child process, registers it in the registry, and starts the
@@ -283,6 +286,11 @@ pub(crate) fn spawn_one(
         if let Ok(Some(secret)) = crate::secrets::read(&format!("provider_credential.{cred_id}")) {
             command.env(env_name, secret);
         }
+    }
+
+    if let Some(token) = crate::github::token_for_workspace(args.workspace_id) {
+        command.env("GH_TOKEN", &token);
+        command.env("GITHUB_TOKEN", &token);
     }
 
     let cli_args = build_provider_cli_args(args.binary, &args);
@@ -369,6 +377,7 @@ pub fn turn_spawn(
             effort: args.effort.as_deref(),
             api_key_env: args.api_key_env.as_deref(),
             credential_id: args.credential_id.as_deref(),
+            workspace_id: args.workspace_id.as_deref(),
         },
     )
 }

--- a/apps/desktop/src-tauri/src/turn.rs
+++ b/apps/desktop/src-tauri/src/turn.rs
@@ -519,6 +519,7 @@ mod tests {
             effort: None,
             api_key_env: None,
             credential_id: None,
+            workspace_id: None,
         };
         assert_eq!(args.run_id, "run-1");
         assert_eq!(args.binary, "echo");
@@ -544,6 +545,7 @@ mod tests {
             effort: None,
             api_key_env: None,
             credential_id: None,
+            workspace_id: None,
         }
     }
 
@@ -762,6 +764,7 @@ mod tests {
             effort: None,
             api_key_env: None,
             credential_id: None,
+            workspace_id: None,
         };
         let cli = build_provider_cli_args("codex", &args);
         let out = std::process::Command::new("codex")

--- a/apps/desktop/src/features/chat/turn.ts
+++ b/apps/desktop/src/features/chat/turn.ts
@@ -92,6 +92,7 @@ type SpawnArgs = {
   readonly resumeSessionId?: string;
   readonly systemPrompt?: string;
   readonly effort?: string;
+  readonly workspaceId?: string;
   readonly apiKeyEnv?: string;
   readonly credentialId?: string;
 };
@@ -264,6 +265,7 @@ export type ParallelSpawnArgs = {
   readonly permissionMode?: ClaudePermissionMode;
   readonly allowedTools?: ReadonlyArray<string>;
   readonly disallowedTools?: ReadonlyArray<string>;
+  readonly workspaceId?: string;
   readonly apiKeyEnv?: string;
   readonly credentialId?: string;
 };

--- a/apps/desktop/src/store/slices/turn/sendTurn.ts
+++ b/apps/desktop/src/store/slices/turn/sendTurn.ts
@@ -749,6 +749,7 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
         workingDir,
         prompt: resolvedPrompt,
         binary: providerInfo?.binary,
+        workspaceId: session.workspaceId,
         ...(resumeSessionId !== undefined && { resumeSessionId }),
         systemPrompt: fullSystemPrompt,
         ...(effortFlag !== undefined && { effort: effortFlag }),


### PR DESCRIPTION
## Symptom

An agent refuses to open a PR with "gh is not authenticated (`gh auth status` → not logged in). Run `gh auth login`", while Settings shows **connected as `<user>`, mode: pat**.

## Both are telling the truth

Reproduced on a machine with no persisted gh login at all (no `~/.config/gh`, no `~/Library/Application Support/gh`):

```bash
env -u GITHUB_TOKEN -u GH_TOKEN gh auth status
# You are not logged into any GitHub hosts.
```

- The settings pane reports on Goodboy's **own** gh calls, and those work: the PAT is read from the keychain (`github.pat`, or `github.pat.<workspaceId>`) and injected explicitly in `run_gh` ([github.rs:74-75](apps/desktop/src-tauri/src/github.rs#L74-L75)) and `run_git_push` ([github.rs:102-103](apps/desktop/src-tauri/src/github.rs#L102-L103)).
- Agent turns get none of it. `spawn_one` builds the child with `path_env::command()`, which sets **only** `PATH`, and the sole env var it injects is the provider API key. No `GH_TOKEN`, no `GITHUB_TOKEN`.
- There is nothing to inherit either: launched from Finder the app has no shell-profile environment.

So gh inside an agent is correct to say it has no credentials, and the "connected" badge is correct about a different process. Nothing about the user's setup is broken.

## Fix

Resolve the same workspace-scoped token the github commands already use and set `GH_TOKEN` + `GITHUB_TOKEN` on every spawned turn.

- `github.rs`: `token_for_workspace(workspace_id)`, wrapping the existing `read_token` (per-workspace override, global PAT fallback, empty filtered out).
- `turn.rs`: `SpawnOneArgs.workspace_id`, injection in `spawn_one` next to the API-key block; `SpawnArgs.workspace_id` is `#[serde(default)]` so older payloads still deserialize.
- `parallel_groups.rs`: same field threaded through `ParallelSpawnArgs`.
- TS: `workspaceId` on the spawn arg types, passed from `sendTurn`.

Deliberately **not** switching the spawn to `command_with_login_env()`. That would also fix the symptom, by handing every agent the user's entire shell profile.

## Verify

```bash
cargo check --locked && pnpm typecheck && pnpm test
```

Rust compiles clean (only pre-existing warnings), `apps/desktop` 2875 passed, unchanged from baseline.

Manually: with a workspace connected in Settings → GitHub, ask an agent to run `gh auth status`. It should report the same account the settings pane shows.

Not covered by an automated test: the injection reads the OS keychain, which the Rust test suite has no fixture for. Worth adding a seam later so `spawn_one` can be tested against a fake secret store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)