### PR TITLE
feat(desktop): add the jira cloud backend command surface

### DIFF
--- a/apps/desktop/src-tauri/src/jira.rs
+++ b/apps/desktop/src-tauri/src/jira.rs
@@ -401,7 +401,10 @@ fn render_list(node: &Value, ordered: bool) -> String {
                 false => "- ".to_string(),
             };
             let width = marker.len();
-            indent_continuation(&format!("{marker}{}", render_blocks(item.get("content"))), width)
+            indent_continuation(
+                &format!("{marker}{}", render_blocks(item.get("content"))),
+                width,
+            )
         })
         .collect::<Vec<_>>()
         .join("\n")
@@ -417,7 +420,11 @@ fn render_block(node: &Value) -> String {
                 .and_then(|value| value.as_u64())
                 .unwrap_or(1)
                 .clamp(1, 6) as usize;
-            format!("{} {}", "#".repeat(level), render_inline(node.get("content")))
+            format!(
+                "{} {}",
+                "#".repeat(level),
+                render_inline(node.get("content"))
+            )
         }
         Some("bulletList") => render_list(node, false),
         Some("orderedList") => render_list(node, true),
@@ -748,6 +755,43 @@ struct JiraTransitionsPayload {
     transitions: Vec<JiraTransition>,
 }
 
+struct JiraWrite {
+    url: String,
+    body: Value,
+}
+
+fn comment_write(base: &str, issue_key: &str, text: &str) -> JiraWrite {
+    JiraWrite {
+        url: format!("{}/comment", issue_path(base, issue_key)),
+        body: serde_json::json!({ "body": text_to_adf(text) }),
+    }
+}
+
+fn description_write(base: &str, issue_key: &str, description: &str) -> JiraWrite {
+    JiraWrite {
+        url: issue_path(base, issue_key),
+        body: serde_json::json!({ "fields": { "description": text_to_adf(description) } }),
+    }
+}
+
+fn assignee_write(base: &str, issue_key: &str, account_id: Option<&str>) -> JiraWrite {
+    let target = match account_id.map(str::trim).filter(|id| !id.is_empty()) {
+        Some(id) => Value::String(id.to_string()),
+        None => Value::Null,
+    };
+    JiraWrite {
+        url: format!("{}/assignee", issue_path(base, issue_key)),
+        body: serde_json::json!({ "accountId": target }),
+    }
+}
+
+fn transition_write(base: &str, issue_key: &str, transition_id: &str) -> JiraWrite {
+    JiraWrite {
+        url: format!("{}/transitions", issue_path(base, issue_key)),
+        body: serde_json::json!({ "transition": { "id": transition_id } }),
+    }
+}
+
 #[tauri::command]
 pub async fn jira_validate_connection(
     workspace_id: String,
@@ -879,14 +923,9 @@ pub async fn jira_create_comment(
         email: &email,
         token: &token,
     };
-    let payload = serde_json::json!({ "body": text_to_adf(&body) });
-    let raw: JiraCommentRaw = send_json(
-        &credentials,
-        reqwest::Method::POST,
-        &format!("{}/comment", issue_path(&base, &issue_key)),
-        &payload,
-    )
-    .await?;
+    let write = comment_write(&base, &issue_key, &body);
+    let raw: JiraCommentRaw =
+        send_json(&credentials, reqwest::Method::POST, &write.url, &write.body).await?;
     Ok(map_comment(raw))
 }
 
@@ -907,21 +946,8 @@ pub async fn jira_update_issue(
         email: &email,
         token: &token,
     };
-    let payload = serde_json::json!({ "fields": { "description": text_to_adf(&description) } });
-    send_no_content(
-        &credentials,
-        reqwest::Method::PUT,
-        &issue_path(&base, &issue_key),
-        &payload,
-    )
-    .await
-}
-
-fn assignee_payload(account_id: Option<&str>) -> Value {
-    match account_id.map(str::trim).filter(|id| !id.is_empty()) {
-        Some(id) => serde_json::json!({ "accountId": id }),
-        None => serde_json::json!({ "accountId": Value::Null }),
-    }
+    let write = description_write(&base, &issue_key, &description);
+    send_no_content(&credentials, reqwest::Method::PUT, &write.url, &write.body).await
 }
 
 #[tauri::command]
@@ -941,13 +967,8 @@ pub async fn jira_set_assignee(
         email: &email,
         token: &token,
     };
-    send_no_content(
-        &credentials,
-        reqwest::Method::PUT,
-        &format!("{}/assignee", issue_path(&base, &issue_key)),
-        &assignee_payload(account_id.as_deref()),
-    )
-    .await
+    let write = assignee_write(&base, &issue_key, account_id.as_deref());
+    send_no_content(&credentials, reqwest::Method::PUT, &write.url, &write.body).await
 }
 
 #[tauri::command]
@@ -1015,13 +1036,8 @@ pub async fn jira_transition_issue(
         email: &email,
         token: &token,
     };
-    send_no_content(
-        &credentials,
-        reqwest::Method::POST,
-        &format!("{}/transitions", issue_path(&base, &issue_key)),
-        &serde_json::json!({ "transition": { "id": transition_id } }),
-    )
-    .await
+    let write = transition_write(&base, &issue_key, &transition_id);
+    send_no_content(&credentials, reqwest::Method::POST, &write.url, &write.body).await
 }
 
 #[cfg(test)]
@@ -1123,7 +1139,11 @@ mod tests {
 
     #[test]
     fn search_url_encodes_the_jql_and_pins_an_explicit_field_list() {
-        let url = search_url("https://acme.atlassian.net/rest/api/3", "project = \"GB\"", None);
+        let url = search_url(
+            "https://acme.atlassian.net/rest/api/3",
+            "project = \"GB\"",
+            None,
+        );
         assert!(url.starts_with("https://acme.atlassian.net/rest/api/3/search/jql?jql="));
         assert!(url.contains("project%20%3D%20%22GB%22"));
         assert!(url.contains("&fields=summary%2Cdescription"));
@@ -1171,7 +1191,10 @@ mod tests {
         );
         let filtered = assignable_url("https://x/rest/api/3", "GB-12", Some(" ami "));
         assert!(filtered.ends_with("&query=ami"));
-        assert_eq!(assignable_url("https://x/rest/api/3", "GB-12", Some("  ")), bare);
+        assert_eq!(
+            assignable_url("https://x/rest/api/3", "GB-12", Some("  ")),
+            bare
+        );
     }
 
     #[test]
@@ -1397,10 +1420,9 @@ mod tests {
             r#"{ "issues": [{ "id": "1", "key": "GB-1" }], "nextPageToken": "t1", "isLast": false }"#,
         )
         .unwrap();
-        let second: JiraSearchPage = serde_json::from_str(
-            r#"{ "issues": [{ "id": "2", "key": "GB-2" }], "isLast": true }"#,
-        )
-        .unwrap();
+        let second: JiraSearchPage =
+            serde_json::from_str(r#"{ "issues": [{ "id": "2", "key": "GB-2" }], "isLast": true }"#)
+                .unwrap();
         assert_eq!(pager.absorb(first).unwrap(), Some("t1".to_string()));
         assert_eq!(pager.absorb(second).unwrap(), None);
         assert_eq!(pager.issues.len(), 2);
@@ -1419,7 +1441,11 @@ mod tests {
         .unwrap();
         pager.absorb(first).unwrap();
         pager.absorb(second).unwrap();
-        let keys: Vec<&str> = pager.issues.iter().map(|issue| issue.key.as_str()).collect();
+        let keys: Vec<&str> = pager
+            .issues
+            .iter()
+            .map(|issue| issue.key.as_str())
+            .collect();
         assert_eq!(keys, vec!["GB-1", "GB-2"]);
     }
 
@@ -1465,10 +1491,9 @@ mod tests {
 
     #[test]
     fn next_comment_offset_stops_once_total_is_reached() {
-        let page: JiraCommentPage = serde_json::from_str(
-            r#"{ "startAt": 2, "total": 3, "comments": [{ "id": "3" }] }"#,
-        )
-        .unwrap();
+        let page: JiraCommentPage =
+            serde_json::from_str(r#"{ "startAt": 2, "total": 3, "comments": [{ "id": "3" }] }"#)
+                .unwrap();
         assert_eq!(next_comment_offset(&page), None);
     }
 
@@ -1520,28 +1545,60 @@ mod tests {
     }
 
     #[test]
-    fn assignee_payload_sends_a_null_account_id_to_unassign() {
-        assert_eq!(assignee_payload(None)["accountId"], Value::Null);
-        assert_eq!(assignee_payload(Some("  "))["accountId"], Value::Null);
-        assert_eq!(assignee_payload(Some("acc-1"))["accountId"], "acc-1");
-    }
-
-    #[test]
-    fn comment_payload_wraps_the_text_in_an_adf_document() {
-        let payload = serde_json::json!({ "body": text_to_adf("ship it") });
-        assert_eq!(payload["body"]["type"], "doc");
-        assert_eq!(payload["body"]["version"], 1);
-        assert_eq!(payload["body"]["content"][0]["content"][0]["text"], "ship it");
-    }
-
-    #[test]
-    fn description_payload_nests_the_document_under_fields() {
-        let payload =
-            serde_json::json!({ "fields": { "description": text_to_adf("new description") } });
-        assert_eq!(payload["fields"]["description"]["type"], "doc");
+    fn assignee_write_sends_a_null_account_id_to_unassign() {
+        let base = "https://x/rest/api/3";
         assert_eq!(
-            payload["fields"]["description"]["content"][0]["content"][0]["text"],
+            assignee_write(base, "GB-1", None).url,
+            "https://x/rest/api/3/issue/GB-1/assignee"
+        );
+        assert_eq!(
+            assignee_write(base, "GB-1", None).body["accountId"],
+            Value::Null
+        );
+        assert_eq!(
+            assignee_write(base, "GB-1", Some("  ")).body["accountId"],
+            Value::Null
+        );
+    }
+
+    #[test]
+    fn assignee_write_echoes_the_account_id_and_never_the_default_sentinel() {
+        let write = assignee_write("https://x/rest/api/3", "GB-1", Some("acc-1"));
+        assert_eq!(write.body["accountId"], "acc-1");
+        assert_ne!(write.body["accountId"], "-1");
+    }
+
+    #[test]
+    fn comment_write_targets_the_comment_collection_with_an_adf_body() {
+        let write = comment_write("https://x/rest/api/3", "GB-1", "ship it");
+        assert_eq!(write.url, "https://x/rest/api/3/issue/GB-1/comment");
+        assert_eq!(write.body["body"]["type"], "doc");
+        assert_eq!(write.body["body"]["version"], 1);
+        assert_eq!(
+            write.body["body"]["content"][0]["content"][0]["text"],
+            "ship it"
+        );
+    }
+
+    #[test]
+    fn description_write_targets_the_issue_itself_and_nests_the_document_under_fields() {
+        let write = description_write("https://x/rest/api/3", "GB-1", "new description");
+        assert_eq!(write.url, "https://x/rest/api/3/issue/GB-1");
+        assert_eq!(write.body["fields"]["description"]["type"], "doc");
+        assert_eq!(
+            write.body["fields"]["description"]["content"][0]["content"][0]["text"],
             "new description"
+        );
+    }
+
+    #[test]
+    fn transition_write_posts_the_chosen_transition_id_to_the_transitions_collection() {
+        let write = transition_write("https://x/rest/api/3", "GB-1", "31");
+        assert_eq!(write.url, "https://x/rest/api/3/issue/GB-1/transitions");
+        assert_eq!(write.body["transition"]["id"], "31");
+        assert_eq!(
+            transition_write("https://x/rest/api/3", "GB-1", "41").body["transition"]["id"],
+            "41"
         );
     }
 }

--- a/apps/desktop/src-tauri/src/jira.rs
+++ b/apps/desktop/src-tauri/src/jira.rs
@@ -1,0 +1,1547 @@
+use std::collections::{HashMap, HashSet};
+use std::sync::{Mutex, OnceLock};
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tauri::State;
+use thiserror::Error;
+
+use crate::secrets;
+
+pub struct JiraTokenCache(Mutex<HashMap<String, String>>);
+
+impl JiraTokenCache {
+    pub fn new() -> Self {
+        Self(Mutex::new(HashMap::new()))
+    }
+}
+
+fn http_client() -> &'static reqwest::Client {
+    static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+    CLIENT.get_or_init(reqwest::Client::new)
+}
+
+fn credential_key(workspace_id: &str) -> String {
+    format!("goodboy.workspace.{}.jira", workspace_id)
+}
+
+#[derive(Debug, Error)]
+pub enum JiraError {
+    #[error("http error {status}: {body}")]
+    Http { status: u16, body: String },
+    #[error("authentication failed: {0}")]
+    Auth(String),
+    #[error("not found: {0}")]
+    NotFound(String),
+    #[error("invalid response shape: {0}")]
+    InvalidShape(String),
+    #[error("no token stored for workspace {0}")]
+    NoToken(String),
+    #[error("secret store error: {0}")]
+    Secret(#[from] secrets::SecretError),
+}
+
+crate::util::impl_error_serialize!(JiraError);
+
+impl JiraError {
+    fn kind(&self) -> &'static str {
+        match self {
+            JiraError::Http { .. } => "http",
+            JiraError::Auth(_) => "auth",
+            JiraError::NotFound(_) => "not_found",
+            JiraError::InvalidShape(_) => "shape",
+            JiraError::NoToken(_) => "no_token",
+            JiraError::Secret(_) => "secret",
+        }
+    }
+}
+
+impl From<reqwest::Error> for JiraError {
+    fn from(e: reqwest::Error) -> Self {
+        JiraError::Http {
+            status: 0,
+            body: e.to_string(),
+        }
+    }
+}
+
+const MAX_PAGES: u32 = 20;
+const SEARCH_PAGE_SIZE: u32 = 50;
+const COMMENT_PAGE_SIZE: i64 = 100;
+const ISSUE_FIELDS: &str =
+    "summary,description,status,issuetype,priority,assignee,reporter,labels,created,updated";
+
+fn percent_encode(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                out.push(byte as char)
+            }
+            _ => out.push_str(&format!("%{byte:02X}")),
+        }
+    }
+    out
+}
+
+fn site_root(site_url: &str) -> Result<String, JiraError> {
+    let trimmed = site_url.trim().trim_end_matches('/');
+    if !(trimmed.starts_with("http://") || trimmed.starts_with("https://")) {
+        return Err(JiraError::InvalidShape(format!(
+            "invalid site url: {}",
+            site_url
+        )));
+    }
+    Ok(trimmed.to_string())
+}
+
+fn api_base(site_url: &str) -> Result<String, JiraError> {
+    Ok(format!("{}/rest/api/3", site_root(site_url)?))
+}
+
+fn browse_url(root: &str, issue_key: &str) -> String {
+    format!("{}/browse/{}", root, issue_key)
+}
+
+fn issue_path(base: &str, issue_key: &str) -> String {
+    format!("{}/issue/{}", base, percent_encode(issue_key))
+}
+
+fn search_url(base: &str, jql: &str, page_token: Option<&str>) -> String {
+    let mut url = format!(
+        "{}/search/jql?jql={}&fields={}&maxResults={}",
+        base,
+        percent_encode(jql),
+        percent_encode(ISSUE_FIELDS),
+        SEARCH_PAGE_SIZE
+    );
+    if let Some(token) = page_token {
+        url.push_str(&format!("&nextPageToken={}", percent_encode(token)));
+    }
+    url
+}
+
+fn assignable_url(base: &str, issue_key: &str, query: Option<&str>) -> String {
+    let mut url = format!(
+        "{}/user/assignable/search?issueKey={}&maxResults=50",
+        base,
+        percent_encode(issue_key)
+    );
+    if let Some(term) = query.map(str::trim).filter(|term| !term.is_empty()) {
+        url.push_str(&format!("&query={}", percent_encode(term)));
+    }
+    url
+}
+
+fn comments_url(base: &str, issue_key: &str, start_at: i64) -> String {
+    format!(
+        "{}/comment?startAt={}&maxResults={}&orderBy=created",
+        issue_path(base, issue_key),
+        start_at,
+        COMMENT_PAGE_SIZE
+    )
+}
+
+fn build_project_jql(project_key: &str, assigned_only: bool) -> String {
+    let scope = match assigned_only {
+        true => " AND assignee = currentUser()",
+        false => "",
+    };
+    format!(
+        "project = \"{}\"{} AND statusCategory != Done ORDER BY updated DESC",
+        project_key.trim(),
+        scope
+    )
+}
+
+fn error_message(body: &str) -> Option<String> {
+    let parsed: Value = serde_json::from_str(body).ok()?;
+    let messages: Vec<String> = parsed
+        .get("errorMessages")
+        .and_then(|value| value.as_array())
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|item| item.as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default();
+    if !messages.is_empty() {
+        return Some(messages.join("; "));
+    }
+    let fields: Vec<String> = parsed
+        .get("errors")
+        .and_then(|value| value.as_object())
+        .map(|map| {
+            map.iter()
+                .filter_map(|(key, value)| value.as_str().map(|text| format!("{key}: {text}")))
+                .collect()
+        })
+        .unwrap_or_default();
+    match fields.is_empty() {
+        true => None,
+        false => Some(fields.join("; ")),
+    }
+}
+
+fn error_for_status(status: u16, body: String) -> JiraError {
+    let detail = error_message(&body).unwrap_or_else(|| body.clone());
+    match status {
+        401 | 403 => JiraError::Auth(detail),
+        404 => JiraError::NotFound(detail),
+        _ => JiraError::Http { status, body },
+    }
+}
+
+struct Credentials<'a> {
+    root: &'a str,
+    email: &'a str,
+    token: &'a str,
+}
+
+async fn get_json<T: serde::de::DeserializeOwned>(
+    credentials: &Credentials<'_>,
+    url: &str,
+) -> Result<T, JiraError> {
+    let res = http_client()
+        .get(url)
+        .basic_auth(credentials.email, Some(credentials.token))
+        .header("Accept", "application/json")
+        .send()
+        .await?;
+    let status = res.status();
+    let body = res.text().await?;
+    if !status.is_success() {
+        return Err(error_for_status(status.as_u16(), body));
+    }
+    serde_json::from_str(&body).map_err(|e| JiraError::InvalidShape(e.to_string()))
+}
+
+async fn send_json<T: serde::de::DeserializeOwned>(
+    credentials: &Credentials<'_>,
+    method: reqwest::Method,
+    url: &str,
+    body: &Value,
+) -> Result<T, JiraError> {
+    let res = http_client()
+        .request(method, url)
+        .basic_auth(credentials.email, Some(credentials.token))
+        .header("Accept", "application/json")
+        .json(body)
+        .send()
+        .await?;
+    let status = res.status();
+    let text = res.text().await?;
+    if !status.is_success() {
+        return Err(error_for_status(status.as_u16(), text));
+    }
+    serde_json::from_str(&text).map_err(|e| JiraError::InvalidShape(e.to_string()))
+}
+
+async fn send_no_content(
+    credentials: &Credentials<'_>,
+    method: reqwest::Method,
+    url: &str,
+    body: &Value,
+) -> Result<(), JiraError> {
+    let res = http_client()
+        .request(method, url)
+        .basic_auth(credentials.email, Some(credentials.token))
+        .header("Accept", "application/json")
+        .json(body)
+        .send()
+        .await?;
+    let status = res.status();
+    let text = res.text().await?;
+    if !status.is_success() {
+        return Err(error_for_status(status.as_u16(), text));
+    }
+    Ok(())
+}
+
+fn read_token(workspace_id: &str, cache: &JiraTokenCache) -> Result<String, JiraError> {
+    if let Some(token) = cache.0.lock().unwrap().get(workspace_id) {
+        return Ok(token.clone());
+    }
+    let token = secrets::read(&credential_key(workspace_id))?
+        .ok_or_else(|| JiraError::NoToken(workspace_id.to_string()))?;
+    cache
+        .0
+        .lock()
+        .unwrap()
+        .insert(workspace_id.to_string(), token.clone());
+    Ok(token)
+}
+
+fn flatten_text(node: &Value) -> String {
+    if let Some(text) = node.get("text").and_then(|value| value.as_str()) {
+        return text.to_string();
+    }
+    let Some(items) = node.get("content").and_then(|value| value.as_array()) else {
+        return String::new();
+    };
+    items.iter().map(flatten_text).collect::<Vec<_>>().join("")
+}
+
+fn link_href(marks: &[Value]) -> Option<String> {
+    marks
+        .iter()
+        .find(|mark| mark.get("type").and_then(|value| value.as_str()) == Some("link"))
+        .and_then(|mark| mark.get("attrs"))
+        .and_then(|attrs| attrs.get("href"))
+        .and_then(|href| href.as_str())
+        .map(str::to_string)
+}
+
+fn apply_marks(node: &Value) -> String {
+    let mut out = node
+        .get("text")
+        .and_then(|value| value.as_str())
+        .unwrap_or("")
+        .to_string();
+    let Some(marks) = node.get("marks").and_then(|value| value.as_array()) else {
+        return out;
+    };
+    let has = |name: &str| {
+        marks
+            .iter()
+            .any(|mark| mark.get("type").and_then(|value| value.as_str()) == Some(name))
+    };
+    if has("code") {
+        out = format!("`{out}`");
+    }
+    if has("strong") {
+        out = format!("**{out}**");
+    }
+    if has("em") {
+        out = format!("*{out}*");
+    }
+    if has("strike") {
+        out = format!("~~{out}~~");
+    }
+    if has("underline") {
+        out = format!("_{out}_");
+    }
+    if let Some(href) = link_href(marks) {
+        out = format!("[{out}]({href})");
+    }
+    out
+}
+
+fn render_inline_node(node: &Value) -> String {
+    match node.get("type").and_then(|value| value.as_str()) {
+        Some("text") => apply_marks(node),
+        Some("hardBreak") => "\n".to_string(),
+        Some("mention") => {
+            let label = node
+                .get("attrs")
+                .and_then(|attrs| attrs.get("text"))
+                .and_then(|value| value.as_str())
+                .unwrap_or("")
+                .trim_start_matches('@');
+            format!("@{label}")
+        }
+        Some("emoji") => node
+            .get("attrs")
+            .and_then(|attrs| attrs.get("text").or_else(|| attrs.get("shortName")))
+            .and_then(|value| value.as_str())
+            .unwrap_or("")
+            .to_string(),
+        Some("inlineCard") => node
+            .get("attrs")
+            .and_then(|attrs| attrs.get("url"))
+            .and_then(|value| value.as_str())
+            .unwrap_or("")
+            .to_string(),
+        _ => flatten_text(node),
+    }
+}
+
+fn render_inline(content: Option<&Value>) -> String {
+    let Some(items) = content.and_then(|value| value.as_array()) else {
+        return String::new();
+    };
+    items
+        .iter()
+        .map(render_inline_node)
+        .collect::<Vec<_>>()
+        .join("")
+}
+
+fn prefix_lines(text: &str, prefix: &str) -> String {
+    text.lines()
+        .map(|line| format!("{prefix}{line}"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn indent_continuation(text: &str, width: usize) -> String {
+    let pad = " ".repeat(width);
+    let mut lines = text.lines();
+    let Some(first) = lines.next() else {
+        return String::new();
+    };
+    let rest: Vec<String> = lines.map(|line| format!("{pad}{line}")).collect();
+    match rest.is_empty() {
+        true => first.to_string(),
+        false => format!("{}\n{}", first, rest.join("\n")),
+    }
+}
+
+fn render_list(node: &Value, ordered: bool) -> String {
+    let Some(items) = node.get("content").and_then(|value| value.as_array()) else {
+        return String::new();
+    };
+    items
+        .iter()
+        .enumerate()
+        .map(|(index, item)| {
+            let marker = match ordered {
+                true => format!("{}. ", index + 1),
+                false => "- ".to_string(),
+            };
+            let width = marker.len();
+            indent_continuation(&format!("{marker}{}", render_blocks(item.get("content"))), width)
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn render_block(node: &Value) -> String {
+    match node.get("type").and_then(|value| value.as_str()) {
+        Some("paragraph") => render_inline(node.get("content")),
+        Some("heading") => {
+            let level = node
+                .get("attrs")
+                .and_then(|attrs| attrs.get("level"))
+                .and_then(|value| value.as_u64())
+                .unwrap_or(1)
+                .clamp(1, 6) as usize;
+            format!("{} {}", "#".repeat(level), render_inline(node.get("content")))
+        }
+        Some("bulletList") => render_list(node, false),
+        Some("orderedList") => render_list(node, true),
+        Some("listItem") => render_blocks(node.get("content")),
+        Some("codeBlock") => {
+            let language = node
+                .get("attrs")
+                .and_then(|attrs| attrs.get("language"))
+                .and_then(|value| value.as_str())
+                .unwrap_or("");
+            format!("```{}\n{}\n```", language, flatten_text(node))
+        }
+        Some("blockquote") => prefix_lines(&render_blocks(node.get("content")), "> "),
+        Some("rule") => "---".to_string(),
+        _ => flatten_text(node),
+    }
+}
+
+fn render_blocks(content: Option<&Value>) -> String {
+    let Some(items) = content.and_then(|value| value.as_array()) else {
+        return String::new();
+    };
+    items
+        .iter()
+        .map(render_block)
+        .filter(|block| !block.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n\n")
+}
+
+fn adf_to_markdown(document: &Value) -> String {
+    render_blocks(document.get("content"))
+}
+
+fn adf_field_to_markdown(value: Option<&Value>) -> String {
+    match value {
+        None | Some(Value::Null) => String::new(),
+        Some(Value::String(text)) => text.clone(),
+        Some(document) => adf_to_markdown(document),
+    }
+}
+
+fn text_to_adf(text: &str) -> Value {
+    let paragraphs: Vec<Value> = text
+        .lines()
+        .map(str::trim_end)
+        .filter(|line| !line.is_empty())
+        .map(|line| {
+            serde_json::json!({
+                "type": "paragraph",
+                "content": [{ "type": "text", "text": line }]
+            })
+        })
+        .collect();
+    let content = match paragraphs.is_empty() {
+        true => vec![serde_json::json!({ "type": "paragraph", "content": [] })],
+        false => paragraphs,
+    };
+    serde_json::json!({ "type": "doc", "version": 1, "content": content })
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JiraAvatarUrls {
+    #[serde(rename = "48x48", default)]
+    pub large: Option<String>,
+    #[serde(rename = "24x24", default)]
+    pub small: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JiraUser {
+    #[serde(rename = "accountId")]
+    pub account_id: String,
+    #[serde(rename = "displayName", default)]
+    pub display_name: String,
+    #[serde(rename = "emailAddress", default)]
+    pub email_address: Option<String>,
+    #[serde(rename = "avatarUrls", default)]
+    pub avatar_urls: Option<JiraAvatarUrls>,
+    #[serde(default)]
+    pub active: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+struct JiraStatusCategory {
+    #[serde(default)]
+    key: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct JiraStatus {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(rename = "statusCategory", default)]
+    status_category: Option<JiraStatusCategory>,
+}
+
+#[derive(Debug, Deserialize)]
+struct JiraNamed {
+    #[serde(default)]
+    name: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct JiraIssueFields {
+    #[serde(default)]
+    summary: Option<String>,
+    #[serde(default)]
+    description: Option<Value>,
+    #[serde(default)]
+    status: Option<JiraStatus>,
+    #[serde(default)]
+    issuetype: Option<JiraNamed>,
+    #[serde(default)]
+    priority: Option<JiraNamed>,
+    #[serde(default)]
+    assignee: Option<JiraUser>,
+    #[serde(default)]
+    reporter: Option<JiraUser>,
+    #[serde(default)]
+    labels: Vec<String>,
+    #[serde(default)]
+    created: Option<String>,
+    #[serde(default)]
+    updated: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct JiraIssueRaw {
+    #[serde(default)]
+    id: String,
+    key: String,
+    #[serde(default)]
+    fields: Option<JiraIssueFields>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct JiraIssue {
+    pub id: String,
+    pub key: String,
+    pub summary: String,
+    pub description: String,
+    pub status: String,
+    #[serde(rename = "statusCategory")]
+    pub status_category: String,
+    #[serde(rename = "issueType")]
+    pub issue_type: String,
+    pub priority: Option<String>,
+    pub assignee: Option<JiraUser>,
+    pub reporter: Option<JiraUser>,
+    pub labels: Vec<String>,
+    pub created: String,
+    pub updated: String,
+    pub url: String,
+}
+
+fn map_issue(raw: JiraIssueRaw, root: &str) -> JiraIssue {
+    let url = browse_url(root, &raw.key);
+    let fields = raw.fields.unwrap_or_default();
+    let status = fields.status;
+    JiraIssue {
+        id: raw.id,
+        key: raw.key,
+        summary: fields.summary.unwrap_or_default(),
+        description: adf_field_to_markdown(fields.description.as_ref()),
+        status: status
+            .as_ref()
+            .and_then(|value| value.name.clone())
+            .unwrap_or_default(),
+        status_category: status
+            .as_ref()
+            .and_then(|value| value.status_category.as_ref())
+            .and_then(|category| category.key.clone())
+            .unwrap_or_default(),
+        issue_type: fields
+            .issuetype
+            .and_then(|value| value.name)
+            .unwrap_or_default(),
+        priority: fields.priority.and_then(|value| value.name),
+        assignee: fields.assignee,
+        reporter: fields.reporter,
+        labels: fields.labels,
+        created: fields.created.unwrap_or_default(),
+        updated: fields.updated.unwrap_or_default(),
+        url,
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct JiraSearchPage {
+    #[serde(default)]
+    issues: Vec<JiraIssueRaw>,
+    #[serde(rename = "nextPageToken", default)]
+    next_page_token: Option<String>,
+    #[serde(rename = "isLast", default)]
+    is_last: Option<bool>,
+}
+
+struct SearchPager {
+    seen_keys: HashSet<String>,
+    seen_tokens: HashSet<String>,
+    issues: Vec<JiraIssueRaw>,
+}
+
+impl SearchPager {
+    fn new() -> Self {
+        Self {
+            seen_keys: HashSet::new(),
+            seen_tokens: HashSet::new(),
+            issues: Vec::new(),
+        }
+    }
+
+    fn absorb(&mut self, page: JiraSearchPage) -> Result<Option<String>, JiraError> {
+        for issue in page.issues {
+            if self.seen_keys.insert(issue.key.clone()) {
+                self.issues.push(issue);
+            }
+        }
+        if page.is_last == Some(true) {
+            return Ok(None);
+        }
+        let Some(token) = page.next_page_token.filter(|token| !token.is_empty()) else {
+            return Ok(None);
+        };
+        if !self.seen_tokens.insert(token.clone()) {
+            return Err(JiraError::InvalidShape(format!(
+                "jira search pagination looped on token {token}"
+            )));
+        }
+        Ok(Some(token))
+    }
+}
+
+async fn search_issues(
+    credentials: &Credentials<'_>,
+    base: &str,
+    jql: &str,
+) -> Result<Vec<JiraIssueRaw>, JiraError> {
+    let mut pager = SearchPager::new();
+    let mut page_token: Option<String> = None;
+    let mut pages: u32 = 0;
+    loop {
+        let url = search_url(base, jql, page_token.as_deref());
+        let page: JiraSearchPage = get_json(credentials, &url).await?;
+        page_token = pager.absorb(page)?;
+        pages += 1;
+        if page_token.is_none() || pages >= MAX_PAGES {
+            break;
+        }
+    }
+    Ok(pager.issues)
+}
+
+#[derive(Debug, Deserialize)]
+struct JiraCommentRaw {
+    #[serde(default)]
+    id: String,
+    #[serde(default)]
+    author: Option<JiraUser>,
+    #[serde(default)]
+    body: Option<Value>,
+    #[serde(default)]
+    created: Option<String>,
+    #[serde(default)]
+    updated: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct JiraComment {
+    pub id: String,
+    pub author: Option<JiraUser>,
+    pub body: String,
+    pub created: String,
+    pub updated: String,
+}
+
+fn map_comment(raw: JiraCommentRaw) -> JiraComment {
+    JiraComment {
+        id: raw.id,
+        author: raw.author,
+        body: adf_field_to_markdown(raw.body.as_ref()),
+        created: raw.created.unwrap_or_default(),
+        updated: raw.updated.unwrap_or_default(),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct JiraCommentPage {
+    #[serde(default)]
+    comments: Vec<JiraCommentRaw>,
+    #[serde(rename = "startAt", default)]
+    start_at: i64,
+    #[serde(default)]
+    total: i64,
+}
+
+fn next_comment_offset(page: &JiraCommentPage) -> Option<i64> {
+    let fetched = page.start_at + page.comments.len() as i64;
+    if page.comments.is_empty() || fetched >= page.total {
+        return None;
+    }
+    Some(fetched)
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct JiraTransitionTarget {
+    #[serde(default)]
+    pub id: String,
+    #[serde(default)]
+    pub name: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct JiraTransition {
+    pub id: String,
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub to: Option<JiraTransitionTarget>,
+    #[serde(rename = "hasScreen", default)]
+    pub has_screen: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct JiraTransitionsPayload {
+    #[serde(default)]
+    transitions: Vec<JiraTransition>,
+}
+
+#[tauri::command]
+pub async fn jira_validate_connection(
+    workspace_id: String,
+    site_url: String,
+    email: String,
+    api_token: String,
+    cache: State<'_, JiraTokenCache>,
+) -> Result<JiraUser, JiraError> {
+    let root = site_root(&site_url)?;
+    let base = api_base(&site_url)?;
+    let credentials = Credentials {
+        root: &root,
+        email: &email,
+        token: &api_token,
+    };
+    let user: JiraUser = get_json(&credentials, &format!("{base}/myself")).await?;
+    secrets::set(&credential_key(&workspace_id), &api_token)?;
+    cache.0.lock().unwrap().insert(workspace_id, api_token);
+    Ok(user)
+}
+
+#[tauri::command]
+pub async fn jira_disconnect(
+    workspace_id: String,
+    cache: State<'_, JiraTokenCache>,
+) -> Result<(), JiraError> {
+    secrets::clear(&credential_key(&workspace_id))?;
+    cache.0.lock().unwrap().remove(&workspace_id);
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn jira_list_issues(
+    workspace_id: String,
+    site_url: String,
+    email: String,
+    project_key: String,
+    assigned_only: bool,
+    cache: State<'_, JiraTokenCache>,
+) -> Result<Vec<JiraIssue>, JiraError> {
+    let token = read_token(&workspace_id, &cache)?;
+    let root = site_root(&site_url)?;
+    let base = api_base(&site_url)?;
+    let credentials = Credentials {
+        root: &root,
+        email: &email,
+        token: &token,
+    };
+    let jql = build_project_jql(&project_key, assigned_only);
+    let raw = search_issues(&credentials, &base, &jql).await?;
+    Ok(raw
+        .into_iter()
+        .map(|issue| map_issue(issue, credentials.root))
+        .collect())
+}
+
+#[tauri::command]
+pub async fn jira_get_issue(
+    workspace_id: String,
+    site_url: String,
+    email: String,
+    issue_key: String,
+    cache: State<'_, JiraTokenCache>,
+) -> Result<JiraIssue, JiraError> {
+    let token = read_token(&workspace_id, &cache)?;
+    let root = site_root(&site_url)?;
+    let base = api_base(&site_url)?;
+    let credentials = Credentials {
+        root: &root,
+        email: &email,
+        token: &token,
+    };
+    let url = format!(
+        "{}?fields={}",
+        issue_path(&base, &issue_key),
+        percent_encode(ISSUE_FIELDS)
+    );
+    let raw: JiraIssueRaw = get_json(&credentials, &url).await?;
+    Ok(map_issue(raw, credentials.root))
+}
+
+#[tauri::command]
+pub async fn jira_list_comments(
+    workspace_id: String,
+    site_url: String,
+    email: String,
+    issue_key: String,
+    cache: State<'_, JiraTokenCache>,
+) -> Result<Vec<JiraComment>, JiraError> {
+    let token = read_token(&workspace_id, &cache)?;
+    let root = site_root(&site_url)?;
+    let base = api_base(&site_url)?;
+    let credentials = Credentials {
+        root: &root,
+        email: &email,
+        token: &token,
+    };
+    let mut collected: Vec<JiraComment> = Vec::new();
+    let mut start_at: i64 = 0;
+    let mut pages: u32 = 0;
+    loop {
+        let page: JiraCommentPage =
+            get_json(&credentials, &comments_url(&base, &issue_key, start_at)).await?;
+        let next = next_comment_offset(&page);
+        collected.extend(page.comments.into_iter().map(map_comment));
+        pages += 1;
+        match next {
+            Some(offset) if pages < MAX_PAGES => start_at = offset,
+            _ => break,
+        }
+    }
+    Ok(collected)
+}
+
+#[tauri::command]
+pub async fn jira_create_comment(
+    workspace_id: String,
+    site_url: String,
+    email: String,
+    issue_key: String,
+    body: String,
+    cache: State<'_, JiraTokenCache>,
+) -> Result<JiraComment, JiraError> {
+    let token = read_token(&workspace_id, &cache)?;
+    let root = site_root(&site_url)?;
+    let base = api_base(&site_url)?;
+    let credentials = Credentials {
+        root: &root,
+        email: &email,
+        token: &token,
+    };
+    let payload = serde_json::json!({ "body": text_to_adf(&body) });
+    let raw: JiraCommentRaw = send_json(
+        &credentials,
+        reqwest::Method::POST,
+        &format!("{}/comment", issue_path(&base, &issue_key)),
+        &payload,
+    )
+    .await?;
+    Ok(map_comment(raw))
+}
+
+#[tauri::command]
+pub async fn jira_update_issue(
+    workspace_id: String,
+    site_url: String,
+    email: String,
+    issue_key: String,
+    description: String,
+    cache: State<'_, JiraTokenCache>,
+) -> Result<(), JiraError> {
+    let token = read_token(&workspace_id, &cache)?;
+    let root = site_root(&site_url)?;
+    let base = api_base(&site_url)?;
+    let credentials = Credentials {
+        root: &root,
+        email: &email,
+        token: &token,
+    };
+    let payload = serde_json::json!({ "fields": { "description": text_to_adf(&description) } });
+    send_no_content(
+        &credentials,
+        reqwest::Method::PUT,
+        &issue_path(&base, &issue_key),
+        &payload,
+    )
+    .await
+}
+
+fn assignee_payload(account_id: Option<&str>) -> Value {
+    match account_id.map(str::trim).filter(|id| !id.is_empty()) {
+        Some(id) => serde_json::json!({ "accountId": id }),
+        None => serde_json::json!({ "accountId": Value::Null }),
+    }
+}
+
+#[tauri::command]
+pub async fn jira_set_assignee(
+    workspace_id: String,
+    site_url: String,
+    email: String,
+    issue_key: String,
+    account_id: Option<String>,
+    cache: State<'_, JiraTokenCache>,
+) -> Result<(), JiraError> {
+    let token = read_token(&workspace_id, &cache)?;
+    let root = site_root(&site_url)?;
+    let base = api_base(&site_url)?;
+    let credentials = Credentials {
+        root: &root,
+        email: &email,
+        token: &token,
+    };
+    send_no_content(
+        &credentials,
+        reqwest::Method::PUT,
+        &format!("{}/assignee", issue_path(&base, &issue_key)),
+        &assignee_payload(account_id.as_deref()),
+    )
+    .await
+}
+
+#[tauri::command]
+pub async fn jira_list_assignable_users(
+    workspace_id: String,
+    site_url: String,
+    email: String,
+    issue_key: String,
+    query: Option<String>,
+    cache: State<'_, JiraTokenCache>,
+) -> Result<Vec<JiraUser>, JiraError> {
+    let token = read_token(&workspace_id, &cache)?;
+    let root = site_root(&site_url)?;
+    let base = api_base(&site_url)?;
+    let credentials = Credentials {
+        root: &root,
+        email: &email,
+        token: &token,
+    };
+    get_json(
+        &credentials,
+        &assignable_url(&base, &issue_key, query.as_deref()),
+    )
+    .await
+}
+
+#[tauri::command]
+pub async fn jira_list_transitions(
+    workspace_id: String,
+    site_url: String,
+    email: String,
+    issue_key: String,
+    cache: State<'_, JiraTokenCache>,
+) -> Result<Vec<JiraTransition>, JiraError> {
+    let token = read_token(&workspace_id, &cache)?;
+    let root = site_root(&site_url)?;
+    let base = api_base(&site_url)?;
+    let credentials = Credentials {
+        root: &root,
+        email: &email,
+        token: &token,
+    };
+    let payload: JiraTransitionsPayload = get_json(
+        &credentials,
+        &format!("{}/transitions", issue_path(&base, &issue_key)),
+    )
+    .await?;
+    Ok(payload.transitions)
+}
+
+#[tauri::command]
+pub async fn jira_transition_issue(
+    workspace_id: String,
+    site_url: String,
+    email: String,
+    issue_key: String,
+    transition_id: String,
+    cache: State<'_, JiraTokenCache>,
+) -> Result<(), JiraError> {
+    let token = read_token(&workspace_id, &cache)?;
+    let root = site_root(&site_url)?;
+    let base = api_base(&site_url)?;
+    let credentials = Credentials {
+        root: &root,
+        email: &email,
+        token: &token,
+    };
+    send_no_content(
+        &credentials,
+        reqwest::Method::POST,
+        &format!("{}/transitions", issue_path(&base, &issue_key)),
+        &serde_json::json!({ "transition": { "id": transition_id } }),
+    )
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn doc(content: Value) -> Value {
+        serde_json::json!({ "type": "doc", "version": 1, "content": content })
+    }
+
+    #[test]
+    fn site_root_trims_trailing_slash_and_whitespace() {
+        assert_eq!(
+            site_root("  https://acme.atlassian.net/  ").unwrap(),
+            "https://acme.atlassian.net"
+        );
+    }
+
+    #[test]
+    fn site_root_rejects_a_url_without_scheme() {
+        let err = site_root("acme.atlassian.net").unwrap_err();
+        assert!(matches!(err, JiraError::InvalidShape(_)));
+    }
+
+    #[test]
+    fn api_base_appends_the_v3_rest_prefix() {
+        assert_eq!(
+            api_base("https://acme.atlassian.net").unwrap(),
+            "https://acme.atlassian.net/rest/api/3"
+        );
+    }
+
+    #[test]
+    fn browse_url_points_at_the_issue_key() {
+        assert_eq!(
+            browse_url("https://acme.atlassian.net", "GB-12"),
+            "https://acme.atlassian.net/browse/GB-12"
+        );
+    }
+
+    #[test]
+    fn credential_key_is_namespaced_per_workspace() {
+        assert_eq!(credential_key("ws-1"), "goodboy.workspace.ws-1.jira");
+    }
+
+    #[test]
+    fn error_kind_maps_each_variant() {
+        assert_eq!(
+            JiraError::Http {
+                status: 500,
+                body: "x".into()
+            }
+            .kind(),
+            "http"
+        );
+        assert_eq!(JiraError::Auth("x".into()).kind(), "auth");
+        assert_eq!(JiraError::NotFound("x".into()).kind(), "not_found");
+        assert_eq!(JiraError::InvalidShape("x".into()).kind(), "shape");
+        assert_eq!(JiraError::NoToken("ws".into()).kind(), "no_token");
+    }
+
+    #[test]
+    fn error_for_status_treats_401_and_403_as_auth_failures() {
+        let unauthorized = error_for_status(401, r#"{"errorMessages":["Bad token"]}"#.into());
+        assert!(matches!(unauthorized, JiraError::Auth(ref m) if m == "Bad token"));
+        let forbidden = error_for_status(403, r#"{"errorMessages":["No permission"]}"#.into());
+        assert!(matches!(forbidden, JiraError::Auth(ref m) if m == "No permission"));
+    }
+
+    #[test]
+    fn error_for_status_maps_404_to_not_found() {
+        let err = error_for_status(
+            404,
+            r#"{"errorMessages":["Issue does not exist"],"errors":{}}"#.into(),
+        );
+        assert!(matches!(err, JiraError::NotFound(ref m) if m == "Issue does not exist"));
+    }
+
+    #[test]
+    fn error_for_status_keeps_a_400_as_http_with_the_raw_body() {
+        let body = r#"{"errorMessages":[],"errors":{"description":"Operation value must be an Atlassian Document"}}"#;
+        let err = error_for_status(400, body.into());
+        assert!(matches!(err, JiraError::Http { status: 400, .. }));
+    }
+
+    #[test]
+    fn error_message_reads_the_field_errors_when_messages_are_empty() {
+        let body = r#"{"errorMessages":[],"errors":{"body":"Comment body is not valid!"}}"#;
+        assert_eq!(
+            error_message(body),
+            Some("body: Comment body is not valid!".to_string())
+        );
+    }
+
+    #[test]
+    fn error_message_is_none_for_a_non_json_body() {
+        assert!(error_message("<html>gateway timeout</html>").is_none());
+    }
+
+    #[test]
+    fn search_url_encodes_the_jql_and_pins_an_explicit_field_list() {
+        let url = search_url("https://acme.atlassian.net/rest/api/3", "project = \"GB\"", None);
+        assert!(url.starts_with("https://acme.atlassian.net/rest/api/3/search/jql?jql="));
+        assert!(url.contains("project%20%3D%20%22GB%22"));
+        assert!(url.contains("&fields=summary%2Cdescription"));
+        assert!(url.contains("&maxResults=50"));
+        assert!(!url.contains("nextPageToken"));
+    }
+
+    #[test]
+    fn search_url_appends_the_opaque_page_token() {
+        let url = search_url("https://x/rest/api/3", "project = \"GB\"", Some("tok/1="));
+        assert!(url.ends_with("&nextPageToken=tok%2F1%3D"));
+    }
+
+    #[test]
+    fn build_project_jql_scopes_to_the_project_and_skips_done() {
+        assert_eq!(
+            build_project_jql("GB", false),
+            "project = \"GB\" AND statusCategory != Done ORDER BY updated DESC"
+        );
+    }
+
+    #[test]
+    fn build_project_jql_can_narrow_to_the_current_user() {
+        assert_eq!(
+            build_project_jql(" GB ", true),
+            "project = \"GB\" AND assignee = currentUser() AND statusCategory != Done ORDER BY updated DESC"
+        );
+    }
+
+    #[test]
+    fn issue_path_percent_encodes_the_key() {
+        assert_eq!(
+            issue_path("https://x/rest/api/3", "GB-12"),
+            "https://x/rest/api/3/issue/GB-12"
+        );
+        assert!(issue_path("https://x/rest/api/3", "a b").ends_with("/issue/a%20b"));
+    }
+
+    #[test]
+    fn assignable_url_requires_the_issue_key_and_adds_the_query_when_present() {
+        let bare = assignable_url("https://x/rest/api/3", "GB-12", None);
+        assert_eq!(
+            bare,
+            "https://x/rest/api/3/user/assignable/search?issueKey=GB-12&maxResults=50"
+        );
+        let filtered = assignable_url("https://x/rest/api/3", "GB-12", Some(" ami "));
+        assert!(filtered.ends_with("&query=ami"));
+        assert_eq!(assignable_url("https://x/rest/api/3", "GB-12", Some("  ")), bare);
+    }
+
+    #[test]
+    fn comments_url_carries_the_start_at_offset() {
+        assert_eq!(
+            comments_url("https://x/rest/api/3", "GB-1", 100),
+            "https://x/rest/api/3/issue/GB-1/comment?startAt=100&maxResults=100&orderBy=created"
+        );
+    }
+
+    #[test]
+    fn adf_reader_renders_a_paragraph_with_every_supported_mark() {
+        let document = doc(serde_json::json!([{
+            "type": "paragraph",
+            "content": [
+                { "type": "text", "text": "plain " },
+                { "type": "text", "text": "bold", "marks": [{ "type": "strong" }] },
+                { "type": "text", "text": " " },
+                { "type": "text", "text": "italic", "marks": [{ "type": "em" }] },
+                { "type": "text", "text": " " },
+                { "type": "text", "text": "mono", "marks": [{ "type": "code" }] },
+                { "type": "text", "text": " " },
+                { "type": "text", "text": "gone", "marks": [{ "type": "strike" }] }
+            ]
+        }]));
+        assert_eq!(
+            adf_to_markdown(&document),
+            "plain **bold** *italic* `mono` ~~gone~~"
+        );
+    }
+
+    #[test]
+    fn adf_reader_wraps_a_link_mark_around_the_other_marks() {
+        let document = doc(serde_json::json!([{
+            "type": "paragraph",
+            "content": [{
+                "type": "text",
+                "text": "docs",
+                "marks": [{ "type": "strong" }, { "type": "link", "attrs": { "href": "https://x.dev" } }]
+            }]
+        }]));
+        assert_eq!(adf_to_markdown(&document), "[**docs**](https://x.dev)");
+    }
+
+    #[test]
+    fn adf_reader_renders_headings_at_their_level() {
+        let document = doc(serde_json::json!([
+            { "type": "heading", "attrs": { "level": 1 }, "content": [{ "type": "text", "text": "Top" }] },
+            { "type": "heading", "attrs": { "level": 3 }, "content": [{ "type": "text", "text": "Deep" }] }
+        ]));
+        assert_eq!(adf_to_markdown(&document), "# Top\n\n### Deep");
+    }
+
+    #[test]
+    fn adf_reader_renders_bullet_and_ordered_lists() {
+        let list = |kind: &str| {
+            serde_json::json!({
+                "type": kind,
+                "content": [
+                    { "type": "listItem", "content": [{ "type": "paragraph", "content": [{ "type": "text", "text": "one" }] }] },
+                    { "type": "listItem", "content": [{ "type": "paragraph", "content": [{ "type": "text", "text": "two" }] }] }
+                ]
+            })
+        };
+        assert_eq!(
+            adf_to_markdown(&doc(serde_json::json!([list("bulletList")]))),
+            "- one\n- two"
+        );
+        assert_eq!(
+            adf_to_markdown(&doc(serde_json::json!([list("orderedList")]))),
+            "1. one\n2. two"
+        );
+    }
+
+    #[test]
+    fn adf_reader_fences_a_code_block_with_its_language() {
+        let document = doc(serde_json::json!([{
+            "type": "codeBlock",
+            "attrs": { "language": "rust" },
+            "content": [{ "type": "text", "text": "let x = 1;" }]
+        }]));
+        assert_eq!(adf_to_markdown(&document), "```rust\nlet x = 1;\n```");
+    }
+
+    #[test]
+    fn adf_reader_turns_a_hard_break_into_a_newline_and_a_mention_into_a_handle() {
+        let document = doc(serde_json::json!([{
+            "type": "paragraph",
+            "content": [
+                { "type": "text", "text": "ping" },
+                { "type": "hardBreak" },
+                { "type": "mention", "attrs": { "id": "acc-1", "text": "@Amin", "userType": "APP" } }
+            ]
+        }]));
+        assert_eq!(adf_to_markdown(&document), "ping\n@Amin");
+    }
+
+    #[test]
+    fn adf_reader_flattens_an_unknown_node_instead_of_dropping_it() {
+        let document = doc(serde_json::json!([{
+            "type": "panel",
+            "attrs": { "panelType": "warning" },
+            "content": [{ "type": "paragraph", "content": [{ "type": "text", "text": "heads up" }] }]
+        }]));
+        assert_eq!(adf_to_markdown(&document), "heads up");
+    }
+
+    #[test]
+    fn adf_reader_prefixes_a_blockquote_and_renders_a_rule() {
+        let document = doc(serde_json::json!([
+            { "type": "blockquote", "content": [{ "type": "paragraph", "content": [{ "type": "text", "text": "quoted" }] }] },
+            { "type": "rule" }
+        ]));
+        assert_eq!(adf_to_markdown(&document), "> quoted\n\n---");
+    }
+
+    #[test]
+    fn adf_field_reads_a_null_description_as_empty_and_a_string_verbatim() {
+        assert_eq!(adf_field_to_markdown(None), "");
+        assert_eq!(adf_field_to_markdown(Some(&Value::Null)), "");
+        assert_eq!(
+            adf_field_to_markdown(Some(&Value::String("legacy".into()))),
+            "legacy"
+        );
+    }
+
+    #[test]
+    fn adf_writer_emits_the_minimal_document_jira_accepts() {
+        let document = text_to_adf("hello");
+        assert_eq!(document["type"], "doc");
+        assert_eq!(document["version"], 1);
+        assert_eq!(document["content"][0]["type"], "paragraph");
+        assert_eq!(document["content"][0]["content"][0]["type"], "text");
+        assert_eq!(document["content"][0]["content"][0]["text"], "hello");
+    }
+
+    #[test]
+    fn adf_writer_emits_one_paragraph_per_non_empty_line() {
+        let document = text_to_adf("first\n\nsecond\n");
+        let content = document["content"].as_array().unwrap();
+        assert_eq!(content.len(), 2);
+        assert_eq!(content[0]["content"][0]["text"], "first");
+        assert_eq!(content[1]["content"][0]["text"], "second");
+    }
+
+    #[test]
+    fn adf_writer_falls_back_to_one_empty_paragraph_for_blank_input() {
+        let document = text_to_adf("   \n\n");
+        let content = document["content"].as_array().unwrap();
+        assert_eq!(content.len(), 1);
+        assert_eq!(content[0]["type"], "paragraph");
+        assert!(content[0]["content"].as_array().unwrap().is_empty());
+    }
+
+    #[test]
+    fn adf_round_trips_a_multi_paragraph_body() {
+        let text = "first line\n\nsecond line";
+        assert_eq!(adf_to_markdown(&text_to_adf(text)), text);
+    }
+
+    #[test]
+    fn issue_parses_from_a_captured_shape_payload() {
+        let raw = r#"{
+            "id": "10002",
+            "key": "GB-12",
+            "fields": {
+                "summary": "Ship the jira lens",
+                "description": { "type": "doc", "version": 1, "content": [
+                    { "type": "paragraph", "content": [{ "type": "text", "text": "Needs ADF" }] } ] },
+                "status": { "name": "In Progress", "statusCategory": { "key": "indeterminate" } },
+                "issuetype": { "name": "Task" },
+                "priority": { "name": "High" },
+                "assignee": { "accountId": "acc-1", "displayName": "Amin", "emailAddress": null,
+                              "avatarUrls": { "48x48": "https://x/a.png" } },
+                "reporter": { "accountId": "acc-2", "displayName": "Bot" },
+                "labels": ["backend"],
+                "created": "2026-07-01T10:00:00.000+0000",
+                "updated": "2026-07-02T10:00:00.000+0000"
+            }
+        }"#;
+        let issue = map_issue(
+            serde_json::from_str(raw).unwrap(),
+            "https://acme.atlassian.net",
+        );
+        assert_eq!(issue.key, "GB-12");
+        assert_eq!(issue.description, "Needs ADF");
+        assert_eq!(issue.status_category, "indeterminate");
+        assert_eq!(issue.url, "https://acme.atlassian.net/browse/GB-12");
+        assert_eq!(
+            issue.assignee.unwrap().avatar_urls.unwrap().large.unwrap(),
+            "https://x/a.png"
+        );
+    }
+
+    #[test]
+    fn issue_defaults_every_optional_field_on_a_bare_payload() {
+        let raw = r#"{ "id": "1", "key": "GB-1" }"#;
+        let issue = map_issue(serde_json::from_str(raw).unwrap(), "https://x");
+        assert_eq!(issue.summary, "");
+        assert_eq!(issue.description, "");
+        assert_eq!(issue.status, "");
+        assert!(issue.priority.is_none());
+        assert!(issue.assignee.is_none());
+        assert!(issue.labels.is_empty());
+    }
+
+    #[test]
+    fn issue_serializes_to_camel_case_for_the_frontend() {
+        let issue = map_issue(
+            serde_json::from_str(r#"{ "id": "1", "key": "GB-1" }"#).unwrap(),
+            "https://x",
+        );
+        let value = serde_json::to_value(&issue).unwrap();
+        assert_eq!(value["statusCategory"], "");
+        assert_eq!(value["issueType"], "");
+        assert_eq!(value["key"], "GB-1");
+    }
+
+    #[test]
+    fn search_pager_collects_pages_until_is_last() {
+        let mut pager = SearchPager::new();
+        let first: JiraSearchPage = serde_json::from_str(
+            r#"{ "issues": [{ "id": "1", "key": "GB-1" }], "nextPageToken": "t1", "isLast": false }"#,
+        )
+        .unwrap();
+        let second: JiraSearchPage = serde_json::from_str(
+            r#"{ "issues": [{ "id": "2", "key": "GB-2" }], "isLast": true }"#,
+        )
+        .unwrap();
+        assert_eq!(pager.absorb(first).unwrap(), Some("t1".to_string()));
+        assert_eq!(pager.absorb(second).unwrap(), None);
+        assert_eq!(pager.issues.len(), 2);
+    }
+
+    #[test]
+    fn search_pager_drops_issues_reserved_across_pages() {
+        let mut pager = SearchPager::new();
+        let first: JiraSearchPage = serde_json::from_str(
+            r#"{ "issues": [{ "id": "1", "key": "GB-1" }], "nextPageToken": "t1" }"#,
+        )
+        .unwrap();
+        let second: JiraSearchPage = serde_json::from_str(
+            r#"{ "issues": [{ "id": "1", "key": "GB-1" }, { "id": "2", "key": "GB-2" }], "isLast": true }"#,
+        )
+        .unwrap();
+        pager.absorb(first).unwrap();
+        pager.absorb(second).unwrap();
+        let keys: Vec<&str> = pager.issues.iter().map(|issue| issue.key.as_str()).collect();
+        assert_eq!(keys, vec!["GB-1", "GB-2"]);
+    }
+
+    #[test]
+    fn search_pager_bails_when_the_page_token_repeats_with_no_progress() {
+        let mut pager = SearchPager::new();
+        let page = || -> JiraSearchPage {
+            serde_json::from_str(
+                r#"{ "issues": [{ "id": "1", "key": "GB-1" }], "nextPageToken": "t1", "isLast": false }"#,
+            )
+            .unwrap()
+        };
+        assert_eq!(pager.absorb(page()).unwrap(), Some("t1".to_string()));
+        let err = pager.absorb(page()).unwrap_err();
+        assert!(matches!(err, JiraError::InvalidShape(ref m) if m.contains("looped on token t1")));
+    }
+
+    #[test]
+    fn search_pager_stops_on_a_missing_token_even_without_is_last() {
+        let mut pager = SearchPager::new();
+        let page: JiraSearchPage =
+            serde_json::from_str(r#"{ "issues": [{ "id": "1", "key": "GB-1" }] }"#).unwrap();
+        assert_eq!(pager.absorb(page).unwrap(), None);
+    }
+
+    #[test]
+    fn comment_page_uses_start_at_and_total_not_a_cursor() {
+        let raw = r#"{
+            "startAt": 0, "maxResults": 100, "total": 3,
+            "comments": [
+                { "id": "1", "author": { "accountId": "acc-1", "displayName": "Amin" },
+                  "body": { "type": "doc", "version": 1, "content": [
+                    { "type": "paragraph", "content": [{ "type": "text", "text": "looks good" }] } ] },
+                  "created": "2026-07-01T10:00:00.000+0000", "updated": "2026-07-01T10:00:00.000+0000" }
+            ]
+        }"#;
+        let page: JiraCommentPage = serde_json::from_str(raw).unwrap();
+        assert_eq!(next_comment_offset(&page), Some(1));
+        let comment = map_comment(page.comments.into_iter().next().unwrap());
+        assert_eq!(comment.body, "looks good");
+        assert_eq!(comment.author.unwrap().display_name, "Amin");
+    }
+
+    #[test]
+    fn next_comment_offset_stops_once_total_is_reached() {
+        let page: JiraCommentPage = serde_json::from_str(
+            r#"{ "startAt": 2, "total": 3, "comments": [{ "id": "3" }] }"#,
+        )
+        .unwrap();
+        assert_eq!(next_comment_offset(&page), None);
+    }
+
+    #[test]
+    fn next_comment_offset_stops_on_an_empty_page() {
+        let page: JiraCommentPage =
+            serde_json::from_str(r#"{ "startAt": 0, "total": 9, "comments": [] }"#).unwrap();
+        assert_eq!(next_comment_offset(&page), None);
+    }
+
+    #[test]
+    fn transitions_parse_from_the_wrapped_payload() {
+        let raw = r#"{ "transitions": [
+            { "id": "31", "name": "Done", "hasScreen": false,
+              "to": { "id": "10001", "name": "Done" } },
+            { "id": "21", "name": "In Progress" }
+        ] }"#;
+        let payload: JiraTransitionsPayload = serde_json::from_str(raw).unwrap();
+        assert_eq!(payload.transitions.len(), 2);
+        assert_eq!(payload.transitions[0].to.as_ref().unwrap().name, "Done");
+        assert!(payload.transitions[1].to.is_none());
+    }
+
+    #[test]
+    fn assignable_users_parse_from_a_flat_array() {
+        let raw = r#"[
+            { "accountId": "acc-1", "displayName": "Amin", "active": true,
+              "avatarUrls": { "24x24": "https://x/s.png", "48x48": "https://x/l.png" } },
+            { "accountId": "acc-2", "displayName": "Bot" }
+        ]"#;
+        let users: Vec<JiraUser> = serde_json::from_str(raw).unwrap();
+        assert_eq!(users.len(), 2);
+        assert_eq!(users[0].active, Some(true));
+        assert_eq!(
+            users[0].avatar_urls.as_ref().unwrap().small.as_deref(),
+            Some("https://x/s.png")
+        );
+        assert!(users[1].avatar_urls.is_none());
+    }
+
+    #[test]
+    fn myself_parses_with_a_private_email_address() {
+        let raw = r#"{ "accountId": "acc-1", "displayName": "Amin K", "emailAddress": null,
+                       "active": true, "timeZone": "Europe/Rome" }"#;
+        let user: JiraUser = serde_json::from_str(raw).unwrap();
+        assert_eq!(user.account_id, "acc-1");
+        assert_eq!(user.display_name, "Amin K");
+        assert!(user.email_address.is_none());
+    }
+
+    #[test]
+    fn assignee_payload_sends_a_null_account_id_to_unassign() {
+        assert_eq!(assignee_payload(None)["accountId"], Value::Null);
+        assert_eq!(assignee_payload(Some("  "))["accountId"], Value::Null);
+        assert_eq!(assignee_payload(Some("acc-1"))["accountId"], "acc-1");
+    }
+
+    #[test]
+    fn comment_payload_wraps_the_text_in_an_adf_document() {
+        let payload = serde_json::json!({ "body": text_to_adf("ship it") });
+        assert_eq!(payload["body"]["type"], "doc");
+        assert_eq!(payload["body"]["version"], 1);
+        assert_eq!(payload["body"]["content"][0]["content"][0]["text"], "ship it");
+    }
+
+    #[test]
+    fn description_payload_nests_the_document_under_fields() {
+        let payload =
+            serde_json::json!({ "fields": { "description": text_to_adf("new description") } });
+        assert_eq!(payload["fields"]["description"]["type"], "doc");
+        assert_eq!(
+            payload["fields"]["description"]["content"][0]["content"][0]["text"],
+            "new description"
+        );
+    }
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -11,6 +11,7 @@ mod external_terminal;
 mod file_versions;
 mod github;
 mod gitlab;
+mod jira;
 mod linear;
 mod parallel_groups;
 mod path_env;
@@ -72,6 +73,7 @@ pub fn run() {
     let linear_token_cache = linear::LinearTokenCache::new();
     let sentry_token_cache = sentry::SentryTokenCache::new();
     let gitlab_token_cache = gitlab::GitlabTokenCache::new();
+    let jira_token_cache = jira::JiraTokenCache::new();
 
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
@@ -91,6 +93,7 @@ pub fn run() {
         .manage(linear_token_cache)
         .manage(sentry_token_cache)
         .manage(gitlab_token_cache)
+        .manage(jira_token_cache)
         .setup(|app| {
             #[cfg(desktop)]
             app.handle()
@@ -293,6 +296,17 @@ pub fn run() {
             gitlab::gitlab_approve_mr,
             gitlab::gitlab_unapprove_mr,
             gitlab::gitlab_update_mr_state,
+            jira::jira_validate_connection,
+            jira::jira_disconnect,
+            jira::jira_list_issues,
+            jira::jira_get_issue,
+            jira::jira_list_comments,
+            jira::jira_create_comment,
+            jira::jira_update_issue,
+            jira::jira_set_assignee,
+            jira::jira_list_assignable_users,
+            jira::jira_list_transitions,
+            jira::jira_transition_issue,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/apps/desktop/src/features/integrations/jira/client.test.ts
+++ b/apps/desktop/src/features/integrations/jira/client.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { invoke } from '@tauri-apps/api/core';
+import type { WorkspaceId } from '@goodboy/types';
+import {
+  jiraCreateComment,
+  jiraDisconnect,
+  jiraGetIssue,
+  jiraListAssignableUsers,
+  jiraListComments,
+  jiraListIssues,
+  jiraListTransitions,
+  jiraSetAssignee,
+  jiraTransitionIssue,
+  jiraUpdateIssueDescription,
+  jiraValidateConnection,
+  type JiraIssue,
+} from './client';
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
+
+const mockInvoke = vi.mocked(invoke);
+
+afterEach(() => {
+  mockInvoke.mockReset();
+});
+
+const site = {
+  workspaceId: 'w1' as WorkspaceId,
+  siteUrl: 'https://acme.atlassian.net',
+  email: 'amin@acme.io',
+};
+
+const target = { ...site, issueKey: 'GB-12' };
+
+describe('jira client', () => {
+  it('validates a connection with the site, email and api token', async () => {
+    mockInvoke.mockResolvedValue({ accountId: 'acc-1', displayName: 'Amin' });
+
+    await jiraValidateConnection({ ...site, apiToken: 'tok' });
+
+    expect(mockInvoke).toHaveBeenCalledWith('jira_validate_connection', {
+      workspaceId: 'w1',
+      siteUrl: 'https://acme.atlassian.net',
+      email: 'amin@acme.io',
+      apiToken: 'tok',
+    });
+  });
+
+  it('disconnects with the workspace alone', async () => {
+    mockInvoke.mockResolvedValue(undefined);
+
+    await jiraDisconnect({ workspaceId: 'w1' as WorkspaceId });
+
+    expect(mockInvoke).toHaveBeenCalledWith('jira_disconnect', { workspaceId: 'w1' });
+  });
+
+  it('lists issues for a project key and returns the payload untouched', async () => {
+    const issue: JiraIssue = {
+      id: '10002',
+      key: 'GB-12',
+      summary: 'Ship the jira lens',
+      description: 'Needs ADF',
+      status: 'In Progress',
+      statusCategory: 'indeterminate',
+      issueType: 'Task',
+      priority: 'High',
+      assignee: null,
+      reporter: null,
+      labels: ['backend'],
+      created: '2026-07-01T10:00:00.000+0000',
+      updated: '2026-07-02T10:00:00.000+0000',
+      url: 'https://acme.atlassian.net/browse/GB-12',
+    };
+    mockInvoke.mockResolvedValue([issue]);
+
+    const issues = await jiraListIssues({ ...site, projectKey: 'GB', assignedOnly: true });
+
+    expect(mockInvoke).toHaveBeenCalledWith('jira_list_issues', {
+      ...site,
+      projectKey: 'GB',
+      assignedOnly: true,
+    });
+    expect(issues).toEqual([issue]);
+  });
+
+  it('reads a single issue by key', async () => {
+    mockInvoke.mockResolvedValue({ key: 'GB-12' });
+
+    await jiraGetIssue(target);
+
+    expect(mockInvoke).toHaveBeenCalledWith('jira_get_issue', target);
+  });
+
+  it('lists and creates comments against the same issue key', async () => {
+    mockInvoke.mockResolvedValue([]);
+    await jiraListComments(target);
+    expect(mockInvoke).toHaveBeenCalledWith('jira_list_comments', target);
+
+    mockInvoke.mockResolvedValue({ id: '1', author: null, body: 'ok', created: '', updated: '' });
+    await jiraCreateComment({ ...target, body: 'ship it' });
+    expect(mockInvoke).toHaveBeenCalledWith('jira_create_comment', {
+      ...target,
+      body: 'ship it',
+    });
+  });
+
+  it('sends the description as plain text and resolves to nothing', async () => {
+    mockInvoke.mockResolvedValue(undefined);
+
+    const result = await jiraUpdateIssueDescription({ ...target, description: 'new body' });
+
+    expect(mockInvoke).toHaveBeenCalledWith('jira_update_issue', {
+      ...target,
+      description: 'new body',
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it('passes a null account id through when unassigning', async () => {
+    mockInvoke.mockResolvedValue(undefined);
+
+    await jiraSetAssignee({ ...target, accountId: null });
+
+    expect(mockInvoke).toHaveBeenCalledWith('jira_set_assignee', { ...target, accountId: null });
+  });
+
+  it('normalizes a missing assignable-user query to null', async () => {
+    mockInvoke.mockResolvedValue([]);
+
+    await jiraListAssignableUsers(target);
+
+    expect(mockInvoke).toHaveBeenCalledWith('jira_list_assignable_users', {
+      ...target,
+      query: null,
+    });
+  });
+
+  it('lists transitions and posts the chosen transition id', async () => {
+    mockInvoke.mockResolvedValue([{ id: '31', name: 'Done', to: null, hasScreen: false }]);
+    const transitions = await jiraListTransitions(target);
+    expect(transitions).toHaveLength(1);
+    expect(mockInvoke).toHaveBeenCalledWith('jira_list_transitions', target);
+
+    mockInvoke.mockResolvedValue(undefined);
+    await jiraTransitionIssue({ ...target, transitionId: '31' });
+    expect(mockInvoke).toHaveBeenCalledWith('jira_transition_issue', {
+      ...target,
+      transitionId: '31',
+    });
+  });
+});

--- a/apps/desktop/src/features/integrations/jira/client.ts
+++ b/apps/desktop/src/features/integrations/jira/client.ts
@@ -1,0 +1,221 @@
+import { invoke } from '@tauri-apps/api/core';
+import type { WorkspaceId } from '@goodboy/types';
+
+export type JiraAvatarUrls = {
+  readonly '48x48': string | null;
+  readonly '24x24': string | null;
+};
+
+export type JiraUser = {
+  readonly accountId: string;
+  readonly displayName: string;
+  readonly emailAddress: string | null;
+  readonly avatarUrls: JiraAvatarUrls | null;
+  readonly active: boolean | null;
+};
+
+export type JiraStatusCategoryKey = 'new' | 'indeterminate' | 'done' | '';
+
+export type JiraIssue = {
+  readonly id: string;
+  readonly key: string;
+  readonly summary: string;
+  readonly description: string;
+  readonly status: string;
+  readonly statusCategory: JiraStatusCategoryKey;
+  readonly issueType: string;
+  readonly priority: string | null;
+  readonly assignee: JiraUser | null;
+  readonly reporter: JiraUser | null;
+  readonly labels: ReadonlyArray<string>;
+  readonly created: string;
+  readonly updated: string;
+  readonly url: string;
+};
+
+export type JiraComment = {
+  readonly id: string;
+  readonly author: JiraUser | null;
+  readonly body: string;
+  readonly created: string;
+  readonly updated: string;
+};
+
+export type JiraTransitionTarget = {
+  readonly id: string;
+  readonly name: string;
+};
+
+export type JiraTransition = {
+  readonly id: string;
+  readonly name: string;
+  readonly to: JiraTransitionTarget | null;
+  readonly hasScreen: boolean;
+};
+
+export type JiraSite = {
+  readonly workspaceId: WorkspaceId;
+  readonly siteUrl: string;
+  readonly email: string;
+};
+
+export type JiraIssueTarget = JiraSite & {
+  readonly issueKey: string;
+};
+
+type ValidateParams = {
+  readonly workspaceId: WorkspaceId;
+  readonly siteUrl: string;
+  readonly email: string;
+  readonly apiToken: string;
+};
+
+export const jiraValidateConnection = async ({
+  workspaceId,
+  siteUrl,
+  email,
+  apiToken,
+}: ValidateParams): Promise<JiraUser> =>
+  invoke<JiraUser>('jira_validate_connection', { workspaceId, siteUrl, email, apiToken });
+
+type DisconnectParams = {
+  readonly workspaceId: WorkspaceId;
+};
+
+export const jiraDisconnect = async ({ workspaceId }: DisconnectParams): Promise<void> => {
+  await invoke('jira_disconnect', { workspaceId });
+};
+
+type ListIssuesParams = JiraSite & {
+  readonly projectKey: string;
+  readonly assignedOnly: boolean;
+};
+
+export const jiraListIssues = async ({
+  workspaceId,
+  siteUrl,
+  email,
+  projectKey,
+  assignedOnly,
+}: ListIssuesParams): Promise<ReadonlyArray<JiraIssue>> =>
+  invoke<ReadonlyArray<JiraIssue>>('jira_list_issues', {
+    workspaceId,
+    siteUrl,
+    email,
+    projectKey,
+    assignedOnly,
+  });
+
+export const jiraGetIssue = async ({
+  workspaceId,
+  siteUrl,
+  email,
+  issueKey,
+}: JiraIssueTarget): Promise<JiraIssue> =>
+  invoke<JiraIssue>('jira_get_issue', { workspaceId, siteUrl, email, issueKey });
+
+export const jiraListComments = async ({
+  workspaceId,
+  siteUrl,
+  email,
+  issueKey,
+}: JiraIssueTarget): Promise<ReadonlyArray<JiraComment>> =>
+  invoke<ReadonlyArray<JiraComment>>('jira_list_comments', {
+    workspaceId,
+    siteUrl,
+    email,
+    issueKey,
+  });
+
+type CreateCommentParams = JiraIssueTarget & {
+  readonly body: string;
+};
+
+export const jiraCreateComment = async ({
+  workspaceId,
+  siteUrl,
+  email,
+  issueKey,
+  body,
+}: CreateCommentParams): Promise<JiraComment> =>
+  invoke<JiraComment>('jira_create_comment', { workspaceId, siteUrl, email, issueKey, body });
+
+type UpdateDescriptionParams = JiraIssueTarget & {
+  readonly description: string;
+};
+
+export const jiraUpdateIssueDescription = async ({
+  workspaceId,
+  siteUrl,
+  email,
+  issueKey,
+  description,
+}: UpdateDescriptionParams): Promise<void> => {
+  await invoke('jira_update_issue', { workspaceId, siteUrl, email, issueKey, description });
+};
+
+type SetAssigneeParams = JiraIssueTarget & {
+  readonly accountId: string | null;
+};
+
+export const jiraSetAssignee = async ({
+  workspaceId,
+  siteUrl,
+  email,
+  issueKey,
+  accountId,
+}: SetAssigneeParams): Promise<void> => {
+  await invoke('jira_set_assignee', { workspaceId, siteUrl, email, issueKey, accountId });
+};
+
+type AssignableParams = JiraIssueTarget & {
+  readonly query?: string;
+};
+
+export const jiraListAssignableUsers = async ({
+  workspaceId,
+  siteUrl,
+  email,
+  issueKey,
+  query,
+}: AssignableParams): Promise<ReadonlyArray<JiraUser>> =>
+  invoke<ReadonlyArray<JiraUser>>('jira_list_assignable_users', {
+    workspaceId,
+    siteUrl,
+    email,
+    issueKey,
+    query: query ?? null,
+  });
+
+export const jiraListTransitions = async ({
+  workspaceId,
+  siteUrl,
+  email,
+  issueKey,
+}: JiraIssueTarget): Promise<ReadonlyArray<JiraTransition>> =>
+  invoke<ReadonlyArray<JiraTransition>>('jira_list_transitions', {
+    workspaceId,
+    siteUrl,
+    email,
+    issueKey,
+  });
+
+type TransitionParams = JiraIssueTarget & {
+  readonly transitionId: string;
+};
+
+export const jiraTransitionIssue = async ({
+  workspaceId,
+  siteUrl,
+  email,
+  issueKey,
+  transitionId,
+}: TransitionParams): Promise<void> => {
+  await invoke('jira_transition_issue', {
+    workspaceId,
+    siteUrl,
+    email,
+    issueKey,
+    transitionId,
+  });
+};

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -102,6 +102,7 @@ import { m101TelemetryOrchestratorKind } from './m101-telemetry-orchestrator-kin
 import { m102WorkflowOrchestrationStopKind } from './m102-workflow-orchestration-stop-kind';
 import { m103SessionExternalTaskBranch } from './m103-session-external-task-branch';
 import { m104PendingResolutionReplyPosted } from './m104-pending-resolution-reply-posted';
+import { m105IntegrationJiraProvider } from './m105-integration-jira-provider';
 
 export type Migration = {
   readonly version: number;
@@ -213,4 +214,5 @@ export const migrations: ReadonlyArray<Migration> = [
   { version: 102, sql: m102WorkflowOrchestrationStopKind },
   { version: 103, sql: m103SessionExternalTaskBranch },
   { version: 104, sql: m104PendingResolutionReplyPosted },
+  { version: 105, sql: m105IntegrationJiraProvider },
 ];

--- a/packages/db/src/migrations/m105-integration-jira-provider.test.ts
+++ b/packages/db/src/migrations/m105-integration-jira-provider.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import type { Database } from '../client';
+import { makeTestDatabase } from '../test-helpers/test-db';
+import { migrate } from './runner';
+import { migrations } from './index';
+
+const workspaceId = 'ws-1';
+const sessionId = 's-1';
+
+const seedThrough104 = async (): Promise<Database> => {
+  const db = makeTestDatabase();
+  await migrate(
+    db,
+    migrations.filter((migration) => migration.version <= 104),
+  );
+  const now = Date.now();
+  await db.execute(
+    'INSERT INTO workspaces (id, name, root_path, created_at, updated_at) VALUES (?, ?, ?, ?, ?)',
+    [workspaceId, 'ws', '/tmp/ws', now, now],
+  );
+  await db.execute(
+    'INSERT INTO sessions (id, workspace_id, goal, state_kind, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)',
+    [sessionId, workspaceId, 'goal', 'idle', now, now],
+  );
+  return db;
+};
+
+describe('m105 integration jira provider', () => {
+  it('carries mount_workspace_id and branch through the external task rebuild', async () => {
+    const db = await seedThrough104();
+    await db.execute(
+      `INSERT INTO session_external_tasks
+         (session_id, mount_workspace_id, provider, external_id, identifier, url, title, created_at, branch)
+       VALUES (?, ?, 'linear', 'ext-1', 'GB-1', 'https://linear.app/goodboy/issue/GB-1', 'Ship it', ?, 'ak/fix-auth')`,
+      [sessionId, workspaceId, Date.now()],
+    );
+
+    await migrate(db, migrations);
+
+    const rows = await db.select<{ mount_workspace_id: string | null; branch: string | null }>(
+      'SELECT mount_workspace_id, branch FROM session_external_tasks',
+    );
+    expect(rows).toEqual([{ mount_workspace_id: workspaceId, branch: 'ak/fix-auth' }]);
+  });
+
+  it('keeps both external task indexes after the rebuild', async () => {
+    const db = await seedThrough104();
+
+    await migrate(db, migrations);
+
+    const indexes = await db.select<{ name: string }>(
+      "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'session_external_tasks' AND sql IS NOT NULL ORDER BY name",
+    );
+    expect(indexes.map((index) => index.name)).toEqual([
+      'idx_session_external_tasks_identity',
+      'idx_session_external_tasks_provider_external',
+    ]);
+  });
+
+  it('accepts a jira row in both widened tables', async () => {
+    const db = await seedThrough104();
+
+    await migrate(db, migrations);
+
+    const now = Date.now();
+    await db.execute(
+      `INSERT INTO workspace_integrations (id, workspace_id, provider, config, credential_key, created_at, updated_at)
+       VALUES ('wi-jira', ?, 'jira', '{}', 'goodboy.workspace.ws-1.jira', ?, ?)`,
+      [workspaceId, now, now],
+    );
+    await db.execute(
+      `INSERT INTO session_external_tasks
+         (session_id, mount_workspace_id, provider, external_id, identifier, url, title, created_at, branch)
+       VALUES (?, NULL, 'jira', '10001', 'GB-7', 'https://acme.atlassian.net/browse/GB-7', 'Ship it', ?, NULL)`,
+      [sessionId, now],
+    );
+
+    const providers = await db.select<{ provider: string }>(
+      'SELECT provider FROM session_external_tasks',
+    );
+    expect(providers).toEqual([{ provider: 'jira' }]);
+  });
+
+  it('still rejects a provider outside the widened check', async () => {
+    const db = await seedThrough104();
+
+    await migrate(db, migrations);
+
+    await expect(
+      db.execute(
+        `INSERT INTO workspace_integrations (id, workspace_id, provider, config, credential_key, created_at, updated_at)
+         VALUES ('wi-x', ?, 'asana', '{}', 'k', ?, ?)`,
+        [workspaceId, Date.now(), Date.now()],
+      ),
+    ).rejects.toThrow(/CHECK constraint/);
+  });
+});

--- a/packages/db/src/migrations/m105-integration-jira-provider.ts
+++ b/packages/db/src/migrations/m105-integration-jira-provider.ts
@@ -1,0 +1,65 @@
+export const m105IntegrationJiraProvider = /* sql */ `
+PRAGMA foreign_keys = OFF;
+
+DROP TABLE IF EXISTS workspace_integrations_new;
+
+CREATE TABLE workspace_integrations_new (
+  id TEXT PRIMARY KEY,
+  workspace_id TEXT NOT NULL,
+  provider TEXT NOT NULL CHECK (provider IN ('linear', 'sentry', 'gitlab', 'jira')),
+  config TEXT NOT NULL DEFAULT '{}',
+  credential_key TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  UNIQUE (workspace_id, provider),
+  FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE
+);
+
+INSERT INTO workspace_integrations_new (id, workspace_id, provider, config, credential_key, created_at, updated_at)
+  SELECT id, workspace_id, provider, config, credential_key, created_at, updated_at
+  FROM workspace_integrations;
+
+DROP TABLE workspace_integrations;
+ALTER TABLE workspace_integrations_new RENAME TO workspace_integrations;
+
+DROP INDEX IF EXISTS idx_workspace_integrations_workspace_id;
+CREATE INDEX idx_workspace_integrations_workspace_id ON workspace_integrations(workspace_id);
+
+DROP TABLE IF EXISTS session_external_tasks_new;
+
+CREATE TABLE session_external_tasks_new (
+  session_id TEXT NOT NULL,
+  mount_workspace_id TEXT,
+  provider TEXT NOT NULL CHECK (provider IN ('linear', 'sentry', 'gitlab', 'github', 'jira')),
+  external_id TEXT NOT NULL,
+  identifier TEXT NOT NULL,
+  url TEXT NOT NULL,
+  title TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  branch TEXT,
+  FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+);
+
+INSERT INTO session_external_tasks_new
+  (session_id, mount_workspace_id, provider, external_id, identifier, url, title, created_at, branch)
+  SELECT session_id, mount_workspace_id, provider, external_id, identifier, url, title, created_at, branch
+  FROM session_external_tasks;
+
+DROP TABLE session_external_tasks;
+ALTER TABLE session_external_tasks_new RENAME TO session_external_tasks;
+
+DROP INDEX IF EXISTS idx_session_external_tasks_provider_external;
+CREATE INDEX idx_session_external_tasks_provider_external
+  ON session_external_tasks(provider, external_id);
+DROP INDEX IF EXISTS idx_session_external_tasks_identity;
+CREATE UNIQUE INDEX idx_session_external_tasks_identity
+  ON session_external_tasks(
+    session_id,
+    provider,
+    external_id,
+    COALESCE(mount_workspace_id, '')
+  );
+
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys = ON;
+`;

--- a/packages/db/src/queries/workspace-integration.test.ts
+++ b/packages/db/src/queries/workspace-integration.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type {
   GitlabIntegrationConfig,
+  JiraIntegrationConfig,
   LinearIntegrationConfig,
   SentryIntegrationConfig,
   WorkspaceId,
@@ -265,7 +266,33 @@ describe('workspace_integrations queries', () => {
   it('rejects an unknown provider via the widened CHECK constraint', async () => {
     const db = await seed();
     await expect(
-      upsertWorkspaceIntegration(db, makeSentryIntegration({ provider: 'jira' as never })),
+      upsertWorkspaceIntegration(db, makeSentryIntegration({ provider: 'asana' as never })),
     ).rejects.toThrow(/CHECK constraint/);
+  });
+
+  it('round-trips a jira integration with its site url, email and project key', async () => {
+    const db = await seed();
+    const jiraConfig: JiraIntegrationConfig = {
+      siteUrl: 'https://acme.atlassian.net',
+      email: 'amin@acme.io',
+      projectKey: 'GB',
+      accountId: '5b10a2844c20165700ede21g',
+      displayName: 'Amin K',
+    };
+    await upsertWorkspaceIntegration(
+      db,
+      makeIntegration({
+        id: 'jira-1' as WorkspaceIntegrationId,
+        provider: 'jira',
+        config: jiraConfig,
+        credentialKey: `goodboy.workspace.${workspaceId}.jira`,
+      }),
+    );
+
+    const got = await getWorkspaceIntegration(db, workspaceId, 'jira');
+    expect(got!.provider).toBe('jira');
+    expect((got!.config as JiraIntegrationConfig).siteUrl).toBe('https://acme.atlassian.net');
+    expect((got!.config as JiraIntegrationConfig).projectKey).toBe('GB');
+    expect(got!.credentialKey).toBe(`goodboy.workspace.${workspaceId}.jira`);
   });
 });

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -29,6 +29,8 @@ export type {
   ContextSlotHistoryEntry,
   GitlabIntegrationConfig,
   GitlabWorkspaceIntegration,
+  JiraIntegrationConfig,
+  JiraWorkspaceIntegration,
   LinearIntegrationConfig,
   LinearWorkspaceIntegration,
   OrchestratorRouting,

--- a/packages/types/src/workspace.ts
+++ b/packages/types/src/workspace.ts
@@ -149,7 +149,7 @@ export type WorkspaceScript = Readonly<{
   updatedAt: IsoDateTime;
 }>;
 
-export type WorkspaceIntegrationProvider = 'linear' | 'sentry' | 'gitlab';
+export type WorkspaceIntegrationProvider = 'linear' | 'sentry' | 'gitlab' | 'jira';
 
 export type LinearIntegrationConfig = Readonly<{
   workspaceUrlKey: string;
@@ -170,10 +170,19 @@ export type GitlabIntegrationConfig = Readonly<{
   host: string;
 }>;
 
+export type JiraIntegrationConfig = Readonly<{
+  siteUrl: string;
+  email: string;
+  projectKey: string;
+  accountId?: string;
+  displayName?: string;
+}>;
+
 export type WorkspaceIntegrationConfig =
   | LinearIntegrationConfig
   | SentryIntegrationConfig
-  | GitlabIntegrationConfig;
+  | GitlabIntegrationConfig
+  | JiraIntegrationConfig;
 
 type WorkspaceIntegrationBase = Readonly<{
   id: WorkspaceIntegrationId;
@@ -201,10 +210,17 @@ export type GitlabWorkspaceIntegration = WorkspaceIntegrationBase &
     config: GitlabIntegrationConfig;
   }>;
 
+export type JiraWorkspaceIntegration = WorkspaceIntegrationBase &
+  Readonly<{
+    provider: 'jira';
+    config: JiraIntegrationConfig;
+  }>;
+
 export type WorkspaceIntegration =
   | LinearWorkspaceIntegration
   | SentryWorkspaceIntegration
-  | GitlabWorkspaceIntegration;
+  | GitlabWorkspaceIntegration
+  | JiraWorkspaceIntegration;
 
 export type SessionExternalTaskProvider = 'linear' | 'sentry' | 'gitlab' | 'github';
 


### PR DESCRIPTION
## What

The Jira Cloud backend for v0.1.63: a Rust command surface over Jira REST v3, the ADF bridge, the
workspace-integration types, migration m105, and the TypeScript client. No UI ships here. Items 2
and 3 build the studio and the action verbs on top of this.

### Files

- `apps/desktop/src-tauri/src/jira.rs` (new, 49 inline network-free tests)
- `apps/desktop/src-tauri/src/lib.rs` (module, token cache, `.manage()`, `generate_handler!`)
- `apps/desktop/src/features/integrations/jira/client.ts` (new)
- `apps/desktop/src/features/integrations/jira/client.test.ts` (new)
- `packages/types/src/workspace.ts`, `packages/types/src/index.ts`
- `packages/db/src/migrations/m105-integration-jira-provider.ts` (new)
- `packages/db/src/migrations/m105-integration-jira-provider.test.ts` (new)
- `packages/db/src/migrations/index.ts`
- `packages/db/src/queries/workspace-integration.test.ts`

### Why it looks the way it does

`gitlab.rs`'s helpers are module-private, so `jira.rs` owns its own private HTTP set rather than
importing them. Auth is `reqwest`'s built-in `.basic_auth(email, Some(api_token))`, no hand-rolled
base64. `get_json_paged` is unusable for Jira: it reads the `x-next-page` response header as an
integer, while Jira's enhanced search returns an opaque `nextPageToken` string in the JSON body, so
the search path gets its own `SearchPager`.

That pager does three things beyond collecting pages, because the community reports this endpoint's
pagination is currently unreliable in production: it caps at `MAX_PAGES = 20`, it dedupes issues by
key across pages, and it returns an explicit `InvalidShape` error when a `nextPageToken` repeats
rather than quietly returning twenty pages of duplicates. A "token repeats, no progress" fixture
test locks that in.

The comments endpoint deliberately does NOT share the search cursor scheme: it still uses
`startAt`/`total`, and `next_comment_offset` is a separate pure function so the two paginations can
never bleed into each other.

The ADF bridge is a permissive reader (paragraph, heading, bullet and ordered lists, codeBlock,
blockquote, rule, text marks, hardBreak, mention, emoji, inlineCard, with unknown nodes flattened to
their contained text instead of dropped) and a deliberately minimal writer (plain text to one
paragraph node per non-blank line, nothing else), to keep the 400-on-write risk as low as possible.

## Tauri command checklist

Every command below is present in `generate_handler![...]` in `apps/desktop/src-tauri/src/lib.rs`
(lines 299 to 309). Checked one by one against the file.

- [x] `jira::jira_validate_connection`
- [x] `jira::jira_disconnect`
- [x] `jira::jira_list_issues`
- [x] `jira::jira_get_issue`
- [x] `jira::jira_list_comments`
- [x] `jira::jira_create_comment`
- [x] `jira::jira_update_issue`
- [x] `jira::jira_set_assignee`
- [x] `jira::jira_list_assignable_users`
- [x] `jira::jira_list_transitions`
- [x] `jira::jira_transition_issue`

`jira_disconnect` is the one command beyond the specified list. Without it nothing can invalidate
the in-process token cache, so a disconnect performed through the generic `secret_delete` command
would clear the keychain and leave a live token in memory for the rest of the app session. It
mirrors `gitlab_disconnect` exactly.

## UNVERIFIED AGAINST A LIVE TENANT

Every Jira call in this PR is contract-tested against fixture payloads shaped from Atlassian's
documentation. **None of them has ever been exercised against a real Atlassian site.** The following
list is carried verbatim from the release plan, restricted to the calls implemented here:

- GET /rest/api/3/myself (connect validation)
- GET /rest/api/3/search/jql (issue list, nextPageToken pagination), incl. the assumption that
  enhanced search fully replaced legacy /rest/api/3/search on Cloud
- GET /rest/api/3/issue/{key}
- GET /rest/api/3/issue/{key}/comment and POST same (ADF write acceptance)
- PUT /rest/api/3/issue/{key} (description ADF write acceptance)
- PUT /rest/api/3/issue/{key}/assignee and GET /rest/api/3/user/assignable/search
- GET /rest/api/3/issue/{key}/transitions and POST same

Green tests here mean the URL building, the serde parsing, the pagination folding, the error mapping
and the ADF conversion agree with the documented contracts. They do not mean a single byte has ever
reached atlassian.net.

## Migration m105

One file, both CHECK rebuilds, `PRAGMA foreign_keys = OFF` to `PRAGMA foreign_key_check` to
`PRAGMA foreign_keys = ON`.

- `workspace_integrations` half: template is **m065**. `provider IN ('linear','sentry','gitlab')`
  becomes `provider IN ('linear','sentry','gitlab','jira')`. The `UNIQUE (workspace_id, provider)`
  constraint, the cascade to `workspaces`, and `idx_workspace_integrations_workspace_id` are all
  recreated.
- `session_external_tasks` half: template is **m096**, NOT m065. m065 is stale for this table: since
  then it gained `mount_workspace_id` (m096) and `branch` (m103), `session_id` stopped being the
  primary key (m071), and a unique identity index was added (m096).
  `provider IN ('linear','sentry','gitlab','github')` becomes
  `provider IN ('linear','sentry','gitlab','github','jira')`. Note the two tables have different
  starting lists; each was widened against its own.

**Confirmed: `mount_workspace_id` and `branch` both survive the rebuild.** The new table declares
both, and the `INSERT ... SELECT` names both explicitly rather than relying on column order. Both
`idx_session_external_tasks_provider_external` and the unique
`idx_session_external_tasks_identity` are recreated. `m105-integration-jira-provider.test.ts` seeds
a row carrying a non-null `mount_workspace_id` and a non-null `branch`, migrates, and asserts both
values come out the other side, plus asserts both indexes exist by name.

## Tests deleted or weakened

Three rewritten, one of them after an independent verification pass found them worthless.

`comment_payload_wraps_the_text_in_an_adf_document`, `description_payload_nests_the_document_under_fields`
and `assignee_payload_sends_a_null_account_id_to_unassign` re-declared the same `json!` expression the
command built inline, so they asserted a copy of the code rather than the code. Sabotaging all four
write call sites at once (comment body sent as a raw string, description sent as a raw string,
`accountId` hardcoded to `"-1"`, transition id hardcoded to `"31"`) left every test green. Each write
verb now goes through a pure `JiraWrite` builder returning both url and body, and five tests assert
those builders: the same four sabotages now fail. No assertion was weakened; the coverage moved onto
the code that actually runs.

One more rewritten, as instructed:

`packages/db/src/queries/workspace-integration.test.ts` asserted that
`upsertWorkspaceIntegration(..., { provider: 'jira' as never })` was rejected by the CHECK
constraint. That test inverts once m105 lands, since jira is now valid. It was rewritten to assert
the constraint still rejects an unrelated unknown provider (`'asana'`), so the guard itself is not
weakened, and a positive jira round-trip test was added alongside it (site url, email, project key,
credential key).

## Assumptions made without anyone to ask

1. **`SessionExternalTaskProvider` was NOT widened here.** This is the one place the brief and the
   scout corrections disagree, so it needs stating plainly. The brief asks for all four unions.
   Widening that fifth-provider union produces 9 compile errors, and all 9 are in files the
   corrections explicitly assign to item 2: `providerLens.ts` (needs a `jira_issues` `LensKind`
   that does not exist yet), `ExternalTaskChip` (needs an `IntegrationGlyph` arm and a
   `--color-provider-jira` token), `IntegrationPane`, `LinkedWorkSection`, `definitionOfDone`,
   `parseIntegrationTaskUrl`, plus the two exhaustive switches in `fetchIssueCandidates.ts` and
   `connection.ts` that the brief lists as explicit non-goals. Satisfying them from here would mean
   shipping half-wired lens plumbing, which is exactly the runtime-only failure mode ranked risk 3,
   and would collide with item 2 in six files. The corrections' own item 2 section calls those two
   switch failures item 2's "safety net", which is only true if item 2 owns the widening. So this PR
   widens `WorkspaceIntegrationProvider`, `WorkspaceIntegrationConfig` and `WorkspaceIntegration`
   and adds `JiraIntegrationConfig` and `JiraWorkspaceIntegration`, and leaves the one-line
   `SessionExternalTaskProvider` widening to item 2, where its fallout is that agent's actual work.
   m105 still widens the `session_external_tasks` CHECK, since the corrections mandate both rebuilds
   in one file and a wider DB constraint than the TS union is forward-compatible and inert.

2. **`jira_validate_connection` also persists.** It validates against `/myself`, then writes the API
   token to the keychain and primes the cache, mirroring `gitlab_connect`. Nothing else in this
   backend writes the token, so without it every other command would fail with `NoToken`.

3. **The inbox JQL is built in Rust, not passed in.** `build_project_jql` produces
   `project = "KEY" AND statusCategory != Done ORDER BY updated DESC`, with an optional
   `AND assignee = currentUser()` behind the `assignedOnly` boolean. No JQL string crosses the
   command boundary, so no JQL editor can leak into the UI by accident.

4. **`jira_update_issue` returns `()`.** The Jira PUT answers 204 No Content. Echoing the issue back
   would need `returnIssue=true` and a second parse for no gain, since the caller already holds the
   text it sent.

5. **Unassign sends `{"accountId": null}`.** Never `"-1"`, which means "project default assignee",
   not unassigned.

6. **The ADF writer skips blank lines.** Each non-blank line becomes its own paragraph, which
   already renders as a visual break, so an empty paragraph node would add nothing while adding
   400-risk. Blank input falls back to a single empty paragraph.

7. **401 and 403 both map to `JiraError::Auth`, everywhere, not only on connect.** Jira returns
   either depending on context. 404 maps to `JiraError::NotFound`, since Jira answers 404 rather
   than 403 to avoid leaking existence. Both are surfaced through the existing
   `impl_error_serialize!` `{kind, message}` envelope, with the `errorMessages`/`errors` body parsed
   into the message.

8. **Rust doc comments were not added**, matching the existing modules, which carry none.

## Test plan

All four gates green from the worktree root:

- `pnpm typecheck`: 5 tasks successful
- `pnpm test`: 666 files, 5832 tests passed (desktop 520/4503, core 100/1047, db 26/182, ui 20/100)
- `pnpm knip --include files,duplicates,unlisted`: no findings (only the 6 pre-existing
  configuration hints that are already there on main)
- `CARGO_TARGET_DIR=... cargo test --locked --manifest-path apps/desktop/src-tauri/Cargo.toml`:
  261 passed, 0 failed, of which 49 are the new `jira::tests`

The 49 Rust tests cover: URL and query building for every command, JQL construction, the ADF reader
over fixtures for every supported node type plus an unknown-node flatten, the ADF writer shape and a
reader/writer round trip, serde parsing from captured-shape payloads for issue, comment page,
transitions, assignable users and `/myself`, error mapping for 401, 403, 404 and 400 including the
`errorMessages`/`errors` envelope, the url and body of all four write verbs through their builders,
and the pager: happy path, cross-page dedupe, stop on `isLast`, stop on a missing token, and the
repeated-token bail.

