### PR TITLE
fix(desktop): one truth for the provider and model of a step

### DIFF
--- a/apps/desktop/src-tauri/src/bridge/snapshot.rs
+++ b/apps/desktop/src-tauri/src/bridge/snapshot.rs
@@ -175,6 +175,7 @@ pub fn build() -> Result<Snapshot, BridgeError> {
     let agents = rows(
         &conn,
         "SELECT id, session_id, step_id, ordinal, name, kind, status, provider_run_id, output_summary, \
+         effort, model_override, provider_override, \
          group_id, parallel_index, parent_agent_id, workflow_run_id, started_at, completed_at, deleted_at \
          FROM agents WHERE deleted_at IS NULL",
     )?;

--- a/apps/desktop/src-tauri/src/workflows.rs
+++ b/apps/desktop/src-tauri/src/workflows.rs
@@ -220,6 +220,11 @@ pub struct PhaseRunInsertInput {
     pub completed_at: Option<String>,
     pub kind: Option<String>,
     pub verbosity: Option<String>,
+    pub effort: Option<String>,
+    #[serde(rename = "modelOverride")]
+    pub model_override: Option<String>,
+    #[serde(rename = "providerOverride")]
+    pub provider_override: Option<String>,
     #[serde(rename = "parentAgentId")]
     pub parent_agent_id: Option<String>,
     #[serde(rename = "workflowRunId")]
@@ -966,6 +971,14 @@ pub fn agent_list_for_session(
     rows.collect::<Result<Vec<_>, _>>().map_err(PhaseError::Db)
 }
 
+const AGENT_INSERT_SQL: &str = "INSERT INTO agents
+   (id, session_id, step_id, ordinal, name, status,
+    provider_run_id, output_summary, started_at, completed_at, kind, verbosity,
+    effort, model_override, provider_override,
+    parent_agent_id, workflow_run_id, source_thread_id, source_thread_ids, source_comment_url, source_kind,
+    domains_json)
+ VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22)";
+
 #[tauri::command]
 pub fn agent_insert(
     state: State<'_, Db>,
@@ -975,12 +988,7 @@ pub fn agent_insert(
     let id = input.id.clone().unwrap_or_else(crate::util::uuid_v4);
 
     conn.execute(
-        "INSERT INTO agents
-           (id, session_id, step_id, ordinal, name, status,
-            provider_run_id, output_summary, started_at, completed_at, kind, verbosity,
-            parent_agent_id, workflow_run_id, source_thread_id, source_thread_ids, source_comment_url, source_kind,
-            domains_json)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19)",
+        AGENT_INSERT_SQL,
         rusqlite::params![
             id,
             input.session_id,
@@ -994,6 +1002,9 @@ pub fn agent_insert(
             input.completed_at,
             input.kind,
             input.verbosity,
+            input.effort,
+            input.model_override,
+            input.provider_override,
             input.parent_agent_id,
             input.workflow_run_id,
             input.source_thread_id,
@@ -1022,9 +1033,9 @@ pub fn agent_insert(
         done_at: None,
         kind: input.kind,
         verbosity: input.verbosity,
-        effort: None,
-        model_override: None,
-        provider_override: None,
+        effort: input.effort,
+        model_override: input.model_override,
+        provider_override: input.provider_override,
         parent_agent_id: input.parent_agent_id,
         workflow_run_id: input.workflow_run_id,
         source_thread_id: input.source_thread_id,
@@ -1313,5 +1324,48 @@ mod tests {
         assert!(row.model_override.is_none());
         assert!(row.provider_override.is_none());
         assert!(row.provider_session_provider_id.is_none());
+    }
+
+    #[test]
+    fn agent_insert_sql_writes_the_routing_columns() {
+        let conn = agents_table_conn();
+        conn.execute(
+            AGENT_INSERT_SQL,
+            rusqlite::params![
+                "a3",
+                "s1",
+                "step-1",
+                0,
+                "implement",
+                "pending",
+                None::<String>,
+                None::<String>,
+                None::<String>,
+                None::<String>,
+                "implementer",
+                None::<String>,
+                "high",
+                "gpt-5.6",
+                "codex",
+                None::<String>,
+                "run-1",
+                None::<String>,
+                None::<String>,
+                None::<String>,
+                None::<String>,
+                None::<String>,
+            ],
+        )
+        .unwrap();
+
+        let sql = format!("SELECT {cols} FROM agents WHERE id = ?1", cols = AGENT_SESSION_COLS);
+        let mut stmt = conn.prepare(&sql).unwrap();
+        let row = stmt
+            .query_row(rusqlite::params!["a3"], session_row_from_row)
+            .unwrap();
+
+        assert_eq!(row.effort.as_deref(), Some("high"));
+        assert_eq!(row.model_override.as_deref(), Some("gpt-5.6"));
+        assert_eq!(row.provider_override.as_deref(), Some("codex"));
     }
 }

--- a/apps/desktop/src/features/chat/components/ChatInput/hooks/useAgentSwitchSync.ts
+++ b/apps/desktop/src/features/chat/components/ChatInput/hooks/useAgentSwitchSync.ts
@@ -49,10 +49,12 @@ export function useAgentSwitchSync({
     const outgoingAgentId = lastAgentIdRef.current;
     lastAgentIdRef.current = selectedAgentId;
 
-    if (outgoingAgentId !== null) {
+    const outgoingProvider = currentProviderRef.current;
+    const outgoingModel = currentModelRef.current;
+    if (outgoingAgentId !== null && (outgoingProvider !== null || outgoingModel !== null)) {
       void storeSetAgentConfig(session.id, outgoingAgentId, {
-        providerOverride: currentProviderRef.current,
-        modelOverride: currentModelRef.current,
+        providerOverride: outgoingProvider,
+        modelOverride: outgoingModel,
         effort: currentEffortRef.current,
       });
     }

--- a/apps/desktop/src/features/chat/components/ChatInput/hooks/useTurnRouting.ts
+++ b/apps/desktop/src/features/chat/components/ChatInput/hooks/useTurnRouting.ts
@@ -118,7 +118,12 @@ export const useTurnRouting = ({ session }: Params) => {
         }).selection
       : storedSelection.selection;
   const routingOverride: TurnProviderOverride | undefined = allowOverride
-    ? { providerId: effectiveProvider, model: effectiveModel, selection: effectiveSelection }
+    ? {
+        providerId: effectiveProvider,
+        model: effectiveModel,
+        selection: effectiveSelection,
+        explicit: selectedProvider !== null || selectedModel !== null,
+      }
     : undefined;
 
   const connectedProviderIds = connectedProviders.map((p) => p.id);

--- a/apps/desktop/src/features/session/components/AgentMetrics/index.tsx
+++ b/apps/desktop/src/features/session/components/AgentMetrics/index.tsx
@@ -1,5 +1,5 @@
 import { cn } from '@goodboy/ui';
-import type { Agent, TelemetryRecord } from '@goodboy/types';
+import type { Agent, ProviderId, TelemetryRecord } from '@goodboy/types';
 import { getModelProvider } from '@goodboy/core';
 import type { ProviderContextUsage } from '../../../workspace/components/WorkspacesSidebar/parts/ContextWindowBar';
 import { CostBadge } from '../../../providers/components/CostBadge';
@@ -25,6 +25,7 @@ type Props = {
   readonly turnsLoading: boolean;
   readonly density: 'compact' | 'full';
   readonly plannedModel?: string | null;
+  readonly plannedProvider?: ProviderId | null;
   readonly muted?: boolean;
 };
 
@@ -37,6 +38,7 @@ export const AgentMetrics = ({
   turnsLoading,
   density,
   plannedModel = null,
+  plannedProvider = null,
   muted = false,
 }: Props) => {
   const dominant = contextUsage[0] ?? null;
@@ -44,6 +46,7 @@ export const AgentMetrics = ({
   const provider =
     telemetry?.provider ??
     dominant?.provider ??
+    plannedProvider ??
     (plannedModel != null ? getModelProvider(plannedModel) : undefined);
   const summary = contextUsageSummary({ usage: contextUsage });
   const pct = summary == null ? null : Math.round(summary.pct * 100);

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowRunDetail.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowRunDetail.test.tsx
@@ -1,88 +1,48 @@
 // @vitest-environment happy-dom
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
-import type { AgentId, Session, WorkflowRunId } from '@goodboy/types';
-
-const { selectAgent } = vi.hoisted(() => ({ selectAgent: vi.fn(async () => undefined) }));
+import { cleanup, render, screen } from '@testing-library/react';
+import type { Session, WorkflowRunId } from '@goodboy/types';
 
 type AgentsSectionMockProps = {
-  readonly inspectedStepId: AgentId | null;
-  readonly onInspectStep: (agentId: AgentId) => void;
+  readonly workflowRunId: WorkflowRunId;
+  readonly workflowVariant: string;
+  readonly showWorkflowAttach: boolean;
 };
-
-type InspectorMockProps = {
-  readonly agentId: AgentId;
-  readonly onClose: () => void;
-  readonly onOpenChat: () => void;
-};
-
-vi.mock('../../../../../store', () => ({
-  EMPTY_ARRAY: Object.freeze([]),
-  useAppStore: (selector: (state: Record<string, unknown>) => unknown) => selector({ selectAgent }),
-}));
 
 vi.mock('@goodboy/ui', () => ({
-  ResizeHandle: () => <div role="separator" />,
   ScrollFade: ({ children }: { readonly children: React.ReactNode }) => <div>{children}</div>,
 }));
 
 vi.mock('../../../../workspace/components/WorkspacesSidebar/parts/AgentsSection', () => ({
-  AgentsSection: ({ inspectedStepId, onInspectStep }: AgentsSectionMockProps) => (
-    <button type="button" data-inspected={inspectedStepId} onClick={() => onInspectStep(STEP_ID)}>
-      pick step
-    </button>
-  ),
-}));
-
-vi.mock('../../../../workflows/components/WorkflowStepInspector', () => ({
-  WorkflowStepInspector: ({ agentId, onClose, onOpenChat }: InspectorMockProps) => (
-    <div data-testid="step-inspector" data-agent-id={agentId}>
-      <button type="button" onClick={onOpenChat}>
-        open chat
-      </button>
-      <button type="button" onClick={onClose}>
-        close
-      </button>
-    </div>
+  AgentsSection: ({
+    workflowRunId,
+    workflowVariant,
+    showWorkflowAttach,
+  }: AgentsSectionMockProps) => (
+    <div
+      data-testid="agents-section"
+      data-run-id={workflowRunId}
+      data-variant={workflowVariant}
+      data-attach={String(showWorkflowAttach)}
+    />
   ),
 }));
 
 import { WorkflowRunDetail } from './WorkflowRunDetail';
 
-const SESSION_ID = 'session-1';
-const STEP_ID = 'agent-1' as AgentId;
 const RUN_ID = 'run-1' as WorkflowRunId;
+const session = { id: 'session-1' } as unknown as Session;
 
-const session = { id: SESSION_ID } as unknown as Session;
-
-afterEach(() => {
-  selectAgent.mockClear();
-  cleanup();
-});
+afterEach(cleanup);
 
 describe('WorkflowRunDetail', () => {
-  it('opens the step detail beside the run and keeps the chat one click away', () => {
+  it('shows the steps of the focused run without a second detail surface', () => {
     render(<WorkflowRunDetail session={session} workflowRunId={RUN_ID} />);
 
-    expect(screen.queryByTestId('step-inspector')).toBeNull();
-
-    fireEvent.click(screen.getByRole('button', { name: 'pick step' }));
-
-    expect(screen.getByTestId('step-inspector').getAttribute('data-agent-id')).toBe(STEP_ID);
-
-    fireEvent.click(screen.getByRole('button', { name: 'open chat' }));
-
-    expect(selectAgent).toHaveBeenCalledWith(SESSION_ID, STEP_ID);
-  });
-
-  it('closes the step detail without leaving the run', () => {
-    render(<WorkflowRunDetail session={session} workflowRunId={RUN_ID} />);
-
-    fireEvent.click(screen.getByRole('button', { name: 'pick step' }));
-    fireEvent.click(screen.getByRole('button', { name: 'close' }));
-
-    expect(screen.queryByTestId('step-inspector')).toBeNull();
-    expect(screen.getByRole('button', { name: 'pick step' })).toBeDefined();
+    const section = screen.getByTestId('agents-section');
+    expect(section.getAttribute('data-run-id')).toBe(RUN_ID);
+    expect(section.getAttribute('data-variant')).toBe('detail');
+    expect(section.getAttribute('data-attach')).toBe('false');
   });
 });

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowRunDetail.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowRunDetail.tsx
@@ -1,47 +1,22 @@
-import { useState } from 'react';
-import type { AgentId, Session, SessionId, WorkflowRunId } from '@goodboy/types';
+import type { Session, WorkflowRunId } from '@goodboy/types';
 import { ScrollFade } from '@goodboy/ui';
-import { useAppStore } from '../../../../../store';
-import { WorkflowStepInspector } from '../../../../workflows/components/WorkflowStepInspector';
 import { AgentsSection } from '../../../../workspace/components/WorkspacesSidebar/parts/AgentsSection';
-import { InspectorSplit } from './InspectorSplit';
 
 type Props = {
   readonly session: Session;
   readonly workflowRunId: WorkflowRunId;
 };
 
-export const WorkflowRunDetail = ({ session, workflowRunId }: Props) => {
-  const [inspectedStepId, setInspectedStepId] = useState<AgentId | null>(null);
-  const selectAgent = useAppStore((state) => state.selectAgent);
-
-  return (
-    <InspectorSplit
-      open={inspectedStepId !== null}
-      panel={
-        inspectedStepId !== null ? (
-          <WorkflowStepInspector
-            session={session}
-            agentId={inspectedStepId}
-            onClose={() => setInspectedStepId(null)}
-            onOpenChat={() => void selectAgent(session.id as SessionId, inspectedStepId)}
-          />
-        ) : null
-      }
-    >
-      <ScrollFade className="h-full min-w-0" viewportClassName="px-6 py-5" fadeSize={24}>
-        <div className="mx-auto flex w-full max-w-5xl flex-col gap-5 motion-safe:animate-studio-in">
-          <AgentsSection
-            task={session}
-            only="workflows"
-            workflowRunId={workflowRunId}
-            workflowVariant="detail"
-            showWorkflowAttach={false}
-            inspectedStepId={inspectedStepId}
-            onInspectStep={setInspectedStepId}
-          />
-        </div>
-      </ScrollFade>
-    </InspectorSplit>
-  );
-};
+export const WorkflowRunDetail = ({ session, workflowRunId }: Props) => (
+  <ScrollFade className="h-full min-w-0" viewportClassName="px-6 py-5" fadeSize={24}>
+    <div className="mx-auto flex w-full max-w-5xl flex-col gap-5 motion-safe:animate-studio-in">
+      <AgentsSection
+        task={session}
+        only="workflows"
+        workflowRunId={workflowRunId}
+        workflowVariant="detail"
+        showWorkflowAttach={false}
+      />
+    </div>
+  </ScrollFade>
+);

--- a/apps/desktop/src/features/workflows/components/WorkflowStepInspector/index.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowStepInspector/index.tsx
@@ -14,15 +14,15 @@ import { RoutingBadge } from '../../../../shared/components/RoutingBadge';
 import { formatAbsoluteDateTime } from '../../../../shared/utils/relativeDate';
 import { useAttachedWorkflowRuns } from '../../useAttachedWorkflowRuns';
 import { isWorkflowStepAgent } from '../../isWorkflowStepAgent';
+import { resolveStepRouting } from '../../resolveStepRouting';
+import { roleModelsForSession } from '../../../../store/slices/overrides/roleModelsForSession';
 
 type Props = {
   readonly session: Session;
   readonly agentId: AgentId;
-  readonly onClose?: () => void;
-  readonly onOpenChat?: () => void;
 };
 
-export const WorkflowStepInspector = ({ session, agentId, onClose, onOpenChat }: Props) => {
+export const WorkflowStepInspector = ({ session, agentId }: Props) => {
   const agent = useAppStore(
     (state) =>
       (state.sessionPhaseRuns[session.id] ?? (EMPTY_ARRAY as ReadonlyArray<Agent>)).find(
@@ -37,6 +37,7 @@ export const WorkflowStepInspector = ({ session, agentId, onClose, onOpenChat }:
     (state) => state.agentProviderOverride?.[agentId] ?? agent?.providerOverride ?? null,
   );
   const attachedRuns = useAttachedWorkflowRuns({ session });
+  const roleModels = useAppStore((state) => roleModelsForSession({ state, sessionId: session.id }));
   const metrics = useAgentMetrics({ sessionId: session.id });
 
   if (agent == null || !isWorkflowStepAgent({ agent })) {
@@ -58,29 +59,25 @@ export const WorkflowStepInspector = ({ session, agentId, onClose, onOpenChat }:
   const contextUsage = metrics.providerUsageByAgentId.get(agentId) ?? EMPTY_ARRAY;
   const dominantUsage = contextUsage[0] ?? null;
   const kind = classifyAgent(agent, kindOverride);
-  const model = telemetry?.model ?? dominantUsage?.model ?? step.modelOverride ?? modelOverride;
-  const provider = telemetry?.provider ?? dominantUsage?.provider ?? providerOverride;
+  const planned = resolveStepRouting({
+    step,
+    kind,
+    roleModels,
+    agentModel: modelOverride,
+    agentProvider: providerOverride,
+  });
+  const model = telemetry?.model ?? dominantUsage?.model ?? planned.model;
+  const provider = telemetry?.provider ?? dominantUsage?.provider ?? planned.provider;
   const instructions = step.promptPrefix.trim();
   const expectedOutput = step.expectedOutput?.trim() ?? '';
   const outputSummary = agent.outputSummary?.trim() ?? '';
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      <InspectorHeader title={step.name} closeLabel="close step details" onClose={onClose} />
+      <InspectorHeader title={step.name} />
       <ScrollFade className="min-h-0 flex-1" viewportClassName="px-3 py-3">
         <div className="flex flex-col gap-4">
           <InspectorSection question="What it is">
-            {onOpenChat == null ? null : (
-              <button
-                type="button"
-                onClick={onOpenChat}
-                data-testid="workflow-step-open-chat"
-                className="flex items-center gap-1.5 self-start rounded-md bg-primary/10 px-2 py-1 text-2xs font-medium text-primary transition-colors hover:bg-primary/15"
-              >
-                <MessagesSquare size={11} aria-hidden />
-                Open the step chat
-              </button>
-            )}
             <div className="flex flex-wrap items-center gap-1.5">
               <AgentKindChip kind={kind} />
               <AgentStatusBadge status={agent.status} />

--- a/apps/desktop/src/features/workflows/components/WorkflowStepStrip/WorkflowStepStripItem.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowStepStrip/WorkflowStepStripItem.tsx
@@ -1,5 +1,5 @@
 import { cn } from '@goodboy/ui';
-import type { Agent } from '@goodboy/types';
+import type { Agent, ProviderId } from '@goodboy/types';
 import type { AgentKind } from '../../../session/agent-kind';
 import { AgentKindChip } from '../../../session/components/AgentKindChip';
 import { RoutingBadge } from '../../../../shared/components/RoutingBadge';
@@ -8,6 +8,7 @@ import { WorkflowStepStatusGlyph } from './WorkflowStepStatusGlyph';
 type Props = {
   readonly run: Agent;
   readonly kind: AgentKind;
+  readonly provider: ProviderId;
   readonly model: string;
   readonly children: ReadonlyArray<Agent>;
   readonly isSelected: boolean;
@@ -17,6 +18,7 @@ type Props = {
 export const WorkflowStepStripItem = ({
   run,
   kind,
+  provider,
   model,
   children,
   isSelected,
@@ -45,7 +47,7 @@ export const WorkflowStepStripItem = ({
           <WorkflowStepStatusGlyph status={run.status} />
         )}
       </span>
-      <RoutingBadge model={model} className="max-w-28 shrink-0" />
+      <RoutingBadge provider={provider} model={model} className="max-w-28 shrink-0" />
     </button>
   );
 };

--- a/apps/desktop/src/features/workflows/components/WorkflowStepStrip/index.test.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowStepStrip/index.test.tsx
@@ -12,6 +12,7 @@ import type {
   WorkflowId,
   WorkspaceId,
 } from '@goodboy/types';
+import { brandColor } from '../../../providers/components/provider-brand';
 import { WorkflowStepStrip } from './index';
 
 const WORKFLOW_ID = 'workflow-1' as WorkflowId;
@@ -81,6 +82,7 @@ describe('WorkflowStepStrip', () => {
         runs={runs}
         childrenByParentId={new Map([[runs[0]!.id, [child]]])}
         agentKindOverride={{}}
+        agentProviderOverride={{}}
         agentModelOverride={{}}
         roleModels={null}
         selectedAgentId={runs[1]!.id}
@@ -94,5 +96,25 @@ describe('WorkflowStepStrip', () => {
     expect(screen.getByText('gpt-5.1-codex')).toBeDefined();
     fireEvent.click(screen.getByRole('button', { name: /scout/i }));
     expect(onSelect).toHaveBeenCalledWith(runs[0]!.id);
+  });
+
+  it('shows the provider the agent runs on instead of guessing it from the model id', () => {
+    render(
+      <WorkflowStepStrip
+        workflow={workflow}
+        runs={runs}
+        childrenByParentId={new Map()}
+        agentKindOverride={{}}
+        agentProviderOverride={{ 'agent-2': 'cursor' }}
+        agentModelOverride={{}}
+        roleModels={null}
+        selectedAgentId={null}
+        onSelect={vi.fn()}
+      />,
+    );
+
+    const chip = screen.getByRole('button', { name: /implement/i });
+    expect(chip.outerHTML).toContain(brandColor('cursor'));
+    expect(chip.outerHTML).not.toContain(brandColor('codex'));
   });
 });

--- a/apps/desktop/src/features/workflows/components/WorkflowStepStrip/index.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowStepStrip/index.tsx
@@ -1,6 +1,13 @@
 import { Fragment } from 'react';
 import { ArrowRight } from 'lucide-react';
-import type { Agent, AgentId, RoleModelPreferences, Step, Workflow } from '@goodboy/types';
+import type {
+  Agent,
+  AgentId,
+  ProviderId,
+  RoleModelPreferences,
+  Step,
+  Workflow,
+} from '@goodboy/types';
 import { inferAgentKindFromName, type AgentKind } from '../../../session/agent-kind';
 import { resolveStepRouting } from '../../resolveStepRouting';
 import { WorkflowStepStripItem } from './WorkflowStepStripItem';
@@ -11,6 +18,7 @@ type Props = {
   readonly childrenByParentId: ReadonlyMap<string, ReadonlyArray<Agent>>;
   readonly agentKindOverride: Readonly<Record<string, AgentKind>>;
   readonly agentModelOverride: Readonly<Record<string, string>>;
+  readonly agentProviderOverride: Readonly<Record<string, ProviderId>>;
   readonly roleModels: RoleModelPreferences | null;
   readonly selectedAgentId: AgentId | null;
   readonly onSelect: (id: AgentId) => void;
@@ -22,6 +30,7 @@ export const WorkflowStepStrip = ({
   childrenByParentId,
   agentKindOverride,
   agentModelOverride,
+  agentProviderOverride,
   roleModels,
   selectedAgentId,
   onSelect,
@@ -38,12 +47,13 @@ export const WorkflowStepStrip = ({
       {sortedRuns.map((run, index) => {
         const kind = agentKindOverride[run.id] ?? inferAgentKindFromName(run.name);
         const step = run.stepId == null ? null : (stepById.get(run.stepId) ?? null);
-        const model = resolveStepRouting({
+        const routing = resolveStepRouting({
           step,
           kind,
           roleModels,
           agentModel: agentModelOverride[run.id] ?? run.modelOverride,
-        }).model;
+          agentProvider: agentProviderOverride[run.id] ?? run.providerOverride,
+        });
 
         return (
           <Fragment key={run.id}>
@@ -53,7 +63,8 @@ export const WorkflowStepStrip = ({
             <WorkflowStepStripItem
               run={run}
               kind={kind}
-              model={model}
+              provider={routing.provider}
+              model={routing.model}
               children={childrenByParentId.get(run.id) ?? []}
               isSelected={selectedAgentId === run.id}
               onSelect={() => onSelect(run.id)}

--- a/apps/desktop/src/features/workflows/resolveStepRouting.test.ts
+++ b/apps/desktop/src/features/workflows/resolveStepRouting.test.ts
@@ -58,4 +58,27 @@ describe('resolveStepRouting', () => {
 
     expect(routing.effort).toBe('xhigh');
   });
+
+  it('reports the provider the agent actually runs on, not one guessed from the model', () => {
+    const routing = resolveStepRouting({
+      step: step({ modelOverride: 'gpt-5.6' }),
+      kind: 'generic',
+      roleModels: null,
+      agentProvider: 'cursor',
+    });
+
+    expect(routing.provider).toBe('cursor');
+    expect(routing.model).toBe('gpt-5.6');
+  });
+
+  it('lets the provider pinned on the step win over the one of the agent', () => {
+    const routing = resolveStepRouting({
+      step: step({ providerOverride: 'codex' }),
+      kind: 'generic',
+      roleModels: null,
+      agentProvider: 'cursor',
+    });
+
+    expect(routing.provider).toBe('codex');
+  });
 });

--- a/apps/desktop/src/features/workflows/resolveStepRouting.ts
+++ b/apps/desktop/src/features/workflows/resolveStepRouting.ts
@@ -1,5 +1,5 @@
 import { recommendedModelForRole, resolveRoleRouting } from '@goodboy/core';
-import type { ModelEffort, RoleModelPreferences, Step } from '@goodboy/types';
+import type { ModelEffort, ProviderId, RoleModelPreferences, Step } from '@goodboy/types';
 import { kindRouting, type AgentKind } from '../session/agent-kind';
 
 type Params = {
@@ -7,21 +7,31 @@ type Params = {
   readonly kind: AgentKind;
   readonly roleModels: RoleModelPreferences | null;
   readonly agentModel?: string | null;
+  readonly agentProvider?: ProviderId | null;
 };
 
 export type StepRouting = {
+  readonly provider: ProviderId;
   readonly model: string;
   readonly effort: ModelEffort;
 };
 
-export const resolveStepRouting = ({ step, kind, roleModels, agentModel }: Params): StepRouting => {
+export const resolveStepRouting = ({
+  step,
+  kind,
+  roleModels,
+  agentModel,
+  agentProvider,
+}: Params): StepRouting => {
   const fallback = kindRouting({ kind, roleModels });
   const role = step?.role;
   const roleRouting = role != null ? resolveRoleRouting({ role, prefs: roleModels }) : null;
-  const provider = step?.providerOverride ?? roleRouting?.provider ?? fallback.provider;
+  const provider =
+    step?.providerOverride ?? agentProvider ?? roleRouting?.provider ?? fallback.provider;
   const roleModel =
     role != null ? recommendedModelForRole({ role, provider, prefs: roleModels }) : null;
   return {
+    provider,
     model: step?.modelOverride ?? agentModel ?? roleModel ?? fallback.model,
     effort: step?.effort ?? roleRouting?.effort ?? fallback.effort,
   };

--- a/apps/desktop/src/features/workflows/workflows.ts
+++ b/apps/desktop/src/features/workflows/workflows.ts
@@ -204,7 +204,7 @@ function rowToAgent(row: RawAgentRow): Agent {
     ...(row.verbosity != null && { verbosity: row.verbosity as VerbosityLevel }),
     ...(row.effort != null && { effort: row.effort as AgentEffort }),
     ...(row.modelOverride != null && { modelOverride: row.modelOverride }),
-    ...(row.providerOverride != null && { providerOverride: row.providerOverride }),
+    ...(row.providerOverride != null && { providerOverride: row.providerOverride as ProviderId }),
     ...(row.sourceThreadId != null && { sourceThreadId: row.sourceThreadId }),
     ...(sourceThreadIds.length > 0 && { sourceThreadIds }),
     ...(row.sourceCommentUrl != null && { sourceCommentUrl: row.sourceCommentUrl }),
@@ -344,6 +344,9 @@ export type AgentInsertArgs = {
   readonly completedAt?: IsoDateTime;
   readonly kind?: string;
   readonly verbosity?: VerbosityLevel;
+  readonly effort?: AgentEffort;
+  readonly modelOverride?: string;
+  readonly providerOverride?: ProviderId;
   readonly sourceThreadId?: string;
   readonly sourceThreadIds?: ReadonlyArray<string>;
   readonly sourceCommentUrl?: string;
@@ -368,6 +371,9 @@ export const invokeAgentInsert = async (run: AgentInsertArgs): Promise<Agent> =>
       completedAt: run.completedAt ?? null,
       kind: run.kind ?? null,
       verbosity: run.verbosity ?? null,
+      effort: run.effort ?? null,
+      modelOverride: run.modelOverride ?? null,
+      providerOverride: run.providerOverride ?? null,
       sourceThreadId: run.sourceThreadId ?? null,
       sourceThreadIds:
         run.sourceThreadIds !== undefined ? JSON.stringify(run.sourceThreadIds) : null,

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.tsx
@@ -22,8 +22,6 @@ type Props = {
   workflowRunId?: WorkflowRunId;
   workflowVariant?: 'sidebar' | 'detail';
   showWorkflowAttach?: boolean;
-  inspectedStepId?: AgentId | null;
-  onInspectStep?: (agentId: AgentId) => void;
 };
 
 export const AgentsSection = ({
@@ -32,8 +30,6 @@ export const AgentsSection = ({
   workflowRunId,
   workflowVariant = 'sidebar',
   showWorkflowAttach = true,
-  inspectedStepId = null,
-  onInspectStep,
 }: Props) => {
   const forceExpanded = only === 'workflows';
   const showSidebarSections = only == null;
@@ -99,6 +95,7 @@ export const AgentsSection = ({
                 onDeleteWorkflow={section.onDeleteWorkflow}
                 agentKindOverride={section.agentKindOverride}
                 agentModelOverride={section.agentModelOverride}
+                agentProviderOverride={section.agentProviderOverride}
                 childrenByParentId={section.childrenByParentId}
                 clusterExpand={section.clusterExpand}
                 selectedAgentId={section.selectedAgentId}
@@ -111,8 +108,6 @@ export const AgentsSection = ({
                 isTranscriptLoading={section.isTranscriptLoading}
                 onStartStepAgent={section.onStartStepAgent}
                 onPickAgent={section.onPickAgent}
-                inspectedStepId={inspectedStepId}
-                onInspectStep={onInspectStep}
                 setEditingId={section.setEditingId}
                 onRenameCommit={section.onRenameCommit}
                 onResolveFirstForRun={section.onResolveFirstForRun}

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.test.tsx
@@ -124,6 +124,7 @@ type RenderParams = {
   readonly childrenByParentId?: ReadonlyMap<string, Agent[]>;
   readonly clusterExpand?: ReadonlyMap<string, boolean>;
   readonly onDeleteWorkflow?: (runId: WorkflowRunId) => Promise<void>;
+  readonly onPickAgent?: (agentId: AgentId) => void;
 };
 
 const renderDetail = ({
@@ -133,6 +134,7 @@ const renderDetail = ({
   childrenByParentId = new Map(),
   clusterExpand = new Map(),
   onDeleteWorkflow = vi.fn(async () => undefined),
+  onPickAgent = vi.fn(),
 }: RenderParams = {}) =>
   render(
     <WorkflowRow
@@ -158,6 +160,7 @@ const renderDetail = ({
       onDeleteWorkflow={onDeleteWorkflow}
       agentKindOverride={{}}
       agentModelOverride={{}}
+      agentProviderOverride={{}}
       childrenByParentId={childrenByParentId}
       clusterExpand={clusterExpand}
       selectedAgentId={null}
@@ -173,7 +176,7 @@ const renderDetail = ({
       turnsByAgentId={new Map()}
       isTranscriptLoading={false}
       onStartStepAgent={vi.fn(async () => undefined)}
-      onPickAgent={vi.fn()}
+      onPickAgent={onPickAgent}
       setEditingId={vi.fn()}
       onRenameCommit={vi.fn(async () => undefined)}
       onResolveFirstForRun={vi.fn()}
@@ -234,6 +237,17 @@ describe('WorkflowRow detail dashboard', () => {
 
     expect(goal.compareDocumentPosition(attachments)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
     expect(attachments.compareDocumentPosition(steps)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+  });
+
+  it('opens the chat of a step when its chip is clicked', () => {
+    const onPickAgent = vi.fn();
+    renderDetail({ onPickAgent });
+
+    const steps = screen.getByTestId('workflow-step-strip');
+    const chips = steps.querySelectorAll('button');
+    fireEvent.click(chips[0] as HTMLElement);
+
+    expect(onPickAgent).toHaveBeenCalledWith(agents[0]!.id);
   });
 
   it('deletes the workflow run after confirmation', () => {

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.tsx
@@ -13,6 +13,7 @@ import {
 import type {
   Agent,
   AgentId,
+  ProviderId,
   Session,
   TelemetryRecord,
   Workflow,
@@ -65,6 +66,7 @@ type Props = {
   readonly onDeleteWorkflow: (runId: WorkflowRunId) => Promise<void>;
   readonly agentKindOverride: Readonly<Record<string, AgentKind>>;
   readonly agentModelOverride: Readonly<Record<string, string>>;
+  readonly agentProviderOverride: Readonly<Record<string, ProviderId>>;
   readonly childrenByParentId: ReadonlyMap<string, Agent[]>;
   readonly clusterExpand: ReadonlyMap<string, boolean>;
   readonly selectedAgentId: AgentId | null;
@@ -77,8 +79,6 @@ type Props = {
   readonly isTranscriptLoading: boolean;
   readonly onStartStepAgent: (agent: Agent, model?: string) => Promise<void>;
   readonly onPickAgent: (id: AgentId) => void;
-  readonly inspectedStepId?: AgentId | null;
-  readonly onInspectStep?: (id: AgentId) => void;
   readonly setEditingId: Dispatch<SetStateAction<AgentId | null>>;
   readonly onRenameCommit: (id: AgentId, name: string) => Promise<void>;
   readonly onResolveFirstForRun: (run: WorkflowRun) => void;
@@ -109,6 +109,7 @@ export const WorkflowRow = ({
   onDeleteWorkflow,
   agentKindOverride,
   agentModelOverride,
+  agentProviderOverride,
   childrenByParentId,
   clusterExpand,
   selectedAgentId,
@@ -121,8 +122,6 @@ export const WorkflowRow = ({
   isTranscriptLoading,
   onStartStepAgent,
   onPickAgent,
-  inspectedStepId = null,
-  onInspectStep,
   setEditingId,
   onRenameCommit,
   onResolveFirstForRun,
@@ -400,9 +399,10 @@ export const WorkflowRow = ({
               childrenByParentId={childrenByParentId}
               agentKindOverride={agentKindOverride}
               agentModelOverride={agentModelOverride}
+              agentProviderOverride={agentProviderOverride}
               roleModels={roleModels}
-              selectedAgentId={onInspectStep == null ? selectedAgentId : inspectedStepId}
-              onSelect={onInspectStep ?? onPickAgent}
+              selectedAgentId={selectedAgentId}
+              onSelect={onPickAgent}
             />
           ) : (
             <div className={cn('flex flex-col gap-1 pb-1', forceExpanded ? 'pl-1' : 'pl-3')}>
@@ -410,12 +410,13 @@ export const WorkflowRow = ({
                 const isActionable = run.stepId === actionableStepId && run.status === 'pending';
                 const kind = agentKindOverride[run.id] ?? inferAgentKindFromName(run.name);
                 const step = run.stepId != null ? stepById.get(run.stepId) : undefined;
-                const resolvedModel = resolveStepRouting({
+                const resolvedRouting = resolveStepRouting({
                   step: step ?? null,
                   kind,
                   roleModels,
                   agentModel: agentModelOverride[run.id] ?? run.modelOverride,
-                }).model;
+                  agentProvider: agentProviderOverride[run.id] ?? run.providerOverride,
+                });
                 const clusterChildren = childrenByParentId.get(run.id) ?? EMPTY_ARRAY;
                 const clustersExpanded = clusterExpand.get(run.id) ?? false;
                 const clusterUnread = countUnread(clusterChildren);
@@ -425,7 +426,8 @@ export const WorkflowRow = ({
                       run={run}
                       kind={kind}
                       index={index}
-                      resolvedModel={resolvedModel}
+                      resolvedModel={resolvedRouting.model}
+                      resolvedProvider={resolvedRouting.provider}
                       isActionable={isActionable}
                       blockReason={isActionable ? wfBlockReason : null}
                       isSelected={run.id === selectedAgentId}

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowStepRow.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowStepRow.test.tsx
@@ -78,6 +78,7 @@ const renderRow = ({
       kind={kind}
       index={0}
       resolvedModel="claude-opus-4-5"
+      resolvedProvider="anthropic"
       isActionable={false}
       blockReason={null}
       isSelected={false}

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowStepRow.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowStepRow.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { StatusDot, cn } from '@goodboy/ui';
 import { AlertTriangle, Check, Clock, Play } from 'lucide-react';
-import type { Agent, TelemetryRecord } from '@goodboy/types';
+import type { Agent, ProviderId, TelemetryRecord } from '@goodboy/types';
 import { agentHasUnread } from '../../../../../store';
 import type { AgentKind } from '../../../../../features/session/agent-kind';
 import { AgentKindChip } from '../../../../../features/session/components/AgentKindChip';
@@ -20,6 +20,7 @@ type Props = {
   readonly kind: AgentKind;
   readonly index: number;
   readonly resolvedModel: string;
+  readonly resolvedProvider: ProviderId;
   readonly isActionable: boolean;
   readonly blockReason: WorkflowBlockReason | null;
   readonly isSelected: boolean;
@@ -43,6 +44,7 @@ export const WorkflowStepRow = ({
   kind,
   index,
   resolvedModel,
+  resolvedProvider,
   isActionable,
   blockReason,
   isSelected,
@@ -244,6 +246,7 @@ export const WorkflowStepRow = ({
             turns={turns}
             turnsLoading={turnsLoading}
             plannedModel={resolvedModel}
+            plannedProvider={resolvedProvider}
             muted={isPendingFuture}
             density={isPendingFuture ? 'compact' : 'full'}
           />

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/useAgentsSection.ts
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/useAgentsSection.ts
@@ -1,6 +1,13 @@
 import { useCallback, useMemo, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
-import type { Agent, AgentId, Session, WorkflowRun, WorkflowRunId } from '@goodboy/types';
+import type {
+  Agent,
+  AgentId,
+  ProviderId,
+  Session,
+  WorkflowRun,
+  WorkflowRunId,
+} from '@goodboy/types';
 import {
   EMPTY_ARRAY,
   useAppStore,
@@ -57,6 +64,22 @@ export const useAgentsSection = ({ task, workflowRunId }: Params) => {
         const model = s.agentModelOverride[run.id];
         if (model) {
           out[run.id] = model;
+        }
+      }
+      return out;
+    }),
+  );
+  const agentProviderOverride = useAppStore(
+    useShallow((s) => {
+      const out: Record<string, ProviderId> = {};
+      const runs = s.sessionPhaseRuns[task.id];
+      if (!runs) {
+        return out;
+      }
+      for (const run of runs) {
+        const provider = s.agentProviderOverride?.[run.id];
+        if (provider) {
+          out[run.id] = provider;
         }
       }
       return out;
@@ -239,6 +262,7 @@ export const useAgentsSection = ({ task, workflowRunId }: Params) => {
     actionableStepIdByRunId,
     agentKindOverride,
     agentModelOverride,
+    agentProviderOverride,
     agentsByRunId: tree.agentsByRunId,
     agentsExpanded,
     attachedRuns,

--- a/apps/desktop/src/store/slices/turn/resolveTurnModelSelection.test.ts
+++ b/apps/desktop/src/store/slices/turn/resolveTurnModelSelection.test.ts
@@ -122,7 +122,7 @@ describe('resolveTurnModelSelection', () => {
     expect(selection.key).toBe('sonnet-4.5');
   });
 
-  it('gives the auto step model precedence over a turn override', () => {
+  it('gives the auto step model precedence over a turn override the user never touched', () => {
     const selection = resolveTurnModelSelection({
       ...BASE_PARAMS,
       autoStepModel: { provider: 'anthropic', model: 'claude-haiku-4-5' },
@@ -130,6 +130,26 @@ describe('resolveTurnModelSelection', () => {
     });
 
     expect(selection.key).toBe('haiku-4.5');
+  });
+
+  it('sends the model the user picked in the composer, not the auto step model', () => {
+    const selection = resolveTurnModelSelection({
+      ...BASE_PARAMS,
+      autoStepModel: { provider: 'anthropic', model: 'claude-haiku-4-5' },
+      turnOverride: { providerId: 'anthropic', model: 'claude-opus-5', explicit: true },
+    });
+
+    expect(selection.key).toBe('opus-5');
+  });
+
+  it('sends the model the user picked in the composer, not the step definition', () => {
+    const selection = resolveTurnModelSelection({
+      ...BASE_PARAMS,
+      phaseModelOverride: 'claude-haiku-4-5',
+      turnOverride: { providerId: 'anthropic', model: 'claude-opus-5', explicit: true },
+    });
+
+    expect(selection.key).toBe('opus-5');
   });
 
   it('gives the turn override precedence over an agent pin', () => {

--- a/apps/desktop/src/store/slices/turn/resolveTurnModelSelection.ts
+++ b/apps/desktop/src/store/slices/turn/resolveTurnModelSelection.ts
@@ -50,37 +50,40 @@ export const resolveTurnModelSelection = ({
   })
     ? agentModelPin
     : null;
+  const turnCandidate: Candidate | null =
+    turnOverride == null
+      ? null
+      : {
+          provider: turnOverride.providerId,
+          id: turnOverride.model ?? turnOverride.selection?.key ?? routingDecision.selectedModel,
+          ...(turnOverride.selection != null && { selection: turnOverride.selection }),
+        };
   const candidate: Candidate =
     retryModel != null
       ? { provider, id: retryModel }
-      : phaseModelOverride != null
-        ? {
-            provider: phaseProviderOverride ?? provider,
-            id: phaseModelOverride,
-          }
-        : autoStepModel != null
+      : turnCandidate != null && turnOverride?.explicit === true
+        ? turnCandidate
+        : phaseModelOverride != null
           ? {
-              provider: autoStepModel.provider,
-              id: autoStepModel.model,
+              provider: phaseProviderOverride ?? provider,
+              id: phaseModelOverride,
             }
-          : turnOverride != null
+          : autoStepModel != null
             ? {
-                provider: turnOverride.providerId,
-                id:
-                  turnOverride.model ??
-                  turnOverride.selection?.key ??
-                  routingDecision.selectedModel,
-                ...(turnOverride.selection != null && { selection: turnOverride.selection }),
+                provider: autoStepModel.provider,
+                id: autoStepModel.model,
               }
-            : applicableAgentModelPin != null
-              ? {
-                  provider: agentProvider ?? provider,
-                  id: applicableAgentModelPin,
-                }
-              : {
-                  provider,
-                  id: routingDecision.selectedModel,
-                };
+            : turnCandidate != null
+              ? turnCandidate
+              : applicableAgentModelPin != null
+                ? {
+                    provider: agentProvider ?? provider,
+                    id: applicableAgentModelPin,
+                  }
+                : {
+                    provider,
+                    id: routingDecision.selectedModel,
+                  };
   const shouldUseRoutingDefault =
     retryModel == null &&
     (routingDecision.fallbackUsed || candidate.provider !== routingDecision.selectedProvider);

--- a/apps/desktop/src/store/slices/workflows/preSpawnWorkflowAgents.test.ts
+++ b/apps/desktop/src/store/slices/workflows/preSpawnWorkflowAgents.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AgentId, SessionId, Step, StepId, WorkflowId, WorkflowRunId } from '@goodboy/types';
+
+const { invokeAgentInsertSpy } = vi.hoisted(() => ({
+  invokeAgentInsertSpy: vi.fn(),
+}));
+
+vi.mock('../../../features/workflows/workflows', () => ({
+  invokeAgentInsert: invokeAgentInsertSpy,
+}));
+
+import { preSpawnWorkflowAgents } from './preSpawnWorkflowAgents';
+
+const SESSION_ID = 'session-1' as SessionId;
+const RUN_ID = 'run-1' as WorkflowRunId;
+
+const step = (patch: Partial<Step> = {}): Step =>
+  ({
+    id: 'step-1' as StepId,
+    workflowId: 'workflow-1' as WorkflowId,
+    ordinal: 0,
+    name: 'Implement the fix',
+    role: 'implementer',
+    promptPrefix: 'Do it.',
+    ...patch,
+  }) as Step;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  invokeAgentInsertSpy.mockImplementation(async (input: Record<string, unknown>) => ({
+    id: 'agent-1' as AgentId,
+    sessionId: input['sessionId'] as SessionId,
+    ordinal: input['ordinal'] as number,
+    name: input['name'] as string,
+    status: 'pending',
+  }));
+});
+
+describe('preSpawnWorkflowAgents', () => {
+  it('writes the resolved routing on the agent row instead of only in memory', async () => {
+    const result = await preSpawnWorkflowAgents({
+      sessionId: SESSION_ID,
+      workflowRunId: RUN_ID,
+      steps: [step({ modelOverride: 'opus-5', effort: 'high' })],
+      baseOrdinal: 0,
+      defaultProvider: 'anthropic',
+      roleModels: null,
+    });
+
+    const insert = invokeAgentInsertSpy.mock.calls[0]![0] as Record<string, unknown>;
+    expect(insert['providerOverride']).toBe('anthropic');
+    expect(insert['modelOverride']).toBe('opus-5');
+    expect(insert['effort']).toBe('high');
+    expect(result.modelOverrides['agent-1']).toBe(insert['modelOverride']);
+    expect(result.providerOverrides['agent-1']).toBe(insert['providerOverride']);
+  });
+
+  it('persists the role default when the step pins no model', async () => {
+    await preSpawnWorkflowAgents({
+      sessionId: SESSION_ID,
+      steps: [step()],
+      baseOrdinal: 0,
+      defaultProvider: 'anthropic',
+      roleModels: null,
+    });
+
+    const insert = invokeAgentInsertSpy.mock.calls[0]![0] as Record<string, unknown>;
+    expect(insert['modelOverride']).toBeTypeOf('string');
+    expect(insert['modelOverride']).not.toBe('');
+    expect(insert['providerOverride']).toBe('anthropic');
+  });
+});

--- a/apps/desktop/src/store/slices/workflows/preSpawnWorkflowAgents.ts
+++ b/apps/desktop/src/store/slices/workflows/preSpawnWorkflowAgents.ts
@@ -52,19 +52,8 @@ export const preSpawnWorkflowAgents = async ({
 
   for (const [index, step] of sortedSteps.entries()) {
     const kind = step.role ? ROLE_TO_KIND[step.role] : inferAgentKindFromName(step.name);
-    const agent = await invokeAgentInsert({
-      sessionId,
-      stepId: step.id,
-      ...(workflowRunId != null && { workflowRunId }),
-      ordinal: baseOrdinal + index,
-      name: step.name,
-      status: 'pending',
-      kind,
-      ...(defaultVerbosity != null && { verbosity: defaultVerbosity }),
-    });
     const provider = step.providerOverride ?? defaultProvider;
-    providerOverrides[agent.id] = provider;
-    modelOverrides[agent.id] = resolveModelForProvider({
+    const model = resolveModelForProvider({
       provider,
       modelId:
         step.modelOverride ??
@@ -76,6 +65,21 @@ export const preSpawnWorkflowAgents = async ({
             })
           : kindRouting({ kind, roleModels }).model),
     });
+    const agent = await invokeAgentInsert({
+      sessionId,
+      stepId: step.id,
+      ...(workflowRunId != null && { workflowRunId }),
+      ordinal: baseOrdinal + index,
+      name: step.name,
+      status: 'pending',
+      kind,
+      ...(defaultVerbosity != null && { verbosity: defaultVerbosity }),
+      providerOverride: provider,
+      modelOverride: model,
+      ...(step.effort != null && { effort: step.effort }),
+    });
+    providerOverrides[agent.id] = provider;
+    modelOverrides[agent.id] = model;
     kindOverrides[agent.id] = kind;
     if (step.effort != null) {
       effortOverrides[agent.id] = step.effort;

--- a/packages/db/src/queries/agent.ts
+++ b/packages/db/src/queries/agent.ts
@@ -99,7 +99,7 @@ const toAgent = ({ row }: ToAgentParams): Agent => {
       effort: row.effort as ModelEffort,
     }),
     ...(row.model_override && { modelOverride: row.model_override }),
-    ...(row.provider_override && { providerOverride: row.provider_override }),
+    ...(row.provider_override && { providerOverride: row.provider_override as ProviderId }),
     ...(row.kind && { kind: row.kind }),
     ...(domains.length > 0 && { domains }),
   };

--- a/packages/types/src/provider-preference.ts
+++ b/packages/types/src/provider-preference.ts
@@ -12,6 +12,7 @@ export type TurnProviderOverride = {
   readonly providerId: ProviderId;
   readonly model?: string;
   readonly selection?: ModelSelection;
+  readonly explicit?: boolean;
 };
 
 export const DEFAULT_SESSION_PROVIDER_PREFERENCE: SessionProviderPreference = {

--- a/packages/types/src/workflow.ts
+++ b/packages/types/src/workflow.ts
@@ -101,7 +101,7 @@ export type Agent = Readonly<{
   verbosity?: VerbosityLevel;
   effort?: ModelEffort;
   modelOverride?: string;
-  providerOverride?: string;
+  providerOverride?: ProviderId;
   kind?: string;
   sourceThreadId?: string;
   sourceThreadIds?: ReadonlyArray<string>;


### PR DESCRIPTION
Stacked on [#1103](https://github.com/akhayam99/goodboy/pull/1103). Review that one first.

## The step that claimed three different models

Same agent, three answers:

- **the strip** rendered `<RoutingBadge model={model} />` with no provider, and `RoutingBadge` falls back to `getModelProvider(model)`. The provider glyph was guessed from the model string, which is why a step running on cursor showed the codex mark next to `gpt-5.6`.
- **the inspector** preferred telemetry, but `model` fell back to `step.modelOverride` while `provider` did not fall back to `step.providerOverride`. Model and provider in the same badge could come from different sources.
- **the composer** ran the id through `resolveModelForProvider`, which silently remaps a foreign model into the current provider's catalog, and `resolveRouting` displays `catalog[0]` when the id is unknown. No signal either way.

`resolveStepRouting` computed a provider internally and threw it away: its return type was `{model, effort}`. It now returns `{provider, model, effort}` and every workflow surface reads that one function. The badge is told the provider instead of inferring it.

## The routing was never written down

`preSpawnWorkflowAgents` put provider, model and effort only into the zustand override maps. `agent_insert` could not write those columns at all (the Rust INSERT omitted them and the returned row hardcoded `None`), so the agent row stayed NULL and `loadPhaseRunsForSession` re-seeded the maps from NULL after a reload. The resolved routing disappeared and the UI fell back to the session default.

The insert now accepts and writes `effort`, `model_override` and `provider_override`, and the spawn path sends them. The SQL moved to a const so a test can prove the column list and the params agree.

## The picker that was ignored

Two paths dropped the user's choice:

- `resolveTurnModelSelection` ranked `autoStepModel` above `turnOverride`, pinned by a test. In a workflow step chat the composer selection lost to the role auto-model every time, deterministically. `TurnProviderOverride` now carries `explicit`, set only when the user actually touched the picker, and an explicit pick outranks both the auto model and the step definition. An untouched picker keeps the old order.
- `useAgentSwitchSync` wrote the outgoing agent's config from the local picker state on every agent switch, and that state is `null` when the user never touched it. `setAgentConfig` then deleted the override entries and nulled the columns, so navigating away from a step chat erased its routing. It now writes only what the user actually chose.

## Also

`Agent.providerOverride` was typed `string` while `Step.providerOverride` was `ProviderId`. Same domain, one type now. The mobile snapshot SELECT was dropping the routing columns; it no longer does.

## Included: the step-click regression from v0.1.51

Clicking a step opened an inspector beside the run, and the chat needed a second click inside that panel. The chat overlay already mounts the same `WorkflowStepInspector` on its right, so that panel was a duplicate of a surface one click away. The click goes back to the chat.

## Verified

`pnpm typecheck` 5/5, `pnpm test` 3252 desktop tests, `cargo test --locked` 157, knip clean.