### PR TITLE
fix(desktop): finishing an agent is one click from its card

### DIFF
--- a/apps/desktop/src/features/session/components/ResolverAgentsLane/ResolverCard.test.tsx
+++ b/apps/desktop/src/features/session/components/ResolverAgentsLane/ResolverCard.test.tsx
@@ -5,6 +5,12 @@ import { cleanup, fireEvent, render, screen, within } from '@testing-library/rea
 import type { Agent, AgentId, SessionId, TelemetryRecord } from '@goodboy/types';
 import type { ResolverStatus } from '../../resolver-linkage';
 
+const lifecycle = vi.hoisted(() => ({
+  setAgentDone: vi.fn(),
+  clearAgentDone: vi.fn(),
+  deleteAgent: vi.fn(),
+}));
+
 vi.mock('../../../../store', () => ({
   agentHasUnread: () => false,
   useAppStore: <T,>(selector: (state: Record<string, unknown>) => T) =>
@@ -22,6 +28,9 @@ vi.mock('../../../../store', () => ({
       forceCloseResolver: vi.fn(),
       sendTurn: vi.fn(),
       selectAgent: vi.fn(),
+      setAgentDone: lifecycle.setAgentDone,
+      clearAgentDone: lifecycle.clearAgentDone,
+      deleteAgent: lifecycle.deleteAgent,
     }),
 }));
 
@@ -259,5 +268,40 @@ describe('ResolverCard', () => {
     fireEvent.click(details);
     expect(onInspect).toHaveBeenCalledOnce();
     expect(onOpenChat).toHaveBeenCalledOnce();
+  });
+
+  it('marks the resolver done from the card', () => {
+    renderCard();
+    fireEvent.click(screen.getByRole('button', { name: 'Mark resolver done' }));
+    expect(lifecycle.setAgentDone).toHaveBeenCalledWith(SID, 'resolver-1');
+  });
+
+  it('offers reopen instead of mark done once the resolver is done', () => {
+    renderCard({ run: { ...agent, doneAt: '2026-05-28T00:02:00Z' } as Agent });
+    expect(screen.queryByRole('button', { name: 'Mark resolver done' })).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'Reopen resolver' }));
+    expect(lifecycle.clearAgentDone).toHaveBeenCalledWith(SID, 'resolver-1');
+  });
+
+  it('deletes the resolver only after the confirm step', () => {
+    renderCard();
+    fireEvent.click(screen.getByRole('button', { name: 'Delete resolver' }));
+    expect(lifecycle.deleteAgent).not.toHaveBeenCalled();
+
+    const panel = screen.getByRole('group', { name: 'Delete this resolver?' });
+    fireEvent.click(within(panel).getByRole('button', { name: 'Delete' }));
+    expect(lifecycle.deleteAgent).toHaveBeenCalledWith(SID, 'resolver-1');
+  });
+
+  it('keeps the lifecycle actions in their own slot, away from navigation', () => {
+    renderCard();
+    const lifecycleSlot = screen.getByRole('group', { name: 'Agent lifecycle actions' });
+    expect(lifecycleSlot.contains(screen.getByRole('button', { name: 'Delete resolver' }))).toBe(
+      true,
+    );
+    const navigationSlot = screen.getByRole('group', { name: 'Agent navigation actions' });
+    expect(navigationSlot.contains(screen.getByRole('button', { name: 'Delete resolver' }))).toBe(
+      false,
+    );
   });
 });

--- a/apps/desktop/src/features/session/components/ResolverAgentsLane/ResolverCard.tsx
+++ b/apps/desktop/src/features/session/components/ResolverAgentsLane/ResolverCard.tsx
@@ -1,5 +1,14 @@
-import { FileDiff, GitCommitHorizontal, MessageSquareReply, PanelRight } from 'lucide-react';
-import { Chip } from '@goodboy/ui';
+import { useState } from 'react';
+import {
+  CircleCheck,
+  FileDiff,
+  GitCommitHorizontal,
+  MessageSquareReply,
+  PanelRight,
+  RotateCcw,
+  Trash2,
+} from 'lucide-react';
+import { Chip, InlineConfirm } from '@goodboy/ui';
 import type { Agent, DiffComment, PrComment, TelemetryRecord } from '@goodboy/types';
 import { agentHasUnread, useAppStore } from '../../../../store';
 import type { ProviderContextUsage } from '../../../workspace/components/WorkspacesSidebar/parts/ContextWindowBar';
@@ -78,6 +87,11 @@ export const ResolverCard = ({
   const plannedModel = useAppStore(
     (state) => state.agentModelOverride?.[agent.id] ?? agent.modelOverride ?? null,
   );
+  const setAgentDone = useAppStore((state) => state.setAgentDone);
+  const clearAgentDone = useAppStore((state) => state.clearAgentDone);
+  const deleteAgent = useAppStore((state) => state.deleteAgent);
+  const [isConfirmingDelete, setIsConfirmingDelete] = useState(false);
+  const canMarkDone = agent.status !== 'running' && agent.doneAt == null;
   const origin = resolverOrigin({ agent, hasDiffComment: diffComment !== null });
   const rowTitle = [
     agent.name,
@@ -149,6 +163,55 @@ export const ResolverCard = ({
           density="lane"
           plannedModel={plannedModel}
         />
+      }
+      lifecycleActions={
+        <>
+          <span className="flex size-6 shrink-0 items-center justify-center">
+            {canMarkDone && (
+              <AgentCardAction
+                icon={CircleCheck}
+                label="Mark resolver done"
+                tone="success"
+                reveal
+                onClick={() => void setAgentDone(agent.sessionId, agent.id)}
+              />
+            )}
+            {agent.doneAt != null && (
+              <AgentCardAction
+                icon={RotateCcw}
+                label="Reopen resolver"
+                reveal
+                onClick={() => void clearAgentDone(agent.sessionId, agent.id)}
+              />
+            )}
+          </span>
+          <span className="flex size-6 shrink-0 items-center justify-center">
+            <AgentCardAction
+              icon={Trash2}
+              label="Delete resolver"
+              tone="danger"
+              highlighted={isConfirmingDelete}
+              reveal={!isConfirmingDelete}
+              onClick={() => setIsConfirmingDelete(true)}
+            />
+          </span>
+        </>
+      }
+      confirmation={
+        isConfirmingDelete ? (
+          <InlineConfirm
+            role="danger"
+            icon={<Trash2 size={12} aria-hidden />}
+            title="Delete this resolver?"
+            description="Removes this resolver and its transcript from the session."
+            confirmLabel="Delete"
+            onConfirm={() => {
+              setIsConfirmingDelete(false);
+              void deleteAgent(agent.sessionId, agent.id);
+            }}
+            onCancel={() => setIsConfirmingDelete(false)}
+          />
+        ) : null
       }
       footer={
         <ResolverCardAction

--- a/apps/desktop/src/features/session/components/StandaloneAgentsLane/index.tsx
+++ b/apps/desktop/src/features/session/components/StandaloneAgentsLane/index.tsx
@@ -80,6 +80,7 @@ export const StandaloneAgentsLane = ({
           isInspected={run.id === inspectedAgentId}
           onInspectAgent={onInspectAgent}
           onMarkDone={lane.onMarkDone}
+          onReopen={lane.onReopen}
           isMuted={muted}
           density={isLens ? 'lane' : 'sidebar'}
         />

--- a/apps/desktop/src/features/session/components/StandaloneAgentsLane/useStandaloneAgentsLane.ts
+++ b/apps/desktop/src/features/session/components/StandaloneAgentsLane/useStandaloneAgentsLane.ts
@@ -40,6 +40,7 @@ export const useStandaloneAgentsLane = ({ session }: Params) => {
   const renameAgent = useAppStore((state) => state.renameAgent);
   const deleteAgent = useAppStore((state) => state.deleteAgent);
   const setAgentDone = useAppStore((state) => state.setAgentDone);
+  const clearAgentDone = useAppStore((state) => state.clearAgentDone);
   const loading = useSessionLoading(sessionId);
   const metrics = useAgentMetrics({ sessionId });
 
@@ -177,6 +178,13 @@ export const useStandaloneAgentsLane = ({ session }: Params) => {
     [setAgentDone, sessionId],
   );
 
+  const onReopen = useCallback(
+    (agentId: AgentId) => {
+      void clearAgentDone(sessionId, agentId);
+    },
+    [clearAgentDone, sessionId],
+  );
+
   return {
     activeAgents,
     agentKindOverride,
@@ -192,6 +200,7 @@ export const useStandaloneAgentsLane = ({ session }: Params) => {
     metrics,
     onDeleteAgent,
     onMarkDone,
+    onReopen,
     onPickAgent,
     onRenameCommit,
     selectedAgentId,

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AdHocRow.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AdHocRow.tsx
@@ -30,6 +30,7 @@ type Props = {
   readonly isInspected?: boolean;
   readonly onInspectAgent?: (id: AgentId) => void;
   readonly onMarkDone: (id: AgentId) => void;
+  readonly onReopen?: (id: AgentId) => void;
   readonly isMuted?: boolean;
   readonly density?: AgentCardDensity;
 };
@@ -56,6 +57,7 @@ export const AdHocRow = ({
   isInspected = false,
   onInspectAgent,
   onMarkDone,
+  onReopen,
   isMuted = false,
   density = 'sidebar',
 }: Props) => {
@@ -86,6 +88,7 @@ export const AdHocRow = ({
         isInspected={isInspected}
         onInspect={onInspectAgent === undefined ? undefined : () => onInspectAgent(run.id)}
         onMarkDone={() => onMarkDone(run.id)}
+        {...(onReopen !== undefined && { onReopen: () => onReopen(run.id) })}
         isMuted={isMuted}
         density={density}
       />

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentRow.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentRow.test.tsx
@@ -236,12 +236,23 @@ describe('AgentRow', () => {
     expect(remove).toHaveBeenCalledOnce();
   });
 
-  it('drops mark done and delete from the lane density card, the inspector footer owns them there', () => {
+  it('keeps mark done and delete on the lane density card too', () => {
     renderRow(false, {}, 'lane');
 
-    expect(screen.queryByRole('button', { name: 'Mark agent done' })).toBeNull();
-    expect(screen.queryByRole('button', { name: 'Delete agent' })).toBeNull();
+    expect(screen.getByRole('button', { name: 'Mark agent done' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Delete agent' })).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Toggle agent details' })).toBeTruthy();
+  });
+
+  it('keeps every action in the same order whether or not the card is hovered', () => {
+    renderRow(false, {}, 'lane');
+    const labelsOf = () =>
+      Array.from(document.querySelectorAll('button')).map((button) =>
+        button.getAttribute('aria-label'),
+      );
+    const atRest = labelsOf();
+    fireEvent.mouseEnter(screen.getByRole('button', { name: 'Toggle agent details' }));
+    expect(labelsOf()).toEqual(atRest);
   });
 
   it('keeps mark done and delete on the sidebar density card', () => {

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentRow.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentRow.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { CircleCheck, PanelRight, Trash2 } from 'lucide-react';
+import { CircleCheck, PanelRight, RotateCcw, Trash2 } from 'lucide-react';
 import { InlineConfirm } from '@goodboy/ui';
 import { contextTokensForUsage } from '@goodboy/core';
 import type { Agent, TelemetryRecord } from '@goodboy/types';
@@ -42,6 +42,7 @@ type Props = {
   readonly isMuted?: boolean;
   readonly onInspect?: () => void;
   readonly onMarkDone?: () => void;
+  readonly onReopen?: () => void;
 };
 
 export const AgentRow = ({
@@ -65,6 +66,7 @@ export const AgentRow = ({
   isMuted = false,
   onInspect,
   onMarkDone,
+  onReopen,
 }: Props) => {
   const [isConfirmingDelete, setIsConfirmingDelete] = useState(false);
 
@@ -89,6 +91,7 @@ export const AgentRow = ({
   ].filter((part): part is string => part !== null);
   const isMarkDoneAvailable =
     onMarkDone !== undefined && run.status !== 'running' && run.doneAt == null;
+  const isReopenAvailable = onReopen !== undefined && run.doneAt != null;
   const hasUnread = agentHasUnread(run, isSelected && isTaskActive);
   const hoverMarkViewed = useHoverMarkViewed({
     sessionId: run.sessionId,
@@ -147,31 +150,37 @@ export const AgentRow = ({
         )
       }
       lifecycleActions={
-        density === 'sidebar' ? (
-          <>
-            <span className="flex size-6 shrink-0 items-center justify-center">
-              {isMarkDoneAvailable && (
-                <AgentCardAction
-                  icon={CircleCheck}
-                  label="Mark agent done"
-                  tone="success"
-                  reveal
-                  onClick={() => onMarkDone?.()}
-                />
-              )}
-            </span>
-            <span className="flex size-6 shrink-0 items-center justify-center">
+        <>
+          <span className="flex size-6 shrink-0 items-center justify-center">
+            {isMarkDoneAvailable && (
               <AgentCardAction
-                icon={Trash2}
-                label="Delete agent"
-                tone="danger"
-                highlighted={isConfirmingDelete}
-                reveal={!isConfirmingDelete}
-                onClick={() => setIsConfirmingDelete(true)}
+                icon={CircleCheck}
+                label="Mark agent done"
+                tone="success"
+                reveal
+                onClick={() => onMarkDone?.()}
               />
-            </span>
-          </>
-        ) : undefined
+            )}
+            {isReopenAvailable && (
+              <AgentCardAction
+                icon={RotateCcw}
+                label="Reopen agent"
+                reveal
+                onClick={() => onReopen?.()}
+              />
+            )}
+          </span>
+          <span className="flex size-6 shrink-0 items-center justify-center">
+            <AgentCardAction
+              icon={Trash2}
+              label="Delete agent"
+              tone="danger"
+              highlighted={isConfirmingDelete}
+              reveal={!isConfirmingDelete}
+              onClick={() => setIsConfirmingDelete(true)}
+            />
+          </span>
+        </>
       }
       status={
         <AgentKindChip


### PR DESCRIPTION
## What was wrong

`4be8aa0f` (PR #1174) moved lifecycle actions off the agent card into the inspector footer, gating `lifecycleActions` behind `density === 'sidebar'`. The Agents lens renders at `lane` density, so in the lens the most frequent act on a finished agent, closing it, cost an extra round trip through the right panel. The resolver card never had those actions in the first place, so the same act had two different gestures depending on the surface.

## What it is now

Both lens cards carry mark done, reopen (when the agent is already done) and delete in the bottom-right lifecycle slot, per `DESIGN.md` line 307. Delete keeps its two-step `InlineConfirm`. The inspector footer is untouched and keeps all of its actions: the two surfaces agree instead of competing.

Reopen is new on the card, so `clearAgentDone` is plumbed through the lane hook the way `setAgentDone` already was.

## The moving-affordance trap

`a2f86754` fixed a defect where hovering a card revealed icons to the right of an existing button and pushed the thing you were aiming at sideways. The slots here reserve a fixed `size-6` box per action whether or not it is visible, so nothing shifts. A test asserts the full button order is identical before and after `mouseEnter`, on order rather than on pixels, because happy-dom cannot measure position.

## Tests

- `AgentRow.test.tsx`: the test that asserted the lane card has no mark-done/delete is rewritten to assert the new rule, with the sidebar test kept as is. New: the hover-order test.
- `ResolverCard.test.tsx`: mark done, reopen replacing mark done once done, delete only after confirm, and lifecycle actions living in the lifecycle slot rather than the navigation one. The store mock gained the three lifecycle spies instead of production code guarding against a partial fixture.
- `AgentInspector/resolver.test.tsx` still passes unchanged: the footer and the header overflow keep their contract.

## Verification

- `vitest` session + workspace + store: 2166 passed, 204 files
- `tsc --noEmit`: clean

Performance: no new store subscription per card beyond the three action selectors already used by the sidebar variant, and no new render path. Layout claims are not provable under happy-dom, so this PR asserts order and slot membership only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)