### PR TITLE
fix(desktop): open questions chat visibility, pane states, card restyle

### DIFF
--- a/apps/desktop/src/features/chat/components/ChatView/AnsweredCard.tsx
+++ b/apps/desktop/src/features/chat/components/ChatView/AnsweredCard.tsx
@@ -1,0 +1,89 @@
+import { useState } from 'react';
+import { Bot, CheckCircle2, ChevronDown } from 'lucide-react';
+import { cn, Markdown } from '@goodboy/ui';
+import type { OpenQuestion } from '@goodboy/types';
+import { formatRelativeAge } from '../../../../shared/utils/relativeDate';
+import { MARKER_ACCENT } from '../marker-accents';
+import { TranscriptShell } from '../TranscriptShell';
+
+const successAccent = MARKER_ACCENT.success;
+
+type Props = {
+  readonly question: OpenQuestion;
+};
+
+const RESOLVED_BY_AGENT = '[resolved by agent]';
+
+export const AnsweredCard = ({ question }: Props) => {
+  const [expanded, setExpanded] = useState(false);
+  const resolvedByAgent = question.userAnswer === RESOLVED_BY_AGENT;
+  const answeredAt = question.answeredAt ?? question.createdAt;
+
+  return (
+    <TranscriptShell
+      tone={resolvedByAgent ? 'neutral' : 'success'}
+      variant="leftBorder"
+      className={cn('flex flex-col gap-1.5', resolvedByAgent && 'opacity-80')}
+    >
+      <button
+        type="button"
+        onClick={() => setExpanded((value) => !value)}
+        className="flex w-full items-start justify-between gap-2 text-left"
+      >
+        <div className="flex min-w-0 items-start gap-2">
+          {resolvedByAgent ? (
+            <Bot
+              size={13}
+              aria-hidden
+              className="shrink-0 translate-y-0.5 text-muted-foreground/60"
+            />
+          ) : (
+            <CheckCircle2
+              size={13}
+              aria-hidden
+              className={cn('shrink-0 translate-y-0.5', successAccent.icon)}
+            />
+          )}
+          {expanded ? (
+            <Markdown
+              text={question.text}
+              className="min-w-0 gap-1.5 break-words text-sm leading-relaxed text-foreground"
+            />
+          ) : (
+            <p className="min-w-0 break-words text-xs leading-relaxed text-foreground line-clamp-1">
+              {question.text}
+            </p>
+          )}
+        </div>
+        <div className="flex shrink-0 items-center gap-1.5 text-2xs text-muted-foreground">
+          <span>{formatRelativeAge({ fromIso: answeredAt })}</span>
+          <ChevronDown
+            size={12}
+            aria-hidden
+            className={cn('transition-transform duration-150', expanded && 'rotate-180')}
+          />
+        </div>
+      </button>
+
+      <div className="flex flex-col gap-0.5 pl-[21px]">
+        {resolvedByAgent ? (
+          <p className="text-2xs italic text-muted-foreground">resolved by agent</p>
+        ) : (
+          <>
+            <span className="text-2xs font-medium text-muted-foreground">You answered:</span>
+            {expanded ? (
+              <Markdown
+                text={question.userAnswer ?? ''}
+                className="gap-1.5 break-words text-sm leading-relaxed text-foreground"
+              />
+            ) : (
+              <p className="line-clamp-2 break-words text-xs leading-relaxed text-foreground">
+                {question.userAnswer ?? ''}
+              </p>
+            )}
+          </>
+        )}
+      </div>
+    </TranscriptShell>
+  );
+};

--- a/apps/desktop/src/features/chat/components/ChatView/InteractiveQuestionCard.tsx
+++ b/apps/desktop/src/features/chat/components/ChatView/InteractiveQuestionCard.tsx
@@ -1,0 +1,42 @@
+import { useCallback } from 'react';
+import type { OpenQuestion, SessionId } from '@goodboy/types';
+import { useAppStore } from '../../../../store';
+import { QuestionCard } from '../../../context/components/QuestionsTab/QuestionCard';
+import { useOpenQuestions } from '../../../context/components/QuestionsTab/useOpenQuestions';
+
+type Props = {
+  readonly question: OpenQuestion;
+  readonly sessionId: SessionId;
+};
+
+export const InteractiveQuestionCard = ({ question, sessionId }: Props) => {
+  const {
+    drafts,
+    justAnswered,
+    toggleSuggestion,
+    setCustomAnswer,
+    toggleCustomField,
+    clearJustAnswered,
+  } = useOpenQuestions();
+  const dismissOpenQuestion = useAppStore((state) => state.dismissOpenQuestion);
+  const draft = drafts[question.id];
+
+  const handleDismiss = useCallback(() => {
+    void dismissOpenQuestion(sessionId, question);
+  }, [dismissOpenQuestion, sessionId, question]);
+
+  return (
+    <QuestionCard
+      question={question}
+      selectedSuggestions={draft?.selectedSuggestions ?? []}
+      customAnswer={draft?.customAnswer ?? ''}
+      showCustomField={draft?.showCustomField ?? false}
+      justAnswered={justAnswered.includes(question.id)}
+      onToggleSuggestion={toggleSuggestion}
+      onSetCustomAnswer={setCustomAnswer}
+      onToggleCustomField={toggleCustomField}
+      onDismiss={handleDismiss}
+      onClearJustAnswered={clearJustAnswered}
+    />
+  );
+};

--- a/apps/desktop/src/features/chat/components/ChatView/OpenQuestionCluster.tsx
+++ b/apps/desktop/src/features/chat/components/ChatView/OpenQuestionCluster.tsx
@@ -1,8 +1,7 @@
 import { useCallback, useMemo } from 'react';
-import { ArrowRight } from 'lucide-react';
-import { cn } from '@goodboy/ui';
 import type { Agent, AgentId, OpenQuestion, SessionId, Workflow } from '@goodboy/types';
 import { useAppStore } from '../../../../store';
+import { AnswerSubmitButton } from '../../../context/components/QuestionsTab/AnswerSubmitButton';
 import { QuestionClusterHeader } from '../../../context/components/QuestionsTab/QuestionClusterHeader';
 import { buildQuestionClusters } from '../../../context/components/QuestionsTab/clusters';
 import {
@@ -85,25 +84,7 @@ export const OpenQuestionCluster = ({ questions, sessionId, viewerAgentId = null
         );
       })}
       {pendingPairs.length > 0 && (
-        <button
-          type="button"
-          onClick={() => void handleSubmit()}
-          className={cn(
-            'group flex w-full items-center justify-center gap-1.5 rounded-lg px-3 py-2 text-xs font-semibold',
-            'bg-primary text-primary-foreground shadow-sm transition-all duration-150',
-            'hover:brightness-105 active:scale-[0.99]',
-            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
-          )}
-        >
-          <span>
-            {pendingPairs.length > 1 ? `send ${pendingPairs.length} answers` : 'send answer'}
-          </span>
-          <ArrowRight
-            size={13}
-            aria-hidden
-            className="transition-transform group-hover:translate-x-0.5"
-          />
-        </button>
+        <AnswerSubmitButton answerCount={pendingPairs.length} onClick={() => void handleSubmit()} />
       )}
     </div>
   );

--- a/apps/desktop/src/features/chat/components/ChatView/OpenQuestionInlineCard.tsx
+++ b/apps/desktop/src/features/chat/components/ChatView/OpenQuestionInlineCard.tsx
@@ -1,136 +1,10 @@
-import { useCallback, useState } from 'react';
-import { Bot, CheckCircle2, ChevronDown } from 'lucide-react';
-import { cn, Markdown } from '@goodboy/ui';
 import type { OpenQuestion, SessionId } from '@goodboy/types';
-import { useAppStore } from '../../../../store';
-import { QuestionCard } from '../../../context/components/QuestionsTab/QuestionCard';
-import { useOpenQuestions } from '../../../context/components/QuestionsTab/useOpenQuestions';
-import { MARKER_ACCENT } from '../marker-accents';
-
-const RESOLVED_BY_AGENT = '[resolved by agent]';
-const successAccent = MARKER_ACCENT.success;
+import { AnsweredCard } from './AnsweredCard';
+import { InteractiveQuestionCard } from './InteractiveQuestionCard';
 
 type Props = {
-  question: OpenQuestion;
-  sessionId: SessionId;
-};
-
-function relativeTime(isoDate: string): string {
-  const diffMs = Date.now() - new Date(isoDate).getTime();
-  const mins = Math.floor(diffMs / 60_000);
-  if (mins < 1) {
-    return 'just now';
-  }
-  if (mins < 60) {
-    return `${mins}m ago`;
-  }
-  const hrs = Math.floor(mins / 60);
-  if (hrs < 24) {
-    return `${hrs}h ago`;
-  }
-  return `${Math.floor(hrs / 24)}d ago`;
-}
-
-const InteractiveCard = ({ question, sessionId }: Props) => {
-  const {
-    drafts,
-    justAnswered,
-    toggleSuggestion,
-    setCustomAnswer,
-    toggleCustomField,
-    clearJustAnswered,
-  } = useOpenQuestions();
-  const dismissOpenQuestion = useAppStore((s) => s.dismissOpenQuestion);
-
-  const draft = drafts[question.id];
-
-  const handleDismiss = useCallback(() => {
-    void dismissOpenQuestion(sessionId, question);
-  }, [dismissOpenQuestion, sessionId, question]);
-
-  return (
-    <div className="flex flex-col gap-2">
-      <QuestionCard
-        question={question}
-        selectedSuggestions={draft?.selectedSuggestions ?? []}
-        customAnswer={draft?.customAnswer ?? ''}
-        showCustomField={draft?.showCustomField ?? false}
-        justAnswered={justAnswered.includes(question.id)}
-        onToggleSuggestion={toggleSuggestion}
-        onSetCustomAnswer={setCustomAnswer}
-        onToggleCustomField={toggleCustomField}
-        onDismiss={handleDismiss}
-        onClearJustAnswered={clearJustAnswered}
-      />
-    </div>
-  );
-};
-
-export const AnsweredCard = ({ question }: { question: OpenQuestion }) => {
-  const [expanded, setExpanded] = useState(false);
-  const resolvedByAgent = question.userAnswer === RESOLVED_BY_AGENT;
-  const answeredAt = question.answeredAt ?? question.createdAt;
-
-  return (
-    <div
-      className={cn(
-        'flex flex-col gap-1.5 rounded-lg border bg-elevated px-3 py-2 shadow-sm',
-        resolvedByAgent ? 'border-border-soft opacity-80' : successAccent.border,
-      )}
-    >
-      <button
-        type="button"
-        onClick={() => setExpanded((v) => !v)}
-        className="flex w-full items-start justify-between gap-2 text-left"
-      >
-        <div className="flex min-w-0 items-start gap-2">
-          {resolvedByAgent ? (
-            <Bot size={13} aria-hidden className="mt-0.5 shrink-0 text-muted-foreground/60" />
-          ) : (
-            <CheckCircle2 size={13} aria-hidden className="mt-0.5 shrink-0 text-success" />
-          )}
-          {expanded ? (
-            <Markdown
-              text={question.text}
-              className="min-w-0 gap-1.5 break-words text-sm leading-relaxed text-foreground"
-            />
-          ) : (
-            <p className="min-w-0 break-words text-xs leading-relaxed text-foreground line-clamp-1">
-              {question.text}
-            </p>
-          )}
-        </div>
-        <div className="flex shrink-0 items-center gap-1.5 text-2xs text-muted-foreground">
-          <span>{relativeTime(answeredAt)}</span>
-          <ChevronDown
-            size={12}
-            aria-hidden
-            className={cn('transition-transform duration-150', expanded && 'rotate-180')}
-          />
-        </div>
-      </button>
-
-      <div className="flex flex-col gap-0.5 pl-[21px]">
-        {resolvedByAgent ? (
-          <p className="text-2xs italic text-muted-foreground">resolved by agent</p>
-        ) : (
-          <>
-            <span className="text-2xs font-medium text-muted-foreground">You answered:</span>
-            {expanded ? (
-              <Markdown
-                text={question.userAnswer ?? ''}
-                className="gap-1.5 break-words text-sm leading-relaxed text-foreground"
-              />
-            ) : (
-              <p className="line-clamp-2 break-words text-xs leading-relaxed text-foreground">
-                {question.userAnswer ?? ''}
-              </p>
-            )}
-          </>
-        )}
-      </div>
-    </div>
-  );
+  readonly question: OpenQuestion;
+  readonly sessionId: SessionId;
 };
 
 export const OpenQuestionInlineCard = ({ question, sessionId }: Props) => {
@@ -139,7 +13,7 @@ export const OpenQuestionInlineCard = ({ question, sessionId }: Props) => {
       {question.status === 'answered' ? (
         <AnsweredCard question={question} />
       ) : (
-        <InteractiveCard question={question} sessionId={sessionId} />
+        <InteractiveQuestionCard question={question} sessionId={sessionId} />
       )}
     </div>
   );

--- a/apps/desktop/src/features/chat/components/ChatView/TranscriptRows.test.tsx
+++ b/apps/desktop/src/features/chat/components/ChatView/TranscriptRows.test.tsx
@@ -19,7 +19,9 @@ vi.mock('../ThinkingIndicator', () => ({
 }));
 
 vi.mock('./OpenQuestionCluster', () => ({
-  OpenQuestionCluster: () => <div data-testid="oq" />,
+  OpenQuestionCluster: ({ questions }: { questions: ReadonlyArray<{ id: string }> }) => (
+    <div data-testid="oq">{questions.map((question) => question.id).join(',')}</div>
+  ),
 }));
 
 import { TranscriptRows } from './TranscriptRows';
@@ -33,12 +35,15 @@ const userText = (key: string, at: Date): TranscriptItem => ({
   at: at.toISOString() as IsoDateTime,
 });
 
-const renderRows = (rows: ReadonlyArray<TranscriptRow>) =>
+const renderRows = (
+  rows: ReadonlyArray<TranscriptRow>,
+  oqByTurnOrdinal: ReadonlyMap<number | null, ReadonlyArray<never>> = new Map(),
+) =>
   render(
     <ul>
       <TranscriptRows
         rows={rows}
-        oqByTurnOrdinal={new Map()}
+        oqByTurnOrdinal={oqByTurnOrdinal}
         sessionId={'s1' as SessionId}
         selectedAgentId={'a1' as AgentId}
         workingDir={null}
@@ -79,5 +84,19 @@ describe('TranscriptRows', () => {
     ]);
     expect(screen.getAllByTestId('card')).toHaveLength(2);
     expect(container.querySelectorAll('li')).toHaveLength(4);
+  });
+
+  it('renders future and null ordinal question buckets at the transcript tail', () => {
+    const oqByTurnOrdinal = new Map([
+      [4, [{ id: 'future' }]],
+      [null, [{ id: 'legacy' }]],
+    ]) as unknown as ReadonlyMap<number | null, ReadonlyArray<never>>;
+
+    renderRows([itemRow(userText('u1', new Date(2026, 4, 15, 9, 0, 0)))], oqByTurnOrdinal);
+
+    expect(screen.getAllByTestId('oq').map((question) => question.textContent)).toEqual([
+      'future',
+      'legacy',
+    ]);
   });
 });

--- a/apps/desktop/src/features/chat/components/ChatView/TranscriptRows.tsx
+++ b/apps/desktop/src/features/chat/components/ChatView/TranscriptRows.tsx
@@ -10,7 +10,7 @@ import { dayKey, formatDayLabel } from './lib';
 
 type Props = {
   rows: ReadonlyArray<TranscriptRow>;
-  oqByTurnOrdinal: ReadonlyMap<number, ReadonlyArray<OpenQuestion>>;
+  oqByTurnOrdinal: ReadonlyMap<number | null, ReadonlyArray<OpenQuestion>>;
   sessionId: SessionId;
   selectedAgentId: AgentId | null;
   workingDir: string | null;
@@ -103,6 +103,24 @@ export const TranscriptRows = ({
   });
 
   flushOrdinal(userTurnOrdinal);
+  const remainingOrdinals = [...oqByTurnOrdinal.keys()]
+    .filter((ordinal): ordinal is number => ordinal !== null && ordinal > userTurnOrdinal)
+    .sort((a, b) => a - b);
+  for (const ordinal of remainingOrdinals) {
+    flushOrdinal(ordinal);
+  }
+  const tailCards = oqByTurnOrdinal.get(null);
+  if (tailCards != null && tailCards.length > 0) {
+    out.push(
+      <li key="oq-tail">
+        <OpenQuestionCluster
+          questions={tailCards}
+          sessionId={sessionId}
+          viewerAgentId={selectedAgentId}
+        />
+      </li>,
+    );
+  }
   return (
     <>
       {out}

--- a/apps/desktop/src/features/chat/components/ChatView/index.test.tsx
+++ b/apps/desktop/src/features/chat/components/ChatView/index.test.tsx
@@ -33,6 +33,7 @@ const { state, openQuestions, answeredQuestions, transcriptItems } = vi.hoisted(
     loadSessionAnsweredQuestions: vi.fn(async () => undefined),
     openQuestionScrollTarget: null as { agentId: string; questionId: string } | null,
     clearOpenQuestionScroll: vi.fn(() => undefined),
+    requestOpenQuestionScroll: vi.fn(() => undefined),
   },
 }));
 
@@ -132,6 +133,8 @@ beforeEach(() => {
   state.loadSessionOpenQuestions.mockClear();
   state.loadSessionAnsweredQuestions.mockClear();
   state.clearOpenQuestionScroll.mockClear();
+  state.requestOpenQuestionScroll.mockClear();
+  state.selectAgent.mockClear();
   chatBreadcrumbMock.mockClear();
   diffViewerMock.mockClear();
   openQuestions.current = [];
@@ -216,8 +219,39 @@ describe('ChatView', () => {
     render(<ChatView session={session} />);
 
     const clusters = screen.getAllByTestId('cluster');
-    expect(clusters).toHaveLength(1);
-    expect(clusters[0]?.textContent).toBe('q-early,q-late');
+    expect(clusters).toHaveLength(2);
+    expect(clusters.map((cluster) => cluster.textContent)).toEqual([
+      'q-early,q-late',
+      'q-no-ordinal',
+    ]);
+    expect(screen.queryByText('q-other-agent')).toBeNull();
+  });
+
+  it('opens the agent chat that owns questions outside the selected chat', () => {
+    state.selectedAgentId = { 'sess-1': 'agent-1' };
+    state.sessionPhaseRuns = {
+      'sess-1': [
+        { id: 'agent-1', name: 'planner' },
+        { id: 'agent-2', name: 'implementer' },
+      ],
+    };
+    openQuestions.current = [
+      {
+        id: 'q-other-agent',
+        createdByAgentId: 'agent-2',
+        turnOrdinal: 3,
+        createdAt: '2026-06-13T00:00:00.000Z',
+      },
+    ];
+
+    render(<ChatView session={session} />);
+    fireEvent.click(screen.getByRole('button', { name: '1 open question from implementer' }));
+
+    expect(state.selectAgent).toHaveBeenCalledWith('sess-1', 'agent-2');
+    expect(state.requestOpenQuestionScroll).toHaveBeenCalledWith({
+      agentId: 'agent-2',
+      questionId: 'q-other-agent',
+    });
   });
 
   it('splits questions from different turns into separate clusters', () => {

--- a/apps/desktop/src/features/chat/components/ChatView/index.tsx
+++ b/apps/desktop/src/features/chat/components/ChatView/index.tsx
@@ -221,6 +221,7 @@ export const ChatView = ({ session, isActive = true, header }: Props) => {
   const loadSessionAnsweredQuestions = useAppStore((s) => s.loadSessionAnsweredQuestions);
   const openQuestionScrollTarget = useAppStore((s) => s.openQuestionScrollTarget);
   const clearOpenQuestionScroll = useAppStore((s) => s.clearOpenQuestionScroll);
+  const requestOpenQuestionScroll = useAppStore((s) => s.requestOpenQuestionScroll);
 
   useEffect(() => {
     void loadSessionOpenQuestions(session.id);
@@ -231,16 +232,17 @@ export const ChatView = ({ session, isActive = true, header }: Props) => {
   }, [session.id, loadSessionAnsweredQuestions]);
 
   const oqByTurnOrdinal = useMemo(() => {
-    const map = new Map<number, OpenQuestion[]>();
+    const map = new Map<number | null, OpenQuestion[]>();
     for (const q of [...openQuestions, ...answeredQuestions]) {
-      if (q.createdByAgentId !== selectedAgentId || q.turnOrdinal == null) {
+      if (q.createdByAgentId !== selectedAgentId) {
         continue;
       }
-      const bucket = map.get(q.turnOrdinal);
+      const ordinal = q.turnOrdinal ?? null;
+      const bucket = map.get(ordinal);
       if (bucket) {
         bucket.push(q);
       } else {
-        map.set(q.turnOrdinal, [q]);
+        map.set(ordinal, [q]);
       }
     }
     for (const bucket of map.values()) {
@@ -248,6 +250,27 @@ export const ChatView = ({ session, isActive = true, header }: Props) => {
     }
     return map;
   }, [openQuestions, answeredQuestions, selectedAgentId]);
+
+  const otherAgentQuestion = useMemo(
+    () =>
+      openQuestions.find(
+        (question) =>
+          question.createdByAgentId != null && question.createdByAgentId !== selectedAgentId,
+      ) ?? null,
+    [openQuestions, selectedAgentId],
+  );
+  const otherAgentQuestionCount = useMemo(() => {
+    if (otherAgentQuestion?.createdByAgentId == null) {
+      return 0;
+    }
+    return openQuestions.filter(
+      (question) => question.createdByAgentId === otherAgentQuestion.createdByAgentId,
+    ).length;
+  }, [openQuestions, otherAgentQuestion]);
+  const otherAgentName =
+    phaseRuns.find((run) => run.id === otherAgentQuestion?.createdByAgentId)?.name ??
+    'another agent';
+  const otherAgentId = otherAgentQuestion?.createdByAgentId ?? null;
 
   useEffect(() => {
     const target = openQuestionScrollTarget;
@@ -411,10 +434,10 @@ export const ChatView = ({ session, isActive = true, header }: Props) => {
           fadeSize="h-12"
           viewportClassName="px-6 pb-4 pt-6 [scrollbar-gutter:stable]"
         >
-          {transcriptStale || deferredItems.length === 0 ? (
-            loading.transcript || transcriptStale ? (
-              <TranscriptSkeleton />
-            ) : isProviderDisconnected ? (
+          {transcriptStale || (loading.transcript && deferredItems.length === 0) ? (
+            <TranscriptSkeleton />
+          ) : deferredItems.length === 0 && oqByTurnOrdinal.size === 0 ? (
+            isProviderDisconnected ? (
               <div className="flex h-full items-center justify-center">
                 <div className="mx-auto w-full max-w-[880px]">
                   <AuthRequiredCallout
@@ -481,6 +504,28 @@ export const ChatView = ({ session, isActive = true, header }: Props) => {
           </button>
         )}
       </div>
+      {selectedAgentId != null &&
+      otherAgentQuestion != null &&
+      otherAgentId != null &&
+      otherAgentQuestionCount > 0 ? (
+        <div className="flex shrink-0 justify-center">
+          <button
+            type="button"
+            className="rounded-md border border-warning/20 bg-warning/5 px-3 py-1.5 text-xs font-medium text-warning transition-colors hover:bg-warning/10"
+            onClick={() => {
+              void selectAgent(session.id, otherAgentId);
+              requestOpenQuestionScroll({
+                agentId: otherAgentId,
+                questionId: otherAgentQuestion.id,
+              });
+            }}
+          >
+            {otherAgentQuestionCount}{' '}
+            {otherAgentQuestionCount === 1 ? 'open question' : 'open questions'} from{' '}
+            {otherAgentName}
+          </button>
+        </div>
+      ) : null}
       {isEnded ? (
         <div className="border-t border-border px-4 py-3 text-xs text-muted-foreground">
           session ended. no further turns. branch preserved.

--- a/apps/desktop/src/features/context/components/QuestionsTab/AnswerSubmitButton/index.tsx
+++ b/apps/desktop/src/features/context/components/QuestionsTab/AnswerSubmitButton/index.tsx
@@ -1,0 +1,29 @@
+import { ArrowRight } from 'lucide-react';
+import { cn } from '@goodboy/ui';
+
+type Props = {
+  readonly answerCount: number;
+  readonly onClick: () => void;
+};
+
+export const AnswerSubmitButton = ({ answerCount, onClick }: Props) => {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'group flex w-full items-center justify-center gap-1.5 rounded-lg px-3 py-2 text-xs font-semibold',
+        'bg-primary text-primary-foreground shadow-sm motion-safe:transition-all duration-150',
+        'hover:brightness-105 active:scale-[0.99]',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
+      )}
+    >
+      <span>{answerCount > 1 ? `send ${answerCount} answers` : 'send answer'}</span>
+      <ArrowRight
+        size={13}
+        aria-hidden
+        className="motion-safe:transition-transform group-hover:translate-x-0.5"
+      />
+    </button>
+  );
+};

--- a/apps/desktop/src/features/context/components/QuestionsTab/DismissedQuestionUndo/index.tsx
+++ b/apps/desktop/src/features/context/components/QuestionsTab/DismissedQuestionUndo/index.tsx
@@ -1,0 +1,24 @@
+import { TranscriptShell } from '../../../../chat/components/TranscriptShell';
+
+type Props = {
+  readonly onUndo: () => void;
+};
+
+export const DismissedQuestionUndo = ({ onUndo }: Props) => {
+  return (
+    <TranscriptShell
+      tone="neutral"
+      variant="leftBorder"
+      className="flex items-center justify-between gap-2 text-xs text-muted-foreground"
+    >
+      <span>Dismissed -</span>
+      <button
+        type="button"
+        onClick={onUndo}
+        className="rounded-md px-2 py-1 font-medium text-foreground transition-colors hover:bg-muted"
+      >
+        Undo
+      </button>
+    </TranscriptShell>
+  );
+};

--- a/apps/desktop/src/features/context/components/QuestionsTab/QuestionCard/index.tsx
+++ b/apps/desktop/src/features/context/components/QuestionsTab/QuestionCard/index.tsx
@@ -2,9 +2,14 @@ import { useEffect, useState } from 'react';
 import { Check, MessageCircleQuestion, X } from 'lucide-react';
 import { cn, Markdown } from '@goodboy/ui';
 import type { OpenQuestion, OpenQuestionId } from '@goodboy/types';
+import { formatRelativeAge } from '../../../../../shared/utils/relativeDate';
+import { MARKER_ACCENT } from '../../../../chat/components/marker-accents';
+import { TranscriptShell } from '../../../../chat/components/TranscriptShell';
 import { SuggestionChip } from '../SuggestionChip';
 import { CustomAnswerField } from '../CustomAnswerField';
 import { deriveSuggestions } from '../deriveSuggestions';
+
+const warningAccent = MARKER_ACCENT.warning;
 
 type Props = {
   question: OpenQuestion;
@@ -18,22 +23,6 @@ type Props = {
   onDismiss: (id: OpenQuestionId) => void;
   onClearJustAnswered: (id: OpenQuestionId) => void;
 };
-
-function relativeAge(isoDate: string): string {
-  const diffMs = Date.now() - new Date(isoDate).getTime();
-  const mins = Math.floor(diffMs / 60_000);
-  if (mins < 1) {
-    return 'just now';
-  }
-  if (mins < 60) {
-    return `${mins}m ago`;
-  }
-  const hrs = Math.floor(mins / 60);
-  if (hrs < 24) {
-    return `${hrs}h ago`;
-  }
-  return `${Math.floor(hrs / 24)}d ago`;
-}
 
 export const QuestionCard = ({
   question,
@@ -61,7 +50,6 @@ export const QuestionCard = ({
     return () => clearTimeout(t);
   }, [justAnswered, question.id, onClearJustAnswered]);
 
-  const hasPendingAnswer = selectedSuggestions.length > 0 || customAnswer.trim().length > 0;
   const baseSuggestions =
     question.suggestedAnswers.length > 0
       ? question.suggestedAnswers
@@ -74,27 +62,25 @@ export const QuestionCard = ({
       : baseSuggestions;
 
   return (
-    <div
+    <TranscriptShell
+      tone="warning"
+      variant="leftBorder"
       className={cn(
-        'group relative flex flex-col gap-2 overflow-hidden rounded-lg border border-warning/30 bg-warning/[0.06] py-2.5 pl-3 pr-2.5 shadow-sm',
-        'transition-[border-color,background-color,box-shadow,transform] duration-200',
-        !hasPendingAnswer && 'hover:border-warning/50',
+        'group flex flex-col gap-2 transition-[background-color,transform] duration-200',
+        warningAccent.bgSoft,
+        warningAccent.hoverBgSoft,
         animate
           ? 'motion-safe:animate-answer-lock motion-reduce:bg-success/5'
           : 'motion-safe:animate-fade-in',
       )}
     >
-      <span
-        aria-hidden
-        className={cn(
-          'pointer-events-none absolute inset-y-2 left-0 w-0.5 rounded-full transition-colors duration-200',
-          hasPendingAnswer ? 'bg-primary/70' : 'bg-warning/60',
-        )}
-      />
-
       <div className="flex items-start justify-between gap-2">
         <div className="flex min-w-0 items-start gap-2">
-          <MessageCircleQuestion size={13} aria-hidden className="mt-0.5 shrink-0 text-warning" />
+          <MessageCircleQuestion
+            size={13}
+            aria-hidden
+            className={cn('shrink-0 translate-y-0.5', warningAccent.icon)}
+          />
           <Markdown
             text={question.text}
             className="min-w-0 gap-1.5 break-words text-[13px] font-medium leading-relaxed text-foreground"
@@ -135,7 +121,7 @@ export const QuestionCard = ({
       </div>
 
       <div className="flex items-center gap-2 pl-[21px] text-2xs text-muted-foreground">
-        <span>{relativeAge(question.createdAt)}</span>
+        <span>{formatRelativeAge({ fromIso: question.createdAt })}</span>
         {question.ownedByStepOrdinal != null && (
           <span className="rounded-md bg-muted px-1 py-0.5 font-mono text-2xs text-muted-foreground">
             step {question.ownedByStepOrdinal}
@@ -147,6 +133,6 @@ export const QuestionCard = ({
           </span>
         )}
       </div>
-    </div>
+    </TranscriptShell>
   );
 };

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/QuestionsPane.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/QuestionsPane.test.tsx
@@ -5,9 +5,11 @@ let _openQuestions: Array<{ status: string; [k: string]: unknown }> = [];
 let _answeredQuestions: Array<{ status: string; [k: string]: unknown }> = [];
 let _oqDrafts: Record<string, unknown> = {};
 let _oqJustAnswered: string[] = [];
+let _oqPendingUndo: { question: { id: string; sessionId: string }; timer: number } | null = null;
 
 const mockAnswerOpenQuestions = vi.fn().mockResolvedValue(undefined);
 const mockDismissOpenQuestion = vi.fn().mockResolvedValue(undefined);
+const mockRestoreDismissedOpenQuestion = vi.fn().mockResolvedValue(undefined);
 const mockLoadSessionAnsweredQuestions = vi.fn().mockResolvedValue(undefined);
 const mockSelectAgent = vi.fn().mockResolvedValue(undefined);
 const mockFlashAnswered = vi.fn();
@@ -15,6 +17,8 @@ const mockToggleSuggestion = vi.fn();
 const mockSetCustomAnswer = vi.fn();
 const mockToggleCustomField = vi.fn();
 const mockClearJustAnswered = vi.fn();
+const mockBeginUndo = vi.fn();
+const mockClearUndo = vi.fn();
 
 vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
 vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn() }));
@@ -41,6 +45,9 @@ vi.mock('../../../../context/components/QuestionsTab/useOpenQuestions', () => ({
       toggleCustomField: mockToggleCustomField,
       flashAnswered: mockFlashAnswered,
       clearJustAnswered: mockClearJustAnswered,
+      pendingUndo: _oqPendingUndo,
+      beginUndo: mockBeginUndo,
+      clearUndo: mockClearUndo,
     }),
   ),
   deriveDraftAnswer: vi.fn(
@@ -77,7 +84,7 @@ vi.mock('../../SessionOverviewPane/lib', () => ({
   selectOpenQuestions: (qs: Array<{ status: string }>) => qs.filter((q) => q.status === 'open'),
 }));
 
-vi.mock('../../../../chat/components/ChatView/OpenQuestionInlineCard', () => ({
+vi.mock('../../../../chat/components/ChatView/AnsweredCard', () => ({
   AnsweredCard: (props: { question: { id: string; text: string } }) => (
     <div data-testid={`answered-card-${props.question.id}`}>{props.question.text}</div>
   ),
@@ -85,7 +92,7 @@ vi.mock('../../../../chat/components/ChatView/OpenQuestionInlineCard', () => ({
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import React from 'react';
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type {
   Agent,
   AgentId,
@@ -177,6 +184,7 @@ function setupStore(overrides: {
   openQuestions?: OpenQuestion[];
   answeredQuestions?: OpenQuestion[];
   drafts?: Record<string, unknown>;
+  pendingUndoQuestion?: OpenQuestion;
 }) {
   const agents = overrides.agents ?? [];
   const workflows = overrides.workflows ?? [];
@@ -187,6 +195,9 @@ function setupStore(overrides: {
   _answeredQuestions = answeredQuestions;
   _oqDrafts = overrides.drafts ?? {};
   _oqJustAnswered = [];
+  _oqPendingUndo = overrides.pendingUndoQuestion
+    ? { question: overrides.pendingUndoQuestion, timer: 0 }
+    : null;
   _storeState = {
     sessionPhaseRuns: { [SESSION_ID]: agents },
     phaseTemplates: { [WS_ID]: workflows },
@@ -194,6 +205,7 @@ function setupStore(overrides: {
     sessionAnsweredQuestions: { [SESSION_ID]: answeredQuestions },
     answerOpenQuestions: mockAnswerOpenQuestions,
     dismissOpenQuestion: mockDismissOpenQuestion,
+    restoreDismissedOpenQuestion: mockRestoreDismissedOpenQuestion,
     loadSessionAnsweredQuestions: mockLoadSessionAnsweredQuestions,
     selectAgent: mockSelectAgent,
   };
@@ -207,6 +219,7 @@ afterEach(() => {
   _answeredQuestions = [];
   _oqDrafts = {};
   _oqJustAnswered = [];
+  _oqPendingUndo = null;
 });
 
 describe('QuestionsPane', () => {
@@ -405,13 +418,14 @@ describe('QuestionsPane', () => {
   });
 
   describe('dismiss callback', () => {
-    it('calls dismissOpenQuestion with session id and question', () => {
+    it('calls dismissOpenQuestion and starts the undo window', async () => {
       const question = mkQuestion('q1');
       setupStore({ openQuestions: [question] });
       render(<QuestionsPane session={BASE_SESSION} />);
 
       fireEvent.click(screen.getByText('dismiss'));
       expect(mockDismissOpenQuestion).toHaveBeenCalledWith(SESSION_ID, question);
+      await waitFor(() => expect(mockBeginUndo).toHaveBeenCalledWith(question));
     });
   });
 
@@ -590,6 +604,18 @@ describe('QuestionsPane', () => {
       expect(screen.getByTestId('answered-card-aq1')).toBeDefined();
       expect(screen.getByTestId('answered-card-aq2')).toBeDefined();
       expect(screen.getByText('scout')).toBeDefined();
+      expect(screen.queryByText('No open questions')).toBeNull();
+    });
+
+    it('restores a transiently dismissed question from the undo state', async () => {
+      const question = mkQuestion('q1');
+      setupStore({ openQuestions: [], pendingUndoQuestion: question });
+
+      render(<QuestionsPane session={BASE_SESSION} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Undo' }));
+
+      expect(mockRestoreDismissedOpenQuestion).toHaveBeenCalledWith(SESSION_ID, question);
+      await waitFor(() => expect(mockClearUndo).toHaveBeenCalled());
     });
 
     it('clusters answered by different agents separately', () => {

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/QuestionsPane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/QuestionsPane.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo } from 'react';
-import { ArrowRight, Bot, CircleCheck } from 'lucide-react';
-import { EmptyState, cn } from '@goodboy/ui';
+import { Bot, CircleCheck } from 'lucide-react';
+import { EmptyState } from '@goodboy/ui';
 import type {
   Agent,
   AgentId,
@@ -15,7 +15,10 @@ import {
   useSessionAnsweredQuestions,
   useSessionOpenQuestions,
 } from '../../../../../store';
-import { AnsweredCard } from '../../../../chat/components/ChatView/OpenQuestionInlineCard';
+import { formatRelativeAge } from '../../../../../shared/utils/relativeDate';
+import { AnsweredCard } from '../../../../chat/components/ChatView/AnsweredCard';
+import { AnswerSubmitButton } from '../../../../context/components/QuestionsTab/AnswerSubmitButton';
+import { DismissedQuestionUndo } from '../../../../context/components/QuestionsTab/DismissedQuestionUndo';
 import { QuestionCard } from '../../../../context/components/QuestionsTab/QuestionCard';
 import { QuestionClusterHeader } from '../../../../context/components/QuestionsTab/QuestionClusterHeader';
 import {
@@ -46,6 +49,8 @@ type ClusterSectionProps = {
   readonly onToggleCustomField: (questionId: OpenQuestionId) => void;
   readonly onClearJustAnswered: (id: OpenQuestionId) => void;
   readonly onDismiss: (question: OpenQuestion) => void;
+  readonly pendingUndoQuestionId: OpenQuestionId | null;
+  readonly onUndo: (question: OpenQuestion) => void;
   readonly onSubmit: (pairs: ReadonlyArray<AnswerPair>, ownerAgentId: AgentId | null) => void;
 };
 
@@ -60,9 +65,12 @@ const ClusterSection = ({
   onToggleCustomField,
   onClearJustAnswered,
   onDismiss,
+  pendingUndoQuestionId,
+  onUndo,
   onSubmit,
 }: ClusterSectionProps) => {
   const pendingPairs = cluster.questions
+    .filter((question) => question.id !== pendingUndoQuestionId)
     .map((q) => ({ id: q.id, text: q.text, answer: deriveDraftAnswer(drafts[q.id]) }))
     .filter((pair) => pair.answer.length > 0);
 
@@ -76,41 +84,30 @@ const ClusterSection = ({
           creatorAgentName={cluster.creatorAgentName}
         />
       )}
-      {cluster.questions.map((q) => (
-        <QuestionCard
-          key={q.id}
-          question={q}
-          selectedSuggestions={drafts[q.id]?.selectedSuggestions ?? []}
-          customAnswer={drafts[q.id]?.customAnswer ?? ''}
-          showCustomField={drafts[q.id]?.showCustomField ?? false}
-          justAnswered={justAnswered.includes(q.id)}
-          onToggleSuggestion={onToggleSuggestion}
-          onSetCustomAnswer={onSetCustomAnswer}
-          onToggleCustomField={onToggleCustomField}
-          onDismiss={() => onDismiss(q)}
-          onClearJustAnswered={onClearJustAnswered}
-        />
-      ))}
-      {pendingPairs.length > 0 ? (
-        <button
-          type="button"
-          onClick={() => onSubmit(pendingPairs, cluster.ownerAgentId)}
-          className={cn(
-            'group flex w-full items-center justify-center gap-1.5 rounded-lg px-3 py-2 text-xs font-semibold',
-            'bg-primary text-primary-foreground shadow-sm motion-safe:transition-all duration-150',
-            'hover:brightness-105 active:scale-[0.99]',
-            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
-          )}
-        >
-          <span>
-            {pendingPairs.length > 1 ? `send ${pendingPairs.length} answers` : 'send answer'}
-          </span>
-          <ArrowRight
-            size={13}
-            aria-hidden
-            className="motion-safe:transition-transform group-hover:translate-x-0.5"
+      {cluster.questions.map((q) =>
+        q.id === pendingUndoQuestionId ? (
+          <DismissedQuestionUndo key={q.id} onUndo={() => onUndo(q)} />
+        ) : (
+          <QuestionCard
+            key={q.id}
+            question={q}
+            selectedSuggestions={drafts[q.id]?.selectedSuggestions ?? []}
+            customAnswer={drafts[q.id]?.customAnswer ?? ''}
+            showCustomField={drafts[q.id]?.showCustomField ?? false}
+            justAnswered={justAnswered.includes(q.id)}
+            onToggleSuggestion={onToggleSuggestion}
+            onSetCustomAnswer={onSetCustomAnswer}
+            onToggleCustomField={onToggleCustomField}
+            onDismiss={() => onDismiss(q)}
+            onClearJustAnswered={onClearJustAnswered}
           />
-        </button>
+        ),
+      )}
+      {pendingPairs.length > 0 ? (
+        <AnswerSubmitButton
+          answerCount={pendingPairs.length}
+          onClick={() => onSubmit(pendingPairs, cluster.ownerAgentId)}
+        />
       ) : null}
     </div>
   );
@@ -178,17 +175,6 @@ const AnsweredClusterHeader = ({
 }: AnsweredClusterHeaderProps) => {
   const selectAgent = useAppStore((s) => s.selectAgent);
 
-  const diffMs = Date.now() - new Date(newestAt).getTime();
-  const mins = Math.floor(diffMs / 60_000);
-  const timeLabel =
-    mins < 1
-      ? 'just now'
-      : mins < 60
-        ? `${mins}m ago`
-        : mins < 1440
-          ? `${Math.floor(mins / 60)}h ago`
-          : `${Math.floor(mins / 1440)}d ago`;
-
   return (
     <div className="flex items-center justify-between gap-2 px-0.5">
       {agentId !== null && agentName !== null ? (
@@ -206,7 +192,9 @@ const AnsweredClusterHeader = ({
           <span className="truncate text-foreground/80">unknown agent</span>
         </div>
       )}
-      <span className="shrink-0 text-2xs text-muted-foreground">{timeLabel}</span>
+      <span className="shrink-0 text-2xs text-muted-foreground">
+        {formatRelativeAge({ fromIso: newestAt })}
+      </span>
     </div>
   );
 };
@@ -259,16 +247,32 @@ export const QuestionsPane = ({ session }: QuestionsPaneProps) => {
   const toggleCustomField = useOpenQuestions((s) => s.toggleCustomField);
   const clearJustAnswered = useOpenQuestions((s) => s.clearJustAnswered);
   const flashAnswered = useOpenQuestions((s) => s.flashAnswered);
+  const pendingUndo = useOpenQuestions((s) => s.pendingUndo);
+  const beginUndo = useOpenQuestions((s) => s.beginUndo);
+  const clearUndo = useOpenQuestions((s) => s.clearUndo);
   const answerOpenQuestions = useAppStore((s) => s.answerOpenQuestions);
   const dismissOpenQuestion = useAppStore((s) => s.dismissOpenQuestion);
+  const restoreDismissedOpenQuestion = useAppStore((s) => s.restoreDismissedOpenQuestion);
 
   useEffect(() => {
     void loadSessionAnsweredQuestions(sessionId);
   }, [sessionId, loadSessionAnsweredQuestions]);
 
+  const pendingUndoQuestion =
+    pendingUndo?.question.sessionId === sessionId ? pendingUndo.question : null;
+  const displayedOpen = useMemo(() => {
+    if (
+      pendingUndoQuestion === null ||
+      open.some((question) => question.id === pendingUndoQuestion.id)
+    ) {
+      return open;
+    }
+    return [...open, pendingUndoQuestion].sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+  }, [open, pendingUndoQuestion]);
+
   const clusters = useMemo(
-    () => buildQuestionClusters({ questions: open, agents, workflows }),
-    [open, agents, workflows],
+    () => buildQuestionClusters({ questions: displayedOpen, agents, workflows }),
+    [displayedOpen, agents, workflows],
   );
 
   const agentById = useMemo(() => {
@@ -295,19 +299,40 @@ export const QuestionsPane = ({ session }: QuestionsPaneProps) => {
     [flashAnswered, answerOpenQuestions, sessionId],
   );
 
-  if (open.length === 0) {
+  const handleDismiss = useCallback(
+    async (question: OpenQuestion) => {
+      await dismissOpenQuestion(sessionId, question);
+      beginUndo(question);
+    },
+    [beginUndo, dismissOpenQuestion, sessionId],
+  );
+
+  const handleUndo = useCallback(
+    async (question: OpenQuestion) => {
+      await restoreDismissedOpenQuestion(sessionId, question);
+      clearUndo();
+    },
+    [clearUndo, restoreDismissedOpenQuestion, sessionId],
+  );
+
+  if (open.length === 0 && answeredClusters.length === 0 && pendingUndoQuestion === null) {
     return (
       <PaneShell title="Questions" description="Decisions agents need from you to keep going.">
-        <div className="flex flex-col gap-6">
-          <EmptyState
-            bordered
-            tone="success"
-            icon={CircleCheck}
-            title="No open questions"
-            description="When an agent needs a decision, it shows up here."
-          />
-          <AnsweredHistory clusters={answeredClusters} sessionId={sessionId} />
-        </div>
+        <EmptyState
+          bordered
+          tone="success"
+          icon={CircleCheck}
+          title="No open questions"
+          description="When an agent needs a decision, it shows up here."
+        />
+      </PaneShell>
+    );
+  }
+
+  if (open.length === 0 && pendingUndoQuestion === null) {
+    return (
+      <PaneShell title="Questions" description="Decisions agents need from you to keep going.">
+        <AnsweredHistory clusters={answeredClusters} sessionId={sessionId} />
       </PaneShell>
     );
   }
@@ -315,7 +340,11 @@ export const QuestionsPane = ({ session }: QuestionsPaneProps) => {
   return (
     <PaneShell
       title="Questions"
-      description={`${open.length} open ${open.length === 1 ? 'question' : 'questions'} waiting on you.`}
+      description={
+        open.length > 0
+          ? `${open.length} open ${open.length === 1 ? 'question' : 'questions'} waiting on you.`
+          : 'Decisions agents need from you to keep going.'
+      }
     >
       <div className="flex flex-col gap-4">
         {clusters.map((cluster) => (
@@ -330,7 +359,9 @@ export const QuestionsPane = ({ session }: QuestionsPaneProps) => {
             onSetCustomAnswer={setCustomAnswer}
             onToggleCustomField={toggleCustomField}
             onClearJustAnswered={clearJustAnswered}
-            onDismiss={(q) => void dismissOpenQuestion(sessionId, q)}
+            onDismiss={(question) => void handleDismiss(question)}
+            pendingUndoQuestionId={pendingUndoQuestion?.id ?? null}
+            onUndo={(question) => void handleUndo(question)}
             onSubmit={(pairs, ownerAgentId) => void handleSubmit(pairs, ownerAgentId)}
           />
         ))}

--- a/apps/desktop/src/store/slices/open-questions/dismissOpenQuestion.test.ts
+++ b/apps/desktop/src/store/slices/open-questions/dismissOpenQuestion.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createStore } from 'zustand';
+import type { IsoDateTime, OpenQuestion, OpenQuestionId, SessionId } from '@goodboy/types';
+
+const {
+  addQuestionsToSlot,
+  markOpenQuestionDismissed,
+  removeQuestionsFromSlot,
+  restoreOpenQuestion,
+} = vi.hoisted(() => ({
+  addQuestionsToSlot: vi.fn(async () => false),
+  markOpenQuestionDismissed: vi.fn(async () => undefined),
+  removeQuestionsFromSlot: vi.fn(async () => false),
+  restoreOpenQuestion: vi.fn(async () => undefined),
+}));
+
+vi.mock('@goodboy/db', () => ({
+  markOpenQuestionDismissed,
+  restoreOpenQuestion,
+}));
+vi.mock('@goodboy/core', () => ({
+  addQuestionsToSlot,
+  removeQuestionsFromSlot,
+}));
+vi.mock('../../../shared/lib/db', () => ({ tauriDatabase: {} }));
+
+import { dismissOpenQuestion } from './dismissOpenQuestion';
+import { restoreDismissedOpenQuestion } from './restoreDismissedOpenQuestion';
+
+type TestState = {
+  sessionOpenQuestions: Record<string, ReadonlyArray<OpenQuestion>>;
+  loadSessionSlots: (sessionId: SessionId) => Promise<void>;
+  maybeAutoAdvanceWorkflow: (sessionId: SessionId) => Promise<void>;
+};
+
+const sessionId = 'sess-1' as SessionId;
+const question = {
+  id: 'oq-1' as OpenQuestionId,
+  sessionId,
+  text: 'Which database?',
+  suggestedAnswers: ['SQLite'],
+  userAnswer: null,
+  status: 'open',
+  createdAt: '2026-07-30T10:00:00.000Z' as IsoDateTime,
+} satisfies OpenQuestion;
+
+describe('dismissed open question restoration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('round-trips a dismissed question through persistence and store state', async () => {
+    const store = createStore<TestState>(() => ({
+      sessionOpenQuestions: { [sessionId]: [question] },
+      loadSessionSlots: vi.fn(async () => undefined),
+      maybeAutoAdvanceWorkflow: vi.fn(async () => undefined),
+    }));
+    const dismiss = dismissOpenQuestion(store.setState as never, store.getState as never);
+    const restore = restoreDismissedOpenQuestion(store.setState as never, store.getState as never);
+
+    await dismiss(sessionId, question);
+    expect(store.getState().sessionOpenQuestions[sessionId]).toEqual([]);
+    expect(markOpenQuestionDismissed).toHaveBeenCalledWith(expect.anything(), question.id);
+
+    await restore(sessionId, question);
+    expect(store.getState().sessionOpenQuestions[sessionId]).toEqual([question]);
+    expect(restoreOpenQuestion).toHaveBeenCalledWith(expect.anything(), question.id);
+    expect(store.getState().maybeAutoAdvanceWorkflow).toHaveBeenCalledWith(sessionId);
+  });
+});

--- a/apps/desktop/src/store/slices/turn/sendTurn.ts
+++ b/apps/desktop/src/store/slices/turn/sendTurn.ts
@@ -13,6 +13,7 @@ import {
   type ClaudeFlagSet,
 } from '@goodboy/core';
 import {
+  countUserTextEvents,
   insertMessage,
   insertProviderRun,
   listContextSlotsForSession,
@@ -913,9 +914,18 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
           }
           return undefined;
         })();
-        const turnOrdinal = (get().transcripts[activeAgentId] ?? []).filter(
+        const transcriptTurnOrdinal = (get().transcripts[activeAgentId] ?? []).filter(
           (e) => e.kind === 'user_text',
         ).length;
+        let turnOrdinal = transcriptTurnOrdinal;
+        try {
+          turnOrdinal = await countUserTextEvents({
+            db: tauriDatabase,
+            agentId: activeAgentId,
+          });
+        } catch {
+          turnOrdinal = transcriptTurnOrdinal;
+        }
         const result = await autoPopulateContext({
           db: tauriDatabase,
           sessionId,

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -68,6 +68,7 @@ export {
 export {
   insertTurnEvent,
   insertTurnEventsBatch,
+  countUserTextEvents,
   listTurnEventsForAgent,
   listTurnEventsForSession,
   listAgentRunIdsForSession,

--- a/packages/db/src/queries/turn-event.test.ts
+++ b/packages/db/src/queries/turn-event.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import type {
+  Agent,
+  AgentId,
+  IsoDateTime,
+  ProviderRunId,
+  SessionId,
+  WorkspaceId,
+} from '@goodboy/types';
+import type { Database } from '../client';
+import { migrate } from '../migrations/runner';
+import { makeTestDatabase } from '../test-helpers/test-db';
+import { insertAgent } from './agent';
+import { countUserTextEvents, insertTurnEvent } from './turn-event';
+
+const workspaceId = 'workspace-1' as WorkspaceId;
+const sessionId = 'session-1' as SessionId;
+const agentId = 'agent-1' as AgentId;
+const otherAgentId = 'agent-2' as AgentId;
+const runId = 'run-1' as ProviderRunId;
+const at = '2026-07-30T10:00:00.000Z' as IsoDateTime;
+
+describe('turn event queries', () => {
+  let db: Database;
+
+  beforeEach(async () => {
+    db = makeTestDatabase();
+    await migrate(db);
+    const now = Date.now();
+    await db.execute(
+      'INSERT INTO workspaces (id, name, root_path, created_at, updated_at) VALUES (?, ?, ?, ?, ?)',
+      [workspaceId, 'workspace', '/tmp/workspace', now, now],
+    );
+    await db.execute(
+      'INSERT INTO sessions (id, workspace_id, goal, state_kind, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)',
+      [sessionId, workspaceId, 'goal', 'idle', now, now],
+    );
+    const agents: ReadonlyArray<Agent> = [
+      {
+        id: agentId,
+        sessionId,
+        ordinal: 0,
+        name: 'agent one',
+        status: 'pending',
+      },
+      {
+        id: otherAgentId,
+        sessionId,
+        ordinal: 1,
+        name: 'agent two',
+        status: 'pending',
+      },
+    ];
+    for (const agent of agents) {
+      await insertAgent(db, agent);
+    }
+  });
+
+  it('counts only user_text payloads for the requested agent', async () => {
+    await insertTurnEvent(db, {
+      id: 'event-1',
+      sessionId,
+      agentId,
+      event: { kind: 'user_text', runId, text: 'first', at },
+    });
+    await insertTurnEvent(db, {
+      id: 'event-2',
+      sessionId,
+      agentId,
+      event: { kind: 'assistant_text', runId, delta: 'reply', at },
+    });
+    await insertTurnEvent(db, {
+      id: 'event-3',
+      sessionId,
+      agentId,
+      event: { kind: 'user_text', runId, text: 'second', at },
+    });
+    await insertTurnEvent(db, {
+      id: 'event-4',
+      sessionId,
+      agentId: otherAgentId,
+      event: { kind: 'user_text', runId, text: 'other agent', at },
+    });
+
+    await expect(countUserTextEvents({ db, agentId })).resolves.toBe(2);
+    await expect(countUserTextEvents({ db, agentId: otherAgentId })).resolves.toBe(1);
+  });
+});

--- a/packages/db/src/queries/turn-event.ts
+++ b/packages/db/src/queries/turn-event.ts
@@ -9,6 +9,15 @@ type TurnEventRow = {
   created_at: number;
 };
 
+type CountUserTextEventsParams = {
+  readonly db: Database;
+  readonly agentId: AgentId;
+};
+
+type CountRow = {
+  count: number;
+};
+
 function rowToEvent(row: TurnEventRow): TurnEvent | null {
   try {
     return JSON.parse(row.payload) as TurnEvent;
@@ -109,6 +118,19 @@ export const listTurnEventsForSession = async (
     [sessionId],
   );
   return rows.map(rowToEvent).filter((e): e is TurnEvent => e !== null);
+};
+
+export const countUserTextEvents = async ({
+  db,
+  agentId,
+}: CountUserTextEventsParams): Promise<number> => {
+  const rows = await db.select<CountRow>(
+    `SELECT COUNT(*) AS count
+     FROM turn_events
+     WHERE agent_id = ? AND json_extract(payload, '$.kind') = 'user_text'`,
+    [agentId],
+  );
+  return rows[0]?.count ?? 0;
 };
 
 export const listAgentRunIdsForSession = async (


### PR DESCRIPTION
## Description

Open questions could be invisible in chat: the turn ordinal was derived from the in-memory transcript, which is hydrated with only the last 50 events, so questions from agents with longer histories were bucketed against old turns (or never rendered). The Questions lens also stacked a permanent "No open questions" empty state on top of the answered history, and the question cards used hand-rolled styling outside the transcript card system.

## Scope

- `turn_ordinal` now derives from a DB count of user turns (`countUserTextEvents`), falling back to the in-memory count on failure
- open questions with null or out-of-window ordinals render at the transcript tail instead of being dropped; an open question for the selected agent is always visible in its chat
- open questions owned by other agents surface as a compact affordance that selects the owning agent and scrolls to the question
- the Questions lens empty state renders only when there are no open and no answered questions
- question cards rebuilt on `TranscriptShell leftBorder` + `MARKER_ACCENT.warning`, matching the workflow/system transcript cards; answered cards share the same shell
- shared `AnswerSubmitButton` replaces the duplicated submit markup in chat clusters and the Questions lens
- dismiss now shows a 5s undo wired to the previously dead `restoreDismissedOpenQuestion` action, with a new slice round-trip test

## Verification

- monorepo typecheck green
- full apps/desktop suite: 3113 tests passed
- packages/db suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)