### PR TITLE
fix(desktop): number agents by when they were created

### DIFF
--- a/apps/desktop/src/features/session/components/ResolverAgentsLane/ResolverCard.tsx
+++ b/apps/desktop/src/features/session/components/ResolverAgentsLane/ResolverCard.tsx
@@ -8,6 +8,7 @@ import { AgentCard } from '../AgentCard';
 import { AgentCardAction } from '../AgentCard/AgentCardAction';
 import { AgentCardActions } from '../AgentCard/AgentCardActions';
 import { AgentMetricsBlock, type AgentAggregate } from '../AgentMetricsBlock';
+import { AgentLastUpdate } from '../../../../shared/components/AgentLastUpdate';
 import { AgentMetricsInline } from '../AgentMetricsInline';
 import { ResolverStateBadge, resolverBadgeState } from '../ResolverStateBadge';
 import { resolverOrigin } from '../../resolver-origin';
@@ -137,6 +138,7 @@ export const ResolverCard = ({
             turnsLoading={turnsLoading}
           />
           <AgentMetricsBlock run={agent} aggregate={aggregate} />
+          <AgentLastUpdate agent={agent} />
           <ContextWindowBar usage={contextUsage} />
         </div>
         <ResolverCardSnippet threadComment={threadComment} diffComment={diffComment} />

--- a/apps/desktop/src/features/session/components/StandaloneAgentsLane/index.tsx
+++ b/apps/desktop/src/features/session/components/StandaloneAgentsLane/index.tsx
@@ -45,11 +45,10 @@ export const StandaloneAgentsLane = ({
 
   const list = (
     <ul className="flex flex-col gap-1">
-      {agents.map((run, index) => (
+      {agents.map((run) => (
         <AdHocRow
           key={run.id}
           run={run}
-          index={index}
           firstUserTextByAgentId={lane.firstUserTextByAgentId}
           agentKindOverride={lane.agentKindOverride}
           childrenByParentId={lane.childrenByParentId}

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AdHocRow.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AdHocRow.tsx
@@ -9,7 +9,6 @@ import { ScoutSubtree } from './ScoutSubtree';
 
 type Props = {
   readonly run: Agent;
-  readonly index: number;
   readonly firstUserTextByAgentId: ReadonlyMap<string, string>;
   readonly agentKindOverride: Readonly<Record<string, AgentKind>>;
   readonly childrenByParentId: ReadonlyMap<string, Agent[]>;
@@ -35,7 +34,6 @@ type Props = {
 
 export const AdHocRow = ({
   run,
-  index,
   firstUserTextByAgentId,
   agentKindOverride,
   childrenByParentId,
@@ -69,7 +67,6 @@ export const AdHocRow = ({
       <AgentRow
         run={run}
         kind={kind}
-        index={index}
         telemetry={latestTelemetryByAgentId.get(run.id) ?? null}
         aggregate={aggregatesByAgentId.get(run.id) ?? null}
         contextUsage={providerUsageByAgentId.get(run.id) ?? EMPTY_ARRAY}

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentRow.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentRow.test.tsx
@@ -43,7 +43,6 @@ const renderRow = (isSelected: boolean, runOverride: Partial<Agent> = {}) =>
       <AgentRow
         run={{ ...run, ...runOverride }}
         kind="scout"
-        index={0}
         telemetry={telemetry}
         aggregate={{ inputTokens: 100, outputTokens: 20, estimatedCostUsd: 1.5, turns: 3 }}
         contextUsage={[
@@ -159,5 +158,20 @@ describe('AgentRow', () => {
     expect(remove).not.toHaveBeenCalled();
     fireEvent.click(screen.getByRole('button', { name: 'confirm delete agent' }));
     expect(remove).toHaveBeenCalledOnce();
+  });
+});
+
+describe('AgentRow numbering', () => {
+  afterEach(cleanup);
+
+  it('numbers the row by creation order, not by its position in the list', () => {
+    renderRow(false, { ordinal: 14 });
+    expect(screen.getByText('15.')).toBeDefined();
+  });
+
+  it('keeps the badge and the row tooltip on the same number', () => {
+    renderRow(false, { ordinal: 3 });
+    expect(screen.getByText('4.')).toBeDefined();
+    expect(screen.getAllByTitle(/agent 4/).length).toBeGreaterThan(0);
   });
 });

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentRow.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentRow.tsx
@@ -14,6 +14,7 @@ import {
   AgentMetricsBlock,
   type AgentAggregate,
 } from '../../../../../features/session/components/AgentMetricsBlock';
+import { AgentLastUpdate } from '../../../../../shared/components/AgentLastUpdate';
 import { AgentMetricsInline } from '../../../../../features/session/components/AgentMetricsInline';
 import { ContextWindowBar, type ProviderContextUsage } from './ContextWindowBar';
 import { AgentStatusBadge } from './AgentStatusBadge';
@@ -24,7 +25,6 @@ const COMPACT_ACTIONS_CLASS = 'w-20';
 type Props = {
   readonly run: Agent;
   readonly kind: AgentKind;
-  readonly index: number;
   readonly telemetry: TelemetryRecord | null;
   readonly aggregate: AgentAggregate | null;
   readonly contextUsage: ReadonlyArray<ProviderContextUsage>;
@@ -47,7 +47,6 @@ type Props = {
 export const AgentRow = ({
   run,
   kind,
-  index,
   telemetry,
   aggregate,
   contextUsage,
@@ -99,7 +98,7 @@ export const AgentRow = ({
             aria-hidden
             className="w-4 shrink-0 text-right text-2xs tabular-nums text-muted-foreground/60"
           >
-            {index + 1}.
+            {run.ordinal + 1}.
           </span>
           <AgentKindChip
             kind={kind}
@@ -162,6 +161,7 @@ export const AgentRow = ({
           turnsLoading={turnsLoading}
         />
         <AgentMetricsBlock run={run} aggregate={aggregate} />
+        <AgentLastUpdate agent={run} />
         <ContextWindowBar usage={contextUsage} />
       </div>
     </AgentCard>

--- a/apps/desktop/src/shared/components/AgentLastUpdate/index.test.tsx
+++ b/apps/desktop/src/shared/components/AgentLastUpdate/index.test.tsx
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { Agent, AgentId, IsoDateTime, SessionId } from '@goodboy/types';
+import { AgentLastUpdate } from './index';
+
+const agent = (stamps: Partial<Agent>): Agent =>
+  ({
+    id: 'a1' as AgentId,
+    sessionId: 's1' as SessionId,
+    ordinal: 0,
+    name: 'agent 1',
+    status: 'pending',
+    ...stamps,
+  }) as Agent;
+
+describe('AgentLastUpdate', () => {
+  it('says the agent has not started when it carries no timestamp', () => {
+    render(<AgentLastUpdate agent={agent({})} />);
+    expect(screen.getByText('not started')).toBeDefined();
+  });
+
+  it('shows how long ago the agent last moved', () => {
+    const tenMinutesAgo = new Date(Date.now() - (10 * 60_000 + 5_000)).toISOString() as IsoDateTime;
+    render(<AgentLastUpdate agent={agent({ lastFinishedAt: tenMinutesAgo })} />);
+    expect(screen.getByText('updated 10m ago')).toBeDefined();
+  });
+});

--- a/apps/desktop/src/shared/components/AgentLastUpdate/index.tsx
+++ b/apps/desktop/src/shared/components/AgentLastUpdate/index.tsx
@@ -1,0 +1,21 @@
+import type { Agent } from '@goodboy/types';
+import { useNow } from '../../hooks/useNow';
+import { agentLastUpdate } from '../../utils/agentLastUpdate';
+import { formatRelativeAge } from '../../utils/relativeDate';
+
+type Props = {
+  readonly agent: Agent;
+};
+
+export const AgentLastUpdate = ({ agent }: Props) => {
+  const lastUpdate = agentLastUpdate({ agent });
+  const nowMs = useNow(60_000, lastUpdate !== null);
+  if (lastUpdate === null) {
+    return <span className="text-2xs text-muted-foreground/60">not started</span>;
+  }
+  return (
+    <span className="text-2xs tabular-nums text-muted-foreground/60">
+      {`updated ${formatRelativeAge({ fromIso: lastUpdate, nowMs })}`}
+    </span>
+  );
+};

--- a/apps/desktop/src/shared/utils/agentLastUpdate.test.ts
+++ b/apps/desktop/src/shared/utils/agentLastUpdate.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import type { Agent, AgentId, IsoDateTime, SessionId } from '@goodboy/types';
+import { agentLastUpdate } from './agentLastUpdate';
+
+const agent = (stamps: Partial<Agent>): Agent =>
+  ({
+    id: 'a1' as AgentId,
+    sessionId: 's1' as SessionId,
+    ordinal: 0,
+    name: 'agent 1',
+    status: 'pending',
+    ...stamps,
+  }) as Agent;
+
+describe('agentLastUpdate', () => {
+  it('reports nothing for an agent that never ran', () => {
+    expect(agentLastUpdate({ agent: agent({}) })).toBeNull();
+  });
+
+  it('picks the latest stamp regardless of which field carries it', () => {
+    const result = agentLastUpdate({
+      agent: agent({
+        startedAt: '2026-07-28T10:00:00.000Z' as IsoDateTime,
+        lastFinishedAt: '2026-07-28T10:05:00.000Z' as IsoDateTime,
+        doneAt: '2026-07-28T10:09:00.000Z' as IsoDateTime,
+      }),
+    });
+    expect(result).toBe('2026-07-28T10:09:00.000Z');
+  });
+
+  it('keeps the latest stamp when a later field holds an earlier time', () => {
+    const result = agentLastUpdate({
+      agent: agent({
+        lastFinishedAt: '2026-07-28T10:05:00.000Z' as IsoDateTime,
+        doneAt: '2026-07-28T09:00:00.000Z' as IsoDateTime,
+      }),
+    });
+    expect(result).toBe('2026-07-28T10:05:00.000Z');
+  });
+});

--- a/apps/desktop/src/shared/utils/agentLastUpdate.ts
+++ b/apps/desktop/src/shared/utils/agentLastUpdate.ts
@@ -1,0 +1,17 @@
+import type { Agent } from '@goodboy/types';
+
+type AgentLastUpdateParams = {
+  readonly agent: Agent;
+};
+
+export const agentLastUpdate = ({ agent }: AgentLastUpdateParams): string | null => {
+  const stamps = [agent.startedAt, agent.completedAt, agent.lastFinishedAt, agent.doneAt].filter(
+    (stamp): stamp is NonNullable<typeof stamp> => stamp != null && stamp !== '',
+  );
+  if (stamps.length === 0) {
+    return null;
+  }
+  return stamps.reduce((latest, stamp) =>
+    Date.parse(stamp) > Date.parse(latest) ? stamp : latest,
+  );
+};

--- a/apps/desktop/src/shared/utils/relativeDate.ts
+++ b/apps/desktop/src/shared/utils/relativeDate.ts
@@ -22,3 +22,21 @@ export const formatRelativeDuration = (fromIso: string, toIso?: string): string 
   const d = Math.floor(h / 24);
   return `${d}d`;
 };
+
+type FormatRelativeAgeParams = {
+  readonly fromIso: string;
+  readonly nowMs?: number;
+};
+
+export const formatRelativeAge = ({ fromIso, nowMs }: FormatRelativeAgeParams): string => {
+  const fromMs = Date.parse(fromIso);
+  if (Number.isNaN(fromMs)) {
+    return '';
+  }
+  const toMs = nowMs ?? Date.now();
+  const seconds = Math.max(0, Math.floor((toMs - fromMs) / 1000));
+  if (seconds < 60) {
+    return 'just now';
+  }
+  return `${formatRelativeDuration(fromIso, new Date(toMs).toISOString())} ago`;
+};

--- a/apps/desktop/src/store/slices/agents/spawnAgent.ts
+++ b/apps/desktop/src/store/slices/agents/spawnAgent.ts
@@ -84,12 +84,11 @@ export const spawnAgent = (set: SetFn, get: GetFn) => {
         stepPromptPrefix = step.promptPrefix;
       }
     }
-    if (!resolvedName) {
-      const existing = state.sessionPhaseRuns[sessionId] ?? [];
-      resolvedName = `agent ${existing.length + 1}`;
-    }
     const currentRuns = state.sessionPhaseRuns[sessionId] ?? [];
     const nextOrdinal = currentRuns.reduce((max, r) => Math.max(max, r.ordinal), -1) + 1;
+    if (!resolvedName) {
+      resolvedName = `agent ${nextOrdinal + 1}`;
+    }
     const workspaceVerbositySeed =
       state.workspaceOverrides[session.workspaceId]?.defaultVerbosity ?? undefined;
     const resolvedKind = args.kindOverride ?? inferAgentKindFromName(resolvedName);


### PR DESCRIPTION
## What

Two things, both about knowing which agent you are looking at.

### The badge lied

The agents lens renders newest-first, and the badge was `{index + 1}` over the already-reversed array. So the 15th agent you created read `1.`, and there was no way to tell which one you made last.

Worse, the same row already had the real number in its tooltip (`agent ${run.ordinal + 1}`), so badge and tooltip contradicted each other for any session with 2+ agents. Nothing tested the relationship, so CI was fine with it.

The default name was a third source again: `agent ${list.length + 1}`, which drifts from the ordinal after any delete.

All three now read `agent.ordinal`, which is persisted at spawn and never rewritten. `index` was the badge's only consumer, so the prop is gone from `AgentRow`, `AdHocRow` and the lane.

Note: agent delete is a hard delete, so deleting the newest agent frees its ordinal and the next spawn reuses it. That is the same semantics as VS Code terminals, and it does not seem worth a schema change; if agent numbers ever become cross-references in transcripts, revisit with a monotonic counter.

### No sense of recency

A row showed how long the agent *worked* (`AgentDuration`) but never when it last moved, so a list of 15 agents gave no way to tell the one that stopped an hour ago from the one that just finished.

New `AgentLastUpdate`, on both the agents lens rows and the resolver cards, backed by the **max** of `startedAt`, `completedAt`, `lastFinishedAt`, `doneAt`. A coalesce chain would be wrong: `doneAt` is a user acknowledgement and can land after `lastFinishedAt`, and the stamping order across terminal transitions is not guaranteed. An agent with no timestamp at all reads `not started`, never "just now".

It ticks on the existing shared `useNow` singleton at 60s, so the text stays true while a lens is open. Most of the app's other relative times do not do this: they only recompute when something unrelated re-renders. Fixing that everywhere means collapsing the nine independent "N ago" formatters this repo has accumulated, which is out of scope here.

## Changes

- `shared/utils/relativeDate.ts`: `formatRelativeAge`, next to the existing duration formatter rather than as a tenth copy.
- `shared/utils/agentLastUpdate.ts` + test: the max-of-stamps resolver.
- `shared/components/AgentLastUpdate/` + test: the rendered line, `not started` fallback, 60s tick.
- `AgentRow`: badge from `run.ordinal`, `index` prop removed, last-update line added.
- `ResolverCard`: last-update line added.
- `spawnAgent`: default name from `nextOrdinal`.
- Regression tests: an agent at ordinal 14 renders `15.`, and badge and tooltip agree.

## Verify

```bash
pnpm typecheck && pnpm test
```

`apps/desktop` 2882 passed, 360 files, up from 2875/358 on the baseline. Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)