### PR TITLE
feat(desktop): give the sessions column back to the user

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -60,8 +60,9 @@ functional. One register per surface; let the other supply only texture.
   answers "where do I want to be". Each has one job; they must not compete.
 - **Pin the structure, flex the density.** Nothing appears or disappears at a
   count threshold. A control's position is fixed so it can be learned. The
-  sidebar has no collapse rail or toggle; it is either hidden (board-only
-  Overview) or at its persisted width.
+  sidebar has no collapse rail. Overview stays board-only. Inside a session,
+  the sessions column can be hidden or shown from the workspace header or with
+  ⌘B, and that choice persists.
 - **Settings match the scope they edit.** Configuration splits into two
   surfaces by ownership: application settings is a full-page studio; workspace
   settings is a lightweight scoped pane. Each surface edits only

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -65,6 +65,7 @@ import { useGithubPolling } from './features/github/hooks/useGithubPolling';
 import { useUpdaterPolling } from './features/updater/hooks/useUpdaterPolling';
 import { useWorkspaceRemoteHostKind } from './features/worktree/useWorkspaceRemoteHostKind';
 import { resolveSessionRepo } from './store/slices/worktrees/resolveSessionRepo';
+import { useSessionSidebarVisibility } from './features/workspace/hooks/useSessionSidebarVisibility';
 
 const KEEP_ALIVE_CAP = 5;
 
@@ -79,6 +80,8 @@ export const App = () => {
   const hasWorkspaces = workspaces.length > 0;
   const currentWorkspace = useCurrentWorkspace();
   const currentSession = useCurrentSession();
+  const hasActiveSession = currentSession != null;
+  const sessionSidebar = useSessionSidebarVisibility({ hasActiveSession });
   const remoteKind = useWorkspaceRemoteHostKind({ workspaceId: currentWorkspace?.id ?? null });
   const hasLinear = useAppStore((s) =>
     (s.workspaceIntegrations?.[currentWorkspace?.id ?? ('' as WorkspaceId)] ?? []).some(
@@ -687,6 +690,7 @@ export const App = () => {
   useKeyboardShortcut('cmd+k', () => openPalette());
   useKeyboardShortcut('cmd+o', () => setSwitcherOpen(true));
   useKeyboardShortcut('cmd+n', openNewSession, { ignoreInInputs: false });
+  useKeyboardShortcut('cmd+b', sessionSidebar.toggle, { ignoreInInputs: false });
   useKeyboardShortcut('cmd+[', () => navigateLens(-1), { ignoreInInputs: false });
   useKeyboardShortcut('cmd+]', () => navigateLens(1), { ignoreInInputs: false });
   useKeyboardShortcut('cmd+shift+[', () => navigateSession(-1), { ignoreInInputs: false });
@@ -774,7 +778,15 @@ export const App = () => {
             activeStudio={activeStudio}
           />
         }
-        workspaceBar={currentWorkspace ? <WorkspaceHeader /> : undefined}
+        workspaceBar={
+          currentWorkspace ? (
+            <WorkspaceHeader
+              hasActiveSession={hasActiveSession}
+              isSessionSidebarCollapsed={sessionSidebar.isCollapsed}
+              onToggleSessionSidebar={sessionSidebar.toggle}
+            />
+          ) : undefined
+        }
         footer={
           currentWorkspace ? (
             <AppFooter
@@ -821,7 +833,7 @@ export const App = () => {
             />
           ) : undefined
         }
-        leftHidden={!currentSession}
+        leftHidden={sessionSidebar.leftHidden}
         leftSidebar={hasWorkspaces ? <WorkspacesSidebar /> : undefined}
         main={
           <div className="relative h-full w-full">

--- a/apps/desktop/src/__tests__/keyboard/lens-shortcuts.test.tsx
+++ b/apps/desktop/src/__tests__/keyboard/lens-shortcuts.test.tsx
@@ -136,6 +136,23 @@ afterEach(() => {
 });
 
 describe('App lens shortcuts', () => {
+  it('registers cmd+b for the sessions column without colliding with agents lens', () => {
+    render(<App />);
+
+    expect(shortcutHandlers.has('cmd+b')).toBe(true);
+    expect(shortcutHandlers.has('cmd+shift+b')).toBe(true);
+
+    act(() => {
+      shortcutHandlers.get('cmd+b')?.();
+    });
+    expect(setActiveLens).not.toHaveBeenCalled();
+
+    act(() => {
+      shortcutHandlers.get('cmd+shift+b')?.();
+    });
+    expect(setActiveLens).toHaveBeenCalledWith('session-1', 'agents');
+  });
+
   it('dispatches overview, pull request, decisions, and summary lenses', () => {
     render(<App />);
 

--- a/apps/desktop/src/features/settings/components/SettingsStudio/ShortcutsSection.tsx
+++ b/apps/desktop/src/features/settings/components/SettingsStudio/ShortcutsSection.tsx
@@ -10,7 +10,7 @@ const SHORTCUTS: ReadonlyArray<{ readonly combo: readonly string[]; readonly lab
   { combo: ['⌘', 'K'], label: 'command palette' },
   { combo: ['⌘', 'O'], label: 'open workspace switcher' },
   { combo: ['⌘', 'N'], label: 'new session' },
-  { combo: ['⌘', 'B'], label: 'toggle sessions sidebar' },
+  { combo: ['⌘', 'B'], label: 'toggle sessions column' },
   { combo: ['⌘', '1', '..', '9'], label: 'jump to workspace 1 to 9' },
   { combo: ['⌘', '['], label: 'back (lens history)' },
   { combo: ['⌘', ']'], label: 'forward (lens history)' },

--- a/apps/desktop/src/features/workspace/components/WorkspaceHeader/index.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspaceHeader/index.test.tsx
@@ -31,14 +31,26 @@ afterEach(cleanup);
 
 describe('WorkspaceHeader', () => {
   it('renders the current workspace name', () => {
-    render(<WorkspaceHeader />);
+    render(
+      <WorkspaceHeader
+        hasActiveSession={false}
+        isSessionSidebarCollapsed={false}
+        onToggleSessionSidebar={vi.fn()}
+      />,
+    );
     expect(screen.getByText('alpha')).toBeDefined();
   });
 
   it('opens the switcher via the global event', () => {
     const spy = vi.fn();
     window.addEventListener('goodboy:open-workspace-switcher', spy);
-    render(<WorkspaceHeader />);
+    render(
+      <WorkspaceHeader
+        hasActiveSession={false}
+        isSessionSidebarCollapsed={false}
+        onToggleSessionSidebar={vi.fn()}
+      />,
+    );
     fireEvent.click(screen.getByLabelText(/switch or open a workspace/i));
     expect(spy).toHaveBeenCalledOnce();
     window.removeEventListener('goodboy:open-workspace-switcher', spy);
@@ -46,16 +58,56 @@ describe('WorkspaceHeader', () => {
 
   it('renders nothing without a current workspace', () => {
     state.currentWorkspace = null;
-    const { container } = render(<WorkspaceHeader />);
+    const { container } = render(
+      <WorkspaceHeader
+        hasActiveSession={false}
+        isSessionSidebarCollapsed={false}
+        onToggleSessionSidebar={vi.fn()}
+      />,
+    );
     expect(container.firstChild).toBeNull();
   });
 
   it('dispatches the workspace settings event when the gear is clicked', () => {
     const spy = vi.fn();
     window.addEventListener(SETTINGS_EVENT, spy);
-    render(<WorkspaceHeader />);
+    render(
+      <WorkspaceHeader
+        hasActiveSession={false}
+        isSessionSidebarCollapsed={false}
+        onToggleSessionSidebar={vi.fn()}
+      />,
+    );
     fireEvent.click(screen.getByLabelText(/open workspace settings for alpha/i));
     expect(spy).toHaveBeenCalledOnce();
     window.removeEventListener(SETTINGS_EVENT, spy);
+  });
+
+  it('renders the sessions column toggle when a session is open', () => {
+    const onToggleSessionSidebar = vi.fn();
+    render(
+      <WorkspaceHeader
+        hasActiveSession
+        isSessionSidebarCollapsed={false}
+        onToggleSessionSidebar={onToggleSessionSidebar}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /hide sessions column \(⌘B\)/i }));
+    expect(onToggleSessionSidebar).toHaveBeenCalledOnce();
+  });
+
+  it('disables the sessions column toggle when no session is open', () => {
+    render(
+      <WorkspaceHeader
+        hasActiveSession={false}
+        isSessionSidebarCollapsed={false}
+        onToggleSessionSidebar={vi.fn()}
+      />,
+    );
+    expect(
+      screen
+        .getByRole('button', { name: /open a session to show the sessions column/i })
+        .getAttribute('disabled'),
+    ).not.toBeNull();
   });
 });

--- a/apps/desktop/src/features/workspace/components/WorkspaceHeader/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspaceHeader/index.tsx
@@ -1,4 +1,4 @@
-import { ChevronsUpDown, Settings } from 'lucide-react';
+import { ChevronsUpDown, PanelLeft, PanelLeftClose, Settings } from 'lucide-react';
 import { StatusDot } from '@goodboy/ui';
 import { useCurrentWorkspace, useHasUnreadElsewhere } from '../../../../store';
 import { workspaceAccent } from '../../color';
@@ -7,7 +7,35 @@ const initialOf = (name: string): string => name.trim().charAt(0).toUpperCase() 
 
 const basenameOf = (path: string): string => path.replace(/\/+$/, '').split('/').pop() || path;
 
-export const WorkspaceHeader = () => {
+type LabelParams = {
+  readonly hasActiveSession: boolean;
+  readonly isSessionSidebarCollapsed: boolean;
+};
+
+const sidebarActionLabelFor = ({
+  hasActiveSession,
+  isSessionSidebarCollapsed,
+}: LabelParams): string => {
+  if (!hasActiveSession) {
+    return 'open a session to show the sessions column';
+  }
+  if (isSessionSidebarCollapsed) {
+    return 'show sessions column (⌘B)';
+  }
+  return 'hide sessions column (⌘B)';
+};
+
+type Props = {
+  readonly hasActiveSession: boolean;
+  readonly isSessionSidebarCollapsed: boolean;
+  readonly onToggleSessionSidebar: () => void;
+};
+
+export const WorkspaceHeader = ({
+  hasActiveSession,
+  isSessionSidebarCollapsed,
+  onToggleSessionSidebar,
+}: Props) => {
   const currentWorkspace = useCurrentWorkspace();
   const hasUnreadElsewhere = useHasUnreadElsewhere(currentWorkspace?.id ?? null);
 
@@ -17,6 +45,11 @@ export const WorkspaceHeader = () => {
   const accent = workspaceAccent(currentWorkspace.id);
   const memberCount = currentWorkspace.members?.length ?? 0;
   const subtitle = memberCount > 1 ? `${memberCount} repos` : basenameOf(currentWorkspace.rootPath);
+  const sidebarActionDisabled = !hasActiveSession;
+  const sidebarActionLabel = sidebarActionLabelFor({
+    hasActiveSession,
+    isSessionSidebarCollapsed,
+  });
 
   return (
     <div className="flex shrink-0 items-center gap-1 px-2.5 py-2.5" data-tauri-drag-region="false">
@@ -53,6 +86,21 @@ export const WorkspaceHeader = () => {
           aria-hidden
           className="shrink-0 text-muted-foreground/40 transition-colors group-hover:text-muted-foreground"
         />
+      </button>
+      <button
+        type="button"
+        onClick={onToggleSessionSidebar}
+        disabled={sidebarActionDisabled}
+        data-tauri-drag-region="false"
+        className="flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground/50 transition-colors hover:bg-muted/50 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+        title={sidebarActionLabel}
+        aria-label={sidebarActionLabel}
+      >
+        {isSessionSidebarCollapsed ? (
+          <PanelLeft size={14} aria-hidden />
+        ) : (
+          <PanelLeftClose size={14} aria-hidden />
+        )}
       </button>
       <button
         type="button"

--- a/apps/desktop/src/features/workspace/hooks/useSessionSidebarVisibility/index.test.ts
+++ b/apps/desktop/src/features/workspace/hooks/useSessionSidebarVisibility/index.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { act, cleanup, renderHook } from '@testing-library/react';
+import { STORAGE_KEYS } from '../../../../shared/lib/storage-keys';
+import { useSessionSidebarVisibility } from './index';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(cleanup);
+
+describe('useSessionSidebarVisibility', () => {
+  it('shows the sessions column by default when a session is open', () => {
+    const { result } = renderHook(() => useSessionSidebarVisibility({ hasActiveSession: true }));
+    expect(result.current.leftHidden).toBe(false);
+    expect(result.current.isCollapsed).toBe(false);
+  });
+
+  it('toggles the sessions column and persists the choice', () => {
+    const { result } = renderHook(() => useSessionSidebarVisibility({ hasActiveSession: true }));
+    act(() => {
+      result.current.toggle();
+    });
+    expect(result.current.leftHidden).toBe(true);
+    expect(result.current.isCollapsed).toBe(true);
+    expect(localStorage.getItem(STORAGE_KEYS.sessionSidebarCollapsed)).toBe('1');
+
+    act(() => {
+      result.current.toggle();
+    });
+    expect(result.current.leftHidden).toBe(false);
+    expect(result.current.isCollapsed).toBe(false);
+    expect(localStorage.getItem(STORAGE_KEYS.sessionSidebarCollapsed)).toBe('0');
+  });
+
+  it('restores a persisted collapsed choice on remount', () => {
+    localStorage.setItem(STORAGE_KEYS.sessionSidebarCollapsed, '1');
+    const { result } = renderHook(() => useSessionSidebarVisibility({ hasActiveSession: true }));
+    expect(result.current.leftHidden).toBe(true);
+    expect(result.current.isCollapsed).toBe(true);
+  });
+
+  it('keeps overview board-only and ignores toggle while no session is open', () => {
+    const { result } = renderHook(() => useSessionSidebarVisibility({ hasActiveSession: false }));
+    act(() => {
+      result.current.toggle();
+    });
+    expect(result.current.leftHidden).toBe(true);
+    expect(result.current.isCollapsed).toBe(false);
+    expect(localStorage.getItem(STORAGE_KEYS.sessionSidebarCollapsed)).toBeNull();
+  });
+});

--- a/apps/desktop/src/features/workspace/hooks/useSessionSidebarVisibility/index.ts
+++ b/apps/desktop/src/features/workspace/hooks/useSessionSidebarVisibility/index.ts
@@ -1,0 +1,57 @@
+import { useCallback, useMemo, useState } from 'react';
+import { STORAGE_KEYS } from '../../../../shared/lib/storage-keys';
+
+type Params = {
+  readonly hasActiveSession: boolean;
+};
+
+const readPreference = (): boolean => {
+  if (typeof localStorage === 'undefined') {
+    return false;
+  }
+  try {
+    return localStorage.getItem(STORAGE_KEYS.sessionSidebarCollapsed) === '1';
+  } catch {
+    return false;
+  }
+};
+
+type WriteParams = {
+  readonly next: boolean;
+};
+
+const writePreference = ({ next }: WriteParams): void => {
+  if (typeof localStorage === 'undefined') {
+    return;
+  }
+  try {
+    localStorage.setItem(STORAGE_KEYS.sessionSidebarCollapsed, next ? '1' : '0');
+  } catch {
+    return;
+  }
+};
+
+export const useSessionSidebarVisibility = ({ hasActiveSession }: Params) => {
+  const [isCollapsed, setIsCollapsed] = useState(readPreference);
+  const leftHidden = useMemo(
+    () => !hasActiveSession || isCollapsed,
+    [hasActiveSession, isCollapsed],
+  );
+
+  const toggle = useCallback(() => {
+    if (!hasActiveSession) {
+      return;
+    }
+    setIsCollapsed((current) => {
+      const next = !current;
+      writePreference({ next });
+      return next;
+    });
+  }, [hasActiveSession]);
+
+  return {
+    isCollapsed,
+    leftHidden,
+    toggle,
+  };
+};

--- a/apps/desktop/src/shared/lib/storage-keys.ts
+++ b/apps/desktop/src/shared/lib/storage-keys.ts
@@ -4,6 +4,7 @@ export const STORAGE_KEYS = {
   theme: `${PREFIX}theme`,
   pricingSortKey: `${PREFIX}pricing-sort-key`,
   diffSidebarCollapsed: `${PREFIX}diff-sidebar-collapsed`,
+  sessionSidebarCollapsed: `${PREFIX}sessions-sidebar-collapsed`,
   lensColumnWidth: `${PREFIX}lens-column-width`,
   inspectorPanelWidth: `${PREFIX}inspector-panel-width`,
   studioDetailRailWidth: `${PREFIX}studio-detail-rail-width`,

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -143,13 +143,14 @@ animates to zero width via `grid-template-columns` transition; the cell fades
 and slides (`opacity` + `transform`). The resize handle is suppressed while
 hidden.
 
-`App.tsx` sets `leftHidden={!currentSession}`:
+`App.tsx` keeps Overview board-only and applies the user preference in session:
 
 - Overview (no session active): board-only, sidebar hidden.
-- Session entered: sidebar reveals with a ~200ms animation.
+- Session entered: sidebar follows the persisted sessions-column preference.
 
-The sidebar has no collapse toggle, rail, or `cmd+b` shortcut. The left column
-is either `leftHidden` (at Overview) or at its persisted width.
+The sidebar has no collapse rail. In a session, users can hide or show the
+sessions column from the workspace header or with `cmd+b`. The toggle writes a
+persisted preference, while Overview still forces `leftHidden`.
 
 ## Studios
 


### PR DESCRIPTION
Stacked on #1133.

## What

The sessions column can be hidden and shown again. The toggle lives in the workspace header, the
choice persists, and `cmd+b` does the same thing.

## Why this is a reversal, stated plainly

This was not lost, it was removed on purpose in `689ac06a`, whose message says it "removes the
sessions sidebar collapse rail, toggle and cmd+b binding, which contradicted both DESIGN.md and
docs/navigation.md". Both documents still said so.

So both documents are amended in this commit. Leaving `DESIGN.md` and `docs/navigation.md` asserting
that the sidebar has no toggle while the app ships one is exactly the drift that made the original
removal necessary.

What does **not** come back is the collapse rail. That was the part that was wrong: a permanent strip
of chrome whose only job was to undo itself. The control goes where the user is already looking.

`cmd+b` was free (`cmd+shift+b` is the agents lens) and is what VS Code, Cursor and every editor the
user has open bind to toggling the side column, so it costs them nothing to learn. It is registered in
the shortcuts help.

Overview stays board-only: `leftHidden` still wins with no session open, and the preference applies
only inside a session.

## Verified

`pnpm -w typecheck`, the desktop suite (3644 tests) and the ui suite green.