### PR TITLE
fix(desktop): rebuild resolver verdicts from the persisted transcript

### DIFF
--- a/apps/desktop/src/features/session/resolverTurnOutcomes.ts
+++ b/apps/desktop/src/features/session/resolverTurnOutcomes.ts
@@ -1,0 +1,55 @@
+import {
+  extractAllCommentAnalysis,
+  extractAllCommentReplies,
+  extractAllCommentResolved,
+  extractAllCommentWontfix,
+} from '@goodboy/core';
+import type { ResolverThreadOutcome } from '../../store/types';
+
+type Params = {
+  readonly assistantText: string;
+  readonly previousOutcomes: Readonly<Record<string, ResolverThreadOutcome>>;
+};
+
+export type ResolverTurnOutcomes = {
+  readonly outcomes: Readonly<Record<string, ResolverThreadOutcome>>;
+  readonly turnOutcomes: Readonly<Record<string, ResolverThreadOutcome>>;
+  readonly markerCount: number;
+};
+
+export const resolverTurnOutcomes = ({
+  assistantText,
+  previousOutcomes,
+}: Params): ResolverTurnOutcomes => {
+  const resolvedMarkers = extractAllCommentResolved(assistantText);
+  const wontfixMarkers = extractAllCommentWontfix(assistantText);
+  const analysisMarkers = extractAllCommentAnalysis(assistantText);
+  const turnOutcomes: Record<string, ResolverThreadOutcome> = {};
+  for (const marker of resolvedMarkers) {
+    turnOutcomes[marker.threadId] = { kind: 'resolved', commitSha: marker.commitSha };
+  }
+  for (const marker of wontfixMarkers) {
+    if (turnOutcomes[marker.threadId]?.kind === 'resolved') {
+      continue;
+    }
+    turnOutcomes[marker.threadId] = { kind: 'wontfix', reason: marker.reason };
+  }
+  for (const marker of analysisMarkers) {
+    if (turnOutcomes[marker.threadId]?.kind === 'resolved') {
+      continue;
+    }
+    turnOutcomes[marker.threadId] = { kind: 'analyzed', reply: marker.summary };
+  }
+  for (const marker of extractAllCommentReplies(assistantText)) {
+    const outcome = turnOutcomes[marker.threadId];
+    if (outcome !== undefined) {
+      turnOutcomes[marker.threadId] = { ...outcome, reply: marker.body };
+    }
+  }
+  const markerCount = resolvedMarkers.length + wontfixMarkers.length + analysisMarkers.length;
+  return {
+    outcomes: markerCount === 0 ? previousOutcomes : { ...previousOutcomes, ...turnOutcomes },
+    turnOutcomes,
+    markerCount,
+  };
+};

--- a/apps/desktop/src/store/slices/agents/hydrateResolverOutcomes.test.ts
+++ b/apps/desktop/src/store/slices/agents/hydrateResolverOutcomes.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Agent, AgentId, IsoDateTime, Message, MessageId, SessionId } from '@goodboy/types';
+import { resolverMissingVerdicts } from '../../../features/session/resolverMissingVerdicts';
+import { resolverThreadSettlements } from '../../../features/session/resolverThreadSettlements';
+import type { ResolverThreadOutcome } from '../../types';
+import type { GetFn, SetFn } from './types';
+
+const h = vi.hoisted(() => ({
+  invokeAgentList: vi.fn(async () => [] as ReadonlyArray<Agent>),
+  invokeAgentUpdateStatus: vi.fn(async () => undefined),
+  listMessagesForAgent: vi.fn(async () => [] as ReadonlyArray<Message>),
+}));
+
+vi.mock('../../../features/workflows/workflows', () => ({
+  invokeAgentList: h.invokeAgentList,
+  invokeAgentUpdateStatus: h.invokeAgentUpdateStatus,
+}));
+
+vi.mock('@goodboy/db', () => ({
+  listMessagesForAgent: h.listMessagesForAgent,
+}));
+
+vi.mock('../../../shared/lib/db', () => ({
+  tauriDatabase: { execute: vi.fn(), select: vi.fn() },
+}));
+
+import { completeResolvedAgent } from '../turn/completeResolvedAgent';
+import { hydrateResolverOutcomes } from './hydrateResolverOutcomes';
+
+const SESSION_ID = 'session-1' as SessionId;
+const AGENT_ID = 'agent-1' as AgentId;
+const NOW = '2026-08-05T00:00:00.000Z' as IsoDateTime;
+
+const agent: Agent = {
+  id: AGENT_ID,
+  sessionId: SESSION_ID,
+  ordinal: 0,
+  name: 'resolver',
+  kind: 'resolver',
+  status: 'completed',
+  sourceThreadIds: ['PRRT_1', 'PRRT_2'],
+};
+
+const ASSISTANT_TEXT =
+  '<<comment-resolved threadId="PRRT_1" commitSha="abcdef1234567890">> <<comment-wontfix threadId="PRRT_2" reason="intentional">>';
+
+const assistantMessage: Message = {
+  id: 'message-1' as MessageId,
+  sessionId: SESSION_ID,
+  agentId: AGENT_ID,
+  role: 'assistant',
+  content: ASSISTANT_TEXT,
+  createdAt: NOW,
+};
+
+type State = {
+  sessionPhaseRuns: Record<SessionId, ReadonlyArray<Agent>>;
+  agentKindOverride: Record<AgentId, never>;
+  resolverState: Record<AgentId, string>;
+  resolverThreadOutcomes: Record<AgentId, Readonly<Record<string, ResolverThreadOutcome>>>;
+  refreshUnreadWorkspaces: ReturnType<typeof vi.fn>;
+  activateNextResolver: ReturnType<typeof vi.fn>;
+};
+
+const createHarness = (): { state: State; set: SetFn; get: GetFn } => {
+  const state: State = {
+    sessionPhaseRuns: { [SESSION_ID]: [agent] },
+    agentKindOverride: {},
+    resolverState: {},
+    resolverThreadOutcomes: {},
+    refreshUnreadWorkspaces: vi.fn(async () => undefined),
+    activateNextResolver: vi.fn(async () => undefined),
+  };
+  const set = ((update: unknown) => {
+    if (typeof update === 'function') {
+      Object.assign(state, update(state));
+      return;
+    }
+    Object.assign(state, update);
+  }) as SetFn;
+  const get = (() => state) as unknown as GetFn;
+  return { state, set, get };
+};
+
+const missingVerdictsFor = (state: State) =>
+  resolverMissingVerdicts({
+    settlements: resolverThreadSettlements({
+      threadIds: ['PRRT_1', 'PRRT_2'],
+      outcomes: state.resolverThreadOutcomes[AGENT_ID] ?? {},
+      pendingResolutions: [],
+      closedThreadIds: new Set<string>(),
+    }),
+    status: 'done',
+    isBusy: false,
+  });
+
+describe('hydrateResolverOutcomes', () => {
+  beforeEach(() => {
+    h.listMessagesForAgent.mockReset();
+    h.listMessagesForAgent.mockResolvedValue([assistantMessage]);
+  });
+
+  it('brings back the verdicts a restart dropped from memory', async () => {
+    const live = createHarness();
+    await completeResolvedAgent({
+      set: live.set,
+      get: live.get,
+      sessionId: SESSION_ID,
+      resolvedAgentId: AGENT_ID,
+      assistantText: ASSISTANT_TEXT,
+      now: () => NOW,
+    });
+    const beforeRestart = live.state.resolverThreadOutcomes[AGENT_ID];
+    expect(beforeRestart).toEqual({
+      PRRT_1: { kind: 'resolved', commitSha: 'abcdef1234567890' },
+      PRRT_2: { kind: 'wontfix', reason: 'intentional' },
+    });
+
+    const rebooted = createHarness();
+    expect(rebooted.state.resolverThreadOutcomes[AGENT_ID]).toBeUndefined();
+
+    await hydrateResolverOutcomes(rebooted.set, rebooted.get)(SESSION_ID);
+
+    expect(rebooted.state.resolverThreadOutcomes[AGENT_ID]).toEqual(beforeRestart);
+  });
+
+  it('stops the silence notice from accusing a resolver that did report', async () => {
+    const rebooted = createHarness();
+    expect(missingVerdictsFor(rebooted.state)?.threadIds).toEqual(['PRRT_1', 'PRRT_2']);
+
+    await hydrateResolverOutcomes(rebooted.set, rebooted.get)(SESSION_ID);
+
+    expect(missingVerdictsFor(rebooted.state)).toBeNull();
+  });
+
+  it('names only the thread left without a verdict', async () => {
+    h.listMessagesForAgent.mockResolvedValue([
+      {
+        ...assistantMessage,
+        content: '<<comment-resolved threadId="PRRT_1" commitSha="abcdef1234567890">>',
+      },
+    ]);
+    const rebooted = createHarness();
+
+    await hydrateResolverOutcomes(rebooted.set, rebooted.get)(SESSION_ID);
+
+    expect(missingVerdictsFor(rebooted.state)?.threadIds).toEqual(['PRRT_2']);
+  });
+
+  it('keeps the outcomes already in memory over the rebuilt ones', async () => {
+    const rebooted = createHarness();
+    rebooted.state.resolverThreadOutcomes = {
+      [AGENT_ID]: { PRRT_1: { kind: 'analyzed', reply: 'newer' } },
+    };
+
+    await hydrateResolverOutcomes(rebooted.set, rebooted.get)(SESSION_ID);
+
+    expect(rebooted.state.resolverThreadOutcomes[AGENT_ID]).toEqual({
+      PRRT_1: { kind: 'analyzed', reply: 'newer' },
+    });
+    expect(h.listMessagesForAgent).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/store/slices/agents/hydrateResolverOutcomes.ts
+++ b/apps/desktop/src/store/slices/agents/hydrateResolverOutcomes.ts
@@ -1,0 +1,56 @@
+import type { AgentId, SessionId } from '@goodboy/types';
+import { listMessagesForAgent } from '@goodboy/db';
+import { tauriDatabase } from '../../../shared/lib/db';
+import { classifyAgent } from '../../../features/session/agent-kind';
+import { resolverTurnOutcomes } from '../../../features/session/resolverTurnOutcomes';
+import type { ResolverThreadOutcome } from '../../types';
+import type { GetFn, SetFn } from './types';
+
+const EMPTY_OUTCOMES: Readonly<Record<string, ResolverThreadOutcome>> = {};
+
+export const hydrateResolverOutcomes = (set: SetFn, get: GetFn) => {
+  return async (sessionId: SessionId): Promise<void> => {
+    const runs = get().sessionPhaseRuns[sessionId] ?? [];
+    const resolvers = runs.filter(
+      (agent) =>
+        agent.parentAgentId == null &&
+        agent.stepId == null &&
+        get().resolverThreadOutcomes[agent.id] === undefined &&
+        classifyAgent(agent, get().agentKindOverride[agent.id] ?? null) === 'resolver',
+    );
+    if (resolvers.length === 0) {
+      return;
+    }
+    const rebuilt = await Promise.all(
+      resolvers.map(async (agent) => {
+        const messages = await listMessagesForAgent(tauriDatabase, agent.id).catch(() => []);
+        let outcomes = EMPTY_OUTCOMES;
+        for (const message of messages) {
+          if (message.role !== 'assistant') {
+            continue;
+          }
+          outcomes = resolverTurnOutcomes({
+            assistantText: message.content,
+            previousOutcomes: outcomes,
+          }).outcomes;
+        }
+        return [agent.id, outcomes] as const;
+      }),
+    );
+    const hydrated = rebuilt.filter(([, outcomes]) => Object.keys(outcomes).length > 0);
+    if (hydrated.length === 0) {
+      return;
+    }
+    set((state) => {
+      const next: Record<AgentId, Readonly<Record<string, ResolverThreadOutcome>>> = {
+        ...state.resolverThreadOutcomes,
+      };
+      for (const [agentId, outcomes] of hydrated) {
+        if (next[agentId] === undefined) {
+          next[agentId] = outcomes;
+        }
+      }
+      return { resolverThreadOutcomes: next };
+    });
+  };
+};

--- a/apps/desktop/src/store/slices/agents/index.ts
+++ b/apps/desktop/src/store/slices/agents/index.ts
@@ -6,6 +6,7 @@ import { clearAgentQueue } from './clearAgentQueue';
 import { deleteAgent } from './deleteAgent';
 import { deselectAgent } from './deselectAgent';
 import { forceCloseResolver } from './forceCloseResolver';
+import { hydrateResolverOutcomes } from './hydrateResolverOutcomes';
 import { markAgentSeen } from './markAgentSeen';
 import { markAgentViewed } from './markAgentViewed';
 import { markAllAgentsSeen } from './markAllAgentsSeen';
@@ -44,5 +45,6 @@ export const createAgentsSlice = (set: SetFn, get: GetFn) => {
     activateNextResolver: activateNextResolver(set, get),
     forceCloseResolver: forceCloseResolver(set, get),
     setResolverThreadReply: setResolverThreadReply(set),
+    hydrateResolverOutcomes: hydrateResolverOutcomes(set, get),
   };
 };

--- a/apps/desktop/src/store/slices/sessions/index.test.ts
+++ b/apps/desktop/src/store/slices/sessions/index.test.ts
@@ -13,6 +13,8 @@ import type {
   PlanConsumption,
   PlanConsumptionId,
   PlanId,
+  Message,
+  MessageId,
   PlanWithCount,
   ProviderRunId,
   Session,
@@ -84,6 +86,7 @@ vi.mock('@goodboy/db', () => ({
   listContextSlotsForSession: vi.fn(async () => []),
   insertContextSlotHistory: vi.fn(async () => undefined),
   listContextSlotHistory: vi.fn(async () => []),
+  listGoalAttachmentsForSession: vi.fn(async () => []),
   listMessagesForAgent: vi.fn(async () => []),
   listMessagesForSession: vi.fn(async () => []),
   listTurnEventsForAgent: vi.fn(async () => []),
@@ -553,6 +556,39 @@ describe('store contract', () => {
       expect(ss).toHaveLength(2);
       expect(ss[0]?.id).toBe(SESSION_ID);
       expect(ss[1]?.goal).toBe('two');
+    });
+
+    it('setCurrentSession rebuilds resolver verdicts from the persisted transcript', async () => {
+      const store = await getStore();
+      store.setState({ resolverThreadOutcomes: {} } as never);
+      invokeAgentListSpy.mockResolvedValue([
+        buildAgent({
+          id: AGENT_ID,
+          name: 'resolver',
+          kind: 'resolver',
+          status: 'completed',
+          sourceThreadIds: ['PRRT_1'],
+        }),
+      ]);
+      const { listMessagesForAgent } = await import('@goodboy/db');
+      (listMessagesForAgent as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([
+        {
+          id: 'message-1' as MessageId,
+          sessionId: SESSION_ID,
+          agentId: AGENT_ID,
+          role: 'assistant',
+          content: '<<comment-resolved threadId="PRRT_1" commitSha="abcdef1234567890">>',
+          createdAt: NOW,
+        } satisfies Message,
+      ]);
+
+      await store.getState().setCurrentSession(SESSION_ID);
+
+      await vi.waitFor(() => {
+        expect(store.getState().resolverThreadOutcomes[AGENT_ID]).toEqual({
+          PRRT_1: { kind: 'resolved', commitSha: 'abcdef1234567890' },
+        });
+      });
     });
 
     it('renameTask updates goal and stamps titleUserEdited', async () => {

--- a/apps/desktop/src/store/slices/sessions/setCurrentSession.ts
+++ b/apps/desktop/src/store/slices/sessions/setCurrentSession.ts
@@ -221,6 +221,7 @@ export const setCurrentSession = (set: SetFn, get: GetFn) => {
             agentKindOverride: { ...state.agentKindOverride, ...kindOverridesFromDb },
           }));
           markDone('agents');
+          void get().hydrateResolverOutcomes(id);
 
           if (!get().selectedAgentId[id]) {
             set((state) => ({

--- a/apps/desktop/src/store/slices/turn/completeResolvedAgent.ts
+++ b/apps/desktop/src/store/slices/turn/completeResolvedAgent.ts
@@ -1,8 +1,4 @@
 import {
-  extractAllCommentAnalysis,
-  extractAllCommentReplies,
-  extractAllCommentResolved,
-  extractAllCommentWontfix,
   extractFanOut,
   extractPlanFromMarker,
   extractReviewComments,
@@ -12,13 +8,13 @@ import {
 import type { AgentId, IsoDateTime, SessionId } from '@goodboy/types';
 import { invokeAgentList, invokeAgentUpdateStatus } from '../../../features/workflows/workflows';
 import { agentThreadIds } from '../../../features/session/agentThreadIds';
+import { resolverTurnOutcomes } from '../../../features/session/resolverTurnOutcomes';
 import {
   inferAgentKindFromName,
   KIND_TO_ROLE,
   type AgentKind,
 } from '../../../features/session/agent-kind';
 import type { GetFn, SetFn } from './types';
-import type { ResolverThreadOutcome } from '../../types';
 
 type Params = {
   readonly set: SetFn;
@@ -95,36 +91,15 @@ export const completeResolvedAgent = async ({
     return null;
   }
 
-  const resolvedMarkers = extractAllCommentResolved(assistantText);
-  const wontfixMarkers = extractAllCommentWontfix(assistantText);
-  const analysisMarkers = extractAllCommentAnalysis(assistantText);
-  const outcomes: Record<string, ResolverThreadOutcome> = {};
-  for (const marker of resolvedMarkers) {
-    outcomes[marker.threadId] = { kind: 'resolved', commitSha: marker.commitSha };
-  }
-  for (const marker of wontfixMarkers) {
-    if (outcomes[marker.threadId]?.kind === 'resolved') {
-      continue;
-    }
-    outcomes[marker.threadId] = { kind: 'wontfix', reason: marker.reason };
-  }
-  for (const marker of analysisMarkers) {
-    if (outcomes[marker.threadId]?.kind === 'resolved') {
-      continue;
-    }
-    outcomes[marker.threadId] = { kind: 'analyzed', reply: marker.summary };
-  }
-  for (const marker of extractAllCommentReplies(assistantText)) {
-    const outcome = outcomes[marker.threadId];
-    if (outcome !== undefined) {
-      outcomes[marker.threadId] = { ...outcome, reply: marker.body };
-    }
-  }
-  const markerCount = resolvedMarkers.length + wontfixMarkers.length + analysisMarkers.length;
-  const previousOutcomes = get().resolverThreadOutcomes[resolvedAgentId] ?? {};
-  const nextOutcomes: Record<string, ResolverThreadOutcome> =
-    markerCount === 0 ? previousOutcomes : { ...previousOutcomes, ...outcomes };
-  const verdictOutcomes = markerCount === 0 ? outcomes : nextOutcomes;
+  const {
+    outcomes: nextOutcomes,
+    turnOutcomes,
+    markerCount,
+  } = resolverTurnOutcomes({
+    assistantText,
+    previousOutcomes: get().resolverThreadOutcomes[resolvedAgentId] ?? {},
+  });
+  const verdictOutcomes = markerCount === 0 ? turnOutcomes : nextOutcomes;
   const ownedThreadIds = ranAgent ? agentThreadIds(ranAgent) : [];
   const settledThreadIds =
     ownedThreadIds.length > 0 ? ownedThreadIds : Object.keys(verdictOutcomes);

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -422,6 +422,7 @@ export type AppActions = {
   activateNextResolver(sessionId: SessionId): Promise<void>;
   forceCloseResolver(sessionId: SessionId, agentId: AgentId): Promise<void>;
   setResolverThreadReply(params: { agentId: AgentId; threadId: string; reply: string }): void;
+  hydrateResolverOutcomes(sessionId: SessionId): Promise<void>;
   renameAgent(sessionId: SessionId, agentId: AgentId, name: string): Promise<void>;
   setAgentKind(agentId: AgentId, kind: AgentKind): void;
   setAgentEffortOverride(agentId: AgentId, effort: string): void;


### PR DESCRIPTION
## The gap

`resolverThreadOutcomes` was never rehydrated. The verdicts a resolver
emitted (`<<comment-resolved>>`, `<<comment-wontfix>>`,
`<<comment-analysis>>`, `<<comment-reply>>`) only ever landed in the
store from a live turn, so a restart dropped all of them and every
thread read back as unreported.

The silence notice from #1195 (`resolverMissingVerdicts`) inherited the
gap: after a restart it told the user the agent had stopped without
saying what to do on threads it had actually settled, and its button
asked again for verdicts already given.

## Derived, not persisted

No migration. The raw assistant text is already persisted verbatim in
`messages` (`sendTurn` inserts it before any stripping; stripping is a
render-time concern in `AssistantText`), so the verdicts are fully
rebuildable and a new column would only duplicate the transcript.

The marker parsing that ran inline in `completeResolvedAgent` moved to
`features/session/resolverTurnOutcomes.ts` unchanged, strictness
included. It now has exactly one implementation, used by the live turn
and by the rehydration, which folds it over the persisted assistant
messages of each resolver agent in order.

`hydrateResolverOutcomes` runs from `setCurrentSession` when a session's
agents are loaded, and it never overwrites an agent that already has
outcomes in memory: the live turn always wins over the replay.

## Scope

Only the verdicts are rebuilt. `resolverState` stays out: a force-closed
resolver persists as a `skipped` agent, and replaying its turns would
relabel it `awaiting` rather than `stopped`. That is a separate gap and
it does not affect the invariants above.

## Verification

- `npx tsc -p apps/desktop --noEmit`: clean (exit 0).
- `cd apps/desktop && npx vitest run`: 491 files, 4284 tests, all green.
- `npx knip --include files,duplicates,unlisted`: unchanged, only the 6
  pre-existing configuration hints.

Mutation check, wiring line deleted
(`setCurrentSession.ts:224`, `void get().hydrateResolverOutcomes(id);`):

```
FAIL  src/store/slices/sessions/index.test.ts > store contract > sessions >
setCurrentSession rebuilds resolver verdicts from the persisted transcript
AssertionError: expected undefined to deeply equal { PRRT_1: { kind: 'resolved', ...(1) } }
 ❯ src/store/slices/sessions/index.test.ts:588:67
```

Mutation check, rebuild line deleted
(`hydrateResolverOutcomes.ts:50`, `next[agentId] = outcomes;`): 3 of 4
tests fail, including

```
FAIL  src/store/slices/agents/hydrateResolverOutcomes.test.ts >
hydrateResolverOutcomes > names only the thread left without a verdict
AssertionError: expected [ 'PRRT_1', 'PRRT_2' ] to deeply equal [ 'PRRT_2' ]
 ❯ src/store/slices/agents/hydrateResolverOutcomes.test.ts:147:59
```

Both restored.