### PR TITLE
fix(desktop): surface workflow gate failures and show the routing that runs

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -53,6 +53,7 @@ import { useShortcut } from './shared/keyboard/useShortcut';
 import { useProviderRefreshOnFocus } from './shared/hooks/useProviderRefreshOnFocus';
 import { useZoomShortcuts } from './shared/hooks/useZoomShortcuts';
 import { useCommitLinkInterceptor } from './shared/hooks/useCommitLinkInterceptor';
+import { useUnhandledRejectionNotice } from './shared/hooks/useUnhandledRejectionNotice';
 import { isBranchlessSession } from './shared/utils/isBranchlessSession';
 import {
   useAppStore,
@@ -176,6 +177,7 @@ export const App = () => {
   useUpdaterPolling();
   useWindowPresence();
   useZoomShortcuts();
+  useUnhandledRejectionNotice();
 
   useEffect(() => {
     const onOpenSettings = (event: Event) => {

--- a/apps/desktop/src/features/context/openQuestionsGate.test.ts
+++ b/apps/desktop/src/features/context/openQuestionsGate.test.ts
@@ -5,13 +5,16 @@ import type {
   OpenQuestionId,
   SessionId,
   WorkflowId,
+  WorkflowRunId,
 } from '@goodboy/types';
-import { hasOrphanOpenQuestions, workflowHasOpenQuestions } from './openQuestionsGate';
+import { workflowHasOpenQuestions, workflowRunHasOpenQuestions } from './openQuestionsGate';
 
 const NOW = '2026-05-26T00:00:00.000Z' as IsoDateTime;
 const SESSION = 'sess_1' as SessionId;
 const WF_A = 'wf_a' as WorkflowId;
 const WF_B = 'wf_b' as WorkflowId;
+const RUN_A = 'run_a' as WorkflowRunId;
+const RUN_B = 'run_b' as WorkflowRunId;
 
 function q(id: string, opts: Partial<OpenQuestion> = {}): OpenQuestion {
   return {
@@ -53,16 +56,25 @@ describe('workflowHasOpenQuestions', () => {
   });
 });
 
-describe('hasOrphanOpenQuestions', () => {
-  it('detects an orphan question', () => {
-    expect(hasOrphanOpenQuestions([q('q1')])).toBe(true);
+describe('workflowRunHasOpenQuestions', () => {
+  it('returns true when the run has an open question of its own', () => {
+    expect(workflowRunHasOpenQuestions([q('q1', { workflowRunId: RUN_A })], RUN_A)).toBe(true);
   });
 
-  it('rejects questions tied to any workflow', () => {
-    expect(hasOrphanOpenQuestions([q('q1', { workflowId: WF_A })])).toBe(false);
+  it('returns false when only ANOTHER run has open questions', () => {
+    expect(workflowRunHasOpenQuestions([q('q1', { workflowRunId: RUN_B })], RUN_A)).toBe(false);
   });
 
-  it('ignores answered orphans', () => {
-    expect(hasOrphanOpenQuestions([q('q1', { status: 'answered' })])).toBe(false);
+  it('lets an orphan question from a free agent through instead of halting every run', () => {
+    expect(workflowRunHasOpenQuestions([q('q1')], RUN_A)).toBe(false);
+    expect(workflowRunHasOpenQuestions([q('q1')], RUN_B)).toBe(false);
+  });
+
+  it('ignores answered and dismissed questions of its own run', () => {
+    const qs = [
+      q('q1', { workflowRunId: RUN_A, status: 'answered' }),
+      q('q2', { workflowRunId: RUN_A, status: 'dismissed' }),
+    ];
+    expect(workflowRunHasOpenQuestions(qs, RUN_A)).toBe(false);
   });
 });

--- a/apps/desktop/src/features/context/openQuestionsGate.ts
+++ b/apps/desktop/src/features/context/openQuestionsGate.ts
@@ -23,13 +23,9 @@ export const workflowRunHasOpenQuestions = (
     if (q.status !== 'open') {
       continue;
     }
-    if (!q.workflowRunId || q.workflowRunId === workflowRunId) {
+    if (q.workflowRunId === workflowRunId) {
       return true;
     }
   }
   return false;
-};
-
-export const hasOrphanOpenQuestions = (questions: ReadonlyArray<OpenQuestion>): boolean => {
-  return questions.some((q) => q.status === 'open' && !q.workflowId);
 };

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/PipelineLane.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/PipelineLane.tsx
@@ -2,7 +2,7 @@ import { ArrowRight } from 'lucide-react';
 import { Chip } from '@goodboy/ui';
 import { CONCEPT_ICONS } from '../../../../shared/components/conceptIcons';
 import type { RunLaneModel } from '../../../orchestration/hooks/useWorkspaceRuns';
-import { pickNextWorkflowStep } from '../../../workflows/components/WorkflowNextStepCta';
+import { pickNextWorkflowStep } from '../../../workflows/pickNextWorkflowStep';
 import type { LaneAdvance } from './LaneAdvance';
 import { StepBadge } from './StepBadge';
 

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/ChatWorkflowAdvance.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/ChatWorkflowAdvance.test.tsx
@@ -1,11 +1,13 @@
 // @vitest-environment happy-dom
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { getModelDescriptor } from '@goodboy/core';
 import type {
   Agent,
   AgentId,
   IsoDateTime,
+  ProviderId,
   SessionId,
   StepId,
   Workflow,
@@ -24,8 +26,12 @@ type Store = {
   agentTurnState: Record<string, { kind: string }>;
   summarizerStatus: Record<string, { status: string }>;
   sessions: ReadonlyArray<StoreSession>;
+  agentModelOverride: Record<string, string>;
+  agentProviderOverride: Record<string, ProviderId>;
+  agentEffortOverride: Record<string, string>;
   activateWorkflowAgent: ReturnType<typeof vi.fn>;
   skipStuckStepAndAdvance: ReturnType<typeof vi.fn>;
+  emitNotification: ReturnType<typeof vi.fn>;
 };
 
 const { store, gate } = vi.hoisted(() => ({
@@ -34,8 +40,12 @@ const { store, gate } = vi.hoisted(() => ({
     agentTurnState: {},
     summarizerStatus: {},
     sessions: [],
+    agentModelOverride: {},
+    agentProviderOverride: {},
+    agentEffortOverride: {},
     activateWorkflowAgent: vi.fn(async () => undefined),
     skipStuckStepAndAdvance: vi.fn(async () => undefined),
+    emitNotification: vi.fn(async () => undefined),
   } as Store,
   gate: { hasOpenQuestions: false },
 }));
@@ -51,11 +61,13 @@ vi.mock('../../../../context/openQuestionsGate', () => ({
 }));
 
 import { ChatWorkflowAdvance } from './ChatWorkflowAdvance';
+import { WorkflowGateError } from '../../../../../store/slices/workflows/workflowActivationGate';
 
 const SESSION_ID = 'session-1' as SessionId;
 const WORKFLOW_ID = 'workflow-1' as WorkflowId;
 const RUN_ID = 'run-1' as WorkflowRunId;
 const NOW = '2026-07-25T00:00:00.000Z' as IsoDateTime;
+const FROZEN_MODEL = 'opus-5';
 
 const workflow: Workflow = {
   id: WORKFLOW_ID,
@@ -98,8 +110,14 @@ beforeEach(() => {
   store.agentTurnState = {};
   store.summarizerStatus = {};
   store.sessions = withAutoRun(false);
+  store.agentModelOverride = {};
+  store.agentProviderOverride = {};
+  store.agentEffortOverride = {};
   store.activateWorkflowAgent.mockReset();
+  store.activateWorkflowAgent.mockResolvedValue(undefined);
   store.skipStuckStepAndAdvance.mockReset();
+  store.emitNotification.mockReset();
+  store.emitNotification.mockResolvedValue(undefined);
   gate.hasOpenQuestions = false;
 });
 
@@ -176,6 +194,46 @@ describe('ChatWorkflowAdvance', () => {
     renderStrip();
 
     expect(screen.getByTestId('workflow-force-next-step-cta')).toBeDefined();
+  });
+
+  it('names the blocker and frees the button when the engine rejects the advance', async () => {
+    store.sessionPhaseRuns = { [SESSION_ID]: [agent(0, 'completed'), agent(1, 'pending')] };
+    store.activateWorkflowAgent.mockRejectedValue(new WorkflowGateError({ reason: 'questions' }));
+    renderStrip();
+
+    fireEvent.click(screen.getByTestId('workflow-next-step-cta'));
+
+    await waitFor(() => expect(store.emitNotification).toHaveBeenCalledTimes(1));
+    expect(store.emitNotification).toHaveBeenCalledWith(
+      'error',
+      'warning',
+      'workflow step held back',
+      'Open questions are waiting for an answer.',
+      { sessionId: SESSION_ID },
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId('workflow-next-step-cta').hasAttribute('disabled')).toBe(false),
+    );
+  });
+
+  it('shows the routing frozen on the pending agent, not the one preferences resolve today', () => {
+    store.sessionPhaseRuns = { [SESSION_ID]: [agent(0, 'completed'), agent(1, 'pending')] };
+    const withoutOverride = render(
+      <ChatWorkflowAdvance sessionId={SESSION_ID} workflowRunId={RUN_ID} workflow={workflow} />,
+    );
+    const defaultLabel = withoutOverride
+      .getByTestId('workflow-next-step-cta')
+      .getAttribute('aria-label');
+    withoutOverride.unmount();
+
+    store.agentModelOverride = { 'agent-1': FROZEN_MODEL };
+    store.agentEffortOverride = { 'agent-1': 'xhigh' };
+    renderStrip();
+
+    const label = screen.getByTestId('workflow-next-step-cta').getAttribute('aria-label');
+    expect(label).toContain(getModelDescriptor(FROZEN_MODEL)?.label ?? FROZEN_MODEL);
+    expect(label).toContain('xhigh effort');
+    expect(label).not.toBe(defaultLabel);
   });
 
   it('renders nothing once every step is done', () => {

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/ChatWorkflowAdvance.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/ChatWorkflowAdvance.tsx
@@ -2,7 +2,9 @@ import { useMemo } from 'react';
 import type { Agent, SessionId, Step, Workflow, WorkflowRunId } from '@goodboy/types';
 import { runsForWorkflowRun } from '@goodboy/core';
 import { EMPTY_ARRAY, useAppStore, useSessionOpenQuestions } from '../../../../../store';
+import { notifyWorkflowGateBlock } from '../../../../../store/slices/workflows/notifyWorkflowGateBlock';
 import { workflowRunHasOpenQuestions } from '../../../../context/openQuestionsGate';
+import { agentRoutingOverrides } from '../../../../workflows/agentRoutingOverrides';
 import { resolveWorkflowAdvance } from '../../../../workflows/advanceGate';
 import { WorkflowNextStepCta } from '../../../../workflows/components/WorkflowNextStepCta';
 import { useSessionRoleModels } from '../../../../../shared/hooks/useSessionRoleModels';
@@ -35,6 +37,7 @@ export const ChatWorkflowAdvance = ({ sessionId, workflowRunId, workflow }: Prop
   const roleModels = useSessionRoleModels({ sessionId });
   const activateWorkflowAgent = useAppStore((state) => state.activateWorkflowAgent);
   const skipStuckStepAndAdvance = useAppStore((state) => state.skipStuckStepAndAdvance);
+  const emitNotification = useAppStore((state) => state.emitNotification);
 
   const stepAgents = useMemo(
     () =>
@@ -59,6 +62,24 @@ export const ChatWorkflowAdvance = ({ sessionId, workflowRunId, workflow }: Prop
     isTurnRunning,
     isAutoRun,
   });
+  const nextStepId = state.kind === 'complete' ? null : state.step.id;
+  const pendingAgent =
+    stepAgents.find((agent) => agent.stepId === nextStepId && agent.status === 'pending') ?? null;
+  const modelOverride = useAppStore((store) =>
+    pendingAgent != null ? (store.agentModelOverride[pendingAgent.id] ?? null) : null,
+  );
+  const providerOverride = useAppStore((store) =>
+    pendingAgent != null ? (store.agentProviderOverride[pendingAgent.id] ?? null) : null,
+  );
+  const effortOverride = useAppStore((store) =>
+    pendingAgent != null ? (store.agentEffortOverride[pendingAgent.id] ?? null) : null,
+  );
+  const routing = agentRoutingOverrides({
+    agent: pendingAgent,
+    modelOverride,
+    providerOverride,
+    effortOverride,
+  });
   if (state.kind === 'complete' || state.kind === 'automatic') {
     return null;
   }
@@ -70,12 +91,16 @@ export const ChatWorkflowAdvance = ({ sessionId, workflowRunId, workflow }: Prop
     if (pending == null) {
       return;
     }
-    await activateWorkflowAgent({
-      sessionId,
-      agentId: pending.id,
-      focus: 'agent',
-      bypassGate: isConfirmed,
-    });
+    try {
+      await activateWorkflowAgent({
+        sessionId,
+        agentId: pending.id,
+        focus: 'agent',
+        bypassGate: isConfirmed,
+      });
+    } catch (error) {
+      notifyWorkflowGateBlock({ error, sessionId, emitNotification });
+    }
   };
 
   return (
@@ -83,6 +108,9 @@ export const ChatWorkflowAdvance = ({ sessionId, workflowRunId, workflow }: Prop
       workflow={workflow}
       runs={stepAgents}
       roleModels={roleModels}
+      agentModel={routing.agentModel}
+      agentProvider={routing.agentProvider}
+      agentEffort={routing.agentEffort}
       blockReason={state.kind === 'blocked' ? state.reason : null}
       onAdvance={({ step, isConfirmed }) => void onAdvance({ step, isConfirmed })}
       onForceAdvance={() =>

--- a/apps/desktop/src/features/workflows/agentRoutingOverrides.ts
+++ b/apps/desktop/src/features/workflows/agentRoutingOverrides.ts
@@ -1,0 +1,27 @@
+import type { Agent, ModelEffort, ProviderId } from '@goodboy/types';
+import { EFFORT_LEVELS } from '../chat/utils/chat-constants';
+
+type Params = {
+  readonly agent: Agent | null;
+  readonly modelOverride: string | null;
+  readonly providerOverride: ProviderId | null;
+  readonly effortOverride: string | null;
+};
+
+export const agentRoutingOverrides = ({
+  agent,
+  modelOverride,
+  providerOverride,
+  effortOverride,
+}: Params): {
+  readonly agentModel: string | null;
+  readonly agentProvider: ProviderId | null;
+  readonly agentEffort: ModelEffort | null;
+} => {
+  const effort = effortOverride ?? agent?.effort ?? null;
+  return {
+    agentModel: modelOverride ?? agent?.modelOverride ?? null,
+    agentProvider: providerOverride ?? agent?.providerOverride ?? null,
+    agentEffort: EFFORT_LEVELS.find((level) => level === effort) ?? null,
+  };
+};

--- a/apps/desktop/src/features/workflows/components/WorkflowNextStepCta/index.test.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowNextStepCta/index.test.tsx
@@ -14,7 +14,7 @@ import type {
   WorkflowRunId,
   WorkspaceId,
 } from '@goodboy/types';
-import { WorkflowNextStepCta, pickNextWorkflowStep } from './index';
+import { WorkflowNextStepCta } from './index';
 
 afterEach(cleanup);
 
@@ -54,59 +54,6 @@ function preCreated(...statuses: Agent['status'][]): Agent[] {
   const stepIds = ['s1', 's2', 's3'] as const;
   return statuses.map((status, i) => run(stepIds[i] as StepId, status, i));
 }
-
-describe('pickNextWorkflowStep', () => {
-  it('returns first step when all pre-created agents are pending', () => {
-    expect(pickNextWorkflowStep(wf(), preCreated('pending', 'pending', 'pending'))?.id).toBe('s1');
-  });
-
-  it('returns null while current step is running', () => {
-    expect(pickNextWorkflowStep(wf(), preCreated('running', 'pending', 'pending'))).toBeNull();
-  });
-
-  it('advances to next step once previous one is completed', () => {
-    expect(pickNextWorkflowStep(wf(), preCreated('completed', 'pending', 'pending'))?.id).toBe(
-      's2',
-    );
-  });
-
-  it('skips ahead past multiple completed steps to the next pending one', () => {
-    expect(pickNextWorkflowStep(wf(), preCreated('completed', 'completed', 'pending'))?.id).toBe(
-      's3',
-    );
-  });
-
-  it('returns null when all steps are completed', () => {
-    expect(
-      pickNextWorkflowStep(wf(), preCreated('completed', 'completed', 'completed')),
-    ).toBeNull();
-  });
-
-  it('returns null when an earlier step failed (cannot advance over failure)', () => {
-    expect(pickNextWorkflowStep(wf(), preCreated('failed', 'pending', 'pending'))).toBeNull();
-  });
-
-  it('treats skipped steps as done for advancement', () => {
-    expect(pickNextWorkflowStep(wf(), preCreated('skipped', 'pending', 'pending'))?.id).toBe('s2');
-  });
-
-  it('returns null when open questions are pending, even if otherwise actionable', () => {
-    const runs = preCreated('completed', 'pending', 'pending');
-    expect(pickNextWorkflowStep(wf(), runs, { hasOpenQuestions: true })).toBeNull();
-  });
-
-  it('returns null while summarizer is busy', () => {
-    const runs = preCreated('completed', 'pending', 'pending');
-    expect(pickNextWorkflowStep(wf(), runs, { summarizerBusy: true })).toBeNull();
-  });
-
-  it('allows advancement when gate flags are explicitly false', () => {
-    const runs = preCreated('completed', 'pending', 'pending');
-    expect(
-      pickNextWorkflowStep(wf(), runs, { hasOpenQuestions: false, summarizerBusy: false })?.id,
-    ).toBe('s2');
-  });
-});
 
 describe('WorkflowNextStepCta', () => {
   const ctaRuns: Agent[] = [run('s1' as StepId, 'pending', 0), run('s2' as StepId, 'pending', 1)];

--- a/apps/desktop/src/features/workflows/components/WorkflowNextStepCta/index.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowNextStepCta/index.tsx
@@ -2,7 +2,14 @@ import { useMemo, useState } from 'react';
 import { AlertTriangle, Play } from 'lucide-react';
 import { InlineConfirm, cn } from '@goodboy/ui';
 import { classifyWorkflowChain, getModelDescriptor } from '@goodboy/core';
-import type { Agent, RoleModelPreferences, Step, Workflow } from '@goodboy/types';
+import type {
+  Agent,
+  ModelEffort,
+  ProviderId,
+  RoleModelPreferences,
+  Step,
+  Workflow,
+} from '@goodboy/types';
 import type { VerbosityLevel } from '../../../../features/settings/verbosity';
 import { inferAgentKindFromName } from '../../../../features/session/agent-kind';
 import { resolveStepRouting } from '../../resolveStepRouting';
@@ -28,37 +35,9 @@ export type Props = {
   readonly consumesActivePlan?: boolean;
   readonly className?: string;
   readonly roleModels?: RoleModelPreferences | null;
-};
-
-export type PickNextWorkflowStepGate = {
-  readonly hasOpenQuestions?: boolean;
-  readonly summarizerBusy?: boolean;
-};
-
-export const pickNextWorkflowStep = (
-  workflow: Workflow,
-  runs: ReadonlyArray<Agent>,
-  gate?: PickNextWorkflowStepGate,
-): Step | null => {
-  if (gate?.hasOpenQuestions || gate?.summarizerBusy) {
-    return null;
-  }
-  const sorted = [...workflow.steps].sort((a, b) => a.ordinal - b.ordinal);
-  for (const step of sorted) {
-    const agent = runs.find((r) => r.stepId === step.id);
-    if (!agent || agent.status !== 'pending') {
-      continue;
-    }
-    const prevSteps = sorted.filter((s) => s.ordinal < step.ordinal);
-    const allDone = prevSteps.every((s) =>
-      runs.some((r) => r.stepId === s.id && (r.status === 'completed' || r.status === 'skipped')),
-    );
-    if (allDone) {
-      return step;
-    }
-    return null;
-  }
-  return null;
+  readonly agentModel?: string | null;
+  readonly agentProvider?: ProviderId | null;
+  readonly agentEffort?: ModelEffort | null;
 };
 
 export const WorkflowNextStepCta = ({
@@ -70,13 +49,23 @@ export const WorkflowNextStepCta = ({
   consumesActivePlan = false,
   className,
   roleModels = null,
+  agentModel = null,
+  agentProvider = null,
+  agentEffort = null,
 }: Props) => {
   const [busy, setBusy] = useState(false);
   const [pendingForce, setPendingForce] = useState(false);
   const chain = useMemo(() => classifyWorkflowChain(workflow, runs), [workflow, runs]);
   const next = chain.kind === 'step' ? chain.step : null;
   const kind = useMemo(() => (next ? inferAgentKindFromName(next.name) : 'generic'), [next]);
-  const routing = resolveStepRouting({ step: next, kind, roleModels });
+  const routing = resolveStepRouting({
+    step: next,
+    kind,
+    roleModels,
+    agentModel,
+    agentProvider,
+    agentEffort,
+  });
   const advance = useStartAnywayConfirm({
     blockReason,
     onStart: async ({ isConfirmed }) => {

--- a/apps/desktop/src/features/workflows/pickNextWorkflowStep.test.ts
+++ b/apps/desktop/src/features/workflows/pickNextWorkflowStep.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  Agent,
+  AgentId,
+  IsoDateTime,
+  SessionId,
+  StepId,
+  Workflow,
+  WorkflowId,
+  WorkspaceId,
+} from '@goodboy/types';
+import { pickNextWorkflowStep } from './pickNextWorkflowStep';
+
+const WS_ID = 'ws-1' as WorkspaceId;
+const SESSION_ID = 't-1' as SessionId;
+const WF_ID = 'wf' as WorkflowId;
+const NOW = '2026-05-10T00:00:00.000Z' as IsoDateTime;
+
+const wf = (): Workflow => ({
+  id: WF_ID,
+  workspaceId: WS_ID,
+  name: 'Refactor',
+  description: '',
+  steps: [
+    { id: 's1' as StepId, workflowId: WF_ID, ordinal: 0, name: 'Scout', promptPrefix: '' },
+    { id: 's2' as StepId, workflowId: WF_ID, ordinal: 1, name: 'Plan', promptPrefix: '' },
+    { id: 's3' as StepId, workflowId: WF_ID, ordinal: 2, name: 'Refactor', promptPrefix: '' },
+  ],
+  createdAt: NOW,
+  updatedAt: NOW,
+});
+
+const run = (stepId: StepId, status: Agent['status'], idx = 0): Agent => ({
+  id: `r-${idx}` as AgentId,
+  sessionId: SESSION_ID,
+  stepId,
+  ordinal: idx,
+  name: stepId,
+  status,
+});
+
+const preCreated = (...statuses: Agent['status'][]): Agent[] => {
+  const stepIds = ['s1', 's2', 's3'] as const;
+  return statuses.map((status, i) => run(stepIds[i] as StepId, status, i));
+};
+
+describe('pickNextWorkflowStep', () => {
+  it('returns first step when all pre-created agents are pending', () => {
+    expect(pickNextWorkflowStep(wf(), preCreated('pending', 'pending', 'pending'))?.id).toBe('s1');
+  });
+
+  it('returns null while current step is running', () => {
+    expect(pickNextWorkflowStep(wf(), preCreated('running', 'pending', 'pending'))).toBeNull();
+  });
+
+  it('advances to next step once previous one is completed', () => {
+    expect(pickNextWorkflowStep(wf(), preCreated('completed', 'pending', 'pending'))?.id).toBe(
+      's2',
+    );
+  });
+
+  it('skips ahead past multiple completed steps to the next pending one', () => {
+    expect(pickNextWorkflowStep(wf(), preCreated('completed', 'completed', 'pending'))?.id).toBe(
+      's3',
+    );
+  });
+
+  it('returns null when all steps are completed', () => {
+    expect(
+      pickNextWorkflowStep(wf(), preCreated('completed', 'completed', 'completed')),
+    ).toBeNull();
+  });
+
+  it('returns null when an earlier step failed (cannot advance over failure)', () => {
+    expect(pickNextWorkflowStep(wf(), preCreated('failed', 'pending', 'pending'))).toBeNull();
+  });
+
+  it('treats skipped steps as done for advancement', () => {
+    expect(pickNextWorkflowStep(wf(), preCreated('skipped', 'pending', 'pending'))?.id).toBe('s2');
+  });
+
+  it('returns null when open questions are pending, even if otherwise actionable', () => {
+    const runs = preCreated('completed', 'pending', 'pending');
+    expect(pickNextWorkflowStep(wf(), runs, { hasOpenQuestions: true })).toBeNull();
+  });
+
+  it('returns null while summarizer is busy', () => {
+    const runs = preCreated('completed', 'pending', 'pending');
+    expect(pickNextWorkflowStep(wf(), runs, { summarizerBusy: true })).toBeNull();
+  });
+
+  it('allows advancement when gate flags are explicitly false', () => {
+    const runs = preCreated('completed', 'pending', 'pending');
+    expect(
+      pickNextWorkflowStep(wf(), runs, { hasOpenQuestions: false, summarizerBusy: false })?.id,
+    ).toBe('s2');
+  });
+});

--- a/apps/desktop/src/features/workflows/pickNextWorkflowStep.ts
+++ b/apps/desktop/src/features/workflows/pickNextWorkflowStep.ts
@@ -1,0 +1,32 @@
+import type { Agent, Step, Workflow } from '@goodboy/types';
+
+type Gate = {
+  readonly hasOpenQuestions?: boolean;
+  readonly summarizerBusy?: boolean;
+};
+
+export const pickNextWorkflowStep = (
+  workflow: Workflow,
+  runs: ReadonlyArray<Agent>,
+  gate?: Gate,
+): Step | null => {
+  if (gate?.hasOpenQuestions || gate?.summarizerBusy) {
+    return null;
+  }
+  const sorted = [...workflow.steps].sort((a, b) => a.ordinal - b.ordinal);
+  for (const step of sorted) {
+    const agent = runs.find((r) => r.stepId === step.id);
+    if (!agent || agent.status !== 'pending') {
+      continue;
+    }
+    const prevSteps = sorted.filter((s) => s.ordinal < step.ordinal);
+    const allDone = prevSteps.every((s) =>
+      runs.some((r) => r.stepId === s.id && (r.status === 'completed' || r.status === 'skipped')),
+    );
+    if (allDone) {
+      return step;
+    }
+    return null;
+  }
+  return null;
+};

--- a/apps/desktop/src/features/workflows/useStartAnywayConfirm/index.test.ts
+++ b/apps/desktop/src/features/workflows/useStartAnywayConfirm/index.test.ts
@@ -1,0 +1,61 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
+
+const { state } = vi.hoisted(() => ({
+  state: { emitNotification: vi.fn(async () => undefined) },
+}));
+
+vi.mock('../../../store', () => ({
+  useAppStore: <T>(selector: (s: typeof state) => T) => selector(state),
+}));
+
+import { useStartAnywayConfirm } from './index';
+
+afterEach(() => {
+  cleanup();
+  state.emitNotification.mockClear();
+});
+
+describe('useStartAnywayConfirm', () => {
+  it('names the failure and frees the control when the start rejects', async () => {
+    const onStart = vi.fn(async () => {
+      throw new Error('open questions are waiting for an answer');
+    });
+    const { result } = renderHook(() => useStartAnywayConfirm({ blockReason: null, onStart }));
+
+    act(() => result.current.onTrigger());
+
+    await waitFor(() => expect(state.emitNotification).toHaveBeenCalledTimes(1));
+    expect(state.emitNotification).toHaveBeenCalledWith(
+      'error',
+      'warning',
+      'the next step did not start',
+      'open questions are waiting for an answer',
+    );
+    expect(result.current.isBusy).toBe(false);
+  });
+
+  it('stays silent when the start resolves', async () => {
+    const onStart = vi.fn(async () => undefined);
+    const { result } = renderHook(() => useStartAnywayConfirm({ blockReason: null, onStart }));
+
+    act(() => result.current.onTrigger());
+
+    await waitFor(() => expect(onStart).toHaveBeenCalledWith({ isConfirmed: false }));
+    expect(state.emitNotification).not.toHaveBeenCalled();
+  });
+
+  it('arms the confirmation instead of starting while a blocker stands', () => {
+    const onStart = vi.fn(async () => undefined);
+    const { result } = renderHook(() =>
+      useStartAnywayConfirm({ blockReason: 'questions', onStart }),
+    );
+
+    act(() => result.current.onTrigger());
+
+    expect(onStart).not.toHaveBeenCalled();
+    expect(result.current.isConfirming).toBe(true);
+  });
+});

--- a/apps/desktop/src/features/workflows/useStartAnywayConfirm/index.ts
+++ b/apps/desktop/src/features/workflows/useStartAnywayConfirm/index.ts
@@ -1,4 +1,6 @@
 import { useState } from 'react';
+import { useAppStore } from '../../../store';
+import { formatError } from '../../../shared/lib/errors';
 import type { WorkflowBlockReason } from '../advanceGate';
 import { WORKFLOW_BLOCK_COPY } from '../blockCopy';
 
@@ -19,6 +21,7 @@ export const useStartAnywayConfirm = ({
 }: Params) => {
   const [isBusy, setIsBusy] = useState(false);
   const [isArmed, setIsArmed] = useState(false);
+  const emitNotification = useAppStore((state) => state.emitNotification);
 
   const start = async ({ isConfirmed }: StartParams) => {
     if (isBusy) {
@@ -28,6 +31,13 @@ export const useStartAnywayConfirm = ({
     setIsArmed(false);
     try {
       await onStart({ isConfirmed });
+    } catch (error) {
+      void emitNotification(
+        'error',
+        'warning',
+        'the next step did not start',
+        formatError(error),
+      ).catch(() => undefined);
     } finally {
       setIsBusy(false);
     }

--- a/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/useDynamicActions/index.test.ts
+++ b/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/useDynamicActions/index.test.ts
@@ -20,7 +20,7 @@ vi.mock('../../../../../../store', () => ({
   useSessionHasUnread: () => state.hasUnread,
 }));
 
-vi.mock('../../../../../workflows/components/WorkflowNextStepCta', () => ({
+vi.mock('../../../../../workflows/pickNextWorkflowStep', () => ({
   pickNextWorkflowStep: pickNextMock,
 }));
 

--- a/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/useDynamicActions/index.ts
+++ b/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/useDynamicActions/index.ts
@@ -10,7 +10,7 @@ import type {
   Workflow,
 } from '@goodboy/types';
 import { useAppStore, useSessionHasUnread } from '../../../../../../store';
-import { pickNextWorkflowStep } from '../../../../../workflows/components/WorkflowNextStepCta';
+import { pickNextWorkflowStep } from '../../../../../workflows/pickNextWorkflowStep';
 import { workflowRunHasOpenQuestions } from '../../../../../context/openQuestionsGate';
 import type { BoardNavigation } from '../../useBoardNavigation';
 

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.test.tsx
@@ -195,8 +195,10 @@ vi.mock(
 vi.mock('../../../../../shared/components/DogMascot', () => ({ DogMascot: () => null }));
 vi.mock('../../../../providers/components/CostBadge', () => ({ CostBadge: () => null }));
 
-vi.mock('../../../../../features/workflows/components/WorkflowNextStepCta', () => ({
+vi.mock('../../../../../features/workflows/pickNextWorkflowStep', () => ({
   pickNextWorkflowStep: () => null,
+}));
+vi.mock('../../../../../features/workflows/components/WorkflowNextStepCta', () => ({
   WorkflowNextStepCta: () => null,
 }));
 vi.mock('../../../../../features/context/openQuestionsGate', () => ({

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.test.tsx
@@ -22,7 +22,7 @@ const storeMocks = vi.hoisted(() => ({ renameWorkflow: vi.fn(async () => undefin
 vi.mock('../../../../../store', () => ({
   EMPTY_ARRAY: Object.freeze([]),
   useAppStore: <T,>(selector: (state: unknown) => T) =>
-    selector({ renameWorkflow: storeMocks.renameWorkflow }),
+    selector({ renameWorkflow: storeMocks.renameWorkflow, agentEffortOverride: {} }),
 }));
 
 vi.mock(

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.tsx
@@ -14,6 +14,7 @@ import type {
 import { EMPTY_ARRAY, useAppStore } from '../../../../../store';
 import type { AppStore } from '../../../../../store/store';
 import { inferAgentKindFromName, type AgentKind } from '../../../../../features/session/agent-kind';
+import { agentRoutingOverrides } from '../../../../../features/workflows/agentRoutingOverrides';
 import { resolveStepRouting } from '../../../../../features/workflows/resolveStepRouting';
 import { useSessionRoleModels } from '../../../../../shared/hooks/useSessionRoleModels';
 import type { AgentAggregate } from '../../../../../features/session/components/AgentMetrics';
@@ -165,6 +166,18 @@ export const WorkflowRow = ({
   );
   const stepById = new Map(workflow.steps.map((step) => [step.id, step]));
   const hasOrchestratorStrip = isDynamic && !isDiscarded && expanded;
+  const ctaAgent =
+    wfAgents.find((agent) => agent.stepId === actionableStepId && agent.status === 'pending') ??
+    null;
+  const ctaEffortOverride = useAppStore((s) =>
+    ctaAgent != null ? (s.agentEffortOverride[ctaAgent.id] ?? null) : null,
+  );
+  const ctaRouting = agentRoutingOverrides({
+    agent: ctaAgent,
+    modelOverride: ctaAgent != null ? (agentModelOverride[ctaAgent.id] ?? null) : null,
+    providerOverride: ctaAgent != null ? (agentProviderOverride[ctaAgent.id] ?? null) : null,
+    effortOverride: ctaEffortOverride,
+  });
   return (
     <div
       className={cn(
@@ -533,6 +546,9 @@ export const WorkflowRow = ({
                 workflow={workflow}
                 runs={wfAgents}
                 roleModels={roleModels}
+                agentModel={ctaRouting.agentModel}
+                agentProvider={ctaRouting.agentProvider}
+                agentEffort={ctaRouting.agentEffort}
                 blockReason={wfBlockReason}
                 onAdvance={({ step, isConfirmed }) => {
                   const pending = wfAgents.find(

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/useAgentsSection.ts
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/useAgentsSection.ts
@@ -16,7 +16,7 @@ import {
   useSessionLoading,
   useSessionOpenQuestions,
 } from '../../../../../store';
-import { pickNextWorkflowStep } from '../../../../../features/workflows/components/WorkflowNextStepCta';
+import { pickNextWorkflowStep } from '../../../../../features/workflows/pickNextWorkflowStep';
 import {
   resolveWorkflowAdvance,
   type WorkflowBlockReason,

--- a/apps/desktop/src/shared/hooks/useUnhandledRejectionNotice/index.test.ts
+++ b/apps/desktop/src/shared/hooks/useUnhandledRejectionNotice/index.test.ts
@@ -1,0 +1,61 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, renderHook, waitFor } from '@testing-library/react';
+
+const { emitNotification } = vi.hoisted(() => ({
+  emitNotification: vi.fn(async () => undefined),
+}));
+
+vi.mock('../../../store', () => ({
+  useAppStore: { getState: () => ({ emitNotification }) },
+}));
+
+import { useUnhandledRejectionNotice } from './index';
+
+const rejectionEvent = (reason: unknown): Event =>
+  Object.assign(new Event('unhandledrejection'), { reason });
+
+afterEach(() => {
+  cleanup();
+  emitNotification.mockClear();
+  emitNotification.mockImplementation(async () => undefined);
+});
+
+describe('useUnhandledRejectionNotice', () => {
+  it('turns an unhandled rejection into a notification carrying the failure', async () => {
+    renderHook(() => useUnhandledRejectionNotice());
+
+    window.dispatchEvent(rejectionEvent(new Error('agent list refused')));
+
+    await waitFor(() => expect(emitNotification).toHaveBeenCalledTimes(1));
+    expect(emitNotification).toHaveBeenCalledWith(
+      'error',
+      'warning',
+      'an action failed in the background',
+      'agent list refused',
+    );
+  });
+
+  it('does not notify again when the notification itself fails', async () => {
+    emitNotification.mockImplementation(async () => {
+      throw new Error('database is gone');
+    });
+    renderHook(() => useUnhandledRejectionNotice());
+
+    window.dispatchEvent(rejectionEvent(new Error('agent list refused')));
+
+    await waitFor(() => expect(emitNotification).toHaveBeenCalledTimes(1));
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(emitNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops listening once the app unmounts', () => {
+    const { unmount } = renderHook(() => useUnhandledRejectionNotice());
+    unmount();
+
+    window.dispatchEvent(rejectionEvent(new Error('agent list refused')));
+
+    expect(emitNotification).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/shared/hooks/useUnhandledRejectionNotice/index.ts
+++ b/apps/desktop/src/shared/hooks/useUnhandledRejectionNotice/index.ts
@@ -1,0 +1,29 @@
+import { useEffect } from 'react';
+import { useAppStore } from '../../../store';
+import { formatError } from '../../lib/errors';
+
+export const useUnhandledRejectionNotice = () => {
+  useEffect(() => {
+    let isNotifying = false;
+    const onUnhandledRejection = (event: PromiseRejectionEvent) => {
+      if (isNotifying) {
+        return;
+      }
+      isNotifying = true;
+      void useAppStore
+        .getState()
+        .emitNotification(
+          'error',
+          'warning',
+          'an action failed in the background',
+          formatError(event.reason),
+        )
+        .catch(() => undefined)
+        .finally(() => {
+          isNotifying = false;
+        });
+    };
+    window.addEventListener('unhandledrejection', onUnhandledRejection);
+    return () => window.removeEventListener('unhandledrejection', onUnhandledRejection);
+  }, []);
+};

--- a/apps/desktop/src/store/slices/plans/runPlan.ts
+++ b/apps/desktop/src/store/slices/plans/runPlan.ts
@@ -1,7 +1,7 @@
 import type { AgentId, PlanId, SessionId } from '@goodboy/types';
 import { runsForWorkflowRun } from '@goodboy/core';
 import { inferAgentKindFromName, kindConsumesPlan } from '../../../features/session/agent-kind';
-import { pickNextWorkflowStep } from '../../../features/workflows/components/WorkflowNextStepCta';
+import { pickNextWorkflowStep } from '../../../features/workflows/pickNextWorkflowStep';
 import { activateWorkflowAgentOrNotify } from '../workflows/activateWorkflowAgentOrNotify';
 import type { GetFn } from './types';
 

--- a/apps/desktop/src/store/slices/workflows/activateWorkflowAgentOrNotify.ts
+++ b/apps/desktop/src/store/slices/workflows/activateWorkflowAgentOrNotify.ts
@@ -1,6 +1,6 @@
 import type { AgentId, PlanId, SessionId } from '@goodboy/types';
 import type { SpawnFocus } from '../session-view/spawnFocus';
-import { WorkflowGateError } from './workflowActivationGate';
+import { notifyWorkflowGateBlock } from './notifyWorkflowGateBlock';
 import type { GetFn } from './types';
 
 type Params = {
@@ -22,12 +22,7 @@ export const activateWorkflowAgentOrNotify = async ({
     await get().activateWorkflowAgent({ sessionId, agentId, explicitPlanId, focus });
     return true;
   } catch (error) {
-    if (!(error instanceof WorkflowGateError)) {
-      throw error;
-    }
-    void get().emitNotification('error', 'warning', 'workflow step held back', error.message, {
-      sessionId,
-    });
+    notifyWorkflowGateBlock({ error, sessionId, emitNotification: get().emitNotification });
     return false;
   }
 };

--- a/apps/desktop/src/store/slices/workflows/chainTriggers.test.ts
+++ b/apps/desktop/src/store/slices/workflows/chainTriggers.test.ts
@@ -354,6 +354,7 @@ describe('startWorkflowRun', () => {
       startWorkflowRun(set, get)(SESSION_ID, 'q' as WorkflowRunId),
     ).resolves.toBeUndefined();
 
+    expect(state['emitNotification']).toHaveBeenCalledTimes(1);
     expect(state['emitNotification']).toHaveBeenCalledWith(
       'error',
       'warning',

--- a/apps/desktop/src/store/slices/workflows/notifyWorkflowGateBlock.ts
+++ b/apps/desktop/src/store/slices/workflows/notifyWorkflowGateBlock.ts
@@ -1,0 +1,18 @@
+import type { SessionId } from '@goodboy/types';
+import type { GetFn } from './types';
+import { WorkflowGateError } from './workflowActivationGate';
+
+type Params = {
+  readonly error: unknown;
+  readonly sessionId: SessionId;
+  readonly emitNotification: ReturnType<GetFn>['emitNotification'];
+};
+
+export const notifyWorkflowGateBlock = ({ error, sessionId, emitNotification }: Params): void => {
+  if (!(error instanceof WorkflowGateError)) {
+    throw error;
+  }
+  void emitNotification('error', 'warning', 'workflow step held back', error.message, {
+    sessionId,
+  });
+};

--- a/apps/desktop/src/store/slices/workflows/skipStuckStepAndAdvance.test.ts
+++ b/apps/desktop/src/store/slices/workflows/skipStuckStepAndAdvance.test.ts
@@ -97,6 +97,7 @@ const nextAgent: Agent = {
 const buildHarness = (turnKind: 'idle' | 'running' | 'unseeded') => {
   const activateWorkflowAgent = vi.fn();
   const orchestrateNextStep = vi.fn();
+  const emitNotification = vi.fn(async () => undefined);
   const state = {
     sessions: [session],
     phaseTemplates: { [WORKSPACE_ID]: [workflow] },
@@ -105,6 +106,7 @@ const buildHarness = (turnKind: 'idle' | 'running' | 'unseeded') => {
       turnKind === 'unseeded' ? {} : { [STUCK]: { kind: turnKind, lastActivityAt: NOW } },
     activateWorkflowAgent,
     orchestrateNextStep,
+    emitNotification,
     refreshUnreadWorkspaces: vi.fn(),
   };
   const set = vi.fn();
@@ -116,6 +118,7 @@ const buildHarness = (turnKind: 'idle' | 'running' | 'unseeded') => {
     ),
     activateWorkflowAgent,
     orchestrateNextStep,
+    emitNotification,
   };
 };
 
@@ -219,6 +222,22 @@ describe('skipStuckStepAndAdvance', () => {
     );
     expect(activateWorkflowAgent).not.toHaveBeenCalled();
     expect(orchestrateNextStep).toHaveBeenCalledWith(SESSION_ID, RUN_ID, { bypassGate: true });
+  });
+
+  it('names the failure instead of dropping it when the skip cannot be written', async () => {
+    invokeAgentUpdateStatusSpy.mockRejectedValue(new Error('agent row is gone'));
+    const { run, activateWorkflowAgent, emitNotification } = buildHarness('idle');
+
+    await expect(run(SESSION_ID, RUN_ID)).resolves.toBeUndefined();
+
+    expect(activateWorkflowAgent).not.toHaveBeenCalled();
+    expect(emitNotification).toHaveBeenCalledWith(
+      'error',
+      'warning',
+      'the blocked step was not skipped',
+      'agent row is gone',
+      { sessionId: SESSION_ID },
+    );
   });
 
   it('leaves a dynamic run alone once the orchestrator already closed it', async () => {

--- a/apps/desktop/src/store/slices/workflows/skipStuckStepAndAdvance.ts
+++ b/apps/desktop/src/store/slices/workflows/skipStuckStepAndAdvance.ts
@@ -1,9 +1,84 @@
 import type { IsoDateTime, SessionId, WorkflowRunId } from '@goodboy/types';
 import { classifyWorkflowChain, findReusableAgent, runsForWorkflowRun } from '@goodboy/core';
 import { invokeAgentList, invokeAgentUpdateStatus } from '../../../features/workflows/workflows';
+import { formatError } from '../../../shared/lib/errors';
 import type { GetFn, SetFn } from './types';
 
 const nowIso = (): IsoDateTime => new Date().toISOString() as IsoDateTime;
+
+type SkipParams = {
+  readonly set: SetFn;
+  readonly get: GetFn;
+  readonly sessionId: SessionId;
+  readonly workflowRunId: WorkflowRunId;
+  readonly onlyWhenBlocked: boolean;
+};
+
+const runSkipAndAdvance = async ({
+  set,
+  get,
+  sessionId,
+  workflowRunId,
+  onlyWhenBlocked,
+}: SkipParams): Promise<void> => {
+  const session = get().sessions.find((s) => s.id === sessionId);
+  if (!session) {
+    return;
+  }
+  const run = session.workflowRuns.find((r) => r.id === workflowRunId);
+  if (!run || run.discardedAt) {
+    return;
+  }
+  const templates = get().phaseTemplates[session.workspaceId] ?? [];
+  const template = templates.find((t) => t.id === run.workflowId);
+  if (!template) {
+    return;
+  }
+  const runs = runsForWorkflowRun(get().sessionPhaseRuns[sessionId] ?? [], workflowRunId);
+  const chain = classifyWorkflowChain(template, runs);
+  if (chain.kind === 'complete') {
+    return;
+  }
+  if (onlyWhenBlocked && chain.kind !== 'blocked') {
+    return;
+  }
+  const stuckStep = chain.kind === 'blocked' ? chain.failedStep : chain.step;
+  const stuckAgent = findReusableAgent(runs, stuckStep.id);
+  if (!stuckAgent || stuckAgent.status === 'pending') {
+    return;
+  }
+  const turn = get().agentTurnState[stuckAgent.id];
+  if (turn?.kind === 'running' || turn?.kind === 'starting') {
+    return;
+  }
+  if (stuckAgent.status === 'running' && turn === undefined) {
+    return;
+  }
+  await invokeAgentUpdateStatus(stuckAgent.id, { status: 'skipped', completedAt: nowIso() });
+  const refreshed = await invokeAgentList(sessionId);
+  set((s) => ({ sessionPhaseRuns: { ...s.sessionPhaseRuns, [sessionId]: refreshed } }));
+  void get().refreshUnreadWorkspaces();
+
+  const refreshedRunAgents = runsForWorkflowRun(refreshed, workflowRunId);
+  const nextChain = classifyWorkflowChain(template, refreshedRunAgents);
+  if (nextChain.kind === 'step') {
+    const nextAgent = refreshedRunAgents.find(
+      (candidate) => candidate.stepId === nextChain.step.id && candidate.status === 'pending',
+    );
+    if (nextAgent != null) {
+      await get().activateWorkflowAgent({
+        sessionId,
+        agentId: nextAgent.id,
+        focus: 'agent',
+        bypassGate: true,
+      });
+      return;
+    }
+  }
+  if (run.executionMode === 'dynamic' && run.orchestrationOutcome == null) {
+    await get().orchestrateNextStep(sessionId, workflowRunId, { bypassGate: true });
+  }
+};
 
 export const skipStuckStepAndAdvance = (set: SetFn, get: GetFn) => {
   return async (
@@ -11,62 +86,22 @@ export const skipStuckStepAndAdvance = (set: SetFn, get: GetFn) => {
     workflowRunId: WorkflowRunId,
     options?: { readonly onlyWhenBlocked?: boolean },
   ): Promise<void> => {
-    const session = get().sessions.find((s) => s.id === sessionId);
-    if (!session) {
-      return;
-    }
-    const run = session.workflowRuns.find((r) => r.id === workflowRunId);
-    if (!run || run.discardedAt) {
-      return;
-    }
-    const templates = get().phaseTemplates[session.workspaceId] ?? [];
-    const template = templates.find((t) => t.id === run.workflowId);
-    if (!template) {
-      return;
-    }
-    const runs = runsForWorkflowRun(get().sessionPhaseRuns[sessionId] ?? [], workflowRunId);
-    const chain = classifyWorkflowChain(template, runs);
-    if (chain.kind === 'complete') {
-      return;
-    }
-    if (options?.onlyWhenBlocked === true && chain.kind !== 'blocked') {
-      return;
-    }
-    const stuckStep = chain.kind === 'blocked' ? chain.failedStep : chain.step;
-    const stuckAgent = findReusableAgent(runs, stuckStep.id);
-    if (!stuckAgent || stuckAgent.status === 'pending') {
-      return;
-    }
-    const turn = get().agentTurnState[stuckAgent.id];
-    if (turn?.kind === 'running' || turn?.kind === 'starting') {
-      return;
-    }
-    if (stuckAgent.status === 'running' && turn === undefined) {
-      return;
-    }
-    await invokeAgentUpdateStatus(stuckAgent.id, { status: 'skipped', completedAt: nowIso() });
-    const refreshed = await invokeAgentList(sessionId);
-    set((s) => ({ sessionPhaseRuns: { ...s.sessionPhaseRuns, [sessionId]: refreshed } }));
-    void get().refreshUnreadWorkspaces();
-
-    const refreshedRunAgents = runsForWorkflowRun(refreshed, workflowRunId);
-    const nextChain = classifyWorkflowChain(template, refreshedRunAgents);
-    if (nextChain.kind === 'step') {
-      const nextAgent = refreshedRunAgents.find(
-        (candidate) => candidate.stepId === nextChain.step.id && candidate.status === 'pending',
+    try {
+      await runSkipAndAdvance({
+        set,
+        get,
+        sessionId,
+        workflowRunId,
+        onlyWhenBlocked: options?.onlyWhenBlocked === true,
+      });
+    } catch (error) {
+      void get().emitNotification(
+        'error',
+        'warning',
+        'the blocked step was not skipped',
+        formatError(error),
+        { sessionId },
       );
-      if (nextAgent != null) {
-        await get().activateWorkflowAgent({
-          sessionId,
-          agentId: nextAgent.id,
-          focus: 'agent',
-          bypassGate: true,
-        });
-        return;
-      }
-    }
-    if (run.executionMode === 'dynamic' && run.orchestrationOutcome == null) {
-      await get().orchestrateNextStep(sessionId, workflowRunId, { bypassGate: true });
     }
   };
 };

--- a/apps/desktop/src/store/slices/workflows/workflowActivationGate.test.ts
+++ b/apps/desktop/src/store/slices/workflows/workflowActivationGate.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  IsoDateTime,
+  OpenQuestion,
+  OpenQuestionId,
+  SessionId,
+  WorkflowRunId,
+} from '@goodboy/types';
+
+const { listOpenQuestionsSpy } = vi.hoisted(() => ({
+  listOpenQuestionsSpy: vi.fn(async () => [] as ReadonlyArray<OpenQuestion>),
+}));
+
+vi.mock('@goodboy/db', () => ({ listOpenQuestionsForSession: listOpenQuestionsSpy }));
+vi.mock('../../../shared/lib/db', () => ({ tauriDatabase: {} }));
+
+import { findWorkflowActivationBlock } from './workflowActivationGate';
+
+const SESSION_ID = 'ses-1' as SessionId;
+const RUN_ID = 'run-1' as WorkflowRunId;
+const OTHER_RUN_ID = 'run-2' as WorkflowRunId;
+const NOW = '2026-08-05T00:00:00.000Z' as IsoDateTime;
+
+const question = (id: string, workflowRunId?: WorkflowRunId): OpenQuestion => ({
+  id: id as OpenQuestionId,
+  sessionId: SESSION_ID,
+  text: id,
+  suggestedAnswers: [],
+  userAnswer: null,
+  status: 'open',
+  createdAt: NOW,
+  ...(workflowRunId != null && { workflowRunId }),
+});
+
+beforeEach(() => {
+  listOpenQuestionsSpy.mockReset();
+  listOpenQuestionsSpy.mockResolvedValue([]);
+});
+
+describe('findWorkflowActivationBlock', () => {
+  it('holds the run back when the question belongs to that run', async () => {
+    listOpenQuestionsSpy.mockResolvedValue([question('q1', RUN_ID)]);
+
+    await expect(
+      findWorkflowActivationBlock({ sessionId: SESSION_ID, workflowRunId: RUN_ID }),
+    ).resolves.toBe('questions');
+  });
+
+  it('lets the run start when a free agent left an orphan question in the session', async () => {
+    listOpenQuestionsSpy.mockResolvedValue([question('q1')]);
+
+    await expect(
+      findWorkflowActivationBlock({ sessionId: SESSION_ID, workflowRunId: RUN_ID }),
+    ).resolves.toBeNull();
+  });
+
+  it('lets the run start when the question belongs to another run', async () => {
+    listOpenQuestionsSpy.mockResolvedValue([question('q1', OTHER_RUN_ID)]);
+
+    await expect(
+      findWorkflowActivationBlock({ sessionId: SESSION_ID, workflowRunId: RUN_ID }),
+    ).resolves.toBeNull();
+  });
+
+  it('skips the query for an agent outside any run', async () => {
+    await expect(
+      findWorkflowActivationBlock({ sessionId: SESSION_ID, workflowRunId: undefined }),
+    ).resolves.toBeNull();
+    expect(listOpenQuestionsSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Why

The silent-gate regression class has shipped twice. A user clicks "Run next step", the engine re-reads the gate from the DB, refuses, and the UI shows nothing: the button resets and the run stalls with no explanation. This closes the last known silent call sites, stops two engine surfaces from lying, and adds a net under the whole app.

## What changed

### 1. The gate refusal is caught where the session is known

`ChatWorkflowAdvance.onAdvance` awaited `activateWorkflowAgent` with no `try/catch`, and was `void`-invoked from JSX. `useStartAnywayConfirm` had `try/finally` with no `catch` and is itself `void`-invoked twice. Two stacked void invocations, zero catches.

The catch lives in **`ChatWorkflowAdvance`**, not in the hook, for one decisive reason: `emitNotification`'s `sessionId` option is what links the notification to the session, and `useStartAnywayConfirm` never receives a session id (its other caller, `WorkflowRunStartButton`, does not have one either). The store-aware call site is the only place that can emit an honest, addressable notification. The hook stays presentational.

The catch reuses the canonical pattern rather than re-implementing it: the `WorkflowGateError` check plus notification is extracted from `activateWorkflowAgentOrNotify` into `notifyWorkflowGateBlock`, which both now call. One copy string, one behaviour, no drift. Non-gate errors are rethrown, exactly as before.

### 2. A boundary catch in `useStartAnywayConfirm`

Anything that still escapes `onStart` (a rethrown non-gate error, or a future caller that forgets to catch) is caught at the hook boundary, reported as `the next step did not start` with the real message, and the control is freed. This is defense in depth, not the primary path: a gate refusal never reaches it, so it cannot double-notify.

### 3. `skipStuckStepAndAdvance`

Had no error handling anywhere and is `void`-invoked from two call sites (`ChatWorkflowAdvance`, `WorkflowRow`). The catch goes inside the store action so both call sites are covered, and it names the failure: `the blocked step was not skipped` plus the underlying message. The body moved into `runSkipAndAdvance` so the wrapper stays readable; behaviour is unchanged.

### 4. Global `unhandledrejection` handler

There was zero handling in `apps/desktop/src`. Added as `useUnhandledRejectionNotice`, called from `App.tsx` next to the other app-level hooks (`useZoomShortcuts`, `useWindowPresence`), using the same `useEffect` + `addEventListener` + cleanup pattern. It lives in a hook rather than inline so it is testable without mounting the whole app.

Loop safety was the design constraint: a re-entrancy flag prevents a storm, and the emit's own promise is `.catch`ed, so a failing notification cannot itself produce a rejection that re-enters the handler. A test covers exactly that.

### 5. Orphan open questions no longer block every run

`workflowRunHasOpenQuestions` returned `true` for any question with no `workflowRunId`. `auto-populate.ts` writes `workflowRunId: input.agentContext?.workflowRunId`, which is `undefined` for every free non-workflow agent. Net effect: one stray question from a free agent halted every workflow run in the session.

**The contract this defines**: only a question belonging to *this* run blocks *this* run. An orphan question does not block anything. A question belonging to another run does not block. The change is in the shared helper, so `workflowActivationGate` (the engine) and `ChatWorkflowAdvance`'s `blockReason` (the UI) move together and cannot disagree.

`hasOrphanOpenQuestions` had a test and zero production consumers. It is **deleted**, not wired: an orphan question already surfaces in the questions lens with its author, and a second warning on the workflow CTA would duplicate that while spending the CTA's title, which is reserved for what actually blocks the run. No dead code left behind.

`workflowHasOpenQuestions` (keyed on `workflowId`, used only by `PlanReadySuggestion` to suppress a suggestion, not to gate a run) keeps its legacy behaviour; it is a different key and a different surface.

### 6. The routing badge shows what will actually run

`WorkflowNextStepCta` called `resolveStepRouting` without the three override params, so it recomputed routing from current role-model preferences while dispatch reads `agentModelOverride[agentId]` frozen at spawn by `preSpawnWorkflowAgents`. Change a preference mid-session and the badge lied about the model that was about to run.

`WorkflowNextStepCta` stays presentational: it takes `agentModel`, `agentProvider`, `agentEffort` as props. `ChatWorkflowAdvance` (which has store access) resolves the pending agent from the step `resolveWorkflowAdvance` already computed, looks up its frozen overrides, and passes them down. The lookup itself is shared as `agentRoutingOverrides`, mirroring `childRoutingFromParent`, so the precedence (store override, then agent row, then role preferences) is written once.

**`WorkflowRow` gets the same treatment**, using the `actionableStepId` it already receives, so the dashboard and the chat strip agree.

## One thing outside the brief

`pickNextWorkflowStep` lived inside the `WorkflowNextStepCta` component file, and `store/slices/plans/runPlan.ts` imported it from there. Once `useStartAnywayConfirm` reads the store, that made a real cycle: `store.ts` to `plans/index` to `runPlan` to the component to the hook to `store`, which broke `createPlansSlice` at module init and failed `plans/index.test.ts`.

It is moved to `features/workflows/pickNextWorkflowStep.ts` with its tests, and the four importers updated. This is not the "five next-runnable-step implementations" dedup (still out of scope, still needs its own design pass): it is one function leaving a component file where AGENTS.md says utilities must not live, which removes a store-to-UI-component import.

## The double-notification argument

Every path produces **exactly one** user-visible notification:

- **`PipelineSection`** (untouched): `PipelineLane` calls `advance.onAdvance`, which catches and emits, and does not rethrow. Nothing else in that chain catches. One.
- **`attachWorkflowToSession` / `startWorkflowRun`** via `activateWorkflowAgentOrNotify`: `notifyWorkflowGateBlock` emits and the helper returns `false` without rethrowing, so the caller sees a resolved promise and `useStartAnywayConfirm` (which wraps `WorkflowRunStartButton`) never enters its catch. One. Pinned with `toHaveBeenCalledTimes(1)` in `chainTriggers.test.ts`.
- **The advance CTA** (this change): the gate error is emitted and swallowed in `ChatWorkflowAdvance`, so the hook's catch never fires. A non-gate error is rethrown there and caught once by the hook. Never both. Pinned with `toHaveBeenCalledTimes(1)` in `ChatWorkflowAdvance.test.tsx`.
- **The global handler** only ever sees rejections nobody caught, which by construction excludes all of the above.

And the secondary check: a **run-scoped question still blocks**. `workflowActivationGate.test.ts` asserts the run-scoped question returns `'questions'` and the orphan returns `null`, in the same file, so the pair cannot drift apart.

## The path, walked in code

Clicking the CTA (`data-testid="workflow-next-step-cta"`, `onClick={advance.onTrigger}`) with no visible blocker calls `start({ isConfirmed: false })`, which awaits `onStart`, which calls the `onAdvance` prop, which is `ChatWorkflowAdvance.onAdvance`, which awaits `activateWorkflowAgent`. The engine re-reads the questions from the DB, finds the one the in-memory state did not have yet, and throws `WorkflowGateError`. The new catch hands it to `notifyWorkflowGateBlock`, which emits into the store; `NotificationToastBridge` (mounted in `App.tsx`) renders it. `finally` resets `isBusy`, so the button is usable again. That is the exact stale-window scenario, walked end to end in code, and it is the scenario the new test drives through the real component and the real hook.

## Tests

New, all of them; nothing was unmocked because nothing existed:

- `ChatWorkflowAdvance`: a rejecting gate emits exactly one notification and re-enables the button.
- `ChatWorkflowAdvance`: the frozen per-agent override wins over what preferences resolve now (asserted against a render without the override, so it cannot pass by coincidence).
- `useStartAnywayConfirm`: first test file for this hook, covering the rejection.
- `skipStuckStepAndAdvance`: a write failure resolves and names the failure.
- `useUnhandledRejectionNotice`: routes to a notification, does not loop when the notification itself fails, unregisters on unmount.
- `workflowActivationGate` and `openQuestionsGate`: orphan does not block, run-scoped does.

**Revert check**: each fix was reverted in place and the suite re-run. Six tests failed, one per fix, and every one of them failed for the right reason. Restored, and green again. No test here pins the bug it was written to catch.

`openQuestionsGate.test.ts` lost its orphan-blocks-everything case: that test pinned behaviour this change deliberately replaces, so it was rewritten to state the new contract rather than weakened.

## Verification

- `pnpm typecheck`: 5/5 tasks pass
- `pnpm test`: 663 files, 5797 tests, 0 failures (desktop 518 files / 4473 tests)
- `pnpm knip --include files,duplicates,unlisted`: clean, only the 6 pre-existing config hints

No migration touched; m105 stays free. `PipelineSection.tsx`, `useAgentsSection.ts`, and `orchestrateNextStep.ts` are untouched.
