### PR TITLE
chore(repo): bump version to 0.1.54

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goodboy/desktop",
-  "version": "0.1.53",
+  "version": "0.1.54",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -1391,7 +1391,7 @@ dependencies = [
 
 [[package]]
 name = "goodboy-desktop"
-version = "0.1.53"
+version = "0.1.54"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goodboy-desktop"
-version = "0.1.53"
+version = "0.1.54"
 description = "Goodboy desktop app"
 authors = ["Amin Khayam"]
 license = "MIT"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Goodboy",
-  "version": "0.1.53",
+  "version": "0.1.54",
   "identifier": "com.goodboy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goodboy",
-  "version": "0.1.53",
+  "version": "0.1.54",
   "private": true,
   "description": "AI workspace orchestrator. Local-first, provider-agnostic.",
   "license": "MIT",


### PR DESCRIPTION
Version bump for the v0.1.54 release.

Bumps `package.json`, `apps/desktop/package.json`, `tauri.conf.json`, `Cargo.toml` and the `goodboy-desktop` entry in `Cargo.lock`.