### PR TITLE
fix(desktop): the peek opens as a sidebar, not as a panel

### DIFF
--- a/apps/desktop/src/features/workspace/components/SidebarPeekOverlay/index.test.tsx
+++ b/apps/desktop/src/features/workspace/components/SidebarPeekOverlay/index.test.tsx
@@ -2,6 +2,7 @@
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { LEFT_SIDEBAR_STORAGE_KEY } from '@goodboy/ui';
 import { SidebarPeekOverlay } from './index';
 import { useSidebarPeekHold } from './hold';
 
@@ -83,6 +84,13 @@ describe('SidebarPeekOverlay', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'release' }));
     expect(onRelease).toHaveBeenCalledOnce();
+  });
+
+  it('opens a little wider than the pinned sidebar, not half again', () => {
+    localStorage.setItem(LEFT_SIDEBAR_STORAGE_KEY, '300');
+    renderOverlay(true);
+
+    expect(screen.getByRole('region', { name: 'Sessions' }).style.width).toBe('360px');
   });
 
   it('does nothing when nobody provides a hold', () => {

--- a/apps/desktop/src/features/workspace/components/SidebarPeekOverlay/index.tsx
+++ b/apps/desktop/src/features/workspace/components/SidebarPeekOverlay/index.tsx
@@ -8,7 +8,7 @@ import {
 } from '@goodboy/ui';
 import { SidebarPeekHoldContext, type SidebarPeekHold } from './hold';
 
-const PEEK_WIDTH_FACTOR = 1.5;
+const PEEK_WIDTH_FACTOR = 1.2;
 
 const pinnedWidth = (): number => {
   if (typeof localStorage === 'undefined') {


### PR DESCRIPTION
The collapsed sidebar peeked at 1.5x the pinned width. At the default 340px that is a 510px overlay, which reads as a panel taking over the screen rather than as the column coming back.

The factor drops to 1.2, so the peek opens a fifth wider than pinned (408px at the default) and still reads as a sidebar. A test pins the ratio against the real storage key and a non-default pinned width, so the number cannot drift back by accident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)