### PR TITLE
refactor(desktop): take set-once preferences out of the top bar

### DIFF
--- a/apps/desktop/src/app/components/AppTopBar/index.test.tsx
+++ b/apps/desktop/src/app/components/AppTopBar/index.test.tsx
@@ -38,15 +38,6 @@ vi.mock('../../../store', () => ({
   useAppStore: <T,>(selector: (state: typeof store) => T) => selector(store),
 }));
 
-vi.mock('../../../shared/lib/theme', () => ({
-  useThemeStore: <T,>(selector: (s: { theme: string; toggleTheme: () => void }) => T) =>
-    selector({ theme: 'light', toggleTheme: vi.fn() }),
-}));
-
-vi.mock('../../../features/companion/bridge', () => ({
-  bridgeStatus: () => Promise.resolve({ running: false, enrolledCount: 0 }),
-}));
-
 vi.mock('../../../features/updater/components/UpdateIndicator', () => ({
   UpdateIndicator: () => <button type="button">Update to 0.2.0</button>,
 }));
@@ -86,6 +77,14 @@ describe('AppTopBar', () => {
   it('renders settings button', () => {
     render(<AppTopBar onOpenSettings={vi.fn()} onOpenBudget={vi.fn()} activeStudio={null} />);
     expect(screen.getByRole('button', { name: 'open settings' })).toBeDefined();
+  });
+
+  it('keeps set-once preferences out of the bar', () => {
+    render(<AppTopBar onOpenSettings={vi.fn()} onOpenBudget={vi.fn()} activeStudio={null} />);
+
+    expect(screen.queryByRole('button', { name: /switch to (light|dark) mode/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /pair your iphone/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /getting started/i })).toBeNull();
   });
 
   it('settings button has active state when settings studio is open', () => {

--- a/apps/desktop/src/app/components/AppTopBar/index.tsx
+++ b/apps/desktop/src/app/components/AppTopBar/index.tsx
@@ -1,18 +1,11 @@
-import { useEffect, useState } from 'react';
-import { Moon, Smartphone, Sun } from 'lucide-react';
-import { cn, Divider, StatusDot, Tooltip } from '@goodboy/ui';
+import { cn, Divider, Tooltip } from '@goodboy/ui';
 import { DogMascot } from '../../../shared/components/DogMascot';
 import { CONCEPT_ICONS } from '../../../shared/components/conceptIcons';
 import { UpdateIndicator } from '../../../features/updater/components/UpdateIndicator';
-import { bridgeStatus } from '../../../features/companion/bridge';
-import { useThemeStore } from '../../../shared/lib/theme';
 import { NotificationCenter } from '../../../features/notifications/components/NotificationCenter';
 import { RunningScriptsIndicator } from '../../../features/scripts/components/RunningScriptsIndicator';
 import { OnboardingChip } from '../../../features/onboarding/OnboardingCard';
 import { WorkspaceRollupStrip } from './WorkspaceRollupStrip';
-
-const TOPBAR_ICON_BTN =
-  'flex items-center justify-center rounded p-1.5 text-muted-foreground transition-colors hover:text-foreground hover:bg-muted/50' as const;
 
 export type AppTopBarProps = {
   onOpenSettings: () => void;
@@ -21,9 +14,6 @@ export type AppTopBarProps = {
 };
 
 export const AppTopBar = ({ onOpenSettings, onOpenBudget, activeStudio }: AppTopBarProps) => {
-  const theme = useThemeStore((s) => s.theme);
-  const toggleTheme = useThemeStore((s) => s.toggleTheme);
-
   return (
     <>
       <div
@@ -48,27 +38,6 @@ export const AppTopBar = ({ onOpenSettings, onOpenBudget, activeStudio }: AppTop
         <div className="flex shrink-0 items-center gap-0.5">
           <RunningScriptsIndicator />
           <NotificationCenter />
-          <Tooltip content={theme === 'dark' ? 'switch to light mode' : 'switch to dark mode'}>
-            <button
-              type="button"
-              onClick={toggleTheme}
-              aria-label={theme === 'dark' ? 'switch to light mode' : 'switch to dark mode'}
-              className={TOPBAR_ICON_BTN}
-            >
-              {theme === 'dark' ? <Sun size={14} aria-hidden /> : <Moon size={14} aria-hidden />}
-            </button>
-          </Tooltip>
-          <PairDeviceCta />
-          <Tooltip content="getting started">
-            <button
-              type="button"
-              onClick={() => window.dispatchEvent(new CustomEvent('goodboy:open-guide'))}
-              aria-label="open getting started guide"
-              className={TOPBAR_ICON_BTN}
-            >
-              <CONCEPT_ICONS.guide size={14} aria-hidden />
-            </button>
-          </Tooltip>
           <OnboardingChip />
           <Tooltip content="settings (⌘,)">
             <button
@@ -89,45 +58,5 @@ export const AppTopBar = ({ onOpenSettings, onOpenBudget, activeStudio }: AppTop
       </div>
       <Divider />
     </>
-  );
-};
-
-const PairDeviceCta = () => {
-  const [linked, setLinked] = useState(false);
-
-  useEffect(() => {
-    let active = true;
-    const refresh = () => {
-      bridgeStatus()
-        .then((s) => {
-          if (active) setLinked(s.running && s.enrolledCount > 0);
-        })
-        .catch(() => {});
-    };
-    refresh();
-    const id = window.setInterval(refresh, 5000);
-    const onChanged = () => refresh();
-    window.addEventListener('goodboy:bridge-paired-changed', onChanged);
-    return () => {
-      active = false;
-      window.clearInterval(id);
-      window.removeEventListener('goodboy:bridge-paired-changed', onChanged);
-    };
-  }, []);
-
-  const label = linked ? 'iPhone linked, manage' : 'Pair your iPhone';
-
-  return (
-    <button
-      type="button"
-      onClick={() => window.dispatchEvent(new CustomEvent('goodboy:open-pair-device'))}
-      title={label}
-      aria-label={label}
-      className="group/pair relative inline-flex shrink-0 items-center gap-1 rounded-full border border-border-soft/70 bg-gradient-to-b from-muted/40 to-muted/10 px-2 py-0.5 text-[10px] font-medium text-muted-foreground shadow-sm motion-safe:transition-all hover:border-primary/40 hover:from-primary/15 hover:to-primary/5 hover:text-primary hover:shadow-md"
-    >
-      <Smartphone size={11} aria-hidden />
-      <span>Pair</span>
-      {linked ? <StatusDot tone="success" size="sm" /> : null}
-    </button>
   );
 };

--- a/apps/desktop/src/features/session/components/CommandPalette/index.tsx
+++ b/apps/desktop/src/features/session/components/CommandPalette/index.tsx
@@ -18,6 +18,7 @@ import {
 import { PREFIXES, parseQuery, type QuickActionGroup } from '../../../quick-actions';
 import { useToast } from '../../../../app/components/Toast';
 import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../shared/components/conceptIcons';
+import { useThemeStore } from '../../../../shared/lib/theme';
 
 type PaletteGroup = Exclude<QuickActionGroup, 'skill' | 'workflow'> | 'recents';
 
@@ -110,6 +111,8 @@ export const CommandPalette = ({
     currentSession ? (s.sessionWorktrees[currentSession.id]?.[0] ?? null) : null,
   );
   const { showToast } = useToast();
+  const theme = useThemeStore((s) => s.theme);
+  const toggleTheme = useThemeStore((s) => s.toggleTheme);
 
   const parsed = useMemo(() => parseQuery(query), [query]);
 
@@ -194,6 +197,19 @@ export const CommandPalette = ({
       });
     }
 
+    out.push({
+      id: 'action:toggle-theme',
+      label: theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode',
+      group: 'action',
+      onSelect: () => toggleTheme(),
+    });
+    out.push({
+      id: 'action:pair-device',
+      label: 'Pair your iPhone',
+      group: 'action',
+      onSelect: () => window.dispatchEvent(new CustomEvent('goodboy:open-pair-device')),
+    });
+
     if (onOpenShortcutHelp) {
       out.push({
         id: 'help:shortcuts',
@@ -203,6 +219,12 @@ export const CommandPalette = ({
         onSelect: () => onOpenShortcutHelp(),
       });
     }
+    out.push({
+      id: 'help:guide',
+      label: 'Getting started',
+      group: 'help',
+      onSelect: () => window.dispatchEvent(new CustomEvent('goodboy:open-guide')),
+    });
 
     return out;
   }, [
@@ -221,6 +243,8 @@ export const CommandPalette = ({
     onOpenSettings,
     onNewSession,
     onOpenShortcutHelp,
+    theme,
+    toggleTheme,
   ]);
 
   const filtered = useMemo(() => {

--- a/apps/desktop/src/features/settings/components/SettingsStudio/AppScopePanel.tsx
+++ b/apps/desktop/src/features/settings/components/SettingsStudio/AppScopePanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { RotateCcw } from 'lucide-react';
+import { RotateCcw, Smartphone } from 'lucide-react';
 import { Button, cn, Divider, FieldRow, ScrollFade, SectionHeader, Select } from '@goodboy/ui';
 import { GithubPanel } from '../../../../features/github/components/Panel';
 import { ImportConfigDialog } from '../ImportConfigDialog';
@@ -12,6 +12,8 @@ import { reopenWizard } from '../../../onboarding/onboarding-store';
 import { formatError } from '../../../../shared/lib/errors';
 import { useToast } from '../../../../app/components/Toast';
 import { useAppStore } from '../../../../store';
+import { useThemeStore } from '../../../../shared/lib/theme';
+import { CONCEPT_ICONS } from '../../../../shared/components/conceptIcons';
 import { ShortcutsSection } from './ShortcutsSection';
 
 type Props = {
@@ -20,6 +22,8 @@ type Props = {
 };
 
 export const AppScopePanel = ({ initialSection, requestClose }: Props) => {
+  const theme = useThemeStore((s) => s.theme);
+  const setTheme = useThemeStore((s) => s.setTheme);
   const loadSetting = useAppStore((s) => s.loadSetting);
   const saveSetting = useAppStore((s) => s.saveSetting);
   const exportConfig = useAppStore((s) => s.exportConfig);
@@ -117,6 +121,25 @@ export const AppScopePanel = ({ initialSection, requestClose }: Props) => {
     <ScrollFade className="h-full w-full" viewportClassName="px-5 py-5">
       <div className="mx-auto flex w-full max-w-2xl flex-col">
         <div className="flex flex-col gap-6">
+          <section id="appearance" ref={anchor('appearance')} className="flex flex-col gap-4">
+            <SectionHeader label="Appearance" hint="How the app looks on this Mac." />
+            <div className="flex flex-col">
+              <FieldRow label="Theme" help="Applies to every window.">
+                <Select
+                  size="sm"
+                  value={theme}
+                  onChange={(e) => setTheme(e.target.value === 'light' ? 'light' : 'dark')}
+                  aria-label="theme"
+                >
+                  <option value="dark">Dark</option>
+                  <option value="light">Light</option>
+                </Select>
+              </FieldRow>
+            </div>
+          </section>
+
+          <Divider />
+
           <section id="editor" ref={anchor('editor')} className="flex flex-col gap-4">
             <SectionHeader label="Editor" hint="Default tools and first-run preferences." />
             <div className="flex flex-col">
@@ -145,6 +168,32 @@ export const AppScopePanel = ({ initialSection, requestClose }: Props) => {
                   }}
                 >
                   <RotateCcw size={14} aria-hidden /> Run setup again
+                </Button>
+              </FieldRow>
+
+              <FieldRow label="Getting started" help="Open the guide.">
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => {
+                    requestClose();
+                    window.dispatchEvent(new CustomEvent('goodboy:open-guide'));
+                  }}
+                >
+                  <CONCEPT_ICONS.guide size={14} aria-hidden /> Open guide
+                </Button>
+              </FieldRow>
+
+              <FieldRow label="iPhone" help="Follow your sessions from your phone.">
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => {
+                    requestClose();
+                    window.dispatchEvent(new CustomEvent('goodboy:open-pair-device'));
+                  }}
+                >
+                  <Smartphone size={14} aria-hidden /> Pair your iPhone
                 </Button>
               </FieldRow>
             </div>


### PR DESCRIPTION
Theme, Pair and the guide sat permanently in chrome for choices made once. They move to settings and the command palette, which buys the room the single strip needs.

- Appearance section in app settings owns the theme.
- Getting started and Pair your iPhone become rows in settings and entries in the palette.
- `PairDeviceCta` deleted; the bar keeps only cross-session monitoring plus app settings.

First of three. Stacked on ak/fix-nav-balance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)