### PR TITLE
fix(desktop): the archive opens where the list ends

### DIFF
--- a/apps/desktop/src/features/plans/components/PlanStudio/PlanListPanel.tsx
+++ b/apps/desktop/src/features/plans/components/PlanStudio/PlanListPanel.tsx
@@ -1,10 +1,12 @@
-import { X } from 'lucide-react';
+import { useState } from 'react';
+import { CircleCheck, X } from 'lucide-react';
 import { Divider, ResizeHandle, ScrollFade, SelectableRow, cn } from '@goodboy/ui';
 import type { PlanId, PlanWithCount } from '@goodboy/types';
 import { useColumnWidth } from '../../../../shared/hooks/useColumnWidth';
 import { STORAGE_KEYS } from '../../../../shared/lib/storage-keys';
 import { fmtTimestamp } from './fmtTimestamp';
 import { planStatusBadge } from './planStatusBadge';
+import { FiledItemsToggle } from '../../../../shared/components/FiledItemsToggle';
 
 type Props = {
   readonly plans: ReadonlyArray<PlanWithCount>;
@@ -15,6 +17,10 @@ type Props = {
 
 export const PlanListPanel = ({ plans, selectedId, onSelect, onClose }: Props) => {
   const [width, setWidth] = useColumnWidth(STORAGE_KEYS.planListWidth, 320);
+  const [showFiled, setShowFiled] = useState(false);
+  const active = plans.filter((plan) => plan.status === 'active');
+  const filed = plans.filter((plan) => plan.status !== 'active');
+  const visible = showFiled ? [...active, ...filed] : active;
 
   return (
     <div className="flex min-h-0 shrink-0">
@@ -42,7 +48,7 @@ export const PlanListPanel = ({ plans, selectedId, onSelect, onClose }: Props) =
         <Divider />
         <ScrollFade className="min-h-0 flex-1">
           <ul className="flex w-full flex-col gap-1 px-3 py-3">
-            {plans.map((plan, idx) => {
+            {visible.map((plan, idx) => {
               const badge = planStatusBadge({ status: plan.status });
               return (
                 <li key={plan.id}>
@@ -77,6 +83,16 @@ export const PlanListPanel = ({ plans, selectedId, onSelect, onClose }: Props) =
               );
             })}
           </ul>
+          <div className="px-3 pb-3">
+            <FiledItemsToggle
+              noun="consumed"
+              items="plans"
+              count={filed.length}
+              isShown={showFiled}
+              icon={CircleCheck}
+              onChange={setShowFiled}
+            />
+          </div>
         </ScrollFade>
       </div>
     </div>

--- a/apps/desktop/src/features/plans/components/PlanStudio/index.test.tsx
+++ b/apps/desktop/src/features/plans/components/PlanStudio/index.test.tsx
@@ -193,9 +193,12 @@ describe('PlanStudio subpage', () => {
     expect(screen.getByText('beta body')).toBeDefined();
 
     fireEvent.click(screen.getByRole('button', { name: 'Other plans (1)' }));
+    expect(container.querySelectorAll('li')).toHaveLength(1);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show consumed (1)' }));
     expect(container.querySelectorAll('li')).toHaveLength(2);
 
-    fireEvent.click(screen.getByRole('button', { name: /plan 1 consumed Alpha plan/i }));
+    fireEvent.click(screen.getByRole('button', { name: /plan 2 consumed Alpha plan/i }));
     expect(screen.getByText('alpha body')).toBeDefined();
     expect(container.querySelectorAll('li')).toHaveLength(0);
   });

--- a/apps/desktop/src/features/session/components/ResolverAgentsLane/index.tsx
+++ b/apps/desktop/src/features/session/components/ResolverAgentsLane/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, type ReactNode } from 'react';
 import type { AgentId, Session } from '@goodboy/types';
 import { EmptyState } from '@goodboy/ui';
 import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../shared/components/conceptIcons';
@@ -20,6 +20,7 @@ type Props = {
   readonly onInspectResolver: (agentId: AgentId) => void;
   readonly showCompleted?: boolean;
   readonly onCompletedCountChange?: (completedCount: number) => void;
+  readonly filedToggle?: ReactNode;
 };
 
 export const ResolverAgentsLane = ({
@@ -28,6 +29,7 @@ export const ResolverAgentsLane = ({
   onInspectResolver,
   showCompleted = false,
   onCompletedCountChange,
+  filedToggle,
 }: Props) => {
   const lane = useResolverAgentsLane({ session });
   const hasNoResolvers = lane.totalCount === 0;
@@ -67,7 +69,7 @@ export const ResolverAgentsLane = ({
         ) : null
       }
     >
-      {hasVisibleEntries ? (
+      {hasVisibleEntries || filedToggle != null ? (
         <div className="flex flex-col gap-5">
           {hasActiveEntries ? (
             <ResolverRows
@@ -91,6 +93,7 @@ export const ResolverAgentsLane = ({
               onOpenDiff={lane.onOpenDiff}
             />
           ) : null}
+          {filedToggle}
           {showCompleted && lane.completedEntries.length > 0 ? (
             <ResolverRows
               entries={lane.completedEntries}

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/AgentsPane.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/AgentsPane.test.tsx
@@ -34,11 +34,13 @@ vi.mock('../../StandaloneAgentsLane', () => ({
     inspectedAgentId,
     showCompleted,
     onCompletedCountChange,
+    filedToggle,
   }: {
     readonly variant?: string;
     readonly inspectedAgentId?: string | null;
     readonly showCompleted?: boolean;
     readonly onCompletedCountChange?: (completedCount: number) => void;
+    readonly filedToggle?: React.ReactNode;
   }) => (
     <>
       <div
@@ -46,7 +48,9 @@ vi.mock('../../StandaloneAgentsLane', () => ({
         data-variant={variant}
         data-inspected={String(inspectedAgentId)}
         data-show-completed={String(showCompleted)}
-      />
+      >
+        {filedToggle}
+      </div>
       <button type="button" onClick={() => onCompletedCountChange?.(2)}>
         Report completed agents
       </button>
@@ -108,7 +112,7 @@ describe('AgentsPane', () => {
     expect(lane.getAttribute('data-inspected')).toBe('agent-7');
   });
 
-  it('places the completed toggle before create and forwards its state', () => {
+  it('places the completed toggle after the list, not in the header, and forwards its state', () => {
     const onShowCompletedChange = vi.fn();
     render(
       <AgentsPane
@@ -122,9 +126,11 @@ describe('AgentsPane', () => {
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'Report completed agents' }));
-    const toggle = screen.getByRole('button', { name: 'Completed (2)' });
+    const toggle = screen.getByRole('button', { name: 'Show completed (2)' });
     const create = screen.getByTestId('header-spawn');
-    expect(toggle.compareDocumentPosition(create) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    const lane = screen.getByTestId('agents-lane');
+    expect(create.compareDocumentPosition(toggle) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(lane.contains(toggle)).toBe(true);
     fireEvent.click(toggle);
     expect(onShowCompletedChange).toHaveBeenCalledWith(true);
     expect(screen.getByTestId('agents-lane').getAttribute('data-show-completed')).toBe('false');

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/AgentsPane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/AgentsPane.tsx
@@ -1,12 +1,12 @@
 import { useState } from 'react';
 import { CircleCheck } from 'lucide-react';
-import { CountToggle } from '@goodboy/ui';
 import type { AgentId, Session, SessionId } from '@goodboy/types';
 import { AgentInspector } from '../../AgentInspector';
 import { CreateAgentPopover } from '../../CreateAgentPopover';
 import { StandaloneAgentsLane } from '../../StandaloneAgentsLane';
 import { InspectorSplit } from './InspectorSplit';
 import { PaneShell } from '../../../../../shared/components/PaneShell';
+import { FiledItemsToggle } from '../../../../../shared/components/FiledItemsToggle';
 
 type Props = {
   readonly session: Session;
@@ -45,19 +45,7 @@ export const AgentsPane = ({
         title="Agents"
         description="Agents you spawn by hand to work this session."
         meta={meta}
-        actions={
-          <>
-            <CountToggle
-              label="Completed"
-              count={completedCount}
-              isShown={showCompleted}
-              icon={CircleCheck}
-              itemsLabel="agents"
-              onChange={onShowCompletedChange}
-            />
-            <CreateAgentPopover sessionId={sessionId} variant="compact" />
-          </>
-        }
+        actions={<CreateAgentPopover sessionId={sessionId} variant="compact" />}
       >
         <StandaloneAgentsLane
           session={session}
@@ -66,6 +54,16 @@ export const AgentsPane = ({
           onInspectAgent={(agentId) => onInspectAgent(agentId)}
           showCompleted={showCompleted}
           onCompletedCountChange={setCompletedCount}
+          filedToggle={
+            <FiledItemsToggle
+              noun="completed"
+              items="agents"
+              count={completedCount}
+              isShown={showCompleted}
+              icon={CircleCheck}
+              onChange={onShowCompletedChange}
+            />
+          }
         />
       </PaneShell>
     </InspectorSplit>

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/QuestionsPane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/QuestionsPane.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Bot, Check } from 'lucide-react';
-import { CountToggle } from '@goodboy/ui';
 import { LensEmptyState } from '../../../../../shared/components/LensEmptyState';
 import type {
   Agent,
@@ -32,6 +31,7 @@ import {
 } from '../../../../context/components/QuestionsTab/useOpenQuestions';
 import { selectOpenQuestions } from '../../SessionOverviewPane/lib';
 import { PaneShell } from '../../../../../shared/components/PaneShell';
+import { FiledItemsToggle } from '../../../../../shared/components/FiledItemsToggle';
 import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../../shared/components/conceptIcons';
 
 type AnswerPair = { id: OpenQuestionId; text: string; answer: string };
@@ -328,23 +328,8 @@ export const QuestionsPane = ({ session }: QuestionsPaneProps) => {
 
   if (open.length === 0 && pendingUndoQuestion === null) {
     return (
-      <PaneShell
-        title="Questions"
-        description="Decisions agents need from you to keep going."
-        actions={
-          <CountToggle
-            label="Answered"
-            count={answered.length}
-            isShown={showAnswered}
-            icon={Check}
-            itemsLabel="questions"
-            onChange={setShowAnswered}
-          />
-        }
-      >
-        {showAnswered ? (
-          <AnsweredHistory clusters={answeredClusters} sessionId={sessionId} />
-        ) : (
+      <PaneShell title="Questions" description="Decisions agents need from you to keep going.">
+        {showAnswered ? null : (
           <LensEmptyState
             tone={CONCEPT_TONE.questions}
             icon={CONCEPT_ICONS.questions}
@@ -352,6 +337,17 @@ export const QuestionsPane = ({ session }: QuestionsPaneProps) => {
             description={`Every question on this session is answered. Reveal the ${answered.length} answered ${answered.length === 1 ? 'one' : 'ones'} to reread them.`}
           />
         )}
+        <FiledItemsToggle
+          noun="answered"
+          items="questions"
+          count={answered.length}
+          isShown={showAnswered}
+          icon={Check}
+          onChange={setShowAnswered}
+        />
+        {showAnswered ? (
+          <AnsweredHistory clusters={answeredClusters} sessionId={sessionId} />
+        ) : null}
       </PaneShell>
     );
   }
@@ -363,16 +359,6 @@ export const QuestionsPane = ({ session }: QuestionsPaneProps) => {
         open.length > 0
           ? `${open.length} open ${open.length === 1 ? 'question' : 'questions'} waiting on you.`
           : 'Decisions agents need from you to keep going.'
-      }
-      actions={
-        <CountToggle
-          label="Answered"
-          count={answered.length}
-          isShown={showAnswered}
-          icon={Check}
-          itemsLabel="questions"
-          onChange={setShowAnswered}
-        />
       }
     >
       <div className="flex flex-col gap-4">
@@ -394,6 +380,14 @@ export const QuestionsPane = ({ session }: QuestionsPaneProps) => {
             onSubmit={(pairs, ownerAgentId) => void handleSubmit(pairs, ownerAgentId)}
           />
         ))}
+        <FiledItemsToggle
+          noun="answered"
+          items="questions"
+          count={answered.length}
+          isShown={showAnswered}
+          icon={Check}
+          onChange={setShowAnswered}
+        />
         {showAnswered ? (
           <AnsweredHistory clusters={answeredClusters} sessionId={sessionId} />
         ) : null}

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/ResolvePane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/ResolvePane.tsx
@@ -1,11 +1,11 @@
 import { useState } from 'react';
 import { CircleCheck } from 'lucide-react';
-import { CountToggle } from '@goodboy/ui';
 import type { AgentId, Session, SessionId } from '@goodboy/types';
 import { ResolverAgentsLane } from '../../ResolverAgentsLane';
 import { AgentInspector } from '../../AgentInspector';
 import { InspectorSplit } from './InspectorSplit';
 import { PaneShell } from '../../../../../shared/components/PaneShell';
+import { FiledItemsToggle } from '../../../../../shared/components/FiledItemsToggle';
 import { WorkSurfaceBackButton } from '../../../../../shared/components/WorkSurfaceBackButton';
 
 type Props = {
@@ -45,19 +45,7 @@ export const ResolvePane = ({
         title="Resolve"
         description="Resolver agents spawned from pull request comments and diff selections."
         meta={meta}
-        actions={
-          <>
-            <WorkSurfaceBackButton sessionId={sessionId} />
-            <CountToggle
-              label="Completed"
-              count={completedCount}
-              isShown={showCompleted}
-              icon={CircleCheck}
-              itemsLabel="agents"
-              onChange={onShowCompletedChange}
-            />
-          </>
-        }
+        actions={<WorkSurfaceBackButton sessionId={sessionId} />}
       >
         <ResolverAgentsLane
           session={session}
@@ -65,6 +53,16 @@ export const ResolvePane = ({
           onInspectResolver={(agentId) => onInspectResolver(agentId)}
           showCompleted={showCompleted}
           onCompletedCountChange={setCompletedCount}
+          filedToggle={
+            <FiledItemsToggle
+              noun="completed"
+              items="resolvers"
+              count={completedCount}
+              isShown={showCompleted}
+              icon={CircleCheck}
+              onChange={onShowCompletedChange}
+            />
+          }
         />
       </PaneShell>
     </InspectorSplit>

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowsPane.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowsPane.test.tsx
@@ -237,7 +237,7 @@ describe('WorkflowsPane', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Completed (1)' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Show completed (1)' }));
 
     expect(screen.getByText('2 of 2 steps run')).toBeDefined();
     expect(screen.getByText('3m')).toBeDefined();
@@ -272,7 +272,7 @@ describe('WorkflowsPane', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Completed (1)' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Show completed (1)' }));
 
     expect(screen.getByText('1 step run')).toBeDefined();
     expect(screen.queryByText('1 of 2 steps run')).toBeNull();
@@ -319,7 +319,7 @@ describe('WorkflowsPane', () => {
     expect(screen.queryByText('First workflow')).toBeNull();
     expect(screen.getAllByRole('button', { name: 'Attach another workflow' })).toHaveLength(1);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Completed (2)' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Show completed (2)' }));
 
     expect(screen.getByTestId('workflow-empty').textContent).toContain('Nothing running');
     expect(screen.getByText('First workflow')).toBeDefined();
@@ -339,7 +339,7 @@ describe('WorkflowsPane', () => {
     expect(screen.queryByText('First workflow')).toBeNull();
     expect(screen.getByText('Second workflow')).toBeDefined();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Discarded (1)' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Show completed (1)' }));
 
     expect(screen.getByText('First workflow')).toBeDefined();
   });
@@ -356,7 +356,7 @@ describe('WorkflowsPane', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Completed (1)' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Show completed (1)' }));
     rerender(
       <WorkflowsPane
         session={buildSession({
@@ -380,7 +380,7 @@ describe('WorkflowsPane', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Discarded (1)' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Show completed (1)' }));
     fireEvent.click(screen.getByRole('button', { name: 'Restore' }));
 
     expect(store.restoreWorkflow).toHaveBeenCalledWith(SESSION_ID, 'run-1');
@@ -400,7 +400,7 @@ describe('WorkflowsPane', () => {
 
     expect(screen.queryByText('First workflow')).toBeNull();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Completed (1)' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Show completed (1)' }));
 
     expect(screen.getByText('First workflow')).toBeDefined();
   });

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowsPane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowsPane.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
-import { Ban, Check } from 'lucide-react';
-import { CountToggle } from '@goodboy/ui';
+import { Check } from 'lucide-react';
 import type { Agent, Session, SessionId, Workflow, WorkflowRun } from '@goodboy/types';
 import { EMPTY_ARRAY, useAppStore } from '../../../../../store';
 import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../../shared/components/conceptIcons';
@@ -16,6 +15,7 @@ import { useAgentMetrics } from '../../../hooks/useAgentMetrics';
 import { PaneShell } from '../../../../../shared/components/PaneShell';
 import { FocusedPane } from '../../../../../shared/components/PaneShell/FocusedPane';
 import { WorkSurfaceBackButton } from '../../../../../shared/components/WorkSurfaceBackButton';
+import { FiledItemsToggle } from '../../../../../shared/components/FiledItemsToggle';
 
 type Props = {
   readonly session: Session;
@@ -33,8 +33,7 @@ export const WorkflowsPane = ({ session }: Props) => {
   );
   const setFocusedWorkflowRun = useAppStore((state) => state.setFocusedWorkflowRun);
   const restoreWorkflow = useAppStore((state) => state.restoreWorkflow);
-  const [showCompleted, setShowCompleted] = useState(false);
-  const [showDiscarded, setShowDiscarded] = useState(false);
+  const [showFiled, setShowFiled] = useState(false);
   const { agentsByRunId, discarded, completed, active } = splitWorkflowRuns({
     attachedRuns,
     agents: phaseRuns,
@@ -98,27 +97,9 @@ export const WorkflowsPane = ({ session }: Props) => {
       description="Sequences of agents this session runs toward its goal."
       meta={hasRuns ? attachedRuns.length : undefined}
       actions={
-        <>
-          <CountToggle
-            label="Completed"
-            count={completed.length}
-            isShown={showCompleted}
-            icon={Check}
-            itemsLabel="workflows"
-            onChange={setShowCompleted}
-          />
-          <CountToggle
-            label="Discarded"
-            count={discarded.length}
-            isShown={showDiscarded}
-            icon={Ban}
-            itemsLabel="workflows"
-            onChange={setShowDiscarded}
-          />
-          {shouldShowHeaderAttach ? (
-            <WorkflowAttachButton sessionId={sessionId} placement="header" />
-          ) : null}
-        </>
+        shouldShowHeaderAttach ? (
+          <WorkflowAttachButton sessionId={sessionId} placement="header" />
+        ) : null
       }
     >
       {!hasRuns ? <WorkflowStartButton sessionId={sessionId} /> : null}
@@ -136,10 +117,18 @@ export const WorkflowsPane = ({ session }: Props) => {
         />
       ) : null}
       {active.length > 0 ? <ul className="flex flex-col gap-2">{active.map(renderCard)}</ul> : null}
-      {showCompleted && completed.length > 0 ? (
+      <FiledItemsToggle
+        noun="completed"
+        items="workflows"
+        count={completed.length + discarded.length}
+        isShown={showFiled}
+        icon={Check}
+        onChange={setShowFiled}
+      />
+      {showFiled && completed.length > 0 ? (
         <ul className="flex flex-col gap-2">{completed.map(renderCard)}</ul>
       ) : null}
-      {showDiscarded && discarded.length > 0 ? (
+      {showFiled && discarded.length > 0 ? (
         <ul className="flex flex-col gap-2">{discarded.map(renderCard)}</ul>
       ) : null}
     </PaneShell>

--- a/apps/desktop/src/features/session/components/StandaloneAgentsLane/index.tsx
+++ b/apps/desktop/src/features/session/components/StandaloneAgentsLane/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, type ReactNode } from 'react';
 import type { Agent, AgentId, Session, SessionId } from '@goodboy/types';
 import { AdHocRow } from '../../../workspace/components/WorkspacesSidebar/parts/AdHocRow';
 import { AgentLane } from '../AgentLane';
@@ -23,6 +23,7 @@ type Props = {
   readonly onInspectAgent?: (agentId: AgentId) => void;
   readonly showCompleted?: boolean;
   readonly onCompletedCountChange?: (completedCount: number) => void;
+  readonly filedToggle?: ReactNode;
 };
 
 export const StandaloneAgentsLane = ({
@@ -33,6 +34,7 @@ export const StandaloneAgentsLane = ({
   onInspectAgent,
   showCompleted = false,
   onCompletedCountChange,
+  filedToggle,
 }: Props) => {
   const sessionId = session.id as SessionId;
   const lane = useStandaloneAgentsLane({ session });
@@ -121,9 +123,10 @@ export const StandaloneAgentsLane = ({
       }
       footer={error}
     >
-      {agents.length > 0 ? (
+      {agents.length > 0 || filedToggle != null ? (
         <div className="flex flex-col gap-5">
           {lane.activeAgents.length > 0 ? renderList(lane.activeAgents, false) : null}
+          {filedToggle}
           {showCompleted && lane.completedAgents.length > 0
             ? renderList(lane.completedAgents, true)
             : null}

--- a/apps/desktop/src/shared/components/FiledItemsToggle/index.tsx
+++ b/apps/desktop/src/shared/components/FiledItemsToggle/index.tsx
@@ -1,0 +1,40 @@
+import type { LucideIcon } from 'lucide-react';
+import { cn } from '@goodboy/ui';
+
+type Props = {
+  readonly noun: string;
+  readonly items: string;
+  readonly count: number;
+  readonly isShown: boolean;
+  readonly icon: LucideIcon;
+  readonly onChange: (isShown: boolean) => void;
+};
+
+export const FiledItemsToggle = ({ noun, items, count, isShown, icon, onChange }: Props) => {
+  if (count === 0) {
+    return null;
+  }
+
+  const Icon = icon;
+  const action = isShown ? 'Hide' : 'Show';
+
+  return (
+    <div className="flex justify-center pt-1">
+      <button
+        type="button"
+        onClick={() => onChange(!isShown)}
+        aria-pressed={isShown}
+        title={`${action.toLowerCase()} the ${count} ${noun} ${items}`}
+        className={cn(
+          'flex h-7 items-center gap-1.5 rounded-md px-2 text-2xs font-medium transition-colors',
+          isShown
+            ? 'bg-primary/10 text-primary'
+            : 'text-muted-foreground hover:bg-foreground/5 hover:text-foreground',
+        )}
+      >
+        <Icon size={10} aria-hidden />
+        {action} {noun} ({count})
+      </button>
+    </div>
+  );
+};


### PR DESCRIPTION
## What was wrong

Five lists, four different answers, and all of them in the wrong place.

- Agents, Resolve, Workflows and Questions put the reveal control in the pane header's action row, next to the primary action, far from the point where the user learns the list has ended.
- Workflows had **two** controls, Completed and Discarded, so reading everything filed took two gestures.
- Plans had no control at all, even though `PlanStatus` has carried `consumed` since `m030` and the list showed consumed plans at full opacity between the live ones.

## What it is now

One shared `FiledItemsToggle`, rendered under the last live card, or under the empty state when nothing is live. Its copy says what pressing it does rather than naming a bucket: `Show completed (3)` / `Hide completed (3)`, `Show answered (2)`, `Show consumed (4)`. It renders nothing when the count is zero.

- Agents and Resolve pass it into their lane, which drops it between the live rows and the revealed ones, so the archive appears below the control that revealed it.
- Workflows: one control, counting completed plus discarded. Discarded runs are filed with completed ones instead of behind their own toggle.
- Questions: the answered history moves below the control in both the has-open and no-open branches.
- Plans: the plan list splits into live and filed, and consumed, superseded and discarded plans sit behind the control.

The pane headers keep their primary action (create agent, attach workflow) and nothing else moved into them.

## Tests

- `AgentsPane.test.tsx`: the placement test is rewritten. It asserted the toggle came before the create button in the header; it now asserts the toggle comes after it and lives inside the lane. Mutation-checked by putting the toggle back in the header: that test fails and nothing else does.
- `WorkflowsPane.test.tsx`: the seven cases that clicked `Completed (N)` or `Discarded (N)` now go through the single control.
- `PlanStudio/index.test.tsx`: opening the plan list shows one live plan, and the consumed one appears only after `Show consumed (1)`.
- The lane mock in the agents pane test was completed to render the new prop rather than working around it in production code.

## Verification

- `vitest` desktop, whole suite: 4113 passed, 472 files
- `tsc --noEmit`: clean
- `knip --include files,duplicates,unlisted`: clean

`CountToggle` in packages/ui keeps its own unit tests and stays exported; it is no longer used by these five surfaces. happy-dom cannot measure position, so the placement assertions are on DOM order and containment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)