### PR TITLE
refactor(desktop): the budget popover reads at a glance

### DIFF
--- a/apps/desktop/src/features/budget/components/BudgetStudio/ModelTable.tsx
+++ b/apps/desktop/src/features/budget/components/BudgetStudio/ModelTable.tsx
@@ -5,17 +5,23 @@ import { CONCEPT_ICONS } from '../../../../shared/components/conceptIcons';
 
 type Props = {
   readonly entries: ReadonlyArray<ModelBreakdownEntry>;
+  readonly formatSpent?: (value: number) => string;
+  readonly borderedEmptyState?: boolean;
 };
 
-export const ModelTable = ({ entries }: Props) => {
+export const ModelTable = ({
+  entries,
+  formatSpent = formatUsdPrecise,
+  borderedEmptyState = true,
+}: Props) => {
   if (entries.length === 0) {
     return (
       <EmptyState
-        bordered
+        bordered={borderedEmptyState}
         icon={CONCEPT_ICONS.budget}
         title="No model usage recorded yet"
         size="inline"
-        className="justify-center border-solid bg-muted/10 px-3 py-4"
+        className="justify-center bg-muted/10 px-3 py-4"
       />
     );
   }
@@ -46,7 +52,7 @@ export const ModelTable = ({ entries }: Props) => {
               {formatTokens(entry.tokensOut)}
             </td>
             <td className="px-3 py-2 text-right font-mono tabular-nums font-medium text-foreground">
-              {formatUsdPrecise(entry.spentUsd)}
+              {formatSpent(entry.spentUsd)}
             </td>
           </tr>
         ))}

--- a/apps/desktop/src/features/budget/components/BudgetStudio/SessionBudgetContent.tsx
+++ b/apps/desktop/src/features/budget/components/BudgetStudio/SessionBudgetContent.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { StatCard, formatUsdPrecise } from '@goodboy/ui';
+import { Divider, StatCard, cn, formatUsd, formatUsdPrecise } from '@goodboy/ui';
 import type { SessionId } from '@goodboy/types';
 import { CapEditor } from './CapEditor';
 import { ModelTable } from './ModelTable';
@@ -8,14 +8,23 @@ import { StudioWidget } from '../../../../shared/components/StudioWidget';
 import { Sparkline } from '../../../../shared/components/Sparkline';
 import { buildModelBreakdown, chronologicalTurnCosts, type WorkspaceTurn } from './lib';
 
+type Density = 'studio' | 'glance';
+
 type Props = {
   readonly turns: ReadonlyArray<WorkspaceTurn>;
   readonly softCapUsd: number | null;
   readonly onSaveCap: (capUsd: number) => Promise<void>;
-  readonly onOpenSession: (sessionId: SessionId) => void;
+  readonly onOpenSession?: (sessionId: SessionId) => void;
+  readonly density?: Density;
 };
 
-export const SessionBudgetContent = ({ turns, softCapUsd, onSaveCap, onOpenSession }: Props) => {
+export const SessionBudgetContent = ({
+  turns,
+  softCapUsd,
+  onSaveCap,
+  onOpenSession,
+  density = 'studio',
+}: Props) => {
   const records = useMemo(() => turns.map((turn) => turn.record), [turns]);
   const models = useMemo(() => buildModelBreakdown(records), [records]);
   const turnCosts = useMemo(() => chronologicalTurnCosts(records), [records]);
@@ -28,12 +37,15 @@ export const SessionBudgetContent = ({ turns, softCapUsd, onSaveCap, onOpenSessi
     0,
   );
   const turnCount = records.filter((record) => record.kind === 'turn').length;
+  const isStudio = density === 'studio';
+  const formatSpend = isStudio ? formatUsdPrecise : formatUsd;
+  const showsTurns = isStudio && onOpenSession != null;
 
   return (
-    <div className="flex flex-col gap-6">
-      <div className="grid grid-cols-3 gap-3">
-        <StatCard label="session cost" value={formatUsdPrecise(sessionCost)} />
-        <StatCard label="summarizer" value={formatUsdPrecise(summarizer)} />
+    <div className={cn('flex flex-col', isStudio ? 'gap-6' : 'gap-4')}>
+      <div className={cn('grid gap-3', isStudio ? 'grid-cols-3' : 'grid-cols-1 sm:grid-cols-3')}>
+        <StatCard label="session cost" value={formatSpend(sessionCost)} />
+        <StatCard label="summarizer" value={formatSpend(summarizer)} />
         <StatCard label="turns" value={String(turnCount)} />
       </div>
       <CapEditor
@@ -42,13 +54,21 @@ export const SessionBudgetContent = ({ turns, softCapUsd, onSaveCap, onOpenSessi
         currentCapUsd={softCapUsd}
         onSave={onSaveCap}
       />
-      <StudioWidget label="by model">
-        <ModelTable entries={models} />
+      {!isStudio ? <Divider /> : null}
+      <StudioWidget
+        label="by model"
+        className={isStudio ? undefined : 'border-none bg-transparent p-0'}
+      >
+        <ModelTable entries={models} formatSpent={formatSpend} borderedEmptyState={isStudio} />
       </StudioWidget>
-      <StudioWidget label="cost per turn">
-        <Sparkline values={turnCosts} />
-      </StudioWidget>
-      <TurnsTable turns={turns} showSession={false} onOpenSession={onOpenSession} />
+      {showsTurns ? (
+        <>
+          <StudioWidget label="cost per turn">
+            <Sparkline values={turnCosts} />
+          </StudioWidget>
+          <TurnsTable turns={turns} showSession={false} onOpenSession={onOpenSession} />
+        </>
+      ) : null}
     </div>
   );
 };

--- a/apps/desktop/src/features/budget/components/BudgetStudio/index.test.tsx
+++ b/apps/desktop/src/features/budget/components/BudgetStudio/index.test.tsx
@@ -95,6 +95,8 @@ describe('BudgetStudio', () => {
     );
     expect(screen.getAllByText(/build the feature/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/session cost/i)).toBeDefined();
+    expect(screen.getByText(/cost per turn/i)).toBeDefined();
+    expect(screen.getByRole('button', { name: 'recent' })).toBeDefined();
   });
 
   it('authors a new provider cap via saveBudgetRule', () => {

--- a/apps/desktop/src/features/budget/openBudgetStudio.ts
+++ b/apps/desktop/src/features/budget/openBudgetStudio.ts
@@ -1,0 +1,9 @@
+import type { BudgetScope } from './components/BudgetStudio/lib';
+
+type Params = {
+  readonly scope?: BudgetScope;
+};
+
+export const openBudgetStudio = ({ scope }: Params) => {
+  window.dispatchEvent(new CustomEvent('goodboy:open-budget-studio', { detail: { scope } }));
+};

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/SessionCostChip.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/SessionCostChip.test.tsx
@@ -54,6 +54,21 @@ const alert = (over: Partial<BudgetAlert> = {}): BudgetAlert =>
     ...over,
   }) as BudgetAlert;
 
+const telemetryRecord = (over: Partial<TelemetryRecord> = {}): TelemetryRecord =>
+  ({
+    id: 'telemetry-1',
+    runId: 'run-1',
+    sessionId: SID,
+    kind: 'turn',
+    provider: 'anthropic',
+    model: 'claude-opus-4-8',
+    inputTokens: 120,
+    outputTokens: 220,
+    estimatedCostUsd: 1.7562,
+    recordedAt: '2026-07-27T10:00:00.000Z',
+    ...over,
+  }) as TelemetryRecord;
+
 beforeEach(() => {
   state.sessionCost = 0;
   store.budgetAlerts = [];
@@ -131,6 +146,20 @@ describe('SessionCostChip', () => {
     expect(screen.getByRole('button').getAttribute('title')).toContain('$1.7562');
   });
 
+  it('uses at-a-glance cost formatting in the popover while keeping cap editing', () => {
+    state.sessionCost = 1.7562;
+    store.sessionTelemetry = {
+      [SID]: [telemetryRecord()],
+    };
+    render(<SessionCostChip sessionId={SID} />);
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(screen.getByLabelText('session soft cap')).toBeDefined();
+    expect(screen.getAllByText('$1.76').length).toBeGreaterThan(0);
+    expect(screen.queryByText('$1.7562')).toBeNull();
+  });
+
   it('keeps a sub-cent cap exact in the tooltip too', () => {
     state.sessionCost = 0.0012;
     store.sessionBudgets = {
@@ -157,6 +186,23 @@ describe('SessionCostChip', () => {
     expect(store.loadSessionTelemetry).toHaveBeenCalledWith(SID);
     expect(store.loadSessionBudget).toHaveBeenCalledWith(SID);
     expect(handler).not.toHaveBeenCalled();
+    window.removeEventListener('goodboy:open-budget-studio', handler);
+  });
+
+  it('opens budget studio at the same session scope from the popover', () => {
+    const handler = vi.fn();
+    window.addEventListener('goodboy:open-budget-studio', handler);
+    render(<SessionCostChip sessionId={SID} />);
+
+    fireEvent.click(screen.getByRole('button'));
+    fireEvent.click(screen.getByRole('button', { name: /open full budget details/i }));
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    const event = handler.mock.calls[0]?.[0] as CustomEvent<{
+      scope?: { kind?: string; sessionId?: SessionId };
+    }>;
+    expect(event.detail.scope).toEqual({ kind: 'session', sessionId: SID });
+    expect(screen.queryByRole('dialog', { name: 'session budget details' })).toBeNull();
     window.removeEventListener('goodboy:open-budget-studio', handler);
   });
 

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/SessionCostChip.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/SessionCostChip.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import {
+  Button,
   Divider,
   Popover,
   ScrollFade,
@@ -9,11 +10,11 @@ import {
   tintClasses,
 } from '@goodboy/ui';
 import type { SessionId } from '@goodboy/types';
+import { openBudgetStudio as openBudgetStudioEvent } from '../../../budget/openBudgetStudio';
 import { SessionBudgetContent } from '../../../budget/components/BudgetStudio/SessionBudgetContent';
 import type { WorkspaceTurn } from '../../../budget/components/BudgetStudio/lib';
 import { useDropdown } from '../../../../shared/hooks/useDropdown';
 import { DropdownPortal } from '../../../../shared/hooks/useDropdown/DropdownPortal';
-import { useOpenSession } from '../../../../shared/hooks/useOpenSession';
 import { EMPTY_ARRAY, useAppStore, useSessionCost } from '../../../../store';
 import { manageDialogFocus } from './manageDialogFocus';
 
@@ -51,7 +52,6 @@ export const SessionCostChip = ({ sessionId }: Props) => {
   const loadSessionTelemetry = useAppStore((state) => state.loadSessionTelemetry);
   const loadSessionBudget = useAppStore((state) => state.loadSessionBudget);
   const setSessionBudget = useAppStore((state) => state.setSessionBudget);
-  const openSession = useOpenSession();
   const { open, toggle, containerRef, popupRef, popupClassName, popupStyle, portal, portalTarget } =
     useDropdown({
       align: 'end',
@@ -117,6 +117,11 @@ export const SessionCostChip = ({ sessionId }: Props) => {
     });
   }, [open, popupRef]);
 
+  const openBudgetStudio = () => {
+    openBudgetStudioEvent({ scope: { kind: 'session', sessionId } });
+    toggle();
+  };
+
   return (
     <div ref={containerRef} className="relative">
       <button
@@ -159,9 +164,15 @@ export const SessionCostChip = ({ sessionId }: Props) => {
                 turns={turns}
                 softCapUsd={sessionBudget}
                 onSaveCap={(nextCapUsd) => setSessionBudget(sessionId, nextCapUsd)}
-                onOpenSession={(nextSessionId) => openSession(nextSessionId, toggle)}
+                density="glance"
               />
             </ScrollFade>
+            <Divider />
+            <div className="p-3">
+              <Button variant="ghost" size="sm" onClick={openBudgetStudio}>
+                Open full budget details
+              </Button>
+            </div>
           </Popover>
         ) : null}
       </DropdownPortal>


### PR DESCRIPTION
Stacked on #1143.

## What

The popover mounted `SessionBudgetContent` unchanged, which is the same component the Budget studio
renders inside a `StudioPanel` at `max-w-3xl` with `px-10 py-8`. In the popover that becomes 640 by
512 with 16px of padding. Four of its blocks wrap themselves in a bordered, padded widget with their
own section header, so four boxes stacked vertically inside a box, and the turns table alone could
take 400 of the 512 pixels.

- Flat separation replaces the per-section box chrome.
- The turns table stays in the studio, and the popover links to the session scope rather than
  reproducing it.
- The popover uses the at-a-glance money format. The chip's own label already rounded with `formatUsd`
  and the popover then showed the same number to four decimals; in the rest of the repo four decimals
  are for tooltips and stat cards.

## One component, not two

`SessionBudgetContent` takes a density and both callers pass theirs. Forking it would have left two
near-identical components to keep in step, which is the failure mode this round keeps finding
elsewhere.

**The cap editor stays**, as asked.

## Verified

`pnpm -w typecheck` and the desktop suite green (3662 tests). Coverage asserts the popover keeps the
cap editor and the glance formatting, that what was cut is reachable from it, and that the studio still
renders the full set.

happy-dom does not measure heights, so no test here claims the popover fits; the assertions are about
what is rendered.