### PR TITLE
refactor(desktop): stop the code host lens assuming github

### DIFF
--- a/apps/desktop/src/features/context/components/ContextPanel/strips/GitlabMrStrip.tsx
+++ b/apps/desktop/src/features/context/components/ContextPanel/strips/GitlabMrStrip.tsx
@@ -7,17 +7,20 @@ import { useAppStore } from '../../../../../store';
 
 type Props = {
   readonly sessionId: SessionId;
+  readonly onOpenStudio?: () => void;
 };
 
-export const GitlabMrStrip = ({ sessionId }: Props) => {
+export const GitlabMrStrip = ({ sessionId, onOpenStudio }: Props) => {
   const remoteKind = useRemoteHostKind({ sessionId });
   const mrState = useAppStore((s) => s.sessionGitlabMr[sessionId]);
   const refreshSessionMr = useAppStore((s) => s.refreshSessionMr);
   const mr = mrState?.mr ?? null;
   const loading = mrState?.loading ?? false;
   const error = mrState?.error ?? null;
-  const openPane = () =>
-    window.dispatchEvent(new CustomEvent('goodboy:open-gitlab-mr', { detail: { sessionId } }));
+  const openPane =
+    onOpenStudio ??
+    (() =>
+      window.dispatchEvent(new CustomEvent('goodboy:open-gitlab-mr', { detail: { sessionId } })));
 
   if (remoteKind !== 'gitlab') {
     return null;

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.test.tsx
@@ -80,7 +80,14 @@ vi.mock('../../../../../store/slices/worktrees/useSessionRepo', () => ({
 }));
 
 vi.mock('../../../../context/components/ContextPanel/strips/GitlabMrStrip', () => ({
-  GitlabMrStrip: () => <div>GitLab merge request detail</div>,
+  GitlabMrStrip: ({ onOpenStudio }: { readonly onOpenStudio?: () => void }) => (
+    <div>
+      <div>GitLab merge request detail</div>
+      <button type="button" onClick={onOpenStudio}>
+        Open merge request from code host
+      </button>
+    </div>
+  ),
 }));
 
 vi.mock('../../../../github/github', () => ({
@@ -169,6 +176,18 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe('PrPane', () => {
+  it('uses neutral code host copy for title and description on GitLab sessions', () => {
+    h.remoteKind = 'gitlab';
+
+    render(<PrPane session={session} onSelectLens={h.onSelectLens} />);
+
+    expect(screen.getByRole('heading', { name: 'Code host work' })).toBeDefined();
+    expect(
+      screen.getByText('Linked issues and pull or merge request for this session.'),
+    ).toBeDefined();
+    expect(screen.queryByText('GitHub')).toBeNull();
+  });
+
   it('never offers create-PR actions inside a PR review session', () => {
     h.store.sessionPhaseRuns = {
       [SESSION_ID]: [{ id: 'agent-1', name: 'pr review', kind: 'pr-reviewer' }],
@@ -199,7 +218,7 @@ describe('PrPane', () => {
     ).toBeNull();
     expect(screen.getAllByText('Refactor authentication')).toHaveLength(1);
     expect(screen.getByText('No CI')).toBeDefined();
-    expect(screen.getByRole('button', { name: 'Open PR' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Open in code host' })).toBeDefined();
   });
 
   it('offers a switcher across every pull request on the branch', () => {
@@ -279,7 +298,7 @@ describe('PrPane', () => {
     view.rerender(<PrPane session={session} onSelectLens={h.onSelectLens} />);
 
     expect(screen.queryByText('GitLab merge request detail')).toBeNull();
-    expect(screen.getByRole('button', { name: 'Open PR' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Open in code host' })).toBeDefined();
   });
 
   it('shows PR status, linked issues, and code-host external tasks from stored state', () => {
@@ -421,30 +440,55 @@ describe('PrPane', () => {
     fireEvent.click(screen.getByRole('button', { name: 'open #9 in GitHub' }));
     expect(h.openUrl).toHaveBeenCalledWith('https://github.com/acme/goodboy/issues/9');
     expect(h.onSelectLens).not.toHaveBeenCalled();
-    expect(screen.getByText('No pull request yet')).toBeDefined();
+    expect(screen.getByText('No pull or merge request yet')).toBeDefined();
     expect(screen.getByText('ak/refactor-auth')).toBeDefined();
-    expect(screen.getByRole('button', { name: /Open a pull request/i })).toBeDefined();
+    expect(screen.getByRole('button', { name: /Open in code host/i })).toBeDefined();
 
     expect(screen.queryByRole('region', { name: 'issue #7 details' })).toBeNull();
   });
 
-  it('routes creating a PR to the shared PR studio surface', () => {
-    const events: Array<CustomEvent> = [];
-    const listener = (event: Event) => events.push(event as CustomEvent);
-    window.addEventListener('goodboy:open-github-session', listener);
+  it('routes the open action to GitHub for GitHub sessions', () => {
+    const githubEvents: Array<CustomEvent> = [];
+    const gitlabEvents: Array<CustomEvent> = [];
+    const githubListener = (event: Event) => githubEvents.push(event as CustomEvent);
+    const gitlabListener = (event: Event) => gitlabEvents.push(event as CustomEvent);
+    window.addEventListener('goodboy:open-github-session', githubListener);
+    window.addEventListener('goodboy:open-gitlab-mr', gitlabListener);
 
     render(<PrPane session={session} onSelectLens={h.onSelectLens} />);
-    const cta = screen.getByRole('button', { name: /Open a pull request/i });
+    const cta = screen.getByRole('button', { name: /Open in code host/i });
     fireEvent.click(cta);
-    window.removeEventListener('goodboy:open-github-session', listener);
+    window.removeEventListener('goodboy:open-github-session', githubListener);
+    window.removeEventListener('goodboy:open-gitlab-mr', gitlabListener);
 
-    expect(events).toHaveLength(1);
-    expect(events[0]?.detail).toEqual({ sessionId: SESSION_ID });
+    expect(githubEvents).toHaveLength(1);
+    expect(githubEvents[0]?.detail).toEqual({ sessionId: SESSION_ID });
+    expect(gitlabEvents).toHaveLength(0);
     expect(
       screen.getByText('No issues or external tasks are linked to this session yet.'),
     ).toBeDefined();
     expect(screen.queryByRole('button', { name: 'Quick draft' })).toBeNull();
     expect(screen.queryByRole('button', { name: 'Draft with agent' })).toBeNull();
+  });
+
+  it('routes the open action to GitLab for GitLab sessions', () => {
+    h.remoteKind = 'gitlab';
+    const githubEvents: Array<CustomEvent> = [];
+    const gitlabEvents: Array<CustomEvent> = [];
+    const githubListener = (event: Event) => githubEvents.push(event as CustomEvent);
+    const gitlabListener = (event: Event) => gitlabEvents.push(event as CustomEvent);
+    window.addEventListener('goodboy:open-github-session', githubListener);
+    window.addEventListener('goodboy:open-gitlab-mr', gitlabListener);
+
+    render(<PrPane session={session} onSelectLens={h.onSelectLens} />);
+    const cta = screen.getByRole('button', { name: 'Open merge request from code host' });
+    fireEvent.click(cta);
+    window.removeEventListener('goodboy:open-github-session', githubListener);
+    window.removeEventListener('goodboy:open-gitlab-mr', gitlabListener);
+
+    expect(gitlabEvents).toHaveLength(1);
+    expect(gitlabEvents[0]?.detail).toEqual({ sessionId: SESSION_ID });
+    expect(githubEvents).toHaveLength(0);
   });
 
   it('explains that a missing GitHub remote cannot be fixed with a token', () => {
@@ -454,7 +498,7 @@ describe('PrPane', () => {
     expect(screen.getByRole('heading', { name: 'GitHub', level: 2 })).toBeDefined();
     expect(screen.getByText(/does not have a GitHub remote/i)).toBeDefined();
     expect(screen.queryByLabelText('GitHub personal access token')).toBeNull();
-    expect(screen.queryByRole('button', { name: /Open a pull request/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /Open in code host/i })).toBeNull();
   });
 
   it('clears the token empty state after connecting a repository with a GitHub remote', async () => {
@@ -472,6 +516,6 @@ describe('PrPane', () => {
     await waitFor(() => {
       expect(screen.queryByLabelText('GitHub personal access token')).toBeNull();
     });
-    expect(screen.getByRole('button', { name: /Open a pull request/i })).toBeDefined();
+    expect(screen.getByRole('button', { name: /Open in code host/i })).toBeDefined();
   });
 });

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.tsx
@@ -33,6 +33,7 @@ import { useSessionRepo } from '../../../../../store/slices/worktrees/useSession
 import { CONCEPT_ICONS } from '../../../../../shared/components/conceptIcons';
 import { LinkedWorkRow } from '../../../../../shared/components/LinkedWorkRow';
 import { openUrl } from '../../../../../shared/lib/editor';
+import type { RemoteHostKind } from '../../../../../shared/lib/remoteHost';
 
 type Props = {
   readonly session: Session;
@@ -40,6 +41,28 @@ type Props = {
 };
 
 type PullRequestProvider = 'github' | 'gitlab';
+
+type SessionStudioOpenEvent = 'goodboy:open-github-session' | 'goodboy:open-gitlab-mr';
+
+const resolveSessionStudioOpenEvent = ({
+  remoteKind,
+}: {
+  readonly remoteKind: RemoteHostKind | null;
+}): SessionStudioOpenEvent => {
+  switch (remoteKind) {
+    case 'gitlab':
+      return 'goodboy:open-gitlab-mr';
+    case 'github':
+    case 'other':
+    case 'none':
+    case null:
+      return 'goodboy:open-github-session';
+    default: {
+      const unexpectedKind: never = remoteKind;
+      return unexpectedKind;
+    }
+  }
+};
 
 export const PrPane = ({ session, onSelectLens }: Props) => {
   const sessionId = session.id as SessionId;
@@ -83,18 +106,20 @@ export const PrPane = ({ session, onSelectLens }: Props) => {
             ? 'closed'
             : 'open';
   const hasBothProviders = pullRequest != null && mergeRequest != null;
-
-  const description =
-    activeProvider === 'gitlab'
-      ? 'Merge request and linked issues for this session.'
-      : 'Pull request and linked issues for this session.';
+  const openStudio = () =>
+    window.dispatchEvent(
+      new CustomEvent(resolveSessionStudioOpenEvent({ remoteKind }), { detail: { sessionId } }),
+    );
 
   return (
-    <PaneShell title="Pull requests" description={description}>
+    <PaneShell
+      title="Code host work"
+      description="Linked issues and pull or merge request for this session."
+    >
       <div className="flex flex-col gap-3">
         {hasBothProviders ? (
           <div className="flex flex-col gap-1.5">
-            <Eyebrow label="Pull requests" muted className="px-0.5 font-medium" />
+            <Eyebrow label="Code host requests" muted className="px-0.5 font-medium" />
             <div className="flex flex-col gap-1">
               {pullRequest != null ? (
                 <PrListRow
@@ -122,9 +147,15 @@ export const PrPane = ({ session, onSelectLens }: Props) => {
           </div>
         ) : null}
         {activeProvider === 'gitlab' ? (
-          <GitlabMrStrip sessionId={sessionId} />
+          <GitlabMrStrip sessionId={sessionId} onOpenStudio={openStudio} />
         ) : (
-          <GithubPrCard session={session} isPrReview={isPrReview} onSelectLens={onSelectLens} />
+          <GithubPrCard
+            session={session}
+            isPrReview={isPrReview}
+            onSelectLens={onSelectLens}
+            remoteKind={remoteKind}
+            onOpenStudio={openStudio}
+          />
         )}
       </div>
     </PaneShell>
@@ -135,10 +166,14 @@ const GithubPrCard = ({
   session,
   isPrReview,
   onSelectLens,
+  remoteKind,
+  onOpenStudio,
 }: {
   session: Session;
   isPrReview: boolean;
   onSelectLens: (lens: LensKind) => void;
+  remoteKind: RemoteHostKind | null;
+  onOpenStudio: () => void;
 }) => {
   const sessionId = session.id as SessionId;
   const github = useAppStore((s) => s.sessionGithub[sessionId]);
@@ -154,7 +189,6 @@ const GithubPrCard = ({
   const workspace = useAppStore(
     (s) => s.workspaces.find((candidate) => candidate.id === session.workspaceId) ?? null,
   );
-  const remoteKind = useRemoteHostKind({ sessionId });
   const githubConnection = useGithubConnection({ workspaceId: session.workspaceId });
   const isGithubConnected = resolveIntegrationConnection({
     provider: 'github',
@@ -176,9 +210,6 @@ const GithubPrCard = ({
   );
   const loading = github?.loading ?? false;
   const error = github?.error ?? null;
-
-  const openStudio = () =>
-    window.dispatchEvent(new CustomEvent('goodboy:open-github-session', { detail: { sessionId } }));
   const refresh = () => void refreshSessionPr(sessionId, { force: true });
 
   if (!pr && remoteKind !== 'github') {
@@ -223,8 +254,8 @@ const GithubPrCard = ({
           bordered
           tone="primary"
           icon={CONCEPT_ICONS.pr}
-          title="Open a pull request"
-          description="Turn this session’s work into a PR. Fill in the title and description, or hand it to an agent that writes them from your commits."
+          title="Open a pull or merge request"
+          description="Turn this session's work into a pull or merge request. Fill in the title and description, or hand it to an agent that writes them from your commits."
           size="lg"
           headingLevel={2}
           className="animate-fade-in relative py-8"
@@ -248,8 +279,8 @@ const GithubPrCard = ({
                   <span className="truncate text-foreground/80">{branch}</span>
                 </span>
               ) : null}
-              <Button onClick={openStudio}>
-                Open a pull request
+              <Button onClick={onOpenStudio}>
+                Open in code host
                 <ArrowRight size={13} aria-hidden className="shrink-0 opacity-70" />
               </Button>
             </>
@@ -269,8 +300,8 @@ const GithubPrCard = ({
           bordered
           tone="primary"
           icon={CONCEPT_ICONS.pr}
-          title="No pull request yet"
-          description="Turn this session’s work into a PR when it is ready."
+          title="No pull or merge request yet"
+          description="Turn this session's work into a pull or merge request when it is ready."
           className="relative items-start px-4 py-4 text-left"
           action={
             <>
@@ -289,8 +320,8 @@ const GithubPrCard = ({
                   <span className="truncate text-foreground/80">{branch}</span>
                 </span>
               ) : null}
-              <Button size="sm" onClick={openStudio}>
-                Open a pull request
+              <Button size="sm" onClick={onOpenStudio}>
+                Open in code host
                 <ArrowRight size={13} aria-hidden className="shrink-0 opacity-70" />
               </Button>
             </>
@@ -352,10 +383,10 @@ const GithubPrCard = ({
 
       <button
         type="button"
-        onClick={openStudio}
+        onClick={onOpenStudio}
         className="inline-flex items-center justify-center gap-1.5 rounded-lg bg-foreground/[0.04] px-3 py-2 text-xs font-medium text-foreground ring-1 ring-border-soft transition-colors hover:bg-foreground/[0.08]"
       >
-        Open PR
+        Open in code host
         <ArrowRight size={13} aria-hidden className="shrink-0 opacity-70" />
       </button>
 


### PR DESCRIPTION
Stacked on #1138.

## What

`PrPane` serves GitHub and GitLab and spoke as if it served GitHub.

1. **The copy names the thing, not a vendor**: the session's work on its code host, which is its
   linked issues plus its pull or merge request. States that really are about one provider, a missing
   GitHub token for example, still name it: that is a fact, not an assumption.
2. **The open affordances resolve their host.** All four of them called one handler that dispatched
   the hardwired `goodboy:open-github-session`, handled in `App.tsx` with no provider branch, while
   GitLab had a separate event and handler. A GitLab session was being sent to the GitHub studio.

## Where "which hosts exist" is encoded, after this change

Four places, and they are named here so the next person adding a host knows where to look:

1. `RemoteHostKind` in `shared/lib/remoteHost.ts`
2. the pair of session-studio events, `goodboy:open-github-session` and `goodboy:open-gitlab-mr`
3. `PullRequestProvider` in `PrPane.tsx`, which drives the provider selector
4. the code-host task filter in `PrPane.tsx`

No new surface was added to that list.

## Verified

`pnpm -w typecheck` and the desktop suite green (3651 tests). New coverage: a GitLab session sees no
GitHub in the pane's copy, and the open affordance dispatches the event for the session's own host.

## Not touched, and why

- **No third host.** This removes the assumption that there are exactly two; implementing Bitbucket is
  a different piece of work.
- **`GithubPrCard` and `GitlabMrStrip` internals** are untouched beyond what the above required.