### PR TITLE
fix(desktop): an update that is waiting asks for attention

### DIFF
--- a/apps/desktop/src/features/updater/components/UpdateIndicator/index.test.tsx
+++ b/apps/desktop/src/features/updater/components/UpdateIndicator/index.test.tsx
@@ -1,0 +1,58 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAppStore } from '../../../../store';
+import { UpdateIndicator } from './index';
+
+const installUpdate = vi.fn(async () => undefined);
+
+const setStatus = (status: 'idle' | 'available' | 'downloading') => {
+  useAppStore.setState({
+    updaterStatus: status,
+    updateVersion: '0.1.58',
+    installUpdate,
+  } as never);
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(cleanup);
+
+describe('UpdateIndicator', () => {
+  it('says nothing while there is no update', () => {
+    setStatus('idle');
+    render(<UpdateIndicator variant="pip" />);
+    expect(screen.queryByTestId('update-indicator')).toBeNull();
+  });
+
+  it('asks for attention while an update waits for the user', () => {
+    setStatus('available');
+    render(<UpdateIndicator variant="pip" />);
+    const chip = screen.getByTestId('update-indicator') as HTMLButtonElement;
+    expect(chip.textContent).toContain('Update to 0.1.58');
+    expect(chip.className).toContain('attention-ring');
+    expect(chip.className).not.toContain('spin-border');
+    expect(chip.disabled).toBe(false);
+  });
+
+  it('switches to a running border while the update downloads', () => {
+    setStatus('downloading');
+    render(<UpdateIndicator variant="pip" />);
+    const chip = screen.getByTestId('update-indicator') as HTMLButtonElement;
+    expect(chip.textContent).toContain('Updating to 0.1.58');
+    expect(chip.className).toContain('spin-border');
+    expect(chip.className).not.toContain('attention-ring');
+    expect(chip.disabled).toBe(true);
+  });
+
+  it('installs only after the confirmation is accepted', async () => {
+    setStatus('available');
+    render(<UpdateIndicator variant="pip" />);
+    await userEvent.click(screen.getByTestId('update-indicator'));
+    expect(installUpdate).not.toHaveBeenCalled();
+    await userEvent.click(screen.getByRole('button', { name: 'Update and restart' }));
+    expect(installUpdate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/features/updater/components/UpdateIndicator/index.tsx
+++ b/apps/desktop/src/features/updater/components/UpdateIndicator/index.tsx
@@ -40,7 +40,11 @@ export const UpdateIndicator = ({ variant }: Props) => {
       onClick={() => setConfirmOpen(true)}
       disabled={downloading}
       title={title}
-      className={cn('pointer-events-auto relative', downloading && 'animate-border-pulse')}
+      className={cn(
+        'pointer-events-auto relative',
+        downloading ? 'spin-border spin-border-primary' : 'attention-ring',
+      )}
+      testId="update-indicator"
     />
   );
 

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -500,6 +500,30 @@ dialog[open]::backdrop {
   animation: cost-chip-pulse 1100ms cubic-bezier(0.2, 0, 0, 1);
 }
 
+/* Attention halo for a chip that is waiting on the user, not working: the ring
+   breathes outward and settles, so the eye is drawn to it without the element
+   claiming to be running. Rings, not borders: a Chip carries ring-1, so a
+   border-color animation would have nothing to animate. */
+@keyframes attention-ring {
+  0%,
+  100% {
+    box-shadow:
+      0 0 0 0 oklch(from var(--color-primary) l c h / 0.5),
+      0 0 0 0 oklch(from var(--color-primary) l c h / 0);
+  }
+  50% {
+    box-shadow:
+      0 0 0 3px oklch(from var(--color-primary) l c h / 0.28),
+      0 0 12px 2px oklch(from var(--color-primary) l c h / 0.4);
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .attention-ring {
+    animation: attention-ring 2.4s ease-in-out infinite;
+  }
+}
+
 @keyframes text-shimmer {
   to {
     background-position: -200% center;


### PR DESCRIPTION
## What was wrong

`UpdateIndicator` applied `animate-border-pulse` only when `status === 'downloading'`. Two problems in one line:

- the state that needs the user (`available`) was the silent one, and the state that needs nothing (`downloading`, already under way) was the animated one
- `animate-border-pulse` animates `border-color`, and the chip is a `Chip`, which draws a `ring-1` and no border, so even the download state animated nothing at all

## What it is now

- **available**: `attention-ring`, a new halo that breathes outward from the chip's ring and settles. Rings, not borders, because that is what a Chip actually draws. Defined only under `prefers-reduced-motion: no-preference`, on top of the global reduced-motion reset.
- **downloading**: `spin-border spin-border-primary`, the moving border this codebase reserves for running work (`DESIGN.md` line 294: "Loading is a skeleton; running is a moving border"), matching `OrchestratorPanel` and `ProviderConnect`.

The two states are distinguishable by motion as well as by label, and the chip stays disabled while downloading.

## Guard

First test file for this component: silent when idle, attention halo and enabled when available, moving border and disabled when downloading, and install fires only after the dialog is accepted.

Mutation-checked: restoring the old single `animate-border-pulse` line fails the two state tests.

## Verification

- `vitest` updater + launcher + app shell: 54 passed
- `tsc --noEmit`: clean

happy-dom does not run CSS animations or media queries, so the suite proves which class each state carries, not what the animation looks like. The keyframes follow the shape of the existing `cost-chip-pulse` halo, which is the only precedent in the repo for a glow on a chip.

Performance: the animation exists only while an update is pending, on one element, and is a compositor-friendly `box-shadow` pulse. No new subscription, no new render path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)