### PR TITLE
feat(desktop): read and route slack threads from the studio and the session lens

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -35,6 +35,7 @@ import { LinearStudio } from './features/integrations/linear/LinearStudio';
 import { SentryStudio } from './features/integrations/sentry/SentryStudio';
 import { GitlabStudio } from './features/integrations/gitlab/GitlabStudio';
 import { JiraStudio } from './features/integrations/jira/JiraStudio';
+import { SlackStudio } from './features/integrations/slack/SlackStudio';
 import { ProviderStudio } from './features/providers/components/ProviderStudio';
 import { BudgetStudio } from './features/budget/components/BudgetStudio';
 import type { BudgetScope } from './features/budget/components/BudgetStudio/lib';
@@ -108,6 +109,11 @@ export const App = () => {
       (i) => i.provider === 'gitlab',
     ),
   );
+  const hasSlack = useAppStore((s) =>
+    (s.workspaceIntegrations?.[currentWorkspace?.id ?? ('' as WorkspaceId)] ?? []).some(
+      (i) => i.provider === 'slack',
+    ),
+  );
   const [companionOpen, setCompanionOpen] = useState(false);
   const [appSettingsOpen, setAppSettingsOpen] = useState(false);
   const [appSettingsFocus, setAppSettingsFocus] = useState<string | undefined>(undefined);
@@ -131,6 +137,8 @@ export const App = () => {
   const [gitlabStudioFocus, setGitlabStudioFocus] = useState<string | null>(null);
   const [jiraStudioOpen, setJiraStudioOpen] = useState(false);
   const [jiraStudioFocus, setJiraStudioFocus] = useState<string | null>(null);
+  const [slackStudioOpen, setSlackStudioOpen] = useState(false);
+  const [slackStudioFocus, setSlackStudioFocus] = useState<string | null>(null);
   const [providerStudioOpen, setProviderStudioOpen] = useState(false);
   const [providerStudioFocus, setProviderStudioFocus] = useState<ProviderId | null>(null);
   const [providerStudioAction, setProviderStudioAction] = useState<ProviderLifecycleAction | null>(
@@ -169,6 +177,7 @@ export const App = () => {
     setSentryStudioOpen(false);
     setGitlabStudioOpen(false);
     setJiraStudioOpen(false);
+    setSlackStudioOpen(false);
     setAppSettingsOpen(false);
     setGuideStudioOpen(false);
     setAddWorkspaceOpen(false);
@@ -487,11 +496,13 @@ export const App = () => {
                       ? 'gitlab'
                       : jiraStudioOpen
                         ? 'jira'
-                        : appSettingsOpen
-                          ? 'settings'
-                          : guideStudioOpen
-                            ? 'guide'
-                            : null;
+                        : slackStudioOpen
+                          ? 'slack'
+                          : appSettingsOpen
+                            ? 'settings'
+                            : guideStudioOpen
+                              ? 'guide'
+                              : null;
 
   const openSettings = useCallback(() => {
     closeAllStudios();
@@ -691,6 +702,7 @@ export const App = () => {
   useShortcut('lens.sentry', () => goToLens('sentry'));
   useShortcut('lens.gitlab_issues', () => goToLens('gitlab_issues'));
   useShortcut('lens.jira_issues', () => goToLens('jira_issues'));
+  useShortcut('lens.slack_threads', () => goToLens('slack_threads'));
 
   const renderedSessionIds = useMemo<ReadonlyArray<SessionId>>(() => {
     const cid = currentSession?.id ?? null;
@@ -762,6 +774,7 @@ export const App = () => {
                 jiraEnabled={hasJira}
                 sentryEnabled={hasSentry}
                 gitlabEnabled={hasGitlab}
+                slackEnabled={hasSlack}
                 onOpenWorkflows={() => {
                   closeAllStudios();
                   setWorkflowStudioOpen(true);
@@ -800,6 +813,11 @@ export const App = () => {
                   closeAllStudios();
                   setGitlabStudioFocus(null);
                   setGitlabStudioOpen(true);
+                }}
+                onOpenSlack={() => {
+                  closeAllStudios();
+                  setSlackStudioFocus(null);
+                  setSlackStudioOpen(true);
                 }}
               />
             ) : undefined
@@ -999,6 +1017,14 @@ export const App = () => {
           workspaceName={currentWorkspace.name}
           initialIssueId={jiraStudioFocus}
           onClose={() => setJiraStudioOpen(false)}
+        />
+      ) : null}
+      {slackStudioOpen && currentWorkspace ? (
+        <SlackStudio
+          workspaceId={currentWorkspace.id}
+          workspaceName={currentWorkspace.name}
+          initialThreadTs={slackStudioFocus}
+          onClose={() => setSlackStudioOpen(false)}
         />
       ) : null}
       {commitDiff ? (

--- a/apps/desktop/src/__tests__/keyboard/lens-shortcuts.test.tsx
+++ b/apps/desktop/src/__tests__/keyboard/lens-shortcuts.test.tsx
@@ -229,12 +229,14 @@ describe('App lens shortcuts', () => {
     press({ code: 'Digit2', key: '2', metaKey: true, altKey: true });
     press({ code: 'Digit3', key: '3', metaKey: true, altKey: true });
     press({ code: 'Digit4', key: '4', metaKey: true, altKey: true });
+    press({ code: 'Digit6', key: '6', metaKey: true, altKey: true });
 
     expect(setActiveLens.mock.calls).toEqual([
       ['session-1', 'review'],
       ['session-1', 'linear'],
       ['session-1', 'sentry'],
       ['session-1', 'gitlab_issues'],
+      ['session-1', 'slack_threads'],
     ]);
   });
 

--- a/apps/desktop/src/__tests__/slack-studio-reachability.test.tsx
+++ b/apps/desktop/src/__tests__/slack-studio-reachability.test.tsx
@@ -1,0 +1,191 @@
+// @vitest-environment happy-dom
+
+import type { ReactNode } from 'react';
+import { useEffect } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+
+const { state, workspace } = vi.hoisted(() => {
+  const currentWorkspace = {
+    id: 'workspace-1',
+    name: 'Workspace',
+    rootPath: '/repo',
+    kind: 'repo' as const,
+  };
+  return {
+    workspace: currentWorkspace,
+    state: {
+      hydrate: vi.fn(async () => undefined),
+      checkForUpdates: vi.fn(async () => undefined),
+      hydrated: true,
+      bootPhase: 'ready' as const,
+      error: null,
+      workspaceIntegrations: {} as Record<string, ReadonlyArray<{ provider: string }>>,
+      workspaces: [currentWorkspace],
+      sessions: [] as ReadonlyArray<{ id: string; workspaceId: string }>,
+      sessionMounts: {},
+      sessionActiveMount: {},
+      sessionBranches: {} as Record<string, string>,
+      setSessionStudio: vi.fn(),
+      openWorkspace: vi.fn(),
+      setCurrentSession: vi.fn(),
+      lensGo: vi.fn(),
+      currentWorkspaceId: 'workspace-1' as string | null,
+      currentSessionId: null as string | null,
+      activeLens: {} as Record<string, string | null>,
+      selectedAgentId: {} as Record<string, string | null>,
+      setActiveLens: vi.fn(),
+      sessionWorktrees: {},
+      providers: [] as ReadonlyArray<{ connection: string }>,
+    },
+  };
+});
+
+type ShellProps = {
+  readonly footer?: ReactNode;
+};
+
+vi.mock('@goodboy/ui', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@goodboy/ui')>();
+  return { ...actual, AppShell: ({ footer }: ShellProps) => <div>{footer}</div> };
+});
+
+type FooterProps = {
+  readonly onOpenSlack: () => void;
+  readonly slackEnabled: boolean;
+};
+
+vi.mock('../app/components/AppFooter', () => ({
+  AppFooter: ({ onOpenSlack, slackEnabled }: FooterProps) => (
+    <button type="button" onClick={onOpenSlack}>
+      {slackEnabled ? 'Launch a session from a Slack thread' : 'Connect Slack'}
+    </button>
+  ),
+}));
+
+vi.mock('../features/integrations/slack/SlackStudio', () => ({
+  SlackStudio: ({ workspaceName }: { workspaceName: string }) => (
+    <div data-testid="slack-studio">{workspaceName}</div>
+  ),
+}));
+
+vi.mock('../features/session/components/CommandPalette', () => ({ CommandPalette: () => null }));
+vi.mock('../app/components/BootSplash', () => ({
+  BootSplash: ({ onFinished }: { onFinished: () => void }) => {
+    useEffect(() => {
+      onFinished();
+    }, [onFinished]);
+    return null;
+  },
+}));
+vi.mock('../app/components/KeepAliveWorkSurface', () => ({ KeepAliveWorkSurface: () => null }));
+vi.mock('../app/components/AppTopBar', () => ({ AppTopBar: () => null }));
+vi.mock('../app/components/AppEmptyState', () => ({ NoWorkspaceScreen: () => null }));
+vi.mock('../features/workspace/components/StageBoard', () => ({ StageBoard: () => null }));
+vi.mock('../features/session/components/DeleteSessionConfirm', () => ({
+  DeleteSessionConfirm: () => null,
+}));
+vi.mock('../features/session/components/ArchiveSessionConfirm', () => ({
+  ArchiveSessionConfirm: () => null,
+}));
+vi.mock('../features/settings/components/SettingsStudio', () => ({ SettingsStudio: () => null }));
+vi.mock('../features/settings/components/GuideStudio', () => ({ GuideStudio: () => null }));
+vi.mock('../features/workspace/components/WorkspaceSettingsPane', () => ({
+  WorkspaceSettingsPane: () => null,
+}));
+vi.mock('../app/components/Toast', () => ({
+  ToastProvider: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+vi.mock('../features/notifications/components/NotificationToastBridge', () => ({
+  NotificationToastBridge: () => null,
+}));
+vi.mock('../features/workspace/components/WorkspacesSidebar', () => ({
+  WorkspacesSidebar: () => null,
+}));
+vi.mock('../features/workspace/hooks/useWindowPresence', () => ({ useWindowPresence: vi.fn() }));
+vi.mock('../features/workspace/components/WorkspaceLinkDialog', () => ({
+  WorkspaceLinkDialog: () => null,
+}));
+vi.mock('../features/workspace/components/WorkspaceLauncher', () => ({
+  WorkspaceLauncher: () => null,
+}));
+vi.mock('../features/workspace/components/WorkspaceSwitcher', () => ({
+  WorkspaceSwitcher: () => null,
+}));
+vi.mock('../features/workspace/window', () => ({ isMainWindow: () => true }));
+vi.mock('../features/workflows/components/WorkflowStudio', () => ({ WorkflowStudio: () => null }));
+vi.mock('../features/session/components/NewSessionView', () => ({ NewSessionView: () => null }));
+vi.mock('../features/github/components/GitHubStudio', () => ({ GitHubStudio: () => null }));
+vi.mock('../features/integrations/linear/LinearStudio', () => ({ LinearStudio: () => null }));
+vi.mock('../features/integrations/sentry/SentryStudio', () => ({ SentryStudio: () => null }));
+vi.mock('../features/integrations/gitlab/GitlabStudio', () => ({ GitlabStudio: () => null }));
+vi.mock('../features/integrations/jira/JiraStudio', () => ({ JiraStudio: () => null }));
+vi.mock('../features/providers/components/ProviderStudio', () => ({ ProviderStudio: () => null }));
+vi.mock('../features/budget/components/BudgetStudio', () => ({ BudgetStudio: () => null }));
+vi.mock('../features/permissions/components/DiffViewerDialog', () => ({
+  DiffViewerDialog: () => null,
+}));
+vi.mock('../features/github/github', () => ({ ghCommitDiff: vi.fn() }));
+vi.mock('../features/worktree/worktree', () => ({ worktreeDiffCommit: vi.fn() }));
+vi.mock('../features/onboarding/OnboardingCard', () => ({ OnboardingCard: () => null }));
+vi.mock('../features/onboarding/OnboardingWizard', () => ({ OnboardingWizard: () => null }));
+vi.mock('../features/companion/CompanionStudio', () => ({ CompanionStudio: () => null }));
+vi.mock('../features/companion/commandExecutor', () => ({
+  listenBridgeCommands: vi.fn(async () => () => undefined),
+}));
+vi.mock('../features/onboarding/onboarding-store', () => ({ markStepComplete: vi.fn() }));
+vi.mock('../shared/lib/zoom', () => ({
+  applyStoredZoom: vi.fn(async () => undefined),
+  zoomIn: vi.fn(async () => undefined),
+  zoomOut: vi.fn(async () => undefined),
+  zoomReset: vi.fn(async () => undefined),
+}));
+vi.mock('../shared/hooks/useProviderRefreshOnFocus', () => ({
+  useProviderRefreshOnFocus: vi.fn(),
+}));
+vi.mock('../shared/hooks/useCommitLinkInterceptor', () => ({
+  useCommitLinkInterceptor: () => ({ commitDiff: null, setCommitDiff: vi.fn() }),
+}));
+vi.mock('../store', () => {
+  const useAppStore = Object.assign(
+    vi.fn((selector: (store: typeof state) => unknown) => selector(state)),
+    { getState: () => state },
+  );
+  return {
+    useAppStore,
+    useCurrentSession: () => null,
+    useCurrentWorkspace: () => workspace,
+    useSessions: () => state.sessions,
+    useWorkspaces: () => state.workspaces,
+  };
+});
+vi.mock('../features/github/hooks/useGithubPolling', () => ({ useGithubPolling: vi.fn() }));
+vi.mock('../features/updater/hooks/useUpdaterPolling', () => ({ useUpdaterPolling: vi.fn() }));
+
+import { App } from '../App';
+
+beforeEach(() => {
+  state.workspaceIntegrations = {};
+});
+
+afterEach(cleanup);
+
+describe('Slack studio reachability', () => {
+  it('opens the workspace slack studio from the app footer', () => {
+    state.workspaceIntegrations = { 'workspace-1': [{ provider: 'slack' }] };
+    render(<App />);
+
+    expect(screen.queryByTestId('slack-studio')).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'Launch a session from a Slack thread' }));
+
+    expect(screen.getByTestId('slack-studio').textContent).toBe('Workspace');
+  });
+
+  it('still opens the studio when slack is not connected, so the connect form is reachable', () => {
+    render(<App />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Connect Slack' }));
+
+    expect(screen.getByTestId('slack-studio')).toBeDefined();
+  });
+});

--- a/apps/desktop/src/app/components/AppFooter/index.test.tsx
+++ b/apps/desktop/src/app/components/AppFooter/index.test.tsx
@@ -52,11 +52,13 @@ describe('AppFooter', () => {
         onOpenJira={vi.fn()}
         onOpenSentry={vi.fn()}
         onOpenGitlab={vi.fn()}
+        onOpenSlack={vi.fn()}
         githubEnabled={false}
         linearEnabled={false}
         jiraEnabled={false}
         sentryEnabled={false}
         gitlabEnabled={false}
+        slackEnabled={false}
         isSimpleWorkspace={false}
         onConvertToDevProject={vi.fn()}
       />,
@@ -104,11 +106,13 @@ describe('AppFooter', () => {
         onOpenJira={vi.fn()}
         onOpenSentry={vi.fn()}
         onOpenGitlab={vi.fn()}
+        onOpenSlack={vi.fn()}
         githubEnabled={false}
         linearEnabled={false}
         jiraEnabled={false}
         sentryEnabled={false}
         gitlabEnabled={false}
+        slackEnabled={false}
         isSimpleWorkspace={false}
         onConvertToDevProject={vi.fn()}
       />,
@@ -141,11 +145,13 @@ describe('AppFooter', () => {
         onOpenJira={vi.fn()}
         onOpenSentry={vi.fn()}
         onOpenGitlab={onOpenGitlab}
+        onOpenSlack={vi.fn()}
         githubEnabled={false}
         linearEnabled={false}
         jiraEnabled={false}
         sentryEnabled={false}
         gitlabEnabled={false}
+        slackEnabled={false}
         isSimpleWorkspace={false}
         onConvertToDevProject={vi.fn()}
       />,
@@ -156,6 +162,7 @@ describe('AppFooter', () => {
       'gitlab',
       'linear',
       'jira',
+      'slack',
       'sentry',
     ]);
     expect(screen.getByRole('button', { name: 'Connect GitHub' })).toBeDefined();
@@ -163,6 +170,7 @@ describe('AppFooter', () => {
     expect(screen.getByRole('button', { name: 'Connect Linear' })).toBeDefined();
     expect(screen.getByRole('button', { name: 'Connect Jira' })).toBeDefined();
     expect(screen.getByRole('button', { name: 'Connect Sentry' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Connect Slack' })).toBeDefined();
 
     fireEvent.click(screen.getByRole('button', { name: 'Connect GitLab' }));
 
@@ -185,11 +193,13 @@ describe('AppFooter', () => {
         onOpenJira={vi.fn()}
         onOpenSentry={vi.fn()}
         onOpenGitlab={vi.fn()}
+        onOpenSlack={vi.fn()}
         githubEnabled={false}
         linearEnabled={false}
         jiraEnabled={false}
         sentryEnabled={false}
         gitlabEnabled={false}
+        slackEnabled={false}
         isSimpleWorkspace
         onConvertToDevProject={onConvertToDevProject}
       />,
@@ -228,11 +238,13 @@ describe('AppFooter', () => {
         onOpenJira={vi.fn()}
         onOpenSentry={vi.fn()}
         onOpenGitlab={onOpenGitlab}
+        onOpenSlack={vi.fn()}
         githubEnabled={false}
         linearEnabled={false}
         jiraEnabled={false}
         sentryEnabled={false}
         gitlabEnabled
+        slackEnabled={false}
         isSimpleWorkspace={false}
         onConvertToDevProject={vi.fn()}
       />,
@@ -245,5 +257,65 @@ describe('AppFooter', () => {
     );
 
     expect(onOpenGitlab).toHaveBeenCalledOnce();
+  });
+
+  it('offers the Slack studio and says so when Slack is not connected yet', () => {
+    const onOpenSlack = vi.fn();
+    const { rerender } = render(
+      <AppFooter
+        activeStudio={null}
+        onOpenWorkflows={vi.fn()}
+        onOpenProviders={vi.fn()}
+        onOpenBudget={vi.fn()}
+        onOpenImpact={vi.fn()}
+        onOpenChangelog={vi.fn()}
+        onOpenGithub={vi.fn()}
+        onOpenLinear={vi.fn()}
+        onOpenJira={vi.fn()}
+        onOpenSentry={vi.fn()}
+        onOpenGitlab={vi.fn()}
+        onOpenSlack={onOpenSlack}
+        githubEnabled={false}
+        linearEnabled={false}
+        jiraEnabled={false}
+        sentryEnabled={false}
+        gitlabEnabled={false}
+        slackEnabled={false}
+        isSimpleWorkspace={false}
+        onConvertToDevProject={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Connect Slack' }));
+    expect(onOpenSlack).toHaveBeenCalledOnce();
+
+    rerender(
+      <AppFooter
+        activeStudio={null}
+        onOpenWorkflows={vi.fn()}
+        onOpenProviders={vi.fn()}
+        onOpenBudget={vi.fn()}
+        onOpenImpact={vi.fn()}
+        onOpenChangelog={vi.fn()}
+        onOpenGithub={vi.fn()}
+        onOpenLinear={vi.fn()}
+        onOpenJira={vi.fn()}
+        onOpenSentry={vi.fn()}
+        onOpenGitlab={vi.fn()}
+        onOpenSlack={onOpenSlack}
+        githubEnabled={false}
+        linearEnabled={false}
+        jiraEnabled={false}
+        sentryEnabled={false}
+        gitlabEnabled={false}
+        slackEnabled
+        isSimpleWorkspace={false}
+        onConvertToDevProject={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Launch a session from a Slack thread' }),
+    ).toBeDefined();
   });
 });

--- a/apps/desktop/src/app/components/AppFooter/index.tsx
+++ b/apps/desktop/src/app/components/AppFooter/index.tsx
@@ -62,12 +62,14 @@ type Props = {
   onOpenJira: () => void;
   onOpenSentry: () => void;
   onOpenGitlab: () => void;
+  onOpenSlack: () => void;
   onConvertToDevProject: () => void;
   githubEnabled: boolean;
   linearEnabled: boolean;
   jiraEnabled: boolean;
   sentryEnabled: boolean;
   gitlabEnabled: boolean;
+  slackEnabled: boolean;
   isSimpleWorkspace: boolean;
 };
 
@@ -83,12 +85,14 @@ export const AppFooter = ({
   onOpenJira,
   onOpenSentry,
   onOpenGitlab,
+  onOpenSlack,
   onConvertToDevProject,
   githubEnabled,
   linearEnabled,
   jiraEnabled,
   sentryEnabled,
   gitlabEnabled,
+  slackEnabled,
   isSimpleWorkspace,
 }: Props) => {
   const noProviderConnected = useAppStore(
@@ -150,6 +154,14 @@ export const AppFooter = ({
             onClick={onOpenJira}
             active={activeStudio === 'jira'}
             connected={jiraEnabled}
+          />
+          <FooterButton
+            icon={<IntegrationGlyph provider="slack" size="xs" useBrandColor />}
+            label="Slack"
+            title={slackEnabled ? 'Launch a session from a Slack thread' : 'Connect Slack'}
+            onClick={onOpenSlack}
+            active={activeStudio === 'slack'}
+            connected={slackEnabled}
           />
           {isSimpleWorkspace ? null : (
             <FooterButton

--- a/apps/desktop/src/features/integrations/fetchIssueCandidates.ts
+++ b/apps/desktop/src/features/integrations/fetchIssueCandidates.ts
@@ -18,6 +18,7 @@ import { goalFromIssue as goalFromJiraIssue } from './jira/goal-from-issue';
 import { jiraBranchSlug } from './jira/JiraStudio/useJiraIssues';
 import { sentryFetchIssues } from './sentry/client';
 import { goalFromSentry } from './sentry/goal-from-sentry';
+import { slackThreadCandidates } from './slack/slackThreadCandidates';
 
 export type IssueCandidate = {
   readonly provider: SessionExternalTaskProvider;
@@ -126,8 +127,10 @@ export const fetchIssueCandidates = async ({
         branchSlug: slugifyBranch({ input: issue.title, maxLength: SENTRY_SLUG_MAX_LEN }),
       }));
     }
-    case 'bitbucket':
     case 'slack': {
+      return slackThreadCandidates({ workspaceId });
+    }
+    case 'bitbucket': {
       return [];
     }
     default: {

--- a/apps/desktop/src/features/integrations/issueSources.test.ts
+++ b/apps/desktop/src/features/integrations/issueSources.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import type { WorkspaceIntegration, WorkspaceIntegrationProvider } from '@goodboy/types';
+import { resolveIssueSources } from './issueSources';
+
+const integration = (provider: WorkspaceIntegrationProvider): WorkspaceIntegration =>
+  ({ provider }) as WorkspaceIntegration;
+
+describe('resolveIssueSources', () => {
+  it('offers every connected source, slack included', () => {
+    expect(
+      resolveIssueSources({
+        integrations: [integration('slack'), integration('linear')],
+        remoteKind: null,
+        isGithubAuthenticated: false,
+      }).map((source) => source.label),
+    ).toEqual(['Linear', 'Slack']);
+  });
+
+  it('leaves slack out until the workspace connects it', () => {
+    expect(
+      resolveIssueSources({
+        integrations: [integration('linear')],
+        remoteKind: null,
+        isGithubAuthenticated: false,
+      }).map((source) => source.provider),
+    ).toEqual(['linear']);
+  });
+});

--- a/apps/desktop/src/features/integrations/issueSources.ts
+++ b/apps/desktop/src/features/integrations/issueSources.ts
@@ -19,6 +19,7 @@ const SOURCES: ReadonlyArray<IssueSource> = [
   { provider: 'gitlab', label: 'GitLab' },
   { provider: 'jira', label: 'Jira' },
   { provider: 'sentry', label: 'Sentry' },
+  { provider: 'slack', label: 'Slack' },
 ];
 
 export const resolveIssueSources = ({

--- a/apps/desktop/src/features/integrations/slack/SlackStudio/ThreadDetailPanel.test.tsx
+++ b/apps/desktop/src/features/integrations/slack/SlackStudio/ThreadDetailPanel.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment happy-dom
+
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IsoDateTime, WorkspaceId } from '@goodboy/types';
+import type { SlackMessage } from '../client';
+import type { SlackThreadRow } from './useSlackThreads';
+
+const h = vi.hoisted(() => ({
+  messages: [] as ReadonlyArray<SlackMessage>,
+  launch: null as Record<string, unknown> | null,
+}));
+
+vi.mock('../client', () => ({
+  slackGetPermalink: vi.fn(async () => 'https://acme.slack.com/archives/C1/p1723456789123456'),
+}));
+
+vi.mock('../useSlackThread', () => ({
+  useSlackThread: () => ({
+    messages: h.messages,
+    users: [{ id: 'U1', name: 'ada', isBot: false, isDeleted: false, avatarUrl: null }],
+    channels: [],
+    channelName: 'eng-alerts',
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+}));
+
+vi.mock('../../components/LaunchSessionPanel', () => ({
+  LaunchSessionPanel: (props: Record<string, unknown>) => {
+    h.launch = props;
+    return <div data-testid="launch" />;
+  },
+}));
+
+import { ThreadDetailPanel } from './ThreadDetailPanel';
+
+const message = (ts: string, text: string): SlackMessage => ({
+  ts,
+  threadTs: '1723456789.123456',
+  userId: 'U1',
+  botId: null,
+  text,
+  subtype: null,
+  replyCount: 1,
+  replyUserCount: 1,
+  postedAt: '2026-08-05T09:00:00Z' as IsoDateTime,
+  latestReplyAt: '2026-08-05T09:10:00Z' as IsoDateTime,
+  reactions: [],
+});
+
+const ROW: SlackThreadRow = {
+  channel: { id: 'C1', name: 'eng-alerts', isMember: true, topic: null, memberCount: 3 },
+  head: message('1723456789.123456', 'billing webhook fails on retry'),
+  sessionId: null,
+};
+
+beforeEach(() => {
+  h.messages = [];
+  h.launch = null;
+});
+afterEach(cleanup);
+
+describe('ThreadDetailPanel', () => {
+  it('asks for a thread before showing one', () => {
+    render(
+      <ThreadDetailPanel
+        row={null}
+        workspaceId={'workspace-1' as WorkspaceId}
+        sessionId={null}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('No thread selected')).toBeDefined();
+  });
+
+  it('renders the thread messages and hands the launch panel a thread-scoped task', () => {
+    h.messages = [
+      message('1723456789.123456', 'billing webhook fails on retry'),
+      message('1723456999.000100', 'i can *repro* it'),
+    ];
+
+    render(
+      <ThreadDetailPanel
+        row={ROW}
+        workspaceId={'workspace-1' as WorkspaceId}
+        sessionId={null}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('repro')).toBeDefined();
+    expect(h.launch?.externalTask).toMatchObject({
+      provider: 'slack',
+      externalId: 'C1:1723456789.123456',
+      identifier: '#eng-alerts › billing webhook fails on retry',
+      title: 'billing webhook fails on retry',
+    });
+    expect(h.launch?.branchSlugSeed).toBe('billing-webhook-fails-on-retry');
+    expect(String(h.launch?.goalSeed)).toContain('Slack thread in #eng-alerts');
+    expect(String(h.launch?.goalSeed)).toContain('ada: billing webhook fails on retry');
+  });
+});

--- a/apps/desktop/src/features/integrations/slack/SlackStudio/ThreadDetailPanel.tsx
+++ b/apps/desktop/src/features/integrations/slack/SlackStudio/ThreadDetailPanel.tsx
@@ -1,0 +1,109 @@
+import { useEffect, useState } from 'react';
+import { EmptyState } from '@goodboy/ui';
+import type { SessionId, WorkspaceId } from '@goodboy/types';
+import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../shared/components/conceptIcons';
+import { LaunchSessionPanel } from '../../components/LaunchSessionPanel';
+import { slackGetPermalink } from '../client';
+import { goalFromThread } from '../goal-from-thread';
+import { slackUserNames } from '../nameMaps';
+import { SlackThreadDetail } from '../SlackThreadDetail';
+import {
+  slackThreadBranchSlug,
+  slackThreadExternalId,
+  slackThreadIdentifier,
+  slackThreadTitle,
+} from '../threadFormulas';
+import { useSlackThread } from '../useSlackThread';
+import type { SlackThreadRow } from './useSlackThreads';
+
+type Props = {
+  readonly row: SlackThreadRow | null;
+  readonly workspaceId: WorkspaceId;
+  readonly sessionId: SessionId | null;
+  readonly onClose: () => void;
+};
+
+export const ThreadDetailPanel = ({ row, workspaceId, sessionId, onClose }: Props) => {
+  const channelId = row?.channel.id ?? '';
+  const threadTs = row?.head.threadTs ?? row?.head.ts ?? '';
+  const [permalink, setPermalink] = useState<string | null>(null);
+  const thread = useSlackThread({
+    workspaceId,
+    channelId,
+    threadTs,
+    isEnabled: channelId !== '' && threadTs !== '',
+  });
+
+  useEffect(() => {
+    setPermalink(null);
+    if (channelId === '' || threadTs === '') {
+      return;
+    }
+    let isCurrent = true;
+    void slackGetPermalink({ workspaceId, channelId, messageTs: threadTs })
+      .then((url) => {
+        if (isCurrent) {
+          setPermalink(url);
+        }
+      })
+      .catch(() => undefined);
+    return () => {
+      isCurrent = false;
+    };
+  }, [workspaceId, channelId, threadTs]);
+
+  if (row == null) {
+    return (
+      <div className="flex h-full items-center justify-center px-8">
+        <EmptyState
+          bordered
+          tone={CONCEPT_TONE.slack}
+          icon={CONCEPT_ICONS.slack}
+          title="No thread selected"
+          description="Pick a thread to read it and launch a session from it."
+          size="lg"
+          headingLevel={2}
+        />
+      </div>
+    );
+  }
+
+  const channelName = row.channel.name;
+  const rootText = row.head.text;
+  const messages = thread.messages.length > 0 ? thread.messages : [row.head];
+
+  return (
+    <SlackThreadDetail
+      channelName={channelName}
+      rootText={rootText}
+      url={permalink}
+      messages={messages}
+      users={thread.users}
+      channels={thread.channels}
+      isLoading={thread.isLoading}
+      error={thread.error}
+      onRetry={thread.refetch}
+      dock={
+        <LaunchSessionPanel
+          key={`${channelId}:${threadTs}`}
+          workspaceId={workspaceId}
+          linkedSessionId={sessionId}
+          goalSeed={goalFromThread({
+            channelName,
+            messages,
+            userNames: slackUserNames({ users: thread.users }),
+          })}
+          branchSlugSeed={slackThreadBranchSlug({ text: rootText })}
+          externalTask={{
+            provider: 'slack',
+            externalId: slackThreadExternalId({ channelId, threadTs }),
+            identifier: slackThreadIdentifier({ channelName, text: rootText }),
+            url: permalink ?? '',
+            title: slackThreadTitle({ text: rootText }),
+          }}
+          onClose={onClose}
+        />
+      }
+    />
+  );
+};

--- a/apps/desktop/src/features/integrations/slack/SlackStudio/ThreadInbox.tsx
+++ b/apps/desktop/src/features/integrations/slack/SlackStudio/ThreadInbox.tsx
@@ -1,0 +1,183 @@
+import { useMemo, useState } from 'react';
+import {
+  Button,
+  EmptyState,
+  ScrollFade,
+  SectionHeader,
+  SelectableRow,
+  Skeleton,
+} from '@goodboy/ui';
+import { MessagesSquare, Search } from 'lucide-react';
+import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../shared/components/conceptIcons';
+import { formatAdaptiveAge } from '../../../../shared/utils/relativeDate';
+import { InboxStatusIcons } from '../../components/InboxStatusIcons';
+import { slackThreadFirstLine } from '../threadFormulas';
+import type { SlackThreadGroup, SlackThreadRow } from './useSlackThreads';
+
+type Props = {
+  readonly groups: ReadonlyArray<SlackThreadGroup>;
+  readonly focusedThreadTs: string | null;
+  readonly onSelect: (row: SlackThreadRow) => void;
+  readonly isLoading: boolean;
+  readonly error: string | null;
+  readonly onRefresh: () => void;
+  readonly hiddenChannelCount: number;
+};
+
+export const ThreadInbox = ({
+  groups,
+  focusedThreadTs,
+  onSelect,
+  isLoading,
+  error,
+  onRefresh,
+  hiddenChannelCount,
+}: Props) => {
+  const [query, setQuery] = useState('');
+  const hasQuery = query.trim() !== '';
+
+  const filtered = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    if (needle === '') {
+      return groups;
+    }
+    return groups
+      .map((group) => ({
+        ...group,
+        rows: group.rows.filter(
+          (row) =>
+            row.channel.name.toLowerCase().includes(needle) ||
+            row.head.text.toLowerCase().includes(needle),
+        ),
+      }))
+      .filter((group) => group.rows.length > 0);
+  }, [groups, query]);
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="shrink-0 p-3 pb-2">
+        <div className="flex h-9 items-center gap-2 rounded-md border border-border bg-background px-2.5 focus-within:border-primary">
+          <Search size={13} aria-hidden className="shrink-0 text-muted-foreground/60" />
+          <input
+            type="text"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search threads…"
+            aria-label="Search Slack threads"
+            autoComplete="off"
+            className="min-w-0 flex-1 bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground/50"
+          />
+        </div>
+      </div>
+
+      {isLoading && groups.length === 0 ? (
+        <div
+          className="flex min-h-0 flex-1 flex-col gap-0.5 px-3 pb-3"
+          role="status"
+          aria-label="Loading threads"
+        >
+          {Array.from({ length: 7 }).map((_, index) => (
+            <div key={index} className="flex items-center gap-2.5 px-2.5 py-2">
+              <Skeleton className="size-1.5 shrink-0 rounded-full" />
+              <Skeleton className="h-3 flex-1 rounded" />
+              <Skeleton className="h-3 w-7 shrink-0 rounded" />
+            </div>
+          ))}
+        </div>
+      ) : error != null ? (
+        <div className="px-3 pb-3">
+          <div className="flex items-start gap-2.5 rounded-lg border border-danger/30 bg-danger/10 px-3 py-2 text-xs text-danger">
+            {error}
+          </div>
+        </div>
+      ) : filtered.length === 0 ? (
+        <div className="flex min-h-0 flex-1 items-center justify-center px-3">
+          <EmptyState
+            icon={CONCEPT_ICONS.slack}
+            tone={CONCEPT_TONE.slack}
+            title={hasQuery ? 'No matching threads' : 'No channels yet'}
+            description={
+              hasQuery
+                ? 'Try a different search term.'
+                : 'Invite the bot to a public channel in Slack and it shows up here. Goodboy only sees channels the bot has joined.'
+            }
+            size="inline"
+            action={
+              <Button variant="ghost" size="sm" onClick={hasQuery ? () => setQuery('') : onRefresh}>
+                {hasQuery ? 'Clear search' : 'Refresh'}
+              </Button>
+            }
+          />
+        </div>
+      ) : (
+        <ScrollFade className="min-h-0 flex-1" fadeSize={24}>
+          <div className="flex flex-col gap-3 px-3 pb-3">
+            {filtered.map((group) => (
+              <div key={group.key} className="flex flex-col gap-1">
+                <SectionHeader
+                  className="px-1"
+                  label={group.label}
+                  action={
+                    <span className="text-2xs tabular-nums text-muted-foreground/50">
+                      {group.rows.length}
+                    </span>
+                  }
+                />
+                <ul className="flex flex-col gap-0.5">
+                  {group.rows.map((row) => {
+                    const threadTs = row.head.threadTs ?? row.head.ts;
+                    const isActive = threadTs === focusedThreadTs;
+                    const preview = slackThreadFirstLine({ text: row.head.text });
+                    return (
+                      <li key={threadTs}>
+                        <SelectableRow
+                          selected={isActive}
+                          onClick={() => onSelect(row)}
+                          title={preview}
+                          ariaCurrent={isActive}
+                          className="items-center gap-2.5 px-2.5 py-2"
+                        >
+                          <span className="min-w-0 flex-1 truncate text-xs">
+                            {preview !== '' ? preview : 'Untitled thread'}
+                          </span>
+                          <span className="shrink-0 text-2xs tabular-nums text-muted-foreground/50">
+                            {row.head.latestReplyAt != null
+                              ? formatAdaptiveAge({ iso: row.head.latestReplyAt })
+                              : ''}
+                          </span>
+                          <InboxStatusIcons
+                            sessionIcon={
+                              row.sessionId != null ? (
+                                <MessagesSquare
+                                  size={11}
+                                  aria-label="Session launched"
+                                  className="text-success"
+                                />
+                              ) : null
+                            }
+                            codeHostIcon={
+                              <CONCEPT_ICONS.slack
+                                size={11}
+                                aria-label="Slack thread"
+                                className="text-muted-foreground/70"
+                              />
+                            }
+                          />
+                        </SelectableRow>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
+            ))}
+            {hiddenChannelCount > 0 && (
+              <p className="px-1 text-2xs text-muted-foreground/60">
+                {`${hiddenChannelCount} more channels the bot joined are not read here, and each channel only reads its latest 200 messages.`}
+              </p>
+            )}
+          </div>
+        </ScrollFade>
+      )}
+    </div>
+  );
+};

--- a/apps/desktop/src/features/integrations/slack/SlackStudio/index.test.tsx
+++ b/apps/desktop/src/features/integrations/slack/SlackStudio/index.test.tsx
@@ -1,0 +1,173 @@
+// @vitest-environment happy-dom
+
+import type { ReactNode } from 'react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IsoDateTime, WorkspaceId } from '@goodboy/types';
+import type { SlackThreadGroup, SlackThreadRow } from './useSlackThreads';
+
+const h = vi.hoisted(() => ({
+  integrations: {} as Record<string, ReadonlyArray<{ provider: string }>>,
+  groups: [] as ReadonlyArray<SlackThreadGroup>,
+  isEnabled: null as boolean | null,
+}));
+
+vi.mock('../../../../store', () => ({
+  EMPTY_ARRAY: Object.freeze([]),
+  useAppStore: <T,>(selector: (state: { workspaceIntegrations: typeof h.integrations }) => T) =>
+    selector({ workspaceIntegrations: h.integrations }),
+}));
+
+vi.mock('../../../../shared/components/StudioShell', () => ({
+  StudioShell: ({
+    children,
+    headerAccessory,
+  }: {
+    children: (requestClose: () => void) => ReactNode;
+    headerAccessory: ReactNode;
+  }) => (
+    <div>
+      {headerAccessory}
+      {children(vi.fn())}
+    </div>
+  ),
+}));
+
+vi.mock('./useSlackThreads', () => ({
+  useSlackThreads: (params: { isEnabled: boolean }) => {
+    h.isEnabled = params.isEnabled;
+    return {
+      groups: h.groups,
+      channels: [],
+      users: [],
+      hiddenChannelCount: 0,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    };
+  },
+}));
+
+vi.mock('./ThreadDetailPanel', () => ({
+  ThreadDetailPanel: ({ row }: { row: SlackThreadRow | null }) => (
+    <div data-testid="detail">{row?.head.text ?? 'none'}</div>
+  ),
+}));
+
+vi.mock('../SlackFormBody', () => ({
+  SlackFormBody: () => (
+    <label htmlFor="slack-token-test">
+      Bot token
+      <input id="slack-token-test" />
+    </label>
+  ),
+}));
+
+import { SlackStudio } from '.';
+
+const row = (ts: string, text: string): SlackThreadRow => ({
+  channel: { id: 'C1', name: 'eng-alerts', isMember: true, topic: null, memberCount: 3 },
+  head: {
+    ts,
+    threadTs: ts,
+    userId: 'U1',
+    botId: null,
+    text,
+    subtype: null,
+    replyCount: 2,
+    replyUserCount: 2,
+    postedAt: '2026-08-05T09:00:00Z' as IsoDateTime,
+    latestReplyAt: '2026-08-05T09:00:00Z' as IsoDateTime,
+    reactions: [],
+  },
+  sessionId: null,
+});
+
+beforeEach(() => {
+  h.integrations = {};
+  h.groups = [];
+  h.isEnabled = null;
+});
+afterEach(cleanup);
+
+describe('SlackStudio', () => {
+  it('asks for the connection before showing an inbox', () => {
+    render(
+      <SlackStudio
+        workspaceId={'workspace-1' as WorkspaceId}
+        workspaceName="Goodboy"
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Connect Slack to read the threads a task came out of')).toBeDefined();
+    expect(screen.getByLabelText('Bot token')).toBeDefined();
+    expect(h.isEnabled).toBe(false);
+  });
+
+  it('lists thread heads and focuses the first one once connected', () => {
+    h.integrations = { 'workspace-1': [{ provider: 'slack' }] };
+    h.groups = [
+      {
+        key: 'C1',
+        label: '#eng-alerts',
+        rows: [row('1723456789.123456', 'billing webhook fails'), row('1723400000.000100', 'ping')],
+      },
+    ];
+
+    render(
+      <SlackStudio
+        workspaceId={'workspace-1' as WorkspaceId}
+        workspaceName="Goodboy"
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(h.isEnabled).toBe(true);
+    expect(screen.getByText('#eng-alerts')).toBeDefined();
+    expect(screen.getAllByText('billing webhook fails')).toHaveLength(2);
+    expect(screen.getByTestId('detail').textContent).toBe('billing webhook fails');
+  });
+
+  it('opens the thread the user clicks', () => {
+    h.integrations = { 'workspace-1': [{ provider: 'slack' }] };
+    h.groups = [
+      {
+        key: 'C1',
+        label: '#eng-alerts',
+        rows: [row('1723456789.123456', 'billing webhook fails'), row('1723400000.000100', 'ping')],
+      },
+    ];
+
+    render(
+      <SlackStudio
+        workspaceId={'workspace-1' as WorkspaceId}
+        workspaceName="Goodboy"
+        onClose={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByText('ping'));
+
+    expect(screen.getByTestId('detail').textContent).toBe('ping');
+  });
+
+  it('says nothing is there when the bot joined no channels', () => {
+    h.integrations = { 'workspace-1': [{ provider: 'slack' }] };
+
+    render(
+      <SlackStudio
+        workspaceId={'workspace-1' as WorkspaceId}
+        workspaceName="Goodboy"
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('No channels yet')).toBeDefined();
+    expect(
+      screen.getByText(
+        'Invite the bot to a public channel in Slack and it shows up here. Goodboy only sees channels the bot has joined.',
+      ),
+    ).toBeDefined();
+  });
+});

--- a/apps/desktop/src/features/integrations/slack/SlackStudio/index.tsx
+++ b/apps/desktop/src/features/integrations/slack/SlackStudio/index.tsx
@@ -1,0 +1,129 @@
+import { useEffect, useMemo, useState } from 'react';
+import { IconButton } from '@goodboy/ui';
+import { RefreshCw } from 'lucide-react';
+import type { WorkspaceId } from '@goodboy/types';
+import { StudioRailLayout } from '../../../../shared/components/StudioRailLayout';
+import { StudioShell } from '../../../../shared/components/StudioShell';
+import { IntegrationGlyph } from '../../components/IntegrationGlyph';
+import { ConnectIntegrationEmptyState } from '../../ConnectIntegrationEmptyState';
+import { EMPTY_ARRAY, useAppStore } from '../../../../store';
+import { resolveIntegrationConnection } from '../../connection';
+import { ThreadInbox } from './ThreadInbox';
+import { ThreadDetailPanel } from './ThreadDetailPanel';
+import { useSlackThreads } from './useSlackThreads';
+
+type Props = {
+  readonly workspaceId: WorkspaceId;
+  readonly workspaceName: string;
+  readonly initialThreadTs?: string | null;
+  readonly onClose: () => void;
+};
+
+export const SlackStudio = ({ workspaceId, workspaceName, initialThreadTs, onClose }: Props) => {
+  const integrations = useAppStore(
+    (state) => state.workspaceIntegrations[workspaceId] ?? EMPTY_ARRAY,
+  );
+  const isConnected = resolveIntegrationConnection({
+    provider: 'slack',
+    integrations,
+    remoteKind: null,
+    externalTasks: EMPTY_ARRAY,
+    isGithubAuthenticated: false,
+  }).isConnected;
+  const { groups, hiddenChannelCount, isLoading, error, refetch } = useSlackThreads({
+    workspaceId,
+    isEnabled: isConnected,
+  });
+  const [focusedThreadTs, setFocusedThreadTs] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (focusedThreadTs !== null) {
+      return;
+    }
+    const wanted = initialThreadTs != null && initialThreadTs !== '' ? initialThreadTs : null;
+    for (const group of groups) {
+      const match = group.rows.find((row) => (row.head.threadTs ?? row.head.ts) === wanted);
+      if (match != null) {
+        setFocusedThreadTs(wanted);
+        return;
+      }
+    }
+    const first = groups[0]?.rows[0] ?? null;
+    if (first != null) {
+      setFocusedThreadTs(first.head.threadTs ?? first.head.ts);
+    }
+  }, [focusedThreadTs, groups, initialThreadTs]);
+
+  const focusedRow = useMemo(() => {
+    if (focusedThreadTs == null) {
+      return null;
+    }
+    for (const group of groups) {
+      const match = group.rows.find(
+        (row) => (row.head.threadTs ?? row.head.ts) === focusedThreadTs,
+      );
+      if (match != null) {
+        return match;
+      }
+    }
+    return null;
+  }, [focusedThreadTs, groups]);
+
+  return (
+    <StudioShell
+      glyph={<IntegrationGlyph provider="slack" size={20} />}
+      title="Slack"
+      workspaceName={workspaceName}
+      closeLabel="close slack studio"
+      headerAccessory={
+        isConnected ? (
+          <IconButton
+            icon={RefreshCw}
+            label="Refresh threads"
+            onClick={refetch}
+            disabled={isLoading}
+            busy={isLoading}
+          />
+        ) : null
+      }
+      onClose={onClose}
+    >
+      {(requestClose) =>
+        isConnected ? (
+          <StudioRailLayout
+            railLabel="Slack threads"
+            railWidth="standard"
+            rail={
+              <ThreadInbox
+                groups={groups}
+                focusedThreadTs={focusedThreadTs}
+                onSelect={(row) => setFocusedThreadTs(row.head.threadTs ?? row.head.ts)}
+                isLoading={isLoading}
+                error={error}
+                onRefresh={refetch}
+                hiddenChannelCount={hiddenChannelCount}
+              />
+            }
+            detail={
+              <ThreadDetailPanel
+                row={focusedRow}
+                workspaceId={workspaceId}
+                sessionId={focusedRow?.sessionId ?? null}
+                onClose={requestClose}
+              />
+            }
+          />
+        ) : (
+          <div className="flex min-h-0 flex-1 items-center justify-center p-5">
+            <ConnectIntegrationEmptyState
+              provider="slack"
+              workspaceId={workspaceId}
+              shouldAutoFocus
+              wrapped={false}
+            />
+          </div>
+        )
+      }
+    </StudioShell>
+  );
+};

--- a/apps/desktop/src/features/integrations/slack/SlackStudio/useSlackThreads.test.ts
+++ b/apps/desktop/src/features/integrations/slack/SlackStudio/useSlackThreads.test.ts
@@ -1,0 +1,126 @@
+// @vitest-environment happy-dom
+
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SessionId, WorkspaceId } from '@goodboy/types';
+
+const h = vi.hoisted(() => ({
+  state: {} as Record<string, unknown>,
+  calls: { channels: 0, users: 0, heads: [] as string[] },
+}));
+
+const buildState = () => ({
+  ...h.state,
+  refreshSlackChannels: vi.fn(async () => {
+    h.calls.channels += 1;
+  }),
+  refreshSlackUsers: vi.fn(async () => {
+    h.calls.users += 1;
+  }),
+  refreshSlackThreadHeads: vi.fn(async ({ channelId }: { channelId: string }) => {
+    h.calls.heads.push(channelId);
+  }),
+});
+
+vi.mock('../../../../store', () => {
+  const useAppStore = <T>(selector: (state: Record<string, unknown>) => T): T =>
+    selector(buildState());
+  useAppStore.getState = () => buildState();
+  return {
+    EMPTY_ARRAY: Object.freeze([]),
+    useAppStore,
+    useSessions: () => h.state.sessions ?? [],
+  };
+});
+
+const { useSlackThreads } = await import('./useSlackThreads');
+
+const WORKSPACE_ID = 'ws-1' as WorkspaceId;
+
+const head = (ts: string, text: string, latestReplyAt: string) => ({
+  ts,
+  threadTs: ts,
+  userId: 'U1',
+  botId: null,
+  text,
+  subtype: null,
+  replyCount: 2,
+  replyUserCount: 2,
+  postedAt: latestReplyAt,
+  latestReplyAt,
+  reactions: [],
+});
+
+beforeEach(() => {
+  h.calls = { channels: 0, users: 0, heads: [] };
+  h.state = {
+    sessions: [],
+    sessionExternalTasks: {},
+    slackChannels: {
+      [WORKSPACE_ID]: {
+        channels: [
+          { id: 'C1', name: 'eng-alerts', isMember: true, topic: null, memberCount: 3 },
+          { id: 'C2', name: 'product', isMember: true, topic: null, memberCount: 9 },
+        ],
+        loading: false,
+        error: null,
+      },
+    },
+    slackUsers: { [WORKSPACE_ID]: [{ id: 'U1', name: 'ada', isBot: false, isDeleted: false }] },
+    slackThreadHeads: {
+      [`${WORKSPACE_ID}:C1`]: {
+        heads: [head('1723456789.123456', 'billing webhook fails', '2026-08-05T09:00:00Z')],
+        loading: false,
+        error: null,
+      },
+      [`${WORKSPACE_ID}:C2`]: {
+        heads: [head('1723400000.000100', 'roadmap review', '2026-08-04T09:00:00Z')],
+        loading: false,
+        error: null,
+      },
+    },
+  };
+});
+
+describe('useSlackThreads', () => {
+  it('fetches channels, users and every channel thread head on mount', async () => {
+    renderHook(() => useSlackThreads({ workspaceId: WORKSPACE_ID, isEnabled: true }));
+
+    await waitFor(() => {
+      expect(h.calls.heads).toEqual(['C1', 'C2']);
+    });
+    expect(h.calls.channels).toBe(1);
+    expect(h.calls.users).toBe(1);
+  });
+
+  it('does not touch slack when the workspace is not connected', async () => {
+    renderHook(() => useSlackThreads({ workspaceId: WORKSPACE_ID, isEnabled: false }));
+
+    await waitFor(() => {
+      expect(h.calls.channels).toBe(0);
+    });
+    expect(h.calls.heads).toEqual([]);
+  });
+
+  it('groups threads by channel, newest channel first', () => {
+    const { result } = renderHook(() =>
+      useSlackThreads({ workspaceId: WORKSPACE_ID, isEnabled: true }),
+    );
+
+    expect(result.current.groups.map((group) => group.label)).toEqual(['#eng-alerts', '#product']);
+    expect(result.current.groups[0]?.rows[0]?.head.text).toBe('billing webhook fails');
+  });
+
+  it('marks a thread that already has a session', () => {
+    h.state.sessions = [{ id: 'session-1' as SessionId, workspaceId: WORKSPACE_ID }];
+    h.state.sessionExternalTasks = {
+      'session-1': [{ provider: 'slack', externalId: 'C1:1723456789.123456' }],
+    };
+
+    const { result } = renderHook(() =>
+      useSlackThreads({ workspaceId: WORKSPACE_ID, isEnabled: true }),
+    );
+
+    expect(result.current.groups[0]?.rows[0]?.sessionId).toBe('session-1');
+  });
+});

--- a/apps/desktop/src/features/integrations/slack/SlackStudio/useSlackThreads.ts
+++ b/apps/desktop/src/features/integrations/slack/SlackStudio/useSlackThreads.ts
@@ -1,0 +1,169 @@
+import { useCallback, useEffect, useMemo } from 'react';
+import type { Session, SessionExternalTask, SessionId, WorkspaceId } from '@goodboy/types';
+import { EMPTY_ARRAY, useAppStore, useSessions } from '../../../../store';
+import { slackChannelKey } from '../../../../store/slices/slack-threads';
+import type { SlackChannel, SlackMessage, SlackUser } from '../client';
+import { slackThreadExternalId } from '../threadFormulas';
+
+export const CHANNEL_FETCH_CAP = 12;
+
+export type SlackThreadRow = {
+  readonly channel: SlackChannel;
+  readonly head: SlackMessage;
+  readonly sessionId: SessionId | null;
+};
+
+export type SlackThreadGroup = {
+  readonly key: string;
+  readonly label: string;
+  readonly rows: ReadonlyArray<SlackThreadRow>;
+};
+
+type SessionMatchParams = {
+  readonly sessions: ReadonlyArray<Session>;
+  readonly sessionExternalTasks: Readonly<Record<string, ReadonlyArray<SessionExternalTask>>>;
+};
+
+export const resolveThreadSessions = ({
+  sessions,
+  sessionExternalTasks,
+}: SessionMatchParams): ReadonlyMap<string, SessionId> => {
+  const byExternalId = new Map<string, SessionId>();
+  for (const session of sessions) {
+    const tasks = sessionExternalTasks[session.id] ?? [];
+    for (const task of tasks) {
+      if (task.provider === 'slack' && !byExternalId.has(task.externalId)) {
+        byExternalId.set(task.externalId, session.id);
+      }
+    }
+  }
+  return byExternalId;
+};
+
+const headTimestamp = (head: SlackMessage): string => head.latestReplyAt ?? head.postedAt ?? '';
+
+type GroupParams = {
+  readonly channels: ReadonlyArray<SlackChannel>;
+  readonly headsByChannelId: ReadonlyMap<string, ReadonlyArray<SlackMessage>>;
+  readonly sessionIdByExternalId: ReadonlyMap<string, SessionId>;
+};
+
+export const buildThreadGroups = ({
+  channels,
+  headsByChannelId,
+  sessionIdByExternalId,
+}: GroupParams): ReadonlyArray<SlackThreadGroup> =>
+  channels
+    .map((channel) => {
+      const heads = headsByChannelId.get(channel.id) ?? [];
+      const rows = heads
+        .map((head) => ({
+          channel,
+          head,
+          sessionId:
+            sessionIdByExternalId.get(
+              slackThreadExternalId({ channelId: channel.id, threadTs: head.threadTs ?? head.ts }),
+            ) ?? null,
+        }))
+        .sort((left, right) => headTimestamp(right.head).localeCompare(headTimestamp(left.head)));
+      return { key: channel.id, label: `#${channel.name}`, rows };
+    })
+    .filter((group) => group.rows.length > 0)
+    .sort((left, right) =>
+      headTimestamp(right.rows[0]!.head).localeCompare(headTimestamp(left.rows[0]!.head)),
+    );
+
+export type UseSlackThreads = {
+  readonly groups: ReadonlyArray<SlackThreadGroup>;
+  readonly channels: ReadonlyArray<SlackChannel>;
+  readonly users: ReadonlyArray<SlackUser>;
+  readonly hiddenChannelCount: number;
+  readonly isLoading: boolean;
+  readonly error: string | null;
+  readonly refetch: () => void;
+};
+
+type HookParams = {
+  readonly workspaceId: WorkspaceId;
+  readonly isEnabled: boolean;
+};
+
+export const useSlackThreads = ({ workspaceId, isEnabled }: HookParams): UseSlackThreads => {
+  const sessions = useSessions();
+  const sessionExternalTasks = useAppStore((state) => state.sessionExternalTasks);
+  const channelsEntry = useAppStore((state) => state.slackChannels[workspaceId] ?? null);
+  const threadHeads = useAppStore((state) => state.slackThreadHeads);
+  const users = useAppStore((state) => state.slackUsers[workspaceId] ?? EMPTY_ARRAY);
+
+  const load = useCallback(async () => {
+    if (!isEnabled) {
+      return;
+    }
+    const store = useAppStore.getState();
+    await Promise.all([
+      store.refreshSlackChannels({ workspaceId }),
+      store.refreshSlackUsers({ workspaceId }),
+    ]);
+    const channels = useAppStore.getState().slackChannels[workspaceId]?.channels ?? [];
+    await Promise.all(
+      channels
+        .slice(0, CHANNEL_FETCH_CAP)
+        .map((channel) =>
+          useAppStore.getState().refreshSlackThreadHeads({ workspaceId, channelId: channel.id }),
+        ),
+    );
+  }, [workspaceId, isEnabled]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const refetch = useCallback(() => {
+    void load();
+  }, [load]);
+
+  const visibleChannels = useMemo(
+    () => (channelsEntry?.channels ?? EMPTY_ARRAY).slice(0, CHANNEL_FETCH_CAP),
+    [channelsEntry],
+  );
+
+  const headsByChannelId = useMemo(() => {
+    const map = new Map<string, ReadonlyArray<SlackMessage>>();
+    for (const channel of visibleChannels) {
+      const entry = threadHeads[slackChannelKey({ workspaceId, channelId: channel.id })];
+      if (entry != null) {
+        map.set(channel.id, entry.heads);
+      }
+    }
+    return map;
+  }, [visibleChannels, threadHeads, workspaceId]);
+
+  const sessionIdByExternalId = useMemo(
+    () => resolveThreadSessions({ sessions, sessionExternalTasks }),
+    [sessions, sessionExternalTasks],
+  );
+
+  const groups = useMemo(
+    () => buildThreadGroups({ channels: visibleChannels, headsByChannelId, sessionIdByExternalId }),
+    [visibleChannels, headsByChannelId, sessionIdByExternalId],
+  );
+
+  const headEntries = visibleChannels.map(
+    (channel) => threadHeads[slackChannelKey({ workspaceId, channelId: channel.id })] ?? null,
+  );
+  const headError = headEntries.find((entry) => entry?.error != null)?.error ?? null;
+
+  return {
+    groups,
+    channels: channelsEntry?.channels ?? EMPTY_ARRAY,
+    users,
+    hiddenChannelCount: Math.max(
+      0,
+      (channelsEntry?.channels ?? EMPTY_ARRAY).length - CHANNEL_FETCH_CAP,
+    ),
+    isLoading:
+      channelsEntry?.loading === true || headEntries.some((entry) => entry?.loading === true),
+    error: channelsEntry?.error ?? headError,
+    refetch,
+  };
+};

--- a/apps/desktop/src/features/integrations/slack/SlackThreadDetail/index.tsx
+++ b/apps/desktop/src/features/integrations/slack/SlackThreadDetail/index.tsx
@@ -1,0 +1,80 @@
+import { useMemo, type ReactNode } from 'react';
+import { HeaderBand, StudioDetailLayout } from '../../../../shared/components/StudioDetail';
+import { ExternalRefActions } from '../../../../shared/components/ExternalRefActions';
+import { resolveDetailFields, slackThreadFields } from '../../../../shared/detail-fields';
+import type { SlackChannel, SlackMessage, SlackUser } from '../client';
+import { buildThreadProperties } from '../buildThreadProperties';
+import { slackUserNames } from '../nameMaps';
+import { slackThreadTitle } from '../threadFormulas';
+import { ThreadConversation } from '../ThreadConversation';
+
+type Fit = 'fill' | 'bleed' | 'flow';
+
+type Props = {
+  readonly channelName: string;
+  readonly rootText: string;
+  readonly url: string | null;
+  readonly messages: ReadonlyArray<SlackMessage>;
+  readonly users: ReadonlyArray<SlackUser>;
+  readonly channels: ReadonlyArray<SlackChannel>;
+  readonly isLoading: boolean;
+  readonly error: string | null;
+  readonly onRetry: () => void;
+  readonly fit?: Fit;
+  readonly dock?: ReactNode;
+};
+
+export const SlackThreadDetail = ({
+  channelName,
+  rootText,
+  url,
+  messages,
+  users,
+  channels,
+  isLoading,
+  error,
+  onRetry,
+  fit = 'fill',
+  dock,
+}: Props) => {
+  const userNames = useMemo(() => slackUserNames({ users }), [users]);
+  const properties = useMemo(
+    () =>
+      resolveDetailFields({
+        registry: slackThreadFields,
+        entity: buildThreadProperties({ channelName, messages, userNames }),
+      }),
+    [channelName, messages, userNames],
+  );
+  const title = slackThreadTitle({ text: rootText });
+
+  return (
+    <StudioDetailLayout
+      fit={fit}
+      dock={dock}
+      header={
+        <HeaderBand
+          meta={
+            <span className="font-mono text-2xs text-muted-foreground">{`#${channelName}`}</span>
+          }
+          title={title !== '' ? title : `#${channelName}`}
+          actions={
+            url != null && url !== '' ? (
+              <ExternalRefActions url={url} label="thread" hostLabel="Slack" />
+            ) : null
+          }
+        />
+      }
+      properties={properties}
+    >
+      <ThreadConversation
+        messages={messages}
+        users={users}
+        channels={channels}
+        isLoading={isLoading}
+        error={error}
+        onRetry={onRetry}
+      />
+    </StudioDetailLayout>
+  );
+};

--- a/apps/desktop/src/features/integrations/slack/ThreadConversation/ThreadNoteCard.tsx
+++ b/apps/desktop/src/features/integrations/slack/ThreadConversation/ThreadNoteCard.tsx
@@ -1,0 +1,18 @@
+import { NoteCard } from '../../../../shared/components/NoteCard';
+import type { SlackMessage, SlackUser } from '../client';
+import { slackMrkdwnToMarkdown } from '../slackMrkdwnToMarkdown';
+import { ThreadNoteHeader } from './ThreadNoteHeader';
+
+type Props = {
+  readonly message: SlackMessage;
+  readonly author: SlackUser | null;
+  readonly userNames: ReadonlyMap<string, string>;
+  readonly channelNames: ReadonlyMap<string, string>;
+};
+
+export const ThreadNoteCard = ({ message, author, userNames, channelNames }: Props) => (
+  <NoteCard
+    header={<ThreadNoteHeader message={message} author={author} />}
+    body={slackMrkdwnToMarkdown({ text: message.text, userNames, channelNames })}
+  />
+);

--- a/apps/desktop/src/features/integrations/slack/ThreadConversation/ThreadNoteHeader.tsx
+++ b/apps/desktop/src/features/integrations/slack/ThreadConversation/ThreadNoteHeader.tsx
@@ -1,0 +1,29 @@
+import { formatRelativeAge } from '../../../../shared/utils/relativeDate';
+import { NoteAvatar } from '../../../../shared/components/NoteAvatar';
+import { NoteHeader } from '../../../../shared/components/NoteHeader';
+import type { SlackMessage, SlackUser } from '../client';
+
+type Props = {
+  readonly message: SlackMessage;
+  readonly author: SlackUser | null;
+};
+
+export const ThreadNoteHeader = ({ message, author }: Props) => {
+  const name = author?.name ?? message.userId ?? 'Unknown';
+  const age = message.postedAt != null ? formatRelativeAge({ fromIso: message.postedAt }) : '';
+
+  return (
+    <NoteHeader
+      avatar={<NoteAvatar url={author?.avatarUrl ?? null} alt={name} />}
+      author={name}
+      timestamp={
+        age !== '' && (
+          <>
+            <span className="opacity-50">·</span>
+            <span>{age}</span>
+          </>
+        )
+      }
+    />
+  );
+};

--- a/apps/desktop/src/features/integrations/slack/ThreadConversation/index.tsx
+++ b/apps/desktop/src/features/integrations/slack/ThreadConversation/index.tsx
@@ -1,0 +1,66 @@
+import { useMemo } from 'react';
+import { EmptyState } from '@goodboy/ui';
+import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../shared/components/conceptIcons';
+import { ErrorStrip } from '../../../../shared/components/ErrorStrip';
+import { NoteListSkeleton } from '../../../../shared/components/NoteListSkeleton';
+import type { SlackChannel, SlackMessage, SlackUser } from '../client';
+import { slackChannelNames, slackUserNames } from '../nameMaps';
+import { ThreadNoteCard } from './ThreadNoteCard';
+
+type Props = {
+  readonly messages: ReadonlyArray<SlackMessage>;
+  readonly users: ReadonlyArray<SlackUser>;
+  readonly channels: ReadonlyArray<SlackChannel>;
+  readonly isLoading: boolean;
+  readonly error: string | null;
+  readonly onRetry: () => void;
+};
+
+export const ThreadConversation = ({
+  messages,
+  users,
+  channels,
+  isLoading,
+  error,
+  onRetry,
+}: Props) => {
+  const usersById = useMemo(() => new Map(users.map((user) => [user.id, user])), [users]);
+  const userNames = useMemo(() => slackUserNames({ users }), [users]);
+  const channelNames = useMemo(() => slackChannelNames({ channels }), [channels]);
+
+  if (isLoading && messages.length === 0) {
+    return <NoteListSkeleton />;
+  }
+
+  if (error != null) {
+    return <ErrorStrip label="the thread" error={new Error(error)} onRetry={onRetry} />;
+  }
+
+  if (messages.length === 0) {
+    return (
+      <EmptyState
+        icon={CONCEPT_ICONS.slack}
+        tone={CONCEPT_TONE.slack}
+        title="Nothing to read yet"
+        description="The messages in this thread show up here."
+        size="inline"
+        className="py-5"
+      />
+    );
+  }
+
+  return (
+    <ul className="flex flex-col gap-2.5">
+      {messages.map((message) => (
+        <li key={message.ts}>
+          <ThreadNoteCard
+            message={message}
+            author={message.userId != null ? (usersById.get(message.userId) ?? null) : null}
+            userNames={userNames}
+            channelNames={channelNames}
+          />
+        </li>
+      ))}
+    </ul>
+  );
+};

--- a/apps/desktop/src/features/integrations/slack/buildThreadProperties.ts
+++ b/apps/desktop/src/features/integrations/slack/buildThreadProperties.ts
@@ -1,0 +1,34 @@
+import type { SlackThreadProperties } from '../../../shared/detail-fields';
+import type { SlackMessage } from './client';
+
+type Params = {
+  readonly channelName: string;
+  readonly messages: ReadonlyArray<SlackMessage>;
+  readonly userNames: ReadonlyMap<string, string>;
+};
+
+export const buildThreadProperties = ({
+  channelName,
+  messages,
+  userNames,
+}: Params): SlackThreadProperties => {
+  const participants: string[] = [];
+  for (const message of messages) {
+    const userId = message.userId;
+    if (userId == null) {
+      continue;
+    }
+    const name = userNames.get(userId) ?? userId;
+    if (!participants.includes(name)) {
+      participants.push(name);
+    }
+  }
+  const root = messages[0] ?? null;
+  const lastReply = messages.at(-1) ?? null;
+  return {
+    channelName,
+    participants,
+    replyCount: Math.max(0, messages.length - 1),
+    lastActivityAt: lastReply?.postedAt ?? root?.postedAt ?? null,
+  };
+};

--- a/apps/desktop/src/features/integrations/slack/goal-from-thread.ts
+++ b/apps/desktop/src/features/integrations/slack/goal-from-thread.ts
@@ -1,0 +1,38 @@
+import type { SlackMessage } from './client';
+import { slackMrkdwnToMarkdown } from './slackMrkdwnToMarkdown';
+
+const GOAL_CHAR_CAP = 2000;
+const UNKNOWN_AUTHOR = 'Someone';
+
+type Params = {
+  readonly channelName: string;
+  readonly messages: ReadonlyArray<SlackMessage>;
+  readonly userNames?: ReadonlyMap<string, string>;
+};
+
+export const goalFromThread = ({ channelName, messages, userNames }: Params): string => {
+  const heading = `Slack thread in #${channelName}`;
+  const body = messages
+    .map((message) => {
+      const author =
+        message.userId != null
+          ? (userNames?.get(message.userId) ?? message.userId)
+          : UNKNOWN_AUTHOR;
+      const text = slackMrkdwnToMarkdown({
+        text: message.text,
+        ...(userNames != null && { userNames }),
+      }).trim();
+      if (text === '') {
+        return '';
+      }
+      return `${author}: ${text}`;
+    })
+    .filter((line) => line !== '')
+    .join('\n\n');
+
+  if (body === '') {
+    return heading;
+  }
+  const capped = body.length > GOAL_CHAR_CAP ? `${body.slice(0, GOAL_CHAR_CAP).trimEnd()}…` : body;
+  return `${heading}\n\n${capped}`;
+};

--- a/apps/desktop/src/features/integrations/slack/hydrateSlackThreadTask.test.ts
+++ b/apps/desktop/src/features/integrations/slack/hydrateSlackThreadTask.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import type { SlackChannel, SlackMessage } from './client';
+import { hydrateSlackThreadTask } from './hydrateSlackThreadTask';
+
+const CHANNELS = [
+  { id: 'C024BE7LR', name: 'eng-alerts', isMember: true, topic: null, memberCount: 4 },
+] as ReadonlyArray<SlackChannel>;
+
+const message = (ts: string, text: string): SlackMessage =>
+  ({
+    ts,
+    threadTs: '1723456789.123456',
+    userId: 'U1',
+    botId: null,
+    text,
+    subtype: null,
+    replyCount: 1,
+    replyUserCount: 1,
+    postedAt: null,
+    latestReplyAt: null,
+    reactions: [],
+  }) as SlackMessage;
+
+describe('hydrateSlackThreadTask', () => {
+  it('rebuilds the identifier and title from the fetched root message', () => {
+    expect(
+      hydrateSlackThreadTask({
+        channelId: 'C024BE7LR',
+        threadTs: '1723456789.123456',
+        channels: CHANNELS,
+        messages: [
+          message('1723456789.123456', 'billing webhook fails on retry and nobody noticed'),
+          message('1723456999.000100', 'looking'),
+        ],
+      }),
+    ).toEqual({
+      identifier: '#eng-alerts › billing webhook fails on retry a…',
+      title: 'billing webhook fails on retry a…',
+    });
+  });
+
+  it('keeps the channel id when the channel is not in the member list', () => {
+    expect(
+      hydrateSlackThreadTask({
+        channelId: 'C999',
+        threadTs: '1723456789.123456',
+        channels: CHANNELS,
+        messages: [message('1723456789.123456', 'deploy is stuck')],
+      }).identifier,
+    ).toBe('#C999 › deploy is stuck');
+  });
+});

--- a/apps/desktop/src/features/integrations/slack/hydrateSlackThreadTask.test.ts
+++ b/apps/desktop/src/features/integrations/slack/hydrateSlackThreadTask.test.ts
@@ -46,7 +46,18 @@ describe('hydrateSlackThreadTask', () => {
         threadTs: '1723456789.123456',
         channels: CHANNELS,
         messages: [message('1723456789.123456', 'deploy is stuck')],
-      }).identifier,
+      })?.identifier,
     ).toBe('#C999 › deploy is stuck');
+  });
+
+  it('refuses to hydrate a thread that came back with no messages', () => {
+    expect(
+      hydrateSlackThreadTask({
+        channelId: 'C024BE7LR',
+        threadTs: '1723456789.123456',
+        channels: CHANNELS,
+        messages: [],
+      }),
+    ).toBeNull();
   });
 });

--- a/apps/desktop/src/features/integrations/slack/hydrateSlackThreadTask.ts
+++ b/apps/desktop/src/features/integrations/slack/hydrateSlackThreadTask.ts
@@ -18,10 +18,13 @@ export const hydrateSlackThreadTask = ({
   threadTs,
   channels,
   messages,
-}: Params): Result => {
+}: Params): Result | null => {
   const channelName = channels.find((channel) => channel.id === channelId)?.name ?? channelId;
   const root = messages.find((message) => message.ts === threadTs) ?? messages[0] ?? null;
-  const text = root?.text ?? '';
+  if (root == null) {
+    return null;
+  }
+  const text = root.text;
   return {
     identifier: slackThreadIdentifier({ channelName, text }),
     title: slackThreadTitle({ text }),

--- a/apps/desktop/src/features/integrations/slack/hydrateSlackThreadTask.ts
+++ b/apps/desktop/src/features/integrations/slack/hydrateSlackThreadTask.ts
@@ -1,0 +1,29 @@
+import type { SlackChannel, SlackMessage } from './client';
+import { slackThreadIdentifier, slackThreadTitle } from './threadFormulas';
+
+type Params = {
+  readonly channelId: string;
+  readonly threadTs: string;
+  readonly channels: ReadonlyArray<SlackChannel>;
+  readonly messages: ReadonlyArray<SlackMessage>;
+};
+
+type Result = {
+  readonly identifier: string;
+  readonly title: string;
+};
+
+export const hydrateSlackThreadTask = ({
+  channelId,
+  threadTs,
+  channels,
+  messages,
+}: Params): Result => {
+  const channelName = channels.find((channel) => channel.id === channelId)?.name ?? channelId;
+  const root = messages.find((message) => message.ts === threadTs) ?? messages[0] ?? null;
+  const text = root?.text ?? '';
+  return {
+    identifier: slackThreadIdentifier({ channelName, text }),
+    title: slackThreadTitle({ text }),
+  };
+};

--- a/apps/desktop/src/features/integrations/slack/nameMaps.ts
+++ b/apps/desktop/src/features/integrations/slack/nameMaps.ts
@@ -1,0 +1,15 @@
+import type { SlackChannel, SlackUser } from './client';
+
+type UserParams = {
+  readonly users: ReadonlyArray<SlackUser>;
+};
+
+export const slackUserNames = ({ users }: UserParams): ReadonlyMap<string, string> =>
+  new Map(users.map((user) => [user.id, user.name]));
+
+type ChannelParams = {
+  readonly channels: ReadonlyArray<SlackChannel>;
+};
+
+export const slackChannelNames = ({ channels }: ChannelParams): ReadonlyMap<string, string> =>
+  new Map(channels.map((channel) => [channel.id, channel.name]));

--- a/apps/desktop/src/features/integrations/slack/slackMrkdwnToMarkdown.test.ts
+++ b/apps/desktop/src/features/integrations/slack/slackMrkdwnToMarkdown.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { slackMrkdwnToMarkdown } from './slackMrkdwnToMarkdown';
+
+const USERS = new Map([['U024BE7LH', 'ada']]);
+const CHANNELS = new Map([['C024BE7LR', 'eng-alerts']]);
+
+describe('slackMrkdwnToMarkdown', () => {
+  it('turns slack link, mention and channel syntax into markdown', () => {
+    const out = slackMrkdwnToMarkdown({
+      text: 'see <https://goodboy.dev/docs|the docs> <@U024BE7LH> in <#C024BE7LR|eng-alerts>',
+      userNames: USERS,
+      channelNames: CHANNELS,
+    });
+
+    expect(out).toBe('see [the docs](https://goodboy.dev/docs) @ada in #eng-alerts');
+  });
+
+  it('converts single-delimiter bold and strike to their markdown pairs', () => {
+    expect(slackMrkdwnToMarkdown({ text: '*ship it* and ~not this~ but _keep this_' })).toBe(
+      '**ship it** and ~~not this~~ but _keep this_',
+    );
+  });
+
+  it('leaves code spans and fences untouched while unescaping entities around them', () => {
+    const out = slackMrkdwnToMarkdown({
+      text: 'run `a *b* c` then ```<x|y>``` on a &amp;&amp; b',
+    });
+
+    expect(out).toBe('run `a *b* c` then ```<x|y>``` on a && b');
+  });
+
+  it('unescapes after parsing so an escaped angle bracket never becomes link syntax', () => {
+    expect(slackMrkdwnToMarkdown({ text: '&lt;https://evil.test|click&gt;' })).toBe(
+      '<https://evil.test|click>',
+    );
+  });
+
+  it('falls back to the raw id when a mention has no known user', () => {
+    expect(slackMrkdwnToMarkdown({ text: 'ping <@U999NOPE>' })).toBe('ping @U999NOPE');
+  });
+});

--- a/apps/desktop/src/features/integrations/slack/slackMrkdwnToMarkdown.ts
+++ b/apps/desktop/src/features/integrations/slack/slackMrkdwnToMarkdown.ts
@@ -1,0 +1,122 @@
+type Params = {
+  readonly text: string;
+  readonly userNames?: ReadonlyMap<string, string>;
+  readonly channelNames?: ReadonlyMap<string, string>;
+};
+
+const EMPTY_NAMES: ReadonlyMap<string, string> = new Map();
+
+const CODE_PATTERN = /```[\s\S]*?```|`[^`\n]*`/g;
+const PLACEHOLDER_PATTERN = /\u0000(\d+)\u0000/g;
+const ENTITY_PATTERN = /<([^<>\n]*)>/g;
+const BOLD_PATTERN = /\*([^*\n]+)\*/g;
+const STRIKE_PATTERN = /~([^~\n]+)~/g;
+const ESCAPE_PATTERN = /&(amp|lt|gt);/g;
+
+const HTML_ENTITIES: Readonly<Record<string, string>> = {
+  amp: '&',
+  lt: '<',
+  gt: '>',
+};
+
+type EntityParams = {
+  readonly body: string;
+  readonly userNames: ReadonlyMap<string, string>;
+  readonly channelNames: ReadonlyMap<string, string>;
+};
+
+type PrefixedParams = {
+  readonly body: string;
+  readonly names: ReadonlyMap<string, string>;
+  readonly sigil: string;
+};
+
+const renderPrefixed = ({ body, names, sigil }: PrefixedParams): string => {
+  const [rawId, label] = body.slice(1).split('|');
+  const id = rawId ?? '';
+  const resolved = names.get(id);
+  if (resolved != null && resolved !== '') {
+    return `${sigil}${resolved}`;
+  }
+  if (label != null && label !== '') {
+    return `${sigil}${label}`;
+  }
+  return `${sigil}${id}`;
+};
+
+type CommandParams = {
+  readonly body: string;
+};
+
+const renderCommand = ({ body }: CommandParams): string => {
+  const [rawCommand, label] = body.slice(1).split('|');
+  if (label != null && label !== '') {
+    return label.startsWith('@') ? label : `@${label}`;
+  }
+  const command = (rawCommand ?? '').split('^')[0] ?? '';
+  return `@${command}`;
+};
+
+type LinkParams = {
+  readonly body: string;
+};
+
+const renderLink = ({ body }: LinkParams): string => {
+  const separator = body.indexOf('|');
+  if (separator < 0) {
+    return `[${body}](${body})`;
+  }
+  const url = body.slice(0, separator);
+  const label = body.slice(separator + 1);
+  if (label === '') {
+    return `[${url}](${url})`;
+  }
+  return `[${label}](${url})`;
+};
+
+const renderEntity = ({ body, userNames, channelNames }: EntityParams): string => {
+  if (body.startsWith('@')) {
+    return renderPrefixed({ body, names: userNames, sigil: '@' });
+  }
+  if (body.startsWith('#')) {
+    return renderPrefixed({ body, names: channelNames, sigil: '#' });
+  }
+  if (body.startsWith('!')) {
+    return renderCommand({ body });
+  }
+  return renderLink({ body });
+};
+
+export const slackMrkdwnToMarkdown = ({
+  text,
+  userNames = EMPTY_NAMES,
+  channelNames = EMPTY_NAMES,
+}: Params): string => {
+  if (text === '') {
+    return '';
+  }
+
+  const fragments: string[] = [];
+  const masked = text.replace(CODE_PATTERN, (fragment: string) => {
+    fragments.push(fragment);
+    return `\u0000${fragments.length - 1}\u0000`;
+  });
+
+  const linked = masked.replace(ENTITY_PATTERN, (whole: string, body: string) => {
+    if (body === '') {
+      return whole;
+    }
+    return renderEntity({ body, userNames, channelNames });
+  });
+
+  const formatted = linked.replace(BOLD_PATTERN, '**$1**').replace(STRIKE_PATTERN, '~~$1~~');
+
+  const restored = formatted.replace(
+    PLACEHOLDER_PATTERN,
+    (whole: string, index: string) => fragments[Number(index)] ?? whole,
+  );
+
+  return restored.replace(ESCAPE_PATTERN, (whole: string, name: string) => {
+    return HTML_ENTITIES[name] ?? whole;
+  });
+};

--- a/apps/desktop/src/features/integrations/slack/slackThreadCandidates.test.ts
+++ b/apps/desktop/src/features/integrations/slack/slackThreadCandidates.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IsoDateTime, WorkspaceId } from '@goodboy/types';
+import type { SlackChannel, SlackMessage, SlackUser } from './client';
+
+const h = vi.hoisted(() => ({
+  channels: [] as ReadonlyArray<SlackChannel>,
+  users: [] as ReadonlyArray<SlackUser>,
+  headsByChannel: {} as Record<string, ReadonlyArray<SlackMessage>>,
+  permalinkCalls: [] as ReadonlyArray<string>,
+  permalinkFails: false,
+}));
+
+vi.mock('./client', () => ({
+  slackListChannels: vi.fn(async () => h.channels),
+  slackListUsers: vi.fn(async () => h.users),
+  slackListThreadHeads: vi.fn(async ({ channelId }: { channelId: string }) => {
+    return h.headsByChannel[channelId] ?? [];
+  }),
+  slackGetPermalink: vi.fn(
+    async ({ channelId, messageTs }: { channelId: string; messageTs: string }) => {
+      h.permalinkCalls = [...h.permalinkCalls, `${channelId}:${messageTs}`];
+      if (h.permalinkFails) {
+        throw new Error('missing_scope');
+      }
+      return `https://acme.slack.com/archives/${channelId}/p${messageTs.replace('.', '')}`;
+    },
+  ),
+}));
+
+const { slackThreadCandidates } = await import('./slackThreadCandidates');
+const { fetchIssueCandidates } = await import('../fetchIssueCandidates');
+const { parseIntegrationTaskUrl } =
+  await import('../../session/components/SessionWorkspace/parts/IntegrationPane/parseIntegrationTaskUrl');
+
+const WORKSPACE_ID = 'ws-1' as WorkspaceId;
+
+const channel = (id: string, name: string): SlackChannel => ({
+  id,
+  name,
+  isMember: true,
+  topic: null,
+  memberCount: 3,
+});
+
+const head = (ts: string, text: string, latestReplyAt: string): SlackMessage => ({
+  ts,
+  threadTs: ts,
+  userId: 'U1',
+  botId: null,
+  text,
+  subtype: null,
+  replyCount: 2,
+  replyUserCount: 2,
+  postedAt: latestReplyAt as IsoDateTime,
+  latestReplyAt: latestReplyAt as IsoDateTime,
+  reactions: [],
+});
+
+beforeEach(() => {
+  h.permalinkCalls = [];
+  h.permalinkFails = false;
+  h.users = [{ id: 'U1', name: 'ada', isBot: false, isDeleted: false, avatarUrl: null }];
+  h.channels = [channel('C1', 'eng-alerts')];
+  h.headsByChannel = {
+    C1: [head('1723456789.123456', 'billing webhook fails on retry', '2026-08-05T09:00:00Z')],
+  };
+});
+
+describe('slackThreadCandidates', () => {
+  it('builds a candidate whose external id round trips with a pasted permalink', async () => {
+    const [candidate] = await slackThreadCandidates({ workspaceId: WORKSPACE_ID });
+
+    expect(candidate?.externalId).toBe('C1:1723456789.123456');
+    expect(candidate?.identifier).toBe('#eng-alerts › billing webhook fails on retry');
+    expect(candidate?.title).toBe('billing webhook fails on retry');
+    expect(candidate?.branchSlug).toBe('billing-webhook-fails-on-retry');
+    expect(candidate?.goal).toBe(
+      'Slack thread in #eng-alerts\n\nada: billing webhook fails on retry',
+    );
+
+    const pasted = parseIntegrationTaskUrl({ provider: 'slack', rawUrl: candidate?.url ?? '' });
+
+    expect(pasted?.externalId).toBe(candidate?.externalId);
+  });
+
+  it('keeps the candidate when the permalink call fails and leaves the url empty', async () => {
+    h.permalinkFails = true;
+
+    const [candidate] = await slackThreadCandidates({ workspaceId: WORKSPACE_ID });
+
+    expect(candidate?.externalId).toBe('C1:1723456789.123456');
+    expect(candidate?.url).toBe('');
+  });
+
+  it('reads at most twelve channels and returns at most twenty-five candidates', async () => {
+    h.channels = Array.from({ length: 20 }, (_, index) => channel(`C${index}`, `channel-${index}`));
+    h.headsByChannel = Object.fromEntries(
+      h.channels.map((entry, channelIndex) => [
+        entry.id,
+        Array.from({ length: 5 }, (_, headIndex) =>
+          head(
+            `17234567${String(channelIndex).padStart(2, '0')}.00000${headIndex}`,
+            `thread ${channelIndex}-${headIndex}`,
+            '2026-08-05T09:00:00Z',
+          ),
+        ),
+      ]),
+    );
+
+    const candidates = await slackThreadCandidates({ workspaceId: WORKSPACE_ID });
+
+    expect(candidates).toHaveLength(25);
+    expect(h.permalinkCalls).toHaveLength(25);
+    expect(candidates.every((candidate) => !candidate.externalId.startsWith('C12:'))).toBe(true);
+  });
+});
+
+describe('fetchIssueCandidates for slack', () => {
+  it('routes the slack provider to the thread candidates', async () => {
+    const candidates = await fetchIssueCandidates({
+      provider: 'slack',
+      workspaceId: WORKSPACE_ID,
+      rootPath: null,
+      gitlabHost: null,
+      jiraConfig: null,
+    });
+
+    expect(candidates.map((candidate) => candidate.externalId)).toEqual(['C1:1723456789.123456']);
+    expect(candidates[0]?.provider).toBe('slack');
+  });
+});

--- a/apps/desktop/src/features/integrations/slack/slackThreadCandidates.ts
+++ b/apps/desktop/src/features/integrations/slack/slackThreadCandidates.ts
@@ -1,0 +1,72 @@
+import type { WorkspaceId } from '@goodboy/types';
+import type { IssueCandidate } from '../fetchIssueCandidates';
+import {
+  slackGetPermalink,
+  slackListChannels,
+  slackListThreadHeads,
+  slackListUsers,
+  type SlackChannel,
+  type SlackMessage,
+} from './client';
+import { goalFromThread } from './goal-from-thread';
+import { slackUserNames } from './nameMaps';
+import {
+  slackThreadBranchSlug,
+  slackThreadExternalId,
+  slackThreadIdentifier,
+  slackThreadTitle,
+} from './threadFormulas';
+
+const CHANNEL_CAP = 12;
+const CANDIDATE_CAP = 25;
+
+type Params = {
+  readonly workspaceId: WorkspaceId;
+};
+
+type Head = {
+  readonly channel: SlackChannel;
+  readonly head: SlackMessage;
+};
+
+const headTimestamp = (head: SlackMessage): string => head.latestReplyAt ?? head.postedAt ?? '';
+
+export const slackThreadCandidates = async ({
+  workspaceId,
+}: Params): Promise<ReadonlyArray<IssueCandidate>> => {
+  const [channels, users] = await Promise.all([
+    slackListChannels({ workspaceId }),
+    slackListUsers({ workspaceId }),
+  ]);
+  const userNames = slackUserNames({ users });
+  const perChannel = await Promise.all(
+    channels.slice(0, CHANNEL_CAP).map(async (channel) => {
+      const heads = await slackListThreadHeads({ workspaceId, channelId: channel.id });
+      return heads.map((head) => ({ channel, head }) satisfies Head);
+    }),
+  );
+  const ranked = perChannel
+    .flat()
+    .sort((left, right) => headTimestamp(right.head).localeCompare(headTimestamp(left.head)))
+    .slice(0, CANDIDATE_CAP);
+
+  return Promise.all(
+    ranked.map(async ({ channel, head }) => {
+      const threadTs = head.threadTs ?? head.ts;
+      const url = await slackGetPermalink({
+        workspaceId,
+        channelId: channel.id,
+        messageTs: threadTs,
+      }).catch(() => '');
+      return {
+        provider: 'slack',
+        externalId: slackThreadExternalId({ channelId: channel.id, threadTs }),
+        identifier: slackThreadIdentifier({ channelName: channel.name, text: head.text }),
+        title: slackThreadTitle({ text: head.text }),
+        url,
+        goal: goalFromThread({ channelName: channel.name, messages: [head], userNames }),
+        branchSlug: slackThreadBranchSlug({ text: head.text }),
+      } satisfies IssueCandidate;
+    }),
+  );
+};

--- a/apps/desktop/src/features/integrations/slack/threadFormulas.test.ts
+++ b/apps/desktop/src/features/integrations/slack/threadFormulas.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import {
+  parseSlackThreadExternalId,
+  slackThreadBranchSlug,
+  slackThreadExternalId,
+  slackThreadIdentifier,
+  slackThreadTitle,
+} from './threadFormulas';
+
+const LONG = 'the billing webhook fails on retry and nobody noticed';
+
+describe('slack thread formulas', () => {
+  it('truncates the title to 32 characters with an ellipsis', () => {
+    expect(slackThreadTitle({ text: LONG })).toBe('the billing webhook fails on ret…');
+    expect(slackThreadTitle({ text: 'short one\nsecond line' })).toBe('short one');
+  });
+
+  it('scopes the identifier to the thread, not the channel', () => {
+    const first = slackThreadIdentifier({ channelName: 'eng-alerts', text: LONG });
+    const second = slackThreadIdentifier({ channelName: 'eng-alerts', text: 'deploy is stuck' });
+
+    expect(first).toBe('#eng-alerts › the billing webhook fails on ret…');
+    expect(second).not.toBe(first);
+  });
+
+  it('falls back to the channel when the root message has no text', () => {
+    expect(slackThreadIdentifier({ channelName: 'eng-alerts', text: '' })).toBe('#eng-alerts');
+  });
+
+  it('round-trips the external id', () => {
+    const externalId = slackThreadExternalId({
+      channelId: 'C024BE7LR',
+      threadTs: '1723456789.123456',
+    });
+
+    expect(externalId).toBe('C024BE7LR:1723456789.123456');
+    expect(parseSlackThreadExternalId({ externalId })).toEqual({
+      channelId: 'C024BE7LR',
+      threadTs: '1723456789.123456',
+    });
+  });
+
+  it('rejects an external id that carries no thread timestamp', () => {
+    expect(parseSlackThreadExternalId({ externalId: 'C024BE7LR' })).toBeNull();
+    expect(parseSlackThreadExternalId({ externalId: 'C024BE7LR:' })).toBeNull();
+  });
+
+  it('slugs the branch from the untruncated first line', () => {
+    expect(slackThreadBranchSlug({ text: LONG })).toBe(
+      'the-billing-webhook-fails-on-retry-and-nobody-no',
+    );
+  });
+});

--- a/apps/desktop/src/features/integrations/slack/threadFormulas.ts
+++ b/apps/desktop/src/features/integrations/slack/threadFormulas.ts
@@ -1,0 +1,64 @@
+import { slugifyBranch } from '../../../shared/utils/slugifyBranch';
+
+const TITLE_MAX_LEN = 32;
+const SLUG_MAX_LEN = 48;
+
+type TextParams = {
+  readonly text: string;
+};
+
+export const slackThreadFirstLine = ({ text }: TextParams): string =>
+  text
+    .split('\n')
+    .map((line) => line.trim())
+    .find((line) => line !== '') ?? '';
+
+export const slackThreadTitle = ({ text }: TextParams): string => {
+  const firstLine = slackThreadFirstLine({ text });
+  if (firstLine.length <= TITLE_MAX_LEN) {
+    return firstLine;
+  }
+  return `${firstLine.slice(0, TITLE_MAX_LEN).trimEnd()}…`;
+};
+
+type IdentifierParams = TextParams & {
+  readonly channelName: string;
+};
+
+export const slackThreadIdentifier = ({ channelName, text }: IdentifierParams): string => {
+  const title = slackThreadTitle({ text });
+  if (title === '') {
+    return `#${channelName}`;
+  }
+  return `#${channelName} › ${title}`;
+};
+
+type ExternalIdParams = {
+  readonly channelId: string;
+  readonly threadTs: string;
+};
+
+export const slackThreadExternalId = ({ channelId, threadTs }: ExternalIdParams): string =>
+  `${channelId}:${threadTs}`;
+
+type ParseExternalIdParams = {
+  readonly externalId: string;
+};
+
+export const parseSlackThreadExternalId = ({
+  externalId,
+}: ParseExternalIdParams): ExternalIdParams | null => {
+  const separator = externalId.indexOf(':');
+  if (separator <= 0) {
+    return null;
+  }
+  const channelId = externalId.slice(0, separator);
+  const threadTs = externalId.slice(separator + 1);
+  if (threadTs === '') {
+    return null;
+  }
+  return { channelId, threadTs };
+};
+
+export const slackThreadBranchSlug = ({ text }: TextParams): string =>
+  slugifyBranch({ input: slackThreadFirstLine({ text }), maxLength: SLUG_MAX_LEN });

--- a/apps/desktop/src/features/integrations/slack/useSlackThread/index.test.ts
+++ b/apps/desktop/src/features/integrations/slack/useSlackThread/index.test.ts
@@ -1,0 +1,103 @@
+// @vitest-environment happy-dom
+
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { WorkspaceId } from '@goodboy/types';
+
+const h = vi.hoisted(() => ({
+  state: {} as Record<string, unknown>,
+  calls: { thread: [] as ReadonlyArray<unknown>[], users: 0, channels: 0 },
+}));
+
+const buildState = () => ({
+  ...h.state,
+  refreshSlackThread: vi.fn(async (...args: ReadonlyArray<unknown>) => {
+    h.calls.thread.push(args);
+  }),
+  refreshSlackUsers: vi.fn(async () => {
+    h.calls.users += 1;
+  }),
+  refreshSlackChannels: vi.fn(async () => {
+    h.calls.channels += 1;
+  }),
+});
+
+vi.mock('../../../../store', () => {
+  const useAppStore = <T>(selector: (state: Record<string, unknown>) => T): T =>
+    selector(buildState());
+  useAppStore.getState = () => buildState();
+  return { EMPTY_ARRAY: Object.freeze([]), useAppStore };
+});
+
+const { useSlackThread } = await import('./index');
+
+const WORKSPACE_ID = 'ws-1' as WorkspaceId;
+const TARGET = {
+  workspaceId: WORKSPACE_ID,
+  channelId: 'C1',
+  threadTs: '1723456789.123456',
+  isEnabled: true,
+};
+
+beforeEach(() => {
+  h.calls = { thread: [], users: 0, channels: 0 };
+  h.state = {
+    slackThreads: {
+      'ws-1:C1:1723456789.123456': {
+        messages: [{ ts: '1723456789.123456', text: 'billing webhook fails' }],
+        fetchedAt: null,
+        loading: false,
+        error: null,
+      },
+    },
+    slackUsers: {},
+    slackChannels: {},
+  };
+});
+
+describe('useSlackThread', () => {
+  it('fetches the thread on mount and fills the missing user and channel caches', async () => {
+    renderHook(() => useSlackThread(TARGET));
+
+    await waitFor(() => {
+      expect(h.calls.thread).toHaveLength(1);
+    });
+    expect(h.calls.thread[0]?.[0]).toEqual({
+      workspaceId: WORKSPACE_ID,
+      channelId: 'C1',
+      threadTs: '1723456789.123456',
+    });
+    expect(h.calls.users).toBe(1);
+    expect(h.calls.channels).toBe(1);
+  });
+
+  it('leaves an already cached directory alone', async () => {
+    h.state.slackUsers = { [WORKSPACE_ID]: [] };
+    h.state.slackChannels = {
+      [WORKSPACE_ID]: {
+        channels: [{ id: 'C1', name: 'eng-alerts', isMember: true, topic: null, memberCount: 2 }],
+        loading: false,
+        error: null,
+      },
+    };
+
+    const { result } = renderHook(() => useSlackThread(TARGET));
+
+    await waitFor(() => {
+      expect(h.calls.thread).toHaveLength(1);
+    });
+    expect(h.calls.users).toBe(0);
+    expect(h.calls.channels).toBe(0);
+    expect(result.current.channelName).toBe('eng-alerts');
+    expect(result.current.messages).toHaveLength(1);
+  });
+
+  it('stays quiet when the external id could not be read', async () => {
+    renderHook(() => useSlackThread({ ...TARGET, isEnabled: false }));
+
+    await waitFor(() => {
+      expect(h.calls.channels).toBe(0);
+    });
+    expect(h.calls.thread).toEqual([]);
+  });
+});

--- a/apps/desktop/src/features/integrations/slack/useSlackThread/index.ts
+++ b/apps/desktop/src/features/integrations/slack/useSlackThread/index.ts
@@ -1,0 +1,74 @@
+import { useCallback, useEffect } from 'react';
+import type { WorkspaceId } from '@goodboy/types';
+import { EMPTY_ARRAY, useAppStore } from '../../../../store';
+import { slackThreadKey } from '../../../../store/slices/slack-threads';
+import type { SlackChannel, SlackMessage, SlackUser } from '../client';
+
+type Params = {
+  readonly workspaceId: WorkspaceId;
+  readonly channelId: string;
+  readonly threadTs: string;
+  readonly isEnabled: boolean;
+};
+
+export type UseSlackThread = {
+  readonly messages: ReadonlyArray<SlackMessage>;
+  readonly users: ReadonlyArray<SlackUser>;
+  readonly channels: ReadonlyArray<SlackChannel>;
+  readonly channelName: string;
+  readonly isLoading: boolean;
+  readonly error: string | null;
+  readonly refetch: () => void;
+};
+
+export const useSlackThread = ({
+  workspaceId,
+  channelId,
+  threadTs,
+  isEnabled,
+}: Params): UseSlackThread => {
+  const key = slackThreadKey({ workspaceId, channelId, threadTs });
+  const entry = useAppStore((state) => state.slackThreads[key] ?? null);
+  const users = useAppStore((state) => state.slackUsers[workspaceId] ?? EMPTY_ARRAY);
+  const channelsEntry = useAppStore((state) => state.slackChannels[workspaceId] ?? null);
+
+  const load = useCallback(
+    async (force: boolean) => {
+      if (!isEnabled) {
+        return;
+      }
+      const state = useAppStore.getState();
+      const pending: Array<Promise<void>> = [
+        state.refreshSlackThread({ workspaceId, channelId, threadTs }, { force }),
+      ];
+      if (state.slackUsers[workspaceId] == null) {
+        pending.push(state.refreshSlackUsers({ workspaceId }));
+      }
+      if (state.slackChannels[workspaceId] == null) {
+        pending.push(state.refreshSlackChannels({ workspaceId }));
+      }
+      await Promise.all(pending);
+    },
+    [workspaceId, channelId, threadTs, isEnabled],
+  );
+
+  useEffect(() => {
+    void load(false);
+  }, [load]);
+
+  const refetch = useCallback(() => {
+    void load(true);
+  }, [load]);
+
+  const channels = channelsEntry?.channels ?? EMPTY_ARRAY;
+
+  return {
+    messages: entry?.messages ?? EMPTY_ARRAY,
+    users,
+    channels,
+    channelName: channels.find((channel) => channel.id === channelId)?.name ?? channelId,
+    isLoading: entry?.loading === true,
+    error: entry?.error ?? null,
+    refetch,
+  };
+};

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/LinkedWorkSection.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/LinkedWorkSection.test.tsx
@@ -175,8 +175,18 @@ describe('LinkedWorkSection', () => {
     fireEvent.click(screen.getByRole('menuitem', { name: 'Sentry' }));
     fireEvent.click(screen.getByRole('button', { name: 'Link work' }));
     fireEvent.click(screen.getByRole('menuitem', { name: 'GitLab issues' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Link work' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Jira issues' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Link work' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Slack threads' }));
 
-    expect(onSelectLens.mock.calls).toEqual([['linear'], ['sentry'], ['gitlab_issues']]);
+    expect(onSelectLens.mock.calls).toEqual([
+      ['linear'],
+      ['sentry'],
+      ['gitlab_issues'],
+      ['jira_issues'],
+      ['slack_threads'],
+    ]);
   });
 
   it('shows a task repository only in a composite workspace', () => {

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/LinkedWorkSection.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/LinkedWorkSection.tsx
@@ -67,6 +67,13 @@ export const LinkedWorkSection = ({ sessionId, onSelectLens }: Props) => {
       icon: CONCEPT_ICONS.jira,
       onClick: () => onSelectLens('jira_issues'),
     },
+    {
+      kind: 'item',
+      key: 'slack',
+      label: 'Slack threads',
+      icon: CONCEPT_ICONS.slack,
+      onClick: () => onSelectLens('slack_threads'),
+    },
   ];
   const hasLinkedWork = linkedIssues.length > 0 || externalTasks.length > 0;
   const openLinkedIssue = (issueNumber: number) => {

--- a/apps/desktop/src/features/session/components/SessionWorkspace/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/index.test.tsx
@@ -178,6 +178,11 @@ vi.mock('./parts/QuestionsPane', () => ({ QuestionsPane: () => null }));
 vi.mock('./parts/SlotPane', () => ({ SlotPane: () => null }));
 vi.mock('./parts/PrPane', () => ({ PrPane: () => null }));
 vi.mock('./parts/FilesPane', () => ({ FilesPane: () => null }));
+vi.mock('./parts/IntegrationPane', () => ({
+  IntegrationPane: ({ provider }: { provider: string }) => (
+    <div data-testid="integration-pane">{provider}</div>
+  ),
+}));
 vi.mock('./parts/IntegrationPane/GithubTaskDetail', () => ({
   GithubTaskDetail: ({ issueNumber }: { issueNumber: number }) => (
     <div data-testid="github-task-detail">{issueNumber}</div>
@@ -865,5 +870,22 @@ describe('SessionWorkspace github issue lens', () => {
 
     expect(screen.getByTestId('github-task-detail').textContent).toBe('12');
     expect(screen.queryByText('No GitHub issue linked')).toBeNull();
+  });
+});
+
+describe('SessionWorkspace integration lenses', () => {
+  it.each([
+    ['linear', 'linear'],
+    ['sentry', 'sentry'],
+    ['gitlab_issues', 'gitlab'],
+    ['jira_issues', 'jira'],
+    ['slack_threads', 'slack'],
+  ] as const)('mounts the integration pane for the %s lens', (lens, provider) => {
+    store.activeLens = { [SESSION_ID]: lens };
+    store.selectedAgentId = {};
+
+    render(<SessionWorkspace session={session} isActive />);
+
+    expect(screen.getByTestId('integration-pane').textContent).toBe(provider);
   });
 });

--- a/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
@@ -379,6 +379,13 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
                     provider="jira"
                   />
                 ) : null}
+                {lens === 'slack_threads' ? (
+                  <IntegrationPane
+                    sessionId={sessionId}
+                    workspaceId={session.workspaceId}
+                    provider="slack"
+                  />
+                ) : null}
                 {lens === 'github_issue' ? (
                   githubIssueNumber != null ? (
                     <GithubTaskDetail

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/FocusedTaskBody.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/FocusedTaskBody.test.tsx
@@ -32,6 +32,10 @@ vi.mock('./GitlabTaskDetail', () => ({
   GitlabTaskDetail: () => <div>Gitlab detail</div>,
 }));
 
+vi.mock('./SlackTaskDetail', () => ({
+  SlackTaskDetail: () => <div>Slack detail</div>,
+}));
+
 import { FocusedTaskBody } from './FocusedTaskBody';
 
 const WORKSPACE_ID = 'workspace-1' as WorkspaceId;
@@ -53,6 +57,7 @@ describe('FocusedTaskBody', () => {
   it.each([
     ['github', 'Github detail'],
     ['gitlab', 'Gitlab detail'],
+    ['slack', 'Slack detail'],
   ] as const)('dispatches a connected %s task to its detail component', (provider, text) => {
     render(
       <FocusedTaskBody
@@ -82,6 +87,7 @@ describe('FocusedTaskBody', () => {
 
       expect(screen.queryByText('Github detail')).toBeNull();
       expect(screen.queryByText('Gitlab detail')).toBeNull();
+      expect(screen.queryByText('Slack detail')).toBeNull();
       expect(screen.getByRole('button', { name: 'Open #42' })).toBeDefined();
     },
   );

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/FocusedTaskBody.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/FocusedTaskBody.tsx
@@ -13,6 +13,7 @@ import { SentryTaskDetail } from './SentryTaskDetail';
 import { GithubTaskDetail } from './GithubTaskDetail';
 import { GitlabTaskDetail } from './GitlabTaskDetail';
 import { JiraTaskDetail } from './JiraTaskDetail';
+import { SlackTaskDetail } from './SlackTaskDetail';
 
 type Props = {
   readonly provider: SessionExternalTaskProvider;
@@ -45,6 +46,10 @@ export const FocusedTaskBody = ({ provider, sessionId, workspaceId, task, isConn
 
   if (isConnected && provider === 'jira') {
     return <JiraTaskDetail workspaceId={workspaceId} task={task} />;
+  }
+
+  if (isConnected && provider === 'slack') {
+    return <SlackTaskDetail workspaceId={workspaceId} task={task} />;
   }
 
   return (

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/LinkIssueForm.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/LinkIssueForm.tsx
@@ -12,6 +12,9 @@ import { formatError } from '../../../../../../shared/lib/errors';
 import { IssuePicker } from '../../../../../integrations/components/IssuePicker';
 import { useIssueCandidates } from '../../../../../integrations/hooks/useIssueCandidates';
 import type { IssueCandidate } from '../../../../../integrations/fetchIssueCandidates';
+import { slackGetThread, slackListChannels } from '../../../../../integrations/slack/client';
+import { hydrateSlackThreadTask } from '../../../../../integrations/slack/hydrateSlackThreadTask';
+import { parseSlackThreadExternalId } from '../../../../../integrations/slack/threadFormulas';
 import { resolvePastedIssueCandidate } from './resolvePastedIssueCandidate';
 
 type Props = {
@@ -19,7 +22,39 @@ type Props = {
   readonly workspaceId: WorkspaceId;
   readonly provider: SessionExternalTaskProvider;
   readonly providerLabel: string;
+  readonly nounPhrase: string;
+  readonly nounPlural: string;
   readonly onLinked?: () => void;
+};
+
+type HydrateParams = {
+  readonly workspaceId: WorkspaceId;
+  readonly candidate: IssueCandidate;
+};
+
+type Hydrated = {
+  readonly identifier: string;
+  readonly title: string;
+};
+
+const hydrateSlackCandidate = async ({
+  workspaceId,
+  candidate,
+}: HydrateParams): Promise<Hydrated> => {
+  const parsed = parseSlackThreadExternalId({ externalId: candidate.externalId });
+  if (parsed == null) {
+    return { identifier: candidate.identifier, title: candidate.title };
+  }
+  const [channels, messages] = await Promise.all([
+    slackListChannels({ workspaceId }),
+    slackGetThread({ workspaceId, channelId: parsed.channelId, threadTs: parsed.threadTs }),
+  ]);
+  return hydrateSlackThreadTask({
+    channelId: parsed.channelId,
+    threadTs: parsed.threadTs,
+    channels,
+    messages,
+  });
 };
 
 export const LinkIssueForm = ({
@@ -27,6 +62,8 @@ export const LinkIssueForm = ({
   workspaceId,
   provider,
   providerLabel,
+  nounPhrase,
+  nounPlural,
   onLinked,
 }: Props) => {
   const [error, setError] = useState<string | null>(null);
@@ -38,11 +75,15 @@ export const LinkIssueForm = ({
     setError(null);
     setIsLinking(true);
     try {
+      const hydrated =
+        provider === 'slack'
+          ? await hydrateSlackCandidate({ workspaceId, candidate })
+          : { identifier: candidate.identifier, title: candidate.title };
       await linkSessionExternalTask(sessionId, {
         provider,
         externalId: candidate.externalId,
-        identifier: candidate.identifier,
-        title: candidate.title,
+        identifier: hydrated.identifier,
+        title: hydrated.title,
         url: candidate.url,
         createdAt: new Date().toISOString() as IsoDateTime,
       });
@@ -59,7 +100,7 @@ export const LinkIssueForm = ({
   return (
     <div className="flex flex-col gap-2">
       <label htmlFor={`${provider}-issue-picker`} className="text-xs font-medium text-foreground">
-        Link an issue
+        {`Link ${nounPhrase}`}
       </label>
       <IssuePicker
         inputId={`${provider}-issue-picker`}
@@ -68,7 +109,7 @@ export const LinkIssueForm = ({
         isLoaded={candidates.isLoaded}
         error={candidates.error}
         value={null}
-        placeholder={`Search ${providerLabel} issues or paste a URL…`}
+        placeholder={`Search ${providerLabel} ${nounPlural} or paste a URL…`}
         disabled={isLinking}
         resolvePaste={(rawValue) => resolvePastedIssueCandidate({ provider, rawValue })}
         onOpen={candidates.load}

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/LinkIssueForm.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/LinkIssueForm.tsx
@@ -49,12 +49,16 @@ const hydrateSlackCandidate = async ({
     slackListChannels({ workspaceId }),
     slackGetThread({ workspaceId, channelId: parsed.channelId, threadTs: parsed.threadTs }),
   ]);
-  return hydrateSlackThreadTask({
+  const hydrated = hydrateSlackThreadTask({
     channelId: parsed.channelId,
     threadTs: parsed.threadTs,
     channels,
     messages,
   });
+  if (hydrated == null) {
+    throw new Error('That thread has no messages to read. It may have been deleted.');
+  }
+  return hydrated;
 };
 
 export const LinkIssueForm = ({

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/LinkTicketPopover.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/LinkTicketPopover.tsx
@@ -10,9 +10,20 @@ type Props = {
   readonly workspaceId: WorkspaceId;
   readonly provider: SessionExternalTaskProvider;
   readonly providerLabel: string;
+  readonly noun: string;
+  readonly nounPhrase: string;
+  readonly nounPlural: string;
 };
 
-export const LinkTicketPopover = ({ sessionId, workspaceId, provider, providerLabel }: Props) => {
+export const LinkTicketPopover = ({
+  sessionId,
+  workspaceId,
+  provider,
+  providerLabel,
+  noun,
+  nounPhrase,
+  nounPlural,
+}: Props) => {
   const {
     open,
     close,
@@ -35,14 +46,14 @@ export const LinkTicketPopover = ({ sessionId, workspaceId, provider, providerLa
     <div ref={containerRef} className="relative min-w-0">
       <Button variant="secondary" size="sm" onClick={toggle}>
         <Plus size={13} aria-hidden />
-        Link issue
+        {`Link ${noun}`}
       </Button>
       <DropdownPortal portal={portal} portalTarget={portalTarget}>
         {open && (
           <Popover
             innerRef={popupRef}
             role="dialog"
-            ariaLabel={`Link ${providerLabel} issue`}
+            ariaLabel={`Link ${providerLabel} ${noun}`}
             className={cn(popupClassName, 'p-3')}
             style={popupStyle}
           >
@@ -51,6 +62,8 @@ export const LinkTicketPopover = ({ sessionId, workspaceId, provider, providerLa
               workspaceId={workspaceId}
               provider={provider}
               providerLabel={providerLabel}
+              nounPhrase={nounPhrase}
+              nounPlural={nounPlural}
               onLinked={close}
             />
           </Popover>

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/SlackTaskDetail.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/SlackTaskDetail.tsx
@@ -1,0 +1,62 @@
+import type { SessionExternalTask, WorkspaceId } from '@goodboy/types';
+import { HeaderBand, StudioDetailLayout } from '../../../../../../shared/components/StudioDetail';
+import { LensEmptyState } from '../../../../../../shared/components/LensEmptyState';
+import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../../../shared/components/conceptIcons';
+import { SlackThreadDetail } from '../../../../../integrations/slack/SlackThreadDetail';
+import { parseSlackThreadExternalId } from '../../../../../integrations/slack/threadFormulas';
+import { useSlackThread } from '../../../../../integrations/slack/useSlackThread';
+
+type Props = {
+  readonly workspaceId: WorkspaceId;
+  readonly task: SessionExternalTask;
+};
+
+export const SlackTaskDetail = ({ workspaceId, task }: Props) => {
+  const parsed = parseSlackThreadExternalId({ externalId: task.externalId });
+  const thread = useSlackThread({
+    workspaceId,
+    channelId: parsed?.channelId ?? '',
+    threadTs: parsed?.threadTs ?? '',
+    isEnabled: parsed != null,
+  });
+
+  if (parsed == null) {
+    return (
+      <StudioDetailLayout
+        fit="fill"
+        header={
+          <HeaderBand
+            meta={
+              <span className="font-mono text-2xs text-muted-foreground">{task.identifier}</span>
+            }
+            title={task.title}
+          />
+        }
+      >
+        <LensEmptyState
+          icon={CONCEPT_ICONS.slack}
+          tone={CONCEPT_TONE.slack}
+          title="This link no longer points at a thread"
+          description="Unlink it and paste the Slack permalink again."
+        />
+      </StudioDetailLayout>
+    );
+  }
+
+  const rootText = thread.messages[0]?.text ?? task.title;
+
+  return (
+    <SlackThreadDetail
+      channelName={thread.channelName}
+      rootText={rootText}
+      url={task.url}
+      messages={thread.messages}
+      users={thread.users}
+      channels={thread.channels}
+      isLoading={thread.isLoading}
+      error={thread.error}
+      onRetry={thread.refetch}
+      fit="fill"
+    />
+  );
+};

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/index.tsx
@@ -36,6 +36,10 @@ type Props = {
 
 type ProviderMeta = Readonly<{
   label: string;
+  noun: string;
+  nounPhrase: string;
+  nounPlural: string;
+  linkHint: string;
 }>;
 
 type UnlinkParams = {
@@ -43,13 +47,56 @@ type UnlinkParams = {
 };
 
 const PROVIDER_META: Record<SessionExternalTaskProvider, ProviderMeta> = {
-  linear: { label: 'Linear' },
-  sentry: { label: 'Sentry' },
-  gitlab: { label: 'GitLab' },
-  jira: { label: 'Jira' },
-  github: { label: 'GitHub' },
-  bitbucket: { label: 'Bitbucket' },
-  slack: { label: 'Slack' },
+  linear: {
+    label: 'Linear',
+    noun: 'issue',
+    nounPhrase: 'an issue',
+    nounPlural: 'issues',
+    linkHint: 'Search your assigned Linear issues or paste a URL to link one to this session.',
+  },
+  sentry: {
+    label: 'Sentry',
+    noun: 'issue',
+    nounPhrase: 'an issue',
+    nounPlural: 'issues',
+    linkHint: 'Search your assigned Sentry issues or paste a URL to link one to this session.',
+  },
+  gitlab: {
+    label: 'GitLab',
+    noun: 'issue',
+    nounPhrase: 'an issue',
+    nounPlural: 'issues',
+    linkHint: 'Search your assigned GitLab issues or paste a URL to link one to this session.',
+  },
+  jira: {
+    label: 'Jira',
+    noun: 'issue',
+    nounPhrase: 'an issue',
+    nounPlural: 'issues',
+    linkHint: 'Search your assigned Jira issues or paste a URL to link one to this session.',
+  },
+  github: {
+    label: 'GitHub',
+    noun: 'issue',
+    nounPhrase: 'an issue',
+    nounPlural: 'issues',
+    linkHint: 'Search your assigned GitHub issues or paste a URL to link one to this session.',
+  },
+  bitbucket: {
+    label: 'Bitbucket',
+    noun: 'pull request',
+    nounPhrase: 'a pull request',
+    nounPlural: 'pull requests',
+    linkHint: 'Paste a Bitbucket pull request URL to link one to this session.',
+  },
+  slack: {
+    label: 'Slack',
+    noun: 'thread',
+    nounPhrase: 'a thread',
+    nounPlural: 'threads',
+    linkHint:
+      'Pick a thread from a channel the bot has joined, or paste a Slack permalink to link one.',
+  },
 };
 
 export const IntegrationPane = ({ sessionId, workspaceId, provider }: Props) => {
@@ -101,6 +148,9 @@ export const IntegrationPane = ({ sessionId, workspaceId, provider }: Props) => 
       workspaceId={workspaceId}
       provider={provider}
       providerLabel={meta.label}
+      noun={meta.noun}
+      nounPhrase={meta.nounPhrase}
+      nounPlural={meta.nounPlural}
     />
   );
   const focusedTask = tasks.find((task) => integrationTaskKey({ task }) === focusedTaskKey) ?? null;
@@ -141,7 +191,7 @@ export const IntegrationPane = ({ sessionId, workspaceId, provider }: Props) => 
               className="max-w-sm"
               icon={<Unlink size={12} aria-hidden />}
               title={`Unlink ${focusedTask.identifier}?`}
-              description={`Removes the ${meta.label} issue from this session without changing the issue.`}
+              description={`Removes the ${meta.label} ${meta.noun} from this session without changing the ${meta.noun}.`}
               confirmLabel={`Unlink ${focusedTask.identifier}`}
               autoDisarmMs={4000}
               isBusy={isUnlinking}
@@ -152,7 +202,7 @@ export const IntegrationPane = ({ sessionId, workspaceId, provider }: Props) => 
             <div className="flex items-center gap-1.5">
               <GhostActionButton
                 icon={ArrowLeft}
-                label="All issues"
+                label={`All ${meta.nounPlural}`}
                 onClick={() => setFocusedTaskKey(null)}
               />
               <GhostActionButton
@@ -189,7 +239,7 @@ export const IntegrationPane = ({ sessionId, workspaceId, provider }: Props) => 
   return (
     <PaneShell
       title={meta.label}
-      description={`External ${meta.label} issues linked to this session.`}
+      description={`External ${meta.label} ${meta.nounPlural} linked to this session.`}
       meta={hasTasks ? tasks.length : undefined}
       measure="reading"
       actions={connection.isConnected && hasTasks ? linkAction : undefined}
@@ -210,8 +260,8 @@ export const IntegrationPane = ({ sessionId, workspaceId, provider }: Props) => 
         <LensEmptyState
           icon={CONCEPT_ICONS.integrations}
           tone={CONCEPT_TONE.integrations}
-          title={`No ${meta.label} issues linked`}
-          description={`Search your assigned ${meta.label} issues or paste a URL to link one to this session.`}
+          title={`No ${meta.label} ${meta.nounPlural} linked`}
+          description={meta.linkHint}
           action={linkAction}
         />
       ) : null}
@@ -223,7 +273,7 @@ export const IntegrationPane = ({ sessionId, workspaceId, provider }: Props) => 
       <div className="flex justify-center">
         <CountToggle
           label="Completed"
-          itemsLabel="issues"
+          itemsLabel={meta.nounPlural}
           count={workItems.history.length}
           isShown={showHistory}
           icon={Check}

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/parseIntegrationTaskUrl.test.ts
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/parseIntegrationTaskUrl.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { slackThreadExternalId } from '../../../../../integrations/slack/threadFormulas';
 import { parseIntegrationTaskUrl } from './parseIntegrationTaskUrl';
 
 describe('parseIntegrationTaskUrl for bitbucket', () => {
@@ -37,5 +38,49 @@ describe('parseIntegrationTaskUrl for bitbucket', () => {
       rawUrl: 'https://bitbucket.org/acme/rocket/pull-requests',
     });
     expect(parsed?.identifier).toBe('pull-requests');
+  });
+});
+
+describe('parseIntegrationTaskUrl for slack', () => {
+  it('converts the p-format permalink timestamp back into an api thread_ts', () => {
+    expect(
+      parseIntegrationTaskUrl({
+        provider: 'slack',
+        rawUrl: 'https://acme.slack.com/archives/C024BE7LR/p1723456789123456',
+      }),
+    ).toMatchObject({
+      externalId: 'C024BE7LR:1723456789.123456',
+      identifier: '#C024BE7LR',
+    });
+  });
+
+  it('prefers the parent thread_ts so a reply permalink links the thread', () => {
+    expect(
+      parseIntegrationTaskUrl({
+        provider: 'slack',
+        rawUrl:
+          'https://acme.slack.com/archives/C024BE7LR/p1723499999000200?thread_ts=1723456789.123456&cid=C024BE7LR',
+      })?.externalId,
+    ).toBe('C024BE7LR:1723456789.123456');
+  });
+
+  it('emits the same external id the studio path writes for the same thread', () => {
+    const pasted = parseIntegrationTaskUrl({
+      provider: 'slack',
+      rawUrl: 'https://acme.slack.com/archives/C024BE7LR/p1723456789123456',
+    });
+
+    expect(pasted?.externalId).toBe(
+      slackThreadExternalId({ channelId: 'C024BE7LR', threadTs: '1723456789.123456' }),
+    );
+  });
+
+  it('falls back to the trailing segment when the url is not a message permalink', () => {
+    expect(
+      parseIntegrationTaskUrl({
+        provider: 'slack',
+        rawUrl: 'https://acme.slack.com/archives/C024BE7LR',
+      })?.externalId,
+    ).toBe('https://acme.slack.com/archives/C024BE7LR');
   });
 });

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/parseIntegrationTaskUrl.ts
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/parseIntegrationTaskUrl.ts
@@ -1,4 +1,5 @@
 import type { SessionExternalTaskProvider } from '@goodboy/types';
+import { slackThreadExternalId } from '../../../../../integrations/slack/threadFormulas';
 
 type Params = {
   readonly provider: SessionExternalTaskProvider;
@@ -14,6 +15,7 @@ type ParsedIntegrationTaskUrl = Readonly<{
 
 type ProviderParams = {
   readonly segments: ReadonlyArray<string>;
+  readonly searchParams: URLSearchParams;
 };
 
 type ParseProviderParams = ProviderParams & {
@@ -95,22 +97,62 @@ const parseBitbucket = ({ segments }: ProviderParams): ProviderResult => {
   return { externalId: identifier, identifier };
 };
 
-const parseProvider = ({ provider, segments }: ParseProviderParams): ProviderResult => {
+const SLACK_TS_TAIL = 6;
+
+type PermalinkSegmentParams = {
+  readonly segment: string;
+};
+
+const slackTsFromPermalinkSegment = ({ segment }: PermalinkSegmentParams): string | null => {
+  const match = /^p(\d+)$/.exec(segment);
+  const digits = match?.[1];
+  if (digits == null || digits.length <= SLACK_TS_TAIL) {
+    return null;
+  }
+  return `${digits.slice(0, digits.length - SLACK_TS_TAIL)}.${digits.slice(-SLACK_TS_TAIL)}`;
+};
+
+const parseSlack = ({ segments, searchParams }: ProviderParams): ProviderResult => {
+  const archivesIndex = segments.findIndex((segment) => segment.toLowerCase() === 'archives');
+  const channelId = segments[archivesIndex + 1];
+  const messageSegment = segments[archivesIndex + 2];
+  if (archivesIndex < 0 || channelId == null || channelId === '' || messageSegment == null) {
+    return null;
+  }
+  const parentTs = searchParams.get('thread_ts');
+  const threadTs =
+    parentTs != null && parentTs !== ''
+      ? parentTs
+      : slackTsFromPermalinkSegment({ segment: messageSegment });
+  if (threadTs == null) {
+    return null;
+  }
+  return {
+    externalId: slackThreadExternalId({ channelId, threadTs }),
+    identifier: `#${channelId}`,
+  };
+};
+
+const parseProvider = ({
+  provider,
+  segments,
+  searchParams,
+}: ParseProviderParams): ProviderResult => {
   switch (provider) {
     case 'linear':
-      return parseLinear({ segments });
+      return parseLinear({ segments, searchParams });
     case 'sentry':
-      return parseSentry({ segments });
+      return parseSentry({ segments, searchParams });
     case 'gitlab':
-      return parseGitlab({ segments });
+      return parseGitlab({ segments, searchParams });
     case 'jira':
-      return parseJira({ segments });
+      return parseJira({ segments, searchParams });
     case 'github':
-      return parseGithub({ segments });
+      return parseGithub({ segments, searchParams });
     case 'bitbucket':
-      return parseBitbucket({ segments });
+      return parseBitbucket({ segments, searchParams });
     case 'slack':
-      return null;
+      return parseSlack({ segments, searchParams });
     default: {
       const exhaustiveProvider: never = provider;
       return exhaustiveProvider;
@@ -149,7 +191,11 @@ export const parseIntegrationTaskUrl = ({
       .split('/')
       .filter((segment) => segment !== '')
       .map((segment) => decodeSegment({ value: segment }));
-    const providerResult = parseProvider({ provider, segments });
+    const providerResult = parseProvider({
+      provider,
+      segments,
+      searchParams: parsedUrl.searchParams,
+    });
     const identifier = providerResult?.identifier ?? segments.at(-1) ?? parsedUrl.hostname;
     return {
       externalId: providerResult?.externalId ?? parsedUrl.toString(),

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn/index.test.tsx
@@ -262,6 +262,7 @@ describe('LensColumn', () => {
       'Sentry',
       'GitLab',
       'Jira',
+      'Slack',
     ]);
     expect(screen.queryByRole('button', { name: 'Explore' })).toBeNull();
   });

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn/index.tsx
@@ -173,6 +173,7 @@ export const LensColumn = ({
   const sentryCount = externalTasks.filter((task) => task.provider === 'sentry').length;
   const gitlabCount = externalTasks.filter((task) => task.provider === 'gitlab').length;
   const jiraCount = externalTasks.filter((task) => task.provider === 'jira').length;
+  const slackCount = externalTasks.filter((task) => task.provider === 'slack').length;
   const githubConnection = resolveIntegrationConnection({
     provider: 'github',
     integrations: workspaceIntegrations,
@@ -204,6 +205,13 @@ export const LensColumn = ({
   });
   const jiraConnection = resolveIntegrationConnection({
     provider: 'jira',
+    integrations: workspaceIntegrations,
+    remoteKind,
+    externalTasks,
+    isGithubAuthenticated: false,
+  });
+  const slackConnection = resolveIntegrationConnection({
+    provider: 'slack',
     integrations: workspaceIntegrations,
     remoteKind,
     externalTasks,
@@ -251,6 +259,14 @@ export const LensColumn = ({
       tone: CONCEPT_TONE.sentry,
       count: sentryCount,
       isConnected: sentryConnection.isConnected,
+    },
+    {
+      kind: 'slack_threads',
+      label: 'Slack',
+      glyph: 'slack',
+      tone: CONCEPT_TONE.slack,
+      count: slackCount,
+      isConnected: slackConnection.isConnected,
     },
   ];
   const sortedIntegrationRows: ReadonlyArray<LensRow> = [...integrationRows].sort((a, b) => {

--- a/apps/desktop/src/shared/detail-fields/index.ts
+++ b/apps/desktop/src/shared/detail-fields/index.ts
@@ -8,6 +8,7 @@ export { gitlabIssueFields } from './gitlabIssueFields';
 export { gitlabMergeRequestFields } from './gitlabMergeRequestFields';
 export { bitbucketPullRequestFields } from './bitbucketPullRequestFields';
 export { jiraIssueFields } from './jiraIssueFields';
+export { slackThreadFields, type SlackThreadProperties } from './slackThreadFields';
 export {
   sessionPullRequestFields,
   type SessionPullRequestProperties,

--- a/apps/desktop/src/shared/detail-fields/slackThreadFields.tsx
+++ b/apps/desktop/src/shared/detail-fields/slackThreadFields.tsx
@@ -1,0 +1,42 @@
+import { Chip } from '@goodboy/ui';
+import type { IsoDateTime } from '@goodboy/types';
+import { formatAbsoluteDateTime } from '../utils/relativeDate';
+import type { DetailFieldRegistry } from './types';
+
+export type SlackThreadProperties = {
+  readonly channelName: string;
+  readonly participants: ReadonlyArray<string>;
+  readonly replyCount: number;
+  readonly lastActivityAt: IsoDateTime | null;
+};
+
+export const slackThreadFields: DetailFieldRegistry<SlackThreadProperties> = [
+  {
+    kind: 'field',
+    key: 'channel',
+    label: 'Channel',
+    render: ({ entity }) => `#${entity.channelName}`,
+  },
+  {
+    kind: 'field',
+    key: 'participants',
+    label: 'In the thread',
+    render: ({ entity }) =>
+      entity.participants.map((participant) => (
+        <Chip key={participant} tone="neutral" shape="badge" bordered={false} label={participant} />
+      )),
+  },
+  {
+    kind: 'field',
+    key: 'replyCount',
+    label: 'Replies',
+    render: ({ entity }) => (entity.replyCount > 0 ? String(entity.replyCount) : null),
+  },
+  {
+    kind: 'field',
+    key: 'lastActivity',
+    label: 'Last activity',
+    render: ({ entity }) =>
+      entity.lastActivityAt != null ? formatAbsoluteDateTime({ iso: entity.lastActivityAt }) : null,
+  },
+];

--- a/apps/desktop/src/store/slices/session-view/index.test.ts
+++ b/apps/desktop/src/store/slices/session-view/index.test.ts
@@ -35,6 +35,7 @@ import type {
 import { STORAGE_PREFIXES } from '../../../shared/lib/storage-keys';
 import { readPersistedLens } from './workSurfaceStorage';
 import { LENS_KINDS } from './types';
+import { LENS_LABEL } from '../../../features/session/lens-labels';
 import { resolveOpenDiffViewerEvent } from './openDiffViewerEvent';
 
 vi.mock('@tauri-apps/api/core', () => ({
@@ -606,6 +607,10 @@ describe('store contract', () => {
       const store = await getStore();
       store.getState().setActiveLens(SESSION_ID, 'linear');
       expect(readPersistedLens(SESSION_ID)).toBe('linear');
+    });
+
+    it('LENS_KINDS holds every lens kind the union declares', () => {
+      expect([...LENS_KINDS].sort()).toEqual(Object.keys(LENS_LABEL).sort());
     });
 
     it.each([...LENS_KINDS])('every lens kind survives a restart: %s', async (lens) => {

--- a/apps/desktop/src/store/slices/session-view/index.test.ts
+++ b/apps/desktop/src/store/slices/session-view/index.test.ts
@@ -34,6 +34,7 @@ import type {
 } from '@goodboy/types';
 import { STORAGE_PREFIXES } from '../../../shared/lib/storage-keys';
 import { readPersistedLens } from './workSurfaceStorage';
+import { LENS_KINDS } from './types';
 import { resolveOpenDiffViewerEvent } from './openDiffViewerEvent';
 
 vi.mock('@tauri-apps/api/core', () => ({
@@ -605,6 +606,12 @@ describe('store contract', () => {
       const store = await getStore();
       store.getState().setActiveLens(SESSION_ID, 'linear');
       expect(readPersistedLens(SESSION_ID)).toBe('linear');
+    });
+
+    it.each([...LENS_KINDS])('every lens kind survives a restart: %s', async (lens) => {
+      const store = await getStore();
+      store.getState().setActiveLens(SESSION_ID, lens);
+      expect(readPersistedLens(SESSION_ID)).toBe(lens);
     });
 
     it('lensGo walks back and forward through visited lenses', async () => {

--- a/apps/desktop/src/store/slices/slack-threads/index.test.ts
+++ b/apps/desktop/src/store/slices/slack-threads/index.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { WorkspaceId } from '@goodboy/types';
+import type { AppStore } from '../../store';
+
+const listChannelsSpy = vi.fn();
+const listUsersSpy = vi.fn();
+const listThreadHeadsSpy = vi.fn();
+const getThreadSpy = vi.fn();
+
+vi.mock('../../../features/integrations/slack/client', () => ({
+  slackListChannels: (...args: ReadonlyArray<unknown>) => listChannelsSpy(...args),
+  slackListUsers: (...args: ReadonlyArray<unknown>) => listUsersSpy(...args),
+  slackListThreadHeads: (...args: ReadonlyArray<unknown>) => listThreadHeadsSpy(...args),
+  slackGetThread: (...args: ReadonlyArray<unknown>) => getThreadSpy(...args),
+}));
+
+const { createSlackThreadsSlice, initialSlackThreadsState, slackChannelKey, slackThreadKey } =
+  await import('./index');
+
+const WORKSPACE_ID = 'ws-1' as WorkspaceId;
+const CHANNEL_ID = 'C024BE7LR';
+const THREAD_TS = '1723456789.123456';
+
+type TestState = Record<string, unknown>;
+
+const buildStore = () => {
+  let state: TestState = { ...initialSlackThreadsState };
+  const set = (partial: unknown) => {
+    const next = typeof partial === 'function' ? partial(state) : partial;
+    state = { ...state, ...(next as TestState) };
+  };
+  const get = () => state as unknown as AppStore;
+  const slice = createSlackThreadsSlice(
+    set as Parameters<typeof createSlackThreadsSlice>[0],
+    get as Parameters<typeof createSlackThreadsSlice>[1],
+  );
+  Object.assign(state, slice);
+  return { getState: () => state, slice };
+};
+
+describe('slack-threads slice', () => {
+  beforeEach(() => {
+    listChannelsSpy.mockReset();
+    listUsersSpy.mockReset();
+    listThreadHeadsSpy.mockReset();
+    getThreadSpy.mockReset();
+  });
+
+  it('caches channels per workspace', async () => {
+    listChannelsSpy.mockResolvedValue([{ id: CHANNEL_ID, name: 'eng-alerts' }]);
+    const store = buildStore();
+
+    await store.slice.refreshSlackChannels({ workspaceId: WORKSPACE_ID });
+
+    expect(listChannelsSpy).toHaveBeenCalledWith({ workspaceId: WORKSPACE_ID });
+    const entry = (store.getState().slackChannels as Record<string, { channels: unknown[] }>)[
+      WORKSPACE_ID
+    ];
+    expect(entry?.channels).toHaveLength(1);
+  });
+
+  it('caches thread heads under a workspace and channel key', async () => {
+    listThreadHeadsSpy.mockResolvedValue([{ ts: THREAD_TS }]);
+    const store = buildStore();
+
+    await store.slice.refreshSlackThreadHeads({
+      workspaceId: WORKSPACE_ID,
+      channelId: CHANNEL_ID,
+    });
+
+    const key = slackChannelKey({ workspaceId: WORKSPACE_ID, channelId: CHANNEL_ID });
+    expect(
+      (store.getState().slackThreadHeads as Record<string, { heads: unknown[] }>)[key]?.heads,
+    ).toHaveLength(1);
+  });
+
+  it('caches one thread so every surface reads the same messages', async () => {
+    getThreadSpy.mockResolvedValue([{ ts: THREAD_TS }, { ts: '1723456999.000100' }]);
+    const store = buildStore();
+
+    await store.slice.refreshSlackThread({
+      workspaceId: WORKSPACE_ID,
+      channelId: CHANNEL_ID,
+      threadTs: THREAD_TS,
+    });
+
+    const key = slackThreadKey({
+      workspaceId: WORKSPACE_ID,
+      channelId: CHANNEL_ID,
+      threadTs: THREAD_TS,
+    });
+    const entry = (
+      store.getState().slackThreads as Record<
+        string,
+        { messages: unknown[]; loading: boolean; error: string | null }
+      >
+    )[key];
+    expect(entry?.messages).toHaveLength(2);
+    expect(entry?.loading).toBe(false);
+    expect(entry?.error).toBeNull();
+  });
+
+  it('records the failure instead of clearing the thread already on screen', async () => {
+    getThreadSpy.mockResolvedValueOnce([{ ts: THREAD_TS }]);
+    const store = buildStore();
+    const target = { workspaceId: WORKSPACE_ID, channelId: CHANNEL_ID, threadTs: THREAD_TS };
+    await store.slice.refreshSlackThread(target);
+
+    getThreadSpy.mockRejectedValueOnce(new Error('missing_scope: channels:history'));
+    await store.slice.refreshSlackThread(target, { force: true });
+
+    const key = slackThreadKey(target);
+    const entry = (
+      store.getState().slackThreads as Record<
+        string,
+        { messages: unknown[]; error: string | null; loading: boolean }
+      >
+    )[key];
+    expect(entry?.error).toContain('missing_scope: channels:history');
+    expect(entry?.messages).toHaveLength(1);
+    expect(entry?.loading).toBe(false);
+  });
+
+  it('keeps the known user list when the directory call fails', async () => {
+    listUsersSpy.mockResolvedValueOnce([{ id: 'U1', name: 'ada' }]);
+    const store = buildStore();
+    await store.slice.refreshSlackUsers({ workspaceId: WORKSPACE_ID });
+
+    listUsersSpy.mockRejectedValueOnce(new Error('ratelimited'));
+    await store.slice.refreshSlackUsers({ workspaceId: WORKSPACE_ID });
+
+    expect(
+      (store.getState().slackUsers as Record<string, ReadonlyArray<unknown>>)[WORKSPACE_ID],
+    ).toHaveLength(1);
+  });
+});

--- a/apps/desktop/src/store/slices/slack-threads/index.ts
+++ b/apps/desktop/src/store/slices/slack-threads/index.ts
@@ -1,0 +1,22 @@
+import { refreshSlackChannels } from './refreshSlackChannels';
+import { refreshSlackThread } from './refreshSlackThread';
+import { refreshSlackThreadHeads } from './refreshSlackThreadHeads';
+import { refreshSlackUsers } from './refreshSlackUsers';
+import type { GetFn, SetFn } from './types';
+
+export { initialSlackThreadsState, slackChannelKey, slackThreadKey } from './state';
+export type {
+  SlackChannelsEntry,
+  SlackThreadEntry,
+  SlackThreadHeadsEntry,
+  SlackThreadsSliceState,
+} from './state';
+export type { RefreshSlackThreadOptions } from './refreshSlackThread';
+export type { SlackChannelParams, SlackThreadParams, SlackWorkspaceParams } from './types';
+
+export const createSlackThreadsSlice = (set: SetFn, get: GetFn) => ({
+  refreshSlackChannels: refreshSlackChannels(set, get),
+  refreshSlackUsers: refreshSlackUsers(set, get),
+  refreshSlackThreadHeads: refreshSlackThreadHeads(set, get),
+  refreshSlackThread: refreshSlackThread(set, get),
+});

--- a/apps/desktop/src/store/slices/slack-threads/refreshSlackChannels.ts
+++ b/apps/desktop/src/store/slices/slack-threads/refreshSlackChannels.ts
@@ -1,0 +1,35 @@
+import { slackListChannels } from '../../../features/integrations/slack/client';
+import { formatError } from '../../../shared/lib/errors';
+import type { GetFn, SetFn, SlackWorkspaceParams } from './types';
+
+export const refreshSlackChannels = (set: SetFn, get: GetFn) => {
+  return async ({ workspaceId }: SlackWorkspaceParams): Promise<void> => {
+    const current = get().slackChannels[workspaceId];
+    set((state) => ({
+      slackChannels: {
+        ...state.slackChannels,
+        [workspaceId]: { channels: current?.channels ?? [], loading: true, error: null },
+      },
+    }));
+    try {
+      const channels = await slackListChannels({ workspaceId });
+      set((state) => ({
+        slackChannels: {
+          ...state.slackChannels,
+          [workspaceId]: { channels, loading: false, error: null },
+        },
+      }));
+    } catch (error) {
+      set((state) => ({
+        slackChannels: {
+          ...state.slackChannels,
+          [workspaceId]: {
+            channels: state.slackChannels[workspaceId]?.channels ?? [],
+            loading: false,
+            error: formatError(error),
+          },
+        },
+      }));
+    }
+  };
+};

--- a/apps/desktop/src/store/slices/slack-threads/refreshSlackThread.ts
+++ b/apps/desktop/src/store/slices/slack-threads/refreshSlackThread.ts
@@ -1,0 +1,59 @@
+import type { IsoDateTime } from '@goodboy/types';
+import { slackGetThread } from '../../../features/integrations/slack/client';
+import { formatError } from '../../../shared/lib/errors';
+import { slackThreadKey } from './state';
+import type { GetFn, SetFn, SlackThreadParams } from './types';
+
+export type RefreshSlackThreadOptions = {
+  readonly force?: boolean;
+};
+
+export const refreshSlackThread = (set: SetFn, get: GetFn) => {
+  return async (
+    { workspaceId, channelId, threadTs }: SlackThreadParams,
+    options?: RefreshSlackThreadOptions,
+  ): Promise<void> => {
+    const key = slackThreadKey({ workspaceId, channelId, threadTs });
+    const current = get().slackThreads[key];
+    if (options?.force !== true && current?.loading === true) {
+      return;
+    }
+    set((state) => ({
+      slackThreads: {
+        ...state.slackThreads,
+        [key]: {
+          messages: current?.messages ?? [],
+          fetchedAt: current?.fetchedAt ?? null,
+          loading: true,
+          error: null,
+        },
+      },
+    }));
+    try {
+      const messages = await slackGetThread({ workspaceId, channelId, threadTs });
+      set((state) => ({
+        slackThreads: {
+          ...state.slackThreads,
+          [key]: {
+            messages,
+            fetchedAt: new Date().toISOString() as IsoDateTime,
+            loading: false,
+            error: null,
+          },
+        },
+      }));
+    } catch (error) {
+      set((state) => ({
+        slackThreads: {
+          ...state.slackThreads,
+          [key]: {
+            messages: state.slackThreads[key]?.messages ?? [],
+            fetchedAt: state.slackThreads[key]?.fetchedAt ?? null,
+            loading: false,
+            error: formatError(error),
+          },
+        },
+      }));
+    }
+  };
+};

--- a/apps/desktop/src/store/slices/slack-threads/refreshSlackThreadHeads.ts
+++ b/apps/desktop/src/store/slices/slack-threads/refreshSlackThreadHeads.ts
@@ -1,0 +1,37 @@
+import { slackListThreadHeads } from '../../../features/integrations/slack/client';
+import { formatError } from '../../../shared/lib/errors';
+import { slackChannelKey } from './state';
+import type { GetFn, SetFn, SlackChannelParams } from './types';
+
+export const refreshSlackThreadHeads = (set: SetFn, get: GetFn) => {
+  return async ({ workspaceId, channelId }: SlackChannelParams): Promise<void> => {
+    const key = slackChannelKey({ workspaceId, channelId });
+    const current = get().slackThreadHeads[key];
+    set((state) => ({
+      slackThreadHeads: {
+        ...state.slackThreadHeads,
+        [key]: { heads: current?.heads ?? [], loading: true, error: null },
+      },
+    }));
+    try {
+      const heads = await slackListThreadHeads({ workspaceId, channelId });
+      set((state) => ({
+        slackThreadHeads: {
+          ...state.slackThreadHeads,
+          [key]: { heads, loading: false, error: null },
+        },
+      }));
+    } catch (error) {
+      set((state) => ({
+        slackThreadHeads: {
+          ...state.slackThreadHeads,
+          [key]: {
+            heads: state.slackThreadHeads[key]?.heads ?? [],
+            loading: false,
+            error: formatError(error),
+          },
+        },
+      }));
+    }
+  };
+};

--- a/apps/desktop/src/store/slices/slack-threads/refreshSlackUsers.ts
+++ b/apps/desktop/src/store/slices/slack-threads/refreshSlackUsers.ts
@@ -1,0 +1,17 @@
+import { slackListUsers } from '../../../features/integrations/slack/client';
+import type { GetFn, SetFn, SlackWorkspaceParams } from './types';
+
+export const refreshSlackUsers = (set: SetFn, get: GetFn) => {
+  return async ({ workspaceId }: SlackWorkspaceParams): Promise<void> => {
+    try {
+      const users = await slackListUsers({ workspaceId });
+      set((state) => ({ slackUsers: { ...state.slackUsers, [workspaceId]: users } }));
+    } catch {
+      const known = get().slackUsers[workspaceId];
+      if (known != null) {
+        return;
+      }
+      set((state) => ({ slackUsers: { ...state.slackUsers, [workspaceId]: [] } }));
+    }
+  };
+};

--- a/apps/desktop/src/store/slices/slack-threads/state.ts
+++ b/apps/desktop/src/store/slices/slack-threads/state.ts
@@ -1,0 +1,54 @@
+import type { IsoDateTime, WorkspaceId } from '@goodboy/types';
+import type {
+  SlackChannel,
+  SlackMessage,
+  SlackUser,
+} from '../../../features/integrations/slack/client';
+
+export type SlackChannelsEntry = {
+  readonly channels: ReadonlyArray<SlackChannel>;
+  readonly loading: boolean;
+  readonly error: string | null;
+};
+
+export type SlackThreadHeadsEntry = {
+  readonly heads: ReadonlyArray<SlackMessage>;
+  readonly loading: boolean;
+  readonly error: string | null;
+};
+
+export type SlackThreadEntry = {
+  readonly messages: ReadonlyArray<SlackMessage>;
+  readonly fetchedAt: IsoDateTime | null;
+  readonly loading: boolean;
+  readonly error: string | null;
+};
+
+export type SlackThreadsSliceState = {
+  readonly slackChannels: Readonly<Record<WorkspaceId, SlackChannelsEntry>>;
+  readonly slackUsers: Readonly<Record<WorkspaceId, ReadonlyArray<SlackUser>>>;
+  readonly slackThreadHeads: Readonly<Record<string, SlackThreadHeadsEntry>>;
+  readonly slackThreads: Readonly<Record<string, SlackThreadEntry>>;
+};
+
+export const initialSlackThreadsState: SlackThreadsSliceState = {
+  slackChannels: {},
+  slackUsers: {},
+  slackThreadHeads: {},
+  slackThreads: {},
+};
+
+type ChannelKeyParams = {
+  readonly workspaceId: WorkspaceId;
+  readonly channelId: string;
+};
+
+export const slackChannelKey = ({ workspaceId, channelId }: ChannelKeyParams): string =>
+  `${workspaceId}:${channelId}`;
+
+type ThreadKeyParams = ChannelKeyParams & {
+  readonly threadTs: string;
+};
+
+export const slackThreadKey = ({ workspaceId, channelId, threadTs }: ThreadKeyParams): string =>
+  `${workspaceId}:${channelId}:${threadTs}`;

--- a/apps/desktop/src/store/slices/slack-threads/types.ts
+++ b/apps/desktop/src/store/slices/slack-threads/types.ts
@@ -1,0 +1,15 @@
+import type { WorkspaceId } from '@goodboy/types';
+
+export type { SetFn, GetFn } from '../../slice-types';
+
+export type SlackWorkspaceParams = {
+  readonly workspaceId: WorkspaceId;
+};
+
+export type SlackChannelParams = SlackWorkspaceParams & {
+  readonly channelId: string;
+};
+
+export type SlackThreadParams = SlackChannelParams & {
+  readonly threadTs: string;
+};

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -91,6 +91,14 @@ import {
   type BitbucketPrWriteParams,
   type RefreshSessionBitbucketPrOptions,
 } from './slices/bitbucket-pr';
+import {
+  createSlackThreadsSlice,
+  initialSlackThreadsState,
+  type RefreshSlackThreadOptions,
+  type SlackChannelParams,
+  type SlackThreadParams,
+  type SlackWorkspaceParams,
+} from './slices/slack-threads';
 import { createReviewPrsSlice } from './slices/review-prs';
 import { createReviewDraftsSlice } from './slices/review-drafts';
 import type {
@@ -587,6 +595,10 @@ export type AppActions = {
   declineBitbucketPr(params: BitbucketPrWriteParams): Promise<void>;
   commentOnBitbucketPr(params: BitbucketPrCommentParams): Promise<void>;
   replyToBitbucketPrComment(params: BitbucketPrReplyParams): Promise<void>;
+  refreshSlackChannels(params: SlackWorkspaceParams): Promise<void>;
+  refreshSlackUsers(params: SlackWorkspaceParams): Promise<void>;
+  refreshSlackThreadHeads(params: SlackChannelParams): Promise<void>;
+  refreshSlackThread(params: SlackThreadParams, options?: RefreshSlackThreadOptions): Promise<void>;
   closePr(sessionId: SessionId, prNumber?: number): Promise<void>;
   reopenPr(sessionId: SessionId, prNumber?: number): Promise<void>;
   editPr(
@@ -804,6 +816,7 @@ export const initialState: AppState = {
   sessionSelectedPrNumber: {},
   sessionGitlabMr: {},
   ...initialBitbucketPrState,
+  ...initialSlackThreadsState,
   reviewPrs: {},
   reviewDrafts: {},
   sessionPendingResolutions: {},
@@ -860,6 +873,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
   ...createGithubSlice(set, get),
   ...createGitlabMrSlice(set, get),
   ...createBitbucketPrSlice(set, get),
+  ...createSlackThreadsSlice(set, get),
   ...createReviewPrsSlice(set, get),
   ...createReviewDraftsSlice(set, get),
   ...createIntegrationsSlice(set, get),

--- a/apps/desktop/src/store/types.ts
+++ b/apps/desktop/src/store/types.ts
@@ -54,6 +54,7 @@ import type { ResolverState } from '../features/workspace/components/WorkspacesS
 import type { GitlabMergeRequest } from '../features/integrations/gitlab/client';
 import type { BitbucketRepo } from '../features/integrations/bitbucket/client';
 import type { SessionBitbucketPrEntry } from './slices/bitbucket-pr/state';
+import type { SlackThreadsSliceState } from './slices/slack-threads/state';
 import type {
   ProviderAuthResults,
   ProviderInfo,
@@ -165,7 +166,7 @@ export type SummarizerSessionStatus = {
   } | null;
 };
 
-type AppSliceState = UpdaterState & ChangelogState;
+type AppSliceState = UpdaterState & ChangelogState & SlackThreadsSliceState;
 
 export type AppState = AppSliceState & {
   readonly workspaces: ReadonlyArray<Workspace>;

--- a/packages/ui/src/__tests__/Markdown.test.tsx
+++ b/packages/ui/src/__tests__/Markdown.test.tsx
@@ -243,6 +243,16 @@ describe('Markdown preview variant', () => {
     expect(container.textContent).not.toContain('and then some');
   });
 
+  it('strikes through a gfm strikethrough instead of showing the tildes', () => {
+    const { container } = render(<Markdown text={'keep ~~drop this~~ keep'} />);
+    expect(container.querySelector('del')?.textContent).toBe('drop this');
+    expect(container.textContent).not.toContain('~~');
+  });
+
+  it('leaves a lone tilde alone', () => {
+    expect(textOf('about ~5 minutes')).toContain('about ~5 minutes');
+  });
+
   it('tightens list spacing', () => {
     const { container } = render(<Markdown variant="preview" text={'- one\n- two'} />);
     expect(container.querySelector('ul')?.className).toContain('gap-0.5');

--- a/packages/ui/src/components/Markdown/index.tsx
+++ b/packages/ui/src/components/Markdown/index.tsx
@@ -189,6 +189,20 @@ function renderInline(input: string, keyPrefix: string, variant: MarkdownVariant
       }
     }
 
+    if (ch === '~' && input[i + 1] === '~') {
+      const end = input.indexOf('~~', i + 2);
+      if (end > i) {
+        flush();
+        out.push(
+          <del key={nextKey()} className="text-muted-foreground">
+            {renderInline(input.slice(i + 2, end), `${keyPrefix}-s${keyN}`, variant)}
+          </del>,
+        );
+        i = end + 2;
+        continue;
+      }
+    }
+
     if ((ch === '*' || ch === '_') && input[i + 1] !== ch) {
       const prev = input[i - 1];
       const isWordBoundary = !prev || /\s|[(\[{,.!?]/.test(prev);


### PR DESCRIPTION
## What

Slack becomes reachable. PR #1249 landed the backend, the connect form and the type-graph widening, but nothing in the app ever mounted any of it: `SlackFormBody` had no call site, there was no `SlackStudio`, and the `slack_threads` lens had no arm in `SessionWorkspace`'s lens if-chain. This PR builds both surfaces and wires every runtime-only point.

**Part A, the workspace `SlackStudio` overlay** (footer button, Jira's chain):

- `features/integrations/slack/SlackStudio/`: shell on `StudioShell` + `StudioRailLayout`, `ThreadInbox` (the 6th per-host inbox copy, deliberately not extracted), `ThreadDetailPanel` wrapping the thread detail plus `LaunchSessionPanel`, and `useSlackThreads` with the fetch-on-mount effect.
- `App.tsx`: `hasSlack` selector, `slackStudioOpen`/`slackStudioFocus` pair, `onOpenSlack`, inclusion in `closeAllStudios()`, the mount block, and `slackEnabled` + `onOpenSlack` threaded to `<AppFooter>`.
- `AppFooter`: the Slack button, title swapping "Connect Slack" / "Launch a session from a Slack thread".

**Part B, the `slack_threads` session lens**:

- `SessionWorkspace/index.tsx`: the lens-mount arm rendering `<IntegrationPane provider="slack" />`. Without it the lens renders nothing at all.
- `FocusedTaskBody`: an explicit slack branch to a new `SlackTaskDetail` instead of the bare-chip fallback.
- `LensColumn` rail row, `LinkedWorkSection` link item, `useShortcut('lens.slack_threads')` (`SHORTCUTS` already advertised the binding in Settings with nothing bound to it).
- `IntegrationPane` copy is now per-provider: a thread is not an issue, so the pane, the empty state, the unlink confirm, the completed toggle and the link popover all read "thread" for Slack and are unchanged for the issue hosts.

**Shared**:

- `store/slices/slack-threads/`: one thread cache read by both surfaces, so item 3's reply from the lens will refresh the studio and vice versa. Deliberate fork from Jira, which uses per-component hooks.
- `slackMrkdwnToMarkdown.ts`: pure, tested translator for `<url|text>`, `<url>`, `<@U...>` through the user map, `<#C...|name>`, `<!here>`, `*bold*`, `~strike~`, code spans and fences, and the `&amp;`/`&lt;`/`&gt;` unescape. Code is masked first and the unescape runs last, so an escaped angle bracket never becomes link syntax.
- `threadFormulas.ts`: the object model in one place. `externalId = ${channelId}:${threadTs}`, `identifier = #<channel> › <first line, 32 chars>`, thread-scoped so two threads from one channel never render the same label.
- `parseSlack` in `parseIntegrationTaskUrl.ts`, `fetchIssueCandidates`'s slack case, `issueSources.ts`, `shared/detail-fields/slackThreadFields.tsx` (the first registry in the repo with no state field, a thread has no state machine), and paste-link hydration in `LinkIssueForm`.

## Why

VISION names Slack next, and the conversation is the task-origin type Goodboy could not hold. The whole point of item 1 was unreachable without this.

## Test plan

`pnpm typecheck`, `pnpm test`, `pnpm knip --include files,duplicates,unlisted` and `cargo test --locked` are all green.

Both reachability chains are driven end to end and each was sabotaged to prove the test is real:

| Sabotage | Result |
|---|---|
| delete the `slack_threads` arm in `SessionWorkspace`'s lens if-chain | `SessionWorkspace` lens-mount test red |
| delete the fetch-on-mount `useEffect` in `useSlackThreads` and `useSlackThread` | 3 hook tests red |
| delete the Slack `FooterButton` | 2 `AppFooter` tests red |
| delete the `<SlackStudio>` mount block in `App.tsx` | 2 reachability tests red |
| replace `onOpenSlack` with a no-op | 2 reachability tests red |

Unit coverage: the mrkdwn translation table, the object-model formulas, `parseSlack` (p-format conversion, `thread_ts` query-param preference, and a round trip asserting the pasted `externalId` equals the studio-path formula for the same thread), the hydration builder, the slice contract, thread grouping and session correlation, and the missing `it.each([...LENS_KINDS])` persistence round trip that hand-picked 4-provider arrays used to hide.

## Known limits, stated plainly

- **Single page of thread heads.** `slack_list_thread_heads` reads one 200-message page per channel and does not page. In a busy channel whose newest 200 messages contain few threaded parents, the inbox looks near-empty although older threads exist, and there is no "load more".
- **First 12 member channels.** The studio fetches thread heads for at most 12 channels per refresh to keep the open cost bounded. When more channels are joined, the inbox says so in a line under the list.
- **Workspace scope, not company scope.** The schema has no company layer, so the Slack connection is per workspace like every other host. Promotion later is a bounded migration, not a rewrite.
- **Replies and reactions are not in this PR.** Item 3 adds the composer and the reaction affordance on top of the same slice.

### Never sent to a live tenant

Worst first. Every Slack call below was exercised only against fixtures and mocks in this PR:

1. **`conversations.replies`** (`slack_get_thread`). The whole thread detail, both surfaces, and the paste-link hydration decode this payload. If the real envelope differs from the fixture the thread pane shows the decoder's named error, never a silent empty state, but the shape itself is unverified.
2. **`conversations.history`** (`slack_list_thread_heads`). Every inbox row and every issue candidate comes from here, including the `reply_count > 0` filter and the `latest_reply` timestamp the rows sort on.
3. **`conversations.list`** (`slack_list_channels`). The `is_member` filter, the channel names in every identifier, and the hydration path all depend on it.
4. **`chat.getPermalink`** (`slack_get_permalink`). Supplies the `url` on every launched session's external task. On failure the studio falls back to an empty url rather than blocking the launch.
5. **`users.list`** (`slack_list_users`). Author names and avatars in the note list, and the `<@U...>` resolution in the translator. A failure here degrades to raw user ids, by design.
6. **Real `mrkdwn` bodies.** The translator is tested against hand-written Slack syntax, not against messages a real workspace produced. Attachments, blocks, file shares and message subtypes are rendered as their plain `text` field only.
7. **A real permalink.** `parseSlack` is tested against the documented `p1723456789123456` form and the `?thread_ts=` query param, not against a link actually copied out of the Slack client.
8. **Live rate limiting.** Nothing here has seen a real 429, so the `RateLimited` error text has never been rendered in the pane.
