### PR TITLE
fix(desktop): route the diff-viewer event through the diff lens helper

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -66,6 +66,7 @@ import { useGithubPolling } from './features/github/hooks/useGithubPolling';
 import { useUpdaterPolling } from './features/updater/hooks/useUpdaterPolling';
 import { useWorkspaceRemoteHostKind } from './features/worktree/useWorkspaceRemoteHostKind';
 import { resolveSessionRepo } from './store/slices/worktrees/resolveSessionRepo';
+import { resolveOpenDiffViewerEvent } from './store/slices/session-view/openDiffViewerEvent';
 import { useSessionSidebarVisibility } from './features/workspace/hooks/useSessionSidebarVisibility';
 import { SessionSidebarCollapsedContext } from './features/workspace/hooks/useSessionSidebarVisibility/collapsed';
 
@@ -217,13 +218,14 @@ export const App = () => {
     };
     const onOpenDiffViewer = (event: Event) => {
       const detail = (event as CustomEvent<{ sessionId?: SessionId; workingDir?: string }>).detail;
-      if (!detail?.sessionId) {
+      const resolved = resolveOpenDiffViewerEvent({ detail });
+      if (resolved === null) {
         return;
       }
       setNewSessionOpen(false);
       setWorkspaceSettingsOpen(false);
       setWorkspaceSettingsFocus(undefined);
-      useAppStore.getState().setActiveLens(detail.sessionId, 'files');
+      useAppStore.getState().openDiffLens(resolved.sessionId, resolved.focus);
     };
     const onOpenProviderStudio = (event: Event) => {
       const detail = (

--- a/apps/desktop/src/store/slices/session-view/index.test.ts
+++ b/apps/desktop/src/store/slices/session-view/index.test.ts
@@ -33,6 +33,7 @@ import type {
 } from '@goodboy/types';
 import { STORAGE_PREFIXES } from '../../../shared/lib/storage-keys';
 import { readPersistedLens } from './workSurfaceStorage';
+import { resolveOpenDiffViewerEvent } from './openDiffViewerEvent';
 
 vi.mock('@tauri-apps/api/core', () => ({
   invoke: vi.fn(async () => null),
@@ -733,6 +734,50 @@ describe('store contract', () => {
       expect(store.getState().diffFocus[SESSION_ID]).toEqual({ kind: 'working', path: null });
       store.getState().lensGo(SESSION_ID, -1);
       expect(store.getState().activeLens[SESSION_ID]).toBe('resolve');
+    });
+
+    it('the open-diff-viewer event resolution cannot land on a stale commit after going back', async () => {
+      const store = await getStore();
+      store.getState().setActiveLens(SESSION_ID, 'resolve');
+      store.getState().openDiffLens(SESSION_ID, { kind: 'commit', sha: 'abc1234', path: null });
+      store.getState().lensGo(SESSION_ID, -1);
+      expect(store.getState().diffFocus[SESSION_ID]).toEqual({
+        kind: 'commit',
+        sha: 'abc1234',
+        path: null,
+      });
+
+      const resolved = resolveOpenDiffViewerEvent({ detail: { sessionId: SESSION_ID } });
+      if (resolved === null) {
+        throw new Error('expected a resolution');
+      }
+      store.getState().openDiffLens(resolved.sessionId, resolved.focus);
+
+      expect(store.getState().activeLens[SESSION_ID]).toBe('files');
+      expect(store.getState().diffFocus[SESSION_ID]).toEqual({ kind: 'working', path: null });
+    });
+
+    it('the event path and a direct openDiffLens call land in identical state', async () => {
+      const store = await getStore();
+      store.getState().openDiffLens(SESSION_ID, { kind: 'commit', sha: 'abc1234', path: null });
+      const resolved = resolveOpenDiffViewerEvent({ detail: { sessionId: SESSION_ID } });
+      if (resolved === null) {
+        throw new Error('expected a resolution');
+      }
+      store.getState().openDiffLens(resolved.sessionId, resolved.focus);
+      const eventPathState = {
+        activeLens: store.getState().activeLens[SESSION_ID],
+        diffFocus: store.getState().diffFocus[SESSION_ID],
+      };
+
+      store.getState().openDiffLens(SESSION_ID_2, { kind: 'commit', sha: 'abc1234', path: null });
+      store.getState().openDiffLens(SESSION_ID_2, { kind: 'working', path: null });
+      const directCallState = {
+        activeLens: store.getState().activeLens[SESSION_ID_2],
+        diffFocus: store.getState().diffFocus[SESSION_ID_2],
+      };
+
+      expect(eventPathState).toEqual(directCallState);
     });
 
     it('setSessionStudio(non-null) clears the selected agent', async () => {

--- a/apps/desktop/src/store/slices/session-view/openDiffViewerEvent.test.ts
+++ b/apps/desktop/src/store/slices/session-view/openDiffViewerEvent.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import type { SessionId } from '@goodboy/types';
+import { resolveOpenDiffViewerEvent } from './openDiffViewerEvent';
+
+const SESSION_ID = 'session-1' as SessionId;
+
+describe('resolveOpenDiffViewerEvent', () => {
+  it('resolves a working-tree focus for a sessionId, never a stale commit', () => {
+    const resolved = resolveOpenDiffViewerEvent({ detail: { sessionId: SESSION_ID } });
+    expect(resolved).toEqual({ sessionId: SESSION_ID, focus: { kind: 'working', path: null } });
+  });
+
+  it('returns null when the event carries no sessionId', () => {
+    expect(resolveOpenDiffViewerEvent({ detail: undefined })).toBeNull();
+    expect(resolveOpenDiffViewerEvent({ detail: {} })).toBeNull();
+  });
+});

--- a/apps/desktop/src/store/slices/session-view/openDiffViewerEvent.ts
+++ b/apps/desktop/src/store/slices/session-view/openDiffViewerEvent.ts
@@ -1,0 +1,22 @@
+import type { SessionId } from '@goodboy/types';
+import type { DiffFocus } from './types';
+
+export type OpenDiffViewerEventDetail = {
+  readonly sessionId?: SessionId;
+};
+
+export type OpenDiffViewerEventResolution = {
+  readonly sessionId: SessionId;
+  readonly focus: DiffFocus;
+};
+
+export const resolveOpenDiffViewerEvent = ({
+  detail,
+}: {
+  readonly detail: OpenDiffViewerEventDetail | undefined;
+}): OpenDiffViewerEventResolution | null => {
+  if (detail?.sessionId == null) {
+    return null;
+  }
+  return { sessionId: detail.sessionId, focus: { kind: 'working', path: null } };
+};


### PR DESCRIPTION
## Bug

`App.tsx`'s `goodboy:open-diff-viewer` event handler (dispatched from the "Open the diff" affordance in `AgentInspector/ResolverInspector.tsx`) called `setActiveLens(sessionId, 'files')` directly, bypassing `setDiffFocus`. `setActiveLens` only clears `diffFocus[sessionId]` when the target lens is *not* `'files'`; entering `'files'` preserves whatever `diffFocus` is already in the store. So if the user was already on the files lens with a stale commit focus from a previous resolver (or navigated away and the store still carried the old focus, since `lensGo` does not touch `diffFocus` either), this event landed on that stale commit instead of a fresh view.

The other three call sites into the diff lens (`ResolverThreadsCard`, `useResolverAgentsLane`, `ResolverInspector`'s own `ChangesSection` callbacks) already go through the `openDiffLens` helper in `store/slices/session-view/workSurface.ts`, which calls `setDiffFocus` before `setActiveLens`. `App.tsx` was the lone outlier.

## Fix

Routed the handler through `openDiffLens`. The event's `CustomEvent` detail only ever carries `{ sessionId, workingDir }`, never a commit sha, so "no commit payload" maps to `{ kind: 'working', path: null }`, the same working-tree focus `useResolverAgentsLane.ts:197` already uses for its own no-commit case (`sha === null ? { kind: 'working', path: null } : { kind: 'commit', sha, path: null }`).

Extracted the guard + mapping into `apps/desktop/src/store/slices/session-view/openDiffViewerEvent.ts` (`resolveOpenDiffViewerEvent`), colocated with the slice per the "next to the slice" option in the brief, rather than as a new store action (keeps the public store surface unchanged). `App.tsx` now calls this resolver, then `useAppStore.getState().openDiffLens(...)` with the result.

Out of scope, untouched: `diffReturn`/`returnFromDiff`, `WorkSurfacePosition`, `lensHistory`/`lensGo`, `WorkSurfaceBackButton`, `ResolverInspector.tsx`.

## Tests

- `apps/desktop/src/store/slices/session-view/openDiffViewerEvent.test.ts` (new): the resolver returns a working-tree focus for a present `sessionId`, and `null` on a missing one (the same guard the old inline handler had).
- `apps/desktop/src/store/slices/session-view/index.test.ts` (extended, real Zustand store, no mocks):
  - reproduces the exact regression path: `openDiffLens` to a commit focus, `lensGo(-1)` to leave the files lens (which does **not** clear `diffFocus` today), then resolves and applies the event focus — asserts the stale commit sha is gone and the lens lands on `'files'` with a working-tree focus.
  - asserts the event path (`resolveOpenDiffViewerEvent` + `openDiffLens`) and a direct `openDiffLens(id, { kind: 'working', path: null })` call land in identical `{ activeLens, diffFocus }` state.
- `apps/desktop/src/__tests__/overlay-mutual-exclusion.test.ts` already covers the event's `CustomEvent` detail shape (`sessionId`, `workingDir`) and needed no changes; it still passes.

## Verification

- `pnpm typecheck`: clean, all 5 packages.
- `pnpm test`: 510 files / 4442 tests passed.
- `pnpm knip --include files,duplicates,unlisted`: no unused files, duplicates, or unlisted deps (only pre-existing config hints, unrelated to this change).

## Gaps

None known. `workingDir` in the event detail remains unused by the handler, same as before this change; not touched since it's outside the stated scope.
