### PR TITLE
refactor(desktop): one creation grammar for pr and mr forms

### DIFF
--- a/apps/desktop/src/features/github/components/GitHubStudio/CreatePrPanel.test.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/CreatePrPanel.test.tsx
@@ -25,6 +25,8 @@ type ConfigProps = {
   readonly disabled: boolean;
 };
 
+type BaseBranches = { defaultBranch: string | null; branches: ReadonlyArray<string> };
+
 const h = vi.hoisted(() => ({
   config: {
     provider: 'codex',
@@ -32,6 +34,12 @@ const h = vi.hoisted(() => ({
     effort: 'medium',
     hint: 'Keep the public API stable.',
   } satisfies AgentSpawnConfigValue,
+  ghBaseBranches: vi.fn(
+    async (): Promise<{ defaultBranch: string | null; branches: ReadonlyArray<string> }> => ({
+      defaultBranch: 'main',
+      branches: ['main'],
+    }),
+  ),
   store: {
     createPrForSession: vi.fn(async () => undefined),
     spawnAgent: vi.fn<SpawnAgent>(async () => 'agent-2'),
@@ -49,7 +57,7 @@ vi.mock('../../../../store', () => ({
 }));
 
 vi.mock('../../github', () => ({
-  ghBaseBranches: vi.fn(async () => ({ defaultBranch: 'main', branches: ['main'] })),
+  ghBaseBranches: h.ghBaseBranches,
 }));
 
 vi.mock('../../../session/components/AgentSpawnConfig', () => ({
@@ -73,16 +81,103 @@ import { CreatePrPanel } from './CreatePrPanel';
 
 const SESSION_ID = 'session-2' as SessionId;
 
+const renderPanel = () =>
+  render(
+    <CreatePrPanel
+      sessionId={SESSION_ID}
+      defaultTitle="Refactor PR cards"
+      onCreated={vi.fn()}
+      onStudioClose={vi.fn()}
+    />,
+  );
+
+const switchToAgentMode = () => {
+  fireEvent.click(screen.getByRole('tab', { name: 'With an agent' }));
+};
+
 beforeEach(() => {
+  h.store.createPrForSession.mockClear();
+  h.store.createPrForSession.mockImplementation(async () => undefined);
   h.store.spawnAgent.mockClear();
   h.store.selectAgent.mockClear();
   h.store.setCurrentSession.mockClear();
   h.store.workspaceOverrides = {};
+  h.ghBaseBranches.mockClear();
+  h.ghBaseBranches.mockImplementation(async () => ({ defaultBranch: 'main', branches: ['main'] }));
 });
 
 afterEach(cleanup);
 
 describe('CreatePrPanel', () => {
+  it('creates a PR manually with the filled fields and the default base', async () => {
+    renderPanel();
+    await screen.findByRole('combobox', { name: 'Branch' });
+    fireEvent.change(screen.getByRole('textbox', { name: 'Pull request title' }), {
+      target: { value: 'Ship the card refactor' },
+    });
+    fireEvent.change(screen.getByRole('textbox', { name: 'Pull request description' }), {
+      target: { value: 'Documents the change.' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Create PR' }));
+
+    await waitFor(() =>
+      expect(h.store.createPrForSession).toHaveBeenCalledWith(SESSION_ID, {
+        title: 'Ship the card refactor',
+        body: 'Documents the change.',
+        base: 'main',
+        draft: true,
+      }),
+    );
+  });
+
+  it('respects the draft toggle on manual create', async () => {
+    renderPanel();
+    await screen.findByRole('combobox', { name: 'Branch' });
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Open as draft' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Create PR' }));
+
+    await waitFor(() =>
+      expect(h.store.createPrForSession).toHaveBeenCalledWith(
+        SESSION_ID,
+        expect.objectContaining({ draft: false }),
+      ),
+    );
+  });
+
+  it('shows the create error in the footer', async () => {
+    h.store.createPrForSession.mockRejectedValueOnce(new Error('gh exploded'));
+    renderPanel();
+    await screen.findByRole('combobox', { name: 'Branch' });
+    fireEvent.click(screen.getByRole('button', { name: 'Create PR' }));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toContain('gh exploded');
+  });
+
+  it('swaps the body when switching modes', async () => {
+    renderPanel();
+    expect(screen.getByRole('textbox', { name: 'Pull request title' })).toBeDefined();
+    switchToAgentMode();
+    expect(screen.queryByRole('textbox', { name: 'Pull request title' })).toBeNull();
+    expect(screen.getByRole('button', { name: 'Choose agent config' })).toBeDefined();
+    fireEvent.click(screen.getByRole('tab', { name: 'Manual' }));
+    expect(screen.getByRole('textbox', { name: 'Pull request title' })).toBeDefined();
+  });
+
+  it('shows a skeleton instead of the base branch picker while branches load', async () => {
+    let resolve: (value: BaseBranches) => void = () => undefined;
+    h.ghBaseBranches.mockImplementationOnce(
+      () =>
+        new Promise<BaseBranches>((r) => {
+          resolve = r;
+        }),
+    );
+    renderPanel();
+    expect(screen.queryByRole('combobox', { name: 'Branch' })).toBeNull();
+    resolve({ defaultBranch: 'main', branches: ['main'] });
+    expect(await screen.findByRole('combobox', { name: 'Branch' })).toBeDefined();
+  });
+
   it('spawns a PR agent with the chosen config and operator notes', async () => {
     const onStudioClose = vi.fn();
     render(
@@ -93,8 +188,9 @@ describe('CreatePrPanel', () => {
         onStudioClose={onStudioClose}
       />,
     );
+    switchToAgentMode();
     fireEvent.click(screen.getByRole('button', { name: 'Choose agent config' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Draft with an agent' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Draft with agent' }));
 
     await waitFor(() => expect(h.store.spawnAgent).toHaveBeenCalledOnce());
     const args = h.store.spawnAgent.mock.calls[0]![1];
@@ -110,16 +206,10 @@ describe('CreatePrPanel', () => {
   });
 
   it('preserves the prompt for a whitespace-only hint', async () => {
-    render(
-      <CreatePrPanel
-        sessionId={SESSION_ID}
-        defaultTitle="Refactor PR cards"
-        onCreated={vi.fn()}
-        onStudioClose={vi.fn()}
-      />,
-    );
+    renderPanel();
+    switchToAgentMode();
     fireEvent.click(screen.getByRole('button', { name: 'Set whitespace hint' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Draft with an agent' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Draft with agent' }));
 
     await waitFor(() => expect(h.store.spawnAgent).toHaveBeenCalledOnce());
     const args = h.store.spawnAgent.mock.calls[0]![1];
@@ -162,7 +252,8 @@ describe('CreatePrPanel', () => {
         onStudioClose={vi.fn()}
       />,
     );
-    fireEvent.click(screen.getByRole('button', { name: 'Draft with an agent' }));
+    switchToAgentMode();
+    fireEvent.click(screen.getByRole('button', { name: 'Draft with agent' }));
 
     await waitFor(() => expect(h.store.spawnAgent).toHaveBeenCalledOnce());
     expect(h.store.spawnAgent.mock.calls[0]![1]).toMatchObject({

--- a/apps/desktop/src/features/github/components/GitHubStudio/CreatePrPanel.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/CreatePrPanel.tsx
@@ -1,13 +1,28 @@
 import { useEffect, useMemo, useState } from 'react';
 import type { SessionId } from '@goodboy/types';
-import { Button, cn, Divider, Input, ScrollFade, SectionHeader, Textarea } from '@goodboy/ui';
-import { AlertTriangle, ArrowRight, GitBranch, Sparkles } from 'lucide-react';
+import {
+  Button,
+  cn,
+  Divider,
+  FieldRow,
+  Input,
+  ScrollFade,
+  SectionHeader,
+  SegmentedTabs,
+  Skeleton,
+  Textarea,
+} from '@goodboy/ui';
+import { AlertTriangle, ArrowRight, GitBranch, PenLine, Sparkles } from 'lucide-react';
 import { ghBaseBranches } from '../../github';
 import { appendOperatorNotes } from '../../../session/utils/appendOperatorNotes';
 import { AgentSpawnConfig } from '../../../session/components/AgentSpawnConfig';
 import type { AgentSpawnConfigValue } from '../../../session/components/AgentSpawnConfig/AgentSpawnConfigValue';
 import { taskModelAgentSpawnConfig } from '../../../session/components/AgentSpawnConfig/taskModelAgentSpawnConfig';
+import { BranchCombobox } from '../../../worktree/BranchCombobox';
+import type { LocalBranchInfo } from '../../../worktree/worktree';
 import { useAppStore } from '../../../../store';
+
+type CreateMode = 'manual' | 'agent';
 
 type Props = {
   readonly sessionId: SessionId;
@@ -51,15 +66,22 @@ export const CreatePrPanel = ({
     [workspaceOverrides?.taskModels, session?.providerPreference?.defaultProvider],
   );
 
+  const [mode, setMode] = useState<CreateMode>('manual');
   const [title, setTitle] = useState(defaultTitle);
   const [body, setBody] = useState('');
   const [base, setBase] = useState('');
   const [branches, setBranches] = useState<ReadonlyArray<string>>([]);
+  const [branchesLoading, setBranchesLoading] = useState(true);
   const [draft, setDraft] = useState(true);
   const [busy, setBusy] = useState<'create' | 'ai' | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [agentConfig, setAgentConfig] = useState<AgentSpawnConfigValue>(resolvedAgentConfig);
   const [agentConfigUserTouched, setAgentConfigUserTouched] = useState(false);
+
+  const branchOptions = useMemo<ReadonlyArray<LocalBranchInfo>>(
+    () => branches.map((name) => ({ name, inUse: false, hasUncommitted: false })),
+    [branches],
+  );
 
   useEffect(() => {
     if (agentConfigUserTouched) {
@@ -69,16 +91,19 @@ export const CreatePrPanel = ({
   }, [agentConfigUserTouched, resolvedAgentConfig]);
 
   useEffect(() => {
-    if (!workspaceRoot) {
+    if (workspaceRoot == null) {
+      setBranchesLoading(false);
       return;
     }
     let cancelled = false;
+    setBranchesLoading(true);
     void ghBaseBranches(workspaceRoot, workspaceId).then(({ defaultBranch, branches: list }) => {
       if (cancelled) {
         return;
       }
       setBranches(list);
-      if (defaultBranch) {
+      setBranchesLoading(false);
+      if (defaultBranch != null) {
         setBase((cur) => (cur.trim() === '' ? defaultBranch : cur));
       }
     });
@@ -141,10 +166,10 @@ export const CreatePrPanel = ({
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      <ScrollFade className="min-h-0 flex-1" viewportClassName="px-10 py-8" fadeSize={24}>
-        <section className="mx-auto flex w-full max-w-2xl flex-col gap-4">
+      <ScrollFade className="min-h-0 flex-1" viewportClassName="px-6 py-5" fadeSize={24}>
+        <section className="mx-auto flex w-full max-w-2xl flex-col gap-6">
           <SectionHeader
-            label="open a pull request"
+            label="Open a pull request"
             action={
               <span className="inline-flex items-center gap-1 font-mono text-2xs text-muted-foreground">
                 <GitBranch size={11} aria-hidden />
@@ -152,69 +177,88 @@ export const CreatePrPanel = ({
               </span>
             }
           />
-          <div className="flex flex-col gap-1.5">
-            <SectionHeader label="title" />
-            <Input
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              placeholder="pull request title"
-              disabled={busy !== null}
-              aria-label="Pull request title"
-              className="h-8 text-sm"
-              autoFocus
+          <section className="flex flex-col">
+            <SectionHeader
+              label="How"
+              hint="Fill the pull request yourself, or hand it to an agent that drafts and opens it."
+              action={
+                <SegmentedTabs
+                  ariaLabel="Creation mode"
+                  size="sm"
+                  options={[
+                    { value: 'manual', label: 'Manual', icon: PenLine },
+                    { value: 'agent', label: 'With an agent', icon: Sparkles },
+                  ]}
+                  value={mode}
+                  onChange={setMode}
+                />
+              }
             />
-          </div>
-          <div className="flex flex-col gap-1.5">
-            <SectionHeader label="description" />
-            <Textarea
-              value={body}
-              onChange={(e) => setBody(e.target.value)}
-              placeholder="what changed and why (markdown supported)"
-              className="text-sm"
-              autoGrow
-              minRows={3}
-              maxRows={12}
-              disabled={busy !== null}
-              aria-label="Pull request description"
-            />
-          </div>
-          <div className="flex flex-col gap-1.5">
-            <SectionHeader label="base branch" icon={<GitBranch size={13} aria-hidden />} />
-            <Input
-              value={base}
-              onChange={(e) => setBase(e.target.value)}
-              placeholder="default branch"
-              list="pr-base-branches"
-              className="h-8 font-mono text-sm"
-              disabled={busy !== null}
-              autoCapitalize="off"
-              autoCorrect="off"
-              spellCheck={false}
-              aria-label="Base branch"
-            />
-            <datalist id="pr-base-branches">
-              {branches.map((b) => (
-                <option key={b} value={b} />
-              ))}
-            </datalist>
-          </div>
-          <AgentSpawnConfig
-            value={agentConfig}
-            onChange={(value) => {
-              setAgentConfigUserTouched(true);
-              setAgentConfig(value);
-            }}
-            disabled={busy !== null}
-          />
-        </section>
-      </ScrollFade>
-
-      <Divider />
-
-      <footer className="shrink-0">
-        <div className="mx-auto flex w-full max-w-2xl items-center justify-between gap-3 px-10 py-4">
-          <div className="flex min-w-0 items-center gap-3">
-            <label className="flex cursor-pointer items-center gap-2 text-xs text-muted-foreground">
+            {mode === 'manual' ? (
+              <>
+                <FieldRow label="Title" help="A short summary of the change.">
+                  <Input
+                    value={title}
+                    onChange={(e) => setTitle(e.target.value)}
+                    placeholder="Pull request title"
+                    disabled={busy !== null}
+                    aria-label="Pull request title"
+                    className="h-8 w-full text-sm sm:w-96"
+                    autoFocus
+                  />
+                </FieldRow>
+                <Divider />
+                <FieldRow label="Description" help="What changed and why. Markdown supported.">
+                  <Textarea
+                    value={body}
+                    onChange={(e) => setBody(e.target.value)}
+                    placeholder="What changed and why"
+                    className="w-full text-sm sm:w-96"
+                    autoGrow
+                    minRows={3}
+                    maxRows={12}
+                    disabled={busy !== null}
+                    aria-label="Pull request description"
+                  />
+                </FieldRow>
+                <Divider />
+                <FieldRow label="Base branch" help="The branch this pull request merges into.">
+                  <div className="w-full sm:w-96">
+                    {branchesLoading ? (
+                      <Skeleton className="h-9 w-full rounded-md border border-border" />
+                    ) : (
+                      <BranchCombobox
+                        branches={branchOptions}
+                        value={base}
+                        onChange={setBase}
+                        disabled={busy !== null}
+                        loading={false}
+                      />
+                    )}
+                  </div>
+                </FieldRow>
+              </>
+            ) : (
+              <FieldRow
+                label="Agent"
+                layout="stacked"
+                help="Routing and optional notes for the agent that drafts the title and description, then opens the pull request."
+              >
+                <AgentSpawnConfig
+                  value={agentConfig}
+                  onChange={(value) => {
+                    setAgentConfigUserTouched(true);
+                    setAgentConfig(value);
+                  }}
+                  disabled={busy !== null}
+                />
+              </FieldRow>
+            )}
+            <Divider />
+            <FieldRow
+              label="Open as draft"
+              help="Creates the pull request in GitHub's draft state."
+            >
               <input
                 type="checkbox"
                 checked={draft}
@@ -222,45 +266,62 @@ export const CreatePrPanel = ({
                 className="accent-primary"
                 disabled={busy !== null}
               />
-              Mark as draft
-            </label>
-            {error != null && (
-              <span
-                role="alert"
-                className="inline-flex min-w-0 items-center gap-1 truncate text-xs text-danger"
-                title={error}
-              >
-                <AlertTriangle size={12} aria-hidden className="shrink-0" />
-                {error}
-              </span>
-            )}
-          </div>
-          <div className="flex shrink-0 items-center gap-2">
-            {onCancel != null && (
-              <Button variant="ghost" onClick={onCancel} disabled={busy !== null}>
-                Cancel
-              </Button>
-            )}
-            <Button
-              variant="secondary"
-              onClick={() => void onCreateWithAi()}
-              disabled={busy !== null}
-              title="hand it to an agent: it drafts the title and description, then opens the PR"
-              className={cn(busy === 'ai' && 'animate-border-pulse')}
+            </FieldRow>
+          </section>
+        </section>
+      </ScrollFade>
+
+      <Divider />
+
+      <footer className="flex shrink-0 items-center gap-3 px-6 py-3">
+        <div className="flex min-w-0 flex-1 items-center gap-3">
+          {error != null && (
+            <span
+              role="alert"
+              className="inline-flex min-w-0 items-center gap-1 truncate text-xs text-danger"
+              title={error}
             >
-              <Sparkles size={13} className="mr-1.5" aria-hidden />
-              Draft with an agent
-            </Button>
-            <Button
-              onClick={() => void onCreate()}
-              disabled={busy !== null || title.trim().length === 0}
-              className={cn(busy === 'create' && 'animate-border-pulse')}
-            >
-              Create PR
-              <ArrowRight size={13} className="ml-1.5" aria-hidden />
-            </Button>
-          </div>
+              <AlertTriangle size={12} aria-hidden className="shrink-0" />
+              {error}
+            </span>
+          )}
         </div>
+        {onCancel != null && (
+          <Button variant="ghost" onClick={onCancel} disabled={busy !== null}>
+            Cancel
+          </Button>
+        )}
+        {mode === 'manual' ? (
+          <Button
+            onClick={() => void onCreate()}
+            disabled={busy !== null || title.trim().length === 0}
+            className={cn(busy === 'create' && 'animate-border-pulse')}
+          >
+            {busy === 'create' ? (
+              'Creating…'
+            ) : (
+              <>
+                Create PR
+                <ArrowRight size={13} className="ml-1.5" aria-hidden />
+              </>
+            )}
+          </Button>
+        ) : (
+          <Button
+            onClick={() => void onCreateWithAi()}
+            disabled={busy !== null}
+            className={cn(busy === 'ai' && 'animate-border-pulse')}
+          >
+            {busy === 'ai' ? (
+              'Drafting…'
+            ) : (
+              <>
+                <Sparkles size={13} className="mr-1.5" aria-hidden />
+                Draft with agent
+              </>
+            )}
+          </Button>
+        )}
       </footer>
     </div>
   );

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel.test.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel.test.tsx
@@ -16,7 +16,7 @@ type Store = {
     workspaceId: string;
     providerPreference: { defaultProvider: 'anthropic'; allowTurnOverride: false };
   }>;
-  readonly sessionGitlabMr: Record<string, unknown>;
+  sessionGitlabMr: Record<string, unknown>;
   readonly sessionBranches: Record<string, string>;
   readonly refreshSessionMr: ReturnType<typeof vi.fn>;
   readonly createMrForSession: ReturnType<typeof vi.fn>;
@@ -121,7 +121,12 @@ beforeEach(() => {
   h.store.setCurrentSession.mockClear();
   h.showToast.mockClear();
   h.store.workspaceOverrides = {};
+  h.store.sessionGitlabMr = {};
 });
+
+const switchToAgentMode = () => {
+  fireEvent.click(screen.getByRole('tab', { name: 'With an agent' }));
+};
 
 afterEach(cleanup);
 
@@ -149,11 +154,47 @@ describe('MrDetailPanel', () => {
     );
   });
 
+  it('respects the draft toggle on manual create', async () => {
+    render(<MrDetailPanel sessionId={SESSION_ID} onClose={vi.fn()} />);
+    fireEvent.change(screen.getByRole('textbox', { name: 'Merge request title' }), {
+      target: { value: 'Ship the GitLab release' },
+    });
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Open as draft' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Create MR' }));
+
+    await waitFor(() =>
+      expect(h.store.createMrForSession).toHaveBeenCalledWith(
+        SESSION_ID,
+        expect.objectContaining({ draft: false }),
+      ),
+    );
+  });
+
+  it('shows the merge request error in the form footer', () => {
+    h.store.sessionGitlabMr = {
+      'session-3': { mr: null, loading: false, error: 'GitLab token expired' },
+    };
+    render(<MrDetailPanel sessionId={SESSION_ID} onClose={vi.fn()} />);
+
+    expect(screen.getByRole('alert').textContent).toContain('GitLab token expired');
+  });
+
+  it('swaps the form body when switching modes', () => {
+    render(<MrDetailPanel sessionId={SESSION_ID} onClose={vi.fn()} />);
+    expect(screen.getByRole('textbox', { name: 'Merge request title' })).toBeDefined();
+    switchToAgentMode();
+    expect(screen.queryByRole('textbox', { name: 'Merge request title' })).toBeNull();
+    expect(screen.getByRole('button', { name: 'Choose agent config' })).toBeDefined();
+    fireEvent.click(screen.getByRole('tab', { name: 'Manual' }));
+    expect(screen.getByRole('textbox', { name: 'Merge request title' })).toBeDefined();
+  });
+
   it('spawns an MR agent with the chosen config and operator notes', async () => {
     const onClose = vi.fn();
     render(<MrDetailPanel sessionId={SESSION_ID} onClose={onClose} />);
+    switchToAgentMode();
     fireEvent.click(screen.getByRole('button', { name: 'Choose agent config' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Draft with an agent' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Draft with agent' }));
 
     await waitFor(() => expect(h.store.spawnAgent).toHaveBeenCalledOnce());
     const args = h.store.spawnAgent.mock.calls[0]![1];
@@ -176,7 +217,8 @@ describe('MrDetailPanel', () => {
       },
     };
     rerender(<MrDetailPanel sessionId={SESSION_ID} onClose={vi.fn()} />);
-    fireEvent.click(screen.getByRole('button', { name: 'Draft with an agent' }));
+    switchToAgentMode();
+    fireEvent.click(screen.getByRole('button', { name: 'Draft with agent' }));
 
     await waitFor(() => expect(h.store.spawnAgent).toHaveBeenCalledOnce());
     expect(h.store.spawnAgent.mock.calls[0]![1]).toMatchObject({

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel.tsx
@@ -1,11 +1,22 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Button, Divider, EmptyState, Input, Markdown, SectionHeader, Textarea } from '@goodboy/ui';
+import {
+  Button,
+  Divider,
+  EmptyState,
+  FieldRow,
+  Input,
+  Markdown,
+  SectionHeader,
+  SegmentedTabs,
+  Textarea,
+} from '@goodboy/ui';
 import {
   AlertTriangle,
   ArrowRight,
   GitBranch,
   GitMerge,
   MousePointerClick,
+  PenLine,
   Sparkles,
 } from 'lucide-react';
 import type { SessionId, WorkspaceId } from '@goodboy/types';
@@ -33,6 +44,8 @@ import {
   type GitlabMergeStatusTone,
 } from '../client';
 import { projectPathFromMrUrl } from './useGitlabMrs';
+
+type CreateMode = 'manual' | 'agent';
 
 type Props = {
   readonly sessionId?: SessionId | null;
@@ -99,6 +112,7 @@ export const MrDetailPanel = ({
   const loading = mrState?.loading ?? false;
   const error = mrState?.error ?? null;
 
+  const [mode, setMode] = useState<CreateMode>('manual');
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [targetBranch, setTargetBranch] = useState('main');
@@ -358,86 +372,113 @@ export const MrDetailPanel = ({
       }
     >
       {session != null && sessionId != null ? (
-        <section className="flex flex-col gap-4">
-          <div className="flex flex-col gap-1.5">
-            <SectionHeader label="title" />
-            <Input
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              disabled={busy !== null}
-              aria-label="Merge request title"
-              className="h-8 text-sm"
+        <section className="flex flex-col gap-6">
+          <section className="flex flex-col">
+            <SectionHeader
+              label="How"
+              hint="Fill the merge request yourself, or hand it to an agent that drafts and opens it."
+              action={
+                <SegmentedTabs
+                  ariaLabel="Creation mode"
+                  size="sm"
+                  options={[
+                    { value: 'manual', label: 'Manual', icon: PenLine },
+                    { value: 'agent', label: 'With an agent', icon: Sparkles },
+                  ]}
+                  value={mode}
+                  onChange={setMode}
+                />
+              }
             />
-          </div>
-          <div className="flex flex-col gap-1.5">
-            <SectionHeader label="description" />
-            <Textarea
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              autoGrow
-              minRows={3}
-              maxRows={10}
-              disabled={busy !== null}
-              aria-label="Merge request description"
-            />
-          </div>
-          <div className="flex flex-col gap-1.5">
-            <SectionHeader label="target branch" icon={<GitBranch size={13} aria-hidden />} />
-            <Input
-              value={targetBranch}
-              onChange={(e) => setTargetBranch(e.target.value)}
-              placeholder="main"
-              className="h-8 font-mono text-sm"
-              disabled={busy !== null}
-              autoCapitalize="off"
-              autoCorrect="off"
-              spellCheck={false}
-              aria-label="Target branch"
-            />
-          </div>
-          <AgentSpawnConfig
-            value={agentConfig}
-            onChange={(value) => {
-              setAgentConfigUserTouched(true);
-              setAgentConfig(value);
-            }}
-            disabled={busy !== null}
-          />
+            {mode === 'manual' ? (
+              <>
+                <FieldRow label="Title" help="A short summary of the change.">
+                  <Input
+                    value={title}
+                    onChange={(e) => setTitle(e.target.value)}
+                    disabled={busy !== null}
+                    aria-label="Merge request title"
+                    className="h-8 w-full text-sm sm:w-96"
+                  />
+                </FieldRow>
+                <Divider />
+                <FieldRow label="Description" help="What changed and why. Markdown supported.">
+                  <Textarea
+                    value={description}
+                    onChange={(e) => setDescription(e.target.value)}
+                    autoGrow
+                    minRows={3}
+                    maxRows={10}
+                    disabled={busy !== null}
+                    aria-label="Merge request description"
+                    className="w-full text-sm sm:w-96"
+                  />
+                </FieldRow>
+                <Divider />
+                <FieldRow label="Target branch" help="The branch this merge request merges into.">
+                  <Input
+                    value={targetBranch}
+                    onChange={(e) => setTargetBranch(e.target.value)}
+                    placeholder="main"
+                    className="h-8 w-full font-mono text-sm sm:w-96"
+                    disabled={busy !== null}
+                    autoCapitalize="off"
+                    autoCorrect="off"
+                    spellCheck={false}
+                    aria-label="Target branch"
+                  />
+                </FieldRow>
+              </>
+            ) : (
+              <FieldRow
+                label="Agent"
+                layout="stacked"
+                help="Routing and optional notes for the agent that drafts the title and description, then opens the merge request."
+              >
+                <AgentSpawnConfig
+                  value={agentConfig}
+                  onChange={(value) => {
+                    setAgentConfigUserTouched(true);
+                    setAgentConfig(value);
+                  }}
+                  disabled={busy !== null}
+                />
+              </FieldRow>
+            )}
+            <Divider />
+            <FieldRow
+              label="Open as draft"
+              help="Creates the merge request in GitLab's draft state."
+            >
+              <input
+                type="checkbox"
+                checked={draft}
+                onChange={(e) => setDraft(e.target.checked)}
+                className="accent-primary"
+                disabled={busy !== null}
+              />
+            </FieldRow>
+          </section>
 
           <Divider />
 
-          <footer className="flex shrink-0 items-center justify-between gap-3">
-            <div className="flex min-w-0 items-center gap-3">
-              <label className="flex cursor-pointer items-center gap-2 text-xs text-muted-foreground">
-                <input
-                  type="checkbox"
-                  checked={draft}
-                  onChange={(e) => setDraft(e.target.checked)}
-                  className="accent-primary"
-                  disabled={busy !== null}
-                />
-                Mark as draft
-              </label>
+          <footer className="flex shrink-0 items-center gap-3">
+            <div className="flex min-w-0 flex-1 items-center gap-3">
               {error != null ? (
-                <span role="alert" className="text-xs text-danger">
+                <span
+                  role="alert"
+                  className="inline-flex min-w-0 items-center gap-1 truncate text-xs text-danger"
+                  title={error}
+                >
+                  <AlertTriangle size={12} aria-hidden className="shrink-0" />
                   {error}
                 </span>
               ) : null}
             </div>
-            <div className="flex shrink-0 items-center gap-2">
-              <Button
-                variant="secondary"
-                onClick={() => void onCreateWithAi()}
-                disabled={busy !== null || !branch}
-                title="hand it to an agent: it drafts the title and description, then opens the MR"
-                className={busy === 'ai' ? 'animate-border-pulse' : undefined}
-              >
-                {busy === 'ai' ? null : <Sparkles size={13} className="mr-1.5" aria-hidden />}
-                Draft with an agent
-              </Button>
+            {mode === 'manual' ? (
               <Button
                 onClick={() => void onCreate()}
-                disabled={busy !== null || title.trim().length === 0 || !branch}
+                disabled={busy !== null || title.trim().length === 0 || branch == null}
                 className={busy === 'create' ? 'animate-border-pulse' : undefined}
               >
                 {busy === 'create' ? (
@@ -449,7 +490,22 @@ export const MrDetailPanel = ({
                   </>
                 )}
               </Button>
-            </div>
+            ) : (
+              <Button
+                onClick={() => void onCreateWithAi()}
+                disabled={busy !== null || branch == null}
+                className={busy === 'ai' ? 'animate-border-pulse' : undefined}
+              >
+                {busy === 'ai' ? (
+                  'Drafting…'
+                ) : (
+                  <>
+                    <Sparkles size={13} className="mr-1.5" aria-hidden />
+                    Draft with agent
+                  </>
+                )}
+              </Button>
+            )}
           </footer>
         </section>
       ) : null}

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.test.tsx
@@ -106,7 +106,7 @@ describe('PrPane', () => {
     render(<PrPane session={session} />);
 
     expect(screen.getByText('External review session')).toBeDefined();
-    expect(screen.queryByRole('button', { name: 'Draft with an agent' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Draft with agent' })).toBeNull();
     expect(screen.queryByRole('button', { name: 'Quick draft' })).toBeNull();
   });
 
@@ -320,7 +320,7 @@ describe('PrPane', () => {
       screen.getByText('No issues or external tasks are linked to this session yet.'),
     ).toBeDefined();
     expect(screen.queryByRole('button', { name: 'Quick draft' })).toBeNull();
-    expect(screen.queryByRole('button', { name: 'Draft with an agent' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Draft with agent' })).toBeNull();
   });
 
   it('offers a connect action instead of the create-PR state without a GitHub remote', () => {


### PR DESCRIPTION
## Description

Stacked on #1087. `CreatePrPanel` (and its GitLab MR twin) violated the creation grammar codified in DESIGN.md: `SectionHeader` used as bare field labels, no FieldRow/Divider/help, a native datalist for the base branch, `AgentSpawnConfig` orphaned mid-form, and a footer with two competing CTAs where "Mark as draft" (GitHub draft state) sat next to "Draft with an agent" (agent-authored), both feeding the same boolean.

## Scope

- top-level `Manual | With an agent` mode selection via `SegmentedTabs` in the section header action slot (the workflow builder's Approach precedent)
- manual body: FieldRow + Divider for Title, Description, Base branch (`BranchCombobox` with `Skeleton` while branches load), and "Open as draft" as a proper field with help text; primary `Create PR`
- agent body: `AgentSpawnConfig` mounted in a labeled FieldRow plus the same draft field; primary `Draft with agent`
- one footer per mode: error left (`role="alert"`), ghost Cancel, exactly one primary with `animate-border-pulse` busy state; `px-6 py-5`, single `max-w-2xl`, Sentence case labels
- handlers byte-identical: `createPrForSession` args, the pinned 6-line agent prompt, task-model default and user-touched re-sync, `closedPr` variant
- same grammar applied to the MrDetailPanel new-MR form (target branch stays an input: no GitLab branch-list source exists)
- test coverage added for the manual path (create args, draft toggle, footer error, mode switch, branches skeleton), mirrored on the MR form

## Verification

- monorepo typecheck green
- full apps/desktop suite: 3129 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)