### PR TITLE
fix(desktop): gate manual workflow starts behind the block confirm

### DIFF
--- a/apps/desktop/src/features/workflows/components/WorkflowNextStepCta/index.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowNextStepCta/index.tsx
@@ -9,6 +9,7 @@ import { resolveStepRouting } from '../../resolveStepRouting';
 import { RoutingBadge } from '../../../../shared/components/RoutingBadge';
 import type { WorkflowBlockReason } from '../../advanceGate';
 import { WORKFLOW_BLOCK_COPY } from '../../blockCopy';
+import { useStartAnywayConfirm } from '../../useStartAnywayConfirm';
 import { CONCEPT_ICONS } from '../../../../shared/components/conceptIcons';
 
 export type Props = {
@@ -68,12 +69,20 @@ export const WorkflowNextStepCta = ({
   roleModels = null,
 }: Props) => {
   const [busy, setBusy] = useState(false);
-  const [pendingConfirm, setPendingConfirm] = useState(false);
   const [pendingForce, setPendingForce] = useState(false);
   const chain = useMemo(() => classifyWorkflowChain(workflow, runs), [workflow, runs]);
   const next = chain.kind === 'step' ? chain.step : null;
   const kind = useMemo(() => (next ? inferAgentKindFromName(next.name) : 'generic'), [next]);
   const routing = resolveStepRouting({ step: next, kind, roleModels });
+  const advance = useStartAnywayConfirm({
+    blockReason,
+    onStart: async () => {
+      if (next == null) {
+        return;
+      }
+      await onAdvance(next, routing.model, next.verbosity);
+    },
+  });
   const doForce = async () => {
     if (busy) {
       return;
@@ -128,31 +137,12 @@ export const WorkflowNextStepCta = ({
     return null;
   }
   const stepVerbosity = next.verbosity;
-  const doAdvance = async () => {
-    if (busy) {
-      return;
-    }
-    setBusy(true);
-    setPendingConfirm(false);
-    try {
-      await onAdvance(next, routing.model, stepVerbosity);
-    } finally {
-      setBusy(false);
-    }
-  };
-  const onClick = () => {
-    if (blockReason != null) {
-      setPendingConfirm(true);
-      return;
-    }
-    void doAdvance();
-  };
   return (
     <div className={cn('relative', className)}>
       <button
         type="button"
-        onClick={onClick}
-        disabled={busy}
+        onClick={advance.onTrigger}
+        disabled={advance.isBusy}
         data-testid="workflow-next-step-cta"
         title={
           blockReason != null
@@ -189,17 +179,17 @@ export const WorkflowNextStepCta = ({
           </span>
         ) : null}
       </button>
-      {pendingConfirm && blockReason != null ? (
+      {advance.isConfirming ? (
         <InlineConfirm
           role="alert"
           icon={<AlertTriangle size={12} />}
-          title="Start the next agent anyway?"
-          description={WORKFLOW_BLOCK_COPY[blockReason]}
-          confirmLabel="Start anyway"
-          cancelLabel="Wait"
-          isBusy={busy}
-          onConfirm={() => void doAdvance()}
-          onCancel={() => setPendingConfirm(false)}
+          title={advance.title}
+          description={advance.description}
+          confirmLabel={advance.confirmLabel}
+          cancelLabel={advance.cancelLabel}
+          isBusy={advance.isBusy}
+          onConfirm={advance.onConfirm}
+          onCancel={advance.onCancel}
           className="absolute right-0 top-full z-40 mt-1 w-72 bg-background shadow-lg"
         />
       ) : null}

--- a/apps/desktop/src/features/workflows/useStartAnywayConfirm/index.ts
+++ b/apps/desktop/src/features/workflows/useStartAnywayConfirm/index.ts
@@ -1,0 +1,49 @@
+import { useState } from 'react';
+import type { WorkflowBlockReason } from '../advanceGate';
+import { WORKFLOW_BLOCK_COPY } from '../blockCopy';
+
+type Params = {
+  readonly blockReason: WorkflowBlockReason | null;
+  readonly title?: string;
+  readonly onStart: () => void | Promise<void>;
+};
+
+export const useStartAnywayConfirm = ({
+  blockReason,
+  title = 'Start the next agent anyway?',
+  onStart,
+}: Params) => {
+  const [isBusy, setIsBusy] = useState(false);
+  const [isArmed, setIsArmed] = useState(false);
+
+  const start = async () => {
+    if (isBusy) {
+      return;
+    }
+    setIsBusy(true);
+    setIsArmed(false);
+    try {
+      await onStart();
+    } finally {
+      setIsBusy(false);
+    }
+  };
+
+  return {
+    isBusy,
+    isConfirming: isArmed && blockReason != null,
+    title,
+    description: blockReason != null ? WORKFLOW_BLOCK_COPY[blockReason] : '',
+    confirmLabel: 'Start anyway',
+    cancelLabel: 'Wait',
+    onTrigger: () => {
+      if (blockReason != null) {
+        setIsArmed(true);
+        return;
+      }
+      void start();
+    },
+    onConfirm: () => void start(),
+    onCancel: () => setIsArmed(false),
+  };
+};

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.test.tsx
@@ -16,6 +16,7 @@ import type {
 
 const h = vi.hoisted(() => {
   const state: Record<string, unknown> = {};
+  const gate = { hasOpenQuestions: false };
   const detachWorkflowFromSession = vi.fn(async () => undefined);
   const setPanelSectionExpanded = vi.fn((sessionId: string, section: string, expanded: boolean) => {
     const prev = (state.sessionPanelExpanded ?? {}) as Record<string, Record<string, boolean>>;
@@ -24,7 +25,7 @@ const h = vi.hoisted(() => {
       [sessionId]: { ...prev[sessionId], [section]: expanded },
     };
   });
-  return { state, detachWorkflowFromSession, setPanelSectionExpanded };
+  return { state, gate, detachWorkflowFromSession, setPanelSectionExpanded };
 });
 
 vi.mock('../../../../../store', () => ({
@@ -159,8 +160,20 @@ vi.mock('./WorkflowStartButton', () => ({
   WorkflowStartButton: () => <div data-testid="wf-start" />,
 }));
 vi.mock('./WorkflowStepRow', () => ({
-  WorkflowStepRow: ({ run }: { run: Agent }) => (
-    <div data-testid={`workflow-step-${run.id}`}>{run.name}</div>
+  WorkflowStepRow: ({
+    run,
+    onStart,
+    onForceStart,
+  }: {
+    run: Agent;
+    onStart: () => void;
+    onForceStart: () => void;
+  }) => (
+    <div data-testid={`workflow-step-${run.id}`}>
+      {run.name}
+      <button type="button" onClick={onStart}>{`start ${run.id}`}</button>
+      <button type="button" onClick={onForceStart}>{`force ${run.id}`}</button>
+    </div>
   ),
 }));
 vi.mock('./ScoutSubtree', () => ({ ScoutSubtree: () => null }));
@@ -187,7 +200,7 @@ vi.mock('../../../../../features/workflows/components/WorkflowNextStepCta', () =
   WorkflowNextStepCta: () => null,
 }));
 vi.mock('../../../../../features/context/openQuestionsGate', () => ({
-  workflowRunHasOpenQuestions: () => false,
+  workflowRunHasOpenQuestions: () => h.gate.hasOpenQuestions,
 }));
 vi.mock('../../../../../features/session/agent-row-format', () => ({
   computeLatestTelemetryByAgentId: () => new Map(),
@@ -237,6 +250,7 @@ function buildAgent(overrides: Partial<Agent> & Pick<Agent, 'id'>): Agent {
 }
 
 function reset() {
+  h.gate.hasOpenQuestions = false;
   Object.keys(h.state).forEach((k) => delete h.state[k]);
   Object.assign(h.state, {
     currentSessionId: null,
@@ -592,5 +606,95 @@ describe('AgentsSection collapse defaults', () => {
 
     expect(screen.getByTestId('toggle-agents').textContent).toBe('expanded');
     expect(screen.queryByTestId('spawn')).not.toBeNull();
+  });
+});
+
+describe('AgentsSection step start gate', () => {
+  const RUN_ID = 'run-1' as WorkflowRunId;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    reset();
+    h.state.sessionWorkflows = {
+      [SESSION_ID]: [
+        {
+          id: 'wf-def-1',
+          workspaceId: WS_ID,
+          name: 'review',
+          steps: [{ id: 'step-1' as StepId, name: 'implement' }],
+          createdAt: NOW,
+          updatedAt: NOW,
+        },
+      ],
+    };
+    h.state.sessionPhaseRuns = {
+      [SESSION_ID]: [
+        buildAgent({
+          id: 'wf-1' as AgentId,
+          workflowRunId: RUN_ID,
+          stepId: 'step-1' as StepId,
+          status: 'pending',
+        }),
+      ],
+    };
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  function renderSection() {
+    render(
+      <AgentsSection
+        task={buildSession({
+          workflowRuns: [
+            {
+              id: RUN_ID,
+              workflowId: 'wf-def-1',
+              ordinal: 0,
+              triggerMode: 'immediate',
+              autoRun: false,
+            } as never,
+          ],
+        })}
+      />,
+    );
+  }
+
+  it('starts the step agent when the run is not blocked', () => {
+    renderSection();
+
+    fireEvent.click(screen.getByRole('button', { name: 'start wf-1' }));
+
+    expect(h.state.activateWorkflowAgent).toHaveBeenCalledWith(
+      SESSION_ID,
+      'wf-1',
+      undefined,
+      'agent',
+    );
+  });
+
+  it('refuses an unconfirmed start while questions are open, and says why', () => {
+    h.gate.hasOpenQuestions = true;
+    renderSection();
+
+    fireEvent.click(screen.getByRole('button', { name: 'start wf-1' }));
+
+    expect(h.state.activateWorkflowAgent).not.toHaveBeenCalled();
+    expect(screen.getByText('Open questions are waiting for an answer.')).toBeDefined();
+  });
+
+  it('starts the blocked step once the override is explicit', () => {
+    h.gate.hasOpenQuestions = true;
+    renderSection();
+
+    fireEvent.click(screen.getByRole('button', { name: 'force wf-1' }));
+
+    expect(h.state.activateWorkflowAgent).toHaveBeenCalledWith(
+      SESSION_ID,
+      'wf-1',
+      undefined,
+      'agent',
+    );
   });
 });

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.test.tsx
@@ -15,6 +15,7 @@ import type {
   WorkflowRunId,
   WorkspaceId,
 } from '@goodboy/types';
+import type { WorkflowBlockReason } from '../../../../workflows/advanceGate';
 
 const storeMocks = vi.hoisted(() => ({ renameWorkflow: vi.fn(async () => undefined) }));
 
@@ -115,20 +116,26 @@ type RenderParams = {
   readonly runOverride?: WorkflowRun;
   readonly agentsOverride?: ReadonlyArray<Agent>;
   readonly actionableStepId?: string | null;
+  readonly blockReason?: WorkflowBlockReason | null;
   readonly childrenByParentId?: ReadonlyMap<string, Agent[]>;
   readonly clusterExpand?: ReadonlyMap<string, boolean>;
   readonly onDeleteWorkflow?: (runId: WorkflowRunId) => Promise<void>;
   readonly onPickAgent?: (agentId: AgentId) => void;
+  readonly startWorkflowRun?: (sessionId: SessionId, runId: WorkflowRunId) => Promise<void>;
+  readonly variant?: 'sidebar' | 'detail';
 };
 
 const renderDetail = ({
   runOverride = run,
   agentsOverride = agents,
   actionableStepId = 'step-2',
+  blockReason = null,
   childrenByParentId = new Map(),
   clusterExpand = new Map(),
   onDeleteWorkflow = vi.fn(async () => undefined),
   onPickAgent = vi.fn(),
+  startWorkflowRun = vi.fn(async () => undefined),
+  variant = 'detail',
 }: RenderParams = {}) =>
   render(
     <WorkflowRow
@@ -139,15 +146,15 @@ const renderDetail = ({
       attachedRuns={[{ run: runOverride, workflow }]}
       agentsByRunId={new Map([[RUN_ID, [...agentsOverride]]])}
       actionableStepIdByRunId={new Map([[RUN_ID, actionableStepId]])}
-      blockReasonByRunId={new Map([[RUN_ID, null]])}
+      blockReasonByRunId={new Map([[RUN_ID, blockReason]])}
       countUnread={() => 0}
       focusedWorkflowRunId={null}
       workflowExpand={undefined}
       workflowNameByRunId={new Map()}
       forceExpanded
-      variant="detail"
+      variant={variant}
       toggleWorkflowExpand={vi.fn()}
-      startWorkflowRun={vi.fn(async () => undefined)}
+      startWorkflowRun={startWorkflowRun}
       setWorkflowRunAutoRun={vi.fn(async () => undefined)}
       onReorderWorkflow={vi.fn(async () => undefined)}
       onDiscardWorkflow={vi.fn(async () => undefined)}
@@ -320,6 +327,57 @@ describe('WorkflowRow detail dashboard', () => {
     fireEvent.click(within(confirm).getByRole('button', { name: 'Delete' }));
 
     expect(onDeleteWorkflow).toHaveBeenCalledWith(RUN_ID);
+  });
+});
+
+describe('WorkflowRow manual start gate', () => {
+  const queuedRun: WorkflowRun = { ...run, triggerMode: 'manual' };
+
+  it('starts a queued run straight away when nothing blocks it', async () => {
+    const startWorkflowRun = vi.fn(async () => undefined);
+    renderDetail({ runOverride: queuedRun, agentsOverride: [], startWorkflowRun });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Start' }));
+    await Promise.resolve();
+
+    expect(startWorkflowRun).toHaveBeenCalledWith(SESSION_ID, RUN_ID);
+  });
+
+  it('names the blocker and starts only after an explicit override', async () => {
+    const startWorkflowRun = vi.fn(async () => undefined);
+    renderDetail({
+      runOverride: queuedRun,
+      agentsOverride: [],
+      blockReason: 'questions',
+      startWorkflowRun,
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Start' }));
+    const confirm = screen.getByRole('group', { name: 'Start this workflow anyway?' });
+
+    expect(confirm.textContent).toMatch(/open questions are waiting/i);
+    expect(startWorkflowRun).not.toHaveBeenCalled();
+
+    fireEvent.click(within(confirm).getByRole('button', { name: 'Start anyway' }));
+    await Promise.resolve();
+
+    expect(startWorkflowRun).toHaveBeenCalledWith(SESSION_ID, RUN_ID);
+  });
+
+  it('gates the sidebar start action the same way', () => {
+    const startWorkflowRun = vi.fn(async () => undefined);
+    renderDetail({
+      runOverride: queuedRun,
+      agentsOverride: [],
+      blockReason: 'questions',
+      startWorkflowRun,
+      variant: 'sidebar',
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Start workflow now' }));
+
+    expect(screen.getByRole('group', { name: 'Start this workflow anyway?' })).toBeDefined();
+    expect(startWorkflowRun).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.tsx
@@ -1,15 +1,6 @@
 import { Fragment, type Dispatch, type SetStateAction } from 'react';
 import { cn, Divider, formatUsdPrecise, Input, MetaRow, StatusDot } from '@goodboy/ui';
-import {
-  ChevronDown,
-  ChevronRight,
-  ChevronUp,
-  Pencil,
-  Play,
-  Undo2,
-  Zap,
-  ZapOff,
-} from 'lucide-react';
+import { ChevronDown, ChevronRight, ChevronUp, Pencil, Undo2, Zap, ZapOff } from 'lucide-react';
 import type {
   Agent,
   AgentId,
@@ -38,9 +29,11 @@ import { CardActionSlot } from '../../../../../shared/components/CardActionSlot'
 import { GhostActionButton } from '../../../../../shared/components/GhostActionButton';
 import { CONCEPT_ICONS } from '../../../../../shared/components/conceptIcons';
 import type { WorkflowBlockReason } from '../../../../workflows/advanceGate';
+import type { StartStepAgentParams } from './useAgentsSection';
 import { workflowKindName } from '../lib';
 import type { ProviderContextUsage } from './ContextWindowBar';
 import { WorkflowRunAsk } from './WorkflowRunAsk';
+import { WorkflowRunStartButton } from './WorkflowRunStartButton';
 import { WorkflowStepRow } from './WorkflowStepRow';
 import { ScoutSubtree } from './ScoutSubtree';
 import { ClusterChildRow } from './ClusterChildRow';
@@ -82,7 +75,7 @@ type Props = {
   readonly providerUsageByAgentId: ReadonlyMap<string, ReadonlyArray<ProviderContextUsage>>;
   readonly turnsByAgentId: ReadonlyMap<string, number>;
   readonly isTranscriptLoading: boolean;
-  readonly onStartStepAgent: (agent: Agent, model?: string) => Promise<void>;
+  readonly onStartStepAgent: (params: StartStepAgentParams) => Promise<void>;
   readonly onPickAgent: (id: AgentId) => void;
   readonly setEditingId: Dispatch<SetStateAction<AgentId | null>>;
   readonly onRenameCommit: (id: AgentId, name: string) => Promise<void>;
@@ -296,11 +289,10 @@ export const WorkflowRow = ({
             </CardActionSlot>
             <CardActionSlot label="Workflow lifecycle actions" className="gap-2">
               {isQueuedManual ? (
-                <GhostActionButton
-                  icon={Play}
-                  label="Start"
-                  tone="success"
-                  onClick={() => void startWorkflowRun(task.id, run.id)}
+                <WorkflowRunStartButton
+                  variant="detail"
+                  blockReason={wfBlockReason}
+                  onStart={() => startWorkflowRun(task.id, run.id)}
                 />
               ) : null}
               {!isDiscarded && !isCompleted ? (
@@ -327,11 +319,10 @@ export const WorkflowRow = ({
             {!isDiscarded ? (
               <CardActionSlot label="Workflow lifecycle actions">
                 {isQueuedManual ? (
-                  <CardAction
-                    icon={Play}
-                    label="Start workflow now"
-                    tone="success"
-                    onClick={() => void startWorkflowRun(task.id, run.id)}
+                  <WorkflowRunStartButton
+                    variant="sidebar"
+                    blockReason={wfBlockReason}
+                    onStart={() => startWorkflowRun(task.id, run.id)}
                   />
                 ) : null}
                 {!isCompleted ? (
@@ -453,7 +444,10 @@ export const WorkflowRow = ({
                           contextUsage={providerUsageByAgentId.get(run.id) ?? EMPTY_ARRAY}
                           turns={turnsByAgentId.get(run.id) ?? 0}
                           turnsLoading={run.id === selectedAgentId && isTranscriptLoading}
-                          onStart={() => void onStartStepAgent(run)}
+                          onStart={() => void onStartStepAgent({ agent: run })}
+                          onForceStart={() =>
+                            void onStartStepAgent({ agent: run, isConfirmed: true })
+                          }
                           onSelect={() => onPickAgent(run.id)}
                           onRenameStart={() => setEditingId(run.id)}
                           onRenameCommit={(name) => void onRenameCommit(run.id, name)}
@@ -547,7 +541,7 @@ export const WorkflowRow = ({
                   if (pending == null) {
                     return;
                   }
-                  void onStartStepAgent(pending);
+                  void onStartStepAgent({ agent: pending, isConfirmed: true });
                 }}
                 onForceAdvance={() =>
                   void skipStuckStepAndAdvance(task.id, run.id, { onlyWhenBlocked: true })

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRunStartButton.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRunStartButton.tsx
@@ -1,0 +1,58 @@
+import { AlertTriangle, Play } from 'lucide-react';
+import { InlineConfirm } from '@goodboy/ui';
+import type { WorkflowBlockReason } from '../../../../workflows/advanceGate';
+import { useStartAnywayConfirm } from '../../../../workflows/useStartAnywayConfirm';
+import { CardAction } from '../../../../../shared/components/CardAction';
+import { GhostActionButton } from '../../../../../shared/components/GhostActionButton';
+
+type Props = {
+  readonly variant: 'sidebar' | 'detail';
+  readonly blockReason: WorkflowBlockReason | null;
+  readonly onStart: () => void | Promise<void>;
+};
+
+export const WorkflowRunStartButton = ({ variant, blockReason, onStart }: Props) => {
+  const start = useStartAnywayConfirm({
+    blockReason,
+    title: 'Start this workflow anyway?',
+    onStart,
+  });
+  const isBlocked = blockReason != null;
+
+  return (
+    <div className="relative flex shrink-0 items-center">
+      {variant === 'detail' ? (
+        <GhostActionButton
+          icon={isBlocked ? AlertTriangle : Play}
+          label="Start"
+          tone={isBlocked ? 'warning' : 'success'}
+          title={isBlocked ? start.description : undefined}
+          isBusy={start.isBusy}
+          onClick={start.onTrigger}
+        />
+      ) : (
+        <CardAction
+          icon={isBlocked ? AlertTriangle : Play}
+          label="Start workflow now"
+          tone={isBlocked ? 'warning' : 'success'}
+          disabled={start.isBusy}
+          onClick={start.onTrigger}
+        />
+      )}
+      {start.isConfirming ? (
+        <InlineConfirm
+          role="alert"
+          icon={<AlertTriangle size={12} />}
+          title={start.title}
+          description={start.description}
+          confirmLabel={start.confirmLabel}
+          cancelLabel={start.cancelLabel}
+          isBusy={start.isBusy}
+          onConfirm={start.onConfirm}
+          onCancel={start.onCancel}
+          className="absolute right-0 top-full z-40 mt-1 w-72 bg-background shadow-lg"
+        />
+      ) : null}
+    </div>
+  );
+};

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowStepRow.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowStepRow.test.tsx
@@ -104,6 +104,7 @@ const renderRow = ({
       turns={ranAlready ? 5 : 0}
       turnsLoading={false}
       onStart={() => undefined}
+      onForceStart={() => undefined}
       onSelect={() => undefined}
       onRenameStart={() => undefined}
       onRenameCommit={() => undefined}

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowStepRow.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowStepRow.tsx
@@ -34,6 +34,7 @@ type Props = {
   readonly turns: number;
   readonly turnsLoading: boolean;
   readonly onStart: () => void;
+  readonly onForceStart: () => void;
   readonly onSelect: () => void;
   readonly onRenameStart: () => void;
   readonly onRenameCommit: (name: string) => void;
@@ -58,6 +59,7 @@ export const WorkflowStepRow = ({
   turns,
   turnsLoading,
   onStart,
+  onForceStart,
   onSelect,
   onRenameStart,
   onRenameCommit,
@@ -273,7 +275,7 @@ export const WorkflowStepRow = ({
             tone="warning"
             onClick={() => {
               setPendingConfirm(false);
-              onStart();
+              onForceStart();
             }}
           />
         </div>

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/useAgentsSection.ts
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/useAgentsSection.ts
@@ -21,6 +21,7 @@ import {
   resolveWorkflowAdvance,
   type WorkflowBlockReason,
 } from '../../../../../features/workflows/advanceGate';
+import { WORKFLOW_BLOCK_COPY } from '../../../../../features/workflows/blockCopy';
 import { workflowRunHasOpenQuestions } from '../../../../../features/context/openQuestionsGate';
 import { classifyAgent, type AgentKind } from '../../../../../features/session/agent-kind';
 import { useAgentMetrics } from '../../../../../features/session/hooks/useAgentMetrics';
@@ -32,6 +33,12 @@ import { workflowKindName } from '../lib';
 type Params = {
   readonly task: Session;
   readonly workflowRunId: WorkflowRunId | undefined;
+};
+
+export type StartStepAgentParams = {
+  readonly agent: Agent;
+  readonly model?: string;
+  readonly isConfirmed?: boolean;
 };
 
 export const useAgentsSection = ({ task, workflowRunId }: Params) => {
@@ -241,8 +248,14 @@ export const useAgentsSection = ({ task, workflowRunId }: Params) => {
     window.dispatchEvent(new CustomEvent('goodboy:reveal-chat'));
   };
 
-  const onStartStepAgent = async (agent: Agent, model?: string) => {
+  const onStartStepAgent = async ({ agent, model, isConfirmed = false }: StartStepAgentParams) => {
     setSpawnError(null);
+    const blockReason =
+      agent.workflowRunId != null ? (blockReasonByRunId.get(agent.workflowRunId) ?? null) : null;
+    if (agent.status === 'pending' && blockReason != null && !isConfirmed) {
+      setSpawnError(WORKFLOW_BLOCK_COPY[blockReason]);
+      return;
+    }
     window.dispatchEvent(new CustomEvent('goodboy:reveal-chat'));
     try {
       if (agent.status === 'pending') {


### PR DESCRIPTION
## What

The open-question gate is what lets a non-coder trust autopilot: a workflow must not
march past a question nobody answered. The gate existed, but it was caller convention,
so three manual start paths walked around it even though the block reason was already
computed in scope.

### Bypasses closed

1. `WorkflowRow` detail variant, `Start` on a queued manual run: fired
   `startWorkflowRun` with no gate.
2. `WorkflowRow` sidebar variant, `Start workflow now`: same.
3. `useAgentsSection.onStartStepAgent`: activated a pending step agent with no gate of
   its own, relying entirely on each caller to have checked first.

Both start buttons now route through the shared confirm when the run is blocked, and
they carry the state at the action itself (warning tone plus the alert icon) instead of
looking identical to an unblocked run. `onStartStepAgent` now refuses an unconfirmed
start of a blocked run and surfaces the block copy, so a caller that forgets to check
fails closed rather than starting silently.

### The extraction

The `Start anyway?` confirm lived as local `useState` plus an inline `InlineConfirm`
inside `WorkflowNextStepCta`. It is now
`features/workflows/useStartAnywayConfirm/index.ts`, owning the armed/busy state and the
copy. `WorkflowNextStepCta` consumes it, so there is one implementation, not two, and
its behavior and copy are unchanged (title, description from `WORKFLOW_BLOCK_COPY`,
`Start anyway` / `Wait`). The run start buttons use the same hook with their own title,
`Start this workflow anyway?`, since that action starts a workflow rather than the next
agent of a running one.

`WorkflowStepRow` gained an explicit `onForceStart` so its post-confirm force path is
distinct from a plain click. The plain click is gate-checked downstream; only the
confirmed one bypasses.

### Precedent

Linear: a blocked issue shows the block reason at the action itself, and the override is
explicit rather than silent. Same shape here, the button says it is blocked, the confirm
says why, and starting anyway is a deliberate second click.

## Deliberately deferred: engine-level enforcement

No gate was added inside `startWorkflowRun` or `activateWorkflowAgent`, and neither
signature changed. `activateWorkflowAgent` has 10 call sites and 6 are internal engine
flows, not user clicks (`maybeAutoAdvanceWorkflow`, `attachWorkflowToSession`, `runPlan`,
`orchestrateNextStep`, `skipStuckStepAndAdvance`, and `startWorkflowRun` itself).
`skipStuckStepAndAdvance` exists precisely to force past a blocked step, so a blanket
gate there would silently re-block the flow the user just confirmed.

The follow-up: make the gate default-on inside `activateWorkflowAgent` with an explicit
`bypassGate` flag passed by `skipStuckStepAndAdvance` and by the post-confirm paths.
This PR is the UI-layer half of that same shape, which is why the handler flag here is
named `isConfirmed`.

## Tests

- `WorkflowRow.test.tsx`: added the manual start gate cases. Unblocked click starts the
  run directly; blocked click opens the confirm, does not start, and starts after
  `Start anyway`; the sidebar variant is gated the same way. The render helper gained
  `blockReason`, `startWorkflowRun` and `variant` params, since the old fixture hardcoded
  an unblocked run.
- `AgentsSection.test.tsx`: the `WorkflowStepRow` mock now exposes `onStart` and
  `onForceStart`, and `workflowRunHasOpenQuestions` reads a per-test flag instead of a
  constant `false`. Added: unblocked start activates the agent, unconfirmed start of a
  blocked run does not and names the blocker, confirmed start does.
- `WorkflowNextStepCta/index.test.tsx`: untouched. It keeps pinning the extracted hook,
  rather than duplicating that coverage in a hook test.
- `WorkflowStepRow.test.tsx`: only the new required `onForceStart` prop.

No test that still described intended behavior was weakened.

## Verification

`pnpm typecheck`, `pnpm test` (500 desktop files, 4334 tests), and
`pnpm knip --include files,duplicates,unlisted` (the CI invocation) all pass. Bare
`pnpm knip` exits 1 on this branch with output byte-identical to `origin/main`, a
pre-existing unused-export backlog this PR neither adds to nor fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)