### PR TITLE
feat(desktop): say where a workflow came from in the list

### DIFF
--- a/apps/desktop/src-tauri/src/workflows.rs
+++ b/apps/desktop/src-tauri/src/workflows.rs
@@ -103,6 +103,10 @@ pub struct WorkflowRow {
     // session runs without being saved to the preset library.
     #[serde(rename = "isPreset")]
     pub is_preset: bool,
+    // How the workflow came to exist: 'library' (shipped), 'custom' (built by
+    // hand) or 'orchestrated' (born from a dynamic run). None on rows written
+    // before the column existed.
+    pub origin: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -143,6 +147,7 @@ pub struct PhaseTemplateUpsertInput {
     // Defaults to true when omitted so existing callers keep producing presets.
     #[serde(rename = "isPreset", default = "default_true")]
     pub is_preset: bool,
+    pub origin: Option<String>,
 }
 
 fn default_true() -> bool {
@@ -344,6 +349,7 @@ fn row_to_template(
     updated_at: String,
     deleted_at: Option<i64>,
     is_preset: bool,
+    origin: Option<String>,
 ) -> Result<WorkflowRow, rusqlite::Error> {
     let steps = load_steps(conn, &id)?;
     Ok(WorkflowRow {
@@ -358,6 +364,7 @@ fn row_to_template(
         updated_at,
         deleted_at,
         is_preset,
+        origin,
     })
 }
 
@@ -373,7 +380,7 @@ pub fn workflow_list(
     let conn = state.0.lock().map_err(|_| PhaseError::Poisoned)?;
     let mut stmt = conn.prepare(
         "SELECT id, workspace_id, name, description, goal, process_text, created_at, updated_at,
-                deleted_at, is_preset
+                deleted_at, is_preset, origin
          FROM workflows
          WHERE workspace_id = ?1 AND deleted_at IS NULL AND is_preset = 1
          ORDER BY created_at ASC",
@@ -389,6 +396,7 @@ pub fn workflow_list(
         String,
         Option<i64>,
         i64,
+        Option<String>,
     )> = stmt
         .query_map(rusqlite::params![workspace_id], |row| {
             Ok((
@@ -402,15 +410,19 @@ pub fn workflow_list(
                 row.get(7)?,
                 row.get(8)?,
                 row.get(9)?,
+                row.get(10)?,
             ))
         })?
         .collect::<Result<Vec<_>, _>>()
         .map_err(PhaseError::Db)?;
 
     let mut result = Vec::with_capacity(template_ids.len());
-    for (id, ws, name, desc, goal, process, created, updated, deleted, is_preset) in template_ids {
+    for (id, ws, name, desc, goal, process, created, updated, deleted, is_preset, origin) in
+        template_ids
+    {
         let template = row_to_template(
             &conn, id, ws, name, desc, goal, process, created, updated, deleted, is_preset != 0,
+            origin,
         )
         .map_err(PhaseError::Db)?;
         result.push(template);
@@ -426,7 +438,7 @@ pub fn workflow_get(
     let conn = state.0.lock().map_err(|_| PhaseError::Poisoned)?;
     let mut stmt = conn.prepare(
         "SELECT id, workspace_id, name, description, goal, process_text, created_at, updated_at,
-                deleted_at, is_preset
+                deleted_at, is_preset, origin
          FROM workflows
          WHERE id = ?1
          LIMIT 1",
@@ -443,15 +455,16 @@ pub fn workflow_get(
             row.get::<_, String>(7)?,
             row.get::<_, Option<i64>>(8)?,
             row.get::<_, i64>(9)?,
+            row.get::<_, Option<String>>(10)?,
         ))
     })?;
     match rows.next() {
         Some(r) => {
-            let (rid, ws, name, desc, goal, process, created, updated, deleted, is_preset) =
+            let (rid, ws, name, desc, goal, process, created, updated, deleted, is_preset, origin) =
                 r.map_err(PhaseError::Db)?;
             let template = row_to_template(
                 &conn, rid, ws, name, desc, goal, process, created, updated, deleted,
-                is_preset != 0,
+                is_preset != 0, origin,
             )
             .map_err(PhaseError::Db)?;
             Ok(Some(template))
@@ -536,8 +549,8 @@ pub fn workflow_upsert(
     };
 
     conn.execute(
-        "INSERT INTO workflows (id, workspace_id, name, description, goal, process_text, created_at, updated_at, is_preset)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+        "INSERT INTO workflows (id, workspace_id, name, description, goal, process_text, created_at, updated_at, is_preset, origin)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
          ON CONFLICT(id) DO UPDATE SET
            name         = excluded.name,
            description  = excluded.description,
@@ -545,6 +558,7 @@ pub fn workflow_upsert(
            process_text = excluded.process_text,
            updated_at   = excluded.updated_at,
            is_preset    = excluded.is_preset,
+           origin       = COALESCE(workflows.origin, excluded.origin),
            deleted_at   = NULL",
         rusqlite::params![
             id,
@@ -556,6 +570,7 @@ pub fn workflow_upsert(
             created_at,
             now,
             input.is_preset as i32,
+            input.origin.clone(),
         ],
     )?;
 
@@ -660,6 +675,7 @@ pub fn workflow_upsert(
         updated_at: now,
         deleted_at: None,
         is_preset: input.is_preset,
+        origin: input.origin,
     })
 }
 
@@ -726,7 +742,7 @@ pub fn workflows_for_session(
     let conn = state.0.lock().map_err(|_| PhaseError::Poisoned)?;
     let mut stmt = conn.prepare(
         "SELECT w.id, w.workspace_id, w.name, w.description, w.goal, w.process_text, w.created_at,
-                w.updated_at, w.deleted_at, w.is_preset
+                w.updated_at, w.deleted_at, w.is_preset, w.origin
          FROM workflows w
          JOIN session_workflows sw ON sw.workflow_id = w.id
          WHERE sw.session_id = ?1
@@ -743,6 +759,7 @@ pub fn workflows_for_session(
         String,
         Option<i64>,
         i64,
+        Option<String>,
     )> = stmt
         .query_map(rusqlite::params![session_id], |row| {
             Ok((
@@ -756,15 +773,17 @@ pub fn workflows_for_session(
                 row.get(7)?,
                 row.get(8)?,
                 row.get(9)?,
+                row.get(10)?,
             ))
         })?
         .collect::<Result<Vec<_>, _>>()
         .map_err(PhaseError::Db)?;
 
     let mut result = Vec::with_capacity(rows.len());
-    for (id, ws, name, desc, goal, process, created, updated, deleted, is_preset) in rows {
+    for (id, ws, name, desc, goal, process, created, updated, deleted, is_preset, origin) in rows {
         let template = row_to_template(
             &conn, id, ws, name, desc, goal, process, created, updated, deleted, is_preset != 0,
+            origin,
         )
         .map_err(PhaseError::Db)?;
         result.push(template);
@@ -1233,6 +1252,7 @@ mod tests {
             "CREATE TABLE workflows (
                 id TEXT PRIMARY KEY, workspace_id TEXT, name TEXT, description TEXT,
                 created_at TEXT, updated_at TEXT, deleted_at INTEGER, is_preset INTEGER,
+                origin TEXT,
                 goal TEXT, process_text TEXT
             );
             CREATE UNIQUE INDEX idx_workflows_workspace_name_live

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowRailCard.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowRailCard.tsx
@@ -1,11 +1,12 @@
 import { ChevronRight } from 'lucide-react';
-import type { Agent, Workflow, WorkflowRun } from '@goodboy/types';
+import type { Agent, Workflow, WorkflowOrigin, WorkflowRun } from '@goodboy/types';
 import { cn, formatUsdPrecise } from '@goodboy/ui';
 import { classifyWorkflowChain } from '@goodboy/core';
 import { workflowKindName } from '../../../../workspace/components/WorkspacesSidebar/lib';
 import { WorkflowRunStatus } from '../../../../workspace/components/WorkspacesSidebar/parts/WorkflowRunStatus';
 import { formatRelativeDuration } from '../../../../../shared/utils/relativeDate';
 import { CostBadge } from '../../../../providers/components/CostBadge';
+import { WorkflowOriginTag } from '../../../../workflows/components/WorkflowOriginTag';
 
 type Props = {
   readonly run: WorkflowRun;
@@ -56,6 +57,8 @@ export const WorkflowRailCard = ({
     isCompleted && startedAt != null && completedAt != null
       ? formatRelativeDuration(startedAt, completedAt)
       : null;
+  const origin: WorkflowOrigin | null =
+    run.executionMode === 'dynamic' ? 'orchestrated' : (workflow.origin ?? null);
   const stepCount =
     run.executionMode === 'dynamic'
       ? `${ranAgents.length} ${ranAgents.length === 1 ? 'step' : 'steps'} run`
@@ -72,8 +75,11 @@ export const WorkflowRailCard = ({
         )}
       >
         <span className="flex min-w-0 flex-1 flex-col gap-1.5">
-          <span className="line-clamp-2 text-sm font-medium text-foreground">
-            {workflowKindName(workflow)}
+          <span className="flex items-center gap-2">
+            <span className="line-clamp-2 text-sm font-medium text-foreground">
+              {workflowKindName(workflow)}
+            </span>
+            {origin != null ? <WorkflowOriginTag origin={origin} /> : null}
           </span>
           <span className="flex flex-wrap items-center gap-2">
             <WorkflowRunStatus

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowRailCard.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowRailCard.tsx
@@ -75,11 +75,8 @@ export const WorkflowRailCard = ({
         )}
       >
         <span className="flex min-w-0 flex-1 flex-col gap-1.5">
-          <span className="flex items-center gap-2">
-            <span className="line-clamp-2 text-sm font-medium text-foreground">
-              {workflowKindName(workflow)}
-            </span>
-            {origin != null ? <WorkflowOriginTag origin={origin} /> : null}
+          <span className="line-clamp-2 text-sm font-medium text-foreground">
+            {workflowKindName(workflow)}
           </span>
           <span className="flex flex-wrap items-center gap-2">
             <WorkflowRunStatus
@@ -120,7 +117,10 @@ export const WorkflowRailCard = ({
             ) : null}
           </span>
         </span>
-        <ChevronRight size={14} aria-hidden className="shrink-0 text-muted-foreground/50" />
+        <span className="flex shrink-0 items-center gap-2">
+          {origin != null ? <WorkflowOriginTag origin={origin} /> : null}
+          <ChevronRight size={14} aria-hidden className="text-muted-foreground/50" />
+        </span>
       </button>
       {isDiscarded ? (
         <button

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowsPane.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowsPane.test.tsx
@@ -45,6 +45,7 @@ vi.mock('../../../../../store', () => ({
 }));
 
 vi.mock('@goodboy/ui', () => ({
+  Chip: ({ label }: { label?: React.ReactNode }) => <span>{label}</span>,
   Button: ({ children, onClick, className }: ButtonMockProps) => (
     <button type="button" onClick={onClick} className={className}>
       {children}

--- a/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
@@ -689,6 +689,7 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
         ...(process.length > 0 && { processText: process }),
         steps: mode === 'dynamic' ? [] : buildSteps(workflowId),
         isPreset: mode === 'dynamic' ? false : saveAsPreset,
+        origin: mode === 'dynamic' ? 'orchestrated' : 'custom',
         createdAt: now,
         updatedAt: now,
       };

--- a/apps/desktop/src/features/workflows/components/PresetCard/index.test.tsx
+++ b/apps/desktop/src/features/workflows/components/PresetCard/index.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import type { IsoDateTime, Workflow, WorkflowId, WorkspaceId } from '@goodboy/types';
+import { PresetCard } from './index';
+
+afterEach(cleanup);
+
+const NOW = '2026-08-03T00:00:00.000Z' as IsoDateTime;
+
+const workflow = (over: Partial<Workflow> = {}): Workflow => ({
+  id: 'wf-1' as WorkflowId,
+  workspaceId: 'ws-1' as WorkspaceId,
+  name: 'Refactor',
+  description: 'four steps',
+  steps: [],
+  createdAt: NOW,
+  updatedAt: NOW,
+  ...over,
+});
+
+const renderCard = (template: Workflow, approved = true) =>
+  render(
+    <ul>
+      <PresetCard
+        template={template}
+        active={false}
+        approved={approved}
+        onSelect={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    </ul>,
+  );
+
+describe('PresetCard', () => {
+  it('names the origin of the workflow', () => {
+    renderCard(workflow({ origin: 'library' }));
+
+    expect(screen.getByText('preset')).toBeDefined();
+  });
+
+  it('calls an orchestrated workflow by its name, not custom', () => {
+    renderCard(workflow({ origin: 'orchestrated' }));
+
+    expect(screen.getByText('orchestrated')).toBeDefined();
+    expect(screen.queryByText('custom')).toBeNull();
+  });
+
+  it('says nothing about the origin of a row written before it was tracked', () => {
+    renderCard(workflow());
+
+    for (const label of ['preset', 'custom', 'orchestrated']) {
+      expect(screen.queryByText(label)).toBeNull();
+    }
+  });
+
+  it('keeps the draft pill separate from the origin', () => {
+    renderCard(workflow({ origin: 'custom' }), false);
+
+    expect(screen.getByText('draft')).toBeDefined();
+    expect(screen.getByText('custom')).toBeDefined();
+  });
+});

--- a/apps/desktop/src/features/workflows/components/PresetCard/index.tsx
+++ b/apps/desktop/src/features/workflows/components/PresetCard/index.tsx
@@ -4,6 +4,7 @@ import { Check, Trash2, X } from 'lucide-react';
 import type { Workflow } from '@goodboy/types';
 import { inferAgentKindFromName, ROLE_TO_KIND } from '../../../session/agent-kind';
 import { AgentAvatar } from '../../../../shared/components/AgentAvatar';
+import { WorkflowOriginTag } from '../WorkflowOriginTag';
 
 type Props = {
   readonly template: Workflow;
@@ -27,6 +28,7 @@ export const PresetCard = ({ template, active, approved, onSelect, onDelete }: P
       >
         <div className="flex items-center gap-2">
           <span className="truncate text-xs font-medium text-foreground">{template.name}</span>
+          {template.origin != null ? <WorkflowOriginTag origin={template.origin} /> : null}
           {!approved ? (
             <span className="shrink-0 rounded bg-warning/15 px-1 py-px text-2xs font-semibold uppercase leading-none tracking-eyebrow text-warning">
               draft

--- a/apps/desktop/src/features/workflows/components/PresetCard/index.tsx
+++ b/apps/desktop/src/features/workflows/components/PresetCard/index.tsx
@@ -28,14 +28,16 @@ export const PresetCard = ({ template, active, approved, onSelect, onDelete }: P
       >
         <div className="flex items-center gap-2">
           <span className="truncate text-xs font-medium text-foreground">{template.name}</span>
-          {template.origin != null ? <WorkflowOriginTag origin={template.origin} /> : null}
           {!approved ? (
             <span className="shrink-0 rounded bg-warning/15 px-1 py-px text-2xs font-semibold uppercase leading-none tracking-eyebrow text-warning">
               draft
             </span>
           ) : null}
-          <span className="ml-auto shrink-0 text-2xs tabular-nums text-muted-foreground/50">
-            {steps.length} {steps.length === 1 ? 'step' : 'steps'}
+          <span className="ml-auto flex shrink-0 items-center gap-1.5">
+            {template.origin != null ? <WorkflowOriginTag origin={template.origin} /> : null}
+            <span className="text-2xs tabular-nums text-muted-foreground/50">
+              {steps.length} {steps.length === 1 ? 'step' : 'steps'}
+            </span>
           </span>
         </div>
         {description ? (

--- a/apps/desktop/src/features/workflows/components/WorkflowOriginTag/index.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowOriginTag/index.tsx
@@ -1,0 +1,37 @@
+import type { WorkflowOrigin } from '@goodboy/types';
+import { Chip } from '@goodboy/ui';
+import type { Tone } from '@goodboy/ui';
+
+const LABEL: Record<WorkflowOrigin, string> = {
+  library: 'preset',
+  custom: 'custom',
+  orchestrated: 'orchestrated',
+};
+
+const TITLE: Record<WorkflowOrigin, string> = {
+  library: 'Shipped with Goodboy',
+  custom: 'Built step by step',
+  orchestrated: 'Steps decided at runtime',
+};
+
+const TONE: Record<WorkflowOrigin, Tone> = {
+  library: 'neutral',
+  custom: 'neutral',
+  orchestrated: 'accent',
+};
+
+type Props = {
+  readonly origin: WorkflowOrigin;
+};
+
+export const WorkflowOriginTag = ({ origin }: Props) => (
+  <Chip
+    tone={TONE[origin]}
+    size="xs"
+    shape="badge"
+    bordered={false}
+    label={LABEL[origin]}
+    title={TITLE[origin]}
+    className="shrink-0 uppercase tracking-eyebrow"
+  />
+);

--- a/apps/desktop/src/features/workflows/components/WorkflowsPanel/index.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowsPanel/index.tsx
@@ -238,6 +238,7 @@ export const WorkflowsPanel = ({ workspaceId }: Props) => {
       ...(snapshot.goal.trim() ? { goal: snapshot.goal.trim() } : {}),
       steps: defs,
       isPreset: approvedRef.current,
+      origin: 'custom',
     };
 
     isSavingRef.current = true;

--- a/apps/desktop/src/features/workflows/workflows.ts
+++ b/apps/desktop/src/features/workflows/workflows.ts
@@ -17,12 +17,14 @@ import type {
   VerbosityLevel,
   Workflow,
   WorkflowId,
+  WorkflowOrigin,
   WorkflowRunId,
   ProviderRunId,
   SessionId,
   WorkspaceId,
 } from '@goodboy/types';
 import type { ProviderId } from '@goodboy/types';
+import { WORKFLOW_ORIGINS } from '@goodboy/types';
 
 type RawWorkflowStepRow = {
   readonly id: string;
@@ -68,6 +70,7 @@ type RawWorkflowRow = {
   readonly updatedAt: string;
   readonly deletedAt: number | null;
   readonly isPreset: boolean;
+  readonly origin: string | null;
 };
 
 type RawAgentRow = {
@@ -144,6 +147,9 @@ function rowToStepDef(row: RawStepDefRow): StepDef {
   };
 }
 
+const isWorkflowOrigin = (value: string | null): value is WorkflowOrigin =>
+  value != null && (WORKFLOW_ORIGINS as ReadonlyArray<string>).includes(value);
+
 function rowToWorkflow(row: RawWorkflowRow): Workflow {
   return {
     id: row.id as WorkflowId,
@@ -154,6 +160,7 @@ function rowToWorkflow(row: RawWorkflowRow): Workflow {
     ...(row.processText != null && row.processText !== '' && { processText: row.processText }),
     steps: row.steps.map(rowToStep),
     isPreset: row.isPreset,
+    ...(isWorkflowOrigin(row.origin) && { origin: row.origin }),
     createdAt: row.createdAt as IsoDateTime,
     updatedAt: row.updatedAt as IsoDateTime,
     ...(row.deletedAt != null && {
@@ -248,6 +255,7 @@ export type WorkflowUpsertArgs = {
   readonly processText?: string;
   readonly steps: ReadonlyArray<WorkflowStepUpsertArgs>;
   readonly isPreset?: boolean;
+  readonly origin?: WorkflowOrigin;
 };
 
 export const invokeWorkflowUpsert = async (args: WorkflowUpsertArgs): Promise<Workflow> => {
@@ -260,6 +268,7 @@ export const invokeWorkflowUpsert = async (args: WorkflowUpsertArgs): Promise<Wo
       goal: args.goal ?? null,
       processText: args.processText ?? null,
       isPreset: args.isPreset ?? true,
+      origin: args.origin ?? null,
       steps: args.steps.map((d) => ({
         id: d.id ?? null,
         libraryStepId: d.libraryStepId ?? null,

--- a/packages/core/src/workflows/seeder.ts
+++ b/packages/core/src/workflows/seeder.ts
@@ -67,6 +67,7 @@ export const seedWorkflowLibrary = async (
       description: entry.description,
       ...(entry.goal && { goal: entry.goal }),
       steps,
+      origin: 'library',
       createdAt: now,
       updatedAt: now,
     };

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -97,6 +97,7 @@ import { m096SessionExternalTaskMount } from './m096-session-external-task-mount
 import { m097SessionActiveMount } from './m097-session-active-mount';
 import { m098WorkflowStepRouting } from './m098-workflow-step-routing';
 import { m099FileVersions } from './m099-file-versions';
+import { m100WorkflowOrigin } from './m100-workflow-origin';
 
 export type Migration = {
   readonly version: number;
@@ -203,4 +204,5 @@ export const migrations: ReadonlyArray<Migration> = [
   { version: 97, sql: m097SessionActiveMount },
   { version: 98, sql: m098WorkflowStepRouting },
   { version: 99, sql: m099FileVersions },
+  { version: 100, sql: m100WorkflowOrigin },
 ];

--- a/packages/db/src/migrations/m100-workflow-origin.test.ts
+++ b/packages/db/src/migrations/m100-workflow-origin.test.ts
@@ -23,11 +23,15 @@ const seedThrough99 = async () => {
   return db;
 };
 
-const insertWorkflow = async (db: Awaited<ReturnType<typeof seedThrough99>>, id: string) => {
+const insertWorkflow = async (
+  db: Awaited<ReturnType<typeof seedThrough99>>,
+  id: string,
+  name = id,
+) => {
   await db.execute(
     `INSERT INTO workflows (id, workspace_id, name, description, created_at, updated_at, is_preset)
      VALUES (?, ?, ?, ?, ?, ?, 1)`,
-    [id, workspaceId, id, '', new Date().toISOString(), new Date().toISOString()],
+    [id, workspaceId, name, '', new Date().toISOString(), new Date().toISOString()],
   );
 };
 
@@ -61,5 +65,37 @@ describe('m100 workflow origin', () => {
     expect(await originOf(db, `wf_seed_refactor-example_${workspaceId}`)).toBe('library');
     expect(await originOf(db, 'wf_builder_dynamic')).toBe('orchestrated');
     expect(await originOf(db, 'wf_builder_static')).toBe('custom');
+  });
+
+  it('still recognises an orchestrated workflow whose run is gone', async () => {
+    const db = await seedThrough99();
+    await insertWorkflow(db, 'wf_by_name', 'Orchestrated workflow');
+    await insertWorkflow(db, 'wf_by_name_deduped', 'Orchestrated workflow 2');
+    await insertWorkflow(db, 'wf_by_step', 'Ship the thing');
+    await db.execute(
+      `INSERT INTO steps (id, workflow_id, ordinal, name, prompt_prefix, orchestrator_reason)
+       VALUES (?, ?, 0, 'Scout', 'map it', 'the diff touches two packages')`,
+      ['step-1', 'wf_by_step'],
+    );
+
+    await migrate(db, migrations);
+
+    expect(await originOf(db, 'wf_by_name')).toBe('orchestrated');
+    expect(await originOf(db, 'wf_by_name_deduped')).toBe('orchestrated');
+    expect(await originOf(db, 'wf_by_step')).toBe('orchestrated');
+  });
+
+  it('does not read a hand-built workflow as orchestrated', async () => {
+    const db = await seedThrough99();
+    await insertWorkflow(db, 'wf_plain', 'Orchestrated workflows, a guide');
+    await db.execute(
+      `INSERT INTO steps (id, workflow_id, ordinal, name, prompt_prefix)
+       VALUES (?, ?, 0, 'Scout', 'map it')`,
+      ['step-2', 'wf_plain'],
+    );
+
+    await migrate(db, migrations);
+
+    expect(await originOf(db, 'wf_plain')).toBe('custom');
   });
 });

--- a/packages/db/src/migrations/m100-workflow-origin.test.ts
+++ b/packages/db/src/migrations/m100-workflow-origin.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { makeTestDatabase } from '../test-helpers/test-db';
+import { migrate } from './runner';
+import { migrations } from './index';
+
+const workspaceId = 'ws-1';
+
+const seedThrough99 = async () => {
+  const db = makeTestDatabase();
+  await migrate(
+    db,
+    migrations.filter((migration) => migration.version <= 99),
+  );
+  const now = Date.now();
+  await db.execute(
+    'INSERT INTO workspaces (id, name, root_path, created_at, updated_at) VALUES (?, ?, ?, ?, ?)',
+    [workspaceId, 'ws', '/tmp/ws', now, now],
+  );
+  await db.execute(
+    'INSERT INTO sessions (id, workspace_id, goal, state_kind, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)',
+    ['s-1', workspaceId, 'goal', 'idle', now, now],
+  );
+  return db;
+};
+
+const insertWorkflow = async (db: Awaited<ReturnType<typeof seedThrough99>>, id: string) => {
+  await db.execute(
+    `INSERT INTO workflows (id, workspace_id, name, description, created_at, updated_at, is_preset)
+     VALUES (?, ?, ?, ?, ?, ?, 1)`,
+    [id, workspaceId, id, '', new Date().toISOString(), new Date().toISOString()],
+  );
+};
+
+const originOf = async (
+  db: Awaited<ReturnType<typeof seedThrough99>>,
+  id: string,
+): Promise<string | null> => {
+  const rows = await db.select<{ origin: string | null }>(
+    'SELECT origin FROM workflows WHERE id = ?',
+    [id],
+  );
+  return rows[0]?.origin ?? null;
+};
+
+describe('m100 workflow origin', () => {
+  it('reads the origin off rows that predate the column', async () => {
+    const db = await seedThrough99();
+    await insertWorkflow(db, `wf_seed_refactor-example_${workspaceId}`);
+    await insertWorkflow(db, 'wf_builder_dynamic');
+    await insertWorkflow(db, 'wf_builder_static');
+    await db.execute(
+      `INSERT INTO session_workflows
+         (workflow_run_id, session_id, workflow_id, ordinal, current_step_ordinal, auto_run,
+          trigger_mode, execution_mode)
+       VALUES (?, ?, ?, 0, 0, 0, 'immediate', 'dynamic')`,
+      ['run-1', 's-1', 'wf_builder_dynamic'],
+    );
+
+    await migrate(db, migrations);
+
+    expect(await originOf(db, `wf_seed_refactor-example_${workspaceId}`)).toBe('library');
+    expect(await originOf(db, 'wf_builder_dynamic')).toBe('orchestrated');
+    expect(await originOf(db, 'wf_builder_static')).toBe('custom');
+  });
+});

--- a/packages/db/src/migrations/m100-workflow-origin.ts
+++ b/packages/db/src/migrations/m100-workflow-origin.ts
@@ -5,7 +5,12 @@ UPDATE workflows SET origin = 'library' WHERE id LIKE 'wf_seed_%';
 
 UPDATE workflows SET origin = 'orchestrated'
 WHERE origin IS NULL
-  AND id IN (SELECT workflow_id FROM session_workflows WHERE execution_mode = 'dynamic');
+  AND (
+    id IN (SELECT workflow_id FROM session_workflows WHERE execution_mode = 'dynamic')
+    OR id IN (SELECT workflow_id FROM steps WHERE orchestrator_reason IS NOT NULL)
+    OR name = 'Orchestrated workflow'
+    OR name GLOB 'Orchestrated workflow [0-9]*'
+  );
 
 UPDATE workflows SET origin = 'custom' WHERE origin IS NULL;
 `;

--- a/packages/db/src/migrations/m100-workflow-origin.ts
+++ b/packages/db/src/migrations/m100-workflow-origin.ts
@@ -1,0 +1,11 @@
+export const m100WorkflowOrigin = `
+ALTER TABLE workflows ADD COLUMN origin TEXT;
+
+UPDATE workflows SET origin = 'library' WHERE id LIKE 'wf_seed_%';
+
+UPDATE workflows SET origin = 'orchestrated'
+WHERE origin IS NULL
+  AND id IN (SELECT workflow_id FROM session_workflows WHERE execution_mode = 'dynamic');
+
+UPDATE workflows SET origin = 'custom' WHERE origin IS NULL;
+`;

--- a/packages/db/src/queries/workflow.test.ts
+++ b/packages/db/src/queries/workflow.test.ts
@@ -83,6 +83,22 @@ describe('workflow queries', () => {
     expect(live[0]!.name).toBe('Refactor');
   });
 
+  it('round-trips the origin and keeps it when the workflow is saved again', async () => {
+    await upsertWorkflow(db, { ...buildWorkflow(), origin: 'orchestrated' });
+    await upsertWorkflow(db, { ...buildWorkflow(), name: 'Refactor', description: 'edited' });
+
+    const stored = await getWorkflow(db, workflowId);
+
+    expect(stored!.origin).toBe('orchestrated');
+    expect(stored!.description).toBe('edited');
+  });
+
+  it('leaves the origin unset on a workflow written without one', async () => {
+    await upsertWorkflow(db, buildWorkflow());
+
+    expect((await getWorkflow(db, workflowId))!.origin).toBeUndefined();
+  });
+
   it('still rejects a duplicate name among live workflows', async () => {
     await upsertWorkflow(db, buildWorkflow());
 

--- a/packages/db/src/queries/workflow.ts
+++ b/packages/db/src/queries/workflow.ts
@@ -9,8 +9,10 @@ import type {
   VerbosityLevel,
   Workflow,
   WorkflowId,
+  WorkflowOrigin,
   WorkspaceId,
 } from '@goodboy/types';
+import { WORKFLOW_ORIGINS } from '@goodboy/types';
 import type { Database } from '../client';
 
 type WorkflowRow = {
@@ -23,6 +25,7 @@ type WorkflowRow = {
   created_at: string;
   updated_at: string;
   is_preset: number | null;
+  origin: string | null;
   deleted_at: number | null;
 };
 
@@ -64,6 +67,9 @@ function toStep(row: StepRow): Step {
   };
 }
 
+const isWorkflowOrigin = (value: string | null | undefined): value is WorkflowOrigin =>
+  value != null && (WORKFLOW_ORIGINS as ReadonlyArray<string>).includes(value);
+
 function toWorkflow(row: WorkflowRow, steps: ReadonlyArray<Step>): Workflow {
   return {
     id: row.id as WorkflowId,
@@ -74,6 +80,7 @@ function toWorkflow(row: WorkflowRow, steps: ReadonlyArray<Step>): Workflow {
     ...(row.process_text != null && row.process_text !== '' && { processText: row.process_text }),
     steps,
     isPreset: row.is_preset == null ? true : row.is_preset !== 0,
+    ...(isWorkflowOrigin(row.origin) && { origin: row.origin }),
     ...(row.deleted_at != null && {
       deletedAt: new Date(row.deleted_at * 1000).toISOString() as IsoDateTime,
     }),
@@ -121,15 +128,17 @@ export const getWorkflow = async (db: Database, id: WorkflowId): Promise<Workflo
 export const upsertWorkflow = async (db: Database, workflow: Workflow): Promise<void> => {
   await db.execute(
     `INSERT INTO workflows
-      (id, workspace_id, name, description, goal, process_text, created_at, updated_at, is_preset)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      (id, workspace_id, name, description, goal, process_text, created_at, updated_at, is_preset,
+       origin)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
      ON CONFLICT(id) DO UPDATE SET
        name = excluded.name,
        description = excluded.description,
        goal = excluded.goal,
        process_text = excluded.process_text,
        updated_at = excluded.updated_at,
-       is_preset = excluded.is_preset`,
+       is_preset = excluded.is_preset,
+       origin = COALESCE(workflows.origin, excluded.origin)`,
     [
       workflow.id,
       workflow.workspaceId,
@@ -140,6 +149,7 @@ export const upsertWorkflow = async (db: Database, workflow: Workflow): Promise<
       workflow.createdAt,
       workflow.updatedAt,
       workflow.isPreset === false ? 0 : 1,
+      workflow.origin ?? null,
     ],
   );
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -153,7 +153,9 @@ export type {
   Step,
   StepDef,
   Workflow,
+  WorkflowOrigin,
 } from './workflow';
+export { WORKFLOW_ORIGINS } from './workflow';
 export type {
   AuxTaskId,
   GlobalSettings,

--- a/packages/types/src/workflow.ts
+++ b/packages/types/src/workflow.ts
@@ -65,6 +65,14 @@ export type Step = Readonly<{
   deletedAt?: IsoDateTime;
 }>;
 
+export type WorkflowOrigin = 'library' | 'custom' | 'orchestrated';
+
+export const WORKFLOW_ORIGINS: ReadonlyArray<WorkflowOrigin> = [
+  'library',
+  'custom',
+  'orchestrated',
+];
+
 export type Workflow = Readonly<{
   id: WorkflowId;
   workspaceId: WorkspaceId;
@@ -74,6 +82,7 @@ export type Workflow = Readonly<{
   processText?: string;
   steps: ReadonlyArray<Step>;
   isPreset?: boolean;
+  origin?: WorkflowOrigin;
   deletedAt?: IsoDateTime;
   createdAt: IsoDateTime;
   updatedAt: IsoDateTime;


### PR DESCRIPTION
Nella lista dei workflow non si capiva se una riga fosse un preset spedito, uno costruito a mano, o uno nato orchestrato.

Con lo schema attuale la distinzione **non** era ricavabile in modo onesto: `isPreset` significa già "riusabile vs draft", e `executionMode: 'dynamic'` vive sul **run**, non sul workflow. Restava solo l'euristica sul prefisso `wf_seed_` e sul nome.

## Cosa aggiunge

- `WorkflowOrigin = 'library' | 'custom' | 'orchestrated'` sul `Workflow`, scritto nei tre punti dove un workflow nasce: seeder (`library`), Workflow Studio (`custom`), builder di sessione (`orchestrated` in modalità dinamica, altrimenti `custom`).
- **m100** aggiunge la colonna e fa il backfill: `wf_seed_%` → `library`, workflow con un run `execution_mode = 'dynamic'` → `orchestrated`, il resto → `custom`. L'upsert usa `COALESCE(workflows.origin, excluded.origin)`, così un salvataggio successivo non riscrive l'origine.
- `WorkflowOriginTag`: chip xs, neutro per preset/custom, accent per orchestrated (è l'unico che si comporta diversamente a runtime). Il pill "draft" resta separato, è un altro asse.
- Mostrato nella rail dello Studio (`PresetCard`) e nella lista di sessione (`WorkflowRailCard`), dove il run vince sul workflow perché sa già di essere dinamico.

## Test

Backfill provato migrando fino alla 99, inserendo le tre forme di riga e poi applicando la 100. Round-trip dell'origine + prova che un secondo salvataggio non la perde. 4 test su `PresetCard`, incluso il caso di una riga scritta prima che l'origine esistesse (non dice niente).

`cargo check` verde, 3735 test desktop, 145 db, 1024 core, knip pulito.

🤖 Generated with [Claude Code](https://claude.com/claude-code)