### PR TITLE
fix(desktop): a workflow becomes a preset when you say so

### DIFF
--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowsPane.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowsPane.test.tsx
@@ -16,6 +16,7 @@ type Store = {
   lensGo: ReturnType<typeof vi.fn>;
   setFocusedWorkflowRun: ReturnType<typeof vi.fn>;
   restoreWorkflow: ReturnType<typeof vi.fn>;
+  makeWorkflowPreset: ReturnType<typeof vi.fn>;
 };
 
 type ButtonMockProps = React.ComponentProps<'button'>;
@@ -48,6 +49,7 @@ const store: Store = {
   lensGo: vi.fn(),
   setFocusedWorkflowRun: vi.fn(),
   restoreWorkflow: vi.fn(),
+  makeWorkflowPreset: vi.fn(),
 };
 
 vi.mock('../../../../../store', () => ({
@@ -90,6 +92,14 @@ vi.mock('@goodboy/ui', () => ({
   ScrollFade: ({ children }: ChildrenMockProps) => <div>{children}</div>,
   StatusDot: () => <span data-testid="status-dot" />,
   cn: (...values: ReadonlyArray<unknown>) => values.filter(Boolean).join(' '),
+  tintClasses: () => ({
+    text: '',
+    icon: '',
+    border: '',
+    ring: '',
+    bg: '',
+    hover: '',
+  }),
   formatUsd: (value: number) => `$${value.toFixed(2)}`,
   formatUsdPrecise: (value: number) => `$${value.toFixed(2)}`,
 }));
@@ -146,6 +156,7 @@ beforeEach(() => {
   store.agentRunHistory = {};
   store.focusedWorkflowRunId = {};
   store.setFocusedWorkflowRun.mockReset();
+  store.makeWorkflowPreset.mockReset();
   store.restoreWorkflow.mockReset();
 });
 
@@ -284,6 +295,33 @@ describe('WorkflowsPane', () => {
 
     expect(screen.getByTestId('workflow-detail').getAttribute('data-run-id')).toBe('run-2');
     expect(screen.queryByText('First workflow')).toBeNull();
+  });
+
+  it('offers make preset only for a workflow the user declined to save', () => {
+    store.phaseTemplates = {
+      [WORKSPACE_ID]: [
+        { ...firstWorkflow, isPreset: false } as Workflow,
+        { ...secondWorkflow, isPreset: true } as Workflow,
+      ],
+    };
+    store.focusedWorkflowRunId = { [SESSION_ID]: 'run-1' };
+    render(<WorkflowsPane session={buildSession({ runIds: ['run-1', 'run-2'] })} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Make preset' }));
+    expect(store.makeWorkflowPreset).toHaveBeenCalledWith(WORKSPACE_ID, 'workflow-1');
+  });
+
+  it('hides make preset for a workflow that already is one', () => {
+    store.phaseTemplates = {
+      [WORKSPACE_ID]: [
+        { ...firstWorkflow, isPreset: false } as Workflow,
+        { ...secondWorkflow, isPreset: true } as Workflow,
+      ],
+    };
+    store.focusedWorkflowRunId = { [SESSION_ID]: 'run-2' };
+    render(<WorkflowsPane session={buildSession({ runIds: ['run-1', 'run-2'] })} />);
+
+    expect(screen.queryByRole('button', { name: 'Make preset' })).toBeNull();
   });
 
   it('focuses a run when its card is clicked', () => {

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowsPane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowsPane.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Check } from 'lucide-react';
+import { BookmarkPlus, Check } from 'lucide-react';
 import type { Agent, Session, SessionId, Workflow, WorkflowRun } from '@goodboy/types';
 import { EMPTY_ARRAY, useAppStore } from '../../../../../store';
 import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../../shared/components/conceptIcons';
@@ -16,6 +16,7 @@ import { PaneShell } from '../../../../../shared/components/PaneShell';
 import { FocusedPane } from '../../../../../shared/components/PaneShell/FocusedPane';
 import { WorkSurfaceBackButton } from '../../../../../shared/components/WorkSurfaceBackButton';
 import { FiledItemsToggle } from '../../../../../shared/components/FiledItemsToggle';
+import { GhostActionButton } from '../../../../../shared/components/GhostActionButton';
 
 type Props = {
   readonly session: Session;
@@ -24,6 +25,7 @@ type Props = {
 export const WorkflowsPane = ({ session }: Props) => {
   const sessionId = session.id as SessionId;
   const attachedRuns = useAttachedWorkflowRuns({ session });
+  const makeWorkflowPreset = useAppStore((s) => s.makeWorkflowPreset);
   const phaseRuns = useAppStore(
     (state) => state.sessionPhaseRuns[sessionId] ?? (EMPTY_ARRAY as ReadonlyArray<Agent>),
   );
@@ -80,6 +82,16 @@ export const WorkflowsPane = ({ session }: Props) => {
         actions={
           <>
             <WorkSurfaceBackButton sessionId={sessionId} />
+            {focusedRun.workflow != null && focusedRun.workflow.isPreset === false ? (
+              <GhostActionButton
+                icon={BookmarkPlus}
+                label="Make preset"
+                title="Keep this configuration in the workspace presets"
+                onClick={() =>
+                  void makeWorkflowPreset(session.workspaceId, focusedRun.workflow!.id)
+                }
+              />
+            ) : null}
             {shouldShowHeaderAttach ? (
               <WorkflowAttachButton sessionId={sessionId} placement="header" />
             ) : null}

--- a/apps/desktop/src/features/workflows/components/WorkflowsPanel/index.test.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowsPanel/index.test.tsx
@@ -105,7 +105,7 @@ describe('WorkflowsPanel', () => {
     expect(screen.queryByText('Deleted workflow')).toBeNull();
   });
 
-  it('lists draft workflows (isPreset=false) alongside approved ones', () => {
+  it('keeps a workflow the user declined to save out of the preset rail', () => {
     state.phaseTemplates = {
       'ws-1': [
         makeWorkflow({ name: 'Approved preset' }),
@@ -114,8 +114,7 @@ describe('WorkflowsPanel', () => {
     };
     renderPanel();
     expect(screen.getByText('Approved preset')).toBeDefined();
-    // drafts now appear with a status pill rather than being hidden
-    expect(screen.getByText('Draft workflow')).toBeDefined();
+    expect(screen.queryByText('Draft workflow')).toBeNull();
   });
 
   it('shows empty state when every template is soft-deleted', () => {

--- a/apps/desktop/src/features/workflows/components/WorkflowsPanel/index.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowsPanel/index.tsx
@@ -60,7 +60,7 @@ export const WorkflowsPanel = ({ workspaceId }: Props) => {
   const [formatOpen, setFormatOpen] = useState(false);
   const [preview, setPreview] = useState<FormattedWorkflow | null>(null);
 
-  const presets = templates.filter((t) => !t.deletedAt);
+  const presets = templates.filter((t) => !t.deletedAt && t.isPreset !== false);
 
   const editingIdRef = useRef<WorkflowId | null>(null);
   const approvedRef = useRef(approved);

--- a/apps/desktop/src/store/slices/workflows/index.ts
+++ b/apps/desktop/src/store/slices/workflows/index.ts
@@ -22,6 +22,7 @@ import { restoreWorkflow } from './restoreWorkflow';
 import { retryWorkflowOrchestration } from './retryWorkflowOrchestration';
 import { reprocessGoalForWorkflow } from './reprocessGoalForWorkflow';
 import { resetWorkflows } from './resetWorkflows';
+import { makeWorkflowPreset } from './makeWorkflowPreset';
 import { savePhaseTemplate } from './savePhaseTemplate';
 import { saveStepDef } from './saveStepDef';
 import { advanceScoutTree } from './scoutTree';
@@ -36,6 +37,7 @@ export const createWorkflowsSlice = (set: SetFn, get: GetFn) => {
     savePhaseTemplate: savePhaseTemplate(set),
     deleteWorkflow: deleteWorkflow(set),
     renameWorkflow: renameWorkflow(set, get),
+    makeWorkflowPreset: makeWorkflowPreset(set, get),
     generateWorkflowTitle: generateWorkflowTitle(set, get),
     loadStepLibrary: loadStepLibrary(set),
     saveStepDef: saveStepDef(set),

--- a/apps/desktop/src/store/slices/workflows/makeWorkflowPreset.test.ts
+++ b/apps/desktop/src/store/slices/workflows/makeWorkflowPreset.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { IsoDateTime, Workflow, WorkflowId, WorkspaceId } from '@goodboy/types';
+
+const { invokeWorkflowUpsertSpy } = vi.hoisted(() => ({
+  invokeWorkflowUpsertSpy: vi.fn(),
+}));
+
+vi.mock('../../../features/workflows/workflows', () => ({
+  invokeWorkflowUpsert: invokeWorkflowUpsertSpy,
+}));
+
+import { makeWorkflowPreset } from './makeWorkflowPreset';
+
+const WORKSPACE_ID = 'workspace-1' as WorkspaceId;
+const WORKFLOW_ID = 'wf-1' as WorkflowId;
+const NOW = '2026-08-04T00:00:00.000Z' as IsoDateTime;
+
+const workflow: Workflow = {
+  id: WORKFLOW_ID,
+  workspaceId: WORKSPACE_ID,
+  name: 'Orchestrated workflow',
+  description: 'Steps are decided at runtime from the latest results.',
+  goal: 'ship the thing',
+  processText: 'do the process',
+  steps: [],
+  isPreset: false,
+  origin: 'orchestrated',
+  createdAt: NOW,
+  updatedAt: NOW,
+};
+
+type State = {
+  phaseTemplates: Record<WorkspaceId, ReadonlyArray<Workflow>>;
+};
+
+const buildHarness = (seed: Workflow = workflow) => {
+  const state: State = { phaseTemplates: { [WORKSPACE_ID]: [seed] } };
+  const set = vi.fn((updater: (s: State) => Partial<State>) => {
+    Object.assign(state, updater(state));
+  });
+  const get = (() => state) as never;
+  const promote = makeWorkflowPreset(set as never, get);
+  return { promote, state };
+};
+
+describe('makeWorkflowPreset', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('promotes a declined workflow into a preset', async () => {
+    invokeWorkflowUpsertSpy.mockResolvedValue({ ...workflow, isPreset: true });
+    const { promote, state } = buildHarness();
+
+    await promote(WORKSPACE_ID, WORKFLOW_ID);
+
+    expect(invokeWorkflowUpsertSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ id: WORKFLOW_ID, isPreset: true, origin: 'orchestrated' }),
+    );
+    expect(state.phaseTemplates[WORKSPACE_ID]?.[0]?.isPreset).toBe(true);
+  });
+
+  it('does nothing when the workflow is already a preset', async () => {
+    const { promote } = buildHarness({ ...workflow, isPreset: true });
+
+    await promote(WORKSPACE_ID, WORKFLOW_ID);
+
+    expect(invokeWorkflowUpsertSpy).not.toHaveBeenCalled();
+  });
+
+  it('rolls back when the write fails', async () => {
+    invokeWorkflowUpsertSpy.mockRejectedValue(new Error('offline'));
+    const { promote, state } = buildHarness();
+
+    await expect(promote(WORKSPACE_ID, WORKFLOW_ID)).rejects.toThrow('offline');
+    expect(state.phaseTemplates[WORKSPACE_ID]?.[0]?.isPreset).toBe(false);
+  });
+
+  it('refuses a workflow that is not in the workspace', async () => {
+    const { promote } = buildHarness();
+
+    await expect(promote(WORKSPACE_ID, 'wf-missing' as WorkflowId)).rejects.toThrow('not found');
+    expect(invokeWorkflowUpsertSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/store/slices/workflows/makeWorkflowPreset.ts
+++ b/apps/desktop/src/store/slices/workflows/makeWorkflowPreset.ts
@@ -1,0 +1,52 @@
+import type { WorkflowId, WorkspaceId } from '@goodboy/types';
+import { invokeWorkflowUpsert } from '../../../features/workflows/workflows';
+import type { GetFn, SetFn } from './types';
+
+export const makeWorkflowPreset = (set: SetFn, get: GetFn) => {
+  return async (workspaceId: WorkspaceId, workflowId: WorkflowId): Promise<void> => {
+    const prev = (get().phaseTemplates[workspaceId] ?? []).find((w) => w.id === workflowId);
+    if (!prev) {
+      throw new Error(`workflow not found: ${workflowId}`);
+    }
+    if (prev.isPreset === true) {
+      return;
+    }
+    const patch = (workflows: ReadonlyArray<typeof prev>, isPreset: boolean) =>
+      workflows.map((w) => (w.id === workflowId ? { ...w, isPreset } : w));
+    set((state) => ({
+      phaseTemplates: {
+        ...state.phaseTemplates,
+        [workspaceId]: patch(state.phaseTemplates[workspaceId] ?? [], true),
+      },
+    }));
+    try {
+      const saved = await invokeWorkflowUpsert({
+        id: prev.id,
+        workspaceId: prev.workspaceId,
+        name: prev.name,
+        description: prev.description,
+        ...(prev.goal != null && { goal: prev.goal }),
+        ...(prev.processText != null && { processText: prev.processText }),
+        steps: prev.steps,
+        isPreset: true,
+        ...(prev.origin != null && { origin: prev.origin }),
+      });
+      set((state) => ({
+        phaseTemplates: {
+          ...state.phaseTemplates,
+          [workspaceId]: (state.phaseTemplates[workspaceId] ?? []).map((w) =>
+            w.id === workflowId ? saved : w,
+          ),
+        },
+      }));
+    } catch (err) {
+      set((state) => ({
+        phaseTemplates: {
+          ...state.phaseTemplates,
+          [workspaceId]: patch(state.phaseTemplates[workspaceId] ?? [], false),
+        },
+      }));
+      throw err;
+    }
+  };
+};

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -377,6 +377,7 @@ export type AppActions = {
   savePhaseTemplate(template: WorkflowUpsertArgs): Promise<Workflow>;
   deleteWorkflow(id: WorkflowId, workspaceId: WorkspaceId): Promise<void>;
   renameWorkflow(workspaceId: WorkspaceId, workflowId: WorkflowId, name: string): Promise<void>;
+  makeWorkflowPreset(workspaceId: WorkspaceId, workflowId: WorkflowId): Promise<void>;
   generateWorkflowTitle(
     workspaceId: WorkspaceId,
     workflowId: WorkflowId,


### PR DESCRIPTION
## What was wrong

Answering **no** to "Save as preset" did not stop the workflow from appearing in Workflow studio. `onStart` always calls `savePhaseTemplate`; the answer only changes the `isPreset` value it writes. The Rust list query already filters to `is_preset = 1`, but the client re-merges the non-preset rows back into state on every load (`loadPhaseTemplates`), and the studio rail filtered on `deletedAt` only. Result: a rail titled "Presets (N)" listing rows the user had explicitly refused to keep, each wearing a "draft" pill.

## Why the row cannot simply be dropped

`useAttachedWorkflowRuns` resolves an attached run's definition out of the same `phaseTemplates` map. Deleting non-presets from state would leave in-session workflow cards without their steps. The client-side retention exists for that reason, so the fix belongs at the listing layer.

## What it is now

- The studio rail lists presets only (`!deletedAt && isPreset !== false`), so its title and its contents agree.
- New `makeWorkflowPreset(workspaceId, workflowId)` store action, shaped like `renameWorkflow`: optimistic flip, `workflow_upsert`, reconcile with what the backend returns, roll back on failure, no-op when the workflow already is a preset.
- The focused workflow detail header gains **Make preset**, shown only while `isPreset === false`, so an orchestrated run you liked can be kept without going through the builder again.

The two automatic writers that touch the same table during a run (`orchestrateNextStep` appending a step, `generateWorkflowTitle` renaming) are untouched: they preserve `isPreset` as before, and neither is a promotion.

## Tests

- `WorkflowsPanel/index.test.tsx`: the case that asserted drafts appear in the rail is inverted. Mutation-checked: restoring the old filter fails exactly that test.
- New `makeWorkflowPreset.test.ts`: promotes, no-ops when already a preset, rolls back on a failed write, refuses an unknown workflow.
- New `WorkflowsPane` cases: Make preset appears for a declined workflow and calls the action with its id, and is absent for one that is already a preset.
- The pane's `@goodboy/ui` mock gained the `tintClasses` export the real ghost button needs, instead of stubbing the button itself.

## Verification

- `vitest` desktop, whole suite: 4119 passed, 473 files
- `tsc --noEmit`: clean

No data migration: existing rows keep their value, and nothing is deleted from the user's database as part of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)