### PR TITLE
feat(desktop): bitbucket cloud backend and connect lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,13 @@ labels, description and the comment thread, all readable in the app. Launch a
 session from one and the key lands on the branch. Writing back to Jira,
 commenting, assigning, moving status, is not there yet.
 
+**Bitbucket, connect only so far.** Bitbucket Cloud is a code host you can
+connect from onboarding or the integrations panel: a workspace slug, your
+Atlassian account email and an API token, verified against the account and the
+workspace before anything is stored. The pull request inbox, the diff and the
+review verbs are wired in the backend but have no screen yet, so connecting is
+all you can do with it in this build.
+
 **Cost meter that taps your shoulder.** Every session shows what it's costing
 as it runs. Goodboy nudges you before you burn Opus on a one-liner.
 

--- a/apps/desktop/src-tauri/src/bitbucket.rs
+++ b/apps/desktop/src-tauri/src/bitbucket.rs
@@ -208,6 +208,10 @@ async fn get_json<T: serde::de::DeserializeOwned>(
     serde_json::from_str(&body).map_err(|e| BitbucketError::InvalidShape(e.to_string()))
 }
 
+fn reads_as_absent(status: u16) -> bool {
+    status == 404
+}
+
 async fn get_json_optional<T: serde::de::DeserializeOwned>(
     credentials: &Credentials<'_>,
     url: &str,
@@ -220,7 +224,7 @@ async fn get_json_optional<T: serde::de::DeserializeOwned>(
         .await?;
     let status = res.status();
     let body = res.text().await?;
-    if status == reqwest::StatusCode::NOT_FOUND {
+    if reads_as_absent(status.as_u16()) {
         return Ok(None);
     }
     if !status.is_success() {
@@ -763,31 +767,59 @@ fn first_matching_branch(
 }
 
 struct BitbucketWrite {
+    method: reqwest::Method,
     url: String,
-    body: Value,
+    body: Option<Value>,
+}
+
+fn approve_url(base: &str, workspace: &str, repo: &str, id: u64) -> String {
+    format!("{}/approve", pull_request_path(base, workspace, repo, id))
+}
+
+fn request_changes_url(base: &str, workspace: &str, repo: &str, id: u64) -> String {
+    format!(
+        "{}/request-changes",
+        pull_request_path(base, workspace, repo, id)
+    )
 }
 
 fn approve_write(base: &str, workspace: &str, repo: &str, id: u64) -> BitbucketWrite {
     BitbucketWrite {
-        url: format!("{}/approve", pull_request_path(base, workspace, repo, id)),
-        body: Value::Object(serde_json::Map::new()),
+        method: reqwest::Method::POST,
+        url: approve_url(base, workspace, repo, id),
+        body: Some(Value::Object(serde_json::Map::new())),
+    }
+}
+
+fn unapprove_write(base: &str, workspace: &str, repo: &str, id: u64) -> BitbucketWrite {
+    BitbucketWrite {
+        method: reqwest::Method::DELETE,
+        url: approve_url(base, workspace, repo, id),
+        body: None,
     }
 }
 
 fn request_changes_write(base: &str, workspace: &str, repo: &str, id: u64) -> BitbucketWrite {
     BitbucketWrite {
-        url: format!(
-            "{}/request-changes",
-            pull_request_path(base, workspace, repo, id)
-        ),
-        body: Value::Object(serde_json::Map::new()),
+        method: reqwest::Method::POST,
+        url: request_changes_url(base, workspace, repo, id),
+        body: Some(Value::Object(serde_json::Map::new())),
+    }
+}
+
+fn unrequest_changes_write(base: &str, workspace: &str, repo: &str, id: u64) -> BitbucketWrite {
+    BitbucketWrite {
+        method: reqwest::Method::DELETE,
+        url: request_changes_url(base, workspace, repo, id),
+        body: None,
     }
 }
 
 fn decline_write(base: &str, workspace: &str, repo: &str, id: u64) -> BitbucketWrite {
     BitbucketWrite {
+        method: reqwest::Method::POST,
         url: format!("{}/decline", pull_request_path(base, workspace, repo, id)),
-        body: Value::Object(serde_json::Map::new()),
+        body: Some(Value::Object(serde_json::Map::new())),
     }
 }
 
@@ -807,15 +839,17 @@ fn merge_write(
         body.insert("message".to_string(), Value::String(text.to_string()));
     }
     BitbucketWrite {
+        method: reqwest::Method::POST,
         url: format!("{}/merge", pull_request_path(base, workspace, repo, id)),
-        body: Value::Object(body),
+        body: Some(Value::Object(body)),
     }
 }
 
 fn comment_write(base: &str, workspace: &str, repo: &str, id: u64, text: &str) -> BitbucketWrite {
     BitbucketWrite {
+        method: reqwest::Method::POST,
         url: format!("{}/comments", pull_request_path(base, workspace, repo, id)),
-        body: serde_json::json!({ "content": { "raw": text } }),
+        body: Some(serde_json::json!({ "content": { "raw": text } })),
     }
 }
 
@@ -828,11 +862,12 @@ fn reply_write(
     text: &str,
 ) -> BitbucketWrite {
     BitbucketWrite {
+        method: reqwest::Method::POST,
         url: format!("{}/comments", pull_request_path(base, workspace, repo, id)),
-        body: serde_json::json!({
+        body: Some(serde_json::json!({
             "content": { "raw": text },
             "parent": { "id": parent_id }
-        }),
+        })),
     }
 }
 
@@ -1010,13 +1045,8 @@ pub async fn bitbucket_approve_pull_request(
         token: &token,
     };
     let write = approve_write(API_BASE, &workspace_slug, &repo_slug, pull_request_id);
-    let raw: BitbucketParticipantRaw = send_json(
-        &credentials,
-        reqwest::Method::POST,
-        &write.url,
-        Some(&write.body),
-    )
-    .await?;
+    let raw: BitbucketParticipantRaw =
+        send_json(&credentials, write.method, &write.url, write.body.as_ref()).await?;
     Ok(map_participant(raw))
 }
 
@@ -1034,8 +1064,8 @@ pub async fn bitbucket_unapprove_pull_request(
         email: &email,
         token: &token,
     };
-    let write = approve_write(API_BASE, &workspace_slug, &repo_slug, pull_request_id);
-    send_no_content(&credentials, reqwest::Method::DELETE, &write.url, None).await
+    let write = unapprove_write(API_BASE, &workspace_slug, &repo_slug, pull_request_id);
+    send_no_content(&credentials, write.method, &write.url, write.body.as_ref()).await
 }
 
 #[tauri::command]
@@ -1053,13 +1083,8 @@ pub async fn bitbucket_request_changes(
         token: &token,
     };
     let write = request_changes_write(API_BASE, &workspace_slug, &repo_slug, pull_request_id);
-    let raw: BitbucketParticipantRaw = send_json(
-        &credentials,
-        reqwest::Method::POST,
-        &write.url,
-        Some(&write.body),
-    )
-    .await?;
+    let raw: BitbucketParticipantRaw =
+        send_json(&credentials, write.method, &write.url, write.body.as_ref()).await?;
     Ok(map_participant(raw))
 }
 
@@ -1077,8 +1102,8 @@ pub async fn bitbucket_unrequest_changes(
         email: &email,
         token: &token,
     };
-    let write = request_changes_write(API_BASE, &workspace_slug, &repo_slug, pull_request_id);
-    send_no_content(&credentials, reqwest::Method::DELETE, &write.url, None).await
+    let write = unrequest_changes_write(API_BASE, &workspace_slug, &repo_slug, pull_request_id);
+    send_no_content(&credentials, write.method, &write.url, write.body.as_ref()).await
 }
 
 #[tauri::command]
@@ -1105,13 +1130,8 @@ pub async fn bitbucket_merge_pull_request(
         close_source_branch,
         message.as_deref(),
     );
-    let raw: BitbucketPullRequestRaw = send_json(
-        &credentials,
-        reqwest::Method::POST,
-        &write.url,
-        Some(&write.body),
-    )
-    .await?;
+    let raw: BitbucketPullRequestRaw =
+        send_json(&credentials, write.method, &write.url, write.body.as_ref()).await?;
     Ok(map_pull_request(raw))
 }
 
@@ -1130,13 +1150,8 @@ pub async fn bitbucket_decline_pull_request(
         token: &token,
     };
     let write = decline_write(API_BASE, &workspace_slug, &repo_slug, pull_request_id);
-    let raw: BitbucketPullRequestRaw = send_json(
-        &credentials,
-        reqwest::Method::POST,
-        &write.url,
-        Some(&write.body),
-    )
-    .await?;
+    let raw: BitbucketPullRequestRaw =
+        send_json(&credentials, write.method, &write.url, write.body.as_ref()).await?;
     Ok(map_pull_request(raw))
 }
 
@@ -1162,13 +1177,8 @@ pub async fn bitbucket_create_pull_request_comment(
         pull_request_id,
         &body,
     );
-    let raw: BitbucketCommentRaw = send_json(
-        &credentials,
-        reqwest::Method::POST,
-        &write.url,
-        Some(&write.body),
-    )
-    .await?;
+    let raw: BitbucketCommentRaw =
+        send_json(&credentials, write.method, &write.url, write.body.as_ref()).await?;
     Ok(map_comment(raw))
 }
 
@@ -1196,13 +1206,8 @@ pub async fn bitbucket_reply_to_pull_request_comment(
         parent_comment_id,
         &body,
     );
-    let raw: BitbucketCommentRaw = send_json(
-        &credentials,
-        reqwest::Method::POST,
-        &write.url,
-        Some(&write.body),
-    )
-    .await?;
+    let raw: BitbucketCommentRaw =
+        send_json(&credentials, write.method, &write.url, write.body.as_ref()).await?;
     Ok(map_comment(raw))
 }
 
@@ -1358,29 +1363,55 @@ mod tests {
             .starts_with("https://api.bitbucket.org/2.0/repositories/goodboy/desktop/pullrequests/7/statuses?"));
     }
 
+    fn body_of(write: &BitbucketWrite) -> &Value {
+        write.body.as_ref().expect("the write carries a body")
+    }
+
     #[test]
     fn approve_write_posts_to_the_approve_sub_resource_with_an_empty_body() {
         let write = approve_write(BASE, "goodboy", "desktop", 12);
+        assert_eq!(write.method, reqwest::Method::POST);
         assert_eq!(
             write.url,
             "https://api.bitbucket.org/2.0/repositories/goodboy/desktop/pullrequests/12/approve"
         );
-        assert_eq!(write.body, serde_json::json!({}));
+        assert_eq!(*body_of(&write), serde_json::json!({}));
+    }
+
+    #[test]
+    fn unapprove_write_deletes_the_same_approve_sub_resource_without_a_body() {
+        let write = unapprove_write(BASE, "goodboy", "desktop", 12);
+        assert_eq!(write.method, reqwest::Method::DELETE);
+        assert_eq!(write.url, approve_write(BASE, "goodboy", "desktop", 12).url);
+        assert!(write.body.is_none());
     }
 
     #[test]
     fn request_changes_write_uses_the_hyphenated_sub_resource() {
         let write = request_changes_write(BASE, "goodboy", "desktop", 12);
+        assert_eq!(write.method, reqwest::Method::POST);
         assert_eq!(
             write.url,
             "https://api.bitbucket.org/2.0/repositories/goodboy/desktop/pullrequests/12/request-changes"
         );
-        assert_eq!(write.body, serde_json::json!({}));
+        assert_eq!(*body_of(&write), serde_json::json!({}));
+    }
+
+    #[test]
+    fn unrequest_changes_write_deletes_the_same_sub_resource_without_a_body() {
+        let write = unrequest_changes_write(BASE, "goodboy", "desktop", 12);
+        assert_eq!(write.method, reqwest::Method::DELETE);
+        assert_eq!(
+            write.url,
+            request_changes_write(BASE, "goodboy", "desktop", 12).url
+        );
+        assert!(write.body.is_none());
     }
 
     #[test]
     fn decline_write_targets_the_decline_sub_resource() {
         let write = decline_write(BASE, "goodboy", "desktop", 3);
+        assert_eq!(write.method, reqwest::Method::POST);
         assert_eq!(
             write.url,
             "https://api.bitbucket.org/2.0/repositories/goodboy/desktop/pullrequests/3/decline"
@@ -1390,48 +1421,63 @@ mod tests {
     #[test]
     fn merge_write_never_pins_a_merge_strategy() {
         let bare = merge_write(BASE, "goodboy", "desktop", 5, None, None);
+        assert_eq!(bare.method, reqwest::Method::POST);
         assert_eq!(
             bare.url,
             "https://api.bitbucket.org/2.0/repositories/goodboy/desktop/pullrequests/5/merge"
         );
-        assert_eq!(bare.body, serde_json::json!({}));
+        assert_eq!(*body_of(&bare), serde_json::json!({}));
         let full = merge_write(BASE, "goodboy", "desktop", 5, Some(true), Some("ship it"));
-        assert!(full.body.get("merge_strategy").is_none());
+        assert!(body_of(&full).get("merge_strategy").is_none());
     }
 
     #[test]
     fn merge_write_carries_only_the_options_it_was_given() {
         let with_flag = merge_write(BASE, "goodboy", "desktop", 5, Some(false), None);
-        assert_eq!(with_flag.body["close_source_branch"], Value::Bool(false));
-        assert!(with_flag.body.get("message").is_none());
+        assert_eq!(
+            body_of(&with_flag)["close_source_branch"],
+            Value::Bool(false)
+        );
+        assert!(body_of(&with_flag).get("message").is_none());
         let with_message = merge_write(BASE, "goodboy", "desktop", 5, None, Some(" ship it "));
-        assert_eq!(with_message.body["message"], "ship it");
-        assert!(with_message.body.get("close_source_branch").is_none());
+        assert_eq!(body_of(&with_message)["message"], "ship it");
+        assert!(body_of(&with_message).get("close_source_branch").is_none());
         let blank_message = merge_write(BASE, "goodboy", "desktop", 5, None, Some("   "));
-        assert!(blank_message.body.get("message").is_none());
+        assert!(body_of(&blank_message).get("message").is_none());
     }
 
     #[test]
     fn comment_write_nests_the_text_under_content_raw() {
         let write = comment_write(BASE, "goodboy", "desktop", 9, "looks good");
+        assert_eq!(write.method, reqwest::Method::POST);
         assert_eq!(
             write.url,
             "https://api.bitbucket.org/2.0/repositories/goodboy/desktop/pullrequests/9/comments"
         );
-        assert_eq!(write.body["content"]["raw"], "looks good");
-        assert!(write.body.get("parent").is_none());
-        assert!(write.body.get("body").is_none());
+        assert_eq!(body_of(&write)["content"]["raw"], "looks good");
+        assert!(body_of(&write).get("parent").is_none());
+        assert!(body_of(&write).get("body").is_none());
     }
 
     #[test]
     fn reply_write_adds_the_parent_id_beside_the_content() {
         let write = reply_write(BASE, "goodboy", "desktop", 9, 4242, "agreed");
+        assert_eq!(write.method, reqwest::Method::POST);
         assert_eq!(
             write.url,
             "https://api.bitbucket.org/2.0/repositories/goodboy/desktop/pullrequests/9/comments"
         );
-        assert_eq!(write.body["content"]["raw"], "agreed");
-        assert_eq!(write.body["parent"]["id"], 4242);
+        assert_eq!(body_of(&write)["content"]["raw"], "agreed");
+        assert_eq!(body_of(&write)["parent"]["id"], 4242);
+    }
+
+    #[test]
+    fn only_a_404_reads_as_an_absent_resource() {
+        assert!(reads_as_absent(404));
+        assert!(!reads_as_absent(403));
+        assert!(!reads_as_absent(401));
+        assert!(!reads_as_absent(200));
+        assert!(!reads_as_absent(500));
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/bitbucket.rs
+++ b/apps/desktop/src-tauri/src/bitbucket.rs
@@ -1,0 +1,1688 @@
+use std::collections::{HashMap, HashSet};
+use std::sync::{Mutex, OnceLock};
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tauri::State;
+use thiserror::Error;
+
+use crate::secrets;
+
+pub struct BitbucketTokenCache(Mutex<HashMap<String, String>>);
+
+impl BitbucketTokenCache {
+    pub fn new() -> Self {
+        Self(Mutex::new(HashMap::new()))
+    }
+}
+
+fn http_client() -> &'static reqwest::Client {
+    static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+    CLIENT.get_or_init(reqwest::Client::new)
+}
+
+fn credential_key(workspace_id: &str) -> String {
+    format!("goodboy.workspace.{}.bitbucket", workspace_id)
+}
+
+const API_BASE: &str = "https://api.bitbucket.org/2.0";
+const MAX_PAGES: u32 = 20;
+const PAGE_LEN: u32 = 50;
+
+const AUTH_HINT: &str = "bitbucket rejected the credentials. goodboy signs every call with http basic auth, your atlassian account email in the username slot and a secret in the password slot. that secret is either an atlassian api token or a legacy bitbucket app password. check which of the two you pasted, and that it grants the account, repository and pullrequest scopes";
+
+#[derive(Debug, Error)]
+pub enum BitbucketError {
+    #[error("http error {status}: {body}")]
+    Http { status: u16, body: String },
+    #[error("authentication failed: {0}")]
+    Auth(String),
+    #[error("not found: {0}")]
+    NotFound(String),
+    #[error("invalid response shape: {0}")]
+    InvalidShape(String),
+    #[error("no token stored for workspace {0}")]
+    NoToken(String),
+    #[error("secret store error: {0}")]
+    Secret(#[from] secrets::SecretError),
+}
+
+crate::util::impl_error_serialize!(BitbucketError);
+
+impl BitbucketError {
+    fn kind(&self) -> &'static str {
+        match self {
+            BitbucketError::Http { .. } => "http",
+            BitbucketError::Auth(_) => "auth",
+            BitbucketError::NotFound(_) => "not_found",
+            BitbucketError::InvalidShape(_) => "shape",
+            BitbucketError::NoToken(_) => "no_token",
+            BitbucketError::Secret(_) => "secret",
+        }
+    }
+}
+
+impl From<reqwest::Error> for BitbucketError {
+    fn from(e: reqwest::Error) -> Self {
+        BitbucketError::Http {
+            status: 0,
+            body: e.to_string(),
+        }
+    }
+}
+
+fn percent_encode(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                out.push(byte as char)
+            }
+            _ => out.push_str(&format!("%{byte:02X}")),
+        }
+    }
+    out
+}
+
+fn error_message(body: &str) -> Option<String> {
+    let parsed: Value = serde_json::from_str(body).ok()?;
+    let error = parsed.get("error")?;
+    let message = error
+        .get("message")
+        .and_then(|value| value.as_str())
+        .map(str::to_string);
+    let detail = error
+        .get("detail")
+        .and_then(|value| value.as_str())
+        .map(str::to_string);
+    match (message, detail) {
+        (Some(message), Some(detail)) => Some(format!("{message}: {detail}")),
+        (Some(message), None) => Some(message),
+        (None, Some(detail)) => Some(detail),
+        (None, None) => None,
+    }
+}
+
+fn error_for_status(status: u16, body: String) -> BitbucketError {
+    let detail = error_message(&body).unwrap_or_else(|| body.clone());
+    match status {
+        401 | 403 => BitbucketError::Auth(format!("{AUTH_HINT} ({detail})")),
+        404 => BitbucketError::NotFound(detail),
+        _ => BitbucketError::Http { status, body },
+    }
+}
+
+struct Credentials<'a> {
+    email: &'a str,
+    token: &'a str,
+}
+
+fn repo_path(base: &str, workspace: &str, repo: &str) -> String {
+    format!(
+        "{}/repositories/{}/{}",
+        base,
+        percent_encode(workspace.trim().trim_matches('/')),
+        percent_encode(repo.trim().trim_matches('/'))
+    )
+}
+
+fn workspace_url(base: &str, workspace: &str) -> String {
+    format!(
+        "{}/workspaces/{}",
+        base,
+        percent_encode(workspace.trim().trim_matches('/'))
+    )
+}
+
+fn current_user_url(base: &str) -> String {
+    format!("{}/user", base)
+}
+
+fn pull_requests_path(base: &str, workspace: &str, repo: &str) -> String {
+    format!("{}/pullrequests", repo_path(base, workspace, repo))
+}
+
+fn pull_request_path(base: &str, workspace: &str, repo: &str, id: u64) -> String {
+    format!("{}/{}", pull_requests_path(base, workspace, repo), id)
+}
+
+fn pull_requests_url(base: &str, workspace: &str, repo: &str, state: Option<&str>) -> String {
+    let selected = state
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("OPEN")
+        .to_uppercase();
+    format!(
+        "{}?state={}&pagelen={}",
+        pull_requests_path(base, workspace, repo),
+        percent_encode(&selected),
+        PAGE_LEN
+    )
+}
+
+fn pull_requests_for_branch_url(base: &str, workspace: &str, repo: &str, branch: &str) -> String {
+    let query = format!("source.branch.name=\"{}\"", branch.trim());
+    format!(
+        "{}?state=OPEN&pagelen={}&q={}",
+        pull_requests_path(base, workspace, repo),
+        PAGE_LEN,
+        percent_encode(&query)
+    )
+}
+
+fn pull_request_diff_url(base: &str, workspace: &str, repo: &str, id: u64) -> String {
+    format!("{}/diff", pull_request_path(base, workspace, repo, id))
+}
+
+fn pull_request_comments_url(base: &str, workspace: &str, repo: &str, id: u64) -> String {
+    format!(
+        "{}/comments?pagelen={}",
+        pull_request_path(base, workspace, repo, id),
+        PAGE_LEN
+    )
+}
+
+fn pull_request_statuses_url(base: &str, workspace: &str, repo: &str, id: u64) -> String {
+    format!(
+        "{}/statuses?pagelen={}",
+        pull_request_path(base, workspace, repo, id),
+        PAGE_LEN
+    )
+}
+
+async fn get_json<T: serde::de::DeserializeOwned>(
+    credentials: &Credentials<'_>,
+    url: &str,
+) -> Result<T, BitbucketError> {
+    let res = http_client()
+        .get(url)
+        .basic_auth(credentials.email, Some(credentials.token))
+        .header("Accept", "application/json")
+        .send()
+        .await?;
+    let status = res.status();
+    let body = res.text().await?;
+    if !status.is_success() {
+        return Err(error_for_status(status.as_u16(), body));
+    }
+    serde_json::from_str(&body).map_err(|e| BitbucketError::InvalidShape(e.to_string()))
+}
+
+async fn get_json_optional<T: serde::de::DeserializeOwned>(
+    credentials: &Credentials<'_>,
+    url: &str,
+) -> Result<Option<T>, BitbucketError> {
+    let res = http_client()
+        .get(url)
+        .basic_auth(credentials.email, Some(credentials.token))
+        .header("Accept", "application/json")
+        .send()
+        .await?;
+    let status = res.status();
+    let body = res.text().await?;
+    if status == reqwest::StatusCode::NOT_FOUND {
+        return Ok(None);
+    }
+    if !status.is_success() {
+        return Err(error_for_status(status.as_u16(), body));
+    }
+    serde_json::from_str(&body)
+        .map(Some)
+        .map_err(|e| BitbucketError::InvalidShape(e.to_string()))
+}
+
+async fn get_text(credentials: &Credentials<'_>, url: &str) -> Result<String, BitbucketError> {
+    let res = http_client()
+        .get(url)
+        .basic_auth(credentials.email, Some(credentials.token))
+        .header("Accept", "text/plain")
+        .send()
+        .await?;
+    let status = res.status();
+    let body = res.text().await?;
+    if !status.is_success() {
+        return Err(error_for_status(status.as_u16(), body));
+    }
+    Ok(body)
+}
+
+async fn send_json<T: serde::de::DeserializeOwned>(
+    credentials: &Credentials<'_>,
+    method: reqwest::Method,
+    url: &str,
+    body: Option<&Value>,
+) -> Result<T, BitbucketError> {
+    let mut request = http_client()
+        .request(method, url)
+        .basic_auth(credentials.email, Some(credentials.token))
+        .header("Accept", "application/json");
+    if let Some(payload) = body {
+        request = request.json(payload);
+    }
+    let res = request.send().await?;
+    let status = res.status();
+    let text = res.text().await?;
+    if !status.is_success() {
+        return Err(error_for_status(status.as_u16(), text));
+    }
+    serde_json::from_str(&text).map_err(|e| BitbucketError::InvalidShape(e.to_string()))
+}
+
+async fn send_no_content(
+    credentials: &Credentials<'_>,
+    method: reqwest::Method,
+    url: &str,
+    body: Option<&Value>,
+) -> Result<(), BitbucketError> {
+    let mut request = http_client()
+        .request(method, url)
+        .basic_auth(credentials.email, Some(credentials.token))
+        .header("Accept", "application/json");
+    if let Some(payload) = body {
+        request = request.json(payload);
+    }
+    let res = request.send().await?;
+    let status = res.status();
+    let text = res.text().await?;
+    if !status.is_success() {
+        return Err(error_for_status(status.as_u16(), text));
+    }
+    Ok(())
+}
+
+fn read_token(workspace_id: &str, cache: &BitbucketTokenCache) -> Result<String, BitbucketError> {
+    if let Some(token) = cache.0.lock().unwrap().get(workspace_id) {
+        return Ok(token.clone());
+    }
+    let token = secrets::read(&credential_key(workspace_id))?
+        .ok_or_else(|| BitbucketError::NoToken(workspace_id.to_string()))?;
+    cache
+        .0
+        .lock()
+        .unwrap()
+        .insert(workspace_id.to_string(), token.clone());
+    Ok(token)
+}
+
+#[derive(Debug, Deserialize)]
+struct BitbucketHref {
+    #[serde(default)]
+    href: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct BitbucketLinks {
+    #[serde(default)]
+    avatar: Option<BitbucketHref>,
+    #[serde(default)]
+    html: Option<BitbucketHref>,
+}
+
+fn href_of(link: Option<&BitbucketHref>) -> Option<String> {
+    link.and_then(|value| value.href.clone())
+        .filter(|value| !value.is_empty())
+}
+
+#[derive(Debug, Deserialize)]
+struct BitbucketUserRaw {
+    #[serde(default)]
+    uuid: Option<String>,
+    #[serde(default)]
+    account_id: Option<String>,
+    #[serde(default)]
+    nickname: Option<String>,
+    #[serde(default)]
+    display_name: Option<String>,
+    #[serde(default)]
+    links: Option<BitbucketLinks>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct BitbucketUser {
+    pub uuid: String,
+    #[serde(rename = "accountId")]
+    pub account_id: Option<String>,
+    pub nickname: String,
+    #[serde(rename = "displayName")]
+    pub display_name: String,
+    #[serde(rename = "avatarUrl")]
+    pub avatar_url: Option<String>,
+}
+
+fn map_user(raw: BitbucketUserRaw) -> BitbucketUser {
+    let links = raw.links.unwrap_or_default();
+    let display_name = raw.display_name.unwrap_or_default();
+    let nickname = raw.nickname.unwrap_or_else(|| display_name.clone());
+    BitbucketUser {
+        uuid: raw.uuid.unwrap_or_default(),
+        account_id: raw.account_id,
+        nickname,
+        display_name,
+        avatar_url: href_of(links.avatar.as_ref()),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct BitbucketWorkspaceRaw {
+    #[serde(default)]
+    uuid: Option<String>,
+    #[serde(default)]
+    slug: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    links: Option<BitbucketLinks>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct BitbucketWorkspace {
+    pub uuid: String,
+    pub slug: String,
+    pub name: String,
+    #[serde(rename = "webUrl")]
+    pub web_url: Option<String>,
+}
+
+fn map_workspace(raw: BitbucketWorkspaceRaw) -> BitbucketWorkspace {
+    let links = raw.links.unwrap_or_default();
+    let slug = raw.slug.unwrap_or_default();
+    let name = raw.name.unwrap_or_else(|| slug.clone());
+    BitbucketWorkspace {
+        uuid: raw.uuid.unwrap_or_default(),
+        slug,
+        name,
+        web_url: href_of(links.html.as_ref()),
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct BitbucketConnection {
+    pub user: BitbucketUser,
+    pub workspace: BitbucketWorkspace,
+}
+
+#[derive(Debug, Deserialize)]
+struct BitbucketNamed {
+    #[serde(default)]
+    name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct BitbucketCommitRef {
+    #[serde(default)]
+    hash: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct BitbucketEndpointRaw {
+    #[serde(default)]
+    branch: Option<BitbucketNamed>,
+    #[serde(default)]
+    commit: Option<BitbucketCommitRef>,
+}
+
+#[derive(Debug, Deserialize)]
+struct BitbucketParticipantRaw {
+    #[serde(default)]
+    user: Option<BitbucketUserRaw>,
+    #[serde(default)]
+    role: Option<String>,
+    #[serde(default)]
+    approved: bool,
+    #[serde(default)]
+    state: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct BitbucketParticipant {
+    pub user: Option<BitbucketUser>,
+    pub role: String,
+    pub approved: bool,
+    pub state: Option<String>,
+}
+
+fn map_participant(raw: BitbucketParticipantRaw) -> BitbucketParticipant {
+    BitbucketParticipant {
+        user: raw.user.map(map_user),
+        role: raw.role.unwrap_or_default(),
+        approved: raw.approved,
+        state: raw.state,
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct BitbucketPullRequestRaw {
+    id: u64,
+    #[serde(default)]
+    title: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    state: Option<String>,
+    #[serde(default)]
+    created_on: Option<String>,
+    #[serde(default)]
+    updated_on: Option<String>,
+    #[serde(default)]
+    source: Option<BitbucketEndpointRaw>,
+    #[serde(default)]
+    destination: Option<BitbucketEndpointRaw>,
+    #[serde(default)]
+    author: Option<BitbucketUserRaw>,
+    #[serde(default)]
+    reviewers: Vec<BitbucketUserRaw>,
+    #[serde(default)]
+    participants: Vec<BitbucketParticipantRaw>,
+    #[serde(default)]
+    close_source_branch: bool,
+    #[serde(default)]
+    merge_commit: Option<BitbucketCommitRef>,
+    #[serde(default)]
+    comment_count: u64,
+    #[serde(default)]
+    task_count: u64,
+    #[serde(default)]
+    links: Option<BitbucketLinks>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct BitbucketPullRequest {
+    pub id: u64,
+    pub title: String,
+    pub description: String,
+    pub state: String,
+    #[serde(rename = "createdOn")]
+    pub created_on: String,
+    #[serde(rename = "updatedOn")]
+    pub updated_on: String,
+    #[serde(rename = "sourceBranch")]
+    pub source_branch: String,
+    #[serde(rename = "sourceCommit")]
+    pub source_commit: Option<String>,
+    #[serde(rename = "destinationBranch")]
+    pub destination_branch: String,
+    #[serde(rename = "destinationCommit")]
+    pub destination_commit: Option<String>,
+    pub author: Option<BitbucketUser>,
+    pub reviewers: Vec<BitbucketUser>,
+    pub participants: Vec<BitbucketParticipant>,
+    #[serde(rename = "closeSourceBranch")]
+    pub close_source_branch: bool,
+    #[serde(rename = "mergeCommit")]
+    pub merge_commit: Option<String>,
+    #[serde(rename = "commentCount")]
+    pub comment_count: u64,
+    #[serde(rename = "taskCount")]
+    pub task_count: u64,
+    #[serde(rename = "webUrl")]
+    pub web_url: Option<String>,
+}
+
+fn branch_name(endpoint: Option<&BitbucketEndpointRaw>) -> String {
+    endpoint
+        .and_then(|value| value.branch.as_ref())
+        .and_then(|branch| branch.name.clone())
+        .unwrap_or_default()
+}
+
+fn commit_hash(endpoint: Option<&BitbucketEndpointRaw>) -> Option<String> {
+    endpoint
+        .and_then(|value| value.commit.as_ref())
+        .and_then(|commit| commit.hash.clone())
+}
+
+fn map_pull_request(raw: BitbucketPullRequestRaw) -> BitbucketPullRequest {
+    let links = raw.links.unwrap_or_default();
+    BitbucketPullRequest {
+        id: raw.id,
+        title: raw.title.unwrap_or_default(),
+        description: raw.description.unwrap_or_default(),
+        state: raw.state.unwrap_or_default(),
+        created_on: raw.created_on.unwrap_or_default(),
+        updated_on: raw.updated_on.unwrap_or_default(),
+        source_branch: branch_name(raw.source.as_ref()),
+        source_commit: commit_hash(raw.source.as_ref()),
+        destination_branch: branch_name(raw.destination.as_ref()),
+        destination_commit: commit_hash(raw.destination.as_ref()),
+        author: raw.author.map(map_user),
+        reviewers: raw.reviewers.into_iter().map(map_user).collect(),
+        participants: raw.participants.into_iter().map(map_participant).collect(),
+        close_source_branch: raw.close_source_branch,
+        merge_commit: raw.merge_commit.and_then(|commit| commit.hash),
+        comment_count: raw.comment_count,
+        task_count: raw.task_count,
+        web_url: href_of(links.html.as_ref()),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct BitbucketContentRaw {
+    #[serde(default)]
+    raw: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct BitbucketParentRaw {
+    #[serde(default)]
+    id: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct BitbucketInlineRaw {
+    #[serde(default)]
+    path: Option<String>,
+    #[serde(default)]
+    from: Option<u64>,
+    #[serde(default)]
+    to: Option<u64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct BitbucketInline {
+    pub path: String,
+    pub from: Option<u64>,
+    pub to: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct BitbucketCommentRaw {
+    id: u64,
+    #[serde(default)]
+    content: Option<BitbucketContentRaw>,
+    #[serde(default)]
+    user: Option<BitbucketUserRaw>,
+    #[serde(default)]
+    created_on: Option<String>,
+    #[serde(default)]
+    updated_on: Option<String>,
+    #[serde(default)]
+    deleted: bool,
+    #[serde(default)]
+    parent: Option<BitbucketParentRaw>,
+    #[serde(default)]
+    inline: Option<BitbucketInlineRaw>,
+    #[serde(default)]
+    links: Option<BitbucketLinks>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct BitbucketComment {
+    pub id: u64,
+    pub body: String,
+    pub user: Option<BitbucketUser>,
+    #[serde(rename = "createdOn")]
+    pub created_on: String,
+    #[serde(rename = "updatedOn")]
+    pub updated_on: String,
+    pub deleted: bool,
+    #[serde(rename = "parentId")]
+    pub parent_id: Option<u64>,
+    pub inline: Option<BitbucketInline>,
+    #[serde(rename = "webUrl")]
+    pub web_url: Option<String>,
+}
+
+fn map_comment(raw: BitbucketCommentRaw) -> BitbucketComment {
+    let links = raw.links.unwrap_or_default();
+    BitbucketComment {
+        id: raw.id,
+        body: raw
+            .content
+            .and_then(|content| content.raw)
+            .unwrap_or_default(),
+        user: raw.user.map(map_user),
+        created_on: raw.created_on.unwrap_or_default(),
+        updated_on: raw.updated_on.unwrap_or_default(),
+        deleted: raw.deleted,
+        parent_id: raw.parent.and_then(|parent| parent.id),
+        inline: raw.inline.map(|inline| BitbucketInline {
+            path: inline.path.unwrap_or_default(),
+            from: inline.from,
+            to: inline.to,
+        }),
+        web_url: href_of(links.html.as_ref()),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct BitbucketStatusRaw {
+    #[serde(default)]
+    key: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    state: Option<String>,
+    #[serde(default)]
+    url: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    refname: Option<String>,
+    #[serde(default)]
+    created_on: Option<String>,
+    #[serde(default)]
+    updated_on: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct BitbucketStatus {
+    pub key: String,
+    pub name: String,
+    pub state: String,
+    pub url: Option<String>,
+    pub description: Option<String>,
+    pub refname: Option<String>,
+    #[serde(rename = "createdOn")]
+    pub created_on: String,
+    #[serde(rename = "updatedOn")]
+    pub updated_on: String,
+}
+
+fn map_status(raw: BitbucketStatusRaw) -> BitbucketStatus {
+    let key = raw.key.unwrap_or_default();
+    BitbucketStatus {
+        name: raw.name.unwrap_or_else(|| key.clone()),
+        key,
+        state: raw.state.unwrap_or_default(),
+        url: raw.url,
+        description: raw.description,
+        refname: raw.refname,
+        created_on: raw.created_on.unwrap_or_default(),
+        updated_on: raw.updated_on.unwrap_or_default(),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct BitbucketPage<T> {
+    #[serde(default = "Vec::new")]
+    values: Vec<T>,
+    #[serde(default)]
+    next: Option<String>,
+}
+
+struct Pager {
+    seen: HashSet<String>,
+    pages: u32,
+}
+
+impl Pager {
+    fn new() -> Self {
+        Self {
+            seen: HashSet::new(),
+            pages: 0,
+        }
+    }
+
+    fn absorb<T>(
+        &mut self,
+        page: BitbucketPage<T>,
+        sink: &mut Vec<T>,
+    ) -> Result<Option<String>, BitbucketError> {
+        sink.extend(page.values);
+        self.pages += 1;
+        if self.pages >= MAX_PAGES {
+            return Ok(None);
+        }
+        let Some(next) = page.next.filter(|value| !value.trim().is_empty()) else {
+            return Ok(None);
+        };
+        if !self.seen.insert(next.clone()) {
+            return Err(BitbucketError::InvalidShape(format!(
+                "bitbucket pagination looped on {next}"
+            )));
+        }
+        Ok(Some(next))
+    }
+}
+
+async fn get_json_paged<T: serde::de::DeserializeOwned>(
+    credentials: &Credentials<'_>,
+    first_url: &str,
+) -> Result<Vec<T>, BitbucketError> {
+    let mut pager = Pager::new();
+    let mut collected: Vec<T> = Vec::new();
+    let mut url = first_url.to_string();
+    loop {
+        let page: BitbucketPage<T> = get_json(credentials, &url).await?;
+        let Some(next) = pager.absorb(page, &mut collected)? else {
+            break;
+        };
+        url = next;
+    }
+    Ok(collected)
+}
+
+fn first_matching_branch(
+    values: Vec<BitbucketPullRequestRaw>,
+    branch: &str,
+) -> Option<BitbucketPullRequestRaw> {
+    let wanted = branch.trim();
+    values
+        .into_iter()
+        .find(|raw| branch_name(raw.source.as_ref()) == wanted)
+}
+
+struct BitbucketWrite {
+    url: String,
+    body: Value,
+}
+
+fn approve_write(base: &str, workspace: &str, repo: &str, id: u64) -> BitbucketWrite {
+    BitbucketWrite {
+        url: format!("{}/approve", pull_request_path(base, workspace, repo, id)),
+        body: Value::Object(serde_json::Map::new()),
+    }
+}
+
+fn request_changes_write(base: &str, workspace: &str, repo: &str, id: u64) -> BitbucketWrite {
+    BitbucketWrite {
+        url: format!(
+            "{}/request-changes",
+            pull_request_path(base, workspace, repo, id)
+        ),
+        body: Value::Object(serde_json::Map::new()),
+    }
+}
+
+fn decline_write(base: &str, workspace: &str, repo: &str, id: u64) -> BitbucketWrite {
+    BitbucketWrite {
+        url: format!("{}/decline", pull_request_path(base, workspace, repo, id)),
+        body: Value::Object(serde_json::Map::new()),
+    }
+}
+
+fn merge_write(
+    base: &str,
+    workspace: &str,
+    repo: &str,
+    id: u64,
+    close_source_branch: Option<bool>,
+    message: Option<&str>,
+) -> BitbucketWrite {
+    let mut body = serde_json::Map::new();
+    if let Some(flag) = close_source_branch {
+        body.insert("close_source_branch".to_string(), Value::Bool(flag));
+    }
+    if let Some(text) = message.map(str::trim).filter(|text| !text.is_empty()) {
+        body.insert("message".to_string(), Value::String(text.to_string()));
+    }
+    BitbucketWrite {
+        url: format!("{}/merge", pull_request_path(base, workspace, repo, id)),
+        body: Value::Object(body),
+    }
+}
+
+fn comment_write(base: &str, workspace: &str, repo: &str, id: u64, text: &str) -> BitbucketWrite {
+    BitbucketWrite {
+        url: format!("{}/comments", pull_request_path(base, workspace, repo, id)),
+        body: serde_json::json!({ "content": { "raw": text } }),
+    }
+}
+
+fn reply_write(
+    base: &str,
+    workspace: &str,
+    repo: &str,
+    id: u64,
+    parent_id: u64,
+    text: &str,
+) -> BitbucketWrite {
+    BitbucketWrite {
+        url: format!("{}/comments", pull_request_path(base, workspace, repo, id)),
+        body: serde_json::json!({
+            "content": { "raw": text },
+            "parent": { "id": parent_id }
+        }),
+    }
+}
+
+#[tauri::command]
+pub async fn bitbucket_validate_connection(
+    workspace_slug: String,
+    email: String,
+    api_token: String,
+) -> Result<BitbucketConnection, BitbucketError> {
+    let credentials = Credentials {
+        email: &email,
+        token: &api_token,
+    };
+    let user_raw: BitbucketUserRaw = get_json(&credentials, &current_user_url(API_BASE)).await?;
+    let workspace_raw: Option<BitbucketWorkspaceRaw> =
+        get_json_optional(&credentials, &workspace_url(API_BASE, &workspace_slug)).await?;
+    let Some(workspace_raw) = workspace_raw else {
+        return Err(BitbucketError::NotFound(format!(
+            "the credentials are valid but no bitbucket workspace answers to the slug {}. the slug is the segment right after bitbucket.org in your repository url, not your display name",
+            workspace_slug.trim()
+        )));
+    };
+    Ok(BitbucketConnection {
+        user: map_user(user_raw),
+        workspace: map_workspace(workspace_raw),
+    })
+}
+
+#[tauri::command]
+pub async fn bitbucket_connect(
+    workspace_id: String,
+    api_token: String,
+    cache: State<'_, BitbucketTokenCache>,
+) -> Result<(), BitbucketError> {
+    secrets::set(&credential_key(&workspace_id), &api_token)?;
+    cache.0.lock().unwrap().insert(workspace_id, api_token);
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn bitbucket_disconnect(
+    workspace_id: String,
+    cache: State<'_, BitbucketTokenCache>,
+) -> Result<(), BitbucketError> {
+    secrets::clear(&credential_key(&workspace_id))?;
+    cache.0.lock().unwrap().remove(&workspace_id);
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn bitbucket_list_pull_requests(
+    workspace_id: String,
+    workspace_slug: String,
+    repo_slug: String,
+    email: String,
+    state: Option<String>,
+    cache: State<'_, BitbucketTokenCache>,
+) -> Result<Vec<BitbucketPullRequest>, BitbucketError> {
+    let token = read_token(&workspace_id, &cache)?;
+    let credentials = Credentials {
+        email: &email,
+        token: &token,
+    };
+    let url = pull_requests_url(API_BASE, &workspace_slug, &repo_slug, state.as_deref());
+    let raw: Vec<BitbucketPullRequestRaw> = get_json_paged(&credentials, &url).await?;
+    Ok(raw.into_iter().map(map_pull_request).collect())
+}
+
+#[tauri::command]
+pub async fn bitbucket_get_pull_request(
+    workspace_id: String,
+    workspace_slug: String,
+    repo_slug: String,
+    email: String,
+    pull_request_id: u64,
+    cache: State<'_, BitbucketTokenCache>,
+) -> Result<BitbucketPullRequest, BitbucketError> {
+    let token = read_token(&workspace_id, &cache)?;
+    let credentials = Credentials {
+        email: &email,
+        token: &token,
+    };
+    let url = pull_request_path(API_BASE, &workspace_slug, &repo_slug, pull_request_id);
+    let raw: BitbucketPullRequestRaw = get_json(&credentials, &url).await?;
+    Ok(map_pull_request(raw))
+}
+
+#[tauri::command]
+pub async fn bitbucket_pull_request_diff(
+    workspace_id: String,
+    workspace_slug: String,
+    repo_slug: String,
+    email: String,
+    pull_request_id: u64,
+    cache: State<'_, BitbucketTokenCache>,
+) -> Result<String, BitbucketError> {
+    let token = read_token(&workspace_id, &cache)?;
+    let credentials = Credentials {
+        email: &email,
+        token: &token,
+    };
+    let url = pull_request_diff_url(API_BASE, &workspace_slug, &repo_slug, pull_request_id);
+    get_text(&credentials, &url).await
+}
+
+#[tauri::command]
+pub async fn bitbucket_list_pull_request_comments(
+    workspace_id: String,
+    workspace_slug: String,
+    repo_slug: String,
+    email: String,
+    pull_request_id: u64,
+    cache: State<'_, BitbucketTokenCache>,
+) -> Result<Vec<BitbucketComment>, BitbucketError> {
+    let token = read_token(&workspace_id, &cache)?;
+    let credentials = Credentials {
+        email: &email,
+        token: &token,
+    };
+    let url = pull_request_comments_url(API_BASE, &workspace_slug, &repo_slug, pull_request_id);
+    let raw: Vec<BitbucketCommentRaw> = get_json_paged(&credentials, &url).await?;
+    Ok(raw.into_iter().map(map_comment).collect())
+}
+
+#[tauri::command]
+pub async fn bitbucket_list_pull_request_statuses(
+    workspace_id: String,
+    workspace_slug: String,
+    repo_slug: String,
+    email: String,
+    pull_request_id: u64,
+    cache: State<'_, BitbucketTokenCache>,
+) -> Result<Vec<BitbucketStatus>, BitbucketError> {
+    let token = read_token(&workspace_id, &cache)?;
+    let credentials = Credentials {
+        email: &email,
+        token: &token,
+    };
+    let url = pull_request_statuses_url(API_BASE, &workspace_slug, &repo_slug, pull_request_id);
+    let raw: Vec<BitbucketStatusRaw> = get_json_paged(&credentials, &url).await?;
+    Ok(raw.into_iter().map(map_status).collect())
+}
+
+#[tauri::command]
+pub async fn bitbucket_pull_request_for_branch(
+    workspace_id: String,
+    workspace_slug: String,
+    repo_slug: String,
+    email: String,
+    source_branch: String,
+    cache: State<'_, BitbucketTokenCache>,
+) -> Result<Option<BitbucketPullRequest>, BitbucketError> {
+    let token = read_token(&workspace_id, &cache)?;
+    let credentials = Credentials {
+        email: &email,
+        token: &token,
+    };
+    let url = pull_requests_for_branch_url(API_BASE, &workspace_slug, &repo_slug, &source_branch);
+    let raw: Vec<BitbucketPullRequestRaw> = get_json_paged(&credentials, &url).await?;
+    Ok(first_matching_branch(raw, &source_branch).map(map_pull_request))
+}
+
+#[tauri::command]
+pub async fn bitbucket_approve_pull_request(
+    workspace_id: String,
+    workspace_slug: String,
+    repo_slug: String,
+    email: String,
+    pull_request_id: u64,
+    cache: State<'_, BitbucketTokenCache>,
+) -> Result<BitbucketParticipant, BitbucketError> {
+    let token = read_token(&workspace_id, &cache)?;
+    let credentials = Credentials {
+        email: &email,
+        token: &token,
+    };
+    let write = approve_write(API_BASE, &workspace_slug, &repo_slug, pull_request_id);
+    let raw: BitbucketParticipantRaw = send_json(
+        &credentials,
+        reqwest::Method::POST,
+        &write.url,
+        Some(&write.body),
+    )
+    .await?;
+    Ok(map_participant(raw))
+}
+
+#[tauri::command]
+pub async fn bitbucket_unapprove_pull_request(
+    workspace_id: String,
+    workspace_slug: String,
+    repo_slug: String,
+    email: String,
+    pull_request_id: u64,
+    cache: State<'_, BitbucketTokenCache>,
+) -> Result<(), BitbucketError> {
+    let token = read_token(&workspace_id, &cache)?;
+    let credentials = Credentials {
+        email: &email,
+        token: &token,
+    };
+    let write = approve_write(API_BASE, &workspace_slug, &repo_slug, pull_request_id);
+    send_no_content(&credentials, reqwest::Method::DELETE, &write.url, None).await
+}
+
+#[tauri::command]
+pub async fn bitbucket_request_changes(
+    workspace_id: String,
+    workspace_slug: String,
+    repo_slug: String,
+    email: String,
+    pull_request_id: u64,
+    cache: State<'_, BitbucketTokenCache>,
+) -> Result<BitbucketParticipant, BitbucketError> {
+    let token = read_token(&workspace_id, &cache)?;
+    let credentials = Credentials {
+        email: &email,
+        token: &token,
+    };
+    let write = request_changes_write(API_BASE, &workspace_slug, &repo_slug, pull_request_id);
+    let raw: BitbucketParticipantRaw = send_json(
+        &credentials,
+        reqwest::Method::POST,
+        &write.url,
+        Some(&write.body),
+    )
+    .await?;
+    Ok(map_participant(raw))
+}
+
+#[tauri::command]
+pub async fn bitbucket_unrequest_changes(
+    workspace_id: String,
+    workspace_slug: String,
+    repo_slug: String,
+    email: String,
+    pull_request_id: u64,
+    cache: State<'_, BitbucketTokenCache>,
+) -> Result<(), BitbucketError> {
+    let token = read_token(&workspace_id, &cache)?;
+    let credentials = Credentials {
+        email: &email,
+        token: &token,
+    };
+    let write = request_changes_write(API_BASE, &workspace_slug, &repo_slug, pull_request_id);
+    send_no_content(&credentials, reqwest::Method::DELETE, &write.url, None).await
+}
+
+#[tauri::command]
+pub async fn bitbucket_merge_pull_request(
+    workspace_id: String,
+    workspace_slug: String,
+    repo_slug: String,
+    email: String,
+    pull_request_id: u64,
+    close_source_branch: Option<bool>,
+    message: Option<String>,
+    cache: State<'_, BitbucketTokenCache>,
+) -> Result<BitbucketPullRequest, BitbucketError> {
+    let token = read_token(&workspace_id, &cache)?;
+    let credentials = Credentials {
+        email: &email,
+        token: &token,
+    };
+    let write = merge_write(
+        API_BASE,
+        &workspace_slug,
+        &repo_slug,
+        pull_request_id,
+        close_source_branch,
+        message.as_deref(),
+    );
+    let raw: BitbucketPullRequestRaw = send_json(
+        &credentials,
+        reqwest::Method::POST,
+        &write.url,
+        Some(&write.body),
+    )
+    .await?;
+    Ok(map_pull_request(raw))
+}
+
+#[tauri::command]
+pub async fn bitbucket_decline_pull_request(
+    workspace_id: String,
+    workspace_slug: String,
+    repo_slug: String,
+    email: String,
+    pull_request_id: u64,
+    cache: State<'_, BitbucketTokenCache>,
+) -> Result<BitbucketPullRequest, BitbucketError> {
+    let token = read_token(&workspace_id, &cache)?;
+    let credentials = Credentials {
+        email: &email,
+        token: &token,
+    };
+    let write = decline_write(API_BASE, &workspace_slug, &repo_slug, pull_request_id);
+    let raw: BitbucketPullRequestRaw = send_json(
+        &credentials,
+        reqwest::Method::POST,
+        &write.url,
+        Some(&write.body),
+    )
+    .await?;
+    Ok(map_pull_request(raw))
+}
+
+#[tauri::command]
+pub async fn bitbucket_create_pull_request_comment(
+    workspace_id: String,
+    workspace_slug: String,
+    repo_slug: String,
+    email: String,
+    pull_request_id: u64,
+    body: String,
+    cache: State<'_, BitbucketTokenCache>,
+) -> Result<BitbucketComment, BitbucketError> {
+    let token = read_token(&workspace_id, &cache)?;
+    let credentials = Credentials {
+        email: &email,
+        token: &token,
+    };
+    let write = comment_write(
+        API_BASE,
+        &workspace_slug,
+        &repo_slug,
+        pull_request_id,
+        &body,
+    );
+    let raw: BitbucketCommentRaw = send_json(
+        &credentials,
+        reqwest::Method::POST,
+        &write.url,
+        Some(&write.body),
+    )
+    .await?;
+    Ok(map_comment(raw))
+}
+
+#[tauri::command]
+pub async fn bitbucket_reply_to_pull_request_comment(
+    workspace_id: String,
+    workspace_slug: String,
+    repo_slug: String,
+    email: String,
+    pull_request_id: u64,
+    parent_comment_id: u64,
+    body: String,
+    cache: State<'_, BitbucketTokenCache>,
+) -> Result<BitbucketComment, BitbucketError> {
+    let token = read_token(&workspace_id, &cache)?;
+    let credentials = Credentials {
+        email: &email,
+        token: &token,
+    };
+    let write = reply_write(
+        API_BASE,
+        &workspace_slug,
+        &repo_slug,
+        pull_request_id,
+        parent_comment_id,
+        &body,
+    );
+    let raw: BitbucketCommentRaw = send_json(
+        &credentials,
+        reqwest::Method::POST,
+        &write.url,
+        Some(&write.body),
+    )
+    .await?;
+    Ok(map_comment(raw))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const BASE: &str = "https://api.bitbucket.org/2.0";
+
+    fn pr_page(next: Option<&str>, ids: &[u64]) -> BitbucketPage<BitbucketPullRequestRaw> {
+        let values: Vec<Value> = ids
+            .iter()
+            .map(|id| serde_json::json!({ "id": id }))
+            .collect();
+        let mut envelope = serde_json::json!({
+            "values": values,
+            "page": 1,
+            "pagelen": 50,
+            "size": 120
+        });
+        if let Some(url) = next {
+            envelope["next"] = Value::String(url.to_string());
+        }
+        serde_json::from_value(envelope).unwrap()
+    }
+
+    #[test]
+    fn credential_key_is_namespaced_per_workspace() {
+        assert_eq!(credential_key("ws-1"), "goodboy.workspace.ws-1.bitbucket");
+    }
+
+    #[test]
+    fn error_kind_maps_each_variant() {
+        assert_eq!(
+            BitbucketError::Http {
+                status: 500,
+                body: "x".into()
+            }
+            .kind(),
+            "http"
+        );
+        assert_eq!(BitbucketError::Auth("x".into()).kind(), "auth");
+        assert_eq!(BitbucketError::NotFound("x".into()).kind(), "not_found");
+        assert_eq!(BitbucketError::InvalidShape("x".into()).kind(), "shape");
+        assert_eq!(BitbucketError::NoToken("ws".into()).kind(), "no_token");
+    }
+
+    #[test]
+    fn error_for_status_names_both_credential_schemes_on_a_401() {
+        let err = error_for_status(
+            401,
+            r#"{"type":"error","error":{"message":"Access token expired."}}"#.into(),
+        );
+        let BitbucketError::Auth(detail) = err else {
+            panic!("expected an auth error");
+        };
+        assert!(detail.contains("api token"));
+        assert!(detail.contains("app password"));
+        assert!(detail.contains("Access token expired."));
+    }
+
+    #[test]
+    fn error_for_status_maps_403_to_auth_and_404_to_not_found() {
+        assert!(matches!(
+            error_for_status(403, "{}".into()),
+            BitbucketError::Auth(_)
+        ));
+        let err = error_for_status(
+            404,
+            r#"{"type":"error","error":{"message":"Repository not found"}}"#.into(),
+        );
+        assert!(matches!(err, BitbucketError::NotFound(ref m) if m == "Repository not found"));
+    }
+
+    #[test]
+    fn error_for_status_keeps_a_400_as_http_with_the_raw_body() {
+        let err = error_for_status(400, r#"{"error":{"message":"bad"}}"#.into());
+        assert!(matches!(err, BitbucketError::Http { status: 400, .. }));
+    }
+
+    #[test]
+    fn error_message_joins_the_message_and_the_detail() {
+        let body =
+            r#"{"type":"error","error":{"message":"Merge failed","detail":"branch is behind"}}"#;
+        assert_eq!(
+            error_message(body),
+            Some("Merge failed: branch is behind".to_string())
+        );
+    }
+
+    #[test]
+    fn error_message_is_none_for_a_non_json_body() {
+        assert!(error_message("<html>bad gateway</html>").is_none());
+    }
+
+    #[test]
+    fn repo_path_percent_encodes_both_slugs() {
+        assert_eq!(
+            repo_path(BASE, "goodboy", "desktop-app"),
+            "https://api.bitbucket.org/2.0/repositories/goodboy/desktop-app"
+        );
+        assert!(repo_path(BASE, "my team", "a/b").ends_with("/repositories/my%20team/a%2Fb"));
+    }
+
+    #[test]
+    fn workspace_and_user_urls_target_the_two_validation_probes() {
+        assert_eq!(
+            workspace_url(BASE, "goodboy"),
+            "https://api.bitbucket.org/2.0/workspaces/goodboy"
+        );
+        assert_eq!(current_user_url(BASE), "https://api.bitbucket.org/2.0/user");
+    }
+
+    #[test]
+    fn pull_request_path_appends_the_numeric_id() {
+        assert_eq!(
+            pull_request_path(BASE, "goodboy", "desktop", 42),
+            "https://api.bitbucket.org/2.0/repositories/goodboy/desktop/pullrequests/42"
+        );
+    }
+
+    #[test]
+    fn pull_requests_url_defaults_to_open_and_honours_an_explicit_state() {
+        assert_eq!(
+            pull_requests_url(BASE, "goodboy", "desktop", None),
+            "https://api.bitbucket.org/2.0/repositories/goodboy/desktop/pullrequests?state=OPEN&pagelen=50"
+        );
+        assert!(
+            pull_requests_url(BASE, "goodboy", "desktop", Some("merged"))
+                .contains("?state=MERGED&")
+        );
+        assert!(pull_requests_url(BASE, "goodboy", "desktop", Some("  ")).contains("?state=OPEN&"));
+    }
+
+    #[test]
+    fn pull_requests_for_branch_url_quotes_and_encodes_the_branch_query() {
+        let url = pull_requests_for_branch_url(BASE, "goodboy", "desktop", " ak/feat-x ");
+        assert!(url.starts_with(
+            "https://api.bitbucket.org/2.0/repositories/goodboy/desktop/pullrequests?state=OPEN&pagelen=50&q="
+        ));
+        assert!(url.ends_with("q=source.branch.name%3D%22ak%2Ffeat-x%22"));
+    }
+
+    #[test]
+    fn diff_comments_and_statuses_urls_hang_off_the_pull_request() {
+        assert_eq!(
+            pull_request_diff_url(BASE, "goodboy", "desktop", 7),
+            "https://api.bitbucket.org/2.0/repositories/goodboy/desktop/pullrequests/7/diff"
+        );
+        assert!(pull_request_comments_url(BASE, "goodboy", "desktop", 7)
+            .starts_with("https://api.bitbucket.org/2.0/repositories/goodboy/desktop/pullrequests/7/comments?"));
+        assert!(pull_request_statuses_url(BASE, "goodboy", "desktop", 7)
+            .starts_with("https://api.bitbucket.org/2.0/repositories/goodboy/desktop/pullrequests/7/statuses?"));
+    }
+
+    #[test]
+    fn approve_write_posts_to_the_approve_sub_resource_with_an_empty_body() {
+        let write = approve_write(BASE, "goodboy", "desktop", 12);
+        assert_eq!(
+            write.url,
+            "https://api.bitbucket.org/2.0/repositories/goodboy/desktop/pullrequests/12/approve"
+        );
+        assert_eq!(write.body, serde_json::json!({}));
+    }
+
+    #[test]
+    fn request_changes_write_uses_the_hyphenated_sub_resource() {
+        let write = request_changes_write(BASE, "goodboy", "desktop", 12);
+        assert_eq!(
+            write.url,
+            "https://api.bitbucket.org/2.0/repositories/goodboy/desktop/pullrequests/12/request-changes"
+        );
+        assert_eq!(write.body, serde_json::json!({}));
+    }
+
+    #[test]
+    fn decline_write_targets_the_decline_sub_resource() {
+        let write = decline_write(BASE, "goodboy", "desktop", 3);
+        assert_eq!(
+            write.url,
+            "https://api.bitbucket.org/2.0/repositories/goodboy/desktop/pullrequests/3/decline"
+        );
+    }
+
+    #[test]
+    fn merge_write_never_pins_a_merge_strategy() {
+        let bare = merge_write(BASE, "goodboy", "desktop", 5, None, None);
+        assert_eq!(
+            bare.url,
+            "https://api.bitbucket.org/2.0/repositories/goodboy/desktop/pullrequests/5/merge"
+        );
+        assert_eq!(bare.body, serde_json::json!({}));
+        let full = merge_write(BASE, "goodboy", "desktop", 5, Some(true), Some("ship it"));
+        assert!(full.body.get("merge_strategy").is_none());
+    }
+
+    #[test]
+    fn merge_write_carries_only_the_options_it_was_given() {
+        let with_flag = merge_write(BASE, "goodboy", "desktop", 5, Some(false), None);
+        assert_eq!(with_flag.body["close_source_branch"], Value::Bool(false));
+        assert!(with_flag.body.get("message").is_none());
+        let with_message = merge_write(BASE, "goodboy", "desktop", 5, None, Some(" ship it "));
+        assert_eq!(with_message.body["message"], "ship it");
+        assert!(with_message.body.get("close_source_branch").is_none());
+        let blank_message = merge_write(BASE, "goodboy", "desktop", 5, None, Some("   "));
+        assert!(blank_message.body.get("message").is_none());
+    }
+
+    #[test]
+    fn comment_write_nests_the_text_under_content_raw() {
+        let write = comment_write(BASE, "goodboy", "desktop", 9, "looks good");
+        assert_eq!(
+            write.url,
+            "https://api.bitbucket.org/2.0/repositories/goodboy/desktop/pullrequests/9/comments"
+        );
+        assert_eq!(write.body["content"]["raw"], "looks good");
+        assert!(write.body.get("parent").is_none());
+        assert!(write.body.get("body").is_none());
+    }
+
+    #[test]
+    fn reply_write_adds_the_parent_id_beside_the_content() {
+        let write = reply_write(BASE, "goodboy", "desktop", 9, 4242, "agreed");
+        assert_eq!(
+            write.url,
+            "https://api.bitbucket.org/2.0/repositories/goodboy/desktop/pullrequests/9/comments"
+        );
+        assert_eq!(write.body["content"]["raw"], "agreed");
+        assert_eq!(write.body["parent"]["id"], 4242);
+    }
+
+    #[test]
+    fn user_parses_and_falls_back_to_the_display_name_for_the_nickname() {
+        let raw: BitbucketUserRaw = serde_json::from_str(
+            r#"{ "uuid": "{abc}", "account_id": "acc-1", "display_name": "Amin K",
+                 "links": { "avatar": { "href": "https://avatar/x.png" } } }"#,
+        )
+        .unwrap();
+        let user = map_user(raw);
+        assert_eq!(user.uuid, "{abc}");
+        assert_eq!(user.account_id.as_deref(), Some("acc-1"));
+        assert_eq!(user.nickname, "Amin K");
+        assert_eq!(user.avatar_url.as_deref(), Some("https://avatar/x.png"));
+    }
+
+    #[test]
+    fn workspace_parses_and_falls_back_to_the_slug_for_the_name() {
+        let raw: BitbucketWorkspaceRaw =
+            serde_json::from_str(r#"{ "uuid": "{ws}", "slug": "goodboy" }"#).unwrap();
+        let workspace = map_workspace(raw);
+        assert_eq!(workspace.slug, "goodboy");
+        assert_eq!(workspace.name, "goodboy");
+        assert!(workspace.web_url.is_none());
+    }
+
+    #[test]
+    fn pull_request_parses_the_full_documented_shape() {
+        let raw: BitbucketPullRequestRaw = serde_json::from_str(
+            r#"{
+                "id": 42,
+                "title": "Ship bitbucket",
+                "description": "the backend",
+                "state": "OPEN",
+                "created_on": "2026-08-01T09:00:00+00:00",
+                "updated_on": "2026-08-02T09:00:00+00:00",
+                "close_source_branch": true,
+                "comment_count": 3,
+                "task_count": 1,
+                "source": { "branch": { "name": "ak/feat-bb" }, "commit": { "hash": "aaa111" } },
+                "destination": { "branch": { "name": "main" }, "commit": { "hash": "bbb222" } },
+                "author": { "uuid": "{u1}", "display_name": "Amin", "nickname": "amin" },
+                "reviewers": [{ "uuid": "{u2}", "display_name": "Rev" }],
+                "participants": [
+                  { "role": "REVIEWER", "approved": true, "state": "approved",
+                    "user": { "uuid": "{u2}", "display_name": "Rev" } }
+                ],
+                "links": { "html": { "href": "https://bitbucket.org/goodboy/desktop/pull-requests/42" } }
+            }"#,
+        )
+        .unwrap();
+        let pr = map_pull_request(raw);
+        assert_eq!(pr.id, 42);
+        assert_eq!(pr.source_branch, "ak/feat-bb");
+        assert_eq!(pr.destination_branch, "main");
+        assert_eq!(pr.source_commit.as_deref(), Some("aaa111"));
+        assert_eq!(pr.comment_count, 3);
+        assert!(pr.close_source_branch);
+        assert_eq!(pr.participants.len(), 1);
+        assert!(pr.participants[0].approved);
+        assert_eq!(
+            pr.web_url.as_deref(),
+            Some("https://bitbucket.org/goodboy/desktop/pull-requests/42")
+        );
+    }
+
+    #[test]
+    fn pull_request_parses_when_every_optional_branch_is_absent() {
+        let raw: BitbucketPullRequestRaw = serde_json::from_str(r#"{ "id": 1 }"#).unwrap();
+        let pr = map_pull_request(raw);
+        assert_eq!(pr.id, 1);
+        assert_eq!(pr.source_branch, "");
+        assert!(pr.author.is_none());
+        assert!(pr.merge_commit.is_none());
+        assert!(pr.web_url.is_none());
+        assert!(pr.reviewers.is_empty());
+    }
+
+    #[test]
+    fn a_merged_pull_request_carries_its_merge_commit_hash() {
+        let raw: BitbucketPullRequestRaw = serde_json::from_str(
+            r#"{ "id": 8, "state": "MERGED", "merge_commit": { "hash": "ccc333" } }"#,
+        )
+        .unwrap();
+        let pr = map_pull_request(raw);
+        assert_eq!(pr.state, "MERGED");
+        assert_eq!(pr.merge_commit.as_deref(), Some("ccc333"));
+    }
+
+    #[test]
+    fn comment_parses_an_inline_reply() {
+        let raw: BitbucketCommentRaw = serde_json::from_str(
+            r#"{
+                "id": 91,
+                "content": { "raw": "rename this", "markup": "markdown", "html": "<p>rename this</p>" },
+                "user": { "uuid": "{u1}", "display_name": "Amin" },
+                "created_on": "2026-08-01T09:00:00+00:00",
+                "updated_on": "2026-08-01T09:30:00+00:00",
+                "deleted": false,
+                "parent": { "id": 90 },
+                "inline": { "path": "src/lib.rs", "from": null, "to": 12 },
+                "links": { "html": { "href": "https://bitbucket.org/c/91" } }
+            }"#,
+        )
+        .unwrap();
+        let comment = map_comment(raw);
+        assert_eq!(comment.body, "rename this");
+        assert_eq!(comment.parent_id, Some(90));
+        let inline = comment.inline.unwrap();
+        assert_eq!(inline.path, "src/lib.rs");
+        assert_eq!(inline.to, Some(12));
+        assert!(inline.from.is_none());
+    }
+
+    #[test]
+    fn comment_parses_a_top_level_note_without_inline_or_parent() {
+        let raw: BitbucketCommentRaw =
+            serde_json::from_str(r#"{ "id": 5, "content": { "raw": "lgtm" } }"#).unwrap();
+        let comment = map_comment(raw);
+        assert_eq!(comment.id, 5);
+        assert_eq!(comment.body, "lgtm");
+        assert!(comment.parent_id.is_none());
+        assert!(comment.inline.is_none());
+        assert!(!comment.deleted);
+    }
+
+    #[test]
+    fn statuses_parse_and_fall_back_to_the_key_for_the_name() {
+        let raw: BitbucketPage<BitbucketStatusRaw> = serde_json::from_str(
+            r#"{ "values": [
+                  { "key": "PIPELINE", "name": "Pipeline #12", "state": "SUCCESSFUL",
+                    "url": "https://bitbucket.org/p/12", "refname": "ak/feat-bb",
+                    "created_on": "2026-08-01T09:00:00+00:00", "updated_on": "2026-08-01T09:10:00+00:00" },
+                  { "key": "codecov", "state": "FAILED" }
+                ], "page": 1, "pagelen": 50, "size": 2 }"#,
+        )
+        .unwrap();
+        let statuses: Vec<BitbucketStatus> = raw.values.into_iter().map(map_status).collect();
+        assert_eq!(statuses.len(), 2);
+        assert_eq!(statuses[0].name, "Pipeline #12");
+        assert_eq!(statuses[0].state, "SUCCESSFUL");
+        assert_eq!(statuses[1].name, "codecov");
+        assert!(statuses[1].url.is_none());
+    }
+
+    #[test]
+    fn participant_parses_the_changes_requested_state() {
+        let raw: BitbucketParticipantRaw = serde_json::from_str(
+            r#"{ "role": "REVIEWER", "approved": false, "state": "changes_requested",
+                 "user": { "uuid": "{u3}", "display_name": "Rev" } }"#,
+        )
+        .unwrap();
+        let participant = map_participant(raw);
+        assert_eq!(participant.role, "REVIEWER");
+        assert!(!participant.approved);
+        assert_eq!(participant.state.as_deref(), Some("changes_requested"));
+    }
+
+    #[test]
+    fn the_page_envelope_ignores_the_counters_it_does_not_model() {
+        let page = pr_page(Some("https://api.bitbucket.org/2.0/x?page=2"), &[1, 2]);
+        assert_eq!(page.values.len(), 2);
+        assert_eq!(
+            page.next.as_deref(),
+            Some("https://api.bitbucket.org/2.0/x?page=2")
+        );
+    }
+
+    #[test]
+    fn the_page_envelope_tolerates_a_missing_values_array() {
+        let page: BitbucketPage<BitbucketPullRequestRaw> =
+            serde_json::from_str(r#"{ "page": 1, "pagelen": 50, "size": 0 }"#).unwrap();
+        assert!(page.values.is_empty());
+        assert!(page.next.is_none());
+    }
+
+    #[test]
+    fn the_pager_follows_the_absolute_next_url_and_stops_when_it_is_gone() {
+        let mut pager = Pager::new();
+        let mut sink: Vec<BitbucketPullRequestRaw> = Vec::new();
+        let next = pager
+            .absorb(
+                pr_page(Some("https://api.bitbucket.org/2.0/x?page=2"), &[1]),
+                &mut sink,
+            )
+            .unwrap();
+        assert_eq!(
+            next.as_deref(),
+            Some("https://api.bitbucket.org/2.0/x?page=2")
+        );
+        let done = pager.absorb(pr_page(None, &[2, 3]), &mut sink).unwrap();
+        assert!(done.is_none());
+        assert_eq!(sink.len(), 3);
+    }
+
+    #[test]
+    fn the_pager_bails_when_the_next_url_repeats() {
+        let mut pager = Pager::new();
+        let mut sink: Vec<BitbucketPullRequestRaw> = Vec::new();
+        let looping = "https://api.bitbucket.org/2.0/x?page=2";
+        pager
+            .absorb(pr_page(Some(looping), &[1]), &mut sink)
+            .unwrap();
+        let err = pager
+            .absorb(pr_page(Some(looping), &[1]), &mut sink)
+            .unwrap_err();
+        assert!(matches!(err, BitbucketError::InvalidShape(ref m) if m.contains("looped")));
+    }
+
+    #[test]
+    fn the_pager_stops_at_the_page_cap_even_while_next_keeps_coming() {
+        let mut pager = Pager::new();
+        let mut sink: Vec<BitbucketPullRequestRaw> = Vec::new();
+        for page in 0..MAX_PAGES {
+            let next = format!("https://api.bitbucket.org/2.0/x?page={}", page + 2);
+            let outcome = pager
+                .absorb(pr_page(Some(&next), &[page as u64]), &mut sink)
+                .unwrap();
+            if page + 1 == MAX_PAGES {
+                assert!(outcome.is_none());
+            }
+        }
+        assert_eq!(sink.len() as u32, MAX_PAGES);
+    }
+
+    #[test]
+    fn the_pager_treats_a_blank_next_url_as_the_end() {
+        let mut pager = Pager::new();
+        let mut sink: Vec<BitbucketPullRequestRaw> = Vec::new();
+        let next = pager.absorb(pr_page(Some("   "), &[1]), &mut sink).unwrap();
+        assert!(next.is_none());
+    }
+
+    #[test]
+    fn the_branch_lookup_rejects_a_server_side_query_that_returned_the_wrong_branch() {
+        let values: Vec<BitbucketPullRequestRaw> = serde_json::from_str(
+            r#"[
+                { "id": 1, "source": { "branch": { "name": "ak/other" } } },
+                { "id": 2, "source": { "branch": { "name": "ak/feat-bb" } } }
+            ]"#,
+        )
+        .unwrap();
+        let found = first_matching_branch(values, " ak/feat-bb ").unwrap();
+        assert_eq!(found.id, 2);
+    }
+
+    #[test]
+    fn the_branch_lookup_is_none_when_no_open_pull_request_matches() {
+        let values: Vec<BitbucketPullRequestRaw> =
+            serde_json::from_str(r#"[{ "id": 1, "source": { "branch": { "name": "main" } } }]"#)
+                .unwrap();
+        assert!(first_matching_branch(values, "ak/feat-bb").is_none());
+    }
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 mod attachment;
 mod aux_spawn;
+mod bitbucket;
 mod bridge;
 mod budget;
 mod config_export;
@@ -74,6 +75,7 @@ pub fn run() {
     let sentry_token_cache = sentry::SentryTokenCache::new();
     let gitlab_token_cache = gitlab::GitlabTokenCache::new();
     let jira_token_cache = jira::JiraTokenCache::new();
+    let bitbucket_token_cache = bitbucket::BitbucketTokenCache::new();
 
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
@@ -94,6 +96,7 @@ pub fn run() {
         .manage(sentry_token_cache)
         .manage(gitlab_token_cache)
         .manage(jira_token_cache)
+        .manage(bitbucket_token_cache)
         .setup(|app| {
             #[cfg(desktop)]
             app.handle()
@@ -309,6 +312,23 @@ pub fn run() {
             jira::jira_list_assignable_users,
             jira::jira_list_transitions,
             jira::jira_transition_issue,
+            bitbucket::bitbucket_validate_connection,
+            bitbucket::bitbucket_connect,
+            bitbucket::bitbucket_disconnect,
+            bitbucket::bitbucket_list_pull_requests,
+            bitbucket::bitbucket_get_pull_request,
+            bitbucket::bitbucket_pull_request_diff,
+            bitbucket::bitbucket_list_pull_request_comments,
+            bitbucket::bitbucket_list_pull_request_statuses,
+            bitbucket::bitbucket_pull_request_for_branch,
+            bitbucket::bitbucket_approve_pull_request,
+            bitbucket::bitbucket_unapprove_pull_request,
+            bitbucket::bitbucket_request_changes,
+            bitbucket::bitbucket_unrequest_changes,
+            bitbucket::bitbucket_merge_pull_request,
+            bitbucket::bitbucket_decline_pull_request,
+            bitbucket::bitbucket_create_pull_request_comment,
+            bitbucket::bitbucket_reply_to_pull_request_comment,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/apps/desktop/src/features/integrations/ConnectIntegrationEmptyState.tsx
+++ b/apps/desktop/src/features/integrations/ConnectIntegrationEmptyState.tsx
@@ -1,13 +1,14 @@
 import type { ReactNode } from 'react';
 import type { WorkspaceId } from '@goodboy/types';
 import { IntegrationConnectPanel } from './components/IntegrationConnectPanel';
+import { BitbucketFormBody } from './bitbucket/BitbucketFormBody';
 import { GitlabFormBody } from './gitlab/GitlabFormBody';
 import { JiraFormBody } from './jira/JiraFormBody';
 import { LinearFormBody } from './linear/LinearFormBody';
 import { SentryFormBody } from './sentry/SentryFormBody';
 
 type Props = {
-  readonly provider: 'linear' | 'sentry' | 'gitlab' | 'jira';
+  readonly provider: 'linear' | 'sentry' | 'gitlab' | 'jira' | 'bitbucket';
   readonly workspaceId: WorkspaceId;
   readonly compact?: boolean;
   readonly shouldAutoFocus?: boolean;
@@ -19,6 +20,7 @@ const PROVIDER_DESCRIPTIONS: Record<Props['provider'], string> = {
   sentry: 'Connect Sentry to review errors from this workspace',
   gitlab: 'Connect GitLab to review merge requests from this workspace',
   jira: 'Connect Jira to review issues from this workspace',
+  bitbucket: 'Connect Bitbucket to review pull requests from this workspace',
 };
 
 const renderWrapped = ({
@@ -75,6 +77,23 @@ export const ConnectIntegrationEmptyState = ({
           headingLevel={compact ? undefined : 2}
         >
           <SentryFormBody workspaceId={workspaceId} shouldAutoFocus={shouldAutoFocus} />
+        </IntegrationConnectPanel>
+      ),
+    });
+  }
+
+  if (provider === 'bitbucket') {
+    return renderWrapped({
+      compact,
+      wrapped,
+      panel: (
+        <IntegrationConnectPanel
+          provider={provider}
+          description={PROVIDER_DESCRIPTIONS[provider]}
+          size={compact ? 'sm' : 'lg'}
+          headingLevel={compact ? undefined : 2}
+        >
+          <BitbucketFormBody workspaceId={workspaceId} shouldAutoFocus={shouldAutoFocus} />
         </IntegrationConnectPanel>
       ),
     });

--- a/apps/desktop/src/features/integrations/bitbucket/BitbucketFormBody.test.tsx
+++ b/apps/desktop/src/features/integrations/bitbucket/BitbucketFormBody.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { BitbucketWorkspaceIntegration, WorkspaceId } from '@goodboy/types';
+
+const { state } = vi.hoisted(() => ({
+  state: {
+    workspaceIntegrations: {} as Record<string, ReadonlyArray<unknown>>,
+    connectBitbucket: vi.fn(async () => undefined),
+    disconnectBitbucket: vi.fn(async () => undefined),
+  },
+}));
+
+vi.mock('../../../store', () => ({
+  useAppStore: <T,>(selector: (s: typeof state) => T) => selector(state),
+}));
+
+const WS_ID = 'ws-1' as WorkspaceId;
+
+const bitbucketIntegration: BitbucketWorkspaceIntegration = {
+  id: 'wi-1' as never,
+  workspaceId: WS_ID,
+  provider: 'bitbucket',
+  credentialKey: 'cred-1',
+  config: {
+    workspaceSlug: 'goodboy',
+    email: 'grace@acme.com',
+    displayName: 'Grace Hopper',
+  },
+  createdAt: '2026-01-01T00:00:00.000Z' as never,
+  updatedAt: '2026-01-01T00:00:00.000Z' as never,
+};
+
+const fillConnectForm = () => {
+  fireEvent.change(screen.getByLabelText(/workspace slug/i), {
+    target: { value: 'https://bitbucket.org/GoodBoy/desktop' },
+  });
+  fireEvent.change(screen.getByLabelText(/account email/i), {
+    target: { value: ' grace@acme.com ' },
+  });
+  fireEvent.change(screen.getByLabelText(/api token/i), { target: { value: ' ATATT-x ' } });
+};
+
+beforeEach(() => {
+  state.workspaceIntegrations = {};
+  state.connectBitbucket = vi.fn(async () => undefined);
+  state.disconnectBitbucket = vi.fn(async () => undefined);
+});
+afterEach(cleanup);
+
+import { BitbucketFormBody } from './BitbucketFormBody';
+
+describe('BitbucketFormBody', () => {
+  it('keeps Connect disabled until every field is filled', () => {
+    render(<BitbucketFormBody workspaceId={WS_ID} />);
+    const connect = screen.getByRole('button', { name: /^connect$/i }) as HTMLButtonElement;
+    expect(connect.disabled).toBe(true);
+    fillConnectForm();
+    expect(connect.disabled).toBe(false);
+  });
+
+  it('reduces a pasted repository url to the workspace slug and trims the rest', async () => {
+    const onConnected = vi.fn();
+    render(<BitbucketFormBody workspaceId={WS_ID} onConnected={onConnected} />);
+    fillConnectForm();
+    fireEvent.click(screen.getByRole('button', { name: /^connect$/i }));
+    await waitFor(() =>
+      expect(state.connectBitbucket).toHaveBeenCalledWith({
+        workspaceId: WS_ID,
+        workspaceSlug: 'goodboy',
+        email: 'grace@acme.com',
+        apiToken: 'ATATT-x',
+      }),
+    );
+    await waitFor(() => expect(onConnected).toHaveBeenCalledOnce());
+  });
+
+  it('shows the failure and skips onConnected when the connect is rejected', async () => {
+    const onConnected = vi.fn();
+    state.connectBitbucket = vi.fn(async () => {
+      throw new Error('Bitbucket rejected the credentials');
+    });
+    render(<BitbucketFormBody workspaceId={WS_ID} onConnected={onConnected} />);
+    fillConnectForm();
+    fireEvent.click(screen.getByRole('button', { name: /^connect$/i }));
+    expect(await screen.findByText(/Bitbucket rejected the credentials/i)).toBeDefined();
+    expect(onConnected).not.toHaveBeenCalled();
+  });
+
+  describe('when Bitbucket is already connected', () => {
+    beforeEach(() => {
+      state.workspaceIntegrations = { [WS_ID]: [bitbucketIntegration] };
+    });
+
+    it('shows the workspace and account instead of the form', () => {
+      render(<BitbucketFormBody workspaceId={WS_ID} />);
+      expect(screen.getByText(/Connected as Grace Hopper/i)).toBeDefined();
+      expect(screen.getByText('goodboy')).toBeDefined();
+      expect(screen.getByText('grace@acme.com')).toBeDefined();
+      expect(screen.queryByRole('button', { name: /^connect$/i })).toBeNull();
+    });
+
+    it('disconnects Bitbucket for the workspace', () => {
+      render(<BitbucketFormBody workspaceId={WS_ID} />);
+      fireEvent.click(screen.getByRole('button', { name: /^disconnect$/i }));
+      expect(state.disconnectBitbucket).toHaveBeenCalledWith({ workspaceId: WS_ID });
+    });
+  });
+});

--- a/apps/desktop/src/features/integrations/bitbucket/BitbucketFormBody.tsx
+++ b/apps/desktop/src/features/integrations/bitbucket/BitbucketFormBody.tsx
@@ -1,0 +1,179 @@
+import { useState } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+import type { BitbucketWorkspaceIntegration, WorkspaceId } from '@goodboy/types';
+import { Button, Input } from '@goodboy/ui';
+import { CheckCircle2, ExternalLink, Unplug } from 'lucide-react';
+import { useAppStore } from '../../../store';
+import { formatError } from '../../../shared/lib/errors';
+import { normalizeWorkspaceSlug } from './normalizeWorkspaceSlug';
+
+type Props = {
+  readonly workspaceId: WorkspaceId;
+  readonly onConnected?: () => void;
+  readonly shouldAutoFocus?: boolean;
+};
+
+const TOKEN_URL = 'https://id.atlassian.com/manage-profile/security/api-tokens';
+
+export const BitbucketFormBody = ({ workspaceId, onConnected, shouldAutoFocus = false }: Props) => {
+  const integrations = useAppStore(
+    useShallow((state) => state.workspaceIntegrations[workspaceId] ?? []),
+  );
+  const bitbucket =
+    integrations.find(
+      (integration): integration is BitbucketWorkspaceIntegration =>
+        integration.provider === 'bitbucket',
+    ) ?? null;
+  const connectBitbucket = useAppStore((state) => state.connectBitbucket);
+  const disconnectBitbucket = useAppStore((state) => state.disconnectBitbucket);
+
+  const [workspaceSlug, setWorkspaceSlug] = useState('');
+  const [email, setEmail] = useState('');
+  const [apiToken, setApiToken] = useState('');
+  const [isBusy, setIsBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const normalizedSlug = normalizeWorkspaceSlug({ input: workspaceSlug });
+  const trimmedEmail = email.trim();
+  const trimmedToken = apiToken.trim();
+  const canConnect = normalizedSlug !== '' && trimmedEmail !== '' && trimmedToken !== '';
+
+  const onConnect = async () => {
+    setIsBusy(true);
+    setError(null);
+    try {
+      await connectBitbucket({
+        workspaceId,
+        workspaceSlug: normalizedSlug,
+        email: trimmedEmail,
+        apiToken: trimmedToken,
+      });
+      setApiToken('');
+      onConnected?.();
+    } catch (connectError) {
+      setError(formatError(connectError));
+    } finally {
+      setIsBusy(false);
+    }
+  };
+
+  const onDisconnect = async () => {
+    setIsBusy(true);
+    setError(null);
+    try {
+      await disconnectBitbucket({ workspaceId });
+    } catch (disconnectError) {
+      setError(formatError(disconnectError));
+    } finally {
+      setIsBusy(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-5">
+      {bitbucket != null ? (
+        <div className="flex flex-col gap-3 rounded-lg border border-border-soft bg-subtle/40 p-4">
+          <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
+            <CheckCircle2 size={14} aria-hidden className="text-success" />
+            Connected as {bitbucket.config.displayName ?? bitbucket.config.email}
+          </div>
+          <dl className="grid grid-cols-[8rem_1fr] gap-y-1 text-xs">
+            <dt className="text-muted-foreground">workspace</dt>
+            <dd className="font-mono text-foreground">{bitbucket.config.workspaceSlug}</dd>
+            <dt className="text-muted-foreground">account</dt>
+            <dd className="font-mono text-foreground">{bitbucket.config.email}</dd>
+          </dl>
+          <Button variant="danger" size="sm" onClick={() => void onDisconnect()} disabled={isBusy}>
+            <Unplug size={12} aria-hidden />
+            {isBusy ? 'Disconnecting…' : 'Disconnect'}
+          </Button>
+        </div>
+      ) : (
+        <>
+          <div className="flex flex-col gap-2">
+            <label htmlFor="bitbucket-workspace" className="text-xs font-semibold text-foreground">
+              Workspace slug
+            </label>
+            <Input
+              id="bitbucket-workspace"
+              type="text"
+              autoFocus={shouldAutoFocus}
+              placeholder="your-team"
+              value={workspaceSlug}
+              onChange={(event) => setWorkspaceSlug(event.target.value)}
+              disabled={isBusy}
+              autoCapitalize="off"
+              autoCorrect="off"
+              spellCheck={false}
+            />
+            <p className="text-2xs leading-relaxed text-muted-foreground">
+              The segment right after bitbucket.org in your repository url, not the display name.
+              Pasting a full repository url works too.
+            </p>
+          </div>
+          <div className="flex flex-col gap-2">
+            <label htmlFor="bitbucket-email" className="text-xs font-semibold text-foreground">
+              Account email
+            </label>
+            <Input
+              id="bitbucket-email"
+              type="email"
+              placeholder="you@your-team.com"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              disabled={isBusy}
+              autoCapitalize="off"
+              autoCorrect="off"
+              spellCheck={false}
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <label htmlFor="bitbucket-token" className="text-xs font-semibold text-foreground">
+              API token
+            </label>
+            <Input
+              id="bitbucket-token"
+              type="password"
+              placeholder="ATATT…"
+              value={apiToken}
+              onChange={(event) => setApiToken(event.target.value)}
+              disabled={isBusy}
+            />
+            <a
+              href={TOKEN_URL}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-1 text-2xs text-muted-foreground hover:text-foreground"
+            >
+              Create a token in your Atlassian account <ExternalLink size={10} aria-hidden />
+            </a>
+          </div>
+          <p className="text-2xs leading-relaxed text-muted-foreground">
+            Bitbucket Cloud only, Data Center and Server are not supported. An older Bitbucket app
+            password works in the same field while Atlassian keeps it alive. The secret carries your
+            own Bitbucket permissions and is stored encrypted in your operating system keychain,
+            never leaving this machine.
+          </p>
+        </>
+      )}
+
+      {error != null ? (
+        <div className="rounded-md border border-danger/30 bg-danger/5 px-3 py-2 text-xs text-danger">
+          {error}
+        </div>
+      ) : null}
+
+      {bitbucket == null ? (
+        <div className="flex justify-end">
+          <Button
+            onClick={() => void onConnect()}
+            disabled={isBusy || !canConnect}
+            className={isBusy ? 'animate-border-pulse' : undefined}
+          >
+            {isBusy ? 'Verifying…' : 'Connect'}
+          </Button>
+        </div>
+      ) : null}
+    </div>
+  );
+};

--- a/apps/desktop/src/features/integrations/bitbucket/client.test.ts
+++ b/apps/desktop/src/features/integrations/bitbucket/client.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { invoke } from '@tauri-apps/api/core';
+import type { WorkspaceId } from '@goodboy/types';
+import {
+  bitbucketApprovePullRequest,
+  bitbucketConnect,
+  bitbucketCreatePullRequestComment,
+  bitbucketDeclinePullRequest,
+  bitbucketDisconnect,
+  bitbucketGetPullRequest,
+  bitbucketListPullRequestComments,
+  bitbucketListPullRequestStatuses,
+  bitbucketListPullRequests,
+  bitbucketMergePullRequest,
+  bitbucketPullRequestDiff,
+  bitbucketPullRequestForBranch,
+  bitbucketReplyToPullRequestComment,
+  bitbucketRequestChanges,
+  bitbucketUnapprovePullRequest,
+  bitbucketUnrequestChanges,
+  bitbucketValidateConnection,
+} from './client';
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
+
+const mockInvoke = vi.mocked(invoke);
+
+afterEach(() => {
+  mockInvoke.mockReset();
+});
+
+const repo = {
+  workspaceId: 'w1' as WorkspaceId,
+  workspaceSlug: 'goodboy',
+  repoSlug: 'desktop',
+  email: 'amin@acme.io',
+};
+
+const target = { ...repo, pullRequestId: 42 };
+
+describe('bitbucket client', () => {
+  it('validates a connection without the goodboy workspace id', async () => {
+    mockInvoke.mockResolvedValue({ user: {}, workspace: {} });
+
+    await bitbucketValidateConnection({
+      workspaceSlug: 'goodboy',
+      email: 'amin@acme.io',
+      apiToken: 'tok',
+    });
+
+    expect(mockInvoke).toHaveBeenCalledWith('bitbucket_validate_connection', {
+      workspaceSlug: 'goodboy',
+      email: 'amin@acme.io',
+      apiToken: 'tok',
+    });
+  });
+
+  it('stores and clears the token through the two lifecycle commands', async () => {
+    await bitbucketConnect({ workspaceId: 'w1' as WorkspaceId, apiToken: 'tok' });
+    expect(mockInvoke).toHaveBeenCalledWith('bitbucket_connect', {
+      workspaceId: 'w1',
+      apiToken: 'tok',
+    });
+
+    await bitbucketDisconnect({ workspaceId: 'w1' as WorkspaceId });
+    expect(mockInvoke).toHaveBeenCalledWith('bitbucket_disconnect', { workspaceId: 'w1' });
+  });
+
+  it('sends a null state when the caller does not filter the pull request list', async () => {
+    mockInvoke.mockResolvedValue([]);
+
+    await bitbucketListPullRequests(repo);
+
+    expect(mockInvoke).toHaveBeenCalledWith('bitbucket_list_pull_requests', {
+      ...repo,
+      state: null,
+    });
+  });
+
+  it('forwards the pull request id to every single pull request read', async () => {
+    mockInvoke.mockResolvedValue({});
+
+    await bitbucketGetPullRequest(target);
+    await bitbucketPullRequestDiff(target);
+    await bitbucketListPullRequestComments(target);
+    await bitbucketListPullRequestStatuses(target);
+
+    expect(mockInvoke.mock.calls.map((call) => call[0])).toEqual([
+      'bitbucket_get_pull_request',
+      'bitbucket_pull_request_diff',
+      'bitbucket_list_pull_request_comments',
+      'bitbucket_list_pull_request_statuses',
+    ]);
+    expect(mockInvoke).toHaveBeenLastCalledWith('bitbucket_list_pull_request_statuses', target);
+  });
+
+  it('resolves a branch to its open pull request', async () => {
+    mockInvoke.mockResolvedValue(null);
+
+    await bitbucketPullRequestForBranch({ ...repo, sourceBranch: 'ak/feat-bb' });
+
+    expect(mockInvoke).toHaveBeenCalledWith('bitbucket_pull_request_for_branch', {
+      ...repo,
+      sourceBranch: 'ak/feat-bb',
+    });
+  });
+
+  it('maps each review verb to its own command', async () => {
+    mockInvoke.mockResolvedValue({});
+
+    await bitbucketApprovePullRequest(target);
+    await bitbucketUnapprovePullRequest(target);
+    await bitbucketRequestChanges(target);
+    await bitbucketUnrequestChanges(target);
+    await bitbucketDeclinePullRequest(target);
+
+    expect(mockInvoke.mock.calls.map((call) => call[0])).toEqual([
+      'bitbucket_approve_pull_request',
+      'bitbucket_unapprove_pull_request',
+      'bitbucket_request_changes',
+      'bitbucket_unrequest_changes',
+      'bitbucket_decline_pull_request',
+    ]);
+  });
+
+  it('sends null merge options rather than omitting them', async () => {
+    mockInvoke.mockResolvedValue({});
+
+    await bitbucketMergePullRequest(target);
+
+    expect(mockInvoke).toHaveBeenCalledWith('bitbucket_merge_pull_request', {
+      ...target,
+      closeSourceBranch: null,
+      message: null,
+    });
+  });
+
+  it('carries the merge options the caller did give', async () => {
+    mockInvoke.mockResolvedValue({});
+
+    await bitbucketMergePullRequest({ ...target, closeSourceBranch: true, message: 'ship it' });
+
+    expect(mockInvoke).toHaveBeenCalledWith('bitbucket_merge_pull_request', {
+      ...target,
+      closeSourceBranch: true,
+      message: 'ship it',
+    });
+  });
+
+  it('separates a new comment from a reply by the parent comment id', async () => {
+    mockInvoke.mockResolvedValue({});
+
+    await bitbucketCreatePullRequestComment({ ...target, body: 'lgtm' });
+    expect(mockInvoke).toHaveBeenCalledWith('bitbucket_create_pull_request_comment', {
+      ...target,
+      body: 'lgtm',
+    });
+
+    await bitbucketReplyToPullRequestComment({ ...target, parentCommentId: 90, body: 'agreed' });
+    expect(mockInvoke).toHaveBeenCalledWith('bitbucket_reply_to_pull_request_comment', {
+      ...target,
+      parentCommentId: 90,
+      body: 'agreed',
+    });
+  });
+});

--- a/apps/desktop/src/features/integrations/bitbucket/client.ts
+++ b/apps/desktop/src/features/integrations/bitbucket/client.ts
@@ -1,0 +1,371 @@
+import { invoke } from '@tauri-apps/api/core';
+import type { WorkspaceId } from '@goodboy/types';
+
+export type BitbucketUser = {
+  readonly uuid: string;
+  readonly accountId: string | null;
+  readonly nickname: string;
+  readonly displayName: string;
+  readonly avatarUrl: string | null;
+};
+
+export type BitbucketWorkspace = {
+  readonly uuid: string;
+  readonly slug: string;
+  readonly name: string;
+  readonly webUrl: string | null;
+};
+
+export type BitbucketConnection = {
+  readonly user: BitbucketUser;
+  readonly workspace: BitbucketWorkspace;
+};
+
+export type BitbucketPullRequestState = 'OPEN' | 'MERGED' | 'DECLINED' | 'SUPERSEDED';
+
+export type BitbucketParticipant = {
+  readonly user: BitbucketUser | null;
+  readonly role: string;
+  readonly approved: boolean;
+  readonly state: string | null;
+};
+
+export type BitbucketPullRequest = {
+  readonly id: number;
+  readonly title: string;
+  readonly description: string;
+  readonly state: BitbucketPullRequestState;
+  readonly createdOn: string;
+  readonly updatedOn: string;
+  readonly sourceBranch: string;
+  readonly sourceCommit: string | null;
+  readonly destinationBranch: string;
+  readonly destinationCommit: string | null;
+  readonly author: BitbucketUser | null;
+  readonly reviewers: ReadonlyArray<BitbucketUser>;
+  readonly participants: ReadonlyArray<BitbucketParticipant>;
+  readonly closeSourceBranch: boolean;
+  readonly mergeCommit: string | null;
+  readonly commentCount: number;
+  readonly taskCount: number;
+  readonly webUrl: string | null;
+};
+
+export type BitbucketInline = {
+  readonly path: string;
+  readonly from: number | null;
+  readonly to: number | null;
+};
+
+export type BitbucketComment = {
+  readonly id: number;
+  readonly body: string;
+  readonly user: BitbucketUser | null;
+  readonly createdOn: string;
+  readonly updatedOn: string;
+  readonly deleted: boolean;
+  readonly parentId: number | null;
+  readonly inline: BitbucketInline | null;
+  readonly webUrl: string | null;
+};
+
+export type BitbucketStatusState = 'SUCCESSFUL' | 'FAILED' | 'INPROGRESS' | 'STOPPED';
+
+export type BitbucketStatus = {
+  readonly key: string;
+  readonly name: string;
+  readonly state: BitbucketStatusState;
+  readonly url: string | null;
+  readonly description: string | null;
+  readonly refname: string | null;
+  readonly createdOn: string;
+  readonly updatedOn: string;
+};
+
+type ValidateParams = {
+  readonly workspaceSlug: string;
+  readonly email: string;
+  readonly apiToken: string;
+};
+
+export const bitbucketValidateConnection = async ({
+  workspaceSlug,
+  email,
+  apiToken,
+}: ValidateParams): Promise<BitbucketConnection> =>
+  invoke<BitbucketConnection>('bitbucket_validate_connection', {
+    workspaceSlug,
+    email,
+    apiToken,
+  });
+
+type ConnectParams = {
+  readonly workspaceId: WorkspaceId;
+  readonly apiToken: string;
+};
+
+export const bitbucketConnect = async ({ workspaceId, apiToken }: ConnectParams): Promise<void> => {
+  await invoke('bitbucket_connect', { workspaceId, apiToken });
+};
+
+type DisconnectParams = {
+  readonly workspaceId: WorkspaceId;
+};
+
+export const bitbucketDisconnect = async ({ workspaceId }: DisconnectParams): Promise<void> => {
+  await invoke('bitbucket_disconnect', { workspaceId });
+};
+
+export type BitbucketRepo = {
+  readonly workspaceId: WorkspaceId;
+  readonly workspaceSlug: string;
+  readonly repoSlug: string;
+  readonly email: string;
+};
+
+export type BitbucketPullRequestTarget = BitbucketRepo & {
+  readonly pullRequestId: number;
+};
+
+type ListPullRequestsParams = BitbucketRepo & {
+  readonly state?: BitbucketPullRequestState;
+};
+
+export const bitbucketListPullRequests = async ({
+  workspaceId,
+  workspaceSlug,
+  repoSlug,
+  email,
+  state,
+}: ListPullRequestsParams): Promise<ReadonlyArray<BitbucketPullRequest>> =>
+  invoke<ReadonlyArray<BitbucketPullRequest>>('bitbucket_list_pull_requests', {
+    workspaceId,
+    workspaceSlug,
+    repoSlug,
+    email,
+    state: state ?? null,
+  });
+
+export const bitbucketGetPullRequest = async ({
+  workspaceId,
+  workspaceSlug,
+  repoSlug,
+  email,
+  pullRequestId,
+}: BitbucketPullRequestTarget): Promise<BitbucketPullRequest> =>
+  invoke<BitbucketPullRequest>('bitbucket_get_pull_request', {
+    workspaceId,
+    workspaceSlug,
+    repoSlug,
+    email,
+    pullRequestId,
+  });
+
+export const bitbucketPullRequestDiff = async ({
+  workspaceId,
+  workspaceSlug,
+  repoSlug,
+  email,
+  pullRequestId,
+}: BitbucketPullRequestTarget): Promise<string> =>
+  invoke<string>('bitbucket_pull_request_diff', {
+    workspaceId,
+    workspaceSlug,
+    repoSlug,
+    email,
+    pullRequestId,
+  });
+
+export const bitbucketListPullRequestComments = async ({
+  workspaceId,
+  workspaceSlug,
+  repoSlug,
+  email,
+  pullRequestId,
+}: BitbucketPullRequestTarget): Promise<ReadonlyArray<BitbucketComment>> =>
+  invoke<ReadonlyArray<BitbucketComment>>('bitbucket_list_pull_request_comments', {
+    workspaceId,
+    workspaceSlug,
+    repoSlug,
+    email,
+    pullRequestId,
+  });
+
+export const bitbucketListPullRequestStatuses = async ({
+  workspaceId,
+  workspaceSlug,
+  repoSlug,
+  email,
+  pullRequestId,
+}: BitbucketPullRequestTarget): Promise<ReadonlyArray<BitbucketStatus>> =>
+  invoke<ReadonlyArray<BitbucketStatus>>('bitbucket_list_pull_request_statuses', {
+    workspaceId,
+    workspaceSlug,
+    repoSlug,
+    email,
+    pullRequestId,
+  });
+
+type BranchParams = BitbucketRepo & {
+  readonly sourceBranch: string;
+};
+
+export const bitbucketPullRequestForBranch = async ({
+  workspaceId,
+  workspaceSlug,
+  repoSlug,
+  email,
+  sourceBranch,
+}: BranchParams): Promise<BitbucketPullRequest | null> =>
+  invoke<BitbucketPullRequest | null>('bitbucket_pull_request_for_branch', {
+    workspaceId,
+    workspaceSlug,
+    repoSlug,
+    email,
+    sourceBranch,
+  });
+
+export const bitbucketApprovePullRequest = async ({
+  workspaceId,
+  workspaceSlug,
+  repoSlug,
+  email,
+  pullRequestId,
+}: BitbucketPullRequestTarget): Promise<BitbucketParticipant> =>
+  invoke<BitbucketParticipant>('bitbucket_approve_pull_request', {
+    workspaceId,
+    workspaceSlug,
+    repoSlug,
+    email,
+    pullRequestId,
+  });
+
+export const bitbucketUnapprovePullRequest = async ({
+  workspaceId,
+  workspaceSlug,
+  repoSlug,
+  email,
+  pullRequestId,
+}: BitbucketPullRequestTarget): Promise<void> => {
+  await invoke('bitbucket_unapprove_pull_request', {
+    workspaceId,
+    workspaceSlug,
+    repoSlug,
+    email,
+    pullRequestId,
+  });
+};
+
+export const bitbucketRequestChanges = async ({
+  workspaceId,
+  workspaceSlug,
+  repoSlug,
+  email,
+  pullRequestId,
+}: BitbucketPullRequestTarget): Promise<BitbucketParticipant> =>
+  invoke<BitbucketParticipant>('bitbucket_request_changes', {
+    workspaceId,
+    workspaceSlug,
+    repoSlug,
+    email,
+    pullRequestId,
+  });
+
+export const bitbucketUnrequestChanges = async ({
+  workspaceId,
+  workspaceSlug,
+  repoSlug,
+  email,
+  pullRequestId,
+}: BitbucketPullRequestTarget): Promise<void> => {
+  await invoke('bitbucket_unrequest_changes', {
+    workspaceId,
+    workspaceSlug,
+    repoSlug,
+    email,
+    pullRequestId,
+  });
+};
+
+type MergeParams = BitbucketPullRequestTarget & {
+  readonly closeSourceBranch?: boolean;
+  readonly message?: string;
+};
+
+export const bitbucketMergePullRequest = async ({
+  workspaceId,
+  workspaceSlug,
+  repoSlug,
+  email,
+  pullRequestId,
+  closeSourceBranch,
+  message,
+}: MergeParams): Promise<BitbucketPullRequest> =>
+  invoke<BitbucketPullRequest>('bitbucket_merge_pull_request', {
+    workspaceId,
+    workspaceSlug,
+    repoSlug,
+    email,
+    pullRequestId,
+    closeSourceBranch: closeSourceBranch ?? null,
+    message: message ?? null,
+  });
+
+export const bitbucketDeclinePullRequest = async ({
+  workspaceId,
+  workspaceSlug,
+  repoSlug,
+  email,
+  pullRequestId,
+}: BitbucketPullRequestTarget): Promise<BitbucketPullRequest> =>
+  invoke<BitbucketPullRequest>('bitbucket_decline_pull_request', {
+    workspaceId,
+    workspaceSlug,
+    repoSlug,
+    email,
+    pullRequestId,
+  });
+
+type CreateCommentParams = BitbucketPullRequestTarget & {
+  readonly body: string;
+};
+
+export const bitbucketCreatePullRequestComment = async ({
+  workspaceId,
+  workspaceSlug,
+  repoSlug,
+  email,
+  pullRequestId,
+  body,
+}: CreateCommentParams): Promise<BitbucketComment> =>
+  invoke<BitbucketComment>('bitbucket_create_pull_request_comment', {
+    workspaceId,
+    workspaceSlug,
+    repoSlug,
+    email,
+    pullRequestId,
+    body,
+  });
+
+type ReplyParams = CreateCommentParams & {
+  readonly parentCommentId: number;
+};
+
+export const bitbucketReplyToPullRequestComment = async ({
+  workspaceId,
+  workspaceSlug,
+  repoSlug,
+  email,
+  pullRequestId,
+  parentCommentId,
+  body,
+}: ReplyParams): Promise<BitbucketComment> =>
+  invoke<BitbucketComment>('bitbucket_reply_to_pull_request_comment', {
+    workspaceId,
+    workspaceSlug,
+    repoSlug,
+    email,
+    pullRequestId,
+    parentCommentId,
+    body,
+  });

--- a/apps/desktop/src/features/integrations/bitbucket/normalizeWorkspaceSlug.test.ts
+++ b/apps/desktop/src/features/integrations/bitbucket/normalizeWorkspaceSlug.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeWorkspaceSlug } from './normalizeWorkspaceSlug';
+
+describe('normalizeWorkspaceSlug', () => {
+  it('lowercases and trims a bare slug', () => {
+    expect(normalizeWorkspaceSlug({ input: '  GoodBoy  ' })).toBe('goodboy');
+  });
+
+  it('takes the slug out of a pasted repository url', () => {
+    expect(normalizeWorkspaceSlug({ input: 'https://bitbucket.org/goodboy/desktop' })).toBe(
+      'goodboy',
+    );
+    expect(normalizeWorkspaceSlug({ input: 'bitbucket.org/goodboy' })).toBe('goodboy');
+  });
+
+  it('is empty for an empty input', () => {
+    expect(normalizeWorkspaceSlug({ input: '   ' })).toBe('');
+  });
+});

--- a/apps/desktop/src/features/integrations/bitbucket/normalizeWorkspaceSlug.ts
+++ b/apps/desktop/src/features/integrations/bitbucket/normalizeWorkspaceSlug.ts
@@ -1,0 +1,17 @@
+type Params = {
+  readonly input: string;
+};
+
+export const normalizeWorkspaceSlug = ({ input }: Params): string => {
+  const trimmed = input.trim();
+  if (trimmed === '') {
+    return '';
+  }
+  const withoutScheme = trimmed.replace(/^[a-z][a-z0-9+.-]*:\/\//i, '');
+  const withoutHost = withoutScheme.replace(/^(www\.)?bitbucket\.org\//i, '');
+  const [slug] = withoutHost.split('/');
+  if (slug == null) {
+    return '';
+  }
+  return slug.trim().toLowerCase();
+};

--- a/apps/desktop/src/features/integrations/components/IntegrationGlyph/index.tsx
+++ b/apps/desktop/src/features/integrations/components/IntegrationGlyph/index.tsx
@@ -2,7 +2,13 @@ import type { LucideIcon } from 'lucide-react';
 import { BrandGlyph } from '../../../../shared/components/BrandGlyph';
 import { CONCEPT_ICONS } from '../../../../shared/components/conceptIcons';
 
-export type IntegrationGlyphProvider = 'github' | 'gitlab' | 'jira' | 'linear' | 'sentry';
+export type IntegrationGlyphProvider =
+  | 'bitbucket'
+  | 'github'
+  | 'gitlab'
+  | 'jira'
+  | 'linear'
+  | 'sentry';
 
 type IntegrationBrand = {
   readonly icon: LucideIcon;
@@ -11,6 +17,11 @@ type IntegrationBrand = {
 };
 
 const INTEGRATION_BRAND: Record<IntegrationGlyphProvider, IntegrationBrand> = {
+  bitbucket: {
+    icon: CONCEPT_ICONS.bitbucket,
+    label: 'Bitbucket',
+    cssVar: '--color-provider-bitbucket',
+  },
   github: { icon: CONCEPT_ICONS.github, label: 'GitHub', cssVar: '--color-provider-github' },
   gitlab: { icon: CONCEPT_ICONS.gitlab, label: 'GitLab', cssVar: '--color-provider-gitlab' },
   jira: { icon: CONCEPT_ICONS.jira, label: 'Jira', cssVar: '--color-provider-jira' },

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/index.test.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/index.test.tsx
@@ -51,6 +51,7 @@ const baseState: OnboardingWizardState = {
   workspaceKind: null,
   githubConnected: false,
   gitlabConnected: false,
+  bitbucketConnected: false,
   hasCodeHost: false,
   hasLinear: false,
   hasJira: false,

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/index.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/index.tsx
@@ -87,6 +87,7 @@ export const OnboardingWizard = () => {
     workspaceKind,
     githubConnected,
     gitlabConnected,
+    bitbucketConnected,
     hasCodeHost,
     hasLinear,
     hasJira,
@@ -197,6 +198,7 @@ export const OnboardingWizard = () => {
         workspaceId={workspaceId}
         githubConnected={githubConnected}
         gitlabConnected={gitlabConnected}
+        bitbucketConnected={bitbucketConnected}
         onConnected={refreshGithubStatus}
       />
     );

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/steps/CodeHostForm.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/steps/CodeHostForm.tsx
@@ -1,0 +1,27 @@
+import type { WorkspaceId } from '@goodboy/types';
+import { BitbucketFormBody } from '../../../integrations/bitbucket/BitbucketFormBody';
+import { GithubFormBody } from '../../../integrations/github/GithubFormBody';
+import { GitlabFormBody } from '../../../integrations/gitlab/GitlabFormBody';
+
+export type CodeHost = 'github' | 'gitlab' | 'bitbucket';
+
+type Props = {
+  readonly host: CodeHost;
+  readonly workspaceId: WorkspaceId;
+  readonly onConnected: () => void;
+};
+
+export const CodeHostForm = ({ host, workspaceId, onConnected }: Props) => {
+  switch (host) {
+    case 'github':
+      return <GithubFormBody workspaceId={workspaceId} onConnected={onConnected} />;
+    case 'gitlab':
+      return <GitlabFormBody workspaceId={workspaceId} onConnected={onConnected} />;
+    case 'bitbucket':
+      return <BitbucketFormBody workspaceId={workspaceId} onConnected={onConnected} />;
+    default: {
+      const exhaustive: never = host;
+      return exhaustive;
+    }
+  }
+};

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/steps/CodeHostStep.test.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/steps/CodeHostStep.test.tsx
@@ -16,6 +16,12 @@ vi.mock('../../../integrations/gitlab/GitlabFormBody', () => ({
   ),
 }));
 
+vi.mock('../../../integrations/bitbucket/BitbucketFormBody', () => ({
+  BitbucketFormBody: ({ workspaceId }: { workspaceId: WorkspaceId }) => (
+    <div data-testid="bitbucket-form">{workspaceId}</div>
+  ),
+}));
+
 const WS_ID = 'ws-1' as WorkspaceId;
 
 afterEach(cleanup);
@@ -29,6 +35,7 @@ describe('CodeHostStep', () => {
         workspaceId={WS_ID}
         githubConnected={false}
         gitlabConnected={false}
+        bitbucketConnected={false}
         onConnected={vi.fn()}
       />,
     );
@@ -42,6 +49,7 @@ describe('CodeHostStep', () => {
           workspaceId={WS_ID}
           githubConnected={false}
           gitlabConnected={false}
+          bitbucketConnected={false}
           onConnected={vi.fn()}
         />,
       );
@@ -56,11 +64,42 @@ describe('CodeHostStep', () => {
           workspaceId={WS_ID}
           githubConnected={false}
           gitlabConnected={false}
+          bitbucketConnected={false}
           onConnected={vi.fn()}
         />,
       );
       fireEvent.click(screen.getByRole('tab', { name: /gitlab/i }));
       expect(screen.getByTestId('gitlab-form').textContent).toBe(WS_ID);
+      expect(screen.queryByTestId('github-form')).toBeNull();
+    });
+
+    it('swaps to the Bitbucket form when its segment is selected', () => {
+      render(
+        <CodeHostStep
+          workspaceId={WS_ID}
+          githubConnected={false}
+          gitlabConnected={false}
+          bitbucketConnected={false}
+          onConnected={vi.fn()}
+        />,
+      );
+      fireEvent.click(screen.getByRole('tab', { name: /bitbucket/i }));
+      expect(screen.getByTestId('bitbucket-form').textContent).toBe(WS_ID);
+      expect(screen.queryByTestId('github-form')).toBeNull();
+      expect(screen.queryByTestId('gitlab-form')).toBeNull();
+    });
+
+    it('defaults to Bitbucket when only Bitbucket is connected', () => {
+      render(
+        <CodeHostStep
+          workspaceId={WS_ID}
+          githubConnected={false}
+          gitlabConnected={false}
+          bitbucketConnected
+          onConnected={vi.fn()}
+        />,
+      );
+      expect(screen.getByTestId('bitbucket-form').textContent).toBe(WS_ID);
       expect(screen.queryByTestId('github-form')).toBeNull();
     });
 
@@ -70,6 +109,7 @@ describe('CodeHostStep', () => {
           workspaceId={WS_ID}
           githubConnected={false}
           gitlabConnected
+          bitbucketConnected={false}
           onConnected={vi.fn()}
         />,
       );
@@ -85,6 +125,7 @@ describe('CodeHostStep', () => {
           workspaceId={null}
           githubConnected={false}
           gitlabConnected={false}
+          bitbucketConnected={false}
           onConnected={vi.fn()}
         />,
       );
@@ -94,6 +135,7 @@ describe('CodeHostStep', () => {
       expect(screen.getByText(/Add a workspace first to connect a code host/i)).toBeDefined();
       expect(screen.queryByTestId('github-form')).toBeNull();
       expect(screen.queryByTestId('gitlab-form')).toBeNull();
+      expect(screen.queryByTestId('bitbucket-form')).toBeNull();
     });
 
     it('dispatches goodboy:add-workspace when the Add workspace button is clicked', () => {

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/steps/CodeHostStep.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/steps/CodeHostStep.tsx
@@ -2,29 +2,47 @@ import { useState } from 'react';
 import { FolderGit2, GitBranch } from 'lucide-react';
 import { Button } from '@goodboy/ui';
 import type { WorkspaceId } from '@goodboy/types';
-import { GithubIcon, GitlabIcon } from '../../../../shared/components/brand-icons';
-import { GithubFormBody } from '../../../integrations/github/GithubFormBody';
-import { GitlabFormBody } from '../../../integrations/gitlab/GitlabFormBody';
+import { BitbucketIcon, GithubIcon, GitlabIcon } from '../../../../shared/components/brand-icons';
 import { Segmented, type SegmentedOption } from '../Segmented';
-
-type Host = 'github' | 'gitlab';
+import { CodeHostForm, type CodeHost } from './CodeHostForm';
 
 type Props = {
   readonly workspaceId: WorkspaceId | null;
   readonly githubConnected: boolean;
   readonly gitlabConnected: boolean;
+  readonly bitbucketConnected: boolean;
   readonly onConnected: () => void;
+};
+
+const initialHost = ({
+  githubConnected,
+  gitlabConnected,
+  bitbucketConnected,
+}: Pick<Props, 'githubConnected' | 'gitlabConnected' | 'bitbucketConnected'>): CodeHost => {
+  if (githubConnected) {
+    return 'github';
+  }
+  if (gitlabConnected) {
+    return 'gitlab';
+  }
+  if (bitbucketConnected) {
+    return 'bitbucket';
+  }
+  return 'github';
 };
 
 export const CodeHostStep = ({
   workspaceId,
   githubConnected,
   gitlabConnected,
+  bitbucketConnected,
   onConnected,
 }: Props) => {
-  const [host, setHost] = useState<Host>(gitlabConnected && !githubConnected ? 'gitlab' : 'github');
+  const [host, setHost] = useState<CodeHost>(
+    initialHost({ githubConnected, gitlabConnected, bitbucketConnected }),
+  );
 
-  const options: ReadonlyArray<SegmentedOption<Host>> = [
+  const options: ReadonlyArray<SegmentedOption<CodeHost>> = [
     {
       value: 'github',
       label: 'GitHub',
@@ -39,6 +57,13 @@ export const CodeHostStep = ({
       color: 'var(--color-provider-gitlab)',
       connected: gitlabConnected,
     },
+    {
+      value: 'bitbucket',
+      label: 'Bitbucket',
+      icon: BitbucketIcon,
+      color: 'var(--color-provider-bitbucket)',
+      connected: bitbucketConnected,
+    },
   ];
 
   return (
@@ -52,8 +77,8 @@ export const CodeHostStep = ({
           Connect a code host
         </h2>
         <p className="mx-auto max-w-md text-sm leading-relaxed text-muted-foreground">
-          Link GitHub or GitLab so Goodboy can review and resolve pull requests for this workspace.
-          You can only use one at a time.
+          Link GitHub, GitLab or Bitbucket so Goodboy can review and resolve pull requests for this
+          workspace. You can only use one at a time.
         </p>
       </div>
 
@@ -77,11 +102,7 @@ export const CodeHostStep = ({
         <div className="flex w-full flex-col gap-4 text-left">
           <Segmented ariaLabel="Code host" options={options} value={host} onChange={setHost} />
           <div className="rounded-lg border border-border-soft/40 bg-subtle/20 p-4">
-            {host === 'github' ? (
-              <GithubFormBody workspaceId={workspaceId} onConnected={onConnected} />
-            ) : (
-              <GitlabFormBody workspaceId={workspaceId} onConnected={onConnected} />
-            )}
+            <CodeHostForm host={host} workspaceId={workspaceId} onConnected={onConnected} />
           </div>
         </div>
       )}

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/useOnboardingWizard/index.ts
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/useOnboardingWizard/index.ts
@@ -14,6 +14,7 @@ export type OnboardingWizardState = {
   readonly workspaceKind: WorkspaceKind | null;
   readonly githubConnected: boolean;
   readonly gitlabConnected: boolean;
+  readonly bitbucketConnected: boolean;
   readonly hasCodeHost: boolean;
   readonly hasLinear: boolean;
   readonly hasJira: boolean;
@@ -37,6 +38,11 @@ export const useOnboardingWizard = (): OnboardingWizardState => {
   const gitlabConnected = useAppStore((s) =>
     workspaceId
       ? (s.workspaceIntegrations[workspaceId] ?? []).some((i) => i.provider === 'gitlab')
+      : false,
+  );
+  const bitbucketConnected = useAppStore((s) =>
+    workspaceId
+      ? (s.workspaceIntegrations[workspaceId] ?? []).some((i) => i.provider === 'bitbucket')
       : false,
   );
   const hasLinear = useAppStore((s) =>
@@ -70,7 +76,7 @@ export const useOnboardingWizard = (): OnboardingWizardState => {
     refreshGithubStatus();
   }, [refreshGithubStatus]);
 
-  const hasCodeHost = githubScoped || gitlabConnected;
+  const hasCodeHost = githubScoped || gitlabConnected || bitbucketConnected;
 
   const [open, setOpen] = useState(false);
   const [mode, setMode] = useState<WizardMode>('full');
@@ -124,6 +130,7 @@ export const useOnboardingWizard = (): OnboardingWizardState => {
     workspaceKind,
     githubConnected: githubScoped,
     gitlabConnected,
+    bitbucketConnected,
     hasCodeHost,
     hasLinear,
     hasJira,

--- a/apps/desktop/src/features/onboarding/hooks/useOnboardingProgress/index.ts
+++ b/apps/desktop/src/features/onboarding/hooks/useOnboardingProgress/index.ts
@@ -71,6 +71,11 @@ export const useOnboardingProgress = (): OnboardingProgress => {
       ? (s.workspaceIntegrations[workspaceId] ?? []).some((i) => i.provider === 'gitlab')
       : false,
   );
+  const bitbucketConnected = useAppStore((s) =>
+    workspaceId
+      ? (s.workspaceIntegrations[workspaceId] ?? []).some((i) => i.provider === 'bitbucket')
+      : false,
+  );
   const hasTools = useAppStore((s) =>
     workspaceId
       ? (s.workspaceIntegrations[workspaceId] ?? []).some(
@@ -96,7 +101,11 @@ export const useOnboardingProgress = (): OnboardingProgress => {
     if (workspaces.length > 0 && !persistedCompleted.has('workspace')) {
       markStepComplete('workspace');
     }
-    if (!isSimple && (gitlabConnected || githubScoped) && !persistedCompleted.has('codeHost')) {
+    if (
+      !isSimple &&
+      (gitlabConnected || bitbucketConnected || githubScoped) &&
+      !persistedCompleted.has('codeHost')
+    ) {
       markStepComplete('codeHost');
     }
     if (hasTools && !persistedCompleted.has('tools')) {
@@ -117,6 +126,7 @@ export const useOnboardingProgress = (): OnboardingProgress => {
     anyAgent,
     anyPlan,
     gitlabConnected,
+    bitbucketConnected,
     githubScoped,
     hasTools,
     isSimple,

--- a/apps/desktop/src/shared/components/brand-icons.tsx
+++ b/apps/desktop/src/shared/components/brand-icons.tsx
@@ -79,6 +79,13 @@ export const GitlabIcon: LucideIcon = forwardRef<SVGSVGElement, LucideProps>((pr
 ));
 GitlabIcon.displayName = 'GitlabIcon';
 
+export const BitbucketIcon: LucideIcon = forwardRef<SVGSVGElement, LucideProps>((props, ref) => (
+  <svg ref={ref} {...svgProps(props)}>
+    <path d="M.778 1.213a.768.768 0 0 0-.768.892l3.263 19.81c.084.5.515.868 1.022.873H19.95a.772.772 0 0 0 .77-.646l3.27-20.03a.768.768 0 0 0-.768-.891zM14.52 15.53H9.522L8.17 8.466h7.561z" />
+  </svg>
+));
+BitbucketIcon.displayName = 'BitbucketIcon';
+
 export const SentryIcon: LucideIcon = forwardRef<SVGSVGElement, LucideProps>((props, ref) => (
   <svg ref={ref} {...svgProps(props)}>
     <path d="M13.91 2.505c-.873-1.448-2.972-1.448-3.844 0L6.904 7.92a15.478 15.478 0 0 1 8.53 12.811h-2.221A13.301 13.301 0 0 0 5.784 9.814l-2.926 5.06a7.65 7.65 0 0 1 4.435 5.848H2.194a.365.365 0 0 1-.298-.534l1.413-2.402a5.16 5.16 0 0 0-1.614-.913L.296 19.275a2.182 2.182 0 0 0 .812 2.999 2.24 2.24 0 0 0 1.086.288h6.983a9.322 9.322 0 0 0-3.845-8.318l1.11-1.922a11.47 11.47 0 0 1 4.95 10.24h5.915a17.242 17.242 0 0 0-7.885-15.28l2.244-3.845a.37.37 0 0 1 .504-.13c.255.14 9.75 16.708 9.928 16.9a.365.365 0 0 1-.327.543h-2.287c.029.612.029 1.223 0 1.831h2.297a2.206 2.206 0 0 0 1.922-3.31z" />

--- a/apps/desktop/src/shared/components/conceptIcons.ts
+++ b/apps/desktop/src/shared/components/conceptIcons.ts
@@ -32,10 +32,18 @@ import {
   Waypoints,
   Wrench,
 } from 'lucide-react';
-import { GithubIcon, GitlabIcon, JiraIcon, LinearIcon, SentryIcon } from './brand-icons';
+import {
+  BitbucketIcon,
+  GithubIcon,
+  GitlabIcon,
+  JiraIcon,
+  LinearIcon,
+  SentryIcon,
+} from './brand-icons';
 
 export const CONCEPT_ICONS = {
   agents: Bot,
+  bitbucket: BitbucketIcon,
   budget: Wallet,
   changelog: History,
   commits: GitCommit,
@@ -77,6 +85,7 @@ type Concept = keyof typeof CONCEPT_ICONS;
 
 export const CONCEPT_TONE = {
   agents: 'primary',
+  bitbucket: 'primary',
   budget: 'warning',
   changelog: 'neutral',
   commits: 'info',

--- a/apps/desktop/src/store/slices/integrations/configFromBitbucketConnection.ts
+++ b/apps/desktop/src/store/slices/integrations/configFromBitbucketConnection.ts
@@ -1,0 +1,18 @@
+import type { BitbucketIntegrationConfig } from '@goodboy/types';
+import type { BitbucketConnection } from '../../../features/integrations/bitbucket/client';
+
+type Params = {
+  readonly connection: BitbucketConnection;
+};
+
+export const configFromBitbucketConnection = ({
+  connection,
+}: Params): Pick<
+  BitbucketIntegrationConfig,
+  'accountId' | 'displayName' | 'workspaceName' | 'workspaceSlug'
+> => ({
+  accountId: connection.user.accountId ?? undefined,
+  displayName: connection.user.displayName,
+  workspaceName: connection.workspace.name,
+  workspaceSlug: connection.workspace.slug,
+});

--- a/apps/desktop/src/store/slices/integrations/connectBitbucket.ts
+++ b/apps/desktop/src/store/slices/integrations/connectBitbucket.ts
@@ -1,0 +1,64 @@
+import { upsertWorkspaceIntegration } from '@goodboy/db';
+import type {
+  BitbucketWorkspaceIntegration,
+  IsoDateTime,
+  WorkspaceId,
+  WorkspaceIntegrationId,
+} from '@goodboy/types';
+import {
+  bitbucketConnect as bitbucketStoreToken,
+  bitbucketValidateConnection,
+  type BitbucketConnection,
+} from '../../../features/integrations/bitbucket/client';
+import { tauriDatabase } from '../../../shared/lib/db';
+import { configFromBitbucketConnection } from './configFromBitbucketConnection';
+import type { GetFn, SetFn } from './types';
+
+type ConnectParams = {
+  readonly workspaceId: WorkspaceId;
+  readonly workspaceSlug: string;
+  readonly email: string;
+  readonly apiToken: string;
+};
+
+export const connectBitbucket = (set: SetFn, get: GetFn) => {
+  return async ({
+    workspaceId,
+    workspaceSlug,
+    email,
+    apiToken,
+  }: ConnectParams): Promise<BitbucketConnection> => {
+    const connection = await bitbucketValidateConnection({ workspaceSlug, email, apiToken });
+    await bitbucketStoreToken({ workspaceId, apiToken });
+    const now = new Date().toISOString() as IsoDateTime;
+    const existing = get().workspaceIntegrations[workspaceId]?.find(
+      (integration): integration is BitbucketWorkspaceIntegration =>
+        integration.provider === 'bitbucket',
+    );
+    const integration: BitbucketWorkspaceIntegration = {
+      id: (existing?.id ?? crypto.randomUUID()) as WorkspaceIntegrationId,
+      workspaceId,
+      provider: 'bitbucket',
+      config: {
+        ...(existing?.config ?? {}),
+        ...configFromBitbucketConnection({ connection }),
+        email,
+      },
+      credentialKey: `goodboy.workspace.${workspaceId}.bitbucket`,
+      createdAt: existing?.createdAt ?? now,
+      updatedAt: now,
+    };
+    await upsertWorkspaceIntegration(tauriDatabase, integration);
+    set((state) => {
+      const current = state.workspaceIntegrations[workspaceId] ?? [];
+      const rest = current.filter((candidate) => candidate.provider !== 'bitbucket');
+      return {
+        workspaceIntegrations: {
+          ...state.workspaceIntegrations,
+          [workspaceId]: [...rest, integration],
+        },
+      };
+    });
+    return connection;
+  };
+};

--- a/apps/desktop/src/store/slices/integrations/disconnectBitbucket.ts
+++ b/apps/desktop/src/store/slices/integrations/disconnectBitbucket.ts
@@ -1,0 +1,25 @@
+import { deleteWorkspaceIntegration as deleteIntegrationInDb } from '@goodboy/db';
+import type { WorkspaceId } from '@goodboy/types';
+import { bitbucketDisconnect } from '../../../features/integrations/bitbucket/client';
+import { tauriDatabase } from '../../../shared/lib/db';
+import type { SetFn } from './types';
+
+type DisconnectParams = {
+  readonly workspaceId: WorkspaceId;
+};
+
+export const disconnectBitbucket = (set: SetFn) => {
+  return async ({ workspaceId }: DisconnectParams): Promise<void> => {
+    await bitbucketDisconnect({ workspaceId });
+    await deleteIntegrationInDb(tauriDatabase, workspaceId, 'bitbucket');
+    set((state) => {
+      const current = state.workspaceIntegrations[workspaceId] ?? [];
+      return {
+        workspaceIntegrations: {
+          ...state.workspaceIntegrations,
+          [workspaceId]: current.filter((integration) => integration.provider !== 'bitbucket'),
+        },
+      };
+    });
+  };
+};

--- a/apps/desktop/src/store/slices/integrations/index.ts
+++ b/apps/desktop/src/store/slices/integrations/index.ts
@@ -1,7 +1,9 @@
+import { connectBitbucket } from './connectBitbucket';
 import { connectGitlab } from './connectGitlab';
 import { connectJira } from './connectJira';
 import { connectLinear } from './connectLinear';
 import { connectSentry } from './connectSentry';
+import { disconnectBitbucket } from './disconnectBitbucket';
 import { disconnectGitlab } from './disconnectGitlab';
 import { disconnectJira } from './disconnectJira';
 import { disconnectLinear } from './disconnectLinear';
@@ -20,5 +22,7 @@ export const createIntegrationsSlice = (set: SetFn, get: GetFn) => {
     disconnectGitlab: disconnectGitlab(set),
     connectJira: connectJira(set, get),
     disconnectJira: disconnectJira(set),
+    connectBitbucket: connectBitbucket(set, get),
+    disconnectBitbucket: disconnectBitbucket(set),
   };
 };

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -144,6 +144,7 @@ import { initialChangelogState } from './slices/changelog/state';
 import type { LinearViewer } from '../features/integrations/linear/client';
 import type { SentryProject } from '../features/integrations/sentry/client';
 import type { GitlabUser } from '../features/integrations/gitlab/client';
+import type { BitbucketConnection } from '../features/integrations/bitbucket/client';
 import type { JiraUser } from '../features/integrations/jira/client';
 import type { ProviderSpendEntry } from './slices/budget';
 import type { AppState } from './types';
@@ -217,6 +218,13 @@ export type AppActions = {
     apiToken: string;
   }): Promise<JiraUser>;
   disconnectJira(params: { workspaceId: WorkspaceId }): Promise<void>;
+  connectBitbucket(params: {
+    workspaceId: WorkspaceId;
+    workspaceSlug: string;
+    email: string;
+    apiToken: string;
+  }): Promise<BitbucketConnection>;
+  disconnectBitbucket(params: { workspaceId: WorkspaceId }): Promise<void>;
   createSession(input: {
     workspaceId: WorkspaceId;
     goal: string;

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -45,6 +45,7 @@
   --color-provider-openrouter: #6467f2;
   --color-provider-moonshot: #16b8a6;
   --color-provider-jira: #2684ff;
+  --color-provider-bitbucket: #4c9aff;
   --color-provider-linear: oklch(0.57 0.16 277);
   --color-provider-sentry: oklch(0.55 0.18 320);
   --color-provider-gitlab: oklch(0.68 0.18 45);
@@ -282,6 +283,7 @@ html[data-theme='light'] {
   --color-provider-openrouter: #5558d9;
   --color-provider-moonshot: #0f8f81;
   --color-provider-jira: #0052cc;
+  --color-provider-bitbucket: #0747a6;
   --color-provider-linear: oklch(0.5 0.16 277);
   --color-provider-sentry: oklch(0.48 0.18 320);
   --color-provider-gitlab: oklch(0.56 0.18 45);

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -104,6 +104,7 @@ import { m103SessionExternalTaskBranch } from './m103-session-external-task-bran
 import { m104PendingResolutionReplyPosted } from './m104-pending-resolution-reply-posted';
 import { m105IntegrationJiraProvider } from './m105-integration-jira-provider';
 import { m106MoonshotProviderRuns } from './m106-moonshot-provider-runs';
+import { m107IntegrationBitbucketProvider } from './m107-integration-bitbucket-provider';
 
 export type Migration = {
   readonly version: number;
@@ -217,4 +218,5 @@ export const migrations: ReadonlyArray<Migration> = [
   { version: 104, sql: m104PendingResolutionReplyPosted },
   { version: 105, sql: m105IntegrationJiraProvider },
   { version: 106, sql: m106MoonshotProviderRuns },
+  { version: 107, sql: m107IntegrationBitbucketProvider },
 ];

--- a/packages/db/src/migrations/m107-integration-bitbucket-provider.test.ts
+++ b/packages/db/src/migrations/m107-integration-bitbucket-provider.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+import type { Database } from '../client';
+import { makeTestDatabase } from '../test-helpers/test-db';
+import { migrate } from './runner';
+import { migrations } from './index';
+
+const workspaceId = 'ws-1';
+const sessionId = 's-1';
+
+const seedThrough106 = async (): Promise<Database> => {
+  const db = makeTestDatabase();
+  await migrate(
+    db,
+    migrations.filter((migration) => migration.version <= 106),
+  );
+  const now = Date.now();
+  await db.execute(
+    'INSERT INTO workspaces (id, name, root_path, created_at, updated_at) VALUES (?, ?, ?, ?, ?)',
+    [workspaceId, 'ws', '/tmp/ws', now, now],
+  );
+  await db.execute(
+    'INSERT INTO sessions (id, workspace_id, goal, state_kind, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)',
+    [sessionId, workspaceId, 'goal', 'idle', now, now],
+  );
+  return db;
+};
+
+describe('m107 integration bitbucket provider', () => {
+  it('accepts a bitbucket row in all three widened tables', async () => {
+    const db = await seedThrough106();
+
+    await migrate(db, migrations);
+
+    const now = Date.now();
+    await db.execute(
+      `INSERT INTO workspace_integrations (id, workspace_id, provider, config, credential_key, created_at, updated_at)
+       VALUES ('wi-bb', ?, 'bitbucket', '{}', 'goodboy.workspace.ws-1.bitbucket', ?, ?)`,
+      [workspaceId, now, now],
+    );
+    await db.execute(
+      `INSERT INTO session_external_tasks
+         (session_id, mount_workspace_id, provider, external_id, identifier, url, title, created_at, branch)
+       VALUES (?, NULL, 'bitbucket', '42', 'goodboy/desktop#42', 'https://bitbucket.org/goodboy/desktop/pull-requests/42', 'Ship it', ?, NULL)`,
+      [sessionId, now],
+    );
+    await db.execute(
+      `INSERT INTO pr_review_drafts
+         (id, session_id, provider, repo, pr_number, path, line, side, body, created_at)
+       VALUES ('d-1', ?, 'bitbucket', 'goodboy/desktop', 42, 'src/lib.rs', 12, 'new', 'rename this', ?)`,
+      [sessionId, new Date(now).toISOString()],
+    );
+
+    const drafts = await db.select<{ provider: string }>('SELECT provider FROM pr_review_drafts');
+    expect(drafts).toEqual([{ provider: 'bitbucket' }]);
+  });
+
+  it('carries every pr review draft column through the rebuild', async () => {
+    const db = await seedThrough106();
+    const createdAt = new Date().toISOString();
+    await db.execute(
+      `INSERT INTO pr_review_drafts
+         (id, session_id, provider, repo, pr_number, path, line, start_line, side, body, status, origin, created_at)
+       VALUES ('d-0', ?, 'gitlab', 'goodboy/desktop', 7, 'src/app.ts', 30, 24, 'old', 'nit', 'published', 'user', ?)`,
+      [sessionId, createdAt],
+    );
+
+    await migrate(db, migrations);
+
+    const rows = await db.select<Record<string, unknown>>('SELECT * FROM pr_review_drafts');
+    expect(rows).toEqual([
+      {
+        id: 'd-0',
+        session_id: sessionId,
+        provider: 'gitlab',
+        repo: 'goodboy/desktop',
+        pr_number: 7,
+        path: 'src/app.ts',
+        line: 30,
+        start_line: 24,
+        side: 'old',
+        body: 'nit',
+        status: 'published',
+        origin: 'user',
+        created_at: createdAt,
+      },
+    ]);
+  });
+
+  it('keeps every rebuilt index after the three table swaps', async () => {
+    const db = await seedThrough106();
+
+    await migrate(db, migrations);
+
+    const indexes = await db.select<{ name: string }>(
+      "SELECT name FROM sqlite_master WHERE type = 'index' AND sql IS NOT NULL AND tbl_name IN ('workspace_integrations', 'session_external_tasks', 'pr_review_drafts') ORDER BY name",
+    );
+    expect(indexes.map((index) => index.name)).toEqual([
+      'idx_pr_review_drafts_session',
+      'idx_session_external_tasks_identity',
+      'idx_session_external_tasks_provider_external',
+      'idx_workspace_integrations_workspace_id',
+    ]);
+  });
+
+  it('still rejects a provider outside each widened check', async () => {
+    const db = await seedThrough106();
+
+    await migrate(db, migrations);
+
+    await expect(
+      db.execute(
+        `INSERT INTO workspace_integrations (id, workspace_id, provider, config, credential_key, created_at, updated_at)
+         VALUES ('wi-x', ?, 'asana', '{}', 'k', ?, ?)`,
+        [workspaceId, Date.now(), Date.now()],
+      ),
+    ).rejects.toThrow(/CHECK constraint/);
+    await expect(
+      db.execute(
+        `INSERT INTO pr_review_drafts
+           (id, session_id, provider, repo, pr_number, path, line, side, body, created_at)
+         VALUES ('d-x', ?, 'gitea', 'goodboy/desktop', 1, 'a.ts', 1, 'new', 'x', ?)`,
+        [sessionId, new Date().toISOString()],
+      ),
+    ).rejects.toThrow(/CHECK constraint/);
+  });
+});

--- a/packages/db/src/migrations/m107-integration-bitbucket-provider.ts
+++ b/packages/db/src/migrations/m107-integration-bitbucket-provider.ts
@@ -1,0 +1,96 @@
+export const m107IntegrationBitbucketProvider = /* sql */ `
+PRAGMA foreign_keys = OFF;
+
+DROP TABLE IF EXISTS workspace_integrations_new;
+
+CREATE TABLE workspace_integrations_new (
+  id TEXT PRIMARY KEY,
+  workspace_id TEXT NOT NULL,
+  provider TEXT NOT NULL CHECK (provider IN ('linear', 'sentry', 'gitlab', 'jira', 'bitbucket')),
+  config TEXT NOT NULL DEFAULT '{}',
+  credential_key TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  UNIQUE (workspace_id, provider),
+  FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE
+);
+
+INSERT INTO workspace_integrations_new (id, workspace_id, provider, config, credential_key, created_at, updated_at)
+  SELECT id, workspace_id, provider, config, credential_key, created_at, updated_at
+  FROM workspace_integrations;
+
+DROP TABLE workspace_integrations;
+ALTER TABLE workspace_integrations_new RENAME TO workspace_integrations;
+
+DROP INDEX IF EXISTS idx_workspace_integrations_workspace_id;
+CREATE INDEX idx_workspace_integrations_workspace_id ON workspace_integrations(workspace_id);
+
+DROP TABLE IF EXISTS session_external_tasks_new;
+
+CREATE TABLE session_external_tasks_new (
+  session_id TEXT NOT NULL,
+  mount_workspace_id TEXT,
+  provider TEXT NOT NULL CHECK (provider IN ('linear', 'sentry', 'gitlab', 'github', 'jira', 'bitbucket')),
+  external_id TEXT NOT NULL,
+  identifier TEXT NOT NULL,
+  url TEXT NOT NULL,
+  title TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  branch TEXT,
+  FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+);
+
+INSERT INTO session_external_tasks_new
+  (session_id, mount_workspace_id, provider, external_id, identifier, url, title, created_at, branch)
+  SELECT session_id, mount_workspace_id, provider, external_id, identifier, url, title, created_at, branch
+  FROM session_external_tasks;
+
+DROP TABLE session_external_tasks;
+ALTER TABLE session_external_tasks_new RENAME TO session_external_tasks;
+
+DROP INDEX IF EXISTS idx_session_external_tasks_provider_external;
+CREATE INDEX idx_session_external_tasks_provider_external
+  ON session_external_tasks(provider, external_id);
+DROP INDEX IF EXISTS idx_session_external_tasks_identity;
+CREATE UNIQUE INDEX idx_session_external_tasks_identity
+  ON session_external_tasks(
+    session_id,
+    provider,
+    external_id,
+    COALESCE(mount_workspace_id, '')
+  );
+
+DROP TABLE IF EXISTS pr_review_drafts_new;
+
+CREATE TABLE pr_review_drafts_new (
+  id TEXT PRIMARY KEY,
+  session_id TEXT NOT NULL,
+  provider TEXT NOT NULL CHECK (provider IN ('github', 'gitlab', 'bitbucket')),
+  repo TEXT NOT NULL,
+  pr_number INTEGER NOT NULL,
+  path TEXT NOT NULL,
+  line INTEGER NOT NULL,
+  start_line INTEGER,
+  side TEXT NOT NULL DEFAULT 'new',
+  body TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'draft',
+  origin TEXT NOT NULL DEFAULT 'agent',
+  created_at TEXT NOT NULL,
+  FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+);
+
+INSERT INTO pr_review_drafts_new
+  (id, session_id, provider, repo, pr_number, path, line, start_line, side, body, status, origin, created_at)
+  SELECT id, session_id, provider, repo, pr_number, path, line, start_line, side, body, status, origin, created_at
+  FROM pr_review_drafts;
+
+DROP TABLE pr_review_drafts;
+ALTER TABLE pr_review_drafts_new RENAME TO pr_review_drafts;
+
+DROP INDEX IF EXISTS idx_pr_review_drafts_session;
+CREATE INDEX idx_pr_review_drafts_session
+  ON pr_review_drafts(session_id);
+
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys = ON;
+`;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -24,6 +24,8 @@ export type {
 export type { FileVersion, FileVersionChangeKind, FileVersionSnapshotSource } from './file-version';
 export type { OpenQuestion, OpenQuestionStatus } from './open-question';
 export type {
+  BitbucketIntegrationConfig,
+  BitbucketWorkspaceIntegration,
   ContextSlot,
   ContextSlotAuthor,
   ContextSlotHistoryEntry,

--- a/packages/types/src/workspace.ts
+++ b/packages/types/src/workspace.ts
@@ -149,7 +149,7 @@ export type WorkspaceScript = Readonly<{
   updatedAt: IsoDateTime;
 }>;
 
-export type WorkspaceIntegrationProvider = 'linear' | 'sentry' | 'gitlab' | 'jira';
+export type WorkspaceIntegrationProvider = 'linear' | 'sentry' | 'gitlab' | 'jira' | 'bitbucket';
 
 export type LinearIntegrationConfig = Readonly<{
   workspaceUrlKey: string;
@@ -178,11 +178,20 @@ export type JiraIntegrationConfig = Readonly<{
   displayName?: string;
 }>;
 
+export type BitbucketIntegrationConfig = Readonly<{
+  workspaceSlug: string;
+  email: string;
+  workspaceName?: string;
+  accountId?: string;
+  displayName?: string;
+}>;
+
 export type WorkspaceIntegrationConfig =
   | LinearIntegrationConfig
   | SentryIntegrationConfig
   | GitlabIntegrationConfig
-  | JiraIntegrationConfig;
+  | JiraIntegrationConfig
+  | BitbucketIntegrationConfig;
 
 type WorkspaceIntegrationBase = Readonly<{
   id: WorkspaceIntegrationId;
@@ -216,11 +225,18 @@ export type JiraWorkspaceIntegration = WorkspaceIntegrationBase &
     config: JiraIntegrationConfig;
   }>;
 
+export type BitbucketWorkspaceIntegration = WorkspaceIntegrationBase &
+  Readonly<{
+    provider: 'bitbucket';
+    config: BitbucketIntegrationConfig;
+  }>;
+
 export type WorkspaceIntegration =
   | LinearWorkspaceIntegration
   | SentryWorkspaceIntegration
   | GitlabWorkspaceIntegration
-  | JiraWorkspaceIntegration;
+  | JiraWorkspaceIntegration
+  | BitbucketWorkspaceIntegration;
 
 export type SessionExternalTaskProvider = 'linear' | 'sentry' | 'gitlab' | 'github' | 'jira';
 


### PR DESCRIPTION
## What

The Bitbucket Cloud backend for v0.1.64: a Rust command surface over the Bitbucket Cloud REST 2.0
API, the workspace-integration types, migration m107, the TypeScript client, and the connect
lifecycle (form body, store slices, onboarding step). The pull request inbox, the diff surface and
the review verbs have no screen yet: the two later items in this release build them on top of what
lands here, and neither of them touches `bitbucket.rs` or `client.ts` again.

### Files

- `apps/desktop/src-tauri/src/bitbucket.rs` (new, 40 inline network-free tests)
- `apps/desktop/src-tauri/src/lib.rs` (module, token cache, `.manage()`, `generate_handler!`)
- `apps/desktop/src/features/integrations/bitbucket/` (new: `client.ts`, `BitbucketFormBody.tsx`,
  `normalizeWorkspaceSlug.ts`, three test files)
- `apps/desktop/src/store/slices/integrations/` (`connectBitbucket.ts`, `disconnectBitbucket.ts`,
  `configFromBitbucketConnection.ts`, wired in `index.ts` and `store/store.ts`)
- `packages/db/src/migrations/m107-integration-bitbucket-provider.ts` (new) and its test
- `packages/types/src/workspace.ts`, `packages/types/src/index.ts`
- the manual-checklist touchpoints listed below

### Why it looks the way it does

`gitlab.rs` is the template, not `github.rs`: `github.rs` shells out to the `gh` CLI and Bitbucket
has no CLI. Auth is `reqwest`'s `.basic_auth(email, Some(api_token))`, no hand-rolled base64.

Two deliberate divergences from the `gitlab.rs` template, both load-bearing:

1. `get_json_optional` maps **404 only** to `None`. `gitlab.rs:106` maps 404 and 403 together,
   which makes a token missing a scope indistinguishable from an endpoint that does not exist.
   That behaviour is not inherited here. A 403 becomes an `Auth` error with the credential hint.
2. Pagination is body-based. Bitbucket returns `{ values, page, pagelen, size, next?, previous? }`
   with `next` as a full absolute url, so `get_json_paged`'s `x-next-page` header walk is unusable.
   The replacement is a `Pager` that follows `next` directly, caps at `MAX_PAGES = 20`, and returns
   an explicit `InvalidShape` error when a `next` url repeats rather than silently collecting twenty
   pages of duplicates. The envelope struct models only `values` and `next`, so the counters
   Bitbucket sends alongside them cannot break deserialization.

The PR diff endpoint returns raw unified-diff text, not JSON, so it gets its own `get_text` helper
returning `String`. There is no `assemble_mr_diff` equivalent to write: `parseUnifiedDiff` in
`packages/core/src/github/diff.ts` consumes that text as is. The client is
`reqwest::Client::new()`, whose default redirect policy is `limited(10)`, so the 302 to a signed url
is followed; `reqwest` strips `Authorization` on a cross-host redirect, which is what a pre-signed
url wants.

`bitbucket_pull_request_for_branch` sends the documented `q=source.branch.name="..."` server-side
filter **and** re-checks the source branch name on the values that come back. If the `q` syntax is
ever ignored rather than rejected, the command returns nothing instead of the wrong pull request.

## Tauri command checklist

Every command below is present in `generate_handler![...]` in `apps/desktop/src-tauri/src/lib.rs`
(lines 315 to 331). Checked one by one against the file, because a command missing from that list
fails at runtime, not at compile time.

| Command | Method and endpoint |
| --- | --- |
| `bitbucket_validate_connection` | `GET /2.0/user` then `GET /2.0/workspaces/{workspace}` |
| `bitbucket_connect` | keychain set, no network |
| `bitbucket_disconnect` | keychain clear, no network |
| `bitbucket_list_pull_requests` | `GET /2.0/repositories/{ws}/{repo}/pullrequests?state=…`, paged |
| `bitbucket_get_pull_request` | `GET …/pullrequests/{id}` |
| `bitbucket_pull_request_diff` | `GET …/pullrequests/{id}/diff`, raw text |
| `bitbucket_list_pull_request_comments` | `GET …/pullrequests/{id}/comments`, paged |
| `bitbucket_list_pull_request_statuses` | `GET …/pullrequests/{id}/statuses`, paged |
| `bitbucket_pull_request_for_branch` | `GET …/pullrequests?state=OPEN&q=source.branch.name="…"`, paged |
| `bitbucket_approve_pull_request` | `POST …/pullrequests/{id}/approve` |
| `bitbucket_unapprove_pull_request` | `DELETE …/pullrequests/{id}/approve` |
| `bitbucket_request_changes` | `POST …/pullrequests/{id}/request-changes` |
| `bitbucket_unrequest_changes` | `DELETE …/pullrequests/{id}/request-changes` |
| `bitbucket_merge_pull_request` | `POST …/pullrequests/{id}/merge` |
| `bitbucket_decline_pull_request` | `POST …/pullrequests/{id}/decline` |
| `bitbucket_create_pull_request_comment` | `POST …/pullrequests/{id}/comments` |
| `bitbucket_reply_to_pull_request_comment` | `POST …/pullrequests/{id}/comments` with `parent.id` |

`bitbucket_validate_connection` runs two probes on purpose. `GET /2.0/user` proves the credential
pair and nothing else: it answers for any valid account, including one that has never heard of the
workspace slug the user typed. The second probe is what proves the slug. A wrong slug therefore
gets its own message naming where the slug lives in a repository url, not a generic auth failure.

The merge payload never pins `merge_strategy`. Bitbucket applies the repository's configured
default, so a repository restricted to squash-only merges works; a hardcoded `merge_commit` would
400 on it. `close_source_branch` and `message` are optional and only appear in the body when the
caller supplies them.

## Migration m107

One file, three CHECK rebuilds, each a full `PRAGMA foreign_keys = OFF` to `CREATE TABLE _new` to
`INSERT SELECT` to `DROP` and `RENAME` to index recreation to `PRAGMA foreign_key_check` to
`PRAGMA foreign_keys = ON` cycle, because SQLite cannot drop a CHECK.

- `workspace_integrations.provider`: `('linear','sentry','gitlab','jira')` gains `'bitbucket'`.
  `UNIQUE (workspace_id, provider)`, the cascade to `workspaces` and
  `idx_workspace_integrations_workspace_id` are all recreated.
- `session_external_tasks.provider`: `('linear','sentry','gitlab','github','jira')` gains
  `'bitbucket'`. Template is m105, so `mount_workspace_id` and `branch` are both declared and both
  named explicitly in the `INSERT ... SELECT`.
  `idx_session_external_tasks_provider_external` and the unique
  `idx_session_external_tasks_identity` are recreated.
- `pr_review_drafts.provider`: `('github','gitlab')` gains `'bitbucket'`. This table was created by
  m075 and had never been widened since, Jira included. All thirteen columns are named explicitly in
  the `INSERT ... SELECT` and `idx_pr_review_drafts_session` is recreated. A test seeds a row with
  every nullable column populated, migrates, and asserts the whole row survives.

**The database is deliberately ahead of the types.** m107 widens the `session_external_tasks`
CHECK now, but the TypeScript `SessionExternalTaskProvider` union is untouched here and is widened
in the next PR. Doing it in this order means the next PR can never ship a provider value the
database rejects. `connection.ts`, `issueSources.ts`, `fetchIssueCandidates.ts`,
`parseIntegrationTaskUrl.ts`, `LensKind` and `PrPane.tsx` are all left alone for the same reason.

`RemoteHostKind` is also untouched. Adding `'bitbucket'` there breaks a `never`-checked exhaustive
switch and `remoteHost.test.ts:24-26`, which asserts `bitbucket.org` classifies as `'other'`.
Git-remote auto-detection is not a goal of this release: connecting is the only discovery path.

## The manual checklist, because tsc catches nothing here

Widening `WorkspaceIntegrationProvider` produces zero type errors anywhere in the app. Every
provider surface below is an independently hand-written literal union or record that never
references the shared type by name, so a grep for the shared union finds none of them. Each was
edited by hand and read back on the rendered surface:

- [x] `features/integrations/ConnectIntegrationEmptyState.tsx`: local `provider` union, its
      `PROVIDER_DESCRIPTIONS` entry, and the branch that mounts `BitbucketFormBody`
- [x] `features/integrations/components/IntegrationGlyph/index.tsx`: `IntegrationGlyphProvider`
      union and the `INTEGRATION_BRAND` entry
- [x] `shared/components/brand-icons.tsx`: a real Bitbucket brand glyph, same bar as the Jira glyph
      shipped in v0.1.63, not a generic icon
- [x] `shared/components/conceptIcons.ts`: `CONCEPT_ICONS.bitbucket`, consumed by
      `IntegrationConnectPanel`. This one is missing from every previous host's checklist
- [x] `shared/components/conceptIcons.ts`: `CONCEPT_TONE.bitbucket`. The only entry in this list
      `tsc` did catch, because `CONCEPT_TONE` is `satisfies Record<Concept, Tone>`
- [x] `styles.css`: `--color-provider-bitbucket` in both palettes, `#4c9aff` in the `@theme` dark
      block and `#0747a6` in `html[data-theme='light']`, the same light-to-dark relationship
      `--color-provider-jira` has
- [x] `features/onboarding/hooks/useOnboardingProgress/index.ts`: the `codeHost` step gate was
      `gitlabConnected || githubScoped`, so a Bitbucket-only workspace could never finish onboarding
- [x] `features/onboarding/OnboardingWizard/useOnboardingWizard/index.ts`: `hasCodeHost` and the new
      `bitbucketConnected` flag
- [x] `features/onboarding/OnboardingWizard/steps/CodeHostStep.tsx`: the segmented toggle is now
      three-way. The two form bodies were rendered inline from a ternary, which does not extend to
      three branches, so they moved to a `CodeHostForm` sibling with an exhaustive `switch`
- [x] `store/slices/integrations/index.ts` and `store/store.ts`: the two new actions, on Jira's
      object-param shape rather than GitLab's positional one

`BitbucketFormBody` is built on the `JiraFormBody` skeleton, including the detail that its
normalizer runs inline on every render rather than on blur. Replicated knowingly, matched here by
`normalizeWorkspaceSlug`, which also reduces a pasted repository url down to the workspace slug.

## The write-builder test pattern, and the sabotages that prove it

Every mutating command's url, http method and body construction lives in a pure builder
returning a `BitbucketWrite { method, url, body }`. The `#[tauri::command]` is plumbing that calls
the builder and sends exactly what it decided. Tests call the builder and assert hardcoded expected
values, never a reconstruction of the `json!` literal the command builds. That was the failure mode
in v0.1.63's first Jira attempt: four write tests re-declared the same expression the command built
inline, and all four survived sabotage.

The method started out chosen inline at each call site rather than by the builder, which left one
verb flip, `unapprove` sending POST instead of DELETE, compiling clean and passing every test. It
now lives in the builder, `unapprove` and `unrequest-changes` have their own builders beside
`approve` and `request-changes`, and all eight write verbs are pinned.

Each builder was sabotaged, the suite re-run, and the sabotage reverted. Baseline is 40 passing.

| Builder | Sabotage applied | Result |
| --- | --- | --- |
| `approve_write` | url segment `/approve` to `/approvals`; method POST to PUT | 1 failed each |
| `unapprove_write` | method DELETE to POST | 1 failed |
| `request_changes_write` | url segment `/request-changes` to `/request_changes` | 1 failed |
| `unrequest_changes_write` | method DELETE to POST | 1 failed |
| `decline_write` | url segment `/decline` to `/reject` | 1 failed |
| `merge_write` | hardcoded `"merge_strategy": "merge_commit"`; renamed `close_source_branch`; renamed `message` | 1 failed each |
| `comment_write` | body flattened to `{"body":text}`; url `/comments` to `/comment` | 1 failed each |
| `reply_write` | `"parent":{"id":n}` flattened to `"parent_id":n`; `content.raw` to `text`; url to `/comments/reply` | 1 failed each |
| `reads_as_absent` | made 403 read as absent, the `gitlab.rs:106` bug | 1 failed |
| `Pager` | removed the repeated-url bail; raised the page cap; stopped following `next`; treated a blank `next` as a url | 1 to 2 failed each |

Restored, 40 passed.

Three seams remain unpinned by tests, all of them async glue that cannot be exercised without an
http harness, and all of them verified by reading instead. Sabotaging any of the three leaves the
suite green, so they are listed here rather than claimed as covered:

- the `#[tauri::command]` wrappers themselves. Each is a two-line delegation to its builder, but a
  wrapper that ignored its builder and rebuilt the url inline and wrong would not fail anything.
  Moving the method into the builder shrinks this seam; it does not close it.
- `get_json_paged`'s loop, which feeds the pager's `next` back in as the following url. The `Pager`
  is pinned; the code that drives it is not. A version that dropped `next` and returned only the
  first page would pass.
- `get_json_optional`'s status handling. `reads_as_absent` is now pinned, but the call that routes a
  response through it is not. The other tests are network-free deserialization tests against fixture JSON
shaped from the Bitbucket documentation, plus four pager tests: follow, stop, the repeated-`next`
bail, and the `MAX_PAGES` cap firing while `next` keeps arriving.

## Unverified against a live tenant

There is no Bitbucket workspace to test against. Every Bitbucket call in this PR is contract-tested
against fixture payloads shaped from Atlassian's documentation. **None of them has ever been sent to
a real tenant.** Green tests here mean the url building, the serde parsing, the pagination folding
and the error mapping agree with the documented contracts. They do not mean a single byte has
reached bitbucket.org.

Named uncertainties, worst first:

- **The auth scheme.** HTTP Basic with the account email as username and an Atlassian API token as
  password is Atlassian's stated direction while it deprecates Bitbucket app passwords, but whether
  every scope this PR needs accepts the unified token today is unconfirmed. Getting it wrong is a
  silent 401 on every single call for every user, with nothing in the app to distinguish "wrong
  secret type" from "wrong secret". That is why the 401 and 403 message names both schemes
  explicitly, says which field each goes in, and lists the three scopes, so a user can self-diagnose
  without a support round trip. The form body says the same thing in its own copy.
- **`POST .../pullrequests/{id}/request-changes` and its `DELETE`.** Less certain than `approve`,
  both in path spelling and in whether the verb pair is symmetric. Implemented as the mirror of
  `approve` on the assumption that it is. If the path is wrong the failure is loud, a 404 with the
  url in the message, not silent.
- **`q=source.branch.name="..."`.** If Bitbucket rejects the syntax the result is a 400, which
  surfaces. If it silently ignores it, the client-side branch re-check returns `None` rather than
  the wrong pull request. Either way it fails visibly, never wrongly.
- **Every read endpoint's real response shape**, in particular the pull request list. If the
  envelope or the field names differ from the documentation, the inbox the next PR builds is
  empty at runtime and every test in this PR still passes. Nothing here can catch that.
- **The merge response.** `POST .../merge` is assumed to return the updated pull request object.
  If it returns a task or a 202 instead, the command errors with `InvalidShape`.
- **The diff redirect.** The 302 to a signed url is assumed to be followed correctly with the
  `Authorization` header dropped cross-host. Untested against the real signer.

## Test plan

- `pnpm typecheck`: 5 tasks, all passing
- `pnpm test`: 4565 desktop, 1052 core, 188 db (m107 plus the migration convergence suite), 100 ui,
  all passing
- `pnpm knip --include files,duplicates,unlisted`: clean, only the six pre-existing configuration
  hints already on main
- `cargo test --locked` from `apps/desktop/src-tauri`: 305 passed, 2 ignored, of which 40 are the
  new `bitbucket::tests`
- eighteen sabotages across the eight write builders, the pager and the status mapping,
  each performed and reverted, table above
- not covered: any call reaching bitbucket.org

