### PR TITLE
fix(desktop): persist the resolver verdict so push-all survives a restart

### DIFF
--- a/apps/desktop/src/features/session/resolverThreadSettlements.test.ts
+++ b/apps/desktop/src/features/session/resolverThreadSettlements.test.ts
@@ -83,4 +83,28 @@ describe('resolverThreadSettlements', () => {
     expect(settlement?.isQueued).toBe(true);
     expect(settlement?.reply).toBe('legacy resolver reply');
   });
+
+  it('shows the persisted verdict of a queued row after a restart, instead of open', () => {
+    const survivor = {
+      id: 'pending-survivor',
+      sessionId: 'session-1' as SessionId,
+      prNumber: 1,
+      threadId: 'PRRT_1',
+      commitSha: 'abcdef1234567890',
+      reply: 'fixed it',
+      outcome: 'resolved',
+      replyPostedAt: '2026-05-28T00:00:00.000Z' as IsoDateTime,
+      createdAt: '2026-05-28T00:00:00.000Z' as IsoDateTime,
+    } satisfies PendingResolution;
+
+    const [settlement] = resolverThreadSettlements({
+      threadIds: ['PRRT_1'],
+      outcomes: {},
+      pendingResolutions: [survivor],
+      closedThreadIds: NOTHING_CLOSED,
+    });
+
+    expect(settlement?.kind).toBe('resolved');
+    expect(settlement?.isQueued).toBe(true);
+  });
 });

--- a/apps/desktop/src/store/slices/github/index.test.ts
+++ b/apps/desktop/src/store/slices/github/index.test.ts
@@ -1595,6 +1595,40 @@ describe('store contract', () => {
       expect(result).toEqual({ pushed: false, resolved: 0, failed: 0 });
     });
 
+    it('pushAllResolutions resolves a row that survived a restart on a persisted verdict alone', async () => {
+      const store = await getStore();
+      const survivor = {
+        id: 'pending-survivor',
+        sessionId: SESSION_ID,
+        prNumber: 1,
+        threadId: 'PRRT_1',
+        commitSha: 'abcdef1234567890',
+        reply: 'fixed it',
+        outcome: 'resolved',
+        replyPostedAt: NOW,
+        createdAt: NOW,
+      } satisfies PendingResolution;
+      store.setState({
+        workspaces: [buildWorkspace()],
+        sessions: [buildSession()],
+        sessionBranches: { [SESSION_ID]: 'ak/feat-x' },
+        sessionWorktrees: { [SESSION_ID]: ['/tmp/repo/.wt/x'] },
+        resolverThreadOutcomes: {},
+        sessionPendingResolutions: { [SESSION_ID]: [survivor] },
+        refreshSessionPrDetail: vi.fn(async () => undefined),
+      });
+      listPendingResolutionsForSessionSpy
+        .mockResolvedValueOnce([survivor])
+        .mockResolvedValueOnce([]);
+
+      const result = await store.getState().pushAllResolutions(SESSION_ID);
+
+      expect(resolveThreadSpy).toHaveBeenCalledOnce();
+      expect(addReplySpy).not.toHaveBeenCalled();
+      expect(deletePendingResolutionSpy).toHaveBeenCalledOnce();
+      expect(result).toEqual({ pushed: true, resolved: 1, failed: 0 });
+    });
+
     it('pushAllResolutions fails only the fixes when the push is rejected', async () => {
       const store = await getStore();
       const fix = {
@@ -1878,7 +1912,7 @@ describe('store contract', () => {
         threadId: 'PRRT_1',
         commitSha: 'abcdef1234567890',
         reply: 'fixed it',
-        outcome: null,
+        outcome: 'resolved',
         replyPostedAt: NOW,
         createdAt: NOW,
       } satisfies PendingResolution;
@@ -1899,7 +1933,7 @@ describe('store contract', () => {
         threadId: 'PRRT_1',
         commitSha: 'abcdef1234567890',
         reply: 'fixed it',
-        outcome: null,
+        outcome: 'resolved',
       });
       expect(addReplySpy).toHaveBeenCalledOnce();
       expect(deletePendingResolutionSpy).not.toHaveBeenCalled();

--- a/apps/desktop/src/store/slices/github/index.test.ts
+++ b/apps/desktop/src/store/slices/github/index.test.ts
@@ -786,6 +786,94 @@ describe('store contract', () => {
       });
     });
 
+    it('resolveGithubThread persists the derived verdict for a commit closure, not null', async () => {
+      const store = await getStore();
+      const openPr = {
+        number: 5,
+        title: 't',
+        state: 'open',
+        updatedAt: '2026-05-28T00:00:00.000Z',
+      } as PullRequestState;
+      store.setState({
+        workspaces: [buildWorkspace()],
+        sessions: [buildSession()],
+        sessionBranches: { [SESSION_ID]: 'ak/feat-x' },
+        sessionWorktrees: { [SESSION_ID]: ['/tmp/repo/.wt/x'] },
+        sessionGithub: {
+          [SESSION_ID]: {
+            pr: openPr,
+            linkedIssues: [],
+            fetchedAt: null,
+            loading: false,
+            error: null,
+            detail: null,
+            detailFetchedAt: null,
+            detailLoading: false,
+            detailError: null,
+          },
+        },
+      });
+
+      const ok = await store
+        .getState()
+        .resolveGithubThread(SESSION_ID, 'PRT_1', { commitSha: 'abcdef1234567890' });
+
+      expect(ok).toBe(true);
+      expect(queuePendingResolutionSpy).toHaveBeenCalledWith({
+        db: expect.anything(),
+        id: expect.any(String),
+        sessionId: SESSION_ID,
+        prNumber: 5,
+        threadId: 'PRT_1',
+        commitSha: 'abcdef1234567890',
+        reply: null,
+        outcome: 'resolved',
+      });
+    });
+
+    it('resolveGithubThread persists the derived verdict for a reason-only closure, not null', async () => {
+      const store = await getStore();
+      const openPr = {
+        number: 5,
+        title: 't',
+        state: 'open',
+        updatedAt: '2026-05-28T00:00:00.000Z',
+      } as PullRequestState;
+      store.setState({
+        workspaces: [buildWorkspace()],
+        sessions: [buildSession()],
+        sessionGithub: {
+          [SESSION_ID]: {
+            pr: openPr,
+            linkedIssues: [],
+            fetchedAt: null,
+            loading: false,
+            error: null,
+            detail: null,
+            detailFetchedAt: null,
+            detailLoading: false,
+            detailError: null,
+          },
+        },
+      });
+
+      const ok = await store
+        .getState()
+        .resolveGithubThread(SESSION_ID, 'PRT_1', { reason: 'not applicable' });
+
+      expect(ok).toBe(true);
+      expect(queuePendingResolutionSpy).toHaveBeenCalledWith({
+        db: expect.anything(),
+        id: expect.any(String),
+        sessionId: SESSION_ID,
+        prNumber: 5,
+        threadId: 'PRT_1',
+        commitSha: '',
+        reply: null,
+        outcome: 'wontfix',
+      });
+    });
+
     it('resolveGithubThread never clobbers a verdict a caller already queued for the thread', async () => {
       const store = await getStore();
       const openPr = {

--- a/apps/desktop/src/store/slices/github/resolveAgentThreads.ts
+++ b/apps/desktop/src/store/slices/github/resolveAgentThreads.ts
@@ -3,7 +3,7 @@ import {
   listPendingResolutionsForSession,
   queuePendingResolution,
 } from '@goodboy/db';
-import type { AgentId, SessionId } from '@goodboy/types';
+import type { AgentId, PendingResolutionOutcome, SessionId } from '@goodboy/types';
 import { agentThreadIds } from '../../../features/session/agentThreadIds';
 import { closedThreadIds } from '../../../features/session/closedThreadIds';
 import { resolverThreadSettlements } from '../../../features/session/resolverThreadSettlements';
@@ -25,6 +25,7 @@ type Target = {
   readonly threadId: string;
   readonly closure: Closure;
   readonly shouldPush: boolean;
+  readonly outcome: PendingResolutionOutcome;
 };
 
 type ClosureParams = {
@@ -108,7 +109,12 @@ export const resolveAgentThreads = (set: SetFn, get: GetFn) => {
             return [];
           }
           return [
-            { threadId: settlement.threadId, closure, shouldPush: settlement.kind === 'resolved' },
+            {
+              threadId: settlement.threadId,
+              closure,
+              shouldPush: settlement.kind === 'resolved',
+              outcome: settlement.kind,
+            },
           ];
         });
         const alreadyClosed = settlements.filter((settlement) => settlement.isClosed).length;
@@ -158,7 +164,7 @@ export const resolveAgentThreads = (set: SetFn, get: GetFn) => {
                 threadId: target.threadId,
                 commitSha: target.closure.commitSha ?? '',
                 reply: target.closure.reply ?? null,
-                outcome: null,
+                outcome: target.outcome,
               });
             }
             await markThreadResolvedNoPush({

--- a/apps/desktop/src/store/slices/github/resolveGithubThread.ts
+++ b/apps/desktop/src/store/slices/github/resolveGithubThread.ts
@@ -3,7 +3,7 @@ import {
   listPendingResolutionsForSession,
   queuePendingResolution,
 } from '@goodboy/db';
-import type { SessionId } from '@goodboy/types';
+import type { PendingResolutionOutcome, SessionId } from '@goodboy/types';
 import { tauriDatabase } from '../../../shared/lib/db';
 import { formatError } from '../../../shared/lib/errors';
 import { markThreadResolvedNoPush } from './markThreadResolvedNoPush';
@@ -12,6 +12,26 @@ import { withResolutionLock } from './withResolutionLock';
 import type { GetFn, SetFn } from './types';
 
 type Params = { commitSha?: string; reason?: string; reply?: string };
+
+const deriveOutcome = ({
+  closure,
+}: {
+  readonly closure: Params | undefined;
+}): PendingResolutionOutcome | null => {
+  const commitSha = closure?.commitSha ?? '';
+  const reason = closure?.reason ?? '';
+  const reply = closure?.reply ?? '';
+  if (commitSha === '' && reason === '' && reply === '') {
+    return null;
+  }
+  if (commitSha !== '') {
+    return 'resolved';
+  }
+  if (reason !== '') {
+    return 'wontfix';
+  }
+  return 'analyzed';
+};
 
 export const resolveGithubThread = (set: SetFn, get: GetFn) => {
   return async (sessionId: SessionId, threadId: string, closure?: Params): Promise<boolean> =>
@@ -77,7 +97,7 @@ export const resolveGithubThread = (set: SetFn, get: GetFn) => {
                 threadId,
                 commitSha: closure?.commitSha ?? '',
                 reply: closure?.reply ?? null,
-                outcome: null,
+                outcome: deriveOutcome({ closure }),
               });
               const queued = await listPendingResolutionsForSession({
                 db: tauriDatabase,


### PR DESCRIPTION
## Bug

`resolveAgentThreads` and `resolveGithubThread` queued `pending_resolutions` rows with `outcome: null` even when the verdict was already known. After an app restart, `resolverThreadOutcomes` (in-memory only) is empty, so `pushAllResolutions` computes `inMemoryOutcomes[i]?.kind ?? resolution.outcome ?? null` and gets `null`. It falls into `case null`, sees `replyAlreadyPosted`, hits a bare `break`, and the unconditional `deletePendingResolution` at the bottom of the loop deletes the row anyway. The thread never closes on GitHub and silently disappears from the pending queue.

## Fix

**`resolveAgentThreads.ts`**: the local `Target` type now carries an `outcome: PendingResolutionOutcome`, populated straight from `settlement.kind` where targets are built in the `flatMap`. `settlement.kind === 'open'` is already filtered out earlier in that same `flatMap`, so TypeScript narrows `settlement.kind` to exactly `'resolved' | 'wontfix' | 'analyzed'`, which is `PendingResolutionOutcome` with no mapping needed. The `queuePendingResolution` call now passes `target.outcome` instead of `null`.

**`resolveGithubThread.ts`**: this function does not receive a `settlement`, and callers must not be widened to pass one, because `useResolverActions/index.ts`'s `forceResolve` action calls `closeSettled({ includeOpen: true })`, which deliberately processes `settlement.kind === 'open'` entries, and `'open'` is not a legal `PendingResolutionOutcome`. Instead, the outcome is derived from the closure content itself, inside `resolveGithubThread`, mirroring the existing `fromOutcome` logic in `resolverThreadSettlements.ts`:

- `commitSha` present -> `'resolved'`
- otherwise `reason` present -> `'wontfix'`
- otherwise, if the closure carries any content at all (`reply` present) -> `'analyzed'`
- a fully empty closure (no `commitSha`, no `reason`, no `reply`) -> stays `null`

This covers `forceResolve` for free: an open settlement without operator text resolves through the same closure-builder as a direct empty call and stays `null` (no verdict, no lie), while an open settlement with a reply persists honestly as `'analyzed'`. No params widening was needed, so `store.ts`'s inline duplicate of `resolveGithubThread`'s params, and the three call sites in `useResolverActions/index.ts`, are untouched.

## Empty-closure ruling

The existing test `resolveGithubThread persists first and leaves no orphan row when nothing was posted` calls `resolveGithubThread(SESSION_ID, 'PRT_1', {})` with a literal empty closure and asserts `outcome: null` on the queued row. I kept this test as-is and added an explicit guard in `deriveOutcome`: when `commitSha`, `reason`, and `reply` are all absent, the function returns `null` rather than falling through to `'analyzed'`. The honest reading is that a resolve with no commit, no reason, and no reply has produced no verdict at all, so `null` is correct here, matching the pre-existing test's intent rather than breaking it.

## Tests changed

Two stale assertions fixed in `apps/desktop/src/store/slices/github/index.test.ts`, both inside `resolveAgentThreads persists first for a target with no backing row, so a retry does not repost` (this test sets `resolverThreadOutcomes[AGENT_ID].PRRT_1.kind = 'resolved'`):
- `:1881` `survivingRow` fixture: `outcome: null` -> `outcome: 'resolved'`
- `:1902` `queuePendingResolutionSpy` assertion: `outcome: null` -> `outcome: 'resolved'`

Four other `outcome: null` sites were deliberately left untouched, because they describe real behavior this change does not touch:
- `:778` (`resolveGithubThread persists first and leaves no orphan row when nothing was posted`): direct call with a literal empty closure. Governs the empty-closure ruling above.
- `:1570` (`pushAllResolutions replies without closing a row that carries no verdict`): a `legacy` fixture testing backward compat for pre-existing rows that predate this fix.
- `:1729` (`pushAllResolutions only counts a comment as posted when a reply body actually went out`): an `empty` fixture with no commit, reason, or reply.
- `:1760` (`pushAllResolutions never reposts a null-outcome row whose reply already went out`): an `orphaned` fixture, testing the dedup guard independent of outcome derivation.

New tests added:
- `pushAllResolutions resolves a row that survived a restart on a persisted verdict alone` (`apps/desktop/src/store/slices/github/index.test.ts`, near the `pushAllResolutions` block): reproduces the actual bug. Empty `resolverThreadOutcomes` (simulating the restart), a persisted row with `replyPostedAt` set and `outcome: 'resolved'`. Asserts it goes through `case 'resolved'` (`resolveThreadSpy` called, `deletePendingResolutionSpy` called, `result.resolved === 1`) instead of `case null` silently deleting the row.
- `shows the persisted verdict of a queued row after a restart, instead of open` (`apps/desktop/src/features/session/resolverThreadSettlements.test.ts`): covers the free side-effect fix in `fromPending` (`resolution.outcome ?? 'open'`), which today displays a restarted session's queued thread as "open" even when it carried a real verdict.

## Verification

- `pnpm typecheck`: green, all 5 packages.
- `pnpm test`: green, 509 test files, 4425 tests, including `@goodboy/db`.
- `pnpm knip --include files,duplicates,unlisted`: clean, no findings (only pre-existing config hints unrelated to this change).

## Scope

No DB migration: the `outcome TEXT` column has been nullable since `m088-pending-resolution-reply.ts`, and `queuePendingResolution` already persists real outcomes correctly. `store.ts` is untouched. The unconditional `deletePendingResolution` at the bottom of `pushAllResolutions`'s loop is untouched beyond what the outcome fix requires. `resolverStartsPending` pruning and the publish slice's swallow-vs-throw design are separate concerns, left alone.
