### PR TITLE
fix(desktop): post resolve replies once and count outcomes honestly

### DIFF
--- a/apps/desktop/src/features/session/components/AgentInspector/resolver.test.tsx
+++ b/apps/desktop/src/features/session/components/AgentInspector/resolver.test.tsx
@@ -32,6 +32,7 @@ const h = vi.hoisted(() => {
     activateNextResolver: vi.fn(async () => undefined),
     sendTurn: vi.fn(async () => undefined),
     selectAgent: vi.fn(async () => undefined),
+    emitNotification: vi.fn(async () => undefined),
     setAgentDone: vi.fn(async () => undefined),
     clearAgentDone: vi.fn(async () => undefined),
     deleteAgent: vi.fn(async () => undefined),
@@ -164,6 +165,7 @@ const reset = ({
     activateNextResolver: h.activateNextResolver,
     sendTurn: h.sendTurn,
     selectAgent: h.selectAgent,
+    emitNotification: h.emitNotification,
     setAgentDone: h.setAgentDone,
     clearAgentDone: h.clearAgentDone,
     deleteAgent: h.deleteAgent,
@@ -537,6 +539,26 @@ describe('AgentInspector (resolver)', () => {
         agentId: SETTLED_ID,
         content: expect.stringContaining('PRRT_3'),
       }),
+    );
+  });
+
+  it('surfaces a failed resolver turn instead of swallowing it', async () => {
+    reset({
+      resolverState: { [SETTLED_ID]: 'wontfix' },
+      outcomes: { [SETTLED_ID]: { PRRT_3: { kind: 'wontfix', reason: 'the branch is dead' } } },
+    });
+    h.sendTurn.mockRejectedValueOnce(new Error('provider exited without a response'));
+    renderInspector(SETTLED_ID);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Fix it anyway' }));
+
+    await vi.waitFor(() => expect(h.emitNotification).toHaveBeenCalledTimes(1));
+    expect(h.emitNotification).toHaveBeenCalledWith(
+      'error',
+      'error',
+      'resolver turn failed',
+      'provider exited without a response',
+      { sessionId: SESSION_ID },
     );
   });
 

--- a/apps/desktop/src/features/session/hooks/useResolverActions/index.ts
+++ b/apps/desktop/src/features/session/hooks/useResolverActions/index.ts
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import type { Agent, PendingResolution, SessionId } from '@goodboy/types';
 import { useAppStore } from '../../../../store';
 import type { ResolverThreadOutcome } from '../../../../store/types';
+import { formatError } from '../../../../shared/lib/errors';
 import { PROCEED_RESOLVER_PROMPT } from '../../../../shared/utils/proceedResolverPrompt';
 import { RERUN_RESOLVER_PROMPT } from '../../../../shared/utils/rerunResolverPrompt';
 import { agentThreadIds } from '../../agentThreadIds';
@@ -101,6 +102,7 @@ export const useResolverActions = ({
   const forceCloseResolver = useAppStore((state) => state.forceCloseResolver);
   const sendTurn = useAppStore((state) => state.sendTurn);
   const selectAgent = useAppStore((state) => state.selectAgent);
+  const emitNotification = useAppStore((state) => state.emitNotification);
   const turnState = useAppStore((state) => state.agentTurnState[agent.id]);
   const prNumber = useAppStore((state) => state.sessionGithub[sessionId]?.pr?.number ?? null);
   const pending =
@@ -177,9 +179,19 @@ export const useResolverActions = ({
     return [];
   });
 
+  const notifyTurnFailed = ({ error }: { readonly error: unknown }) => {
+    void emitNotification('error', 'error', 'resolver turn failed', formatError(error), {
+      sessionId,
+    });
+  };
+
   const sendToAgent = async ({ content }: { readonly content: string }) => {
     await selectAgent(sessionId, agent.id);
-    await sendTurn({ sessionId, agentId: agent.id, content });
+    try {
+      await sendTurn({ sessionId, agentId: agent.id, content });
+    } catch (error) {
+      notifyTurnFailed({ error });
+    }
   };
 
   const dispatchThread = async ({ threadId, kind, text, notes = '' }: ResolverThreadRunParams) => {
@@ -287,12 +299,20 @@ export const useResolverActions = ({
       return;
     }
     if (kind === 'proceed') {
-      await sendTurn({ sessionId, agentId: agent.id, content: PROCEED_RESOLVER_PROMPT });
+      try {
+        await sendTurn({ sessionId, agentId: agent.id, content: PROCEED_RESOLVER_PROMPT });
+      } catch (error) {
+        notifyTurnFailed({ error });
+      }
       return;
     }
     if (kind === 'rerun') {
       await selectAgent(sessionId, agent.id);
-      await sendTurn({ sessionId, agentId: agent.id, content: RERUN_RESOLVER_PROMPT });
+      try {
+        await sendTurn({ sessionId, agentId: agent.id, content: RERUN_RESOLVER_PROMPT });
+      } catch (error) {
+        notifyTurnFailed({ error });
+      }
       return;
     }
     if (kind === 'answer') {

--- a/apps/desktop/src/features/session/resolverThreadSettlements.test.ts
+++ b/apps/desktop/src/features/session/resolverThreadSettlements.test.ts
@@ -68,6 +68,7 @@ describe('resolverThreadSettlements', () => {
       commitSha: 'abcdef1234567890',
       reply: 'legacy resolver reply',
       outcome: null,
+      replyPostedAt: null,
       createdAt: '2026-05-28T00:00:00.000Z' as IsoDateTime,
     } satisfies PendingResolution;
 

--- a/apps/desktop/src/store/slices/agents/activateNextResolver.test.ts
+++ b/apps/desktop/src/store/slices/agents/activateNextResolver.test.ts
@@ -102,6 +102,46 @@ describe('activateNextResolver', () => {
     );
   });
 
+  it('does not start a second resolver while the first activation is still landing over ipc', async () => {
+    let releaseSendTurn: (() => void) | undefined;
+    const sendTurn = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseSendTurn = () => resolve();
+        }),
+    );
+    const selectAgent = vi.fn(async () => undefined);
+    const state: Record<string, unknown> = {
+      sessionPhaseRuns: {
+        [SID]: [resolver({ id: FIRST, ordinal: 1 }), resolver({ id: SECOND, ordinal: 2 })],
+      },
+      agentKindOverride: {},
+      pendingResolverKickoff: { [FIRST]: 'fix comment one', [SECOND]: 'fix comment two' },
+      sendTurn,
+      selectAgent,
+    };
+    const get = (() => state) as unknown as GetFn;
+    const set = ((u: unknown) => {
+      const patch =
+        typeof u === 'function'
+          ? (u as (s: Record<string, unknown>) => Record<string, unknown>)(state)
+          : (u as Record<string, unknown>);
+      Object.assign(state, patch);
+    }) as unknown as SetFn;
+
+    const activate = activateNextResolver(set, get);
+    const first = activate(SID);
+    const second = activate(SID);
+    await Promise.all([first, second]);
+
+    expect(sendTurn).toHaveBeenCalledOnce();
+    expect(sendTurn).toHaveBeenCalledWith(expect.objectContaining({ agentId: FIRST }));
+
+    releaseSendTurn?.();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+
   it('ignores a force closed resolver when picking the next one', async () => {
     const { get, set, sendTurn } = makeStore({
       agents: [

--- a/apps/desktop/src/store/slices/agents/activateNextResolver.test.ts
+++ b/apps/desktop/src/store/slices/agents/activateNextResolver.test.ts
@@ -142,6 +142,50 @@ describe('activateNextResolver', () => {
     await Promise.resolve();
   });
 
+  it('lets the chain hand off to the next resolver from inside the finishing turn', async () => {
+    const started: AgentId[] = [];
+    const state: Record<string, unknown> = {
+      sessionPhaseRuns: {
+        [SID]: [resolver({ id: FIRST, ordinal: 1 }), resolver({ id: SECOND, ordinal: 2 })],
+      },
+      agentKindOverride: {},
+      pendingResolverKickoff: { [FIRST]: 'fix comment one', [SECOND]: 'fix comment two' },
+    };
+    const get = (() => state) as unknown as GetFn;
+    const set = ((u: unknown) => {
+      const patch =
+        typeof u === 'function'
+          ? (u as (s: Record<string, unknown>) => Record<string, unknown>)(state)
+          : (u as Record<string, unknown>);
+      Object.assign(state, patch);
+    }) as unknown as SetFn;
+
+    const sendTurn = vi.fn(async ({ agentId }: { agentId: AgentId }) => {
+      started.push(agentId);
+      const setStatus = (status: Agent['status']) => {
+        const runs = (state.sessionPhaseRuns as Record<string, ReadonlyArray<Agent>>)[SID] ?? [];
+        state.sessionPhaseRuns = {
+          ...(state.sessionPhaseRuns as Record<string, ReadonlyArray<Agent>>),
+          [SID]: runs.map((agent) => (agent.id === agentId ? { ...agent, status } : agent)),
+        };
+      };
+      setStatus('running');
+      await Promise.resolve();
+      setStatus('completed');
+      if (agentId === FIRST) {
+        await activateNextResolver(set, get)(SID);
+      }
+    });
+    state.sendTurn = sendTurn;
+    state.selectAgent = vi.fn(async () => undefined);
+
+    await activateNextResolver(set, get)(SID);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(started).toEqual([FIRST, SECOND]);
+  });
+
   it('ignores a force closed resolver when picking the next one', async () => {
     const { get, set, sendTurn } = makeStore({
       agents: [

--- a/apps/desktop/src/store/slices/agents/activateNextResolver.ts
+++ b/apps/desktop/src/store/slices/agents/activateNextResolver.ts
@@ -2,8 +2,13 @@ import type { SessionId } from '@goodboy/types';
 import { classifyAgent } from '../../../features/session/agent-kind';
 import type { GetFn, SetFn } from './types';
 
+const resolverActivationsInFlight = new Set<SessionId>();
+
 export const activateNextResolver = (set: SetFn, get: GetFn) => {
   return async (sessionId: SessionId): Promise<void> => {
+    if (resolverActivationsInFlight.has(sessionId)) {
+      return;
+    }
     const pending = get().pendingResolverKickoff;
     const runs = get().sessionPhaseRuns[sessionId] ?? [];
     const resolvers = runs.filter(
@@ -23,11 +28,16 @@ export const activateNextResolver = (set: SetFn, get: GetFn) => {
     if (kickoff === undefined) {
       return;
     }
+    resolverActivationsInFlight.add(sessionId);
     set((s) => {
       const nextPending = { ...s.pendingResolverKickoff };
       delete nextPending[next.id];
       return { pendingResolverKickoff: nextPending };
     });
-    void get().sendTurn({ sessionId, agentId: next.id, content: kickoff });
+    void get()
+      .sendTurn({ sessionId, agentId: next.id, content: kickoff })
+      .finally(() => {
+        resolverActivationsInFlight.delete(sessionId);
+      });
   };
 };

--- a/apps/desktop/src/store/slices/agents/activateNextResolver.ts
+++ b/apps/desktop/src/store/slices/agents/activateNextResolver.ts
@@ -1,16 +1,21 @@
-import type { SessionId } from '@goodboy/types';
+import type { AgentId, SessionId } from '@goodboy/types';
 import { classifyAgent } from '../../../features/session/agent-kind';
 import type { GetFn, SetFn } from './types';
 
-const resolverActivationsInFlight = new Set<SessionId>();
+const resolverStartsPending = new Map<SessionId, AgentId>();
 
 export const activateNextResolver = (set: SetFn, get: GetFn) => {
   return async (sessionId: SessionId): Promise<void> => {
-    if (resolverActivationsInFlight.has(sessionId)) {
-      return;
+    const runs = get().sessionPhaseRuns[sessionId] ?? [];
+    const guardedAgentId = resolverStartsPending.get(sessionId);
+    if (guardedAgentId !== undefined) {
+      const guardedAgent = runs.find((agent) => agent.id === guardedAgentId);
+      if (guardedAgent !== undefined && guardedAgent.status === 'pending') {
+        return;
+      }
+      resolverStartsPending.delete(sessionId);
     }
     const pending = get().pendingResolverKickoff;
-    const runs = get().sessionPhaseRuns[sessionId] ?? [];
     const resolvers = runs.filter(
       (agent) => classifyAgent(agent, get().agentKindOverride[agent.id] ?? null) === 'resolver',
     );
@@ -28,7 +33,7 @@ export const activateNextResolver = (set: SetFn, get: GetFn) => {
     if (kickoff === undefined) {
       return;
     }
-    resolverActivationsInFlight.add(sessionId);
+    resolverStartsPending.set(sessionId, next.id);
     set((s) => {
       const nextPending = { ...s.pendingResolverKickoff };
       delete nextPending[next.id];
@@ -37,7 +42,9 @@ export const activateNextResolver = (set: SetFn, get: GetFn) => {
     void get()
       .sendTurn({ sessionId, agentId: next.id, content: kickoff })
       .finally(() => {
-        resolverActivationsInFlight.delete(sessionId);
+        if (resolverStartsPending.get(sessionId) === next.id) {
+          resolverStartsPending.delete(sessionId);
+        }
       });
   };
 };

--- a/apps/desktop/src/store/slices/github/index.test.ts
+++ b/apps/desktop/src/store/slices/github/index.test.ts
@@ -68,6 +68,7 @@ const listPendingResolutionsForSessionSpy = vi.fn<
   (db: unknown, sessionId: SessionId) => Promise<ReadonlyArray<PendingResolution>>
 >(async () => []);
 const queuePendingResolutionSpy = vi.fn(async () => undefined);
+const markPendingResolutionReplyPostedSpy = vi.fn(async () => undefined);
 
 vi.mock('@goodboy/db', () => ({
   getSetting: dbGetSettingSpy,
@@ -128,6 +129,7 @@ vi.mock('@goodboy/db', () => ({
   deletePendingResolution: deletePendingResolutionSpy,
   listPendingResolutionsForSession: listPendingResolutionsForSessionSpy,
   queuePendingResolution: queuePendingResolutionSpy,
+  markPendingResolutionReplyPosted: markPendingResolutionReplyPostedSpy,
   upsertContextSlot: vi.fn(async () => undefined),
   listOpenQuestionsForSession: vi.fn(async () => []),
   insertNudgeEvent: insertNudgeEventSpy,
@@ -736,6 +738,54 @@ describe('store contract', () => {
       expect(resolveThreadSpy).toHaveBeenCalled();
     });
 
+    it('resolveGithubThread persists first and leaves no orphan row when nothing was posted', async () => {
+      const store = await getStore();
+      const openPr = {
+        number: 5,
+        title: 't',
+        state: 'open',
+        updatedAt: '2026-05-28T00:00:00.000Z',
+      } as PullRequestState;
+      store.setState({
+        workspaces: [buildWorkspace()],
+        sessions: [buildSession()],
+        sessionGithub: {
+          [SESSION_ID]: {
+            pr: openPr,
+            linkedIssues: [],
+            fetchedAt: null,
+            loading: false,
+            error: null,
+            detail: null,
+            detailFetchedAt: null,
+            detailLoading: false,
+            detailError: null,
+          },
+        },
+      });
+
+      const ok = await store.getState().resolveGithubThread(SESSION_ID, 'PRT_1', {});
+
+      expect(ok).toBe(true);
+      expect(queuePendingResolutionSpy).toHaveBeenCalledWith({
+        db: expect.anything(),
+        id: expect.any(String),
+        sessionId: SESSION_ID,
+        prNumber: 5,
+        threadId: 'PRT_1',
+        commitSha: '',
+        reply: null,
+        outcome: null,
+      });
+      expect(addReplySpy).not.toHaveBeenCalled();
+      expect(resolveThreadSpy).toHaveBeenCalled();
+      expect(deletePendingResolutionSpy).toHaveBeenCalledWith({
+        db: expect.anything(),
+        sessionId: SESSION_ID,
+        threadId: 'PRT_1',
+      });
+    });
+
     it('resolveAgentThreads pushes once and resolves every resolved outcome', async () => {
       const store = await getStore();
       const refresh = vi.fn(async () => undefined);
@@ -772,6 +822,7 @@ describe('store contract', () => {
               commitSha: 'abcdef1234567890',
               reply: null,
               outcome: 'resolved',
+              replyPostedAt: null,
               createdAt: NOW,
             },
             {
@@ -782,6 +833,7 @@ describe('store contract', () => {
               commitSha: 'abcdef1234567890',
               reply: null,
               outcome: 'resolved',
+              replyPostedAt: null,
               createdAt: NOW,
             },
           ],
@@ -867,6 +919,7 @@ describe('store contract', () => {
         commitSha: 'abcdef1234567890',
         reply: 'The third thread was already analyzed before restart.',
         outcome: 'analyzed',
+        replyPostedAt: null,
         createdAt: NOW,
       } satisfies PendingResolution;
       store.setState({
@@ -922,6 +975,7 @@ describe('store contract', () => {
         commitSha: 'abcdef1234567890',
         reply: 'Persisted reply from the completed resolver.',
         outcome: 'resolved',
+        replyPostedAt: null,
         createdAt: NOW,
       } satisfies PendingResolution;
       store.setState({
@@ -1332,6 +1386,7 @@ describe('store contract', () => {
         commitSha: 'abcdef1234567890',
         reply: 'persisted reply',
         outcome: 'resolved',
+        replyPostedAt: null,
         createdAt: NOW,
       } satisfies PendingResolution;
       store.setState({
@@ -1393,6 +1448,7 @@ describe('store contract', () => {
         commitSha: 'abcdef1234567890',
         reply: 'persisted resolver reply',
         outcome: 'resolved',
+        replyPostedAt: null,
         createdAt: NOW,
       } satisfies PendingResolution;
       store.setState({
@@ -1462,6 +1518,7 @@ describe('store contract', () => {
         commitSha: 'abcdef1234567890',
         reply: 'legacy resolver reply',
         outcome: null,
+        replyPostedAt: null,
         createdAt: NOW,
       } satisfies PendingResolution;
       store.setState({
@@ -1498,6 +1555,7 @@ describe('store contract', () => {
         commitSha: 'abcdef1234567890',
         reply: 'fixed it',
         outcome: 'resolved',
+        replyPostedAt: null,
         createdAt: NOW,
       } satisfies PendingResolution;
       const wontfix = {
@@ -1508,6 +1566,7 @@ describe('store contract', () => {
         commitSha: 'abcdef1234567890',
         reply: 'the behavior is intentional',
         outcome: 'wontfix',
+        replyPostedAt: null,
         createdAt: NOW,
       } satisfies PendingResolution;
       store.setState({
@@ -1537,6 +1596,106 @@ describe('store contract', () => {
         wontfix.threadId,
         expect.anything(),
       );
+    });
+
+    it('pushAllResolutions does not repost a reply already recorded as posted', async () => {
+      const store = await getStore();
+      const fix = {
+        id: 'pending-fix',
+        sessionId: SESSION_ID,
+        prNumber: 1,
+        threadId: 'PRRT_1',
+        commitSha: 'abcdef1234567890',
+        reply: 'fixed it',
+        outcome: 'resolved',
+        replyPostedAt: NOW,
+        createdAt: NOW,
+      } satisfies PendingResolution;
+      store.setState({
+        workspaces: [buildWorkspace()],
+        sessions: [buildSession()],
+        sessionBranches: { [SESSION_ID]: 'ak/feat-x' },
+        sessionWorktrees: { [SESSION_ID]: ['/tmp/repo/.wt/x'] },
+        resolverThreadOutcomes: {},
+        sessionPendingResolutions: { [SESSION_ID]: [fix] },
+        refreshSessionPrDetail: vi.fn(async () => undefined),
+      });
+      listPendingResolutionsForSessionSpy.mockResolvedValueOnce([fix]).mockResolvedValueOnce([]);
+
+      const result = await store.getState().pushAllResolutions(SESSION_ID);
+
+      expect(result).toEqual({ pushed: true, resolved: 1, failed: 0 });
+      expect(addReplySpy).not.toHaveBeenCalled();
+      expect(resolveThreadSpy).toHaveBeenCalledOnce();
+      expect(deletePendingResolutionSpy).toHaveBeenCalledOnce();
+    });
+
+    it('pushAllResolutions records the reply before resolving, so a failed resolve keeps the dedup flag', async () => {
+      const store = await getStore();
+      const fix = {
+        id: 'pending-fix',
+        sessionId: SESSION_ID,
+        prNumber: 1,
+        threadId: 'PRRT_1',
+        commitSha: 'abcdef1234567890',
+        reply: 'fixed it',
+        outcome: 'resolved',
+        replyPostedAt: null,
+        createdAt: NOW,
+      } satisfies PendingResolution;
+      store.setState({
+        workspaces: [buildWorkspace()],
+        sessions: [buildSession()],
+        sessionBranches: { [SESSION_ID]: 'ak/feat-x' },
+        sessionWorktrees: { [SESSION_ID]: ['/tmp/repo/.wt/x'] },
+        resolverThreadOutcomes: {},
+        sessionPendingResolutions: { [SESSION_ID]: [fix] },
+        refreshSessionPrDetail: vi.fn(async () => undefined),
+      });
+      listPendingResolutionsForSessionSpy.mockResolvedValueOnce([fix]).mockResolvedValueOnce([fix]);
+      resolveThreadSpy.mockRejectedValueOnce(new Error('github timed out'));
+
+      const result = await store.getState().pushAllResolutions(SESSION_ID);
+
+      expect(result).toEqual({ pushed: true, resolved: 0, failed: 1 });
+      expect(addReplySpy).toHaveBeenCalledOnce();
+      expect(markPendingResolutionReplyPostedSpy).toHaveBeenCalledWith({
+        db: expect.anything(),
+        sessionId: SESSION_ID,
+        threadId: fix.threadId,
+      });
+      expect(deletePendingResolutionSpy).not.toHaveBeenCalled();
+    });
+
+    it('pushAllResolutions only counts a comment as posted when a reply body actually went out', async () => {
+      const store = await getStore();
+      const empty = {
+        id: 'pending-empty',
+        sessionId: SESSION_ID,
+        prNumber: 1,
+        threadId: 'PRRT_1',
+        commitSha: '',
+        reply: null,
+        outcome: null,
+        replyPostedAt: null,
+        createdAt: NOW,
+      } satisfies PendingResolution;
+      store.setState({
+        workspaces: [buildWorkspace()],
+        sessions: [buildSession()],
+        notifications: [],
+        resolverThreadOutcomes: {},
+        sessionPendingResolutions: { [SESSION_ID]: [empty] },
+        refreshSessionPrDetail: vi.fn(async () => undefined),
+      });
+      listPendingResolutionsForSessionSpy
+        .mockResolvedValueOnce([empty])
+        .mockResolvedValueOnce([empty]);
+
+      await store.getState().pushAllResolutions(SESSION_ID);
+
+      expect(addReplySpy).not.toHaveBeenCalled();
+      expect(store.getState().notifications.some((n) => n.title.includes('left open'))).toBe(false);
     });
 
     it('resolveAgentThreads keeps closing after one thread throws and still refreshes', async () => {

--- a/apps/desktop/src/store/slices/github/index.test.ts
+++ b/apps/desktop/src/store/slices/github/index.test.ts
@@ -786,6 +786,56 @@ describe('store contract', () => {
       });
     });
 
+    it('resolveGithubThread never clobbers a verdict a caller already queued for the thread', async () => {
+      const store = await getStore();
+      const openPr = {
+        number: 5,
+        title: 't',
+        state: 'open',
+        updatedAt: '2026-05-28T00:00:00.000Z',
+      } as PullRequestState;
+      const queued = {
+        id: 'pending-queued',
+        sessionId: SESSION_ID,
+        prNumber: 5,
+        threadId: 'PRT_1',
+        commitSha: 'abcdef1234567890',
+        reply: 'fixed with the shared guard',
+        outcome: 'resolved',
+        replyPostedAt: null,
+        createdAt: NOW,
+      } satisfies PendingResolution;
+      store.setState({
+        workspaces: [buildWorkspace()],
+        sessions: [buildSession()],
+        sessionGithub: {
+          [SESSION_ID]: {
+            pr: openPr,
+            linkedIssues: [],
+            fetchedAt: null,
+            loading: false,
+            error: null,
+            detail: null,
+            detailFetchedAt: null,
+            detailLoading: false,
+            detailError: null,
+          },
+        },
+        sessionPendingResolutions: { [SESSION_ID]: [queued] },
+      });
+      listPendingResolutionsForSessionSpy.mockResolvedValueOnce([queued]).mockResolvedValueOnce([]);
+
+      const ok = await store.getState().resolveGithubThread(SESSION_ID, 'PRT_1', {});
+
+      expect(ok).toBe(true);
+      expect(queuePendingResolutionSpy).not.toHaveBeenCalled();
+      expect(deletePendingResolutionSpy).toHaveBeenCalledWith({
+        db: expect.anything(),
+        sessionId: SESSION_ID,
+        threadId: 'PRT_1',
+      });
+    });
+
     it('resolveAgentThreads pushes once and resolves every resolved outcome', async () => {
       const store = await getStore();
       const refresh = vi.fn(async () => undefined);
@@ -1698,6 +1748,37 @@ describe('store contract', () => {
       expect(store.getState().notifications.some((n) => n.title.includes('left open'))).toBe(false);
     });
 
+    it('pushAllResolutions never reposts a null-outcome row whose reply already went out', async () => {
+      const store = await getStore();
+      const orphaned = {
+        id: 'pending-orphaned',
+        sessionId: SESSION_ID,
+        prNumber: 1,
+        threadId: 'PRT_1',
+        commitSha: '',
+        reply: null,
+        outcome: null,
+        replyPostedAt: NOW,
+        createdAt: NOW,
+      } satisfies PendingResolution;
+      store.setState({
+        workspaces: [buildWorkspace()],
+        sessions: [buildSession()],
+        resolverThreadOutcomes: {},
+        sessionPendingResolutions: { [SESSION_ID]: [orphaned] },
+        refreshSessionPrDetail: vi.fn(async () => undefined),
+      });
+      listPendingResolutionsForSessionSpy
+        .mockResolvedValueOnce([orphaned])
+        .mockResolvedValueOnce([]);
+
+      const result = await store.getState().pushAllResolutions(SESSION_ID);
+
+      expect(addReplySpy).not.toHaveBeenCalled();
+      expect(deletePendingResolutionSpy).toHaveBeenCalledOnce();
+      expect(result).toEqual({ pushed: false, resolved: 0, failed: 0 });
+    });
+
     it('resolveAgentThreads keeps closing after one thread throws and still refreshes', async () => {
       const store = await getStore();
       const refresh = vi.fn(async () => undefined);
@@ -1741,6 +1822,103 @@ describe('store contract', () => {
           '1 thread failed to close',
         ),
       );
+    });
+
+    it('resolveAgentThreads persists first for a target with no backing row, so a retry does not repost', async () => {
+      const store = await getStore();
+      const openPr = {
+        number: 9,
+        title: 't',
+        state: 'open',
+        updatedAt: '2026-05-28T00:00:00.000Z',
+      } as PullRequestState;
+      const baseState = {
+        workspaces: [buildWorkspace()],
+        sessions: [buildSession()],
+        sessionBranches: { [SESSION_ID]: 'ak/feat-x' },
+        sessionWorktrees: { [SESSION_ID]: ['/tmp/repo/.wt/x'] },
+        sessionGithub: {
+          [SESSION_ID]: {
+            pr: openPr,
+            linkedIssues: [],
+            fetchedAt: null,
+            loading: false,
+            error: null,
+            detail: null,
+            detailFetchedAt: null,
+            detailLoading: false,
+            detailError: null,
+          },
+        },
+        sessionPhaseRuns: {
+          [SESSION_ID]: [
+            {
+              id: AGENT_ID,
+              sessionId: SESSION_ID,
+              ordinal: 0,
+              name: 'combined resolver',
+              status: 'completed',
+              sourceThreadIds: ['PRRT_1'],
+            } as Agent,
+          ],
+        },
+        resolverThreadOutcomes: {
+          [AGENT_ID]: {
+            PRRT_1: { kind: 'resolved' as const, commitSha: 'abcdef1234567890', reply: 'fixed it' },
+          },
+        },
+        refreshSessionPrDetail: vi.fn(async () => undefined),
+      };
+      store.setState({ ...baseState, sessionPendingResolutions: {} });
+
+      const survivingRow = {
+        id: 'pending-survivor',
+        sessionId: SESSION_ID,
+        prNumber: 9,
+        threadId: 'PRRT_1',
+        commitSha: 'abcdef1234567890',
+        reply: 'fixed it',
+        outcome: null,
+        replyPostedAt: NOW,
+        createdAt: NOW,
+      } satisfies PendingResolution;
+
+      listPendingResolutionsForSessionSpy
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([survivingRow]);
+      resolveThreadSpy.mockRejectedValueOnce(new Error('github timed out'));
+
+      const firstAttempt = await store.getState().resolveAgentThreads(SESSION_ID, AGENT_ID);
+
+      expect(firstAttempt).toBe(false);
+      expect(queuePendingResolutionSpy).toHaveBeenCalledWith({
+        db: expect.anything(),
+        id: expect.any(String),
+        sessionId: SESSION_ID,
+        prNumber: 9,
+        threadId: 'PRRT_1',
+        commitSha: 'abcdef1234567890',
+        reply: 'fixed it',
+        outcome: null,
+      });
+      expect(addReplySpy).toHaveBeenCalledOnce();
+      expect(deletePendingResolutionSpy).not.toHaveBeenCalled();
+
+      store.setState({ ...baseState, sessionPendingResolutions: { [SESSION_ID]: [survivingRow] } });
+      listPendingResolutionsForSessionSpy
+        .mockResolvedValueOnce([survivingRow])
+        .mockResolvedValueOnce([]);
+
+      const secondAttempt = await store.getState().resolveAgentThreads(SESSION_ID, AGENT_ID);
+
+      expect(secondAttempt).toBe(true);
+      expect(addReplySpy).toHaveBeenCalledOnce();
+      expect(resolveThreadSpy).toHaveBeenCalledTimes(2);
+      expect(deletePendingResolutionSpy).toHaveBeenCalledWith({
+        db: expect.anything(),
+        sessionId: SESSION_ID,
+        threadId: 'PRRT_1',
+      });
     });
 
     it('resolveAgentThreads skips a second run racing the same session', async () => {

--- a/apps/desktop/src/store/slices/github/markThreadResolvedNoPush.ts
+++ b/apps/desktop/src/store/slices/github/markThreadResolvedNoPush.ts
@@ -1,5 +1,7 @@
 import { resolveReviewThread } from '@goodboy/core';
+import { markPendingResolutionReplyPosted } from '@goodboy/db';
 import type { SessionId } from '@goodboy/types';
+import { tauriDatabase } from '../../../shared/lib/db';
 import { tauriGhRunner } from '../../../features/github/github';
 import { postThreadReply } from './postThreadReply';
 import { sessionThreadGhOptions } from './sessionThreadGhOptions';
@@ -7,14 +9,29 @@ import type { GetFn, SetFn } from './types';
 
 type Closure = { commitSha?: string; reason?: string; reply?: string };
 
-export const markThreadResolvedNoPush = async (
-  set: SetFn,
-  get: GetFn,
-  sessionId: SessionId,
-  threadId: string,
-  closure?: Closure,
-): Promise<void> => {
-  await postThreadReply({ get, sessionId, threadId, closure });
+type Params = {
+  readonly set: SetFn;
+  readonly get: GetFn;
+  readonly sessionId: SessionId;
+  readonly threadId: string;
+  readonly replyAlreadyPosted: boolean;
+  readonly closure?: Closure;
+};
+
+export const markThreadResolvedNoPush = async ({
+  set,
+  get,
+  sessionId,
+  threadId,
+  replyAlreadyPosted,
+  closure,
+}: Params): Promise<void> => {
+  if (!replyAlreadyPosted) {
+    const posted = await postThreadReply({ get, sessionId, threadId, closure });
+    if (posted) {
+      await markPendingResolutionReplyPosted({ db: tauriDatabase, sessionId, threadId });
+    }
+  }
   await resolveReviewThread(tauriGhRunner, threadId, sessionThreadGhOptions({ get, sessionId }));
   set((state) => {
     const known = state.sessionResolvedThreads[sessionId] ?? [];

--- a/apps/desktop/src/store/slices/github/postThreadReply.ts
+++ b/apps/desktop/src/store/slices/github/postThreadReply.ts
@@ -34,7 +34,7 @@ export const postThreadReply = async ({
   sessionId,
   threadId,
   closure,
-}: Params): Promise<void> => {
+}: Params): Promise<boolean> => {
   const pendingReply = get().sessionPendingResolutions[sessionId]?.find(
     (resolution) => resolution.threadId === threadId,
   )?.reply;
@@ -51,7 +51,7 @@ export const postThreadReply = async ({
     pr?.url ?? null,
   );
   if (replyBody === null) {
-    return;
+    return false;
   }
   await addReviewThreadReply(
     tauriGhRunner,
@@ -59,4 +59,5 @@ export const postThreadReply = async ({
     replyBody,
     sessionThreadGhOptions({ get, sessionId }),
   );
+  return true;
 };

--- a/apps/desktop/src/store/slices/github/pushAllResolutions.ts
+++ b/apps/desktop/src/store/slices/github/pushAllResolutions.ts
@@ -85,34 +85,67 @@ export const pushAllResolutions = (set: SetFn, get: GetFn) => {
           }
           try {
             const inMemoryOutcome = inMemoryOutcomes[index];
-            if (outcome === null) {
-              await postThreadReply({
-                get,
-                sessionId,
-                threadId: resolution.threadId,
-                closure: { ...(resolution.reply !== null && { reply: resolution.reply }) },
-              });
-              commented += 1;
-            }
-            if (outcome === 'resolved') {
-              await markThreadResolvedNoPush(set, get, sessionId, resolution.threadId, {
-                commitSha: resolution.commitSha,
-                reply: resolution.reply ?? undefined,
-              });
-              resolved += 1;
-            }
-            if (outcome === 'wontfix') {
-              await markThreadResolvedNoPush(set, get, sessionId, resolution.threadId, {
-                reason: inMemoryOutcome?.kind === 'wontfix' ? inMemoryOutcome.reason : undefined,
-                reply: resolution.reply ?? undefined,
-              });
-              resolved += 1;
-            }
-            if (outcome === 'analyzed') {
-              await markThreadResolvedNoPush(set, get, sessionId, resolution.threadId, {
-                reply: resolution.reply ?? undefined,
-              });
-              resolved += 1;
+            const replyAlreadyPosted = resolution.replyPostedAt != null;
+            switch (outcome) {
+              case null: {
+                const posted = await postThreadReply({
+                  get,
+                  sessionId,
+                  threadId: resolution.threadId,
+                  closure: { ...(resolution.reply !== null && { reply: resolution.reply }) },
+                });
+                if (posted) {
+                  commented += 1;
+                }
+                break;
+              }
+              case 'resolved': {
+                await markThreadResolvedNoPush({
+                  set,
+                  get,
+                  sessionId,
+                  threadId: resolution.threadId,
+                  replyAlreadyPosted,
+                  closure: {
+                    commitSha: resolution.commitSha,
+                    reply: resolution.reply ?? undefined,
+                  },
+                });
+                resolved += 1;
+                break;
+              }
+              case 'wontfix': {
+                await markThreadResolvedNoPush({
+                  set,
+                  get,
+                  sessionId,
+                  threadId: resolution.threadId,
+                  replyAlreadyPosted,
+                  closure: {
+                    reason:
+                      inMemoryOutcome?.kind === 'wontfix' ? inMemoryOutcome.reason : undefined,
+                    reply: resolution.reply ?? undefined,
+                  },
+                });
+                resolved += 1;
+                break;
+              }
+              case 'analyzed': {
+                await markThreadResolvedNoPush({
+                  set,
+                  get,
+                  sessionId,
+                  threadId: resolution.threadId,
+                  replyAlreadyPosted,
+                  closure: { reply: resolution.reply ?? undefined },
+                });
+                resolved += 1;
+                break;
+              }
+              default: {
+                const exhaustive: never = outcome;
+                throw new Error(`unhandled pending resolution outcome: ${String(exhaustive)}`);
+              }
             }
             await deletePendingResolution({
               db: tauriDatabase,

--- a/apps/desktop/src/store/slices/github/pushAllResolutions.ts
+++ b/apps/desktop/src/store/slices/github/pushAllResolutions.ts
@@ -88,6 +88,9 @@ export const pushAllResolutions = (set: SetFn, get: GetFn) => {
             const replyAlreadyPosted = resolution.replyPostedAt != null;
             switch (outcome) {
               case null: {
+                if (replyAlreadyPosted) {
+                  break;
+                }
                 const posted = await postThreadReply({
                   get,
                   sessionId,

--- a/apps/desktop/src/store/slices/github/resolveAgentThreads.ts
+++ b/apps/desktop/src/store/slices/github/resolveAgentThreads.ts
@@ -140,7 +140,17 @@ export const resolveAgentThreads = (set: SetFn, get: GetFn) => {
         let lastError = '';
         for (const target of targets) {
           try {
-            await markThreadResolvedNoPush(set, get, sessionId, target.threadId, target.closure);
+            const replyAlreadyPosted =
+              persisted.find((resolution) => resolution.threadId === target.threadId)
+                ?.replyPostedAt != null;
+            await markThreadResolvedNoPush({
+              set,
+              get,
+              sessionId,
+              threadId: target.threadId,
+              replyAlreadyPosted,
+              closure: target.closure,
+            });
             await deletePendingResolution({
               db: tauriDatabase,
               sessionId,

--- a/apps/desktop/src/store/slices/github/resolveAgentThreads.ts
+++ b/apps/desktop/src/store/slices/github/resolveAgentThreads.ts
@@ -1,4 +1,8 @@
-import { deletePendingResolution, listPendingResolutionsForSession } from '@goodboy/db';
+import {
+  deletePendingResolution,
+  listPendingResolutionsForSession,
+  queuePendingResolution,
+} from '@goodboy/db';
 import type { AgentId, SessionId } from '@goodboy/types';
 import { agentThreadIds } from '../../../features/session/agentThreadIds';
 import { closedThreadIds } from '../../../features/session/closedThreadIds';
@@ -135,14 +139,28 @@ export const resolveAgentThreads = (set: SetFn, get: GetFn) => {
             return false;
           }
         }
+        const prNumber = get().sessionGithub[sessionId]?.pr?.number ?? null;
         let closed = 0;
         let failed = 0;
         let lastError = '';
         for (const target of targets) {
           try {
-            const replyAlreadyPosted =
-              persisted.find((resolution) => resolution.threadId === target.threadId)
-                ?.replyPostedAt != null;
+            const existing = persisted.find(
+              (resolution) => resolution.threadId === target.threadId,
+            );
+            const replyAlreadyPosted = existing?.replyPostedAt != null;
+            if (existing === undefined && prNumber !== null) {
+              await queuePendingResolution({
+                db: tauriDatabase,
+                id: crypto.randomUUID(),
+                sessionId,
+                prNumber,
+                threadId: target.threadId,
+                commitSha: target.closure.commitSha ?? '',
+                reply: target.closure.reply ?? null,
+                outcome: null,
+              });
+            }
             await markThreadResolvedNoPush({
               set,
               get,

--- a/apps/desktop/src/store/slices/github/resolveGithubThread.ts
+++ b/apps/desktop/src/store/slices/github/resolveGithubThread.ts
@@ -1,4 +1,10 @@
+import {
+  deletePendingResolution,
+  listPendingResolutionsForSession,
+  queuePendingResolution,
+} from '@goodboy/db';
 import type { SessionId } from '@goodboy/types';
+import { tauriDatabase } from '../../../shared/lib/db';
 import { formatError } from '../../../shared/lib/errors';
 import { markThreadResolvedNoPush } from './markThreadResolvedNoPush';
 import { pushSessionBranch } from './pushSessionBranch';
@@ -55,7 +61,52 @@ export const resolveGithubThread = (set: SetFn, get: GetFn) => {
               return false;
             }
           }
-          await markThreadResolvedNoPush(set, get, sessionId, threadId, closure);
+          const prNumber = get().sessionGithub[sessionId]?.pr?.number ?? null;
+          const persistFirst = prNumber !== null;
+          let replyAlreadyPosted = false;
+          if (persistFirst) {
+            const before = await listPendingResolutionsForSession({ db: tauriDatabase, sessionId });
+            replyAlreadyPosted =
+              before.find((resolution) => resolution.threadId === threadId)?.replyPostedAt != null;
+            await queuePendingResolution({
+              db: tauriDatabase,
+              id: crypto.randomUUID(),
+              sessionId,
+              prNumber,
+              threadId,
+              commitSha: closure?.commitSha ?? '',
+              reply: closure?.reply ?? null,
+              outcome: null,
+            });
+            const queued = await listPendingResolutionsForSession({ db: tauriDatabase, sessionId });
+            set((state) => ({
+              sessionPendingResolutions: {
+                ...state.sessionPendingResolutions,
+                [sessionId]: queued,
+              },
+            }));
+          }
+          await markThreadResolvedNoPush({
+            set,
+            get,
+            sessionId,
+            threadId,
+            replyAlreadyPosted,
+            closure,
+          });
+          if (persistFirst) {
+            await deletePendingResolution({ db: tauriDatabase, sessionId, threadId });
+            const remaining = await listPendingResolutionsForSession({
+              db: tauriDatabase,
+              sessionId,
+            });
+            set((state) => ({
+              sessionPendingResolutions: {
+                ...state.sessionPendingResolutions,
+                [sessionId]: remaining,
+              },
+            }));
+          }
           await get().refreshSessionPrDetail(sessionId, { force: true });
           return true;
         } catch (err) {

--- a/apps/desktop/src/store/slices/github/resolveGithubThread.ts
+++ b/apps/desktop/src/store/slices/github/resolveGithubThread.ts
@@ -66,25 +66,30 @@ export const resolveGithubThread = (set: SetFn, get: GetFn) => {
           let replyAlreadyPosted = false;
           if (persistFirst) {
             const before = await listPendingResolutionsForSession({ db: tauriDatabase, sessionId });
-            replyAlreadyPosted =
-              before.find((resolution) => resolution.threadId === threadId)?.replyPostedAt != null;
-            await queuePendingResolution({
-              db: tauriDatabase,
-              id: crypto.randomUUID(),
-              sessionId,
-              prNumber,
-              threadId,
-              commitSha: closure?.commitSha ?? '',
-              reply: closure?.reply ?? null,
-              outcome: null,
-            });
-            const queued = await listPendingResolutionsForSession({ db: tauriDatabase, sessionId });
-            set((state) => ({
-              sessionPendingResolutions: {
-                ...state.sessionPendingResolutions,
-                [sessionId]: queued,
-              },
-            }));
+            const existing = before.find((resolution) => resolution.threadId === threadId);
+            replyAlreadyPosted = existing?.replyPostedAt != null;
+            if (existing === undefined) {
+              await queuePendingResolution({
+                db: tauriDatabase,
+                id: crypto.randomUUID(),
+                sessionId,
+                prNumber,
+                threadId,
+                commitSha: closure?.commitSha ?? '',
+                reply: closure?.reply ?? null,
+                outcome: null,
+              });
+              const queued = await listPendingResolutionsForSession({
+                db: tauriDatabase,
+                sessionId,
+              });
+              set((state) => ({
+                sessionPendingResolutions: {
+                  ...state.sessionPendingResolutions,
+                  [sessionId]: queued,
+                },
+              }));
+            }
           }
           await markThreadResolvedNoPush({
             set,

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -199,6 +199,7 @@ export {
 export {
   queuePendingResolution,
   listPendingResolutionsForSession,
+  markPendingResolutionReplyPosted,
   deletePendingResolution,
 } from './queries/pending-resolution';
 export {

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -101,6 +101,7 @@ import { m100WorkflowOrigin } from './m100-workflow-origin';
 import { m101TelemetryOrchestratorKind } from './m101-telemetry-orchestrator-kind';
 import { m102WorkflowOrchestrationStopKind } from './m102-workflow-orchestration-stop-kind';
 import { m103SessionExternalTaskBranch } from './m103-session-external-task-branch';
+import { m104PendingResolutionReplyPosted } from './m104-pending-resolution-reply-posted';
 
 export type Migration = {
   readonly version: number;
@@ -211,4 +212,5 @@ export const migrations: ReadonlyArray<Migration> = [
   { version: 101, sql: m101TelemetryOrchestratorKind },
   { version: 102, sql: m102WorkflowOrchestrationStopKind },
   { version: 103, sql: m103SessionExternalTaskBranch },
+  { version: 104, sql: m104PendingResolutionReplyPosted },
 ];

--- a/packages/db/src/migrations/m104-pending-resolution-reply-posted.ts
+++ b/packages/db/src/migrations/m104-pending-resolution-reply-posted.ts
@@ -1,0 +1,3 @@
+export const m104PendingResolutionReplyPosted = /* sql */ `
+ALTER TABLE pending_resolutions ADD COLUMN reply_posted_at INTEGER;
+`;

--- a/packages/db/src/queries/pending-resolution.test.ts
+++ b/packages/db/src/queries/pending-resolution.test.ts
@@ -3,7 +3,11 @@ import type { SessionId, WorkspaceId } from '@goodboy/types';
 import { makeTestDatabase } from '../test-helpers/test-db';
 import { migrations } from '../migrations';
 import { migrate } from '../migrations/runner';
-import { listPendingResolutionsForSession, queuePendingResolution } from './pending-resolution';
+import {
+  listPendingResolutionsForSession,
+  markPendingResolutionReplyPosted,
+  queuePendingResolution,
+} from './pending-resolution';
 
 const workspaceId = 'w1' as WorkspaceId;
 const sessionId = 's1' as SessionId;
@@ -50,6 +54,27 @@ describe('pending_resolutions queries', () => {
       commitSha: 'abcdef1234567890',
       reply: 'persist this reply',
       outcome: 'resolved',
+      replyPostedAt: null,
     });
+  });
+
+  it('records when the reply was posted, so a retry can skip reposting it', async () => {
+    const db = await seed({});
+    await queuePendingResolution({
+      db,
+      id: 'pending-1',
+      sessionId,
+      prNumber: 42,
+      threadId: 'PRRT_1',
+      commitSha: 'abcdef1234567890',
+      reply: 'persist this reply',
+      outcome: 'resolved',
+    });
+
+    await markPendingResolutionReplyPosted({ db, sessionId, threadId: 'PRRT_1' });
+    const rows = await listPendingResolutionsForSession({ db, sessionId });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.replyPostedAt).not.toBeNull();
   });
 });

--- a/packages/db/src/queries/pending-resolution.ts
+++ b/packages/db/src/queries/pending-resolution.ts
@@ -14,6 +14,7 @@ type PendingResolutionRow = {
   commit_sha: string;
   reply: string | null;
   outcome: string | null;
+  reply_posted_at: number | null;
   created_at: number;
 };
 
@@ -34,6 +35,10 @@ type ListParams = {
 };
 
 type DeleteParams = ListParams & {
+  readonly threadId: string;
+};
+
+type MarkReplyPostedParams = ListParams & {
   readonly threadId: string;
 };
 
@@ -61,11 +66,15 @@ const toDomain = ({ row }: ToDomainParams): PendingResolution => {
     commitSha: row.commit_sha,
     reply: row.reply,
     outcome: toOutcome({ value: row.outcome }),
+    replyPostedAt:
+      row.reply_posted_at != null
+        ? (new Date(row.reply_posted_at).toISOString() as IsoDateTime)
+        : null,
     createdAt: new Date(row.created_at).toISOString() as IsoDateTime,
   };
 };
 
-const SELECT_COLUMNS = `id, session_id, pr_number, thread_id, commit_sha, reply, outcome, created_at`;
+const SELECT_COLUMNS = `id, session_id, pr_number, thread_id, commit_sha, reply, outcome, reply_posted_at, created_at`;
 
 export const queuePendingResolution = async ({
   db,
@@ -103,6 +112,17 @@ export const listPendingResolutionsForSession = async ({
     [sessionId],
   );
   return rows.map((row) => toDomain({ row }));
+};
+
+export const markPendingResolutionReplyPosted = async ({
+  db,
+  sessionId,
+  threadId,
+}: MarkReplyPostedParams): Promise<void> => {
+  await db.execute(
+    `UPDATE pending_resolutions SET reply_posted_at = ? WHERE session_id = ? AND thread_id = ?`,
+    [Date.now(), sessionId, threadId],
+  );
 };
 
 export const deletePendingResolution = async ({

--- a/packages/types/src/github.ts
+++ b/packages/types/src/github.ts
@@ -173,5 +173,6 @@ export type PendingResolution = {
   commitSha: string;
   reply: string | null;
   outcome: PendingResolutionOutcome | null;
+  replyPostedAt: IsoDateTime | null;
   createdAt: IsoDateTime;
 };


### PR DESCRIPTION
## What

Resolve could double-post a machine-authored reply on a real GitHub PR
thread when `resolveReviewThread` failed after the reply had already
gone out, and the summary toast could claim a reply went out when
nothing was posted.

## Why

`markThreadResolvedNoPush` posted a reply and resolved the thread with
no idempotency between the two calls. If `resolveReviewThread` threw
after the reply already landed, the pending row stayed in
`pending_resolutions` and the UI explicitly invited a retry ("retry to
resolve the remaining threads"). The retry reposted an identical
comment on GitHub, compounding on every retry.

This is the same shape of bug Linear's offline mutation queue solves
with an idempotency record on the mutation: a retried write never
duplicates the comment because the retry can check whether it already
landed. `pending_resolutions` gets the same treatment here: a nullable
`reply_posted_at` column, set right after a successful post and before
`resolveReviewThread` is attempted, so a retry can skip reposting.

## Changes

- **`m104`** (`packages/db/src/migrations/m104-pending-resolution-reply-posted.ts`):
  adds `reply_posted_at INTEGER` (nullable) to `pending_resolutions`,
  following the `m088` pattern exactly. Registered in `index.ts` at
  version 104. `registry.test.ts` (duplicate/gap/filename-mismatch
  guard + up-convergence from every intermediate version) passes.
- **Types/queries**: `PendingResolution.replyPostedAt` in
  `packages/types/src/github.ts`; `packages/db/src/queries/pending-resolution.ts`
  gains the column in `SELECT_COLUMNS`/`toDomain` and a new writer
  `markPendingResolutionReplyPosted`.
- **`markThreadResolvedNoPush`**: now takes a `replyAlreadyPosted` flag
  and a single object param. It skips `postThreadReply` when the flag
  is set, and calls `markPendingResolutionReplyPosted` immediately
  after a successful post, before attempting `resolveReviewThread`.
  `postThreadReply` now returns whether it actually posted (it can be
  a no-op when there's nothing to say), so callers only mark the flag
  on a real post.
- **3 callers threaded**:
  - `pushAllResolutions.ts` passes `resolution.replyPostedAt != null`
    per row from the persisted list it already has.
  - `resolveAgentThreads.ts` looks up the persisted row for each
    target's `threadId` from the `persisted` list it already fetches.
  - `resolveGithubThread.ts` has no backing `pending_resolutions` row
    for its ad-hoc single-thread path, so it now **persists first**:
    it queues a pending row (reusing `queuePendingResolution`'s
    upsert, which never overwrites `reply_posted_at`) before calling
    `markThreadResolvedNoPush`, and deletes the row on success. A
    thread with nothing to reply (no commit, no reason, no text)
    posts nothing and the row is deleted right after, so persist-first
    leaves no orphan row.
- **Honest counting**: `pushAllResolutions`'s `NULL`-outcome branch
  only increments `commented` when `postThreadReply` actually posted,
  so the "N comment(s) left open" toast can't fire when nothing went
  out.
- **Exhaustive dispatch**: the `if`-chain over
  `PendingResolutionOutcome | null` in `pushAllResolutions` is now a
  `switch` with a `never` default, so a fifth outcome can't silently
  fall through.
- **Silent resolver failures**: `useResolverActions` swallowed every
  `sendTurn` rejection (fire-and-forget `onClick` handlers, no
  `.catch`). `sendToAgent`, `proceed`, and `rerun` now catch and
  surface the failure through `emitNotification`, matching the
  `'resolve thread failed'` pattern already used in
  `resolveGithubThread.ts`.
- **Concurrent resolvers**: `activateNextResolver` read `anyRunning`
  from the persisted `agent.status === 'running'`, then fired
  `sendTurn` unawaited. Since `sendTurn` flips the status asynchronously
  over IPC, a second trigger landing in that window saw
  `anyRunning === false` and started a second resolver concurrently.
  Closed with an in-flight guard keyed by agent id
  (`Map<SessionId, AgentId>`, see the round-2 section below for why it
  isn't a plain `Set<SessionId>`). None of the 7 call sites needed to
  change.

## Round 2: independent verification found a regression + 3 dedup gaps

An independent verification pass caught one proven regression this PR
introduced and three real holes in the dedup that were reachable but
untested. Fixed all four in a second commit (no history rewrite):

- **Regression (blocker)**: the original `activateNextResolver` guard
  was a `Set<SessionId>` released only in `.finally` on the whole
  `sendTurn` promise. But `sendTurn` calls `completeResolvedAgent`
  (awaited, before `sendTurn` returns), which calls
  `activateNextResolver` again to hand off to the next resolver in a
  chain. That inner call landed while the outer `sendTurn` promise was
  still pending, so the guard blocked it and the chain stalled after
  one resolver, needing a human to click run or force-next. Fixed by
  keying the guard on the specific agent id
  (`Map<SessionId, AgentId>`) and releasing it as soon as that agent's
  status is observed to have left `'pending'` (checked fresh on every
  call), with the `.finally` release kept as a backstop for the case
  where `sendTurn` throws before ever updating status. Added
  `activateNextResolver.test.ts` > "lets the chain hand off to the
  next resolver from inside the finishing turn", which fails against
  the previous implementation and passes against the fix.
- **`pushAllResolutions`'s `NULL`-outcome branch never checked
  `replyAlreadyPosted`**, so a row this PR itself can produce (an
  ad-hoc `resolveGithubThread` call that posts, sets
  `reply_posted_at`, then has `resolveReviewThread` throw, leaving an
  `outcome: null` row) would repost on the next push-all once the
  in-memory outcome was gone (e.g. after a restart). Fixed with an
  early return in the `case null` branch when the flag is already set.
- **`resolveGithubThread`'s persist-first write could clobber an
  existing verdict.** `queuePendingResolution`'s upsert leaves
  `reply_posted_at` alone (as documented) but does overwrite
  `commit_sha`, `reply`, `outcome`, `created_at`. Calling it
  unconditionally downgraded an already-queued `resolved` row (with a
  real commit and reply) to `outcome: null` the moment the same thread
  went through `resolveGithubThread` (reachable via `queueOne` then
  `explain`/`forceResolve` on the same thread from
  `useResolverActions`). On a failed resolve, the persisted verdict
  was gone and a later push-all would comment-and-delete instead of
  resolving. Fixed by only writing the persist-first row when no row
  already exists for that thread; an existing row is left untouched.
- **`resolveAgentThreads` had the same "no backing row" gap as
  `resolveGithubThread`, unfixed.** Targets can come from
  `resolverThreadSettlements` built purely from in-memory
  `resolverThreadOutcomes` with no `pending_resolutions` row
  (`isQueued: false`). For those, `replyAlreadyPosted` was always
  `false` and a failed `resolveReviewThread` had nowhere to persist
  the dedup flag, so a retry reposted. Gave it the same persist-first
  treatment: queue a minimal row before the mark-resolved attempt when
  no row exists yet for that thread.

Confirmed correct and left untouched per the verification: the `m104`
migration, the type/query layer, honest `commented` counting, the
exhaustive `switch`, the `useResolverActions` error surfacing, and the
`down`-migration note below.

**Not fixed (nit, flagged instead of fixed)**: the
`resolverStartsPending` map in `activateNextResolver.ts` is never
pruned on session delete. Since entries now self-clear once the
guarded agent's status leaves `'pending'` (or via the `.finally`
backstop), a leaked entry only lingers if a session is deleted while a
resolver-start attempt is in flight for it *and* the session is never
reactivated afterward. It's a dangling `Map` entry with no functional
impact (nothing reads it for a deleted session), not a growing leak
across normal usage, so I judged it not worth the extra teardown
plumbing for this PR.

## A note on the `down` migration

The task brief for this item said the migration needed "a working
`down`" because the registry test "asserts up/down convergence." I
checked `packages/db/src/migrations/registry.test.ts` and the actual
`Migration` type (`{ version: number; sql: string }` in
`migrations/index.ts`): there is no `down` concept anywhere in this
migration system, not in `m001` through `m103`, not in the runner, not
in the registry test (which only tests forward convergence: applying
from every intermediate version reaches the same schema as a fresh
install). `m088`, cited as the pattern to follow, has no `down`
either. I followed the actual codebase pattern (`m104` is sql-only,
no `down`) rather than inventing a mechanism the rest of the
migrations directory doesn't have. Flagging this in case the brief's
assumption should be corrected for future items.

## Tests

- `packages/db/src/queries/pending-resolution.test.ts`: new test for
  `markPendingResolutionReplyPosted`.
- `apps/desktop/src/store/slices/github/index.test.ts`: `pushAllResolutions`
  gains tests for skip-repost-when-already-posted, marking the flag
  before a failed resolve so the row survives with it set, only
  counting a comment when a reply body actually went out, and never
  reposting a null-outcome row whose reply already went out.
  `resolveGithubThread` gains tests for persist-first leaving no
  orphan row on the no-reply path and never clobbering a verdict a
  caller already queued. `resolveAgentThreads` gains a test that
  persists first for a target with no backing row and proves a retry
  does not repost.
- `apps/desktop/src/store/slices/agents/activateNextResolver.test.ts`:
  one test proving two concurrent triggers only start one resolver,
  and one proving the chain hands off to the next resolver from
  inside the finishing turn (the regression test; verified it fails
  against the pre-fix code and passes against the fix).
- `apps/desktop/src/features/session/components/AgentInspector/resolver.test.tsx`:
  new test proving a failed resolver turn now surfaces a notification
  instead of disappearing silently.

All existing `PendingResolution` fixtures across the touched test
files were updated with the new `replyPostedAt` field to keep them
typed against the widened type; no existing assertion was weakened.

## Test plan

- [x] `pnpm typecheck` (all 5 packages) — clean
- [x] `pnpm test` (4370 tests, all packages) — all pass
- [x] `pnpm knip --include files,duplicates,unlisted` — clean, only
      pre-existing config hints
- [x] `packages/db/src/migrations/registry.test.ts` specifically (no
      duplicate/gap/filename mismatch, up-convergence from every
      intermediate version holds through m104) — 8/8 pass
