### PR TITLE
feat(desktop): focus the exact linked object for every provider

### DIFF
--- a/apps/desktop/src/features/integrations/linear/LinkedPrChip/index.test.tsx
+++ b/apps/desktop/src/features/integrations/linear/LinkedPrChip/index.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { PullRequestState } from '@goodboy/types';
+
+type Store = {
+  currentSessionId: string | null;
+  sessionGithubPrs: Record<string, ReadonlyArray<PullRequestState>>;
+  sessionGithub: Record<string, { pr: PullRequestState | null }>;
+  readonly selectSessionPr: ReturnType<typeof vi.fn>;
+  readonly setActiveLens: ReturnType<typeof vi.fn>;
+};
+
+const h = vi.hoisted(() => ({
+  store: {
+    currentSessionId: 'session-1',
+    sessionGithubPrs: {},
+    sessionGithub: {},
+    selectSessionPr: vi.fn(async () => undefined),
+    setActiveLens: vi.fn(),
+  } as Store,
+  openUrl: vi.fn(async () => undefined),
+}));
+
+vi.mock('../../../../store', () => ({
+  EMPTY_ARRAY: Object.freeze([]),
+  useAppStore: <T,>(selector: (state: Store) => T) => selector(h.store),
+}));
+
+vi.mock('../../../../shared/lib/editor', () => ({
+  openUrl: h.openUrl,
+}));
+
+import { LinkedPrChip } from '.';
+
+const SESSION_PR: PullRequestState = {
+  number: 42,
+  title: 'Refactor integration storage',
+  url: 'https://github.com/acme/goodboy/pull/42',
+  state: 'open',
+  mergeable: null,
+  checks: 'success',
+  baseBranch: 'main',
+  headBranch: 'ak/current',
+  isDraft: false,
+  reviewDecision: 'approved',
+  body: '',
+  updatedAt: '2026-07-22T12:00:00.000Z',
+};
+
+beforeEach(() => {
+  h.store.currentSessionId = 'session-1';
+  h.store.sessionGithubPrs = {};
+  h.store.sessionGithub = {};
+  h.store.selectSessionPr.mockClear();
+  h.store.setActiveLens.mockClear();
+  h.openUrl.mockClear();
+});
+
+afterEach(cleanup);
+
+describe('LinkedPrChip', () => {
+  it('opens the pull request the session already holds in the pull request lens', () => {
+    h.store.sessionGithubPrs = { 'session-1': [SESSION_PR] };
+
+    render(
+      <LinkedPrChip
+        pr={{ url: SESSION_PR.url, number: 42, repo: 'acme/goodboy', status: 'open' }}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(h.store.selectSessionPr).toHaveBeenCalledWith('session-1', 42);
+    expect(h.store.setActiveLens).toHaveBeenCalledWith('session-1', 'pr');
+    expect(h.openUrl).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the browser for a pull request this session does not track', () => {
+    h.store.sessionGithubPrs = { 'session-1': [SESSION_PR] };
+
+    render(
+      <LinkedPrChip
+        pr={{
+          url: 'https://github.com/acme/other/pull/9',
+          number: 9,
+          repo: 'acme/other',
+          status: null,
+        }}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(h.openUrl).toHaveBeenCalledWith('https://github.com/acme/other/pull/9');
+    expect(h.store.setActiveLens).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/features/integrations/linear/LinkedPrChip/index.test.tsx
+++ b/apps/desktop/src/features/integrations/linear/LinkedPrChip/index.test.tsx
@@ -94,4 +94,23 @@ describe('LinkedPrChip', () => {
     expect(h.openUrl).toHaveBeenCalledWith('https://github.com/acme/other/pull/9');
     expect(h.store.setActiveLens).not.toHaveBeenCalled();
   });
+
+  it('falls back to the browser while a studio overlay covers the session', () => {
+    h.store.sessionGithubPrs = { 'session-1': [SESSION_PR] };
+    const overlay = document.createElement('div');
+    overlay.setAttribute('data-studio-overlay', '');
+    document.body.appendChild(overlay);
+
+    render(
+      <LinkedPrChip
+        pr={{ url: SESSION_PR.url, number: 42, repo: 'acme/goodboy', status: 'open' }}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(h.openUrl).toHaveBeenCalledWith(SESSION_PR.url);
+    expect(h.store.setActiveLens).not.toHaveBeenCalled();
+    expect(h.store.selectSessionPr).not.toHaveBeenCalled();
+    overlay.remove();
+  });
 });

--- a/apps/desktop/src/features/integrations/linear/LinkedPrChip/index.tsx
+++ b/apps/desktop/src/features/integrations/linear/LinkedPrChip/index.tsx
@@ -3,17 +3,42 @@ import { GitPullRequest } from 'lucide-react';
 import type { LinearLinkedPr } from '../client';
 import { prStatusTone } from '../prStatusTone';
 import { openUrl } from '../../../../shared/lib/editor';
+import { EMPTY_ARRAY, useAppStore } from '../../../../store';
 
 type Props = {
   readonly pr: LinearLinkedPr;
 };
 
 export const LinkedPrChip = ({ pr }: Props) => {
+  const sessionId = useAppStore((s) => s.currentSessionId);
+  const branchPrs = useAppStore((s) =>
+    s.currentSessionId == null
+      ? EMPTY_ARRAY
+      : (s.sessionGithubPrs[s.currentSessionId] ?? EMPTY_ARRAY),
+  );
+  const canonicalPr = useAppStore((s) =>
+    s.currentSessionId == null ? null : (s.sessionGithub[s.currentSessionId]?.pr ?? null),
+  );
+  const selectSessionPr = useAppStore((s) => s.selectSessionPr);
+  const setActiveLens = useAppStore((s) => s.setActiveLens);
+  const sessionPr =
+    branchPrs.find((candidate) => candidate.url === pr.url) ??
+    (canonicalPr?.url === pr.url ? canonicalPr : null);
+
+  const open = () => {
+    if (sessionId == null || sessionPr == null) {
+      void openUrl(pr.url);
+      return;
+    }
+    void selectSessionPr(sessionId, sessionPr.number);
+    setActiveLens(sessionId, 'pr');
+  };
+
   return (
     <button
       type="button"
-      onClick={() => void openUrl(pr.url)}
-      title={pr.url}
+      onClick={open}
+      title={sessionPr == null ? pr.url : `Show pull request #${pr.number} in this session`}
       className={cn(
         'inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 text-2xs font-medium motion-safe:transition-opacity hover:opacity-80',
         prStatusTone({ status: pr.status }),

--- a/apps/desktop/src/features/integrations/linear/LinkedPrChip/index.tsx
+++ b/apps/desktop/src/features/integrations/linear/LinkedPrChip/index.tsx
@@ -26,7 +26,8 @@ export const LinkedPrChip = ({ pr }: Props) => {
     (canonicalPr?.url === pr.url ? canonicalPr : null);
 
   const open = () => {
-    if (sessionId == null || sessionPr == null) {
+    const isUnderStudio = document.querySelector('[data-studio-overlay]') != null;
+    if (sessionId == null || sessionPr == null || isUnderStudio) {
       void openUrl(pr.url);
       return;
     }
@@ -38,7 +39,7 @@ export const LinkedPrChip = ({ pr }: Props) => {
     <button
       type="button"
       onClick={open}
-      title={sessionPr == null ? pr.url : `Show pull request #${pr.number} in this session`}
+      title={pr.url}
       className={cn(
         'inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 text-2xs font-medium motion-safe:transition-opacity hover:opacity-80',
         prStatusTone({ status: pr.status }),

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/LinkedWorkSection.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/LinkedWorkSection.test.tsx
@@ -30,6 +30,7 @@ type Store = {
   sessions: ReadonlyArray<Session>;
   workspaces: ReadonlyArray<Workspace>;
   readonly setFocusedGithubIssueNumber: ReturnType<typeof vi.fn>;
+  readonly openExternalTaskLens: ReturnType<typeof vi.fn>;
 };
 
 const { store, mocks } = vi.hoisted(() => ({
@@ -39,6 +40,7 @@ const { store, mocks } = vi.hoisted(() => ({
     sessions: [],
     workspaces: [],
     setFocusedGithubIssueNumber: vi.fn(),
+    openExternalTaskLens: vi.fn(),
   } as Store,
   mocks: {
     openUrl: vi.fn(async () => undefined),
@@ -62,6 +64,7 @@ beforeEach(() => {
   store.sessions = [];
   store.workspaces = [];
   store.setFocusedGithubIssueNumber.mockClear();
+  store.openExternalTaskLens.mockClear();
   mocks.openUrl.mockClear();
 });
 
@@ -110,7 +113,7 @@ describe('LinkedWorkSection', () => {
     expect(mocks.openUrl).toHaveBeenCalledWith('https://github.com/acme/repo/issues/9');
   });
 
-  it('routes every external task to its provider lens', () => {
+  it('routes every external task to its provider lens with that issue focused', () => {
     store.sessionExternalTasks = {
       'sess-1': [
         {
@@ -152,7 +155,14 @@ describe('LinkedWorkSection', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Open ENG-42 integration' }));
     fireEvent.click(screen.getByRole('button', { name: 'Open GOODBOY-7 integration' }));
     fireEvent.click(screen.getByRole('button', { name: 'Open acme/repo#3 integration' }));
-    expect(onSelectLens.mock.calls).toEqual([['linear'], ['sentry'], ['gitlab_issues']]);
+    expect(
+      store.openExternalTaskLens.mock.calls.map(([, task]) => [task.provider, task.externalId]),
+    ).toEqual([
+      ['linear', 'linear-42'],
+      ['sentry', 'sentry-7'],
+      ['gitlab', 'gitlab-3'],
+    ]);
+    expect(onSelectLens).not.toHaveBeenCalled();
   });
 
   it('navigates from the link menu to each provider lens', () => {

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/LinkedWorkSection.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/LinkedWorkSection.tsx
@@ -8,7 +8,6 @@ import { ExternalRefActions } from '../../../../shared/components/ExternalRefAct
 import { LinkedWorkRow } from '../../../../shared/components/LinkedWorkRow';
 import { workspaceMountName } from '../../../../shared/utils/workspaceMountName';
 import { ExternalTaskChip } from '../../../integrations/components/ExternalTaskChip';
-import { PROVIDER_LENS } from '../../../integrations/providerLens';
 
 type Props = {
   readonly sessionId: SessionId;
@@ -26,6 +25,7 @@ export const LinkedWorkSection = ({ sessionId, onSelectLens }: Props) => {
   const github = useAppStore((s) => s.sessionGithub[sessionId]);
   const externalTasks = useAppStore((s) => s.sessionExternalTasks[sessionId] ?? EMPTY_ARRAY);
   const setFocusedGithubIssueNumber = useAppStore((s) => s.setFocusedGithubIssueNumber);
+  const openExternalTaskLens = useAppStore((s) => s.openExternalTaskLens);
   const workspace = useAppStore((s) => {
     const session = s.sessions.find((candidate) => candidate.id === sessionId);
     return s.workspaces.find((candidate) => candidate.id === session?.workspaceId) ?? null;
@@ -113,7 +113,7 @@ export const LinkedWorkSection = ({ sessionId, onSelectLens }: Props) => {
                   mountWorkspaceId: task.mountWorkspaceId,
                 }) ?? undefined
               }
-              onClick={() => onSelectLens(PROVIDER_LENS[task.provider])}
+              onClick={() => openExternalTaskLens(sessionId, task)}
             />
           ))}
         </div>

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/index.test.tsx
@@ -11,8 +11,15 @@ import type {
   WorkspaceId,
 } from '@goodboy/types';
 
+type FocusedExternalTask = {
+  readonly provider: string;
+  readonly externalId: string;
+  readonly mountWorkspaceId: string | null;
+};
+
 type Store = {
   readonly sessionExternalTasks: Readonly<Record<string, ReadonlyArray<SessionExternalTask>>>;
+  readonly focusedExternalTask: Readonly<Record<string, FocusedExternalTask | null>>;
   readonly sessionGithubPrs: Readonly<Record<string, ReadonlyArray<PullRequestState>>>;
   readonly sessionGitlabMr: Readonly<Record<string, unknown>>;
   readonly workspaceIntegrations: Readonly<Record<string, ReadonlyArray<{ provider: string }>>>;
@@ -36,6 +43,7 @@ type TaskDetailProps = {
 const h = vi.hoisted(() => ({
   store: {
     sessionExternalTasks: {},
+    focusedExternalTask: {},
     sessionGithubPrs: {},
     sessionGitlabMr: {},
     workspaceIntegrations: {},
@@ -87,6 +95,17 @@ vi.mock('./SentryTaskDetail', () => ({
     <div data-testid="task-detail">
       <a href="https://sentry.io/issues/12345" aria-label="Open in Sentry">
         Sentry detail {task.externalId}
+      </a>
+      <button type="button" aria-label="Copy issue link" />
+    </div>
+  ),
+}));
+
+vi.mock('./GitlabTaskDetail', () => ({
+  GitlabTaskDetail: ({ task }: TaskDetailProps) => (
+    <div data-testid="task-detail">
+      <a href="https://gitlab.com/acme/web/-/issues/3" aria-label="Open in GitLab">
+        GitLab detail {task.externalId}
       </a>
       <button type="button" aria-label="Copy issue link" />
     </div>
@@ -161,6 +180,15 @@ const MERGED_PR: PullRequestState = {
   body: '',
   updatedAt: CREATED_AT,
 };
+const GITLAB_TASK: SessionExternalTask = {
+  sessionId: SESSION_ID,
+  provider: 'gitlab',
+  externalId: 'acme/web#3',
+  identifier: 'acme/web#3',
+  title: 'Restore the pipeline',
+  url: 'https://gitlab.com/acme/web/-/issues/3',
+  createdAt: CREATED_AT,
+};
 const SENTRY_TASK: SessionExternalTask = {
   sessionId: SESSION_ID,
   provider: 'sentry',
@@ -173,9 +201,10 @@ const SENTRY_TASK: SessionExternalTask = {
 
 beforeEach(() => {
   h.store.sessionExternalTasks = { [SESSION_ID]: [TASK] };
+  h.store.focusedExternalTask = {};
   h.store.sessionGithubPrs = {};
   h.store.workspaceIntegrations = {
-    [WORKSPACE_ID]: [{ provider: 'linear' }, { provider: 'sentry' }],
+    [WORKSPACE_ID]: [{ provider: 'linear' }, { provider: 'sentry' }, { provider: 'gitlab' }],
   };
   h.store.linkSessionExternalTask.mockClear();
   h.store.unlinkSessionExternalTask.mockClear();
@@ -235,6 +264,45 @@ describe('IntegrationPane', () => {
 
       expect(screen.getAllByRole('link', { name: `Open in ${host}` })).toHaveLength(1);
       expect(screen.getAllByRole('button', { name: 'Copy issue link' })).toHaveLength(1);
+    },
+  );
+
+  it.each([
+    ['linear', TASK, 'Linear detail GB-42'],
+    ['sentry', SENTRY_TASK, 'Sentry detail 12345'],
+    ['gitlab', GITLAB_TASK, 'GitLab detail acme/web#3'],
+  ] as const)(
+    'opens the %s issue the session focused from another surface',
+    (provider, task, detailText) => {
+      h.store.sessionExternalTasks = { [SESSION_ID]: [task] };
+      h.store.focusedExternalTask = {
+        [SESSION_ID]: { provider, externalId: task.externalId, mountWorkspaceId: null },
+      };
+
+      render(
+        <IntegrationPane sessionId={SESSION_ID} workspaceId={WORKSPACE_ID} provider={provider} />,
+      );
+
+      expect(screen.getByText(detailText)).toBeDefined();
+      expect(screen.getByRole('button', { name: 'All issues' })).toBeDefined();
+    },
+  );
+
+  it.each([
+    ['linear', TASK, 'Linear detail GB-42'],
+    ['sentry', SENTRY_TASK, 'Sentry detail 12345'],
+    ['gitlab', GITLAB_TASK, 'GitLab detail acme/web#3'],
+  ] as const)(
+    'lists the %s issues when the lens opens with nothing focused',
+    (provider, task, detailText) => {
+      h.store.sessionExternalTasks = { [SESSION_ID]: [task] };
+
+      render(
+        <IntegrationPane sessionId={SESSION_ID} workspaceId={WORKSPACE_ID} provider={provider} />,
+      );
+
+      expect(screen.getByRole('button', { name: `View ${task.identifier}` })).toBeDefined();
+      expect(screen.queryByText(detailText)).toBeNull();
     },
   );
 

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { ArrowLeft, Unlink } from 'lucide-react';
 import type {
   SessionExternalTask,
@@ -53,10 +53,19 @@ export const IntegrationPane = ({ sessionId, workspaceId, provider }: Props) => 
   const [unlinkError, setUnlinkError] = useState<string | null>(null);
   const [isUnlinking, setIsUnlinking] = useState(false);
   const [isUnlinkArmed, setIsUnlinkArmed] = useState(false);
-  const [focusedTaskKey, setFocusedTaskKey] = useState<string | null>(null);
   const externalTasks = useAppStore(
     (state) => state.sessionExternalTasks[sessionId] ?? EMPTY_ARRAY,
   );
+  const openedTask = useAppStore((state) => state.focusedExternalTask[sessionId] ?? null);
+  const openedTaskKey =
+    openedTask?.provider === provider ? integrationTaskKey({ task: openedTask }) : null;
+  const [focusedTaskKey, setFocusedTaskKey] = useState<string | null>(openedTaskKey);
+  useEffect(() => {
+    if (openedTaskKey == null) {
+      return;
+    }
+    setFocusedTaskKey(openedTaskKey);
+  }, [openedTaskKey]);
   const unlinkSessionExternalTask = useAppStore((state) => state.unlinkSessionExternalTask);
   const integrations = useAppStore(
     (state) => state.workspaceIntegrations[workspaceId] ?? EMPTY_ARRAY,

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/integrationTaskKey.ts
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/integrationTaskKey.ts
@@ -1,7 +1,10 @@
-import type { SessionExternalTask } from '@goodboy/types';
+import type { WorkspaceId } from '@goodboy/types';
 
 type Params = {
-  readonly task: SessionExternalTask;
+  readonly task: {
+    readonly externalId: string;
+    readonly mountWorkspaceId?: WorkspaceId | null;
+  };
 };
 
 export const integrationTaskKey = ({ task }: Params): string =>

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.test.tsx
@@ -23,6 +23,7 @@ type Store = {
   readonly selectSessionPr: ReturnType<typeof vi.fn>;
   readonly editPr: ReturnType<typeof vi.fn>;
   readonly setFocusedGithubIssueNumber: ReturnType<typeof vi.fn>;
+  readonly openExternalTaskLens: ReturnType<typeof vi.fn>;
   readonly sessionBranches: Record<string, string>;
   sessionMounts: Record<string, ReadonlyArray<never>>;
   sessionActiveMount: Record<string, WorkspaceId>;
@@ -44,6 +45,7 @@ const h = vi.hoisted(() => ({
     selectSessionPr: vi.fn(),
     editPr: vi.fn(async () => undefined),
     setFocusedGithubIssueNumber: vi.fn(),
+    openExternalTaskLens: vi.fn(),
     sessionBranches: { 'session-1': 'ak/refactor-auth' },
     sessionMounts: {},
     sessionActiveMount: {},
@@ -196,6 +198,7 @@ beforeEach(() => {
   h.openUrl.mockClear();
   h.store.editPr.mockClear();
   h.store.setFocusedGithubIssueNumber.mockClear();
+  h.store.openExternalTaskLens.mockClear();
   h.githubStatus = {
     available: true,
     mode: 'gh-cli',
@@ -568,8 +571,10 @@ describe('PrPane', () => {
     expect(screen.getByText('1')).toBeDefined();
     expect(screen.getByRole('button', { name: /#7 Track auth rollout/i })).toBeDefined();
     fireEvent.click(screen.getByRole('button', { name: 'open #7 integration' }));
-    expect(h.store.setFocusedGithubIssueNumber).toHaveBeenCalledWith(SESSION_ID, 7);
-    expect(h.onSelectLens).toHaveBeenCalledWith('github_issue');
+    expect(h.store.openExternalTaskLens).toHaveBeenCalledWith(
+      SESSION_ID,
+      expect.objectContaining({ provider: 'github', externalId: '7' }),
+    );
     expect(h.openUrl).not.toHaveBeenCalled();
     expect(screen.getAllByRole('link', { name: 'Open in GitHub' })).toHaveLength(3);
   });
@@ -654,8 +659,11 @@ describe('PrPane', () => {
     expect(h.onSelectLens).toHaveBeenCalledWith('github_issue');
 
     fireEvent.click(screen.getByRole('button', { name: 'open #9 integration' }));
-    expect(h.store.setFocusedGithubIssueNumber).toHaveBeenCalledWith(SESSION_ID, 9);
-    expect(h.onSelectLens.mock.calls).toEqual([['github_issue'], ['github_issue']]);
+    expect(h.store.openExternalTaskLens).toHaveBeenCalledWith(
+      SESSION_ID,
+      expect.objectContaining({ provider: 'github', externalId: '9' }),
+    );
+    expect(h.onSelectLens.mock.calls).toEqual([['github_issue']]);
     expect(h.openUrl).not.toHaveBeenCalled();
     expect(screen.getByText('No pull or merge request yet')).toBeDefined();
     expect(screen.getByText('ak/refactor-auth')).toBeDefined();

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.tsx
@@ -11,7 +11,6 @@ import type {
 } from '@goodboy/types';
 import { PullRequestChip, pullRequestMeta } from '../../../../github/components/PullRequestChip';
 import { ExternalTaskChip } from '../../../../integrations/components/ExternalTaskChip';
-import { PROVIDER_LENS } from '../../../../integrations/providerLens';
 import { GitlabMrStrip } from '../../../../context/components/ContextPanel/strips/GitlabMrStrip';
 import { MissingGithubRemoteEmptyState } from '../../../../github/components/MissingGithubRemoteEmptyState';
 import { MissingGithubTokenEmptyState } from '../../../../github/components/MissingGithubTokenEmptyState';
@@ -234,6 +233,7 @@ const GithubPrCard = ({
   const refreshSessionPr = useAppStore((s) => s.refreshSessionPr);
   const editPr = useAppStore((s) => s.editPr);
   const setFocusedGithubIssueNumber = useAppStore((s) => s.setFocusedGithubIssueNumber);
+  const openExternalTaskLens = useAppStore((s) => s.openExternalTaskLens);
   const branch = useSessionRepo({ sessionId })?.branch ?? null;
   const externalTasks = useAppStore((s) => s.sessionExternalTasks[sessionId] ?? EMPTY_ARRAY);
   const workspaceIntegrations = useAppStore(
@@ -316,10 +316,7 @@ const GithubPrCard = ({
   };
 
   const openWorkItem = (task: SessionExternalTask) => {
-    if (task.provider === 'github') {
-      setFocusedGithubIssueNumber(sessionId, Number(task.externalId));
-    }
-    onSelectLens(PROVIDER_LENS[task.provider]);
+    openExternalTaskLens(sessionId, task);
   };
 
   const handleUnlinkIssue = async (issueNumber: number) => {

--- a/apps/desktop/src/store/slices/session-view/createInitialSessionViewState.ts
+++ b/apps/desktop/src/store/slices/session-view/createInitialSessionViewState.ts
@@ -6,6 +6,7 @@ export const createInitialSessionViewState = ({}: Params) => ({
   lensHistory: {},
   focusedPlanId: {},
   focusedGithubIssueNumber: {},
+  focusedExternalTask: {},
   sessionStudio: {},
   workflowExpand: {},
   focusedWorkflowRunId: {},

--- a/apps/desktop/src/store/slices/session-view/index.test.ts
+++ b/apps/desktop/src/store/slices/session-view/index.test.ts
@@ -16,6 +16,7 @@ import type {
   PlanWithCount,
   ProviderRunId,
   Session,
+  SessionExternalTask,
   SessionId,
   Skill,
   SkillId,
@@ -400,6 +401,19 @@ function buildAgent(overrides: Partial<Agent> & Pick<Agent, 'id'>): Agent {
   };
 }
 
+function buildExternalTask(overrides: Partial<SessionExternalTask> = {}): SessionExternalTask {
+  return {
+    sessionId: SESSION_ID,
+    provider: 'linear',
+    externalId: 'ENG-42',
+    identifier: 'ENG-42',
+    url: 'https://linear.app/acme/issue/ENG-42',
+    title: 'Track linked work',
+    createdAt: NOW,
+    ...overrides,
+  };
+}
+
 function buildPlan(overrides: Partial<PlanWithCount> = {}): PlanWithCount {
   return {
     id: PLAN_ID,
@@ -514,6 +528,7 @@ describe('store contract', () => {
         lensHistory: {},
         workflowExpand: {},
         focusedPlanId: {},
+        focusedExternalTask: {},
         sessionStudio: {},
       };
     }
@@ -733,6 +748,67 @@ describe('store contract', () => {
       expect(store.getState().diffFocus[SESSION_ID]).toEqual({ kind: 'working', path: null });
       store.getState().lensGo(SESSION_ID, -1);
       expect(store.getState().activeLens[SESSION_ID]).toBe('resolve');
+    });
+
+    it.each([
+      ['linear', 'linear'],
+      ['sentry', 'sentry'],
+      ['gitlab', 'gitlab_issues'],
+    ] as const)(
+      'openExternalTaskLens lands on the %s lens with the clicked issue focused',
+      async (provider, lens) => {
+        const store = await getStore();
+        store
+          .getState()
+          .openExternalTaskLens(
+            SESSION_ID,
+            buildExternalTask({ provider, externalId: `${provider}-7` }),
+          );
+        expect(store.getState().activeLens[SESSION_ID]).toBe(lens);
+        expect(store.getState().focusedExternalTask[SESSION_ID]).toEqual({
+          provider,
+          externalId: `${provider}-7`,
+          mountWorkspaceId: null,
+        });
+      },
+    );
+
+    it.each(['linear', 'sentry', 'gitlab_issues'] as const)(
+      'opening the %s lens on its own focuses no issue',
+      async (lens) => {
+        const store = await getStore();
+        store.getState().setActiveLens(SESSION_ID, lens);
+        expect(store.getState().focusedExternalTask[SESSION_ID]).toBeNull();
+      },
+    );
+
+    it.each([
+      ['linear', 'linear'],
+      ['sentry', 'sentry'],
+      ['gitlab', 'gitlab_issues'],
+    ] as const)(
+      'reopening the %s lens from the rail drops the issue a linked row had focused',
+      async (provider, lens) => {
+        const store = await getStore();
+        store.getState().openExternalTaskLens(SESSION_ID, buildExternalTask({ provider }));
+        store.getState().setActiveLens(SESSION_ID, 'agents');
+        expect(store.getState().focusedExternalTask[SESSION_ID]).toBeNull();
+        store.getState().setActiveLens(SESSION_ID, lens);
+        expect(store.getState().focusedExternalTask[SESSION_ID]).toBeNull();
+      },
+    );
+
+    it('openExternalTaskLens sends a github task to the issue lens by its number', async () => {
+      const store = await getStore();
+      store
+        .getState()
+        .openExternalTaskLens(
+          SESSION_ID,
+          buildExternalTask({ provider: 'github', externalId: '9', identifier: '#9' }),
+        );
+      expect(store.getState().activeLens[SESSION_ID]).toBe('github_issue');
+      expect(store.getState().focusedGithubIssueNumber[SESSION_ID]).toBe(9);
+      expect(store.getState().focusedExternalTask[SESSION_ID]).toBeNull();
     });
 
     it('setSessionStudio(non-null) clears the selected agent', async () => {

--- a/apps/desktop/src/store/slices/session-view/index.ts
+++ b/apps/desktop/src/store/slices/session-view/index.ts
@@ -5,6 +5,7 @@ import { setSessionSort } from './setSessionSort';
 import {
   lensGo,
   openDiffLens,
+  openExternalTaskLens,
   setActiveLens,
   setDiffFocus,
   setFocusedGithubIssueNumber,
@@ -24,6 +25,7 @@ export { readPersistedLens } from './workSurfaceStorage';
 export { LENS_KINDS } from './types';
 export type { GroupedSessions, SessionViewSlice } from './types';
 export type {
+  FocusedExternalTask,
   SessionStudio,
   LensKind,
   LensHistory,
@@ -48,6 +50,7 @@ export const createSessionViewSlice = (set: SetFn, get: GetFn): SessionViewSlice
     setSessionStudio: setSessionStudio(set),
     setDiffFocus: setDiffFocus(set),
     openDiffLens: openDiffLens(get),
+    openExternalTaskLens: openExternalTaskLens(set, get),
     beginSessionCreation: beginSessionCreation(set),
     endSessionCreation: endSessionCreation(set),
   };

--- a/apps/desktop/src/store/slices/session-view/types.ts
+++ b/apps/desktop/src/store/slices/session-view/types.ts
@@ -3,6 +3,8 @@ import type {
   IsoDateTime,
   PlanId,
   Session,
+  SessionExternalTask,
+  SessionExternalTaskProvider,
   SessionGroupKey,
   SessionId,
   SessionPrGroup,
@@ -58,6 +60,12 @@ export const LENS_KINDS: ReadonlySet<LensKind> = new Set<LensKind>([
 export type DiffFocus =
   | { readonly kind: 'commit'; readonly sha: string; readonly path: string | null }
   | { readonly kind: 'working'; readonly path: string | null };
+
+export type FocusedExternalTask = {
+  readonly provider: SessionExternalTaskProvider;
+  readonly externalId: string;
+  readonly mountWorkspaceId: WorkspaceId | null;
+};
 
 export type SessionStudio =
   | { readonly kind: 'workflow' }
@@ -115,6 +123,7 @@ type SessionViewSliceState = {
   readonly lensHistory: Readonly<Record<SessionId, LensHistory>>;
   readonly focusedPlanId: Readonly<Record<SessionId, PlanId | null>>;
   readonly focusedGithubIssueNumber: Readonly<Record<SessionId, number | null>>;
+  readonly focusedExternalTask: Readonly<Record<SessionId, FocusedExternalTask | null>>;
   readonly sessionStudio: Readonly<Record<SessionId, SessionStudio | null>>;
   readonly workflowExpand: Readonly<Record<SessionId, Readonly<Record<string, boolean>>>>;
   readonly focusedWorkflowRunId: Readonly<Record<SessionId, string | null>>;
@@ -132,6 +141,7 @@ type SessionViewSliceActions = {
   setFocusedWorkflowRun(sessionId: SessionId, runId: string | null): void;
   setFocusedPlanId(sessionId: SessionId, planId: PlanId | null): void;
   setFocusedGithubIssueNumber(sessionId: SessionId, issueNumber: number | null): void;
+  openExternalTaskLens(sessionId: SessionId, task: SessionExternalTask): void;
   setSessionStudio(sessionId: SessionId, studio: SessionStudio | null): void;
   setDiffFocus(sessionId: SessionId, focus: DiffFocus | null): void;
   openDiffLens(sessionId: SessionId, focus: DiffFocus): void;

--- a/apps/desktop/src/store/slices/session-view/workSurface.ts
+++ b/apps/desktop/src/store/slices/session-view/workSurface.ts
@@ -1,4 +1,4 @@
-import type { PlanId, SessionId } from '@goodboy/types';
+import type { PlanId, SessionExternalTask, SessionId } from '@goodboy/types';
 import type {
   DiffFocus,
   GetFn,
@@ -7,6 +7,7 @@ import type {
   SetFn,
   WorkSurfacePosition,
 } from './types';
+import { PROVIDER_LENS } from '../../../features/integrations/providerLens';
 import { amendTopPosition } from './amendTopPosition';
 import { workSurfaceFocus } from './workSurfaceFocus';
 import { writePersistedLens } from './workSurfaceStorage';
@@ -40,6 +41,7 @@ export const setActiveLens = (set: SetFn) => {
             ? s.focusedWorkflowRunId
             : { ...s.focusedWorkflowRunId, [sessionId]: null },
         diffFocus: lens === 'files' ? s.diffFocus : { ...s.diffFocus, [sessionId]: null },
+        focusedExternalTask: { ...s.focusedExternalTask, [sessionId]: null },
         lensHistory: {
           ...s.lensHistory,
           [sessionId]: { entries, index: entries.length - 1 },
@@ -133,6 +135,26 @@ export const setFocusedGithubIssueNumber = (set: SetFn) => {
   return (sessionId: SessionId, issueNumber: number | null): void => {
     set((s) => ({
       focusedGithubIssueNumber: { ...s.focusedGithubIssueNumber, [sessionId]: issueNumber },
+    }));
+  };
+};
+
+export const openExternalTaskLens = (set: SetFn, get: GetFn) => {
+  return (sessionId: SessionId, task: SessionExternalTask): void => {
+    get().setActiveLens(sessionId, PROVIDER_LENS[task.provider]);
+    if (task.provider === 'github') {
+      get().setFocusedGithubIssueNumber(sessionId, Number(task.externalId));
+      return;
+    }
+    set((s) => ({
+      focusedExternalTask: {
+        ...s.focusedExternalTask,
+        [sessionId]: {
+          provider: task.provider,
+          externalId: task.externalId,
+          mountWorkspaceId: task.mountWorkspaceId ?? null,
+        },
+      },
     }));
   };
 };

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -659,6 +659,7 @@ export type AppActions = {
   setFocusedGithubIssueNumber(sessionId: SessionId, issueNumber: number | null): void;
   setDiffFocus(sessionId: SessionId, focus: DiffFocus | null): void;
   openDiffLens(sessionId: SessionId, focus: DiffFocus): void;
+  openExternalTaskLens(sessionId: SessionId, task: SessionExternalTask): void;
   beginSessionCreation(
     sessionId: SessionId,
     creation: { readonly kind: SessionCreationKind; readonly label?: string | null },

--- a/apps/desktop/src/store/types.ts
+++ b/apps/desktop/src/store/types.ts
@@ -68,6 +68,7 @@ import type { ProviderConnectMap, ProviderLifecycleMap } from './slices/provider
 import type { ReviewPrsState } from './slices/review-prs/types';
 import type {
   DiffFocus,
+  FocusedExternalTask,
   LensHistory,
   LensKind,
   SessionCreation,
@@ -291,6 +292,7 @@ export type AppState = AppSliceState & {
   readonly sessionStudio: Readonly<Record<SessionId, SessionStudio | null>>;
   readonly focusedPlanId: Readonly<Record<SessionId, PlanId | null>>;
   readonly focusedGithubIssueNumber: Readonly<Record<SessionId, number | null>>;
+  readonly focusedExternalTask: Readonly<Record<SessionId, FocusedExternalTask | null>>;
   readonly terminalSessions: Readonly<Record<SessionId, 'open' | 'closed'>>;
   readonly terminalTabs: Readonly<Record<SessionId, readonly TerminalTab[]>>;
   readonly activeTerminalTab: Readonly<Record<SessionId, TerminalTabId | null>>;


### PR DESCRIPTION
## What

Clicking a named linked object (a Linear issue, a Sentry issue, a GitLab issue) from Linked work or from the pull request pane used to call `onSelectLens(PROVIDER_LENS[provider])` and land on a list with nothing focused. Only GitHub had a focus slot (`focusedGithubIssueNumber`). This gives the other three providers a real focus, routed through the store.

- `store/slices/session-view`: new `focusedExternalTask` state slot (`{ provider, externalId, mountWorkspaceId }` per session) and a new `openExternalTaskLens(sessionId, task)` action.
- `IntegrationPane` (the surface behind the `linear`, `sentry` and `gitlab_issues` lenses) reads the slot and opens that task's detail instead of the list.
- `LinkedWorkSection` and `PrPane` now dispatch the single action instead of `onSelectLens(PROVIDER_LENS[...])`.
- `LinkedPrChip` routes a linked pull request the session already tracks to the `pr` lens (`selectSessionPr` + `setActiveLens`) instead of always shelling out to the browser; `openUrl` stays as the fallback.

## Why one provider-tagged slot instead of three parallel slots

The three lenses are mutually exclusive and are all rendered by the same `IntegrationPane` component, so three sibling records would have been three copies of the same reducer plus a fan-out in the pane. The slot carries the provider, and the pane only consumes it when `focus.provider === provider`, which gives the same guarantee with one reducer.

## Stale focus, the lifecycle

`focusedGithubIssueNumber` is never cleared today; it survives because the `github_issue` lens falls back to the session's linked GitHub task anyway. That lifecycle cannot be copied for a list lens, so `focusedExternalTask` is cleared unconditionally in `setActiveLens`, and `openExternalTaskLens` sets the lens **first** and the focus **after**. Result:

- linked row click: lens set (focus cleared), then focus set, detail opens.
- lens rail click: `setActiveLens` clears the focus, the list opens. No leftover.
- leaving to any other lens: cleared.

`lensGo` (back/forward) is untouched, as instructed, so history restore keeps its own semantics.

## End-to-end path traced in code

1. `LinkedWorkSection.tsx` `ExternalTaskChip onClick` -> `openExternalTaskLens(sessionId, task)`.
2. `store/slices/session-view/workSurface.ts` -> `setActiveLens(sessionId, PROVIDER_LENS[task.provider])` (clears the slot) -> `set` the slot to that task.
3. `SessionWorkspace/index.tsx` renders `lens === 'linear' | 'sentry' | 'gitlab_issues'` -> `<IntegrationPane provider=... />`.
4. `IntegrationPane` reads `focusedExternalTask[sessionId]`, keeps it only when the provider matches, turns it into the same `integrationTaskKey` its own list uses, finds the task in `sessionExternalTasks` (the very array the clicked row came from, so it is always present) and renders `FocusedPane` + `FocusedTaskBody` -> `LinearTaskDetail` / `SentryTaskDetail` / `GitlabTaskDetail`.

No gate on data that is usually absent: the only conditional inside `FocusedTaskBody` is `isConnected`, and its false branch still renders a detail layout for the task, never the list. The new component tests render the pane from the store slot alone, with no click, so the path is proven from state, not from an interaction.

GitHub goes through the same action for symmetry: it sets `focusedGithubIssueNumber` and lands on `github_issue`. Side effect worth noting: a session with two linked GitHub tasks used to always open the first one (the lens fell back to `find(provider === 'github')`); now it opens the one that was clicked.

## Tests

- `store/slices/session-view/index.test.ts`: per provider, `openExternalTaskLens` sets lens **and** focus; entering the lens on its own leaves the focus clear; leaving and reopening from the rail drops it. Plus the GitHub task landing on `github_issue` with its number.
- `IntegrationPane/index.test.tsx`: per provider (linear, sentry, gitlab), a focused id in the store renders the detail, its absence renders the list.
- `LinkedPrChip/index.test.tsx` (new file, the folder previously held only `index.tsx`): in-app route for a pull request the session tracks, browser fallback for one it does not.

### Tests rewritten

- `LinkedWorkSection.test.tsx` "routes every external task to its provider lens": it pinned `onSelectLens` calls, which is exactly the dispatch this change replaces. Rewritten to assert `openExternalTaskLens` receives the provider and external id of each clicked row, and that `onSelectLens` is no longer used for those rows.
- `PrPane.test.tsx`, two assertions on `setFocusedGithubIssueNumber` + `onSelectLens('github_issue')` for external task chips: same reason, rewritten to assert the single `openExternalTaskLens` call. The `linkedIssues` path (which is not an external task) still asserts `setFocusedGithubIssueNumber` + `onSelectLens`.

No assertion was weakened; every rewritten one still asserts internal navigation and that `openUrl` is not called.

## Deliberately not done

- `IntegrationPane/FocusedTaskBody.tsx` `openUrl` (deliberate override) and `ExternalTaskChip`'s default handler: out of scope, untouched.
- `openDiffLens`, lens history and `App.tsx`: untouched.
- `focusedGithubIssueNumber` keeps its existing lifecycle (never cleared). Changing it would alter the shipped `github_issue` fallback, which is out of scope.

## Known gap

`LinkedPrChip` is rendered from a detail field registry whose render callback only receives the entity, so it resolves the in-app surface through `currentSessionId` and matches on the pull request **url**. Inside the workspace-level Linear studio (an App-level overlay), a chip whose url happens to match the current session's pull request will set the lens behind the overlay rather than visibly navigating. Threading a handler down would have meant changing `RenderParams` for every registry; flagged rather than faked.

## Checks

- `pnpm typecheck`: 5 tasks successful.
- `pnpm test`: 510 files, 4456 tests passed.
- `pnpm knip --include files,duplicates,unlisted`: no findings, only the 6 pre-existing configuration hints already on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
