### PR TITLE
fix(desktop): tell the user why the provider refused the turn

### DIFF
--- a/apps/desktop/src/features/chat/classifyProviderError.test.ts
+++ b/apps/desktop/src/features/chat/classifyProviderError.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { classifyProviderError } from './classifyProviderError';
+
+describe('classifyProviderError', () => {
+  it.each([
+    [
+      'ActionRequiredError: Max Mode Required  The model "gpt-5.5-high" requires Max Mode to be enabled.',
+      'gpt-5.5-high',
+      'enable_max_mode',
+    ],
+    [
+      'ActionRequiredError: Max Mode Required  The model "claude-opus-4-7-thinking-high" requires Max Mode to be enabled.',
+      'claude-opus-4-7-thinking-high',
+      'enable_max_mode',
+    ],
+    [
+      '{"type":"error","status":400,"error":{"type":"invalid_request_error","message":"The \'gpt-5.6\' model is not supported when using Codex with a ChatGPT account."}}',
+      'gpt-5.6',
+      'choose_supported_model',
+    ],
+  ])('classifies model availability failures', (message, model, action) => {
+    expect(classifyProviderError({ message })).toEqual({
+      kind: 'model_not_available',
+      model,
+      action,
+    });
+  });
+
+  it('distinguishes authentication and other failures', () => {
+    expect(classifyProviderError({ message: 'request failed with status 401' })).toEqual({
+      kind: 'authentication',
+    });
+    expect(classifyProviderError({ message: 'connection reset by peer' })).toEqual({
+      kind: 'other',
+    });
+  });
+});

--- a/apps/desktop/src/features/chat/classifyProviderError.ts
+++ b/apps/desktop/src/features/chat/classifyProviderError.ts
@@ -1,0 +1,64 @@
+type ModelUnavailableAction = 'enable_max_mode' | 'choose_supported_model';
+
+type ModelUnavailablePattern = {
+  readonly pattern: RegExp;
+  readonly action: ModelUnavailableAction;
+};
+
+type ProviderErrorClassification =
+  | { readonly kind: 'authentication' }
+  | {
+      readonly kind: 'model_not_available';
+      readonly model: string;
+      readonly action: ModelUnavailableAction;
+    }
+  | { readonly kind: 'other' };
+
+type Params = {
+  readonly message: string;
+};
+
+const AUTH_ERROR_PATTERNS = [
+  /not authenticated/i,
+  /not logged in/i,
+  /auth required/i,
+  /authentication required/i,
+  /please log in/i,
+  /please sign in/i,
+  /unauthenticated/i,
+  /\b401\b/,
+  /unauthorized/i,
+  /login required/i,
+  /not signed in/i,
+];
+
+const MODEL_NOT_AVAILABLE_PATTERNS = [
+  {
+    pattern: /The model "([^"]+)" requires Max Mode to be enabled/i,
+    action: 'enable_max_mode',
+  },
+  {
+    pattern: /The '([^']+)' model is not supported when using Codex with a ChatGPT account/i,
+    action: 'choose_supported_model',
+  },
+] satisfies ReadonlyArray<ModelUnavailablePattern>;
+
+export const classifyProviderError = ({ message }: Params): ProviderErrorClassification => {
+  if (AUTH_ERROR_PATTERNS.some((pattern) => pattern.test(message))) {
+    return { kind: 'authentication' };
+  }
+
+  for (const entry of MODEL_NOT_AVAILABLE_PATTERNS) {
+    const match = entry.pattern.exec(message);
+    const model = match?.[1];
+    if (model != null && model !== '') {
+      return {
+        kind: 'model_not_available',
+        model,
+        action: entry.action,
+      };
+    }
+  }
+
+  return { kind: 'other' };
+};

--- a/apps/desktop/src/features/chat/turn.test.ts
+++ b/apps/desktop/src/features/chat/turn.test.ts
@@ -3,10 +3,17 @@ import type { ProviderRunId } from '@goodboy/types';
 
 type TurnEnvelope = {
   readonly runId: string;
-  readonly type: 'end';
-  readonly exit_code: number | null;
-  readonly stderr: string;
-};
+} & (
+  | {
+      readonly type: 'line';
+      readonly line: string;
+    }
+  | {
+      readonly type: 'end';
+      readonly exit_code: number | null;
+      readonly stderr: string;
+    }
+);
 
 const { capturedListeners, invokeMock, unlistenMock } = vi.hoisted(() => ({
   capturedListeners: new Array<(payload: TurnEnvelope) => void>(),
@@ -25,7 +32,7 @@ vi.mock('@tauri-apps/api/event', () => ({
   }),
 }));
 
-import { runTurn, isAuthErrorMessage } from './turn';
+import { runTurn } from './turn';
 
 afterEach(() => {
   capturedListeners.length = 0;
@@ -50,24 +57,53 @@ describe('runTurn', () => {
       prompt: 'hello',
     })[Symbol.asyncIterator]();
 
-    await expect(iterator.next()).rejects.toThrow('provider emitted no events');
+    await expect(iterator.next()).rejects.toThrow(
+      'provider exited without a response. check that the CLI is configured correctly.',
+    );
     expect(unlistenMock).toHaveBeenCalledOnce();
   });
-});
 
-describe('isAuthErrorMessage', () => {
-  it('matches the real claude CLI expired-OAuth-token 401 message', () => {
+  it('surfaces stderr when a provider exits without parseable events', async () => {
+    const runId = 'max-mode-provider-run' as ProviderRunId;
     const message =
-      'Failed to authenticate. API Error: 401 {"type":"error","error":{"type":"authentication_error","message":"OAuth access token has expired. Re-authenticate to continue."},"request_id":null}';
+      'ActionRequiredError: Max Mode Required  The model "gpt-5.5-high" requires Max Mode to be enabled.';
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === 'turn_spawn') {
+        capturedListeners[0]?.({ runId, type: 'end', exit_code: 1, stderr: message });
+      }
+      return runId;
+    });
 
-    expect(isAuthErrorMessage(message)).toBe(true);
+    const iterator = runTurn({
+      runId,
+      provider: 'cursor',
+      model: 'gpt-5.5-high',
+      workingDir: '/tmp/worktree',
+      prompt: 'hello',
+    })[Symbol.asyncIterator]();
+
+    await expect(iterator.next()).rejects.toThrow(message);
   });
 
-  it('does not match an unrelated message that merely contains the digits 401', () => {
-    expect(isAuthErrorMessage('processed 4010 records before the connection dropped')).toBe(false);
-  });
+  it('surfaces unparseable stdout when a provider exits', async () => {
+    const runId = 'stdout-error-provider-run' as ProviderRunId;
+    const message = 'provider rejected this request';
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === 'turn_spawn') {
+        capturedListeners[0]?.({ runId, type: 'line', line: message });
+        capturedListeners[0]?.({ runId, type: 'end', exit_code: 1, stderr: '' });
+      }
+      return runId;
+    });
 
-  it('still matches a plain "401" status embedded in other provider error text', () => {
-    expect(isAuthErrorMessage('request failed with status 401')).toBe(true);
+    const iterator = runTurn({
+      runId,
+      provider: 'cursor',
+      model: 'gpt-5.5-high',
+      workingDir: '/tmp/worktree',
+      prompt: 'hello',
+    })[Symbol.asyncIterator]();
+
+    await expect(iterator.next()).rejects.toThrow(message);
   });
 });

--- a/apps/desktop/src/features/chat/turn.ts
+++ b/apps/desktop/src/features/chat/turn.ts
@@ -9,6 +9,7 @@ import {
   type ParseContext,
 } from '@goodboy/core';
 import type { IsoDateTime, ProviderId, ProviderRunId, TurnEvent } from '@goodboy/types';
+import { classifyProviderError } from './classifyProviderError';
 
 function parseForProvider(
   provider: ProviderId,
@@ -55,24 +56,6 @@ export const decodeAuthRequiredMessage = (message: string): AuthRequiredPayload 
   } catch {
     return null;
   }
-};
-
-const AUTH_ERROR_PATTERNS = [
-  /not authenticated/i,
-  /not logged in/i,
-  /auth required/i,
-  /authentication required/i,
-  /please log in/i,
-  /please sign in/i,
-  /unauthenticated/i,
-  /\b401\b/,
-  /unauthorized/i,
-  /login required/i,
-  /not signed in/i,
-];
-
-export const isAuthErrorMessage = (text: string): boolean => {
-  return AUTH_ERROR_PATTERNS.some((p) => p.test(text));
 };
 
 const EVENT_NAME = 'turn_event';
@@ -136,7 +119,8 @@ export async function* runTurn(
     }
   };
 
-  let receivedAnyLine = false;
+  let receivedAnyEvent = false;
+  const unparsedOutput: string[] = [];
 
   const unlisten: UnlistenFn = await listen<RawTurnEnvelope>(EVENT_NAME, (event) => {
     if (event.payload.runId !== args.runId) {
@@ -144,23 +128,38 @@ export async function* runTurn(
     }
 
     switch (event.payload.type) {
-      case 'line':
-        receivedAnyLine = true;
-        for (const ev of parseForProvider(args.provider, event.payload.line, ctx)) {
+      case 'line': {
+        const parsedEvents = parseForProvider(args.provider, event.payload.line, ctx);
+        if (parsedEvents.length > 0) {
+          receivedAnyEvent = true;
+        }
+        if (parsedEvents.length === 0 && event.payload.line.trim() !== '') {
+          unparsedOutput.push(event.payload.line.trim());
+        }
+        for (const ev of parsedEvents) {
           queue.push(ev);
         }
         flush();
         break;
+      }
       case 'end': {
-        const exitCode = event.payload.exit_code;
-        const stderr = event.payload.stderr;
-        if (!receivedAnyLine) {
-          const tail = stderr.trim().split('\n').slice(-5).join('\n');
-          const detail = tail.length > 0 ? `: ${tail}` : '';
+        if (!receivedAnyEvent) {
+          const stderrMessage = event.payload.stderr.trim();
+          const stdoutMessage = unparsedOutput.join('\n');
+          const hasFailedExit = event.payload.exit_code !== null && event.payload.exit_code !== 0;
+          const stdoutClassification = classifyProviderError({ message: stdoutMessage });
+          const providerMessage = [
+            hasFailedExit || stdoutClassification.kind !== 'other' ? stdoutMessage : '',
+            stderrMessage,
+          ]
+            .filter((value) => value !== '')
+            .join('\n');
           error =
-            exitCode !== null && exitCode !== 0
-              ? new Error(`provider exited with code ${exitCode}${detail}`)
-              : new Error(`provider emitted no events${detail}`);
+            providerMessage !== ''
+              ? new Error(providerMessage)
+              : new Error(
+                  'provider exited without a response. check that the CLI is configured correctly.',
+                );
         }
         ended = true;
         flush();

--- a/apps/desktop/src/store/slices/turn/resolveErrorTurnMessage.test.ts
+++ b/apps/desktop/src/store/slices/turn/resolveErrorTurnMessage.test.ts
@@ -35,4 +35,26 @@ describe('resolveErrorTurnMessage', () => {
 
     expect(resolved).toBe(message);
   });
+
+  it('turns a Max Mode failure into an actionable model message', () => {
+    const message =
+      'ActionRequiredError: Max Mode Required  The model "gpt-5.5-high" requires Max Mode to be enabled.';
+
+    const resolved = resolveErrorTurnMessage({ message, providerId: 'cursor', identity: null });
+
+    expect(resolved).toBe(
+      'The model "gpt-5.5-high" requires Max Mode. Enable Max Mode or choose another model.',
+    );
+  });
+
+  it('tells a Codex user to choose a model supported by their account', () => {
+    const message =
+      '{"type":"error","status":400,"error":{"type":"invalid_request_error","message":"The \'gpt-5.6\' model is not supported when using Codex with a ChatGPT account."}}';
+
+    const resolved = resolveErrorTurnMessage({ message, providerId: 'codex', identity: null });
+
+    expect(resolved).toBe(
+      'The model "gpt-5.6" is not available with this Codex account. Choose a model supported by your account.',
+    );
+  });
 });

--- a/apps/desktop/src/store/slices/turn/resolveErrorTurnMessage.ts
+++ b/apps/desktop/src/store/slices/turn/resolveErrorTurnMessage.ts
@@ -1,5 +1,6 @@
 import type { ProviderId } from '@goodboy/types';
-import { encodeAuthRequiredMessage, isAuthErrorMessage } from '../../../features/chat/turn';
+import { classifyProviderError } from '../../../features/chat/classifyProviderError';
+import { encodeAuthRequiredMessage } from '../../../features/chat/turn';
 
 type Params = {
   message: string;
@@ -8,7 +9,20 @@ type Params = {
 };
 
 export const resolveErrorTurnMessage = ({ message, providerId, identity }: Params): string => {
-  return isAuthErrorMessage(message)
-    ? encodeAuthRequiredMessage({ providerId, identity })
-    : message;
+  const classification = classifyProviderError({ message });
+
+  switch (classification.kind) {
+    case 'authentication':
+      return encodeAuthRequiredMessage({ providerId, identity });
+    case 'model_not_available':
+      return classification.action === 'enable_max_mode'
+        ? `The model "${classification.model}" requires Max Mode. Enable Max Mode or choose another model.`
+        : `The model "${classification.model}" is not available with this Codex account. Choose a model supported by your account.`;
+    case 'other':
+      return message;
+    default: {
+      const exhaustive: never = classification;
+      return exhaustive;
+    }
+  }
 };

--- a/apps/desktop/src/store/slices/turn/sendTurn.ts
+++ b/apps/desktop/src/store/slices/turn/sendTurn.ts
@@ -680,6 +680,7 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
     }
 
     let assistantText = '';
+    let receivedProviderError = false;
     let lastError: unknown = null;
     let turnWasCancelled = false;
     let shouldAutoAdvanceWorkflow = false;
@@ -767,6 +768,9 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
               }
             : rawEvent;
         get().appendTurnEvent(activeAgentId, sessionId, event);
+        if (event.kind === 'error') {
+          receivedProviderError = true;
+        }
         if (event.kind === 'assistant_text') {
           assistantText += event.delta;
         }
@@ -810,7 +814,7 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
         const idleState: TurnState = { kind: 'idle', lastActivityAt: now() };
         const derived = applyAgentTurnState(set, sessionId, activeAgentId, idleState, now());
         await updateSessionState(tauriDatabase, sessionId, derived, now());
-        if (assistantText.length === 0) {
+        if (assistantText.length === 0 && !receivedProviderError) {
           get().appendTurnEvent(activeAgentId, sessionId, {
             kind: 'error',
             runId,

--- a/apps/desktop/src/store/store.idle-on-empty-stream.test.ts
+++ b/apps/desktop/src/store/store.idle-on-empty-stream.test.ts
@@ -193,6 +193,9 @@ async function* throwingStream(runId: ProviderRunId): AsyncIterable<TurnEvent> {
 const OAUTH_EXPIRED_MESSAGE =
   'Failed to authenticate. API Error: 401 {"type":"error","error":{"type":"authentication_error","message":"OAuth access token has expired. Re-authenticate to continue."},"request_id":null}';
 
+const MAX_MODE_MESSAGE =
+  'ActionRequiredError: Max Mode Required  The model "gpt-5.5-high" requires Max Mode to be enabled.';
+
 async function* authErrorEventStream(runId: ProviderRunId): AsyncIterable<TurnEvent> {
   yield {
     kind: 'error',
@@ -211,6 +214,16 @@ async function* throwingAuthErrorStream(runId: ProviderRunId): AsyncIterable<Tur
   };
   throw new Error(OAUTH_EXPIRED_MESSAGE);
 }
+
+type ErrorStreamParams = {
+  readonly message: string;
+};
+
+const throwingErrorStream = async function* ({
+  message,
+}: ErrorStreamParams): AsyncIterable<TurnEvent> {
+  throw new Error(message);
+};
 
 async function* nonAuthErrorEventStream(runId: ProviderRunId): AsyncIterable<TurnEvent> {
   yield {
@@ -393,6 +406,7 @@ describe('sendTurn, terminal state guarantees', () => {
     const transcript = useAppStore.getState().transcripts[AGENT_ID] ?? [];
     const errorEvent = transcript.find((e) => e.kind === 'error');
     const message = errorEvent && 'message' in errorEvent ? errorEvent.message : '';
+    expect(message).toMatch(/^__auth_required__:/);
     expect(decodeAuthRequiredMessage(message)).toEqual({
       providerId: 'anthropic',
       identity: 'test',
@@ -418,6 +432,24 @@ describe('sendTurn, terminal state guarantees', () => {
       providerId: 'anthropic',
       identity: 'test',
     });
+  });
+
+  it('surfaces the model and Max Mode action when the child exits with Max Mode stderr', async () => {
+    runTurnSpy.mockImplementation(() => throwingErrorStream({ message: MAX_MODE_MESSAGE }));
+
+    const useAppStore = await importStore();
+    setupSession(useAppStore);
+
+    await expect(
+      useAppStore.getState().sendTurn({ sessionId: SESSION_ID, content: 'boom' }),
+    ).rejects.toThrow(MAX_MODE_MESSAGE);
+
+    const transcript = useAppStore.getState().transcripts[AGENT_ID] ?? [];
+    const errorEvent = transcript.find((event) => event.kind === 'error');
+    const message = errorEvent && 'message' in errorEvent ? errorEvent.message : '';
+    expect(message).toContain('gpt-5.5-high');
+    expect(message).toContain('Enable Max Mode');
+    expect(message).not.toContain('CLI is configured correctly');
   });
 
   it('leaves a non-auth provider error event message verbatim', async () => {


### PR DESCRIPTION
## Symptom

A turn on several Cursor models, and every turn on Codex, dies with:

> provider exited without a response. check that the CLI is configured correctly.

The CLI is configured correctly. It said something useful and we threw it away.

## What the CLIs actually say

Reproduced by hand:

```
cursor-agent --model gpt-5.5-high --trust -p "reply ok" --output-format text --mode ask
-> ActionRequiredError: Max Mode Required
   The model "gpt-5.5-high" requires Max Mode to be enabled.
```

```
codex exec -m gpt-5.6 ...
-> {"type":"error","status":400,"error":{"type":"invalid_request_error",
    "message":"The 'gpt-5.6' model is not supported when using Codex with a ChatGPT account."}}
```

## Where it was lost

`features/chat/turn.ts` synthesised a generic error from the exit code and a stderr tail whenever no events parsed, and that won before anything could look at the text. `store/slices/turn/resolveErrorTurnMessage.ts` only special-cased authentication, through `AUTH_ERROR_PATTERNS` living in `turn.ts`; every other message fell through to the generic sentence.

## Changes

- The provider's own message survives. The generic sentence is kept only for the case where there genuinely is nothing to show, and a parsed provider error stops it being appended afterwards.
- New `features/chat/classifyProviderError.ts`, one pure function, one home for the patterns: `authentication`, `model_not_available` (with the model name and whether the fix is Max Mode or picking a supported model), `other`. The auth patterns moved here rather than being copied, so there is still one list.
- An unavailable model reads, for Cursor: `The model "gpt-5.5-high" requires Max Mode. Enable Max Mode or choose another model.` and for Codex: `The model "gpt-5.6" is not available with this Codex account. Choose a model supported by your account.` It names the model, says what to do, and does not blame CLI configuration. `Max Mode` is the CLI's own wording, not invented.
- No automatic retry, no silent fallback to another model.

## Not fixed here

Codex's `gpt-5.6` is rejected because it is not a model at all: it is a family whose real members are `gpt-5.6-sol`, `gpt-5.6-terra` and `gpt-5.6-luna`. This PR makes the app say so instead of lying; the registry fix is separate.

## Verify

```bash
pnpm typecheck && pnpm test
```

`apps/desktop` 359 files and 2881 tests passing, up from 358 and 2875. Typecheck clean. Snapshot diff empty. Classifier tested against all three real payloads verbatim, and the existing `__auth_required__:` path still asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)