### PR TITLE
feat(desktop): list the pull requests a session actually has

### DIFF
--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.test.tsx
@@ -239,15 +239,14 @@ describe('PrPane', () => {
 
     render(<PrPane session={session} onSelectLens={h.onSelectLens} />);
 
-    expect(
-      screen.queryByRole('button', { name: /GitHub #42 Refactor authentication In review/i }),
-    ).toBeNull();
-    expect(screen.getAllByText('Refactor authentication')).toHaveLength(1);
+    expect(screen.getByRole('heading', { name: 'Refactor authentication' })).toBeDefined();
+    expect(screen.getByText('Linked pull request')).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Show pull request #42' })).toBeDefined();
     expect(screen.getByText('No CI')).toBeDefined();
-    expect(screen.getByRole('button', { name: 'Open in code host' })).toBeDefined();
+    expect(screen.getByRole('button', { name: /Review this pull request/i })).toBeDefined();
   });
 
-  it('offers a switcher across every pull request on the branch', () => {
+  it('lists every pull request on the branch and switches on click', () => {
     const closedPr = {
       ...PULL_REQUEST,
       number: 40,
@@ -266,8 +265,8 @@ describe('PrPane', () => {
 
     render(<PrPane session={session} onSelectLens={h.onSelectLens} />);
 
-    fireEvent.click(screen.getByRole('button', { name: /#42 of 2/i }));
-    fireEvent.click(screen.getByRole('option', { name: /#40/i }));
+    expect(screen.getByText('Linked pull requests (2)')).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: 'Show pull request #40' }));
 
     expect(h.store.selectSessionPr).toHaveBeenCalledWith(SESSION_ID, 40);
   });
@@ -292,8 +291,17 @@ describe('PrPane', () => {
 
     render(<PrPane session={session} onSelectLens={h.onSelectLens} />);
 
-    expect(screen.getByText(closedPr.title)).toBeDefined();
-    expect(screen.queryByText(PULL_REQUEST.title)).toBeNull();
+    expect(screen.getByRole('heading', { name: closedPr.title })).toBeDefined();
+    expect(screen.queryByRole('heading', { name: PULL_REQUEST.title })).toBeNull();
+    const selectedRow = screen
+      .getByRole('button', { name: `Show pull request #${closedPr.number}` })
+      .closest('[data-selected]');
+    expect(selectedRow).not.toBeNull();
+    expect(
+      screen
+        .getByRole('button', { name: `Show pull request #${PULL_REQUEST.number}` })
+        .closest('[data-selected]'),
+    ).toBeNull();
   });
 
   it('falls back when the selected provider request disappears', () => {
@@ -324,7 +332,7 @@ describe('PrPane', () => {
     view.rerender(<PrPane session={session} onSelectLens={h.onSelectLens} />);
 
     expect(screen.queryByText('GitLab merge request detail')).toBeNull();
-    expect(screen.getByRole('button', { name: 'Open in code host' })).toBeDefined();
+    expect(screen.getByRole('button', { name: /Review this pull request/i })).toBeDefined();
   });
 
   it('shows PR status, linked issues, and code-host external tasks from stored state', () => {
@@ -383,7 +391,7 @@ describe('PrPane', () => {
     fireEvent.click(screen.getByRole('button', { name: 'open #7 in GitHub' }));
     expect(h.openUrl).toHaveBeenCalledWith('https://github.com/acme/goodboy/issues/7');
     expect(h.onSelectLens).not.toHaveBeenCalled();
-    expect(screen.getAllByRole('link', { name: 'Open in GitHub' })).toHaveLength(2);
+    expect(screen.getAllByRole('link', { name: 'Open in GitHub' })).toHaveLength(3);
   });
 
   it('shows repository attribution on composite linked rows', () => {

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.tsx
@@ -3,6 +3,7 @@ import { ArrowRight, GitBranch, GitFork, GitMerge } from 'lucide-react';
 import { Button, Eyebrow } from '@goodboy/ui';
 import type {
   LinkedIssue,
+  PullRequestState,
   PullRequestStateKind,
   Session,
   SessionExternalTask,
@@ -10,7 +11,6 @@ import type {
   Workspace,
 } from '@goodboy/types';
 import { PullRequestChip, pullRequestMeta } from '../../../../github/components/PullRequestChip';
-import { PrSwitcher } from '../../../../github/components/GitHubStudio/PrSwitcher';
 import { ExternalTaskChip } from '../../../../integrations/components/ExternalTaskChip';
 import { PROVIDER_LENS } from '../../../../integrations/providerLens';
 import { GitlabMrStrip } from '../../../../context/components/ContextPanel/strips/GitlabMrStrip';
@@ -338,15 +338,7 @@ const GithubPrCard = ({
       header={
         <HeaderBand
           meta={
-            branchPrs.length > 1 ? (
-              <PrSwitcher
-                prs={branchPrs}
-                selected={pr.number}
-                onSelect={(prNumber) => void selectSessionPr(sessionId, prNumber)}
-              />
-            ) : (
-              <PullRequestChip state={pr.state} variant="badge" number={pr.number} iconSize={12} />
-            )
+            <PullRequestChip state={pr.state} variant="badge" number={pr.number} iconSize={12} />
           }
           title={pr.title}
           actions={
@@ -359,7 +351,7 @@ const GithubPrCard = ({
                 error={error}
               />
               <Button size="sm" variant="ghost" onClick={onOpenStudio}>
-                Open in code host
+                Review this pull request
                 <ArrowRight size={13} aria-hidden className="shrink-0 opacity-70" />
               </Button>
             </>
@@ -372,6 +364,11 @@ const GithubPrCard = ({
         entity: { pr, checks: detail?.checks ?? [], unresolved },
       })}
     >
+      <LinkedPullRequestsSection
+        prs={branchPrs.length > 0 ? branchPrs : [pr]}
+        selectedNumber={pr.number}
+        onSelect={(prNumber) => void selectSessionPr(sessionId, prNumber)}
+      />
       <LinkedIssuesSection issues={linkedIssues} />
       <ExternalTasksSection
         tasks={codeHostTasks}
@@ -384,6 +381,59 @@ const GithubPrCard = ({
         </span>
       ) : null}
     </StudioDetailLayout>
+  );
+};
+
+type LinkedPullRequestsSectionProps = {
+  readonly prs: ReadonlyArray<PullRequestState>;
+  readonly selectedNumber: number;
+  readonly onSelect: (prNumber: number) => void;
+};
+
+const LinkedPullRequestsSection = ({
+  prs,
+  selectedNumber,
+  onSelect,
+}: LinkedPullRequestsSectionProps) => {
+  if (prs.length === 0) {
+    return null;
+  }
+  return (
+    <div className="flex flex-col gap-1.5">
+      <Eyebrow
+        label={prs.length === 1 ? 'Linked pull request' : `Linked pull requests (${prs.length})`}
+        muted
+        className="px-0.5 font-medium"
+      />
+      <div className="flex flex-col gap-1">
+        {prs.map((candidate) => (
+          <LinkedWorkRow
+            key={candidate.number}
+            leading={{ kind: 'glyph', provider: 'github' }}
+            identifier={`#${candidate.number}`}
+            title={candidate.title}
+            isSelected={candidate.number === selectedNumber}
+            ariaLabel={`Show pull request #${candidate.number}`}
+            tooltip={
+              candidate.number === selectedNumber
+                ? 'Showing this pull request'
+                : 'Show this pull request instead'
+            }
+            attribution={
+              <IssueStateBadge>{pullRequestMeta(candidate.state).label}</IssueStateBadge>
+            }
+            onClick={() => onSelect(candidate.number)}
+            actions={
+              <ExternalRefActions
+                url={candidate.url}
+                label={`pull request #${candidate.number}`}
+                hostLabel="GitHub"
+              />
+            }
+          />
+        ))}
+      </div>
+    </div>
   );
 };
 

--- a/apps/desktop/src/shared/components/LinkedWorkRow/index.tsx
+++ b/apps/desktop/src/shared/components/LinkedWorkRow/index.tsx
@@ -31,6 +31,7 @@ type Props = {
   readonly actions?: ReactNode;
   readonly attribution?: ReactNode;
   readonly navigation?: 'internal' | 'external';
+  readonly isSelected?: boolean;
 };
 
 export const LinkedWorkRow = ({
@@ -43,6 +44,7 @@ export const LinkedWorkRow = ({
   actions,
   attribution,
   navigation = 'internal',
+  isSelected = false,
 }: Props) => {
   const glyph =
     leading.kind === 'icon' ? (
@@ -58,7 +60,15 @@ export const LinkedWorkRow = ({
     );
 
   return (
-    <div className="group flex w-full items-center gap-2 rounded-lg border border-border-soft bg-elevated px-3.5 py-2.5 shadow-sm transition-colors hover:border-border">
+    <div
+      data-selected={isSelected ? 'true' : undefined}
+      className={cn(
+        'group flex w-full items-center gap-2 rounded-lg border bg-elevated px-3.5 py-2.5 shadow-sm transition-colors',
+        isSelected
+          ? 'border-primary/40 ring-1 ring-primary/25'
+          : 'border-border-soft hover:border-border',
+      )}
+    >
       <button
         type="button"
         onClick={(event) => {


### PR DESCRIPTION
## Why

The session's GitHub lens had a pull request linked and its only action was **Open in code host**, which says nothing about what it opens (an in-app studio, not github.com) and hides the fact that a branch usually carries more than one request.

## What changed

**Linked pull requests** is now a section in the lens, listing every pull request on the session's branch: number, title, state, an external link each, and a ring on the one currently being shown. Clicking a row switches the lens to that request, which is what the old dropdown switcher did, except now you can see all of them at once without opening anything.

The header action reads **Review this pull request** and still opens the review surface for it. The dropdown switcher (`PrSwitcher`) is gone from this lens.

`LinkedWorkRow` gains an optional `isSelected`, rendered as `border-primary/40 ring-1 ring-primary/25` plus a `data-selected` hook so the state is assertable.

## Verification

Desktop 4097 passed, `tsc --noEmit` clean, prettier clean. Mutation-checked: dropping the section fails four PrPane cases, dropping the `data-selected` hook fails the selected-row case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
