### PR TITLE
fix(desktop): run cursor max mode models and show real errors

### DIFF
--- a/apps/desktop/src-tauri/src/cursor_config.rs
+++ b/apps/desktop/src-tauri/src/cursor_config.rs
@@ -1,0 +1,116 @@
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+
+pub fn source_config_dir() -> Option<PathBuf> {
+    if let Some(path) = std::env::var_os("CURSOR_CONFIG_DIR") {
+        return Some(PathBuf::from(path));
+    }
+    if let Some(path) = std::env::var_os("XDG_CONFIG_HOME") {
+        return Some(PathBuf::from(path).join("cursor"));
+    }
+    Some(dirs::home_dir()?.join(".cursor"))
+}
+
+pub fn write_max_mode_config(source: &Path, target: &Path) -> io::Result<()> {
+    let source_config = fs::read(source.join("cli-config.json"))?;
+    let mut config: Value = serde_json::from_slice(&source_config)
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+    let config_object = config.as_object_mut().ok_or_else(|| {
+        io::Error::new(io::ErrorKind::InvalidData, "cursor config is not an object")
+    })?;
+    config_object.insert("maxMode".to_string(), Value::Bool(true));
+
+    fs::create_dir_all(target)?;
+    let output = serde_json::to_vec_pretty(&config).map_err(io::Error::other)?;
+    fs::write(target.join("cli-config.json"), output)?;
+
+    let source_permissions = source.join("permissions.json");
+    if source_permissions.exists() {
+        fs::copy(source_permissions, target.join("permissions.json"))?;
+    }
+
+    Ok(())
+}
+
+pub fn max_mode_config_dir() -> Option<PathBuf> {
+    let source = source_config_dir()?;
+    let target = dirs::cache_dir()
+        .unwrap_or_else(std::env::temp_dir)
+        .join("goodboy")
+        .join("cursor-max-mode");
+    write_max_mode_config(&source, &target).ok()?;
+    Some(target)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static NEXT_DIRECTORY: AtomicU64 = AtomicU64::new(0);
+
+    fn unique_directory(name: &str) -> PathBuf {
+        let sequence = NEXT_DIRECTORY.fetch_add(1, Ordering::Relaxed);
+        std::env::temp_dir().join(format!(
+            "goodboy-cursor-config-{name}-{}-{sequence}",
+            std::process::id()
+        ))
+    }
+
+    #[test]
+    fn writes_max_mode_and_preserves_existing_keys() {
+        let source = unique_directory("patch-source");
+        let target = unique_directory("patch-target");
+        fs::create_dir_all(&source).unwrap();
+        fs::write(
+            source.join("cli-config.json"),
+            r#"{"theme":"dark","maxMode":false,"nested":{"enabled":true}}"#,
+        )
+        .unwrap();
+
+        write_max_mode_config(&source, &target).unwrap();
+
+        let output: Value =
+            serde_json::from_slice(&fs::read(target.join("cli-config.json")).unwrap()).unwrap();
+        assert_eq!(output["maxMode"], Value::Bool(true));
+        assert_eq!(output["theme"], Value::String("dark".to_string()));
+        assert_eq!(output["nested"]["enabled"], Value::Bool(true));
+
+        fs::remove_dir_all(source).unwrap();
+        fs::remove_dir_all(target).unwrap();
+    }
+
+    #[test]
+    fn copies_existing_permissions() {
+        let source = unique_directory("permissions-source");
+        let target = unique_directory("permissions-target");
+        fs::create_dir_all(&source).unwrap();
+        fs::write(source.join("cli-config.json"), r#"{"theme":"light"}"#).unwrap();
+        fs::write(source.join("permissions.json"), r#"{"allow":["Read"]}"#).unwrap();
+
+        write_max_mode_config(&source, &target).unwrap();
+
+        assert_eq!(
+            fs::read(target.join("permissions.json")).unwrap(),
+            br#"{"allow":["Read"]}"#
+        );
+
+        fs::remove_dir_all(source).unwrap();
+        fs::remove_dir_all(target).unwrap();
+    }
+
+    #[test]
+    fn missing_source_config_returns_an_error() {
+        let source = unique_directory("missing-source");
+        let target = unique_directory("missing-target");
+        fs::create_dir_all(&source).unwrap();
+
+        assert!(write_max_mode_config(&source, &target).is_err());
+        assert!(!target.exists());
+
+        fs::remove_dir_all(source).unwrap();
+    }
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@ mod aux_spawn;
 mod bridge;
 mod budget;
 mod config_export;
+mod cursor_config;
 mod db;
 mod editor;
 mod external_terminal;

--- a/apps/desktop/src-tauri/src/parallel_groups.rs
+++ b/apps/desktop/src-tauri/src/parallel_groups.rs
@@ -332,6 +332,8 @@ pub struct ParallelSpawnArgs {
     pub credential_id: Option<String>,
     #[serde(default)]
     pub workspace_id: Option<String>,
+    #[serde(default)]
+    pub cursor_max_mode: bool,
 }
 
 /// Spawn N child processes concurrently (one per `ParallelRunSpec`).
@@ -374,6 +376,7 @@ pub fn parallel_agent_spawn(
                 api_key_env: args.api_key_env.as_deref(),
                 credential_id: args.credential_id.as_deref(),
                 workspace_id: args.workspace_id.as_deref(),
+                cursor_max_mode: args.cursor_max_mode,
             },
         ) {
             Ok(run_id) => run_ids.push(run_id),
@@ -422,6 +425,7 @@ mod tests {
         assert!(parsed.permission_mode.is_none());
         assert!(parsed.allowed_tools.is_empty());
         assert!(parsed.disallowed_tools.is_empty());
+        assert!(!parsed.cursor_max_mode);
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/turn.rs
+++ b/apps/desktop/src-tauri/src/turn.rs
@@ -73,6 +73,8 @@ pub struct SpawnArgs {
     pub api_key_env: Option<String>,
     #[serde(default)]
     pub credential_id: Option<String>,
+    #[serde(default)]
+    pub cursor_max_mode: bool,
 }
 
 #[derive(Debug, Serialize, Clone)]
@@ -266,6 +268,17 @@ pub struct SpawnOneArgs<'a> {
     pub api_key_env: Option<&'a str>,
     pub credential_id: Option<&'a str>,
     pub workspace_id: Option<&'a str>,
+    pub cursor_max_mode: bool,
+}
+
+fn max_mode_config_dir_for(binary: &str, cursor_max_mode: bool) -> Option<std::path::PathBuf> {
+    let name = std::path::Path::new(binary)
+        .file_name()
+        .and_then(|value| value.to_str());
+    if name != Some("cursor-agent") || !cursor_max_mode {
+        return None;
+    }
+    crate::cursor_config::max_mode_config_dir()
 }
 
 /// Spawns one child process, registers it in the registry, and starts the
@@ -281,6 +294,10 @@ pub(crate) fn spawn_one(
     let mut command = crate::path_env::command(args.binary);
     command.current_dir(args.working_dir);
     crate::aux_spawn::scrub_nested_session_env(&mut command);
+
+    if let Some(directory) = max_mode_config_dir_for(args.binary, args.cursor_max_mode) {
+        command.env("CURSOR_CONFIG_DIR", directory);
+    }
 
     if let (Some(env_name), Some(cred_id)) = (args.api_key_env, args.credential_id) {
         if let Ok(Some(secret)) = crate::secrets::read(&format!("provider_credential.{cred_id}")) {
@@ -378,6 +395,7 @@ pub fn turn_spawn(
             api_key_env: args.api_key_env.as_deref(),
             credential_id: args.credential_id.as_deref(),
             workspace_id: args.workspace_id.as_deref(),
+            cursor_max_mode: args.cursor_max_mode,
         },
     )
 }
@@ -520,6 +538,7 @@ mod tests {
             api_key_env: None,
             credential_id: None,
             workspace_id: None,
+            cursor_max_mode: false,
         };
         assert_eq!(args.run_id, "run-1");
         assert_eq!(args.binary, "echo");
@@ -546,6 +565,7 @@ mod tests {
             api_key_env: None,
             credential_id: None,
             workspace_id: None,
+            cursor_max_mode: false,
         }
     }
 
@@ -740,6 +760,12 @@ mod tests {
     }
 
     #[test]
+    fn max_mode_config_dir_is_cursor_only_and_opt_in() {
+        assert!(max_mode_config_dir_for("claude", true).is_none());
+        assert!(max_mode_config_dir_for("/usr/local/bin/cursor-agent", false).is_none());
+    }
+
+    #[test]
     fn gemini_args_use_short_model_flag() {
         let empty: Vec<String> = vec![];
         let args = make_args(None, None, &empty);
@@ -775,6 +801,7 @@ mod tests {
             api_key_env: None,
             credential_id: None,
             workspace_id: None,
+            cursor_max_mode: false,
         };
         let cli = build_provider_cli_args("codex", &args);
         let out = std::process::Command::new("codex")

--- a/apps/desktop/src/__tests__/parallel-spawn.test.ts
+++ b/apps/desktop/src/__tests__/parallel-spawn.test.ts
@@ -51,6 +51,7 @@ describe('invokeParallelPhaseRunSpawn', () => {
       permissionMode: 'acceptEdits',
       allowedTools: ['Bash', 'Edit'],
       disallowedTools: ['WebSearch'],
+      cursorMaxMode: true,
     };
 
     const result = await invokeParallelPhaseRunSpawn(args);

--- a/apps/desktop/src/features/chat/turn.test.ts
+++ b/apps/desktop/src/features/chat/turn.test.ts
@@ -82,7 +82,54 @@ describe('runTurn', () => {
       prompt: 'hello',
     })[Symbol.asyncIterator]();
 
-    await expect(iterator.next()).rejects.toThrow(message);
+    await expect(iterator.next()).rejects.toHaveProperty('message', message);
+  });
+
+  it('surfaces a generic error after init and only unmodeled JSON frames', async () => {
+    const runId = 'unmodeled-json-provider-run' as ProviderRunId;
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === 'turn_spawn') {
+        capturedListeners[0]?.({
+          runId,
+          type: 'line',
+          line: JSON.stringify({
+            type: 'system',
+            subtype: 'init',
+            session_id: 'cursor-session-2',
+          }),
+        });
+        capturedListeners[0]?.({
+          runId,
+          type: 'line',
+          line: JSON.stringify({
+            type: 'user',
+            message: { role: 'user', content: [{ type: 'text', text: 'hello' }] },
+          }),
+        });
+        capturedListeners[0]?.({ runId, type: 'end', exit_code: 1, stderr: '' });
+      }
+      return runId;
+    });
+
+    const iterator = runTurn({
+      runId,
+      provider: 'cursor',
+      model: 'gpt-5.6-sol-high',
+      workingDir: '/tmp/worktree',
+      prompt: 'hello',
+    })[Symbol.asyncIterator]();
+
+    await expect(iterator.next()).resolves.toMatchObject({
+      done: false,
+      value: {
+        kind: 'provider_session_init',
+        providerSessionId: 'cursor-session-2',
+      },
+    });
+    await expect(iterator.next()).rejects.toHaveProperty(
+      'message',
+      'provider exited without a response. check that the CLI is configured correctly.',
+    );
   });
 
   it('surfaces stderr when the provider dies after emitting only init events', async () => {
@@ -128,7 +175,7 @@ describe('runTurn', () => {
         providerSessionId: 'cursor-session-1',
       },
     });
-    await expect(iterator.next()).rejects.toThrow(message);
+    await expect(iterator.next()).rejects.toHaveProperty('message', message);
   });
 
   it('surfaces unparseable stdout when a provider exits', async () => {

--- a/apps/desktop/src/features/chat/turn.ts
+++ b/apps/desktop/src/features/chat/turn.ts
@@ -59,6 +59,21 @@ export const decodeAuthRequiredMessage = (message: string): AuthRequiredPayload 
 };
 
 const EVENT_NAME = 'turn_event';
+const NO_RESPONSE_MESSAGE =
+  'provider exited without a response. check that the CLI is configured correctly.';
+
+type Params = {
+  readonly line: string;
+};
+
+const isJsonProviderFrame = ({ line }: Params): boolean => {
+  try {
+    const value: unknown = JSON.parse(line);
+    return typeof value === 'object' && value !== null;
+  } catch {
+    return false;
+  }
+};
 
 type ClaudePermissionMode = 'default' | 'acceptEdits' | 'bypassPermissions' | 'dontAsk' | 'plan';
 
@@ -150,7 +165,9 @@ export async function* runTurn(
       case 'end': {
         if (!receivedAnyEvent) {
           const stderrMessage = event.payload.stderr.trim();
-          const stdoutMessage = unparsedOutput.join('\n');
+          const stdoutMessage = unparsedOutput
+            .filter((line) => !isJsonProviderFrame({ line }))
+            .join('\n');
           const hasFailedExit = event.payload.exit_code !== null && event.payload.exit_code !== 0;
           const stdoutClassification = classifyProviderError({ message: stdoutMessage });
           const providerMessage = [
@@ -160,11 +177,7 @@ export async function* runTurn(
             .filter((value) => value !== '')
             .join('\n');
           error =
-            providerMessage !== ''
-              ? new Error(providerMessage)
-              : new Error(
-                  'provider exited without a response. check that the CLI is configured correctly.',
-                );
+            providerMessage !== '' ? new Error(providerMessage) : new Error(NO_RESPONSE_MESSAGE);
         }
         if (
           receivedAnyEvent &&
@@ -173,13 +186,14 @@ export async function* runTurn(
           event.payload.exit_code !== 0
         ) {
           const stderrMessage = event.payload.stderr.trim();
-          const stdoutMessage = unparsedOutput.join('\n');
+          const stdoutMessage = unparsedOutput
+            .filter((line) => !isJsonProviderFrame({ line }))
+            .join('\n');
           const providerMessage = [stdoutMessage, stderrMessage]
             .filter((value) => value !== '')
             .join('\n');
-          if (providerMessage !== '') {
-            error = new Error(providerMessage);
-          }
+          error =
+            providerMessage !== '' ? new Error(providerMessage) : new Error(NO_RESPONSE_MESSAGE);
         }
         ended = true;
         flush();

--- a/apps/desktop/src/features/chat/turn.ts
+++ b/apps/desktop/src/features/chat/turn.ts
@@ -93,6 +93,7 @@ type SpawnArgs = {
   readonly workspaceId?: string;
   readonly apiKeyEnv?: string;
   readonly credentialId?: string;
+  readonly cursorMaxMode?: boolean;
 };
 
 type RawTurnEnvelope =
@@ -301,6 +302,7 @@ export type ParallelSpawnArgs = {
   readonly workspaceId?: string;
   readonly apiKeyEnv?: string;
   readonly credentialId?: string;
+  readonly cursorMaxMode?: boolean;
 };
 
 export const invokeParallelPhaseRunSpawn = async (

--- a/apps/desktop/src/shared/components/RoutingPicker/AxesSection.tsx
+++ b/apps/desktop/src/shared/components/RoutingPicker/AxesSection.tsx
@@ -74,18 +74,14 @@ export const AxesSection = ({
         </AxisRow>
       ))}
       {axes.requiresMaxMode && (
-        <p role="status" aria-label="Max Mode required" className="text-2xs text-warning">
-          Requires Max Mode. Goodboy cannot enable it. Turn it on in the Cursor app.
+        <p role="status" aria-label="Max Mode" className="text-2xs text-warning">
+          Runs in Max Mode. Cursor bills Max Mode requests at a higher rate.
         </p>
       )}
       {hasMaxModeAdvisory && axes.requiresMaxMode === false && (
-        <p
-          role="status"
-          aria-label="Max Mode required previously"
-          className="text-2xs text-warning"
-        >
-          This model previously required Max Mode. Goodboy cannot enable it. Turn it on in the
-          Cursor app, then retry.
+        <p role="status" aria-label="Max Mode rejected" className="text-2xs text-warning">
+          Cursor rejected Max Mode for this model. Check that Max Mode is available on your account,
+          then retry.
         </p>
       )}
       {notice != null && (

--- a/apps/desktop/src/shared/components/RoutingPicker/VersionChip.tsx
+++ b/apps/desktop/src/shared/components/RoutingPicker/VersionChip.tsx
@@ -43,9 +43,6 @@ export const VersionChip = ({
   onSelect,
 }: Props) => {
   const tier = model.presentation.costTier;
-  const alwaysRequiresMaxMode =
-    model.provider === 'cursor' && model.combos.every((combo) => combo.maxMode);
-  const showMaxModeWarning = alwaysRequiresMaxMode || hasMaxModeAdvisory;
   const accessibleName = `${model.label}${isRecommended ? ', Recommended' : ''}`;
   return (
     <button
@@ -62,9 +59,9 @@ export const VersionChip = ({
       )}
     >
       {model.presentation.version}
-      {showMaxModeWarning && (
+      {hasMaxModeAdvisory && (
         <span
-          title="May require Max Mode in the Cursor app"
+          title="Cursor rejected Max Mode for this model"
           className="absolute right-0 top-0 size-1.5 rounded-full bg-warning ring-1 ring-subtle"
         />
       )}

--- a/apps/desktop/src/shared/components/RoutingPicker/index.test.tsx
+++ b/apps/desktop/src/shared/components/RoutingPicker/index.test.tsx
@@ -365,16 +365,18 @@ describe('RoutingPicker', () => {
       />,
     );
     fireEvent.click(screen.getByRole('button', { name: /routing/i }));
-    expect(screen.getByRole('status', { name: 'Max Mode required previously' })).toBeDefined();
+    expect(screen.getByRole('status', { name: 'Max Mode rejected' }).textContent).toBe(
+      'Cursor rejected Max Mode for this model. Check that Max Mode is available on your account, then retry.',
+    );
     const chip = screen.getByRole('button', { name: 'Sonnet 4.6' });
-    expect(within(chip).getByTitle('May require Max Mode in the Cursor app')).toBeDefined();
+    expect(within(chip).getByTitle('Cursor rejected Max Mode for this model')).toBeDefined();
 
     act(() => {
       cursorMaxModeAdvisory.clear({ accountId: 'unknown', model: 'sonnet-4.6' });
     });
 
-    expect(screen.queryByRole('status', { name: 'Max Mode required previously' })).toBeNull();
-    expect(within(chip).queryByTitle('May require Max Mode in the Cursor app')).toBeNull();
+    expect(screen.queryByRole('status', { name: 'Max Mode rejected' })).toBeNull();
+    expect(within(chip).queryByTitle('Cursor rejected Max Mode for this model')).toBeNull();
   });
 
   it('shows a static Max Mode requirement from the selected Cursor combination', () => {
@@ -387,8 +389,12 @@ describe('RoutingPicker', () => {
       />,
     );
     fireEvent.click(screen.getByRole('button', { name: /routing/i }));
-    expect(screen.getByRole('status', { name: 'Max Mode required' })).toBeDefined();
-    expect(screen.queryByRole('status', { name: 'Max Mode required previously' })).toBeNull();
+    expect(screen.getByRole('status', { name: 'Max Mode' }).textContent).toBe(
+      'Runs in Max Mode. Cursor bills Max Mode requests at a higher rate.',
+    );
+    expect(screen.queryByRole('status', { name: 'Max Mode rejected' })).toBeNull();
+    const chip = screen.getByRole('button', { name: 'GPT-5.5' });
+    expect(within(chip).queryByTitle('Cursor rejected Max Mode for this model')).toBeNull();
   });
 
   it('renders every anthropic catalog model as a version chip', () => {

--- a/apps/desktop/src/store/parallel-turn.ts
+++ b/apps/desktop/src/store/parallel-turn.ts
@@ -227,6 +227,7 @@ export type RunParallelBranchDeps = {
   readonly providerBinary: string | undefined;
   readonly model: string;
   readonly effort?: string;
+  readonly cursorMaxMode?: boolean;
   readonly permissionMode?: 'default' | 'acceptEdits' | 'bypassPermissions' | 'dontAsk' | 'plan';
   readonly allowedTools?: ReadonlyArray<string>;
   readonly disallowedTools?: ReadonlyArray<string>;
@@ -371,6 +372,7 @@ export const runParallelBranch = async (
       ...(deps.providerBinary !== undefined && { binary: deps.providerBinary }),
       model: deps.model,
       ...(deps.effort !== undefined && { effort: deps.effort }),
+      ...(deps.cursorMaxMode === true && { cursorMaxMode: true }),
       prompt: promptsByIndex[i]!,
       ...(deps.permissionMode !== undefined && { permissionMode: deps.permissionMode }),
       ...(deps.allowedTools !== undefined && { allowedTools: deps.allowedTools }),

--- a/apps/desktop/src/store/slices/turn/dispatchParallelTurn.ts
+++ b/apps/desktop/src/store/slices/turn/dispatchParallelTurn.ts
@@ -30,6 +30,7 @@ type Params = {
   provider: ProviderId;
   model: string;
   effort: string | undefined;
+  cursorMaxMode: boolean | undefined;
   parallelDispatch: {
     template: Workflow;
     currentDef: Step;
@@ -56,6 +57,7 @@ export const dispatchParallelTurn = async (
     provider,
     model,
     effort,
+    cursorMaxMode,
     parallelDispatch,
     claudeFlags,
     apiKeyBinding,
@@ -164,6 +166,7 @@ export const dispatchParallelTurn = async (
         providerBinary,
         model,
         ...(effort !== undefined && { effort }),
+        ...(cursorMaxMode === true && { cursorMaxMode: true }),
         authIdentity: get().authResults?.[provider]?.identity ?? null,
         ...(claudeFlags.permissionMode !== undefined && {
           permissionMode: claudeFlags.permissionMode,

--- a/apps/desktop/src/store/slices/turn/matchCursorMaxModeFailure.test.ts
+++ b/apps/desktop/src/store/slices/turn/matchCursorMaxModeFailure.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { matchCursorMaxModeFailure } from './matchCursorMaxModeFailure';
+import { cursorMaxModeMessage, matchCursorMaxModeFailure } from './matchCursorMaxModeFailure';
 
 describe('matchCursorMaxModeFailure', () => {
   it('extracts the model from the Cursor ActionRequiredError payload', () => {
@@ -13,5 +13,11 @@ describe('matchCursorMaxModeFailure', () => {
 
   it('ignores unrelated provider failures', () => {
     expect(matchCursorMaxModeFailure({ message: 'cursor exited with code 1' })).toBeNull();
+  });
+
+  it('explains that Cursor rejected Max Mode', () => {
+    expect(cursorMaxModeMessage({ model: 'gpt-5.5-high' })).toBe(
+      'Cursor rejected Max Mode for "gpt-5.5-high". Check that Max Mode (usage-based pricing) is available on your Cursor account, then retry.',
+    );
   });
 });

--- a/apps/desktop/src/store/slices/turn/matchCursorMaxModeFailure.ts
+++ b/apps/desktop/src/store/slices/turn/matchCursorMaxModeFailure.ts
@@ -18,4 +18,4 @@ export const matchCursorMaxModeFailure = ({ message }: Params): Match | null => 
 };
 
 export const cursorMaxModeMessage = ({ model }: Match): string =>
-  `Cursor requires Max Mode for "${model}". Goodboy cannot enable Max Mode. Turn it on in the Cursor app, then retry.`;
+  `Cursor rejected Max Mode for "${model}". Check that Max Mode (usage-based pricing) is available on your Cursor account, then retry.`;

--- a/apps/desktop/src/store/slices/turn/sendTurn.ts
+++ b/apps/desktop/src/store/slices/turn/sendTurn.ts
@@ -621,6 +621,7 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
         provider,
         model: spawnModel,
         effort: effortFlag,
+        cursorMaxMode: resolvedModel.maxMode,
         parallelDispatch,
         claudeFlags,
         apiKeyBinding,
@@ -784,6 +785,7 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
         ...(resumeSessionId !== undefined && { resumeSessionId }),
         systemPrompt: fullSystemPrompt,
         ...(effortFlag !== undefined && { effort: effortFlag }),
+        ...(resolvedModel.maxMode === true && { cursorMaxMode: true }),
         ...(apiKeyBinding ?? {}),
         ...claudeFlags,
       })) {

--- a/apps/desktop/src/store/slices/turn/sendTurn.ts
+++ b/apps/desktop/src/store/slices/turn/sendTurn.ts
@@ -1027,7 +1027,7 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
             });
       const errorState: TurnState = {
         kind: 'error',
-        message: rawMessage,
+        message,
         failedAt: now(),
       };
       const derived = applyAgentTurnState(set, sessionId, activeAgentId, errorState, now());

--- a/apps/desktop/src/store/store.idle-on-empty-stream.test.ts
+++ b/apps/desktop/src/store/store.idle-on-empty-stream.test.ts
@@ -459,6 +459,8 @@ describe('sendTurn, terminal state guarantees', () => {
     expect(runTurnSpy.mock.calls[0]?.[0]).toEqual(
       expect.objectContaining({ model: 'gpt-5.5-high', cursorMaxMode: true }),
     );
+    const turnState = useAppStore.getState().agentTurnState[AGENT_ID];
+    expect(turnState?.kind === 'error' ? turnState.message : '').toBe(message);
   });
 
   it('leaves a non-auth provider error event message verbatim', async () => {

--- a/apps/desktop/src/store/store.idle-on-empty-stream.test.ts
+++ b/apps/desktop/src/store/store.idle-on-empty-stream.test.ts
@@ -439,6 +439,12 @@ describe('sendTurn, terminal state guarantees', () => {
 
     const useAppStore = await importStore();
     setupSession(useAppStore);
+    const routingMod = await import('../features/providers/routing');
+    (routingMod.resolveProviderForTurn as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      selectedProvider: 'cursor',
+      selectedModel: 'gpt-5.5-high',
+      reason: 'preference',
+    });
 
     await expect(
       useAppStore.getState().sendTurn({ sessionId: SESSION_ID, content: 'boom' }),
@@ -448,8 +454,11 @@ describe('sendTurn, terminal state guarantees', () => {
     const errorEvent = transcript.find((event) => event.kind === 'error');
     const message = errorEvent && 'message' in errorEvent ? errorEvent.message : '';
     expect(message).toContain('gpt-5.5-high');
-    expect(message).toContain('Enable Max Mode');
+    expect(message).toContain('usage-based pricing');
     expect(message).not.toContain('CLI is configured correctly');
+    expect(runTurnSpy.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({ model: 'gpt-5.5-high', cursorMaxMode: true }),
+    );
   });
 
   it('leaves a non-auth provider error event message verbatim', async () => {

--- a/apps/desktop/src/store/store.parallel.test.ts
+++ b/apps/desktop/src/store/store.parallel.test.ts
@@ -209,6 +209,7 @@ function buildDef(args: {
   name?: string;
   promptPrefix?: string;
   parallelGroup?: number;
+  modelOverride?: string;
 }): Step {
   return {
     id: args.id as StepId,
@@ -217,6 +218,7 @@ function buildDef(args: {
     name: args.name ?? args.id,
     promptPrefix: args.promptPrefix ?? `[${args.id}]`,
     ...(args.parallelGroup !== undefined && { parallelGroup: args.parallelGroup }),
+    ...(args.modelOverride !== undefined && { modelOverride: args.modelOverride }),
   };
 }
 
@@ -420,6 +422,66 @@ describe('sendTurn, parallel agents branch', () => {
       expect.objectContaining({ parentAgentId: 'agent-1' }),
     );
     expect(phaseRunUpdateStatusSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('threads Cursor Max Mode into every parallel spawn', async () => {
+    agentFeaturesMock.parallelAgents = true;
+    invokeParallelPhaseRunSpawnSpy.mockImplementation(
+      async (args: { runs: ReadonlyArray<{ runId: string }> }) => args.runs.map((r) => r.runId),
+    );
+    const routingMod = await import('../features/providers/routing');
+    (routingMod.resolveProviderForTurn as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      selectedProvider: 'cursor',
+      selectedModel: 'gpt-5.5-high',
+      reason: 'preference',
+    });
+
+    const useAppStore = await importStore();
+    setupSession(useAppStore, [
+      buildDef({ id: 'd-a', ordinal: 1, parallelGroup: 7, modelOverride: 'gpt-5.5-high' }),
+      buildDef({ id: 'd-b', ordinal: 2, parallelGroup: 7 }),
+    ]);
+    useAppStore.setState({
+      providers: [
+        {
+          id: 'cursor',
+          binary: 'cursor-agent',
+          connection: 'connected',
+          name: 'Cursor',
+          installation: 'installed',
+        } as never,
+      ],
+    });
+
+    const turnPromise = useAppStore.getState().sendTurn({ sessionId: SESSION_ID, content: 'plan' });
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    expect(invokeParallelPhaseRunSpawnSpy).toHaveBeenCalledTimes(2);
+    const spawnCalls = invokeParallelPhaseRunSpawnSpy.mock.calls as unknown as ReadonlyArray<
+      [
+        {
+          readonly binary?: string;
+          readonly model: string;
+          readonly cursorMaxMode?: boolean;
+          readonly runs: ReadonlyArray<{ readonly runId: ProviderRunId }>;
+        },
+      ]
+    >;
+    for (const [args] of spawnCalls) {
+      expect(args).toEqual(
+        expect.objectContaining({
+          binary: 'cursor-agent',
+          model: 'gpt-5.5-high',
+          cursorMaxMode: true,
+        }),
+      );
+      const runId = args.runs[0]?.runId;
+      if (runId != null) {
+        emitEnd(runId, 0);
+      }
+    }
+
+    await turnPromise;
   });
 
   it('flag ON but only 1 sibling → falls back to single-run path', async () => {

--- a/apps/desktop/src/store/store.sendturn-agent-routing.test.ts
+++ b/apps/desktop/src/store/store.sendturn-agent-routing.test.ts
@@ -861,6 +861,36 @@ describe('sendTurn, resolver config (provider pin + effort)', () => {
     expect(runTurnSpy.mock.calls[0]?.[0]?.effort).toBe('medium');
   });
 
+  it('passes Cursor Max Mode only for a model combination that requires it', async () => {
+    const useAppStore = await importStore();
+    setup(useAppStore);
+    const routingMod = await import('../features/providers/routing');
+    const routingSpy = routingMod.resolveProviderForTurn as ReturnType<typeof vi.fn>;
+    routingSpy
+      .mockResolvedValueOnce({
+        selectedProvider: 'cursor',
+        selectedModel: 'gpt-5.5-high',
+        reason: 'preference',
+      })
+      .mockResolvedValueOnce({
+        selectedProvider: 'cursor',
+        selectedModel: 'composer-2.5',
+        reason: 'preference',
+      });
+
+    await useAppStore
+      .getState()
+      .sendTurn({ sessionId: SESSION_ID, agentId: AGENT_A, content: 'max' });
+    await useAppStore
+      .getState()
+      .sendTurn({ sessionId: SESSION_ID, agentId: AGENT_A, content: 'standard' });
+
+    expect(runTurnSpy.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({ model: 'gpt-5.5-high', cursorMaxMode: true }),
+    );
+    expect(runTurnSpy.mock.calls[1]?.[0]).not.toHaveProperty('cursorMaxMode');
+  });
+
   it('passes clamped effort to runTurn when the resolved provider is codex', async () => {
     const useAppStore = await importStore();
     setup(useAppStore);

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@ once, so pull the deep-dive only when the task touches it.
 | [styling.md](styling.md)                                |       |         |      ✓      |    ✓     |            |            |
 | [tone-of-voice.md](tone-of-voice.md)                    |       |         |      ✓      |    ✓     |     ✓      |            |
 | [providers.md](providers.md)                            |   ✓   |    ✓    |      ✓      |          |            |     ✓      |
+| [model-picker.md](model-picker.md)                      |       |    ✓    |      ✓      |    ✓     |            |            |
 | [release.md](release.md)                                |       |         |             |          |     ✓      |            |
 | [release-command.md](release-command.md)                |       |         |             |          |     ✓      |            |
 | [workflows.md](workflows.md)                            |       |    ✓    |      ✓      |    ✓     |            |            |
@@ -95,6 +96,7 @@ Every doc, its one-line purpose, and the roles that load it.
 | [styling.md](styling.md)                                    | Concrete Tailwind rules for spacing, radius, scroll. DESIGN.md owns the principles.               | implementer, reviewer                   |
 | [tone-of-voice.md](tone-of-voice.md)                        | How Goodboy talks: README, website, release notes, in-app copy, errors.                           | implementer, reviewer, pr-release       |
 | [providers.md](providers.md)                                | Provider integration guide: install, connect, manage each CLI.                                    | scout, planner, implementer, onboarding |
+| [model-picker.md](model-picker.md)                          | Model picker structure: catalog presentation data, axes, Cursor Max Mode.                         | planner, implementer, reviewer          |
 | [release.md](release.md)                                    | Technical release runbook: signing, notarization, updater, homebrew.                              | pr-release                              |
 | [release-command.md](release-command.md)                    | Agent release playbook: step order and gotchas. Points to release.md for mechanics.               | pr-release                              |
 | [workflows.md](workflows.md)                                | Workflow tables, run advance gate, post-step summarizer, parallel status.                         | planner, implementer, reviewer          |

--- a/docs/model-picker.md
+++ b/docs/model-picker.md
@@ -1,0 +1,145 @@
+# Model picker
+
+Owns how a provider, a model, and its tuning are presented and selected. The
+catalog data behind it is described in [providers.md](providers.md); this doc
+owns the picker's structure: what the catalog must declare, how the UI turns
+that into rows and chips, and what reaches the spawn.
+
+The rule that keeps this alive: **the catalog describes, the picker renders.**
+Every grouping, ordering, and label decision is authored data on the catalog
+entry. No component parses a model id, and no component branches on a provider.
+
+## Surfaces
+
+One implementation serves every mount: the routing picker in the composer, the
+session and workspace routing rows, the workflow step cards, the agent-kind
+rows, and the create-agent popover. `RoutingPicker/` holds the internals; a
+mount composes them, it never forks them.
+
+If a surface needs a different arrangement, it composes `CatalogGrid` and
+`AxesSection` differently. It does not grow a private model list, a private
+effort control, or a native `select`.
+
+## Anatomy
+
+Top to bottom, always in this order:
+
+1. **Provider row.** Provider glyphs, one per connected provider. Picking a
+   provider swaps the catalog below.
+2. **Family sections.** A family is the vendor lineage of a model (`claude`,
+   `gpt`, `composer`, `gemini`). The section header renders only when the
+   provider has more than one family; a single-family provider shows no header.
+3. **Group rows.** One row per macro model: the group label on the left, its
+   versions as chips on the right, separated. `Opus` on the left, `4.6 4.7 4.8
+5` on the right. A group of one still gets a row.
+4. **Flat rows.** An entry with no group is a standalone chip in a shared row,
+   for one-off models that have no version ladder (`Auto`, `Composer`).
+5. **Axes.** Everything the selected model can be tuned by, below the catalog:
+   variant, effort, toggles. Selecting a model refreshes this block.
+
+## What a catalog entry declares
+
+Every entry carries a `presentation` object next to its identity fields:
+
+| Field      | Meaning                                                     |
+| ---------- | ----------------------------------------------------------- |
+| `family`   | Which family section the entry belongs to.                  |
+| `group`    | The macro-model row label, or `null` for a flat chip.       |
+| `version`  | The chip text. This is the only place chip text comes from. |
+| `order`    | Sort position inside the provider. Unique per provider.     |
+| `costTier` | Drives the chip color (`cheap`, `mid`, `expensive`).        |
+
+Two invariants hold, and `catalog.test.ts` fails if either breaks:
+
+- `order` is unique within a provider, so ordering is total and stable.
+- All entries sharing a `group` share a `family`, so a group never straddles
+  two sections.
+
+Grouping consumes nothing else. Adding a model that groups correctly means
+authoring these five fields, not touching the picker.
+
+## Axes
+
+`modelAxes({ model, selection })` in `@goodboy/core` is the only provider-aware
+layer. It returns the same shape for every provider, and the UI renders that
+shape without knowing which provider produced it:
+
+- **effort**: a label plus every level with an `available` flag. Levels the
+  current combination cannot reach render disabled rather than disappearing, so
+  the ladder does not jump around as toggles change.
+- **variant**: present only when a model has more than one variant, currently
+  Codex Sol, Terra, and Luna. Chips, never a `select`.
+- **toggles**: independent booleans, currently Cursor Thinking and Fast. Each
+  carries `canToggle`, false when no combo exists on the other side.
+- **requiresMaxMode**: true when the resolved Cursor combo only answers with
+  Max Mode enabled. See below.
+
+Effort is one component, `EffortChips`, used by every provider and every mount.
+A second effort control anywhere is a bug.
+
+## Selection to spawn
+
+`ModelSelection` (`key`, optional `effort`, `variant`, `toggles`) is what the
+picker owns and what gets persisted. `resolveModelArgs({ provider, selection })`
+turns it into CLI arguments plus, for Cursor, the Max Mode flag. Cursor's
+`resolveCursorCombo` picks the combo matching the toggles, then clamps effort to
+what that combo pair supports and reports the clamp so the UI can say so.
+
+Reading in the other direction, `parseModelId` resolves from the catalog
+descriptor only when the id is a catalog key. Raw CLI ids and provider slugs
+keep their regex parsing, because transcripts store what the provider echoed and
+those strings carry effort suffixes the catalog key does not.
+
+## Max Mode
+
+Cursor gates some models behind Max Mode, an account preference that also
+changes billing. A gated model refuses the turn with
+`ActionRequiredError: Max Mode Required` and exits non-zero.
+
+Max Mode is a persisted preference in the Cursor CLI config (`cli-config.json`,
+top-level `maxMode`), and the CLI resolves its config directory from
+`CURSOR_CONFIG_DIR`, then `XDG_CONFIG_HOME/cursor`, then `~/.cursor`. Goodboy
+uses that: when a spawn resolves to a combo that requires Max Mode, it mirrors
+the user's config into a Goodboy-owned directory with `maxMode` set and points
+that one spawn at it with `CURSOR_CONFIG_DIR`. The user's own config is never
+written to, and models that do not need Max Mode never get it.
+
+Which combos need it is authored on the catalog (`CursorCombo.maxMode`) from
+probing the CLI, not inferred from the slug. To check a new slug:
+
+```
+cursor-agent -p "say ok" --output-format stream-json --workspace /tmp --model <slug> --force
+```
+
+Exit 0 means no Max Mode needed; the `Max Mode Required` stderr means it does.
+
+The picker states this before the first turn is spent: the tuning block says the
+model runs in Max Mode and that Cursor prices those requests higher. The
+per-account advisory remains for models that failed for a different reason, for
+example an account where Max Mode itself is unavailable.
+
+## Adding to the catalog
+
+**A model** in an existing family: add the entry with its `presentation`, give
+it an `order` that places it in the ladder, and for Cursor probe each combo's
+Max Mode. Nothing in the picker changes.
+
+**A family**: add the `ModelFamily` value and its section label. Sections appear
+automatically once a provider has more than one.
+
+**A provider**: author its catalog, then extend `modelAxes` with the axes that
+provider exposes. If the new provider needs a control that is not an effort
+ladder, a variant list, or a toggle, add it to `ModelAxes` and render it in
+`AxesSection` for everyone. Do not special-case it in a mount.
+
+## Settled decisions
+
+These were tried, or shipped and reverted. Do not reintroduce them:
+
+- A flat searchable model list. It replaced the grouped picker once and lost the
+  version ladder, the cost signal, and the tuning context.
+- A native `select` for variants or effort. Every control here is a chip.
+- Deriving family, version, or cost from the model id with a regex. That is what
+  `presentation` exists to replace.
+- Hiding levels that the current toggle combination cannot reach, instead of
+  disabling them.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -227,14 +227,14 @@ agy -p <PROMPT> --model <MODEL> --sandbox
 
 ## Effort
 
-Effort is the third axis of every model picker, next to provider and model. Only Claude and Codex models carry a ladder, declared per model in `packages/core/src/providers/capabilities.ts`:
+Effort is the third axis of every model picker, next to provider and model. How the picker renders it is owned by [model-picker.md](model-picker.md); this section owns which levels each provider actually accepts. Ladders are declared per model in the provider catalogs under `packages/core/src/providers/<provider>/catalog.ts`:
 
 - **Claude Opus and Fable**: `low`, `medium`, `high`, `extra-high`, `max`.
 - **Claude Sonnet**: `low`, `medium`, `high`.
 - **Codex turn models**: `minimal`, `low`, `medium`, `high`.
 - **`gpt-5.4-mini`**: `minimal`, `low`, `medium`.
 
-Everything else has no ladder and ignores effort: `claude-haiku-4-5`, every Cursor model, every Gemini model. No effort arg is emitted for them at all. Picking a level a model does not support clamps to the top of that model's ladder (`clampEffort` in `apps/desktop/src/features/chat/utils/chat-constants.ts`).
+Cursor is the exception to the ladder shape: effort is baked into the model slug, so each catalog entry lists the combos it has and the reachable levels depend on the Thinking and Fast toggles. `claude-haiku-4-5` and every Gemini model have no ladder at all and emit no effort arg. Picking a level a model does not support clamps to the top of what it supports (`clampEffort` in `packages/core/src/providers/clampEffort.ts`).
 
 The UI label and the emitted value diverge in exactly one place: `extra-high` reads **Very high** in the picker and goes out as `xhigh` on the wire. Every other level is emitted verbatim. claude takes `--effort <level>`, codex takes `-c model_reasoning_effort="<level>"`, both built in `apps/desktop/src-tauri/src/turn.rs`.
 

--- a/packages/core/src/providers/resolveModelArgs.test.ts
+++ b/packages/core/src/providers/resolveModelArgs.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { resolveModelArgs } from './resolveModelArgs';
+
+describe('resolveModelArgs', () => {
+  it('includes Max Mode for Cursor combinations that require it', () => {
+    expect(
+      resolveModelArgs({
+        provider: 'cursor',
+        selection: { key: 'gpt-5.5', effort: 'high' },
+      }),
+    ).toEqual({
+      args: ['--model', 'gpt-5.5-high'],
+      maxMode: true,
+    });
+  });
+
+  it('keeps Max Mode when Cursor effort is clamped', () => {
+    expect(
+      resolveModelArgs({
+        provider: 'cursor',
+        selection: { key: 'gpt-5.5', effort: 'max' },
+      }),
+    ).toEqual({
+      args: ['--model', 'gpt-5.5-high'],
+      maxMode: true,
+      clamped: { requested: 'max', applied: 'high' },
+    });
+  });
+
+  it('omits Max Mode for Cursor combinations that do not require it', () => {
+    const resolved = resolveModelArgs({
+      provider: 'cursor',
+      selection: { key: 'composer-2.5' },
+    });
+
+    expect(resolved).toEqual({
+      args: ['--model', 'composer-2.5'],
+    });
+    expect(resolved).not.toHaveProperty('maxMode');
+  });
+});

--- a/packages/core/src/providers/resolveModelArgs.ts
+++ b/packages/core/src/providers/resolveModelArgs.ts
@@ -12,13 +12,18 @@ type WithClampParams = {
   readonly args: ReadonlyArray<string>;
   readonly requested: EffortLevel;
   readonly applied: EffortLevel;
+  readonly maxMode?: true;
 };
 
-const withClamp = ({ args, requested, applied }: WithClampParams): ResolvedModelArgs => {
+const withClamp = ({ args, requested, applied, maxMode }: WithClampParams): ResolvedModelArgs => {
   if (requested === applied) {
-    return { args };
+    return { args, ...(maxMode === true && { maxMode: true }) };
   }
-  return { args, clamped: { requested, applied } };
+  return {
+    args,
+    ...(maxMode === true && { maxMode: true }),
+    clamped: { requested, applied },
+  };
 };
 
 export const resolveModelArgs = ({ provider, selection }: Params): ResolvedModelArgs => {
@@ -57,12 +62,13 @@ export const resolveModelArgs = ({ provider, selection }: Params): ResolvedModel
       const combo = resolveCursorCombo({ model, selection });
       const args = ['--model', combo.slug];
       if (selection.effort == null || combo.effort == null) {
-        return { args };
+        return { args, ...(combo.maxMode === true && { maxMode: true }) };
       }
       return withClamp({
         args,
         requested: selection.effort,
         applied: combo.effort,
+        ...(combo.maxMode === true && { maxMode: true }),
       });
     }
     case 'gemini':

--- a/packages/types/src/model-catalog.ts
+++ b/packages/types/src/model-catalog.ts
@@ -126,6 +126,7 @@ export type ModelAxes = {
 
 export type ResolvedModelArgs = {
   readonly args: ReadonlyArray<string>;
+  readonly maxMode?: true;
   readonly clamped?: {
     readonly requested: EffortLevel;
     readonly applied: EffortLevel;


### PR DESCRIPTION
Cursor models that need Max Mode now run instead of failing, and the failure that used to be shown as a wall of raw JSON is readable again. Adds the model picker design doc.

## Max Mode works now

Max Mode is a persisted preference in the Cursor CLI config (`cli-config.json`, top-level `maxMode`), and the CLI resolves its config directory from `CURSOR_CONFIG_DIR` before `XDG_CONFIG_HOME/cursor` and `~/.cursor`. Chats, projects and plugins live under a separate data dir, so pointing the config dir elsewhere changes nothing else and authentication stays intact.

When a spawn resolves to a Cursor combination flagged `maxMode`, Goodboy mirrors the user's config into its own cache directory with `maxMode` set and points that single spawn at it with `CURSOR_CONFIG_DIR`. The user's config is never written to, and models that do not need Max Mode never get it.

Verified against the CLI: `gpt-5.5-high` refused every attempt before (`ActionRequiredError: Max Mode Required`, exit 1) and answers with exit 0 through the mirrored config directory.

The picker copy follows: the tuning block now says the model runs in Max Mode and that Cursor bills those requests at a higher rate, instead of claiming Goodboy cannot enable it. The warning dot on a version chip is left to the per-account advisory, which now reads as a rejection rather than a missing setting.

## The error was unreadable

Two problems stacked on the same failure. A provider that dies after emitting stream lines the app cannot model had those lines joined into the error message, and for Cursor that includes the echoed `user` frame, so the chat error rendered the entire prompt as JSON. Unparsed lines that are valid JSON are now dropped from the message, leaving the provider's own stderr. Second, the session turn state kept the raw provider dump even when a readable message had already been resolved, so the error banner stayed unreadable after the fact. It now stores the same message the transcript shows.

## Docs

`docs/model-picker.md` documents what the picker is: the catalog describes, the picker renders. It covers the anatomy, the five `presentation` fields a catalog entry must author and the invariants tests pin, the axes contract, how a selection reaches the spawn, Max Mode including how to probe a new slug, what to do when adding a model, a family, or a provider, and the settled decisions not to reintroduce.

## Verification

- `cargo test --locked`: 137 passed
- `@goodboy/core`: 916 passed
- `@goodboy/desktop`: 2913 passed
- `tsc --noEmit` and `knip --include files,duplicates,unlisted` clean
- live CLI probe of the exact runtime path, `gpt-5.5-high` exit 0

Known gap: the summarizer and planner spawns do not carry the flag, so a Cursor model that needs Max Mode still fails there.
