### PR TITLE
refactor(desktop): one convention for active, and a quiet navigation

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -58,6 +58,10 @@ functional. One register per surface; let the other supply only texture.
   The footer holds integration shortcuts and studio launchers. The sidebar
   answers "where am I" (session list, agents). The command palette (⌘K)
   answers "where do I want to be". Each has one job; they must not compete.
+- **Navigation chrome is neutral at rest.** Footer launchers, session lens
+  rows, and the back-to-board action stay muted until selected. The selected
+  item uses the same inverted treatment (`bg-foreground text-background`), and
+  the lens rail keeps `aria-current` on the selected row.
 - **Pin the structure, flex the density.** Nothing appears or disappears at a
   count threshold. A control's position is fixed so it can be learned. The
   sidebar has no collapse rail. Overview stays board-only. Inside a session,

--- a/apps/desktop/src/app/components/AppFooter/index.test.tsx
+++ b/apps/desktop/src/app/components/AppFooter/index.test.tsx
@@ -84,7 +84,7 @@ describe('AppFooter', () => {
     expect(onOpenImpact).toHaveBeenCalledOnce();
   });
 
-  it('tints each studio button and keeps the active one inverted', () => {
+  it('keeps studio buttons muted at rest and keeps the active one inverted', () => {
     render(
       <AppFooter
         activeStudio="impact"
@@ -110,7 +110,8 @@ describe('AppFooter', () => {
       name: 'see how orchestration changed the way this workspace works',
     });
 
-    expect(budget.className).toContain('text-warning');
+    expect(budget.className).toContain('text-muted-foreground');
+    expect(budget.className).not.toContain('text-warning');
     expect(impact.className).toContain('bg-foreground text-background');
     expect(impact.className).not.toContain('text-success');
   });

--- a/apps/desktop/src/app/components/AppFooter/index.tsx
+++ b/apps/desktop/src/app/components/AppFooter/index.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { cn, Divider, StatusDot, tintClasses, type Tone } from '@goodboy/ui';
+import { cn, Divider, StatusDot } from '@goodboy/ui';
 import { FolderGit2 } from 'lucide-react';
 import { useAppStore } from '../../../store';
 import { IntegrationGlyph } from '../../../features/integrations/components/IntegrationGlyph';
@@ -14,7 +14,6 @@ type FooterButtonProps = {
   pulse?: boolean;
   active?: boolean;
   connected?: boolean;
-  tone?: Tone;
 };
 
 const FooterButton = ({
@@ -25,7 +24,6 @@ const FooterButton = ({
   pulse,
   active,
   connected,
-  tone,
 }: FooterButtonProps) => (
   <button
     type="button"
@@ -38,10 +36,7 @@ const FooterButton = ({
         ? 'bg-foreground text-background'
         : pulse
           ? 'animate-soft-pulse text-info hover:bg-info/10'
-          : cn(
-              tone == null ? 'text-muted-foreground hover:text-foreground' : tintClasses(tone).text,
-              'hover:bg-muted/50',
-            ),
+          : 'text-muted-foreground hover:bg-muted/50 hover:text-foreground',
       connected === false && 'opacity-40',
     )}
   >
@@ -107,7 +102,7 @@ export const AppFooter = ({
           ) : (
             <>
               <FooterButton
-                icon={<IntegrationGlyph provider="github" size="xs" />}
+                icon={<IntegrationGlyph provider="github" size="xs" useBrandColor={false} />}
                 label="GitHub"
                 title={
                   githubEnabled
@@ -119,7 +114,7 @@ export const AppFooter = ({
                 connected={githubEnabled}
               />
               <FooterButton
-                icon={<IntegrationGlyph provider="gitlab" size="xs" />}
+                icon={<IntegrationGlyph provider="gitlab" size="xs" useBrandColor={false} />}
                 label="GitLab"
                 title={gitlabEnabled ? 'launch a session from a GitLab issue' : 'Connect GitLab'}
                 onClick={onOpenGitlab}
@@ -129,7 +124,7 @@ export const AppFooter = ({
             </>
           )}
           <FooterButton
-            icon={<IntegrationGlyph provider="linear" size="xs" />}
+            icon={<IntegrationGlyph provider="linear" size="xs" useBrandColor={false} />}
             label="Linear"
             title={linearEnabled ? 'launch a session from a Linear issue' : 'Connect Linear'}
             onClick={onOpenLinear}
@@ -138,7 +133,7 @@ export const AppFooter = ({
           />
           {isSimpleWorkspace ? null : (
             <FooterButton
-              icon={<IntegrationGlyph provider="sentry" size="xs" />}
+              icon={<IntegrationGlyph provider="sentry" size="xs" useBrandColor={false} />}
               label="Sentry"
               title={sentryEnabled ? 'launch a session from a Sentry issue' : 'Connect Sentry'}
               onClick={onOpenSentry}
@@ -157,7 +152,6 @@ export const AppFooter = ({
             title="open the workflow library for this workspace"
             onClick={onOpenWorkflows}
             active={activeStudio === 'workflow'}
-            tone="primary"
           />
           <FooterButton
             icon={<CONCEPT_ICONS.providers size={12} aria-hidden />}
@@ -166,7 +160,6 @@ export const AppFooter = ({
             onClick={onOpenProviders}
             pulse={noProviderConnected && activeStudio !== 'provider'}
             active={activeStudio === 'provider'}
-            tone="info"
           />
           <FooterButton
             icon={<CONCEPT_ICONS.budget size={12} aria-hidden />}
@@ -174,7 +167,6 @@ export const AppFooter = ({
             title="open budget studio"
             onClick={onOpenBudget}
             active={activeStudio === 'budget'}
-            tone="warning"
           />
           <FooterButton
             icon={<CONCEPT_ICONS.impact size={12} aria-hidden />}
@@ -182,7 +174,6 @@ export const AppFooter = ({
             title="see how orchestration changed the way this workspace works"
             onClick={onOpenImpact}
             active={activeStudio === 'impact'}
-            tone="success"
           />
         </div>
       </div>

--- a/apps/desktop/src/features/integrations/components/IntegrationGlyph/index.tsx
+++ b/apps/desktop/src/features/integrations/components/IntegrationGlyph/index.tsx
@@ -24,9 +24,15 @@ type Props = {
   readonly provider: IntegrationGlyphProvider;
   readonly size?: number | 'xs' | 'sm';
   readonly className?: string;
+  readonly useBrandColor?: boolean;
 };
 
-export const IntegrationGlyph = ({ provider, size = 'sm', className }: Props) => {
+export const IntegrationGlyph = ({
+  provider,
+  size = 'sm',
+  className,
+  useBrandColor = true,
+}: Props) => {
   const brand = INTEGRATION_BRAND[provider];
   return (
     <BrandGlyph
@@ -35,6 +41,7 @@ export const IntegrationGlyph = ({ provider, size = 'sm', className }: Props) =>
       size={size}
       className={className}
       label={brand.label}
+      useBrandColor={useBrandColor}
     />
   );
 };

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn/index.test.tsx
@@ -156,6 +156,29 @@ describe('LensColumn', () => {
     expect(onSelectOverview).toHaveBeenCalledOnce();
   });
 
+  it('uses one active style and keeps inactive rows muted', () => {
+    render(
+      <LensColumn
+        session={SESSION}
+        activeLens="agents"
+        onSelectOverview={vi.fn()}
+        onSelect={vi.fn()}
+        filesCount={0}
+      />,
+    );
+
+    const agents = screen.getByRole('button', { name: 'Agents' });
+    const workflows = screen.getByRole('button', { name: 'Workflows' });
+    const decisions = screen.getByRole('button', { name: 'Decisions' });
+
+    expect(agents.getAttribute('aria-current')).toBe('page');
+    expect(agents.className).toContain('bg-foreground text-background');
+    expect(workflows.getAttribute('aria-current')).toBeNull();
+    expect(workflows.className).toContain('text-muted-foreground');
+    expect(workflows.className).not.toContain('bg-foreground text-background');
+    expect(decisions.querySelector('span')?.className).not.toContain('text-success');
+  });
+
   it('marks a disconnected integration and leaves connected ones unmarked', () => {
     const { container } = render(
       <LensColumn

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn/index.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { LayoutDashboard, Unplug } from 'lucide-react';
-import { Divider, KbdPill, ScrollFade, Skeleton, StatusDot, cn, tintClasses } from '@goodboy/ui';
+import { Divider, KbdPill, ScrollFade, Skeleton, StatusDot, cn } from '@goodboy/ui';
 import type { Agent, Session, SessionId } from '@goodboy/types';
 import { classifyAgent, isStandaloneAgent } from '../../../../agent-kind';
 import { isPrReviewSession } from '../../../../../../store/slices/session-view';
@@ -247,11 +247,11 @@ export const LensColumn = ({
               'group relative flex items-center gap-2.5 rounded-md px-2 py-1.5 text-left transition-colors',
               'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]',
               activeLens === null
-                ? 'bg-foreground/[0.06] text-foreground'
-                : 'text-muted-foreground hover:bg-foreground/[0.03] hover:text-foreground',
+                ? 'bg-foreground text-background'
+                : 'text-muted-foreground hover:bg-muted/50 hover:text-foreground',
             )}
           >
-            <span className="flex w-5 flex-none items-center justify-center text-muted-foreground transition-colors">
+            <span className="flex w-5 flex-none items-center justify-center transition-colors">
               <LayoutDashboard size={14} aria-hidden />
             </span>
             <span
@@ -302,23 +302,18 @@ export const LensColumn = ({
                         'group relative flex items-center gap-2.5 rounded-md px-2 py-1.5 text-left transition-colors',
                         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]',
                         active
-                          ? 'bg-foreground/[0.06] text-foreground'
-                          : 'text-muted-foreground hover:bg-foreground/[0.03] hover:text-foreground',
+                          ? 'bg-foreground text-background'
+                          : 'text-muted-foreground hover:bg-muted/50 hover:text-foreground',
                         row.isConnected === false && 'opacity-40 hover:opacity-70',
                       )}
                     >
                       {row.glyph != null ? (
                         <span className="flex w-5 flex-none items-center justify-center transition-colors">
-                          <IntegrationGlyph provider={row.glyph} size={14} />
+                          <IntegrationGlyph provider={row.glyph} size={14} useBrandColor={false} />
                         </span>
                       ) : null}
                       {row.glyph == null && row.icon != null ? (
-                        <span
-                          className={cn(
-                            'flex w-5 flex-none items-center justify-center transition-colors',
-                            tintClasses(row.tone).icon,
-                          )}
-                        >
+                        <span className="flex w-5 flex-none items-center justify-center transition-colors">
                           <row.icon size={14} aria-hidden />
                         </span>
                       ) : null}

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.test.tsx
@@ -1,8 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, render, screen } from '@testing-library/react';
-import type { Workspace, WorkspaceId } from '@goodboy/types';
+import type { Session, Workspace, WorkspaceId } from '@goodboy/types';
 
-const { state, currentWorkspace } = vi.hoisted(() => ({
+const { state, currentWorkspace, currentSessionRef } = vi.hoisted(() => ({
   state: {
     workspaceIntegrations: {} as Record<string, ReadonlyArray<unknown>>,
     archivedSessions: {} as Record<string, ReadonlyArray<unknown>>,
@@ -11,12 +11,13 @@ const { state, currentWorkspace } = vi.hoisted(() => ({
     loadArchivedSessions: vi.fn(),
   },
   currentWorkspace: { id: 'ws-1' as WorkspaceId, name: 'Test WS' } as Workspace,
+  currentSessionRef: { value: null as Session | null },
 }));
 
 vi.mock('../../../../store', () => ({
   useAppStore: <T,>(selector: (s: typeof state) => T) => selector(state),
   useCurrentWorkspace: () => currentWorkspace,
-  useCurrentSession: () => null,
+  useCurrentSession: () => currentSessionRef.value,
   useSessions: () => [],
   useWorkspaces: () => [currentWorkspace],
   useSessionLoading: () => false,
@@ -34,7 +35,17 @@ afterEach(cleanup);
 import { WorkspacesSidebar } from './index';
 
 describe('WorkspacesSidebar', () => {
+  it('uses the shared active navigation style for back to board', () => {
+    currentSessionRef.value = { id: 'session-1' } as Session;
+    render(<WorkspacesSidebar />);
+    const back = screen.getByRole('button', { name: 'back to board' });
+    expect(back.className).toContain('bg-foreground text-background');
+    expect(back.className).not.toContain('text-accent');
+    currentSessionRef.value = null;
+  });
+
   it('renders without crashing when workspace is selected', () => {
+    currentSessionRef.value = null;
     render(<WorkspacesSidebar />);
     expect(screen.queryByRole('button', { name: /collapse sidebar/i })).toBeNull();
   });

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useState } from 'react';
 import { Kanban } from 'lucide-react';
-import { KbdPill } from '@goodboy/ui';
+import { KbdPill, cn, tintClasses } from '@goodboy/ui';
 import type { Session, SessionId } from '@goodboy/types';
 import {
   EMPTY_ARRAY,
@@ -25,6 +25,7 @@ export const WorkspacesSidebar = () => {
     [setCurrentSession],
   );
   const [addWorkspaceOpen, setAddWorkspaceOpen] = useState(false);
+  const neutralTint = tintClasses('neutral');
 
   const archivedSessions = useAppStore((s) =>
     currentWorkspace ? (s.archivedSessions[currentWorkspace.id] ?? EMPTY_ARRAY) : EMPTY_ARRAY,
@@ -45,7 +46,13 @@ export const WorkspacesSidebar = () => {
             type="button"
             onClick={() => void setCurrentSession(null)}
             aria-label="back to board"
-            className="group relative w-full flex items-center justify-center gap-1.5 rounded-md bg-accent/10 px-2 py-1.5 text-xs font-semibold text-accent ring-1 ring-accent/20 motion-safe:transition-colors hover:bg-accent/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
+            className={cn(
+              'group relative w-full flex items-center justify-center gap-1.5 rounded-md px-2 py-1.5 text-xs font-semibold',
+              'bg-foreground text-background ring-1',
+              neutralTint.ring,
+              'motion-safe:transition-opacity hover:opacity-90',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]',
+            )}
           >
             <Kanban size={14} aria-hidden />
             Board

--- a/apps/desktop/src/shared/components/BrandGlyph/index.tsx
+++ b/apps/desktop/src/shared/components/BrandGlyph/index.tsx
@@ -14,9 +14,17 @@ type Props = {
   readonly size?: Size;
   readonly className?: string;
   readonly label?: string;
+  readonly useBrandColor?: boolean;
 };
 
-export const BrandGlyph = ({ icon: Icon, cssVar, size = 'sm', className, label }: Props) => {
+export const BrandGlyph = ({
+  icon: Icon,
+  cssVar,
+  size = 'sm',
+  className,
+  label,
+  useBrandColor = true,
+}: Props) => {
   const color = `var(${cssVar})`;
   const glyphSize = typeof size === 'string' ? MARK_SIZE[size] : size;
 
@@ -27,7 +35,7 @@ export const BrandGlyph = ({ icon: Icon, cssVar, size = 'sm', className, label }
       aria-label={label}
       aria-hidden={label == null ? true : undefined}
       className={cn('shrink-0', className)}
-      style={{ color }}
+      style={useBrandColor ? { color } : undefined}
     />
   );
 };

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -128,13 +128,15 @@ Layout:
 
 - Left: integration tools (GitHub, GitLab, Linear, Sentry), each gated by
   enablement.
-- Right: common studios (workflows, providers, budget, impact), each with its
-  own tone (`primary`, `info`, `warning`, `success` respectively) applied to
-  its icon and label while inactive.
+- Right: common studios (workflows, providers, budget, impact).
 
-Studio buttons show an inverted active state (`bg-foreground text-background`
-with a transition) when their studio is open. Opening any studio closes the
-others (`closeAllStudios` in `App.tsx`).
+Navigation chrome stays muted while inactive across footer launchers, session
+lens rows, and the back-to-board action in the workspace sidebar.
+
+The active navigation item uses one inverted state
+(`bg-foreground text-background`) across those surfaces. Lens rows keep
+`aria-current="page"` on the active row. Opening any studio closes the others
+(`closeAllStudios` in `App.tsx`).
 
 ## Board-only Overview and animated sidebar
 


### PR DESCRIPTION
Stacked on #1140.

## What

1. **One active convention.** The footer inverted completely (`bg-foreground text-background`), the
   lens rail used a 6% tint plus `aria-current="page"`, and the workspaces sidebar wrote its own accent
   classes by hand. All three now use the inversion, and the rail keeps `aria-current` because that is
   the part assistive technology actually reads.
2. **Navigation is neutral at rest.** The footer's four launchers were tinted by tone at rest while
   the four integration entries next to them were not, and every lens row tinted its icon by a tone
   from `groups.ts`. That colour carried no information: a lens does not become urgent because its row
   is green. Colour now appears on the selected item and nowhere else in nav.
3. **`WorkspacesSidebar` goes through `tintClasses`** like everything else.

## The line between tone and decoration

Everything that communicates state keeps its colour: status dots, session stage, alerts, budget
warnings, running indicators, the attention tone on a card action. The test used was whether the tone
would ever change while nothing about the user's work changed. A lens row's tone never changes, so it
was decoration.

## DESIGN.md

Amended in the same commit, so the convention is written down rather than inferred from three
implementations that disagreed.

## Verified

`pnpm -w typecheck` and the desktop suite green (3653 tests). New coverage: an active item in each of
the three surfaces renders the one convention, an inactive one does not, and the rail still exposes
`aria-current="page"`.