### PR TITLE
feat(desktop): close the issue to PR loop, on both code hosts

### DIFF
--- a/apps/desktop/src/features/github/closingIssueReferences.ts
+++ b/apps/desktop/src/features/github/closingIssueReferences.ts
@@ -1,8 +1,10 @@
 import type { SessionExternalTask } from '@goodboy/types';
+import { CLOSING_KEYWORDS } from './closingKeywords';
 
 export type ClosingIssueReference = Readonly<{
   number: number;
   identifier: string;
+  title: string;
   url: string;
   line: string;
 }>;
@@ -12,8 +14,6 @@ type Params = {
   readonly branch: string | null;
   readonly body: string;
 };
-
-const CLOSING_KEYWORDS = 'close[sd]?|fix(?:es|ed)?|resolve[sd]?';
 
 export const closingIssueReferences = ({
   tasks,
@@ -46,6 +46,7 @@ export const closingIssueReferences = ({
     byNumber.set(number, {
       number,
       identifier: task.identifier,
+      title: task.title,
       url: task.url,
       line: `Closes #${number}`,
     });

--- a/apps/desktop/src/features/github/closingKeywords.ts
+++ b/apps/desktop/src/features/github/closingKeywords.ts
@@ -1,0 +1,1 @@
+export const CLOSING_KEYWORDS = 'close[sd]?|fix(?:es|ed)?|resolve[sd]?';

--- a/apps/desktop/src/features/github/closingReferenceLines.ts
+++ b/apps/desktop/src/features/github/closingReferenceLines.ts
@@ -1,0 +1,19 @@
+import { CLOSING_KEYWORDS } from './closingKeywords';
+
+type Params = {
+  readonly body: string;
+};
+
+const STANDALONE_LINE = new RegExp(`^(?:${CLOSING_KEYWORDS})\\s+#(\\d+)\\.?$`, 'i');
+
+export const closingReferenceLines = ({ body }: Params): ReadonlySet<number> => {
+  const numbers = new Set<number>();
+  for (const line of body.split('\n')) {
+    const match = STANDALONE_LINE.exec(line.trim());
+    if (match === null) {
+      continue;
+    }
+    numbers.add(Number.parseInt(match[1]!, 10));
+  }
+  return numbers;
+};

--- a/apps/desktop/src/features/github/removeClosingReference.test.ts
+++ b/apps/desktop/src/features/github/removeClosingReference.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { closingReferenceLines } from './closingReferenceLines';
+import { removeClosingReference } from './removeClosingReference';
+
+describe('removeClosingReference', () => {
+  it('drops only the line closing that issue', () => {
+    const body = 'Refactors auth.\n\nCloses #9\nCloses #12';
+    expect(removeClosingReference({ body, number: 9 })).toBe('Refactors auth.\n\nCloses #12');
+  });
+
+  it('leaves a prose mention of the issue alone', () => {
+    const body = 'Follows up on fixes #9 from last week.\n\nCloses #12';
+    expect(removeClosingReference({ body, number: 9 })).toBe(body);
+  });
+});
+
+describe('closingReferenceLines', () => {
+  it('reads only the standalone closing lines it can rewrite', () => {
+    const body = 'Resolves #3 in passing.\n\nFixes #9\ncloses #12.';
+    expect([...closingReferenceLines({ body })]).toEqual([9, 12]);
+  });
+});

--- a/apps/desktop/src/features/github/removeClosingReference.ts
+++ b/apps/desktop/src/features/github/removeClosingReference.ts
@@ -1,0 +1,15 @@
+import { CLOSING_KEYWORDS } from './closingKeywords';
+
+type Params = {
+  readonly body: string;
+  readonly number: number;
+};
+
+export const removeClosingReference = ({ body, number }: Params): string => {
+  const line = new RegExp(`^(?:${CLOSING_KEYWORDS})\\s+#${number}\\.?$`, 'i');
+  const kept = body.split('\n').filter((candidate) => !line.test(candidate.trim()));
+  return kept
+    .join('\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trimEnd();
+};

--- a/apps/desktop/src/features/integrations/gitlab/gitlabMrStateKind.ts
+++ b/apps/desktop/src/features/integrations/gitlab/gitlabMrStateKind.ts
@@ -1,0 +1,19 @@
+import type { PullRequestStateKind } from '@goodboy/types';
+import type { GitlabMergeRequest } from './client';
+
+type Params = {
+  readonly mr: GitlabMergeRequest;
+};
+
+export const gitlabMrStateKind = ({ mr }: Params): PullRequestStateKind => {
+  if (mr.state === 'merged') {
+    return 'merged';
+  }
+  if (mr.state === 'closed' || mr.state === 'locked') {
+    return 'closed';
+  }
+  if (mr.draft) {
+    return 'draft';
+  }
+  return 'open';
+};

--- a/apps/desktop/src/features/integrations/gitlab/mapMrToPullRequestState.ts
+++ b/apps/desktop/src/features/integrations/gitlab/mapMrToPullRequestState.ts
@@ -1,0 +1,27 @@
+import type { PullRequestState } from '@goodboy/types';
+import type { GitlabMergeRequest } from './client';
+import { gitlabMrStateKind } from './gitlabMrStateKind';
+
+type Params = {
+  readonly mr: GitlabMergeRequest | null;
+};
+
+export const mapMrToPullRequestState = ({ mr }: Params): PullRequestState | null => {
+  if (mr == null) {
+    return null;
+  }
+  return {
+    number: mr.iid,
+    title: mr.title,
+    url: mr.webUrl,
+    state: gitlabMrStateKind({ mr }),
+    mergeable: null,
+    checks: null,
+    baseBranch: mr.targetBranch,
+    headBranch: mr.sourceBranch,
+    isDraft: mr.draft,
+    reviewDecision: null,
+    body: mr.description ?? '',
+    updatedAt: mr.updatedAt,
+  };
+};

--- a/apps/desktop/src/features/session/branchRequests.test.ts
+++ b/apps/desktop/src/features/session/branchRequests.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import type { IsoDateTime, SessionExternalTask, SessionId } from '@goodboy/types';
+import type { GitlabMergeRequest } from '../integrations/gitlab/client';
+import { branchRequests } from './branchRequests';
+import { buildWorkItems } from './workItems';
+
+const SESSION_ID = 'session-1' as SessionId;
+const DATE = '2026-08-04T00:00:00.000Z' as IsoDateTime;
+
+type MrParams = {
+  readonly overrides?: Partial<GitlabMergeRequest>;
+};
+
+const makeMr = ({ overrides = {} }: MrParams): GitlabMergeRequest => ({
+  id: 100,
+  iid: 7,
+  projectId: 3,
+  title: 'Refactor authentication',
+  description: null,
+  state: 'merged',
+  webUrl: 'https://gitlab.com/acme/goodboy/-/merge_requests/7',
+  sourceBranch: 'ak/refactor-auth',
+  targetBranch: 'main',
+  draft: false,
+  hasConflicts: false,
+  mergeStatus: 'can_be_merged',
+  updatedAt: DATE,
+  ...overrides,
+});
+
+const task: SessionExternalTask = {
+  sessionId: SESSION_ID,
+  provider: 'linear',
+  externalId: 'GB-1',
+  identifier: 'GB-1',
+  url: 'https://linear.app/goodboy/issue/GB-1',
+  title: 'Ship the work item',
+  createdAt: DATE,
+};
+
+describe('branchRequests', () => {
+  it('completes a work item from a merged merge request on the session branch', () => {
+    const groups = buildWorkItems({
+      tasks: [task],
+      currentBranch: 'ak/refactor-auth',
+      branchPrs: branchRequests({ prs: [], mr: makeMr({}), branch: 'ak/refactor-auth' }),
+    });
+    expect(groups.current).toEqual([]);
+    expect(groups.history.map((item) => item.isCompleted)).toEqual([true]);
+  });
+
+  it('ignores a merge request opened from another branch', () => {
+    const mr = makeMr({ overrides: { sourceBranch: 'ak/other-work' } });
+    expect(branchRequests({ prs: [], mr, branch: 'ak/refactor-auth' })).toEqual([]);
+  });
+});

--- a/apps/desktop/src/features/session/branchRequests.ts
+++ b/apps/desktop/src/features/session/branchRequests.ts
@@ -1,0 +1,20 @@
+import type { PullRequestState } from '@goodboy/types';
+import type { GitlabMergeRequest } from '../integrations/gitlab/client';
+import { mapMrToPullRequestState } from '../integrations/gitlab/mapMrToPullRequestState';
+
+type Params = {
+  readonly prs: ReadonlyArray<PullRequestState>;
+  readonly mr: GitlabMergeRequest | null;
+  readonly branch: string | null;
+};
+
+export const branchRequests = ({ prs, mr, branch }: Params): ReadonlyArray<PullRequestState> => {
+  if (mr == null) {
+    return prs;
+  }
+  if (branch !== null && mr.sourceBranch !== branch) {
+    return prs;
+  }
+  const mapped = mapMrToPullRequestState({ mr });
+  return mapped === null ? prs : [...prs, mapped];
+};

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/index.test.tsx
@@ -14,6 +14,7 @@ import type {
 type Store = {
   readonly sessionExternalTasks: Readonly<Record<string, ReadonlyArray<SessionExternalTask>>>;
   readonly sessionGithubPrs: Readonly<Record<string, ReadonlyArray<PullRequestState>>>;
+  readonly sessionGitlabMr: Readonly<Record<string, unknown>>;
   readonly workspaceIntegrations: Readonly<Record<string, ReadonlyArray<{ provider: string }>>>;
   readonly sessions: ReadonlyArray<{ id: string; workspaceId: string }>;
   readonly linkSessionExternalTask: ReturnType<typeof vi.fn>;
@@ -36,6 +37,7 @@ const h = vi.hoisted(() => ({
   store: {
     sessionExternalTasks: {},
     sessionGithubPrs: {},
+    sessionGitlabMr: {},
     workspaceIntegrations: {},
     sessions: [],
     linkSessionExternalTask: vi.fn(async () => undefined),

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/index.tsx
@@ -21,6 +21,7 @@ import { PaneShell } from '../../../../../../shared/components/PaneShell';
 import { FocusedPane } from '../../../../../../shared/components/PaneShell/FocusedPane';
 import { PANE_RHYTHM } from '../../../../../../shared/components/paneRhythm';
 import { useSessionRepo } from '../../../../../../store/slices/worktrees/useSessionRepo';
+import { branchRequests } from '../../../../branchRequests';
 import { buildWorkItems } from '../../../../workItems';
 import { FocusedTaskBody } from './FocusedTaskBody';
 import { integrationTaskKey } from './integrationTaskKey';
@@ -64,6 +65,7 @@ export const IntegrationPane = ({ sessionId, workspaceId, provider }: Props) => 
   const githubConnection = useGithubConnection({ workspaceId });
   const sessionBranch = useSessionRepo({ sessionId })?.branch ?? null;
   const branchPrs = useAppStore((state) => state.sessionGithubPrs[sessionId] ?? EMPTY_ARRAY);
+  const mergeRequest = useAppStore((state) => state.sessionGitlabMr[sessionId]?.mr ?? null);
   const tasks = useMemo(
     () => externalTasks.filter((task) => task.provider === provider),
     [externalTasks, provider],
@@ -89,7 +91,11 @@ export const IntegrationPane = ({ sessionId, workspaceId, provider }: Props) => 
     />
   );
   const focusedTask = tasks.find((task) => integrationTaskKey({ task }) === focusedTaskKey) ?? null;
-  const workItems = buildWorkItems({ tasks, currentBranch: sessionBranch, branchPrs });
+  const workItems = buildWorkItems({
+    tasks,
+    currentBranch: sessionBranch,
+    branchPrs: branchRequests({ prs: branchPrs, mr: mergeRequest, branch: sessionBranch }),
+  });
 
   const handleUnlink = async ({ task }: UnlinkParams) => {
     const mountWorkspaceId = task.mountWorkspaceId;

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/LinkIssueToPrPopover.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/LinkIssueToPrPopover.tsx
@@ -1,0 +1,107 @@
+import { useState } from 'react';
+import { Plus } from 'lucide-react';
+import type { SessionId } from '@goodboy/types';
+import { Button, Popover, cn } from '@goodboy/ui';
+import { useDropdown } from '../../../../../shared/hooks/useDropdown';
+import { DropdownPortal } from '../../../../../shared/hooks/useDropdown/DropdownPortal';
+import { formatError } from '../../../../../shared/lib/errors';
+import { useAppStore } from '../../../../../store';
+import { appendClosingReferences } from '../../../../github/appendClosingReferences';
+import type { ClosingIssueReference } from '../../../../github/closingIssueReferences';
+
+type Props = {
+  readonly sessionId: SessionId;
+  readonly prNumber: number;
+  readonly body: string;
+  readonly candidates: ReadonlyArray<ClosingIssueReference>;
+};
+
+export const LinkIssueToPrPopover = ({ sessionId, prNumber, body, candidates }: Props) => {
+  const [error, setError] = useState<string | null>(null);
+  const [pendingNumber, setPendingNumber] = useState<number | null>(null);
+  const editPr = useAppStore((state) => state.editPr);
+  const {
+    open,
+    close,
+    toggle,
+    containerRef,
+    popupRef,
+    popupClassName,
+    popupStyle,
+    portal,
+    portalTarget,
+  } = useDropdown({
+    align: 'end',
+    expectedHeight: 260,
+    expectedWidth: 384,
+    width: 'w-96 max-w-[calc(100vw-2rem)]',
+    strategy: 'fixed',
+  });
+
+  const handlePick = async (reference: ClosingIssueReference) => {
+    setError(null);
+    setPendingNumber(reference.number);
+    try {
+      await editPr(sessionId, prNumber, {
+        body: appendClosingReferences({ body, references: [reference] }),
+      });
+      close();
+    } catch (linkError) {
+      setError(formatError(linkError));
+    } finally {
+      setPendingNumber(null);
+    }
+  };
+
+  return (
+    <div ref={containerRef} className="relative min-w-0">
+      <Button variant="ghost" size="sm" onClick={toggle}>
+        <Plus size={13} aria-hidden />
+        Link issue
+      </Button>
+      <DropdownPortal portal={portal} portalTarget={portalTarget}>
+        {open && (
+          <Popover
+            innerRef={popupRef}
+            role="dialog"
+            ariaLabel="Link an issue to this pull request"
+            className={cn(popupClassName, 'p-3')}
+            style={popupStyle}
+          >
+            <div className="flex flex-col gap-2">
+              <span className="text-xs font-medium text-foreground">
+                Link an issue to this pull request
+              </span>
+              {candidates.length === 0 ? (
+                <p className="text-xs text-muted-foreground">
+                  Link the issue to the session first, from the integrations lens.
+                </p>
+              ) : (
+                <div className="flex flex-col gap-1">
+                  {candidates.map((candidate) => (
+                    <button
+                      key={candidate.number}
+                      type="button"
+                      disabled={pendingNumber !== null}
+                      onClick={() => void handlePick(candidate)}
+                      aria-label={`Link issue ${candidate.identifier} to this pull request`}
+                      className="flex min-w-0 items-center gap-2 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] disabled:pointer-events-none disabled:opacity-40"
+                    >
+                      <span className="shrink-0 font-mono text-xs font-semibold text-foreground">
+                        {candidate.identifier}
+                      </span>
+                      <span className="min-w-0 flex-1 truncate text-xs text-muted-foreground">
+                        {candidate.title}
+                      </span>
+                    </button>
+                  ))}
+                </div>
+              )}
+              {error !== null ? <p className="text-xs text-danger">{error}</p> : null}
+            </div>
+          </Popover>
+        )}
+      </DropdownPortal>
+    </div>
+  );
+};

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.test.tsx
@@ -21,6 +21,7 @@ type Store = {
   workspaceIntegrations: Record<string, ReadonlyArray<{ readonly provider: string }>>;
   readonly refreshSessionPr: ReturnType<typeof vi.fn>;
   readonly selectSessionPr: ReturnType<typeof vi.fn>;
+  readonly editPr: ReturnType<typeof vi.fn>;
   readonly sessionBranches: Record<string, string>;
   sessionMounts: Record<string, ReadonlyArray<never>>;
   sessionActiveMount: Record<string, WorkspaceId>;
@@ -40,6 +41,7 @@ const h = vi.hoisted(() => ({
     workspaceIntegrations: {},
     refreshSessionPr: vi.fn(),
     selectSessionPr: vi.fn(),
+    editPr: vi.fn(async () => undefined),
     sessionBranches: { 'session-1': 'ak/refactor-auth' },
     sessionMounts: {},
     sessionActiveMount: {},
@@ -133,6 +135,41 @@ const session: Session = {
   updatedAt: DATE,
 };
 
+type GithubPrStateParams = {
+  readonly body: string;
+  readonly linkedIssues?: ReadonlyArray<{
+    readonly number: number;
+    readonly title: string;
+    readonly url: string;
+    readonly closes: boolean;
+  }>;
+};
+
+const githubPrState = ({ body, linkedIssues = [] }: GithubPrStateParams) => {
+  const pr = { ...PULL_REQUEST, body } satisfies PullRequestState;
+  h.store.sessionGithub = {
+    [SESSION_ID]: {
+      pr,
+      linkedIssues,
+      detail: { checks: [], comments: [] },
+      loading: false,
+      error: null,
+    },
+  };
+  h.store.sessionGithubPrs = { [SESSION_ID]: [pr] };
+};
+
+const issueTask = (overrides: Partial<SessionExternalTask>): SessionExternalTask => ({
+  sessionId: SESSION_ID,
+  provider: 'github',
+  externalId: '9',
+  identifier: `#${overrides.externalId ?? '9'}`,
+  url: 'https://github.com/acme/goodboy/issues/9',
+  title: 'Harden token refresh',
+  createdAt: DATE,
+  ...overrides,
+});
+
 beforeEach(() => {
   h.store.sessionGithub = {};
   h.store.sessionGithubPrs = {};
@@ -155,6 +192,7 @@ beforeEach(() => {
   h.remoteKind = 'github';
   h.onSelectLens.mockReset();
   h.openUrl.mockClear();
+  h.store.editPr.mockClear();
   h.githubStatus = {
     available: true,
     mode: 'gh-cli',
@@ -599,6 +637,74 @@ describe('PrPane', () => {
     expect(screen.getByRole('button', { name: /Open in code host/i })).toBeDefined();
 
     expect(screen.queryByRole('region', { name: 'issue #7 details' })).toBeNull();
+  });
+
+  it('closes the loop by appending the issue the popover offered to the pull request body', async () => {
+    githubPrState({ body: 'Refactors authentication.' });
+    h.store.sessionExternalTasks = { [SESSION_ID]: [issueTask({ externalId: '9' })] };
+
+    render(<PrPane session={session} onSelectLens={h.onSelectLens} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Link issue' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Link issue #9 to this pull request' }));
+
+    await waitFor(() => {
+      expect(h.store.editPr).toHaveBeenCalledWith(SESSION_ID, 42, {
+        body: 'Refactors authentication.\n\nCloses #9',
+      });
+    });
+  });
+
+  it('never offers an issue the body already closes', () => {
+    githubPrState({ body: 'Refactors authentication.\n\nCloses #9' });
+    h.store.sessionExternalTasks = { [SESSION_ID]: [issueTask({ externalId: '9' })] };
+
+    render(<PrPane session={session} onSelectLens={h.onSelectLens} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Link issue' }));
+
+    expect(screen.queryByRole('button', { name: 'Link issue #9 to this pull request' })).toBeNull();
+    expect(
+      screen.getByText('Link the issue to the session first, from the integrations lens.'),
+    ).toBeDefined();
+  });
+
+  it('unlinks one issue without touching the other closing lines', async () => {
+    githubPrState({
+      body: 'Refactors authentication.\n\nCloses #9\nCloses #12',
+      linkedIssues: [
+        {
+          number: 9,
+          title: 'Harden token refresh',
+          url: 'https://github.com/acme/goodboy/issues/9',
+          closes: true,
+        },
+        {
+          number: 12,
+          title: 'Track auth rollout',
+          url: 'https://github.com/acme/goodboy/issues/12',
+          closes: true,
+        },
+      ],
+    });
+
+    render(<PrPane session={session} onSelectLens={h.onSelectLens} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Unlink issue #9' }));
+
+    await waitFor(() => {
+      expect(h.store.editPr).toHaveBeenCalledWith(SESSION_ID, 42, {
+        body: 'Refactors authentication.\n\nCloses #12',
+      });
+    });
+  });
+
+  it('renders no link affordance when the session has no GitHub issue to offer', () => {
+    githubPrState({ body: 'Refactors authentication.' });
+    h.store.sessionExternalTasks = {
+      [SESSION_ID]: [issueTask({ provider: 'linear', externalId: 'GB-4', identifier: 'GB-4' })],
+    };
+
+    render(<PrPane session={session} onSelectLens={h.onSelectLens} />);
+
+    expect(screen.queryByRole('button', { name: 'Link issue' })).toBeNull();
   });
 
   it('routes the open action to GitHub for GitHub sessions', () => {

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.tsx
@@ -1,14 +1,7 @@
 import { useMemo, useState, type ReactNode } from 'react';
 import { ArrowRight, GitBranch, GitFork, GitMerge, Unlink } from 'lucide-react';
 import { Button, Eyebrow } from '@goodboy/ui';
-import type {
-  LinkedIssue,
-  PullRequestState,
-  PullRequestStateKind,
-  Session,
-  SessionId,
-  Workspace,
-} from '@goodboy/types';
+import type { LinkedIssue, PullRequestState, Session, SessionId, Workspace } from '@goodboy/types';
 import { PullRequestChip, pullRequestMeta } from '../../../../github/components/PullRequestChip';
 import { ExternalTaskChip } from '../../../../integrations/components/ExternalTaskChip';
 import { PROVIDER_LENS } from '../../../../integrations/providerLens';
@@ -18,6 +11,7 @@ import { MissingGithubTokenEmptyState } from '../../../../github/components/Miss
 import { resolveIntegrationConnection } from '../../../../integrations/connection';
 import { useGithubConnection } from '../../../../integrations/github/useGithubConnection';
 import { useRemoteHostKind } from '../../../../worktree/useRemoteHostKind';
+import { gitlabMrStateKind } from '../../../../integrations/gitlab/gitlabMrStateKind';
 import { closingIssueReferences } from '../../../../github/closingIssueReferences';
 import { closingReferenceLines } from '../../../../github/closingReferenceLines';
 import { removeClosingReference } from '../../../../github/removeClosingReference';
@@ -40,6 +34,7 @@ import { LensEmptyState } from '../../../../../shared/components/LensEmptyState'
 import { LinkedWorkRow } from '../../../../../shared/components/LinkedWorkRow';
 import { openUrl } from '../../../../../shared/lib/editor';
 import type { RemoteHostKind } from '../../../../../shared/lib/remoteHost';
+import { branchRequests } from '../../../branchRequests';
 import { buildWorkItems, type WorkItem, type WorkItemGroups } from '../../../workItems';
 import { LinkIssueToPrPopover } from './LinkIssueToPrPopover';
 
@@ -130,16 +125,7 @@ export const PrPane = ({ session, onSelectLens }: Props) => {
       : selectedProvider === 'gitlab' && mergeRequest != null
         ? 'gitlab'
         : defaultProvider;
-  const mergeRequestState: PullRequestStateKind | null =
-    mergeRequest == null
-      ? null
-      : mergeRequest.draft
-        ? 'draft'
-        : mergeRequest.state === 'merged'
-          ? 'merged'
-          : mergeRequest.state === 'closed'
-            ? 'closed'
-            : 'open';
+  const mergeRequestState = mergeRequest == null ? null : gitlabMrStateKind({ mr: mergeRequest });
   const hasBothProviders = pullRequest != null && mergeRequest != null;
   const openStudio = () =>
     window.dispatchEvent(
@@ -222,6 +208,7 @@ const GithubPrCard = ({
   const [unlinkingIssueNumber, setUnlinkingIssueNumber] = useState<number | null>(null);
   const github = useAppStore((s) => s.sessionGithub[sessionId]);
   const branchPrs = useAppStore((s) => s.sessionGithubPrs[sessionId] ?? EMPTY_ARRAY);
+  const mergeRequest = useAppStore((s) => s.sessionGitlabMr[sessionId]?.mr ?? null);
   const selectedPrNumber = useAppStore((s) => s.sessionSelectedPrNumber[sessionId] ?? null);
   const selectSessionPr = useAppStore((s) => s.selectSessionPr);
   const refreshSessionPr = useAppStore((s) => s.refreshSessionPr);
@@ -274,7 +261,11 @@ const GithubPrCard = ({
   const workItems = buildWorkItems({
     tasks: codeHostTasks,
     currentBranch: branch,
-    branchPrs: branchPrs.length > 0 ? branchPrs : pr != null ? [pr] : [],
+    branchPrs: branchRequests({
+      prs: branchPrs.length > 0 ? branchPrs : pr != null ? [pr] : [],
+      mr: mergeRequest,
+      branch,
+    }),
   });
 
   const githubTasks = codeHostTasks.filter((task) => task.provider === 'github');

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState, type ReactNode } from 'react';
-import { ArrowRight, GitBranch, GitFork, GitMerge } from 'lucide-react';
+import { ArrowRight, GitBranch, GitFork, GitMerge, Unlink } from 'lucide-react';
 import { Button, Eyebrow } from '@goodboy/ui';
 import type {
   LinkedIssue,
@@ -18,8 +18,12 @@ import { MissingGithubTokenEmptyState } from '../../../../github/components/Miss
 import { resolveIntegrationConnection } from '../../../../integrations/connection';
 import { useGithubConnection } from '../../../../integrations/github/useGithubConnection';
 import { useRemoteHostKind } from '../../../../worktree/useRemoteHostKind';
+import { closingIssueReferences } from '../../../../github/closingIssueReferences';
+import { closingReferenceLines } from '../../../../github/closingReferenceLines';
+import { removeClosingReference } from '../../../../github/removeClosingReference';
 import { RefreshIconButton } from '../../../../../shared/components/RefreshIconButton';
 import { ExternalRefActions } from '../../../../../shared/components/ExternalRefActions';
+import { GhostActionButton } from '../../../../../shared/components/GhostActionButton';
 import { workspaceMountName } from '../../../../../shared/utils/workspaceMountName';
 import { EMPTY_ARRAY, useAppStore, type LensKind } from '../../../../../store';
 import { isPrReviewSession } from '../../../../../store/slices/session-view';
@@ -37,6 +41,7 @@ import { LinkedWorkRow } from '../../../../../shared/components/LinkedWorkRow';
 import { openUrl } from '../../../../../shared/lib/editor';
 import type { RemoteHostKind } from '../../../../../shared/lib/remoteHost';
 import { buildWorkItems, type WorkItem, type WorkItemGroups } from '../../../workItems';
+import { LinkIssueToPrPopover } from './LinkIssueToPrPopover';
 
 type Props = {
   readonly session: Session;
@@ -214,11 +219,13 @@ const GithubPrCard = ({
   tabs?: ReactNode;
 }) => {
   const sessionId = session.id as SessionId;
+  const [unlinkingIssueNumber, setUnlinkingIssueNumber] = useState<number | null>(null);
   const github = useAppStore((s) => s.sessionGithub[sessionId]);
   const branchPrs = useAppStore((s) => s.sessionGithubPrs[sessionId] ?? EMPTY_ARRAY);
   const selectedPrNumber = useAppStore((s) => s.sessionSelectedPrNumber[sessionId] ?? null);
   const selectSessionPr = useAppStore((s) => s.selectSessionPr);
   const refreshSessionPr = useAppStore((s) => s.refreshSessionPr);
+  const editPr = useAppStore((s) => s.editPr);
   const branch = useSessionRepo({ sessionId })?.branch ?? null;
   const externalTasks = useAppStore((s) => s.sessionExternalTasks[sessionId] ?? EMPTY_ARRAY);
   const workspaceIntegrations = useAppStore(
@@ -269,6 +276,37 @@ const GithubPrCard = ({
     currentBranch: branch,
     branchPrs: branchPrs.length > 0 ? branchPrs : pr != null ? [pr] : [],
   });
+
+  const githubTasks = codeHostTasks.filter((task) => task.provider === 'github');
+  const linkedIssueNumbers = new Set(linkedIssues.map((issue) => issue.number));
+  const linkCandidates =
+    pr === null
+      ? []
+      : closingIssueReferences({ tasks: githubTasks, branch, body: pr.body }).filter(
+          (reference) => !linkedIssueNumbers.has(reference.number),
+        );
+  const unlinkableIssueNumbers =
+    pr === null ? new Set<number>() : closingReferenceLines({ body: pr.body });
+  const linkIssueAction =
+    pr !== null && githubTasks.length > 0 ? (
+      <LinkIssueToPrPopover
+        sessionId={sessionId}
+        prNumber={pr.number}
+        body={pr.body}
+        candidates={linkCandidates}
+      />
+    ) : null;
+
+  const handleUnlinkIssue = async (issueNumber: number) => {
+    if (pr === null) {
+      return;
+    }
+    setUnlinkingIssueNumber(issueNumber);
+    await editPr(sessionId, pr.number, {
+      body: removeClosingReference({ body: pr.body, number: issueNumber }),
+    }).catch(() => undefined);
+    setUnlinkingIssueNumber(null);
+  };
 
   const shell = ({ children }: { readonly children: ReactNode }) => (
     <StudioDetailLayout
@@ -390,7 +428,13 @@ const GithubPrCard = ({
         selectedNumber={pr.number}
         onSelect={(prNumber) => void selectSessionPr(sessionId, prNumber)}
       />
-      <LinkedIssuesSection issues={linkedIssues} />
+      <LinkedIssuesSection
+        issues={linkedIssues}
+        action={linkIssueAction}
+        unlinkableNumbers={unlinkableIssueNumbers}
+        unlinkingNumber={unlinkingIssueNumber}
+        onUnlink={(issueNumber) => void handleUnlinkIssue(issueNumber)}
+      />
       <WorkItemsSections groups={workItems} workspace={workspace} onSelectLens={onSelectLens} />
       {error ? (
         <span className="text-2xs text-danger" title={error}>
@@ -469,15 +513,28 @@ const LinkedPullRequestsSection = ({
 
 type LinkedIssuesSectionProps = {
   readonly issues: ReadonlyArray<LinkedIssue>;
+  readonly action?: ReactNode;
+  readonly unlinkableNumbers?: ReadonlySet<number>;
+  readonly unlinkingNumber?: number | null;
+  readonly onUnlink?: (issueNumber: number) => void;
 };
 
-const LinkedIssuesSection = ({ issues }: LinkedIssuesSectionProps) => {
-  if (issues.length === 0) {
+const LinkedIssuesSection = ({
+  issues,
+  action = null,
+  unlinkableNumbers,
+  unlinkingNumber = null,
+  onUnlink,
+}: LinkedIssuesSectionProps) => {
+  if (issues.length === 0 && action === null) {
     return null;
   }
   return (
     <div className="flex flex-col gap-1.5">
-      <Eyebrow label="Linked issues" muted className="px-0.5 font-medium" />
+      <div className="flex min-w-0 items-center justify-between gap-2">
+        <Eyebrow label="Linked issues" muted className="px-0.5 font-medium" />
+        {action}
+      </div>
       <div className="flex flex-col gap-1">
         {issues.map((issue) => (
           <LinkedWorkRow
@@ -488,11 +545,25 @@ const LinkedIssuesSection = ({ issues }: LinkedIssuesSectionProps) => {
             navigation="external"
             onClick={() => void openUrl(issue.url)}
             actions={
-              <ExternalRefActions
-                url={issue.url}
-                label={`issue #${issue.number}`}
-                hostLabel="GitHub"
-              />
+              <span className="inline-flex shrink-0 items-center gap-0.5">
+                {unlinkableNumbers?.has(issue.number) === true && onUnlink != null && (
+                  <span className="opacity-0 motion-safe:transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
+                    <GhostActionButton
+                      icon={Unlink}
+                      tone="danger"
+                      label="Unlink"
+                      ariaLabel={`Unlink issue #${issue.number}`}
+                      disabled={unlinkingNumber !== null}
+                      onClick={() => onUnlink(issue.number)}
+                    />
+                  </span>
+                )}
+                <ExternalRefActions
+                  url={issue.url}
+                  label={`issue #${issue.number}`}
+                  hostLabel="GitHub"
+                />
+              </span>
             }
           />
         ))}

--- a/apps/desktop/src/store/selectors.test.ts
+++ b/apps/desktop/src/store/selectors.test.ts
@@ -98,6 +98,7 @@ beforeEach(() => {
     terminalTabs: {},
     terminalSessions: {},
     sessionGithub: {},
+    sessionGitlabMr: {},
     sessionOpenQuestions: {},
     sessionViewPrefs: {},
     getSessionViewPrefs: vi.fn(),
@@ -264,6 +265,21 @@ describe('useStageGroupedSessions', () => {
     store.state.sessionBranches = { [SESSION_ID]: 'ak/feat-thing' };
     store.state.sessionGithub = {
       [SESSION_ID]: { pr: { number: 12, state: 'merged', isDraft: false } },
+    };
+    const sessions = [createSession(SESSION_ID)];
+
+    const { result } = renderHook(() => useStageGroupedSessions(WORKSPACE_ID, sessions));
+
+    expect(result.current).toEqual([{ key: 'done', sessions }]);
+  });
+
+  it('groups a GitLab-only session by its merge request stage', () => {
+    store.state.workspaces = [createWorkspace('repo')];
+    store.state.sessionBranches = { [SESSION_ID]: 'ak/feat-thing' };
+    store.state.sessionGitlabMr = {
+      [SESSION_ID]: {
+        mr: { iid: 7, state: 'merged', draft: false, sourceBranch: 'ak/feat-thing' },
+      },
     };
     const sessions = [createSession(SESSION_ID)];
 

--- a/apps/desktop/src/store/selectors.ts
+++ b/apps/desktop/src/store/selectors.ts
@@ -31,6 +31,7 @@ import type { AppState, SessionLoadingFlags, SummarizerSessionStatus } from './t
 import {
   deriveSessionStage,
   isPrReviewSession,
+  resolveSessionRequest,
   sortAndGroupSessions,
   type GroupedSessions,
 } from './slices/session-view';
@@ -81,6 +82,7 @@ type StageInfoState = Pick<
   | 'workspaces'
   | 'sessionBranches'
   | 'sessionGithub'
+  | 'sessionGitlabMr'
   | 'sessionOpenQuestions'
   | 'sessionPhaseRuns'
   | 'selectedAgentId'
@@ -116,9 +118,14 @@ function stageInfoOf(state: StageInfoState, session: Session): SessionStageInfo 
     workspaceKind: state.workspaces.find((workspace) => workspace.id === session.workspaceId)?.kind,
     branch: state.sessionBranches[sessionId],
   });
+  const request = resolveSessionRequest({
+    pr: state.sessionGithub[sessionId]?.pr ?? null,
+    mr: state.sessionGitlabMr[sessionId]?.mr ?? null,
+  });
   return deriveSessionStage({
     session,
-    pr: state.sessionGithub[sessionId]?.pr ?? null,
+    pr: request.pr,
+    requestLabel: request.requestLabel,
     hasUnread: sessionHasUnreadIn(state, sessionId),
     openQuestionCount: countOpenQuestions(state, sessionId),
     hasRunningAgent: sessionHasRunningAgentIn(state, sessionId),
@@ -143,6 +150,9 @@ export const useSortedGroupedSessions = (
   const sessionGithub = useAppStore((s) =>
     needsGithub ? s.sessionGithub : (EMPTY_GITHUB_STATE as typeof s.sessionGithub),
   );
+  const sessionGitlabMr = useAppStore((s) =>
+    needsStage ? s.sessionGitlabMr : (EMPTY_GITHUB_STATE as typeof s.sessionGitlabMr),
+  );
   const sessionOpenQuestions = useAppStore((s) =>
     needsStage ? s.sessionOpenQuestions : (EMPTY_GITHUB_STATE as typeof s.sessionOpenQuestions),
   );
@@ -162,6 +172,7 @@ export const useSortedGroupedSessions = (
       workspaces,
       sessionBranches,
       sessionGithub,
+      sessionGitlabMr,
       sessionOpenQuestions,
       sessionPhaseRuns,
       selectedAgentId,
@@ -181,6 +192,7 @@ export const useSortedGroupedSessions = (
     workspaces,
     sessionBranches,
     sessionGithub,
+    sessionGitlabMr,
     sessionOpenQuestions,
     sessionPhaseRuns,
     selectedAgentId,
@@ -194,6 +206,7 @@ export const useStageGroupedSessions = (
 ): ReadonlyArray<GroupedSessions> => {
   const prefs = useSessionViewPrefs(workspaceId);
   const sessionGithub = useAppStore((s) => s.sessionGithub);
+  const sessionGitlabMr = useAppStore((s) => s.sessionGitlabMr);
   const sessionOpenQuestions = useAppStore((s) => s.sessionOpenQuestions);
   const sessionPhaseRuns = useAppStore((s) => s.sessionPhaseRuns);
   const selectedAgentId = useAppStore((s) => s.selectedAgentId);
@@ -205,6 +218,7 @@ export const useStageGroupedSessions = (
       workspaces,
       sessionBranches,
       sessionGithub,
+      sessionGitlabMr,
       sessionOpenQuestions,
       sessionPhaseRuns,
       selectedAgentId,
@@ -226,6 +240,7 @@ export const useStageGroupedSessions = (
     workspaces,
     sessionBranches,
     sessionGithub,
+    sessionGitlabMr,
     sessionOpenQuestions,
     sessionPhaseRuns,
     selectedAgentId,

--- a/apps/desktop/src/store/slices/review-prs/mapGitlabMr.ts
+++ b/apps/desktop/src/store/slices/review-prs/mapGitlabMr.ts
@@ -1,23 +1,11 @@
-import type { PullRequestStateKind, ReviewablePr } from '@goodboy/types';
+import type { ReviewablePr } from '@goodboy/types';
 import type { GitlabMergeRequest } from '../../../features/integrations/gitlab/client';
+import { gitlabMrStateKind } from '../../../features/integrations/gitlab/gitlabMrStateKind';
 
 type Params = {
   mr: GitlabMergeRequest;
   currentUserName: string;
   projectPath: string;
-};
-
-const deriveState = ({ mr }: { mr: GitlabMergeRequest }): PullRequestStateKind => {
-  if (mr.state === 'merged') {
-    return 'merged';
-  }
-  if (mr.state === 'closed' || mr.state === 'locked') {
-    return 'closed';
-  }
-  if (mr.draft) {
-    return 'draft';
-  }
-  return 'open';
 };
 
 export const mapGitlabMr = ({ mr, currentUserName, projectPath }: Params): ReviewablePr => {
@@ -33,7 +21,7 @@ export const mapGitlabMr = ({ mr, currentUserName, projectPath }: Params): Revie
     authorAvatarUrl: mr.author?.avatarUrl ?? null,
     mine: author !== '' && author === currentUserName,
     reviewRequested: (mr.reviewers ?? []).some((r) => r.username === currentUserName),
-    state: deriveState({ mr }),
+    state: gitlabMrStateKind({ mr }),
     baseBranch: mr.targetBranch,
     headBranch: mr.sourceBranch,
     isDraft: mr.draft,

--- a/apps/desktop/src/store/slices/session-view/deriveSessionStage.ts
+++ b/apps/desktop/src/store/slices/session-view/deriveSessionStage.ts
@@ -8,6 +8,7 @@ type Params = {
   hasRunningAgent?: boolean;
   isPrReview?: boolean;
   isBranchless?: boolean;
+  requestLabel?: string;
 };
 
 const isPrLive = (pr: PullRequestState | null): pr is PullRequestState =>
@@ -24,7 +25,9 @@ export const deriveSessionStage = ({
   hasRunningAgent = false,
   isPrReview = false,
   isBranchless = false,
+  requestLabel,
 }: Params): SessionStageInfo => {
+  const label = requestLabel ?? (pr === null ? '' : `PR #${pr.number}`);
   if (isBranchless) {
     if (session.state.kind === 'running' || session.state.kind === 'starting' || hasRunningAgent) {
       return { stage: 'running', reason: 'agent running' };
@@ -57,12 +60,12 @@ export const deriveSessionStage = ({
     return { stage: 'running', reason: 'agent running' };
   }
   if (isPrLive(pr) && pr.checks === 'failure') {
-    return { stage: 'attention', reason: `PR #${pr.number}: CI failed`, attention: 'ci-failed' };
+    return { stage: 'attention', reason: `${label}: CI failed`, attention: 'ci-failed' };
   }
   if (isPrLive(pr) && pr.reviewDecision === 'changes_requested') {
     return {
       stage: 'attention',
-      reason: `PR #${pr.number}: changes requested`,
+      reason: `${label}: changes requested`,
       attention: 'changes-requested',
     };
   }
@@ -79,7 +82,7 @@ export const deriveSessionStage = ({
   if (isPrLive(pr) && isPrApproved(pr)) {
     return {
       stage: 'attention',
-      reason: `PR #${pr.number} approved, ready to merge`,
+      reason: `${label} approved, ready to merge`,
       attention: 'pr-approved',
     };
   }
@@ -93,16 +96,16 @@ export const deriveSessionStage = ({
     return { stage: 'building', reason: 'no PR yet' };
   }
   if (pr.state === 'merged') {
-    return { stage: 'done', reason: `PR #${pr.number} merged` };
+    return { stage: 'done', reason: `${label} merged` };
   }
   if (pr.state === 'closed') {
-    return { stage: 'done', reason: `PR #${pr.number} closed` };
+    return { stage: 'done', reason: `${label} closed` };
   }
   if (pr.isDraft) {
-    return { stage: 'review', reason: `draft PR #${pr.number}` };
+    return { stage: 'review', reason: `draft ${label}` };
   }
   if (pr.checks === 'pending') {
-    return { stage: 'review', reason: `PR #${pr.number}: CI running` };
+    return { stage: 'review', reason: `${label}: CI running` };
   }
-  return { stage: 'review', reason: `PR #${pr.number} awaiting review` };
+  return { stage: 'review', reason: `${label} awaiting review` };
 };

--- a/apps/desktop/src/store/slices/session-view/index.ts
+++ b/apps/desktop/src/store/slices/session-view/index.ts
@@ -17,6 +17,7 @@ import type { GetFn, SessionViewSlice, SetFn } from './types';
 
 export { sortAndGroupSessions } from './sortAndGroupSessions';
 export { deriveSessionStage } from './deriveSessionStage';
+export { resolveSessionRequest } from './resolveSessionRequest';
 export { isPrReviewSession } from './isPrReviewSession';
 export { readPersistedLens } from './workSurfaceStorage';
 export { LENS_KINDS } from './types';

--- a/apps/desktop/src/store/slices/session-view/resolveSessionRequest.test.ts
+++ b/apps/desktop/src/store/slices/session-view/resolveSessionRequest.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import type { PullRequestState, Session, SessionId, WorkspaceId } from '@goodboy/types';
+import type { GitlabMergeRequest } from '../../../features/integrations/gitlab/client';
+import { deriveSessionStage } from './deriveSessionStage';
+import { resolveSessionRequest } from './resolveSessionRequest';
+
+const DATE = '2026-08-04T00:00:00.000Z';
+
+const session: Session = {
+  id: 'session-1' as SessionId,
+  workspaceId: 'workspace-1' as WorkspaceId,
+  goal: 'Refactor authentication',
+  state: { kind: 'idle', lastActivityAt: DATE as Session['createdAt'] },
+  contextSlots: [],
+  providerPreference: { defaultProvider: 'anthropic', allowTurnOverride: false },
+  permissionMode: 'bypassPermissions',
+  workflowRuns: [],
+  autoRun: false,
+  titleUserEdited: false,
+  createdAt: DATE as Session['createdAt'],
+  updatedAt: DATE as Session['updatedAt'],
+};
+
+type MrParams = {
+  readonly overrides?: Partial<GitlabMergeRequest>;
+};
+
+const makeMr = ({ overrides = {} }: MrParams): GitlabMergeRequest => ({
+  id: 100,
+  iid: 7,
+  projectId: 3,
+  title: 'Refactor authentication',
+  description: 'Refactors authentication.',
+  state: 'merged',
+  webUrl: 'https://gitlab.com/acme/goodboy/-/merge_requests/7',
+  sourceBranch: 'ak/refactor-auth',
+  targetBranch: 'main',
+  draft: false,
+  hasConflicts: false,
+  mergeStatus: 'can_be_merged',
+  updatedAt: DATE,
+  ...overrides,
+});
+
+type PrParams = {
+  readonly overrides?: Partial<PullRequestState>;
+};
+
+const makePr = ({ overrides = {} }: PrParams): PullRequestState => ({
+  number: 42,
+  title: 'Refactor authentication',
+  url: 'https://github.com/acme/goodboy/pull/42',
+  state: 'open',
+  mergeable: true,
+  checks: 'success',
+  baseBranch: 'main',
+  headBranch: 'ak/refactor-auth',
+  isDraft: false,
+  reviewDecision: null,
+  body: '',
+  updatedAt: DATE,
+  ...overrides,
+});
+
+describe('resolveSessionRequest', () => {
+  it('completes a session that only ever had a merged GitLab merge request', () => {
+    const request = resolveSessionRequest({ pr: null, mr: makeMr({}) });
+    const info = deriveSessionStage({
+      session,
+      pr: request.pr,
+      requestLabel: request.requestLabel,
+      hasUnread: false,
+      openQuestionCount: 0,
+    });
+    expect(info).toEqual({ stage: 'done', reason: 'MR !7 merged' });
+  });
+
+  it('lets the GitHub pull request win when both hosts answer', () => {
+    const request = resolveSessionRequest({ pr: makePr({}), mr: makeMr({}) });
+    const info = deriveSessionStage({
+      session,
+      pr: request.pr,
+      requestLabel: request.requestLabel,
+      hasUnread: false,
+      openQuestionCount: 0,
+    });
+    expect(info).toEqual({ stage: 'review', reason: 'PR #42 awaiting review' });
+  });
+
+  it('never reads CI from a merge request', () => {
+    const request = resolveSessionRequest({
+      pr: null,
+      mr: makeMr({ overrides: { state: 'opened' } }),
+    });
+    expect(request.pr?.checks).toBeNull();
+    expect(request.pr?.reviewDecision).toBeNull();
+  });
+});

--- a/apps/desktop/src/store/slices/session-view/resolveSessionRequest.ts
+++ b/apps/desktop/src/store/slices/session-view/resolveSessionRequest.ts
@@ -1,0 +1,24 @@
+import type { PullRequestState } from '@goodboy/types';
+import type { GitlabMergeRequest } from '../../../features/integrations/gitlab/client';
+import { mapMrToPullRequestState } from '../../../features/integrations/gitlab/mapMrToPullRequestState';
+
+type Params = {
+  readonly pr: PullRequestState | null;
+  readonly mr: GitlabMergeRequest | null;
+};
+
+export type SessionRequest = Readonly<{
+  pr: PullRequestState | null;
+  requestLabel: string;
+}>;
+
+export const resolveSessionRequest = ({ pr, mr }: Params): SessionRequest => {
+  if (pr !== null) {
+    return { pr, requestLabel: `PR #${pr.number}` };
+  }
+  const mapped = mapMrToPullRequestState({ mr });
+  if (mapped !== null) {
+    return { pr: mapped, requestLabel: `MR !${mapped.number}` };
+  }
+  return { pr: null, requestLabel: '' };
+};


### PR DESCRIPTION
Two product decisions, one branch, two commits.

## Link an issue to an already open pull request (GitHub only)

`Closes #N` only ever reached the body at creation time, so an issue linked to the session
*after* the pull request was opened never closed the loop.

- The **Linked issues** section carries a `Link issue` header action opening an anchored
  popover, built on the `LinkTicketPopover` pattern.
- It lists the session's GitHub external tasks that are neither already linked on the graph
  nor already closing in the body, reusing the dedupe in `closingIssueReferences`.
- Picking one appends `Closes #N` to the end of the body via `gh pr edit`, and the existing
  refresh inside `editPr` brings the linked issue back from the GitHub graph.
- A row whose standalone `Closes #N` line we can rewrite reveals `Unlink` on hover and on
  keyboard focus; issues linked on GitHub by other means stay read only.
- With no GitHub task on the session the action does not render at all.

No new link is persisted and no migration: the body stays the single source of truth.

## A work item completes from a merged GitLab merge request

`definitionOfDone` already promised "MR !N merges", but `buildWorkItems` and the `done`
stage read GitHub pull requests only, so a GitLab repo could never finish anything and the
copy was lying.

- New `mapMrToPullRequestState` maps a merge request onto a minimal `PullRequestState`
  (`number = iid`, `checks: null`, `reviewDecision: null`).
- `resolveSessionRequest` picks the pull request when both hosts answer, and builds the
  label the reason string uses, so a merged MR reads `MR !12 merged` rather than
  `PR #12 merged`.
- `branchRequests` folds the merge request into the branch requests when its source branch
  matches, so a work item on a merged MR groups as completed work.
- `checks` stays `null`, so GitLab can never produce a "CI failed" stage.

Pull requests and merge requests stay derived from the branch. Nothing new is persisted.

## Checks

- `npx tsc -p apps/desktop --noEmit` clean.
- `npx vitest run` in `apps/desktop`: 493 files, 4293 tests passing.
- `npx knip --include files,duplicates,unlisted` identical to the baseline on `main`.
- Every new test was mutation checked: the line that makes it work was deleted, the named
  test was watched failing, then restored.

## Deviations

- `closingIssueReferences.ts` lives in `features/github/`, not `features/session/`.
- `deriveSessionStage`'s `requestLabel` is optional with a `PR #N` fallback, so the 20+
  existing direct call sites keep passing; both production callers pass it explicitly.
- `useWorkspaceRuns` still derives its lane stage from GitHub only, left out of scope.
- `mapGitlabMr` and `PrPane` now share one `gitlabMrStateKind`, replacing three copies of
  the same state derivation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)