### PR TITLE
fix(core): keep fable at the top, off the coding roles

### DIFF
--- a/apps/desktop/src/__tests__/chat-constants.test.ts
+++ b/apps/desktop/src/__tests__/chat-constants.test.ts
@@ -73,11 +73,11 @@ describe('suggestLighterModel', () => {
 });
 
 describe('suggestHeavierModel', () => {
-  it('Opus 4.8 → Opus 5, optional within the expensive tier, at the same price', () => {
+  it('Opus 4.8 → Fable 5, optional within the expensive tier, about 2x cost', () => {
     expect(suggestHeavierModel('claude-opus-4-8', ANTHROPIC)).toEqual({
-      id: 'claude-opus-5',
+      id: 'claude-fable-5',
       kind: 'optional',
-      costMultiplier: null,
+      costMultiplier: 2,
     });
   });
 
@@ -91,12 +91,12 @@ describe('suggestHeavierModel', () => {
     });
   });
 
-  it('Sonnet 4.6 → Opus 5 (heavy task escalates to the strongest coding model)', () => {
-    expect(suggestHeavierModel('claude-sonnet-4-6', ANTHROPIC)?.id).toBe('claude-opus-5');
+  it('Sonnet 4.6 → Fable 5 (heavy task escalates straight to the top)', () => {
+    expect(suggestHeavierModel('claude-sonnet-4-6', ANTHROPIC)?.id).toBe('claude-fable-5');
   });
 
   it('no suggestion when already on the top model', () => {
-    expect(suggestHeavierModel('claude-opus-5', ANTHROPIC)).toBeNull();
+    expect(suggestHeavierModel('claude-fable-5', ANTHROPIC)).toBeNull();
   });
 
   it('codex: GPT-5.4 → GPT-5.5', () => {
@@ -111,11 +111,11 @@ describe('suggestHeavierModel', () => {
     });
   });
 
-  it('Sonnet 4.6 → Opus 5, strong, about 1.7x cost', () => {
+  it('Sonnet 4.6 → Fable 5, strong, about 3.3x cost', () => {
     expect(suggestHeavierModel('claude-sonnet-4-6', ANTHROPIC)).toEqual({
-      id: 'claude-opus-5',
+      id: 'claude-fable-5',
       kind: 'strong',
-      costMultiplier: 1.7,
+      costMultiplier: 3.3,
     });
   });
 

--- a/packages/core/src/providers/auto-model.test.ts
+++ b/packages/core/src/providers/auto-model.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { autoModelForRole, recommendedModelForRole } from './auto-model';
+import { PROVIDER_CAPABILITIES } from './capabilities';
 import { CURSOR_MODELS } from './cursor/models';
 
 describe('autoModelForRole', () => {
@@ -84,7 +85,7 @@ describe('autoModelForRole', () => {
       expect(result).toEqual({ provider: 'cursor', model: 'opus-5' });
     });
 
-    it('substitutes a coding role with Opus, never the storytelling model', () => {
+    it('substitutes a coding role with Opus, never with a thinker-only model', () => {
       const prefs = {
         implementer: { providerId: 'cursor' as const, model: 'gpt-5.6', effort: 'high' as const },
       };
@@ -95,6 +96,25 @@ describe('autoModelForRole', () => {
       expect(recommendedModelForRole({ role: 'implementer', provider: 'anthropic', prefs })).toBe(
         'opus-5',
       );
+    });
+
+    it('still reaches for the thinker on a role that only thinks', () => {
+      const prefs = {
+        planner: { providerId: 'cursor' as const, model: 'gpt-5.6', effort: 'high' as const },
+      };
+      expect(autoModelForRole({ role: 'planner', providers: ['anthropic'], prefs })).toEqual({
+        provider: 'anthropic',
+        model: 'fable-5',
+      });
+    });
+
+    it('leaves the thinker above Opus in raw strength', () => {
+      const anthropic = PROVIDER_CAPABILITIES.anthropic.models;
+      const fable = anthropic.find((model) => model.id === 'fable-5');
+      const opus = anthropic.find((model) => model.id === 'opus-5');
+      expect(fable?.weight ?? 0).toBeGreaterThan(opus?.weight ?? 0);
+      expect(fable?.thinkerOnly).toBe(true);
+      expect(opus?.thinkerOnly).toBe(false);
     });
   });
 });

--- a/packages/core/src/providers/auto-model.ts
+++ b/packages/core/src/providers/auto-model.ts
@@ -25,6 +25,8 @@ const COST_RANK: Readonly<Record<ModelCostTier, number>> = {
   expensive: 3,
 };
 
+const THINKING_ROLES: ReadonlySet<string> = new Set(['planner', 'investigator', 'custom']);
+
 export const autoModelForRole = ({
   role,
   providers,
@@ -41,9 +43,13 @@ export const autoModelForRole = ({
 
   const tier = PROVIDER_CAPABILITIES[def.provider].models.find((m) => m.id === def.model)?.costTier;
   const target = COST_RANK[tier ?? 'mid'];
+  const wantsThinker = THINKING_ROLES.has(role);
   let best: { provider: ProviderId; model: string; score: number } | null = null;
   for (const provider of providers) {
     for (const m of PROVIDER_CAPABILITIES[provider].models) {
+      if (m.thinkerOnly && !wantsThinker) {
+        continue;
+      }
       const score = -Math.abs(COST_RANK[m.costTier] - target) * 1000 + m.weight;
       if (best === null || score > best.score) {
         best = { provider, model: m.id, score };

--- a/packages/core/src/providers/catalogDescriptor.ts
+++ b/packages/core/src/providers/catalogDescriptor.ts
@@ -4,9 +4,11 @@ type Params = {
   readonly model: CatalogModel;
 };
 
+const THINKER_ONLY_KEYS: ReadonlySet<string> = new Set(['fable-5']);
+
 const WEIGHT_BY_KEY: Readonly<Record<string, number>> = {
   'opus-5': 85,
-  'fable-5': 82,
+  'fable-5': 90,
   'opus-4.8': 80,
   'opus-4.7': 75,
   'opus-4.6': 60,
@@ -56,5 +58,6 @@ export const catalogDescriptor = ({ model }: Params): ModelDescriptor => {
     costTier: model.presentation.costTier,
     weight: WEIGHT_BY_KEY[model.key] ?? 10,
     effort: effortFor({ model }),
+    thinkerOnly: THINKER_ONLY_KEYS.has(model.key),
   };
 };

--- a/packages/types/src/provider-registry.ts
+++ b/packages/types/src/provider-registry.ts
@@ -37,6 +37,7 @@ export type ModelDescriptor = {
   readonly costTier: ModelCostTier;
   readonly weight: number;
   readonly effort: ReadonlyArray<ModelEffort> | null;
+  readonly thinkerOnly: boolean;
 };
 
 export type ProviderRegistryCapabilities = {


### PR DESCRIPTION
## Why the previous fix was the wrong lever

#1179 stopped an implementer from landing on Fable 5 by lowering its weight from 90 to 82. That is wrong: `weight` is raw strength, not suitability. It is read by the substitution, by `getMidModel`, by `planTurnFallback`, and by the chat's `suggestHeavierModel`, so demoting Fable also stopped the chat from ever escalating to it, and quietly told the rest of the app that Opus is the stronger model. Fable is the most capable and the most expensive; it should stay that way.

## What changed

Fable 5 is back at weight 90. `ModelDescriptor` gains `thinkerOnly`, set for `fable-5` alone, and `autoModelForRole` skips a `thinkerOnly` candidate unless the role is one that only thinks (`planner`, `investigator`, `custom`).

So: an implementer whose preference points at `cursor/gpt-5.6` substitutes to `anthropic/opus-5`, a planner in the same situation substitutes to `anthropic/fable-5`, the chat still offers Fable as the heavier model, and picking Fable by hand is untouched.

## Verification

core 1042 passed, desktop 4097, `tsc --noEmit` clean across 5 packages, prettier clean. The escalation tests that #1179 had rewritten are back to their original expectations, which is the proof the weight table is intact. Mutation-checked: dropping the `thinkerOnly` guard fails the implementer case, dropping `planner` from the thinking roles fails the planner case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
