### PR TITLE
refactor(desktop): one failure, one place, with the retry on it

### DIFF
--- a/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
+++ b/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
@@ -1626,11 +1626,11 @@ exports[`snapshot, error states > NewSessionView: form error 1`] = `
 
 exports[`snapshot, error states > TranscriptCard: turn error item 1`] = `
 <div
-  class="flex w-full items-start gap-2 text-xs"
+  class="flex w-full items-start gap-2 rounded-md border px-2.5 py-2 text-xs border-danger/20 bg-danger/5"
 >
   <svg
     aria-hidden="true"
-    class="lucide lucide-circle-alert shrink-0 translate-y-0.5 text-danger"
+    class="lucide lucide-circle-alert mt-0.5 shrink-0 text-danger"
     data-testid="transcript-error-icon"
     fill="none"
     height="12"
@@ -1660,10 +1660,14 @@ exports[`snapshot, error states > TranscriptCard: turn error item 1`] = `
       y2="16"
     />
   </svg>
-  <span
-    class="min-w-0 break-words text-danger"
+  <div
+    class="flex min-w-0 flex-1 flex-col gap-1"
   >
-    provider failed to respond
-  </span>
+    <p
+      class="min-w-0 break-words leading-relaxed text-danger"
+    >
+      provider failed to respond
+    </p>
+  </div>
 </div>
 `;

--- a/apps/desktop/src/features/chat/components/ChatInput/hooks/useTurnDispatch.ts
+++ b/apps/desktop/src/features/chat/components/ChatInput/hooks/useTurnDispatch.ts
@@ -2,6 +2,7 @@ import { useCallback, useState } from 'react';
 import type { AgentId, SessionId, TurnProviderOverride } from '@goodboy/types';
 import { useAppStore } from '../../../../../store';
 import { formatError } from '../../../../../shared/lib/errors';
+import { isTranscriptOwnedTurnError } from '../../../turn-errors';
 import { toAttachmentInput } from '../lib';
 import type { PendingAttachment, QueuedTurn } from '../lib';
 
@@ -10,7 +11,7 @@ type UseTurnDispatchArgs = {
   readonly cleanupSentAttachments: (atts: ReadonlyArray<PendingAttachment>) => void;
 };
 
-export function useTurnDispatch({ sessionId, cleanupSentAttachments }: UseTurnDispatchArgs) {
+export const useTurnDispatch = ({ sessionId, cleanupSentAttachments }: UseTurnDispatchArgs) => {
   const sendTurn = useAppStore((s) => s.sendTurn);
 
   const [error, setError] = useState<string | null>(null);
@@ -34,6 +35,11 @@ export function useTurnDispatch({ sessionId, cleanupSentAttachments }: UseTurnDi
         setLastFailedTurn(null);
         cleanupSentAttachments(atts);
       } catch (err) {
+        if (isTranscriptOwnedTurnError({ error: err })) {
+          setError(null);
+          setLastFailedTurn(null);
+          return;
+        }
         setError(formatError(err));
         setLastFailedTurn({ agentId, content, attachments: atts, override });
       }
@@ -42,4 +48,4 @@ export function useTurnDispatch({ sessionId, cleanupSentAttachments }: UseTurnDi
   );
 
   return { dispatchTurn, error, setError, lastFailedTurn, setLastFailedTurn };
-}
+};

--- a/apps/desktop/src/features/chat/components/ChatInput/index.test.tsx
+++ b/apps/desktop/src/features/chat/components/ChatInput/index.test.tsx
@@ -334,6 +334,39 @@ describe('ChatInput, input wiring', () => {
     expect(sendTurnMock).toHaveBeenCalledWith(expect.objectContaining({ content: 'hi there' }));
   });
 
+  it('shows a composer alert with retry when sendTurn fails before transcript append', async () => {
+    sendTurnMock.mockRejectedValueOnce(new Error('session not found: session-1'));
+    const user = userEvent.setup();
+    render(<ChatInput session={makeSession()} />);
+
+    const textarea = screen.getByRole('textbox');
+    await user.type(textarea, 'hello');
+    await user.keyboard('{Enter}');
+
+    expect(await screen.findByRole('alert')).toBeTruthy();
+    expect(screen.getByText('session not found: session-1')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'retry' })).toBeTruthy();
+  });
+
+  it('suppresses the composer alert for transcript-owned stream failures', async () => {
+    sendTurnMock.mockRejectedValueOnce(
+      Object.assign(new Error('connection reset by peer'), {
+        code: 'TRANSCRIPT_OWNED_TURN_ERROR',
+      }),
+    );
+    const user = userEvent.setup();
+    render(<ChatInput session={makeSession()} />);
+
+    const textarea = screen.getByRole('textbox');
+    await user.type(textarea, 'hello');
+    await user.keyboard('{Enter}');
+
+    await waitFor(() => {
+      expect(sendTurnMock).toHaveBeenCalledOnce();
+    });
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+
   it('does not leak a stale session model into an agent without a model pin', async () => {
     const setSessionConfig = vi.fn(async () => undefined);
     mockStore.setState({ setSessionConfig });

--- a/apps/desktop/src/features/chat/components/ChatInput/index.tsx
+++ b/apps/desktop/src/features/chat/components/ChatInput/index.tsx
@@ -27,6 +27,7 @@ import { useSuggestionCards } from './hooks/useSuggestionCards';
 import { AttachmentChip } from './parts/AttachmentChip';
 import { QueuedMessages } from './parts/QueuedMessages';
 import { SuggestionStack } from './parts/SuggestionStack';
+import { TurnErrorCallout } from '../TurnErrorCallout';
 
 type Props = {
   readonly session: Session;
@@ -522,28 +523,28 @@ export const ChatInput = ({ session, providerDisconnected = false }: Props) => {
           </div>
         </div>
         {dispatch.error ? (
-          <div role="alert" className="flex items-center gap-2">
-            <p className="flex-1 text-xs text-danger">{dispatch.error}</p>
-            {dispatch.lastFailedTurn !== null && (
-              <button
-                type="button"
-                onClick={() => {
-                  const failed = dispatch.lastFailedTurn;
-                  if (!failed) return;
-                  dispatch.setError(null);
-                  void dispatch.dispatchTurn(
-                    failed.content,
-                    failed.attachments,
-                    failed.override,
-                    failed.agentId,
-                  );
-                }}
-                className="shrink-0 rounded border border-danger/30 bg-danger/5 px-2 py-0.5 text-xs font-medium text-danger hover:bg-danger/15"
-              >
-                retry
-              </button>
-            )}
-          </div>
+          <TurnErrorCallout
+            role="alert"
+            message={dispatch.error}
+            retryAction={
+              dispatch.lastFailedTurn != null
+                ? {
+                    label: 'retry',
+                    onClick: () => {
+                      const failed = dispatch.lastFailedTurn;
+                      if (!failed) return;
+                      dispatch.setError(null);
+                      void dispatch.dispatchTurn(
+                        failed.content,
+                        failed.attachments,
+                        failed.override,
+                        failed.agentId,
+                      );
+                    },
+                  }
+                : undefined
+            }
+          />
         ) : null}
       </div>
     </div>

--- a/apps/desktop/src/features/chat/components/ChatView/ParallelColumn.tsx
+++ b/apps/desktop/src/features/chat/components/ChatView/ParallelColumn.tsx
@@ -4,6 +4,7 @@ import type { Agent, ProviderRunId } from '@goodboy/types';
 import { Divider, ScrollFade, StatusDot } from '@goodboy/ui';
 import { useAppStore, useTranscript } from '../../../../store';
 import { filterEventsByRunId, reduceTranscript } from '../../utils/transcript-items';
+import type { TranscriptItem } from '../../utils/transcript-items';
 import { clusterOperations } from '../../utils/cluster-operations';
 import { inferAgentKindFromName } from '../../../session/agent-kind';
 import { AgentAvatar } from '../../../../shared/components/AgentAvatar';
@@ -18,6 +19,8 @@ type Props = {
   readonly workingDir: string | null;
   readonly onRefreshAuth: () => void;
   readonly onOpenDiff: (filePath: string) => void;
+  readonly onRetryError?: (item: Extract<TranscriptItem, { kind: 'error' }>) => void;
+  readonly retryingErrorRunId?: ProviderRunId | null;
 };
 
 export const ParallelColumn = ({
@@ -27,6 +30,8 @@ export const ParallelColumn = ({
   workingDir,
   onRefreshAuth,
   onOpenDiff,
+  onRetryError,
+  retryingErrorRunId = null,
 }: Props) => {
   const columnEvents = useMemo(() => filterEventsByRunId(events, runId), [events, runId]);
   const items = useMemo(() => reduceTranscript(columnEvents), [columnEvents]);
@@ -85,6 +90,8 @@ export const ParallelColumn = ({
                       workingDir={workingDir}
                       onRefreshAuth={onRefreshAuth}
                       onOpenDiff={onOpenDiff}
+                      onRetryError={onRetryError}
+                      retryingErrorRunId={retryingErrorRunId}
                     />
                   ) : (
                     <TranscriptCard
@@ -94,6 +101,8 @@ export const ParallelColumn = ({
                       workingDir={workingDir}
                       onRefreshAuth={onRefreshAuth}
                       onOpenDiff={onOpenDiff}
+                      onRetryError={onRetryError}
+                      retryingErrorRunId={retryingErrorRunId}
                     />
                   )}
                 </li>

--- a/apps/desktop/src/features/chat/components/ChatView/TranscriptRows.test.tsx
+++ b/apps/desktop/src/features/chat/components/ChatView/TranscriptRows.test.tsx
@@ -26,6 +26,8 @@ vi.mock('./OpenQuestionCluster', () => ({
 
 import { TranscriptRows } from './TranscriptRows';
 
+const retryErrorSpy = vi.fn();
+
 const itemRow = (item: TranscriptItem): TranscriptRow => ({ kind: 'item', key: item.key, item });
 
 const userText = (key: string, at: Date): TranscriptItem => ({
@@ -51,6 +53,8 @@ const renderRows = (
         onOpenDiff={() => undefined}
         isThinking={false}
         thinkingContext="think"
+        onRetryError={retryErrorSpy}
+        retryingErrorRunId={null}
       />
     </ul>,
   );

--- a/apps/desktop/src/features/chat/components/ChatView/TranscriptRows.tsx
+++ b/apps/desktop/src/features/chat/components/ChatView/TranscriptRows.tsx
@@ -1,7 +1,8 @@
 import type { ReactNode } from 'react';
-import type { AgentId, OpenQuestion, SessionId } from '@goodboy/types';
+import type { AgentId, OpenQuestion, ProviderRunId, SessionId } from '@goodboy/types';
 import type { TranscriptRow } from '../../utils/cluster-operations';
 import type { ThinkingContext } from '../../utils/thinking-context';
+import type { TranscriptItem } from '../../utils/transcript-items';
 import { OperationsCluster } from '../OperationsCluster';
 import { ThinkingIndicator } from '../ThinkingIndicator';
 import { TranscriptCard } from '../TranscriptCards';
@@ -19,6 +20,8 @@ type Props = {
   onOpenDiff: (filePath: string) => void;
   isThinking: boolean;
   thinkingContext: ThinkingContext;
+  onRetryError: (item: Extract<TranscriptItem, { kind: 'error' }>) => void;
+  retryingErrorRunId: ProviderRunId | null;
 };
 
 export const TranscriptRows = ({
@@ -31,6 +34,8 @@ export const TranscriptRows = ({
   onOpenDiff,
   isThinking,
   thinkingContext,
+  onRetryError,
+  retryingErrorRunId,
 }: Props) => {
   const out: ReactNode[] = [];
   let lastDay: string | null = null;
@@ -108,6 +113,8 @@ export const TranscriptRows = ({
           workingDir={workingDir}
           onRefreshAuth={onRefreshAuth}
           onOpenDiff={onOpenDiff}
+          onRetryError={onRetryError}
+          retryingErrorRunId={retryingErrorRunId}
         />,
       );
       return;
@@ -123,6 +130,8 @@ export const TranscriptRows = ({
             workingDir={workingDir}
             onRefreshAuth={onRefreshAuth}
             onOpenDiff={onOpenDiff}
+            onRetryError={onRetryError}
+            retryingErrorRunId={retryingErrorRunId}
           />
         ) : (
           <TranscriptCard
@@ -132,6 +141,8 @@ export const TranscriptRows = ({
             workingDir={workingDir}
             onRefreshAuth={onRefreshAuth}
             onOpenDiff={onOpenDiff}
+            onRetryError={onRetryError}
+            retryingErrorRunId={retryingErrorRunId}
           />
         )}
       </li>,

--- a/apps/desktop/src/features/chat/components/ChatView/index.tsx
+++ b/apps/desktop/src/features/chat/components/ChatView/index.tsx
@@ -11,7 +11,17 @@ import {
 import type { ReactNode } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { ArrowDown } from 'lucide-react';
-import type { AgentId, OpenQuestion, ProviderRunId, Session } from '@goodboy/types';
+import type {
+  AgentId,
+  AttachmentInput,
+  MessageAttachment,
+  OpenQuestion,
+  ProviderId,
+  ProviderRunId,
+  Session,
+  TurnEvent,
+  TurnProviderOverride,
+} from '@goodboy/types';
 import { Divider, ScrollFade } from '@goodboy/ui';
 import {
   EMPTY_ARRAY,
@@ -22,6 +32,7 @@ import {
   useTranscript,
 } from '../../../../store';
 import { detectParallelRunIds, reduceTranscript } from '../../utils/transcript-items';
+import type { TranscriptItem } from '../../utils/transcript-items';
 import { clusterOperations } from '../../utils/cluster-operations';
 import { classifyThinkingContext } from '../../utils/thinking-context';
 import { AuthRequiredCallout } from '../AuthRequiredCallout';
@@ -41,10 +52,11 @@ import { ClusterProgressDashboard } from './ClusterProgressDashboard';
 import { selectClusterDashboard } from './clusterDashboard';
 import { ParallelColumn } from './ParallelColumn';
 import { TranscriptRows } from './TranscriptRows';
-import { useTranscriptErrorToasts } from '../../hooks/useTranscriptErrorToasts';
 import { useScrollPin } from './useScrollPin';
 import { TranscriptSkeleton } from './parts/TranscriptSkeleton';
 import { resolveSessionRepo } from '../../../../store/slices/worktrees/resolveSessionRepo';
+import { readAttachment } from '../../turn';
+import { dataUrlToBase64 } from '../ChatInput/lib';
 
 type Props = {
   readonly session: Session;
@@ -54,13 +66,90 @@ type Props = {
 
 const TERMINAL_STATUSES = new Set(['completed', 'failed', 'cancelled']);
 
+type RetrySource = {
+  readonly content: string;
+  readonly attachments: ReadonlyArray<MessageAttachment>;
+  readonly provider?: ProviderId;
+  readonly model?: string;
+};
+
+type RetrySourceParams = {
+  readonly events: ReadonlyArray<TurnEvent>;
+  readonly runId: ProviderRunId;
+};
+
+type RetryAttachmentsParams = {
+  readonly worktreePath: string | null;
+  readonly attachments: ReadonlyArray<MessageAttachment>;
+};
+
+type RetryOverrideParams = {
+  readonly provider?: ProviderId;
+  readonly model?: string;
+};
+
+const findRetrySource = ({ events, runId }: RetrySourceParams): RetrySource | null => {
+  for (let i = events.length - 1; i >= 0; i -= 1) {
+    const event = events[i];
+    if (event?.kind !== 'user_text') {
+      continue;
+    }
+    if (event.runId !== runId) {
+      continue;
+    }
+    return {
+      content: event.text,
+      attachments: event.attachments ?? [],
+      provider: event.provider,
+      model: event.model,
+    };
+  }
+  return null;
+};
+
+const readRetryAttachments = async ({
+  worktreePath,
+  attachments,
+}: RetryAttachmentsParams): Promise<ReadonlyArray<AttachmentInput>> => {
+  if (worktreePath == null || attachments.length === 0) {
+    return [];
+  }
+  const out: AttachmentInput[] = [];
+  for (const attachment of attachments) {
+    try {
+      const dataUrl = await readAttachment(worktreePath, attachment.relPath);
+      out.push({
+        id: attachment.id,
+        fileName: attachment.fileName,
+        mimeType: attachment.mimeType,
+        dataBase64: dataUrlToBase64(dataUrl),
+      });
+    } catch {}
+  }
+  return out;
+};
+
+const buildRetryOverride = ({
+  provider,
+  model,
+}: RetryOverrideParams): TurnProviderOverride | undefined => {
+  if (provider == null) {
+    return undefined;
+  }
+  return {
+    providerId: provider,
+    ...(model != null ? { model } : {}),
+  };
+};
+
 export const ChatView = ({ session, isActive = true, header }: Props) => {
   const selectedAgentId = useAppStore(
     (s) => s.selectedAgentId[session.id] ?? null,
   ) as AgentId | null;
+  const sendTurn = useAppStore((s) => s.sendTurn);
   const events = useTranscript(selectedAgentId);
   const items = useMemo(() => reduceTranscript(events), [events]);
-  useTranscriptErrorToasts({ items, sessionId: session.id, agentId: selectedAgentId });
+  const [retryingErrorRunId, setRetryingErrorRunId] = useState<ProviderRunId | null>(null);
   const taggedItems = useMemo(
     () => ({ agentId: selectedAgentId, items }),
     [selectedAgentId, items],
@@ -219,6 +308,38 @@ export const ChatView = ({ session, isActive = true, header }: Props) => {
   const handleRefreshAuth = useCallback(() => {
     void refreshProviders();
   }, [refreshProviders]);
+  const handleRetryError = useCallback(
+    async ({ item }: { item: Extract<TranscriptItem, { kind: 'error' }> }) => {
+      if (item.retryable !== true) {
+        return;
+      }
+      if (item.runId == null || selectedAgentId == null) {
+        return;
+      }
+      const source = findRetrySource({ events, runId: item.runId });
+      if (source == null) {
+        return;
+      }
+      setRetryingErrorRunId(item.runId);
+      try {
+        const attachments = await readRetryAttachments({
+          worktreePath,
+          attachments: source.attachments,
+        });
+        const override = buildRetryOverride({ provider: source.provider, model: source.model });
+        await sendTurn({
+          sessionId: session.id,
+          agentId: selectedAgentId,
+          content: source.content,
+          ...(attachments.length > 0 ? { attachments } : {}),
+          ...(override !== undefined ? { override } : {}),
+        });
+      } finally {
+        setRetryingErrorRunId(null);
+      }
+    },
+    [events, selectedAgentId, sendTurn, session.id, worktreePath],
+  );
 
   const openQuestions = useSessionOpenQuestions(session.id);
   const answeredQuestions = useSessionAnsweredQuestions(session.id);
@@ -376,6 +497,8 @@ export const ChatView = ({ session, isActive = true, header }: Props) => {
                 workingDir={worktreePath}
                 onRefreshAuth={() => void refreshProviders()}
                 onOpenDiff={handleOpenDiff}
+                onRetryError={(item) => void handleRetryError({ item })}
+                retryingErrorRunId={retryingErrorRunId}
               />
             </Fragment>
           ))}
@@ -490,6 +613,8 @@ export const ChatView = ({ session, isActive = true, header }: Props) => {
                 onOpenDiff={handleOpenDiff}
                 isThinking={isThinking}
                 thinkingContext={thinkingContext}
+                onRetryError={(item) => void handleRetryError({ item })}
+                retryingErrorRunId={retryingErrorRunId}
               />
             </ul>
           )}

--- a/apps/desktop/src/features/chat/components/OperationsCluster/index.tsx
+++ b/apps/desktop/src/features/chat/components/OperationsCluster/index.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 import { Layers } from 'lucide-react';
 import { cn, tintClasses } from '@goodboy/ui';
-import type { AgentId, SessionId } from '@goodboy/types';
+import type { AgentId, ProviderRunId, SessionId } from '@goodboy/types';
 import type { TranscriptItem } from '../../utils/transcript-items';
 import { formatDuration } from '../../utils/format-duration';
 import { useElapsedMs } from '../../hooks/useElapsedMs';
@@ -16,6 +16,8 @@ type Props = {
   readonly workingDir?: string | null;
   readonly onRefreshAuth?: () => void;
   readonly onOpenDiff?: (filePath: string) => void;
+  readonly onRetryError?: (item: Extract<TranscriptItem, { kind: 'error' }>) => void;
+  readonly retryingErrorRunId?: ProviderRunId | null;
 };
 
 const runningTool = (
@@ -42,6 +44,8 @@ export const OperationsCluster = ({
   workingDir = null,
   onRefreshAuth,
   onOpenDiff,
+  onRetryError,
+  retryingErrorRunId = null,
 }: Props) => {
   const [open, setOpen] = useState(false);
   const running = runningTool(items);
@@ -142,6 +146,8 @@ export const OperationsCluster = ({
           workingDir={workingDir}
           onRefreshAuth={onRefreshAuth}
           onOpenDiff={onOpenDiff}
+          onRetryError={onRetryError}
+          retryingErrorRunId={retryingErrorRunId}
         />
       ))}
     </TranscriptDisclosure>

--- a/apps/desktop/src/features/chat/components/TranscriptCards/TranscriptErrorRow.tsx
+++ b/apps/desktop/src/features/chat/components/TranscriptCards/TranscriptErrorRow.tsx
@@ -1,20 +1,23 @@
-import { CircleAlert } from 'lucide-react';
-import { cn, tintClasses } from '@goodboy/ui';
-
-const dangerTint = tintClasses('danger');
+import { TurnErrorCallout } from '../TurnErrorCallout';
 
 type Props = {
   readonly message: string;
+  readonly onRetry?: () => void;
+  readonly isRetrying?: boolean;
 };
 
-export const TranscriptErrorRow = ({ message }: Props) => (
-  <div className="flex w-full items-start gap-2 text-xs">
-    <CircleAlert
-      size={12}
-      aria-hidden
-      data-testid="transcript-error-icon"
-      className={cn('shrink-0 translate-y-0.5', dangerTint.icon)}
-    />
-    <span className={cn('min-w-0 break-words', dangerTint.text)}>{message}</span>
-  </div>
+export const TranscriptErrorRow = ({ message, onRetry, isRetrying = false }: Props) => (
+  <TurnErrorCallout
+    message={message}
+    iconTestId="transcript-error-icon"
+    retryAction={
+      onRetry != null
+        ? {
+            label: isRetrying ? 'retrying' : 'retry',
+            onClick: onRetry,
+            disabled: isRetrying === true,
+          }
+        : undefined
+    }
+  />
 );

--- a/apps/desktop/src/features/chat/components/TranscriptCards/index.test.tsx
+++ b/apps/desktop/src/features/chat/components/TranscriptCards/index.test.tsx
@@ -1,10 +1,13 @@
 // @vitest-environment happy-dom
 
-import { afterEach, describe, expect, it } from 'vitest';
-import { cleanup, render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ProviderRunId } from '@goodboy/types';
 import { TranscriptCard } from './index';
 
 afterEach(cleanup);
+const runId = 'run-1' as ProviderRunId;
 
 describe('TranscriptCard', () => {
   it('renders nothing for a run completion', () => {
@@ -15,5 +18,64 @@ describe('TranscriptCard', () => {
   it('renders no separator for a run completion', () => {
     const { container } = render(<TranscriptCard item={{ kind: 'done', key: 'done-1' }} />);
     expect(container.querySelectorAll('[role="separator"]')).toHaveLength(0);
+  });
+
+  it('renders retry in the transcript for retryable errors', async () => {
+    const user = userEvent.setup();
+    const onRetryError = vi.fn();
+    render(
+      <TranscriptCard
+        item={{
+          kind: 'error',
+          key: 'error-1',
+          message: 'provider crashed mid-stream',
+          runId,
+          retryable: true,
+        }}
+        onRetryError={onRetryError}
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: 'retry' }));
+    expect(onRetryError).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'error', key: 'error-1', runId, retryable: true }),
+    );
+  });
+
+  it('does not render retry for non-retryable transcript errors', () => {
+    render(
+      <TranscriptCard
+        item={{
+          kind: 'error',
+          key: 'error-1',
+          message:
+            'provider exited without a response. check that the CLI is configured correctly.',
+          runId,
+          retryable: false,
+        }}
+      />,
+    );
+    expect(screen.queryByRole('button', { name: 'retry' })).toBeNull();
+  });
+
+  it('truncates long transcript errors and reveals full text on demand', async () => {
+    const user = userEvent.setup();
+    const longMessage =
+      'provider stderr: ' +
+      'x'.repeat(320) +
+      ' this tail should only be visible after expanding the full error body';
+    render(
+      <TranscriptCard
+        item={{
+          kind: 'error',
+          key: 'error-long',
+          message: longMessage,
+          runId,
+          retryable: false,
+        }}
+      />,
+    );
+    expect(screen.queryByText(longMessage)).toBeNull();
+    await user.click(screen.getByRole('button', { name: 'show full error' }));
+    expect(screen.getByText(longMessage)).toBeTruthy();
   });
 });

--- a/apps/desktop/src/features/chat/components/TranscriptCards/index.tsx
+++ b/apps/desktop/src/features/chat/components/TranscriptCards/index.tsx
@@ -1,5 +1,5 @@
 import { memo } from 'react';
-import type { AgentId, SessionId } from '@goodboy/types';
+import type { AgentId, ProviderRunId, SessionId } from '@goodboy/types';
 import type { TranscriptItem } from '../../utils/transcript-items';
 import { AuthRequiredCallout } from '../AuthRequiredCallout';
 import { SkillInvocationCard } from '../SkillInvocationCard';
@@ -22,6 +22,8 @@ type TranscriptCardProps = {
   readonly workingDir?: string | null;
   readonly onRefreshAuth?: () => void;
   readonly onOpenDiff?: (filePath: string) => void;
+  readonly onRetryError?: (item: Extract<TranscriptItem, { kind: 'error' }>) => void;
+  readonly retryingErrorRunId?: ProviderRunId | null;
 };
 
 function TranscriptCardImpl({
@@ -31,6 +33,8 @@ function TranscriptCardImpl({
   workingDir = null,
   onRefreshAuth,
   onOpenDiff,
+  onRetryError,
+  retryingErrorRunId = null,
 }: TranscriptCardProps) {
   switch (item.kind) {
     case 'user_text':
@@ -60,7 +64,17 @@ function TranscriptCardImpl({
     case 'usage':
       return <UsageRow usage={item.usage} />;
     case 'error':
-      return <TranscriptErrorRow message={item.message} />;
+      return (
+        <TranscriptErrorRow
+          message={item.message}
+          onRetry={
+            item.retryable === true && onRetryError != null ? () => onRetryError(item) : undefined
+          }
+          isRetrying={
+            item.runId != null && retryingErrorRunId != null && item.runId === retryingErrorRunId
+          }
+        />
+      );
     case 'auth_required':
       return (
         <AuthRequiredCallout
@@ -112,5 +126,7 @@ export const TranscriptCard = memo(
     prev.agentId === next.agentId &&
     prev.workingDir === next.workingDir &&
     prev.onRefreshAuth === next.onRefreshAuth &&
-    prev.onOpenDiff === next.onOpenDiff,
+    prev.onOpenDiff === next.onOpenDiff &&
+    prev.onRetryError === next.onRetryError &&
+    prev.retryingErrorRunId === next.retryingErrorRunId,
 );

--- a/apps/desktop/src/features/chat/components/TurnErrorCallout/index.tsx
+++ b/apps/desktop/src/features/chat/components/TurnErrorCallout/index.tsx
@@ -1,0 +1,96 @@
+import { useMemo, useState } from 'react';
+import { CircleAlert } from 'lucide-react';
+import { cn, tintClasses } from '@goodboy/ui';
+
+const MAX_INLINE_ERROR_LENGTH = 220;
+const dangerTint = tintClasses('danger');
+
+type RetryAction = {
+  readonly label: string;
+  readonly onClick: () => void;
+  readonly disabled?: boolean;
+};
+
+type Props = {
+  readonly message: string;
+  readonly role?: 'alert';
+  readonly className?: string;
+  readonly iconTestId?: string;
+  readonly retryAction?: RetryAction;
+};
+
+type TruncateParams = {
+  readonly message: string;
+  readonly maxLength: number;
+};
+
+const truncateMessage = ({ message, maxLength }: TruncateParams): string => {
+  if (message.length <= maxLength) {
+    return message;
+  }
+  return `${message.slice(0, maxLength).trimEnd()}...`;
+};
+
+export const TurnErrorCallout = ({ message, role, className, iconTestId, retryAction }: Props) => {
+  const [expanded, setExpanded] = useState(false);
+  const longMessage = message.length > MAX_INLINE_ERROR_LENGTH;
+  const truncatedMessage = useMemo(
+    () => truncateMessage({ message, maxLength: MAX_INLINE_ERROR_LENGTH }),
+    [message],
+  );
+  const displayMessage = longMessage && !expanded ? truncatedMessage : message;
+
+  return (
+    <div
+      role={role}
+      className={cn(
+        'flex w-full items-start gap-2 rounded-md border px-2.5 py-2 text-xs',
+        dangerTint.borderSoft,
+        dangerTint.bgSoft,
+        className,
+      )}
+    >
+      <CircleAlert
+        size={12}
+        aria-hidden
+        {...(iconTestId != null ? { 'data-testid': iconTestId } : {})}
+        className={cn('mt-0.5 shrink-0', dangerTint.icon)}
+      />
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        <p className={cn('min-w-0 break-words leading-relaxed', dangerTint.text)}>
+          {displayMessage}
+        </p>
+        {longMessage ? (
+          <button
+            type="button"
+            onClick={() => setExpanded((value) => !value)}
+            aria-expanded={expanded}
+            className={cn(
+              'w-fit rounded px-1 py-0.5 text-2xs font-medium',
+              dangerTint.text,
+              dangerTint.hoverBgSoft,
+            )}
+          >
+            {expanded ? 'show less' : 'show full error'}
+          </button>
+        ) : null}
+      </div>
+      {retryAction != null ? (
+        <button
+          type="button"
+          onClick={retryAction.onClick}
+          disabled={retryAction.disabled === true}
+          className={cn(
+            'shrink-0 rounded border px-2 py-0.5 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-60',
+            dangerTint.text,
+            dangerTint.borderSoft,
+            dangerTint.bgSoft,
+            dangerTint.hoverBg,
+          )}
+        >
+          {retryAction.label}
+        </button>
+      ) : null}
+    </div>
+  );
+};

--- a/apps/desktop/src/features/chat/turn-errors.ts
+++ b/apps/desktop/src/features/chat/turn-errors.ts
@@ -1,0 +1,44 @@
+const TRANSCRIPT_OWNED_TURN_ERROR_CODE = 'TRANSCRIPT_OWNED_TURN_ERROR';
+
+type TranscriptOwnedTurnError = Error & {
+  readonly code: string;
+  readonly cause: unknown;
+};
+
+type CreateParams = {
+  readonly message: string;
+  readonly cause: unknown;
+};
+
+type GuardParams = {
+  readonly error: unknown;
+};
+
+const readErrorCode = ({ error }: GuardParams): string | null => {
+  if (typeof error !== 'object' || error == null) {
+    return null;
+  }
+  if (!('code' in error)) {
+    return null;
+  }
+  const value = error.code;
+  if (typeof value !== 'string') {
+    return null;
+  }
+  return value;
+};
+
+export const createTranscriptOwnedTurnError = ({
+  message,
+  cause,
+}: CreateParams): TranscriptOwnedTurnError => {
+  const code = TRANSCRIPT_OWNED_TURN_ERROR_CODE;
+  return Object.assign(new Error(message), {
+    code,
+    cause,
+  });
+};
+
+export const isTranscriptOwnedTurnError = ({ error }: GuardParams): boolean => {
+  return readErrorCode({ error }) === TRANSCRIPT_OWNED_TURN_ERROR_CODE;
+};

--- a/apps/desktop/src/features/chat/utils/transcript-items.ts
+++ b/apps/desktop/src/features/chat/utils/transcript-items.ts
@@ -35,7 +35,13 @@ export type TranscriptItem =
     }
   | { kind: 'file_edit'; key: string; path: string; editType: 'create' | 'modify' | 'delete' }
   | { kind: 'usage'; key: string; usage: ProviderUsage }
-  | { kind: 'error'; key: string; message: string }
+  | {
+      kind: 'error';
+      key: string;
+      message: string;
+      runId?: ProviderRunId;
+      retryable?: boolean;
+    }
   | { kind: 'auth_required'; key: string; providerId: ProviderId; identity: string | null }
   | { kind: 'skill_invocation'; key: string; skillName: string; args: ReadonlyArray<string> }
   | {
@@ -220,7 +226,13 @@ export const reduceTranscript = (
             identity: authPayload.identity,
           });
         } else {
-          items.push({ kind: 'error', key: `error-${i}`, message: event.message });
+          items.push({
+            kind: 'error',
+            key: `error-${i}`,
+            message: event.message,
+            runId: event.runId,
+            retryable: event.retryable,
+          });
         }
         break;
       }

--- a/apps/desktop/src/store/slices/turn/dispatchParallelTurn.ts
+++ b/apps/desktop/src/store/slices/turn/dispatchParallelTurn.ts
@@ -18,6 +18,7 @@ import type {
 import { tauriDatabase } from '../../../shared/lib/db';
 import { formatError } from '../../../shared/lib/errors';
 import { AGENT_FEATURES } from '../../../shared/lib/features';
+import { createTranscriptOwnedTurnError } from '../../../features/chat/turn-errors';
 import { runParallelBranch, type ParallelBranchEffects } from '../../parallel-turn';
 import { applySessionUpdate } from '../../session-mutators';
 import { invokeAgentList } from '../../../features/workflows/workflows';
@@ -214,6 +215,7 @@ export const dispatchParallelTurn = async (
       kind: 'error',
       runId: groupSessionRunId,
       message,
+      retryable: true,
       at: now(),
     });
     const errorState: TurnState = {
@@ -223,6 +225,6 @@ export const dispatchParallelTurn = async (
     };
     await updateSessionState(tauriDatabase, sessionId, errorState, now());
     applySessionUpdate(set, sessionId, errorState, activeAgentId);
-    throw err;
+    throw createTranscriptOwnedTurnError({ message: rawMessage, cause: err });
   }
 };

--- a/apps/desktop/src/store/slices/turn/sendTurn.ts
+++ b/apps/desktop/src/store/slices/turn/sendTurn.ts
@@ -51,6 +51,7 @@ import { resolveProviderForTurn } from '../../../features/providers/routing';
 import { simpleSessionDirExists, worktreeChangedFiles } from '../../../features/worktree/worktree';
 import { encodeAuthRequiredMessage, runTurn } from '../../../features/chat/turn';
 import { classifyProviderError } from '../../../features/chat/classifyProviderError';
+import { createTranscriptOwnedTurnError } from '../../../features/chat/turn-errors';
 import { EFFORT_LEVELS } from '../../../features/chat/utils/chat-constants';
 import { verbosityDirective } from '../../../features/settings/verbosity';
 import { detectDrift } from '../../../features/session/drift-detection';
@@ -889,6 +890,7 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
             runId,
             message:
               'provider exited without a response. check that the CLI is configured correctly.',
+            retryable: false,
             at: now(),
           });
         }
@@ -1021,7 +1023,6 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
         console.error('autoPopulateContext failed', e);
       }
     } catch (err) {
-      lastError = err;
       const rawMessage = formatError(err);
       const maxModeFailure =
         provider === 'cursor' ? matchCursorMaxModeFailure({ message: rawMessage }) : null;
@@ -1067,6 +1068,7 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
           kind: 'error',
           runId,
           message,
+          retryable: false,
           at: now(),
         });
         get().appendTurnEvent(activeAgentId, sessionId, {
@@ -1113,6 +1115,7 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
         kind: 'error',
         runId,
         message,
+        retryable: true,
         at: now(),
       });
       if (resolvedAgentId) {
@@ -1126,6 +1129,7 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
         }));
         void get().refreshUnreadWorkspaces();
       }
+      lastError = createTranscriptOwnedTurnError({ message: rawMessage, cause: err });
     }
 
     if (assistantText.length > 0) {

--- a/apps/desktop/src/store/store.idle-on-empty-stream.test.ts
+++ b/apps/desktop/src/store/store.idle-on-empty-stream.test.ts
@@ -322,6 +322,9 @@ describe('sendTurn, terminal state guarantees', () => {
     expect(errorEvent && 'message' in errorEvent ? errorEvent.message : '').toMatch(
       /provider exited without a response/i,
     );
+    expect(errorEvent && 'retryable' in errorEvent ? errorEvent.retryable : undefined).not.toBe(
+      true,
+    );
   });
 
   it('appends user_text event so the user message is visible immediately', async () => {
@@ -368,10 +371,13 @@ describe('sendTurn, terminal state guarantees', () => {
     expect(session?.state.kind).toBe('error');
 
     const transcript = useAppStore.getState().transcripts[AGENT_ID] ?? [];
-    const errorEvent = transcript.find((e) => e.kind === 'error');
+    const errorEvents = transcript.filter((e) => e.kind === 'error');
+    expect(errorEvents).toHaveLength(1);
+    const errorEvent = errorEvents[0];
     expect(errorEvent && 'message' in errorEvent ? errorEvent.message : '').toMatch(
       /provider crashed mid-stream/i,
     );
+    expect(errorEvent && 'retryable' in errorEvent ? errorEvent.retryable : undefined).toBe(true);
   });
 
   it('marks the provider run failed when the stream throws mid-turn', async () => {

--- a/packages/types/src/adapter.ts
+++ b/packages/types/src/adapter.ts
@@ -81,7 +81,13 @@ export type TurnEvent =
       at: IsoDateTime;
     }
   | { kind: 'usage'; runId: ProviderRunId; usage: ProviderUsage; at: IsoDateTime }
-  | { kind: 'error'; runId: ProviderRunId; message: string; at: IsoDateTime }
+  | {
+      kind: 'error';
+      runId: ProviderRunId;
+      message: string;
+      retryable?: boolean;
+      at: IsoDateTime;
+    }
   | { kind: 'done'; runId: ProviderRunId; at: IsoDateTime }
   | {
       kind: 'provider_session_init';


### PR DESCRIPTION
Stacked on #1141.

## What

One failed turn could be painted three times: `sendTurn` appended a transcript item **and** rethrew,
the composer rendered the rethrow as an inline alert, and a toast rendered it again.

The transcript owns a failure that has already been recorded there, and it now carries the retry.
Pre-flight throws never reach the transcript, so for those the composer remains the only surface, as
it already correctly was.

Also:

- **A long provider error stays readable.** It truncates with a way to see the whole thing, instead of
  a wall of red inline.
- **One presentation.** The two danger blocks were hand-written and disagreed with each other: one
  used `tintClasses('danger')`, the other hardcoded `text-danger`, `border-danger/30`, `bg-danger/5`.

## Why the retry moved with the copy

Whichever surface survives has to be the one the user can act from. The composer was the only one that
offered a retry, and it was the copy being removed for streaming failures, so the retry travelled with
the message rather than being left behind on a surface that no longer appears.

## Verified

`pnpm -w typecheck` and the desktop suite green (3660 tests). This area had **no test coverage at all**
before: `ChatInput/index.test.tsx` had no assertion about an error or a retry. It now covers a
streaming failure rendered exactly once with its retry, a pre-flight failure rendered exactly once by
the composer, truncation and expansion of a long error, and the no-response path staying a single
transcript row with no retry. A regression in either direction fails.

## Not touched, and why

- **The transcript record is not silenced.** It is the durable history of the run; what changed is what
  the composer shows above it.
- **`sendTurn`'s "provider exited without a response" path is untouched.** It appends without throwing,
  so it always rendered once, which was already right.