### PR TITLE
fix(core): make gemini turns work against the shipped cli

### DIFF
--- a/apps/desktop/src/shared/components/RoutingPicker/index.test.tsx
+++ b/apps/desktop/src/shared/components/RoutingPicker/index.test.tsx
@@ -67,7 +67,7 @@ describe('RoutingPicker', () => {
     );
   });
 
-  it('shows the muted no-tuning line for Gemini', () => {
+  it('offers the effort axis for Gemini because its cli refuses a model without one', () => {
     render(
       <RoutingPicker
         {...baseProps}
@@ -78,11 +78,13 @@ describe('RoutingPicker', () => {
     );
     const trigger = screen.getByRole('button', { name: /^routing:/ });
     expect(trigger.textContent).toContain('3.5 Flash');
-    expect(trigger.textContent).not.toContain('High');
     fireEvent.click(trigger);
-    expect(screen.getByRole('region', { name: 'Tuning' }).textContent).toContain(
-      'No tuning options for this provider',
-    );
+    const effort = within(screen.getByRole('group', { name: 'Effort' }));
+    expect(effort.getAllByRole('button').map((button) => button.textContent)).toEqual([
+      'Low',
+      'Medium',
+      'High',
+    ]);
   });
 
   it('keeps provider tuning visible but disabled when the caller cannot edit effort', () => {
@@ -354,7 +356,7 @@ describe('RoutingPicker', () => {
     ).toHaveLength(5);
   });
 
-  it('reshapes tuning labels for effort, variant, and no-option providers', () => {
+  it('reshapes tuning labels for every provider that carries an effort axis', () => {
     const view = render(<RoutingPicker {...baseProps} />);
     fireEvent.click(screen.getByRole('button', { name: /routing/i }));
     expect(screen.getByRole('group', { name: 'Effort' })).toBeDefined();
@@ -369,9 +371,11 @@ describe('RoutingPicker', () => {
     routerView.unmount();
     render(<RoutingPicker {...baseProps} provider="gemini" model="gemini-3.1-pro" />);
     fireEvent.click(screen.getByRole('button', { name: /routing/i }));
-    expect(screen.getByRole('region', { name: 'Tuning' }).textContent).toContain(
-      'No tuning options for this provider',
-    );
+    expect(
+      within(screen.getByRole('group', { name: 'Effort' }))
+        .getAllByRole('button')
+        .map((button) => button.textContent),
+    ).toEqual(['Low', 'High']);
   });
 
   it('shows the no-option message without an effort row for Haiku', () => {

--- a/apps/desktop/src/shared/components/RoutingPicker/resolveRouting.ts
+++ b/apps/desktop/src/shared/components/RoutingPicker/resolveRouting.ts
@@ -49,6 +49,7 @@ const effortsFor = ({ model, selection, fallback }: EffortParams): ReadonlyArray
   switch (model.provider) {
     case 'anthropic':
     case 'codex':
+    case 'gemini':
     case 'opencode':
     case 'openrouter':
       return model.efforts;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -131,6 +131,7 @@ export {
   type TurnFallbackPlan,
 } from './providers/planTurnFallback';
 export { cliModelId } from './providers/cliModelId';
+export { cliExitEvents } from './providers/shared/cli-exit-events';
 export { extractAuxOutput, type AuxOutput, type AuxUsage } from './providers/aux-output';
 export { runAuxOneShot, type AuxSpawnResult } from './providers/aux-spawn';
 

--- a/packages/core/src/providers/catalog.test.ts
+++ b/packages/core/src/providers/catalog.test.ts
@@ -33,9 +33,7 @@ type AssertParams = {
 
 const emittedModel = ({ provider, selection }: AssertParams): string => {
   const args = resolveModelArgs({ provider, selection }).args;
-  const flag = provider === 'anthropic' || provider === 'cursor' ? '--model' : '-m';
-  const index = args.indexOf(flag);
-  const id = args[index + 1];
+  const id = args[1];
   if (id == null) {
     throw new Error(`missing model argument for ${provider}`);
   }
@@ -64,7 +62,6 @@ const selectionsFor = ({ model }: CrossParams): ReadonlyArray<ModelSelection> =>
         toggles: { thinking: combo.thinking, fast: combo.fast },
       }));
     case 'gemini':
-      return [{ key: model.key }];
     case 'opencode':
     case 'openrouter':
       return model.efforts.map((effort) => ({ key: model.key, effort }));

--- a/packages/core/src/providers/catalogDescriptor.ts
+++ b/packages/core/src/providers/catalogDescriptor.ts
@@ -28,6 +28,7 @@ const effortFor = ({ model }: Params) => {
   switch (model.provider) {
     case 'anthropic':
     case 'codex':
+    case 'gemini':
     case 'opencode':
     case 'openrouter':
       return model.efforts.length > 0 ? model.efforts : null;
@@ -35,8 +36,6 @@ const effortFor = ({ model }: Params) => {
       const efforts = model.combos.map((combo) => combo.effort).filter((effort) => effort != null);
       return efforts.length > 0 ? Array.from(new Set(efforts)) : null;
     }
-    case 'gemini':
-      return null;
     default: {
       const exhaustive: never = model;
       throw new Error(`unknown catalog model: ${String(exhaustive)}`);

--- a/packages/core/src/providers/codex/adapter.ts
+++ b/packages/core/src/providers/codex/adapter.ts
@@ -136,6 +136,8 @@ const spawnCodex = async function* ({
   const ctx = { runId: request.runId, now, onUnknown };
 
   yield* streamChildEvents(child, ctx, parseJsonLine, {
-    onClose: () => [{ kind: 'done', runId: request.runId, at: now() }],
+    onClose: ({ exitCode: _exitCode, stderr: _stderr }) => [
+      { kind: 'done', runId: request.runId, at: now() },
+    ],
   });
 };

--- a/packages/core/src/providers/defaultModelSelection.ts
+++ b/packages/core/src/providers/defaultModelSelection.ts
@@ -14,6 +14,7 @@ export const defaultModelSelection = ({ provider, tier = 'turn' }: Params): Mode
   }
   switch (model.provider) {
     case 'anthropic':
+    case 'gemini':
     case 'opencode':
     case 'openrouter':
       return { key: model.key, effort: model.defaultEffort };
@@ -34,8 +35,6 @@ export const defaultModelSelection = ({ provider, tier = 'turn' }: Params): Mode
         },
       };
     }
-    case 'gemini':
-      return { key: model.key };
     default: {
       const exhaustive: never = model;
       throw new Error(`unknown catalog model: ${String(exhaustive)}`);

--- a/packages/core/src/providers/gemini/adapter.test.ts
+++ b/packages/core/src/providers/gemini/adapter.test.ts
@@ -126,7 +126,7 @@ describe('GeminiAdapter.spawn', () => {
     await expect(collect(adapter)).rejects.toThrow('ENOENT gemini');
   });
 
-  it('passes -p <prompt> -m <model> --sandbox with system prompt prepended', async () => {
+  it('passes the model with --model and a supported --effort because agy rejects a bare model', async () => {
     let captured: ReadonlyArray<string> = [];
     let capturedBin = '';
     const child = new FakeChild(['ok']);
@@ -138,11 +138,31 @@ describe('GeminiAdapter.spawn', () => {
     const adapter = new GeminiAdapter({ now: fakeNow, spawnFn });
     await collect(adapter);
     expect(capturedBin).toBe('agy');
-    expect(captured[0]).toBe('-p');
-    expect(captured[1]).toBe('sys\n\nhi');
-    expect(captured[2]).toBe('-m');
-    expect(captured[3]).toBe(GEMINI_DEFAULT_MODEL);
-    expect(captured[4]).toBe('--sandbox');
+    expect(captured).toEqual([
+      '-p',
+      'sys\n\nhi',
+      '--model',
+      GEMINI_DEFAULT_MODEL,
+      '--effort',
+      'medium',
+      '--sandbox',
+    ]);
+  });
+
+  it('clamps an unsupported effort to one declared by the selected model', async () => {
+    let captured: ReadonlyArray<string> = [];
+    const child = new FakeChild(['ok']);
+    const spawnFn = ((_: string, args: ReadonlyArray<string>) => {
+      captured = args;
+      return child;
+    }) as never;
+    const adapter = new GeminiAdapter({ now: fakeNow, spawnFn });
+    await collect(adapter, {
+      ...makeRequest(),
+      model: 'gemini-3.1-pro',
+      selection: { key: 'gemini-3.1-pro', effort: 'medium' },
+    });
+    expect(captured.slice(2, 6)).toEqual(['--model', 'gemini-3.1-pro', '--effort', 'low']);
   });
 
   it('kills the child on early break', async () => {

--- a/packages/core/src/providers/gemini/adapter.test.ts
+++ b/packages/core/src/providers/gemini/adapter.test.ts
@@ -14,10 +14,10 @@ class FakeChild extends EventEmitter {
   killed = false;
   signal: NodeJS.Signals | null = null;
 
-  constructor(lines: ReadonlyArray<string>, exit = 0) {
+  constructor(lines: ReadonlyArray<string>, exit = 0, stderrLines: ReadonlyArray<string> = []) {
     super();
     this.stdout = Readable.from(lines.map((line) => `${line}\n`));
-    this.stderr = Readable.from([]);
+    this.stderr = Readable.from(stderrLines.map((line) => `${line}\n`));
     queueMicrotask(() => {
       this.exitCode = exit;
       this.stdout.on('end', () => this.emit('close', exit));
@@ -132,6 +132,25 @@ describe('GeminiAdapter.spawn', () => {
     const adapter = new GeminiAdapter({ now: fakeNow, spawnFn: (() => child) as never });
     const events = await collect(adapter);
     expect(events[events.length - 1]?.kind).toBe('done');
+  });
+
+  it('emits a rejected flag error before done when the CLI exits non-zero', async () => {
+    const child = new FakeChild([], 2, [
+      'flags provided but not defined: -m',
+      'Usage:',
+      '  agy [flags]',
+    ]);
+    const adapter = new GeminiAdapter({ now: fakeNow, spawnFn: (() => child) as never });
+    const events = await collect(adapter);
+    expect(events).toEqual([
+      {
+        kind: 'error',
+        runId: makeRequest().runId,
+        message: 'The installed agy CLI does not accept the -m flag.',
+        at: fakeNow(),
+      },
+      { kind: 'done', runId: makeRequest().runId, at: fakeNow() },
+    ]);
   });
 
   it('throws when the child process emits error', async () => {

--- a/packages/core/src/providers/gemini/adapter.test.ts
+++ b/packages/core/src/providers/gemini/adapter.test.ts
@@ -82,18 +82,28 @@ describe('GeminiAdapter.spawn', () => {
     expect(events[0]).toMatchObject({ delta: 'Hello from gemini\n' });
   });
 
-  it('parses a JSON response.delta line into assistant_text', async () => {
-    const line = JSON.stringify({ type: 'response.delta', text: 'streamed' });
+  it('streams agent response text from structured output', async () => {
+    const line = JSON.stringify({
+      event: 'step_update',
+      step_update: {
+        state: 'ACTIVE',
+        step_type: 'agent_response',
+        text_delta: 'streamed',
+      },
+    });
     const child = new FakeChild([line]);
     const adapter = new GeminiAdapter({ now: fakeNow, spawnFn: (() => child) as never });
     const events = await collect(adapter);
     expect(events.find((e) => e.kind === 'assistant_text')).toMatchObject({ delta: 'streamed' });
   });
 
-  it('emits usage with token counts from a usage JSON line', async () => {
+  it('emits usage with token counts from the final result', async () => {
     const line = JSON.stringify({
-      type: 'usage',
-      usage: { input_tokens: 100, cached_input_tokens: 30, output_tokens: 50 },
+      event: 'result',
+      result: {
+        status: 'SUCCESS',
+        usage: { input_tokens: 100, cache_read_tokens: 30, output_tokens: 50 },
+      },
     });
     const child = new FakeChild([line]);
     const adapter = new GeminiAdapter({ now: fakeNow, spawnFn: (() => child) as never });
@@ -104,12 +114,17 @@ describe('GeminiAdapter.spawn', () => {
     });
   });
 
-  it('surfaces a JSON error line as an error event', async () => {
-    const line = JSON.stringify({ type: 'error', message: 'quota exceeded' });
+  it('surfaces a failed final result as an error event', async () => {
+    const line = JSON.stringify({
+      event: 'result',
+      result: { status: 'FAILED', error: 'quota exceeded' },
+    });
     const child = new FakeChild([line]);
     const adapter = new GeminiAdapter({ now: fakeNow, spawnFn: (() => child) as never });
     const events = await collect(adapter);
-    expect(events.find((e) => e.kind === 'error')).toMatchObject({ message: 'quota exceeded' });
+    expect(events.find((e) => e.kind === 'error')).toMatchObject({
+      message: 'FAILED: quota exceeded',
+    });
   });
 
   it('always emits done as the last event', async () => {
@@ -141,6 +156,8 @@ describe('GeminiAdapter.spawn', () => {
     expect(captured).toEqual([
       '-p',
       'sys\n\nhi',
+      '--output-format',
+      'stream-json',
       '--model',
       GEMINI_DEFAULT_MODEL,
       '--effort',
@@ -162,7 +179,8 @@ describe('GeminiAdapter.spawn', () => {
       model: 'gemini-3.1-pro',
       selection: { key: 'gemini-3.1-pro', effort: 'medium' },
     });
-    expect(captured.slice(2, 6)).toEqual(['--model', 'gemini-3.1-pro', '--effort', 'low']);
+    expect(captured.slice(2, 4)).toEqual(['--output-format', 'stream-json']);
+    expect(captured.slice(4, 8)).toEqual(['--model', 'gemini-3.1-pro', '--effort', 'low']);
   });
 
   it('kills the child on early break', async () => {

--- a/packages/core/src/providers/gemini/adapter.ts
+++ b/packages/core/src/providers/gemini/adapter.ts
@@ -11,6 +11,7 @@ import type {
 import { GEMINI_DEFAULT_MODEL, GEMINI_MODELS } from './constants';
 import { computeGeminiCostUsd } from './cost';
 import { parseJsonLine } from './parser';
+import { cliExitEvents } from '../shared/cli-exit-events';
 import { streamChildEvents } from '../shared/stream-events';
 import { resolveModelArgs } from '../resolveModelArgs';
 import { resolveStoredModelSelection } from '../resolveStoredModelSelection';
@@ -123,6 +124,12 @@ const spawnGemini = async function* ({
   const ctx = { runId: request.runId, now, onUnknown };
 
   yield* streamChildEvents(child, ctx, parseJsonLine, {
-    onClose: () => [{ kind: 'done', runId: request.runId, at: now() }],
+    onClose: ({ exitCode, stderr }) => {
+      const at = now();
+      return [
+        ...cliExitEvents({ exitCode, stderr, runId: request.runId, at, binary }),
+        { kind: 'done', runId: request.runId, at },
+      ];
+    },
   });
 };

--- a/packages/core/src/providers/gemini/adapter.ts
+++ b/packages/core/src/providers/gemini/adapter.ts
@@ -109,7 +109,7 @@ const spawnGemini = async function* ({
     request.selection ??
     resolveStoredModelSelection({ provider: 'gemini', id: request.model }).selection;
   const modelArgs = resolveModelArgs({ provider: 'gemini', selection }).args;
-  const args = ['-p', prompt, ...modelArgs, '--sandbox'];
+  const args = ['-p', prompt, '--output-format', 'stream-json', ...modelArgs, '--sandbox'];
 
   const child: ChildProcess = spawnFn(binary, args, {
     stdio: ['ignore', 'pipe', 'pipe'],

--- a/packages/core/src/providers/gemini/catalog.ts
+++ b/packages/core/src/providers/gemini/catalog.ts
@@ -15,6 +15,8 @@ export const GEMINI_CATALOG = [
     },
     provider: 'gemini',
     cliId: 'gemini-3.1-pro',
+    efforts: ['low', 'high'],
+    defaultEffort: 'high',
   },
   {
     key: 'gemini-3.5-flash',
@@ -30,5 +32,7 @@ export const GEMINI_CATALOG = [
     },
     provider: 'gemini',
     cliId: 'gemini-3.5-flash',
+    efforts: ['low', 'medium', 'high'],
+    defaultEffort: 'medium',
   },
 ] satisfies ReadonlyArray<GeminiModel>;

--- a/packages/core/src/providers/gemini/parser.test.ts
+++ b/packages/core/src/providers/gemini/parser.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import type { IsoDateTime, ProviderRunId } from '@goodboy/types';
 import { parseJsonLine, type ParseContext } from './parser';
 
@@ -8,19 +8,23 @@ const ctx: ParseContext = {
   now: () => at,
 };
 
-function parse(line: string) {
-  return parseJsonLine(line, ctx);
-}
+type ParseParams = {
+  readonly line: string;
+  readonly overrides?: Partial<ParseContext>;
+};
 
-describe('parseJsonLine (gemini v0.x)', () => {
-  it('returns [] for empty / blank lines', () => {
-    expect(parse('')).toEqual([]);
-    expect(parse('   ')).toEqual([]);
+const parse = ({ line, overrides = {} }: ParseParams) => {
+  return parseJsonLine(line, { ...ctx, ...overrides });
+};
+
+describe('parseJsonLine (gemini stream-json)', () => {
+  it('returns no events for blank lines', () => {
+    expect(parse({ line: '' })).toEqual([]);
+    expect(parse({ line: '   ' })).toEqual([]);
   });
 
-  it('treats plain text as an assistant_text delta with trailing newline', () => {
-    const events = parse('Hello, world!');
-    expect(events).toEqual([
+  it('keeps plain prose readable as assistant text', () => {
+    expect(parse({ line: 'Hello, world!' })).toEqual([
       {
         kind: 'assistant_text',
         runId: ctx.runId,
@@ -30,37 +34,122 @@ describe('parseJsonLine (gemini v0.x)', () => {
     ]);
   });
 
-  it('parses response.delta when CLI emits structured json', () => {
-    const events = parse(JSON.stringify({ type: 'response.delta', text: 'hi' }));
-    expect(events).toEqual([{ kind: 'assistant_text', runId: ctx.runId, delta: 'hi', at }]);
-  });
-
-  it('skips response.completed (no event needed before done)', () => {
-    expect(parse(JSON.stringify({ type: 'response.completed' }))).toEqual([]);
-  });
-
-  it('extracts usage when emitted', () => {
-    const events = parse(
-      JSON.stringify({
-        type: 'usage',
-        usage: {
-          input_tokens: 100,
-          output_tokens: 50,
-          cached_input_tokens: 10,
-          cache_creation_input_tokens: 4,
+  it('initializes the Gemini provider session from the conversation id', () => {
+    const events = parse({
+      line: JSON.stringify({
+        event: 'init',
+        conversation_id: 'fe3759b4',
+        init: {
+          model: 'gemini-3.5-flash',
+          cwd: '/tmp/x',
+          tools: ['view_file', 'run_command'],
+          permission_mode: 'request-review',
         },
       }),
+    });
+    expect(events).toEqual([
+      {
+        kind: 'provider_session_init',
+        runId: ctx.runId,
+        providerSessionId: 'fe3759b4',
+        provider: 'gemini',
+        at,
+      },
+    ]);
+  });
+
+  it('concatenates agent response deltas in stream order', () => {
+    const lines = [
+      {
+        event: 'step_update',
+        step_update: {
+          conversation_id: 'fe3759b4',
+          step_index: 2,
+          state: 'ACTIVE',
+          step_type: 'agent_response',
+          text_delta: 'line one\nline two',
+        },
+      },
+      {
+        event: 'step_update',
+        step_update: {
+          conversation_id: 'fe3759b4',
+          step_index: 2,
+          state: 'DONE',
+          step_type: 'agent_response',
+          text_delta: '\n',
+          usage: {
+            input_tokens: 17648,
+            output_tokens: 21,
+            thinking_tokens: 20,
+            cache_read_tokens: 0,
+            total_tokens: 17669,
+          },
+        },
+      },
+    ];
+    const events = lines.flatMap((line) => parse({ line: JSON.stringify(line) }));
+    expect(events).toEqual([
+      { kind: 'assistant_text', runId: ctx.runId, delta: 'line one\nline two', at },
+      { kind: 'assistant_text', runId: ctx.runId, delta: '\n', at },
+    ]);
+    expect(events.map((event) => ('delta' in event ? event.delta : '')).join('')).toBe(
+      'line one\nline two\n',
     );
+  });
+
+  it('ignores checkpoint lifecycle updates including their usage', () => {
+    const events = parse({
+      line: JSON.stringify({
+        event: 'step_update',
+        step_update: {
+          conversation_id: 'fe3759b4',
+          step_index: 3,
+          state: 'DONE',
+          step_type: 'checkpoint',
+          usage: {
+            input_tokens: 103,
+            output_tokens: 5,
+            thinking_tokens: 0,
+            cache_read_tokens: 0,
+            total_tokens: 108,
+          },
+        },
+      }),
+    });
+    expect(events).toEqual([]);
+  });
+
+  it('emits exactly one usage event from the final turn totals', () => {
+    const events = parse({
+      line: JSON.stringify({
+        event: 'result',
+        result: {
+          conversation_id: 'fe3759b4',
+          status: 'SUCCESS',
+          response: 'line one\nline two\n',
+          duration_seconds: 1.8,
+          num_turns: 1,
+          usage: {
+            input_tokens: 17751,
+            output_tokens: 26,
+            thinking_tokens: 20,
+            cache_read_tokens: 7,
+            total_tokens: 17777,
+          },
+        },
+      }),
+    });
     expect(events).toEqual([
       {
         kind: 'usage',
         runId: ctx.runId,
         usage: {
-          inputTokens: 100,
-          outputTokens: 50,
-          cachedInputTokens: 10,
-          cacheCreationInputTokens: 4,
-          contextTokens: 150,
+          inputTokens: 17751,
+          outputTokens: 26,
+          cachedInputTokens: 7,
+          cacheCreationInputTokens: 0,
+          contextTokens: 17777,
           estimatedCostUsd: 0,
         },
         at,
@@ -68,8 +157,59 @@ describe('parseJsonLine (gemini v0.x)', () => {
     ]);
   });
 
-  it('surfaces error payloads', () => {
-    const events = parse(JSON.stringify({ type: 'error', message: 'oops' }));
-    expect(events).toEqual([{ kind: 'error', runId: ctx.runId, message: 'oops', at }]);
+  it('emits usage and an error when the final result failed', () => {
+    const events = parse({
+      line: JSON.stringify({
+        event: 'result',
+        result: {
+          conversation_id: 'fe3759b4',
+          status: 'FAILED',
+          error: { message: 'quota exceeded' },
+          usage: {
+            input_tokens: 3,
+            output_tokens: 2,
+            cache_read_tokens: 1,
+          },
+        },
+      }),
+    });
+    expect(events).toEqual([
+      {
+        kind: 'usage',
+        runId: ctx.runId,
+        usage: {
+          inputTokens: 3,
+          outputTokens: 2,
+          cachedInputTokens: 1,
+          cacheCreationInputTokens: 0,
+          contextTokens: 5,
+          estimatedCostUsd: 0,
+        },
+        at,
+      },
+      {
+        kind: 'error',
+        runId: ctx.runId,
+        message: 'FAILED: quota exceeded',
+        at,
+      },
+    ]);
+  });
+
+  it('reports unrecognized events through the unknown payload callback', () => {
+    const onUnknown = vi.fn();
+    const payload = { event: 'future_event', value: 42 };
+    const events = parse({ line: JSON.stringify(payload), overrides: { onUnknown } });
+    expect(onUnknown).toHaveBeenCalledWith('future_event', payload);
+    expect(events).toEqual([
+      {
+        kind: 'unknown_payload',
+        runId: ctx.runId,
+        adapter: 'gemini',
+        payloadType: 'future_event',
+        raw: payload,
+        at,
+      },
+    ]);
   });
 });

--- a/packages/core/src/providers/gemini/parser.ts
+++ b/packages/core/src/providers/gemini/parser.ts
@@ -7,43 +7,111 @@ export type ParseContext = {
   readonly onUnknown?: (type: string, payload: unknown) => void;
 };
 
-const KNOWN_TYPES = new Set(['response.delta', 'response.completed', 'usage', 'error']);
+type Payload = {
+  readonly event?: unknown;
+  readonly init?: unknown;
+  readonly step_update?: unknown;
+  readonly result?: unknown;
+} & Record<string, unknown>;
 
-type UsagePayload = {
-  readonly input_tokens?: number;
-  readonly cached_input_tokens?: number;
-  readonly cache_creation_input_tokens?: number;
-  readonly output_tokens?: number;
-  readonly inputTokens?: number;
-  readonly cachedInputTokens?: number;
-  readonly cacheCreationInputTokens?: number;
-  readonly outputTokens?: number;
+type UnknownValueParams = {
+  readonly value: unknown;
 };
 
-function buildUsage(raw: UsagePayload | undefined): ProviderUsage {
-  const inputTokens = raw?.input_tokens ?? raw?.inputTokens ?? 0;
-  const outputTokens = raw?.output_tokens ?? raw?.outputTokens ?? 0;
-  return {
-    inputTokens,
-    outputTokens,
-    cachedInputTokens: raw?.cached_input_tokens ?? raw?.cachedInputTokens ?? 0,
-    cacheCreationInputTokens:
-      raw?.cache_creation_input_tokens ?? raw?.cacheCreationInputTokens ?? 0,
-    contextTokens: inputTokens + outputTokens,
-    estimatedCostUsd: 0,
-  };
-}
+type TryParseJsonParams = {
+  readonly line: string;
+};
 
-function tryParseJson(line: string): ({ type?: string } & Record<string, unknown>) | null {
+type ReadNumberParams = {
+  readonly payload: Readonly<Record<string, unknown>> | undefined;
+  readonly key: string;
+};
+
+type BuildUsageParams = {
+  readonly raw: Readonly<Record<string, unknown>> | undefined;
+};
+
+type BuildErrorMessageParams = {
+  readonly payload: Payload;
+  readonly result: Readonly<Record<string, unknown>> | undefined;
+};
+
+const toRecord = ({ value }: UnknownValueParams): Record<string, unknown> | undefined => {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return undefined;
+  }
+  return value as Record<string, unknown>;
+};
+
+const tryParseJson = ({ line }: TryParseJsonParams): Payload | null => {
   if (!line.startsWith('{') && !line.startsWith('[')) {
     return null;
   }
+
   try {
-    return JSON.parse(line) as { type?: string } & Record<string, unknown>;
+    const parsed: unknown = JSON.parse(line);
+    if (typeof parsed !== 'object' || parsed === null) {
+      return null;
+    }
+    return parsed as Payload;
   } catch {
     return null;
   }
-}
+};
+
+const readNumber = ({ payload, key }: ReadNumberParams): number | undefined => {
+  const value = payload?.[key];
+  if (typeof value !== 'number') {
+    return undefined;
+  }
+  return value;
+};
+
+const buildUsage = ({ raw }: BuildUsageParams): ProviderUsage => {
+  const inputTokens = readNumber({ payload: raw, key: 'input_tokens' }) ?? 0;
+  const outputTokens = readNumber({ payload: raw, key: 'output_tokens' }) ?? 0;
+  const totalTokens = readNumber({ payload: raw, key: 'total_tokens' });
+  return {
+    inputTokens,
+    outputTokens,
+    cachedInputTokens: readNumber({ payload: raw, key: 'cache_read_tokens' }) ?? 0,
+    cacheCreationInputTokens: 0,
+    contextTokens: totalTokens ?? inputTokens + outputTokens,
+    estimatedCostUsd: 0,
+  };
+};
+
+const findErrorText = ({ value }: UnknownValueParams): string | undefined => {
+  if (typeof value === 'string' && value.length > 0) {
+    return value;
+  }
+  const record = toRecord({ value });
+  if (record === undefined) {
+    return undefined;
+  }
+
+  const candidates = [record['message'], record['error'], record['error_message'], record['text']];
+  for (const candidate of candidates) {
+    const text = findErrorText({ value: candidate });
+    if (text !== undefined) {
+      return text;
+    }
+  }
+  return undefined;
+};
+
+const buildErrorMessage = ({ payload, result }: BuildErrorMessageParams): string => {
+  const status = result?.['status'];
+  const errorText =
+    findErrorText({ value: result?.['error'] }) ??
+    findErrorText({ value: result?.['error_message'] }) ??
+    findErrorText({ value: result?.['message'] });
+  const detail = errorText ?? JSON.stringify(payload);
+  if (typeof status !== 'string' || status.length === 0) {
+    return detail;
+  }
+  return `${status}: ${detail}`;
+};
 
 export const parseJsonLine = (line: string, ctx: ParseContext): ReadonlyArray<TurnEvent> => {
   const trimmed = line.trim();
@@ -52,53 +120,74 @@ export const parseJsonLine = (line: string, ctx: ParseContext): ReadonlyArray<Tu
   }
 
   const at = ctx.now();
-  const payload = tryParseJson(trimmed);
+  const payload = tryParseJson({ line: trimmed });
 
   if (payload === null) {
     return [{ kind: 'assistant_text', runId: ctx.runId, delta: `${trimmed}\n`, at }];
   }
 
-  const type = payload.type;
-  switch (type) {
-    case 'response.delta': {
-      const delta = typeof payload['text'] === 'string' ? (payload['text'] as string) : '';
-      if (delta.length === 0) {
+  const event = payload.event;
+  switch (event) {
+    case 'init': {
+      const conversationId = payload['conversation_id'];
+      if (typeof conversationId !== 'string' || conversationId.length === 0) {
+        return [];
+      }
+      return [
+        {
+          kind: 'provider_session_init',
+          runId: ctx.runId,
+          providerSessionId: conversationId,
+          provider: 'gemini',
+          at,
+        },
+      ];
+    }
+
+    case 'step_update': {
+      const stepUpdate = toRecord({ value: payload.step_update });
+      if (stepUpdate?.['step_type'] !== 'agent_response') {
+        return [];
+      }
+      const delta = stepUpdate['text_delta'];
+      if (typeof delta !== 'string' || delta.length === 0) {
         return [];
       }
       return [{ kind: 'assistant_text', runId: ctx.runId, delta, at }];
     }
 
-    case 'response.completed':
-      return [];
-
-    case 'usage': {
-      const usage = buildUsage(payload['usage'] as UsagePayload | undefined);
-      return [{ kind: 'usage', runId: ctx.runId, usage, at }];
-    }
-
-    case 'error': {
-      const msg =
-        typeof payload['message'] === 'string'
-          ? (payload['message'] as string)
-          : JSON.stringify(payload);
-      return [{ kind: 'error', runId: ctx.runId, message: msg, at }];
+    case 'result': {
+      const result = toRecord({ value: payload.result });
+      const rawUsage = toRecord({ value: result?.['usage'] });
+      const events: TurnEvent[] = [
+        { kind: 'usage', runId: ctx.runId, usage: buildUsage({ raw: rawUsage }), at },
+      ];
+      if (result?.['status'] !== 'SUCCESS') {
+        events.push({
+          kind: 'error',
+          runId: ctx.runId,
+          message: buildErrorMessage({ payload, result }),
+          at,
+        });
+      }
+      return events;
     }
 
     default:
-      if (typeof type === 'string' && !KNOWN_TYPES.has(type)) {
-        devWarn(`[gemini-adapter] unknown json payload type: ${type}`);
-        ctx.onUnknown?.(type, payload);
-        return [
-          {
-            kind: 'unknown_payload',
-            runId: ctx.runId,
-            adapter: 'gemini',
-            payloadType: type,
-            raw: payload,
-            at,
-          },
-        ];
+      if (typeof event !== 'string') {
+        return [];
       }
-      return [];
+      devWarn(`[gemini-adapter] unknown json payload event: ${event}`);
+      ctx.onUnknown?.(event, payload);
+      return [
+        {
+          kind: 'unknown_payload',
+          runId: ctx.runId,
+          adapter: 'gemini',
+          payloadType: event,
+          raw: payload,
+          at,
+        },
+      ];
   }
 };

--- a/packages/core/src/providers/modelAxes.ts
+++ b/packages/core/src/providers/modelAxes.ts
@@ -153,12 +153,6 @@ export const modelAxes = ({ model, selection }: Params): ModelAxes => {
     case 'cursor':
       return cursorAxes({ model, selection });
     case 'gemini':
-      return {
-        effort: null,
-        variant: null,
-        toggles: [],
-        requiresMaxMode: false,
-      };
     case 'opencode':
     case 'openrouter':
       return {

--- a/packages/core/src/providers/modelIdForSelection.ts
+++ b/packages/core/src/providers/modelIdForSelection.ts
@@ -8,11 +8,9 @@ type Params = {
 
 export const modelIdForSelection = ({ provider, selection }: Params): string => {
   const { args } = resolveModelArgs({ provider, selection });
-  const flag = provider === 'anthropic' || provider === 'cursor' ? '--model' : '-m';
-  const index = args.indexOf(flag);
-  const id = args[index + 1];
+  const id = args[1];
   if (id == null) {
-    throw new Error(`resolved model args omit ${flag} for ${provider}`);
+    throw new Error(`resolved model args carry no model id for ${provider}`);
   }
   return id;
 };

--- a/packages/core/src/providers/opencode/adapter.ts
+++ b/packages/core/src/providers/opencode/adapter.ts
@@ -156,7 +156,7 @@ const spawnOpenCode = async function* ({
   }
   const ctx = { runId: request.runId, now, onUnknown };
   yield* streamChildEvents(child, ctx, (line, parseCtx) => parseJsonLine({ line, ctx: parseCtx }), {
-    onClose: () => {
+    onClose: ({ exitCode: _exitCode, stderr: _stderr }) => {
       resetOpenCodeParseState({ runId: request.runId });
       return [{ kind: 'done', runId: request.runId, at: now() }];
     },

--- a/packages/core/src/providers/resolveModelArgs.test.ts
+++ b/packages/core/src/providers/resolveModelArgs.test.ts
@@ -38,4 +38,27 @@ describe('resolveModelArgs', () => {
     });
     expect(resolved).not.toHaveProperty('maxMode');
   });
+
+  it('gives Gemini the long model flag and an effort, both of which its cli demands', () => {
+    expect(
+      resolveModelArgs({
+        provider: 'gemini',
+        selection: { key: 'gemini-3.5-flash', effort: 'low' },
+      }),
+    ).toEqual({
+      args: ['--model', 'gemini-3.5-flash', '--effort', 'low'],
+    });
+  });
+
+  it('clamps a Gemini effort the selected model does not publish', () => {
+    expect(
+      resolveModelArgs({
+        provider: 'gemini',
+        selection: { key: 'gemini-3.1-pro', effort: 'medium' },
+      }),
+    ).toEqual({
+      args: ['--model', 'gemini-3.1-pro', '--effort', 'low'],
+      clamped: { requested: 'medium', applied: 'low' },
+    });
+  });
 });

--- a/packages/core/src/providers/resolveModelArgs.ts
+++ b/packages/core/src/providers/resolveModelArgs.ts
@@ -71,8 +71,15 @@ export const resolveModelArgs = ({ provider, selection }: Params): ResolvedModel
         ...(combo.maxMode === true && { maxMode: true }),
       });
     }
-    case 'gemini':
-      return { args: ['-m', model.cliId] };
+    case 'gemini': {
+      const requested = selection.effort ?? model.defaultEffort;
+      const applied = clampEffort({ requested, available: model.efforts });
+      return withClamp({
+        args: ['--model', model.cliId, '--effort', applied],
+        requested,
+        applied,
+      });
+    }
     case 'opencode':
     case 'openrouter': {
       const requested = selection.effort ?? model.defaultEffort;

--- a/packages/core/src/providers/shared/cli-exit-events.test.ts
+++ b/packages/core/src/providers/shared/cli-exit-events.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import type { IsoDateTime, ProviderRunId } from '@goodboy/types';
+import { cliExitEvents } from './cli-exit-events';
+
+const RUN_ID = 'run_cli_exit' as ProviderRunId;
+const AT = '2026-08-02T00:00:00.000Z' as IsoDateTime;
+
+describe('cliExitEvents', () => {
+  it('names the rejected flag and binary without including the usage text', () => {
+    const events = cliExitEvents({
+      exitCode: 2,
+      stderr: 'flags provided but not defined: -m\nUsage:\n  agy [flags]\n  hundreds of lines',
+      runId: RUN_ID,
+      at: AT,
+      binary: 'agy',
+    });
+    expect(events).toEqual([
+      {
+        kind: 'error',
+        runId: RUN_ID,
+        message: 'The installed agy CLI does not accept the -m flag.',
+        at: AT,
+      },
+    ]);
+  });
+
+  it('quotes only the first non-empty stderr line for a plain non-zero exit', () => {
+    const events = cliExitEvents({
+      exitCode: 1,
+      stderr: '\nquota exceeded\nUsage:\n  agy [flags]',
+      runId: RUN_ID,
+      at: AT,
+      binary: 'agy',
+    });
+    expect(events[0]).toMatchObject({
+      kind: 'error',
+      message: 'agy exited with code 1: "quota exceeded".',
+    });
+  });
+
+  it('returns no events for a successful exit', () => {
+    expect(
+      cliExitEvents({ exitCode: 0, stderr: 'ignored', runId: RUN_ID, at: AT, binary: 'agy' }),
+    ).toEqual([]);
+  });
+
+  it('returns no events for a signalled exit', () => {
+    expect(
+      cliExitEvents({ exitCode: null, stderr: 'ignored', runId: RUN_ID, at: AT, binary: 'agy' }),
+    ).toEqual([]);
+  });
+});

--- a/packages/core/src/providers/shared/cli-exit-events.ts
+++ b/packages/core/src/providers/shared/cli-exit-events.ts
@@ -1,0 +1,56 @@
+import type { IsoDateTime, ProviderRunId, TurnEvent } from '@goodboy/types';
+
+type Params = {
+  readonly exitCode: number | null;
+  readonly stderr: string;
+  readonly runId: ProviderRunId;
+  readonly at: IsoDateTime;
+  readonly binary: string;
+};
+
+const REJECTED_FLAG_PATTERN = /^[\t ]*flags provided but not defined:[\t ]+(\S+)[\t ]*$/m;
+
+export const cliExitEvents = ({
+  exitCode,
+  stderr,
+  runId,
+  at,
+  binary,
+}: Params): ReadonlyArray<TurnEvent> => {
+  if (exitCode === 0 || exitCode === null) {
+    return [];
+  }
+  const rejectedFlag = stderr.match(REJECTED_FLAG_PATTERN)?.[1];
+  if (rejectedFlag != null) {
+    return [
+      {
+        kind: 'error',
+        runId,
+        message: `The installed ${binary} CLI does not accept the ${rejectedFlag} flag.`,
+        at,
+      },
+    ];
+  }
+  const firstStderrLine = stderr
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find((line) => line.length > 0);
+  if (firstStderrLine != null) {
+    return [
+      {
+        kind: 'error',
+        runId,
+        message: `${binary} exited with code ${exitCode}: "${firstStderrLine}".`,
+        at,
+      },
+    ];
+  }
+  return [
+    {
+      kind: 'error',
+      runId,
+      message: `${binary} exited with code ${exitCode}.`,
+      at,
+    },
+  ];
+};

--- a/packages/core/src/providers/shared/stream-events.ts
+++ b/packages/core/src/providers/shared/stream-events.ts
@@ -5,9 +5,21 @@ import type { ParseContext } from './anthropic-envelope-parser';
 
 type ParseLine = (line: string, ctx: ParseContext) => ReadonlyArray<TurnEvent>;
 
-type StreamChildEventsOptions = {
-  readonly onClose?: () => ReadonlyArray<TurnEvent>;
+type CloseParams = {
+  readonly exitCode: number | null;
+  readonly stderr: string;
 };
+
+type EndParams = {
+  readonly exitCode: number | null;
+  readonly source: 'child' | 'stdout';
+};
+
+type StreamChildEventsOptions = {
+  readonly onClose?: ({ exitCode, stderr }: CloseParams) => ReadonlyArray<TurnEvent>;
+};
+
+const STDERR_TAIL_LENGTH = 8000;
 
 export async function* streamChildEvents(
   child: ChildProcess,
@@ -20,24 +32,49 @@ export async function* streamChildEvents(
   let rejector: ((err: unknown) => void) | null = null;
   let ended = false;
   let error: unknown = null;
+  let stderr = '';
+  let exitCode: number | null = null;
+  let isStdoutClosed = false;
+  let isChildClosed = false;
 
   const flush = () => {
-    if (resolver && queue.length > 0) {
+    if (resolver != null && queue.length > 0) {
       const value = queue.shift()!;
       const r = resolver;
       resolver = null;
+      rejector = null;
       r({ value, done: false });
-    } else if (resolver && ended) {
+      return;
+    }
+    if (resolver != null && ended) {
       const r = resolver;
       resolver = null;
-      if (error) {
+      if (error != null) {
         const rej = rejector;
         rejector = null;
         rej?.(error);
-      } else {
-        r({ value: undefined, done: true });
+        return;
       }
+      r({ value: undefined, done: true });
     }
+  };
+
+  const endIfClosed = ({ exitCode: closedExitCode, source }: EndParams) => {
+    if (source === 'stdout') {
+      isStdoutClosed = true;
+    }
+    if (source === 'child') {
+      exitCode = closedExitCode;
+      isChildClosed = true;
+    }
+    if (!isStdoutClosed || !isChildClosed || ended) {
+      return;
+    }
+    if (options.onClose != null) {
+      for (const event of options.onClose({ exitCode, stderr })) queue.push(event);
+    }
+    ended = true;
+    flush();
   };
 
   const lineReader = createInterface({ input: child.stdout! });
@@ -49,11 +86,11 @@ export async function* streamChildEvents(
   });
 
   lineReader.on('close', () => {
-    if (options.onClose) {
-      for (const event of options.onClose()) queue.push(event);
-    }
-    ended = true;
-    flush();
+    endIfClosed({ exitCode: null, source: 'stdout' });
+  });
+
+  child.on('close', (code) => {
+    endIfClosed({ exitCode: code, source: 'child' });
   });
 
   child.on('error', (err) => {
@@ -62,7 +99,10 @@ export async function* streamChildEvents(
     flush();
   });
 
-  child.stderr?.on('data', () => {});
+  child.stderr?.on('data', (chunk: Buffer | string) => {
+    const text = typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+    stderr = `${stderr}${text}`.slice(-STDERR_TAIL_LENGTH);
+  });
 
   try {
     while (true) {
@@ -71,7 +111,7 @@ export async function* streamChildEvents(
         continue;
       }
       if (ended) {
-        if (error) {
+        if (error != null) {
           throw error;
         }
         return;

--- a/packages/types/src/model-catalog.ts
+++ b/packages/types/src/model-catalog.ts
@@ -56,6 +56,8 @@ export type CursorModel = BaseModel & {
 export type GeminiModel = BaseModel & {
   readonly provider: 'gemini';
   readonly cliId: string;
+  readonly efforts: ReadonlyArray<EffortLevel>;
+  readonly defaultEffort: EffortLevel;
 };
 
 export type OpencodeModel = BaseModel & {


### PR DESCRIPTION
## What

Three commits, all provider-level, all verified against the `agy` CLI actually installed (1.1.8).

1. **The model flag.** `resolveModelArgs` emitted `-m`, which this CLI does not define: it prints
   `flags provided but not defined: -m` plus its whole usage text and exits. It wants `--model`, and
   it refuses a bare `--model` too, because every gemini model publishes an effort set and demands
   one of them. `GeminiModel` now carries `efforts` and `defaultEffort` like the other cli-effort
   providers, and the arm goes through the same `clampEffort` path. 3.1 Pro publishes low and high,
   3.5 Flash low, medium and high: that is what `agy models` lists.
2. **The stream.** The parser was written for an envelope keyed on `type` with `response.delta` and
   friends. No such envelope exists in this CLI, so every branch of it was dead: prose fell through
   the non-JSON fallback, which is why gemini rendered text at all, and why every gemini turn was
   recorded at zero cost. We now ask for `--output-format stream-json` and read the real envelope,
   keyed on `event`.
3. **The silence.** The shared stream reader drained stderr into an empty handler and ignored the
   exit code, so a turn killed by a bad flag showed the user nothing at all. It now keeps a bounded
   stderr tail plus the exit code and hands both to `onClose`; `cliExitEvents` turns a rejected flag
   into a sentence that names the flag.

## Why

Every gemini turn failed, and it failed in a way the user could not tell apart from a broken setup
of their own. Two of the three faults were pinned by tests (`expect(captured[2]).toBe('-m')`, and a
picker test asserting gemini had no tuning options), so the suite was green the whole time. Those
tests were rewritten to state the new intention, not flipped.

Usage mapping takes the total from the `result` event alone: the per-step usages overlap, and summing
them double counts.

`modelIdForSelection` guessed the model flag from the provider id and would have read `--model` back
as the model name. It now reads the id positionally, which is where every provider puts it, so the
guess cannot go stale again.

## Verified

- End to end against the installed CLI: a real turn streams `assistant_text` deltas and arrives with
  a `usage` event carrying non-zero tokens. The smoke script was not committed, it hits the network.
- `pnpm -w typecheck` and `pnpm -w test` green (4818 tests).

## Not touched, and why

- **No new gemini models.** `agy models` lists 3.6 Flash and some non-gemini ids the catalog does not
  carry. Adding models is a catalog decision, not a fix for a broken flag.
- **No version sniffing.** If this CLI's interface really moves per version, that gets solved from a
  detected version, not from a second hardcoded guess.
- **Codex and opencode do not opt into `cliExitEvents`.** They pass `onClose` and were updated to the
  new signature, but their behaviour is byte for byte what it was. Turning exit codes into errors for
  them is a per-provider decision about what their non-zero exits mean, and it belongs to whoever
  makes that call for each one.