### PR TITLE
feat(desktop): a changelog of the releases that shipped

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -20,6 +20,7 @@ mod workflows;
 mod provider_credentials;
 mod provider_lifecycle;
 mod providers;
+mod releases;
 mod repo;
 mod scripts;
 mod secrets;
@@ -111,6 +112,7 @@ pub fn run() {
       editor::open_in_editor,
       editor::open_file_in_workspace,
       editor::open_url,
+      releases::releases_list,
       explore::explore_list,
       explore::explore_read,
       explore::explore_open,

--- a/apps/desktop/src-tauri/src/releases.rs
+++ b/apps/desktop/src-tauri/src/releases.rs
@@ -1,0 +1,150 @@
+use std::sync::OnceLock;
+
+use serde::{Deserialize, Serialize};
+
+const REPO_SLUG: &str = "akhayam99/goodboy";
+const PER_PAGE: u32 = 50;
+const CLIENT_USER_AGENT: &str = "goodboy-desktop";
+
+fn http_client() -> &'static reqwest::Client {
+    static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+    CLIENT.get_or_init(reqwest::Client::new)
+}
+
+fn releases_url() -> String {
+    format!(
+        "https://api.github.com/repos/{}/releases?per_page={}",
+        REPO_SLUG, PER_PAGE
+    )
+}
+
+#[derive(Deserialize)]
+pub struct GithubRelease {
+    tag_name: String,
+    html_url: String,
+    #[serde(default)]
+    draft: bool,
+    #[serde(default)]
+    prerelease: bool,
+    #[serde(default)]
+    published_at: Option<String>,
+    #[serde(default)]
+    body: Option<String>,
+}
+
+#[derive(Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReleaseNote {
+    pub version: String,
+    pub published_at: String,
+    pub body: String,
+    pub html_url: String,
+}
+
+fn published_only(raw: Vec<GithubRelease>) -> Vec<ReleaseNote> {
+    raw.into_iter()
+        .filter(|release| !release.draft && !release.prerelease)
+        .filter_map(|release| {
+            let published_at = release.published_at?;
+            Some(ReleaseNote {
+                version: release.tag_name,
+                published_at,
+                body: release.body.unwrap_or_default(),
+                html_url: release.html_url,
+            })
+        })
+        .collect()
+}
+
+#[tauri::command]
+pub async fn releases_list() -> Result<Vec<ReleaseNote>, String> {
+    let response = http_client()
+        .get(releases_url())
+        .header(reqwest::header::USER_AGENT, CLIENT_USER_AGENT)
+        .header(reqwest::header::ACCEPT, "application/vnd.github+json")
+        .send()
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let status = response.status();
+    if !status.is_success() {
+        return Err(format!("github responded {}", status.as_u16()));
+    }
+
+    let raw: Vec<GithubRelease> = response.json().await.map_err(|e| e.to_string())?;
+    Ok(published_only(raw))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(raw: serde_json::Value) -> Vec<GithubRelease> {
+        serde_json::from_value(raw).expect("fixture parses")
+    }
+
+    #[test]
+    fn keeps_only_published_releases() {
+        let raw = parse(serde_json::json!([
+            {
+                "tag_name": "v0.1.55",
+                "html_url": "https://github.com/akhayam99/goodboy/releases/tag/v0.1.55",
+                "draft": false,
+                "prerelease": false,
+                "published_at": "2026-07-01T10:00:00Z",
+                "body": "## the round\n\n- one thing"
+            },
+            {
+                "tag_name": "v0.2.0-rc.1",
+                "html_url": "https://github.com/akhayam99/goodboy/releases/tag/v0.2.0-rc.1",
+                "draft": false,
+                "prerelease": true,
+                "published_at": "2026-07-02T10:00:00Z",
+                "body": "candidate"
+            },
+            {
+                "tag_name": "v0.1.56",
+                "html_url": "https://github.com/akhayam99/goodboy/releases/tag/v0.1.56",
+                "draft": true,
+                "prerelease": false,
+                "published_at": null,
+                "body": "unfinished"
+            }
+        ]));
+
+        let notes = published_only(raw);
+
+        assert_eq!(notes.len(), 1);
+        assert_eq!(notes[0].version, "v0.1.55");
+        assert_eq!(notes[0].published_at, "2026-07-01T10:00:00Z");
+    }
+
+    #[test]
+    fn drops_a_published_flag_without_a_date_and_defaults_a_missing_body() {
+        let raw = parse(serde_json::json!([
+            {
+                "tag_name": "v0.1.54",
+                "html_url": "https://github.com/akhayam99/goodboy/releases/tag/v0.1.54",
+                "published_at": "2026-06-01T10:00:00Z"
+            },
+            {
+                "tag_name": "v0.1.53",
+                "html_url": "https://github.com/akhayam99/goodboy/releases/tag/v0.1.53"
+            }
+        ]));
+
+        let notes = published_only(raw);
+
+        assert_eq!(notes.len(), 1);
+        assert_eq!(notes[0].version, "v0.1.54");
+        assert_eq!(notes[0].body, "");
+    }
+
+    #[test]
+    fn builds_the_api_url_from_the_single_repo_slug() {
+        assert_eq!(
+            releases_url(),
+            "https://api.github.com/repos/akhayam99/goodboy/releases?per_page=50"
+        );
+    }
+}

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -38,6 +38,7 @@ import { ProviderStudio } from './features/providers/components/ProviderStudio';
 import { BudgetStudio } from './features/budget/components/BudgetStudio';
 import type { BudgetScope } from './features/budget/components/BudgetStudio/lib';
 import { ImpactStudio } from './features/impact/components/ImpactStudio';
+import { ChangelogStudio } from './features/changelog/components/ChangelogStudio';
 import { DiffViewerDialog } from './features/permissions/components/DiffViewerDialog';
 import { ghCommitDiff } from './features/github/github';
 import { worktreeDiffCommit } from './features/worktree/worktree';
@@ -130,6 +131,7 @@ export const App = () => {
   const [budgetStudioOpen, setBudgetStudioOpen] = useState(false);
   const [budgetStudioScope, setBudgetStudioScope] = useState<BudgetScope | undefined>(undefined);
   const [impactStudioOpen, setImpactStudioOpen] = useState(false);
+  const [changelogStudioOpen, setChangelogStudioOpen] = useState(false);
   const setSessionStudio = useAppStore((s) => s.setSessionStudio);
   const clearSessionStudio = useCallback(() => {
     const id = useAppStore.getState().currentSessionId;
@@ -168,6 +170,7 @@ export const App = () => {
       setSentryStudioOpen(false);
       setGitlabStudioOpen(false);
       setGuideStudioOpen(false);
+      setChangelogStudioOpen(false);
       setAddWorkspaceOpen(false);
       setAppSettingsFocus(detail?.section);
       setAppSettingsOpen(true);
@@ -181,6 +184,7 @@ export const App = () => {
       setSentryStudioOpen(false);
       setGitlabStudioOpen(false);
       setAppSettingsOpen(false);
+      setChangelogStudioOpen(false);
       setAddWorkspaceOpen(false);
       setGuideStudioOpen(true);
     };
@@ -201,6 +205,7 @@ export const App = () => {
       setGitlabStudioOpen(false);
       setAppSettingsOpen(false);
       setGuideStudioOpen(false);
+      setChangelogStudioOpen(false);
       setAddWorkspaceOpen(false);
       setGithubStudioSession(detail?.sessionId ?? null);
       setGithubStudioPrNumber(detail?.prNumber ?? null);
@@ -242,6 +247,7 @@ export const App = () => {
       setGitlabStudioOpen(false);
       setAppSettingsOpen(false);
       setGuideStudioOpen(false);
+      setChangelogStudioOpen(false);
       setAddWorkspaceOpen(false);
       setProviderStudioFocus(detail?.providerId ?? null);
       setProviderStudioAction(detail?.action ?? null);
@@ -258,6 +264,7 @@ export const App = () => {
       setGitlabStudioOpen(false);
       setAppSettingsOpen(false);
       setGuideStudioOpen(false);
+      setChangelogStudioOpen(false);
       setAddWorkspaceOpen(false);
       setBudgetStudioScope(detail?.scope);
       setBudgetStudioOpen(true);
@@ -272,6 +279,7 @@ export const App = () => {
       setGitlabStudioOpen(false);
       setAppSettingsOpen(false);
       setGuideStudioOpen(false);
+      setChangelogStudioOpen(false);
       setAddWorkspaceOpen(false);
       setLinearStudioFocus(detail?.issueExternalId ?? null);
       setLinearStudioOpen(true);
@@ -286,6 +294,7 @@ export const App = () => {
       setGitlabStudioOpen(false);
       setAppSettingsOpen(false);
       setGuideStudioOpen(false);
+      setChangelogStudioOpen(false);
       setAddWorkspaceOpen(false);
       setSentryStudioFocus(detail?.issueExternalId ?? null);
       setSentryStudioOpen(true);
@@ -300,6 +309,7 @@ export const App = () => {
       setSentryStudioOpen(false);
       setAppSettingsOpen(false);
       setGuideStudioOpen(false);
+      setChangelogStudioOpen(false);
       setAddWorkspaceOpen(false);
       setGitlabStudioFocus(detail?.issueExternalId ?? null);
       setGitlabStudioOpen(true);
@@ -475,6 +485,7 @@ export const App = () => {
     setProviderStudioOpen(false);
     setBudgetStudioOpen(false);
     setImpactStudioOpen(false);
+    setChangelogStudioOpen(false);
     setLinearStudioOpen(false);
     setSentryStudioOpen(false);
     setGitlabStudioOpen(false);
@@ -493,17 +504,19 @@ export const App = () => {
           ? 'budget'
           : impactStudioOpen
             ? 'impact'
-            : linearStudioOpen
-              ? 'linear'
-              : sentryStudioOpen
-                ? 'sentry'
-                : gitlabStudioOpen
-                  ? 'gitlab'
-                  : appSettingsOpen
-                    ? 'settings'
-                    : guideStudioOpen
-                      ? 'guide'
-                      : null;
+            : changelogStudioOpen
+              ? 'changelog'
+              : linearStudioOpen
+                ? 'linear'
+                : sentryStudioOpen
+                  ? 'sentry'
+                  : gitlabStudioOpen
+                    ? 'gitlab'
+                    : appSettingsOpen
+                      ? 'settings'
+                      : guideStudioOpen
+                        ? 'guide'
+                        : null;
 
   const openSettings = useCallback(() => {
     closeAllStudios();
@@ -519,6 +532,10 @@ export const App = () => {
   const openImpact = useCallback(() => {
     closeAllStudios();
     setImpactStudioOpen(true);
+  }, [closeAllStudios]);
+  const openChangelog = useCallback(() => {
+    closeAllStudios();
+    setChangelogStudioOpen(true);
   }, [closeAllStudios]);
   const openDeleteSession = useCallback(() => {
     if (currentSession) {
@@ -779,6 +796,7 @@ export const App = () => {
               }}
               onOpenBudget={openBudget}
               onOpenImpact={openImpact}
+              onOpenChangelog={openChangelog}
               onOpenGithub={() => {
                 closeAllStudios();
                 setGithubStudioSession(currentSession?.id ?? null);
@@ -953,6 +971,12 @@ export const App = () => {
           workspaceId={currentWorkspace.id}
           workspaceName={currentWorkspace.name}
           onClose={() => setImpactStudioOpen(false)}
+        />
+      ) : null}
+      {changelogStudioOpen && currentWorkspace ? (
+        <ChangelogStudio
+          workspaceName={currentWorkspace.name}
+          onClose={() => setChangelogStudioOpen(false)}
         />
       ) : null}
       {linearStudioOpen && currentWorkspace ? (

--- a/apps/desktop/src/app/components/AppFooter/index.test.tsx
+++ b/apps/desktop/src/app/components/AppFooter/index.test.tsx
@@ -38,6 +38,7 @@ describe('AppFooter', () => {
     const onOpenProviders = vi.fn();
     const onOpenBudget = vi.fn();
     const onOpenImpact = vi.fn();
+    const onOpenChangelog = vi.fn();
     render(
       <AppFooter
         activeStudio={null}
@@ -45,6 +46,7 @@ describe('AppFooter', () => {
         onOpenProviders={onOpenProviders}
         onOpenBudget={onOpenBudget}
         onOpenImpact={onOpenImpact}
+        onOpenChangelog={onOpenChangelog}
         onOpenGithub={vi.fn()}
         onOpenLinear={vi.fn()}
         onOpenSentry={vi.fn()}
@@ -75,6 +77,7 @@ describe('AppFooter', () => {
         name: 'see how orchestration changed the way this workspace works',
       }),
     );
+    fireEvent.click(screen.getByRole('button', { name: 'see what changed, release by release' }));
 
     const { container } = render(<BetaPill className={BETA_CENTERING} />);
     expect(beta.className).toBe(container.firstElementChild?.className);
@@ -82,6 +85,7 @@ describe('AppFooter', () => {
     expect(onOpenProviders).toHaveBeenCalledOnce();
     expect(onOpenBudget).toHaveBeenCalledOnce();
     expect(onOpenImpact).toHaveBeenCalledOnce();
+    expect(onOpenChangelog).toHaveBeenCalledOnce();
   });
 
   it('keeps studio buttons muted at rest and gives the active one a subtle surface', () => {
@@ -92,6 +96,7 @@ describe('AppFooter', () => {
         onOpenProviders={vi.fn()}
         onOpenBudget={vi.fn()}
         onOpenImpact={vi.fn()}
+        onOpenChangelog={vi.fn()}
         onOpenGithub={vi.fn()}
         onOpenLinear={vi.fn()}
         onOpenSentry={vi.fn()}
@@ -126,6 +131,7 @@ describe('AppFooter', () => {
         onOpenProviders={vi.fn()}
         onOpenBudget={vi.fn()}
         onOpenImpact={vi.fn()}
+        onOpenChangelog={vi.fn()}
         onOpenGithub={vi.fn()}
         onOpenLinear={vi.fn()}
         onOpenSentry={vi.fn()}
@@ -165,6 +171,7 @@ describe('AppFooter', () => {
         onOpenProviders={vi.fn()}
         onOpenBudget={vi.fn()}
         onOpenImpact={vi.fn()}
+        onOpenChangelog={vi.fn()}
         onOpenGithub={vi.fn()}
         onOpenLinear={vi.fn()}
         onOpenSentry={vi.fn()}
@@ -204,6 +211,7 @@ describe('AppFooter', () => {
         onOpenProviders={vi.fn()}
         onOpenBudget={vi.fn()}
         onOpenImpact={vi.fn()}
+        onOpenChangelog={vi.fn()}
         onOpenGithub={vi.fn()}
         onOpenLinear={vi.fn()}
         onOpenSentry={vi.fn()}

--- a/apps/desktop/src/app/components/AppFooter/index.tsx
+++ b/apps/desktop/src/app/components/AppFooter/index.tsx
@@ -56,6 +56,7 @@ type Props = {
   onOpenProviders: () => void;
   onOpenBudget: () => void;
   onOpenImpact: () => void;
+  onOpenChangelog: () => void;
   onOpenGithub: () => void;
   onOpenLinear: () => void;
   onOpenSentry: () => void;
@@ -74,6 +75,7 @@ export const AppFooter = ({
   onOpenProviders,
   onOpenBudget,
   onOpenImpact,
+  onOpenChangelog,
   onOpenGithub,
   onOpenLinear,
   onOpenSentry,
@@ -180,6 +182,14 @@ export const AppFooter = ({
             title="see how orchestration changed the way this workspace works"
             onClick={onOpenImpact}
             active={activeStudio === 'impact'}
+          />
+          <FooterButton
+            icon={<CONCEPT_ICONS.changelog size={12} aria-hidden />}
+            label="Changelog"
+            tone={CONCEPT_TONE.changelog}
+            title="see what changed, release by release"
+            onClick={onOpenChangelog}
+            active={activeStudio === 'changelog'}
           />
         </div>
       </div>

--- a/apps/desktop/src/features/changelog/changelog.ts
+++ b/apps/desktop/src/features/changelog/changelog.ts
@@ -1,0 +1,12 @@
+import { invoke } from '@tauri-apps/api/core';
+
+export type ReleaseNote = {
+  readonly version: string;
+  readonly publishedAt: string;
+  readonly body: string;
+  readonly htmlUrl: string;
+};
+
+export const fetchReleases = async (): Promise<ReadonlyArray<ReleaseNote>> => {
+  return invoke<ReleaseNote[]>('releases_list');
+};

--- a/apps/desktop/src/features/changelog/components/ChangelogStudio/ChangelogRail.tsx
+++ b/apps/desktop/src/features/changelog/components/ChangelogStudio/ChangelogRail.tsx
@@ -1,0 +1,59 @@
+import { Chip, SelectableRow, Skeleton } from '@goodboy/ui';
+import type { ReleaseNote } from '../../changelog';
+import { formatReleaseDate } from '../../formatReleaseDate';
+import { isInstalledRelease } from '../../isInstalledRelease';
+
+type Props = {
+  readonly releases: ReadonlyArray<ReleaseNote>;
+  readonly selectedVersion: string | null;
+  readonly installedVersion: string | null;
+  readonly isLoading: boolean;
+  readonly onSelect: (version: string) => void;
+};
+
+const SKELETON_ROWS = [0, 1, 2, 3, 4, 5];
+
+export const ChangelogRail = ({
+  releases,
+  selectedVersion,
+  installedVersion,
+  isLoading,
+  onSelect,
+}: Props) => {
+  if (isLoading) {
+    return (
+      <div className="flex flex-col gap-1.5 p-3" role="status" aria-label="Loading releases">
+        {SKELETON_ROWS.map((row) => (
+          <Skeleton key={row} className="h-8 w-full" />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <nav className="flex flex-col gap-0.5 p-3" aria-label="Releases">
+      {releases.map((release) => {
+        const isActive = release.version === selectedVersion;
+        const isInstalled = isInstalledRelease({
+          tag: release.version,
+          installed: installedVersion,
+        });
+        return (
+          <SelectableRow
+            key={release.version}
+            selected={isActive}
+            ariaCurrent={isActive}
+            onClick={() => onSelect(release.version)}
+            className="items-center gap-2 px-2.5 py-2"
+          >
+            <span className="min-w-0 flex-1 truncate text-sm">{release.version}</span>
+            {isInstalled && <Chip tone="neutral" width="sm" label="installed" />}
+            <span className="w-14 shrink-0 text-right text-2xs tabular-nums text-muted-foreground">
+              {formatReleaseDate({ iso: release.publishedAt, style: 'short' })}
+            </span>
+          </SelectableRow>
+        );
+      })}
+    </nav>
+  );
+};

--- a/apps/desktop/src/features/changelog/components/ChangelogStudio/ReleaseDetail.tsx
+++ b/apps/desktop/src/features/changelog/components/ChangelogStudio/ReleaseDetail.tsx
@@ -1,0 +1,101 @@
+import { Button, EmptyState, Markdown, Skeleton, SkeletonText } from '@goodboy/ui';
+import { ExternalLink } from 'lucide-react';
+import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../shared/components/conceptIcons';
+import { ErrorStrip } from '../../../../shared/components/ErrorStrip';
+import { HeaderBand, StudioDetailLayout } from '../../../../shared/components/StudioDetail';
+import { openUrl } from '../../../../shared/lib/editor';
+import { formatRelativeAge } from '../../../../shared/utils/relativeDate';
+import type { ReleaseNote } from '../../changelog';
+import { formatReleaseDate } from '../../formatReleaseDate';
+import type { ChangelogView } from '../../resolveChangelogView';
+
+type Props = {
+  readonly release: ReleaseNote | null;
+  readonly view: ChangelogView;
+  readonly staleError: Error | null;
+  readonly staleSince: string | null;
+  readonly onRetry: () => void;
+};
+
+export const ReleaseDetail = ({ release, view, staleError, staleSince, onRetry }: Props) => {
+  if (view === 'loading') {
+    return (
+      <div className="flex flex-col gap-5 px-6 py-6" role="status" aria-label="Loading releases">
+        <Skeleton className="h-6 w-36" />
+        <SkeletonText lines={7} />
+      </div>
+    );
+  }
+
+  if (view === 'failed') {
+    return (
+      <div className="px-6 py-6">
+        <EmptyState
+          bordered
+          size="inline"
+          icon={CONCEPT_ICONS.changelog}
+          tone={CONCEPT_TONE.changelog}
+          title="couldn't load releases"
+          description="check your connection and retry"
+          action={
+            <Button size="sm" variant="secondary" onClick={onRetry}>
+              Retry
+            </Button>
+          }
+        />
+      </div>
+    );
+  }
+
+  if (release == null) {
+    return (
+      <div className="px-6 py-6">
+        <EmptyState
+          bordered
+          size="inline"
+          icon={CONCEPT_ICONS.changelog}
+          tone={CONCEPT_TONE.changelog}
+          title="no published releases yet"
+          description="release notes appear here once the first version ships"
+        />
+      </div>
+    );
+  }
+
+  return (
+    <StudioDetailLayout
+      header={
+        <HeaderBand
+          meta={
+            <span className="text-2xs tabular-nums text-muted-foreground">
+              {formatReleaseDate({ iso: release.publishedAt, style: 'full' })}
+            </span>
+          }
+          title={release.version}
+          actions={
+            <Button size="sm" variant="secondary" onClick={() => void openUrl(release.htmlUrl)}>
+              <ExternalLink size={12} aria-hidden />
+              Open on GitHub
+            </Button>
+          }
+        />
+      }
+    >
+      {staleError != null ? (
+        <div className="flex flex-col gap-1.5">
+          <ErrorStrip label="the latest releases" error={staleError} onRetry={onRetry} />
+          {staleSince != null && (
+            <span className="text-2xs text-muted-foreground">
+              last updated {formatRelativeAge({ fromIso: staleSince })}
+            </span>
+          )}
+        </div>
+      ) : null}
+      {release.body.trim() === '' ? (
+        <p className="text-sm italic text-muted-foreground/60">no notes for this release.</p>
+      ) : (
+        <Markdown text={release.body} className="text-sm leading-relaxed" />
+      )}
+    </StudioDetailLayout>
+  );
+};

--- a/apps/desktop/src/features/changelog/components/ChangelogStudio/index.test.tsx
+++ b/apps/desktop/src/features/changelog/components/ChangelogStudio/index.test.tsx
@@ -1,0 +1,140 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { ReleaseNote } from '../../changelog';
+import type { ChangelogState } from '../../../../store/slices/changelog/state';
+
+const mocks = vi.hoisted(() => ({
+  state: null as unknown as ChangelogState,
+  loadChangelog: vi.fn(async () => undefined),
+  reloadChangelog: vi.fn(async () => undefined),
+  installedVersion: null as string | null,
+  openUrl: vi.fn(),
+}));
+
+vi.mock('../../../../store', () => ({
+  useAppStore: <T,>(selector: (state: unknown) => T) =>
+    selector({
+      ...mocks.state,
+      loadChangelog: mocks.loadChangelog,
+      reloadChangelog: mocks.reloadChangelog,
+    }),
+}));
+
+vi.mock('../../hooks/useInstalledVersion', () => ({
+  useInstalledVersion: () => mocks.installedVersion,
+}));
+
+vi.mock('../../../../shared/lib/editor', () => ({ openUrl: mocks.openUrl }));
+
+import { ChangelogStudio } from './index';
+
+const buildRelease = (version: string, publishedAt: string): ReleaseNote => ({
+  version,
+  publishedAt,
+  body: '## the round\n\n- shipped something',
+  htmlUrl: `https://github.com/akhayam99/goodboy/releases/tag/${version}`,
+});
+
+const renderStudio = () => render(<ChangelogStudio workspaceName="goodboy" onClose={vi.fn()} />);
+
+beforeEach(() => {
+  mocks.state = {
+    changelogReleases: [],
+    changelogStatus: 'idle',
+    changelogError: null,
+    changelogFetchedAt: null,
+  };
+  mocks.installedVersion = null;
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('ChangelogStudio', () => {
+  it('marks the installed version in the rail and leaves the newer one unmarked', () => {
+    mocks.state = {
+      changelogReleases: [
+        buildRelease('v0.1.56', '2026-07-10T10:00:00Z'),
+        buildRelease('v0.1.55', '2026-07-01T10:00:00Z'),
+      ],
+      changelogStatus: 'ready',
+      changelogError: null,
+      changelogFetchedAt: '2026-07-11T10:00:00Z',
+    };
+    mocks.installedVersion = '0.1.55';
+
+    renderStudio();
+
+    const rail = screen.getByRole('navigation', { name: 'Releases' });
+    const rows = Array.from(rail.querySelectorAll('button'));
+    const installedRow = rows.find((row) => row.textContent?.includes('v0.1.55'));
+    const newerRow = rows.find((row) => row.textContent?.includes('v0.1.56'));
+    expect(installedRow?.textContent).toContain('installed');
+    expect(newerRow?.textContent).not.toContain('installed');
+  });
+
+  it('opens the newest release and links it out through the system browser', () => {
+    mocks.state = {
+      changelogReleases: [buildRelease('v0.1.56', '2026-07-10T10:00:00Z')],
+      changelogStatus: 'ready',
+      changelogError: null,
+      changelogFetchedAt: '2026-07-11T10:00:00Z',
+    };
+
+    renderStudio();
+
+    expect(screen.getByRole('heading', { name: 'v0.1.56' })).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: /Open on GitHub/ }));
+    expect(mocks.openUrl).toHaveBeenCalledWith(
+      'https://github.com/akhayam99/goodboy/releases/tag/v0.1.56',
+    );
+  });
+
+  it('offers a retry and no release list when the fetch failed with no cache', () => {
+    mocks.state = {
+      changelogReleases: [],
+      changelogStatus: 'error',
+      changelogError: 'network down',
+      changelogFetchedAt: null,
+    };
+
+    renderStudio();
+
+    expect(screen.getByText("couldn't load releases")).toBeDefined();
+    expect(screen.getByText('check your connection and retry')).toBeDefined();
+    expect(screen.queryByRole('navigation', { name: 'Releases' })?.textContent).toBe('');
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    expect(mocks.reloadChangelog).toHaveBeenCalledOnce();
+  });
+
+  it('keeps the cached releases visible with a staleness line when the refresh failed', () => {
+    mocks.state = {
+      changelogReleases: [buildRelease('v0.1.55', '2026-07-01T10:00:00Z')],
+      changelogStatus: 'error',
+      changelogError: 'network down',
+      changelogFetchedAt: new Date(Date.now() - 2 * 3_600_000).toISOString(),
+    };
+
+    renderStudio();
+
+    expect(screen.getByRole('heading', { name: 'v0.1.55' })).toBeDefined();
+    expect(screen.getByText(/last updated 2h ago/)).toBeDefined();
+    expect(screen.getByRole('alert').textContent).toContain('network down');
+  });
+
+  it('says nothing shipped yet when the list comes back empty', () => {
+    mocks.state = {
+      changelogReleases: [],
+      changelogStatus: 'ready',
+      changelogError: null,
+      changelogFetchedAt: '2026-07-11T10:00:00Z',
+    };
+
+    renderStudio();
+
+    expect(screen.getByText('no published releases yet')).toBeDefined();
+  });
+});

--- a/apps/desktop/src/features/changelog/components/ChangelogStudio/index.tsx
+++ b/apps/desktop/src/features/changelog/components/ChangelogStudio/index.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useState } from 'react';
+import { ScrollFade } from '@goodboy/ui';
+import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../shared/components/conceptIcons';
+import { StudioRailLayout } from '../../../../shared/components/StudioRailLayout';
+import { StudioShell } from '../../../../shared/components/StudioShell';
+import { useAppStore } from '../../../../store';
+import { useInstalledVersion } from '../../hooks/useInstalledVersion';
+import { resolveChangelogView } from '../../resolveChangelogView';
+import { ChangelogRail } from './ChangelogRail';
+import { ReleaseDetail } from './ReleaseDetail';
+
+type Props = {
+  readonly workspaceName: string;
+  readonly onClose: () => void;
+};
+
+export const ChangelogStudio = ({ workspaceName, onClose }: Props) => {
+  const releases = useAppStore((state) => state.changelogReleases);
+  const status = useAppStore((state) => state.changelogStatus);
+  const error = useAppStore((state) => state.changelogError);
+  const fetchedAt = useAppStore((state) => state.changelogFetchedAt);
+  const loadChangelog = useAppStore((state) => state.loadChangelog);
+  const reloadChangelog = useAppStore((state) => state.reloadChangelog);
+  const installedVersion = useInstalledVersion();
+  const [selectedVersion, setSelectedVersion] = useState<string | null>(null);
+
+  useEffect(() => {
+    void loadChangelog();
+  }, [loadChangelog]);
+
+  const view = resolveChangelogView({ status, releaseCount: releases.length });
+  const selected =
+    releases.find((release) => release.version === selectedVersion) ?? releases[0] ?? null;
+  const isStale = status === 'error' && releases.length > 0;
+  const retry = () => {
+    void reloadChangelog();
+  };
+
+  return (
+    <StudioShell
+      icon={CONCEPT_ICONS.changelog}
+      tone={CONCEPT_TONE.changelog}
+      title="Changelog"
+      workspaceName={workspaceName}
+      closeLabel="close changelog"
+      onClose={onClose}
+    >
+      {() => (
+        <StudioRailLayout
+          railLabel="Releases"
+          railWidth="narrow"
+          rail={
+            <ScrollFade className="min-h-0 flex-1" fadeSize={24}>
+              <ChangelogRail
+                releases={releases}
+                selectedVersion={selected?.version ?? null}
+                installedVersion={installedVersion}
+                isLoading={view === 'loading'}
+                onSelect={setSelectedVersion}
+              />
+            </ScrollFade>
+          }
+          detail={
+            <ReleaseDetail
+              release={selected}
+              view={view}
+              staleError={isStale && error != null ? new Error(error) : null}
+              staleSince={isStale ? fetchedAt : null}
+              onRetry={retry}
+            />
+          }
+        />
+      )}
+    </StudioShell>
+  );
+};

--- a/apps/desktop/src/features/changelog/formatReleaseDate.ts
+++ b/apps/desktop/src/features/changelog/formatReleaseDate.ts
@@ -1,0 +1,16 @@
+type Params = {
+  readonly iso: string;
+  readonly style: 'short' | 'full';
+};
+
+export const formatReleaseDate = ({ iso, style }: Params): string => {
+  const timestamp = Date.parse(iso);
+  if (Number.isNaN(timestamp)) {
+    return '';
+  }
+  const options: Intl.DateTimeFormatOptions =
+    style === 'short'
+      ? { day: 'numeric', month: 'short' }
+      : { day: 'numeric', month: 'long', year: 'numeric' };
+  return new Intl.DateTimeFormat(undefined, options).format(timestamp);
+};

--- a/apps/desktop/src/features/changelog/hooks/useInstalledVersion/index.ts
+++ b/apps/desktop/src/features/changelog/hooks/useInstalledVersion/index.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react';
+import { getVersion } from '@tauri-apps/api/app';
+
+export const useInstalledVersion = (): string | null => {
+  const [installedVersion, setInstalledVersion] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+    void getVersion()
+      .then((version) => {
+        if (isMounted) {
+          setInstalledVersion(version);
+        }
+      })
+      .catch(() => setInstalledVersion(null));
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  return installedVersion;
+};

--- a/apps/desktop/src/features/changelog/isInstalledRelease.ts
+++ b/apps/desktop/src/features/changelog/isInstalledRelease.ts
@@ -1,0 +1,11 @@
+type Params = {
+  readonly tag: string;
+  readonly installed: string | null;
+};
+
+export const isInstalledRelease = ({ tag, installed }: Params): boolean => {
+  if (installed == null || installed.trim() === '') {
+    return false;
+  }
+  return tag.trim().replace(/^v/i, '') === installed.trim().replace(/^v/i, '');
+};

--- a/apps/desktop/src/features/changelog/resolveChangelogView.ts
+++ b/apps/desktop/src/features/changelog/resolveChangelogView.ts
@@ -1,0 +1,21 @@
+import type { ChangelogStatus } from '../../store/slices/changelog/state';
+
+export type ChangelogView = 'loading' | 'failed' | 'empty' | 'ready';
+
+type Params = {
+  readonly status: ChangelogStatus;
+  readonly releaseCount: number;
+};
+
+export const resolveChangelogView = ({ status, releaseCount }: Params): ChangelogView => {
+  if (releaseCount > 0) {
+    return 'ready';
+  }
+  if (status === 'error') {
+    return 'failed';
+  }
+  if (status === 'ready') {
+    return 'empty';
+  }
+  return 'loading';
+};

--- a/apps/desktop/src/shared/components/conceptIcons.ts
+++ b/apps/desktop/src/shared/components/conceptIcons.ts
@@ -13,6 +13,7 @@ import {
   FolderPlus,
   FolderTree,
   GitCommit,
+  History,
   LifeBuoy,
   Link2,
   ListChecks,
@@ -36,6 +37,7 @@ import { GithubIcon, GitlabIcon, LinearIcon, SentryIcon } from './brand-icons';
 export const CONCEPT_ICONS = {
   agents: Bot,
   budget: Wallet,
+  changelog: History,
   commits: GitCommit,
   decisions: CheckCheck,
   errors: CircleAlert,
@@ -75,6 +77,7 @@ type Concept = keyof typeof CONCEPT_ICONS;
 export const CONCEPT_TONE = {
   agents: 'primary',
   budget: 'warning',
+  changelog: 'neutral',
   commits: 'info',
   decisions: 'success',
   errors: 'danger',

--- a/apps/desktop/src/shared/lib/storage-keys.ts
+++ b/apps/desktop/src/shared/lib/storage-keys.ts
@@ -13,6 +13,7 @@ export const STORAGE_KEYS = {
   leftSidebarWidth: `${PREFIX}left-sidebar-width:v2`,
   rightSidebarWidth: `${PREFIX}right-sidebar-width`,
   onboardingWorkspaceDraft: `${PREFIX}onboarding-workspace-draft:v1`,
+  changelogCache: `${PREFIX}changelog-cache:v1`,
 } as const;
 
 export const STORAGE_PREFIXES = {

--- a/apps/desktop/src/store/slices/changelog/cache.ts
+++ b/apps/desktop/src/store/slices/changelog/cache.ts
@@ -1,0 +1,55 @@
+import type { ReleaseNote } from '../../../features/changelog/changelog';
+import { STORAGE_KEYS } from '../../../shared/lib/storage-keys';
+
+export type ChangelogCache = {
+  readonly fetchedAt: string;
+  readonly releases: ReadonlyArray<ReleaseNote>;
+};
+
+const isReleaseNote = (value: unknown): value is ReleaseNote => {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.version === 'string' &&
+    typeof candidate.publishedAt === 'string' &&
+    typeof candidate.body === 'string' &&
+    typeof candidate.htmlUrl === 'string'
+  );
+};
+
+export const readChangelogCache = (): ChangelogCache | null => {
+  if (typeof localStorage === 'undefined') {
+    return null;
+  }
+  const raw = localStorage.getItem(STORAGE_KEYS.changelogCache);
+  if (raw == null) {
+    return null;
+  }
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== 'object' || parsed === null) {
+      return null;
+    }
+    const candidate = parsed as Record<string, unknown>;
+    if (typeof candidate.fetchedAt !== 'string' || !Array.isArray(candidate.releases)) {
+      return null;
+    }
+    const releases = candidate.releases.filter(isReleaseNote);
+    return { fetchedAt: candidate.fetchedAt, releases };
+  } catch {
+    return null;
+  }
+};
+
+export const writeChangelogCache = ({ fetchedAt, releases }: ChangelogCache): void => {
+  if (typeof localStorage === 'undefined') {
+    return;
+  }
+  try {
+    localStorage.setItem(STORAGE_KEYS.changelogCache, JSON.stringify({ fetchedAt, releases }));
+  } catch {
+    return;
+  }
+};

--- a/apps/desktop/src/store/slices/changelog/index.test.ts
+++ b/apps/desktop/src/store/slices/changelog/index.test.ts
@@ -1,0 +1,88 @@
+// @vitest-environment happy-dom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { fetchReleasesMock } = vi.hoisted(() => ({ fetchReleasesMock: vi.fn() }));
+
+vi.mock('../../../features/changelog/changelog', () => ({ fetchReleases: fetchReleasesMock }));
+
+import { createChangelogSlice } from './index';
+import { initialChangelogState, type ChangelogState } from './state';
+import { STORAGE_KEYS } from '../../../shared/lib/storage-keys';
+
+const release = {
+  version: 'v0.1.55',
+  publishedAt: '2026-07-01T10:00:00Z',
+  body: '## the round\n\n- one thing',
+  htmlUrl: 'https://github.com/akhayam99/goodboy/releases/tag/v0.1.55',
+};
+
+const harness = () => {
+  let state: ChangelogState = { ...initialChangelogState };
+  const set = (p: Partial<ChangelogState> | ((s: ChangelogState) => Partial<ChangelogState>)) => {
+    state = { ...state, ...(typeof p === 'function' ? p(state) : p) };
+  };
+  const slice = createChangelogSlice(set as never, (() => ({ ...state, ...slice })) as never);
+  return { slice, getState: () => state };
+};
+
+describe('changelog slice', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it('caches the payload and does not refetch once it is ready', async () => {
+    fetchReleasesMock.mockResolvedValue([release]);
+    const { slice, getState } = harness();
+
+    await slice.loadChangelog();
+    await slice.loadChangelog();
+
+    expect(fetchReleasesMock).toHaveBeenCalledOnce();
+    expect(getState().changelogStatus).toBe('ready');
+    expect(getState().changelogReleases).toEqual([release]);
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEYS.changelogCache) ?? '{}').releases).toEqual([
+      release,
+    ]);
+  });
+
+  it('falls back to the persisted cache when the fetch fails', async () => {
+    localStorage.setItem(
+      STORAGE_KEYS.changelogCache,
+      JSON.stringify({ fetchedAt: '2026-06-30T09:00:00Z', releases: [release] }),
+    );
+    fetchReleasesMock.mockRejectedValue(new Error('network down'));
+    const { slice, getState } = harness();
+
+    await slice.loadChangelog();
+
+    expect(getState().changelogStatus).toBe('error');
+    expect(getState().changelogError).toBe('network down');
+    expect(getState().changelogReleases).toEqual([release]);
+    expect(getState().changelogFetchedAt).toBe('2026-06-30T09:00:00Z');
+  });
+
+  it('reports the failure with nothing to show when there is no cache', async () => {
+    fetchReleasesMock.mockRejectedValue(new Error('network down'));
+    const { slice, getState } = harness();
+
+    await slice.loadChangelog();
+
+    expect(getState().changelogStatus).toBe('error');
+    expect(getState().changelogReleases).toEqual([]);
+    expect(getState().changelogFetchedAt).toBeNull();
+  });
+
+  it('refetches on an explicit reload after a failure', async () => {
+    fetchReleasesMock.mockRejectedValueOnce(new Error('network down'));
+    fetchReleasesMock.mockResolvedValueOnce([release]);
+    const { slice, getState } = harness();
+
+    await slice.loadChangelog();
+    await slice.reloadChangelog();
+
+    expect(fetchReleasesMock).toHaveBeenCalledTimes(2);
+    expect(getState().changelogStatus).toBe('ready');
+    expect(getState().changelogError).toBeNull();
+  });
+});

--- a/apps/desktop/src/store/slices/changelog/index.ts
+++ b/apps/desktop/src/store/slices/changelog/index.ts
@@ -1,0 +1,10 @@
+import { loadChangelog } from './loadChangelog';
+import { reloadChangelog } from './reloadChangelog';
+import type { GetFn, SetFn } from './types';
+
+export const createChangelogSlice = (set: SetFn, get: GetFn) => {
+  return {
+    loadChangelog: loadChangelog(set, get),
+    reloadChangelog: reloadChangelog(set, get),
+  };
+};

--- a/apps/desktop/src/store/slices/changelog/loadChangelog.ts
+++ b/apps/desktop/src/store/slices/changelog/loadChangelog.ts
@@ -1,0 +1,18 @@
+import { readChangelogCache } from './cache';
+import type { GetFn, SetFn } from './types';
+
+export const loadChangelog = (set: SetFn, get: GetFn) => {
+  return async (): Promise<void> => {
+    const { changelogStatus, changelogReleases } = get();
+    if (changelogStatus === 'loading' || changelogStatus === 'ready') {
+      return;
+    }
+    if (changelogReleases.length === 0) {
+      const cached = readChangelogCache();
+      if (cached != null && cached.releases.length > 0) {
+        set({ changelogReleases: cached.releases, changelogFetchedAt: cached.fetchedAt });
+      }
+    }
+    await get().reloadChangelog();
+  };
+};

--- a/apps/desktop/src/store/slices/changelog/reloadChangelog.ts
+++ b/apps/desktop/src/store/slices/changelog/reloadChangelog.ts
@@ -1,0 +1,23 @@
+import { fetchReleases } from '../../../features/changelog/changelog';
+import { formatError } from '../../../shared/lib/errors';
+import { writeChangelogCache } from './cache';
+import type { GetFn, SetFn } from './types';
+
+export const reloadChangelog = (set: SetFn, _get: GetFn) => {
+  return async (): Promise<void> => {
+    set({ changelogStatus: 'loading', changelogError: null });
+    try {
+      const releases = await fetchReleases();
+      const fetchedAt = new Date().toISOString();
+      writeChangelogCache({ fetchedAt, releases });
+      set({
+        changelogReleases: releases,
+        changelogStatus: 'ready',
+        changelogError: null,
+        changelogFetchedAt: fetchedAt,
+      });
+    } catch (err) {
+      set({ changelogStatus: 'error', changelogError: formatError(err) });
+    }
+  };
+};

--- a/apps/desktop/src/store/slices/changelog/state.ts
+++ b/apps/desktop/src/store/slices/changelog/state.ts
@@ -1,0 +1,17 @@
+import type { ReleaseNote } from '../../../features/changelog/changelog';
+
+export type ChangelogStatus = 'idle' | 'loading' | 'ready' | 'error';
+
+export type ChangelogState = {
+  readonly changelogReleases: ReadonlyArray<ReleaseNote>;
+  readonly changelogStatus: ChangelogStatus;
+  readonly changelogError: string | null;
+  readonly changelogFetchedAt: string | null;
+};
+
+export const initialChangelogState: ChangelogState = {
+  changelogReleases: [],
+  changelogStatus: 'idle',
+  changelogError: null,
+  changelogFetchedAt: null,
+};

--- a/apps/desktop/src/store/slices/changelog/types.ts
+++ b/apps/desktop/src/store/slices/changelog/types.ts
@@ -1,0 +1,1 @@
+export type { SetFn, GetFn } from '../../slice-types';

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -126,6 +126,8 @@ import { createWorktreesSlice } from './slices/worktrees';
 import { createBootSlice } from './slices/boot';
 import { createUpdaterSlice } from './slices/updater';
 import { initialUpdaterState } from './slices/updater/state';
+import { createChangelogSlice } from './slices/changelog';
+import { initialChangelogState } from './slices/changelog/state';
 import type { LinearViewer } from '../features/integrations/linear/client';
 import type { SentryProject } from '../features/integrations/sentry/client';
 import type { GitlabUser } from '../features/integrations/gitlab/client';
@@ -148,6 +150,8 @@ export type AppActions = {
   hydrate(): Promise<void>;
   checkForUpdates(): Promise<void>;
   installUpdate(): Promise<void>;
+  loadChangelog(): Promise<void>;
+  reloadChangelog(): Promise<void>;
   loadDetectedEditors(): Promise<void>;
   setCurrentWorkspace(id: WorkspaceId | null): Promise<void>;
   openWorkspace(id: WorkspaceId, title: string): Promise<void>;
@@ -641,6 +645,7 @@ export type AppStore = AppState & AppActions;
 
 export const initialState: AppState = {
   ...initialUpdaterState,
+  ...initialChangelogState,
   ...createInitialSessionViewState({}),
   workspaces: [],
   workspaceIntegrations: {},
@@ -792,6 +797,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
   ...createWorktreesSlice(set, get),
   ...createBootSlice(set, get),
   ...createUpdaterSlice(set, get),
+  ...createChangelogSlice(set, get),
 }));
 
 export const useResolvedSettings = (sessionId: SessionId | null): ResolvedSettings => {

--- a/apps/desktop/src/store/types.ts
+++ b/apps/desktop/src/store/types.ts
@@ -60,6 +60,7 @@ import type { TerminalTab, TerminalTabId } from '../shared/types/terminal';
 import type { DraftAttachment } from './slices/agents/setAgentAttachments';
 import type { AgentQueuedTurn } from './slices/agents/setAgentQueue';
 import type { ProviderSpendEntry } from './slices/budget';
+import type { ChangelogState } from './slices/changelog/state';
 import type { ProviderLifecycleMap } from './slices/providers';
 import type { ReviewPrsState } from './slices/review-prs/types';
 import type { DiffFocus, LensHistory, LensKind, SessionStudio } from './slices/session-view';
@@ -152,7 +153,9 @@ export type SummarizerSessionStatus = {
   } | null;
 };
 
-export type AppState = UpdaterState & {
+type AppSliceState = UpdaterState & ChangelogState;
+
+export type AppState = AppSliceState & {
   readonly workspaces: ReadonlyArray<Workspace>;
   readonly workspaceIntegrations: Readonly<
     Record<WorkspaceId, ReadonlyArray<WorkspaceIntegration>>


### PR DESCRIPTION
The footer gains a **Changelog** studio, last in the right cluster: a rail of published releases newest first, the installed one marked with a neutral `installed` chip, and the release body rendered as written.

## Decisions worth knowing

- **Published only.** Drafts and prereleases are dropped in Rust, along with anything without a publish date. Assets and release plumbing never reach the surface.
- **Live, not baked.** A baked changelog can never show a release newer than the installed build, which is the exact moment a user opens it. The webview CSP allows `connect-src` only for self/ipc/linear, and the `gh` integration needs auth the user may not have, so the fetch is a new Rust command on the shared `reqwest` client. One call per app run, memoized, cached to localStorage so an offline launch still shows the last list it saw.
- **The body is rendered as written.** The release notes are hand-written themed prose, not commit dumps. A features/fixes classifier would misfile half the bullets and destroy writing that is already better than that taxonomy, so there is no classifier.
- **No update CTA inside the changelog.** The updater owns update signalling. If the newest release has no `installed` chip, the user is behind, and the strip indicator already says so.

## States

Skeletons while loading, never a spinner. Failed with no cache is an inline empty state with one retry. Failed with a cache shows the cached list, a "last updated" line and a retry strip. Empty says release notes appear once the first version ships, with no CTA.

## Verification

`pnpm -w typecheck` 5/5, `pnpm --filter @goodboy/desktop test` 3746 passed (+9 new), `pnpm knip --include files,duplicates,unlisted` exit 0, `cargo test --locked` 175 passed.

Tests cover the Rust filter dropping drafts and prereleases, the single repo-slug constant, the store cache and its offline fallback, the rail marking the installed version, the failed-with-no-cache retry, and the footer button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)