### PR TITLE
fix(desktop): let the diff pane span the full lens width

### DIFF
--- a/apps/desktop/src/features/permissions/components/DiffViewerDialog/DiffViewerContent.tsx
+++ b/apps/desktop/src/features/permissions/components/DiffViewerDialog/DiffViewerContent.tsx
@@ -785,7 +785,7 @@ export const DiffViewerContent = ({
     <div
       className={cn(
         'flex h-full min-h-0 w-full flex-col',
-        isPane && 'mx-auto max-w-5xl gap-5 px-6 py-5 motion-safe:animate-studio-in',
+        isPane && 'gap-5 px-6 py-5 motion-safe:animate-studio-in',
       )}
       onKeyDown={handleKeyDown}
     >

--- a/apps/desktop/src/features/permissions/components/DiffViewerDialog/index.test.tsx
+++ b/apps/desktop/src/features/permissions/components/DiffViewerDialog/index.test.tsx
@@ -176,11 +176,12 @@ describe('DiffViewerPane', () => {
     expect(container.firstElementChild?.className).toContain('motion-safe:animate-studio-in');
   });
 
-  it('centers the pane content at the widest section width', () => {
+  it('lets the pane content span the full lens width', () => {
     const { container } = render(<DiffViewerPane onClose={vi.fn()} />);
     const shell = container.firstElementChild as HTMLElement;
-    expect(shell.className).toContain('mx-auto');
-    expect(shell.className).toContain('max-w-5xl');
+    expect(shell.className).toContain('w-full');
+    expect(shell.className).not.toContain('mx-auto');
+    expect(shell.className).not.toContain('max-w-');
     expect(shell.className).not.toContain('fixed');
   });
 
@@ -756,15 +757,15 @@ describe('progressive batching', () => {
 });
 
 describe('DiffViewerDialog vs DiffViewerPane structural difference', () => {
-  it('DiffViewerDialog uses a fixed overlay and DiffViewerPane uses centered pane layout', () => {
+  it('DiffViewerDialog uses a fixed overlay and DiffViewerPane fills its lens slot', () => {
     const { container: dialogContainer } = render(<DiffViewerDialog open onClose={vi.fn()} />);
     const { container: paneContainer } = render(<DiffViewerPane onClose={vi.fn()} />);
     const dialogRoot = dialogContainer.querySelector('dialog, [role="dialog"]');
     expect(dialogRoot).not.toBeNull();
 
     const paneShell = paneContainer.firstElementChild as HTMLElement;
-    expect(paneShell.className).toContain('mx-auto');
-    expect(paneShell.className).toContain('max-w-5xl');
+    expect(paneShell.className).toContain('w-full');
+    expect(paneShell.className).not.toContain('max-w-');
     expect(paneShell.className).not.toContain('fixed');
   });
 });


### PR DESCRIPTION
## Summary

The diff lens rendered its content inside `mx-auto max-w-5xl`, so on a wide window the file rail and the code column sat in the middle with empty gutters on both sides. The pane now fills the lens slot; padding and the section gap are unchanged, and the dialog presentation keeps its own fixed overlay sizing.

## Verification

Typecheck green across the 5 packages. Permissions and session suites green (76 files, 745 tests). The two tests that pinned the centered layout now assert the pane fills its slot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)