### PR TITLE
feat(desktop): edit a linked issue description in place

### DIFF
--- a/apps/desktop/src/features/github/GithubIssueDetail/index.test.tsx
+++ b/apps/desktop/src/features/github/GithubIssueDetail/index.test.tsx
@@ -1,6 +1,13 @@
-import { afterEach, describe, expect, it } from 'vitest';
-import { cleanup, render, screen } from '@testing-library/react';
-import type { GithubIssue } from '@goodboy/types';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { GithubIssue, WorkspaceId } from '@goodboy/types';
+
+const h = vi.hoisted(() => ({
+  ghUpdateIssueBody: vi.fn(),
+}));
+
+vi.mock('../github', () => ({ ghUpdateIssueBody: h.ghUpdateIssueBody }));
+
 import { GithubIssueDetail } from './index';
 
 const ISSUE: GithubIssue = {
@@ -13,7 +20,15 @@ const ISSUE: GithubIssue = {
   updatedAt: '2026-07-22T10:00:00Z',
 };
 
-afterEach(cleanup);
+const EDIT_CONTEXT = {
+  workspaceId: 'workspace-1' as WorkspaceId,
+  rootPath: '/repo',
+};
+
+afterEach(() => {
+  h.ghUpdateIssueBody.mockReset();
+  cleanup();
+});
 
 describe('GithubIssueDetail', () => {
   it('renders the issue title, description and properties', () => {
@@ -29,5 +44,33 @@ describe('GithubIssueDetail', () => {
     render(<GithubIssueDetail issue={{ ...ISSUE, body: '' }} />);
 
     expect(screen.getByText('No description.')).toBeDefined();
+  });
+
+  it('offers no description editing without an edit context', () => {
+    render(<GithubIssueDetail issue={ISSUE} />);
+
+    expect(screen.queryByRole('button', { name: 'Edit' })).toBeNull();
+  });
+
+  it('writes the edited description to GitHub and shows the stored body', async () => {
+    h.ghUpdateIssueBody.mockResolvedValueOnce('Rewritten from Goodboy.');
+    render(<GithubIssueDetail issue={ISSUE} editContext={EDIT_CONTEXT} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    fireEvent.change(screen.getByRole('textbox', { name: 'Edit description' }), {
+      target: { value: 'Rewritten from Goodboy.' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() =>
+      expect(h.ghUpdateIssueBody).toHaveBeenCalledWith({
+        cwd: '/repo',
+        issueNumber: 42,
+        body: 'Rewritten from Goodboy.',
+        workspaceId: 'workspace-1',
+      }),
+    );
+    await waitFor(() => expect(screen.getByText('Rewritten from Goodboy.')).toBeDefined());
+    expect(screen.queryByText('Show assigned issues in GitHub Studio.')).toBeNull();
   });
 });

--- a/apps/desktop/src/features/github/GithubIssueDetail/index.tsx
+++ b/apps/desktop/src/features/github/GithubIssueDetail/index.tsx
@@ -1,28 +1,38 @@
 import { useMemo, type ReactNode } from 'react';
-import { Markdown } from '@goodboy/ui';
 import type { GithubIssue } from '@goodboy/types';
-import {
-  DetailSection,
-  HeaderBand,
-  StudioDetailLayout,
-} from '../../../shared/components/StudioDetail';
+import { HeaderBand, StudioDetailLayout } from '../../../shared/components/StudioDetail';
 import { githubIssueFields, resolveDetailFields } from '../../../shared/detail-fields';
 import { IssueStateBadge } from '../../../shared/components/IssueStateBadge';
 import { ExternalRefActions } from '../../../shared/components/ExternalRefActions';
+import { DescriptionSection } from '../../../shared/components/DescriptionSection';
+import {
+  useGithubIssueDescription,
+  type GithubIssueEditContext,
+} from '../useGithubIssueDescription';
 
 type Fit = 'fill' | 'bleed' | 'flow';
 
 type Props = {
   readonly issue: GithubIssue;
   readonly headerActions?: ReactNode;
+  readonly dock?: ReactNode;
   readonly fit?: Fit;
+  readonly editContext?: GithubIssueEditContext | null;
 };
 
-export const GithubIssueDetail = ({ issue, headerActions, fit = 'fill' }: Props) => {
+export const GithubIssueDetail = ({
+  issue,
+  headerActions,
+  dock,
+  fit = 'fill',
+  editContext,
+}: Props) => {
+  const { description, save } = useGithubIssueDescription({ issue, editContext });
   const properties = useMemo(
     () => resolveDetailFields({ registry: githubIssueFields, entity: issue }),
     [issue],
   );
+
   return (
     <StudioDetailLayout
       fit={fit}
@@ -45,15 +55,10 @@ export const GithubIssueDetail = ({ issue, headerActions, fit = 'fill' }: Props)
           }
         />
       }
+      dock={dock}
       properties={properties}
     >
-      <DetailSection label="description" variant="frameless">
-        {issue.body.trim() !== '' ? (
-          <Markdown text={issue.body} className="text-sm leading-relaxed" />
-        ) : (
-          <p className="text-sm italic text-muted-foreground/60">No description.</p>
-        )}
-      </DetailSection>
+      <DescriptionSection text={description} onSave={save} />
     </StudioDetailLayout>
   );
 };

--- a/apps/desktop/src/features/github/components/GitHubStudio/GithubIssueDetailPanel/index.test.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/GithubIssueDetailPanel/index.test.tsx
@@ -57,6 +57,7 @@ describe('GithubIssueDetailPanel', () => {
         issue={ISSUE}
         sessionId={null}
         workspaceId={'workspace-1' as WorkspaceId}
+        rootPath="/repo"
         onClose={vi.fn()}
       />,
     );
@@ -90,6 +91,7 @@ describe('GithubIssueDetailPanel', () => {
         issue={ISSUE}
         sessionId={null}
         workspaceId={'workspace-1' as WorkspaceId}
+        rootPath="/repo"
         onClose={vi.fn()}
       />,
     );

--- a/apps/desktop/src/features/github/components/GitHubStudio/GithubIssueDetailPanel/index.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/GithubIssueDetailPanel/index.tsx
@@ -1,26 +1,26 @@
-import { EmptyState, Markdown } from '@goodboy/ui';
+import { EmptyState } from '@goodboy/ui';
 import type { GithubIssue, SessionId, WorkspaceId } from '@goodboy/types';
-import {
-  DetailSection,
-  HeaderBand,
-  StudioDetailLayout,
-} from '../../../../../shared/components/StudioDetail';
-import { githubIssueFields, resolveDetailFields } from '../../../../../shared/detail-fields';
-import { IssueStateBadge } from '../../../../../shared/components/IssueStateBadge';
-import { ExternalRefActions } from '../../../../../shared/components/ExternalRefActions';
 import { LaunchSessionPanel } from '../../../../integrations/components/LaunchSessionPanel';
 import { goalFromIssue } from '../../../goal-from-issue';
 import { githubBranchSlug } from '../useGithubIssues';
+import { GithubIssueDetail } from '../../../GithubIssueDetail';
 import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../../shared/components/conceptIcons';
 
 type Props = {
   readonly issue: GithubIssue | null;
   readonly sessionId: SessionId | null;
   readonly workspaceId: WorkspaceId;
+  readonly rootPath: string;
   readonly onClose: () => void;
 };
 
-export const GithubIssueDetailPanel = ({ issue, sessionId, workspaceId, onClose }: Props) => {
+export const GithubIssueDetailPanel = ({
+  issue,
+  sessionId,
+  workspaceId,
+  rootPath,
+  onClose,
+}: Props) => {
   if (issue == null) {
     return (
       <div className="flex h-full items-center justify-center px-8">
@@ -56,31 +56,6 @@ export const GithubIssueDetailPanel = ({ issue, sessionId, workspaceId, onClose 
   );
 
   return (
-    <StudioDetailLayout
-      header={
-        <HeaderBand
-          meta={
-            <>
-              <span className="font-mono text-2xs tabular-nums text-muted-foreground">
-                #{issue.number}
-              </span>
-              <IssueStateBadge>{issue.state.toLowerCase()}</IssueStateBadge>
-            </>
-          }
-          title={issue.title}
-          actions={<ExternalRefActions url={issue.url} label="issue" hostLabel="GitHub" />}
-        />
-      }
-      dock={launchCard}
-      properties={resolveDetailFields({ registry: githubIssueFields, entity: issue })}
-    >
-      <DetailSection label="description" variant="frameless">
-        {issue.body.trim() !== '' ? (
-          <Markdown text={issue.body} className="text-sm leading-relaxed" />
-        ) : (
-          <p className="text-sm italic text-muted-foreground/60">No description.</p>
-        )}
-      </DetailSection>
-    </StudioDetailLayout>
+    <GithubIssueDetail issue={issue} dock={launchCard} editContext={{ workspaceId, rootPath }} />
   );
 };

--- a/apps/desktop/src/features/github/components/GitHubStudio/index.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/index.tsx
@@ -231,6 +231,7 @@ export const GitHubStudio = ({
                 issue={focusedIssue}
                 sessionId={focusedIssueRow?.sessionId ?? null}
                 workspaceId={workspaceId}
+                rootPath={rootPath}
                 onClose={requestClose}
               />
             }

--- a/apps/desktop/src/features/github/github.test.ts
+++ b/apps/desktop/src/features/github/github.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 const h = vi.hoisted(() => ({
   detectRepoSlug: vi.fn(),
   ghRunJson: vi.fn(),
+  updateIssueBody: vi.fn(),
 }));
 
 vi.mock('@goodboy/core', async (importOriginal) => {
@@ -11,14 +12,16 @@ vi.mock('@goodboy/core', async (importOriginal) => {
     ...actual,
     detectRepoSlug: h.detectRepoSlug,
     ghRunJson: h.ghRunJson,
+    updateIssueBody: h.updateIssueBody,
   };
 });
 
-import { ghIssueByNumber } from './github';
+import { ghIssueByNumber, ghUpdateIssueBody } from './github';
 
 afterEach(() => {
   h.detectRepoSlug.mockReset();
   h.ghRunJson.mockReset();
+  h.updateIssueBody.mockReset();
 });
 
 describe('ghIssueByNumber', () => {
@@ -67,5 +70,37 @@ describe('ghIssueByNumber', () => {
       'could not detect a GitHub repository for this workspace',
     );
     expect(h.ghRunJson).not.toHaveBeenCalled();
+  });
+});
+
+describe('ghUpdateIssueBody', () => {
+  it('writes the new body to the detected repo and returns the stored text', async () => {
+    h.detectRepoSlug.mockResolvedValueOnce('acme/web');
+    h.updateIssueBody.mockResolvedValueOnce('New body');
+
+    const body = await ghUpdateIssueBody({
+      cwd: '/repo',
+      issueNumber: 42,
+      body: 'New body',
+      workspaceId: 'workspace-1',
+    });
+
+    expect(body).toBe('New body');
+    expect(h.updateIssueBody).toHaveBeenCalledWith({
+      runner: expect.anything(),
+      repoSlug: 'acme/web',
+      issueNumber: 42,
+      body: 'New body',
+      opts: { cwd: '/repo', workspaceId: 'workspace-1' },
+    });
+  });
+
+  it('throws without writing when no github repository can be detected', async () => {
+    h.detectRepoSlug.mockResolvedValueOnce(null);
+
+    await expect(ghUpdateIssueBody({ cwd: '/repo', issueNumber: 42, body: 'x' })).rejects.toThrow(
+      'could not detect a GitHub repository for this workspace',
+    );
+    expect(h.updateIssueBody).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/features/github/github.ts
+++ b/apps/desktop/src/features/github/github.ts
@@ -5,6 +5,7 @@ import {
   ghRunJson,
   listAssignedIssues,
   listPrsForBranch,
+  updateIssueBody,
 } from '@goodboy/core';
 import type { GhRunner, GhResult, GhRunOptions, PrCacheStore } from '@goodboy/core';
 import type {
@@ -168,6 +169,32 @@ export const ghIssueByNumber = async (
     labels: raw.labels.map((label) => label.name),
     updatedAt: raw.updatedAt,
   };
+};
+
+type UpdateIssueBodyParams = {
+  readonly cwd: string;
+  readonly issueNumber: number;
+  readonly body: string;
+  readonly workspaceId?: string;
+};
+
+export const ghUpdateIssueBody = async ({
+  cwd,
+  issueNumber,
+  body,
+  workspaceId,
+}: UpdateIssueBodyParams): Promise<string> => {
+  const slug = await detectRepoSlug(tauriGhRunner, cwd, workspaceId);
+  if (slug == null) {
+    throw new Error('could not detect a GitHub repository for this workspace');
+  }
+  return updateIssueBody({
+    runner: tauriGhRunner,
+    repoSlug: slug,
+    issueNumber,
+    body,
+    opts: { cwd, workspaceId },
+  });
 };
 
 export const ghPrDetailByNumber = async (

--- a/apps/desktop/src/features/github/useGithubIssueDescription.ts
+++ b/apps/desktop/src/features/github/useGithubIssueDescription.ts
@@ -1,0 +1,49 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { GithubIssue, WorkspaceId } from '@goodboy/types';
+import { ghUpdateIssueBody } from './github';
+
+export type GithubIssueEditContext = {
+  readonly workspaceId: WorkspaceId;
+  readonly rootPath: string;
+};
+
+type Params = {
+  readonly issue: GithubIssue;
+  readonly editContext?: GithubIssueEditContext | null;
+};
+
+type Result = {
+  readonly description: string;
+  readonly save: ((next: string) => Promise<void>) | null;
+};
+
+export const useGithubIssueDescription = ({ issue, editContext }: Params): Result => {
+  const [saved, setSaved] = useState<string | null>(null);
+  const rootPath = editContext?.rootPath ?? null;
+  const workspaceId = editContext?.workspaceId ?? null;
+
+  useEffect(() => {
+    setSaved(null);
+  }, [issue.number, issue.body]);
+
+  const save = useCallback(
+    async (next: string) => {
+      if (rootPath == null || workspaceId == null) {
+        return;
+      }
+      const body = await ghUpdateIssueBody({
+        cwd: rootPath,
+        issueNumber: issue.number,
+        body: next,
+        workspaceId,
+      });
+      setSaved(body);
+    },
+    [rootPath, workspaceId, issue.number],
+  );
+
+  return {
+    description: saved ?? issue.body,
+    save: rootPath == null || workspaceId == null ? null : save,
+  };
+};

--- a/apps/desktop/src/features/integrations/gitlab/GitlabIssueDetail/index.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabIssueDetail/index.tsx
@@ -1,10 +1,6 @@
 import type { ReactNode } from 'react';
-import { Markdown } from '@goodboy/ui';
-import {
-  DetailSection,
-  HeaderBand,
-  StudioDetailLayout,
-} from '../../../../shared/components/StudioDetail';
+import { HeaderBand, StudioDetailLayout } from '../../../../shared/components/StudioDetail';
+import { DescriptionSection } from '../../../../shared/components/DescriptionSection';
 import { gitlabIssueFields, resolveDetailFields } from '../../../../shared/detail-fields';
 import { IssueStateBadge } from '../../../../shared/components/IssueStateBadge';
 import { ExternalRefActions } from '../../../../shared/components/ExternalRefActions';
@@ -43,13 +39,7 @@ export const GitlabIssueDetail = ({ issue, headerActions, fit = 'fill' }: Props)
       }
       properties={resolveDetailFields({ registry: gitlabIssueFields, entity: issue })}
     >
-      <DetailSection label="description" variant="frameless">
-        {issue.description != null && issue.description !== '' ? (
-          <Markdown text={issue.description} className="text-sm leading-relaxed" />
-        ) : (
-          <p className="text-sm italic text-muted-foreground/60">No description.</p>
-        )}
-      </DetailSection>
+      <DescriptionSection text={issue.description ?? ''} />
     </StudioDetailLayout>
   );
 };

--- a/apps/desktop/src/features/integrations/linear/LinearIssueDetail/index.test.tsx
+++ b/apps/desktop/src/features/integrations/linear/LinearIssueDetail/index.test.tsx
@@ -57,6 +57,18 @@ describe('LinearIssueDetail', () => {
     expect(screen.getByText('The fix is ready for review.')).toBeDefined();
   });
 
+  it('keeps a fenced description as a code block and offers no edit affordance', () => {
+    const { container } = render(
+      <LinearIssueDetail
+        issue={{ ...ISSUE, description: '```\nnot markdown, a fence\n```' }}
+        workspaceId={'workspace-1' as WorkspaceId}
+      />,
+    );
+
+    expect(container.querySelector('pre code')?.textContent).toBe('not markdown, a fence');
+    expect(screen.queryByRole('button', { name: 'Edit' })).toBeNull();
+  });
+
   it('renders the properties in registry order, once', () => {
     render(<LinearIssueDetail issue={ISSUE} workspaceId={'workspace-1' as WorkspaceId} />);
 

--- a/apps/desktop/src/features/integrations/linear/LinearIssueDetail/index.tsx
+++ b/apps/desktop/src/features/integrations/linear/LinearIssueDetail/index.tsx
@@ -1,13 +1,12 @@
 import { useState, type ReactNode } from 'react';
-import { Markdown } from '@goodboy/ui';
 import { FileText, MessageSquare } from 'lucide-react';
 import type { WorkspaceId } from '@goodboy/types';
 import {
-  DetailSection,
   HeaderBand,
   StudioDetailLayout,
   StudioDetailTabs,
 } from '../../../../shared/components/StudioDetail';
+import { DescriptionSection } from '../../../../shared/components/DescriptionSection';
 import { linearIssueFields, resolveDetailFields } from '../../../../shared/detail-fields';
 import { IssueStateBadge } from '../../../../shared/components/IssueStateBadge';
 import { ExternalRefActions } from '../../../../shared/components/ExternalRefActions';
@@ -81,13 +80,7 @@ export const LinearIssueDetail = ({
       properties={resolveDetailFields({ registry: linearIssueFields, entity: issue })}
     >
       {section === 'overview' ? (
-        <DetailSection label="description" variant="frameless">
-          {issue.description != null && issue.description !== '' ? (
-            <Markdown text={issue.description} className="text-sm leading-relaxed" />
-          ) : (
-            <p className="text-sm italic text-muted-foreground/60">No description.</p>
-          )}
-        </DetailSection>
+        <DescriptionSection text={issue.description ?? ''} />
       ) : (
         <LinearIssueComments comments={comments} isLoading={isLoading} error={error} />
       )}

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/GithubTaskDetail.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/GithubTaskDetail.tsx
@@ -19,7 +19,13 @@ export const GithubTaskDetail = ({ workspaceId, rootPath, task }: Props) => {
   });
 
   if (issue != null) {
-    return <GithubIssueDetail issue={issue} fit="fill" />;
+    return (
+      <GithubIssueDetail
+        issue={issue}
+        fit="fill"
+        {...(rootPath != null && { editContext: { workspaceId, rootPath } })}
+      />
+    );
   }
 
   return (

--- a/apps/desktop/src/shared/components/DescriptionSection/index.test.tsx
+++ b/apps/desktop/src/shared/components/DescriptionSection/index.test.tsx
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { DescriptionSection } from './index';
+
+const SOURCE = '## Goal\n\nShip the **editor**.';
+const FENCED = '```\nplain body, not markdown\n```';
+
+afterEach(cleanup);
+
+describe('DescriptionSection', () => {
+  it('renders the prose instead of the markdown source', () => {
+    render(<DescriptionSection text={SOURCE} />);
+
+    expect(screen.getByRole('heading', { name: 'Goal' })).toBeDefined();
+    expect(screen.queryByText('## Goal')).toBeNull();
+  });
+
+  it('keeps a description that is one code fence rendered as a code block', () => {
+    const { container } = render(<DescriptionSection text={FENCED} />);
+
+    const code = container.querySelector('pre code');
+    expect(code?.textContent).toBe('plain body, not markdown');
+    expect(screen.queryByText(/```/)).toBeNull();
+  });
+
+  it('shows no edit affordance when no write path is available', () => {
+    render(<DescriptionSection text={SOURCE} />);
+
+    expect(screen.queryByRole('button', { name: 'Edit' })).toBeNull();
+    fireEvent.click(screen.getByTestId('description-body'));
+    expect(screen.queryByRole('textbox', { name: 'Edit description' })).toBeNull();
+  });
+
+  it('enters edit mode on click with the source, restores the rendered view on Escape and keeps the draft', () => {
+    render(<DescriptionSection text={SOURCE} onSave={vi.fn(async () => {})} />);
+
+    fireEvent.click(screen.getByTestId('description-body'));
+    const field = screen.getByRole('textbox', { name: 'Edit description' }) as HTMLTextAreaElement;
+    expect(field.value).toBe(SOURCE);
+
+    fireEvent.change(field, { target: { value: 'typed but not saved' } });
+    fireEvent.keyDown(field, { key: 'Escape' });
+
+    expect(screen.queryByRole('textbox', { name: 'Edit description' })).toBeNull();
+    expect(screen.getByRole('heading', { name: 'Goal' })).toBeDefined();
+    expect(screen.getByText('Unsaved edits')).toBeDefined();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    expect(
+      (screen.getByRole('textbox', { name: 'Edit description' }) as HTMLTextAreaElement).value,
+    ).toBe('typed but not saved');
+  });
+
+  it('commits the draft through the write path', async () => {
+    const onSave = vi.fn(async () => {});
+    render(<DescriptionSection text={SOURCE} onSave={onSave} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    fireEvent.change(screen.getByRole('textbox', { name: 'Edit description' }), {
+      target: { value: 'A new body.' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(onSave).toHaveBeenCalledWith('A new body.'));
+    await waitFor(() =>
+      expect(screen.queryByRole('textbox', { name: 'Edit description' })).toBeNull(),
+    );
+  });
+
+  it('keeps the draft and surfaces the error when the save is rejected', async () => {
+    const onSave = vi.fn(async () => {
+      throw new Error('gh api rejected the update');
+    });
+    render(<DescriptionSection text={SOURCE} onSave={onSave} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    fireEvent.change(screen.getByRole('textbox', { name: 'Edit description' }), {
+      target: { value: 'body that fails' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert').textContent).toContain('gh api rejected the update'),
+    );
+    expect(
+      (screen.getByRole('textbox', { name: 'Edit description' }) as HTMLTextAreaElement).value,
+    ).toBe('body that fails');
+  });
+});

--- a/apps/desktop/src/shared/components/DescriptionSection/index.tsx
+++ b/apps/desktop/src/shared/components/DescriptionSection/index.tsx
@@ -1,0 +1,85 @@
+import { Pencil } from 'lucide-react';
+import { Button, Markdown, Textarea, cn } from '@goodboy/ui';
+import { useInlineProseEdit } from '../../hooks/useInlineProseEdit';
+import { DetailSection } from '../StudioDetail';
+
+type Props = {
+  readonly text: string;
+  readonly onSave?: ((next: string) => Promise<void>) | null;
+};
+
+export const DescriptionSection = ({ text, onSave }: Props) => {
+  const edit = useInlineProseEdit({ value: text, onCommit: onSave });
+
+  if (edit.isEditing) {
+    return (
+      <DetailSection label="description" variant="frameless">
+        <div className="flex flex-col gap-3">
+          <Textarea
+            autoFocus
+            autoGrow
+            minRows={8}
+            maxRows={28}
+            value={edit.draft}
+            aria-label="Edit description"
+            onChange={(event) => edit.setDraft(event.target.value)}
+            onKeyDown={edit.onKeyDown}
+            className="font-mono text-xs leading-relaxed"
+          />
+          <div className="flex items-center justify-between gap-3">
+            {edit.error != null ? (
+              <p role="alert" className="min-w-0 text-xs text-danger">
+                {edit.error}
+              </p>
+            ) : (
+              <p className="text-2xs text-muted-foreground">Escape to cancel</p>
+            )}
+            <div className="flex shrink-0 items-center gap-2">
+              <Button size="sm" variant="ghost" onClick={edit.cancel}>
+                Cancel
+              </Button>
+              <Button
+                size="sm"
+                isBusy={edit.isSaving}
+                busyLabel="Saving"
+                onClick={() => void edit.commit()}
+              >
+                Save
+              </Button>
+            </div>
+          </div>
+        </div>
+      </DetailSection>
+    );
+  }
+
+  return (
+    <DetailSection
+      label="description"
+      variant="frameless"
+      action={
+        edit.canEdit ? (
+          <div className="flex items-center gap-2">
+            {edit.isDirty ? <span className="text-2xs text-warning">Unsaved edits</span> : null}
+            <Button size="sm" variant="ghost" onClick={edit.start}>
+              <Pencil size={12} aria-hidden />
+              Edit
+            </Button>
+          </div>
+        ) : undefined
+      }
+    >
+      <div
+        onClick={edit.start}
+        className={cn('flex flex-col', edit.canEdit && 'cursor-text')}
+        data-testid="description-body"
+      >
+        {text.trim() !== '' ? (
+          <Markdown text={text} className="text-sm leading-relaxed" />
+        ) : (
+          <p className="text-sm italic text-muted-foreground/60">No description.</p>
+        )}
+      </div>
+    </DetailSection>
+  );
+};

--- a/apps/desktop/src/shared/hooks/useInlineProseEdit/index.test.ts
+++ b/apps/desktop/src/shared/hooks/useInlineProseEdit/index.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { useInlineProseEdit } from './index';
+
+describe('useInlineProseEdit', () => {
+  it('refuses to edit without a commit handler', () => {
+    const { result } = renderHook(() => useInlineProseEdit({ value: 'body' }));
+
+    act(() => result.current.start());
+
+    expect(result.current.canEdit).toBe(false);
+    expect(result.current.isEditing).toBe(false);
+  });
+
+  it('keeps the draft after a cancel and drops it when the source changes', () => {
+    const onCommit = vi.fn(async () => {});
+    const { result, rerender } = renderHook(
+      ({ value }: { value: string }) => useInlineProseEdit({ value, onCommit }),
+      { initialProps: { value: 'body' } },
+    );
+
+    act(() => result.current.start());
+    act(() => result.current.setDraft('edited body'));
+    act(() => result.current.cancel());
+
+    expect(result.current.isEditing).toBe(false);
+    expect(result.current.draft).toBe('edited body');
+    expect(result.current.isDirty).toBe(true);
+
+    rerender({ value: 'body from the provider' });
+
+    expect(result.current.draft).toBe('body from the provider');
+    expect(result.current.isDirty).toBe(false);
+  });
+
+  it('reports the failure and keeps the draft when the commit throws', async () => {
+    const onCommit = vi.fn(async () => {
+      throw new Error('write rejected');
+    });
+    const { result } = renderHook(() => useInlineProseEdit({ value: 'body', onCommit }));
+
+    act(() => result.current.start());
+    act(() => result.current.setDraft('edited body'));
+    await act(() => result.current.commit());
+
+    expect(result.current.error).toContain('write rejected');
+    expect(result.current.draft).toBe('edited body');
+    expect(result.current.isEditing).toBe(true);
+  });
+});

--- a/apps/desktop/src/shared/hooks/useInlineProseEdit/index.ts
+++ b/apps/desktop/src/shared/hooks/useInlineProseEdit/index.ts
@@ -1,0 +1,103 @@
+import { useEffect, useRef, useState, type KeyboardEvent } from 'react';
+import { formatError } from '../../lib/errors';
+
+type Params = {
+  readonly value: string;
+  readonly onCommit?: ((next: string) => void | Promise<void>) | null;
+};
+
+type Result = {
+  readonly isEditing: boolean;
+  readonly isSaving: boolean;
+  readonly isDirty: boolean;
+  readonly canEdit: boolean;
+  readonly draft: string;
+  readonly error: string | null;
+  readonly setDraft: (next: string) => void;
+  readonly start: () => void;
+  readonly cancel: () => void;
+  readonly commit: () => Promise<void>;
+  readonly onKeyDown: (event: KeyboardEvent<HTMLTextAreaElement>) => void;
+};
+
+export const useInlineProseEdit = ({ value, onCommit }: Params): Result => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isDirty, setIsDirty] = useState(false);
+  const [draft, setDraft] = useState(value);
+  const [error, setError] = useState<string | null>(null);
+  const committed = useRef(value);
+  const canEdit = onCommit != null;
+
+  useEffect(() => {
+    if (value === committed.current) {
+      return;
+    }
+    committed.current = value;
+    setDraft(value);
+    setIsDirty(false);
+    setError(null);
+  }, [value]);
+
+  const updateDraft = (next: string) => {
+    setDraft(next);
+    setIsDirty(next !== committed.current);
+    setError(null);
+  };
+
+  const start = () => {
+    if (!canEdit) {
+      return;
+    }
+    setIsEditing(true);
+  };
+
+  const cancel = () => {
+    setIsEditing(false);
+  };
+
+  const commit = async () => {
+    if (onCommit == null || isSaving) {
+      return;
+    }
+    setIsSaving(true);
+    try {
+      await onCommit(draft);
+      committed.current = draft;
+      setIsDirty(false);
+      setIsEditing(false);
+      setError(null);
+    } catch (commitError) {
+      setError(formatError(commitError));
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const onKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    event.stopPropagation();
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      cancel();
+      return;
+    }
+    if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
+      event.preventDefault();
+      void commit();
+    }
+  };
+
+  return {
+    isEditing,
+    isSaving,
+    isDirty,
+    canEdit,
+    draft,
+    error,
+    setDraft: updateDraft,
+    start,
+    cancel,
+    commit,
+    onKeyDown,
+  };
+};

--- a/packages/core/src/github/__tests__/issues.test.ts
+++ b/packages/core/src/github/__tests__/issues.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { GhRunner } from '../gh';
-import { listAssignedIssues } from '../issues';
+import { listAssignedIssues, updateIssueBody } from '../issues';
 
 describe('listAssignedIssues', () => {
   it('lists open assigned issues and maps GitHub labels', async () => {
@@ -58,5 +58,55 @@ describe('listAssignedIssues', () => {
         updatedAt: '2026-07-22T10:00:00Z',
       },
     ]);
+  });
+});
+
+describe('updateIssueBody', () => {
+  it('patches the issue body and returns the stored text', async () => {
+    const run = vi.fn().mockResolvedValue({
+      stdout: JSON.stringify({ number: 42, body: 'Rewritten from Goodboy.' }),
+      stderr: '',
+      exitCode: 0,
+    });
+    const runner: GhRunner = { run };
+
+    const body = await updateIssueBody({
+      runner,
+      repoSlug: 'goodboy/goodboy',
+      issueNumber: 42,
+      body: 'Rewritten from Goodboy.',
+      opts: { cwd: '/repos/goodboy', workspaceId: 'workspace-1' },
+    });
+
+    expect(run).toHaveBeenCalledWith(
+      [
+        'api',
+        'repos/goodboy/goodboy/issues/42',
+        '-X',
+        'PATCH',
+        '-f',
+        'body=Rewritten from Goodboy.',
+      ],
+      { cwd: '/repos/goodboy', workspaceId: 'workspace-1' },
+    );
+    expect(body).toBe('Rewritten from Goodboy.');
+  });
+
+  it('raises the gh failure so the caller can keep the draft', async () => {
+    const run = vi.fn().mockResolvedValue({
+      stdout: '',
+      stderr: 'HTTP 403: Resource not accessible by integration',
+      exitCode: 1,
+    });
+    const runner: GhRunner = { run };
+
+    await expect(
+      updateIssueBody({
+        runner,
+        repoSlug: 'goodboy/goodboy',
+        issueNumber: 42,
+        body: 'nope',
+      }),
+    ).rejects.toThrow(/exited with 1/);
   });
 });

--- a/packages/core/src/github/index.ts
+++ b/packages/core/src/github/index.ts
@@ -26,7 +26,7 @@ export { fetchPrDiff, parseUnifiedDiff } from './diff';
 
 export { fetchPrDetail } from './details';
 
-export { listAssignedIssues } from './issues';
+export { listAssignedIssues, updateIssueBody } from './issues';
 
 export {
   addReviewThreadReply,

--- a/packages/core/src/github/issues.ts
+++ b/packages/core/src/github/issues.ts
@@ -24,6 +24,33 @@ type RawGithubIssue = {
   updatedAt: string;
 };
 
+type UpdateIssueBodyParams = {
+  readonly runner: GhRunner;
+  readonly repoSlug: string;
+  readonly issueNumber: number;
+  readonly body: string;
+  readonly opts?: GhRunOptions;
+};
+
+type RawUpdatedIssue = {
+  body: string | null;
+};
+
+export const updateIssueBody = async ({
+  runner,
+  repoSlug,
+  issueNumber,
+  body,
+  opts = {},
+}: UpdateIssueBodyParams): Promise<string> => {
+  const updated = await runJson<RawUpdatedIssue>(
+    runner,
+    ['api', `repos/${repoSlug}/issues/${issueNumber}`, '-X', 'PATCH', '-f', `body=${body}`],
+    opts,
+  );
+  return updated.body ?? '';
+};
+
 export const listAssignedIssues = async (
   runner: GhRunner,
   repoSlug: string,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -315,6 +315,7 @@ export {
   resolvePrForBranch,
   resolveReviewThread,
   runJson as ghRunJson,
+  updateIssueBody,
   type GetPrInput,
   type GhDetectResult,
   type GhResult,


### PR DESCRIPTION
## Correction first

The rendering was never broken. The Linear issue in the screenshot has a body that **begins and ends with a triple-backtick fence**, so `Markdown` correctly renders the whole thing as one code block. No parser change and no special case for a leading fence: a fence in the source stays a code block, and a test pins that.

What was missing is the other half: no provider had a write path for a description, and there was no edit affordance anywhere.

## What it is now

- Read mode keeps rendering prose. Clicking it enters edit mode with the source in a textarea; Escape leaves edit mode and the draft survives, marked unsaved; an explicit save commits.
- A failed save keeps the draft and shows the error inline, so nothing typed is discarded.
- The multi-line behaviour is a sibling primitive, `useInlineProseEdit`, plus one shared `DescriptionSection` used by all providers. `useInlineRename` and its four single-line consumers are untouched: Enter-commits and blur-commits are the opposite of what a prose field needs.

## Provider coverage, stated plainly

- **GitHub: covered**, through the existing `gh_run` command (`gh api repos/<slug>/issues/<n> -X PATCH -f body=...`). What the detail shows afterwards is the body GitHub returned, not the local draft. Wired both in the GitHub studio and in the session's linked-issue lens.
- **Linear and GitLab: read-only, with no affordance at all.** Their Tauri commands expose connect, disconnect and fetch only, and there is no generic passthrough to reuse, so a write needs a new Rust command. Rather than ship a button that cannot work, they pass no save handler.
- **Sentry: untouched**, it has no description field.

## Tests

Prose not source; a fenced description stays a code block (regression fence for the reported issue); no affordance without a write path; click enters edit with the source, Escape restores the rendered view, the draft survives the switch; save calls the write and the detail then shows the stored body; a rejected save shows the error and keeps the draft. Plus the gh argument shape and failure propagation in core.

Mutation-checked: removing the click handler fails the named test with "Unable to find an accessible element with the role textbox".

## Verification

- `vitest` desktop: 4144 passed, 476 files
- `tsc --noEmit` on desktop and core: clean
- `knip --include files,duplicates,unlisted`: clean

Known tension, stated rather than hidden: `DESIGN.md` line 266 says editing opens a focused surface. The request was in-place click-to-edit, and the issue detail pane is treated as that focused surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)