### PR TITLE
feat(desktop): write the issue description back to linear and gitlab

### DIFF
--- a/apps/desktop/src-tauri/src/gitlab.rs
+++ b/apps/desktop/src-tauri/src/gitlab.rs
@@ -241,6 +241,29 @@ pub async fn gitlab_fetch_issue(
     .await
 }
 
+#[tauri::command]
+pub async fn gitlab_update_issue(
+    workspace_id: String,
+    host: String,
+    project_path: String,
+    issue_iid: i64,
+    description: String,
+    cache: State<'_, GitlabTokenCache>,
+) -> Result<String, GitlabError> {
+    let token = read_token(&workspace_id, &cache)?;
+    let encoded = encode_project_path(&project_path);
+    let body = serde_json::json!({ "description": description });
+    let issue: GitlabIssue = send_json(
+        reqwest::Method::PUT,
+        &host,
+        &token,
+        &format!("/projects/{encoded}/issues/{issue_iid}"),
+        &body,
+    )
+    .await?;
+    Ok(issue.description.unwrap_or_default())
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GitlabMrAuthor {
     pub username: String,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -265,6 +265,7 @@ pub fn run() {
       linear::linear_fetch_assigned_issues,
       linear::linear_fetch_issue,
       linear::linear_fetch_issue_comments,
+      linear::linear_update_issue,
       sentry::sentry_connect,
       sentry::sentry_disconnect,
       sentry::sentry_fetch_issues,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -274,6 +274,7 @@ pub fn run() {
       gitlab::gitlab_disconnect,
       gitlab::gitlab_fetch_assigned_issues,
       gitlab::gitlab_fetch_issue,
+      gitlab::gitlab_update_issue,
       gitlab::gitlab_fetch_assigned_mrs,
       gitlab::gitlab_fetch_project_mrs,
       gitlab::gitlab_mr_for_branch,

--- a/apps/desktop/src-tauri/src/linear.rs
+++ b/apps/desktop/src-tauri/src/linear.rs
@@ -289,6 +289,15 @@ query IssueComments($issueId: String!) {
 }
 "#;
 
+const ISSUE_UPDATE_MUTATION: &str = r#"
+mutation IssueUpdate($issueId: String!, $input: IssueUpdateInput!) {
+  issueUpdate(id: $issueId, input: $input) {
+    success
+    issue { description }
+  }
+}
+"#;
+
 /// Verify token via /viewer query and save to keyring on success.
 #[tauri::command]
 pub async fn linear_connect(
@@ -370,6 +379,36 @@ pub async fn linear_fetch_issue_comments(
     Ok(comments)
 }
 
+#[tauri::command]
+pub async fn linear_update_issue(
+    workspace_id: String,
+    issue_id: String,
+    description: String,
+    cache: State<'_, LinearTokenCache>,
+) -> Result<String, LinearError> {
+    let token = read_token(&workspace_id, &cache)?;
+    let resp: IssueUpdateResponse = graphql(
+        &token,
+        ISSUE_UPDATE_MUTATION,
+        Some(serde_json::json!({
+            "issueId": issue_id,
+            "input": { "description": description }
+        })),
+    )
+    .await?;
+    if !resp.issue_update.success {
+        return Err(LinearError::GraphQl(format!(
+            "issueUpdate rejected for {}",
+            issue_id
+        )));
+    }
+    let issue = resp
+        .issue_update
+        .issue
+        .ok_or_else(|| LinearError::InvalidShape("missing issue".into()))?;
+    Ok(issue.description.unwrap_or_default())
+}
+
 #[derive(Deserialize)]
 struct ViewerResponse {
     viewer: LinearViewer,
@@ -398,4 +437,21 @@ struct IssueComments {
 #[derive(Deserialize)]
 struct IssueCommentsResponse {
     issue: Option<IssueComments>,
+}
+
+#[derive(Deserialize)]
+struct IssueDescription {
+    description: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct IssueUpdatePayload {
+    success: bool,
+    issue: Option<IssueDescription>,
+}
+
+#[derive(Deserialize)]
+struct IssueUpdateResponse {
+    #[serde(rename = "issueUpdate")]
+    issue_update: IssueUpdatePayload,
 }

--- a/apps/desktop/src/features/integrations/gitlab/GitlabIssueDetail/index.test.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabIssueDetail/index.test.tsx
@@ -1,7 +1,28 @@
-import { afterEach, describe, expect, it } from 'vitest';
-import { cleanup, render, screen } from '@testing-library/react';
-import type { GitlabIssue } from '../client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { WorkspaceId } from '@goodboy/types';
+import { gitlabUpdateIssueDescription, type GitlabIssue } from '../client';
 import { GitlabIssueDetail } from './index';
+
+type StoreGitlabIntegration = { provider: string; config: { host: string } };
+
+const h = vi.hoisted(() => ({
+  store: {
+    workspaceIntegrations: {} as Record<string, ReadonlyArray<StoreGitlabIntegration>>,
+  },
+}));
+
+vi.mock('../../../../store', () => ({
+  useAppStore: <T,>(selector: (state: typeof h.store) => T) => selector(h.store),
+}));
+
+vi.mock('../client', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../client')>()),
+  gitlabUpdateIssueDescription: vi.fn(),
+}));
+
+const updateDescription = vi.mocked(gitlabUpdateIssueDescription);
+const WORKSPACE_ID = 'workspace-1' as WorkspaceId;
 
 const ISSUE: GitlabIssue = {
   id: 101,
@@ -17,11 +38,18 @@ const ISSUE: GitlabIssue = {
   labels: ['bug'],
 };
 
+beforeEach(() => {
+  updateDescription.mockReset();
+  h.store.workspaceIntegrations = {
+    [WORKSPACE_ID]: [{ provider: 'gitlab', config: { host: 'https://gitlab.com' } }],
+  };
+});
+
 afterEach(cleanup);
 
 describe('GitlabIssueDetail', () => {
   it('renders the issue title, description and properties', () => {
-    render(<GitlabIssueDetail issue={ISSUE} />);
+    render(<GitlabIssueDetail issue={ISSUE} workspaceId={WORKSPACE_ID} />);
 
     expect(screen.getByText('Fix the thing')).toBeDefined();
     expect(screen.getByText('Investigate the flaky request.')).toBeDefined();
@@ -31,8 +59,62 @@ describe('GitlabIssueDetail', () => {
   });
 
   it('falls back to a placeholder when there is no description', () => {
-    render(<GitlabIssueDetail issue={{ ...ISSUE, description: null }} />);
+    render(
+      <GitlabIssueDetail issue={{ ...ISSUE, description: null }} workspaceId={WORKSPACE_ID} />,
+    );
 
     expect(screen.getByText('No description.')).toBeDefined();
+  });
+
+  it('saves an edited description and renders the body GitLab returned', async () => {
+    updateDescription.mockResolvedValueOnce('Body normalized by GitLab');
+    render(<GitlabIssueDetail issue={ISSUE} workspaceId={WORKSPACE_ID} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    fireEvent.change(screen.getByRole('textbox', { name: 'Edit description' }), {
+      target: { value: 'Body typed by the user' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() =>
+      expect(updateDescription).toHaveBeenCalledWith({
+        workspaceId: WORKSPACE_ID,
+        host: 'https://gitlab.com',
+        projectPath: 'acme/web',
+        issueIid: 7,
+        description: 'Body typed by the user',
+      }),
+    );
+    await waitFor(() => expect(screen.getByText('Body normalized by GitLab')).toBeDefined());
+    expect(screen.queryByText('Body typed by the user')).toBeNull();
+  });
+
+  it('keeps the draft and shows the error inline when GitLab rejects the save', async () => {
+    updateDescription.mockRejectedValueOnce(new Error('gitlab_update_issue: http error 403'));
+    render(<GitlabIssueDetail issue={ISSUE} workspaceId={WORKSPACE_ID} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    fireEvent.change(screen.getByRole('textbox', { name: 'Edit description' }), {
+      target: { value: 'Body that fails' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert').textContent).toContain(
+        'gitlab_update_issue: http error 403',
+      ),
+    );
+    expect(
+      (screen.getByRole('textbox', { name: 'Edit description' }) as HTMLTextAreaElement).value,
+    ).toBe('Body that fails');
+  });
+
+  it('stays read-only when the workspace has no GitLab host to write to', () => {
+    h.store.workspaceIntegrations = {};
+    render(<GitlabIssueDetail issue={ISSUE} workspaceId={WORKSPACE_ID} />);
+
+    expect(screen.queryByRole('button', { name: 'Edit' })).toBeNull();
+    fireEvent.click(screen.getByTestId('description-body'));
+    expect(screen.queryByRole('textbox', { name: 'Edit description' })).toBeNull();
   });
 });

--- a/apps/desktop/src/features/integrations/gitlab/GitlabIssueDetail/index.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabIssueDetail/index.tsx
@@ -1,20 +1,25 @@
 import type { ReactNode } from 'react';
+import type { WorkspaceId } from '@goodboy/types';
 import { HeaderBand, StudioDetailLayout } from '../../../../shared/components/StudioDetail';
 import { DescriptionSection } from '../../../../shared/components/DescriptionSection';
 import { gitlabIssueFields, resolveDetailFields } from '../../../../shared/detail-fields';
 import { IssueStateBadge } from '../../../../shared/components/IssueStateBadge';
 import { ExternalRefActions } from '../../../../shared/components/ExternalRefActions';
 import { issueIdentifier, type GitlabIssue } from '../client';
+import { useGitlabIssueDescription } from '../useGitlabIssueDescription';
 
 type Fit = 'fill' | 'bleed' | 'flow';
 
 type Props = {
   readonly issue: GitlabIssue;
+  readonly workspaceId: WorkspaceId;
   readonly headerActions?: ReactNode;
   readonly fit?: Fit;
 };
 
-export const GitlabIssueDetail = ({ issue, headerActions, fit = 'fill' }: Props) => {
+export const GitlabIssueDetail = ({ issue, workspaceId, headerActions, fit = 'fill' }: Props) => {
+  const { description, save } = useGitlabIssueDescription({ issue, workspaceId });
+
   return (
     <StudioDetailLayout
       fit={fit}
@@ -39,7 +44,7 @@ export const GitlabIssueDetail = ({ issue, headerActions, fit = 'fill' }: Props)
       }
       properties={resolveDetailFields({ registry: gitlabIssueFields, entity: issue })}
     >
-      <DescriptionSection text={issue.description ?? ''} />
+      <DescriptionSection text={description} onSave={save} />
     </StudioDetailLayout>
   );
 };

--- a/apps/desktop/src/features/integrations/gitlab/client.test.ts
+++ b/apps/desktop/src/features/integrations/gitlab/client.test.ts
@@ -1,7 +1,13 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { invoke } from '@tauri-apps/api/core';
 import type { WorkspaceId } from '@goodboy/types';
-import { gitlabFetchIssue, humanizeMergeStatus, issueIdentifier, type GitlabIssue } from './client';
+import {
+  gitlabFetchIssue,
+  gitlabUpdateIssueDescription,
+  humanizeMergeStatus,
+  issueIdentifier,
+  type GitlabIssue,
+} from './client';
 
 vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
 
@@ -61,6 +67,29 @@ describe('gitlabFetchIssue', () => {
       host: 'https://gitlab.com',
       projectPath: 'acme/web',
       issueIid: 7,
+    });
+  });
+});
+
+describe('gitlabUpdateIssueDescription', () => {
+  it('sends the new description to the update command and returns the saved body', async () => {
+    mockInvoke.mockResolvedValueOnce('Saved by GitLab');
+
+    const saved = await gitlabUpdateIssueDescription({
+      workspaceId: 'workspace-1' as WorkspaceId,
+      host: 'https://gitlab.com',
+      projectPath: 'acme/web',
+      issueIid: 7,
+      description: 'Rewritten body',
+    });
+
+    expect(saved).toBe('Saved by GitLab');
+    expect(mockInvoke).toHaveBeenCalledWith('gitlab_update_issue', {
+      workspaceId: 'workspace-1',
+      host: 'https://gitlab.com',
+      projectPath: 'acme/web',
+      issueIid: 7,
+      description: 'Rewritten body',
     });
   });
 });

--- a/apps/desktop/src/features/integrations/gitlab/client.ts
+++ b/apps/desktop/src/features/integrations/gitlab/client.ts
@@ -54,6 +54,30 @@ export const gitlabFetchIssue = async (
   });
 };
 
+type UpdateDescriptionParams = {
+  readonly workspaceId: WorkspaceId;
+  readonly host: string;
+  readonly projectPath: string;
+  readonly issueIid: number;
+  readonly description: string;
+};
+
+export const gitlabUpdateIssueDescription = async ({
+  workspaceId,
+  host,
+  projectPath,
+  issueIid,
+  description,
+}: UpdateDescriptionParams): Promise<string> => {
+  return invoke<string>('gitlab_update_issue', {
+    workspaceId,
+    host,
+    projectPath,
+    issueIid,
+    description,
+  });
+};
+
 export const issueIdentifier = (issue: GitlabIssue): string =>
   issue.references.full ?? `#${issue.iid}`;
 

--- a/apps/desktop/src/features/integrations/gitlab/useGitlabIssueDescription.ts
+++ b/apps/desktop/src/features/integrations/gitlab/useGitlabIssueDescription.ts
@@ -1,0 +1,59 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { GitlabWorkspaceIntegration, WorkspaceId } from '@goodboy/types';
+import { useAppStore } from '../../../store';
+import { gitlabUpdateIssueDescription, type GitlabIssue } from './client';
+
+type Params = {
+  readonly issue: GitlabIssue;
+  readonly workspaceId: WorkspaceId;
+};
+
+type Result = {
+  readonly description: string;
+  readonly save: ((next: string) => Promise<void>) | null;
+};
+
+const projectPathFrom = (issue: GitlabIssue): string | null => {
+  const full = issue.references?.full ?? '';
+  const index = full.indexOf('#');
+  const path = (index >= 0 ? full.slice(0, index) : full).trim();
+  return path === '' ? null : path;
+};
+
+export const useGitlabIssueDescription = ({ issue, workspaceId }: Params): Result => {
+  const host = useAppStore((state) => {
+    const integration = (state.workspaceIntegrations[workspaceId] ?? []).find(
+      (candidate): candidate is GitlabWorkspaceIntegration => candidate.provider === 'gitlab',
+    );
+    return integration != null ? integration.config.host : null;
+  });
+  const [saved, setSaved] = useState<string | null>(null);
+  const projectPath = projectPathFrom(issue);
+  const issueIid = issue.iid;
+
+  useEffect(() => {
+    setSaved(null);
+  }, [issueIid, issue.description]);
+
+  const save = useCallback(
+    async (next: string) => {
+      if (host == null || projectPath == null) {
+        return;
+      }
+      const description = await gitlabUpdateIssueDescription({
+        workspaceId,
+        host,
+        projectPath,
+        issueIid,
+        description: next,
+      });
+      setSaved(description);
+    },
+    [workspaceId, host, projectPath, issueIid],
+  );
+
+  return {
+    description: saved ?? issue.description ?? '',
+    save: host == null || projectPath == null ? null : save,
+  };
+};

--- a/apps/desktop/src/features/integrations/linear/LinearIssueDetail/index.test.tsx
+++ b/apps/desktop/src/features/integrations/linear/LinearIssueDetail/index.test.tsx
@@ -1,9 +1,14 @@
 // @vitest-environment happy-dom
 
-import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { WorkspaceId } from '@goodboy/types';
-import type { LinearIssue } from '../client';
+import { linearUpdateIssueDescription, type LinearIssue } from '../client';
+
+vi.mock('../client', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../client')>()),
+  linearUpdateIssueDescription: vi.fn(),
+}));
 
 vi.mock('../useLinearIssueComments', () => ({
   useLinearIssueComments: () => ({
@@ -38,6 +43,12 @@ const ISSUE: LinearIssue = {
   updatedAt: '2026-07-23T10:00:00Z',
 };
 
+const updateDescription = vi.mocked(linearUpdateIssueDescription);
+
+beforeEach(() => {
+  updateDescription.mockReset();
+});
+
 afterEach(cleanup);
 
 describe('LinearIssueDetail', () => {
@@ -57,7 +68,7 @@ describe('LinearIssueDetail', () => {
     expect(screen.getByText('The fix is ready for review.')).toBeDefined();
   });
 
-  it('keeps a fenced description as a code block and offers no edit affordance', () => {
+  it('keeps a fenced description as a code block', () => {
     const { container } = render(
       <LinearIssueDetail
         issue={{ ...ISSUE, description: '```\nnot markdown, a fence\n```' }}
@@ -66,7 +77,45 @@ describe('LinearIssueDetail', () => {
     );
 
     expect(container.querySelector('pre code')?.textContent).toBe('not markdown, a fence');
-    expect(screen.queryByRole('button', { name: 'Edit' })).toBeNull();
+  });
+
+  it('saves an edited description and renders the body Linear returned', async () => {
+    updateDescription.mockResolvedValueOnce('Body normalized by Linear');
+    render(<LinearIssueDetail issue={ISSUE} workspaceId={'workspace-1' as WorkspaceId} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    fireEvent.change(screen.getByRole('textbox', { name: 'Edit description' }), {
+      target: { value: 'Body typed by the user' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() =>
+      expect(updateDescription).toHaveBeenCalledWith({
+        workspaceId: 'workspace-1',
+        issueId: 'issue-1',
+        description: 'Body typed by the user',
+      }),
+    );
+    await waitFor(() => expect(screen.getByText('Body normalized by Linear')).toBeDefined());
+    expect(screen.queryByText('Body typed by the user')).toBeNull();
+  });
+
+  it('keeps the draft and shows the error inline when Linear rejects the save', async () => {
+    updateDescription.mockRejectedValueOnce(new Error('linear_update_issue: graphql error'));
+    render(<LinearIssueDetail issue={ISSUE} workspaceId={'workspace-1' as WorkspaceId} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    fireEvent.change(screen.getByRole('textbox', { name: 'Edit description' }), {
+      target: { value: 'Body that fails' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert').textContent).toContain('linear_update_issue: graphql error'),
+    );
+    expect(
+      (screen.getByRole('textbox', { name: 'Edit description' }) as HTMLTextAreaElement).value,
+    ).toBe('Body that fails');
   });
 
   it('renders the properties in registry order, once', () => {

--- a/apps/desktop/src/features/integrations/linear/LinearIssueDetail/index.tsx
+++ b/apps/desktop/src/features/integrations/linear/LinearIssueDetail/index.tsx
@@ -13,6 +13,7 @@ import { ExternalRefActions } from '../../../../shared/components/ExternalRefAct
 import type { LinearIssue } from '../client';
 import { LinearIssueComments } from '../LinearIssueComments';
 import { useLinearIssueComments } from '../useLinearIssueComments';
+import { useLinearIssueDescription } from '../useLinearIssueDescription';
 
 type IssueSection = 'overview' | 'conversation';
 type Fit = 'fill' | 'bleed' | 'flow';
@@ -37,6 +38,7 @@ export const LinearIssueDetail = ({
     workspaceId,
     issueId: issue.id,
   });
+  const { description, save } = useLinearIssueDescription({ issue, workspaceId });
 
   return (
     <StudioDetailLayout
@@ -80,7 +82,7 @@ export const LinearIssueDetail = ({
       properties={resolveDetailFields({ registry: linearIssueFields, entity: issue })}
     >
       {section === 'overview' ? (
-        <DescriptionSection text={issue.description ?? ''} />
+        <DescriptionSection text={description} onSave={save} />
       ) : (
         <LinearIssueComments comments={comments} isLoading={isLoading} error={error} />
       )}

--- a/apps/desktop/src/features/integrations/linear/client.test.ts
+++ b/apps/desktop/src/features/integrations/linear/client.test.ts
@@ -5,6 +5,7 @@ import {
   issuePullRequests,
   linearFetchIssue,
   linearFetchIssueComments,
+  linearUpdateIssueDescription,
   type LinearAttachment,
   type LinearIssue,
 } from './client';
@@ -113,5 +114,22 @@ describe('Linear issue requests', () => {
       ['linear_fetch_issue', { workspaceId: WORKSPACE_ID, issueId: 'issue-42' }],
       ['linear_fetch_issue_comments', { workspaceId: WORKSPACE_ID, issueId: 'issue-42' }],
     ]);
+  });
+
+  it('sends the new description to the update command and returns the saved body', async () => {
+    mockInvoke.mockResolvedValueOnce('Saved by Linear');
+
+    const saved = await linearUpdateIssueDescription({
+      workspaceId: WORKSPACE_ID,
+      issueId: 'issue-42',
+      description: 'Rewritten body',
+    });
+
+    expect(saved).toBe('Saved by Linear');
+    expect(mockInvoke).toHaveBeenCalledWith('linear_update_issue', {
+      workspaceId: WORKSPACE_ID,
+      issueId: 'issue-42',
+      description: 'Rewritten body',
+    });
   });
 });

--- a/apps/desktop/src/features/integrations/linear/client.ts
+++ b/apps/desktop/src/features/integrations/linear/client.ts
@@ -128,3 +128,15 @@ export const linearFetchIssueComments = async ({
 }: Params): Promise<LinearIssueComment[]> => {
   return invoke<LinearIssueComment[]>('linear_fetch_issue_comments', { workspaceId, issueId });
 };
+
+type UpdateDescriptionParams = Params & {
+  readonly description: string;
+};
+
+export const linearUpdateIssueDescription = async ({
+  workspaceId,
+  issueId,
+  description,
+}: UpdateDescriptionParams): Promise<string> => {
+  return invoke<string>('linear_update_issue', { workspaceId, issueId, description });
+};

--- a/apps/desktop/src/features/integrations/linear/useLinearIssueDescription.test.tsx
+++ b/apps/desktop/src/features/integrations/linear/useLinearIssueDescription.test.tsx
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, renderHook, screen, waitFor } from '@testing-library/react';
+import type { WorkspaceId } from '@goodboy/types';
+import { DescriptionSection } from '../../../shared/components/DescriptionSection';
+import { linearUpdateIssueDescription, type LinearIssue } from './client';
+import { useLinearIssueDescription } from './useLinearIssueDescription';
+
+vi.mock('./client', () => ({ linearUpdateIssueDescription: vi.fn() }));
+
+const updateDescription = vi.mocked(linearUpdateIssueDescription);
+const WORKSPACE_ID = 'workspace-1' as WorkspaceId;
+
+const ISSUE: LinearIssue = {
+  id: 'issue-1',
+  identifier: 'GB-42',
+  title: 'Improve linked issue detail',
+  description: 'Original body',
+  url: 'https://linear.app/goodboy/issue/GB-42',
+  state: { name: 'In Progress', type: 'started' },
+  team: { key: 'GB' },
+  updatedAt: '2026-07-23T10:00:00Z',
+};
+
+beforeEach(() => {
+  updateDescription.mockReset();
+});
+
+afterEach(cleanup);
+
+describe('useLinearIssueDescription', () => {
+  it('sends the typed body to Linear and then shows the body Linear returned', async () => {
+    updateDescription.mockResolvedValueOnce('Body normalized by Linear');
+    const { result } = renderHook(() =>
+      useLinearIssueDescription({ issue: ISSUE, workspaceId: WORKSPACE_ID }),
+    );
+
+    await result.current.save?.('Body typed by the user');
+
+    expect(updateDescription).toHaveBeenCalledWith({
+      workspaceId: WORKSPACE_ID,
+      issueId: 'issue-1',
+      description: 'Body typed by the user',
+    });
+    await waitFor(() => expect(result.current.description).toBe('Body normalized by Linear'));
+  });
+
+  it('leaves the surface read-only when there is no workspace to write to', () => {
+    const { result } = renderHook(() =>
+      useLinearIssueDescription({ issue: ISSUE, workspaceId: null }),
+    );
+
+    expect(result.current.save).toBeNull();
+
+    render(<DescriptionSection text={result.current.description} onSave={result.current.save} />);
+
+    expect(screen.queryByRole('button', { name: 'Edit' })).toBeNull();
+  });
+});

--- a/apps/desktop/src/features/integrations/linear/useLinearIssueDescription.ts
+++ b/apps/desktop/src/features/integrations/linear/useLinearIssueDescription.ts
@@ -1,0 +1,42 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { WorkspaceId } from '@goodboy/types';
+import { linearUpdateIssueDescription, type LinearIssue } from './client';
+
+type Params = {
+  readonly issue: LinearIssue;
+  readonly workspaceId: WorkspaceId | null;
+};
+
+type Result = {
+  readonly description: string;
+  readonly save: ((next: string) => Promise<void>) | null;
+};
+
+export const useLinearIssueDescription = ({ issue, workspaceId }: Params): Result => {
+  const [saved, setSaved] = useState<string | null>(null);
+  const issueId = issue.id;
+
+  useEffect(() => {
+    setSaved(null);
+  }, [issueId, issue.description]);
+
+  const save = useCallback(
+    async (next: string) => {
+      if (workspaceId == null) {
+        return;
+      }
+      const description = await linearUpdateIssueDescription({
+        workspaceId,
+        issueId,
+        description: next,
+      });
+      setSaved(description);
+    },
+    [workspaceId, issueId],
+  );
+
+  return {
+    description: saved ?? issue.description ?? '',
+    save: workspaceId == null ? null : save,
+  };
+};

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/GitlabTaskDetail.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/GitlabTaskDetail.tsx
@@ -17,7 +17,7 @@ export const GitlabTaskDetail = ({ workspaceId, task }: Props) => {
   });
 
   if (issue != null) {
-    return <GitlabIssueDetail issue={issue} fit="fill" />;
+    return <GitlabIssueDetail issue={issue} workspaceId={workspaceId} fit="fill" />;
   }
 
   return (


### PR DESCRIPTION
## What

#1196 brought inline description editing to linked GitHub issues. Linear and GitLab stayed read-only with no affordance at all, because their Tauri commands exposed connect, disconnect and fetch only.

This adds the missing write path on both, one dedicated command per provider (no generic HTTP passthrough): the provider logic stays in Rust, the token surface stays bounded to the calls we know.

**Linear** (`linear_update_issue`): `issueUpdate` GraphQL mutation, returns the saved description.

**GitLab** (`gitlab_update_issue`): `PUT /projects/:id/issues/:iid`, returns the saved description.

Both mount through the same `DescriptionSection` GitHub already uses, so the editing surface is identical across the three providers.

## Invariants

- No optimistic write: the body rendered after a save is the one the server returned, not the one typed.
- A failed save keeps the draft and shows the error inline in the editor footer, never a pinned toast.
- No refetch of the whole issue on save.
- No disabled affordance where the write path does not exist: the hook returns `save: null` (Linear without a workspace, GitLab without a connected host or a resolvable project path) and the section renders read-only.

## Out of scope

Sentry (a Sentry issue has no editable description as a concept), other write fields (title, state transition, assign, comment), and a generic passthrough for future providers.

## Checks

- `npx tsc -p apps/desktop --noEmit` clean
- `npx vitest run` green, 4287 tests / 491 files
- `cargo test --locked` green, 198 tests
- `rustfmt --check` unchanged on the touched files (`linear.rs` 1 pre-existing diff, `gitlab.rs` 3, `lib.rs` 120: the crate is not fmt-clean, no delta introduced)
- `npx knip --include files,duplicates,unlisted` unchanged

Every new test was mutation-checked: breaking the line that makes it work (the command name, the `onSave` mount, `setSaved(serverBody)`, the null gate, the project-path parse) fails the test that names it.