### PR TITLE
Diff lens: file navigation, note action, commit picker, line comments

### DIFF
--- a/apps/desktop/src/features/permissions/components/DiffViewSelector/index.test.tsx
+++ b/apps/desktop/src/features/permissions/components/DiffViewSelector/index.test.tsx
@@ -2,12 +2,32 @@
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
-import type { DiffView } from '@goodboy/types';
+import type { BranchCommit, DiffView } from '@goodboy/types';
 import { DiffViewSelector } from './index';
 
 afterEach(cleanup);
 
 const workingView: DiffView = { kind: 'working', scope: 'all' };
+const commits: ReadonlyArray<BranchCommit> = [
+  {
+    sha: 'abc123456789',
+    shortSha: 'abc1234',
+    subject: 'local change',
+    author: 'Ada',
+    timestamp: Date.now() / 1000 - 60,
+    pushed: false,
+    parentSha: null,
+  },
+  {
+    sha: 'def567856789',
+    shortSha: 'def5678',
+    subject: 'origin change',
+    author: 'Lin',
+    timestamp: Date.now() / 1000 - 120,
+    pushed: true,
+    parentSha: 'abc123456789',
+  },
+];
 
 describe('DiffViewSelector', () => {
   it('renders the current label in the trigger', () => {
@@ -51,5 +71,42 @@ describe('DiffViewSelector', () => {
     fireEvent.click(screen.getByTitle(/change diff view/i));
     fireEvent.click(screen.getByText('staged only'));
     expect(onChange).toHaveBeenCalledWith({ kind: 'working', scope: 'staged' });
+  });
+
+  it('keeps commit details and section semantics in the portaled picker', () => {
+    render(
+      <DiffViewSelector
+        view={workingView}
+        onChange={vi.fn()}
+        commits={commits}
+        status={null}
+        filesCount={2}
+      />,
+    );
+    fireEvent.click(screen.getByTitle(/change diff view/i));
+
+    expect(screen.getByText('ready to push')).toBeDefined();
+    expect(screen.getByText('abc1234')).toBeDefined();
+    expect(screen.getByText('origin change')).toBeDefined();
+    expect(screen.getByText('pushed')).toBeDefined();
+  });
+
+  it('preserves arrow and enter keyboard selection from the filter', () => {
+    const onChange = vi.fn();
+    render(
+      <DiffViewSelector
+        view={{ kind: 'branch' }}
+        onChange={onChange}
+        commits={[]}
+        status={null}
+        filesCount={null}
+      />,
+    );
+    fireEvent.click(screen.getByTitle(/change diff view/i));
+    const filter = screen.getByRole('textbox', { name: 'filter commits' });
+    fireEvent.keyDown(filter, { key: 'ArrowDown' });
+    fireEvent.keyDown(filter, { key: 'Enter' });
+
+    expect(onChange).toHaveBeenCalledWith({ kind: 'working', scope: 'all' });
   });
 });

--- a/apps/desktop/src/features/permissions/components/DiffViewSelector/index.tsx
+++ b/apps/desktop/src/features/permissions/components/DiffViewSelector/index.tsx
@@ -1,21 +1,62 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ChevronDown, GitCommit } from 'lucide-react';
-import { cn, ScrollFade } from '@goodboy/ui';
+import { Divider, Popover, ScrollFade, cn } from '@goodboy/ui';
 import type { BranchCommit, DiffView, WorktreeStatus } from '@goodboy/types';
+import { PickerSection } from '../../../../shared/components/RoutingPicker/PickerSection';
+import { DropdownPortal } from '../../../../shared/hooks/useDropdown/DropdownPortal';
+import { useDropdown } from '../../../../shared/hooks/useDropdown';
 
 type Props = {
-  view: DiffView;
-  onChange: (next: DiffView) => void;
-  commits: ReadonlyArray<BranchCommit>;
-  status: WorktreeStatus | null;
-  filesCount: number | null;
-  loading?: boolean;
+  readonly view: DiffView;
+  readonly onChange: (next: DiffView) => void;
+  readonly commits: ReadonlyArray<BranchCommit>;
+  readonly status: WorktreeStatus | null;
+  readonly filesCount: number | null;
+  readonly loading?: boolean;
 };
 
-type Row =
-  | { kind: 'header'; label: string; badge?: string }
-  | { kind: 'option'; view: DiffView; label: string; meta?: string; badge?: string }
-  | { kind: 'placeholder'; label: string };
+type OptionRow = {
+  readonly kind: 'option';
+  readonly view: DiffView;
+  readonly label: string;
+  readonly commit?: BranchCommit;
+};
+
+type PlaceholderRow = {
+  readonly kind: 'placeholder';
+  readonly label: string;
+};
+
+type SectionRow = OptionRow | PlaceholderRow;
+
+type Section = {
+  readonly label: string;
+  readonly rows: ReadonlyArray<SectionRow>;
+};
+
+type ViewLabelParams = {
+  readonly view: DiffView;
+  readonly commits: ReadonlyArray<BranchCommit>;
+};
+
+type RelativeTimeParams = {
+  readonly timestamp: number;
+};
+
+type ViewEqualsParams = {
+  readonly left: DiffView;
+  readonly right: DiffView;
+};
+
+type NextFocusIndexParams = {
+  readonly currentIndex: number;
+  readonly direction: 1 | -1;
+  readonly optionCount: number;
+};
+
+type SelectViewParams = {
+  readonly next: DiffView;
+};
 
 const SCOPE_LABEL: Record<'working' | 'unstaged' | 'staged' | 'all', string> = {
   working: 'working tree',
@@ -24,56 +65,81 @@ const SCOPE_LABEL: Record<'working' | 'unstaged' | 'staged' | 'all', string> = {
   all: 'working tree',
 };
 
-function viewLabel(view: DiffView, commits: ReadonlyArray<BranchCommit>): string {
+const viewLabel = ({ view, commits }: ViewLabelParams): string => {
   if (view.kind === 'working') {
     if (view.scope === 'all') {
       return 'working tree';
     }
+
     return SCOPE_LABEL[view.scope];
   }
+
   if (view.kind === 'commit') {
-    const found = commits.find((c) => c.sha === view.sha);
-    if (found) {
-      return `commit ${found.shortSha}`;
+    const commit = commits.find((candidate) => candidate.sha === view.sha);
+    if (commit != null) {
+      return `commit ${commit.shortSha}`;
     }
+
     return `commit ${view.sha.slice(0, 7)}`;
   }
-  return 'branch vs main';
-}
 
-function relativeTime(ts: number): string {
+  return 'branch vs main';
+};
+
+const relativeTime = ({ timestamp }: RelativeTimeParams): string => {
   const now = Date.now() / 1000;
-  const delta = Math.max(0, now - ts);
+  const delta = Math.max(0, now - timestamp);
   if (delta < 60) {
     return `${Math.floor(delta)}s`;
   }
+
   if (delta < 3600) {
     return `${Math.floor(delta / 60)}min`;
   }
+
   if (delta < 86400) {
     return `${Math.floor(delta / 3600)}h`;
   }
+
   if (delta < 86400 * 7) {
     return `${Math.floor(delta / 86400)}d`;
   }
+
   if (delta < 86400 * 30) {
     return `${Math.floor(delta / (86400 * 7))}w`;
   }
-  return `${Math.floor(delta / (86400 * 30))}mo`;
-}
 
-function viewEquals(a: DiffView, b: DiffView): boolean {
-  if (a.kind !== b.kind) {
+  return `${Math.floor(delta / (86400 * 30))}mo`;
+};
+
+const viewEquals = ({ left, right }: ViewEqualsParams): boolean => {
+  if (left.kind !== right.kind) {
     return false;
   }
-  if (a.kind === 'working' && b.kind === 'working') {
-    return a.scope === b.scope;
+
+  if (left.kind === 'working' && right.kind === 'working') {
+    return left.scope === right.scope;
   }
-  if (a.kind === 'commit' && b.kind === 'commit') {
-    return a.sha === b.sha;
+
+  if (left.kind === 'commit' && right.kind === 'commit') {
+    return left.sha === right.sha;
   }
+
   return true;
-}
+};
+
+const nextFocusIndex = ({ currentIndex, direction, optionCount }: NextFocusIndexParams): number => {
+  if (optionCount === 0) {
+    return -1;
+  }
+
+  if (currentIndex < 0) {
+    return direction === 1 ? 0 : optionCount - 1;
+  }
+
+  const nextIndex = currentIndex + direction;
+  return Math.max(0, Math.min(optionCount - 1, nextIndex));
+};
 
 export const DiffViewSelector = ({
   view,
@@ -83,164 +149,171 @@ export const DiffViewSelector = ({
   filesCount,
   loading,
 }: Props) => {
-  const [open, setOpen] = useState(false);
+  const {
+    open,
+    close,
+    toggle,
+    containerRef,
+    popupRef,
+    popupClassName,
+    popupStyle,
+    portal,
+    portalTarget,
+  } = useDropdown({
+    expectedHeight: 440,
+    expectedWidth: 440,
+    width: 'w-[440px] max-w-[calc(100vw-2rem)]',
+    strategy: 'fixed',
+  });
   const [query, setQuery] = useState('');
-  const [focusIdx, setFocusIdx] = useState(0);
-  const rootRef = useRef<HTMLDivElement>(null);
+  const [focusIndex, setFocusIndex] = useState(-1);
   const searchRef = useRef<HTMLInputElement>(null);
-
-  const localCommits = useMemo(() => commits.filter((c) => !c.pushed), [commits]);
-  const pushedCommits = useMemo(() => commits.filter((c) => c.pushed), [commits]);
+  const localCommits = useMemo(() => commits.filter((commit) => !commit.pushed), [commits]);
+  const pushedCommits = useMemo(() => commits.filter((commit) => commit.pushed), [commits]);
 
   const filterMatch = useCallback(
-    (c: BranchCommit) => {
-      const q = query.trim().toLowerCase();
-      if (q.length === 0) {
+    (commit: BranchCommit) => {
+      const normalizedQuery = query.trim().toLowerCase();
+      if (normalizedQuery.length === 0) {
         return true;
       }
-      return c.shortSha.includes(q) || c.subject.toLowerCase().includes(q);
+
+      return (
+        commit.shortSha.toLowerCase().includes(normalizedQuery) ||
+        commit.subject.toLowerCase().includes(normalizedQuery)
+      );
     },
     [query],
   );
 
-  const rows = useMemo<Row[]>(() => {
-    const out: Row[] = [];
-    out.push({ kind: 'header', label: 'currently editing' });
-    out.push({ kind: 'option', view: { kind: 'working', scope: 'all' }, label: 'working tree' });
-    out.push({
-      kind: 'option',
-      view: { kind: 'working', scope: 'staged' },
-      label: 'staged only',
-    });
-    out.push({
-      kind: 'option',
-      view: { kind: 'working', scope: 'unstaged' },
-      label: 'unstaged only',
-    });
+  const sections = useMemo<ReadonlyArray<Section>>(() => {
+    const filteredLocalCommits = localCommits.filter(filterMatch);
+    const readyRows: ReadonlyArray<SectionRow> =
+      localCommits.length === 0
+        ? [{ kind: 'placeholder', label: 'nothing to push' }]
+        : filteredLocalCommits.length === 0
+          ? [{ kind: 'placeholder', label: 'no match' }]
+          : filteredLocalCommits.map((commit) => ({
+              kind: 'option',
+              view: { kind: 'commit', sha: commit.sha },
+              label: commit.subject,
+              commit,
+            }));
+    const filteredPushedCommits = pushedCommits.filter(filterMatch);
+    const originRows: ReadonlyArray<SectionRow> =
+      pushedCommits.length === 0
+        ? [
+            {
+              kind: 'placeholder',
+              label:
+                status?.hasUpstream === false ? 'branch not pushed yet' : 'no commits pushed yet',
+            },
+          ]
+        : filteredPushedCommits.length === 0
+          ? [{ kind: 'placeholder', label: 'no match' }]
+          : filteredPushedCommits.map((commit) => ({
+              kind: 'option',
+              view: { kind: 'commit', sha: commit.sha },
+              label: commit.subject,
+              commit,
+            }));
 
-    const filteredLocal = localCommits.filter(filterMatch);
-    out.push({ kind: 'header', label: 'ready to push' });
-    if (localCommits.length === 0) {
-      out.push({ kind: 'placeholder', label: 'nothing to push' });
-    } else if (filteredLocal.length === 0) {
-      out.push({ kind: 'placeholder', label: 'no match' });
-    } else {
-      for (const c of filteredLocal) {
-        out.push({
-          kind: 'option',
-          view: { kind: 'commit', sha: c.sha },
-          label: `${c.shortSha}  ${c.subject}`,
-          meta: relativeTime(c.timestamp),
-        });
-      }
-    }
+    return [
+      {
+        label: 'currently editing',
+        rows: [
+          {
+            kind: 'option',
+            view: { kind: 'working', scope: 'all' },
+            label: 'working tree',
+          },
+          {
+            kind: 'option',
+            view: { kind: 'working', scope: 'staged' },
+            label: 'staged only',
+          },
+          {
+            kind: 'option',
+            view: { kind: 'working', scope: 'unstaged' },
+            label: 'unstaged only',
+          },
+        ],
+      },
+      { label: 'ready to push', rows: readyRows },
+      { label: 'on origin', rows: originRows },
+      {
+        label: 'presets',
+        rows: [{ kind: 'option', view: { kind: 'branch' }, label: 'branch vs main' }],
+      },
+    ];
+  }, [filterMatch, localCommits, pushedCommits, status?.hasUpstream]);
 
-    const filteredPushed = pushedCommits.filter(filterMatch);
-    out.push({ kind: 'header', label: 'on origin' });
-    if (pushedCommits.length === 0) {
-      out.push({
-        kind: 'placeholder',
-        label: status?.hasUpstream === false ? 'branch not pushed yet' : 'no commits pushed yet',
-      });
-    } else if (filteredPushed.length === 0) {
-      out.push({ kind: 'placeholder', label: 'no match' });
-    } else {
-      for (const c of filteredPushed) {
-        out.push({
-          kind: 'option',
-          view: { kind: 'commit', sha: c.sha },
-          label: `${c.shortSha}  ${c.subject}`,
-          meta: relativeTime(c.timestamp),
-        });
-      }
-    }
-
-    out.push({ kind: 'header', label: 'presets' });
-    out.push({ kind: 'option', view: { kind: 'branch' }, label: 'branch vs main' });
-
-    return out;
-  }, [localCommits, pushedCommits, filterMatch, query, status]);
-
-  const optionIndices = useMemo(
+  const options = useMemo(
     () =>
-      rows.reduce<number[]>((acc, r, i) => {
-        if (r.kind === 'option') {
-          acc.push(i);
-        }
-        return acc;
-      }, []),
-    [rows],
+      sections.flatMap((section) =>
+        section.rows.filter((row): row is OptionRow => row.kind === 'option'),
+      ),
+    [sections],
   );
 
   useEffect(() => {
     if (!open) {
       return;
     }
-    const handler = (e: MouseEvent) => {
-      if (!rootRef.current) {
-        return;
-      }
-      if (!rootRef.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
-    };
-    document.addEventListener('mousedown', handler);
-    return () => document.removeEventListener('mousedown', handler);
+
+    setQuery('');
+    setFocusIndex(-1);
+    const focusTimer = window.setTimeout(() => searchRef.current?.focus(), 0);
+    return () => window.clearTimeout(focusTimer);
   }, [open]);
 
-  useEffect(() => {
-    if (open) {
-      setQuery('');
-      setFocusIdx(0);
-      window.setTimeout(() => searchRef.current?.focus(), 0);
-    }
-  }, [open]);
+  const selectView = ({ next }: SelectViewParams) => {
+    onChange(next);
+    close();
+  };
 
-  const moveFocus = (dir: 1 | -1) => {
-    if (optionIndices.length === 0) {
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      setFocusIndex((currentIndex) =>
+        nextFocusIndex({ currentIndex, direction: 1, optionCount: options.length }),
+      );
       return;
     }
-    const currentPos = optionIndices.findIndex((i) => i === focusIdx);
-    const startPos = currentPos === -1 ? (dir === 1 ? -1 : optionIndices.length) : currentPos;
-    const nextPos = Math.max(0, Math.min(optionIndices.length - 1, startPos + dir));
-    const targetIdx = optionIndices[nextPos];
-    if (targetIdx !== undefined) {
-      setFocusIdx(targetIdx);
+
+    if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      setFocusIndex((currentIndex) =>
+        nextFocusIndex({ currentIndex, direction: -1, optionCount: options.length }),
+      );
+      return;
     }
-  };
 
-  const commitOption = (v: DiffView) => {
-    onChange(v);
-    setOpen(false);
-  };
-
-  const handleKey = (e: React.KeyboardEvent<HTMLDivElement>) => {
-    if (e.key === 'ArrowDown') {
-      e.preventDefault();
-      moveFocus(1);
-    } else if (e.key === 'ArrowUp') {
-      e.preventDefault();
-      moveFocus(-1);
-    } else if (e.key === 'Enter') {
-      e.preventDefault();
-      const row = rows[focusIdx];
-      if (row?.kind === 'option') {
-        commitOption(row.view);
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      const focusedOption = options[focusIndex];
+      if (focusedOption != null) {
+        selectView({ next: focusedOption.view });
       }
-    } else if (e.key === 'Escape') {
-      e.preventDefault();
-      setOpen(false);
+      return;
+    }
+
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      close();
     }
   };
 
-  const label = viewLabel(view, commits);
-  const countStr = filesCount === null ? '' : ` · ${filesCount} file${filesCount === 1 ? '' : 's'}`;
+  const label = viewLabel({ view, commits });
+  const countLabel =
+    filesCount === null ? '' : ` · ${filesCount} file${filesCount === 1 ? '' : 's'}`;
+  let optionIndex = -1;
 
   return (
-    <div ref={rootRef} className="relative">
+    <div ref={containerRef} className="relative">
       <button
         type="button"
-        onClick={() => setOpen((v) => !v)}
+        onClick={toggle}
         className={cn(
           'inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-2 py-1 text-xs',
           'hover:border-foreground/30 hover:bg-muted/30',
@@ -253,104 +326,114 @@ export const DiffViewSelector = ({
         {loading ? (
           <span className="text-muted-foreground/60">…</span>
         ) : (
-          <span className="text-muted-foreground/70 tabular-nums">{countStr}</span>
+          <span className="text-muted-foreground/70 tabular-nums">{countLabel}</span>
         )}
         <ChevronDown size={11} aria-hidden className="text-muted-foreground/70" />
       </button>
 
-      {open ? (
-        // eslint-disable-next-line jsx-a11y/no-static-element-interactions -- captures keys for menu nav
-        <div
-          className="absolute left-0 top-[calc(100%+4px)] z-50 w-[440px] overflow-hidden rounded-md border border-border bg-subtle shadow-lg"
-          onKeyDown={handleKey}
-        >
-          <div className="border-b border-border-soft px-2 py-1.5">
-            <input
-              ref={searchRef}
-              value={query}
-              onChange={(e) => {
-                setQuery(e.target.value);
-                setFocusIdx(0);
-              }}
-              placeholder="filter commits by sha or subject…"
-              className="w-full bg-transparent text-xs outline-none placeholder:text-muted-foreground/60"
-              aria-label="filter commits"
-            />
-          </div>
-          <ScrollFade className="max-h-[400px] py-1">
-            {rows.map((row, i) => {
-              if (row.kind === 'header') {
-                return (
-                  <div
-                    key={`h-${i}`}
-                    className="mt-1 flex items-center justify-between px-2 pb-0.5 pt-1.5 text-[9px] font-semibold uppercase tracking-wider text-muted-foreground/60"
-                  >
-                    <span>{row.label}</span>
-                    {row.badge ? (
-                      <span className="rounded-sm bg-warning/15 px-1 py-px text-[8px] font-medium text-warning">
-                        {row.badge}
-                      </span>
-                    ) : null}
-                  </div>
-                );
-              }
-              if (row.kind === 'placeholder') {
-                return (
-                  <div
-                    key={`p-${i}`}
-                    className="px-2 py-1 text-[11px] italic text-muted-foreground/50"
-                  >
-                    {row.label}
-                  </div>
-                );
-              }
-              const isActive = viewEquals(view, row.view);
-              const isFocused = i === focusIdx;
-              return (
-                <button
-                  key={`o-${i}`}
-                  type="button"
-                  onMouseEnter={() => setFocusIdx(i)}
-                  onClick={() => commitOption(row.view)}
-                  className={cn(
-                    'flex w-full items-center gap-2 px-2 py-1 text-left text-xs',
-                    isFocused ? 'bg-muted/60' : 'hover:bg-muted/30',
-                  )}
-                >
-                  <span
-                    className={cn(
-                      'w-2 shrink-0 text-center text-[10px]',
-                      isActive ? 'text-primary' : 'text-transparent',
-                    )}
-                    aria-hidden
-                  >
-                    ●
-                  </span>
-                  <span
-                    className={cn(
-                      'min-w-0 flex-1 truncate font-mono',
-                      isActive ? 'text-foreground' : 'text-foreground/85',
-                    )}
-                    title={row.label}
-                  >
-                    {row.label}
-                  </span>
-                  {row.badge ? (
-                    <span className="shrink-0 rounded-sm bg-warning/15 px-1 py-px text-[8px] font-medium text-warning">
-                      {row.badge}
-                    </span>
-                  ) : null}
-                  {row.meta ? (
-                    <span className="shrink-0 text-[10px] tabular-nums text-muted-foreground/70">
-                      {row.meta}
-                    </span>
-                  ) : null}
-                </button>
-              );
-            })}
-          </ScrollFade>
-        </div>
-      ) : null}
+      <DropdownPortal portal={portal} portalTarget={portalTarget}>
+        {open && (
+          <Popover
+            innerRef={popupRef}
+            role="dialog"
+            ariaLabel="diff view"
+            className={cn(popupClassName, 'flex flex-col bg-subtle')}
+            style={popupStyle}
+          >
+            <div className="px-2.5 py-2">
+              <input
+                ref={searchRef}
+                value={query}
+                onChange={(event) => {
+                  setQuery(event.target.value);
+                  setFocusIndex(-1);
+                }}
+                onKeyDown={handleKeyDown}
+                placeholder="filter commits by sha or subject…"
+                className="w-full bg-transparent text-xs outline-none placeholder:text-muted-foreground/60"
+                aria-label="filter commits"
+              />
+            </div>
+            <Divider />
+            <ScrollFade fadeFrom="subtle" className="max-h-[400px]">
+              <div className="flex flex-col gap-0.5 py-1" onKeyDown={handleKeyDown}>
+                {sections.map((section) => (
+                  <PickerSection key={section.label} label={section.label}>
+                    <div className="flex flex-col gap-0.5 px-1">
+                      {section.rows.map((row) => {
+                        if (row.kind === 'placeholder') {
+                          return (
+                            <span
+                              key={`${section.label}-${row.label}`}
+                              className="px-1.5 py-1 text-[11px] italic text-muted-foreground/50"
+                            >
+                              {row.label}
+                            </span>
+                          );
+                        }
+
+                        optionIndex += 1;
+                        const currentOptionIndex = optionIndex;
+                        const isActive = viewEquals({ left: view, right: row.view });
+                        const isFocused = currentOptionIndex === focusIndex;
+                        return (
+                          <button
+                            key={`${section.label}-${row.label}-${currentOptionIndex}`}
+                            type="button"
+                            aria-pressed={isActive}
+                            onMouseEnter={() => setFocusIndex(currentOptionIndex)}
+                            onClick={() => selectView({ next: row.view })}
+                            className={cn(
+                              'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs transition-colors',
+                              isActive
+                                ? 'bg-background text-foreground shadow-sm ring-1 ring-inset ring-border-soft'
+                                : 'text-foreground/85 hover:bg-background/60',
+                              isFocused && !isActive && 'bg-background/60 text-foreground',
+                            )}
+                          >
+                            <span
+                              aria-hidden
+                              className={cn(
+                                'size-1.5 shrink-0 rounded-full ring-1 ring-inset',
+                                isActive
+                                  ? 'bg-primary ring-primary/40'
+                                  : 'bg-transparent ring-transparent',
+                              )}
+                            />
+                            {row.commit != null ? (
+                              <>
+                                <span className="shrink-0 font-mono text-2xs text-muted-foreground">
+                                  {row.commit.shortSha}
+                                </span>
+                                <span
+                                  className="min-w-0 flex-1 truncate"
+                                  title={row.commit.subject}
+                                >
+                                  {row.commit.subject}
+                                </span>
+                                {row.commit.pushed && (
+                                  <span className="shrink-0 rounded-full bg-muted px-1.5 py-0.5 text-[9px] font-medium text-muted-foreground">
+                                    pushed
+                                  </span>
+                                )}
+                                <span className="shrink-0 text-[10px] tabular-nums text-muted-foreground/70">
+                                  {relativeTime({ timestamp: row.commit.timestamp })}
+                                </span>
+                              </>
+                            ) : (
+                              <span className="min-w-0 flex-1 truncate">{row.label}</span>
+                            )}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </PickerSection>
+                ))}
+              </div>
+            </ScrollFade>
+          </Popover>
+        )}
+      </DropdownPortal>
     </div>
   );
 };

--- a/apps/desktop/src/features/permissions/components/DiffViewerDialog/DiffViewerContent.tsx
+++ b/apps/desktop/src/features/permissions/components/DiffViewerDialog/DiffViewerContent.tsx
@@ -195,6 +195,10 @@ const writeSidebarPref = (collapsed: boolean): void => {
 
 type ReviewedMap = Record<string, string>;
 
+type RegisterFileRefParams = {
+  path: string;
+};
+
 const viewKeyOf = (view: DiffView): string => {
   if (view.kind === 'commit') {
     return `commit:${view.sha}`;
@@ -266,6 +270,8 @@ export const DiffViewerContent = ({
   const [sidebarCollapsed, setSidebarCollapsed] = useState(readSidebarPref);
   const [activePath, setActivePath] = useState<string | null>(null);
   const fileRefs = useRef<Map<string, HTMLElement>>(new Map());
+  const fileRefCallbacks = useRef<Map<string, React.RefCallback<HTMLElement>>>(new Map());
+  const intersectionObserverRef = useRef<IntersectionObserver | null>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const didInitialScroll = useRef(false);
   const pendingScrollPath = useRef<string | null>(null);
@@ -578,22 +584,40 @@ export const DiffViewerContent = ({
       scrollRef.current?.querySelector<HTMLElement>('.overflow-y-auto') ?? scrollRef.current;
     const obs = new IntersectionObserver(
       (entries) => {
-        for (const e of entries) {
-          if (e.isIntersecting) {
-            const p = e.target.getAttribute('data-file-path');
-            if (p) {
-              setActivePath(p);
-            }
+        let topmostEntry: IntersectionObserverEntry | null = null;
+        for (const entry of entries) {
+          if (!entry.isIntersecting) {
+            continue;
           }
+          if (
+            topmostEntry !== null &&
+            entry.boundingClientRect.top >= topmostEntry.boundingClientRect.top
+          ) {
+            continue;
+          }
+          topmostEntry = entry;
+        }
+        if (topmostEntry === null) {
+          return;
+        }
+        const path = topmostEntry.target.getAttribute('data-file-path');
+        if (path !== null) {
+          setActivePath(path);
         }
       },
       { root: viewport, rootMargin: '0px 0px -70% 0px', threshold: 0 },
     );
+    intersectionObserverRef.current = obs;
     for (const el of fileRefs.current.values()) {
       obs.observe(el);
     }
-    return () => obs.disconnect();
-  }, [files, mountedCount]);
+    return () => {
+      obs.disconnect();
+      if (intersectionObserverRef.current === obs) {
+        intersectionObserverRef.current = null;
+      }
+    };
+  }, [files]);
 
   const toggleSidebar = () => {
     setSidebarCollapsed((v) => {
@@ -726,16 +750,28 @@ export const DiffViewerContent = ({
     await addDiffComment(sessionId, filePath, body);
   };
 
-  const registerFileRef = useCallback(
-    (path: string) => (el: HTMLElement | null) => {
-      if (el) {
-        fileRefs.current.set(path, el);
-      } else {
-        fileRefs.current.delete(path);
+  const registerFileRef = useCallback(({ path }: RegisterFileRefParams) => {
+    const existingCallback = fileRefCallbacks.current.get(path);
+    if (existingCallback !== undefined) {
+      return existingCallback;
+    }
+
+    const callback: React.RefCallback<HTMLElement> = (element) => {
+      const previousElement = fileRefs.current.get(path);
+      if (previousElement !== undefined && previousElement !== element) {
+        intersectionObserverRef.current?.unobserve(previousElement);
       }
-    },
-    [],
-  );
+      if (element === null) {
+        fileRefs.current.delete(path);
+        return;
+      }
+
+      fileRefs.current.set(path, element);
+      intersectionObserverRef.current?.observe(element);
+    };
+    fileRefCallbacks.current.set(path, callback);
+    return callback;
+  }, []);
 
   const isEmpty = !loading && !error && files.length === 0;
   const isPane = presentation === 'pane';
@@ -988,7 +1024,7 @@ export const DiffViewerContent = ({
                   <FileDiffCard
                     key={file.path}
                     file={file}
-                    registerRef={registerFileRef(file.path)}
+                    registerRef={registerFileRef({ path: file.path })}
                     reviewState={reviewStateByPath.get(file.path) ?? 'none'}
                     onToggleReviewed={(next) => toggleReviewed(file, next)}
                     canOpenEditor={Boolean(workingDir)}

--- a/apps/desktop/src/features/permissions/components/DiffViewerDialog/DiffViewerContent.tsx
+++ b/apps/desktop/src/features/permissions/components/DiffViewerDialog/DiffViewerContent.tsx
@@ -268,6 +268,7 @@ export const DiffViewerContent = ({
   const fileRefs = useRef<Map<string, HTMLElement>>(new Map());
   const scrollRef = useRef<HTMLDivElement>(null);
   const didInitialScroll = useRef(false);
+  const pendingScrollPath = useRef<string | null>(null);
 
   const [view, setViewState] = useState<DiffView>(
     () => readPersistedView(sessionId) ?? DEFAULT_VIEW,
@@ -455,6 +456,7 @@ export const DiffViewerContent = ({
   }, [view, refreshTick]);
 
   useLayoutEffect(() => {
+    pendingScrollPath.current = null;
     setMountedCount(DIFF_BATCH_SIZE);
   }, [files]);
 
@@ -513,9 +515,43 @@ export const DiffViewerContent = ({
     }
   }, [sessionId, loadDiffComments]);
 
-  const scrollToFile = useCallback((path: string) => {
-    fileRefs.current.get(path)?.scrollIntoView({ block: 'start', behavior: 'smooth' });
-  }, []);
+  const scrollToFile = useCallback(
+    (path: string) => {
+      const fileElement = fileRefs.current.get(path);
+      if (fileElement != null) {
+        fileElement.scrollIntoView({ block: 'start', behavior: 'smooth' });
+        return;
+      }
+
+      const fileIndex = files.findIndex((file) => file.path === path);
+      if (fileIndex < 0) {
+        return;
+      }
+
+      pendingScrollPath.current = path;
+      const requiredCount = Math.min(
+        Math.ceil((fileIndex + 1) / DIFF_BATCH_SIZE) * DIFF_BATCH_SIZE,
+        files.length,
+      );
+      setMountedCount((currentCount) => Math.max(currentCount, requiredCount));
+    },
+    [files],
+  );
+
+  useEffect(() => {
+    const path = pendingScrollPath.current;
+    if (path == null) {
+      return;
+    }
+
+    const fileElement = fileRefs.current.get(path);
+    if (fileElement == null) {
+      return;
+    }
+
+    pendingScrollPath.current = null;
+    fileElement.scrollIntoView({ block: 'start', behavior: 'smooth' });
+  }, [mountedCount]);
 
   useEffect(() => {
     if (files.length === 0 || didInitialScroll.current) {
@@ -557,7 +593,7 @@ export const DiffViewerContent = ({
       obs.observe(el);
     }
     return () => obs.disconnect();
-  }, [files]);
+  }, [files, mountedCount]);
 
   const toggleSidebar = () => {
     setSidebarCollapsed((v) => {

--- a/apps/desktop/src/features/permissions/components/DiffViewerDialog/FileDiffCard.tsx
+++ b/apps/desktop/src/features/permissions/components/DiffViewerDialog/FileDiffCard.tsx
@@ -1,6 +1,6 @@
 import { Fragment, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { Check, ChevronRight, Copy, ExternalLink, MessageSquarePlus } from 'lucide-react';
-import { Divider, cn } from '@goodboy/ui';
+import { Divider, Tooltip, cn } from '@goodboy/ui';
 import { useToast } from '../../../../app/components/Toast';
 import type {
   AgentId,
@@ -279,33 +279,50 @@ export const FileDiffCard = ({
             {file.additions > 0 && file.deletions > 0 && <span className="opacity-40"> </span>}
             {file.deletions > 0 && <span className="text-danger">−{file.deletions}</span>}
           </span>
-          <div className="flex shrink-0 items-center gap-0.5">
-            <button
-              type="button"
-              onClick={copyPath}
-              title="copy path"
-              aria-label="copy file path"
-              className={TOOLBAR_ICON_BTN}
-            >
-              {pathCopied ? <Check size={12} aria-hidden /> : <Copy size={12} aria-hidden />}
-            </button>
-            {canOpenEditor ? (
+          <div className="flex shrink-0 items-center gap-1">
+            <Tooltip content="copy path">
               <button
                 type="button"
-                onClick={onOpenInEditor}
-                title="open file in editor"
-                aria-label="open file in editor"
+                onClick={copyPath}
+                aria-label="copy file path"
                 className={TOOLBAR_ICON_BTN}
               >
-                <ExternalLink size={12} />
+                {pathCopied ? <Check size={12} aria-hidden /> : <Copy size={12} aria-hidden />}
               </button>
+            </Tooltip>
+            {canOpenEditor ? (
+              <Tooltip content="open file in editor">
+                <button
+                  type="button"
+                  onClick={onOpenInEditor}
+                  aria-label="open file in editor"
+                  className={TOOLBAR_ICON_BTN}
+                >
+                  <ExternalLink size={12} aria-hidden />
+                </button>
+              </Tooltip>
+            ) : null}
+            {canComment ? (
+              <Tooltip content="add file note">
+                <button
+                  type="button"
+                  onClick={() => {
+                    setCollapsed(false);
+                    setFileLevelComposerOpen(true);
+                  }}
+                  aria-label="add file note"
+                  className={TOOLBAR_ICON_BTN}
+                >
+                  <MessageSquarePlus size={12} aria-hidden />
+                </button>
+              </Tooltip>
             ) : null}
             <button
               type="button"
               onClick={handleToggleReviewed}
               title={isReviewed ? 'mark as not reviewed' : 'mark as reviewed'}
               className={cn(
-                'ml-1 inline-flex items-center gap-1 rounded-sm border px-1.5 py-0.5 text-[10px] font-medium transition-colors',
+                'inline-flex items-center gap-1 rounded-sm border px-1.5 py-0.5 text-[10px] font-medium transition-colors',
                 isReviewed
                   ? 'border-success/40 bg-success/10 text-success'
                   : 'border-border text-muted-foreground hover:bg-muted hover:text-foreground',
@@ -351,22 +368,9 @@ export const FileDiffCard = ({
           ) : null}
           {fileLevelComments.length > 0 || fileLevelComposerOpen ? (
             <div className="mb-3 flex flex-col gap-1.5">
-              <div className="flex items-center justify-between">
-                <span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
-                  file notes
-                </span>
-                {canComment && !fileLevelComposerOpen ? (
-                  <button
-                    type="button"
-                    onClick={() => setFileLevelComposerOpen(true)}
-                    title="add file-level note"
-                    aria-label="add file-level note"
-                    className="rounded-sm p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
-                  >
-                    <MessageSquarePlus size={11} aria-hidden />
-                  </button>
-                ) : null}
-              </div>
+              <span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                file notes
+              </span>
               {fileLevelComments.map((c) => (
                 <CommentItem
                   key={c.id}
@@ -384,18 +388,6 @@ export const FileDiffCard = ({
                   onCancel={() => setFileLevelComposerOpen(false)}
                 />
               ) : null}
-            </div>
-          ) : canComment ? (
-            <div className="mb-3">
-              <button
-                type="button"
-                onClick={() => setFileLevelComposerOpen(true)}
-                title="add file-level note"
-                className="flex items-center gap-1 rounded-sm px-1 py-0.5 text-[10px] text-muted-foreground hover:bg-muted hover:text-foreground"
-              >
-                <MessageSquarePlus size={10} aria-hidden />
-                Add file note
-              </button>
             </div>
           ) : null}
           {file.binary ? (
@@ -415,7 +407,7 @@ export const FileDiffCard = ({
                     if (row.type === 'header') {
                       return (
                         <tr key={`hunk-${row.hi}`}>
-                          <td colSpan={4} className="border-y border-border-soft/40 bg-muted/30">
+                          <td colSpan={3} className="border-y border-border-soft/40 bg-muted/30">
                             <div
                               className={cn(
                                 DIFF_SCROLL_CONTENT_CLASS,
@@ -457,8 +449,28 @@ export const FileDiffCard = ({
                           )}
                         >
                           <td
+                            onPointerDown={
+                              canComment && anchor !== null
+                                ? (event) => {
+                                    event.preventDefault();
+                                    setDrag({
+                                      side: anchor.side,
+                                      start: anchor.lineNumber,
+                                      end: anchor.lineNumber,
+                                    });
+                                  }
+                                : undefined
+                            }
+                            aria-label={
+                              canComment && anchor !== null
+                                ? `comment on line ${anchor.lineNumber}`
+                                : undefined
+                            }
                             className={cn(
-                              'w-6 select-none border-l-2 px-0.5 align-top',
+                              'w-9 select-none border-l-2 px-1.5 text-right text-[10px] tabular-nums text-muted-foreground/50',
+                              canComment &&
+                                anchor !== null &&
+                                'cursor-pointer transition-colors hover:bg-muted hover:text-foreground',
                               rangeCommented
                                 ? 'border-warning/60'
                                 : line.kind === 'add'
@@ -468,34 +480,33 @@ export const FileDiffCard = ({
                                     : 'border-transparent',
                             )}
                           >
-                            {canComment && anchor ? (
-                              <button
-                                type="button"
-                                onPointerDown={(e) => {
-                                  e.preventDefault();
-                                  setDrag({
-                                    side: anchor.side,
-                                    start: anchor.lineNumber,
-                                    end: anchor.lineNumber,
-                                  });
-                                }}
-                                title="comment on this line (drag to select a range)"
-                                aria-label="comment on this line"
-                                className={cn(
-                                  'flex h-4 w-4 items-center justify-center rounded-sm text-muted-foreground transition-opacity hover:bg-muted hover:text-foreground',
-                                  isActive || selecting
-                                    ? 'opacity-100'
-                                    : 'opacity-0 group-hover:opacity-100',
-                                )}
-                              >
-                                <MessageSquarePlus size={9} aria-hidden />
-                              </button>
-                            ) : null}
-                          </td>
-                          <td className="w-9 select-none px-1.5 text-right text-[10px] tabular-nums text-muted-foreground/50">
                             {line.oldLine ?? ''}
                           </td>
-                          <td className="w-9 select-none border-r border-border-soft/40 px-1.5 text-right text-[10px] tabular-nums text-muted-foreground/50">
+                          <td
+                            onPointerDown={
+                              canComment && anchor !== null
+                                ? (event) => {
+                                    event.preventDefault();
+                                    setDrag({
+                                      side: anchor.side,
+                                      start: anchor.lineNumber,
+                                      end: anchor.lineNumber,
+                                    });
+                                  }
+                                : undefined
+                            }
+                            aria-label={
+                              canComment && anchor !== null
+                                ? `comment on line ${anchor.lineNumber}`
+                                : undefined
+                            }
+                            className={cn(
+                              'w-9 select-none border-r border-border-soft/40 px-1.5 text-right text-[10px] tabular-nums text-muted-foreground/50',
+                              canComment &&
+                                anchor !== null &&
+                                'cursor-pointer transition-colors hover:bg-muted hover:text-foreground',
+                            )}
+                          >
                             {line.newLine ?? ''}
                           </td>
                           <td className="whitespace-pre px-2.5 text-foreground/80">
@@ -527,7 +538,7 @@ export const FileDiffCard = ({
                         </tr>
                         {lineComments.length > 0 && (
                           <tr>
-                            <td colSpan={4} className="bg-background">
+                            <td colSpan={3} className="bg-background">
                               <div
                                 data-diff-scroll-content
                                 className={cn(
@@ -558,7 +569,7 @@ export const FileDiffCard = ({
                         )}
                         {isActive && anchor ? (
                           <tr>
-                            <td colSpan={4} className="bg-background">
+                            <td colSpan={3} className="bg-background">
                               <div
                                 data-diff-scroll-content
                                 className={cn(DIFF_SCROLL_CONTENT_CLASS, 'px-3 py-2')}
@@ -583,7 +594,7 @@ export const FileDiffCard = ({
                   })}
                   {remaining > 0 && (
                     <tr>
-                      <td colSpan={4}>
+                      <td colSpan={3}>
                         <div data-diff-scroll-content className={DIFF_SCROLL_CONTENT_CLASS}>
                           <ShowMoreBar
                             step={Math.min(VISIBLE_LINES_STEP, remaining)}

--- a/apps/desktop/src/features/permissions/components/DiffViewerDialog/FileDiffCard.tsx
+++ b/apps/desktop/src/features/permissions/components/DiffViewerDialog/FileDiffCard.tsx
@@ -18,7 +18,6 @@ import {
   TOOLBAR_ICON_BTN,
   VISIBLE_LINES_STEP,
   anchorKey,
-  lineAnchor,
   type ReviewState,
 } from './lib';
 import { CommentItem } from './comments/CommentItem';
@@ -421,28 +420,51 @@ export const FileDiffCard = ({
                       );
                     }
                     const { line, hi, li } = row;
-                    const anchor = lineAnchor(line);
-                    const lineComments = anchor
-                      ? (commentsByAnchor.get(anchorKey(anchor)) ?? [])
-                      : [];
-                    const isActive =
-                      anchor !== null &&
+                    const oldAnchor: DiffCommentAnchor | null =
+                      line.oldLine === null ? null : { side: 'old', lineNumber: line.oldLine };
+                    const newAnchor: DiffCommentAnchor | null =
+                      line.newLine === null ? null : { side: 'new', lineNumber: line.newLine };
+                    const lineComments = [
+                      ...(oldAnchor === null
+                        ? []
+                        : (commentsByAnchor.get(anchorKey(oldAnchor)) ?? [])),
+                      ...(newAnchor === null
+                        ? []
+                        : (commentsByAnchor.get(anchorKey(newAnchor)) ?? [])),
+                    ];
+                    const isActiveOld =
+                      oldAnchor !== null &&
                       activeAnchor !== null &&
-                      activeAnchor.side === anchor.side &&
-                      activeAnchor.lineNumber === anchor.lineNumber;
+                      activeAnchor.side === oldAnchor.side &&
+                      activeAnchor.lineNumber === oldAnchor.lineNumber;
+                    const isActiveNew =
+                      newAnchor !== null &&
+                      activeAnchor !== null &&
+                      activeAnchor.side === newAnchor.side &&
+                      activeAnchor.lineNumber === newAnchor.lineNumber;
+                    const isActive = isActiveOld || isActiveNew;
                     const linePrefix = LINE_PREFIX[line.kind];
-                    const rangeCommented = anchor !== null && commentedRange.has(anchorKey(anchor));
-                    const selecting = inDrag(anchor);
+                    const oldRangeCommented =
+                      oldAnchor !== null && commentedRange.has(anchorKey(oldAnchor));
+                    const dragAnchor =
+                      drag?.side === 'old' ? oldAnchor : drag?.side === 'new' ? newAnchor : null;
+                    const selecting = inDrag(dragAnchor);
                     return (
                       <Fragment key={`hunk-${hi}-line-${li}`}>
                         <tr
                           onMouseEnter={() => {
-                            if (drag && anchor && anchor.side === drag.side) {
-                              setDrag((d) => (d ? { ...d, end: anchor.lineNumber } : d));
+                            if (drag === null) {
+                              return;
                             }
+                            const hoverAnchor = drag.side === 'old' ? oldAnchor : newAnchor;
+                            if (hoverAnchor === null) {
+                              return;
+                            }
+                            setDrag((current) =>
+                              current === null ? null : { ...current, end: hoverAnchor.lineNumber },
+                            );
                           }}
                           className={cn(
-                            'group',
                             line.kind === 'add' && 'bg-success/[0.07]',
                             line.kind === 'del' && 'bg-danger/[0.07]',
                             selecting && 'bg-primary/15',
@@ -450,28 +472,41 @@ export const FileDiffCard = ({
                         >
                           <td
                             onPointerDown={
-                              canComment && anchor !== null
+                              canComment && oldAnchor !== null
                                 ? (event) => {
                                     event.preventDefault();
                                     setDrag({
-                                      side: anchor.side,
-                                      start: anchor.lineNumber,
-                                      end: anchor.lineNumber,
+                                      side: oldAnchor.side,
+                                      start: oldAnchor.lineNumber,
+                                      end: oldAnchor.lineNumber,
                                     });
                                   }
                                 : undefined
                             }
+                            onKeyDown={
+                              canComment && oldAnchor !== null
+                                ? (event) => {
+                                    if (event.key !== 'Enter' && event.key !== ' ') {
+                                      return;
+                                    }
+                                    event.preventDefault();
+                                    setActiveAnchor(oldAnchor);
+                                  }
+                                : undefined
+                            }
+                            role={canComment && oldAnchor !== null ? 'button' : undefined}
+                            tabIndex={canComment && oldAnchor !== null ? 0 : undefined}
                             aria-label={
-                              canComment && anchor !== null
-                                ? `comment on line ${anchor.lineNumber}`
+                              canComment && line.oldLine !== null
+                                ? `comment on old line ${line.oldLine}`
                                 : undefined
                             }
                             className={cn(
                               'w-9 select-none border-l-2 px-1.5 text-right text-[10px] tabular-nums text-muted-foreground/50',
                               canComment &&
-                                anchor !== null &&
-                                'cursor-pointer transition-colors hover:bg-muted hover:text-foreground',
-                              rangeCommented
+                                oldAnchor !== null &&
+                                'cursor-pointer transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary/60',
+                              oldRangeCommented
                                 ? 'border-warning/60'
                                 : line.kind === 'add'
                                   ? 'border-success/50'
@@ -484,27 +519,40 @@ export const FileDiffCard = ({
                           </td>
                           <td
                             onPointerDown={
-                              canComment && anchor !== null
+                              canComment && newAnchor !== null
                                 ? (event) => {
                                     event.preventDefault();
                                     setDrag({
-                                      side: anchor.side,
-                                      start: anchor.lineNumber,
-                                      end: anchor.lineNumber,
+                                      side: newAnchor.side,
+                                      start: newAnchor.lineNumber,
+                                      end: newAnchor.lineNumber,
                                     });
                                   }
                                 : undefined
                             }
+                            onKeyDown={
+                              canComment && newAnchor !== null
+                                ? (event) => {
+                                    if (event.key !== 'Enter' && event.key !== ' ') {
+                                      return;
+                                    }
+                                    event.preventDefault();
+                                    setActiveAnchor(newAnchor);
+                                  }
+                                : undefined
+                            }
+                            role={canComment && newAnchor !== null ? 'button' : undefined}
+                            tabIndex={canComment && newAnchor !== null ? 0 : undefined}
                             aria-label={
-                              canComment && anchor !== null
-                                ? `comment on line ${anchor.lineNumber}`
+                              canComment && line.newLine !== null
+                                ? `comment on new line ${line.newLine}`
                                 : undefined
                             }
                             className={cn(
                               'w-9 select-none border-r border-border-soft/40 px-1.5 text-right text-[10px] tabular-nums text-muted-foreground/50',
                               canComment &&
-                                anchor !== null &&
-                                'cursor-pointer transition-colors hover:bg-muted hover:text-foreground',
+                                newAnchor !== null &&
+                                'cursor-pointer transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary/60',
                             )}
                           >
                             {line.newLine ?? ''}
@@ -567,7 +615,7 @@ export const FileDiffCard = ({
                             </td>
                           </tr>
                         )}
-                        {isActive && anchor ? (
+                        {isActive && activeAnchor !== null ? (
                           <tr>
                             <td colSpan={3} className="bg-background">
                               <div
@@ -578,11 +626,9 @@ export const FileDiffCard = ({
                                   label={
                                     activeAnchor?.endLineNumber
                                       ? `commenting on lines ${activeAnchor.lineNumber}–${activeAnchor.endLineNumber}`
-                                      : `commenting on line ${anchor.lineNumber}`
+                                      : `commenting on line ${activeAnchor.lineNumber}`
                                   }
-                                  onSubmit={(body) =>
-                                    handleSubmitComment(activeAnchor ?? anchor, body)
-                                  }
+                                  onSubmit={(body) => handleSubmitComment(activeAnchor, body)}
                                   onCancel={() => setActiveAnchor(null)}
                                 />
                               </div>

--- a/apps/desktop/src/features/permissions/components/DiffViewerDialog/index.test.tsx
+++ b/apps/desktop/src/features/permissions/components/DiffViewerDialog/index.test.tsx
@@ -52,6 +52,8 @@ const { state, fixtures } = vi.hoisted(() => ({
   },
 }));
 
+const scrollIntoViewMock = vi.fn();
+
 vi.mock('../../../../store', () => ({
   useAppStore: <T,>(selector: (s: typeof state) => T) => selector(state),
   useDiffComments: () => fixtures.comments,
@@ -88,6 +90,11 @@ vi.mock('@goodboy/core', async (importOriginal) => ({
 }));
 
 beforeEach(() => {
+  Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+    configurable: true,
+    value: scrollIntoViewMock,
+  });
+  scrollIntoViewMock.mockReset();
   state.settings = {};
   state.sessionPhaseRuns = {};
   state.workspaceOverrides = {};
@@ -107,7 +114,10 @@ beforeEach(() => {
     localStorage.clear();
   }
 });
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
 
 import { DiffViewerDialog, DiffViewerPane } from './index';
 
@@ -272,12 +282,12 @@ describe('DiffViewerPane', () => {
 });
 
 describe('line comment add (single + multi-line drag)', () => {
-  it('single click on the gutter opens a single-line composer', async () => {
+  it('single click on a line number opens a single-line composer', async () => {
     fixtures.files = fileFixture();
     render(<DiffViewerPane sessionId={SID} loader={async () => 'raw'} onClose={vi.fn()} />);
     await screen.findByText(/alpha/);
-    const btns = screen.getAllByLabelText('comment on this line');
-    fireEvent.pointerDown(btns[0]!);
+    const lineNumbers = screen.getAllByLabelText('comment on line 1');
+    fireEvent.pointerDown(lineNumbers[0]!);
     fireEvent.pointerUp(window);
     const composerLabel = await screen.findByText('commenting on line 1');
     const scrollContent = composerLabel.closest('[data-diff-scroll-content]');
@@ -286,12 +296,12 @@ describe('line comment add (single + multi-line drag)', () => {
     expect(scrollContent?.className).toContain('w-[var(--diff-card-width)]');
   });
 
-  it('dragging the gutter across lines opens a range composer and persists endLineNumber', async () => {
+  it('dragging a line number across rows opens a range composer and persists endLineNumber', async () => {
     fixtures.files = fileFixture();
     render(<DiffViewerPane sessionId={SID} loader={async () => 'raw'} onClose={vi.fn()} />);
     await screen.findByText(/alpha/);
-    const btns = screen.getAllByLabelText('comment on this line');
-    fireEvent.pointerDown(btns[0]!);
+    const lineNumbers = screen.getAllByLabelText('comment on line 1');
+    fireEvent.pointerDown(lineNumbers[0]!);
     const lastRow = screen.getByText(/gamma/).closest('tr');
     expect(lastRow).not.toBeNull();
     fireEvent.mouseEnter(lastRow as HTMLElement);
@@ -366,7 +376,7 @@ describe('line comment add (single + multi-line drag)', () => {
     ];
     render(<DiffViewerPane sessionId={SID} loader={async () => 'raw'} onClose={vi.fn()} />);
     const showMoreButton = await screen.findByRole('button', { name: /show 1 more lines/i });
-    fireEvent.pointerDown(screen.getAllByLabelText('comment on this line')[0]!);
+    fireEvent.pointerDown(screen.getAllByLabelText('comment on line 1')[0]!);
     fireEvent.pointerUp(window);
 
     const scrollContents = [
@@ -380,8 +390,18 @@ describe('line comment add (single + multi-line drag)', () => {
       expect(scrollContent?.className).toContain('left-0');
       expect(scrollContent?.className).toContain('w-[var(--diff-card-width)]');
       expect(scrollContent?.parentElement?.tagName).toBe('TD');
-      expect(scrollContent?.parentElement?.getAttribute('colspan')).toBe('4');
+      expect(scrollContent?.parentElement?.getAttribute('colspan')).toBe('3');
     }
+  });
+
+  it('opens file notes from the header action without a body call to action', async () => {
+    fixtures.files = fileFixture();
+    render(<DiffViewerPane sessionId={SID} loader={async () => 'raw'} onClose={vi.fn()} />);
+
+    const addFileNote = await screen.findByRole('button', { name: 'add file note' });
+    expect(screen.queryByText('Add file note')).toBeNull();
+    fireEvent.click(addFileNote);
+    expect(await screen.findByPlaceholderText(/note for the agent/i)).toBeDefined();
   });
 
   it('offers a routing picker for the resolver spawned from open notes', async () => {
@@ -511,6 +531,29 @@ const makeFiles = (count: number, prefix = 'file') =>
   }));
 
 describe('progressive batching', () => {
+  it('mounts and scrolls to a file beyond the first batch when its rail entry is clicked', async () => {
+    vi.stubGlobal(
+      'requestIdleCallback',
+      vi.fn(() => 1),
+    );
+    vi.stubGlobal('cancelIdleCallback', vi.fn());
+    localStorage.setItem('goodboy:diff-sidebar-collapsed', '0');
+    fixtures.files = makeFiles(25);
+    const { container } = render(
+      <DiffViewerPane sessionId={SID} loader={async () => 'raw'} onClose={vi.fn()} />,
+    );
+
+    await screen.findByTitle('src/file22.ts');
+    expect(container.querySelector('[data-file-path="src/file22.ts"]')).toBeNull();
+    fireEvent.click(screen.getByTitle('src/file22.ts'));
+
+    await waitFor(() => {
+      const fileCard = container.querySelector('[data-file-path="src/file22.ts"]');
+      expect(fileCard).not.toBeNull();
+      expect(scrollIntoViewMock.mock.contexts).toContain(fileCard);
+    });
+  });
+
   it('mounts only the first batch initially and appends more after idle', async () => {
     vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
 

--- a/apps/desktop/src/features/permissions/components/DiffViewerDialog/index.test.tsx
+++ b/apps/desktop/src/features/permissions/components/DiffViewerDialog/index.test.tsx
@@ -286,8 +286,7 @@ describe('line comment add (single + multi-line drag)', () => {
     fixtures.files = fileFixture();
     render(<DiffViewerPane sessionId={SID} loader={async () => 'raw'} onClose={vi.fn()} />);
     await screen.findByText(/alpha/);
-    const lineNumbers = screen.getAllByLabelText('comment on line 1');
-    fireEvent.pointerDown(lineNumbers[0]!);
+    fireEvent.pointerDown(screen.getByLabelText('comment on new line 1'));
     fireEvent.pointerUp(window);
     const composerLabel = await screen.findByText('commenting on line 1');
     const scrollContent = composerLabel.closest('[data-diff-scroll-content]');
@@ -300,8 +299,7 @@ describe('line comment add (single + multi-line drag)', () => {
     fixtures.files = fileFixture();
     render(<DiffViewerPane sessionId={SID} loader={async () => 'raw'} onClose={vi.fn()} />);
     await screen.findByText(/alpha/);
-    const lineNumbers = screen.getAllByLabelText('comment on line 1');
-    fireEvent.pointerDown(lineNumbers[0]!);
+    fireEvent.pointerDown(screen.getByLabelText('comment on new line 1'));
     const lastRow = screen.getByText(/gamma/).closest('tr');
     expect(lastRow).not.toBeNull();
     fireEvent.mouseEnter(lastRow as HTMLElement);
@@ -335,6 +333,43 @@ describe('line comment add (single + multi-line drag)', () => {
     render(<DiffViewerPane sessionId={SID} loader={async () => 'raw'} onClose={vi.fn()} />);
     expect(await screen.findByText('lines 2–3')).toBeDefined();
     expect(screen.getByText('spans a range')).toBeDefined();
+  });
+
+  it('labels old and new line cells with the numbers they display', async () => {
+    fixtures.files = [
+      {
+        path: 'src/context.ts',
+        status: 'modified',
+        additions: 0,
+        deletions: 0,
+        binary: false,
+        hunks: [
+          {
+            header: '@@ -10,1 +20,1 @@',
+            oldStart: 10,
+            oldLines: 1,
+            newStart: 20,
+            newLines: 1,
+            lines: [{ kind: 'context', oldLine: 10, newLine: 20, text: 'shared' }],
+          },
+        ],
+      },
+    ];
+    render(<DiffViewerPane sessionId={SID} loader={async () => 'raw'} onClose={vi.fn()} />);
+
+    expect(await screen.findByRole('button', { name: 'comment on old line 10' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'comment on new line 20' })).toBeDefined();
+    expect(screen.queryByLabelText('comment on old line 20')).toBeNull();
+  });
+
+  it('opens a single-line composer from a line cell with Enter', async () => {
+    fixtures.files = fileFixture();
+    render(<DiffViewerPane sessionId={SID} loader={async () => 'raw'} onClose={vi.fn()} />);
+    const lineCell = await screen.findByRole('button', { name: 'comment on new line 1' });
+
+    fireEvent.keyDown(lineCell, { key: 'Enter' });
+
+    expect(await screen.findByText('commenting on line 1')).toBeDefined();
   });
 
   it('keeps colSpan controls sticky within the wide diff table', async () => {
@@ -376,7 +411,7 @@ describe('line comment add (single + multi-line drag)', () => {
     ];
     render(<DiffViewerPane sessionId={SID} loader={async () => 'raw'} onClose={vi.fn()} />);
     const showMoreButton = await screen.findByRole('button', { name: /show 1 more lines/i });
-    fireEvent.pointerDown(screen.getAllByLabelText('comment on line 1')[0]!);
+    fireEvent.pointerDown(screen.getByLabelText('comment on new line 1'));
     fireEvent.pointerUp(window);
 
     const scrollContents = [
@@ -530,6 +565,62 @@ const makeFiles = (count: number, prefix = 'file') =>
     ],
   }));
 
+type EmitIntersectionParams = {
+  entries: ReadonlyArray<{
+    target: Element;
+    top: number;
+  }>;
+};
+
+type IdleCallbackState = {
+  current: IdleRequestCallback | null;
+};
+
+class TestIntersectionObserver implements IntersectionObserver {
+  static instances: TestIntersectionObserver[] = [];
+
+  readonly root = null;
+  readonly rootMargin = '0px';
+  readonly thresholds = [0];
+  readonly targets = new Set<Element>();
+
+  constructor(private readonly callback: IntersectionObserverCallback) {
+    TestIntersectionObserver.instances.push(this);
+  }
+
+  disconnect(): void {
+    this.targets.clear();
+  }
+
+  observe(target: Element): void {
+    this.targets.add(target);
+  }
+
+  takeRecords(): IntersectionObserverEntry[] {
+    return [];
+  }
+
+  unobserve(target: Element): void {
+    this.targets.delete(target);
+  }
+
+  emit({ entries }: EmitIntersectionParams): void {
+    const records = entries.map(({ target, top }) => {
+      const rect = new DOMRect(0, top, 100, 100);
+      return {
+        boundingClientRect: rect,
+        intersectionRatio: 1,
+        intersectionRect: rect,
+        isIntersecting: true,
+        rootBounds: null,
+        target,
+        time: 0,
+      } satisfies IntersectionObserverEntry;
+    });
+    this.callback(records, this);
+  }
+}
+
 describe('progressive batching', () => {
   it('mounts and scrolls to a file beyond the first batch when its rail entry is clicked', async () => {
     vi.stubGlobal(
@@ -575,6 +666,62 @@ describe('progressive batching', () => {
     expect(container.querySelectorAll('[data-file-path]').length).toBe(25);
 
     vi.useRealTimers();
+  });
+
+  it('keeps the active file stable while idle batches mount', async () => {
+    TestIntersectionObserver.instances = [];
+    const idleCallbackState: IdleCallbackState = { current: null };
+    vi.stubGlobal('IntersectionObserver', TestIntersectionObserver);
+    vi.stubGlobal(
+      'requestIdleCallback',
+      vi.fn((callback: IdleRequestCallback) => {
+        idleCallbackState.current = callback;
+        return 1;
+      }),
+    );
+    vi.stubGlobal('cancelIdleCallback', vi.fn());
+    localStorage.setItem('goodboy:diff-sidebar-collapsed', '0');
+    fixtures.files = makeFiles(25);
+    const { container } = render(
+      <DiffViewerPane sessionId={SID} loader={async () => 'raw'} onClose={vi.fn()} />,
+    );
+    await screen.findByTitle('src/file22.ts');
+    const firstCard = container.querySelector('[data-file-path="src/file0.ts"]');
+    const secondCard = container.querySelector('[data-file-path="src/file1.ts"]');
+    if (
+      firstCard === null ||
+      secondCard === null ||
+      TestIntersectionObserver.instances[0] === undefined
+    ) {
+      throw new Error('expected initial diff cards and observer');
+    }
+
+    act(() => {
+      TestIntersectionObserver.instances[0]?.emit({
+        entries: [
+          { target: firstCard, top: 0 },
+          { target: secondCard, top: 100 },
+        ],
+      });
+    });
+    const activeRailEntry = screen
+      .getAllByTitle('src/file0.ts')
+      .find((element) => element.parentElement?.className.includes('group relative') === true);
+    expect(activeRailEntry?.parentElement?.className).toContain('border-primary');
+
+    const scheduledIdleCallback = idleCallbackState.current;
+    if (scheduledIdleCallback === null) {
+      throw new Error('expected an idle batch callback');
+    }
+    await act(async () => {
+      scheduledIdleCallback({
+        didTimeout: false,
+        timeRemaining: () => 50,
+      });
+    });
+
+    expect(TestIntersectionObserver.instances).toHaveLength(1);
+    expect(activeRailEntry?.parentElement?.className).toContain('border-primary');
   });
 
   it('resets batch count when the diff source changes', async () => {

--- a/packages/ui/src/__tests__/Tooltip.test.tsx
+++ b/packages/ui/src/__tests__/Tooltip.test.tsx
@@ -79,4 +79,22 @@ describe('Tooltip', () => {
     expect(screen.queryByRole('tooltip')).toBeNull();
     vi.useRealTimers();
   });
+
+  it('portals the tooltip into its nearest open dialog', async () => {
+    vi.useFakeTimers();
+    const { container } = render(
+      <dialog open>
+        <Tooltip content="dialog tip">
+          <button type="button">btn</button>
+        </Tooltip>
+      </dialog>,
+    );
+    fireEvent.focus(screen.getByRole('button'));
+    await act(async () => {
+      vi.advanceTimersByTime(400);
+    });
+    const dialog = container.querySelector('dialog');
+    expect(dialog?.contains(screen.getByRole('tooltip'))).toBe(true);
+    vi.useRealTimers();
+  });
 });

--- a/packages/ui/src/components/Tooltip.tsx
+++ b/packages/ui/src/components/Tooltip.tsx
@@ -94,7 +94,6 @@ const positionFor = (anchor: DOMRect, tip: DOMRect, side: TooltipSide): Coords =
     }
   }
 
-  // clamp into viewport on the cross axis
   const left = Math.max(GAP, Math.min(pos.left, vw - tip.width - GAP));
   const top = Math.max(GAP, Math.min(pos.top, vh - tip.height - GAP));
   return { top, left, side: chosen };
@@ -136,9 +135,6 @@ export const Tooltip = ({ content, side = 'top', children }: TooltipProps) => {
     reposition();
   }, [visible, content, reposition]);
 
-  // The portaled tip is position:fixed, computed once on show. Keep it pinned to
-  // the anchor while visible by re-running on scroll (capture, to catch nested
-  // scrollers) and resize.
   useEffect(() => {
     if (!visible) {
       return;
@@ -151,7 +147,6 @@ export const Tooltip = ({ content, side = 'top', children }: TooltipProps) => {
     };
   }, [visible, reposition]);
 
-  // React 19: ref is a regular prop, available on children.props.ref.
   const childRef = (children.props as { ref?: React.Ref<HTMLElement> }).ref;
   const mergedRef = useCallback(
     (node: HTMLElement | null) => {
@@ -180,11 +175,15 @@ export const Tooltip = ({ content, side = 'top', children }: TooltipProps) => {
       children.props.onBlur?.(e);
     },
   });
+  const portalTarget =
+    typeof document === 'undefined'
+      ? null
+      : (anchorRef.current?.closest('dialog[open]') ?? document.body);
 
   return (
     <>
       {enhanced}
-      {visible && typeof document !== 'undefined'
+      {visible && portalTarget !== null
         ? createPortal(
             <span
               ref={tipRef}
@@ -201,7 +200,7 @@ export const Tooltip = ({ content, side = 'top', children }: TooltipProps) => {
             >
               {content}
             </span>,
-            document.body,
+            portalTarget,
           )
         : null}
     </>


### PR DESCRIPTION
## Summary

Four fixes to the diff lens, plus the tooltip gap they exposed.

### Clicking a file in the tree always lands on that file
Cards mount in batches of 20, but the file tree lists every file, so clicking anything past the first batch hit a ref that did not exist yet and did nothing at all. The click now raises the mount count to cover the target and scrolls once the card exists. The observer that highlights the active file keeps a single instance across batches and picks the topmost visible file, so growing batches no longer move the highlight on their own.

### One place to add a file note
The note action was a text button in the file body plus a second icon variant in the header once notes existed. It is now a single icon in the header row next to copy, open in editor and viewed, with a tooltip.

### Commit selector rebuilt on the picker pattern
Same sections, same filter, same keyboard navigation and persistence, now on the shared dropdown, portal, popover and section primitives the model picker uses. It no longer clips inside scroll containers.

### Commenting on a line
The hover icon column is gone. The line numbers are the target: click one to comment on that line, drag across rows for a range, Enter or Space to open a composer from the keyboard. Code text stays selectable. Lines whose composer was opened and abandoned no longer keep a pinned icon, and each number cell announces the number it actually shows.

### Tooltips inside modals
`Tooltip` portalled into `document.body`, which paints below a modal promoted to the top layer, so tooltips inside dialogs were invisible. It now portals into the nearest open dialog, matching what the dropdown hook already did.

## Verification

Full monorepo suite and typecheck green. Adversarial review of the first pass found five defects (observer rebuild moving the highlight, invisible tooltips with the `title` fallback removed, line labels announcing the wrong number, the affordance dropping keyboard access, an orphaned class); all five are fixed in the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
