### PR TITLE
chore(repo): bump version to 0.1.58

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ version in the same PR that bumps the version numbers (see
 `docs/release-command.md`), before the tag is pushed: the release build fails
 if it can't find a matching `## Goodboy vX.Y.Z` heading.
 
+## Goodboy v0.1.58
+
+Deleting a session no longer leaves an orphaned worktree behind, the issue-to-PR loop closes on GitHub and GitLab alike, and Linear and GitLab issue descriptions get the same in-app editor GitHub already had.
+
+### [#1202] Deleting a session cleans up its worktree, every time
+
+Deleting a session could fail with "Directory not empty" when a dev server was still running inside its worktree: git de-registered the folder anyway and it stayed on disk forever. Closing a session now kills every process in its terminal session, not just the shell, waits for the terminals to close before touching the filesystem, retries the removal and falls back to deleting the folder directly if it still won't budge, and reports the path if it truly can't. On startup, folders git or the app lost track of are found and offered up for cleanup, never removed automatically.
+
+### [#1205] The issue-to-PR loop closes on GitHub and GitLab
+
+An issue linked to a session after its pull request was already open never got a `Closes #N` line, so it never auto-closed. Linked issues now get a "Link issue" action that adds the reference to an already open PR. On GitLab, a work item now also completes when its merge request merges, matching the behavior GitHub already had.
+
+### [#1204] Edit a Linear or GitLab issue description in place
+
+GitHub issue descriptions became editable in-app in the last release. Linear and GitLab issues now get the same editor, writing straight back to the provider.
+
+### [#1200] A resolver's verdicts survive a restart
+
+Restarting the app used to wipe a resolver's decisions on a review thread, and the "no verdicts" warning would blame the agent for threads it had actually resolved. Verdicts are now rebuilt from the session transcript on load, so a restart no longer loses them.
+
+### Smaller fixes
+
+- [#1201] The "update available" chip pulses three times, then rests, instead of forever
+- [#1198] Spawning a resolver shows a status dot instead of a spinner
+
 ## Goodboy v0.1.57
 
 One visual grammar across every screen, a provider you connect in one click, diffs side by side, and the round where a workflow's orchestrator stopped hiding what it decided.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,15 @@ if it can't find a matching `## Goodboy vX.Y.Z` heading.
 
 ## Goodboy v0.1.58
 
-Deleting a session no longer leaves an orphaned worktree behind, the issue-to-PR loop closes on GitHub and GitLab alike, and Linear and GitLab issue descriptions get the same in-app editor GitHub already had.
+Deleting a session no longer leaves an orphaned worktree behind, a new Storage section lets you see and reclaim what archived sessions cost on disk, the issue-to-PR loop closes on GitHub and GitLab alike, and Linear and GitLab issue descriptions get the same in-app editor GitHub already had.
 
 ### [#1202] Deleting a session cleans up its worktree, every time
 
 Deleting a session could fail with "Directory not empty" when a dev server was still running inside its worktree: git de-registered the folder anyway and it stayed on disk forever. Closing a session now kills every process in its terminal session, not just the shell, waits for the terminals to close before touching the filesystem, retries the removal and falls back to deleting the folder directly if it still won't budge, and reports the path if it truly can't. On startup, folders git or the app lost track of are found and offered up for cleanup, never removed automatically.
+
+### [#1203] See what archived sessions cost on disk, and reclaim it
+
+Settings gets a Storage section, above the danger zone, showing the database size and how much archived sessions' transcripts and worktrees add up to. Two explicit actions, each confirmed twice: prune archived transcripts (deletes their `turn_events` rows and vacuums the database so the file actually shrinks; the chat view of an unarchived session comes back empty, though the session's own messages stay in the database) and remove archived worktrees (drops the folders and keeps the branches, so a worktree can be recreated later). Nothing runs on a timer, nothing runs automatically.
 
 ### [#1205] The issue-to-PR loop closes on GitHub and GitLab
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goodboy/desktop",
-  "version": "0.1.57",
+  "version": "0.1.58",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -1391,7 +1391,7 @@ dependencies = [
 
 [[package]]
 name = "goodboy-desktop"
-version = "0.1.57"
+version = "0.1.58"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goodboy-desktop"
-version = "0.1.57"
+version = "0.1.58"
 description = "Goodboy desktop app"
 authors = ["Amin Khayam"]
 license = "MIT"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Goodboy",
-  "version": "0.1.57",
+  "version": "0.1.58",
   "identifier": "com.goodboy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goodboy",
-  "version": "0.1.57",
+  "version": "0.1.58",
   "private": true,
   "description": "AI workspace orchestrator. Local-first, provider-agnostic.",
   "license": "MIT",


### PR DESCRIPTION
## What

Step 1 of `docs/release.md`: bump to 0.1.58 in the four version files and add the CHANGELOG.md section the release build reads its notes from.

- `package.json`
- `apps/desktop/package.json`
- `apps/desktop/src-tauri/tauri.conf.json` (`version`)
- `apps/desktop/src-tauri/Cargo.toml` (`package.version`), plus a regenerated `apps/desktop/src-tauri/Cargo.lock` (`cargo metadata --offline`, no dependency changes beyond the `goodboy-desktop` version bump)

## Note on scope: #1203

#1203 (storage pruning section) was still open when this PR was first opened, so it was left out of the notes. It is now confirmed `MERGEABLE` with all CI green and will land on `main` before the tag, so its entry was added back in a follow-up commit, positioned right after #1202 since both are about reclaiming worktree disk space.

#1199 (release-notes plumbing + `.gitignore` for the root `target/` dir) stays excluded: it is `chore(repo)`/`ci` scope, and `docs/release-command.md` limits app-facing notes to `desktop`/`ui`/`core`.

## Version check

```
apps/desktop/src-tauri/Cargo.toml:3:version = "0.1.58"
package.json:3:  "version": "0.1.58",
apps/desktop/src-tauri/tauri.conf.json:4:  "version": "0.1.58",
apps/desktop/package.json:3:  "version": "0.1.58",
```

## Checks

- `npx tsc -p apps/desktop --noEmit`: clean
- `cd apps/desktop/src-tauri && cargo check --locked`: green (`Finished` dev profile, only a pre-existing `repo_path` dead-code warning unrelated to this change)
- Extracted the `.github/workflows/release.yml` "extract release notes" step's script and ran it locally with `GITHUB_REF_NAME=v0.1.58`. Re-ran it after adding #1203's entry. Both times it printed the `## Goodboy v0.1.58` section verbatim, correctly delimited, exit 0.

## Not in this PR

No tag, no merge, no local `main` advance. The product owner tags after merge per the runbook.