### PR TITLE
fix(desktop): four carried seams from the v0.1.63 audit

### DIFF
--- a/apps/desktop/src/features/companion/commandExecutor.ts
+++ b/apps/desktop/src/features/companion/commandExecutor.ts
@@ -229,18 +229,27 @@ async function fetchIssuesFor(
   provider: WorkspaceIntegrationProvider,
 ): Promise<NormalizedIssue[]> {
   try {
-    if (provider === 'linear') {
-      return (await linearFetchAssignedIssues(workspaceId)).map(normalizeLinear);
+    switch (provider) {
+      case 'linear':
+        return (await linearFetchAssignedIssues(workspaceId)).map(normalizeLinear);
+      case 'sentry': {
+        const page = await sentryFetchIssues(workspaceId);
+        return page.issues.map(normalizeSentry);
+      }
+      case 'gitlab': {
+        const host = gitlabHostFor(workspaceId);
+        if (!host) {
+          return [];
+        }
+        return (await gitlabFetchAssignedIssues(workspaceId, host)).map(normalizeGitlab);
+      }
+      case 'jira':
+        return [];
+      default: {
+        const unexpected: never = provider;
+        throw new BridgeSafeError(`unsupported issue provider: ${String(unexpected)}`);
+      }
     }
-    if (provider === 'sentry') {
-      const page = await sentryFetchIssues(workspaceId);
-      return page.issues.map(normalizeSentry);
-    }
-    const host = gitlabHostFor(workspaceId);
-    if (!host) {
-      return [];
-    }
-    return (await gitlabFetchAssignedIssues(workspaceId, host)).map(normalizeGitlab);
   } catch (e) {
     console.error(`[bridge] queryIssues ${provider} fetch failed`, e);
     return [];
@@ -279,62 +288,72 @@ async function resolveIssueForSession(
     title: string;
   };
 }> {
-  if (provider === 'linear') {
-    const issue = (await linearFetchAssignedIssues(workspaceId)).find(
-      (i) => i.identifier === identifier,
-    );
-    if (!issue) {
-      throw new BridgeSafeError(`linear issue not found: ${identifier}`);
+  switch (provider) {
+    case 'linear': {
+      const issue = (await linearFetchAssignedIssues(workspaceId)).find(
+        (i) => i.identifier === identifier,
+      );
+      if (!issue) {
+        throw new BridgeSafeError(`linear issue not found: ${identifier}`);
+      }
+      return {
+        goal: linearGoalFromIssue(issue),
+        externalTask: {
+          provider: 'linear',
+          externalId: issue.id,
+          identifier: issue.identifier,
+          url: issue.url,
+          title: issue.title,
+        },
+      };
     }
-    return {
-      goal: linearGoalFromIssue(issue),
-      externalTask: {
-        provider: 'linear',
-        externalId: issue.id,
-        identifier: issue.identifier,
-        url: issue.url,
-        title: issue.title,
-      },
-    };
-  }
-  if (provider === 'sentry') {
-    const page = await sentryFetchIssues(workspaceId);
-    const issue = page.issues.find((i) => (i.shortId ?? i.id) === identifier);
-    if (!issue) {
-      throw new BridgeSafeError(`sentry issue not found: ${identifier}`);
+    case 'sentry': {
+      const page = await sentryFetchIssues(workspaceId);
+      const issue = page.issues.find((i) => (i.shortId ?? i.id) === identifier);
+      if (!issue) {
+        throw new BridgeSafeError(`sentry issue not found: ${identifier}`);
+      }
+      const detail = await sentryFetchIssueDetail(workspaceId, issue.id).catch(() => null);
+      return {
+        goal: goalFromSentry(issue, detail),
+        externalTask: {
+          provider: 'sentry',
+          externalId: issue.id,
+          identifier: issue.shortId ?? issue.id,
+          url: issue.permalink ?? '',
+          title: issue.title,
+        },
+      };
     }
-    const detail = await sentryFetchIssueDetail(workspaceId, issue.id).catch(() => null);
-    return {
-      goal: goalFromSentry(issue, detail),
-      externalTask: {
-        provider: 'sentry',
-        externalId: issue.id,
-        identifier: issue.shortId ?? issue.id,
-        url: issue.permalink ?? '',
-        title: issue.title,
-      },
-    };
+    case 'gitlab': {
+      const host = gitlabHostFor(workspaceId);
+      if (!host) {
+        throw new BridgeSafeError('gitlab host not configured for this workspace');
+      }
+      const issue = (await gitlabFetchAssignedIssues(workspaceId, host)).find(
+        (i) => gitlabIssueIdentifier(i) === identifier,
+      );
+      if (!issue) {
+        throw new BridgeSafeError(`gitlab issue not found: ${identifier}`);
+      }
+      return {
+        goal: gitlabGoalFromIssue(issue),
+        externalTask: {
+          provider: 'gitlab',
+          externalId: String(issue.id),
+          identifier: gitlabIssueIdentifier(issue),
+          url: issue.webUrl,
+          title: issue.title,
+        },
+      };
+    }
+    case 'jira':
+      throw new BridgeSafeError(`jira issue creation is not available from mobile: ${identifier}`);
+    default: {
+      const unexpected: never = provider;
+      throw new BridgeSafeError(`unsupported issue provider: ${String(unexpected)}`);
+    }
   }
-  const host = gitlabHostFor(workspaceId);
-  if (!host) {
-    throw new BridgeSafeError('gitlab host not configured for this workspace');
-  }
-  const issue = (await gitlabFetchAssignedIssues(workspaceId, host)).find(
-    (i) => gitlabIssueIdentifier(i) === identifier,
-  );
-  if (!issue) {
-    throw new BridgeSafeError(`gitlab issue not found: ${identifier}`);
-  }
-  return {
-    goal: gitlabGoalFromIssue(issue),
-    externalTask: {
-      provider: 'gitlab',
-      externalId: String(issue.id),
-      identifier: gitlabIssueIdentifier(issue),
-      url: issue.webUrl,
-      title: issue.title,
-    },
-  };
 }
 
 async function resolveIssueForSessionSafe(

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel/MrActionBar.test.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel/MrActionBar.test.tsx
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import type { GitlabMergeRequest, GitlabMrApprovalState } from '../../client';
+import { MrActionBar } from './MrActionBar';
+
+const makeMr = (overrides: Partial<GitlabMergeRequest> = {}): GitlabMergeRequest => ({
+  id: 1,
+  iid: 4,
+  projectId: 9,
+  title: 'Add merge request dashboard',
+  description: null,
+  state: 'opened',
+  webUrl: 'https://gitlab.com/acme/web/-/merge_requests/4',
+  sourceBranch: 'ak/gitlab-dashboard',
+  targetBranch: 'main',
+  draft: false,
+  hasConflicts: false,
+  mergeStatus: 'can_be_merged',
+  updatedAt: '2026-08-01T00:00:00Z',
+  ...overrides,
+});
+
+const makeApproval = (overrides: Partial<GitlabMrApprovalState> = {}): GitlabMrApprovalState => ({
+  approvalsRequired: 1,
+  approvalsLeft: 1,
+  userHasApproved: false,
+  userCanApprove: true,
+  approvedBy: [],
+  ...overrides,
+});
+
+const baseProps = {
+  mr: makeMr(),
+  busy: null,
+  isApprovalBusy: false,
+  canAct: true,
+  onApprove: vi.fn(),
+  onUnapprove: vi.fn(),
+  onToggleDraft: vi.fn(),
+  onClose: vi.fn(),
+  onReopen: vi.fn(),
+};
+
+describe('MrActionBar', () => {
+  afterEach(() => cleanup());
+
+  it('hides the vote button when the GitLab instance has no approvals endpoint', () => {
+    render(<MrActionBar {...baseProps} approval={null} isSupported={false} approvalError={null} />);
+
+    expect(screen.queryByRole('button', { name: 'Approve' })).toBeNull();
+  });
+
+  it('renders the vote button disabled with a reason on a transient approval fetch error', () => {
+    render(
+      <MrActionBar
+        {...baseProps}
+        approval={null}
+        isSupported
+        approvalError="Network request failed"
+      />,
+    );
+
+    const button = screen.getByRole('button', { name: 'Approve' });
+    expect(button.getAttribute('aria-disabled')).toBe('true');
+    expect(button.getAttribute('title')).toBe('Network request failed');
+  });
+
+  it('renders the vote button disabled when the user cannot approve their own merge request', () => {
+    render(
+      <MrActionBar
+        {...baseProps}
+        approval={makeApproval({ userCanApprove: false })}
+        isSupported
+        approvalError={null}
+      />,
+    );
+
+    const button = screen.getByRole('button', { name: 'Approve' });
+    expect(button.getAttribute('aria-disabled')).toBe('true');
+    expect(button.getAttribute('title')).toBe(
+      'You do not have permission to approve this merge request.',
+    );
+  });
+
+  it('renders the vote button enabled when the user can approve', () => {
+    render(
+      <MrActionBar
+        {...baseProps}
+        approval={makeApproval({ userCanApprove: true })}
+        isSupported
+        approvalError={null}
+      />,
+    );
+
+    const button = screen.getByRole('button', { name: 'Approve' });
+    expect(button.getAttribute('aria-disabled')).toBe('false');
+  });
+});

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel/MrActionBar.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel/MrActionBar.tsx
@@ -21,11 +21,36 @@ const TONE = {
   warning: actionTone({ tone: 'warning' }),
 } as const;
 
+type ApprovalReasonParams = {
+  readonly approval: GitlabMrApprovalState | null;
+  readonly approvalError: string | null;
+  readonly hasApproved: boolean;
+};
+
+const approvalBlockReason = ({
+  approval,
+  approvalError,
+  hasApproved,
+}: ApprovalReasonParams): string | null => {
+  if (approval == null) {
+    return approvalError ?? 'Could not load approval status for this merge request.';
+  }
+  if (hasApproved) {
+    return null;
+  }
+  if (approval.userCanApprove === false) {
+    return 'You do not have permission to approve this merge request.';
+  }
+  return null;
+};
+
 type Props = {
   readonly mr: GitlabMergeRequest;
   readonly busy: MrActionBusy;
   readonly approval: GitlabMrApprovalState | null;
   readonly isApprovalBusy: boolean;
+  readonly isSupported: boolean;
+  readonly approvalError: string | null;
   readonly canAct: boolean;
   readonly onApprove: (() => void) | null;
   readonly onUnapprove: (() => void) | null;
@@ -39,6 +64,8 @@ export const MrActionBar = ({
   busy,
   approval,
   isApprovalBusy,
+  isSupported,
+  approvalError,
   canAct,
   onApprove,
   onUnapprove,
@@ -51,18 +78,27 @@ export const MrActionBar = ({
   const hasApproved = approval?.userHasApproved === true;
   const approveHandler = hasApproved ? onUnapprove : onApprove;
   const isDisabled = busy !== null || !canAct;
+  const approvalReason = approvalBlockReason({ approval, approvalError, hasApproved });
+  const isApproveBlocked = isDisabled || isApprovalBusy || approvalReason != null;
 
   return (
     <div className="flex flex-wrap items-center gap-1.5">
-      {isOpen && approval != null && approveHandler != null && (
+      {isOpen && isSupported && (
         <button
           type="button"
-          onClick={approveHandler}
-          disabled={isDisabled || isApprovalBusy}
+          aria-disabled={isApproveBlocked}
+          title={approvalReason ?? undefined}
+          onClick={() => {
+            if (isApproveBlocked) {
+              return;
+            }
+            approveHandler?.();
+          }}
           className={cn(
             MR_ACTION_BUTTON,
             hasApproved ? TONE.neutral : TONE.success,
             isApprovalBusy && 'animate-border-pulse',
+            isApproveBlocked && 'opacity-50',
           )}
         >
           {hasApproved ? (

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel/index.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel/index.tsx
@@ -287,6 +287,8 @@ export const MrDetailPanel = ({
               busy={actionBusy}
               approval={approvals.approval}
               isApprovalBusy={approvals.isSubmitting}
+              isSupported={approvals.isSupported}
+              approvalError={approvals.error}
               canAct={canAct}
               onApprove={approvals.approve == null ? null : () => void approvals.approve?.()}
               onUnapprove={approvals.unapprove == null ? null : () => void approvals.unapprove?.()}

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/PipelineSection.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/PipelineSection.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import type { Agent, Session, SessionId, Workflow, WorkspaceId } from '@goodboy/types';
 import { EMPTY_ARRAY, useAppStore, useSessionOpenQuestions } from '../../../../store';
 import type { LensKind } from '../../../../store';
-import { WorkflowGateError } from '../../../../store/slices/workflows/workflowActivationGate';
+import { notifyWorkflowGateBlock } from '../../../../store/slices/workflows/notifyWorkflowGateBlock';
 import { workflowRunHasOpenQuestions } from '../../../context/openQuestionsGate';
 import type { SpawnNode } from '../../../orchestration/components/SpawnTree/lib';
 import type { RunLaneModel } from '../../../orchestration/hooks/useWorkspaceRuns';
@@ -77,12 +77,7 @@ export const PipelineSection = ({
         try {
           await activateWorkflowAgent({ sessionId, agentId: agent.id, focus: 'none' });
         } catch (error) {
-          if (!(error instanceof WorkflowGateError)) {
-            throw error;
-          }
-          void emitNotification('error', 'warning', 'workflow step held back', error.message, {
-            sessionId,
-          });
+          notifyWorkflowGateBlock({ error, sessionId, emitNotification });
         }
       },
     };

--- a/apps/desktop/src/store/slices/session-view/index.test.ts
+++ b/apps/desktop/src/store/slices/session-view/index.test.ts
@@ -730,6 +730,24 @@ describe('store contract', () => {
       expect(store.getState().diffFocus[SESSION_ID]).toBeNull();
     });
 
+    it('focusedPlanId survives the switch to the plans lens and dies on any other', async () => {
+      const store = await getStore();
+      store.getState().setFocusedPlanId(SESSION_ID, PLAN_ID);
+      store.getState().setActiveLens(SESSION_ID, 'plans');
+      expect(store.getState().focusedPlanId[SESSION_ID]).toBe(PLAN_ID);
+      store.getState().setActiveLens(SESSION_ID, 'agents');
+      expect(store.getState().focusedPlanId[SESSION_ID]).toBeNull();
+    });
+
+    it('focusedGithubIssueNumber survives the switch to the github_issue lens and dies on any other', async () => {
+      const store = await getStore();
+      store.getState().setFocusedGithubIssueNumber(SESSION_ID, 9);
+      store.getState().setActiveLens(SESSION_ID, 'github_issue');
+      expect(store.getState().focusedGithubIssueNumber[SESSION_ID]).toBe(9);
+      store.getState().setActiveLens(SESSION_ID, 'agents');
+      expect(store.getState().focusedGithubIssueNumber[SESSION_ID]).toBeNull();
+    });
+
     it('openDiffLens lands on the files lens with the commit focus still set', async () => {
       const store = await getStore();
       store.getState().setActiveLens(SESSION_ID, 'agents');

--- a/apps/desktop/src/store/slices/session-view/workSurface.ts
+++ b/apps/desktop/src/store/slices/session-view/workSurface.ts
@@ -41,6 +41,12 @@ export const setActiveLens = (set: SetFn) => {
             ? s.focusedWorkflowRunId
             : { ...s.focusedWorkflowRunId, [sessionId]: null },
         diffFocus: lens === 'files' ? s.diffFocus : { ...s.diffFocus, [sessionId]: null },
+        focusedPlanId:
+          lens === 'plans' ? s.focusedPlanId : { ...s.focusedPlanId, [sessionId]: null },
+        focusedGithubIssueNumber:
+          lens === 'github_issue'
+            ? s.focusedGithubIssueNumber
+            : { ...s.focusedGithubIssueNumber, [sessionId]: null },
         focusedExternalTask: { ...s.focusedExternalTask, [sessionId]: null },
         lensHistory: {
           ...s.lensHistory,


### PR DESCRIPTION
## Summary

Four carried seams from the v0.1.63 audit. Two had a naive fix that would have shipped a regression; both are avoided here.

## A. Gitlab approve/unapprove vanishes on a fetch error

`apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel/MrActionBar.tsx:57` rendered the vote button only when `approval != null`. A transient approval-fetch error and a real "you can't approve your own MR" case both hid the button instead of disabling it.

Fix: `useGitlabMrApprovals` already computed `isSupported` but never passed it down. Threaded `isSupported` and `approvalError` into `MrActionBar` as new props:
- `!isSupported` still hides the button (CE instance, no approvals endpoint), the existing "hides the approval row" test in `MrDetailPanel/index.test.tsx` stays green untouched
- `isSupported && approval == null` renders the button disabled, with the fetch error as the reason
- `isSupported && approval != null && !approval.userCanApprove` renders disabled with "you do not have permission to approve this merge request"

Followed the `TransitionMenu.tsx` precedent: `aria-disabled` plus `opacity-50` plus `title` plus a guard clause in `onClick`, not the native `disabled` attribute, since `Button` styling makes a disabled control unhoverable and the reason would never surface.

Added `MrActionBar.test.tsx` (didn't exist before), four cases: hidden when unsupported, disabled with the fetch error, disabled when `userCanApprove` is false, enabled when the user can approve.

Sabotage: dropped the `userCanApprove === false` branch from the reason function. The "disabled when the user cannot approve" test failed (`aria-disabled` came back `false` instead of `true`). Restored, reran, green.

## B. `setActiveLens` leaks focused plan and focused github issue

`apps/desktop/src/store/slices/session-view/workSurface.ts` nulled `focusedExternalTask` unconditionally on every lens switch but never touched `focusedPlanId` or `focusedGithubIssueNumber`, so switching away from the plans lens (or the github issue lens) and back left a stale focus pointing at whatever was open last time.

Fix: gated both the same way `focusedWorkflowRunId` and `diffFocus` already are, preserved only when the new lens still owns them (`lens === 'plans'`, `lens === 'github_issue'`), nulled otherwise. Left the explicit `setFocusedPlanId(sessionId, null)` breadcrumb clear in `useSessionCrumbs/index.ts:63` alone: it clears the plan before calling `setActiveLens(sessionId, 'plans')`, and the gate preserves whatever was just set, so the two don't fight.

Added two tests in `store/slices/session-view/index.test.ts`, mirroring the existing `diffFocus` gate test: focus survives switching to its own lens, dies on any other.

Sabotage: replaced both gated assignments with a straight passthrough (`s.focusedPlanId`, `s.focusedGithubIssueNumber`, no reset). Both new tests failed with the stale value still present. Restored, reran, green plus the rest of the suite (42/42).

## C. Duplicated workflow gate-block handler

`SessionOverviewPane/PipelineSection.tsx:79-85` hand-rolled the same `WorkflowGateError` catch already extracted into `store/slices/workflows/notifyWorkflowGateBlock.ts`. Swapped in the shared helper, dropped the `WorkflowGateError` import. `emitNotification` stays: it's still consumed by the call site.

Verified the two existing consumers (`activateWorkflowAgentOrNotify.ts:25`, `SessionWorkspace/parts/ChatWorkflowAdvance.tsx:102`) both call `notifyWorkflowGateBlock({ error, sessionId, emitNotification })` with the identical shape, so this is a pure dedup with no behavior change. No new test: the helper's own coverage plus the two existing consumers already exercise the logic, and the diff is byte-identical in effect to what it replaces.

## D. Mobile companion falls through to gitlab for unknown providers (defense-in-depth)

`apps/desktop/src/features/companion/commandExecutor.ts`, `fetchIssuesFor` and `resolveIssueForSession` were `if` chains for `linear`/`sentry` that fell through unconditionally into the gitlab path for anything else. TypeScript doesn't check `if` chains for exhaustiveness, so a future provider added to `ALL_ISSUE_PROVIDERS` without a matching arm would silently query gitlab.

Converted both to a `switch (provider)` with `default: { const unexpected: never = provider; ... }`. Behavior for `linear`, `sentry`, `gitlab` is unchanged byte for byte. `jira` gets its own explicit arm: `fetchIssuesFor` returns an empty list, `resolveIssueForSession` throws a `BridgeSafeError` naming it.

This is defense-in-depth, not a live defect. Both `queryIssues` and `createSessionFromIssue` already gate `jira` out before reaching these functions today: it's absent from `ALL_ISSUE_PROVIDERS` (commandExecutor.ts:183-187) and `CREATE_SESSION_PROVIDERS` (mobileConfinement.ts:67-71), so no user can currently trigger the fall-through. The value is that the next provider added to the type can't ship a silent wrong-host query without the compiler stopping it at the `never` assignment.

No new test: existing `commandExecutor.commands.test.ts` and `commandExecutor.test.ts` (70 tests) already cover `linear`/`sentry`/`gitlab` through the public `queryIssues` and `createSessionFromIssue` RPCs and stayed green after the conversion, which is the behavior-preservation proof for those three arms. The `jira`/`never` arms aren't reachable from outside today (see above), so there's nothing to sabotage-test without exporting private functions purely for the test.

## Investigated and rejected

A fifth candidate, replacing the `document.querySelector('[data-studio-overlay]')` sniff in `LinkedPrChip/index.tsx:29` with the `sessionStudio` store slot, was looked at and dropped. `[data-studio-overlay]` is emitted by every `StudioShell variant="fullscreen"`, backing 17 studios; `sessionStudio` only tracks 3 kinds, the rest live in plain `useState` in `App.tsx`. Swapping would silently navigate the hidden session pane under 14 unrelated overlays. Left both sniffs alone.

## Test plan

- `pnpm typecheck`: clean
- `pnpm test`: 4552/4552 passed (532 files)
- `pnpm knip --include files,duplicates,unlisted`: no findings
- Every added test sabotaged and confirmed to fail before being restored (see A and B above)
