### PR TITLE
feat(desktop): comment on and edit gitlab issues in place

### DIFF
--- a/apps/desktop/src-tauri/src/gitlab.rs
+++ b/apps/desktop/src-tauri/src/gitlab.rs
@@ -751,6 +751,59 @@ pub async fn gitlab_reply_to_mr_discussion(
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+pub struct GitlabIssueNote {
+    pub id: i64,
+    #[serde(default)]
+    pub body: String,
+    #[serde(default)]
+    pub system: bool,
+    #[serde(default)]
+    pub author: Option<GitlabMrAuthor>,
+    #[serde(rename = "createdAt", alias = "created_at", default)]
+    pub created_at: String,
+}
+
+#[tauri::command]
+pub async fn gitlab_list_issue_notes(
+    workspace_id: String,
+    host: String,
+    project_path: String,
+    issue_iid: i64,
+    cache: State<'_, GitlabTokenCache>,
+) -> Result<Vec<GitlabIssueNote>, GitlabError> {
+    let token = read_token(&workspace_id, &cache)?;
+    let encoded = encode_project_path(&project_path);
+    get_json_paged(
+        &host,
+        &token,
+        &format!("/projects/{encoded}/issues/{issue_iid}/notes?order_by=created_at&sort=asc"),
+    )
+    .await
+}
+
+#[tauri::command]
+pub async fn gitlab_create_issue_note(
+    workspace_id: String,
+    host: String,
+    project_path: String,
+    issue_iid: i64,
+    body: String,
+    cache: State<'_, GitlabTokenCache>,
+) -> Result<i64, GitlabError> {
+    let token = read_token(&workspace_id, &cache)?;
+    let encoded = encode_project_path(&project_path);
+    let note: GitlabNote = send_json(
+        reqwest::Method::POST,
+        &host,
+        &token,
+        &format!("/projects/{encoded}/issues/{issue_iid}/notes"),
+        &serde_json::json!({ "body": body }),
+    )
+    .await?;
+    Ok(note.id)
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 pub struct GitlabApproval {
     pub user: GitlabMrAuthor,
 }
@@ -1273,6 +1326,43 @@ mod tests {
         assert_eq!(issue.updated_at, "2026-05-21T10:00:00Z");
         assert_eq!(issue.references.full, "acme/web#7");
         assert!(issue.description.is_none());
+    }
+
+    #[test]
+    fn issue_note_deserializes_snake_case_payload_with_system_flag() {
+        let raw = r#"{
+            "id": 5,
+            "body": "changed the milestone",
+            "system": true,
+            "created_at": "2026-07-22T10:00:00Z",
+            "author": { "username": "bob", "name": "Bob" }
+        }"#;
+        let note: GitlabIssueNote = serde_json::from_str(raw).unwrap();
+        assert!(note.system);
+        assert_eq!(note.author.unwrap().username, "bob");
+        assert_eq!(note.created_at, "2026-07-22T10:00:00Z");
+    }
+
+    #[test]
+    fn issue_note_defaults_missing_fields_on_a_bare_payload() {
+        let note: GitlabIssueNote = serde_json::from_str(r#"{ "id": 1 }"#).unwrap();
+        assert_eq!(note.body, "");
+        assert!(!note.system);
+        assert!(note.author.is_none());
+    }
+
+    #[test]
+    fn issue_note_serializes_to_camel_case_for_the_frontend() {
+        let note = GitlabIssueNote {
+            id: 1,
+            body: "looks good".into(),
+            system: false,
+            author: None,
+            created_at: "2026-07-22T10:00:00Z".into(),
+        };
+        let value = serde_json::to_value(&note).unwrap();
+        assert_eq!(value["createdAt"], "2026-07-22T10:00:00Z");
+        assert_eq!(value["body"], "looks good");
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -276,6 +276,8 @@ pub fn run() {
             gitlab::gitlab_fetch_assigned_issues,
             gitlab::gitlab_fetch_issue,
             gitlab::gitlab_update_issue,
+            gitlab::gitlab_list_issue_notes,
+            gitlab::gitlab_create_issue_note,
             gitlab::gitlab_fetch_assigned_mrs,
             gitlab::gitlab_fetch_project_mrs,
             gitlab::gitlab_mr_for_branch,

--- a/apps/desktop/src/features/integrations/gitlab/GitlabIssueDetail/index.test.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabIssueDetail/index.test.tsx
@@ -1,7 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { WorkspaceId } from '@goodboy/types';
-import { gitlabUpdateIssueDescription, type GitlabIssue } from '../client';
+import {
+  gitlabCreateIssueNote,
+  gitlabListIssueNotes,
+  gitlabUpdateIssueDescription,
+  type GitlabIssue,
+} from '../client';
 import { GitlabIssueDetail } from './index';
 
 type StoreGitlabIntegration = { provider: string; config: { host: string } };
@@ -19,9 +24,13 @@ vi.mock('../../../../store', () => ({
 vi.mock('../client', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../client')>()),
   gitlabUpdateIssueDescription: vi.fn(),
+  gitlabListIssueNotes: vi.fn(async () => []),
+  gitlabCreateIssueNote: vi.fn(async () => 1),
 }));
 
 const updateDescription = vi.mocked(gitlabUpdateIssueDescription);
+const listIssueNotes = vi.mocked(gitlabListIssueNotes);
+const createIssueNote = vi.mocked(gitlabCreateIssueNote);
 const WORKSPACE_ID = 'workspace-1' as WorkspaceId;
 
 const ISSUE: GitlabIssue = {
@@ -40,6 +49,10 @@ const ISSUE: GitlabIssue = {
 
 beforeEach(() => {
   updateDescription.mockReset();
+  listIssueNotes.mockReset();
+  listIssueNotes.mockResolvedValue([]);
+  createIssueNote.mockReset();
+  createIssueNote.mockResolvedValue(1);
   h.store.workspaceIntegrations = {
     [WORKSPACE_ID]: [{ provider: 'gitlab', config: { host: 'https://gitlab.com' } }],
   };
@@ -116,5 +129,53 @@ describe('GitlabIssueDetail', () => {
     expect(screen.queryByRole('button', { name: 'Edit' })).toBeNull();
     fireEvent.click(screen.getByTestId('description-body'));
     expect(screen.queryByRole('textbox', { name: 'Edit description' })).toBeNull();
+  });
+
+  it('renders the conversation notes without the system notes', async () => {
+    listIssueNotes.mockResolvedValue([
+      {
+        id: 1,
+        body: 'This needs a repro',
+        system: false,
+        author: { username: 'bob', name: 'Bob', avatarUrl: null },
+        createdAt: '2026-07-22T10:00:00Z',
+      },
+      {
+        id: 2,
+        body: 'changed the milestone to v1.4',
+        system: true,
+        author: null,
+        createdAt: '2026-07-22T10:01:00Z',
+      },
+    ]);
+    render(<GitlabIssueDetail issue={ISSUE} workspaceId={WORKSPACE_ID} />);
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Conversation' }));
+
+    await waitFor(() => expect(screen.getByText('This needs a repro')).toBeDefined());
+    expect(screen.queryByText('changed the milestone to v1.4')).toBeNull();
+    expect(screen.getByText('1 system event hidden')).toBeDefined();
+  });
+
+  it('posts a note through the GitLab client and reloads the conversation', async () => {
+    render(<GitlabIssueDetail issue={ISSUE} workspaceId={WORKSPACE_ID} />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Conversation' }));
+    await waitFor(() => expect(listIssueNotes).toHaveBeenCalledOnce());
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Write a note' }), {
+      target: { value: 'Reproduced on main' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Comment' }));
+
+    await waitFor(() =>
+      expect(createIssueNote).toHaveBeenCalledWith({
+        workspaceId: WORKSPACE_ID,
+        host: 'https://gitlab.com',
+        projectPath: 'acme/web',
+        issueIid: 7,
+        body: 'Reproduced on main',
+      }),
+    );
+    await waitFor(() => expect(listIssueNotes).toHaveBeenCalledTimes(2));
   });
 });

--- a/apps/desktop/src/features/integrations/gitlab/GitlabIssueDetail/index.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabIssueDetail/index.tsx
@@ -1,14 +1,23 @@
-import type { ReactNode } from 'react';
+import { useState, type ReactNode } from 'react';
+import { FileText, MessageSquare } from 'lucide-react';
 import type { WorkspaceId } from '@goodboy/types';
-import { HeaderBand, StudioDetailLayout } from '../../../../shared/components/StudioDetail';
+import type { SegmentedTabOption } from '@goodboy/ui';
+import {
+  HeaderBand,
+  StudioDetailLayout,
+  StudioDetailTabs,
+} from '../../../../shared/components/StudioDetail';
 import { DescriptionSection } from '../../../../shared/components/DescriptionSection';
 import { gitlabIssueFields, resolveDetailFields } from '../../../../shared/detail-fields';
 import { IssueStateBadge } from '../../../../shared/components/IssueStateBadge';
 import { ExternalRefActions } from '../../../../shared/components/ExternalRefActions';
 import { issueIdentifier, type GitlabIssue } from '../client';
 import { useGitlabIssueDescription } from '../useGitlabIssueDescription';
+import { useGitlabIssueNotes } from '../useGitlabIssueNotes';
+import { IssueConversation } from '../IssueConversation';
 
 type Fit = 'fill' | 'bleed' | 'flow';
+type IssueSection = 'overview' | 'conversation';
 
 type Props = {
   readonly issue: GitlabIssue;
@@ -17,8 +26,15 @@ type Props = {
   readonly fit?: Fit;
 };
 
+const SECTION_OPTIONS: ReadonlyArray<SegmentedTabOption<IssueSection>> = [
+  { value: 'overview', label: 'Overview', icon: FileText },
+  { value: 'conversation', label: 'Conversation', icon: MessageSquare },
+];
+
 export const GitlabIssueDetail = ({ issue, workspaceId, headerActions, fit = 'fill' }: Props) => {
+  const [section, setSection] = useState<IssueSection>('overview');
   const { description, save } = useGitlabIssueDescription({ issue, workspaceId });
+  const notes = useGitlabIssueNotes({ issue, workspaceId });
 
   return (
     <StudioDetailLayout
@@ -42,9 +58,27 @@ export const GitlabIssueDetail = ({ issue, workspaceId, headerActions, fit = 'fi
           }
         />
       }
+      tabs={
+        <StudioDetailTabs
+          ariaLabel="Issue sections"
+          options={SECTION_OPTIONS}
+          value={section}
+          onChange={setSection}
+        />
+      }
       properties={resolveDetailFields({ registry: gitlabIssueFields, entity: issue })}
     >
-      <DescriptionSection text={description} onSave={save} />
+      {section === 'overview' ? (
+        <DescriptionSection text={description} onSave={save} />
+      ) : (
+        <IssueConversation
+          notes={notes.notes}
+          isLoading={notes.isLoading}
+          error={notes.error}
+          onRetry={notes.reload}
+          onPost={notes.post}
+        />
+      )}
     </StudioDetailLayout>
   );
 };

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/IssueDetailPanel.test.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/IssueDetailPanel.test.tsx
@@ -1,7 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { WorkspaceId } from '@goodboy/types';
-import type { GitlabIssue } from '../client';
+import {
+  gitlabCreateIssueNote,
+  gitlabListIssueNotes,
+  gitlabUpdateIssueDescription,
+  type GitlabIssue,
+} from '../client';
+
+type StoreGitlabIntegration = { provider: string; config: { host: string } };
 
 const h = vi.hoisted(() => ({
   createSession: vi.fn(async () => ({
@@ -11,6 +18,9 @@ const h = vi.hoisted(() => ({
   showToast: vi.fn(),
   store: {
     workspaces: [{ id: 'workspace-1', rootPath: '/repo' }],
+    workspaceIntegrations: {
+      'workspace-1': [{ provider: 'gitlab', config: { host: 'https://gitlab.com' } }],
+    } as Record<string, ReadonlyArray<StoreGitlabIntegration>>,
   },
 }));
 
@@ -29,9 +39,19 @@ vi.mock('../../../../app/components/Toast', () => ({
 }));
 vi.mock('../../../worktree/useBranchConflict', () => ({ useBranchConflict: () => null }));
 vi.mock('../../../worktree/worktree', () => ({ removeWorktree: vi.fn() }));
+vi.mock('../client', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../client')>()),
+  gitlabUpdateIssueDescription: vi.fn(),
+  gitlabListIssueNotes: vi.fn(async () => []),
+  gitlabCreateIssueNote: vi.fn(async () => 1),
+}));
 
 import { IssueDetailPanel } from './IssueDetailPanel';
 import { formatAbsoluteDateTime } from '../../../../shared/utils/relativeDate';
+
+const updateDescription = vi.mocked(gitlabUpdateIssueDescription);
+const listIssueNotes = vi.mocked(gitlabListIssueNotes);
+const createIssueNote = vi.mocked(gitlabCreateIssueNote);
 
 const ISSUE: GitlabIssue = {
   id: 71,
@@ -51,6 +71,11 @@ beforeEach(() => {
   h.createSession.mockClear();
   h.loadSetting.mockClear();
   h.showToast.mockClear();
+  updateDescription.mockReset();
+  listIssueNotes.mockReset();
+  listIssueNotes.mockResolvedValue([]);
+  createIssueNote.mockReset();
+  createIssueNote.mockResolvedValue(1);
 });
 
 afterEach(cleanup);
@@ -73,5 +98,82 @@ describe('IssueDetailPanel', () => {
     expect(screen.getByText('bug')).toBeDefined();
     expect(screen.getByText('Updated')).toBeDefined();
     expect(screen.getByText(formatAbsoluteDateTime({ iso: ISSUE.updatedAt }))).toBeDefined();
+  });
+
+  it('saves an edited description through the GitLab client', async () => {
+    updateDescription.mockResolvedValueOnce('Body normalized by GitLab');
+    render(
+      <IssueDetailPanel
+        issue={ISSUE}
+        sessionId={null}
+        workspaceId={'workspace-1' as WorkspaceId}
+        onClose={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    fireEvent.change(screen.getByRole('textbox', { name: 'Edit description' }), {
+      target: { value: 'Body typed by the user' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() =>
+      expect(updateDescription).toHaveBeenCalledWith({
+        workspaceId: 'workspace-1',
+        host: 'https://gitlab.com',
+        projectPath: 'acme/web',
+        issueIid: 7,
+        description: 'Body typed by the user',
+      }),
+    );
+    await waitFor(() => expect(screen.getByText('Body normalized by GitLab')).toBeDefined());
+  });
+
+  it('renders the conversation notes without the system notes and posts a new one', async () => {
+    listIssueNotes.mockResolvedValue([
+      {
+        id: 1,
+        body: 'Reproduced on staging',
+        system: false,
+        author: { username: 'alice', name: 'Alice', avatarUrl: null },
+        createdAt: '2026-07-22T10:00:00Z',
+      },
+      {
+        id: 2,
+        body: 'changed the weight to 3',
+        system: true,
+        author: null,
+        createdAt: '2026-07-22T10:01:00Z',
+      },
+    ]);
+    render(
+      <IssueDetailPanel
+        issue={ISSUE}
+        sessionId={null}
+        workspaceId={'workspace-1' as WorkspaceId}
+        onClose={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Conversation' }));
+
+    await waitFor(() => expect(screen.getByText('Reproduced on staging')).toBeDefined());
+    expect(screen.queryByText('changed the weight to 3')).toBeNull();
+    expect(screen.getByText('1 system event hidden')).toBeDefined();
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Write a note' }), {
+      target: { value: 'Confirmed the fix' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Comment' }));
+
+    await waitFor(() =>
+      expect(createIssueNote).toHaveBeenCalledWith({
+        workspaceId: 'workspace-1',
+        host: 'https://gitlab.com',
+        projectPath: 'acme/web',
+        issueIid: 7,
+        body: 'Confirmed the fix',
+      }),
+    );
   });
 });

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/IssueDetailPanel.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/IssueDetailPanel.tsx
@@ -1,10 +1,14 @@
-import { EmptyState, Markdown } from '@goodboy/ui';
+import { useState } from 'react';
+import { EmptyState } from '@goodboy/ui';
+import { FileText, MessageSquare } from 'lucide-react';
 import type { SessionId, WorkspaceId } from '@goodboy/types';
+import type { SegmentedTabOption } from '@goodboy/ui';
 import {
-  DetailSection,
   HeaderBand,
   StudioDetailLayout,
+  StudioDetailTabs,
 } from '../../../../shared/components/StudioDetail';
+import { DescriptionSection } from '../../../../shared/components/DescriptionSection';
 import { gitlabIssueFields, resolveDetailFields } from '../../../../shared/detail-fields';
 import { IssueStateBadge } from '../../../../shared/components/IssueStateBadge';
 import { ExternalRefActions } from '../../../../shared/components/ExternalRefActions';
@@ -13,6 +17,9 @@ import { goalFromIssue } from '../goal-from-issue';
 import { issueIdentifier, type GitlabIssue } from '../client';
 import { gitlabBranchSlug } from './useGitlabIssues';
 import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../shared/components/conceptIcons';
+import { useGitlabIssueDescription } from '../useGitlabIssueDescription';
+import { useGitlabIssueNotes } from '../useGitlabIssueNotes';
+import { IssueConversation } from '../IssueConversation';
 
 type Props = {
   readonly issue: GitlabIssue | null;
@@ -21,7 +28,18 @@ type Props = {
   readonly onClose: () => void;
 };
 
+type IssueSection = 'overview' | 'conversation';
+
+const SECTION_OPTIONS: ReadonlyArray<SegmentedTabOption<IssueSection>> = [
+  { value: 'overview', label: 'Overview', icon: FileText },
+  { value: 'conversation', label: 'Conversation', icon: MessageSquare },
+];
+
 export const IssueDetailPanel = ({ issue, sessionId, workspaceId, onClose }: Props) => {
+  const [section, setSection] = useState<IssueSection>('overview');
+  const { description, save } = useGitlabIssueDescription({ issue, workspaceId });
+  const notes = useGitlabIssueNotes({ issue, workspaceId });
+
   if (!issue) {
     return (
       <div className="flex h-full items-center justify-center px-8">
@@ -72,16 +90,28 @@ export const IssueDetailPanel = ({ issue, sessionId, workspaceId, onClose }: Pro
           actions={<ExternalRefActions url={issue.webUrl} label="issue" hostLabel="GitLab" />}
         />
       }
+      tabs={
+        <StudioDetailTabs
+          ariaLabel="Issue sections"
+          options={SECTION_OPTIONS}
+          value={section}
+          onChange={setSection}
+        />
+      }
       dock={launch}
       properties={resolveDetailFields({ registry: gitlabIssueFields, entity: issue })}
     >
-      <DetailSection label="description" variant="frameless">
-        {issue.description ? (
-          <Markdown text={issue.description} className="text-sm leading-relaxed" />
-        ) : (
-          <p className="text-sm italic text-muted-foreground/60">No description.</p>
-        )}
-      </DetailSection>
+      {section === 'overview' ? (
+        <DescriptionSection text={description} onSave={save} />
+      ) : (
+        <IssueConversation
+          notes={notes.notes}
+          isLoading={notes.isLoading}
+          error={notes.error}
+          onRetry={notes.reload}
+          onPost={notes.post}
+        />
+      )}
     </StudioDetailLayout>
   );
 };

--- a/apps/desktop/src/features/integrations/gitlab/IssueConversation/IssueNoteAvatar.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/IssueConversation/IssueNoteAvatar.tsx
@@ -1,0 +1,18 @@
+type Props = {
+  readonly url: string | null;
+  readonly alt: string;
+};
+
+export const IssueNoteAvatar = ({ url, alt }: Props) => {
+  if (url == null || url === '') {
+    return (
+      <span
+        aria-hidden
+        className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-muted text-2xs font-semibold text-muted-foreground"
+      >
+        {alt.slice(0, 1).toUpperCase()}
+      </span>
+    );
+  }
+  return <img src={url} alt={alt} className="h-5 w-5 shrink-0 rounded-full" loading="lazy" />;
+};

--- a/apps/desktop/src/features/integrations/gitlab/IssueConversation/IssueNoteCard.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/IssueConversation/IssueNoteCard.tsx
@@ -1,0 +1,14 @@
+import { Markdown } from '@goodboy/ui';
+import type { GitlabIssueNote } from '../client';
+import { IssueNoteHeader } from './IssueNoteHeader';
+
+type Props = {
+  readonly note: GitlabIssueNote;
+};
+
+export const IssueNoteCard = ({ note }: Props) => (
+  <div className="flex flex-col gap-2 rounded-lg bg-muted/20 p-3">
+    <IssueNoteHeader note={note} />
+    <Markdown text={note.body} className="text-sm leading-relaxed" />
+  </div>
+);

--- a/apps/desktop/src/features/integrations/gitlab/IssueConversation/IssueNoteComposer.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/IssueConversation/IssueNoteComposer.tsx
@@ -1,0 +1,65 @@
+import { useState } from 'react';
+import { Button, Textarea } from '@goodboy/ui';
+import { formatError } from '../../../../shared/lib/errors';
+
+type Props = {
+  readonly placeholder: string;
+  readonly submitLabel: string;
+  readonly onSubmit: (body: string) => Promise<void>;
+};
+
+export const IssueNoteComposer = ({ placeholder, submitLabel, onSubmit }: Props) => {
+  const [draft, setDraft] = useState('');
+  const [isPosting, setIsPosting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const body = draft.trim();
+
+  const submit = async () => {
+    if (body === '') {
+      return;
+    }
+    setIsPosting(true);
+    setError(null);
+    try {
+      await onSubmit(body);
+      setDraft('');
+    } catch (postError: unknown) {
+      setError(formatError(postError));
+    } finally {
+      setIsPosting(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <Textarea
+        autoGrow
+        minRows={3}
+        maxRows={16}
+        value={draft}
+        aria-label={placeholder}
+        placeholder={placeholder}
+        onChange={(event) => setDraft(event.target.value)}
+        className="text-sm leading-relaxed"
+      />
+      <div className="flex items-center justify-between gap-3">
+        {error != null ? (
+          <p role="alert" className="min-w-0 text-xs text-danger">
+            {error}
+          </p>
+        ) : (
+          <p className="text-2xs text-muted-foreground">Markdown supported</p>
+        )}
+        <Button
+          size="sm"
+          disabled={body === ''}
+          isBusy={isPosting}
+          busyLabel="Posting"
+          onClick={() => void submit()}
+        >
+          {submitLabel}
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/apps/desktop/src/features/integrations/gitlab/IssueConversation/IssueNoteHeader.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/IssueConversation/IssueNoteHeader.tsx
@@ -1,0 +1,25 @@
+import { formatRelativeAge } from '../../../../shared/utils/relativeDate';
+import type { GitlabIssueNote } from '../client';
+import { IssueNoteAvatar } from './IssueNoteAvatar';
+
+type Props = {
+  readonly note: GitlabIssueNote;
+};
+
+export const IssueNoteHeader = ({ note }: Props) => {
+  const age = formatRelativeAge({ fromIso: note.createdAt });
+  const name = note.author?.name ?? 'Unknown';
+
+  return (
+    <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+      <IssueNoteAvatar url={note.author?.avatarUrl ?? null} alt={name} />
+      <span className="font-medium text-foreground">{name}</span>
+      {age !== '' && (
+        <>
+          <span className="opacity-50">·</span>
+          <span>{age}</span>
+        </>
+      )}
+    </div>
+  );
+};

--- a/apps/desktop/src/features/integrations/gitlab/IssueConversation/index.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/IssueConversation/index.tsx
@@ -1,0 +1,71 @@
+import { useMemo } from 'react';
+import { EmptyState, Skeleton } from '@goodboy/ui';
+import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../shared/components/conceptIcons';
+import { ErrorStrip } from '../../../../shared/components/ErrorStrip';
+import type { GitlabIssueNote } from '../client';
+import { IssueNoteCard } from './IssueNoteCard';
+import { IssueNoteComposer } from './IssueNoteComposer';
+import { buildIssueConversation } from './issueNotes';
+
+type Props = {
+  readonly notes: ReadonlyArray<GitlabIssueNote>;
+  readonly isLoading: boolean;
+  readonly error: string | null;
+  readonly onRetry: () => void;
+  readonly onPost: ((body: string) => Promise<void>) | null;
+};
+
+export const IssueConversation = ({ notes, isLoading, error, onRetry, onPost }: Props) => {
+  const conversation = useMemo(() => buildIssueConversation({ notes }), [notes]);
+
+  if (isLoading) {
+    return (
+      <div role="status" aria-label="Loading the conversation" className="flex flex-col gap-3">
+        {[0, 1, 2].map((row) => (
+          <div key={row} className="flex flex-col gap-2 rounded-lg bg-muted/20 p-3">
+            <Skeleton className="h-3 w-28 rounded" />
+            <Skeleton className="h-3 w-full rounded" />
+            <Skeleton className="h-3 w-2/3 rounded" />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (error != null) {
+    return <ErrorStrip label="the conversation" error={new Error(error)} onRetry={onRetry} />;
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      {conversation.notes.length === 0 ? (
+        <EmptyState
+          icon={CONCEPT_ICONS.comments}
+          tone={CONCEPT_TONE.comments}
+          title="No comments yet"
+          description="Notes on this issue show up here."
+          size="inline"
+          className="py-5"
+        />
+      ) : (
+        <ul className="flex flex-col gap-2.5">
+          {conversation.notes.map((note) => (
+            <li key={note.id}>
+              <IssueNoteCard note={note} />
+            </li>
+          ))}
+        </ul>
+      )}
+      {conversation.systemNoteCount > 0 && (
+        <p className="text-2xs text-muted-foreground">
+          {conversation.systemNoteCount === 1
+            ? '1 system event hidden'
+            : `${conversation.systemNoteCount} system events hidden`}
+        </p>
+      )}
+      {onPost != null && (
+        <IssueNoteComposer placeholder="Write a note" submitLabel="Comment" onSubmit={onPost} />
+      )}
+    </div>
+  );
+};

--- a/apps/desktop/src/features/integrations/gitlab/IssueConversation/issueNotes.test.ts
+++ b/apps/desktop/src/features/integrations/gitlab/IssueConversation/issueNotes.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import type { GitlabIssueNote } from '../client';
+import { buildIssueConversation } from './issueNotes';
+
+type NoteParams = Partial<GitlabIssueNote> & { readonly id: number };
+
+const note = ({ id, ...rest }: NoteParams): GitlabIssueNote => ({
+  id,
+  body: `note ${id}`,
+  system: false,
+  author: { username: 'alice', name: 'Alice', avatarUrl: null },
+  createdAt: '2026-07-22T10:00:00Z',
+  ...rest,
+});
+
+describe('buildIssueConversation', () => {
+  it('drops system notes and counts them', () => {
+    const conversation = buildIssueConversation({
+      notes: [
+        note({ id: 1, body: 'tighten this' }),
+        note({ id: 2, body: 'changed milestone to v2', system: true }),
+        note({ id: 3, body: 'done' }),
+      ],
+    });
+
+    expect(conversation.systemNoteCount).toBe(1);
+    expect(conversation.notes.map((n) => n.body)).toEqual(['tighten this', 'done']);
+  });
+
+  it('returns an empty conversation when every note is a system note', () => {
+    const conversation = buildIssueConversation({
+      notes: [note({ id: 1, body: 'assigned to bob', system: true })],
+    });
+
+    expect(conversation.notes).toHaveLength(0);
+    expect(conversation.systemNoteCount).toBe(1);
+  });
+
+  it('sorts notes oldest first for a chronological conversation', () => {
+    const conversation = buildIssueConversation({
+      notes: [
+        note({ id: 1, createdAt: '2026-07-24T10:00:00Z' }),
+        note({ id: 2, createdAt: '2026-07-20T10:00:00Z' }),
+      ],
+    });
+
+    expect(conversation.notes.map((n) => n.id)).toEqual([2, 1]);
+  });
+});

--- a/apps/desktop/src/features/integrations/gitlab/IssueConversation/issueNotes.ts
+++ b/apps/desktop/src/features/integrations/gitlab/IssueConversation/issueNotes.ts
@@ -1,0 +1,28 @@
+import type { GitlabIssueNote } from '../client';
+
+type Params = {
+  readonly notes: ReadonlyArray<GitlabIssueNote>;
+};
+
+export type IssueConversation = {
+  readonly notes: ReadonlyArray<GitlabIssueNote>;
+  readonly systemNoteCount: number;
+};
+
+export const buildIssueConversation = ({ notes }: Params): IssueConversation => {
+  const visible: GitlabIssueNote[] = [];
+  let systemNoteCount = 0;
+
+  for (const note of notes) {
+    if (note.system) {
+      systemNoteCount += 1;
+      continue;
+    }
+    visible.push(note);
+  }
+
+  return {
+    notes: visible.sort((left, right) => left.createdAt.localeCompare(right.createdAt)),
+    systemNoteCount,
+  };
+};

--- a/apps/desktop/src/features/integrations/gitlab/client.ts
+++ b/apps/desktop/src/features/integrations/gitlab/client.ts
@@ -336,6 +336,55 @@ export const gitlabReplyToMrDiscussion = async ({
   });
 };
 
+export type GitlabIssueNote = {
+  id: number;
+  body: string;
+  system: boolean;
+  author: GitlabMrAuthor | null;
+  createdAt: string;
+};
+
+type IssueTarget = {
+  readonly workspaceId: WorkspaceId;
+  readonly host: string;
+  readonly projectPath: string;
+  readonly issueIid: number;
+};
+
+export const gitlabListIssueNotes = async ({
+  workspaceId,
+  host,
+  projectPath,
+  issueIid,
+}: IssueTarget): Promise<ReadonlyArray<GitlabIssueNote>> => {
+  return invoke<ReadonlyArray<GitlabIssueNote>>('gitlab_list_issue_notes', {
+    workspaceId,
+    host,
+    projectPath,
+    issueIid,
+  });
+};
+
+type CreateIssueNoteParams = IssueTarget & {
+  readonly body: string;
+};
+
+export const gitlabCreateIssueNote = async ({
+  workspaceId,
+  host,
+  projectPath,
+  issueIid,
+  body,
+}: CreateIssueNoteParams): Promise<number> => {
+  return invoke<number>('gitlab_create_issue_note', {
+    workspaceId,
+    host,
+    projectPath,
+    issueIid,
+    body,
+  });
+};
+
 export const gitlabMrApprovalState = async ({
   workspaceId,
   host,

--- a/apps/desktop/src/features/integrations/gitlab/issueProjectPath.test.ts
+++ b/apps/desktop/src/features/integrations/gitlab/issueProjectPath.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from 'vitest';
 import type { GitlabIssue } from './client';
 import { projectPathFromIssue } from './issueProjectPath';
 
-const issue = (full: string): GitlabIssue => ({
+type Params = {
+  readonly full: string;
+};
+
+const issue = ({ full }: Params): GitlabIssue => ({
   id: 1,
   iid: 1,
   projectId: 1,
@@ -18,14 +22,14 @@ const issue = (full: string): GitlabIssue => ({
 
 describe('projectPathFromIssue', () => {
   it('strips the issue suffix from the full reference', () => {
-    expect(projectPathFromIssue({ issue: issue('acme/web#7') })).toBe('acme/web');
+    expect(projectPathFromIssue({ issue: issue({ full: 'acme/web#7' }) })).toBe('acme/web');
   });
 
   it('returns null when the reference has no project prefix', () => {
-    expect(projectPathFromIssue({ issue: issue('#7') })).toBeNull();
+    expect(projectPathFromIssue({ issue: issue({ full: '#7' }) })).toBeNull();
   });
 
   it('returns null when the reference is empty', () => {
-    expect(projectPathFromIssue({ issue: issue('') })).toBeNull();
+    expect(projectPathFromIssue({ issue: issue({ full: '' }) })).toBeNull();
   });
 });

--- a/apps/desktop/src/features/integrations/gitlab/issueProjectPath.test.ts
+++ b/apps/desktop/src/features/integrations/gitlab/issueProjectPath.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import type { GitlabIssue } from './client';
+import { projectPathFromIssue } from './issueProjectPath';
+
+const issue = (full: string): GitlabIssue => ({
+  id: 1,
+  iid: 1,
+  projectId: 1,
+  title: 't',
+  description: null,
+  state: 'opened',
+  webUrl: 'https://gitlab.com/acme/web/-/issues/1',
+  references: { full },
+  updatedAt: '2026-01-01T00:00:00Z',
+  milestone: null,
+  labels: [],
+});
+
+describe('projectPathFromIssue', () => {
+  it('strips the issue suffix from the full reference', () => {
+    expect(projectPathFromIssue({ issue: issue('acme/web#7') })).toBe('acme/web');
+  });
+
+  it('returns null when the reference has no project prefix', () => {
+    expect(projectPathFromIssue({ issue: issue('#7') })).toBeNull();
+  });
+
+  it('returns null when the reference is empty', () => {
+    expect(projectPathFromIssue({ issue: issue('') })).toBeNull();
+  });
+});

--- a/apps/desktop/src/features/integrations/gitlab/issueProjectPath.ts
+++ b/apps/desktop/src/features/integrations/gitlab/issueProjectPath.ts
@@ -1,0 +1,12 @@
+import type { GitlabIssue } from './client';
+
+type Params = {
+  readonly issue: GitlabIssue;
+};
+
+export const projectPathFromIssue = ({ issue }: Params): string | null => {
+  const full = issue.references?.full ?? '';
+  const index = full.indexOf('#');
+  const path = (index >= 0 ? full.slice(0, index) : full).trim();
+  return path === '' ? null : path;
+};

--- a/apps/desktop/src/features/integrations/gitlab/useGitlabIssueDescription.ts
+++ b/apps/desktop/src/features/integrations/gitlab/useGitlabIssueDescription.ts
@@ -2,22 +2,16 @@ import { useCallback, useEffect, useState } from 'react';
 import type { GitlabWorkspaceIntegration, WorkspaceId } from '@goodboy/types';
 import { useAppStore } from '../../../store';
 import { gitlabUpdateIssueDescription, type GitlabIssue } from './client';
+import { projectPathFromIssue } from './issueProjectPath';
 
 type Params = {
-  readonly issue: GitlabIssue;
+  readonly issue: GitlabIssue | null;
   readonly workspaceId: WorkspaceId;
 };
 
 type Result = {
   readonly description: string;
   readonly save: ((next: string) => Promise<void>) | null;
-};
-
-const projectPathFrom = (issue: GitlabIssue): string | null => {
-  const full = issue.references?.full ?? '';
-  const index = full.indexOf('#');
-  const path = (index >= 0 ? full.slice(0, index) : full).trim();
-  return path === '' ? null : path;
 };
 
 export const useGitlabIssueDescription = ({ issue, workspaceId }: Params): Result => {
@@ -28,16 +22,16 @@ export const useGitlabIssueDescription = ({ issue, workspaceId }: Params): Resul
     return integration != null ? integration.config.host : null;
   });
   const [saved, setSaved] = useState<string | null>(null);
-  const projectPath = projectPathFrom(issue);
-  const issueIid = issue.iid;
+  const projectPath = issue == null ? null : projectPathFromIssue({ issue });
+  const issueIid = issue?.iid ?? null;
 
   useEffect(() => {
     setSaved(null);
-  }, [issueIid, issue.description]);
+  }, [issueIid, issue?.description]);
 
   const save = useCallback(
     async (next: string) => {
-      if (host == null || projectPath == null) {
+      if (host == null || projectPath == null || issueIid == null) {
         return;
       }
       const description = await gitlabUpdateIssueDescription({
@@ -53,7 +47,7 @@ export const useGitlabIssueDescription = ({ issue, workspaceId }: Params): Resul
   );
 
   return {
-    description: saved ?? issue.description ?? '',
-    save: host == null || projectPath == null ? null : save,
+    description: saved ?? issue?.description ?? '',
+    save: host == null || projectPath == null || issueIid == null ? null : save,
   };
 };

--- a/apps/desktop/src/features/integrations/gitlab/useGitlabIssueNotes/index.test.ts
+++ b/apps/desktop/src/features/integrations/gitlab/useGitlabIssueNotes/index.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, renderHook, waitFor } from '@testing-library/react';
+import type { WorkspaceId } from '@goodboy/types';
+import type { GitlabIssue, GitlabIssueNote } from '../client';
+
+type StoreGitlabIntegration = { provider: string; config: { host: string } };
+
+const h = vi.hoisted(() => ({
+  list: vi.fn<() => Promise<ReadonlyArray<GitlabIssueNote>>>(),
+  createNote: vi.fn(async () => 1),
+  store: {
+    workspaceIntegrations: {} as Record<string, ReadonlyArray<StoreGitlabIntegration>>,
+  },
+}));
+
+vi.mock('../../../../store', () => ({
+  useAppStore: <T>(selector: (state: typeof h.store) => T) => selector(h.store),
+}));
+
+vi.mock('../client', () => ({
+  gitlabListIssueNotes: h.list,
+  gitlabCreateIssueNote: h.createNote,
+}));
+
+import { useGitlabIssueNotes } from './index';
+
+const WORKSPACE_ID = 'workspace-1' as WorkspaceId;
+
+const ISSUE: GitlabIssue = {
+  id: 101,
+  iid: 7,
+  projectId: 3,
+  title: 'Fix the thing',
+  description: 'Investigate the flaky request.',
+  state: 'opened',
+  webUrl: 'https://gitlab.com/acme/web/-/issues/7',
+  references: { full: 'acme/web#7' },
+  updatedAt: '2026-05-21T10:00:00Z',
+  milestone: null,
+  labels: [],
+};
+
+const note = (id: number): GitlabIssueNote => ({
+  id,
+  body: `note ${id}`,
+  system: false,
+  author: { username: 'alice', name: 'Alice', avatarUrl: null },
+  createdAt: '2026-07-22T10:00:00Z',
+});
+
+beforeEach(() => {
+  h.list.mockReset();
+  h.list.mockResolvedValue([note(1)]);
+  h.createNote.mockClear();
+  h.store.workspaceIntegrations = {
+    [WORKSPACE_ID]: [{ provider: 'gitlab', config: { host: 'https://gitlab.com' } }],
+  };
+});
+
+afterEach(cleanup);
+
+describe('useGitlabIssueNotes', () => {
+  it('loads the notes for an issue backed by a connected workspace', async () => {
+    const { result } = renderHook(() =>
+      useGitlabIssueNotes({ issue: ISSUE, workspaceId: WORKSPACE_ID }),
+    );
+
+    await waitFor(() => expect(result.current.notes).toHaveLength(1));
+    expect(h.list).toHaveBeenCalledWith({
+      workspaceId: WORKSPACE_ID,
+      host: 'https://gitlab.com',
+      projectPath: 'acme/web',
+      issueIid: 7,
+    });
+  });
+
+  it('stays idle and offers no post path without an issue', async () => {
+    const { result } = renderHook(() =>
+      useGitlabIssueNotes({ issue: null, workspaceId: WORKSPACE_ID }),
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(h.list).not.toHaveBeenCalled();
+    expect(result.current.post).toBeNull();
+  });
+
+  it('surfaces a load failure', async () => {
+    h.list.mockRejectedValue(new Error('GitLab token expired'));
+    const { result } = renderHook(() =>
+      useGitlabIssueNotes({ issue: ISSUE, workspaceId: WORKSPACE_ID }),
+    );
+
+    await waitFor(() => expect(result.current.error).toBe('GitLab token expired'));
+  });
+
+  it('reloads after posting a note', async () => {
+    const { result } = renderHook(() =>
+      useGitlabIssueNotes({ issue: ISSUE, workspaceId: WORKSPACE_ID }),
+    );
+    await waitFor(() => expect(h.list).toHaveBeenCalledOnce());
+
+    await result.current.post?.('looks good');
+
+    expect(h.createNote).toHaveBeenCalledWith({
+      workspaceId: WORKSPACE_ID,
+      host: 'https://gitlab.com',
+      projectPath: 'acme/web',
+      issueIid: 7,
+      body: 'looks good',
+    });
+    await waitFor(() => expect(h.list).toHaveBeenCalledTimes(2));
+  });
+});

--- a/apps/desktop/src/features/integrations/gitlab/useGitlabIssueNotes/index.test.ts
+++ b/apps/desktop/src/features/integrations/gitlab/useGitlabIssueNotes/index.test.ts
@@ -40,7 +40,11 @@ const ISSUE: GitlabIssue = {
   labels: [],
 };
 
-const note = (id: number): GitlabIssueNote => ({
+type Params = {
+  readonly id: number;
+};
+
+const note = ({ id }: Params): GitlabIssueNote => ({
   id,
   body: `note ${id}`,
   system: false,
@@ -50,7 +54,7 @@ const note = (id: number): GitlabIssueNote => ({
 
 beforeEach(() => {
   h.list.mockReset();
-  h.list.mockResolvedValue([note(1)]);
+  h.list.mockResolvedValue([note({ id: 1 })]);
   h.createNote.mockClear();
   h.store.workspaceIntegrations = {
     [WORKSPACE_ID]: [{ provider: 'gitlab', config: { host: 'https://gitlab.com' } }],

--- a/apps/desktop/src/features/integrations/gitlab/useGitlabIssueNotes/index.ts
+++ b/apps/desktop/src/features/integrations/gitlab/useGitlabIssueNotes/index.ts
@@ -1,0 +1,98 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { GitlabWorkspaceIntegration, WorkspaceId } from '@goodboy/types';
+import { useAppStore } from '../../../../store';
+import { formatError } from '../../../../shared/lib/errors';
+import {
+  gitlabCreateIssueNote,
+  gitlabListIssueNotes,
+  type GitlabIssue,
+  type GitlabIssueNote,
+} from '../client';
+import { projectPathFromIssue } from '../issueProjectPath';
+
+type Params = {
+  readonly issue: GitlabIssue | null;
+  readonly workspaceId: WorkspaceId;
+};
+
+type Result = {
+  readonly notes: ReadonlyArray<GitlabIssueNote>;
+  readonly isLoading: boolean;
+  readonly error: string | null;
+  readonly reload: () => void;
+  readonly post: ((body: string) => Promise<void>) | null;
+};
+
+export const useGitlabIssueNotes = ({ issue, workspaceId }: Params): Result => {
+  const host = useAppStore((state) => {
+    const integration = (state.workspaceIntegrations[workspaceId] ?? []).find(
+      (candidate): candidate is GitlabWorkspaceIntegration => candidate.provider === 'gitlab',
+    );
+    return integration != null ? integration.config.host : null;
+  });
+  const [notes, setNotes] = useState<ReadonlyArray<GitlabIssueNote>>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadToken, setReloadToken] = useState(0);
+  const projectPath = issue == null ? null : projectPathFromIssue({ issue });
+  const issueIid = issue?.iid ?? null;
+  const isReady = host != null && projectPath != null && issueIid != null;
+
+  useEffect(() => {
+    setNotes([]);
+    setError(null);
+    if (host == null || projectPath == null || issueIid == null) {
+      setIsLoading(false);
+      return;
+    }
+
+    let isCancelled = false;
+    setIsLoading(true);
+    gitlabListIssueNotes({ workspaceId, host, projectPath, issueIid })
+      .then((next) => {
+        if (isCancelled) {
+          return;
+        }
+        setNotes(next);
+      })
+      .catch((fetchError: unknown) => {
+        if (isCancelled) {
+          return;
+        }
+        setError(formatError(fetchError));
+      })
+      .finally(() => {
+        if (isCancelled) {
+          return;
+        }
+        setIsLoading(false);
+      });
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [workspaceId, host, projectPath, issueIid, reloadToken]);
+
+  const reload = useCallback(() => {
+    setReloadToken((token) => token + 1);
+  }, []);
+
+  const post = useCallback(
+    async (body: string) => {
+      if (host == null || projectPath == null || issueIid == null) {
+        return;
+      }
+      await gitlabCreateIssueNote({ workspaceId, host, projectPath, issueIid, body });
+      setReloadToken((token) => token + 1);
+    },
+    [workspaceId, host, projectPath, issueIid],
+  );
+
+  return {
+    notes,
+    isLoading,
+    error,
+    reload,
+    post: isReady ? post : null,
+  };
+};


### PR DESCRIPTION
## What

GitLab issues were read-only in the desktop app: the detail panel showed title, description, and state, with no way to comment or edit the description. GitHub issues already had both. This closes the gap so a PM or PO can work a GitLab issue end to end without opening gitlab.com.

- Rust: `gitlab_list_issue_notes` (paginated the same way #1215 paginates MR discussions: `per_page=100` + `x-next-page`, same page cap) and `gitlab_create_issue_note`, both in `apps/desktop/src-tauri/src/gitlab.rs`, registered in `lib.rs`. `gitlab_update_issue` already existed from an earlier pass and needed no change.
- TS wrappers `gitlabListIssueNotes` / `gitlabCreateIssueNote` in `apps/desktop/src/features/integrations/gitlab/client.ts`, matching the existing wrapper style.
- New `useGitlabIssueNotes` hook and a new `IssueConversation` component group (`IssueConversation/index.tsx`, `IssueNoteCard`, `IssueNoteHeader`, `IssueNoteAvatar`, `IssueNoteComposer`, `issueNotes.ts`), structurally parallel to `MrDetailPanel`'s `MrConversation` from #1215 but built fresh for the flat issue-notes shape (no discussion threading). Shared the layout and labels, not the logic, per the brief.
- Both GitLab issue surfaces now use the same tabbed overview/conversation layout as the MR panel and as `GithubIssueDetail`:
  - `GitlabStudio/IssueDetailPanel.tsx` (the standalone issue browser) gained description editing (previously static `Markdown`) and the conversation tab.
  - `GitlabIssueDetail/index.tsx` (the session-embedded surface, already had inline description editing from an earlier pass) gained the conversation tab.
  - Both reuse the existing `DescriptionSection` / `useInlineProseEdit` house pattern for the inline editor, and `useGitlabIssueDescription` (extended to accept a nullable issue so it can be called unconditionally before either panel's early-return for "no issue selected", same pattern `MrDetailPanel` uses for its own hooks).
- Extracted `projectPathFromIssue` (`issueProjectPath.ts`) out of `useGitlabIssueDescription` so both the description hook and the new notes hook derive the GitLab project path from `issue.references.full` the same way.

System notes (`note.system === true`) are filtered out of the conversation, with a "N system events hidden" line, exactly as #1215 does for MR discussions. Notes render oldest-first with the composer at the bottom, matching the Linear precedent cited in the brief: the description is inline-editable wherever the issue renders, and the composer sits at the bottom of the activity thread. The MR side sorts its threads newest-first because each is an independent discussion cluster; a flat issue-notes list reads better as a chronological conversation, so it sorts oldest-first instead.

Labels match the MR side: "Write a note" placeholder, "Comment" submit button, "No comments yet" empty state.

## Test plan

- `pnpm typecheck` — green.
- `pnpm test` — 509 files / 4401 tests green, including new coverage:
  - `IssueConversation/issueNotes.test.ts`: system-note filtering, count, chronological sort (pure function).
  - `useGitlabIssueNotes/index.test.ts`: load, idle-without-issue, load failure, post-then-reload.
  - `issueProjectPath.test.ts`: project path parsing edge cases.
  - `GitlabIssueDetail/index.test.tsx`: added conversation filtering + posting tests alongside the existing description save-path tests.
  - `GitlabStudio/IssueDetailPanel.test.tsx`: added a description save-path test and a conversation filtering + posting test (this surface was read-only before, so these are new).
- `pnpm knip --include files,duplicates,unlisted` — clean (only pre-existing config hints).
- `cargo test --locked` (in `apps/desktop/src-tauri`) — 212 passed, 2 ignored (pre-existing, require a real codex binary), including 28 gitlab tests (3 new for `GitlabIssueNote` (de)serialization).
- `cargo fmt --check` — clean.

Nothing was skipped and no existing assertion was weakened; the two tests that changed behavior (`IssueDetailPanel` no longer being pure read-only) got new coverage added rather than existing assertions rewritten.
