### PR TITLE
feat(desktop): act on a jira issue without leaving goodboy

### DIFF
--- a/apps/desktop/src/features/integrations/jira/AssigneePicker.test.tsx
+++ b/apps/desktop/src/features/integrations/jira/AssigneePicker.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment happy-dom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { WorkspaceId } from '@goodboy/types';
+import { jiraListAssignableUsers, type JiraUser } from './client';
+
+const h = vi.hoisted(() => ({
+  config: {
+    siteUrl: 'https://acme.atlassian.net',
+    email: 'grace@acme.com',
+    projectKey: 'ENG',
+  } as unknown,
+}));
+
+vi.mock('./useJiraConfig', () => ({ useJiraConfig: () => h.config }));
+vi.mock('./client', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./client')>()),
+  jiraListAssignableUsers: vi.fn(async () => []),
+}));
+
+import { AssigneePicker } from './AssigneePicker';
+
+const listAssignableUsers = vi.mocked(jiraListAssignableUsers);
+
+const GRACE: JiraUser = {
+  accountId: 'a1',
+  displayName: 'Grace Hopper',
+  emailAddress: null,
+  avatarUrls: null,
+  active: true,
+};
+
+const ADA: JiraUser = { ...GRACE, accountId: 'a2', displayName: 'Ada Lovelace' };
+
+const WORKSPACE = 'workspace-1' as WorkspaceId;
+
+type MountParams = {
+  readonly assignee: JiraUser | null;
+  readonly onAssign: (accountId: string | null) => Promise<void>;
+};
+
+const mount = ({ assignee, onAssign }: MountParams) =>
+  render(
+    <AssigneePicker
+      issueKey="ENG-142"
+      workspaceId={WORKSPACE}
+      assignee={assignee}
+      onAssign={onAssign}
+    />,
+  );
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  listAssignableUsers.mockResolvedValue([GRACE, ADA]);
+});
+afterEach(cleanup);
+
+describe('AssigneePicker', () => {
+  it('reads the candidates only once the picker is opened, and filters them by name', async () => {
+    mount({ assignee: GRACE, onAssign: vi.fn(async () => {}) });
+
+    expect(listAssignableUsers).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: 'Grace Hopper' }));
+    await screen.findByRole('menuitem', { name: 'Ada Lovelace' });
+    fireEvent.change(screen.getByLabelText('Filter assignable people'), {
+      target: { value: 'ada' },
+    });
+
+    expect(screen.queryByRole('menuitem', { name: 'Grace Hopper' })).toBeNull();
+    expect(screen.getByRole('menuitem', { name: 'Ada Lovelace' })).toBeDefined();
+  });
+
+  it('offers no unassign row when nobody owns the issue', async () => {
+    mount({ assignee: null, onAssign: vi.fn(async () => {}) });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Unassigned' }));
+    await screen.findByRole('menuitem', { name: 'Ada Lovelace' });
+
+    expect(screen.queryByRole('menuitem', { name: 'Unassign' })).toBeNull();
+  });
+
+  it('keeps the picker mounted and shows the failure when Jira refuses the change', async () => {
+    mount({
+      assignee: GRACE,
+      onAssign: vi.fn(async () => {
+        throw new Error('User cannot be assigned issues');
+      }),
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Grace Hopper' }));
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Ada Lovelace' }));
+
+    expect((await screen.findByRole('alert')).textContent).toContain('cannot be assigned');
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Grace Hopper' })).toBeDefined());
+  });
+});

--- a/apps/desktop/src/features/integrations/jira/AssigneePicker.tsx
+++ b/apps/desktop/src/features/integrations/jira/AssigneePicker.tsx
@@ -1,0 +1,164 @@
+import { useMemo, useState } from 'react';
+import { Check, Loader2, UserRound } from 'lucide-react';
+import { Button, Divider, Input, Popover, ScrollFade } from '@goodboy/ui';
+import type { WorkspaceId } from '@goodboy/types';
+import { formatError } from '../../../shared/lib/errors';
+import type { JiraUser } from './client';
+import { useJiraAssignableUsers } from './useJiraAssignableUsers';
+
+type Props = {
+  readonly issueKey: string;
+  readonly workspaceId: WorkspaceId;
+  readonly assignee: JiraUser | null;
+  readonly onAssign: (accountId: string | null) => Promise<void>;
+};
+
+type FilterParams = {
+  readonly users: ReadonlyArray<JiraUser>;
+  readonly query: string;
+};
+
+const UNASSIGN_ROW_ID = 'unassign';
+
+const MENU_ROW =
+  'flex w-full items-center justify-between gap-2 rounded-md px-2 py-1.5 text-left text-xs text-foreground transition-colors hover:bg-muted/50 disabled:cursor-not-allowed disabled:opacity-50';
+
+const filterAssignees = ({ users, query }: FilterParams): ReadonlyArray<JiraUser> => {
+  const needle = query.trim().toLowerCase();
+  if (needle === '') {
+    return users;
+  }
+  return users.filter((user) => user.displayName.toLowerCase().includes(needle));
+};
+
+export const AssigneePicker = ({ issueKey, workspaceId, assignee, onAssign }: Props) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [assignError, setAssignError] = useState<string | null>(null);
+  const { users, isLoading, error, reload } = useJiraAssignableUsers({
+    issueKey,
+    workspaceId,
+    isEnabled: isOpen,
+  });
+  const filtered = useMemo(() => filterAssignees({ users, query }), [users, query]);
+
+  const assign = async (accountId: string | null) => {
+    setBusyId(accountId ?? UNASSIGN_ROW_ID);
+    setAssignError(null);
+    try {
+      await onAssign(accountId);
+      setIsOpen(false);
+      setQuery('');
+    } catch (assignFailure: unknown) {
+      setAssignError(formatError(assignFailure));
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  return (
+    <div className="relative">
+      <Button
+        size="sm"
+        variant="secondary"
+        aria-haspopup="menu"
+        aria-expanded={isOpen}
+        title="Change who owns this issue in Jira"
+        isBusy={busyId != null}
+        busyLabel="Assigning"
+        onClick={() => setIsOpen((open) => !open)}
+      >
+        <UserRound size={12} aria-hidden />
+        {assignee?.displayName ?? 'Unassigned'}
+      </Button>
+      {isOpen && (
+        <>
+          <div className="fixed inset-0 z-40" onClick={() => setIsOpen(false)} aria-hidden />
+          <Popover
+            role="menu"
+            ariaLabel="Assign this issue"
+            className="absolute right-0 z-50 mt-1 flex w-64 flex-col"
+          >
+            <div className="p-1">
+              <Input
+                autoFocus
+                value={query}
+                aria-label="Filter assignable people"
+                placeholder="Filter by name"
+                onChange={(event) => setQuery(event.target.value)}
+                className="h-7 text-xs"
+              />
+            </div>
+            <Divider />
+            <ScrollFade className="max-h-64" viewportClassName="flex flex-col gap-0.5 p-1">
+              {assignee != null && (
+                <button
+                  type="button"
+                  role="menuitem"
+                  disabled={busyId != null}
+                  onClick={() => void assign(null)}
+                  className={MENU_ROW}
+                >
+                  <span className="min-w-0 truncate text-muted-foreground">Unassign</span>
+                  {busyId === UNASSIGN_ROW_ID && (
+                    <Loader2 size={12} aria-hidden className="motion-safe:animate-spin" />
+                  )}
+                </button>
+              )}
+              {filtered.map((user) => (
+                <button
+                  key={user.accountId}
+                  type="button"
+                  role="menuitem"
+                  disabled={busyId != null}
+                  onClick={() => void assign(user.accountId)}
+                  className={MENU_ROW}
+                >
+                  <span className="min-w-0 truncate">{user.displayName}</span>
+                  {busyId === user.accountId && (
+                    <Loader2 size={12} aria-hidden className="motion-safe:animate-spin" />
+                  )}
+                  {busyId !== user.accountId && user.accountId === assignee?.accountId && (
+                    <Check size={12} aria-hidden />
+                  )}
+                </button>
+              ))}
+              {isLoading && (
+                <p role="status" className="px-2 py-1.5 text-2xs text-muted-foreground">
+                  Reading who can take this issue
+                </p>
+              )}
+              {!isLoading && error == null && filtered.length === 0 && (
+                <p className="px-2 py-1.5 text-2xs text-muted-foreground">
+                  No one matches that name
+                </p>
+              )}
+            </ScrollFade>
+            {error != null && (
+              <>
+                <Divider />
+                <div className="flex items-center justify-between gap-2 p-1">
+                  <p role="alert" className="min-w-0 text-2xs text-danger">
+                    {error}
+                  </p>
+                  <Button size="sm" variant="ghost" onClick={reload}>
+                    Retry
+                  </Button>
+                </div>
+              </>
+            )}
+            {assignError != null && (
+              <>
+                <Divider />
+                <p role="alert" className="px-2 py-1.5 text-2xs text-danger">
+                  {assignError}
+                </p>
+              </>
+            )}
+          </Popover>
+        </>
+      )}
+    </div>
+  );
+};

--- a/apps/desktop/src/features/integrations/jira/IssueConversation/index.tsx
+++ b/apps/desktop/src/features/integrations/jira/IssueConversation/index.tsx
@@ -64,7 +64,12 @@ export const IssueConversation = ({ comments, isLoading, error, onRetry, onPost 
         </p>
       )}
       {onPost != null && (
-        <NoteComposer placeholder="Write a comment" submitLabel="Comment" onSubmit={onPost} />
+        <NoteComposer
+          placeholder="Write a comment"
+          submitLabel="Comment"
+          hint="Plain text, one paragraph per line"
+          onSubmit={onPost}
+        />
       )}
     </div>
   );

--- a/apps/desktop/src/features/integrations/jira/IssueConversation/index.tsx
+++ b/apps/desktop/src/features/integrations/jira/IssueConversation/index.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { EmptyState, Skeleton } from '@goodboy/ui';
 import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../shared/components/conceptIcons';
 import { ErrorStrip } from '../../../../shared/components/ErrorStrip';
+import { NoteComposer } from '../../../../shared/components/NoteComposer';
 import type { JiraComment } from '../client';
 import { IssueNoteCard } from './IssueNoteCard';
 import { buildIssueConversation } from './issueNotes';
@@ -11,9 +12,10 @@ type Props = {
   readonly isLoading: boolean;
   readonly error: string | null;
   readonly onRetry: () => void;
+  readonly onPost: ((body: string) => Promise<void>) | null;
 };
 
-export const IssueConversation = ({ comments, isLoading, error, onRetry }: Props) => {
+export const IssueConversation = ({ comments, isLoading, error, onRetry, onPost }: Props) => {
   const conversation = useMemo(() => buildIssueConversation({ comments }), [comments]);
 
   if (isLoading) {
@@ -60,6 +62,9 @@ export const IssueConversation = ({ comments, isLoading, error, onRetry }: Props
             ? '1 comment has no readable text'
             : `${conversation.emptyCommentCount} comments have no readable text`}
         </p>
+      )}
+      {onPost != null && (
+        <NoteComposer placeholder="Write a comment" submitLabel="Comment" onSubmit={onPost} />
       )}
     </div>
   );

--- a/apps/desktop/src/features/integrations/jira/JiraIssueDetail/index.test.tsx
+++ b/apps/desktop/src/features/integrations/jira/JiraIssueDetail/index.test.tsx
@@ -1,9 +1,20 @@
 // @vitest-environment happy-dom
 
-import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { WorkspaceId } from '@goodboy/types';
-import { jiraListComments, type JiraIssue } from '../client';
+import {
+  jiraCreateComment,
+  jiraGetIssue,
+  jiraListAssignableUsers,
+  jiraListComments,
+  jiraListTransitions,
+  jiraSetAssignee,
+  jiraTransitionIssue,
+  jiraUpdateIssueDescription,
+  type JiraIssue,
+  type JiraUser,
+} from '../client';
 
 const h = vi.hoisted(() => ({
   config: {
@@ -17,11 +28,35 @@ vi.mock('../useJiraConfig', () => ({ useJiraConfig: () => h.config }));
 vi.mock('../client', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../client')>()),
   jiraListComments: vi.fn(async () => []),
+  jiraCreateComment: vi.fn(),
+  jiraGetIssue: vi.fn(),
+  jiraUpdateIssueDescription: vi.fn(async () => {}),
+  jiraSetAssignee: vi.fn(async () => {}),
+  jiraTransitionIssue: vi.fn(async () => {}),
+  jiraListTransitions: vi.fn(async () => []),
+  jiraListAssignableUsers: vi.fn(async () => []),
 }));
 
-import { JiraIssueDetail } from '.';
+import { JiraIssueDetail } from './index';
 
 const listComments = vi.mocked(jiraListComments);
+const createComment = vi.mocked(jiraCreateComment);
+const getIssue = vi.mocked(jiraGetIssue);
+const updateDescription = vi.mocked(jiraUpdateIssueDescription);
+const setAssignee = vi.mocked(jiraSetAssignee);
+const transitionIssue = vi.mocked(jiraTransitionIssue);
+const listTransitions = vi.mocked(jiraListTransitions);
+const listAssignableUsers = vi.mocked(jiraListAssignableUsers);
+
+const GRACE: JiraUser = {
+  accountId: 'a1',
+  displayName: 'Grace Hopper',
+  emailAddress: null,
+  avatarUrls: null,
+  active: true,
+};
+
+const ADA: JiraUser = { ...GRACE, accountId: 'a2', displayName: 'Ada Lovelace' };
 
 const ISSUE: JiraIssue = {
   id: '10042',
@@ -32,7 +67,7 @@ const ISSUE: JiraIssue = {
   statusCategory: 'indeterminate',
   issueType: 'Bug',
   priority: 'High',
-  assignee: { accountId: 'a1', displayName: 'Grace Hopper' } as JiraIssue['assignee'],
+  assignee: GRACE,
   reporter: null,
   labels: ['rail'],
   created: '2026-07-01T10:00:00.000Z',
@@ -40,15 +75,25 @@ const ISSUE: JiraIssue = {
   url: 'https://acme.atlassian.net/browse/ENG-142',
 };
 
+const WORKSPACE = 'workspace-1' as WorkspaceId;
+
+const mount = () => render(<JiraIssueDetail issue={ISSUE} workspaceId={WORKSPACE} />);
+
 beforeEach(() => {
-  listComments.mockClear();
+  vi.clearAllMocks();
   listComments.mockResolvedValue([]);
+  listTransitions.mockResolvedValue([]);
+  listAssignableUsers.mockResolvedValue([]);
+  updateDescription.mockResolvedValue(undefined);
+  setAssignee.mockResolvedValue(undefined);
+  transitionIssue.mockResolvedValue(undefined);
+  getIssue.mockResolvedValue(ISSUE);
 });
 afterEach(cleanup);
 
 describe('JiraIssueDetail', () => {
   it('leads with the key, the live status and the summary', async () => {
-    render(<JiraIssueDetail issue={ISSUE} workspaceId={'workspace-1' as WorkspaceId} />);
+    mount();
 
     expect(screen.getByText('ENG-142')).toBeDefined();
     expect(screen.getByText('In Progress')).toBeDefined();
@@ -56,20 +101,102 @@ describe('JiraIssueDetail', () => {
     await waitFor(() => expect(listComments).toHaveBeenCalled());
   });
 
-  it('renders the description read-only, with no edit affordance', async () => {
-    render(<JiraIssueDetail issue={ISSUE} workspaceId={'workspace-1' as WorkspaceId} />);
+  it('surfaces the issue type, assignee and labels as properties', async () => {
+    mount();
 
-    expect(screen.getByText(/The rail loses focus after a turn ends/i)).toBeDefined();
-    expect(screen.queryByRole('button', { name: /edit/i })).toBeNull();
+    expect(screen.getByText('Bug')).toBeDefined();
+    expect(screen.getAllByText('Grace Hopper').length).toBeGreaterThan(0);
+    expect(screen.getByText('rail')).toBeDefined();
     await waitFor(() => expect(listComments).toHaveBeenCalled());
   });
 
-  it('surfaces the issue type, assignee and labels as properties', async () => {
-    render(<JiraIssueDetail issue={ISSUE} workspaceId={'workspace-1' as WorkspaceId} />);
+  it('saves an edited description and re-renders the issue Jira returns', async () => {
+    getIssue.mockResolvedValue({ ...ISSUE, description: 'Rewritten by the PM.' });
+    mount();
 
-    expect(screen.getByText('Bug')).toBeDefined();
-    expect(screen.getByText('Grace Hopper')).toBeDefined();
-    expect(screen.getByText('rail')).toBeDefined();
-    await waitFor(() => expect(listComments).toHaveBeenCalled());
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    fireEvent.change(screen.getByRole('textbox', { name: 'Edit description' }), {
+      target: { value: 'Rewritten by the PM.' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() =>
+      expect(updateDescription).toHaveBeenCalledWith({
+        workspaceId: WORKSPACE,
+        siteUrl: 'https://acme.atlassian.net',
+        email: 'grace@acme.com',
+        issueKey: 'ENG-142',
+        description: 'Rewritten by the PM.',
+      }),
+    );
+    expect(await screen.findByText('Rewritten by the PM.')).toBeDefined();
+  });
+
+  it('posts a comment and appends it to the thread without reloading it', async () => {
+    createComment.mockResolvedValue({
+      id: 'c9',
+      author: GRACE,
+      body: 'Moving this to review',
+      created: '2026-07-03T10:00:00.000Z',
+      updated: '2026-07-03T10:00:00.000Z',
+    });
+    mount();
+    fireEvent.click(screen.getByRole('tab', { name: 'Conversation' }));
+
+    fireEvent.change(await screen.findByRole('textbox', { name: 'Write a comment' }), {
+      target: { value: 'Moving this to review' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Comment' }));
+
+    await waitFor(() =>
+      expect(createComment).toHaveBeenCalledWith(
+        expect.objectContaining({ issueKey: 'ENG-142', body: 'Moving this to review' }),
+      ),
+    );
+    expect(await screen.findByText('Moving this to review')).toBeDefined();
+    expect(listComments).toHaveBeenCalledTimes(1);
+  });
+
+  it('moves the issue through a transition read from Jira and shows the new status', async () => {
+    listTransitions.mockResolvedValue([
+      { id: '31', name: 'Ready for review', to: { id: '5', name: 'In Review' }, hasScreen: false },
+    ]);
+    getIssue.mockResolvedValue({ ...ISSUE, status: 'In Review' });
+    mount();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Move' }));
+    fireEvent.click(await screen.findByRole('menuitem', { name: /Ready for review/ }));
+
+    await waitFor(() =>
+      expect(transitionIssue).toHaveBeenCalledWith(
+        expect.objectContaining({ issueKey: 'ENG-142', transitionId: '31' }),
+      ),
+    );
+    expect(await screen.findByText('In Review')).toBeDefined();
+  });
+
+  it('assigns the issue to a person taken from the assignable list', async () => {
+    listAssignableUsers.mockResolvedValue([ADA]);
+    mount();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Grace Hopper' }));
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Ada Lovelace' }));
+
+    await waitFor(() =>
+      expect(setAssignee).toHaveBeenCalledWith(
+        expect.objectContaining({ issueKey: 'ENG-142', accountId: 'a2' }),
+      ),
+    );
+    expect(getIssue).toHaveBeenCalled();
+  });
+
+  it('unassigns with a null accountId, never the project default', async () => {
+    mount();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Grace Hopper' }));
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Unassign' }));
+
+    await waitFor(() => expect(setAssignee).toHaveBeenCalled());
+    expect(setAssignee.mock.calls[0]?.[0].accountId).toBeNull();
   });
 });

--- a/apps/desktop/src/features/integrations/jira/JiraIssueDetail/index.test.tsx
+++ b/apps/desktop/src/features/integrations/jira/JiraIssueDetail/index.test.tsx
@@ -77,6 +77,16 @@ const ISSUE: JiraIssue = {
 
 const WORKSPACE = 'workspace-1' as WorkspaceId;
 
+const OTHER: JiraIssue = {
+  ...ISSUE,
+  id: '10099',
+  key: 'ENG-900',
+  summary: 'Inbox forgets the scope',
+  assignee: null,
+  updated: '2026-07-04T10:00:00.000Z',
+  url: 'https://acme.atlassian.net/browse/ENG-900',
+};
+
 const mount = () => render(<JiraIssueDetail issue={ISSUE} workspaceId={WORKSPACE} />);
 
 beforeEach(() => {
@@ -198,5 +208,61 @@ describe('JiraIssueDetail', () => {
 
     await waitFor(() => expect(setAssignee).toHaveBeenCalled());
     expect(setAssignee.mock.calls[0]?.[0].accountId).toBeNull();
+  });
+
+  it('writes to the issue on screen after the inbox switches, never the previous one', async () => {
+    listAssignableUsers.mockResolvedValue([ADA]);
+    listTransitions.mockResolvedValue([
+      { id: '31', name: 'Ready for review', to: null, hasScreen: false },
+    ]);
+    getIssue.mockResolvedValueOnce({ ...ISSUE, status: 'In Review' });
+    const view = render(<JiraIssueDetail issue={ISSUE} workspaceId={WORKSPACE} />);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Move' }));
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Ready for review' }));
+    expect(await screen.findByText('In Review')).toBeDefined();
+
+    getIssue.mockResolvedValue(OTHER);
+    view.rerender(<JiraIssueDetail issue={OTHER} workspaceId={WORKSPACE} />);
+    await screen.findByText('Inbox forgets the scope');
+    expect(screen.queryByText('Session rail drops focus')).toBeNull();
+    expect(screen.getByText('ENG-900')).toBeDefined();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Unassigned' }));
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Ada Lovelace' }));
+    await waitFor(() =>
+      expect(setAssignee).toHaveBeenCalledWith(
+        expect.objectContaining({ issueKey: 'ENG-900', accountId: 'a2' }),
+      ),
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Move' }));
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Ready for review' }));
+    await waitFor(() =>
+      expect(transitionIssue).toHaveBeenCalledWith(
+        expect.objectContaining({ issueKey: 'ENG-900', transitionId: '31' }),
+      ),
+    );
+
+    expect(listTransitions).toHaveBeenCalledWith(expect.objectContaining({ issueKey: 'ENG-900' }));
+    expect(listAssignableUsers).toHaveBeenCalledWith(
+      expect.objectContaining({ issueKey: 'ENG-900' }),
+    );
+    expect(getIssue).toHaveBeenCalledWith(expect.objectContaining({ issueKey: 'ENG-900' }));
+  });
+
+  it('tells the studio to refresh its rail after a write', async () => {
+    const onIssueWritten = vi.fn();
+    listTransitions.mockResolvedValue([
+      { id: '31', name: 'Ready for review', to: null, hasScreen: false },
+    ]);
+    render(
+      <JiraIssueDetail issue={ISSUE} workspaceId={WORKSPACE} onIssueWritten={onIssueWritten} />,
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Move' }));
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Ready for review' }));
+
+    await waitFor(() => expect(onIssueWritten).toHaveBeenCalled());
   });
 });

--- a/apps/desktop/src/features/integrations/jira/JiraIssueDetail/index.tsx
+++ b/apps/desktop/src/features/integrations/jira/JiraIssueDetail/index.tsx
@@ -28,6 +28,7 @@ type Props = {
   readonly headerActions?: ReactNode;
   readonly dock?: ReactNode;
   readonly fit?: Fit;
+  readonly onIssueWritten?: (() => void) | null;
 };
 
 const SECTION_OPTIONS: ReadonlyArray<SegmentedTabOption<IssueSection>> = [
@@ -41,9 +42,10 @@ export const JiraIssueDetail = ({
   headerActions,
   dock,
   fit = 'fill',
+  onIssueWritten,
 }: Props) => {
   const [section, setSection] = useState<IssueSection>('overview');
-  const actions = useJiraIssueActions({ issue, workspaceId });
+  const actions = useJiraIssueActions({ issue, workspaceId, onWritten: onIssueWritten });
   const live = actions.issue;
   const conversation = useJiraIssueComments({ issue: live, workspaceId });
 

--- a/apps/desktop/src/features/integrations/jira/JiraIssueDetail/index.tsx
+++ b/apps/desktop/src/features/integrations/jira/JiraIssueDetail/index.tsx
@@ -13,7 +13,10 @@ import { IssueStateBadge } from '../../../../shared/components/IssueStateBadge';
 import { ExternalRefActions } from '../../../../shared/components/ExternalRefActions';
 import type { JiraIssue } from '../client';
 import { statusCategoryTone } from '../statusCategoryTone';
+import { useJiraIssueActions } from '../useJiraIssueActions';
 import { useJiraIssueComments } from '../useJiraIssueComments';
+import { AssigneePicker } from '../AssigneePicker';
+import { TransitionMenu } from '../TransitionMenu';
 import { IssueConversation } from '../IssueConversation';
 
 type Fit = 'fill' | 'bleed' | 'flow';
@@ -40,7 +43,9 @@ export const JiraIssueDetail = ({
   fit = 'fill',
 }: Props) => {
   const [section, setSection] = useState<IssueSection>('overview');
-  const conversation = useJiraIssueComments({ issue, workspaceId });
+  const actions = useJiraIssueActions({ issue, workspaceId });
+  const live = actions.issue;
+  const conversation = useJiraIssueComments({ issue: live, workspaceId });
 
   return (
     <StudioDetailLayout
@@ -51,18 +56,33 @@ export const JiraIssueDetail = ({
           meta={
             <>
               <span className="font-mono text-2xs tabular-nums text-muted-foreground">
-                {issue.key}
+                {live.key}
               </span>
-              <IssueStateBadge tone={statusCategoryTone({ statusCategory: issue.statusCategory })}>
-                {issue.status}
+              <IssueStateBadge tone={statusCategoryTone({ statusCategory: live.statusCategory })}>
+                {live.status}
               </IssueStateBadge>
             </>
           }
-          title={issue.summary}
+          title={live.summary}
           actions={
             <>
+              {actions.assign != null && (
+                <AssigneePicker
+                  issueKey={live.key}
+                  workspaceId={workspaceId}
+                  assignee={live.assignee}
+                  onAssign={actions.assign}
+                />
+              )}
+              {actions.transition != null && (
+                <TransitionMenu
+                  issueKey={live.key}
+                  workspaceId={workspaceId}
+                  onTransition={actions.transition}
+                />
+              )}
               {headerActions}
-              <ExternalRefActions url={issue.url} label="issue" hostLabel="Jira" />
+              <ExternalRefActions url={live.url} label="issue" hostLabel="Jira" />
             </>
           }
         />
@@ -75,16 +95,17 @@ export const JiraIssueDetail = ({
           onChange={setSection}
         />
       }
-      properties={resolveDetailFields({ registry: jiraIssueFields, entity: issue })}
+      properties={resolveDetailFields({ registry: jiraIssueFields, entity: live })}
     >
       {section === 'overview' ? (
-        <DescriptionSection text={issue.description} />
+        <DescriptionSection text={live.description} onSave={actions.saveDescription} />
       ) : (
         <IssueConversation
           comments={conversation.comments}
           isLoading={conversation.isLoading}
           error={conversation.error}
           onRetry={conversation.reload}
+          onPost={conversation.post}
         />
       )}
     </StudioDetailLayout>

--- a/apps/desktop/src/features/integrations/jira/JiraStudio/IssueDetailPanel.tsx
+++ b/apps/desktop/src/features/integrations/jira/JiraStudio/IssueDetailPanel.tsx
@@ -11,10 +11,17 @@ type Props = {
   readonly issue: JiraIssue | null;
   readonly sessionId: SessionId | null;
   readonly workspaceId: WorkspaceId;
+  readonly onIssueWritten: () => void;
   readonly onClose: () => void;
 };
 
-export const IssueDetailPanel = ({ issue, sessionId, workspaceId, onClose }: Props) => {
+export const IssueDetailPanel = ({
+  issue,
+  sessionId,
+  workspaceId,
+  onIssueWritten,
+  onClose,
+}: Props) => {
   if (issue == null) {
     return (
       <div className="flex h-full items-center justify-center px-8">
@@ -35,6 +42,7 @@ export const IssueDetailPanel = ({ issue, sessionId, workspaceId, onClose }: Pro
     <JiraIssueDetail
       issue={issue}
       workspaceId={workspaceId}
+      onIssueWritten={onIssueWritten}
       dock={
         <LaunchSessionPanel
           key={issue.id}

--- a/apps/desktop/src/features/integrations/jira/JiraStudio/index.tsx
+++ b/apps/desktop/src/features/integrations/jira/JiraStudio/index.tsx
@@ -132,6 +132,7 @@ export const JiraStudio = ({ workspaceId, workspaceName, initialIssueId, onClose
                 issue={focused}
                 sessionId={focusedRow?.sessionId ?? null}
                 workspaceId={workspaceId}
+                onIssueWritten={refetch}
                 onClose={requestClose}
               />
             }

--- a/apps/desktop/src/features/integrations/jira/JiraStudio/useJiraIssues.ts
+++ b/apps/desktop/src/features/integrations/jira/JiraStudio/useJiraIssues.ts
@@ -182,5 +182,9 @@ export const useJiraIssues = ({
     [issues, sessionIdByIssueId],
   );
 
-  return { groups, isLoading, error, refetch: () => void fetchIssues() };
+  const refetch = useCallback(() => {
+    void fetchIssues();
+  }, [fetchIssues]);
+
+  return { groups, isLoading, error, refetch };
 };

--- a/apps/desktop/src/features/integrations/jira/TransitionMenu.test.tsx
+++ b/apps/desktop/src/features/integrations/jira/TransitionMenu.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment happy-dom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { WorkspaceId } from '@goodboy/types';
+import { jiraListTransitions } from './client';
+
+const h = vi.hoisted(() => ({
+  config: {
+    siteUrl: 'https://acme.atlassian.net',
+    email: 'grace@acme.com',
+    projectKey: 'ENG',
+  } as unknown,
+}));
+
+vi.mock('./useJiraConfig', () => ({ useJiraConfig: () => h.config }));
+vi.mock('./client', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./client')>()),
+  jiraListTransitions: vi.fn(async () => []),
+}));
+
+import { TransitionMenu } from './TransitionMenu';
+
+const listTransitions = vi.mocked(jiraListTransitions);
+
+const WORKSPACE = 'workspace-1' as WorkspaceId;
+
+const mount = ({ onTransition }: { onTransition: (id: string) => Promise<void> }) =>
+  render(<TransitionMenu issueKey="ENG-142" workspaceId={WORKSPACE} onTransition={onTransition} />);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  listTransitions.mockResolvedValue([]);
+});
+afterEach(cleanup);
+
+describe('TransitionMenu', () => {
+  it('offers exactly the moves Jira reports for that issue', async () => {
+    listTransitions.mockResolvedValue([
+      { id: '11', name: 'Start progress', to: { id: '3', name: 'In Progress' }, hasScreen: false },
+      { id: '31', name: 'Ready for review', to: { id: '5', name: 'In Review' }, hasScreen: true },
+    ]);
+    mount({ onTransition: vi.fn(async () => {}) });
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Move' }));
+
+    expect(listTransitions).toHaveBeenCalledWith(
+      expect.objectContaining({ issueKey: 'ENG-142', siteUrl: 'https://acme.atlassian.net' }),
+    );
+    expect(screen.getAllByRole('menuitem')).toHaveLength(2);
+    expect(screen.getByRole('menuitem', { name: /Start progress/ })).toBeDefined();
+  });
+
+  it('stays visible and disabled with a readable reason when the workflow cannot be read', async () => {
+    listTransitions.mockRejectedValue(new Error('403 Forbidden'));
+    mount({ onTransition: vi.fn(async () => {}) });
+
+    const trigger = await screen.findByRole('button', { name: 'Move' });
+    await waitFor(() => expect(trigger.getAttribute('aria-disabled')).toBe('true'));
+
+    expect(trigger.getAttribute('title')).toContain('403 Forbidden');
+    fireEvent.click(trigger);
+    expect(screen.queryByRole('menu')).toBeNull();
+  });
+
+  it('keeps the menu mounted and shows what Jira refused when a move fails', async () => {
+    listTransitions.mockResolvedValue([
+      { id: '31', name: 'Ready for review', to: null, hasScreen: false },
+    ]);
+    mount({
+      onTransition: vi.fn(async () => {
+        throw new Error('Field "Reviewer" is required');
+      }),
+    });
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Move' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Ready for review' }));
+
+    expect((await screen.findByRole('alert')).textContent).toContain('Reviewer');
+    expect(screen.getByRole('menuitem', { name: 'Ready for review' })).toBeDefined();
+  });
+});

--- a/apps/desktop/src/features/integrations/jira/TransitionMenu.tsx
+++ b/apps/desktop/src/features/integrations/jira/TransitionMenu.tsx
@@ -1,0 +1,123 @@
+import { useState } from 'react';
+import { ArrowRightLeft } from 'lucide-react';
+import { Button, Divider, Popover, ScrollFade, cn } from '@goodboy/ui';
+import type { WorkspaceId } from '@goodboy/types';
+import { formatError } from '../../../shared/lib/errors';
+import { useJiraTransitions } from './useJiraTransitions';
+
+type Props = {
+  readonly issueKey: string;
+  readonly workspaceId: WorkspaceId;
+  readonly onTransition: (transitionId: string) => Promise<void>;
+};
+
+type ReasonParams = {
+  readonly isLoading: boolean;
+  readonly error: string | null;
+  readonly count: number;
+};
+
+const MENU_ROW =
+  'flex w-full items-center justify-between gap-2 rounded-md px-2 py-1.5 text-left text-xs text-foreground transition-colors hover:bg-muted/50 disabled:cursor-not-allowed disabled:opacity-50';
+
+const SCREEN_HINT = 'Jira asks for extra fields on this move. Goodboy sends it without them.';
+
+const blockReason = ({ isLoading, error, count }: ReasonParams): string | null => {
+  if (isLoading) {
+    return 'Reading the Jira workflow for this issue';
+  }
+  if (error != null) {
+    return `Could not read the Jira workflow for this issue. ${error}`;
+  }
+  if (count === 0) {
+    return 'Jira offers no move from this status';
+  }
+  return null;
+};
+
+export const TransitionMenu = ({ issueKey, workspaceId, onTransition }: Props) => {
+  const { transitions, isLoading, error, reload } = useJiraTransitions({ issueKey, workspaceId });
+  const [isOpen, setIsOpen] = useState(false);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [moveError, setMoveError] = useState<string | null>(null);
+  const reason = blockReason({ isLoading, error, count: transitions.length });
+  const isBlocked = reason != null;
+
+  const move = async (transitionId: string) => {
+    setBusyId(transitionId);
+    setMoveError(null);
+    try {
+      await onTransition(transitionId);
+      setIsOpen(false);
+      reload();
+    } catch (moveFailure: unknown) {
+      setMoveError(formatError(moveFailure));
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  return (
+    <div className="relative">
+      <Button
+        size="sm"
+        variant="secondary"
+        aria-haspopup="menu"
+        aria-expanded={isOpen}
+        aria-disabled={isBlocked}
+        title={reason ?? 'Move this issue through its Jira workflow'}
+        isBusy={busyId != null}
+        busyLabel="Moving"
+        className={cn(isBlocked && 'opacity-50')}
+        onClick={() => {
+          if (isBlocked) {
+            return;
+          }
+          setIsOpen((open) => !open);
+        }}
+      >
+        <ArrowRightLeft size={12} aria-hidden />
+        Move
+      </Button>
+      {isOpen && (
+        <>
+          <div className="fixed inset-0 z-40" onClick={() => setIsOpen(false)} aria-hidden />
+          <Popover
+            role="menu"
+            ariaLabel="Move this issue"
+            className="absolute right-0 z-50 mt-1 flex w-60 flex-col"
+          >
+            <ScrollFade className="max-h-64" viewportClassName="flex flex-col gap-0.5 p-1">
+              {transitions.map((transition) => (
+                <button
+                  key={transition.id}
+                  type="button"
+                  role="menuitem"
+                  disabled={busyId != null}
+                  title={transition.hasScreen ? SCREEN_HINT : undefined}
+                  onClick={() => void move(transition.id)}
+                  className={MENU_ROW}
+                >
+                  <span className="min-w-0 truncate">{transition.name}</span>
+                  {transition.to != null && (
+                    <span className="shrink-0 text-2xs text-muted-foreground">
+                      {transition.to.name}
+                    </span>
+                  )}
+                </button>
+              ))}
+            </ScrollFade>
+            {moveError != null && (
+              <>
+                <Divider />
+                <p role="alert" className="px-2 py-1.5 text-2xs text-danger">
+                  {moveError}
+                </p>
+              </>
+            )}
+          </Popover>
+        </>
+      )}
+    </div>
+  );
+};

--- a/apps/desktop/src/features/integrations/jira/useJiraAssignableUsers/index.ts
+++ b/apps/desktop/src/features/integrations/jira/useJiraAssignableUsers/index.ts
@@ -1,48 +1,48 @@
 import { useCallback, useEffect, useState } from 'react';
 import type { WorkspaceId } from '@goodboy/types';
 import { formatError } from '../../../../shared/lib/errors';
-import { jiraCreateComment, jiraListComments, type JiraComment, type JiraIssue } from '../client';
+import { jiraListAssignableUsers, type JiraUser } from '../client';
 import { useJiraConfig } from '../useJiraConfig';
 
 type Params = {
-  readonly issue: JiraIssue | null;
+  readonly issueKey: string;
   readonly workspaceId: WorkspaceId;
+  readonly isEnabled: boolean;
 };
 
 type Result = {
-  readonly comments: ReadonlyArray<JiraComment>;
+  readonly users: ReadonlyArray<JiraUser>;
   readonly isLoading: boolean;
   readonly error: string | null;
   readonly reload: () => void;
-  readonly post: ((body: string) => Promise<void>) | null;
 };
 
-export const useJiraIssueComments = ({ issue, workspaceId }: Params): Result => {
+export const useJiraAssignableUsers = ({ issueKey, workspaceId, isEnabled }: Params): Result => {
   const config = useJiraConfig({ workspaceId });
   const siteUrl = config?.siteUrl ?? null;
   const email = config?.email ?? null;
-  const issueKey = issue?.key ?? null;
-  const [comments, setComments] = useState<ReadonlyArray<JiraComment>>([]);
+  const [users, setUsers] = useState<ReadonlyArray<JiraUser>>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [reloadToken, setReloadToken] = useState(0);
 
   useEffect(() => {
-    setComments([]);
-    setError(null);
-    if (siteUrl == null || email == null || issueKey == null) {
-      setIsLoading(false);
+    if (!isEnabled) {
+      return;
+    }
+    if (siteUrl == null || email == null || issueKey === '') {
       return;
     }
 
     let isCancelled = false;
     setIsLoading(true);
-    jiraListComments({ workspaceId, siteUrl, email, issueKey })
+    setError(null);
+    jiraListAssignableUsers({ workspaceId, siteUrl, email, issueKey })
       .then((next) => {
         if (isCancelled) {
           return;
         }
-        setComments(next);
+        setUsers(next);
       })
       .catch((fetchError: unknown) => {
         if (isCancelled) {
@@ -60,24 +60,11 @@ export const useJiraIssueComments = ({ issue, workspaceId }: Params): Result => 
     return () => {
       isCancelled = true;
     };
-  }, [workspaceId, siteUrl, email, issueKey, reloadToken]);
+  }, [workspaceId, siteUrl, email, issueKey, isEnabled, reloadToken]);
 
   const reload = useCallback(() => {
     setReloadToken((token) => token + 1);
   }, []);
 
-  const post = useCallback(
-    async (body: string) => {
-      if (siteUrl == null || email == null || issueKey == null) {
-        return;
-      }
-      const created = await jiraCreateComment({ workspaceId, siteUrl, email, issueKey, body });
-      setComments((current) => [...current, created]);
-    },
-    [workspaceId, siteUrl, email, issueKey],
-  );
-
-  const isReady = siteUrl != null && email != null && issueKey != null;
-
-  return { comments, isLoading, error, reload, post: isReady ? post : null };
+  return { users, isLoading, error, reload };
 };

--- a/apps/desktop/src/features/integrations/jira/useJiraAssignableUsers/index.ts
+++ b/apps/desktop/src/features/integrations/jira/useJiraAssignableUsers/index.ts
@@ -22,20 +22,21 @@ export const useJiraAssignableUsers = ({ issueKey, workspaceId, isEnabled }: Par
   const siteUrl = config?.siteUrl ?? null;
   const email = config?.email ?? null;
   const [users, setUsers] = useState<ReadonlyArray<JiraUser>>([]);
-  const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [reloadToken, setReloadToken] = useState(0);
+  const [settledKey, setSettledKey] = useState<string | null>(null);
+  const fetchKey = `${siteUrl ?? ''}|${email ?? ''}|${issueKey}|${reloadToken}`;
 
   useEffect(() => {
     if (!isEnabled) {
       return;
     }
     if (siteUrl == null || email == null || issueKey === '') {
+      setSettledKey(fetchKey);
       return;
     }
 
     let isCancelled = false;
-    setIsLoading(true);
     setError(null);
     jiraListAssignableUsers({ workspaceId, siteUrl, email, issueKey })
       .then((next) => {
@@ -54,17 +55,17 @@ export const useJiraAssignableUsers = ({ issueKey, workspaceId, isEnabled }: Par
         if (isCancelled) {
           return;
         }
-        setIsLoading(false);
+        setSettledKey(fetchKey);
       });
 
     return () => {
       isCancelled = true;
     };
-  }, [workspaceId, siteUrl, email, issueKey, isEnabled, reloadToken]);
+  }, [workspaceId, siteUrl, email, issueKey, isEnabled, fetchKey]);
 
   const reload = useCallback(() => {
     setReloadToken((token) => token + 1);
   }, []);
 
-  return { users, isLoading, error, reload };
+  return { users, isLoading: isEnabled && settledKey !== fetchKey, error, reload };
 };

--- a/apps/desktop/src/features/integrations/jira/useJiraIssueActions/index.ts
+++ b/apps/desktop/src/features/integrations/jira/useJiraIssueActions/index.ts
@@ -1,0 +1,90 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { WorkspaceId } from '@goodboy/types';
+import {
+  jiraGetIssue,
+  jiraSetAssignee,
+  jiraTransitionIssue,
+  jiraUpdateIssueDescription,
+  type JiraIssue,
+} from '../client';
+import { useJiraConfig } from '../useJiraConfig';
+
+type Params = {
+  readonly issue: JiraIssue;
+  readonly workspaceId: WorkspaceId;
+};
+
+type Result = {
+  readonly issue: JiraIssue;
+  readonly assign: ((accountId: string | null) => Promise<void>) | null;
+  readonly transition: ((transitionId: string) => Promise<void>) | null;
+  readonly saveDescription: ((next: string) => Promise<void>) | null;
+};
+
+export const useJiraIssueActions = ({ issue, workspaceId }: Params): Result => {
+  const config = useJiraConfig({ workspaceId });
+  const siteUrl = config?.siteUrl ?? null;
+  const email = config?.email ?? null;
+  const issueKey = issue.key;
+  const [fresh, setFresh] = useState<JiraIssue | null>(null);
+
+  useEffect(() => {
+    setFresh(null);
+  }, [issue.id, issue.updated]);
+
+  const refresh = useCallback(async () => {
+    if (siteUrl == null || email == null) {
+      return;
+    }
+    const next = await jiraGetIssue({ workspaceId, siteUrl, email, issueKey });
+    setFresh(next);
+  }, [workspaceId, siteUrl, email, issueKey]);
+
+  const assign = useCallback(
+    async (accountId: string | null) => {
+      if (siteUrl == null || email == null) {
+        return;
+      }
+      await jiraSetAssignee({ workspaceId, siteUrl, email, issueKey, accountId });
+      await refresh();
+    },
+    [workspaceId, siteUrl, email, issueKey, refresh],
+  );
+
+  const transition = useCallback(
+    async (transitionId: string) => {
+      if (siteUrl == null || email == null) {
+        return;
+      }
+      await jiraTransitionIssue({ workspaceId, siteUrl, email, issueKey, transitionId });
+      await refresh();
+    },
+    [workspaceId, siteUrl, email, issueKey, refresh],
+  );
+
+  const saveDescription = useCallback(
+    async (next: string) => {
+      if (siteUrl == null || email == null) {
+        return;
+      }
+      await jiraUpdateIssueDescription({
+        workspaceId,
+        siteUrl,
+        email,
+        issueKey,
+        description: next,
+      });
+      await refresh();
+    },
+    [workspaceId, siteUrl, email, issueKey, refresh],
+  );
+
+  const isReady = siteUrl != null && email != null;
+
+  return {
+    issue: fresh ?? issue,
+    assign: isReady ? assign : null,
+    transition: isReady ? transition : null,
+    saveDescription: isReady ? saveDescription : null,
+  };
+};

--- a/apps/desktop/src/features/integrations/jira/useJiraIssueActions/index.ts
+++ b/apps/desktop/src/features/integrations/jira/useJiraIssueActions/index.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import type { WorkspaceId } from '@goodboy/types';
 import {
   jiraGetIssue,
@@ -12,6 +12,7 @@ import { useJiraConfig } from '../useJiraConfig';
 type Params = {
   readonly issue: JiraIssue;
   readonly workspaceId: WorkspaceId;
+  readonly onWritten?: (() => void) | null;
 };
 
 type Result = {
@@ -21,24 +22,33 @@ type Result = {
   readonly saveDescription: ((next: string) => Promise<void>) | null;
 };
 
-export const useJiraIssueActions = ({ issue, workspaceId }: Params): Result => {
+type Held = {
+  readonly signature: string;
+  readonly issue: JiraIssue;
+};
+
+type SignatureParams = {
+  readonly issue: JiraIssue;
+};
+
+const issueSignature = ({ issue }: SignatureParams): string => `${issue.id}:${issue.updated}`;
+
+export const useJiraIssueActions = ({ issue, workspaceId, onWritten }: Params): Result => {
   const config = useJiraConfig({ workspaceId });
   const siteUrl = config?.siteUrl ?? null;
   const email = config?.email ?? null;
   const issueKey = issue.key;
-  const [fresh, setFresh] = useState<JiraIssue | null>(null);
-
-  useEffect(() => {
-    setFresh(null);
-  }, [issue.id, issue.updated]);
+  const signature = issueSignature({ issue });
+  const [held, setHeld] = useState<Held | null>(null);
 
   const refresh = useCallback(async () => {
     if (siteUrl == null || email == null) {
       return;
     }
     const next = await jiraGetIssue({ workspaceId, siteUrl, email, issueKey });
-    setFresh(next);
-  }, [workspaceId, siteUrl, email, issueKey]);
+    setHeld({ signature, issue: next });
+    onWritten?.();
+  }, [workspaceId, siteUrl, email, issueKey, signature, onWritten]);
 
   const assign = useCallback(
     async (accountId: string | null) => {
@@ -82,7 +92,7 @@ export const useJiraIssueActions = ({ issue, workspaceId }: Params): Result => {
   const isReady = siteUrl != null && email != null;
 
   return {
-    issue: fresh ?? issue,
+    issue: held != null && held.signature === signature ? held.issue : issue,
     assign: isReady ? assign : null,
     transition: isReady ? transition : null,
     saveDescription: isReady ? saveDescription : null,

--- a/apps/desktop/src/features/integrations/jira/useJiraTransitions/index.ts
+++ b/apps/desktop/src/features/integrations/jira/useJiraTransitions/index.ts
@@ -1,48 +1,46 @@
 import { useCallback, useEffect, useState } from 'react';
 import type { WorkspaceId } from '@goodboy/types';
 import { formatError } from '../../../../shared/lib/errors';
-import { jiraCreateComment, jiraListComments, type JiraComment, type JiraIssue } from '../client';
+import { jiraListTransitions, type JiraTransition } from '../client';
 import { useJiraConfig } from '../useJiraConfig';
 
 type Params = {
-  readonly issue: JiraIssue | null;
+  readonly issueKey: string;
   readonly workspaceId: WorkspaceId;
 };
 
 type Result = {
-  readonly comments: ReadonlyArray<JiraComment>;
+  readonly transitions: ReadonlyArray<JiraTransition>;
   readonly isLoading: boolean;
   readonly error: string | null;
   readonly reload: () => void;
-  readonly post: ((body: string) => Promise<void>) | null;
 };
 
-export const useJiraIssueComments = ({ issue, workspaceId }: Params): Result => {
+export const useJiraTransitions = ({ issueKey, workspaceId }: Params): Result => {
   const config = useJiraConfig({ workspaceId });
   const siteUrl = config?.siteUrl ?? null;
   const email = config?.email ?? null;
-  const issueKey = issue?.key ?? null;
-  const [comments, setComments] = useState<ReadonlyArray<JiraComment>>([]);
+  const [transitions, setTransitions] = useState<ReadonlyArray<JiraTransition>>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [reloadToken, setReloadToken] = useState(0);
 
   useEffect(() => {
-    setComments([]);
+    setTransitions([]);
     setError(null);
-    if (siteUrl == null || email == null || issueKey == null) {
+    if (siteUrl == null || email == null || issueKey === '') {
       setIsLoading(false);
       return;
     }
 
     let isCancelled = false;
     setIsLoading(true);
-    jiraListComments({ workspaceId, siteUrl, email, issueKey })
+    jiraListTransitions({ workspaceId, siteUrl, email, issueKey })
       .then((next) => {
         if (isCancelled) {
           return;
         }
-        setComments(next);
+        setTransitions(next);
       })
       .catch((fetchError: unknown) => {
         if (isCancelled) {
@@ -66,18 +64,5 @@ export const useJiraIssueComments = ({ issue, workspaceId }: Params): Result => 
     setReloadToken((token) => token + 1);
   }, []);
 
-  const post = useCallback(
-    async (body: string) => {
-      if (siteUrl == null || email == null || issueKey == null) {
-        return;
-      }
-      const created = await jiraCreateComment({ workspaceId, siteUrl, email, issueKey, body });
-      setComments((current) => [...current, created]);
-    },
-    [workspaceId, siteUrl, email, issueKey],
-  );
-
-  const isReady = siteUrl != null && email != null && issueKey != null;
-
-  return { comments, isLoading, error, reload, post: isReady ? post : null };
+  return { transitions, isLoading, error, reload };
 };

--- a/apps/desktop/src/features/integrations/jira/useJiraTransitions/index.ts
+++ b/apps/desktop/src/features/integrations/jira/useJiraTransitions/index.ts
@@ -21,20 +21,20 @@ export const useJiraTransitions = ({ issueKey, workspaceId }: Params): Result =>
   const siteUrl = config?.siteUrl ?? null;
   const email = config?.email ?? null;
   const [transitions, setTransitions] = useState<ReadonlyArray<JiraTransition>>([]);
-  const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [reloadToken, setReloadToken] = useState(0);
+  const [settledKey, setSettledKey] = useState<string | null>(null);
+  const fetchKey = `${siteUrl ?? ''}|${email ?? ''}|${issueKey}|${reloadToken}`;
 
   useEffect(() => {
     setTransitions([]);
     setError(null);
     if (siteUrl == null || email == null || issueKey === '') {
-      setIsLoading(false);
+      setSettledKey(fetchKey);
       return;
     }
 
     let isCancelled = false;
-    setIsLoading(true);
     jiraListTransitions({ workspaceId, siteUrl, email, issueKey })
       .then((next) => {
         if (isCancelled) {
@@ -52,17 +52,17 @@ export const useJiraTransitions = ({ issueKey, workspaceId }: Params): Result =>
         if (isCancelled) {
           return;
         }
-        setIsLoading(false);
+        setSettledKey(fetchKey);
       });
 
     return () => {
       isCancelled = true;
     };
-  }, [workspaceId, siteUrl, email, issueKey, reloadToken]);
+  }, [workspaceId, siteUrl, email, issueKey, fetchKey]);
 
   const reload = useCallback(() => {
     setReloadToken((token) => token + 1);
   }, []);
 
-  return { transitions, isLoading, error, reload };
+  return { transitions, isLoading: settledKey !== fetchKey, error, reload };
 };

--- a/apps/desktop/src/shared/components/NoteComposer/index.test.tsx
+++ b/apps/desktop/src/shared/components/NoteComposer/index.test.tsx
@@ -1,0 +1,39 @@
+// @vitest-environment happy-dom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { NoteComposer } from './index';
+
+afterEach(cleanup);
+
+const field = () => screen.getByRole('textbox', { name: 'Write a comment' }) as HTMLTextAreaElement;
+
+describe('NoteComposer', () => {
+  it('submits the trimmed draft and clears the field', async () => {
+    const onSubmit = vi.fn(async () => {});
+    render(
+      <NoteComposer placeholder="Write a comment" submitLabel="Comment" onSubmit={onSubmit} />,
+    );
+
+    fireEvent.change(field(), { target: { value: '  ships it  ' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Comment' }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledWith('ships it'));
+    await waitFor(() => expect(field().value).toBe(''));
+  });
+
+  it('keeps the draft and shows the failure when the post is rejected', async () => {
+    const onSubmit = vi.fn(async () => {
+      throw new Error('Comment body is not valid!');
+    });
+    render(
+      <NoteComposer placeholder="Write a comment" submitLabel="Comment" onSubmit={onSubmit} />,
+    );
+
+    fireEvent.change(field(), { target: { value: 'ships it' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Comment' }));
+
+    expect((await screen.findByRole('alert')).textContent).toBe('Comment body is not valid!');
+    expect(field().value).toBe('ships it');
+  });
+});

--- a/apps/desktop/src/shared/components/NoteComposer/index.tsx
+++ b/apps/desktop/src/shared/components/NoteComposer/index.tsx
@@ -6,10 +6,17 @@ type Props = {
   readonly placeholder: string;
   readonly submitLabel: string;
   readonly minRows?: number;
+  readonly hint?: string;
   readonly onSubmit: (body: string) => Promise<void>;
 };
 
-export const NoteComposer = ({ placeholder, submitLabel, minRows = 3, onSubmit }: Props) => {
+export const NoteComposer = ({
+  placeholder,
+  submitLabel,
+  minRows = 3,
+  hint = 'Markdown supported',
+  onSubmit,
+}: Props) => {
   const [draft, setDraft] = useState('');
   const [isPosting, setIsPosting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -49,7 +56,7 @@ export const NoteComposer = ({ placeholder, submitLabel, minRows = 3, onSubmit }
             {error}
           </p>
         ) : (
-          <p className="text-2xs text-muted-foreground">Markdown supported</p>
+          <p className="text-2xs text-muted-foreground">{hint}</p>
         )}
         <Button
           size="sm"

--- a/apps/desktop/src/shared/components/NoteComposer/index.tsx
+++ b/apps/desktop/src/shared/components/NoteComposer/index.tsx
@@ -1,0 +1,66 @@
+import { useState } from 'react';
+import { Button, Textarea } from '@goodboy/ui';
+import { formatError } from '../../lib/errors';
+
+type Props = {
+  readonly placeholder: string;
+  readonly submitLabel: string;
+  readonly minRows?: number;
+  readonly onSubmit: (body: string) => Promise<void>;
+};
+
+export const NoteComposer = ({ placeholder, submitLabel, minRows = 3, onSubmit }: Props) => {
+  const [draft, setDraft] = useState('');
+  const [isPosting, setIsPosting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const body = draft.trim();
+
+  const submit = async () => {
+    if (body === '') {
+      return;
+    }
+    setIsPosting(true);
+    setError(null);
+    try {
+      await onSubmit(body);
+      setDraft('');
+    } catch (postError: unknown) {
+      setError(formatError(postError));
+    } finally {
+      setIsPosting(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <Textarea
+        autoGrow
+        minRows={minRows}
+        maxRows={16}
+        value={draft}
+        aria-label={placeholder}
+        placeholder={placeholder}
+        onChange={(event) => setDraft(event.target.value)}
+        className="text-sm leading-relaxed"
+      />
+      <div className="flex items-center justify-between gap-3">
+        {error != null ? (
+          <p role="alert" className="min-w-0 text-xs text-danger">
+            {error}
+          </p>
+        ) : (
+          <p className="text-2xs text-muted-foreground">Markdown supported</p>
+        )}
+        <Button
+          size="sm"
+          disabled={body === ''}
+          isBusy={isPosting}
+          busyLabel="Posting"
+          onClick={() => void submit()}
+        >
+          {submitLabel}
+        </Button>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## What

The ACT half of the Jira integration. #1233 shipped the backend, #1236 shipped SEE and ROUTE and
deliberately left the write seams open. This wires all four of them: comment, assign or unassign,
transition, edit description. After this a PM can move a Jira ticket through its workflow from
inside Goodboy without a browser tab and without ever seeing a diff.

The four controls are mounted **inside** `JiraIssueDetail`, not passed down through the
`headerActions` slot. That slot stays available for callers (every other host detail has the same
prop, also unused today). Mounting inside means both places that render a Jira issue get the verbs
for free: the Jira Studio detail pane and the session integration pane
(`IntegrationPane/JiraTaskDetail.tsx`). Passing them from outside would have meant duplicating the
wiring in both parents.

## The four click paths, button to HTTP request

**1. Comment**

`IssueConversation` Conversation tab -> `NoteComposer` "Comment" button -> `onSubmit` ->
`onPost` prop -> `useJiraIssueComments().post(body)` -> `jiraCreateComment({ workspaceId, siteUrl,
email, issueKey, body })` -> `invoke('jira_create_comment')` -> `comment_write` ->
`POST {siteUrl}/rest/api/3/issue/{key}/comment` with
`{"body": {"type":"doc","version":1,"content":[{"type":"paragraph","content":[{"type":"text","text":"..."}]}]}}`.

The command returns the created `JiraComment`, and `post` appends **that server object** to the
thread state. No refetch and no optimistic placeholder: the row that appears is the one Jira just
wrote. `jiraListComments` is asserted to still have been called exactly once after a post.

**2. Assign / unassign**

`AssigneePicker` trigger (labelled with the current assignee, or "Unassigned") -> popover opens ->
`useJiraAssignableUsers({ isEnabled: isOpen })` fires
`GET {siteUrl}/rest/api/3/user/assignable/search?issueKey=ENG-142` -> click a row (or the
"Unassign" row) -> `assign(accountId)` -> `onAssign` prop -> `useJiraIssueActions().assign` ->
`jiraSetAssignee({ ..., accountId })` -> `invoke('jira_set_assignee')` -> `assignee_write` ->
`PUT {siteUrl}/rest/api/3/issue/{key}/assignee` with `{"accountId": "<id>"}` or
`{"accountId": null}`. On success the hook calls `jiraGetIssue` and swaps in the fresh issue.

**3. Transition**

`TransitionMenu` mounts with the issue and immediately runs
`useJiraTransitions` -> `jiraListTransitions` -> `invoke('jira_list_transitions')` ->
`GET {siteUrl}/rest/api/3/issue/{key}/transitions`. Click "Move" -> popover lists exactly those
transitions -> click one -> `move(id)` -> `onTransition` prop -> `useJiraIssueActions().transition`
-> `jiraTransitionIssue({ ..., transitionId })` -> `invoke('jira_transition_issue')` ->
`transition_write` -> `POST {siteUrl}/rest/api/3/issue/{key}/transitions` with
`{"transition":{"id":"31"}}`. On success the menu closes, `useJiraTransitions.reload()` refetches
the now different set of legal moves, and `jiraGetIssue` refreshes the issue so the status badge in
the header shows the new status.

**4. Edit description**

Overview tab -> `DescriptionSection` "Edit" button (revealed only because `onSave` is now passed)
-> textarea -> "Save" -> `useInlineProseEdit.commit` -> `onSave` ->
`useJiraIssueActions().saveDescription` -> `jiraUpdateIssueDescription({ ..., description })` ->
`invoke('jira_update_issue')` -> `description_write` -> `PUT {siteUrl}/rest/api/3/issue/{key}` with
`{"fields":{"description": <ADF doc>}}`. Then `jiraGetIssue` re-reads the issue, so the rendered
markdown is what Jira actually stored after the round trip through ADF, not the local draft.

## Unassign sends a null accountId

Confirmed. `AssigneePicker`'s unassign row calls `assign(null)`, which reaches
`jiraSetAssignee({ accountId: null })` and the existing Rust `assignee_write`, which maps
`None` to `Value::Null`. The string `"-1"` appears nowhere in this diff, and nowhere in the Jira
feature folder (`grep -rn "'-1'\|\"-1\"" apps/desktop/src/features/integrations/jira` is empty).
`"-1"` means "project default assignee" in Jira, not unassigned, so it is never emitted. A test
pins it: `expect(setAssignee.mock.calls[0]?.[0].accountId).toBeNull()`.

## The transition menu is server-driven, and fails loudly

The menu is populated **only** from the per-issue `jiraListTransitions` call, fired when the detail
mounts and re-fired after every successful move. There is no hardcoded status list anywhere and no
list derived from another issue. Every Jira project has its own workflow graph, so the server is the
only source of truth for which moves are legal right now.

When the fetch fails the control **does not vanish**. `blockReason` in `TransitionMenu.tsx` turns
the three blocked states into readable copy on a still-visible trigger:

| state | trigger |
|---|---|
| fetch in flight | `aria-disabled`, title "Reading the Jira workflow for this issue" |
| fetch failed | `aria-disabled`, title "Could not read the Jira workflow for this issue. `<jira error>`" |
| fetch returned zero moves | `aria-disabled`, title "Jira offers no move from this status" |

It uses `aria-disabled` rather than the `disabled` attribute on purpose: `Button` carries
`disabled:pointer-events-none`, so a natively disabled button would swallow the hover and the reason
would be unreadable. Clicking a blocked trigger is a no-op guard clause, so no menu opens. This is
the explicit opposite of `MrActionBar.tsx:57`, which hides the approve controls on a transient error
(known bug, in the backlog, not touched here).

A failed transition (Jira rejecting the move) renders inside the open menu as a `role="alert"` strip
under the rows, and the rows stay clickable for a retry.

## Composer duplication

Extracted `apps/desktop/src/shared/components/NoteComposer/index.tsx`, the shared
`draft`/`isPosting`/`error` machine, and put the Jira surface on it. It is the same component as
`MrNoteComposer` plus GitLab's `IssueNoteComposer` and `GithubIssueCommentComposer`, with
`MrNoteComposer`'s `minRows` prop kept as the only variation point, so the other three can be
deleted in favour of it with a one-line import change each.

**I did not migrate the other three.** The brief's non-goals forbid changes to the GitHub, GitLab,
Linear and Sentry surfaces, and the reuse note calls that migration optional and out of scope. So
this lands the primitive and one consumer; the three duplicates are unchanged and the follow-up is a
mechanical delete. Net effect on the count: still 3 duplicates, but a canonical home now exists and
Jira did not become the fourth.

The avatar initial-fallback duplication was avoided rather than extended: `AssigneePicker` renders
names as text with no avatar, so it does not become the fifth copy.

## In-flight and failure states

Every verb gets a visible in-flight state through `Button`'s `isBusy` / `busyLabel` (spinner plus
`aria-busy`), the same pattern the PR panel uses:

- comment: "Posting" on the composer button
- assign: "Assigning" on the trigger, plus a spinner on the specific row being applied
- transition: "Moving" on the trigger, other rows disabled while it runs
- description: "Saving" on the existing `DescriptionSection` button

Every failure renders as a `role="alert"` next to the control that caused it, and no control
unmounts on error. The assignable-users fetch failing shows the error plus a Retry inside the
popover; the picker trigger stays exactly where it was.

## Files

New:
- `apps/desktop/src/shared/components/NoteComposer/{index.tsx,index.test.tsx}`
- `apps/desktop/src/features/integrations/jira/AssigneePicker.tsx` + test
- `apps/desktop/src/features/integrations/jira/TransitionMenu.tsx` + test
- `apps/desktop/src/features/integrations/jira/useJiraIssueActions/index.ts`
- `apps/desktop/src/features/integrations/jira/useJiraTransitions/index.ts`
- `apps/desktop/src/features/integrations/jira/useJiraAssignableUsers/index.ts`

Modified:
- `JiraIssueDetail/index.tsx` (mounts the two header controls, passes `onSave` and `onPost`, renders
  from the live issue instead of the prop)
- `IssueConversation/index.tsx` (`onPost` prop, mirroring GitLab's shape)
- `useJiraIssueComments/index.ts` (`post`)
- `JiraIssueDetail/index.test.tsx`

No new Rust commands, no new Tauri handler registration, no migration, no store slice. All four
client functions and all six Rust commands already existed and were simply uncalled.

## Tests deleted or rewritten

Both in `JiraIssueDetail/index.test.tsx`:

1. **Deleted: "renders the description read-only, with no edit affordance."** It asserted
   `queryByRole('button', { name: /edit/i })` is null, which pinned exactly the behavior this PR
   removes. Replaced by "saves an edited description and re-renders the issue Jira returns", which
   drives Edit -> type -> Save through the UI and asserts the `jiraUpdateIssueDescription` payload
   plus the refreshed body rendering.
2. **Adjusted: "surfaces the issue type, assignee and labels as properties."** `getByText('Grace
   Hopper')` now matches twice, once in the property row and once as the `AssigneePicker` trigger
   label, so it became `getAllByText(...).length > 0`. Same intent, still fails if the assignee
   stops rendering.

Everything else was added, not changed. 43 tests across the Jira feature plus the new primitive.

## UNVERIFIED AGAINST A LIVE TENANT

Every write in this PR is contract-tested against fixtures and mocks only. **None of it has ever
been exercised against a real Atlassian site.** The endpoints this PR is the first to actually call
from the UI:

- `POST /rest/api/3/issue/{key}/comment` (ADF write acceptance)
- `PUT /rest/api/3/issue/{key}` (description ADF write acceptance)
- `PUT /rest/api/3/issue/{key}/assignee`, including the `{"accountId": null}` unassign
- `GET /rest/api/3/user/assignable/search`
- `GET /rest/api/3/issue/{key}/transitions` and `POST` on the same path
- `GET /rest/api/3/issue/{key}` (re-read after every write)

The ADF writer is minimal by design (one paragraph node per line), which is the thing most likely to
come back as a 400 from a real tenant. If it does, the error text lands in the alert strip next to
the control rather than being swallowed.

## Assumptions I had to make alone

1. **Assignable users are fetched once per popover open, without a `query`, and filtered client
   side.** `jiraListAssignableUsers` accepts a server-side `query`, but using it means debouncing
   keystrokes into network calls. For a project with more people than Jira's default page returns,
   the filter box will only search what came back on the first page. Cheap to change to a debounced
   server query later; it is one prop on the hook.
2. **Transitions that require a screen are shown and attempted plainly.** Jira reports `hasScreen`,
   and those transitions need fields Goodboy cannot fill. Hiding them would make a legal move vanish
   with no explanation, which is the failure mode this PR is explicitly avoiding elsewhere. So they
   are listed like any other, carry a title explaining that Goodboy sends the move without the extra
   fields, and if Jira refuses, Jira's own message is what the user reads.
3. **The freshest issue is held locally in `useJiraIssueActions`, not pushed up to the parent.**
   After a write the hook re-reads the issue and overrides the prop; the override resets whenever
   the parent sends a genuinely different `issue.id`/`issue.updated`. This keeps both mount points
   working without threading a refresh callback through `IssueDetailPanel` and `JiraTaskDetail`. The
   visible consequence: the studio's left rail row still shows the pre-write status until its own
   list refetch, while the detail pane is current.
4. **The assignee picker only lists people, with no avatars.** Deliberate, to avoid adding a fifth
   copy of the avatar initial-fallback that the backlog already tracks.

## Verification

```
pnpm typecheck                                                    5 tasks, all green
pnpm test                                                         531 files, 4544 tests, all green
pnpm knip --include files,duplicates,unlisted                     clean (config hints only)
cargo test --locked (apps/desktop/src-tauri)                      265 passed, 0 failed
```
