### PR TITLE
fix(desktop): every session lens states its own title, and a linked issue carries its branch

### DIFF
--- a/apps/desktop/src/features/integrations/components/ExternalTaskChip/index.tsx
+++ b/apps/desktop/src/features/integrations/components/ExternalTaskChip/index.tsx
@@ -12,6 +12,7 @@ type Props = {
   appearance?: 'chip' | 'row';
   ariaLabel?: string;
   repoLabel?: string;
+  branchLabel?: string;
   navigation?: 'internal' | 'external';
   hasReferenceActions?: boolean;
 };
@@ -51,6 +52,7 @@ export const ExternalTaskChip = ({
   appearance = 'chip',
   ariaLabel,
   repoLabel,
+  branchLabel,
   navigation = 'external',
   hasReferenceActions = true,
 }: Props) => {
@@ -81,6 +83,13 @@ export const ExternalTaskChip = ({
     });
 
   if (appearance === 'row') {
+    const attribution =
+      repoLabel == null && branchLabel == null ? null : (
+        <span className="flex min-w-0 items-center gap-1">
+          {repoLabel != null ? <Chip tone="neutral" label={repoLabel} size="xs" /> : null}
+          {branchLabel != null ? <Chip tone="neutral" label={branchLabel} size="xs" /> : null}
+        </span>
+      );
     return (
       <LinkedWorkRow
         leading={{ kind: 'glyph', provider: task.provider }}
@@ -90,9 +99,7 @@ export const ExternalTaskChip = ({
         ariaLabel={ariaLabel ?? `open ${task.identifier} in ${meta.label}`}
         tooltip={tooltip}
         navigation={navigation}
-        {...(repoLabel != null
-          ? { attribution: <Chip tone="neutral" label={repoLabel} size="xs" /> }
-          : {})}
+        {...(attribution != null ? { attribution } : {})}
         actions={
           hasReferenceActions && task.url !== '' ? (
             <ExternalRefActions url={task.url} label={task.identifier} hostLabel={meta.label} />

--- a/apps/desktop/src/features/review/components/ReviewBoardPane/index.test.tsx
+++ b/apps/desktop/src/features/review/components/ReviewBoardPane/index.test.tsx
@@ -240,4 +240,19 @@ describe('ReviewBoardPane', () => {
     expect(screen.getByRole('tab', { name: 'Split' }).getAttribute('aria-selected')).toBe('true');
     expect(screen.getByLabelText('Draft a comment on new line 4')).toBeDefined();
   });
+
+  it('states its section title with the reviewed record below it', () => {
+    render(<ReviewBoardPane session={SESSION} />);
+
+    expect(screen.getByRole('heading', { name: 'Review board' })).toBeDefined();
+    expect(screen.getByText('acme/web #41')).toBeDefined();
+  });
+
+  it('states its section title with no reviewed record', () => {
+    h.diff.target = null;
+    render(<ReviewBoardPane session={SESSION} />);
+
+    expect(screen.getByRole('heading', { name: 'Review board' })).toBeDefined();
+    expect(screen.queryByText('acme/web #41')).toBeNull();
+  });
 });

--- a/apps/desktop/src/features/review/components/ReviewBoardPane/index.tsx
+++ b/apps/desktop/src/features/review/components/ReviewBoardPane/index.tsx
@@ -115,11 +115,12 @@ export const ReviewBoardPane = ({ session }: Props) => {
 
   const header = (
     <div className="flex items-center gap-2">
-      <span className="min-w-0 truncate text-sm font-medium text-foreground">
-        {target == null
-          ? 'Review board'
-          : `${target.repo} ${target.provider === 'gitlab' ? '!' : '#'}${target.prNumber}`}
-      </span>
+      <h2 className="min-w-0 truncate text-sm font-medium text-foreground">Review board</h2>
+      {target != null ? (
+        <span className="min-w-0 truncate font-mono text-2xs text-muted-foreground">
+          {`${target.repo} ${target.provider === 'gitlab' ? '!' : '#'}${target.prNumber}`}
+        </span>
+      ) : null}
       <span className="text-2xs tabular-nums text-muted-foreground/60">
         {loading ? '' : `${files.length} files`}
       </span>

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/FocusedTaskBody.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/FocusedTaskBody.test.tsx
@@ -61,7 +61,6 @@ describe('FocusedTaskBody', () => {
         workspaceId={WORKSPACE_ID}
         task={makeTask(provider)}
         isConnected
-        headerActions={null}
       />,
     );
 
@@ -78,7 +77,6 @@ describe('FocusedTaskBody', () => {
           workspaceId={WORKSPACE_ID}
           task={makeTask(provider)}
           isConnected={false}
-          headerActions={null}
         />,
       );
 

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/FocusedTaskBody.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/FocusedTaskBody.tsx
@@ -1,4 +1,3 @@
-import type { ReactNode } from 'react';
 import type {
   SessionExternalTask,
   SessionExternalTaskProvider,
@@ -20,40 +19,27 @@ type Props = {
   readonly workspaceId: WorkspaceId;
   readonly task: SessionExternalTask;
   readonly isConnected: boolean;
-  readonly headerActions: ReactNode;
 };
 
-export const FocusedTaskBody = ({
-  provider,
-  sessionId,
-  workspaceId,
-  task,
-  isConnected,
-  headerActions,
-}: Props) => {
+export const FocusedTaskBody = ({ provider, sessionId, workspaceId, task, isConnected }: Props) => {
   const repo = useSessionRepo({ sessionId });
 
   if (isConnected && provider === 'linear') {
-    return <LinearTaskDetail workspaceId={workspaceId} task={task} headerActions={headerActions} />;
+    return <LinearTaskDetail workspaceId={workspaceId} task={task} />;
   }
 
   if (isConnected && provider === 'sentry') {
-    return <SentryTaskDetail workspaceId={workspaceId} task={task} headerActions={headerActions} />;
+    return <SentryTaskDetail workspaceId={workspaceId} task={task} />;
   }
 
   if (isConnected && provider === 'github') {
     return (
-      <GithubTaskDetail
-        workspaceId={workspaceId}
-        rootPath={repo?.repoRoot ?? null}
-        task={task}
-        headerActions={headerActions}
-      />
+      <GithubTaskDetail workspaceId={workspaceId} rootPath={repo?.repoRoot ?? null} task={task} />
     );
   }
 
   if (isConnected && provider === 'gitlab') {
-    return <GitlabTaskDetail workspaceId={workspaceId} task={task} headerActions={headerActions} />;
+    return <GitlabTaskDetail workspaceId={workspaceId} task={task} />;
   }
 
   return (
@@ -67,7 +53,6 @@ export const FocusedTaskBody = ({
             </span>
           }
           title={task.title}
-          actions={headerActions}
         />
       }
     >

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/GithubTaskDetail.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/GithubTaskDetail.test.tsx
@@ -48,14 +48,7 @@ describe('GithubTaskDetail', () => {
       refetch: vi.fn(),
     });
 
-    render(
-      <GithubTaskDetail
-        workspaceId={WORKSPACE_ID}
-        rootPath="/repo"
-        task={TASK}
-        headerActions={null}
-      />,
-    );
+    render(<GithubTaskDetail workspaceId={WORKSPACE_ID} rootPath="/repo" task={TASK} />);
 
     expect(screen.getByRole('status', { name: 'Loading GitHub issue' })).toBeDefined();
   });
@@ -69,14 +62,7 @@ describe('GithubTaskDetail', () => {
       refetch,
     });
 
-    render(
-      <GithubTaskDetail
-        workspaceId={WORKSPACE_ID}
-        rootPath="/repo"
-        task={TASK}
-        headerActions={null}
-      />,
-    );
+    render(<GithubTaskDetail workspaceId={WORKSPACE_ID} rootPath="/repo" task={TASK} />);
 
     expect(screen.getByRole('alert')).toBeDefined();
     fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
@@ -91,14 +77,7 @@ describe('GithubTaskDetail', () => {
       refetch: vi.fn(),
     });
 
-    render(
-      <GithubTaskDetail
-        workspaceId={WORKSPACE_ID}
-        rootPath="/repo"
-        task={TASK}
-        headerActions={null}
-      />,
-    );
+    render(<GithubTaskDetail workspaceId={WORKSPACE_ID} rootPath="/repo" task={TASK} />);
 
     expect(screen.getByText('Add issue dashboard')).toBeDefined();
     expect(screen.getByText('Show assigned issues in GitHub Studio.')).toBeDefined();

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/GithubTaskDetail.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/GithubTaskDetail.tsx
@@ -1,4 +1,3 @@
-import type { ReactNode } from 'react';
 import { Skeleton } from '@goodboy/ui';
 import type { SessionExternalTask, WorkspaceId } from '@goodboy/types';
 import { ErrorStrip } from '../../../../../../shared/components/ErrorStrip';
@@ -10,10 +9,9 @@ type Props = {
   readonly workspaceId: WorkspaceId;
   readonly rootPath: string | null;
   readonly task: SessionExternalTask;
-  readonly headerActions: ReactNode;
 };
 
-export const GithubTaskDetail = ({ workspaceId, rootPath, task, headerActions }: Props) => {
+export const GithubTaskDetail = ({ workspaceId, rootPath, task }: Props) => {
   const { issue, isLoading, error, refetch } = useGithubIssue({
     workspaceId,
     rootPath,
@@ -21,7 +19,7 @@ export const GithubTaskDetail = ({ workspaceId, rootPath, task, headerActions }:
   });
 
   if (issue != null) {
-    return <GithubIssueDetail issue={issue} fit="fill" headerActions={headerActions} />;
+    return <GithubIssueDetail issue={issue} fit="fill" />;
   }
 
   return (
@@ -35,7 +33,6 @@ export const GithubTaskDetail = ({ workspaceId, rootPath, task, headerActions }:
             </span>
           }
           title={task.title}
-          actions={headerActions}
         />
       }
     >

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/GitlabTaskDetail.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/GitlabTaskDetail.test.tsx
@@ -47,7 +47,7 @@ describe('GitlabTaskDetail', () => {
       refetch: vi.fn(),
     });
 
-    render(<GitlabTaskDetail workspaceId={WORKSPACE_ID} task={TASK} headerActions={null} />);
+    render(<GitlabTaskDetail workspaceId={WORKSPACE_ID} task={TASK} />);
 
     expect(screen.getByRole('status', { name: 'Loading GitLab issue' })).toBeDefined();
   });
@@ -61,7 +61,7 @@ describe('GitlabTaskDetail', () => {
       refetch,
     });
 
-    render(<GitlabTaskDetail workspaceId={WORKSPACE_ID} task={TASK} headerActions={null} />);
+    render(<GitlabTaskDetail workspaceId={WORKSPACE_ID} task={TASK} />);
 
     expect(screen.getByRole('alert')).toBeDefined();
     fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
@@ -76,7 +76,7 @@ describe('GitlabTaskDetail', () => {
       refetch: vi.fn(),
     });
 
-    render(<GitlabTaskDetail workspaceId={WORKSPACE_ID} task={TASK} headerActions={null} />);
+    render(<GitlabTaskDetail workspaceId={WORKSPACE_ID} task={TASK} />);
 
     expect(screen.getByText('Fix the thing')).toBeDefined();
     expect(screen.getByText('Investigate the flaky request.')).toBeDefined();

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/GitlabTaskDetail.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/GitlabTaskDetail.tsx
@@ -1,4 +1,3 @@
-import type { ReactNode } from 'react';
 import { Skeleton } from '@goodboy/ui';
 import type { SessionExternalTask, WorkspaceId } from '@goodboy/types';
 import { ErrorStrip } from '../../../../../../shared/components/ErrorStrip';
@@ -9,17 +8,16 @@ import { useGitlabIssue } from '../../../../../integrations/gitlab/useGitlabIssu
 type Props = {
   readonly workspaceId: WorkspaceId;
   readonly task: SessionExternalTask;
-  readonly headerActions: ReactNode;
 };
 
-export const GitlabTaskDetail = ({ workspaceId, task, headerActions }: Props) => {
+export const GitlabTaskDetail = ({ workspaceId, task }: Props) => {
   const { issue, isLoading, error, refetch } = useGitlabIssue({
     workspaceId,
     identifier: task.identifier,
   });
 
   if (issue != null) {
-    return <GitlabIssueDetail issue={issue} fit="fill" headerActions={headerActions} />;
+    return <GitlabIssueDetail issue={issue} fit="fill" />;
   }
 
   return (
@@ -33,7 +31,6 @@ export const GitlabTaskDetail = ({ workspaceId, task, headerActions }: Props) =>
             </span>
           }
           title={task.title}
-          actions={headerActions}
         />
       }
     >

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/IntegrationTaskCard.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/IntegrationTaskCard.tsx
@@ -1,18 +1,33 @@
 import type { SessionExternalTask } from '@goodboy/types';
-import { MetaRow } from '@goodboy/ui';
+import { Chip, MetaRow } from '@goodboy/ui';
 import { RailCard } from '../../../../../../shared/components/RailCard';
 import { formatRelativeAge } from '../../../../../../shared/utils/relativeDate';
 
 type Props = {
   readonly task: SessionExternalTask;
   readonly providerLabel: string;
+  readonly branch: string | null;
+  readonly isCompleted: boolean;
   readonly onSelect: () => void;
 };
 
-export const IntegrationTaskCard = ({ task, providerLabel, onSelect }: Props) => (
+export const IntegrationTaskCard = ({
+  task,
+  providerLabel,
+  branch,
+  isCompleted,
+  onSelect,
+}: Props) => (
   <RailCard
     title={task.title !== '' ? task.title : task.identifier}
     ariaLabel={`View ${task.identifier}`}
+    muted={isCompleted}
+    status={
+      <>
+        <Chip tone="neutral" label={branch ?? 'No branch'} size="xs" />
+        {isCompleted && <Chip tone="merged" label="Completed" size="xs" />}
+      </>
+    }
     meta={
       <MetaRow
         items={[

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/LinearTaskDetail.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/LinearTaskDetail.tsx
@@ -1,4 +1,3 @@
-import type { ReactNode } from 'react';
 import { Skeleton } from '@goodboy/ui';
 import type { SessionExternalTask, WorkspaceId } from '@goodboy/types';
 import { HeaderBand, StudioDetailLayout } from '../../../../../../shared/components/StudioDetail';
@@ -8,24 +7,16 @@ import { useLinearIssue } from '../../../../../integrations/linear/useLinearIssu
 type Props = {
   readonly workspaceId: WorkspaceId;
   readonly task: SessionExternalTask;
-  readonly headerActions: ReactNode;
 };
 
-export const LinearTaskDetail = ({ workspaceId, task, headerActions }: Props) => {
+export const LinearTaskDetail = ({ workspaceId, task }: Props) => {
   const { issue, isLoading, error } = useLinearIssue({
     workspaceId,
     issueId: task.externalId,
   });
 
   if (issue != null) {
-    return (
-      <LinearIssueDetail
-        issue={issue}
-        workspaceId={workspaceId}
-        fit="fill"
-        headerActions={headerActions}
-      />
-    );
+    return <LinearIssueDetail issue={issue} workspaceId={workspaceId} fit="fill" />;
   }
 
   return (
@@ -39,7 +30,6 @@ export const LinearTaskDetail = ({ workspaceId, task, headerActions }: Props) =>
             </span>
           }
           title={task.title}
-          actions={headerActions}
         />
       }
     >

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/SentryTaskDetail.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/SentryTaskDetail.tsx
@@ -1,4 +1,3 @@
-import type { ReactNode } from 'react';
 import type { SessionExternalTask, WorkspaceId } from '@goodboy/types';
 import { SentryIssueDetail } from '../../../../../integrations/sentry/SentryIssueDetail';
 import { useSentryIssueDetail } from '../../../../../integrations/sentry/useSentryIssueDetail';
@@ -6,10 +5,9 @@ import { useSentryIssueDetail } from '../../../../../integrations/sentry/useSent
 type Props = {
   readonly workspaceId: WorkspaceId;
   readonly task: SessionExternalTask;
-  readonly headerActions: ReactNode;
 };
 
-export const SentryTaskDetail = ({ workspaceId, task, headerActions }: Props) => {
+export const SentryTaskDetail = ({ workspaceId, task }: Props) => {
   const { detail, isLoading, error } = useSentryIssueDetail({
     workspaceId,
     issueId: task.externalId,
@@ -27,7 +25,6 @@ export const SentryTaskDetail = ({ workspaceId, task, headerActions }: Props) =>
       isLoading={isLoading}
       error={error}
       fit="fill"
-      headerActions={headerActions}
     />
   );
 };

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/WorkItemList.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/WorkItemList.tsx
@@ -1,0 +1,30 @@
+import type { WorkItem } from '../../../../workItems';
+import { IntegrationTaskCard } from './IntegrationTaskCard';
+import { integrationTaskKey } from './integrationTaskKey';
+
+type Props = {
+  readonly items: ReadonlyArray<WorkItem>;
+  readonly providerLabel: string;
+  readonly onSelect: (taskKey: string) => void;
+};
+
+export const WorkItemList = ({ items, providerLabel, onSelect }: Props) => {
+  if (items.length === 0) {
+    return null;
+  }
+  return (
+    <ul className="flex flex-col gap-2">
+      {items.map((item) => (
+        <li key={item.key}>
+          <IntegrationTaskCard
+            task={item.task}
+            providerLabel={providerLabel}
+            branch={item.branch}
+            isCompleted={item.isCompleted}
+            onSelect={() => onSelect(integrationTaskKey({ task: item.task }))}
+          />
+        </li>
+      ))}
+    </ul>
+  );
+};

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/index.test.tsx
@@ -3,10 +3,17 @@
 import type { ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
-import type { IsoDateTime, SessionExternalTask, SessionId, WorkspaceId } from '@goodboy/types';
+import type {
+  IsoDateTime,
+  PullRequestState,
+  SessionExternalTask,
+  SessionId,
+  WorkspaceId,
+} from '@goodboy/types';
 
 type Store = {
   readonly sessionExternalTasks: Readonly<Record<string, ReadonlyArray<SessionExternalTask>>>;
+  readonly sessionGithubPrs: Readonly<Record<string, ReadonlyArray<PullRequestState>>>;
   readonly workspaceIntegrations: Readonly<Record<string, ReadonlyArray<{ provider: string }>>>;
   readonly sessions: ReadonlyArray<{ id: string; workspaceId: string }>;
   readonly linkSessionExternalTask: ReturnType<typeof vi.fn>;
@@ -16,18 +23,19 @@ type Store = {
 };
 
 type Props = {
+  readonly title: string;
   readonly children: ReactNode;
   readonly actions?: ReactNode;
 };
 
 type TaskDetailProps = {
   readonly task: SessionExternalTask;
-  readonly headerActions: ReactNode;
 };
 
 const h = vi.hoisted(() => ({
   store: {
     sessionExternalTasks: {},
+    sessionGithubPrs: {},
     workspaceIntegrations: {},
     sessions: [],
     linkSessionExternalTask: vi.fn(async () => undefined),
@@ -62,9 +70,8 @@ vi.mock('../../../../../worktree/useRemoteHostKind', () => ({
 }));
 
 vi.mock('./LinearTaskDetail', () => ({
-  LinearTaskDetail: ({ task, headerActions }: TaskDetailProps) => (
+  LinearTaskDetail: ({ task }: TaskDetailProps) => (
     <div data-testid="task-detail">
-      {headerActions}
       <a href="https://linear.app/GB-42" aria-label="Open in Linear">
         Linear detail {task.externalId}
       </a>
@@ -74,9 +81,8 @@ vi.mock('./LinearTaskDetail', () => ({
 }));
 
 vi.mock('./SentryTaskDetail', () => ({
-  SentryTaskDetail: ({ task, headerActions }: TaskDetailProps) => (
+  SentryTaskDetail: ({ task }: TaskDetailProps) => (
     <div data-testid="task-detail">
-      {headerActions}
       <a href="https://sentry.io/issues/12345" aria-label="Open in Sentry">
         Sentry detail {task.externalId}
       </a>
@@ -86,12 +92,23 @@ vi.mock('./SentryTaskDetail', () => ({
 }));
 
 vi.mock('../../../../../../shared/components/PaneShell', () => ({
-  PaneShell: ({ children, actions }: Props) => (
+  PaneShell: ({ title, children, actions }: Props) => (
     <div>
+      <h1>{title}</h1>
       {actions}
       {children}
     </div>
   ),
+}));
+
+vi.mock('../../../../../../store/slices/worktrees/useSessionRepo', () => ({
+  useSessionRepo: () => ({
+    repoRoot: '/tmp/goodboy',
+    worktreePath: '/tmp/goodboy/.goodboy/worktrees/current',
+    branch: 'ak/current',
+    mountName: null,
+    workspaceId: 'workspace-1',
+  }),
 }));
 
 vi.mock('../../../../../integrations/hooks/useIssueCandidates', () => ({
@@ -128,6 +145,20 @@ const SECOND_TASK: SessionExternalTask = {
   url: 'https://linear.app/goodboy/issue/GB-43/trim-the-integration-pane',
   createdAt: CREATED_AT,
 };
+const MERGED_PR: PullRequestState = {
+  number: 42,
+  title: 'Refactor integration storage',
+  url: 'https://github.com/acme/goodboy/pull/42',
+  state: 'merged',
+  mergeable: null,
+  checks: 'success',
+  baseBranch: 'main',
+  headBranch: 'ak/current',
+  isDraft: false,
+  reviewDecision: 'approved',
+  body: '',
+  updatedAt: CREATED_AT,
+};
 const SENTRY_TASK: SessionExternalTask = {
   sessionId: SESSION_ID,
   provider: 'sentry',
@@ -140,6 +171,7 @@ const SENTRY_TASK: SessionExternalTask = {
 
 beforeEach(() => {
   h.store.sessionExternalTasks = { [SESSION_ID]: [TASK] };
+  h.store.sessionGithubPrs = {};
   h.store.workspaceIntegrations = {
     [WORKSPACE_ID]: [{ provider: 'linear' }, { provider: 'sentry' }],
   };
@@ -197,28 +229,34 @@ describe('IntegrationPane', () => {
       render(
         <IntegrationPane sessionId={SESSION_ID} workspaceId={WORKSPACE_ID} provider={provider} />,
       );
+      fireEvent.click(screen.getByRole('button', { name: `View ${task.identifier}` }));
 
       expect(screen.getAllByRole('link', { name: `Open in ${host}` })).toHaveLength(1);
       expect(screen.getAllByRole('button', { name: 'Copy issue link' })).toHaveLength(1);
     },
   );
 
-  it('auto-focuses the only linked task instead of listing it', () => {
+  it.each([0, 1, 2] as const)('states its section title with %i linked records', (count) => {
+    h.store.sessionExternalTasks = { [SESSION_ID]: [TASK, SECOND_TASK].slice(0, count) };
+
     render(<IntegrationPane sessionId={SESSION_ID} workspaceId={WORKSPACE_ID} provider="linear" />);
 
-    expect(screen.getByText('Linear detail GB-42')).toBeDefined();
-    expect(screen.queryByRole('button', { name: 'View GB-42' })).toBeNull();
-    expect(screen.queryByRole('button', { name: 'All issues' })).toBeNull();
+    expect(screen.getByRole('heading', { name: 'Linear' })).toBeDefined();
+    expect(screen.queryAllByRole('button', { name: /^View GB-/ })).toHaveLength(count);
+    expect(screen.queryByTestId('task-detail')).toBeNull();
   });
 
-  it('hands the focused actions to the detail header instead of stacking a pane header', () => {
+  it('states the section title above the focused record and holds its actions', () => {
     render(<IntegrationPane sessionId={SESSION_ID} workspaceId={WORKSPACE_ID} provider="linear" />);
+    fireEvent.click(screen.getByRole('button', { name: 'View GB-42' }));
 
     const detail = screen.getByTestId('task-detail');
 
-    expect(within(detail).getByRole('button', { name: 'Unlink GB-42' })).toBeDefined();
-    expect(within(detail).getByRole('button', { name: 'Link issue' })).toBeDefined();
-    expect(screen.getAllByRole('button', { name: 'Unlink GB-42' })).toHaveLength(1);
+    expect(screen.getByRole('heading', { name: 'Linear' })).toBeDefined();
+    expect(within(detail).queryByRole('button', { name: 'Unlink GB-42' })).toBeNull();
+    expect(screen.getByRole('button', { name: 'Unlink GB-42' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Link issue' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'All issues' })).toBeDefined();
   });
 
   it('lists every linked task as a card and focuses the clicked one', () => {
@@ -236,8 +274,25 @@ describe('IntegrationPane', () => {
     expect(screen.getByRole('button', { name: 'All issues' })).toBeDefined();
   });
 
+  it('groups a merged work item as completed instead of current work', () => {
+    h.store.sessionExternalTasks = {
+      [SESSION_ID]: [
+        { ...TASK, branch: 'ak/current' },
+        { ...SECOND_TASK, branch: 'ak/shipped' },
+      ],
+    };
+    h.store.sessionGithubPrs = { [SESSION_ID]: [MERGED_PR] };
+
+    render(<IntegrationPane sessionId={SESSION_ID} workspaceId={WORKSPACE_ID} provider="linear" />);
+
+    expect(screen.getByText('Completed work (2)')).toBeDefined();
+    expect(screen.getAllByText('Completed')).toHaveLength(1);
+    expect(screen.getByText('ak/shipped')).toBeDefined();
+  });
+
   it('opens and confirms before unlinking the focused task', async () => {
     render(<IntegrationPane sessionId={SESSION_ID} workspaceId={WORKSPACE_ID} provider="linear" />);
+    fireEvent.click(screen.getByRole('button', { name: 'View GB-42' }));
 
     expect(screen.getByText('Linear detail GB-42')).toBeDefined();
     fireEvent.click(screen.getByRole('button', { name: 'Unlink GB-42' }));
@@ -297,7 +352,7 @@ describe('IntegrationPane', () => {
 
     render(<IntegrationPane sessionId={SESSION_ID} workspaceId={WORKSPACE_ID} provider="linear" />);
 
-    expect(screen.getByText('Linear')).toBeDefined();
+    expect(screen.getByRole('heading', { name: 'Linear' })).toBeDefined();
     expect(screen.queryByRole('combobox', { name: 'Link an issue' })).toBeNull();
     fireEvent.change(screen.getByLabelText('Personal access token'), {
       target: { value: 'lin_api_test' },

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/index.tsx
@@ -6,7 +6,7 @@ import type {
   SessionId,
   WorkspaceId,
 } from '@goodboy/types';
-import { InlineConfirm, cn } from '@goodboy/ui';
+import { Eyebrow, InlineConfirm, cn } from '@goodboy/ui';
 import { LensEmptyState } from '../../../../../../shared/components/LensEmptyState';
 import { EMPTY_ARRAY, useAppStore } from '../../../../../../store';
 import { formatError } from '../../../../../../shared/lib/errors';
@@ -18,11 +18,14 @@ import { useRemoteHostKind } from '../../../../../worktree/useRemoteHostKind';
 import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../../../shared/components/conceptIcons';
 import { GhostActionButton } from '../../../../../../shared/components/GhostActionButton';
 import { PaneShell } from '../../../../../../shared/components/PaneShell';
+import { FocusedPane } from '../../../../../../shared/components/PaneShell/FocusedPane';
 import { PANE_RHYTHM } from '../../../../../../shared/components/paneRhythm';
+import { useSessionRepo } from '../../../../../../store/slices/worktrees/useSessionRepo';
+import { buildWorkItems } from '../../../../workItems';
 import { FocusedTaskBody } from './FocusedTaskBody';
-import { IntegrationTaskCard } from './IntegrationTaskCard';
 import { integrationTaskKey } from './integrationTaskKey';
 import { LinkTicketPopover } from './LinkTicketPopover';
+import { WorkItemList } from './WorkItemList';
 
 type Props = {
   readonly sessionId: SessionId;
@@ -59,6 +62,8 @@ export const IntegrationPane = ({ sessionId, workspaceId, provider }: Props) => 
   );
   const remoteKind = useRemoteHostKind({ sessionId });
   const githubConnection = useGithubConnection({ workspaceId });
+  const sessionBranch = useSessionRepo({ sessionId })?.branch ?? null;
+  const branchPrs = useAppStore((state) => state.sessionGithubPrs[sessionId] ?? EMPTY_ARRAY);
   const tasks = useMemo(
     () => externalTasks.filter((task) => task.provider === provider),
     [externalTasks, provider],
@@ -83,9 +88,8 @@ export const IntegrationPane = ({ sessionId, workspaceId, provider }: Props) => 
       providerLabel={meta.label}
     />
   );
-  const autoFocusedTask = connection.isConnected && tasks.length === 1 ? (tasks[0] ?? null) : null;
-  const focusedTask =
-    tasks.find((task) => integrationTaskKey({ task }) === focusedTaskKey) ?? autoFocusedTask;
+  const focusedTask = tasks.find((task) => integrationTaskKey({ task }) === focusedTaskKey) ?? null;
+  const workItems = buildWorkItems({ tasks, currentBranch: sessionBranch, branchPrs });
 
   const handleUnlink = async ({ task }: UnlinkParams) => {
     const mountWorkspaceId = task.mountWorkspaceId;
@@ -108,57 +112,58 @@ export const IntegrationPane = ({ sessionId, workspaceId, provider }: Props) => 
 
   if (focusedTask != null) {
     return (
-      <div className="flex h-full min-h-0 min-w-0 flex-col bg-background">
-        {unlinkError != null ? (
-          <p className={cn('shrink-0 pt-3 text-xs text-danger', PANE_RHYTHM.inset)}>
-            {unlinkError}
-          </p>
-        ) : null}
+      <FocusedPane
+        lens={meta.label}
+        count={tasks.length}
+        actions={
+          isUnlinkArmed ? (
+            <InlineConfirm
+              role="danger"
+              className="max-w-sm"
+              icon={<Unlink size={12} aria-hidden />}
+              title={`Unlink ${focusedTask.identifier}?`}
+              description={`Removes the ${meta.label} issue from this session without changing the issue.`}
+              confirmLabel={`Unlink ${focusedTask.identifier}`}
+              autoDisarmMs={4000}
+              isBusy={isUnlinking}
+              onConfirm={() => handleUnlink({ task: focusedTask })}
+              onCancel={() => setIsUnlinkArmed(false)}
+            />
+          ) : (
+            <div className="flex items-center gap-1.5">
+              <GhostActionButton
+                icon={ArrowLeft}
+                label="All issues"
+                onClick={() => setFocusedTaskKey(null)}
+              />
+              <GhostActionButton
+                icon={Unlink}
+                tone="danger"
+                label="Unlink"
+                ariaLabel={`Unlink ${focusedTask.identifier}`}
+                disabled={isUnlinking}
+                onClick={() => setIsUnlinkArmed(true)}
+              />
+              {linkAction}
+            </div>
+          )
+        }
+      >
         <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+          {unlinkError != null ? (
+            <p className={cn('shrink-0 pt-3 text-xs text-danger', PANE_RHYTHM.inset)}>
+              {unlinkError}
+            </p>
+          ) : null}
           <FocusedTaskBody
             provider={provider}
             sessionId={sessionId}
             workspaceId={workspaceId}
             task={focusedTask}
             isConnected={connection.isConnected}
-            headerActions={
-              isUnlinkArmed ? (
-                <InlineConfirm
-                  role="danger"
-                  className="max-w-sm"
-                  icon={<Unlink size={12} aria-hidden />}
-                  title={`Unlink ${focusedTask.identifier}?`}
-                  description={`Removes the ${meta.label} issue from this session without changing the issue.`}
-                  confirmLabel={`Unlink ${focusedTask.identifier}`}
-                  autoDisarmMs={4000}
-                  isBusy={isUnlinking}
-                  onConfirm={() => handleUnlink({ task: focusedTask })}
-                  onCancel={() => setIsUnlinkArmed(false)}
-                />
-              ) : (
-                <div className="flex items-center gap-1.5">
-                  {tasks.length > 1 ? (
-                    <GhostActionButton
-                      icon={ArrowLeft}
-                      label="All issues"
-                      onClick={() => setFocusedTaskKey(null)}
-                    />
-                  ) : null}
-                  <GhostActionButton
-                    icon={Unlink}
-                    tone="danger"
-                    label="Unlink"
-                    ariaLabel={`Unlink ${focusedTask.identifier}`}
-                    disabled={isUnlinking}
-                    onClick={() => setIsUnlinkArmed(true)}
-                  />
-                  {linkAction}
-                </div>
-              )
-            }
           />
         </div>
-      </div>
+      </FocusedPane>
     );
   }
 
@@ -191,18 +196,24 @@ export const IntegrationPane = ({ sessionId, workspaceId, provider }: Props) => 
           action={linkAction}
         />
       ) : null}
-      {hasTasks ? (
-        <ul className="flex flex-col gap-2">
-          {tasks.map((task) => (
-            <li key={integrationTaskKey({ task })}>
-              <IntegrationTaskCard
-                task={task}
-                providerLabel={meta.label}
-                onSelect={() => setFocusedTaskKey(integrationTaskKey({ task }))}
-              />
-            </li>
-          ))}
-        </ul>
+      <WorkItemList
+        items={workItems.current}
+        providerLabel={meta.label}
+        onSelect={setFocusedTaskKey}
+      />
+      {workItems.history.length > 0 ? (
+        <div className="flex flex-col gap-2">
+          <Eyebrow
+            label={`Completed work (${workItems.history.length})`}
+            muted
+            className="px-0.5 font-medium"
+          />
+          <WorkItemList
+            items={workItems.history}
+            providerLabel={meta.label}
+            onSelect={setFocusedTaskKey}
+          />
+        </div>
       ) : null}
       {unlinkError != null ? <p className="text-xs text-danger">{unlinkError}</p> : null}
     </PaneShell>

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.test.tsx
@@ -185,6 +185,21 @@ describe('PrPane', () => {
     expect(screen.queryByText('GitHub')).toBeNull();
   });
 
+  it('keeps naming GitLab with a merge request linked below the title', () => {
+    h.remoteKind = 'gitlab';
+    h.store.sessionGitlabMr = {
+      [SESSION_ID]: {
+        mr: { iid: 7, title: 'Refactor authentication', state: 'open', draft: false },
+      },
+    };
+
+    render(<PrPane session={session} onSelectLens={h.onSelectLens} />);
+
+    expect(screen.getByRole('heading', { name: 'GitLab', level: 2 })).toBeDefined();
+    expect(screen.getByText('!7')).toBeDefined();
+    expect(screen.getByText('Refactor authentication')).toBeDefined();
+  });
+
   it('names GitHub when that is the host', () => {
     h.remoteKind = 'github';
 
@@ -209,9 +224,114 @@ describe('PrPane', () => {
 
     render(<PrPane session={session} onSelectLens={h.onSelectLens} />);
 
-    expect(screen.getByRole('heading', { name: 'Refactor authentication' })).toBeDefined();
+    expect(screen.getByRole('heading', { name: 'Code host work' })).toBeDefined();
+    expect(screen.getAllByText('Refactor authentication').length).toBeGreaterThan(0);
     expect(screen.getByRole('tab', { name: 'GitHub' })).toBeDefined();
     expect(screen.getByRole('tab', { name: 'GitLab' })).toBeDefined();
+  });
+
+  it.each([0, 1, 2] as const)('states its section title with %i linked records', (count) => {
+    const secondPr = {
+      ...PULL_REQUEST,
+      number: 40,
+      title: 'Refactor authentication (superseded)',
+      state: 'closed',
+    } satisfies PullRequestState;
+    const prs = [PULL_REQUEST, secondPr].slice(0, count);
+    h.store.sessionGithub = {
+      [SESSION_ID]: {
+        pr: prs[0] ?? null,
+        detail: { checks: [], comments: [] },
+        loading: false,
+        error: null,
+      },
+    };
+    h.store.sessionGithubPrs = { [SESSION_ID]: prs };
+
+    render(<PrPane session={session} onSelectLens={h.onSelectLens} />);
+
+    expect(screen.getByRole('heading', { name: 'GitHub', level: 2 })).toBeDefined();
+    expect(screen.queryByRole('heading', { name: PULL_REQUEST.title })).toBeNull();
+  });
+
+  it('scopes the pull request list to the branch it reads', () => {
+    h.store.sessionGithub = {
+      [SESSION_ID]: {
+        pr: PULL_REQUEST,
+        detail: { checks: [], comments: [] },
+        loading: false,
+        error: null,
+      },
+    };
+    h.store.sessionGithubPrs = { [SESSION_ID]: [PULL_REQUEST] };
+
+    render(<PrPane session={session} onSelectLens={h.onSelectLens} />);
+
+    expect(screen.getByText('Pull request on ak/refactor-auth')).toBeDefined();
+  });
+
+  it('moves a work item stamped on another branch to the completed section', () => {
+    h.store.sessionGithub = {
+      [SESSION_ID]: {
+        pr: PULL_REQUEST,
+        detail: { checks: [], comments: [] },
+        loading: false,
+        error: null,
+      },
+    };
+    h.store.sessionGithubPrs = { [SESSION_ID]: [PULL_REQUEST] };
+    h.store.sessionExternalTasks = {
+      [SESSION_ID]: [
+        {
+          sessionId: SESSION_ID,
+          provider: 'github',
+          externalId: '9',
+          identifier: '#9',
+          url: 'https://github.com/acme/goodboy/issues/9',
+          title: 'Harden token refresh',
+          branch: 'ak/previous-work',
+          createdAt: DATE,
+        },
+      ],
+    };
+
+    render(<PrPane session={session} onSelectLens={h.onSelectLens} />);
+
+    expect(screen.getByText('Completed work (1)')).toBeDefined();
+    expect(screen.getByText('ak/previous-work')).toBeDefined();
+    expect(screen.queryByText('External tasks')).toBeNull();
+  });
+
+  it('reads a merged pull request as completed work', () => {
+    const mergedPr = { ...PULL_REQUEST, state: 'merged' } satisfies PullRequestState;
+    h.store.sessionGithub = {
+      [SESSION_ID]: {
+        pr: mergedPr,
+        detail: { checks: [], comments: [] },
+        loading: false,
+        error: null,
+      },
+    };
+    h.store.sessionGithubPrs = { [SESSION_ID]: [mergedPr] };
+    h.store.sessionExternalTasks = {
+      [SESSION_ID]: [
+        {
+          sessionId: SESSION_ID,
+          provider: 'github',
+          externalId: '9',
+          identifier: '#9',
+          url: 'https://github.com/acme/goodboy/issues/9',
+          title: 'Harden token refresh',
+          branch: 'ak/refactor-auth',
+          createdAt: DATE,
+        },
+      ],
+    };
+
+    render(<PrPane session={session} onSelectLens={h.onSelectLens} />);
+
+    expect(screen.getByText('Completed work (1)')).toBeDefined();
+    expect(screen.queryByText('External tasks')).toBeNull();
   });
 
   it('never offers create-PR actions inside a PR review session', () => {
@@ -239,8 +359,8 @@ describe('PrPane', () => {
 
     render(<PrPane session={session} onSelectLens={h.onSelectLens} />);
 
-    expect(screen.getByRole('heading', { name: 'Refactor authentication' })).toBeDefined();
-    expect(screen.getByText('Linked pull request')).toBeDefined();
+    expect(screen.getByRole('heading', { name: 'GitHub', level: 2 })).toBeDefined();
+    expect(screen.getByText('Pull request on ak/refactor-auth')).toBeDefined();
     expect(screen.getByRole('button', { name: 'Show pull request #42' })).toBeDefined();
     expect(screen.getByText('No CI')).toBeDefined();
     expect(screen.getByRole('button', { name: /Review this pull request/i })).toBeDefined();
@@ -265,7 +385,7 @@ describe('PrPane', () => {
 
     render(<PrPane session={session} onSelectLens={h.onSelectLens} />);
 
-    expect(screen.getByText('Linked pull requests (2)')).toBeDefined();
+    expect(screen.getByText('Pull requests (2) on ak/refactor-auth')).toBeDefined();
     fireEvent.click(screen.getByRole('button', { name: 'Show pull request #40' }));
 
     expect(h.store.selectSessionPr).toHaveBeenCalledWith(SESSION_ID, 40);
@@ -291,7 +411,7 @@ describe('PrPane', () => {
 
     render(<PrPane session={session} onSelectLens={h.onSelectLens} />);
 
-    expect(screen.getByRole('heading', { name: closedPr.title })).toBeDefined();
+    expect(screen.getAllByText(closedPr.title).length).toBeGreaterThan(0);
     expect(screen.queryByRole('heading', { name: PULL_REQUEST.title })).toBeNull();
     const selectedRow = screen
       .getByRole('button', { name: `Show pull request #${closedPr.number}` })
@@ -384,7 +504,7 @@ describe('PrPane', () => {
 
     expect(screen.getByText('CI passing')).toBeDefined();
     expect(screen.getByText('Review required')).toBeDefined();
-    expect(screen.getByText('ak/refactor-auth')).toBeDefined();
+    expect(screen.getAllByText('ak/refactor-auth').length).toBeGreaterThan(0);
     expect(screen.getByText('main')).toBeDefined();
     expect(screen.getByText('1')).toBeDefined();
     expect(screen.getByRole('button', { name: /#7 Track auth rollout/i })).toBeDefined();

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.tsx
@@ -6,7 +6,6 @@ import type {
   PullRequestState,
   PullRequestStateKind,
   Session,
-  SessionExternalTask,
   SessionId,
   Workspace,
 } from '@goodboy/types';
@@ -37,6 +36,7 @@ import { LensEmptyState } from '../../../../../shared/components/LensEmptyState'
 import { LinkedWorkRow } from '../../../../../shared/components/LinkedWorkRow';
 import { openUrl } from '../../../../../shared/lib/editor';
 import type { RemoteHostKind } from '../../../../../shared/lib/remoteHost';
+import { buildWorkItems, type WorkItem, type WorkItemGroups } from '../../../workItems';
 
 type Props = {
   readonly session: Session;
@@ -96,6 +96,7 @@ const resolveSessionStudioOpenEvent = ({
 export const PrPane = ({ session, onSelectLens }: Props) => {
   const sessionId = session.id as SessionId;
   const remoteKind = useRemoteHostKind({ sessionId });
+  const sessionBranch = useSessionRepo({ sessionId })?.branch ?? null;
   const canonicalPullRequest = useAppStore((state) => state.sessionGithub[sessionId]?.pr ?? null);
   const branchPrs = useAppStore((state) => state.sessionGithubPrs[sessionId] ?? EMPTY_ARRAY);
   const selectedPrNumber = useAppStore((state) => state.sessionSelectedPrNumber[sessionId] ?? null);
@@ -158,17 +159,21 @@ export const PrPane = ({ session, onSelectLens }: Props) => {
         fit="fill"
         header={
           <HeaderBand
-            meta={
+            meta={<SessionBranchTag branch={sessionBranch} />}
+            title={hostTitle({ remoteKind, hasBothProviders })}
+            subtitle={
               mergeRequest != null && mergeRequestState != null ? (
-                <>
+                <div className="flex min-w-0 flex-wrap items-center gap-2">
                   <span className="font-mono text-2xs tabular-nums text-muted-foreground">
                     !{mergeRequest.iid}
                   </span>
                   <IssueStateBadge>{pullRequestMeta(mergeRequestState).label}</IssueStateBadge>
-                </>
+                  <span className="min-w-0 truncate text-sm text-muted-foreground">
+                    {mergeRequest.title}
+                  </span>
+                </div>
               ) : null
             }
-            title={mergeRequest?.title ?? hostTitle({ remoteKind, hasBothProviders })}
           />
         }
         {...(providerTabs != null && { tabs: providerTabs })}
@@ -245,10 +250,21 @@ const GithubPrCard = ({
   const error = github?.error ?? null;
   const refresh = () => void refreshSessionPr(sessionId, { force: true });
 
+  const workItems = buildWorkItems({
+    tasks: codeHostTasks,
+    currentBranch: branch,
+    branchPrs: branchPrs.length > 0 ? branchPrs : pr != null ? [pr] : [],
+  });
+
   const shell = ({ children }: { readonly children: ReactNode }) => (
     <StudioDetailLayout
       fit="fill"
-      header={<HeaderBand meta={null} title={hostTitle({ remoteKind, hasBothProviders })} />}
+      header={
+        <HeaderBand
+          meta={<SessionBranchTag branch={branch} />}
+          title={hostTitle({ remoteKind, hasBothProviders })}
+        />
+      }
       {...(tabs != null && { tabs })}
     >
       {children}
@@ -286,13 +302,10 @@ const GithubPrCard = ({
   if (!pr) {
     const hasLinkedWork = linkedIssues.length > 0 || codeHostTasks.length > 0;
     const openAction = (
-      <div className="flex items-center gap-2">
-        <SessionBranchTag branch={branch} />
-        <Button size="sm" onClick={onOpenStudio}>
-          Open in code host
-          <ArrowRight size={13} aria-hidden className="shrink-0 opacity-70" />
-        </Button>
-      </div>
+      <Button size="sm" onClick={onOpenStudio}>
+        Open in code host
+        <ArrowRight size={13} aria-hidden className="shrink-0 opacity-70" />
+      </Button>
     );
     if (!hasLinkedWork) {
       return shell({
@@ -311,11 +324,7 @@ const GithubPrCard = ({
       children: (
         <>
           <LinkedIssuesSection issues={linkedIssues} />
-          <ExternalTasksSection
-            tasks={codeHostTasks}
-            workspace={workspace}
-            onSelectLens={onSelectLens}
-          />
+          <WorkItemsSections groups={workItems} workspace={workspace} onSelectLens={onSelectLens} />
           <LensEmptyState
             tone={CONCEPT_TONE.pr}
             icon={CONCEPT_ICONS.pr}
@@ -337,10 +346,14 @@ const GithubPrCard = ({
       fit="fill"
       header={
         <HeaderBand
-          meta={
-            <PullRequestChip state={pr.state} variant="badge" number={pr.number} iconSize={12} />
+          meta={<SessionBranchTag branch={branch} />}
+          title={hostTitle({ remoteKind, hasBothProviders })}
+          subtitle={
+            <div className="flex min-w-0 flex-wrap items-center gap-2">
+              <PullRequestChip state={pr.state} variant="badge" number={pr.number} iconSize={12} />
+              <span className="min-w-0 truncate text-sm text-muted-foreground">{pr.title}</span>
+            </div>
           }
-          title={pr.title}
           actions={
             <>
               <RefreshIconButton
@@ -366,15 +379,12 @@ const GithubPrCard = ({
     >
       <LinkedPullRequestsSection
         prs={branchPrs.length > 0 ? branchPrs : [pr]}
+        branch={branch}
         selectedNumber={pr.number}
         onSelect={(prNumber) => void selectSessionPr(sessionId, prNumber)}
       />
       <LinkedIssuesSection issues={linkedIssues} />
-      <ExternalTasksSection
-        tasks={codeHostTasks}
-        workspace={workspace}
-        onSelectLens={onSelectLens}
-      />
+      <WorkItemsSections groups={workItems} workspace={workspace} onSelectLens={onSelectLens} />
       {error ? (
         <span className="text-2xs text-danger" title={error}>
           {error}
@@ -386,12 +396,25 @@ const GithubPrCard = ({
 
 type LinkedPullRequestsSectionProps = {
   readonly prs: ReadonlyArray<PullRequestState>;
+  readonly branch: string | null;
   readonly selectedNumber: number;
   readonly onSelect: (prNumber: number) => void;
 };
 
+const branchScopedLabel = ({
+  count,
+  branch,
+}: {
+  readonly count: number;
+  readonly branch: string | null;
+}): string => {
+  const noun = count === 1 ? 'Pull request' : `Pull requests (${count})`;
+  return branch == null || branch === '' ? noun : `${noun} on ${branch}`;
+};
+
 const LinkedPullRequestsSection = ({
   prs,
+  branch,
   selectedNumber,
   onSelect,
 }: LinkedPullRequestsSectionProps) => {
@@ -401,7 +424,7 @@ const LinkedPullRequestsSection = ({
   return (
     <div className="flex flex-col gap-1.5">
       <Eyebrow
-        label={prs.length === 1 ? 'Linked pull request' : `Linked pull requests (${prs.length})`}
+        label={branchScopedLabel({ count: prs.length, branch })}
         muted
         className="px-0.5 font-medium"
       />
@@ -471,24 +494,49 @@ const LinkedIssuesSection = ({ issues }: LinkedIssuesSectionProps) => {
   );
 };
 
-type ExternalTasksSectionProps = {
-  readonly tasks: ReadonlyArray<SessionExternalTask>;
+type WorkItemsSectionsProps = {
+  readonly groups: WorkItemGroups;
   readonly workspace: Workspace | null;
   readonly onSelectLens: (lens: LensKind) => void;
 };
 
-const ExternalTasksSection = ({ tasks, workspace, onSelectLens }: ExternalTasksSectionProps) => {
-  if (tasks.length === 0) {
+const WorkItemsSections = ({ groups, workspace, onSelectLens }: WorkItemsSectionsProps) => (
+  <>
+    <WorkItemsSection
+      label="External tasks"
+      items={groups.current}
+      workspace={workspace}
+      onSelectLens={onSelectLens}
+    />
+    <WorkItemsSection
+      label={`Completed work (${groups.history.length})`}
+      items={groups.history}
+      workspace={workspace}
+      onSelectLens={onSelectLens}
+    />
+  </>
+);
+
+type WorkItemsSectionProps = {
+  readonly label: string;
+  readonly items: ReadonlyArray<WorkItem>;
+  readonly workspace: Workspace | null;
+  readonly onSelectLens: (lens: LensKind) => void;
+};
+
+const WorkItemsSection = ({ label, items, workspace, onSelectLens }: WorkItemsSectionProps) => {
+  if (items.length === 0) {
     return null;
   }
   return (
     <div className="flex flex-col gap-1.5">
-      <Eyebrow label="External tasks" muted className="px-0.5 font-medium" />
+      <Eyebrow label={label} muted className="px-0.5 font-medium" />
       <div className="flex flex-col gap-1">
-        {tasks.map((task) => (
+        {items.map(({ key, task, branch }) => (
           <ExternalTaskChip
-            key={`${task.provider}:${task.externalId}:${task.mountWorkspaceId ?? ''}`}
+            key={key}
             task={task}
+            branchLabel={branch ?? undefined}
             appearance="row"
             navigation={task.provider === 'github' ? 'external' : 'internal'}
             ariaLabel={

--- a/apps/desktop/src/features/session/workItems.test.ts
+++ b/apps/desktop/src/features/session/workItems.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import type { IsoDateTime, PullRequestState, SessionExternalTask, SessionId } from '@goodboy/types';
+import { buildWorkItems } from './workItems';
+
+const SESSION_ID = 'session-1' as SessionId;
+const DATE = '2026-07-22T10:00:00.000Z' as IsoDateTime;
+
+type TaskParams = {
+  readonly overrides?: Partial<SessionExternalTask>;
+};
+
+const makeTask = ({ overrides = {} }: TaskParams): SessionExternalTask => ({
+  sessionId: SESSION_ID,
+  provider: 'linear',
+  externalId: 'GB-1',
+  identifier: 'GB-1',
+  url: 'https://linear.app/goodboy/issue/GB-1',
+  title: 'Ship the work item',
+  createdAt: DATE,
+  ...overrides,
+});
+
+type PrParams = {
+  readonly overrides?: Partial<PullRequestState>;
+};
+
+const makePr = ({ overrides = {} }: PrParams): PullRequestState => ({
+  number: 42,
+  title: 'Ship the work item',
+  url: 'https://github.com/acme/goodboy/pull/42',
+  state: 'open',
+  mergeable: true,
+  checks: 'success',
+  baseBranch: 'main',
+  headBranch: 'ak/current',
+  isDraft: false,
+  reviewDecision: null,
+  body: '',
+  updatedAt: DATE,
+  ...overrides,
+});
+
+describe('buildWorkItems', () => {
+  it('projects an issue on the current branch with the pull requests of that branch', () => {
+    const task = makeTask({ overrides: { branch: 'ak/current' } });
+
+    const { current, history } = buildWorkItems({
+      tasks: [task],
+      currentBranch: 'ak/current',
+      branchPrs: [makePr({})],
+    });
+
+    expect(history).toEqual([]);
+    expect(current).toHaveLength(1);
+    expect(current[0]?.branch).toBe('ak/current');
+    expect(current[0]?.prs.map((pr) => pr.number)).toEqual([42]);
+    expect(current[0]?.isCompleted).toBe(false);
+  });
+
+  it('moves an issue stamped on another branch to the history with no pull requests', () => {
+    const outgoing = makeTask({ overrides: { branch: 'ak/outgoing' } });
+
+    const { current, history } = buildWorkItems({
+      tasks: [outgoing],
+      currentBranch: 'ak/current',
+      branchPrs: [makePr({})],
+    });
+
+    expect(current).toEqual([]);
+    expect(history).toHaveLength(1);
+    expect(history[0]?.isOnCurrentBranch).toBe(false);
+    expect(history[0]?.prs).toEqual([]);
+  });
+
+  it('reads a merged work item as completed instead of current work', () => {
+    const task = makeTask({ overrides: { branch: 'ak/current' } });
+
+    const { current, history } = buildWorkItems({
+      tasks: [task],
+      currentBranch: 'ak/current',
+      branchPrs: [makePr({ overrides: { state: 'merged' } })],
+    });
+
+    expect(current).toEqual([]);
+    expect(history[0]?.isCompleted).toBe(true);
+  });
+
+  it('keeps an unstamped link on the current branch instead of hiding it', () => {
+    const { current, history } = buildWorkItems({
+      tasks: [makeTask({})],
+      currentBranch: 'ak/current',
+      branchPrs: [],
+    });
+
+    expect(history).toEqual([]);
+    expect(current[0]?.branch).toBeNull();
+  });
+});

--- a/apps/desktop/src/features/session/workItems.ts
+++ b/apps/desktop/src/features/session/workItems.ts
@@ -1,0 +1,44 @@
+import type { PullRequestState, SessionExternalTask } from '@goodboy/types';
+
+export type WorkItem = Readonly<{
+  key: string;
+  task: SessionExternalTask;
+  branch: string | null;
+  prs: ReadonlyArray<PullRequestState>;
+  isOnCurrentBranch: boolean;
+  isCompleted: boolean;
+}>;
+
+export type WorkItemGroups = Readonly<{
+  current: ReadonlyArray<WorkItem>;
+  history: ReadonlyArray<WorkItem>;
+}>;
+
+type Params = {
+  readonly tasks: ReadonlyArray<SessionExternalTask>;
+  readonly currentBranch: string | null;
+  readonly branchPrs: ReadonlyArray<PullRequestState>;
+};
+
+const workItemKey = ({ task }: { readonly task: SessionExternalTask }): string =>
+  `${task.provider}:${task.externalId}:${task.mountWorkspaceId ?? ''}:${task.branch ?? ''}`;
+
+export const buildWorkItems = ({ tasks, currentBranch, branchPrs }: Params): WorkItemGroups => {
+  const items = tasks.map((task) => {
+    const branch = task.branch ?? null;
+    const isOnCurrentBranch = branch == null || currentBranch == null || branch === currentBranch;
+    const prs = isOnCurrentBranch ? branchPrs : [];
+    return {
+      key: workItemKey({ task }),
+      task,
+      branch,
+      prs,
+      isOnCurrentBranch,
+      isCompleted: prs.length > 0 && prs.every((pr) => pr.state === 'merged'),
+    } satisfies WorkItem;
+  });
+  return {
+    current: items.filter((item) => item.isOnCurrentBranch && !item.isCompleted),
+    history: items.filter((item) => !item.isOnCurrentBranch || item.isCompleted),
+  };
+};

--- a/apps/desktop/src/store/slices/sessions/createSession.ts
+++ b/apps/desktop/src/store/slices/sessions/createSession.ts
@@ -224,6 +224,7 @@ export const createSession = (set: SetFn, get: GetFn) => {
         ...(externalTask.mountWorkspaceId != null
           ? { mountWorkspaceId: externalTask.mountWorkspaceId }
           : {}),
+        ...(worktree.branchName !== '' ? { branch: worktree.branchName } : {}),
         provider: externalTask.provider,
         externalId: externalTask.externalId,
         identifier: externalTask.identifier,

--- a/apps/desktop/src/store/slices/sessions/index.test.ts
+++ b/apps/desktop/src/store/slices/sessions/index.test.ts
@@ -1140,6 +1140,21 @@ describe('store contract', () => {
       ]);
     });
 
+    it('stamps the branch the session is on when an issue is linked', async () => {
+      const store = await getStore();
+      const db = await import('@goodboy/db');
+      store.setState({ sessionBranches: { [SESSION_ID]: 'ak/fix-auth' } });
+
+      await store.getState().linkSessionExternalTask(SESSION_ID, LINEAR_TASK);
+
+      const linkedTask = { ...LINEAR_TASK, sessionId: SESSION_ID, branch: 'ak/fix-auth' };
+      expect(vi.mocked(db.upsertSessionExternalTask)).toHaveBeenCalledWith({
+        db: expect.anything(),
+        task: linkedTask,
+      });
+      expect(store.getState().sessionExternalTasks[SESSION_ID]).toEqual([linkedTask]);
+    });
+
     it('attributes a linked task to the active composite mount', async () => {
       const store = await getStore();
       const db = await import('@goodboy/db');
@@ -1179,6 +1194,7 @@ describe('store contract', () => {
         ...LINEAR_TASK,
         sessionId: SESSION_ID,
         mountWorkspaceId: memberWorkspaceId,
+        branch: 'ak/member',
       };
       expect(vi.mocked(db.upsertSessionExternalTask)).toHaveBeenCalledWith({
         db: expect.anything(),

--- a/apps/desktop/src/store/slices/sessions/linkSessionExternalTask.ts
+++ b/apps/desktop/src/store/slices/sessions/linkSessionExternalTask.ts
@@ -19,10 +19,12 @@ export const linkSessionExternalTask = ({ set, get }: Params) => {
     const workspace = state.workspaces.find((candidate) => candidate.id === session?.workspaceId);
     const repo = workspace?.kind === 'composite' ? resolveSessionRepo({ state, sessionId }) : null;
     const mountWorkspaceId = task.mountWorkspaceId ?? repo?.workspaceId;
+    const branch = task.branch ?? repo?.branch ?? state.sessionBranches[sessionId] ?? null;
     const linkedTask: SessionExternalTask = {
       ...task,
       sessionId,
       ...(mountWorkspaceId != null ? { mountWorkspaceId } : {}),
+      ...(branch != null && branch !== '' ? { branch } : {}),
     };
     await upsertSessionExternalTask({ db: tauriDatabase, task: linkedTask });
     set((state) => {

--- a/apps/desktop/src/store/slices/worktrees/announceSessionBranchChange.ts
+++ b/apps/desktop/src/store/slices/worktrees/announceSessionBranchChange.ts
@@ -1,0 +1,34 @@
+import type { SessionId } from '@goodboy/types';
+import type { GetFn } from './types';
+
+type Params = {
+  readonly get: GetFn;
+  readonly sessionId: SessionId;
+  readonly fromBranch: string | null;
+  readonly toBranch: string;
+};
+
+export const announceSessionBranchChange = async ({
+  get,
+  sessionId,
+  fromBranch,
+  toBranch,
+}: Params): Promise<void> => {
+  if (fromBranch === toBranch) {
+    return;
+  }
+  const state = get();
+  const session = state.sessions.find((candidate) => candidate.id === sessionId);
+  const carried = (state.sessionExternalTasks[sessionId] ?? []).filter(
+    (task) => task.branch != null && task.branch !== toBranch,
+  );
+  const outgoing = fromBranch == null ? 'the previous branch' : fromBranch;
+  const body =
+    carried.length === 0
+      ? `Pull requests now read from ${toBranch}.`
+      : `${carried.length} linked ${carried.length === 1 ? 'issue stays' : 'issues stay'} on ${outgoing} and moved to the work history. Pull requests now read from ${toBranch}.`;
+  await get().emitNotification('branch-changed', 'info', `Branch is now ${toBranch}`, body, {
+    sessionId,
+    ...(session != null ? { workspaceId: session.workspaceId } : {}),
+  });
+};

--- a/apps/desktop/src/store/slices/worktrees/changeSessionBranch.test.ts
+++ b/apps/desktop/src/store/slices/worktrees/changeSessionBranch.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SessionId } from '@goodboy/types';
+
+const h = vi.hoisted(() => ({
+  listWorktreesForSession: vi.fn(async () => [
+    {
+      worktreePath: '/repos/goodboy/.goodboy/worktrees/task',
+      branch: 'ak/outgoing',
+      parallelIndex: 0,
+    },
+  ]),
+  updateSessionWorktreeBranch: vi.fn(async () => undefined),
+  changeWorktreeBranch: vi.fn(async () => undefined),
+  emitNotification: vi.fn(async () => undefined),
+}));
+
+vi.mock('@goodboy/db', () => ({
+  listWorktreesForSession: h.listWorktreesForSession,
+  updateSessionWorktreeBranch: h.updateSessionWorktreeBranch,
+}));
+
+vi.mock('../../../shared/lib/db', () => ({ tauriDatabase: {} }));
+
+vi.mock('../../../features/worktree/worktree', () => ({
+  changeWorktreeBranch: h.changeWorktreeBranch,
+  invalidateLocalBranchesCache: vi.fn(),
+}));
+
+import { changeSessionBranch } from './changeSessionBranch';
+
+const SESSION_ID = 'session-1' as SessionId;
+
+type State = Record<string, unknown>;
+
+const makeState = (): State => ({
+  sessions: [{ id: SESSION_ID, workspaceId: 'workspace-1' }],
+  workspaces: [{ id: 'workspace-1', kind: 'repo', rootPath: '/repos/goodboy' }],
+  sessionBranches: { [SESSION_ID]: 'ak/outgoing' },
+  sessionMounts: {},
+  sessionGithub: { [SESSION_ID]: { pr: { number: 42 } } },
+  sessionGithubPrs: { [SESSION_ID]: [{ number: 42 }] },
+  sessionSelectedPrNumber: { [SESSION_ID]: 40 },
+  sessionExternalTasks: {
+    [SESSION_ID]: [{ provider: 'linear', externalId: 'GB-1', branch: 'ak/outgoing' }],
+  },
+  emitNotification: h.emitNotification,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('changeSessionBranch', () => {
+  it('surfaces the branch change as an event naming the work it leaves behind', async () => {
+    const state = makeState();
+    const set = vi.fn((updater: (current: State) => State) => {
+      Object.assign(state, updater(state));
+    });
+
+    await changeSessionBranch(set as never, (() => state) as never)(SESSION_ID, {
+      branch: 'ak/incoming',
+      createNew: false,
+    });
+
+    expect(h.emitNotification).toHaveBeenCalledWith(
+      'branch-changed',
+      'info',
+      'Branch is now ak/incoming',
+      '1 linked issue stays on ak/outgoing and moved to the work history. Pull requests now read from ak/incoming.',
+      { sessionId: SESSION_ID, workspaceId: 'workspace-1' },
+    );
+  });
+
+  it('resets the pull requests of the outgoing branch and the selected one', async () => {
+    const state = makeState();
+    const set = vi.fn((updater: (current: State) => State) => {
+      Object.assign(state, updater(state));
+    });
+
+    await changeSessionBranch(set as never, (() => state) as never)(SESSION_ID, {
+      branch: 'ak/incoming',
+      createNew: false,
+    });
+
+    expect(state.sessionBranches).toEqual({ [SESSION_ID]: 'ak/incoming' });
+    expect(state.sessionGithub).toEqual({});
+    expect(state.sessionGithubPrs).toEqual({});
+    expect(state.sessionSelectedPrNumber).toEqual({});
+  });
+});

--- a/apps/desktop/src/store/slices/worktrees/changeSessionBranch.ts
+++ b/apps/desktop/src/store/slices/worktrees/changeSessionBranch.ts
@@ -6,6 +6,7 @@ import {
   invalidateLocalBranchesCache,
 } from '../../../features/worktree/worktree';
 import { isBranchlessSession } from '../../../shared/utils/isBranchlessSession';
+import { announceSessionBranchChange } from './announceSessionBranchChange';
 import { getSessionRepo } from './getSessionRepo';
 import type { GetFn, SetFn } from './types';
 
@@ -66,9 +67,14 @@ export const changeSessionBranch = (set: SetFn, get: GetFn) => {
       changedWorktree.parallelIndex,
       target,
     );
+    const previousBranch = changedWorktree.branch;
     set((state) => {
       const nextGithub = { ...state.sessionGithub };
+      const nextGithubPrs = { ...state.sessionGithubPrs };
+      const nextSelectedPrNumber = { ...state.sessionSelectedPrNumber };
       delete nextGithub[sessionId];
+      delete nextGithubPrs[sessionId];
+      delete nextSelectedPrNumber[sessionId];
       const mounts = state.sessionMounts[sessionId] ?? [];
       const shouldUpdateSessionBranch =
         workspace.kind !== 'composite' || mounts[0]?.worktreePath === worktreePath;
@@ -87,7 +93,15 @@ export const changeSessionBranch = (set: SetFn, get: GetFn) => {
           : state.sessionBranches,
         sessionMounts,
         sessionGithub: nextGithub,
+        sessionGithubPrs: nextGithubPrs,
+        sessionSelectedPrNumber: nextSelectedPrNumber,
       };
+    });
+    await announceSessionBranchChange({
+      get,
+      sessionId,
+      fromBranch: previousBranch,
+      toBranch: target,
     });
   };
 };

--- a/apps/desktop/src/store/slices/worktrees/reconcileSessionBranch.test.ts
+++ b/apps/desktop/src/store/slices/worktrees/reconcileSessionBranch.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SessionId } from '@goodboy/types';
+
+const WORKTREE_PATH = '/repos/goodboy/.goodboy/worktrees/task';
+
+const h = vi.hoisted(() => ({
+  listWorktreesForSession: vi.fn(async () => [
+    {
+      worktreePath: '/repos/goodboy/.goodboy/worktrees/task',
+      branch: 'ak/outgoing',
+      parallelIndex: 0,
+    },
+  ]),
+  updateSessionWorktreeBranch: vi.fn(async () => undefined),
+  emitNotification: vi.fn(async () => undefined),
+}));
+
+vi.mock('@goodboy/db', () => ({
+  listWorktreesForSession: h.listWorktreesForSession,
+  updateSessionWorktreeBranch: h.updateSessionWorktreeBranch,
+}));
+
+vi.mock('../../../shared/lib/db', () => ({ tauriDatabase: {} }));
+
+import { reconcileSessionBranch } from './reconcileSessionBranch';
+
+const SESSION_ID = 'session-1' as SessionId;
+
+type State = Record<string, unknown>;
+
+const makeState = (): State => ({
+  sessions: [{ id: SESSION_ID, workspaceId: 'workspace-1' }],
+  workspaces: [{ id: 'workspace-1', kind: 'repo', rootPath: '/repos/goodboy' }],
+  sessionBranches: { [SESSION_ID]: 'ak/outgoing' },
+  sessionMounts: {},
+  sessionWorktrees: { [SESSION_ID]: [WORKTREE_PATH] },
+  sessionActiveMount: {},
+  sessionGithub: { [SESSION_ID]: { pr: { number: 42 } } },
+  sessionGithubPrs: { [SESSION_ID]: [{ number: 42 }] },
+  sessionSelectedPrNumber: { [SESSION_ID]: 40 },
+  sessionExternalTasks: { [SESSION_ID]: [] },
+  emitNotification: h.emitNotification,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('reconcileSessionBranch', () => {
+  it('announces a branch observed outside the app and resets the branch pull requests', async () => {
+    const state = makeState();
+    const set = vi.fn((updater: (current: State) => State) => {
+      Object.assign(state, updater(state));
+    });
+
+    await reconcileSessionBranch(set as never, (() => state) as never)(SESSION_ID, 'ak/incoming');
+
+    expect(h.emitNotification).toHaveBeenCalledWith(
+      'branch-changed',
+      'info',
+      'Branch is now ak/incoming',
+      'Pull requests now read from ak/incoming.',
+      { sessionId: SESSION_ID, workspaceId: 'workspace-1' },
+    );
+    expect(state.sessionBranches).toEqual({ [SESSION_ID]: 'ak/incoming' });
+    expect(state.sessionGithubPrs).toEqual({});
+    expect(state.sessionSelectedPrNumber).toEqual({});
+  });
+
+  it('stays silent when the observed branch is the one already recorded', async () => {
+    const state = makeState();
+    const set = vi.fn();
+
+    await reconcileSessionBranch(set as never, (() => state) as never)(SESSION_ID, 'ak/outgoing');
+
+    expect(set).not.toHaveBeenCalled();
+    expect(h.emitNotification).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/store/slices/worktrees/reconcileSessionBranch.ts
+++ b/apps/desktop/src/store/slices/worktrees/reconcileSessionBranch.ts
@@ -2,6 +2,7 @@ import type { SessionId } from '@goodboy/types';
 import { listWorktreesForSession, updateSessionWorktreeBranch } from '@goodboy/db';
 import { tauriDatabase } from '../../../shared/lib/db';
 import { isBranchlessSession } from '../../../shared/utils/isBranchlessSession';
+import { announceSessionBranchChange } from './announceSessionBranchChange';
 import { getSessionRepo } from './getSessionRepo';
 import type { GetFn, SetFn } from './types';
 
@@ -45,9 +46,14 @@ export const reconcileSessionBranch = (set: SetFn, get: GetFn) => {
         trimmed,
       );
     }
+    const previousBranch = repo.branch;
     set((state) => {
       const nextGithub = { ...state.sessionGithub };
+      const nextGithubPrs = { ...state.sessionGithubPrs };
+      const nextSelectedPrNumber = { ...state.sessionSelectedPrNumber };
       delete nextGithub[sessionId];
+      delete nextGithubPrs[sessionId];
+      delete nextSelectedPrNumber[sessionId];
       const mounts = state.sessionMounts[sessionId] ?? [];
       const shouldUpdateSessionBranch =
         workspace?.kind !== 'composite' || mounts[0]?.worktreePath === repo.worktreePath;
@@ -66,7 +72,15 @@ export const reconcileSessionBranch = (set: SetFn, get: GetFn) => {
           : state.sessionBranches,
         sessionMounts,
         sessionGithub: nextGithub,
+        sessionGithubPrs: nextGithubPrs,
+        sessionSelectedPrNumber: nextSelectedPrNumber,
       };
+    });
+    await announceSessionBranchChange({
+      get,
+      sessionId,
+      fromBranch: previousBranch,
+      toBranch: trimmed,
     });
   };
 };

--- a/apps/desktop/src/store/store.branchless-session.test.ts
+++ b/apps/desktop/src/store/store.branchless-session.test.ts
@@ -73,6 +73,9 @@ type Store = {
   sessionBranches: Record<string, string>;
   sessionWorktrees: Record<string, ReadonlyArray<string>>;
   sessionGithub: Record<string, unknown>;
+  sessionGithubPrs: Record<string, ReadonlyArray<unknown>>;
+  sessionSelectedPrNumber: Record<string, number | null>;
+  sessionExternalTasks: Record<string, ReadonlyArray<{ readonly branch?: string }>>;
   sessionPhaseRuns: Record<string, ReadonlyArray<unknown>>;
   closeSessionTerminals: () => void;
   emitNotification: () => void;
@@ -85,6 +88,9 @@ const makeStore = (branch: string): Store => ({
   sessionBranches: { 'sess-1': branch },
   sessionWorktrees: { 'sess-1': ['/root/sessions/study-plan'] },
   sessionGithub: {},
+  sessionGithubPrs: {},
+  sessionSelectedPrNumber: {},
+  sessionExternalTasks: {},
   sessionPhaseRuns: {},
   closeSessionTerminals: vi.fn(),
   emitNotification: vi.fn(),

--- a/apps/desktop/src/store/store.composite-session.test.ts
+++ b/apps/desktop/src/store/store.composite-session.test.ts
@@ -123,6 +123,7 @@ type Store = {
   sessionGithub: Record<string, unknown>;
   sessionGithubPrs: Record<string, ReadonlyArray<unknown>>;
   sessionSelectedPrNumber: Record<string, number | null>;
+  sessionExternalTasks: Record<string, ReadonlyArray<{ readonly branch?: string }>>;
   sessionPhaseRuns: Record<string, ReadonlyArray<unknown>>;
   closeSessionTerminals: () => void;
   emitNotification: () => void;
@@ -179,6 +180,7 @@ const makeStore = ({ activeMount }: MakeStoreParams): Store => ({
   sessionGithub: {},
   sessionGithubPrs: {},
   sessionSelectedPrNumber: {},
+  sessionExternalTasks: {},
   sessionPhaseRuns: {},
   closeSessionTerminals: vi.fn(),
   emitNotification: vi.fn(),

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -100,6 +100,7 @@ import { m099FileVersions } from './m099-file-versions';
 import { m100WorkflowOrigin } from './m100-workflow-origin';
 import { m101TelemetryOrchestratorKind } from './m101-telemetry-orchestrator-kind';
 import { m102WorkflowOrchestrationStopKind } from './m102-workflow-orchestration-stop-kind';
+import { m103SessionExternalTaskBranch } from './m103-session-external-task-branch';
 
 export type Migration = {
   readonly version: number;
@@ -209,4 +210,5 @@ export const migrations: ReadonlyArray<Migration> = [
   { version: 100, sql: m100WorkflowOrigin },
   { version: 101, sql: m101TelemetryOrchestratorKind },
   { version: 102, sql: m102WorkflowOrchestrationStopKind },
+  { version: 103, sql: m103SessionExternalTaskBranch },
 ];

--- a/packages/db/src/migrations/m103-session-external-task-branch.test.ts
+++ b/packages/db/src/migrations/m103-session-external-task-branch.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+import type { Database } from '../client';
+import { makeTestDatabase } from '../test-helpers/test-db';
+import { migrate } from './runner';
+import { migrations } from './index';
+
+const workspaceId = 'ws-1';
+const sessionId = 's-1';
+
+const seedThrough102 = async (): Promise<Database> => {
+  const db = makeTestDatabase();
+  await migrate(
+    db,
+    migrations.filter((migration) => migration.version <= 102),
+  );
+  const now = Date.now();
+  await db.execute(
+    'INSERT INTO workspaces (id, name, root_path, created_at, updated_at) VALUES (?, ?, ?, ?, ?)',
+    [workspaceId, 'ws', '/tmp/ws', now, now],
+  );
+  await db.execute(
+    'INSERT INTO sessions (id, workspace_id, goal, state_kind, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)',
+    [sessionId, workspaceId, 'goal', 'idle', now, now],
+  );
+  return db;
+};
+
+type WorktreeParams = {
+  readonly db: Database;
+  readonly branch: string;
+  readonly parallelIndex: number;
+};
+
+const insertWorktree = async ({ db, branch, parallelIndex }: WorktreeParams): Promise<void> => {
+  await db.execute(
+    `INSERT INTO session_worktrees (id, session_id, worktree_path, branch, parallel_index, created_at)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+    [
+      `wt-${parallelIndex}`,
+      sessionId,
+      `/tmp/wt-${parallelIndex}`,
+      branch,
+      parallelIndex,
+      Date.now(),
+    ],
+  );
+};
+
+type TaskParams = {
+  readonly db: Database;
+  readonly externalId: string;
+};
+
+const insertTask = async ({ db, externalId }: TaskParams): Promise<void> => {
+  await db.execute(
+    `INSERT INTO session_external_tasks
+       (session_id, mount_workspace_id, provider, external_id, identifier, url, title, created_at)
+     VALUES (?, NULL, 'linear', ?, ?, 'https://linear.app/goodboy/issue/GB-1', 'Ship it', ?)`,
+    [sessionId, externalId, externalId, Date.now()],
+  );
+};
+
+type DbParams = {
+  readonly db: Database;
+};
+
+const branchRows = async ({
+  db,
+}: DbParams): Promise<ReadonlyArray<{ external_id: string; branch: string | null }>> =>
+  db.select<{ external_id: string; branch: string | null }>(
+    'SELECT external_id, branch FROM session_external_tasks ORDER BY external_id',
+  );
+
+describe('m103 session external task branch', () => {
+  it('backfills an existing link with the branch of the session', async () => {
+    const db = await seedThrough102();
+    await insertWorktree({ db, branch: 'ak/fix-auth', parallelIndex: 0 });
+    await insertTask({ db, externalId: 'GB-1' });
+
+    await migrate(db, migrations);
+
+    expect(await branchRows({ db })).toEqual([{ external_id: 'GB-1', branch: 'ak/fix-auth' }]);
+  });
+
+  it('backfills from the primary worktree when the session has several', async () => {
+    const db = await seedThrough102();
+    await insertWorktree({ db, branch: 'ak/primary', parallelIndex: 0 });
+    await insertWorktree({ db, branch: 'ak/parallel', parallelIndex: 1 });
+    await insertTask({ db, externalId: 'GB-2' });
+
+    await migrate(db, migrations);
+
+    expect(await branchRows({ db })).toEqual([{ external_id: 'GB-2', branch: 'ak/primary' }]);
+  });
+
+  it('leaves a link with no worktree unstamped instead of failing', async () => {
+    const db = await seedThrough102();
+    await insertTask({ db, externalId: 'GB-3' });
+
+    await migrate(db, migrations);
+
+    expect(await branchRows({ db })).toEqual([{ external_id: 'GB-3', branch: null }]);
+  });
+
+  it('keeps the identity index and the cascade of the table', async () => {
+    const db = await seedThrough102();
+    await insertWorktree({ db, branch: 'ak/fix-auth', parallelIndex: 0 });
+    await insertTask({ db, externalId: 'GB-4' });
+
+    await migrate(db, migrations);
+
+    const indexes = await db.select<{ name: string }>(
+      "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'session_external_tasks' AND sql IS NOT NULL ORDER BY name",
+    );
+    expect(indexes.map((index) => index.name)).toEqual([
+      'idx_session_external_tasks_identity',
+      'idx_session_external_tasks_provider_external',
+    ]);
+    await db.execute('DELETE FROM sessions WHERE id = ?', [sessionId]);
+    expect(await branchRows({ db })).toEqual([]);
+  });
+});

--- a/packages/db/src/migrations/m103-session-external-task-branch.ts
+++ b/packages/db/src/migrations/m103-session-external-task-branch.ts
@@ -1,0 +1,13 @@
+export const m103SessionExternalTaskBranch = /* sql */ `
+ALTER TABLE session_external_tasks ADD COLUMN branch TEXT;
+
+UPDATE session_external_tasks
+   SET branch = (
+     SELECT w.branch
+       FROM session_worktrees w
+      WHERE w.session_id = session_external_tasks.session_id
+      ORDER BY w.parallel_index ASC
+      LIMIT 1
+   )
+ WHERE branch IS NULL;
+`;

--- a/packages/db/src/queries/notification.ts
+++ b/packages/db/src/queries/notification.ts
@@ -11,6 +11,7 @@ export type NotificationKind =
   | 'pr-created'
   | 'workspace-deleted'
   | 'boundary-drift'
+  | 'branch-changed'
   | 'budget-cap'
   | 'title-generation'
   | 'provider-connected'

--- a/packages/db/src/queries/session-external-task.test.ts
+++ b/packages/db/src/queries/session-external-task.test.ts
@@ -17,7 +17,7 @@ type SeedParams = {
   readonly throughVersion?: number;
 };
 
-const seed = async ({ throughVersion = 96 }: SeedParams) => {
+const seed = async ({ throughVersion = 103 }: SeedParams) => {
   const db = makeTestDatabase();
   await migrate(
     db,
@@ -178,17 +178,7 @@ describe('session_external_tasks queries', () => {
         Date.parse(original.createdAt),
       ],
     );
-    const migration = migrations.find((candidate) => candidate.version === 71);
-    if (migration == null) {
-      throw new Error('Migration 71 should exist');
-    }
-
-    await migrate(db, [migration]);
-    const mountMigration = migrations.find((candidate) => candidate.version === 96);
-    if (mountMigration == null) {
-      throw new Error('Migration 96 should exist');
-    }
-    await migrate(db, [mountMigration]);
+    await migrate(db, migrations);
 
     expect(await listSessionExternalTasks({ db, sessionId })).toEqual([original]);
   });
@@ -218,17 +208,7 @@ describe('session_external_tasks queries', () => {
         Date.parse(gitlab.createdAt),
       ],
     );
-    const migration = migrations.find((candidate) => candidate.version === 73);
-    if (migration == null) {
-      throw new Error('Migration 73 should exist');
-    }
-
-    await migrate(db, [migration]);
-    const mountMigration = migrations.find((candidate) => candidate.version === 96);
-    if (mountMigration == null) {
-      throw new Error('Migration 96 should exist');
-    }
-    await migrate(db, [mountMigration]);
+    await migrate(db, migrations);
     const github = makeTask({
       overrides: {
         provider: 'github',
@@ -260,13 +240,29 @@ describe('session_external_tasks queries', () => {
         Date.parse(original.createdAt),
       ],
     );
-    const migration = migrations.find((candidate) => candidate.version === 96);
-    if (migration == null) {
-      throw new Error('Migration 96 should exist');
-    }
-
-    await migrate(db, [migration]);
+    await migrate(db, migrations);
 
     expect(await listSessionExternalTasks({ db, sessionId })).toEqual([original]);
+  });
+
+  it('keeps the branch an issue was linked on', async () => {
+    const db = await seed({});
+    const stamped = makeTask({ overrides: { branch: 'ak/fix-auth' } });
+    await upsertSessionExternalTask({ db, task: stamped });
+
+    expect(await listSessionExternalTasks({ db, sessionId })).toEqual([stamped]);
+  });
+
+  it('keeps the original branch when the same link is upserted without one', async () => {
+    const db = await seed({});
+    await upsertSessionExternalTask({
+      db,
+      task: makeTask({ overrides: { branch: 'ak/fix-auth' } }),
+    });
+    await upsertSessionExternalTask({ db, task: makeTask({ overrides: { title: 'Renamed' } }) });
+
+    expect(await listSessionExternalTasks({ db, sessionId })).toEqual([
+      makeTask({ overrides: { branch: 'ak/fix-auth', title: 'Renamed' } }),
+    ]);
   });
 });

--- a/packages/db/src/queries/session-external-task.ts
+++ b/packages/db/src/queries/session-external-task.ts
@@ -10,6 +10,7 @@ import type { Database } from '../client';
 type SessionExternalTaskRow = {
   readonly session_id: string;
   readonly mount_workspace_id: string | null;
+  readonly branch: string | null;
   readonly provider: string;
   readonly external_id: string;
   readonly identifier: string;
@@ -27,6 +28,7 @@ const toDomain = ({ row }: ToDomainParams): SessionExternalTask => ({
   ...(row.mount_workspace_id != null
     ? { mountWorkspaceId: row.mount_workspace_id as WorkspaceId }
     : {}),
+  ...(row.branch != null ? { branch: row.branch } : {}),
   provider: row.provider as SessionExternalTaskProvider,
   externalId: row.external_id,
   identifier: row.identifier,
@@ -43,15 +45,17 @@ type UpsertParams = {
 export const upsertSessionExternalTask = async ({ db, task }: UpsertParams): Promise<void> => {
   await db.execute(
     `INSERT INTO session_external_tasks
-       (session_id, mount_workspace_id, provider, external_id, identifier, url, title, created_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+       (session_id, mount_workspace_id, branch, provider, external_id, identifier, url, title, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
      ON CONFLICT DO UPDATE SET
        identifier = excluded.identifier,
        url = excluded.url,
-       title = excluded.title`,
+       title = excluded.title,
+       branch = COALESCE(excluded.branch, session_external_tasks.branch)`,
     [
       task.sessionId,
       task.mountWorkspaceId ?? null,
+      task.branch ?? null,
       task.provider,
       task.externalId,
       task.identifier,
@@ -72,7 +76,7 @@ export const listSessionExternalTasks = async ({
   sessionId,
 }: ListForSessionParams): Promise<ReadonlyArray<SessionExternalTask>> => {
   const rows = await db.select<SessionExternalTaskRow>(
-    `SELECT session_id, mount_workspace_id, provider, external_id, identifier, url, title, created_at
+    `SELECT session_id, mount_workspace_id, branch, provider, external_id, identifier, url, title, created_at
        FROM session_external_tasks
       WHERE session_id = ?
       ORDER BY created_at ASC, provider ASC, external_id ASC, mount_workspace_id ASC`,
@@ -91,7 +95,7 @@ export const listExternalTasksForWorkspace = async ({
   workspaceId,
 }: ListForWorkspaceParams): Promise<ReadonlyArray<SessionExternalTask>> => {
   const rows = await db.select<SessionExternalTaskRow>(
-    `SELECT t.session_id, t.mount_workspace_id, t.provider, t.external_id, t.identifier, t.url, t.title, t.created_at
+    `SELECT t.session_id, t.mount_workspace_id, t.branch, t.provider, t.external_id, t.identifier, t.url, t.title, t.created_at
        FROM session_external_tasks t
        INNER JOIN sessions s ON s.id = t.session_id
       WHERE s.workspace_id = ?

--- a/packages/types/src/workspace.ts
+++ b/packages/types/src/workspace.ts
@@ -196,6 +196,7 @@ export type SessionExternalTaskProvider = 'linear' | 'sentry' | 'gitlab' | 'gith
 export type SessionExternalTask = Readonly<{
   sessionId: SessionId;
   mountWorkspaceId?: WorkspaceId;
+  branch?: string;
   provider: SessionExternalTaskProvider;
   externalId: string;
   identifier: string;


### PR DESCRIPTION
## Goal A: one grammar for section titles

Correction to the original complaint: it was not two surfaces, it was five, and the collapse was cardinality-gated, so the page structure changed depending on how many records were linked.

- `PrPane` rendered the PR title as the header. It now states GitHub / GitLab / Code host work, with the record identity as subtitle and the branch in meta.
- `IntegrationPane` auto-focused a record when exactly one was linked, which is what made linear, sentry and gitlab_issues lose their section title. The list is always the landing surface now; focusing a record renders it inside `FocusedPane`, so the section title stays above it. Unlink, All issues and Link issue moved to the pane toolbar, which is what `DESIGN.md` prescribes for a record alone in a pane.
- `ReviewBoardPane` used `repo #number` as its title; it says Review board now, with the reference as a secondary chip.

Zero, one and two linked records all produce the same page structure. Tested at each cardinality on every surface.

## Goal B: the link model, smallest correct increment

A **work item is a projection, not an entity**: a linked issue, the branch stamped on it, and the pull requests of that branch. No new table, no new studio, one migration.

- `session_external_tasks` gains a nullable `branch` (m103), stamped at link time, backfilled from the session's primary worktree. It is data, not identity: the unique index is untouched, so relinking restamps instead of duplicating.
- Everything else stays derived: PRs remain `gh pr list --head <branch>`, issue-to-PR stays GitHub's own read-only inference.
- The PR list now names its branch. A branch change emits an event saying which branch replaced which and how much work moved to history, instead of silently dropping the PR cache; both branch mutations also reset the selected PR, which is per-branch state. A work item whose PRs are all merged renders muted under Completed work.
- An unstamped legacy link stays current, so nothing disappears for existing sessions.

Explicitly out of scope and not implemented: issue references written into PR bodies, several live branches at once, a stored branch-history table, any suggest-a-new-session heuristic.

## Verification

Run on this tree rebased onto current main:

- `vitest` desktop: 4153 passed, 477 files
- `vitest` packages/db: 166 passed, 23 files
- `tsc --noEmit` on desktop, db, types: clean
- `knip --include files,duplicates,unlisted`: clean

Two mutation checks: restoring the PR title as the header fails the cardinality tests naming the missing heading; dropping the branch stamp fails the link test showing the absent field.

Known limit, stated rather than hidden: completion detection reads the GitHub PR list, so a GitLab-hosted repo cannot mark a work item merged yet. That follows from keeping PRs derived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)