### PR TITLE
fix(desktop): surface stderr when a turn dies without a response

### DIFF
--- a/apps/desktop/src/features/chat/turn.test.ts
+++ b/apps/desktop/src/features/chat/turn.test.ts
@@ -85,6 +85,52 @@ describe('runTurn', () => {
     await expect(iterator.next()).rejects.toThrow(message);
   });
 
+  it('surfaces stderr when the provider dies after emitting only init events', async () => {
+    const runId = 'max-mode-init-provider-run' as ProviderRunId;
+    const message =
+      'ActionRequiredError: Max Mode Required The model "gpt-5.6-sol-high" requires Max Mode to be enabled. Please enable Max Mode and try again.';
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === 'turn_spawn') {
+        capturedListeners[0]?.({
+          runId,
+          type: 'line',
+          line: JSON.stringify({
+            type: 'system',
+            subtype: 'init',
+            session_id: 'cursor-session-1',
+          }),
+        });
+        capturedListeners[0]?.({
+          runId,
+          type: 'line',
+          line: JSON.stringify({
+            type: 'user',
+            message: { role: 'user', content: [{ type: 'text', text: 'hello' }] },
+          }),
+        });
+        capturedListeners[0]?.({ runId, type: 'end', exit_code: 1, stderr: message });
+      }
+      return runId;
+    });
+
+    const iterator = runTurn({
+      runId,
+      provider: 'cursor',
+      model: 'gpt-5.6-sol-high',
+      workingDir: '/tmp/worktree',
+      prompt: 'hello',
+    })[Symbol.asyncIterator]();
+
+    await expect(iterator.next()).resolves.toMatchObject({
+      done: false,
+      value: {
+        kind: 'provider_session_init',
+        providerSessionId: 'cursor-session-1',
+      },
+    });
+    await expect(iterator.next()).rejects.toThrow(message);
+  });
+
   it('surfaces unparseable stdout when a provider exits', async () => {
     const runId = 'stdout-error-provider-run' as ProviderRunId;
     const message = 'provider rejected this request';

--- a/apps/desktop/src/features/chat/turn.ts
+++ b/apps/desktop/src/features/chat/turn.ts
@@ -121,6 +121,7 @@ export async function* runTurn(
   };
 
   let receivedAnyEvent = false;
+  let receivedResponseEvent = false;
   const unparsedOutput: string[] = [];
 
   const unlisten: UnlistenFn = await listen<RawTurnEnvelope>(EVENT_NAME, (event) => {
@@ -138,6 +139,9 @@ export async function* runTurn(
           unparsedOutput.push(event.payload.line.trim());
         }
         for (const ev of parsedEvents) {
+          if (ev.kind === 'assistant_text' || ev.kind === 'done' || ev.kind === 'error') {
+            receivedResponseEvent = true;
+          }
           queue.push(ev);
         }
         flush();
@@ -161,6 +165,21 @@ export async function* runTurn(
               : new Error(
                   'provider exited without a response. check that the CLI is configured correctly.',
                 );
+        }
+        if (
+          receivedAnyEvent &&
+          !receivedResponseEvent &&
+          event.payload.exit_code !== null &&
+          event.payload.exit_code !== 0
+        ) {
+          const stderrMessage = event.payload.stderr.trim();
+          const stdoutMessage = unparsedOutput.join('\n');
+          const providerMessage = [stdoutMessage, stderrMessage]
+            .filter((value) => value !== '')
+            .join('\n');
+          if (providerMessage !== '') {
+            error = new Error(providerMessage);
+          }
         }
         ended = true;
         flush();


### PR DESCRIPTION
## Problem

When a provider prints parseable stream lines (e.g. Cursor's system/init and user echo) and then dies with a non-zero exit, the real error on stderr is dropped: the `end` handler in `turn.ts` only surfaces stderr when zero events were parsed. The user sees the generic "provider exited without a response" banner. This is exactly how Cursor fails on models that require Max Mode, so those models look broken while the actionable message ("enable Max Mode") never reaches the UI, and the Max Mode advisory never marks.

## Fix

Track whether any response event (assistant_text, done, error) arrived. When the stream ends with a failed exit code and no response event, surface stderr plus unparsed stdout as the turn error. The existing sendTurn catch path already matches the Max Mode pattern, marks the advisory and renders the provider message. The generic banner remains only when there is truly nothing to show. Healthy turns and the existing zero-event path are untouched.

## Proof

New regression test simulates the real Cursor failure shape (parsed init line, user echo line, end with exit 1 and Max Mode stderr) and asserts the init event still yields and the stderr message is thrown. All existing turn tests and store.idle-on-empty-stream tests pass unchanged (14 tests green), typecheck green.