### PR TITLE
fix(desktop): say so when a plan run is held back

### DIFF
--- a/apps/desktop/src/features/session/components/SessionOverviewPane/PipelineSection.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/PipelineSection.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import type { Agent, Session, SessionId, Workflow, WorkspaceId } from '@goodboy/types';
 import { EMPTY_ARRAY, useAppStore, useSessionOpenQuestions } from '../../../../store';
 import type { LensKind } from '../../../../store';
+import { WorkflowGateError } from '../../../../store/slices/workflows/workflowActivationGate';
 import { workflowRunHasOpenQuestions } from '../../../context/openQuestionsGate';
 import type { SpawnNode } from '../../../orchestration/components/SpawnTree/lib';
 import type { RunLaneModel } from '../../../orchestration/hooks/useWorkspaceRuns';
@@ -27,6 +28,7 @@ export const PipelineSection = ({
   const sessionId = session.id as SessionId;
   const setFocusedWorkflowRun = useAppStore((s) => s.setFocusedWorkflowRun);
   const activateWorkflowAgent = useAppStore((s) => s.activateWorkflowAgent);
+  const emitNotification = useAppStore((s) => s.emitNotification);
   const phaseRuns = useAppStore(
     (s) => s.sessionPhaseRuns?.[sessionId] ?? (EMPTY_ARRAY as ReadonlyArray<Agent>),
   );
@@ -69,8 +71,18 @@ export const PipelineSection = ({
       hasOpenQuestions: workflowRunHasOpenQuestions(openQuestions, run.id),
       onAdvance: async (step) => {
         const agent = workflowAgents.find((r) => r.stepId === step.id);
-        if (agent?.status === 'pending') {
+        if (agent?.status !== 'pending') {
+          return;
+        }
+        try {
           await activateWorkflowAgent({ sessionId, agentId: agent.id, focus: 'none' });
+        } catch (error) {
+          if (!(error instanceof WorkflowGateError)) {
+            throw error;
+          }
+          void emitNotification('error', 'warning', 'workflow step held back', error.message, {
+            sessionId,
+          });
         }
       },
     };

--- a/apps/desktop/src/store/slices/plans/index.test.ts
+++ b/apps/desktop/src/store/slices/plans/index.test.ts
@@ -255,7 +255,7 @@ describe('runPlan, workflow-aware spawn routing', () => {
   });
 
   describe('workflow gate rejects the activation (open questions block the run)', () => {
-    it('notifies instead of throwing, and does not free-spawn', async () => {
+    it('notifies instead of throwing, resolves to null, and does not free-spawn', async () => {
       const state = defaultState({
         activateWorkflowAgent: vi.fn(async () => {
           throw new WorkflowGateError({ reason: 'questions' });
@@ -263,7 +263,7 @@ describe('runPlan, workflow-aware spawn routing', () => {
       });
       const slice = buildSlice(state);
 
-      await expect(slice.runPlan(SESSION_ID, PLAN_ID)).resolves.toBe(IMPL_AGENT_ID);
+      await expect(slice.runPlan(SESSION_ID, PLAN_ID)).resolves.toBeNull();
 
       expect(state.activateWorkflowAgent).toHaveBeenCalledWith({
         sessionId: SESSION_ID,

--- a/apps/desktop/src/store/slices/plans/index.test.ts
+++ b/apps/desktop/src/store/slices/plans/index.test.ts
@@ -22,6 +22,7 @@ vi.mock('../../../shared/lib/db', () => ({
 }));
 
 import { createPlansSlice } from './index';
+import { WorkflowGateError } from '../workflows/workflowActivationGate';
 
 const WS_ID = 'ws-1' as WorkspaceId;
 const WF_ID = 'wf-refactor' as WorkflowId;
@@ -118,6 +119,7 @@ type FakeState = {
   phaseTemplates: Record<WorkspaceId, ReadonlyArray<Workflow>>;
   spawnAgent: ReturnType<typeof vi.fn>;
   activateWorkflowAgent: ReturnType<typeof vi.fn>;
+  emitNotification: ReturnType<typeof vi.fn>;
 };
 
 function buildSlice(state: FakeState) {
@@ -156,6 +158,7 @@ function defaultState(overrides: Partial<FakeState> = {}): FakeState {
     phaseTemplates: { [WS_ID]: [wf] },
     spawnAgent: vi.fn(async () => 'spawned' as AgentId),
     activateWorkflowAgent: vi.fn(async () => undefined),
+    emitNotification: vi.fn(async () => undefined),
     ...overrides,
   };
 }
@@ -249,6 +252,29 @@ describe('runPlan, workflow-aware spawn routing', () => {
         });
       },
     );
+  });
+
+  describe('workflow gate rejects the activation (open questions block the run)', () => {
+    it('notifies instead of throwing, and does not free-spawn', async () => {
+      const state = defaultState({
+        activateWorkflowAgent: vi.fn(async () => {
+          throw new WorkflowGateError({ reason: 'questions' });
+        }),
+      });
+      const slice = buildSlice(state);
+
+      await expect(slice.runPlan(SESSION_ID, PLAN_ID)).resolves.toBe(IMPL_AGENT_ID);
+
+      expect(state.activateWorkflowAgent).toHaveBeenCalledWith({
+        sessionId: SESSION_ID,
+        agentId: IMPL_AGENT_ID,
+        explicitPlanId: PLAN_ID,
+        focus: 'none',
+      });
+      expect(state.emitNotification).toHaveBeenCalledTimes(1);
+      expect(state.emitNotification.mock.calls[0]![2]).toBe('workflow step held back');
+      expect(state.spawnAgent).not.toHaveBeenCalled();
+    });
   });
 
   describe('gate A, session has no workflows attached → free-spawn', () => {

--- a/apps/desktop/src/store/slices/plans/runPlan.ts
+++ b/apps/desktop/src/store/slices/plans/runPlan.ts
@@ -2,6 +2,7 @@ import type { AgentId, PlanId, SessionId } from '@goodboy/types';
 import { runsForWorkflowRun } from '@goodboy/core';
 import { inferAgentKindFromName, kindConsumesPlan } from '../../../features/session/agent-kind';
 import { pickNextWorkflowStep } from '../../../features/workflows/components/WorkflowNextStepCta';
+import { activateWorkflowAgentOrNotify } from '../workflows/activateWorkflowAgentOrNotify';
 import type { GetFn } from './types';
 
 export const runPlan = (get: GetFn) => {
@@ -73,7 +74,8 @@ export const runPlan = (get: GetFn) => {
         focus: 'none',
       });
     }
-    await get().activateWorkflowAgent({
+    await activateWorkflowAgentOrNotify({
+      get,
       sessionId,
       agentId: stepAgent.id,
       explicitPlanId: planId,

--- a/apps/desktop/src/store/slices/plans/runPlan.ts
+++ b/apps/desktop/src/store/slices/plans/runPlan.ts
@@ -74,13 +74,13 @@ export const runPlan = (get: GetFn) => {
         focus: 'none',
       });
     }
-    await activateWorkflowAgentOrNotify({
+    const activated = await activateWorkflowAgentOrNotify({
       get,
       sessionId,
       agentId: stepAgent.id,
       explicitPlanId: planId,
       focus: 'none',
     });
-    return stepAgent.id;
+    return activated ? stepAgent.id : null;
   };
 };

--- a/apps/desktop/src/store/slices/workflows/activateWorkflowAgentOrNotify.ts
+++ b/apps/desktop/src/store/slices/workflows/activateWorkflowAgentOrNotify.ts
@@ -1,4 +1,4 @@
-import type { AgentId, SessionId } from '@goodboy/types';
+import type { AgentId, PlanId, SessionId } from '@goodboy/types';
 import type { SpawnFocus } from '../session-view/spawnFocus';
 import { WorkflowGateError } from './workflowActivationGate';
 import type { GetFn } from './types';
@@ -7,6 +7,7 @@ type Params = {
   readonly get: GetFn;
   readonly sessionId: SessionId;
   readonly agentId: AgentId;
+  readonly explicitPlanId?: PlanId;
   readonly focus: SpawnFocus;
 };
 
@@ -14,10 +15,11 @@ export const activateWorkflowAgentOrNotify = async ({
   get,
   sessionId,
   agentId,
+  explicitPlanId,
   focus,
 }: Params): Promise<void> => {
   try {
-    await get().activateWorkflowAgent({ sessionId, agentId, focus });
+    await get().activateWorkflowAgent({ sessionId, agentId, explicitPlanId, focus });
   } catch (error) {
     if (!(error instanceof WorkflowGateError)) {
       throw error;

--- a/apps/desktop/src/store/slices/workflows/activateWorkflowAgentOrNotify.ts
+++ b/apps/desktop/src/store/slices/workflows/activateWorkflowAgentOrNotify.ts
@@ -17,9 +17,10 @@ export const activateWorkflowAgentOrNotify = async ({
   agentId,
   explicitPlanId,
   focus,
-}: Params): Promise<void> => {
+}: Params): Promise<boolean> => {
   try {
     await get().activateWorkflowAgent({ sessionId, agentId, explicitPlanId, focus });
+    return true;
   } catch (error) {
     if (!(error instanceof WorkflowGateError)) {
       throw error;
@@ -27,5 +28,6 @@ export const activateWorkflowAgentOrNotify = async ({
     void get().emitNotification('error', 'warning', 'workflow step held back', error.message, {
       sessionId,
     });
+    return false;
   }
 };

--- a/apps/desktop/src/store/slices/workflows/maybeAutoAdvanceWorkflow.ts
+++ b/apps/desktop/src/store/slices/workflows/maybeAutoAdvanceWorkflow.ts
@@ -128,19 +128,21 @@ const runAdvance = async ({ set, get, sessionId }: Params): Promise<void> => {
     }
     return;
   }
-  await activateWorkflowAgentOrNotify({
+  const activated = await activateWorkflowAgentOrNotify({
     get,
     sessionId,
     agentId: nextPendingAgent.id,
     focus: 'agent',
   });
-  void get().emitNotification(
-    'agent-auto-spawn',
-    'info',
-    `agent auto-spawned: ${nextPendingAgent.name}`,
-    undefined,
-    { sessionId },
-  );
+  if (activated) {
+    void get().emitNotification(
+      'agent-auto-spawn',
+      'info',
+      `agent auto-spawned: ${nextPendingAgent.name}`,
+      undefined,
+      { sessionId },
+    );
+  }
 };
 
 export const maybeAutoAdvanceWorkflow = (set: SetFn, get: GetFn) => {


### PR DESCRIPTION
## The bug

PR #1214 added an engine-level open-question gate (`findWorkflowActivationBlock`, throwing `WorkflowGateError`) inside `activateWorkflowAgent`. `runPlan` was never rewired to handle it. Result: pressing "Run plan" in Plan Studio while the session has any open question did nothing and said nothing. The rejection was swallowed by nobody; there is no global `unhandledrejection` handler in this app, so it was invisible unless devtools happened to be open. Shipped in v0.1.60.

## The fix

Route the plan-run call site through the existing `activateWorkflowAgentOrNotify` wrapper (already used elsewhere, just never wired to `runPlan`), which catches `WorkflowGateError` and calls `emitNotification('error', 'warning', 'workflow step held back', ...)`. `NotificationToastBridge` is mounted globally in `App.tsx` and turns any `error`/`warning` severity notification into an app-wide toast, so the fix alone produces a visible toast regardless of where the user is.

1. **`activateWorkflowAgentOrNotify.ts`**: widened `Params` with an optional `explicitPlanId: PlanId`, passed through to the inner `activateWorkflowAgent` call. This was the actual feasibility blocker; `runPlan` needs `explicitPlanId` to route the clicked plan.
2. **`runPlan.ts`**: swapped the bare `get().activateWorkflowAgent(...)` call for `activateWorkflowAgentOrNotify({ get, ... })`.
3. **`PipelineSection.tsx`**: its `onAdvance` handler had the identical bare, catchless `activateWorkflowAgent` call. Not currently reachable from the UI (`pickNextWorkflowStep` returns null when questions block, so no advance handler gets wired), but it was one refactor away from repeating the same silent failure. Fixed with a local `try/catch` on `WorkflowGateError` calling the store's `emitNotification` directly. Did not expose `activateWorkflowAgentOrNotify` on the store for this: it is a slice-internal helper that takes a raw `get`, a React component cannot call it, and widening the store surface for one component was the wrong trade.
4. **`plans/index.test.ts`**: the existing `FakeState`/`defaultState` mocked `activateWorkflowAgent` to always resolve, so the gate never rejected in any test, which is exactly why this regression shipped unnoticed. Added a test where `activateWorkflowAgent` throws `WorkflowGateError({ reason: 'questions' })` and asserts `emitNotification` was called with the "workflow step held back" title and that nothing escapes `runPlan`. Also added `emitNotification: vi.fn()` to `FakeState`, which was missing.

## Coverage: what's gated now, what's deliberately not

Covered by the gate (produces a toast on rejection):
- `runPlan` (Plan Studio "Run plan" button) — this PR
- `PipelineSection`'s `onAdvance` (session overview pipeline lane) — this PR, currently unreachable but fixed pre-emptively
- `ChatWorkflowAdvance.tsx` — already correct before this PR (its confirm path passes `bypassGate: isConfirmed`)

Deliberately NOT touched in this PR:
- `PlanStudio/index.tsx` `handleTrigger` and `WorkspacesSidebar/parts/PlanReadySuggestion.tsx` `onSpawn`: both already have `finally { setSpawning(false) }`, and once the wrapper swallows `WorkflowGateError` nothing reaches them. Adding catches there would be scope creep beyond "say so when held back."
- No global `unhandledrejection` handler. Bigger call than this PR.
- No dedup of the five duplicate next-runnable-step implementations. Separate release.

## Verification

- `pnpm typecheck`: green, all 5 packages.
- `pnpm test`: green, 509 test files / 4424 tests passed (whole workspace, `@goodboy/db` included). One new test added in `apps/desktop/src/store/slices/plans/index.test.ts`.
- `pnpm knip --include files,duplicates,unlisted`: clean, no new findings (only pre-existing config hints unrelated to this change).
- Confirmed `SessionOverviewPane/index.test.tsx:683-690` (asserts `store.activateWorkflowAgent` called with `{sessionId, agentId, focus:'none'}` from the pipeline "start execute" click) still passes: the happy path still calls through with identical args, the new catch branch is not exercised by that test.
