### PR TITLE
fix(desktop): complete boot provider mock and drop forbidden spinner

### DIFF
--- a/apps/desktop/src/features/github/components/GitHubStudio/ResolverSpawnStatus.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/ResolverSpawnStatus.tsx
@@ -1,5 +1,6 @@
 import type { AgentId, SessionId } from '@goodboy/types';
-import { ArrowUpRight, Check, Loader2 } from 'lucide-react';
+import { ArrowUpRight, Check } from 'lucide-react';
+import { StatusDot } from '@goodboy/ui';
 import { GhostActionButton } from '../../../../shared/components/GhostActionButton';
 import { useAppStore } from '../../../../store';
 
@@ -32,7 +33,7 @@ export const ResolverSpawnStatus = ({ sessionId, spawnedIds, onView }: Props) =>
       className="flex items-center gap-2 rounded-md border border-border-soft bg-subtle px-2.5 py-1.5"
     >
       {creating > 0 ? (
-        <Loader2 size={13} aria-hidden className="motion-safe:animate-spin text-muted-foreground" />
+        <StatusDot tone="primary" size="sm" pulsing />
       ) : (
         <Check size={13} aria-hidden className="text-success" />
       )}

--- a/apps/desktop/src/store/slices/boot/index.test.ts
+++ b/apps/desktop/src/store/slices/boot/index.test.ts
@@ -147,6 +147,7 @@ vi.mock('@goodboy/db', () => ({
   getGithubPrCache: vi.fn(async () => null),
   upsertGithubPrCache: vi.fn(async () => undefined),
   deleteGithubPrCache: vi.fn(async () => undefined),
+  listProviderCredentials: vi.fn(async () => []),
 }));
 
 vi.mock('../../../shared/lib/db', () => ({
@@ -186,6 +187,9 @@ vi.mock('../../../features/providers/providers', () => ({
   checkProviderAuth: vi.fn(async () => ({ state: 'connected', identity: 'test' })),
   getCursorStatus: vi.fn(async () => null),
   getCodexStatus: vi.fn(async () => null),
+  getGeminiStatus: vi.fn(async () => null),
+  getOpenCodeStatus: vi.fn(async () => null),
+  getOpenRouterStatus: vi.fn(async () => null),
   getProviderStatus: vi.fn(async () => null),
 }));
 
@@ -535,7 +539,7 @@ describe('store contract', () => {
       await store.getState().hydrate();
       const s = store.getState();
       expect(s.hydrated).toBe(true);
-      expect(s.bootPhase === 'ready' || s.bootPhase === 'error').toBe(true);
+      expect(s.bootPhase).toBe('ready');
     });
 
     it('loads notifications at boot without waiting for the bell to mount', async () => {


### PR DESCRIPTION
## Summary

**Boot test was vacuous.** `apps/desktop/src/store/slices/boot/index.test.ts` mocked `features/providers/providers` without `getGeminiStatus`, `getOpenCodeStatus`, or `getOpenRouterStatus`. `hydrate()` calls all six status functions inside a `Promise.all` during the `detecting-cli` phase; calling an undefined mock export threw synchronously, the outer try/catch set `bootPhase: 'error'`, and the nearby assertion (`s.bootPhase === 'ready' || s.bootPhase === 'error'`) accepted either outcome. The test could never fail on a broken boot path.

Fix: filled the missing mock surface (plus `listProviderCredentials` on the `@goodboy/db` mock, silently swallowed before by a `.catch()` in `loadCredentials` but still part of the real surface `hydrate()` touches), and tightened the assertion to `expect(s.bootPhase).toBe('ready')`.

Searched for the same "accepts ready or error" pattern in the other boot-adjacent slice tests (`budget`, `notifications`, `nudges`, `sessions`, `conflicts`, `slots`, `terminal`, `settings`, `integrations`, `diff-comments`, `agents`, `skills`, `permissions`, `transcripts`, `scripts`, `sidebar`, `github`, `overrides`, `plans`, `session-view`) — none of them assert on `bootPhase` beyond the shared reset scaffolding, and only `store.audit-retry.test.ts` calls `hydrate()` elsewhere; it already mocks the full provider surface and asserts concrete side effects (retry queue drain), so it wasn't vacuous.

**Forbidden spinner.** `ResolverSpawnStatus.tsx` used `Loader2` with `animate-spin` while resolvers are being spawned. DESIGN.md bans spinners: this is a "running" state (an agent/resolver actively being created), not a "loading" state, so it takes a pulsing `StatusDot` rather than a skeleton, matching the same convention already used by `WorkflowStepStatus` and `AgentStatusIcon` for `status: 'running'`.

Two other `Loader2` usages remain, both on shared button primitives (`packages/ui/src/components/Button.tsx`'s `isBusy` and `apps/desktop/src/shared/components/GhostActionButton`'s `isBusy`, used across 23 files). Not touched: redesigning a busy-button affordance repo-wide is a real design decision, not a mechanical swap.

## Test plan

- [x] `npx tsc -p apps/desktop --noEmit` clean
- [x] `cd apps/desktop && npx vitest run` — 490 files, 4278 tests passed
- [x] Mutation check: changed `hydrate.ts`'s final `set({ bootPhase: 'ready', ... })` to `'loading-workspaces'`, reran the boot test — it failed naming `index.test.ts:542` with `expected 'loading-workspaces' to be 'ready'`. Reverted (confirmed no diff against original).