### PR TITLE
feat(desktop): close the linked issue from the pull request, and stop two more yanks

### DIFF
--- a/apps/desktop/src/features/chat/components/ChatInput/index.tsx
+++ b/apps/desktop/src/features/chat/components/ChatInput/index.tsx
@@ -1,7 +1,7 @@
 import { useRef, useCallback, useEffect, type KeyboardEvent as ReactKeyboardEvent } from 'react';
 import { Paperclip, Send, Square } from 'lucide-react';
 import { Divider, Textarea, cn, formatUsd } from '@goodboy/ui';
-import type { Session, TurnProviderOverride } from '@goodboy/types';
+import type { Session, SessionId, TurnProviderOverride } from '@goodboy/types';
 import { resolveStoredModelSelection } from '@goodboy/core';
 import { useAppStore, useSessionCost } from '../../../../store';
 import { RoutingIndicator } from '../RoutingIndicator';
@@ -25,6 +25,7 @@ import { useScopeNudge } from './hooks/useScopeNudge';
 import { useRightSizeNudge } from './hooks/useRightSizeNudge';
 import { useAgentSwitchSync } from './hooks/useAgentSwitchSync';
 import { useSuggestionCards } from './hooks/useSuggestionCards';
+import { useAgentStartedToast } from '../../../../shared/hooks/useAgentStartedToast';
 import { AttachmentChip } from './parts/AttachmentChip';
 import { QueuedMessages } from './parts/QueuedMessages';
 import { SuggestionStack } from './parts/SuggestionStack';
@@ -59,6 +60,7 @@ export const ChatInput = ({ session, providerDisconnected = false }: Props) => {
   const loadPhaseRunsForSession = useAppStore((s) => s.loadPhaseRunsForSession);
 
   const { showToast } = useToast();
+  const announceAgentStarted = useAgentStartedToast();
 
   const value = useAppStore((s) => (selectedAgentId ? (s.agentDraft[selectedAgentId] ?? '') : ''));
   const setAgentDraft = useAppStore((s) => s.setAgentDraft);
@@ -305,6 +307,16 @@ export const ChatInput = ({ session, providerDisconnected = false }: Props) => {
     await rightSize.recordRightSizeOutcome({ outcome: 'dismissed' });
   };
 
+  const onAcceptHandoff = async (targetSessionId: SessionId) => {
+    const agentId = await acceptSessionNudgeHandoff(targetSessionId);
+    announceAgentStarted({
+      sessionId: targetSessionId,
+      agentId,
+      title: 'Agent started',
+      message: 'The agent is picking this up. You can keep working.',
+    });
+  };
+
   const suggestions = useSuggestionCards({
     session,
     sessionNudge,
@@ -320,7 +332,7 @@ export const ChatInput = ({ session, providerDisconnected = false }: Props) => {
     onKeepCurrent,
     onChangeModel,
     dismissSessionNudge,
-    acceptSessionNudgeHandoff,
+    acceptSessionNudgeHandoff: onAcceptHandoff,
   });
 
   const onKeyDown = (event: ReactKeyboardEvent<HTMLTextAreaElement>) => {

--- a/apps/desktop/src/features/chat/components/HandoffChip/index.test.tsx
+++ b/apps/desktop/src/features/chat/components/HandoffChip/index.test.tsx
@@ -1,15 +1,23 @@
 // @vitest-environment happy-dom
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 
-const { extractHandoffMock, state } = vi.hoisted(() => ({
+type ToastAction = { readonly label: string; readonly onClick: () => void };
+
+type ToastOptions = { readonly title?: string; readonly action?: ToastAction };
+
+const { extractHandoffMock, showToast, state } = vi.hoisted(() => ({
   extractHandoffMock: vi.fn<(text: string) => unknown>(() => null),
+  showToast: vi.fn<(kind: string, message: string, opts?: ToastOptions) => void>(),
   state: {
     sessions: [{ id: 'sess-1', workflowRuns: [] as ReadonlyArray<string> }],
     sessionNudges: {} as Record<string, unknown>,
-    spawnAgent: vi.fn(async () => undefined),
-    acceptSessionNudgeHandoff: vi.fn(async () => undefined),
+    spawnAgent: vi.fn(async () => 'agent-impl'),
+    acceptSessionNudgeHandoff: vi.fn(async () => 'agent-accepted'),
+    selectAgent: vi.fn(async () => undefined),
+    setCurrentSession: vi.fn(async () => undefined),
+    setActiveLens: vi.fn(),
   },
 }));
 
@@ -18,14 +26,21 @@ vi.mock('../../../../store', () => ({
   useAppStore: <T,>(selector: (s: typeof state) => T) => selector(state),
 }));
 
+vi.mock('../../../../app/components/Toast', () => ({
+  useToast: () => ({ showToast }),
+}));
+
 import { HandoffChip } from './index';
 
 beforeEach(() => {
   extractHandoffMock.mockReset();
+  showToast.mockClear();
   state.sessions = [{ id: 'sess-1', workflowRuns: [] }];
   state.sessionNudges = {};
-  state.spawnAgent = vi.fn(async () => undefined);
-  state.acceptSessionNudgeHandoff = vi.fn(async () => undefined);
+  state.spawnAgent = vi.fn(async () => 'agent-impl');
+  state.acceptSessionNudgeHandoff = vi.fn(async () => 'agent-accepted');
+  state.selectAgent = vi.fn(async () => undefined);
+  state.setActiveLens = vi.fn();
 });
 afterEach(cleanup);
 
@@ -43,13 +58,34 @@ describe('HandoffChip', () => {
     expect(container.firstChild).toBeNull();
   });
 
-  it('spawns the suggested agent when the chip is clicked', () => {
+  it('spawns the suggested agent without stealing focus when the chip is clicked', () => {
     extractHandoffMock.mockReturnValue({ kind: 'implementer', reason: null });
     render(<HandoffChip assistantText="x" sessionId={'sess-1' as never} />);
     fireEvent.click(screen.getByTestId('handoff-chip'));
     expect(state.spawnAgent).toHaveBeenCalledWith('sess-1', {
       kindOverride: 'implementer',
-      focus: 'agent',
+      focus: 'none',
     });
+  });
+
+  it('accepts the live nudge, reports it started, and opens the agent only from the toast', async () => {
+    extractHandoffMock.mockReturnValue({ kind: 'implementer', reason: null });
+    state.sessionNudges = {
+      'sess-1': { id: 'nudge-1', kind: 'handoff-suggested', targetKind: 'implementer' },
+    };
+    render(<HandoffChip assistantText="x" sessionId={'sess-1' as never} />);
+    fireEvent.click(screen.getByTestId('handoff-chip'));
+
+    await waitFor(() => expect(state.acceptSessionNudgeHandoff).toHaveBeenCalledWith('sess-1'));
+    await waitFor(() => expect(showToast).toHaveBeenCalledOnce());
+    expect(state.spawnAgent).not.toHaveBeenCalled();
+    expect(state.selectAgent).not.toHaveBeenCalled();
+    const opts = showToast.mock.calls[0]![2];
+    expect(opts?.action?.label).toBe('Open the agent');
+
+    opts?.action?.onClick();
+
+    await waitFor(() => expect(state.selectAgent).toHaveBeenCalledWith('sess-1', 'agent-accepted'));
+    expect(state.setActiveLens).toHaveBeenCalledWith('sess-1', 'agents');
   });
 });

--- a/apps/desktop/src/features/chat/components/HandoffChip/index.tsx
+++ b/apps/desktop/src/features/chat/components/HandoffChip/index.tsx
@@ -5,6 +5,7 @@ import { extractHandoff } from '@goodboy/core';
 import { useAppStore } from '../../../../store';
 import { AGENT_KIND_META } from '../../../session/agent-kind';
 import { TranscriptShell } from '../TranscriptShell';
+import { useAgentStartedToast } from '../../../../shared/hooks/useAgentStartedToast';
 import { tintClasses } from '@goodboy/ui';
 
 const accent = tintClasses('info');
@@ -20,6 +21,7 @@ export const HandoffChip = ({ assistantText, sessionId }: Props) => {
   const sessionNudge = useAppStore((s) => s.sessionNudges[sessionId] ?? null);
   const spawnAgent = useAppStore((s) => s.spawnAgent);
   const acceptHandoff = useAppStore((s) => s.acceptSessionNudgeHandoff);
+  const announceAgentStarted = useAgentStartedToast();
 
   if (!handoff || !session) {
     return null;
@@ -33,15 +35,21 @@ export const HandoffChip = ({ assistantText, sessionId }: Props) => {
     sessionNudge?.kind === 'handoff-suggested' && sessionNudge.targetKind === handoff.kind;
 
   const onClick = () => {
-    if (isActiveNudge) {
-      void acceptHandoff(sessionId);
-      return;
-    }
-    void spawnAgent(sessionId, {
-      kindOverride: handoff.kind,
-      ...(handoff.planId ? { triggeredPlanId: handoff.planId as PlanId } : {}),
-      focus: 'agent',
-    });
+    void (async () => {
+      const agentId = isActiveNudge
+        ? await acceptHandoff(sessionId)
+        : await spawnAgent(sessionId, {
+            kindOverride: handoff.kind,
+            ...(handoff.planId ? { triggeredPlanId: handoff.planId as PlanId } : {}),
+            focus: 'none',
+          });
+      announceAgentStarted({
+        sessionId,
+        agentId,
+        title: `${meta.label} started`,
+        message: 'The agent is picking this up. You can keep working.',
+      });
+    })();
   };
   return (
     <TranscriptShell

--- a/apps/desktop/src/features/github/appendClosingReferences.ts
+++ b/apps/desktop/src/features/github/appendClosingReferences.ts
@@ -1,0 +1,15 @@
+import type { ClosingIssueReference } from './closingIssueReferences';
+
+type Params = {
+  readonly body: string;
+  readonly references: ReadonlyArray<ClosingIssueReference>;
+};
+
+export const appendClosingReferences = ({ body, references }: Params): string => {
+  if (references.length === 0) {
+    return body;
+  }
+  const block = references.map((reference) => reference.line).join('\n');
+  const kept = body.trimEnd();
+  return kept.length === 0 ? block : `${kept}\n\n${block}`;
+};

--- a/apps/desktop/src/features/github/closingIssueReferences.test.ts
+++ b/apps/desktop/src/features/github/closingIssueReferences.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import type { IsoDateTime, SessionExternalTask, SessionId } from '@goodboy/types';
+import { closingIssueReferences } from './closingIssueReferences';
+import { appendClosingReferences } from './appendClosingReferences';
+
+const NOW = '2026-08-04T00:00:00.000Z' as IsoDateTime;
+
+const task = (overrides: Partial<SessionExternalTask>): SessionExternalTask => ({
+  sessionId: 'sess-1' as SessionId,
+  provider: 'github',
+  externalId: '41',
+  identifier: '#41',
+  url: 'https://github.com/acme/web/issues/41',
+  title: 'Broken card',
+  createdAt: NOW,
+  ...overrides,
+});
+
+describe('closingIssueReferences', () => {
+  it('references a github issue linked on the current branch', () => {
+    const refs = closingIssueReferences({
+      tasks: [task({ branch: 'ak/cards' })],
+      branch: 'ak/cards',
+      body: '',
+    });
+    expect(refs.map((ref) => ref.line)).toEqual(['Closes #41']);
+  });
+
+  it('skips a github issue linked on another branch', () => {
+    const refs = closingIssueReferences({
+      tasks: [task({ branch: 'ak/other' })],
+      branch: 'ak/cards',
+      body: '',
+    });
+    expect(refs).toEqual([]);
+  });
+
+  it('never writes a non-github issue as a closing reference', () => {
+    const refs = closingIssueReferences({
+      tasks: [
+        task({
+          provider: 'linear',
+          externalId: 'GRO-12',
+          identifier: 'GRO-12',
+          branch: 'ak/cards',
+        }),
+        task({ provider: 'sentry', externalId: '99', identifier: 'SENTRY-99', branch: 'ak/cards' }),
+        task({ provider: 'gitlab', externalId: '7', identifier: '!7', branch: 'ak/cards' }),
+      ],
+      branch: 'ak/cards',
+      body: '',
+    });
+    expect(refs).toEqual([]);
+  });
+
+  it('sorts and dedupes several linked issues, and keeps the ones without a branch', () => {
+    const refs = closingIssueReferences({
+      tasks: [
+        task({ externalId: '52', identifier: '#52', branch: 'ak/cards' }),
+        task({ externalId: '41', identifier: '#41' }),
+        task({ externalId: '41', identifier: '#41', branch: 'ak/cards' }),
+      ],
+      branch: 'ak/cards',
+      body: '',
+    });
+    expect(refs.map((ref) => ref.line)).toEqual(['Closes #41', 'Closes #52']);
+  });
+
+  it('does not repeat a reference the body already closes', () => {
+    const refs = closingIssueReferences({
+      tasks: [task({ branch: 'ak/cards' }), task({ externalId: '52', identifier: '#52' })],
+      branch: 'ak/cards',
+      body: 'Fixes #41 in the card renderer.',
+    });
+    expect(refs.map((ref) => ref.line)).toEqual(['Closes #52']);
+  });
+});
+
+describe('appendClosingReferences', () => {
+  it('appends the reference block after the body', () => {
+    const references = closingIssueReferences({
+      tasks: [task({ branch: 'ak/cards' })],
+      branch: 'ak/cards',
+      body: 'Documents the change.',
+    });
+    expect(appendClosingReferences({ body: 'Documents the change.', references })).toBe(
+      'Documents the change.\n\nCloses #41',
+    );
+  });
+
+  it('leaves the body untouched when nothing is referenced', () => {
+    expect(appendClosingReferences({ body: 'Documents the change.', references: [] })).toBe(
+      'Documents the change.',
+    );
+  });
+});

--- a/apps/desktop/src/features/github/closingIssueReferences.ts
+++ b/apps/desktop/src/features/github/closingIssueReferences.ts
@@ -1,0 +1,54 @@
+import type { SessionExternalTask } from '@goodboy/types';
+
+export type ClosingIssueReference = Readonly<{
+  number: number;
+  identifier: string;
+  url: string;
+  line: string;
+}>;
+
+type Params = {
+  readonly tasks: ReadonlyArray<SessionExternalTask>;
+  readonly branch: string | null;
+  readonly body: string;
+};
+
+const CLOSING_KEYWORDS = 'close[sd]?|fix(?:es|ed)?|resolve[sd]?';
+
+export const closingIssueReferences = ({
+  tasks,
+  branch,
+  body,
+}: Params): ReadonlyArray<ClosingIssueReference> => {
+  const byNumber = new Map<number, ClosingIssueReference>();
+  for (const task of tasks) {
+    if (task.provider !== 'github') {
+      continue;
+    }
+    const taskBranch = task.branch ?? null;
+    if (taskBranch !== null && branch !== null && taskBranch !== branch) {
+      continue;
+    }
+    const raw = task.externalId.trim();
+    const number = Number.parseInt(raw, 10);
+    if (!Number.isSafeInteger(number) || number <= 0 || String(number) !== raw) {
+      continue;
+    }
+    if (byNumber.has(number)) {
+      continue;
+    }
+    const alreadyClosing = new RegExp(`\\b(?:${CLOSING_KEYWORDS})\\s+#${number}\\b`, 'i').test(
+      body,
+    );
+    if (alreadyClosing) {
+      continue;
+    }
+    byNumber.set(number, {
+      number,
+      identifier: task.identifier,
+      url: task.url,
+      line: `Closes #${number}`,
+    });
+  }
+  return [...byNumber.values()].sort((a, b) => a.number - b.number);
+};

--- a/apps/desktop/src/features/github/components/GitHubStudio/CreatePrPanel.test.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/CreatePrPanel.test.tsx
@@ -1,6 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import type { SessionId, TaskModelPreferences } from '@goodboy/types';
+import type {
+  IsoDateTime,
+  SessionExternalTask,
+  SessionId,
+  TaskModelPreferences,
+} from '@goodboy/types';
 import type { AgentSpawnConfigValue } from '../../../session/components/AgentSpawnConfig/AgentSpawnConfigValue';
 
 type SpawnAgent = (
@@ -8,8 +13,18 @@ type SpawnAgent = (
   args: Readonly<Record<string, unknown>>,
 ) => Promise<string>;
 
+type CreatePr = (
+  sessionId: SessionId,
+  opts: {
+    readonly title: string;
+    readonly body: string;
+    readonly base: string;
+    readonly draft: boolean;
+  },
+) => Promise<void>;
+
 type Store = {
-  readonly createPrForSession: ReturnType<typeof vi.fn>;
+  readonly createPrForSession: ReturnType<typeof vi.fn<CreatePr>>;
   readonly spawnAgent: ReturnType<typeof vi.fn<SpawnAgent>>;
   readonly selectAgent: ReturnType<typeof vi.fn>;
   readonly setCurrentSession: ReturnType<typeof vi.fn>;
@@ -18,6 +33,7 @@ type Store = {
   readonly sessionActiveMount: Record<string, string>;
   readonly sessionWorktrees: Record<string, ReadonlyArray<string>>;
   readonly sessions: ReadonlyArray<{ id: SessionId; workspaceId: string }>;
+  sessionExternalTasks: Record<string, ReadonlyArray<SessionExternalTask>>;
   readonly workspaces: ReadonlyArray<{ id: string; rootPath: string; kind: 'repo' }>;
   workspaceOverrides: Record<string, { readonly taskModels: TaskModelPreferences | null }>;
 };
@@ -49,7 +65,7 @@ const h = vi.hoisted(() => ({
     }),
   ),
   store: {
-    createPrForSession: vi.fn(async () => undefined),
+    createPrForSession: vi.fn<CreatePr>(async () => undefined),
     spawnAgent: vi.fn<SpawnAgent>(async () => 'agent-2'),
     selectAgent: vi.fn(async () => undefined),
     setCurrentSession: vi.fn(async () => undefined),
@@ -58,12 +74,14 @@ const h = vi.hoisted(() => ({
     sessionActiveMount: {},
     sessionWorktrees: { 'session-2': ['/repo/.goodboy/worktrees/card-config'] },
     sessions: [{ id: 'session-2' as SessionId, workspaceId: 'workspace-1' }],
+    sessionExternalTasks: {} as Record<string, ReadonlyArray<SessionExternalTask>>,
     workspaces: [{ id: 'workspace-1', rootPath: '/repo', kind: 'repo' }],
     workspaceOverrides: {},
   } satisfies Store,
 }));
 
 vi.mock('../../../../store', () => ({
+  EMPTY_ARRAY: [] as readonly never[],
   useAppStore: <T,>(selector: (state: Store) => T) => selector(h.store),
 }));
 
@@ -103,8 +121,22 @@ vi.mock('../../../session/components/AgentSpawnConfig', () => ({
 }));
 
 import { CreatePrPanel } from './CreatePrPanel';
+import { closingIssueReferences } from '../../closingIssueReferences';
+import { appendClosingReferences } from '../../appendClosingReferences';
 
 const SESSION_ID = 'session-2' as SessionId;
+
+const linkedIssue = (overrides: Partial<SessionExternalTask>): SessionExternalTask => ({
+  sessionId: SESSION_ID,
+  provider: 'github',
+  externalId: '41',
+  identifier: '#41',
+  url: 'https://github.com/acme/web/issues/41',
+  title: 'Broken card',
+  branch: 'ak/card-config',
+  createdAt: '2026-08-04T00:00:00.000Z' as IsoDateTime,
+  ...overrides,
+});
 
 const renderPanel = () =>
   render(
@@ -128,6 +160,7 @@ beforeEach(() => {
   h.store.setCurrentSession.mockClear();
   h.showToast.mockClear();
   h.store.workspaceOverrides = {};
+  h.store.sessionExternalTasks = {};
   h.ghBaseBranches.mockClear();
   h.ghBaseBranches.mockImplementation(async () => ({ defaultBranch: 'main', branches: ['main'] }));
 });
@@ -311,5 +344,63 @@ describe('CreatePrPanel', () => {
       provider: 'codex',
       model: 'gpt-5.4-mini',
     });
+  });
+
+  it('previews the closing reference for an issue linked on the session branch, and only that one', async () => {
+    h.store.sessionExternalTasks = {
+      'session-2': [
+        linkedIssue({}),
+        linkedIssue({ externalId: '52', identifier: '#52', branch: 'ak/other' }),
+        linkedIssue({ provider: 'linear', externalId: 'GRO-9', identifier: 'GRO-9' }),
+      ],
+    };
+    renderPanel();
+    await screen.findByRole('combobox', { name: 'Branch' });
+
+    expect(screen.getAllByTestId('pr-issue-reference').map((node) => node.textContent)).toEqual([
+      'Closes #41',
+    ]);
+  });
+
+  it('previews exactly the block the store appends to the body it is given', async () => {
+    h.store.sessionExternalTasks = { 'session-2': [linkedIssue({})] };
+    renderPanel();
+    await screen.findByRole('combobox', { name: 'Branch' });
+    fireEvent.change(screen.getByRole('textbox', { name: 'Pull request description' }), {
+      target: { value: 'Documents the change.' },
+    });
+    const previewed = screen
+      .getAllByTestId('pr-issue-reference')
+      .map((node) => node.textContent)
+      .join('\n');
+    fireEvent.click(screen.getByRole('button', { name: 'Create PR' }));
+
+    await waitFor(() => expect(h.store.createPrForSession).toHaveBeenCalledOnce());
+    const sent = h.store.createPrForSession.mock.calls[0]![1];
+    const stored = appendClosingReferences({
+      body: sent.body,
+      references: closingIssueReferences({
+        tasks: h.store.sessionExternalTasks['session-2']!,
+        branch: 'ak/card-config',
+        body: sent.body,
+      }),
+    });
+    expect(stored).toBe(`${sent.body}\n\n${previewed}`);
+  });
+
+  it('hides the preview when nothing will be referenced', async () => {
+    renderPanel();
+    await screen.findByRole('combobox', { name: 'Branch' });
+    expect(screen.queryByTestId('pr-issue-reference')).toBeNull();
+  });
+
+  it('tells the drafting agent to write the closing references it previewed', async () => {
+    h.store.sessionExternalTasks = { 'session-2': [linkedIssue({})] };
+    renderPanel();
+    switchToAgentMode();
+    fireEvent.click(screen.getByRole('button', { name: 'Draft with agent' }));
+
+    await waitFor(() => expect(h.store.spawnAgent).toHaveBeenCalledOnce());
+    expect(h.store.spawnAgent.mock.calls[0]![1].initialPrompt).toContain('Closes #41');
   });
 });

--- a/apps/desktop/src/features/github/components/GitHubStudio/CreatePrPanel.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/CreatePrPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import type { SessionId } from '@goodboy/types';
+import type { SessionExternalTask, SessionId } from '@goodboy/types';
 import {
   Button,
   Checkbox,
@@ -15,13 +15,14 @@ import {
 } from '@goodboy/ui';
 import { AlertTriangle, ArrowRight, GitBranch, PenLine, Sparkles } from 'lucide-react';
 import { ghBaseBranches } from '../../github';
+import { closingIssueReferences } from '../../closingIssueReferences';
 import { appendOperatorNotes } from '../../../session/utils/appendOperatorNotes';
 import { AgentSpawnConfig } from '../../../session/components/AgentSpawnConfig';
 import type { AgentSpawnConfigValue } from '../../../session/components/AgentSpawnConfig/AgentSpawnConfigValue';
 import { taskModelAgentSpawnConfig } from '../../../session/components/AgentSpawnConfig/taskModelAgentSpawnConfig';
 import { BranchCombobox } from '../../../worktree/BranchCombobox';
 import type { LocalBranchInfo } from '../../../worktree/worktree';
-import { useAppStore } from '../../../../store';
+import { EMPTY_ARRAY, useAppStore } from '../../../../store';
 import { useToast } from '../../../../app/components/Toast';
 import { useSessionRepo } from '../../../../store/slices/worktrees/useSessionRepo';
 
@@ -83,6 +84,19 @@ export const CreatePrPanel = ({
   const branchOptions = useMemo<ReadonlyArray<LocalBranchInfo>>(
     () => branches.map((name) => ({ name, inUse: false, hasUncommitted: false })),
     [branches],
+  );
+
+  const linkedTasks = useAppStore(
+    (s) => s.sessionExternalTasks[sessionId] ?? (EMPTY_ARRAY as ReadonlyArray<SessionExternalTask>),
+  );
+  const references = useMemo(
+    () =>
+      closingIssueReferences({
+        tasks: linkedTasks,
+        branch,
+        body: mode === 'manual' ? body : '',
+      }),
+    [body, branch, linkedTasks, mode],
   );
 
   useEffect(() => {
@@ -148,6 +162,11 @@ export const CreatePrPanel = ({
           : []),
         `- Write a clear, conventional title and a concise description from the committed changes.`,
         `- Session goal: "${defaultTitle}".`,
+        ...(references.length > 0
+          ? [
+              `- End the description with these lines exactly, so GitHub links the issues:\n${references.map((reference) => reference.line).join('\n')}`,
+            ]
+          : []),
         `- If this project defines a PR-creation skill, command, or template (look under .claude/), follow it.`,
         `- Open it as a ${draft ? 'draft' : 'ready-for-review'} PR.`,
         `Then run \`gh pr create\` to open it and report the PR URL.`,
@@ -269,6 +288,36 @@ export const CreatePrPanel = ({
                   disabled={busy !== null}
                 />
               </FieldRow>
+            )}
+            {references.length > 0 && (
+              <>
+                <Divider />
+                <FieldRow
+                  label="Issue links"
+                  help="Added to the description so GitHub closes these issues when this merges."
+                >
+                  <ul className="flex flex-col gap-1.5">
+                    {references.map((reference) => (
+                      <li key={reference.number} className="flex items-center gap-2">
+                        <code
+                          data-testid="pr-issue-reference"
+                          className="rounded-md bg-muted px-1.5 py-0.5 font-mono text-2xs text-foreground"
+                        >
+                          {reference.line}
+                        </code>
+                        <a
+                          href={reference.url}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="truncate text-2xs text-muted-foreground transition-colors hover:text-foreground"
+                        >
+                          {reference.identifier}
+                        </a>
+                      </li>
+                    ))}
+                  </ul>
+                </FieldRow>
+              </>
             )}
             <Divider />
             <FieldRow

--- a/apps/desktop/src/features/plans/components/PlanStudio/index.test.tsx
+++ b/apps/desktop/src/features/plans/components/PlanStudio/index.test.tsx
@@ -1,9 +1,14 @@
 // @vitest-environment happy-dom
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 
-const { state } = vi.hoisted(() => ({
+type ToastAction = { readonly label: string; readonly onClick: () => void };
+
+type ToastOptions = { readonly title?: string; readonly action?: ToastAction };
+
+const { state, showToast } = vi.hoisted(() => ({
+  showToast: vi.fn<(kind: string, message: string, opts?: ToastOptions) => void>(),
   state: {
     sessionPhaseRuns: {} as Record<string, ReadonlyArray<unknown>>,
     planConsumptions: {} as Record<string, ReadonlyArray<unknown>>,
@@ -11,8 +16,10 @@ const { state } = vi.hoisted(() => ({
     updatePlanBody: vi.fn(async () => undefined),
     deletePlan: vi.fn(async () => undefined),
     restorePlan: vi.fn(async () => undefined),
-    runPlan: vi.fn(async () => undefined),
+    runPlan: vi.fn(async () => 'agent-impl'),
     selectAgent: vi.fn(async () => undefined),
+    setCurrentSession: vi.fn(async () => undefined),
+    setActiveLens: vi.fn(),
     setFocusedPlanId: vi.fn(),
     plans: [] as ReadonlyArray<unknown>,
   },
@@ -25,10 +32,14 @@ vi.mock('../../../../store', () => ({
 }));
 
 vi.mock('../../../../app/components/Toast', () => ({
-  useToast: () => ({ showToast: vi.fn() }),
+  useToast: () => ({ showToast }),
 }));
 
 beforeEach(() => {
+  showToast.mockClear();
+  state.runPlan.mockClear();
+  state.selectAgent.mockClear();
+  state.setActiveLens.mockClear();
   state.sessionPhaseRuns = {};
   state.planConsumptions = {};
   state.plans = [];
@@ -102,6 +113,35 @@ describe('PlanStudio', () => {
     expect(state.deletePlan).not.toHaveBeenCalled();
     fireEvent.click(screen.getByRole('button', { name: 'Delete Implement auth module' }));
     expect(state.deletePlan).toHaveBeenCalledWith('sess-1', 'plan-1');
+  });
+
+  it('starts the plan without opening the agent, and opens it only from the toast action', async () => {
+    state.plans = [
+      {
+        id: 'plan-1',
+        agentId: 'agent-1',
+        sessionId: 'sess-1',
+        title: 'Implement auth module',
+        bodyMd: '## Steps',
+        status: 'active',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        runCount: 0,
+      },
+    ];
+    render(<PlanStudio sessionId={'sess-1' as never} initialPlanId={'plan-1' as never} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Start' }));
+
+    await waitFor(() => expect(state.runPlan).toHaveBeenCalledWith('sess-1', 'plan-1'));
+    await waitFor(() => expect(showToast).toHaveBeenCalledOnce());
+    expect(state.selectAgent).not.toHaveBeenCalled();
+    const opts = showToast.mock.calls[0]![2];
+    expect(opts?.title).toBe('Implementer started');
+    expect(opts?.action?.label).toBe('Open the agent');
+
+    opts?.action?.onClick();
+
+    await waitFor(() => expect(state.selectAgent).toHaveBeenCalledWith('sess-1', 'agent-impl'));
+    expect(state.setActiveLens).toHaveBeenCalledWith('sess-1', 'agents');
   });
 });
 

--- a/apps/desktop/src/features/plans/components/PlanStudio/index.tsx
+++ b/apps/desktop/src/features/plans/components/PlanStudio/index.tsx
@@ -19,6 +19,7 @@ import { PlanListPanel } from './PlanListPanel';
 import { PlanProvenance } from './PlanProvenance';
 import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../shared/components/conceptIcons';
 import { LensEmptyState } from '../../../../shared/components/LensEmptyState';
+import { useAgentStartedToast } from '../../../../shared/hooks/useAgentStartedToast';
 
 type Props = {
   readonly sessionId: SessionId;
@@ -39,6 +40,7 @@ export const PlanStudio = ({ sessionId, initialPlanId }: Props) => {
   const selectAgent = useAppStore((s) => s.selectAgent);
   const setFocusedPlanId = useAppStore((s) => s.setFocusedPlanId);
   const { showToast } = useToast();
+  const announceAgentStarted = useAgentStartedToast();
 
   const [selectedId, setSelectedId] = useState<PlanId | null>(initialPlanId ?? null);
   const [listOpen, setListOpen] = useState(false);
@@ -105,8 +107,14 @@ export const PlanStudio = ({ sessionId, initialPlanId }: Props) => {
     }
     setSpawning(true);
     try {
-      await runPlan(sessionId, selected.id);
+      const agentId = await runPlan(sessionId, selected.id);
       flushEdit();
+      announceAgentStarted({
+        sessionId,
+        agentId,
+        title: 'Implementer started',
+        message: 'An agent is running this plan. You can keep working.',
+      });
     } finally {
       setSpawning(false);
     }

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/PlanReadySuggestion.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/PlanReadySuggestion.tsx
@@ -14,6 +14,7 @@ import {
   inferAgentKindFromName,
   kindConsumesPlan,
 } from '../../../../session/agent-kind';
+import { useAgentStartedToast } from '../../../../../shared/hooks/useAgentStartedToast';
 
 type Props = {
   task: Session;
@@ -29,6 +30,7 @@ export const PlanReadySuggestion = ({ task }: Props) => {
     (s) => s.phaseTemplates[task.workspaceId] ?? (EMPTY_ARRAY as ReadonlyArray<Workflow>),
   );
   const runPlan = useAppStore((s) => s.runPlan);
+  const announceAgentStarted = useAgentStartedToast();
   const [spawning, setSpawning] = useState(false);
 
   const latest = plans[plans.length - 1];
@@ -74,7 +76,13 @@ export const PlanReadySuggestion = ({ task }: Props) => {
     }
     setSpawning(true);
     try {
-      await runPlan(task.id, latest.id);
+      const agentId = await runPlan(task.id, latest.id);
+      announceAgentStarted({
+        sessionId: task.id,
+        agentId,
+        title: 'Implementer started',
+        message: 'An agent is running this plan. You can keep working.',
+      });
     } finally {
       setSpawning(false);
     }

--- a/apps/desktop/src/shared/hooks/useAgentStartedToast/index.ts
+++ b/apps/desktop/src/shared/hooks/useAgentStartedToast/index.ts
@@ -1,0 +1,39 @@
+import { useCallback } from 'react';
+import type { AgentId, SessionId } from '@goodboy/types';
+import { useAppStore } from '../../../store';
+import { useToast } from '../../../app/components/Toast';
+
+type AnnounceParams = {
+  readonly sessionId: SessionId;
+  readonly agentId: AgentId | null;
+  readonly title: string;
+  readonly message: string;
+};
+
+export const useAgentStartedToast = (): ((params: AnnounceParams) => void) => {
+  const setCurrentSession = useAppStore((s) => s.setCurrentSession);
+  const setActiveLens = useAppStore((s) => s.setActiveLens);
+  const selectAgent = useAppStore((s) => s.selectAgent);
+  const { showToast } = useToast();
+  return useCallback(
+    ({ sessionId, agentId, title, message }: AnnounceParams) => {
+      if (agentId == null) {
+        return;
+      }
+      showToast('info', message, {
+        title,
+        action: {
+          label: 'Open the agent',
+          onClick: () => {
+            void (async () => {
+              await setCurrentSession(sessionId);
+              setActiveLens(sessionId, 'agents');
+              await selectAgent(sessionId, agentId);
+            })();
+          },
+        },
+      });
+    },
+    [selectAgent, setActiveLens, setCurrentSession, showToast],
+  );
+};

--- a/apps/desktop/src/store/slices/github/createPrForSession.test.ts
+++ b/apps/desktop/src/store/slices/github/createPrForSession.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  IsoDateTime,
+  PullRequestState,
+  SessionExternalTask,
+  SessionId,
+  WorkspaceId,
+} from '@goodboy/types';
+
+type GhRun = (
+  args: ReadonlyArray<string>,
+  opts: Readonly<Record<string, unknown>>,
+) => Promise<{ stdout: string; stderr: string; exitCode: number }>;
+
+const h = vi.hoisted(() => ({
+  run: vi.fn<GhRun>(async () => ({ stdout: '', stderr: '', exitCode: 0 })),
+}));
+
+vi.mock('../../../features/github/github', () => ({
+  tauriGhRunner: { run: h.run },
+}));
+
+import { createPrForSession } from './createPrForSession';
+import type { GetFn, SetFn } from './types';
+
+const SESSION_ID = 'sess-1' as SessionId;
+const WORKSPACE_ID = 'ws-1' as WorkspaceId;
+const BRANCH = 'ak/cards';
+const NOW = '2026-08-04T00:00:00.000Z' as IsoDateTime;
+
+const githubIssue = (overrides: Partial<SessionExternalTask> = {}): SessionExternalTask => ({
+  sessionId: SESSION_ID,
+  provider: 'github',
+  externalId: '41',
+  identifier: '#41',
+  url: 'https://github.com/acme/web/issues/41',
+  title: 'Broken card',
+  branch: BRANCH,
+  createdAt: NOW,
+  ...overrides,
+});
+
+type FakeState = {
+  sessions: ReadonlyArray<unknown>;
+  workspaces: ReadonlyArray<unknown>;
+  sessionBranches: Record<string, string>;
+  sessionWorktrees: Record<string, ReadonlyArray<string>>;
+  sessionMounts: Record<string, ReadonlyArray<unknown>>;
+  sessionActiveMount: Record<string, string>;
+  sessionExternalTasks: Record<string, ReadonlyArray<SessionExternalTask>>;
+  sessionGithub: Record<string, { pr: PullRequestState | null }>;
+  refreshSessionPr: ReturnType<typeof vi.fn>;
+  editPr: ReturnType<typeof vi.fn>;
+  emitNotification: ReturnType<typeof vi.fn>;
+};
+
+const buildState = (overrides: Partial<FakeState> = {}): FakeState => ({
+  sessions: [{ id: SESSION_ID, workspaceId: WORKSPACE_ID, goal: 'Fix the cards' }],
+  workspaces: [{ id: WORKSPACE_ID, rootPath: '/repo', kind: 'repo' }],
+  sessionBranches: { [SESSION_ID]: BRANCH },
+  sessionWorktrees: { [SESSION_ID]: ['/repo/.goodboy/worktrees/cards'] },
+  sessionMounts: {},
+  sessionActiveMount: {},
+  sessionExternalTasks: {},
+  sessionGithub: {},
+  refreshSessionPr: vi.fn(async () => undefined),
+  editPr: vi.fn(async () => undefined),
+  emitNotification: vi.fn(async () => undefined),
+  ...overrides,
+});
+
+const buildCreate = (state: FakeState) => {
+  const set = vi.fn() as unknown as SetFn;
+  const get = (() => state) as unknown as GetFn;
+  return createPrForSession(set, get);
+};
+
+const bodyArg = (): string => {
+  const args = h.run.mock.calls[0]![0];
+  return args[args.indexOf('--body') + 1] ?? '';
+};
+
+beforeEach(() => {
+  h.run.mockClear();
+  h.run.mockImplementation(async () => ({ stdout: '', stderr: '', exitCode: 0 }));
+});
+
+describe('createPrForSession, issue references', () => {
+  it('closes the github issue linked on the session branch', async () => {
+    const state = buildState({
+      sessionExternalTasks: { [SESSION_ID]: [githubIssue()] },
+    });
+
+    await buildCreate(state)(SESSION_ID, { title: 'Fix cards', body: 'Documents the change.' });
+
+    expect(bodyArg()).toBe('Documents the change.\n\nCloses #41');
+  });
+
+  it('closes every github issue linked on the session branch', async () => {
+    const state = buildState({
+      sessionExternalTasks: {
+        [SESSION_ID]: [githubIssue(), githubIssue({ externalId: '52', identifier: '#52' })],
+      },
+    });
+
+    await buildCreate(state)(SESSION_ID, { title: 'Fix cards', body: '' });
+
+    expect(bodyArg()).toBe('Closes #41\nCloses #52');
+  });
+
+  it('leaves out an issue linked on another branch', async () => {
+    const state = buildState({
+      sessionExternalTasks: {
+        [SESSION_ID]: [githubIssue({ branch: 'ak/somewhere-else' })],
+      },
+    });
+
+    await buildCreate(state)(SESSION_ID, { title: 'Fix cards', body: 'Documents the change.' });
+
+    expect(bodyArg()).toBe('Documents the change.');
+  });
+
+  it('never writes a linear issue as a closing reference', async () => {
+    const state = buildState({
+      sessionExternalTasks: {
+        [SESSION_ID]: [
+          githubIssue({ provider: 'linear', externalId: 'GRO-12', identifier: 'GRO-12' }),
+        ],
+      },
+    });
+
+    await buildCreate(state)(SESSION_ID, { title: 'Fix cards', body: 'Documents the change.' });
+
+    expect(bodyArg()).toBe('Documents the change.');
+    expect(h.run.mock.calls[0]![0]).not.toContain('--fill');
+  });
+
+  it('patches the body gh generated with --fill so the reference still lands', async () => {
+    const created = {
+      number: 7,
+      body: 'Generated from the commits.',
+    } as PullRequestState;
+    const state = buildState({
+      sessionExternalTasks: { [SESSION_ID]: [githubIssue()] },
+      sessionGithub: { [SESSION_ID]: { pr: created } },
+    });
+
+    await buildCreate(state)(SESSION_ID);
+
+    expect(h.run.mock.calls[0]![0]).toContain('--fill');
+    expect(state.editPr).toHaveBeenCalledWith(SESSION_ID, 7, {
+      body: 'Generated from the commits.\n\nCloses #41',
+    });
+  });
+
+  it('does not patch a filled body that already closes the issue', async () => {
+    const created = { number: 7, body: 'fix #41' } as PullRequestState;
+    const state = buildState({
+      sessionExternalTasks: { [SESSION_ID]: [githubIssue()] },
+      sessionGithub: { [SESSION_ID]: { pr: created } },
+    });
+
+    await buildCreate(state)(SESSION_ID);
+
+    expect(state.editPr).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/store/slices/github/createPrForSession.ts
+++ b/apps/desktop/src/store/slices/github/createPrForSession.ts
@@ -1,5 +1,7 @@
 import type { SessionId } from '@goodboy/types';
 import { tauriGhRunner } from '../../../features/github/github';
+import { appendClosingReferences } from '../../../features/github/appendClosingReferences';
+import { closingIssueReferences } from '../../../features/github/closingIssueReferences';
 import { getSessionRepo } from '../worktrees/getSessionRepo';
 import type { GetFn, SetFn } from './types';
 
@@ -30,11 +32,19 @@ export const createPrForSession = (_set: SetFn, get: GetFn) => {
       );
     }
 
+    const linkedTasks = get().sessionExternalTasks[sessionId] ?? [];
     const args = ['pr', 'create'];
     const hasFields = opts?.title !== undefined || opts?.body !== undefined;
     if (hasFields) {
+      const body = opts?.body ?? '';
       args.push('--title', opts?.title?.trim() || session.goal);
-      args.push('--body', opts?.body ?? '');
+      args.push(
+        '--body',
+        appendClosingReferences({
+          body,
+          references: closingIssueReferences({ tasks: linkedTasks, branch: repo.branch, body }),
+        }),
+      );
     } else {
       args.push('--fill');
     }
@@ -59,6 +69,21 @@ export const createPrForSession = (_set: SetFn, get: GetFn) => {
       throw new Error(errMsg);
     }
     await get().refreshSessionPr(sessionId, { force: true });
+    const filled = hasFields ? null : (get().sessionGithub[sessionId]?.pr ?? null);
+    if (filled != null) {
+      const references = closingIssueReferences({
+        tasks: linkedTasks,
+        branch: repo.branch,
+        body: filled.body,
+      });
+      if (references.length > 0) {
+        await get()
+          .editPr(sessionId, filled.number, {
+            body: appendClosingReferences({ body: filled.body, references }),
+          })
+          .catch(() => undefined);
+      }
+    }
     void get().emitNotification(
       'pr-created',
       'success',

--- a/apps/desktop/src/store/slices/nudges/acceptSessionNudgeHandoff.test.ts
+++ b/apps/desktop/src/store/slices/nudges/acceptSessionNudgeHandoff.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AgentId, PlanId, SessionId } from '@goodboy/types';
+
+const h = vi.hoisted(() => ({
+  recordOutcome: vi.fn(async () => undefined),
+}));
+
+vi.mock('./recordOutcome', () => ({ recordOutcome: h.recordOutcome }));
+
+import { acceptSessionNudgeHandoff } from './acceptSessionNudgeHandoff';
+import type { GetFn, SetFn } from './types';
+
+const SESSION_ID = 'sess-1' as SessionId;
+const PLAN_ID = 'plan-1' as PlanId;
+
+type FakeState = {
+  sessionNudges: Record<string, unknown>;
+  spawnAgent: ReturnType<typeof vi.fn>;
+};
+
+const buildAccept = (state: FakeState) => {
+  const set = ((updater: (s: FakeState) => Partial<FakeState>) => {
+    Object.assign(state, updater(state));
+  }) as unknown as SetFn;
+  const get = (() => state) as unknown as GetFn;
+  return acceptSessionNudgeHandoff(set, get);
+};
+
+const buildState = (nudge: unknown): FakeState => ({
+  sessionNudges: { [SESSION_ID]: nudge },
+  spawnAgent: vi.fn(async () => 'agent-impl' as AgentId),
+});
+
+beforeEach(() => {
+  h.recordOutcome.mockClear();
+});
+
+describe('acceptSessionNudgeHandoff, spawning does not steal focus', () => {
+  it('spawns the plan implementer without focus and hands back the agent to open', async () => {
+    const state = buildState({ id: 'nudge-1', kind: 'plan-ready', planId: PLAN_ID });
+
+    const agentId = await buildAccept(state)(SESSION_ID);
+
+    expect(state.spawnAgent).toHaveBeenCalledWith(SESSION_ID, {
+      triggeredPlanId: PLAN_ID,
+      kindOverride: 'implementer',
+      focus: 'none',
+    });
+    expect(agentId).toBe('agent-impl');
+  });
+
+  it('spawns a planless implementer without focus', async () => {
+    const state = buildState({ id: 'nudge-2', kind: 'plan-ready', planId: null });
+
+    await buildAccept(state)(SESSION_ID);
+
+    expect(state.spawnAgent).toHaveBeenCalledWith(SESSION_ID, {
+      kindOverride: 'implementer',
+      focus: 'none',
+    });
+  });
+
+  it('spawns the suggested handoff target without focus', async () => {
+    const state = buildState({
+      id: 'nudge-3',
+      kind: 'handoff-suggested',
+      targetKind: 'reviewer',
+      planId: null,
+    });
+
+    const agentId = await buildAccept(state)(SESSION_ID);
+
+    expect(state.spawnAgent).toHaveBeenCalledWith(SESSION_ID, {
+      kindOverride: 'reviewer',
+      focus: 'none',
+    });
+    expect(agentId).toBe('agent-impl');
+  });
+
+  it('hands back nothing when there is no nudge to accept', async () => {
+    const state: FakeState = { sessionNudges: {}, spawnAgent: vi.fn(async () => 'x' as AgentId) };
+
+    const agentId = await buildAccept(state)(SESSION_ID);
+
+    expect(agentId).toBeNull();
+    expect(state.spawnAgent).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/store/slices/nudges/acceptSessionNudgeHandoff.ts
+++ b/apps/desktop/src/store/slices/nudges/acceptSessionNudgeHandoff.ts
@@ -1,12 +1,12 @@
-import type { SessionId } from '@goodboy/types';
+import type { AgentId, SessionId } from '@goodboy/types';
 import { recordOutcome } from './recordOutcome';
 import type { GetFn, SetFn } from './types';
 
 export const acceptSessionNudgeHandoff = (set: SetFn, get: GetFn) => {
-  return async (sessionId: SessionId) => {
+  return async (sessionId: SessionId): Promise<AgentId | null> => {
     const nudge = get().sessionNudges[sessionId] ?? null;
     if (!nudge) {
-      return;
+      return null;
     }
     set((state) => ({
       sessionNudges: { ...state.sessionNudges, [sessionId]: null },
@@ -14,20 +14,21 @@ export const acceptSessionNudgeHandoff = (set: SetFn, get: GetFn) => {
     await recordOutcome(nudge.id, 'accepted');
     if (nudge.kind === 'plan-ready') {
       if (nudge.planId !== null) {
-        await get().spawnAgent(sessionId, {
+        return await get().spawnAgent(sessionId, {
           triggeredPlanId: nudge.planId,
           kindOverride: 'implementer',
-          focus: 'agent',
+          focus: 'none',
         });
-      } else {
-        await get().spawnAgent(sessionId, { kindOverride: 'implementer', focus: 'agent' });
       }
-    } else if (nudge.kind === 'handoff-suggested') {
-      await get().spawnAgent(sessionId, {
+      return await get().spawnAgent(sessionId, { kindOverride: 'implementer', focus: 'none' });
+    }
+    if (nudge.kind === 'handoff-suggested') {
+      return await get().spawnAgent(sessionId, {
         kindOverride: nudge.targetKind,
         ...(nudge.planId !== null && { triggeredPlanId: nudge.planId }),
-        focus: 'agent',
+        focus: 'none',
       });
     }
+    return null;
   };
 };

--- a/apps/desktop/src/store/slices/plans/index.test.ts
+++ b/apps/desktop/src/store/slices/plans/index.test.ts
@@ -178,7 +178,7 @@ describe('runPlan, workflow-aware spawn routing', () => {
         SESSION_ID,
         IMPL_AGENT_ID,
         PLAN_ID,
-        'agent',
+        'none',
       );
     });
 
@@ -214,7 +214,7 @@ describe('runPlan, workflow-aware spawn routing', () => {
         expect(
           state.activateWorkflowAgent,
           `alias "${name}" should activate the slot`,
-        ).toHaveBeenCalledWith(SESSION_ID, IMPL_AGENT_ID, PLAN_ID, 'agent');
+        ).toHaveBeenCalledWith(SESSION_ID, IMPL_AGENT_ID, PLAN_ID, 'none');
       }
     });
 
@@ -240,7 +240,7 @@ describe('runPlan, workflow-aware spawn routing', () => {
           SESSION_ID,
           IMPL_AGENT_ID,
           PLAN_ID,
-          'agent',
+          'none',
         );
       },
     );
@@ -260,7 +260,7 @@ describe('runPlan, workflow-aware spawn routing', () => {
       expect(args).toEqual({
         triggeredPlanId: PLAN_ID,
         kindOverride: 'implementer',
-        focus: 'agent',
+        focus: 'none',
       });
       expect(args).not.toHaveProperty('stepId');
     });
@@ -275,7 +275,7 @@ describe('runPlan, workflow-aware spawn routing', () => {
       expect(args).toEqual({
         triggeredPlanId: PLAN_ID,
         kindOverride: 'implementer',
-        focus: 'agent',
+        focus: 'none',
       });
     });
   });
@@ -310,7 +310,7 @@ describe('runPlan, workflow-aware spawn routing', () => {
       expect(args).toEqual({
         triggeredPlanId: PLAN_ID,
         kindOverride: 'implementer',
-        focus: 'agent',
+        focus: 'none',
       });
     });
 
@@ -326,7 +326,7 @@ describe('runPlan, workflow-aware spawn routing', () => {
       expect(args).toEqual({
         triggeredPlanId: PLAN_ID,
         kindOverride: 'implementer',
-        focus: 'agent',
+        focus: 'none',
       });
     });
 
@@ -352,7 +352,7 @@ describe('runPlan, workflow-aware spawn routing', () => {
       expect(args).toEqual({
         triggeredPlanId: PLAN_ID,
         kindOverride: 'implementer',
-        focus: 'agent',
+        focus: 'none',
       });
     });
   });
@@ -368,7 +368,7 @@ describe('runPlan, workflow-aware spawn routing', () => {
       expect(args).toEqual({
         triggeredPlanId: PLAN_ID,
         kindOverride: 'implementer',
-        focus: 'agent',
+        focus: 'none',
       });
     });
 
@@ -382,7 +382,7 @@ describe('runPlan, workflow-aware spawn routing', () => {
       expect(args).toEqual({
         triggeredPlanId: PLAN_ID,
         kindOverride: 'implementer',
-        focus: 'agent',
+        focus: 'none',
       });
     });
   });
@@ -417,7 +417,7 @@ describe('runPlan, workflow-aware spawn routing', () => {
       expect(args).toEqual({
         triggeredPlanId: PLAN_ID,
         kindOverride: 'implementer',
-        focus: 'agent',
+        focus: 'none',
       });
     });
 
@@ -464,7 +464,7 @@ describe('runPlan, workflow-aware spawn routing', () => {
       expect(args).toEqual({
         triggeredPlanId: PLAN_ID,
         kindOverride: 'implementer',
-        focus: 'agent',
+        focus: 'none',
       });
     });
   });
@@ -504,7 +504,7 @@ describe('runPlan, workflow-aware spawn routing', () => {
       expect(args).toEqual({
         triggeredPlanId: PLAN_ID,
         kindOverride: 'implementer',
-        focus: 'agent',
+        focus: 'none',
       });
     });
 
@@ -548,8 +548,57 @@ describe('runPlan, workflow-aware spawn routing', () => {
       expect(args, `next step "${name}" must trigger free-spawn`).toEqual({
         triggeredPlanId: PLAN_ID,
         kindOverride: 'implementer',
-        focus: 'agent',
+        focus: 'none',
       });
+    });
+  });
+
+  describe('spawning does not steal focus', () => {
+    it('activates the workflow slot without focus and hands back the agent to open', async () => {
+      const state = defaultState();
+      const slice = buildSlice(state);
+
+      const agentId = await slice.runPlan(SESSION_ID, PLAN_ID);
+
+      expect(state.activateWorkflowAgent).toHaveBeenCalledWith(
+        SESSION_ID,
+        IMPL_AGENT_ID,
+        PLAN_ID,
+        'none',
+      );
+      expect(agentId).toBe(IMPL_AGENT_ID);
+    });
+
+    it('free-spawns without focus and hands back the spawned agent', async () => {
+      const state = defaultState({ sessions: [makeSession({ workflowRuns: [] })] });
+
+      const agentId = await buildSlice(state).runPlan(SESSION_ID, PLAN_ID);
+
+      expect(state.spawnAgent.mock.calls[0]![1]).toMatchObject({ focus: 'none' });
+      expect(agentId).toBe('spawned');
+    });
+
+    it('hands back nothing when the plan creator failed and no agent starts', async () => {
+      const state = defaultState({
+        sessionPhaseRuns: {
+          [SESSION_ID]: [
+            makeAgent({
+              id: CREATOR_AGENT_ID,
+              stepId: STEP_PLAN,
+              workflowRunId: RUN_ID,
+              status: 'failed',
+              name: 'Plan',
+              ordinal: 0,
+            }),
+          ],
+        },
+      });
+
+      const agentId = await buildSlice(state).runPlan(SESSION_ID, PLAN_ID);
+
+      expect(agentId).toBeNull();
+      expect(state.spawnAgent).not.toHaveBeenCalled();
+      expect(state.activateWorkflowAgent).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/desktop/src/store/slices/plans/runPlan.ts
+++ b/apps/desktop/src/store/slices/plans/runPlan.ts
@@ -1,37 +1,35 @@
-import type { PlanId, SessionId } from '@goodboy/types';
+import type { AgentId, PlanId, SessionId } from '@goodboy/types';
 import { runsForWorkflowRun } from '@goodboy/core';
 import { inferAgentKindFromName, kindConsumesPlan } from '../../../features/session/agent-kind';
 import { pickNextWorkflowStep } from '../../../features/workflows/components/WorkflowNextStepCta';
 import type { GetFn } from './types';
 
 export const runPlan = (get: GetFn) => {
-  return async (sessionId: SessionId, planId: PlanId) => {
+  return async (sessionId: SessionId, planId: PlanId): Promise<AgentId | null> => {
     const state = get();
 
     const session = state.sessions.find((s) => s.id === sessionId);
     if (!session || session.workflowRuns.length === 0) {
-      await get().spawnAgent(sessionId, {
+      return await get().spawnAgent(sessionId, {
         triggeredPlanId: planId,
         kindOverride: 'implementer',
-        focus: 'agent',
+        focus: 'none',
       });
-      return;
     }
 
     const plan = state.sessionPlans[sessionId]?.find((p) => p.id === planId);
     const runs = state.sessionPhaseRuns[sessionId] ?? [];
     const creatorAgent = plan ? runs.find((r) => r.id === plan.agentId) : undefined;
     if (!creatorAgent?.stepId || !creatorAgent.workflowRunId) {
-      await get().spawnAgent(sessionId, {
+      return await get().spawnAgent(sessionId, {
         triggeredPlanId: planId,
         kindOverride: 'implementer',
-        focus: 'agent',
+        focus: 'none',
       });
-      return;
     }
 
     if (creatorAgent.status === 'failed') {
-      return;
+      return null;
     }
 
     const templates = state.phaseTemplates[session.workspaceId] ?? [];
@@ -41,44 +39,41 @@ export const runPlan = (get: GetFn) => {
         ? (templates.find((t) => t.id === creatorRun.workflowId) ?? null)
         : null;
     if (!creatorRun || !template) {
-      await get().spawnAgent(sessionId, {
+      return await get().spawnAgent(sessionId, {
         triggeredPlanId: planId,
         kindOverride: 'implementer',
-        focus: 'agent',
+        focus: 'none',
       });
-      return;
     }
 
     const runAgents = runsForWorkflowRun(runs, creatorRun.id);
     const nextStep = pickNextWorkflowStep(template, runAgents);
     if (!nextStep) {
-      await get().spawnAgent(sessionId, {
+      return await get().spawnAgent(sessionId, {
         triggeredPlanId: planId,
         kindOverride: 'implementer',
-        focus: 'agent',
+        focus: 'none',
       });
-      return;
     }
 
     const nextKind = inferAgentKindFromName(nextStep.name);
     if (!kindConsumesPlan(nextKind)) {
-      await get().spawnAgent(sessionId, {
+      return await get().spawnAgent(sessionId, {
         triggeredPlanId: planId,
         kindOverride: 'implementer',
-        focus: 'agent',
+        focus: 'none',
       });
-      return;
     }
 
     const stepAgent = runAgents.find((r) => r.stepId === nextStep.id && r.status === 'pending');
     if (!stepAgent) {
-      await get().spawnAgent(sessionId, {
+      return await get().spawnAgent(sessionId, {
         triggeredPlanId: planId,
         kindOverride: 'implementer',
-        focus: 'agent',
+        focus: 'none',
       });
-      return;
     }
-    await get().activateWorkflowAgent(sessionId, stepAgent.id, planId, 'agent');
+    await get().activateWorkflowAgent(sessionId, stepAgent.id, planId, 'none');
+    return stepAgent.id;
   };
 };

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -646,9 +646,9 @@ export type AppActions = {
   deletePlan(sessionId: SessionId, planId: PlanId): Promise<void>;
   restorePlan(sessionId: SessionId, planId: PlanId): Promise<void>;
   loadConsumptionsForPlan(planId: PlanId): Promise<void>;
-  runPlan(sessionId: SessionId, planId: PlanId): Promise<void>;
+  runPlan(sessionId: SessionId, planId: PlanId): Promise<AgentId | null>;
   dismissSessionNudge(sessionId: SessionId, outcome?: 'accepted' | 'dismissed'): Promise<void>;
-  acceptSessionNudgeHandoff(sessionId: SessionId): Promise<void>;
+  acceptSessionNudgeHandoff(sessionId: SessionId): Promise<AgentId | null>;
   getSessionViewPrefs(workspaceId: WorkspaceId): SessionViewPrefs;
   setSessionSort(workspaceId: WorkspaceId, sort: SessionSortKey): void;
   setSessionGroup(workspaceId: WorkspaceId, group: SessionGroupKey): void;


### PR DESCRIPTION
Two gaps a compliance sweep found after the round landed. Both were MUSTs in the round's spec that the shipped tree did not meet.

## Gap 1: a created PR now references the issue the session is working on

What landed in the round only grouped them by inference: the issue link stores the branch it was made on, and a work item pairs an issue with that branch's PRs. Nothing wrote the reference into the PR, so GitHub never made the link itself.

Now, creating a PR from a session with a GitHub issue linked on the **current** branch appends a closing reference per issue. An issue linked on another branch is not referenced. Non-GitHub issues are never written as closing references: they close on their own systems.

The reference is derived at creation time from the existing data, not stored: no new link, no migration.

`--fill` needed its own path, since `gh pr create` refuses `--body` alongside it. The slice recomputes the references against the body gh actually generated and patches the PR through the existing edit action, which also means a commit message that already closed the issue does not produce a duplicate.

The create-PR panel shows an issue-links row listing exactly the lines that will be sent, in both manual and agent mode, and a test asserts the preview text equals the block the store appends.

## Gap 2: running a plan and accepting a nudge no longer open the chat

`runPlan` (six spawns) and `acceptSessionNudgeHandoff` (three) still passed `focus: 'agent'`. They follow the rule now: spawn without stealing focus, report that the work started, and offer an explicit action that opens the agent only when clicked. One shared hook holds that toast, mirroring the rebase hook.

`HandoffChip`'s non-nudge branch was also converted: leaving it would have made the same button navigate or not depending on whether a nudge happened to be live.

Sixteen assertions that pinned the old navigation were inverted rather than deleted.

Deliberately not added: the in-flight strip registration. The rebase needs it because its agent has no row until it finishes; a plan run and a handoff insert a visible agent row immediately, so it would duplicate the agent list.

## Verification

- `vitest` desktop: 4278 passed, 490 files
- `vitest` packages/core: 1044 passed
- `tsc --noEmit` on desktop and core: clean
- `knip --include files,duplicates,unlisted`: clean

Two mutation checks: dropping the reference append fails the two named PR tests with the exact missing lines; restoring `focus: 'agent'` on the workflow activation fails five named plan tests.

Still not in the tree, and stated rather than hidden: attaching an issue to an existing PR from the PR surface (the link flow lives in the integration lens), and multi-branch sessions, which the spec allowed to defer if declared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)