### PR TITLE
fix(ui): bring the two failing token pairs above threshold

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ AI workspace orchestrator. Manage macro sessions, route agents across providers,
 - **State**: Zustand
 - **Persistence**: SQLite (via Tauri)
 - **Styling**: Tailwind CSS + Shadcn/ui
-- **Theme**: Light mode (default)
+- **Theme**: Dark mode (default)
 
 ## Claude-specific notes
 

--- a/apps/desktop/src/features/chat/components/ChatInput/index.tsx
+++ b/apps/desktop/src/features/chat/components/ChatInput/index.tsx
@@ -434,7 +434,7 @@ export const ChatInput = ({ session, providerDisconnected = false }: Props) => {
                 disabled={!canSend}
                 title={sendDisabledTitle ?? (isRunning ? 'queue message (enter)' : 'send (enter)')}
                 aria-label={isRunning ? 'queue message' : 'send message'}
-                className="absolute bottom-2.5 right-2.5 inline-flex h-8 w-8 items-center justify-center rounded-lg bg-primary text-primary-foreground shadow-sm transition-all hover:brightness-110 disabled:cursor-not-allowed disabled:bg-muted disabled:text-muted-foreground/40 disabled:shadow-none"
+                className="absolute bottom-2.5 right-2.5 inline-flex h-8 w-8 items-center justify-center rounded-lg bg-primary text-primary-foreground shadow-sm transition-all hover:brightness-110 disabled:cursor-not-allowed disabled:bg-muted disabled:text-muted-foreground disabled:shadow-none"
               >
                 <Send size={14} aria-hidden className="-translate-x-px" />
               </button>

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/steps/PreferencesStep.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/steps/PreferencesStep.tsx
@@ -173,7 +173,7 @@ const PreferencesForm = ({ workspaceId, isSimple }: FormProps) => {
                   busy && 'cursor-not-allowed opacity-50',
                 )}
               />
-              <span className="font-mono text-sm text-muted-foreground/40">/&lt;slug&gt;</span>
+              <span className="font-mono text-sm text-muted-foreground">/&lt;slug&gt;</span>
             </div>
           </FieldRow>
         ) : null}

--- a/apps/desktop/src/features/session/components/AgentMetrics/index.tsx
+++ b/apps/desktop/src/features/session/components/AgentMetrics/index.tsx
@@ -117,7 +117,7 @@ export const AgentMetrics = ({
             className="inline-flex items-baseline gap-0.5 tabular-nums"
             title={`in: ${inputTokens.toLocaleString()} tokens (cumulative)`}
           >
-            <span aria-hidden className="text-muted-foreground/40">
+            <span aria-hidden className="text-muted-foreground/70">
               ↓
             </span>
             {formatTokens(inputTokens)}
@@ -126,7 +126,7 @@ export const AgentMetrics = ({
             className="inline-flex items-baseline gap-0.5 tabular-nums"
             title={`out: ${outputTokens.toLocaleString()} tokens (cumulative)`}
           >
-            <span aria-hidden className="text-muted-foreground/40">
+            <span aria-hidden className="text-muted-foreground/70">
               ↑
             </span>
             {formatTokens(outputTokens)}

--- a/apps/desktop/src/features/session/components/NewSessionView/NewSessionForm.tsx
+++ b/apps/desktop/src/features/session/components/NewSessionView/NewSessionForm.tsx
@@ -214,7 +214,7 @@ export const NewSessionForm = ({
               className={cn(
                 'inline-flex w-fit items-center gap-1.5 rounded-md border border-border px-2.5 py-1 text-xs motion-safe:transition-colors',
                 busy
-                  ? 'cursor-not-allowed text-muted-foreground/40'
+                  ? 'cursor-not-allowed text-muted-foreground'
                   : 'text-muted-foreground hover:bg-muted hover:text-foreground',
               )}
             >

--- a/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
@@ -882,7 +882,7 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
                         className={cn(
                           'inline-flex shrink-0 items-center gap-1.5 rounded-md border border-border px-2.5 py-1 text-xs transition-colors',
                           blocked
-                            ? 'cursor-not-allowed text-muted-foreground/40'
+                            ? 'cursor-not-allowed text-muted-foreground'
                             : 'text-muted-foreground hover:bg-muted hover:text-foreground',
                         )}
                       >
@@ -1021,7 +1021,7 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
                                         <AgentAvatar key={`${k}-${i}`} kind={k} size="xs" />
                                       ))}
                                       {kinds.length > shown.length ? (
-                                        <span className="text-[10px] text-muted-foreground/40">
+                                        <span className="text-[10px] text-muted-foreground">
                                           +{kinds.length - shown.length}
                                         </span>
                                       ) : null}

--- a/apps/desktop/src/features/session/components/WorkflowBuilderView/parts/StepperRail.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowBuilderView/parts/StepperRail.tsx
@@ -44,7 +44,7 @@ export const StepperRail = ({ current, canReach, disabled, onJump }: Props) => (
               active && 'bg-primary/10 text-primary ring-1 ring-primary/20',
               done && !active && 'text-foreground hover:bg-muted/50',
               !active && !done && reachable && 'text-muted-foreground hover:bg-muted/40',
-              !active && !done && !reachable && 'cursor-not-allowed text-muted-foreground/40',
+              !active && !done && !reachable && 'cursor-not-allowed text-muted-foreground',
             )}
           >
             <span

--- a/apps/desktop/src/features/session/components/WorkflowStepCard/index.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowStepCard/index.tsx
@@ -142,7 +142,7 @@ export const WorkflowStepCard = ({
 
   const headerRow = (trailing?: ReactNode) => (
     <span className="flex min-w-0 items-center gap-2.5">
-      <span className="w-4 shrink-0 text-right font-mono text-2xs tabular-nums text-muted-foreground/40">
+      <span className="w-4 shrink-0 text-right font-mono text-2xs tabular-nums text-muted-foreground">
         {String(ordinal + 1).padStart(2, '0')}
       </span>
       <AgentAvatar kind={kind} size="sm" />
@@ -206,7 +206,7 @@ export const WorkflowStepCard = ({
             <span
               className={cn(
                 'line-clamp-1 pl-[1.625rem] text-[11px] leading-relaxed',
-                promptPrefix.trim() ? 'text-muted-foreground' : 'italic text-muted-foreground/40',
+                promptPrefix.trim() ? 'text-muted-foreground' : 'italic text-muted-foreground',
               )}
             >
               {promptPrefix.trim() || 'Click to add instructions'}

--- a/apps/desktop/src/features/settings/components/SettingsStudio/WorkspaceScopePanel.tsx
+++ b/apps/desktop/src/features/settings/components/SettingsStudio/WorkspaceScopePanel.tsx
@@ -156,7 +156,7 @@ export const WorkspaceScopePanel = ({ workspaceId, initialSection, requestClose 
                       busy && 'cursor-not-allowed opacity-50',
                     )}
                   />
-                  <span className="font-mono text-sm text-muted-foreground/40">/&lt;slug&gt;</span>
+                  <span className="font-mono text-sm text-muted-foreground">/&lt;slug&gt;</span>
                 </div>
               </FieldRow>
 

--- a/apps/desktop/src/features/workflows/components/LibraryCard/index.tsx
+++ b/apps/desktop/src/features/workflows/components/LibraryCard/index.tsx
@@ -52,7 +52,7 @@ export const LibraryCard = ({ def, dragDisabled, onStartDrag, onEdit, onDelete }
 
       <div className="absolute right-1.5 top-1.5 flex items-center gap-1">
         {isGlobal ? (
-          <span className="px-1 text-2xs uppercase tracking-eyebrow text-muted-foreground/40 group-focus-within:hidden group-hover:hidden">
+          <span className="px-1 text-2xs uppercase tracking-eyebrow text-muted-foreground group-focus-within:hidden group-hover:hidden">
             global
           </span>
         ) : null}

--- a/apps/desktop/src/features/workspace/components/SessionActivityBar/index.tsx
+++ b/apps/desktop/src/features/workspace/components/SessionActivityBar/index.tsx
@@ -212,7 +212,7 @@ export const SessionActivityBar = ({
                     >
                       {groupLabel(group.key, prefs.group)}
                     </span>
-                    <span aria-hidden className="text-2xs text-muted-foreground/40 tabular-nums">
+                    <span aria-hidden className="text-2xs text-muted-foreground tabular-nums">
                       {group.sessions.length}
                     </span>
                     <span aria-hidden className="ml-1 h-px flex-1 bg-border-soft" />

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowStepRow.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowStepRow.tsx
@@ -192,7 +192,7 @@ export const WorkflowStepRow = ({
             aria-hidden
             className={cn(
               'w-4 shrink-0 text-right text-2xs tabular-nums',
-              isPendingFuture ? 'text-muted-foreground/40' : 'text-muted-foreground/60',
+              isPendingFuture ? 'text-muted-foreground' : 'text-muted-foreground/60',
             )}
           >
             {index + 1}.

--- a/apps/desktop/src/shared/components/OverflowMenu/index.tsx
+++ b/apps/desktop/src/shared/components/OverflowMenu/index.tsx
@@ -136,7 +136,7 @@ export const OverflowMenu = ({
                 className={cn(
                   'flex w-full items-center gap-2 px-2.5 py-1.5 text-left transition-colors',
                   item.disabled
-                    ? 'cursor-not-allowed text-muted-foreground/40'
+                    ? 'cursor-not-allowed text-muted-foreground'
                     : item.destructive
                       ? 'text-danger/90 hover:bg-danger/10 hover:text-danger'
                       : 'text-foreground/80 hover:bg-muted hover:text-foreground',

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -15,7 +15,7 @@
   --color-muted: oklch(0.33 0.01 255);
   --color-elevated: oklch(0.37 0.011 255);
   --color-muted-foreground: oklch(0.78 0.015 255);
-  --color-border: oklch(0.4 0.012 255);
+  --color-border: oklch(0.55 0.012 255);
   --color-border-soft: oklch(0.32 0.01 255);
 
   /* Brand accent, teal/cyan. */
@@ -24,7 +24,7 @@
 
   /* Semantic tokens, slightly softer chroma for dark mode. */
   --color-danger: oklch(0.63 0.17 22);
-  --color-danger-foreground: oklch(0.95 0.01 22);
+  --color-danger-foreground: oklch(0.15 0 0);
   --color-warning: oklch(0.76 0.13 78);
   --color-warning-foreground: oklch(0.15 0 0);
   --color-success: oklch(0.69 0.13 148);
@@ -252,7 +252,7 @@ html[data-theme='light'] {
   --color-muted: oklch(0.962 0.004 250);
   --color-elevated: oklch(0.985 0.003 250);
   --color-muted-foreground: oklch(0.44 0.006 250);
-  --color-border: oklch(0.82 0.006 250);
+  --color-border: oklch(0.6 0.006 250);
   --color-border-soft: oklch(0.87 0.005 250);
   --color-primary: oklch(0.5 0.13 200);
   --color-primary-foreground: oklch(0.99 0.003 200);


### PR DESCRIPTION
Stacked on #1137.

## Ratios, computed both before and after (oklch to sRGB to relative luminance, WCAG 2.x)

| pair | theme | before | after | threshold |
|---|---|---|---|---|
| `danger-foreground` on `danger` | dark | **3.27** | **5.18** | 4.5 |
| `danger-foreground` on `danger` | light | 6.45 | 6.45 | 4.5 |
| `border` on `background` | dark | **1.74** | **3.30** | 3.0 |
| `border` on `background` | light | **1.36** | **3.07** | 3.0 |

Everything else already passed and did not move: light danger 6.45, warning 4.77, success 6.46, info
6.02, primary 5.14; dark foreground/background 12.24, muted-foreground/background 8.00,
muted-foreground/elevated 5.21.

## Why the foreground moved and not the tone

`danger` is also the colour of error copy, where it scores 4.21 on the background. Taking it to 0.55
lightness would have bought 4.56 on the button and cost 3.02 on the text: fixing the rarer case by
breaking the more common one. In the dark theme `warning-foreground`, `success-foreground`,
`info-foreground`, `accent-foreground` and `merged-foreground` are all dark, and `danger-foreground`
was the only light one. It now matches its siblings.

## Why `border-soft` did not move

The system already has two border tokens, and 184 call sites choose the quiet one deliberately. This
change makes `border` the token that can be relied on to identify a control (3.30 dark, 3.07 light)
and leaves `border-soft` as the decorative tone it already was (1.26 dark, 1.15 light). A component
that wants a quiet edge already has the token for it.

## `text-muted-foreground/40`

2.45 dark, 1.83 light. Declared decorative rather than raised: it may dress a separator glyph, a
chevron or an input placeholder, and nothing that carries information. The call sites where it was
carrying information were moved up.

## Also

`CLAUDE.md` claimed the default theme is light. The default that ships is dark; light is opt-in and
persisted.

## Verified

`pnpm -w typecheck`, desktop suite (3649 tests) and ui suite green. Ratios recomputed independently
after the edit.

## Not touched, and why

- **No component was restyled to work around a token.** The tokens were wrong; the tokens moved.
- **No parallel palette.** Same tokens, same names, same chroma and hue.