### PR TITLE
refactor(desktop): one home for the workspace identity

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -27,7 +27,6 @@ import { useWindowPresence } from './features/workspace/hooks/useWindowPresence'
 import { WorkspaceLinkDialog } from './features/workspace/components/WorkspaceLinkDialog';
 import { ConvertWorkspaceDialog } from './features/workspace/components/ConvertWorkspaceDialog';
 import { WorkspaceLauncher } from './features/workspace/components/WorkspaceLauncher';
-import { WorkspaceSwitcher } from './features/workspace/components/WorkspaceSwitcher';
 import { isMainWindow } from './features/workspace/window';
 import { WorkflowStudio } from './features/workflows/components/WorkflowStudio';
 import { NewSessionView } from './features/session/components/NewSessionView';
@@ -113,7 +112,6 @@ export const App = () => {
   const [palettePrefix, setPalettePrefix] = useState('');
   const [addWorkspaceOpen, setAddWorkspaceOpen] = useState(false);
   const [convertWorkspaceOpen, setConvertWorkspaceOpen] = useState(false);
-  const [switcherOpen, setSwitcherOpen] = useState(false);
   const [workflowStudioOpen, setWorkflowStudioOpen] = useState(false);
   const [linearStudioOpen, setLinearStudioOpen] = useState(false);
   const [linearStudioFocus, setLinearStudioFocus] = useState<string | null>(null);
@@ -174,7 +172,6 @@ export const App = () => {
       setGitlabStudioOpen(false);
       setGuideStudioOpen(false);
       setAddWorkspaceOpen(false);
-      setSwitcherOpen(false);
       setAppSettingsFocus(detail?.section);
       setAppSettingsOpen(true);
     };
@@ -188,7 +185,6 @@ export const App = () => {
       setGitlabStudioOpen(false);
       setAppSettingsOpen(false);
       setAddWorkspaceOpen(false);
-      setSwitcherOpen(false);
       setGuideStudioOpen(true);
     };
     const onOpenGithubStudio = (event: Event) => {
@@ -209,7 +205,6 @@ export const App = () => {
       setAppSettingsOpen(false);
       setGuideStudioOpen(false);
       setAddWorkspaceOpen(false);
-      setSwitcherOpen(false);
       setGithubStudioSession(detail?.sessionId ?? null);
       setGithubStudioPrNumber(detail?.prNumber ?? null);
       setGithubStudioThreadId(detail?.threadId ?? null);
@@ -251,7 +246,6 @@ export const App = () => {
       setAppSettingsOpen(false);
       setGuideStudioOpen(false);
       setAddWorkspaceOpen(false);
-      setSwitcherOpen(false);
       setProviderStudioFocus(detail?.providerId ?? null);
       setProviderStudioAction(detail?.action ?? null);
       setProviderStudioOpen(true);
@@ -268,7 +262,6 @@ export const App = () => {
       setAppSettingsOpen(false);
       setGuideStudioOpen(false);
       setAddWorkspaceOpen(false);
-      setSwitcherOpen(false);
       setBudgetStudioScope(detail?.scope);
       setBudgetStudioOpen(true);
     };
@@ -283,7 +276,6 @@ export const App = () => {
       setAppSettingsOpen(false);
       setGuideStudioOpen(false);
       setAddWorkspaceOpen(false);
-      setSwitcherOpen(false);
       setLinearStudioFocus(detail?.issueExternalId ?? null);
       setLinearStudioOpen(true);
     };
@@ -298,7 +290,6 @@ export const App = () => {
       setAppSettingsOpen(false);
       setGuideStudioOpen(false);
       setAddWorkspaceOpen(false);
-      setSwitcherOpen(false);
       setSentryStudioFocus(detail?.issueExternalId ?? null);
       setSentryStudioOpen(true);
     };
@@ -313,7 +304,6 @@ export const App = () => {
       setAppSettingsOpen(false);
       setGuideStudioOpen(false);
       setAddWorkspaceOpen(false);
-      setSwitcherOpen(false);
       setGitlabStudioFocus(detail?.issueExternalId ?? null);
       setGitlabStudioOpen(true);
     };
@@ -328,7 +318,6 @@ export const App = () => {
       }
     };
     const onAddWorkspace = () => setAddWorkspaceOpen(true);
-    const onOpenSwitcher = () => setSwitcherOpen(true);
     const onPairDevice = () => setCompanionOpen(true);
 
     window.addEventListener('goodboy:open-settings', onOpenSettings);
@@ -343,7 +332,6 @@ export const App = () => {
     window.addEventListener('goodboy:open-gitlab-studio', onOpenGitlabStudio);
     window.addEventListener('goodboy:reveal-chat', onRevealChat);
     window.addEventListener('goodboy:add-workspace', onAddWorkspace);
-    window.addEventListener('goodboy:open-workspace-switcher', onOpenSwitcher);
     window.addEventListener('goodboy:open-pair-device', onPairDevice);
     return () => {
       window.removeEventListener('goodboy:open-settings', onOpenSettings);
@@ -358,7 +346,6 @@ export const App = () => {
       window.removeEventListener('goodboy:open-gitlab-studio', onOpenGitlabStudio);
       window.removeEventListener('goodboy:reveal-chat', onRevealChat);
       window.removeEventListener('goodboy:add-workspace', onAddWorkspace);
-      window.removeEventListener('goodboy:open-workspace-switcher', onOpenSwitcher);
       window.removeEventListener('goodboy:open-pair-device', onPairDevice);
     };
   }, []);
@@ -497,7 +484,6 @@ export const App = () => {
     setAppSettingsOpen(false);
     setGuideStudioOpen(false);
     setAddWorkspaceOpen(false);
-    setSwitcherOpen(false);
   }, []);
 
   const activeStudio: string | null = workflowStudioOpen
@@ -708,7 +694,9 @@ export const App = () => {
   useKeyboardShortcut('cmd+.', openDeleteSession);
   useKeyboardShortcut('cmd+shift+a', openArchiveSession);
   useKeyboardShortcut('cmd+k', () => openPalette());
-  useKeyboardShortcut('cmd+o', () => setSwitcherOpen(true));
+  useKeyboardShortcut('cmd+o', () =>
+    window.dispatchEvent(new CustomEvent('goodboy:open-workspace-switcher')),
+  );
   useKeyboardShortcut('cmd+n', openNewSession, { ignoreInInputs: false });
   useKeyboardShortcut('cmd+b', sessionSidebar.toggle, { ignoreInInputs: false });
   useKeyboardShortcut('cmd+[', () => navigateLens(-1), { ignoreInInputs: false });
@@ -782,7 +770,6 @@ export const App = () => {
       <ToastProvider>
         <NotificationToastBridge />
         <WorkspaceLauncher />
-        {switcherOpen ? <WorkspaceSwitcher onClose={() => setSwitcherOpen(false)} /> : null}
       </ToastProvider>
     );
   }
@@ -799,7 +786,7 @@ export const App = () => {
             hasWorkspace={currentWorkspace != null}
             hasActiveSession={hasActiveSession}
             isSessionSidebarCollapsed={sessionSidebar.isCollapsed}
-            isSessionSidebarHidden={sessionSidebar.leftHidden}
+            isSessionSidebarPeeking={sessionSidebar.isPeeking}
             onToggleSessionSidebar={
               sessionSidebar.isCollapsed ? sessionSidebar.pin : sessionSidebar.toggle
             }
@@ -1051,7 +1038,6 @@ export const App = () => {
           <ArchiveSessionConfirm session={currentSession} onClose={() => setArchiveOpen(false)} />
         </div>
       ) : null}
-      {switcherOpen ? <WorkspaceSwitcher onClose={() => setSwitcherOpen(false)} /> : null}
 
       {companionOpen ? <CompanionStudio onClose={() => setCompanionOpen(false)} /> : null}
 

--- a/apps/desktop/src/app/components/AppTopBar/index.test.tsx
+++ b/apps/desktop/src/app/components/AppTopBar/index.test.tsx
@@ -89,7 +89,7 @@ type BarOverrides = {
   readonly hasWorkspace?: boolean;
   readonly hasActiveSession?: boolean;
   readonly isSessionSidebarCollapsed?: boolean;
-  readonly isSessionSidebarHidden?: boolean;
+  readonly isSessionSidebarPeeking?: boolean;
   readonly onToggleSessionSidebar?: () => void;
   readonly onSessionSidebarAnchorEnter?: () => void;
   readonly onSessionSidebarAnchorLeave?: () => void;
@@ -104,7 +104,7 @@ const renderBar = (overrides: BarOverrides = {}) =>
       hasWorkspace={overrides.hasWorkspace ?? true}
       hasActiveSession={overrides.hasActiveSession ?? false}
       isSessionSidebarCollapsed={overrides.isSessionSidebarCollapsed ?? false}
-      isSessionSidebarHidden={overrides.isSessionSidebarHidden ?? true}
+      isSessionSidebarPeeking={overrides.isSessionSidebarPeeking ?? false}
       onToggleSessionSidebar={overrides.onToggleSessionSidebar ?? vi.fn()}
       onSessionSidebarAnchorEnter={overrides.onSessionSidebarAnchorEnter ?? vi.fn()}
       onSessionSidebarAnchorLeave={overrides.onSessionSidebarAnchorLeave ?? vi.fn()}
@@ -125,8 +125,8 @@ describe('AppTopBar', () => {
     expect(screen.queryByRole('button', { name: /getting started/i })).toBeNull();
   });
 
-  it('carries workspace identity only when the sidebar is not showing it', () => {
-    const { rerender } = renderBar({ isSessionSidebarHidden: true });
+  it('carries workspace identity whatever the column is doing', () => {
+    const { rerender } = renderBar({ hasActiveSession: false });
     expect(screen.getByLabelText('Switch or open a workspace')).toBeDefined();
 
     rerender(
@@ -137,13 +137,45 @@ describe('AppTopBar', () => {
         hasWorkspace
         hasActiveSession
         isSessionSidebarCollapsed={false}
-        isSessionSidebarHidden={false}
+        isSessionSidebarPeeking={false}
         onToggleSessionSidebar={vi.fn()}
         onSessionSidebarAnchorEnter={vi.fn()}
         onSessionSidebarAnchorLeave={vi.fn()}
       />,
     );
+    expect(screen.getByLabelText('Switch or open a workspace')).toBeDefined();
+  });
+
+  it('falls back to the wordmark before any workspace exists', () => {
+    renderBar({ hasWorkspace: false });
+
+    expect(screen.getByText('Goodboy')).toBeDefined();
     expect(screen.queryByLabelText('Switch or open a workspace')).toBeNull();
+  });
+
+  it('holds the column control pressed while the peek is open', () => {
+    const { rerender } = renderBar({ hasActiveSession: true, isSessionSidebarCollapsed: true });
+    expect(
+      screen.getByRole('button', { name: /show sessions column/i }).getAttribute('aria-pressed'),
+    ).toBe('false');
+
+    rerender(
+      <AppTopBar
+        onOpenSettings={vi.fn()}
+        onOpenBudget={vi.fn()}
+        activeStudio={null}
+        hasWorkspace
+        hasActiveSession
+        isSessionSidebarCollapsed
+        isSessionSidebarPeeking
+        onToggleSessionSidebar={vi.fn()}
+        onSessionSidebarAnchorEnter={vi.fn()}
+        onSessionSidebarAnchorLeave={vi.fn()}
+      />,
+    );
+    const toggle = screen.getByRole('button', { name: /show sessions column/i });
+    expect(toggle.className).toContain('bg-muted text-foreground');
+    expect(toggle.getAttribute('aria-pressed')).toBe('true');
   });
 
   it('shows the column control only inside a session', () => {
@@ -159,7 +191,7 @@ describe('AppTopBar', () => {
         hasWorkspace
         hasActiveSession
         isSessionSidebarCollapsed
-        isSessionSidebarHidden
+        isSessionSidebarPeeking={false}
         onToggleSessionSidebar={onToggleSessionSidebar}
         onSessionSidebarAnchorEnter={vi.fn()}
         onSessionSidebarAnchorLeave={vi.fn()}

--- a/apps/desktop/src/app/components/AppTopBar/index.tsx
+++ b/apps/desktop/src/app/components/AppTopBar/index.tsx
@@ -20,7 +20,7 @@ export type AppTopBarProps = {
   hasWorkspace: boolean;
   hasActiveSession: boolean;
   isSessionSidebarCollapsed: boolean;
-  isSessionSidebarHidden: boolean;
+  isSessionSidebarPeeking: boolean;
   onToggleSessionSidebar: () => void;
   onSessionSidebarAnchorEnter: () => void;
   onSessionSidebarAnchorLeave: () => void;
@@ -33,7 +33,7 @@ export const AppTopBar = ({
   hasWorkspace,
   hasActiveSession,
   isSessionSidebarCollapsed,
-  isSessionSidebarHidden,
+  isSessionSidebarPeeking,
   onToggleSessionSidebar,
   onSessionSidebarAnchorEnter,
   onSessionSidebarAnchorLeave,
@@ -46,6 +46,8 @@ export const AppTopBar = ({
         data-tauri-drag-region
         className="relative flex h-9 shrink-0 items-center gap-2 bg-background px-3"
       >
+        <DogMascot size={15} className="shrink-0 text-foreground" />
+
         {hasActiveSession ? (
           <Tooltip content={columnActionLabel}>
             <button
@@ -55,7 +57,13 @@ export const AppTopBar = ({
               onPointerLeave={onSessionSidebarAnchorLeave}
               data-tauri-drag-region="false"
               aria-label={columnActionLabel}
-              className="flex shrink-0 items-center justify-center rounded p-1.5 text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
+              aria-pressed={isSessionSidebarPeeking}
+              className={cn(
+                'flex shrink-0 items-center justify-center rounded p-1.5 transition-colors',
+                isSessionSidebarPeeking
+                  ? 'bg-muted text-foreground'
+                  : 'text-muted-foreground hover:bg-muted/50 hover:text-foreground',
+              )}
             >
               {isSessionSidebarCollapsed ? (
                 <PanelLeft size={14} aria-hidden />
@@ -66,13 +74,12 @@ export const AppTopBar = ({
           </Tooltip>
         ) : null}
 
-        {hasWorkspace && isSessionSidebarHidden ? (
-          <WorkspaceIdentityRow variant="compact" />
+        {hasWorkspace ? (
+          <WorkspaceIdentityRow />
         ) : (
-          <div className="flex shrink-0 items-center gap-1.5">
-            <DogMascot size={15} className="shrink-0 text-foreground" />
-            <span className="text-xs font-semibold tracking-tight text-foreground">Goodboy</span>
-          </div>
+          <span className="shrink-0 text-xs font-semibold tracking-tight text-foreground">
+            Goodboy
+          </span>
         )}
 
         <div className="flex min-w-0 flex-1 items-center overflow-hidden pl-1">

--- a/apps/desktop/src/features/workspace/components/SidebarPeekOverlay/index.tsx
+++ b/apps/desktop/src/features/workspace/components/SidebarPeekOverlay/index.tsx
@@ -78,12 +78,16 @@ export const SidebarPeekOverlay = ({
             style={{ width: readWidth() }}
             className={cn(
               'pointer-events-auto absolute inset-y-0 left-0 flex min-h-0 flex-col overflow-hidden',
-              'border-r border-border bg-background shadow-[8px_0_24px_-10px_rgba(0,0,0,0.75)]',
+              'bg-background shadow-[16px_0_40px_-24px_rgba(0,0,0,0.5)]',
               'motion-safe:transition-transform duration-200 ease-out',
               hasEntered ? 'translate-x-0' : '-translate-x-full',
             )}
           >
             {children}
+            <span
+              aria-hidden
+              className="pointer-events-none absolute inset-y-0 right-0 w-px bg-gradient-to-b from-transparent via-border-soft to-transparent"
+            />
           </div>
         </SidebarPeekHoldContext>
       ) : null}

--- a/apps/desktop/src/features/workspace/components/WorkspaceIdentityRow/index.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspaceIdentityRow/index.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 
+import { act } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import type { Workspace, WorkspaceId } from '@goodboy/types';
@@ -17,6 +18,10 @@ const { workspaceRef } = vi.hoisted(() => ({
 vi.mock('../../../../store', () => ({
   useCurrentWorkspace: () => workspaceRef.value,
   useHasUnreadElsewhere: () => false,
+  useWorkspaces: () => (workspaceRef.value ? [workspaceRef.value] : []),
+  useWorkspaceHasUnread: () => false,
+  useAppStore: (selector: (s: { openWorkspace: () => Promise<void> }) => unknown) =>
+    selector({ openWorkspace: async () => undefined }),
 }));
 
 import { WorkspaceIdentityRow } from './index';
@@ -24,33 +29,45 @@ import { WorkspaceIdentityRow } from './index';
 afterEach(cleanup);
 
 describe('WorkspaceIdentityRow', () => {
-  it('carries the repo subtitle in the sidebar', () => {
-    render(<WorkspaceIdentityRow variant="sidebar" />);
-
-    expect(screen.getByText('Acme')).toBeDefined();
-    expect(screen.getByText('monorepo')).toBeDefined();
-  });
-
-  it('drops the subtitle when it rides in the strip', () => {
-    render(<WorkspaceIdentityRow variant="compact" />);
+  it('names the workspace and keeps the repo out of the strip', () => {
+    render(<WorkspaceIdentityRow />);
 
     expect(screen.getByText('Acme')).toBeDefined();
     expect(screen.queryByText('monorepo')).toBeNull();
   });
 
-  it('keeps settings next to the identity it configures', () => {
-    const spy = vi.fn();
-    window.addEventListener('goodboy:open-workspace-settings', spy);
-    render(<WorkspaceIdentityRow variant="compact" />);
+  it('carries the repo in the switcher title', () => {
+    render(<WorkspaceIdentityRow />);
 
-    fireEvent.click(screen.getByLabelText(/open workspace settings for acme/i));
-    expect(spy).toHaveBeenCalledOnce();
-    window.removeEventListener('goodboy:open-workspace-settings', spy);
+    expect(screen.getByLabelText('Switch or open a workspace').getAttribute('title')).toBe(
+      'Acme, monorepo',
+    );
+  });
+
+  it('opens the selector as a popover, not a full-screen layer', () => {
+    render(<WorkspaceIdentityRow />);
+    const trigger = screen.getByLabelText('Switch or open a workspace');
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+
+    fireEvent.click(trigger);
+
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+    expect(screen.getByText('Workspace settings')).toBeDefined();
+  });
+
+  it('answers the global switcher shortcut', () => {
+    render(<WorkspaceIdentityRow />);
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent('goodboy:open-workspace-switcher'));
+    });
+
+    expect(screen.getByText('Workspace settings')).toBeDefined();
   });
 
   it('renders nothing without a workspace', () => {
     workspaceRef.value = null;
-    const { container } = render(<WorkspaceIdentityRow variant="sidebar" />);
+    const { container } = render(<WorkspaceIdentityRow />);
 
     expect(container.firstChild).toBeNull();
     workspaceRef.value = {

--- a/apps/desktop/src/features/workspace/components/WorkspaceIdentityRow/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspaceIdentityRow/index.tsx
@@ -1,95 +1,67 @@
-import { ChevronsUpDown, Settings } from 'lucide-react';
-import { StatusDot, cn } from '@goodboy/ui';
+import { useEffect, useRef, useState } from 'react';
+import { ChevronsUpDown } from 'lucide-react';
+import { StatusDot } from '@goodboy/ui';
 import { useCurrentWorkspace, useHasUnreadElsewhere } from '../../../../store';
 import { workspaceAccent } from '../../color';
+import { WorkspaceSwitcher } from '../WorkspaceSwitcher';
 
 const initialOf = (name: string): string => name.trim().charAt(0).toUpperCase() || '?';
 
 const basenameOf = (path: string): string => path.replace(/\/+$/, '').split('/').pop() || path;
 
-export type WorkspaceIdentityVariant = 'sidebar' | 'compact';
-
-type Props = {
-  readonly variant: WorkspaceIdentityVariant;
-};
-
-export const WorkspaceIdentityRow = ({ variant }: Props) => {
+export const WorkspaceIdentityRow = () => {
   const currentWorkspace = useCurrentWorkspace();
   const hasUnreadElsewhere = useHasUnreadElsewhere(currentWorkspace?.id ?? null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const [isOpen, setIsOpen] = useState(false);
+
+  useEffect(() => {
+    const open = () => setIsOpen(true);
+    window.addEventListener('goodboy:open-workspace-switcher', open);
+    return () => window.removeEventListener('goodboy:open-workspace-switcher', open);
+  }, []);
 
   if (!currentWorkspace) {
     return null;
   }
-  const isSidebar = variant === 'sidebar';
   const accent = workspaceAccent(currentWorkspace.id);
   const memberCount = currentWorkspace.members?.length ?? 0;
   const subtitle = memberCount > 1 ? `${memberCount} repos` : basenameOf(currentWorkspace.rootPath);
 
   return (
-    <div
-      className={cn('flex min-w-0 items-center', isSidebar ? 'gap-1' : 'gap-0.5')}
-      data-tauri-drag-region="false"
-    >
+    <>
       <button
+        ref={triggerRef}
         type="button"
-        onClick={() => window.dispatchEvent(new CustomEvent('goodboy:open-workspace-switcher'))}
+        onClick={() => setIsOpen((current) => !current)}
         data-tauri-drag-region="false"
-        className={cn(
-          'group flex min-w-0 items-center rounded-md text-left transition-colors hover:bg-muted/50',
-          isSidebar ? 'flex-1 gap-2.5 px-1.5 py-1.5' : 'max-w-56 gap-1.5 px-1.5 py-1',
-        )}
-        title="Switch or open a workspace"
         aria-label="Switch or open a workspace"
+        aria-expanded={isOpen}
+        className="group flex min-w-0 max-w-56 items-center gap-1.5 rounded-md px-1.5 py-1 text-left transition-colors hover:bg-muted/50"
+        title={`${currentWorkspace.name}, ${subtitle}`}
       >
         <span
           aria-hidden
-          className={cn(
-            'flex shrink-0 items-center justify-center rounded-md font-bold text-primary-foreground shadow-sm',
-            isSidebar ? 'size-7 text-xs' : 'size-5 text-[10px]',
-          )}
+          className="flex size-5 shrink-0 items-center justify-center rounded-md text-[10px] font-bold text-primary-foreground shadow-sm"
           style={{ backgroundColor: accent }}
         >
           {initialOf(currentWorkspace.name)}
         </span>
-        <span className="flex min-w-0 flex-1 flex-col">
-          <span className="flex min-w-0 items-center gap-1.5">
-            <span
-              className={cn(
-                'truncate font-semibold leading-tight text-foreground',
-                isSidebar ? 'text-sm' : 'text-xs',
-              )}
-            >
-              {currentWorkspace.name}
-            </span>
-            {hasUnreadElsewhere ? (
-              <StatusDot tone="warning" size="sm" title="activity in another workspace" />
-            ) : null}
-          </span>
-          {isSidebar ? (
-            <span className="truncate text-2xs leading-tight text-muted-foreground/70">
-              {subtitle}
-            </span>
-          ) : null}
+        <span className="truncate text-xs font-semibold leading-tight text-foreground">
+          {currentWorkspace.name}
         </span>
+        {hasUnreadElsewhere ? (
+          <StatusDot tone="warning" size="sm" title="activity in another workspace" />
+        ) : null}
         <ChevronsUpDown
-          size={isSidebar ? 14 : 12}
+          size={12}
           aria-hidden
           className="shrink-0 text-muted-foreground/40 transition-colors group-hover:text-muted-foreground"
         />
       </button>
-      <button
-        type="button"
-        onClick={() => window.dispatchEvent(new CustomEvent('goodboy:open-workspace-settings'))}
-        data-tauri-drag-region="false"
-        className={cn(
-          'flex shrink-0 items-center justify-center rounded-md text-muted-foreground/50 transition-colors hover:bg-muted/50 hover:text-foreground',
-          isSidebar ? 'size-7' : 'size-6',
-        )}
-        title={`workspace settings, ${currentWorkspace.name}`}
-        aria-label={`open workspace settings for ${currentWorkspace.name}`}
-      >
-        <Settings size={isSidebar ? 14 : 12} aria-hidden />
-      </button>
-    </div>
+      {isOpen ? (
+        <WorkspaceSwitcher anchorRef={triggerRef} onClose={() => setIsOpen(false)} />
+      ) : null}
+    </>
   );
 };

--- a/apps/desktop/src/features/workspace/components/WorkspaceSwitcher/index.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspaceSwitcher/index.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 
+import { createRef, type RefObject } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import type { Workspace, WorkspaceId } from '@goodboy/types';
@@ -22,6 +23,14 @@ vi.mock('../../../../store', () => ({
 
 import { WorkspaceSwitcher } from './index';
 
+const anchored = (): RefObject<HTMLElement | null> => {
+  const ref = createRef<HTMLElement>();
+  const anchor = document.createElement('button');
+  document.body.appendChild(anchor);
+  ref.current = anchor;
+  return ref;
+};
+
 beforeEach(() => {
   state.workspaces = [
     { id: 'ws-a', name: 'alpha', rootPath: '/repos/alpha' } as Workspace,
@@ -31,19 +40,22 @@ beforeEach(() => {
   state.shown = new Set();
   state.openWorkspace = vi.fn(async () => undefined);
 });
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  document.body.innerHTML = '';
+});
 
 describe('WorkspaceSwitcher', () => {
   it('lists workspaces and opens one on click', () => {
     const onClose = vi.fn();
-    render(<WorkspaceSwitcher onClose={onClose} />);
+    render(<WorkspaceSwitcher anchorRef={anchored()} onClose={onClose} />);
     fireEvent.click(screen.getByText('bravo'));
     expect(state.openWorkspace).toHaveBeenCalledWith('ws-b', 'bravo');
     expect(onClose).toHaveBeenCalledOnce();
   });
 
   it('filters by query', () => {
-    render(<WorkspaceSwitcher onClose={vi.fn()} />);
+    render(<WorkspaceSwitcher anchorRef={anchored()} onClose={vi.fn()} />);
     fireEvent.change(screen.getByPlaceholderText(/switch or open/i), {
       target: { value: 'brav' },
     });
@@ -55,10 +67,28 @@ describe('WorkspaceSwitcher', () => {
     const onClose = vi.fn();
     const spy = vi.fn();
     window.addEventListener('goodboy:add-workspace', spy);
-    render(<WorkspaceSwitcher onClose={onClose} />);
+    render(<WorkspaceSwitcher anchorRef={anchored()} onClose={onClose} />);
     fireEvent.click(screen.getByText('New workspace'));
     expect(spy).toHaveBeenCalledOnce();
     expect(onClose).toHaveBeenCalledOnce();
     window.removeEventListener('goodboy:add-workspace', spy);
+  });
+
+  it('carries workspace settings inside the selector', () => {
+    const onClose = vi.fn();
+    const spy = vi.fn();
+    window.addEventListener('goodboy:open-workspace-settings', spy);
+    render(<WorkspaceSwitcher anchorRef={anchored()} onClose={onClose} />);
+    fireEvent.click(screen.getByText('Workspace settings'));
+    expect(spy).toHaveBeenCalledOnce();
+    expect(onClose).toHaveBeenCalledOnce();
+    window.removeEventListener('goodboy:open-workspace-settings', spy);
+  });
+
+  it('anchors to the trigger instead of covering the app', () => {
+    render(<WorkspaceSwitcher anchorRef={anchored()} onClose={vi.fn()} />);
+    const panel = screen.getByRole('dialog', { name: 'Switch or open a workspace' });
+    expect(panel.className).toContain('fixed');
+    expect(panel.style.width).toBe('288px');
   });
 });

--- a/apps/desktop/src/features/workspace/components/WorkspaceSwitcher/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspaceSwitcher/index.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
-import { Plus } from 'lucide-react';
-import { Divider, EmptyState, ScrollFade } from '@goodboy/ui';
+import { useEffect, useLayoutEffect, useMemo, useRef, useState, type RefObject } from 'react';
+import { createPortal } from 'react-dom';
+import { Plus, Settings } from 'lucide-react';
+import { Divider, EmptyState, Popover, ScrollFade } from '@goodboy/ui';
 import type { Workspace } from '@goodboy/types';
 import { useAppStore, useWorkspaces } from '../../../../store';
 import { WorkspaceRow } from '../WorkspaceRow';
@@ -8,15 +9,30 @@ import { filterWorkspaces, sortWorkspacesByRecent } from '../../recent';
 import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../shared/components/conceptIcons';
 
 type Props = {
-  onClose: () => void;
+  readonly anchorRef: RefObject<HTMLElement | null>;
+  readonly onClose: () => void;
 };
 
-export const WorkspaceSwitcher = ({ onClose }: Props) => {
+type Coordinates = {
+  readonly top?: number;
+  readonly bottom?: number;
+  readonly left: number;
+};
+
+const PANEL_WIDTH = 288;
+const VIEWPORT_MARGIN = 8;
+const PANEL_MAX_HEIGHT = 420;
+
+const actionClass =
+  'flex w-full items-center gap-2 px-3 py-2 text-xs text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground';
+
+export const WorkspaceSwitcher = ({ anchorRef, onClose }: Props) => {
   const workspaces = useWorkspaces();
   const openWorkspace = useAppStore((s) => s.openWorkspace);
   const inputRef = useRef<HTMLInputElement>(null);
   const [query, setQuery] = useState('');
   const [activeIndex, setActiveIndex] = useState(0);
+  const [coordinates, setCoordinates] = useState<Coordinates | null>(null);
 
   useEffect(() => {
     inputRef.current?.focus();
@@ -30,6 +46,36 @@ export const WorkspaceSwitcher = ({ onClose }: Props) => {
   useEffect(() => {
     setActiveIndex(0);
   }, [query]);
+
+  useLayoutEffect(() => {
+    const updatePosition = () => {
+      const anchor = anchorRef.current;
+      if (anchor == null) {
+        return;
+      }
+      const rect = anchor.getBoundingClientRect();
+      const maxLeft = window.innerWidth - PANEL_WIDTH - VIEWPORT_MARGIN;
+      const left = Math.min(
+        Math.max(rect.left, VIEWPORT_MARGIN),
+        Math.max(maxLeft, VIEWPORT_MARGIN),
+      );
+      const spaceBelow = window.innerHeight - rect.bottom;
+      const shouldOpenAbove = spaceBelow < PANEL_MAX_HEIGHT + VIEWPORT_MARGIN;
+      setCoordinates({
+        top: shouldOpenAbove ? undefined : rect.bottom + 6,
+        bottom: shouldOpenAbove ? window.innerHeight - rect.top + 6 : undefined,
+        left,
+      });
+    };
+
+    updatePosition();
+    window.addEventListener('resize', updatePosition);
+    window.addEventListener('scroll', updatePosition, true);
+    return () => {
+      window.removeEventListener('resize', updatePosition);
+      window.removeEventListener('scroll', updatePosition, true);
+    };
+  }, [anchorRef]);
 
   const select = (workspace: Workspace) => {
     void openWorkspace(workspace.id, workspace.name);
@@ -55,26 +101,35 @@ export const WorkspaceSwitcher = ({ onClose }: Props) => {
     }
   };
 
-  return (
-    <div
-      className="fixed inset-0 z-50 flex items-start justify-center bg-black/20 pt-[18vh]"
-      onMouseDown={(e) => {
-        if (e.target === e.currentTarget) {
-          onClose();
-        }
-      }}
-    >
-      <div className="flex w-full max-w-lg flex-col overflow-hidden rounded-lg border border-border bg-background shadow-2xl motion-safe:animate-fade-in">
+  if (coordinates == null) {
+    return null;
+  }
+
+  return createPortal(
+    <>
+      <div className="fixed inset-0 z-30" onMouseDown={onClose} aria-hidden />
+      <Popover
+        role="dialog"
+        ariaLabel="Switch or open a workspace"
+        className="fixed z-40 flex flex-col"
+        style={{
+          top: coordinates.top,
+          bottom: coordinates.bottom,
+          left: coordinates.left,
+          width: PANEL_WIDTH,
+        }}
+      >
         <input
           ref={inputRef}
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           onKeyDown={handleKeyDown}
           placeholder="Switch or open a workspace…"
-          className="w-full bg-background px-4 py-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
+          aria-label="Filter workspaces"
+          className="w-full bg-transparent px-3 py-2.5 text-xs focus-visible:outline-none"
         />
         <Divider />
-        <ScrollFade className="max-h-80" viewportClassName="p-1.5">
+        <ScrollFade className="max-h-72" viewportClassName="p-1">
           <ul>
             {filtered.length === 0 ? (
               <li>
@@ -83,7 +138,7 @@ export const WorkspaceSwitcher = ({ onClose }: Props) => {
                   tone={CONCEPT_TONE.workspace}
                   title="No workspaces"
                   size="inline"
-                  className="px-4 py-6"
+                  className="px-3 py-5"
                 />
               </li>
             ) : (
@@ -104,15 +159,27 @@ export const WorkspaceSwitcher = ({ onClose }: Props) => {
         <button
           type="button"
           onClick={() => {
+            window.dispatchEvent(new CustomEvent('goodboy:open-workspace-settings'));
+            onClose();
+          }}
+          className={actionClass}
+        >
+          <Settings size={13} aria-hidden />
+          Workspace settings
+        </button>
+        <button
+          type="button"
+          onClick={() => {
             window.dispatchEvent(new CustomEvent('goodboy:add-workspace'));
             onClose();
           }}
-          className="flex w-full items-center gap-2 px-4 py-2.5 text-sm text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground"
+          className={actionClass}
         >
-          <Plus size={14} aria-hidden />
+          <Plus size={13} aria-hidden />
           New workspace
         </button>
-      </div>
-    </div>
+      </Popover>
+    </>,
+    document.body,
   );
 };

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
@@ -10,7 +10,6 @@ import {
   useSessions,
 } from '../../../../store';
 import { WorkspaceLinkDialog } from '../WorkspaceLinkDialog';
-import { WorkspaceIdentityRow } from '../WorkspaceIdentityRow';
 import { SessionActivityBar } from '../SessionActivityBar';
 import { NoWorkspaceEmpty } from './parts/NoWorkspaceEmpty';
 
@@ -46,11 +45,6 @@ export const WorkspacesSidebar = ({ onNavigate }: Props) => {
 
   return (
     <div className="flex h-full min-h-0 flex-col">
-      {currentWorkspace ? (
-        <div className="shrink-0 px-2 pt-2">
-          <WorkspaceIdentityRow variant="sidebar" />
-        </div>
-      ) : null}
       {currentWorkspace && currentSession ? (
         <div className="shrink-0 px-2 pt-2 pb-1">
           <button

--- a/docs/styling.md
+++ b/docs/styling.md
@@ -156,6 +156,25 @@ use the `<Divider>` component from `@goodboy/ui` (a faded hairline), rendered as
 sibling. Never a `border-t/-r/-b/-l` on a container to act as a divider. Borders that
 define a control's own shape (buttons, inputs, popovers, chips) are fine.
 
+## A dialog is the last resort, not the default
+
+Anything that belongs to a control opens anchored to that control, as a `Popover`
+from `@goodboy/ui` portaled to `document.body` and positioned off the trigger's
+`getBoundingClientRect()`. `AppTopBar/NeedsYouPopover` and
+`workspace/components/WorkspaceSwitcher` are the reference implementations: fixed
+coordinates, a `z-30` click-catcher behind, Escape to close, and a flip above the
+trigger when the space below runs out. A centred overlay for a menu that has an
+obvious on-screen owner is a bug, not a style choice.
+
+Confirmations never open a dialog. A destructive action swaps its own row or button
+for `InlineConfirm`, so the thing being destroyed stays visible while the user
+decides. `WorkspaceLauncher`'s disconnect and `DeleteSessionConfirm` are the pattern.
+
+`Dialog` survives for the three cases an anchor cannot serve: a full-screen viewer
+(`DiffViewerDialog`, the chat lightbox), a multi-step flow that owns the whole
+screen (`OnboardingWizard`, `WorkspaceLinkDialog`), and a blocking system prompt
+(`UpdateIndicator`). Everything else is a popover or inline.
+
 ## An expanded row is one group, not two
 
 A disclosure (header plus the body it reveals) is a single surface. The container


### PR DESCRIPTION
Stacked on #1150.

The peek panel drew a solid full-height `border-border` on its right edge. The pinned column does not: its edge is `ResizeHandle`'s hairline, a 1px gradient that fades out top and bottom. That mismatched pixel is what made the panel read as something glued over the content rather than the column coming back, so it now copies the same hairline and the shadow goes wider and weaker.

Workspace identity moves into the strip and out of the sidebar. It had to live in the strip anyway, because on the board there is no sessions column at all, and the second mount only bought a duplicate whenever the peek panel was open. The strip composition no longer changes when the column collapses: mascot, column toggle, identity, crumbs. The toggle now holds a pressed state while the peek is open.

The selector stops being a centred overlay and opens anchored to the chip that owns it, with `Workspace settings` and `New workspace` as rows inside it, so the gear leaves the strip. Cmd+O and the create-workspace breadcrumb both reach it through the event the chip listens to.

`docs/styling.md` records the rule: anchored popovers by default, `InlineConfirm` for destructive actions, `Dialog` only for full-screen viewers, whole-screen flows and update prompts.

## Verified

- `pnpm -w typecheck` 5/5
- `@goodboy/desktop` 3718 tests, `@goodboy/ui` 54 tests
- `pnpm knip --include files,duplicates,unlisted` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)