### PR TITLE
fix(desktop): tear down the whole pty session before removing a worktree

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -136,6 +136,8 @@ pub fn run() {
       session_dir::simple_session_dir_exists,
       worktree::worktree_create,
       worktree::worktree_remove,
+      worktree::worktree_orphans,
+      worktree::worktree_orphan_remove,
       worktree::worktree_list,
       worktree::worktree_remote_url,
       worktree::worktree_exists,

--- a/apps/desktop/src-tauri/src/terminal.rs
+++ b/apps/desktop/src-tauri/src/terminal.rs
@@ -64,6 +64,57 @@ fn login_shell() -> String {
     crate::path_env::login_shell()
 }
 
+#[cfg(unix)]
+const SESSION_DRAIN_POLLS: usize = 6;
+
+#[cfg(unix)]
+const SESSION_DRAIN_INTERVAL: std::time::Duration = std::time::Duration::from_millis(50);
+
+#[cfg(unix)]
+fn session_descendants(sid: libc::pid_t) -> Vec<libc::pid_t> {
+    let Ok(output) = crate::path_env::command("ps")
+        .args(["-Ao", "pid="])
+        .output()
+    else {
+        return Vec::new();
+    };
+    let Ok(text) = String::from_utf8(output.stdout) else {
+        return Vec::new();
+    };
+    text.split_whitespace()
+        .filter_map(|token| token.parse::<libc::pid_t>().ok())
+        .filter(|pid| *pid != sid && *pid > 1)
+        .filter(|pid| unsafe { libc::getsid(*pid) } == sid)
+        .collect()
+}
+
+#[cfg(unix)]
+fn signal_pty_session(sid: libc::pid_t, signal: libc::c_int) {
+    for pid in session_descendants(sid) {
+        unsafe { libc::kill(pid, signal) };
+    }
+    unsafe { libc::kill(sid, signal) };
+}
+
+#[cfg(unix)]
+pub(crate) fn terminate_pty_session(leader_pid: u32) {
+    let sid = leader_pid as libc::pid_t;
+    if session_descendants(sid).is_empty() {
+        return;
+    }
+    signal_pty_session(sid, libc::SIGTERM);
+    for _ in 0..SESSION_DRAIN_POLLS {
+        thread::sleep(SESSION_DRAIN_INTERVAL);
+        if session_descendants(sid).is_empty() {
+            return;
+        }
+    }
+    signal_pty_session(sid, libc::SIGKILL);
+}
+
+#[cfg(not(unix))]
+pub(crate) fn terminate_pty_session(_leader_pid: u32) {}
+
 #[tauri::command]
 pub async fn terminal_open(
     app: AppHandle,
@@ -262,6 +313,9 @@ pub fn terminal_close(
     if let Some(slot) = slot {
         if let Ok(mut guard) = slot.lock() {
             if let Some(mut session) = guard.take() {
+                if let Some(leader_pid) = session.child.process_id() {
+                    terminate_pty_session(leader_pid);
+                }
                 let _ = session.child.kill();
             }
         }
@@ -272,6 +326,77 @@ pub fn terminal_close(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(unix)]
+    fn read_announced_pid(reader: &mut Box<dyn Read + Send>) -> libc::pid_t {
+        let mut collected = String::new();
+        let mut buf = [0u8; 1024];
+        for _ in 0..200 {
+            let Ok(n) = reader.read(&mut buf) else {
+                break;
+            };
+            if n == 0 {
+                break;
+            }
+            collected.push_str(&String::from_utf8_lossy(&buf[..n]));
+            if let Some(rest) = collected.split("BACKGROUND:").nth(1) {
+                let digits: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+                if digits.len() > 0 && rest.len() > digits.len() {
+                    return digits.parse().unwrap();
+                }
+            }
+        }
+        panic!("background pid never announced: {collected}");
+    }
+
+    #[cfg(unix)]
+    fn is_alive(pid: libc::pid_t) -> bool {
+        unsafe { libc::kill(pid, 0) == 0 }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn terminate_pty_session_kills_backgrounded_descendant() {
+        let pair = native_pty_system()
+            .openpty(PtySize {
+                rows: 24,
+                cols: 80,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .unwrap();
+        let mut cmd = CommandBuilder::new("/bin/sh");
+        cmd.arg("-c");
+        cmd.arg("trap '' HUP; sleep 120 & echo BACKGROUND:$! ; sleep 120");
+        let mut child = pair.slave.spawn_command(cmd).unwrap();
+        drop(pair.slave);
+        let mut reader = pair.master.try_clone_reader().unwrap();
+
+        let background_pid = read_announced_pid(&mut reader);
+        let leader_pid = child.process_id().unwrap();
+        assert_eq!(
+            unsafe { libc::getsid(background_pid) },
+            leader_pid as libc::pid_t,
+            "the backgrounded process must share the pty session"
+        );
+
+        terminate_pty_session(leader_pid);
+        let _ = child.kill();
+        let _ = child.wait();
+
+        let mut still_alive = true;
+        for _ in 0..60 {
+            if !is_alive(background_pid) {
+                still_alive = false;
+                break;
+            }
+            thread::sleep(std::time::Duration::from_millis(50));
+        }
+        assert!(
+            !still_alive,
+            "backgrounded descendant {background_pid} survived the terminal close"
+        );
+    }
 
     #[test]
     fn login_shell_returns_existing_executable() {

--- a/apps/desktop/src-tauri/src/worktree.rs
+++ b/apps/desktop/src-tauri/src/worktree.rs
@@ -391,12 +391,171 @@ pub fn worktree_change_branch(args: ChangeBranchArgs) -> Result<(), WorktreeErro
     Ok(())
 }
 
+const REMOVE_RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(300);
+
+fn is_directory_not_empty(error: &WorktreeError) -> bool {
+    let WorktreeError::Git { message } = error else {
+        return false;
+    };
+    let lowered = message.to_ascii_lowercase();
+    lowered.contains("directory not empty") || lowered.contains("failed to delete")
+}
+
+pub(crate) fn remove_worktree_with(
+    repo_path: &Path,
+    worktree_path: &str,
+    run_git: &mut dyn FnMut(&Path, &[&str]) -> Result<String, WorktreeError>,
+) -> Result<(), WorktreeError> {
+    let remove_args = ["worktree", "remove", "--force", worktree_path];
+    let first = run_git(repo_path, &remove_args);
+    if first.is_ok() {
+        return Ok(());
+    }
+    let error = first.unwrap_err();
+    if !is_directory_not_empty(&error) {
+        return Err(error);
+    }
+    std::thread::sleep(REMOVE_RETRY_DELAY);
+    if run_git(repo_path, &remove_args).is_ok() {
+        return Ok(());
+    }
+    let target = Path::new(worktree_path);
+    if target.exists() {
+        let _ = std::fs::remove_dir_all(target);
+    }
+    let _ = run_git(repo_path, &["worktree", "prune"]);
+    if target.exists() {
+        return Err(WorktreeError::Git {
+            message: format!(
+                "worktree folder is still on disk after cleanup: {worktree_path}. close anything running inside it and remove it by hand"
+            ),
+        });
+    }
+    Ok(())
+}
+
 #[tauri::command]
 pub fn worktree_remove(repo_path: String, worktree_path: String) -> Result<(), WorktreeError> {
-    git(
-        Path::new(&repo_path),
-        &["worktree", "remove", "--force", &worktree_path],
-    )?;
+    remove_worktree_with(Path::new(&repo_path), &worktree_path, &mut |cwd, args| {
+        git(cwd, args)
+    })
+}
+
+const WORKTREE_PARENT: [&str; 2] = [".goodboy", "worktrees"];
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub struct OrphanWorktree {
+    pub path: String,
+    pub name: String,
+    #[serde(rename = "sizeBytes")]
+    pub size_bytes: u64,
+}
+
+fn worktrees_parent(repo_path: &Path) -> PathBuf {
+    repo_path.join(WORKTREE_PARENT[0]).join(WORKTREE_PARENT[1])
+}
+
+fn canonical_key(path: &Path) -> String {
+    std::fs::canonicalize(path)
+        .unwrap_or_else(|_| path.to_path_buf())
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn directory_size(path: &Path) -> u64 {
+    let Ok(entries) = std::fs::read_dir(path) else {
+        return 0;
+    };
+    let mut total = 0u64;
+    for entry in entries.flatten() {
+        let Ok(meta) = entry.metadata() else {
+            continue;
+        };
+        if meta.is_symlink() {
+            continue;
+        }
+        if meta.is_dir() {
+            total = total.saturating_add(directory_size(&entry.path()));
+            continue;
+        }
+        total = total.saturating_add(meta.len());
+    }
+    total
+}
+
+pub(crate) fn collect_orphans(
+    repo_path: &Path,
+    registered: &[String],
+    known_paths: &[String],
+) -> Vec<OrphanWorktree> {
+    let parent = worktrees_parent(repo_path);
+    let Ok(entries) = std::fs::read_dir(&parent) else {
+        return Vec::new();
+    };
+    let claimed: std::collections::HashSet<String> = registered
+        .iter()
+        .chain(known_paths.iter())
+        .map(|p| canonical_key(Path::new(p)))
+        .collect();
+    let mut orphans: Vec<OrphanWorktree> = entries
+        .flatten()
+        .filter(|entry| entry.path().is_dir())
+        .filter(|entry| !claimed.contains(&canonical_key(&entry.path())))
+        .map(|entry| OrphanWorktree {
+            path: entry.path().to_string_lossy().into_owned(),
+            name: entry.file_name().to_string_lossy().into_owned(),
+            size_bytes: directory_size(&entry.path()),
+        })
+        .collect();
+    orphans.sort_by(|a, b| a.path.cmp(&b.path));
+    orphans
+}
+
+#[tauri::command]
+pub async fn worktree_orphans(
+    repo_path: String,
+    known_paths: Vec<String>,
+) -> Result<Vec<OrphanWorktree>, WorktreeError> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let repo = Path::new(&repo_path);
+        if !worktrees_parent(repo).is_dir() {
+            return Ok(Vec::new());
+        }
+        let registered: Vec<String> = git(repo, &["worktree", "list", "--porcelain"])
+            .map(|stdout| {
+                parse_porcelain(&stdout)
+                    .into_iter()
+                    .map(|entry| entry.path)
+                    .collect()
+            })
+            .unwrap_or_default();
+        Ok(collect_orphans(repo, &registered, &known_paths))
+    })
+    .await
+    .map_err(|e| WorktreeError::Git {
+        message: e.to_string(),
+    })?
+}
+
+#[tauri::command]
+pub fn worktree_orphan_remove(repo_path: String, path: String) -> Result<(), WorktreeError> {
+    let repo = Path::new(&repo_path);
+    let parent = worktrees_parent(repo);
+    let target = Path::new(&path);
+    let parent_key = canonical_key(&parent);
+    let is_contained = target
+        .parent()
+        .map(|p| canonical_key(p) == parent_key)
+        .unwrap_or(false);
+    if !is_contained {
+        return Err(WorktreeError::Git {
+            message: format!("refusing to remove a path outside {parent_key}: {path}"),
+        });
+    }
+    if target.exists() {
+        std::fs::remove_dir_all(target)?;
+    }
+    let _ = git(repo, &["worktree", "prune"]);
     Ok(())
 }
 
@@ -1564,5 +1723,143 @@ mod rewrite_tests {
         assert_eq!(log_subjects(&root), vec!["third", "second", "first"]);
         assert!(!root.join(".git").join("rebase-merge").exists());
         assert!(!root.join(".git").join("rebase-apply").exists());
+    }
+}
+
+#[cfg(test)]
+mod teardown_tests {
+    use super::{collect_orphans, remove_worktree_with, worktree_orphan_remove, WorktreeError};
+    use std::path::{Path, PathBuf};
+
+    fn temp_root(name: &str) -> PathBuf {
+        let root = std::env::temp_dir().join(format!(
+            "goodboy-{name}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        root
+    }
+
+    fn not_empty() -> WorktreeError {
+        WorktreeError::Git {
+            message:
+                "git worktree remove --force /x failed: fatal: could not remove: Directory not empty"
+                    .to_string(),
+        }
+    }
+
+    #[test]
+    fn a_directory_not_empty_failure_is_retried_once_before_giving_up() {
+        let root = temp_root("remove-retry");
+        let target = root.join("wt");
+        std::fs::create_dir_all(&target).unwrap();
+        let mut calls: Vec<String> = Vec::new();
+        let mut attempts = 0;
+
+        let outcome = remove_worktree_with(&root, target.to_str().unwrap(), &mut |_, args| {
+            calls.push(args.join(" "));
+            attempts += 1;
+            if attempts == 1 {
+                return Err(not_empty());
+            }
+            std::fs::remove_dir_all(&target).unwrap();
+            Ok(String::new())
+        });
+
+        assert!(outcome.is_ok(), "{outcome:?}");
+        assert_eq!(calls.len(), 2, "the second attempt never ran: {calls:?}");
+    }
+
+    #[test]
+    fn a_worktree_git_cannot_delete_is_removed_from_disk_and_pruned() {
+        let root = temp_root("remove-fallback");
+        let target = root.join("wt");
+        std::fs::create_dir_all(target.join("apps").join("web")).unwrap();
+        std::fs::write(target.join("apps").join("web").join("page.tsx"), "x").unwrap();
+        let mut calls: Vec<String> = Vec::new();
+
+        let outcome = remove_worktree_with(&root, target.to_str().unwrap(), &mut |_, args| {
+            calls.push(args.join(" "));
+            if args.first() == Some(&"worktree") && args.get(1) == Some(&"remove") {
+                return Err(not_empty());
+            }
+            Ok(String::new())
+        });
+
+        assert!(outcome.is_ok(), "{outcome:?}");
+        assert!(!target.exists(), "the folder is still on disk");
+        assert!(
+            calls.contains(&"worktree prune".to_string()),
+            "git worktree prune never ran: {calls:?}"
+        );
+    }
+
+    #[test]
+    fn a_failure_that_is_not_about_a_dirty_directory_is_reported_as_is() {
+        let root = temp_root("remove-other-error");
+        let target = root.join("wt");
+        std::fs::create_dir_all(&target).unwrap();
+        let mut calls = 0;
+
+        let outcome = remove_worktree_with(&root, target.to_str().unwrap(), &mut |_, _| {
+            calls += 1;
+            Err(WorktreeError::Git {
+                message: "fatal: 'wt' is not a working tree".to_string(),
+            })
+        });
+
+        assert!(outcome.is_err());
+        assert_eq!(calls, 1, "a hopeless failure must not be retried");
+        assert!(target.exists(), "the folder must be left untouched");
+    }
+
+    fn make_worktree_dir(parent: &Path, name: &str, bytes: usize) -> PathBuf {
+        let dir = parent.join(name);
+        std::fs::create_dir_all(dir.join("src")).unwrap();
+        std::fs::write(dir.join("src").join("main.ts"), "x".repeat(bytes)).unwrap();
+        dir
+    }
+
+    #[test]
+    fn a_folder_git_forgot_and_no_session_claims_is_reported_with_its_size() {
+        let root = temp_root("orphan-scan");
+        let parent = root.join(".goodboy").join("worktrees");
+        std::fs::create_dir_all(&parent).unwrap();
+        let registered = make_worktree_dir(&parent, "gb-live", 10);
+        let claimed = make_worktree_dir(&parent, "gb-known", 10);
+        let orphan = make_worktree_dir(&parent, "gb-ghost", 4096);
+
+        let found = collect_orphans(
+            &root,
+            &[registered.to_string_lossy().into_owned()],
+            &[claimed.to_string_lossy().into_owned()],
+        );
+
+        assert_eq!(
+            found.iter().map(|o| o.name.as_str()).collect::<Vec<_>>(),
+            vec!["gb-ghost"]
+        );
+        assert_eq!(found[0].size_bytes, 4096);
+        assert!(orphan.exists());
+    }
+
+    #[test]
+    fn orphan_removal_refuses_a_path_outside_the_worktrees_folder() {
+        let root = temp_root("orphan-confine");
+        std::fs::create_dir_all(root.join(".goodboy").join("worktrees")).unwrap();
+        let outside = root.join("precious");
+        std::fs::create_dir_all(&outside).unwrap();
+
+        let outcome = worktree_orphan_remove(
+            root.to_string_lossy().into_owned(),
+            outside.to_string_lossy().into_owned(),
+        );
+
+        assert!(outcome.is_err(), "{outcome:?}");
+        assert!(outside.exists(), "a path outside the folder was deleted");
     }
 }

--- a/apps/desktop/src/features/notifications/components/NotificationToastBridge/index.tsx
+++ b/apps/desktop/src/features/notifications/components/NotificationToastBridge/index.tsx
@@ -82,6 +82,19 @@ export const mapNotificationAction = (
       },
     };
   }
+  if (action.kind === 'open-orphan-worktrees') {
+    const { workspaceId } = action;
+    return {
+      label: 'Review folders',
+      onClick: () => {
+        void store.setCurrentWorkspace(workspaceId).then(() => {
+          window.dispatchEvent(
+            new CustomEvent('goodboy:open-workspace-settings', { detail: { section: 'orphans' } }),
+          );
+        });
+      },
+    };
+  }
   const _exhaustive: never = action;
   return undefined;
 };

--- a/apps/desktop/src/features/settings/components/SettingsStudio/WorkspaceScopePanel.test.tsx
+++ b/apps/desktop/src/features/settings/components/SettingsStudio/WorkspaceScopePanel.test.tsx
@@ -12,6 +12,11 @@ const { state, toastMock } = vi.hoisted(() => ({
     setWorkspaceOverrides: vi.fn(async () => undefined),
     workspaceIntegrations: {} as Record<string, ReadonlyArray<unknown>>,
     providers: [] as ReadonlyArray<{ id: string; connection: string }>,
+    orphanWorktrees: {} as Record<
+      string,
+      ReadonlyArray<{ path: string; name: string; sizeBytes: number }>
+    >,
+    removeOrphanWorktrees: vi.fn(async () => undefined),
   },
   toastMock: vi.fn(),
 }));
@@ -54,6 +59,8 @@ beforeEach(() => {
   state.setWorkspaceOverrides = vi.fn(async () => undefined);
   state.workspaceIntegrations = {};
   state.providers = [];
+  state.orphanWorktrees = {};
+  state.removeOrphanWorktrees = vi.fn(async () => undefined);
   toastMock.mockReset();
 });
 afterEach(cleanup);
@@ -76,5 +83,27 @@ describe('WorkspaceScopePanel', () => {
     fireEvent.click(screen.getByRole('button', { name: /disconnect/i }));
     expect(screen.getByRole('button', { name: /confirm/i })).toBeDefined();
     expect(screen.getByRole('button', { name: /cancel/i })).toBeDefined();
+  });
+
+  it('hides the leftover folders section when there is nothing to clean', () => {
+    render(<WorkspaceScopePanel workspaceId={'ws-1' as never} requestClose={vi.fn()} />);
+    expect(screen.queryByText(/session folders left on disk/i)).toBeNull();
+  });
+
+  it('asks twice before deleting the folders it found', () => {
+    state.orphanWorktrees = {
+      'ws-1': [{ path: '/repo/.goodboy/worktrees/gb-ghost', name: 'gb-ghost', sizeBytes: 2048 }],
+    };
+    render(<WorkspaceScopePanel workspaceId={'ws-1' as never} requestClose={vi.fn()} />);
+
+    expect(screen.getByText('gb-ghost')).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: /delete 1 folders \(2 kb\)/i }));
+
+    expect(state.removeOrphanWorktrees).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: /^delete$/i }));
+    expect(state.removeOrphanWorktrees).toHaveBeenCalledWith({
+      workspaceId: 'ws-1',
+      paths: ['/repo/.goodboy/worktrees/gb-ghost'],
+    });
   });
 });

--- a/apps/desktop/src/features/settings/components/SettingsStudio/WorkspaceScopePanel.tsx
+++ b/apps/desktop/src/features/settings/components/SettingsStudio/WorkspaceScopePanel.tsx
@@ -3,6 +3,7 @@ import type { VerbosityLevel, WorkspaceId } from '@goodboy/types';
 import { Button, Divider, FieldRow, ScrollFade, SectionHeader, Switch, cn } from '@goodboy/ui';
 import { Check, GitBranch, Unplug } from 'lucide-react';
 import { SkillsPanel } from '../../../../features/skills/components/SkillsPanel';
+import { OrphanWorktreesSection } from '../../../../features/worktree/components/OrphanWorktreesSection';
 import { VerbositySelect } from '../../../../features/session/components/VerbositySelect';
 import { formatError } from '../../../../shared/lib/errors';
 import { DEFAULT_BRANCH_PREFIX, settingBranchPrefix } from '../../../../features/settings/settings';
@@ -205,6 +206,10 @@ export const WorkspaceScopePanel = ({ workspaceId, initialSection, requestClose 
           ) : null}
 
           <Divider />
+
+          <div ref={anchor('orphans')}>
+            <OrphanWorktreesSection workspaceId={workspaceId} />
+          </div>
 
           <section id="danger" ref={anchor('danger')} className="flex flex-col gap-4">
             <SectionHeader label="Danger zone" hint="Destructive workspace controls." />

--- a/apps/desktop/src/features/worktree/components/OrphanWorktreesSection/index.tsx
+++ b/apps/desktop/src/features/worktree/components/OrphanWorktreesSection/index.tsx
@@ -1,0 +1,81 @@
+import { useState } from 'react';
+import { FolderX, Trash2 } from 'lucide-react';
+import { Button, InlineConfirm, SectionHeader } from '@goodboy/ui';
+import type { WorkspaceId } from '@goodboy/types';
+import { useAppStore } from '../../../../store';
+import { useToast } from '../../../../app/components/Toast';
+import { formatError } from '../../../../shared/lib/errors';
+import { formatDiskSize } from '../../utils/formatDiskSize';
+
+const EMPTY: ReadonlyArray<never> = [];
+
+type Props = {
+  readonly workspaceId: WorkspaceId;
+};
+
+export const OrphanWorktreesSection = ({ workspaceId }: Props) => {
+  const orphans = useAppStore((s) => s.orphanWorktrees[workspaceId] ?? EMPTY);
+  const removeOrphanWorktrees = useAppStore((s) => s.removeOrphanWorktrees);
+  const { showToast } = useToast();
+  const [isArmed, setIsArmed] = useState(false);
+
+  if (orphans.length === 0) {
+    return null;
+  }
+
+  const totalBytes = orphans.reduce((sum, orphan) => sum + orphan.sizeBytes, 0);
+
+  const onConfirm = async () => {
+    try {
+      await removeOrphanWorktrees({ workspaceId, paths: orphans.map((o) => o.path) });
+      showToast('success', `removed ${orphans.length} folders`);
+    } catch (error) {
+      showToast('error', formatError(error));
+    } finally {
+      setIsArmed(false);
+    }
+  };
+
+  return (
+    <section className="flex flex-col gap-4">
+      <SectionHeader
+        label="Session folders left on disk"
+        hint="Git no longer tracks these and no session claims them. Deleting them frees the space."
+      />
+      <div className="flex flex-col gap-1.5">
+        {orphans.map((orphan) => (
+          <div
+            key={orphan.path}
+            className="flex items-center justify-between gap-3 rounded-md border border-border px-2.5 py-1.5"
+          >
+            <div className="flex min-w-0 flex-col">
+              <span className="truncate font-mono text-xs text-foreground">{orphan.name}</span>
+              <span className="truncate text-2xs text-muted-foreground">{orphan.path}</span>
+            </div>
+            <span className="shrink-0 text-2xs tabular-nums text-muted-foreground">
+              {formatDiskSize({ bytes: orphan.sizeBytes })}
+            </span>
+          </div>
+        ))}
+      </div>
+      {isArmed ? (
+        <InlineConfirm
+          role="danger"
+          icon={<FolderX size={13} aria-hidden />}
+          title={`Delete ${orphans.length} folders`}
+          description={`${formatDiskSize({ bytes: totalBytes })} will be removed from disk. This cannot be undone.`}
+          confirmLabel="Delete"
+          onConfirm={onConfirm}
+          onCancel={() => setIsArmed(false)}
+        />
+      ) : (
+        <div className="flex justify-start">
+          <Button variant="danger" size="sm" onClick={() => setIsArmed(true)}>
+            <Trash2 size={13} aria-hidden />
+            Delete {orphans.length} folders ({formatDiskSize({ bytes: totalBytes })})
+          </Button>
+        </div>
+      )}
+    </section>
+  );
+};

--- a/apps/desktop/src/features/worktree/utils/formatDiskSize.ts
+++ b/apps/desktop/src/features/worktree/utils/formatDiskSize.ts
@@ -1,0 +1,19 @@
+const UNITS = ['B', 'KB', 'MB', 'GB', 'TB'] as const;
+
+type Params = {
+  readonly bytes: number;
+};
+
+export const formatDiskSize = ({ bytes }: Params): string => {
+  if (bytes < 1) {
+    return '0 B';
+  }
+  let value = bytes;
+  let unit = 0;
+  while (value >= 1024 && unit < UNITS.length - 1) {
+    value = value / 1024;
+    unit += 1;
+  }
+  const rounded = unit === 0 || value >= 100 ? Math.round(value) : Math.round(value * 10) / 10;
+  return `${rounded} ${UNITS[unit]}`;
+};

--- a/apps/desktop/src/features/worktree/worktree.ts
+++ b/apps/desktop/src/features/worktree/worktree.ts
@@ -111,6 +111,36 @@ export const removeWorktree = async (repoPath: string, worktreePath: string): Pr
   await invoke('worktree_remove', { repoPath, worktreePath });
 };
 
+export type OrphanWorktree = {
+  readonly path: string;
+  readonly name: string;
+  readonly sizeBytes: number;
+};
+
+type ScanOrphanWorktreesParams = {
+  readonly repoPath: string;
+  readonly knownPaths: ReadonlyArray<string>;
+};
+
+export const scanOrphanWorktrees = async ({
+  repoPath,
+  knownPaths,
+}: ScanOrphanWorktreesParams): Promise<ReadonlyArray<OrphanWorktree>> => {
+  return invoke<ReadonlyArray<OrphanWorktree>>('worktree_orphans', { repoPath, knownPaths });
+};
+
+type RemoveOrphanWorktreeParams = {
+  readonly repoPath: string;
+  readonly path: string;
+};
+
+export const removeOrphanWorktree = async ({
+  repoPath,
+  path,
+}: RemoveOrphanWorktreeParams): Promise<void> => {
+  await invoke('worktree_orphan_remove', { repoPath, path });
+};
+
 export type WorktreeEntry = {
   readonly path: string;
   readonly branch: string | null;

--- a/apps/desktop/src/store/slices/boot/hydrate.ts
+++ b/apps/desktop/src/store/slices/boot/hydrate.ts
@@ -214,6 +214,10 @@ export const hydrate = (set: SetFn, get: GetFn) => {
 
         void drainAuditRetryQueue(set);
 
+        void get()
+          .reconcileOrphanWorktrees()
+          .catch(() => {});
+
         void get().refreshGithubStatus();
       } catch (err) {
         set({

--- a/apps/desktop/src/store/slices/boot/index.test.ts
+++ b/apps/desktop/src/store/slices/boot/index.test.ts
@@ -40,6 +40,7 @@ vi.mock('@tauri-apps/api/event', () => ({
   listen: vi.fn(async () => () => undefined),
 }));
 
+const listWorkspacesSpy = vi.fn(async () => [] as ReadonlyArray<Workspace>);
 const dbSetSettingSpy = vi.fn(async () => undefined);
 const dbGetSettingSpy: ReturnType<typeof vi.fn> = vi.fn<() => Promise<string | null>>(
   async () => null,
@@ -91,7 +92,7 @@ vi.mock('@goodboy/db', () => ({
   listSessionsForWorkspace: vi.fn(async () => []),
   listArchivedSessionsForWorkspace: vi.fn(async () => []),
   listTelemetryForSession: vi.fn(async () => []),
-  listWorkspaces: vi.fn(async () => []),
+  listWorkspaces: listWorkspacesSpy,
   listWorktreesForSession: vi.fn(async () => []),
   listWorktreesForSessions: vi.fn(async () => new Map()),
   listAgentsForSessions: vi.fn(async () => new Map()),
@@ -186,6 +187,9 @@ vi.mock('../../../features/providers/providers', () => ({
   checkProviderAuth: vi.fn(async () => ({ state: 'connected', identity: 'test' })),
   getCursorStatus: vi.fn(async () => null),
   getCodexStatus: vi.fn(async () => null),
+  getGeminiStatus: vi.fn(async () => null),
+  getOpenCodeStatus: vi.fn(async () => null),
+  getOpenRouterStatus: vi.fn(async () => null),
   getProviderStatus: vi.fn(async () => null),
 }));
 
@@ -258,12 +262,18 @@ vi.mock('../../../features/workflows/workflows', () => ({
 const createWorktreeSpy = vi.fn();
 const removeWorktreeSpy = vi.fn(async () => undefined);
 const changeWorktreeBranchSpy = vi.fn(async () => undefined);
+const scanOrphanWorktreesSpy = vi.fn(
+  async () => [] as ReadonlyArray<{ path: string; name: string; sizeBytes: number }>,
+);
+const removeOrphanWorktreeSpy = vi.fn(async () => undefined);
 
 vi.mock('../../../features/worktree/worktree', () => ({
   createWorktree: createWorktreeSpy,
   removeWorktree: removeWorktreeSpy,
   changeWorktreeBranch: changeWorktreeBranchSpy,
   worktreeChangedFiles: vi.fn(async () => []),
+  scanOrphanWorktrees: scanOrphanWorktreesSpy,
+  removeOrphanWorktree: removeOrphanWorktreeSpy,
 }));
 
 vi.mock('../../../shared/lib/repo', () => ({
@@ -542,6 +552,30 @@ describe('store contract', () => {
       const store = await getStore();
       await store.getState().hydrate();
       expect(listNotificationsSpy).toHaveBeenCalled();
+    });
+
+    it('offers to clean the session folders left behind on disk', async () => {
+      const store = await getStore();
+      listWorkspacesSpy.mockResolvedValueOnce([
+        {
+          id: 'ws-1' as WorkspaceId,
+          name: 'demo',
+          rootPath: '/repo',
+          kind: 'repo',
+          createdAt: '2026-01-01T00:00:00.000Z' as IsoDateTime,
+          updatedAt: '2026-01-01T00:00:00.000Z' as IsoDateTime,
+        },
+      ]);
+      scanOrphanWorktreesSpy.mockResolvedValueOnce([
+        { path: '/repo/.goodboy/worktrees/gb-ghost', name: 'gb-ghost', sizeBytes: 2048 },
+      ]);
+
+      await store.getState().hydrate();
+
+      await vi.waitFor(() => {
+        expect(store.getState().orphanWorktrees['ws-1']).toHaveLength(1);
+      });
+      expect(insertNotificationSpy).toHaveBeenCalled();
     });
   });
 });

--- a/apps/desktop/src/store/slices/sessions/deleteTask.teardown.test.ts
+++ b/apps/desktop/src/store/slices/sessions/deleteTask.teardown.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const order: Array<string> = [];
+
+const { removeWorktree, listWorktreesForSession, deleteSession } = vi.hoisted(() => ({
+  removeWorktree: vi.fn(async () => undefined),
+  listWorktreesForSession: vi.fn(async () => [
+    { worktreePath: '/repo/.goodboy/worktrees/gb-ghost', branch: 'gb/ghost', parallelIndex: 0 },
+  ]),
+  deleteSession: vi.fn(async () => undefined),
+}));
+
+vi.mock('@goodboy/db', () => ({ listWorktreesForSession, deleteSession }));
+vi.mock('../../../shared/lib/db', () => ({ tauriDatabase: {} }));
+vi.mock('../../../features/worktree/worktree', () => ({
+  removeWorktree,
+  removeSessionDirectory: vi.fn(async () => undefined),
+}));
+vi.mock('../../../features/chat/turn', () => ({ cancelTurn: vi.fn(async () => undefined) }));
+
+import { deleteTask } from './deleteTask';
+
+const SESSION_ID = 'sess-1' as never;
+
+const makeStore = () => ({
+  sessions: [{ id: 'sess-1', workspaceId: 'ws-1', goal: 'ship it', state: { kind: 'idle' } }],
+  archivedSessions: {},
+  workspaces: [{ id: 'ws-1', rootPath: '/repo', kind: 'repo' }],
+  sessionBranches: { 'sess-1': 'gb/ghost' },
+  sessionPhaseRuns: {},
+  closeSessionTerminals: vi.fn(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    order.push('terminals closed');
+  }),
+  emitNotification: vi.fn(async () => undefined),
+});
+
+beforeEach(() => {
+  order.length = 0;
+  vi.clearAllMocks();
+  removeWorktree.mockImplementation(async () => {
+    order.push('worktree removed');
+  });
+});
+
+describe('deleting a session', () => {
+  it('waits for the terminals to die before touching the folder', async () => {
+    const store = makeStore();
+
+    await deleteTask(vi.fn(), (() => store) as never)(SESSION_ID);
+
+    expect(order).toEqual(['terminals closed', 'worktree removed']);
+  });
+
+  it('reports the paths it could not remove', async () => {
+    const store = makeStore();
+    removeWorktree.mockRejectedValueOnce(new Error('Directory not empty'));
+
+    await deleteTask(vi.fn(), (() => store) as never)(SESSION_ID);
+
+    expect(store.emitNotification).toHaveBeenCalledWith(
+      'error',
+      'warning',
+      'failed to remove 1 session paths',
+      expect.stringContaining('Directory not empty'),
+      expect.anything(),
+    );
+  });
+});

--- a/apps/desktop/src/store/slices/sessions/deleteTask.ts
+++ b/apps/desktop/src/store/slices/sessions/deleteTask.ts
@@ -20,7 +20,9 @@ export const deleteTask = (set: SetFn, get: GetFn) => {
     if (!session) {
       throw new Error(`session not found: ${sessionId}`);
     }
-    get().closeSessionTerminals(sessionId);
+    await get()
+      .closeSessionTerminals(sessionId)
+      .catch(() => undefined);
     if (session.state.kind === 'running') {
       await cancelTurn((session.state as { kind: 'running'; runId: ProviderRunId }).runId).catch(
         () => undefined,

--- a/apps/desktop/src/store/slices/terminal/closeSessionTerminals.ts
+++ b/apps/desktop/src/store/slices/terminal/closeSessionTerminals.ts
@@ -4,13 +4,14 @@ import { clearTerminalCache } from '../../../shared/components/GenericTerminalPa
 import type { SetFn, GetFn } from './types';
 
 export const closeSessionTerminals = (set: SetFn, get: GetFn) => {
-  return (sessionId: SessionId): void => {
+  return async (sessionId: SessionId): Promise<void> => {
+    const closing: Array<Promise<void>> = [];
     for (const tab of get().terminalTabs[sessionId] ?? []) {
-      invokeTerminalClose(tab.id).catch(() => undefined);
+      closing.push(invokeTerminalClose(tab.id).catch(() => undefined));
       clearTerminalCache(tab.id);
     }
     if (get().terminalSessions[sessionId] === 'open') {
-      invokeTerminalClose(sessionId).catch(() => undefined);
+      closing.push(invokeTerminalClose(sessionId).catch(() => undefined));
     }
     set((s) => {
       const nextTabs = { ...s.terminalTabs };
@@ -19,5 +20,6 @@ export const closeSessionTerminals = (set: SetFn, get: GetFn) => {
       delete nextActive[sessionId];
       return { terminalTabs: nextTabs, activeTerminalTab: nextActive };
     });
+    await Promise.all(closing);
   };
 };

--- a/apps/desktop/src/store/slices/terminal/index.test.ts
+++ b/apps/desktop/src/store/slices/terminal/index.test.ts
@@ -332,9 +332,11 @@ vi.mock('../../../features/scripts/scripts', () => ({
   listenScriptExit: vi.fn(async () => () => undefined),
 }));
 
+const invokeTerminalCloseSpy = vi.fn(async () => undefined);
+
 vi.mock('../../../features/terminal/terminal', () => ({
   invokeTerminalOpen: vi.fn(async () => undefined),
-  invokeTerminalClose: vi.fn(async () => undefined),
+  invokeTerminalClose: invokeTerminalCloseSpy,
   invokeTerminalWrite: vi.fn(async () => undefined),
   invokeTerminalResize: vi.fn(async () => undefined),
 }));
@@ -594,9 +596,24 @@ describe('store contract', () => {
       const store = await getStore();
       store.getState().addTerminalTab(SESSION_ID, null);
       store.getState().addTerminalTab(SESSION_ID, null);
-      store.getState().closeSessionTerminals(SESSION_ID);
+      await store.getState().closeSessionTerminals(SESSION_ID);
       expect(store.getState().terminalTabs[SESSION_ID]).toBeUndefined();
       expect(store.getState().activeTerminalTab[SESSION_ID]).toBeUndefined();
+    });
+
+    it('closeSessionTerminals settles only once every shell has been told to close', async () => {
+      const store = await getStore();
+      store.getState().addTerminalTab(SESSION_ID, null);
+      let shellIsDown = false;
+      invokeTerminalCloseSpy.mockImplementationOnce(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        shellIsDown = true;
+        return undefined;
+      });
+
+      await store.getState().closeSessionTerminals(SESSION_ID);
+
+      expect(shellIsDown).toBe(true);
     });
   });
 });

--- a/apps/desktop/src/store/slices/worktrees/index.ts
+++ b/apps/desktop/src/store/slices/worktrees/index.ts
@@ -1,6 +1,8 @@
 import { amendSessionCommit } from './amendSessionCommit';
 import { changeSessionBranch } from './changeSessionBranch';
+import { reconcileOrphanWorktrees } from './reconcileOrphanWorktrees';
 import { reconcileSessionBranch } from './reconcileSessionBranch';
+import { removeOrphanWorktrees } from './removeOrphanWorktrees';
 import { setSessionActiveMount } from './setSessionActiveMount';
 import { squashSessionCommits } from './squashSessionCommits';
 import type { GetFn, SetFn } from './types';
@@ -9,6 +11,8 @@ export const createWorktreesSlice = (set: SetFn, get: GetFn) => {
   return {
     changeSessionBranch: changeSessionBranch(set, get),
     reconcileSessionBranch: reconcileSessionBranch(set, get),
+    reconcileOrphanWorktrees: reconcileOrphanWorktrees(set, get),
+    removeOrphanWorktrees: removeOrphanWorktrees(set, get),
     setSessionActiveMount: setSessionActiveMount({ set }),
     amendSessionCommit: amendSessionCommit(set, get),
     squashSessionCommits: squashSessionCommits(set, get),

--- a/apps/desktop/src/store/slices/worktrees/reconcileOrphanWorktrees.test.ts
+++ b/apps/desktop/src/store/slices/worktrees/reconcileOrphanWorktrees.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { listAllSessionWorktrees, scanOrphanWorktrees } = vi.hoisted(() => ({
+  listAllSessionWorktrees: vi.fn(async () => [
+    { worktreePath: '/repo/.goodboy/worktrees/gb-live' },
+  ]),
+  scanOrphanWorktrees: vi.fn(async () => [
+    { path: '/repo/.goodboy/worktrees/gb-ghost', name: 'gb-ghost', sizeBytes: 4096 },
+  ]),
+}));
+
+vi.mock('@goodboy/db', () => ({ listAllSessionWorktrees }));
+vi.mock('../../../shared/lib/db', () => ({ tauriDatabase: {} }));
+vi.mock('../../../features/worktree/worktree', () => ({ scanOrphanWorktrees }));
+
+import { reconcileOrphanWorktrees } from './reconcileOrphanWorktrees';
+
+const emitNotification = vi.fn(async () => undefined);
+
+const makeStore = (kind: string) => ({
+  workspaces: [{ id: 'ws-1', name: 'demo', rootPath: '/repo', kind }],
+  orphanWorktrees: {},
+  emitNotification,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('reconciling the worktrees folder at startup', () => {
+  it('reports a folder git forgot, and never counts one a session still owns', async () => {
+    const store = makeStore('repo');
+    const set = vi.fn((updater: (s: unknown) => unknown) => {
+      Object.assign(store, updater(store));
+    });
+
+    await reconcileOrphanWorktrees(set as never, (() => store) as never)();
+
+    expect(scanOrphanWorktrees).toHaveBeenCalledWith({
+      repoPath: '/repo',
+      knownPaths: ['/repo/.goodboy/worktrees/gb-live'],
+    });
+    expect(store.orphanWorktrees).toEqual({
+      'ws-1': [{ path: '/repo/.goodboy/worktrees/gb-ghost', name: 'gb-ghost', sizeBytes: 4096 }],
+    });
+  });
+
+  it('offers the cleanup instead of running it', async () => {
+    const store = makeStore('repo');
+    const set = vi.fn((updater: (s: unknown) => unknown) => {
+      Object.assign(store, updater(store));
+    });
+
+    await reconcileOrphanWorktrees(set as never, (() => store) as never)();
+
+    expect(emitNotification).toHaveBeenCalledWith(
+      'orphan-worktrees',
+      'info',
+      expect.stringContaining('1 session folders left on disk'),
+      expect.any(String),
+      { workspaceId: 'ws-1', action: { kind: 'open-orphan-worktrees', workspaceId: 'ws-1' } },
+    );
+  });
+
+  it('leaves a folder-backed workspace alone', async () => {
+    const store = makeStore('simple');
+    const set = vi.fn();
+
+    await reconcileOrphanWorktrees(set as never, (() => store) as never)();
+
+    expect(scanOrphanWorktrees).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/store/slices/worktrees/reconcileOrphanWorktrees.ts
+++ b/apps/desktop/src/store/slices/worktrees/reconcileOrphanWorktrees.ts
@@ -1,0 +1,44 @@
+import type { WorkspaceId } from '@goodboy/types';
+import { listAllSessionWorktrees } from '@goodboy/db';
+import { tauriDatabase } from '../../../shared/lib/db';
+import { scanOrphanWorktrees, type OrphanWorktree } from '../../../features/worktree/worktree';
+import type { GetFn, SetFn } from './types';
+
+export const reconcileOrphanWorktrees = (set: SetFn, get: GetFn) => {
+  return async (): Promise<void> => {
+    const workspaces = get().workspaces.filter((w) => (w.kind ?? 'repo') === 'repo');
+    if (workspaces.length === 0) {
+      return;
+    }
+    const knownPaths = (await listAllSessionWorktrees(tauriDatabase)).map(
+      (row) => row.worktreePath,
+    );
+    const found: Array<[WorkspaceId, ReadonlyArray<OrphanWorktree>]> = [];
+    for (const workspace of workspaces) {
+      const orphans = await scanOrphanWorktrees({
+        repoPath: workspace.rootPath,
+        knownPaths,
+      }).catch(() => []);
+      found.push([workspace.id, orphans]);
+    }
+    set((state) => {
+      const next = { ...state.orphanWorktrees };
+      for (const [workspaceId, orphans] of found) {
+        next[workspaceId] = orphans;
+      }
+      return { orphanWorktrees: next };
+    });
+    for (const [workspaceId, orphans] of found) {
+      if (orphans.length === 0) {
+        continue;
+      }
+      await get().emitNotification(
+        'orphan-worktrees',
+        'info',
+        `${orphans.length} session folders left on disk`,
+        'They belong to no session any more. Review them in workspace settings and remove them when you want the space back.',
+        { workspaceId, action: { kind: 'open-orphan-worktrees', workspaceId } },
+      );
+    }
+  };
+};

--- a/apps/desktop/src/store/slices/worktrees/removeOrphanWorktrees.ts
+++ b/apps/desktop/src/store/slices/worktrees/removeOrphanWorktrees.ts
@@ -1,0 +1,38 @@
+import type { WorkspaceId } from '@goodboy/types';
+import { removeOrphanWorktree } from '../../../features/worktree/worktree';
+import { formatError } from '../../../shared/lib/errors';
+import type { GetFn, SetFn } from './types';
+
+type Params = {
+  readonly workspaceId: WorkspaceId;
+  readonly paths: ReadonlyArray<string>;
+};
+
+export const removeOrphanWorktrees = (set: SetFn, get: GetFn) => {
+  return async ({ workspaceId, paths }: Params): Promise<void> => {
+    const workspace = get().workspaces.find((w) => w.id === workspaceId);
+    if (workspace == null) {
+      throw new Error(`workspace not found: ${workspaceId}`);
+    }
+    const failures: Array<string> = [];
+    const removed = new Set<string>();
+    for (const path of paths) {
+      try {
+        await removeOrphanWorktree({ repoPath: workspace.rootPath, path });
+        removed.add(path);
+      } catch (error) {
+        failures.push(formatError(error));
+      }
+    }
+    set((state) => {
+      const next = { ...state.orphanWorktrees };
+      next[workspaceId] = (state.orphanWorktrees[workspaceId] ?? []).filter(
+        (orphan) => !removed.has(orphan.path),
+      );
+      return { orphanWorktrees: next };
+    });
+    if (failures.length > 0) {
+      throw new Error(failures.join('\n'));
+    }
+  };
+};

--- a/apps/desktop/src/store/store.branchless-session.test.ts
+++ b/apps/desktop/src/store/store.branchless-session.test.ts
@@ -77,7 +77,7 @@ type Store = {
   sessionSelectedPrNumber: Record<string, number | null>;
   sessionExternalTasks: Record<string, ReadonlyArray<{ readonly branch?: string }>>;
   sessionPhaseRuns: Record<string, ReadonlyArray<unknown>>;
-  closeSessionTerminals: () => void;
+  closeSessionTerminals: () => Promise<void>;
   emitNotification: () => void;
 };
 
@@ -92,7 +92,7 @@ const makeStore = (branch: string): Store => ({
   sessionSelectedPrNumber: {},
   sessionExternalTasks: {},
   sessionPhaseRuns: {},
-  closeSessionTerminals: vi.fn(),
+  closeSessionTerminals: vi.fn(async () => undefined),
   emitNotification: vi.fn(),
 });
 

--- a/apps/desktop/src/store/store.composite-session.test.ts
+++ b/apps/desktop/src/store/store.composite-session.test.ts
@@ -125,7 +125,7 @@ type Store = {
   sessionSelectedPrNumber: Record<string, number | null>;
   sessionExternalTasks: Record<string, ReadonlyArray<{ readonly branch?: string }>>;
   sessionPhaseRuns: Record<string, ReadonlyArray<unknown>>;
-  closeSessionTerminals: () => void;
+  closeSessionTerminals: () => Promise<void>;
   emitNotification: () => void;
 };
 
@@ -182,7 +182,7 @@ const makeStore = ({ activeMount }: MakeStoreParams): Store => ({
   sessionSelectedPrNumber: {},
   sessionExternalTasks: {},
   sessionPhaseRuns: {},
-  closeSessionTerminals: vi.fn(),
+  closeSessionTerminals: vi.fn(async () => undefined),
   emitNotification: vi.fn(),
 });
 

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -671,7 +671,12 @@ export type AppActions = {
   closeTerminalTab(sessionId: SessionId, tabId: TerminalTabId): void;
   setActiveTerminalTab(sessionId: SessionId, tabId: TerminalTabId): void;
   setTerminalTabStatus(sessionId: SessionId, tabId: TerminalTabId, status: TerminalTabStatus): void;
-  closeSessionTerminals(sessionId: SessionId): void;
+  closeSessionTerminals(sessionId: SessionId): Promise<void>;
+  reconcileOrphanWorktrees(): Promise<void>;
+  removeOrphanWorktrees(params: {
+    workspaceId: WorkspaceId;
+    paths: ReadonlyArray<string>;
+  }): Promise<void>;
 };
 
 export type AppStore = AppState & AppActions;
@@ -713,6 +718,7 @@ export const initialState: AppState = {
   transcripts: {},
   messages: {},
   sessionWorktrees: {},
+  orphanWorktrees: {},
   sessionMounts: {},
   sessionActiveMount: {},
   sessionBranches: {},

--- a/apps/desktop/src/store/types.ts
+++ b/apps/desktop/src/store/types.ts
@@ -1,4 +1,5 @@
 import type { FileConflict } from '@goodboy/core';
+import type { OrphanWorktree } from '../features/worktree/worktree';
 import type { Notification, NotificationCounts, TelemetrySummary } from '@goodboy/db';
 import type {
   Agent,
@@ -191,6 +192,7 @@ export type AppState = AppSliceState & {
   readonly transcripts: Readonly<Record<string, ReadonlyArray<TurnEvent>>>;
   readonly messages: Readonly<Record<string, ReadonlyArray<Message>>>;
   readonly sessionWorktrees: Readonly<Record<string, ReadonlyArray<string>>>;
+  readonly orphanWorktrees: Readonly<Record<string, ReadonlyArray<OrphanWorktree>>>;
   readonly sessionMounts: Readonly<Record<string, ReadonlyArray<SessionMount>>>;
   readonly sessionActiveMount: Readonly<Record<string, WorkspaceId>>;
   readonly sessionBranches: Readonly<Record<string, string>>;

--- a/packages/db/src/queries/notification.ts
+++ b/packages/db/src/queries/notification.ts
@@ -15,6 +15,7 @@ export type NotificationKind =
   | 'budget-cap'
   | 'title-generation'
   | 'provider-connected'
+  | 'orphan-worktrees'
   | 'error';
 
 export type NotificationAction =
@@ -24,7 +25,8 @@ export type NotificationAction =
       readonly sessionId: SessionId;
       readonly agentId: AgentId;
     }
-  | { readonly kind: 'open-budget'; readonly sessionId: SessionId | null };
+  | { readonly kind: 'open-budget'; readonly sessionId: SessionId | null }
+  | { readonly kind: 'open-orphan-worktrees'; readonly workspaceId: WorkspaceId };
 
 export type Notification = {
   readonly id: string;


### PR DESCRIPTION
## The bug

Deleting a session raised `failed to remove 1 session paths`, with
`git worktree remove --force <path> failed: Directory not empty`, and the
folder stayed on disk forever.

## Cause

Two defects compounding:

1. `terminal_close` called `session.child.kill()`, which kills the login shell
   and nothing else. Anything the shell had spawned (in the reported case a
   `next dev -p 5005`, reparented to launchd) kept running and kept writing
   into the worktree. On top of that `closeSessionTerminals` was fire and
   forget, so `deleteTask` started deleting files before the kill had even
   been dispatched.
2. `worktree_remove` had no retry and no fallback. `git worktree remove
   --force` deletes the tree recursively, the survivor recreated files under
   it while git worked, and the final `rmdir` failed with ENOTEMPTY. Git had
   already de-registered the worktree, so the folder no longer showed in
   `git worktree list`, `deleteTask` dropped the DB row anyway, and the app
   lost every reference to it.

## Fix

**Kill the whole pty session.** `portable_pty` calls `setsid()` before exec,
so the shell is a session leader, but an interactive shell puts each job in
its own process group: `killpg` on the leader is not enough. `terminate_pty_session`
now enumerates the pids whose `getsid()` matches the leader, SIGTERMs them,
drains for up to 300ms, then SIGKILLs whatever is left. `child.kill()` still
runs afterwards, so the normal close path is unchanged.

**Await the teardown.** `closeSessionTerminals` returns a promise that settles
only once every `terminal_close` has landed, and `deleteTask` awaits it before
touching the filesystem. It is the only caller that removes a worktree
(`deleteWorkspace` disconnects, it never deletes).

**Retry, then fall back, then tell the truth.** `worktree_remove` retries a
"Directory not empty" failure once after 300ms, then removes the folder itself
and runs `git worktree prune`. If the folder is still there it returns an
error naming the path, so nothing pretends the disk is clean. Any other git
failure is returned untouched, without a pointless retry.

**Reconcile at startup.** Boot scans `<repo>/.goodboy/worktrees` for folders
that are neither registered in `git worktree list` nor claimed by a session
row, records them with their size, and posts one notification per workspace
with a "Review folders" action. The cleanup itself lives in workspace
settings behind a two-step `InlineConfirm` that names the folders and the
space. Nothing is ever deleted automatically. `worktree_orphan_remove`
refuses any path whose parent is not the worktrees folder.

No spinners: the section is static, the confirm is inline.

## Mutation checks

Every new test was mutation-checked (break the line that makes it work, watch
the named test fail, restore):

| Mutation | Test that failed |
| --- | --- |
| drop the SIGTERM/SIGKILL sweep in `terminate_pty_session` | `terminate_pty_session_kills_backgrounded_descendant` |
| drop the retry in `remove_worktree_with` | `a_directory_not_empty_failure_is_retried_once_before_giving_up` |
| drop the `remove_dir_all` fallback | `a_worktree_git_cannot_delete_is_removed_from_disk_and_pruned` |
| drop the `is_directory_not_empty` guard | `a_failure_that_is_not_about_a_dirty_directory_is_reported_as_is` |
| drop the claimed-paths filter in `collect_orphans` | `a_folder_git_forgot_and_no_session_claims_is_reported_with_its_size` |
| drop the containment guard in `worktree_orphan_remove` | `orphan_removal_refuses_a_path_outside_the_worktrees_folder` |
| `await` back to `void` in `deleteTask` | `waits for the terminals to die before touching the folder` |
| `await` back to `void` on `Promise.all` in `closeSessionTerminals` | `closeSessionTerminals settles only once every shell has been told to close` |
| drop the workspace-kind filter in `reconcileOrphanWorktrees` | `leaves a folder-backed workspace alone` |
| drop the notification | `offers the cleanup instead of running it` + `offers to clean the session folders left behind on disk` |
| drop `knownPaths` from the scan call | `reports a folder git forgot, and never counts one a session still owns` |
| arm the delete on the first click | `asks twice before deleting the folders it found` |

The first attempt at the pty test was vacuous: killing the shell alone already
took the descendant down through SIGHUP on the controlling terminal. The test
now traps SIGHUP in the descendant, so only the session sweep can kill it, and
it asserts the descendant shares the pty session before doing so.

## Verification

- `npx tsc -p apps/desktop --noEmit`: clean
- `cd apps/desktop && npx vitest run`: 492 files, 4287 tests passed
- `cd apps/desktop/src-tauri && cargo test --locked`: 204 passed, 0 failed
- `rustfmt --check` on `terminal.rs` and `worktree.rs`: clean (the crate as a
  whole is not fmt-clean, untouched files were left alone)
- `npx knip --include files,duplicates,unlisted`: no findings, only the
  pre-existing configuration hints

One deviation from the plan: the boot test harness mocked
`features/providers/providers` without `getGeminiStatus`, `getOpenCodeStatus`
or `getOpenRouterStatus`, so `hydrate` had been throwing and every boot
assertion was passing on `bootPhase === 'error'`. The startup reconciliation
test cannot exist under that, so the three exports were added to the mock.
`hydrate` now actually reaches `ready` in that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
