### PR TITLE
feat(desktop): enforce the open-question gate inside the engine

### DIFF
--- a/apps/desktop/src/features/companion/commandExecutor.commands.test.ts
+++ b/apps/desktop/src/features/companion/commandExecutor.commands.test.ts
@@ -135,6 +135,7 @@ import {
   isSessionMobileShared,
 } from './mobileConfinement';
 import type { SessionId } from '@goodboy/types';
+import { WorkflowGateError } from '../../store/slices/workflows/workflowActivationGate';
 
 const invokeMock = vi.mocked(invoke);
 
@@ -424,7 +425,11 @@ describe('advanceStep workflow advancement', () => {
     });
     const res = await executeBridgeCommand(cmd('advanceStep', { sessionId: 's1' }));
     expect(res.ok).toBe(true);
-    expect(h.activateWorkflowAgent).toHaveBeenCalledWith('s1', 'ag2', undefined, 'agent');
+    expect(h.activateWorkflowAgent).toHaveBeenCalledWith({
+      sessionId: 's1',
+      agentId: 'ag2',
+      focus: 'none',
+    });
     expect(isSessionMobileShared('s1' as SessionId)).toBe(true);
   });
 
@@ -434,7 +439,11 @@ describe('advanceStep workflow advancement', () => {
     });
     const res = await executeBridgeCommand(cmd('advanceStep', { sessionId: 's1' }));
     expect(res.ok).toBe(true);
-    expect(h.activateWorkflowAgent).toHaveBeenCalledWith('s1', 'ag1', undefined, 'agent');
+    expect(h.activateWorkflowAgent).toHaveBeenCalledWith({
+      sessionId: 's1',
+      agentId: 'ag1',
+      focus: 'none',
+    });
   });
 
   it('refuses to skip ahead when an earlier step is still running', async () => {
@@ -448,6 +457,21 @@ describe('advanceStep workflow advancement', () => {
     expect(res.ok).toBe(false);
     expect(res.error).toMatch(/no workflow step is ready/i);
     expect(h.activateWorkflowAgent).not.toHaveBeenCalled();
+  });
+
+  it('surfaces the engine gate refusal instead of forcing the step from the phone', async () => {
+    h.state.value = workflowStore({
+      phaseRuns: [
+        { id: 'ag1', workflowRunId: 'run1', stepId: 'step1', status: 'completed' },
+        { id: 'ag2', workflowRunId: 'run1', stepId: 'step2', status: 'pending' },
+      ],
+    });
+    h.activateWorkflowAgent.mockRejectedValueOnce(new WorkflowGateError({ reason: 'questions' }));
+
+    const res = await executeBridgeCommand(cmd('advanceStep', { sessionId: 's1' }));
+
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/open questions are waiting/i);
   });
 
   it('errors when the session has no workflow at all', async () => {

--- a/apps/desktop/src/features/companion/commandExecutor.ts
+++ b/apps/desktop/src/features/companion/commandExecutor.ts
@@ -17,6 +17,7 @@ import type {
 } from '@goodboy/types';
 import { useAppStore } from '../../store/store';
 import { resolveSessionRepo } from '../../store/slices/worktrees/resolveSessionRepo';
+import { WorkflowGateError } from '../../store/slices/workflows/workflowActivationGate';
 import { PROVIDER_LABEL_LOWER } from '../providers/providers';
 import { isMainWindow } from '../workspace/window';
 import { worktreeDiffFile } from '../worktree/worktree';
@@ -385,7 +386,14 @@ async function advanceNextWorkflowStep(sessionId: SessionId): Promise<void> {
           ),
         );
       if (allPrevDone) {
-        await store.activateWorkflowAgent(sessionId, agent.id, undefined, 'agent');
+        try {
+          await store.activateWorkflowAgent({ sessionId, agentId: agent.id, focus: 'none' });
+        } catch (e) {
+          if (e instanceof WorkflowGateError) {
+            throw new BridgeSafeError(`step not ready: ${e.message}`);
+          }
+          throw e;
+        }
         return;
       }
       break;

--- a/apps/desktop/src/features/companion/commandExecutor.ts
+++ b/apps/desktop/src/features/companion/commandExecutor.ts
@@ -390,7 +390,7 @@ async function advanceNextWorkflowStep(sessionId: SessionId): Promise<void> {
           await store.activateWorkflowAgent({ sessionId, agentId: agent.id, focus: 'none' });
         } catch (e) {
           if (e instanceof WorkflowGateError) {
-            throw new BridgeSafeError(`step not ready: ${e.message}`);
+            throw new BridgeSafeError(e.message);
           }
           throw e;
         }

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/PipelineSection.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/PipelineSection.tsx
@@ -70,7 +70,7 @@ export const PipelineSection = ({
       onAdvance: async (step) => {
         const agent = workflowAgents.find((r) => r.stepId === step.id);
         if (agent?.status === 'pending') {
-          await activateWorkflowAgent(sessionId, agent.id, undefined, 'none');
+          await activateWorkflowAgent({ sessionId, agentId: agent.id, focus: 'none' });
         }
       },
     };

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/index.test.tsx
@@ -683,7 +683,11 @@ describe('SessionOverviewPane pipeline lane next-step badge', () => {
   it('clicking the next-step badge starts the step without navigating', () => {
     const { onSelectLens } = renderPane(sessionWithRun());
     fireEvent.click(screen.getByTitle(/^start execute$/i));
-    expect(store.activateWorkflowAgent).toHaveBeenCalledWith('sess-1', AGENT_ID, undefined, 'none');
+    expect(store.activateWorkflowAgent).toHaveBeenCalledWith({
+      sessionId: 'sess-1',
+      agentId: AGENT_ID,
+      focus: 'none',
+    });
     expect(store.setFocusedWorkflowRun).not.toHaveBeenCalled();
     expect(onSelectLens).not.toHaveBeenCalledWith('workflows');
   });

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/ChatWorkflowAdvance.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/ChatWorkflowAdvance.test.tsx
@@ -112,12 +112,12 @@ describe('ChatWorkflowAdvance', () => {
 
     fireEvent.click(screen.getByTestId('workflow-next-step-cta'));
 
-    expect(store.activateWorkflowAgent).toHaveBeenCalledWith(
-      SESSION_ID,
-      'agent-1',
-      undefined,
-      'agent',
-    );
+    expect(store.activateWorkflowAgent).toHaveBeenCalledWith({
+      sessionId: SESSION_ID,
+      agentId: 'agent-1',
+      focus: 'agent',
+      bypassGate: false,
+    });
   });
 
   it('names the blocker instead of hiding the CTA while the summarizer runs', () => {
@@ -141,12 +141,12 @@ describe('ChatWorkflowAdvance', () => {
     fireEvent.click(cta);
     expect(store.activateWorkflowAgent).not.toHaveBeenCalled();
     fireEvent.click(screen.getByRole('button', { name: 'Start anyway' }));
-    expect(store.activateWorkflowAgent).toHaveBeenCalledWith(
-      SESSION_ID,
-      'agent-1',
-      undefined,
-      'agent',
-    );
+    expect(store.activateWorkflowAgent).toHaveBeenCalledWith({
+      sessionId: SESSION_ID,
+      agentId: 'agent-1',
+      focus: 'agent',
+      bypassGate: true,
+    });
   });
 
   it('forces past a stuck step only after an explicit confirmation', () => {

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/ChatWorkflowAdvance.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/ChatWorkflowAdvance.tsx
@@ -84,7 +84,7 @@ export const ChatWorkflowAdvance = ({ sessionId, workflowRunId, workflow }: Prop
       runs={stepAgents}
       roleModels={roleModels}
       blockReason={state.kind === 'blocked' ? state.reason : null}
-      onAdvance={(step, _model, _verbosity, isConfirmed) => void onAdvance({ step, isConfirmed })}
+      onAdvance={({ step, isConfirmed }) => void onAdvance({ step, isConfirmed })}
       onForceAdvance={() =>
         void skipStuckStepAndAdvance(sessionId, workflowRunId, { onlyWhenBlocked: true })
       }

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/ChatWorkflowAdvance.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/ChatWorkflowAdvance.tsx
@@ -13,6 +13,11 @@ type Props = {
   readonly workflow: Workflow;
 };
 
+type AdvanceParams = {
+  readonly step: Step;
+  readonly isConfirmed: boolean;
+};
+
 export const ChatWorkflowAdvance = ({ sessionId, workflowRunId, workflow }: Props) => {
   const phaseRuns = useAppStore(
     (state) => state.sessionPhaseRuns[sessionId] ?? (EMPTY_ARRAY as ReadonlyArray<Agent>),
@@ -58,14 +63,19 @@ export const ChatWorkflowAdvance = ({ sessionId, workflowRunId, workflow }: Prop
     return null;
   }
 
-  const onAdvance = async (step: Step) => {
+  const onAdvance = async ({ step, isConfirmed }: AdvanceParams) => {
     const pending = stepAgents.find(
       (agent) => agent.stepId === step.id && agent.status === 'pending',
     );
     if (pending == null) {
       return;
     }
-    await activateWorkflowAgent(sessionId, pending.id, undefined, 'agent');
+    await activateWorkflowAgent({
+      sessionId,
+      agentId: pending.id,
+      focus: 'agent',
+      bypassGate: isConfirmed,
+    });
   };
 
   return (
@@ -74,7 +84,7 @@ export const ChatWorkflowAdvance = ({ sessionId, workflowRunId, workflow }: Prop
       runs={stepAgents}
       roleModels={roleModels}
       blockReason={state.kind === 'blocked' ? state.reason : null}
-      onAdvance={(step) => void onAdvance(step)}
+      onAdvance={(step, _model, _verbosity, isConfirmed) => void onAdvance({ step, isConfirmed })}
       onForceAdvance={() =>
         void skipStuckStepAndAdvance(sessionId, workflowRunId, { onlyWhenBlocked: true })
       }

--- a/apps/desktop/src/features/workflows/components/OrchestratorPanel/index.test.tsx
+++ b/apps/desktop/src/features/workflows/components/OrchestratorPanel/index.test.tsx
@@ -6,6 +6,8 @@ import type {
   Agent,
   AgentId,
   IsoDateTime,
+  OpenQuestion,
+  OpenQuestionId,
   SessionId,
   Step,
   StepId,
@@ -63,6 +65,17 @@ const step = (ordinal: number, orchestratorReason: string): Step =>
     promptPrefix: '',
     orchestratorReason,
   }) as Step;
+
+const openQuestion = (): OpenQuestion => ({
+  id: 'oq-1' as OpenQuestionId,
+  sessionId: SESSION_ID,
+  workflowRunId: RUN_ID,
+  text: 'which database?',
+  suggestedAnswers: [],
+  userAnswer: null,
+  status: 'open',
+  createdAt: '2025-01-01T00:00:00.000Z' as IsoDateTime,
+});
 
 const EMPTY_AGENTS: ReadonlyArray<Agent> = [];
 const EMPTY_STEPS: ReadonlyArray<Step> = [];
@@ -239,6 +252,7 @@ describe('OrchestratorPanel state ladder', () => {
   });
 
   it('reads a question stop as a question to answer, with no retry on offer', () => {
+    storeState['sessionOpenQuestions'] = { [SESSION_ID]: [openQuestion()] };
     renderPanel({
       runOverride: run({
         orchestrationStop: {
@@ -253,6 +267,23 @@ describe('OrchestratorPanel state ladder', () => {
     fireEvent.click(screen.getByTestId('orchestrator-answer-question'));
 
     expect(storeState['setActiveLens']).toHaveBeenCalledWith(SESSION_ID, 'questions');
+  });
+
+  it('offers the next step again once the question behind the stop is answered', () => {
+    renderPanel({
+      runOverride: run({
+        orchestrationStop: {
+          kind: 'questions',
+          message: 'Open questions are waiting for an answer.',
+        },
+      }),
+      agents: [agent(0, 'completed')],
+    });
+
+    expect(sentence()).toContain('ready to continue');
+    fireEvent.click(screen.getByTestId('workflow-orchestrate-next-cta'));
+
+    expect(storeState['orchestrateNextStep']).toHaveBeenCalledWith(SESSION_ID, RUN_ID);
   });
 
   it('shows the failure with its reason and offers a retry', () => {

--- a/apps/desktop/src/features/workflows/components/OrchestratorPanel/index.test.tsx
+++ b/apps/desktop/src/features/workflows/components/OrchestratorPanel/index.test.tsx
@@ -238,6 +238,23 @@ describe('OrchestratorPanel state ladder', () => {
     expect(screen.getByTestId('orchestrator-review-budget')).toBeDefined();
   });
 
+  it('reads a question stop as a question to answer, with no retry on offer', () => {
+    renderPanel({
+      runOverride: run({
+        orchestrationStop: {
+          kind: 'questions',
+          message: 'Open questions are waiting for an answer.',
+        },
+      }),
+    });
+
+    expect(sentence()).toContain('Paused · an open question needs your answer');
+    expect(screen.queryByTestId('orchestrator-retry')).toBeNull();
+    fireEvent.click(screen.getByTestId('orchestrator-answer-question'));
+
+    expect(storeState['setActiveLens']).toHaveBeenCalledWith(SESSION_ID, 'questions');
+  });
+
   it('shows the failure with its reason and offers a retry', () => {
     renderPanel({
       runOverride: run({

--- a/apps/desktop/src/features/workflows/components/OrchestratorPanel/orchestratorState.ts
+++ b/apps/desktop/src/features/workflows/components/OrchestratorPanel/orchestratorState.ts
@@ -100,7 +100,8 @@ export const resolveOrchestratorState = ({
     };
   }
   const stop = run.orchestrationStop;
-  if (stop != null) {
+  const isAnsweredQuestionStop = stop?.kind === 'questions' && hasOpenQuestions === false;
+  if (stop != null && isAnsweredQuestionStop === false) {
     const presentation = STOP_PRESENTATION[stop.kind];
     return {
       ...base,

--- a/apps/desktop/src/features/workflows/components/OrchestratorPanel/orchestratorState.ts
+++ b/apps/desktop/src/features/workflows/components/OrchestratorPanel/orchestratorState.ts
@@ -56,6 +56,12 @@ const STOP_PRESENTATION: Record<WorkflowOrchestrationStopKind, StopPresentation>
     sentence: 'Last decision failed',
     showsMessage: true,
   },
+  questions: {
+    phase: 'needs-answer',
+    tone: 'warning',
+    sentence: 'Paused · an open question needs your answer',
+    showsMessage: false,
+  },
 };
 
 const isDone = (agent: Agent): boolean =>

--- a/apps/desktop/src/features/workflows/components/WorkflowNextStepCta/index.test.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowNextStepCta/index.test.tsx
@@ -117,7 +117,10 @@ describe('WorkflowNextStepCta', () => {
     fireEvent.click(screen.getByTestId('workflow-next-step-cta'));
     await Promise.resolve();
     expect(onAdvance).toHaveBeenCalled();
-    expect(onAdvance.mock.calls[0]?.[0]).toMatchObject({ id: 's1' });
+    expect(onAdvance.mock.calls[0]?.[0]).toMatchObject({
+      step: { id: 's1' },
+      isConfirmed: false,
+    });
   });
 
   it('names what blocks it and asks for confirmation when questions are open', () => {
@@ -164,7 +167,10 @@ describe('WorkflowNextStepCta', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Start anyway' }));
     await Promise.resolve();
     expect(onAdvance).toHaveBeenCalledTimes(1);
-    expect(onAdvance.mock.calls[0]?.[0]).toMatchObject({ id: 's2' });
+    expect(onAdvance.mock.calls[0]?.[0]).toMatchObject({
+      step: { id: 's2' },
+      isConfirmed: true,
+    });
   });
 
   it('uses the primary tone when predecessors and gates are clear', () => {

--- a/apps/desktop/src/features/workflows/components/WorkflowNextStepCta/index.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowNextStepCta/index.tsx
@@ -19,6 +19,7 @@ export type Props = {
     step: Step,
     model: string,
     verbosity: VerbosityLevel | undefined,
+    isConfirmed: boolean,
   ) => void | Promise<void>;
   readonly onForceAdvance?: () => void | Promise<void>;
   readonly blockReason?: WorkflowBlockReason | null;
@@ -76,11 +77,11 @@ export const WorkflowNextStepCta = ({
   const routing = resolveStepRouting({ step: next, kind, roleModels });
   const advance = useStartAnywayConfirm({
     blockReason,
-    onStart: async () => {
+    onStart: async ({ isConfirmed }) => {
       if (next == null) {
         return;
       }
-      await onAdvance(next, routing.model, next.verbosity);
+      await onAdvance(next, routing.model, next.verbosity, isConfirmed);
     },
   });
   const doForce = async () => {

--- a/apps/desktop/src/features/workflows/components/WorkflowNextStepCta/index.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowNextStepCta/index.tsx
@@ -12,15 +12,17 @@ import { WORKFLOW_BLOCK_COPY } from '../../blockCopy';
 import { useStartAnywayConfirm } from '../../useStartAnywayConfirm';
 import { CONCEPT_ICONS } from '../../../../shared/components/conceptIcons';
 
+export type AdvanceParams = {
+  readonly step: Step;
+  readonly model: string;
+  readonly verbosity: VerbosityLevel | undefined;
+  readonly isConfirmed: boolean;
+};
+
 export type Props = {
   readonly workflow: Workflow;
   readonly runs: ReadonlyArray<Agent>;
-  readonly onAdvance: (
-    step: Step,
-    model: string,
-    verbosity: VerbosityLevel | undefined,
-    isConfirmed: boolean,
-  ) => void | Promise<void>;
+  readonly onAdvance: (params: AdvanceParams) => void | Promise<void>;
   readonly onForceAdvance?: () => void | Promise<void>;
   readonly blockReason?: WorkflowBlockReason | null;
   readonly consumesActivePlan?: boolean;
@@ -81,7 +83,12 @@ export const WorkflowNextStepCta = ({
       if (next == null) {
         return;
       }
-      await onAdvance(next, routing.model, next.verbosity, isConfirmed);
+      await onAdvance({
+        step: next,
+        model: routing.model,
+        verbosity: next.verbosity,
+        isConfirmed,
+      });
     },
   });
   const doForce = async () => {

--- a/apps/desktop/src/features/workflows/useStartAnywayConfirm/index.ts
+++ b/apps/desktop/src/features/workflows/useStartAnywayConfirm/index.ts
@@ -2,10 +2,14 @@ import { useState } from 'react';
 import type { WorkflowBlockReason } from '../advanceGate';
 import { WORKFLOW_BLOCK_COPY } from '../blockCopy';
 
+type StartParams = {
+  readonly isConfirmed: boolean;
+};
+
 type Params = {
   readonly blockReason: WorkflowBlockReason | null;
   readonly title?: string;
-  readonly onStart: () => void | Promise<void>;
+  readonly onStart: (params: StartParams) => void | Promise<void>;
 };
 
 export const useStartAnywayConfirm = ({
@@ -16,14 +20,14 @@ export const useStartAnywayConfirm = ({
   const [isBusy, setIsBusy] = useState(false);
   const [isArmed, setIsArmed] = useState(false);
 
-  const start = async () => {
+  const start = async ({ isConfirmed }: StartParams) => {
     if (isBusy) {
       return;
     }
     setIsBusy(true);
     setIsArmed(false);
     try {
-      await onStart();
+      await onStart({ isConfirmed });
     } finally {
       setIsBusy(false);
     }
@@ -41,9 +45,9 @@ export const useStartAnywayConfirm = ({
         setIsArmed(true);
         return;
       }
-      void start();
+      void start({ isConfirmed: false });
     },
-    onConfirm: () => void start(),
+    onConfirm: () => void start({ isConfirmed: true }),
     onCancel: () => setIsArmed(false),
   };
 };

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.test.tsx
@@ -661,17 +661,17 @@ describe('AgentsSection step start gate', () => {
     );
   }
 
-  it('starts the step agent when the run is not blocked', () => {
+  it('starts the step agent when the run is not blocked, without asking the engine to bypass', () => {
     renderSection();
 
     fireEvent.click(screen.getByRole('button', { name: 'start wf-1' }));
 
-    expect(h.state.activateWorkflowAgent).toHaveBeenCalledWith(
-      SESSION_ID,
-      'wf-1',
-      undefined,
-      'agent',
-    );
+    expect(h.state.activateWorkflowAgent).toHaveBeenCalledWith({
+      sessionId: SESSION_ID,
+      agentId: 'wf-1',
+      focus: 'agent',
+      bypassGate: false,
+    });
   });
 
   it('refuses an unconfirmed start while questions are open, and says why', () => {
@@ -684,17 +684,17 @@ describe('AgentsSection step start gate', () => {
     expect(screen.getByText('Open questions are waiting for an answer.')).toBeDefined();
   });
 
-  it('starts the blocked step once the override is explicit', () => {
+  it('bypasses the engine gate only once the operator confirmed the blocked start', () => {
     h.gate.hasOpenQuestions = true;
     renderSection();
 
     fireEvent.click(screen.getByRole('button', { name: 'force wf-1' }));
 
-    expect(h.state.activateWorkflowAgent).toHaveBeenCalledWith(
-      SESSION_ID,
-      'wf-1',
-      undefined,
-      'agent',
-    );
+    expect(h.state.activateWorkflowAgent).toHaveBeenCalledWith({
+      sessionId: SESSION_ID,
+      agentId: 'wf-1',
+      focus: 'agent',
+      bypassGate: true,
+    });
   });
 });

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.tsx
@@ -534,7 +534,7 @@ export const WorkflowRow = ({
                 runs={wfAgents}
                 roleModels={roleModels}
                 blockReason={wfBlockReason}
-                onAdvance={(step, _model, _verbosity, isConfirmed) => {
+                onAdvance={({ step, isConfirmed }) => {
                   const pending = wfAgents.find(
                     (agent) => agent.stepId === step.id && agent.status === 'pending',
                   );

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.tsx
@@ -534,14 +534,14 @@ export const WorkflowRow = ({
                 runs={wfAgents}
                 roleModels={roleModels}
                 blockReason={wfBlockReason}
-                onAdvance={(step) => {
+                onAdvance={(step, _model, _verbosity, isConfirmed) => {
                   const pending = wfAgents.find(
                     (agent) => agent.stepId === step.id && agent.status === 'pending',
                   );
                   if (pending == null) {
                     return;
                   }
-                  void onStartStepAgent({ agent: pending, isConfirmed: true });
+                  void onStartStepAgent({ agent: pending, isConfirmed });
                 }}
                 onForceAdvance={() =>
                   void skipStuckStepAndAdvance(task.id, run.id, { onlyWhenBlocked: true })

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/useAgentsSection.ts
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/useAgentsSection.ts
@@ -259,7 +259,12 @@ export const useAgentsSection = ({ task, workflowRunId }: Params) => {
     window.dispatchEvent(new CustomEvent('goodboy:reveal-chat'));
     try {
       if (agent.status === 'pending') {
-        await activateWorkflowAgent(task.id, agent.id, undefined, 'agent');
+        await activateWorkflowAgent({
+          sessionId: task.id,
+          agentId: agent.id,
+          focus: 'agent',
+          bypassGate: isConfirmed,
+        });
         return;
       }
       await spawnAgent(task.id, {

--- a/apps/desktop/src/store/slices/plans/index.test.ts
+++ b/apps/desktop/src/store/slices/plans/index.test.ts
@@ -174,12 +174,12 @@ describe('runPlan, workflow-aware spawn routing', () => {
 
       expect(state.spawnAgent).not.toHaveBeenCalled();
       expect(state.activateWorkflowAgent).toHaveBeenCalledTimes(1);
-      expect(state.activateWorkflowAgent).toHaveBeenCalledWith(
-        SESSION_ID,
-        IMPL_AGENT_ID,
-        PLAN_ID,
-        'none',
-      );
+      expect(state.activateWorkflowAgent).toHaveBeenCalledWith({
+        sessionId: SESSION_ID,
+        agentId: IMPL_AGENT_ID,
+        explicitPlanId: PLAN_ID,
+        focus: 'none',
+      });
     });
 
     it('does not insert a duplicate agent for a step that already has a pending slot', async () => {
@@ -214,7 +214,12 @@ describe('runPlan, workflow-aware spawn routing', () => {
         expect(
           state.activateWorkflowAgent,
           `alias "${name}" should activate the slot`,
-        ).toHaveBeenCalledWith(SESSION_ID, IMPL_AGENT_ID, PLAN_ID, 'none');
+        ).toHaveBeenCalledWith({
+          sessionId: SESSION_ID,
+          agentId: IMPL_AGENT_ID,
+          explicitPlanId: PLAN_ID,
+          focus: 'none',
+        });
       }
     });
 
@@ -236,12 +241,12 @@ describe('runPlan, workflow-aware spawn routing', () => {
         await slice.runPlan(SESSION_ID, PLAN_ID);
 
         expect(state.spawnAgent).not.toHaveBeenCalled();
-        expect(state.activateWorkflowAgent).toHaveBeenCalledWith(
-          SESSION_ID,
-          IMPL_AGENT_ID,
-          PLAN_ID,
-          'none',
-        );
+        expect(state.activateWorkflowAgent).toHaveBeenCalledWith({
+          sessionId: SESSION_ID,
+          agentId: IMPL_AGENT_ID,
+          explicitPlanId: PLAN_ID,
+          focus: 'none',
+        });
       },
     );
   });
@@ -560,12 +565,12 @@ describe('runPlan, workflow-aware spawn routing', () => {
 
       const agentId = await slice.runPlan(SESSION_ID, PLAN_ID);
 
-      expect(state.activateWorkflowAgent).toHaveBeenCalledWith(
-        SESSION_ID,
-        IMPL_AGENT_ID,
-        PLAN_ID,
-        'none',
-      );
+      expect(state.activateWorkflowAgent).toHaveBeenCalledWith({
+        sessionId: SESSION_ID,
+        agentId: IMPL_AGENT_ID,
+        explicitPlanId: PLAN_ID,
+        focus: 'none',
+      });
       expect(agentId).toBe(IMPL_AGENT_ID);
     });
 
@@ -675,8 +680,8 @@ describe('runPlan, workflow-aware spawn routing', () => {
         await slice.runPlan(SESSION_ID, PLAN_ID);
 
         if (state.activateWorkflowAgent.mock.calls.length > 0) {
-          const [, , planId] = state.activateWorkflowAgent.mock.calls[0]!;
-          expect(planId, `${name} must route the clicked plan`).toBe(PLAN_ID);
+          const [params] = state.activateWorkflowAgent.mock.calls[0]!;
+          expect(params.explicitPlanId, `${name} must route the clicked plan`).toBe(PLAN_ID);
         } else {
           const [, args] = state.spawnAgent.mock.calls[0]!;
           expect(args.triggeredPlanId, `${name} must carry triggeredPlanId`).toBe(PLAN_ID);

--- a/apps/desktop/src/store/slices/plans/runPlan.ts
+++ b/apps/desktop/src/store/slices/plans/runPlan.ts
@@ -73,7 +73,12 @@ export const runPlan = (get: GetFn) => {
         focus: 'none',
       });
     }
-    await get().activateWorkflowAgent(sessionId, stepAgent.id, planId, 'none');
+    await get().activateWorkflowAgent({
+      sessionId,
+      agentId: stepAgent.id,
+      explicitPlanId: planId,
+      focus: 'none',
+    });
     return stepAgent.id;
   };
 };

--- a/apps/desktop/src/store/slices/workflows/activateWorkflowAgent.test.ts
+++ b/apps/desktop/src/store/slices/workflows/activateWorkflowAgent.test.ts
@@ -4,6 +4,8 @@ import type {
   AgentId,
   ImplementationCluster,
   IsoDateTime,
+  OpenQuestion,
+  OpenQuestionId,
   PlanId,
   PlanWithCount,
   Session,
@@ -23,12 +25,17 @@ const {
   listConsumptionsForPlanSpy,
   listPlansForSessionSpy,
   fanOutClustersSpy,
+  listOpenQuestionsSpy,
 } = vi.hoisted(() => ({
   addPlanConsumptionSpy: vi.fn(async () => undefined),
   listConsumptionsForPlanSpy: vi.fn(async () => []),
   listPlansForSessionSpy: vi.fn(async () => [] as ReadonlyArray<PlanWithCount>),
   fanOutClustersSpy: vi.fn(async () => undefined),
+  listOpenQuestionsSpy: vi.fn(async () => [] as ReadonlyArray<OpenQuestion>),
 }));
+
+vi.mock('@goodboy/db', () => ({ listOpenQuestionsForSession: listOpenQuestionsSpy }));
+vi.mock('../../../shared/lib/db', () => ({ tauriDatabase: {} }));
 
 vi.mock('../../../features/plans/plans', () => ({
   addPlanConsumption: addPlanConsumptionSpy,
@@ -42,6 +49,8 @@ vi.mock('./clusterImplementation', async (importOriginal) => {
 });
 
 import { activateWorkflowAgent } from './activateWorkflowAgent';
+import { WorkflowGateError } from './workflowActivationGate';
+import { WORKFLOW_BLOCK_COPY } from '../../../features/workflows/blockCopy';
 
 const WS_ID = 'ws-1' as WorkspaceId;
 const WF_ID = 'wf-1' as WorkflowId;
@@ -163,10 +172,91 @@ function mergedSetPartials(set: ReturnType<typeof vi.fn>, state: Record<string, 
   }, {});
 }
 
+const makeOpenQuestion = (overrides: Partial<OpenQuestion> = {}): OpenQuestion => ({
+  id: 'oq-1' as OpenQuestionId,
+  sessionId: SESSION_ID,
+  workflowRunId: RUN_ID,
+  text: 'which database?',
+  suggestedAnswers: [],
+  userAnswer: null,
+  status: 'open',
+  createdAt: NOW,
+  ...overrides,
+});
+
+describe('activateWorkflowAgent, open-question gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    listConsumptionsForPlanSpy.mockResolvedValue([]);
+    listOpenQuestionsSpy.mockResolvedValue([]);
+  });
+
+  it('refuses to start a pending step while its run has an unanswered question', async () => {
+    listOpenQuestionsSpy.mockResolvedValue([makeOpenQuestion()]);
+    const { set, sendTurn, activate } = buildHarness({
+      agent: makeAgent('generic', 'Execute commits'),
+      workflow: makeWorkflow('Execute commits'),
+      plans: [makePlan()],
+    });
+
+    await expect(activate({ sessionId: SESSION_ID, agentId: AGENT_ID })).rejects.toThrow(
+      WORKFLOW_BLOCK_COPY.questions,
+    );
+    expect(sendTurn).not.toHaveBeenCalled();
+    expect(set).not.toHaveBeenCalled();
+  });
+
+  it('blocks the mobile bridge shape too: no caller-side gate, no bypass flag', async () => {
+    listOpenQuestionsSpy.mockResolvedValue([makeOpenQuestion()]);
+    const { sendTurn, activate } = buildHarness({
+      agent: makeAgent('generic', 'Execute commits'),
+      workflow: makeWorkflow('Execute commits'),
+      plans: [makePlan()],
+    });
+
+    const error = await activate({
+      sessionId: SESSION_ID,
+      agentId: AGENT_ID,
+      focus: 'none',
+    }).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(WorkflowGateError);
+    expect((error as WorkflowGateError).reason).toBe('questions');
+    expect(sendTurn).not.toHaveBeenCalled();
+  });
+
+  it('lets the skip path through: bypassGate starts the step despite open questions', async () => {
+    listOpenQuestionsSpy.mockResolvedValue([makeOpenQuestion()]);
+    const { sendTurn, activate } = buildHarness({
+      agent: makeAgent('generic', 'Execute commits'),
+      workflow: makeWorkflow('Execute commits'),
+      plans: [makePlan()],
+    });
+
+    await activate({ sessionId: SESSION_ID, agentId: AGENT_ID, bypassGate: true });
+
+    expect(sendTurn).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores a question already answered and starts the step', async () => {
+    listOpenQuestionsSpy.mockResolvedValue([]);
+    const { sendTurn, activate } = buildHarness({
+      agent: makeAgent('generic', 'Execute commits'),
+      workflow: makeWorkflow('Execute commits'),
+      plans: [makePlan()],
+    });
+
+    await activate({ sessionId: SESSION_ID, agentId: AGENT_ID });
+
+    expect(sendTurn).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe('activateWorkflowAgent, plan consumption by kind', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     listConsumptionsForPlanSpy.mockResolvedValue([]);
+    listOpenQuestionsSpy.mockResolvedValue([]);
   });
 
   it('a generic step after a plan consumes it and receives the plan body', async () => {
@@ -176,7 +266,7 @@ describe('activateWorkflowAgent, plan consumption by kind', () => {
       plans: [makePlan()],
     });
 
-    await activate(SESSION_ID, AGENT_ID);
+    await activate({ sessionId: SESSION_ID, agentId: AGENT_ID });
 
     expect(addPlanConsumptionSpy).toHaveBeenCalledWith(PLAN_ID, AGENT_ID);
     const [payload] = sendTurn.mock.calls[0]!;
@@ -192,7 +282,7 @@ describe('activateWorkflowAgent, plan consumption by kind', () => {
       plans: [makePlan()],
     });
 
-    await activate(SESSION_ID, AGENT_ID);
+    await activate({ sessionId: SESSION_ID, agentId: AGENT_ID });
 
     expect(addPlanConsumptionSpy).not.toHaveBeenCalled();
     const [payload] = sendTurn.mock.calls[0]!;
@@ -213,7 +303,7 @@ describe('activateWorkflowAgent, plan consumption by kind', () => {
       autoRun: true,
     });
 
-    await activate(SESSION_ID, AGENT_ID);
+    await activate({ sessionId: SESSION_ID, agentId: AGENT_ID });
 
     expect(addPlanConsumptionSpy).toHaveBeenCalledWith(PLAN_ID, AGENT_ID);
     expect(fanOutClustersSpy).toHaveBeenCalledTimes(1);
@@ -231,7 +321,7 @@ describe('activateWorkflowAgent, plan consumption by kind', () => {
       autoRun: false,
     });
 
-    await activate(SESSION_ID, AGENT_ID);
+    await activate({ sessionId: SESSION_ID, agentId: AGENT_ID });
 
     expect(fanOutClustersSpy).toHaveBeenCalledTimes(1);
   });
@@ -247,7 +337,7 @@ describe('activateWorkflowAgent, plan consumption by kind', () => {
       plans: [makePlan({ clusters, status: 'consumed' })],
     });
 
-    await activate(SESSION_ID, AGENT_ID);
+    await activate({ sessionId: SESSION_ID, agentId: AGENT_ID });
 
     expect(addPlanConsumptionSpy).not.toHaveBeenCalled();
     expect(fanOutClustersSpy).not.toHaveBeenCalled();
@@ -263,7 +353,7 @@ describe('activateWorkflowAgent, plan consumption by kind', () => {
       plans: [makePlan({ status: 'consumed' })],
     });
 
-    await activate(SESSION_ID, AGENT_ID);
+    await activate({ sessionId: SESSION_ID, agentId: AGENT_ID });
 
     expect(addPlanConsumptionSpy).not.toHaveBeenCalled();
   });
@@ -279,7 +369,7 @@ describe('activateWorkflowAgent, plan consumption by kind', () => {
       ],
     });
 
-    await activate(SESSION_ID, AGENT_ID, EXPLICIT_ID);
+    await activate({ sessionId: SESSION_ID, agentId: AGENT_ID, explicitPlanId: EXPLICIT_ID });
 
     expect(addPlanConsumptionSpy).toHaveBeenCalledWith(EXPLICIT_ID, AGENT_ID);
     expect(addPlanConsumptionSpy).not.toHaveBeenCalledWith(PLAN_ID, AGENT_ID);
@@ -295,7 +385,7 @@ describe('activateWorkflowAgent, plan consumption by kind', () => {
       plans: [makePlan()],
     });
 
-    await activate(SESSION_ID, AGENT_ID);
+    await activate({ sessionId: SESSION_ID, agentId: AGENT_ID });
 
     const merged = mergedSetPartials(set, state);
     expect(merged.selectedAgentId).toBeUndefined();
@@ -310,7 +400,7 @@ describe('activateWorkflowAgent, plan consumption by kind', () => {
     });
     Object.assign(state, { activeLens: { [SESSION_ID]: 'workflows' } });
 
-    await activate(SESSION_ID, AGENT_ID, undefined, 'agent');
+    await activate({ sessionId: SESSION_ID, agentId: AGENT_ID, focus: 'agent' });
 
     const merged = mergedSetPartials(set, state);
     expect(merged.selectedAgentId).toBeUndefined();
@@ -328,7 +418,7 @@ describe('activateWorkflowAgent, plan consumption by kind', () => {
       selectedAgentId: { [SESSION_ID]: 'other-agent' },
     });
 
-    await activate(SESSION_ID, AGENT_ID, undefined, 'agent');
+    await activate({ sessionId: SESSION_ID, agentId: AGENT_ID, focus: 'agent' });
 
     const merged = mergedSetPartials(set, state);
     expect((merged.selectedAgentId as Record<string, unknown>)[SESSION_ID]).toBe(AGENT_ID);
@@ -341,7 +431,7 @@ describe('activateWorkflowAgent, plan consumption by kind', () => {
       plans: [makePlan()],
     });
 
-    await activate(SESSION_ID, AGENT_ID, undefined, 'none');
+    await activate({ sessionId: SESSION_ID, agentId: AGENT_ID, focus: 'none' });
 
     const merged = mergedSetPartials(set, state);
     expect(merged.selectedAgentId).toBeUndefined();
@@ -356,7 +446,7 @@ describe('activateWorkflowAgent, plan consumption by kind', () => {
       plans: [makePlan({ status: 'consumed' })],
     });
 
-    await activate(SESSION_ID, AGENT_ID, PLAN_ID);
+    await activate({ sessionId: SESSION_ID, agentId: AGENT_ID, explicitPlanId: PLAN_ID });
 
     expect(addPlanConsumptionSpy).toHaveBeenCalledWith(PLAN_ID, AGENT_ID);
   });
@@ -373,7 +463,7 @@ describe('activateWorkflowAgent, plan consumption by kind', () => {
       autoRun: true,
     });
 
-    await activate(SESSION_ID, AGENT_ID, undefined, 'none');
+    await activate({ sessionId: SESSION_ID, agentId: AGENT_ID, focus: 'none' });
 
     expect(fanOutClustersSpy).toHaveBeenCalledTimes(1);
     const merged = mergedSetPartials(set, state);
@@ -388,7 +478,7 @@ describe('activateWorkflowAgent, plan consumption by kind', () => {
       plans: [makePlan()],
     });
 
-    await activate(SESSION_ID, AGENT_ID, undefined, 'none');
+    await activate({ sessionId: SESSION_ID, agentId: AGENT_ID, focus: 'none' });
 
     const merged = mergedSetPartials(set, state);
     expect(merged.selectedAgentId).toBeUndefined();
@@ -406,7 +496,12 @@ describe('activateWorkflowAgent, plan consumption by kind', () => {
       plans: [makePlan({ id: EXPLICIT_ID, bodyMd: 'explicit body' })],
     });
 
-    await activate(SESSION_ID, AGENT_ID, EXPLICIT_ID, 'none');
+    await activate({
+      sessionId: SESSION_ID,
+      agentId: AGENT_ID,
+      explicitPlanId: EXPLICIT_ID,
+      focus: 'none',
+    });
 
     expect(addPlanConsumptionSpy).toHaveBeenCalledWith(EXPLICIT_ID, AGENT_ID);
     const merged = mergedSetPartials(set, state);
@@ -421,7 +516,7 @@ describe('activateWorkflowAgent, plan consumption by kind', () => {
       plans: [makePlan()],
     });
 
-    await activate(SESSION_ID, AGENT_ID, undefined, 'none');
+    await activate({ sessionId: SESSION_ID, agentId: AGENT_ID, focus: 'none' });
 
     const touchesSelection = set.mock.calls.some((call) => {
       const updater = call[0] as (s: Record<string, unknown>) => Record<string, unknown>;
@@ -437,7 +532,7 @@ describe('activateWorkflowAgent, plan consumption by kind', () => {
       plans: [makePlan()],
     });
 
-    await activate(SESSION_ID, AGENT_ID, undefined, 'agent');
+    await activate({ sessionId: SESSION_ID, agentId: AGENT_ID, focus: 'agent' });
 
     const merged = mergedSetPartials(set, state);
     expect((merged.selectedAgentId as Record<string, unknown>)[SESSION_ID]).toBe(AGENT_ID);
@@ -450,9 +545,9 @@ describe('activateWorkflowAgent, plan consumption by kind', () => {
       plans: [makePlan()],
     });
 
-    await expect(activate(SESSION_ID, 'nope' as AgentId, undefined, 'none')).rejects.toThrow(
-      'agent not found or not a workflow agent',
-    );
+    await expect(
+      activate({ sessionId: SESSION_ID, agentId: 'nope' as AgentId, focus: 'none' }),
+    ).rejects.toThrow('agent not found or not a workflow agent');
     expect(set).not.toHaveBeenCalled();
     expect(sendTurn).not.toHaveBeenCalled();
   });

--- a/apps/desktop/src/store/slices/workflows/activateWorkflowAgent.ts
+++ b/apps/desktop/src/store/slices/workflows/activateWorkflowAgent.ts
@@ -19,15 +19,25 @@ import {
 import type { SpawnFocus } from '../session-view/spawnFocus';
 import { fanOutClusters, selectFanOutPlan } from './clusterImplementation';
 import { isWatchingWorkflowLens } from './isWatchingWorkflowLens';
+import { WorkflowGateError, findWorkflowActivationBlock } from './workflowActivationGate';
 import type { GetFn, SetFn } from './types';
 
+export type ActivateWorkflowAgentParams = {
+  readonly sessionId: SessionId;
+  readonly agentId: AgentId;
+  readonly explicitPlanId?: PlanId;
+  readonly focus?: SpawnFocus;
+  readonly bypassGate?: boolean;
+};
+
 export const activateWorkflowAgent = (set: SetFn, get: GetFn) => {
-  return async (
-    sessionId: SessionId,
-    agentId: AgentId,
-    explicitPlanId?: PlanId,
-    focus: SpawnFocus = 'none',
-  ) => {
+  return async ({
+    sessionId,
+    agentId,
+    explicitPlanId,
+    focus = 'none',
+    bypassGate = false,
+  }: ActivateWorkflowAgentParams) => {
     const runs = get().sessionPhaseRuns[sessionId] ?? [];
     const agent = runs.find((r) => r.id === agentId);
     if (!agent || !agent.stepId) {
@@ -37,6 +47,16 @@ export const activateWorkflowAgent = (set: SetFn, get: GetFn) => {
     const session = get().sessions.find((s) => s.id === sessionId);
     if (!session || session.workflowRuns.length === 0) {
       throw new Error('session has no workflow');
+    }
+
+    if (bypassGate !== true) {
+      const blocked = await findWorkflowActivationBlock({
+        sessionId,
+        workflowRunId: agent.workflowRunId,
+      });
+      if (blocked !== null) {
+        throw new WorkflowGateError({ reason: blocked });
+      }
     }
 
     const run = session.workflowRuns.find((r) => r.id === agent.workflowRunId);

--- a/apps/desktop/src/store/slices/workflows/activateWorkflowAgentOrNotify.ts
+++ b/apps/desktop/src/store/slices/workflows/activateWorkflowAgentOrNotify.ts
@@ -1,0 +1,29 @@
+import type { AgentId, SessionId } from '@goodboy/types';
+import type { SpawnFocus } from '../session-view/spawnFocus';
+import { WorkflowGateError } from './workflowActivationGate';
+import type { GetFn } from './types';
+
+type Params = {
+  readonly get: GetFn;
+  readonly sessionId: SessionId;
+  readonly agentId: AgentId;
+  readonly focus: SpawnFocus;
+};
+
+export const activateWorkflowAgentOrNotify = async ({
+  get,
+  sessionId,
+  agentId,
+  focus,
+}: Params): Promise<void> => {
+  try {
+    await get().activateWorkflowAgent({ sessionId, agentId, focus });
+  } catch (error) {
+    if (!(error instanceof WorkflowGateError)) {
+      throw error;
+    }
+    void get().emitNotification('error', 'warning', 'workflow step held back', error.message, {
+      sessionId,
+    });
+  }
+};

--- a/apps/desktop/src/store/slices/workflows/attachWorkflowToSession.navigation.test.ts
+++ b/apps/desktop/src/store/slices/workflows/attachWorkflowToSession.navigation.test.ts
@@ -138,6 +138,10 @@ describe('starting a workflow lands on the workflow detail', () => {
 
     await attachWorkflowToSession(set, get)(SESSION_ID, WF_ID);
 
-    expect(activateWorkflowAgent).toHaveBeenCalledWith(SESSION_ID, 'agent-0', undefined, 'none');
+    expect(activateWorkflowAgent).toHaveBeenCalledWith({
+      sessionId: SESSION_ID,
+      agentId: 'agent-0',
+      focus: 'none',
+    });
   });
 });

--- a/apps/desktop/src/store/slices/workflows/attachWorkflowToSession.ts
+++ b/apps/desktop/src/store/slices/workflows/attachWorkflowToSession.ts
@@ -164,7 +164,11 @@ export const attachWorkflowToSession = (set: SetFn, get: GetFn) => {
       } else if (autoRun) {
         void get().maybeAutoAdvanceWorkflow(sessionId);
       } else if (newAgents.length > 0) {
-        void get().activateWorkflowAgent(sessionId, newAgents[0]!.id, undefined, 'none');
+        void get().activateWorkflowAgent({
+          sessionId,
+          agentId: newAgents[0]!.id,
+          focus: 'none',
+        });
       }
     }
   };

--- a/apps/desktop/src/store/slices/workflows/attachWorkflowToSession.ts
+++ b/apps/desktop/src/store/slices/workflows/attachWorkflowToSession.ts
@@ -15,6 +15,7 @@ import { isWorkflowComplete, runsForWorkflowRun } from '@goodboy/core';
 import { tauriDatabase } from '../../../shared/lib/db';
 import { roleModelsForSession } from '../overrides/roleModelsForSession';
 import { preSpawnWorkflowAgents } from './preSpawnWorkflowAgents';
+import { activateWorkflowAgentOrNotify } from './activateWorkflowAgentOrNotify';
 import type { GetFn, SetFn } from './types';
 
 type Options = {
@@ -164,7 +165,8 @@ export const attachWorkflowToSession = (set: SetFn, get: GetFn) => {
       } else if (autoRun) {
         void get().maybeAutoAdvanceWorkflow(sessionId);
       } else if (newAgents.length > 0) {
-        void get().activateWorkflowAgent({
+        void activateWorkflowAgentOrNotify({
+          get,
           sessionId,
           agentId: newAgents[0]!.id,
           focus: 'none',

--- a/apps/desktop/src/store/slices/workflows/chainTriggers.test.ts
+++ b/apps/desktop/src/store/slices/workflows/chainTriggers.test.ts
@@ -331,12 +331,11 @@ describe('startWorkflowRun', () => {
     const state = baseState(run, agents);
     const { set, get } = harness(state);
     await startWorkflowRun(set, get)(SESSION_ID, 'q' as WorkflowRunId);
-    expect(state['activateWorkflowAgent']).toHaveBeenCalledWith(
-      SESSION_ID,
-      'q-s0',
-      undefined,
-      'none',
-    );
+    expect(state['activateWorkflowAgent']).toHaveBeenCalledWith({
+      sessionId: SESSION_ID,
+      agentId: 'q-s0',
+      focus: 'none',
+    });
     expect(state['setFocusedWorkflowRun']).toHaveBeenCalledWith(SESSION_ID, 'q');
     expect(state['setActiveLens']).not.toHaveBeenCalled();
   });

--- a/apps/desktop/src/store/slices/workflows/chainTriggers.test.ts
+++ b/apps/desktop/src/store/slices/workflows/chainTriggers.test.ts
@@ -54,6 +54,7 @@ vi.mock('../../../features/chat/turn', () => ({ cancelTurn: cancelTurnSpy }));
 import { attachWorkflowToSession } from './attachWorkflowToSession';
 import { maybeAutoAdvanceWorkflow } from './maybeAutoAdvanceWorkflow';
 import { startWorkflowRun } from './startWorkflowRun';
+import { WorkflowGateError } from './workflowActivationGate';
 import { discardWorkflow } from './discardWorkflow';
 
 const WS_ID = 'ws-1' as WorkspaceId;
@@ -304,6 +305,7 @@ describe('startWorkflowRun', () => {
       activateWorkflowAgent: vi.fn(async () => undefined),
       setFocusedWorkflowRun: vi.fn(),
       setActiveLens: vi.fn(),
+      emitNotification: vi.fn(async () => undefined),
     };
   }
 
@@ -338,6 +340,41 @@ describe('startWorkflowRun', () => {
     });
     expect(state['setFocusedWorkflowRun']).toHaveBeenCalledWith(SESSION_ID, 'q');
     expect(state['setActiveLens']).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a gate refusal as a notification instead of throwing out of the run', async () => {
+    const run = makeRun('q', 'manual', { autoRun: false });
+    const state = baseState(run, [makeAgent('q' as WorkflowRunId, 's0', 'pending', 0)]);
+    state.activateWorkflowAgent = vi.fn(async () => {
+      throw new WorkflowGateError({ reason: 'questions' });
+    });
+    const { set, get } = harness(state);
+
+    await expect(
+      startWorkflowRun(set, get)(SESSION_ID, 'q' as WorkflowRunId),
+    ).resolves.toBeUndefined();
+
+    expect(state['emitNotification']).toHaveBeenCalledWith(
+      'error',
+      'warning',
+      'workflow step held back',
+      expect.stringContaining('Open questions'),
+      { sessionId: SESSION_ID },
+    );
+  });
+
+  it('lets a real failure keep propagating', async () => {
+    const run = makeRun('q', 'manual', { autoRun: false });
+    const state = baseState(run, [makeAgent('q' as WorkflowRunId, 's0', 'pending', 0)]);
+    state.activateWorkflowAgent = vi.fn(async () => {
+      throw new Error('provider exploded');
+    });
+    const { set, get } = harness(state);
+
+    await expect(startWorkflowRun(set, get)(SESSION_ID, 'q' as WorkflowRunId)).rejects.toThrow(
+      'provider exploded',
+    );
+    expect(state['emitNotification']).not.toHaveBeenCalled();
   });
 
   it('is a no-op for an already-immediate run', async () => {

--- a/apps/desktop/src/store/slices/workflows/maybeAutoAdvanceWorkflow.test.ts
+++ b/apps/desktop/src/store/slices/workflows/maybeAutoAdvanceWorkflow.test.ts
@@ -133,12 +133,11 @@ describe('maybeAutoAdvanceWorkflow', () => {
     );
     const { set, get } = harness(state);
     await maybeAutoAdvanceWorkflow(set, get)(SESSION_ID);
-    expect(state['activateWorkflowAgent']).toHaveBeenCalledWith(
-      SESSION_ID,
-      `${RUN_ID}-s1`,
-      undefined,
-      'agent',
-    );
+    expect(state['activateWorkflowAgent']).toHaveBeenCalledWith({
+      sessionId: SESSION_ID,
+      agentId: `${RUN_ID}-s1`,
+      focus: 'agent',
+    });
   });
 
   it('does not skip past a step that failed', async () => {
@@ -216,12 +215,11 @@ describe('maybeAutoAdvanceWorkflow', () => {
     await maybeAutoAdvanceWorkflow(set, get)(SESSION_ID);
 
     expect(state['startWorkflowRun']).toHaveBeenCalledWith(SESSION_ID, CHAINED_ID);
-    expect(state['activateWorkflowAgent']).toHaveBeenCalledWith(
-      SESSION_ID,
-      `${CHAINED_ID}-s0`,
-      undefined,
-      'agent',
-    );
+    expect(state['activateWorkflowAgent']).toHaveBeenCalledWith({
+      sessionId: SESSION_ID,
+      agentId: `${CHAINED_ID}-s0`,
+      focus: 'agent',
+    });
   });
 
   it('holds while the summarizer runs and advances once it finishes', async () => {
@@ -235,12 +233,11 @@ describe('maybeAutoAdvanceWorkflow', () => {
 
     state['summarizerStatus'] = { [SESSION_ID]: { status: 'idle' } };
     await advance(SESSION_ID);
-    expect(state['activateWorkflowAgent']).toHaveBeenCalledWith(
-      SESSION_ID,
-      `${RUN_ID}-s0`,
-      undefined,
-      'agent',
-    );
+    expect(state['activateWorkflowAgent']).toHaveBeenCalledWith({
+      sessionId: SESSION_ID,
+      agentId: `${RUN_ID}-s0`,
+      focus: 'agent',
+    });
   });
 
   it('orchestrates a dynamic run when no pending agent exists', async () => {

--- a/apps/desktop/src/store/slices/workflows/maybeAutoAdvanceWorkflow.ts
+++ b/apps/desktop/src/store/slices/workflows/maybeAutoAdvanceWorkflow.ts
@@ -127,7 +127,11 @@ const runAdvance = async ({ set, get, sessionId }: Params): Promise<void> => {
     }
     return;
   }
-  await get().activateWorkflowAgent(sessionId, nextPendingAgent.id, undefined, 'agent');
+  await get().activateWorkflowAgent({
+    sessionId,
+    agentId: nextPendingAgent.id,
+    focus: 'agent',
+  });
   void get().emitNotification(
     'agent-auto-spawn',
     'info',

--- a/apps/desktop/src/store/slices/workflows/maybeAutoAdvanceWorkflow.ts
+++ b/apps/desktop/src/store/slices/workflows/maybeAutoAdvanceWorkflow.ts
@@ -5,6 +5,7 @@ import { tauriDatabase } from '../../../shared/lib/db';
 import { workflowRunHasOpenQuestions } from '../../../features/context/openQuestionsGate';
 import { BUDGET_BLOCK_MESSAGE, isBudgetBlocked } from './budgetBlock';
 import { persistOrchestrationStop } from './orchestrateNextStep';
+import { activateWorkflowAgentOrNotify } from './activateWorkflowAgentOrNotify';
 import type { GetFn, SetFn } from './types';
 
 const advanceInFlight = new Set<SessionId>();
@@ -127,7 +128,8 @@ const runAdvance = async ({ set, get, sessionId }: Params): Promise<void> => {
     }
     return;
   }
-  await get().activateWorkflowAgent({
+  await activateWorkflowAgentOrNotify({
+    get,
     sessionId,
     agentId: nextPendingAgent.id,
     focus: 'agent',

--- a/apps/desktop/src/store/slices/workflows/orchestrateNextStep.test.ts
+++ b/apps/desktop/src/store/slices/workflows/orchestrateNextStep.test.ts
@@ -3,6 +3,8 @@ import type {
   Agent,
   AgentId,
   IsoDateTime,
+  OpenQuestion,
+  OpenQuestionId,
   ProviderRunId,
   Session,
   SessionId,
@@ -33,7 +35,7 @@ const {
   decideSpy: vi.fn(),
   invokeWorkflowUpsertSpy: vi.fn(),
   invokeAgentInsertSpy: vi.fn(),
-  listOpenQuestionsSpy: vi.fn(async () => []),
+  listOpenQuestionsSpy: vi.fn(async () => [] as ReadonlyArray<OpenQuestion>),
   updateOutcomeSpy: vi.fn(async () => undefined),
   updateStopSpy: vi.fn(async () => undefined),
   insertProviderRunSpy: vi.fn(async () => undefined),
@@ -150,6 +152,17 @@ const session = (): Session => ({
   updatedAt: NOW,
 });
 
+const openQuestion = (): OpenQuestion => ({
+  id: 'oq-1' as OpenQuestionId,
+  sessionId: SESSION_ID,
+  workflowRunId: WORKFLOW_RUN_ID,
+  text: 'which database?',
+  suggestedAnswers: [],
+  userAnswer: null,
+  status: 'open',
+  createdAt: NOW,
+});
+
 const completedAgent = (): Agent => ({
   id: AGENT_ID,
   sessionId: SESSION_ID,
@@ -249,6 +262,7 @@ describe('orchestrateNextStep', () => {
       sessionId: SESSION_ID,
       agentId: 'agent-2',
       focus: 'agent',
+      bypassGate: true,
     });
     expect(state['appendTurnEvent']).toHaveBeenCalledWith(
       'agent-2',
@@ -922,5 +936,48 @@ describe('orchestrateNextStep', () => {
     });
     const paused = (state['sessions'] as ReadonlyArray<Session>)[0]!.workflowRuns[0]!;
     expect(paused.orchestrationStop?.kind).toBe('budget');
+  });
+
+  it('stops on an open question before mutating anything, and says so on the run', async () => {
+    listOpenQuestionsSpy.mockResolvedValue([openQuestion()]);
+    const state = baseState();
+    const { set, get } = harness(state);
+
+    await orchestrateNextStep(set, get)(SESSION_ID, WORKFLOW_RUN_ID);
+
+    expect(decideSpy).not.toHaveBeenCalled();
+    expect(invokeAgentInsertSpy).not.toHaveBeenCalled();
+    expect(invokeWorkflowUpsertSpy).not.toHaveBeenCalled();
+    expect(state['activateWorkflowAgent']).not.toHaveBeenCalled();
+    expect(updateStopSpy).toHaveBeenCalledWith({}, WORKFLOW_RUN_ID, {
+      kind: 'questions',
+      message: expect.stringContaining('Open questions'),
+    });
+    const paused = (state['sessions'] as ReadonlyArray<Session>)[0]!.workflowRuns[0]!;
+    expect(paused.orchestrationStop?.kind).toBe('questions');
+  });
+
+  it('decides anyway when the operator forced a skip, which already cleared the gate', async () => {
+    listOpenQuestionsSpy.mockResolvedValue([openQuestion()]);
+    decideSpy.mockResolvedValue({
+      usage: NO_USAGE,
+      decision: {
+        action: 'next',
+        reason: 'The implementation is ready.',
+        step: { name: 'Implement', role: 'implementer', promptPrefix: 'Implement it.' },
+      },
+    });
+    const state = baseState();
+    const { set, get } = harness(state);
+
+    await orchestrateNextStep(set, get)(SESSION_ID, WORKFLOW_RUN_ID, { bypassGate: true });
+
+    expect(decideSpy).toHaveBeenCalledTimes(1);
+    expect(state['activateWorkflowAgent']).toHaveBeenCalledWith({
+      sessionId: SESSION_ID,
+      agentId: 'agent-2',
+      focus: 'agent',
+      bypassGate: true,
+    });
   });
 });

--- a/apps/desktop/src/store/slices/workflows/orchestrateNextStep.test.ts
+++ b/apps/desktop/src/store/slices/workflows/orchestrateNextStep.test.ts
@@ -245,12 +245,11 @@ describe('orchestrateNextStep', () => {
     expect(templates[WORKSPACE_ID]![0]!.steps).toHaveLength(2);
     const agents = (state['sessionPhaseRuns'] as Record<string, ReadonlyArray<Agent>>)[SESSION_ID]!;
     expect(agents[1]).toMatchObject({ name: 'Implement', status: 'pending' });
-    expect(state['activateWorkflowAgent']).toHaveBeenCalledWith(
-      SESSION_ID,
-      'agent-2',
-      undefined,
-      'agent',
-    );
+    expect(state['activateWorkflowAgent']).toHaveBeenCalledWith({
+      sessionId: SESSION_ID,
+      agentId: 'agent-2',
+      focus: 'agent',
+    });
     expect(state['appendTurnEvent']).toHaveBeenCalledWith(
       'agent-2',
       SESSION_ID,

--- a/apps/desktop/src/store/slices/workflows/orchestrateNextStep.ts
+++ b/apps/desktop/src/store/slices/workflows/orchestrateNextStep.ts
@@ -44,11 +44,14 @@ import { getSessionRepo } from '../worktrees/getSessionRepo';
 import { preSpawnWorkflowAgents } from './preSpawnWorkflowAgents';
 import { patchWorkflowRun, withoutKeys } from './patchWorkflowRun';
 import { recordOrchestratorUsage } from './recordOrchestratorUsage';
+import { findWorkflowActivationBlock } from './workflowActivationGate';
+import { WORKFLOW_BLOCK_COPY } from '../../../features/workflows/blockCopy';
 import type { GetFn, SetFn } from './types';
 
 export type OrchestrateOptions = {
   readonly routing?: OrchestratorRouting;
   readonly extraHints?: string;
+  readonly bypassGate?: boolean;
 };
 
 const orchestrationInFlight = new Set<WorkflowRunId>();
@@ -349,6 +352,18 @@ export const orchestrateNextStep = (set: SetFn, get: GetFn) => {
         });
         return;
       }
+      if (options?.bypassGate !== true) {
+        const blocked = await findWorkflowActivationBlock({ sessionId, workflowRunId });
+        if (blocked !== null) {
+          await persistOrchestrationStop({
+            set,
+            sessionId,
+            workflowRunId,
+            stop: { kind: 'questions', message: WORKFLOW_BLOCK_COPY[blocked] },
+          });
+          return;
+        }
+      }
       if (workflow.steps.length >= ORCHESTRATOR_STEP_HARD_CAP) {
         const reason = `the run reached the hard cap of ${ORCHESTRATOR_STEP_HARD_CAP} steps without closing. Review what the steps produced and start a new run for what is left.`;
         await persistOrchestrationOutcome({
@@ -518,7 +533,12 @@ export const orchestrateNextStep = (set: SetFn, get: GetFn) => {
           model: result.model,
           usage: result.usage,
         });
-        await get().activateWorkflowAgent({ sessionId, agentId: agent.id, focus: 'agent' });
+        await get().activateWorkflowAgent({
+          sessionId,
+          agentId: agent.id,
+          focus: 'agent',
+          bypassGate: true,
+        });
         return;
       }
       await persistOrchestrationOutcome({

--- a/apps/desktop/src/store/slices/workflows/orchestrateNextStep.ts
+++ b/apps/desktop/src/store/slices/workflows/orchestrateNextStep.ts
@@ -518,7 +518,7 @@ export const orchestrateNextStep = (set: SetFn, get: GetFn) => {
           model: result.model,
           usage: result.usage,
         });
-        await get().activateWorkflowAgent(sessionId, agent.id, undefined, 'agent');
+        await get().activateWorkflowAgent({ sessionId, agentId: agent.id, focus: 'agent' });
         return;
       }
       await persistOrchestrationOutcome({

--- a/apps/desktop/src/store/slices/workflows/skipStuckStepAndAdvance.test.ts
+++ b/apps/desktop/src/store/slices/workflows/skipStuckStepAndAdvance.test.ts
@@ -218,7 +218,7 @@ describe('skipStuckStepAndAdvance', () => {
       expect.objectContaining({ status: 'skipped' }),
     );
     expect(activateWorkflowAgent).not.toHaveBeenCalled();
-    expect(orchestrateNextStep).toHaveBeenCalledWith(SESSION_ID, RUN_ID);
+    expect(orchestrateNextStep).toHaveBeenCalledWith(SESSION_ID, RUN_ID, { bypassGate: true });
   });
 
   it('leaves a dynamic run alone once the orchestrator already closed it', async () => {

--- a/apps/desktop/src/store/slices/workflows/skipStuckStepAndAdvance.test.ts
+++ b/apps/desktop/src/store/slices/workflows/skipStuckStepAndAdvance.test.ts
@@ -94,14 +94,15 @@ const nextAgent: Agent = {
   status: 'pending',
 };
 
-const buildHarness = (turnKind: 'idle' | 'running') => {
+const buildHarness = (turnKind: 'idle' | 'running' | 'unseeded') => {
   const activateWorkflowAgent = vi.fn();
   const orchestrateNextStep = vi.fn();
   const state = {
     sessions: [session],
     phaseTemplates: { [WORKSPACE_ID]: [workflow] },
     sessionPhaseRuns: { [SESSION_ID]: [stuckAgent, nextAgent] },
-    agentTurnState: { [STUCK]: { kind: turnKind, lastActivityAt: NOW } },
+    agentTurnState:
+      turnKind === 'unseeded' ? {} : { [STUCK]: { kind: turnKind, lastActivityAt: NOW } },
     activateWorkflowAgent,
     orchestrateNextStep,
     refreshUnreadWorkspaces: vi.fn(),
@@ -172,7 +173,7 @@ describe('skipStuckStepAndAdvance', () => {
     vi.clearAllMocks();
   });
 
-  it('skips a paused running step and activates the next pending step', async () => {
+  it('skips a paused step and starts the next one past the gate the operator just acknowledged', async () => {
     const { run, activateWorkflowAgent } = buildHarness('idle');
 
     await run(SESSION_ID, RUN_ID);
@@ -181,11 +182,25 @@ describe('skipStuckStepAndAdvance', () => {
       STUCK,
       expect.objectContaining({ status: 'skipped' }),
     );
-    expect(activateWorkflowAgent).toHaveBeenCalledWith(SESSION_ID, NEXT, undefined, 'agent');
+    expect(activateWorkflowAgent).toHaveBeenCalledWith({
+      sessionId: SESSION_ID,
+      agentId: NEXT,
+      focus: 'agent',
+      bypassGate: true,
+    });
   });
 
   it('does not skip a step with a live turn', async () => {
     const { run, activateWorkflowAgent } = buildHarness('running');
+
+    await run(SESSION_ID, RUN_ID);
+
+    expect(invokeAgentUpdateStatusSpy).not.toHaveBeenCalled();
+    expect(activateWorkflowAgent).not.toHaveBeenCalled();
+  });
+
+  it('refuses a background session where the persisted status is the only signal', async () => {
+    const { run, activateWorkflowAgent } = buildHarness('unseeded');
 
     await run(SESSION_ID, RUN_ID);
 

--- a/apps/desktop/src/store/slices/workflows/skipStuckStepAndAdvance.ts
+++ b/apps/desktop/src/store/slices/workflows/skipStuckStepAndAdvance.ts
@@ -66,7 +66,7 @@ export const skipStuckStepAndAdvance = (set: SetFn, get: GetFn) => {
       }
     }
     if (run.executionMode === 'dynamic' && run.orchestrationOutcome == null) {
-      await get().orchestrateNextStep(sessionId, workflowRunId);
+      await get().orchestrateNextStep(sessionId, workflowRunId, { bypassGate: true });
     }
   };
 };

--- a/apps/desktop/src/store/slices/workflows/skipStuckStepAndAdvance.ts
+++ b/apps/desktop/src/store/slices/workflows/skipStuckStepAndAdvance.ts
@@ -41,6 +41,9 @@ export const skipStuckStepAndAdvance = (set: SetFn, get: GetFn) => {
     if (turn?.kind === 'running' || turn?.kind === 'starting') {
       return;
     }
+    if (stuckAgent.status === 'running' && turn === undefined) {
+      return;
+    }
     await invokeAgentUpdateStatus(stuckAgent.id, { status: 'skipped', completedAt: nowIso() });
     const refreshed = await invokeAgentList(sessionId);
     set((s) => ({ sessionPhaseRuns: { ...s.sessionPhaseRuns, [sessionId]: refreshed } }));
@@ -53,7 +56,12 @@ export const skipStuckStepAndAdvance = (set: SetFn, get: GetFn) => {
         (candidate) => candidate.stepId === nextChain.step.id && candidate.status === 'pending',
       );
       if (nextAgent != null) {
-        await get().activateWorkflowAgent(sessionId, nextAgent.id, undefined, 'agent');
+        await get().activateWorkflowAgent({
+          sessionId,
+          agentId: nextAgent.id,
+          focus: 'agent',
+          bypassGate: true,
+        });
         return;
       }
     }

--- a/apps/desktop/src/store/slices/workflows/startWorkflowRun.ts
+++ b/apps/desktop/src/store/slices/workflows/startWorkflowRun.ts
@@ -2,6 +2,7 @@ import type { IsoDateTime, SessionId, WorkflowRunId } from '@goodboy/types';
 import { updateSessionWorkflowTriggerMode } from '@goodboy/db';
 import { runsForWorkflowRun } from '@goodboy/core';
 import { tauriDatabase } from '../../../shared/lib/db';
+import { activateWorkflowAgentOrNotify } from './activateWorkflowAgentOrNotify';
 import type { GetFn, SetFn } from './types';
 
 export const startWorkflowRun = (set: SetFn, get: GetFn) => {
@@ -49,7 +50,12 @@ export const startWorkflowRun = (set: SetFn, get: GetFn) => {
       .sort((a, b) => a.ordinal - b.ordinal)
       .find((r) => r.status === 'pending');
     if (firstPending) {
-      await get().activateWorkflowAgent({ sessionId, agentId: firstPending.id, focus: 'none' });
+      await activateWorkflowAgentOrNotify({
+        get,
+        sessionId,
+        agentId: firstPending.id,
+        focus: 'none',
+      });
       return;
     }
     if (run.executionMode === 'dynamic') {

--- a/apps/desktop/src/store/slices/workflows/startWorkflowRun.ts
+++ b/apps/desktop/src/store/slices/workflows/startWorkflowRun.ts
@@ -49,7 +49,7 @@ export const startWorkflowRun = (set: SetFn, get: GetFn) => {
       .sort((a, b) => a.ordinal - b.ordinal)
       .find((r) => r.status === 'pending');
     if (firstPending) {
-      await get().activateWorkflowAgent(sessionId, firstPending.id, undefined, 'none');
+      await get().activateWorkflowAgent({ sessionId, agentId: firstPending.id, focus: 'none' });
       return;
     }
     if (run.executionMode === 'dynamic') {

--- a/apps/desktop/src/store/slices/workflows/workflowActivationGate.ts
+++ b/apps/desktop/src/store/slices/workflows/workflowActivationGate.ts
@@ -1,0 +1,39 @@
+import { listOpenQuestionsForSession } from '@goodboy/db';
+import type { SessionId, WorkflowRunId } from '@goodboy/types';
+import { tauriDatabase } from '../../../shared/lib/db';
+import { workflowRunHasOpenQuestions } from '../../../features/context/openQuestionsGate';
+import { WORKFLOW_BLOCK_COPY } from '../../../features/workflows/blockCopy';
+import type { WorkflowBlockReason } from '../../../features/workflows/advanceGate';
+
+type ErrorParams = {
+  readonly reason: WorkflowBlockReason;
+};
+
+export class WorkflowGateError extends Error {
+  readonly reason: WorkflowBlockReason;
+
+  constructor({ reason }: ErrorParams) {
+    super(WORKFLOW_BLOCK_COPY[reason]);
+    this.name = 'WorkflowGateError';
+    this.reason = reason;
+  }
+}
+
+type Params = {
+  readonly sessionId: SessionId;
+  readonly workflowRunId: WorkflowRunId | undefined;
+};
+
+export const findWorkflowActivationBlock = async ({
+  sessionId,
+  workflowRunId,
+}: Params): Promise<WorkflowBlockReason | null> => {
+  if (workflowRunId == null) {
+    return null;
+  }
+  const questions = await listOpenQuestionsForSession(tauriDatabase, sessionId, 'open');
+  if (!workflowRunHasOpenQuestions(questions, workflowRunId)) {
+    return null;
+  }
+  return 'questions';
+};

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -126,6 +126,7 @@ import { createOverridesSlice } from './slices/overrides';
 import { createCredentialsSlice } from './slices/credentials';
 import { createWorkflowsSlice } from './slices/workflows';
 import type { OrchestrateOptions } from './slices/workflows/orchestrateNextStep';
+import type { ActivateWorkflowAgentParams } from './slices/workflows/activateWorkflowAgent';
 import { createSettingsSlice } from './slices/settings';
 import { createConflictsSlice } from './slices/conflicts';
 import { createTranscriptsSlice } from './slices/transcripts';
@@ -281,12 +282,7 @@ export type AppActions = {
     sessionId: SessionId,
     workflowRunIds: ReadonlyArray<WorkflowRunId>,
   ): Promise<void>;
-  activateWorkflowAgent(
-    sessionId: SessionId,
-    agentId: AgentId,
-    explicitPlanId?: PlanId,
-    focus?: SpawnFocus,
-  ): Promise<void>;
+  activateWorkflowAgent(params: ActivateWorkflowAgentParams): Promise<void>;
   advanceClusterImplementation(
     sessionId: SessionId,
     childAgentId: AgentId,

--- a/packages/types/src/workspace.ts
+++ b/packages/types/src/workspace.ts
@@ -86,7 +86,7 @@ export type WorkflowExecutionMode = 'static' | 'dynamic';
 
 export type WorkflowOrchestrationOutcome = 'done' | 'blocked';
 
-export type WorkflowOrchestrationStopKind = 'failure' | 'budget';
+export type WorkflowOrchestrationStopKind = 'failure' | 'budget' | 'questions';
 
 export type WorkflowOrchestrationStop = Readonly<{
   kind: WorkflowOrchestrationStopKind;


### PR DESCRIPTION
## What

Moves the open-question gate out of the callers and into the engine.
`activateWorkflowAgent` now refuses to start a pending step whose workflow run
has an unanswered question, **default-on**, and only an explicit `bypassGate`
flag gets past it. Every refusal reaches the user.

## Why

v0.1.59 closed three manual UI bypasses one call site at a time. The gate still
lived in the callers, so every new entry point could forget it, and one already
had: `advanceNextWorkflowStep` in the mobile bridge (`commandExecutor.ts`)
reimplemented next-step selection and activated with zero gating. A phone tap
could force a step past a gate the desktop blocks on.

Precedent: Claude Code enforces permission and plan gates in the engine loop,
default-on, bypassed only by an explicit flag, never by whichever UI remembered
to check.

## How

- New `store/slices/workflows/workflowActivationGate.ts`:
  `findWorkflowActivationBlock` reads the open questions for the session from
  the DB (the authoritative source, not the store, which is only hydrated for
  the session currently open) and returns a `WorkflowBlockReason` or `null`.
  `WorkflowGateError` carries that reason and its user-facing copy.
- `activateWorkflowAgent` takes one named destructured param
  (`ActivateWorkflowAgentParams`) instead of four positional args, so
  `bypassGate` is explicit and typed at every call site. The gate runs before
  any state mutation, so a blocked activation leaves nothing half-applied.
- The gate fails **closed**, and a refusal is never allowed to disappear:
  - the mobile bridge converts it into a `BridgeSafeError` carrying the real
    reason instead of the generic mask;
  - `orchestrateNextStep` pre-checks and persists an `orchestrationStop` of the
    new kind `questions`, which the orchestrator panel already renders as
    `needs-answer` with an "Answer question" CTA;
  - the remaining fire-and-forget activations go through
    `activateWorkflowAgentOrNotify`, which turns a `WorkflowGateError` into a
    "workflow step held back" notification and lets every other error keep
    propagating;
  - on desktop the existing blocked CTA and inline block copy still explain the
    block on their own.

### Who bypasses, and why

Four call sites pass a bypass, each with a test asserting why:

- `skipStuckStepAndAdvance`: the operator explicitly confirmed skipping a
  blocked step; the next step must start. It also threads `bypassGate` into
  `orchestrateNextStep`, so a confirmed force-skip is not silently dropped on
  dynamic runs, which is exactly the case the bypass exists for.
- `useAgentsSection.onStartStepAgent` when `isConfirmed` is true: post-confirm
  "Start anyway" from the sidebar.
- `ChatWorkflowAdvance` when the CTA reports a confirmed start: post-confirm
  "Start anyway" from the chat strip.
- `orchestrateNextStep` when it activates the step it just decided: it ran the
  same gate itself, earlier and better, before inserting anything.

Everything else (mobile bridge, auto-advance, plan run, workflow attach/start,
pipeline lane) is gated.

## Also fixed here

- **`orchestrateNextStep` could half-apply and then throw into a `void`.** It is
  reachable from "Retry" (`retryWorkflowOrchestration`), "Continue the run"
  (`continueWorkflowRun`) and the force-skip path, none of which go through
  `maybeAutoAdvanceWorkflow`, and `orchestratorState` resolves `failed`/`blocked`
  /`done` before `needs-answer`, so those buttons are on screen while questions
  are open. The refusal used to land after the run had been mutated and a
  `pending` agent row inserted that would never start. The pre-check now runs
  before any mutation and leaves a durable, actionable stop instead.
- **`skipStuckStepAndAdvance` trusted memory over the DB.** It guarded only on
  `agentTurnState`, which `setCurrentSession` seeds *only for the session
  currently open*. `WorkflowRow` fires this for background sessions, where the
  map is empty, so a genuinely `running` agent could be marked `skipped` and its
  output dropped from carry-forward. It now refuses when the persisted status is
  `running` and there is no in-memory turn state to contradict it. In-memory
  state remains an additional signal (a seeded `idle`/`error` turn still means
  the run really stopped, which is the case force-advance exists for), never the
  only one.
- **`WorkflowRow` passed `isConfirmed: true` unconditionally**, disabling the
  fail-closed guard #1212 added for the CTA path. Correct only by accident,
  because the CTA gated upstream. `useStartAnywayConfirm` now reports whether
  the start came through the confirm dialog, `WorkflowNextStepCta` forwards it
  to `onAdvance`, and the row passes the real value.
- **Mobile advance yanked the desktop into a chat.** The bridge's
  `advanceNextWorkflowStep` activated with `focus: 'agent'`; it now uses
  `focus: 'none'`. A tap on the phone should not move the desktop user's view.
  (The `ChatInput` twin of this issue belongs to another PR and is untouched.
  The two `spawnAgent` `focus: 'agent'` calls in the bridge are deliberate
  explicit spawn requests and are left alone.)
- `WorkflowNextStepCta.onAdvance` takes one named destructured param, per the
  house rule, so consumers no longer need positional placeholders.

`WorkflowOrchestrationStopKind` gains `questions`. No migration: the kind is
stored in the existing `orchestration_stop_kind` TEXT column and round-trips as
a plain string.

## Tests

Added:

- engine gate blocks a pending step with an unanswered question, mutating no
  state and sending no turn;
- the gate blocks the mobile bridge call shape (no caller gate, no bypass flag)
  with a `WorkflowGateError` whose reason is `questions`;
- `bypassGate: true` starts the step despite open questions (skip path);
- the bridge surfaces the gate refusal to the phone instead of forcing the step;
- `orchestrateNextStep` stops on an open question before calling the
  orchestrator, before upserting the workflow and before inserting the agent,
  and records a `questions` stop on the run;
- `orchestrateNextStep` still decides when the operator forced a skip;
- the orchestrator panel reads a `questions` stop as "answer the question", with
  no retry on offer;
- `startWorkflowRun` surfaces a gate refusal as a notification instead of
  throwing out of the run, and still lets a real failure propagate;
- `skipStuckStepAndAdvance` refuses to skip an agent whose persisted status is
  `running` when `agentTurnState` was never seeded, and threads its bypass into
  the dynamic branch;
- `skipStuckStepAndAdvance`, the sidebar CTA and the chat CTA each assert their
  `bypassGate` value and the confirmation that earns it.

No test was deleted. Every existing assertion on `activateWorkflowAgent` was
rewritten from positional args to the object shape; all of them still assert the
same behavior. Two `AgentsSection.test.tsx` tests were retitled because they now
pin the bypass flag rather than the bare call
("starts the step agent when the run is not blocked, without asking the engine
to bypass" and "bypasses the engine gate only once the operator confirmed the
blocked start"). The two `WorkflowNextStepCta` `onAdvance` assertions were
updated for the object param and now also pin `isConfirmed`.

Out of scope on purpose: the five duplicate "next runnable step"
implementations, and the orphan-question semantics of
`workflowRunHasOpenQuestions` (a question with no `workflowRunId` matches every
run). The latter is why the surfacing paths above matter, but changing it
belongs in its own PR.

## Test plan

- `pnpm typecheck` green
- `pnpm test` green: ui 100, core 1047, db 176, desktop 4371
- `pnpm knip --include files,duplicates,unlisted` green
