### PR TITLE
fix(desktop): a disconnected provider stops claiming an account

### DIFF
--- a/apps/desktop/src/store/slices/providers/clearStaleConnect.ts
+++ b/apps/desktop/src/store/slices/providers/clearStaleConnect.ts
@@ -1,0 +1,28 @@
+import { PROVIDER_IDS, type ProviderId } from '@goodboy/types';
+import type { ProviderAuthResults } from '../../../features/providers/providers';
+import { IDLE_CONNECT, type ProviderConnectMap, type ProviderConnectPhase } from './types';
+
+const CLAIMS_CONNECTED: ReadonlySet<ProviderConnectPhase> = new Set<ProviderConnectPhase>([
+  'success',
+  'finished-unverified',
+]);
+
+type Params = {
+  readonly connect: ProviderConnectMap;
+  readonly authResults: ProviderAuthResults;
+};
+
+export const clearStaleConnect = ({ connect, authResults }: Params): ProviderConnectMap => {
+  const stale = PROVIDER_IDS.filter(
+    (id: ProviderId) =>
+      CLAIMS_CONNECTED.has(connect[id].phase) && authResults[id]?.state !== 'connected',
+  );
+  if (stale.length === 0) {
+    return connect;
+  }
+  const next = { ...connect };
+  for (const id of stale) {
+    next[id] = IDLE_CONNECT;
+  }
+  return next;
+};

--- a/apps/desktop/src/store/slices/providers/refreshProviders.test.ts
+++ b/apps/desktop/src/store/slices/providers/refreshProviders.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { refreshProviders } from './refreshProviders';
+import { IDLE_CONNECT, INITIAL_CONNECT_MAP } from './types';
 
 const providerMocks = vi.hoisted(() => {
   const status = {
@@ -30,6 +31,7 @@ describe('refreshProviders', () => {
     const set = vi.fn();
     const get = vi.fn(() => ({
       providerCredentials: [{ providerId: 'openrouter' }],
+      providerConnect: INITIAL_CONNECT_MAP,
     }));
     await refreshProviders(set as never, get as never)();
     expect(providerMocks.refreshProviderDetection).toHaveBeenCalledTimes(5);
@@ -44,5 +46,39 @@ describe('refreshProviders', () => {
       }),
     );
     expect(providerMocks.buildProviderList.mock.calls[0]?.[2]).toEqual(new Set(['openrouter']));
+  });
+
+  it('drops a connect state that still claims success once auth reports disconnected', async () => {
+    providerMocks.checkProviderAuth.mockImplementation(async () => ({
+      state: 'disconnected',
+      identity: null,
+    }));
+    const set = vi.fn();
+    const get = vi.fn(() => ({
+      providerCredentials: [],
+      providerConnect: {
+        ...INITIAL_CONNECT_MAP,
+        cursor: { ...IDLE_CONNECT, phase: 'success', identity: 'amin@serenis.it' },
+      },
+    }));
+    await refreshProviders(set as never, get as never)();
+    const patch = set.mock.calls[0]?.[0] as { providerConnect: typeof INITIAL_CONNECT_MAP };
+    expect(patch.providerConnect.cursor).toEqual(IDLE_CONNECT);
+  });
+
+  it('leaves a connect state alone while auth still reports connected', async () => {
+    providerMocks.checkProviderAuth.mockImplementation(async () => ({
+      state: 'connected',
+      identity: null,
+    }));
+    const set = vi.fn();
+    const connected = { ...IDLE_CONNECT, phase: 'success' as const, identity: 'amin@serenis.it' };
+    const get = vi.fn(() => ({
+      providerCredentials: [],
+      providerConnect: { ...INITIAL_CONNECT_MAP, cursor: connected },
+    }));
+    await refreshProviders(set as never, get as never)();
+    const patch = set.mock.calls[0]?.[0] as { providerConnect: typeof INITIAL_CONNECT_MAP };
+    expect(patch.providerConnect.cursor).toEqual(connected);
   });
 });

--- a/apps/desktop/src/store/slices/providers/refreshProviders.ts
+++ b/apps/desktop/src/store/slices/providers/refreshProviders.ts
@@ -6,6 +6,7 @@ import {
   type ProviderStatuses,
 } from '../../../features/providers/providers';
 import { cursorMaxModeAdvisory } from '../../../shared/lib/cursorMaxModeAdvisory';
+import { clearStaleConnect } from './clearStaleConnect';
 import type { GetFn, SetFn } from './types';
 
 export const refreshProviders = (set: SetFn, get: GetFn) => {
@@ -60,6 +61,7 @@ export const refreshProviders = (set: SetFn, get: GetFn) => {
       geminiStatus,
       authResults,
       providers: buildProviderList(statuses, authResults, credentialProviderIds),
+      providerConnect: clearStaleConnect({ connect: get().providerConnect, authResults }),
     });
   };
 };

--- a/apps/desktop/src/store/slices/providers/runLifecycle.test.ts
+++ b/apps/desktop/src/store/slices/providers/runLifecycle.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { INITIAL_LIFECYCLE_MAP } from './types';
+import { IDLE_CONNECT, INITIAL_CONNECT_MAP, INITIAL_LIFECYCLE_MAP } from './types';
 import { runLifecycle } from './runLifecycle';
 
 const providerMocks = vi.hoisted(() => ({
@@ -43,6 +43,7 @@ describe('runLifecycle', () => {
       authResults: null,
       providers: [],
       providerCredentials: [],
+      providerConnect: { ...INITIAL_CONNECT_MAP },
       refreshProviders,
     };
     const set = vi.fn(
@@ -114,6 +115,7 @@ describe('runLifecycle', () => {
       authResults: null,
       providers: [],
       providerCredentials: [],
+      providerConnect: { ...INITIAL_CONNECT_MAP },
       refreshProviders,
     };
     const set = vi.fn(
@@ -163,5 +165,52 @@ describe('runLifecycle', () => {
       }),
       new Set(),
     );
+  });
+
+  it('drops a connect state claiming success when a logout lands disconnected', async () => {
+    const refreshProviders = vi.fn(async () => undefined);
+    let state: Record<string, unknown> = {
+      providerLifecycle: { ...INITIAL_LIFECYCLE_MAP },
+      providerStatus: null,
+      cursorStatus: null,
+      codexStatus: null,
+      geminiStatus: null,
+      authResults: null,
+      providers: [],
+      providerCredentials: [],
+      providerConnect: {
+        ...INITIAL_CONNECT_MAP,
+        cursor: { ...IDLE_CONNECT, phase: 'success', identity: 'amin@serenis.it' },
+      },
+      refreshProviders,
+    };
+    const set = vi.fn(
+      (
+        update:
+          | Record<string, unknown>
+          | ((current: Record<string, unknown>) => Record<string, unknown>),
+      ) => {
+        const patch = typeof update === 'function' ? update(state) : update;
+        state = { ...state, ...patch };
+      },
+    );
+    const get = vi.fn(() => state);
+
+    await runLifecycle(set as never, get as never, { providerId: 'cursor', action: 'logout' });
+    const invocation = lifecycleMocks.invokeProviderLifecycleRun.mock.calls[0]?.[0];
+    expect(invocation).toBeDefined();
+    if (invocation === undefined) {
+      return;
+    }
+    lifecycleMocks.exitHandler?.({
+      runId: invocation.runId,
+      providerId: 'cursor',
+      action: 'logout',
+      exitCode: 0,
+      status: { id: 'cursor', binary: 'cursor-agent', available: true, version: '1', error: null },
+      auth: { state: 'disconnected', identity: null },
+    });
+
+    expect((state.providerConnect as Record<string, unknown>).cursor).toEqual(IDLE_CONNECT);
   });
 });

--- a/apps/desktop/src/store/slices/providers/runLifecycle.ts
+++ b/apps/desktop/src/store/slices/providers/runLifecycle.ts
@@ -13,6 +13,7 @@ import {
   type LifecycleExitPayload,
 } from '../../../features/providers/provider-lifecycle';
 import { formatError } from '../../../shared/lib/errors';
+import { clearStaleConnect } from './clearStaleConnect';
 import { detectAuthUrl } from './detectAuthUrl';
 import { stripAnsi } from './stripAnsi';
 import type { GetFn, SetFn } from './types';
@@ -208,6 +209,7 @@ export const runLifecycle = async (
         ...statusSlotPatch(providerId, payload.status),
         authResults,
         providers: buildProviderList(statuses, authResults, credentialProviderIds),
+        providerConnect: clearStaleConnect({ connect: state.providerConnect, authResults }),
         providerLifecycle: {
           ...state.providerLifecycle,
           [providerId]: {


### PR DESCRIPTION
## The bug

Disconnect cursor and the provider detail keeps saying **Connected as amin@serenis.it** with a green check, while the rail two centimetres to its left says `installed`.

## Why

`logoutProvider` never touched `providerConnect[providerId]`. After the logout, `info.connection` correctly stops being `connected`, so the panel drops `ConnectedAccount` and falls through to `ProviderConnect` — whose phase is still `success` from the sign-in, and whose `success` branch renders `Connected as ${identity}` with the identity captured back then. The rail reads the real connection; the panel reads a leftover of the connect state machine. The reset existed but was wired only to `dismissProviderConnect`.

## The fix

`clearStaleConnect` returns the connect map with any provider that still claims a positive outcome (`success`, `finished-unverified`) reset to idle when auth no longer reports it connected. It is applied at the two points where the connection can change:

- the lifecycle exit patch in `runLifecycle`, so a logout clears it as it lands
- the `refreshProviders` patch, so a detection that finds a provider disconnected clears it too

In-flight phases (`working`, `handoff`, `waiting-long`, `fallback-offered`, `stall`) are untouched, so a sign-in in progress is never cancelled by a refresh. The panel itself is unchanged: the fix is at the source, not a hidden branch in the view.

## Verification

- New: `runLifecycle` drops a success phase when a logout lands disconnected. Mutation-checked: removing the one line in `runLifecycle` makes exactly this test fail, restoring it turns it green.
- New: `refreshProviders` clears a stale success phase, and leaves it alone while auth still reports connected.
- Two existing fixtures were missing `providerConnect` and were completed rather than guarded around in production code.
- `vitest` providers slice + provider features: 84 passed. `tsc --noEmit`: clean.

The connect flow itself is untouched: it opens the browser and reports its result correctly today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)