### PR TITLE
docs(repo): prefer the stable release over the newest one

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,7 +100,7 @@ Co-locate tests, 1 to 5 behavior-focused assertions, never test implementation d
 
 ## Dependencies
 
-Every dependency is a liability: min 100k weekly downloads or a known maintainer, MIT/Apache/BSD/ISC license only, `pnpm audit` clean, justify anything outside the approved core set in the PR. Full vetting checklist and rules in [docs/dependencies.md](./docs/dependencies.md).
+Every dependency is a liability: min 100k weekly downloads or a known maintainer, MIT/Apache/BSD/ISC license only, `pnpm audit` clean, justify anything outside the approved core set in the PR. On upgrades, track the stable adopted release rather than the newest tag, keep types on the runtime's LTS, and treat every major as its own migration. Full vetting checklist and rules in [docs/dependencies.md](./docs/dependencies.md).
 
 ---
 

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -29,6 +29,27 @@ Every dependency is a liability. Add the minimum, vet each one, audit regularly.
 
 Internal workspace deps (the `workspace:*` protocol, no phantom deps) are governed by [CONVENTIONS.md](../CONVENTIONS.md) → pnpm.
 
+## Upgrades: stable over newest
+
+A version that just shipped is a version nobody has run in anger yet. Track the
+stable, widely adopted release, not the latest tag.
+
+- **Runtimes and their types move together, on LTS.** We ship on Node 24, so
+  `@types/node` is pinned to `^24`. Types ahead of the runtime make the
+  typechecker accept APIs that do not exist at run time.
+- **Majors are never automatic.** A major bump is a migration: its own branch,
+  clean install, typecheck, full suite, and a real build. Merging one on a
+  dependabot rebase is how a green CI ships a broken app.
+- **Majors that share a toolchain land together.** Vite, its plugins, and vitest
+  are one migration, not three PRs.
+- **A `0.x` minor is a major.** Cargo and npm both treat it as breaking.
+- **Minor and patch bumps are the routine path**, and still need install +
+  typecheck + suite before merging, plus `cargo test --locked` when
+  `Cargo.lock` moved.
+- **Close what we are not ready to migrate**, with the reason written in the PR.
+  An open PR nobody will act on is noise, and dependabot re-proposes the bump on
+  the next release anyway.
+
 ## Enforcement
 
 `pnpm audit` runs on CI. Manual review of `pnpm-lock.yaml` diff on every PR.


### PR DESCRIPTION
Scrive nella policy la regola applicata stasera gestendo le PR di dependabot: si sta sulla release stabile e adottata, non sull'ultima uscita.

- i tipi seguono l'LTS del runtime (giriamo su Node 24, quindi `@types/node` va su `^24`)
- ogni major e' una migrazione con branch, install pulito, typecheck, suite e build veri
- i major che condividono una toolchain atterrano insieme (vite, i suoi plugin, vitest)
- un minor `0.x` conta come major, sia per cargo sia per npm
- minor e patch restano la strada di routine, ma passano comunque da install + typecheck + suite, piu' `cargo test --locked` se si e' mosso `Cargo.lock`
- quello che non siamo pronti a migrare si chiude con la ragione scritta, invece di restare aperto come rumore