### PR TITLE
fix(desktop): the things that only showed up on real data

### DIFF
--- a/apps/desktop/src/features/github/components/GitHubStudio/InboxList.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/InboxList.tsx
@@ -1,9 +1,10 @@
 import type { SessionId } from '@goodboy/types';
 import { Button, EmptyState, Eyebrow, SelectableRow } from '@goodboy/ui';
-import { GitBranch, Plus } from 'lucide-react';
+import { GitBranch, MessagesSquare, Plus } from 'lucide-react';
 import { CONCEPT_ICONS } from '../../../../shared/components/conceptIcons';
 import { PullRequestChip } from '../PullRequestChip';
 import type { InboxGroup } from './useGithubInbox';
+import { InboxStatusIcons } from '../../../integrations/components/InboxStatusIcons';
 
 type Props = {
   readonly groups: ReadonlyArray<InboxGroup>;
@@ -81,6 +82,24 @@ export const InboxList = ({ groups, focusedSessionId, onSelect }: Props) => {
                         className="size-1.5 shrink-0 rounded-full bg-danger"
                       />
                     ) : null}
+                    <InboxStatusIcons
+                      sessionIcon={
+                        <MessagesSquare
+                          size={11}
+                          aria-label="session launched"
+                          className="text-success"
+                        />
+                      }
+                      codeHostIcon={
+                        row.pr != null ? (
+                          <CONCEPT_ICONS.github
+                            size={11}
+                            aria-label="GitHub pull request"
+                            className="text-muted-foreground/70"
+                          />
+                        ) : null
+                      }
+                    />
                   </SelectableRow>
                 </li>
               );

--- a/apps/desktop/src/features/github/components/GitHubStudio/IssueInbox.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/IssueInbox.tsx
@@ -11,6 +11,7 @@ import { MessagesSquare, Search } from 'lucide-react';
 import type { GithubIssue } from '@goodboy/types';
 import { CONCEPT_ICONS } from '../../../../shared/components/conceptIcons';
 import type { GithubIssueGroup } from './useGithubIssues';
+import { InboxStatusIcons } from '../../../integrations/components/InboxStatusIcons';
 
 type Props = {
   readonly groups: ReadonlyArray<GithubIssueGroup>;
@@ -137,10 +138,6 @@ export const IssueInbox = ({
                           ariaCurrent={isActive}
                           className="items-center gap-2.5 px-2.5 py-2"
                         >
-                          <span
-                            aria-hidden
-                            className="size-1.5 shrink-0 rounded-full bg-provider-github"
-                          />
                           <span className="shrink-0 font-mono text-2xs tabular-nums text-muted-foreground/70">
                             #{row.issue.number}
                           </span>
@@ -148,13 +145,24 @@ export const IssueInbox = ({
                           <span className="shrink-0 text-2xs tabular-nums text-muted-foreground/50">
                             {shortDate({ iso: row.issue.updatedAt })}
                           </span>
-                          {row.sessionId != null ? (
-                            <MessagesSquare
-                              size={11}
-                              aria-label="session launched"
-                              className="shrink-0 text-success"
-                            />
-                          ) : null}
+                          <InboxStatusIcons
+                            sessionIcon={
+                              row.sessionId != null ? (
+                                <MessagesSquare
+                                  size={11}
+                                  aria-label="session launched"
+                                  className="text-success"
+                                />
+                              ) : null
+                            }
+                            codeHostIcon={
+                              <CONCEPT_ICONS.github
+                                size={11}
+                                aria-label="GitHub issue"
+                                className="text-muted-foreground/70"
+                              />
+                            }
+                          />
                         </SelectableRow>
                       </li>
                     );

--- a/apps/desktop/src/features/integrations/components/InboxStatusIcons/index.tsx
+++ b/apps/desktop/src/features/integrations/components/InboxStatusIcons/index.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from 'react';
+
+type Props = {
+  readonly sessionIcon?: ReactNode;
+  readonly codeHostIcon?: ReactNode;
+};
+
+export const InboxStatusIcons = ({ sessionIcon = null, codeHostIcon = null }: Props) => (
+  <span className="flex shrink-0 items-center gap-1">
+    <span className="flex size-3 shrink-0 items-center justify-center">{sessionIcon}</span>
+    <span className="flex size-3 shrink-0 items-center justify-center">{codeHostIcon}</span>
+  </span>
+);

--- a/apps/desktop/src/features/integrations/components/LaunchSessionPanel/index.tsx
+++ b/apps/desktop/src/features/integrations/components/LaunchSessionPanel/index.tsx
@@ -179,7 +179,7 @@ export const LaunchSessionPanel = ({
         }
       />
 
-      <FieldRow label="Goal">
+      <FieldRow label="Goal" layout="stacked">
         <Textarea
           value={goal}
           onChange={(event) => setGoal(event.target.value)}
@@ -188,7 +188,7 @@ export const LaunchSessionPanel = ({
           maxRows={10}
           disabled={busy}
           aria-label="Session goal"
-          className="w-full sm:w-96"
+          className="w-full"
         />
       </FieldRow>
 
@@ -196,27 +196,26 @@ export const LaunchSessionPanel = ({
         <>
           <Divider />
           <section className="flex flex-col">
-            <SectionHeader
-              icon={<GitBranch size={12} aria-hidden />}
-              label="Branch"
-              action={
-                adoptable != null ? (
-                  <SegmentedTabs
-                    ariaLabel="branch source"
-                    options={[
-                      { value: 'adopt', label: adoptable.label, disabled: busy },
-                      { value: 'fresh', label: 'Start fresh', disabled: busy },
-                    ]}
-                    value={mode}
-                    onChange={setModeChoice}
-                    size="sm"
-                  />
-                ) : null
-              }
-            />
+            <div className="flex flex-col gap-2">
+              <SectionHeader icon={<GitBranch size={12} aria-hidden />} label="Branch" />
+              {adoptable != null ? (
+                <SegmentedTabs
+                  ariaLabel="branch source"
+                  options={[
+                    { value: 'adopt', label: adoptable.label, disabled: busy },
+                    { value: 'fresh', label: 'Start fresh', disabled: busy },
+                  ]}
+                  value={mode}
+                  onChange={setModeChoice}
+                  size="sm"
+                  fill
+                />
+              ) : null}
+            </div>
             <FieldRow
               label={isAdopting ? 'Adopted branch' : 'Branch name'}
               help={isAdopting ? adoptable.hint : undefined}
+              layout="stacked"
             >
               <div className="flex w-full flex-col gap-1.5">
                 {isAdopting ? (
@@ -249,7 +248,7 @@ export const LaunchSessionPanel = ({
                         )
                       }
                       placeholder="branch-slug"
-                      className="h-8 flex-1 font-mono text-sm"
+                      className="h-8 min-w-0 flex-1 font-mono text-sm"
                       disabled={busy}
                       autoCapitalize="off"
                       autoCorrect="off"

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/IssueInbox.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/IssueInbox.tsx
@@ -11,6 +11,7 @@ import { MessagesSquare, Search } from 'lucide-react';
 import { issueIdentifier, type GitlabIssue } from '../client';
 import { CONCEPT_ICONS } from '../../../../shared/components/conceptIcons';
 import type { GitlabIssueGroup } from './useGitlabIssues';
+import { InboxStatusIcons } from '../../components/InboxStatusIcons';
 
 type Props = {
   readonly groups: ReadonlyArray<GitlabIssueGroup>;
@@ -137,10 +138,6 @@ export const IssueInbox = ({
                           ariaCurrent={active}
                           className="items-center gap-2.5 px-2.5 py-2"
                         >
-                          <span
-                            aria-hidden
-                            className="size-1.5 shrink-0 rounded-full bg-provider-gitlab"
-                          />
                           <span className="shrink-0 font-mono text-2xs tabular-nums text-muted-foreground/70">
                             #{row.issue.iid}
                           </span>
@@ -148,13 +145,24 @@ export const IssueInbox = ({
                           <span className="shrink-0 text-2xs tabular-nums text-muted-foreground/50">
                             {shortDate(row.issue.updatedAt)}
                           </span>
-                          {row.sessionId ? (
-                            <MessagesSquare
-                              size={11}
-                              aria-label="session launched"
-                              className="shrink-0 text-success"
-                            />
-                          ) : null}
+                          <InboxStatusIcons
+                            sessionIcon={
+                              row.sessionId != null ? (
+                                <MessagesSquare
+                                  size={11}
+                                  aria-label="session launched"
+                                  className="text-success"
+                                />
+                              ) : null
+                            }
+                            codeHostIcon={
+                              <CONCEPT_ICONS.gitlab
+                                size={11}
+                                aria-label="GitLab issue"
+                                className="text-muted-foreground/70"
+                              />
+                            }
+                          />
                         </SelectableRow>
                       </li>
                     );

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrInbox.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrInbox.tsx
@@ -11,6 +11,7 @@ import { GitMerge, Search } from 'lucide-react';
 import type { GitlabMergeRequest } from '../client';
 import { CONCEPT_ICONS } from '../../../../shared/components/conceptIcons';
 import type { GitlabMrGroup } from './useGitlabMrs';
+import { InboxStatusIcons } from '../../components/InboxStatusIcons';
 
 type Props = {
   readonly groups: ReadonlyArray<GitlabMrGroup>;
@@ -139,6 +140,15 @@ export const MrInbox = ({ groups, focusedMrId, onSelect, loading, error, onRefre
                           <span className="shrink-0 text-2xs tabular-nums text-muted-foreground/50">
                             {shortDate({ iso: mr.updatedAt })}
                           </span>
+                          <InboxStatusIcons
+                            codeHostIcon={
+                              <CONCEPT_ICONS.gitlab
+                                size={11}
+                                aria-label="GitLab merge request"
+                                className="text-muted-foreground/70"
+                              />
+                            }
+                          />
                         </SelectableRow>
                       </li>
                     );

--- a/apps/desktop/src/features/integrations/linear/LinearStudio/IssueInbox.tsx
+++ b/apps/desktop/src/features/integrations/linear/LinearStudio/IssueInbox.tsx
@@ -12,6 +12,7 @@ import { issuePullRequests, type LinearIssue } from '../client';
 import { LinearPriority } from '../LinearPriority';
 import type { LinearIssueGroup } from './useLinearIssues';
 import { CONCEPT_ICONS } from '../../../../shared/components/conceptIcons';
+import { InboxStatusIcons } from '../../components/InboxStatusIcons';
 
 type Props = {
   readonly groups: ReadonlyArray<LinearIssueGroup>;
@@ -114,6 +115,10 @@ export const IssueInbox = ({
                 <ul className="flex flex-col gap-0.5">
                   {group.rows.map((row) => {
                     const active = row.issue.id === focusedIssueId;
+                    const linkedPullRequest = issuePullRequests(row.issue)[0] ?? null;
+                    const CodeHostIcon = linkedPullRequest?.url.includes('/merge_requests/')
+                      ? CONCEPT_ICONS.gitlab
+                      : CONCEPT_ICONS.github;
                     return (
                       <li key={row.issue.id}>
                         <SelectableRow
@@ -132,20 +137,26 @@ export const IssueInbox = ({
                             {row.issue.identifier}
                           </span>
                           <span className="min-w-0 flex-1 truncate text-xs">{row.issue.title}</span>
-                          {issuePullRequests(row.issue).length > 0 && (
-                            <CONCEPT_ICONS.pr
-                              size={11}
-                              aria-label="has linked pull request"
-                              className="shrink-0 text-muted-foreground/70"
-                            />
-                          )}
-                          {row.sessionId ? (
-                            <MessagesSquare
-                              size={11}
-                              aria-label="session launched"
-                              className="shrink-0 text-success"
-                            />
-                          ) : null}
+                          <InboxStatusIcons
+                            sessionIcon={
+                              row.sessionId != null ? (
+                                <MessagesSquare
+                                  size={11}
+                                  aria-label="session launched"
+                                  className="text-success"
+                                />
+                              ) : null
+                            }
+                            codeHostIcon={
+                              linkedPullRequest != null ? (
+                                <CodeHostIcon
+                                  size={11}
+                                  aria-label="has linked pull request"
+                                  className="text-muted-foreground/70"
+                                />
+                              ) : null
+                            }
+                          />
                         </SelectableRow>
                       </li>
                     );

--- a/apps/desktop/src/features/integrations/sentry/SentryStudio/IssueInbox.tsx
+++ b/apps/desktop/src/features/integrations/sentry/SentryStudio/IssueInbox.tsx
@@ -6,6 +6,7 @@ import type { SentryIssue } from '../client';
 import { SentryLevelBadge } from '../SentryLevelBadge';
 import type { SentryIssueRow } from './useSentryIssues';
 import { CONCEPT_ICONS } from '../../../../shared/components/conceptIcons';
+import { InboxStatusIcons } from '../../components/InboxStatusIcons';
 
 type Props = {
   readonly rows: ReadonlyArray<SentryIssueRow>;
@@ -115,13 +116,17 @@ export const IssueInbox = ({
                       <span className="min-w-0 flex-1 truncate text-xs font-medium text-foreground">
                         {row.issue.title}
                       </span>
-                      {row.sessionId ? (
-                        <MessagesSquare
-                          size={11}
-                          aria-label="session launched"
-                          className="shrink-0 text-success"
-                        />
-                      ) : null}
+                      <InboxStatusIcons
+                        sessionIcon={
+                          row.sessionId != null ? (
+                            <MessagesSquare
+                              size={11}
+                              aria-label="session launched"
+                              className="text-success"
+                            />
+                          ) : null
+                        }
+                      />
                     </div>
                     {row.issue.culprit ? (
                       <span className="truncate font-mono text-2xs text-muted-foreground/70">

--- a/apps/desktop/src/features/session/components/SessionWorkspace/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/index.test.tsx
@@ -14,6 +14,9 @@ type Store = {
   sessionActiveMount: Record<string, string>;
   sessionStudio: Record<string, null>;
   sessionPhaseRuns: Record<string, ReadonlyArray<Agent>>;
+  sessionTelemetry: Record<string, ReadonlyArray<never>>;
+  messages: Record<string, ReadonlyArray<never>>;
+  agentRunHistory: Record<string, ReadonlyArray<never>>;
   focusedWorkflowRunId: Record<string, string | null>;
   phaseTemplates: Record<string, ReadonlyArray<unknown>>;
   sessionWorkflows: Record<string, ReadonlyArray<unknown>>;
@@ -50,6 +53,9 @@ const { store, hooks } = vi.hoisted(() => ({
     sessionActiveMount: {},
     sessionStudio: {},
     sessionPhaseRuns: {},
+    sessionTelemetry: {},
+    messages: {},
+    agentRunHistory: {},
     focusedWorkflowRunId: {},
     phaseTemplates: {},
     sessionWorkflows: {},

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowRailCard.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowRailCard.tsx
@@ -1,14 +1,17 @@
 import { ChevronRight } from 'lucide-react';
 import type { Agent, Workflow, WorkflowRun } from '@goodboy/types';
-import { cn } from '@goodboy/ui';
+import { cn, formatUsdPrecise } from '@goodboy/ui';
 import { classifyWorkflowChain } from '@goodboy/core';
 import { workflowKindName } from '../../../../workspace/components/WorkspacesSidebar/lib';
 import { WorkflowRunStatus } from '../../../../workspace/components/WorkspacesSidebar/parts/WorkflowRunStatus';
+import { formatRelativeDuration } from '../../../../../shared/utils/relativeDate';
+import { CostBadge } from '../../../../providers/components/CostBadge';
 
 type Props = {
   readonly run: WorkflowRun;
   readonly workflow: Workflow;
   readonly agents: ReadonlyArray<Agent>;
+  readonly costUsd: number | null;
   readonly predecessorName: string;
   readonly onSelect: () => void;
   readonly onRestore: () => void;
@@ -18,6 +21,7 @@ export const WorkflowRailCard = ({
   run,
   workflow,
   agents,
+  costUsd,
   predecessorName,
   onSelect,
   onRestore,
@@ -31,6 +35,31 @@ export const WorkflowRailCard = ({
         : `Next: ${chain.step.name}`;
 
   const isDiscarded = run.discardedAt != null;
+  const ranAgents = [...agents]
+    .filter((agent) => agent.status !== 'pending')
+    .sort((left, right) => left.ordinal - right.ordinal);
+  const lastAgent = ranAgents.at(-1) ?? null;
+  const startedAt = ranAgents
+    .map((agent) => agent.startedAt)
+    .filter((value): value is NonNullable<typeof value> => value != null)
+    .sort()[0];
+  const completedAt = ranAgents
+    .map((agent) => agent.completedAt)
+    .filter((value): value is NonNullable<typeof value> => value != null)
+    .sort()
+    .at(-1);
+  const isCompleted =
+    run.executionMode === 'dynamic'
+      ? run.orchestrationOutcome === 'done'
+      : chain.kind === 'complete';
+  const duration =
+    isCompleted && startedAt != null && completedAt != null
+      ? formatRelativeDuration(startedAt, completedAt)
+      : null;
+  const stepCount =
+    run.executionMode === 'dynamic'
+      ? `${ranAgents.length} ${ranAgents.length === 1 ? 'step' : 'steps'} run`
+      : `${ranAgents.length} of ${workflow.steps.length} steps run`;
 
   return (
     <div className="relative flex w-full flex-col">
@@ -55,6 +84,33 @@ export const WorkflowRailCard = ({
             />
             {stepLine != null ? (
               <span className="line-clamp-1 text-2xs text-muted-foreground">{stepLine}</span>
+            ) : null}
+          </span>
+          <span className="flex flex-wrap items-center gap-1.5 text-2xs text-muted-foreground">
+            <span className="tabular-nums">{stepCount}</span>
+            {duration != null ? (
+              <>
+                <span aria-hidden className="text-muted-foreground/40">
+                  ·
+                </span>
+                <span className="tabular-nums">{duration}</span>
+              </>
+            ) : null}
+            {costUsd != null ? (
+              <>
+                <span aria-hidden className="text-muted-foreground/40">
+                  ·
+                </span>
+                <CostBadge value={costUsd} title={`${formatUsdPrecise(costUsd)} for this run`} />
+              </>
+            ) : null}
+            {lastAgent != null ? (
+              <>
+                <span aria-hidden className="text-muted-foreground/40">
+                  ·
+                </span>
+                <span className="min-w-0 truncate">Last: {lastAgent.name}</span>
+              </>
             ) : null}
           </span>
         </span>

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowRailSectionToggle.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowRailSectionToggle.tsx
@@ -23,7 +23,7 @@ export const WorkflowRailSectionToggle = ({ label, count, isShown, icon, onChang
       aria-pressed={isShown}
       title={`${isShown ? 'hide' : 'show'} ${label.toLowerCase()} workflows`}
       className={cn(
-        'flex items-center gap-1 self-start rounded-md px-1.5 py-0.5 text-2xs font-medium transition-colors',
+        'flex h-7 items-center gap-1 self-start rounded-md px-1.5 text-2xs font-medium transition-colors',
         isShown
           ? 'bg-primary/10 text-primary'
           : 'text-muted-foreground hover:bg-foreground/5 hover:text-foreground',

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowsPane.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowsPane.test.tsx
@@ -2,12 +2,15 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
-import type { Agent, Session, Workflow } from '@goodboy/types';
+import type { Agent, Session, TelemetryRecord, Workflow } from '@goodboy/types';
 
 type Store = {
   phaseTemplates: Record<string, ReadonlyArray<Workflow>>;
   sessionWorkflows: Record<string, ReadonlyArray<Workflow>>;
   sessionPhaseRuns: Record<string, ReadonlyArray<Agent>>;
+  sessionTelemetry: Record<string, ReadonlyArray<TelemetryRecord>>;
+  messages: Record<string, ReadonlyArray<never>>;
+  agentRunHistory: Record<string, ReadonlyArray<never>>;
   focusedWorkflowRunId: Record<string, string | null>;
   setFocusedWorkflowRun: ReturnType<typeof vi.fn>;
   restoreWorkflow: ReturnType<typeof vi.fn>;
@@ -28,6 +31,9 @@ const store: Store = {
   phaseTemplates: {},
   sessionWorkflows: {},
   sessionPhaseRuns: {},
+  sessionTelemetry: {},
+  messages: {},
+  agentRunHistory: {},
   focusedWorkflowRunId: {},
   setFocusedWorkflowRun: vi.fn(),
   restoreWorkflow: vi.fn(),
@@ -65,6 +71,8 @@ vi.mock('@goodboy/ui', () => ({
   ScrollFade: ({ children }: ChildrenMockProps) => <div>{children}</div>,
   StatusDot: () => <span data-testid="status-dot" />,
   cn: (...values: ReadonlyArray<unknown>) => values.filter(Boolean).join(' '),
+  formatUsd: (value: number) => `$${value.toFixed(2)}`,
+  formatUsdPrecise: (value: number) => `$${value.toFixed(2)}`,
 }));
 
 vi.mock('./WorkflowRunDetail', () => ({
@@ -114,6 +122,9 @@ beforeEach(() => {
   store.phaseTemplates = { [WORKSPACE_ID]: [firstWorkflow, secondWorkflow] };
   store.sessionWorkflows = {};
   store.sessionPhaseRuns = {};
+  store.sessionTelemetry = {};
+  store.messages = {};
+  store.agentRunHistory = {};
   store.focusedWorkflowRunId = {};
   store.setFocusedWorkflowRun.mockReset();
   store.restoreWorkflow.mockReset();
@@ -139,6 +150,113 @@ describe('WorkflowsPane', () => {
     expect(screen.getAllByRole('button', { name: 'Attach another workflow' })).toHaveLength(1);
     expect(screen.queryByTestId('workflow-detail')).toBeNull();
     expect(screen.getByRole('heading', { name: 'Workflows' })).toBeDefined();
+  });
+
+  it('shows static run progress, duration, last step, and tracked cost', () => {
+    store.sessionPhaseRuns = {
+      [SESSION_ID]: [
+        {
+          id: 'agent-1',
+          sessionId: SESSION_ID,
+          stepId: 'workflow-1-step-1',
+          workflowRunId: 'run-1',
+          ordinal: 0,
+          name: 'First',
+          status: 'completed',
+          runId: 'provider-run-1',
+          startedAt: '2026-07-21T10:00:00.000Z',
+          completedAt: '2026-07-21T10:01:00.000Z',
+        },
+        {
+          id: 'agent-2',
+          sessionId: SESSION_ID,
+          stepId: 'workflow-1-step-2',
+          workflowRunId: 'run-1',
+          ordinal: 1,
+          name: 'Second',
+          status: 'completed',
+          runId: 'provider-run-2',
+          startedAt: '2026-07-21T10:01:00.000Z',
+          completedAt: '2026-07-21T10:03:00.000Z',
+        },
+      ] as unknown as ReadonlyArray<Agent>,
+    };
+    store.sessionTelemetry = {
+      [SESSION_ID]: [
+        {
+          id: 'telemetry-1',
+          runId: 'provider-run-1',
+          sessionId: SESSION_ID,
+          kind: 'turn',
+          provider: 'anthropic',
+          model: 'claude-sonnet-4-6',
+          inputTokens: 100,
+          outputTokens: 20,
+          estimatedCostUsd: 0.1,
+          recordedAt: '2026-07-21T10:01:00.000Z',
+        },
+        {
+          id: 'telemetry-2',
+          runId: 'provider-run-2',
+          sessionId: SESSION_ID,
+          kind: 'turn',
+          provider: 'anthropic',
+          model: 'claude-sonnet-4-6',
+          inputTokens: 200,
+          outputTokens: 40,
+          estimatedCostUsd: 0.2,
+          recordedAt: '2026-07-21T10:03:00.000Z',
+        },
+      ] as unknown as ReadonlyArray<TelemetryRecord>,
+    };
+    render(
+      <WorkflowsPane
+        session={buildSession({
+          runIds: ['run-1'],
+          runOverrides: { 'run-1': { executionMode: 'static' } },
+        })}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Completed (1)' }));
+
+    expect(screen.getByText('2 of 2 steps run')).toBeDefined();
+    expect(screen.getByText('3m')).toBeDefined();
+    expect(screen.getByText('Last: Second')).toBeDefined();
+    expect(screen.getByTitle('$0.30 for this run')).toBeDefined();
+  });
+
+  it('shows dynamic run progress without a fixed total', () => {
+    store.sessionPhaseRuns = {
+      [SESSION_ID]: [
+        {
+          id: 'agent-1',
+          sessionId: SESSION_ID,
+          stepId: 'workflow-1-step-1',
+          workflowRunId: 'run-1',
+          ordinal: 0,
+          name: 'First',
+          status: 'completed',
+          startedAt: '2026-07-21T10:00:00.000Z',
+          completedAt: '2026-07-21T10:01:00.000Z',
+        },
+      ] as unknown as ReadonlyArray<Agent>,
+    };
+    render(
+      <WorkflowsPane
+        session={buildSession({
+          runIds: ['run-1'],
+          runOverrides: {
+            'run-1': { executionMode: 'dynamic', orchestrationOutcome: 'done' },
+          },
+        })}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Completed (1)' }));
+
+    expect(screen.getByText('1 step run')).toBeDefined();
+    expect(screen.queryByText('1 of 2 steps run')).toBeNull();
   });
 
   it('opens the detail of the focused run', () => {

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowsPane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowsPane.tsx
@@ -12,6 +12,7 @@ import { WorkflowStartButton } from '../../../../workspace/components/Workspaces
 import { workflowKindName } from '../../../../workspace/components/WorkspacesSidebar/lib';
 import { WorkflowRailCard } from './WorkflowRailCard';
 import { WorkflowRunDetail } from './WorkflowRunDetail';
+import { useAgentMetrics } from '../../../hooks/useAgentMetrics';
 
 type Props = {
   readonly session: Session;
@@ -23,6 +24,7 @@ export const WorkflowsPane = ({ session }: Props) => {
   const phaseRuns = useAppStore(
     (state) => state.sessionPhaseRuns[sessionId] ?? (EMPTY_ARRAY as ReadonlyArray<Agent>),
   );
+  const { aggregatesByAgentId } = useAgentMetrics({ sessionId });
   const focusedWorkflowRunId = useAppStore(
     (state) => state.focusedWorkflowRunId[sessionId] ?? null,
   );
@@ -58,6 +60,12 @@ export const WorkflowsPane = ({ session }: Props) => {
   const shouldShowEmptyCard = hasRuns && focusedRun == null && !hasVisibleRuns;
 
   const renderCard = ({ run, workflow }: { run: WorkflowRun; workflow: Workflow }) => {
+    const agents = agentsByRunId.get(run.id) ?? EMPTY_ARRAY;
+    const aggregates = agents.map((agent) => aggregatesByAgentId.get(agent.id));
+    const isCostTracked = aggregates.some((aggregate) => (aggregate?.turns ?? 0) > 0);
+    const costUsd = isCostTracked
+      ? aggregates.reduce((total, aggregate) => total + (aggregate?.estimatedCostUsd ?? 0), 0)
+      : null;
     const predecessorName = run.chainAfterId
       ? (workflowNameByRunId.get(run.chainAfterId) ?? 'previous')
       : 'previous';
@@ -66,7 +74,8 @@ export const WorkflowsPane = ({ session }: Props) => {
         <WorkflowRailCard
           run={run}
           workflow={workflow}
-          agents={agentsByRunId.get(run.id) ?? EMPTY_ARRAY}
+          agents={agents}
+          costUsd={costUsd}
           predecessorName={predecessorName}
           onSelect={() => setFocusedWorkflowRun(sessionId, run.id)}
           onRestore={() => void restoreWorkflow(sessionId, run.id)}

--- a/apps/desktop/src/shared/components/StudioDetail/RailStack.tsx
+++ b/apps/desktop/src/shared/components/StudioDetail/RailStack.tsx
@@ -1,6 +1,8 @@
-import type { ReactNode } from 'react';
-import { Divider, ScrollFade, cn } from '@goodboy/ui';
+import type { CSSProperties, ReactNode } from 'react';
+import { Divider, ResizeHandle, ScrollFade, cn } from '@goodboy/ui';
 import type { ResolvedDetailFields } from '../../detail-fields';
+import { useColumnWidth } from '../../hooks/useColumnWidth';
+import { STORAGE_KEYS } from '../../lib/storage-keys';
 import { DetailProperties } from './DetailProperties';
 
 type Props = {
@@ -9,8 +11,16 @@ type Props = {
   readonly isScrollable: boolean;
 };
 
+type Style = CSSProperties & {
+  readonly '--studio-detail-rail-width': string;
+};
+
 export const RailStack = ({ rail, properties, isScrollable }: Props) => {
+  const [width, setWidth] = useColumnWidth(STORAGE_KEYS.studioDetailRailWidth, 320);
   const hasProperties = properties != null && properties.length > 0;
+  const style: Style = {
+    '--studio-detail-rail-width': `${width}px`,
+  };
   const extras = isScrollable ? (
     <ScrollFade className="order-3 max-h-64 lg:order-1 lg:max-h-none lg:flex-1" fadeSize={24}>
       {rail}
@@ -20,19 +30,32 @@ export const RailStack = ({ rail, properties, isScrollable }: Props) => {
   );
 
   return (
-    <div
-      className={cn(
-        'flex w-full flex-col gap-4 lg:w-80',
-        isScrollable && 'px-6 py-4 lg:h-full lg:min-h-0 lg:p-4',
-      )}
-    >
-      {rail != null ? extras : null}
-      {rail != null && hasProperties ? <Divider className="order-2" /> : null}
-      {hasProperties ? (
-        <div className="order-1 shrink-0 lg:order-3">
-          <DetailProperties entries={properties} />
-        </div>
-      ) : null}
+    <div className="flex w-full flex-col lg:w-auto lg:flex-row" style={style}>
+      <div className="hidden h-full lg:block">
+        <ResizeHandle
+          value={width}
+          min={260}
+          max={560}
+          onChange={setWidth}
+          onReset={() => setWidth(320)}
+          side="right"
+          ariaLabel="resize studio detail rail"
+        />
+      </div>
+      <div
+        className={cn(
+          'flex w-full flex-col gap-4 lg:w-[var(--studio-detail-rail-width)]',
+          isScrollable && 'px-6 py-4 lg:h-full lg:min-h-0 lg:p-4',
+        )}
+      >
+        {rail != null ? extras : null}
+        {rail != null && hasProperties ? <Divider className="order-2" /> : null}
+        {hasProperties ? (
+          <div className="order-1 shrink-0 lg:order-3">
+            <DetailProperties entries={properties} />
+          </div>
+        ) : null}
+      </div>
     </div>
   );
 };

--- a/apps/desktop/src/shared/components/StudioDetail/StudioDetailLayout.tsx
+++ b/apps/desktop/src/shared/components/StudioDetail/StudioDetailLayout.tsx
@@ -59,7 +59,6 @@ export const StudioDetailLayout = ({
               !isFlow && 'min-h-0',
             )}
           >
-            <Divider orientation="vertical" className="hidden lg:block" />
             <RailStack rail={rail} properties={properties} isScrollable={!isFlow} />
             <Divider className="lg:hidden" />
           </div>

--- a/apps/desktop/src/shared/components/StudioDetail/index.test.tsx
+++ b/apps/desktop/src/shared/components/StudioDetail/index.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import { resolveDetailFields, type DetailFieldRegistry } from '../../detail-fields';
 import { DetailSection } from './DetailSection';
@@ -6,8 +6,16 @@ import { HeaderBand } from './HeaderBand';
 import { RailBlock } from './RailBlock';
 import { StudioDetailLayout } from './StudioDetailLayout';
 import { StudioDetailTabs } from './StudioDetailTabs';
+import { STORAGE_KEYS } from '../../lib/storage-keys';
 
-afterEach(cleanup);
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+});
 
 type Entity = {
   readonly state: string;
@@ -147,6 +155,24 @@ describe('StudioDetailLayout', () => {
     }
 
     expect(hidden).toEqual([]);
+  });
+
+  it('restores, resizes, and resets the studio detail rail width', () => {
+    localStorage.setItem(STORAGE_KEYS.studioDetailRailWidth, '420');
+    render(
+      <StudioDetailLayout header={<span>Header slot</span>} rail={<span>Rail slot</span>}>
+        <span>Main slot</span>
+      </StudioDetailLayout>,
+    );
+
+    const handle = screen.getByRole('separator', { name: 'resize studio detail rail' });
+    expect(handle.getAttribute('aria-valuenow')).toBe('420');
+
+    fireEvent.keyDown(handle, { key: 'ArrowLeft' });
+    expect(localStorage.getItem(STORAGE_KEYS.studioDetailRailWidth)).toBe('428');
+
+    fireEvent.doubleClick(handle);
+    expect(localStorage.getItem(STORAGE_KEYS.studioDetailRailWidth)).toBe('320');
   });
 });
 

--- a/apps/desktop/src/shared/lib/storage-keys.ts
+++ b/apps/desktop/src/shared/lib/storage-keys.ts
@@ -6,6 +6,7 @@ export const STORAGE_KEYS = {
   diffSidebarCollapsed: `${PREFIX}diff-sidebar-collapsed`,
   lensColumnWidth: `${PREFIX}lens-column-width`,
   inspectorPanelWidth: `${PREFIX}inspector-panel-width`,
+  studioDetailRailWidth: `${PREFIX}studio-detail-rail-width`,
   reviewBoardListWidth: `${PREFIX}review-board-list-width`,
   planListWidth: `${PREFIX}plan-list-width`,
   leftSidebarWidth: `${PREFIX}left-sidebar-width:v2`,


### PR DESCRIPTION
## What

Found by running the app against a copy of the production database, so none of it was reachable from the test suite.

- **The studio detail rail clipped its own content.** `LaunchSessionPanel` was written for the session form, whose column is `max-w-2xl`, and hardcoded its controls to `sm:w-96` (384px). Mounted in a 320px rail with a `shrink-0` control cell, it overflowed and the window cut it off: in the Linear studio the goal, the workflow toggle, the branch chips and the adopted-branch value were all unreadable. It sizes to its container now.
- **Trailing icons stopped trading places.** In the integration inboxes the PR icon and the session icon were two independent conditionals rendered in sequence, so nothing lined up down the list. Both slots are reserved now, and the code-host icon is always last.
- **The rail is resizable**, using the `ResizeHandle` the plan studio, the review board and the inspector split already use, persisted per rail and clamped between 260 and 560px so it can never squeeze the body to nothing.
- **A completed workflow run says something.** It showed a title and a COMPLETED chip; it now shows steps run, duration, the last step's name and the tracked cost. A static run shows `n of total`, a dynamic run has no known total so it shows none.
- **The routing status chip lines up.** The reset control sat outside the chip and only existed on custom rows, so CUSTOM and DEFAULT never aligned down the column. The reset is inside the chip now.
- The Completed filter chip and the attach button share one control height.

## Why the rail is resizable again

#1116 deliberately dropped user resizing of the workflow rail and its saved width key. This reopens that decision on purpose: a fixed 320px rail is what made the overflow above unrecoverable, and it was raised twice.

## What was NOT touched, and why

- **The fixed control widths that live in full-width form and detail surfaces** (`NewSessionForm`, `CreatePrPanel`, the skills and scripts editors). They are not in a rail or a popover, so 384px is correct there.

## Verification

`turbo run typecheck` clean, 415 files / 3610 tests green. Also exercised against a real 22-session, 13-workspace database: migrations 96, 97 and 98 applied cleanly with `integrity_check` ok and no row loss.