### PR TITLE
feat(desktop): linear in repo-less workspaces

### DIFF
--- a/apps/desktop/src/app/components/AppFooter/index.test.tsx
+++ b/apps/desktop/src/app/components/AppFooter/index.test.tsx
@@ -150,7 +150,7 @@ describe('AppFooter', () => {
     expect(onOpenGitlab).toHaveBeenCalledOnce();
   });
 
-  it('replaces the git integrations with the conversion CTA in a simple workspace', () => {
+  it('keeps Linear and swaps the git integrations for the conversion CTA in a simple workspace', () => {
     const onConvertToDevProject = vi.fn();
 
     render(
@@ -175,8 +175,8 @@ describe('AppFooter', () => {
 
     expect(screen.queryByRole('button', { name: 'Connect GitHub' })).toBeNull();
     expect(screen.queryByRole('button', { name: 'Connect GitLab' })).toBeNull();
-    expect(screen.queryByRole('button', { name: 'Connect Linear' })).toBeNull();
     expect(screen.queryByRole('button', { name: 'Connect Sentry' })).toBeNull();
+    expect(screen.getByRole('button', { name: 'Connect Linear' })).toBeDefined();
     expect(
       screen.getByRole('button', { name: 'open the workflow library for this workspace' }),
     ).toBeDefined();

--- a/apps/desktop/src/app/components/AppFooter/index.tsx
+++ b/apps/desktop/src/app/components/AppFooter/index.tsx
@@ -128,23 +128,25 @@ export const AppFooter = ({
                 active={activeStudio === 'gitlab'}
                 connected={gitlabEnabled}
               />
-              <FooterButton
-                icon={<IntegrationGlyph provider="linear" size="xs" />}
-                label="Linear"
-                title={linearEnabled ? 'launch a session from a Linear issue' : 'Connect Linear'}
-                onClick={onOpenLinear}
-                active={activeStudio === 'linear'}
-                connected={linearEnabled}
-              />
-              <FooterButton
-                icon={<IntegrationGlyph provider="sentry" size="xs" />}
-                label="Sentry"
-                title={sentryEnabled ? 'launch a session from a Sentry issue' : 'Connect Sentry'}
-                onClick={onOpenSentry}
-                active={activeStudio === 'sentry'}
-                connected={sentryEnabled}
-              />
             </>
+          )}
+          <FooterButton
+            icon={<IntegrationGlyph provider="linear" size="xs" />}
+            label="Linear"
+            title={linearEnabled ? 'launch a session from a Linear issue' : 'Connect Linear'}
+            onClick={onOpenLinear}
+            active={activeStudio === 'linear'}
+            connected={linearEnabled}
+          />
+          {isSimpleWorkspace ? null : (
+            <FooterButton
+              icon={<IntegrationGlyph provider="sentry" size="xs" />}
+              label="Sentry"
+              title={sentryEnabled ? 'launch a session from a Sentry issue' : 'Connect Sentry'}
+              onClick={onOpenSentry}
+              active={activeStudio === 'sentry'}
+              connected={sentryEnabled}
+            />
           )}
         </div>
 

--- a/apps/desktop/src/features/integrations/components/LaunchSessionPanel/index.test.tsx
+++ b/apps/desktop/src/features/integrations/components/LaunchSessionPanel/index.test.tsx
@@ -13,7 +13,9 @@ const h = vi.hoisted(() => ({
   loadSetting: vi.fn(async () => null),
   showToast: vi.fn(),
   store: {
-    workspaces: [{ id: 'workspace-1', rootPath: '/repo' }],
+    workspaces: [{ id: 'workspace-1', rootPath: '/repo', kind: 'dev' }] as ReadonlyArray<
+      Record<string, unknown>
+    >,
   },
 }));
 
@@ -63,6 +65,7 @@ beforeEach(() => {
   localStorage.clear();
   h.createSession.mockClear();
   h.showToast.mockClear();
+  h.store.workspaces = [{ id: 'workspace-1', rootPath: '/repo', kind: 'dev' }];
 });
 
 afterEach(cleanup);
@@ -118,5 +121,38 @@ describe('LaunchSessionPanel', () => {
 
     expect(screen.getByRole('tab', { name: /Continue on PR #12/ })).toBeDefined();
     expect(screen.getByText('ak/fix-the-flake')).toBeDefined();
+  });
+
+  it('drops the branch field and the branch payload in a repo-less workspace', async () => {
+    h.store.workspaces = [{ id: 'workspace-1', rootPath: '/notes', kind: 'simple' }];
+
+    render(
+      <LaunchSessionPanel
+        workspaceId={WORKSPACE_ID}
+        linkedSessionId={null}
+        goalSeed="Fix the flake"
+        branchSlugSeed="7-fix-the-flake"
+        externalTask={EXTERNAL_TASK}
+        adoptable={{
+          label: 'Continue on PR #12',
+          branch: 'ak/fix-the-flake',
+          hint: 'Adopts the branch of PR #12.',
+          isResolving: false,
+          error: null,
+        }}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByLabelText('Branch slug')).toBeNull();
+    expect(screen.queryByRole('tab', { name: /Continue on PR #12/ })).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: /Launch session/i }));
+
+    await waitFor(() => expect(h.createSession).toHaveBeenCalledOnce());
+    const payload = h.createSession.mock.calls[0]?.[0] ?? {};
+    expect(payload.branchPrefix).toBeUndefined();
+    expect(payload.branchSlug).toBeUndefined();
+    expect(payload.existingBranch).toBeUndefined();
   });
 });

--- a/apps/desktop/src/features/integrations/components/LaunchSessionPanel/index.tsx
+++ b/apps/desktop/src/features/integrations/components/LaunchSessionPanel/index.tsx
@@ -59,7 +59,7 @@ export const LaunchSessionPanel = ({
   goalSeed,
   branchSlugSeed,
   externalTask,
-  adoptable = null,
+  adoptable: adoptableInput = null,
   onClose,
 }: Props) => {
   const createSession = useAppStore((state) => state.createSession);
@@ -67,6 +67,11 @@ export const LaunchSessionPanel = ({
   const rootPath = useAppStore(
     (state) => state.workspaces.find((workspace) => workspace.id === workspaceId)?.rootPath ?? null,
   );
+  const isBranchless = useAppStore(
+    (state) =>
+      state.workspaces.find((workspace) => workspace.id === workspaceId)?.kind === 'simple',
+  );
+  const adoptable = isBranchless ? null : adoptableInput;
   const { showToast } = useToast();
   const [setupWorkflow, setSetupWorkflow] = useSetupWorkflowPreference();
   const [goal, setGoal] = useState(goalSeed);
@@ -94,17 +99,23 @@ export const LaunchSessionPanel = ({
   const isSlugValid = isValidBranchSlug({ slug: branchSlug });
   const isAdopting = mode === 'adopt' && adoptable != null;
   const adoptedBranch = isAdopting ? adoptable.branch : null;
-  const effectiveBranch = isAdopting
-    ? adoptedBranch
-    : isSlugValid
-      ? `${prefix}/${branchSlug.trim()}`
-      : null;
+  const effectiveBranch = isBranchless
+    ? null
+    : isAdopting
+      ? adoptedBranch
+      : isSlugValid
+        ? `${prefix}/${branchSlug.trim()}`
+        : null;
   const conflict = useBranchConflict(effectiveBranch, rootPath);
   const conflictSessionId = conflict?.kind === 'session' ? conflict.sessionId : null;
   const conflictPath = conflict?.kind === 'worktree' ? conflict.path : null;
   const openableSessionId = linkedSessionId ?? conflictSessionId;
   const isMissingBase = error != null && isMissingBaseRefError(error);
-  const isBranchReady = isAdopting ? adoptedBranch != null && !adoptable.isResolving : isSlugValid;
+  const isBranchReady = isBranchless
+    ? true
+    : isAdopting
+      ? adoptedBranch != null && !adoptable.isResolving
+      : isSlugValid;
   const canLaunch = goal.trim() !== '' && isBranchReady && !busy && conflictPath == null;
 
   const launch = async (eraseWorktreePath?: string) => {
@@ -117,8 +128,9 @@ export const LaunchSessionPanel = ({
       const { session } = await createSession({
         workspaceId,
         goal,
-        branchPrefix: prefix,
-        branchSlug: branchSlug.trim() || undefined,
+        ...(isBranchless
+          ? {}
+          : { branchPrefix: prefix, branchSlug: branchSlug.trim() || undefined }),
         ...(adoptedBranch != null ? { existingBranch: adoptedBranch } : {}),
         externalTask,
         openWorkflowBuilder: setupWorkflow,
@@ -179,76 +191,78 @@ export const LaunchSessionPanel = ({
         />
       </LaunchField>
 
-      <LaunchField
-        label="Branch"
-        icon={<GitBranch size={13} aria-hidden className="text-success" />}
-      >
-        <div className="flex flex-col gap-2">
-          {adoptable != null && (
-            <SegmentedTabs
-              ariaLabel="branch source"
-              options={[
-                { value: 'adopt', label: adoptable.label, disabled: busy },
-                { value: 'fresh', label: 'Start fresh', disabled: busy },
-              ]}
-              value={mode}
-              onChange={setModeChoice}
-              size="sm"
-            />
-          )}
-          {isAdopting ? (
-            <div className="flex flex-col gap-1">
-              <div className="flex min-h-8 items-center gap-2 bg-subtle/40 px-2.5 font-mono text-sm">
-                {adoptable.isResolving ? (
-                  <span className="inline-flex items-center gap-1.5 text-muted-foreground">
-                    <StatusDot tone="info" size="sm" pulsing /> resolving…
-                  </span>
-                ) : adoptedBranch != null ? (
-                  <span className="truncate text-foreground">{adoptedBranch}</span>
-                ) : (
-                  <span className="truncate text-danger">
-                    {adoptable.error ?? 'No branch found'}
-                  </span>
-                )}
-              </div>
-              <span className="text-2xs leading-relaxed text-muted-foreground/70">
-                {adoptable.hint}
-              </span>
-            </div>
-          ) : (
-            <div className="flex items-center gap-1.5">
-              <span className="shrink-0 font-mono text-xs text-muted-foreground">
-                {prefix + '/'}
-              </span>
-              <Input
-                value={branchSlug}
-                onChange={(event) =>
-                  setBranchSlug(
-                    sanitizeBranchSlug({ input: event.target.value, maxLength: SLUG_MAX_LEN }),
-                  )
-                }
-                placeholder="branch-slug"
-                className="h-8 flex-1 font-mono text-sm"
-                disabled={busy}
-                autoCapitalize="off"
-                autoCorrect="off"
-                spellCheck={false}
-                aria-label="Branch slug"
+      {isBranchless ? null : (
+        <LaunchField
+          label="Branch"
+          icon={<GitBranch size={13} aria-hidden className="text-success" />}
+        >
+          <div className="flex flex-col gap-2">
+            {adoptable != null && (
+              <SegmentedTabs
+                ariaLabel="branch source"
+                options={[
+                  { value: 'adopt', label: adoptable.label, disabled: busy },
+                  { value: 'fresh', label: 'Start fresh', disabled: busy },
+                ]}
+                value={mode}
+                onChange={setModeChoice}
+                size="sm"
               />
-            </div>
-          )}
-          {conflictPath != null && (
-            <div className="flex items-start gap-2 rounded-lg border border-warning/30 bg-warning/10 px-2.5 py-2 text-2xs leading-relaxed text-foreground">
-              <AlertTriangle size={12} aria-hidden className="mt-0.5 shrink-0 text-warning" />
-              <span>
-                This branch is already checked out in another worktree (
-                <span className="break-all font-mono">{conflictPath}</span>). Launching erases that
-                worktree and recreates it here.
-              </span>
-            </div>
-          )}
-        </div>
-      </LaunchField>
+            )}
+            {isAdopting ? (
+              <div className="flex flex-col gap-1">
+                <div className="flex min-h-8 items-center gap-2 bg-subtle/40 px-2.5 font-mono text-sm">
+                  {adoptable.isResolving ? (
+                    <span className="inline-flex items-center gap-1.5 text-muted-foreground">
+                      <StatusDot tone="info" size="sm" pulsing /> resolving…
+                    </span>
+                  ) : adoptedBranch != null ? (
+                    <span className="truncate text-foreground">{adoptedBranch}</span>
+                  ) : (
+                    <span className="truncate text-danger">
+                      {adoptable.error ?? 'No branch found'}
+                    </span>
+                  )}
+                </div>
+                <span className="text-2xs leading-relaxed text-muted-foreground/70">
+                  {adoptable.hint}
+                </span>
+              </div>
+            ) : (
+              <div className="flex items-center gap-1.5">
+                <span className="shrink-0 font-mono text-xs text-muted-foreground">
+                  {prefix + '/'}
+                </span>
+                <Input
+                  value={branchSlug}
+                  onChange={(event) =>
+                    setBranchSlug(
+                      sanitizeBranchSlug({ input: event.target.value, maxLength: SLUG_MAX_LEN }),
+                    )
+                  }
+                  placeholder="branch-slug"
+                  className="h-8 flex-1 font-mono text-sm"
+                  disabled={busy}
+                  autoCapitalize="off"
+                  autoCorrect="off"
+                  spellCheck={false}
+                  aria-label="Branch slug"
+                />
+              </div>
+            )}
+            {conflictPath != null && (
+              <div className="flex items-start gap-2 rounded-lg border border-warning/30 bg-warning/10 px-2.5 py-2 text-2xs leading-relaxed text-foreground">
+                <AlertTriangle size={12} aria-hidden className="mt-0.5 shrink-0 text-warning" />
+                <span>
+                  This branch is already checked out in another worktree (
+                  <span className="break-all font-mono">{conflictPath}</span>). Launching erases
+                  that worktree and recreates it here.
+                </span>
+              </div>
+            )}
+          </div>
+        </LaunchField>
+      )}
 
       {isMissingBase && <BaseBranchGuide />}
 

--- a/apps/desktop/src/features/integrations/linear/LinearStudio/IssueDetailPanel.tsx
+++ b/apps/desktop/src/features/integrations/linear/LinearStudio/IssueDetailPanel.tsx
@@ -54,8 +54,12 @@ export const IssueDetailPanel = ({ issue, sessionId, workspaceId, onClose }: Pro
   const rootPath = useAppStore(
     (s) => s.workspaces.find((w) => w.id === workspaceId)?.rootPath ?? null,
   );
+  const isBranchless = useAppStore(
+    (s) => s.workspaces.find((w) => w.id === workspaceId)?.kind === 'simple',
+  );
 
-  const adoptablePr = issue ? (issuePullRequests(issue).find((pr) => pr.repo) ?? null) : null;
+  const adoptablePr =
+    issue && !isBranchless ? (issuePullRequests(issue).find((pr) => pr.repo) ?? null) : null;
 
   const [prBranch, setPrBranch] = useState<string | null>(null);
   const [prResolving, setPrResolving] = useState(false);

--- a/apps/desktop/src/features/onboarding/OnboardingCard/index.test.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingCard/index.test.tsx
@@ -6,7 +6,7 @@ const { finishMock } = vi.hoisted(() => ({
 }));
 
 vi.mock('../onboarding-store', () => ({
-  ONBOARDING_STEPS: [
+  visibleOnboardingSteps: () => [
     { id: 'workspace', title: 'Workspace', why: 'Workspace', group: 'setup' },
     { id: 'session', title: 'Session', why: 'Session', group: 'build' },
   ],

--- a/apps/desktop/src/features/onboarding/OnboardingCard/index.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingCard/index.tsx
@@ -1,7 +1,7 @@
 import { Check, Sparkles, X } from 'lucide-react';
 import { cn } from '@goodboy/ui';
 import {
-  ONBOARDING_STEPS,
+  visibleOnboardingSteps,
   collapse,
   finish,
   reopen,
@@ -37,9 +37,7 @@ export const OnboardingCard = () => {
 };
 
 function ChecklistBody({ progress }: { progress: OnboardingProgress }) {
-  const visibleSteps = progress.isSimple
-    ? ONBOARDING_STEPS.filter((step) => step.id !== 'codeHost' && step.id !== 'tools')
-    : ONBOARDING_STEPS;
+  const visibleSteps = visibleOnboardingSteps({ isSimple: progress.isSimple });
   return (
     <>
       <div className="flex items-center justify-between">
@@ -148,9 +146,7 @@ export const OnboardingChip = () => {
     return null;
   }
 
-  const visibleSteps = progress.isSimple
-    ? ONBOARDING_STEPS.filter((step) => step.id !== 'codeHost' && step.id !== 'tools')
-    : ONBOARDING_STEPS;
+  const visibleSteps = visibleOnboardingSteps({ isSimple: progress.isSimple });
 
   return (
     <div className="group inline-flex shrink-0 items-center gap-1 rounded-md border border-border-soft bg-subtle/60 px-1.5 py-1 motion-safe:transition-colors hover:border-border">

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/index.test.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/index.test.tsx
@@ -148,7 +148,7 @@ describe('OnboardingWizard', () => {
       expect(screen.queryByTestId('stepper')).toBeNull();
     });
 
-    it('jumps from preferences to ready for a simple workspace', () => {
+    it('keeps only the tracker step between preferences and ready for a simple workspace', () => {
       setHook({
         mode: 'setup',
         hasWorkspace: true,
@@ -158,9 +158,10 @@ describe('OnboardingWizard', () => {
       render(<OnboardingWizard />);
       expect(screen.getByTestId('PreferencesStep')).toBeDefined();
       fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+      expect(screen.getByTestId('TrackerStep')).toBeDefined();
+      fireEvent.click(screen.getByRole('button', { name: /skip for now/i }));
       expect(screen.getByTestId('ReadyStep')).toBeDefined();
       expect(screen.queryByTestId('CodeHostStep')).toBeNull();
-      expect(screen.queryByTestId('TrackerStep')).toBeNull();
       expect(screen.queryByTestId('SentryStep')).toBeNull();
     });
   });

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/index.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/index.tsx
@@ -16,7 +16,7 @@ const STEP_COUNT = 8;
 const SETUP_START_STEP = 3;
 const EXIT_MS = 200;
 const ALL_STEPS = Array.from({ length: STEP_COUNT }, (_, index) => index);
-const SIMPLE_STEPS = [0, 1, 2, 3, 7];
+const SIMPLE_STEPS = [0, 1, 2, 3, 5, 7];
 
 type Cta = {
   readonly label: string;

--- a/apps/desktop/src/features/onboarding/hooks/useOnboardingProgress/index.test.ts
+++ b/apps/desktop/src/features/onboarding/hooks/useOnboardingProgress/index.test.ts
@@ -13,8 +13,8 @@ const { markStepCompleteMock, ghStatusMock } = vi.hoisted(() => ({
   ghStatusMock: vi.fn(async () => ({ scoped: false }) as unknown),
 }));
 
-vi.mock('../../onboarding-store', () => ({
-  ONBOARDING_STEPS: [
+const { STEPS } = vi.hoisted(() => ({
+  STEPS: [
     { id: 'workspace', title: 'x', why: 'x' },
     { id: 'codeHost', title: 'x', why: 'x' },
     { id: 'tools', title: 'x', why: 'x' },
@@ -23,6 +23,12 @@ vi.mock('../../onboarding-store', () => ({
     { id: 'plan', title: 'x', why: 'x' },
     { id: 'palette', title: 'x', why: 'x' },
   ],
+}));
+
+vi.mock('../../onboarding-store', () => ({
+  ONBOARDING_STEPS: STEPS,
+  visibleOnboardingSteps: ({ isSimple }: { readonly isSimple: boolean }) =>
+    isSimple ? STEPS.filter((step) => step.id !== 'codeHost') : STEPS,
   getCompleted: () => completed,
   isCollapsed: () => false,
   isFinished: () => false,
@@ -123,13 +129,13 @@ describe('useOnboardingProgress auto-mark', () => {
     expect(result.current.isDone).toBe(false);
   });
 
-  it('removes integration steps from progress for a simple workspace', () => {
-    completed = ['workspace', 'session', 'agent', 'plan', 'palette'];
+  it('removes the code host step but keeps the tracker step for a simple workspace', () => {
+    completed = ['workspace', 'tools', 'session', 'agent', 'plan', 'palette'];
     workspaces.push({ id: 'w1', kind: 'simple' });
     const { result } = renderHook(() => useOnboardingProgress());
     expect(result.current.isSimple).toBe(true);
-    expect(result.current.completedCount).toBe(5);
-    expect(result.current.totalCount).toBe(5);
+    expect(result.current.completedCount).toBe(6);
+    expect(result.current.totalCount).toBe(6);
     expect(result.current.isDone).toBe(true);
     expect(ghStatusMock).not.toHaveBeenCalled();
   });

--- a/apps/desktop/src/features/onboarding/hooks/useOnboardingProgress/index.ts
+++ b/apps/desktop/src/features/onboarding/hooks/useOnboardingProgress/index.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState, useMemo } from 'react';
 import { useAppStore, useCurrentSession, useWorkspaces } from '../../../../store';
 import { ghStatus } from '../../../github/github';
 import {
-  ONBOARDING_STEPS,
+  visibleOnboardingSteps,
   getCompleted,
   isCollapsed,
   isFinished,
@@ -99,7 +99,7 @@ export const useOnboardingProgress = (): OnboardingProgress => {
     if (!isSimple && (gitlabConnected || githubScoped) && !persistedCompleted.has('codeHost')) {
       markStepComplete('codeHost');
     }
-    if (!isSimple && hasTools && !persistedCompleted.has('tools')) {
+    if (hasTools && !persistedCompleted.has('tools')) {
       markStepComplete('tools');
     }
     if (sessionCount > 0 && !persistedCompleted.has('session')) {
@@ -124,9 +124,7 @@ export const useOnboardingProgress = (): OnboardingProgress => {
     currentSession,
   ]);
 
-  const visibleSteps = isSimple
-    ? ONBOARDING_STEPS.filter((step) => step.id !== 'codeHost' && step.id !== 'tools')
-    : ONBOARDING_STEPS;
+  const visibleSteps = visibleOnboardingSteps({ isSimple });
   const totalCount = visibleSteps.length;
   const completedCount = visibleSteps.filter((step) => persistedCompleted.has(step.id)).length;
 

--- a/apps/desktop/src/features/onboarding/onboarding-store.ts
+++ b/apps/desktop/src/features/onboarding/onboarding-store.ts
@@ -12,6 +12,10 @@ export type OnboardingStepId =
 
 export type OnboardingGroup = 'setup' | 'build';
 
+type VisibleStepsParams = {
+  readonly isSimple: boolean;
+};
+
 export const ONBOARDING_STEPS: ReadonlyArray<{
   readonly id: OnboardingStepId;
   readonly title: string;
@@ -61,6 +65,9 @@ export const ONBOARDING_STEPS: ReadonlyArray<{
     group: 'build',
   },
 ];
+
+export const visibleOnboardingSteps = ({ isSimple }: VisibleStepsParams) =>
+  isSimple ? ONBOARDING_STEPS.filter((step) => step.id !== 'codeHost') : ONBOARDING_STEPS;
 
 const SETTING_PROGRESS = 'onboarding.progress';
 const SETTING_COLLAPSED = 'onboarding.collapsed';


### PR DESCRIPTION
## Why

Linear issues are not a dev-only surface: someone in marketing or ops running a repo-less workspace has tasks too. Today the whole integration row is swapped for the add-a-repo CTA in simple workspaces, so Linear is unreachable there.

## What

- Footer: Linear is always mounted. Simple workspaces show `Add a repo` + `Linear`; GitHub, GitLab and Sentry stay hidden because they all assume a repo.
- `LaunchSessionPanel`: in a repo-less workspace the Branch field, the adopt-a-PR-branch tabs and the worktree conflict path are dropped, and `createSession` is called without `branchPrefix` / `branchSlug` / `existingBranch`. `createSession` already routes simple workspaces to `createSessionDir`.
- `IssueDetailPanel`: no `gh pr view` probe against a path that is not a git repo.
- Onboarding: simple workspaces keep the tracker step (`SIMPLE_STEPS` gains 5) and the `tools` checklist item; only `codeHost` stays hidden. The three copies of the step filter collapse into `visibleOnboardingSteps`.

## Verification

`pnpm typecheck` 5/5, `pnpm test` 396 files / 3213 tests green, `knip --include files,duplicates,unlisted` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)