### PR TITLE
fix(desktop): keep session actions on the current view

### DIFF
--- a/apps/desktop/src/features/explore/components/ExplorePane/ExploreSpawnPopover.tsx
+++ b/apps/desktop/src/features/explore/components/ExplorePane/ExploreSpawnPopover.tsx
@@ -5,6 +5,7 @@ import type { SessionId } from '@goodboy/types';
 import { useDropdown } from '../../../../shared/hooks/useDropdown';
 import { DropdownPortal } from '../../../../shared/hooks/useDropdown/DropdownPortal';
 import { useAppStore } from '../../../../store';
+import { useToast } from '../../../../app/components/Toast';
 import { clampEffort } from '../../../chat/utils/chat-constants';
 import { AgentSpawnConfig } from '../../../session/components/AgentSpawnConfig';
 import { resolveSpawnRouting } from '../../../session/spawn-routing';
@@ -46,6 +47,8 @@ export const ExploreSpawnPopover = ({ sessionId, entry }: Props) => {
     strategy: 'fixed',
   });
   const spawnAgent = useAppStore((state) => state.spawnAgent);
+  const selectAgent = useAppStore((state) => state.selectAgent);
+  const { showToast } = useToast();
   const session = useAppStore(
     (state) => state.sessions.find((candidate) => candidate.id === sessionId) ?? null,
   );
@@ -85,15 +88,24 @@ export const ExploreSpawnPopover = ({ sessionId, entry }: Props) => {
     try {
       const kickoff = buildExploreSpawnPrompt({ ask: trimmedAsk, relPath: entry.relPath });
       const initialPrompt = appendOperatorNotes({ prompt: kickoff, hint: config.hint });
-      await spawnAgent(sessionId, {
+      const agentId = await spawnAgent(sessionId, {
         initialPrompt,
         model: config.model,
         ...(config.provider !== '' && { provider: config.provider }),
         effort: config.effort,
-        focus: 'agent',
+        focus: 'none',
       });
       close();
-      window.dispatchEvent(new CustomEvent('goodboy:reveal-chat'));
+      showToast('success', `An agent is working on ${entry.name}. You can keep working.`, {
+        title: 'Agent started',
+        action: {
+          label: 'Open the agent',
+          onClick: () => {
+            void selectAgent(sessionId, agentId);
+            window.dispatchEvent(new CustomEvent('goodboy:reveal-chat'));
+          },
+        },
+      });
     } catch (error) {
       setSpawnError(toErrorMessage({ error }));
     }

--- a/apps/desktop/src/features/explore/components/ExplorePane/index.test.tsx
+++ b/apps/desktop/src/features/explore/components/ExplorePane/index.test.tsx
@@ -5,8 +5,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { ProviderId, Session, SessionId } from '@goodboy/types';
 
+type ToastAction = { readonly label: string; readonly onClick: () => void };
+
+type ToastOptions = { readonly title?: string; readonly action?: ToastAction };
+
 type Store = {
   readonly spawnAgent: ReturnType<typeof vi.fn>;
+  readonly selectAgent: ReturnType<typeof vi.fn>;
   readonly providers: ReadonlyArray<{
     readonly id: ProviderId;
     readonly connection: string;
@@ -25,6 +30,8 @@ const h = vi.hoisted(() => ({
       args: { readonly model: string; readonly initialPrompt: string },
     ) => Promise<string>
   >(async () => 'agent-1'),
+  selectAgent: vi.fn(async () => undefined),
+  showToast: vi.fn<(kind: string, message: string, opts?: ToastOptions) => void>(),
   providers: [{ id: 'anthropic' as ProviderId, connection: 'connected' }],
   sessions: [
     {
@@ -54,10 +61,15 @@ vi.mock('../../../../store', () => ({
   useAppStore: <T,>(selector: (state: Store) => T) =>
     selector({
       spawnAgent: h.spawnAgent,
+      selectAgent: h.selectAgent,
       providers: h.providers,
       sessions: h.sessions,
       workspaceOverrides: {},
     }),
+}));
+
+vi.mock('../../../../app/components/Toast', () => ({
+  useToast: () => ({ showToast: h.showToast }),
 }));
 
 vi.mock('@goodboy/ui', async (importOriginal) => {
@@ -83,6 +95,8 @@ beforeEach(() => {
   h.exploreRead.mockReset();
   h.spawnAgent.mockReset();
   h.spawnAgent.mockResolvedValue('agent-1');
+  h.selectAgent.mockClear();
+  h.showToast.mockClear();
   h.providers = [{ id: 'anthropic' as ProviderId, connection: 'connected' }];
 });
 
@@ -265,8 +279,9 @@ describe('ExplorePane', () => {
 
     await waitFor(() => expect(h.spawnAgent).toHaveBeenCalled());
     const spawnArgs = h.spawnAgent.mock.calls.at(-1)?.[1] as
-      | { readonly model: string; readonly initialPrompt: string }
+      | { readonly model: string; readonly initialPrompt: string; readonly focus: string }
       | undefined;
+    expect(spawnArgs?.focus).toBe('none');
     expect(spawnArgs?.model).toBe('claude-opus-5');
     expect(spawnArgs?.initialPrompt).toContain('Analyze this spreadsheet and summarize trends.');
     expect(spawnArgs?.initialPrompt).toContain('- budget.xlsx');
@@ -274,6 +289,13 @@ describe('ExplorePane', () => {
       (spawnArgs?.initialPrompt.indexOf('Analyze this spreadsheet and summarize trends.') ?? 0) <
         (spawnArgs?.initialPrompt.indexOf('- budget.xlsx') ?? 0),
     ).toBe(true);
+    expect(h.selectAgent).not.toHaveBeenCalled();
+
+    const action = h.showToast.mock.calls[0]![2]?.action;
+    expect(action?.label).toBe('Open the agent');
+    action?.onClick();
+
+    expect(h.selectAgent).toHaveBeenCalledWith(SESSION_ID, 'agent-1');
   });
 
   it('keeps spawn disabled when the ask is empty', async () => {

--- a/apps/desktop/src/features/github/components/GitHubStudio/CreatePrPanel.test.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/CreatePrPanel.test.tsx
@@ -30,7 +30,12 @@ type ConfigProps = {
 
 type BaseBranches = { defaultBranch: string | null; branches: ReadonlyArray<string> };
 
+type ToastAction = { readonly label: string; readonly onClick: () => void };
+
+type ToastOptions = { readonly title?: string; readonly action?: ToastAction };
+
 const h = vi.hoisted(() => ({
+  showToast: vi.fn<(kind: string, message: string, opts?: ToastOptions) => void>(),
   config: {
     provider: 'codex',
     model: 'gpt-5.4-mini',
@@ -64,6 +69,10 @@ vi.mock('../../../../store', () => ({
 
 vi.mock('../../github', () => ({
   ghBaseBranches: h.ghBaseBranches,
+}));
+
+vi.mock('../../../../app/components/Toast', () => ({
+  useToast: () => ({ showToast: h.showToast }),
 }));
 
 vi.mock('../../../../store/slices/worktrees/useSessionRepo', () => ({
@@ -117,6 +126,7 @@ beforeEach(() => {
   h.store.spawnAgent.mockClear();
   h.store.selectAgent.mockClear();
   h.store.setCurrentSession.mockClear();
+  h.showToast.mockClear();
   h.store.workspaceOverrides = {};
   h.ghBaseBranches.mockClear();
   h.ghBaseBranches.mockImplementation(async () => ({ defaultBranch: 'main', branches: ['main'] }));
@@ -218,6 +228,31 @@ describe('CreatePrPanel', () => {
     expect(args.initialPrompt).toContain(
       '\n\nOperator notes:\n---\nKeep the public API stable.\n---',
     );
+    expect(args).toMatchObject({ focus: 'none' });
+    expect(onStudioClose).not.toHaveBeenCalled();
+  });
+
+  it('keeps the panel in place after the spawn and opens the agent only from the toast action', async () => {
+    const onStudioClose = vi.fn();
+    render(
+      <CreatePrPanel
+        sessionId={SESSION_ID}
+        defaultTitle="Refactor PR cards"
+        onCreated={vi.fn()}
+        onStudioClose={onStudioClose}
+      />,
+    );
+    switchToAgentMode();
+    fireEvent.click(screen.getByRole('button', { name: 'Draft with agent' }));
+
+    await waitFor(() => expect(h.showToast).toHaveBeenCalledOnce());
+    expect(h.store.selectAgent).not.toHaveBeenCalled();
+    const action = h.showToast.mock.calls[0]![2]?.action;
+    expect(action?.label).toBe('Open the agent');
+
+    action?.onClick();
+
+    await waitFor(() => expect(h.store.selectAgent).toHaveBeenCalledWith(SESSION_ID, 'agent-2'));
     await waitFor(() => expect(onStudioClose).toHaveBeenCalledOnce());
   });
 

--- a/apps/desktop/src/features/github/components/GitHubStudio/CreatePrPanel.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/CreatePrPanel.tsx
@@ -22,6 +22,7 @@ import { taskModelAgentSpawnConfig } from '../../../session/components/AgentSpaw
 import { BranchCombobox } from '../../../worktree/BranchCombobox';
 import type { LocalBranchInfo } from '../../../worktree/worktree';
 import { useAppStore } from '../../../../store';
+import { useToast } from '../../../../app/components/Toast';
 import { useSessionRepo } from '../../../../store/slices/worktrees/useSessionRepo';
 
 type CreateMode = 'manual' | 'agent';
@@ -47,6 +48,7 @@ export const CreatePrPanel = ({
   const spawnAgent = useAppStore((s) => s.spawnAgent);
   const selectAgent = useAppStore((s) => s.selectAgent);
   const setCurrentSession = useAppStore((s) => s.setCurrentSession);
+  const { showToast } = useToast();
   const repo = useSessionRepo({ sessionId });
   const branch = repo?.branch ?? null;
   const workspaceRoot = repo?.repoRoot ?? null;
@@ -156,13 +158,24 @@ export const CreatePrPanel = ({
         model: agentConfig.model,
         ...(agentConfig.provider !== '' && { provider: agentConfig.provider }),
         effort: agentConfig.effort,
-        focus: 'agent',
+        focus: 'none',
       });
-      await setCurrentSession(sessionId);
-      await selectAgent(sessionId, agentId);
-      onStudioClose();
+      showToast('success', 'An agent is drafting the pull request. You can keep working.', {
+        title: 'Agent started',
+        action: {
+          label: 'Open the agent',
+          onClick: () => {
+            void (async () => {
+              await setCurrentSession(sessionId);
+              await selectAgent(sessionId, agentId);
+              onStudioClose();
+            })();
+          },
+        },
+      });
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
+    } finally {
       setBusy(null);
     }
   };

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel.test.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel.test.tsx
@@ -32,6 +32,10 @@ type ConfigProps = {
   readonly disabled: boolean;
 };
 
+type ToastAction = { readonly label: string; readonly onClick: () => void };
+
+type ToastOptions = { readonly title?: string; readonly action?: ToastAction };
+
 type MrParams = {
   readonly mergeStatus?: GitlabMergeRequest['mergeStatus'];
   readonly webUrl?: string;
@@ -45,7 +49,7 @@ const h = vi.hoisted(() => ({
     hint: 'Mention the rollout order.',
   } satisfies AgentSpawnConfigValue,
   gitlabMergeMr: vi.fn(async () => undefined),
-  showToast: vi.fn(),
+  showToast: vi.fn<(kind: string, message: string, opts?: ToastOptions) => void>(),
   store: {
     sessions: [
       {
@@ -206,6 +210,24 @@ describe('MrDetailPanel', () => {
     expect(args.initialPrompt).toContain(
       '\n\nOperator notes:\n---\nMention the rollout order.\n---',
     );
+    expect(args).toMatchObject({ focus: 'none' });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('keeps the panel in place after the spawn and opens the agent only from the toast action', async () => {
+    const onClose = vi.fn();
+    render(<MrDetailPanel sessionId={SESSION_ID} onClose={onClose} />);
+    switchToAgentMode();
+    fireEvent.click(screen.getByRole('button', { name: 'Draft with agent' }));
+
+    await waitFor(() => expect(h.showToast).toHaveBeenCalledOnce());
+    expect(h.store.selectAgent).not.toHaveBeenCalled();
+    const action = h.showToast.mock.calls[0]![2]?.action;
+    expect(action?.label).toBe('Open the agent');
+
+    action?.onClick();
+
+    await waitFor(() => expect(h.store.selectAgent).toHaveBeenCalledWith(SESSION_ID, 'agent-3'));
     await waitFor(() => expect(onClose).toHaveBeenCalledOnce());
   });
 

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel.tsx
@@ -196,13 +196,24 @@ export const MrDetailPanel = ({
         model: agentConfig.model,
         ...(agentConfig.provider !== '' && { provider: agentConfig.provider }),
         effort: agentConfig.effort,
-        focus: 'agent',
+        focus: 'none',
       });
-      await setCurrentSession(sessionId);
-      await selectAgent(sessionId, agentId);
-      onClose();
+      showToast('success', 'An agent is drafting the merge request. You can keep working.', {
+        title: 'Agent started',
+        action: {
+          label: 'Open the agent',
+          onClick: () => {
+            void (async () => {
+              await setCurrentSession(sessionId);
+              await selectAgent(sessionId, agentId);
+              onClose();
+            })();
+          },
+        },
+      });
     } catch (err) {
       showToast('error', formatError(err));
+    } finally {
       setBusy(null);
     }
   };

--- a/apps/desktop/src/features/permissions/components/DiffViewerDialog/index.test.tsx
+++ b/apps/desktop/src/features/permissions/components/DiffViewerDialog/index.test.tsx
@@ -9,7 +9,12 @@ type DiffViewSelectorMockProps = {
   onChange: (view: DiffView) => void;
 };
 
-const { state, fixtures } = vi.hoisted(() => ({
+type ToastAction = { readonly label: string; readonly onClick: () => void };
+
+type ToastOptions = { readonly title?: string; readonly action?: ToastAction };
+
+const { showToast, state, fixtures } = vi.hoisted(() => ({
+  showToast: vi.fn<(kind: string, message: string, opts?: ToastOptions) => void>(),
   state: {
     settings: {} as Record<string, string>,
     sessionPhaseRuns: {} as Record<string, ReadonlyArray<unknown>>,
@@ -29,6 +34,9 @@ const { state, fixtures } = vi.hoisted(() => ({
     reopenDiffComment: vi.fn(async () => undefined),
     deleteDiffComment: vi.fn(async () => undefined),
     selectAgent: vi.fn(async () => undefined),
+    setActiveLens: vi.fn(),
+    beginSessionCreation: vi.fn(() => 'creation-1'),
+    endSessionCreation: vi.fn(),
     spawnAgent: vi.fn(async () => 'a1'),
     sendTurn: vi.fn(async () => undefined),
   },
@@ -65,7 +73,7 @@ vi.mock('../../../../features/github/github', () => ({
 }));
 
 vi.mock('../../../../app/components/Toast', () => ({
-  useToast: () => ({ showToast: vi.fn() }),
+  useToast: () => ({ showToast }),
 }));
 
 vi.mock('../../../../features/worktree/worktree', () => ({
@@ -101,7 +109,9 @@ beforeEach(() => {
   state.loadDiffComments = vi.fn(async () => undefined);
   state.addDiffComment = vi.fn(async () => undefined);
   state.selectAgent.mockClear();
+  state.setActiveLens.mockClear();
   state.spawnAgent.mockClear();
+  showToast.mockClear();
   fixtures.files = [];
   fixtures.comments = [];
   fixtures.status.hasUpstream = false;
@@ -225,6 +235,18 @@ describe('DiffViewerPane', () => {
     expect(screen.queryByText('1 file')).toBeNull();
   });
 
+  it('keeps the diff on screen when the rebase starts and opens the agent only on request', async () => {
+    fixtures.files = fileFixture();
+    render(<DiffViewerPane sessionId={SID} worktreePath="/tmp/worktree" onClose={vi.fn()} />);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Rebase' }));
+
+    await waitFor(() => expect(showToast).toHaveBeenCalledOnce());
+    expect(showToast.mock.calls[0]?.[2]?.title).toBe('Rebase started');
+    expect(state.selectAgent).not.toHaveBeenCalled();
+    expect(await screen.findByRole('button', { name: 'Rebase' })).toBeDefined();
+  });
+
   it('spawns a rebase agent with the resolved task model when behind main', async () => {
     fixtures.files = fileFixture();
     state.workspaceOverrides = {
@@ -246,9 +268,10 @@ describe('DiffViewerPane', () => {
         provider: 'codex',
         model: 'gpt-5.4',
         effort: 'low',
+        focus: 'none',
       }),
     );
-    await waitFor(() => expect(state.selectAgent).toHaveBeenCalledWith(SID, 'a1'));
+    expect(state.selectAgent).not.toHaveBeenCalled();
   });
 
   it('surfaces rebase agent failures beside the action', async () => {

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ActivitySection.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ActivitySection.tsx
@@ -6,6 +6,7 @@ import { PendingResolutionsStrip } from '../../../context/components/ContextPane
 import type { WorkspaceRuns } from '../../../orchestration/hooks/useWorkspaceRuns';
 import { CreateAgentPopover } from '../CreateAgentPopover';
 import { ActivityEmptyState } from './ActivityEmptyState';
+import { InFlightActionsStrip } from './InFlightActionsStrip';
 import { PipelineSection } from './PipelineSection';
 import { SummaryRow } from './SummaryRow';
 
@@ -56,6 +57,7 @@ export const ActivitySection = ({
           </div>
         )}
       </div>
+      <InFlightActionsStrip sessionId={sessionId} />
       {isFresh ? (
         <ActivityEmptyState sessionId={sessionId} onOpenWorkflowBuilder={onOpenWorkflowBuilder} />
       ) : (

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/InFlightActionsStrip.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/InFlightActionsStrip.tsx
@@ -1,0 +1,34 @@
+import type { SessionId } from '@goodboy/types';
+import { StatusDot } from '@goodboy/ui';
+import { useAppStore } from '../../../../store';
+import { sessionCreationLabel } from './sessionCreationLabel';
+
+type Props = {
+  readonly sessionId: SessionId;
+};
+
+export const InFlightActionsStrip = ({ sessionId }: Props) => {
+  const creations = useAppStore((state) => state.sessionCreations[sessionId]);
+  const inFlight = creations ?? [];
+
+  if (inFlight.length === 0) {
+    return null;
+  }
+
+  return (
+    <ul
+      aria-live="polite"
+      aria-label="Actions in flight"
+      className="flex flex-col gap-1.5 rounded-lg border border-border-soft bg-subtle px-3 py-2"
+    >
+      {inFlight.map((creation) => (
+        <li key={creation.id} className="flex items-center gap-2">
+          <StatusDot tone="info" size="sm" pulsing />
+          <span className="min-w-0 flex-1 truncate text-xs text-muted-foreground">
+            {sessionCreationLabel({ creation })}
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+};

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/index.test.tsx
@@ -44,6 +44,10 @@ type Store = {
   agentKindOverride: Record<string, unknown>;
   messages: Record<string, ReadonlyArray<unknown>>;
   providers: ReadonlyArray<{ id: string; connection: string }>;
+  sessionCreations: Record<
+    string,
+    ReadonlyArray<{ id: string; kind: string; label: string | null; startedAt: string }>
+  >;
 };
 
 type Runs = {
@@ -83,6 +87,10 @@ const { store, hooks, runs } = vi.hoisted(() => ({
     agentKindOverride: {} as Record<string, unknown>,
     messages: {} as Record<string, ReadonlyArray<unknown>>,
     providers: [{ id: 'anthropic', connection: 'connected' }],
+    sessionCreations: {} as Record<
+      string,
+      ReadonlyArray<{ id: string; kind: string; label: string | null; startedAt: string }>
+    >,
   } as Store,
   hooks: {
     workspace: { id: 'ws-1', name: 'My workspace' } as Workspace | null,
@@ -257,6 +265,7 @@ beforeEach(() => {
   store.sessionPendingResolutions = {};
   store.agentKindOverride = {};
   store.messages = {};
+  store.sessionCreations = {};
   hooks.workspace = { id: 'ws-1', name: 'My workspace' } as Workspace;
   hooks.openQuestions = [];
   hooks.stage = { stage: 'building', reason: '' } as SessionStageInfo;
@@ -568,6 +577,21 @@ describe('SessionOverviewPane activity', () => {
     fireEvent.click(screen.getByText('1 completed agent'));
     expect(onSelectLens).toHaveBeenCalledWith('agents');
     expect(store.setFocusedWorkflowRun).not.toHaveBeenCalled();
+  });
+
+  it('shows a branch action started elsewhere as in flight', () => {
+    store.sessionCreations = {
+      'sess-1': [
+        {
+          id: 'creation-1',
+          kind: 'branch',
+          label: 'Rebasing on main',
+          startedAt: '2026-08-04T10:00:00.000Z',
+        },
+      ],
+    };
+    renderPane();
+    expect(screen.getByText('Rebasing on main')).toBeDefined();
   });
 
   it('offers the batched push once resolutions are queued', async () => {

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/sessionCreationLabel.ts
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/sessionCreationLabel.ts
@@ -1,0 +1,15 @@
+import type { SessionCreation } from '../../../../store/slices/session-view';
+
+type Params = {
+  readonly creation: SessionCreation;
+};
+
+export const sessionCreationLabel = ({ creation }: Params): string => {
+  if (creation.kind === 'branch') {
+    return creation.label ?? 'Working on the branch';
+  }
+  if (creation.kind === 'workflow') {
+    return creation.label == null ? 'Starting a workflow' : `Starting ${creation.label}`;
+  }
+  return creation.label == null ? 'Creating an agent' : `Creating ${creation.label}`;
+};

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/SessionGitActions.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/SessionGitActions.test.tsx
@@ -1,0 +1,146 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { Session, SessionId, WorktreeStatus } from '@goodboy/types';
+
+type PushResult = { ok: true } | { ok: false; error: string };
+
+const h = vi.hoisted(() => ({
+  state: {
+    sessions: [
+      {
+        id: 'session-1',
+        workspaceId: 'workspace-1',
+        providerPreference: { defaultProvider: 'anthropic' },
+      },
+    ],
+    workspaceOverrides: {},
+    sessionPhaseRuns: {} as Record<
+      string,
+      ReadonlyArray<{ id: string; name: string; status: string }>
+    >,
+    sessionCreations: {},
+    spawnAgent: vi.fn(async () => 'agent-1'),
+    selectAgent: vi.fn(async () => undefined),
+    setActiveLens: vi.fn(),
+    emitNotification: vi.fn(async () => undefined),
+    pushSessionBranch: vi.fn(async (): Promise<PushResult> => ({ ok: true })),
+    beginSessionCreation: vi.fn(() => 'creation-1'),
+    endSessionCreation: vi.fn(),
+  },
+  worktreeStatus: vi.fn(
+    async (): Promise<WorktreeStatus> =>
+      ({ ahead: 1, commitsBehindMain: 2 }) as unknown as WorktreeStatus,
+  ),
+}));
+
+vi.mock('../../../../../store', () => ({
+  useAppStore: <T,>(selector: (state: typeof h.state) => T) => selector(h.state),
+}));
+
+vi.mock('../../../../worktree/worktree', () => ({
+  worktreeStatus: h.worktreeStatus,
+}));
+
+vi.mock('../../../../../store/slices/worktrees/resolveSessionRepo', () => ({
+  resolveSessionRepo: () => ({
+    worktreePath: '/repo/.goodboy/worktrees/card-config',
+    mountName: null,
+  }),
+}));
+
+vi.mock('../../../components/AgentSpawnConfig/taskModelAgentSpawnConfig', () => ({
+  taskModelAgentSpawnConfig: () => ({
+    provider: 'anthropic',
+    model: 'haiku-4.5',
+    effort: 'low',
+    hint: '',
+  }),
+}));
+
+import { ToastProvider } from '../../../../../app/components/Toast';
+import { SessionGitActions } from './SessionGitActions';
+
+const SESSION_ID = 'session-1' as SessionId;
+
+const session = { id: SESSION_ID, workspaceId: 'workspace-1' } as unknown as Session;
+
+const renderActions = () =>
+  render(
+    <ToastProvider>
+      <SessionGitActions session={session} />
+    </ToastProvider>,
+  );
+
+const openMenu = () => {
+  fireEvent.click(screen.getByRole('button', { name: 'Branch actions' }));
+};
+
+beforeEach(() => {
+  h.state.sessionPhaseRuns = {};
+  h.state.spawnAgent.mockClear();
+  h.state.selectAgent.mockClear();
+  h.state.setActiveLens.mockClear();
+  h.state.pushSessionBranch.mockClear();
+  h.state.pushSessionBranch.mockResolvedValue({ ok: true });
+  h.state.beginSessionCreation.mockClear();
+  h.state.endSessionCreation.mockClear();
+});
+
+afterEach(cleanup);
+
+describe('SessionGitActions', () => {
+  it('keeps the user in place when the rebase starts and opens the agent only from the toast action', async () => {
+    const { rerender } = renderActions();
+    openMenu();
+    await waitFor(() =>
+      expect(
+        (screen.getByRole('menuitem', { name: 'Rebase on main' }) as HTMLButtonElement).disabled,
+      ).toBe(false),
+    );
+
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Rebase on main' }));
+
+    await waitFor(() => expect(screen.getByText('Rebase started')).toBeDefined());
+    expect(h.state.spawnAgent).toHaveBeenCalledWith(
+      SESSION_ID,
+      expect.objectContaining({ focus: 'none' }),
+    );
+    expect(h.state.selectAgent).not.toHaveBeenCalled();
+
+    h.state.sessionPhaseRuns = {
+      [SESSION_ID]: [{ id: 'agent-1', name: 'Rebase on main', status: 'completed' }],
+    };
+    rerender(
+      <ToastProvider>
+        <SessionGitActions session={session} />
+      </ToastProvider>,
+    );
+
+    const action = await screen.findByRole('button', { name: 'Open the rebase agent' });
+    expect(h.state.selectAgent).not.toHaveBeenCalled();
+
+    fireEvent.click(action);
+
+    expect(h.state.selectAgent).toHaveBeenCalledWith(SESSION_ID, 'agent-1');
+    expect(h.state.setActiveLens).toHaveBeenCalledWith(SESSION_ID, 'agents');
+  });
+
+  it('confirms a finished push without leaving the current view', async () => {
+    renderActions();
+    openMenu();
+    await waitFor(() =>
+      expect(
+        (screen.getByRole('menuitem', { name: 'Push branch' }) as HTMLButtonElement).disabled,
+      ).toBe(false),
+    );
+
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Push branch' }));
+
+    expect(await screen.findByText('Push started')).toBeDefined();
+    expect(await screen.findByText('Push done')).toBeDefined();
+    expect(h.state.pushSessionBranch).toHaveBeenCalledWith(SESSION_ID);
+    expect(h.state.selectAgent).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/features/session/hooks/usePushBranch/index.test.ts
+++ b/apps/desktop/src/features/session/hooks/usePushBranch/index.test.ts
@@ -6,14 +6,23 @@ import type { SessionId } from '@goodboy/types';
 
 type PushResult = { ok: true } | { ok: false; error: string };
 
-const { state } = vi.hoisted(() => ({
+type ToastOptions = { readonly title?: string };
+
+const { showToast, state } = vi.hoisted(() => ({
+  showToast: vi.fn<(kind: string, message: string, opts?: ToastOptions) => void>(),
   state: {
     pushSessionBranch: vi.fn(async (): Promise<PushResult> => ({ ok: true })),
+    beginSessionCreation: vi.fn(() => 'creation-1'),
+    endSessionCreation: vi.fn(),
   },
 }));
 
 vi.mock('../../../../store', () => ({
   useAppStore: <T>(selector: (store: typeof state) => T) => selector(state),
+}));
+
+vi.mock('../../../../app/components/Toast', () => ({
+  useToast: () => ({ showToast }),
 }));
 
 import { usePushBranch } from './index';
@@ -23,6 +32,10 @@ const sessionId = 'session-1' as SessionId;
 beforeEach(() => {
   state.pushSessionBranch.mockReset();
   state.pushSessionBranch.mockResolvedValue({ ok: true });
+  state.beginSessionCreation.mockReset();
+  state.beginSessionCreation.mockReturnValue('creation-1');
+  state.endSessionCreation.mockReset();
+  showToast.mockClear();
 });
 
 afterEach(cleanup);
@@ -38,6 +51,22 @@ describe('usePushBranch', () => {
     expect(result.current.error).toBeNull();
   });
 
+  it('confirms the start and the end of a successful push in place', async () => {
+    const { result } = renderHook(() => usePushBranch({ sessionId }));
+
+    await act(() => result.current.run());
+
+    expect(showToast.mock.calls.map((call) => call[2]?.title)).toEqual([
+      'Push started',
+      'Push done',
+    ]);
+    expect(state.beginSessionCreation).toHaveBeenCalledWith(sessionId, {
+      kind: 'branch',
+      label: 'Pushing the branch',
+    });
+    expect(state.endSessionCreation).toHaveBeenCalledWith(sessionId, 'creation-1');
+  });
+
   it('surfaces an unsuccessful push result', async () => {
     state.pushSessionBranch.mockResolvedValueOnce({
       ok: false,
@@ -48,6 +77,8 @@ describe('usePushBranch', () => {
     await act(() => result.current.run());
 
     expect(result.current.error).toBe('remote rejected the branch');
+    expect(showToast.mock.calls.map((call) => call[2]?.title)).toEqual(['Push started']);
+    expect(state.endSessionCreation).toHaveBeenCalledWith(sessionId, 'creation-1');
   });
 
   it('surfaces a rejected push', async () => {

--- a/apps/desktop/src/features/session/hooks/usePushBranch/index.ts
+++ b/apps/desktop/src/features/session/hooks/usePushBranch/index.ts
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import type { SessionId } from '@goodboy/types';
 import { useAppStore } from '../../../../store';
+import { useToast } from '../../../../app/components/Toast';
 import { formatError } from '../../../../shared/lib/errors';
 
 type Params = {
@@ -14,8 +15,13 @@ type Result = {
   readonly run: () => Promise<void>;
 };
 
+const PUSH_PROGRESS_LABEL = 'Pushing the branch';
+
 export const usePushBranch = ({ sessionId, onError }: Params): Result => {
   const pushSessionBranch = useAppStore((state) => state.pushSessionBranch);
+  const beginSessionCreation = useAppStore((state) => state.beginSessionCreation);
+  const endSessionCreation = useAppStore((state) => state.endSessionCreation);
+  const { showToast } = useToast();
   const [isBusy, setIsBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -30,14 +36,22 @@ export const usePushBranch = ({ sessionId, onError }: Params): Result => {
     }
     setError(null);
     setIsBusy(true);
+    const creationId = beginSessionCreation(sessionId, {
+      kind: 'branch',
+      label: PUSH_PROGRESS_LABEL,
+    });
+    showToast('info', 'Pushing this branch to its remote.', { title: 'Push started' });
     try {
       const result = await pushSessionBranch(sessionId);
       if (!result.ok) {
         fail(result.error);
+        return;
       }
+      showToast('success', 'This branch is pushed to its remote.', { title: 'Push done' });
     } catch (failure) {
       fail(formatError(failure));
     } finally {
+      endSessionCreation(sessionId, creationId);
       setIsBusy(false);
     }
   };

--- a/apps/desktop/src/features/session/hooks/useRebaseAgent/index.test.ts
+++ b/apps/desktop/src/features/session/hooks/useRebaseAgent/index.test.ts
@@ -4,7 +4,12 @@ import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { SessionId, WorktreeStatus } from '@goodboy/types';
 
-const { state } = vi.hoisted(() => ({
+type ToastAction = { readonly label: string; readonly onClick: () => void };
+
+type ToastOptions = { readonly title?: string; readonly action?: ToastAction };
+
+const { showToast, state } = vi.hoisted(() => ({
+  showToast: vi.fn<(kind: string, message: string, opts?: ToastOptions) => void>(),
   state: {
     sessions: [
       {
@@ -20,14 +25,24 @@ const { state } = vi.hoisted(() => ({
         },
       },
     },
-    sessionPhaseRuns: {} as Record<string, ReadonlyArray<{ name: string; status: string }>>,
+    sessionPhaseRuns: {} as Record<
+      string,
+      ReadonlyArray<{ id: string; name: string; status: string }>
+    >,
     spawnAgent: vi.fn(async () => 'agent-1'),
     selectAgent: vi.fn(async () => undefined),
+    setActiveLens: vi.fn(),
+    beginSessionCreation: vi.fn(() => 'creation-1'),
+    endSessionCreation: vi.fn(),
   },
 }));
 
 vi.mock('../../../../store', () => ({
   useAppStore: <T>(selector: (store: typeof state) => T) => selector(state),
+}));
+
+vi.mock('../../../../app/components/Toast', () => ({
+  useToast: () => ({ showToast }),
 }));
 
 vi.mock('../../components/AgentSpawnConfig/taskModelAgentSpawnConfig', () => ({
@@ -53,6 +68,11 @@ beforeEach(() => {
   state.spawnAgent.mockResolvedValue('agent-1');
   state.selectAgent.mockReset();
   state.selectAgent.mockResolvedValue(undefined);
+  state.setActiveLens.mockReset();
+  state.beginSessionCreation.mockReset();
+  state.beginSessionCreation.mockReturnValue('creation-1');
+  state.endSessionCreation.mockReset();
+  showToast.mockClear();
 });
 
 afterEach(cleanup);
@@ -69,7 +89,7 @@ describe('useRebaseAgent', () => {
     expect(result.current.canRebase).toBe(true);
   });
 
-  it('spawns and selects the rebase agent with the resolved task model', async () => {
+  it('spawns the rebase agent with the resolved task model without selecting it', async () => {
     const { result } = renderHook(() => useRebaseAgent({ sessionId, status: status(2) }));
 
     await act(() => result.current.run());
@@ -84,7 +104,44 @@ describe('useRebaseAgent', () => {
         effort: 'low',
       }),
     );
+    expect(state.selectAgent).not.toHaveBeenCalled();
+  });
+
+  it('spawns without taking the focus and marks the branch action in flight', async () => {
+    const { result } = renderHook(() => useRebaseAgent({ sessionId, status: status(2) }));
+
+    await act(() => result.current.run());
+
+    expect(state.spawnAgent).toHaveBeenCalledWith(
+      sessionId,
+      expect.objectContaining({ focus: 'none' }),
+    );
+    expect(state.beginSessionCreation).toHaveBeenCalledWith(sessionId, {
+      kind: 'branch',
+      label: 'Rebasing on main',
+    });
+    expect(showToast.mock.calls[0]?.[2]?.title).toBe('Rebase started');
+  });
+
+  it('offers an action that opens the agent once the rebase settles', async () => {
+    const { result, rerender } = renderHook(() => useRebaseAgent({ sessionId, status: status(2) }));
+
+    await act(() => result.current.run());
+    state.sessionPhaseRuns = {
+      [sessionId]: [{ id: 'agent-1', name: 'Rebase on main', status: 'failed' }],
+    };
+    rerender();
+
+    await waitFor(() => expect(showToast).toHaveBeenCalledTimes(2));
+    expect(state.endSessionCreation).toHaveBeenCalledWith(sessionId, 'creation-1');
+    const action = showToast.mock.calls[1]?.[2]?.action;
+    expect(action?.label).toBe('Open the rebase agent');
+    expect(state.selectAgent).not.toHaveBeenCalled();
+
+    action?.onClick();
+
     expect(state.selectAgent).toHaveBeenCalledWith(sessionId, 'agent-1');
+    expect(state.setActiveLens).toHaveBeenCalledWith(sessionId, 'agents');
   });
 
   it('reports spawn failures', async () => {
@@ -94,11 +151,12 @@ describe('useRebaseAgent', () => {
     await act(() => result.current.run());
 
     expect(result.current.error).toBe('agent launch failed');
+    expect(state.endSessionCreation).toHaveBeenCalledWith(sessionId, 'creation-1');
   });
 
   it('guards against a second rebase while the named agent is running', async () => {
     state.sessionPhaseRuns = {
-      [sessionId]: [{ name: 'Rebase on main', status: 'running' }],
+      [sessionId]: [{ id: 'agent-9', name: 'Rebase on main', status: 'running' }],
     };
     const { result } = renderHook(() => useRebaseAgent({ sessionId, status: status(2) }));
 

--- a/apps/desktop/src/features/session/hooks/useRebaseAgent/index.ts
+++ b/apps/desktop/src/features/session/hooks/useRebaseAgent/index.ts
@@ -1,6 +1,8 @@
-import { useMemo, useState } from 'react';
-import type { SessionId, WorktreeStatus } from '@goodboy/types';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { AgentId, SessionId, WorktreeStatus } from '@goodboy/types';
 import { useAppStore } from '../../../../store';
+import type { SessionCreationId } from '../../../../store/slices/session-view';
+import { useToast } from '../../../../app/components/Toast';
 import { formatError } from '../../../../shared/lib/errors';
 import { taskModelAgentSpawnConfig } from '../../components/AgentSpawnConfig/taskModelAgentSpawnConfig';
 
@@ -17,7 +19,14 @@ type Result = {
   readonly run: () => Promise<void>;
 };
 
+type Pending = {
+  readonly agentId: AgentId;
+  readonly creationId: SessionCreationId;
+};
+
 const REBASE_AGENT_NAME = 'Rebase on main';
+
+const REBASE_PROGRESS_LABEL = 'Rebasing on main';
 
 const REBASE_PROMPT = [
   'Rebase this session branch onto origin/main.',
@@ -32,6 +41,9 @@ const REBASE_PROMPT = [
 export const useRebaseAgent = ({ sessionId, status, onError }: Params): Result => {
   const [isStarting, setIsStarting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState<Pending | null>(null);
+  const settledAgentIds = useRef(new Set<AgentId>());
+  const pendingRef = useRef<Pending | null>(null);
   const session = useAppStore((state) =>
     sessionId == null
       ? null
@@ -45,6 +57,10 @@ export const useRebaseAgent = ({ sessionId, status, onError }: Params): Result =
   );
   const spawnAgent = useAppStore((state) => state.spawnAgent);
   const selectAgent = useAppStore((state) => state.selectAgent);
+  const setActiveLens = useAppStore((state) => state.setActiveLens);
+  const beginSessionCreation = useAppStore((state) => state.beginSessionCreation);
+  const endSessionCreation = useAppStore((state) => state.endSessionCreation);
+  const { showToast } = useToast();
   const config = useMemo(
     () =>
       taskModelAgentSpawnConfig({
@@ -63,12 +79,64 @@ export const useRebaseAgent = ({ sessionId, status, onError }: Params): Result =
   const isRunning = isStarting || isAgentRunning;
   const canRebase = sessionId != null && status != null && status.commitsBehindMain > 0;
 
+  useEffect(() => {
+    pendingRef.current = pending;
+  }, [pending]);
+
+  useEffect(
+    () => () => {
+      const leftOver = pendingRef.current;
+      if (sessionId == null || leftOver == null) {
+        return;
+      }
+      pendingRef.current = null;
+      endSessionCreation(sessionId, leftOver.creationId);
+    },
+    [endSessionCreation, sessionId],
+  );
+
+  useEffect(() => {
+    if (sessionId == null || pending == null) {
+      return;
+    }
+    const agent = phaseRuns?.find((candidate) => candidate.id === pending.agentId) ?? null;
+    if (agent == null || (agent.status !== 'completed' && agent.status !== 'failed')) {
+      return;
+    }
+    if (settledAgentIds.current.has(pending.agentId)) {
+      return;
+    }
+    settledAgentIds.current.add(pending.agentId);
+    const agentId = pending.agentId;
+    const isFailed = agent.status === 'failed';
+    endSessionCreation(sessionId, pending.creationId);
+    setPending(null);
+    showToast(
+      isFailed ? 'error' : 'success',
+      isFailed ? 'The rebase agent stopped before finishing.' : 'This branch is rebased on main.',
+      {
+        title: isFailed ? 'Rebase failed' : 'Rebase done',
+        action: {
+          label: 'Open the rebase agent',
+          onClick: () => {
+            setActiveLens(sessionId, 'agents');
+            void selectAgent(sessionId, agentId);
+          },
+        },
+      },
+    );
+  }, [endSessionCreation, pending, phaseRuns, selectAgent, sessionId, setActiveLens, showToast]);
+
   const run = async (): Promise<void> => {
     if (!canRebase || isRunning || sessionId == null || config.provider === '') {
       return;
     }
     setError(null);
     setIsStarting(true);
+    const creationId = beginSessionCreation(sessionId, {
+      kind: 'branch',
+      label: REBASE_PROGRESS_LABEL,
+    });
     try {
       const agentId = await spawnAgent(sessionId, {
         name: REBASE_AGENT_NAME,
@@ -76,10 +144,14 @@ export const useRebaseAgent = ({ sessionId, status, onError }: Params): Result =
         model: config.model,
         provider: config.provider,
         effort: config.effort,
-        focus: 'agent',
+        focus: 'none',
       });
-      await selectAgent(sessionId, agentId);
+      setPending({ agentId, creationId });
+      showToast('info', 'An agent is rebasing this branch on main. You can keep working.', {
+        title: 'Rebase started',
+      });
     } catch (failure) {
+      endSessionCreation(sessionId, creationId);
       const message = formatError(failure);
       setError(message);
       onError?.(message);

--- a/apps/desktop/src/store/slices/session-view/types.ts
+++ b/apps/desktop/src/store/slices/session-view/types.ts
@@ -96,7 +96,7 @@ export type LensHistory = {
   readonly index: number;
 };
 
-export type SessionCreationKind = 'agent' | 'workflow';
+export type SessionCreationKind = 'agent' | 'workflow' | 'branch';
 
 export type SessionCreationId = string;
 


### PR DESCRIPTION
## What was wrong

Asking for a rebase from the Branch menu spawned an agent with `focus: 'agent'` and then also called `selectAgent`, so `selectedAgentId` went non-null and `SessionWorkspace` swapped the whole lens for the agent overlay. The chat became the default view of a maintenance action, against `VISION.md:72` ("Chat is one destination among the lenses, not the frame around them"). Push had the opposite problem: it never navigated, and never reported success either.

Correction to the original report: push does not spawn an agent at all, so only the rebase carried the navigation defect. The same defect existed in two more places that were not in the complaint (`CreatePrPanel`, `MrDetailPanel`, both spawn-then-`setCurrentSession`-then-`selectAgent`), plus `ExploreSpawnPopover` which also fired a `goodboy:reveal-chat` event, and the Rebase button inside the diff viewer header, which shares the hook.

## What it is now

The rule lives in the two hooks, so every surface that uses them behaves the same:

- the rebase spawns with `focus: 'none'` and never selects the agent
- both actions register an entry in the existing `sessionCreations` mechanism, so the in-flight state is visible from the session Overview through a new in-flight strip, not only from the menu that started it
- a start toast, then a finish toast in both outcomes; the rebase's finish toast carries "Open the rebase agent", and that click is the only thing that navigates
- `CreatePrPanel`, `MrDetailPanel` and `ExploreSpawnPopover` spawn without stealing focus and offer the same explicit action

`CreateAgentPopover` and `HandoffChip` are untouched: there the click already means "open it". `runPlan`, the nudge handoff and the mobile companion are out of scope for this change and unchanged. No spinner was added: the strip uses a pulsing `StatusDot`, per `DESIGN.md:294`.

## Tests

- `useRebaseAgent/index.test.ts`: the assertion that `selectAgent` was called is inverted, plus new cases for `focus: 'none'`, the in-flight marker and the CTA that navigates only on click.
- New `SessionGitActions.test.tsx` drives the real toast provider end to end for both actions.
- `usePushBranch`, `DiffViewerDialog`, `CreatePrPanel`, `MrDetailPanel`, `ExplorePane` and `SessionOverviewPane` tests updated to assert the new behaviour explicitly rather than dropping the old assertions.
- Mutation-checked: removing `focus: 'none'` fails the named test with the expected diff, restoring it turns it green.

## Verification

Re-run in the integration worktree after rebasing onto the rest of the stack, not only in isolation:

- `vitest` desktop, whole suite: 4130 passed, 474 files
- `tsc --noEmit`: clean

happy-dom does not lay out or animate, so the claims here are about which surface is mounted and which action navigates, not about how the strip looks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)