### PR TITLE
fix(desktop): make the model picker tell the truth

### DIFF
--- a/apps/desktop/src/features/notifications/components/NotificationCenter/index.test.tsx
+++ b/apps/desktop/src/features/notifications/components/NotificationCenter/index.test.tsx
@@ -142,7 +142,7 @@ describe('NotificationCenter', () => {
       fireEvent.click(screen.getByRole('button', { name: /confirm retry with selected model/i }));
     });
 
-    const expected = resolveTaskModel('summarizer', null, 'anthropic');
+    const expected = { ...resolveTaskModel('summarizer', null, 'anthropic'), effort: 'medium' };
     expect(state.retryStepSummary).toHaveBeenCalledWith({
       sessionId: 'session-1',
       agentId: 'agent-1',
@@ -188,9 +188,62 @@ describe('NotificationCenter', () => {
       fireEvent.click(screen.getByRole('button', { name: /confirm retry with selected model/i }));
     });
 
-    const expected = resolveTaskModel('summarizer', null, 'anthropic');
+    const expected = { ...resolveTaskModel('summarizer', null, 'anthropic'), effort: 'medium' };
     expect(state.retrySummarizer).toHaveBeenCalledWith('session-2', expected);
     expect(screen.queryByRole('button', { name: /confirm retry with selected model/i })).toBeNull();
+  });
+
+  it('retry with picker dispatches the selected effort', async () => {
+    state.providers = [{ id: 'anthropic', connection: 'connected' }];
+    state.sessions = [
+      {
+        id: 'session-2',
+        providerPreference: { defaultProvider: 'anthropic', allowTurnOverride: false },
+      },
+    ];
+    state.summarizerStatus = {
+      'session-2': { status: 'error', lastAttempt: { turnInput: 'in', turnOutput: 'out' } },
+    };
+    state.notifications = [
+      {
+        id: 'n2',
+        read: true,
+        severity: 'error',
+        kind: 'error',
+        title: 'summarizer failed',
+        body: 'anthropic: boom',
+        ts: new Date().toISOString(),
+        sessionId: 'session-2',
+        workspaceId: null,
+        action: { kind: 'retry-summarizer', sessionId: 'session-2' },
+      } as unknown as Notification,
+    ];
+
+    render(<NotificationCenter />);
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /notifications/i }));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /retry with/i }));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /retry routing/i }));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Opus 5' }));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'High' }));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /confirm retry with selected model/i }));
+    });
+
+    expect(state.retrySummarizer).toHaveBeenCalledWith('session-2', {
+      providerId: 'anthropic',
+      model: 'claude-opus-5',
+      effort: 'high',
+    });
   });
 
   it('navigates to the session and agent of a row and closes the panel', async () => {

--- a/apps/desktop/src/features/notifications/components/NotificationCenter/index.tsx
+++ b/apps/desktop/src/features/notifications/components/NotificationCenter/index.tsx
@@ -15,7 +15,7 @@ import { Fragment } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import type { Notification, NotificationAction, NotificationSeverity } from '@goodboy/db';
 import { PROVIDER_CAPABILITIES, resolveTaskModel } from '@goodboy/core';
-import type { ProviderId, TaskModelPreference } from '@goodboy/types';
+import type { ModelEffort, ProviderId, TaskModelPreference } from '@goodboy/types';
 import { useAppStore } from '../../../../store';
 import { mapNotificationAction } from '../NotificationToastBridge';
 import { RoutingPicker } from '../../../../shared/components/RoutingPicker';
@@ -361,13 +361,15 @@ function RetryWithPicker({ action, onDone }: RetryWithPickerProps) {
       : availableProviderIds[0];
   const [providerId, setProviderId] = useState<ProviderId | undefined>(initialProvider);
   const [model, setModel] = useState('');
+  const [effort, setEffort] = useState<ModelEffort>('medium');
   if (providerId == null) {
     return null;
   }
   const recommendedModel = resolveTaskModel('summarizer', null, providerId).model;
   const dispatch = () => {
-    const override: TaskModelPreference =
+    const taskModel =
       model === '' ? resolveTaskModel('summarizer', null, providerId) : { providerId, model };
+    const override: TaskModelPreference = { ...taskModel, effort };
     const store = useAppStore.getState();
     if (action.kind === 'retry-summarizer') {
       store.retrySummarizer(action.sessionId, override);
@@ -388,7 +390,7 @@ function RetryWithPicker({ action, onDone }: RetryWithPickerProps) {
           connectedProviders={availableProviderIds}
           provider={providerId}
           model={model}
-          effort={{ editable: false }}
+          effort={{ editable: true, value: effort, onChange: setEffort }}
           recommendation={{ model: recommendedModel }}
           disabled={false}
           onProvider={(next) => {

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/steps/PreferencesStep.test.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/steps/PreferencesStep.test.tsx
@@ -77,21 +77,25 @@ describe('PreferencesStep', () => {
   describe('default provider picker', () => {
     it('disables offline providers and marks them as offline', () => {
       render(<PreferencesStep workspaceId={WS_ID} />);
+      fireEvent.click(screen.getByRole('button', { name: /default provider/i }));
       const codex = screen.getByRole('button', { name: /codex/i }) as HTMLButtonElement;
       const gemini = screen.getByRole('button', { name: /gemini/i }) as HTMLButtonElement;
       expect(codex.disabled).toBe(true);
       expect(gemini.disabled).toBe(true);
-      expect(screen.getAllByText(/offline/i).length).toBe(4);
+      expect(codex.getAttribute('title')).toContain('not connected');
+      expect(gemini.getAttribute('title')).toContain('not connected');
     });
 
     it('leaves connected providers enabled', () => {
       render(<PreferencesStep workspaceId={WS_ID} />);
+      fireEvent.click(screen.getByRole('button', { name: /default provider/i }));
       const cursor = screen.getByRole('button', { name: /cursor/i }) as HTMLButtonElement;
       expect(cursor.disabled).toBe(false);
     });
 
     it('persists the picked provider through setWorkspaceOverrides', async () => {
       render(<PreferencesStep workspaceId={WS_ID} />);
+      fireEvent.click(screen.getByRole('button', { name: /default provider/i }));
       fireEvent.click(screen.getByRole('button', { name: /cursor/i }));
       await waitFor(() =>
         expect(state.setWorkspaceOverrides).toHaveBeenCalledWith(

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/steps/PreferencesStep.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/steps/PreferencesStep.tsx
@@ -1,35 +1,20 @@
 import { useEffect, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
-import type {
-  OverrideSettings,
-  ProviderId,
-  VerbosityLevel,
-  WorkspaceId,
-  WorkspaceKind,
-} from '@goodboy/types';
+import type { OverrideSettings, VerbosityLevel, WorkspaceId, WorkspaceKind } from '@goodboy/types';
 import { DEFAULT_SESSION_PROVIDER_PREFERENCE } from '@goodboy/types';
 import { Button, EmptyState, FieldRow, Switch, cn } from '@goodboy/ui';
 import { FolderGit2, GitBranch, SlidersHorizontal, Sparkles } from 'lucide-react';
-import { ProviderChip } from '../../../providers/components/ProviderChip';
 import { VerbositySelect } from '../../../session/components/VerbositySelect';
 import { formatError } from '../../../../shared/lib/errors';
 import { DEFAULT_BRANCH_PREFIX, settingBranchPrefix } from '../../../settings/settings';
 import { useAppStore } from '../../../../store';
 import { CONCEPT_ICONS } from '../../../../shared/components/conceptIcons';
+import { ProviderPicker } from '../../../../shared/components/RoutingPicker/ProviderPicker';
 
 type Props = {
   readonly workspaceId: WorkspaceId | null;
   readonly workspaceKind?: WorkspaceKind | null;
 };
-
-const PROVIDER_OPTIONS: ReadonlyArray<ProviderId> = [
-  'anthropic',
-  'cursor',
-  'codex',
-  'gemini',
-  'opencode',
-  'openrouter',
-];
 
 const sanitizePrefix = (input: string): string =>
   input
@@ -199,24 +184,13 @@ const PreferencesForm = ({ workspaceId, isSimple }: FormProps) => {
           layout="stacked"
         >
           <div className="flex flex-col gap-2.5">
-            <div className="flex flex-wrap gap-1.5">
-              {PROVIDER_OPTIONS.map((id) => (
-                <ProviderChip
-                  key={id}
-                  id={id}
-                  selected={defaultProvider === id}
-                  disabled={busy || !connectedProviderIds.includes(id)}
-                  onClick={() => void persistOverrides({ defaultProviderId: id })}
-                  trailing={
-                    connectedProviderIds.includes(id) ? null : (
-                      <span className="text-[9px] uppercase tracking-wide text-warning">
-                        offline
-                      </span>
-                    )
-                  }
-                />
-              ))}
-            </div>
+            <ProviderPicker
+              connectedProviders={connectedProviderIds}
+              provider={defaultProvider}
+              disabled={busy}
+              onProvider={(providerId) => void persistOverrides({ defaultProviderId: providerId })}
+              ariaLabel="Default provider"
+            />
             <p className="flex items-start gap-1.5 text-2xs leading-relaxed text-muted-foreground">
               <Sparkles size={12} aria-hidden className="mt-0.5 shrink-0 text-primary" />
               Goodboy routes work across the providers you connect, by priority and budget.

--- a/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/RoutingStatusControl.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/RoutingStatusControl.tsx
@@ -12,25 +12,26 @@ export const RoutingStatusControl = ({ label, isCustom, disabled, onReset }: Pro
   const status = isCustom ? 'custom' : 'default';
 
   return (
-    <div className="flex shrink-0 items-center gap-1">
+    <div className="flex w-24 shrink-0 items-center justify-end">
       <Chip
         tone={isCustom ? 'primary' : 'neutral'}
         label={status.toUpperCase()}
         ariaLabel={`${label} routing status: ${status}`}
         bordered={false}
+        trailing={
+          isCustom ? (
+            <button
+              type="button"
+              onClick={onReset}
+              disabled={disabled}
+              aria-label="Reset to default"
+              className="inline-flex items-center justify-center rounded-full text-current opacity-70 transition-opacity hover:opacity-100 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              <RotateCcw size={11} aria-hidden />
+            </button>
+          ) : null
+        }
       />
-      {isCustom ? (
-        <button
-          type="button"
-          onClick={onReset}
-          disabled={disabled}
-          aria-label="Reset to default"
-          title="Reset to default"
-          className="inline-flex items-center justify-center rounded-full p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-60"
-        >
-          <RotateCcw size={12} aria-hidden />
-        </button>
-      ) : null}
     </div>
   );
 };

--- a/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/RoutingStatusControl.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/RoutingStatusControl.tsx
@@ -15,10 +15,9 @@ export const RoutingStatusControl = ({ label, isCustom, disabled, onReset }: Pro
     <div className="flex shrink-0 items-center gap-1">
       <Chip
         tone={isCustom ? 'primary' : 'neutral'}
-        label={status}
+        label={status.toUpperCase()}
         ariaLabel={`${label} routing status: ${status}`}
         bordered={false}
-        className={isCustom ? 'bg-primary/10 text-primary' : 'bg-muted text-muted-foreground'}
       />
       {isCustom ? (
         <button

--- a/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/index.test.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/index.test.tsx
@@ -90,6 +90,22 @@ vi.mock('../../../../../shared/components/RoutingPicker', () => ({
   ),
 }));
 
+vi.mock('../../../../../shared/components/RoutingPicker/ProviderPicker', () => ({
+  ProviderPicker: ({
+    ariaLabel,
+    provider,
+    onProvider,
+  }: {
+    ariaLabel: string;
+    provider: string;
+    onProvider: (provider: string) => void;
+  }) => (
+    <button type="button" aria-label={ariaLabel} onClick={() => onProvider('cursor')}>
+      {provider}
+    </button>
+  ),
+}));
+
 const EMPTY_OVERRIDES: OverrideSettings = {
   defaultProviderId: null,
   defaultWorkflowId: null,
@@ -132,8 +148,8 @@ describe('DefaultsPanel', () => {
   it('uses connected providers as the routing pool and locks the default', () => {
     render(<DefaultsPanel workspaceId={'ws-1' as never} />);
 
-    const anthropic = screen.getAllByRole('button', { name: 'anthropic' })[1]!;
-    const cursor = screen.getAllByRole('button', { name: 'cursor' })[1]!;
+    const anthropic = screen.getByRole('button', { name: 'anthropic' });
+    const cursor = screen.getByRole('button', { name: 'cursor' });
 
     expect(anthropic.getAttribute('aria-pressed')).toBe('true');
     expect(anthropic.hasAttribute('disabled')).toBe(true);
@@ -143,7 +159,7 @@ describe('DefaultsPanel', () => {
   it('persists a restricted routing pool', () => {
     render(<DefaultsPanel workspaceId={'ws-1' as never} />);
 
-    fireEvent.click(screen.getAllByRole('button', { name: 'cursor' })[1]!);
+    fireEvent.click(screen.getByRole('button', { name: 'cursor' }));
 
     expect(state.setWorkspaceOverrides).toHaveBeenCalledWith(
       'ws-1',
@@ -157,7 +173,7 @@ describe('DefaultsPanel', () => {
     };
     render(<DefaultsPanel workspaceId={'ws-1' as never} />);
 
-    fireEvent.click(screen.getAllByRole('button', { name: 'cursor' })[0]!);
+    fireEvent.click(screen.getByRole('button', { name: 'Default provider' }));
 
     expect(state.setWorkspaceOverrides).toHaveBeenCalledWith(
       'ws-1',
@@ -185,10 +201,12 @@ describe('DefaultsPanel', () => {
       );
     }
     expect(screen.queryByText(/auto/)).toBeNull();
-    expect(screen.getByLabelText('Step summaries routing status: default')).toBeDefined();
+    expect(screen.getByLabelText('Step summaries routing status: default').textContent).toBe(
+      'DEFAULT',
+    );
 
     openRolesTab();
-    expect(screen.getByLabelText('Planner routing status: default')).toBeDefined();
+    expect(screen.getByLabelText('Planner routing status: default').textContent).toBe('DEFAULT');
   });
 
   it('marks a task override as custom and resets it to default', async () => {
@@ -207,7 +225,9 @@ describe('DefaultsPanel', () => {
     );
 
     rerender(<DefaultsPanel workspaceId={'ws-1' as never} />);
-    expect(screen.getByLabelText('Step summaries routing status: custom')).toBeDefined();
+    expect(screen.getByLabelText('Step summaries routing status: custom').textContent).toBe(
+      'CUSTOM',
+    );
     const reset = screen.getByRole('button', { name: 'Reset to default' });
     await waitFor(() => expect(reset.hasAttribute('disabled')).toBe(false));
     fireEvent.click(reset);
@@ -411,12 +431,15 @@ describe('DefaultsPanel', () => {
     expect(screen.queryByText('Summaries')).toBeNull();
   });
 
-  it('bounds the default provider and routing pool chip rows so they wrap instead of squeezing the label', () => {
+  it('bounds the default provider picker and routing pool without squeezing the label', () => {
     render(<DefaultsPanel workspaceId={'ws-1' as never} />);
 
-    const anthropicChips = screen.getAllByRole('button', { name: 'anthropic' });
-    expect(anthropicChips[0]!.parentElement?.className).toContain('max-w-64');
-    expect(anthropicChips[1]!.parentElement?.className).toContain('max-w-64');
+    expect(screen.getByRole('button', { name: 'Default provider' }).parentElement?.className).toBe(
+      'w-64',
+    );
+    expect(screen.getByRole('button', { name: 'anthropic' }).parentElement?.className).toContain(
+      'max-w-64',
+    );
   });
 
   it('shows the override count for each group in its tab label', () => {

--- a/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/index.test.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/index.test.tsx
@@ -136,6 +136,7 @@ const TASK_LABELS = [
   'Step summaries',
   'Branch naming',
   'Plan drafting',
+  'Prose polish',
   'Agent naming',
   'Workflow orchestrator',
   'PR and MR drafts',

--- a/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/index.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/index.tsx
@@ -1,12 +1,6 @@
 import { useState } from 'react';
-import { DEFAULT_SESSION_PROVIDER_PREFERENCE } from '@goodboy/types';
-import type {
-  AgentRole,
-  AuxTaskId,
-  OverrideSettings,
-  ProviderId,
-  WorkspaceId,
-} from '@goodboy/types';
+import { DEFAULT_SESSION_PROVIDER_PREFERENCE, TASKS } from '@goodboy/types';
+import type { AgentRole, OverrideSettings, ProviderId, WorkspaceId } from '@goodboy/types';
 import { ROLE_DEFAULTS, isAgentRole } from '@goodboy/core';
 import {
   Divider,
@@ -35,48 +29,6 @@ type ProviderParams = {
 };
 
 type DefaultsGroup = 'task' | 'role';
-
-const TASKS: ReadonlyArray<{
-  readonly id: AuxTaskId;
-  readonly label: string;
-  readonly help: string;
-}> = [
-  {
-    id: 'summarizer',
-    label: 'Step summaries',
-    help: 'Condenses each finished step into the summary the next step starts from',
-  },
-  {
-    id: 'branch_naming',
-    label: 'Branch naming',
-    help: 'Turns the session goal into a git branch name when the session is created',
-  },
-  {
-    id: 'plan_generation',
-    label: 'Plan drafting',
-    help: 'Writes step plans in the workflow builder and Plan Studio',
-  },
-  {
-    id: 'agent_naming',
-    label: 'Agent naming',
-    help: 'Titles new agents, and the session itself, from your first message',
-  },
-  {
-    id: 'workflow_orchestrator',
-    label: 'Workflow orchestrator',
-    help: 'Reads each finished step of a dynamic workflow and picks the next one, or ends the run',
-  },
-  {
-    id: 'pr_draft',
-    label: 'PR and MR drafts',
-    help: 'Preselected model for the agent that drafts a pull or merge request',
-  },
-  {
-    id: 'rebase',
-    label: 'Rebase',
-    help: 'Preselected model for the agent that rebases the session branch onto main',
-  },
-];
 
 const ROLES: ReadonlyArray<AgentRole> = Object.keys(ROLE_DEFAULTS).filter(isAgentRole);
 
@@ -231,7 +183,7 @@ export const DefaultsPanel = ({ workspaceId }: Props) => {
                     <TaskModelRow
                       task={task.id}
                       label={task.label}
-                      help={task.help}
+                      help={task.description}
                       preference={overrides.taskModels?.[task.id] ?? null}
                       defaultProviderId={defaultProviderId}
                       connectedProviderIds={connectedProviderIds}

--- a/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/index.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/index.tsx
@@ -20,11 +20,11 @@ import { useShallow } from 'zustand/react/shallow';
 import { ProviderChip } from '../../ProviderChip';
 import { ROLE_LABEL } from '../../../../session/agent-kind';
 import { useAppStore } from '../../../../../store';
-import { PROVIDER_ORDER } from '../providerOrder';
 import { RoleModelRow } from './RoleModelRow';
 import { TaskModelRow } from './TaskModelRow';
 import { useDefaultsPersistence } from './useDefaultsPersistence';
 import { CONCEPT_ICONS } from '../../../../../shared/components/conceptIcons';
+import { ProviderPicker } from '../../../../../shared/components/RoutingPicker/ProviderPicker';
 
 type Props = {
   readonly workspaceId: WorkspaceId;
@@ -168,23 +168,15 @@ export const DefaultsPanel = ({ workspaceId }: Props) => {
               hint="Governs every task and role below unless it has its own override."
             />
             <FieldRow label="Default provider" help="New sessions start on it and can override it.">
-              <div className="flex max-w-64 flex-wrap justify-end gap-1">
-                {PROVIDER_ORDER.map((providerId) => (
-                  <ProviderChip
-                    key={providerId}
-                    id={providerId}
-                    selected={defaultProviderId === providerId}
-                    disabled={busy || !connectedProviderIds.includes(providerId)}
-                    onClick={() => onDefaultProvider({ providerId })}
-                    trailing={
-                      connectedProviderIds.includes(providerId) ? null : (
-                        <span className="text-2xs uppercase tracking-wide text-warning">
-                          offline
-                        </span>
-                      )
-                    }
-                  />
-                ))}
+              <div className="w-64">
+                <ProviderPicker
+                  connectedProviders={connectedProviderIds}
+                  provider={defaultProviderId}
+                  disabled={busy}
+                  onProvider={(providerId) => onDefaultProvider({ providerId })}
+                  align="end"
+                  ariaLabel="Default provider"
+                />
               </div>
             </FieldRow>
             <p className="text-2xs text-muted-foreground">
@@ -213,13 +205,6 @@ export const DefaultsPanel = ({ workspaceId }: Props) => {
                         disabled={busy || isDefaultProvider}
                         onClick={() => onToggleRoutingProvider({ providerId })}
                         title={isDefaultProvider ? 'Default provider is always enabled' : undefined}
-                        trailing={
-                          isDefaultProvider ? (
-                            <span className="text-2xs uppercase tracking-wide text-muted-foreground/70">
-                              default
-                            </span>
-                          ) : null
-                        }
                       />
                     );
                   })}

--- a/apps/desktop/src/features/session/components/WorkflowBuilderView/index.test.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowBuilderView/index.test.tsx
@@ -111,7 +111,7 @@ vi.mock('../../../../shared/components/RoutingPicker', () => ({
         };
   }) => (
     <>
-      <button type="button" onClick={() => onProvider(provider === '' ? 'cursor' : '')}>
+      <button type="button" onClick={() => onProvider(provider === 'cursor' ? '' : 'cursor')}>
         provider:{provider === '' ? 'default' : provider}
       </button>
       <button
@@ -465,6 +465,34 @@ describe('WorkflowBuilderView (orchestrated mode)', () => {
       'sess-1',
       expect.any(String),
       expect.objectContaining({ autoRun: false, executionMode: 'dynamic' }),
+    );
+  });
+
+  it('attaches one routing policy for every runtime-decided step', async () => {
+    render(<WorkflowBuilderView session={session} onClose={vi.fn()} />);
+    goToApproach();
+    fireEvent.click(screen.getByRole('tab', { name: /orchestrated/i }));
+    fireEvent.change(screen.getByPlaceholderText(/describe the intent/i), {
+      target: { value: 'Inspect each result and stop after tests pass.' },
+    });
+    fireEvent.click(continueBtn());
+
+    fireEvent.click(screen.getByRole('button', { name: /^provider:anthropic$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^model:auto$/i }));
+    fireEvent.click(startBtn());
+
+    await waitFor(() => expect(mockAttach).toHaveBeenCalledOnce());
+    expect(mockAttach).toHaveBeenCalledWith(
+      'sess-1',
+      expect.any(String),
+      expect.objectContaining({
+        executionMode: 'dynamic',
+        stepRouting: {
+          providerId: 'cursor',
+          model: 'claude-opus-4-6',
+          effort: 'medium',
+        },
+      }),
     );
   });
 });

--- a/apps/desktop/src/features/session/components/WorkflowBuilderView/index.test.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowBuilderView/index.test.tsx
@@ -194,6 +194,7 @@ afterEach(() => {
   vi.clearAllMocks();
   storeState.phaseTemplates = {};
   storeState.sessionPhaseRuns = {};
+  storeState.workspaceOverrides = {};
   storeState.workflowDrafts = {};
 });
 
@@ -575,6 +576,31 @@ describe('WorkflowBuilderView (goal affordances)', () => {
     expect(goalField().value).toBe('rough goal');
   });
 
+  it('uses the prose polish task model override', async () => {
+    storeState.workspaceOverrides = {
+      'ws-1': {
+        taskModels: {
+          prose_polish: {
+            providerId: 'anthropic',
+            model: 'claude-sonnet-4-6',
+            effort: 'high',
+          },
+        },
+      },
+    };
+    mockPolish.mockResolvedValue('Polished goal.');
+    render(<WorkflowBuilderView session={session} onClose={vi.fn()} />);
+    fireEvent.change(goalField(), { target: { value: 'rough goal' } });
+    fireEvent.click(screen.getByRole('button', { name: /polish goal/i }));
+
+    await waitFor(() =>
+      expect(mockPolish).toHaveBeenCalledWith(
+        expect.objectContaining({ providerId: 'anthropic', model: 'sonnet-4.6', effort: 'high' }),
+        'rough goal',
+      ),
+    );
+  });
+
   it('keeps the wording and toasts when polish returns nothing', async () => {
     mockPolish.mockResolvedValue(null);
     render(<WorkflowBuilderView session={session} onClose={vi.fn()} />);
@@ -786,7 +812,7 @@ describe('WorkflowBuilderView (per-step polish)', () => {
     fireEvent.click(screen.getAllByRole('button', { name: /polish step instruction/i })[0]!);
     await waitFor(() =>
       expect(mockPolishStep).toHaveBeenCalledWith(
-        expect.objectContaining({ providerId: 'anthropic' }),
+        expect.objectContaining({ providerId: 'anthropic', model: 'haiku-4.5' }),
         expect.objectContaining({ role: 'scout', instruction: 'scout prefix' }),
       ),
     );

--- a/apps/desktop/src/features/session/components/WorkflowBuilderView/index.test.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowBuilderView/index.test.tsx
@@ -2,7 +2,7 @@
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import type { Session, Workflow } from '@goodboy/types';
+import type { ModelEffort, Session, Workflow } from '@goodboy/types';
 import type { WorkflowBuilderDraft } from '../../../../store/slices/workflowDrafts/types';
 
 const {
@@ -95,12 +95,20 @@ vi.mock('../../../../shared/components/RoutingPicker', () => ({
     recommendation,
     onProvider,
     onModel,
+    effort,
   }: {
     provider: string;
     model: string;
     recommendation?: { provider?: string; model?: string };
     onProvider: (v: string) => void;
     onModel: (v: string) => void;
+    effort:
+      | { readonly editable: false; readonly value?: ModelEffort }
+      | {
+          readonly editable: true;
+          readonly value: ModelEffort;
+          readonly onChange: (value: ModelEffort) => void;
+        };
   }) => (
     <>
       <button type="button" onClick={() => onProvider(provider === '' ? 'cursor' : '')}>
@@ -117,6 +125,11 @@ vi.mock('../../../../shared/components/RoutingPicker', () => ({
       <button type="button" onClick={() => onModel('claude-sonnet-4-6')}>
         model:sonnet
       </button>
+      {effort.editable ? (
+        <button type="button" onClick={() => effort.onChange('xhigh')}>
+          effort:{effort.value}
+        </button>
+      ) : null}
     </>
   ),
 }));
@@ -865,6 +878,23 @@ describe('WorkflowBuilderView (planner model picker)', () => {
 
     expect(vi.mocked(PlannerClient)).toHaveBeenCalledWith(
       expect.objectContaining({ providerId: 'cursor', model: 'claude-opus-4-6' }),
+    );
+  });
+
+  it('picking planner effort makes PlannerClient receive it', async () => {
+    mockPlan.mockResolvedValue({ output: PLAN_FIXTURE });
+    render(<WorkflowBuilderView session={session} onClose={vi.fn()} />);
+    goToApproach();
+    fireEvent.click(screen.getByRole('button', { name: /^effort:high$/i }));
+
+    fireEvent.change(screen.getByPlaceholderText(/describe the process/i), {
+      target: { value: 'do something' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /generate plan/i }));
+    await waitFor(() => screen.getByText('Ready'));
+
+    expect(vi.mocked(PlannerClient)).toHaveBeenCalledWith(
+      expect.objectContaining({ effort: 'xhigh' }),
     );
   });
 

--- a/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
@@ -274,6 +274,11 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
     [workspaceOverrides, providerId],
   );
 
+  const resolvedProsePolishTaskModel = useMemo(
+    () => resolveTaskModel('prose_polish', workspaceOverrides?.taskModels, providerId),
+    [workspaceOverrides, providerId],
+  );
+
   const plannerEffectiveProviderId: ProviderId =
     plannerProviderOverride !== '' ? plannerProviderOverride : resolvedPlanTaskModel.providerId;
 
@@ -472,7 +477,7 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
     try {
       const polished = await polishStepInstruction(
         {
-          providerId,
+          ...resolvedProsePolishTaskModel,
           invokeFn: invoke,
           ...(sessionWorktree != null && { workingDir: sessionWorktree }),
         },
@@ -527,7 +532,7 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
     try {
       const polished = await polishWorkflowGoal(
         {
-          providerId,
+          ...resolvedProsePolishTaskModel,
           invokeFn: invoke,
           ...(sessionWorktree != null && { workingDir: sessionWorktree }),
         },

--- a/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
@@ -47,6 +47,7 @@ import { useSessionRepo } from '../../../../store/slices/worktrees/useSessionRep
 import type {
   AgentEffort,
   AgentRole,
+  OrchestratorRouting,
   ProviderId,
   RoleModelPreferences,
   Session,
@@ -83,6 +84,7 @@ import { LaunchToggleRow } from './parts/LaunchToggleRow';
 import { StageHeading } from './parts/StageHeading';
 import { StepperRail } from './parts/StepperRail';
 import { TriggerButton } from './parts/TriggerButton';
+import { WorkflowStepRoutingPicker } from '../../../workflows/components/WorkflowStepRoutingPicker';
 
 type Props = {
   readonly session: Session;
@@ -259,6 +261,7 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
   const [plannerProviderOverride, setPlannerProviderOverride] = useState<ProviderId | ''>('');
   const [plannerModelOverride, setPlannerModelOverride] = useState('');
   const [plannerEffortOverride, setPlannerEffortOverride] = useState<EffortLevel>(PLANNER_EFFORT);
+  const [stepRouting, setStepRouting] = useState<OrchestratorRouting | null>(null);
 
   const providerId =
     providers.find((p) => p.id === session.providerOverride)?.id ??
@@ -383,6 +386,7 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
     setSteps([]);
     setSaveAsPreset(false);
     setAutoRun(false);
+    setStepRouting(null);
     setError(null);
     setStage(0);
     setExpandedKey(null);
@@ -567,6 +571,7 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
       ...(triggerMode === 'after_run' && after && { chainAfterId: after }),
       ...(attachments.length > 0 && { attachmentInputs: attachments.map(toAttachmentInput) }),
       ...(mode === 'dynamic' && { executionMode: 'dynamic' as const }),
+      ...(mode === 'dynamic' && stepRouting != null && { stepRouting }),
     };
   };
 
@@ -1162,6 +1167,16 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
                           your process, prior outputs, and open questions before choosing what comes
                           next.
                         </p>
+                        <div className="flex flex-col gap-1">
+                          <span className={SECTION_LABEL_CLS}>Step agent policy</span>
+                          <WorkflowStepRoutingPicker
+                            connectedProviders={connectedProviders}
+                            defaultProvider={providerId}
+                            routing={stepRouting}
+                            disabled={blocked}
+                            onChange={setStepRouting}
+                          />
+                        </div>
                       </div>
                     ) : showSteps ? (
                       <div className="flex flex-col gap-3">

--- a/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
@@ -258,6 +258,7 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
   const [stage, setStage] = useState<Stage>(() => initialStage(initialDraft));
   const [plannerProviderOverride, setPlannerProviderOverride] = useState<ProviderId | ''>('');
   const [plannerModelOverride, setPlannerModelOverride] = useState('');
+  const [plannerEffortOverride, setPlannerEffortOverride] = useState<EffortLevel>(PLANNER_EFFORT);
 
   const providerId =
     providers.find((p) => p.id === session.providerOverride)?.id ??
@@ -577,7 +578,11 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
     try {
       const effectiveModel =
         plannerModelOverride !== '' ? plannerModelOverride : plannerRecommendedModel;
-      const taskModel = { providerId: plannerEffectiveProviderId, model: effectiveModel };
+      const taskModel = {
+        providerId: plannerEffectiveProviderId,
+        model: effectiveModel,
+        effort: plannerEffortOverride,
+      };
       const client = new PlannerClient({
         ...taskModel,
         invokeFn: invoke,
@@ -1074,7 +1079,11 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
                                 connectedProviders={connectedProviders}
                                 provider={plannerProviderOverride}
                                 model={plannerModelOverride}
-                                effort={{ editable: false, value: PLANNER_EFFORT }}
+                                effort={{
+                                  editable: true,
+                                  value: plannerEffortOverride,
+                                  onChange: setPlannerEffortOverride,
+                                }}
                                 recommendation={{
                                   provider: resolvedPlanTaskModel.providerId,
                                   model: plannerRecommendedModel,

--- a/apps/desktop/src/features/workflows/components/OrchestratorPanel/StepRoutingRow.tsx
+++ b/apps/desktop/src/features/workflows/components/OrchestratorPanel/StepRoutingRow.tsx
@@ -1,0 +1,42 @@
+import { PROVIDER_CAPABILITIES } from '@goodboy/core';
+import type { ProviderId, SessionId, WorkflowRun } from '@goodboy/types';
+import { useAppStore } from '../../../../store/store';
+import { WorkflowStepRoutingPicker } from '../WorkflowStepRoutingPicker';
+
+type Props = {
+  readonly sessionId: SessionId;
+  readonly run: WorkflowRun;
+  readonly disabled: boolean;
+};
+
+export const StepRoutingRow = ({ sessionId, run, disabled }: Props) => {
+  const session = useAppStore((state) =>
+    state.sessions.find((current) => current.id === sessionId),
+  );
+  const providers = useAppStore((state) => state.providers);
+  const setWorkflowStepRouting = useAppStore((state) => state.setWorkflowStepRouting);
+  const defaultProvider = (session?.providerOverride ??
+    session?.providerPreference.defaultProvider ??
+    'anthropic') as ProviderId;
+  const connectedProviders = providers
+    .filter((provider) => provider.connection === 'connected')
+    .map((provider) => provider.id)
+    .filter((candidate) => PROVIDER_CAPABILITIES[candidate].models.length > 0);
+
+  return (
+    <div
+      data-testid="step-routing"
+      className="flex min-w-0 flex-wrap items-center gap-1.5 text-2xs text-muted-foreground"
+    >
+      <span>steps run on</span>
+      <WorkflowStepRoutingPicker
+        connectedProviders={connectedProviders}
+        defaultProvider={defaultProvider}
+        routing={run.stepRouting ?? null}
+        disabled={disabled}
+        variant="pill"
+        onChange={(routing) => void setWorkflowStepRouting(sessionId, run.id, routing)}
+      />
+    </div>
+  );
+};

--- a/apps/desktop/src/features/workflows/components/OrchestratorPanel/index.test.tsx
+++ b/apps/desktop/src/features/workflows/components/OrchestratorPanel/index.test.tsx
@@ -35,6 +35,7 @@ beforeEach(() => {
     continueWorkflowRun: vi.fn(async () => undefined),
     setWorkflowOrchestratorHints: vi.fn(async () => undefined),
     setWorkflowOrchestratorRouting: vi.fn(async () => undefined),
+    setWorkflowStepRouting: vi.fn(async () => undefined),
     sessions: [],
     workspaceOverrides: {},
     providers: [
@@ -132,6 +133,24 @@ describe('OrchestratorPanel', () => {
     fireEvent.click(screen.getByTestId('workflow-orchestrate-next-cta'));
 
     expect(storeState['orchestrateNextStep']).toHaveBeenCalledWith(SESSION_ID, RUN_ID);
+  });
+
+  it('shows the run-wide routing policy for decided step agents', () => {
+    render(
+      <OrchestratorPanel
+        sessionId={SESSION_ID}
+        run={run({
+          stepRouting: { providerId: 'anthropic', model: 'opus-5', effort: 'high' },
+        })}
+        agents={EMPTY_AGENTS}
+        isOrchestrating={false}
+      />,
+    );
+
+    expect(screen.getByTestId('step-routing').textContent).toContain('steps run on');
+    expect(
+      screen.getByRole('button', { name: /step agent routing/i }).getAttribute('aria-label'),
+    ).toContain('Opus 5');
   });
 
   it('drops the next step control once the run is complete', () => {

--- a/apps/desktop/src/features/workflows/components/OrchestratorPanel/index.tsx
+++ b/apps/desktop/src/features/workflows/components/OrchestratorPanel/index.tsx
@@ -4,6 +4,7 @@ import { cn, Markdown, StatusDot } from '@goodboy/ui';
 import type { Agent, SessionId, WorkflowRun } from '@goodboy/types';
 import { useAppStore } from '../../../../store/store';
 import { OrchestratorRoutingRow } from './OrchestratorRoutingRow';
+import { StepRoutingRow } from './StepRoutingRow';
 
 type Props = {
   readonly sessionId: SessionId;
@@ -95,6 +96,7 @@ export const OrchestratorPanel = ({ sessionId, run, agents, isOrchestrating }: P
       ) : null}
 
       <OrchestratorRoutingRow sessionId={sessionId} run={run} disabled={busy || isOrchestrating} />
+      <StepRoutingRow sessionId={sessionId} run={run} disabled={busy || isOrchestrating} />
 
       <div className="flex flex-wrap items-center gap-1.5">
         {phase === 'idle' ? (

--- a/apps/desktop/src/features/workflows/components/WorkflowStepRoutingPicker.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowStepRoutingPicker.tsx
@@ -1,0 +1,99 @@
+import { useEffect, useRef, useState } from 'react';
+import { getDefaultTurnModel } from '@goodboy/core';
+import type { ModelEffort, OrchestratorRouting, ProviderId } from '@goodboy/types';
+import { clampEffort, modelEffortLevels } from '../../chat/utils/chat-constants';
+import { RoutingPicker } from '../../../shared/components/RoutingPicker';
+
+type Props = {
+  readonly connectedProviders: ReadonlyArray<ProviderId>;
+  readonly defaultProvider: ProviderId;
+  readonly routing: OrchestratorRouting | null;
+  readonly disabled: boolean;
+  readonly variant?: 'field' | 'pill';
+  readonly onChange: (routing: OrchestratorRouting | null) => void;
+};
+
+type EffortParams = {
+  readonly model: string;
+  readonly requested: ModelEffort;
+};
+
+const DEFAULT_EFFORT: ModelEffort = 'medium';
+
+const effortForModel = ({ model, requested }: EffortParams): ModelEffort | null =>
+  modelEffortLevels(model) == null ? null : clampEffort(model, requested);
+
+export const WorkflowStepRoutingPicker = ({
+  connectedProviders,
+  defaultProvider,
+  routing,
+  disabled,
+  variant = 'field',
+  onChange,
+}: Props) => {
+  const initialProvider = routing?.providerId ?? defaultProvider;
+  const [providerId, setProviderId] = useState<ProviderId>(initialProvider);
+  const providerRef = useRef(initialProvider);
+  const modelRef = useRef(routing?.model ?? getDefaultTurnModel({ id: initialProvider }));
+  const defaultModel = getDefaultTurnModel({ id: defaultProvider });
+  const model = routing?.model ?? '';
+  const effortModel = model === '' ? getDefaultTurnModel({ id: providerId }) : model;
+  const effortValue = routing?.effort ?? DEFAULT_EFFORT;
+
+  useEffect(() => {
+    const nextProvider = routing?.providerId ?? defaultProvider;
+    providerRef.current = nextProvider;
+    modelRef.current = routing?.model ?? getDefaultTurnModel({ id: nextProvider });
+    setProviderId(nextProvider);
+  }, [defaultProvider, routing]);
+
+  return (
+    <RoutingPicker
+      ariaLabel="step agent routing"
+      variant={variant}
+      connectedProviders={connectedProviders}
+      provider={providerId}
+      model={model}
+      effort={{
+        editable: true,
+        value: effortForModel({ model: effortModel, requested: effortValue }) ?? effortValue,
+        onChange: (effort) => {
+          const applied = effortForModel({ model: modelRef.current, requested: effort });
+          onChange({
+            providerId: providerRef.current,
+            model: modelRef.current,
+            ...(applied != null && { effort: applied }),
+          });
+        },
+      }}
+      recommendation={{ provider: defaultProvider, model: defaultModel }}
+      disabled={disabled}
+      overridden={routing != null}
+      defaultSummary="role defaults"
+      onReset={() => onChange(null)}
+      onProvider={(next) => {
+        const nextProvider = next === '' ? defaultProvider : next;
+        providerRef.current = nextProvider;
+        setProviderId(nextProvider);
+        if (next === '') {
+          modelRef.current = defaultModel;
+          onChange(null);
+        }
+      }}
+      onModel={(nextModel) => {
+        if (nextModel === '') {
+          modelRef.current = defaultModel;
+          onChange(null);
+          return;
+        }
+        modelRef.current = nextModel;
+        const applied = effortForModel({ model: nextModel, requested: effortValue });
+        onChange({
+          providerId: providerRef.current,
+          model: nextModel,
+          ...(applied != null && { effort: applied }),
+        });
+      }}
+    />
+  );
+};

--- a/apps/desktop/src/shared/components/RoutingPicker/AxesSection.tsx
+++ b/apps/desktop/src/shared/components/RoutingPicker/AxesSection.tsx
@@ -30,7 +30,7 @@ export const AxesSection = ({
   onToggle,
 }: Props) => {
   const hasNoAxes = axes.effort == null && axes.variant == null && axes.toggles.length === 0;
-  const toggleRowLabel = axes.variant == null ? 'Variant' : 'Modes';
+  const toggleRowLabel = 'Modes';
   return (
     <section aria-label="Tuning" className="flex flex-col gap-2.5 p-3">
       {hasNoAxes && (

--- a/apps/desktop/src/shared/components/RoutingPicker/ProviderGrid.tsx
+++ b/apps/desktop/src/shared/components/RoutingPicker/ProviderGrid.tsx
@@ -1,0 +1,57 @@
+import type { ProviderId } from '@goodboy/types';
+import { cn } from '@goodboy/ui';
+import { PROVIDER_LABEL } from '../../../features/chat/utils/chat-constants';
+import { ProviderGlyph } from './ProviderGlyph';
+import { ROUTING_PICKER_CONSTANTS } from './constants';
+
+type Props = {
+  readonly connectedProviders: ReadonlyArray<ProviderId>;
+  readonly activeProvider: ProviderId | null;
+  readonly secondaryProvider?: ProviderId | null;
+  readonly disableDisconnected?: boolean;
+  readonly onSelect: (provider: ProviderId) => void;
+};
+
+export const ProviderGrid = ({
+  connectedProviders,
+  activeProvider,
+  secondaryProvider = null,
+  disableDisconnected = false,
+  onSelect,
+}: Props) => (
+  <div className={ROUTING_PICKER_CONSTANTS.providerChipGroupClassName}>
+    {ROUTING_PICKER_CONSTANTS.providers.map((id) => {
+      const isConnected = connectedProviders.includes(id);
+      const isActive = activeProvider === id;
+      const isSecondary = secondaryProvider === id;
+      const isDisabled = disableDisconnected && !isConnected;
+      return (
+        <button
+          key={id}
+          type="button"
+          title={isConnected ? PROVIDER_LABEL[id] : `${PROVIDER_LABEL[id]} is not connected`}
+          aria-label={PROVIDER_LABEL[id]}
+          aria-pressed={isActive}
+          disabled={isDisabled}
+          onClick={() => onSelect(id)}
+          className={cn(
+            'relative inline-flex min-w-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-background/60 hover:text-foreground',
+            isActive && 'bg-background text-foreground shadow-sm',
+            isSecondary && 'text-foreground ring-1 ring-inset ring-border-soft',
+            isDisabled && 'cursor-not-allowed',
+          )}
+        >
+          <span className={cn(!isConnected && 'opacity-35')}>
+            <ProviderGlyph id={id} size={15} />
+          </span>
+          {!isConnected ? (
+            <span
+              className="absolute right-1 top-1 size-1.5 rounded-full bg-warning ring-1 ring-subtle"
+              aria-hidden
+            />
+          ) : null}
+        </button>
+      );
+    })}
+  </div>
+);

--- a/apps/desktop/src/shared/components/RoutingPicker/ProviderPicker.test.tsx
+++ b/apps/desktop/src/shared/components/RoutingPicker/ProviderPicker.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { ProviderId } from '@goodboy/types';
+import { ProviderPicker } from './ProviderPicker';
+
+const connectedProviders = ['anthropic', 'cursor'] as ReadonlyArray<ProviderId>;
+
+afterEach(cleanup);
+
+describe('ProviderPicker', () => {
+  it('shows only the provider dimension', () => {
+    render(
+      <ProviderPicker
+        connectedProviders={connectedProviders}
+        provider="anthropic"
+        disabled={false}
+        onProvider={vi.fn()}
+        ariaLabel="Default provider"
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Default provider: Claude' }).textContent).toContain(
+      'Claude',
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Default provider: Claude' }));
+    expect(screen.getByText('Provider')).toBeDefined();
+    expect(screen.queryByText('Models')).toBeNull();
+    expect(screen.queryByText('Tuning')).toBeNull();
+  });
+
+  it('selects a connected provider and closes the picker', () => {
+    const onProvider = vi.fn();
+    render(
+      <ProviderPicker
+        connectedProviders={connectedProviders}
+        provider="anthropic"
+        disabled={false}
+        onProvider={onProvider}
+        ariaLabel="Default provider"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Default provider: Claude' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Cursor' }));
+    expect(onProvider).toHaveBeenCalledWith('cursor');
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('keeps disconnected providers visible and unavailable', () => {
+    render(
+      <ProviderPicker
+        connectedProviders={connectedProviders}
+        provider="anthropic"
+        disabled={false}
+        onProvider={vi.fn()}
+        ariaLabel="Default provider"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Default provider: Claude' }));
+    const codex = screen.getByRole('button', { name: 'Codex' });
+    expect(codex.hasAttribute('disabled')).toBe(true);
+    expect(codex.getAttribute('title')).toBe('Codex is not connected');
+  });
+});

--- a/apps/desktop/src/shared/components/RoutingPicker/ProviderPicker.tsx
+++ b/apps/desktop/src/shared/components/RoutingPicker/ProviderPicker.tsx
@@ -1,0 +1,102 @@
+import { ChevronDown } from 'lucide-react';
+import type { ProviderId } from '@goodboy/types';
+import { Popover, cn } from '@goodboy/ui';
+import { PROVIDER_LABEL } from '../../../features/chat/utils/chat-constants';
+import { DropdownPortal } from '../../hooks/useDropdown/DropdownPortal';
+import { useDropdown } from '../../hooks/useDropdown';
+import { PickerSection } from './PickerSection';
+import { ProviderGlyph } from './ProviderGlyph';
+import { ProviderGrid } from './ProviderGrid';
+
+type Props = {
+  readonly connectedProviders: ReadonlyArray<ProviderId>;
+  readonly provider: ProviderId;
+  readonly disabled: boolean;
+  readonly onProvider: (provider: ProviderId) => void;
+  readonly align?: 'start' | 'end';
+  readonly ariaLabel?: string;
+};
+
+export const ProviderPicker = ({
+  connectedProviders,
+  provider,
+  disabled,
+  onProvider,
+  align = 'start',
+  ariaLabel = 'provider',
+}: Props) => {
+  const {
+    open,
+    close,
+    toggle,
+    containerRef,
+    popupRef,
+    popupClassName,
+    popupStyle,
+    portal,
+    portalTarget,
+  } = useDropdown({
+    disabled,
+    align,
+    expectedHeight: 64,
+    expectedWidth: 384,
+    width: 'w-96 max-w-[calc(100vw-2rem)]',
+    strategy: 'fixed',
+  });
+  const summary = PROVIDER_LABEL[provider];
+
+  return (
+    <div ref={containerRef} className="relative flex w-full items-center">
+      <button
+        type="button"
+        onClick={toggle}
+        disabled={disabled}
+        title={disabled ? summary : `${summary}. Click to change.`}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        aria-label={`${ariaLabel}: ${summary}`}
+        className={cn(
+          'flex w-full items-center gap-1.5 rounded-md border px-2 py-1.5 text-left text-xs transition-colors',
+          open
+            ? 'border-primary bg-primary/5'
+            : 'border-border-soft bg-subtle hover:border-border hover:bg-muted/50',
+          disabled && 'cursor-not-allowed opacity-60',
+        )}
+      >
+        <ProviderGlyph id={provider} />
+        <span className="min-w-0 flex-1 truncate">{summary}</span>
+        <ChevronDown
+          size={11}
+          aria-hidden
+          className={cn(
+            'shrink-0 text-muted-foreground transition-transform',
+            open && 'rotate-180',
+          )}
+        />
+      </button>
+      <DropdownPortal portal={portal} portalTarget={portalTarget}>
+        {open ? (
+          <Popover
+            innerRef={popupRef}
+            role="dialog"
+            ariaLabel={ariaLabel}
+            className={cn(popupClassName, 'bg-subtle')}
+            style={popupStyle}
+          >
+            <PickerSection label="Provider" hint="Which CLI agent starts new sessions">
+              <ProviderGrid
+                connectedProviders={connectedProviders}
+                activeProvider={provider}
+                disableDisconnected
+                onSelect={(nextProvider) => {
+                  onProvider(nextProvider);
+                  close();
+                }}
+              />
+            </PickerSection>
+          </Popover>
+        ) : null}
+      </DropdownPortal>
+    </div>
+  );
+};

--- a/apps/desktop/src/shared/components/RoutingPicker/index.test.tsx
+++ b/apps/desktop/src/shared/components/RoutingPicker/index.test.tsx
@@ -264,7 +264,7 @@ describe('RoutingPicker', () => {
     expect(onModel).toHaveBeenCalledWith('auto');
   });
 
-  it('renders Cursor toggles once in a single Variant row', () => {
+  it('renders Cursor toggles once in a single Modes row', () => {
     render(
       <RoutingPicker
         {...baseProps}
@@ -275,13 +275,13 @@ describe('RoutingPicker', () => {
     );
     fireEvent.click(screen.getByRole('button', { name: /routing/i }));
     const tuning = screen.getByRole('region', { name: 'Tuning' });
-    const variants = within(tuning).getByRole('group', { name: 'Variant' });
-    expect(within(tuning).getAllByText('Variant')).toHaveLength(1);
+    const modes = within(tuning).getByRole('group', { name: 'Modes' });
+    expect(within(tuning).getAllByText('Modes')).toHaveLength(1);
     expect(within(tuning).getAllByText('Fast')).toHaveLength(1);
-    expect(
-      within(variants).getByRole('button', { name: 'Fast' }).getAttribute('aria-pressed'),
-    ).toBe('true');
-    expect(variants.className).toContain('justify-center');
+    expect(within(modes).getByRole('button', { name: 'Fast' }).getAttribute('aria-pressed')).toBe(
+      'true',
+    );
+    expect(modes.className).toContain('justify-center');
   });
 
   it('reports the picked effort and keeps the popover open', () => {
@@ -364,7 +364,7 @@ describe('RoutingPicker', () => {
       <RoutingPicker {...baseProps} provider="openrouter" model="gpt-5.4" />,
     );
     fireEvent.click(screen.getByRole('button', { name: /routing/i }));
-    expect(screen.getByRole('group', { name: 'Variant' })).toBeDefined();
+    expect(screen.getByRole('group', { name: 'Effort' })).toBeDefined();
 
     routerView.unmount();
     render(<RoutingPicker {...baseProps} provider="gemini" model="gemini-3.1-pro" />);
@@ -372,6 +372,14 @@ describe('RoutingPicker', () => {
     expect(screen.getByRole('region', { name: 'Tuning' }).textContent).toContain(
       'No tuning options for this provider',
     );
+  });
+
+  it('shows the no-option message without an effort row for Haiku', () => {
+    render(<RoutingPicker {...baseProps} model="haiku-4.5" />);
+    fireEvent.click(screen.getByRole('button', { name: /routing/i }));
+    const tuning = screen.getByRole('region', { name: 'Tuning' });
+    expect(within(tuning).queryByRole('group', { name: 'Effort' })).toBeNull();
+    expect(tuning.textContent).toContain('No tuning options for this provider');
   });
 
   it('shows a Max Mode advisory after failure and clears it after success', () => {

--- a/apps/desktop/src/shared/components/RoutingPicker/index.tsx
+++ b/apps/desktop/src/shared/components/RoutingPicker/index.tsx
@@ -28,7 +28,7 @@ import { verbosityTone } from './chipTone';
 import { CatalogGrid } from './CatalogGrid';
 import { PickerChip } from './PickerChip';
 import { PickerSection } from './PickerSection';
-import { ProviderGlyph } from './ProviderGlyph';
+import { ProviderGrid } from './ProviderGrid';
 import { RecommendationRow } from './RecommendationRow';
 import { TriggerLabel } from './TriggerLabel';
 import { ROUTING_PICKER_CONSTANTS } from './constants';
@@ -376,56 +376,31 @@ export const RoutingPicker = ({
               </>
             )}
             <PickerSection label="Provider" hint="Which CLI agent runs the turn">
-              <div className={ROUTING_PICKER_CONSTANTS.providerChipGroupClassName}>
-                {ROUTING_PICKER_CONSTANTS.providers.map((id) => {
+              <ProviderGrid
+                connectedProviders={connectedProviders}
+                activeProvider={isViewingAuto ? null : viewProvider}
+                secondaryProvider={isViewingAuto ? (recommendedProvider ?? null) : null}
+                onSelect={(id) => {
                   const isConnected = connectedProviders.includes(id);
-                  const isActive = !isViewingAuto && viewProvider === id;
-                  const isRecommendedTab = isViewingAuto && recommendedProvider === id;
-                  return (
-                    <button
-                      key={id}
-                      type="button"
-                      title={PROVIDER_LABEL[id]}
-                      aria-label={PROVIDER_LABEL[id]}
-                      aria-pressed={isActive}
-                      onClick={() => {
-                        setViewProvider(id);
-                        setIsViewingAuto(false);
-                        setConnectProvider(null);
-                        if (!isConnected) {
-                          const preview = remapModelSelection({
-                            sourceProvider: viewProvider,
-                            targetProvider: id,
-                            selection: viewedRouting.selection,
-                          });
-                          setDraftSelection(
-                            id === 'gemini'
-                              ? { ...preview.selection, effort: viewedRouting.effort }
-                              : preview.selection,
-                          );
-                          return;
-                        }
-                        onPickProvider({ next: id, viewedProvider: id });
-                      }}
-                      className={cn(
-                        'relative inline-flex min-w-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-background/60 hover:text-foreground',
-                        isActive && 'bg-background text-foreground shadow-sm',
-                        isRecommendedTab && 'text-foreground ring-1 ring-inset ring-border-soft',
-                      )}
-                    >
-                      <span className={cn(!isConnected && 'opacity-35')}>
-                        <ProviderGlyph id={id} size={15} />
-                      </span>
-                      {!isConnected && (
-                        <span
-                          className="absolute right-1 top-1 size-1.5 rounded-full bg-warning ring-1 ring-subtle"
-                          aria-hidden
-                        />
-                      )}
-                    </button>
-                  );
-                })}
-              </div>
+                  setViewProvider(id);
+                  setIsViewingAuto(false);
+                  setConnectProvider(null);
+                  if (!isConnected) {
+                    const preview = remapModelSelection({
+                      sourceProvider: viewProvider,
+                      targetProvider: id,
+                      selection: viewedRouting.selection,
+                    });
+                    setDraftSelection(
+                      id === 'gemini'
+                        ? { ...preview.selection, effort: viewedRouting.effort }
+                        : preview.selection,
+                    );
+                    return;
+                  }
+                  onPickProvider({ next: id, viewedProvider: id });
+                }}
+              />
             </PickerSection>
             <Divider />
             {connectProvider != null ? (

--- a/apps/desktop/src/store/slices/workflows/attachWorkflowToSession.ts
+++ b/apps/desktop/src/store/slices/workflows/attachWorkflowToSession.ts
@@ -2,6 +2,7 @@ import type {
   Agent,
   AttachmentInput,
   IsoDateTime,
+  OrchestratorRouting,
   ProviderId,
   SessionId,
   WorkflowId,
@@ -24,6 +25,7 @@ type Options = {
   chainAfterId?: WorkflowRunId;
   attachmentInputs?: ReadonlyArray<AttachmentInput>;
   executionMode?: WorkflowExecutionMode;
+  stepRouting?: OrchestratorRouting;
 };
 
 export const attachWorkflowToSession = (set: SetFn, get: GetFn) => {
@@ -77,6 +79,7 @@ export const attachWorkflowToSession = (set: SetFn, get: GetFn) => {
       triggerMode,
       chainAfterId,
       executionMode,
+      options?.stepRouting,
     );
 
     const existingRuns = get().sessionPhaseRuns[sessionId] ?? [];
@@ -111,6 +114,7 @@ export const attachWorkflowToSession = (set: SetFn, get: GetFn) => {
       autoRun,
       triggerMode,
       executionMode,
+      ...(options?.stepRouting != null && { stepRouting: options.stepRouting }),
       ...(chainAfterId && { chainAfterId }),
       ...(goal && { goal }),
     };

--- a/apps/desktop/src/store/slices/workflows/index.ts
+++ b/apps/desktop/src/store/slices/workflows/index.ts
@@ -15,6 +15,7 @@ import { continueWorkflowRun } from './continueWorkflowRun';
 import { orchestrateNextStep } from './orchestrateNextStep';
 import { setWorkflowOrchestratorHints } from './setWorkflowOrchestratorHints';
 import { setWorkflowOrchestratorRouting } from './setWorkflowOrchestratorRouting';
+import { setWorkflowStepRouting } from './setWorkflowStepRouting';
 import { reorderSessionWorkflows } from './reorderSessionWorkflows';
 import { restoreWorkflow } from './restoreWorkflow';
 import { retryWorkflowOrchestration } from './retryWorkflowOrchestration';
@@ -57,6 +58,7 @@ export const createWorkflowsSlice = (set: SetFn, get: GetFn) => {
     continueWorkflowRun: continueWorkflowRun(set, get),
     setWorkflowOrchestratorHints: setWorkflowOrchestratorHints(set, get),
     setWorkflowOrchestratorRouting: setWorkflowOrchestratorRouting(set, get),
+    setWorkflowStepRouting: setWorkflowStepRouting(set, get),
     retryStepSummary: retryStepSummary(set, get),
   };
 };

--- a/apps/desktop/src/store/slices/workflows/orchestrateNextStep.test.ts
+++ b/apps/desktop/src/store/slices/workflows/orchestrateNextStep.test.ts
@@ -240,6 +240,44 @@ describe('orchestrateNextStep', () => {
     expect(invokeWorkflowUpsertSpy.mock.calls[0]![0].steps[1].name).toBe('Scout 2');
   });
 
+  it('spawns every decided step on the routing policy pinned to the run', async () => {
+    decideSpy.mockResolvedValue({
+      decision: {
+        action: 'next',
+        reason: 'Implement it.',
+        step: {
+          name: 'Implement',
+          role: 'implementer',
+          promptPrefix: 'Implement the change.',
+          model: 'opus-5',
+          effort: 'max',
+        },
+      },
+    });
+    const state = baseState();
+    const current = (state['sessions'] as ReadonlyArray<Session>)[0]!;
+    state['sessions'] = [
+      {
+        ...current,
+        workflowRuns: current.workflowRuns.map((run) => ({
+          ...run,
+          stepRouting: { providerId: 'codex', model: 'gpt-5.5', effort: 'high' },
+        })),
+      },
+    ];
+    const { set, get } = harness(state);
+
+    await orchestrateNextStep(set, get)(SESSION_ID, WORKFLOW_RUN_ID);
+
+    expect(invokeAgentInsertSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerOverride: 'codex',
+        modelOverride: 'gpt-5.5',
+        effort: 'high',
+      }),
+    );
+  });
+
   it('emits done and stops without adding a step', async () => {
     decideSpy.mockResolvedValue({
       decision: { action: 'done', reason: 'All required tests pass.' },

--- a/apps/desktop/src/store/slices/workflows/orchestrateNextStep.ts
+++ b/apps/desktop/src/store/slices/workflows/orchestrateNextStep.ts
@@ -260,6 +260,10 @@ const appendStep = async ({
   if (session == null) {
     throw new Error(`session not found: ${sessionId}`);
   }
+  const run = session.workflowRuns.find((candidate) => candidate.id === workflowRunId);
+  if (run == null) {
+    throw new Error(`workflow run not found: ${workflowRunId}`);
+  }
   const existingAgents = get().sessionPhaseRuns[sessionId] ?? [];
   const baseOrdinal =
     existingAgents.reduce((max, current) => Math.max(max, current.ordinal), -1) + 1;
@@ -271,6 +275,7 @@ const appendStep = async ({
     defaultProvider: (session.providerOverride ??
       session.providerPreference.defaultProvider) as ProviderId,
     roleModels: roleModelsForSession({ state: get(), sessionId }),
+    ...(run.stepRouting != null && { routingOverride: run.stepRouting }),
   });
   const agent = spawned.agents[0];
   if (agent == null) {

--- a/apps/desktop/src/store/slices/workflows/preSpawnWorkflowAgents.test.ts
+++ b/apps/desktop/src/store/slices/workflows/preSpawnWorkflowAgents.test.ts
@@ -69,4 +69,47 @@ describe('preSpawnWorkflowAgents', () => {
     expect(insert['modelOverride']).not.toBe('');
     expect(insert['providerOverride']).toBe('anthropic');
   });
+
+  it('gives a run policy precedence over the decided step routing', async () => {
+    const result = await preSpawnWorkflowAgents({
+      sessionId: SESSION_ID,
+      workflowRunId: RUN_ID,
+      steps: [
+        step({
+          providerOverride: 'anthropic',
+          modelOverride: 'opus-5',
+          effort: 'max',
+        }),
+      ],
+      baseOrdinal: 0,
+      defaultProvider: 'anthropic',
+      roleModels: null,
+      routingOverride: { providerId: 'codex', model: 'gpt-5.5', effort: 'high' },
+    });
+
+    const insert = invokeAgentInsertSpy.mock.calls[0]![0] as Record<string, unknown>;
+    expect(insert).toMatchObject({
+      providerOverride: 'codex',
+      modelOverride: 'gpt-5.5',
+      effort: 'high',
+    });
+    expect(result.effortOverrides['agent-1']).toBe('high');
+  });
+
+  it('does not carry a decided effort into a policy model with no effort', async () => {
+    const result = await preSpawnWorkflowAgents({
+      sessionId: SESSION_ID,
+      workflowRunId: RUN_ID,
+      steps: [step({ modelOverride: 'opus-5', effort: 'max' })],
+      baseOrdinal: 0,
+      defaultProvider: 'anthropic',
+      roleModels: null,
+      routingOverride: { providerId: 'anthropic', model: 'haiku-4.5' },
+    });
+
+    const insert = invokeAgentInsertSpy.mock.calls[0]![0] as Record<string, unknown>;
+    expect(insert['modelOverride']).toBe('haiku-4.5');
+    expect(insert['effort']).toBeUndefined();
+    expect(result.effortOverrides['agent-1']).toBeUndefined();
+  });
 });

--- a/apps/desktop/src/store/slices/workflows/preSpawnWorkflowAgents.ts
+++ b/apps/desktop/src/store/slices/workflows/preSpawnWorkflowAgents.ts
@@ -1,6 +1,7 @@
 import type {
   Agent,
   ModelEffort,
+  OrchestratorRouting,
   ProviderId,
   RoleModelPreferences,
   SessionId,
@@ -24,6 +25,7 @@ type Params = {
   readonly defaultProvider: ProviderId;
   readonly roleModels: RoleModelPreferences | null;
   readonly defaultVerbosity?: VerbosityLevel;
+  readonly routingOverride?: OrchestratorRouting;
 };
 
 type PreSpawnWorkflowAgentsResult = {
@@ -42,6 +44,7 @@ export const preSpawnWorkflowAgents = async ({
   defaultProvider,
   roleModels,
   defaultVerbosity,
+  routingOverride,
 }: Params): Promise<PreSpawnWorkflowAgentsResult> => {
   const agents: Agent[] = [];
   const modelOverrides: Record<string, string> = {};
@@ -52,10 +55,11 @@ export const preSpawnWorkflowAgents = async ({
 
   for (const [index, step] of sortedSteps.entries()) {
     const kind = step.role ? ROLE_TO_KIND[step.role] : inferAgentKindFromName(step.name);
-    const provider = step.providerOverride ?? defaultProvider;
+    const provider = routingOverride?.providerId ?? step.providerOverride ?? defaultProvider;
     const model = resolveModelForProvider({
       provider,
       modelId:
+        routingOverride?.model ??
         step.modelOverride ??
         (step.role != null
           ? recommendedModelForRole({
@@ -76,13 +80,15 @@ export const preSpawnWorkflowAgents = async ({
       ...(defaultVerbosity != null && { verbosity: defaultVerbosity }),
       providerOverride: provider,
       modelOverride: model,
-      ...(step.effort != null && { effort: step.effort }),
+      ...(routingOverride?.effort != null && { effort: routingOverride.effort }),
+      ...(routingOverride == null && step.effort != null && { effort: step.effort }),
     });
     providerOverrides[agent.id] = provider;
     modelOverrides[agent.id] = model;
     kindOverrides[agent.id] = kind;
-    if (step.effort != null) {
-      effortOverrides[agent.id] = step.effort;
+    const effort = routingOverride == null ? step.effort : routingOverride.effort;
+    if (effort != null) {
+      effortOverrides[agent.id] = effort;
     }
     agents.push(agent);
   }

--- a/apps/desktop/src/store/slices/workflows/reprocessGoalForWorkflow.ts
+++ b/apps/desktop/src/store/slices/workflows/reprocessGoalForWorkflow.ts
@@ -1,5 +1,5 @@
 import type { ContextSlot, SessionId } from '@goodboy/types';
-import { rewriteWorkflowGoal } from '@goodboy/core';
+import { resolveTaskModel, rewriteWorkflowGoal } from '@goodboy/core';
 import { upsertContextSlot } from '@goodboy/db';
 import { invoke } from '@tauri-apps/api/core';
 import { tauriDatabase } from '../../../shared/lib/db';
@@ -37,9 +37,14 @@ export const reprocessGoalForWorkflow = (set: SetFn, get: GetFn) => {
       }
 
       const worktreePath = getSessionRepo({ get, sessionId })?.worktreePath ?? null;
+      const taskModel = resolveTaskModel(
+        'prose_polish',
+        state.workspaceOverrides?.[session.workspaceId]?.taskModels,
+        session.providerPreference.defaultProvider,
+      );
       const rewritten = await rewriteWorkflowGoal(
         {
-          providerId: session.providerPreference.defaultProvider,
+          ...taskModel,
           invokeFn: invoke,
           ...(worktreePath != null && { workingDir: worktreePath }),
         },

--- a/apps/desktop/src/store/slices/workflows/setWorkflowStepRouting.ts
+++ b/apps/desktop/src/store/slices/workflows/setWorkflowStepRouting.ts
@@ -1,0 +1,29 @@
+import type { OrchestratorRouting, SessionId, WorkflowRunId } from '@goodboy/types';
+import { updateWorkflowRunStepRouting } from '@goodboy/db';
+import { tauriDatabase } from '../../../shared/lib/db';
+import { patchWorkflowRun, withoutKeys } from './patchWorkflowRun';
+import type { GetFn, SetFn } from './types';
+
+export const setWorkflowStepRouting = (set: SetFn, get: GetFn) => {
+  return async (
+    sessionId: SessionId,
+    workflowRunId: WorkflowRunId,
+    routing: OrchestratorRouting | null,
+  ) => {
+    const session = get().sessions.find((candidate) => candidate.id === sessionId);
+    const run = session?.workflowRuns.find((candidate) => candidate.id === workflowRunId);
+    if (run == null) {
+      return;
+    }
+    await updateWorkflowRunStepRouting(tauriDatabase, workflowRunId, routing);
+    patchWorkflowRun({
+      set,
+      sessionId,
+      workflowRunId,
+      patch: (current) =>
+        routing == null
+          ? withoutKeys(current, ['stepRouting'])
+          : { ...current, stepRouting: routing },
+    });
+  };
+};

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -247,6 +247,7 @@ export type AppActions = {
       chainAfterId?: WorkflowRunId;
       attachmentInputs?: ReadonlyArray<AttachmentInput>;
       executionMode?: WorkflowExecutionMode;
+      stepRouting?: OrchestratorRouting;
     },
   ): Promise<void>;
   detachWorkflowFromSession(sessionId: SessionId, workflowRunId: WorkflowRunId): Promise<void>;
@@ -299,6 +300,11 @@ export type AppActions = {
     hints: string,
   ): Promise<void>;
   setWorkflowOrchestratorRouting(
+    sessionId: SessionId,
+    workflowRunId: WorkflowRunId,
+    routing: OrchestratorRouting | null,
+  ): Promise<void>;
+  setWorkflowStepRouting(
     sessionId: SessionId,
     workflowRunId: WorkflowRunId,
     routing: OrchestratorRouting | null,

--- a/packages/core/src/providers/modelAxes.test.ts
+++ b/packages/core/src/providers/modelAxes.test.ts
@@ -4,6 +4,8 @@ import { ANTHROPIC_CATALOG } from './claude/catalog';
 import { CODEX_CATALOG } from './codex/catalog';
 import { CURSOR_CATALOG } from './cursor/catalog';
 import { modelAxes } from './modelAxes';
+import { OPENCODE_CATALOG } from './opencode/catalog';
+import { OPENROUTER_CATALOG } from './openrouter/catalog';
 import { selectionRequiresMaxMode } from './selectionRequiresMaxMode';
 
 describe('modelAxes', () => {
@@ -82,20 +84,29 @@ describe('modelAxes', () => {
     ]);
   });
 
-  it('renders a fully unavailable effort row for anthropic models without authored efforts', () => {
+  it('omits the effort axis for anthropic models without authored efforts', () => {
     const model = ANTHROPIC_CATALOG.find((candidate) => candidate.key === 'haiku-4.5');
     if (model == null) {
       throw new Error('missing anthropic haiku-4.5');
     }
     const axes = modelAxes({ model, selection: { key: model.key } });
-    expect(axes.effort?.levels.map((entry) => entry.level)).toEqual([
-      'low',
-      'medium',
-      'high',
-      'xhigh',
-      'max',
-    ]);
-    expect(axes.effort?.levels.every((entry) => entry.available === false)).toBe(true);
+    expect(axes.effort).toBeNull();
+  });
+
+  it('uses Effort as the effort axis label across providers', () => {
+    const models = [
+      ANTHROPIC_CATALOG.find((candidate) => candidate.key === 'opus-5'),
+      CODEX_CATALOG[0],
+      CURSOR_CATALOG.find((candidate) => candidate.key === 'opus-5'),
+      OPENCODE_CATALOG[0],
+      OPENROUTER_CATALOG[0],
+    ];
+    for (const model of models) {
+      if (model == null) {
+        throw new Error('missing effort axis fixture');
+      }
+      expect(modelAxes({ model, selection: { key: model.key } }).effort?.label).toBe('Effort');
+    }
   });
 
   it('reports Max Mode from the resolved cursor combo', () => {

--- a/packages/core/src/providers/modelAxes.ts
+++ b/packages/core/src/providers/modelAxes.ts
@@ -129,13 +129,16 @@ export const modelAxes = ({ model, selection }: Params): ModelAxes => {
   switch (model.provider) {
     case 'anthropic':
       return {
-        effort: {
-          label: 'Effort',
-          levels: ANTHROPIC_EFFORT_ORDER.map((level) => ({
-            level,
-            available: model.efforts.includes(level),
-          })),
-        },
+        effort:
+          model.efforts.length > 0
+            ? {
+                label: 'Effort',
+                levels: ANTHROPIC_EFFORT_ORDER.map((level) => ({
+                  level,
+                  available: model.efforts.includes(level),
+                })),
+              }
+            : null,
         variant: null,
         toggles: [],
         requiresMaxMode: false,
@@ -159,7 +162,7 @@ export const modelAxes = ({ model, selection }: Params): ModelAxes => {
     case 'opencode':
     case 'openrouter':
       return {
-        effort: effortAxis({ label: 'Variant', efforts: model.efforts }),
+        effort: effortAxis({ label: 'Effort', efforts: model.efforts }),
         variant: null,
         toggles: [],
         requiresMaxMode: false,

--- a/packages/core/src/summarizer/goal-rewrite.test.ts
+++ b/packages/core/src/summarizer/goal-rewrite.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from 'vitest';
+import { rewriteWorkflowGoal } from './goal-rewrite';
+
+describe('rewriteWorkflowGoal', () => {
+  it('uses the resolved task model and effort', async () => {
+    const invokeFn = vi.fn().mockResolvedValue({
+      stdout: JSON.stringify({ result: 'Ship the finished feature.' }),
+      stderr: '',
+      exitCode: 0,
+    });
+
+    await expect(
+      rewriteWorkflowGoal(
+        { providerId: 'anthropic', model: 'sonnet-4.6', effort: 'high', invokeFn },
+        { goal: 'Plan and implement the feature', stepNames: ['Plan', 'Implement'] },
+      ),
+    ).resolves.toBe('Ship the finished feature.');
+    expect(invokeFn).toHaveBeenCalledWith(
+      'summarize_session',
+      expect.objectContaining({
+        args: expect.objectContaining({ model: 'claude-sonnet-4-6', effort: 'high' }),
+      }),
+    );
+  });
+});

--- a/packages/core/src/summarizer/goal-rewrite.ts
+++ b/packages/core/src/summarizer/goal-rewrite.ts
@@ -1,7 +1,7 @@
-import type { ProviderId } from '@goodboy/types';
+import type { TaskModelPreference } from '@goodboy/types';
 import { extractAuxOutput } from '../providers/aux-output';
 import { runAuxOneShot } from '../providers/aux-spawn';
-import { getCheapModel, getDefaultBinary } from '../providers/cli-defaults';
+import { getDefaultBinary } from '../providers/cli-defaults';
 
 const GOAL_REWRITE_SYSTEM_PROMPT = `You clean the "goal" note for an AI coding session that is driven by a multi-step agent workflow. Each workflow step runs as its own dedicated agent, so the goal note must describe ONLY the desired end result, never the process used to reach it.
 
@@ -22,8 +22,7 @@ export type GoalRewriteInput = {
   readonly stepNames: ReadonlyArray<string>;
 };
 
-export type GoalRewriteDeps = {
-  readonly providerId: ProviderId;
+export type GoalRewriteDeps = TaskModelPreference & {
   readonly binary?: string;
   readonly workingDir?: string;
   readonly invokeFn: <T>(cmd: string, args?: Record<string, unknown>) => Promise<T>;
@@ -53,7 +52,8 @@ export const rewriteWorkflowGoal = async (
 
   const result = await runAuxOneShot({
     providerId: deps.providerId,
-    model: getCheapModel(deps.providerId),
+    model: deps.model,
+    ...(deps.effort != null && { effort: deps.effort }),
     binary: deps.binary ?? getDefaultBinary(deps.providerId),
     userMessage: buildGoalRewriteUserPrompt(input),
     systemPrompt: GOAL_REWRITE_SYSTEM_PROMPT,

--- a/packages/core/src/workflows/polish-step.test.ts
+++ b/packages/core/src/workflows/polish-step.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from 'vitest';
+import { polishStepInstruction } from './polish-step';
+
+describe('polishStepInstruction', () => {
+  it('uses the resolved task model and effort', async () => {
+    const invokeFn = vi.fn().mockResolvedValue({
+      stdout: JSON.stringify({ result: '<<step>>Polished instruction.<</step>>' }),
+      stderr: '',
+      exitCode: 0,
+    });
+
+    await expect(
+      polishStepInstruction(
+        { providerId: 'anthropic', model: 'sonnet-4.6', effort: 'high', invokeFn },
+        { role: 'implementer', name: 'Implement', instruction: 'rough instruction' },
+      ),
+    ).resolves.toBe('Polished instruction.');
+    expect(invokeFn).toHaveBeenCalledWith(
+      'summarize_session',
+      expect.objectContaining({
+        args: expect.objectContaining({ model: 'claude-sonnet-4-6', effort: 'high' }),
+      }),
+    );
+  });
+});

--- a/packages/core/src/workflows/polish-step.ts
+++ b/packages/core/src/workflows/polish-step.ts
@@ -1,7 +1,7 @@
-import type { ProviderId } from '@goodboy/types';
+import type { TaskModelPreference } from '@goodboy/types';
 import { extractAuxOutput } from '../providers/aux-output';
 import { runAuxOneShot } from '../providers/aux-spawn';
-import { getCheapModel, getDefaultBinary } from '../providers/cli-defaults';
+import { getDefaultBinary } from '../providers/cli-defaults';
 
 const STEP_POLISH_SYSTEM_PROMPT = `You polish step instructions for AI coding workflows.
 
@@ -22,8 +22,7 @@ the polished instruction text
 
 Plain text inside the block. No markdown, no quotes, no trailing prose.`;
 
-export type StepPolishDeps = {
-  readonly providerId: ProviderId;
+export type StepPolishDeps = TaskModelPreference & {
   readonly binary?: string;
   readonly workingDir?: string;
   readonly invokeFn: <T>(cmd: string, args?: Record<string, unknown>) => Promise<T>;
@@ -55,7 +54,8 @@ export const polishStepInstruction = async (
 
   const result = await runAuxOneShot({
     providerId: deps.providerId,
-    model: getCheapModel(deps.providerId),
+    model: deps.model,
+    ...(deps.effort != null && { effort: deps.effort }),
     binary: deps.binary ?? getDefaultBinary(deps.providerId),
     userMessage,
     systemPrompt: STEP_POLISH_SYSTEM_PROMPT,

--- a/packages/core/src/workflows/polish.test.ts
+++ b/packages/core/src/workflows/polish.test.ts
@@ -29,6 +29,7 @@ describe('parsePolishedGoal', () => {
 describe('polishWorkflowGoal', () => {
   const deps = (stdout: string, exitCode = 0): GoalPolishDeps => ({
     providerId: 'anthropic',
+    model: 'sonnet-4.6',
     invokeFn: vi.fn().mockResolvedValue({ stdout, stderr: '', exitCode }),
   });
 
@@ -40,7 +41,12 @@ describe('polishWorkflowGoal', () => {
 
   it('parses the anthropic result envelope', async () => {
     const stdout = JSON.stringify({ result: '<<goal>>Polished goal.<</goal>>' });
-    expect(await polishWorkflowGoal(deps(stdout), 'rough goal')).toBe('Polished goal.');
+    const d = deps(stdout);
+    expect(await polishWorkflowGoal(d, 'rough goal')).toBe('Polished goal.');
+    expect(d.invokeFn).toHaveBeenCalledWith(
+      'summarize_session',
+      expect.objectContaining({ args: expect.objectContaining({ model: 'claude-sonnet-4-6' }) }),
+    );
   });
 
   it('returns null on non-zero exit code', async () => {

--- a/packages/core/src/workflows/polish.ts
+++ b/packages/core/src/workflows/polish.ts
@@ -1,7 +1,7 @@
-import type { ProviderId } from '@goodboy/types';
+import type { TaskModelPreference } from '@goodboy/types';
 import { extractAuxOutput } from '../providers/aux-output';
 import { runAuxOneShot } from '../providers/aux-spawn';
-import { getCheapModel, getDefaultBinary } from '../providers/cli-defaults';
+import { getDefaultBinary } from '../providers/cli-defaults';
 
 const GOAL_POLISH_SYSTEM_PROMPT = `You polish goal statements for AI coding workflows.
 
@@ -21,8 +21,7 @@ the polished goal text
 
 Plain text inside the block. No markdown, no quotes, no trailing prose.`;
 
-export type GoalPolishDeps = {
-  readonly providerId: ProviderId;
+export type GoalPolishDeps = TaskModelPreference & {
   readonly binary?: string;
   readonly workingDir?: string;
   readonly invokeFn: <T>(cmd: string, args?: Record<string, unknown>) => Promise<T>;
@@ -39,7 +38,8 @@ export const polishWorkflowGoal = async (
 
   const result = await runAuxOneShot({
     providerId: deps.providerId,
-    model: getCheapModel(deps.providerId),
+    model: deps.model,
+    ...(deps.effort != null && { effort: deps.effort }),
     binary: deps.binary ?? getDefaultBinary(deps.providerId),
     userMessage: `GOAL (rough draft):\n${trimmed}\n\nRewrite it as the single <<goal>> marker block.`,
     systemPrompt: GOAL_POLISH_SYSTEM_PROMPT,

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -63,6 +63,7 @@ export {
   updateWorkflowRunOrchestrationError,
   updateWorkflowRunOrchestratorHints,
   updateWorkflowRunOrchestratorRouting,
+  updateWorkflowRunStepRouting,
 } from './queries/session-workflow';
 export { insertMessage, listMessagesForAgent, listMessagesForSession } from './queries/message';
 export {

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -95,6 +95,7 @@ import { m094WorkflowOrchestrationState } from './m094-workflow-orchestration-st
 import { m095WorkflowOrchestratorRouting } from './m095-workflow-orchestrator-routing';
 import { m096SessionExternalTaskMount } from './m096-session-external-task-mount';
 import { m097SessionActiveMount } from './m097-session-active-mount';
+import { m098WorkflowStepRouting } from './m098-workflow-step-routing';
 
 export type Migration = {
   readonly version: number;
@@ -199,4 +200,5 @@ export const migrations: ReadonlyArray<Migration> = [
   { version: 95, sql: m095WorkflowOrchestratorRouting },
   { version: 96, sql: m096SessionExternalTaskMount },
   { version: 97, sql: m097SessionActiveMount },
+  { version: 98, sql: m098WorkflowStepRouting },
 ];

--- a/packages/db/src/migrations/m098-workflow-step-routing.ts
+++ b/packages/db/src/migrations/m098-workflow-step-routing.ts
@@ -1,0 +1,5 @@
+export const m098WorkflowStepRouting = `
+ALTER TABLE session_workflows ADD COLUMN step_provider TEXT;
+ALTER TABLE session_workflows ADD COLUMN step_model TEXT;
+ALTER TABLE session_workflows ADD COLUMN step_effort TEXT;
+`;

--- a/packages/db/src/queries/session-workflow.test.ts
+++ b/packages/db/src/queries/session-workflow.test.ts
@@ -18,6 +18,7 @@ import {
   updateWorkflowOrder,
   updateWorkflowRunOrchestrationOutcome,
   updateWorkflowRunOrchestratorRouting,
+  updateWorkflowRunStepRouting,
 } from './session-workflow';
 import { listSessionsForWorkspace } from './session';
 
@@ -407,6 +408,44 @@ describe('session_workflows trigger-mode queries', () => {
       ).toBeUndefined();
     });
 
+    it('round-trips the step routing policy pinned on the run and clears it', async () => {
+      await attachDynamic();
+      await updateWorkflowRunStepRouting(db, 'run-1' as WorkflowRunId, {
+        providerId: 'codex',
+        model: 'gpt-5.6-terra',
+        effort: 'high',
+      });
+      expect((await listWorkflowsForSession(db, sessionId))[0]!.stepRouting).toEqual({
+        providerId: 'codex',
+        model: 'gpt-5.6-terra',
+        effort: 'high',
+      });
+      await updateWorkflowRunStepRouting(db, 'run-1' as WorkflowRunId, null);
+      expect((await listWorkflowsForSession(db, sessionId))[0]!.stepRouting).toBeUndefined();
+    });
+
+    it('persists the step routing policy when the run is attached', async () => {
+      await attachWorkflowToSession(
+        db,
+        sessionId,
+        'run-1' as WorkflowRunId,
+        workflowId,
+        true,
+        NOW,
+        undefined,
+        'immediate',
+        undefined,
+        'dynamic',
+        { providerId: 'cursor', model: 'composer-2.5', effort: 'medium' },
+      );
+
+      expect((await listWorkflowsForSession(db, sessionId))[0]!.stepRouting).toEqual({
+        providerId: 'cursor',
+        model: 'composer-2.5',
+        effort: 'medium',
+      });
+    });
+
     it('carries the reason and the routing through a reorder', async () => {
       await attachDynamic();
       await attachWorkflowToSession(
@@ -422,6 +461,10 @@ describe('session_workflows trigger-mode queries', () => {
         providerId: 'codex',
         model: 'gpt-5.6',
       });
+      await updateWorkflowRunStepRouting(db, 'run-1' as WorkflowRunId, {
+        providerId: 'cursor',
+        model: 'composer-2.5',
+      });
       await updateWorkflowOrder(
         db,
         sessionId,
@@ -433,6 +476,7 @@ describe('session_workflows trigger-mode queries', () => {
       )!;
       expect(run.orchestrationReason).toBe('all set');
       expect(run.orchestratorRouting).toEqual({ providerId: 'codex', model: 'gpt-5.6' });
+      expect(run.stepRouting).toEqual({ providerId: 'cursor', model: 'composer-2.5' });
     });
   });
 
@@ -499,6 +543,11 @@ describe('session hydration carries the orchestrator state', () => {
       model: 'gpt-5.6',
       effort: 'high',
     });
+    await updateWorkflowRunStepRouting(db, 'run-1' as WorkflowRunId, {
+      providerId: 'cursor',
+      model: 'composer-2.5',
+      effort: 'medium',
+    });
 
     const sessions = await listSessionsForWorkspace(db, workspaceId);
     const run = sessions[0]!.workflowRuns[0]!;
@@ -508,6 +557,11 @@ describe('session hydration carries the orchestrator state', () => {
       providerId: 'codex',
       model: 'gpt-5.6',
       effort: 'high',
+    });
+    expect(run.stepRouting).toEqual({
+      providerId: 'cursor',
+      model: 'composer-2.5',
+      effort: 'medium',
     });
   });
 });

--- a/packages/db/src/queries/session-workflow.ts
+++ b/packages/db/src/queries/session-workflow.ts
@@ -28,27 +28,45 @@ export type SessionWorkflowRow = {
   orchestrator_provider: string | null;
   orchestrator_model: string | null;
   orchestrator_effort: string | null;
+  step_provider: string | null;
+  step_model: string | null;
+  step_effort: string | null;
   chain_after_run_id: string | null;
   goal: string | null;
   discarded_at: string | null;
 };
 
 export const SESSION_WORKFLOW_COLS =
-  'workflow_run_id, workflow_id, ordinal, current_step_ordinal, auto_run, trigger_mode, execution_mode, orchestration_outcome, orchestration_reason, orchestration_error, orchestrator_hints, orchestrator_provider, orchestrator_model, orchestrator_effort, chain_after_run_id, goal, discarded_at';
+  'workflow_run_id, workflow_id, ordinal, current_step_ordinal, auto_run, trigger_mode, execution_mode, orchestration_outcome, orchestration_reason, orchestration_error, orchestrator_hints, orchestrator_provider, orchestrator_model, orchestrator_effort, step_provider, step_model, step_effort, chain_after_run_id, goal, discarded_at';
 
-const toRouting = (row: SessionWorkflowRow): OrchestratorRouting | null => {
-  if (row.orchestrator_provider == null || row.orchestrator_model == null) {
+type RoutingColumns = {
+  readonly provider: string | null;
+  readonly model: string | null;
+  readonly effort: string | null;
+};
+
+const toRouting = ({ provider, model, effort }: RoutingColumns): OrchestratorRouting | null => {
+  if (provider == null || model == null) {
     return null;
   }
   return {
-    providerId: row.orchestrator_provider as ProviderId,
-    model: row.orchestrator_model,
-    ...(row.orchestrator_effort != null && { effort: row.orchestrator_effort as ModelEffort }),
+    providerId: provider as ProviderId,
+    model,
+    ...(effort != null && { effort: effort as ModelEffort }),
   };
 };
 
 export function toWorkflowRun(row: SessionWorkflowRow): WorkflowRun {
-  const routing = toRouting(row);
+  const orchestratorRouting = toRouting({
+    provider: row.orchestrator_provider,
+    model: row.orchestrator_model,
+    effort: row.orchestrator_effort,
+  });
+  const stepRouting = toRouting({
+    provider: row.step_provider,
+    model: row.step_model,
+    effort: row.step_effort,
+  });
   return {
     id: row.workflow_run_id as WorkflowRunId,
     workflowId: row.workflow_id as WorkflowId,
@@ -66,7 +84,8 @@ export function toWorkflowRun(row: SessionWorkflowRow): WorkflowRun {
       row.orchestration_error !== '' && { orchestrationError: row.orchestration_error }),
     ...(row.orchestrator_hints != null &&
       row.orchestrator_hints !== '' && { orchestratorHints: row.orchestrator_hints }),
-    ...(routing != null && { orchestratorRouting: routing }),
+    ...(orchestratorRouting != null && { orchestratorRouting }),
+    ...(stepRouting != null && { stepRouting }),
     ...(row.chain_after_run_id != null && {
       chainAfterId: row.chain_after_run_id as WorkflowRunId,
     }),
@@ -108,6 +127,7 @@ export const attachWorkflowToSession = async (
   triggerMode: WorkflowTriggerMode = 'immediate',
   chainAfterRunId?: WorkflowRunId,
   executionMode: WorkflowExecutionMode = 'static',
+  stepRouting?: OrchestratorRouting,
 ): Promise<void> => {
   const maxOrdinal = await db.select<{ max_ordinal: number | null }>(
     'SELECT MAX(ordinal) as max_ordinal FROM session_workflows WHERE session_id = ?',
@@ -116,7 +136,7 @@ export const attachWorkflowToSession = async (
   const nextOrdinal = (maxOrdinal[0]?.max_ordinal ?? -1) + 1;
 
   await db.execute(
-    'INSERT INTO session_workflows (workflow_run_id, session_id, workflow_id, ordinal, current_step_ordinal, auto_run, goal, trigger_mode, chain_after_run_id, execution_mode) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+    'INSERT INTO session_workflows (workflow_run_id, session_id, workflow_id, ordinal, current_step_ordinal, auto_run, goal, trigger_mode, chain_after_run_id, execution_mode, step_provider, step_model, step_effort) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
     [
       workflowRunId,
       sessionId,
@@ -128,6 +148,9 @@ export const attachWorkflowToSession = async (
       triggerMode,
       chainAfterRunId ?? null,
       executionMode,
+      stepRouting?.providerId ?? null,
+      stepRouting?.model ?? null,
+      stepRouting?.effort ?? null,
     ],
   );
   await bumpSessionUpdatedAt(db, sessionId, updatedAt);
@@ -164,7 +187,7 @@ export const updateWorkflowOrder = async (
         continue;
       }
       await db.execute(
-        'INSERT INTO session_workflows (workflow_run_id, session_id, workflow_id, ordinal, current_step_ordinal, auto_run, goal, discarded_at, trigger_mode, chain_after_run_id, execution_mode, orchestration_outcome, orchestration_reason, orchestration_error, orchestrator_hints, orchestrator_provider, orchestrator_model, orchestrator_effort) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+        'INSERT INTO session_workflows (workflow_run_id, session_id, workflow_id, ordinal, current_step_ordinal, auto_run, goal, discarded_at, trigger_mode, chain_after_run_id, execution_mode, orchestration_outcome, orchestration_reason, orchestration_error, orchestrator_hints, orchestrator_provider, orchestrator_model, orchestrator_effort, step_provider, step_model, step_effort) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
         [
           runId,
           sessionId,
@@ -184,6 +207,9 @@ export const updateWorkflowOrder = async (
           prev.orchestrator_provider,
           prev.orchestrator_model,
           prev.orchestrator_effort,
+          prev.step_provider,
+          prev.step_model,
+          prev.step_effort,
         ],
       );
     }
@@ -270,6 +296,17 @@ export const updateWorkflowRunOrchestratorRouting = async (
 ): Promise<void> => {
   await db.execute(
     'UPDATE session_workflows SET orchestrator_provider = ?, orchestrator_model = ?, orchestrator_effort = ? WHERE workflow_run_id = ?',
+    [routing?.providerId ?? null, routing?.model ?? null, routing?.effort ?? null, workflowRunId],
+  );
+};
+
+export const updateWorkflowRunStepRouting = async (
+  db: Database,
+  workflowRunId: WorkflowRunId,
+  routing: OrchestratorRouting | null,
+): Promise<void> => {
+  await db.execute(
+    'UPDATE session_workflows SET step_provider = ?, step_model = ?, step_effort = ? WHERE workflow_run_id = ?',
     [routing?.providerId ?? null, routing?.model ?? null, routing?.effort ?? null, workflowRunId],
   );
 };

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -165,6 +165,7 @@ export type {
   TaskModelPreferences,
   VerbosityLevel,
 } from './settings';
+export { TASKS } from './settings';
 export type { BranchCommit, DiffView, WorktreeDiffScope, WorktreeStatus } from './worktree';
 export type {
   ConfigBundle,

--- a/packages/types/src/settings.ts
+++ b/packages/types/src/settings.ts
@@ -10,10 +10,59 @@ export type AuxTaskId =
   | 'summarizer'
   | 'branch_naming'
   | 'plan_generation'
+  | 'prose_polish'
   | 'agent_naming'
   | 'workflow_orchestrator'
   | 'pr_draft'
   | 'rebase';
+
+export const TASKS: ReadonlyArray<{
+  readonly id: AuxTaskId;
+  readonly label: string;
+  readonly description: string;
+}> = [
+  {
+    id: 'summarizer',
+    label: 'Step summaries',
+    description: 'Condenses each finished step into the summary the next step starts from',
+  },
+  {
+    id: 'branch_naming',
+    label: 'Branch naming',
+    description: 'Turns the session goal into a git branch name when the session is created',
+  },
+  {
+    id: 'plan_generation',
+    label: 'Plan drafting',
+    description: 'Writes step plans in the workflow builder and Plan Studio',
+  },
+  {
+    id: 'prose_polish',
+    label: 'Prose polish',
+    description: 'Polishes workflow goals and step instructions before they are used',
+  },
+  {
+    id: 'agent_naming',
+    label: 'Agent naming',
+    description: 'Titles new agents, and the session itself, from your first message',
+  },
+  {
+    id: 'workflow_orchestrator',
+    label: 'Workflow orchestrator',
+    description:
+      'Reads each finished step of a dynamic workflow and picks the next one, or ends the run',
+  },
+  {
+    id: 'pr_draft',
+    label: 'PR and MR drafts',
+    description: 'Preselected model for the agent that drafts a pull or merge request',
+  },
+  {
+    id: 'rebase',
+    label: 'Rebase',
+    description: 'Preselected model for the agent that rebases the session branch onto main',
+  },
+];
 
 export type TaskModelPreference = Readonly<{
   providerId: ProviderId;

--- a/packages/types/src/workspace.ts
+++ b/packages/types/src/workspace.ts
@@ -90,6 +90,7 @@ export type WorkflowRun = Readonly<{
   orchestrationError?: string;
   orchestratorHints?: string;
   orchestratorRouting?: OrchestratorRouting;
+  stepRouting?: OrchestratorRouting;
   chainAfterId?: WorkflowRunId;
   goal?: string;
   discardedAt?: IsoDateTime;


### PR DESCRIPTION
## What

- **The effort row is editable in the custom workflow.** It was disabled by a hardcoded `editable: false` at the call site, not by a failed lookup, and that branch of the union carries no `onChange` at all. `PlannerClient` already accepted an effort; `onPlan` simply never passed one. Same hardcode fixed in the notification retry picker.
- **A model with no efforts no longer draws five dead chips.** `haiku-4.5` declares `efforts: []` but the anthropic branch built the axis anyway, so the closed trigger hid effort while the open panel showed a fully unavailable row. It now behaves like Gemini: no row, plus the honest "no tuning options" line. This also mattered for the planner, whose default model is haiku, so the row opened dead twice over.
- **One name for the effort axis** across every provider (opencode and openrouter called it "Variant"), and cursor's Thinking/Fast toggles are no longer labelled "Variant" either.
- **Default provider** is on the canonical picker with the provider dimension only, and the chip grid duplicated verbatim in onboarding is gone.
- **Routing pool** no longer repeats "default" directly under a row headed Default provider; the status chips are uppercase and go through `tintClasses` instead of the hand-written tone classes `DESIGN.md:118-120` forbids.
- **Prose polish is a task-model role.** `polishWorkflowGoal`, `polishStepInstruction` and `rewriteWorkflowGoal` pinned `getCheapModel` themselves, outside the registry, so the one task that rewrites wording the user reads was the only one nobody could configure. It is now `prose_polish`, resolved like the other seven, and the label registry moved out of the UI literal to sit next to the ids.
- **An orchestrated run can pin the model its steps run on**, stored per run next to the decider's routing.

## Why the orchestrated override is per run and not per step

A dynamic run starts with `steps: []` and appends exactly one step per decision, budget 8 and hard cap 12. A step does not exist until the orchestrator decides it, so a pre-emptive per-step picker is not expressible. A per-run policy is. When it is unset, the orchestrator's own choice still wins.

## What was NOT touched, and why

- **No `provider` field on `OrchestratorStep`.** Cross-provider orchestrated steps need type, parser and prompt changes; out of scope.
- **`RoutingPicker`'s own test that `editable: false` disables the chips.** That behaviour is correct. The defect was at the call site.
- **Version chips.** They were already clickable for every model; the belief that they were disabled was wrong. The only gate is the outer `disabled`, which stops the popover opening at all.

The haiku axis test was rewritten with a new name and stated intent rather than relaxed.

## Verification

`turbo run typecheck` clean. Desktop 415 files / 3607 tests, db 140, core 1004, all green.