### PR TITLE
fix(desktop): english question chips and folded completed work

### DIFF
--- a/apps/desktop/src/__tests__/store/unknown-payload.test.ts
+++ b/apps/desktop/src/__tests__/store/unknown-payload.test.ts
@@ -118,7 +118,6 @@ const RUN_ID = 'run-1' as ProviderRunId;
 const AT: IsoDateTime = '2026-05-07T00:00:00.000Z' as IsoDateTime;
 
 describe('store unknownPayloadCounts', () => {
-  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
   let useAppStore: (typeof import('../../store/store'))['useAppStore'];
 
   beforeEach(async () => {

--- a/apps/desktop/src/features/chat/components/ChatInput/hooks/useAgentSwitchSync.ts
+++ b/apps/desktop/src/features/chat/components/ChatInput/hooks/useAgentSwitchSync.ts
@@ -87,5 +87,5 @@ export function useAgentSwitchSync({
     setRightSizeDismissed(false);
     setScopePending(null);
     setScopeNudgeEventId(null);
-  }, [selectedAgentId]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [selectedAgentId]);
 }

--- a/apps/desktop/src/features/chat/components/ChatInput/hooks/useAttachments.ts
+++ b/apps/desktop/src/features/chat/components/ChatInput/hooks/useAttachments.ts
@@ -7,13 +7,13 @@ import type { ToastKind } from '../../../../../app/components/Toast';
 import { dataUrlToBase64, type PendingAttachment } from '../lib';
 import { usePendingAttachments } from './usePendingAttachments';
 
-interface UseAttachmentsArgs {
+type Params = {
   readonly sessionId: SessionId;
   readonly selectedAgentId: AgentId | null;
   readonly sessionWorktree: string | null;
   readonly providerDisconnected: boolean;
   readonly showToast: (kind: ToastKind, message: string) => void;
-}
+};
 
 export function useAttachments({
   sessionId,
@@ -21,7 +21,7 @@ export function useAttachments({
   sessionWorktree,
   providerDisconnected,
   showToast,
-}: UseAttachmentsArgs) {
+}: Params) {
   const setAgentAttachments = useAppStore((s) => s.setAgentAttachments);
 
   const sessionWorktreeRef = useRef(sessionWorktree);

--- a/apps/desktop/src/features/chat/components/ChatInput/hooks/useChatPrefix.ts
+++ b/apps/desktop/src/features/chat/components/ChatInput/hooks/useChatPrefix.ts
@@ -18,14 +18,14 @@ import { CHAT_PREFIX_RE } from '../lib';
 
 export { QuickActionsPopover };
 
-interface UseChatPrefixArgs {
+type Params = {
   readonly session: Session;
   readonly value: string;
   readonly setValue: (next: string) => void;
   readonly sessionWorktree: string | null;
   readonly showToast: (kind: ToastKind, message: string) => void;
   readonly wrapperRef: RefObject<HTMLDivElement | null>;
-}
+};
 
 export function useChatPrefix({
   session,
@@ -34,7 +34,7 @@ export function useChatPrefix({
   sessionWorktree,
   showToast,
   wrapperRef,
-}: UseChatPrefixArgs) {
+}: Params) {
   const workspaceSkills = useAppStore(
     useShallow((s) => s.skills[session.workspaceId] ?? EMPTY_ARRAY),
   );

--- a/apps/desktop/src/features/chat/components/ChatView/useScrollPin.ts
+++ b/apps/desktop/src/features/chat/components/ChatView/useScrollPin.ts
@@ -17,7 +17,7 @@ export const useScrollPin = (deps: ReadonlyArray<unknown>, resetKey?: unknown) =
       return;
     }
     el.scrollTop = el.scrollHeight;
-  }, [pinned, ...deps]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [pinned, ...deps]);
 
   const onScroll = () => {
     const el = scrollerRef.current;

--- a/apps/desktop/src/features/context/components/ContextPanel/lib.ts
+++ b/apps/desktop/src/features/context/components/ContextPanel/lib.ts
@@ -1,11 +1,11 @@
 import type { ContextSlot } from '@goodboy/types';
 
-export interface FilesTouchedShape {
+export type FilesTouchedShape = {
   readonly paths: ReadonlyArray<string>;
   readonly count: number;
   readonly additions: number;
   readonly deletions: number;
-}
+};
 
 export function normalizeFilesSlot(slot: ContextSlot, workingDir: string | null): ContextSlot {
   if (!workingDir || slot.value.length === 0) return slot;

--- a/apps/desktop/src/features/context/components/QuestionsTab/deriveSuggestions/index.test.ts
+++ b/apps/desktop/src/features/context/components/QuestionsTab/deriveSuggestions/index.test.ts
@@ -14,8 +14,12 @@ describe('deriveSuggestions', () => {
     expect(deriveSuggestions('Lo mettiamo in core oppure db?')).toEqual(['core', 'db']);
   });
 
-  it('returns yes/no for a yes-no phrasing', () => {
-    expect(deriveSuggestions('Devo procedere con il refactor?')).toEqual(['sì', 'no']);
+  it('returns english yes/no for an english yes-no phrasing', () => {
+    expect(deriveSuggestions('Should I proceed with the refactor?')).toEqual(['yes', 'no']);
+  });
+
+  it('does not treat an italian opener as a yes-no trigger anymore', () => {
+    expect(deriveSuggestions('Devo procedere con il refactor?')).toEqual([]);
   });
 
   it('returns nothing for an open-ended question', () => {

--- a/apps/desktop/src/features/context/components/QuestionsTab/deriveSuggestions/index.ts
+++ b/apps/desktop/src/features/context/components/QuestionsTab/deriveSuggestions/index.ts
@@ -1,5 +1,4 @@
-const YES_NO_RE =
-  /^\s*(vuoi|devo|dobbiamo|posso|possiamo|procedo|procediamo|conviene|ti torna|should|shall|do you|does|did|can|could|is|are|was|were|may|would)\b/i;
+const YES_NO_RE = /^\s*(should|shall|do you|does|did|can|could|is|are|was|were|may|would)\b/i;
 
 const SEPARATORS = [' oppure ', ' or ', ' o '];
 
@@ -66,7 +65,7 @@ export const deriveSuggestions = (question: string): ReadonlyArray<string> => {
   }
 
   if (YES_NO_RE.test(trimmed)) {
-    return ['sì', 'no'];
+    return ['yes', 'no'];
   }
   return [];
 };

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/index.test.tsx
@@ -344,7 +344,7 @@ describe('IntegrationPane', () => {
     expect(screen.getByRole('button', { name: 'All issues' })).toBeDefined();
   });
 
-  it('groups a merged work item as completed instead of current work', () => {
+  it('folds a merged work item behind a completed count until expanded', () => {
     h.store.sessionExternalTasks = {
       [SESSION_ID]: [
         { ...TASK, branch: 'ak/current' },
@@ -355,9 +355,21 @@ describe('IntegrationPane', () => {
 
     render(<IntegrationPane sessionId={SESSION_ID} workspaceId={WORKSPACE_ID} provider="linear" />);
 
-    expect(screen.getByText('Completed work (2)')).toBeDefined();
+    const toggle = screen.getByRole('button', { name: 'Completed (2)' });
+    expect(screen.queryByText('ak/shipped')).toBeNull();
+
+    fireEvent.click(toggle);
+
     expect(screen.getAllByText('Completed')).toHaveLength(1);
     expect(screen.getByText('ak/shipped')).toBeDefined();
+  });
+
+  it('renders no completed toggle when nothing is completed', () => {
+    h.store.sessionExternalTasks = { [SESSION_ID]: [{ ...TASK, branch: 'ak/current' }] };
+
+    render(<IntegrationPane sessionId={SESSION_ID} workspaceId={WORKSPACE_ID} provider="linear" />);
+
+    expect(screen.queryByRole('button', { name: /^Completed/ })).toBeNull();
   });
 
   it('opens and confirms before unlinking the focused task', async () => {

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/index.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useMemo, useState } from 'react';
-import { ArrowLeft, Unlink } from 'lucide-react';
+import { ArrowLeft, Check, Unlink } from 'lucide-react';
 import type {
   SessionExternalTask,
   SessionExternalTaskProvider,
   SessionId,
   WorkspaceId,
 } from '@goodboy/types';
-import { Eyebrow, InlineConfirm, cn } from '@goodboy/ui';
+import { CountToggle, InlineConfirm, cn } from '@goodboy/ui';
 import { LensEmptyState } from '../../../../../../shared/components/LensEmptyState';
 import { EMPTY_ARRAY, useAppStore } from '../../../../../../store';
 import { formatError } from '../../../../../../shared/lib/errors';
@@ -53,6 +53,7 @@ export const IntegrationPane = ({ sessionId, workspaceId, provider }: Props) => 
   const [unlinkError, setUnlinkError] = useState<string | null>(null);
   const [isUnlinking, setIsUnlinking] = useState(false);
   const [isUnlinkArmed, setIsUnlinkArmed] = useState(false);
+  const [showHistory, setShowHistory] = useState(false);
   const externalTasks = useAppStore(
     (state) => state.sessionExternalTasks[sessionId] ?? EMPTY_ARRAY,
   );
@@ -216,19 +217,22 @@ export const IntegrationPane = ({ sessionId, workspaceId, provider }: Props) => 
         providerLabel={meta.label}
         onSelect={setFocusedTaskKey}
       />
-      {workItems.history.length > 0 ? (
-        <div className="flex flex-col gap-2">
-          <Eyebrow
-            label={`Completed work (${workItems.history.length})`}
-            muted
-            className="px-0.5 font-medium"
-          />
-          <WorkItemList
-            items={workItems.history}
-            providerLabel={meta.label}
-            onSelect={setFocusedTaskKey}
-          />
-        </div>
+      <div className="flex justify-center">
+        <CountToggle
+          label="Completed"
+          itemsLabel="issues"
+          count={workItems.history.length}
+          isShown={showHistory}
+          icon={Check}
+          onChange={setShowHistory}
+        />
+      </div>
+      {showHistory && workItems.history.length > 0 ? (
+        <WorkItemList
+          items={workItems.history}
+          providerLabel={meta.label}
+          onSelect={setFocusedTaskKey}
+        />
       ) : null}
       {unlinkError != null ? <p className="text-xs text-danger">{unlinkError}</p> : null}
     </PaneShell>

--- a/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
@@ -359,7 +359,6 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
     } else {
       setWorkflowDraft(session.id, draft);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     session.id,
     mode,

--- a/apps/desktop/src/shared/components/GenericTerminalPanel/index.tsx
+++ b/apps/desktop/src/shared/components/GenericTerminalPanel/index.tsx
@@ -176,7 +176,6 @@ export const GenericTerminalPanel = ({
       termRef.current = null;
       fitAndSyncRef.current = null;
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [terminalId]);
 
   useEffect(() => {

--- a/apps/desktop/src/store/slices/agents/setAgentKind.ts
+++ b/apps/desktop/src/store/slices/agents/setAgentKind.ts
@@ -29,8 +29,9 @@ export const setAgentKind = (set: SetFn, get: GetFn) => {
       };
     });
     void invokeAgentSetKind(agentId, kind).catch((err) => {
-      // eslint-disable-next-line no-console
-      console.warn('[store] failed to persist agent kind', err);
+      if (import.meta.env.DEV) {
+        console.warn('[store] failed to persist agent kind', err);
+      }
     });
   };
 };

--- a/apps/desktop/src/store/slices/scripts/runScript.ts
+++ b/apps/desktop/src/store/slices/scripts/runScript.ts
@@ -40,7 +40,6 @@ export const runScript = (set: SetFn, get: GetFn) => {
     });
 
     const STDOUT_CAP = 64 * 1024;
-    // eslint-disable-next-line no-control-regex
     const ANSI_RE = /\x1B\[[0-?]*[ -/]*[@-~]/g;
     let stdoutBuf = '';
     let truncated = false;


### PR DESCRIPTION
## Four small, independent fixes

### 1. English answer chips (the important one)
`deriveSuggestions` returned `['sì', 'no']` for a yes-no question, and `YES_NO_RE` matched both Italian openers (`vuoi|devo|dobbiamo|posso|possiamo|procedo|procediamo|conviene|ti torna`) and English ones. `QuestionCard` falls back to `deriveSuggestions` whenever `question.suggestedAnswers` is empty (the common case), so English questions were rendering Italian answer chips.

Fix: the fallback now returns `['yes', 'no']`, and the Italian openers are dropped from `YES_NO_RE`, leaving every English trigger (`should|shall|do you|does|did|can|could|is|are|was|were|may|would`) intact.

**Non-English sweep of `deriveSuggestions` and neighbors**: found two more Italian-language spots left as-is because they're out of this item's stated scope (only `YES_NO_RE` was called out):
- `SEPARATORS = [' oppure ', ' or ', ' o ']` still splits on the Italian "oppure"/"o" connectors.
- `SKIP_TOKENS` still carries Italian stop words (`che`, `cosa`, `come`, `di`, `da`, `su`, `con`, `per`, `un`, `una`).
- The test file still has three Italian question strings exercising the separator path (`'Vuoi che usi OAuth o JWT?'`, `'Lo mettiamo in core oppure db?'`, `'Come strutturiamo il modulo di auth?'`).

None of these leak Italian text into the UI (they parse arbitrary input, they don't emit Italian copy), so left untouched, flagging for a follow-up if the product should go English-only end to end. `QuestionCard` and its other siblings (`SuggestionChip`, `CustomAnswerField`) have no Italian strings.

### 2. Completed work folds behind a count
`IntegrationPane` rendered its "Completed work" history unconditionally under a bare `Eyebrow`. Replaced with the same `CountToggle` pattern `WorkflowsPane` already uses: collapsed by default, centered toggle button showing the count, expands to the full list on click, and (since `CountToggle` self-hides at `count === 0`) nothing renders when there's nothing completed.

### 3. `interface` → `type`
Converted the three remaining `interface` declarations:
- `useChatPrefix.ts`: `UseChatPrefixArgs` → `Params`.
- `useAttachments.ts`: `UseAttachmentsArgs` → `Params`.
- `ContextPanel/lib.ts`: `FilesTouchedShape` kept its descriptive name (domain type, not a hook param).

No collisions; neither hook's `Params` was already in use in its file.

### 4. Dead `eslint-disable` comments
Verified there's no eslint config and no `lint` script implementation anywhere in the repo (`AGENTS.md:128`, `turbo.json` lint task has no consumer). Removed all 7 dead `eslint-disable` comments:
`useScrollPin.ts:20`, `useAgentSwitchSync.ts:90`, `WorkflowBuilderView/index.tsx:362`, `GenericTerminalPanel/index.tsx:179`, `unknown-payload.test.ts:121`, `setAgentKind.ts:32`, `runScript.ts:43`.

`setAgentKind.ts` also had an ungated `console.warn` next to its disable comment. Chose to **gate it behind `import.meta.env.DEV`** (not remove it) to match the existing pattern used throughout `store/slices/*` (e.g. `selectAgent.ts`, `sendTurn.ts`, `setCurrentSession.ts`) rather than silently dropping a real failure signal.

## Regression check: both toggle states verified
- Count > 0: collapsed by default (history hidden), toggle button reads `Completed (N)`, clicking expands to the exact same list as before.
- Count 0: `CountToggle` renders nothing (no header, no divider, no orphaned chrome), matching `WorkflowsPane` exactly.

## Tests
- `deriveSuggestions/index.test.ts`: replaced the Italian yes/no assertion with `'Should I proceed with the refactor?' → ['yes', 'no']`, and added `'Devo procedere con il refactor?' → []` to prove the Italian opener no longer triggers. Both fail if the fix is reverted (old code returned `['sì', 'no']` for both).
- `IntegrationPane/index.test.tsx`: reworked the completed-work test into `'folds a merged work item behind a completed count until expanded'` (asserts the toggle button `Completed (2)`, that `ak/shipped` is hidden until clicked, then visible after), and added `'renders no completed toggle when nothing is completed'`. Both fail if the fix is reverted (old code always rendered the list, no toggle button existed).
- `tsc -b` covers the three `interface` → `type` conversions (no `.d.ts` shape change).

## Verification (worktree `.claude/worktrees/v162-fix-fine-pass`)
- `pnpm typecheck` → all 5 packages green.
- `pnpm test` → 515 test files / 4480 tests passed (whole workspace).
- `pnpm knip --include files,duplicates,unlisted` (exact CI gate) → clean, only pre-existing config hints.

## Files touched
- `apps/desktop/src/features/context/components/QuestionsTab/deriveSuggestions/index.ts`
- `apps/desktop/src/features/context/components/QuestionsTab/deriveSuggestions/index.test.ts`
- `apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/index.tsx`
- `apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/index.test.tsx`
- `apps/desktop/src/features/chat/components/ChatInput/hooks/useChatPrefix.ts`
- `apps/desktop/src/features/chat/components/ChatInput/hooks/useAttachments.ts`
- `apps/desktop/src/features/context/components/ContextPanel/lib.ts`
- `apps/desktop/src/features/chat/components/ChatView/useScrollPin.ts`
- `apps/desktop/src/features/chat/components/ChatInput/hooks/useAgentSwitchSync.ts`
- `apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx`
- `apps/desktop/src/shared/components/GenericTerminalPanel/index.tsx`
- `apps/desktop/src/__tests__/store/unknown-payload.test.ts`
- `apps/desktop/src/store/slices/agents/setAgentKind.ts`
- `apps/desktop/src/store/slices/scripts/runScript.ts`
