### PR TITLE
fix(core): read the real check status and merge queue

### DIFF
--- a/apps/desktop/src/features/github/components/GitHubStudio/PrActionBar.test.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/PrActionBar.test.tsx
@@ -5,6 +5,7 @@ import type { ActionBusy } from './PrActionBar';
 import type { PrVerdictSubmission } from './PrVerdictAction';
 
 type Params = {
+  readonly pr?: PullRequestState;
   readonly canMerge?: boolean;
   readonly canReview?: boolean;
   readonly busy?: ActionBusy;
@@ -30,6 +31,7 @@ const PR = {
 import { PrActionBar } from './PrActionBar';
 
 const renderActionBar = ({
+  pr = PR,
   canMerge = true,
   canReview = true,
   busy = null,
@@ -38,7 +40,7 @@ const renderActionBar = ({
 }: Params = {}) =>
   render(
     <PrActionBar
-      pr={PR}
+      pr={pr}
       busy={busy}
       canMerge={canMerge}
       canReview={canReview}
@@ -120,5 +122,20 @@ describe('PrActionBar', () => {
     const merge = screen.getByRole('button', { name: 'Merge' });
     expect(merge.hasAttribute('disabled')).toBe(true);
     expect(merge.getAttribute('title')).toBe('PR has conflicts, resolve them first');
+  });
+
+  it('replaces merge with the queue position once the PR is in the merge queue', () => {
+    renderActionBar({ pr: { ...PR, state: 'queued', mergeQueue: { position: 3 } } });
+
+    expect(screen.getByText('In merge queue')).toBeDefined();
+    expect(screen.getByText('#3')).toBeDefined();
+    expect(screen.queryByRole('button', { name: 'Merge' })).toBeNull();
+  });
+
+  it('calls auto-merge by its name instead of claiming a merge queue', () => {
+    renderActionBar({ pr: { ...PR, state: 'queued', mergeQueue: null } });
+
+    expect(screen.getByText('Auto-merge on')).toBeDefined();
+    expect(screen.queryByText('In merge queue')).toBeNull();
   });
 });

--- a/apps/desktop/src/features/github/components/GitHubStudio/PrActionBar.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/PrActionBar.tsx
@@ -63,7 +63,7 @@ export const PrActionBar = ({
       {!isTerminal && isQueued && (
         <span className="inline-flex items-center gap-1.5 rounded-md border border-primary/40 bg-primary/10 px-2 py-1 text-xs font-medium text-primary">
           <GitMerge size={13} aria-hidden />
-          In merge queue
+          {pr.mergeQueue != null ? 'In merge queue' : 'Auto-merge on'}
           {pr.mergeQueue?.position != null && <span>#{pr.mergeQueue.position}</span>}
         </span>
       )}

--- a/packages/core/src/github/__tests__/cache.test.ts
+++ b/packages/core/src/github/__tests__/cache.test.ts
@@ -112,7 +112,10 @@ describe('getPrForBranch', () => {
     const deps: PrCacheDeps = { runner, store, now: () => NOW };
 
     const result = await getPrForBranch(deps, BASE_INPUT);
-    expect(runner.run).toHaveBeenCalledOnce();
+    expect(runner.run).toHaveBeenCalledWith(
+      expect.arrayContaining(['pr', 'list']),
+      expect.anything(),
+    );
     expect(store.upsert).toHaveBeenCalledOnce();
     expect(result?.title).toBe('Updated PR');
   });
@@ -123,7 +126,10 @@ describe('getPrForBranch', () => {
     const deps: PrCacheDeps = { runner, store, now: () => NOW };
 
     const result = await getPrForBranch(deps, BASE_INPUT);
-    expect(runner.run).toHaveBeenCalledOnce();
+    expect(runner.run).toHaveBeenCalledWith(
+      expect.arrayContaining(['pr', 'list']),
+      expect.anything(),
+    );
     expect(result).not.toBeNull();
   });
 
@@ -139,7 +145,10 @@ describe('getPrForBranch', () => {
     const deps: PrCacheDeps = { runner, store, now: () => NOW };
 
     await getPrForBranch(deps, { ...BASE_INPUT, force: true });
-    expect(runner.run).toHaveBeenCalledOnce();
+    expect(runner.run).toHaveBeenCalledWith(
+      expect.arrayContaining(['pr', 'list']),
+      expect.anything(),
+    );
   });
 
   it('upserts null and returns null when runner returns no PR', async () => {

--- a/packages/core/src/github/__tests__/merge-queue.test.ts
+++ b/packages/core/src/github/__tests__/merge-queue.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { GhRunner } from '../gh';
+import { fetchMergeQueuePlacements } from '../merge-queue';
+
+const makeRunner = (result: { stdout: string; stderr: string; exitCode: number }): GhRunner => ({
+  run: vi.fn().mockResolvedValue(result),
+});
+
+const graphqlPayload = (nodes: unknown) =>
+  JSON.stringify({ data: { repository: { pullRequests: { nodes } } } });
+
+describe('fetchMergeQueuePlacements', () => {
+  it('keeps only the pull requests that are actually in the queue', async () => {
+    const runner = makeRunner({
+      stdout: graphqlPayload([
+        { number: 4, isInMergeQueue: true, mergeQueueEntry: { position: 1, state: 'QUEUED' } },
+        { number: 5, isInMergeQueue: false, mergeQueueEntry: null },
+      ]),
+      stderr: '',
+      exitCode: 0,
+    });
+
+    const placements = await fetchMergeQueuePlacements({
+      runner,
+      repo: 'org/repo',
+      branch: 'feature',
+    });
+
+    expect(placements.get(4)).toEqual({ position: 1 });
+    expect(placements.has(5)).toBe(false);
+  });
+
+  it('asks for the whole repo when no branch is given', async () => {
+    const runner = makeRunner({ stdout: graphqlPayload([]), stderr: '', exitCode: 0 });
+
+    await fetchMergeQueuePlacements({ runner, repo: 'org/repo', branch: null });
+
+    const args = vi.mocked(runner.run).mock.calls[0]?.[0] ?? [];
+    expect(args.some((arg) => arg.includes('headRefName'))).toBe(false);
+  });
+
+  it('returns no placements when gh cannot answer, instead of failing the PR fetch', async () => {
+    const runner = makeRunner({ stdout: '', stderr: 'not authorized', exitCode: 1 });
+
+    const placements = await fetchMergeQueuePlacements({
+      runner,
+      repo: 'org/repo',
+      branch: 'feature',
+    });
+
+    expect(placements.size).toBe(0);
+  });
+
+  it('returns no placements when the repo slug is malformed', async () => {
+    const runner = makeRunner({ stdout: graphqlPayload([]), stderr: '', exitCode: 0 });
+
+    const placements = await fetchMergeQueuePlacements({ runner, repo: 'repo', branch: null });
+
+    expect(placements.size).toBe(0);
+    expect(runner.run).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/github/__tests__/merge-queue.test.ts
+++ b/packages/core/src/github/__tests__/merge-queue.test.ts
@@ -59,4 +59,14 @@ describe('fetchMergeQueuePlacements', () => {
     expect(placements.size).toBe(0);
     expect(runner.run).not.toHaveBeenCalled();
   });
+
+  it('passes graphql variables untyped so an all-digit branch is not coerced to a number', async () => {
+    const runner = makeRunner({ stdout: graphqlPayload([]), stderr: '', exitCode: 0 });
+
+    await fetchMergeQueuePlacements({ runner, repo: 'org/repo', branch: '1234' });
+
+    const args = vi.mocked(runner.run).mock.calls[0]?.[0] ?? [];
+    expect(args).not.toContain('-F');
+    expect(args).toEqual(expect.arrayContaining(['-f', 'branch=1234']));
+  });
 });

--- a/packages/core/src/github/__tests__/repo-prs.test.ts
+++ b/packages/core/src/github/__tests__/repo-prs.test.ts
@@ -10,6 +10,33 @@ function makeJsonRunner(data: unknown): GhRunner {
   return makeRunner({ stdout: JSON.stringify(data), stderr: '', exitCode: 0 });
 }
 
+type MergeQueueNode = {
+  number: number;
+  isInMergeQueue: boolean;
+  mergeQueueEntry: { position: number | null; state: string } | null;
+};
+
+const makeMergeQueueAwareRunner = ({
+  prs,
+  mergeQueueNodes,
+}: {
+  prs: unknown;
+  mergeQueueNodes: ReadonlyArray<MergeQueueNode>;
+}): GhRunner => ({
+  run: vi.fn(async (args: ReadonlyArray<string>) => {
+    if (args.includes('graphql')) {
+      return {
+        stdout: JSON.stringify({
+          data: { repository: { pullRequests: { nodes: mergeQueueNodes } } },
+        }),
+        stderr: '',
+        exitCode: 0,
+      };
+    }
+    return { stdout: JSON.stringify(prs), stderr: '', exitCode: 0 };
+  }),
+});
+
 const BASE_RAW = {
   number: 1,
   title: 'PR title',
@@ -89,5 +116,20 @@ describe('listOpenPrsForRepo', () => {
       run: vi.fn().mockRejectedValue(new TypeError('network error')),
     };
     await expect(listOpenPrsForRepo(runner, 'org/repo')).rejects.toBeInstanceOf(TypeError);
+  });
+
+  it('attaches merge queue placement to the listed pull requests', async () => {
+    const pr = { ...BASE_RAW, number: 7 };
+    const runner = makeMergeQueueAwareRunner({
+      prs: [pr],
+      mergeQueueNodes: [
+        { number: 7, isInMergeQueue: true, mergeQueueEntry: { position: 3, state: 'QUEUED' } },
+      ],
+    });
+
+    const result = await listOpenPrsForRepo(runner, 'org/repo');
+
+    expect(result[0]?.state).toBe('queued');
+    expect(result[0]?.mergeQueue).toEqual({ position: 3 });
   });
 });

--- a/packages/core/src/github/__tests__/resolver.test.ts
+++ b/packages/core/src/github/__tests__/resolver.test.ts
@@ -11,6 +11,33 @@ function makeJsonRunner(data: unknown): GhRunner {
   return makeRunner({ stdout: JSON.stringify(data), stderr: '', exitCode: 0 });
 }
 
+type MergeQueueNode = {
+  number: number;
+  isInMergeQueue: boolean;
+  mergeQueueEntry: { position: number | null; state: string } | null;
+};
+
+const makeMergeQueueAwareRunner = ({
+  prs,
+  mergeQueueNodes,
+}: {
+  prs: unknown;
+  mergeQueueNodes: ReadonlyArray<MergeQueueNode>;
+}): GhRunner => ({
+  run: vi.fn(async (args: ReadonlyArray<string>) => {
+    if (args.includes('graphql')) {
+      return {
+        stdout: JSON.stringify({
+          data: { repository: { pullRequests: { nodes: mergeQueueNodes } } },
+        }),
+        stderr: '',
+        exitCode: 0,
+      };
+    }
+    return { stdout: JSON.stringify(prs), stderr: '', exitCode: 0 };
+  }),
+});
+
 const BASE_RAW = {
   number: 1,
   title: 'PR title',
@@ -130,17 +157,43 @@ describe('resolvePrForBranch', () => {
     expect(result?.state).toBe('merged');
   });
 
-  it('maps OPEN + autoMergeRequest object → queued (with mergeQueue)', async () => {
+  it('maps OPEN + autoMergeRequest object → queued without forging a mergeQueue entry', async () => {
     const pr = {
       ...BASE_RAW,
       number: 1,
       state: 'OPEN' as const,
       autoMergeRequest: { enabledAt: '2024-01-01T00:00:00Z' },
     };
-    const runner = makeJsonRunner([pr]);
+    const runner = makeMergeQueueAwareRunner({ prs: [pr], mergeQueueNodes: [] });
     const result = await resolvePrForBranch(runner, 'org/repo', 'feature');
     expect(result?.state).toBe('queued');
-    expect(result?.mergeQueue).toEqual({ position: null });
+    expect(result?.mergeQueue).toBeNull();
+  });
+
+  it('maps a live merge queue entry → queued with its position', async () => {
+    const pr = { ...BASE_RAW, number: 7, state: 'OPEN' as const };
+    const runner = makeMergeQueueAwareRunner({
+      prs: [pr],
+      mergeQueueNodes: [
+        { number: 7, isInMergeQueue: true, mergeQueueEntry: { position: 2, state: 'QUEUED' } },
+      ],
+    });
+    const result = await resolvePrForBranch(runner, 'org/repo', 'feature');
+    expect(result?.state).toBe('queued');
+    expect(result?.mergeQueue).toEqual({ position: 2 });
+  });
+
+  it('leaves a PR absent from the merge queue as open', async () => {
+    const pr = { ...BASE_RAW, number: 7, state: 'OPEN' as const };
+    const runner = makeMergeQueueAwareRunner({
+      prs: [pr],
+      mergeQueueNodes: [
+        { number: 99, isInMergeQueue: true, mergeQueueEntry: { position: 1, state: 'QUEUED' } },
+      ],
+    });
+    const result = await resolvePrForBranch(runner, 'org/repo', 'feature');
+    expect(result?.state).toBe('open');
+    expect(result?.mergeQueue).toBeNull();
   });
 
   it('queued beats approved when autoMergeRequest present', async () => {
@@ -247,6 +300,60 @@ describe('resolvePrForBranch', () => {
       number: 1,
       state: 'OPEN' as const,
       statusCheckRollup: [{ conclusion: 'SUCCESS' as const }, { state: 'PENDING' as const }],
+    };
+    const runner = makeJsonRunner([pr]);
+    const result = await resolvePrForBranch(runner, 'org/repo', 'feature');
+    expect(result?.checks).toBe('pending');
+  });
+
+  it('checks: IN_PROGRESS run with an empty-string conclusion → pending', async () => {
+    const pr = {
+      ...BASE_RAW,
+      number: 1,
+      state: 'OPEN' as const,
+      statusCheckRollup: [
+        { conclusion: 'SUCCESS', status: 'COMPLETED' },
+        { conclusion: '', status: 'IN_PROGRESS' },
+      ],
+    };
+    const runner = makeJsonRunner([pr]);
+    const result = await resolvePrForBranch(runner, 'org/repo', 'feature');
+    expect(result?.checks).toBe('pending');
+  });
+
+  it('checks: QUEUED run with an empty-string conclusion → pending', async () => {
+    const pr = {
+      ...BASE_RAW,
+      number: 1,
+      state: 'OPEN' as const,
+      statusCheckRollup: [{ conclusion: '', status: 'QUEUED' }],
+    };
+    const runner = makeJsonRunner([pr]);
+    const result = await resolvePrForBranch(runner, 'org/repo', 'feature');
+    expect(result?.checks).toBe('pending');
+  });
+
+  it('checks: STARTUP_FAILURE conclusion → failure', async () => {
+    const pr = {
+      ...BASE_RAW,
+      number: 1,
+      state: 'OPEN' as const,
+      statusCheckRollup: [
+        { conclusion: 'SUCCESS', status: 'COMPLETED' },
+        { conclusion: 'STARTUP_FAILURE', status: 'COMPLETED' },
+      ],
+    };
+    const runner = makeJsonRunner([pr]);
+    const result = await resolvePrForBranch(runner, 'org/repo', 'feature');
+    expect(result?.checks).toBe('failure');
+  });
+
+  it('checks: a run GitHub reports with no verdict at all → pending', async () => {
+    const pr = {
+      ...BASE_RAW,
+      number: 1,
+      state: 'OPEN' as const,
+      statusCheckRollup: [{ conclusion: '', status: '', state: '' }],
     };
     const runner = makeJsonRunner([pr]);
     const result = await resolvePrForBranch(runner, 'org/repo', 'feature');

--- a/packages/core/src/github/__tests__/resolver.test.ts
+++ b/packages/core/src/github/__tests__/resolver.test.ts
@@ -391,6 +391,21 @@ describe('listPrsForBranch', () => {
       GhCliError,
     );
   });
+
+  it('attaches merge queue placement to the listed pull requests', async () => {
+    const pr = { ...BASE_RAW, number: 7, state: 'OPEN' as const };
+    const runner = makeMergeQueueAwareRunner({
+      prs: [pr],
+      mergeQueueNodes: [
+        { number: 7, isInMergeQueue: true, mergeQueueEntry: { position: 3, state: 'QUEUED' } },
+      ],
+    });
+
+    const result = await listPrsForBranch(runner, 'org/repo', 'feature');
+
+    expect(result[0]?.state).toBe('queued');
+    expect(result[0]?.mergeQueue).toEqual({ position: 3 });
+  });
 });
 
 describe('detectRepoSlug', () => {

--- a/packages/core/src/github/merge-queue.ts
+++ b/packages/core/src/github/merge-queue.ts
@@ -1,0 +1,119 @@
+import type { GhRunner, GhRunOptions } from './gh';
+import { GhCliError, GhJsonParseError, runJson } from './gh';
+
+export type MergeQueuePlacement = {
+  readonly position: number | null;
+};
+
+type RawMergeQueueNode = {
+  number: number;
+  isInMergeQueue?: boolean | null;
+  mergeQueueEntry?: { position?: number | null; state?: string | null } | null;
+};
+
+type RawMergeQueueResponse = {
+  data?: {
+    repository?: {
+      pullRequests?: { nodes?: ReadonlyArray<RawMergeQueueNode> | null } | null;
+    } | null;
+  } | null;
+};
+
+const BRANCH_MERGE_QUEUE_QUERY = `query($owner:String!,$name:String!,$branch:String!){
+  repository(owner:$owner,name:$name){
+    pullRequests(first:20,states:[OPEN],headRefName:$branch){
+      nodes{ number isInMergeQueue mergeQueueEntry{ position state } }
+    }
+  }
+}`;
+
+const REPO_MERGE_QUEUE_QUERY = `query($owner:String!,$name:String!){
+  repository(owner:$owner,name:$name){
+    pullRequests(first:100,states:[OPEN],orderBy:{field:UPDATED_AT,direction:DESC}){
+      nodes{ number isInMergeQueue mergeQueueEntry{ position state } }
+    }
+  }
+}`;
+
+const EMPTY_PLACEMENTS: ReadonlyMap<number, MergeQueuePlacement> = new Map();
+
+const toPlacements = ({
+  nodes,
+}: {
+  nodes: ReadonlyArray<RawMergeQueueNode>;
+}): ReadonlyMap<number, MergeQueuePlacement> => {
+  const placements = new Map<number, MergeQueuePlacement>();
+  for (const node of nodes) {
+    const entry = node.mergeQueueEntry;
+    if (entry == null && node.isInMergeQueue !== true) {
+      continue;
+    }
+    placements.set(node.number, { position: entry?.position ?? null });
+  }
+  return placements;
+};
+
+const buildArgs = ({
+  owner,
+  name,
+  branch,
+}: {
+  owner: string;
+  name: string;
+  branch: string | null;
+}): ReadonlyArray<string> => {
+  if (branch == null) {
+    return [
+      'api',
+      'graphql',
+      '-f',
+      `query=${REPO_MERGE_QUEUE_QUERY}`,
+      '-F',
+      `owner=${owner}`,
+      '-F',
+      `name=${name}`,
+    ];
+  }
+  return [
+    'api',
+    'graphql',
+    '-f',
+    `query=${BRANCH_MERGE_QUEUE_QUERY}`,
+    '-F',
+    `owner=${owner}`,
+    '-F',
+    `name=${name}`,
+    '-F',
+    `branch=${branch}`,
+  ];
+};
+
+export const fetchMergeQueuePlacements = async ({
+  runner,
+  repo,
+  branch,
+  opts = {},
+}: {
+  runner: GhRunner;
+  repo: string;
+  branch: string | null;
+  opts?: GhRunOptions;
+}): Promise<ReadonlyMap<number, MergeQueuePlacement>> => {
+  const [owner, name] = repo.split('/');
+  if (owner == null || owner === '' || name == null || name === '') {
+    return EMPTY_PLACEMENTS;
+  }
+  try {
+    const raw = await runJson<RawMergeQueueResponse>(
+      runner,
+      buildArgs({ owner, name, branch }),
+      opts,
+    );
+    return toPlacements({ nodes: raw.data?.repository?.pullRequests?.nodes ?? [] });
+  } catch (err) {
+    if (err instanceof GhCliError || err instanceof GhJsonParseError) {
+      return EMPTY_PLACEMENTS;
+    }
+    throw err;
+  }
+};

--- a/packages/core/src/github/merge-queue.ts
+++ b/packages/core/src/github/merge-queue.ts
@@ -68,9 +68,9 @@ const buildArgs = ({
       'graphql',
       '-f',
       `query=${REPO_MERGE_QUEUE_QUERY}`,
-      '-F',
+      '-f',
       `owner=${owner}`,
-      '-F',
+      '-f',
       `name=${name}`,
     ];
   }
@@ -79,11 +79,11 @@ const buildArgs = ({
     'graphql',
     '-f',
     `query=${BRANCH_MERGE_QUEUE_QUERY}`,
-    '-F',
+    '-f',
     `owner=${owner}`,
-    '-F',
+    '-f',
     `name=${name}`,
-    '-F',
+    '-f',
     `branch=${branch}`,
   ];
 };

--- a/packages/core/src/github/repo-prs.ts
+++ b/packages/core/src/github/repo-prs.ts
@@ -1,6 +1,7 @@
 import type { PullRequestState } from '@goodboy/types';
 import type { GhRunner, GhRunOptions } from './gh';
 import { GhCliError, runJson } from './gh';
+import { fetchMergeQueuePlacements } from './merge-queue';
 import { PR_FIELDS, toPullRequestState, type RawPullRequest } from './resolver';
 
 const REPO_PR_FIELDS = [...PR_FIELDS, 'author', 'reviewRequests'] as const;
@@ -41,10 +42,14 @@ export const listOpenPrsForRepo = async (
     }
     throw err;
   }
+  if (raw.length === 0) {
+    return [];
+  }
+  const placements = await fetchMergeQueuePlacements({ runner, repo, branch: null, opts });
   return [...raw]
     .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
     .map((pr) => ({
-      ...toPullRequestState(pr),
+      ...toPullRequestState({ raw: pr, mergeQueue: placements.get(pr.number) ?? null }),
       author: pr.author?.login ?? '',
       reviewRequestLogins: (pr.reviewRequests ?? [])
         .map((r) => r.login ?? '')

--- a/packages/core/src/github/resolver.ts
+++ b/packages/core/src/github/resolver.ts
@@ -1,6 +1,12 @@
-import type { LinkedIssue, PullRequestState, PullRequestStateKind } from '@goodboy/types';
+import type {
+  LinkedIssue,
+  PullRequestChecks,
+  PullRequestState,
+  PullRequestStateKind,
+} from '@goodboy/types';
 import type { GhRunner, GhRunOptions } from './gh';
 import { GhCliError, runJson } from './gh';
+import { fetchMergeQueuePlacements, type MergeQueuePlacement } from './merge-queue';
 
 export const PR_FIELDS = [
   'number',
@@ -18,6 +24,12 @@ export const PR_FIELDS = [
   'autoMergeRequest',
 ] as const;
 
+export type RawStatusCheck = {
+  state?: string | null;
+  status?: string | null;
+  conclusion?: string | null;
+};
+
 export type RawPullRequest = {
   number: number;
   title: string;
@@ -28,10 +40,7 @@ export type RawPullRequest = {
   baseRefName: string;
   headRefName: string;
   reviewDecision: 'APPROVED' | 'CHANGES_REQUESTED' | 'REVIEW_REQUIRED' | null;
-  statusCheckRollup: ReadonlyArray<{
-    state?: 'SUCCESS' | 'FAILURE' | 'PENDING' | 'ERROR' | null;
-    conclusion?: 'SUCCESS' | 'FAILURE' | 'NEUTRAL' | 'CANCELLED' | 'TIMED_OUT' | null;
-  }> | null;
+  statusCheckRollup: ReadonlyArray<RawStatusCheck> | null;
   updatedAt: string;
   body: string | null;
   autoMergeRequest: Record<string, unknown> | null;
@@ -43,7 +52,77 @@ type ClosingIssueRef = {
   url: string;
 };
 
-function deriveStateKind(raw: RawPullRequest): PullRequestStateKind {
+const UNFINISHED_CHECK_STATUSES = new Set([
+  'REQUESTED',
+  'QUEUED',
+  'IN_PROGRESS',
+  'WAITING',
+  'PENDING',
+]);
+
+const FAILED_CHECK_CONCLUSIONS = new Set([
+  'FAILURE',
+  'CANCELLED',
+  'TIMED_OUT',
+  'ACTION_REQUIRED',
+  'STARTUP_FAILURE',
+]);
+
+const FAILED_CHECK_STATES = new Set(['FAILURE', 'ERROR']);
+
+const PASSED_CHECK_CONCLUSIONS = new Set(['SUCCESS', 'NEUTRAL', 'SKIPPED', 'STALE']);
+
+type CheckOutcome = 'pending' | 'success' | 'failure';
+
+const readCheckSignal = ({ value }: { value?: string | null }): string | null => {
+  const normalized = (value ?? '').trim().toUpperCase();
+  return normalized === '' ? null : normalized;
+};
+
+const classifyCheck = ({ check }: { check: RawStatusCheck }): CheckOutcome => {
+  const status = readCheckSignal({ value: check.status });
+  if (status != null && UNFINISHED_CHECK_STATUSES.has(status)) {
+    return 'pending';
+  }
+  const conclusion = readCheckSignal({ value: check.conclusion });
+  if (conclusion != null && FAILED_CHECK_CONCLUSIONS.has(conclusion)) {
+    return 'failure';
+  }
+  const state = readCheckSignal({ value: check.state });
+  if (state != null && FAILED_CHECK_STATES.has(state)) {
+    return 'failure';
+  }
+  if (conclusion != null && PASSED_CHECK_CONCLUSIONS.has(conclusion)) {
+    return 'success';
+  }
+  if (state === 'SUCCESS') {
+    return 'success';
+  }
+  return 'pending';
+};
+
+const deriveChecks = ({ raw }: { raw: RawPullRequest }): PullRequestChecks => {
+  const checks = raw.statusCheckRollup ?? [];
+  if (checks.length === 0) {
+    return null;
+  }
+  const outcomes = checks.map((check) => classifyCheck({ check }));
+  if (outcomes.includes('failure')) {
+    return 'failure';
+  }
+  if (outcomes.includes('pending')) {
+    return 'pending';
+  }
+  return 'success';
+};
+
+const deriveStateKind = ({
+  raw,
+  mergeQueue,
+}: {
+  raw: RawPullRequest;
+  mergeQueue: MergeQueuePlacement | null;
+}): PullRequestStateKind => {
   if (raw.state === 'MERGED') {
     return 'merged';
   }
@@ -53,6 +132,9 @@ function deriveStateKind(raw: RawPullRequest): PullRequestStateKind {
   if (raw.isDraft) {
     return 'draft';
   }
+  if (mergeQueue != null) {
+    return 'queued';
+  }
   if (raw.autoMergeRequest != null) {
     return 'queued';
   }
@@ -60,32 +142,9 @@ function deriveStateKind(raw: RawPullRequest): PullRequestStateKind {
     return 'approved';
   }
   return 'open';
-}
+};
 
-function deriveChecks(raw: RawPullRequest): PullRequestState['checks'] {
-  const checks = raw.statusCheckRollup ?? [];
-  if (checks.length === 0) {
-    return null;
-  }
-  let pending = false;
-  for (const c of checks) {
-    const status = c.conclusion ?? c.state ?? null;
-    if (
-      status === 'FAILURE' ||
-      status === 'CANCELLED' ||
-      status === 'TIMED_OUT' ||
-      status === 'ERROR'
-    ) {
-      return 'failure';
-    }
-    if (status === 'PENDING' || status === null) {
-      pending = true;
-    }
-  }
-  return pending ? 'pending' : 'success';
-}
-
-function deriveMergeable(raw: RawPullRequest): boolean | null {
+const deriveMergeable = ({ raw }: { raw: RawPullRequest }): boolean | null => {
   if (raw.mergeable === 'MERGEABLE') {
     return true;
   }
@@ -93,30 +152,36 @@ function deriveMergeable(raw: RawPullRequest): boolean | null {
     return false;
   }
   return null;
-}
-
-export const toPullRequestState = (raw: RawPullRequest): PullRequestState => {
-  const reviewMap: Record<string, PullRequestState['reviewDecision']> = {
-    APPROVED: 'approved',
-    CHANGES_REQUESTED: 'changes_requested',
-    REVIEW_REQUIRED: 'review_required',
-  };
-  return {
-    number: raw.number,
-    title: raw.title,
-    url: raw.url,
-    state: deriveStateKind(raw),
-    mergeable: deriveMergeable(raw),
-    checks: deriveChecks(raw),
-    baseBranch: raw.baseRefName,
-    headBranch: raw.headRefName,
-    isDraft: raw.isDraft,
-    reviewDecision: raw.reviewDecision ? (reviewMap[raw.reviewDecision] ?? null) : null,
-    body: raw.body ?? '',
-    updatedAt: raw.updatedAt,
-    mergeQueue: raw.autoMergeRequest != null ? { position: null } : null,
-  };
 };
+
+const REVIEW_DECISIONS: Record<string, PullRequestState['reviewDecision']> = {
+  APPROVED: 'approved',
+  CHANGES_REQUESTED: 'changes_requested',
+  REVIEW_REQUIRED: 'review_required',
+};
+
+export const toPullRequestState = ({
+  raw,
+  mergeQueue = null,
+}: {
+  raw: RawPullRequest;
+  mergeQueue?: MergeQueuePlacement | null;
+}): PullRequestState => ({
+  number: raw.number,
+  title: raw.title,
+  url: raw.url,
+  state: deriveStateKind({ raw, mergeQueue }),
+  mergeable: deriveMergeable({ raw }),
+  checks: deriveChecks({ raw }),
+  baseBranch: raw.baseRefName,
+  headBranch: raw.headRefName,
+  isDraft: raw.isDraft,
+  reviewDecision:
+    raw.reviewDecision != null ? (REVIEW_DECISIONS[raw.reviewDecision] ?? null) : null,
+  body: raw.body ?? '',
+  updatedAt: raw.updatedAt,
+  mergeQueue,
+});
 
 export const resolvePrForBranch = async (
   runner: GhRunner,
@@ -153,7 +218,11 @@ export const resolvePrForBranch = async (
   const open = raw.filter((p) => p.state === 'OPEN');
   open.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
   const head = open[0] ?? [...raw].sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))[0];
-  return head ? toPullRequestState(head) : null;
+  if (head == null) {
+    return null;
+  }
+  const placements = await fetchMergeQueuePlacements({ runner, repo, branch, opts });
+  return toPullRequestState({ raw: head, mergeQueue: placements.get(head.number) ?? null });
 };
 
 export const listPrsForBranch = async (
@@ -177,6 +246,10 @@ export const listPrsForBranch = async (
     PR_FIELDS.join(','),
   ];
   const raw = await runJson<ReadonlyArray<RawPullRequest>>(runner, args, opts);
+  if (raw.length === 0) {
+    return [];
+  }
+  const placements = await fetchMergeQueuePlacements({ runner, repo, branch, opts });
   return [...raw]
     .sort((a, b) => {
       const aTerminal = a.state === 'OPEN' ? 0 : 1;
@@ -186,7 +259,7 @@ export const listPrsForBranch = async (
       }
       return b.updatedAt.localeCompare(a.updatedAt);
     })
-    .map(toPullRequestState);
+    .map((pr) => toPullRequestState({ raw: pr, mergeQueue: placements.get(pr.number) ?? null }));
 };
 
 const LINKED_KEYWORD_RE =


### PR DESCRIPTION
Closes #1266.

The owner's report: after clicking Merge, the operation can be repeated shortly after, because GitHub moved the PR to `queued` and Goodboy did not. Two independent defects sat behind that.

## Defect 1: a queued or in-progress check reported as passed

`packages/core/src/github/resolver.ts` `deriveChecks` collapsed the rollup with `const status = c.conclusion ?? c.state ?? null`, flagged pending only on `PENDING` or `null`, and never read `status` at all.

Live evidence, `gh pr list --repo microsoft/vscode --json statusCheckRollup` on gh 2.89.0:

```
pr 329311 (conclusion "",        status "IN_PROGRESS")
pr 329311 (conclusion "SUCCESS", status "COMPLETED")
pr 329284 (conclusion "FAILURE", status "COMPLETED")
```

The conclusion of an unfinished run is an **empty string, not null**. `""` is not nullish, so `??` kept it, it matched no failure branch and no pending branch, and the rollup returned `success`. Goodboy told the user CI had passed on a run that had not started.

`classifyCheck` now reads all three signals, treats a blank string as absent, and returns `success` only on an affirmative pass (`SUCCESS`, `NEUTRAL`, `SKIPPED`, `STALE`, or `state === 'SUCCESS'`). Anything unrecognised falls to `pending`, never to green. Two conclusions GitHub does return and the old code did not treat as failures, `ACTION_REQUIRED` and `STARTUP_FAILURE`, are now failures. The enum values come from schema introspection of `CheckStatusState`, `StatusState` and `CheckConclusionState`, not from memory.

`RawPullRequest.statusCheckRollup` had no `status` member and typed `conclusion` as an enum-or-null, so the type could not express the real payload. It is now `RawStatusCheck` with `state`, `status` and `conclusion` as nullable strings.

### The union decision: mapped onto `pending`, not widened

`PullRequestChecks` stays `'pending' | 'success' | 'failure' | null`. Queued and in-progress map to `pending`.

Reason: every consumer compares by equality, none is an exhaustive `switch` with a `never` default, so a widened union would compile clean and silently fall through in all of them. Consumers checked:

- `packages/types/src/github.ts` (the definition, and `PullRequestState.checks`)
- `apps/desktop/src/features/github/utils/compute-tab-status.tsx`
- `apps/desktop/src/features/github/components/GitHubStudio/useGithubInbox.ts`
- `apps/desktop/src/features/companion/mobileConfinement.ts` (the mobile gate: `checks !== 'success'` blocks the action, so a new member would have been safe here but nowhere else)
- `apps/desktop/src/features/session/components/SessionOverviewPane/PrStatusLine.tsx`
- `apps/desktop/src/features/session/components/SessionOverviewPane/selectNextUp.ts`
- `apps/desktop/src/store/slices/session-view/deriveSessionStage.ts`
- `apps/desktop/src/shared/detail-fields/sessionPullRequestFields.tsx`

On the Bitbucket overlap: the shared surface is the `PrChecks` **component**, which takes `ReadonlyArray<PrCheckRun>`, a different type. `PullRequestChecks` never reaches Bitbucket, which has its own `BitbucketPullRequestState`. So widening would not have hit Bitbucket, but it would have hit the eight GitHub sites above with no compiler help. `pending` already means "not done yet", which is exactly what queued and in-progress are.

## Defect 2: `queued` meant the wrong thing

`deriveStateKind` returned `queued` when `raw.autoMergeRequest != null`. That field is auto-merge, not the merge queue. A PR sitting in GitHub's merge queue read as plain open, and `PrActionBar` kept offering Merge, which is the reported bug.

**The merge-queue half shipped.** gh 2.89.0's `--json` field list has no merge-queue field (verified: it offers `autoMergeRequest`, `mergeCommit`, `mergeStateStatus`, `mergeable`, `mergedAt`, `mergedBy`, `potentialMergeCommit` and nothing else queue-related), so this goes through graphql, the same pattern already used in `details.ts`, `mutations.ts` and `reviews.ts`. Both fields resolve against the live schema:

```
$ gh api graphql -f query='... pullRequest(number:329311){ isInMergeQueue mergeQueueEntry{ position state } }'
{"data":{"repository":{"pullRequest":{"number":329311,"isInMergeQueue":false,"mergeQueueEntry":null}}}}
```

with a bogus-field control returning `Field 'bogusFieldXyz' doesn't exist on type 'PullRequest'`, so the success above is a real schema match and not a silent ignore.

New `packages/core/src/github/merge-queue.ts` exposes `fetchMergeQueuePlacements`, returning a `Map` from PR number to queue position. It is **one extra round trip**, not one per PR: the query filters by `headRefName` for the branch paths and takes the first 100 open PRs for the repo path, so a branch with five PRs still costs a single call. It is skipped entirely when the `gh pr list` came back empty, and it swallows `GhCliError` and `GhJsonParseError` into an empty map, so a token without the scope, or a GitHub Enterprise instance without merge queues, degrades to the previous behaviour instead of blanking the PR.

`toPullRequestState` now takes the placement and `mergeQueue` carries a real position instead of being forged from auto-merge.

### `autoMergeRequest` still maps to `queued`, deliberately

Both auto-merge and the merge queue mean "a merge is already requested, do not offer Merge again", and `PrActionBar` uses `state === 'queued'` to swap the Merge button for a status pill. Dropping auto-merge from `queued` would have re-introduced the duplicate-Merge bug for auto-merge users. What was wrong was the label: the pill said "In merge queue" for both. It now says "In merge queue #N" only when there is a real `mergeQueueEntry`, and "Auto-merge on" otherwise.

## Tests

Rewritten deliberately:

- `resolver.test.ts` "maps OPEN + autoMergeRequest object to queued (with mergeQueue)" asserted `mergeQueue` equals `{ position: null }`. That assertion pinned the forgery this PR removes. The state half of the test is kept, the `mergeQueue` assertion now expects `null`.
- Three `cache.test.ts` assertions were `expect(runner.run).toHaveBeenCalledOnce()`. Their intent is "the cache miss went to the network", and a cache miss now legitimately makes two gh calls. They assert the `pr list` invocation by name instead, which is a stronger statement of the same intent.

Added:

- `resolver.test.ts`: `IN_PROGRESS` with an empty-string conclusion is pending; `QUEUED` with an empty-string conclusion is pending; `STARTUP_FAILURE` is a failure; a run with no verdict at all is pending. All four fixtures use `conclusion: ""` rather than `conclusion: null`, because a `null` fixture already returned `pending` against the unfixed code and would have proved nothing. All four were confirmed red before the fix.
- `resolver.test.ts`: a live `mergeQueueEntry` maps to `queued` with its position; a PR absent from the queue stays open.
- `merge-queue.test.ts` (new): only queued PRs land in the map; the branchless call omits `headRefName`; a gh failure yields an empty map rather than an error; a malformed repo slug never reaches the network.
- `PrActionBar.test.tsx`: the queue position replaces the Merge button; auto-merge is named as auto-merge instead of claiming a queue. The second was confirmed red by reverting the label change.

## Not verified

- No PR was pushed through a real GitHub merge queue. Merge queues need a ruleset on a protected branch, which this repo does not have. `isInMergeQueue` and `mergeQueueEntry` were verified to exist and resolve against the live schema, and the parsing is covered by tests, but the populated shape of `mergeQueueEntry` (a non-null `position` on a PR actually sitting in a queue) is taken from the schema, not observed.
- `MergeQueueEntryState` (`QUEUED`, `AWAITING_CHECKS`, `MERGEABLE`, `UNMERGEABLE`, `LOCKED`) is read from the query but not surfaced. `mergeQueue` carries only the position, matching the existing type. Distinguishing "awaiting checks" from "queued" in the UI is left out.
- The repo-wide path takes the first 100 open PRs ordered by update time, matching the existing `gh pr list --limit 100`. On a repo with more than 100 open PRs, a queued PR outside that window keeps the old behaviour.

No docs or website copy describe PR check or merge-queue states, so nothing there went stale.
