### PR TITLE
fix(desktop): load pending resolutions when a session activates

### DIFF
--- a/apps/desktop/src/store/slices/agents/activateNextResolver.test.ts
+++ b/apps/desktop/src/store/slices/agents/activateNextResolver.test.ts
@@ -201,4 +201,39 @@ describe('activateNextResolver', () => {
       expect.objectContaining({ agentId: SECOND, content: 'fix comment two' }),
     );
   });
+
+  it('surfaces a notification instead of an unhandled rejection when the kickoff turn fails', async () => {
+    const sendTurn = vi.fn(async () => {
+      throw new Error('provider unreachable');
+    });
+    const emitNotification = vi.fn(async () => undefined);
+    const state: Record<string, unknown> = {
+      sessionPhaseRuns: { [SID]: [resolver({ id: FIRST, ordinal: 1 })] },
+      agentKindOverride: {},
+      pendingResolverKickoff: { [FIRST]: 'fix comment one' },
+      sendTurn,
+      selectAgent: vi.fn(async () => undefined),
+      emitNotification,
+    };
+    const get = (() => state) as unknown as GetFn;
+    const set = ((u: unknown) => {
+      const patch =
+        typeof u === 'function'
+          ? (u as (s: Record<string, unknown>) => Record<string, unknown>)(state)
+          : (u as Record<string, unknown>);
+      Object.assign(state, patch);
+    }) as unknown as SetFn;
+
+    await activateNextResolver(set, get)(SID);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(emitNotification).toHaveBeenCalledWith(
+      'error',
+      'error',
+      'resolver failed to start',
+      'provider unreachable',
+      { sessionId: SID },
+    );
+  });
 });

--- a/apps/desktop/src/store/slices/agents/activateNextResolver.ts
+++ b/apps/desktop/src/store/slices/agents/activateNextResolver.ts
@@ -1,5 +1,6 @@
 import type { AgentId, SessionId } from '@goodboy/types';
 import { classifyAgent } from '../../../features/session/agent-kind';
+import { formatError } from '../../../shared/lib/errors';
 import type { GetFn, SetFn } from './types';
 
 const resolverStartsPending = new Map<SessionId, AgentId>();
@@ -41,6 +42,15 @@ export const activateNextResolver = (set: SetFn, get: GetFn) => {
     });
     void get()
       .sendTurn({ sessionId, agentId: next.id, content: kickoff })
+      .catch((error: unknown) => {
+        void get().emitNotification(
+          'error',
+          'error',
+          'resolver failed to start',
+          formatError(error),
+          { sessionId },
+        );
+      })
       .finally(() => {
         if (resolverStartsPending.get(sessionId) === next.id) {
           resolverStartsPending.delete(sessionId);

--- a/apps/desktop/src/store/slices/github/loadPendingResolutions.test.ts
+++ b/apps/desktop/src/store/slices/github/loadPendingResolutions.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { IsoDateTime, PendingResolution, SessionId } from '@goodboy/types';
+import type { GetFn, SetFn } from './types';
+
+const h = vi.hoisted(() => ({
+  listPendingResolutionsForSession: vi.fn(),
+}));
+
+vi.mock('@goodboy/db', () => ({
+  listPendingResolutionsForSession: h.listPendingResolutionsForSession,
+}));
+
+vi.mock('../../../shared/lib/db', () => ({ tauriDatabase: {} }));
+
+import { loadPendingResolutions } from './loadPendingResolutions';
+
+const SESSION_ID = 'sess-1' as SessionId;
+
+const row = (threadId: string): PendingResolution => ({
+  id: `row-${threadId}`,
+  sessionId: SESSION_ID,
+  prNumber: 5,
+  threadId,
+  commitSha: '',
+  reply: null,
+  outcome: null,
+  replyPostedAt: null,
+  createdAt: '2026-08-05T00:00:00.000Z' as IsoDateTime,
+});
+
+type State = {
+  sessionPendingResolutions: Record<string, ReadonlyArray<PendingResolution>>;
+};
+
+const makeStore = () => {
+  const state: State = { sessionPendingResolutions: {} };
+  const get = (() => state) as unknown as GetFn;
+  const set = ((update: unknown) => {
+    const patch =
+      typeof update === 'function'
+        ? (update as (s: State) => Partial<State>)(state)
+        : (update as Partial<State>);
+    Object.assign(state, patch);
+  }) as unknown as SetFn;
+  return { state, get, set };
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('loadPendingResolutions', () => {
+  it('reads the DB once when session activation and the strip mount race for the same session', async () => {
+    let resolveRead!: (rows: ReadonlyArray<PendingResolution>) => void;
+    h.listPendingResolutionsForSession.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveRead = resolve;
+      }),
+    );
+    const { state, get, set } = makeStore();
+    const load = loadPendingResolutions(set, get);
+
+    const fromActivation = load(SESSION_ID);
+    const fromStripMount = load(SESSION_ID);
+
+    resolveRead([row('T1')]);
+    await Promise.all([fromActivation, fromStripMount]);
+
+    expect(h.listPendingResolutionsForSession).toHaveBeenCalledTimes(1);
+    expect(state.sessionPendingResolutions[SESSION_ID]).toEqual([row('T1')]);
+  });
+
+  it('skips the read once the session already has a loaded row, so a strip remount does not refetch', async () => {
+    h.listPendingResolutionsForSession.mockResolvedValueOnce([row('T1')]);
+    const { state, get, set } = makeStore();
+    const load = loadPendingResolutions(set, get);
+
+    await load(SESSION_ID);
+    await load(SESSION_ID);
+
+    expect(h.listPendingResolutionsForSession).toHaveBeenCalledTimes(1);
+    expect(state.sessionPendingResolutions[SESSION_ID]).toEqual([row('T1')]);
+  });
+});

--- a/apps/desktop/src/store/slices/github/resolveAgentThreads.test.ts
+++ b/apps/desktop/src/store/slices/github/resolveAgentThreads.test.ts
@@ -1,0 +1,172 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  Agent,
+  AgentId,
+  IsoDateTime,
+  PendingResolution,
+  SessionId,
+  WorkspaceId,
+} from '@goodboy/types';
+import type { GetFn, SetFn } from './types';
+
+type GhRun = (
+  args: ReadonlyArray<string>,
+  opts?: Readonly<Record<string, unknown>>,
+) => Promise<{ stdout: string; stderr: string; exitCode: number }>;
+
+const h = vi.hoisted(() => ({
+  rows: [] as PendingResolution[],
+  run: vi.fn<GhRun>(),
+}));
+
+vi.mock('@goodboy/db', () => ({
+  listPendingResolutionsForSession: vi.fn(async ({ sessionId }: { sessionId: SessionId }) =>
+    h.rows.filter((r) => r.sessionId === sessionId),
+  ),
+  queuePendingResolution: vi.fn(async (params: Record<string, unknown>) => {
+    h.rows.push({
+      id: params.id as string,
+      sessionId: params.sessionId as SessionId,
+      prNumber: params.prNumber as number,
+      threadId: params.threadId as string,
+      commitSha: params.commitSha as string,
+      reply: params.reply as string | null,
+      outcome: params.outcome as PendingResolution['outcome'],
+      replyPostedAt: null,
+      createdAt: NOW,
+    });
+  }),
+  deletePendingResolution: vi.fn(
+    async ({ sessionId, threadId }: { sessionId: SessionId; threadId: string }) => {
+      h.rows = h.rows.filter((r) => !(r.sessionId === sessionId && r.threadId === threadId));
+    },
+  ),
+  markPendingResolutionReplyPosted: vi.fn(async () => undefined),
+}));
+
+vi.mock('../../../shared/lib/db', () => ({ tauriDatabase: {} }));
+vi.mock('../../../features/github/github', () => ({ tauriGhRunner: { run: h.run } }));
+
+import { resolveAgentThreads } from './resolveAgentThreads';
+
+const NOW = '2026-08-05T00:00:00.000Z' as IsoDateTime;
+const SESSION_ID = 'sess-1' as SessionId;
+const WORKSPACE_ID = 'ws-1' as WorkspaceId;
+const AGENT_ID = 'agent-1' as AgentId;
+const THREAD_OK = 'PRRT_ok';
+const THREAD_FAIL = 'PRRT_fail';
+
+const agent: Agent = {
+  id: AGENT_ID,
+  sessionId: SESSION_ID,
+  ordinal: 0,
+  name: 'resolver',
+  kind: 'resolver',
+  status: 'completed',
+  sourceThreadIds: [THREAD_OK, THREAD_FAIL],
+};
+
+const resolveThreadResponse = (threadId: string): string =>
+  JSON.stringify({ data: { resolveReviewThread: { thread: { id: threadId, isResolved: true } } } });
+const resolveThreadFailed = JSON.stringify({ errors: [{ message: 'graphql boom' }] });
+
+type State = {
+  sessions: ReadonlyArray<{ id: SessionId; workspaceId: WorkspaceId }>;
+  workspaces: ReadonlyArray<{ id: WorkspaceId }>;
+  sessionGithub: Record<string, { pr: { number: number } | null; detail?: { comments: [] } }>;
+  sessionResolvedThreads: Record<string, ReadonlyArray<string>>;
+  sessionPhaseRuns: Record<string, ReadonlyArray<Agent>>;
+  resolverThreadOutcomes: Record<string, Record<string, unknown>>;
+  sessionPendingResolutions: Record<string, ReadonlyArray<PendingResolution>>;
+  sessionMounts: Record<string, ReadonlyArray<unknown>>;
+  sessionActiveMount: Record<string, string>;
+  sessionWorktrees: Record<string, ReadonlyArray<string>>;
+  sessionBranches: Record<string, string>;
+  emitNotification: ReturnType<typeof vi.fn>;
+  refreshSessionPrDetail: ReturnType<typeof vi.fn>;
+};
+
+const makeStore = () => {
+  const state: State = {
+    sessions: [{ id: SESSION_ID, workspaceId: WORKSPACE_ID }],
+    workspaces: [{ id: WORKSPACE_ID }],
+    sessionGithub: { [SESSION_ID]: { pr: { number: 42 } } },
+    sessionResolvedThreads: {},
+    sessionPhaseRuns: { [SESSION_ID]: [agent] },
+    resolverThreadOutcomes: {
+      [AGENT_ID]: {
+        [THREAD_OK]: { kind: 'wontfix', reason: 'skip', reply: null },
+        [THREAD_FAIL]: { kind: 'wontfix', reason: 'skip', reply: null },
+      },
+    },
+    sessionPendingResolutions: {},
+    sessionMounts: {},
+    sessionActiveMount: {},
+    sessionWorktrees: {},
+    sessionBranches: {},
+    emitNotification: vi.fn(async () => undefined),
+    refreshSessionPrDetail: vi.fn(async () => undefined),
+  };
+  const get = (() => state) as unknown as GetFn;
+  const set = ((update: unknown) => {
+    const patch =
+      typeof update === 'function'
+        ? (update as (s: State) => Partial<State>)(state)
+        : (update as Partial<State>);
+    Object.assign(state, patch);
+  }) as unknown as SetFn;
+  return { state, get, set };
+};
+
+const addReplyOk = JSON.stringify({
+  data: { addPullRequestReviewThreadReply: { comment: { id: 'c1', url: 'https://x' } } },
+});
+
+const defaultRunMock = async (args: ReadonlyArray<string>) => {
+  const joined = args.join(' ');
+  if (joined.includes('addPullRequestReviewThreadReply')) {
+    return { stdout: addReplyOk, stderr: '', exitCode: 0 };
+  }
+  if (joined.includes(`threadId=${THREAD_FAIL}`)) {
+    return { stdout: resolveThreadFailed, stderr: '', exitCode: 0 };
+  }
+  return { stdout: resolveThreadResponse(THREAD_OK), stderr: '', exitCode: 0 };
+};
+
+beforeEach(() => {
+  h.rows = [];
+  h.run.mockReset();
+  h.run.mockImplementation(defaultRunMock);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('resolveAgentThreads, write-ahead pending queue', () => {
+  it('deletes the row for a thread that closes on github but retains the row for one that fails', async () => {
+    const { get, set } = makeStore();
+
+    const ok = await resolveAgentThreads(set, get)(SESSION_ID, AGENT_ID);
+
+    expect(ok).toBe(false);
+    const remaining = h.rows.map((r) => r.threadId);
+    expect(remaining).toEqual([THREAD_FAIL]);
+  });
+
+  it('writes a thread row before its resolve mutation reaches github, so a mid-flight crash leaves it queued', async () => {
+    const { get, set } = makeStore();
+    let queuedAtFirstMutation: ReadonlyArray<string> = [];
+    h.run.mockImplementation(async (args) => {
+      const joined = args.join(' ');
+      if (joined.includes('resolveReviewThread') && queuedAtFirstMutation.length === 0) {
+        queuedAtFirstMutation = h.rows.map((r) => r.threadId);
+      }
+      return defaultRunMock(args);
+    });
+
+    await resolveAgentThreads(set, get)(SESSION_ID, AGENT_ID);
+
+    expect(queuedAtFirstMutation).toContain(THREAD_OK);
+  });
+});

--- a/apps/desktop/src/store/slices/github/resolveGithubThread.test.ts
+++ b/apps/desktop/src/store/slices/github/resolveGithubThread.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IsoDateTime, PendingResolution, SessionId, WorkspaceId } from '@goodboy/types';
+import type { GetFn, SetFn } from './types';
+
+type GhRun = (
+  args: ReadonlyArray<string>,
+  opts?: Readonly<Record<string, unknown>>,
+) => Promise<{ stdout: string; stderr: string; exitCode: number }>;
+
+const h = vi.hoisted(() => ({
+  rows: [] as PendingResolution[],
+  run: vi.fn<GhRun>(),
+}));
+
+vi.mock('@goodboy/db', () => ({
+  listPendingResolutionsForSession: vi.fn(async ({ sessionId }: { sessionId: SessionId }) =>
+    h.rows.filter((r) => r.sessionId === sessionId),
+  ),
+  queuePendingResolution: vi.fn(async (params: Record<string, unknown>) => {
+    h.rows.push({
+      id: params.id as string,
+      sessionId: params.sessionId as SessionId,
+      prNumber: params.prNumber as number,
+      threadId: params.threadId as string,
+      commitSha: params.commitSha as string,
+      reply: params.reply as string | null,
+      outcome: params.outcome as PendingResolution['outcome'],
+      replyPostedAt: null,
+      createdAt: NOW,
+    });
+  }),
+  deletePendingResolution: vi.fn(
+    async ({ sessionId, threadId }: { sessionId: SessionId; threadId: string }) => {
+      h.rows = h.rows.filter((r) => !(r.sessionId === sessionId && r.threadId === threadId));
+    },
+  ),
+  markPendingResolutionReplyPosted: vi.fn(async () => undefined),
+}));
+
+vi.mock('../../../shared/lib/db', () => ({ tauriDatabase: {} }));
+vi.mock('../../../features/github/github', () => ({ tauriGhRunner: { run: h.run } }));
+
+import { resolveGithubThread } from './resolveGithubThread';
+
+const NOW = '2026-08-05T00:00:00.000Z' as IsoDateTime;
+const SESSION_ID = 'sess-1' as SessionId;
+const WORKSPACE_ID = 'ws-1' as WorkspaceId;
+const THREAD_ID = 'PRRT_1';
+
+const resolveThreadOk = JSON.stringify({
+  data: { resolveReviewThread: { thread: { id: THREAD_ID, isResolved: true } } },
+});
+const resolveThreadFailed = JSON.stringify({ errors: [{ message: 'graphql boom' }] });
+
+type State = {
+  sessions: ReadonlyArray<{ id: SessionId; workspaceId: WorkspaceId }>;
+  workspaces: ReadonlyArray<{ id: WorkspaceId }>;
+  sessionGithub: Record<string, { pr: { number: number } | null }>;
+  sessionResolvedThreads: Record<string, ReadonlyArray<string>>;
+  resolverThreadOutcomes: Record<string, Record<string, unknown>>;
+  sessionPendingResolutions: Record<string, ReadonlyArray<PendingResolution>>;
+  sessionMounts: Record<string, ReadonlyArray<unknown>>;
+  sessionActiveMount: Record<string, string>;
+  sessionWorktrees: Record<string, ReadonlyArray<string>>;
+  sessionBranches: Record<string, string>;
+  emitNotification: ReturnType<typeof vi.fn>;
+  refreshSessionPrDetail: ReturnType<typeof vi.fn>;
+};
+
+const makeStore = () => {
+  const state: State = {
+    sessions: [{ id: SESSION_ID, workspaceId: WORKSPACE_ID }],
+    workspaces: [{ id: WORKSPACE_ID }],
+    sessionGithub: { [SESSION_ID]: { pr: { number: 42 } } },
+    sessionResolvedThreads: {},
+    resolverThreadOutcomes: {},
+    sessionPendingResolutions: {},
+    sessionMounts: {},
+    sessionActiveMount: {},
+    sessionWorktrees: {},
+    sessionBranches: {},
+    emitNotification: vi.fn(async () => undefined),
+    refreshSessionPrDetail: vi.fn(async () => undefined),
+  };
+  const get = (() => state) as unknown as GetFn;
+  const set = ((update: unknown) => {
+    const patch =
+      typeof update === 'function'
+        ? (update as (s: State) => Partial<State>)(state)
+        : (update as Partial<State>);
+    Object.assign(state, patch);
+  }) as unknown as SetFn;
+  return { state, get, set };
+};
+
+beforeEach(() => {
+  h.rows = [];
+  h.run.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('resolveGithubThread, write-ahead pending queue', () => {
+  it('queues the pending row before the resolve mutation reaches github', async () => {
+    let rowQueuedBeforeMutation = false;
+    h.run.mockImplementation(async (args) => {
+      if (args.join(' ').includes('resolveReviewThread')) {
+        rowQueuedBeforeMutation = h.rows.some((r) => r.threadId === THREAD_ID);
+        return { stdout: resolveThreadOk, stderr: '', exitCode: 0 };
+      }
+      return { stdout: '{}', stderr: '', exitCode: 0 };
+    });
+    const { get, set } = makeStore();
+
+    await resolveGithubThread(set, get)(SESSION_ID, THREAD_ID, {});
+
+    expect(rowQueuedBeforeMutation).toBe(true);
+  });
+
+  it('deletes the pending row once the thread resolves on github', async () => {
+    h.run.mockResolvedValue({ stdout: resolveThreadOk, stderr: '', exitCode: 0 });
+    const { get, set } = makeStore();
+
+    const ok = await resolveGithubThread(set, get)(SESSION_ID, THREAD_ID, {});
+
+    expect(ok).toBe(true);
+    expect(h.rows).toHaveLength(0);
+  });
+
+  it('keeps the pending row queued when the github call fails, so the retry strip can pick it up later', async () => {
+    h.run.mockResolvedValue({ stdout: resolveThreadFailed, stderr: '', exitCode: 0 });
+    const { get, set } = makeStore();
+
+    const ok = await resolveGithubThread(set, get)(SESSION_ID, THREAD_ID, {});
+
+    expect(ok).toBe(false);
+    expect(h.rows).toHaveLength(1);
+    expect(h.rows[0]?.threadId).toBe(THREAD_ID);
+  });
+});

--- a/apps/desktop/src/store/slices/sessions/index.test.ts
+++ b/apps/desktop/src/store/slices/sessions/index.test.ts
@@ -15,6 +15,7 @@ import type {
   PlanId,
   Message,
   MessageId,
+  PendingResolution,
   PlanWithCount,
   ProviderRunId,
   Session,
@@ -65,6 +66,9 @@ const listWorkspaceScriptsSpy = vi.fn(async () => [] as ReadonlyArray<WorkspaceS
 const upsertWorkspaceScriptSpy = vi.fn(async () => undefined);
 const deleteWorkspaceScriptSpy = vi.fn(async () => undefined);
 const deleteFileVersionsForSessionSpy = vi.fn(async () => undefined);
+const listPendingResolutionsForSessionSpy = vi.fn(
+  async () => [] as ReadonlyArray<PendingResolution>,
+);
 
 vi.mock('@goodboy/db', () => ({
   getSetting: dbGetSettingSpy,
@@ -151,6 +155,10 @@ vi.mock('@goodboy/db', () => ({
   getGithubPrCache: vi.fn(async () => null),
   upsertGithubPrCache: vi.fn(async () => undefined),
   deleteGithubPrCache: vi.fn(async () => undefined),
+  listPendingResolutionsForSession: listPendingResolutionsForSessionSpy,
+  queuePendingResolution: vi.fn(async () => undefined),
+  deletePendingResolution: vi.fn(async () => undefined),
+  markPendingResolutionReplyPosted: vi.fn(async () => undefined),
 }));
 
 vi.mock('../../../shared/lib/db', () => ({
@@ -451,6 +459,7 @@ describe('store contract', () => {
     listWorkspaceScriptsSpy.mockResolvedValue([]);
     listIntegrationsForWorkspaceSpy.mockResolvedValue([]);
     listDiffCommentsSpy.mockResolvedValue([]);
+    listPendingResolutionsForSessionSpy.mockResolvedValue([]);
     dbGetSettingSpy.mockResolvedValue(null);
     ghStatusSpy.mockResolvedValue({ available: true, mode: 'gh-cli', scopes: [] });
 
@@ -588,6 +597,29 @@ describe('store contract', () => {
         expect(store.getState().resolverThreadOutcomes[AGENT_ID]).toEqual({
           PRRT_1: { kind: 'resolved', commitSha: 'abcdef1234567890' },
         });
+      });
+    });
+
+    it('loads pending resolutions on activation, so a session landing on a lens other than Overview still sees the retry strip', async () => {
+      const store = await getStore();
+      store.setState({ sessionPendingResolutions: {} });
+      const pending: PendingResolution = {
+        id: 'pending-1',
+        sessionId: SESSION_ID,
+        prNumber: 7,
+        threadId: 'PRRT_2',
+        commitSha: '',
+        reply: null,
+        outcome: 'wontfix',
+        replyPostedAt: null,
+        createdAt: NOW,
+      };
+      listPendingResolutionsForSessionSpy.mockResolvedValue([pending]);
+
+      await store.getState().setCurrentSession(SESSION_ID);
+
+      await vi.waitFor(() => {
+        expect(store.getState().sessionPendingResolutions[SESSION_ID]).toEqual([pending]);
       });
     });
 

--- a/apps/desktop/src/store/slices/sessions/setCurrentSession.ts
+++ b/apps/desktop/src/store/slices/sessions/setCurrentSession.ts
@@ -224,6 +224,7 @@ export const setCurrentSession = (set: SetFn, get: GetFn) => {
           }));
           markDone('agents');
           void get().hydrateResolverOutcomes(id);
+          void get().loadPendingResolutions(id);
 
           if (!get().selectedAgentId[id]) {
             set((state) => ({


### PR DESCRIPTION
## What

Three changes, scoped tight to the item title.

**1. Wire `loadPendingResolutions` into session activation**

`setCurrentSession.ts` fetches session agents on the non-cached path and, once
they land, calls `hydrateResolverOutcomes(id)` to rebuild resolver verdicts.
`loadPendingResolutions` was never called from anywhere except two component
mount effects (`PendingResolutionsStrip.tsx:14`, `SessionOverviewPane/index.tsx:62`),
both of which only render on the Overview lens. A session that landed on Diff,
Chat, or Agents after a restart never fetched `sessionPendingResolutions`, so
the "Push & resolve N comments" retry strip (which only renders when
`pending.length > 0`) stayed invisible even though the row was sitting in the
`pending_resolutions` table.

Fix: added `void get().loadPendingResolutions(id);` right next to the
`hydrateResolverOutcomes` call in `setCurrentSession.ts:227`, same fire-and-forget
style (`void`, no await, no extra error handling since `loadPendingResolutions`
already has its own try/finally).

**Left the two component mount effects in place, deliberately.** `loadPendingResolutions`
(`store/slices/github/loadPendingResolutions.ts`) already guards itself on two
axes: it no-ops if `sessionPendingResolutions[sessionId] !== undefined` (already
loaded) and it no-ops if `pendingResolutionReadsInFlight.has(sessionId)` (a read
is already in flight for that session). That makes every caller idempotent by
construction, so keeping the strip's own effect costs nothing and keeps the strip
self-sufficient for cases where it mounts without going through `setCurrentSession`
(e.g. a resolver-lane toolbar re-rendering after `sessionPendingResolutions` was
cleared for some other reason). Removing them would just make the strip more
fragile for a call that's already free.

**2. Missing co-located tests for the write-ahead pending queue**

`resolveGithubThread.ts` and `resolveAgentThreads.ts` had zero tests despite
being the only two places that queue and delete `pending_resolutions` rows.
Added:

- `store/slices/github/resolveGithubThread.test.ts` (3 tests): the row is queued
  before the resolve mutation reaches github, deleted once the thread resolves,
  and retained when the github call fails (this last one is the actual crash-safety
  contract: a killed process between queue and github call leaves the row for a
  restart to pick up).
- `store/slices/github/resolveAgentThreads.test.ts` (2 tests): across two threads
  handled in the same call, the one that fails on github keeps its row while the
  one that succeeds gets deleted; and a thread's row exists in the DB before its
  own resolve mutation is attempted (captured mid-flight via the mocked `gh` runner).
- `store/slices/github/loadPendingResolutions.test.ts` (2 tests): the loader reads
  the DB once even when two callers race for the same session (the in-flight guard),
  and skips the read entirely once a session already has a loaded row (the
  already-loaded guard). This is the direct unit-level proof for the idempotence
  claim above.

**3. Catch on `activateNextResolver`'s kickoff turn**

`activateNextResolver.ts:42-48` had `void get().sendTurn(...).finally(...)` with a
`finally` but no `catch`. `finally` doesn't swallow a rejection, so a failed
resolver kickoff (provider unreachable, turn rejected, etc.) was an unhandled
promise rejection, silent to the user. Added `.catch()` before `.finally()` that
calls `get().emitNotification('error', 'error', 'resolver failed to start', formatError(error), { sessionId })`,
matching the pattern already used at `resolveGithubThread.ts` and the reference
call at `SessionOverviewPane/PipelineSection.tsx:83-85`. Added a rejection-path
test to `activateNextResolver.test.ts` asserting the exact notification call.

## End-to-end path traced

`setCurrentSession(id)` (session activation) → non-cached agents branch resolves
→ `void get().loadPendingResolutions(id)` → `loadPendingResolutions` reads
`listPendingResolutionsForSession` and does `set({ sessionPendingResolutions: { ...state.sessionPendingResolutions, [id]: rows } })`
→ `PendingResolutionsStrip` selects `s.sessionPendingResolutions[sessionId] ?? EMPTY_ARRAY`
→ `if (count === 0) return null;` else renders the "Push & resolve N comments" button.
Walked this by reading every file in the chain (`setCurrentSession.ts`,
`loadPendingResolutions.ts`, `PendingResolutionsStrip.tsx`, `types.ts` for the
store key), not just grepping for the symbol name.

## Idempotence argument

`loadPendingResolutions` has two independent guards: `sessionPendingResolutions[sessionId] !== undefined`
(already loaded) and `pendingResolutionReadsInFlight.has(sessionId)` (in flight).
Whichever caller (session activation or a strip's mount effect) runs first wins
the DB read; the other one is a no-op by one of the two guards, so the state
update only ever happens once, `sessionPendingResolutions[sessionId]` is set
exactly once per load cycle, and the strip renders one row per pending resolution,
never duplicated. `loadPendingResolutions.test.ts`'s first test proves this
directly: two concurrent calls for the same session, `listPendingResolutionsForSession`
asserted to have been called exactly once.

## Revert-check on the new tests

- `resolveGithubThread.test.ts` / `resolveAgentThreads.test.ts`: these test
  existing, unmodified code (the write-ahead queue predates this PR). Checked by
  reasoning through the assertions against the actual control flow: if
  `deletePendingResolution` were called unconditionally (not gated on the github
  call succeeding), the "retains the row on failure" test fails. If the row were
  written after the github call instead of before, the "writes before the mutation"
  test fails (the mocked runner captures `h.rows` state synchronously at call time).
  Both are real, falsifiable assertions, not tautologies.
- `loadPendingResolutions.test.ts`: if either guard in `loadPendingResolutions.ts`
  were removed, the "reads once when two callers race" test fails
  (`toHaveBeenCalledTimes(1)` would become 2).
- `sessions/index.test.ts` new test ("loads pending resolutions on activation..."):
  directly exercises only `setCurrentSession`, no direct call to
  `loadPendingResolutions`. Reverting the one-line wiring in `setCurrentSession.ts`
  makes this test fail, since nothing else would populate `sessionPendingResolutions`
  for that session. This is the test that actually pins item 1's fix.
- `activateNextResolver.test.ts` new test: reverting the `.catch()` means
  `emitNotification` is never called, so the assertion fails (and the test run
  would also surface the unhandled rejection the fix eliminates).

## Explicitly out of scope

- No migration touched, m105 stays free.
- No `agent_id` column on `pending_resolutions`.
- `pending_resolutions` is left as a transient write-ahead push queue, not turned
  into a durable verdict source. `hydrateResolverOutcomes`'s message-replay is the
  durable source for completed verdicts (see `hydrateResolverOutcomes.test.ts:103-125`).
  `hydrateResolverOutcomes.ts` itself is untouched.
- `App.tsx`, `workSurface.ts`, and workflow-gate files are untouched.

## Verification

- `pnpm typecheck`: all 5 packages pass (`@goodboy/types`, `@goodboy/ui`, `@goodboy/db`, `@goodboy/core`, `@goodboy/desktop`).
- `pnpm test`: 512 test files, 4447 tests, all passing.
- `pnpm knip --include files,duplicates,unlisted`: clean, only pre-existing
  `knip.json` configuration hints (unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
