### PR TITLE
chore(desktop): one beta chip, in the footer

### DIFF
--- a/apps/desktop/src/__tests__/regressions/beta-chip-only-in-footer.test.ts
+++ b/apps/desktop/src/__tests__/regressions/beta-chip-only-in-footer.test.ts
@@ -1,0 +1,49 @@
+import { readdirSync, readFileSync, statSync } from 'fs';
+import { join, relative, sep } from 'path';
+import { describe, expect, it } from 'vitest';
+
+const DESKTOP_SRC = join(__dirname, '..', '..');
+const UI_SRC = join(DESKTOP_SRC, '..', '..', '..', 'packages', 'ui', 'src');
+const SKIP_SEGMENTS = new Set(['__tests__', 'node_modules', 'dist']);
+const ALLOWED = ['shared', 'components', 'BetaPill', 'index.tsx'].join(sep);
+
+const BETA_LABEL = /label=(?:"Beta"|\{'Beta'\}|\{"Beta"\})/i;
+const BETA_TEXT = />\s*Beta\s*</i;
+
+const listSourceFiles = (dir: string, acc: string[] = []): string[] => {
+  for (const entry of readdirSync(dir)) {
+    if (SKIP_SEGMENTS.has(entry)) {
+      continue;
+    }
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      listSourceFiles(full, acc);
+    } else if (entry.endsWith('.tsx') && !entry.endsWith('.test.tsx')) {
+      acc.push(full);
+    }
+  }
+  return acc;
+};
+
+describe('beta chip', () => {
+  it('renders in the footer pill and nowhere else in the app', () => {
+    const offenders: string[] = [];
+    for (const root of [DESKTOP_SRC, UI_SRC]) {
+      for (const file of listSourceFiles(root)) {
+        if (file.endsWith(ALLOWED)) {
+          continue;
+        }
+        const source = readFileSync(file, 'utf8');
+        source.split('\n').forEach((line, idx) => {
+          if (BETA_LABEL.test(line) || BETA_TEXT.test(line)) {
+            offenders.push(`${relative(root, file)}:${idx + 1} ${line.trim()}`);
+          }
+        });
+      }
+    }
+    expect(
+      offenders,
+      `A Beta chip may only live in the footer pill (shared/components/BetaPill). Remove these:\n${offenders.join('\n')}`,
+    ).toEqual([]);
+  });
+});

--- a/apps/desktop/src/features/providers/components/ProviderStudio/ApiProviderDetail.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/ApiProviderDetail.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useState } from 'react';
-import { Chip, SectionHeader } from '@goodboy/ui';
+import { SectionHeader } from '@goodboy/ui';
 import { CircleCheck, RotateCw, Terminal, TriangleAlert } from 'lucide-react';
-import { PROVIDER_BETA } from '@goodboy/types';
 import type { ProviderInfo } from '../../../../features/providers/providers';
 import { useAppStore } from '../../../../store';
 import { brandColor, PROVIDER_BRAND } from '../provider-brand';
@@ -31,7 +30,6 @@ export const ApiProviderDetail = ({ info }: Props) => {
 
   const action = (
     <div className="flex items-center gap-2">
-      {PROVIDER_BETA.has(info.id) ? <Chip tone="warning" label="Beta" /> : null}
       <button
         type="button"
         aria-label="Re-detect OpenCode"

--- a/apps/desktop/src/features/providers/components/ProviderStudio/ProviderDetailPanel.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/ProviderDetailPanel.tsx
@@ -1,12 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { Button, Chip, EmptyState, SectionHeader, StatusDot } from '@goodboy/ui';
+import { Button, EmptyState, SectionHeader, StatusDot } from '@goodboy/ui';
 import { RotateCw, Sparkles, type LucideIcon } from 'lucide-react';
-import {
-  PROVIDER_BETA,
-  PROVIDER_CONNECT_CAPABILITIES,
-  isApiProvider,
-  type ProviderId,
-} from '@goodboy/types';
+import { PROVIDER_CONNECT_CAPABILITIES, isApiProvider, type ProviderId } from '@goodboy/types';
 import type { ProviderInfo } from '../../../../features/providers/providers';
 import { useAppStore } from '../../../../store';
 import { useToast } from '../../../../app/components/Toast';
@@ -86,7 +81,6 @@ function Detail({
   const subtitle = info.version ? `${info.binary} ${info.version}` : info.binary;
   const action = (
     <div className="flex items-center gap-2">
-      {PROVIDER_BETA.has(id) ? <Chip tone="warning" label="Beta" /> : null}
       <button
         type="button"
         aria-label="Re-detect CLIs"

--- a/apps/desktop/src/features/providers/components/ProviderStudio/ProvidersRail.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/ProvidersRail.tsx
@@ -1,5 +1,5 @@
-import { Chip, Eyebrow, SelectableRow, StatusDot, type Tone } from '@goodboy/ui';
-import { PROVIDER_BETA, type ProviderConnectionState, type ProviderId } from '@goodboy/types';
+import { Eyebrow, SelectableRow, StatusDot, type Tone } from '@goodboy/ui';
+import { type ProviderConnectionState, type ProviderId } from '@goodboy/types';
 import type { ProviderInfo } from '../../../../features/providers/providers';
 import { brandColor, PROVIDER_BRAND } from '../provider-brand';
 import { SlidersHorizontal } from 'lucide-react';
@@ -66,10 +66,7 @@ export const ProvidersRail = ({ providers, focusedId, onSelect, onSelectDefaults
                   style={{ color: brandColor(id) }}
                 />
                 <span className="flex min-w-0 flex-1 flex-col">
-                  <span className="flex items-center gap-1.5">
-                    <span className="truncate text-sm font-medium text-foreground">{p.label}</span>
-                    {PROVIDER_BETA.has(id) ? <Chip tone="warning" label="Beta" /> : null}
-                  </span>
+                  <span className="truncate text-sm font-medium text-foreground">{p.label}</span>
                   <span className="truncate text-2xs text-muted-foreground">{subtitle}</span>
                 </span>
                 <StatusDot tone={STATUS_TONE[p.connection]} size="md" />

--- a/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
@@ -1377,7 +1377,6 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
                       <LaunchToggleRow
                         title="Auto-run"
                         description="Each step runs as soon as the previous finishes. No manual hand-off."
-                        beta
                         checked={autoRun}
                         onChange={setAutoRun}
                         disabled={busy}

--- a/apps/desktop/src/features/session/components/WorkflowBuilderView/parts/LaunchToggleRow.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowBuilderView/parts/LaunchToggleRow.tsx
@@ -6,19 +6,11 @@ type Props = {
   readonly checked: boolean;
   readonly onChange: (v: boolean) => void;
   readonly disabled: boolean;
-  readonly beta?: boolean;
 };
 
-export const LaunchToggleRow = ({
-  title,
-  description,
-  checked,
-  onChange,
-  disabled,
-  beta,
-}: Props) => (
+export const LaunchToggleRow = ({ title, description, checked, onChange, disabled }: Props) => (
   <div className="flex items-center justify-between gap-3 px-3 py-2.5">
     <p className="min-w-0 text-2xs leading-relaxed text-muted-foreground/60">{description}</p>
-    <Switch label={title} beta={beta} checked={checked} onChange={onChange} disabled={disabled} />
+    <Switch label={title} checked={checked} onChange={onChange} disabled={disabled} />
   </div>
 );

--- a/apps/desktop/src/features/workspace/components/WorkspaceLinkForm/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspaceLinkForm/index.tsx
@@ -648,12 +648,7 @@ export const WorkspaceLinkForm = ({
             >
               <SegmentedTabs
                 ariaLabel="Workspace type"
-                options={MODE_OPTIONS.filter((option) => modes.includes(option.value)).map(
-                  (option) =>
-                    option.value === 'multi'
-                      ? { ...option, badge: <Chip tone="warning" label="Beta" /> }
-                      : option,
-                )}
+                options={MODE_OPTIONS.filter((option) => modes.includes(option.value))}
                 value={mode}
                 onChange={(nextMode) => {
                   setMode(nextMode);

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -115,7 +115,6 @@ export { PROVIDER_API_KEY_ENV, PROVIDER_IDS } from './provider-registry';
 export type { OpenCodeRouting, ProviderKind } from './provider-catalog';
 export {
   OPENCODE_ROUTING,
-  PROVIDER_BETA,
   PROVIDER_KIND,
   isApiProvider,
   opencodeModelArg,

--- a/packages/types/src/provider-catalog.ts
+++ b/packages/types/src/provider-catalog.ts
@@ -19,11 +19,6 @@ export const OPENCODE_ROUTING: Readonly<Partial<Record<ProviderId, OpenCodeRouti
   openrouter: { slug: 'openrouter' },
 };
 
-export const PROVIDER_BETA: ReadonlySet<ProviderId> = new Set<ProviderId>([
-  'opencode',
-  'openrouter',
-]);
-
 type ProviderParams = {
   readonly id: ProviderId;
 };

--- a/packages/ui/src/components/Switch.tsx
+++ b/packages/ui/src/components/Switch.tsx
@@ -1,17 +1,15 @@
 import type { ReactNode } from 'react';
 import { cn } from '../cn';
-import { Chip } from './Chip';
 
 export type SwitchProps = {
   readonly label: ReactNode;
   readonly checked: boolean;
   readonly disabled?: boolean;
-  readonly beta?: boolean;
   readonly onChange: (next: boolean) => void;
   readonly className?: string;
 };
 
-export const Switch = ({ label, checked, disabled, beta, onChange, className }: SwitchProps) => (
+export const Switch = ({ label, checked, disabled, onChange, className }: SwitchProps) => (
   <button
     type="button"
     role="switch"
@@ -40,6 +38,5 @@ export const Switch = ({ label, checked, disabled, beta, onChange, className }: 
       />
     </span>
     {label}
-    {beta ? <Chip tone="warning" label="Beta" /> : null}
   </button>
 );


### PR DESCRIPTION
## What

The Beta chip had spread to five surfaces. Only the footer pill keeps it.

Removed: the chip in the provider rail, the provider detail header, the api provider detail header, the `multi` option of the workspace type picker, and the `beta` prop on `Switch` (with its single consumer, `LaunchToggleRow`, and that row's only truthy call site in the workflow builder). `PROVIDER_BETA` lost its last consumer and went with it.

Kept: `BetaPill` in `AppFooter`, which is the one the product wants.

## Guard

`apps/desktop/src/__tests__/regressions/beta-chip-only-in-footer.test.ts` walks `apps/desktop/src` and `packages/ui/src` for a Beta label or a Beta text node and allows only `shared/components/BetaPill/index.tsx`. It scans the tree rather than a fixed list of paths, so a chip added to a file that does not exist yet still fails.

Mutation-checked: dropping a `label="Beta"` into an unrelated component makes the test fail with that file and line, and the failure disappears when it is removed.

## Verification

- `vitest` desktop (providers, workspace link form, workflow builder, app footer): 125 passed
- `vitest` packages/ui: 98 passed
- `tsc --noEmit` on desktop, ui, types: clean
- `knip --include files,duplicates,unlisted`: clean (only the four pre-existing config hints)

happy-dom does not measure layout, so this PR makes no claim about how the surfaces look after the chip is gone beyond the assertions above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)