### PR TITLE
fix(desktop): round UX11, areas 2 to 9 and 14

### DIFF
--- a/apps/desktop/src/features/explore/components/ExplorePane/ExploreSpawnPopover.tsx
+++ b/apps/desktop/src/features/explore/components/ExplorePane/ExploreSpawnPopover.tsx
@@ -5,6 +5,7 @@ import type { SessionId } from '@goodboy/types';
 import { useDropdown } from '../../../../shared/hooks/useDropdown';
 import { DropdownPortal } from '../../../../shared/hooks/useDropdown/DropdownPortal';
 import { useAppStore } from '../../../../store';
+import { useToast } from '../../../../app/components/Toast';
 import { clampEffort } from '../../../chat/utils/chat-constants';
 import { AgentSpawnConfig } from '../../../session/components/AgentSpawnConfig';
 import { resolveSpawnRouting } from '../../../session/spawn-routing';
@@ -46,6 +47,8 @@ export const ExploreSpawnPopover = ({ sessionId, entry }: Props) => {
     strategy: 'fixed',
   });
   const spawnAgent = useAppStore((state) => state.spawnAgent);
+  const selectAgent = useAppStore((state) => state.selectAgent);
+  const { showToast } = useToast();
   const session = useAppStore(
     (state) => state.sessions.find((candidate) => candidate.id === sessionId) ?? null,
   );
@@ -85,15 +88,24 @@ export const ExploreSpawnPopover = ({ sessionId, entry }: Props) => {
     try {
       const kickoff = buildExploreSpawnPrompt({ ask: trimmedAsk, relPath: entry.relPath });
       const initialPrompt = appendOperatorNotes({ prompt: kickoff, hint: config.hint });
-      await spawnAgent(sessionId, {
+      const agentId = await spawnAgent(sessionId, {
         initialPrompt,
         model: config.model,
         ...(config.provider !== '' && { provider: config.provider }),
         effort: config.effort,
-        focus: 'agent',
+        focus: 'none',
       });
       close();
-      window.dispatchEvent(new CustomEvent('goodboy:reveal-chat'));
+      showToast('success', `An agent is working on ${entry.name}. You can keep working.`, {
+        title: 'Agent started',
+        action: {
+          label: 'Open the agent',
+          onClick: () => {
+            void selectAgent(sessionId, agentId);
+            window.dispatchEvent(new CustomEvent('goodboy:reveal-chat'));
+          },
+        },
+      });
     } catch (error) {
       setSpawnError(toErrorMessage({ error }));
     }

--- a/apps/desktop/src/features/explore/components/ExplorePane/index.test.tsx
+++ b/apps/desktop/src/features/explore/components/ExplorePane/index.test.tsx
@@ -5,8 +5,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { ProviderId, Session, SessionId } from '@goodboy/types';
 
+type ToastAction = { readonly label: string; readonly onClick: () => void };
+
+type ToastOptions = { readonly title?: string; readonly action?: ToastAction };
+
 type Store = {
   readonly spawnAgent: ReturnType<typeof vi.fn>;
+  readonly selectAgent: ReturnType<typeof vi.fn>;
   readonly providers: ReadonlyArray<{
     readonly id: ProviderId;
     readonly connection: string;
@@ -25,6 +30,8 @@ const h = vi.hoisted(() => ({
       args: { readonly model: string; readonly initialPrompt: string },
     ) => Promise<string>
   >(async () => 'agent-1'),
+  selectAgent: vi.fn(async () => undefined),
+  showToast: vi.fn<(kind: string, message: string, opts?: ToastOptions) => void>(),
   providers: [{ id: 'anthropic' as ProviderId, connection: 'connected' }],
   sessions: [
     {
@@ -54,10 +61,15 @@ vi.mock('../../../../store', () => ({
   useAppStore: <T,>(selector: (state: Store) => T) =>
     selector({
       spawnAgent: h.spawnAgent,
+      selectAgent: h.selectAgent,
       providers: h.providers,
       sessions: h.sessions,
       workspaceOverrides: {},
     }),
+}));
+
+vi.mock('../../../../app/components/Toast', () => ({
+  useToast: () => ({ showToast: h.showToast }),
 }));
 
 vi.mock('@goodboy/ui', async (importOriginal) => {
@@ -83,6 +95,8 @@ beforeEach(() => {
   h.exploreRead.mockReset();
   h.spawnAgent.mockReset();
   h.spawnAgent.mockResolvedValue('agent-1');
+  h.selectAgent.mockClear();
+  h.showToast.mockClear();
   h.providers = [{ id: 'anthropic' as ProviderId, connection: 'connected' }];
 });
 
@@ -265,8 +279,9 @@ describe('ExplorePane', () => {
 
     await waitFor(() => expect(h.spawnAgent).toHaveBeenCalled());
     const spawnArgs = h.spawnAgent.mock.calls.at(-1)?.[1] as
-      | { readonly model: string; readonly initialPrompt: string }
+      | { readonly model: string; readonly initialPrompt: string; readonly focus: string }
       | undefined;
+    expect(spawnArgs?.focus).toBe('none');
     expect(spawnArgs?.model).toBe('claude-opus-5');
     expect(spawnArgs?.initialPrompt).toContain('Analyze this spreadsheet and summarize trends.');
     expect(spawnArgs?.initialPrompt).toContain('- budget.xlsx');
@@ -274,6 +289,13 @@ describe('ExplorePane', () => {
       (spawnArgs?.initialPrompt.indexOf('Analyze this spreadsheet and summarize trends.') ?? 0) <
         (spawnArgs?.initialPrompt.indexOf('- budget.xlsx') ?? 0),
     ).toBe(true);
+    expect(h.selectAgent).not.toHaveBeenCalled();
+
+    const action = h.showToast.mock.calls[0]![2]?.action;
+    expect(action?.label).toBe('Open the agent');
+    action?.onClick();
+
+    expect(h.selectAgent).toHaveBeenCalledWith(SESSION_ID, 'agent-1');
   });
 
   it('keeps spawn disabled when the ask is empty', async () => {

--- a/apps/desktop/src/features/github/components/GitHubStudio/CreatePrPanel.test.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/CreatePrPanel.test.tsx
@@ -30,7 +30,12 @@ type ConfigProps = {
 
 type BaseBranches = { defaultBranch: string | null; branches: ReadonlyArray<string> };
 
+type ToastAction = { readonly label: string; readonly onClick: () => void };
+
+type ToastOptions = { readonly title?: string; readonly action?: ToastAction };
+
 const h = vi.hoisted(() => ({
+  showToast: vi.fn<(kind: string, message: string, opts?: ToastOptions) => void>(),
   config: {
     provider: 'codex',
     model: 'gpt-5.4-mini',
@@ -64,6 +69,10 @@ vi.mock('../../../../store', () => ({
 
 vi.mock('../../github', () => ({
   ghBaseBranches: h.ghBaseBranches,
+}));
+
+vi.mock('../../../../app/components/Toast', () => ({
+  useToast: () => ({ showToast: h.showToast }),
 }));
 
 vi.mock('../../../../store/slices/worktrees/useSessionRepo', () => ({
@@ -117,6 +126,7 @@ beforeEach(() => {
   h.store.spawnAgent.mockClear();
   h.store.selectAgent.mockClear();
   h.store.setCurrentSession.mockClear();
+  h.showToast.mockClear();
   h.store.workspaceOverrides = {};
   h.ghBaseBranches.mockClear();
   h.ghBaseBranches.mockImplementation(async () => ({ defaultBranch: 'main', branches: ['main'] }));
@@ -218,6 +228,31 @@ describe('CreatePrPanel', () => {
     expect(args.initialPrompt).toContain(
       '\n\nOperator notes:\n---\nKeep the public API stable.\n---',
     );
+    expect(args).toMatchObject({ focus: 'none' });
+    expect(onStudioClose).not.toHaveBeenCalled();
+  });
+
+  it('keeps the panel in place after the spawn and opens the agent only from the toast action', async () => {
+    const onStudioClose = vi.fn();
+    render(
+      <CreatePrPanel
+        sessionId={SESSION_ID}
+        defaultTitle="Refactor PR cards"
+        onCreated={vi.fn()}
+        onStudioClose={onStudioClose}
+      />,
+    );
+    switchToAgentMode();
+    fireEvent.click(screen.getByRole('button', { name: 'Draft with agent' }));
+
+    await waitFor(() => expect(h.showToast).toHaveBeenCalledOnce());
+    expect(h.store.selectAgent).not.toHaveBeenCalled();
+    const action = h.showToast.mock.calls[0]![2]?.action;
+    expect(action?.label).toBe('Open the agent');
+
+    action?.onClick();
+
+    await waitFor(() => expect(h.store.selectAgent).toHaveBeenCalledWith(SESSION_ID, 'agent-2'));
     await waitFor(() => expect(onStudioClose).toHaveBeenCalledOnce());
   });
 

--- a/apps/desktop/src/features/github/components/GitHubStudio/CreatePrPanel.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/CreatePrPanel.tsx
@@ -22,6 +22,7 @@ import { taskModelAgentSpawnConfig } from '../../../session/components/AgentSpaw
 import { BranchCombobox } from '../../../worktree/BranchCombobox';
 import type { LocalBranchInfo } from '../../../worktree/worktree';
 import { useAppStore } from '../../../../store';
+import { useToast } from '../../../../app/components/Toast';
 import { useSessionRepo } from '../../../../store/slices/worktrees/useSessionRepo';
 
 type CreateMode = 'manual' | 'agent';
@@ -47,6 +48,7 @@ export const CreatePrPanel = ({
   const spawnAgent = useAppStore((s) => s.spawnAgent);
   const selectAgent = useAppStore((s) => s.selectAgent);
   const setCurrentSession = useAppStore((s) => s.setCurrentSession);
+  const { showToast } = useToast();
   const repo = useSessionRepo({ sessionId });
   const branch = repo?.branch ?? null;
   const workspaceRoot = repo?.repoRoot ?? null;
@@ -156,13 +158,24 @@ export const CreatePrPanel = ({
         model: agentConfig.model,
         ...(agentConfig.provider !== '' && { provider: agentConfig.provider }),
         effort: agentConfig.effort,
-        focus: 'agent',
+        focus: 'none',
       });
-      await setCurrentSession(sessionId);
-      await selectAgent(sessionId, agentId);
-      onStudioClose();
+      showToast('success', 'An agent is drafting the pull request. You can keep working.', {
+        title: 'Agent started',
+        action: {
+          label: 'Open the agent',
+          onClick: () => {
+            void (async () => {
+              await setCurrentSession(sessionId);
+              await selectAgent(sessionId, agentId);
+              onStudioClose();
+            })();
+          },
+        },
+      });
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
+    } finally {
       setBusy(null);
     }
   };

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel.test.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel.test.tsx
@@ -32,6 +32,10 @@ type ConfigProps = {
   readonly disabled: boolean;
 };
 
+type ToastAction = { readonly label: string; readonly onClick: () => void };
+
+type ToastOptions = { readonly title?: string; readonly action?: ToastAction };
+
 type MrParams = {
   readonly mergeStatus?: GitlabMergeRequest['mergeStatus'];
   readonly webUrl?: string;
@@ -45,7 +49,7 @@ const h = vi.hoisted(() => ({
     hint: 'Mention the rollout order.',
   } satisfies AgentSpawnConfigValue,
   gitlabMergeMr: vi.fn(async () => undefined),
-  showToast: vi.fn(),
+  showToast: vi.fn<(kind: string, message: string, opts?: ToastOptions) => void>(),
   store: {
     sessions: [
       {
@@ -206,6 +210,24 @@ describe('MrDetailPanel', () => {
     expect(args.initialPrompt).toContain(
       '\n\nOperator notes:\n---\nMention the rollout order.\n---',
     );
+    expect(args).toMatchObject({ focus: 'none' });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('keeps the panel in place after the spawn and opens the agent only from the toast action', async () => {
+    const onClose = vi.fn();
+    render(<MrDetailPanel sessionId={SESSION_ID} onClose={onClose} />);
+    switchToAgentMode();
+    fireEvent.click(screen.getByRole('button', { name: 'Draft with agent' }));
+
+    await waitFor(() => expect(h.showToast).toHaveBeenCalledOnce());
+    expect(h.store.selectAgent).not.toHaveBeenCalled();
+    const action = h.showToast.mock.calls[0]![2]?.action;
+    expect(action?.label).toBe('Open the agent');
+
+    action?.onClick();
+
+    await waitFor(() => expect(h.store.selectAgent).toHaveBeenCalledWith(SESSION_ID, 'agent-3'));
     await waitFor(() => expect(onClose).toHaveBeenCalledOnce());
   });
 

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel.tsx
@@ -196,13 +196,24 @@ export const MrDetailPanel = ({
         model: agentConfig.model,
         ...(agentConfig.provider !== '' && { provider: agentConfig.provider }),
         effort: agentConfig.effort,
-        focus: 'agent',
+        focus: 'none',
       });
-      await setCurrentSession(sessionId);
-      await selectAgent(sessionId, agentId);
-      onClose();
+      showToast('success', 'An agent is drafting the merge request. You can keep working.', {
+        title: 'Agent started',
+        action: {
+          label: 'Open the agent',
+          onClick: () => {
+            void (async () => {
+              await setCurrentSession(sessionId);
+              await selectAgent(sessionId, agentId);
+              onClose();
+            })();
+          },
+        },
+      });
     } catch (err) {
       showToast('error', formatError(err));
+    } finally {
       setBusy(null);
     }
   };

--- a/apps/desktop/src/features/permissions/components/DiffViewerDialog/index.test.tsx
+++ b/apps/desktop/src/features/permissions/components/DiffViewerDialog/index.test.tsx
@@ -9,7 +9,12 @@ type DiffViewSelectorMockProps = {
   onChange: (view: DiffView) => void;
 };
 
-const { state, fixtures } = vi.hoisted(() => ({
+type ToastAction = { readonly label: string; readonly onClick: () => void };
+
+type ToastOptions = { readonly title?: string; readonly action?: ToastAction };
+
+const { showToast, state, fixtures } = vi.hoisted(() => ({
+  showToast: vi.fn<(kind: string, message: string, opts?: ToastOptions) => void>(),
   state: {
     settings: {} as Record<string, string>,
     sessionPhaseRuns: {} as Record<string, ReadonlyArray<unknown>>,
@@ -29,6 +34,9 @@ const { state, fixtures } = vi.hoisted(() => ({
     reopenDiffComment: vi.fn(async () => undefined),
     deleteDiffComment: vi.fn(async () => undefined),
     selectAgent: vi.fn(async () => undefined),
+    setActiveLens: vi.fn(),
+    beginSessionCreation: vi.fn(() => 'creation-1'),
+    endSessionCreation: vi.fn(),
     spawnAgent: vi.fn(async () => 'a1'),
     sendTurn: vi.fn(async () => undefined),
   },
@@ -65,7 +73,7 @@ vi.mock('../../../../features/github/github', () => ({
 }));
 
 vi.mock('../../../../app/components/Toast', () => ({
-  useToast: () => ({ showToast: vi.fn() }),
+  useToast: () => ({ showToast }),
 }));
 
 vi.mock('../../../../features/worktree/worktree', () => ({
@@ -101,7 +109,9 @@ beforeEach(() => {
   state.loadDiffComments = vi.fn(async () => undefined);
   state.addDiffComment = vi.fn(async () => undefined);
   state.selectAgent.mockClear();
+  state.setActiveLens.mockClear();
   state.spawnAgent.mockClear();
+  showToast.mockClear();
   fixtures.files = [];
   fixtures.comments = [];
   fixtures.status.hasUpstream = false;
@@ -225,6 +235,18 @@ describe('DiffViewerPane', () => {
     expect(screen.queryByText('1 file')).toBeNull();
   });
 
+  it('keeps the diff on screen when the rebase starts and opens the agent only on request', async () => {
+    fixtures.files = fileFixture();
+    render(<DiffViewerPane sessionId={SID} worktreePath="/tmp/worktree" onClose={vi.fn()} />);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Rebase' }));
+
+    await waitFor(() => expect(showToast).toHaveBeenCalledOnce());
+    expect(showToast.mock.calls[0]?.[2]?.title).toBe('Rebase started');
+    expect(state.selectAgent).not.toHaveBeenCalled();
+    expect(await screen.findByRole('button', { name: 'Rebase' })).toBeDefined();
+  });
+
   it('spawns a rebase agent with the resolved task model when behind main', async () => {
     fixtures.files = fileFixture();
     state.workspaceOverrides = {
@@ -246,9 +268,10 @@ describe('DiffViewerPane', () => {
         provider: 'codex',
         model: 'gpt-5.4',
         effort: 'low',
+        focus: 'none',
       }),
     );
-    await waitFor(() => expect(state.selectAgent).toHaveBeenCalledWith(SID, 'a1'));
+    expect(state.selectAgent).not.toHaveBeenCalled();
   });
 
   it('surfaces rebase agent failures beside the action', async () => {

--- a/apps/desktop/src/features/plans/components/PlanStudio/PlanListPanel.tsx
+++ b/apps/desktop/src/features/plans/components/PlanStudio/PlanListPanel.tsx
@@ -1,10 +1,12 @@
-import { X } from 'lucide-react';
+import { useState } from 'react';
+import { CircleCheck, X } from 'lucide-react';
 import { Divider, ResizeHandle, ScrollFade, SelectableRow, cn } from '@goodboy/ui';
 import type { PlanId, PlanWithCount } from '@goodboy/types';
 import { useColumnWidth } from '../../../../shared/hooks/useColumnWidth';
 import { STORAGE_KEYS } from '../../../../shared/lib/storage-keys';
 import { fmtTimestamp } from './fmtTimestamp';
 import { planStatusBadge } from './planStatusBadge';
+import { FiledItemsToggle } from '../../../../shared/components/FiledItemsToggle';
 
 type Props = {
   readonly plans: ReadonlyArray<PlanWithCount>;
@@ -15,6 +17,10 @@ type Props = {
 
 export const PlanListPanel = ({ plans, selectedId, onSelect, onClose }: Props) => {
   const [width, setWidth] = useColumnWidth(STORAGE_KEYS.planListWidth, 320);
+  const [showFiled, setShowFiled] = useState(false);
+  const active = plans.filter((plan) => plan.status === 'active');
+  const filed = plans.filter((plan) => plan.status !== 'active');
+  const visible = showFiled ? [...active, ...filed] : active;
 
   return (
     <div className="flex min-h-0 shrink-0">
@@ -42,7 +48,7 @@ export const PlanListPanel = ({ plans, selectedId, onSelect, onClose }: Props) =
         <Divider />
         <ScrollFade className="min-h-0 flex-1">
           <ul className="flex w-full flex-col gap-1 px-3 py-3">
-            {plans.map((plan, idx) => {
+            {visible.map((plan, idx) => {
               const badge = planStatusBadge({ status: plan.status });
               return (
                 <li key={plan.id}>
@@ -77,6 +83,16 @@ export const PlanListPanel = ({ plans, selectedId, onSelect, onClose }: Props) =
               );
             })}
           </ul>
+          <div className="px-3 pb-3">
+            <FiledItemsToggle
+              noun="consumed"
+              items="plans"
+              count={filed.length}
+              isShown={showFiled}
+              icon={CircleCheck}
+              onChange={setShowFiled}
+            />
+          </div>
         </ScrollFade>
       </div>
     </div>

--- a/apps/desktop/src/features/plans/components/PlanStudio/index.test.tsx
+++ b/apps/desktop/src/features/plans/components/PlanStudio/index.test.tsx
@@ -193,9 +193,12 @@ describe('PlanStudio subpage', () => {
     expect(screen.getByText('beta body')).toBeDefined();
 
     fireEvent.click(screen.getByRole('button', { name: 'Other plans (1)' }));
+    expect(container.querySelectorAll('li')).toHaveLength(1);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show consumed (1)' }));
     expect(container.querySelectorAll('li')).toHaveLength(2);
 
-    fireEvent.click(screen.getByRole('button', { name: /plan 1 consumed Alpha plan/i }));
+    fireEvent.click(screen.getByRole('button', { name: /plan 2 consumed Alpha plan/i }));
     expect(screen.getByText('alpha body')).toBeDefined();
     expect(container.querySelectorAll('li')).toHaveLength(0);
   });

--- a/apps/desktop/src/features/session/components/ResolverAgentsLane/ResolverCard.test.tsx
+++ b/apps/desktop/src/features/session/components/ResolverAgentsLane/ResolverCard.test.tsx
@@ -5,6 +5,12 @@ import { cleanup, fireEvent, render, screen, within } from '@testing-library/rea
 import type { Agent, AgentId, SessionId, TelemetryRecord } from '@goodboy/types';
 import type { ResolverStatus } from '../../resolver-linkage';
 
+const lifecycle = vi.hoisted(() => ({
+  setAgentDone: vi.fn(),
+  clearAgentDone: vi.fn(),
+  deleteAgent: vi.fn(),
+}));
+
 vi.mock('../../../../store', () => ({
   agentHasUnread: () => false,
   useAppStore: <T,>(selector: (state: Record<string, unknown>) => T) =>
@@ -22,6 +28,9 @@ vi.mock('../../../../store', () => ({
       forceCloseResolver: vi.fn(),
       sendTurn: vi.fn(),
       selectAgent: vi.fn(),
+      setAgentDone: lifecycle.setAgentDone,
+      clearAgentDone: lifecycle.clearAgentDone,
+      deleteAgent: lifecycle.deleteAgent,
     }),
 }));
 
@@ -259,5 +268,40 @@ describe('ResolverCard', () => {
     fireEvent.click(details);
     expect(onInspect).toHaveBeenCalledOnce();
     expect(onOpenChat).toHaveBeenCalledOnce();
+  });
+
+  it('marks the resolver done from the card', () => {
+    renderCard();
+    fireEvent.click(screen.getByRole('button', { name: 'Mark resolver done' }));
+    expect(lifecycle.setAgentDone).toHaveBeenCalledWith(SID, 'resolver-1');
+  });
+
+  it('offers reopen instead of mark done once the resolver is done', () => {
+    renderCard({ run: { ...agent, doneAt: '2026-05-28T00:02:00Z' } as Agent });
+    expect(screen.queryByRole('button', { name: 'Mark resolver done' })).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'Reopen resolver' }));
+    expect(lifecycle.clearAgentDone).toHaveBeenCalledWith(SID, 'resolver-1');
+  });
+
+  it('deletes the resolver only after the confirm step', () => {
+    renderCard();
+    fireEvent.click(screen.getByRole('button', { name: 'Delete resolver' }));
+    expect(lifecycle.deleteAgent).not.toHaveBeenCalled();
+
+    const panel = screen.getByRole('group', { name: 'Delete this resolver?' });
+    fireEvent.click(within(panel).getByRole('button', { name: 'Delete' }));
+    expect(lifecycle.deleteAgent).toHaveBeenCalledWith(SID, 'resolver-1');
+  });
+
+  it('keeps the lifecycle actions in their own slot, away from navigation', () => {
+    renderCard();
+    const lifecycleSlot = screen.getByRole('group', { name: 'Agent lifecycle actions' });
+    expect(lifecycleSlot.contains(screen.getByRole('button', { name: 'Delete resolver' }))).toBe(
+      true,
+    );
+    const navigationSlot = screen.getByRole('group', { name: 'Agent navigation actions' });
+    expect(navigationSlot.contains(screen.getByRole('button', { name: 'Delete resolver' }))).toBe(
+      false,
+    );
   });
 });

--- a/apps/desktop/src/features/session/components/ResolverAgentsLane/ResolverCard.tsx
+++ b/apps/desktop/src/features/session/components/ResolverAgentsLane/ResolverCard.tsx
@@ -1,5 +1,14 @@
-import { FileDiff, GitCommitHorizontal, MessageSquareReply, PanelRight } from 'lucide-react';
-import { Chip } from '@goodboy/ui';
+import { useState } from 'react';
+import {
+  CircleCheck,
+  FileDiff,
+  GitCommitHorizontal,
+  MessageSquareReply,
+  PanelRight,
+  RotateCcw,
+  Trash2,
+} from 'lucide-react';
+import { Chip, InlineConfirm } from '@goodboy/ui';
 import type { Agent, DiffComment, PrComment, TelemetryRecord } from '@goodboy/types';
 import { agentHasUnread, useAppStore } from '../../../../store';
 import type { ProviderContextUsage } from '../../../workspace/components/WorkspacesSidebar/parts/ContextWindowBar';
@@ -78,6 +87,11 @@ export const ResolverCard = ({
   const plannedModel = useAppStore(
     (state) => state.agentModelOverride?.[agent.id] ?? agent.modelOverride ?? null,
   );
+  const setAgentDone = useAppStore((state) => state.setAgentDone);
+  const clearAgentDone = useAppStore((state) => state.clearAgentDone);
+  const deleteAgent = useAppStore((state) => state.deleteAgent);
+  const [isConfirmingDelete, setIsConfirmingDelete] = useState(false);
+  const canMarkDone = agent.status !== 'running' && agent.doneAt == null;
   const origin = resolverOrigin({ agent, hasDiffComment: diffComment !== null });
   const rowTitle = [
     agent.name,
@@ -149,6 +163,55 @@ export const ResolverCard = ({
           density="lane"
           plannedModel={plannedModel}
         />
+      }
+      lifecycleActions={
+        <>
+          <span className="flex size-6 shrink-0 items-center justify-center">
+            {canMarkDone && (
+              <AgentCardAction
+                icon={CircleCheck}
+                label="Mark resolver done"
+                tone="success"
+                reveal
+                onClick={() => void setAgentDone(agent.sessionId, agent.id)}
+              />
+            )}
+            {agent.doneAt != null && (
+              <AgentCardAction
+                icon={RotateCcw}
+                label="Reopen resolver"
+                reveal
+                onClick={() => void clearAgentDone(agent.sessionId, agent.id)}
+              />
+            )}
+          </span>
+          <span className="flex size-6 shrink-0 items-center justify-center">
+            <AgentCardAction
+              icon={Trash2}
+              label="Delete resolver"
+              tone="danger"
+              highlighted={isConfirmingDelete}
+              reveal={!isConfirmingDelete}
+              onClick={() => setIsConfirmingDelete(true)}
+            />
+          </span>
+        </>
+      }
+      confirmation={
+        isConfirmingDelete ? (
+          <InlineConfirm
+            role="danger"
+            icon={<Trash2 size={12} aria-hidden />}
+            title="Delete this resolver?"
+            description="Removes this resolver and its transcript from the session."
+            confirmLabel="Delete"
+            onConfirm={() => {
+              setIsConfirmingDelete(false);
+              void deleteAgent(agent.sessionId, agent.id);
+            }}
+            onCancel={() => setIsConfirmingDelete(false)}
+          />
+        ) : null
       }
       footer={
         <ResolverCardAction

--- a/apps/desktop/src/features/session/components/ResolverAgentsLane/index.tsx
+++ b/apps/desktop/src/features/session/components/ResolverAgentsLane/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, type ReactNode } from 'react';
 import type { AgentId, Session } from '@goodboy/types';
 import { EmptyState } from '@goodboy/ui';
 import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../shared/components/conceptIcons';
@@ -20,6 +20,7 @@ type Props = {
   readonly onInspectResolver: (agentId: AgentId) => void;
   readonly showCompleted?: boolean;
   readonly onCompletedCountChange?: (completedCount: number) => void;
+  readonly filedToggle?: ReactNode;
 };
 
 export const ResolverAgentsLane = ({
@@ -28,6 +29,7 @@ export const ResolverAgentsLane = ({
   onInspectResolver,
   showCompleted = false,
   onCompletedCountChange,
+  filedToggle,
 }: Props) => {
   const lane = useResolverAgentsLane({ session });
   const hasNoResolvers = lane.totalCount === 0;
@@ -67,7 +69,7 @@ export const ResolverAgentsLane = ({
         ) : null
       }
     >
-      {hasVisibleEntries ? (
+      {hasVisibleEntries || filedToggle != null ? (
         <div className="flex flex-col gap-5">
           {hasActiveEntries ? (
             <ResolverRows
@@ -91,6 +93,7 @@ export const ResolverAgentsLane = ({
               onOpenDiff={lane.onOpenDiff}
             />
           ) : null}
+          {filedToggle}
           {showCompleted && lane.completedEntries.length > 0 ? (
             <ResolverRows
               entries={lane.completedEntries}

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ActivitySection.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ActivitySection.tsx
@@ -6,6 +6,7 @@ import { PendingResolutionsStrip } from '../../../context/components/ContextPane
 import type { WorkspaceRuns } from '../../../orchestration/hooks/useWorkspaceRuns';
 import { CreateAgentPopover } from '../CreateAgentPopover';
 import { ActivityEmptyState } from './ActivityEmptyState';
+import { InFlightActionsStrip } from './InFlightActionsStrip';
 import { PipelineSection } from './PipelineSection';
 import { SummaryRow } from './SummaryRow';
 
@@ -56,6 +57,7 @@ export const ActivitySection = ({
           </div>
         )}
       </div>
+      <InFlightActionsStrip sessionId={sessionId} />
       {isFresh ? (
         <ActivityEmptyState sessionId={sessionId} onOpenWorkflowBuilder={onOpenWorkflowBuilder} />
       ) : (

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/InFlightActionsStrip.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/InFlightActionsStrip.tsx
@@ -1,0 +1,34 @@
+import type { SessionId } from '@goodboy/types';
+import { StatusDot } from '@goodboy/ui';
+import { useAppStore } from '../../../../store';
+import { sessionCreationLabel } from './sessionCreationLabel';
+
+type Props = {
+  readonly sessionId: SessionId;
+};
+
+export const InFlightActionsStrip = ({ sessionId }: Props) => {
+  const creations = useAppStore((state) => state.sessionCreations[sessionId]);
+  const inFlight = creations ?? [];
+
+  if (inFlight.length === 0) {
+    return null;
+  }
+
+  return (
+    <ul
+      aria-live="polite"
+      aria-label="Actions in flight"
+      className="flex flex-col gap-1.5 rounded-lg border border-border-soft bg-subtle px-3 py-2"
+    >
+      {inFlight.map((creation) => (
+        <li key={creation.id} className="flex items-center gap-2">
+          <StatusDot tone="info" size="sm" pulsing />
+          <span className="min-w-0 flex-1 truncate text-xs text-muted-foreground">
+            {sessionCreationLabel({ creation })}
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+};

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/index.test.tsx
@@ -44,6 +44,10 @@ type Store = {
   agentKindOverride: Record<string, unknown>;
   messages: Record<string, ReadonlyArray<unknown>>;
   providers: ReadonlyArray<{ id: string; connection: string }>;
+  sessionCreations: Record<
+    string,
+    ReadonlyArray<{ id: string; kind: string; label: string | null; startedAt: string }>
+  >;
 };
 
 type Runs = {
@@ -83,6 +87,10 @@ const { store, hooks, runs } = vi.hoisted(() => ({
     agentKindOverride: {} as Record<string, unknown>,
     messages: {} as Record<string, ReadonlyArray<unknown>>,
     providers: [{ id: 'anthropic', connection: 'connected' }],
+    sessionCreations: {} as Record<
+      string,
+      ReadonlyArray<{ id: string; kind: string; label: string | null; startedAt: string }>
+    >,
   } as Store,
   hooks: {
     workspace: { id: 'ws-1', name: 'My workspace' } as Workspace | null,
@@ -257,6 +265,7 @@ beforeEach(() => {
   store.sessionPendingResolutions = {};
   store.agentKindOverride = {};
   store.messages = {};
+  store.sessionCreations = {};
   hooks.workspace = { id: 'ws-1', name: 'My workspace' } as Workspace;
   hooks.openQuestions = [];
   hooks.stage = { stage: 'building', reason: '' } as SessionStageInfo;
@@ -568,6 +577,21 @@ describe('SessionOverviewPane activity', () => {
     fireEvent.click(screen.getByText('1 completed agent'));
     expect(onSelectLens).toHaveBeenCalledWith('agents');
     expect(store.setFocusedWorkflowRun).not.toHaveBeenCalled();
+  });
+
+  it('shows a branch action started elsewhere as in flight', () => {
+    store.sessionCreations = {
+      'sess-1': [
+        {
+          id: 'creation-1',
+          kind: 'branch',
+          label: 'Rebasing on main',
+          startedAt: '2026-08-04T10:00:00.000Z',
+        },
+      ],
+    };
+    renderPane();
+    expect(screen.getByText('Rebasing on main')).toBeDefined();
   });
 
   it('offers the batched push once resolutions are queued', async () => {

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/sessionCreationLabel.ts
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/sessionCreationLabel.ts
@@ -1,0 +1,15 @@
+import type { SessionCreation } from '../../../../store/slices/session-view';
+
+type Params = {
+  readonly creation: SessionCreation;
+};
+
+export const sessionCreationLabel = ({ creation }: Params): string => {
+  if (creation.kind === 'branch') {
+    return creation.label ?? 'Working on the branch';
+  }
+  if (creation.kind === 'workflow') {
+    return creation.label == null ? 'Starting a workflow' : `Starting ${creation.label}`;
+  }
+  return creation.label == null ? 'Creating an agent' : `Creating ${creation.label}`;
+};

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/AgentsPane.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/AgentsPane.test.tsx
@@ -34,11 +34,13 @@ vi.mock('../../StandaloneAgentsLane', () => ({
     inspectedAgentId,
     showCompleted,
     onCompletedCountChange,
+    filedToggle,
   }: {
     readonly variant?: string;
     readonly inspectedAgentId?: string | null;
     readonly showCompleted?: boolean;
     readonly onCompletedCountChange?: (completedCount: number) => void;
+    readonly filedToggle?: React.ReactNode;
   }) => (
     <>
       <div
@@ -46,7 +48,9 @@ vi.mock('../../StandaloneAgentsLane', () => ({
         data-variant={variant}
         data-inspected={String(inspectedAgentId)}
         data-show-completed={String(showCompleted)}
-      />
+      >
+        {filedToggle}
+      </div>
       <button type="button" onClick={() => onCompletedCountChange?.(2)}>
         Report completed agents
       </button>
@@ -108,7 +112,7 @@ describe('AgentsPane', () => {
     expect(lane.getAttribute('data-inspected')).toBe('agent-7');
   });
 
-  it('places the completed toggle before create and forwards its state', () => {
+  it('places the completed toggle after the list, not in the header, and forwards its state', () => {
     const onShowCompletedChange = vi.fn();
     render(
       <AgentsPane
@@ -122,9 +126,11 @@ describe('AgentsPane', () => {
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'Report completed agents' }));
-    const toggle = screen.getByRole('button', { name: 'Completed (2)' });
+    const toggle = screen.getByRole('button', { name: 'Show completed (2)' });
     const create = screen.getByTestId('header-spawn');
-    expect(toggle.compareDocumentPosition(create) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    const lane = screen.getByTestId('agents-lane');
+    expect(create.compareDocumentPosition(toggle) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(lane.contains(toggle)).toBe(true);
     fireEvent.click(toggle);
     expect(onShowCompletedChange).toHaveBeenCalledWith(true);
     expect(screen.getByTestId('agents-lane').getAttribute('data-show-completed')).toBe('false');

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/AgentsPane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/AgentsPane.tsx
@@ -1,12 +1,12 @@
 import { useState } from 'react';
 import { CircleCheck } from 'lucide-react';
-import { CountToggle } from '@goodboy/ui';
 import type { AgentId, Session, SessionId } from '@goodboy/types';
 import { AgentInspector } from '../../AgentInspector';
 import { CreateAgentPopover } from '../../CreateAgentPopover';
 import { StandaloneAgentsLane } from '../../StandaloneAgentsLane';
 import { InspectorSplit } from './InspectorSplit';
 import { PaneShell } from '../../../../../shared/components/PaneShell';
+import { FiledItemsToggle } from '../../../../../shared/components/FiledItemsToggle';
 
 type Props = {
   readonly session: Session;
@@ -45,19 +45,7 @@ export const AgentsPane = ({
         title="Agents"
         description="Agents you spawn by hand to work this session."
         meta={meta}
-        actions={
-          <>
-            <CountToggle
-              label="Completed"
-              count={completedCount}
-              isShown={showCompleted}
-              icon={CircleCheck}
-              itemsLabel="agents"
-              onChange={onShowCompletedChange}
-            />
-            <CreateAgentPopover sessionId={sessionId} variant="compact" />
-          </>
-        }
+        actions={<CreateAgentPopover sessionId={sessionId} variant="compact" />}
       >
         <StandaloneAgentsLane
           session={session}
@@ -66,6 +54,16 @@ export const AgentsPane = ({
           onInspectAgent={(agentId) => onInspectAgent(agentId)}
           showCompleted={showCompleted}
           onCompletedCountChange={setCompletedCount}
+          filedToggle={
+            <FiledItemsToggle
+              noun="completed"
+              items="agents"
+              count={completedCount}
+              isShown={showCompleted}
+              icon={CircleCheck}
+              onChange={onShowCompletedChange}
+            />
+          }
         />
       </PaneShell>
     </InspectorSplit>

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/QuestionsPane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/QuestionsPane.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Bot, Check } from 'lucide-react';
-import { CountToggle } from '@goodboy/ui';
 import { LensEmptyState } from '../../../../../shared/components/LensEmptyState';
 import type {
   Agent,
@@ -32,6 +31,7 @@ import {
 } from '../../../../context/components/QuestionsTab/useOpenQuestions';
 import { selectOpenQuestions } from '../../SessionOverviewPane/lib';
 import { PaneShell } from '../../../../../shared/components/PaneShell';
+import { FiledItemsToggle } from '../../../../../shared/components/FiledItemsToggle';
 import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../../shared/components/conceptIcons';
 
 type AnswerPair = { id: OpenQuestionId; text: string; answer: string };
@@ -328,23 +328,8 @@ export const QuestionsPane = ({ session }: QuestionsPaneProps) => {
 
   if (open.length === 0 && pendingUndoQuestion === null) {
     return (
-      <PaneShell
-        title="Questions"
-        description="Decisions agents need from you to keep going."
-        actions={
-          <CountToggle
-            label="Answered"
-            count={answered.length}
-            isShown={showAnswered}
-            icon={Check}
-            itemsLabel="questions"
-            onChange={setShowAnswered}
-          />
-        }
-      >
-        {showAnswered ? (
-          <AnsweredHistory clusters={answeredClusters} sessionId={sessionId} />
-        ) : (
+      <PaneShell title="Questions" description="Decisions agents need from you to keep going.">
+        {showAnswered ? null : (
           <LensEmptyState
             tone={CONCEPT_TONE.questions}
             icon={CONCEPT_ICONS.questions}
@@ -352,6 +337,17 @@ export const QuestionsPane = ({ session }: QuestionsPaneProps) => {
             description={`Every question on this session is answered. Reveal the ${answered.length} answered ${answered.length === 1 ? 'one' : 'ones'} to reread them.`}
           />
         )}
+        <FiledItemsToggle
+          noun="answered"
+          items="questions"
+          count={answered.length}
+          isShown={showAnswered}
+          icon={Check}
+          onChange={setShowAnswered}
+        />
+        {showAnswered ? (
+          <AnsweredHistory clusters={answeredClusters} sessionId={sessionId} />
+        ) : null}
       </PaneShell>
     );
   }
@@ -363,16 +359,6 @@ export const QuestionsPane = ({ session }: QuestionsPaneProps) => {
         open.length > 0
           ? `${open.length} open ${open.length === 1 ? 'question' : 'questions'} waiting on you.`
           : 'Decisions agents need from you to keep going.'
-      }
-      actions={
-        <CountToggle
-          label="Answered"
-          count={answered.length}
-          isShown={showAnswered}
-          icon={Check}
-          itemsLabel="questions"
-          onChange={setShowAnswered}
-        />
       }
     >
       <div className="flex flex-col gap-4">
@@ -394,6 +380,14 @@ export const QuestionsPane = ({ session }: QuestionsPaneProps) => {
             onSubmit={(pairs, ownerAgentId) => void handleSubmit(pairs, ownerAgentId)}
           />
         ))}
+        <FiledItemsToggle
+          noun="answered"
+          items="questions"
+          count={answered.length}
+          isShown={showAnswered}
+          icon={Check}
+          onChange={setShowAnswered}
+        />
         {showAnswered ? (
           <AnsweredHistory clusters={answeredClusters} sessionId={sessionId} />
         ) : null}

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/ResolvePane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/ResolvePane.tsx
@@ -1,11 +1,11 @@
 import { useState } from 'react';
 import { CircleCheck } from 'lucide-react';
-import { CountToggle } from '@goodboy/ui';
 import type { AgentId, Session, SessionId } from '@goodboy/types';
 import { ResolverAgentsLane } from '../../ResolverAgentsLane';
 import { AgentInspector } from '../../AgentInspector';
 import { InspectorSplit } from './InspectorSplit';
 import { PaneShell } from '../../../../../shared/components/PaneShell';
+import { FiledItemsToggle } from '../../../../../shared/components/FiledItemsToggle';
 import { WorkSurfaceBackButton } from '../../../../../shared/components/WorkSurfaceBackButton';
 
 type Props = {
@@ -45,19 +45,7 @@ export const ResolvePane = ({
         title="Resolve"
         description="Resolver agents spawned from pull request comments and diff selections."
         meta={meta}
-        actions={
-          <>
-            <WorkSurfaceBackButton sessionId={sessionId} />
-            <CountToggle
-              label="Completed"
-              count={completedCount}
-              isShown={showCompleted}
-              icon={CircleCheck}
-              itemsLabel="agents"
-              onChange={onShowCompletedChange}
-            />
-          </>
-        }
+        actions={<WorkSurfaceBackButton sessionId={sessionId} />}
       >
         <ResolverAgentsLane
           session={session}
@@ -65,6 +53,16 @@ export const ResolvePane = ({
           onInspectResolver={(agentId) => onInspectResolver(agentId)}
           showCompleted={showCompleted}
           onCompletedCountChange={setCompletedCount}
+          filedToggle={
+            <FiledItemsToggle
+              noun="completed"
+              items="resolvers"
+              count={completedCount}
+              isShown={showCompleted}
+              icon={CircleCheck}
+              onChange={onShowCompletedChange}
+            />
+          }
         />
       </PaneShell>
     </InspectorSplit>

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/SessionGitActions.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/SessionGitActions.test.tsx
@@ -1,0 +1,146 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { Session, SessionId, WorktreeStatus } from '@goodboy/types';
+
+type PushResult = { ok: true } | { ok: false; error: string };
+
+const h = vi.hoisted(() => ({
+  state: {
+    sessions: [
+      {
+        id: 'session-1',
+        workspaceId: 'workspace-1',
+        providerPreference: { defaultProvider: 'anthropic' },
+      },
+    ],
+    workspaceOverrides: {},
+    sessionPhaseRuns: {} as Record<
+      string,
+      ReadonlyArray<{ id: string; name: string; status: string }>
+    >,
+    sessionCreations: {},
+    spawnAgent: vi.fn(async () => 'agent-1'),
+    selectAgent: vi.fn(async () => undefined),
+    setActiveLens: vi.fn(),
+    emitNotification: vi.fn(async () => undefined),
+    pushSessionBranch: vi.fn(async (): Promise<PushResult> => ({ ok: true })),
+    beginSessionCreation: vi.fn(() => 'creation-1'),
+    endSessionCreation: vi.fn(),
+  },
+  worktreeStatus: vi.fn(
+    async (): Promise<WorktreeStatus> =>
+      ({ ahead: 1, commitsBehindMain: 2 }) as unknown as WorktreeStatus,
+  ),
+}));
+
+vi.mock('../../../../../store', () => ({
+  useAppStore: <T,>(selector: (state: typeof h.state) => T) => selector(h.state),
+}));
+
+vi.mock('../../../../worktree/worktree', () => ({
+  worktreeStatus: h.worktreeStatus,
+}));
+
+vi.mock('../../../../../store/slices/worktrees/resolveSessionRepo', () => ({
+  resolveSessionRepo: () => ({
+    worktreePath: '/repo/.goodboy/worktrees/card-config',
+    mountName: null,
+  }),
+}));
+
+vi.mock('../../../components/AgentSpawnConfig/taskModelAgentSpawnConfig', () => ({
+  taskModelAgentSpawnConfig: () => ({
+    provider: 'anthropic',
+    model: 'haiku-4.5',
+    effort: 'low',
+    hint: '',
+  }),
+}));
+
+import { ToastProvider } from '../../../../../app/components/Toast';
+import { SessionGitActions } from './SessionGitActions';
+
+const SESSION_ID = 'session-1' as SessionId;
+
+const session = { id: SESSION_ID, workspaceId: 'workspace-1' } as unknown as Session;
+
+const renderActions = () =>
+  render(
+    <ToastProvider>
+      <SessionGitActions session={session} />
+    </ToastProvider>,
+  );
+
+const openMenu = () => {
+  fireEvent.click(screen.getByRole('button', { name: 'Branch actions' }));
+};
+
+beforeEach(() => {
+  h.state.sessionPhaseRuns = {};
+  h.state.spawnAgent.mockClear();
+  h.state.selectAgent.mockClear();
+  h.state.setActiveLens.mockClear();
+  h.state.pushSessionBranch.mockClear();
+  h.state.pushSessionBranch.mockResolvedValue({ ok: true });
+  h.state.beginSessionCreation.mockClear();
+  h.state.endSessionCreation.mockClear();
+});
+
+afterEach(cleanup);
+
+describe('SessionGitActions', () => {
+  it('keeps the user in place when the rebase starts and opens the agent only from the toast action', async () => {
+    const { rerender } = renderActions();
+    openMenu();
+    await waitFor(() =>
+      expect(
+        (screen.getByRole('menuitem', { name: 'Rebase on main' }) as HTMLButtonElement).disabled,
+      ).toBe(false),
+    );
+
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Rebase on main' }));
+
+    await waitFor(() => expect(screen.getByText('Rebase started')).toBeDefined());
+    expect(h.state.spawnAgent).toHaveBeenCalledWith(
+      SESSION_ID,
+      expect.objectContaining({ focus: 'none' }),
+    );
+    expect(h.state.selectAgent).not.toHaveBeenCalled();
+
+    h.state.sessionPhaseRuns = {
+      [SESSION_ID]: [{ id: 'agent-1', name: 'Rebase on main', status: 'completed' }],
+    };
+    rerender(
+      <ToastProvider>
+        <SessionGitActions session={session} />
+      </ToastProvider>,
+    );
+
+    const action = await screen.findByRole('button', { name: 'Open the rebase agent' });
+    expect(h.state.selectAgent).not.toHaveBeenCalled();
+
+    fireEvent.click(action);
+
+    expect(h.state.selectAgent).toHaveBeenCalledWith(SESSION_ID, 'agent-1');
+    expect(h.state.setActiveLens).toHaveBeenCalledWith(SESSION_ID, 'agents');
+  });
+
+  it('confirms a finished push without leaving the current view', async () => {
+    renderActions();
+    openMenu();
+    await waitFor(() =>
+      expect(
+        (screen.getByRole('menuitem', { name: 'Push branch' }) as HTMLButtonElement).disabled,
+      ).toBe(false),
+    );
+
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Push branch' }));
+
+    expect(await screen.findByText('Push started')).toBeDefined();
+    expect(await screen.findByText('Push done')).toBeDefined();
+    expect(h.state.pushSessionBranch).toHaveBeenCalledWith(SESSION_ID);
+    expect(h.state.selectAgent).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowsPane.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowsPane.test.tsx
@@ -237,7 +237,7 @@ describe('WorkflowsPane', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Completed (1)' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Show completed (1)' }));
 
     expect(screen.getByText('2 of 2 steps run')).toBeDefined();
     expect(screen.getByText('3m')).toBeDefined();
@@ -272,7 +272,7 @@ describe('WorkflowsPane', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Completed (1)' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Show completed (1)' }));
 
     expect(screen.getByText('1 step run')).toBeDefined();
     expect(screen.queryByText('1 of 2 steps run')).toBeNull();
@@ -319,7 +319,7 @@ describe('WorkflowsPane', () => {
     expect(screen.queryByText('First workflow')).toBeNull();
     expect(screen.getAllByRole('button', { name: 'Attach another workflow' })).toHaveLength(1);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Completed (2)' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Show completed (2)' }));
 
     expect(screen.getByTestId('workflow-empty').textContent).toContain('Nothing running');
     expect(screen.getByText('First workflow')).toBeDefined();
@@ -339,7 +339,7 @@ describe('WorkflowsPane', () => {
     expect(screen.queryByText('First workflow')).toBeNull();
     expect(screen.getByText('Second workflow')).toBeDefined();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Discarded (1)' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Show completed (1)' }));
 
     expect(screen.getByText('First workflow')).toBeDefined();
   });
@@ -356,7 +356,7 @@ describe('WorkflowsPane', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Completed (1)' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Show completed (1)' }));
     rerender(
       <WorkflowsPane
         session={buildSession({
@@ -380,7 +380,7 @@ describe('WorkflowsPane', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Discarded (1)' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Show completed (1)' }));
     fireEvent.click(screen.getByRole('button', { name: 'Restore' }));
 
     expect(store.restoreWorkflow).toHaveBeenCalledWith(SESSION_ID, 'run-1');
@@ -400,7 +400,7 @@ describe('WorkflowsPane', () => {
 
     expect(screen.queryByText('First workflow')).toBeNull();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Completed (1)' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Show completed (1)' }));
 
     expect(screen.getByText('First workflow')).toBeDefined();
   });

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowsPane.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowsPane.test.tsx
@@ -16,6 +16,7 @@ type Store = {
   lensGo: ReturnType<typeof vi.fn>;
   setFocusedWorkflowRun: ReturnType<typeof vi.fn>;
   restoreWorkflow: ReturnType<typeof vi.fn>;
+  makeWorkflowPreset: ReturnType<typeof vi.fn>;
 };
 
 type ButtonMockProps = React.ComponentProps<'button'>;
@@ -48,6 +49,7 @@ const store: Store = {
   lensGo: vi.fn(),
   setFocusedWorkflowRun: vi.fn(),
   restoreWorkflow: vi.fn(),
+  makeWorkflowPreset: vi.fn(),
 };
 
 vi.mock('../../../../../store', () => ({
@@ -90,6 +92,14 @@ vi.mock('@goodboy/ui', () => ({
   ScrollFade: ({ children }: ChildrenMockProps) => <div>{children}</div>,
   StatusDot: () => <span data-testid="status-dot" />,
   cn: (...values: ReadonlyArray<unknown>) => values.filter(Boolean).join(' '),
+  tintClasses: () => ({
+    text: '',
+    icon: '',
+    border: '',
+    ring: '',
+    bg: '',
+    hover: '',
+  }),
   formatUsd: (value: number) => `$${value.toFixed(2)}`,
   formatUsdPrecise: (value: number) => `$${value.toFixed(2)}`,
 }));
@@ -146,6 +156,7 @@ beforeEach(() => {
   store.agentRunHistory = {};
   store.focusedWorkflowRunId = {};
   store.setFocusedWorkflowRun.mockReset();
+  store.makeWorkflowPreset.mockReset();
   store.restoreWorkflow.mockReset();
 });
 
@@ -284,6 +295,33 @@ describe('WorkflowsPane', () => {
 
     expect(screen.getByTestId('workflow-detail').getAttribute('data-run-id')).toBe('run-2');
     expect(screen.queryByText('First workflow')).toBeNull();
+  });
+
+  it('offers make preset only for a workflow the user declined to save', () => {
+    store.phaseTemplates = {
+      [WORKSPACE_ID]: [
+        { ...firstWorkflow, isPreset: false } as Workflow,
+        { ...secondWorkflow, isPreset: true } as Workflow,
+      ],
+    };
+    store.focusedWorkflowRunId = { [SESSION_ID]: 'run-1' };
+    render(<WorkflowsPane session={buildSession({ runIds: ['run-1', 'run-2'] })} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Make preset' }));
+    expect(store.makeWorkflowPreset).toHaveBeenCalledWith(WORKSPACE_ID, 'workflow-1');
+  });
+
+  it('hides make preset for a workflow that already is one', () => {
+    store.phaseTemplates = {
+      [WORKSPACE_ID]: [
+        { ...firstWorkflow, isPreset: false } as Workflow,
+        { ...secondWorkflow, isPreset: true } as Workflow,
+      ],
+    };
+    store.focusedWorkflowRunId = { [SESSION_ID]: 'run-2' };
+    render(<WorkflowsPane session={buildSession({ runIds: ['run-1', 'run-2'] })} />);
+
+    expect(screen.queryByRole('button', { name: 'Make preset' })).toBeNull();
   });
 
   it('focuses a run when its card is clicked', () => {

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowsPane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowsPane.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Check } from 'lucide-react';
+import { BookmarkPlus, Check } from 'lucide-react';
 import type { Agent, Session, SessionId, Workflow, WorkflowRun } from '@goodboy/types';
 import { EMPTY_ARRAY, useAppStore } from '../../../../../store';
 import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../../shared/components/conceptIcons';
@@ -16,6 +16,7 @@ import { PaneShell } from '../../../../../shared/components/PaneShell';
 import { FocusedPane } from '../../../../../shared/components/PaneShell/FocusedPane';
 import { WorkSurfaceBackButton } from '../../../../../shared/components/WorkSurfaceBackButton';
 import { FiledItemsToggle } from '../../../../../shared/components/FiledItemsToggle';
+import { GhostActionButton } from '../../../../../shared/components/GhostActionButton';
 
 type Props = {
   readonly session: Session;
@@ -24,6 +25,7 @@ type Props = {
 export const WorkflowsPane = ({ session }: Props) => {
   const sessionId = session.id as SessionId;
   const attachedRuns = useAttachedWorkflowRuns({ session });
+  const makeWorkflowPreset = useAppStore((s) => s.makeWorkflowPreset);
   const phaseRuns = useAppStore(
     (state) => state.sessionPhaseRuns[sessionId] ?? (EMPTY_ARRAY as ReadonlyArray<Agent>),
   );
@@ -80,6 +82,16 @@ export const WorkflowsPane = ({ session }: Props) => {
         actions={
           <>
             <WorkSurfaceBackButton sessionId={sessionId} />
+            {focusedRun.workflow != null && focusedRun.workflow.isPreset === false ? (
+              <GhostActionButton
+                icon={BookmarkPlus}
+                label="Make preset"
+                title="Keep this configuration in the workspace presets"
+                onClick={() =>
+                  void makeWorkflowPreset(session.workspaceId, focusedRun.workflow!.id)
+                }
+              />
+            ) : null}
             {shouldShowHeaderAttach ? (
               <WorkflowAttachButton sessionId={sessionId} placement="header" />
             ) : null}

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowsPane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowsPane.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
-import { Ban, Check } from 'lucide-react';
-import { CountToggle } from '@goodboy/ui';
+import { Check } from 'lucide-react';
 import type { Agent, Session, SessionId, Workflow, WorkflowRun } from '@goodboy/types';
 import { EMPTY_ARRAY, useAppStore } from '../../../../../store';
 import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../../shared/components/conceptIcons';
@@ -16,6 +15,7 @@ import { useAgentMetrics } from '../../../hooks/useAgentMetrics';
 import { PaneShell } from '../../../../../shared/components/PaneShell';
 import { FocusedPane } from '../../../../../shared/components/PaneShell/FocusedPane';
 import { WorkSurfaceBackButton } from '../../../../../shared/components/WorkSurfaceBackButton';
+import { FiledItemsToggle } from '../../../../../shared/components/FiledItemsToggle';
 
 type Props = {
   readonly session: Session;
@@ -33,8 +33,7 @@ export const WorkflowsPane = ({ session }: Props) => {
   );
   const setFocusedWorkflowRun = useAppStore((state) => state.setFocusedWorkflowRun);
   const restoreWorkflow = useAppStore((state) => state.restoreWorkflow);
-  const [showCompleted, setShowCompleted] = useState(false);
-  const [showDiscarded, setShowDiscarded] = useState(false);
+  const [showFiled, setShowFiled] = useState(false);
   const { agentsByRunId, discarded, completed, active } = splitWorkflowRuns({
     attachedRuns,
     agents: phaseRuns,
@@ -98,27 +97,9 @@ export const WorkflowsPane = ({ session }: Props) => {
       description="Sequences of agents this session runs toward its goal."
       meta={hasRuns ? attachedRuns.length : undefined}
       actions={
-        <>
-          <CountToggle
-            label="Completed"
-            count={completed.length}
-            isShown={showCompleted}
-            icon={Check}
-            itemsLabel="workflows"
-            onChange={setShowCompleted}
-          />
-          <CountToggle
-            label="Discarded"
-            count={discarded.length}
-            isShown={showDiscarded}
-            icon={Ban}
-            itemsLabel="workflows"
-            onChange={setShowDiscarded}
-          />
-          {shouldShowHeaderAttach ? (
-            <WorkflowAttachButton sessionId={sessionId} placement="header" />
-          ) : null}
-        </>
+        shouldShowHeaderAttach ? (
+          <WorkflowAttachButton sessionId={sessionId} placement="header" />
+        ) : null
       }
     >
       {!hasRuns ? <WorkflowStartButton sessionId={sessionId} /> : null}
@@ -136,10 +117,18 @@ export const WorkflowsPane = ({ session }: Props) => {
         />
       ) : null}
       {active.length > 0 ? <ul className="flex flex-col gap-2">{active.map(renderCard)}</ul> : null}
-      {showCompleted && completed.length > 0 ? (
+      <FiledItemsToggle
+        noun="completed"
+        items="workflows"
+        count={completed.length + discarded.length}
+        isShown={showFiled}
+        icon={Check}
+        onChange={setShowFiled}
+      />
+      {showFiled && completed.length > 0 ? (
         <ul className="flex flex-col gap-2">{completed.map(renderCard)}</ul>
       ) : null}
-      {showDiscarded && discarded.length > 0 ? (
+      {showFiled && discarded.length > 0 ? (
         <ul className="flex flex-col gap-2">{discarded.map(renderCard)}</ul>
       ) : null}
     </PaneShell>

--- a/apps/desktop/src/features/session/components/StandaloneAgentsLane/index.tsx
+++ b/apps/desktop/src/features/session/components/StandaloneAgentsLane/index.tsx
@@ -80,6 +80,7 @@ export const StandaloneAgentsLane = ({
           isInspected={run.id === inspectedAgentId}
           onInspectAgent={onInspectAgent}
           onMarkDone={lane.onMarkDone}
+          onReopen={lane.onReopen}
           isMuted={muted}
           density={isLens ? 'lane' : 'sidebar'}
         />

--- a/apps/desktop/src/features/session/components/StandaloneAgentsLane/index.tsx
+++ b/apps/desktop/src/features/session/components/StandaloneAgentsLane/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, type ReactNode } from 'react';
 import type { Agent, AgentId, Session, SessionId } from '@goodboy/types';
 import { AdHocRow } from '../../../workspace/components/WorkspacesSidebar/parts/AdHocRow';
 import { AgentLane } from '../AgentLane';
@@ -23,6 +23,7 @@ type Props = {
   readonly onInspectAgent?: (agentId: AgentId) => void;
   readonly showCompleted?: boolean;
   readonly onCompletedCountChange?: (completedCount: number) => void;
+  readonly filedToggle?: ReactNode;
 };
 
 export const StandaloneAgentsLane = ({
@@ -33,6 +34,7 @@ export const StandaloneAgentsLane = ({
   onInspectAgent,
   showCompleted = false,
   onCompletedCountChange,
+  filedToggle,
 }: Props) => {
   const sessionId = session.id as SessionId;
   const lane = useStandaloneAgentsLane({ session });
@@ -121,9 +123,10 @@ export const StandaloneAgentsLane = ({
       }
       footer={error}
     >
-      {agents.length > 0 ? (
+      {agents.length > 0 || filedToggle != null ? (
         <div className="flex flex-col gap-5">
           {lane.activeAgents.length > 0 ? renderList(lane.activeAgents, false) : null}
+          {filedToggle}
           {showCompleted && lane.completedAgents.length > 0
             ? renderList(lane.completedAgents, true)
             : null}

--- a/apps/desktop/src/features/session/components/StandaloneAgentsLane/useStandaloneAgentsLane.ts
+++ b/apps/desktop/src/features/session/components/StandaloneAgentsLane/useStandaloneAgentsLane.ts
@@ -40,6 +40,7 @@ export const useStandaloneAgentsLane = ({ session }: Params) => {
   const renameAgent = useAppStore((state) => state.renameAgent);
   const deleteAgent = useAppStore((state) => state.deleteAgent);
   const setAgentDone = useAppStore((state) => state.setAgentDone);
+  const clearAgentDone = useAppStore((state) => state.clearAgentDone);
   const loading = useSessionLoading(sessionId);
   const metrics = useAgentMetrics({ sessionId });
 
@@ -177,6 +178,13 @@ export const useStandaloneAgentsLane = ({ session }: Params) => {
     [setAgentDone, sessionId],
   );
 
+  const onReopen = useCallback(
+    (agentId: AgentId) => {
+      void clearAgentDone(sessionId, agentId);
+    },
+    [clearAgentDone, sessionId],
+  );
+
   return {
     activeAgents,
     agentKindOverride,
@@ -192,6 +200,7 @@ export const useStandaloneAgentsLane = ({ session }: Params) => {
     metrics,
     onDeleteAgent,
     onMarkDone,
+    onReopen,
     onPickAgent,
     onRenameCommit,
     selectedAgentId,

--- a/apps/desktop/src/features/session/hooks/usePushBranch/index.test.ts
+++ b/apps/desktop/src/features/session/hooks/usePushBranch/index.test.ts
@@ -6,14 +6,23 @@ import type { SessionId } from '@goodboy/types';
 
 type PushResult = { ok: true } | { ok: false; error: string };
 
-const { state } = vi.hoisted(() => ({
+type ToastOptions = { readonly title?: string };
+
+const { showToast, state } = vi.hoisted(() => ({
+  showToast: vi.fn<(kind: string, message: string, opts?: ToastOptions) => void>(),
   state: {
     pushSessionBranch: vi.fn(async (): Promise<PushResult> => ({ ok: true })),
+    beginSessionCreation: vi.fn(() => 'creation-1'),
+    endSessionCreation: vi.fn(),
   },
 }));
 
 vi.mock('../../../../store', () => ({
   useAppStore: <T>(selector: (store: typeof state) => T) => selector(state),
+}));
+
+vi.mock('../../../../app/components/Toast', () => ({
+  useToast: () => ({ showToast }),
 }));
 
 import { usePushBranch } from './index';
@@ -23,6 +32,10 @@ const sessionId = 'session-1' as SessionId;
 beforeEach(() => {
   state.pushSessionBranch.mockReset();
   state.pushSessionBranch.mockResolvedValue({ ok: true });
+  state.beginSessionCreation.mockReset();
+  state.beginSessionCreation.mockReturnValue('creation-1');
+  state.endSessionCreation.mockReset();
+  showToast.mockClear();
 });
 
 afterEach(cleanup);
@@ -38,6 +51,22 @@ describe('usePushBranch', () => {
     expect(result.current.error).toBeNull();
   });
 
+  it('confirms the start and the end of a successful push in place', async () => {
+    const { result } = renderHook(() => usePushBranch({ sessionId }));
+
+    await act(() => result.current.run());
+
+    expect(showToast.mock.calls.map((call) => call[2]?.title)).toEqual([
+      'Push started',
+      'Push done',
+    ]);
+    expect(state.beginSessionCreation).toHaveBeenCalledWith(sessionId, {
+      kind: 'branch',
+      label: 'Pushing the branch',
+    });
+    expect(state.endSessionCreation).toHaveBeenCalledWith(sessionId, 'creation-1');
+  });
+
   it('surfaces an unsuccessful push result', async () => {
     state.pushSessionBranch.mockResolvedValueOnce({
       ok: false,
@@ -48,6 +77,8 @@ describe('usePushBranch', () => {
     await act(() => result.current.run());
 
     expect(result.current.error).toBe('remote rejected the branch');
+    expect(showToast.mock.calls.map((call) => call[2]?.title)).toEqual(['Push started']);
+    expect(state.endSessionCreation).toHaveBeenCalledWith(sessionId, 'creation-1');
   });
 
   it('surfaces a rejected push', async () => {

--- a/apps/desktop/src/features/session/hooks/usePushBranch/index.ts
+++ b/apps/desktop/src/features/session/hooks/usePushBranch/index.ts
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import type { SessionId } from '@goodboy/types';
 import { useAppStore } from '../../../../store';
+import { useToast } from '../../../../app/components/Toast';
 import { formatError } from '../../../../shared/lib/errors';
 
 type Params = {
@@ -14,8 +15,13 @@ type Result = {
   readonly run: () => Promise<void>;
 };
 
+const PUSH_PROGRESS_LABEL = 'Pushing the branch';
+
 export const usePushBranch = ({ sessionId, onError }: Params): Result => {
   const pushSessionBranch = useAppStore((state) => state.pushSessionBranch);
+  const beginSessionCreation = useAppStore((state) => state.beginSessionCreation);
+  const endSessionCreation = useAppStore((state) => state.endSessionCreation);
+  const { showToast } = useToast();
   const [isBusy, setIsBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -30,14 +36,22 @@ export const usePushBranch = ({ sessionId, onError }: Params): Result => {
     }
     setError(null);
     setIsBusy(true);
+    const creationId = beginSessionCreation(sessionId, {
+      kind: 'branch',
+      label: PUSH_PROGRESS_LABEL,
+    });
+    showToast('info', 'Pushing this branch to its remote.', { title: 'Push started' });
     try {
       const result = await pushSessionBranch(sessionId);
       if (!result.ok) {
         fail(result.error);
+        return;
       }
+      showToast('success', 'This branch is pushed to its remote.', { title: 'Push done' });
     } catch (failure) {
       fail(formatError(failure));
     } finally {
+      endSessionCreation(sessionId, creationId);
       setIsBusy(false);
     }
   };

--- a/apps/desktop/src/features/session/hooks/useRebaseAgent/index.test.ts
+++ b/apps/desktop/src/features/session/hooks/useRebaseAgent/index.test.ts
@@ -4,7 +4,12 @@ import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { SessionId, WorktreeStatus } from '@goodboy/types';
 
-const { state } = vi.hoisted(() => ({
+type ToastAction = { readonly label: string; readonly onClick: () => void };
+
+type ToastOptions = { readonly title?: string; readonly action?: ToastAction };
+
+const { showToast, state } = vi.hoisted(() => ({
+  showToast: vi.fn<(kind: string, message: string, opts?: ToastOptions) => void>(),
   state: {
     sessions: [
       {
@@ -20,14 +25,24 @@ const { state } = vi.hoisted(() => ({
         },
       },
     },
-    sessionPhaseRuns: {} as Record<string, ReadonlyArray<{ name: string; status: string }>>,
+    sessionPhaseRuns: {} as Record<
+      string,
+      ReadonlyArray<{ id: string; name: string; status: string }>
+    >,
     spawnAgent: vi.fn(async () => 'agent-1'),
     selectAgent: vi.fn(async () => undefined),
+    setActiveLens: vi.fn(),
+    beginSessionCreation: vi.fn(() => 'creation-1'),
+    endSessionCreation: vi.fn(),
   },
 }));
 
 vi.mock('../../../../store', () => ({
   useAppStore: <T>(selector: (store: typeof state) => T) => selector(state),
+}));
+
+vi.mock('../../../../app/components/Toast', () => ({
+  useToast: () => ({ showToast }),
 }));
 
 vi.mock('../../components/AgentSpawnConfig/taskModelAgentSpawnConfig', () => ({
@@ -53,6 +68,11 @@ beforeEach(() => {
   state.spawnAgent.mockResolvedValue('agent-1');
   state.selectAgent.mockReset();
   state.selectAgent.mockResolvedValue(undefined);
+  state.setActiveLens.mockReset();
+  state.beginSessionCreation.mockReset();
+  state.beginSessionCreation.mockReturnValue('creation-1');
+  state.endSessionCreation.mockReset();
+  showToast.mockClear();
 });
 
 afterEach(cleanup);
@@ -69,7 +89,7 @@ describe('useRebaseAgent', () => {
     expect(result.current.canRebase).toBe(true);
   });
 
-  it('spawns and selects the rebase agent with the resolved task model', async () => {
+  it('spawns the rebase agent with the resolved task model without selecting it', async () => {
     const { result } = renderHook(() => useRebaseAgent({ sessionId, status: status(2) }));
 
     await act(() => result.current.run());
@@ -84,7 +104,44 @@ describe('useRebaseAgent', () => {
         effort: 'low',
       }),
     );
+    expect(state.selectAgent).not.toHaveBeenCalled();
+  });
+
+  it('spawns without taking the focus and marks the branch action in flight', async () => {
+    const { result } = renderHook(() => useRebaseAgent({ sessionId, status: status(2) }));
+
+    await act(() => result.current.run());
+
+    expect(state.spawnAgent).toHaveBeenCalledWith(
+      sessionId,
+      expect.objectContaining({ focus: 'none' }),
+    );
+    expect(state.beginSessionCreation).toHaveBeenCalledWith(sessionId, {
+      kind: 'branch',
+      label: 'Rebasing on main',
+    });
+    expect(showToast.mock.calls[0]?.[2]?.title).toBe('Rebase started');
+  });
+
+  it('offers an action that opens the agent once the rebase settles', async () => {
+    const { result, rerender } = renderHook(() => useRebaseAgent({ sessionId, status: status(2) }));
+
+    await act(() => result.current.run());
+    state.sessionPhaseRuns = {
+      [sessionId]: [{ id: 'agent-1', name: 'Rebase on main', status: 'failed' }],
+    };
+    rerender();
+
+    await waitFor(() => expect(showToast).toHaveBeenCalledTimes(2));
+    expect(state.endSessionCreation).toHaveBeenCalledWith(sessionId, 'creation-1');
+    const action = showToast.mock.calls[1]?.[2]?.action;
+    expect(action?.label).toBe('Open the rebase agent');
+    expect(state.selectAgent).not.toHaveBeenCalled();
+
+    action?.onClick();
+
     expect(state.selectAgent).toHaveBeenCalledWith(sessionId, 'agent-1');
+    expect(state.setActiveLens).toHaveBeenCalledWith(sessionId, 'agents');
   });
 
   it('reports spawn failures', async () => {
@@ -94,11 +151,12 @@ describe('useRebaseAgent', () => {
     await act(() => result.current.run());
 
     expect(result.current.error).toBe('agent launch failed');
+    expect(state.endSessionCreation).toHaveBeenCalledWith(sessionId, 'creation-1');
   });
 
   it('guards against a second rebase while the named agent is running', async () => {
     state.sessionPhaseRuns = {
-      [sessionId]: [{ name: 'Rebase on main', status: 'running' }],
+      [sessionId]: [{ id: 'agent-9', name: 'Rebase on main', status: 'running' }],
     };
     const { result } = renderHook(() => useRebaseAgent({ sessionId, status: status(2) }));
 

--- a/apps/desktop/src/features/session/hooks/useRebaseAgent/index.ts
+++ b/apps/desktop/src/features/session/hooks/useRebaseAgent/index.ts
@@ -1,6 +1,8 @@
-import { useMemo, useState } from 'react';
-import type { SessionId, WorktreeStatus } from '@goodboy/types';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { AgentId, SessionId, WorktreeStatus } from '@goodboy/types';
 import { useAppStore } from '../../../../store';
+import type { SessionCreationId } from '../../../../store/slices/session-view';
+import { useToast } from '../../../../app/components/Toast';
 import { formatError } from '../../../../shared/lib/errors';
 import { taskModelAgentSpawnConfig } from '../../components/AgentSpawnConfig/taskModelAgentSpawnConfig';
 
@@ -17,7 +19,14 @@ type Result = {
   readonly run: () => Promise<void>;
 };
 
+type Pending = {
+  readonly agentId: AgentId;
+  readonly creationId: SessionCreationId;
+};
+
 const REBASE_AGENT_NAME = 'Rebase on main';
+
+const REBASE_PROGRESS_LABEL = 'Rebasing on main';
 
 const REBASE_PROMPT = [
   'Rebase this session branch onto origin/main.',
@@ -32,6 +41,9 @@ const REBASE_PROMPT = [
 export const useRebaseAgent = ({ sessionId, status, onError }: Params): Result => {
   const [isStarting, setIsStarting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState<Pending | null>(null);
+  const settledAgentIds = useRef(new Set<AgentId>());
+  const pendingRef = useRef<Pending | null>(null);
   const session = useAppStore((state) =>
     sessionId == null
       ? null
@@ -45,6 +57,10 @@ export const useRebaseAgent = ({ sessionId, status, onError }: Params): Result =
   );
   const spawnAgent = useAppStore((state) => state.spawnAgent);
   const selectAgent = useAppStore((state) => state.selectAgent);
+  const setActiveLens = useAppStore((state) => state.setActiveLens);
+  const beginSessionCreation = useAppStore((state) => state.beginSessionCreation);
+  const endSessionCreation = useAppStore((state) => state.endSessionCreation);
+  const { showToast } = useToast();
   const config = useMemo(
     () =>
       taskModelAgentSpawnConfig({
@@ -63,12 +79,64 @@ export const useRebaseAgent = ({ sessionId, status, onError }: Params): Result =
   const isRunning = isStarting || isAgentRunning;
   const canRebase = sessionId != null && status != null && status.commitsBehindMain > 0;
 
+  useEffect(() => {
+    pendingRef.current = pending;
+  }, [pending]);
+
+  useEffect(
+    () => () => {
+      const leftOver = pendingRef.current;
+      if (sessionId == null || leftOver == null) {
+        return;
+      }
+      pendingRef.current = null;
+      endSessionCreation(sessionId, leftOver.creationId);
+    },
+    [endSessionCreation, sessionId],
+  );
+
+  useEffect(() => {
+    if (sessionId == null || pending == null) {
+      return;
+    }
+    const agent = phaseRuns?.find((candidate) => candidate.id === pending.agentId) ?? null;
+    if (agent == null || (agent.status !== 'completed' && agent.status !== 'failed')) {
+      return;
+    }
+    if (settledAgentIds.current.has(pending.agentId)) {
+      return;
+    }
+    settledAgentIds.current.add(pending.agentId);
+    const agentId = pending.agentId;
+    const isFailed = agent.status === 'failed';
+    endSessionCreation(sessionId, pending.creationId);
+    setPending(null);
+    showToast(
+      isFailed ? 'error' : 'success',
+      isFailed ? 'The rebase agent stopped before finishing.' : 'This branch is rebased on main.',
+      {
+        title: isFailed ? 'Rebase failed' : 'Rebase done',
+        action: {
+          label: 'Open the rebase agent',
+          onClick: () => {
+            setActiveLens(sessionId, 'agents');
+            void selectAgent(sessionId, agentId);
+          },
+        },
+      },
+    );
+  }, [endSessionCreation, pending, phaseRuns, selectAgent, sessionId, setActiveLens, showToast]);
+
   const run = async (): Promise<void> => {
     if (!canRebase || isRunning || sessionId == null || config.provider === '') {
       return;
     }
     setError(null);
     setIsStarting(true);
+    const creationId = beginSessionCreation(sessionId, {
+      kind: 'branch',
+      label: REBASE_PROGRESS_LABEL,
+    });
     try {
       const agentId = await spawnAgent(sessionId, {
         name: REBASE_AGENT_NAME,
@@ -76,10 +144,14 @@ export const useRebaseAgent = ({ sessionId, status, onError }: Params): Result =
         model: config.model,
         provider: config.provider,
         effort: config.effort,
-        focus: 'agent',
+        focus: 'none',
       });
-      await selectAgent(sessionId, agentId);
+      setPending({ agentId, creationId });
+      showToast('info', 'An agent is rebasing this branch on main. You can keep working.', {
+        title: 'Rebase started',
+      });
     } catch (failure) {
+      endSessionCreation(sessionId, creationId);
       const message = formatError(failure);
       setError(message);
       onError?.(message);

--- a/apps/desktop/src/features/updater/components/UpdateIndicator/index.test.tsx
+++ b/apps/desktop/src/features/updater/components/UpdateIndicator/index.test.tsx
@@ -1,0 +1,58 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAppStore } from '../../../../store';
+import { UpdateIndicator } from './index';
+
+const installUpdate = vi.fn(async () => undefined);
+
+const setStatus = (status: 'idle' | 'available' | 'downloading') => {
+  useAppStore.setState({
+    updaterStatus: status,
+    updateVersion: '0.1.58',
+    installUpdate,
+  } as never);
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(cleanup);
+
+describe('UpdateIndicator', () => {
+  it('says nothing while there is no update', () => {
+    setStatus('idle');
+    render(<UpdateIndicator variant="pip" />);
+    expect(screen.queryByTestId('update-indicator')).toBeNull();
+  });
+
+  it('asks for attention while an update waits for the user', () => {
+    setStatus('available');
+    render(<UpdateIndicator variant="pip" />);
+    const chip = screen.getByTestId('update-indicator') as HTMLButtonElement;
+    expect(chip.textContent).toContain('Update to 0.1.58');
+    expect(chip.className).toContain('attention-ring');
+    expect(chip.className).not.toContain('spin-border');
+    expect(chip.disabled).toBe(false);
+  });
+
+  it('switches to a running border while the update downloads', () => {
+    setStatus('downloading');
+    render(<UpdateIndicator variant="pip" />);
+    const chip = screen.getByTestId('update-indicator') as HTMLButtonElement;
+    expect(chip.textContent).toContain('Updating to 0.1.58');
+    expect(chip.className).toContain('spin-border');
+    expect(chip.className).not.toContain('attention-ring');
+    expect(chip.disabled).toBe(true);
+  });
+
+  it('installs only after the confirmation is accepted', async () => {
+    setStatus('available');
+    render(<UpdateIndicator variant="pip" />);
+    await userEvent.click(screen.getByTestId('update-indicator'));
+    expect(installUpdate).not.toHaveBeenCalled();
+    await userEvent.click(screen.getByRole('button', { name: 'Update and restart' }));
+    expect(installUpdate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/features/updater/components/UpdateIndicator/index.tsx
+++ b/apps/desktop/src/features/updater/components/UpdateIndicator/index.tsx
@@ -40,7 +40,11 @@ export const UpdateIndicator = ({ variant }: Props) => {
       onClick={() => setConfirmOpen(true)}
       disabled={downloading}
       title={title}
-      className={cn('pointer-events-auto relative', downloading && 'animate-border-pulse')}
+      className={cn(
+        'pointer-events-auto relative',
+        downloading ? 'spin-border spin-border-primary' : 'attention-ring',
+      )}
+      testId="update-indicator"
     />
   );
 

--- a/apps/desktop/src/features/workflows/components/WorkflowsPanel/index.test.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowsPanel/index.test.tsx
@@ -105,7 +105,7 @@ describe('WorkflowsPanel', () => {
     expect(screen.queryByText('Deleted workflow')).toBeNull();
   });
 
-  it('lists draft workflows (isPreset=false) alongside approved ones', () => {
+  it('keeps a workflow the user declined to save out of the preset rail', () => {
     state.phaseTemplates = {
       'ws-1': [
         makeWorkflow({ name: 'Approved preset' }),
@@ -114,8 +114,7 @@ describe('WorkflowsPanel', () => {
     };
     renderPanel();
     expect(screen.getByText('Approved preset')).toBeDefined();
-    // drafts now appear with a status pill rather than being hidden
-    expect(screen.getByText('Draft workflow')).toBeDefined();
+    expect(screen.queryByText('Draft workflow')).toBeNull();
   });
 
   it('shows empty state when every template is soft-deleted', () => {

--- a/apps/desktop/src/features/workflows/components/WorkflowsPanel/index.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowsPanel/index.tsx
@@ -60,7 +60,7 @@ export const WorkflowsPanel = ({ workspaceId }: Props) => {
   const [formatOpen, setFormatOpen] = useState(false);
   const [preview, setPreview] = useState<FormattedWorkflow | null>(null);
 
-  const presets = templates.filter((t) => !t.deletedAt);
+  const presets = templates.filter((t) => !t.deletedAt && t.isPreset !== false);
 
   const editingIdRef = useRef<WorkflowId | null>(null);
   const approvedRef = useRef(approved);

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AdHocRow.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AdHocRow.tsx
@@ -30,6 +30,7 @@ type Props = {
   readonly isInspected?: boolean;
   readonly onInspectAgent?: (id: AgentId) => void;
   readonly onMarkDone: (id: AgentId) => void;
+  readonly onReopen?: (id: AgentId) => void;
   readonly isMuted?: boolean;
   readonly density?: AgentCardDensity;
 };
@@ -56,6 +57,7 @@ export const AdHocRow = ({
   isInspected = false,
   onInspectAgent,
   onMarkDone,
+  onReopen,
   isMuted = false,
   density = 'sidebar',
 }: Props) => {
@@ -86,6 +88,7 @@ export const AdHocRow = ({
         isInspected={isInspected}
         onInspect={onInspectAgent === undefined ? undefined : () => onInspectAgent(run.id)}
         onMarkDone={() => onMarkDone(run.id)}
+        {...(onReopen !== undefined && { onReopen: () => onReopen(run.id) })}
         isMuted={isMuted}
         density={density}
       />

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentRow.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentRow.test.tsx
@@ -236,12 +236,23 @@ describe('AgentRow', () => {
     expect(remove).toHaveBeenCalledOnce();
   });
 
-  it('drops mark done and delete from the lane density card, the inspector footer owns them there', () => {
+  it('keeps mark done and delete on the lane density card too', () => {
     renderRow(false, {}, 'lane');
 
-    expect(screen.queryByRole('button', { name: 'Mark agent done' })).toBeNull();
-    expect(screen.queryByRole('button', { name: 'Delete agent' })).toBeNull();
+    expect(screen.getByRole('button', { name: 'Mark agent done' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Delete agent' })).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Toggle agent details' })).toBeTruthy();
+  });
+
+  it('keeps every action in the same order whether or not the card is hovered', () => {
+    renderRow(false, {}, 'lane');
+    const labelsOf = () =>
+      Array.from(document.querySelectorAll('button')).map((button) =>
+        button.getAttribute('aria-label'),
+      );
+    const atRest = labelsOf();
+    fireEvent.mouseEnter(screen.getByRole('button', { name: 'Toggle agent details' }));
+    expect(labelsOf()).toEqual(atRest);
   });
 
   it('keeps mark done and delete on the sidebar density card', () => {

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentRow.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentRow.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { CircleCheck, PanelRight, Trash2 } from 'lucide-react';
+import { CircleCheck, PanelRight, RotateCcw, Trash2 } from 'lucide-react';
 import { InlineConfirm } from '@goodboy/ui';
 import { contextTokensForUsage } from '@goodboy/core';
 import type { Agent, TelemetryRecord } from '@goodboy/types';
@@ -42,6 +42,7 @@ type Props = {
   readonly isMuted?: boolean;
   readonly onInspect?: () => void;
   readonly onMarkDone?: () => void;
+  readonly onReopen?: () => void;
 };
 
 export const AgentRow = ({
@@ -65,6 +66,7 @@ export const AgentRow = ({
   isMuted = false,
   onInspect,
   onMarkDone,
+  onReopen,
 }: Props) => {
   const [isConfirmingDelete, setIsConfirmingDelete] = useState(false);
 
@@ -89,6 +91,7 @@ export const AgentRow = ({
   ].filter((part): part is string => part !== null);
   const isMarkDoneAvailable =
     onMarkDone !== undefined && run.status !== 'running' && run.doneAt == null;
+  const isReopenAvailable = onReopen !== undefined && run.doneAt != null;
   const hasUnread = agentHasUnread(run, isSelected && isTaskActive);
   const hoverMarkViewed = useHoverMarkViewed({
     sessionId: run.sessionId,
@@ -147,31 +150,37 @@ export const AgentRow = ({
         )
       }
       lifecycleActions={
-        density === 'sidebar' ? (
-          <>
-            <span className="flex size-6 shrink-0 items-center justify-center">
-              {isMarkDoneAvailable && (
-                <AgentCardAction
-                  icon={CircleCheck}
-                  label="Mark agent done"
-                  tone="success"
-                  reveal
-                  onClick={() => onMarkDone?.()}
-                />
-              )}
-            </span>
-            <span className="flex size-6 shrink-0 items-center justify-center">
+        <>
+          <span className="flex size-6 shrink-0 items-center justify-center">
+            {isMarkDoneAvailable && (
               <AgentCardAction
-                icon={Trash2}
-                label="Delete agent"
-                tone="danger"
-                highlighted={isConfirmingDelete}
-                reveal={!isConfirmingDelete}
-                onClick={() => setIsConfirmingDelete(true)}
+                icon={CircleCheck}
+                label="Mark agent done"
+                tone="success"
+                reveal
+                onClick={() => onMarkDone?.()}
               />
-            </span>
-          </>
-        ) : undefined
+            )}
+            {isReopenAvailable && (
+              <AgentCardAction
+                icon={RotateCcw}
+                label="Reopen agent"
+                reveal
+                onClick={() => onReopen?.()}
+              />
+            )}
+          </span>
+          <span className="flex size-6 shrink-0 items-center justify-center">
+            <AgentCardAction
+              icon={Trash2}
+              label="Delete agent"
+              tone="danger"
+              highlighted={isConfirmingDelete}
+              reveal={!isConfirmingDelete}
+              onClick={() => setIsConfirmingDelete(true)}
+            />
+          </span>
+        </>
       }
       status={
         <AgentKindChip

--- a/apps/desktop/src/shared/components/FiledItemsToggle/index.tsx
+++ b/apps/desktop/src/shared/components/FiledItemsToggle/index.tsx
@@ -1,0 +1,40 @@
+import type { LucideIcon } from 'lucide-react';
+import { cn } from '@goodboy/ui';
+
+type Props = {
+  readonly noun: string;
+  readonly items: string;
+  readonly count: number;
+  readonly isShown: boolean;
+  readonly icon: LucideIcon;
+  readonly onChange: (isShown: boolean) => void;
+};
+
+export const FiledItemsToggle = ({ noun, items, count, isShown, icon, onChange }: Props) => {
+  if (count === 0) {
+    return null;
+  }
+
+  const Icon = icon;
+  const action = isShown ? 'Hide' : 'Show';
+
+  return (
+    <div className="flex justify-center pt-1">
+      <button
+        type="button"
+        onClick={() => onChange(!isShown)}
+        aria-pressed={isShown}
+        title={`${action.toLowerCase()} the ${count} ${noun} ${items}`}
+        className={cn(
+          'flex h-7 items-center gap-1.5 rounded-md px-2 text-2xs font-medium transition-colors',
+          isShown
+            ? 'bg-primary/10 text-primary'
+            : 'text-muted-foreground hover:bg-foreground/5 hover:text-foreground',
+        )}
+      >
+        <Icon size={10} aria-hidden />
+        {action} {noun} ({count})
+      </button>
+    </div>
+  );
+};

--- a/apps/desktop/src/shared/components/RoutingPicker/resolveRouting.test.ts
+++ b/apps/desktop/src/shared/components/RoutingPicker/resolveRouting.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { PROVIDER_IDS, type ProviderId } from '@goodboy/types';
+import { MODEL_CATALOGS, modelAxes } from '@goodboy/core';
+import { resolveRouting } from './resolveRouting';
+
+const routingFor = ({ provider, model }: { provider: ProviderId; model: string }) =>
+  resolveRouting({ providers: [provider], provider, model, effort: 'medium' });
+
+describe('resolveRouting parity across providers', () => {
+  it('resolves every catalog model of every provider', () => {
+    for (const provider of PROVIDER_IDS) {
+      const catalog = MODEL_CATALOGS[provider];
+      expect(catalog.length, `${provider} has an empty catalog`).toBeGreaterThan(0);
+      for (const model of catalog) {
+        const routing = routingFor({ provider, model: model.key });
+        expect(routing.provider).toBe(provider);
+        expect(routing.model).toBe(model.key);
+      }
+    }
+  });
+
+  it('calls the effort fixed only when the picker offers no choice', () => {
+    const disagreements: string[] = [];
+    for (const provider of PROVIDER_IDS) {
+      for (const model of MODEL_CATALOGS[provider]) {
+        const routing = routingFor({ provider, model: model.key });
+        const axis = modelAxes({ model, selection: routing.selection }).effort;
+        const editable = (axis?.levels ?? []).filter((level) => level.available).length > 1;
+        if (editable === routing.isEffortFixed) {
+          disagreements.push(
+            `${provider}/${model.key}: axis offers ${axis?.levels.filter((l) => l.available).length ?? 0} levels, isEffortFixed=${routing.isEffortFixed}`,
+          );
+        }
+      }
+    }
+    expect(
+      disagreements,
+      `The trigger label and the effort chips must agree on whether effort is editable:\n${disagreements.join('\n')}`,
+    ).toEqual([]);
+  });
+
+  it('offers gemini the effort levels its catalog declares', () => {
+    const gemini = MODEL_CATALOGS.gemini.find((model) => model.efforts.length > 1);
+    expect(gemini, 'gemini should ship at least one model with a choice of efforts').toBeDefined();
+    if (gemini == null) {
+      return;
+    }
+    const routing = routingFor({ provider: 'gemini', model: gemini.key });
+    expect(routing.effortLevels).toEqual(gemini.efforts);
+    expect(routing.isEffortFixed).toBe(false);
+  });
+});

--- a/apps/desktop/src/shared/components/RoutingPicker/resolveRouting.ts
+++ b/apps/desktop/src/shared/components/RoutingPicker/resolveRouting.ts
@@ -62,8 +62,6 @@ const effortsFor = ({ model, selection, fallback }: EffortParams): ReadonlyArray
         .filter((effort) => effort != null);
       return efforts.length > 0 ? Array.from(new Set(efforts)) : [fallback];
     }
-    case 'gemini':
-      return [fallback];
     default: {
       const exhaustive: never = model;
       throw new Error(`unknown catalog model: ${String(exhaustive)}`);
@@ -119,11 +117,7 @@ export const resolveRouting = ({
     effort: appliedEffort,
     effortLevels,
     ...(resolved.clamped != null && { clamped: resolved.clamped }),
-    isEffortFixed:
-      selectedModel.provider === 'gemini' ||
-      (selectedModel.provider === 'anthropic' && selectedModel.efforts.length === 0) ||
-      (selectedModel.provider === 'cursor' &&
-        selectedModel.combos.every((combo) => combo.effort == null)),
+    isEffortFixed: effortLevels.length <= 1,
     models: catalog.map((candidate) => candidate.key),
     catalog,
     hasThinkingToggle,

--- a/apps/desktop/src/store/parallel-turn.ts
+++ b/apps/desktop/src/store/parallel-turn.ts
@@ -137,8 +137,12 @@ function parseProviderLine(
     case 'opencode':
     case 'openrouter':
       return parseOpenCodeJsonLine({ line, ctx });
-    default:
+    case 'anthropic':
       return parseStreamJsonLine(line, ctx);
+    default: {
+      const exhaustive: never = provider;
+      throw new Error(`unknown provider stream: ${String(exhaustive)}`);
+    }
   }
 }
 

--- a/apps/desktop/src/store/slices/providers/clearStaleConnect.ts
+++ b/apps/desktop/src/store/slices/providers/clearStaleConnect.ts
@@ -1,0 +1,28 @@
+import { PROVIDER_IDS, type ProviderId } from '@goodboy/types';
+import type { ProviderAuthResults } from '../../../features/providers/providers';
+import { IDLE_CONNECT, type ProviderConnectMap, type ProviderConnectPhase } from './types';
+
+const CLAIMS_CONNECTED: ReadonlySet<ProviderConnectPhase> = new Set<ProviderConnectPhase>([
+  'success',
+  'finished-unverified',
+]);
+
+type Params = {
+  readonly connect: ProviderConnectMap;
+  readonly authResults: ProviderAuthResults;
+};
+
+export const clearStaleConnect = ({ connect, authResults }: Params): ProviderConnectMap => {
+  const stale = PROVIDER_IDS.filter(
+    (id: ProviderId) =>
+      CLAIMS_CONNECTED.has(connect[id].phase) && authResults[id]?.state !== 'connected',
+  );
+  if (stale.length === 0) {
+    return connect;
+  }
+  const next = { ...connect };
+  for (const id of stale) {
+    next[id] = IDLE_CONNECT;
+  }
+  return next;
+};

--- a/apps/desktop/src/store/slices/providers/refreshProviders.test.ts
+++ b/apps/desktop/src/store/slices/providers/refreshProviders.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { refreshProviders } from './refreshProviders';
+import { IDLE_CONNECT, INITIAL_CONNECT_MAP } from './types';
 
 const providerMocks = vi.hoisted(() => {
   const status = {
@@ -30,6 +31,7 @@ describe('refreshProviders', () => {
     const set = vi.fn();
     const get = vi.fn(() => ({
       providerCredentials: [{ providerId: 'openrouter' }],
+      providerConnect: INITIAL_CONNECT_MAP,
     }));
     await refreshProviders(set as never, get as never)();
     expect(providerMocks.refreshProviderDetection).toHaveBeenCalledTimes(5);
@@ -44,5 +46,39 @@ describe('refreshProviders', () => {
       }),
     );
     expect(providerMocks.buildProviderList.mock.calls[0]?.[2]).toEqual(new Set(['openrouter']));
+  });
+
+  it('drops a connect state that still claims success once auth reports disconnected', async () => {
+    providerMocks.checkProviderAuth.mockImplementation(async () => ({
+      state: 'disconnected',
+      identity: null,
+    }));
+    const set = vi.fn();
+    const get = vi.fn(() => ({
+      providerCredentials: [],
+      providerConnect: {
+        ...INITIAL_CONNECT_MAP,
+        cursor: { ...IDLE_CONNECT, phase: 'success', identity: 'amin@serenis.it' },
+      },
+    }));
+    await refreshProviders(set as never, get as never)();
+    const patch = set.mock.calls[0]?.[0] as { providerConnect: typeof INITIAL_CONNECT_MAP };
+    expect(patch.providerConnect.cursor).toEqual(IDLE_CONNECT);
+  });
+
+  it('leaves a connect state alone while auth still reports connected', async () => {
+    providerMocks.checkProviderAuth.mockImplementation(async () => ({
+      state: 'connected',
+      identity: null,
+    }));
+    const set = vi.fn();
+    const connected = { ...IDLE_CONNECT, phase: 'success' as const, identity: 'amin@serenis.it' };
+    const get = vi.fn(() => ({
+      providerCredentials: [],
+      providerConnect: { ...INITIAL_CONNECT_MAP, cursor: connected },
+    }));
+    await refreshProviders(set as never, get as never)();
+    const patch = set.mock.calls[0]?.[0] as { providerConnect: typeof INITIAL_CONNECT_MAP };
+    expect(patch.providerConnect.cursor).toEqual(connected);
   });
 });

--- a/apps/desktop/src/store/slices/providers/refreshProviders.ts
+++ b/apps/desktop/src/store/slices/providers/refreshProviders.ts
@@ -6,6 +6,7 @@ import {
   type ProviderStatuses,
 } from '../../../features/providers/providers';
 import { cursorMaxModeAdvisory } from '../../../shared/lib/cursorMaxModeAdvisory';
+import { clearStaleConnect } from './clearStaleConnect';
 import type { GetFn, SetFn } from './types';
 
 export const refreshProviders = (set: SetFn, get: GetFn) => {
@@ -60,6 +61,7 @@ export const refreshProviders = (set: SetFn, get: GetFn) => {
       geminiStatus,
       authResults,
       providers: buildProviderList(statuses, authResults, credentialProviderIds),
+      providerConnect: clearStaleConnect({ connect: get().providerConnect, authResults }),
     });
   };
 };

--- a/apps/desktop/src/store/slices/providers/runLifecycle.test.ts
+++ b/apps/desktop/src/store/slices/providers/runLifecycle.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { INITIAL_LIFECYCLE_MAP } from './types';
+import { IDLE_CONNECT, INITIAL_CONNECT_MAP, INITIAL_LIFECYCLE_MAP } from './types';
 import { runLifecycle } from './runLifecycle';
 
 const providerMocks = vi.hoisted(() => ({
@@ -43,6 +43,7 @@ describe('runLifecycle', () => {
       authResults: null,
       providers: [],
       providerCredentials: [],
+      providerConnect: { ...INITIAL_CONNECT_MAP },
       refreshProviders,
     };
     const set = vi.fn(
@@ -114,6 +115,7 @@ describe('runLifecycle', () => {
       authResults: null,
       providers: [],
       providerCredentials: [],
+      providerConnect: { ...INITIAL_CONNECT_MAP },
       refreshProviders,
     };
     const set = vi.fn(
@@ -163,5 +165,52 @@ describe('runLifecycle', () => {
       }),
       new Set(),
     );
+  });
+
+  it('drops a connect state claiming success when a logout lands disconnected', async () => {
+    const refreshProviders = vi.fn(async () => undefined);
+    let state: Record<string, unknown> = {
+      providerLifecycle: { ...INITIAL_LIFECYCLE_MAP },
+      providerStatus: null,
+      cursorStatus: null,
+      codexStatus: null,
+      geminiStatus: null,
+      authResults: null,
+      providers: [],
+      providerCredentials: [],
+      providerConnect: {
+        ...INITIAL_CONNECT_MAP,
+        cursor: { ...IDLE_CONNECT, phase: 'success', identity: 'amin@serenis.it' },
+      },
+      refreshProviders,
+    };
+    const set = vi.fn(
+      (
+        update:
+          | Record<string, unknown>
+          | ((current: Record<string, unknown>) => Record<string, unknown>),
+      ) => {
+        const patch = typeof update === 'function' ? update(state) : update;
+        state = { ...state, ...patch };
+      },
+    );
+    const get = vi.fn(() => state);
+
+    await runLifecycle(set as never, get as never, { providerId: 'cursor', action: 'logout' });
+    const invocation = lifecycleMocks.invokeProviderLifecycleRun.mock.calls[0]?.[0];
+    expect(invocation).toBeDefined();
+    if (invocation === undefined) {
+      return;
+    }
+    lifecycleMocks.exitHandler?.({
+      runId: invocation.runId,
+      providerId: 'cursor',
+      action: 'logout',
+      exitCode: 0,
+      status: { id: 'cursor', binary: 'cursor-agent', available: true, version: '1', error: null },
+      auth: { state: 'disconnected', identity: null },
+    });
+
+    expect((state.providerConnect as Record<string, unknown>).cursor).toEqual(IDLE_CONNECT);
   });
 });

--- a/apps/desktop/src/store/slices/providers/runLifecycle.ts
+++ b/apps/desktop/src/store/slices/providers/runLifecycle.ts
@@ -13,6 +13,7 @@ import {
   type LifecycleExitPayload,
 } from '../../../features/providers/provider-lifecycle';
 import { formatError } from '../../../shared/lib/errors';
+import { clearStaleConnect } from './clearStaleConnect';
 import { detectAuthUrl } from './detectAuthUrl';
 import { stripAnsi } from './stripAnsi';
 import type { GetFn, SetFn } from './types';
@@ -208,6 +209,7 @@ export const runLifecycle = async (
         ...statusSlotPatch(providerId, payload.status),
         authResults,
         providers: buildProviderList(statuses, authResults, credentialProviderIds),
+        providerConnect: clearStaleConnect({ connect: state.providerConnect, authResults }),
         providerLifecycle: {
           ...state.providerLifecycle,
           [providerId]: {

--- a/apps/desktop/src/store/slices/session-view/types.ts
+++ b/apps/desktop/src/store/slices/session-view/types.ts
@@ -96,7 +96,7 @@ export type LensHistory = {
   readonly index: number;
 };
 
-export type SessionCreationKind = 'agent' | 'workflow';
+export type SessionCreationKind = 'agent' | 'workflow' | 'branch';
 
 export type SessionCreationId = string;
 

--- a/apps/desktop/src/store/slices/workflows/index.ts
+++ b/apps/desktop/src/store/slices/workflows/index.ts
@@ -22,6 +22,7 @@ import { restoreWorkflow } from './restoreWorkflow';
 import { retryWorkflowOrchestration } from './retryWorkflowOrchestration';
 import { reprocessGoalForWorkflow } from './reprocessGoalForWorkflow';
 import { resetWorkflows } from './resetWorkflows';
+import { makeWorkflowPreset } from './makeWorkflowPreset';
 import { savePhaseTemplate } from './savePhaseTemplate';
 import { saveStepDef } from './saveStepDef';
 import { advanceScoutTree } from './scoutTree';
@@ -36,6 +37,7 @@ export const createWorkflowsSlice = (set: SetFn, get: GetFn) => {
     savePhaseTemplate: savePhaseTemplate(set),
     deleteWorkflow: deleteWorkflow(set),
     renameWorkflow: renameWorkflow(set, get),
+    makeWorkflowPreset: makeWorkflowPreset(set, get),
     generateWorkflowTitle: generateWorkflowTitle(set, get),
     loadStepLibrary: loadStepLibrary(set),
     saveStepDef: saveStepDef(set),

--- a/apps/desktop/src/store/slices/workflows/makeWorkflowPreset.test.ts
+++ b/apps/desktop/src/store/slices/workflows/makeWorkflowPreset.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { IsoDateTime, Workflow, WorkflowId, WorkspaceId } from '@goodboy/types';
+
+const { invokeWorkflowUpsertSpy } = vi.hoisted(() => ({
+  invokeWorkflowUpsertSpy: vi.fn(),
+}));
+
+vi.mock('../../../features/workflows/workflows', () => ({
+  invokeWorkflowUpsert: invokeWorkflowUpsertSpy,
+}));
+
+import { makeWorkflowPreset } from './makeWorkflowPreset';
+
+const WORKSPACE_ID = 'workspace-1' as WorkspaceId;
+const WORKFLOW_ID = 'wf-1' as WorkflowId;
+const NOW = '2026-08-04T00:00:00.000Z' as IsoDateTime;
+
+const workflow: Workflow = {
+  id: WORKFLOW_ID,
+  workspaceId: WORKSPACE_ID,
+  name: 'Orchestrated workflow',
+  description: 'Steps are decided at runtime from the latest results.',
+  goal: 'ship the thing',
+  processText: 'do the process',
+  steps: [],
+  isPreset: false,
+  origin: 'orchestrated',
+  createdAt: NOW,
+  updatedAt: NOW,
+};
+
+type State = {
+  phaseTemplates: Record<WorkspaceId, ReadonlyArray<Workflow>>;
+};
+
+const buildHarness = (seed: Workflow = workflow) => {
+  const state: State = { phaseTemplates: { [WORKSPACE_ID]: [seed] } };
+  const set = vi.fn((updater: (s: State) => Partial<State>) => {
+    Object.assign(state, updater(state));
+  });
+  const get = (() => state) as never;
+  const promote = makeWorkflowPreset(set as never, get);
+  return { promote, state };
+};
+
+describe('makeWorkflowPreset', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('promotes a declined workflow into a preset', async () => {
+    invokeWorkflowUpsertSpy.mockResolvedValue({ ...workflow, isPreset: true });
+    const { promote, state } = buildHarness();
+
+    await promote(WORKSPACE_ID, WORKFLOW_ID);
+
+    expect(invokeWorkflowUpsertSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ id: WORKFLOW_ID, isPreset: true, origin: 'orchestrated' }),
+    );
+    expect(state.phaseTemplates[WORKSPACE_ID]?.[0]?.isPreset).toBe(true);
+  });
+
+  it('does nothing when the workflow is already a preset', async () => {
+    const { promote } = buildHarness({ ...workflow, isPreset: true });
+
+    await promote(WORKSPACE_ID, WORKFLOW_ID);
+
+    expect(invokeWorkflowUpsertSpy).not.toHaveBeenCalled();
+  });
+
+  it('rolls back when the write fails', async () => {
+    invokeWorkflowUpsertSpy.mockRejectedValue(new Error('offline'));
+    const { promote, state } = buildHarness();
+
+    await expect(promote(WORKSPACE_ID, WORKFLOW_ID)).rejects.toThrow('offline');
+    expect(state.phaseTemplates[WORKSPACE_ID]?.[0]?.isPreset).toBe(false);
+  });
+
+  it('refuses a workflow that is not in the workspace', async () => {
+    const { promote } = buildHarness();
+
+    await expect(promote(WORKSPACE_ID, 'wf-missing' as WorkflowId)).rejects.toThrow('not found');
+    expect(invokeWorkflowUpsertSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/store/slices/workflows/makeWorkflowPreset.ts
+++ b/apps/desktop/src/store/slices/workflows/makeWorkflowPreset.ts
@@ -1,0 +1,52 @@
+import type { WorkflowId, WorkspaceId } from '@goodboy/types';
+import { invokeWorkflowUpsert } from '../../../features/workflows/workflows';
+import type { GetFn, SetFn } from './types';
+
+export const makeWorkflowPreset = (set: SetFn, get: GetFn) => {
+  return async (workspaceId: WorkspaceId, workflowId: WorkflowId): Promise<void> => {
+    const prev = (get().phaseTemplates[workspaceId] ?? []).find((w) => w.id === workflowId);
+    if (!prev) {
+      throw new Error(`workflow not found: ${workflowId}`);
+    }
+    if (prev.isPreset === true) {
+      return;
+    }
+    const patch = (workflows: ReadonlyArray<typeof prev>, isPreset: boolean) =>
+      workflows.map((w) => (w.id === workflowId ? { ...w, isPreset } : w));
+    set((state) => ({
+      phaseTemplates: {
+        ...state.phaseTemplates,
+        [workspaceId]: patch(state.phaseTemplates[workspaceId] ?? [], true),
+      },
+    }));
+    try {
+      const saved = await invokeWorkflowUpsert({
+        id: prev.id,
+        workspaceId: prev.workspaceId,
+        name: prev.name,
+        description: prev.description,
+        ...(prev.goal != null && { goal: prev.goal }),
+        ...(prev.processText != null && { processText: prev.processText }),
+        steps: prev.steps,
+        isPreset: true,
+        ...(prev.origin != null && { origin: prev.origin }),
+      });
+      set((state) => ({
+        phaseTemplates: {
+          ...state.phaseTemplates,
+          [workspaceId]: (state.phaseTemplates[workspaceId] ?? []).map((w) =>
+            w.id === workflowId ? saved : w,
+          ),
+        },
+      }));
+    } catch (err) {
+      set((state) => ({
+        phaseTemplates: {
+          ...state.phaseTemplates,
+          [workspaceId]: patch(state.phaseTemplates[workspaceId] ?? [], false),
+        },
+      }));
+      throw err;
+    }
+  };
+};

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -377,6 +377,7 @@ export type AppActions = {
   savePhaseTemplate(template: WorkflowUpsertArgs): Promise<Workflow>;
   deleteWorkflow(id: WorkflowId, workspaceId: WorkspaceId): Promise<void>;
   renameWorkflow(workspaceId: WorkspaceId, workflowId: WorkflowId, name: string): Promise<void>;
+  makeWorkflowPreset(workspaceId: WorkspaceId, workflowId: WorkflowId): Promise<void>;
   generateWorkflowTitle(
     workspaceId: WorkspaceId,
     workflowId: WorkflowId,

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -500,6 +500,30 @@ dialog[open]::backdrop {
   animation: cost-chip-pulse 1100ms cubic-bezier(0.2, 0, 0, 1);
 }
 
+/* Attention halo for a chip that is waiting on the user, not working: the ring
+   breathes outward and settles, so the eye is drawn to it without the element
+   claiming to be running. Rings, not borders: a Chip carries ring-1, so a
+   border-color animation would have nothing to animate. */
+@keyframes attention-ring {
+  0%,
+  100% {
+    box-shadow:
+      0 0 0 0 oklch(from var(--color-primary) l c h / 0.5),
+      0 0 0 0 oklch(from var(--color-primary) l c h / 0);
+  }
+  50% {
+    box-shadow:
+      0 0 0 3px oklch(from var(--color-primary) l c h / 0.28),
+      0 0 12px 2px oklch(from var(--color-primary) l c h / 0.4);
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .attention-ring {
+    animation: attention-ring 2.4s ease-in-out infinite;
+  }
+}
+
 @keyframes text-shimmer {
   to {
     background-position: -200% center;


### PR DESCRIPTION
Recovery PR for the stacked round. The seven area PRs (#1183 to #1189) were merged into their own base branches rather than into main, because GitHub only retargets a stacked PR when its base branch is deleted, not when it is merged. Only #1182 reached main. This PR carries the same reviewed commits, unchanged, onto main.

Commits, each already reviewed in its own PR:

- `1389ec6f` a disconnected provider stops claiming an account (#1183)
- `4ec0da0a` one honest answer on whether effort is editable (#1184)
- `826fc9f5` an update that is waiting asks for attention (#1185)
- `a4126ddc` finishing an agent is one click from its card (#1186)
- `5cef68ac` the archive opens where the list ends (#1187)
- `b84eac06` a workflow becomes a preset when you say so (#1188)
- `07ccfaa4` keep session actions on the current view (#1189)

No new work, no rewritten commits: `git merge-tree` reports no conflicts against main, and the tree is the one the individual PRs were checked against.

## Verification

Run on this exact tree, after rebasing the last area onto the rest of the stack:

- `vitest` desktop, whole suite: 4130 passed, 474 files
- `tsc --noEmit` on desktop, ui, types, db: clean
- `knip --include files,duplicates,unlisted`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)