### PR TITLE
refactor(desktop): per-card resolve config popover, combined args fix

### DIFF
--- a/apps/desktop/src/features/chat/spawn-from-comment.test.ts
+++ b/apps/desktop/src/features/chat/spawn-from-comment.test.ts
@@ -203,4 +203,52 @@ describe('spawn-from-comment', () => {
       'Every review thread id above must receive exactly one marker',
     );
   });
+
+  it('keeps the omitted and explicit fix-mode combined prompts byte-identical', () => {
+    const threads = [
+      { head: makeComment({ threadId: 'PRRT_1' }), replies: [] },
+      { head: makeComment({ id: 'review-2', threadId: 'PRRT_2' }), replies: [] },
+    ];
+    const omitted = buildCombinedCommentAgentArgs(threads, PR).initialPrompt;
+    const explicit = buildCombinedCommentAgentArgs(threads, PR, {
+      mode: 'fix',
+      hint: '  ',
+    }).initialPrompt;
+    expect(omitted).toBe(explicit);
+    expect(omitted).not.toContain('Operator notes');
+    expect(omitted).not.toContain('Analysis mode');
+  });
+
+  it('appends the read-only analysis contract to the combined prompt in analyze mode', () => {
+    const args = buildCombinedCommentAgentArgs(
+      [
+        { head: makeComment({ threadId: 'PRRT_1' }), replies: [] },
+        { head: makeComment({ id: 'review-2', threadId: 'PRRT_2' }), replies: [] },
+      ],
+      PR,
+      { mode: 'analyze' },
+    );
+    expect(args.mode).toBe('analyze');
+    expect(args.initialPrompt).toContain('Analyze all 2 review threads together in one pass.');
+    expect(args.initialPrompt).toContain('Analysis mode: do not modify or commit any file.');
+    expect(args.initialPrompt).toContain(
+      'summary must be one paragraph of plain text with no double quotes',
+    );
+  });
+
+  it('appends trimmed operator notes to the combined prompt', () => {
+    const args = buildCombinedCommentAgentArgs(
+      [
+        { head: makeComment({ threadId: 'PRRT_1' }), replies: [] },
+        { head: makeComment({ id: 'review-2', threadId: 'PRRT_2' }), replies: [] },
+      ],
+      PR,
+      { hint: '  Use the existing helper.\nAvoid schema changes.  ' },
+    );
+    expect(args.mode).toBeUndefined();
+    expect(args.initialPrompt).toContain(
+      'Operator notes:\nUse the existing helper.\nAvoid schema changes.',
+    );
+    expect(args.initialPrompt.endsWith('Avoid schema changes.')).toBe(true);
+  });
 });

--- a/apps/desktop/src/features/chat/spawn-from-comment.ts
+++ b/apps/desktop/src/features/chat/spawn-from-comment.ts
@@ -107,11 +107,14 @@ export type CommentAgentArgs = {
 export const buildCombinedCommentAgentPrompt = (
   comments: ReadonlyArray<CommentThread>,
   pr: PullRequestState,
+  choice: ResolveModelChoice = {},
 ): string => {
+  const mode = choice.mode ?? 'fix';
+  const verb = mode === 'analyze' ? 'Analyze' : 'Fix';
   const lines: Array<string> = [
     `Context: PR #${pr.number} on branch \`${pr.headBranch}\`.`,
     '',
-    `Fix all ${comments.length} review threads together in one pass.`,
+    `${verb} all ${comments.length} review threads together in one pass.`,
   ];
   for (const [index, thread] of comments.entries()) {
     const comment = thread.head;
@@ -145,6 +148,23 @@ export const buildCombinedCommentAgentPrompt = (
     '<<comment-reply id="PRRT_...">>your answer for that thread<</comment-reply>>',
     'A block is posted only on the thread whose id it names, so never reuse one answer for several ids.',
   );
+  if (mode === 'analyze') {
+    lines.push('');
+    lines.push('Analysis mode: do not modify or commit any file.');
+    lines.push('Investigate every thread and produce a short analysis for each.');
+    lines.push('Decide for each thread whether it is worth fixing.');
+    lines.push(
+      'Use the <<comment-analysis threadId="PRRT_..." verdict="fix" summary="...">> marker for every thread, never <<comment-resolved>>.',
+    );
+    lines.push('Use verdict="wontfix" instead when a thread is not worth fixing.');
+    lines.push('The summary must be one paragraph of plain text with no double quotes.');
+  }
+  const operatorNotes = (choice.hint ?? '').trim();
+  if (operatorNotes.length > 0) {
+    lines.push('');
+    lines.push('Operator notes:');
+    lines.push(operatorNotes);
+  }
   return lines.join('\n');
 };
 
@@ -161,16 +181,18 @@ export const buildCombinedCommentAgentArgs = (
   const sourceThreadIds = threads.flatMap((thread) =>
     thread.head.threadId != null ? [thread.head.threadId] : [],
   );
+  const mode = choice.mode ?? 'fix';
   return {
     name: `resolve: ${threads.length} review threads`,
     kind: 'resolver',
     model: choice.model ?? defaults.model,
     ...(choice.provider !== undefined && { provider: choice.provider }),
     effort: choice.effort ?? defaults.effort,
-    initialPrompt: buildCombinedCommentAgentPrompt(threads, pr),
+    initialPrompt: buildCombinedCommentAgentPrompt(threads, pr, choice),
     sourceThreadIds,
     sourceCommentUrl: first.head.url,
     sourceKind: 'review_comment',
+    ...(mode !== 'fix' && { mode }),
   };
 };
 

--- a/apps/desktop/src/features/github/components/GitHubStudio/PrDetailPanel.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/PrDetailPanel.tsx
@@ -254,10 +254,7 @@ export const PrDetailPanel = ({
     })();
   };
 
-  const onSpawnCombined = (
-    batch: ReadonlyArray<CommentThread>,
-    choiceById: Readonly<Record<string, ResolveModelChoice>>,
-  ) => {
+  const onSpawnCombined = (batch: ReadonlyArray<CommentThread>, choice: ResolveModelChoice) => {
     if (activePr == null || batch.length < 2 || batch.length > 8) {
       return;
     }
@@ -268,11 +265,6 @@ export const PrDetailPanel = ({
     if (fresh.length < 2) {
       return;
     }
-    const first = fresh[0];
-    if (first === undefined) {
-      return;
-    }
-    const choice = choiceById[first.head.id] ?? {};
     void (async () => {
       await spawnResolver(buildCombinedCommentAgentArgs(fresh, activePr, choice), choice, true);
       await setCurrentSession(sessionId);

--- a/apps/desktop/src/features/github/components/GitHubStudio/ResolveBoard/ResolveCard.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/ResolveBoard/ResolveCard.tsx
@@ -1,0 +1,164 @@
+import type { AgentId, ProviderId } from '@goodboy/types';
+import { cn } from '@goodboy/ui';
+import { ArrowUpRight, ChevronDown, ExternalLink, RotateCcw, Sparkles } from 'lucide-react';
+import { modelEffortLevels } from '../../../../chat/utils/chat-constants';
+import { RoutingBadge } from '../../../../../shared/components/RoutingBadge';
+import type { CommentThread } from '../../../comment-threads';
+import {
+  ResolverStateBadge,
+  resolverBadgeState,
+} from '../../../../session/components/ResolverStateBadge';
+import type { ResolverLink } from '../../../../session/resolver-linkage';
+import { ResolveConfigPopover } from './ResolveConfigPopover';
+import { isClaimedLink } from './isClaimedLink';
+import type { CardConfig } from './config';
+
+type Props = {
+  readonly thread: CommentThread;
+  readonly config: CardConfig;
+  readonly checked: boolean;
+  readonly link?: ResolverLink;
+  readonly connectedProviders: ReadonlyArray<ProviderId>;
+  readonly onToggle: () => void;
+  readonly onConfig: (next: CardConfig) => void;
+  readonly onResolve: () => void;
+  readonly onOpenResolver?: (agentId: AgentId) => void;
+  readonly onOpenThread?: () => void;
+};
+
+export const ResolveCard = ({
+  thread,
+  config,
+  checked,
+  link,
+  connectedProviders,
+  onToggle,
+  onConfig,
+  onResolve,
+  onOpenResolver,
+  onOpenThread,
+}: Props) => {
+  const { head, replies } = thread;
+  const loc = head.path ? `${head.path}${head.line ? `:${head.line}` : ''}` : 'conversation';
+  const claimed = isClaimedLink({ link });
+  const failed = link != null && link.status === 'failed';
+  return (
+    <div
+      className={cn(
+        'rounded-lg border p-3 transition-colors',
+        checked ? 'border-border bg-muted/10' : 'border-border-soft/60 bg-muted/5 opacity-70',
+      )}
+    >
+      <div className="flex items-start gap-2">
+        <input
+          type="checkbox"
+          checked={checked && !claimed}
+          disabled={claimed}
+          onChange={onToggle}
+          aria-label={`include comment by ${head.author}`}
+          className="mt-0.5 size-3.5 accent-primary disabled:opacity-40"
+        />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+            <span className="font-medium text-foreground">{head.author}</span>
+            <span className="opacity-50">·</span>
+            <span className="min-w-0 truncate font-mono text-[11px]">{loc}</span>
+            <div className="ml-auto flex shrink-0 items-center gap-1.5">
+              {link ? <ResolverStateBadge state={resolverBadgeState(link.status)} /> : null}
+              {onOpenThread ? (
+                <button
+                  type="button"
+                  onClick={onOpenThread}
+                  title="open the full thread"
+                  aria-label="open the full thread"
+                  className="shrink-0 rounded p-0.5 text-muted-foreground/60 transition-colors hover:bg-muted hover:text-foreground"
+                >
+                  <ExternalLink size={12} aria-hidden />
+                </button>
+              ) : null}
+            </div>
+          </div>
+          <p className="mt-1 line-clamp-3 whitespace-pre-wrap text-[13px] leading-snug text-foreground [overflow-wrap:anywhere]">
+            {head.body.trim() || '(empty)'}
+          </p>
+
+          {replies.length > 0 && (
+            <div className="mt-2 flex flex-col gap-1.5 border-l border-border-soft pl-2.5">
+              {replies.map((r) => (
+                <div key={r.id} className="flex flex-col gap-0.5">
+                  <span className="text-[11px] font-medium text-muted-foreground">{r.author}</span>
+                  <p className="line-clamp-2 whitespace-pre-wrap text-[12px] leading-snug text-muted-foreground/80 [overflow-wrap:anywhere]">
+                    {r.body.trim() || '(empty)'}
+                  </p>
+                </div>
+              ))}
+            </div>
+          )}
+
+          <div className="mt-2 flex flex-wrap items-center gap-1.5">
+            {claimed && link ? (
+              <button
+                type="button"
+                onClick={() => onOpenResolver?.(link.agent.id as AgentId)}
+                title="open the resolver working on this comment"
+                className="inline-flex items-center gap-1 rounded-md border border-info/40 bg-info/10 px-2 py-1 text-2xs font-semibold text-info transition-colors hover:bg-info/20"
+              >
+                Open resolver
+                <ArrowUpRight size={11} aria-hidden />
+              </button>
+            ) : (
+              <>
+                <ResolveConfigPopover
+                  ariaLabel="configure resolver"
+                  config={config}
+                  connectedProviders={connectedProviders}
+                  primaryLabel="Resolve comment"
+                  onChange={onConfig}
+                  onPrimary={onResolve}
+                  renderTrigger={(open, toggle) => (
+                    <button
+                      type="button"
+                      onClick={toggle}
+                      aria-expanded={open}
+                      className="inline-flex items-center gap-1.5 rounded-md border border-border-soft bg-subtle px-2 py-1 text-2xs transition-colors hover:bg-muted/50"
+                    >
+                      <span className="text-muted-foreground">Resolve with</span>
+                      <RoutingBadge
+                        provider={config.provider}
+                        model={config.model}
+                        effort={modelEffortLevels(config.model) ? config.effort : null}
+                      />
+                      <ChevronDown size={11} aria-hidden className="text-muted-foreground" />
+                    </button>
+                  )}
+                />
+                <button
+                  type="button"
+                  onClick={onResolve}
+                  title={
+                    failed
+                      ? 'retry the resolver for this comment'
+                      : 'spawn a resolver for this comment now'
+                  }
+                  className={cn(
+                    'inline-flex items-center gap-1 rounded-md border px-2 py-1 text-2xs font-semibold transition-colors',
+                    failed
+                      ? 'border-danger/40 bg-danger/10 text-danger hover:bg-danger/20'
+                      : 'border-accent/40 bg-accent/10 text-accent hover:bg-accent/20',
+                  )}
+                >
+                  {failed ? (
+                    <RotateCcw size={11} aria-hidden />
+                  ) : (
+                    <Sparkles size={11} aria-hidden />
+                  )}
+                  {failed ? 'Retry' : 'Resolve'}
+                </button>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/apps/desktop/src/features/github/components/GitHubStudio/ResolveBoard/ResolveConfigPopover/index.test.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/ResolveBoard/ResolveConfigPopover/index.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { ProviderId } from '@goodboy/types';
+import type { CardConfig } from '../config';
+
+vi.mock('../../../../../../store', () => ({
+  useAppStore: <T,>(selector: (s: Record<string, never>) => T) => selector({}),
+}));
+
+import { ResolveConfigPopover } from './index';
+
+const CONFIG: CardConfig = {
+  provider: 'anthropic',
+  model: 'claude-sonnet-4-5',
+  effort: 'medium',
+  mode: 'fix',
+  hint: '',
+};
+
+const renderPopover = (over: Partial<Parameters<typeof ResolveConfigPopover>[0]> = {}) =>
+  render(
+    <ResolveConfigPopover
+      ariaLabel="configure resolver"
+      config={CONFIG}
+      connectedProviders={['anthropic' as ProviderId]}
+      primaryLabel="Resolve comment"
+      onChange={vi.fn()}
+      onPrimary={vi.fn()}
+      renderTrigger={(open, toggle) => (
+        <button type="button" aria-expanded={open} onClick={toggle}>
+          Open config
+        </button>
+      )}
+      {...over}
+    />,
+  );
+
+const open = () => {
+  fireEvent.click(screen.getByRole('button', { name: 'Open config' }));
+};
+
+afterEach(cleanup);
+
+describe('ResolveConfigPopover', () => {
+  it('opens a portaled dialog with mode, instructions and routing sections', () => {
+    renderPopover();
+    expect(screen.queryByRole('dialog', { name: 'configure resolver' })).toBeNull();
+
+    open();
+    const dialog = screen.getByRole('dialog', { name: 'configure resolver' });
+    expect(dialog.closest('[data-dropdown-portal]')?.parentElement).toBe(document.body);
+    expect(screen.getByText('Mode')).toBeDefined();
+    expect(screen.getByText('Instructions')).toBeDefined();
+    expect(screen.getByText('Provider')).toBeDefined();
+  });
+
+  it('reports a mode change through onChange', () => {
+    const onChange = vi.fn();
+    renderPopover({ onChange });
+    open();
+    fireEvent.click(screen.getByRole('tab', { name: 'Analyze' }));
+    expect(onChange).toHaveBeenCalledWith({ ...CONFIG, mode: 'analyze' });
+  });
+
+  it('reports hint edits through onChange', () => {
+    const onChange = vi.fn();
+    renderPopover({ onChange });
+    open();
+    fireEvent.change(screen.getByRole('textbox', { name: 'Resolver hint' }), {
+      target: { value: 'Keep the public API stable.' },
+    });
+    expect(onChange).toHaveBeenCalledWith({ ...CONFIG, hint: 'Keep the public API stable.' });
+  });
+
+  it('fires onPrimary from the single footer action and closes', () => {
+    const onPrimary = vi.fn();
+    renderPopover({ onPrimary });
+    open();
+    fireEvent.click(screen.getByRole('button', { name: 'Resolve comment' }));
+    expect(onPrimary).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('dialog', { name: 'configure resolver' })).toBeNull();
+  });
+
+  it('reports a model pick with the viewed provider', () => {
+    const onChange = vi.fn();
+    renderPopover({ onChange });
+    open();
+    fireEvent.click(screen.getByRole('button', { name: 'Opus 5' }));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: 'anthropic', model: 'claude-opus-5' }),
+    );
+  });
+});

--- a/apps/desktop/src/features/github/components/GitHubStudio/ResolveBoard/ResolveConfigPopover/index.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/ResolveBoard/ResolveConfigPopover/index.tsx
@@ -1,0 +1,146 @@
+import { useEffect, useState, type ReactNode } from 'react';
+import {
+  Button,
+  Divider,
+  Popover,
+  SegmentedTabs,
+  Textarea,
+  cn,
+  type SegmentedTabOption,
+} from '@goodboy/ui';
+import type { ProviderId } from '@goodboy/types';
+import type { ResolveMode } from '../../../../../chat/spawn-from-comment';
+import { PickerSection } from '../../../../../../shared/components/RoutingPicker/PickerSection';
+import { useDropdown } from '../../../../../../shared/hooks/useDropdown';
+import { DropdownPortal } from '../../../../../../shared/hooks/useDropdown/DropdownPortal';
+import { AgentRoutingSections } from '../../../../../session/components/CreateAgentPopover/AgentRoutingSections';
+import { configFor, type CardConfig } from '../config';
+
+const MODE_OPTIONS: ReadonlyArray<SegmentedTabOption<ResolveMode>> = [
+  { label: 'Fix', value: 'fix' },
+  { label: 'Analyze', value: 'analyze' },
+];
+
+const MODE_HINT: Record<ResolveMode, string> = {
+  fix: 'Edits the code and resolves the thread',
+  analyze: 'Read-only: investigates and reports a verdict',
+};
+
+type Props = {
+  readonly ariaLabel: string;
+  readonly config: CardConfig;
+  readonly connectedProviders: ReadonlyArray<ProviderId>;
+  readonly primaryLabel: string;
+  readonly onChange: (next: CardConfig) => void;
+  readonly onPrimary: () => void;
+  readonly renderTrigger: (open: boolean, toggle: () => void) => ReactNode;
+};
+
+export const ResolveConfigPopover = ({
+  ariaLabel,
+  config,
+  connectedProviders,
+  primaryLabel,
+  onChange,
+  onPrimary,
+  renderTrigger,
+}: Props) => {
+  const {
+    open,
+    close,
+    toggle,
+    containerRef,
+    popupRef,
+    popupClassName,
+    popupStyle,
+    portal,
+    portalTarget,
+  } = useDropdown({
+    align: 'end',
+    expectedHeight: 520,
+    expectedWidth: 384,
+    width: 'w-96 max-w-[calc(100vw-2rem)]',
+    strategy: 'fixed',
+  });
+  const [viewProvider, setViewProvider] = useState<ProviderId>(config.provider);
+
+  useEffect(() => {
+    setViewProvider(config.provider);
+  }, [open, config.provider]);
+
+  return (
+    <div ref={containerRef} className="relative min-w-0">
+      {renderTrigger(open, toggle)}
+      <DropdownPortal portal={portal} portalTarget={portalTarget}>
+        {open && (
+          <Popover
+            innerRef={popupRef}
+            role="dialog"
+            ariaLabel={ariaLabel}
+            className={cn(popupClassName, 'flex flex-col bg-subtle')}
+            style={popupStyle}
+          >
+            <PickerSection label="Mode" hint={MODE_HINT[config.mode]}>
+              <div className="px-2.5">
+                <SegmentedTabs
+                  ariaLabel="Resolver mode"
+                  value={config.mode}
+                  options={MODE_OPTIONS}
+                  onChange={(mode) => onChange({ ...config, mode })}
+                  size="sm"
+                  fill
+                />
+              </div>
+            </PickerSection>
+            <Divider />
+            <PickerSection label="Instructions" hint="Notes the resolver reads before starting">
+              <div className="px-2.5">
+                <Textarea
+                  aria-label="Resolver hint"
+                  autoGrow
+                  minRows={2}
+                  maxRows={6}
+                  value={config.hint}
+                  onChange={(event) => onChange({ ...config, hint: event.target.value })}
+                  placeholder="Optional notes for the resolver: how to fix, what to avoid..."
+                  className="px-2 py-1.5 text-xs"
+                />
+              </div>
+            </PickerSection>
+            <Divider />
+            <AgentRoutingSections
+              connectedProviders={connectedProviders}
+              effective={{ provider: config.provider, model: config.model, effort: config.effort }}
+              viewProvider={viewProvider}
+              onViewProvider={setViewProvider}
+              onPickProvider={(provider) => onChange(configFor({ provider, base: config }))}
+              onPickModel={(model, effort) =>
+                onChange({ ...config, provider: viewProvider, model, effort })
+              }
+              onConnectProvider={(provider) => {
+                window.dispatchEvent(
+                  new CustomEvent('goodboy:open-provider-studio', {
+                    detail: { providerId: provider },
+                  }),
+                );
+                close();
+              }}
+            />
+            <Divider />
+            <div className="flex items-center justify-end px-2.5 py-2">
+              <Button
+                size="sm"
+                onClick={() => {
+                  onPrimary();
+                  close();
+                }}
+              >
+                {primaryLabel}
+              </Button>
+            </div>
+          </Popover>
+        )}
+      </DropdownPortal>
+    </div>
+  );
+};

--- a/apps/desktop/src/features/github/components/GitHubStudio/ResolveBoard/config.test.ts
+++ b/apps/desktop/src/features/github/components/GitHubStudio/ResolveBoard/config.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { aggregateConfig, clampEffort, configFor, defaultConfig, sameConfig } from './config';
+import { clampEffort } from '../../../../chat/utils/chat-constants';
+import { aggregateConfig, configFor, defaultConfig, sameConfig } from './config';
 
 const DEFAULT_CONFIG = defaultConfig({ roleModels: null });
 
@@ -13,19 +14,31 @@ describe('ResolveBoard config', () => {
     expect(clampEffort('gpt-5.5', 'minimal')).toBe('low');
   });
 
+  it('defaultConfig seeds fix mode with an empty hint', () => {
+    expect(DEFAULT_CONFIG.mode).toBe('fix');
+    expect(DEFAULT_CONFIG.hint).toBe('');
+  });
+
   it('configFor seeds the resolver default model for anthropic', () => {
     expect(configFor({ provider: 'anthropic', base: DEFAULT_CONFIG })).toEqual(DEFAULT_CONFIG);
   });
 
-  it('configFor uses the provider default model for non-anthropic', () => {
-    const cfg = configFor({ provider: 'codex', base: DEFAULT_CONFIG });
+  it('configFor uses the provider default model and keeps mode and hint', () => {
+    const cfg = configFor({
+      provider: 'codex',
+      base: { ...DEFAULT_CONFIG, mode: 'analyze', hint: 'careful' },
+    });
     expect(cfg.provider).toBe('codex');
     expect(cfg.model).not.toBe(DEFAULT_CONFIG.model);
+    expect(cfg.mode).toBe('analyze');
+    expect(cfg.hint).toBe('careful');
   });
 
-  it('sameConfig compares provider, model and effort', () => {
+  it('sameConfig compares routing, mode and hint', () => {
     expect(sameConfig(DEFAULT_CONFIG, { ...DEFAULT_CONFIG })).toBe(true);
     expect(sameConfig(DEFAULT_CONFIG, { ...DEFAULT_CONFIG, effort: 'high' })).toBe(false);
+    expect(sameConfig(DEFAULT_CONFIG, { ...DEFAULT_CONFIG, mode: 'analyze' })).toBe(false);
+    expect(sameConfig(DEFAULT_CONFIG, { ...DEFAULT_CONFIG, hint: 'x' })).toBe(false);
   });
 
   it('aggregateConfig returns the shared config when uniform, else mixed', () => {

--- a/apps/desktop/src/features/github/components/GitHubStudio/ResolveBoard/config.ts
+++ b/apps/desktop/src/features/github/components/GitHubStudio/ResolveBoard/config.ts
@@ -1,14 +1,15 @@
 import type { ProviderId, RoleModelPreferences } from '@goodboy/types';
 import { getDefaultTurnModel } from '@goodboy/core';
 import { clampEffort, type EffortLevel } from '../../../../chat/utils/chat-constants';
+import type { ResolveMode } from '../../../../chat/spawn-from-comment';
 import { kindRouting } from '../../../../session/agent-kind';
-
-export { clampEffort };
 
 export type CardConfig = {
   readonly provider: ProviderId;
   readonly model: string;
   readonly effort: EffortLevel;
+  readonly mode: ResolveMode;
+  readonly hint: string;
 };
 
 type DefaultParams = {
@@ -17,7 +18,13 @@ type DefaultParams = {
 
 export const defaultConfig = ({ roleModels }: DefaultParams): CardConfig => {
   const routing = kindRouting({ kind: 'resolver', roleModels });
-  return { provider: routing.provider, model: routing.model, effort: routing.effort };
+  return {
+    provider: routing.provider,
+    model: routing.model,
+    effort: routing.effort,
+    mode: 'fix',
+    hint: '',
+  };
 };
 
 type ConfigForParams = {
@@ -27,11 +34,17 @@ type ConfigForParams = {
 
 export const configFor = ({ provider, base }: ConfigForParams): CardConfig => {
   const model = provider === base.provider ? base.model : getDefaultTurnModel({ id: provider });
-  return { provider, model, effort: clampEffort(model, base.effort) };
+  return { ...base, provider, model, effort: clampEffort(model, base.effort) };
 };
 
 export const sameConfig = (a: CardConfig, b: CardConfig): boolean => {
-  return a.provider === b.provider && a.model === b.model && a.effort === b.effort;
+  return (
+    a.provider === b.provider &&
+    a.model === b.model &&
+    a.effort === b.effort &&
+    a.mode === b.mode &&
+    a.hint === b.hint
+  );
 };
 
 type AggregateParams = {

--- a/apps/desktop/src/features/github/components/GitHubStudio/ResolveBoard/index.test.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/ResolveBoard/index.test.tsx
@@ -44,6 +44,16 @@ function thread(
   return { head: comment(over), replies };
 }
 
+const setHint = (value: string) => {
+  fireEvent.change(screen.getByRole('textbox', { name: /Resolver hint/i }), {
+    target: { value },
+  });
+};
+
+const closePopover = () => {
+  fireEvent.keyDown(window, { key: 'Escape' });
+};
+
 beforeEach(() => {
   h.providers = [{ id: 'anthropic', connection: 'connected' }];
 });
@@ -100,7 +110,7 @@ describe('ResolveBoard', () => {
     );
   });
 
-  it('applies mode and hint to a single resolver', () => {
+  it('applies mode and hint from the card popover to that resolver', () => {
     const onSpawnOne = vi.fn<(thread: CommentThread, choice: ResolveModelChoice) => void>();
     render(
       <ResolveBoard
@@ -115,21 +125,22 @@ describe('ResolveBoard', () => {
     act(() => {
       fireEvent.click(screen.getByRole('button', { name: /Resolve with/i }));
     });
+    expect(screen.getByRole('dialog', { name: 'configure resolver' })).toBeDefined();
     act(() => {
       fireEvent.click(screen.getByRole('tab', { name: 'Analyze' }));
-      fireEvent.change(screen.getByRole('textbox', { name: /Resolver hint/i }), {
-        target: { value: 'Avoid schema changes.' },
-      });
     });
     act(() => {
-      fireEvent.click(screen.getByRole('button', { name: /^Resolve$/i }));
+      setHint('Avoid schema changes.');
+    });
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: 'Resolve comment' }));
     });
     expect(onSpawnOne.mock.calls[0]?.[1]).toEqual(
       expect.objectContaining({ mode: 'analyze', hint: 'Avoid schema changes.' }),
     );
   });
 
-  it('shares mode and hint across every resolver in a batch', () => {
+  it('keeps a per-card hint on that card only', () => {
     const onSpawnBatch =
       vi.fn<
         (
@@ -148,24 +159,113 @@ describe('ResolveBoard', () => {
       />,
     );
     act(() => {
-      fireEvent.click(screen.getByRole('button', { name: /Resolve all with/i }));
+      fireEvent.click(screen.getAllByRole('button', { name: /Resolve with/i })[0]!);
     });
     act(() => {
-      fireEvent.click(screen.getByRole('tab', { name: 'Analyze' }));
-      fireEvent.change(screen.getByRole('textbox', { name: /Resolver hint/i }), {
-        target: { value: 'Keep the public API stable.' },
-      });
+      setHint('Only here.');
+    });
+    act(() => {
+      closePopover();
     });
     act(() => {
       fireEvent.click(screen.getByRole('button', { name: /Spawn 2 resolvers/i }));
     });
     const choices = onSpawnBatch.mock.calls[0]?.[1];
-    expect(choices?.c1).toEqual(
-      expect.objectContaining({ mode: 'analyze', hint: 'Keep the public API stable.' }),
+    expect(choices?.c1).toEqual(expect.objectContaining({ hint: 'Only here.' }));
+    expect(choices?.c2).toEqual(expect.objectContaining({ hint: '' }));
+  });
+
+  it('applies batch defaults to cards without an explicit override', () => {
+    const onSpawnBatch =
+      vi.fn<
+        (
+          threads: ReadonlyArray<CommentThread>,
+          choiceById: Readonly<Record<string, ResolveModelChoice>>,
+        ) => void
+      >();
+    render(
+      <ResolveBoard
+        roleModels={null}
+        threads={[thread({ id: 'c1' }), thread({ id: 'c2', threadId: 'PRRT_2' })]}
+        onSpawnOne={vi.fn()}
+        onSpawnBatch={onSpawnBatch}
+        onSpawnCombined={vi.fn()}
+        onOpenThread={vi.fn()}
+      />,
     );
+    act(() => {
+      fireEvent.click(screen.getAllByRole('button', { name: /Resolve with/i })[0]!);
+    });
+    act(() => {
+      setHint('Card override.');
+    });
+    act(() => {
+      closePopover();
+    });
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: /Resolve all with/i }));
+    });
+    act(() => {
+      fireEvent.click(screen.getByRole('tab', { name: 'Analyze' }));
+    });
+    act(() => {
+      setHint('Batch default.');
+    });
+    act(() => {
+      closePopover();
+    });
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: /Spawn 2 resolvers/i }));
+    });
+    const choices = onSpawnBatch.mock.calls[0]?.[1];
+    expect(choices?.c1).toEqual(expect.objectContaining({ mode: 'fix', hint: 'Card override.' }));
     expect(choices?.c2).toEqual(
-      expect.objectContaining({ mode: 'analyze', hint: 'Keep the public API stable.' }),
+      expect.objectContaining({ mode: 'analyze', hint: 'Batch default.' }),
     );
+  });
+
+  it('apply-to-all overwrites every per-card override', () => {
+    const onSpawnBatch =
+      vi.fn<
+        (
+          threads: ReadonlyArray<CommentThread>,
+          choiceById: Readonly<Record<string, ResolveModelChoice>>,
+        ) => void
+      >();
+    render(
+      <ResolveBoard
+        roleModels={null}
+        threads={[thread({ id: 'c1' }), thread({ id: 'c2', threadId: 'PRRT_2' })]}
+        onSpawnOne={vi.fn()}
+        onSpawnBatch={onSpawnBatch}
+        onSpawnCombined={vi.fn()}
+        onOpenThread={vi.fn()}
+      />,
+    );
+    act(() => {
+      fireEvent.click(screen.getAllByRole('button', { name: /Resolve with/i })[0]!);
+    });
+    act(() => {
+      setHint('Card override.');
+    });
+    act(() => {
+      closePopover();
+    });
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: /Resolve all with/i }));
+    });
+    act(() => {
+      setHint('Everywhere.');
+    });
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: 'Apply to all cards' }));
+    });
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: /Spawn 2 resolvers/i }));
+    });
+    const choices = onSpawnBatch.mock.calls[0]?.[1];
+    expect(choices?.c1).toEqual(expect.objectContaining({ hint: 'Everywhere.' }));
+    expect(choices?.c2).toEqual(expect.objectContaining({ hint: 'Everywhere.' }));
   });
 
   it('renders the head comment plus its replies as context', () => {
@@ -202,8 +302,9 @@ describe('ResolveBoard', () => {
     expect(screen.getByText(/Nothing to resolve/i)).toBeDefined();
   });
 
-  it('spawns one combined resolver for the selected threads', () => {
-    const onSpawnCombined = vi.fn();
+  it('spawns one combined resolver with the batch defaults', () => {
+    const onSpawnCombined =
+      vi.fn<(threads: ReadonlyArray<CommentThread>, choice: ResolveModelChoice) => void>();
     render(
       <ResolveBoard
         roleModels={null}
@@ -215,11 +316,26 @@ describe('ResolveBoard', () => {
       />,
     );
     act(() => {
+      fireEvent.click(screen.getByRole('button', { name: /Resolve all with/i }));
+    });
+    act(() => {
+      fireEvent.click(screen.getByRole('tab', { name: 'Analyze' }));
+    });
+    act(() => {
+      setHint('Read only please.');
+    });
+    act(() => {
+      closePopover();
+    });
+    act(() => {
       fireEvent.click(screen.getByRole('button', { name: 'Spawn 1 combined resolver' }));
     });
     expect(onSpawnCombined).toHaveBeenCalledOnce();
     expect(
-      onSpawnCombined.mock.calls[0]?.[0].map((item: CommentThread) => item.head.threadId),
+      onSpawnCombined.mock.calls[0]?.[0]?.map((item: CommentThread) => item.head.threadId),
     ).toEqual(['PRRT_1', 'PRRT_2']);
+    expect(onSpawnCombined.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({ mode: 'analyze', hint: 'Read only please.' }),
+    );
   });
 });

--- a/apps/desktop/src/features/github/components/GitHubStudio/ResolveBoard/index.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/ResolveBoard/index.tsx
@@ -1,27 +1,17 @@
-import { useMemo, useState, type ReactNode } from 'react';
+import { useMemo, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
-import type { AgentId, ProviderId, RoleModelPreferences } from '@goodboy/types';
-import { cn, EmptyState, SegmentedTabs, type SegmentedTabOption } from '@goodboy/ui';
-import {
-  ArrowUpRight,
-  ChevronDown,
-  ExternalLink,
-  RotateCcw,
-  Sliders,
-  Sparkles,
-} from 'lucide-react';
-import { modelEffortLevels, type EffortLevel } from '../../../../chat/utils/chat-constants';
+import type { AgentId, RoleModelPreferences } from '@goodboy/types';
+import { EmptyState } from '@goodboy/ui';
+import { ChevronDown, Sliders, Sparkles } from 'lucide-react';
 import { RoutingBadge } from '../../../../../shared/components/RoutingBadge';
-import { RoutingPicker } from '../../../../../shared/components/RoutingPicker';
-import type { ResolveMode, ResolveModelChoice } from '../../../../chat/spawn-from-comment';
+import type { ResolveModelChoice } from '../../../../chat/spawn-from-comment';
 import type { CommentThread } from '../../../comment-threads';
-import {
-  ResolverStateBadge,
-  resolverBadgeState,
-} from '../../../../session/components/ResolverStateBadge';
 import type { ResolverLink } from '../../../../session/resolver-linkage';
 import { useAppStore } from '../../../../../store';
-import { aggregateConfig, clampEffort, configFor, defaultConfig, type CardConfig } from './config';
+import { aggregateConfig, defaultConfig, type CardConfig } from './config';
+import { isClaimedLink } from './isClaimedLink';
+import { ResolveCard } from './ResolveCard';
+import { ResolveConfigPopover } from './ResolveConfigPopover';
 
 type Props = {
   readonly threads: ReadonlyArray<CommentThread>;
@@ -33,20 +23,12 @@ type Props = {
   ) => void;
   readonly onSpawnCombined: (
     threads: ReadonlyArray<CommentThread>,
-    choiceById: Readonly<Record<string, ResolveModelChoice>>,
+    choice: ResolveModelChoice,
   ) => void;
   readonly onOpenResolver?: (agentId: AgentId) => void;
   readonly onOpenThread: (threadId: string) => void;
   readonly roleModels: RoleModelPreferences | null;
 };
-
-const isClaimed = (link: ResolverLink | undefined): boolean =>
-  link != null && link.status !== 'failed';
-
-const MODE_OPTIONS: ReadonlyArray<SegmentedTabOption<ResolveMode>> = [
-  { label: 'Fix', value: 'fix' },
-  { label: 'Analyze', value: 'analyze' },
-];
 
 export const ResolveBoard = ({
   threads,
@@ -62,20 +44,18 @@ export const ResolveBoard = ({
     useShallow((s) => s.providers.filter((p) => p.connection === 'connected').map((p) => p.id)),
   );
   const [configById, setConfigById] = useState<Readonly<Record<string, CardConfig>>>({});
+  const [defaultsOverride, setDefaultsOverride] = useState<CardConfig | null>(null);
   const [deselected, setDeselected] = useState<ReadonlySet<string>>(new Set());
-  const [overrideOpen, setOverrideOpen] = useState(false);
-  const [mode, setMode] = useState<ResolveMode>('fix');
-  const [hint, setHint] = useState('');
 
   const base = useMemo(() => defaultConfig({ roleModels }), [roleModels]);
-  const getConfig = (id: string): CardConfig => configById[id] ?? base;
+  const defaults = defaultsOverride ?? base;
+  const getConfig = (id: string): CardConfig => configById[id] ?? defaults;
   const patchConfig = (id: string, next: CardConfig) =>
     setConfigById((prev) => ({ ...prev, [id]: next }));
-  const applyToAll = (next: CardConfig) =>
-    setConfigById(() => Object.fromEntries(threads.map((t) => [t.head.id, next])));
+  const applyToAll = () => setConfigById({});
 
   const selectable = useMemo(
-    () => threads.filter((t) => !isClaimed(resolverFor?.(t))),
+    () => threads.filter((t) => !isClaimedLink({ link: resolverFor?.(t) })),
     [threads, resolverFor],
   );
   const selected = useMemo(
@@ -85,7 +65,7 @@ export const ResolveBoard = ({
   const allSelected = selectable.length > 0 && selected.length === selectable.length;
   const aggregate = aggregateConfig({
     configs: threads.map((t) => getConfig(t.head.id)),
-    fallback: base,
+    fallback: defaults,
   });
 
   if (threads.length === 0) {
@@ -114,7 +94,7 @@ export const ResolveBoard = ({
     setDeselected(allSelected ? new Set(selectable.map((t) => t.head.id)) : new Set());
 
   const choiceById: Record<string, ResolveModelChoice> = Object.fromEntries(
-    threads.map((t) => [t.head.id, { ...getConfig(t.head.id), mode, hint }]),
+    threads.map((t) => [t.head.id, { ...getConfig(t.head.id) }]),
   );
 
   return (
@@ -135,51 +115,39 @@ export const ResolveBoard = ({
           <span className="font-medium">{selected.length} selected</span>
         </label>
 
-        <div className="relative ml-auto">
-          <button
-            type="button"
-            onClick={() => setOverrideOpen((v) => !v)}
-            title="apply one resolver configuration to every comment"
-            className="inline-flex items-center gap-1.5 rounded-md border border-border-soft bg-subtle px-2 py-1 text-xs transition-colors hover:bg-muted/50"
-          >
-            <Sliders size={12} aria-hidden className="text-muted-foreground" />
-            <span className="text-muted-foreground">Resolve all with</span>
-            {aggregate === 'mixed' ? (
-              <span className="font-medium text-foreground">Customized</span>
-            ) : (
-              <RoutingBadge provider={aggregate.provider} model={aggregate.model} />
+        <div className="ml-auto">
+          <ResolveConfigPopover
+            ariaLabel="configure batch resolvers"
+            config={defaults}
+            connectedProviders={connectedProviders}
+            primaryLabel="Apply to all cards"
+            onChange={setDefaultsOverride}
+            onPrimary={applyToAll}
+            renderTrigger={(open, popoverToggle) => (
+              <button
+                type="button"
+                onClick={popoverToggle}
+                aria-expanded={open}
+                title="apply one resolver configuration to every comment"
+                className="inline-flex items-center gap-1.5 rounded-md border border-border-soft bg-subtle px-2 py-1 text-xs transition-colors hover:bg-muted/50"
+              >
+                <Sliders size={12} aria-hidden className="text-muted-foreground" />
+                <span className="text-muted-foreground">Resolve all with</span>
+                {aggregate === 'mixed' ? (
+                  <span className="font-medium text-foreground">Customized</span>
+                ) : (
+                  <RoutingBadge provider={aggregate.provider} model={aggregate.model} />
+                )}
+                <ChevronDown size={11} aria-hidden className="text-muted-foreground" />
+              </button>
             )}
-            <ChevronDown size={11} aria-hidden className="text-muted-foreground" />
-          </button>
-          {overrideOpen ? (
-            <ConfigPanel
-              className="absolute right-0 top-8 z-20 w-64"
-              title="Apply to all comments"
-              config={aggregate === 'mixed' ? base : aggregate}
-              base={base}
-              mode={mode}
-              hint={hint}
-              connectedProviders={connectedProviders}
-              onChange={(next) => applyToAll(next)}
-              onMode={setMode}
-              onHint={setHint}
-              footer={
-                <button
-                  type="button"
-                  onClick={() => setOverrideOpen(false)}
-                  className="w-full rounded-md bg-primary px-2 py-1 text-xs font-semibold text-primary-foreground transition-opacity hover:opacity-90"
-                >
-                  Done
-                </button>
-              }
-            />
-          ) : null}
+          />
         </div>
 
         {selected.length >= 2 ? (
           <button
             type="button"
-            onClick={() => onSpawnCombined(selected, choiceById)}
+            onClick={() => onSpawnCombined(selected, { ...defaults })}
             disabled={selected.length > 8}
             title={selected.length > 8 ? 'Too many threads for one resolver (max 8)' : undefined}
             className="inline-flex items-center gap-1.5 rounded-md border border-accent/40 px-2.5 py-1 text-xs font-semibold text-accent transition-opacity hover:bg-accent/10 disabled:cursor-not-allowed disabled:opacity-50"
@@ -207,17 +175,12 @@ export const ResolveBoard = ({
             <ResolveCard
               thread={t}
               config={getConfig(t.head.id)}
-              base={base}
               checked={!deselected.has(t.head.id)}
               link={resolverFor?.(t)}
               connectedProviders={connectedProviders}
               onToggle={() => toggle(t.head.id)}
               onConfig={(next) => patchConfig(t.head.id, next)}
-              onResolve={() => onSpawnOne(t, { ...getConfig(t.head.id), mode, hint })}
-              mode={mode}
-              hint={hint}
-              onMode={setMode}
-              onHint={setHint}
+              onResolve={() => onSpawnOne(t, { ...getConfig(t.head.id) })}
               onOpenResolver={onOpenResolver}
               onOpenThread={
                 t.head.threadId ? () => onOpenThread(t.head.threadId as string) : undefined
@@ -229,251 +192,3 @@ export const ResolveBoard = ({
     </div>
   );
 };
-
-function ResolveCard({
-  thread,
-  config,
-  base,
-  checked,
-  link,
-  connectedProviders,
-  onToggle,
-  onConfig,
-  onResolve,
-  mode,
-  hint,
-  onMode,
-  onHint,
-  onOpenResolver,
-  onOpenThread,
-}: {
-  thread: CommentThread;
-  config: CardConfig;
-  base: CardConfig;
-  checked: boolean;
-  link?: ResolverLink;
-  connectedProviders: ReadonlyArray<ProviderId>;
-  onToggle: () => void;
-  onConfig: (next: CardConfig) => void;
-  onResolve: () => void;
-  mode: ResolveMode;
-  hint: string;
-  onMode: (next: ResolveMode) => void;
-  onHint: (next: string) => void;
-  onOpenResolver?: (agentId: AgentId) => void;
-  onOpenThread?: () => void;
-}) {
-  const [configOpen, setConfigOpen] = useState(false);
-  const { head, replies } = thread;
-  const loc = head.path ? `${head.path}${head.line ? `:${head.line}` : ''}` : 'conversation';
-  const claimed = isClaimed(link);
-  const failed = link != null && link.status === 'failed';
-  return (
-    <div
-      className={cn(
-        'rounded-lg border p-3 transition-colors',
-        checked ? 'border-border bg-muted/10' : 'border-border-soft/60 bg-muted/5 opacity-70',
-      )}
-    >
-      <div className="flex items-start gap-2">
-        <input
-          type="checkbox"
-          checked={checked && !claimed}
-          disabled={claimed}
-          onChange={onToggle}
-          aria-label={`include comment by ${head.author}`}
-          className="mt-0.5 size-3.5 accent-primary disabled:opacity-40"
-        />
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-            <span className="font-medium text-foreground">{head.author}</span>
-            <span className="opacity-50">·</span>
-            <span className="min-w-0 truncate font-mono text-[11px]">{loc}</span>
-            <div className="ml-auto flex shrink-0 items-center gap-1.5">
-              {link ? <ResolverStateBadge state={resolverBadgeState(link.status)} /> : null}
-              {onOpenThread ? (
-                <button
-                  type="button"
-                  onClick={onOpenThread}
-                  title="open the full thread"
-                  aria-label="open the full thread"
-                  className="shrink-0 rounded p-0.5 text-muted-foreground/60 transition-colors hover:bg-muted hover:text-foreground"
-                >
-                  <ExternalLink size={12} aria-hidden />
-                </button>
-              ) : null}
-            </div>
-          </div>
-          <p className="mt-1 line-clamp-3 whitespace-pre-wrap text-[13px] leading-snug text-foreground [overflow-wrap:anywhere]">
-            {head.body.trim() || '(empty)'}
-          </p>
-
-          {replies.length > 0 && (
-            <div className="mt-2 flex flex-col gap-1.5 border-l border-border-soft pl-2.5">
-              {replies.map((r) => (
-                <div key={r.id} className="flex flex-col gap-0.5">
-                  <span className="text-[11px] font-medium text-muted-foreground">{r.author}</span>
-                  <p className="line-clamp-2 whitespace-pre-wrap text-[12px] leading-snug text-muted-foreground/80 [overflow-wrap:anywhere]">
-                    {r.body.trim() || '(empty)'}
-                  </p>
-                </div>
-              ))}
-            </div>
-          )}
-
-          <div className="mt-2 flex flex-wrap items-center gap-1.5">
-            {claimed && link ? (
-              <button
-                type="button"
-                onClick={() => onOpenResolver?.(link.agent.id as AgentId)}
-                title="open the resolver working on this comment"
-                className="inline-flex items-center gap-1 rounded-md border border-info/40 bg-info/10 px-2 py-1 text-2xs font-semibold text-info transition-colors hover:bg-info/20"
-              >
-                Open resolver
-                <ArrowUpRight size={11} aria-hidden />
-              </button>
-            ) : (
-              <>
-                <div className="relative">
-                  <button
-                    type="button"
-                    onClick={() => setConfigOpen((v) => !v)}
-                    className="inline-flex items-center gap-1.5 rounded-md border border-border-soft bg-subtle px-2 py-1 text-2xs transition-colors hover:bg-muted/50"
-                  >
-                    <span className="text-muted-foreground">Resolve with</span>
-                    <RoutingBadge
-                      provider={config.provider}
-                      model={config.model}
-                      effort={modelEffortLevels(config.model) ? config.effort : null}
-                    />
-                    <ChevronDown size={11} aria-hidden className="text-muted-foreground" />
-                  </button>
-                  {configOpen ? (
-                    <ConfigPanel
-                      className="absolute left-0 top-8 z-20 w-60"
-                      title="Resolve with"
-                      config={config}
-                      base={base}
-                      mode={mode}
-                      hint={hint}
-                      connectedProviders={connectedProviders}
-                      onChange={onConfig}
-                      onMode={onMode}
-                      onHint={onHint}
-                      footer={
-                        <button
-                          type="button"
-                          onClick={() => setConfigOpen(false)}
-                          className="w-full rounded-md bg-muted px-2 py-1 text-xs font-medium text-foreground transition-colors hover:bg-muted/70"
-                        >
-                          Done
-                        </button>
-                      }
-                    />
-                  ) : null}
-                </div>
-                <button
-                  type="button"
-                  onClick={onResolve}
-                  title={
-                    failed
-                      ? 'retry the resolver for this comment'
-                      : 'spawn a resolver for this comment now'
-                  }
-                  className={cn(
-                    'inline-flex items-center gap-1 rounded-md border px-2 py-1 text-2xs font-semibold transition-colors',
-                    failed
-                      ? 'border-danger/40 bg-danger/10 text-danger hover:bg-danger/20'
-                      : 'border-accent/40 bg-accent/10 text-accent hover:bg-accent/20',
-                  )}
-                >
-                  {failed ? (
-                    <RotateCcw size={11} aria-hidden />
-                  ) : (
-                    <Sparkles size={11} aria-hidden />
-                  )}
-                  {failed ? 'Retry' : 'Resolve'}
-                </button>
-              </>
-            )}
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function ConfigPanel({
-  className,
-  title,
-  config,
-  base,
-  mode,
-  hint,
-  connectedProviders,
-  onChange,
-  onMode,
-  onHint,
-  footer,
-}: {
-  className?: string;
-  title: string;
-  config: CardConfig;
-  base: CardConfig;
-  mode: ResolveMode;
-  hint: string;
-  connectedProviders: ReadonlyArray<ProviderId>;
-  onChange: (next: CardConfig) => void;
-  onMode: (next: ResolveMode) => void;
-  onHint: (next: string) => void;
-  footer?: ReactNode;
-}) {
-  const onProvider = (next: ProviderId | '') => {
-    if (next === '') {
-      return;
-    }
-    onChange(configFor({ provider: next, base }));
-  };
-  const onModel = (model: string) =>
-    onChange({ ...config, model, effort: clampEffort(model, config.effort) });
-  const onEffort = (effort: EffortLevel) => onChange({ ...config, effort });
-  return (
-    <div
-      className={cn(
-        'flex flex-col gap-2 rounded-lg border border-border-soft bg-background p-2 shadow-lg',
-        className,
-      )}
-    >
-      <span className="text-2xs font-semibold uppercase tracking-wide text-muted-foreground/70">
-        {title}
-      </span>
-      <RoutingPicker
-        ariaLabel={`${title} routing`}
-        connectedProviders={connectedProviders}
-        provider={config.provider}
-        model={config.model}
-        effort={{ editable: true, value: config.effort, onChange: onEffort }}
-        disabled={false}
-        onProvider={onProvider}
-        onModel={onModel}
-      />
-      <SegmentedTabs
-        ariaLabel="Resolver mode"
-        value={mode}
-        options={MODE_OPTIONS}
-        onChange={onMode}
-        size="sm"
-        fill
-      />
-      <textarea
-        aria-label="Resolver hint"
-        value={hint}
-        onChange={(event) => onHint(event.target.value)}
-        rows={2}
-        placeholder="Optional notes for the resolver: how to fix, what to avoid..."
-        className="w-full resize-none rounded-md border border-border-soft bg-subtle px-2 py-1.5 text-xs text-foreground placeholder:text-muted-foreground/60 focus:border-primary focus:outline-none"
-      />
-      {footer}
-    </div>
-  );
-}

--- a/apps/desktop/src/features/github/components/GitHubStudio/ResolveBoard/isClaimedLink.ts
+++ b/apps/desktop/src/features/github/components/GitHubStudio/ResolveBoard/isClaimedLink.ts
@@ -1,0 +1,8 @@
+import type { ResolverLink } from '../../../../session/resolver-linkage';
+
+type Params = {
+  readonly link: ResolverLink | undefined;
+};
+
+export const isClaimedLink = ({ link }: Params): boolean =>
+  link != null && link.status !== 'failed';


### PR DESCRIPTION
## Description

Stacked on #1088. The resolver spawn "popover" was a hand-rolled absolutely-positioned panel inside ResolveBoard, and its fix/analyze mode and hint were board-level singletons: editing the message on one card silently changed it for every card. Worse, the combined resolver dropped mode and hint entirely (`buildCombinedCommentAgentArgs` never read them).

## Scope

- new `ResolveConfigPopover` on the CreateAgentPopover pattern: real portal popover, Mode (Fix/Analyze `SegmentedTabs` with per-mode hint), Instructions textarea, routing sections, one primary naming the action
- config is fully per-card (`CardConfig` gains mode + hint); the toolbar popover edits batch defaults that untouched cards follow, with an explicit "Apply to all cards"; per-card edits create overrides
- bug fix: combined resolver args now carry mode and hint (analyze appends the existing read-only analysis contract, operator notes appended like the single path); fix-mode/empty-hint prompts stay byte-identical
- resolver pipeline untouched: deferKickoff semantics, one `activateNextResolver` per batch, marker contracts, push/queue actions
- diff-viewer twin deliberately not unified: diff comments have no review-thread ids, the analyze marker contract is undefined there

## Verification

- monorepo typecheck green
- full apps/desktop suite: 3140 tests passed
- spawn-from-comment: 21 tests incl. byte-identical fix-path pin

🤖 Generated with [Claude Code](https://claude.com/claude-code)