### PR TITLE
fix(desktop): close the two provider switches bitbucket left open

### DIFF
--- a/apps/desktop/src/features/companion/commandExecutor.ts
+++ b/apps/desktop/src/features/companion/commandExecutor.ts
@@ -244,6 +244,7 @@ async function fetchIssuesFor(
         return (await gitlabFetchAssignedIssues(workspaceId, host)).map(normalizeGitlab);
       }
       case 'jira':
+      case 'bitbucket':
         return [];
       default: {
         const unexpected: never = provider;
@@ -349,6 +350,8 @@ async function resolveIssueForSession(
     }
     case 'jira':
       throw new BridgeSafeError(`jira issue creation is not available from mobile: ${identifier}`);
+    case 'bitbucket':
+      throw new BridgeSafeError(`bitbucket does not expose issues to Goodboy: ${identifier}`);
     default: {
       const unexpected: never = provider;
       throw new BridgeSafeError(`unsupported issue provider: ${String(unexpected)}`);


### PR DESCRIPTION
## What

`WorkspaceIntegrationProvider` gained `bitbucket` in #1241 while #1240 was converting the two companion issue paths to exhaustive switches. Both PRs were green on their own branch. Together they leave `main` red:

```
src/features/companion/commandExecutor.ts(249,15): error TS2322: Type '"bitbucket"' is not assignable to type 'never'
src/features/companion/commandExecutor.ts(353,13): error TS2322: Type '"bitbucket"' is not assignable to type 'never'
```

Both the `ci` and the `rust` workflow fail on it, since the rust job builds the frontend.

## The fix

Give both switches a `bitbucket` arm, matching what `jira` already does. Bitbucket has no issue surface Goodboy reads, so `fetchIssuesFor` returns nothing and `resolveIssueForSession` refuses with a message naming the provider.

This is the exhaustive switch doing its job. Before #1240 those functions were `if` chains that fell through to GitLab, so the same omission would have shipped a silent wrong-host query instead of a build failure.

## Test plan

- `pnpm typecheck` clean
- `pnpm test` green
