### PR TITLE
feat(desktop): reply to a slack thread without leaving goodboy

### DIFF
--- a/apps/desktop/src/features/integrations/slack/SlackStudio/ThreadDetailPanel.test.tsx
+++ b/apps/desktop/src/features/integrations/slack/SlackStudio/ThreadDetailPanel.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { IsoDateTime, WorkspaceId } from '@goodboy/types';
 import type { SlackMessage } from '../client';
@@ -9,11 +9,24 @@ import type { SlackThreadRow } from './useSlackThreads';
 const h = vi.hoisted(() => ({
   messages: [] as ReadonlyArray<SlackMessage>,
   launch: null as Record<string, unknown> | null,
+  reply: vi.fn(async (_params: Record<string, unknown>) => undefined),
+  react: vi.fn(async (_params: Record<string, unknown>) => undefined),
 }));
 
 vi.mock('../client', () => ({
   slackGetPermalink: vi.fn(async () => 'https://acme.slack.com/archives/C1/p1723456789123456'),
 }));
+
+vi.mock('../../../../store', () => {
+  const state = {
+    replyToSlackThread: (params: Record<string, unknown>) => h.reply(params),
+    addSlackReaction: (params: Record<string, unknown>) => h.react(params),
+  };
+  return {
+    EMPTY_ARRAY: Object.freeze([]),
+    useAppStore: <T,>(selector: (value: typeof state) => T): T => selector(state),
+  };
+});
 
 vi.mock('../useSlackThread', () => ({
   useSlackThread: () => ({
@@ -59,6 +72,10 @@ const ROW: SlackThreadRow = {
 beforeEach(() => {
   h.messages = [];
   h.launch = null;
+  h.reply.mockReset();
+  h.reply.mockResolvedValue(undefined);
+  h.react.mockReset();
+  h.react.mockResolvedValue(undefined);
 });
 afterEach(cleanup);
 
@@ -101,5 +118,59 @@ describe('ThreadDetailPanel', () => {
     expect(h.launch?.branchSlugSeed).toBe('billing-webhook-fails-on-retry');
     expect(String(h.launch?.goalSeed)).toContain('Slack thread in #eng-alerts');
     expect(String(h.launch?.goalSeed)).toContain('ada: billing webhook fails on retry');
+  });
+
+  it('posts a reply into the thread the panel is reading', async () => {
+    h.messages = [
+      message('1723456789.123456', 'billing webhook fails on retry'),
+      message('1723456999.000100', 'i can repro it'),
+    ];
+
+    render(
+      <ThreadDetailPanel
+        row={ROW}
+        workspaceId={'workspace-1' as WorkspaceId}
+        sessionId={null}
+        onClose={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText('Reply in thread'), { target: { value: 'on it' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Reply' }));
+
+    await waitFor(() => {
+      expect(h.reply).toHaveBeenCalledWith({
+        workspaceId: 'workspace-1',
+        channelId: 'C1',
+        threadTs: '1723456789.123456',
+        text: 'on it',
+      });
+    });
+  });
+
+  it('reacts to a reply the thread fetch returned, not to the head it fell back on', () => {
+    h.messages = [
+      message('1723456789.123456', 'billing webhook fails on retry'),
+      message('1723456999.000100', 'i can repro it'),
+    ];
+
+    render(
+      <ThreadDetailPanel
+        row={ROW}
+        workspaceId={'workspace-1' as WorkspaceId}
+        sessionId={null}
+        onClose={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'React with :eyes:' })[1]!);
+
+    expect(h.react).toHaveBeenCalledWith({
+      workspaceId: 'workspace-1',
+      channelId: 'C1',
+      threadTs: '1723456789.123456',
+      messageTs: '1723456999.000100',
+      name: 'eyes',
+    });
   });
 });

--- a/apps/desktop/src/features/integrations/slack/SlackStudio/ThreadDetailPanel.tsx
+++ b/apps/desktop/src/features/integrations/slack/SlackStudio/ThreadDetailPanel.tsx
@@ -14,6 +14,7 @@ import {
   slackThreadTitle,
 } from '../threadFormulas';
 import { useSlackThread } from '../useSlackThread';
+import { useSlackThreadActions } from '../useSlackThreadActions';
 import type { SlackThreadRow } from './useSlackThreads';
 
 type Props = {
@@ -28,6 +29,12 @@ export const ThreadDetailPanel = ({ row, workspaceId, sessionId, onClose }: Prop
   const threadTs = row?.head.threadTs ?? row?.head.ts ?? '';
   const [permalink, setPermalink] = useState<string | null>(null);
   const thread = useSlackThread({
+    workspaceId,
+    channelId,
+    threadTs,
+    isEnabled: channelId !== '' && threadTs !== '',
+  });
+  const actions = useSlackThreadActions({
     workspaceId,
     channelId,
     threadTs,
@@ -83,6 +90,7 @@ export const ThreadDetailPanel = ({ row, workspaceId, sessionId, onClose }: Prop
       isLoading={thread.isLoading}
       error={thread.error}
       onRetry={thread.refetch}
+      actions={actions}
       dock={
         <LaunchSessionPanel
           key={`${channelId}:${threadTs}`}

--- a/apps/desktop/src/features/integrations/slack/SlackThreadDetail/index.tsx
+++ b/apps/desktop/src/features/integrations/slack/SlackThreadDetail/index.tsx
@@ -7,6 +7,7 @@ import { buildThreadProperties } from '../buildThreadProperties';
 import { slackUserNames } from '../nameMaps';
 import { slackThreadTitle } from '../threadFormulas';
 import { ThreadConversation } from '../ThreadConversation';
+import type { SlackThreadActions } from '../useSlackThreadActions';
 
 type Fit = 'fill' | 'bleed' | 'flow';
 
@@ -20,6 +21,7 @@ type Props = {
   readonly isLoading: boolean;
   readonly error: string | null;
   readonly onRetry: () => void;
+  readonly actions: SlackThreadActions;
   readonly fit?: Fit;
   readonly dock?: ReactNode;
 };
@@ -34,6 +36,7 @@ export const SlackThreadDetail = ({
   isLoading,
   error,
   onRetry,
+  actions,
   fit = 'fill',
   dock,
 }: Props) => {
@@ -74,6 +77,7 @@ export const SlackThreadDetail = ({
         isLoading={isLoading}
         error={error}
         onRetry={onRetry}
+        actions={actions}
       />
     </StudioDetailLayout>
   );

--- a/apps/desktop/src/features/integrations/slack/ThreadConversation/ThreadNoteCard.tsx
+++ b/apps/desktop/src/features/integrations/slack/ThreadConversation/ThreadNoteCard.tsx
@@ -1,18 +1,37 @@
 import { NoteCard } from '../../../../shared/components/NoteCard';
 import type { SlackMessage, SlackUser } from '../client';
 import { slackMrkdwnToMarkdown } from '../slackMrkdwnToMarkdown';
+import type { SlackReactionPick } from '../useSlackThreadActions';
 import { ThreadNoteHeader } from './ThreadNoteHeader';
+import { ThreadReactions } from './ThreadReactions';
 
 type Props = {
   readonly message: SlackMessage;
   readonly author: SlackUser | null;
   readonly userNames: ReadonlyMap<string, string>;
   readonly channelNames: ReadonlyMap<string, string>;
+  readonly isWriting: boolean;
+  readonly onReact: ((pick: SlackReactionPick) => void) | null;
 };
 
-export const ThreadNoteCard = ({ message, author, userNames, channelNames }: Props) => (
+export const ThreadNoteCard = ({
+  message,
+  author,
+  userNames,
+  channelNames,
+  isWriting,
+  onReact,
+}: Props) => (
   <NoteCard
     header={<ThreadNoteHeader message={message} author={author} />}
     body={slackMrkdwnToMarkdown({ text: message.text, userNames, channelNames })}
+    footer={
+      <ThreadReactions
+        messageTs={message.ts}
+        reactions={message.reactions}
+        isWriting={isWriting}
+        onReact={onReact}
+      />
+    }
   />
 );

--- a/apps/desktop/src/features/integrations/slack/ThreadConversation/ThreadReactions.tsx
+++ b/apps/desktop/src/features/integrations/slack/ThreadConversation/ThreadReactions.tsx
@@ -1,0 +1,72 @@
+import type { SlackReaction } from '../client';
+import type { SlackReactionPick } from '../useSlackThreadActions';
+import { QUICK_REACTIONS, reactionEmoji } from './quickReactions';
+
+type Props = {
+  readonly messageTs: string;
+  readonly reactions: ReadonlyArray<SlackReaction>;
+  readonly isWriting: boolean;
+  readonly onReact: ((pick: SlackReactionPick) => void) | null;
+};
+
+type ReasonParams = {
+  readonly canReact: boolean;
+  readonly isWriting: boolean;
+};
+
+const blockReason = ({ canReact, isWriting }: ReasonParams): string | null => {
+  if (!canReact) {
+    return 'Reactions are off for this thread';
+  }
+  if (isWriting) {
+    return 'Waiting for the current Slack write';
+  }
+  return null;
+};
+
+const PILL =
+  'inline-flex items-center gap-1 rounded-full border border-border-soft px-1.5 py-0.5 text-2xs text-muted-foreground motion-safe:transition-colors hover:border-border hover:bg-muted/50 hover:text-foreground disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]';
+
+const QUICK_ROW =
+  'flex items-center gap-1 opacity-0 motion-safe:transition-opacity focus-within:opacity-100 group-hover:opacity-100';
+
+export const ThreadReactions = ({ messageTs, reactions, isWriting, onReact }: Props) => {
+  const reason = blockReason({ canReact: onReact != null, isWriting });
+  const isBlocked = reason != null;
+  const existing = new Set(reactions.map((reaction) => reaction.name));
+  const quick = QUICK_REACTIONS.filter((reaction) => !existing.has(reaction.name));
+
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      {reactions.map((reaction) => (
+        <button
+          key={reaction.name}
+          type="button"
+          disabled={isBlocked}
+          title={reason ?? `React with :${reaction.name}:`}
+          aria-label={`React with :${reaction.name}:`}
+          onClick={() => onReact?.({ messageTs, name: reaction.name })}
+          className={PILL}
+        >
+          <span aria-hidden>{reactionEmoji({ name: reaction.name })}</span>
+          <span className="tabular-nums">{reaction.count}</span>
+        </button>
+      ))}
+      <div className={QUICK_ROW}>
+        {quick.map((reaction) => (
+          <button
+            key={reaction.name}
+            type="button"
+            disabled={isBlocked}
+            title={reason ?? `React with :${reaction.name}:`}
+            aria-label={`React with :${reaction.name}:`}
+            onClick={() => onReact?.({ messageTs, name: reaction.name })}
+            className={PILL}
+          >
+            <span aria-hidden>{reaction.emoji}</span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/apps/desktop/src/features/integrations/slack/ThreadConversation/index.test.tsx
+++ b/apps/desktop/src/features/integrations/slack/ThreadConversation/index.test.tsx
@@ -1,0 +1,142 @@
+// @vitest-environment happy-dom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { IsoDateTime } from '@goodboy/types';
+import type { SlackMessage, SlackReaction } from '../client';
+import type { SlackThreadActions } from '../useSlackThreadActions';
+import { ThreadConversation } from './index';
+
+const ROOT_TS = '1723456789.123456';
+const REPLY_TS = '1723456999.000100';
+
+type MessageParams = {
+  readonly ts: string;
+  readonly text: string;
+  readonly reactions?: ReadonlyArray<SlackReaction>;
+};
+
+const message = ({ ts, text, reactions = [] }: MessageParams): SlackMessage => ({
+  ts,
+  threadTs: ROOT_TS,
+  userId: 'U1',
+  botId: null,
+  text,
+  subtype: null,
+  replyCount: 1,
+  replyUserCount: 1,
+  postedAt: '2026-08-05T09:00:00Z' as IsoDateTime,
+  latestReplyAt: null,
+  reactions,
+});
+
+const MESSAGES: ReadonlyArray<SlackMessage> = [
+  message({ ts: ROOT_TS, text: 'billing webhook fails on retry' }),
+  message({ ts: REPLY_TS, text: 'i can repro it', reactions: [{ name: 'eyes', count: 2 }] }),
+];
+
+type ActionsParams = {
+  readonly reply?: SlackThreadActions['reply'];
+  readonly react?: SlackThreadActions['react'];
+  readonly isWriting?: boolean;
+  readonly error?: string | null;
+};
+
+const buildActions = ({
+  reply = vi.fn(async () => undefined),
+  react = vi.fn(),
+  isWriting = false,
+  error = null,
+}: ActionsParams): SlackThreadActions => ({ reply, react, isWriting, error });
+
+type RenderParams = {
+  readonly actions: SlackThreadActions;
+};
+
+const renderConversation = ({ actions }: RenderParams) =>
+  render(
+    <ThreadConversation
+      messages={MESSAGES}
+      users={[{ id: 'U1', name: 'ada', isBot: false, isDeleted: false, avatarUrl: null }]}
+      channels={[]}
+      isLoading={false}
+      error={null}
+      onRetry={vi.fn()}
+      actions={actions}
+    />,
+  );
+
+afterEach(cleanup);
+
+describe('ThreadConversation', () => {
+  it('says replies go out as plain text from the bot', () => {
+    renderConversation({ actions: buildActions({}) });
+
+    expect(screen.getByText('Sent as plain text')).toBeDefined();
+    expect(screen.queryByText('Markdown supported')).toBeNull();
+    expect(
+      screen.getByText('Replies post to Slack as the connected bot, not as you.'),
+    ).toBeDefined();
+  });
+
+  it('hands the composer text to the reply action', async () => {
+    const reply = vi.fn(async () => undefined);
+    renderConversation({ actions: buildActions({ reply }) });
+
+    fireEvent.change(screen.getByLabelText('Reply in thread'), { target: { value: '  on it  ' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Reply' }));
+
+    await waitFor(() => {
+      expect(reply).toHaveBeenCalledWith('on it');
+    });
+  });
+
+  it('shows the composer error when the reply is refused', async () => {
+    const reply = vi.fn(async () => {
+      throw new Error('missing_scope: chat:write');
+    });
+    renderConversation({ actions: buildActions({ reply }) });
+
+    fireEvent.change(screen.getByLabelText('Reply in thread'), { target: { value: 'on it' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Reply' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert').textContent).toContain('missing_scope: chat:write');
+    });
+  });
+
+  it('reacts to the message the affordance sits on', () => {
+    const react = vi.fn();
+    renderConversation({ actions: buildActions({ react }) });
+
+    const buttons = screen.getAllByRole('button', { name: 'React with :tada:' });
+    fireEvent.click(buttons[1]!);
+
+    expect(react).toHaveBeenCalledWith({ messageTs: REPLY_TS, name: 'tada' });
+  });
+
+  it('adds to a reaction already on the message', () => {
+    const react = vi.fn();
+    renderConversation({ actions: buildActions({ react }) });
+
+    const pill = screen.getAllByRole('button', { name: 'React with :eyes:' })[1]!;
+    expect(pill.textContent).toContain('2');
+    fireEvent.click(pill);
+
+    expect(react).toHaveBeenCalledWith({ messageTs: REPLY_TS, name: 'eyes' });
+  });
+
+  it('disables the reaction affordance with a reason while a write runs', () => {
+    renderConversation({ actions: buildActions({ isWriting: true }) });
+
+    const button = screen.getAllByRole('button', { name: 'React with :eyes:' })[0]!;
+    expect(button.hasAttribute('disabled')).toBe(true);
+    expect(button.getAttribute('title')).toBe('Waiting for the current Slack write');
+  });
+
+  it('surfaces a reaction failure above the composer', () => {
+    renderConversation({ actions: buildActions({ error: 'missing_scope: reactions:write' }) });
+
+    expect(screen.getByRole('alert').textContent).toContain('missing_scope: reactions:write');
+  });
+});

--- a/apps/desktop/src/features/integrations/slack/ThreadConversation/index.tsx
+++ b/apps/desktop/src/features/integrations/slack/ThreadConversation/index.tsx
@@ -2,9 +2,11 @@ import { useMemo } from 'react';
 import { EmptyState } from '@goodboy/ui';
 import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../shared/components/conceptIcons';
 import { ErrorStrip } from '../../../../shared/components/ErrorStrip';
+import { NoteComposer } from '../../../../shared/components/NoteComposer';
 import { NoteListSkeleton } from '../../../../shared/components/NoteListSkeleton';
 import type { SlackChannel, SlackMessage, SlackUser } from '../client';
 import { slackChannelNames, slackUserNames } from '../nameMaps';
+import type { SlackThreadActions } from '../useSlackThreadActions';
 import { ThreadNoteCard } from './ThreadNoteCard';
 
 type Props = {
@@ -14,6 +16,7 @@ type Props = {
   readonly isLoading: boolean;
   readonly error: string | null;
   readonly onRetry: () => void;
+  readonly actions: SlackThreadActions;
 };
 
 export const ThreadConversation = ({
@@ -23,6 +26,7 @@ export const ThreadConversation = ({
   isLoading,
   error,
   onRetry,
+  actions,
 }: Props) => {
   const usersById = useMemo(() => new Map(users.map((user) => [user.id, user])), [users]);
   const userNames = useMemo(() => slackUserNames({ users }), [users]);
@@ -36,31 +40,51 @@ export const ThreadConversation = ({
     return <ErrorStrip label="the thread" error={new Error(error)} onRetry={onRetry} />;
   }
 
-  if (messages.length === 0) {
-    return (
-      <EmptyState
-        icon={CONCEPT_ICONS.slack}
-        tone={CONCEPT_TONE.slack}
-        title="Nothing to read yet"
-        description="The messages in this thread show up here."
-        size="inline"
-        className="py-5"
-      />
-    );
-  }
-
   return (
-    <ul className="flex flex-col gap-2.5">
-      {messages.map((message) => (
-        <li key={message.ts}>
-          <ThreadNoteCard
-            message={message}
-            author={message.userId != null ? (usersById.get(message.userId) ?? null) : null}
-            userNames={userNames}
-            channelNames={channelNames}
+    <div className="flex flex-col gap-4">
+      {messages.length === 0 ? (
+        <EmptyState
+          icon={CONCEPT_ICONS.slack}
+          tone={CONCEPT_TONE.slack}
+          title="Nothing to read yet"
+          description="The messages in this thread show up here."
+          size="inline"
+          className="py-5"
+        />
+      ) : (
+        <ul className="flex flex-col gap-2.5">
+          {messages.map((message) => (
+            <li key={message.ts}>
+              <ThreadNoteCard
+                message={message}
+                author={message.userId != null ? (usersById.get(message.userId) ?? null) : null}
+                userNames={userNames}
+                channelNames={channelNames}
+                isWriting={actions.isWriting}
+                onReact={actions.react}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+      {actions.error != null && (
+        <p role="alert" className="text-xs text-danger">
+          {actions.error}
+        </p>
+      )}
+      {actions.reply != null && (
+        <div className="flex flex-col gap-2">
+          <p className="text-2xs text-muted-foreground">
+            Replies post to Slack as the connected bot, not as you.
+          </p>
+          <NoteComposer
+            placeholder="Reply in thread"
+            submitLabel="Reply"
+            hint="Sent as plain text"
+            onSubmit={actions.reply}
           />
-        </li>
-      ))}
-    </ul>
+        </div>
+      )}
+    </div>
   );
 };

--- a/apps/desktop/src/features/integrations/slack/ThreadConversation/quickReactions.ts
+++ b/apps/desktop/src/features/integrations/slack/ThreadConversation/quickReactions.ts
@@ -1,0 +1,21 @@
+export type QuickReaction = {
+  readonly name: string;
+  readonly emoji: string;
+};
+
+export const QUICK_REACTIONS: ReadonlyArray<QuickReaction> = [
+  { name: 'eyes', emoji: '👀' },
+  { name: '+1', emoji: '👍' },
+  { name: 'white_check_mark', emoji: '✅' },
+  { name: 'tada', emoji: '🎉' },
+];
+
+const BY_NAME: ReadonlyMap<string, string> = new Map(
+  QUICK_REACTIONS.map((reaction) => [reaction.name, reaction.emoji]),
+);
+
+type EmojiParams = {
+  readonly name: string;
+};
+
+export const reactionEmoji = ({ name }: EmojiParams): string => BY_NAME.get(name) ?? `:${name}:`;

--- a/apps/desktop/src/features/integrations/slack/useSlackThreadActions/index.test.tsx
+++ b/apps/desktop/src/features/integrations/slack/useSlackThreadActions/index.test.tsx
@@ -1,0 +1,126 @@
+// @vitest-environment happy-dom
+
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { WorkspaceId } from '@goodboy/types';
+
+const h = vi.hoisted(() => ({
+  reply: vi.fn(async (_params: Record<string, unknown>) => undefined),
+  react: vi.fn(async (_params: Record<string, unknown>) => undefined),
+}));
+
+vi.mock('../../../../store', () => {
+  const state = {
+    replyToSlackThread: (params: Record<string, unknown>) => h.reply(params),
+    addSlackReaction: (params: Record<string, unknown>) => h.react(params),
+  };
+  return {
+    EMPTY_ARRAY: Object.freeze([]),
+    useAppStore: <T,>(selector: (value: typeof state) => T): T => selector(state),
+  };
+});
+
+const { useSlackThreadActions } = await import('./index');
+
+const WORKSPACE_ID = 'ws-1' as WorkspaceId;
+const TARGET = {
+  workspaceId: WORKSPACE_ID,
+  channelId: 'C1',
+  threadTs: '1723456789.123456',
+  isEnabled: true,
+};
+
+beforeEach(() => {
+  h.reply.mockReset();
+  h.reply.mockResolvedValue(undefined);
+  h.react.mockReset();
+  h.react.mockResolvedValue(undefined);
+});
+
+describe('useSlackThreadActions', () => {
+  it('sends the reply with the channel and thread it was mounted on', async () => {
+    const { result } = renderHook(() => useSlackThreadActions(TARGET));
+
+    await result.current.reply?.('on it');
+
+    expect(h.reply).toHaveBeenCalledWith({
+      workspaceId: WORKSPACE_ID,
+      channelId: 'C1',
+      threadTs: '1723456789.123456',
+      text: 'on it',
+    });
+  });
+
+  it('fires one write when two replies land in the same tick', async () => {
+    let resolveWrite: () => void = () => undefined;
+    h.reply.mockImplementation(
+      async () =>
+        new Promise<undefined>((resolve) => {
+          resolveWrite = () => resolve(undefined);
+        }),
+    );
+    const { result } = renderHook(() => useSlackThreadActions(TARGET));
+
+    const first = result.current.reply?.('first');
+    const second = result.current.reply?.('second');
+
+    await expect(second).rejects.toThrow('Another Slack write is still running');
+    resolveWrite();
+    await first;
+    expect(h.reply).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires one reaction when two clicks land in the same tick', async () => {
+    let resolveWrite: () => void = () => undefined;
+    h.react.mockImplementation(
+      async () =>
+        new Promise<undefined>((resolve) => {
+          resolveWrite = () => resolve(undefined);
+        }),
+    );
+    const { result } = renderHook(() => useSlackThreadActions(TARGET));
+
+    result.current.react?.({ messageTs: '1723456999.000100', name: 'eyes' });
+    result.current.react?.({ messageTs: '1723456999.000100', name: 'tada' });
+
+    expect(h.react).toHaveBeenCalledTimes(1);
+    expect(h.react).toHaveBeenCalledWith({
+      workspaceId: WORKSPACE_ID,
+      channelId: 'C1',
+      threadTs: '1723456789.123456',
+      messageTs: '1723456999.000100',
+      name: 'eyes',
+    });
+    resolveWrite();
+    await waitFor(() => {
+      expect(result.current.isWriting).toBe(false);
+    });
+  });
+
+  it('surfaces a failed reaction instead of dropping it', async () => {
+    h.react.mockRejectedValue(new Error('missing_scope: reactions:write'));
+    const { result } = renderHook(() => useSlackThreadActions(TARGET));
+
+    result.current.react?.({ messageTs: '1723456999.000100', name: 'eyes' });
+
+    await waitFor(() => {
+      expect(result.current.error).toContain('missing_scope: reactions:write');
+    });
+  });
+
+  it('rethrows a failed reply so the composer can show it', async () => {
+    h.reply.mockRejectedValue(new Error('channel_not_found'));
+    const { result } = renderHook(() => useSlackThreadActions(TARGET));
+
+    await expect(result.current.reply?.('on it')).rejects.toThrow('channel_not_found');
+  });
+
+  it('offers nothing to act with when the thread is not resolved', () => {
+    const { result } = renderHook(() =>
+      useSlackThreadActions({ ...TARGET, channelId: '', threadTs: '', isEnabled: false }),
+    );
+
+    expect(result.current.reply).toBeNull();
+    expect(result.current.react).toBeNull();
+  });
+});

--- a/apps/desktop/src/features/integrations/slack/useSlackThreadActions/index.ts
+++ b/apps/desktop/src/features/integrations/slack/useSlackThreadActions/index.ts
@@ -1,0 +1,79 @@
+import { useRef, useState } from 'react';
+import type { WorkspaceId } from '@goodboy/types';
+import { formatError } from '../../../../shared/lib/errors';
+import { useAppStore } from '../../../../store';
+
+type Params = {
+  readonly workspaceId: WorkspaceId;
+  readonly channelId: string;
+  readonly threadTs: string;
+  readonly isEnabled: boolean;
+};
+
+export type SlackReactionPick = {
+  readonly messageTs: string;
+  readonly name: string;
+};
+
+export type SlackThreadActions = {
+  readonly reply: ((text: string) => Promise<void>) | null;
+  readonly react: ((pick: SlackReactionPick) => void) | null;
+  readonly isWriting: boolean;
+  readonly error: string | null;
+};
+
+const IN_FLIGHT = 'Another Slack write is still running. Try again in a moment.';
+
+export const useSlackThreadActions = ({
+  workspaceId,
+  channelId,
+  threadTs,
+  isEnabled,
+}: Params): SlackThreadActions => {
+  const replyToSlackThread = useAppStore((state) => state.replyToSlackThread);
+  const addSlackReaction = useAppStore((state) => state.addSlackReaction);
+  const busyRef = useRef(false);
+  const [isWriting, setIsWriting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const reply = async (text: string): Promise<void> => {
+    if (busyRef.current) {
+      throw new Error(IN_FLIGHT);
+    }
+    busyRef.current = true;
+    setIsWriting(true);
+    setError(null);
+    try {
+      await replyToSlackThread({ workspaceId, channelId, threadTs, text });
+    } finally {
+      busyRef.current = false;
+      setIsWriting(false);
+    }
+  };
+
+  const react = ({ messageTs, name }: SlackReactionPick): void => {
+    if (busyRef.current) {
+      return;
+    }
+    busyRef.current = true;
+    setIsWriting(true);
+    setError(null);
+    void (async () => {
+      try {
+        await addSlackReaction({ workspaceId, channelId, threadTs, messageTs, name });
+      } catch (reactionError: unknown) {
+        setError(formatError(reactionError));
+      } finally {
+        busyRef.current = false;
+        setIsWriting(false);
+      }
+    })();
+  };
+
+  return {
+    reply: isEnabled ? reply : null,
+    react: isEnabled ? react : null,
+    isWriting,
+    error,
+  };
+};

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/SlackTaskDetail.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/SlackTaskDetail.test.tsx
@@ -1,0 +1,100 @@
+// @vitest-environment happy-dom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IsoDateTime, SessionExternalTask, WorkspaceId } from '@goodboy/types';
+import type { SlackMessage } from '../../../../../integrations/slack/client';
+
+const h = vi.hoisted(() => ({
+  messages: [] as ReadonlyArray<SlackMessage>,
+  reply: vi.fn(async (_params: Record<string, unknown>) => undefined),
+  react: vi.fn(async (_params: Record<string, unknown>) => undefined),
+}));
+
+vi.mock('../../../../../../store', () => {
+  const state = {
+    replyToSlackThread: (params: Record<string, unknown>) => h.reply(params),
+    addSlackReaction: (params: Record<string, unknown>) => h.react(params),
+  };
+  return {
+    EMPTY_ARRAY: Object.freeze([]),
+    useAppStore: <T,>(selector: (value: typeof state) => T): T => selector(state),
+  };
+});
+
+vi.mock('../../../../../integrations/slack/useSlackThread', () => ({
+  useSlackThread: () => ({
+    messages: h.messages,
+    users: [{ id: 'U1', name: 'ada', isBot: false, isDeleted: false, avatarUrl: null }],
+    channels: [],
+    channelName: 'eng-alerts',
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+}));
+
+const { SlackTaskDetail } = await import('./SlackTaskDetail');
+
+const message = (ts: string, text: string): SlackMessage => ({
+  ts,
+  threadTs: '1723456789.123456',
+  userId: 'U1',
+  botId: null,
+  text,
+  subtype: null,
+  replyCount: 1,
+  replyUserCount: 1,
+  postedAt: '2026-08-05T09:00:00Z' as IsoDateTime,
+  latestReplyAt: null,
+  reactions: [],
+});
+
+const TASK = {
+  provider: 'slack',
+  externalId: 'C1:1723456789.123456',
+  identifier: '#eng-alerts › billing webhook fails on retry',
+  url: 'https://acme.slack.com/archives/C1/p1723456789123456',
+  title: 'billing webhook fails on retry',
+  createdAt: '2026-08-05T09:00:00Z' as IsoDateTime,
+} as SessionExternalTask;
+
+beforeEach(() => {
+  h.messages = [message('1723456789.123456', 'billing webhook fails on retry')];
+  h.reply.mockReset();
+  h.reply.mockResolvedValue(undefined);
+  h.react.mockReset();
+  h.react.mockResolvedValue(undefined);
+});
+afterEach(cleanup);
+
+describe('SlackTaskDetail', () => {
+  it('replies from the session lens to the thread the task points at', async () => {
+    render(<SlackTaskDetail workspaceId={'workspace-1' as WorkspaceId} task={TASK} />);
+
+    expect(screen.getByText('Sent as plain text')).toBeDefined();
+    fireEvent.change(screen.getByLabelText('Reply in thread'), { target: { value: 'on it' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Reply' }));
+
+    await waitFor(() => {
+      expect(h.reply).toHaveBeenCalledWith({
+        workspaceId: 'workspace-1',
+        channelId: 'C1',
+        threadTs: '1723456789.123456',
+        text: 'on it',
+      });
+    });
+  });
+
+  it('offers no composer when the link no longer points at a thread', () => {
+    render(
+      <SlackTaskDetail
+        workspaceId={'workspace-1' as WorkspaceId}
+        task={{ ...TASK, externalId: 'not-a-thread' } as SessionExternalTask}
+      />,
+    );
+
+    expect(screen.getByText('This link no longer points at a thread')).toBeDefined();
+    expect(screen.queryByLabelText('Reply in thread')).toBeNull();
+  });
+});

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/SlackTaskDetail.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/SlackTaskDetail.tsx
@@ -5,6 +5,7 @@ import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../../../shared/components
 import { SlackThreadDetail } from '../../../../../integrations/slack/SlackThreadDetail';
 import { parseSlackThreadExternalId } from '../../../../../integrations/slack/threadFormulas';
 import { useSlackThread } from '../../../../../integrations/slack/useSlackThread';
+import { useSlackThreadActions } from '../../../../../integrations/slack/useSlackThreadActions';
 
 type Props = {
   readonly workspaceId: WorkspaceId;
@@ -14,6 +15,12 @@ type Props = {
 export const SlackTaskDetail = ({ workspaceId, task }: Props) => {
   const parsed = parseSlackThreadExternalId({ externalId: task.externalId });
   const thread = useSlackThread({
+    workspaceId,
+    channelId: parsed?.channelId ?? '',
+    threadTs: parsed?.threadTs ?? '',
+    isEnabled: parsed != null,
+  });
+  const actions = useSlackThreadActions({
     workspaceId,
     channelId: parsed?.channelId ?? '',
     threadTs: parsed?.threadTs ?? '',
@@ -56,6 +63,7 @@ export const SlackTaskDetail = ({ workspaceId, task }: Props) => {
       isLoading={thread.isLoading}
       error={thread.error}
       onRetry={thread.refetch}
+      actions={actions}
       fit="fill"
     />
   );

--- a/apps/desktop/src/shared/components/NoteCard/index.tsx
+++ b/apps/desktop/src/shared/components/NoteCard/index.tsx
@@ -4,11 +4,13 @@ import { Markdown } from '@goodboy/ui';
 type Props = {
   readonly header: ReactNode;
   readonly body: string;
+  readonly footer?: ReactNode;
 };
 
-export const NoteCard = ({ header, body }: Props) => (
-  <div className="flex flex-col gap-2 rounded-lg bg-muted/20 p-3">
+export const NoteCard = ({ header, body, footer }: Props) => (
+  <div className="group flex flex-col gap-2 rounded-lg bg-muted/20 p-3">
     {header}
     <Markdown text={body} className="text-sm leading-relaxed" />
+    {footer}
   </div>
 );

--- a/apps/desktop/src/store/slices/slack-threads/addSlackReaction.ts
+++ b/apps/desktop/src/store/slices/slack-threads/addSlackReaction.ts
@@ -1,0 +1,23 @@
+import { slackAddReaction as slackAddReactionCall } from '../../../features/integrations/slack/client';
+import { runSlackWrite } from './runSlackWrite';
+import type { GetFn, SlackReactionParams } from './types';
+
+export const addSlackReaction = (get: GetFn) => {
+  return async ({
+    workspaceId,
+    channelId,
+    threadTs,
+    messageTs,
+    name,
+  }: SlackReactionParams): Promise<void> => {
+    await runSlackWrite({
+      get,
+      workspaceId,
+      channelId,
+      threadTs,
+      write: async () => {
+        await slackAddReactionCall({ workspaceId, channelId, messageTs, name });
+      },
+    });
+  };
+};

--- a/apps/desktop/src/store/slices/slack-threads/index.test.ts
+++ b/apps/desktop/src/store/slices/slack-threads/index.test.ts
@@ -6,12 +6,16 @@ const listChannelsSpy = vi.fn();
 const listUsersSpy = vi.fn();
 const listThreadHeadsSpy = vi.fn();
 const getThreadSpy = vi.fn();
+const postReplySpy = vi.fn();
+const addReactionSpy = vi.fn();
 
 vi.mock('../../../features/integrations/slack/client', () => ({
   slackListChannels: (...args: ReadonlyArray<unknown>) => listChannelsSpy(...args),
   slackListUsers: (...args: ReadonlyArray<unknown>) => listUsersSpy(...args),
   slackListThreadHeads: (...args: ReadonlyArray<unknown>) => listThreadHeadsSpy(...args),
   slackGetThread: (...args: ReadonlyArray<unknown>) => getThreadSpy(...args),
+  slackPostReply: (...args: ReadonlyArray<unknown>) => postReplySpy(...args),
+  slackAddReaction: (...args: ReadonlyArray<unknown>) => addReactionSpy(...args),
 }));
 
 const { createSlackThreadsSlice, initialSlackThreadsState, slackChannelKey, slackThreadKey } =
@@ -20,6 +24,7 @@ const { createSlackThreadsSlice, initialSlackThreadsState, slackChannelKey, slac
 const WORKSPACE_ID = 'ws-1' as WorkspaceId;
 const CHANNEL_ID = 'C024BE7LR';
 const THREAD_TS = '1723456789.123456';
+const REPLY_TS = '1723456999.000100';
 
 type TestState = Record<string, unknown>;
 
@@ -44,6 +49,8 @@ describe('slack-threads slice', () => {
     listUsersSpy.mockReset();
     listThreadHeadsSpy.mockReset();
     getThreadSpy.mockReset();
+    postReplySpy.mockReset();
+    addReactionSpy.mockReset();
   });
 
   it('caches channels per workspace', async () => {
@@ -119,6 +126,90 @@ describe('slack-threads slice', () => {
     expect(entry?.error).toContain('missing_scope: channels:history');
     expect(entry?.messages).toHaveLength(1);
     expect(entry?.loading).toBe(false);
+  });
+
+  it('posts the reply into the thread it is reading and refreshes past an in-flight fetch', async () => {
+    postReplySpy.mockResolvedValue({ ts: REPLY_TS });
+    getThreadSpy.mockResolvedValue([{ ts: THREAD_TS }, { ts: REPLY_TS }]);
+    listThreadHeadsSpy.mockResolvedValue([{ ts: THREAD_TS }]);
+    const store = buildStore();
+    const key = slackThreadKey({
+      workspaceId: WORKSPACE_ID,
+      channelId: CHANNEL_ID,
+      threadTs: THREAD_TS,
+    });
+    store.getState().slackThreads = {
+      [key]: { messages: [], fetchedAt: null, loading: true, error: null },
+    };
+
+    await store.slice.replyToSlackThread({
+      workspaceId: WORKSPACE_ID,
+      channelId: CHANNEL_ID,
+      threadTs: THREAD_TS,
+      text: 'on it',
+    });
+
+    expect(postReplySpy).toHaveBeenCalledWith({
+      workspaceId: WORKSPACE_ID,
+      channelId: CHANNEL_ID,
+      threadTs: THREAD_TS,
+      text: 'on it',
+    });
+    expect(getThreadSpy).toHaveBeenCalledWith({
+      workspaceId: WORKSPACE_ID,
+      channelId: CHANNEL_ID,
+      threadTs: THREAD_TS,
+    });
+    expect(listThreadHeadsSpy).toHaveBeenCalledWith({
+      workspaceId: WORKSPACE_ID,
+      channelId: CHANNEL_ID,
+    });
+    expect(
+      (store.getState().slackThreads as Record<string, { messages: unknown[] }>)[key]?.messages,
+    ).toHaveLength(2);
+  });
+
+  it('reacts to the message it was asked about, not to the thread root', async () => {
+    addReactionSpy.mockResolvedValue(undefined);
+    getThreadSpy.mockResolvedValue([{ ts: THREAD_TS }, { ts: REPLY_TS }]);
+    listThreadHeadsSpy.mockResolvedValue([{ ts: THREAD_TS }]);
+    const store = buildStore();
+
+    await store.slice.addSlackReaction({
+      workspaceId: WORKSPACE_ID,
+      channelId: CHANNEL_ID,
+      threadTs: THREAD_TS,
+      messageTs: REPLY_TS,
+      name: 'eyes',
+    });
+
+    expect(addReactionSpy).toHaveBeenCalledWith({
+      workspaceId: WORKSPACE_ID,
+      channelId: CHANNEL_ID,
+      messageTs: REPLY_TS,
+      name: 'eyes',
+    });
+    expect(getThreadSpy).toHaveBeenCalledWith({
+      workspaceId: WORKSPACE_ID,
+      channelId: CHANNEL_ID,
+      threadTs: THREAD_TS,
+    });
+  });
+
+  it('surfaces a failed write instead of refreshing over it', async () => {
+    postReplySpy.mockRejectedValueOnce(new Error('missing_scope: chat:write'));
+    const store = buildStore();
+
+    await expect(
+      store.slice.replyToSlackThread({
+        workspaceId: WORKSPACE_ID,
+        channelId: CHANNEL_ID,
+        threadTs: THREAD_TS,
+        text: 'on it',
+      }),
+    ).rejects.toThrow('missing_scope: chat:write');
+    expect(getThreadSpy).not.toHaveBeenCalled();
+    expect(listThreadHeadsSpy).not.toHaveBeenCalled();
   });
 
   it('keeps the known user list when the directory call fails', async () => {

--- a/apps/desktop/src/store/slices/slack-threads/index.ts
+++ b/apps/desktop/src/store/slices/slack-threads/index.ts
@@ -1,7 +1,9 @@
+import { addSlackReaction } from './addSlackReaction';
 import { refreshSlackChannels } from './refreshSlackChannels';
 import { refreshSlackThread } from './refreshSlackThread';
 import { refreshSlackThreadHeads } from './refreshSlackThreadHeads';
 import { refreshSlackUsers } from './refreshSlackUsers';
+import { replyToSlackThread } from './replyToSlackThread';
 import type { GetFn, SetFn } from './types';
 
 export { initialSlackThreadsState, slackChannelKey, slackThreadKey } from './state';
@@ -12,11 +14,19 @@ export type {
   SlackThreadsSliceState,
 } from './state';
 export type { RefreshSlackThreadOptions } from './refreshSlackThread';
-export type { SlackChannelParams, SlackThreadParams, SlackWorkspaceParams } from './types';
+export type {
+  SlackChannelParams,
+  SlackReactionParams,
+  SlackReplyParams,
+  SlackThreadParams,
+  SlackWorkspaceParams,
+} from './types';
 
 export const createSlackThreadsSlice = (set: SetFn, get: GetFn) => ({
   refreshSlackChannels: refreshSlackChannels(set, get),
   refreshSlackUsers: refreshSlackUsers(set, get),
   refreshSlackThreadHeads: refreshSlackThreadHeads(set, get),
   refreshSlackThread: refreshSlackThread(set, get),
+  replyToSlackThread: replyToSlackThread(get),
+  addSlackReaction: addSlackReaction(get),
 });

--- a/apps/desktop/src/store/slices/slack-threads/replyToSlackThread.ts
+++ b/apps/desktop/src/store/slices/slack-threads/replyToSlackThread.ts
@@ -1,0 +1,17 @@
+import { slackPostReply } from '../../../features/integrations/slack/client';
+import { runSlackWrite } from './runSlackWrite';
+import type { GetFn, SlackReplyParams } from './types';
+
+export const replyToSlackThread = (get: GetFn) => {
+  return async ({ workspaceId, channelId, threadTs, text }: SlackReplyParams): Promise<void> => {
+    await runSlackWrite({
+      get,
+      workspaceId,
+      channelId,
+      threadTs,
+      write: async () => {
+        await slackPostReply({ workspaceId, channelId, threadTs, text });
+      },
+    });
+  };
+};

--- a/apps/desktop/src/store/slices/slack-threads/runSlackWrite.ts
+++ b/apps/desktop/src/store/slices/slack-threads/runSlackWrite.ts
@@ -1,0 +1,18 @@
+import type { GetFn, SlackThreadParams } from './types';
+
+type Params = SlackThreadParams & {
+  readonly get: GetFn;
+  readonly write: () => Promise<void>;
+};
+
+export const runSlackWrite = async ({
+  get,
+  workspaceId,
+  channelId,
+  threadTs,
+  write,
+}: Params): Promise<void> => {
+  await write();
+  await get().refreshSlackThread({ workspaceId, channelId, threadTs }, { force: true });
+  await get().refreshSlackThreadHeads({ workspaceId, channelId });
+};

--- a/apps/desktop/src/store/slices/slack-threads/types.ts
+++ b/apps/desktop/src/store/slices/slack-threads/types.ts
@@ -13,3 +13,12 @@ export type SlackChannelParams = SlackWorkspaceParams & {
 export type SlackThreadParams = SlackChannelParams & {
   readonly threadTs: string;
 };
+
+export type SlackReplyParams = SlackThreadParams & {
+  readonly text: string;
+};
+
+export type SlackReactionParams = SlackThreadParams & {
+  readonly messageTs: string;
+  readonly name: string;
+};

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -96,6 +96,8 @@ import {
   initialSlackThreadsState,
   type RefreshSlackThreadOptions,
   type SlackChannelParams,
+  type SlackReactionParams,
+  type SlackReplyParams,
   type SlackThreadParams,
   type SlackWorkspaceParams,
 } from './slices/slack-threads';
@@ -599,6 +601,8 @@ export type AppActions = {
   refreshSlackUsers(params: SlackWorkspaceParams): Promise<void>;
   refreshSlackThreadHeads(params: SlackChannelParams): Promise<void>;
   refreshSlackThread(params: SlackThreadParams, options?: RefreshSlackThreadOptions): Promise<void>;
+  replyToSlackThread(params: SlackReplyParams): Promise<void>;
+  addSlackReaction(params: SlackReactionParams): Promise<void>;
   closePr(sessionId: SessionId, prNumber?: number): Promise<void>;
   reopenPr(sessionId: SessionId, prNumber?: number): Promise<void>;
   editPr(


### PR DESCRIPTION
## What

The Slack integration stops being a read-only mirror. A `NoteComposer` sits under the thread and a reaction affordance sits on every message, in **both** Slack surfaces: the `SlackStudio` thread detail panel and the `slack_threads` session lens. Both render the same `SlackThreadDetail`, so the act surface lands in both by construction rather than by remembering to wire it twice.

- `replyToSlackThread` and `addSlackReaction` join the `slack-threads` slice, both behind a shared `runSlackWrite`: write, then refresh. It is `runBitbucketPrWrite` minus the selection stamp, which a thread reply does not need.
- `useSlackThreadActions` is the one hook both surfaces mount. It owns the busy guard and the error state.
- `NoteCard` gains an optional `footer` and a `group` class so the reaction row can live inside the message bubble and reveal the quick reactions on hover.

## Why

Item 3 of the v0.1.65 plan. Without an act surface, the release mandate rejects the integration: seeing the conversation a task came out of is half the loop, answering "which flag did you mean?" without tabbing out is the other half.

## The reply posts as the bot

The connected `xoxb-` token is a bot token, so a reply is authored by the bot user, not by the person typing it. That is a fact a user has to know before they hit send, so it sits above the composer as its own line: "Replies post to Slack as the connected bot, not as you." The composer hint reads "Sent as plain text", not `NoteComposer`'s default "Markdown supported", which is false for Slack (outgoing replies are not translated to mrkdwn; that is a stated non-goal of this release).

## Decision: the inbox heads are refreshed too, not left stale

`useSlackThreads` (the inbox) and `useSlackThread` (the detail) are separate hooks over separate store keys, so refreshing the thread leaves the inbox row's reply count and `latest_reply` ordering stale after a write. `runSlackWrite` therefore refreshes both: `refreshSlackThread(..., { force: true })` and then `refreshSlackThreadHeads({ workspaceId, channelId })`. It costs one extra `conversations.history` call per write, on a user-initiated action that is rare, and it buys an inbox that agrees with the thread you just replied in. It lives in the wrapper, so every future write path inherits it.

The force flag is load-bearing: `refreshSlackThread` returns early when a fetch is already in flight, so a non-forced refresh after a write can read a cached thread and never show the reply.

## Decision: the composer is not a second dock

`SlackThreadDetail`'s `dock` is already occupied by `LaunchSessionPanel` in the studio, and a second dock would either fight it or push it off screen. The composer instead sits at the end of the conversation, under the last message, which is what every other integration in this repo already does (`PrConversation`, `MrConversation`, both `IssueConversation` copies, `GithubIssueComments`) and what GitHub's own PR timeline does. In the studio it reads as "the thread, then the reply box, then the launch panel below the divider"; in the lens the dock stays empty and the composer is simply the last thing in the thread. One layout, both surfaces, no new prop on the shared layout.

## Decision: no emoji picker

The reaction affordance is four quick reactions (`eyes`, `+1`, `white_check_mark`, `tada`) revealed on message hover, plus the message's existing reactions as clickable pills that add your own. Slack's and GitHub's hover reaction bars are the precedent. A full picker is a different product surface and is not in the release scope.

## Failures surface, never hide

- A failed reply rejects out of the store action, through the hook, into `NoteComposer`'s inline `role="alert"`, and the draft is kept.
- A failed reaction has no composer to land in, so it renders as a `role="alert"` line above the composer.
- Reaction buttons disabled while a write runs carry the reason in their `title` ("Waiting for the current Slack write").
- A second write dispatched while one is in flight is refused by a `busyRef` read and set synchronously at call time, not by `busy` read from the render closure. That is the `usePrActions.run` shape this PR deliberately does not inherit: there, two invocations in the same tick both pass the guard before the first `setBusy` commits.

## Test plan

`pnpm typecheck`, `pnpm test` (573 files, 4794 tests), `pnpm knip --include files,duplicates,unlisted`, and `cargo test --locked` are all green.

Button to request, traced and asserted:

- **Reply**: composer submit -> `actions.reply` -> `useSlackThreadActions.reply` -> `replyToSlackThread({ workspaceId, channelId, threadTs, text })` -> `runSlackWrite` -> `slackPostReply` -> `invoke('slack_post_reply', { workspaceId, channelId, threadTs, text })`. Covered by `ThreadDetailPanel.test.tsx` (studio), `SlackTaskDetail.test.tsx` (lens), `useSlackThreadActions/index.test.tsx` (hook to store), `slack-threads/index.test.ts` (store to client), `slack/client.test.ts` (client to invoke, already on main).
- **Reaction**: pill or quick button click -> `actions.react({ messageTs, name })` -> `addSlackReaction({ workspaceId, channelId, threadTs, messageTs, name })` -> `runSlackWrite` -> `slackAddReaction` -> `invoke('slack_add_reaction', { workspaceId, channelId, messageTs, name })`. The reaction test deliberately reacts to a **reply** message whose ts differs from the thread root, so a `thread_ts` for `ts` swap cannot pass.

`ThreadDetailPanel` falls back to `[row.head]` when the thread fetch is empty, so both panel assertions run against a two-message thread and target the second message, which does not exist in the fallback.

### Sabotage results

Every test written here was sabotaged and confirmed red, wrapper included, not only the payload builders:

| Sabotage | Result |
| --- | --- |
| `{ force: true }` becomes `{ force: false }` in `runSlackWrite` | red |
| the heads refresh is deleted from `runSlackWrite` | red |
| `runSlackWrite` wraps `write()` in a swallowing try/catch | red |
| `slackAddReaction` gets `messageTs: threadTs` | red |
| `slackPostReply` gets the wrong channel | red |
| `slackPostReply` loses its `threadTs` | red |
| the `busyRef` guard is deleted | red |
| the guard reads `isWriting` from the render closure instead of the ref | red |
| the reaction error is swallowed instead of set | red |
| the composer hint falls back to "Markdown supported" | red |
| the write error stops rendering | red |
| the bot disclosure is reworded away | red |
| the reaction affordance loses its message ts | red |
| a disabled reaction button loses its reason | red |

The two error assertions read the rendered `role="alert"` text, they do not merely assert a mock was called.

### Never sent to a live tenant

Worst first, everything below was exercised against fixtures only. No Slack workspace was contacted at any point in this PR.

1. **`chat.postMessage` with `thread_ts`.** Whether a bot-authored reply actually threads under the parent, rather than landing as a new top-level channel message, has never been observed live. This is the single riskiest claim in the PR: the payload is asserted, the server's interpretation of it is not.
2. **`reactions.add`.** Whether the four quick reaction names (`eyes`, `+1`, `white_check_mark`, `tada`) all resolve on a real workspace has never been checked. `+1` is Slack's canonical name and `thumbsup` its alias, but a workspace that has removed or aliased an emoji would return `invalid_name`, which surfaces as the inline error and has never been seen for real.
3. **Write scopes.** `chat:write` and `reactions:write` have never been granted to a real token. A token connected before those scopes were added fails at write time, not at connect time, because `slack_validate_connection` probes `auth.test` only.
4. **`already_reacted`.** Clicking a reaction you already added returns `ok:false` with `already_reacted`. It renders as the inline error like any other named failure, which is honest but has never been seen live; a friendlier "you already reacted" path is not built.
5. **The post-write refresh under rate limiting.** A write followed immediately by two reads (thread, then heads) is three calls in quick succession. Live 429 behavior and the `Retry-After` path were never exercised; they are inherited untested from #1249.
6. **Whether the reply appears in the refreshed thread at all.** The refresh is asserted to fire with the right arguments against a fixture that returns two messages. That the real `conversations.replies` includes a just-posted message without a propagation delay is assumed, not observed.

## Not in this PR

Composing new top-level messages, creating channels, an emoji picker, editing or deleting a reply, removing a reaction, and a markdown-to-mrkdwn writer for outgoing replies. All are stated non-goals of the v0.1.65 plan.
