### PR TITLE
fix(desktop): one honest answer on whether effort is editable

### DIFF
--- a/apps/desktop/src/shared/components/RoutingPicker/resolveRouting.test.ts
+++ b/apps/desktop/src/shared/components/RoutingPicker/resolveRouting.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { PROVIDER_IDS, type ProviderId } from '@goodboy/types';
+import { MODEL_CATALOGS, modelAxes } from '@goodboy/core';
+import { resolveRouting } from './resolveRouting';
+
+const routingFor = ({ provider, model }: { provider: ProviderId; model: string }) =>
+  resolveRouting({ providers: [provider], provider, model, effort: 'medium' });
+
+describe('resolveRouting parity across providers', () => {
+  it('resolves every catalog model of every provider', () => {
+    for (const provider of PROVIDER_IDS) {
+      const catalog = MODEL_CATALOGS[provider];
+      expect(catalog.length, `${provider} has an empty catalog`).toBeGreaterThan(0);
+      for (const model of catalog) {
+        const routing = routingFor({ provider, model: model.key });
+        expect(routing.provider).toBe(provider);
+        expect(routing.model).toBe(model.key);
+      }
+    }
+  });
+
+  it('calls the effort fixed only when the picker offers no choice', () => {
+    const disagreements: string[] = [];
+    for (const provider of PROVIDER_IDS) {
+      for (const model of MODEL_CATALOGS[provider]) {
+        const routing = routingFor({ provider, model: model.key });
+        const axis = modelAxes({ model, selection: routing.selection }).effort;
+        const editable = (axis?.levels ?? []).filter((level) => level.available).length > 1;
+        if (editable === routing.isEffortFixed) {
+          disagreements.push(
+            `${provider}/${model.key}: axis offers ${axis?.levels.filter((l) => l.available).length ?? 0} levels, isEffortFixed=${routing.isEffortFixed}`,
+          );
+        }
+      }
+    }
+    expect(
+      disagreements,
+      `The trigger label and the effort chips must agree on whether effort is editable:\n${disagreements.join('\n')}`,
+    ).toEqual([]);
+  });
+
+  it('offers gemini the effort levels its catalog declares', () => {
+    const gemini = MODEL_CATALOGS.gemini.find((model) => model.efforts.length > 1);
+    expect(gemini, 'gemini should ship at least one model with a choice of efforts').toBeDefined();
+    if (gemini == null) {
+      return;
+    }
+    const routing = routingFor({ provider: 'gemini', model: gemini.key });
+    expect(routing.effortLevels).toEqual(gemini.efforts);
+    expect(routing.isEffortFixed).toBe(false);
+  });
+});

--- a/apps/desktop/src/shared/components/RoutingPicker/resolveRouting.ts
+++ b/apps/desktop/src/shared/components/RoutingPicker/resolveRouting.ts
@@ -62,8 +62,6 @@ const effortsFor = ({ model, selection, fallback }: EffortParams): ReadonlyArray
         .filter((effort) => effort != null);
       return efforts.length > 0 ? Array.from(new Set(efforts)) : [fallback];
     }
-    case 'gemini':
-      return [fallback];
     default: {
       const exhaustive: never = model;
       throw new Error(`unknown catalog model: ${String(exhaustive)}`);
@@ -119,11 +117,7 @@ export const resolveRouting = ({
     effort: appliedEffort,
     effortLevels,
     ...(resolved.clamped != null && { clamped: resolved.clamped }),
-    isEffortFixed:
-      selectedModel.provider === 'gemini' ||
-      (selectedModel.provider === 'anthropic' && selectedModel.efforts.length === 0) ||
-      (selectedModel.provider === 'cursor' &&
-        selectedModel.combos.every((combo) => combo.effort == null)),
+    isEffortFixed: effortLevels.length <= 1,
     models: catalog.map((candidate) => candidate.key),
     catalog,
     hasThinkingToggle,

--- a/apps/desktop/src/store/parallel-turn.ts
+++ b/apps/desktop/src/store/parallel-turn.ts
@@ -137,8 +137,12 @@ function parseProviderLine(
     case 'opencode':
     case 'openrouter':
       return parseOpenCodeJsonLine({ line, ctx });
-    default:
+    case 'anthropic':
       return parseStreamJsonLine(line, ctx);
+    default: {
+      const exhaustive: never = provider;
+      throw new Error(`unknown provider stream: ${String(exhaustive)}`);
+    }
   }
 }
 


### PR DESCRIPTION
## What was wrong

Three defects of the same family, found by walking every provider rather than the one that was reported.

1. `effortsFor` in `resolveRouting.ts` had two `case 'gemini'` branches, the second unreachable. Dead code, no runtime effect, but it hid the contradiction below.
2. `isEffortFixed` hardcoded `provider === 'gemini'` to `true`. Gemini ships models with two and three effort levels, and the picker rendered those chips, so the popover let you change a value the trigger label insisted was fixed and never printed.
3. `parseProviderLine` in `store/parallel-turn.ts` reached anthropic through a `default:` with no exhaustiveness guard, so a seventh provider would have been parsed by the anthropic parser in silence.

## What it is now

- One branch per provider in `effortsFor`, no unreachable case.
- `isEffortFixed` is derived: the effort is fixed when the resolved levels offer no choice. That covers anthropic models with no efforts, cursor models whose combos carry no effort, and correctly stops covering gemini.
- The stream switch names anthropic and ends in a `never` guard.

## Guard

`resolveRouting.test.ts` enumerates `PROVIDER_IDS`, and for every model in every catalog asserts that the trigger label and the effort chips agree on whether effort is editable, cross-checking `resolveRouting` against `modelAxes` (the function that actually renders the chips). Adding a provider or a model that reintroduces the disagreement fails the suite.

Mutation-checked: restoring the old `isEffortFixed` expression makes the test fail naming both gemini models and their level counts; putting the derivation back turns it green.

## Verification

- `vitest` RoutingPicker + whole store: 901 passed, 97 files
- `tsc --noEmit`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)