### PR TITLE
feat(desktop): approve or request changes from the pr panel

### DIFF
--- a/apps/desktop/src/features/github/components/GitHubStudio/PrActionBar.test.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/PrActionBar.test.tsx
@@ -2,11 +2,14 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import type { PullRequestState } from '@goodboy/types';
 import type { ActionBusy } from './PrActionBar';
+import type { PrVerdictSubmission } from './PrVerdictAction';
 
 type Params = {
   readonly canMerge?: boolean;
+  readonly canReview?: boolean;
   readonly busy?: ActionBusy;
   readonly onMerge?: () => Promise<void>;
+  readonly onSubmitVerdict?: (submission: PrVerdictSubmission) => void;
 };
 
 const PR = {
@@ -28,15 +31,19 @@ import { PrActionBar } from './PrActionBar';
 
 const renderActionBar = ({
   canMerge = true,
+  canReview = true,
   busy = null,
   onMerge = vi.fn(async () => undefined),
+  onSubmitVerdict = vi.fn(),
 }: Params = {}) =>
   render(
     <PrActionBar
       pr={PR}
       busy={busy}
       canMerge={canMerge}
+      canReview={canReview}
       mergeReason={canMerge ? 'squash merge this PR' : 'PR has conflicts, resolve them first'}
+      onSubmitVerdict={onSubmitVerdict}
       onMarkReady={vi.fn()}
       onConvertDraft={vi.fn()}
       onClose={vi.fn()}
@@ -65,6 +72,46 @@ describe('PrActionBar', () => {
     await waitFor(() =>
       expect(screen.queryByRole('group', { name: 'Squash merge this pull request?' })).toBeNull(),
     );
+  });
+
+  it('approves from the bar without asking for a summary', () => {
+    const onSubmitVerdict = vi.fn();
+    renderActionBar({ onSubmitVerdict });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Review' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Submit review' }));
+
+    expect(onSubmitVerdict).toHaveBeenCalledWith({ verdict: 'approve', body: '' });
+  });
+
+  it('holds request changes until a summary is written', () => {
+    const onSubmitVerdict = vi.fn();
+    renderActionBar({ onSubmitVerdict });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Review' }));
+    fireEvent.change(screen.getByRole('combobox', { name: 'Review verdict' }), {
+      target: { value: 'request_changes' },
+    });
+
+    expect(screen.getByRole('button', { name: 'Submit review' }).hasAttribute('disabled')).toBe(
+      true,
+    );
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Review summary' }), {
+      target: { value: 'split this helper' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Submit review' }));
+
+    expect(onSubmitVerdict).toHaveBeenCalledWith({
+      verdict: 'request_changes',
+      body: 'split this helper',
+    });
+  });
+
+  it('disables the review action while another write is in flight', () => {
+    renderActionBar({ busy: 'merge' });
+
+    expect(screen.getByRole('button', { name: 'Review' }).hasAttribute('disabled')).toBe(true);
   });
 
   it('keeps merge gating on the launch action', () => {

--- a/apps/desktop/src/features/github/components/GitHubStudio/PrActionBar.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/PrActionBar.tsx
@@ -2,11 +2,10 @@ import { useState } from 'react';
 import type { PullRequestState } from '@goodboy/types';
 import { cn, Divider, InlineConfirm, tintClasses, type Tone } from '@goodboy/ui';
 import { GitMerge, GitPullRequestDraft, Plus, RotateCcw, Send, XCircle } from 'lucide-react';
+import { PrVerdictAction, type PrVerdictSubmission } from './PrVerdictAction';
+import { PR_ACTION_BUTTON } from './prActionButton';
 
-export type ActionBusy = 'ready' | 'undraft' | 'merge' | 'close' | 'reopen' | null;
-
-const BTN =
-  'inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50';
+export type ActionBusy = 'ready' | 'undraft' | 'merge' | 'close' | 'reopen' | 'review' | null;
 
 const actionTone = (
   tone: Extract<Tone, 'neutral' | 'success' | 'danger' | 'primary' | 'warning'>,
@@ -27,7 +26,9 @@ type Props = {
   readonly pr: PullRequestState;
   readonly busy: ActionBusy;
   readonly canMerge: boolean;
+  readonly canReview: boolean;
   readonly mergeReason: string;
+  readonly onSubmitVerdict: (submission: PrVerdictSubmission) => void;
   readonly onMarkReady: () => void;
   readonly onConvertDraft: () => void;
   readonly onClose: () => void;
@@ -40,7 +41,9 @@ export const PrActionBar = ({
   pr,
   busy,
   canMerge,
+  canReview,
   mergeReason,
+  onSubmitVerdict,
   onMarkReady,
   onConvertDraft,
   onClose,
@@ -101,6 +104,15 @@ export const PrActionBar = ({
           </button>
         ))}
 
+      {!isTerminal && (
+        <PrVerdictAction
+          canReview={canReview}
+          isBusy={busy !== null}
+          isSubmitting={spin('review')}
+          onSubmit={onSubmitVerdict}
+        />
+      )}
+
       {!isTerminal && <Divider orientation="vertical" className="mx-0.5 h-5" />}
 
       {!isTerminal && isDraft ? (
@@ -108,7 +120,7 @@ export const PrActionBar = ({
           type="button"
           onClick={onMarkReady}
           disabled={busy !== null}
-          className={cn(BTN, TONE.success, spin('ready') && 'animate-border-pulse')}
+          className={cn(PR_ACTION_BUTTON, TONE.success, spin('ready') && 'animate-border-pulse')}
         >
           <Send size={13} aria-hidden />
           Mark ready
@@ -118,7 +130,7 @@ export const PrActionBar = ({
           type="button"
           onClick={onConvertDraft}
           disabled={busy !== null}
-          className={cn(BTN, TONE.warning, spin('undraft') && 'animate-border-pulse')}
+          className={cn(PR_ACTION_BUTTON, TONE.warning, spin('undraft') && 'animate-border-pulse')}
         >
           <GitPullRequestDraft size={13} aria-hidden />
           Convert to draft
@@ -130,7 +142,7 @@ export const PrActionBar = ({
           type="button"
           onClick={onClose}
           disabled={busy !== null}
-          className={cn(BTN, TONE.danger, spin('close') && 'animate-border-pulse')}
+          className={cn(PR_ACTION_BUTTON, TONE.danger, spin('close') && 'animate-border-pulse')}
         >
           <XCircle size={13} aria-hidden />
           Close
@@ -143,12 +155,16 @@ export const PrActionBar = ({
             type="button"
             onClick={onReopen}
             disabled={busy !== null}
-            className={cn(BTN, TONE.success, spin('reopen') && 'animate-border-pulse')}
+            className={cn(PR_ACTION_BUTTON, TONE.success, spin('reopen') && 'animate-border-pulse')}
           >
             <RotateCcw size={13} aria-hidden />
             Reopen
           </button>
-          <button type="button" onClick={onCreateNew} className={cn(BTN, TONE.primary)}>
+          <button
+            type="button"
+            onClick={onCreateNew}
+            className={cn(PR_ACTION_BUTTON, TONE.primary)}
+          >
             <Plus size={13} aria-hidden />
             Create new PR
           </button>

--- a/apps/desktop/src/features/github/components/GitHubStudio/PrDetailPanel.test.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/PrDetailPanel.test.tsx
@@ -33,6 +33,7 @@ type Store = {
   readonly closePr: ReturnType<typeof vi.fn>;
   readonly reopenPr: ReturnType<typeof vi.fn>;
   readonly requestReview: ReturnType<typeof vi.fn>;
+  readonly publishPrReview: ReturnType<typeof vi.fn>;
   readonly editPr: ReturnType<typeof vi.fn>;
   readonly spawnAgent: ReturnType<typeof vi.fn>;
   readonly selectAgent: ReturnType<typeof vi.fn>;
@@ -95,6 +96,7 @@ const h = vi.hoisted(() => {
     secondPr,
     detail,
     thread,
+    showToast: vi.fn(),
     prs: [] as ReadonlyArray<PullRequestState>,
     store: {
       sessions: [
@@ -125,6 +127,7 @@ const h = vi.hoisted(() => {
       closePr: vi.fn(async () => undefined),
       reopenPr: vi.fn(async () => undefined),
       requestReview: vi.fn(async () => undefined),
+      publishPrReview: vi.fn(async () => ({ published: 0, stale: [], failed: [] })),
       editPr: vi.fn(async () => undefined),
       spawnAgent: vi.fn(async () => 'agent-1'),
       selectAgent: vi.fn(async () => undefined),
@@ -162,8 +165,26 @@ vi.mock('../../../../shared/hooks/useSessionRoleModels', () => ({
   useSessionRoleModels: () => null,
 }));
 
+vi.mock('../../../../app/components/Toast', () => ({
+  useToast: () => ({ showToast: h.showToast }),
+}));
+
 vi.mock('./PrActionBar', () => ({
-  PrActionBar: () => <div>Pull request actions</div>,
+  PrActionBar: ({
+    onSubmitVerdict,
+  }: {
+    readonly onSubmitVerdict: (submission: { verdict: string; body: string }) => void;
+  }) => (
+    <div>
+      Pull request actions
+      <button
+        type="button"
+        onClick={() => onSubmitVerdict({ verdict: 'approve', body: 'ship it' })}
+      >
+        Approve pull request
+      </button>
+    </div>
+  ),
 }));
 
 vi.mock('./PrConversation', () => ({
@@ -207,6 +228,8 @@ beforeEach(() => {
   h.store.sessionGithubPrs = { [h.sessionId]: [h.pr] };
   h.store.sessionSelectedPrNumber = {};
   h.store.selectSessionPr.mockClear();
+  h.store.publishPrReview.mockClear();
+  h.showToast.mockClear();
 });
 
 afterEach(cleanup);
@@ -335,6 +358,24 @@ describe('PrDetailPanel', () => {
     await waitFor(() => expect(h.store.selectAgent).toHaveBeenCalledWith(h.sessionId, 'agent-1'));
     expect(h.store.setActiveLens).toHaveBeenCalledWith(h.sessionId, 'resolve');
     expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('publishes the verdict against the pull request selected in the panel', async () => {
+    h.store.sessionGithubPrs = { [h.sessionId]: [h.pr, h.secondPr] };
+    h.store.sessionSelectedPrNumber = { [h.sessionId]: h.secondPr.number };
+
+    renderPanel();
+    fireEvent.click(screen.getByRole('button', { name: 'Approve pull request' }));
+
+    await waitFor(() => expect(h.store.publishPrReview).toHaveBeenCalledOnce());
+    expect(h.store.publishPrReview).toHaveBeenCalledWith(h.sessionId, {
+      verdict: 'approve',
+      body: 'ship it',
+      target: { provider: 'github', repo: 'goodboy/goodboy', prNumber: h.secondPr.number },
+    });
+    await waitFor(() =>
+      expect(h.showToast).toHaveBeenCalledWith('success', 'Pull request approved'),
+    );
   });
 
   it('drives the active pr and switcher selection through store state', () => {

--- a/apps/desktop/src/features/github/components/GitHubStudio/PrDetailPanel.test.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/PrDetailPanel.test.tsx
@@ -127,7 +127,13 @@ const h = vi.hoisted(() => {
       closePr: vi.fn(async () => undefined),
       reopenPr: vi.fn(async () => undefined),
       requestReview: vi.fn(async () => undefined),
-      publishPrReview: vi.fn(async () => ({ published: 0, stale: [], failed: [] })),
+      publishPrReview: vi.fn(
+        async (): Promise<{
+          published: number;
+          stale: ReadonlyArray<{ id: string }>;
+          failed: ReadonlyArray<{ draft: { id: string }; error: string }>;
+        }> => ({ published: 0, stale: [], failed: [] }),
+      ),
       editPr: vi.fn(async () => undefined),
       spawnAgent: vi.fn(async () => 'agent-1'),
       selectAgent: vi.fn(async () => undefined),
@@ -376,6 +382,25 @@ describe('PrDetailPanel', () => {
     await waitFor(() =>
       expect(h.showToast).toHaveBeenCalledWith('success', 'Pull request approved'),
     );
+  });
+
+  it('never claims success when the publish reports failed comments', async () => {
+    h.store.publishPrReview.mockResolvedValueOnce({
+      published: 0,
+      stale: [],
+      failed: [{ draft: { id: 'draft-1' }, error: 'resource not accessible by integration' }],
+    });
+
+    renderPanel();
+    fireEvent.click(screen.getByRole('button', { name: 'Approve pull request' }));
+
+    await waitFor(() =>
+      expect(h.showToast).toHaveBeenCalledWith(
+        'error',
+        'Review not posted: resource not accessible by integration',
+      ),
+    );
+    expect(h.showToast).not.toHaveBeenCalledWith('success', expect.anything());
   });
 
   it('drives the active pr and switcher selection through store state', () => {

--- a/apps/desktop/src/features/github/components/GitHubStudio/PrDetailPanel.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/PrDetailPanel.tsx
@@ -377,9 +377,14 @@ export const PrDetailPanel = ({
     }
     setBusy('review');
     try {
-      await publishPrReview(sessionId, { verdict, body, target: verdictTarget });
-      showToast('success', VERDICT_TOAST[verdict]);
+      const result = await publishPrReview(sessionId, { verdict, body, target: verdictTarget });
       onMutated();
+      const failure = result.failed[0];
+      if (failure != null) {
+        showToast('error', `Review not posted: ${failure.error}`);
+        return;
+      }
+      showToast('success', VERDICT_TOAST[verdict]);
     } catch (err) {
       showToast('error', formatError(err));
     } finally {

--- a/apps/desktop/src/features/github/components/GitHubStudio/PrDetailPanel.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/PrDetailPanel.tsx
@@ -27,6 +27,7 @@ import { groupThreads, type CommentThread } from '../../comment-threads';
 import { PullRequestChip } from '../PullRequestChip';
 import { CreatePrPanel } from './CreatePrPanel';
 import { PrActionBar, type ActionBusy } from './PrActionBar';
+import type { PrVerdictSubmission } from './PrVerdictAction';
 import { PrChecks } from './PrChecks';
 import { PrConversation } from './PrConversation';
 import { ResolveBoard } from './ResolveBoard';
@@ -38,6 +39,16 @@ import { SectionBody } from './SectionBody';
 import type { PrSection } from './prSection';
 import { prSectionOptions } from './prSectionOptions';
 import { useSessionRepo } from '../../../../store/slices/worktrees/useSessionRepo';
+import { githubReviewTarget } from '../../../../store/slices/review-drafts/githubReviewTarget';
+import type { PublishPrReviewVerdict } from '../../../../store/slices/review-drafts/types';
+import { useToast } from '../../../../app/components/Toast';
+import { formatError } from '../../../../shared/lib/errors';
+
+const VERDICT_TOAST = {
+  comment: 'Comment posted on the pull request',
+  approve: 'Pull request approved',
+  request_changes: 'Changes requested on the pull request',
+} satisfies Record<PublishPrReviewVerdict, string>;
 
 type Props = {
   readonly sessionId: SessionId | null;
@@ -75,6 +86,7 @@ export const PrDetailPanel = ({
   const closePr = useAppStore((s) => s.closePr);
   const reopenPr = useAppStore((s) => s.reopenPr);
   const requestReview = useAppStore((s) => s.requestReview);
+  const publishPrReview = useAppStore((s) => s.publishPrReview);
   const spawnAgent = useAppStore((s) => s.spawnAgent);
   const selectAgent = useAppStore((s) => s.selectAgent);
   const setCurrentSession = useAppStore((s) => s.setCurrentSession);
@@ -89,6 +101,7 @@ export const PrDetailPanel = ({
     [resolverIndex],
   );
 
+  const { showToast } = useToast();
   const [busy, setBusy] = useState<ActionBusy>(null);
   const [createOpen, setCreateOpen] = useState(false);
   const [section, setSection] = useState<PrSection>('overview');
@@ -356,6 +369,23 @@ export const PrDetailPanel = ({
       : 'squash merge this PR';
   const num = activePr.number;
   const hasStateActions = !isTerminal || isClosed;
+  const verdictTarget = githubReviewTarget({ url: activePr.url, prNumber: num });
+
+  const submitVerdict = async ({ verdict, body }: PrVerdictSubmission) => {
+    if (busy != null || verdictTarget == null) {
+      return;
+    }
+    setBusy('review');
+    try {
+      await publishPrReview(sessionId, { verdict, body, target: verdictTarget });
+      showToast('success', VERDICT_TOAST[verdict]);
+      onMutated();
+    } catch (err) {
+      showToast('error', formatError(err));
+    } finally {
+      setBusy(null);
+    }
+  };
 
   const header = (
     <>
@@ -400,7 +430,9 @@ export const PrDetailPanel = ({
           pr={activePr}
           busy={busy}
           canMerge={canMerge}
+          canReview={verdictTarget != null}
           mergeReason={mergeReason}
+          onSubmitVerdict={(submission) => void submitVerdict(submission)}
           onMarkReady={() => void run('ready', () => markPrReady(sessionId, num))}
           onConvertDraft={() => void run('undraft', () => convertPrToDraft(sessionId, num))}
           onClose={() => void run('close', () => closePr(sessionId, num))}

--- a/apps/desktop/src/features/github/components/GitHubStudio/PrVerdictAction.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/PrVerdictAction.tsx
@@ -1,0 +1,98 @@
+import { useState } from 'react';
+import { Button, cn, Popover, Select, Textarea } from '@goodboy/ui';
+import { CheckCircle2 } from 'lucide-react';
+import type { PublishPrReviewVerdict } from '../../../../store/slices/review-drafts/types';
+import { PR_ACTION_BUTTON } from './prActionButton';
+
+export type PrVerdictSubmission = {
+  readonly verdict: PublishPrReviewVerdict;
+  readonly body: string;
+};
+
+type Props = {
+  readonly canReview: boolean;
+  readonly isBusy: boolean;
+  readonly isSubmitting: boolean;
+  readonly onSubmit: (submission: PrVerdictSubmission) => void;
+};
+
+export const PrVerdictAction = ({ canReview, isBusy, isSubmitting, onSubmit }: Props) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [verdict, setVerdict] = useState<PublishPrReviewVerdict>('approve');
+  const [body, setBody] = useState('');
+  const needsSummary = verdict !== 'approve';
+  const canSubmit = needsSummary === false || body.trim() !== '';
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={() => setIsOpen((open) => !open)}
+        disabled={canReview === false || isBusy}
+        aria-haspopup="dialog"
+        aria-expanded={isOpen}
+        title={
+          canReview
+            ? 'Approve or request changes on this pull request'
+            : 'Could not read the repository from the pull request link'
+        }
+        className={cn(
+          PR_ACTION_BUTTON,
+          'border-border-soft text-foreground hover:border-border hover:bg-muted/50',
+          isSubmitting && 'animate-border-pulse',
+        )}
+      >
+        <CheckCircle2 size={13} aria-hidden />
+        Review
+      </button>
+      {isOpen && (
+        <>
+          <div className="fixed inset-0 z-40" onClick={() => setIsOpen(false)} aria-hidden />
+          <Popover
+            role="dialog"
+            ariaLabel="Submit a review"
+            className="absolute left-0 z-50 mt-1 flex w-72 flex-col gap-2 p-3"
+          >
+            <Select
+              size="sm"
+              block
+              aria-label="Review verdict"
+              value={verdict}
+              onChange={(event) => setVerdict(event.target.value as PublishPrReviewVerdict)}
+            >
+              <option value="approve">Approve</option>
+              <option value="request_changes">Request changes</option>
+              <option value="comment">Comment</option>
+            </Select>
+            <Textarea
+              value={body}
+              onChange={(event) => setBody(event.target.value)}
+              placeholder="Review summary"
+              aria-label="Review summary"
+              autoGrow
+              minRows={2}
+              maxRows={6}
+              className="text-xs"
+            />
+            {canSubmit === false && (
+              <p className="text-2xs text-muted-foreground">
+                Approve is the only verdict that posts without a summary
+              </p>
+            )}
+            <Button
+              size="sm"
+              disabled={canSubmit === false}
+              onClick={() => {
+                onSubmit({ verdict, body });
+                setBody('');
+                setIsOpen(false);
+              }}
+            >
+              Submit review
+            </Button>
+          </Popover>
+        </>
+      )}
+    </div>
+  );
+};

--- a/apps/desktop/src/features/github/components/GitHubStudio/prActionButton.ts
+++ b/apps/desktop/src/features/github/components/GitHubStudio/prActionButton.ts
@@ -1,0 +1,2 @@
+export const PR_ACTION_BUTTON =
+  'inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50';

--- a/apps/desktop/src/store/slices/review-drafts/githubReviewTarget.ts
+++ b/apps/desktop/src/store/slices/review-drafts/githubReviewTarget.ts
@@ -1,0 +1,20 @@
+import type { ReviewTarget } from './resolveReviewTarget';
+
+type Params = {
+  readonly url: string;
+  readonly prNumber: number;
+};
+
+export const githubReviewTarget = ({ url, prNumber }: Params): ReviewTarget | null => {
+  try {
+    const segments = new URL(url).pathname.split('/').filter((segment) => segment.length > 0);
+    const owner = segments[0];
+    const name = segments[1];
+    if (owner == null || name == null) {
+      return null;
+    }
+    return { provider: 'github', repo: `${owner}/${name}`, prNumber };
+  } catch {
+    return null;
+  }
+};

--- a/apps/desktop/src/store/slices/review-drafts/index.test.ts
+++ b/apps/desktop/src/store/slices/review-drafts/index.test.ts
@@ -233,6 +233,28 @@ describe('review-drafts slice', () => {
     ]);
   });
 
+  it('publishes against the explicit target instead of the first linked task', async () => {
+    const secondTask: SessionExternalTask = {
+      ...githubTask,
+      externalId: '77',
+      identifier: '#77',
+      url: 'https://github.com/acme/api/pull/77',
+    };
+    const { slice } = buildHarness({
+      sessionExternalTasks: { [SESSION_ID]: [githubTask, secondTask] },
+    });
+
+    await slice.publishPrReview(SESSION_ID, {
+      verdict: 'approve',
+      body: '',
+      target: { provider: 'github', repo: 'acme/api', prNumber: 77 },
+    });
+
+    expect(ghPrDiffSpy.mock.calls[0]?.slice(0, 2)).toEqual(['acme/api', 77]);
+    expect(fetchPrNodeIdSpy.mock.calls[0]?.slice(1, 3)).toEqual(['acme/api', 77]);
+    expect(addPullRequestReviewSpy.mock.calls[0]?.[1].event).toBe('APPROVE');
+  });
+
   it('excludes stale drafts from the published review and flags them in state', async () => {
     const drafts = [makeDraft({}), makeDraft({ overrides: { id: 'draft-stale', line: 99 } })];
     const { slice, getState } = buildHarness({ reviewDrafts: { [SESSION_ID]: drafts } });

--- a/apps/desktop/src/store/slices/review-drafts/index.ts
+++ b/apps/desktop/src/store/slices/review-drafts/index.ts
@@ -19,4 +19,4 @@ export const createReviewDraftsSlice = (set: SetFn, get: GetFn) => {
 
 export { computeStaleDrafts } from './computeStaleDrafts';
 export type { AddReviewDraftInput } from './addReviewDraft';
-export type { PublishPrReviewResult, PublishPrReviewVerdict } from './types';
+export type { PublishPrReviewOpts, PublishPrReviewResult } from './types';

--- a/apps/desktop/src/store/slices/review-drafts/publishPrReview.ts
+++ b/apps/desktop/src/store/slices/review-drafts/publishPrReview.ts
@@ -24,7 +24,13 @@ import { computeStaleDrafts } from './computeStaleDrafts';
 import { resolveReviewTarget, type ReviewTarget } from './resolveReviewTarget';
 import { getSessionRepo } from '../worktrees/getSessionRepo';
 import type { SessionRepo } from '../worktrees/resolveSessionRepo';
-import type { GetFn, PublishPrReviewResult, PublishPrReviewVerdict, SetFn } from './types';
+import type {
+  GetFn,
+  PublishPrReviewOpts,
+  PublishPrReviewResult,
+  PublishPrReviewVerdict,
+  SetFn,
+} from './types';
 
 const VERDICT_EVENT = {
   comment: 'COMMENT',
@@ -205,9 +211,9 @@ const publishGitlab = async ({
 export const publishPrReview = (set: SetFn, get: GetFn) => {
   return async (
     sessionId: SessionId,
-    opts: { verdict: PublishPrReviewVerdict; body: string },
+    opts: PublishPrReviewOpts,
   ): Promise<PublishPrReviewResult> => {
-    const target = resolveReviewTarget({ get, sessionId });
+    const target = opts.target ?? resolveReviewTarget({ get, sessionId });
     if (target == null) {
       throw new Error('no linked pull request or merge request for this session');
     }

--- a/apps/desktop/src/store/slices/review-drafts/types.ts
+++ b/apps/desktop/src/store/slices/review-drafts/types.ts
@@ -1,6 +1,13 @@
 import type { PrReviewDraft } from '@goodboy/types';
+import type { ReviewTarget } from './resolveReviewTarget';
 
 export type PublishPrReviewVerdict = 'comment' | 'approve' | 'request_changes';
+
+export type PublishPrReviewOpts = {
+  readonly verdict: PublishPrReviewVerdict;
+  readonly body: string;
+  readonly target?: ReviewTarget;
+};
 
 export type PublishPrReviewResult = {
   readonly published: number;

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -87,8 +87,8 @@ import { createReviewPrsSlice } from './slices/review-prs';
 import { createReviewDraftsSlice } from './slices/review-drafts';
 import type {
   AddReviewDraftInput,
+  PublishPrReviewOpts,
   PublishPrReviewResult,
-  PublishPrReviewVerdict,
 } from './slices/review-drafts';
 import { createIntegrationsSlice } from './slices/integrations';
 import { createSidebarSlice } from './slices/sidebar';
@@ -544,10 +544,7 @@ export type AppActions = {
     agentId: AgentId,
     markers: ReadonlyArray<ExtractedReviewComment>,
   ): Promise<void>;
-  publishPrReview(
-    sessionId: SessionId,
-    opts: { verdict: PublishPrReviewVerdict; body: string },
-  ): Promise<PublishPrReviewResult>;
+  publishPrReview(sessionId: SessionId, opts: PublishPrReviewOpts): Promise<PublishPrReviewResult>;
   createMrForSession(
     sessionId: SessionId,
     opts?: { title?: string; description?: string; targetBranch?: string; draft?: boolean },


### PR DESCRIPTION
## What changed

The GitHub PR detail panel rendered the whole PR and could merge, close, reopen, and toggle draft, but had no verdict control: approving meant leaving the app for a browser tab.

- New `PrVerdictAction` in the github feature: a compact `Review` button in `PrActionBar` that opens a popover with a verdict select (Approve / Request changes / Comment) and an optional summary.
- It calls the existing `publishPrReview` store action. No new publish path, no new gh plumbing.
- `ActionBusy` gains a `review` member, so the verdict shares the same in-flight gating as merge, close, and mark-ready: while a review is posting every other write in the bar is disabled, and vice versa.
- Result feedback goes through the app toast, then the panel refreshes the PR detail.
- `BTN` in `PrActionBar` moved to `prActionButton.ts` as `PR_ACTION_BUTTON` so the new control shares the same button shape instead of copying the class string.

## The wrong-target sub-fix (mandatory, not optional)

`publishPrReview` resolved its target via `resolveReviewTarget` -> `reviewTargetFromTasks`, which picks the **first** github or gitlab external task of the session. The panel has a `PrSwitcher`: in any session with more than one linked PR, a verdict submitted from the panel would have been published to a different PR than the one on screen. Approving the wrong PR is not a cosmetic bug, so the control could not ship without this.

`publishPrReview` now takes an optional `target` on its opts (`PublishPrReviewOpts`), and the panel derives it from the selected PR URL via `githubReviewTarget`. `ReviewBoardPane` omits the param and keeps today's resolution exactly.

If the repo cannot be read from the PR link the control is rendered disabled with the reason in its title, rather than silently posting somewhere else.

## Verdict and body rules

`publishPrReview` early-returns only when there are no fresh drafts, no body, and the verdict is `comment`, so a comment-free approve already works and posts `event: APPROVE` with empty threads. The control mirrors that: Approve submits with no summary, Comment and Request changes require one (GitHub itself rejects a bodyless request-changes), with the reason shown inline.

## Failure honesty

`publishGithub` returns a `failed` list instead of throwing when fresh drafts exist, so a review that never reached GitHub still resolves. The panel reads `result.failed` and reports the error GitHub returned instead of showing a success toast. The swallow-vs-throw design of the slice is untouched, out of scope here. Pinned by a test: with a failing publish the panel must not claim success.

## Precedent

GitHub's own PR page: "Review changes" lives on the pull request, next to the merge control, not in a separate review inbox. The verdict belongs where the dev is already reading the PR.

## Tests

No test was rewritten or deleted. Every existing assertion still describes intended behavior.

Added:

- `PrActionBar.test.tsx`: approve submits without a summary; request changes stays disabled until a summary is typed, then submits with it; the Review action is disabled while another write is in flight.
- `PrDetailPanel.test.tsx`: with two PRs linked and #43 selected, the verdict publishes with `target: { provider: 'github', repo: 'goodboy/goodboy', prNumber: 43 }`. This is the wrong-target regression: without the new param it would resolve to the first linked task. A second test pins the failure path: a publish that reports failed comments never produces a success toast.
- `review-drafts/index.test.ts`: with two github tasks linked, an explicit target wins over the first one (diff fetch and node-id lookup both hit `acme/api#77`).

The `PrActionBar` mock in `PrDetailPanel.test.tsx` was extended to expose the new callback; the panel test now also mocks the toast provider, matching what `CreatePrPanel.test.tsx` already does.

## What I did NOT do

- No GitLab branch. `PrDetailPanel` is GitHub-only (it hardcodes `hostLabel="GitHub"`), so the verdict control is too. The GitLab path inside `publishPrReview` is untouched.
- Did not touch `ReviewBoardPane/PublishBar.tsx`. It is coupled to draft counts and publishing state and lives in the review feature; the new control is separate and owns its own state.
- No draft-comment surface in the panel. Staging and editing line comments still belongs to the review board. Be aware this control is not summary-only: `publishPrReview` selects drafts by session (`reviewDrafts[sessionId]`) and never filters on `draft.repo` or `draft.prNumber`, so submitting a verdict from the panel also publishes every fresh session draft that survives the staleness check. That is existing behavior of the publish path, unchanged here.
- Did not change the fetch-and-parse-the-diff step in `publishPrReview`, or the stale-draft computation.
- The control is hidden on merged and closed PRs, where a verdict has no meaning.

## Verification

`pnpm typecheck`, `pnpm test` (500 desktop files, 4334 tests), and `pnpm knip --include files,duplicates,unlisted` (the CI gate, `.github/workflows/ci.yml:58`) all pass. Bare `pnpm knip` still exits 1, with exactly the same unused-export list as before this branch (32 exports / 43 types, verified against a stashed baseline).
