### PR TITLE
fix(desktop): a confirm no longer bursts the rail it sits in

### DIFF
--- a/apps/desktop/src/features/session/components/ProjectSwitcher/index.test.tsx
+++ b/apps/desktop/src/features/session/components/ProjectSwitcher/index.test.tsx
@@ -64,4 +64,16 @@ describe('ProjectSwitcher', () => {
 
     expect(screen.queryByRole('tablist', { name: 'Active project' })).toBeNull();
   });
+
+  it('uses a compact trigger that keeps the active project name while choosing from a menu', () => {
+    render(<ProjectSwitcher sessionId={'session-1' as never} density="compact" />);
+
+    expect(screen.queryByRole('tablist', { name: 'Active project' })).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'Active project' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: 'api' }));
+    expect(store.setSessionActiveMount).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      workspaceId: 'workspace-api',
+    });
+  });
 });

--- a/apps/desktop/src/features/session/components/ProjectSwitcher/index.tsx
+++ b/apps/desktop/src/features/session/components/ProjectSwitcher/index.tsx
@@ -1,14 +1,20 @@
+import { FolderTree } from 'lucide-react';
 import { SegmentedTabs, type SegmentedTabOption } from '@goodboy/ui';
 import type { SessionId, SessionMount, WorkspaceId } from '@goodboy/types';
 import { useAppStore } from '../../../../store';
+import { OverflowMenu, type OverflowMenuItem } from '../../../../shared/components/OverflowMenu';
+import type { Density } from '../../density';
 
 const EMPTY_MOUNTS: ReadonlyArray<SessionMount> = [];
+const COMPACT_TRIGGER_BUTTON =
+  'inline-flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground motion-safe:transition-colors hover:bg-muted/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]';
 
 type Props = {
   readonly sessionId: SessionId;
+  readonly density?: Density;
 };
 
-export const ProjectSwitcher = ({ sessionId }: Props) => {
+export const ProjectSwitcher = ({ sessionId, density = 'full' }: Props) => {
   const mounts = useAppStore((state) => state.sessionMounts[sessionId] ?? EMPTY_MOUNTS);
   const activeWorkspaceId = useAppStore((state) => state.sessionActiveMount[sessionId] ?? null);
   const setSessionActiveMount = useAppStore((state) => state.setSessionActiveMount);
@@ -25,6 +31,33 @@ export const ProjectSwitcher = ({ sessionId }: Props) => {
     value: mount.workspaceId,
     label: mount.mountName,
   }));
+
+  if (density === 'compact') {
+    const items: ReadonlyArray<OverflowMenuItem> = mounts.map((mount) => ({
+      kind: 'item',
+      key: mount.workspaceId,
+      label: mount.mountName,
+      onClick: () => void setSessionActiveMount({ sessionId, workspaceId: mount.workspaceId }),
+      disabled: mount.workspaceId === activeMount.workspaceId,
+    }));
+    return (
+      <OverflowMenu
+        items={items}
+        label="Active project"
+        align="left"
+        side="top"
+        triggerClassName={COMPACT_TRIGGER_BUTTON}
+        trigger={
+          <>
+            <FolderTree size={13} aria-hidden />
+            <span className="density-trigger-label" data-density={density}>
+              {activeMount.mountName}
+            </span>
+          </>
+        }
+      />
+    );
+  }
 
   return (
     <SegmentedTabs

--- a/apps/desktop/src/features/session/components/ResolverActions/index.tsx
+++ b/apps/desktop/src/features/session/components/ResolverActions/index.tsx
@@ -15,6 +15,7 @@ import type { Agent, SessionId } from '@goodboy/types';
 import { useAppStore } from '../../../../store';
 import type { ResolverThreadOutcome } from '../../../../store/types';
 import { PROCEED_RESOLVER_PROMPT } from '../../../../shared/utils/proceedResolverPrompt';
+import type { Density } from '../../density';
 import { agentThreadIds } from '../../agentThreadIds';
 import type { ResolverStatus } from '../../resolver-linkage';
 import { resolverCommitSha } from '../../resolverCommitSha';
@@ -25,8 +26,6 @@ import {
   type ResolverActionRole,
 } from '../../resolverActions';
 import { INSPECTOR_ACTION_CLASS } from '../InspectorSection';
-
-type Density = 'compact' | 'full';
 
 type Props = {
   readonly agent: Agent;

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/EditorMenu.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/EditorMenu.test.tsx
@@ -62,6 +62,12 @@ describe('EditorMenu', () => {
     expect(trigger.getAttribute('data-side')).toBe('top');
   });
 
+  it('keeps the open-worktree accessible name in compact density', () => {
+    render(<EditorMenu sessionId={'sess-1' as SessionId} density="compact" />);
+    const trigger = screen.getByRole('button', { name: /open worktree/i });
+    expect(trigger.getAttribute('aria-label')).toBe('open worktree');
+  });
+
   it('loads detected editors once when none are known yet', () => {
     render(<EditorMenu sessionId={'sess-1' as SessionId} />);
     expect(state.loadDetectedEditors).toHaveBeenCalledOnce();

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/EditorMenu.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/EditorMenu.tsx
@@ -6,17 +6,22 @@ import { openInEditor } from '../../../../shared/lib/editor';
 import { OverflowMenu, type OverflowMenuItem } from '../../../../shared/components/OverflowMenu';
 import { formatError } from '../../../../shared/lib/errors';
 import { useToast } from '../../../../app/components/Toast';
+import type { Density } from '../../density';
 
 const REFERENCE_EDITORS = new Set(['code', 'cursor']);
 
-const TRIGGER_BUTTON =
+const FULL_TRIGGER_BUTTON =
   'inline-flex h-6 shrink-0 items-center gap-1.5 rounded-md px-2 text-xs text-muted-foreground motion-safe:transition-colors hover:bg-muted/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]';
+
+const COMPACT_TRIGGER_BUTTON =
+  'inline-flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground motion-safe:transition-colors hover:bg-muted/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]';
 
 type Props = {
   readonly sessionId: SessionId;
+  readonly density?: Density;
 };
 
-export const EditorMenu = ({ sessionId }: Props) => {
+export const EditorMenu = ({ sessionId, density = 'full' }: Props) => {
   const worktreePath = useAppStore((s) => s.sessionWorktrees[sessionId]?.[0] ?? null);
   const detectedEditors = useAppStore((s) => s.detectedEditors);
   const loadDetectedEditors = useAppStore((s) => s.loadDetectedEditors);
@@ -93,17 +98,21 @@ export const EditorMenu = ({ sessionId }: Props) => {
     ];
   }, [detectedEditors, worktreePath]);
 
+  const triggerClassName = density === 'compact' ? COMPACT_TRIGGER_BUTTON : FULL_TRIGGER_BUTTON;
+
   return (
     <OverflowMenu
       items={items}
       label="open worktree"
       align="left"
       side="top"
-      triggerClassName={TRIGGER_BUTTON}
+      triggerClassName={triggerClassName}
       trigger={
         <>
           <FolderOpen size={13} aria-hidden />
-          <span>Open</span>
+          <span className="density-trigger-label" data-density={density}>
+            Open
+          </span>
         </>
       }
     />

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumnFooter.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumnFooter.test.tsx
@@ -25,11 +25,27 @@ vi.mock('../../../../../app/components/Toast', () => ({
 }));
 
 vi.mock('../../SessionOverviewPane/EditorMenu', () => ({
-  EditorMenu: () => <button type="button">open worktree</button>,
+  EditorMenu: ({ density = 'full' }: { readonly density?: 'compact' | 'full' }) => (
+    <button type="button" aria-label="open worktree">
+      {density === 'full' ? 'Open' : null}
+    </button>
+  ),
 }));
 
 vi.mock('./SessionGitActions', () => ({
-  SessionGitActions: () => <button type="button">branch actions</button>,
+  SessionGitActions: ({ density = 'full' }: { readonly density?: 'compact' | 'full' }) => (
+    <button type="button" aria-label="branch actions">
+      {density === 'full' ? 'Branch' : null}
+    </button>
+  ),
+}));
+
+vi.mock('../../ProjectSwitcher', () => ({
+  ProjectSwitcher: ({ density = 'full' }: { readonly density?: 'compact' | 'full' }) => (
+    <button type="button" aria-label="Active project">
+      {density === 'full' ? 'Project' : null}
+    </button>
+  ),
 }));
 
 import { LensColumnFooter } from './LensColumnFooter';
@@ -48,10 +64,12 @@ afterEach(cleanup);
 describe('LensColumnFooter', () => {
   it('orders the editor, archive, and delete controls across the footer', () => {
     render(<LensColumnFooter session={session()} />);
+    const project = screen.getByRole('button', { name: /active project/i });
     const editor = screen.getByRole('button', { name: /open worktree/i });
     const archive = screen.getByRole('button', { name: /archive session/i });
     const remove = screen.getByRole('button', { name: /delete session/i });
 
+    expect(project.compareDocumentPosition(editor) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0);
     expect(editor.compareDocumentPosition(archive) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0);
     expect(archive.compareDocumentPosition(remove) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0);
   });
@@ -78,6 +96,36 @@ describe('LensColumnFooter', () => {
     fireEvent.click(screen.getByRole('button', { name: /^cancel$/i }));
     expect(state.deleteTask).not.toHaveBeenCalled();
     expect(screen.getByRole('button', { name: /delete session/i })).toBeDefined();
+  });
+
+  it('hides neighboring control labels while delete confirm is armed and keeps names', () => {
+    render(<LensColumnFooter session={session()} />);
+    expect(screen.getByText('Project')).toBeDefined();
+    expect(screen.getByText('Open')).toBeDefined();
+    expect(screen.getByText('Branch')).toBeDefined();
+
+    fireEvent.click(screen.getByRole('button', { name: /delete session/i }));
+
+    expect(screen.getByRole('button', { name: /active project/i })).toBeDefined();
+    expect(screen.getByRole('button', { name: /open worktree/i })).toBeDefined();
+    expect(screen.getByRole('button', { name: /branch actions/i })).toBeDefined();
+    expect(screen.queryByText('Project')).toBeNull();
+    expect(screen.queryByText('Open')).toBeNull();
+    expect(screen.queryByText('Branch')).toBeNull();
+  });
+
+  it('restores neighboring control labels after disarming delete confirm', () => {
+    render(<LensColumnFooter session={session()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /delete session/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^cancel$/i }));
+
+    expect(screen.getByRole('button', { name: /active project/i })).toBeDefined();
+    expect(screen.getByRole('button', { name: /open worktree/i })).toBeDefined();
+    expect(screen.getByRole('button', { name: /branch actions/i })).toBeDefined();
+    expect(screen.getByText('Project')).toBeDefined();
+    expect(screen.getByText('Open')).toBeDefined();
+    expect(screen.getByText('Branch')).toBeDefined();
   });
 
   it('shows an unarchive control for an archived session instead of the archive control', () => {

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumnFooter.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumnFooter.tsx
@@ -8,6 +8,7 @@ import { useToast } from '../../../../../app/components/Toast';
 import { EditorMenu } from '../../SessionOverviewPane/EditorMenu';
 import { SessionGitActions } from './SessionGitActions';
 import { ProjectSwitcher } from '../../ProjectSwitcher';
+import type { Density } from '../../../density';
 
 const ICON_BUTTON =
   'inline-flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground motion-safe:transition-colors hover:bg-muted/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]';
@@ -28,6 +29,7 @@ export const LensColumnFooter = ({ session }: Props) => {
 
   const [armed, setArmed] = useState<Armed>(null);
   const [busy, setBusy] = useState(false);
+  const density: Density = armed === null ? 'full' : 'compact';
 
   useEffect(() => {
     if (armed == null) {
@@ -71,9 +73,9 @@ export const LensColumnFooter = ({ session }: Props) => {
 
   return (
     <div className="flex shrink-0 items-center gap-2 px-2 py-2">
-      <ProjectSwitcher sessionId={sessionId} />
-      <EditorMenu sessionId={sessionId} />
-      <SessionGitActions session={session} />
+      <ProjectSwitcher sessionId={sessionId} density={density} />
+      <EditorMenu sessionId={sessionId} density={density} />
+      <SessionGitActions session={session} density={density} />
       <span className="flex-1" />
       <div className="flex items-center gap-1">
         {archived ? (

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/SessionGitActions.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/SessionGitActions.tsx
@@ -8,17 +8,22 @@ import { worktreeStatus } from '../../../../worktree/worktree';
 import { resolveSessionRepo } from '../../../../../store/slices/worktrees/resolveSessionRepo';
 import { useRebaseAgent } from '../../../hooks/useRebaseAgent';
 import { usePushBranch } from '../../../hooks/usePushBranch';
+import type { Density } from '../../../density';
 
 type Props = {
   readonly session: Session;
+  readonly density?: Density;
 };
 
 const STATUS_REFRESH_INTERVAL_MS = 10_000;
 
-const TRIGGER_BUTTON =
+const FULL_TRIGGER_BUTTON =
   'inline-flex h-6 shrink-0 items-center gap-1.5 rounded-md px-2 text-xs text-muted-foreground motion-safe:transition-colors hover:bg-muted/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]';
 
-export const SessionGitActions = ({ session }: Props) => {
+const COMPACT_TRIGGER_BUTTON =
+  'inline-flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground motion-safe:transition-colors hover:bg-muted/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]';
+
+export const SessionGitActions = ({ session, density = 'full' }: Props) => {
   const sessionId = session.id as SessionId;
   const repo = useAppStore(useShallow((state) => resolveSessionRepo({ state, sessionId })));
   const worktreePath = repo?.worktreePath ?? null;
@@ -74,6 +79,8 @@ export const SessionGitActions = ({ session }: Props) => {
   }
 
   const canPush = status != null && status.ahead > 0;
+  const triggerClassName = density === 'compact' ? COMPACT_TRIGGER_BUTTON : FULL_TRIGGER_BUTTON;
+  const triggerLabel = mountName == null ? 'Branch' : `${mountName} branch`;
   const items: ReadonlyArray<OverflowMenuItem> = [
     {
       kind: 'item',
@@ -103,11 +110,13 @@ export const SessionGitActions = ({ session }: Props) => {
       label="branch actions"
       align="left"
       side="top"
-      triggerClassName={TRIGGER_BUTTON}
+      triggerClassName={triggerClassName}
       trigger={
         <>
           <GitBranch size={13} aria-hidden />
-          <span>{mountName == null ? 'Branch' : `${mountName} branch`}</span>
+          <span className="density-trigger-label" data-density={density}>
+            {triggerLabel}
+          </span>
         </>
       }
     />

--- a/apps/desktop/src/features/session/density.ts
+++ b/apps/desktop/src/features/session/density.ts
@@ -1,0 +1,1 @@
+export type Density = 'compact' | 'full';

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -449,6 +449,27 @@ dialog[open]::backdrop {
   animation: border-pulse 2.8s ease-in-out infinite;
 }
 
+.density-trigger-label {
+  display: inline-block;
+  max-width: 10rem;
+  overflow: hidden;
+  white-space: nowrap;
+  opacity: 1;
+}
+
+.density-trigger-label[data-density='compact'] {
+  max-width: 0;
+  opacity: 0;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .density-trigger-label {
+    transition:
+      max-width 160ms cubic-bezier(0.2, 0, 0, 1),
+      opacity 120ms cubic-bezier(0.2, 0, 0, 1);
+  }
+}
+
 /* Slot-machine cost chip, outer success-tinted halo + a brief inner lift that
    sells the "the meter just ticked" moment. Paired in JS with a per-digit roll
    so the glow peaks while the numbers are still settling, then fades as they


### PR DESCRIPTION
Stacked on #1136.

## What

Arming archive or delete in the lens column footer overflowed the row. The footer is
`flex items-center gap-2` in a rail that starts at 240px, and every child is `shrink-0`: the project
switcher, the editor menu that renders the word "Open", the git actions that render the word "Branch",
and `ConfirmPill` itself. Nothing could yield, so the pill pushed the row past its bounds.

While a confirm is armed, the controls that render a word drop to their glyph and give the pill the
space. They keep their `aria-label`, so the row narrowing is invisible to a screen reader.

## One implementation of the concept

`ResolverActions` already had `type Density = 'compact' | 'full'`, local to one file. It is shared now
and both use it, rather than a second enum growing beside the first.

The width transition is a utility in `styles.css` next to the other animations, not an inline style,
and it is behind a reduced-motion guard.

## Verified

`pnpm -w typecheck` and the desktop suite green (3649 tests). New coverage: the row's controls lose
their text while a confirm is armed and keep their accessible names, and get them back on disarm.

happy-dom does not lay out or measure, so no test here claims the row fits. The assertions are about
what is rendered.

## Not touched, and why

- **The confirm keeps its hit area.** Solving an overflow by shrinking a destructive button below a
  deliberate target is not solving it.
- **The three `w-72` absolute overlays stay.** They are the answer already shipped for a confirm that
  leaves the flow; this footer's confirm belongs in its row.