### PR TITLE
feat(desktop): orchestrator feedback, runtime hints and copy-link ctas

### DIFF
--- a/apps/desktop/src/__tests__/transcript-items.test.ts
+++ b/apps/desktop/src/__tests__/transcript-items.test.ts
@@ -250,18 +250,14 @@ describe('reduceTranscript, open-question answer boundary', () => {
   });
 });
 
-const workflowMarker = [
-  'Complete ONLY this workflow step. Do not start later steps or work on their scope.',
-  'When this step is fully complete, emit on its own line exactly:',
-  '<<step-done id="agent-1">>',
-  'Do not emit that marker until the step is truly done.',
-].join('\n');
+const workflowMarker =
+  '**Scope** this step only, never a later one. Emit `<<step-done id="agent-1">>` on its own line once it is truly done.';
 
 describe('reduceTranscript, workflow kickoff boundary', () => {
   it('maps a composed kickoff to a workflow_kickoff item with parsed sections', () => {
     const kickoff = [
-      'Workflow goal:\n\nShip the onboarding wizard',
-      'Active plan to execute:\n\n1. wire steps',
+      '**Goal** Ship the onboarding wizard',
+      '**Plan**\n1. wire steps',
       'Focus on the providers step only.',
       workflowMarker,
     ].join('\n\n');
@@ -284,7 +280,7 @@ describe('reduceTranscript, workflow kickoff boundary', () => {
   });
 
   it('emits a workflow_kickoff even when parsed:false (malformed goal)', () => {
-    const malformed = `Workflow goal:\n\n\n\n${workflowMarker}`;
+    const malformed = `**Goal**\n\n\n\n${workflowMarker}`;
     const items = reduceTranscript([userTextEvent(malformed)]);
     expect(items).toHaveLength(1);
     const item = items[0]!;
@@ -296,7 +292,7 @@ describe('reduceTranscript, workflow kickoff boundary', () => {
   });
 
   it('carries the at timestamp from the event', () => {
-    const kickoff = `Workflow goal:\n\nGoal text\n\n${workflowMarker}`;
+    const kickoff = `**Goal** Goal text\n\n${workflowMarker}`;
     const items = reduceTranscript([userTextEvent(kickoff)]);
     const item = items[0]!;
     expect(item.kind).toBe('workflow_kickoff');
@@ -306,14 +302,14 @@ describe('reduceTranscript, workflow kickoff boundary', () => {
   });
 
   it('key starts with kickoff-', () => {
-    const kickoff = `Workflow goal:\n\nGoal text\n\n${workflowMarker}`;
+    const kickoff = `**Goal** Goal text\n\n${workflowMarker}`;
     const items = reduceTranscript([userTextEvent(kickoff)]);
     const item = items[0]!;
     expect(item.key).toMatch(/^kickoff-/);
   });
 
   it('multiple kickoff events get distinct keys', () => {
-    const kickoff = `Workflow goal:\n\nGoal text\n\n${workflowMarker}`;
+    const kickoff = `**Goal** Goal text\n\n${workflowMarker}`;
     const items = reduceTranscript([userTextEvent(kickoff), userTextEvent(kickoff)]);
     expect(items).toHaveLength(2);
     expect(items[0]!.key).not.toBe(items[1]!.key);
@@ -327,7 +323,7 @@ describe('reduceTranscript, workflow kickoff boundary', () => {
   });
 
   it('flushes buffered assistant_text before a kickoff event', () => {
-    const kickoff = `Workflow goal:\n\nGoal text\n\n${workflowMarker}`;
+    const kickoff = `**Goal** Goal text\n\n${workflowMarker}`;
     const events: TurnEvent[] = [
       assistantTextEvent('some assistant output'),
       userTextEvent(kickoff),
@@ -337,14 +333,14 @@ describe('reduceTranscript, workflow kickoff boundary', () => {
   });
 
   it('kickoff followed by assistant_text produces both items in order', () => {
-    const kickoff = `Workflow goal:\n\nGoal text\n\n${workflowMarker}`;
+    const kickoff = `**Goal** Goal text\n\n${workflowMarker}`;
     const events: TurnEvent[] = [userTextEvent(kickoff), assistantTextEvent('ok, starting')];
     const items = reduceTranscript(events);
     expect(items.map((i) => i.kind)).toEqual(['workflow_kickoff', 'assistant_text']);
   });
 
   it('kickoff without plan section produces empty instructions', () => {
-    const noInstructions = `Workflow goal:\n\nOnly a goal\n\n${workflowMarker}`;
+    const noInstructions = `**Goal** Only a goal\n\n${workflowMarker}`;
     const items = reduceTranscript([userTextEvent(noInstructions)]);
     const item = items[0]!;
     expect(item.kind).toBe('workflow_kickoff');

--- a/apps/desktop/src/features/chat/utils/parse-workflow-kickoff.test.ts
+++ b/apps/desktop/src/features/chat/utils/parse-workflow-kickoff.test.ts
@@ -1,22 +1,18 @@
 import { describe, expect, it } from 'vitest';
 import { isWorkflowKickoff, parseWorkflowKickoff } from './parse-workflow-kickoff';
 
-const marker = [
-  'Complete ONLY this workflow step. Do not start later steps or work on their scope.',
-  'When this step is fully complete, emit on its own line exactly:',
-  '<<step-done id="agent-1">>',
-  'Do not emit that marker until the step is truly done.',
-].join('\n');
+const marker =
+  '**Scope** this step only, never a later one. Emit `<<step-done id="agent-1">>` on its own line once it is truly done.';
 
 const withPlan = [
-  'Workflow goal:\n\nShip the onboarding wizard',
-  'Active plan to execute:\n\n1. wire steps\n2. add tests',
+  '**Goal** Ship the onboarding wizard',
+  '**Plan**\n1. wire steps\n2. add tests',
   'Focus on the providers step only.',
   marker,
 ].join('\n\n');
 
 const withoutPlan = [
-  'Workflow goal:\n\nShip the onboarding wizard',
+  '**Goal** Ship the onboarding wizard',
   'Focus on the providers step only.',
   marker,
 ].join('\n\n');
@@ -32,8 +28,8 @@ describe('isWorkflowKickoff', () => {
   });
 
   it('is false when only one anchor is present', () => {
-    expect(isWorkflowKickoff('Workflow goal:\n\ndo a thing')).toBe(false);
-    expect(isWorkflowKickoff('Complete ONLY this workflow step now')).toBe(false);
+    expect(isWorkflowKickoff('**Goal** do a thing')).toBe(false);
+    expect(isWorkflowKickoff('**Scope** this step only now')).toBe(false);
   });
 });
 
@@ -42,9 +38,9 @@ describe('parseWorkflowKickoff', () => {
     const parsed = parseWorkflowKickoff(withPlan);
     expect(parsed.parsed).toBe(true);
     expect(parsed.goal).toBe('Ship the onboarding wizard');
-    expect(parsed.instructions).toContain('Active plan to execute:');
+    expect(parsed.instructions).toContain('**Plan**');
     expect(parsed.instructions).toContain('Focus on the providers step only.');
-    expect(parsed.marker.startsWith('Complete ONLY this workflow step')).toBe(true);
+    expect(parsed.marker.startsWith('**Scope** this step only')).toBe(true);
   });
 
   it('splits on the first paragraph when no plan is present', () => {
@@ -55,9 +51,7 @@ describe('parseWorkflowKickoff', () => {
   });
 
   it('keeps only the first paragraph as goal for a multi-paragraph goal', () => {
-    const text = ['Workflow goal:\n\nMain objective', 'Secondary detail paragraph', marker].join(
-      '\n\n',
-    );
+    const text = ['**Goal** Main objective', 'Secondary detail paragraph', marker].join('\n\n');
     const parsed = parseWorkflowKickoff(text);
     expect(parsed.parsed).toBe(true);
     expect(parsed.goal).toBe('Main objective');
@@ -72,27 +66,27 @@ describe('parseWorkflowKickoff', () => {
   });
 
   it('returns parsed:false when the goal body is empty', () => {
-    const malformed = `Workflow goal:\n\n\n\n${marker}`;
+    const malformed = `**Goal**\n\n\n\n${marker}`;
     const parsed = parseWorkflowKickoff(malformed);
     expect(parsed.parsed).toBe(false);
   });
 
   it('returns parsed:false when the goal is only whitespace', () => {
-    const malformed = `Workflow goal:\n\n   \n\n${marker}`;
+    const malformed = `**Goal**\n\n   \n\n${marker}`;
     const parsed = parseWorkflowKickoff(malformed);
     expect(parsed.parsed).toBe(false);
     expect(parsed.goal).toBe('');
   });
 
   it('still captures the marker on a parsed:false empty-goal result', () => {
-    const malformed = `Workflow goal:\n\n\n\n${marker}`;
+    const malformed = `**Goal**\n\n\n\n${marker}`;
     const parsed = parseWorkflowKickoff(malformed);
     expect(parsed.parsed).toBe(false);
-    expect(parsed.marker).toContain('Complete ONLY this workflow step');
+    expect(parsed.marker).toContain('**Scope** this step only');
   });
 
   it('handles no paragraph break — goal is the whole body, instructions empty', () => {
-    const text = `Workflow goal:\n\nSingle line goal with no break\n\n${marker}`;
+    const text = `**Goal** Single line goal with no break\n\n${marker}`;
     const parsed = parseWorkflowKickoff(text);
     expect(parsed.parsed).toBe(true);
     expect(parsed.goal).toBe('Single line goal with no break');
@@ -109,9 +103,8 @@ describe('parseWorkflowKickoff', () => {
 
   it('marker contains the full step-done instruction block', () => {
     const parsed = parseWorkflowKickoff(withPlan);
-    expect(parsed.marker).toContain('Complete ONLY this workflow step');
+    expect(parsed.marker).toContain('**Scope** this step only');
     expect(parsed.marker).toContain('<<step-done id="agent-1">>');
-    expect(parsed.marker).toContain('Do not emit that marker until the step is truly done.');
   });
 
   it('instructions include plan body when plan is present', () => {

--- a/apps/desktop/src/features/chat/utils/parse-workflow-kickoff.ts
+++ b/apps/desktop/src/features/chat/utils/parse-workflow-kickoff.ts
@@ -1,6 +1,6 @@
-const GOAL_LABEL = 'Workflow goal:';
-const PLAN_LABEL = 'Active plan to execute:';
-const MARKER_ANCHOR = 'Complete ONLY this workflow step';
+const GOAL_LABEL = '**Goal**';
+const PLAN_LABEL = '**Plan**';
+const MARKER_ANCHOR = '**Scope** this step only';
 
 export type ParsedWorkflowKickoff = {
   goal: string;

--- a/apps/desktop/src/features/github/components/GitHubStudio/GithubIssueDetailPanel/index.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/GithubIssueDetailPanel/index.tsx
@@ -67,7 +67,7 @@ export const GithubIssueDetailPanel = ({ issue, sessionId, workspaceId, onClose 
             </>
           }
           title={issue.title}
-          actions={<OpenExternalLink url={issue.url} label="Open in GitHub" />}
+          actions={<OpenExternalLink url={issue.url} label="Open in GitHub" copyLabel="issue" />}
         />
       }
       rail={

--- a/apps/desktop/src/features/github/components/GitHubStudio/PrDetailPanel.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/PrDetailPanel.tsx
@@ -29,6 +29,7 @@ import { PrSectionTabs } from './PrSectionTabs';
 import { PrSwitcher } from './PrSwitcher';
 import { SectionBody } from './SectionBody';
 import type { PrSection } from './prSection';
+import { CopyLinkButton } from '../../../../shared/components/CopyLinkButton';
 
 type Props = {
   readonly sessionId: SessionId | null;
@@ -367,6 +368,7 @@ export const PrDetailPanel = ({
                 label="open on GitHub"
                 onClick={() => void openUrl(activePr.url)}
               />
+              <CopyLinkButton url={activePr.url} label={`PR #${activePr.number}`} size={14} />
               <RefreshIconButton
                 label="refresh"
                 iconSize={14}

--- a/apps/desktop/src/features/integrations/components/ExternalTaskChip/index.tsx
+++ b/apps/desktop/src/features/integrations/components/ExternalTaskChip/index.tsx
@@ -2,6 +2,7 @@ import { ArrowRight } from 'lucide-react';
 import { cn } from '@goodboy/ui';
 import type { SessionExternalTask, SessionExternalTaskProvider } from '@goodboy/types';
 import { IntegrationGlyph } from '../IntegrationGlyph';
+import { CopyLinkButton } from '../../../../shared/components/CopyLinkButton';
 
 type Props = {
   task: SessionExternalTask;
@@ -76,7 +77,7 @@ export const ExternalTaskChip = ({
         new CustomEvent(meta.studioEvent, { detail: { issueExternalId: task.externalId } }),
       ));
 
-  return (
+  const trigger = (
     <button
       type="button"
       onClick={(e) => {
@@ -109,5 +110,14 @@ export const ExternalTaskChip = ({
         />
       ) : null}
     </button>
+  );
+
+  if (!isRow || !task.url) return trigger;
+
+  return (
+    <span className="flex w-full min-w-0 items-center gap-1">
+      {trigger}
+      <CopyLinkButton url={task.url} label={task.identifier} />
+    </span>
   );
 };

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/IssueDetailPanel.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/IssueDetailPanel.tsx
@@ -68,7 +68,7 @@ export const IssueDetailPanel = ({ issue, sessionId, workspaceId, onClose }: Pro
             </>
           }
           title={issue.title}
-          actions={<OpenExternalLink url={issue.webUrl} label="Open in GitLab" />}
+          actions={<OpenExternalLink url={issue.webUrl} label="Open in GitLab" copyLabel="issue" />}
         />
       }
       rail={

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel.tsx
@@ -279,7 +279,7 @@ export const MrDetailPanel = ({
             actions={
               <>
                 {refreshButton}
-                <OpenExternalLink url={mr.webUrl} label="Open in GitLab" />
+                <OpenExternalLink url={mr.webUrl} label="Open in GitLab" copyLabel="MR" />
               </>
             }
           />

--- a/apps/desktop/src/features/integrations/linear/LinearIssueDetail/index.tsx
+++ b/apps/desktop/src/features/integrations/linear/LinearIssueDetail/index.tsx
@@ -95,7 +95,7 @@ export const LinearIssueDetail = ({ issue, workspaceId }: Props) => {
           {issue.state.name}
         </span>
       }
-      actions={<OpenExternalLink url={issue.url} label="Open in Linear" />}
+      actions={<OpenExternalLink url={issue.url} label="Open in Linear" copyLabel="issue" />}
       meta={<MetaGrid items={meta} />}
       sections={[
         {

--- a/apps/desktop/src/features/integrations/linear/LinearStudio/IssueDetailPanel.tsx
+++ b/apps/desktop/src/features/integrations/linear/LinearStudio/IssueDetailPanel.tsx
@@ -168,7 +168,7 @@ export const IssueDetailPanel = ({ issue, sessionId, workspaceId, onClose }: Pro
             </>
           }
           title={issue.title}
-          actions={<OpenExternalLink url={issue.url} label="Open in Linear" />}
+          actions={<OpenExternalLink url={issue.url} label="Open in Linear" copyLabel="issue" />}
         />
       }
       rail={

--- a/apps/desktop/src/features/integrations/sentry/SentryIssueDetail/index.tsx
+++ b/apps/desktop/src/features/integrations/sentry/SentryIssueDetail/index.tsx
@@ -79,7 +79,7 @@ export const SentryIssueDetail = ({
       state={<SentryLevelBadge level={view.level} />}
       actions={
         view.permalink != null && view.permalink !== '' ? (
-          <OpenExternalLink url={view.permalink} label="Open in Sentry" />
+          <OpenExternalLink url={view.permalink} label="Open in Sentry" copyLabel="issue" />
         ) : undefined
       }
       meta={<MetaGrid items={meta} />}

--- a/apps/desktop/src/features/integrations/sentry/SentryStudio/IssueDetailPanel.tsx
+++ b/apps/desktop/src/features/integrations/sentry/SentryStudio/IssueDetailPanel.tsx
@@ -110,7 +110,7 @@ export const IssueDetailPanel = ({ issue, sessionId, workspaceId, onClose }: Pro
           }
           actions={
             view.permalink != null && view.permalink !== '' ? (
-              <OpenExternalLink url={view.permalink} label="Open in Sentry" />
+              <OpenExternalLink url={view.permalink} label="Open in Sentry" copyLabel="issue" />
             ) : undefined
           }
         />

--- a/apps/desktop/src/features/review/components/ReviewPrDetailPanel/index.tsx
+++ b/apps/desktop/src/features/review/components/ReviewPrDetailPanel/index.tsx
@@ -14,6 +14,7 @@ import { formatError } from '../../../../shared/lib/errors';
 import { formatRelativeDuration } from '../../../../shared/utils/relativeDate';
 import { PullRequestChip } from '../../../github/components/PullRequestChip';
 import { OpenSessionButton } from '../../../../shared/components/OpenSessionButton';
+import { CopyLinkButton } from '../../../../shared/components/CopyLinkButton';
 import { AuthorAvatar } from '../AuthorAvatar';
 
 type Props = {
@@ -101,6 +102,7 @@ export const ReviewPrDetailPanel = ({ pr, workspaceId, onClose }: Props) => {
           >
             Open in {hostLabel} <ExternalLink size={11} aria-hidden />
           </a>
+          <CopyLinkButton url={pr.url} label={`PR #${pr.number}`} />
         </div>
         <h2 className="text-lg font-semibold leading-snug text-foreground">{pr.title}</h2>
         <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5 text-2xs text-muted-foreground">

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/PrStatusLine.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/PrStatusLine.tsx
@@ -2,6 +2,7 @@ import { Check, XCircle } from 'lucide-react';
 import type { PullRequestState, PullRequestStateKind } from '@goodboy/types';
 import { StatusDot } from '@goodboy/ui';
 import { openUrl } from '../../../../shared/lib/editor';
+import { CopyLinkButton } from '../../../../shared/components/CopyLinkButton';
 import { PullRequestChip } from '../../../github/components/PullRequestChip';
 
 type Props = {
@@ -29,6 +30,7 @@ export const PrStatusLine = ({ pr }: Props) => {
       >
         #{pr.number}
       </button>
+      <CopyLinkButton url={pr.url} label={`PR #${pr.number}`} size={10} className="p-0.5" />
       {pr.checks === 'failure' ? (
         <span title="Checks failing" className="shrink-0 text-danger">
           <XCircle size={12} aria-hidden />

--- a/apps/desktop/src/features/workflows/components/OrchestratorPanel/index.test.tsx
+++ b/apps/desktop/src/features/workflows/components/OrchestratorPanel/index.test.tsx
@@ -1,0 +1,122 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { Agent, SessionId, WorkflowId, WorkflowRun, WorkflowRunId } from '@goodboy/types';
+
+const { storeState } = vi.hoisted(() => ({
+  storeState: {} as Record<string, unknown>,
+}));
+
+vi.mock('../../../../store/store', () => ({
+  useAppStore: (selector: (state: Record<string, unknown>) => unknown) => selector(storeState),
+}));
+
+import { OrchestratorPanel } from './index';
+
+const SESSION_ID = 'session-1' as SessionId;
+const RUN_ID = 'run-1' as WorkflowRunId;
+
+const run = (overrides: Partial<WorkflowRun> = {}): WorkflowRun => ({
+  id: RUN_ID,
+  workflowId: 'workflow-1' as WorkflowId,
+  ordinal: 0,
+  currentStep: 0,
+  autoRun: true,
+  triggerMode: 'immediate',
+  executionMode: 'dynamic',
+  ...overrides,
+});
+
+beforeEach(() => {
+  Object.assign(storeState, {
+    retryWorkflowOrchestration: vi.fn(async () => undefined),
+    continueWorkflowRun: vi.fn(async () => undefined),
+    setWorkflowOrchestratorHints: vi.fn(async () => undefined),
+    providers: [
+      { id: 'anthropic', connection: 'connected' },
+      { id: 'codex', connection: 'missing' },
+    ],
+  });
+});
+
+afterEach(cleanup);
+
+const EMPTY_AGENTS: ReadonlyArray<Agent> = [];
+
+describe('OrchestratorPanel', () => {
+  it('says what the orchestrator is doing while it decides', () => {
+    render(
+      <OrchestratorPanel
+        sessionId={SESSION_ID}
+        run={run()}
+        agents={EMPTY_AGENTS}
+        isOrchestrating
+      />,
+    );
+    expect(screen.getByTestId('orchestrator-panel').textContent).toContain(
+      'deciding the next step',
+    );
+  });
+
+  it('shows the failure and offers a retry on another provider', () => {
+    render(
+      <OrchestratorPanel
+        sessionId={SESSION_ID}
+        run={run({ orchestrationError: 'usage limit reached (anthropic/haiku-4.5)' })}
+        agents={EMPTY_AGENTS}
+        isOrchestrating={false}
+      />,
+    );
+    expect(screen.getByTestId('orchestrator-error').textContent).toContain('usage limit reached');
+    fireEvent.click(screen.getByTestId('orchestrator-retry-provider'));
+    fireEvent.click(screen.getByRole('button', { name: 'anthropic' }));
+    expect(storeState['retryWorkflowOrchestration']).toHaveBeenCalledWith(
+      SESSION_ID,
+      RUN_ID,
+      expect.objectContaining({ providerId: 'anthropic' }),
+    );
+  });
+
+  it('keeps a completed run extendable with a note', () => {
+    render(
+      <OrchestratorPanel
+        sessionId={SESSION_ID}
+        run={run({ orchestrationOutcome: 'done' })}
+        agents={EMPTY_AGENTS}
+        isOrchestrating={false}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('orchestrator-continue-toggle'));
+    fireEvent.change(screen.getByTestId('orchestrator-continue-note'), {
+      target: { value: 'tests are missing' },
+    });
+    fireEvent.click(screen.getByTestId('orchestrator-continue-confirm'));
+    expect(storeState['continueWorkflowRun']).toHaveBeenCalledWith(
+      SESSION_ID,
+      RUN_ID,
+      'tests are missing',
+    );
+  });
+
+  it('saves runtime hints', () => {
+    render(
+      <OrchestratorPanel
+        sessionId={SESSION_ID}
+        run={run()}
+        agents={EMPTY_AGENTS}
+        isOrchestrating={false}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('orchestrator-hints-toggle'));
+    fireEvent.change(screen.getByTestId('orchestrator-hints-input'), {
+      target: { value: 'ignore the website' },
+    });
+    fireEvent.click(screen.getByTestId('orchestrator-hints-save'));
+    expect(storeState['setWorkflowOrchestratorHints']).toHaveBeenCalledWith(
+      SESSION_ID,
+      RUN_ID,
+      'ignore the website',
+    );
+  });
+});

--- a/apps/desktop/src/features/workflows/components/OrchestratorPanel/index.tsx
+++ b/apps/desktop/src/features/workflows/components/OrchestratorPanel/index.tsx
@@ -1,0 +1,238 @@
+import { useState } from 'react';
+import {
+  AlertTriangle,
+  CheckCircle2,
+  ChevronDown,
+  Loader2,
+  Play,
+  RotateCcw,
+  Sparkles,
+} from 'lucide-react';
+import { cn } from '@goodboy/ui';
+import { getCheapModel } from '@goodboy/core';
+import type { Agent, ProviderId, SessionId, WorkflowRun } from '@goodboy/types';
+import { useAppStore } from '../../../../store/store';
+
+type Props = {
+  readonly sessionId: SessionId;
+  readonly run: WorkflowRun;
+  readonly agents: ReadonlyArray<Agent>;
+  readonly isOrchestrating: boolean;
+};
+
+type Phase = 'deciding' | 'running' | 'idle' | 'failed' | 'blocked' | 'done';
+
+const phaseOf = ({
+  run,
+  agents,
+  isOrchestrating,
+}: Pick<Props, 'run' | 'agents' | 'isOrchestrating'>): Phase => {
+  if (isOrchestrating) return 'deciding';
+  if (run.orchestrationOutcome === 'done') return 'done';
+  if (run.orchestrationOutcome === 'blocked') return 'blocked';
+  if (run.orchestrationError != null) return 'failed';
+  if (agents.some((agent) => agent.status === 'running' || agent.status === 'pending')) {
+    return 'running';
+  }
+  return 'idle';
+};
+
+const PHASE_COPY: Readonly<Record<Phase, string>> = {
+  deciding: 'deciding the next step',
+  running: 'waiting for the running step to finish',
+  idle: 'idle, waiting for you to ask for the next step',
+  failed: 'the last decision failed',
+  blocked: 'stopped, it needs a human call',
+  done: 'run complete',
+};
+
+const PHASE_TONE: Readonly<Record<Phase, string>> = {
+  deciding: 'border-info/40 bg-info/5 text-info',
+  running: 'border-primary/30 bg-primary/5 text-primary',
+  idle: 'border-border-soft bg-muted/20 text-muted-foreground',
+  failed: 'border-danger/40 bg-danger/5 text-danger',
+  blocked: 'border-warning/40 bg-warning/5 text-warning',
+  done: 'border-success/30 bg-success/5 text-success',
+};
+
+export const OrchestratorPanel = ({ sessionId, run, agents, isOrchestrating }: Props) => {
+  const retryWorkflowOrchestration = useAppStore((state) => state.retryWorkflowOrchestration);
+  const continueWorkflowRun = useAppStore((state) => state.continueWorkflowRun);
+  const setWorkflowOrchestratorHints = useAppStore((state) => state.setWorkflowOrchestratorHints);
+  const providers = useAppStore((state) => state.providers);
+  const [hintsOpen, setHintsOpen] = useState(false);
+  const [hintsDraft, setHintsDraft] = useState(run.orchestratorHints ?? '');
+  const [continueNote, setContinueNote] = useState('');
+  const [continueOpen, setContinueOpen] = useState(false);
+  const [providerMenuOpen, setProviderMenuOpen] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  const phase = phaseOf({ run, agents, isOrchestrating });
+  const connected = providers.filter((provider) => provider.connection === 'connected');
+
+  const guard = async (action: () => Promise<void>) => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      await action();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const retryWith = (providerId: ProviderId) => {
+    setProviderMenuOpen(false);
+    void guard(() =>
+      retryWorkflowOrchestration(sessionId, run.id, {
+        providerId,
+        model: getCheapModel(providerId),
+      }),
+    );
+  };
+
+  return (
+    <section
+      data-testid="orchestrator-panel"
+      className={cn('flex flex-col gap-2 rounded-lg border px-3 py-2', PHASE_TONE[phase])}
+    >
+      <div className="flex items-center gap-1.5 text-2xs font-semibold">
+        {phase === 'deciding' ? (
+          <Loader2 size={12} aria-hidden className="shrink-0 motion-safe:animate-spin" />
+        ) : phase === 'done' ? (
+          <CheckCircle2 size={12} aria-hidden className="shrink-0" />
+        ) : phase === 'failed' || phase === 'blocked' ? (
+          <AlertTriangle size={12} aria-hidden className="shrink-0" />
+        ) : (
+          <Sparkles size={12} aria-hidden className="shrink-0" />
+        )}
+        <span>Orchestrator: {PHASE_COPY[phase]}</span>
+      </div>
+
+      {run.orchestrationError != null ? (
+        <p data-testid="orchestrator-error" className="text-2xs leading-relaxed text-danger">
+          {run.orchestrationError}
+        </p>
+      ) : null}
+
+      <div className="flex flex-wrap items-center gap-1.5">
+        {phase === 'failed' || phase === 'blocked' ? (
+          <>
+            <button
+              type="button"
+              disabled={busy}
+              data-testid="orchestrator-retry"
+              onClick={() => void guard(() => retryWorkflowOrchestration(sessionId, run.id))}
+              className="inline-flex items-center gap-1 rounded-md border border-border-soft bg-elevated px-2 py-1 text-2xs font-semibold text-foreground hover:border-border disabled:opacity-60"
+            >
+              <RotateCcw size={11} aria-hidden />
+              retry
+            </button>
+            <div className="relative">
+              <button
+                type="button"
+                disabled={busy || connected.length === 0}
+                data-testid="orchestrator-retry-provider"
+                onClick={() => setProviderMenuOpen((open) => !open)}
+                className="inline-flex items-center gap-1 rounded-md border border-border-soft bg-elevated px-2 py-1 text-2xs font-semibold text-foreground hover:border-border disabled:opacity-60"
+              >
+                retry with another provider
+                <ChevronDown size={11} aria-hidden />
+              </button>
+              {providerMenuOpen ? (
+                <div className="absolute left-0 top-full z-40 mt-1 w-48 rounded-md border border-border-soft bg-background p-1 shadow-lg">
+                  {connected.map((provider) => (
+                    <button
+                      key={provider.id}
+                      type="button"
+                      onClick={() => retryWith(provider.id)}
+                      className="flex w-full items-center rounded px-2 py-1 text-left text-2xs text-foreground hover:bg-muted/50"
+                    >
+                      {provider.id}
+                    </button>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+          </>
+        ) : null}
+
+        {phase === 'done' ? (
+          <button
+            type="button"
+            disabled={busy}
+            data-testid="orchestrator-continue-toggle"
+            onClick={() => setContinueOpen((open) => !open)}
+            className="inline-flex items-center gap-1 rounded-md border border-border-soft bg-elevated px-2 py-1 text-2xs font-semibold text-foreground hover:border-border disabled:opacity-60"
+          >
+            <Play size={11} aria-hidden />
+            keep going
+          </button>
+        ) : null}
+
+        <button
+          type="button"
+          data-testid="orchestrator-hints-toggle"
+          onClick={() => setHintsOpen((open) => !open)}
+          className="inline-flex items-center gap-1 rounded-md border border-border-soft bg-elevated px-2 py-1 text-2xs font-semibold text-foreground hover:border-border"
+        >
+          {run.orchestratorHints ? 'hints (on)' : 'add hints'}
+        </button>
+      </div>
+
+      {continueOpen ? (
+        <div className="flex flex-col gap-1.5">
+          <textarea
+            value={continueNote}
+            onChange={(event) => setContinueNote(event.target.value)}
+            rows={2}
+            placeholder="what is still missing? this is handed to the orchestrator"
+            data-testid="orchestrator-continue-note"
+            className="w-full rounded-md border border-border-soft bg-background px-2 py-1 text-2xs text-foreground focus:outline-none focus:ring-1 focus:ring-[var(--color-focus-ring)]"
+          />
+          <button
+            type="button"
+            disabled={busy}
+            data-testid="orchestrator-continue-confirm"
+            onClick={() =>
+              void guard(async () => {
+                await continueWorkflowRun(sessionId, run.id, continueNote);
+                setContinueNote('');
+                setContinueOpen(false);
+              })
+            }
+            className="w-fit rounded-md border border-primary/40 bg-primary/10 px-2 py-1 text-2xs font-semibold text-primary hover:border-primary disabled:opacity-60"
+          >
+            continue this run
+          </button>
+        </div>
+      ) : null}
+
+      {hintsOpen ? (
+        <div className="flex flex-col gap-1.5">
+          <textarea
+            value={hintsDraft}
+            onChange={(event) => setHintsDraft(event.target.value)}
+            rows={3}
+            placeholder="runtime hints: what to look at, what to ignore, how to sequence"
+            data-testid="orchestrator-hints-input"
+            className="w-full rounded-md border border-border-soft bg-background px-2 py-1 text-2xs text-foreground focus:outline-none focus:ring-1 focus:ring-[var(--color-focus-ring)]"
+          />
+          <button
+            type="button"
+            disabled={busy}
+            data-testid="orchestrator-hints-save"
+            onClick={() =>
+              void guard(async () => {
+                await setWorkflowOrchestratorHints(sessionId, run.id, hintsDraft);
+                setHintsOpen(false);
+              })
+            }
+            className="w-fit rounded-md border border-border-soft bg-elevated px-2 py-1 text-2xs font-semibold text-foreground hover:border-border disabled:opacity-60"
+          >
+            save hints
+          </button>
+        </div>
+      ) : null}
+    </section>
+  );
+};

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.tsx
@@ -27,6 +27,7 @@ import { useSessionRoleModels } from '../../../../../shared/hooks/useSessionRole
 import type { AgentAggregate } from '../../../../../features/session/components/AgentMetrics';
 import { WorkflowNextStepCta } from '../../../../../features/workflows/components/WorkflowNextStepCta';
 import { WorkflowOrchestratorTldr } from '../../../../../features/workflows/components/WorkflowOrchestratorTldr';
+import { OrchestratorPanel } from '../../../../../features/workflows/components/OrchestratorPanel';
 import { WorkflowStepStrip } from '../../../../../features/workflows/components/WorkflowStepStrip';
 import { GoalAttachmentsStrip } from '../../../../../features/context/components/ContextPanel/strips/GoalAttachmentsStrip';
 import { CostBadge } from '../../../../providers/components/CostBadge';
@@ -375,6 +376,14 @@ export const WorkflowRow = ({
             processText={(workflow.processText ?? '').trim()}
           />
           <GoalAttachmentsStrip owner={{ type: 'workflow_run', id: run.id }} />
+          {isDynamic ? (
+            <OrchestratorPanel
+              sessionId={task.id}
+              run={run}
+              agents={wfAgents}
+              isOrchestrating={isOrchestrating}
+            />
+          ) : null}
           {isDynamic ? <WorkflowOrchestratorTldr steps={workflow.steps} /> : null}
         </div>
       ) : null}

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRunStatus.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRunStatus.tsx
@@ -1,4 +1,4 @@
-import { Ban, Check, Link2, Pause, Wand2 } from 'lucide-react';
+import { AlertTriangle, Ban, Check, Link2, Pause, Wand2 } from 'lucide-react';
 import type { Agent, Workflow, WorkflowRun } from '@goodboy/types';
 import { StatusDot, cn } from '@goodboy/ui';
 
@@ -48,6 +48,18 @@ export const WorkflowRunStatus = ({ run, workflow, agents, predecessorName }: Pr
       <span className={cn(baseClass, 'bg-success/10 text-success')}>
         <Check size={10} aria-hidden />
         Completed
+      </span>
+    );
+  }
+  if (run.orchestrationError != null && !isRunning) {
+    return (
+      <span
+        className={cn(baseClass, 'bg-danger/10 text-danger')}
+        title={run.orchestrationError}
+        data-testid="workflow-orchestrator-failed"
+      >
+        <AlertTriangle size={10} aria-hidden />
+        Orchestrator failed
       </span>
     );
   }

--- a/apps/desktop/src/shared/components/CopyLinkButton/index.test.tsx
+++ b/apps/desktop/src/shared/components/CopyLinkButton/index.test.tsx
@@ -1,0 +1,47 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { CopyLinkButton } from './index';
+
+afterEach(cleanup);
+
+describe('CopyLinkButton', () => {
+  it('copies the url and confirms it', async () => {
+    const writeText = vi.fn(async () => undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+
+    render(<CopyLinkButton url="https://linear.app/GB-12" label="GB-12" />);
+    fireEvent.click(screen.getByRole('button', { name: 'Copy GB-12 link' }));
+
+    expect(writeText).toHaveBeenCalledWith('https://linear.app/GB-12');
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Copy GB-12 link' }).className).toContain(
+        'text-success',
+      ),
+    );
+  });
+
+  it('reports a failed copy instead of pretending it worked', async () => {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: vi.fn(async () => {
+          throw new Error('denied');
+        }),
+      },
+    });
+
+    render(<CopyLinkButton url="https://linear.app/GB-12" label="GB-12" />);
+    fireEvent.click(screen.getByRole('button', { name: 'Copy GB-12 link' }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Copy GB-12 link' }).getAttribute('title')).toBe(
+        'copy failed',
+      ),
+    );
+  });
+});

--- a/apps/desktop/src/shared/components/CopyLinkButton/index.tsx
+++ b/apps/desktop/src/shared/components/CopyLinkButton/index.tsx
@@ -1,0 +1,41 @@
+import { Check, Link2, X } from 'lucide-react';
+import { cn } from '@goodboy/ui';
+import { useCopyLink } from '../../hooks/useCopyLink';
+
+type Props = {
+  readonly url: string;
+  readonly label: string;
+  readonly size?: number;
+  readonly className?: string;
+};
+
+export const CopyLinkButton = ({ url, label, size = 11, className }: Props) => {
+  const { copied, failed, copy } = useCopyLink();
+
+  return (
+    <button
+      type="button"
+      onClick={(event) => {
+        event.stopPropagation();
+        void copy(url);
+      }}
+      title={failed ? 'copy failed' : `Copy ${label} link`}
+      aria-label={`Copy ${label} link`}
+      className={cn(
+        'inline-flex shrink-0 items-center rounded-md p-1 transition-colors',
+        copied && 'text-success',
+        failed && 'text-danger',
+        !copied && !failed && 'text-muted-foreground hover:bg-muted/50 hover:text-foreground',
+        className,
+      )}
+    >
+      {copied ? (
+        <Check size={size} aria-hidden />
+      ) : failed ? (
+        <X size={size} aria-hidden />
+      ) : (
+        <Link2 size={size} aria-hidden />
+      )}
+    </button>
+  );
+};

--- a/apps/desktop/src/shared/components/OpenExternalLink/index.tsx
+++ b/apps/desktop/src/shared/components/OpenExternalLink/index.tsx
@@ -1,19 +1,21 @@
 import type { MouseEvent } from 'react';
 import { ExternalLink } from 'lucide-react';
 import { openUrl } from '../../lib/editor';
+import { CopyLinkButton } from '../CopyLinkButton';
 
 type Props = {
   readonly url: string;
   readonly label: string;
+  readonly copyLabel?: string;
 };
 
-export const OpenExternalLink = ({ url, label }: Props) => {
+export const OpenExternalLink = ({ url, label, copyLabel }: Props) => {
   const onClick = (event: MouseEvent<HTMLAnchorElement>) => {
     event.preventDefault();
     void openUrl(url);
   };
 
-  return (
+  const link = (
     <a
       href={url}
       target="_blank"
@@ -23,5 +25,14 @@ export const OpenExternalLink = ({ url, label }: Props) => {
     >
       {label} <ExternalLink size={11} aria-hidden />
     </a>
+  );
+
+  if (!copyLabel) return link;
+
+  return (
+    <span className="inline-flex items-center gap-0.5">
+      {link}
+      <CopyLinkButton url={url} label={copyLabel} />
+    </span>
   );
 };

--- a/apps/desktop/src/shared/hooks/useCopyLink/index.ts
+++ b/apps/desktop/src/shared/hooks/useCopyLink/index.ts
@@ -1,0 +1,47 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+const RESET_MS = 1200;
+
+type UseCopyLinkResult = {
+  readonly copied: boolean;
+  readonly failed: boolean;
+  readonly copy: (value: string) => Promise<void>;
+};
+
+export const useCopyLink = (): UseCopyLinkResult => {
+  const [copied, setCopied] = useState(false);
+  const [failed, setFailed] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(
+    () => () => {
+      if (timer.current) clearTimeout(timer.current);
+    },
+    [],
+  );
+
+  const schedule = useCallback(() => {
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = setTimeout(() => {
+      setCopied(false);
+      setFailed(false);
+    }, RESET_MS);
+  }, []);
+
+  const copy = useCallback(
+    async (value: string) => {
+      try {
+        await navigator.clipboard.writeText(value);
+        setCopied(true);
+        setFailed(false);
+      } catch {
+        setCopied(false);
+        setFailed(true);
+      }
+      schedule();
+    },
+    [schedule],
+  );
+
+  return { copied, failed, copy };
+};

--- a/apps/desktop/src/store/kickoff.test.ts
+++ b/apps/desktop/src/store/kickoff.test.ts
@@ -1,9 +1,15 @@
 import { describe, expect, it } from 'vitest';
-import { buildGoalKickoffSection, composeKickoff } from './kickoff';
+import type { AgentId } from '@goodboy/types';
+import {
+  buildGoalKickoffSection,
+  composeKickoff,
+  composePlanSection,
+  composeStepBoundary,
+} from './kickoff';
 
 describe('buildGoalKickoffSection', () => {
-  it('wraps a goal in a labelled section', () => {
-    expect(buildGoalKickoffSection('Ship gitlab.')).toBe('Workflow goal:\n\nShip gitlab.');
+  it('wraps a goal in a labelled line', () => {
+    expect(buildGoalKickoffSection('Ship gitlab.')).toBe('**Goal** Ship gitlab.');
   });
 
   it('returns an empty string for a missing or blank goal', () => {
@@ -19,5 +25,20 @@ describe('composeKickoff', () => {
 
   it('returns an empty string when every section is empty', () => {
     expect(composeKickoff('', '')).toBe('');
+  });
+});
+
+describe('composePlanSection', () => {
+  it('labels the plan body on a single line header', () => {
+    expect(composePlanSection({ bodyMd: '1. do it' })).toBe('**Plan**\n1. do it');
+  });
+});
+
+describe('composeStepBoundary', () => {
+  it('states the scope and the done marker in one line', () => {
+    const text = composeStepBoundary('agent-1' as AgentId);
+    expect(text).toContain('**Scope** this step only');
+    expect(text).toContain('<<step-done id="agent-1">>');
+    expect(text.split('\n')).toHaveLength(1);
   });
 });

--- a/apps/desktop/src/store/kickoff.ts
+++ b/apps/desktop/src/store/kickoff.ts
@@ -1,6 +1,9 @@
 import type { AgentId, PlanWithCount, SessionId, WorkflowRunId } from '@goodboy/types';
 import { listPlansForSession as invokeListPlansForSession } from '../features/plans/plans';
 
+export const composePlanSection = ({ bodyMd }: { readonly bodyMd: string }): string =>
+  `**Plan**\n${bodyMd}`;
+
 export const buildPlanKickoffSection = async (
   sessionId: SessionId,
   workflowRunId?: WorkflowRunId,
@@ -13,7 +16,7 @@ export const buildPlanKickoffSection = async (
       return { section: '', plan: latest };
     }
     return {
-      section: ['Active plan to execute:', '', latest.bodyMd].join('\n'),
+      section: composePlanSection({ bodyMd: latest.bodyMd }),
       plan: latest,
     };
   } catch {
@@ -26,15 +29,18 @@ export const composeKickoff = (...sections: ReadonlyArray<string>): string =>
 
 export const buildGoalKickoffSection = (goal?: string): string => {
   const trimmed = (goal ?? '').trim();
-  return trimmed.length > 0 ? `Workflow goal:\n\n${trimmed}` : '';
+  return trimmed.length > 0 ? `**Goal** ${trimmed}` : '';
 };
+
+type BoundaryParams = {
+  readonly unit: string;
+  readonly marker: string;
+};
+
+export const composeUnitBoundary = ({ unit, marker }: BoundaryParams): string =>
+  `**Scope** this ${unit} only, never a later one. Emit \`${marker}\` on its own line once it is truly done.`;
 
 export const stepBoundaryMarker = (agentId: AgentId): string => `<<step-done id="${agentId}">>`;
 
 export const composeStepBoundary = (agentId: AgentId): string =>
-  [
-    'Complete ONLY this workflow step. Do not start later steps or work on their scope.',
-    'When this step is fully complete, emit on its own line exactly:',
-    stepBoundaryMarker(agentId),
-    'Do not emit that marker until the step is truly done.',
-  ].join('\n');
+  composeUnitBoundary({ unit: 'step', marker: stepBoundaryMarker(agentId) });

--- a/apps/desktop/src/store/preamble.ts
+++ b/apps/desktop/src/store/preamble.ts
@@ -11,11 +11,9 @@ import { contextWindowFor } from '../features/session/contextWindowFor';
 import { estimateTokens } from '../shared/utils/estimate-tokens';
 
 const CONTEXT_MARKER_HINT =
-  '## context handoff protocol\n' +
-  'when you reach a durable design decision, wrap it as `<<ctx-decision>>your decision<</ctx-decision>>`.\n' +
-  'when you have an open question that the user must answer before continuing, wrap it as `<<ctx-question>>your question<</ctx-question>>`. write the question in plain, self-contained language: the user has not read your reasoning, so spell out what you are asking and why it matters in one sentence. when the question is a bounded choice, offer 2 to 4 concrete options the user can pick in one tap via the `suggestions` attribute, pipe-separated. always include a `recommended` attribute with the single answer you would pick given the current context (match one of the suggestions verbatim when applicable), so the user can accept your default in one tap: `<<ctx-question suggestions="option a | option b | option c" recommended="option a">>your question<</ctx-question>>`.\n' +
-  'when an open question listed in the shared context above has just been answered (by the user, or because work has clarified it), wrap it as `<<ctx-resolved>>the original question text<</ctx-resolved>>`, the orchestrator removes matching lines from open_questions. emit one resolved marker per question; reuse the original phrasing closely so the substring match succeeds.\n' +
-  "the orchestrator parses these markers and persists them to this task's shared context panel, every other agent in this task will see them automatically. don't repeat what's already in the shared context above.";
+  '## context handoff protocol (parsed into the shared context above, seen by every agent, never repeat what is already there)\n' +
+  '`<<ctx-decision>>durable decision<</ctx-decision>>`. `<<ctx-resolved>>original question text, quoted closely<</ctx-resolved>>` once an open question above is answered, one per question.\n' +
+  '`<<ctx-question suggestions="a | b | c" recommended="a">>question<</ctx-question>>` when the user must answer first: self-contained, what and why in one sentence; `suggestions` = 2 to 4 pipe-separated options when bounded; `recommended` always set, verbatim from suggestions when present.';
 
 export const buildContextPreamble = (
   sharedSlots: ReadonlyArray<ContextSlot>,

--- a/apps/desktop/src/store/slices/agents/spawnAgent.ts
+++ b/apps/desktop/src/store/slices/agents/spawnAgent.ts
@@ -25,7 +25,7 @@ import {
   kindConsumesPlan,
   type AgentKind,
 } from '../../../features/session/agent-kind';
-import { buildPlanKickoffSection, composeKickoff } from '../../kickoff';
+import { buildPlanKickoffSection, composeKickoff, composePlanSection } from '../../kickoff';
 import { fanOutClusters, selectFanOutPlan } from '../workflows/clusterImplementation';
 import type { GetFn, SetFn } from './types';
 
@@ -173,7 +173,7 @@ export const spawnAgent = (set: SetFn, get: GetFn) => {
           ? (get().sessionPlans[sessionId]?.find((p) => p.id === args.triggeredPlanId) ?? null)
           : null;
       planSection = explicitPlan
-        ? ['Active plan to execute:', '', explicitPlan.bodyMd].join('\n')
+        ? composePlanSection({ bodyMd: explicitPlan.bodyMd })
         : latestSection;
       planForKickoff = explicitPlan ?? latestPlan;
       const workflowAutoConsume = args.stepId !== undefined && latestPlan?.status === 'active';

--- a/apps/desktop/src/store/slices/turn/sendTurn.ts
+++ b/apps/desktop/src/store/slices/turn/sendTurn.ts
@@ -347,8 +347,10 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
           }
 
           if (parallelDispatch === null) {
+            const prefix = nextDef.promptPrefix.trim();
+            const hasPrefixAlready = prefix.length > 0 && resolvedPrompt.includes(prefix);
             resolvedPrompt = buildStepPrompt({
-              definition: nextDef,
+              definition: hasPrefixAlready ? { ...nextDef, promptPrefix: '' } : nextDef,
               carryForwardContext: phasePromptCarryForward,
               userMessage: resolvedPrompt,
             });

--- a/apps/desktop/src/store/slices/workflows/activateWorkflowAgent.test.ts
+++ b/apps/desktop/src/store/slices/workflows/activateWorkflowAgent.test.ts
@@ -302,6 +302,38 @@ describe('activateWorkflowAgent, plan consumption by kind', () => {
     expect((merged.agentTurnState as Record<string, unknown>)[AGENT_ID]).toBeDefined();
   });
 
+  it('leaves the selection alone while the operator is watching the workflows lens', async () => {
+    const { set, state, activate } = buildHarness({
+      agent: makeAgent('generic', 'Execute commits'),
+      workflow: makeWorkflow('Execute commits'),
+      plans: [makePlan()],
+    });
+    Object.assign(state, { activeLens: { [SESSION_ID]: 'workflows' } });
+
+    await activate(SESSION_ID, AGENT_ID);
+
+    const merged = mergedSetPartials(set, state);
+    expect(merged.selectedAgentId).toBeUndefined();
+    expect((merged.agentTurnState as Record<string, unknown>)[AGENT_ID]).toBeDefined();
+  });
+
+  it('still navigates when the operator is reading a step chat', async () => {
+    const { set, state, activate } = buildHarness({
+      agent: makeAgent('generic', 'Execute commits'),
+      workflow: makeWorkflow('Execute commits'),
+      plans: [makePlan()],
+    });
+    Object.assign(state, {
+      activeLens: { [SESSION_ID]: 'workflows' },
+      selectedAgentId: { [SESSION_ID]: 'other-agent' },
+    });
+
+    await activate(SESSION_ID, AGENT_ID);
+
+    const merged = mergedSetPartials(set, state);
+    expect((merged.selectedAgentId as Record<string, unknown>)[SESSION_ID]).toBe(AGENT_ID);
+  });
+
   it('navigate=false starts the step without setting selectedAgentId but still inits turn and sends', async () => {
     const { set, state, sendTurn, activate } = buildHarness({
       agent: makeAgent('generic', 'Execute commits'),

--- a/apps/desktop/src/store/slices/workflows/activateWorkflowAgent.ts
+++ b/apps/desktop/src/store/slices/workflows/activateWorkflowAgent.ts
@@ -13,9 +13,11 @@ import {
   buildGoalKickoffSection,
   buildPlanKickoffSection,
   composeKickoff,
+  composePlanSection,
   composeStepBoundary,
 } from '../../kickoff';
 import { fanOutClusters, selectFanOutPlan } from './clusterImplementation';
+import { isWatchingWorkflowLens } from './isWatchingWorkflowLens';
 import type { GetFn, SetFn } from './types';
 
 export const activateWorkflowAgent = (set: SetFn, get: GetFn) => {
@@ -51,7 +53,9 @@ export const activateWorkflowAgent = (set: SetFn, get: GetFn) => {
           lastActivityAt: new Date().toISOString() as IsoDateTime,
         },
       },
-      ...(navigate ? { selectedAgentId: { ...s.selectedAgentId, [sessionId]: agentId } } : {}),
+      ...(navigate && !isWatchingWorkflowLens({ state: s, sessionId })
+        ? { selectedAgentId: { ...s.selectedAgentId, [sessionId]: agentId } }
+        : {}),
     }));
 
     const effectiveKind: AgentKind =
@@ -68,7 +72,7 @@ export const activateWorkflowAgent = (set: SetFn, get: GetFn) => {
 
     const planSection = consumesPlan
       ? explicitPlan
-        ? ['Active plan to execute:', '', explicitPlan.bodyMd].join('\n')
+        ? composePlanSection({ bodyMd: explicitPlan.bodyMd })
         : latestSection
       : '';
     const planToConsume = explicitPlan ?? (latestPlan?.status === 'active' ? latestPlan : null);

--- a/apps/desktop/src/store/slices/workflows/clusterImplementation.test.ts
+++ b/apps/desktop/src/store/slices/workflows/clusterImplementation.test.ts
@@ -172,9 +172,9 @@ describe('selectFanOutPlan', () => {
 describe('composeClusterBoundary', () => {
   it('states the single-cluster boundary and embeds the child-scoped done marker', () => {
     const text = composeClusterBoundary('child-7' as AgentId);
-    expect(text).toContain('Execute ONLY this cluster');
-    expect(text).toContain('Do not start later clusters');
+    expect(text).toContain('**Scope** this cluster only');
     expect(text).toContain('<<cluster-done id="child-7">>');
+    expect(text.split('\n')).toHaveLength(1);
   });
 });
 
@@ -366,8 +366,8 @@ describe('advanceClusterImplementation', () => {
     expect(sendTurn).toHaveBeenCalledTimes(1);
     const call = (sendTurn.mock.calls[0]! as unknown[])[0] as { agentId: AgentId; content: string };
     expect(call.agentId).toBe('cont-a');
-    expect(call.content).toContain('stopped before finishing');
-    expect(call.content).toContain('Do not start later clusters');
+    expect(call.content).toContain('**Resume**');
+    expect(call.content).toContain('**Scope** this cluster only');
     expect(call.content).toContain('<<cluster-done id="cont-a">>');
     expect(state.selectedAgentId).toBe(PARENT);
     expect(hoisted.invokeAgentUpdateStatus).not.toHaveBeenCalled();
@@ -609,7 +609,7 @@ describe('advanceClusterImplementation', () => {
     expect(call.content).toContain('2/2');
     expect(call.content).toContain('c1');
     expect(call.content).toContain('do 1');
-    expect(call.content).toContain('Overall goal: goal');
+    expect(call.content).toContain('**Goal** goal');
   });
 
   it('hydrates the plans from the db when the store has none for the session', async () => {

--- a/apps/desktop/src/store/slices/workflows/clusterImplementation.ts
+++ b/apps/desktop/src/store/slices/workflows/clusterImplementation.ts
@@ -14,6 +14,7 @@ import {
   invokeAgentUpdateStatus,
 } from '../../../features/workflows/workflows';
 import { listConsumptionsForPlan as invokeListConsumptionsForPlan } from '../../../features/plans/plans';
+import { composeKickoff, composeUnitBoundary } from '../../kickoff';
 import { isHandsFree } from './handsFree';
 import type { GetFn, SetFn } from './types';
 
@@ -27,16 +28,11 @@ function childrenOf(runs: ReadonlyArray<Agent>, containerId: AgentId): ReadonlyA
   return runs.filter((r) => r.parentAgentId === containerId).sort((a, b) => a.ordinal - b.ordinal);
 }
 
-export const composeClusterBoundary = (childId: AgentId): string =>
-  [
-    'Execute ONLY this cluster. Do not start later clusters or work on their scope.',
-    'When every item in this cluster is fully complete, emit on its own line exactly:',
-    `<<cluster-done id="${childId}">>`,
-    'Do not emit that marker until the cluster is truly done.',
-  ].join('\n');
-
 export const clusterBoundaryMarker = (childId: AgentId): string =>
   `<<cluster-done id="${childId}">>`;
+
+export const composeClusterBoundary = (childId: AgentId): string =>
+  composeUnitBoundary({ unit: 'cluster', marker: clusterBoundaryMarker(childId) });
 
 function composeClusterKickoff(
   childId: AgentId,
@@ -48,19 +44,15 @@ function composeClusterKickoff(
   const priorTitles = clusters.slice(0, index).map((c, i) => `${i + 1}. ${c.title}`);
   const priorBlock =
     priorTitles.length > 0
-      ? `Already completed (their changes are on disk, read files as needed):\n${priorTitles.join('\n')}`
-      : 'This is the first cluster.';
-  return [
-    'You are executing ONE cluster of a larger implementation plan, in sequence.',
-    `Overall goal: ${goalTitle}`,
+      ? `**Done before you** ${priorTitles.join(', ')} (changes already on disk)`
+      : '';
+  return composeKickoff(
+    `**Goal** ${goalTitle}`,
     priorBlock,
-    '',
-    `Your cluster (${index + 1}/${clusters.length}): ${cluster?.title ?? ''}`,
-    '',
+    `**Cluster ${index + 1}/${clusters.length}** ${cluster?.title ?? ''}`,
     cluster?.instructions ?? '',
-    '',
     composeClusterBoundary(childId),
-  ].join('\n');
+  );
 }
 
 const hasInstructions = (cluster: ImplementationCluster | undefined): boolean =>
@@ -70,11 +62,10 @@ function composeContinuePrompt(
   childId: AgentId,
   cluster: ImplementationCluster | undefined,
 ): string {
-  return [
-    `You stopped before finishing this cluster${cluster ? ` (${cluster.title})` : ''}.`,
-    'Continue with the remaining items now.',
+  return composeKickoff(
+    `**Resume**${cluster ? ` ${cluster.title}` : ''}: finish the remaining items now.`,
     composeClusterBoundary(childId),
-  ].join('\n');
+  );
 }
 
 function startChild(

--- a/apps/desktop/src/store/slices/workflows/continueWorkflowRun.test.ts
+++ b/apps/desktop/src/store/slices/workflows/continueWorkflowRun.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IsoDateTime, Session, SessionId, WorkflowId, WorkflowRunId } from '@goodboy/types';
+
+const { updateOutcomeSpy, updateHintsSpy } = vi.hoisted(() => ({
+  updateOutcomeSpy: vi.fn(async () => undefined),
+  updateHintsSpy: vi.fn(async () => undefined),
+}));
+
+vi.mock('@goodboy/db', () => ({
+  updateWorkflowRunOrchestrationOutcome: updateOutcomeSpy,
+  updateWorkflowRunOrchestratorHints: updateHintsSpy,
+}));
+
+vi.mock('../../../shared/lib/db', () => ({ tauriDatabase: {} }));
+
+import { continueWorkflowRun } from './continueWorkflowRun';
+import { setWorkflowOrchestratorHints } from './setWorkflowOrchestratorHints';
+
+const SESSION_ID = 'session-1' as SessionId;
+const RUN_ID = 'run-1' as WorkflowRunId;
+const NOW = '2026-07-31T00:00:00.000Z' as IsoDateTime;
+
+type State = Record<string, unknown>;
+
+const session = (overrides: Record<string, unknown> = {}): Session =>
+  ({
+    id: SESSION_ID,
+    workspaceId: 'workspace-1',
+    goal: 'Ship it',
+    state: { kind: 'idle', lastActivityAt: NOW },
+    contextSlots: [],
+    providerPreference: { defaultProvider: 'anthropic', allowTurnOverride: true },
+    permissionMode: 'default',
+    workflowRuns: [
+      {
+        id: RUN_ID,
+        workflowId: 'workflow-1' as WorkflowId,
+        ordinal: 0,
+        currentStep: 0,
+        autoRun: true,
+        triggerMode: 'immediate',
+        executionMode: 'dynamic',
+        orchestrationOutcome: 'done',
+        orchestrationError: 'boom',
+        ...overrides,
+      },
+    ],
+    autoRun: true,
+    titleUserEdited: false,
+    createdAt: NOW,
+    updatedAt: NOW,
+  }) as unknown as Session;
+
+const harness = (state: State) => {
+  const set = vi.fn((updater: unknown) => {
+    if (typeof updater === 'function') {
+      Object.assign(state, (updater as (current: State) => State)(state));
+      return;
+    }
+    Object.assign(state, updater as State);
+  });
+  return { set: set as never, get: (() => state) as never };
+};
+
+const baseState = (overrides: Record<string, unknown> = {}): State => {
+  const state: State = {
+    sessions: [session(overrides)],
+    orchestrateNextStep: vi.fn(async () => undefined),
+  };
+  const { set, get } = harness(state);
+  state['setWorkflowOrchestratorHints'] = setWorkflowOrchestratorHints(set, get);
+  return state;
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('continueWorkflowRun', () => {
+  it('reopens a completed run and asks the orchestrator for more', async () => {
+    const state = baseState();
+    const { set, get } = harness(state);
+
+    await continueWorkflowRun(set, get)(SESSION_ID, RUN_ID);
+
+    expect(updateOutcomeSpy).toHaveBeenCalledWith({}, RUN_ID, null);
+    const run = (state['sessions'] as ReadonlyArray<Session>)[0]!.workflowRuns[0]!;
+    expect(run.orchestrationOutcome).toBeUndefined();
+    expect(run.orchestrationError).toBeUndefined();
+    expect(state['orchestrateNextStep']).toHaveBeenCalledWith(SESSION_ID, RUN_ID);
+  });
+
+  it('folds the note into the hints the orchestrator already has', async () => {
+    const state = baseState({ orchestratorHints: 'skip the docs' });
+    const { set, get } = harness(state);
+
+    await continueWorkflowRun(set, get)(SESSION_ID, RUN_ID, '  also check the migrations  ');
+
+    expect(updateHintsSpy).toHaveBeenCalledWith(
+      {},
+      RUN_ID,
+      'skip the docs\nalso check the migrations',
+    );
+  });
+
+  it('leaves a static run alone', async () => {
+    const state = baseState({ executionMode: 'static' });
+    const { set, get } = harness(state);
+
+    await continueWorkflowRun(set, get)(SESSION_ID, RUN_ID);
+
+    expect(updateOutcomeSpy).not.toHaveBeenCalled();
+    expect(state['orchestrateNextStep']).not.toHaveBeenCalled();
+  });
+});
+
+describe('setWorkflowOrchestratorHints', () => {
+  it('drops the hints when the operator clears the field', async () => {
+    const state = baseState({ orchestratorHints: 'skip the docs' });
+    const { set, get } = harness(state);
+
+    await setWorkflowOrchestratorHints(set, get)(SESSION_ID, RUN_ID, '   ');
+
+    expect(updateHintsSpy).toHaveBeenCalledWith({}, RUN_ID, null);
+    const run = (state['sessions'] as ReadonlyArray<Session>)[0]!.workflowRuns[0]!;
+    expect(run.orchestratorHints).toBeUndefined();
+  });
+});

--- a/apps/desktop/src/store/slices/workflows/continueWorkflowRun.ts
+++ b/apps/desktop/src/store/slices/workflows/continueWorkflowRun.ts
@@ -1,20 +1,20 @@
 import type { SessionId, WorkflowRunId } from '@goodboy/types';
 import { updateWorkflowRunOrchestrationOutcome } from '@goodboy/db';
 import { tauriDatabase } from '../../../shared/lib/db';
-import type { OrchestratorRouting } from './orchestrateNextStep';
 import { patchWorkflowRun, withoutKeys } from './patchWorkflowRun';
 import type { GetFn, SetFn } from './types';
 
-export const retryWorkflowOrchestration = (set: SetFn, get: GetFn) => {
-  return async (
-    sessionId: SessionId,
-    workflowRunId: WorkflowRunId,
-    routing?: OrchestratorRouting,
-  ): Promise<void> => {
+export const continueWorkflowRun = (set: SetFn, get: GetFn) => {
+  return async (sessionId: SessionId, workflowRunId: WorkflowRunId, note?: string) => {
     const session = get().sessions.find((candidate) => candidate.id === sessionId);
     const run = session?.workflowRuns.find((candidate) => candidate.id === workflowRunId);
-    if (session == null || run == null || run.executionMode !== 'dynamic') {
+    if (run == null || run.executionMode !== 'dynamic') {
       return;
+    }
+    const trimmed = note?.trim() ?? '';
+    if (trimmed !== '') {
+      const merged = [run.orchestratorHints, trimmed].filter(Boolean).join('\n');
+      await get().setWorkflowOrchestratorHints(sessionId, workflowRunId, merged);
     }
     await updateWorkflowRunOrchestrationOutcome(tauriDatabase, workflowRunId, null);
     patchWorkflowRun({
@@ -23,6 +23,6 @@ export const retryWorkflowOrchestration = (set: SetFn, get: GetFn) => {
       workflowRunId,
       patch: (current) => withoutKeys(current, ['orchestrationOutcome', 'orchestrationError']),
     });
-    await get().orchestrateNextStep(sessionId, workflowRunId, routing ? { routing } : undefined);
+    await get().orchestrateNextStep(sessionId, workflowRunId);
   };
 };

--- a/apps/desktop/src/store/slices/workflows/index.ts
+++ b/apps/desktop/src/store/slices/workflows/index.ts
@@ -11,7 +11,9 @@ import { loadPhaseRunsForSession } from './loadPhaseRunsForSession';
 import { loadPhaseTemplates } from './loadPhaseTemplates';
 import { loadStepLibrary } from './loadStepLibrary';
 import { maybeAutoAdvanceWorkflow } from './maybeAutoAdvanceWorkflow';
+import { continueWorkflowRun } from './continueWorkflowRun';
 import { orchestrateNextStep } from './orchestrateNextStep';
+import { setWorkflowOrchestratorHints } from './setWorkflowOrchestratorHints';
 import { reorderSessionWorkflows } from './reorderSessionWorkflows';
 import { restoreWorkflow } from './restoreWorkflow';
 import { retryWorkflowOrchestration } from './retryWorkflowOrchestration';
@@ -51,6 +53,8 @@ export const createWorkflowsSlice = (set: SetFn, get: GetFn) => {
     maybeAutoAdvanceWorkflow: maybeAutoAdvanceWorkflow(set, get),
     orchestrateNextStep: orchestrateNextStep(set, get),
     retryWorkflowOrchestration: retryWorkflowOrchestration(set, get),
+    continueWorkflowRun: continueWorkflowRun(set, get),
+    setWorkflowOrchestratorHints: setWorkflowOrchestratorHints(set, get),
     retryStepSummary: retryStepSummary(set, get),
   };
 };

--- a/apps/desktop/src/store/slices/workflows/isWatchingWorkflowLens.ts
+++ b/apps/desktop/src/store/slices/workflows/isWatchingWorkflowLens.ts
@@ -1,0 +1,10 @@
+import type { SessionId } from '@goodboy/types';
+import type { AppState } from '../../types';
+
+type Params = {
+  readonly state: Pick<AppState, 'activeLens' | 'selectedAgentId'>;
+  readonly sessionId: SessionId;
+};
+
+export const isWatchingWorkflowLens = ({ state, sessionId }: Params): boolean =>
+  state.activeLens?.[sessionId] === 'workflows' && state.selectedAgentId?.[sessionId] == null;

--- a/apps/desktop/src/store/slices/workflows/orchestrateNextStep.test.ts
+++ b/apps/desktop/src/store/slices/workflows/orchestrateNextStep.test.ts
@@ -21,12 +21,14 @@ const {
   invokeAgentInsertSpy,
   listOpenQuestionsSpy,
   updateOutcomeSpy,
+  updateErrorSpy,
 } = vi.hoisted(() => ({
   decideSpy: vi.fn(),
   invokeWorkflowUpsertSpy: vi.fn(),
   invokeAgentInsertSpy: vi.fn(),
   listOpenQuestionsSpy: vi.fn(async () => []),
   updateOutcomeSpy: vi.fn(async () => undefined),
+  updateErrorSpy: vi.fn(async () => undefined),
 }));
 
 vi.mock('@goodboy/core', async (importOriginal) => {
@@ -40,6 +42,7 @@ vi.mock('@goodboy/core', async (importOriginal) => {
 vi.mock('@goodboy/db', () => ({
   listOpenQuestionsForSession: listOpenQuestionsSpy,
   updateWorkflowRunOrchestrationOutcome: updateOutcomeSpy,
+  updateWorkflowRunOrchestrationError: updateErrorSpy,
 }));
 
 vi.mock('../../../shared/lib/db', () => ({ tauriDatabase: {} }));
@@ -49,6 +52,7 @@ vi.mock('../../../features/workflows/workflows', () => ({
   invokeAgentInsert: invokeAgentInsertSpy,
 }));
 
+import { OrchestratorClient } from '@goodboy/core';
 import { orchestrateNextStep } from './orchestrateNextStep';
 
 const WORKSPACE_ID = 'workspace-1' as WorkspaceId;
@@ -308,7 +312,7 @@ describe('orchestrateNextStep', () => {
       'error',
       'warning',
       'orchestrator failed',
-      'orchestrator decision timed out',
+      expect.stringContaining('the orchestrator timed out after 120s'),
       { sessionId: SESSION_ID },
     );
     expect(state['appendTurnEvent']).toHaveBeenCalledWith(
@@ -316,7 +320,7 @@ describe('orchestrateNextStep', () => {
       SESSION_ID,
       expect.objectContaining({
         action: 'blocked',
-        reason: 'orchestrator failed: orchestrator decision timed out',
+        reason: expect.stringContaining('orchestrator failed: the orchestrator timed out'),
       }),
     );
     expect(invokeWorkflowUpsertSpy).not.toHaveBeenCalled();
@@ -409,5 +413,73 @@ describe('orchestrateNextStep', () => {
     await Promise.all([first, second]);
 
     expect(decideSpy).toHaveBeenCalledTimes(1);
+  });
+  it('persists the failure so the run can explain itself, and clears it on the next decision', async () => {
+    decideSpy.mockRejectedValueOnce(new Error('usage limit reached'));
+    const state = baseState();
+    const { set, get } = harness(state);
+    const orchestrate = orchestrateNextStep(set, get);
+
+    await orchestrate(SESSION_ID, WORKFLOW_RUN_ID);
+
+    expect(updateErrorSpy).toHaveBeenCalledWith(
+      {},
+      WORKFLOW_RUN_ID,
+      expect.stringContaining('usage limit reached'),
+    );
+    const failed = (state['sessions'] as ReadonlyArray<Session>)[0]!.workflowRuns[0]!;
+    expect(failed.orchestrationError).toContain('anthropic');
+
+    decideSpy.mockResolvedValueOnce({
+      decision: { action: 'done', reason: 'all set' },
+      usage: {},
+      model: 'haiku-4.5',
+    });
+    await orchestrate(SESSION_ID, WORKFLOW_RUN_ID);
+
+    expect(updateErrorSpy).toHaveBeenLastCalledWith({}, WORKFLOW_RUN_ID, null);
+    const cleared = (state['sessions'] as ReadonlyArray<Session>)[0]!.workflowRuns[0]!;
+    expect(cleared.orchestrationError).toBeUndefined();
+  });
+
+  it('hands the operator hints of the run to the orchestrator', async () => {
+    const state = baseState();
+    const sessions = state['sessions'] as ReadonlyArray<Session>;
+    state['sessions'] = [
+      {
+        ...sessions[0]!,
+        workflowRuns: [{ ...sessions[0]!.workflowRuns[0]!, orchestratorHints: 'ignore the docs' }],
+      },
+    ];
+    decideSpy.mockResolvedValueOnce({
+      decision: { action: 'done', reason: 'all set' },
+      usage: {},
+      model: 'haiku-4.5',
+    });
+    const { set, get } = harness(state);
+
+    await orchestrateNextStep(set, get)(SESSION_ID, WORKFLOW_RUN_ID);
+
+    expect(decideSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ operatorHints: 'ignore the docs' }),
+    );
+  });
+
+  it('routes the decision through the provider handed by the caller', async () => {
+    decideSpy.mockResolvedValueOnce({
+      decision: { action: 'done', reason: 'all set' },
+      usage: {},
+      model: 'gpt-5.6',
+    });
+    const state = baseState();
+    const { set, get } = harness(state);
+
+    await orchestrateNextStep(set, get)(SESSION_ID, WORKFLOW_RUN_ID, {
+      routing: { providerId: 'codex', model: 'gpt-5.6' },
+    });
+
+    expect(OrchestratorClient).toHaveBeenCalledWith(
+      expect.objectContaining({ providerId: 'codex', model: 'gpt-5.6' }),
+    );
   });
 });

--- a/apps/desktop/src/store/slices/workflows/orchestrateNextStep.ts
+++ b/apps/desktop/src/store/slices/workflows/orchestrateNextStep.ts
@@ -5,6 +5,7 @@ import type {
   AgentRole,
   IsoDateTime,
   ModelCostTier,
+  ModelEffort,
   ProviderId,
   ProviderRunId,
   RoleModelPreferences,
@@ -18,6 +19,7 @@ import type {
 } from '@goodboy/types';
 import {
   OrchestratorClient,
+  OrchestratorProviderError,
   PROVIDER_CAPABILITIES,
   ROLE_DEFAULTS,
   recommendedModelForRole,
@@ -27,12 +29,27 @@ import {
   type OrchestratorModelOption,
   type OrchestratorRoleDefault,
 } from '@goodboy/core';
-import { listOpenQuestionsForSession, updateWorkflowRunOrchestrationOutcome } from '@goodboy/db';
+import {
+  listOpenQuestionsForSession,
+  updateWorkflowRunOrchestrationError,
+  updateWorkflowRunOrchestrationOutcome,
+} from '@goodboy/db';
 import { invokeWorkflowUpsert } from '../../../features/workflows/workflows';
 import { tauriDatabase } from '../../../shared/lib/db';
 import { roleModelsForSession } from '../overrides/roleModelsForSession';
 import { preSpawnWorkflowAgents } from './preSpawnWorkflowAgents';
+import { patchWorkflowRun, withoutKeys } from './patchWorkflowRun';
 import type { GetFn, SetFn } from './types';
+
+export type OrchestratorRouting = {
+  readonly providerId: ProviderId;
+  readonly model: string;
+  readonly effort?: ModelEffort;
+};
+
+export type OrchestrateOptions = {
+  readonly routing?: OrchestratorRouting;
+};
 
 const orchestrationInFlight = new Set<WorkflowRunId>();
 
@@ -128,18 +145,47 @@ const persistOrchestrationOutcome = async ({
   outcome,
 }: PersistOutcomeParams): Promise<void> => {
   await updateWorkflowRunOrchestrationOutcome(tauriDatabase, workflowRunId, outcome);
-  set((state) => ({
-    sessions: state.sessions.map((session) =>
-      session.id === sessionId
-        ? {
-            ...session,
-            workflowRuns: session.workflowRuns.map((run) =>
-              run.id === workflowRunId ? { ...run, orchestrationOutcome: outcome } : run,
-            ),
-          }
-        : session,
-    ),
-  }));
+  patchWorkflowRun({
+    set,
+    sessionId,
+    workflowRunId,
+    patch: (run) => ({ ...run, orchestrationOutcome: outcome }),
+  });
+};
+
+type PersistErrorParams = {
+  readonly set: SetFn;
+  readonly sessionId: SessionId;
+  readonly workflowRunId: WorkflowRunId;
+  readonly message: string | null;
+};
+
+export const persistOrchestrationError = async ({
+  set,
+  sessionId,
+  workflowRunId,
+  message,
+}: PersistErrorParams): Promise<void> => {
+  await updateWorkflowRunOrchestrationError(tauriDatabase, workflowRunId, message);
+  patchWorkflowRun({
+    set,
+    sessionId,
+    workflowRunId,
+    patch: (run) =>
+      message == null
+        ? withoutKeys(run, ['orchestrationError'])
+        : { ...run, orchestrationError: message },
+  });
+};
+
+const failureLabel = (error: unknown): string => {
+  if (error instanceof OrchestratorProviderError) {
+    return `provider refused the request: ${error.detail}`;
+  }
+  if (error instanceof Error && error.message.includes('timed out')) {
+    return 'the orchestrator timed out after 120s';
+  }
+  return error instanceof Error ? error.message : String(error);
 };
 
 type UniqueNameParams = {
@@ -252,7 +298,11 @@ const appendStep = async ({
 };
 
 export const orchestrateNextStep = (set: SetFn, get: GetFn) => {
-  return async (sessionId: SessionId, workflowRunId: WorkflowRunId): Promise<void> => {
+  return async (
+    sessionId: SessionId,
+    workflowRunId: WorkflowRunId,
+    options?: OrchestrateOptions,
+  ): Promise<void> => {
     if (orchestrationInFlight.has(workflowRunId)) {
       return;
     }
@@ -294,8 +344,9 @@ export const orchestrateNextStep = (set: SetFn, get: GetFn) => {
         get().workspaceOverrides?.[session.workspaceId]?.taskModels,
         defaultProvider,
       );
+      const routing = options?.routing ?? taskModel;
       const client = new OrchestratorClient({
-        ...taskModel,
+        ...routing,
         invokeFn: invoke,
         ...(get().sessionWorktrees?.[sessionId]?.[0] != null && {
           workingDir: get().sessionWorktrees[sessionId]![0],
@@ -308,12 +359,14 @@ export const orchestrateNextStep = (set: SetFn, get: GetFn) => {
           processText: workflow.processText ?? '',
           completedSteps,
           openQuestionCount: openQuestions.length,
+          ...(run.orchestratorHints != null && { operatorHints: run.orchestratorHints }),
           providerId: defaultProvider,
           modelMenu: modelMenuFor({ provider: defaultProvider, roleModels }),
           roleDefaults: roleDefaultsFor({ provider: defaultProvider, roleModels }),
         });
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = `${failureLabel(error)} (${routing.providerId}/${routing.model})`;
+        await persistOrchestrationError({ set, sessionId, workflowRunId, message });
         emitDecision({
           get,
           sessionId,
@@ -328,6 +381,12 @@ export const orchestrateNextStep = (set: SetFn, get: GetFn) => {
       }
       const decision = result.decision;
       if (decision == null) {
+        await persistOrchestrationError({
+          set,
+          sessionId,
+          workflowRunId,
+          message: `${routing.providerId}/${routing.model} replied with something that is not a decision`,
+        });
         emitDecision({
           get,
           sessionId,
@@ -344,6 +403,7 @@ export const orchestrateNextStep = (set: SetFn, get: GetFn) => {
         );
         return;
       }
+      await persistOrchestrationError({ set, sessionId, workflowRunId, message: null });
       if (decision.action === 'next') {
         const agent = await appendStep({
           set,

--- a/apps/desktop/src/store/slices/workflows/patchWorkflowRun.ts
+++ b/apps/desktop/src/store/slices/workflows/patchWorkflowRun.ts
@@ -1,0 +1,33 @@
+import type { SessionId, WorkflowRun, WorkflowRunId } from '@goodboy/types';
+import type { SetFn } from './types';
+
+type Params = {
+  readonly set: SetFn;
+  readonly sessionId: SessionId;
+  readonly workflowRunId: WorkflowRunId;
+  readonly patch: (run: WorkflowRun) => WorkflowRun;
+};
+
+export const patchWorkflowRun = ({ set, sessionId, workflowRunId, patch }: Params): void => {
+  set((state) => ({
+    sessions: state.sessions.map((session) =>
+      session.id === sessionId
+        ? {
+            ...session,
+            workflowRuns: session.workflowRuns.map((run) =>
+              run.id === workflowRunId ? patch(run) : run,
+            ),
+          }
+        : session,
+    ),
+  }));
+};
+
+export const withoutKeys = <K extends keyof WorkflowRun>(
+  run: WorkflowRun,
+  keys: ReadonlyArray<K>,
+): WorkflowRun => {
+  const next = { ...run } as Record<string, unknown>;
+  keys.forEach((key) => delete next[key as string]);
+  return next as WorkflowRun;
+};

--- a/apps/desktop/src/store/slices/workflows/scoutTree.fanout.test.ts
+++ b/apps/desktop/src/store/slices/workflows/scoutTree.fanout.test.ts
@@ -114,7 +114,7 @@ describe('fanOutScouts workflowRunId propagation', () => {
     expect(sendTurn).toHaveBeenCalledTimes(3);
     for (const [args] of sendTurn.mock.calls) {
       expect(args.content).toContain('<<scout-domains keywords="auth,db,routing">>');
-      expect(args.content).toContain('2 to 4 bare single-word domain keywords');
+      expect(args.content).toContain('2 to 4 single-word keywords');
     }
   });
 
@@ -212,7 +212,7 @@ describe('advanceScoutTree split decision', () => {
     expect(hoisted.insertArgs).toHaveLength(0);
     expect(sendTurn).toHaveBeenCalledTimes(1);
     const [payload] = sendTurn.mock.calls[0]!;
-    expect(payload.content).toContain('do NOT split');
+    expect(payload.content).toContain('do not split');
   });
 
   it('does not fan out past the depth cap even with a split marker', async () => {

--- a/apps/desktop/src/store/slices/workflows/scoutTree.ts
+++ b/apps/desktop/src/store/slices/workflows/scoutTree.ts
@@ -60,23 +60,19 @@ export const scoutDepth = (runs: ReadonlyArray<Agent>, agentId: AgentId): number
 function composeScoutKickoff(area: ExtractedScoutArea, depth: number): string {
   const canSplit = depth < SCOUT_DEPTH_CAP;
   return [
-    'You are a scout exploring ONE area of a larger search, running in parallel with sibling scouts.',
-    `Area: ${area.area}`,
-    `Objective: ${area.query}`,
-    '',
-    'Read ONLY what this area needs. Never edit files. Report your findings concisely in this single turn.',
+    `**Area** ${area.area} (one of several scouts running in parallel)`,
+    `**Find** ${area.query}`,
     canSplit
-      ? 'If this area is itself too broad, you MAY fan out further: emit on its own line <<scout-split>> followed by a JSON array of {"area","query"} (2 to 6 entries), then <</scout-split>>.'
-      : 'You are at maximum split depth. Do not fan out further: read your scope and summarize directly.',
-    'End your exploration reply with <<scout-domains keywords="auth,db,routing">>, listing 2 to 4 bare single-word domain keywords and no prose inside the attribute.',
+      ? '**Split** allowed via `<<scout-split>>` if this area is itself too broad.'
+      : '**Split** not allowed, you are at max depth. Read your scope and summarize.',
+    '**End with** `<<scout-domains keywords="auth,db,routing">>`, 2 to 4 single-word keywords, no prose.',
   ].join('\n');
 }
 
 function composeSelfExploreKickoff(areas: ReadonlyArray<ExtractedScoutArea>): string {
   const list = areas.map((a) => `- ${a.area}: ${a.query}`).join('\n');
   return [
-    'Multi-scout fan-out is disabled for this workspace, so do NOT split.',
-    'Explore all of these areas yourself in this turn and report one consolidated finding:',
+    '**Explore yourself** fan-out is disabled here, so do not split. Cover every area below in this turn and report one consolidated finding.',
     list,
   ].join('\n');
 }
@@ -119,8 +115,7 @@ function composeSynthesisKickoff(containerName: string, children: ReadonlyArray<
     .map((c) => `[${c.name}] (${c.status})\n${c.outputSummary ?? '(no findings reported)'}`)
     .join('\n\n');
   return [
-    `Your sub-scouts for "${containerName}" finished. Consolidate their findings into ONE report.`,
-    'Do NOT re-read the repo: synthesize only from the summaries below.',
+    `**Consolidate** the sub-scout findings for "${containerName}" into one report, from the summaries below only.`,
     '',
     blocks,
   ].join('\n');

--- a/apps/desktop/src/store/slices/workflows/setWorkflowOrchestratorHints.ts
+++ b/apps/desktop/src/store/slices/workflows/setWorkflowOrchestratorHints.ts
@@ -1,0 +1,26 @@
+import type { SessionId, WorkflowRunId } from '@goodboy/types';
+import { updateWorkflowRunOrchestratorHints } from '@goodboy/db';
+import { tauriDatabase } from '../../../shared/lib/db';
+import { patchWorkflowRun, withoutKeys } from './patchWorkflowRun';
+import type { GetFn, SetFn } from './types';
+
+export const setWorkflowOrchestratorHints = (set: SetFn, get: GetFn) => {
+  return async (sessionId: SessionId, workflowRunId: WorkflowRunId, hints: string) => {
+    const session = get().sessions.find((candidate) => candidate.id === sessionId);
+    const run = session?.workflowRuns.find((candidate) => candidate.id === workflowRunId);
+    if (run == null) {
+      return;
+    }
+    const trimmed = hints.trim();
+    await updateWorkflowRunOrchestratorHints(tauriDatabase, workflowRunId, trimmed || null);
+    patchWorkflowRun({
+      set,
+      sessionId,
+      workflowRunId,
+      patch: (current) =>
+        trimmed === ''
+          ? withoutKeys(current, ['orchestratorHints'])
+          : { ...current, orchestratorHints: trimmed },
+    });
+  };
+};

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -105,6 +105,10 @@ import { createSlotsSlice } from './slices/slots';
 import { createOverridesSlice } from './slices/overrides';
 import { createCredentialsSlice } from './slices/credentials';
 import { createWorkflowsSlice } from './slices/workflows';
+import type {
+  OrchestrateOptions,
+  OrchestratorRouting,
+} from './slices/workflows/orchestrateNextStep';
 import { createSettingsSlice } from './slices/settings';
 import { createConflictsSlice } from './slices/conflicts';
 import { createTranscriptsSlice } from './slices/transcripts';
@@ -277,8 +281,26 @@ export type AppActions = {
     options?: { readonly onlyWhenBlocked?: boolean },
   ): Promise<void>;
   maybeAutoAdvanceWorkflow(sessionId: SessionId): Promise<void>;
-  orchestrateNextStep(sessionId: SessionId, workflowRunId: WorkflowRunId): Promise<void>;
-  retryWorkflowOrchestration(sessionId: SessionId, workflowRunId: WorkflowRunId): Promise<void>;
+  orchestrateNextStep(
+    sessionId: SessionId,
+    workflowRunId: WorkflowRunId,
+    options?: OrchestrateOptions,
+  ): Promise<void>;
+  retryWorkflowOrchestration(
+    sessionId: SessionId,
+    workflowRunId: WorkflowRunId,
+    routing?: OrchestratorRouting,
+  ): Promise<void>;
+  continueWorkflowRun(
+    sessionId: SessionId,
+    workflowRunId: WorkflowRunId,
+    note?: string,
+  ): Promise<void>;
+  setWorkflowOrchestratorHints(
+    sessionId: SessionId,
+    workflowRunId: WorkflowRunId,
+    hints: string,
+  ): Promise<void>;
   reprocessGoalForWorkflow(sessionId: SessionId): Promise<void>;
   loadTranscript(agentId: AgentId, sessionId: SessionId): Promise<void>;
   appendTurnEvent(agentId: AgentId, sessionId: SessionId, event: TurnEvent): void;

--- a/apps/desktop/src/store/turn-helpers.ts
+++ b/apps/desktop/src/store/turn-helpers.ts
@@ -57,16 +57,21 @@ import { buildProviderSpendBreakdown } from './slices/budget';
 import type { SessionNudge } from './types';
 import type { SetFn, GetFn } from './slice-types';
 
-export const buildAttachmentPromptBlock = (refs: ReadonlyArray<MessageAttachment>): string => {
-  const list = refs.map((r) => `- ${r.relPath}`).join('\n');
-  return [
-    '[attached-files]',
-    `The user attached ${refs.length} file${refs.length === 1 ? '' : 's'} to this message.`,
-    'Inspect each path below before answering. Images and PDFs render with your Read tool; for spreadsheets or other binary formats, read or parse the file with the appropriate tool:',
-    list,
-    '[/attached-files]',
-  ].join('\n');
+type AttachmentsBlockParams = {
+  readonly scope: string;
+  readonly paths: ReadonlyArray<string>;
 };
+
+const composeAttachmentsBlock = ({ scope, paths }: AttachmentsBlockParams): string =>
+  `**Attached** (${scope}) read each path with your Read tool before relying on it:\n${paths
+    .map((path) => `- ${path}`)
+    .join('\n')}`;
+
+export const buildAttachmentPromptBlock = (refs: ReadonlyArray<MessageAttachment>): string =>
+  composeAttachmentsBlock({
+    scope: 'this message',
+    paths: refs.map((ref) => ref.relPath),
+  });
 
 export const buildGoalAttachmentsBlock = (
   kind: AgentKind,
@@ -80,13 +85,10 @@ export const buildGoalAttachmentsBlock = (
   if (relevant.length === 0) {
     return '';
   }
-  const list = relevant.map((a) => `- ${a.relPath}`).join('\n');
-  return [
-    '## attachments',
-    `The user attached ${relevant.length} file${relevant.length === 1 ? '' : 's'} to the goal of this session.`,
-    'Read only those relevant to your role; ignore the rest. Inspect each path below with your Read tool before relying on it:',
-    list,
-  ].join('\n');
+  return composeAttachmentsBlock({
+    scope: 'session goal, read only what your role needs',
+    paths: relevant.map((att) => att.relPath),
+  });
 };
 
 export const toRelPath = (absPath: string, workingDir: string): string => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -346,6 +346,7 @@ export {
   ORCHESTRATOR_SYSTEM_PROMPT,
   OrchestratorClient,
   OrchestratorClientSpawnError,
+  OrchestratorProviderError,
   type OrchestratorClientDeps,
   type OrchestratorClientResult,
   type OrchestratorCompletedStep,

--- a/packages/core/src/orchestrator/client.provider-error.test.ts
+++ b/packages/core/src/orchestrator/client.provider-error.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest';
+import { OrchestratorClient, OrchestratorProviderError } from './client';
+
+const input = {
+  goal: 'Ship the change',
+  processText: 'Inspect, implement, test.',
+  completedSteps: [],
+  openQuestionCount: 0,
+  providerId: 'anthropic' as const,
+  modelMenu: [],
+  roleDefaults: [],
+};
+
+describe('OrchestratorClient provider errors', () => {
+  it('surfaces a provider error envelope instead of an unparseable decision', async () => {
+    const invokeFn = vi.fn(async () => ({
+      stdout: JSON.stringify({
+        type: 'result',
+        subtype: 'error_during_execution',
+        is_error: true,
+        result: 'usage limit reached',
+      }),
+      stderr: '',
+      exitCode: 0,
+    }));
+    const client = new OrchestratorClient({
+      providerId: 'anthropic',
+      model: 'haiku-4.5',
+      invokeFn: invokeFn as never,
+    });
+
+    await expect(client.decide(input)).rejects.toBeInstanceOf(OrchestratorProviderError);
+  });
+});

--- a/packages/core/src/orchestrator/client.ts
+++ b/packages/core/src/orchestrator/client.ts
@@ -33,6 +33,13 @@ export type OrchestratorClientDeps = {
   readonly invokeFn: InvokeFn;
 };
 
+export class OrchestratorProviderError extends Error {
+  constructor(public readonly detail: string) {
+    super(detail);
+    this.name = 'OrchestratorProviderError';
+  }
+}
+
 export class OrchestratorClientSpawnError extends Error {
   constructor(
     public readonly exitCode: number | null,
@@ -105,6 +112,9 @@ export class OrchestratorClient {
       throw new OrchestratorClientSpawnError(result.exitCode, result.stderr);
     }
     const extracted = extractAuxOutput({ providerId: this.providerId, stdout: result.stdout });
+    if (extracted.isError) {
+      throw new OrchestratorProviderError(extracted.errorMessage ?? 'provider reported an error');
+    }
     const usage: OrchestratorUsage = {
       ...extracted.usage,
       estimatedCostUsd: computeProviderCostUsd({

--- a/packages/core/src/orchestrator/index.ts
+++ b/packages/core/src/orchestrator/index.ts
@@ -3,6 +3,7 @@ export { buildOrchestratorUserPrompt, ORCHESTRATOR_SYSTEM_PROMPT } from './promp
 export {
   OrchestratorClient,
   OrchestratorClientSpawnError,
+  OrchestratorProviderError,
   type OrchestratorClientDeps,
   type OrchestratorClientResult,
   type OrchestratorUsage,

--- a/packages/core/src/orchestrator/prompt.test.ts
+++ b/packages/core/src/orchestrator/prompt.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { buildOrchestratorUserPrompt } from './prompt';
+import type { OrchestratorInput } from './types';
+
+const input = (overrides: Partial<OrchestratorInput> = {}): OrchestratorInput => ({
+  goal: 'Ship the change',
+  processText: 'Inspect, implement, test.',
+  completedSteps: [],
+  openQuestionCount: 0,
+  providerId: 'anthropic',
+  modelMenu: [],
+  roleDefaults: [],
+  ...overrides,
+});
+
+describe('buildOrchestratorUserPrompt', () => {
+  it('passes the operator hints through and tells the orchestrator they win', () => {
+    const prompt = buildOrchestratorUserPrompt(
+      input({ operatorHints: 'ignore the website, start from the migrations' }),
+    );
+    expect(prompt).toContain('Operator hints');
+    expect(prompt).toContain('ignore the website, start from the migrations');
+  });
+
+  it('leaves the hints section out when there are none', () => {
+    expect(buildOrchestratorUserPrompt(input())).not.toContain('Operator hints');
+    expect(buildOrchestratorUserPrompt(input({ operatorHints: '   ' }))).not.toContain(
+      'Operator hints',
+    );
+  });
+});

--- a/packages/core/src/orchestrator/prompt.ts
+++ b/packages/core/src/orchestrator/prompt.ts
@@ -25,6 +25,7 @@ export const buildOrchestratorUserPrompt = ({
   processText,
   completedSteps,
   openQuestionCount,
+  operatorHints,
   providerId,
   modelMenu,
   roleDefaults,
@@ -70,6 +71,14 @@ export const buildOrchestratorUserPrompt = ({
         rendered.length > 0 ? rendered : '(no output captured)',
       );
     });
+  }
+  const hints = operatorHints?.trim() ?? '';
+  if (hints.length > 0) {
+    lines.push(
+      '',
+      'Operator hints (runtime, they override your own judgement where they conflict):',
+      hints,
+    );
   }
   lines.push('', 'Return the marked decision now.');
   return lines.join('\n');

--- a/packages/core/src/orchestrator/types.ts
+++ b/packages/core/src/orchestrator/types.ts
@@ -46,6 +46,7 @@ export type OrchestratorInput = {
   readonly processText: string;
   readonly completedSteps: ReadonlyArray<OrchestratorCompletedStep>;
   readonly openQuestionCount: number;
+  readonly operatorHints?: string;
   readonly providerId: ProviderId;
   readonly modelMenu: ReadonlyArray<OrchestratorModelOption>;
   readonly roleDefaults: ReadonlyArray<OrchestratorRoleDefault>;

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -59,6 +59,8 @@ export {
   updateSessionWorkflowAutoRun,
   updateSessionWorkflowTriggerMode,
   updateWorkflowRunOrchestrationOutcome,
+  updateWorkflowRunOrchestrationError,
+  updateWorkflowRunOrchestratorHints,
 } from './queries/session-workflow';
 export { insertMessage, listMessagesForAgent, listMessagesForSession } from './queries/message';
 export {

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -91,6 +91,7 @@ import { m090TelemetryContextTokens } from './m090-telemetry-context-tokens';
 import { m091WorkflowExecutionMode } from './m091-workflow-execution-mode';
 import { m092WorkflowNameUniqueLive } from './m092-workflow-name-unique-live';
 import { m093StepOrchestratorReason } from './m093-step-orchestrator-reason';
+import { m094WorkflowOrchestrationState } from './m094-workflow-orchestration-state';
 
 export type Migration = {
   readonly version: number;
@@ -191,4 +192,5 @@ export const migrations: ReadonlyArray<Migration> = [
   { version: 91, sql: m091WorkflowExecutionMode },
   { version: 92, sql: m092WorkflowNameUniqueLive },
   { version: 93, sql: m093StepOrchestratorReason },
+  { version: 94, sql: m094WorkflowOrchestrationState },
 ];

--- a/packages/db/src/migrations/m094-workflow-orchestration-state.ts
+++ b/packages/db/src/migrations/m094-workflow-orchestration-state.ts
@@ -1,0 +1,4 @@
+export const m094WorkflowOrchestrationState = /* sql */ `
+ALTER TABLE session_workflows ADD COLUMN orchestration_error TEXT;
+ALTER TABLE session_workflows ADD COLUMN orchestrator_hints TEXT;
+`;

--- a/packages/db/src/queries/session-workflow.ts
+++ b/packages/db/src/queries/session-workflow.ts
@@ -19,6 +19,8 @@ type SessionWorkflowRow = {
   trigger_mode: string;
   execution_mode: string;
   orchestration_outcome: string | null;
+  orchestration_error: string | null;
+  orchestrator_hints: string | null;
   chain_after_run_id: string | null;
   goal: string | null;
   discarded_at: string | null;
@@ -36,6 +38,10 @@ function toWorkflowRun(row: SessionWorkflowRow): WorkflowRun {
     ...(row.orchestration_outcome != null && {
       orchestrationOutcome: row.orchestration_outcome as WorkflowOrchestrationOutcome,
     }),
+    ...(row.orchestration_error != null &&
+      row.orchestration_error !== '' && { orchestrationError: row.orchestration_error }),
+    ...(row.orchestrator_hints != null &&
+      row.orchestrator_hints !== '' && { orchestratorHints: row.orchestrator_hints }),
     ...(row.chain_after_run_id != null && {
       chainAfterId: row.chain_after_run_id as WorkflowRunId,
     }),
@@ -49,7 +55,7 @@ export const listWorkflowsForSession = async (
   sessionId: SessionId,
 ): Promise<ReadonlyArray<WorkflowRun>> => {
   const rows = await db.select<SessionWorkflowRow>(
-    'SELECT workflow_run_id, workflow_id, ordinal, current_step_ordinal, auto_run, trigger_mode, execution_mode, orchestration_outcome, chain_after_run_id, goal, discarded_at FROM session_workflows WHERE session_id = ? ORDER BY ordinal ASC',
+    'SELECT workflow_run_id, workflow_id, ordinal, current_step_ordinal, auto_run, trigger_mode, execution_mode, orchestration_outcome, orchestration_error, orchestrator_hints, chain_after_run_id, goal, discarded_at FROM session_workflows WHERE session_id = ? ORDER BY ordinal ASC',
     [sessionId],
   );
   return rows.map(toWorkflowRun);
@@ -119,7 +125,7 @@ export const updateWorkflowOrder = async (
   updatedAt: IsoDateTime,
 ): Promise<void> => {
   const existing = await db.select<SessionWorkflowRow>(
-    'SELECT workflow_run_id, workflow_id, ordinal, current_step_ordinal, auto_run, trigger_mode, execution_mode, orchestration_outcome, chain_after_run_id, goal, discarded_at FROM session_workflows WHERE session_id = ?',
+    'SELECT workflow_run_id, workflow_id, ordinal, current_step_ordinal, auto_run, trigger_mode, execution_mode, orchestration_outcome, orchestration_error, orchestrator_hints, chain_after_run_id, goal, discarded_at FROM session_workflows WHERE session_id = ?',
     [sessionId],
   );
   const byRun = new Map(existing.map((r) => [r.workflow_run_id, r]));
@@ -133,7 +139,7 @@ export const updateWorkflowOrder = async (
         continue;
       }
       await db.execute(
-        'INSERT INTO session_workflows (workflow_run_id, session_id, workflow_id, ordinal, current_step_ordinal, auto_run, goal, discarded_at, trigger_mode, chain_after_run_id, execution_mode, orchestration_outcome) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+        'INSERT INTO session_workflows (workflow_run_id, session_id, workflow_id, ordinal, current_step_ordinal, auto_run, goal, discarded_at, trigger_mode, chain_after_run_id, execution_mode, orchestration_outcome, orchestration_error, orchestrator_hints) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
         [
           runId,
           sessionId,
@@ -147,6 +153,8 @@ export const updateWorkflowOrder = async (
           prev.chain_after_run_id,
           prev.execution_mode,
           prev.orchestration_outcome,
+          prev.orchestration_error,
+          prev.orchestrator_hints,
         ],
       );
     }
@@ -222,6 +230,28 @@ export const updateWorkflowRunOrchestrationOutcome = async (
   await db.execute(
     'UPDATE session_workflows SET orchestration_outcome = ? WHERE workflow_run_id = ?',
     [outcome, workflowRunId],
+  );
+};
+
+export const updateWorkflowRunOrchestrationError = async (
+  db: Database,
+  workflowRunId: WorkflowRunId,
+  message: string | null,
+): Promise<void> => {
+  await db.execute(
+    'UPDATE session_workflows SET orchestration_error = ? WHERE workflow_run_id = ?',
+    [message, workflowRunId],
+  );
+};
+
+export const updateWorkflowRunOrchestratorHints = async (
+  db: Database,
+  workflowRunId: WorkflowRunId,
+  hints: string | null,
+): Promise<void> => {
+  await db.execute(
+    'UPDATE session_workflows SET orchestrator_hints = ? WHERE workflow_run_id = ?',
+    [hints, workflowRunId],
   );
 };
 

--- a/packages/types/src/workspace.ts
+++ b/packages/types/src/workspace.ts
@@ -72,6 +72,8 @@ export type WorkflowRun = Readonly<{
   triggerMode: WorkflowTriggerMode;
   executionMode: WorkflowExecutionMode;
   orchestrationOutcome?: WorkflowOrchestrationOutcome;
+  orchestrationError?: string;
+  orchestratorHints?: string;
   chainAfterId?: WorkflowRunId;
   goal?: string;
   discardedAt?: IsoDateTime;


### PR DESCRIPTION
## What

Round on the dynamic orchestrator UX plus two small copy affordances.

**Orchestrator feedback.** A failed decision used to leave the run in exactly the state it has before it ever runs, so token exhaustion, a 120s timeout and a malformed reply were indistinguishable. `m094` adds `orchestration_error` and `orchestrator_hints` on `session_workflows`. `OrchestratorClient` now raises a typed `OrchestratorProviderError` when the provider envelope reports an error instead of handing an empty string to the parser and reporting "unparseable". The failure text carries the provider and model that produced it.

**Orchestrator panel.** The workflow detail gets a panel that always states the phase (deciding / waiting on the running step / idle / failed / blocked / done), shows the failure verbatim, and offers: retry, retry on another connected provider, runtime hints, and a keep-going CTA.

**Runtime hints.** Free text per run, persisted, injected into the orchestrator prompt as operator hints that override its own judgement.

**Continue after done.** Rather than a new chained run, `continueWorkflowRun` reopens the same run: it clears the outcome, folds the note into the hints and asks for the next step. The completed steps stay in the prompt, so the orchestrator continues with full context instead of starting cold.

**No more selection theft.** Spawning a step no longer writes `selectedAgentId` when the operator is parked on the workflows lens with no agent open. Reading a step chat still follows the new step.

**Compact prompts.** Kickoff, cluster, scout and the per-turn preamble move to labelled lines. `CONTEXT_MARKER_HINT` goes from 1485 to 574 chars on every turn, boundaries and attachment blocks roughly halve, and the step `promptPrefix` is no longer sent twice (it was in the turn content and prepended again by `buildStepPrompt`).

**Copy link.** Shared `useCopyLink` + `CopyLinkButton`, wired to the Linear, Sentry, GitLab and GitHub issue panels, the linked-work task row and the PR surfaces (overview line, GitHub studio header, review board).

## Verification

`pnpm typecheck` 5/5, `pnpm test` 3230 tests green, `knip --include files,duplicates,unlisted` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)