### PR TITLE
feat(desktop): read the review thread inside the resolver kickoff card

### DIFF
--- a/apps/desktop/src/features/chat/components/ResolverKickoffCard/ThreadCard.test.tsx
+++ b/apps/desktop/src/features/chat/components/ResolverKickoffCard/ThreadCard.test.tsx
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { PrComment, SessionId } from '@goodboy/types';
+import type { ResolverKickoffThread } from '../../utils/parse-resolver-kickoff';
+
+const h = vi.hoisted(() => ({
+  comments: [] as ReadonlyArray<PrComment>,
+  detail: null as { comments: ReadonlyArray<PrComment> } | null,
+  openUrl: vi.fn(async () => undefined),
+}));
+
+vi.mock('../../../../store', () => ({
+  EMPTY_ARRAY: [],
+  useAppStore: <T,>(
+    selector: (state: {
+      sessionGithub: Record<string, { detail: { comments: ReadonlyArray<PrComment> } | null }>;
+    }) => T,
+  ) => selector({ sessionGithub: { s: { detail: h.detail } } }),
+}));
+
+vi.mock('../../../../shared/lib/editor', () => ({ openUrl: h.openUrl }));
+
+import { ThreadCard } from './ThreadCard';
+
+const SESSION_ID = 's' as SessionId;
+
+const comment = (over: Partial<PrComment> = {}): PrComment => ({
+  id: 'review-1',
+  author: 'alice',
+  authorAvatarUrl: null,
+  body: 'this should use a helper',
+  createdAt: '2026-05-15T10:00:00Z',
+  url: 'https://github.com/o/r/pull/9108#discussion_r1',
+  source: 'review',
+  path: 'src/foo.ts',
+  line: 42,
+  resolved: false,
+  threadId: 'PRRT_1',
+  ...over,
+});
+
+const kickoffThread = (over: Partial<ResolverKickoffThread> = {}): ResolverKickoffThread => ({
+  position: 1,
+  total: 1,
+  threadId: 'PRRT_1',
+  author: 'alice',
+  location: 'src/foo.ts:42',
+  link: 'https://github.com/o/r/pull/9108#discussion_r1',
+  body: 'this should use a helper',
+  replies: [],
+  ...over,
+});
+
+describe('ThreadCard', () => {
+  beforeEach(() => {
+    h.comments = [];
+    h.detail = null;
+    h.openUrl.mockClear();
+  });
+
+  afterEach(cleanup);
+
+  it('docks the real thread from the store, collapsed by default', () => {
+    h.detail = {
+      comments: [
+        comment(),
+        comment({
+          id: 'reply-1',
+          author: 'bob',
+          body: 'agreed, extracting a helper makes sense',
+          inReplyToId: 'review-1',
+        }),
+      ],
+    };
+
+    render(<ThreadCard thread={kickoffThread()} sessionId={SESSION_ID} />);
+
+    expect(screen.getByRole('button', { name: 'Expand thread' })).toBeDefined();
+    expect(screen.queryByText('agreed, extracting a helper makes sense')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Expand thread' }));
+
+    expect(screen.getByRole('button', { name: 'Collapse thread' })).toBeDefined();
+    expect(screen.getByText('agreed, extracting a helper makes sense')).toBeDefined();
+    expect(screen.getAllByText('alice').length).toBeGreaterThan(0);
+  });
+
+  it('shows the resolved state once docked', () => {
+    h.detail = { comments: [comment({ resolved: true })] };
+
+    render(<ThreadCard thread={kickoffThread()} sessionId={SESSION_ID} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Expand thread' }));
+
+    expect(screen.getByText('resolved')).toBeDefined();
+  });
+
+  it('never renders a reply or resolve affordance for the docked thread', () => {
+    h.detail = { comments: [comment()] };
+
+    render(<ThreadCard thread={kickoffThread()} sessionId={SESSION_ID} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Expand thread' }));
+
+    expect(screen.queryByRole('textbox')).toBeNull();
+    expect(screen.queryByRole('button', { name: /reply/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /resolve/i })).toBeNull();
+  });
+
+  it('falls back to the honest external link when no session is attached', () => {
+    render(<ThreadCard thread={kickoffThread()} sessionId={null} />);
+
+    expect(screen.queryByRole('button', { name: 'Expand thread' })).toBeNull();
+    expect(screen.getByRole('button', { name: /Open on GitHub/ })).toBeDefined();
+    expect(screen.getByText('this should use a helper')).toBeDefined();
+  });
+
+  it('falls back to the honest external link when the session has no PR detail yet', () => {
+    h.detail = null;
+
+    render(<ThreadCard thread={kickoffThread()} sessionId={SESSION_ID} />);
+
+    expect(screen.queryByRole('button', { name: 'Expand thread' })).toBeNull();
+    expect(screen.getByRole('button', { name: /Open on GitHub/ })).toBeDefined();
+  });
+
+  it('falls back to the honest external link when the thread id is not among the grouped threads', () => {
+    h.detail = { comments: [comment({ threadId: 'PRRT_other' })] };
+
+    render(<ThreadCard thread={kickoffThread()} sessionId={SESSION_ID} />);
+
+    expect(screen.queryByRole('button', { name: 'Expand thread' })).toBeNull();
+    expect(screen.getByRole('button', { name: /Open on GitHub/ })).toBeDefined();
+  });
+
+  it('opens the external link on click', () => {
+    render(<ThreadCard thread={kickoffThread()} sessionId={null} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Open on GitHub/ }));
+
+    expect(h.openUrl).toHaveBeenCalledWith('https://github.com/o/r/pull/9108#discussion_r1');
+  });
+});

--- a/apps/desktop/src/features/chat/components/ResolverKickoffCard/ThreadCard.tsx
+++ b/apps/desktop/src/features/chat/components/ResolverKickoffCard/ThreadCard.tsx
@@ -1,13 +1,23 @@
+import { useState } from 'react';
 import { ArrowUpRight } from 'lucide-react';
 import { Markdown, MetaRow } from '@goodboy/ui';
+import type { SessionId } from '@goodboy/types';
 import type { ResolverKickoffThread } from '../../utils/parse-resolver-kickoff';
 import { openUrl } from '../../../../shared/lib/editor';
+import { ConversationThread } from '../../../github/components/GitHubStudio/ConversationThread';
+import { TranscriptChevron } from '../TranscriptChevron';
+import { useKickoffDockedThread } from './useKickoffDockedThread';
 
 type Props = {
   readonly thread: ResolverKickoffThread;
+  readonly sessionId: SessionId | null;
 };
 
-const titleOf = ({ thread }: Props): string => {
+type TitleOfParams = {
+  readonly thread: ResolverKickoffThread;
+};
+
+const titleOf = ({ thread }: TitleOfParams): string => {
   const location = thread.location?.trim() ?? '';
   if (location !== '') {
     return location;
@@ -15,7 +25,9 @@ const titleOf = ({ thread }: Props): string => {
   return 'PR conversation';
 };
 
-export const ThreadCard = ({ thread }: Props) => {
+export const ThreadCard = ({ thread, sessionId }: Props) => {
+  const [open, setOpen] = useState(false);
+  const docked = useKickoffDockedThread({ sessionId, threadId: thread.threadId });
   const link = thread.link?.trim() ?? '';
   const author = thread.author?.trim() ?? '';
   const replyCount = thread.replies.length;
@@ -30,24 +42,41 @@ export const ThreadCard = ({ thread }: Props) => {
         <span className="min-w-0 flex-1 truncate font-mono text-xs text-foreground">
           {titleOf({ thread })}
         </span>
-        {link !== '' && (
+        {docked !== null ? (
           <button
             type="button"
-            onClick={() => void openUrl(link)}
+            onClick={() => setOpen((value) => !value)}
+            aria-expanded={open}
+            aria-label={open ? 'Collapse thread' : 'Expand thread'}
             className="inline-flex shrink-0 items-center gap-1 rounded-md px-1.5 py-0.5 text-2xs font-medium text-muted-foreground/80 transition-colors hover:bg-foreground/10 hover:text-foreground"
           >
-            Open thread
-            <ArrowUpRight size={10} aria-hidden className="opacity-70" />
+            {open ? 'Hide thread' : 'View thread'}
+            <TranscriptChevron open={open} />
           </button>
+        ) : (
+          link !== '' && (
+            <button
+              type="button"
+              onClick={() => void openUrl(link)}
+              className="inline-flex shrink-0 items-center gap-1 rounded-md px-1.5 py-0.5 text-2xs font-medium text-muted-foreground/80 transition-colors hover:bg-foreground/10 hover:text-foreground"
+            >
+              Open on GitHub
+              <ArrowUpRight size={10} aria-hidden className="opacity-70" />
+            </button>
+          )
         )}
       </div>
       <MetaRow
         items={[author === '' ? null : who, `thread ${thread.position} of ${thread.total}`]}
       />
-      <Markdown
-        text={thread.body}
-        className="line-clamp-3 gap-1 text-xs leading-relaxed text-muted-foreground"
-      />
+      {open && docked !== null ? (
+        <ConversationThread thread={docked} onOpenUrl={(url) => void openUrl(url)} />
+      ) : (
+        <Markdown
+          text={thread.body}
+          className="line-clamp-3 gap-1 text-xs leading-relaxed text-muted-foreground"
+        />
+      )}
     </div>
   );
 };

--- a/apps/desktop/src/features/chat/components/ResolverKickoffCard/index.test.tsx
+++ b/apps/desktop/src/features/chat/components/ResolverKickoffCard/index.test.tsx
@@ -95,7 +95,7 @@ describe('ResolverKickoffCard', () => {
     expect(screen.getByText(/carol/)).toBeDefined();
     expect(screen.getByText('this should use a helper')).toBeDefined();
     expect(screen.getByText('this name does not match the folder')).toBeDefined();
-    expect(screen.getAllByRole('button', { name: /Open thread/ })).toHaveLength(2);
+    expect(screen.getAllByRole('button', { name: /Open on GitHub/ })).toHaveLength(2);
   });
 
   it('keeps the full instructions collapsed and never first in the transcript', () => {
@@ -128,7 +128,7 @@ describe('ResolverKickoffCard', () => {
   it('opens the thread it names on GitHub', () => {
     render(<ResolverKickoffCard item={kickoffItem()} />);
 
-    fireEvent.click(screen.getAllByRole('button', { name: /Open thread/ })[1]!);
+    fireEvent.click(screen.getAllByRole('button', { name: /Open on GitHub/ })[1]!);
 
     expect(openUrl).toHaveBeenCalledWith('https://github.com/o/r/pull/9108#discussion_r2');
   });

--- a/apps/desktop/src/features/chat/components/ResolverKickoffCard/index.tsx
+++ b/apps/desktop/src/features/chat/components/ResolverKickoffCard/index.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { Markdown } from '@goodboy/ui';
+import type { SessionId } from '@goodboy/types';
 import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../shared/components/conceptIcons';
 import type { TranscriptItem } from '../../utils/transcript-items';
 import { codeFenceMarkers } from '../../utils/codeFenceMarkers';
@@ -10,12 +11,13 @@ import { ThreadCard } from './ThreadCard';
 
 type Props = {
   readonly item: Extract<TranscriptItem, { kind: 'resolver_kickoff' }>;
+  readonly sessionId?: SessionId | null;
 };
 
 const Icon = CONCEPT_ICONS.resolve;
 const TONE = CONCEPT_TONE.resolve;
 
-export const ResolverKickoffCard = ({ item }: Props) => {
+export const ResolverKickoffCard = ({ item, sessionId = null }: Props) => {
   const [open, setOpen] = useState(false);
 
   return (
@@ -30,7 +32,7 @@ export const ResolverKickoffCard = ({ item }: Props) => {
       <ul className="flex min-w-0 flex-col gap-2">
         {item.threads.map((thread) => (
           <li key={thread.threadId ?? `thread-${thread.position}`} className="min-w-0">
-            <ThreadCard thread={thread} />
+            <ThreadCard thread={thread} sessionId={sessionId} />
           </li>
         ))}
       </ul>

--- a/apps/desktop/src/features/chat/components/ResolverKickoffCard/useKickoffDockedThread/index.ts
+++ b/apps/desktop/src/features/chat/components/ResolverKickoffCard/useKickoffDockedThread/index.ts
@@ -1,0 +1,28 @@
+import { useMemo } from 'react';
+import type { PrComment, SessionId } from '@goodboy/types';
+import { EMPTY_ARRAY, useAppStore } from '../../../../../store';
+import { groupThreads, type CommentThread } from '../../../../github/comment-threads';
+
+type Params = {
+  readonly sessionId: SessionId | null;
+  readonly threadId: string | null;
+};
+
+export const useKickoffDockedThread = ({ sessionId, threadId }: Params): CommentThread | null => {
+  const comments = useAppStore((state) =>
+    sessionId === null
+      ? (EMPTY_ARRAY as ReadonlyArray<PrComment>)
+      : (state.sessionGithub[sessionId]?.detail?.comments ??
+        (EMPTY_ARRAY as ReadonlyArray<PrComment>)),
+  );
+
+  return useMemo(() => {
+    if (threadId === null) {
+      return null;
+    }
+    const match = groupThreads(comments).find(
+      ({ head }) => head.source === 'review' && head.threadId === threadId,
+    );
+    return match ?? null;
+  }, [comments, threadId]);
+};

--- a/apps/desktop/src/features/chat/components/TranscriptCards/index.tsx
+++ b/apps/desktop/src/features/chat/components/TranscriptCards/index.tsx
@@ -93,7 +93,7 @@ function TranscriptCardImpl({
     case 'workflow_kickoff':
       return <WorkflowKickoffCard item={item} />;
     case 'resolver_kickoff':
-      return <ResolverKickoffCard item={item} />;
+      return <ResolverKickoffCard item={item} sessionId={sessionId} />;
     case 'oq_answer':
       return null;
     case 'done':

--- a/apps/desktop/src/features/session/components/ResolverAgentsLane/useResolverAgentsLane.ts
+++ b/apps/desktop/src/features/session/components/ResolverAgentsLane/useResolverAgentsLane.ts
@@ -214,6 +214,17 @@ export const useResolverAgentsLane = ({ session }: Params) => {
     return map;
   }, [prComments]);
 
+  const threadIdByCommentUrl = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const comment of prComments) {
+      if (comment.source !== 'review' || comment.threadId == null) {
+        continue;
+      }
+      map.set(comment.url, comment.threadId);
+    }
+    return map;
+  }, [prComments]);
+
   const diffCommentByAgentId = useMemo(() => {
     const map = new Map<AgentId, DiffComment>();
     for (const comment of diffComments) {
@@ -241,7 +252,12 @@ export const useResolverAgentsLane = ({ session }: Params) => {
 
   const onJump = useCallback(
     (agent: Agent) => {
-      const threadId = agentThreadIds(agent)[0];
+      const linkedThreadId = agentThreadIds(agent)[0] ?? null;
+      const matchedThreadId =
+        agent.sourceCommentUrl != null
+          ? (threadIdByCommentUrl.get(agent.sourceCommentUrl) ?? null)
+          : null;
+      const threadId = linkedThreadId ?? matchedThreadId;
       if (threadId != null && prNumber != null) {
         window.dispatchEvent(
           new CustomEvent('goodboy:open-github-session', {
@@ -254,7 +270,7 @@ export const useResolverAgentsLane = ({ session }: Params) => {
         void openUrl(agent.sourceCommentUrl);
       }
     },
-    [prNumber, sessionId],
+    [prNumber, sessionId, threadIdByCommentUrl],
   );
 
   const onForceNext = useCallback(() => {


### PR DESCRIPTION
## What changed

`ThreadCard` (inside `ResolverKickoffCard`, the chat transcript card that fires when a resolve fan-out kicks off) now docks and renders the real PR review thread in-app, read-only, instead of only offering an external "Open thread" link.

- New hook `features/chat/components/ResolverKickoffCard/useKickoffDockedThread/index.ts` reads `sessionGithub[sessionId]?.detail?.comments` from the store, runs it through the existing `groupThreads` (`features/github/comment-threads.ts`), and matches the already-parsed `thread.threadId` (from `parse-resolver-kickoff.ts`, unchanged) against `CommentThread.head.threadId`.
- `ThreadCard` renders the matched thread through the existing `ConversationThread` component (`features/github/components/GitHubStudio/ConversationThread.tsx`), which dispatches to `OpenThread`/`ResolvedThread` depending on resolved state. No new thread renderer was written, per the review that scoped this ticket.
- The thread is collapsed by default behind a "View thread" / "Hide thread" toggle (chevron via the shared `TranscriptChevron`), matching the house rule that a docked disclosure starts closed.
- `sessionId` now flows: `TranscriptCardImpl` (`features/chat/components/TranscriptCards/index.tsx`, already had it in scope) -> `ResolverKickoffCard` (new optional prop, default `null`) -> `ThreadCard` (new required prop).
- `useResolverAgentsLane`'s `onJump` (`features/session/components/ResolverAgentsLane/useResolverAgentsLane.ts`) now also resolves a `threadId` by matching `agent.sourceCommentUrl` against `PrComment.url` in the already-loaded `prComments`, before falling back to `openUrl`. This routes more jumps in-app through the existing `goodboy:open-github-session` event (same event `onJump` already used for the linked-threadId case, and the same one `ResolverInspector`'s `openThread` uses).

## The three fallback cases (never blank, never a crash, never a dead button)

`ThreadCard` falls back to the original compact summary (title, MetaRow, clamped body preview) plus an honest external link when any of:

1. `sessionId` is `null` (no session context, e.g. rendering outside a session).
2. `sessionGithub[sessionId]?.detail` is absent (PR detail not fetched yet for that session).
3. `thread.threadId` does not match any thread in `groupThreads(comments)` (comments loaded but this particular thread isn't among them).

All three are covered by dedicated tests in `ThreadCard.test.tsx`.

## Copy fix

The external fallback button now reads "Open on GitHub" instead of "Open thread". The old label collided with the in-app "Open thread" label used in `ResolverThreadCardHeader.tsx` and `ResolverThreadVerdictRow.tsx` (which opens the resolver inspector in-app, not the browser) — same label, opposite destination. "Open on GitHub" matches the label already used for the equivalent fallback in `ResolverInspector.tsx` and `ResolvedThread.tsx`.

## End-to-end trace (walked in code, not just typechecked)

`transcript item` (`resolver_kickoff`) -> `TranscriptCardImpl` passes its in-scope `sessionId` prop to `ResolverKickoffCard` -> `ResolverKickoffCard` passes it to each `ThreadCard` alongside the already-parsed `thread` -> `ThreadCard` calls `useKickoffDockedThread({ sessionId, threadId: thread.threadId })` -> the hook selects `state.sessionGithub[sessionId]?.detail?.comments` from the store (a reference the store already owns, no `useShallow` needed) -> `groupThreads(comments)` groups by `PrComment.threadId` for review comments -> `.find` matches `head.threadId === threadId` -> the matched `CommentThread` is passed to `ConversationThread`, which renders `OpenThread` or `ResolvedThread` depending on `head.resolved`.

Verified this render path with `ThreadCard.test.tsx`, which mocks the store to the real shape (`sessionGithub.s.detail.comments` as an array of `PrComment`), renders `ThreadCard` with a matching `threadId`, expands it, and asserts the reply body and author actually appear on screen (not just that the component didn't throw).

## Tests

`ConversationThread`/`OpenThread`/`ResolvedThread` had zero isolated tests before this change; `ThreadCard.test.tsx` is the first coverage that exercises them through a real store shape. New file `apps/desktop/src/features/chat/components/ResolverKickoffCard/ThreadCard.test.tsx`:

- docks the real thread from the store and renders it collapsed by default (toggle present, reply body not yet in the DOM until expanded)
- shows the resolved state once docked (asserts the "resolved" eyebrow renders)
- pins that **no reply or resolve affordance renders** for the docked thread (no textbox, no button named `/reply/i` or `/resolve/i`) — this is the explicit out-of-scope boundary
- all three not-found fallbacks (no session, no PR detail, unmatched threadId) render the compact summary + external link, never the toggle
- the external link still calls `openUrl` with the right URL

Existing `ResolverKickoffCard/index.test.tsx` was updated (not deleted) because it pinned the literal button label "Open thread" for the external-open case, which this change deliberately renames to "Open on GitHub" for the copy-hazard fix described above. Behavior (clicking still calls `openUrl` with the comment's URL) is unchanged and still asserted.

## Explicitly out of scope

No reply or resolve affordance was added anywhere. The shipped resolve UX stays queue-then-batch (`queueResolution` -> `pushAllResolutions`, driven from `useResolverActions` and `ResolverThreadList`). `addReviewThreadReply`/`resolveReviewThread` are still never called from a `.tsx` file; adding an immediate per-thread mutation from the docked view is a separate product decision, not part of this PR. `GitHubStudio/CreatePrPanel.tsx` and the resolve queue itself were not touched.

## Verification

- `pnpm typecheck` — green (5/5 packages, `@goodboy/desktop` `tsc --noEmit` clean)
- `pnpm test` — green, 510 files / 4446 tests passed
- `pnpm knip --include files,duplicates,unlisted` — clean (only the 6 pre-existing config hints, no unused files/duplicates/unlisted deps)

## Files touched

- `apps/desktop/src/features/chat/components/ResolverKickoffCard/ThreadCard.tsx`
- `apps/desktop/src/features/chat/components/ResolverKickoffCard/ThreadCard.test.tsx` (new)
- `apps/desktop/src/features/chat/components/ResolverKickoffCard/index.tsx`
- `apps/desktop/src/features/chat/components/ResolverKickoffCard/index.test.tsx`
- `apps/desktop/src/features/chat/components/ResolverKickoffCard/useKickoffDockedThread/index.ts` (new)
- `apps/desktop/src/features/chat/components/TranscriptCards/index.tsx`
- `apps/desktop/src/features/session/components/ResolverAgentsLane/useResolverAgentsLane.ts`
