### PR TITLE
fix(desktop): a closed thread says so, and nobody closes it twice

### DIFF
--- a/apps/desktop/src/features/session/branchShaMatches.ts
+++ b/apps/desktop/src/features/session/branchShaMatches.ts
@@ -1,0 +1,10 @@
+type Params = {
+  readonly sha: string;
+  readonly candidate: string;
+};
+
+export const branchShaMatches = ({ sha, candidate }: Params): boolean => {
+  const a = sha.toLowerCase();
+  const b = candidate.toLowerCase();
+  return a.startsWith(b) || b.startsWith(a);
+};

--- a/apps/desktop/src/features/session/closedThreadIds.ts
+++ b/apps/desktop/src/features/session/closedThreadIds.ts
@@ -1,0 +1,14 @@
+import type { PrComment } from '@goodboy/types';
+
+type Params = {
+  readonly comments: ReadonlyArray<PrComment>;
+  readonly ledger: ReadonlyArray<string>;
+};
+
+export const closedThreadIds = ({ comments, ledger }: Params): ReadonlySet<string> =>
+  new Set([
+    ...comments.flatMap((comment) =>
+      comment.resolved === true && comment.threadId != null ? [comment.threadId] : [],
+    ),
+    ...ledger,
+  ]);

--- a/apps/desktop/src/features/session/components/AgentInspector/ResolverInspector.tsx
+++ b/apps/desktop/src/features/session/components/AgentInspector/ResolverInspector.tsx
@@ -10,6 +10,7 @@ import { useResolverChanges } from '../../hooks/useResolverChanges';
 import { useResolverActions } from '../../hooks/useResolverActions';
 import { resolverOrigin } from '../../resolver-origin';
 import { resolverCommitSha } from '../../resolverCommitSha';
+import { resolverThreadCommitShas } from '../../resolverThreadCommitShas';
 import { agentThreadIds } from '../../agentThreadIds';
 import type { AgentAggregate } from '../AgentMetrics';
 import type { ProviderContextUsage } from '../../../workspace/components/WorkspacesSidebar/parts/ContextWindowBar';
@@ -72,7 +73,16 @@ export const ResolverInspector = ({
   const link = resolverIndex.links[position] ?? null;
   const status = link?.status ?? 'done';
   const threadIds = agentThreadIds(agent);
-  const changes = useResolverChanges({ agent, worktreePath });
+  const shaByThreadId = useMemo(
+    () =>
+      resolverThreadCommitShas({
+        threadIds: agentThreadIds(agent),
+        outcomes,
+        pendingResolutions,
+      }),
+    [agent, outcomes, pendingResolutions],
+  );
+  const changes = useResolverChanges({ agent, worktreePath, shaByThreadId });
   const diffComment = useMemo(
     () => diffComments.find((comment) => comment.consumedByAgentId === agent.id) ?? null,
     [diffComments, agent.id],
@@ -220,7 +230,11 @@ export const ResolverInspector = ({
             onOpenFile={
               commitSha === null
                 ? undefined
-                : (path) => openDiffLens({ sha: commitSha, path: displayPath(path, worktreePath) })
+                : (path) =>
+                    openDiffLens({
+                      sha: changes.commitShaByFile[path] ?? commitSha,
+                      path: displayPath(path, worktreePath),
+                    })
             }
           />
           <Divider />

--- a/apps/desktop/src/features/session/components/AgentInspector/ResolverOutcomeChip.tsx
+++ b/apps/desktop/src/features/session/components/AgentInspector/ResolverOutcomeChip.tsx
@@ -1,9 +1,10 @@
-import { Ban, CheckCheck, CircleHelp, Search } from 'lucide-react';
+import { Ban, CheckCheck, CircleHelp, Lock, Search } from 'lucide-react';
 import { cn, tintClasses, type Tone } from '@goodboy/ui';
 import type { ResolverThreadSettlementKind } from '../../resolverThreadSettlements';
 
 type Props = {
   readonly kind: ResolverThreadSettlementKind;
+  readonly isClosed: boolean;
 };
 
 const COPY: Record<ResolverThreadSettlementKind, string> = {
@@ -27,9 +28,13 @@ const ICON = {
   open: CircleHelp,
 } satisfies Record<ResolverThreadSettlementKind, typeof CheckCheck>;
 
-export const ResolverOutcomeChip = ({ kind }: Props) => {
-  const tint = tintClasses(TONE[kind]);
-  const Icon = ICON[kind];
+const CLOSED_COPY = 'closed';
+
+const CLOSED_TONE: Tone = 'success';
+
+export const ResolverOutcomeChip = ({ kind, isClosed }: Props) => {
+  const tint = tintClasses(isClosed ? CLOSED_TONE : TONE[kind]);
+  const Icon = isClosed ? Lock : ICON[kind];
 
   return (
     <span
@@ -40,7 +45,7 @@ export const ResolverOutcomeChip = ({ kind }: Props) => {
       )}
     >
       <Icon size={10} aria-hidden />
-      {COPY[kind]}
+      {isClosed ? CLOSED_COPY : COPY[kind]}
     </span>
   );
 };

--- a/apps/desktop/src/features/session/components/AgentInspector/ResolverThreadRow.tsx
+++ b/apps/desktop/src/features/session/components/AgentInspector/ResolverThreadRow.tsx
@@ -63,8 +63,9 @@ export const ResolverThreadRow = ({
   const [edited, setEdited] = useState<string | null>(null);
   const [armed, setArmed] = useState<ResolverActionKind | null>(null);
   const text = edited ?? initial;
+  const isEditable = canAct && !settlement.isClosed;
   const plan = resolverThreadActions({ settlement, prNumber, isBusy });
-  const buttons = (canAct ? [plan.primary, ...plan.overflow] : []).filter(
+  const buttons = (isEditable ? [plan.primary, ...plan.overflow] : []).filter(
     (action): action is ResolverAction =>
       action !== null && (canForceResolve || action.kind !== 'forceResolve'),
   );
@@ -75,7 +76,7 @@ export const ResolverThreadRow = ({
   return (
     <li className="flex flex-col gap-2 rounded-md bg-muted/20 p-2.5">
       <div className="flex min-w-0 items-center gap-2">
-        <ResolverOutcomeChip kind={settlement.kind} />
+        <ResolverOutcomeChip kind={settlement.kind} isClosed={settlement.isClosed} />
         <span className="min-w-0 flex-1 truncate text-2xs text-muted-foreground/70">
           thread {position}
         </span>
@@ -100,7 +101,10 @@ export const ResolverThreadRow = ({
       {settlement.reply !== null && settlement.reply !== initial && (
         <p className="text-2xs leading-relaxed text-muted-foreground">{settlement.reply}</p>
       )}
-      {canAct && (
+      {settlement.isClosed && initial !== '' && (
+        <p className="text-2xs leading-relaxed text-muted-foreground">{initial}</p>
+      )}
+      {isEditable && (
         <Textarea
           value={text}
           onChange={(event) => setEdited(event.target.value)}

--- a/apps/desktop/src/features/session/components/AgentInspector/resolver.test.tsx
+++ b/apps/desktop/src/features/session/components/AgentInspector/resolver.test.tsx
@@ -472,6 +472,70 @@ describe('AgentInspector (resolver)', () => {
     expect(h.setActiveLens).toHaveBeenCalledWith(SESSION_ID, 'files');
   });
 
+  it('opens each file at the commit its own thread was fixed in', async () => {
+    reset({
+      settledThreadIds: ['PRRT_3', 'PRRT_4'],
+      resolverState: { [SETTLED_ID]: 'committed' },
+      outcomes: {
+        [SETTLED_ID]: {
+          PRRT_3: { kind: 'resolved', commitSha: 'abc1234def' },
+          PRRT_4: { kind: 'resolved', commitSha: 'other12345' },
+        },
+      },
+    });
+    h.listBranchCommits.mockResolvedValue([LOCAL_COMMIT, OTHER_AGENT_HEAD]);
+    h.runtime.events = [
+      { ...fileEdit, path: 'src/first.ts', at: '2026-07-25T09:01:00.000Z' as IsoDateTime },
+      {
+        ...resolvedMarker,
+        delta: '<<comment-resolved threadId="PRRT_3" commitSha="abc1234def" />>',
+        at: '2026-07-25T09:02:00.000Z' as IsoDateTime,
+      },
+      { ...fileEdit, path: 'src/second.ts', at: '2026-07-25T09:03:00.000Z' as IsoDateTime },
+      {
+        ...resolvedMarker,
+        delta: '<<comment-resolved threadId="PRRT_4" commitSha="other12345" />>',
+        at: '2026-07-25T09:04:00.000Z' as IsoDateTime,
+      },
+    ];
+    renderInspector(SETTLED_ID);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'src/second.ts' }));
+
+    expect(h.setDiffFocus).toHaveBeenCalledWith(SESSION_ID, {
+      sha: 'other12345',
+      path: 'src/second.ts',
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'src/first.ts' }));
+
+    expect(h.setDiffFocus).toHaveBeenCalledWith(SESSION_ID, {
+      sha: 'abc1234def',
+      path: 'src/first.ts',
+    });
+  });
+
+  it('reads a thread github already closed as closed and offers nothing on it', () => {
+    reset({
+      settledThreadIds: ['PRRT_3', 'PRRT_4'],
+      resolvedThreadIds: ['PRRT_3'],
+      resolverState: { [SETTLED_ID]: 'awaiting' },
+      outcomes: {
+        [SETTLED_ID]: {
+          PRRT_3: { kind: 'resolved', commitSha: 'abc1234def', reply: 'guarded the null case' },
+          PRRT_4: { kind: 'wontfix', reason: 'the branch is unreachable' },
+        },
+      },
+    });
+    renderInspector(SETTLED_ID);
+
+    expect(screen.getByText('closed')).toBeDefined();
+    expect(screen.queryByText('fixed')).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Add to batch' })).toBeNull();
+    expect(screen.queryByLabelText('reply for thread 1')).toBeNull();
+    expect(screen.getByRole('button', { name: 'Post & close' })).toBeDefined();
+  });
+
   it('opens the diff lens at a reported sha the branch does not carry', () => {
     h.runtime.events = [resolvedMarker];
     renderInspector(RUNNING_ID);

--- a/apps/desktop/src/features/session/components/ResolverAgentsLane/ResolverCard.test.tsx
+++ b/apps/desktop/src/features/session/components/ResolverAgentsLane/ResolverCard.test.tsx
@@ -11,6 +11,7 @@ vi.mock('../../../../store', () => ({
     selector({
       agentTurnState: {},
       sessionGithub: { 'sess-1': { pr: { number: 7 } } },
+      sessionResolvedThreads: {},
       sessionPendingResolutions: {},
       resolverThreadOutcomes: {},
       resolveGithubThread: vi.fn(),

--- a/apps/desktop/src/features/session/components/ResolverAgentsLane/ResolverCardTally.tsx
+++ b/apps/desktop/src/features/session/components/ResolverAgentsLane/ResolverCardTally.tsx
@@ -5,6 +5,7 @@ import { agentThreadIds } from '../../agentThreadIds';
 import { resolverTallySentence } from '../../resolverTallySentence';
 import { resolverThreadSettlements } from '../../resolverThreadSettlements';
 import { resolverThreadTally } from '../../resolverThreadTally';
+import { useClosedThreadIds } from '../../hooks/useClosedThreadIds';
 
 type Props = {
   readonly agent: Agent;
@@ -18,6 +19,7 @@ export const ResolverCardTally = ({ agent, sessionId }: Props) => {
   const pending =
     useAppStore((state) => state.sessionPendingResolutions[sessionId]) ?? EMPTY_PENDING;
   const outcomes = useAppStore((state) => state.resolverThreadOutcomes[agent.id]) ?? EMPTY_OUTCOMES;
+  const closedThreadIds = useClosedThreadIds({ sessionId });
 
   const threadIds = agentThreadIds(agent);
   if (threadIds.length < 2) {
@@ -29,6 +31,7 @@ export const ResolverCardTally = ({ agent, sessionId }: Props) => {
         threadIds,
         outcomes,
         pendingResolutions: pending,
+        closedThreadIds,
       }),
     }),
   });

--- a/apps/desktop/src/features/session/hooks/useClosedThreadIds/index.ts
+++ b/apps/desktop/src/features/session/hooks/useClosedThreadIds/index.ts
@@ -1,0 +1,18 @@
+import { useShallow } from 'zustand/react/shallow';
+import type { SessionId } from '@goodboy/types';
+import { useAppStore } from '../../../../store';
+import { closedThreadIds } from '../../closedThreadIds';
+
+type Params = {
+  readonly sessionId: SessionId;
+};
+
+export const useClosedThreadIds = ({ sessionId }: Params): ReadonlySet<string> =>
+  useAppStore(
+    useShallow((s) =>
+      closedThreadIds({
+        comments: s.sessionGithub[sessionId]?.detail?.comments ?? [],
+        ledger: s.sessionResolvedThreads[sessionId] ?? [],
+      }),
+    ),
+  );

--- a/apps/desktop/src/features/session/hooks/useResolverActions/index.ts
+++ b/apps/desktop/src/features/session/hooks/useResolverActions/index.ts
@@ -16,6 +16,7 @@ import {
   type ResolverThreadSettlement,
 } from '../../resolverThreadSettlements';
 import { resolverThreadTally, type ResolverThreadTally } from '../../resolverThreadTally';
+import { useClosedThreadIds } from '../useClosedThreadIds';
 
 const EMPTY_PENDING: ReadonlyArray<PendingResolution> = [];
 const EMPTY_OUTCOMES: Readonly<Record<string, ResolverThreadOutcome>> = {};
@@ -89,12 +90,14 @@ export const useResolverActions = ({
   const pending =
     useAppStore((state) => state.sessionPendingResolutions[sessionId]) ?? EMPTY_PENDING;
   const outcomes = useAppStore((state) => state.resolverThreadOutcomes[agent.id]) ?? EMPTY_OUTCOMES;
+  const closedThreadIds = useClosedThreadIds({ sessionId });
 
   const threadIds = agentThreadIds(agent);
   const settlements = resolverThreadSettlements({
     threadIds,
     outcomes,
     pendingResolutions: pending,
+    closedThreadIds,
   });
   const tally = resolverThreadTally({ settlements });
 
@@ -136,6 +139,9 @@ export const useResolverActions = ({
   };
 
   const queueTargets = settlements.flatMap((settlement) => {
+    if (settlement.isClosed) {
+      return [];
+    }
     if (settlement.kind === 'resolved' && settlement.commitSha !== null && !settlement.isQueued) {
       return [
         { threadId: settlement.threadId, sha: settlement.commitSha, reply: settlement.reply },
@@ -190,7 +196,7 @@ export const useResolverActions = ({
 
   const closeSettled = async ({ includeOpen }: { readonly includeOpen: boolean }) => {
     for (const settlement of settlements) {
-      if (settlement.kind === 'resolved') {
+      if (settlement.kind === 'resolved' || settlement.isClosed) {
         continue;
       }
       if (settlement.kind === 'open' && !includeOpen) {

--- a/apps/desktop/src/features/session/hooks/useResolverChanges/index.ts
+++ b/apps/desktop/src/features/session/hooks/useResolverChanges/index.ts
@@ -6,10 +6,12 @@ import { tauriDatabase } from '../../../../shared/lib/db';
 import { useTranscript } from '../../../../store/transcript';
 import { listBranchCommits } from '../../../worktree/worktree';
 import { attributeResolverCommits, type AttributedCommits } from '../../resolver-commits';
+import { resolverFileCommits } from '../../resolverFileCommits';
 import { resolverReportedShas } from '../../resolver-reported-shas';
 
 export type ResolverChanges = AttributedCommits & {
   readonly files: ReadonlyArray<string>;
+  readonly commitShaByFile: Readonly<Record<string, string>>;
   readonly headSha: string | null;
   readonly isLoading: boolean;
   readonly reload: () => void;
@@ -21,9 +23,14 @@ const EMPTY_COMMITS: ReadonlyArray<BranchCommit> = [];
 type Params = {
   readonly agent: Agent | null;
   readonly worktreePath: string | null;
+  readonly shaByThreadId: Readonly<Record<string, string>>;
 };
 
-export const useResolverChanges = ({ agent, worktreePath }: Params): ResolverChanges => {
+export const useResolverChanges = ({
+  agent,
+  worktreePath,
+  shaByThreadId,
+}: Params): ResolverChanges => {
   const liveEvents = useTranscript(agent?.id ?? null);
   const [storedEvents, setStoredEvents] = useState<ReadonlyArray<TurnEvent>>(EMPTY_EVENTS);
   const [commits, setCommits] = useState<ReadonlyArray<BranchCommit>>(EMPTY_COMMITS);
@@ -88,9 +95,14 @@ export const useResolverChanges = ({ agent, worktreePath }: Params): ResolverCha
     return {
       ...attributed,
       files: extractFilesTouched(events),
+      commitShaByFile: resolverFileCommits({
+        events,
+        commits: attributed.reported,
+        shaByThreadId,
+      }),
       headSha: commits[0]?.sha ?? null,
       isLoading,
       reload,
     };
-  }, [events, commits, agent?.startedAt, agent?.completedAt, isLoading, reload]);
+  }, [events, commits, agent?.startedAt, agent?.completedAt, shaByThreadId, isLoading, reload]);
 };

--- a/apps/desktop/src/features/session/hooks/useResolverIndex/index.ts
+++ b/apps/desktop/src/features/session/hooks/useResolverIndex/index.ts
@@ -10,6 +10,7 @@ import {
   type ResolverState,
   type ResolverStatus,
 } from '../../resolver-linkage';
+import { useClosedThreadIds } from '../useClosedThreadIds';
 
 export const useResolverIndex = (sessionId: SessionId): ResolverIndex => {
   const phaseRuns = useAppStore(
@@ -31,17 +32,7 @@ export const useResolverIndex = (sessionId: SessionId): ResolverIndex => {
       return out;
     }),
   );
-  const resolvedThreadIds = useAppStore(
-    useShallow(
-      (s) =>
-        new Set([
-          ...(s.sessionGithub[sessionId]?.detail?.comments ?? [])
-            .filter((c) => c.resolved === true && c.threadId != null)
-            .map((c) => c.threadId as string),
-          ...(s.sessionResolvedThreads[sessionId] ?? []),
-        ]),
-    ),
-  );
+  const resolvedThreadIds = useClosedThreadIds({ sessionId });
   const pendingThreadIds = useAppStore(
     useShallow(
       (s) => new Set((s.sessionPendingResolutions[sessionId] ?? []).map((r) => r.threadId)),

--- a/apps/desktop/src/features/session/resolver-commits.ts
+++ b/apps/desktop/src/features/session/resolver-commits.ts
@@ -1,15 +1,10 @@
 import type { BranchCommit } from '@goodboy/types';
+import { branchShaMatches } from './branchShaMatches';
 
 export type AttributedCommits = {
   readonly reported: ReadonlyArray<BranchCommit>;
   readonly reportedMissingShas: ReadonlyArray<string>;
   readonly withinRunWindow: ReadonlyArray<BranchCommit>;
-};
-
-const shaMatches = ({ sha, candidate }: { readonly sha: string; readonly candidate: string }) => {
-  const a = sha.toLowerCase();
-  const b = candidate.toLowerCase();
-  return a.startsWith(b) || b.startsWith(a);
 };
 
 const toEpoch = ({ iso }: { readonly iso: string | undefined }): number | null => {
@@ -39,7 +34,7 @@ export const attributeResolverCommits = ({
   const reportedMissingShas: string[] = [];
   const matchedShas = new Set<string>();
   for (const sha of reportedShas) {
-    const found = commits.find((commit) => shaMatches({ sha: commit.sha, candidate: sha }));
+    const found = commits.find((commit) => branchShaMatches({ sha: commit.sha, candidate: sha }));
     if (found === undefined) {
       reportedMissingShas.push(sha);
       continue;

--- a/apps/desktop/src/features/session/resolverActions.test.ts
+++ b/apps/desktop/src/features/session/resolverActions.test.ts
@@ -31,6 +31,7 @@ const settlement = (
   reason: kind === 'wontfix' ? 'intentional' : null,
   reply: null,
   isQueued: false,
+  isClosed: false,
 });
 
 const tallyOf = (...kinds: ReadonlyArray<ResolverThreadSettlement['kind']>) =>
@@ -151,6 +152,42 @@ describe('resolverActionPlan', () => {
 
     expect(inspector.primary?.label).toBe('Push & resolve 2');
     expect(inspector.secondary?.label).toBe('Add 1 to batch');
+    expect(inspector.note).toBe('1 thread still needs you');
+  });
+
+  it('counts a thread github already closed out of the push and the batch', () => {
+    const inspector = resolverActionPlan({
+      ...base,
+      status: 'committed',
+      tally: resolverThreadTally({
+        settlements: [
+          { ...settlement('PRRT_1', 'resolved'), isClosed: true },
+          settlement('PRRT_2', 'resolved'),
+          { ...settlement('PRRT_3', 'open'), isClosed: true },
+          settlement('PRRT_4', 'open'),
+        ],
+      }),
+    });
+
+    expect(inspector.primary?.label).toBe('Push & resolve 1');
+    expect(inspector.secondary?.label).toBe('Add 1 to batch');
+    expect(inspector.note).toBe('1 thread still needs you');
+  });
+
+  it('offers no push when every fix it recorded is already closed', () => {
+    const inspector = resolverActionPlan({
+      ...base,
+      status: 'committed',
+      tally: resolverThreadTally({
+        settlements: [
+          { ...settlement('PRRT_1', 'resolved'), isClosed: true },
+          settlement('PRRT_2', 'open'),
+        ],
+      }),
+    });
+
+    expect(inspector.primary).toBeNull();
+    expect(inspector.secondary).toBeNull();
     expect(inspector.note).toBe('1 thread still needs you');
   });
 

--- a/apps/desktop/src/features/session/resolverActions.ts
+++ b/apps/desktop/src/features/session/resolverActions.ts
@@ -222,7 +222,7 @@ const canForceResolve = ({
 };
 
 const canPush = ({ tally, commitSha }: Pick<Params, 'tally' | 'commitSha'>): boolean =>
-  tally.resolved > 0 || (tally.total === 1 && tally.settled === 0 && commitSha !== null);
+  tally.pushable > 0 || (tally.total === 1 && tally.settled === 0 && commitSha !== null);
 
 const openNote = ({ tally }: Pick<Params, 'tally'>): string | null =>
   tally.open === 0
@@ -269,18 +269,18 @@ const mixedBlock = (params: Params): Block => {
     return { primary: REVIEW_THREADS, secondary: null, note: null };
   }
   const { tally, queuedThreadIds, prNumber } = params;
-  const primary = pushAction({
-    label: `Push & resolve ${tally.settled}`,
-    isEnabled: true,
-  });
+  const primary =
+    tally.closable > 0
+      ? pushAction({ label: `Push & resolve ${tally.closable}`, isEnabled: true })
+      : null;
   if (queuedThreadIds.length > 0) {
     return { primary, secondary: DEQUEUE, note: openNote({ tally }) };
   }
   return {
     primary,
     secondary:
-      tally.resolved > 0
-        ? queueAction({ label: `Add ${tally.resolved} to batch`, isEnabled: prNumber !== null })
+      tally.pushable > 0
+        ? queueAction({ label: `Add ${tally.pushable} to batch`, isEnabled: prNumber !== null })
         : null,
     note: openNote({ tally }),
   };

--- a/apps/desktop/src/features/session/resolverFileCommits.test.ts
+++ b/apps/desktop/src/features/session/resolverFileCommits.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import type { BranchCommit, IsoDateTime, ProviderRunId, TurnEvent } from '@goodboy/types';
+import { resolverFileCommits } from './resolverFileCommits';
+
+const RUN = 'run-1' as ProviderRunId;
+
+const edit = ({ path, at }: { readonly path: string; readonly at: string }): TurnEvent => ({
+  kind: 'file_edit',
+  runId: RUN,
+  path,
+  editType: 'modify',
+  at: at as IsoDateTime,
+});
+
+const report = ({
+  threadId,
+  sha,
+  at,
+}: {
+  readonly threadId: string;
+  readonly sha: string;
+  readonly at: string;
+}): TurnEvent => ({
+  kind: 'assistant_text',
+  runId: RUN,
+  delta: `<<comment-resolved threadId="${threadId}" commitSha="${sha}" />>`,
+  at: at as IsoDateTime,
+});
+
+const commit = ({ sha }: { readonly sha: string }): BranchCommit => ({
+  sha,
+  shortSha: sha.slice(0, 7),
+  subject: 'fix: something',
+  author: 'agent',
+  timestamp: 1,
+  pushed: false,
+  parentSha: null,
+});
+
+const TWO_THREADS: ReadonlyArray<TurnEvent> = [
+  edit({ path: 'src/a.ts', at: '2026-07-25T09:01:00.000Z' }),
+  report({ threadId: 'PRRT_1', sha: 'aaa1111', at: '2026-07-25T09:02:00.000Z' }),
+  edit({ path: 'src/b.ts', at: '2026-07-25T09:03:00.000Z' }),
+  report({ threadId: 'PRRT_2', sha: 'bbb2222', at: '2026-07-25T09:04:00.000Z' }),
+];
+
+describe('resolverFileCommits', () => {
+  it('gives each file the commit of the thread it was fixed for', () => {
+    const byFile = resolverFileCommits({
+      events: TWO_THREADS,
+      commits: [],
+      shaByThreadId: {},
+    });
+
+    expect(byFile['src/a.ts']).toBe('aaa1111');
+    expect(byFile['src/b.ts']).toBe('bbb2222');
+  });
+
+  it('reads the sha the thread settled on rather than the one it first reported', () => {
+    const byFile = resolverFileCommits({
+      events: TWO_THREADS,
+      commits: [],
+      shaByThreadId: { PRRT_2: 'amended2' },
+    });
+
+    expect(byFile['src/b.ts']).toBe('amended2');
+  });
+
+  it('resolves a short reported sha to the commit the branch carries', () => {
+    const byFile = resolverFileCommits({
+      events: TWO_THREADS,
+      commits: [commit({ sha: 'aaa1111ffffffff' })],
+      shaByThreadId: {},
+    });
+
+    expect(byFile['src/a.ts']).toBe('aaa1111ffffffff');
+  });
+
+  it('sends a file edited after the last report to the newest commit', () => {
+    const byFile = resolverFileCommits({
+      events: [...TWO_THREADS, edit({ path: 'src/c.ts', at: '2026-07-25T09:05:00.000Z' })],
+      commits: [],
+      shaByThreadId: {},
+    });
+
+    expect(byFile['src/c.ts']).toBe('bbb2222');
+  });
+
+  it('gives every file the same sha when a single thread reported once', () => {
+    const byFile = resolverFileCommits({
+      events: [
+        edit({ path: 'src/a.ts', at: '2026-07-25T09:01:00.000Z' }),
+        edit({ path: 'src/b.ts', at: '2026-07-25T09:01:30.000Z' }),
+        report({ threadId: 'PRRT_1', sha: 'aaa1111', at: '2026-07-25T09:02:00.000Z' }),
+      ],
+      commits: [],
+      shaByThreadId: {},
+    });
+
+    expect(byFile).toEqual({ 'src/a.ts': 'aaa1111', 'src/b.ts': 'aaa1111' });
+  });
+
+  it('attributes nothing when the resolver reported no commit', () => {
+    const byFile = resolverFileCommits({
+      events: [edit({ path: 'src/a.ts', at: '2026-07-25T09:01:00.000Z' })],
+      commits: [commit({ sha: 'aaa1111ffffffff' })],
+      shaByThreadId: {},
+    });
+
+    expect(byFile).toEqual({});
+  });
+});

--- a/apps/desktop/src/features/session/resolverFileCommits.ts
+++ b/apps/desktop/src/features/session/resolverFileCommits.ts
@@ -1,0 +1,79 @@
+import { extractAllCommentResolved } from '@goodboy/core';
+import type { BranchCommit, ProviderRunId, TurnEvent } from '@goodboy/types';
+import { branchShaMatches } from './branchShaMatches';
+
+type Params = {
+  readonly events: ReadonlyArray<TurnEvent>;
+  readonly commits: ReadonlyArray<BranchCommit>;
+  readonly shaByThreadId: Readonly<Record<string, string>>;
+};
+
+type Report = {
+  readonly at: number;
+  readonly sha: string;
+};
+
+const MARKER_CLOSE = '>>';
+
+const epochOf = ({ iso }: { readonly iso: string }): number => {
+  const parsed = Date.parse(iso);
+  return Number.isNaN(parsed) ? 0 : parsed;
+};
+
+const onBranch = ({
+  sha,
+  commits,
+}: {
+  readonly sha: string;
+  readonly commits: ReadonlyArray<BranchCommit>;
+}): string => {
+  const found = commits.find((commit) => branchShaMatches({ sha: commit.sha, candidate: sha }));
+  return found?.sha ?? sha;
+};
+
+export const resolverFileCommits = ({
+  events,
+  commits,
+  shaByThreadId,
+}: Params): Readonly<Record<string, string>> => {
+  const textByRun = new Map<ProviderRunId, string>();
+  const seen = new Set<string>();
+  const reports: Report[] = [];
+  const lastEditAt = new Map<string, number>();
+
+  for (const event of events) {
+    if (event.kind === 'file_edit') {
+      lastEditAt.set(event.path, epochOf({ iso: event.at }));
+      continue;
+    }
+    if (event.kind !== 'assistant_text') {
+      continue;
+    }
+    const text = `${textByRun.get(event.runId) ?? ''}${event.delta}`;
+    textByRun.set(event.runId, text);
+    if (!event.delta.includes(MARKER_CLOSE)) {
+      continue;
+    }
+    for (const marker of extractAllCommentResolved(text)) {
+      const key = `${marker.threadId} ${marker.commitSha}`;
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      reports.push({
+        at: epochOf({ iso: event.at }),
+        sha: onBranch({ sha: shaByThreadId[marker.threadId] ?? marker.commitSha, commits }),
+      });
+    }
+  }
+
+  const newest = reports[reports.length - 1];
+  if (newest === undefined) {
+    return {};
+  }
+  const out: Record<string, string> = {};
+  for (const [path, editedAt] of lastEditAt) {
+    out[path] = (reports.find((report) => report.at >= editedAt) ?? newest).sha;
+  }
+  return out;
+};

--- a/apps/desktop/src/features/session/resolverTallySentence.test.ts
+++ b/apps/desktop/src/features/session/resolverTallySentence.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { resolverTallySentence } from './resolverTallySentence';
+import { resolverThreadTally } from './resolverThreadTally';
+import type {
+  ResolverThreadSettlement,
+  ResolverThreadSettlementKind,
+} from './resolverThreadSettlements';
+
+const settlement = ({
+  threadId,
+  kind,
+  isClosed = false,
+}: {
+  readonly threadId: string;
+  readonly kind: ResolverThreadSettlementKind;
+  readonly isClosed?: boolean;
+}): ResolverThreadSettlement => ({
+  threadId,
+  kind,
+  commitSha: kind === 'resolved' ? 'abc1234' : null,
+  reason: kind === 'wontfix' ? 'intentional' : null,
+  reply: null,
+  isQueued: false,
+  isClosed,
+});
+
+describe('resolverTallySentence', () => {
+  it('calls a closed thread closed instead of saying it needs you', () => {
+    const sentence = resolverTallySentence({
+      tally: resolverThreadTally({
+        settlements: [
+          settlement({ threadId: 'PRRT_1', kind: 'resolved' }),
+          settlement({ threadId: 'PRRT_2', kind: 'open', isClosed: true }),
+        ],
+      }),
+    });
+
+    expect(sentence).toBe('1 fixed · 1 closed');
+  });
+
+  it('still ends on what the operator has left to do', () => {
+    const sentence = resolverTallySentence({
+      tally: resolverThreadTally({
+        settlements: [
+          settlement({ threadId: 'PRRT_1', kind: 'open', isClosed: true }),
+          settlement({ threadId: 'PRRT_2', kind: 'open' }),
+        ],
+      }),
+    });
+
+    expect(sentence).toBe('1 closed · 1 needs you');
+  });
+
+  it('reads the same as before on an agent nothing closed', () => {
+    const sentence = resolverTallySentence({
+      tally: resolverThreadTally({
+        settlements: [
+          settlement({ threadId: 'PRRT_1', kind: 'resolved' }),
+          settlement({ threadId: 'PRRT_2', kind: 'wontfix' }),
+          settlement({ threadId: 'PRRT_3', kind: 'open' }),
+        ],
+      }),
+    });
+
+    expect(sentence).toBe('1 fixed · 1 no change · 1 needs you');
+  });
+});

--- a/apps/desktop/src/features/session/resolverTallySentence.ts
+++ b/apps/desktop/src/features/session/resolverTallySentence.ts
@@ -12,6 +12,7 @@ export const resolverTallySentence = ({ tally }: Params): string | null => {
     tally.resolved > 0 ? `${tally.resolved} fixed` : null,
     tally.wontfix > 0 ? `${tally.wontfix} no change` : null,
     tally.analyzed > 0 ? `${tally.analyzed} explained` : null,
+    tally.closed > 0 ? `${tally.closed} closed` : null,
     tally.open > 0 ? `${tally.open} needs you` : null,
   ].filter((part): part is string => part !== null);
   if (parts.length === 0) {

--- a/apps/desktop/src/features/session/resolverThreadActions.test.ts
+++ b/apps/desktop/src/features/session/resolverThreadActions.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { resolverThreadActions } from './resolverThreadActions';
+import type {
+  ResolverThreadSettlement,
+  ResolverThreadSettlementKind,
+} from './resolverThreadSettlements';
+
+const settlement = ({
+  kind,
+  isClosed,
+}: {
+  readonly kind: ResolverThreadSettlementKind;
+  readonly isClosed: boolean;
+}): ResolverThreadSettlement => ({
+  threadId: 'PRRT_1',
+  kind,
+  commitSha: kind === 'resolved' ? 'abc1234' : null,
+  reason: kind === 'wontfix' ? 'unreachable branch' : null,
+  reply: null,
+  isQueued: false,
+  isClosed,
+});
+
+describe('resolverThreadActions', () => {
+  it('offers nothing on a thread that is already closed', () => {
+    const plan = resolverThreadActions({
+      settlement: settlement({ kind: 'open', isClosed: true }),
+      prNumber: 7,
+      isBusy: false,
+    });
+
+    expect(plan.primary).toBeNull();
+    expect(plan.overflow).toEqual([]);
+  });
+
+  it('will not batch a fix whose thread is already closed', () => {
+    const plan = resolverThreadActions({
+      settlement: settlement({ kind: 'resolved', isClosed: true }),
+      prNumber: 7,
+      isBusy: false,
+    });
+
+    expect(plan.primary).toBeNull();
+  });
+
+  it('still asks the operator to answer a thread that is open', () => {
+    const plan = resolverThreadActions({
+      settlement: settlement({ kind: 'open', isClosed: false }),
+      prNumber: 7,
+      isBusy: false,
+    });
+
+    expect(plan.primary?.kind).toBe('answer');
+    expect(plan.overflow.map((action) => action.kind)).toEqual(['forceResolve']);
+  });
+
+  it('still offers to batch a fix nobody closed yet', () => {
+    const plan = resolverThreadActions({
+      settlement: settlement({ kind: 'resolved', isClosed: false }),
+      prNumber: 7,
+      isBusy: false,
+    });
+
+    expect(plan.primary?.kind).toBe('queue');
+  });
+});

--- a/apps/desktop/src/features/session/resolverThreadActions.ts
+++ b/apps/desktop/src/features/session/resolverThreadActions.ts
@@ -72,6 +72,9 @@ export const resolverThreadActions = ({
   prNumber,
   isBusy,
 }: Params): ResolverThreadActionPlan => {
+  if (settlement.isClosed) {
+    return { primary: null, overflow: [] };
+  }
   if (settlement.kind === 'resolved') {
     return {
       primary: settlement.isQueued ? DEQUEUE : queueAction({ isEnabled: prNumber !== null }),

--- a/apps/desktop/src/features/session/resolverThreadCommitShas.ts
+++ b/apps/desktop/src/features/session/resolverThreadCommitShas.ts
@@ -1,0 +1,28 @@
+import type { PendingResolution } from '@goodboy/types';
+import type { ResolverThreadOutcome } from '../../store/types';
+
+type Params = {
+  readonly threadIds: ReadonlyArray<string>;
+  readonly outcomes: Readonly<Record<string, ResolverThreadOutcome>>;
+  readonly pendingResolutions: ReadonlyArray<PendingResolution>;
+};
+
+export const resolverThreadCommitShas = ({
+  threadIds,
+  outcomes,
+  pendingResolutions,
+}: Params): Readonly<Record<string, string>> => {
+  const out: Record<string, string> = {};
+  for (const threadId of threadIds) {
+    const outcome = outcomes[threadId];
+    if (outcome?.kind === 'resolved') {
+      out[threadId] = outcome.commitSha;
+      continue;
+    }
+    const queued = pendingResolutions.find((resolution) => resolution.threadId === threadId);
+    if (queued !== undefined) {
+      out[threadId] = queued.commitSha;
+    }
+  }
+  return out;
+};

--- a/apps/desktop/src/features/session/resolverThreadSettlements.test.ts
+++ b/apps/desktop/src/features/session/resolverThreadSettlements.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import type { PendingResolution } from '@goodboy/types';
+import { resolverThreadSettlements } from './resolverThreadSettlements';
+
+const NO_PENDING: ReadonlyArray<PendingResolution> = [];
+
+const NOTHING_CLOSED: ReadonlySet<string> = new Set();
+
+describe('resolverThreadSettlements', () => {
+  it('marks the thread the local ledger already closed', () => {
+    const [settlement] = resolverThreadSettlements({
+      threadIds: ['PRRT_1'],
+      outcomes: {},
+      pendingResolutions: NO_PENDING,
+      closedThreadIds: new Set(['PRRT_1']),
+    });
+
+    expect(settlement?.kind).toBe('open');
+    expect(settlement?.isClosed).toBe(true);
+  });
+
+  it('leaves a thread nobody closed to the operator', () => {
+    const [settlement] = resolverThreadSettlements({
+      threadIds: ['PRRT_1'],
+      outcomes: {},
+      pendingResolutions: NO_PENDING,
+      closedThreadIds: NOTHING_CLOSED,
+    });
+
+    expect(settlement?.kind).toBe('open');
+    expect(settlement?.isClosed).toBe(false);
+  });
+
+  it('closes one thread of an agent without touching its sibling', () => {
+    const settlements = resolverThreadSettlements({
+      threadIds: ['PRRT_1', 'PRRT_2'],
+      outcomes: {
+        PRRT_1: { kind: 'resolved', commitSha: 'abc1234' },
+        PRRT_2: { kind: 'wontfix', reason: 'unreachable branch' },
+      },
+      pendingResolutions: NO_PENDING,
+      closedThreadIds: new Set(['PRRT_1']),
+    });
+
+    expect(settlements[0]?.isClosed).toBe(true);
+    expect(settlements[1]?.isClosed).toBe(false);
+  });
+
+  it('keeps the verdict of a closed thread readable', () => {
+    const [settlement] = resolverThreadSettlements({
+      threadIds: ['PRRT_1'],
+      outcomes: { PRRT_1: { kind: 'wontfix', reason: 'covered elsewhere' } },
+      pendingResolutions: NO_PENDING,
+      closedThreadIds: new Set(['PRRT_1']),
+    });
+
+    expect(settlement?.kind).toBe('wontfix');
+    expect(settlement?.reason).toBe('covered elsewhere');
+    expect(settlement?.isClosed).toBe(true);
+  });
+});

--- a/apps/desktop/src/features/session/resolverThreadSettlements.ts
+++ b/apps/desktop/src/features/session/resolverThreadSettlements.ts
@@ -10,12 +10,14 @@ export type ResolverThreadSettlement = {
   readonly reason: string | null;
   readonly reply: string | null;
   readonly isQueued: boolean;
+  readonly isClosed: boolean;
 };
 
 type Params = {
   readonly threadIds: ReadonlyArray<string>;
   readonly outcomes: Readonly<Record<string, ResolverThreadOutcome>>;
   readonly pendingResolutions: ReadonlyArray<PendingResolution>;
+  readonly closedThreadIds: ReadonlySet<string>;
 };
 
 const trimmed = (value: string | null | undefined): string | null => {
@@ -27,10 +29,12 @@ const fromOutcome = ({
   threadId,
   outcome,
   isQueued,
+  isClosed,
 }: {
   readonly threadId: string;
   readonly outcome: ResolverThreadOutcome;
   readonly isQueued: boolean;
+  readonly isClosed: boolean;
 }): ResolverThreadSettlement => {
   if (outcome.kind === 'resolved') {
     return {
@@ -40,6 +44,7 @@ const fromOutcome = ({
       reason: null,
       reply: trimmed(outcome.reply),
       isQueued,
+      isClosed,
     };
   }
   if (outcome.kind === 'wontfix') {
@@ -50,6 +55,7 @@ const fromOutcome = ({
       reason: trimmed(outcome.reason),
       reply: trimmed(outcome.reply),
       isQueued,
+      isClosed,
     };
   }
   return {
@@ -59,15 +65,18 @@ const fromOutcome = ({
     reason: null,
     reply: trimmed(outcome.reply),
     isQueued,
+    isClosed,
   };
 };
 
 const fromPending = ({
   threadId,
   resolution,
+  isClosed,
 }: {
   readonly threadId: string;
   readonly resolution: PendingResolution;
+  readonly isClosed: boolean;
 }): ResolverThreadSettlement => {
   const kind = resolution.outcome ?? 'resolved';
   return {
@@ -77,6 +86,7 @@ const fromPending = ({
     reason: null,
     reply: trimmed(resolution.reply),
     isQueued: true,
+    isClosed,
   };
 };
 
@@ -84,16 +94,18 @@ export const resolverThreadSettlements = ({
   threadIds,
   outcomes,
   pendingResolutions,
+  closedThreadIds,
 }: Params): ReadonlyArray<ResolverThreadSettlement> => {
   const keys = threadIds.length > 0 ? threadIds : Object.keys(outcomes);
   return keys.map((threadId) => {
     const resolution = pendingResolutions.find((row) => row.threadId === threadId);
     const outcome = outcomes[threadId];
+    const isClosed = closedThreadIds.has(threadId);
     if (outcome !== undefined) {
-      return fromOutcome({ threadId, outcome, isQueued: resolution !== undefined });
+      return fromOutcome({ threadId, outcome, isQueued: resolution !== undefined, isClosed });
     }
     if (resolution !== undefined) {
-      return fromPending({ threadId, resolution });
+      return fromPending({ threadId, resolution, isClosed });
     }
     return {
       threadId,
@@ -102,6 +114,7 @@ export const resolverThreadSettlements = ({
       reason: null,
       reply: null,
       isQueued: false,
+      isClosed,
     };
   });
 };

--- a/apps/desktop/src/features/session/resolverThreadTally.test.ts
+++ b/apps/desktop/src/features/session/resolverThreadTally.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import { resolverThreadTally } from './resolverThreadTally';
+import type {
+  ResolverThreadSettlement,
+  ResolverThreadSettlementKind,
+} from './resolverThreadSettlements';
+
+const settlement = ({
+  threadId,
+  kind,
+  isClosed = false,
+}: {
+  readonly threadId: string;
+  readonly kind: ResolverThreadSettlementKind;
+  readonly isClosed?: boolean;
+}): ResolverThreadSettlement => ({
+  threadId,
+  kind,
+  commitSha: kind === 'resolved' ? 'abc1234' : null,
+  reason: kind === 'wontfix' ? 'intentional' : null,
+  reply: null,
+  isQueued: false,
+  isClosed,
+});
+
+describe('resolverThreadTally', () => {
+  it('counts a closed thread apart from the ones that need you', () => {
+    const tally = resolverThreadTally({
+      settlements: [
+        settlement({ threadId: 'PRRT_1', kind: 'open', isClosed: true }),
+        settlement({ threadId: 'PRRT_2', kind: 'open' }),
+      ],
+    });
+
+    expect(tally.open).toBe(1);
+    expect(tally.closed).toBe(1);
+    expect(tally.total).toBe(2);
+  });
+
+  it('keeps the verdict of a closed thread in its own bucket', () => {
+    const tally = resolverThreadTally({
+      settlements: [
+        settlement({ threadId: 'PRRT_1', kind: 'resolved', isClosed: true }),
+        settlement({ threadId: 'PRRT_2', kind: 'wontfix', isClosed: true }),
+      ],
+    });
+
+    expect(tally.resolved).toBe(1);
+    expect(tally.wontfix).toBe(1);
+    expect(tally.settled).toBe(2);
+    expect(tally.closed).toBe(0);
+  });
+
+  it('counts only what a push would actually close', () => {
+    const tally = resolverThreadTally({
+      settlements: [
+        settlement({ threadId: 'PRRT_1', kind: 'resolved', isClosed: true }),
+        settlement({ threadId: 'PRRT_2', kind: 'wontfix' }),
+        settlement({ threadId: 'PRRT_3', kind: 'open' }),
+      ],
+    });
+
+    expect(tally.settled).toBe(2);
+    expect(tally.closable).toBe(1);
+  });
+
+  it('counts only the fixes a batch could still take', () => {
+    const tally = resolverThreadTally({
+      settlements: [
+        settlement({ threadId: 'PRRT_1', kind: 'resolved', isClosed: true }),
+        settlement({ threadId: 'PRRT_2', kind: 'resolved' }),
+      ],
+    });
+
+    expect(tally.resolved).toBe(2);
+    expect(tally.pushable).toBe(1);
+  });
+
+  it('leaves an untouched agent counting exactly as its verdicts read', () => {
+    const tally = resolverThreadTally({
+      settlements: [
+        settlement({ threadId: 'PRRT_1', kind: 'resolved' }),
+        settlement({ threadId: 'PRRT_2', kind: 'open' }),
+      ],
+    });
+
+    expect(tally.closed).toBe(0);
+    expect(tally.closable).toBe(tally.settled);
+    expect(tally.pushable).toBe(tally.resolved);
+    expect(tally.isMixed).toBe(true);
+  });
+});

--- a/apps/desktop/src/features/session/resolverThreadTally.ts
+++ b/apps/desktop/src/features/session/resolverThreadTally.ts
@@ -6,7 +6,10 @@ export type ResolverThreadTally = {
   readonly wontfix: number;
   readonly analyzed: number;
   readonly open: number;
+  readonly closed: number;
   readonly settled: number;
+  readonly closable: number;
+  readonly pushable: number;
   readonly isMixed: boolean;
 };
 
@@ -20,7 +23,12 @@ export const resolverThreadTally = ({ settlements }: Params): ResolverThreadTall
   const resolved = countOf('resolved');
   const wontfix = countOf('wontfix');
   const analyzed = countOf('analyzed');
-  const open = countOf('open');
+  const open = settlements.filter(
+    (settlement) => settlement.kind === 'open' && !settlement.isClosed,
+  ).length;
+  const closed = settlements.filter(
+    (settlement) => settlement.kind === 'open' && settlement.isClosed,
+  ).length;
   const buckets = [resolved, wontfix, analyzed, open].filter((count) => count > 0).length;
   return {
     total: settlements.length,
@@ -28,7 +36,13 @@ export const resolverThreadTally = ({ settlements }: Params): ResolverThreadTall
     wontfix,
     analyzed,
     open,
+    closed,
     settled: resolved + wontfix + analyzed,
+    closable: settlements.filter((settlement) => settlement.kind !== 'open' && !settlement.isClosed)
+      .length,
+    pushable: settlements.filter(
+      (settlement) => settlement.kind === 'resolved' && !settlement.isClosed,
+    ).length,
     isMixed: settlements.length > 1 && buckets > 1,
   };
 };

--- a/apps/desktop/src/store/slices/github/index.test.ts
+++ b/apps/desktop/src/store/slices/github/index.test.ts
@@ -511,6 +511,7 @@ describe('store contract', () => {
         sidebarProviderFilter: [],
         githubStatus: null,
         sessionGithub: {},
+        sessionResolvedThreads: {},
         sessionGithubPrs: {},
         sessionSelectedPrNumber: {},
         volatilePermissionAllows: new Set<string>(),
@@ -1086,6 +1087,117 @@ describe('store contract', () => {
         .sort();
       expect(closedThreadIds).toEqual(['PRRT_1', 'PRRT_2']);
       expect(store.getState().notifications[0]?.title).toBe('1 thread left open');
+    });
+
+    it('resolveAgentThreads never posts a second reply on a thread already closed', async () => {
+      const store = await getStore();
+      store.setState({
+        workspaces: [buildWorkspace()],
+        sessions: [buildSession()],
+        notifications: [],
+        sessionBranches: { [SESSION_ID]: 'ak/feat-x' },
+        sessionWorktrees: { [SESSION_ID]: ['/tmp/repo/.wt/x'] },
+        sessionPhaseRuns: {
+          [SESSION_ID]: [
+            {
+              id: AGENT_ID,
+              sessionId: SESSION_ID,
+              ordinal: 0,
+              name: 'combined resolver',
+              status: 'completed',
+              sourceThreadIds: ['PRRT_1', 'PRRT_2'],
+            },
+          ],
+        },
+        resolverThreadOutcomes: {
+          [AGENT_ID]: {
+            PRRT_1: { kind: 'resolved', commitSha: 'abcdef1234567890' },
+            PRRT_2: { kind: 'resolved', commitSha: 'abcdef1234567890' },
+          },
+        },
+        sessionResolvedThreads: { [SESSION_ID]: ['PRRT_1'] },
+        refreshSessionPrDetail: vi.fn(async () => undefined),
+      });
+      listPendingResolutionsForSessionSpy.mockResolvedValue([]);
+
+      const didResolve = await store.getState().resolveAgentThreads(SESSION_ID, AGENT_ID);
+
+      expect(didResolve).toBe(true);
+      expect(addReplySpy).toHaveBeenCalledOnce();
+      expect(resolveThreadSpy).toHaveBeenCalledOnce();
+      const closedFirst = (resolveThreadSpy.mock.calls as ReadonlyArray<ReadonlyArray<unknown>>)[0];
+      expect(String(closedFirst?.[1])).toBe('PRRT_2');
+      expect(store.getState().notifications).toEqual([]);
+    });
+
+    it('resolveAgentThreads leaves a thread github already closed out of the push', async () => {
+      const store = await getStore();
+      store.setState({
+        workspaces: [buildWorkspace()],
+        sessions: [buildSession()],
+        notifications: [],
+        sessionBranches: { [SESSION_ID]: 'ak/feat-x' },
+        sessionWorktrees: { [SESSION_ID]: ['/tmp/repo/.wt/x'] },
+        sessionPhaseRuns: {
+          [SESSION_ID]: [
+            {
+              id: AGENT_ID,
+              sessionId: SESSION_ID,
+              ordinal: 0,
+              name: 'combined resolver',
+              status: 'completed',
+              sourceThreadIds: ['PRRT_1', 'PRRT_2'],
+            },
+          ],
+        },
+        resolverThreadOutcomes: {
+          [AGENT_ID]: {
+            PRRT_1: { kind: 'resolved', commitSha: 'abcdef1234567890' },
+            PRRT_2: { kind: 'wontfix', reason: 'the behavior is intentional' },
+          },
+        },
+        sessionGithub: {
+          [SESSION_ID]: {
+            pr: null,
+            linkedIssues: [],
+            fetchedAt: null,
+            loading: false,
+            error: null,
+            detail: {
+              prNumber: 1,
+              comments: [
+                {
+                  id: 'c1',
+                  author: 'reviewer',
+                  authorAvatarUrl: null,
+                  body: 'already handled',
+                  createdAt: NOW,
+                  url: 'https://github.com/x/y/pull/1#discussion_r1',
+                  source: 'review',
+                  threadId: 'PRRT_2',
+                  resolved: true,
+                },
+              ],
+              reviews: [],
+              reviewRequests: [],
+              checks: [],
+            },
+            detailFetchedAt: null,
+            detailLoading: false,
+            detailError: null,
+          },
+        },
+        refreshSessionPrDetail: vi.fn(async () => undefined),
+      });
+      listPendingResolutionsForSessionSpy.mockResolvedValue([]);
+
+      const didResolve = await store.getState().resolveAgentThreads(SESSION_ID, AGENT_ID);
+
+      expect(didResolve).toBe(true);
+      expect(resolveThreadSpy).toHaveBeenCalledOnce();
+      const closedOnly = (resolveThreadSpy.mock.calls as ReadonlyArray<ReadonlyArray<unknown>>)[0];
+      expect(String(closedOnly?.[1])).toBe('PRRT_1');
+      expect(store.getState().notifications).toEqual([]);
     });
 
     it('resolveAgentThreads never closes a thread without a reply to post', async () => {

--- a/apps/desktop/src/store/slices/github/resolveAgentThreads.ts
+++ b/apps/desktop/src/store/slices/github/resolveAgentThreads.ts
@@ -1,6 +1,7 @@
 import { deletePendingResolution, listPendingResolutionsForSession } from '@goodboy/db';
 import type { AgentId, SessionId } from '@goodboy/types';
 import { agentThreadIds } from '../../../features/session/agentThreadIds';
+import { closedThreadIds } from '../../../features/session/closedThreadIds';
 import { resolverThreadSettlements } from '../../../features/session/resolverThreadSettlements';
 import type { ResolverThreadSettlement } from '../../../features/session/resolverThreadSettlements';
 import { tauriDatabase } from '../../../shared/lib/db';
@@ -72,9 +73,13 @@ export const resolveAgentThreads = (set: SetFn, get: GetFn) => {
       threadIds,
       outcomes,
       pendingResolutions: persisted,
+      closedThreadIds: closedThreadIds({
+        comments: get().sessionGithub[sessionId]?.detail?.comments ?? [],
+        ledger: get().sessionResolvedThreads[sessionId] ?? [],
+      }),
     });
     const targets = settlements.flatMap((settlement): ReadonlyArray<Target> => {
-      if (settlement.kind === 'open') {
+      if (settlement.isClosed || settlement.kind === 'open') {
         return [];
       }
       const closure = settlementClosure({ settlement });
@@ -85,13 +90,16 @@ export const resolveAgentThreads = (set: SetFn, get: GetFn) => {
         { threadId: settlement.threadId, closure, shouldPush: settlement.kind === 'resolved' },
       ];
     });
-    const skipped = threadIds.length - targets.length;
+    const alreadyClosed = settlements.filter((settlement) => settlement.isClosed).length;
+    const skipped = threadIds.length - targets.length - alreadyClosed;
     if (targets.length === 0) {
       void get().emitNotification(
         'error',
         'error',
         'nothing to resolve',
-        'no thread of this resolver carries a resolution yet, so nothing was closed on GitHub',
+        skipped === 0
+          ? 'every thread of this resolver is already closed on GitHub'
+          : 'no thread of this resolver carries a resolution yet, so nothing was closed on GitHub',
         notifyTarget,
       );
       return false;


### PR DESCRIPTION
Two defects left over from the per-thread resolver work.

## A thread already closed on GitHub read as needing you

A settlement was derived from the verdict alone, never from the two places that know a thread is shut: the `resolved` flag on the PR comment, and the local ledger of threads we closed ourselves. A partially closed multi-thread agent therefore showed a closed thread as still needing the operator, and offered actions on a thread that was already shut.

A settlement now carries `isClosed`, as a property rather than a new kind: the verdict the agent reached and where the thread stands on GitHub are orthogonal, and folding one into the other would have destroyed the verdict at the moment of closing.

The tally follows: a closed thread with no verdict counts in its own bucket instead of `open`, so the sentence reads `1 fixed · 1 closed` beside rows whose chips say exactly that. Every consumer was decided deliberately rather than inherited: push enablement gates on what still has a fix to push, and the mixed block's counts equal what the button would actually close.

## Push posted a second reply on a closed thread

`resolveAgentThreads` still targeted closed threads, so `markThreadResolvedNoPush` posted a duplicate reply and resolved them again. They are dropped from the targets now. The skipped-threads warning keeps its wording and is finally true, since it means only "carries no resolution yet"; an already-closed thread produces no notification at all, because it is a fact and not something to worry about.

## The diff opened at a sibling's commit

`resolverCommitSha` returned the first resolved thread's sha for the whole agent, so a changed file could open at a commit that did not contain it. Files are now attributed to the commit that actually carries them, walking the transcript once. The old helper survives as the last-resort fallback for transcripts with no marker at all.

## Verification

`pnpm -w typecheck` 5/5 · `pnpm --filter @goodboy/desktop test` 3801 passed (3768 before) · `pnpm knip --include files,duplicates,unlisted` exit 0.

Every fix was reverted in place to confirm its test fails: the duplicate-reply test fails with "expected to be called once, but got 2 times", which is the bug itself. An agent with nothing closed produces byte-identical labels, notes and gates, asserted directly.

Also fixes a test-isolation bug: the store contract's reset snapshot never cleared `sessionResolvedThreads`, so a closed thread leaked into the next test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)