### PR TITLE
refactor(desktop): a quiet empty column, and one way to open a card

### DIFF
--- a/apps/desktop/src/features/github/components/GitHubStudio/InboxList.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/InboxList.tsx
@@ -22,6 +22,7 @@ export const InboxList = ({ groups, focusedSessionId, onSelect }: Props) => {
           icon={CONCEPT_ICONS.github}
           title="No sessions yet"
           description="Sessions in this workspace will show up here."
+          size="inline"
           action={
             <Button
               variant="ghost"

--- a/apps/desktop/src/features/github/components/GitHubStudio/IssueInbox.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/IssueInbox.tsx
@@ -105,6 +105,7 @@ export const IssueInbox = ({
             description={
               !hasQuery ? 'No open issues assigned to you.' : 'Try a different search term.'
             }
+            size="inline"
             action={
               <Button variant="ghost" size="sm" onClick={hasQuery ? () => setQuery('') : onRefresh}>
                 {hasQuery ? 'Clear search' : 'Refresh'}

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/IssueInbox.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/IssueInbox.tsx
@@ -105,6 +105,7 @@ export const IssueInbox = ({
             description={
               hasQuery ? 'Try a different search term.' : 'No open issues assigned to you.'
             }
+            size="inline"
             action={
               <Button variant="ghost" size="sm" onClick={hasQuery ? () => setQuery('') : onRefresh}>
                 {hasQuery ? 'Clear search' : 'Refresh'}

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrInbox.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrInbox.tsx
@@ -95,6 +95,7 @@ export const MrInbox = ({ groups, focusedMrId, onSelect, loading, error, onRefre
             description={
               !hasQuery ? 'No open merge requests assigned to you.' : 'Try a different search term.'
             }
+            size="inline"
             action={
               <Button variant="ghost" size="sm" onClick={hasQuery ? () => setQuery('') : onRefresh}>
                 {hasQuery ? 'Clear search' : 'Refresh'}

--- a/apps/desktop/src/features/integrations/linear/LinearIssueComments/index.tsx
+++ b/apps/desktop/src/features/integrations/linear/LinearIssueComments/index.tsx
@@ -34,6 +34,7 @@ export const LinearIssueComments = ({ comments, isLoading, error }: Props) => {
         icon={CONCEPT_ICONS.comments}
         title="No comments"
         description="This issue has no comments yet."
+        size="inline"
         className="py-5"
       />
     );

--- a/apps/desktop/src/features/integrations/linear/LinearStudio/IssueInbox.tsx
+++ b/apps/desktop/src/features/integrations/linear/LinearStudio/IssueInbox.tsx
@@ -91,6 +91,7 @@ export const IssueInbox = ({
             description={
               hasQuery ? 'Try a different search term.' : 'No open issues assigned to you.'
             }
+            size="inline"
             action={
               <Button variant="ghost" size="sm" onClick={hasQuery ? () => setQuery('') : onRefresh}>
                 {hasQuery ? 'Clear search' : 'Refresh'}

--- a/apps/desktop/src/features/integrations/sentry/SentryStudio/IssueInbox.tsx
+++ b/apps/desktop/src/features/integrations/sentry/SentryStudio/IssueInbox.tsx
@@ -89,6 +89,7 @@ export const IssueInbox = ({
             description={
               hasQuery ? 'Try a different search term.' : 'No unresolved issues in this project.'
             }
+            size="inline"
             action={
               <Button variant="ghost" size="sm" onClick={hasQuery ? () => setQuery('') : onRefresh}>
                 {hasQuery ? 'Clear search' : 'Refresh'}

--- a/apps/desktop/src/features/notifications/components/NotificationCenter/index.tsx
+++ b/apps/desktop/src/features/notifications/components/NotificationCenter/index.tsx
@@ -200,6 +200,7 @@ export const NotificationCenter = () => {
                     icon={CONCEPT_ICONS.notifications}
                     title="Nothing to catch up on"
                     description="Session milestones, retries, and budget alerts land here as they happen, so you don't have to babysit a running session."
+                    size="inline"
                     action={
                       <Button
                         size="sm"

--- a/apps/desktop/src/features/providers/components/ProviderStudio/ProviderCredentialsSection.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/ProviderCredentialsSection.tsx
@@ -86,6 +86,7 @@ export const ProviderCredentialsSection = ({ providerId }: Props) => {
           bordered
           icon={CONCEPT_ICONS.providers}
           title="No API keys yet"
+          size="inline"
           className="bg-muted/10 py-8"
         />
       ) : null}

--- a/apps/desktop/src/features/review/components/ReviewBoardPane/DraftsPanel.tsx
+++ b/apps/desktop/src/features/review/components/ReviewBoardPane/DraftsPanel.tsx
@@ -39,6 +39,7 @@ export const DraftsPanel = ({ drafts, onEdit, onDiscard }: Props) => {
             icon={CONCEPT_ICONS.review}
             title="No draft comments yet"
             description="Ask the agent to draft comments, or click a diff line."
+            size="inline"
           />
         </div>
       ) : (

--- a/apps/desktop/src/features/review/components/ReviewInboxList/index.tsx
+++ b/apps/desktop/src/features/review/components/ReviewInboxList/index.tsx
@@ -106,6 +106,7 @@ export const ReviewInboxList = ({ workspaceId, provider, scope, focusedPrId, onS
                 ? 'Pull requests by other authors will show up here.'
                 : 'Open pull requests on this repository will show up here.'
             }
+            size="inline"
             action={
               <Button variant="ghost" size="sm" onClick={() => void refreshReviewPrs(workspaceId)}>
                 Refresh

--- a/apps/desktop/src/features/scripts/components/ScriptsPanel/ScriptRow.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsPanel/ScriptRow.tsx
@@ -206,7 +206,7 @@ export const ScriptRow = ({
               label="Copy script"
               tone={copied ? 'success' : 'neutral'}
               size="default"
-              active={copied}
+              highlighted={copied}
               onClick={onCopy}
             />
             <CardAction
@@ -220,7 +220,7 @@ export const ScriptRow = ({
               label="Delete script"
               tone="danger"
               size="default"
-              active={isDeleteArmed}
+              highlighted={isDeleteArmed}
               expanded={isDeleteArmed}
               onClick={() => setIsDeleteArmed(true)}
             />

--- a/apps/desktop/src/features/session/components/ResolverAgentsLane/ResolverCard.tsx
+++ b/apps/desktop/src/features/session/components/ResolverAgentsLane/ResolverCard.tsx
@@ -112,7 +112,7 @@ export const ResolverCard = ({
             icon={PanelRight}
             label="Toggle resolver details"
             pressed={isInspected}
-            active={isInspected}
+            highlighted={isInspected}
             onClick={onInspect}
           />
         </>

--- a/apps/desktop/src/features/session/components/ResolverAgentsLane/index.tsx
+++ b/apps/desktop/src/features/session/components/ResolverAgentsLane/index.tsx
@@ -58,6 +58,7 @@ export const ResolverAgentsLane = ({
           icon={CONCEPT_ICONS.resolve}
           title={hasNoResolvers ? 'Nothing to resolve' : 'No active resolvers'}
           description={hasNoResolvers ? NOTHING_TO_RESOLVE_DESCRIPTION : ALL_RESOLVED_DESCRIPTION}
+          size="inline"
           action={<ResolveCommentsAction variant="tile" onOpen={lane.onOpenResolveBoard} />}
         />
       }

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowsPane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowsPane.tsx
@@ -140,6 +140,7 @@ export const WorkflowsPane = ({ session }: Props) => {
                       ? 'Every attached workflow is done. Reveal the completed ones to reread them, or attach another.'
                       : 'No live workflow on this session. Attach one to start.'
                   }
+                  size="inline"
                   action={<WorkflowAttachButton sessionId={sessionId} placement="header" />}
                 />
               ) : null}

--- a/apps/desktop/src/features/session/components/StandaloneAgentsLane/index.tsx
+++ b/apps/desktop/src/features/session/components/StandaloneAgentsLane/index.tsx
@@ -112,6 +112,7 @@ export const StandaloneAgentsLane = ({
             icon={CONCEPT_ICONS.agents}
             title={hasNoAgents ? 'No agents yet' : 'No active agents'}
             description={hasNoAgents ? NO_AGENTS_DESCRIPTION : ALL_DONE_DESCRIPTION}
+            size="inline"
           />
         )
       }

--- a/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
@@ -955,6 +955,7 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
                             bordered
                             icon={CONCEPT_ICONS.workflows}
                             title="No presets in this workspace yet"
+                            size="inline"
                             className="items-start px-4 py-5 text-left"
                             action={
                               <button

--- a/apps/desktop/src/features/skills/components/SkillsPanel/index.tsx
+++ b/apps/desktop/src/features/skills/components/SkillsPanel/index.tsx
@@ -269,7 +269,7 @@ const SkillRow = ({ skill, onEdit, onDelete }: SkillRowProps) => {
               label={`Delete ${skill.name}`}
               tone="danger"
               size="default"
-              active={isDeleteArmed}
+              highlighted={isDeleteArmed}
               expanded={isDeleteArmed}
               onClick={() => setIsDeleteArmed(true)}
             />

--- a/apps/desktop/src/features/workflows/components/WorkflowStudio/StepLibraryPalette/index.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowStudio/StepLibraryPalette/index.tsx
@@ -63,6 +63,7 @@ export const StepLibraryPalette = ({
           icon={CONCEPT_ICONS.workflows}
           title="No library steps yet"
           description="Create one to reuse it across workflows."
+          size="inline"
           bordered
           action={newStepAction}
         />

--- a/apps/desktop/src/features/workflows/components/WorkflowStudio/WorkflowsRail/index.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowStudio/WorkflowsRail/index.tsx
@@ -59,6 +59,7 @@ export const WorkflowsRail = ({
             icon={CONCEPT_ICONS.workflows}
             title="No presets yet"
             description="Create one to chain several agents in a single session."
+            size="inline"
             bordered
           />
         ) : (

--- a/apps/desktop/src/features/workspace/components/SessionActivityBar/index.tsx
+++ b/apps/desktop/src/features/workspace/components/SessionActivityBar/index.tsx
@@ -239,6 +239,7 @@ export const SessionActivityBar = ({
             <EmptyState
               icon={CONCEPT_ICONS.sessions}
               title={isArchivedView ? 'No archived sessions' : 'No sessions yet'}
+              size="inline"
               className="px-1 py-3"
             />
           ) : null}

--- a/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.test.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.test.tsx
@@ -1,6 +1,7 @@
 import type { ReactElement } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { HelpCircle, Play, type LucideIcon } from 'lucide-react';
 import type {
   PullRequestState,
   Session,
@@ -11,7 +12,15 @@ import type {
 import type { GitlabMergeRequest } from '../../../../integrations/gitlab/client';
 import type { BoardNavigation } from '../useBoardNavigation';
 
-const { state, hooks } = vi.hoisted(() => ({
+type MockDynamicAction = {
+  readonly key: string;
+  readonly icon: LucideIcon;
+  readonly tone: 'primary' | 'warning';
+  readonly label: string;
+  readonly onClick: () => void;
+};
+
+const { state, hooks, useDynamicActionsMock } = vi.hoisted(() => ({
   state: {
     sessionGithub: {} as Record<string, { pr: PullRequestState | null }>,
     sessionGitlabMr: {} as Record<string, { mr: GitlabMergeRequest | null }>,
@@ -27,6 +36,7 @@ const { state, hooks } = vi.hoisted(() => ({
     agents: [] as ReadonlyArray<unknown>,
     cost: 0,
   },
+  useDynamicActionsMock: vi.fn((): ReadonlyArray<MockDynamicAction> => []),
 }));
 
 vi.mock('../../../../../store', () => ({
@@ -38,7 +48,7 @@ vi.mock('../../../../../store', () => ({
 }));
 
 vi.mock('./useDynamicActions', () => ({
-  useDynamicActions: () => [],
+  useDynamicActions: () => useDynamicActionsMock(),
 }));
 
 vi.mock('@goodboy/ui', async (importOriginal) => {
@@ -109,6 +119,8 @@ beforeEach(() => {
   state.sessionPhaseRuns = {};
   state.reviewDrafts = {};
   state.loadReviewDrafts.mockClear();
+  useDynamicActionsMock.mockReset();
+  useDynamicActionsMock.mockReturnValue([]);
   nav.selectCard.mockClear();
   hooks.reason = 'no PR yet';
   hooks.agents = [];
@@ -230,23 +242,39 @@ describe('StageBoardCard linked request', () => {
 });
 
 describe('StageBoardCard actions visibility', () => {
-  it('keeps navigation and lifecycle actions in stable declared slots', () => {
+  it('keeps session details navigation only on the card body and keyboard', () => {
     render(<StageBoardCard session={session} nav={nav} />);
-    const archiveBtn = screen.getByLabelText('archive');
-    const detailsBtn = screen.getByLabelText('Open session details');
-    const navigationSlot = screen.getByRole('group', { name: 'Session navigation actions' });
-    const lifecycleSlot = screen.getByRole('group', { name: 'Session lifecycle actions' });
-
-    expect(navigationSlot.contains(detailsBtn)).toBe(true);
-    expect(lifecycleSlot.contains(archiveBtn)).toBe(true);
-    expect(detailsBtn.className).not.toContain('opacity-0');
-    expect(archiveBtn.className).not.toContain('opacity-0');
+    const card = screen.getAllByRole('button')[0] as HTMLElement;
+    expect(screen.queryByLabelText('Open session details')).toBeNull();
+    fireEvent.click(card);
+    fireEvent.keyDown(card, { key: 'Enter' });
+    expect(nav.selectCard).toHaveBeenCalledTimes(2);
   });
 
-  it('renders action buttons with hover color classes', () => {
+  it('shows attention action tint at rest and keeps non-attention neutral', () => {
+    useDynamicActionsMock.mockReturnValue([
+      {
+        key: 'questions',
+        icon: HelpCircle,
+        tone: 'warning',
+        label: '1 open question',
+        onClick: vi.fn(),
+      },
+      {
+        key: 'run',
+        icon: Play,
+        tone: 'primary',
+        label: 'run next step',
+        onClick: vi.fn(),
+      },
+    ]);
     render(<StageBoardCard session={session} nav={nav} />);
-    const deleteBtn = screen.getByLabelText('delete');
-    expect(deleteBtn.className).toContain('hover:text-danger');
+    const attention = screen.getByLabelText('1 open question');
+    const nonAttention = screen.getByLabelText('run next step');
+    expect(attention.className.includes(' bg-warning/5')).toBe(true);
+    expect(attention.className).toContain('text-warning');
+    expect(nonAttention.className).not.toContain('bg-warning/5');
+    expect(nonAttention.className.includes(' bg-primary/5')).toBe(false);
   });
 });
 

--- a/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.tsx
@@ -5,7 +5,6 @@ import {
   Check,
   Code,
   MessageSquareDiff,
-  PanelRight,
   RotateCcw,
   SquareTerminal,
   Trash2,
@@ -24,6 +23,7 @@ import { CostBadge } from '../../../../providers/components/CostBadge';
 import { PullRequestChip, pullRequestMeta } from '../../../../github/components/PullRequestChip';
 import { ExternalTaskChip } from '../../../../integrations/components/ExternalTaskChip';
 import { CardAction } from '../../../../../shared/components/CardAction';
+import { STAGE_TONE } from '../../../../session/session-stage';
 import { CardActionSlot } from '../../../../../shared/components/CardActionSlot';
 import type { BoardNavigation } from '../useBoardNavigation';
 import { getLinkedRequest } from './getLinkedRequest';
@@ -248,11 +248,6 @@ export const StageBoardCard = memo(function StageBoardCard({
               </span>
             </Tooltip>
           )}
-          <CardAction
-            icon={PanelRight}
-            label="Open session details"
-            onClick={() => nav.selectCard(session)}
-          />
         </span>
         {!archived && (
           <span className="flex flex-nowrap justify-end gap-1">
@@ -261,6 +256,7 @@ export const StageBoardCard = memo(function StageBoardCard({
                 key={action.key}
                 icon={action.icon}
                 tone={action.tone}
+                highlighted={action.tone === STAGE_TONE.attention}
                 label={action.label}
                 onClick={action.onClick}
               />

--- a/apps/desktop/src/features/workspace/components/StageBoard/StageColumn/index.test.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/StageColumn/index.test.tsx
@@ -70,6 +70,13 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe('StageColumn selection', () => {
+  it('uses the quiet empty state for an empty column', () => {
+    const { container } = renderColumn([]);
+    expect(screen.getByText('nothing building')).toBeDefined();
+    expect(container.querySelector('.size-12')).toBeNull();
+    expect(container.querySelector('.mt-0\\.5')).not.toBeNull();
+  });
+
   it('shows no bulk bar until a card is selected', () => {
     renderColumn([makeSession('s-1', 'one')]);
     expect(screen.queryByText(/selected/)).toBeNull();

--- a/apps/desktop/src/features/workspace/components/StageBoard/StageColumn/index.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/StageColumn/index.tsx
@@ -127,6 +127,7 @@ export const StageColumn = ({
               <EmptyState
                 icon={CONCEPT_ICONS.sessions}
                 title={ZERO_STATE[view.key]}
+                size="inline"
                 className="px-1 py-6"
               />
             ) : (

--- a/apps/desktop/src/features/workspace/components/WorkspaceLauncher/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspaceLauncher/index.tsx
@@ -102,6 +102,7 @@ export const WorkspaceLauncher = () => {
                 <EmptyState
                   icon={CONCEPT_ICONS.workspace}
                   title="No workspaces found"
+                  size="inline"
                   className="px-3 py-8"
                 />
               </li>

--- a/apps/desktop/src/features/workspace/components/WorkspaceSwitcher/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspaceSwitcher/index.tsx
@@ -81,6 +81,7 @@ export const WorkspaceSwitcher = ({ onClose }: Props) => {
                 <EmptyState
                   icon={CONCEPT_ICONS.workspace}
                   title="No workspaces"
+                  size="inline"
                   className="px-4 py-6"
                 />
               </li>

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentRow.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentRow.tsx
@@ -139,7 +139,7 @@ export const AgentRow = ({
             icon={PanelRight}
             label="Toggle agent details"
             pressed={isInspected}
-            active={isInspected}
+            highlighted={isInspected}
             onClick={onInspect}
           />
         ) : (
@@ -164,7 +164,7 @@ export const AgentRow = ({
               icon={Trash2}
               label="delete agent"
               tone="danger"
-              active={isConfirmingDelete}
+              highlighted={isConfirmingDelete}
               reveal={!isConfirmingDelete}
               onClick={() => setIsConfirmingDelete(true)}
             />

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.tsx
@@ -288,7 +288,7 @@ export const WorkflowRow = ({
                     label={run.autoRun ? 'autorun on' : 'autorun off'}
                     tone="primary"
                     pressed={run.autoRun}
-                    active={run.autoRun}
+                    highlighted={run.autoRun}
                     onClick={() => void setWorkflowRunAutoRun(task.id, run.id, !run.autoRun)}
                   />
                 ) : null}

--- a/apps/desktop/src/shared/components/CardAction.tsx
+++ b/apps/desktop/src/shared/components/CardAction.tsx
@@ -7,7 +7,7 @@ type Props = {
   readonly tone?: Tone;
   readonly size?: 'compact' | 'default';
   readonly reveal?: boolean;
-  readonly active?: boolean;
+  readonly highlighted?: boolean;
   readonly pressed?: boolean;
   readonly expanded?: boolean;
   readonly disabled?: boolean;
@@ -20,7 +20,7 @@ export const CardAction = ({
   tone = 'neutral',
   size = 'compact',
   reveal = false,
-  active = false,
+  highlighted = false,
   pressed,
   expanded,
   disabled = false,
@@ -44,7 +44,7 @@ export const CardAction = ({
         tintClasses(tone).hoverText,
         reveal &&
           'opacity-0 group-hover/agent-card:opacity-100 group-focus-within/agent-card:opacity-100',
-        active && cn(tintClasses(tone).bgSoft, tintClasses(tone).text),
+        highlighted && cn(tintClasses(tone).bgSoft, tintClasses(tone).text),
       )}
     >
       <Icon size={size === 'compact' ? 12 : 14} aria-hidden />


### PR DESCRIPTION
Stacked on #1132.

## What

1. **The empty column stops shouting.** `StageColumn` passed no `size`, so it fell on the `sm` default
   and drew the 48px tinted ball next to columns holding real cards. `inline` is the only size that
   omits the ball and is already the app's norm at thirty-odd call sites. The stage column uses it,
   and so do the other lists, lanes and table bodies that were in the same position. Everything that
   is the whole content of a page, pane or detail region keeps what it had: those states are supposed
   to fill their space.
2. **One way to open a card.** `StageBoardCard` mounted a `PanelRight` action whose `onClick` was the
   same `nav.selectCard(session)` the card body and the Enter key already call. Removed. Editor,
   terminal, archive, delete, restore and the selection checkbox all stay.
3. **Attention is visible at rest.** `useDynamicActions` has always given the open-questions action
   the `warning` tone, and `CardAction` painted its tone only on hover, so the one signal that a
   session is waiting for you appeared once the cursor was already on it. The card asks for the tone
   at rest, following the `NextUpCard` idiom, and derives which action counts as attention from
   `STAGE_TONE.attention` rather than hardcoding a key.

## Why `active` became `highlighted`

The prop that renders a tone at rest was called `active`. Five toggles used it and for them the name
was true. For an attention signal it is not: the action is not active, it is waiting. One name that is
honest for both beats a second prop that renders identically.

## Verified

`pnpm -w typecheck` and the desktop suite green (3637 tests). New coverage: the column's quiet empty
state, exactly one way to open session details, and an attention action visible without hover while a
non-attention one is not.

## Not touched, and why

- **No new colour.** The tone was already there and already canonical; only its visibility changed.
- **Only the attention action is tinted.** `run` and `unread` carry a tone too, and tinting all three
  would turn the card into a traffic light and cost the signal its meaning.