### PR TITLE
fix(desktop): never close a review thread on an unknown verdict

### DIFF
--- a/apps/desktop/src/features/session/resolverThreadSettlements.test.ts
+++ b/apps/desktop/src/features/session/resolverThreadSettlements.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { PendingResolution } from '@goodboy/types';
+import type { IsoDateTime, PendingResolution, SessionId } from '@goodboy/types';
 import { resolverThreadSettlements } from './resolverThreadSettlements';
 
 const NO_PENDING: ReadonlyArray<PendingResolution> = [];
@@ -57,5 +57,29 @@ describe('resolverThreadSettlements', () => {
     expect(settlement?.kind).toBe('wontfix');
     expect(settlement?.reason).toBe('covered elsewhere');
     expect(settlement?.isClosed).toBe(true);
+  });
+
+  it('never reads a queued row without a stored verdict as resolved', () => {
+    const legacy = {
+      id: 'pending-legacy',
+      sessionId: 'session-1' as SessionId,
+      prNumber: 1,
+      threadId: 'PRRT_1',
+      commitSha: 'abcdef1234567890',
+      reply: 'legacy resolver reply',
+      outcome: null,
+      createdAt: '2026-05-28T00:00:00.000Z' as IsoDateTime,
+    } satisfies PendingResolution;
+
+    const [settlement] = resolverThreadSettlements({
+      threadIds: ['PRRT_1'],
+      outcomes: {},
+      pendingResolutions: [legacy],
+      closedThreadIds: NOTHING_CLOSED,
+    });
+
+    expect(settlement?.kind).toBe('open');
+    expect(settlement?.isQueued).toBe(true);
+    expect(settlement?.reply).toBe('legacy resolver reply');
   });
 });

--- a/apps/desktop/src/features/session/resolverThreadSettlements.ts
+++ b/apps/desktop/src/features/session/resolverThreadSettlements.ts
@@ -78,7 +78,7 @@ const fromPending = ({
   readonly resolution: PendingResolution;
   readonly isClosed: boolean;
 }): ResolverThreadSettlement => {
-  const kind = resolution.outcome ?? 'resolved';
+  const kind: ResolverThreadSettlementKind = resolution.outcome ?? 'open';
   return {
     threadId,
     kind,

--- a/apps/desktop/src/store/slices/github/index.test.ts
+++ b/apps/desktop/src/store/slices/github/index.test.ts
@@ -1451,5 +1451,175 @@ describe('store contract', () => {
       );
       expect(store.getState().sessionPendingResolutions[SESSION_ID]).toEqual([]);
     });
+
+    it('pushAllResolutions replies without closing a row that carries no verdict', async () => {
+      const store = await getStore();
+      const legacy = {
+        id: 'pending-legacy',
+        sessionId: SESSION_ID,
+        prNumber: 1,
+        threadId: 'PRRT_1',
+        commitSha: 'abcdef1234567890',
+        reply: 'legacy resolver reply',
+        outcome: null,
+        createdAt: NOW,
+      } satisfies PendingResolution;
+      store.setState({
+        workspaces: [buildWorkspace()],
+        sessions: [buildSession()],
+        sessionBranches: { [SESSION_ID]: 'ak/feat-x' },
+        sessionWorktrees: { [SESSION_ID]: ['/tmp/repo/.wt/x'] },
+        resolverThreadOutcomes: {},
+        sessionPendingResolutions: { [SESSION_ID]: [legacy] },
+        refreshSessionPrDetail: vi.fn(async () => undefined),
+      });
+      listPendingResolutionsForSessionSpy.mockResolvedValueOnce([legacy]).mockResolvedValueOnce([]);
+
+      const result = await store.getState().pushAllResolutions(SESSION_ID);
+
+      expect(resolveThreadSpy).not.toHaveBeenCalled();
+      expect(gitPushSpy).not.toHaveBeenCalled();
+      expect(addReplySpy).toHaveBeenCalledWith(
+        expect.anything(),
+        legacy.threadId,
+        expect.stringContaining(legacy.reply),
+        expect.anything(),
+      );
+      expect(result).toEqual({ pushed: false, resolved: 0, failed: 0 });
+    });
+
+    it('pushAllResolutions fails only the fixes when the push is rejected', async () => {
+      const store = await getStore();
+      const fix = {
+        id: 'pending-fix',
+        sessionId: SESSION_ID,
+        prNumber: 1,
+        threadId: 'PRRT_1',
+        commitSha: 'abcdef1234567890',
+        reply: 'fixed it',
+        outcome: 'resolved',
+        createdAt: NOW,
+      } satisfies PendingResolution;
+      const wontfix = {
+        id: 'pending-wontfix',
+        sessionId: SESSION_ID,
+        prNumber: 1,
+        threadId: 'PRRT_2',
+        commitSha: 'abcdef1234567890',
+        reply: 'the behavior is intentional',
+        outcome: 'wontfix',
+        createdAt: NOW,
+      } satisfies PendingResolution;
+      store.setState({
+        workspaces: [buildWorkspace()],
+        sessions: [buildSession()],
+        sessionBranches: { [SESSION_ID]: 'ak/feat-x' },
+        sessionWorktrees: { [SESSION_ID]: ['/tmp/repo/.wt/x'] },
+        resolverThreadOutcomes: {},
+        sessionPendingResolutions: { [SESSION_ID]: [fix, wontfix] },
+        refreshSessionPrDetail: vi.fn(async () => undefined),
+      });
+      listPendingResolutionsForSessionSpy
+        .mockResolvedValueOnce([fix, wontfix])
+        .mockResolvedValueOnce([fix]);
+      gitPushSpy.mockResolvedValueOnce({
+        stdout: '',
+        stderr: 'rejected: non-fast-forward',
+        exitCode: 1,
+      });
+
+      const result = await store.getState().pushAllResolutions(SESSION_ID);
+
+      expect(result).toEqual({ pushed: false, resolved: 1, failed: 1 });
+      expect(resolveThreadSpy).toHaveBeenCalledTimes(1);
+      expect(resolveThreadSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        wontfix.threadId,
+        expect.anything(),
+      );
+    });
+
+    it('resolveAgentThreads keeps closing after one thread throws and still refreshes', async () => {
+      const store = await getStore();
+      const refresh = vi.fn(async () => undefined);
+      store.setState({
+        workspaces: [buildWorkspace()],
+        sessions: [buildSession()],
+        sessionBranches: { [SESSION_ID]: 'ak/feat-x' },
+        sessionWorktrees: { [SESSION_ID]: ['/tmp/repo/.wt/x'] },
+        notifications: [],
+        sessionPhaseRuns: {
+          [SESSION_ID]: [
+            {
+              id: AGENT_ID,
+              sessionId: SESSION_ID,
+              ordinal: 0,
+              name: 'combined resolver',
+              status: 'completed',
+              sourceThreadIds: ['PRRT_1', 'PRRT_2'],
+            },
+          ],
+        },
+        resolverThreadOutcomes: {
+          [AGENT_ID]: {
+            PRRT_1: { kind: 'resolved', commitSha: 'abcdef1234567890' },
+            PRRT_2: { kind: 'resolved', commitSha: 'abcdef1234567890' },
+          },
+        },
+        sessionPendingResolutions: {},
+        refreshSessionPrDetail: refresh,
+      });
+      listPendingResolutionsForSessionSpy.mockResolvedValue([]);
+      resolveThreadSpy.mockRejectedValueOnce(new Error('gh api exploded'));
+
+      const didResolve = await store.getState().resolveAgentThreads(SESSION_ID, AGENT_ID);
+
+      expect(didResolve).toBe(false);
+      expect(resolveThreadSpy).toHaveBeenCalledTimes(2);
+      expect(refresh).toHaveBeenCalledOnce();
+      await vi.waitFor(() =>
+        expect(store.getState().notifications.map((entry) => entry.title)).toContain(
+          '1 thread failed to close',
+        ),
+      );
+    });
+
+    it('resolveAgentThreads skips a second run racing the same session', async () => {
+      const store = await getStore();
+      store.setState({
+        workspaces: [buildWorkspace()],
+        sessions: [buildSession()],
+        sessionBranches: { [SESSION_ID]: 'ak/feat-x' },
+        sessionWorktrees: { [SESSION_ID]: ['/tmp/repo/.wt/x'] },
+        sessionPhaseRuns: {
+          [SESSION_ID]: [
+            {
+              id: AGENT_ID,
+              sessionId: SESSION_ID,
+              ordinal: 0,
+              name: 'single resolver',
+              status: 'completed',
+              sourceThreadIds: ['PRRT_1'],
+            },
+          ],
+        },
+        resolverThreadOutcomes: {
+          [AGENT_ID]: { PRRT_1: { kind: 'resolved', commitSha: 'abcdef1234567890' } },
+        },
+        sessionPendingResolutions: {},
+        refreshSessionPrDetail: vi.fn(async () => undefined),
+      });
+      listPendingResolutionsForSessionSpy.mockResolvedValue([]);
+
+      const [first, second] = await Promise.all([
+        store.getState().resolveAgentThreads(SESSION_ID, AGENT_ID),
+        store.getState().resolveAgentThreads(SESSION_ID, AGENT_ID),
+      ]);
+
+      expect(first).toBe(true);
+      expect(second).toBe(false);
+      expect(gitPushSpy).toHaveBeenCalledTimes(1);
+      expect(resolveThreadSpy).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/apps/desktop/src/store/slices/github/loadPendingResolutions.ts
+++ b/apps/desktop/src/store/slices/github/loadPendingResolutions.ts
@@ -1,24 +1,24 @@
 import { listPendingResolutionsForSession } from '@goodboy/db';
 import type { SessionId } from '@goodboy/types';
 import { tauriDatabase } from '../../../shared/lib/db';
-import { pendingResolutionsInFlight, type GetFn, type SetFn } from './types';
+import { pendingResolutionReadsInFlight, type GetFn, type SetFn } from './types';
 
 export const loadPendingResolutions = (set: SetFn, get: GetFn) => {
   return async (sessionId: SessionId): Promise<void> => {
     if (get().sessionPendingResolutions[sessionId] !== undefined) {
       return;
     }
-    if (pendingResolutionsInFlight.has(sessionId)) {
+    if (pendingResolutionReadsInFlight.has(sessionId)) {
       return;
     }
-    pendingResolutionsInFlight.add(sessionId);
+    pendingResolutionReadsInFlight.add(sessionId);
     try {
       const rows = await listPendingResolutionsForSession({ db: tauriDatabase, sessionId });
       set((state) => ({
         sessionPendingResolutions: { ...state.sessionPendingResolutions, [sessionId]: rows },
       }));
     } finally {
-      pendingResolutionsInFlight.delete(sessionId);
+      pendingResolutionReadsInFlight.delete(sessionId);
     }
   };
 };

--- a/apps/desktop/src/store/slices/github/markThreadResolvedNoPush.ts
+++ b/apps/desktop/src/store/slices/github/markThreadResolvedNoPush.ts
@@ -1,9 +1,8 @@
-import { addReviewThreadReply, resolveReviewThread } from '@goodboy/core';
+import { resolveReviewThread } from '@goodboy/core';
 import type { SessionId } from '@goodboy/types';
 import { tauriGhRunner } from '../../../features/github/github';
-import { getSessionRepo } from '../worktrees/getSessionRepo';
-import { buildResolutionReplyBody } from './buildResolutionReplyBody';
-import { resolverReplyForThread } from './resolverReplyForThread';
+import { postThreadReply } from './postThreadReply';
+import { sessionThreadGhOptions } from './sessionThreadGhOptions';
 import type { GetFn, SetFn } from './types';
 
 type Closure = { commitSha?: string; reason?: string; reply?: string };
@@ -15,33 +14,8 @@ export const markThreadResolvedNoPush = async (
   threadId: string,
   closure?: Closure,
 ): Promise<void> => {
-  const session = get().sessions.find((s) => s.id === sessionId);
-  const repo = getSessionRepo({ get, sessionId });
-  const pr = get().sessionGithub[sessionId]?.pr ?? null;
-  const closureReply = closure?.reply?.trim();
-  const pendingReply = get()
-    .sessionPendingResolutions[sessionId]?.find((resolution) => resolution.threadId === threadId)
-    ?.reply?.trim();
-  const globalReply = resolverReplyForThread(get().resolverThreadOutcomes, threadId);
-  const reply =
-    closureReply != null && closureReply.length > 0
-      ? closureReply
-      : pendingReply != null && pendingReply.length > 0
-        ? pendingReply
-        : globalReply;
-  const replyBody = buildResolutionReplyBody(
-    reply === null ? closure : { ...closure, reply },
-    pr?.url ?? null,
-  );
-  const ghOpts = {
-    cwd: repo?.repoRoot,
-    workspaceId: session?.workspaceId,
-    memberWorkspaceId: repo?.workspaceId,
-  };
-  if (replyBody) {
-    await addReviewThreadReply(tauriGhRunner, threadId, replyBody, ghOpts);
-  }
-  await resolveReviewThread(tauriGhRunner, threadId, ghOpts);
+  await postThreadReply({ get, sessionId, threadId, closure });
+  await resolveReviewThread(tauriGhRunner, threadId, sessionThreadGhOptions({ get, sessionId }));
   set((state) => {
     const known = state.sessionResolvedThreads[sessionId] ?? [];
     if (known.includes(threadId)) {

--- a/apps/desktop/src/store/slices/github/postThreadReply.ts
+++ b/apps/desktop/src/store/slices/github/postThreadReply.ts
@@ -1,0 +1,62 @@
+import { addReviewThreadReply } from '@goodboy/core';
+import type { SessionId } from '@goodboy/types';
+import { tauriGhRunner } from '../../../features/github/github';
+import { buildResolutionReplyBody } from './buildResolutionReplyBody';
+import { resolverReplyForThread } from './resolverReplyForThread';
+import { sessionThreadGhOptions } from './sessionThreadGhOptions';
+import type { GetFn } from './types';
+
+type Closure = { commitSha?: string; reason?: string; reply?: string };
+
+type Params = {
+  readonly get: GetFn;
+  readonly sessionId: SessionId;
+  readonly threadId: string;
+  readonly closure?: Closure;
+};
+
+const firstFilled = ({
+  candidates,
+}: {
+  readonly candidates: ReadonlyArray<string | null | undefined>;
+}): string | null => {
+  for (const candidate of candidates) {
+    const text = candidate?.trim() ?? '';
+    if (text !== '') {
+      return text;
+    }
+  }
+  return null;
+};
+
+export const postThreadReply = async ({
+  get,
+  sessionId,
+  threadId,
+  closure,
+}: Params): Promise<void> => {
+  const pendingReply = get().sessionPendingResolutions[sessionId]?.find(
+    (resolution) => resolution.threadId === threadId,
+  )?.reply;
+  const reply = firstFilled({
+    candidates: [
+      closure?.reply,
+      pendingReply,
+      resolverReplyForThread(get().resolverThreadOutcomes, threadId),
+    ],
+  });
+  const pr = get().sessionGithub[sessionId]?.pr ?? null;
+  const replyBody = buildResolutionReplyBody(
+    reply === null ? closure : { ...closure, reply },
+    pr?.url ?? null,
+  );
+  if (replyBody === null) {
+    return;
+  }
+  await addReviewThreadReply(
+    tauriGhRunner,
+    threadId,
+    replyBody,
+    sessionThreadGhOptions({ get, sessionId }),
+  );
+};

--- a/apps/desktop/src/store/slices/github/pushAllResolutions.ts
+++ b/apps/desktop/src/store/slices/github/pushAllResolutions.ts
@@ -1,10 +1,12 @@
 import { deletePendingResolution, listPendingResolutionsForSession } from '@goodboy/db';
-import type { SessionId } from '@goodboy/types';
+import type { PendingResolutionOutcome, SessionId } from '@goodboy/types';
 import { tauriDatabase } from '../../../shared/lib/db';
 import { formatError } from '../../../shared/lib/errors';
 import { markThreadResolvedNoPush } from './markThreadResolvedNoPush';
+import { postThreadReply } from './postThreadReply';
 import { pushSessionBranch } from './pushSessionBranch';
 import { resolverOutcomeForThread } from './resolverOutcomeForThread';
+import { withResolutionLock } from './withResolutionLock';
 import type { GetFn, SetFn } from './types';
 
 export type PushAllResult = {
@@ -14,93 +16,140 @@ export type PushAllResult = {
 };
 
 export const pushAllResolutions = (set: SetFn, get: GetFn) => {
-  return async (sessionId: SessionId): Promise<PushAllResult> => {
-    const session = get().sessions.find((s) => s.id === sessionId);
-    const workspace = session
-      ? get().workspaces.find((w) => w.id === session.workspaceId)
-      : undefined;
-    const notifyTarget = { sessionId, ...(workspace && { workspaceId: workspace.id }) };
-
-    const pending = await listPendingResolutionsForSession({ db: tauriDatabase, sessionId });
-    if (pending.length === 0) {
-      return { pushed: false, resolved: 0, failed: 0 };
-    }
-
-    const inMemoryOutcomes = pending.map((resolution) =>
-      resolverOutcomeForThread({
-        outcomes: get().resolverThreadOutcomes,
-        threadId: resolution.threadId,
-      }),
-    );
-    const shouldPush = pending.some((resolution, index) => {
-      const outcome = inMemoryOutcomes[index];
-      return (outcome?.kind ?? resolution.outcome ?? 'resolved') === 'resolved';
-    });
-    if (shouldPush) {
-      const push = await pushSessionBranch(get, sessionId);
-      if (!push.ok) {
+  return async (sessionId: SessionId): Promise<PushAllResult> =>
+    withResolutionLock<PushAllResult>({
+      sessionId,
+      onBusy: () => {
         void get().emitNotification(
           'error',
-          'error',
-          'push failed, comments left unresolved',
-          push.error,
-          notifyTarget,
+          'warning',
+          'resolve already running',
+          'another resolve is still working on this session, so nothing was pushed.',
+          { sessionId },
         );
-        return { pushed: false, resolved: 0, failed: pending.length };
-      }
-    }
-
-    let resolved = 0;
-    let failed = 0;
-    let lastError = '';
-    for (const [index, resolution] of pending.entries()) {
-      try {
-        const inMemoryOutcome = inMemoryOutcomes[index];
-        const outcome = inMemoryOutcome?.kind ?? resolution.outcome ?? 'resolved';
-        if (outcome === 'resolved') {
-          await markThreadResolvedNoPush(set, get, sessionId, resolution.threadId, {
-            commitSha: resolution.commitSha,
-            reply: resolution.reply ?? undefined,
-          });
-        }
-        if (outcome === 'wontfix') {
-          await markThreadResolvedNoPush(set, get, sessionId, resolution.threadId, {
-            reason: inMemoryOutcome?.kind === 'wontfix' ? inMemoryOutcome.reason : undefined,
-            reply: resolution.reply ?? undefined,
-          });
-        }
-        if (outcome === 'analyzed') {
-          await markThreadResolvedNoPush(set, get, sessionId, resolution.threadId, {
-            reply: resolution.reply ?? undefined,
-          });
-        }
-        await deletePendingResolution({
-          db: tauriDatabase,
+        return { pushed: false, resolved: 0, failed: 0 };
+      },
+      run: async () => {
+        const session = get().sessions.find((candidate) => candidate.id === sessionId);
+        const workspace =
+          session !== undefined
+            ? get().workspaces.find((candidate) => candidate.id === session.workspaceId)
+            : undefined;
+        const notifyTarget = {
           sessionId,
-          threadId: resolution.threadId,
-        });
-        resolved += 1;
-      } catch (err) {
-        failed += 1;
-        lastError = formatError(err);
-      }
-    }
+          ...(workspace !== undefined && { workspaceId: workspace.id }),
+        };
 
-    const rows = await listPendingResolutionsForSession({ db: tauriDatabase, sessionId });
-    set((state) => ({
-      sessionPendingResolutions: { ...state.sessionPendingResolutions, [sessionId]: rows },
-    }));
-    await get().refreshSessionPrDetail(sessionId, { force: true });
+        const pending = await listPendingResolutionsForSession({ db: tauriDatabase, sessionId });
+        if (pending.length === 0) {
+          return { pushed: false, resolved: 0, failed: 0 };
+        }
 
-    if (failed > 0) {
-      void get().emitNotification(
-        'error',
-        failed === pending.length ? 'error' : 'warning',
-        `pushed, but ${failed} comment${failed === 1 ? '' : 's'} failed to resolve`,
-        lastError || 'the branch was pushed; retry to resolve the remaining threads',
-        notifyTarget,
-      );
-    }
-    return { pushed: shouldPush, resolved, failed };
-  };
+        const inMemoryOutcomes = pending.map((resolution) =>
+          resolverOutcomeForThread({
+            outcomes: get().resolverThreadOutcomes,
+            threadId: resolution.threadId,
+          }),
+        );
+        const outcomes = pending.map(
+          (resolution, index): PendingResolutionOutcome | null =>
+            inMemoryOutcomes[index]?.kind ?? resolution.outcome ?? null,
+        );
+
+        const pushNeeded = outcomes.filter((outcome) => outcome === 'resolved').length;
+        let pushed = false;
+        let blocked = 0;
+        if (pushNeeded > 0) {
+          const push = await pushSessionBranch(get, sessionId);
+          pushed = push.ok;
+          if (!push.ok) {
+            blocked = pushNeeded;
+            void get().emitNotification(
+              'error',
+              'error',
+              'push failed, comments left unresolved',
+              push.error,
+              notifyTarget,
+            );
+          }
+        }
+
+        let resolved = 0;
+        let commented = 0;
+        let failed = 0;
+        let lastError = '';
+        for (const [index, resolution] of pending.entries()) {
+          const outcome = outcomes[index] ?? null;
+          if (outcome === 'resolved' && !pushed) {
+            continue;
+          }
+          try {
+            const inMemoryOutcome = inMemoryOutcomes[index];
+            if (outcome === null) {
+              await postThreadReply({
+                get,
+                sessionId,
+                threadId: resolution.threadId,
+                closure: { ...(resolution.reply !== null && { reply: resolution.reply }) },
+              });
+              commented += 1;
+            }
+            if (outcome === 'resolved') {
+              await markThreadResolvedNoPush(set, get, sessionId, resolution.threadId, {
+                commitSha: resolution.commitSha,
+                reply: resolution.reply ?? undefined,
+              });
+              resolved += 1;
+            }
+            if (outcome === 'wontfix') {
+              await markThreadResolvedNoPush(set, get, sessionId, resolution.threadId, {
+                reason: inMemoryOutcome?.kind === 'wontfix' ? inMemoryOutcome.reason : undefined,
+                reply: resolution.reply ?? undefined,
+              });
+              resolved += 1;
+            }
+            if (outcome === 'analyzed') {
+              await markThreadResolvedNoPush(set, get, sessionId, resolution.threadId, {
+                reply: resolution.reply ?? undefined,
+              });
+              resolved += 1;
+            }
+            await deletePendingResolution({
+              db: tauriDatabase,
+              sessionId,
+              threadId: resolution.threadId,
+            });
+          } catch (err) {
+            failed += 1;
+            lastError = formatError(err);
+          }
+        }
+
+        const rows = await listPendingResolutionsForSession({ db: tauriDatabase, sessionId });
+        set((state) => ({
+          sessionPendingResolutions: { ...state.sessionPendingResolutions, [sessionId]: rows },
+        }));
+        await get().refreshSessionPrDetail(sessionId, { force: true });
+
+        if (failed > 0) {
+          void get().emitNotification(
+            'error',
+            resolved === 0 ? 'error' : 'warning',
+            `${failed} comment${failed === 1 ? '' : 's'} failed to resolve`,
+            lastError !== '' ? lastError : 'retry to resolve the remaining threads.',
+            notifyTarget,
+          );
+        }
+        if (commented > 0) {
+          void get().emitNotification(
+            'error',
+            'warning',
+            `${commented} comment${commented === 1 ? '' : 's'} left open`,
+            'no verdict was recorded, so the reply went out and the thread stays open on GitHub.',
+            notifyTarget,
+          );
+        }
+        return { pushed, resolved, failed: failed + blocked };
+      },
+    });
 };

--- a/apps/desktop/src/store/slices/github/queueResolution.ts
+++ b/apps/desktop/src/store/slices/github/queueResolution.ts
@@ -29,7 +29,7 @@ export const queueResolution = (set: SetFn, get: GetFn) => {
       threadId,
       commitSha,
       reply: reply === undefined ? (outcome?.reply ?? null) : reply,
-      outcome: explicitOutcome === undefined ? (outcome?.kind ?? null) : explicitOutcome,
+      outcome: explicitOutcome ?? outcome?.kind ?? null,
     });
     const rows = await listPendingResolutionsForSession({ db: tauriDatabase, sessionId });
     set((state) => ({

--- a/apps/desktop/src/store/slices/github/resolveAgentThreads.ts
+++ b/apps/desktop/src/store/slices/github/resolveAgentThreads.ts
@@ -8,6 +8,7 @@ import { tauriDatabase } from '../../../shared/lib/db';
 import { formatError } from '../../../shared/lib/errors';
 import { markThreadResolvedNoPush } from './markThreadResolvedNoPush';
 import { pushSessionBranch } from './pushSessionBranch';
+import { withResolutionLock } from './withResolutionLock';
 import type { GetFn, SetFn } from './types';
 
 type Closure = {
@@ -36,124 +37,158 @@ const hasContent = ({ closure }: { readonly closure: Closure }): boolean =>
   closure.commitSha !== undefined || closure.reason !== undefined || closure.reply !== undefined;
 
 export const resolveAgentThreads = (set: SetFn, get: GetFn) => {
-  return async (sessionId: SessionId, agentId: AgentId): Promise<boolean> => {
-    const agent = get().sessionPhaseRuns[sessionId]?.find((candidate) => candidate.id === agentId);
-    if (agent === undefined) {
-      void get().emitNotification(
-        'error',
-        'error',
-        'resolve threads failed',
-        'the resolver is no longer loaded, so its threads were left open',
-        { sessionId },
-      );
-      return false;
-    }
-    const session = get().sessions.find((candidate) => candidate.id === sessionId);
-    const workspace = session
-      ? get().workspaces.find((candidate) => candidate.id === session.workspaceId)
-      : undefined;
-    const notifyTarget = {
+  return async (sessionId: SessionId, agentId: AgentId): Promise<boolean> =>
+    withResolutionLock<boolean>({
       sessionId,
-      ...(workspace !== undefined && { workspaceId: workspace.id }),
-    };
-    const outcomes = get().resolverThreadOutcomes[agentId] ?? {};
-    const persisted = await listPendingResolutionsForSession({ db: tauriDatabase, sessionId });
-    const threadIds = [...new Set([...agentThreadIds(agent), ...Object.keys(outcomes)])];
-    if (threadIds.length === 0) {
-      void get().emitNotification(
-        'error',
-        'error',
-        'nothing to resolve',
-        'this resolver owns no review thread, so nothing was closed on GitHub',
-        notifyTarget,
-      );
-      return false;
-    }
-    const settlements = resolverThreadSettlements({
-      threadIds,
-      outcomes,
-      pendingResolutions: persisted,
-      closedThreadIds: closedThreadIds({
-        comments: get().sessionGithub[sessionId]?.detail?.comments ?? [],
-        ledger: get().sessionResolvedThreads[sessionId] ?? [],
-      }),
-    });
-    const targets = settlements.flatMap((settlement): ReadonlyArray<Target> => {
-      if (settlement.isClosed || settlement.kind === 'open') {
-        return [];
-      }
-      const closure = settlementClosure({ settlement });
-      if (!hasContent({ closure })) {
-        return [];
-      }
-      return [
-        { threadId: settlement.threadId, closure, shouldPush: settlement.kind === 'resolved' },
-      ];
-    });
-    const alreadyClosed = settlements.filter((settlement) => settlement.isClosed).length;
-    const skipped = threadIds.length - targets.length - alreadyClosed;
-    if (targets.length === 0) {
-      void get().emitNotification(
-        'error',
-        'error',
-        'nothing to resolve',
-        skipped === 0
-          ? 'every thread of this resolver is already closed on GitHub'
-          : 'no thread of this resolver carries a resolution yet, so nothing was closed on GitHub',
-        notifyTarget,
-      );
-      return false;
-    }
-    const shouldPush = targets.some((target) => target.shouldPush);
-    if (shouldPush) {
-      const push = await pushSessionBranch(get, sessionId);
-      if (!push.ok) {
-        void get().emitNotification(
-          'error',
-          'error',
-          'push failed, threads left open',
-          push.error,
-          notifyTarget,
-        );
-        return false;
-      }
-    }
-    try {
-      for (const target of targets) {
-        await markThreadResolvedNoPush(set, get, sessionId, target.threadId, target.closure);
-        await deletePendingResolution({
-          db: tauriDatabase,
-          sessionId,
-          threadId: target.threadId,
-        });
-      }
-      const pending = await listPendingResolutionsForSession({ db: tauriDatabase, sessionId });
-      set((state) => ({
-        sessionPendingResolutions: {
-          ...state.sessionPendingResolutions,
-          [sessionId]: pending,
-        },
-      }));
-      await get().refreshSessionPrDetail(sessionId, { force: true });
-      if (skipped > 0) {
+      onBusy: () => {
         void get().emitNotification(
           'error',
           'warning',
-          `${skipped} thread${skipped === 1 ? '' : 's'} left open`,
-          'they carry no resolution yet, so only the settled threads were closed on GitHub',
-          notifyTarget,
+          'resolve already running',
+          'another resolve is still working on this session, so these threads were left alone.',
+          { sessionId },
         );
-      }
-      return true;
-    } catch (error) {
-      void get().emitNotification(
-        'error',
-        'error',
-        'resolve threads failed',
-        formatError(error),
-        notifyTarget,
-      );
-      return false;
-    }
-  };
+        return false;
+      },
+      run: async () => {
+        const agent = get().sessionPhaseRuns[sessionId]?.find(
+          (candidate) => candidate.id === agentId,
+        );
+        if (agent === undefined) {
+          void get().emitNotification(
+            'error',
+            'error',
+            'resolve threads failed',
+            'the resolver is no longer loaded, so its threads were left open',
+            { sessionId },
+          );
+          return false;
+        }
+        const session = get().sessions.find((candidate) => candidate.id === sessionId);
+        const workspace =
+          session !== undefined
+            ? get().workspaces.find((candidate) => candidate.id === session.workspaceId)
+            : undefined;
+        const notifyTarget = {
+          sessionId,
+          ...(workspace !== undefined && { workspaceId: workspace.id }),
+        };
+        const outcomes = get().resolverThreadOutcomes[agentId] ?? {};
+        const persisted = await listPendingResolutionsForSession({ db: tauriDatabase, sessionId });
+        const threadIds = [...new Set([...agentThreadIds(agent), ...Object.keys(outcomes)])];
+        if (threadIds.length === 0) {
+          void get().emitNotification(
+            'error',
+            'error',
+            'nothing to resolve',
+            'this resolver owns no review thread, so nothing was closed on GitHub',
+            notifyTarget,
+          );
+          return false;
+        }
+        const settlements = resolverThreadSettlements({
+          threadIds,
+          outcomes,
+          pendingResolutions: persisted,
+          closedThreadIds: closedThreadIds({
+            comments: get().sessionGithub[sessionId]?.detail?.comments ?? [],
+            ledger: get().sessionResolvedThreads[sessionId] ?? [],
+          }),
+        });
+        const targets = settlements.flatMap((settlement): ReadonlyArray<Target> => {
+          if (settlement.isClosed || settlement.kind === 'open') {
+            return [];
+          }
+          const closure = settlementClosure({ settlement });
+          if (!hasContent({ closure })) {
+            return [];
+          }
+          return [
+            { threadId: settlement.threadId, closure, shouldPush: settlement.kind === 'resolved' },
+          ];
+        });
+        const alreadyClosed = settlements.filter((settlement) => settlement.isClosed).length;
+        const skipped = threadIds.length - targets.length - alreadyClosed;
+        if (targets.length === 0) {
+          void get().emitNotification(
+            'error',
+            'error',
+            'nothing to resolve',
+            skipped === 0
+              ? 'every thread of this resolver is already closed on GitHub'
+              : 'no thread of this resolver carries a resolution yet, so nothing was closed on GitHub',
+            notifyTarget,
+          );
+          return false;
+        }
+        const shouldPush = targets.some((target) => target.shouldPush);
+        if (shouldPush) {
+          const push = await pushSessionBranch(get, sessionId);
+          if (!push.ok) {
+            void get().emitNotification(
+              'error',
+              'error',
+              'push failed, threads left open',
+              push.error,
+              notifyTarget,
+            );
+            return false;
+          }
+        }
+        let closed = 0;
+        let failed = 0;
+        let lastError = '';
+        for (const target of targets) {
+          try {
+            await markThreadResolvedNoPush(set, get, sessionId, target.threadId, target.closure);
+            await deletePendingResolution({
+              db: tauriDatabase,
+              sessionId,
+              threadId: target.threadId,
+            });
+            closed += 1;
+          } catch (error) {
+            failed += 1;
+            lastError = formatError(error);
+          }
+        }
+        try {
+          const pending = await listPendingResolutionsForSession({ db: tauriDatabase, sessionId });
+          set((state) => ({
+            sessionPendingResolutions: {
+              ...state.sessionPendingResolutions,
+              [sessionId]: pending,
+            },
+          }));
+          await get().refreshSessionPrDetail(sessionId, { force: true });
+        } catch (error) {
+          void get().emitNotification(
+            'error',
+            'warning',
+            'the pending list is stale',
+            formatError(error),
+            notifyTarget,
+          );
+        }
+        if (failed > 0) {
+          void get().emitNotification(
+            'error',
+            closed === 0 ? 'error' : 'warning',
+            `${failed} thread${failed === 1 ? '' : 's'} failed to close`,
+            `${closed} closed on GitHub. ${lastError}`,
+            notifyTarget,
+          );
+        }
+        if (skipped > 0) {
+          void get().emitNotification(
+            'error',
+            'warning',
+            `${skipped} thread${skipped === 1 ? '' : 's'} left open`,
+            'they carry no resolution yet, so only the settled threads were closed on GitHub',
+            notifyTarget,
+          );
+        }
+        return failed === 0;
+      },
+    });
 };

--- a/apps/desktop/src/store/slices/github/resolveGithubThread.ts
+++ b/apps/desktop/src/store/slices/github/resolveGithubThread.ts
@@ -2,51 +2,72 @@ import type { SessionId } from '@goodboy/types';
 import { formatError } from '../../../shared/lib/errors';
 import { markThreadResolvedNoPush } from './markThreadResolvedNoPush';
 import { pushSessionBranch } from './pushSessionBranch';
+import { withResolutionLock } from './withResolutionLock';
 import type { GetFn, SetFn } from './types';
 
 type Params = { commitSha?: string; reason?: string; reply?: string };
 
 export const resolveGithubThread = (set: SetFn, get: GetFn) => {
-  return async (sessionId: SessionId, threadId: string, closure?: Params): Promise<boolean> => {
-    const session = get().sessions.find((s) => s.id === sessionId);
-    if (!session) {
-      void get().emitNotification(
-        'error',
-        'error',
-        'resolve thread failed',
-        'the session is no longer loaded, so the thread was left open',
-        { sessionId },
-      );
-      return false;
-    }
-    const workspace = get().workspaces.find((w) => w.id === session.workspaceId);
-    const notifyTarget = { sessionId, ...(workspace && { workspaceId: workspace.id }) };
-    try {
-      if (closure?.commitSha) {
-        const push = await pushSessionBranch(get, sessionId);
-        if (!push.ok) {
+  return async (sessionId: SessionId, threadId: string, closure?: Params): Promise<boolean> =>
+    withResolutionLock<boolean>({
+      sessionId,
+      onBusy: () => {
+        void get().emitNotification(
+          'error',
+          'warning',
+          'resolve already running',
+          'another resolve is still working on this session, so this thread was left alone.',
+          { sessionId },
+        );
+        return false;
+      },
+      run: async () => {
+        const session = get().sessions.find((candidate) => candidate.id === sessionId);
+        if (session === undefined) {
           void get().emitNotification(
             'error',
             'error',
-            'push failed, thread left open',
-            push.error,
+            'resolve thread failed',
+            'the session is no longer loaded, so the thread was left open',
+            { sessionId },
+          );
+          return false;
+        }
+        const workspace = get().workspaces.find(
+          (candidate) => candidate.id === session.workspaceId,
+        );
+        const notifyTarget = {
+          sessionId,
+          ...(workspace !== undefined && { workspaceId: workspace.id }),
+        };
+        try {
+          const commitSha = closure?.commitSha ?? '';
+          if (commitSha !== '') {
+            const push = await pushSessionBranch(get, sessionId);
+            if (!push.ok) {
+              void get().emitNotification(
+                'error',
+                'error',
+                'push failed, thread left open',
+                push.error,
+                notifyTarget,
+              );
+              return false;
+            }
+          }
+          await markThreadResolvedNoPush(set, get, sessionId, threadId, closure);
+          await get().refreshSessionPrDetail(sessionId, { force: true });
+          return true;
+        } catch (err) {
+          void get().emitNotification(
+            'error',
+            'error',
+            'resolve thread failed',
+            formatError(err),
             notifyTarget,
           );
           return false;
         }
-      }
-      await markThreadResolvedNoPush(set, get, sessionId, threadId, closure);
-      await get().refreshSessionPrDetail(sessionId, { force: true });
-      return true;
-    } catch (err) {
-      void get().emitNotification(
-        'error',
-        'error',
-        'resolve thread failed',
-        formatError(err),
-        notifyTarget,
-      );
-      return false;
-    }
-  };
+      },
+    });
 };

--- a/apps/desktop/src/store/slices/github/sessionThreadGhOptions.ts
+++ b/apps/desktop/src/store/slices/github/sessionThreadGhOptions.ts
@@ -1,0 +1,18 @@
+import type { SessionId } from '@goodboy/types';
+import { getSessionRepo } from '../worktrees/getSessionRepo';
+import type { GetFn } from './types';
+
+type Params = {
+  readonly get: GetFn;
+  readonly sessionId: SessionId;
+};
+
+export const sessionThreadGhOptions = ({ get, sessionId }: Params) => {
+  const session = get().sessions.find((candidate) => candidate.id === sessionId);
+  const repo = getSessionRepo({ get, sessionId });
+  return {
+    cwd: repo?.repoRoot,
+    workspaceId: session?.workspaceId,
+    memberWorkspaceId: repo?.workspaceId,
+  };
+};

--- a/apps/desktop/src/store/slices/github/types.ts
+++ b/apps/desktop/src/store/slices/github/types.ts
@@ -2,4 +2,4 @@ import type { SessionId } from '@goodboy/types';
 
 export type { SetFn, GetFn } from '../../slice-types';
 
-export const pendingResolutionsInFlight = new Set<SessionId>();
+export const pendingResolutionReadsInFlight = new Set<SessionId>();

--- a/apps/desktop/src/store/slices/github/withResolutionLock.ts
+++ b/apps/desktop/src/store/slices/github/withResolutionLock.ts
@@ -1,0 +1,21 @@
+import type { SessionId } from '@goodboy/types';
+
+const resolutionWritesInFlight = new Set<SessionId>();
+
+type Params<T> = {
+  readonly sessionId: SessionId;
+  readonly onBusy: () => T;
+  readonly run: () => Promise<T>;
+};
+
+export const withResolutionLock = async <T>({ sessionId, onBusy, run }: Params<T>): Promise<T> => {
+  if (resolutionWritesInFlight.has(sessionId)) {
+    return onBusy();
+  }
+  resolutionWritesInFlight.add(sessionId);
+  try {
+    return await run();
+  } finally {
+    resolutionWritesInFlight.delete(sessionId);
+  }
+};


### PR DESCRIPTION
## What

Four fixes on the resolve engine, one concern: a queued resolution must never close a GitHub review thread that nobody settled.

### B1, the data-affecting one: an unknown verdict closed the thread

`outcome` was read with a `?? 'resolved'` fallback in four places, so a row with no verdict was treated as a fix and the thread was resolved on GitHub.

Why it was reachable, not theoretical: m088 added the column with `ALTER TABLE ... ADD COLUMN outcome TEXT` and no default, so every row written before that migration is NULL. `toOutcome()` in the query layer also returns `null` for any string it does not recognize. Those rows walked straight into the fallback.

- `pushAllResolutions.ts`: `shouldPush` no longer counts an unknown outcome as a fix, and the write-back loop degrades an unknown outcome to comment-only. The queued reply goes out, the thread stays open on GitHub, and the user gets a toast saying so.
- `resolverThreadSettlements.ts`: a queued row with no stored verdict now settles as `open` instead of `resolved`. It keeps its `isQueued` flag and its reply, so the UI still shows it as queued and asks the resolver for a verdict, but no bulk action closes it.
- `queueResolution.ts`: `explicitOutcome ?? outcome?.kind ?? null`, so a caller passing `null` no longer erases a verdict the store already knows. Fewer unknown rows written from here on.

The union `PendingResolutionOutcome` is untouched: `null` was already the unknown sentinel. No exhaustive switch exists over these kinds (consumers use `??` chains), so this is a logic-path change only.

Precedent: on GitHub, resolving a conversation is an explicit per-thread act with a per-item error state. It is never a default.

### B2, partial failure was invisible

`resolveAgentThreads` wrapped the entire write-back in one try/catch: the target loop, the pending refresh, and the skipped-notification. One throw on target N abandoned every remaining target and skipped the refresh, so threads already closed on GitHub kept showing as pending locally, and the toast said nothing about what had succeeded.

Now: per-item try/catch inside the loop, the pending refresh and PR detail refresh run outside it so they always happen, and a failure emits `N thread(s) failed to close` with how many did close. `pushAllResolutions` already had correct per-item handling and was used as the in-repo model; its loop is unchanged in shape.

### B6, failure count was over-scoped

If any queued item was a fix, `pushAllResolutions` pushed the branch, and a rejected push returned `failed: pending.length`, marking `wontfix` and `analyzed` items failed even though they never needed the push.

Now only the push-needing items are counted as failed, and everything that does not depend on the push is processed normally.

### B4, no guard on the destructive path

`pushAllResolutions`, `resolveAgentThreads` and `resolveGithubThread` each list-then-delete `pending_resolutions` with no in-flight guard, so two UI entry points on the same session both read the same row before either deleted it and the comment double-posted.

All three now run inside `withResolutionLock`, which keeps its own `Set<SessionId>`. To be explicit: this is **not** `pendingResolutionsInFlight` from `loadPendingResolutions.ts`. That set dedupes concurrent reads and cannot serialize writes. It has been renamed to `pendingResolutionReadsInFlight` so the two are never confused again.

## Supporting refactor

`markThreadResolvedNoPush` posts a reply and then resolves. Comment-only needs the first half without the second, so the reply chain moved to `postThreadReply.ts` and the gh options to `sessionThreadGhOptions.ts`. `markThreadResolvedNoPush` keeps its signature and its behavior.

## Not in this PR

The reply-double-post-on-retry fix is deliberately cut. It needs a `pending_resolutions` migration for a reply-posted flag, a `PendingResolution` type change, and a `markThreadResolvedNoPush` signature threaded through three callers, and `resolveGithubThread` does not always have a persisted row to key the flag off. **No migration here: m104 stays free.**

## Tests

Five added, one per sub-fix plus the settlement layer. No existing test was rewritten or weakened: none of them covered the `?? 'resolved'` default, the failed-count scoping, or concurrency.

- `pushAllResolutions replies without closing a row that carries no verdict`: the B1 proof. A legacy NULL-outcome row posts its reply, never calls `resolveReviewThread`, and never pushes. Verified to fail against the old fallback before the fix landed.
- `never reads a queued row without a stored verdict as resolved`: same guarantee at the settlement layer.
- `pushAllResolutions fails only the fixes when the push is rejected`: a rejected push blocks the one fix and still closes the `wontfix` item.
- `resolveAgentThreads keeps closing after one thread throws and still refreshes`: first target throws, second still closes, refresh still runs, toast reports the split.
- `resolveAgentThreads skips a second run racing the same session`: two concurrent calls, one push, one resolve, the second returns false.

## Test plan

```
pnpm typecheck   5 successful, 5 total
pnpm test        500 files, 4333 tests passed
pnpm knip        exit 1
```

`pnpm knip` is red on the base commit too (32 unused exports, 43 unused exported types, all pre-existing and unrelated). Verified by stashing this branch and re-running on the clean tree: byte-identical findings, this change adds none.
