### PR TITLE
refactor(ui): let a description read like prose

### DIFF
--- a/apps/desktop/src/__tests__/markdown.test.tsx
+++ b/apps/desktop/src/__tests__/markdown.test.tsx
@@ -52,9 +52,28 @@ describe('Markdown', () => {
     expect(container.textContent).toBe('this is *unmatched and ok');
   });
 
-  it('preserves whitespace inside paragraphs', () => {
+  it('reflows a soft line break inside a paragraph into a space', () => {
     const { container } = render(<Markdown text={'line1\nline2'} />);
-    expect(container.querySelector('p')?.textContent).toBe('line1\nline2');
+    expect(container.querySelector('p')?.textContent).toBe('line1 line2');
+  });
+
+  it('renders two trailing spaces as a hard break element', () => {
+    const { container } = render(<Markdown text={'line1  \nline2'} />);
+    const paragraph = container.querySelector('p');
+    expect(paragraph?.textContent).toBe('line1line2');
+    expect(paragraph?.querySelector('br')).not.toBeNull();
+  });
+
+  it('preserves newlines in a box-drawing tree paragraph', () => {
+    const { container } = render(<Markdown text={'root\n├── child\n└── child'} />);
+    const paragraph = container.querySelector('p');
+    expect(paragraph?.textContent).toBe('root\n├── child\n└── child');
+    expect(paragraph?.className).toContain('whitespace-pre-wrap');
+  });
+
+  it('allows a very long unbroken paragraph token to wrap via its class', () => {
+    const { container } = render(<Markdown text={'a'.repeat(200)} />);
+    expect(container.querySelector('p')?.className).toContain('wrap-anywhere');
   });
 
   it('renders a pipe table as a real table with header and aligned cells', () => {

--- a/apps/desktop/src/features/github/components/GitHubStudio/GithubIssueDetailPanel/index.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/GithubIssueDetailPanel/index.tsx
@@ -74,7 +74,7 @@ export const GithubIssueDetailPanel = ({ issue, sessionId, workspaceId, onClose 
       rail={launchCard}
       properties={resolveDetailFields({ registry: githubIssueFields, entity: issue })}
     >
-      <DetailSection label="description">
+      <DetailSection label="description" variant="frameless">
         {issue.body.trim() !== '' ? (
           <Markdown text={issue.body} className="text-sm leading-relaxed" />
         ) : (

--- a/apps/desktop/src/features/integrations/components/ExternalTaskChip/index.tsx
+++ b/apps/desktop/src/features/integrations/components/ExternalTaskChip/index.tsx
@@ -13,6 +13,7 @@ type Props = {
   ariaLabel?: string;
   repoLabel?: string;
   navigation?: 'internal' | 'external';
+  hasReferenceActions?: boolean;
 };
 
 type ProviderMeta = {
@@ -51,6 +52,7 @@ export const ExternalTaskChip = ({
   ariaLabel,
   repoLabel,
   navigation = 'external',
+  hasReferenceActions = true,
 }: Props) => {
   const meta = PROVIDER_META[task.provider];
   const tooltip = `${task.identifier}: ${task.title}`;
@@ -92,7 +94,7 @@ export const ExternalTaskChip = ({
           ? { attribution: <Chip tone="neutral" label={repoLabel} size="xs" /> }
           : {})}
         actions={
-          task.url !== '' ? (
+          hasReferenceActions && task.url !== '' ? (
             <ExternalRefActions url={task.url} label={task.identifier} hostLabel={meta.label} />
           ) : undefined
         }

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/IssueDetailPanel.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/IssueDetailPanel.tsx
@@ -75,7 +75,7 @@ export const IssueDetailPanel = ({ issue, sessionId, workspaceId, onClose }: Pro
       rail={launch}
       properties={resolveDetailFields({ registry: gitlabIssueFields, entity: issue })}
     >
-      <DetailSection label="description">
+      <DetailSection label="description" variant="frameless">
         {issue.description ? (
           <Markdown text={issue.description} className="text-sm leading-relaxed" />
         ) : (

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel.tsx
@@ -296,7 +296,7 @@ export const MrDetailPanel = ({
           </div>
         ) : null}
 
-        <DetailSection label="description">
+        <DetailSection label="description" variant="frameless">
           {mr.description != null && mr.description !== '' ? (
             <Markdown text={mr.description} className="text-sm leading-relaxed" />
           ) : (

--- a/apps/desktop/src/features/integrations/linear/LinearIssueDetail/index.tsx
+++ b/apps/desktop/src/features/integrations/linear/LinearIssueDetail/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, type ReactNode } from 'react';
 import { Markdown } from '@goodboy/ui';
 import { FileText, MessageSquare } from 'lucide-react';
 import type { WorkspaceId } from '@goodboy/types';
@@ -16,13 +16,16 @@ import { LinearIssueComments } from '../LinearIssueComments';
 import { useLinearIssueComments } from '../useLinearIssueComments';
 
 type IssueSection = 'overview' | 'conversation';
+type Fit = 'fill' | 'bleed' | 'flow';
 
 type Props = {
   readonly issue: LinearIssue;
   readonly workspaceId: WorkspaceId;
+  readonly rail?: ReactNode;
+  readonly fit?: Fit;
 };
 
-export const LinearIssueDetail = ({ issue, workspaceId }: Props) => {
+export const LinearIssueDetail = ({ issue, workspaceId, rail, fit = 'flow' }: Props) => {
   const [section, setSection] = useState<IssueSection>('overview');
   const { comments, isLoading, error } = useLinearIssueComments({
     workspaceId,
@@ -31,7 +34,7 @@ export const LinearIssueDetail = ({ issue, workspaceId }: Props) => {
 
   return (
     <StudioDetailLayout
-      fit="flow"
+      fit={fit}
       header={
         <HeaderBand
           meta={
@@ -62,10 +65,11 @@ export const LinearIssueDetail = ({ issue, workspaceId }: Props) => {
           ]}
         />
       }
+      rail={rail}
       properties={resolveDetailFields({ registry: linearIssueFields, entity: issue })}
     >
       {section === 'overview' ? (
-        <DetailSection label="description">
+        <DetailSection label="description" variant="frameless">
           {issue.description != null && issue.description !== '' ? (
             <Markdown text={issue.description} className="text-sm leading-relaxed" />
           ) : (

--- a/apps/desktop/src/features/integrations/linear/LinearStudio/IssueDetailPanel.tsx
+++ b/apps/desktop/src/features/integrations/linear/LinearStudio/IssueDetailPanel.tsx
@@ -1,29 +1,16 @@
 import { useEffect, useState } from 'react';
-import { EmptyState, Markdown } from '@goodboy/ui';
-import { FileText, MessageSquare } from 'lucide-react';
+import { EmptyState } from '@goodboy/ui';
 import type { SessionId, WorkspaceId } from '@goodboy/types';
 import { useAppStore } from '../../../../store';
 import { formatError } from '../../../../shared/lib/errors';
 import { sanitizeBranchSlug } from '../../../../shared/utils/sanitizeBranchSlug';
 import { slugifyBranch } from '../../../../shared/utils/slugifyBranch';
 import { ghPrHeadBranch } from '../../../github/github';
-import {
-  DetailSection,
-  HeaderBand,
-  StudioDetailLayout,
-  StudioDetailTabs,
-} from '../../../../shared/components/StudioDetail';
-import { linearIssueFields, resolveDetailFields } from '../../../../shared/detail-fields';
-import { IssueStateBadge } from '../../../../shared/components/IssueStateBadge';
-import { ExternalRefActions } from '../../../../shared/components/ExternalRefActions';
 import { LaunchSessionPanel } from '../../../integrations/components/LaunchSessionPanel';
 import { goalFromIssue } from '../goal-from-issue';
 import { issuePullRequests, type LinearIssue } from '../client';
-import { LinearIssueComments } from '../LinearIssueComments';
-import { useLinearIssueComments } from '../useLinearIssueComments';
+import { LinearIssueDetail } from '../LinearIssueDetail';
 import { CONCEPT_ICONS } from '../../../../shared/components/conceptIcons';
-
-type IssueSection = 'overview' | 'conversation';
 
 type Props = {
   readonly issue: LinearIssue | null;
@@ -34,23 +21,22 @@ type Props = {
 
 const SLUG_MAX_LEN = 48;
 
-const slugify = (input: string): string => slugifyBranch({ input, maxLength: SLUG_MAX_LEN });
+type Params = {
+  readonly issue: LinearIssue;
+};
 
-const sanitizeSlug = (input: string): string =>
-  sanitizeBranchSlug({ input, maxLength: SLUG_MAX_LEN });
-
-function branchSlugFor(issue: LinearIssue): string {
+const branchSlugFor = ({ issue }: Params): string => {
   const branchName = issue.branchName;
-  if (branchName) {
+  if (branchName != null && branchName !== '') {
     const idx = branchName.indexOf('/');
     const tail = idx >= 0 ? branchName.slice(idx + 1) : branchName;
-    const cleaned = sanitizeSlug(tail);
+    const cleaned = sanitizeBranchSlug({ input: tail, maxLength: SLUG_MAX_LEN });
     if (cleaned.length > 0) {
       return cleaned;
     }
   }
-  return slugify(issue.title);
-}
+  return slugifyBranch({ input: issue.title, maxLength: SLUG_MAX_LEN });
+};
 
 export const IssueDetailPanel = ({ issue, sessionId, workspaceId, onClose }: Props) => {
   const rootPath = useAppStore(
@@ -61,14 +47,9 @@ export const IssueDetailPanel = ({ issue, sessionId, workspaceId, onClose }: Pro
   );
 
   const adoptablePr =
-    issue && !isBranchless ? (issuePullRequests(issue).find((pr) => pr.repo) ?? null) : null;
-
-  const [section, setSection] = useState<IssueSection>('overview');
-  const {
-    comments,
-    isLoading: commentsLoading,
-    error: commentsError,
-  } = useLinearIssueComments({ workspaceId, issueId: issue?.id ?? null });
+    issue != null && !isBranchless
+      ? (issuePullRequests(issue).find((pr) => pr.repo != null && pr.repo !== '') ?? null)
+      : null;
 
   const [prBranch, setPrBranch] = useState<string | null>(null);
   const [prResolving, setPrResolving] = useState(false);
@@ -77,7 +58,6 @@ export const IssueDetailPanel = ({ issue, sessionId, workspaceId, onClose }: Pro
   useEffect(() => {
     setPrBranch(null);
     setPrError(null);
-    setSection('overview');
   }, [issue]);
 
   useEffect(() => {
@@ -109,7 +89,7 @@ export const IssueDetailPanel = ({ issue, sessionId, workspaceId, onClose }: Pro
     };
   }, [adoptablePr?.repo, adoptablePr?.number, rootPath, workspaceId]);
 
-  if (!issue) {
+  if (issue == null) {
     return (
       <div className="flex h-full items-center justify-center px-8">
         <EmptyState
@@ -131,7 +111,7 @@ export const IssueDetailPanel = ({ issue, sessionId, workspaceId, onClose }: Pro
       workspaceId={workspaceId}
       linkedSessionId={sessionId}
       goalSeed={goalFromIssue(issue)}
-      branchSlugSeed={branchSlugFor(issue)}
+      branchSlugSeed={branchSlugFor({ issue })}
       externalTask={{
         provider: 'linear',
         externalId: issue.id,
@@ -140,7 +120,7 @@ export const IssueDetailPanel = ({ issue, sessionId, workspaceId, onClose }: Pro
         title: issue.title,
       }}
       adoptable={
-        adoptablePr
+        adoptablePr != null
           ? {
               label: `Continue on PR #${adoptablePr.number}`,
               branch: prBranch,
@@ -155,55 +135,12 @@ export const IssueDetailPanel = ({ issue, sessionId, workspaceId, onClose }: Pro
   );
 
   return (
-    <StudioDetailLayout
-      header={
-        <HeaderBand
-          meta={
-            <>
-              <span className="font-mono text-2xs tabular-nums text-muted-foreground">
-                {issue.identifier}
-              </span>
-              <IssueStateBadge>{issue.state.name}</IssueStateBadge>
-            </>
-          }
-          title={issue.title}
-          actions={<ExternalRefActions url={issue.url} label="issue" hostLabel="Linear" />}
-        />
-      }
-      tabs={
-        <StudioDetailTabs
-          ariaLabel="Issue sections"
-          value={section}
-          onChange={setSection}
-          options={[
-            { value: 'overview', label: 'Overview', icon: FileText },
-            {
-              value: 'conversation',
-              label: 'Conversation',
-              icon: MessageSquare,
-              ...(comments.length > 0 && { badge: String(comments.length) }),
-            },
-          ]}
-        />
-      }
+    <LinearIssueDetail
+      key={issue.id}
+      issue={issue}
+      workspaceId={workspaceId}
       rail={launch}
-      properties={resolveDetailFields({ registry: linearIssueFields, entity: issue })}
-    >
-      {section === 'overview' ? (
-        <DetailSection label="description">
-          {issue.description != null && issue.description !== '' ? (
-            <Markdown text={issue.description} className="text-sm leading-relaxed" />
-          ) : (
-            <p className="text-sm italic text-muted-foreground/60">No description.</p>
-          )}
-        </DetailSection>
-      ) : (
-        <LinearIssueComments
-          comments={comments}
-          isLoading={commentsLoading}
-          error={commentsError}
-        />
-      )}
-    </StudioDetailLayout>
+      fit="fill"
+    />
   );
 };

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/index.test.tsx
@@ -19,6 +19,14 @@ type Props = {
   readonly actions?: ReactNode;
 };
 
+type LinearDetailProps = {
+  readonly issueId: string;
+};
+
+type SentryDetailProps = {
+  readonly task: SessionExternalTask;
+};
+
 const h = vi.hoisted(() => ({
   store: {
     sessionExternalTasks: {},
@@ -55,12 +63,24 @@ vi.mock('../../../../../worktree/useRemoteHostKind', () => ({
 }));
 
 vi.mock('./LinearTaskDetail', () => ({
-  LinearTaskDetail: ({ issueId }: { issueId: string }) => <div>Linear detail {issueId}</div>,
+  LinearTaskDetail: ({ issueId }: LinearDetailProps) => (
+    <div>
+      <a href="https://linear.app/GB-42" aria-label="Open in Linear">
+        Linear detail {issueId}
+      </a>
+      <button type="button" aria-label="Copy issue link" />
+    </div>
+  ),
 }));
 
 vi.mock('./SentryTaskDetail', () => ({
-  SentryTaskDetail: ({ task }: { task: SessionExternalTask }) => (
-    <div>Sentry detail {task.externalId}</div>
+  SentryTaskDetail: ({ task }: SentryDetailProps) => (
+    <div>
+      <a href="https://sentry.io/issues/12345" aria-label="Open in Sentry">
+        Sentry detail {task.externalId}
+      </a>
+      <button type="button" aria-label="Copy issue link" />
+    </div>
   ),
 }));
 
@@ -156,6 +176,23 @@ describe('parseIntegrationTaskUrl', () => {
 });
 
 describe('IntegrationPane', () => {
+  it.each([
+    ['linear', TASK, 'Linear'],
+    ['sentry', SENTRY_TASK, 'Sentry'],
+  ] as const)(
+    'shows one open and copy affordance for a linked %s task with detail',
+    (provider, task, host) => {
+      h.store.sessionExternalTasks = { [SESSION_ID]: [task] };
+
+      render(
+        <IntegrationPane sessionId={SESSION_ID} workspaceId={WORKSPACE_ID} provider={provider} />,
+      );
+
+      expect(screen.getAllByRole('link', { name: `Open in ${host}` })).toHaveLength(1);
+      expect(screen.getAllByRole('button', { name: 'Copy issue link' })).toHaveLength(1);
+    },
+  );
+
   it('opens and confirms before unlinking every provider task shown for the session', async () => {
     render(<IntegrationPane sessionId={SESSION_ID} workspaceId={WORKSPACE_ID} provider="linear" />);
 

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/index.tsx
@@ -147,6 +147,12 @@ export const IntegrationPane = ({ sessionId, workspaceId, provider }: Props) => 
                       task={task}
                       appearance="row"
                       navigation="external"
+                      hasReferenceActions={
+                        !(
+                          connection.isConnected &&
+                          (provider === 'linear' || provider === 'sentry')
+                        )
+                      }
                       ariaLabel={`open ${task.identifier}`}
                       onClick={() => void openUrl(task.url)}
                     />

--- a/apps/desktop/src/shared/components/StudioDetail/DetailSection.tsx
+++ b/apps/desktop/src/shared/components/StudioDetail/DetailSection.tsx
@@ -5,14 +5,21 @@ type Props = {
   readonly label: string;
   readonly icon?: ReactNode;
   readonly action?: ReactNode;
+  readonly variant?: 'framed' | 'frameless';
   readonly children: ReactNode;
 };
 
-export const DetailSection = ({ label, icon, action, children }: Props) => {
+export const DetailSection = ({ label, icon, action, variant = 'framed', children }: Props) => {
   return (
     <section className="flex flex-col gap-3">
       <SectionHeader label={label} icon={icon} action={action} />
-      <div className="rounded-lg border border-border-soft bg-muted/10 p-4">{children}</div>
+      <div
+        className={
+          variant === 'framed' ? 'rounded-lg border border-border-soft bg-muted/10 p-4' : undefined
+        }
+      >
+        {children}
+      </div>
     </section>
   );
 };

--- a/apps/desktop/src/shared/components/StudioDetail/RailStack.tsx
+++ b/apps/desktop/src/shared/components/StudioDetail/RailStack.tsx
@@ -44,8 +44,8 @@ export const RailStack = ({ rail, properties, isScrollable }: Props) => {
       </div>
       <div
         className={cn(
-          'flex w-full flex-col gap-4 lg:w-[var(--studio-detail-rail-width)]',
-          isScrollable && 'px-6 py-4 lg:h-full lg:min-h-0 lg:p-4',
+          'flex w-full flex-col gap-4 px-6 py-4 lg:w-[var(--studio-detail-rail-width)] lg:p-4',
+          isScrollable && 'lg:h-full lg:min-h-0',
         )}
       >
         {rail != null ? extras : null}

--- a/apps/desktop/src/shared/components/StudioDetail/index.test.tsx
+++ b/apps/desktop/src/shared/components/StudioDetail/index.test.tsx
@@ -110,6 +110,23 @@ describe('StudioDetailLayout', () => {
     expect(band.className).toContain('bg-background');
   });
 
+  it('insets the properties rail in flow mode', () => {
+    render(
+      <StudioDetailLayout
+        header={<span>Header slot</span>}
+        properties={resolveDetailFields({ registry: PROPERTY_REGISTRY, entity: PROPERTY_ENTITY })}
+        fit="flow"
+      >
+        <span>Main slot</span>
+      </StudioDetailLayout>,
+    );
+
+    const rail = screen.getByTestId('detail-properties').closest('.px-6');
+    expect(rail).not.toBeNull();
+    expect((rail as HTMLElement).className).toContain('py-4');
+    expect((rail as HTMLElement).className).toContain('lg:p-4');
+  });
+
   it('renders the properties once, as a wrapping row below lg and a column from lg', () => {
     render(
       <StudioDetailLayout
@@ -221,6 +238,17 @@ describe('DetailSection', () => {
     expect(screen.getByText('description')).toBeDefined();
     expect(screen.getByRole('button', { name: 'Edit' })).toBeDefined();
     expect(screen.getByText('Body copy')).toBeDefined();
+  });
+
+  it('renders a frameless body without card styling', () => {
+    render(
+      <DetailSection label="description" variant="frameless">
+        <p>Primary body</p>
+      </DetailSection>,
+    );
+
+    const body = screen.getByText('Primary body').parentElement;
+    expect(body?.className).toBe('');
   });
 });
 

--- a/packages/ui/src/components/Markdown.tsx
+++ b/packages/ui/src/components/Markdown.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode } from 'react';
+import { Fragment, type ReactNode } from 'react';
 import { Activity, CheckCheck, FileEdit, HelpCircle, Target, type LucideIcon } from 'lucide-react';
 import { cn } from '../cn';
 
@@ -108,7 +108,7 @@ type Block =
       rows: ReadonlyArray<ReadonlyArray<string>>;
     }
   | { kind: 'callout'; tag: string; content: string }
-  | { kind: 'paragraph'; content: string };
+  | { kind: 'paragraph'; content: string; isTree: boolean };
 
 type ListItem = {
   readonly content: string;
@@ -124,6 +124,35 @@ const QUOTE_RE = /^>\s?(.*)$/;
 const TABLE_ROW_RE = /^\s*\|.*\|\s*$/;
 const TABLE_DIVIDER_RE = /^\s*\|?\s*:?-{2,}:?(\s*\|\s*:?-{2,}:?)*\s*\|?\s*$/;
 const CALLOUT_OPEN_RE = /^<<([a-zA-Z][a-zA-Z0-9_-]*)>>(.*)$/;
+const TREE_RE = /[├└│┌┐┘┤┬┼]/;
+
+type Params = {
+  readonly lines: ReadonlyArray<string>;
+};
+
+const joinParagraphLines = ({ lines }: Params): string => {
+  let content = '';
+
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+    const line = lines[lineIndex] ?? '';
+    const isLastLine = lineIndex === lines.length - 1;
+    if (isLastLine) {
+      content += line;
+      continue;
+    }
+    if (/ {2,}$/.test(line)) {
+      content += `${line.replace(/ {2,}$/, '')}\n`;
+      continue;
+    }
+    if (line.endsWith('\\')) {
+      content += `${line.slice(0, -1)}\n`;
+      continue;
+    }
+    content += `${line} `;
+  }
+
+  return content;
+};
 
 function splitTableCells(line: string): ReadonlyArray<string> {
   const trimmed = line.trim().replace(/^\|/, '').replace(/\|$/, '');
@@ -361,7 +390,12 @@ function parseBlocks(input: string): ReadonlyArray<Block> {
       paraBuf.push(next);
       i++;
     }
-    blocks.push({ kind: 'paragraph', content: paraBuf.join('\n') });
+    const isTree = paraBuf.some((paragraphLine) => TREE_RE.test(paragraphLine));
+    blocks.push({
+      kind: 'paragraph',
+      content: isTree ? paraBuf.join('\n') : joinParagraphLines({ lines: paraBuf }),
+      isTree,
+    });
   }
 
   return blocks;
@@ -440,7 +474,7 @@ function renderInline(input: string, keyPrefix: string): ReactNode {
         out.push(
           <code
             key={nextKey()}
-            className="rounded bg-muted px-1 py-0.5 font-mono text-[0.875em] text-foreground"
+            className="rounded bg-muted px-1 py-0.5 font-mono text-[0.875em] text-foreground wrap-anywhere"
           >
             {inner}
           </code>,
@@ -572,7 +606,7 @@ function renderBlock(block: Block, idx: number): ReactNode {
       };
       const Tag = `h${block.level}` as 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
       return (
-        <Tag key={key} className={sizes[block.level]}>
+        <Tag key={key} className={cn(sizes[block.level], 'wrap-anywhere')}>
           {renderInline(block.content, key)}
         </Tag>
       );
@@ -590,7 +624,7 @@ function renderBlock(block: Block, idx: number): ReactNode {
         return (
           <ol key={key} className="flex list-decimal flex-col gap-1.5 pl-5">
             {block.items.map((item, j) => (
-              <li key={`${key}-${j}`} className="leading-relaxed">
+              <li key={`${key}-${j}`} className="leading-relaxed wrap-anywhere">
                 {renderInline(item.content, `${key}-${j}`)}
               </li>
             ))}
@@ -600,7 +634,7 @@ function renderBlock(block: Block, idx: number): ReactNode {
       return (
         <ul key={key} className="flex list-disc flex-col gap-1.5 pl-5">
           {block.items.map((item, j) => (
-            <li key={`${key}-${j}`} className="leading-relaxed">
+            <li key={`${key}-${j}`} className="leading-relaxed wrap-anywhere">
               {renderInline(item.content, `${key}-${j}`)}
             </li>
           ))}
@@ -608,7 +642,10 @@ function renderBlock(block: Block, idx: number): ReactNode {
       );
     case 'quote':
       return (
-        <blockquote key={key} className="border-l-2 border-border pl-3 text-muted-foreground">
+        <blockquote
+          key={key}
+          className="border-l-2 border-border pl-3 text-muted-foreground wrap-anywhere"
+        >
           {block.lines.map((ln, j) => (
             <p key={`${key}-${j}`}>{renderInline(ln, `${key}-${j}`)}</p>
           ))}
@@ -633,7 +670,7 @@ function renderBlock(block: Block, idx: number): ReactNode {
                   <th
                     key={`${key}-h-${j}`}
                     className={cn(
-                      'px-3 py-1.5 font-medium text-foreground/75',
+                      'px-3 py-1.5 font-medium text-foreground/75 wrap-anywhere',
                       alignClass(block.align[j]),
                     )}
                   >
@@ -651,7 +688,10 @@ function renderBlock(block: Block, idx: number): ReactNode {
                   {row.map((cell, ci) => (
                     <td
                       key={`${key}-r-${ri}-c-${ci}`}
-                      className={cn('px-3 py-1.5 align-top', alignClass(block.align[ci]))}
+                      className={cn(
+                        'px-3 py-1.5 align-top wrap-anywhere',
+                        alignClass(block.align[ci]),
+                      )}
                     >
                       {renderInline(cell, `${key}-r-${ri}-c-${ci}`)}
                     </td>
@@ -678,23 +718,30 @@ function renderBlock(block: Block, idx: number): ReactNode {
             <Icon size={11} aria-hidden className={style.iconClass} />
             {label}
           </div>
-          <div className="whitespace-pre-wrap leading-relaxed text-foreground/90">
+          <div className="whitespace-pre-wrap leading-relaxed text-foreground/90 wrap-anywhere">
             {renderInline(block.content, key)}
           </div>
         </div>
       );
     }
     case 'paragraph': {
-      const isTree = /[├└│┌┐┘┤┬┼]/.test(block.content);
       return (
         <p
           key={key}
           className={cn(
-            'whitespace-pre-wrap leading-relaxed',
-            isTree && 'overflow-x-auto font-mono',
+            'leading-relaxed',
+            block.isTree && 'overflow-x-auto whitespace-pre-wrap font-mono',
+            !block.isTree && 'wrap-anywhere',
           )}
         >
-          {renderInline(block.content, key)}
+          {block.isTree
+            ? renderInline(block.content, key)
+            : block.content.split('\n').map((line, lineIndex, lines) => (
+                <Fragment key={`${key}-${lineIndex}`}>
+                  {renderInline(line, `${key}-${lineIndex}`)}
+                  {lineIndex < lines.length - 1 && <br />}
+                </Fragment>
+              ))}
         </p>
       );
     }


### PR DESCRIPTION
Stacked on #1129.

## What

1. **Markdown paragraphs reflow.** Lines were joined with a newline and printed inside
   `whitespace-pre-wrap`, so every a-capo someone typed became a forced break and prose read like
   preformatted text. Soft lines join with a space now, the way CommonMark says, and only the breaks
   markdown asks for survive: two trailing spaces or a trailing backslash, rendered as a real `br`.
   A box-drawing tree keeps its newlines and its horizontal scroll, detected before the join.
2. **Long tokens can break.** The file had zero word-breaking in any block while `MetaItem` and
   `RailBlock` have had it for a while. A URL with no spaces widened its container, and since
   `ScrollFade` sets `overflow-y-auto` the spec computes `overflow-x` as `auto`: that is where the
   horizontal scrollbar in the body of a detail page came from. Every text-bearing block wraps now.
3. **The description is the page.** `DetailSection` takes a frameless variant, and Linear, GitHub and
   GitLab descriptions use it. The asides keep their frame.
4. **The properties column breathes in flow mode.** `RailStack` padded only when scrollable.
5. **One Linear detail view.** The studio panel and the pane view had drifted into near copies. The
   studio now keeps only its empty state, launch panel and PR adoption, and passes the launch panel
   as a rail into the single view.
6. **One open, one copy.** For Linear and Sentry the pane rendered the linked row (open plus copy)
   directly above a detail whose header carries the same two actions. The row can now say it does not
   carry them, and does so wherever a detail follows.

## Why

Both bugs the user hit in the description panel were in the shared renderer, not in the three call
sites: all of Linear, GitHub and GitLab already passed their description to `Markdown`.

## Verified

`pnpm -w typecheck` and `pnpm -w test` green (4837 tests). New coverage: reflow, hard break, tree
preservation, wrapping class, flow padding, frameless section, and exactly one open/copy pair per
linked task.

## Not touched, and why

- **`Markdown` was not moved onto a library.** It is a hand-written parser used in twenty-odd places;
  swapping it is a different project with a different risk profile. Only reflow and wrapping changed.
- **Fenced code does not wrap.** A horizontal scrollbar beats a line of code broken mid-token. Same
  for the tree paragraph.
- **Sentry did not get a description.** The model does not have one, and inventing a field is not a
  layout fix. Only its duplicate actions were in scope.
- **The launch panel and PR adoption stayed in the studio.** They belong to the studio, not to the
  detail view, so consolidating the two views did not drag them along.