### PR TITLE
feat(desktop): orchestrator flow rules, step cap and visible routing

### DIFF
--- a/apps/desktop/src/features/workflows/components/OrchestratorPanel/OrchestratorRoutingRow.tsx
+++ b/apps/desktop/src/features/workflows/components/OrchestratorPanel/OrchestratorRoutingRow.tsx
@@ -1,0 +1,104 @@
+import { useState } from 'react';
+import { PROVIDER_CAPABILITIES, resolveTaskModel } from '@goodboy/core';
+import type { ModelEffort, ProviderId, SessionId, WorkflowRun } from '@goodboy/types';
+import { clampEffort, modelEffortLevels } from '../../../chat/utils/chat-constants';
+import { RoutingPicker } from '../../../../shared/components/RoutingPicker';
+import { useAppStore } from '../../../../store/store';
+
+type Props = {
+  readonly sessionId: SessionId;
+  readonly run: WorkflowRun;
+  readonly disabled: boolean;
+};
+
+const DEFAULT_EFFORT: ModelEffort = 'medium';
+
+const effortForModel = (model: string, requested: ModelEffort): ModelEffort | null =>
+  modelEffortLevels(model) == null ? null : clampEffort(model, requested);
+
+export const OrchestratorRoutingRow = ({ sessionId, run, disabled }: Props) => {
+  const session = useAppStore((state) =>
+    state.sessions.find((current) => current.id === sessionId),
+  );
+  const providers = useAppStore((state) => state.providers);
+  const taskModels = useAppStore((state) =>
+    session == null ? undefined : state.workspaceOverrides?.[session.workspaceId]?.taskModels,
+  );
+  const setWorkflowOrchestratorRouting = useAppStore(
+    (state) => state.setWorkflowOrchestratorRouting,
+  );
+  const defaultProvider = (session?.providerOverride ??
+    session?.providerPreference.defaultProvider ??
+    'anthropic') as ProviderId;
+  const automatic = resolveTaskModel('workflow_orchestrator', taskModels, defaultProvider);
+  const pinned = run.orchestratorRouting ?? null;
+  const [providerId, setProviderId] = useState<ProviderId>(
+    pinned?.providerId ?? automatic.providerId,
+  );
+  const model = pinned?.model ?? '';
+  const recommendedModel = resolveTaskModel('workflow_orchestrator', taskModels, providerId).model;
+  const effortModel = model === '' ? recommendedModel : model;
+  const effortValue = pinned?.effort ?? automatic.effort ?? DEFAULT_EFFORT;
+  const connectedProviders = providers
+    .filter((provider) => provider.connection === 'connected')
+    .map((provider) => provider.id)
+    .filter((candidate) => PROVIDER_CAPABILITIES[candidate].models.length > 0);
+
+  const apply = (next: { readonly model: string; readonly effort?: ModelEffort }) => {
+    void setWorkflowOrchestratorRouting(sessionId, run.id, {
+      providerId,
+      model: next.model,
+      ...(next.effort != null && { effort: next.effort }),
+    });
+  };
+
+  return (
+    <div
+      data-testid="orchestrator-routing"
+      className="flex min-w-0 flex-wrap items-center gap-1.5 text-2xs text-muted-foreground"
+    >
+      <span>decided by</span>
+      <RoutingPicker
+        ariaLabel="orchestrator routing"
+        variant="pill"
+        connectedProviders={connectedProviders}
+        provider={providerId}
+        model={model}
+        effort={{
+          editable: true,
+          value: effortForModel(effortModel, effortValue) ?? effortValue,
+          onChange: (effort) => {
+            const applied = effortForModel(effortModel, effort);
+            apply({
+              model: effortModel,
+              ...(applied != null && { effort: applied }),
+            });
+          },
+        }}
+        recommendation={{ model: recommendedModel }}
+        disabled={disabled}
+        overridden={pinned != null}
+        defaultSummary={`${automatic.providerId} ${automatic.model}`}
+        onReset={() => void setWorkflowOrchestratorRouting(sessionId, run.id, null)}
+        onProvider={(next) => {
+          if (next === '') {
+            return;
+          }
+          setProviderId(next);
+          if (pinned == null) {
+            return;
+          }
+          apply(resolveTaskModel('workflow_orchestrator', taskModels, next));
+        }}
+        onModel={(nextModel) => {
+          if (nextModel === '') {
+            void setWorkflowOrchestratorRouting(sessionId, run.id, null);
+            return;
+          }
+          const carried = pinned?.effort == null ? null : effortForModel(nextModel, pinned.effort);
+          apply({ model: nextModel, ...(carried != null && { effort: carried }) });
+        }}
+      />
+    </div>
+  );
+};

--- a/apps/desktop/src/features/workflows/components/OrchestratorPanel/index.test.tsx
+++ b/apps/desktop/src/features/workflows/components/OrchestratorPanel/index.test.tsx
@@ -33,6 +33,9 @@ beforeEach(() => {
     retryWorkflowOrchestration: vi.fn(async () => undefined),
     continueWorkflowRun: vi.fn(async () => undefined),
     setWorkflowOrchestratorHints: vi.fn(async () => undefined),
+    setWorkflowOrchestratorRouting: vi.fn(async () => undefined),
+    sessions: [],
+    workspaceOverrides: {},
     providers: [
       { id: 'anthropic', connection: 'connected' },
       { id: 'codex', connection: 'missing' },
@@ -59,7 +62,7 @@ describe('OrchestratorPanel', () => {
     );
   });
 
-  it('shows the failure and offers a retry on another provider', () => {
+  it('shows the failure and offers a retry', () => {
     render(
       <OrchestratorPanel
         sessionId={SESSION_ID}
@@ -69,13 +72,8 @@ describe('OrchestratorPanel', () => {
       />,
     );
     expect(screen.getByTestId('orchestrator-error').textContent).toContain('usage limit reached');
-    fireEvent.click(screen.getByTestId('orchestrator-retry-provider'));
-    fireEvent.click(screen.getByRole('button', { name: 'anthropic' }));
-    expect(storeState['retryWorkflowOrchestration']).toHaveBeenCalledWith(
-      SESSION_ID,
-      RUN_ID,
-      expect.objectContaining({ providerId: 'anthropic' }),
-    );
+    fireEvent.click(screen.getByTestId('orchestrator-retry'));
+    expect(storeState['retryWorkflowOrchestration']).toHaveBeenCalledWith(SESSION_ID, RUN_ID);
   });
 
   it('keeps a completed run extendable with a note', () => {

--- a/apps/desktop/src/features/workflows/components/OrchestratorPanel/index.tsx
+++ b/apps/desktop/src/features/workflows/components/OrchestratorPanel/index.tsx
@@ -1,17 +1,9 @@
 import { useState } from 'react';
-import {
-  AlertTriangle,
-  CheckCircle2,
-  ChevronDown,
-  Loader2,
-  Play,
-  RotateCcw,
-  Sparkles,
-} from 'lucide-react';
+import { AlertTriangle, CheckCircle2, Loader2, Play, RotateCcw, Sparkles } from 'lucide-react';
 import { cn } from '@goodboy/ui';
-import { getCheapModel } from '@goodboy/core';
-import type { Agent, ProviderId, SessionId, WorkflowRun } from '@goodboy/types';
+import type { Agent, SessionId, WorkflowRun } from '@goodboy/types';
 import { useAppStore } from '../../../../store/store';
+import { OrchestratorRoutingRow } from './OrchestratorRoutingRow';
 
 type Props = {
   readonly sessionId: SessionId;
@@ -59,16 +51,13 @@ export const OrchestratorPanel = ({ sessionId, run, agents, isOrchestrating }: P
   const retryWorkflowOrchestration = useAppStore((state) => state.retryWorkflowOrchestration);
   const continueWorkflowRun = useAppStore((state) => state.continueWorkflowRun);
   const setWorkflowOrchestratorHints = useAppStore((state) => state.setWorkflowOrchestratorHints);
-  const providers = useAppStore((state) => state.providers);
   const [hintsOpen, setHintsOpen] = useState(false);
   const [hintsDraft, setHintsDraft] = useState(run.orchestratorHints ?? '');
   const [continueNote, setContinueNote] = useState('');
   const [continueOpen, setContinueOpen] = useState(false);
-  const [providerMenuOpen, setProviderMenuOpen] = useState(false);
   const [busy, setBusy] = useState(false);
 
   const phase = phaseOf({ run, agents, isOrchestrating });
-  const connected = providers.filter((provider) => provider.connection === 'connected');
 
   const guard = async (action: () => Promise<void>) => {
     if (busy) return;
@@ -78,16 +67,6 @@ export const OrchestratorPanel = ({ sessionId, run, agents, isOrchestrating }: P
     } finally {
       setBusy(false);
     }
-  };
-
-  const retryWith = (providerId: ProviderId) => {
-    setProviderMenuOpen(false);
-    void guard(() =>
-      retryWorkflowOrchestration(sessionId, run.id, {
-        providerId,
-        model: getCheapModel(providerId),
-      }),
-    );
   };
 
   return (
@@ -114,46 +93,20 @@ export const OrchestratorPanel = ({ sessionId, run, agents, isOrchestrating }: P
         </p>
       ) : null}
 
+      <OrchestratorRoutingRow sessionId={sessionId} run={run} disabled={busy || isOrchestrating} />
+
       <div className="flex flex-wrap items-center gap-1.5">
         {phase === 'failed' || phase === 'blocked' ? (
-          <>
-            <button
-              type="button"
-              disabled={busy}
-              data-testid="orchestrator-retry"
-              onClick={() => void guard(() => retryWorkflowOrchestration(sessionId, run.id))}
-              className="inline-flex items-center gap-1 rounded-md border border-border-soft bg-elevated px-2 py-1 text-2xs font-semibold text-foreground hover:border-border disabled:opacity-60"
-            >
-              <RotateCcw size={11} aria-hidden />
-              retry
-            </button>
-            <div className="relative">
-              <button
-                type="button"
-                disabled={busy || connected.length === 0}
-                data-testid="orchestrator-retry-provider"
-                onClick={() => setProviderMenuOpen((open) => !open)}
-                className="inline-flex items-center gap-1 rounded-md border border-border-soft bg-elevated px-2 py-1 text-2xs font-semibold text-foreground hover:border-border disabled:opacity-60"
-              >
-                retry with another provider
-                <ChevronDown size={11} aria-hidden />
-              </button>
-              {providerMenuOpen ? (
-                <div className="absolute left-0 top-full z-40 mt-1 w-48 rounded-md border border-border-soft bg-background p-1 shadow-lg">
-                  {connected.map((provider) => (
-                    <button
-                      key={provider.id}
-                      type="button"
-                      onClick={() => retryWith(provider.id)}
-                      className="flex w-full items-center rounded px-2 py-1 text-left text-2xs text-foreground hover:bg-muted/50"
-                    >
-                      {provider.id}
-                    </button>
-                  ))}
-                </div>
-              ) : null}
-            </div>
-          </>
+          <button
+            type="button"
+            disabled={busy}
+            data-testid="orchestrator-retry"
+            onClick={() => void guard(() => retryWorkflowOrchestration(sessionId, run.id))}
+            className="inline-flex items-center gap-1 rounded-md border border-border-soft bg-elevated px-2 py-1 text-2xs font-semibold text-foreground hover:border-border disabled:opacity-60"
+          >
+            <RotateCcw size={11} aria-hidden />
+            retry
+          </button>
         ) : null}
 
         {phase === 'done' ? (

--- a/apps/desktop/src/store/slices/workflows/continueWorkflowRun.test.ts
+++ b/apps/desktop/src/store/slices/workflows/continueWorkflowRun.test.ts
@@ -87,20 +87,21 @@ describe('continueWorkflowRun', () => {
     const run = (state['sessions'] as ReadonlyArray<Session>)[0]!.workflowRuns[0]!;
     expect(run.orchestrationOutcome).toBeUndefined();
     expect(run.orchestrationError).toBeUndefined();
-    expect(state['orchestrateNextStep']).toHaveBeenCalledWith(SESSION_ID, RUN_ID);
+    expect(state['orchestrateNextStep']).toHaveBeenCalledWith(SESSION_ID, RUN_ID, {});
   });
 
-  it('folds the note into the hints the orchestrator already has', async () => {
+  it('hands the note to the orchestrator once without pinning it to the hints', async () => {
     const state = baseState({ orchestratorHints: 'skip the docs' });
     const { set, get } = harness(state);
 
     await continueWorkflowRun(set, get)(SESSION_ID, RUN_ID, '  also check the migrations  ');
 
-    expect(updateHintsSpy).toHaveBeenCalledWith(
-      {},
-      RUN_ID,
-      'skip the docs\nalso check the migrations',
-    );
+    expect(updateHintsSpy).not.toHaveBeenCalled();
+    expect(state['orchestrateNextStep']).toHaveBeenCalledWith(SESSION_ID, RUN_ID, {
+      extraHints: 'also check the migrations',
+    });
+    const run = (state['sessions'] as ReadonlyArray<Session>)[0]!.workflowRuns[0]!;
+    expect(run.orchestratorHints).toBe('skip the docs');
   });
 
   it('leaves a static run alone', async () => {

--- a/apps/desktop/src/store/slices/workflows/continueWorkflowRun.ts
+++ b/apps/desktop/src/store/slices/workflows/continueWorkflowRun.ts
@@ -12,17 +12,16 @@ export const continueWorkflowRun = (set: SetFn, get: GetFn) => {
       return;
     }
     const trimmed = note?.trim() ?? '';
-    if (trimmed !== '') {
-      const merged = [run.orchestratorHints, trimmed].filter(Boolean).join('\n');
-      await get().setWorkflowOrchestratorHints(sessionId, workflowRunId, merged);
-    }
     await updateWorkflowRunOrchestrationOutcome(tauriDatabase, workflowRunId, null);
     patchWorkflowRun({
       set,
       sessionId,
       workflowRunId,
-      patch: (current) => withoutKeys(current, ['orchestrationOutcome', 'orchestrationError']),
+      patch: (current) =>
+        withoutKeys(current, ['orchestrationOutcome', 'orchestrationReason', 'orchestrationError']),
     });
-    await get().orchestrateNextStep(sessionId, workflowRunId);
+    await get().orchestrateNextStep(sessionId, workflowRunId, {
+      ...(trimmed !== '' && { extraHints: trimmed }),
+    });
   };
 };

--- a/apps/desktop/src/store/slices/workflows/index.ts
+++ b/apps/desktop/src/store/slices/workflows/index.ts
@@ -14,6 +14,7 @@ import { maybeAutoAdvanceWorkflow } from './maybeAutoAdvanceWorkflow';
 import { continueWorkflowRun } from './continueWorkflowRun';
 import { orchestrateNextStep } from './orchestrateNextStep';
 import { setWorkflowOrchestratorHints } from './setWorkflowOrchestratorHints';
+import { setWorkflowOrchestratorRouting } from './setWorkflowOrchestratorRouting';
 import { reorderSessionWorkflows } from './reorderSessionWorkflows';
 import { restoreWorkflow } from './restoreWorkflow';
 import { retryWorkflowOrchestration } from './retryWorkflowOrchestration';
@@ -55,6 +56,7 @@ export const createWorkflowsSlice = (set: SetFn, get: GetFn) => {
     retryWorkflowOrchestration: retryWorkflowOrchestration(set, get),
     continueWorkflowRun: continueWorkflowRun(set, get),
     setWorkflowOrchestratorHints: setWorkflowOrchestratorHints(set, get),
+    setWorkflowOrchestratorRouting: setWorkflowOrchestratorRouting(set, get),
     retryStepSummary: retryStepSummary(set, get),
   };
 };

--- a/apps/desktop/src/store/slices/workflows/orchestrateNextStep.test.ts
+++ b/apps/desktop/src/store/slices/workflows/orchestrateNextStep.test.ts
@@ -52,7 +52,11 @@ vi.mock('../../../features/workflows/workflows', () => ({
   invokeAgentInsert: invokeAgentInsertSpy,
 }));
 
-import { OrchestratorClient } from '@goodboy/core';
+import {
+  ORCHESTRATOR_STEP_BUDGET,
+  ORCHESTRATOR_STEP_HARD_CAP,
+  OrchestratorClient,
+} from '@goodboy/core';
 import { orchestrateNextStep } from './orchestrateNextStep';
 
 const WORKSPACE_ID = 'workspace-1' as WorkspaceId;
@@ -254,7 +258,7 @@ describe('orchestrateNextStep', () => {
       'All required tests pass.',
       { sessionId: SESSION_ID },
     );
-    expect(updateOutcomeSpy).toHaveBeenCalledWith({}, WORKFLOW_RUN_ID, 'done');
+    expect(updateOutcomeSpy).toHaveBeenCalledWith({}, WORKFLOW_RUN_ID, 'done', expect.any(String));
     const updated = (state['sessions'] as ReadonlyArray<Session>)[0]!.workflowRuns[0]!;
     expect(updated.orchestrationOutcome).toBe('done');
   });
@@ -295,7 +299,12 @@ describe('orchestrateNextStep', () => {
       'A product choice is required.',
       { sessionId: SESSION_ID },
     );
-    expect(updateOutcomeSpy).toHaveBeenCalledWith({}, WORKFLOW_RUN_ID, 'blocked');
+    expect(updateOutcomeSpy).toHaveBeenCalledWith(
+      {},
+      WORKFLOW_RUN_ID,
+      'blocked',
+      expect.any(String),
+    );
     const updated = (state['sessions'] as ReadonlyArray<Session>)[0]!.workflowRuns[0]!;
     expect(updated.orchestrationOutcome).toBe('blocked');
   });
@@ -334,7 +343,7 @@ describe('orchestrateNextStep', () => {
     await orchestrate(SESSION_ID, WORKFLOW_RUN_ID);
 
     expect(decideSpy).toHaveBeenCalledTimes(2);
-    expect(updateOutcomeSpy).toHaveBeenCalledWith({}, WORKFLOW_RUN_ID, 'done');
+    expect(updateOutcomeSpy).toHaveBeenCalledWith({}, WORKFLOW_RUN_ID, 'done', expect.any(String));
   });
 
   it('targets the run latest agent over the session selection for decision events', async () => {
@@ -480,6 +489,92 @@ describe('orchestrateNextStep', () => {
 
     expect(OrchestratorClient).toHaveBeenCalledWith(
       expect.objectContaining({ providerId: 'codex', model: 'gpt-5.6' }),
+    );
+  });
+
+  it('routes the decision through the model pinned on the run', async () => {
+    decideSpy.mockResolvedValueOnce({
+      decision: { action: 'done', reason: 'all set' },
+      usage: {},
+      model: 'gpt-5.6',
+    });
+    const state = baseState();
+    const sessions = state['sessions'] as ReadonlyArray<Session>;
+    state['sessions'] = [
+      {
+        ...sessions[0]!,
+        workflowRuns: [
+          {
+            ...sessions[0]!.workflowRuns[0]!,
+            orchestratorRouting: { providerId: 'codex', model: 'gpt-5.6', effort: 'high' },
+          },
+        ],
+      },
+    ];
+    const { set, get } = harness(state);
+
+    await orchestrateNextStep(set, get)(SESSION_ID, WORKFLOW_RUN_ID);
+
+    expect(OrchestratorClient).toHaveBeenCalledWith(
+      expect.objectContaining({ providerId: 'codex', model: 'gpt-5.6', effort: 'high' }),
+    );
+  });
+
+  it('tells the orchestrator how much of the step budget is spent', async () => {
+    decideSpy.mockResolvedValueOnce({
+      decision: { action: 'done', reason: 'all set' },
+      usage: {},
+      model: 'haiku-4.5',
+    });
+    const state = baseState();
+    const { set, get } = harness(state);
+
+    await orchestrateNextStep(set, get)(SESSION_ID, WORKFLOW_RUN_ID);
+
+    expect(decideSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ stepsUsed: 1, stepBudget: ORCHESTRATOR_STEP_BUDGET }),
+    );
+  });
+
+  it('blocks the run once it reaches the hard step cap instead of asking for more', async () => {
+    const state = baseState();
+    const template = state['phaseTemplates'] as Record<string, ReadonlyArray<Workflow>>;
+    const base = template[WORKSPACE_ID]![0]!;
+    const capped: Workflow = {
+      ...base,
+      steps: Array.from({ length: ORCHESTRATOR_STEP_HARD_CAP }, (_, index) => ({
+        ...base.steps[0]!,
+        id: `step-${index}` as StepId,
+        ordinal: index,
+        name: `Step ${index}`,
+      })),
+    };
+    state['phaseTemplates'] = { [WORKSPACE_ID]: [capped] };
+    const { set, get } = harness(state);
+
+    await orchestrateNextStep(set, get)(SESSION_ID, WORKFLOW_RUN_ID);
+
+    expect(decideSpy).not.toHaveBeenCalled();
+    expect(updateOutcomeSpy).toHaveBeenCalledWith(
+      {},
+      WORKFLOW_RUN_ID,
+      'blocked',
+      expect.stringContaining('hard cap'),
+    );
+  });
+
+  it('refuses to start a step while the budget cap is reached', async () => {
+    const state = baseState();
+    state['budgetAlerts'] = [{ kind: 'session-exceeded', sessionId: SESSION_ID }];
+    const { set, get } = harness(state);
+
+    await orchestrateNextStep(set, get)(SESSION_ID, WORKFLOW_RUN_ID);
+
+    expect(decideSpy).not.toHaveBeenCalled();
+    expect(updateErrorSpy).toHaveBeenCalledWith(
+      {},
+      WORKFLOW_RUN_ID,
+      expect.stringContaining('budget cap'),
     );
   });
 });

--- a/apps/desktop/src/store/slices/workflows/orchestrateNextStep.ts
+++ b/apps/desktop/src/store/slices/workflows/orchestrateNextStep.ts
@@ -5,7 +5,7 @@ import type {
   AgentRole,
   IsoDateTime,
   ModelCostTier,
-  ModelEffort,
+  OrchestratorRouting,
   ProviderId,
   ProviderRunId,
   RoleModelPreferences,
@@ -18,6 +18,8 @@ import type {
   WorkflowRunId,
 } from '@goodboy/types';
 import {
+  ORCHESTRATOR_STEP_BUDGET,
+  ORCHESTRATOR_STEP_HARD_CAP,
   OrchestratorClient,
   OrchestratorProviderError,
   PROVIDER_CAPABILITIES,
@@ -41,14 +43,9 @@ import { preSpawnWorkflowAgents } from './preSpawnWorkflowAgents';
 import { patchWorkflowRun, withoutKeys } from './patchWorkflowRun';
 import type { GetFn, SetFn } from './types';
 
-export type OrchestratorRouting = {
-  readonly providerId: ProviderId;
-  readonly model: string;
-  readonly effort?: ModelEffort;
-};
-
 export type OrchestrateOptions = {
   readonly routing?: OrchestratorRouting;
+  readonly extraHints?: string;
 };
 
 const orchestrationInFlight = new Set<WorkflowRunId>();
@@ -136,6 +133,7 @@ type PersistOutcomeParams = {
   readonly sessionId: SessionId;
   readonly workflowRunId: WorkflowRunId;
   readonly outcome: WorkflowOrchestrationOutcome;
+  readonly reason: string;
 };
 
 const persistOrchestrationOutcome = async ({
@@ -143,13 +141,24 @@ const persistOrchestrationOutcome = async ({
   sessionId,
   workflowRunId,
   outcome,
+  reason,
 }: PersistOutcomeParams): Promise<void> => {
-  await updateWorkflowRunOrchestrationOutcome(tauriDatabase, workflowRunId, outcome);
+  const trimmed = reason.trim();
+  await updateWorkflowRunOrchestrationOutcome(
+    tauriDatabase,
+    workflowRunId,
+    outcome,
+    trimmed === '' ? null : trimmed,
+  );
   patchWorkflowRun({
     set,
     sessionId,
     workflowRunId,
-    patch: (run) => ({ ...run, orchestrationOutcome: outcome }),
+    patch: (run) => ({
+      ...run,
+      orchestrationOutcome: outcome,
+      ...(trimmed !== '' && { orchestrationReason: trimmed }),
+    }),
   });
 };
 
@@ -325,6 +334,40 @@ export const orchestrateNextStep = (set: SetFn, get: GetFn) => {
       if (workflow == null) {
         return;
       }
+      const budgetExceeded = (get().budgetAlerts ?? []).some(
+        (alert) =>
+          alert.dismissedAt === undefined &&
+          ((alert.kind === 'session-exceeded' && alert.sessionId === sessionId) ||
+            alert.kind === 'provider-exceeded'),
+      );
+      if (budgetExceeded) {
+        await persistOrchestrationError({
+          set,
+          sessionId,
+          workflowRunId,
+          message: 'the budget cap is reached, raise it in Budget to keep this run going',
+        });
+        return;
+      }
+      if (workflow.steps.length >= ORCHESTRATOR_STEP_HARD_CAP) {
+        const reason = `the run reached the hard cap of ${ORCHESTRATOR_STEP_HARD_CAP} steps without closing. Review what the steps produced and start a new run for what is left.`;
+        await persistOrchestrationOutcome({
+          set,
+          sessionId,
+          workflowRunId,
+          outcome: 'blocked',
+          reason,
+        });
+        emitDecision({ get, sessionId, workflowRunId, action: 'blocked', reason });
+        void get().emitNotification(
+          'error',
+          'warning',
+          'dynamic workflow hit the step cap',
+          reason,
+          { sessionId },
+        );
+        return;
+      }
       setDeciding({ set, workflowRunId, isDeciding: true });
       const agents = [
         ...runsForWorkflowRun(get().sessionPhaseRuns[sessionId] ?? [], workflowRunId),
@@ -344,7 +387,11 @@ export const orchestrateNextStep = (set: SetFn, get: GetFn) => {
         get().workspaceOverrides?.[session.workspaceId]?.taskModels,
         defaultProvider,
       );
-      const routing = options?.routing ?? taskModel;
+      const routing = options?.routing ?? run.orchestratorRouting ?? taskModel;
+      const hints = [run.orchestratorHints, options?.extraHints]
+        .map((entry) => entry?.trim() ?? '')
+        .filter((entry) => entry !== '')
+        .join('\n');
       const client = new OrchestratorClient({
         ...routing,
         invokeFn: invoke,
@@ -359,10 +406,12 @@ export const orchestrateNextStep = (set: SetFn, get: GetFn) => {
           processText: workflow.processText ?? '',
           completedSteps,
           openQuestionCount: openQuestions.length,
-          ...(run.orchestratorHints != null && { operatorHints: run.orchestratorHints }),
+          ...(hints !== '' && { operatorHints: hints }),
           providerId: defaultProvider,
           modelMenu: modelMenuFor({ provider: defaultProvider, roleModels }),
           roleDefaults: roleDefaultsFor({ provider: defaultProvider, roleModels }),
+          stepsUsed: workflow.steps.length,
+          stepBudget: ORCHESTRATOR_STEP_BUDGET,
         });
       } catch (error) {
         const message = `${failureLabel(error)} (${routing.providerId}/${routing.model})`;
@@ -440,6 +489,7 @@ export const orchestrateNextStep = (set: SetFn, get: GetFn) => {
         sessionId,
         workflowRunId,
         outcome: decision.action,
+        reason: decision.reason,
       });
       emitDecision({
         get,

--- a/apps/desktop/src/store/slices/workflows/retryWorkflowOrchestration.ts
+++ b/apps/desktop/src/store/slices/workflows/retryWorkflowOrchestration.ts
@@ -1,16 +1,11 @@
 import type { SessionId, WorkflowRunId } from '@goodboy/types';
 import { updateWorkflowRunOrchestrationOutcome } from '@goodboy/db';
 import { tauriDatabase } from '../../../shared/lib/db';
-import type { OrchestratorRouting } from './orchestrateNextStep';
 import { patchWorkflowRun, withoutKeys } from './patchWorkflowRun';
 import type { GetFn, SetFn } from './types';
 
 export const retryWorkflowOrchestration = (set: SetFn, get: GetFn) => {
-  return async (
-    sessionId: SessionId,
-    workflowRunId: WorkflowRunId,
-    routing?: OrchestratorRouting,
-  ): Promise<void> => {
+  return async (sessionId: SessionId, workflowRunId: WorkflowRunId): Promise<void> => {
     const session = get().sessions.find((candidate) => candidate.id === sessionId);
     const run = session?.workflowRuns.find((candidate) => candidate.id === workflowRunId);
     if (session == null || run == null || run.executionMode !== 'dynamic') {
@@ -21,8 +16,9 @@ export const retryWorkflowOrchestration = (set: SetFn, get: GetFn) => {
       set,
       sessionId,
       workflowRunId,
-      patch: (current) => withoutKeys(current, ['orchestrationOutcome', 'orchestrationError']),
+      patch: (current) =>
+        withoutKeys(current, ['orchestrationOutcome', 'orchestrationReason', 'orchestrationError']),
     });
-    await get().orchestrateNextStep(sessionId, workflowRunId, routing ? { routing } : undefined);
+    await get().orchestrateNextStep(sessionId, workflowRunId);
   };
 };

--- a/apps/desktop/src/store/slices/workflows/setWorkflowOrchestratorRouting.ts
+++ b/apps/desktop/src/store/slices/workflows/setWorkflowOrchestratorRouting.ts
@@ -1,0 +1,29 @@
+import type { OrchestratorRouting, SessionId, WorkflowRunId } from '@goodboy/types';
+import { updateWorkflowRunOrchestratorRouting } from '@goodboy/db';
+import { tauriDatabase } from '../../../shared/lib/db';
+import { patchWorkflowRun, withoutKeys } from './patchWorkflowRun';
+import type { GetFn, SetFn } from './types';
+
+export const setWorkflowOrchestratorRouting = (set: SetFn, get: GetFn) => {
+  return async (
+    sessionId: SessionId,
+    workflowRunId: WorkflowRunId,
+    routing: OrchestratorRouting | null,
+  ) => {
+    const session = get().sessions.find((candidate) => candidate.id === sessionId);
+    const run = session?.workflowRuns.find((candidate) => candidate.id === workflowRunId);
+    if (run == null) {
+      return;
+    }
+    await updateWorkflowRunOrchestratorRouting(tauriDatabase, workflowRunId, routing);
+    patchWorkflowRun({
+      set,
+      sessionId,
+      workflowRunId,
+      patch: (current) =>
+        routing == null
+          ? withoutKeys(current, ['orchestratorRouting'])
+          : { ...current, orchestratorRouting: routing },
+    });
+  };
+};

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -19,6 +19,7 @@ import type {
   OverrideSettings,
   OpenQuestion,
   OpenQuestionId,
+  OrchestratorRouting,
   PendingResolutionOutcome,
   PermissionScope,
   PlanId,
@@ -105,10 +106,7 @@ import { createSlotsSlice } from './slices/slots';
 import { createOverridesSlice } from './slices/overrides';
 import { createCredentialsSlice } from './slices/credentials';
 import { createWorkflowsSlice } from './slices/workflows';
-import type {
-  OrchestrateOptions,
-  OrchestratorRouting,
-} from './slices/workflows/orchestrateNextStep';
+import type { OrchestrateOptions } from './slices/workflows/orchestrateNextStep';
 import { createSettingsSlice } from './slices/settings';
 import { createConflictsSlice } from './slices/conflicts';
 import { createTranscriptsSlice } from './slices/transcripts';
@@ -286,11 +284,7 @@ export type AppActions = {
     workflowRunId: WorkflowRunId,
     options?: OrchestrateOptions,
   ): Promise<void>;
-  retryWorkflowOrchestration(
-    sessionId: SessionId,
-    workflowRunId: WorkflowRunId,
-    routing?: OrchestratorRouting,
-  ): Promise<void>;
+  retryWorkflowOrchestration(sessionId: SessionId, workflowRunId: WorkflowRunId): Promise<void>;
   continueWorkflowRun(
     sessionId: SessionId,
     workflowRunId: WorkflowRunId,
@@ -300,6 +294,11 @@ export type AppActions = {
     sessionId: SessionId,
     workflowRunId: WorkflowRunId,
     hints: string,
+  ): Promise<void>;
+  setWorkflowOrchestratorRouting(
+    sessionId: SessionId,
+    workflowRunId: WorkflowRunId,
+    routing: OrchestratorRouting | null,
   ): Promise<void>;
   reprocessGoalForWorkflow(sessionId: SessionId): Promise<void>;
   loadTranscript(agentId: AgentId, sessionId: SessionId): Promise<void>;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -343,6 +343,8 @@ export {
 export {
   parseOrchestratorDecision,
   buildOrchestratorUserPrompt,
+  ORCHESTRATOR_STEP_BUDGET,
+  ORCHESTRATOR_STEP_HARD_CAP,
   ORCHESTRATOR_SYSTEM_PROMPT,
   OrchestratorClient,
   OrchestratorClientSpawnError,

--- a/packages/core/src/orchestrator/client.provider-error.test.ts
+++ b/packages/core/src/orchestrator/client.provider-error.test.ts
@@ -9,6 +9,8 @@ const input = {
   providerId: 'anthropic' as const,
   modelMenu: [],
   roleDefaults: [],
+  stepsUsed: 0,
+  stepBudget: 8,
 };
 
 describe('OrchestratorClient provider errors', () => {

--- a/packages/core/src/orchestrator/client.test.ts
+++ b/packages/core/src/orchestrator/client.test.ts
@@ -30,6 +30,8 @@ describe('OrchestratorClient', () => {
       providerId: 'anthropic',
       modelMenu: [{ id: 'haiku-4.5', label: 'Haiku 4.5', note: 'cheap, fast' }],
       roleDefaults: [{ role: 'implementer', model: 'sonnet-5', effort: 'medium' }],
+      stepsUsed: 0,
+      stepBudget: 8,
     });
 
     const args = request?.['args'] as Record<string, unknown> | undefined;
@@ -65,6 +67,8 @@ describe('OrchestratorClient', () => {
       providerId: 'anthropic',
       modelMenu: [{ id: 'haiku-4.5', label: 'Haiku 4.5', note: 'cheap, fast' }],
       roleDefaults: [{ role: 'implementer', model: 'sonnet-5', effort: 'medium' }],
+      stepsUsed: 0,
+      stepBudget: 8,
     });
 
     const args = request?.['args'] as Record<string, unknown> | undefined;
@@ -88,6 +92,8 @@ describe('OrchestratorClient', () => {
       providerId: 'codex',
       modelMenu: [],
       roleDefaults: [],
+      stepsUsed: 0,
+      stepBudget: 8,
     });
 
     expect(result.decision).toBeNull();
@@ -112,6 +118,8 @@ describe('OrchestratorClient', () => {
         providerId: 'codex',
         modelMenu: [],
         roleDefaults: [],
+        stepsUsed: 0,
+        stepBudget: 8,
       }),
     ).rejects.toThrow('orchestrator decision timed out');
   });

--- a/packages/core/src/orchestrator/index.ts
+++ b/packages/core/src/orchestrator/index.ts
@@ -1,5 +1,6 @@
 export { parseOrchestratorDecision } from './parser';
 export { buildOrchestratorUserPrompt, ORCHESTRATOR_SYSTEM_PROMPT } from './prompt';
+export { ORCHESTRATOR_STEP_BUDGET, ORCHESTRATOR_STEP_HARD_CAP } from './limits';
 export {
   OrchestratorClient,
   OrchestratorClientSpawnError,

--- a/packages/core/src/orchestrator/limits.ts
+++ b/packages/core/src/orchestrator/limits.ts
@@ -1,0 +1,3 @@
+export const ORCHESTRATOR_STEP_BUDGET = 8;
+
+export const ORCHESTRATOR_STEP_HARD_CAP = 12;

--- a/packages/core/src/orchestrator/prompt.test.ts
+++ b/packages/core/src/orchestrator/prompt.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildOrchestratorUserPrompt } from './prompt';
+import { buildOrchestratorUserPrompt, ORCHESTRATOR_SYSTEM_PROMPT } from './prompt';
 import type { OrchestratorInput } from './types';
 
 const input = (overrides: Partial<OrchestratorInput> = {}): OrchestratorInput => ({
@@ -10,6 +10,8 @@ const input = (overrides: Partial<OrchestratorInput> = {}): OrchestratorInput =>
   providerId: 'anthropic',
   modelMenu: [],
   roleDefaults: [],
+  stepsUsed: 0,
+  stepBudget: 8,
   ...overrides,
 });
 
@@ -27,5 +29,39 @@ describe('buildOrchestratorUserPrompt', () => {
     expect(buildOrchestratorUserPrompt(input({ operatorHints: '   ' }))).not.toContain(
       'Operator hints',
     );
+  });
+
+  it('states how much of the step budget is already spent', () => {
+    const prompt = buildOrchestratorUserPrompt(input({ stepsUsed: 5, stepBudget: 8 }));
+
+    expect(prompt).toContain('Step budget: 5 used of 8');
+  });
+
+  it('presents the role defaults as the operator configuration', () => {
+    const prompt = buildOrchestratorUserPrompt(
+      input({ roleDefaults: [{ role: 'implementer', model: 'sonnet-5', effort: 'medium' }] }),
+    );
+
+    expect(prompt).toContain('Role defaults (operator configured');
+    expect(prompt).toContain('implementer=sonnet-5/medium');
+  });
+});
+
+describe('ORCHESTRATOR_SYSTEM_PROMPT', () => {
+  it('dictates the flow rules that keep a run from running forever', () => {
+    expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain('Stay inside the step budget');
+    expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain(
+      'Never reopen work a completed step already covers',
+    );
+    expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain('planner step');
+  });
+
+  it('makes the operator role defaults the routing baseline', () => {
+    expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain("the operator's own configuration");
+    expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain('When you deviate you must say so in reason');
+  });
+
+  it('gives reason an operator facing contract', () => {
+    expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain('reason is written for the operator');
   });
 });

--- a/packages/core/src/orchestrator/prompt.ts
+++ b/packages/core/src/orchestrator/prompt.ts
@@ -5,13 +5,22 @@ const OLDER_SUMMARY_PREVIEW_LENGTH = 280;
 
 export const ORCHESTRATOR_SYSTEM_PROMPT = `You are the workflow orchestrator for an AI coding workspace. You never execute the work yourself: dedicated agents run each step and report back. You have no tools and no repository access, and you must not ask for either. Your only job is to emit the next decision from the information given.
 
-After each completed step, including kickoff when no steps exist, decide the single next step. Return done when the goal and operator process are satisfied or when the process says to stop. Return blocked only when progress requires a human decision, never because you lack repository access. Keep steps small and purposeful.
+After each completed step, including kickoff when no steps exist, decide the single next step or end the run. Keep steps small and purposeful.
+
+Flow rules, in this order of precedence:
+1. Stay inside the step budget given in the request. Once the used count reaches the budget, return done and name what is left instead of opening another step.
+2. Discovery, then a decision, then work. Unless the goal is already a located one-file fix or the operator process says otherwise, the run starts with a scout or investigator step and the step after it is a planner step that turns those findings into the work to do. Do not go from discovery straight to an implementer.
+3. Never reopen work a completed step already covers. If the gap left behind is small, return done and name that gap in the reason.
+4. One review or test pass per implementation. Wanting a second review of the same work means the run should end.
+5. Return done when the goal and the operator process are satisfied, when what is left needs the operator to decide, or when the process says to stop. Return blocked only when progress requires a human decision, never because you lack repository access.
 
 Roles are limited to: scout, planner, implementer, reviewer, investigator, tester, custom.
 
 For a next step, promptPrefix is the instruction the step agent starts from and expectedOutput tells the post-step summarizer exactly what to extract.
 
-You also route the step. model and effort are optional: omit both to accept the role default listed in the request. Set model only to one of the listed model ids and effort only to one of the listed effort levels. Pick a stronger model when the step genuinely needs it (planning, cross-file reasoning, tricky debugging) and a cheap one for lookup, scouting and mechanical edits.
+Routing: the role defaults in the request are the operator's own configuration, so they are your default and not a suggestion. Omit model and effort to accept them, which is the right call for almost every step. Set model or effort only when the role default genuinely cannot serve this step, for example a mechanical rename that does not need the default reasoning model or a cross-file refactor that needs a stronger one. When you deviate you must say so in reason, naming the model you picked and why in one clause. Set model only to one of the listed model ids and effort only to one of the listed effort levels.
+
+reason is written for the operator, not for you. Say why this step is needed now: what the step before it left open, what this one settles. One or two sentences, plain markdown, never a recap of what already happened. For done and blocked, say what the run achieved and what is left.
 
 Respond immediately with exactly one marked JSON object on a single line, using \\n escapes for any newlines inside strings, and nothing else:
 <<orchestrator>>{"action":"next","reason":"...","step":{"name":"...","role":"implementer","promptPrefix":"...","expectedOutput":"...","model":"...","effort":"medium"}}<</orchestrator>>
@@ -29,6 +38,8 @@ export const buildOrchestratorUserPrompt = ({
   providerId,
   modelMenu,
   roleDefaults,
+  stepsUsed,
+  stepBudget,
 }: OrchestratorInput): string => {
   const lines = [
     'Goal:',
@@ -38,6 +49,8 @@ export const buildOrchestratorUserPrompt = ({
     processText.trim(),
     '',
     `Open questions: ${openQuestionCount}`,
+    '',
+    `Step budget: ${stepsUsed} used of ${stepBudget}`,
     '',
     `Models (provider ${providerId}):`,
   ];
@@ -52,7 +65,7 @@ export const buildOrchestratorUserPrompt = ({
     '',
     `Effort levels: ${providerEffortLevels({ provider: providerId }).join(', ')}`,
     '',
-    'Role defaults:',
+    'Role defaults (operator configured, keep them unless the step cannot be served by them):',
     roleDefaults.length === 0
       ? '(none)'
       : roleDefaults.map((entry) => `${entry.role}=${entry.model}/${entry.effort}`).join(', '),

--- a/packages/core/src/orchestrator/types.ts
+++ b/packages/core/src/orchestrator/types.ts
@@ -50,4 +50,6 @@ export type OrchestratorInput = {
   readonly providerId: ProviderId;
   readonly modelMenu: ReadonlyArray<OrchestratorModelOption>;
   readonly roleDefaults: ReadonlyArray<OrchestratorRoleDefault>;
+  readonly stepsUsed: number;
+  readonly stepBudget: number;
 };

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -61,6 +61,7 @@ export {
   updateWorkflowRunOrchestrationOutcome,
   updateWorkflowRunOrchestrationError,
   updateWorkflowRunOrchestratorHints,
+  updateWorkflowRunOrchestratorRouting,
 } from './queries/session-workflow';
 export { insertMessage, listMessagesForAgent, listMessagesForSession } from './queries/message';
 export {

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -92,6 +92,7 @@ import { m091WorkflowExecutionMode } from './m091-workflow-execution-mode';
 import { m092WorkflowNameUniqueLive } from './m092-workflow-name-unique-live';
 import { m093StepOrchestratorReason } from './m093-step-orchestrator-reason';
 import { m094WorkflowOrchestrationState } from './m094-workflow-orchestration-state';
+import { m095WorkflowOrchestratorRouting } from './m095-workflow-orchestrator-routing';
 
 export type Migration = {
   readonly version: number;
@@ -193,4 +194,5 @@ export const migrations: ReadonlyArray<Migration> = [
   { version: 92, sql: m092WorkflowNameUniqueLive },
   { version: 93, sql: m093StepOrchestratorReason },
   { version: 94, sql: m094WorkflowOrchestrationState },
+  { version: 95, sql: m095WorkflowOrchestratorRouting },
 ];

--- a/packages/db/src/migrations/m095-workflow-orchestrator-routing.ts
+++ b/packages/db/src/migrations/m095-workflow-orchestrator-routing.ts
@@ -1,0 +1,6 @@
+export const m095WorkflowOrchestratorRouting = /* sql */ `
+ALTER TABLE session_workflows ADD COLUMN orchestration_reason TEXT;
+ALTER TABLE session_workflows ADD COLUMN orchestrator_provider TEXT;
+ALTER TABLE session_workflows ADD COLUMN orchestrator_model TEXT;
+ALTER TABLE session_workflows ADD COLUMN orchestrator_effort TEXT;
+`;

--- a/packages/db/src/queries/session-workflow.test.ts
+++ b/packages/db/src/queries/session-workflow.test.ts
@@ -17,6 +17,7 @@ import {
   updateSessionWorkflowTriggerMode,
   updateWorkflowOrder,
   updateWorkflowRunOrchestrationOutcome,
+  updateWorkflowRunOrchestratorRouting,
 } from './session-workflow';
 
 const workspaceId = 'ws-1' as WorkspaceId;
@@ -349,6 +350,88 @@ describe('session_workflows trigger-mode queries', () => {
       const runs = await listWorkflowsForSession(db, sessionId);
       const first = runs.find((r) => r.id === ('run-1' as WorkflowRunId));
       expect(first!.orchestrationOutcome).toBe('done');
+    });
+  });
+
+  describe('orchestrator reason and routing', () => {
+    const attachDynamic = async () =>
+      attachWorkflowToSession(
+        db,
+        sessionId,
+        'run-1' as WorkflowRunId,
+        workflowId,
+        true,
+        NOW,
+        undefined,
+        'immediate',
+        undefined,
+        'dynamic',
+      );
+
+    it('keeps the reason the orchestrator gave for ending the run', async () => {
+      await attachDynamic();
+      await updateWorkflowRunOrchestrationOutcome(
+        db,
+        'run-1' as WorkflowRunId,
+        'done',
+        'the fix and its test are in, the docs are left',
+      );
+      const run = (await listWorkflowsForSession(db, sessionId))[0]!;
+      expect(run.orchestrationReason).toBe('the fix and its test are in, the docs are left');
+    });
+
+    it('drops the reason when the run is reopened', async () => {
+      await attachDynamic();
+      await updateWorkflowRunOrchestrationOutcome(db, 'run-1' as WorkflowRunId, 'done', 'all set');
+      await updateWorkflowRunOrchestrationOutcome(db, 'run-1' as WorkflowRunId, null);
+      const run = (await listWorkflowsForSession(db, sessionId))[0]!;
+      expect(run.orchestrationReason).toBeUndefined();
+    });
+
+    it('round-trips the routing pinned on the run and clears it', async () => {
+      await attachDynamic();
+      await updateWorkflowRunOrchestratorRouting(db, 'run-1' as WorkflowRunId, {
+        providerId: 'codex',
+        model: 'gpt-5.6',
+        effort: 'high',
+      });
+      expect((await listWorkflowsForSession(db, sessionId))[0]!.orchestratorRouting).toEqual({
+        providerId: 'codex',
+        model: 'gpt-5.6',
+        effort: 'high',
+      });
+      await updateWorkflowRunOrchestratorRouting(db, 'run-1' as WorkflowRunId, null);
+      expect(
+        (await listWorkflowsForSession(db, sessionId))[0]!.orchestratorRouting,
+      ).toBeUndefined();
+    });
+
+    it('carries the reason and the routing through a reorder', async () => {
+      await attachDynamic();
+      await attachWorkflowToSession(
+        db,
+        sessionId,
+        'run-2' as WorkflowRunId,
+        workflowId2,
+        true,
+        NOW,
+      );
+      await updateWorkflowRunOrchestrationOutcome(db, 'run-1' as WorkflowRunId, 'done', 'all set');
+      await updateWorkflowRunOrchestratorRouting(db, 'run-1' as WorkflowRunId, {
+        providerId: 'codex',
+        model: 'gpt-5.6',
+      });
+      await updateWorkflowOrder(
+        db,
+        sessionId,
+        ['run-2' as WorkflowRunId, 'run-1' as WorkflowRunId],
+        NOW,
+      );
+      const run = (await listWorkflowsForSession(db, sessionId)).find(
+        (candidate) => candidate.id === ('run-1' as WorkflowRunId),
+      )!;
+      expect(run.orchestrationReason).toBe('all set');
+      expect(run.orchestratorRouting).toEqual({ providerId: 'codex', model: 'gpt-5.6' });
     });
   });
 

--- a/packages/db/src/queries/session-workflow.ts
+++ b/packages/db/src/queries/session-workflow.ts
@@ -1,5 +1,8 @@
 import type {
   IsoDateTime,
+  ModelEffort,
+  OrchestratorRouting,
+  ProviderId,
   SessionId,
   WorkflowId,
   WorkflowExecutionMode,
@@ -19,14 +22,33 @@ type SessionWorkflowRow = {
   trigger_mode: string;
   execution_mode: string;
   orchestration_outcome: string | null;
+  orchestration_reason: string | null;
   orchestration_error: string | null;
   orchestrator_hints: string | null;
+  orchestrator_provider: string | null;
+  orchestrator_model: string | null;
+  orchestrator_effort: string | null;
   chain_after_run_id: string | null;
   goal: string | null;
   discarded_at: string | null;
 };
 
+const SESSION_WORKFLOW_COLS =
+  'workflow_run_id, workflow_id, ordinal, current_step_ordinal, auto_run, trigger_mode, execution_mode, orchestration_outcome, orchestration_reason, orchestration_error, orchestrator_hints, orchestrator_provider, orchestrator_model, orchestrator_effort, chain_after_run_id, goal, discarded_at';
+
+const toRouting = (row: SessionWorkflowRow): OrchestratorRouting | null => {
+  if (row.orchestrator_provider == null || row.orchestrator_model == null) {
+    return null;
+  }
+  return {
+    providerId: row.orchestrator_provider as ProviderId,
+    model: row.orchestrator_model,
+    ...(row.orchestrator_effort != null && { effort: row.orchestrator_effort as ModelEffort }),
+  };
+};
+
 function toWorkflowRun(row: SessionWorkflowRow): WorkflowRun {
+  const routing = toRouting(row);
   return {
     id: row.workflow_run_id as WorkflowRunId,
     workflowId: row.workflow_id as WorkflowId,
@@ -38,10 +60,13 @@ function toWorkflowRun(row: SessionWorkflowRow): WorkflowRun {
     ...(row.orchestration_outcome != null && {
       orchestrationOutcome: row.orchestration_outcome as WorkflowOrchestrationOutcome,
     }),
+    ...(row.orchestration_reason != null &&
+      row.orchestration_reason !== '' && { orchestrationReason: row.orchestration_reason }),
     ...(row.orchestration_error != null &&
       row.orchestration_error !== '' && { orchestrationError: row.orchestration_error }),
     ...(row.orchestrator_hints != null &&
       row.orchestrator_hints !== '' && { orchestratorHints: row.orchestrator_hints }),
+    ...(routing != null && { orchestratorRouting: routing }),
     ...(row.chain_after_run_id != null && {
       chainAfterId: row.chain_after_run_id as WorkflowRunId,
     }),
@@ -55,7 +80,7 @@ export const listWorkflowsForSession = async (
   sessionId: SessionId,
 ): Promise<ReadonlyArray<WorkflowRun>> => {
   const rows = await db.select<SessionWorkflowRow>(
-    'SELECT workflow_run_id, workflow_id, ordinal, current_step_ordinal, auto_run, trigger_mode, execution_mode, orchestration_outcome, orchestration_error, orchestrator_hints, chain_after_run_id, goal, discarded_at FROM session_workflows WHERE session_id = ? ORDER BY ordinal ASC',
+    `SELECT ${SESSION_WORKFLOW_COLS} FROM session_workflows WHERE session_id = ? ORDER BY ordinal ASC`,
     [sessionId],
   );
   return rows.map(toWorkflowRun);
@@ -125,7 +150,7 @@ export const updateWorkflowOrder = async (
   updatedAt: IsoDateTime,
 ): Promise<void> => {
   const existing = await db.select<SessionWorkflowRow>(
-    'SELECT workflow_run_id, workflow_id, ordinal, current_step_ordinal, auto_run, trigger_mode, execution_mode, orchestration_outcome, orchestration_error, orchestrator_hints, chain_after_run_id, goal, discarded_at FROM session_workflows WHERE session_id = ?',
+    `SELECT ${SESSION_WORKFLOW_COLS} FROM session_workflows WHERE session_id = ?`,
     [sessionId],
   );
   const byRun = new Map(existing.map((r) => [r.workflow_run_id, r]));
@@ -139,7 +164,7 @@ export const updateWorkflowOrder = async (
         continue;
       }
       await db.execute(
-        'INSERT INTO session_workflows (workflow_run_id, session_id, workflow_id, ordinal, current_step_ordinal, auto_run, goal, discarded_at, trigger_mode, chain_after_run_id, execution_mode, orchestration_outcome, orchestration_error, orchestrator_hints) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+        'INSERT INTO session_workflows (workflow_run_id, session_id, workflow_id, ordinal, current_step_ordinal, auto_run, goal, discarded_at, trigger_mode, chain_after_run_id, execution_mode, orchestration_outcome, orchestration_reason, orchestration_error, orchestrator_hints, orchestrator_provider, orchestrator_model, orchestrator_effort) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
         [
           runId,
           sessionId,
@@ -153,8 +178,12 @@ export const updateWorkflowOrder = async (
           prev.chain_after_run_id,
           prev.execution_mode,
           prev.orchestration_outcome,
+          prev.orchestration_reason,
           prev.orchestration_error,
           prev.orchestrator_hints,
+          prev.orchestrator_provider,
+          prev.orchestrator_model,
+          prev.orchestrator_effort,
         ],
       );
     }
@@ -226,10 +255,22 @@ export const updateWorkflowRunOrchestrationOutcome = async (
   db: Database,
   workflowRunId: WorkflowRunId,
   outcome: WorkflowOrchestrationOutcome | null,
+  reason: string | null = null,
 ): Promise<void> => {
   await db.execute(
-    'UPDATE session_workflows SET orchestration_outcome = ? WHERE workflow_run_id = ?',
-    [outcome, workflowRunId],
+    'UPDATE session_workflows SET orchestration_outcome = ?, orchestration_reason = ? WHERE workflow_run_id = ?',
+    [outcome, reason, workflowRunId],
+  );
+};
+
+export const updateWorkflowRunOrchestratorRouting = async (
+  db: Database,
+  workflowRunId: WorkflowRunId,
+  routing: OrchestratorRouting | null,
+): Promise<void> => {
+  await db.execute(
+    'UPDATE session_workflows SET orchestrator_provider = ?, orchestrator_model = ?, orchestrator_effort = ? WHERE workflow_run_id = ?',
+    [routing?.providerId ?? null, routing?.model ?? null, routing?.effort ?? null, workflowRunId],
   );
 };
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -29,6 +29,7 @@ export type {
   GitlabWorkspaceIntegration,
   LinearIntegrationConfig,
   LinearWorkspaceIntegration,
+  OrchestratorRouting,
   Session,
   SentryIntegrationConfig,
   SessionExternalTask,

--- a/packages/types/src/workspace.ts
+++ b/packages/types/src/workspace.ts
@@ -9,7 +9,7 @@ import type {
   WorkspaceScriptId,
 } from './ids';
 import type { SessionProviderPreference } from './provider-preference';
-import type { ModelEffort } from './provider-registry';
+import type { ModelEffort, ProviderId } from './provider-registry';
 import type { ClaudePermissionMode } from './permission';
 
 export type WorkspaceKind = 'repo' | 'composite' | 'simple';
@@ -63,6 +63,12 @@ export type WorkflowExecutionMode = 'static' | 'dynamic';
 
 export type WorkflowOrchestrationOutcome = 'done' | 'blocked';
 
+export type OrchestratorRouting = Readonly<{
+  providerId: ProviderId;
+  model: string;
+  effort?: ModelEffort;
+}>;
+
 export type WorkflowRun = Readonly<{
   id: WorkflowRunId;
   workflowId: WorkflowId;
@@ -72,8 +78,10 @@ export type WorkflowRun = Readonly<{
   triggerMode: WorkflowTriggerMode;
   executionMode: WorkflowExecutionMode;
   orchestrationOutcome?: WorkflowOrchestrationOutcome;
+  orchestrationReason?: string;
   orchestrationError?: string;
   orchestratorHints?: string;
+  orchestratorRouting?: OrchestratorRouting;
   chainAfterId?: WorkflowRunId;
   goal?: string;
   discardedAt?: IsoDateTime;


### PR DESCRIPTION
An orchestrated run had no reason to stop and no reason to plan. This gives it both, and puts the model that decides the run where you can see and change it.

## What changes

**Flow rules instead of an invitation.** The system prompt said only "keep steps small and purposeful", so a simple task went scout, implement, review, implement, review, without ever planning and without ever closing. It now carries ordered rules: stay inside the step budget echoed in the user prompt, run discovery then a planner step before any implementation, never reopen work a completed step covers, one review pass per implementation, and an explicit sufficiency criterion for `done`.

**The operator's model is the baseline.** `Pick a stronger model when the step genuinely needs it` next to a menu that labels the priciest model `deepest reasoning` is an invitation, and the orchestrator took it: an implementation step spawned on a model the operator never picked. The role defaults are now presented as the operator's own configuration, deviating is allowed only when the default cannot serve the step, and a deviation has to be named in `reason`.

**`reason` has a contract.** It had none: the prompt only showed `"reason":"..."` as a placeholder, which is why "why these steps" reads like a recap of the previous step. It is now defined as operator-facing, one or two sentences, why this step now.

**A cap that is code, not a suggestion.** `ORCHESTRATOR_STEP_BUDGET` (8) is what the prompt sees; `ORCHESTRATOR_STEP_HARD_CAP` (12) is enforced in the store: past it the run is blocked with the reason instead of asking for another step. The manual `next step` CTA also passes the budget-alert gate that only the autorun path had.

**The closing reason survives.** `done` and `blocked` reasons lived only in a transcript event and a notification. m095 persists `orchestration_reason`, so a finished run can say why it finished.

**The orchestrator model is visible and changeable mid-run.** It was only reachable from Provider Studio defaults, and `retry with another provider` always forced that provider's cheap model. m095 pins provider, model and effort on the run; the orchestrator card carries the routing picker; retry reuses what is pinned. The separate provider menu is gone, the picker does that job.

**The keep-going note is one-shot.** It used to be concatenated into the runtime hints forever, with no way to remove it short of clearing the whole field.

## Not in this PR

- The orchestrator's own token usage is still discarded (`result.usage` is read and dropped). Surfacing that cost needs a place to put it.
- The card layout, the "why these steps" rendering and the CTA consolidation land in the next PR of the stack.

## Verified

`pnpm typecheck` 5/5, `pnpm test` 401 files / 3245 tests, `pnpm knip --include files,duplicates,unlisted` clean.