### PR TITLE
feat(desktop): let the user name the session folder

### DIFF
--- a/apps/desktop/src-tauri/src/session_dir.rs
+++ b/apps/desktop/src-tauri/src/session_dir.rs
@@ -11,6 +11,10 @@ pub enum SessionDirError {
     EmptyPath,
     #[error("refusing to remove a path outside the workspace")]
     OutsideWorkspace,
+    #[error("session directory already belongs to another session")]
+    SessionDirectoryConflict,
+    #[error("invalid session directory name")]
+    InvalidDirectoryName,
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
     #[error("json error: {0}")]
@@ -25,6 +29,8 @@ impl SessionDirError {
             SessionDirError::HomeUnavailable => "home_unavailable",
             SessionDirError::EmptyPath => "empty_path",
             SessionDirError::OutsideWorkspace => "outside_workspace",
+            SessionDirError::SessionDirectoryConflict => "session_directory_conflict",
+            SessionDirError::InvalidDirectoryName => "invalid_directory_name",
             SessionDirError::Io(_) => "io",
             SessionDirError::Json(_) => "json",
         }
@@ -36,6 +42,8 @@ pub struct CreateArgs {
     #[serde(rename = "basePath")]
     pub base_path: String,
     pub slug: String,
+    #[serde(rename = "directoryName")]
+    pub directory_name: Option<String>,
     #[serde(rename = "sessionId")]
     pub session_id: String,
     #[serde(rename = "workspaceId")]
@@ -121,6 +129,50 @@ fn marker_write(
     Ok(())
 }
 
+fn marker_read(path: &Path) -> Result<SessionMarker, SessionDirError> {
+    let marker = std::fs::read(path.join(".goodboy"))?;
+    Ok(serde_json::from_slice::<SessionMarker>(&marker)?)
+}
+
+fn validate_directory_name(name: &str) -> Result<(), SessionDirError> {
+    if name.is_empty() {
+        return Err(SessionDirError::InvalidDirectoryName);
+    }
+    if name.chars().count() > 60 {
+        return Err(SessionDirError::InvalidDirectoryName);
+    }
+    if name.contains('/') || name.contains('\\') {
+        return Err(SessionDirError::InvalidDirectoryName);
+    }
+    if name.contains("..") {
+        return Err(SessionDirError::InvalidDirectoryName);
+    }
+    if name.starts_with('.') {
+        return Err(SessionDirError::InvalidDirectoryName);
+    }
+    if name.ends_with('.') || name.ends_with(' ') {
+        return Err(SessionDirError::InvalidDirectoryName);
+    }
+    if name.chars().any(|ch| ch.is_control()) {
+        return Err(SessionDirError::InvalidDirectoryName);
+    }
+    if name
+        .chars()
+        .any(|ch| matches!(ch, ':' | '*' | '?' | '"' | '<' | '>' | '|'))
+    {
+        return Err(SessionDirError::InvalidDirectoryName);
+    }
+    Ok(())
+}
+
+fn resolve_directory_name(args: &CreateArgs) -> Result<String, SessionDirError> {
+    let Some(name) = args.directory_name.as_deref() else {
+        return Ok(crate::worktree::sanitize_slug(&args.slug));
+    };
+    validate_directory_name(name)?;
+    Ok(name.to_string())
+}
+
 fn scan_directory(path: &Path, root: &Path) -> Option<SimpleSessionScanEntry> {
     let metadata = std::fs::symlink_metadata(path).ok()?;
     if !metadata.file_type().is_dir() {
@@ -170,16 +222,39 @@ pub fn simple_workspace_prepare(path: String) -> Result<String, SessionDirError>
 #[tauri::command]
 pub fn session_dir_create(args: CreateArgs) -> Result<CreatedSessionDir, SessionDirError> {
     let base = expand_home(&args.base_path)?;
-    let slug = crate::worktree::sanitize_slug(&args.slug);
+    let slug = resolve_directory_name(&args)?;
     let target = absolute_path(base)?.join("sessions").join(&slug);
-    let reused = target.exists();
+    if target.exists() {
+        let metadata = std::fs::symlink_metadata(&target)?;
+        if !metadata.is_dir() {
+            return Err(SessionDirError::SessionDirectoryConflict);
+        }
+        let marker = match marker_read(&target) {
+            Ok(marker) => marker,
+            Err(SessionDirError::Io(error)) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Err(SessionDirError::SessionDirectoryConflict);
+            }
+            Err(SessionDirError::Json(_)) => return Err(SessionDirError::SessionDirectoryConflict),
+            Err(error) => return Err(error),
+        };
+        if marker.session_id != args.session_id {
+            return Err(SessionDirError::SessionDirectoryConflict);
+        }
+        let resolved = std::fs::canonicalize(target)?;
+        return Ok(CreatedSessionDir {
+            worktree_path: resolved.to_string_lossy().into_owned(),
+            branch_name: String::new(),
+            slug,
+            reused: true,
+        });
+    }
     let resolved = create_absolute_dir(target)?;
     marker_write(&resolved, args.session_id, args.workspace_id)?;
     Ok(CreatedSessionDir {
         worktree_path: resolved.to_string_lossy().into_owned(),
         branch_name: String::new(),
         slug,
-        reused,
+        reused: false,
     })
 }
 
@@ -241,7 +316,9 @@ pub fn simple_session_dir_exists(path: String) -> Result<bool, SessionDirError> 
 mod tests {
     use std::path::Path;
 
-    use super::{session_dir_create, simple_sessions_scan, CreateArgs, SessionMarker};
+    use super::{
+        session_dir_create, simple_sessions_scan, CreateArgs, SessionDirError, SessionMarker,
+    };
 
     fn test_root(name: &str) -> std::path::PathBuf {
         std::env::temp_dir().join(format!(
@@ -260,6 +337,7 @@ mod tests {
         let args = || CreateArgs {
             base_path: root.to_string_lossy().into_owned(),
             slug: "Study Plan".to_string(),
+            directory_name: None,
             session_id: "session-1".to_string(),
             workspace_id: "workspace-1".to_string(),
         };
@@ -273,9 +351,122 @@ mod tests {
         assert_eq!(marker.session_id, "session-1");
         assert_eq!(marker.workspace_id, "workspace-1");
         assert!(!marker.created_at.is_empty());
+        let first_created_at = marker.created_at.clone();
         let reused = session_dir_create(args()).unwrap();
         assert!(reused.reused);
+        let marker_after_reuse = std::fs::read(Path::new(&created.worktree_path).join(".goodboy")).unwrap();
+        let marker_after_reuse = serde_json::from_slice::<SessionMarker>(&marker_after_reuse).unwrap();
+        assert_eq!(marker_after_reuse.created_at, first_created_at);
+        assert_eq!(marker_after_reuse.workspace_id, "workspace-1");
         std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn rejects_reusing_a_directory_without_marker() {
+        let root = test_root("simple-session-missing-marker");
+        let sessions = root.join("sessions");
+        std::fs::create_dir_all(sessions.join("study-plan")).unwrap();
+
+        let result = session_dir_create(CreateArgs {
+            base_path: root.to_string_lossy().into_owned(),
+            slug: "Study Plan".to_string(),
+            directory_name: None,
+            session_id: "session-1".to_string(),
+            workspace_id: "workspace-1".to_string(),
+        });
+
+        assert!(matches!(
+            result,
+            Err(SessionDirError::SessionDirectoryConflict)
+        ));
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn rejects_reusing_a_directory_owned_by_another_session() {
+        let root = test_root("simple-session-session-conflict");
+        let created = session_dir_create(CreateArgs {
+            base_path: root.to_string_lossy().into_owned(),
+            slug: "Study Plan".to_string(),
+            directory_name: None,
+            session_id: "session-1".to_string(),
+            workspace_id: "workspace-1".to_string(),
+        })
+        .unwrap();
+
+        let result = session_dir_create(CreateArgs {
+            base_path: root.to_string_lossy().into_owned(),
+            slug: "Study Plan".to_string(),
+            directory_name: None,
+            session_id: "session-2".to_string(),
+            workspace_id: "workspace-1".to_string(),
+        });
+
+        assert!(matches!(
+            result,
+            Err(SessionDirError::SessionDirectoryConflict)
+        ));
+        assert!(Path::new(&created.worktree_path).is_dir());
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn creates_a_directory_from_an_explicit_name() {
+        let root = test_root("simple-session-explicit-name");
+        let created = session_dir_create(CreateArgs {
+            base_path: root.to_string_lossy().into_owned(),
+            slug: "ignored".to_string(),
+            directory_name: Some("MatchAnalysis_20260514".to_string()),
+            session_id: "session-1".to_string(),
+            workspace_id: "workspace-1".to_string(),
+        })
+        .unwrap();
+
+        assert_eq!(created.slug, "MatchAnalysis_20260514");
+        assert!(created.worktree_path.ends_with("/sessions/MatchAnalysis_20260514"));
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn rejects_invalid_explicit_directory_names() {
+        let root = test_root("simple-session-invalid-explicit-name");
+        let too_long = "a".repeat(61);
+        let invalid_names = [
+            ".hidden",
+            "name/part",
+            "name\\part",
+            "name..part",
+            "name.",
+            "name ",
+            "name|part",
+            &too_long,
+        ];
+
+        for name in invalid_names {
+            let result = session_dir_create(CreateArgs {
+                base_path: root.to_string_lossy().into_owned(),
+                slug: "ignored".to_string(),
+                directory_name: Some(name.to_string()),
+                session_id: "session-1".to_string(),
+                workspace_id: "workspace-1".to_string(),
+            });
+            assert!(matches!(
+                result,
+                Err(SessionDirError::InvalidDirectoryName)
+            ));
+        }
+
+        let control_result = session_dir_create(CreateArgs {
+            base_path: root.to_string_lossy().into_owned(),
+            slug: "ignored".to_string(),
+            directory_name: Some("name\u{0007}part".to_string()),
+            session_id: "session-1".to_string(),
+            workspace_id: "workspace-1".to_string(),
+        });
+        assert!(matches!(
+            control_result,
+            Err(SessionDirError::InvalidDirectoryName)
+        ));
     }
 
     #[test]
@@ -284,6 +475,7 @@ mod tests {
         let created = session_dir_create(CreateArgs {
             base_path: root.to_string_lossy().into_owned(),
             slug: "Study Plan".to_string(),
+            directory_name: None,
             session_id: "session-1".to_string(),
             workspace_id: "workspace-1".to_string(),
         })
@@ -294,6 +486,7 @@ mod tests {
         let second = session_dir_create(CreateArgs {
             base_path: root.to_string_lossy().into_owned(),
             slug: "Second Plan".to_string(),
+            directory_name: None,
             session_id: "session-2".to_string(),
             workspace_id: "workspace-1".to_string(),
         })
@@ -319,6 +512,7 @@ mod tests {
         let created = session_dir_create(CreateArgs {
             base_path: outside.to_string_lossy().into_owned(),
             slug: "Outside Plan".to_string(),
+            directory_name: None,
             session_id: "session-outside".to_string(),
             workspace_id: "workspace-1".to_string(),
         })
@@ -340,6 +534,7 @@ mod tests {
         session_dir_create(CreateArgs {
             base_path: root.to_string_lossy().into_owned(),
             slug: "Study Plan".to_string(),
+            directory_name: None,
             session_id: "session-1".to_string(),
             workspace_id: "workspace-marker".to_string(),
         })

--- a/apps/desktop/src/features/integrations/components/LaunchSessionPanel/index.test.tsx
+++ b/apps/desktop/src/features/integrations/components/LaunchSessionPanel/index.test.tsx
@@ -11,6 +11,7 @@ const h = vi.hoisted(() => ({
     session: { id: 'session-9', goal: 'Fix the flake' },
   })),
   loadSetting: vi.fn(async () => null),
+  simpleSessionDirExists: vi.fn(async () => false),
   showToast: vi.fn(),
   store: {
     workspaces: [{ id: 'workspace-1', rootPath: '/repo', kind: 'dev' }] as ReadonlyArray<
@@ -35,7 +36,10 @@ vi.mock('../../../../app/components/Toast', () => ({
 }));
 
 vi.mock('../../../worktree/useBranchConflict', () => ({ useBranchConflict: () => null }));
-vi.mock('../../../worktree/worktree', () => ({ removeWorktree: vi.fn() }));
+vi.mock('../../../worktree/worktree', () => ({
+  removeWorktree: vi.fn(),
+  simpleSessionDirExists: h.simpleSessionDirExists,
+}));
 
 import { LaunchSessionPanel } from './index';
 
@@ -64,6 +68,7 @@ const renderPanel = () =>
 beforeEach(() => {
   localStorage.clear();
   h.createSession.mockClear();
+  h.simpleSessionDirExists.mockClear();
   h.showToast.mockClear();
   h.store.workspaces = [{ id: 'workspace-1', rootPath: '/repo', kind: 'dev' }];
 });
@@ -123,7 +128,44 @@ describe('LaunchSessionPanel', () => {
     expect(screen.getByText('ak/fix-the-flake')).toBeDefined();
   });
 
-  it('drops the branch field and the branch payload in a repo-less workspace', async () => {
+  it('blocks launch for invalid folder names in a repo-less workspace', () => {
+    h.store.workspaces = [{ id: 'workspace-1', rootPath: '/notes', kind: 'simple' }];
+
+    renderPanel();
+    fireEvent.change(screen.getByLabelText('Folder name'), { target: { value: 'bad/name' } });
+
+    expect(screen.queryByLabelText('Branch slug')).toBeNull();
+    expect(screen.getByText('Use one folder name. Slashes are not allowed')).toBeDefined();
+    expect(screen.getByRole('button', { name: /Launch session/i }).getAttribute('disabled')).toBe(
+      '',
+    );
+  });
+
+  it('blocks launch when the folder already exists in a repo-less workspace', async () => {
+    h.store.workspaces = [{ id: 'workspace-1', rootPath: '/notes', kind: 'simple' }];
+    h.simpleSessionDirExists.mockResolvedValueOnce(true);
+
+    renderPanel();
+    fireEvent.change(screen.getByLabelText('Folder name'), {
+      target: { value: 'Existing folder' },
+    });
+
+    await waitFor(() =>
+      expect(h.simpleSessionDirExists).toHaveBeenCalledWith({
+        path: '/notes/sessions/Existing folder',
+      }),
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByText('A folder with this name already exists in this workspace'),
+      ).toBeDefined(),
+    );
+    expect(screen.getByRole('button', { name: /Launch session/i }).getAttribute('disabled')).toBe(
+      '',
+    );
+  });
+
+  it('drops the branch field and passes the typed folder name in a repo-less workspace', async () => {
     h.store.workspaces = [{ id: 'workspace-1', rootPath: '/notes', kind: 'simple' }];
 
     render(
@@ -146,6 +188,22 @@ describe('LaunchSessionPanel', () => {
 
     expect(screen.queryByLabelText('Branch slug')).toBeNull();
     expect(screen.queryByRole('tab', { name: /Continue on PR #12/ })).toBeNull();
+    expect(screen.getByText('Folder')).toBeDefined();
+    fireEvent.change(screen.getByLabelText('Folder name'), {
+      target: { value: 'Issue 7 follow-up' },
+    });
+    await waitFor(() =>
+      expect(h.simpleSessionDirExists).toHaveBeenCalledWith({
+        path: '/notes/sessions/Issue 7 follow-up',
+      }),
+    );
+    await waitFor(
+      () =>
+        expect(
+          screen.getByRole('button', { name: /Launch session/i }).getAttribute('disabled'),
+        ).toBeNull(),
+      { timeout: 2000 },
+    );
 
     fireEvent.click(screen.getByRole('button', { name: /Launch session/i }));
 
@@ -154,5 +212,6 @@ describe('LaunchSessionPanel', () => {
     expect(payload.branchPrefix).toBeUndefined();
     expect(payload.branchSlug).toBeUndefined();
     expect(payload.existingBranch).toBeUndefined();
+    expect(payload.folderName).toBe('Issue 7 follow-up');
   });
 });

--- a/apps/desktop/src/features/integrations/components/LaunchSessionPanel/index.tsx
+++ b/apps/desktop/src/features/integrations/components/LaunchSessionPanel/index.tsx
@@ -9,7 +9,7 @@ import {
   StatusDot,
   Textarea,
 } from '@goodboy/ui';
-import { AlertTriangle, ArrowRight, GitBranch, MessagesSquare } from 'lucide-react';
+import { AlertTriangle, ArrowRight, Folder, GitBranch, MessagesSquare } from 'lucide-react';
 import type { SessionExternalTaskProvider, SessionId, WorkspaceId } from '@goodboy/types';
 import { useAppStore } from '../../../../store';
 import { useToast } from '../../../../app/components/Toast';
@@ -19,11 +19,16 @@ import { formatError, isMissingBaseRefError } from '../../../../shared/lib/error
 import { isValidBranchSlug } from '../../../../shared/utils/isValidBranchSlug';
 import { sanitizeBranchPrefix } from '../../../../shared/utils/sanitizeBranchPrefix';
 import { sanitizeBranchSlug } from '../../../../shared/utils/sanitizeBranchSlug';
+import { validateSessionDirectoryName } from '../../../../shared/utils/validateSessionDirectoryName';
+import { deriveDefaultSessionDirectoryNameFromGoal } from '../../../../shared/utils/deriveDefaultSessionDirectoryNameFromGoal';
+import { buildSimpleSessionDirectoryPath } from '../../../../shared/utils/buildSimpleSessionDirectoryPath';
+import { sessionDirectoryNameValidationMessage } from '../../../../shared/utils/sessionDirectoryNameValidationMessage';
 import { DEFAULT_BRANCH_PREFIX, settingBranchPrefix } from '../../../settings/settings';
 import { SetupWorkflowToggle } from '../../../session/components/SetupWorkflowToggle';
 import { useSetupWorkflowPreference } from '../../../session/hooks/useSetupWorkflowPreference';
 import { removeWorktree } from '../../../worktree/worktree';
 import { useBranchConflict } from '../../../worktree/useBranchConflict';
+import { useSimpleSessionDirectoryConflict } from '../../../worktree/useSimpleSessionDirectoryConflict';
 
 type AdoptableBranch = {
   readonly label: string;
@@ -76,6 +81,10 @@ export const LaunchSessionPanel = ({
   const [setupWorkflow, setSetupWorkflow] = useSetupWorkflowPreference();
   const [goal, setGoal] = useState(goalSeed);
   const [branchSlug, setBranchSlug] = useState(branchSlugSeed);
+  const [folderName, setFolderName] = useState(() =>
+    deriveDefaultSessionDirectoryNameFromGoal({ goal: goalSeed }),
+  );
+  const [folderNameTouched, setFolderNameTouched] = useState(false);
   const [branchPrefix, setBranchPrefix] = useState(DEFAULT_BRANCH_PREFIX);
   const [modeChoice, setModeChoice] = useState<'adopt' | 'fresh' | null>(null);
   const [busy, setBusy] = useState(false);
@@ -89,6 +98,17 @@ export const LaunchSessionPanel = ({
   }, [goalSeed]);
 
   useEffect(() => {
+    if (!isBranchless || folderNameTouched) {
+      return;
+    }
+    const nextFolderName = deriveDefaultSessionDirectoryNameFromGoal({ goal });
+    if (nextFolderName === folderName) {
+      return;
+    }
+    setFolderName(nextFolderName);
+  }, [folderName, folderNameTouched, goal, isBranchless]);
+
+  useEffect(() => {
     void loadSetting(settingBranchPrefix(workspaceId)).then((value) => {
       setBranchPrefix(value ?? DEFAULT_BRANCH_PREFIX);
     });
@@ -97,6 +117,18 @@ export const LaunchSessionPanel = ({
   const mode = modeChoice ?? (adoptable == null ? 'fresh' : 'adopt');
   const prefix = sanitizeBranchPrefix({ input: branchPrefix }) || DEFAULT_BRANCH_PREFIX;
   const isSlugValid = isValidBranchSlug({ slug: branchSlug });
+  const folderValidation = validateSessionDirectoryName({ name: folderName });
+  const folderNameError = sessionDirectoryNameValidationMessage({ validation: folderValidation });
+  const folderPathPreview =
+    isBranchless && rootPath != null
+      ? buildSimpleSessionDirectoryPath({
+          workspaceRoot: rootPath,
+          folderName,
+        })
+      : null;
+  const folderConflictPath =
+    isBranchless && folderValidation.ok && folderPathPreview != null ? folderPathPreview : null;
+  const folderConflict = useSimpleSessionDirectoryConflict({ path: folderConflictPath });
   const isAdopting = mode === 'adopt' && adoptable != null;
   const adoptedBranch = isAdopting ? adoptable.branch : null;
   const effectiveBranch = isBranchless
@@ -116,7 +148,10 @@ export const LaunchSessionPanel = ({
     : isAdopting
       ? adoptedBranch != null && !adoptable.isResolving
       : isSlugValid;
-  const canLaunch = goal.trim() !== '' && isBranchReady && !busy && conflictPath == null;
+  const isFolderReady =
+    !isBranchless || (folderValidation.ok && !folderConflict.exists && !folderConflict.checking);
+  const canLaunch =
+    goal.trim() !== '' && isBranchReady && isFolderReady && !busy && conflictPath == null;
 
   const launch = async (eraseWorktreePath?: string) => {
     setError(null);
@@ -129,7 +164,7 @@ export const LaunchSessionPanel = ({
         workspaceId,
         goal,
         ...(isBranchless
-          ? {}
+          ? { folderName }
           : { branchPrefix: prefix, branchSlug: branchSlug.trim() || undefined }),
         ...(adoptedBranch != null ? { existingBranch: adoptedBranch } : {}),
         externalTask,
@@ -192,7 +227,65 @@ export const LaunchSessionPanel = ({
         />
       </FieldRow>
 
-      {isBranchless ? null : (
+      {isBranchless ? (
+        <>
+          <Divider />
+          <section className="flex flex-col">
+            <SectionHeader
+              icon={<Folder size={12} aria-hidden />}
+              label="Folder"
+              hint="This is the folder name you will find on disk inside your workspace folder."
+            />
+            <FieldRow
+              label="Folder name"
+              help="The app creates this folder in your workspace under sessions"
+              layout="stacked"
+            >
+              <div className="flex w-full flex-col gap-1.5">
+                <div className="flex w-full items-center gap-1.5">
+                  <span className="shrink-0 font-mono text-xs text-muted-foreground">
+                    sessions/
+                  </span>
+                  <Input
+                    value={folderName}
+                    onChange={(event) => {
+                      setFolderName(event.target.value);
+                      setFolderNameTouched(true);
+                    }}
+                    placeholder="session"
+                    className="h-8 min-w-0 flex-1 text-sm"
+                    disabled={busy}
+                    aria-label="Folder name"
+                  />
+                </div>
+                {folderPathPreview != null ? (
+                  <p className="text-2xs leading-relaxed text-muted-foreground">
+                    Folder on disk:{' '}
+                    <span className="break-all font-mono text-muted-foreground">
+                      {folderPathPreview}
+                    </span>
+                  </p>
+                ) : null}
+                {folderNameError != null ? (
+                  <p role="alert" className="text-2xs leading-relaxed text-danger">
+                    {folderNameError}
+                  </p>
+                ) : null}
+                {folderNameError == null && folderConflict.exists ? (
+                  <p role="alert" className="text-2xs leading-relaxed text-danger">
+                    A folder with this name already exists in this workspace
+                  </p>
+                ) : null}
+                {folderNameError == null && !folderConflict.exists && folderConflict.checking ? (
+                  <p className="text-2xs leading-relaxed text-muted-foreground">
+                    Checking if this folder already exists
+                  </p>
+                ) : null}
+              </div>
+            </FieldRow>
+          </section>
+        </>
+      ) : (
         <>
           <Divider />
           <section className="flex flex-col">

--- a/apps/desktop/src/features/session/components/NewSessionView/NewSessionForm.tsx
+++ b/apps/desktop/src/features/session/components/NewSessionView/NewSessionForm.tsx
@@ -1,6 +1,6 @@
 import type { ChangeEventHandler, RefObject } from 'react';
 import { Divider, FieldRow, Input, SectionHeader, Skeleton, Textarea, cn } from '@goodboy/ui';
-import { AlertTriangle, Expand, GitBranch, Paperclip, Target, Wand2 } from 'lucide-react';
+import { AlertTriangle, Expand, Folder, GitBranch, Paperclip, Target, Wand2 } from 'lucide-react';
 import type { SessionId, WorkspaceId } from '@goodboy/types';
 import { PROVIDER_LABEL } from '../../../chat/utils/chat-constants';
 import { AttachmentChip } from '../../../chat/components/ChatInput/parts/AttachmentChip';
@@ -40,6 +40,12 @@ type Props = {
   readonly branchPrefix: string;
   readonly branchSlug: string;
   readonly onBranchSlugChange: (value: string) => void;
+  readonly folderName: string;
+  readonly onFolderNameChange: (value: string) => void;
+  readonly folderPathPreview: string | null;
+  readonly folderNameError: string | null;
+  readonly folderConflict: boolean;
+  readonly folderConflictChecking: boolean;
   readonly slugGenerating: boolean;
   readonly onGenerateSlug: () => void;
   readonly existingBranches: ReadonlyArray<LocalBranchInfo>;
@@ -74,6 +80,12 @@ export const NewSessionForm = ({
   branchPrefix,
   branchSlug,
   onBranchSlugChange,
+  folderName,
+  onFolderNameChange,
+  folderPathPreview,
+  folderNameError,
+  folderConflict,
+  folderConflictChecking,
   slugGenerating,
   onGenerateSlug,
   existingBranches,
@@ -225,9 +237,62 @@ export const NewSessionForm = ({
         </FieldRow>
       </section>
 
-      {!isSimple ? (
+      <Divider />
+      {isSimple ? (
         <>
-          <Divider />
+          <section className="flex flex-col">
+            <SectionHeader
+              icon={<Folder size={12} aria-hidden />}
+              label="Folder"
+              hint="This is the folder name you will find on disk inside your workspace folder."
+            />
+            <FieldRow
+              label="Folder name"
+              help="The app creates this folder in your workspace under sessions"
+            >
+              <div className="flex w-full flex-col gap-1.5 sm:w-96">
+                <div className="flex w-full items-center gap-1.5">
+                  <span className="shrink-0 font-mono text-xs text-muted-foreground">
+                    sessions/
+                  </span>
+                  <Input
+                    value={folderName}
+                    onChange={(event) => onFolderNameChange(event.target.value)}
+                    placeholder="session"
+                    className="h-8 min-w-0 flex-1 text-sm"
+                    disabled={busy}
+                    aria-label="Folder name"
+                  />
+                </div>
+                {folderPathPreview != null ? (
+                  <p className="text-2xs leading-relaxed text-muted-foreground">
+                    Folder on disk:{' '}
+                    <span className="break-all font-mono text-muted-foreground">
+                      {folderPathPreview}
+                    </span>
+                  </p>
+                ) : null}
+                {folderNameError != null ? (
+                  <p role="alert" className="text-2xs leading-relaxed text-danger">
+                    {folderNameError}
+                  </p>
+                ) : null}
+                {folderNameError == null && folderConflict ? (
+                  <p role="alert" className="text-2xs leading-relaxed text-danger">
+                    A folder with this name already exists in this workspace
+                  </p>
+                ) : null}
+                {folderNameError == null && !folderConflict && folderConflictChecking ? (
+                  <p className="text-2xs leading-relaxed text-muted-foreground">
+                    Checking if this folder already exists
+                  </p>
+                ) : null}
+              </div>
+            </FieldRow>
+          </section>
+        </>
+      ) : (
+        <>
           <section className="flex flex-col">
             <SectionHeader
               icon={<GitBranch size={12} aria-hidden />}
@@ -311,7 +376,7 @@ export const NewSessionForm = ({
             </FieldRow>
           </section>
         </>
-      ) : null}
+      )}
     </div>
   );
 };

--- a/apps/desktop/src/features/session/components/NewSessionView/index.test.tsx
+++ b/apps/desktop/src/features/session/components/NewSessionView/index.test.tsx
@@ -10,6 +10,7 @@ import type {
 const h = vi.hoisted(() => ({
   remoteKind: 'github' as string | null,
   listLocalBranches: vi.fn(async () => []),
+  simpleSessionDirExists: vi.fn(async () => false),
   invoke: vi.fn(),
   showToast: vi.fn(),
   store: {
@@ -62,6 +63,7 @@ vi.mock('../../../../features/worktree/useBranchConflict', () => ({
 
 vi.mock('../../../../features/worktree/worktree', () => ({
   listLocalBranches: h.listLocalBranches,
+  simpleSessionDirExists: h.simpleSessionDirExists,
   removeWorktree: vi.fn(),
 }));
 
@@ -95,6 +97,8 @@ beforeEach(() => {
       goal: '',
       branchSlug: '',
       slugTouched: false,
+      folderName: '',
+      folderNameTouched: false,
       branchMode: 'new',
       existingBranch: '',
       issue: null,
@@ -107,6 +111,7 @@ beforeEach(() => {
     delete h.store.newSessionDrafts[workspaceId];
   });
   h.listLocalBranches.mockClear();
+  h.simpleSessionDirExists.mockClear();
   h.invoke.mockReset();
   h.invoke.mockResolvedValue({
     stdout: JSON.stringify({ result: '<<goal>>Polished goal.<</goal>>' }),
@@ -125,6 +130,8 @@ describe('NewSessionView issue sources', () => {
         goal: 'Original goal',
         branchSlug: 'original-goal',
         slugTouched: true,
+        folderName: 'Original goal',
+        folderNameTouched: false,
         branchMode: 'new',
         existingBranch: '',
         issue: null,
@@ -163,6 +170,8 @@ describe('NewSessionView issue sources', () => {
         goal: 'Rough goal',
         branchSlug: 'rough-goal',
         slugTouched: true,
+        folderName: 'Rough goal',
+        folderNameTouched: false,
         branchMode: 'new',
         existingBranch: '',
         issue: null,
@@ -254,7 +263,107 @@ describe('NewSessionView issue sources', () => {
     expect(screen.queryByText('Start from an issue')).toBeNull();
   });
 
-  it('hides issue and branch controls and creates without branch fields for simple workspaces', async () => {
+  it('derives the folder name from the goal and stops following after manual edits', () => {
+    h.store.workspaces[0]!.kind = 'simple';
+    const view = render(
+      <NewSessionView onClose={vi.fn()} workspaceId={WORKSPACE_ID} onOpenSettings={vi.fn()} />,
+    );
+
+    view.rerender(
+      <NewSessionView onClose={vi.fn()} workspaceId={WORKSPACE_ID} onOpenSettings={vi.fn()} />,
+    );
+    const initialFolderInput = screen.getByLabelText('Folder name');
+    if (!(initialFolderInput instanceof HTMLInputElement)) {
+      throw new Error('Expected the folder name field to be an input');
+    }
+    expect(initialFolderInput.value).toBe('session');
+
+    fireEvent.change(screen.getByLabelText('Goal'), {
+      target: { value: 'Prepare for the exam' },
+    });
+    view.rerender(
+      <NewSessionView onClose={vi.fn()} workspaceId={WORKSPACE_ID} onOpenSettings={vi.fn()} />,
+    );
+    view.rerender(
+      <NewSessionView onClose={vi.fn()} workspaceId={WORKSPACE_ID} onOpenSettings={vi.fn()} />,
+    );
+    const derivedFolderInput = screen.getByLabelText('Folder name');
+    if (!(derivedFolderInput instanceof HTMLInputElement)) {
+      throw new Error('Expected the folder name field to be an input');
+    }
+    expect(derivedFolderInput.value).toBe('Prepare for the exam');
+
+    fireEvent.change(derivedFolderInput, {
+      target: { value: 'Exam prep notes' },
+    });
+    view.rerender(
+      <NewSessionView onClose={vi.fn()} workspaceId={WORKSPACE_ID} onOpenSettings={vi.fn()} />,
+    );
+
+    fireEvent.change(screen.getByLabelText('Goal'), {
+      target: { value: 'Another goal for tomorrow' },
+    });
+    view.rerender(
+      <NewSessionView onClose={vi.fn()} workspaceId={WORKSPACE_ID} onOpenSettings={vi.fn()} />,
+    );
+    const customFolderInput = screen.getByLabelText('Folder name');
+    if (!(customFolderInput instanceof HTMLInputElement)) {
+      throw new Error('Expected the folder name field to be an input');
+    }
+    expect(customFolderInput.value).toBe('Exam prep notes');
+  });
+
+  it('blocks creation when the folder name is invalid and explains why', () => {
+    h.store.workspaces[0]!.kind = 'simple';
+    const view = render(
+      <NewSessionView onClose={vi.fn()} workspaceId={WORKSPACE_ID} onOpenSettings={vi.fn()} />,
+    );
+
+    fireEvent.change(screen.getByLabelText('Folder name'), {
+      target: { value: 'bad/name' },
+    });
+    view.rerender(
+      <NewSessionView onClose={vi.fn()} workspaceId={WORKSPACE_ID} onOpenSettings={vi.fn()} />,
+    );
+
+    expect(screen.getByText('Use one folder name. Slashes are not allowed')).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Create session' }).getAttribute('disabled')).toBe(
+      '',
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Create session' }));
+    expect(h.store.createSession).not.toHaveBeenCalled();
+  });
+
+  it('blocks creation when the folder already exists', async () => {
+    h.store.workspaces[0]!.kind = 'simple';
+    h.simpleSessionDirExists.mockResolvedValueOnce(true);
+    const view = render(
+      <NewSessionView onClose={vi.fn()} workspaceId={WORKSPACE_ID} onOpenSettings={vi.fn()} />,
+    );
+
+    fireEvent.change(screen.getByLabelText('Folder name'), {
+      target: { value: 'Existing folder' },
+    });
+    view.rerender(
+      <NewSessionView onClose={vi.fn()} workspaceId={WORKSPACE_ID} onOpenSettings={vi.fn()} />,
+    );
+
+    await waitFor(() =>
+      expect(h.simpleSessionDirExists).toHaveBeenCalledWith({
+        path: '/repo/sessions/Existing folder',
+      }),
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByText('A folder with this name already exists in this workspace'),
+      ).toBeDefined(),
+    );
+    expect(screen.getByRole('button', { name: 'Create session' }).getAttribute('disabled')).toBe(
+      '',
+    );
+  });
+
+  it('hides issue and branch controls and creates with the typed folder name for simple workspaces', async () => {
     h.store.workspaces[0]!.kind = 'simple';
     h.store.workspaceIntegrations = {
       [WORKSPACE_ID]: [integration('linear'), integration('sentry')],
@@ -266,6 +375,7 @@ describe('NewSessionView issue sources', () => {
     expect(screen.queryByText('Start from an issue')).toBeNull();
     expect(screen.queryByText('Branch')).toBeNull();
     expect(screen.queryByLabelText('Branch slug')).toBeNull();
+    expect(screen.getByText('Folder')).toBeDefined();
     expect(h.listLocalBranches).not.toHaveBeenCalled();
 
     fireEvent.change(screen.getByLabelText('Goal'), {
@@ -274,12 +384,31 @@ describe('NewSessionView issue sources', () => {
     view.rerender(
       <NewSessionView onClose={vi.fn()} workspaceId={WORKSPACE_ID} onOpenSettings={vi.fn()} />,
     );
+    fireEvent.change(screen.getByLabelText('Folder name'), {
+      target: { value: 'Exam prep 2026' },
+    });
+    view.rerender(
+      <NewSessionView onClose={vi.fn()} workspaceId={WORKSPACE_ID} onOpenSettings={vi.fn()} />,
+    );
+    await waitFor(() =>
+      expect(h.simpleSessionDirExists).toHaveBeenCalledWith({
+        path: '/repo/sessions/Exam prep 2026',
+      }),
+    );
+    await waitFor(
+      () =>
+        expect(
+          screen.getByRole('button', { name: 'Create session' }).getAttribute('disabled'),
+        ).toBeNull(),
+      { timeout: 2000 },
+    );
     fireEvent.click(screen.getByRole('button', { name: 'Create session' }));
     await waitFor(() => expect(h.store.createSession).toHaveBeenCalledOnce());
     const input = h.store.createSession.mock.calls[0]?.[0];
     expect(input).not.toHaveProperty('branchPrefix');
     expect(input).not.toHaveProperty('branchSlug');
     expect(input).not.toHaveProperty('existingBranch');
+    expect(input.folderName).toBe('Exam prep 2026');
     expect(h.store.newSessionDrafts[WORKSPACE_ID]).toBeUndefined();
   });
 });

--- a/apps/desktop/src/features/session/components/NewSessionView/index.tsx
+++ b/apps/desktop/src/features/session/components/NewSessionView/index.tsx
@@ -15,6 +15,7 @@ import {
   type LocalBranchInfo,
 } from '../../../../features/worktree/worktree';
 import { useBranchConflict } from '../../../../features/worktree/useBranchConflict';
+import { useSimpleSessionDirectoryConflict } from '../../../../features/worktree/useSimpleSessionDirectoryConflict';
 import { useWorkspaceRemoteHostKind } from '../../../../features/worktree/useWorkspaceRemoteHostKind';
 import type { IssueCandidate } from '../../../../features/integrations/fetchIssueCandidates';
 import { resolveIssueSources } from '../../../../features/integrations/issueSources';
@@ -24,6 +25,10 @@ import { isValidBranchSlug as validateBranchSlug } from '../../../../shared/util
 import { sanitizeBranchPrefix } from '../../../../shared/utils/sanitizeBranchPrefix';
 import { sanitizeBranchSlug as sanitizeBranchSlugValue } from '../../../../shared/utils/sanitizeBranchSlug';
 import { slugifyBranch } from '../../../../shared/utils/slugifyBranch';
+import { validateSessionDirectoryName } from '../../../../shared/utils/validateSessionDirectoryName';
+import { deriveDefaultSessionDirectoryNameFromGoal } from '../../../../shared/utils/deriveDefaultSessionDirectoryNameFromGoal';
+import { buildSimpleSessionDirectoryPath } from '../../../../shared/utils/buildSimpleSessionDirectoryPath';
+import { sessionDirectoryNameValidationMessage } from '../../../../shared/utils/sessionDirectoryNameValidationMessage';
 import { PROVIDER_ORDER } from '../../../providers/components/ProviderStudio/providerOrder';
 import { useSetupWorkflowPreference } from '../../hooks/useSetupWorkflowPreference';
 import { EMPTY_NEW_SESSION_DRAFT } from '../../../../store/slices/newSessionDrafts/emptyNewSessionDraft';
@@ -59,7 +64,16 @@ export const NewSessionView = ({ onClose, workspaceId, onOpenSettings }: Props) 
   const isSimple = workspace?.kind === 'simple';
   const workspaceOverrides = useAppStore((s) => s.workspaceOverrides?.[workspaceId] ?? null);
 
-  const { goal, branchSlug, slugTouched, branchMode, existingBranch, issue } = draft;
+  const {
+    goal,
+    branchSlug,
+    slugTouched,
+    folderName,
+    folderNameTouched,
+    branchMode,
+    existingBranch,
+    issue,
+  } = draft;
   const [branchPrefix, setBranchPrefix] = useState(DEFAULT_BRANCH_PREFIX);
   const [slugGenerating, setSlugGenerating] = useState(false);
   const [existingBranches, setExistingBranches] = useState<ReadonlyArray<LocalBranchInfo>>([]);
@@ -174,6 +188,17 @@ export const NewSessionView = ({ onClose, workspaceId, onOpenSettings }: Props) 
     setNewSessionDraft({ workspaceId, draft: { branchSlug: nextBranchSlug } });
   }, [branchSlug, goal, setNewSessionDraft, slugTouched, workspaceId]);
 
+  useEffect(() => {
+    if (!isSimple || folderNameTouched) {
+      return;
+    }
+    const nextFolderName = deriveDefaultSessionDirectoryNameFromGoal({ goal });
+    if (nextFolderName === folderName) {
+      return;
+    }
+    setNewSessionDraft({ workspaceId, draft: { folderName: nextFolderName } });
+  }, [folderName, folderNameTouched, goal, isSimple, setNewSessionDraft, workspaceId]);
+
   const handleGenerateSlug = () => {
     const trimmed = goal.trim();
     if (trimmed === '' || slugGenerating) {
@@ -277,6 +302,18 @@ export const NewSessionView = ({ onClose, workspaceId, onOpenSettings }: Props) 
   );
   const conflictSessionId = conflict?.kind === 'session' ? conflict.sessionId : null;
   const conflictWorktreePath = conflict?.kind === 'worktree' ? conflict.path : null;
+  const folderValidation = validateSessionDirectoryName({ name: folderName });
+  const folderNameError = sessionDirectoryNameValidationMessage({ validation: folderValidation });
+  const folderPathPreview =
+    isSimple && workspace?.rootPath != null
+      ? buildSimpleSessionDirectoryPath({
+          workspaceRoot: workspace.rootPath,
+          folderName,
+        })
+      : null;
+  const folderConflictPath =
+    isSimple && folderValidation.ok && folderPathPreview != null ? folderPathPreview : null;
+  const folderConflict = useSimpleSessionDirectoryConflict({ path: folderConflictPath });
 
   const branchReady =
     isSimple ||
@@ -284,9 +321,12 @@ export const NewSessionView = ({ onClose, workspaceId, onOpenSettings }: Props) 
       ? validateBranchSlug({ slug: branchSlug })
       : existingBranch.trim().length > 0);
   const goalReady = goal.trim().length > 0;
+  const folderReady =
+    !isSimple || (folderValidation.ok && !folderConflict.exists && !folderConflict.checking);
   const canCreate =
     goalReady &&
     branchReady &&
+    folderReady &&
     !busy &&
     !noProviderConnected &&
     conflictSessionId === null &&
@@ -314,13 +354,13 @@ export const NewSessionView = ({ onClose, workspaceId, onOpenSettings }: Props) 
       await createSession({
         workspaceId,
         goal,
-        ...(!isSimple
-          ? {
+        ...(isSimple
+          ? { folderName }
+          : {
               branchPrefix:
                 sanitizeBranchPrefix({ input: branchPrefix }).trim() || DEFAULT_BRANCH_PREFIX,
               branchSlug: branchSlug.trim() || undefined,
-            }
-          : {}),
+            }),
         ...(useExisting ? { existingBranch: existingBranch.trim() } : {}),
         ...(issue
           ? {
@@ -398,6 +438,20 @@ export const NewSessionView = ({ onClose, workspaceId, onOpenSettings }: Props) 
                     },
                   });
                 }}
+                folderName={folderName}
+                onFolderNameChange={(value) => {
+                  setNewSessionDraft({
+                    workspaceId,
+                    draft: {
+                      folderName: value,
+                      folderNameTouched: true,
+                    },
+                  });
+                }}
+                folderPathPreview={folderPathPreview}
+                folderNameError={folderNameError}
+                folderConflict={folderConflict.exists}
+                folderConflictChecking={folderConflict.checking}
                 slugGenerating={slugGenerating}
                 onGenerateSlug={handleGenerateSlug}
                 existingBranches={existingBranches}

--- a/apps/desktop/src/features/worktree/useSimpleSessionDirectoryConflict.ts
+++ b/apps/desktop/src/features/worktree/useSimpleSessionDirectoryConflict.ts
@@ -1,0 +1,61 @@
+import { useEffect, useState } from 'react';
+import { simpleSessionDirExists } from './worktree';
+
+type Params = {
+  readonly path: string | null;
+  readonly debounceMs?: number;
+};
+
+type SimpleSessionDirectoryConflict = {
+  readonly exists: boolean;
+  readonly checking: boolean;
+};
+
+const DEFAULT_DEBOUNCE_MS = 250;
+
+export const useSimpleSessionDirectoryConflict = ({
+  path,
+  debounceMs = DEFAULT_DEBOUNCE_MS,
+}: Params): SimpleSessionDirectoryConflict => {
+  const [exists, setExists] = useState(false);
+  const [checking, setChecking] = useState(false);
+
+  useEffect(() => {
+    setExists(false);
+    if (path == null || path === '') {
+      setChecking(false);
+      return;
+    }
+
+    let cancelled = false;
+    setChecking(true);
+    const timerId = window.setTimeout(() => {
+      simpleSessionDirExists({ path })
+        .then((directoryExists) => {
+          if (cancelled) {
+            return;
+          }
+          setExists(directoryExists);
+        })
+        .catch(() => {
+          if (cancelled) {
+            return;
+          }
+          setExists(false);
+        })
+        .finally(() => {
+          if (cancelled) {
+            return;
+          }
+          setChecking(false);
+        });
+    }, debounceMs);
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timerId);
+    };
+  }, [debounceMs, path]);
+
+  return { exists, checking };
+};

--- a/apps/desktop/src/features/worktree/worktree.ts
+++ b/apps/desktop/src/features/worktree/worktree.ts
@@ -32,6 +32,7 @@ export const createWorktree = async (args: CreateWorktreeArgs): Promise<CreatedW
 export type CreateSessionDirArgs = {
   readonly basePath: string;
   readonly slug: string;
+  readonly directoryName?: string;
   readonly sessionId: SessionId;
   readonly workspaceId: WorkspaceId;
 };
@@ -39,11 +40,18 @@ export type CreateSessionDirArgs = {
 export const createSessionDir = async ({
   basePath,
   slug,
+  directoryName,
   sessionId,
   workspaceId,
 }: CreateSessionDirArgs): Promise<CreatedWorktree> => {
   return invoke<CreatedWorktree>('session_dir_create', {
-    args: { basePath, slug, sessionId, workspaceId },
+    args: {
+      basePath,
+      slug,
+      ...(directoryName != null ? { directoryName } : {}),
+      sessionId,
+      workspaceId,
+    },
   });
 };
 

--- a/apps/desktop/src/shared/utils/buildSimpleSessionDirectoryPath.ts
+++ b/apps/desktop/src/shared/utils/buildSimpleSessionDirectoryPath.ts
@@ -1,0 +1,9 @@
+type Params = {
+  readonly workspaceRoot: string;
+  readonly folderName: string;
+};
+
+export const buildSimpleSessionDirectoryPath = ({ workspaceRoot, folderName }: Params): string => {
+  const normalizedRoot = workspaceRoot === '/' ? workspaceRoot : workspaceRoot.replace(/\/+$/, '');
+  return `${normalizedRoot}/sessions/${folderName}`;
+};

--- a/apps/desktop/src/shared/utils/deriveDefaultSessionDirectoryNameFromGoal.test.ts
+++ b/apps/desktop/src/shared/utils/deriveDefaultSessionDirectoryNameFromGoal.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { deriveDefaultSessionDirectoryNameFromGoal } from './deriveDefaultSessionDirectoryNameFromGoal';
+
+describe('deriveDefaultSessionDirectoryNameFromGoal', () => {
+  it('takes the opening words while keeping casing and spaces between words', () => {
+    expect(
+      deriveDefaultSessionDirectoryNameFromGoal({ goal: 'Prepare a study plan for next week' }),
+    ).toBe('Prepare a study plan');
+  });
+
+  it('strips only characters rejected by directory-name validation', () => {
+    expect(
+      deriveDefaultSessionDirectoryNameFromGoal({ goal: 'Roadmap: Q4/2026*launch? draft' }),
+    ).toBe('Roadmap Q42026launch draft');
+  });
+
+  it('caps defaults to forty characters without cutting a selected word', () => {
+    expect(
+      deriveDefaultSessionDirectoryNameFromGoal({
+        goal: 'Alpha Beta Gamma Delta Epsilon Zeta Eta Theta Iota Kappa',
+      }),
+    ).toBe('Alpha Beta Gamma Delta');
+  });
+
+  it('falls back to session when sanitization removes everything', () => {
+    expect(deriveDefaultSessionDirectoryNameFromGoal({ goal: '////****????' })).toBe('session');
+  });
+});

--- a/apps/desktop/src/shared/utils/deriveDefaultSessionDirectoryNameFromGoal.ts
+++ b/apps/desktop/src/shared/utils/deriveDefaultSessionDirectoryNameFromGoal.ts
@@ -1,0 +1,59 @@
+type Params = {
+  readonly goal: string;
+};
+
+const MAX_WORDS = 4;
+const MAX_DIRECTORY_NAME_LENGTH = 40;
+const CONTROL_CHARACTER_RE = /\p{Cc}/gu;
+const RESERVED_CHARACTER_RE = /[\\/:*?"<>|]/g;
+const LEADING_DOT_RE = /^\.+/;
+const TRAILING_DOT_OR_SPACE_RE = /[. ]+$/;
+const DOT_DOT_RE = /\.{2,}/g;
+
+const sanitizeGoal = ({ goal }: Params): string => {
+  const cleaned = goal
+    .replace(CONTROL_CHARACTER_RE, '')
+    .replace(RESERVED_CHARACTER_RE, '')
+    .replace(LEADING_DOT_RE, '')
+    .replace(DOT_DOT_RE, '.')
+    .replace(TRAILING_DOT_OR_SPACE_RE, '')
+    .trim();
+  if (cleaned === '') {
+    return 'session';
+  }
+  return cleaned;
+};
+
+export const deriveDefaultSessionDirectoryNameFromGoal = ({ goal }: Params): string => {
+  const cleaned = sanitizeGoal({ goal });
+  const tokens = cleaned.match(/\S+|\s+/g) ?? [];
+  let selected = '';
+  let selectedWordCount = 0;
+
+  for (const token of tokens) {
+    const isWhitespace = token.trim() === '';
+    if (isWhitespace && selected === '') {
+      continue;
+    }
+    if (!isWhitespace && selectedWordCount >= MAX_WORDS) {
+      break;
+    }
+    const candidate = `${selected}${token}`;
+    if (Array.from(candidate).length > MAX_DIRECTORY_NAME_LENGTH) {
+      if (selectedWordCount === 0 && !isWhitespace) {
+        return Array.from(token).slice(0, MAX_DIRECTORY_NAME_LENGTH).join('');
+      }
+      break;
+    }
+    selected = candidate;
+    if (!isWhitespace) {
+      selectedWordCount += 1;
+    }
+  }
+
+  selected = selected.replace(TRAILING_DOT_OR_SPACE_RE, '');
+  if (selected === '') {
+    return 'session';
+  }
+  return selected;
+};

--- a/apps/desktop/src/shared/utils/sessionDirectoryNameValidationMessage.ts
+++ b/apps/desktop/src/shared/utils/sessionDirectoryNameValidationMessage.ts
@@ -1,0 +1,34 @@
+import type { SessionDirectoryNameValidationResult } from './validateSessionDirectoryName';
+
+type Params = {
+  readonly validation: SessionDirectoryNameValidationResult;
+};
+
+export const sessionDirectoryNameValidationMessage = ({ validation }: Params): string | null => {
+  if (validation.ok) {
+    return null;
+  }
+
+  switch (validation.kind) {
+    case 'empty':
+      return 'Enter the folder name you want to create';
+    case 'too_long':
+      return 'Use 60 characters or fewer';
+    case 'path_separator':
+      return 'Use one folder name. Slashes are not allowed';
+    case 'dot_dot':
+      return 'Consecutive dots are not allowed';
+    case 'leading_dot':
+      return 'The folder name cannot start with a dot';
+    case 'trailing_dot_or_space':
+      return 'The folder name cannot end with a dot or a space';
+    case 'control_character':
+      return 'Control characters are not allowed';
+    case 'reserved_character':
+      return 'Reserved characters are not allowed: : * ? " < > |';
+    default: {
+      const exhaustive: never = validation.kind;
+      return exhaustive;
+    }
+  }
+};

--- a/apps/desktop/src/shared/utils/validateSessionDirectoryName.test.ts
+++ b/apps/desktop/src/shared/utils/validateSessionDirectoryName.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { validateSessionDirectoryName } from './validateSessionDirectoryName';
+
+describe('validateSessionDirectoryName', () => {
+  it('accepts letters across scripts, digits, spaces, dashes, underscores, and dots', () => {
+    expect(validateSessionDirectoryName({ name: 'gestione finanze 2025' })).toEqual({ ok: true });
+    expect(validateSessionDirectoryName({ name: 'MatchAnalysis_20260514' })).toEqual({ ok: true });
+    expect(validateSessionDirectoryName({ name: 'План тестирования 2026.08' })).toEqual({
+      ok: true,
+    });
+    expect(validateSessionDirectoryName({ name: '分析 セッション 01' })).toEqual({ ok: true });
+  });
+
+  it('rejects separators and double dots', () => {
+    expect(validateSessionDirectoryName({ name: 'folder/name' })).toEqual({
+      ok: false,
+      kind: 'path_separator',
+    });
+    expect(validateSessionDirectoryName({ name: 'folder\\name' })).toEqual({
+      ok: false,
+      kind: 'path_separator',
+    });
+    expect(validateSessionDirectoryName({ name: 'folder..name' })).toEqual({
+      ok: false,
+      kind: 'dot_dot',
+    });
+  });
+
+  it('rejects leading dots and trailing dot or space', () => {
+    expect(validateSessionDirectoryName({ name: '.hidden' })).toEqual({
+      ok: false,
+      kind: 'leading_dot',
+    });
+    expect(validateSessionDirectoryName({ name: 'folder.' })).toEqual({
+      ok: false,
+      kind: 'trailing_dot_or_space',
+    });
+    expect(validateSessionDirectoryName({ name: 'folder ' })).toEqual({
+      ok: false,
+      kind: 'trailing_dot_or_space',
+    });
+  });
+
+  it('rejects control and reserved Windows characters', () => {
+    expect(validateSessionDirectoryName({ name: 'folder\u0007name' })).toEqual({
+      ok: false,
+      kind: 'control_character',
+    });
+    expect(validateSessionDirectoryName({ name: 'folder|name' })).toEqual({
+      ok: false,
+      kind: 'reserved_character',
+    });
+  });
+
+  it('rejects empty and too-long names', () => {
+    expect(validateSessionDirectoryName({ name: '' })).toEqual({ ok: false, kind: 'empty' });
+    expect(validateSessionDirectoryName({ name: 'a'.repeat(61) })).toEqual({
+      ok: false,
+      kind: 'too_long',
+    });
+  });
+});

--- a/apps/desktop/src/shared/utils/validateSessionDirectoryName.ts
+++ b/apps/desktop/src/shared/utils/validateSessionDirectoryName.ts
@@ -2,11 +2,11 @@ type Params = {
   readonly name: string;
 };
 
-type SessionDirectoryNameValidationResult =
+export type SessionDirectoryNameValidationResult =
   | { readonly ok: true }
   | { readonly ok: false; readonly kind: SessionDirectoryNameValidationErrorKind };
 
-type SessionDirectoryNameValidationErrorKind =
+export type SessionDirectoryNameValidationErrorKind =
   | 'empty'
   | 'too_long'
   | 'path_separator'

--- a/apps/desktop/src/shared/utils/validateSessionDirectoryName.ts
+++ b/apps/desktop/src/shared/utils/validateSessionDirectoryName.ts
@@ -1,0 +1,51 @@
+type Params = {
+  readonly name: string;
+};
+
+type SessionDirectoryNameValidationResult =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly kind: SessionDirectoryNameValidationErrorKind };
+
+type SessionDirectoryNameValidationErrorKind =
+  | 'empty'
+  | 'too_long'
+  | 'path_separator'
+  | 'dot_dot'
+  | 'leading_dot'
+  | 'trailing_dot_or_space'
+  | 'control_character'
+  | 'reserved_character';
+
+const MAX_DIRECTORY_NAME_LENGTH = 60;
+const CONTROL_CHARACTER_RE = /\p{Cc}/u;
+const RESERVED_CHARACTER_RE = /[:*?"<>|]/;
+
+export const validateSessionDirectoryName = ({
+  name,
+}: Params): SessionDirectoryNameValidationResult => {
+  if (name === '') {
+    return { ok: false, kind: 'empty' };
+  }
+  if (Array.from(name).length > MAX_DIRECTORY_NAME_LENGTH) {
+    return { ok: false, kind: 'too_long' };
+  }
+  if (name.includes('/') || name.includes('\\')) {
+    return { ok: false, kind: 'path_separator' };
+  }
+  if (name.includes('..')) {
+    return { ok: false, kind: 'dot_dot' };
+  }
+  if (name.startsWith('.')) {
+    return { ok: false, kind: 'leading_dot' };
+  }
+  if (name.endsWith('.') || name.endsWith(' ')) {
+    return { ok: false, kind: 'trailing_dot_or_space' };
+  }
+  if (CONTROL_CHARACTER_RE.test(name)) {
+    return { ok: false, kind: 'control_character' };
+  }
+  if (RESERVED_CHARACTER_RE.test(name)) {
+    return { ok: false, kind: 'reserved_character' };
+  }
+  return { ok: true };
+};

--- a/apps/desktop/src/store/slices/newSessionDrafts/emptyNewSessionDraft.ts
+++ b/apps/desktop/src/store/slices/newSessionDrafts/emptyNewSessionDraft.ts
@@ -4,6 +4,8 @@ export const EMPTY_NEW_SESSION_DRAFT: NewSessionDraft = {
   goal: '',
   branchSlug: '',
   slugTouched: false,
+  folderName: '',
+  folderNameTouched: false,
   branchMode: 'new',
   existingBranch: '',
   issue: null,

--- a/apps/desktop/src/store/slices/newSessionDrafts/index.test.ts
+++ b/apps/desktop/src/store/slices/newSessionDrafts/index.test.ts
@@ -30,6 +30,8 @@ describe('newSessionDrafts slice', () => {
         goal: 'Fix the checkout flow',
         branchSlug: 'fix-checkout-flow',
         slugTouched: true,
+        folderName: 'Checkout repair',
+        folderNameTouched: true,
         branchMode: 'existing',
         existingBranch: 'checkout-work',
         issue: {
@@ -56,6 +58,8 @@ describe('newSessionDrafts slice', () => {
       goal: 'Fix checkout and payment',
       branchSlug: 'fix-checkout-flow',
       slugTouched: true,
+      folderName: 'Checkout repair',
+      folderNameTouched: true,
       branchMode: 'existing',
       existingBranch: 'checkout-work',
       issue: { identifier: '#42' },

--- a/apps/desktop/src/store/slices/newSessionDrafts/types.ts
+++ b/apps/desktop/src/store/slices/newSessionDrafts/types.ts
@@ -7,6 +7,8 @@ export type NewSessionDraft = {
   readonly goal: string;
   readonly branchSlug: string;
   readonly slugTouched: boolean;
+  readonly folderName: string;
+  readonly folderNameTouched: boolean;
   readonly branchMode: 'new' | 'existing';
   readonly existingBranch: string;
   readonly issue: IssueCandidate | null;

--- a/apps/desktop/src/store/slices/sessions/createSession.ts
+++ b/apps/desktop/src/store/slices/sessions/createSession.ts
@@ -41,6 +41,7 @@ import { markSessionMobileShared } from '../../../features/companion/mobileConfi
 import { workSurfaceFocus } from '../session-view/workSurfaceFocus';
 import { clampTitle } from './titleLimit';
 import { preSpawnWorkflowAgents } from '../workflows/preSpawnWorkflowAgents';
+import { deriveDefaultSessionDirectoryNameFromGoal } from '../../../shared/utils/deriveDefaultSessionDirectoryNameFromGoal';
 import type { GetFn, SetFn } from './types';
 
 const slugifyDir = (raw: string): string =>
@@ -58,6 +59,7 @@ type Input = {
   branchSlug?: string;
   existingBranch?: string;
   fallbackRef?: string;
+  folderName?: string;
   providerPreference?: SessionProviderPreference;
   workflowId?: WorkflowId;
   autoRun?: boolean;
@@ -88,6 +90,7 @@ export const createSession = (set: SetFn, get: GetFn) => {
     branchSlug,
     existingBranch,
     fallbackRef,
+    folderName,
     providerPreference,
     workflowId,
     autoRun,
@@ -124,9 +127,14 @@ export const createSession = (set: SetFn, get: GetFn) => {
     const memberWorktrees: Array<{ member: WorkspaceMember; worktree: CreatedWorktree }> = [];
     if (isSimple) {
       const dirSlug = `${slugifyDir(slugSeed)}-${sessionId.slice(0, 8)}`;
+      const directoryName =
+        folderName !== undefined
+          ? folderName
+          : deriveDefaultSessionDirectoryNameFromGoal({ goal: goal.trim() });
       worktree = await createSessionDir({
         basePath: workspace.rootPath,
         slug: dirSlug,
+        directoryName,
         sessionId,
         workspaceId,
       });

--- a/apps/desktop/src/store/slices/sessions/index.test.ts
+++ b/apps/desktop/src/store/slices/sessions/index.test.ts
@@ -824,7 +824,7 @@ describe('store contract', () => {
   });
 
   describe('createSession simple workspace', () => {
-    it('registers a plain session directory with an empty branch', async () => {
+    it('registers a simple session directory with the requested folder name and an empty branch', async () => {
       const store = await getStore();
       const db = await import('@goodboy/db');
       vi.mocked(db.listWorkspaces).mockResolvedValueOnce([
@@ -834,20 +834,23 @@ describe('store contract', () => {
         }),
       ]);
       createSessionDirSpy.mockResolvedValueOnce({
-        worktreePath: '/tmp/study-space/sessions/study-plan-12345678',
+        worktreePath: '/tmp/study-space/sessions/MatchAnalysis_20260514',
         branchName: '',
-        slug: 'study-plan-12345678',
+        slug: 'MatchAnalysis_20260514',
         reused: false,
       });
       store.setState({ currentWorkspaceId: WS_ID });
 
-      const { session, worktree } = await store
-        .getState()
-        .createSession({ workspaceId: WS_ID, goal: 'Study plan' });
+      const { session, worktree } = await store.getState().createSession({
+        workspaceId: WS_ID,
+        goal: 'Study plan',
+        folderName: 'MatchAnalysis_20260514',
+      });
 
       expect(createSessionDirSpy).toHaveBeenCalledWith({
         basePath: '/tmp/study-space',
         slug: expect.stringMatching(/^study-plan-[a-f0-9]{8}$/),
+        directoryName: 'MatchAnalysis_20260514',
         sessionId: session.id,
         workspaceId: WS_ID,
       });
@@ -875,9 +878,9 @@ describe('store contract', () => {
         }),
       ]);
       createSessionDirSpy.mockResolvedValueOnce({
-        worktreePath: '/tmp/study-space/sessions/study-plan-12345678',
+        worktreePath: '/tmp/study-space/sessions/Study plan',
         branchName: '',
-        slug: 'study-plan-12345678',
+        slug: 'Study plan',
         reused: false,
       });
       store.setState({
@@ -894,6 +897,11 @@ describe('store contract', () => {
         .getState()
         .createSession({ workspaceId: WS_ID, goal: 'Study plan' });
 
+      expect(createSessionDirSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          directoryName: 'Study plan',
+        }),
+      );
       expect(session.providerPreference).toEqual({
         defaultProvider: 'codex',
         allowTurnOverride: true,

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -194,6 +194,7 @@ export type AppActions = {
     branchSlug?: string;
     existingBranch?: string;
     fallbackRef?: string;
+    folderName?: string;
     providerPreference?: SessionProviderPreference;
     workflowId?: WorkflowId;
     autoRun?: boolean;


### PR DESCRIPTION
Designed with Fable, implemented from that plan. Independent of the UI polish stack and of #1135.

## What

A session in a standalone workspace got a folder named after its goal, run through a branch-style
slugifier: a sentence like "in this session I want to reconcile the 2025 invoices" became
`in-this-session-i-want-to-a1b2c3d4`. The user reasons about that folder the way a developer reasons
about a branch name, so they now pick it.

1. **The name is taken verbatim.** `session_dir_create` accepts an explicit name and validates rather
   than rewrites: one path segment, no separators, no leading dot, no trailing dot or space, none of
   the characters Windows refuses, sixty characters at most. The same rule exists as a pure helper in
   TypeScript so the form can say no before submit instead of after.
2. **A Folder field**, in the slot repositories use for the branch, with a `sessions/` prefix, a
   default derived from the goal that follows it until the user edits it, and the real path shown
   underneath. Invalid names and collisions are reported inline and block creation.
3. **Same field when launching from an integration**, so the two ways into the same folder agree.

## A latent bug this had to fix first

`session_dir_create` used to reuse a directory that already existed and overwrite its `.goodboy`
marker, so a second session would silently take over the first one's folder and its attribution. The
eight-character session id suffix hid it. A name the user chose would not have, so it now refuses
unless the marker names the same session.

## Two decisions worth stating

**The branch field and the folder field stay separate controls.** They share a slot and a mental
model, not their rules: a branch name inherits git's constraints and feeds the worktree path and the
PR, while a folder name is allowed spaces, capitals and unicode that a branch is not. Merging them
would have meant one of the two lying about what it accepts.

**Renaming after creation is not in this pass.** It has to move the directory, update
`session_worktrees.worktree_path`, and survive agent subprocesses still holding the old working
directory. Meanwhile a rename done in Finder between launches is already tolerated: the `.goodboy`
marker plus `relinkSimpleSessionDirectories` re-adopt the folder at workspace load.

## Verified

`cargo test --locked`, `pnpm -w typecheck`, desktop suite green (3646 tests).

## No migration

The name lives on disk and in `session_worktrees.worktree_path`; no session column was added.