### PR TITLE
feat(desktop): reply to a linear issue without leaving goodboy

### DIFF
--- a/VISION.md
+++ b/VISION.md
@@ -145,9 +145,10 @@ Where each connected source stands, honestly:
 - **Jira.** Issues read in full and acted on: comment, assign, transition,
   edit description. Cloud only, one project key per workspace, no sprints or
   boards yet.
-- **Linear.** Issues read and routed; the only write today is the
-  description. Comments, assign and transition are the open gap, and Linear
-  is where the PM persona lives.
+- **Linear.** Issues read and routed, with two writes: the description and a
+  comment. Assign and transition are still the open gap, because the state
+  and team we read carry no id to send back. Linear is where the PM persona
+  lives.
 - **Sentry.** Issues and events read; no write path yet.
 - **Slack.** Threads read and replied to (replies post as the connected bot),
   routed into sessions with the goal pre-filled. Shipped ahead of the company

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -277,6 +277,7 @@ pub fn run() {
             linear::linear_fetch_assigned_issues,
             linear::linear_fetch_issue,
             linear::linear_fetch_issue_comments,
+            linear::linear_create_comment,
             linear::linear_update_issue,
             sentry::sentry_connect,
             sentry::sentry_disconnect,

--- a/apps/desktop/src-tauri/src/linear.rs
+++ b/apps/desktop/src-tauri/src/linear.rs
@@ -289,6 +289,29 @@ query IssueComments($issueId: String!) {
 }
 "#;
 
+const COMMENT_CREATE_MUTATION: &str = r#"
+mutation CommentCreate($input: CommentCreateInput!) {
+  commentCreate(input: $input) {
+    success
+    comment {
+      id
+      body
+      createdAt
+      user { name }
+    }
+  }
+}
+"#;
+
+fn comment_create_variables(issue_id: &str, body: &str) -> serde_json::Value {
+    serde_json::json!({
+        "input": {
+            "issueId": issue_id,
+            "body": body
+        }
+    })
+}
+
 const ISSUE_UPDATE_MUTATION: &str = r#"
 mutation IssueUpdate($issueId: String!, $input: IssueUpdateInput!) {
   issueUpdate(id: $issueId, input: $input) {
@@ -384,6 +407,31 @@ pub async fn linear_fetch_issue_comments(
 }
 
 #[tauri::command]
+pub async fn linear_create_comment(
+    workspace_id: String,
+    issue_id: String,
+    body: String,
+    cache: State<'_, LinearTokenCache>,
+) -> Result<LinearIssueComment, LinearError> {
+    let token = read_token(&workspace_id, &cache)?;
+    let resp: CommentCreateResponse = graphql(
+        &token,
+        COMMENT_CREATE_MUTATION,
+        Some(comment_create_variables(&issue_id, &body)),
+    )
+    .await?;
+    if !resp.comment_create.success {
+        return Err(LinearError::GraphQl(format!(
+            "commentCreate rejected for {}",
+            issue_id
+        )));
+    }
+    resp.comment_create
+        .comment
+        .ok_or_else(|| LinearError::InvalidShape("missing comment".into()))
+}
+
+#[tauri::command]
 pub async fn linear_update_issue(
     workspace_id: String,
     issue_id: String,
@@ -458,4 +506,38 @@ struct IssueUpdatePayload {
 struct IssueUpdateResponse {
     #[serde(rename = "issueUpdate")]
     issue_update: IssueUpdatePayload,
+}
+
+#[derive(Deserialize)]
+struct CommentCreatePayload {
+    success: bool,
+    comment: Option<LinearIssueComment>,
+}
+
+#[derive(Deserialize)]
+struct CommentCreateResponse {
+    #[serde(rename = "commentCreate")]
+    comment_create: CommentCreatePayload,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn comment_create_variables_nest_the_issue_and_the_body_under_input() {
+        let variables = comment_create_variables("issue-42", "ship it");
+
+        assert_eq!(variables["input"]["issueId"], "issue-42");
+        assert_eq!(variables["input"]["body"], "ship it");
+        assert!(variables.get("issueId").is_none());
+        assert!(variables.get("body").is_none());
+    }
+
+    #[test]
+    fn comment_create_mutation_asks_linear_for_the_created_comment_back() {
+        assert!(COMMENT_CREATE_MUTATION.contains("$input: CommentCreateInput!"));
+        assert!(COMMENT_CREATE_MUTATION.contains("commentCreate(input: $input)"));
+        assert!(COMMENT_CREATE_MUTATION.contains("createdAt"));
+    }
 }

--- a/apps/desktop/src/features/integrations/linear/LinearIssueComments/index.test.tsx
+++ b/apps/desktop/src/features/integrations/linear/LinearIssueComments/index.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, render, screen } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
 import type { LinearIssueComment } from '../client';
 import { LinearIssueComments } from './index';
 
@@ -20,18 +20,55 @@ afterEach(() => {
   cleanup();
 });
 
+const composer = () =>
+  screen.queryByRole('textbox', { name: 'Write a comment' }) as HTMLTextAreaElement | null;
+
 describe('LinearIssueComments', () => {
   it('renders no avatar for any comment', () => {
-    render(<LinearIssueComments comments={[COMMENT]} isLoading={false} error={null} />);
+    render(
+      <LinearIssueComments comments={[COMMENT]} isLoading={false} error={null} onPost={null} />,
+    );
 
     expect(screen.queryByRole('img')).toBeNull();
   });
 
   it('renders the author name and a relative timestamp for each comment', () => {
-    render(<LinearIssueComments comments={[COMMENT]} isLoading={false} error={null} />);
+    render(
+      <LinearIssueComments comments={[COMMENT]} isLoading={false} error={null} onPost={null} />,
+    );
 
     expect(screen.getByText('Ada Lovelace')).toBeDefined();
     expect(screen.getByText('3d ago')).toBeDefined();
     expect(screen.getByText('Shipped in v2.')).toBeDefined();
+  });
+
+  it('keeps the composer out of the way when posting is unavailable', () => {
+    render(
+      <LinearIssueComments comments={[COMMENT]} isLoading={false} error={null} onPost={null} />,
+    );
+
+    expect(composer()).toBeNull();
+  });
+
+  it('posts the typed comment and clears the composer', async () => {
+    const onPost = vi.fn(async () => {});
+    render(
+      <LinearIssueComments comments={[COMMENT]} isLoading={false} error={null} onPost={onPost} />,
+    );
+
+    fireEvent.change(composer() as HTMLTextAreaElement, { target: { value: '  Looks good  ' } });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Comment' }));
+    });
+
+    expect(onPost).toHaveBeenCalledWith('Looks good');
+    expect(composer()?.value).toBe('');
+  });
+
+  it('offers the composer on an issue that has no comments yet', () => {
+    render(<LinearIssueComments comments={[]} isLoading={false} error={null} onPost={vi.fn()} />);
+
+    expect(screen.getByText('No comments')).toBeDefined();
+    expect(composer()).not.toBeNull();
   });
 });

--- a/apps/desktop/src/features/integrations/linear/LinearIssueComments/index.tsx
+++ b/apps/desktop/src/features/integrations/linear/LinearIssueComments/index.tsx
@@ -3,6 +3,7 @@ import { formatRelativeDuration } from '../../../../shared/utils/relativeDate';
 import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../shared/components/conceptIcons';
 import { NoteCard } from '../../../../shared/components/NoteCard';
 import { NoteHeader } from '../../../../shared/components/NoteHeader';
+import { NoteComposer } from '../../../../shared/components/NoteComposer';
 import { NoteListSkeleton } from '../../../../shared/components/NoteListSkeleton';
 import type { LinearIssueComment } from '../client';
 
@@ -10,9 +11,10 @@ type Props = {
   readonly comments: ReadonlyArray<LinearIssueComment>;
   readonly isLoading: boolean;
   readonly error: string | null;
+  readonly onPost: ((body: string) => Promise<void>) | null;
 };
 
-export const LinearIssueComments = ({ comments, isLoading, error }: Props) => {
+export const LinearIssueComments = ({ comments, isLoading, error, onPost }: Props) => {
   if (isLoading) {
     return <NoteListSkeleton />;
   }
@@ -21,37 +23,40 @@ export const LinearIssueComments = ({ comments, isLoading, error }: Props) => {
     return <p className="text-sm text-danger">{error}</p>;
   }
 
-  if (comments.length === 0) {
-    return (
-      <EmptyState
-        icon={CONCEPT_ICONS.comments}
-        tone={CONCEPT_TONE.comments}
-        title="No comments"
-        description="This issue has no comments yet."
-        size="inline"
-        className="py-5"
-      />
-    );
-  }
-
   return (
-    <div className="flex flex-col gap-3">
-      {comments.map((comment) => {
-        const relativeDate = formatRelativeDuration(comment.createdAt);
-        return (
-          <NoteCard
-            key={comment.id}
-            header={
-              <NoteHeader
-                author={comment.user?.name ?? 'Unknown author'}
-                timestamp={relativeDate !== '' ? <span>{relativeDate} ago</span> : null}
-                size="xs"
+    <div className="flex flex-col gap-4">
+      {comments.length === 0 ? (
+        <EmptyState
+          icon={CONCEPT_ICONS.comments}
+          tone={CONCEPT_TONE.comments}
+          title="No comments"
+          description="This issue has no comments yet."
+          size="inline"
+          className="py-5"
+        />
+      ) : (
+        <div className="flex flex-col gap-3">
+          {comments.map((comment) => {
+            const relativeDate = formatRelativeDuration(comment.createdAt);
+            return (
+              <NoteCard
+                key={comment.id}
+                header={
+                  <NoteHeader
+                    author={comment.user?.name ?? 'Unknown author'}
+                    timestamp={relativeDate !== '' ? <span>{relativeDate} ago</span> : null}
+                    size="xs"
+                  />
+                }
+                body={comment.body}
               />
-            }
-            body={comment.body}
-          />
-        );
-      })}
+            );
+          })}
+        </div>
+      )}
+      {onPost != null && (
+        <NoteComposer placeholder="Write a comment" submitLabel="Comment" onSubmit={onPost} />
+      )}
     </div>
   );
 };

--- a/apps/desktop/src/features/integrations/linear/LinearIssueDetail/index.test.tsx
+++ b/apps/desktop/src/features/integrations/linear/LinearIssueDetail/index.test.tsx
@@ -10,6 +10,8 @@ vi.mock('../client', async (importOriginal) => ({
   linearUpdateIssueDescription: vi.fn(),
 }));
 
+const postComment = vi.hoisted(() => vi.fn(async () => {}));
+
 vi.mock('../useLinearIssueComments', () => ({
   useLinearIssueComments: () => ({
     comments: [
@@ -22,6 +24,7 @@ vi.mock('../useLinearIssueComments', () => ({
     ],
     isLoading: false,
     error: null,
+    post: postComment,
   }),
 }));
 
@@ -47,6 +50,7 @@ const updateDescription = vi.mocked(linearUpdateIssueDescription);
 
 beforeEach(() => {
   updateDescription.mockReset();
+  postComment.mockClear();
 });
 
 afterEach(cleanup);
@@ -66,6 +70,18 @@ describe('LinearIssueDetail', () => {
 
     expect(screen.getByText('Ada Lovelace')).toBeDefined();
     expect(screen.getByText('The fix is ready for review.')).toBeDefined();
+  });
+
+  it('sends a comment written in the conversation tab back to Linear', async () => {
+    render(<LinearIssueDetail issue={ISSUE} workspaceId={'workspace-1' as WorkspaceId} />);
+
+    fireEvent.click(screen.getByRole('tab', { name: /Conversation/ }));
+    fireEvent.change(screen.getByRole('textbox', { name: 'Write a comment' }), {
+      target: { value: 'Merging this' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Comment' }));
+
+    await waitFor(() => expect(postComment).toHaveBeenCalledWith('Merging this'));
   });
 
   it('keeps a fenced description as a code block', () => {

--- a/apps/desktop/src/features/integrations/linear/LinearIssueDetail/index.tsx
+++ b/apps/desktop/src/features/integrations/linear/LinearIssueDetail/index.tsx
@@ -34,7 +34,7 @@ export const LinearIssueDetail = ({
   fit = 'fill',
 }: Props) => {
   const [section, setSection] = useState<IssueSection>('overview');
-  const { comments, isLoading, error } = useLinearIssueComments({
+  const { comments, isLoading, error, post } = useLinearIssueComments({
     workspaceId,
     issueId: issue.id,
   });
@@ -84,7 +84,12 @@ export const LinearIssueDetail = ({
       {section === 'overview' ? (
         <DescriptionSection text={description} onSave={save} />
       ) : (
-        <LinearIssueComments comments={comments} isLoading={isLoading} error={error} />
+        <LinearIssueComments
+          comments={comments}
+          isLoading={isLoading}
+          error={error}
+          onPost={post}
+        />
       )}
     </StudioDetailLayout>
   );

--- a/apps/desktop/src/features/integrations/linear/LinearStudio/IssueDetailPanel.test.tsx
+++ b/apps/desktop/src/features/integrations/linear/LinearStudio/IssueDetailPanel.test.tsx
@@ -41,6 +41,7 @@ vi.mock('../useLinearIssueComments', () => ({
     ],
     isLoading: false,
     error: null,
+    post: vi.fn(async () => {}),
   }),
 }));
 

--- a/apps/desktop/src/features/integrations/linear/client.test.ts
+++ b/apps/desktop/src/features/integrations/linear/client.test.ts
@@ -3,6 +3,7 @@ import { invoke } from '@tauri-apps/api/core';
 import type { WorkspaceId } from '@goodboy/types';
 import {
   issuePullRequests,
+  linearCreateComment,
   linearFetchIssue,
   linearFetchIssueComments,
   linearUpdateIssueDescription,
@@ -114,6 +115,29 @@ describe('Linear issue requests', () => {
       ['linear_fetch_issue', { workspaceId: WORKSPACE_ID, issueId: 'issue-42' }],
       ['linear_fetch_issue_comments', { workspaceId: WORKSPACE_ID, issueId: 'issue-42' }],
     ]);
+  });
+
+  it('posts a comment against the issue and returns the comment Linear created', async () => {
+    const created = {
+      id: 'comment-7',
+      body: 'Looks good',
+      createdAt: '2026-08-05T09:00:00Z',
+      user: { name: 'Ada' },
+    };
+    mockInvoke.mockResolvedValueOnce(created);
+
+    const comment = await linearCreateComment({
+      workspaceId: WORKSPACE_ID,
+      issueId: 'issue-42',
+      body: 'Looks good',
+    });
+
+    expect(mockInvoke).toHaveBeenCalledWith('linear_create_comment', {
+      workspaceId: WORKSPACE_ID,
+      issueId: 'issue-42',
+      body: 'Looks good',
+    });
+    expect(comment).toEqual(created);
   });
 
   it('sends the new description to the update command and returns the saved body', async () => {

--- a/apps/desktop/src/features/integrations/linear/client.ts
+++ b/apps/desktop/src/features/integrations/linear/client.ts
@@ -129,6 +129,18 @@ export const linearFetchIssueComments = async ({
   return invoke<LinearIssueComment[]>('linear_fetch_issue_comments', { workspaceId, issueId });
 };
 
+type CreateCommentParams = Params & {
+  readonly body: string;
+};
+
+export const linearCreateComment = async ({
+  workspaceId,
+  issueId,
+  body,
+}: CreateCommentParams): Promise<LinearIssueComment> => {
+  return invoke<LinearIssueComment>('linear_create_comment', { workspaceId, issueId, body });
+};
+
 type UpdateDescriptionParams = Params & {
   readonly description: string;
 };

--- a/apps/desktop/src/features/integrations/linear/useLinearIssueComments.test.ts
+++ b/apps/desktop/src/features/integrations/linear/useLinearIssueComments.test.ts
@@ -1,14 +1,16 @@
 // @vitest-environment happy-dom
 
-import { cleanup, renderHook, waitFor } from '@testing-library/react';
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { WorkspaceId } from '@goodboy/types';
 import { useLinearIssueComments } from './useLinearIssueComments';
 
 const fetchComments = vi.hoisted(() => vi.fn());
+const createComment = vi.hoisted(() => vi.fn());
 
 vi.mock('./client', () => ({
   linearFetchIssueComments: fetchComments,
+  linearCreateComment: createComment,
 }));
 
 const WORKSPACE_ID = 'workspace-1' as WorkspaceId;
@@ -16,6 +18,7 @@ const WORKSPACE_ID = 'workspace-1' as WorkspaceId;
 afterEach(() => {
   cleanup();
   fetchComments.mockReset();
+  createComment.mockReset();
 });
 
 describe('useLinearIssueComments', () => {
@@ -44,5 +47,48 @@ describe('useLinearIssueComments', () => {
       [{ workspaceId: WORKSPACE_ID, issueId: 'issue-1' }],
       [{ workspaceId: WORKSPACE_ID, issueId: 'issue-2' }],
     ]);
+  });
+
+  it('appends the comment Linear returns so the list carries the new post', async () => {
+    fetchComments.mockResolvedValue([
+      {
+        id: 'comment-1',
+        body: 'First comment',
+        createdAt: '2026-07-23T10:00:00Z',
+        user: { name: 'Ada' },
+      },
+    ]);
+    createComment.mockResolvedValue({
+      id: 'comment-2',
+      body: 'Looks good',
+      createdAt: '2026-07-24T10:00:00Z',
+      user: { name: 'Grace' },
+    });
+    const { result } = renderHook(() =>
+      useLinearIssueComments({ workspaceId: WORKSPACE_ID, issueId: 'issue-1' }),
+    );
+
+    await waitFor(() => expect(result.current.comments).toHaveLength(1));
+    await act(async () => {
+      await result.current.post?.('Looks good');
+    });
+
+    expect(createComment).toHaveBeenCalledWith({
+      workspaceId: WORKSPACE_ID,
+      issueId: 'issue-1',
+      body: 'Looks good',
+    });
+    expect(result.current.comments.map((comment) => comment.id)).toEqual([
+      'comment-1',
+      'comment-2',
+    ]);
+  });
+
+  it('offers no post callback while there is no issue selected', () => {
+    const { result } = renderHook(() =>
+      useLinearIssueComments({ workspaceId: WORKSPACE_ID, issueId: null }),
+    );
+
+    expect(result.current.post).toBeNull();
   });
 });

--- a/apps/desktop/src/features/integrations/linear/useLinearIssueComments.ts
+++ b/apps/desktop/src/features/integrations/linear/useLinearIssueComments.ts
@@ -1,7 +1,7 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import type { WorkspaceId } from '@goodboy/types';
 import { formatError } from '../../../shared/lib/errors';
-import { linearFetchIssueComments, type LinearIssueComment } from './client';
+import { linearCreateComment, linearFetchIssueComments, type LinearIssueComment } from './client';
 
 type Params = {
   readonly workspaceId: WorkspaceId;
@@ -12,6 +12,7 @@ type Result = {
   readonly comments: ReadonlyArray<LinearIssueComment>;
   readonly isLoading: boolean;
   readonly error: string | null;
+  readonly post: ((body: string) => Promise<void>) | null;
 };
 
 export const useLinearIssueComments = ({ workspaceId, issueId }: Params): Result => {
@@ -54,5 +55,16 @@ export const useLinearIssueComments = ({ workspaceId, issueId }: Params): Result
     };
   }, [issueId, workspaceId]);
 
-  return { comments, isLoading, error };
+  const post = useCallback(
+    async (body: string) => {
+      if (issueId == null) {
+        return;
+      }
+      const created = await linearCreateComment({ workspaceId, issueId, body });
+      setComments((current) => [...current, created]);
+    },
+    [issueId, workspaceId],
+  );
+
+  return { comments, isLoading, error, post: issueId != null ? post : null };
 };


### PR DESCRIPTION
## What shipped

Commenting on a Linear issue no longer sends you to linear.app.

A new `linear_create_comment` Tauri command posts through Linear's `commentCreate`
mutation. The TS client gains `linearCreateComment`, `useLinearIssueComments`
gains a `post` callback that appends the comment Linear returns, and
`LinearIssueComments` mounts the shared `NoteComposer`. Both the Linear studio
and the session integration pane render the same `LinearIssueDetail`, so both
surfaces gain the composer from one change.

`VISION.md` said Linear's only write was the description. It now says the
comment ships too, and keeps assign and transition on the gap list with the
reason. `README.md` and `website/` make no claim about Linear's write surface,
so neither needed a change.

## The API shape, and where it came from

Nothing in this repo grounded the mutation, so the shape comes from Linear's own
published GraphQL schema:
https://github.com/linear/linear/blob/master/packages/sdk/src/schema.graphql

```graphql
mutation CommentCreate($input: CommentCreateInput!) {
  commentCreate(input: $input) {
    success
    comment {
      id
      body
      createdAt
      user { name }
    }
  }
}
```

Variables: `{ "input": { "issueId": "<uuid or LIN-123>", "body": "<markdown>" } }`.

From that schema:

- `Mutation.commentCreate(input: CommentCreateInput!): CommentPayload!`
- `CommentCreateInput.issueId: String` documented as "The issue to associate the
  comment with. Can be a UUID or issue identifier (e.g., 'LIN-123')"
- `CommentCreateInput.body: String` documented as "The comment content in
  markdown format"
- `CommentPayload { comment: Comment!, lastSyncId: Float!, success: Boolean! }`

Everything else on `CommentCreateInput` is optional and left unsent. The call
reuses the existing `graphql()` helper in `linear.rs`, so it inherits the bare
`Authorization: <token>` header the rest of the Linear surface already uses.

## Never run against a live Linear workspace

No call in this PR has touched a real Linear tenant. It is grounded in the
vendor's published schema and in unit tests, nothing more.

If the shape is wrong, the failure is loud rather than silent. Linear answers
with a GraphQL error, `graphql()` turns it into `LinearError::GraphQl`, the
promise rejects, and `NoteComposer` keeps the typed draft and prints what Linear
returned above the button. The comment does not disappear and the list does not
lie about having posted it. The one shape that would fail quietly is a
`success: false` with no error, which is why the command rejects on `success ==
false` instead of returning an empty comment.

## Tests

Each of these was checked by sabotaging the code it covers and confirming it
goes red.

- `linear.rs`: `comment_create_variables_nest_the_issue_and_the_body_under_input`
  pins that `issueId` and `body` sit under `input`, not at the top level. Fails
  when the key is renamed.
- `linear.rs`: `comment_create_mutation_asks_linear_for_the_created_comment_back`
  pins the mutation against `CommentCreateInput` and the returned `createdAt`.
- `client.test.ts`: the invoke name and payload for `linear_create_comment`.
  Fails on a typo in the command string.
- `useLinearIssueComments.test.ts`: posting appends the comment Linear returned,
  and `post` is null with no issue selected. Fails if the append is dropped.
- `LinearIssueComments/index.test.tsx`: the composer posts the trimmed body and
  clears, it shows on an issue with no comments yet, and it stays out when
  posting is unavailable.
- `LinearIssueDetail/index.test.tsx`: a comment written in the Conversation tab
  reaches the hook, which is the check that both mounted surfaces got it.

No existing test was deleted or rewritten to pass. Three test files that mock
`useLinearIssueComments` gained `post` in the mock, because the hook's result
type grew.

## What stayed unbuilt, and why

Assign and transition are not here. Both need a read command that does not
exist: `LinearIssueState` and `LinearIssueTeam` in `linear.rs` carry only `name`,
`type` and `key`, no `id`, so neither the workflow-state list nor the team member
list can be fetched, and there is no id to send back in an `IssueUpdateInput`.
Building them means new queries and struct changes, which is a separate change.

Also deliberately untouched: no store slice (Jira's writes go hook to client to
`invoke` and this follows that), no change to `shared/detail-fields/`, and no
change to the shared `NoteComposer`, which eight surfaces depend on.

## Verified

`pnpm typecheck`, `pnpm test` (4801 desktop tests green),
`pnpm knip --include files,duplicates,unlisted`, and `cargo test --locked` (341
passed) all pass locally.
