### PR TITLE
feat(desktop): integration panes cleanup and github session dashboard

### DIFF
--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/LinkIssueForm.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/LinkIssueForm.tsx
@@ -1,0 +1,129 @@
+import { useState, type FormEvent } from 'react';
+import { Link2 } from 'lucide-react';
+import type {
+  IsoDateTime,
+  SessionExternalTaskProvider,
+  SessionId,
+  WorkspaceId,
+} from '@goodboy/types';
+import { Button, Input } from '@goodboy/ui';
+import { useAppStore } from '../../../../../../store';
+import { formatError } from '../../../../../../shared/lib/errors';
+import { IssuePicker } from '../../../../../integrations/components/IssuePicker';
+import { useIssueCandidates } from '../../../../../integrations/hooks/useIssueCandidates';
+import type { IssueCandidate } from '../../../../../integrations/fetchIssueCandidates';
+import { parseIntegrationTaskUrl } from './parseIntegrationTaskUrl';
+
+type Props = {
+  readonly sessionId: SessionId;
+  readonly workspaceId: WorkspaceId;
+  readonly provider: SessionExternalTaskProvider;
+  readonly providerLabel: string;
+  readonly onLinked?: () => void;
+};
+
+export const LinkIssueForm = ({
+  sessionId,
+  workspaceId,
+  provider,
+  providerLabel,
+  onLinked,
+}: Props) => {
+  const [url, setUrl] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [isLinking, setIsLinking] = useState(false);
+  const linkSessionExternalTask = useAppStore((state) => state.linkSessionExternalTask);
+  const candidates = useIssueCandidates({ workspaceId, provider });
+
+  const finishLink = () => {
+    if (onLinked != null) {
+      onLinked();
+    }
+  };
+
+  const handlePick = async (candidate: IssueCandidate) => {
+    setError(null);
+    setIsLinking(true);
+    try {
+      await linkSessionExternalTask(sessionId, {
+        provider,
+        externalId: candidate.externalId,
+        identifier: candidate.identifier,
+        title: candidate.title,
+        url: candidate.url,
+        createdAt: new Date().toISOString() as IsoDateTime,
+      });
+      finishLink();
+    } catch (linkError) {
+      setError(formatError(linkError));
+    } finally {
+      setIsLinking(false);
+    }
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const parsedTask = parseIntegrationTaskUrl({ provider, rawUrl: url });
+    if (parsedTask == null) {
+      setError('Paste an issue URL to link it.');
+      return;
+    }
+    setError(null);
+    setIsLinking(true);
+    try {
+      await linkSessionExternalTask(sessionId, {
+        ...parsedTask,
+        provider,
+        createdAt: new Date().toISOString() as IsoDateTime,
+      });
+      setUrl('');
+      finishLink();
+    } catch (linkError) {
+      setError(formatError(linkError));
+    } finally {
+      setIsLinking(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <label htmlFor={`${provider}-issue-picker`} className="text-xs font-medium text-foreground">
+        Link an issue
+      </label>
+      <IssuePicker
+        inputId={`${provider}-issue-picker`}
+        rows={candidates.rows}
+        isLoading={candidates.isLoading}
+        isLoaded={candidates.isLoaded}
+        error={candidates.error}
+        value={null}
+        placeholder={`Search ${providerLabel} issues assigned to you…`}
+        disabled={isLinking}
+        onOpen={candidates.load}
+        onPick={(candidate) => void handlePick(candidate)}
+        onClear={() => undefined}
+      />
+      <form onSubmit={handleSubmit} className="flex flex-col gap-1.5">
+        <label
+          htmlFor={`${provider}-issue-url`}
+          className="text-xs font-medium text-muted-foreground"
+        >
+          Or paste a {providerLabel} issue URL
+        </label>
+        <div className="flex items-center gap-2">
+          <Input
+            id={`${provider}-issue-url`}
+            value={url}
+            onChange={(event) => setUrl(event.target.value)}
+            placeholder={`Or paste a ${providerLabel} issue URL`}
+          />
+          <Button type="submit" size="sm" disabled={isLinking}>
+            <Link2 size={13} aria-hidden />
+            Link
+          </Button>
+        </div>
+        {error != null ? <p className="text-xs text-danger">{error}</p> : null}
+      </form>
+    </div>
+  );
+};

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/LinkTicketPopover.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/LinkTicketPopover.tsx
@@ -1,0 +1,61 @@
+import { Plus } from 'lucide-react';
+import type { SessionExternalTaskProvider, SessionId, WorkspaceId } from '@goodboy/types';
+import { Button, Popover, cn } from '@goodboy/ui';
+import { useDropdown } from '../../../../../../shared/hooks/useDropdown';
+import { DropdownPortal } from '../../../../../../shared/hooks/useDropdown/DropdownPortal';
+import { LinkIssueForm } from './LinkIssueForm';
+
+type Props = {
+  readonly sessionId: SessionId;
+  readonly workspaceId: WorkspaceId;
+  readonly provider: SessionExternalTaskProvider;
+  readonly providerLabel: string;
+};
+
+export const LinkTicketPopover = ({ sessionId, workspaceId, provider, providerLabel }: Props) => {
+  const {
+    open,
+    close,
+    toggle,
+    containerRef,
+    popupRef,
+    popupClassName,
+    popupStyle,
+    portal,
+    portalTarget,
+  } = useDropdown({
+    align: 'end',
+    expectedHeight: 280,
+    expectedWidth: 384,
+    width: 'w-96 max-w-[calc(100vw-2rem)]',
+    strategy: 'fixed',
+  });
+
+  return (
+    <div ref={containerRef} className="relative min-w-0">
+      <Button variant="secondary" size="sm" onClick={toggle}>
+        <Plus size={13} aria-hidden />
+        Link ticket
+      </Button>
+      <DropdownPortal portal={portal} portalTarget={portalTarget}>
+        {open && (
+          <Popover
+            innerRef={popupRef}
+            role="dialog"
+            ariaLabel={`link ${providerLabel} ticket`}
+            className={cn(popupClassName, 'p-3')}
+            style={popupStyle}
+          >
+            <LinkIssueForm
+              sessionId={sessionId}
+              workspaceId={workspaceId}
+              provider={provider}
+              providerLabel={providerLabel}
+              onLinked={close}
+            />
+          </Popover>
+        )}
+      </DropdownPortal>
+    </div>
+  );
+};

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/index.test.tsx
@@ -14,6 +14,7 @@ type Store = {
 
 type Props = {
   readonly children: ReactNode;
+  readonly actions?: ReactNode;
 };
 
 const h = vi.hoisted(() => ({
@@ -60,7 +61,12 @@ vi.mock('./SentryTaskDetail', () => ({
 }));
 
 vi.mock('../PaneShell', () => ({
-  PaneShell: ({ children }: Props) => <div>{children}</div>,
+  PaneShell: ({ children, actions }: Props) => (
+    <div>
+      {actions}
+      {children}
+    </div>
+  ),
 }));
 
 vi.mock('../../../../../integrations/hooks/useIssueCandidates', () => ({
@@ -159,9 +165,10 @@ describe('IntegrationPane', () => {
     );
   });
 
-  it('links a pasted provider URL', async () => {
+  it('links a pasted provider URL from the Link ticket popover and closes it', async () => {
     render(<IntegrationPane sessionId={SESSION_ID} workspaceId={WORKSPACE_ID} provider="linear" />);
 
+    fireEvent.click(screen.getByRole('button', { name: 'Link ticket' }));
     fireEvent.change(screen.getByRole('textbox', { name: 'Or paste a Linear issue URL' }), {
       target: { value: 'https://linear.app/goodboy/issue/GB-99/new-link' },
     });
@@ -176,15 +183,34 @@ describe('IntegrationPane', () => {
       url: 'https://linear.app/goodboy/issue/GB-99/new-link',
       createdAt: expect.any(String),
     });
+    await waitFor(() =>
+      expect(screen.queryByRole('dialog', { name: 'link Linear ticket' })).toBeNull(),
+    );
   });
 
-  it('keeps the link form as the connected empty state and opens the provider studio', () => {
+  it('shows the Link ticket action only when a task is already linked', () => {
+    render(<IntegrationPane sessionId={SESSION_ID} workspaceId={WORKSPACE_ID} provider="linear" />);
+
+    expect(screen.queryByRole('textbox', { name: 'Or paste a Linear issue URL' })).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'Link ticket' }));
+    expect(screen.getByRole('dialog', { name: 'link Linear ticket' })).toBeDefined();
+    expect(screen.getByRole('textbox', { name: 'Or paste a Linear issue URL' })).toBeDefined();
+
+    cleanup();
+    h.store.sessionExternalTasks = {};
+    render(<IntegrationPane sessionId={SESSION_ID} workspaceId={WORKSPACE_ID} provider="linear" />);
+    expect(screen.queryByRole('button', { name: 'Link ticket' })).toBeNull();
+  });
+
+  it('integrates the link form into the connected empty state and opens the provider studio', () => {
     h.store.sessionExternalTasks = {};
     const listener = vi.fn();
     window.addEventListener('goodboy:open-sentry-studio', listener);
     render(<IntegrationPane sessionId={SESSION_ID} workspaceId={WORKSPACE_ID} provider="sentry" />);
 
+    expect(screen.getByText('No Sentry issues linked')).toBeDefined();
     expect(screen.getByRole('textbox', { name: 'Or paste a Sentry issue URL' })).toBeDefined();
+    expect(screen.queryByRole('button', { name: 'Link ticket' })).toBeNull();
     fireEvent.click(screen.getByRole('button', { name: 'Open Sentry studio' }));
     expect(listener).toHaveBeenCalledOnce();
     window.removeEventListener('goodboy:open-sentry-studio', listener);
@@ -228,6 +254,7 @@ describe('IntegrationPane', () => {
 
     render(<IntegrationPane sessionId={SESSION_ID} workspaceId={WORKSPACE_ID} provider="linear" />);
 
+    fireEvent.click(screen.getByRole('button', { name: 'Link ticket' }));
     fireEvent.focus(screen.getByRole('combobox', { name: 'Link an issue' }));
     fireEvent.mouseDown(screen.getByText('Ship the issue picker'));
 
@@ -246,6 +273,7 @@ describe('IntegrationPane', () => {
 
   it('does not submit the URL form when Enter is pressed in a closed issue picker', () => {
     render(<IntegrationPane sessionId={SESSION_ID} workspaceId={WORKSPACE_ID} provider="linear" />);
+    fireEvent.click(screen.getByRole('button', { name: 'Link ticket' }));
     const picker = screen.getByRole('combobox', { name: 'Link an issue' });
 
     fireEvent.focus(picker);

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/index.tsx
@@ -1,25 +1,19 @@
-import { useMemo, useState, type FormEvent } from 'react';
-import { ExternalLink, Link2, Unlink } from 'lucide-react';
-import type {
-  IsoDateTime,
-  SessionExternalTaskProvider,
-  SessionId,
-  WorkspaceId,
-} from '@goodboy/types';
-import { Button, Divider, InlineConfirm, Input } from '@goodboy/ui';
+import { useMemo, useState } from 'react';
+import { Link2, Unlink } from 'lucide-react';
+import type { SessionExternalTaskProvider, SessionId, WorkspaceId } from '@goodboy/types';
+import { Button, Divider, EmptyState, InlineConfirm } from '@goodboy/ui';
 import { EMPTY_ARRAY, useAppStore } from '../../../../../../store';
 import { formatError } from '../../../../../../shared/lib/errors';
 import { openUrl } from '../../../../../../shared/lib/editor';
 import { ConnectIntegrationEmptyState } from '../../../../../integrations/ConnectIntegrationEmptyState';
-import { IssuePicker } from '../../../../../integrations/components/IssuePicker';
-import { useIssueCandidates } from '../../../../../integrations/hooks/useIssueCandidates';
-import type { IssueCandidate } from '../../../../../integrations/fetchIssueCandidates';
+import { ExternalTaskChip } from '../../../../../integrations/components/ExternalTaskChip';
 import { resolveIntegrationConnection } from '../../../../../integrations/connection';
 import { MissingGithubRemoteEmptyState } from '../../../../../github/components/MissingGithubRemoteEmptyState';
 import { useRemoteHostKind } from '../../../../../worktree/useRemoteHostKind';
 import { PaneShell } from '../PaneShell';
 import { LinearTaskDetail } from './LinearTaskDetail';
-import { parseIntegrationTaskUrl } from './parseIntegrationTaskUrl';
+import { LinkIssueForm } from './LinkIssueForm';
+import { LinkTicketPopover } from './LinkTicketPopover';
 import { SentryTaskDetail } from './SentryTaskDetail';
 
 type Props = {
@@ -45,15 +39,12 @@ const PROVIDER_META: Record<SessionExternalTaskProvider, ProviderMeta> = {
 };
 
 export const IntegrationPane = ({ sessionId, workspaceId, provider }: Props) => {
-  const [url, setUrl] = useState('');
-  const [error, setError] = useState<string | null>(null);
-  const [isLinking, setIsLinking] = useState(false);
+  const [unlinkError, setUnlinkError] = useState<string | null>(null);
   const [unlinkingExternalId, setUnlinkingExternalId] = useState<string | null>(null);
   const [armedExternalId, setArmedExternalId] = useState<string | null>(null);
   const externalTasks = useAppStore(
     (state) => state.sessionExternalTasks[sessionId] ?? EMPTY_ARRAY,
   );
-  const linkSessionExternalTask = useAppStore((state) => state.linkSessionExternalTask);
   const unlinkSessionExternalTask = useAppStore((state) => state.unlinkSessionExternalTask);
   const integrations = useAppStore(
     (state) => state.workspaceIntegrations[workspaceId] ?? EMPTY_ARRAY,
@@ -70,58 +61,16 @@ export const IntegrationPane = ({ sessionId, workspaceId, provider }: Props) => 
     remoteKind,
     externalTasks,
   });
-  const candidates = useIssueCandidates({ workspaceId, provider });
-
-  const handlePick = async (candidate: IssueCandidate) => {
-    setError(null);
-    setIsLinking(true);
-    try {
-      await linkSessionExternalTask(sessionId, {
-        provider,
-        externalId: candidate.externalId,
-        identifier: candidate.identifier,
-        title: candidate.title,
-        url: candidate.url,
-        createdAt: new Date().toISOString() as IsoDateTime,
-      });
-    } catch (linkError) {
-      setError(formatError(linkError));
-    } finally {
-      setIsLinking(false);
-    }
-  };
-
-  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    const parsedTask = parseIntegrationTaskUrl({ provider, rawUrl: url });
-    if (parsedTask == null) {
-      setError('Paste an issue URL to link it.');
-      return;
-    }
-    setError(null);
-    setIsLinking(true);
-    try {
-      await linkSessionExternalTask(sessionId, {
-        ...parsedTask,
-        provider,
-        createdAt: new Date().toISOString() as IsoDateTime,
-      });
-      setUrl('');
-    } catch (linkError) {
-      setError(formatError(linkError));
-    } finally {
-      setIsLinking(false);
-    }
-  };
+  const hasTasks = tasks.length > 0;
 
   const handleUnlink = async ({ externalId }: UnlinkParams) => {
-    setError(null);
+    setUnlinkError(null);
     setUnlinkingExternalId(externalId);
     try {
       await unlinkSessionExternalTask(sessionId, provider, externalId);
       setArmedExternalId(null);
-    } catch (unlinkError) {
-      setError(formatError(unlinkError));
+    } catch (error) {
+      setUnlinkError(formatError(error));
     } finally {
       setUnlinkingExternalId(null);
     }
@@ -131,119 +80,99 @@ export const IntegrationPane = ({ sessionId, workspaceId, provider }: Props) => 
     <PaneShell
       title={meta.label}
       description={`External ${meta.label} issues linked to this session.`}
+      actions={
+        connection.isConnected && hasTasks ? (
+          <LinkTicketPopover
+            sessionId={sessionId}
+            workspaceId={workspaceId}
+            provider={provider}
+            providerLabel={meta.label}
+          />
+        ) : undefined
+      }
     >
       <div className="flex flex-col gap-3">
-        {connection.isConnected ? (
-          <div className="flex flex-col gap-2 rounded-lg bg-muted/20 p-3">
-            <div className="flex items-center justify-between gap-2">
-              <label
-                htmlFor={`${provider}-issue-picker`}
-                className="text-xs font-medium text-foreground"
-              >
-                Link an issue
-              </label>
-              <Button
-                variant="secondary"
-                size="sm"
-                onClick={() => window.dispatchEvent(new CustomEvent(meta.studioEvent))}
-              >
-                Open {meta.label} studio
-              </Button>
-            </div>
-            <IssuePicker
-              inputId={`${provider}-issue-picker`}
-              rows={candidates.rows}
-              isLoading={candidates.isLoading}
-              isLoaded={candidates.isLoaded}
-              error={candidates.error}
-              value={null}
-              placeholder={`Search ${meta.label} issues assigned to you…`}
-              disabled={isLinking}
-              onOpen={candidates.load}
-              onPick={(candidate) => void handlePick(candidate)}
-              onClear={() => undefined}
-            />
-            <form onSubmit={handleSubmit} className="flex flex-col gap-1.5">
-              <label
-                htmlFor={`${provider}-issue-url`}
-                className="text-xs font-medium text-muted-foreground"
-              >
-                Or paste a {meta.label} issue URL
-              </label>
-              <div className="flex items-center gap-2">
-                <Input
-                  id={`${provider}-issue-url`}
-                  value={url}
-                  onChange={(event) => setUrl(event.target.value)}
-                  placeholder={`Or paste a ${meta.label} issue URL`}
+        {!connection.isConnected ? (
+          provider === 'github' ? (
+            <MissingGithubRemoteEmptyState compact />
+          ) : (
+            <ConnectIntegrationEmptyState provider={provider} compact />
+          )
+        ) : null}
+        {connection.isConnected && !hasTasks ? (
+          <EmptyState
+            icon={Link2}
+            bordered
+            className="px-6 py-8"
+            title={`No ${meta.label} issues linked`}
+            description={`Search your assigned ${meta.label} issues or paste a URL to link one to this session.`}
+            action={
+              <div className="flex w-full max-w-md flex-col gap-3 text-left">
+                <LinkIssueForm
+                  sessionId={sessionId}
+                  workspaceId={workspaceId}
+                  provider={provider}
+                  providerLabel={meta.label}
                 />
-                <Button type="submit" size="sm" disabled={isLinking}>
-                  <Link2 size={13} aria-hidden />
-                  Link
-                </Button>
-              </div>
-              {error != null ? <p className="text-xs text-danger">{error}</p> : null}
-            </form>
-          </div>
-        ) : provider === 'github' ? (
-          <MissingGithubRemoteEmptyState compact />
-        ) : (
-          <ConnectIntegrationEmptyState provider={provider} compact />
-        )}
-
-        {tasks.length > 0 ? <Divider /> : null}
-        <div className="flex flex-col gap-5">
-          {tasks.map((task, index) => (
-            <div key={task.externalId} className="flex flex-col gap-5">
-              {index > 0 ? <Divider /> : null}
-              <div className="flex items-center gap-3 rounded-lg bg-muted/35 p-3">
-                <button
-                  type="button"
-                  onClick={() => void openUrl(task.url)}
-                  aria-label={`open ${task.identifier}`}
-                  className="flex min-w-0 flex-1 items-center gap-3 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
-                >
-                  <span className="shrink-0 font-mono text-xs font-semibold text-foreground">
-                    {task.identifier}
-                  </span>
-                  <span className="min-w-0 flex-1 truncate text-sm text-muted-foreground">
-                    {task.title}
-                  </span>
-                  <ExternalLink size={14} aria-hidden className="shrink-0 text-muted-foreground" />
-                </button>
                 <Button
-                  variant="ghost"
+                  variant="secondary"
                   size="sm"
-                  disabled={unlinkingExternalId === task.externalId}
-                  aria-label={`unlink ${task.identifier}`}
-                  onClick={() => setArmedExternalId(task.externalId)}
+                  className="self-center"
+                  onClick={() => window.dispatchEvent(new CustomEvent(meta.studioEvent))}
                 >
-                  <Unlink size={13} aria-hidden />
-                  Unlink
+                  Open {meta.label} studio
                 </Button>
               </div>
-              {armedExternalId === task.externalId ? (
-                <InlineConfirm
-                  role="danger"
-                  icon={<Unlink size={12} aria-hidden />}
-                  title={`Unlink ${task.identifier}?`}
-                  description={`Removes the ${meta.label} issue from this session without changing the issue.`}
-                  confirmLabel={`Unlink ${task.identifier}`}
-                  autoDisarmMs={4000}
-                  isBusy={unlinkingExternalId === task.externalId}
-                  onConfirm={() => handleUnlink({ externalId: task.externalId })}
-                  onCancel={() => setArmedExternalId(null)}
-                />
-              ) : null}
-              {connection.isConnected && provider === 'linear' ? (
-                <LinearTaskDetail workspaceId={workspaceId} issueId={task.externalId} />
-              ) : null}
-              {connection.isConnected && provider === 'sentry' ? (
-                <SentryTaskDetail workspaceId={workspaceId} task={task} />
-              ) : null}
-            </div>
-          ))}
-        </div>
+            }
+          />
+        ) : null}
+        {hasTasks ? (
+          <div className="flex flex-col gap-5">
+            {tasks.map((task, index) => (
+              <div key={task.externalId} className="flex flex-col gap-5">
+                {index > 0 ? <Divider /> : null}
+                <div className="flex items-center gap-2">
+                  <ExternalTaskChip
+                    task={task}
+                    appearance="row"
+                    ariaLabel={`open ${task.identifier}`}
+                    onClick={() => void openUrl(task.url)}
+                  />
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    disabled={unlinkingExternalId === task.externalId}
+                    aria-label={`unlink ${task.identifier}`}
+                    onClick={() => setArmedExternalId(task.externalId)}
+                  >
+                    <Unlink size={13} aria-hidden />
+                    Unlink
+                  </Button>
+                </div>
+                {armedExternalId === task.externalId ? (
+                  <InlineConfirm
+                    role="danger"
+                    icon={<Unlink size={12} aria-hidden />}
+                    title={`Unlink ${task.identifier}?`}
+                    description={`Removes the ${meta.label} issue from this session without changing the issue.`}
+                    confirmLabel={`Unlink ${task.identifier}`}
+                    autoDisarmMs={4000}
+                    isBusy={unlinkingExternalId === task.externalId}
+                    onConfirm={() => handleUnlink({ externalId: task.externalId })}
+                    onCancel={() => setArmedExternalId(null)}
+                  />
+                ) : null}
+                {connection.isConnected && provider === 'linear' ? (
+                  <LinearTaskDetail workspaceId={workspaceId} issueId={task.externalId} />
+                ) : null}
+                {connection.isConnected && provider === 'sentry' ? (
+                  <SentryTaskDetail workspaceId={workspaceId} task={task} />
+                ) : null}
+              </div>
+            ))}
+          </div>
+        ) : null}
+        {unlinkError != null ? <p className="text-xs text-danger">{unlinkError}</p> : null}
       </div>
     </PaneShell>
   );

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn/index.test.tsx
@@ -108,6 +108,7 @@ beforeEach(() => {
   hooks.summarizerStatus = 'idle';
   store.sessionPhaseRuns = {};
   store.reviewDrafts = {};
+  store.sessionGithub = {};
   store.sessionExternalTasks = {};
   store.workspaceIntegrations = {
     'workspace-1': [{ provider: 'linear' }, { provider: 'sentry' }],
@@ -409,6 +410,40 @@ describe('LensColumn', () => {
     );
 
     expect(screen.getByRole('button', { name: 'GitLab 1' })).toBeDefined();
+  });
+
+  it('counts linked github tasks plus the open PR on the GitHub row', () => {
+    store.sessionExternalTasks = {
+      'session-1': [{ provider: 'github' }, { provider: 'linear' }],
+    };
+    store.sessionGithub = { 'session-1': { pr: { number: 42 } } };
+
+    render(
+      <LensColumn
+        session={SESSION}
+        activeLens={null}
+        onSelectOverview={vi.fn()}
+        onSelect={vi.fn()}
+        filesCount={0}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'GitHub 2' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Linear 1' })).toBeDefined();
+
+    cleanup();
+    store.sessionGithub = {};
+    render(
+      <LensColumn
+        session={SESSION}
+        activeLens={null}
+        onSelectOverview={vi.fn()}
+        onSelect={vi.fn()}
+        filesCount={0}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'GitHub 1' })).toBeDefined();
   });
 
   it.each([

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn/index.tsx
@@ -129,6 +129,8 @@ export const LensColumn = ({
     (s) =>
       (s.reviewDrafts[sessionId] ?? EMPTY_ARRAY).filter((draft) => draft.status === 'draft').length,
   );
+  const githubCount =
+    externalTasks.filter((task) => task.provider === 'github').length + (hasGithubPr ? 1 : 0);
   const linearCount = externalTasks.filter((task) => task.provider === 'linear').length;
   const sentryCount = externalTasks.filter((task) => task.provider === 'sentry').length;
   const gitlabCount = externalTasks.filter((task) => task.provider === 'gitlab').length;
@@ -162,6 +164,7 @@ export const LensColumn = ({
       label: 'GitHub',
       glyph: 'github',
       tone: 'accent',
+      count: githubCount,
       dot: hasGithubPr ? 'running' : undefined,
       isConnected: githubConnection.isConnected,
     },

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.test.tsx
@@ -264,6 +264,46 @@ describe('PrPane', () => {
     expect(screen.getByRole('button', { name: /open #7 in GitHub studio/i })).toBeDefined();
   });
 
+  it('keeps linked issues and external tasks visible without a pull request', () => {
+    h.store.sessionGithub = {
+      [SESSION_ID]: {
+        pr: null,
+        linkedIssues: [
+          {
+            number: 7,
+            title: 'Track auth rollout',
+            url: 'https://github.com/acme/goodboy/issues/7',
+            closes: true,
+          },
+        ],
+        detail: null,
+        loading: false,
+        error: null,
+      },
+    };
+    h.store.sessionExternalTasks = {
+      [SESSION_ID]: [
+        {
+          sessionId: SESSION_ID,
+          provider: 'github',
+          externalId: '9',
+          identifier: '#9',
+          url: 'https://github.com/acme/goodboy/issues/9',
+          title: 'Harden token refresh',
+          createdAt: DATE,
+        },
+      ],
+    };
+
+    render(<PrPane session={session} />);
+
+    expect(screen.getByRole('link', { name: /#7 Track auth rollout/i })).toBeDefined();
+    expect(screen.getByRole('button', { name: /open #9 in GitHub studio/i })).toBeDefined();
+    expect(screen.getByText('No pull request yet')).toBeDefined();
+    expect(screen.getByText('ak/refactor-auth')).toBeDefined();
+    expect(screen.getByRole('button', { name: /Open a pull request/i })).toBeDefined();
+  });
+
   it('routes creating a PR to the shared PR studio surface', () => {
     const events: Array<CustomEvent> = [];
     const listener = (event: Event) => events.push(event as CustomEvent);
@@ -276,6 +316,9 @@ describe('PrPane', () => {
 
     expect(events).toHaveLength(1);
     expect(events[0]?.detail).toEqual({ sessionId: SESSION_ID });
+    expect(
+      screen.getByText('No issues or external tasks are linked to this session yet.'),
+    ).toBeDefined();
     expect(screen.queryByRole('button', { name: 'Quick draft' })).toBeNull();
     expect(screen.queryByRole('button', { name: 'Draft with an agent' })).toBeNull();
   });

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.tsx
@@ -13,7 +13,14 @@ import {
   type LucideIcon,
 } from 'lucide-react';
 import { Button, Eyebrow, cn } from '@goodboy/ui';
-import type { PrCheckRun, PullRequestStateKind, Session, SessionId } from '@goodboy/types';
+import type {
+  LinkedIssue,
+  PrCheckRun,
+  PullRequestStateKind,
+  Session,
+  SessionExternalTask,
+  SessionId,
+} from '@goodboy/types';
 import { PullRequestChip, pullRequestMeta } from '../../../../github/components/PullRequestChip';
 import { PrSwitcher } from '../../../../github/components/GitHubStudio/PrSwitcher';
 import { ExternalTaskChip } from '../../../../integrations/components/ExternalTaskChip';
@@ -75,8 +82,13 @@ export const PrPane = ({ session }: Props) => {
             : 'open';
   const hasBothProviders = pullRequest != null && mergeRequest != null;
 
+  const description =
+    activeProvider === 'gitlab'
+      ? 'Merge request and linked issues for this session.'
+      : 'Pull request and linked issues for this session.';
+
   return (
-    <PaneShell title="Pull requests" description="Review status for this session.">
+    <PaneShell title="Pull requests" description={description}>
       <div className="flex flex-col gap-3">
         {hasBothProviders ? (
           <div className="flex flex-col gap-1.5">
@@ -182,34 +194,67 @@ const GithubPrCard = ({ session, isPrReview }: { session: Session; isPrReview: b
   }
 
   if (!pr) {
-    return (
-      <div className="animate-fade-in relative flex flex-col items-center gap-5 rounded-lg border border-dashed border-border-soft bg-elevated/40 px-8 py-8 text-center">
-        <div className="absolute right-3 top-3">
-          <RefreshButton onClick={refresh} loading={loading} error={error} />
+    const hasLinkedWork = linkedIssues.length > 0 || codeHostTasks.length > 0;
+    if (!hasLinkedWork) {
+      return (
+        <div className="animate-fade-in relative flex flex-col items-center gap-5 rounded-lg border border-dashed border-border-soft bg-elevated/40 px-8 py-8 text-center">
+          <div className="absolute right-3 top-3">
+            <RefreshButton onClick={refresh} loading={loading} error={error} />
+          </div>
+          <span
+            aria-hidden
+            className="flex size-12 items-center justify-center rounded-full bg-primary/10"
+          >
+            <GitPullRequest size={24} className="text-primary" />
+          </span>
+          <div className="flex flex-col items-center gap-1.5">
+            <h2 className="text-base font-semibold text-foreground">Open a pull request</h2>
+            <p className="max-w-sm text-sm leading-relaxed text-muted-foreground">
+              Turn this session&rsquo;s work into a PR. Fill in the title and description, or hand
+              it to an agent that writes them from your commits.
+            </p>
+            <p className="text-xs text-muted-foreground/70">
+              No issues or external tasks are linked to this session yet.
+            </p>
+            {branch != null && (
+              <span className="inline-flex items-center gap-1.5 rounded-full bg-foreground/[0.04] px-2.5 py-1 font-mono text-2xs text-muted-foreground ring-1 ring-border-soft/60">
+                <GitBranch size={11} aria-hidden className="shrink-0" />
+                <span className="truncate text-foreground/80">{branch}</span>
+              </span>
+            )}
+          </div>
+          <Button onClick={openStudio}>
+            Open a pull request
+            <ArrowUpRight size={13} aria-hidden className="ml-1.5 shrink-0 opacity-70" />
+          </Button>
         </div>
-        <span
-          aria-hidden
-          className="flex size-12 items-center justify-center rounded-full bg-primary/10"
-        >
-          <GitPullRequest size={24} className="text-primary" />
-        </span>
-        <div className="flex flex-col items-center gap-1.5">
-          <h2 className="text-base font-semibold text-foreground">Open a pull request</h2>
-          <p className="max-w-sm text-sm leading-relaxed text-muted-foreground">
-            Turn this session&rsquo;s work into a PR. Fill in the title and description, or hand it
-            to an agent that writes them from your commits.
-          </p>
+      );
+    }
+    return (
+      <div className="animate-fade-in flex flex-col gap-3">
+        <LinkedIssuesSection issues={linkedIssues} />
+        <ExternalTasksSection tasks={codeHostTasks} />
+        <div className="relative flex flex-col items-start gap-3 rounded-lg border border-dashed border-border-soft bg-elevated/40 px-4 py-4">
+          <div className="absolute right-3 top-3">
+            <RefreshButton onClick={refresh} loading={loading} error={error} />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <h2 className="text-sm font-semibold text-foreground">No pull request yet</h2>
+            <p className="max-w-sm text-sm leading-relaxed text-muted-foreground">
+              Turn this session&rsquo;s work into a PR when it is ready.
+            </p>
+          </div>
           {branch != null && (
             <span className="inline-flex items-center gap-1.5 rounded-full bg-foreground/[0.04] px-2.5 py-1 font-mono text-2xs text-muted-foreground ring-1 ring-border-soft/60">
               <GitBranch size={11} aria-hidden className="shrink-0" />
               <span className="truncate text-foreground/80">{branch}</span>
             </span>
           )}
+          <Button size="sm" onClick={openStudio}>
+            Open a pull request
+            <ArrowUpRight size={13} aria-hidden className="ml-1.5 shrink-0 opacity-70" />
+          </Button>
         </div>
-        <Button onClick={openStudio}>
-          Open a pull request
-          <ArrowUpRight size={13} aria-hidden className="ml-1.5 shrink-0 opacity-70" />
-        </Button>
       </div>
     );
   }
@@ -261,41 +306,8 @@ const GithubPrCard = ({ session, isPrReview }: { session: Session; isPrReview: b
         </span>
       </div>
 
-      {linkedIssues.length > 0 ? (
-        <div className="flex flex-col gap-1.5">
-          <Eyebrow label="Linked issues" muted className="px-0.5 font-medium" />
-          <div className="flex flex-col gap-1">
-            {linkedIssues.map((issue) => (
-              <a
-                key={issue.url}
-                href={issue.url}
-                target="_blank"
-                rel="noreferrer"
-                className="flex items-center gap-2 rounded-lg bg-muted/25 px-3 py-2 text-xs text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground"
-              >
-                <span className="shrink-0 font-mono">#{issue.number}</span>
-                <span className="min-w-0 flex-1 truncate">{issue.title ?? 'GitHub issue'}</span>
-                <ArrowUpRight size={12} aria-hidden className="shrink-0" />
-              </a>
-            ))}
-          </div>
-        </div>
-      ) : null}
-
-      {codeHostTasks.length > 0 ? (
-        <div className="flex flex-col gap-1.5">
-          <Eyebrow label="External tasks" muted className="px-0.5 font-medium" />
-          <div className="flex flex-col gap-1">
-            {codeHostTasks.map((task) => (
-              <ExternalTaskChip
-                key={`${task.provider}:${task.externalId}`}
-                task={task}
-                appearance="row"
-              />
-            ))}
-          </div>
-        </div>
-      ) : null}
+      <LinkedIssuesSection issues={linkedIssues} />
+      <ExternalTasksSection tasks={codeHostTasks} />
 
       <button
         type="button"
@@ -311,6 +323,60 @@ const GithubPrCard = ({ session, isPrReview }: { session: Session; isPrReview: b
           {error}
         </span>
       ) : null}
+    </div>
+  );
+};
+
+type LinkedIssuesSectionProps = {
+  readonly issues: ReadonlyArray<LinkedIssue>;
+};
+
+const LinkedIssuesSection = ({ issues }: LinkedIssuesSectionProps) => {
+  if (issues.length === 0) {
+    return null;
+  }
+  return (
+    <div className="flex flex-col gap-1.5">
+      <Eyebrow label="Linked issues" muted className="px-0.5 font-medium" />
+      <div className="flex flex-col gap-1">
+        {issues.map((issue) => (
+          <a
+            key={issue.url}
+            href={issue.url}
+            target="_blank"
+            rel="noreferrer"
+            className="flex items-center gap-2 rounded-lg bg-muted/25 px-3 py-2 text-xs text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground"
+          >
+            <span className="shrink-0 font-mono">#{issue.number}</span>
+            <span className="min-w-0 flex-1 truncate">{issue.title ?? 'GitHub issue'}</span>
+            <ArrowUpRight size={12} aria-hidden className="shrink-0" />
+          </a>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+type ExternalTasksSectionProps = {
+  readonly tasks: ReadonlyArray<SessionExternalTask>;
+};
+
+const ExternalTasksSection = ({ tasks }: ExternalTasksSectionProps) => {
+  if (tasks.length === 0) {
+    return null;
+  }
+  return (
+    <div className="flex flex-col gap-1.5">
+      <Eyebrow label="External tasks" muted className="px-0.5 font-medium" />
+      <div className="flex flex-col gap-1">
+        {tasks.map((task) => (
+          <ExternalTaskChip
+            key={`${task.provider}:${task.externalId}`}
+            task={task}
+            appearance="row"
+          />
+        ))}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Description

Stacked on #1083. Sentry/Linear/GitLab panes always rendered the full "Link an issue" block (label + studio button + picker + URL form) even with an issue already linked, wasting the top of the pane. The GitHub pane dropped linked issues entirely when no PR existed: its early return rendered only "Open a pull request".

## Scope

- with at least one linked task the link block disappears; a compact "Link ticket" CTA sits in the `PaneShell` actions slot (same slot as "Create agent"), opening a popover with the picker + paste-URL form (extracted `LinkIssueForm`, lazy candidates load preserved)
- with zero tasks: one clean empty state integrating the link form and the studio button, no stacked duplicates
- linked rows now use `ExternalTaskChip appearance="row"` with the unlink confirm preserved
- GitHub pane becomes a session dashboard: linked issues and code-host tasks render with or without a PR; the no-PR case shows a compact "No pull request yet" sub-state with branch chip and CTA; when nothing is linked it says so explicitly
- LensColumn GitHub row gains the same count badge as the other integrations (tasks + PR)

Not done by design: GitLab task detail leaf (no fetch-by-id hook exists to reuse; row parity only).

## Verification

- monorepo typecheck green
- full apps/desktop suite: 3121 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)