### PR TITLE
fix(desktop): clear what the first run leaves behind

### DIFF
--- a/apps/desktop/src/features/onboarding/OnboardingWizard/index.test.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/index.test.tsx
@@ -158,6 +158,30 @@ describe('OnboardingWizard', () => {
       expect(screen.getByTestId('CodeHostStep')).toBeDefined();
       expect(screen.getByRole('button', { name: /continue/i })).toBeDefined();
     });
+
+    it('announces when changing workspace removes setup steps and moves to the next valid step', () => {
+      setHook({
+        providersConnected: 1,
+        hasWorkspace: true,
+        workspaceKind: 'repo',
+      });
+      const { rerender } = render(<OnboardingWizard />);
+      advance(/get started/i, 1);
+      advance(/continue/i, 3);
+      expect(screen.getByTestId('CodeHostStep')).toBeDefined();
+
+      setHook({
+        providersConnected: 1,
+        hasWorkspace: true,
+        workspaceKind: 'simple',
+      });
+      rerender(<OnboardingWizard />);
+
+      expect(screen.getByTestId('TrackerStep')).toBeDefined();
+      expect(
+        screen.getByText('Code host and Sentry are skipped for standalone workspaces.'),
+      ).toBeDefined();
+    });
   });
 
   describe('setup mode', () => {

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/index.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/index.tsx
@@ -17,6 +17,57 @@ const SETUP_START_STEP = 3;
 const EXIT_MS = 200;
 const ALL_STEPS = Array.from({ length: STEP_COUNT }, (_, index) => index);
 const SIMPLE_STEPS = [0, 1, 2, 3, 5, 7];
+const STEP_LABELS = {
+  4: 'Code host',
+  6: 'Sentry',
+} as const;
+
+const joinStepLabels = ({ labels }: { readonly labels: ReadonlyArray<string> }): string => {
+  if (labels.length === 0) {
+    return '';
+  }
+  if (labels.length === 1) {
+    const first = labels[0];
+    if (first === undefined) {
+      return '';
+    }
+    return first;
+  }
+  if (labels.length === 2) {
+    const first = labels[0];
+    const second = labels[1];
+    if (first === undefined || second === undefined) {
+      return '';
+    }
+    return `${first} and ${second}`;
+  }
+  const head = labels.slice(0, -1).join(', ');
+  const tail = labels[labels.length - 1];
+  if (tail === undefined) {
+    return head;
+  }
+  return `${head}, and ${tail}`;
+};
+
+const buildStepRemovalNotice = ({
+  removed,
+}: {
+  readonly removed: ReadonlyArray<number>;
+}): string | null => {
+  const labels: string[] = [];
+  for (const candidate of removed) {
+    if (candidate === 4) {
+      labels.push(STEP_LABELS[4]);
+    }
+    if (candidate === 6) {
+      labels.push(STEP_LABELS[6]);
+    }
+  }
+  if (labels.length === 0) {
+    return null;
+  }
+  return `${joinStepLabels({ labels })} ${labels.length === 1 ? 'is' : 'are'} skipped for standalone workspaces.`;
+};
 
 type Cta = {
   readonly label: string;
@@ -45,6 +96,7 @@ export const OnboardingWizard = () => {
   const [workspaceAudience, setWorkspaceAudience] = useState<WorkspaceAudience | null>(null);
   const [changingWorkspace, setChangingWorkspace] = useState(false);
   const [closing, setClosing] = useState(false);
+  const [stepRemovalNotice, setStepRemovalNotice] = useState<string | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
   const isSimple = workspaceKind === 'simple';
@@ -54,6 +106,7 @@ export const OnboardingWizard = () => {
   );
   const minStep = steps[0] ?? 0;
   const last = STEP_COUNT - 1;
+  const previousStepsRef = useRef<ReadonlyArray<number>>(steps);
 
   useEffect(() => {
     if (!open) {
@@ -61,8 +114,34 @@ export const OnboardingWizard = () => {
     }
     setStep(minStep);
     setClosing(false);
+    setStepRemovalNotice(null);
+    previousStepsRef.current = steps;
     containerRef.current?.focus();
   }, [open, minStep]);
+
+  useEffect(() => {
+    if (!open) {
+      previousStepsRef.current = steps;
+      return;
+    }
+    const previousSteps = previousStepsRef.current;
+    previousStepsRef.current = steps;
+    const removed = previousSteps.filter((candidate) => !steps.includes(candidate));
+    const notice = buildStepRemovalNotice({ removed });
+    if (notice !== null) {
+      setStepRemovalNotice(notice);
+    }
+    if (steps.includes(step)) {
+      return;
+    }
+    const nextStep = steps.find((candidate) => candidate > step);
+    if (nextStep !== undefined) {
+      setStep(nextStep);
+      return;
+    }
+    const fallbackStep = [...steps].reverse().find((candidate) => candidate < step);
+    setStep(fallbackStep ?? minStep);
+  }, [open, steps, step, minStep]);
 
   if (!open) {
     return null;
@@ -182,6 +261,11 @@ export const OnboardingWizard = () => {
       <ScrollFade className="min-h-0 flex-1">
         <div className="flex min-h-full items-center justify-center px-6 py-10">
           <div className="flex w-full max-w-xl flex-col gap-8">
+            {stepRemovalNotice !== null ? (
+              <p role="status" className="text-center text-xs text-muted-foreground">
+                {stepRemovalNotice}
+              </p>
+            ) : null}
             <div key={step} className="motion-safe:animate-fade-in">
               {body}
             </div>

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/steps/WorkspaceStep.test.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/steps/WorkspaceStep.test.tsx
@@ -7,15 +7,19 @@ import type { IsoDateTime, Workspace, WorkspaceId } from '@goodboy/types';
 
 vi.mock('../../../workspace/components/WorkspaceLinkForm', () => ({
   WorkspaceLinkForm: ({
+    onComplete,
     onCancel,
     cancelLabel,
     modes,
   }: {
+    onComplete: (params: { readonly mode: 'single' | 'multi' | 'simple' }) => void;
     onCancel: () => void;
     cancelLabel: string;
     modes: ReadonlyArray<string>;
   }) => (
     <div data-testid="workspace-link-form" data-modes={modes.join(',')}>
+      <button onClick={() => onComplete({ mode: 'single' })}>Complete single</button>
+      <button onClick={() => onComplete({ mode: 'multi' })}>Complete multi</button>
       <button onClick={onCancel}>{cancelLabel}</button>
     </div>
   ),
@@ -68,6 +72,16 @@ describe('WorkspaceStep', () => {
     expect(screen.getByTestId('workspace-link-form').getAttribute('data-modes')).toBe(
       'single,multi',
     );
+  });
+
+  it('keeps the form open after adding the first single-project workspace', () => {
+    const { rerender } = render(<Harness workspace={null} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /I write code/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'Complete single' }));
+    rerender(<Harness workspace={REPOSITORY_WORKSPACE} />);
+
+    expect(screen.getByTestId('workspace-link-form')).toBeDefined();
   });
 
   it('sends everyone else straight to the standalone path', () => {

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/steps/WorkspaceStep.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/steps/WorkspaceStep.tsx
@@ -4,6 +4,7 @@ import { Button } from '@goodboy/ui';
 import type { Workspace, WorkspaceKind } from '@goodboy/types';
 import type { WorkspaceLinkMode } from '../../../workspace/components/WorkspaceLinkForm';
 import { WorkspaceLinkForm } from '../../../workspace/components/WorkspaceLinkForm';
+import { STORAGE_KEYS } from '../../../../shared/lib/storage-keys';
 
 export type WorkspaceAudience = 'developer' | 'everyone-else';
 
@@ -114,6 +115,22 @@ export const WorkspaceStep = ({
     );
   }
 
+  const onFormComplete = ({ mode }: { readonly mode: WorkspaceLinkMode }) => {
+    if (workspace === null && audience === 'developer' && mode === 'single') {
+      onIsChangingChange(true);
+      return;
+    }
+    onIsChangingChange(false);
+  };
+
+  const onFormCancel = () => {
+    if (workspace !== null) {
+      onIsChangingChange(false);
+      return;
+    }
+    onAudienceChange(null);
+  };
+
   return (
     <StepFrame
       title={workspace === null ? 'Add workspace' : 'Change workspace'}
@@ -124,11 +141,12 @@ export const WorkspaceStep = ({
       }
     >
       <WorkspaceLinkForm
-        onComplete={() => onIsChangingChange(false)}
-        onCancel={() => onAudienceChange(null)}
+        onComplete={onFormComplete}
+        onCancel={onFormCancel}
         cancelLabel="Back"
         showBreadcrumb={false}
         modes={AUDIENCE_MODES[audience]}
+        draftStorageKey={STORAGE_KEYS.onboardingWorkspaceDraft}
       />
     </StepFrame>
   );

--- a/apps/desktop/src/features/workspace/components/WorkspaceLinkDialog/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspaceLinkDialog/index.tsx
@@ -11,7 +11,7 @@ type Props = {
 export const WorkspaceLinkDialog = ({ open, onClose }: Props) => {
   const [footerContainer, setFooterContainer] = useState<HTMLElement | null>(null);
 
-  const onComplete = () => {
+  const onComplete = ({ mode: _mode }: { readonly mode: 'single' | 'multi' | 'simple' }) => {
     onClose();
     if (!isWizardDone()) {
       reopenWizard('setup');

--- a/apps/desktop/src/features/workspace/components/WorkspaceLinkForm/index.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspaceLinkForm/index.test.tsx
@@ -9,7 +9,12 @@ const { state, validateMock } = vi.hoisted(() => ({
     addCompositeWorkspace: vi.fn(async () => ({ id: 'ws-composite' })),
     addSimpleWorkspace: vi.fn(async () => ({ id: 'ws-simple' })),
     setCurrentWorkspace: vi.fn(async () => undefined),
-    workspaces: [] as ReadonlyArray<{ id: string }>,
+    workspaces: [] as ReadonlyArray<{
+      id: string;
+      name: string;
+      rootPath: string;
+      kind?: 'repo' | 'composite' | 'simple';
+    }>,
   },
   validateMock: vi.fn(async () => ({ isRepo: true })),
 }));
@@ -47,6 +52,7 @@ vi.mock('../../defaultSimpleWorkspacePath', () => ({
 import { WorkspaceLinkForm, type WorkspaceLinkMode } from './index';
 
 const ALL_MODES: ReadonlyArray<WorkspaceLinkMode> = ['single', 'multi', 'simple'];
+const DRAFT_KEY = 'goodboy:test-workspace-link-draft';
 
 beforeEach(() => {
   state.addWorkspace = vi.fn(async () => ({ id: 'ws-new' }));
@@ -54,6 +60,7 @@ beforeEach(() => {
   state.addSimpleWorkspace = vi.fn(async () => ({ id: 'ws-simple' }));
   state.setCurrentWorkspace = vi.fn(async () => undefined);
   state.workspaces = [];
+  localStorage.clear();
   validateMock.mockClear();
   validateMock.mockResolvedValue({ isRepo: true });
 });
@@ -144,5 +151,109 @@ describe('WorkspaceLinkForm', () => {
     expect(validateMock).not.toHaveBeenCalled();
     expect(state.setCurrentWorkspace).toHaveBeenCalledWith('ws-simple');
     expect(onComplete).toHaveBeenCalledOnce();
+  });
+
+  it('restores a draft across unmount and remount', async () => {
+    state.workspaces = [
+      { id: 'ws-1', name: 'alpha', rootPath: '/repos/alpha', kind: 'repo' },
+      { id: 'ws-2', name: 'beta', rootPath: '/repos/beta', kind: 'repo' },
+    ];
+
+    const firstRender = render(
+      <WorkspaceLinkForm
+        onComplete={vi.fn()}
+        onCancel={vi.fn()}
+        showBreadcrumb={false}
+        modes={ALL_MODES}
+        draftStorageKey={DRAFT_KEY}
+      />,
+    );
+
+    fireEvent.change(screen.getByPlaceholderText('/path/to/repo'), {
+      target: { value: '/repos/solo' },
+    });
+    fireEvent.click(screen.getByRole('tab', { name: /multi project/i }));
+    fireEvent.click(screen.getByRole('button', { name: /alpha/i }));
+    fireEvent.click(screen.getByRole('button', { name: /beta/i }));
+    fireEvent.change(screen.getByLabelText('alpha mount name'), { target: { value: 'main' } });
+    fireEvent.change(screen.getByLabelText('beta mount name'), { target: { value: 'docs' } });
+    fireEvent.change(screen.getByLabelText('Container path'), { target: { value: '/tmp/work' } });
+    fireEvent.change(screen.getByLabelText('Workspace name'), { target: { value: 'My fleet' } });
+    await waitFor(() =>
+      expect(localStorage.getItem(DRAFT_KEY)).toContain('"containerPath":"/tmp/work"'),
+    );
+    await waitFor(() =>
+      expect(localStorage.getItem(DRAFT_KEY)).toContain('"selected":["ws-1","ws-2"]'),
+    );
+    await waitFor(() =>
+      expect(localStorage.getItem(DRAFT_KEY)).toContain('"containerEdited":true'),
+    );
+    firstRender.unmount();
+
+    render(
+      <WorkspaceLinkForm
+        onComplete={vi.fn()}
+        onCancel={vi.fn()}
+        showBreadcrumb={false}
+        modes={ALL_MODES}
+        draftStorageKey={DRAFT_KEY}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole('tab', { name: /multi project/i, selected: true })).toBeDefined(),
+    );
+    await waitFor(() =>
+      expect((screen.getByLabelText('Container path') as HTMLInputElement).value).toBe('/tmp/work'),
+    );
+    expect((screen.getByLabelText('Workspace name') as HTMLInputElement).value).toBe('My fleet');
+    expect((screen.getByLabelText('alpha mount name') as HTMLInputElement).value).toBe('main');
+    expect((screen.getByLabelText('beta mount name') as HTMLInputElement).value).toBe('docs');
+  });
+
+  it('clears the persisted draft when cancelled', async () => {
+    const onCancel = vi.fn();
+    render(
+      <WorkspaceLinkForm
+        onComplete={vi.fn()}
+        onCancel={onCancel}
+        showBreadcrumb={false}
+        modes={ALL_MODES}
+        draftStorageKey={DRAFT_KEY}
+      />,
+    );
+
+    fireEvent.change(screen.getByPlaceholderText('/path/to/repo'), {
+      target: { value: '/repos/solo' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(onCancel).toHaveBeenCalledOnce();
+    expect(localStorage.getItem(DRAFT_KEY)).toBeNull();
+  });
+
+  it('clears the persisted draft when submitted', async () => {
+    const onComplete = vi.fn();
+    render(
+      <WorkspaceLinkForm
+        onComplete={onComplete}
+        onCancel={vi.fn()}
+        showBreadcrumb={false}
+        modes={ALL_MODES}
+        draftStorageKey={DRAFT_KEY}
+      />,
+    );
+
+    fireEvent.change(screen.getByPlaceholderText('/path/to/repo'), {
+      target: { value: '/repos/solo' },
+    });
+    await waitFor(() => screen.getByText(/valid git repository/i), { timeout: 2000 });
+    fireEvent.click(screen.getByRole('button', { name: 'Add workspace' }));
+
+    await waitFor(() =>
+      expect(state.addWorkspace).toHaveBeenCalledWith({ rootPath: '/repos/solo' }),
+    );
+    expect(onComplete).toHaveBeenCalledOnce();
+    expect(localStorage.getItem(DRAFT_KEY)).toBeNull();
   });
 });

--- a/apps/desktop/src/features/workspace/components/WorkspaceLinkForm/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspaceLinkForm/index.tsx
@@ -1,4 +1,13 @@
-import { useCallback, useEffect, useId, useMemo, useRef, useState, type FormEvent } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type FormEvent,
+} from 'react';
 import { createPortal } from 'react-dom';
 import { open as openDialog } from '@tauri-apps/plugin-dialog';
 import {
@@ -13,7 +22,7 @@ import {
   StatusDot,
   cn,
 } from '@goodboy/ui';
-import type { Workspace, WorkspaceId } from '@goodboy/types';
+import type { Workspace } from '@goodboy/types';
 import { AlertTriangle, Boxes, Check, Folder, FolderGit2 } from 'lucide-react';
 import { useAppStore, useWorkspaces } from '../../../../store';
 import { AppBreadcrumb } from '../../../../app/components/AppBreadcrumb';
@@ -27,23 +36,164 @@ import { lastPathSegment } from './lastPathSegment';
 export type WorkspaceLinkMode = 'single' | 'multi' | 'simple';
 
 type Props = {
-  readonly onComplete: () => void;
+  readonly onComplete: (params: { readonly mode: WorkspaceLinkMode }) => void;
   readonly onCancel: () => void;
   readonly cancelLabel?: string;
   readonly showBreadcrumb: boolean;
   readonly modes: ReadonlyArray<WorkspaceLinkMode>;
   readonly footerContainer?: HTMLElement | null;
+  readonly draftStorageKey?: string;
 };
 
 type Mode = WorkspaceLinkMode;
 
 const DEFAULT_SIMPLE_NAME = 'My workspace';
+const WORKSPACE_LINK_DRAFT_VERSION = 1;
 
 const MODE_OPTIONS = [
   { value: 'single', label: 'Single project', icon: FolderGit2 },
   { value: 'multi', label: 'Multi project', icon: Boxes },
   { value: 'simple', label: 'Standalone', icon: Folder },
 ] as const;
+
+type WorkspaceLinkDraft = {
+  readonly v: number;
+  readonly mode: WorkspaceLinkMode;
+  readonly path: string;
+  readonly selected: ReadonlyArray<string>;
+  readonly mountNames: Record<string, string>;
+  readonly containerPath: string;
+  readonly containerEdited: boolean;
+  readonly compositeName: string;
+  readonly simpleName: string;
+  readonly simplePath: string;
+  readonly simplePathEdited: boolean;
+};
+
+const readMode = ({ value }: { readonly value: unknown }): WorkspaceLinkMode | null => {
+  if (value === 'single' || value === 'multi' || value === 'simple') {
+    return value;
+  }
+  return null;
+};
+
+const readStringArray = ({ value }: { readonly value: unknown }): ReadonlyArray<string> | null => {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+  if (!value.every((item) => typeof item === 'string')) {
+    return null;
+  }
+  return value;
+};
+
+const readStringRecord = ({
+  value,
+}: {
+  readonly value: unknown;
+}): Record<string, string> | null => {
+  if (typeof value !== 'object' || value === null) {
+    return null;
+  }
+  if (!Object.values(value).every((item) => typeof item === 'string')) {
+    return null;
+  }
+  return value as Record<string, string>;
+};
+
+const readDraft = ({ storageKey }: { readonly storageKey: string }): WorkspaceLinkDraft | null => {
+  try {
+    const raw = localStorage.getItem(storageKey);
+    if (raw === null) {
+      return null;
+    }
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== 'object' || parsed === null) {
+      return null;
+    }
+    const record = parsed as Record<string, unknown>;
+    if (record['v'] !== WORKSPACE_LINK_DRAFT_VERSION) {
+      return null;
+    }
+    const mode = readMode({ value: record['mode'] });
+    if (mode === null) {
+      return null;
+    }
+    const path = typeof record['path'] === 'string' ? record['path'] : null;
+    if (path === null) {
+      return null;
+    }
+    const selected = readStringArray({ value: record['selected'] });
+    if (selected === null) {
+      return null;
+    }
+    const mountNames = readStringRecord({ value: record['mountNames'] });
+    if (mountNames === null) {
+      return null;
+    }
+    const containerPath =
+      typeof record['containerPath'] === 'string' ? record['containerPath'] : null;
+    if (containerPath === null) {
+      return null;
+    }
+    const containerEdited =
+      typeof record['containerEdited'] === 'boolean' ? record['containerEdited'] : null;
+    if (containerEdited === null) {
+      return null;
+    }
+    const compositeName =
+      typeof record['compositeName'] === 'string' ? record['compositeName'] : null;
+    if (compositeName === null) {
+      return null;
+    }
+    const simpleName = typeof record['simpleName'] === 'string' ? record['simpleName'] : null;
+    if (simpleName === null) {
+      return null;
+    }
+    const simplePath = typeof record['simplePath'] === 'string' ? record['simplePath'] : null;
+    if (simplePath === null) {
+      return null;
+    }
+    const simplePathEdited =
+      typeof record['simplePathEdited'] === 'boolean' ? record['simplePathEdited'] : null;
+    if (simplePathEdited === null) {
+      return null;
+    }
+    return {
+      v: WORKSPACE_LINK_DRAFT_VERSION,
+      mode,
+      path,
+      selected,
+      mountNames,
+      containerPath,
+      containerEdited,
+      compositeName,
+      simpleName,
+      simplePath,
+      simplePathEdited,
+    };
+  } catch {
+    return null;
+  }
+};
+
+const writeDraft = ({
+  storageKey,
+  draft,
+}: {
+  readonly storageKey: string;
+  readonly draft: WorkspaceLinkDraft;
+}): void => {
+  try {
+    localStorage.setItem(storageKey, JSON.stringify(draft));
+  } catch {}
+};
+
+const clearDraft = ({ storageKey }: { readonly storageKey: string }): void => {
+  try {
+    localStorage.removeItem(storageKey);
+  } catch {}
+};
 
 export const WorkspaceLinkForm = ({
   onComplete,
@@ -52,6 +202,7 @@ export const WorkspaceLinkForm = ({
   showBreadcrumb,
   modes,
   footerContainer,
+  draftStorageKey,
 }: Props) => {
   const formId = useId();
   const addWorkspace = useAppStore((state) => state.addWorkspace);
@@ -74,7 +225,7 @@ export const WorkspaceLinkForm = ({
   const [validationError, setValidationError] = useState<string | null>(null);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
-  const [selected, setSelected] = useState<ReadonlyArray<WorkspaceId>>([]);
+  const [selected, setSelected] = useState<ReadonlyArray<string>>([]);
   const [mountNames, setMountNames] = useState<Record<string, string>>({});
   const [containerPath, setContainerPath] = useState('');
   const [containerEdited, setContainerEdited] = useState(false);
@@ -82,7 +233,91 @@ export const WorkspaceLinkForm = ({
   const [simpleName, setSimpleName] = useState(DEFAULT_SIMPLE_NAME);
   const [simplePath, setSimplePath] = useState('');
   const [simplePathEdited, setSimplePathEdited] = useState(false);
+  const [draftLoaded, setDraftLoaded] = useState(draftStorageKey == null);
+  const persistDraftRef = useRef(true);
+  const latestDraftRef = useRef<WorkspaceLinkDraft | null>(null);
   const pathInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (modes.includes(mode)) {
+      return;
+    }
+    setMode(modes[0] ?? 'single');
+  }, [mode, modes]);
+
+  useEffect(() => {
+    persistDraftRef.current = true;
+    if (draftStorageKey == null) {
+      setDraftLoaded(true);
+      return;
+    }
+    const draft = readDraft({ storageKey: draftStorageKey });
+    if (draft === null) {
+      setDraftLoaded(true);
+      return;
+    }
+    setMode(modes.includes(draft.mode) ? draft.mode : (modes[0] ?? 'single'));
+    setPath(draft.path);
+    setSelected(draft.selected);
+    setMountNames(draft.mountNames);
+    setContainerPath(draft.containerPath);
+    setContainerEdited(draft.containerEdited);
+    setCompositeName(draft.compositeName);
+    setSimpleName(draft.simpleName);
+    setSimplePath(draft.simplePath);
+    setSimplePathEdited(draft.simplePathEdited);
+    setDraftLoaded(true);
+  }, [draftStorageKey, modes]);
+
+  useLayoutEffect(() => {
+    if (!draftLoaded || draftStorageKey == null || !persistDraftRef.current) {
+      return;
+    }
+    const draft: WorkspaceLinkDraft = {
+      v: WORKSPACE_LINK_DRAFT_VERSION,
+      mode,
+      path,
+      selected,
+      mountNames,
+      containerPath,
+      containerEdited,
+      compositeName,
+      simpleName,
+      simplePath,
+      simplePathEdited,
+    };
+    latestDraftRef.current = draft;
+    writeDraft({
+      storageKey: draftStorageKey,
+      draft,
+    });
+  }, [
+    draftLoaded,
+    draftStorageKey,
+    mode,
+    path,
+    selected,
+    mountNames,
+    containerPath,
+    containerEdited,
+    compositeName,
+    simpleName,
+    simplePath,
+    simplePathEdited,
+  ]);
+
+  useEffect(() => {
+    return () => {
+      if (draftStorageKey == null || !persistDraftRef.current) {
+        return;
+      }
+      const draft = latestDraftRef.current;
+      if (draft === null) {
+        return;
+      }
+      writeDraft({ storageKey: draftStorageKey, draft });
+    };
+  }, [draftStorageKey]);
 
   useEffect(() => {
     if (mode !== 'simple' || simplePathEdited) {
@@ -180,10 +415,11 @@ export const WorkspaceLinkForm = ({
   }, [selectedWorkspaces, mountNames]);
 
   useEffect(() => {
-    if (!containerEdited) {
-      setContainerPath(suggestedContainer);
+    if (!draftLoaded || containerEdited) {
+      return;
     }
-  }, [suggestedContainer, containerEdited]);
+    setContainerPath(suggestedContainer);
+  }, [suggestedContainer, containerEdited, draftLoaded]);
 
   const toggleMember = useCallback(({ workspace }: { readonly workspace: Workspace }) => {
     setSelected((previous) =>
@@ -225,19 +461,36 @@ export const WorkspaceLinkForm = ({
     setSimplePath(picked);
   }, []);
 
+  const clearPersistedDraft = useCallback(() => {
+    if (draftStorageKey == null) {
+      return;
+    }
+    persistDraftRef.current = false;
+    clearDraft({ storageKey: draftStorageKey });
+  }, [draftStorageKey]);
+
+  const onCancelClick = useCallback(() => {
+    clearPersistedDraft();
+    onCancel();
+  }, [clearPersistedDraft, onCancel]);
+
   const onSubmitSingle = useCallback(async () => {
     setBusy(true);
     setSubmitError(null);
     try {
       const workspace = await addWorkspace({ rootPath: path });
       await setCurrentWorkspace(workspace.id);
-      onComplete();
+      clearPersistedDraft();
+      setPath('');
+      setValidPath(false);
+      setValidationError(null);
+      onComplete({ mode: 'single' });
     } catch (error) {
       setSubmitError(formatError(error));
     } finally {
       setBusy(false);
     }
-  }, [path, addWorkspace, setCurrentWorkspace, onComplete]);
+  }, [path, addWorkspace, setCurrentWorkspace, clearPersistedDraft, onComplete]);
 
   const onSubmitMulti = useCallback(async () => {
     setBusy(true);
@@ -255,7 +508,8 @@ export const WorkspaceLinkForm = ({
         members,
       });
       await setCurrentWorkspace(workspace.id);
-      onComplete();
+      clearPersistedDraft();
+      onComplete({ mode: 'multi' });
     } catch (error) {
       setSubmitError(formatError(error));
     } finally {
@@ -268,6 +522,7 @@ export const WorkspaceLinkForm = ({
     containerPath,
     addCompositeWorkspace,
     setCurrentWorkspace,
+    clearPersistedDraft,
     onComplete,
   ]);
 
@@ -280,13 +535,21 @@ export const WorkspaceLinkForm = ({
         path: simplePath.trim(),
       });
       await setCurrentWorkspace(workspace.id);
-      onComplete();
+      clearPersistedDraft();
+      onComplete({ mode: 'simple' });
     } catch (error) {
       setSubmitError(formatError(error));
     } finally {
       setBusy(false);
     }
-  }, [addSimpleWorkspace, onComplete, setCurrentWorkspace, simpleName, simplePath]);
+  }, [
+    addSimpleWorkspace,
+    clearPersistedDraft,
+    onComplete,
+    setCurrentWorkspace,
+    simpleName,
+    simplePath,
+  ]);
 
   const onSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -338,12 +601,12 @@ export const WorkspaceLinkForm = ({
     session: null,
     chrome: { kind: 'workspace-create' },
     handlers: {
-      toOverview: onCancel,
+      toOverview: onCancelClick,
       toWorkspaceLauncher: () => {
-        onCancel();
+        onCancelClick();
         window.dispatchEvent(new CustomEvent('goodboy:open-workspace-switcher'));
       },
-      toWorkspaceBoard: onCancel,
+      toWorkspaceBoard: onCancelClick,
     },
   });
 
@@ -357,7 +620,7 @@ export const WorkspaceLinkForm = ({
       ) : (
         <span className="min-w-0 flex-1" aria-hidden />
       )}
-      <Button type="button" variant="ghost" onClick={onCancel} disabled={busy}>
+      <Button type="button" variant="ghost" onClick={onCancelClick} disabled={busy}>
         {cancelLabel}
       </Button>
       <Button type="submit" form={formId} disabled={primaryDisabled} aria-busy={busy}>

--- a/apps/desktop/src/shared/lib/storage-keys.test.ts
+++ b/apps/desktop/src/shared/lib/storage-keys.test.ts
@@ -8,6 +8,10 @@ describe('storage keys', () => {
     expect(STORAGE_KEYS.rightSidebarWidth).toBe(RIGHT_SIDEBAR_STORAGE_KEY);
   });
 
+  it('registers the onboarding workspace draft key', () => {
+    expect(STORAGE_KEYS.onboardingWorkspaceDraft).toBe('goodboy:onboarding-workspace-draft:v1');
+  });
+
   it('keeps every registered key under the goodboy namespace', () => {
     for (const key of Object.values(STORAGE_KEYS)) {
       expect(key.startsWith('goodboy:')).toBe(true);

--- a/apps/desktop/src/shared/lib/storage-keys.ts
+++ b/apps/desktop/src/shared/lib/storage-keys.ts
@@ -12,6 +12,7 @@ export const STORAGE_KEYS = {
   planListWidth: `${PREFIX}plan-list-width`,
   leftSidebarWidth: `${PREFIX}left-sidebar-width:v2`,
   rightSidebarWidth: `${PREFIX}right-sidebar-width`,
+  onboardingWorkspaceDraft: `${PREFIX}onboarding-workspace-draft:v1`,
 } as const;
 
 export const STORAGE_PREFIXES = {

--- a/packages/ui/src/__tests__/Dialog.test.tsx
+++ b/packages/ui/src/__tests__/Dialog.test.tsx
@@ -1,0 +1,22 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { Dialog } from '../components/Dialog';
+
+afterEach(cleanup);
+
+describe('Dialog', () => {
+  it('focuses the first enabled field in the dialog body', () => {
+    render(
+      <Dialog open onClose={() => undefined} title="Add workspace">
+        <div className="flex flex-col gap-2">
+          <input aria-label="Workspace path" />
+          <button type="button">Secondary action</button>
+        </div>
+      </Dialog>,
+    );
+
+    expect(screen.getByRole('button', { name: 'close' })).not.toBe(document.activeElement);
+    expect(screen.getByLabelText('Workspace path')).toBe(document.activeElement);
+  });
+});

--- a/packages/ui/src/components/Dialog.tsx
+++ b/packages/ui/src/components/Dialog.tsx
@@ -65,6 +65,7 @@ export const Dialog = ({
   panelClassName,
 }: DialogProps) => {
   const ref = useRef<HTMLDialogElement>(null);
+  const bodyRef = useRef<HTMLDivElement>(null);
   const uid = useId();
   const titleId = title ? `${uid}-title` : undefined;
   const descId = description ? `${uid}-desc` : undefined;
@@ -98,8 +99,8 @@ export const Dialog = ({
         if (target) {
           target.focus();
         } else {
-          const first = dialog.querySelector<HTMLElement>(
-            'input:not([disabled]), textarea:not([disabled]), button:not([disabled]), [tabindex]:not([tabindex="-1"])',
+          const first = (bodyRef.current ?? dialog).querySelector<HTMLElement>(
+            'input:not([disabled]), textarea:not([disabled]), select:not([disabled]), button:not([disabled]), a[href], [tabindex]:not([tabindex="-1"])',
           );
           first?.focus();
         }
@@ -197,20 +198,24 @@ export const Dialog = ({
               {panel}
             </div>
             <Divider orientation="vertical" />
+            <div ref={bodyRef} className="min-w-0 flex-1">
+              <ScrollFade
+                className="min-w-0 flex-1 text-sm"
+                viewportClassName={cn('flex flex-col', bodyClassName ?? 'gap-4 px-6 py-5')}
+              >
+                {children}
+              </ScrollFade>
+            </div>
+          </div>
+        ) : (
+          <div ref={bodyRef} className="min-h-0 flex-1">
             <ScrollFade
-              className="min-w-0 flex-1 text-sm"
+              className="min-h-0 flex-1 text-sm"
               viewportClassName={cn('flex flex-col', bodyClassName ?? 'gap-4 px-6 py-5')}
             >
               {children}
             </ScrollFade>
           </div>
-        ) : (
-          <ScrollFade
-            className="min-h-0 flex-1 text-sm"
-            viewportClassName={cn('flex flex-col', bodyClassName ?? 'gap-4 px-6 py-5')}
-          >
-            {children}
-          </ScrollFade>
         )}
         {footer ? (
           <>


### PR DESCRIPTION
Stacked on #1144. Last of the UI polish stack.

## What

Four things found by running the first launch on an empty database. Two are in the new wizard, two are
older and reach much further.

1. **Every `autoFocus` in the app was inert.** `Dialog` queried the whole dialog for the first
   focusable element when no `initialFocusRef` was given, and the `<header>` with the close button
   comes first in DOM order, so focus always landed on the ×. It searches the body now. This is a
   primitive fix, not a per-dialog one.
2. **The workspace form's draft died on every step change.** The wizard keys the step body, so
   changing step remounted it and the typed path, the selected members, the mount name and the name
   went with it. The draft persists, survives navigation, and is cleared on submit and on cancel.
3. **A multi-project setup cost three passes through one step**, because creating a workspace always
   returned the user to the "Workspace connected" card. It is reachable in one pass now.
4. **Changing the current workspace could silently remove setup steps.** The step list derives from the
   workspace kind, so switching to a standalone workspace mid-flow made the code host and Sentry steps
   disappear without a word. The user is told.

## Verified

`pnpm -w typecheck`, desktop suite (3668 tests) and ui suite (51 tests) green.

## Not touched, and why

- **The mandatory gate on the provider and workspace steps is untouched.**
- **No footer went back into the workspace step.** The rule that landed in `cae1a2e1` is that the step
  owns its actions while it is asking or collecting, and the wizard draws the rest.
- **`reopenWizard('setup')` stays in the dialog wrapper**, where the wizard's own guard makes it
  harmless when the wizard is already open.