### PR TITLE
feat(desktop): reach bitbucket from the footer connect surface

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -40,9 +40,11 @@ functional. One register per surface; let the other supply only texture.
   notifications, because it is reached often enough to earn the rent; the
   guide and pair-device stay out and live in the app settings studio and the
   command palette. A persistent footer
-  (`AppFooter`) holds integration tools (GitHub/GitLab/Linear/Sentry, gated) on
-  the left and studio launchers (workflows, providers, budget, impact) on the
-  right. The top bar is context, never content: every control in it opens
+  (`AppFooter`) holds integration tools (the code hosts GitHub/GitLab/Bitbucket
+  first, then Linear/Jira/Slack/Sentry, all gated) on the left and studio
+  launchers (workflows, providers, budget, impact) on the right. Every shipped
+  integration owns one of those entries: it is where a workspace connects the
+  integration, so an integration missing from the footer is unreachable. The top bar is context, never content: every control in it opens
   something elsewhere, none of them edits a record in place. See
   [docs/design.md](docs/design.md) for what each surface is made of and
   [docs/navigation.md](docs/navigation.md) for the full IA and breadcrumb

--- a/README.md
+++ b/README.md
@@ -82,10 +82,14 @@ its real transitions, and edit the description. Launch a session from one and
 the key lands on the branch. Creating a new issue, sprints, boards and
 priority edits are not there yet, and Jira Server is unsupported.
 
-**Bitbucket, read, act and route.** Connect Bitbucket Cloud from onboarding or
-the integrations panel with a workspace slug, your Atlassian account email and
-an API token, all verified against the account and the workspace before
-anything is stored. From there a session's pull request lens shows the
+**Bitbucket, read, act and route.** Connect Bitbucket Cloud from the footer,
+from onboarding or from the integrations panel with a workspace slug, your
+Atlassian account email and an API token, all verified against the account and
+the workspace before anything is stored. The footer entry sits next to GitHub
+and GitLab and opens the workspace's pull requests without a session, though
+that view is read-only: you browse a request and start a session from it, and
+the approve, comment and merge actions live inside a session. From there a
+session's pull request lens shows the
 Bitbucket request for its branch beside any GitHub or GitLab one, and the
 studio behind it lists the repository's pull requests with the description, the
 changed files, the build statuses read as plain language, and the review
@@ -94,8 +98,10 @@ changes or withdraw the ask, comment, reply on a thread, and merge or decline
 behind a confirmation. Merging uses whatever strategy the repository is set to,
 Goodboy does not pick one for you, and declining is closed to reopening from
 here. Bitbucket issues are out of scope, Atlassian points issue tracking at
-Jira and Goodboy follows that. Goodboy does not read a `bitbucket.org` git
-remote either, the workspace integration is how it finds your pull requests.
+Jira and Goodboy follows that. A `bitbucket.org` git remote does not turn the
+integration on by itself either: the workspace integration is what enables
+Bitbucket, and the remote is read only to work out which repository the pull
+requests belong to.
 
 **Slack, read the thread and reply.** Connect a workspace with a bot token
 (`xoxb-`), checked against the workspace before anything is stored and kept in

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -33,6 +33,7 @@ import { NewSessionView } from './features/session/components/NewSessionView';
 import { GitHubStudio } from './features/github/components/GitHubStudio';
 import { LinearStudio } from './features/integrations/linear/LinearStudio';
 import { SentryStudio } from './features/integrations/sentry/SentryStudio';
+import { BitbucketWorkspaceStudio } from './features/integrations/bitbucket/BitbucketWorkspaceStudio';
 import { GitlabStudio } from './features/integrations/gitlab/GitlabStudio';
 import { JiraStudio } from './features/integrations/jira/JiraStudio';
 import { SlackStudio } from './features/integrations/slack/SlackStudio';
@@ -109,6 +110,11 @@ export const App = () => {
       (i) => i.provider === 'gitlab',
     ),
   );
+  const hasBitbucket = useAppStore((s) =>
+    (s.workspaceIntegrations?.[currentWorkspace?.id ?? ('' as WorkspaceId)] ?? []).some(
+      (i) => i.provider === 'bitbucket',
+    ),
+  );
   const hasSlack = useAppStore((s) =>
     (s.workspaceIntegrations?.[currentWorkspace?.id ?? ('' as WorkspaceId)] ?? []).some(
       (i) => i.provider === 'slack',
@@ -137,6 +143,7 @@ export const App = () => {
   const [gitlabStudioFocus, setGitlabStudioFocus] = useState<string | null>(null);
   const [jiraStudioOpen, setJiraStudioOpen] = useState(false);
   const [jiraStudioFocus, setJiraStudioFocus] = useState<string | null>(null);
+  const [bitbucketStudioOpen, setBitbucketStudioOpen] = useState(false);
   const [slackStudioOpen, setSlackStudioOpen] = useState(false);
   const [slackStudioFocus, setSlackStudioFocus] = useState<string | null>(null);
   const [providerStudioOpen, setProviderStudioOpen] = useState(false);
@@ -177,6 +184,7 @@ export const App = () => {
     setSentryStudioOpen(false);
     setGitlabStudioOpen(false);
     setJiraStudioOpen(false);
+    setBitbucketStudioOpen(false);
     setSlackStudioOpen(false);
     setAppSettingsOpen(false);
     setGuideStudioOpen(false);
@@ -496,13 +504,15 @@ export const App = () => {
                       ? 'gitlab'
                       : jiraStudioOpen
                         ? 'jira'
-                        : slackStudioOpen
-                          ? 'slack'
-                          : appSettingsOpen
-                            ? 'settings'
-                            : guideStudioOpen
-                              ? 'guide'
-                              : null;
+                        : bitbucketStudioOpen
+                          ? 'bitbucket'
+                          : slackStudioOpen
+                            ? 'slack'
+                            : appSettingsOpen
+                              ? 'settings'
+                              : guideStudioOpen
+                                ? 'guide'
+                                : null;
 
   const openSettings = useCallback(() => {
     closeAllStudios();
@@ -774,6 +784,7 @@ export const App = () => {
                 jiraEnabled={hasJira}
                 sentryEnabled={hasSentry}
                 gitlabEnabled={hasGitlab}
+                bitbucketEnabled={hasBitbucket}
                 slackEnabled={hasSlack}
                 onOpenWorkflows={() => {
                   closeAllStudios();
@@ -813,6 +824,10 @@ export const App = () => {
                   closeAllStudios();
                   setGitlabStudioFocus(null);
                   setGitlabStudioOpen(true);
+                }}
+                onOpenBitbucket={() => {
+                  closeAllStudios();
+                  setBitbucketStudioOpen(true);
                 }}
                 onOpenSlack={() => {
                   closeAllStudios();
@@ -1017,6 +1032,13 @@ export const App = () => {
           workspaceName={currentWorkspace.name}
           initialIssueId={jiraStudioFocus}
           onClose={() => setJiraStudioOpen(false)}
+        />
+      ) : null}
+      {bitbucketStudioOpen && currentWorkspace ? (
+        <BitbucketWorkspaceStudio
+          workspaceId={currentWorkspace.id}
+          workspaceName={currentWorkspace.name}
+          onClose={() => setBitbucketStudioOpen(false)}
         />
       ) : null}
       {slackStudioOpen && currentWorkspace ? (

--- a/apps/desktop/src/__tests__/footer-studio-reachability.test.tsx
+++ b/apps/desktop/src/__tests__/footer-studio-reachability.test.tsx
@@ -53,19 +53,32 @@ vi.mock('@goodboy/ui', async (importOriginal) => {
 type FooterProps = {
   readonly onOpenSlack: () => void;
   readonly slackEnabled: boolean;
+  readonly onOpenBitbucket: () => void;
+  readonly bitbucketEnabled: boolean;
 };
 
 vi.mock('../app/components/AppFooter', () => ({
-  AppFooter: ({ onOpenSlack, slackEnabled }: FooterProps) => (
-    <button type="button" onClick={onOpenSlack}>
-      {slackEnabled ? 'Launch a session from a Slack thread' : 'Connect Slack'}
-    </button>
+  AppFooter: ({ onOpenSlack, slackEnabled, onOpenBitbucket, bitbucketEnabled }: FooterProps) => (
+    <>
+      <button type="button" onClick={onOpenSlack}>
+        {slackEnabled ? 'Launch a session from a Slack thread' : 'Connect Slack'}
+      </button>
+      <button type="button" onClick={onOpenBitbucket}>
+        {bitbucketEnabled ? 'Review pull requests across this workspace' : 'Connect Bitbucket'}
+      </button>
+    </>
   ),
 }));
 
 vi.mock('../features/integrations/slack/SlackStudio', () => ({
   SlackStudio: ({ workspaceName }: { workspaceName: string }) => (
     <div data-testid="slack-studio">{workspaceName}</div>
+  ),
+}));
+
+vi.mock('../features/integrations/bitbucket/BitbucketWorkspaceStudio', () => ({
+  BitbucketWorkspaceStudio: ({ workspaceName }: { workspaceName: string }) => (
+    <div data-testid="bitbucket-studio">{workspaceName}</div>
   ),
 }));
 
@@ -187,5 +200,27 @@ describe('Slack studio reachability', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Connect Slack' }));
 
     expect(screen.getByTestId('slack-studio')).toBeDefined();
+  });
+});
+
+describe('Bitbucket studio reachability', () => {
+  it('opens the workspace bitbucket studio from the app footer', () => {
+    state.workspaceIntegrations = { 'workspace-1': [{ provider: 'bitbucket' }] };
+    render(<App />);
+
+    expect(screen.queryByTestId('bitbucket-studio')).toBeNull();
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Review pull requests across this workspace' }),
+    );
+
+    expect(screen.getByTestId('bitbucket-studio').textContent).toBe('Workspace');
+  });
+
+  it('still opens the studio when bitbucket is not connected, so the connect form is reachable', () => {
+    render(<App />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Connect Bitbucket' }));
+
+    expect(screen.getByTestId('bitbucket-studio')).toBeDefined();
   });
 });

--- a/apps/desktop/src/__tests__/keyboard/lens-shortcuts.test.tsx
+++ b/apps/desktop/src/__tests__/keyboard/lens-shortcuts.test.tsx
@@ -92,6 +92,9 @@ vi.mock('../../features/github/components/GitHubStudio', () => ({ GitHubStudio: 
 vi.mock('../../features/integrations/linear/LinearStudio', () => ({ LinearStudio: () => null }));
 vi.mock('../../features/integrations/sentry/SentryStudio', () => ({ SentryStudio: () => null }));
 vi.mock('../../features/integrations/gitlab/GitlabStudio', () => ({ GitlabStudio: () => null }));
+vi.mock('../../features/integrations/bitbucket/BitbucketWorkspaceStudio', () => ({
+  BitbucketWorkspaceStudio: () => null,
+}));
 vi.mock('../../features/providers/components/ProviderStudio', () => ({
   ProviderStudio: () => null,
 }));

--- a/apps/desktop/src/app/components/AppFooter/index.test.tsx
+++ b/apps/desktop/src/app/components/AppFooter/index.test.tsx
@@ -1,3 +1,4 @@
+import type { ComponentProps } from 'react';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -32,6 +33,38 @@ import { BetaPill } from '../../../shared/components/BetaPill';
 
 const BETA_CENTERING = 'pointer-events-none absolute inset-x-0 mx-auto w-fit';
 
+type FooterProps = ComponentProps<typeof AppFooter>;
+
+type Params = {
+  readonly overrides?: Partial<FooterProps>;
+};
+
+const footerProps = ({ overrides = {} }: Params = {}): FooterProps => ({
+  activeStudio: null,
+  onOpenWorkflows: vi.fn(),
+  onOpenProviders: vi.fn(),
+  onOpenBudget: vi.fn(),
+  onOpenImpact: vi.fn(),
+  onOpenChangelog: vi.fn(),
+  onOpenGithub: vi.fn(),
+  onOpenLinear: vi.fn(),
+  onOpenJira: vi.fn(),
+  onOpenSentry: vi.fn(),
+  onOpenGitlab: vi.fn(),
+  onOpenBitbucket: vi.fn(),
+  onOpenSlack: vi.fn(),
+  onConvertToDevProject: vi.fn(),
+  githubEnabled: false,
+  linearEnabled: false,
+  jiraEnabled: false,
+  sentryEnabled: false,
+  gitlabEnabled: false,
+  bitbucketEnabled: false,
+  slackEnabled: false,
+  isSimpleWorkspace: false,
+  ...overrides,
+});
+
 describe('AppFooter', () => {
   it('centers beta and opens each section', () => {
     const onOpenWorkflows = vi.fn();
@@ -41,26 +74,15 @@ describe('AppFooter', () => {
     const onOpenChangelog = vi.fn();
     render(
       <AppFooter
-        activeStudio={null}
-        onOpenWorkflows={onOpenWorkflows}
-        onOpenProviders={onOpenProviders}
-        onOpenBudget={onOpenBudget}
-        onOpenImpact={onOpenImpact}
-        onOpenChangelog={onOpenChangelog}
-        onOpenGithub={vi.fn()}
-        onOpenLinear={vi.fn()}
-        onOpenJira={vi.fn()}
-        onOpenSentry={vi.fn()}
-        onOpenGitlab={vi.fn()}
-        onOpenSlack={vi.fn()}
-        githubEnabled={false}
-        linearEnabled={false}
-        jiraEnabled={false}
-        sentryEnabled={false}
-        gitlabEnabled={false}
-        slackEnabled={false}
-        isSimpleWorkspace={false}
-        onConvertToDevProject={vi.fn()}
+        {...footerProps({
+          overrides: {
+            onOpenWorkflows,
+            onOpenProviders,
+            onOpenBudget,
+            onOpenImpact,
+            onOpenChangelog,
+          },
+        })}
       />,
     );
 
@@ -93,30 +115,7 @@ describe('AppFooter', () => {
   });
 
   it('keeps studio buttons muted at rest and gives the active one a subtle surface', () => {
-    render(
-      <AppFooter
-        activeStudio="impact"
-        onOpenWorkflows={vi.fn()}
-        onOpenProviders={vi.fn()}
-        onOpenBudget={vi.fn()}
-        onOpenImpact={vi.fn()}
-        onOpenChangelog={vi.fn()}
-        onOpenGithub={vi.fn()}
-        onOpenLinear={vi.fn()}
-        onOpenJira={vi.fn()}
-        onOpenSentry={vi.fn()}
-        onOpenGitlab={vi.fn()}
-        onOpenSlack={vi.fn()}
-        githubEnabled={false}
-        linearEnabled={false}
-        jiraEnabled={false}
-        sentryEnabled={false}
-        gitlabEnabled={false}
-        slackEnabled={false}
-        isSimpleWorkspace={false}
-        onConvertToDevProject={vi.fn()}
-      />,
-    );
+    render(<AppFooter {...footerProps({ overrides: { activeStudio: 'impact' } })} />);
 
     const budget = screen.getByRole('button', { name: 'Open budget studio' });
     const impact = screen.getByRole('button', {
@@ -132,34 +131,12 @@ describe('AppFooter', () => {
   it('renders every disconnected integration and opens its studio', () => {
     const onOpenGitlab = vi.fn();
 
-    render(
-      <AppFooter
-        activeStudio={null}
-        onOpenWorkflows={vi.fn()}
-        onOpenProviders={vi.fn()}
-        onOpenBudget={vi.fn()}
-        onOpenImpact={vi.fn()}
-        onOpenChangelog={vi.fn()}
-        onOpenGithub={vi.fn()}
-        onOpenLinear={vi.fn()}
-        onOpenJira={vi.fn()}
-        onOpenSentry={vi.fn()}
-        onOpenGitlab={onOpenGitlab}
-        onOpenSlack={vi.fn()}
-        githubEnabled={false}
-        linearEnabled={false}
-        jiraEnabled={false}
-        sentryEnabled={false}
-        gitlabEnabled={false}
-        slackEnabled={false}
-        isSimpleWorkspace={false}
-        onConvertToDevProject={vi.fn()}
-      />,
-    );
+    render(<AppFooter {...footerProps({ overrides: { onOpenGitlab } })} />);
 
     expect(integrationGlyph.mock.calls.map(([provider]) => provider)).toEqual([
       'github',
       'gitlab',
+      'bitbucket',
       'linear',
       'jira',
       'slack',
@@ -167,6 +144,7 @@ describe('AppFooter', () => {
     ]);
     expect(screen.getByRole('button', { name: 'Connect GitHub' })).toBeDefined();
     expect(screen.getByRole('button', { name: 'Connect GitLab' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Connect Bitbucket' })).toBeDefined();
     expect(screen.getByRole('button', { name: 'Connect Linear' })).toBeDefined();
     expect(screen.getByRole('button', { name: 'Connect Jira' })).toBeDefined();
     expect(screen.getByRole('button', { name: 'Connect Sentry' })).toBeDefined();
@@ -182,31 +160,13 @@ describe('AppFooter', () => {
 
     render(
       <AppFooter
-        activeStudio={null}
-        onOpenWorkflows={vi.fn()}
-        onOpenProviders={vi.fn()}
-        onOpenBudget={vi.fn()}
-        onOpenImpact={vi.fn()}
-        onOpenChangelog={vi.fn()}
-        onOpenGithub={vi.fn()}
-        onOpenLinear={vi.fn()}
-        onOpenJira={vi.fn()}
-        onOpenSentry={vi.fn()}
-        onOpenGitlab={vi.fn()}
-        onOpenSlack={vi.fn()}
-        githubEnabled={false}
-        linearEnabled={false}
-        jiraEnabled={false}
-        sentryEnabled={false}
-        gitlabEnabled={false}
-        slackEnabled={false}
-        isSimpleWorkspace
-        onConvertToDevProject={onConvertToDevProject}
+        {...footerProps({ overrides: { isSimpleWorkspace: true, onConvertToDevProject } })}
       />,
     );
 
     expect(screen.queryByRole('button', { name: 'Connect GitHub' })).toBeNull();
     expect(screen.queryByRole('button', { name: 'Connect GitLab' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Connect Bitbucket' })).toBeNull();
     expect(screen.queryByRole('button', { name: 'Connect Sentry' })).toBeNull();
     expect(screen.getByRole('button', { name: 'Connect Linear' })).toBeDefined();
     expect(screen.getByRole('button', { name: 'Connect Jira' })).toBeDefined();
@@ -225,30 +185,7 @@ describe('AppFooter', () => {
 
   it('opens the GitLab studio when GitLab is connected', () => {
     const onOpenGitlab = vi.fn();
-    render(
-      <AppFooter
-        activeStudio={null}
-        onOpenWorkflows={vi.fn()}
-        onOpenProviders={vi.fn()}
-        onOpenBudget={vi.fn()}
-        onOpenImpact={vi.fn()}
-        onOpenChangelog={vi.fn()}
-        onOpenGithub={vi.fn()}
-        onOpenLinear={vi.fn()}
-        onOpenJira={vi.fn()}
-        onOpenSentry={vi.fn()}
-        onOpenGitlab={onOpenGitlab}
-        onOpenSlack={vi.fn()}
-        githubEnabled={false}
-        linearEnabled={false}
-        jiraEnabled={false}
-        sentryEnabled={false}
-        gitlabEnabled
-        slackEnabled={false}
-        isSimpleWorkspace={false}
-        onConvertToDevProject={vi.fn()}
-      />,
-    );
+    render(<AppFooter {...footerProps({ overrides: { gitlabEnabled: true, onOpenGitlab } })} />);
 
     fireEvent.click(
       screen.getByRole('button', {
@@ -259,60 +196,30 @@ describe('AppFooter', () => {
     expect(onOpenGitlab).toHaveBeenCalledOnce();
   });
 
+  it('offers the Bitbucket studio and says so when Bitbucket is not connected yet', () => {
+    const onOpenBitbucket = vi.fn();
+    const { rerender } = render(<AppFooter {...footerProps({ overrides: { onOpenBitbucket } })} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Connect Bitbucket' }));
+    expect(onOpenBitbucket).toHaveBeenCalledOnce();
+
+    rerender(
+      <AppFooter {...footerProps({ overrides: { bitbucketEnabled: true, onOpenBitbucket } })} />,
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Review pull requests across this workspace' }),
+    ).toBeDefined();
+  });
+
   it('offers the Slack studio and says so when Slack is not connected yet', () => {
     const onOpenSlack = vi.fn();
-    const { rerender } = render(
-      <AppFooter
-        activeStudio={null}
-        onOpenWorkflows={vi.fn()}
-        onOpenProviders={vi.fn()}
-        onOpenBudget={vi.fn()}
-        onOpenImpact={vi.fn()}
-        onOpenChangelog={vi.fn()}
-        onOpenGithub={vi.fn()}
-        onOpenLinear={vi.fn()}
-        onOpenJira={vi.fn()}
-        onOpenSentry={vi.fn()}
-        onOpenGitlab={vi.fn()}
-        onOpenSlack={onOpenSlack}
-        githubEnabled={false}
-        linearEnabled={false}
-        jiraEnabled={false}
-        sentryEnabled={false}
-        gitlabEnabled={false}
-        slackEnabled={false}
-        isSimpleWorkspace={false}
-        onConvertToDevProject={vi.fn()}
-      />,
-    );
+    const { rerender } = render(<AppFooter {...footerProps({ overrides: { onOpenSlack } })} />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Connect Slack' }));
     expect(onOpenSlack).toHaveBeenCalledOnce();
 
-    rerender(
-      <AppFooter
-        activeStudio={null}
-        onOpenWorkflows={vi.fn()}
-        onOpenProviders={vi.fn()}
-        onOpenBudget={vi.fn()}
-        onOpenImpact={vi.fn()}
-        onOpenChangelog={vi.fn()}
-        onOpenGithub={vi.fn()}
-        onOpenLinear={vi.fn()}
-        onOpenJira={vi.fn()}
-        onOpenSentry={vi.fn()}
-        onOpenGitlab={vi.fn()}
-        onOpenSlack={onOpenSlack}
-        githubEnabled={false}
-        linearEnabled={false}
-        jiraEnabled={false}
-        sentryEnabled={false}
-        gitlabEnabled={false}
-        slackEnabled
-        isSimpleWorkspace={false}
-        onConvertToDevProject={vi.fn()}
-      />,
-    );
+    rerender(<AppFooter {...footerProps({ overrides: { slackEnabled: true, onOpenSlack } })} />);
 
     expect(
       screen.getByRole('button', { name: 'Launch a session from a Slack thread' }),

--- a/apps/desktop/src/app/components/AppFooter/index.tsx
+++ b/apps/desktop/src/app/components/AppFooter/index.tsx
@@ -62,6 +62,7 @@ type Props = {
   onOpenJira: () => void;
   onOpenSentry: () => void;
   onOpenGitlab: () => void;
+  onOpenBitbucket: () => void;
   onOpenSlack: () => void;
   onConvertToDevProject: () => void;
   githubEnabled: boolean;
@@ -69,6 +70,7 @@ type Props = {
   jiraEnabled: boolean;
   sentryEnabled: boolean;
   gitlabEnabled: boolean;
+  bitbucketEnabled: boolean;
   slackEnabled: boolean;
   isSimpleWorkspace: boolean;
 };
@@ -85,6 +87,7 @@ export const AppFooter = ({
   onOpenJira,
   onOpenSentry,
   onOpenGitlab,
+  onOpenBitbucket,
   onOpenSlack,
   onConvertToDevProject,
   githubEnabled,
@@ -92,6 +95,7 @@ export const AppFooter = ({
   jiraEnabled,
   sentryEnabled,
   gitlabEnabled,
+  bitbucketEnabled,
   slackEnabled,
   isSimpleWorkspace,
 }: Props) => {
@@ -136,6 +140,18 @@ export const AppFooter = ({
                 onClick={onOpenGitlab}
                 active={activeStudio === 'gitlab'}
                 connected={gitlabEnabled}
+              />
+              <FooterButton
+                icon={<IntegrationGlyph provider="bitbucket" size="xs" useBrandColor />}
+                label="Bitbucket"
+                title={
+                  bitbucketEnabled
+                    ? 'Review pull requests across this workspace'
+                    : 'Connect Bitbucket'
+                }
+                onClick={onOpenBitbucket}
+                active={activeStudio === 'bitbucket'}
+                connected={bitbucketEnabled}
               />
             </>
           )}

--- a/apps/desktop/src/features/integrations/bitbucket/BitbucketWorkspaceStudio/index.test.tsx
+++ b/apps/desktop/src/features/integrations/bitbucket/BitbucketWorkspaceStudio/index.test.tsx
@@ -1,0 +1,160 @@
+// @vitest-environment happy-dom
+
+import type { ReactNode } from 'react';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SessionId, WorkspaceId } from '@goodboy/types';
+import type { BitbucketPullRequest, BitbucketRepo } from '../client';
+import type { BitbucketPrGroup } from '../BitbucketStudio/useBitbucketPrs';
+
+const h = vi.hoisted(() => ({
+  integrations: {} as Record<string, ReadonlyArray<{ provider: string }>>,
+  repo: null as BitbucketRepo | null,
+  groups: [] as ReadonlyArray<BitbucketPrGroup>,
+  repoHookEnabled: null as boolean | null,
+  detailSessionId: undefined as SessionId | null | undefined,
+}));
+
+vi.mock('../../../../store', () => ({
+  EMPTY_ARRAY: Object.freeze([]),
+  useAppStore: <T,>(selector: (state: { workspaceIntegrations: typeof h.integrations }) => T) =>
+    selector({ workspaceIntegrations: h.integrations }),
+}));
+
+vi.mock('../../../../shared/components/StudioShell', () => ({
+  StudioShell: ({ children }: { children: (requestClose: () => void) => ReactNode }) => (
+    <div>{children(vi.fn())}</div>
+  ),
+}));
+
+vi.mock('../useWorkspaceBitbucketRepo', () => ({
+  useWorkspaceBitbucketRepo: (params: { isEnabled: boolean }) => {
+    h.repoHookEnabled = params.isEnabled;
+    return h.repo;
+  },
+}));
+
+vi.mock('../BitbucketStudio/useBitbucketPrs', () => ({
+  useBitbucketPrs: () => ({
+    groups: h.groups,
+    loading: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+}));
+
+vi.mock('../BitbucketStudio/PrDetailPanel', () => ({
+  PrDetailPanel: ({
+    pullRequest,
+    sessionId,
+  }: {
+    pullRequest: BitbucketPullRequest | null;
+    sessionId: SessionId | null;
+  }) => {
+    h.detailSessionId = sessionId;
+    return <div data-testid="detail">{pullRequest?.title ?? 'none'}</div>;
+  },
+}));
+
+vi.mock('../BitbucketFormBody', () => ({
+  BitbucketFormBody: () => (
+    <label htmlFor="bitbucket-token-test">
+      App password
+      <input id="bitbucket-token-test" />
+    </label>
+  ),
+}));
+
+import { BitbucketWorkspaceStudio } from '.';
+
+type PullRequestParams = {
+  readonly id: number;
+  readonly title: string;
+};
+
+const pullRequest = ({ id, title }: PullRequestParams): BitbucketPullRequest => ({
+  id,
+  title,
+  description: '',
+  state: 'OPEN',
+  createdOn: '2026-08-05T09:00:00Z',
+  updatedOn: '2026-08-05T09:00:00Z',
+  sourceBranch: 'feat/x',
+  sourceCommit: null,
+  destinationBranch: 'main',
+  destinationCommit: null,
+  author: null,
+  reviewers: [],
+  participants: [],
+  closeSourceBranch: false,
+  mergeCommit: null,
+  commentCount: 0,
+  taskCount: 0,
+  webUrl: null,
+});
+
+beforeEach(() => {
+  h.integrations = {};
+  h.repo = null;
+  h.groups = [];
+  h.repoHookEnabled = null;
+  h.detailSessionId = undefined;
+});
+afterEach(cleanup);
+
+describe('BitbucketWorkspaceStudio', () => {
+  it('asks for the connection before resolving a repository', () => {
+    render(
+      <BitbucketWorkspaceStudio
+        workspaceId={'workspace-1' as WorkspaceId}
+        workspaceName="Goodboy"
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByText('Connect Bitbucket to review pull requests from this workspace'),
+    ).toBeDefined();
+    expect(screen.getByLabelText('App password')).toBeDefined();
+    expect(h.repoHookEnabled).toBe(false);
+  });
+
+  it('says the workspace has no Bitbucket remote when the repo does not resolve', () => {
+    h.integrations = { 'workspace-1': [{ provider: 'bitbucket' }] };
+
+    render(
+      <BitbucketWorkspaceStudio
+        workspaceId={'workspace-1' as WorkspaceId}
+        workspaceName="Goodboy"
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(h.repoHookEnabled).toBe(true);
+    expect(screen.getByText('No Bitbucket repository here')).toBeDefined();
+  });
+
+  it('lists pull requests read-only, with no session behind the detail panel', () => {
+    h.integrations = { 'workspace-1': [{ provider: 'bitbucket' }] };
+    h.repo = {
+      workspaceId: 'workspace-1' as WorkspaceId,
+      workspaceSlug: 'acme',
+      repoSlug: 'goodboy',
+      email: 'dev@acme.test',
+    };
+    h.groups = [
+      { key: 'Open', label: 'Open', rows: [pullRequest({ id: 7, title: 'fix billing webhook' })] },
+    ];
+
+    render(
+      <BitbucketWorkspaceStudio
+        workspaceId={'workspace-1' as WorkspaceId}
+        workspaceName="Goodboy"
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('detail').textContent).toBe('fix billing webhook');
+    expect(h.detailSessionId).toBeNull();
+  });
+});

--- a/apps/desktop/src/features/integrations/bitbucket/BitbucketWorkspaceStudio/index.tsx
+++ b/apps/desktop/src/features/integrations/bitbucket/BitbucketWorkspaceStudio/index.tsx
@@ -1,0 +1,110 @@
+import { useEffect, useState } from 'react';
+import { EmptyState } from '@goodboy/ui';
+import type { WorkspaceId } from '@goodboy/types';
+import { StudioRailLayout } from '../../../../shared/components/StudioRailLayout';
+import { StudioShell } from '../../../../shared/components/StudioShell';
+import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../shared/components/conceptIcons';
+import { IntegrationGlyph } from '../../components/IntegrationGlyph';
+import { ConnectIntegrationEmptyState } from '../../ConnectIntegrationEmptyState';
+import { EMPTY_ARRAY, useAppStore } from '../../../../store';
+import { resolveIntegrationConnection } from '../../connection';
+import type { BitbucketPullRequest } from '../client';
+import { useWorkspaceBitbucketRepo } from '../useWorkspaceBitbucketRepo';
+import { PrDetailPanel } from '../BitbucketStudio/PrDetailPanel';
+import { PrInbox } from '../BitbucketStudio/PrInbox';
+import { useBitbucketPrs } from '../BitbucketStudio/useBitbucketPrs';
+
+type Props = {
+  readonly workspaceId: WorkspaceId;
+  readonly workspaceName: string;
+  readonly onClose: () => void;
+};
+
+export const BitbucketWorkspaceStudio = ({ workspaceId, workspaceName, onClose }: Props) => {
+  const integrations = useAppStore(
+    (state) => state.workspaceIntegrations[workspaceId] ?? EMPTY_ARRAY,
+  );
+  const isConnected = resolveIntegrationConnection({
+    provider: 'bitbucket',
+    integrations,
+    remoteKind: null,
+    externalTasks: EMPTY_ARRAY,
+    isGithubAuthenticated: false,
+  }).isConnected;
+  const repo = useWorkspaceBitbucketRepo({ workspaceId, isEnabled: isConnected });
+  const [focused, setFocused] = useState<BitbucketPullRequest | null>(null);
+  const pullRequests = useBitbucketPrs({ repo });
+
+  useEffect(() => {
+    if (focused != null) {
+      return;
+    }
+    const first = pullRequests.groups[0]?.rows[0] ?? null;
+    if (first == null) {
+      return;
+    }
+    setFocused(first);
+  }, [focused, pullRequests.groups]);
+
+  return (
+    <StudioShell
+      glyph={<IntegrationGlyph provider="bitbucket" size={20} />}
+      title="Bitbucket"
+      workspaceName={workspaceName}
+      closeLabel="close bitbucket studio"
+      onClose={onClose}
+    >
+      {(requestClose) =>
+        !isConnected ? (
+          <div className="flex min-h-0 flex-1 items-center justify-center p-5">
+            <ConnectIntegrationEmptyState
+              provider="bitbucket"
+              workspaceId={workspaceId}
+              shouldAutoFocus
+              wrapped={false}
+            />
+          </div>
+        ) : repo == null ? (
+          <div className="flex min-h-0 flex-1 items-center justify-center p-5">
+            <EmptyState
+              bordered
+              icon={CONCEPT_ICONS.bitbucket}
+              tone={CONCEPT_TONE.bitbucket}
+              title="No Bitbucket repository here"
+              description="Goodboy reads pull requests from the workspace git remote, and this workspace has no single Bitbucket remote. Open a session on the repository you want to review."
+              size="lg"
+              headingLevel={2}
+            />
+          </div>
+        ) : (
+          <StudioRailLayout
+            railLabel="Bitbucket pull requests"
+            railWidth="standard"
+            rail={
+              <PrInbox
+                groups={pullRequests.groups}
+                focusedPrId={focused?.id ?? null}
+                onSelect={setFocused}
+                loading={pullRequests.loading}
+                error={pullRequests.error}
+                onRefresh={pullRequests.refetch}
+              />
+            }
+            detail={
+              <PrDetailPanel
+                pullRequest={focused}
+                repo={repo}
+                sessionId={null}
+                workspaceId={workspaceId}
+                isLoading={pullRequests.loading}
+                error={pullRequests.error}
+                onRefresh={pullRequests.refetch}
+                onClose={requestClose}
+              />
+            }
+          />
+        )
+      }
+    </StudioShell>
+  );
+};

--- a/apps/desktop/src/features/integrations/bitbucket/useWorkspaceBitbucketRepo/index.test.ts
+++ b/apps/desktop/src/features/integrations/bitbucket/useWorkspaceBitbucketRepo/index.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment happy-dom
+
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { WorkspaceId } from '@goodboy/types';
+
+const h = vi.hoisted(() => ({
+  workspaces: [] as ReadonlyArray<{ id: string; rootPath: string; kind?: string }>,
+  integrations: {} as Record<string, ReadonlyArray<{ provider: string; config?: unknown }>>,
+  remoteUrl: null as string | null,
+}));
+
+vi.mock('../../../../store', () => ({
+  EMPTY_ARRAY: Object.freeze([]),
+  useAppStore: <T>(
+    selector: (state: {
+      workspaces: typeof h.workspaces;
+      workspaceIntegrations: typeof h.integrations;
+    }) => T,
+  ) => selector({ workspaces: h.workspaces, workspaceIntegrations: h.integrations }),
+}));
+
+vi.mock('../../../worktree/worktree', () => ({
+  worktreeRemoteUrl: () => Promise.resolve(h.remoteUrl),
+}));
+
+import { useWorkspaceBitbucketRepo } from '.';
+
+const bitbucketIntegration = {
+  provider: 'bitbucket',
+  config: { workspaceSlug: 'acme', email: 'dev@acme.test' },
+};
+
+const settle = async () => {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+};
+
+beforeEach(() => {
+  h.workspaces = [];
+  h.integrations = {};
+  h.remoteUrl = null;
+});
+
+describe('useWorkspaceBitbucketRepo', () => {
+  it('resolves the repo slug from the workspace remote', async () => {
+    h.workspaces = [{ id: 'workspace-1', rootPath: '/repos/goodboy', kind: 'repo' }];
+    h.integrations = { 'workspace-1': [bitbucketIntegration] };
+    h.remoteUrl = 'git@bitbucket.org:acme/goodboy.git';
+
+    const { result } = renderHook(() =>
+      useWorkspaceBitbucketRepo({ workspaceId: 'workspace-1' as WorkspaceId, isEnabled: true }),
+    );
+
+    await waitFor(() => {
+      expect(result.current).toEqual({
+        workspaceId: 'workspace-1',
+        workspaceSlug: 'acme',
+        repoSlug: 'goodboy',
+        email: 'dev@acme.test',
+      });
+    });
+  });
+
+  it('resolves nothing for a composite workspace, which has no single repository', async () => {
+    h.workspaces = [{ id: 'workspace-2', rootPath: '/repos/container', kind: 'composite' }];
+    h.integrations = { 'workspace-2': [bitbucketIntegration] };
+    h.remoteUrl = 'git@bitbucket.org:acme/container.git';
+
+    const { result } = renderHook(() =>
+      useWorkspaceBitbucketRepo({ workspaceId: 'workspace-2' as WorkspaceId, isEnabled: true }),
+    );
+    await settle();
+
+    expect(result.current).toBeNull();
+  });
+
+  it('resolves nothing while the integration is missing', async () => {
+    h.workspaces = [{ id: 'workspace-3', rootPath: '/repos/other', kind: 'repo' }];
+    h.remoteUrl = 'git@bitbucket.org:acme/other.git';
+
+    const { result } = renderHook(() =>
+      useWorkspaceBitbucketRepo({ workspaceId: 'workspace-3' as WorkspaceId, isEnabled: false }),
+    );
+    await settle();
+
+    expect(result.current).toBeNull();
+  });
+});

--- a/apps/desktop/src/features/integrations/bitbucket/useWorkspaceBitbucketRepo/index.ts
+++ b/apps/desktop/src/features/integrations/bitbucket/useWorkspaceBitbucketRepo/index.ts
@@ -1,0 +1,77 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { BitbucketWorkspaceIntegration, WorkspaceId } from '@goodboy/types';
+import { EMPTY_ARRAY, useAppStore } from '../../../../store';
+import { worktreeRemoteUrl } from '../../../worktree/worktree';
+import { projectPathFromRemoteUrl } from '../../../../shared/lib/remoteHost';
+import { bitbucketRepoSlug } from '../../../../store/slices/bitbucket-pr/bitbucketRepoSlug';
+import type { BitbucketRepo } from '../client';
+
+const slugCache = new Map<string, string | null>();
+
+type Params = {
+  readonly workspaceId: WorkspaceId;
+  readonly isEnabled: boolean;
+};
+
+export const useWorkspaceBitbucketRepo = ({
+  workspaceId,
+  isEnabled,
+}: Params): BitbucketRepo | null => {
+  const rootPath = useAppStore((state) => {
+    const workspace = state.workspaces.find((candidate) => candidate.id === workspaceId) ?? null;
+    if (workspace == null || (workspace.kind ?? 'repo') !== 'repo') {
+      return null;
+    }
+    return workspace.rootPath;
+  });
+  const config = useAppStore((state) => {
+    const integration = (state.workspaceIntegrations[workspaceId] ?? EMPTY_ARRAY).find(
+      (candidate): candidate is BitbucketWorkspaceIntegration => candidate.provider === 'bitbucket',
+    );
+    return integration?.config ?? null;
+  });
+  const [repoSlug, setRepoSlug] = useState<string | null>(() =>
+    rootPath == null ? null : (slugCache.get(rootPath) ?? null),
+  );
+
+  useEffect(() => {
+    if (rootPath == null || !isEnabled) {
+      setRepoSlug(null);
+      return;
+    }
+    const cached = slugCache.get(rootPath);
+    if (cached !== undefined) {
+      setRepoSlug(cached);
+      return;
+    }
+    let isDisposed = false;
+    void worktreeRemoteUrl(rootPath)
+      .then((remoteUrl) => {
+        const slug = bitbucketRepoSlug({ projectPath: projectPathFromRemoteUrl(remoteUrl) });
+        slugCache.set(rootPath, slug);
+        if (!isDisposed) {
+          setRepoSlug(slug);
+        }
+      })
+      .catch(() => {
+        if (!isDisposed) {
+          setRepoSlug(null);
+        }
+      });
+    return () => {
+      isDisposed = true;
+    };
+  }, [isEnabled, rootPath]);
+
+  return useMemo(() => {
+    if (repoSlug == null || config == null) {
+      return null;
+    }
+    return {
+      workspaceId,
+      workspaceSlug: config.workspaceSlug,
+      repoSlug,
+      email: config.email,
+    };
+  }, [config, repoSlug, workspaceId]);
+};

--- a/apps/desktop/src/features/integrations/connection.test.ts
+++ b/apps/desktop/src/features/integrations/connection.test.ts
@@ -81,6 +81,28 @@ describe('resolveIntegrationConnection', () => {
     });
   });
 
+  it('connects bitbucket from the workspace integration alone, whatever the remote is', () => {
+    const connected = resolveIntegrationConnection({
+      provider: 'bitbucket',
+      integrations: [integration({ provider: 'bitbucket' })],
+      remoteKind: 'other',
+      externalTasks: [],
+      isGithubAuthenticated: false,
+    });
+    const missing = resolveIntegrationConnection({
+      provider: 'bitbucket',
+      integrations: [],
+      remoteKind: 'other',
+      externalTasks: [],
+      isGithubAuthenticated: false,
+    });
+
+    expect({ connected, missing }).toEqual({
+      connected: { isConnected: true, isAvailable: true },
+      missing: { isConnected: false, isAvailable: false },
+    });
+  });
+
   it('does not treat a GitHub remote as an authenticated connection', () => {
     const github = resolveIntegrationConnection({
       provider: 'github',

--- a/apps/desktop/src/features/integrations/issueSources.test.ts
+++ b/apps/desktop/src/features/integrations/issueSources.test.ts
@@ -16,6 +16,16 @@ describe('resolveIssueSources', () => {
     ).toEqual(['Linear', 'Slack']);
   });
 
+  it('never offers bitbucket, which tracks no issues of its own', () => {
+    expect(
+      resolveIssueSources({
+        integrations: [integration('bitbucket'), integration('jira')],
+        remoteKind: null,
+        isGithubAuthenticated: false,
+      }).map((source) => source.provider),
+    ).toEqual(['jira']);
+  });
+
   it('leaves slack out until the workspace connects it', () => {
     expect(
       resolveIssueSources({

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -132,8 +132,10 @@ slot. Always visible on the board and inside a session.
 
 Layout:
 
-- Left: integration tools (GitHub, GitLab, Linear, Jira, Slack, Sentry), each
-  gated by enablement.
+- Left: integration tools (GitHub, GitLab, Bitbucket, Linear, Jira, Slack,
+  Sentry), each gated by enablement. The three code hosts come first and are
+  swapped for the `Add a repo` conversion action in a simple workspace, which
+  has no repository for them to read.
 - Right: common studios (workflows, providers, budget, impact).
 
 Navigation chrome stays muted while inactive across footer launchers, session
@@ -174,13 +176,20 @@ persisted preference.
 ### Utility studios
 
 Settings, budget, providers, impact, changelog, notifications, Linear, Jira,
-Slack, Sentry, GitLab, workflow, guide are modal overlays, all built on `StudioShell`'s
-fullscreen variant. They are not part of the breadcrumb IA and are exited via
-their close button or Esc.
+Slack, Sentry, GitLab, Bitbucket, workflow, guide are modal overlays, all built on
+`StudioShell`'s fullscreen variant. They are not part of the breadcrumb IA and
+are exited via their close button or Esc.
 
-The Bitbucket studio is not one of them. It is a session studio, opened from the
-`pr` lens as `SessionStudio { kind: 'bitbucket' }`, so it needs the session's
-repository to know which pull requests to list. It has no footer entry.
+Bitbucket has two mounts. The footer opens `BitbucketWorkspaceStudio`, which
+resolves the repository from the workspace root path and its git remote and
+lists that repository's pull requests. That surface is browse and launch:
+reading a pull request and starting a session from it work, while the write
+verbs (approve, request changes, comment, merge, decline) stay disabled because
+they are keyed to a session. The `pr` lens opens the session variant as
+`SessionStudio { kind: 'bitbucket' }` in `StudioShell`'s slot variant, which
+knows the session's repository and carries the full action bar. A composite
+workspace has no single repository and no active mount outside a session, so
+the footer variant stops at an empty state and points back at a session.
 
 Most utility studios have a footer entry. The notifications studio does not:
 its only entrance is the `Show more` row at the bottom of the bell popover in


### PR DESCRIPTION
Closes #1251

## The bug

Bitbucket shipped complete in v0.1.64 (Rust commands, connect form, studio, store slice, m107) but `AppFooter` never got an entry for it. The footer is where a workspace connects an integration, so a user with no Bitbucket pull request already linked to a session had no way in. Every other integration (GitHub, GitLab, Linear, Jira, Slack, Sentry) had one.

## What changed

- `AppFooter` gains a Bitbucket button, placed with the other code hosts (after GitLab) rather than after Slack: the left cluster reads as three code hosts then four trackers, and Bitbucket belongs to the first group. It sits inside the existing `isSimpleWorkspace` branch, so a simple workspace still swaps all three code hosts for the `Add a repo` conversion action. A simple workspace has no repository, so a Bitbucket entry there would open on nothing.
- `App.tsx` gains `hasBitbucket` (computed from `workspaceIntegrations`, beside `hasSlack`), `bitbucketStudioOpen`, `onOpenBitbucket`, an `activeStudio` arm, an entry in `closeAllStudios`, and the studio mount gated on `currentWorkspace`. This follows the Slack and Jira chain exactly. `RemoteHostKind` and `classifyRemoteHost` are untouched: a `bitbucket.org` URL still classifies as `other`, and the footer entry is gated on the connected integration, not on the remote.
- New `BitbucketWorkspaceStudio`: when the integration is not connected it renders `ConnectIntegrationEmptyState provider="bitbucket"`, which is the actual fix for the issue. When it is connected it renders `PrInbox` (reused unchanged) plus `PrDetailPanel` with `sessionId={null}`.
- New `useWorkspaceBitbucketRepo` hook: resolves the `BitbucketRepo` at workspace scope from the workspace `rootPath` plus `worktreeRemoteUrl` -> `projectPathFromRemoteUrl` -> `bitbucketRepoSlug`, with the workspace half of the slug coming from `integration.config.workspaceSlug`. It mirrors `useRootRemoteHostKind`, cache keyed by root path included.

## The workspace surface is read-only, on purpose

The eight write verbs in `store/slices/bitbucket-pr/` stay session-scoped, and this PR does not re-key them. `usePrActions` already resolves `target = null` when `sessionId` is null, so approve, unapprove, request changes, withdraw changes, merge, decline, comment and reply are all disabled on the workspace surface. What works there is browsing a pull request and launching a session from it through `LaunchSessionPanel`, which already accepts a null linked session. Acting on a pull request happens from inside a session, same as before.

## Composite workspaces

A composite workspace has no single `rootPath` that is a repository, and outside a session there is no active-mount concept to pick one from. Silently picking the first member would show one repository's pull requests and hide the rest with no signal, so the resolver returns null for `kind: 'composite'` and the studio renders an empty state that says the workspace has no single Bitbucket remote and points back at a session. The connect step still works for a composite workspace, because the connection check runs before the repository check. That is what closes the issue.

## Explicitly not done

- Bitbucket is still absent from `issueSources.ts` `SOURCES`. Bitbucket has no issue tracking; Atlassian points issues at Jira and Goodboy follows.
- No change to `store/slices/bitbucket-pr/` keying.
- No change to `RemoteHostKind`, `classifyRemoteHost`, or `shared/lib/remoteHost.test.ts`.
- No regrouping of the footer and no change to its right-hand cluster.
- No change to the GitHub/GitLab mutual exclusion in the connect forms.

## Tests

Added:

- `BitbucketWorkspaceStudio/index.test.tsx`: the connect panel renders before any repository resolution, the empty state appears when the repository does not resolve, and the detail panel receives `sessionId` null when pull requests are listed. Sabotaging `sessionId={null}` to a real id turns the third one red.
- `useWorkspaceBitbucketRepo/index.test.ts`: a repo workspace resolves its slug from the remote, a composite workspace resolves to null, and a workspace with no integration resolves to null. Removing the composite guard turns the second one red.
- `connection.test.ts`: bitbucket connects from the workspace integration alone whatever the remote is, and is unavailable without it. The file had no bitbucket assertions despite `connection.ts` having a bitbucket case.
- `issueSources.test.ts`: bitbucket is never offered as an issue source. This pins the deliberate omission so nobody "fixes" it into a picker that lists nothing.

Changed:

- `AppFooter/index.test.tsx`: the glyph-order assertion pinned six providers and now pins seven, with bitbucket third. The simple-workspace block now also asserts the Bitbucket entry is hidden. The seven render sites each spelled out the full prop blob, which made a new prop a seven-place edit, so they now share one typed `footerProps` factory. Every previous assertion is kept, and a Bitbucket connect-then-connected case was added.
- `__tests__/keyboard/lens-shortcuts.test.tsx`: this test renders `App` with a one-export `@goodboy/ui` mock and stubs every studio App imports. The new studio pulls `PrActionBar` in through `PrDetailPanel`, which needs `tintClasses`, so the studio is now stubbed like `GitlabStudio` and the others. Without this the file fails to collect.

## Docs

- `docs/navigation.md`: the footer list gains Bitbucket, and the paragraph claiming the Bitbucket studio "is a session studio... It has no footer entry" is replaced with the two-mount description and the read-only limit.
- `DESIGN.md`: the footer sentence listed only GitHub/GitLab/Linear/Sentry. It now lists the real set and states that every shipped integration owns a footer entry, since that is the rule this issue was filed against.
- `README.md`: the Bitbucket paragraph mentions the footer entry and states the read-only limit. The sentence "Goodboy does not read a `bitbucket.org` git remote either" was imprecise even before this PR (the session path already reads the remote to derive the repo slug), so it now says the remote does not turn the integration on and is read only to work out which repository the pull requests belong to.

`docs/design.md` defers to `docs/navigation.md` for footer contents and needed no edit. The README integrations image alt text still lists four providers; it describes a checked-in screenshot that predates Bitbucket, so regenerating it is out of scope here.

## Not verified

No live Bitbucket Cloud workspace was available. The repository-slug resolution, the pull request list, and the disabled action bar on the workspace surface are verified only through unit tests with mocked responses, never against real `api.bitbucket.org` data. The composite-workspace empty state is verified through the hook test, not against a real multi-repo workspace on disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
