### PR TITLE
refactor(desktop): keep workspace settings to settings

### DIFF
--- a/apps/desktop/src/features/settings/components/SettingsStudio/WorkspaceScopePanel.test.tsx
+++ b/apps/desktop/src/features/settings/components/SettingsStudio/WorkspaceScopePanel.test.tsx
@@ -28,10 +28,6 @@ vi.mock('../../../../features/skills/components/SkillsPanel', () => ({
   SkillsPanel: () => null,
 }));
 
-vi.mock('../../../../features/scripts', () => ({
-  ScriptsPanel: () => null,
-}));
-
 vi.mock('../../../../features/session/components/VerbositySelect', () => ({
   VerbositySelect: () => null,
 }));

--- a/apps/desktop/src/features/settings/components/SettingsStudio/WorkspaceScopePanel.tsx
+++ b/apps/desktop/src/features/settings/components/SettingsStudio/WorkspaceScopePanel.tsx
@@ -3,7 +3,6 @@ import type { VerbosityLevel, WorkspaceId } from '@goodboy/types';
 import { Button, Divider, FieldRow, ScrollFade, SectionHeader, Switch, cn } from '@goodboy/ui';
 import { Check, GitBranch, Unplug } from 'lucide-react';
 import { SkillsPanel } from '../../../../features/skills/components/SkillsPanel';
-import { ScriptsPanel } from '../../../../features/scripts';
 import { VerbositySelect } from '../../../../features/session/components/VerbositySelect';
 import { formatError } from '../../../../shared/lib/errors';
 import { DEFAULT_BRANCH_PREFIX, settingBranchPrefix } from '../../../../features/settings/settings';
@@ -204,12 +203,6 @@ export const WorkspaceScopePanel = ({ workspaceId, initialSection, requestClose 
               </div>
             </>
           ) : null}
-
-          <Divider />
-
-          <div ref={anchor('scripts')}>
-            <ScriptsPanel workspaceId={workspaceId} />
-          </div>
 
           <Divider />
 


### PR DESCRIPTION
Stacked on #1134.

## What

`ScriptsPanel` is unmounted from the workspace scope panel, along with the divider it would have
orphaned, and the now-dead test mock is gone with it.

## Why

Every other row in that panel is a choice: a branch prefix, an output verbosity, a toggle, a
disconnect. The scripts row was a content editor, a list to add to, rename and delete, sitting in the
middle of them.

It also declared its own redundancy: the panel's hint reads "Scripts are shared across every session
of this workspace", inside a panel whose whole job is workspace scope. The database agrees, for what
it is worth: `m036-workspace-scripts` has no session column and `workspace-script.ts` selects by
workspace id alone. Scripts are workspace-scoped by construction, so saying it there says nothing.

## Verified

Scripts remain reachable and unchanged at the session Scripts lens, still on `⌘⇧S`. `pnpm -w typecheck`
and the desktop suite green (3644 tests).

## Not touched, and why

- **The scripts feature and its store slice stay.** This removes a mount point, nothing else.
- **Branch prefix, output verbosity, parallel scouts and disconnect stay where they are.** They are
  choices, which is what that panel is for.