### PR TITLE
fix(desktop): never replay a session id to the wrong provider

### DIFF
--- a/apps/desktop/src-tauri/src/workflows.rs
+++ b/apps/desktop/src-tauri/src/workflows.rs
@@ -165,6 +165,8 @@ pub struct SessionRow {
     pub completed_at: Option<String>,
     #[serde(rename = "providerSessionId")]
     pub provider_session_id: Option<String>,
+    #[serde(rename = "providerSessionProviderId")]
+    pub provider_session_provider_id: Option<String>,
     #[serde(rename = "lastFinishedAt")]
     pub last_finished_at: Option<String>,
     #[serde(rename = "lastViewedAt")]
@@ -867,7 +869,7 @@ pub fn step_def_delete(state: State<'_, Db>, id: String) -> Result<(), PhaseErro
 const AGENT_SESSION_COLS: &str =
     "id, session_id, step_id, ordinal, name, status, \
      provider_run_id, output_summary, started_at, completed_at, \
-     provider_session_id, last_finished_at, last_viewed_at, done_at, kind, verbosity, \
+     provider_session_id, provider_session_provider_id, last_finished_at, last_viewed_at, done_at, kind, verbosity, \
      effort, model_override, provider_override, \
      parent_agent_id, workflow_run_id, source_thread_id, source_thread_ids, source_comment_url, \
      source_kind, domains_json";
@@ -885,21 +887,22 @@ fn session_row_from_row(row: &rusqlite::Row<'_>) -> Result<SessionRow, rusqlite:
         started_at: row.get(8)?,
         completed_at: row.get(9)?,
         provider_session_id: row.get(10)?,
-        last_finished_at: row.get(11)?,
-        last_viewed_at: row.get(12)?,
-        done_at: row.get(13)?,
-        kind: row.get(14)?,
-        verbosity: row.get(15)?,
-        effort: row.get(16)?,
-        model_override: row.get(17)?,
-        provider_override: row.get(18)?,
-        parent_agent_id: row.get(19)?,
-        workflow_run_id: row.get(20)?,
-        source_thread_id: row.get(21)?,
-        source_thread_ids: row.get(22)?,
-        source_comment_url: row.get(23)?,
-        source_kind: row.get(24)?,
-        domains_json: row.get(25)?,
+        provider_session_provider_id: row.get(11)?,
+        last_finished_at: row.get(12)?,
+        last_viewed_at: row.get(13)?,
+        done_at: row.get(14)?,
+        kind: row.get(15)?,
+        verbosity: row.get(16)?,
+        effort: row.get(17)?,
+        model_override: row.get(18)?,
+        provider_override: row.get(19)?,
+        parent_agent_id: row.get(20)?,
+        workflow_run_id: row.get(21)?,
+        source_thread_id: row.get(22)?,
+        source_thread_ids: row.get(23)?,
+        source_comment_url: row.get(24)?,
+        source_kind: row.get(25)?,
+        domains_json: row.get(26)?,
     })
 }
 
@@ -968,6 +971,7 @@ pub fn agent_insert(
         started_at: input.started_at,
         completed_at: input.completed_at,
         provider_session_id: None,
+        provider_session_provider_id: None,
         last_finished_at: None,
         last_viewed_at: None,
         done_at: None,
@@ -1070,19 +1074,17 @@ pub fn agent_set_verbosity(
     Ok(())
 }
 
-// Persists the provider-side session id captured from the CLI's `system` init
-// event (claude). Threaded back via `--resume <id>` on subsequent turns so the
-// provider retains full prior-turn context across one-shot invocations.
 #[tauri::command]
 pub fn agent_set_provider_session_id(
     state: State<'_, Db>,
     id: String,
     provider_session_id: String,
+    provider_session_provider_id: String,
 ) -> Result<(), PhaseError> {
     let conn = state.0.lock().map_err(|_| PhaseError::Poisoned)?;
     let affected = conn.execute(
-        "UPDATE agents SET provider_session_id = ?2 WHERE id = ?1",
-        rusqlite::params![id, provider_session_id],
+        "UPDATE agents SET provider_session_id = ?2, provider_session_provider_id = ?3 WHERE id = ?1",
+        rusqlite::params![id, provider_session_id, provider_session_provider_id],
     )?;
     if affected == 0 {
         return Err(PhaseError::RunNotFound(id));
@@ -1159,7 +1161,7 @@ mod tests {
             "CREATE TABLE agents (
                 id TEXT, session_id TEXT, step_id TEXT, ordinal INTEGER, name TEXT, status TEXT,
                 provider_run_id TEXT, output_summary TEXT, started_at TEXT, completed_at TEXT,
-                provider_session_id TEXT, last_finished_at TEXT, last_viewed_at TEXT, done_at TEXT,
+                provider_session_id TEXT, provider_session_provider_id TEXT, last_finished_at TEXT, last_viewed_at TEXT, done_at TEXT,
                 kind TEXT, verbosity TEXT, effort TEXT, model_override TEXT, provider_override TEXT,
                 parent_agent_id TEXT, workflow_run_id TEXT, source_thread_id TEXT,
                 source_thread_ids TEXT, source_comment_url TEXT, source_kind TEXT, domains_json TEXT
@@ -1173,8 +1175,8 @@ mod tests {
     fn agent_session_cols_round_trips_routing_fields() {
         let conn = agents_table_conn();
         conn.execute(
-            "INSERT INTO agents (id, session_id, ordinal, name, status, effort, model_override, provider_override)
-             VALUES ('a1', 's1', 0, 'scout', 'pending', 'high', 'claude-opus-4-8', 'anthropic')",
+            "INSERT INTO agents (id, session_id, ordinal, name, status, provider_session_id, provider_session_provider_id, effort, model_override, provider_override)
+             VALUES ('a1', 's1', 0, 'scout', 'pending', 'session-1', 'anthropic', 'high', 'claude-opus-4-8', 'anthropic')",
             [],
         )
         .unwrap();
@@ -1185,9 +1187,16 @@ mod tests {
             .query_row(rusqlite::params!["a1"], session_row_from_row)
             .unwrap();
 
+        assert_eq!(row.provider_session_id.as_deref(), Some("session-1"));
+        assert_eq!(
+            row.provider_session_provider_id.as_deref(),
+            Some("anthropic")
+        );
         assert_eq!(row.effort.as_deref(), Some("high"));
         assert_eq!(row.model_override.as_deref(), Some("claude-opus-4-8"));
         assert_eq!(row.provider_override.as_deref(), Some("anthropic"));
+        let serialized = serde_json::to_value(row).unwrap();
+        assert_eq!(serialized["providerSessionProviderId"], "anthropic");
     }
 
     #[test]
@@ -1209,5 +1218,6 @@ mod tests {
         assert!(row.effort.is_none());
         assert!(row.model_override.is_none());
         assert!(row.provider_override.is_none());
+        assert!(row.provider_session_provider_id.is_none());
     }
 }

--- a/apps/desktop/src/features/workflows/workflows.test.ts
+++ b/apps/desktop/src/features/workflows/workflows.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { invoke } from '@tauri-apps/api/core';
+import type { SessionId } from '@goodboy/types';
+import { invokeAgentList } from './workflows';
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}));
+
+describe('workflow agent rows', () => {
+  beforeEach(() => {
+    vi.mocked(invoke).mockReset();
+  });
+
+  it('maps the provider session owner returned by the Rust agent select', async () => {
+    vi.mocked(invoke).mockResolvedValue([
+      {
+        id: 'agent-1',
+        sessionId: 'session-1',
+        stepId: null,
+        workflowRunId: null,
+        parentAgentId: null,
+        ordinal: 0,
+        name: 'agent',
+        status: 'pending',
+        providerRunId: null,
+        outputSummary: null,
+        startedAt: null,
+        completedAt: null,
+        providerSessionId: 'codex-session',
+        providerSessionProviderId: 'codex',
+        lastFinishedAt: null,
+        lastViewedAt: null,
+        doneAt: null,
+        kind: null,
+        verbosity: null,
+        effort: null,
+        modelOverride: null,
+        providerOverride: null,
+        sourceThreadId: null,
+        sourceThreadIds: null,
+        sourceCommentUrl: null,
+        sourceKind: null,
+        domainsJson: null,
+      },
+    ]);
+
+    const agents = await invokeAgentList('session-1' as SessionId);
+
+    expect(agents[0]?.providerSessionId).toBe('codex-session');
+    expect(agents[0]?.providerSessionProviderId).toBe('codex');
+  });
+});

--- a/apps/desktop/src/features/workflows/workflows.ts
+++ b/apps/desktop/src/features/workflows/workflows.ts
@@ -83,6 +83,7 @@ type RawAgentRow = {
   readonly startedAt: string | null;
   readonly completedAt: string | null;
   readonly providerSessionId: string | null;
+  readonly providerSessionProviderId: string | null;
   readonly lastFinishedAt: string | null;
   readonly lastViewedAt: string | null;
   readonly doneAt: string | null;
@@ -190,6 +191,9 @@ function rowToAgent(row: RawAgentRow): Agent {
     ...(row.startedAt != null && { startedAt: row.startedAt as IsoDateTime }),
     ...(row.completedAt != null && { completedAt: row.completedAt as IsoDateTime }),
     ...(row.providerSessionId != null && { providerSessionId: row.providerSessionId }),
+    ...(row.providerSessionProviderId != null && {
+      providerSessionProviderId: row.providerSessionProviderId as ProviderId,
+    }),
     ...(row.lastFinishedAt != null && { lastFinishedAt: row.lastFinishedAt as IsoDateTime }),
     ...(row.lastViewedAt != null && { lastViewedAt: row.lastViewedAt as IsoDateTime }),
     ...(row.doneAt != null && { doneAt: row.doneAt as IsoDateTime }),
@@ -406,13 +410,21 @@ export const invokeAgentUpdateStatus = async (
   return rowToAgent(row);
 };
 
-export const invokeAgentSetProviderSessionId = async (
-  id: AgentId,
-  providerSessionId: string,
-): Promise<void> => {
+type Params = {
+  readonly id: AgentId;
+  readonly providerSessionId: string;
+  readonly providerSessionProviderId: ProviderId;
+};
+
+export const invokeAgentSetProviderSessionId = async ({
+  id,
+  providerSessionId,
+  providerSessionProviderId,
+}: Params): Promise<void> => {
   await invoke<void>('agent_set_provider_session_id', {
     id,
     providerSessionId,
+    providerSessionProviderId,
   });
 };
 

--- a/apps/desktop/src/store/parallel-turn.ts
+++ b/apps/desktop/src/store/parallel-turn.ts
@@ -299,7 +299,7 @@ export const runParallelBranch = async (
     });
     listener.registerRun(runId, {
       onEvent: (e) => {
-        const forwarded: TurnEvent =
+        const resolvedEvent: TurnEvent =
           e.kind === 'error'
             ? {
                 ...e,
@@ -310,6 +310,10 @@ export const runParallelBranch = async (
                 }),
               }
             : e;
+        const forwarded: TurnEvent =
+          resolvedEvent.kind === 'provider_session_init'
+            ? { ...resolvedEvent, provider }
+            : resolvedEvent;
         const cb = progressCallbacks.get(runId);
         if (cb) {
           cb(forwarded);

--- a/apps/desktop/src/store/slices/transcripts/appendTurnEvent.ts
+++ b/apps/desktop/src/store/slices/transcripts/appendTurnEvent.ts
@@ -20,9 +20,18 @@ export const appendTurnEvent = (set: SetFn) => {
         };
       }
       if (event.kind === 'provider_session_init') {
+        if (event.provider === undefined) {
+          return { transcripts: updatedTranscripts };
+        }
         const runs = state.sessionPhaseRuns[sessionId] ?? [];
         const updatedRuns = runs.map((s) =>
-          s.id === agentId ? { ...s, providerSessionId: event.providerSessionId } : s,
+          s.id === agentId
+            ? {
+                ...s,
+                providerSessionId: event.providerSessionId,
+                providerSessionProviderId: event.provider,
+              }
+            : s,
         );
         return {
           transcripts: updatedTranscripts,
@@ -39,8 +48,12 @@ export const appendTurnEvent = (set: SetFn) => {
       event,
     });
 
-    if (event.kind === 'provider_session_init') {
-      void invokeAgentSetProviderSessionId(agentId, event.providerSessionId).catch((err) => {
+    if (event.kind === 'provider_session_init' && event.provider !== undefined) {
+      void invokeAgentSetProviderSessionId({
+        id: agentId,
+        providerSessionId: event.providerSessionId,
+        providerSessionProviderId: event.provider,
+      }).catch((err) => {
         if (import.meta.env.DEV) {
           const message = formatError(err);
           console.warn(`[turn-events] persist provider_session_id failed: ${message}`);

--- a/apps/desktop/src/store/slices/transcripts/index.test.ts
+++ b/apps/desktop/src/store/slices/transcripts/index.test.ts
@@ -576,13 +576,19 @@ describe('store contract', () => {
         kind: 'provider_session_init',
         runId: RUN_ID,
         providerSessionId: 'sess-xyz',
+        provider: 'anthropic',
         at: NOW,
       } as TurnEvent;
       store.getState().appendTurnEvent(AGENT_ID, SESSION_ID, ev);
       const run = store.getState().sessionPhaseRuns[SESSION_ID]?.find((r) => r.id === AGENT_ID);
       expect(run?.providerSessionId).toBe('sess-xyz');
+      expect(run?.providerSessionProviderId).toBe('anthropic');
       expect(invokeAgentSetProviderSessionIdSpy).toHaveBeenCalledTimes(1);
-      expect(invokeAgentSetProviderSessionIdSpy).toHaveBeenCalledWith(AGENT_ID, 'sess-xyz');
+      expect(invokeAgentSetProviderSessionIdSpy).toHaveBeenCalledWith({
+        id: AGENT_ID,
+        providerSessionId: 'sess-xyz',
+        providerSessionProviderId: 'anthropic',
+      });
     });
   });
 });

--- a/apps/desktop/src/store/slices/turn/sendTurn.ts
+++ b/apps/desktop/src/store/slices/turn/sendTurn.ts
@@ -685,7 +685,10 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
     let shouldAutoAdvanceWorkflow = false;
     const filesTouchedThisTurn = new Set<string>();
 
-    const resumeSessionId = agentRowEarly?.providerSessionId;
+    const resumeSessionId =
+      agentRowEarly?.providerSessionProviderId === provider
+        ? agentRowEarly.providerSessionId
+        : undefined;
 
     const kindSystemPrompt = AGENT_KIND_DEFAULTS[earlyAgentKind].systemPrompt;
 
@@ -755,7 +758,7 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
         ...(apiKeyBinding ?? {}),
         ...claudeFlags,
       })) {
-        const event: TurnEvent =
+        const resolvedEvent: TurnEvent =
           rawEvent.kind === 'error'
             ? {
                 ...rawEvent,
@@ -766,6 +769,10 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
                 }),
               }
             : rawEvent;
+        const event: TurnEvent =
+          resolvedEvent.kind === 'provider_session_init'
+            ? { ...resolvedEvent, provider }
+            : resolvedEvent;
         get().appendTurnEvent(activeAgentId, sessionId, event);
         if (event.kind === 'assistant_text') {
           assistantText += event.delta;

--- a/apps/desktop/src/store/store.sendturn-agent-routing.test.ts
+++ b/apps/desktop/src/store/store.sendturn-agent-routing.test.ts
@@ -20,6 +20,7 @@ const runTurnSpy = vi.fn();
 const cancelTurnSpy = vi.fn();
 const invokeSpy = vi.fn();
 const invokeAgentUpdateStatusSpy = vi.fn();
+const invokeAgentListSpy = vi.fn(async () => [] as ReadonlyArray<Agent>);
 const invokeAgentSetDoneSpy = vi.fn(async () => undefined);
 
 vi.mock('../features/chat/turn', () => ({
@@ -133,7 +134,7 @@ vi.mock('../features/workflows/workflows', () => ({
   invokeWorkflowList: vi.fn(async () => []),
   invokeWorkflowUpsert: vi.fn(),
   invokeWorkflowDelete: vi.fn(),
-  invokeAgentList: vi.fn(async () => []),
+  invokeAgentList: invokeAgentListSpy,
   invokeAgentInsert: vi.fn(),
   invokeAgentUpdateStatus: invokeAgentUpdateStatusSpy,
   invokeAgentMarkViewed: vi.fn(async () => undefined),
@@ -206,6 +207,8 @@ describe('sendTurn, agent routing', () => {
     cancelTurnSpy.mockReset();
     invokeSpy.mockReset();
     invokeAgentUpdateStatusSpy.mockReset();
+    invokeAgentListSpy.mockReset();
+    invokeAgentListSpy.mockResolvedValue([]);
     runTurnSpy.mockImplementation(() => emptyStream());
     invokeSpy.mockResolvedValue({
       stdout: JSON.stringify({ result: JSON.stringify({ upserts: [] }) }),
@@ -315,6 +318,49 @@ describe('sendTurn, agent routing', () => {
     expect(userEvent && 'text' in userEvent ? userEvent.text : '').toBe('pinned to A');
 
     expect(runTurnSpy).toHaveBeenCalledOnce();
+  });
+
+  it('only resumes a provider session on the provider that created it', async () => {
+    const useAppStore = await importStore();
+    setupTwoAgents(useAppStore, AGENT_A);
+    const agents = [
+      {
+        ...buildAgent(AGENT_A, 0),
+        providerSessionId: 'codex-session',
+        providerSessionProviderId: 'codex',
+      },
+      buildAgent(AGENT_B, 1),
+    ] satisfies ReadonlyArray<Agent>;
+    invokeAgentListSpy.mockResolvedValue(agents);
+    useAppStore.setState({
+      sessionPhaseRuns: {
+        [SESSION_ID]: agents,
+      },
+    });
+    const routingMod = await import('../features/providers/routing');
+
+    await useAppStore
+      .getState()
+      .sendTurn({ sessionId: SESSION_ID, agentId: AGENT_A, content: 'use claude' });
+
+    expect(runTurnSpy.mock.calls[0]?.[0]).not.toHaveProperty('resumeSessionId');
+
+    (routingMod.resolveProviderForTurn as ReturnType<typeof vi.fn>).mockResolvedValue({
+      selectedProvider: 'codex',
+      selectedModel: 'gpt-5.4',
+      reason: 'preference',
+    });
+
+    await useAppStore
+      .getState()
+      .sendTurn({ sessionId: SESSION_ID, agentId: AGENT_A, content: 'use codex' });
+
+    expect(runTurnSpy.mock.calls[1]?.[0]).toEqual(
+      expect.objectContaining({
+        provider: 'codex',
+        resumeSessionId: 'codex-session',
+      }),
+    );
   });
 
   it('stores deterministic fallback output without an LLM call for a non-workflow agent', async () => {

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -84,6 +84,7 @@ import { m083AgentDomains } from './m083-agent-domains';
 import { m084WorkspaceProviderPool } from './m084-workspace-provider-pool';
 import { m085OpencodeOpenrouterProviderRuns } from './m085-opencode-openrouter-provider-runs';
 import { m086ImpactIndexes } from './m086-impact-indexes';
+import { m087AgentProviderSessionProvider } from './m087-agent-provider-session-provider';
 
 export type Migration = {
   readonly version: number;
@@ -177,4 +178,5 @@ export const migrations: ReadonlyArray<Migration> = [
   { version: 84, sql: m084WorkspaceProviderPool },
   { version: 85, sql: m085OpencodeOpenrouterProviderRuns },
   { version: 86, sql: m086ImpactIndexes },
+  { version: 87, sql: m087AgentProviderSessionProvider },
 ];

--- a/packages/db/src/migrations/m087-agent-provider-session-provider.ts
+++ b/packages/db/src/migrations/m087-agent-provider-session-provider.ts
@@ -1,0 +1,3 @@
+export const m087AgentProviderSessionProvider = `
+ALTER TABLE agents ADD COLUMN provider_session_provider_id TEXT;
+`;

--- a/packages/db/src/queries/agent.test.ts
+++ b/packages/db/src/queries/agent.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { Agent, AgentId, SessionId, WorkspaceId } from '@goodboy/types';
+import type { Database } from '../client';
+import { migrate } from '../migrations/runner';
+import { makeTestDatabase } from '../test-helpers/test-db';
+import { getAgentById, insertAgent } from './agent';
+
+const workspaceId = 'workspace-1' as WorkspaceId;
+const sessionId = 'session-1' as SessionId;
+const agentId = 'agent-1' as AgentId;
+
+describe('agent queries', () => {
+  let db: Database;
+
+  beforeEach(async () => {
+    db = makeTestDatabase();
+    await migrate(db);
+    const now = Date.now();
+    await db.execute(
+      'INSERT INTO workspaces (id, name, root_path, created_at, updated_at) VALUES (?, ?, ?, ?, ?)',
+      [workspaceId, 'workspace', '/tmp/workspace', now, now],
+    );
+    await db.execute(
+      'INSERT INTO sessions (id, workspace_id, goal, state_kind, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)',
+      [sessionId, workspaceId, 'goal', 'idle', now, now],
+    );
+  });
+
+  it('round-trips the provider session id and its owning provider', async () => {
+    const agent: Agent = {
+      id: agentId,
+      sessionId,
+      ordinal: 0,
+      name: 'agent',
+      status: 'pending',
+      providerSessionId: 'codex-session',
+      providerSessionProviderId: 'codex',
+    };
+
+    await insertAgent(db, agent);
+
+    const stored = await getAgentById(db, agentId);
+    expect(stored?.providerSessionId).toBe('codex-session');
+    expect(stored?.providerSessionProviderId).toBe('codex');
+  });
+});

--- a/packages/db/src/queries/agent.ts
+++ b/packages/db/src/queries/agent.ts
@@ -27,6 +27,7 @@ type AgentRow = {
   started_at: string | null;
   completed_at: string | null;
   provider_session_id: string | null;
+  provider_session_provider_id: string | null;
   last_finished_at: string | null;
   last_viewed_at: string | null;
   done_at: string | null;
@@ -84,6 +85,9 @@ const toAgent = ({ row }: ToAgentParams): Agent => {
     ...(row.started_at && { startedAt: row.started_at as IsoDateTime }),
     ...(row.completed_at && { completedAt: row.completed_at as IsoDateTime }),
     ...(row.provider_session_id && { providerSessionId: row.provider_session_id }),
+    ...(row.provider_session_provider_id != null && {
+      providerSessionProviderId: row.provider_session_provider_id as ProviderId,
+    }),
     ...(row.last_finished_at && { lastFinishedAt: row.last_finished_at as IsoDateTime }),
     ...(row.last_viewed_at && { lastViewedAt: row.last_viewed_at as IsoDateTime }),
     ...(row.done_at && { doneAt: row.done_at as IsoDateTime }),
@@ -143,8 +147,8 @@ export const getAgentById = async (db: Database, id: AgentId): Promise<Agent | n
 export const insertAgent = async (db: Database, agent: Agent): Promise<void> => {
   await db.execute(
     `INSERT INTO agents
-      (id, session_id, step_id, workflow_run_id, parent_agent_id, ordinal, name, status, provider_run_id, output_summary, started_at, completed_at, domains_json)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      (id, session_id, step_id, workflow_run_id, parent_agent_id, ordinal, name, status, provider_run_id, output_summary, started_at, completed_at, provider_session_id, provider_session_provider_id, domains_json)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     [
       agent.id,
       agent.sessionId,
@@ -158,6 +162,8 @@ export const insertAgent = async (db: Database, agent: Agent): Promise<void> => 
       agent.outputSummary ?? null,
       agent.startedAt ?? null,
       agent.completedAt ?? null,
+      agent.providerSessionId ?? null,
+      agent.providerSessionProviderId ?? null,
       agent.domains !== undefined ? JSON.stringify(agent.domains) : null,
     ],
   );

--- a/packages/types/src/adapter.ts
+++ b/packages/types/src/adapter.ts
@@ -83,6 +83,7 @@ export type TurnEvent =
       kind: 'provider_session_init';
       runId: ProviderRunId;
       providerSessionId: string;
+      provider?: ProviderId;
       at: IsoDateTime;
     }
   | {

--- a/packages/types/src/workflow.ts
+++ b/packages/types/src/workflow.ts
@@ -92,6 +92,7 @@ export type Agent = Readonly<{
   startedAt?: IsoDateTime;
   completedAt?: IsoDateTime;
   providerSessionId?: string;
+  providerSessionProviderId?: ProviderId;
   lastFinishedAt?: IsoDateTime;
   lastViewedAt?: IsoDateTime;
   doneAt?: IsoDateTime;


### PR DESCRIPTION
## Symptom

Any turn on Claude after the first one fails, with `0 IN · 0 OUT` and no output. Claude only works when the agent spawned on Claude for its very first command.

## Cause

`store/slices/turn/sendTurn.ts:688` read the resume id with no idea who created it:

```ts
const resumeSessionId = agentRowEarly?.providerSessionId;
```

`Agent.providerSessionId` and the `agents.provider_session_id` column are a single field with no provider recorded. `turn.rs` sends `--resume <id>` on the claude branch (and `--session <id>` on opencode); cursor and codex ignore it.

So an agent whose first turn ran on Codex or Cursor stores that provider's session id, and switching the agent to Claude hands Claude a foreign id. Claude cannot resume it, produces nothing parseable, and the row reports zero tokens.

## Changes

- Migration **87** adds `agents.provider_session_provider_id`, next to the free number the runner expects. Read `docs/architecture.md` on migrations for why reusing a number is silently fatal; `registry.test.ts` polices it and stays green.
- The column is threaded through the whole boundary: `AGENT_SESSION_COLS` and `session_row_from_row` in `workflows.rs` (positional indices after the insert all shifted and were checked), `packages/db/src/queries/agent.ts`, the `Agent` type, and `RawAgentRow`/`rowToAgent` on the frontend. This boundary has silently dropped columns before, so there is a test proving the value reaches the frontend rather than a reading of the code.
- `sendTurn` resumes only when the stored owner equals the provider about to spawn; a mismatch starts fresh and rewrites both fields once the new provider reports its id.
- A legacy id with no recorded owner is treated as unsafe and never resumed. One extra cold start per pre-existing agent, which is the safe direction.

## Verify

```bash
pnpm typecheck && pnpm test
cd apps/desktop/src-tauri && cargo test --locked
```

typecheck clean, `packages/db` 128 tests, `apps/desktop` 359 files and 2877 tests (up from 358 and 2875), cargo check and cargo test clean, snapshot diff empty.

Store test covers it directly: an agent holding a `codex`-owned id, sent on `anthropic`, spawns with no resume id; sent again on `codex`, it resumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)