### PR TITLE
fix(desktop): resolve workflow name collisions on save

### DIFF
--- a/apps/desktop/src-tauri/src/workflows.rs
+++ b/apps/desktop/src-tauri/src/workflows.rs
@@ -450,6 +450,39 @@ pub fn workflow_get(
     }
 }
 
+fn live_name_taken(
+    conn: &rusqlite::Connection,
+    workspace_id: &str,
+    name: &str,
+    id: &str,
+) -> Result<bool, rusqlite::Error> {
+    let mut stmt = conn.prepare(
+        "SELECT 1 FROM workflows
+         WHERE workspace_id = ?1 AND name = ?2 AND id <> ?3 AND deleted_at IS NULL
+         LIMIT 1",
+    )?;
+    stmt.exists(rusqlite::params![workspace_id, name, id])
+}
+
+fn resolve_live_name(
+    conn: &rusqlite::Connection,
+    workspace_id: &str,
+    requested: &str,
+    id: &str,
+) -> Result<String, rusqlite::Error> {
+    if !live_name_taken(conn, workspace_id, requested, id)? {
+        return Ok(requested.to_string());
+    }
+    let mut suffix = 2;
+    loop {
+        let candidate = format!("{requested} {suffix}");
+        if !live_name_taken(conn, workspace_id, &candidate, id)? {
+            return Ok(candidate);
+        }
+        suffix += 1;
+    }
+}
+
 #[tauri::command]
 pub fn workflow_upsert(
     state: State<'_, Db>,
@@ -464,7 +497,9 @@ pub fn workflow_upsert(
     } else {
         let existing: Option<String> = {
             let mut stmt = conn.prepare(
-                "SELECT id FROM workflows WHERE workspace_id = ?1 AND name = ?2 LIMIT 1",
+                "SELECT id FROM workflows
+                 WHERE workspace_id = ?1 AND name = ?2 AND deleted_at IS NULL
+                 LIMIT 1",
             )?;
             let mut rows = stmt.query_map(
                 rusqlite::params![input.workspace_id, input.name],
@@ -477,6 +512,8 @@ pub fn workflow_upsert(
         };
         existing.unwrap_or_else(crate::util::uuid_v4)
     };
+
+    let name = resolve_live_name(&conn, &input.workspace_id, &input.name, &id)?;
 
     let created_at: String = {
         let mut stmt =
@@ -502,7 +539,7 @@ pub fn workflow_upsert(
         rusqlite::params![
             id,
             input.workspace_id,
-            input.name,
+            name,
             input.description,
             input.goal,
             input.process_text,
@@ -601,7 +638,7 @@ pub fn workflow_upsert(
     Ok(WorkflowRow {
         id,
         workspace_id: input.workspace_id,
-        name: input.name,
+        name,
         description: input.description,
         goal: input.goal,
         process_text: input.process_text,
@@ -1169,6 +1206,55 @@ mod tests {
         )
         .unwrap();
         conn
+    }
+
+    fn workflows_table_conn() -> rusqlite::Connection {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE workflows (
+                id TEXT PRIMARY KEY, workspace_id TEXT, name TEXT, description TEXT,
+                created_at TEXT, updated_at TEXT, deleted_at INTEGER, is_preset INTEGER,
+                goal TEXT, process_text TEXT
+            );
+            CREATE UNIQUE INDEX idx_workflows_workspace_name_live
+              ON workflows(workspace_id, name) WHERE deleted_at IS NULL;",
+        )
+        .unwrap();
+        conn
+    }
+
+    fn insert_workflow(conn: &rusqlite::Connection, id: &str, name: &str, deleted: Option<i64>) {
+        conn.execute(
+            "INSERT INTO workflows (id, workspace_id, name, description, created_at, updated_at, deleted_at, is_preset)
+             VALUES (?1, 'ws1', ?2, '', '2026-01-01', '2026-01-01', ?3, 0)",
+            rusqlite::params![id, name, deleted],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn resolve_live_name_keeps_a_free_name() {
+        let conn = workflows_table_conn();
+        insert_workflow(&conn, "w1", "Orchestrated workflow", Some(1));
+        let name = resolve_live_name(&conn, "ws1", "Orchestrated workflow", "w2").unwrap();
+        assert_eq!(name, "Orchestrated workflow");
+    }
+
+    #[test]
+    fn resolve_live_name_suffixes_against_live_rows() {
+        let conn = workflows_table_conn();
+        insert_workflow(&conn, "w1", "Orchestrated workflow", None);
+        insert_workflow(&conn, "w2", "Orchestrated workflow 2", None);
+        let name = resolve_live_name(&conn, "ws1", "Orchestrated workflow", "w3").unwrap();
+        assert_eq!(name, "Orchestrated workflow 3");
+    }
+
+    #[test]
+    fn resolve_live_name_ignores_the_row_being_updated() {
+        let conn = workflows_table_conn();
+        insert_workflow(&conn, "w1", "Ship It", None);
+        let name = resolve_live_name(&conn, "ws1", "Ship It", "w1").unwrap();
+        assert_eq!(name, "Ship It");
     }
 
     #[test]

--- a/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
@@ -680,9 +680,9 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
         createdAt: now,
         updatedAt: now,
       };
-      await savePhaseTemplate(workflow);
+      const saved = await savePhaseTemplate(workflow);
       await attachWorkflowToSession(session.id, workflowId, attachOptions());
-      showToast('success', `workflow started: ${name}`);
+      showToast('success', `workflow started: ${saved?.name ?? name}`);
       handleClose();
     } catch (err) {
       setError(formatError(err));


### PR DESCRIPTION
Starting an orchestrated workflow still failed with `UNIQUE constraint failed: workflows.workspace_id, workflows.name` after v0.1.47.

Root cause: `workflow_list` returns only `is_preset = 1`, so the ad hoc workflow each dynamic run creates is absent from the store after a restart. The builder's `uniqueWorkflowName` therefore saw no live "Orchestrated workflow" and minted the same name again, colliding with the live row through the new partial unique index.

Fix: `workflow_upsert` resolves the name against live rows in the workspace (excluding the row being updated) and returns the resolved name, so every caller is covered rather than just the builder. The id-by-name lookup also ignores soft-deleted rows so saving a preset no longer resurrects a deleted one.

Tests: 3 new Rust unit tests on `resolve_live_name`; builder suite green (46).

🤖 Generated with [Claude Code](https://claude.com/claude-code)