### PR TITLE
fix(desktop): make a budget cap do something

### DIFF
--- a/apps/desktop/src/features/budget/budget.ts
+++ b/apps/desktop/src/features/budget/budget.ts
@@ -5,8 +5,14 @@ import type {
   BudgetPeriod,
   BudgetRule,
   ProviderName,
+  SessionId,
   SessionBudget,
 } from '@goodboy/types';
+
+type Params = {
+  provider: ProviderName;
+  sessionId: SessionId;
+};
 
 export const invokeBudgetRuleUpsert = async (rule: BudgetRule): Promise<void> => {
   return invoke<void>('budget_rule_upsert', { rule });
@@ -33,6 +39,13 @@ export const invokeSessionBudgetGet = async (sessionId: string): Promise<Session
 
 export const invokeBudgetAlertsList = async (): Promise<BudgetAlert[]> => {
   return invoke<BudgetAlert[]>('budget_alerts_list');
+};
+
+export const invokeBudgetEmitAlerts = async ({
+  provider,
+  sessionId,
+}: Params): Promise<BudgetAlert[]> => {
+  return invoke<BudgetAlert[]>('budget_emit_alerts', { input: { provider, sessionId } });
 };
 
 export const invokeBudgetAlertDismiss = async (id: string): Promise<void> => {

--- a/apps/desktop/src/features/chat/components/ChatInput/hooks/useTurnDispatch.ts
+++ b/apps/desktop/src/features/chat/components/ChatInput/hooks/useTurnDispatch.ts
@@ -2,9 +2,7 @@ import { useCallback, useState } from 'react';
 import type { AgentId, SessionId, TurnProviderOverride } from '@goodboy/types';
 import { useAppStore } from '../../../../../store';
 import { formatError } from '../../../../../shared/lib/errors';
-import { SESSION_FEATURES } from '../../../../../shared/lib/features';
-import { useToast } from '../../../../../app/components/Toast';
-import { toAttachmentInput, toastKindForAlert, toastMessageForAlert } from '../lib';
+import { toAttachmentInput } from '../lib';
 import type { PendingAttachment, QueuedTurn } from '../lib';
 
 type UseTurnDispatchArgs = {
@@ -14,7 +12,6 @@ type UseTurnDispatchArgs = {
 
 export function useTurnDispatch({ sessionId, cleanupSentAttachments }: UseTurnDispatchArgs) {
   const sendTurn = useAppStore((s) => s.sendTurn);
-  const { showToast } = useToast();
 
   const [error, setError] = useState<string | null>(null);
   const [lastFailedTurn, setLastFailedTurn] = useState<Omit<QueuedTurn, 'id'> | null>(null);
@@ -33,12 +30,6 @@ export function useTurnDispatch({ sessionId, cleanupSentAttachments }: UseTurnDi
           content,
           ...(atts.length > 0 ? { attachments: atts.map(toAttachmentInput) } : {}),
           override,
-          onNewAlerts: (alerts) => {
-            if (!SESSION_FEATURES.budget) return;
-            for (const alert of alerts) {
-              showToast(toastKindForAlert(alert.kind), toastMessageForAlert(alert));
-            }
-          },
         });
         setLastFailedTurn(null);
         cleanupSentAttachments(atts);
@@ -47,7 +38,7 @@ export function useTurnDispatch({ sessionId, cleanupSentAttachments }: UseTurnDi
         setLastFailedTurn({ agentId, content, attachments: atts, override });
       }
     },
-    [sendTurn, sessionId, showToast, cleanupSentAttachments],
+    [sendTurn, sessionId, cleanupSentAttachments],
   );
 
   return { dispatchTurn, error, setError, lastFailedTurn, setLastFailedTurn };

--- a/apps/desktop/src/features/chat/components/ChatInput/lib.test.ts
+++ b/apps/desktop/src/features/chat/components/ChatInput/lib.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from 'vitest';
-import type { BudgetAlert } from '@goodboy/types';
 import {
   asEffortLevel,
   asProvider,
@@ -8,20 +7,8 @@ import {
   extFromMime,
   readFileAsDataUrl,
   toAttachmentInput,
-  toastKindForAlert,
-  toastMessageForAlert,
   type PendingAttachment,
 } from './lib';
-
-const makeAlert = (over: Partial<BudgetAlert> = {}): BudgetAlert =>
-  ({
-    id: 'al_1',
-    kind: 'session-threshold',
-    currentUsd: 5,
-    capUsd: 10,
-    createdAt: '2026-05-15T00:00:00.000Z',
-    ...over,
-  }) as BudgetAlert;
 
 describe('extFromMime', () => {
   it('extracts the subtype as the extension', () => {
@@ -96,60 +83,6 @@ describe('asProvider', () => {
 
   it('rejects null input', () => {
     expect(asProvider(null)).toBeNull();
-  });
-});
-
-describe('toastKindForAlert', () => {
-  it('maps exceeded alerts to errors', () => {
-    expect(toastKindForAlert('provider-exceeded')).toBe('error');
-    expect(toastKindForAlert('session-exceeded')).toBe('error');
-  });
-
-  it('maps threshold alerts to warnings', () => {
-    expect(toastKindForAlert('provider-threshold')).toBe('warning');
-    expect(toastKindForAlert('session-threshold')).toBe('warning');
-  });
-});
-
-describe('toastMessageForAlert', () => {
-  it('reports a provider threshold percentage', () => {
-    const alert = makeAlert({
-      kind: 'provider-threshold',
-      provider: 'cursor',
-      currentUsd: 5,
-      capUsd: 10,
-    });
-    expect(toastMessageForAlert(alert)).toBe('provider cursor budget at 50%');
-  });
-
-  it('reports 0% when the cap is zero', () => {
-    const alert = makeAlert({
-      kind: 'provider-threshold',
-      provider: 'cursor',
-      currentUsd: 5,
-      capUsd: 0,
-    });
-    expect(toastMessageForAlert(alert)).toBe('provider cursor budget at 0%');
-  });
-
-  it('reports a provider exceeded message', () => {
-    const alert = makeAlert({ kind: 'provider-exceeded', provider: 'codex' });
-    expect(toastMessageForAlert(alert)).toBe('provider codex budget exceeded');
-  });
-
-  it('falls back to "?" for a missing provider', () => {
-    const alert = makeAlert({ kind: 'provider-exceeded', provider: undefined });
-    expect(toastMessageForAlert(alert)).toBe('provider ? budget exceeded');
-  });
-
-  it('reports a session threshold percentage', () => {
-    const alert = makeAlert({ kind: 'session-threshold', currentUsd: 9, capUsd: 10 });
-    expect(toastMessageForAlert(alert)).toBe('session budget at 90%');
-  });
-
-  it('reports a session exceeded message', () => {
-    const alert = makeAlert({ kind: 'session-exceeded' });
-    expect(toastMessageForAlert(alert)).toBe('session budget exceeded');
   });
 });
 

--- a/apps/desktop/src/features/chat/components/ChatInput/lib.ts
+++ b/apps/desktop/src/features/chat/components/ChatInput/lib.ts
@@ -1,13 +1,5 @@
-import type {
-  AgentId,
-  AttachmentInput,
-  BudgetAlert,
-  BudgetAlertKind,
-  ProviderId,
-  TurnProviderOverride,
-} from '@goodboy/types';
+import type { AgentId, AttachmentInput, ProviderId, TurnProviderOverride } from '@goodboy/types';
 import { EFFORT_LEVELS, type EffortLevel } from '../../utils/chat-constants';
-import type { ToastKind } from '../../../../app/components/Toast';
 
 export const RUNNING_KINDS = new Set(['starting', 'running']);
 
@@ -84,22 +76,4 @@ export function asEffortLevel(v: string | undefined | null): EffortLevel | null 
 
 export function asProvider(v: string | undefined | null): ProviderId | null {
   return v && VALID_PROVIDERS.includes(v as ProviderId) ? (v as ProviderId) : null;
-}
-
-export function toastKindForAlert(kind: BudgetAlertKind): ToastKind {
-  return kind === 'provider-exceeded' || kind === 'session-exceeded' ? 'error' : 'warning';
-}
-
-export function toastMessageForAlert(alert: BudgetAlert): string {
-  const pct = alert.capUsd > 0 ? Math.round((alert.currentUsd / alert.capUsd) * 100) : 0;
-  if (alert.kind === 'provider-threshold') {
-    return `provider ${alert.provider ?? '?'} budget at ${pct}%`;
-  }
-  if (alert.kind === 'provider-exceeded') {
-    return `provider ${alert.provider ?? '?'} budget exceeded`;
-  }
-  if (alert.kind === 'session-threshold') {
-    return `session budget at ${pct}%`;
-  }
-  return 'session budget exceeded';
 }

--- a/apps/desktop/src/features/notifications/components/NotificationCenter/index.tsx
+++ b/apps/desktop/src/features/notifications/components/NotificationCenter/index.tsx
@@ -251,6 +251,10 @@ const NotificationItem = ({ notification: n, onNavigated }: NotificationItemProp
   const selectAgent = useAppStore((s) => s.selectAgent);
   const store = useAppStore.getState();
   const action = n.action != null ? mapNotificationAction(n.action, store) : undefined;
+  const retryAction =
+    n.action?.kind === 'retry-summarizer' || n.action?.kind === 'retry-step-summary'
+      ? n.action
+      : null;
   const [pickerOpen, setPickerOpen] = useState(false);
   const sessionId = n.sessionId;
   const agentId = n.action?.kind === 'retry-step-summary' ? n.action.agentId : null;
@@ -322,26 +326,33 @@ const NotificationItem = ({ notification: n, onNavigated }: NotificationItemProp
           >
             {action.label}
           </button>
-          <button
-            type="button"
-            className="rounded px-1.5 py-0.5 text-2xs text-muted-foreground hover:bg-muted hover:text-foreground"
-            onClick={() => setPickerOpen((v) => !v)}
-          >
-            Retry with…
-          </button>
+          {retryAction != null && (
+            <button
+              type="button"
+              className="rounded px-1.5 py-0.5 text-2xs text-muted-foreground hover:bg-muted hover:text-foreground"
+              onClick={() => setPickerOpen((v) => !v)}
+            >
+              Retry with…
+            </button>
+          )}
         </div>
       ) : null}
-      {action != null && pickerOpen && n.action != null ? (
+      {action != null && pickerOpen && retryAction != null ? (
         <div className="pl-5">
-          <RetryWithPicker action={n.action} onDone={() => setPickerOpen(false)} />
+          <RetryWithPicker action={retryAction} onDone={() => setPickerOpen(false)} />
         </div>
       ) : null}
     </li>
   );
 };
 
+type RetryAction = Extract<
+  NotificationAction,
+  { kind: 'retry-summarizer' } | { kind: 'retry-step-summary' }
+>;
+
 type RetryWithPickerProps = {
-  readonly action: NotificationAction;
+  readonly action: RetryAction;
   readonly onDone: () => void;
 };
 
@@ -371,14 +382,21 @@ function RetryWithPicker({ action, onDone }: RetryWithPickerProps) {
       model === '' ? resolveTaskModel('summarizer', null, providerId) : { providerId, model };
     const override: TaskModelPreference = { ...taskModel, effort };
     const store = useAppStore.getState();
-    if (action.kind === 'retry-summarizer') {
-      store.retrySummarizer(action.sessionId, override);
-    } else {
-      void store.retryStepSummary({
-        sessionId: action.sessionId,
-        agentId: action.agentId,
-        taskModelOverride: override,
-      });
+    switch (action.kind) {
+      case 'retry-summarizer':
+        store.retrySummarizer(action.sessionId, override);
+        break;
+      case 'retry-step-summary':
+        void store.retryStepSummary({
+          sessionId: action.sessionId,
+          agentId: action.agentId,
+          taskModelOverride: override,
+        });
+        break;
+      default: {
+        const _exhaustive: never = action;
+        return _exhaustive;
+      }
     }
     onDone();
   };

--- a/apps/desktop/src/features/notifications/components/NotificationToastBridge/index.tsx
+++ b/apps/desktop/src/features/notifications/components/NotificationToastBridge/index.tsx
@@ -3,6 +3,7 @@ import type { Notification, NotificationAction } from '@goodboy/db';
 import type { Session, Workspace } from '@goodboy/types';
 import { useAppStore } from '../../../../store';
 import { useToast, type ToastAction } from '../../../../app/components/Toast';
+import type { BudgetScope } from '../../../budget/components/BudgetStudio/lib';
 
 export const pickFreshFailures = (
   notifications: ReadonlyArray<Notification>,
@@ -66,6 +67,18 @@ export const mapNotificationAction = (
       label: 'Retry',
       onClick: () => {
         void store.retryStepSummary({ sessionId, agentId });
+      },
+    };
+  }
+  if (action.kind === 'open-budget') {
+    const scope: BudgetScope =
+      action.sessionId != null
+        ? { kind: 'session', sessionId: action.sessionId }
+        : { kind: 'overview' };
+    return {
+      label: 'Open budget',
+      onClick: () => {
+        window.dispatchEvent(new CustomEvent('goodboy:open-budget-studio', { detail: { scope } }));
       },
     };
   }

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/SessionCostChip.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/SessionCostChip.test.tsx
@@ -76,14 +76,7 @@ describe('SessionCostChip', () => {
     expect(screen.getByRole('button').textContent).toBe('$1.75');
   });
 
-  it('shows spend against the cap carried by the session budget alert', () => {
-    state.sessionCost = 1.75;
-    store.budgetAlerts = [alert()];
-    render(<SessionCostChip sessionId={SID} />);
-    expect(screen.getByRole('button').textContent).toBe('$1.75 / $5.00');
-  });
-
-  it('uses the loaded session budget as the single cap source', () => {
+  it('takes the cap from the session budget alone, never from an alert', () => {
     state.sessionCost = 1.75;
     store.budgetAlerts = [alert({ capUsd: 5 })];
     store.sessionBudgets = {
@@ -100,14 +93,36 @@ describe('SessionCostChip', () => {
     expect(screen.getByRole('button').getAttribute('title')).toContain('of a $8.0000 cap');
   });
 
-  it('ignores a cap belonging to another session or to a provider', () => {
+  it('loads the session budget without waiting for the popover to open', () => {
+    render(<SessionCostChip sessionId={SID} />);
+    expect(store.loadSessionBudget).toHaveBeenCalledWith(SID);
+  });
+
+  it('says in the tooltip that the session is over its cap', () => {
+    state.sessionCost = 12;
+    store.budgetAlerts = [alert({ kind: 'session-exceeded', capUsd: 10 })];
+    store.sessionBudgets = {
+      [SID]: {
+        sessionId: SID,
+        softCapUsd: 10,
+        updatedAt: '2026-07-27T10:00:00.000Z',
+      } as SessionBudget,
+    };
+
+    render(<SessionCostChip sessionId={SID} />);
+
+    expect(screen.getByRole('button').getAttribute('title')).toContain('over the cap');
+    expect(screen.getByRole('button').className).toContain('text-danger');
+  });
+
+  it('stays neutral for an alert that belongs to another session or to a provider', () => {
     state.sessionCost = 1.75;
     store.budgetAlerts = [
-      alert({ sessionId: 'sess-2' as SessionId, capUsd: 9 }),
+      alert({ kind: 'session-exceeded', sessionId: 'sess-2' as SessionId, capUsd: 9 }),
       alert({ kind: 'provider-exceeded', sessionId: undefined, capUsd: 40 }),
     ];
     render(<SessionCostChip sessionId={SID} />);
-    expect(screen.getByRole('button').textContent).toBe('$1.75');
+    expect(screen.getByRole('button').className).not.toContain('text-danger');
   });
 
   it('keeps the exact cost in the tooltip', () => {
@@ -118,7 +133,13 @@ describe('SessionCostChip', () => {
 
   it('keeps a sub-cent cap exact in the tooltip too', () => {
     state.sessionCost = 0.0012;
-    store.budgetAlerts = [alert({ capUsd: 0.005 })];
+    store.sessionBudgets = {
+      [SID]: {
+        sessionId: SID,
+        softCapUsd: 0.005,
+        updatedAt: '2026-07-27T10:00:00.000Z',
+      } as SessionBudget,
+    };
     const title = render(<SessionCostChip sessionId={SID} />)
       .container.querySelector('button')
       ?.getAttribute('title');

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/SessionCostChip.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/SessionCostChip.tsx
@@ -1,5 +1,13 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { Divider, Popover, ScrollFade, cn, formatUsd, formatUsdPrecise } from '@goodboy/ui';
+import {
+  Divider,
+  Popover,
+  ScrollFade,
+  cn,
+  formatUsd,
+  formatUsdPrecise,
+  tintClasses,
+} from '@goodboy/ui';
 import type { SessionId } from '@goodboy/types';
 import { SessionBudgetContent } from '../../../budget/components/BudgetStudio/SessionBudgetContent';
 import type { WorkspaceTurn } from '../../../budget/components/BudgetStudio/lib';
@@ -12,23 +20,33 @@ type Props = {
   readonly sessionId: SessionId;
 };
 
+const CAP_TONE = { near: 'warning', exceeded: 'danger' } as const;
+
+const CAP_NOTE = {
+  clear: '',
+  near: ', close to the cap',
+  exceeded: ', over the cap',
+} as const;
+
 export const SessionCostChip = ({ sessionId }: Props) => {
   const sessionCost = useSessionCost(sessionId);
-  const alertCapUsd = useAppStore(
-    (state) =>
-      state.budgetAlerts.find(
-        (alert) =>
-          alert.sessionId === sessionId &&
-          (alert.kind === 'session-threshold' || alert.kind === 'session-exceeded'),
-      )?.capUsd ?? null,
-  );
+  const capState = useAppStore((state) => {
+    const alerts = state.budgetAlerts.filter(
+      (alert) => alert.sessionId === sessionId && alert.dismissedAt === undefined,
+    );
+    if (alerts.some((alert) => alert.kind === 'session-exceeded')) {
+      return 'exceeded';
+    }
+    if (alerts.some((alert) => alert.kind === 'session-threshold')) {
+      return 'near';
+    }
+    return 'clear';
+  });
   const telemetry = useAppStore((state) => state.sessionTelemetry[sessionId]);
   const session = useAppStore(
     (state) => state.sessions.find((candidate) => candidate.id === sessionId) ?? null,
   );
-  const sessionBudget = useAppStore(
-    (state) => state.sessionBudgets[sessionId]?.softCapUsd ?? alertCapUsd,
-  );
+  const sessionBudget = useAppStore((state) => state.sessionBudgets[sessionId]?.softCapUsd ?? null);
   const loadSessionTelemetry = useAppStore((state) => state.loadSessionTelemetry);
   const loadSessionBudget = useAppStore((state) => state.loadSessionBudget);
   const setSessionBudget = useAppStore((state) => state.setSessionBudget);
@@ -40,11 +58,13 @@ export const SessionCostChip = ({ sessionId }: Props) => {
       width: 'w-[40rem] max-w-[calc(100vw-2rem)]',
       strategy: 'fixed',
     });
+  const capTint = capState === 'clear' ? null : tintClasses(CAP_TONE[capState]);
   const spent = formatUsd(sessionCost);
   const label = sessionBudget != null ? `${spent} / ${formatUsd(sessionBudget)}` : spent;
+  const capNote = CAP_NOTE[capState];
   const title =
     sessionBudget != null
-      ? `Estimated cost for this session: ${formatUsdPrecise(sessionCost)} of a ${formatUsdPrecise(sessionBudget)} cap (excluding summarizer), click for budget details`
+      ? `Estimated cost for this session: ${formatUsdPrecise(sessionCost)} of a ${formatUsdPrecise(sessionBudget)} cap${capNote} (excluding summarizer), click for budget details`
       : `Estimated cost for this session: ${formatUsdPrecise(sessionCost)} (excluding summarizer), click for budget details`;
   const turns = useMemo<ReadonlyArray<WorkspaceTurn>>(
     () =>
@@ -75,12 +95,15 @@ export const SessionCostChip = ({ sessionId }: Props) => {
   }, [sessionCost, sessionId]);
 
   useEffect(() => {
+    void loadSessionBudget(sessionId);
+  }, [loadSessionBudget, sessionId]);
+
+  useEffect(() => {
     if (open === false) {
       return;
     }
     void loadSessionTelemetry(sessionId);
-    void loadSessionBudget(sessionId);
-  }, [loadSessionBudget, loadSessionTelemetry, open, sessionId]);
+  }, [loadSessionTelemetry, open, sessionId]);
 
   useEffect(() => {
     if (open === false || popupRef.current == null || triggerRef.current == null) {
@@ -103,7 +126,10 @@ export const SessionCostChip = ({ sessionId }: Props) => {
         title={title}
         onAnimationEnd={() => setPulse(false)}
         className={cn(
-          'inline-flex shrink-0 items-center rounded-md border border-border-soft bg-muted px-2 py-1 font-mono text-2xs tabular-nums text-muted-foreground transition-colors hover:border-border hover:text-foreground',
+          'inline-flex shrink-0 items-center rounded-md border px-2 py-1 font-mono text-2xs tabular-nums transition-colors',
+          capState === 'clear' &&
+            'border-border-soft bg-muted text-muted-foreground hover:border-border hover:text-foreground',
+          capTint != null && `${capTint.borderSoft} ${capTint.bg} ${capTint.text}`,
           pulse && 'cost-chip-pulse',
         )}
       >

--- a/apps/desktop/src/store/slices/turn/notifyBudgetAlerts.ts
+++ b/apps/desktop/src/store/slices/turn/notifyBudgetAlerts.ts
@@ -1,0 +1,54 @@
+import { formatUsd } from '@goodboy/ui';
+import type { BudgetAlert, BudgetAlertKind, ProviderId } from '@goodboy/types';
+import { PROVIDER_LABEL } from '../../../features/chat/utils/chat-constants';
+import type { GetFn } from './types';
+
+type Params = {
+  readonly alerts: ReadonlyArray<BudgetAlert>;
+  readonly get: GetFn;
+};
+
+type AlertParams = {
+  readonly alert: BudgetAlert;
+};
+
+const SEVERITY_BY_KIND = {
+  'provider-exceeded': 'error',
+  'provider-threshold': 'warning',
+  'session-exceeded': 'error',
+  'session-threshold': 'warning',
+} as const satisfies Record<BudgetAlertKind, 'error' | 'warning'>;
+
+const subjectFor = ({ alert }: AlertParams): string => {
+  const provider = alert.provider;
+  if (provider == null) {
+    return 'Session';
+  }
+  if (provider in PROVIDER_LABEL) {
+    return PROVIDER_LABEL[provider as ProviderId];
+  }
+  return provider;
+};
+
+const titleFor = ({ alert }: AlertParams): string => {
+  const subject = subjectFor({ alert });
+  if (alert.kind === 'provider-exceeded' || alert.kind === 'session-exceeded') {
+    return `${subject} budget cap reached`;
+  }
+  return `${subject} budget close to its cap`;
+};
+
+export const notifyBudgetAlerts = ({ alerts, get }: Params) => {
+  for (const alert of alerts) {
+    void get().emitNotification(
+      'budget-cap',
+      SEVERITY_BY_KIND[alert.kind],
+      titleFor({ alert }),
+      `${formatUsd(alert.currentUsd)} spent against a ${formatUsd(alert.capUsd)} cap.`,
+      {
+        ...(alert.sessionId != null && { sessionId: alert.sessionId }),
+        action: { kind: 'open-budget', sessionId: alert.sessionId ?? null },
+      },
+    );
+  }
+};

--- a/apps/desktop/src/store/slices/turn/recordUsageTelemetry.test.ts
+++ b/apps/desktop/src/store/slices/turn/recordUsageTelemetry.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createStore } from 'zustand';
+import type {
+  BudgetAlert,
+  IsoDateTime,
+  ProviderRunId,
+  Session,
+  SessionId,
+  TelemetryRecord,
+  TurnEvent,
+  WorkspaceId,
+} from '@goodboy/types';
+
+const {
+  insertTelemetry,
+  invokeBudgetAlertsList,
+  invokeBudgetEmitAlerts,
+  invokeBudgetRuleList,
+  summarizeSessionTelemetry,
+  summarizeWorkspaceProviderTelemetry,
+  summarizeWorkspaceTelemetry,
+} = vi.hoisted(() => ({
+  insertTelemetry: vi.fn(async () => undefined),
+  invokeBudgetAlertsList: vi.fn(async () => [] as ReadonlyArray<BudgetAlert>),
+  invokeBudgetEmitAlerts: vi.fn(async () => [] as ReadonlyArray<BudgetAlert>),
+  invokeBudgetRuleList: vi.fn(async () => []),
+  summarizeSessionTelemetry: vi.fn(async () => null),
+  summarizeWorkspaceProviderTelemetry: vi.fn(async () => []),
+  summarizeWorkspaceTelemetry: vi.fn(async () => null),
+}));
+
+vi.mock('@goodboy/core', () => ({
+  computeProviderCostUsd: vi.fn(() => 2.5),
+}));
+
+vi.mock('@goodboy/db', () => ({
+  insertTelemetry,
+  summarizeSessionTelemetry,
+  summarizeWorkspaceProviderTelemetry,
+  summarizeWorkspaceTelemetry,
+}));
+
+vi.mock('../../../shared/lib/db', () => ({ tauriDatabase: {} }));
+
+vi.mock('../../../features/budget/budget', () => ({
+  invokeBudgetAlertsList,
+  invokeBudgetEmitAlerts,
+  invokeBudgetRuleList,
+}));
+
+import { recordUsageTelemetry } from './recordUsageTelemetry';
+
+const SESSION_ID = 'session-1' as SessionId;
+const WORKSPACE_ID = 'workspace-1' as WorkspaceId;
+const FIRST_RUN_ID = 'run-1' as ProviderRunId;
+const SECOND_RUN_ID = 'run-2' as ProviderRunId;
+const NOW = '2026-08-02T12:00:00.000Z' as IsoDateTime;
+
+const session = {
+  id: SESSION_ID,
+  workspaceId: WORKSPACE_ID,
+  goal: 'Finish the budget path',
+  state: { kind: 'idle', lastActivityAt: NOW },
+  contextSlots: [],
+  providerPreference: { defaultProvider: 'anthropic', allowTurnOverride: false },
+  permissionMode: 'bypassPermissions',
+  autoRun: false,
+  titleUserEdited: false,
+  workflowRuns: [],
+  createdAt: NOW,
+  updatedAt: NOW,
+} satisfies Session;
+
+const alert = {
+  id: 'alert-1',
+  kind: 'session-exceeded',
+  sessionId: SESSION_ID,
+  currentUsd: 12.3,
+  capUsd: 10,
+  createdAt: NOW,
+} satisfies BudgetAlert;
+
+type TestState = {
+  sessions: ReadonlyArray<Session>;
+  sessionTelemetry: Record<string, ReadonlyArray<TelemetryRecord>>;
+  sessionSummary: unknown;
+  workspaceSummary: unknown;
+  providerSpendBreakdown: ReadonlyArray<unknown>;
+  budgetAlerts: ReadonlyArray<BudgetAlert>;
+  emitNotification: ReturnType<typeof vi.fn>;
+};
+
+describe('recordUsageTelemetry', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    invokeBudgetAlertsList.mockResolvedValue([alert]);
+    invokeBudgetEmitAlerts.mockResolvedValueOnce([alert]).mockResolvedValueOnce([]);
+  });
+
+  it('emits one notification for the first session cap breach and none for the next turn', async () => {
+    const emitNotification = vi.fn(async () => undefined);
+    const store = createStore<TestState>(() => ({
+      sessions: [session],
+      sessionTelemetry: {},
+      sessionSummary: null,
+      workspaceSummary: null,
+      providerSpendBreakdown: [],
+      budgetAlerts: [],
+      emitNotification,
+    }));
+    const usage = {
+      inputTokens: 1_000,
+      outputTokens: 500,
+      cachedInputTokens: 0,
+      estimatedCostUsd: 2.5,
+    };
+
+    await recordUsageTelemetry(store.setState as never, store.getState as never, {
+      event: { kind: 'usage', runId: FIRST_RUN_ID, usage, at: NOW } satisfies Extract<
+        TurnEvent,
+        { kind: 'usage' }
+      >,
+      provider: 'anthropic',
+      model: 'claude-sonnet-4-5',
+      runId: FIRST_RUN_ID,
+      sessionId: SESSION_ID,
+      now: () => NOW,
+    });
+
+    expect(emitNotification).toHaveBeenCalledOnce();
+    expect(emitNotification).toHaveBeenCalledWith(
+      'budget-cap',
+      'error',
+      'Session budget cap reached',
+      '$12.30 spent against a $10.00 cap.',
+      {
+        sessionId: SESSION_ID,
+        action: { kind: 'open-budget', sessionId: SESSION_ID },
+      },
+    );
+
+    await recordUsageTelemetry(store.setState as never, store.getState as never, {
+      event: { kind: 'usage', runId: SECOND_RUN_ID, usage, at: NOW } satisfies Extract<
+        TurnEvent,
+        { kind: 'usage' }
+      >,
+      provider: 'anthropic',
+      model: 'claude-sonnet-4-5',
+      runId: SECOND_RUN_ID,
+      sessionId: SESSION_ID,
+      now: () => NOW,
+    });
+
+    expect(emitNotification).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/desktop/src/store/slices/turn/recordUsageTelemetry.ts
+++ b/apps/desktop/src/store/slices/turn/recordUsageTelemetry.ts
@@ -16,12 +16,17 @@ import type {
   TurnEvent,
 } from '@goodboy/types';
 import { tauriDatabase } from '../../../shared/lib/db';
-import { invokeBudgetAlertsList, invokeBudgetRuleList } from '../../../features/budget/budget';
+import {
+  invokeBudgetAlertsList,
+  invokeBudgetEmitAlerts,
+  invokeBudgetRuleList,
+} from '../../../features/budget/budget';
 import {
   getCodexPriceOverride,
   getGeminiPriceOverride,
 } from '../../../features/providers/provider-pricing';
 import { buildProviderSpendBreakdown } from '../budget';
+import { notifyBudgetAlerts } from './notifyBudgetAlerts';
 import type { GetFn, SetFn } from './types';
 
 type Params = {
@@ -31,13 +36,12 @@ type Params = {
   runId: ProviderRunId;
   sessionId: SessionId;
   now: () => IsoDateTime;
-  onNewAlerts?: (alerts: ReadonlyArray<BudgetAlert>) => void;
 };
 
 export const recordUsageTelemetry = async (
   set: SetFn,
   get: GetFn,
-  { event, provider, model, runId, sessionId, now, onNewAlerts }: Params,
+  { event, provider, model, runId, sessionId, now }: Params,
 ): Promise<void> => {
   const priceOverride =
     provider === 'codex'
@@ -74,7 +78,11 @@ export const recordUsageTelemetry = async (
     },
   }));
   const currentSession = get().sessions.find((s) => s.id === sessionId);
-  if (currentSession) {
+  if (currentSession != null) {
+    const newAlerts: ReadonlyArray<BudgetAlert> = await invokeBudgetEmitAlerts({
+      provider,
+      sessionId,
+    }).catch(() => []);
     const [sessSummary, wsSummary, providerSummaries, budgetRules, freshAlerts] = await Promise.all(
       [
         summarizeSessionTelemetry(tauriDatabase, sessionId),
@@ -84,16 +92,12 @@ export const recordUsageTelemetry = async (
         invokeBudgetAlertsList(),
       ],
     );
-    const knownIds = new Set(get().budgetAlerts.map((a) => a.id));
-    const newAlerts = freshAlerts.filter((a) => !knownIds.has(a.id));
     set({
       sessionSummary: sessSummary,
       workspaceSummary: wsSummary,
       providerSpendBreakdown: buildProviderSpendBreakdown(providerSummaries, budgetRules),
       budgetAlerts: freshAlerts,
     });
-    if (newAlerts.length > 0 && onNewAlerts) {
-      onNewAlerts(newAlerts);
-    }
+    notifyBudgetAlerts({ alerts: newAlerts, get });
   }
 };

--- a/apps/desktop/src/store/slices/turn/sendTurn.ts
+++ b/apps/desktop/src/store/slices/turn/sendTurn.ts
@@ -26,7 +26,6 @@ import {
 import type {
   AgentId,
   AttachmentInput,
-  BudgetAlert,
   IsoDateTime,
   Message,
   MessageAttachment,
@@ -96,7 +95,6 @@ type Input = {
   content: string;
   attachments?: ReadonlyArray<AttachmentInput>;
   override?: TurnProviderOverride;
-  onNewAlerts?: (alerts: ReadonlyArray<BudgetAlert>) => void;
   retry?: {
     readonly attempt: number;
     readonly provider: ProviderId;
@@ -118,7 +116,6 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
     content,
     attachments,
     override,
-    onNewAlerts,
     retry,
   }: Input): Promise<void> => {
     const before = get();
@@ -869,7 +866,6 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
             runId,
             sessionId,
             now,
-            ...(onNewAlerts !== undefined && { onNewAlerts }),
           });
         }
 
@@ -1092,7 +1088,6 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
           content,
           ...(attachments !== undefined && { attachments }),
           ...(override !== undefined && { override }),
-          ...(onNewAlerts !== undefined && { onNewAlerts }),
           retry: {
             attempt: (retry?.attempt ?? 0) + 1,
             provider: fallbackPlan.provider,

--- a/apps/desktop/src/store/slices/workflows/budgetBlock.ts
+++ b/apps/desktop/src/store/slices/workflows/budgetBlock.ts
@@ -1,0 +1,18 @@
+import type { BudgetAlert, SessionId } from '@goodboy/types';
+
+type Params = {
+  readonly alerts: ReadonlyArray<BudgetAlert>;
+  readonly sessionId: SessionId;
+};
+
+export const BUDGET_BLOCK_MESSAGE =
+  'the budget cap is reached, raise it in Budget to keep this run going';
+
+export const isBudgetBlocked = ({ alerts, sessionId }: Params): boolean => {
+  return alerts.some(
+    (alert) =>
+      alert.dismissedAt === undefined &&
+      ((alert.kind === 'session-exceeded' && alert.sessionId === sessionId) ||
+        alert.kind === 'provider-exceeded'),
+  );
+};

--- a/apps/desktop/src/store/slices/workflows/maybeAutoAdvanceWorkflow.test.ts
+++ b/apps/desktop/src/store/slices/workflows/maybeAutoAdvanceWorkflow.test.ts
@@ -17,12 +17,14 @@ import type {
 vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
 vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn() }));
 
-const { listOpenQuestionsSpy } = vi.hoisted(() => ({
+const { listOpenQuestionsSpy, updateOrchestrationErrorSpy } = vi.hoisted(() => ({
   listOpenQuestionsSpy: vi.fn(async () => []),
+  updateOrchestrationErrorSpy: vi.fn(async () => undefined),
 }));
 
 vi.mock('@goodboy/db', () => ({
   listOpenQuestionsForSession: listOpenQuestionsSpy,
+  updateWorkflowRunOrchestrationError: updateOrchestrationErrorSpy,
 }));
 
 vi.mock('../../../shared/lib/db', () => ({ tauriDatabase: {} }));
@@ -335,6 +337,11 @@ describe('maybeAutoAdvanceWorkflow', () => {
     state['summarizerStatus'] = {};
     state['budgetAlerts'] = [{ kind: 'provider-exceeded' }];
     await advance(SESSION_ID);
+    expect(updateOrchestrationErrorSpy).toHaveBeenCalledWith(
+      {},
+      RUN_ID,
+      'the budget cap is reached, raise it in Budget to keep this run going',
+    );
     state['budgetAlerts'] = [];
     listOpenQuestionsSpy.mockResolvedValue([
       {

--- a/apps/desktop/src/store/slices/workflows/maybeAutoAdvanceWorkflow.ts
+++ b/apps/desktop/src/store/slices/workflows/maybeAutoAdvanceWorkflow.ts
@@ -3,11 +3,14 @@ import { listOpenQuestionsForSession } from '@goodboy/db';
 import { isWorkflowComplete, runsForWorkflowRun } from '@goodboy/core';
 import { tauriDatabase } from '../../../shared/lib/db';
 import { workflowRunHasOpenQuestions } from '../../../features/context/openQuestionsGate';
+import { BUDGET_BLOCK_MESSAGE, isBudgetBlocked } from './budgetBlock';
+import { persistOrchestrationError } from './orchestrateNextStep';
 import type { GetFn, SetFn } from './types';
 
 const advanceInFlight = new Set<SessionId>();
 
 type Params = {
+  readonly set: SetFn;
   readonly get: GetFn;
   readonly sessionId: SessionId;
 };
@@ -46,8 +49,8 @@ const startChainedRuns = async ({ get, sessionId }: Params): Promise<void> => {
   }
 };
 
-const runAdvance = async ({ get, sessionId }: Params): Promise<void> => {
-  await startChainedRuns({ get, sessionId });
+const runAdvance = async ({ set, get, sessionId }: Params): Promise<void> => {
+  await startChainedRuns({ set, get, sessionId });
 
   const state = get();
   const session = state.sessions.find((s) => s.id === sessionId);
@@ -63,13 +66,18 @@ const runAdvance = async ({ get, sessionId }: Params): Promise<void> => {
   if (state.summarizerStatus[sessionId]?.status === 'running') {
     return;
   }
-  const exceeded = state.budgetAlerts.some(
-    (a) =>
-      a.dismissedAt === undefined &&
-      ((a.kind === 'session-exceeded' && a.sessionId === sessionId) ||
-        a.kind === 'provider-exceeded'),
-  );
-  if (exceeded) {
+  if (isBudgetBlocked({ alerts: state.budgetAlerts, sessionId })) {
+    for (const run of activeRuns) {
+      if (run.orchestrationError === BUDGET_BLOCK_MESSAGE) {
+        continue;
+      }
+      await persistOrchestrationError({
+        set,
+        sessionId,
+        workflowRunId: run.id,
+        message: BUDGET_BLOCK_MESSAGE,
+      });
+    }
     return;
   }
   const templates = state.phaseTemplates[session.workspaceId] ?? [];
@@ -129,14 +137,14 @@ const runAdvance = async ({ get, sessionId }: Params): Promise<void> => {
   );
 };
 
-export const maybeAutoAdvanceWorkflow = (_set: SetFn, get: GetFn) => {
+export const maybeAutoAdvanceWorkflow = (set: SetFn, get: GetFn) => {
   return async (sessionId: SessionId) => {
     if (advanceInFlight.has(sessionId)) {
       return;
     }
     advanceInFlight.add(sessionId);
     try {
-      await runAdvance({ get, sessionId });
+      await runAdvance({ set, get, sessionId });
     } finally {
       advanceInFlight.delete(sessionId);
     }

--- a/apps/desktop/src/store/slices/workflows/orchestrateNextStep.ts
+++ b/apps/desktop/src/store/slices/workflows/orchestrateNextStep.ts
@@ -38,6 +38,7 @@ import {
 } from '@goodboy/db';
 import { invokeWorkflowUpsert } from '../../../features/workflows/workflows';
 import { tauriDatabase } from '../../../shared/lib/db';
+import { BUDGET_BLOCK_MESSAGE, isBudgetBlocked } from './budgetBlock';
 import { roleModelsForSession } from '../overrides/roleModelsForSession';
 import { getSessionRepo } from '../worktrees/getSessionRepo';
 import { preSpawnWorkflowAgents } from './preSpawnWorkflowAgents';
@@ -339,18 +340,12 @@ export const orchestrateNextStep = (set: SetFn, get: GetFn) => {
       if (workflow == null) {
         return;
       }
-      const budgetExceeded = (get().budgetAlerts ?? []).some(
-        (alert) =>
-          alert.dismissedAt === undefined &&
-          ((alert.kind === 'session-exceeded' && alert.sessionId === sessionId) ||
-            alert.kind === 'provider-exceeded'),
-      );
-      if (budgetExceeded) {
+      if (isBudgetBlocked({ alerts: get().budgetAlerts ?? [], sessionId })) {
         await persistOrchestrationError({
           set,
           sessionId,
           workflowRunId,
-          message: 'the budget cap is reached, raise it in Budget to keep this run going',
+          message: BUDGET_BLOCK_MESSAGE,
         });
         return;
       }

--- a/apps/desktop/src/store/slices/workspaces/setCurrentWorkspace.ts
+++ b/apps/desktop/src/store/slices/workspaces/setCurrentWorkspace.ts
@@ -23,7 +23,7 @@ import {
 import { tauriDatabase } from '../../../shared/lib/db';
 import { cancelTurn, listLiveRunIds } from '../../../features/chat/turn';
 import { isMainWindow } from '../../../features/workspace/window';
-import { invokeBudgetRuleList } from '../../../features/budget/budget';
+import { invokeBudgetAlertsList, invokeBudgetRuleList } from '../../../features/budget/budget';
 import { invokeSkillList } from '../../../features/skills/skills';
 import {
   invokeWorkflowList,
@@ -82,7 +82,7 @@ export const setCurrentWorkspace = (set: SetFn, get: GetFn) => {
       sessionLoading: {},
       boardReady: false,
     });
-    if (id) {
+    if (id != null) {
       const workspace = get().workspaces.find((candidate) => candidate.id === id) ?? null;
       const touchNow = new Date().toISOString() as IsoDateTime;
       set((state) => ({
@@ -219,6 +219,7 @@ export const setCurrentWorkspace = (set: SetFn, get: GetFn) => {
           workspaceSummary,
           providerSummaries,
           budgetRules,
+          budgetAlerts,
           skills,
           phaseTemplates,
           stepLibrary,
@@ -226,6 +227,7 @@ export const setCurrentWorkspace = (set: SetFn, get: GetFn) => {
           summarizeWorkspaceTelemetry(tauriDatabase, id).catch(() => null),
           summarizeWorkspaceProviderTelemetry(tauriDatabase, id).catch(() => []),
           invokeBudgetRuleList().catch(() => []),
+          invokeBudgetAlertsList().catch(() => []),
           invokeSkillList(id).catch(() => []),
           invokeWorkflowList(id).catch(() => []),
           invokeStepDefList(id).catch(() => []),
@@ -262,6 +264,7 @@ export const setCurrentWorkspace = (set: SetFn, get: GetFn) => {
           sessionWorkflows,
           workspaceSummary,
           providerSpendBreakdown: buildProviderSpendBreakdown(providerSummaries, budgetRules),
+          budgetAlerts,
           skills: { ...state.skills, [id]: skills },
           phaseTemplates: { ...state.phaseTemplates, [id]: mergedTemplates },
           stepLibrary: { ...state.stepLibrary, [id]: stepLibrary },

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -324,7 +324,6 @@ export type AppActions = {
     content: string;
     attachments?: ReadonlyArray<AttachmentInput>;
     override?: TurnProviderOverride;
-    onNewAlerts?: (alerts: ReadonlyArray<BudgetAlert>) => void;
   }): Promise<void>;
   cancelCurrentTurn(sessionId: SessionId, agentId?: AgentId): Promise<void>;
   retrySummarizer(sessionId: SessionId, taskModelOverride?: TaskModelPreference): void;

--- a/apps/desktop/src/store/store.workspace-switch.test.ts
+++ b/apps/desktop/src/store/store.workspace-switch.test.ts
@@ -1,7 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { IsoDateTime, ProviderRunId, Session, SessionId, WorkspaceId } from '@goodboy/types';
+import type {
+  BudgetAlert,
+  IsoDateTime,
+  ProviderRunId,
+  Session,
+  SessionId,
+  WorkspaceId,
+} from '@goodboy/types';
 
 const cancelTurnSpy = vi.fn();
+const invokeBudgetAlertsListSpy = vi.fn(async () => [] as ReadonlyArray<BudgetAlert>);
 
 vi.mock('../features/chat/turn', () => ({
   runTurn: vi.fn(),
@@ -92,7 +100,7 @@ vi.mock('../features/budget/budget', () => ({
   invokeBudgetRuleList: vi.fn(async () => []),
   invokeBudgetRuleUpsert: vi.fn(),
   invokeBudgetRuleDelete: vi.fn(),
-  invokeBudgetAlertsList: vi.fn(async () => []),
+  invokeBudgetAlertsList: invokeBudgetAlertsListSpy,
   invokeBudgetAlertDismiss: vi.fn(),
   invokeSessionBudgetGet: vi.fn(),
   invokeSessionBudgetSet: vi.fn(),
@@ -174,6 +182,8 @@ describe('setCurrentWorkspace, session-scoped state cleanup', () => {
   beforeEach(() => {
     cancelTurnSpy.mockReset();
     cancelTurnSpy.mockResolvedValue(undefined);
+    invokeBudgetAlertsListSpy.mockReset();
+    invokeBudgetAlertsListSpy.mockResolvedValue([]);
   });
 
   afterEach(() => {
@@ -280,5 +290,25 @@ describe('setCurrentWorkspace, session-scoped state cleanup', () => {
     await useAppStore.getState().setCurrentWorkspace(WS_B);
 
     expect(cancelTurnSpy).not.toHaveBeenCalled();
+  });
+
+  it('loads budget alerts when a workspace becomes current', async () => {
+    const useAppStore = await importStore();
+    const alert = {
+      id: 'alert-loaded',
+      kind: 'provider-threshold',
+      provider: 'anthropic',
+      currentUsd: 8,
+      capUsd: 10,
+      createdAt: NOW,
+    } satisfies BudgetAlert;
+    invokeBudgetAlertsListSpy.mockResolvedValue([alert]);
+
+    await useAppStore.getState().setCurrentWorkspace(WS_B);
+
+    await vi.waitFor(() => {
+      expect(useAppStore.getState().budgetAlerts).toEqual([alert]);
+    });
+    expect(invokeBudgetAlertsListSpy).toHaveBeenCalledOnce();
   });
 });

--- a/packages/db/src/queries/notification.ts
+++ b/packages/db/src/queries/notification.ts
@@ -11,6 +11,7 @@ export type NotificationKind =
   | 'pr-created'
   | 'workspace-deleted'
   | 'boundary-drift'
+  | 'budget-cap'
   | 'title-generation'
   | 'error';
 
@@ -20,7 +21,8 @@ export type NotificationAction =
       readonly kind: 'retry-step-summary';
       readonly sessionId: SessionId;
       readonly agentId: AgentId;
-    };
+    }
+  | { readonly kind: 'open-budget'; readonly sessionId: SessionId | null };
 
 export type Notification = {
   readonly id: string;


### PR DESCRIPTION
Stacked on #1127.

## What

The user set a soft cap on a session, blew past it, and nothing happened. The prompt for this round
read that as an alert that never gets loaded. It is worse than that: **the alert is never created.**

`budget_emit_alerts` in `src-tauri/src/budget.rs` is the only code in the repo that inserts into
`budget_alerts`. It is registered as a command. Nothing calls it, and there was not even an invoke
wrapper for it. So `budget_alerts_list` returned `[]` forever, `state.budgetAlerts` was always empty,
and every consumer downstream was blind by construction: the chip, the workflow gates, the toast.

1. **Create the alert.** Call the emitter at the end of a turn, where the spend actually changes, and
   use what it returns as the once-per-breach signal. The Rust side already refuses to insert a
   second undismissed alert of the same kind, so there is no second dedupe in TS. The diff against
   `knownIds` that used to stand in for it is gone.
2. **Deliver it.** One `emitNotification` per new alert, kind `budget-cap`, with an `open-budget`
   action that lands on the session scope of the Budget studio. The notification centre persists it
   and `NotificationToastBridge` already mirrors any fresh warning or error into a toast, once. That
   replaces a hand-written toast that lived only in the composer hook, behind `SESSION_FEATURES.budget`
   which is `false`, so orchestrator and workflow turns produced nothing at all. The `onNewAlerts`
   plumbing is deleted end to end.
3. **Load it.** Alerts load when a workspace becomes current, next to the other deferred loads, so a
   session that was already over its cap at boot says so before the first turn.
4. **Show it.** The cost chip took its cap value from the alert, which is the split this area was
   asked to reduce. It now reads `sessionBudgets`, loaded on mount instead of on popover open, and
   the alert is left to say only what it alone knows: close to the cap, or past it. That reads as
   tone on the chip and as words in its tooltip, so the state is not carried by colour alone.
5. **Say why the automation stopped.** `maybeAutoAdvanceWorkflow` returned silently on an exceeded
   budget, so an autorun workflow just went quiet. It now writes the same reason `orchestrateNextStep`
   already writes, once per run, and both read the predicate and the message from one module.

## Verified

`pnpm -w typecheck` and `pnpm -w test` green (4831 tests, 3 new).

## Not touched, and why

- **`SESSION_FEATURES.budget` stays `false`.** It hides budget chrome in the composer and the guide,
  and that is a separate call. What it must not do is decide whether a cap the user set in shipped UI
  does anything, so the new path does not read it.
- **No polling.** The workspace load plus the end of every turn are the two moments the number can
  change; a timer would add a third source of truth for no new information.
- **The threshold percentages stay in Rust.** 80% for a session, the rule's own value for a provider.
  Moving that decision is a budget-rules change, not a feedback change.
- **`CapEditor` and the popover layout are untouched.** The popover's density is its own area.