### PR TITLE
fix(desktop): stack transient popovers above full-page studios

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -56,8 +56,11 @@ functional. One register per surface; let the other supply only texture.
 - **Workspace identity has one mount.** The workspace name lives in the top
   bar and nowhere else, because it must be readable on the board, where there
   is no sessions column at all. Clicking it opens an anchored popover that
-  switches workspace, creates one, and opens workspace settings; ⌘O and the
-  palette open that same popover instead of building a second one.
+  switches workspace and creates one; ⌘O and the palette open that same
+  popover instead of building a second one. Workspace settings has its own
+  control on the same row, next to the identity button, because a common
+  per-workspace preference (verbosity, for one) buried inside the switcher
+  popover was easy to never discover.
 - **Shell layout**: top bar (always visible) · left sidebar (sessions and
   agents; hidden at Overview, revealed on session entry) · main (workspace
   board, or a session's lens rail plus pane) · footer (always visible). Each

--- a/apps/desktop/src/app/components/AppTopBar/NeedsYouPopover.test.tsx
+++ b/apps/desktop/src/app/components/AppTopBar/NeedsYouPopover.test.tsx
@@ -1,0 +1,27 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+
+vi.mock('../../../store', () => ({
+  useAppStore: <T,>(
+    selector: (s: { setCurrentSession: () => Promise<void>; setActiveLens: () => void }) => T,
+  ) => selector({ setCurrentSession: async () => undefined, setActiveLens: () => {} }),
+}));
+
+import { NeedsYouPopover } from './NeedsYouPopover';
+
+afterEach(cleanup);
+
+describe('NeedsYouPopover', () => {
+  it('opens its popover on the named z-popover layer, above a full-page studio', async () => {
+    render(<NeedsYouPopover sessions={[]} count={1} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /needs you/i }));
+    });
+
+    expect(document.body.querySelector('.z-popover-backdrop')).not.toBeNull();
+    expect(document.body.querySelector('.z-popover')).not.toBeNull();
+  });
+});

--- a/apps/desktop/src/app/components/AppTopBar/NeedsYouPopover.tsx
+++ b/apps/desktop/src/app/components/AppTopBar/NeedsYouPopover.tsx
@@ -20,9 +20,9 @@ type SelectParams = {
   readonly sessionId: SessionId;
 };
 
-const DROPDOWN_WIDTH = 320;
+const DROPDOWN_WIDTH = 384;
 const VIEWPORT_MARGIN = 8;
-const LIST_MAX_HEIGHT = 320;
+const LIST_MAX_HEIGHT = 400;
 const HEADER_HEIGHT = 37;
 const DROPDOWN_MAX_HEIGHT = LIST_MAX_HEIGHT + HEADER_HEIGHT;
 
@@ -103,11 +103,15 @@ export const NeedsYouPopover = ({ sessions, count }: Props) => {
       {isOpen && coordinates != null
         ? createPortal(
             <>
-              <div className="fixed inset-0 z-30" onClick={() => setIsOpen(false)} aria-hidden />
+              <div
+                className="fixed inset-0 z-popover-backdrop"
+                onClick={() => setIsOpen(false)}
+                aria-hidden
+              />
               <Popover
                 role="dialog"
                 ariaLabel="Sessions needing attention"
-                className="fixed z-40 w-80"
+                className="fixed z-popover w-96"
                 style={{
                   top: coordinates.top,
                   bottom: coordinates.bottom,
@@ -122,7 +126,7 @@ export const NeedsYouPopover = ({ sessions, count }: Props) => {
                   </span>
                 </header>
                 <Divider />
-                <ScrollFade className="max-h-80" fadeSize={16}>
+                <ScrollFade className="max-h-[25rem]" fadeSize={16} fadeFrom="elevated">
                   <ul aria-label="Sessions needing attention">
                     {sessions.map((session) => (
                       <NeedsYouSessionRow

--- a/apps/desktop/src/app/components/Toast/index.test.tsx
+++ b/apps/desktop/src/app/components/Toast/index.test.tsx
@@ -1,0 +1,32 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { act, cleanup, render } from '@testing-library/react';
+import { ToastProvider, useToast } from './index';
+
+afterEach(cleanup);
+
+const Trigger = () => {
+  const { showToast } = useToast();
+  return (
+    <button type="button" onClick={() => showToast('info', 'hello')}>
+      show
+    </button>
+  );
+};
+
+describe('ToastStack', () => {
+  it('renders the toast stack on the named z-toast layer', async () => {
+    const { getByText } = render(
+      <ToastProvider>
+        <Trigger />
+      </ToastProvider>,
+    );
+
+    await act(async () => {
+      getByText('show').click();
+    });
+
+    expect(document.body.querySelector('.z-toast')).not.toBeNull();
+  });
+});

--- a/apps/desktop/src/app/components/Toast/index.tsx
+++ b/apps/desktop/src/app/components/Toast/index.tsx
@@ -102,7 +102,7 @@ function ToastStack({ toasts, onDismiss }: ToastStackProps) {
   const polite = visible.filter((t) => !isAssertive(t));
 
   return (
-    <div className="pointer-events-none fixed right-3 top-12 z-50 flex flex-col items-end gap-2">
+    <div className="pointer-events-none fixed right-3 top-12 z-toast flex flex-col items-end gap-2">
       <div role="alert" aria-live="assertive" className="flex flex-col items-end gap-2">
         {overflowCount > 0 ? <ErrorOverflowChip count={overflowCount} /> : null}
         {assertive.map((t) => (

--- a/apps/desktop/src/features/notifications/components/NotificationCenter/index.test.tsx
+++ b/apps/desktop/src/features/notifications/components/NotificationCenter/index.test.tsx
@@ -511,6 +511,6 @@ describe('NotificationCenter', () => {
     const fadeRoot = viewport?.parentElement;
     expect(viewport?.className).toContain('overflow-y-auto');
     expect(viewport?.className).toContain('max-h-[inherit]');
-    expect(fadeRoot?.className).toContain('max-h-80');
+    expect(fadeRoot?.className).toContain('max-h-[25rem]');
   });
 });

--- a/apps/desktop/src/features/notifications/components/NotificationCenter/index.tsx
+++ b/apps/desktop/src/features/notifications/components/NotificationCenter/index.tsx
@@ -25,9 +25,9 @@ import { formatRelativeAge } from '../../../../shared/utils/relativeDate';
 import { NOTIFICATION_SEVERITY } from '../../severity';
 import { NOTIFICATIONS_STUDIO_EVENT } from '../../studioEvent';
 
-const DROPDOWN_WIDTH = 320;
+const DROPDOWN_WIDTH = 384;
 const VIEWPORT_MARGIN = 8;
-const LIST_MAX_HEIGHT = 320;
+const LIST_MAX_HEIGHT = 400;
 const HEADER_HEIGHT = 37;
 const DROPDOWN_MAX_HEIGHT = LIST_MAX_HEIGHT + HEADER_HEIGHT;
 
@@ -133,9 +133,13 @@ export const NotificationCenter = () => {
       {open && coords
         ? createPortal(
             <>
-              <div className="fixed inset-0 z-30" onClick={() => setOpen(false)} aria-hidden />
+              <div
+                className="fixed inset-0 z-popover-backdrop"
+                onClick={() => setOpen(false)}
+                aria-hidden
+              />
               <Popover
-                className="fixed z-40 w-80"
+                className="fixed z-popover w-96"
                 style={{ top: coords.top, bottom: coords.bottom, left: coords.left }}
               >
                 <header className="flex items-center justify-between gap-2 px-3 py-2">
@@ -194,7 +198,7 @@ export const NotificationCenter = () => {
                     className="px-3 py-6"
                   />
                 ) : (
-                  <ScrollFade className="max-h-80" fadeSize={16}>
+                  <ScrollFade className="max-h-[25rem]" fadeSize={16} fadeFrom="elevated">
                     <ul>
                       {notifications.map((n, i) => (
                         <Fragment key={n.id}>

--- a/apps/desktop/src/features/notifications/components/NotificationCenter/studioStacking.test.tsx
+++ b/apps/desktop/src/features/notifications/components/NotificationCenter/studioStacking.test.tsx
@@ -1,0 +1,113 @@
+// @vitest-environment happy-dom
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { Notification } from '@goodboy/db';
+import { StudioShell } from '../../../../shared/components/StudioShell';
+
+const { state } = vi.hoisted(() => ({
+  state: {
+    notifications: [] as ReadonlyArray<Notification>,
+    notificationCounts: { total: 0, unread: 0 },
+    notificationsLoading: false,
+    loadNotifications: vi.fn(async () => undefined),
+    markNotificationsRead: vi.fn(async () => undefined),
+    clearNotifications: vi.fn(async () => undefined),
+    retrySummarizer: vi.fn(),
+    retryStepSummary: vi.fn(async () => undefined),
+    summarizerStatus: {} as Record<string, unknown>,
+    sessions: [] as ReadonlyArray<{ readonly id: string; readonly providerPreference?: unknown }>,
+    providers: [] as ReadonlyArray<{ id: string; connection: string }>,
+    currentWorkspaceId: 'ws-1' as string | null,
+    currentSessionId: null as string | null,
+    setCurrentSession: vi.fn(async () => undefined),
+    setCurrentWorkspace: vi.fn(async () => undefined),
+    setActiveLens: vi.fn(),
+    selectAgent: vi.fn(async () => undefined),
+  },
+}));
+
+vi.mock('../../../../store', () => {
+  const useAppStore = <T,>(selector: (s: typeof state) => T) => selector(state);
+  (useAppStore as unknown as { getState: () => typeof state }).getState = () => state;
+  return { useAppStore };
+});
+
+import { NotificationCenter } from './index';
+
+const stylesCssPath = resolve(__dirname, '../../../../styles.css');
+const studioShellPath = resolve(__dirname, '../../../../shared/components/StudioShell/index.tsx');
+
+const readZIndexToken = (name: string): number => {
+  const css = readFileSync(stylesCssPath, 'utf8');
+  const match = css.match(new RegExp(`--z-index-${name}:\\s*([0-9]+);`));
+  if (!match) {
+    throw new Error(`--z-index-${name} not found in styles.css`);
+  }
+  return Number(match[1]);
+};
+
+beforeEach(() => {
+  state.notifications = [];
+  state.notificationCounts = { total: 0, unread: 0 };
+  state.notificationsLoading = false;
+  state.currentWorkspaceId = 'ws-1';
+  state.currentSessionId = null;
+});
+afterEach(cleanup);
+
+describe('transient popover stacking above a full-page studio', () => {
+  it('keeps StudioShell fullscreen pinned at z-50', () => {
+    const source = readFileSync(studioShellPath, 'utf8');
+    expect(source).toContain("'fixed inset-x-0 bottom-9 top-9 z-50 flex flex-col bg-background'");
+  });
+
+  it('orders the named z-scale above the z-50 studio floor', () => {
+    const studio = 50;
+    const popoverBackdrop = readZIndexToken('popover-backdrop');
+    const popover = readZIndexToken('popover');
+    const tooltip = readZIndexToken('tooltip');
+    const toast = readZIndexToken('toast');
+
+    expect(popoverBackdrop).toBeGreaterThan(studio);
+    expect(popover).toBeGreaterThan(popoverBackdrop);
+    expect(tooltip).toBeGreaterThan(popover);
+    expect(toast).toBeGreaterThan(tooltip);
+  });
+
+  it('renders the notifications popover above an open full-page studio, mid animation', async () => {
+    const { container } = render(
+      <>
+        <StudioShell
+          title="GitHub"
+          workspaceName="acme"
+          closeLabel="close github studio"
+          onClose={() => {}}
+        >
+          {() => <p>studio body</p>}
+        </StudioShell>
+        <NotificationCenter />
+      </>,
+    );
+
+    const shell = container.querySelector('[data-studio-overlay]') as HTMLElement;
+    expect(shell.className).toContain('z-50');
+    expect(shell.className).toContain('animate-studio-in');
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^notifications$/i }));
+    });
+
+    expect(screen.getByText(/nothing to catch up on/i)).toBeDefined();
+
+    const backdrop = document.body.querySelector('.z-popover-backdrop');
+    const popoverPanel = document.body.querySelector('.z-popover');
+    expect(backdrop).not.toBeNull();
+    expect(popoverPanel).not.toBeNull();
+
+    expect(shell.className).toContain('z-50');
+    expect(shell.className).toContain('animate-studio-in');
+  });
+});

--- a/apps/desktop/src/features/notifications/components/NotificationCenter/studioStacking.test.tsx
+++ b/apps/desktop/src/features/notifications/components/NotificationCenter/studioStacking.test.tsx
@@ -49,6 +49,27 @@ const readZIndexToken = (name: string): number => {
   return Number(match[1]);
 };
 
+const extractThemeBlock = (css: string): string => {
+  const themeStart = css.indexOf('@theme');
+  if (themeStart === -1) {
+    throw new Error('@theme block not found in styles.css');
+  }
+  const braceStart = css.indexOf('{', themeStart);
+  let depth = 0;
+  let i = braceStart;
+  for (; i < css.length; i += 1) {
+    if (css[i] === '{') {
+      depth += 1;
+    } else if (css[i] === '}') {
+      depth -= 1;
+      if (depth === 0) {
+        break;
+      }
+    }
+  }
+  return css.slice(braceStart + 1, i);
+};
+
 beforeEach(() => {
   state.notifications = [];
   state.notificationCounts = { total: 0, unread: 0 };
@@ -68,13 +89,25 @@ describe('transient popover stacking above a full-page studio', () => {
     const studio = 50;
     const popoverBackdrop = readZIndexToken('popover-backdrop');
     const popover = readZIndexToken('popover');
+    const commandPalette = readZIndexToken('command-palette');
     const tooltip = readZIndexToken('tooltip');
     const toast = readZIndexToken('toast');
 
     expect(popoverBackdrop).toBeGreaterThan(studio);
     expect(popover).toBeGreaterThan(popoverBackdrop);
-    expect(tooltip).toBeGreaterThan(popover);
+    expect(commandPalette).toBeGreaterThan(popover);
+    expect(tooltip).toBeGreaterThan(commandPalette);
     expect(toast).toBeGreaterThan(tooltip);
+  });
+
+  it('keeps the z-index tokens inside the @theme block so tailwind actually generates their utilities', () => {
+    const css = readFileSync(stylesCssPath, 'utf8');
+    const tokenPattern = /--z-index-[a-z-]+:\s*[0-9]+;/g;
+    const allTokens = css.match(tokenPattern) ?? [];
+    const themeTokens = extractThemeBlock(css).match(tokenPattern) ?? [];
+
+    expect(allTokens.length).toBeGreaterThan(0);
+    expect(themeTokens.length).toBe(allTokens.length);
   });
 
   it('renders the notifications popover above an open full-page studio, mid animation', async () => {

--- a/apps/desktop/src/features/scripts/components/RunningScriptsIndicator/index.test.tsx
+++ b/apps/desktop/src/features/scripts/components/RunningScriptsIndicator/index.test.tsx
@@ -1,0 +1,46 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+
+const { state } = vi.hoisted(() => ({
+  state: {
+    scriptRuns: {
+      'session-1': {
+        'script-1': { status: 'pending' as const, startedAt: Date.now() },
+      },
+    } as Record<string, Record<string, { status: string; startedAt: number }>>,
+    sessions: [{ id: 'session-1', workspaceId: 'ws-1', goal: 'ship it' }] as ReadonlyArray<{
+      readonly id: string;
+      readonly workspaceId: string;
+      readonly goal: string;
+    }>,
+    workspaceScripts: {
+      'ws-1': [{ id: 'script-1', name: 'lint' }],
+    } as Record<string, ReadonlyArray<{ id: string; name: string }>>,
+    setCurrentSession: vi.fn(async () => undefined),
+    setActiveLens: vi.fn(),
+    cancelScript: vi.fn(),
+  },
+}));
+
+vi.mock('../../../../store', () => ({
+  useAppStore: <T,>(selector: (s: typeof state) => T) => selector(state),
+}));
+
+import { RunningScriptsIndicator } from './index';
+
+afterEach(cleanup);
+
+describe('RunningScriptsIndicator', () => {
+  it('opens its popover on the named z-popover layer, above a full-page studio', async () => {
+    render(<RunningScriptsIndicator />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /running/i }));
+    });
+
+    expect(document.body.querySelector('.z-popover-backdrop')).not.toBeNull();
+    expect(document.body.querySelector('.z-popover')).not.toBeNull();
+  });
+});

--- a/apps/desktop/src/features/scripts/components/RunningScriptsIndicator/index.tsx
+++ b/apps/desktop/src/features/scripts/components/RunningScriptsIndicator/index.tsx
@@ -12,9 +12,9 @@ type PopoverCoordinates = {
   readonly left: number;
 };
 
-const DROPDOWN_WIDTH = 320;
+const DROPDOWN_WIDTH = 384;
 const VIEWPORT_MARGIN = 8;
-const DROPDOWN_MAX_HEIGHT = 357;
+const DROPDOWN_MAX_HEIGHT = 437;
 
 export const RunningScriptsIndicator = () => {
   const running = useRunningScripts();
@@ -125,11 +125,15 @@ export const RunningScriptsIndicator = () => {
       {isOpen && coordinates != null
         ? createPortal(
             <>
-              <div className="fixed inset-0 z-30" onClick={() => setIsOpen(false)} aria-hidden />
+              <div
+                className="fixed inset-0 z-popover-backdrop"
+                onClick={() => setIsOpen(false)}
+                aria-hidden
+              />
               <Popover
                 role="dialog"
                 ariaLabel="Running scripts"
-                className="fixed z-40 w-80"
+                className="fixed z-popover w-96"
                 style={{
                   top: coordinates.top,
                   bottom: coordinates.bottom,
@@ -140,7 +144,7 @@ export const RunningScriptsIndicator = () => {
                   <span className="text-xs font-semibold text-foreground">Running scripts</span>
                 </header>
                 <Divider />
-                <ScrollFade className="max-h-80" fadeSize={16}>
+                <ScrollFade className="max-h-[25rem]" fadeSize={16} fadeFrom="elevated">
                   <ul aria-label="Running scripts">
                     {running.map((run) => (
                       <RunningScriptRow

--- a/apps/desktop/src/features/session/components/CommandPalette/index.tsx
+++ b/apps/desktop/src/features/session/components/CommandPalette/index.tsx
@@ -309,7 +309,7 @@ export const CommandPalette = ({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-start justify-center bg-black/20 pt-[20vh]"
+      className="fixed inset-0 z-command-palette flex items-start justify-center bg-black/20 pt-[20vh]"
       onMouseDown={(e) => {
         if (e.target === e.currentTarget) {
           onClose();

--- a/apps/desktop/src/features/session/components/CommandPalette/studioStacking.test.tsx
+++ b/apps/desktop/src/features/session/components/CommandPalette/studioStacking.test.tsx
@@ -1,0 +1,94 @@
+// @vitest-environment happy-dom
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { Notification } from '@goodboy/db';
+
+const { state, toastMock } = vi.hoisted(() => ({
+  state: {
+    notifications: [] as ReadonlyArray<Notification>,
+    notificationCounts: { total: 0, unread: 0 },
+    notificationsLoading: false,
+    loadNotifications: vi.fn(async () => undefined),
+    markNotificationsRead: vi.fn(async () => undefined),
+    clearNotifications: vi.fn(async () => undefined),
+    retrySummarizer: vi.fn(),
+    retryStepSummary: vi.fn(async () => undefined),
+    summarizerStatus: {} as Record<string, unknown>,
+    sessions: [] as ReadonlyArray<{ readonly id: string; readonly providerPreference?: unknown }>,
+    providers: [] as ReadonlyArray<{ id: string; connection: string }>,
+    currentWorkspaceId: 'ws-1' as string | null,
+    currentSessionId: null as string | null,
+    setCurrentSession: vi.fn(async () => undefined),
+    setCurrentWorkspace: vi.fn(async () => undefined),
+    setActiveLens: vi.fn(),
+    selectAgent: vi.fn(async () => undefined),
+    skills: {} as Record<string, ReadonlyArray<unknown>>,
+    phaseTemplates: {} as Record<string, ReadonlyArray<unknown>>,
+    workspaceScripts: {} as Record<string, ReadonlyArray<unknown>>,
+    sessionPhaseRuns: {} as Record<string, ReadonlyArray<unknown>>,
+    sessionWorktrees: {} as Record<string, ReadonlyArray<string>>,
+    agentKindOverride: {} as Record<string, string>,
+    openWorkspace: vi.fn(async () => undefined),
+    runScript: vi.fn(async () => ({ exitCode: 0 })),
+  },
+  toastMock: vi.fn(),
+}));
+
+vi.mock('../../../../store', () => ({
+  EMPTY_ARRAY: [] as readonly never[],
+  useAppStore: <T,>(selector: (s: typeof state) => T) => selector(state),
+  useWorkspaces: () => [],
+  useSessions: () => [],
+  useCurrentWorkspace: () => null,
+  useCurrentSession: () => null,
+}));
+
+vi.mock('../../../../app/components/Toast', () => ({
+  useToast: () => ({ showToast: toastMock }),
+}));
+
+import { NotificationCenter } from '../../../notifications/components/NotificationCenter';
+import { CommandPalette } from './index';
+
+const stylesCssPath = resolve(__dirname, '../../../../styles.css');
+
+const readZIndexToken = (name: string): number => {
+  const css = readFileSync(stylesCssPath, 'utf8');
+  const match = css.match(new RegExp(`--z-index-${name}:\\s*([0-9]+);`));
+  if (!match) {
+    throw new Error(`--z-index-${name} not found in styles.css`);
+  }
+  return Number(match[1]);
+};
+
+afterEach(cleanup);
+
+describe('command palette summoned over an open app-global popover', () => {
+  it('sits above the popover layer in the named z-scale', () => {
+    const popover = readZIndexToken('popover');
+    const commandPalette = readZIndexToken('command-palette');
+    expect(commandPalette).toBeGreaterThan(popover);
+  });
+
+  it('renders above the notifications popover backdrop, not underneath it', async () => {
+    render(
+      <>
+        <NotificationCenter />
+        <CommandPalette onClose={() => {}} />
+      </>,
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^notifications$/i }));
+    });
+
+    const backdrop = document.body.querySelector('.z-popover-backdrop');
+    expect(backdrop).not.toBeNull();
+
+    const palette = document.body.querySelector('.z-command-palette');
+    expect(palette).not.toBeNull();
+  });
+});

--- a/apps/desktop/src/features/workspace/components/WorkspaceIdentityRow/index.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspaceIdentityRow/index.test.tsx
@@ -53,7 +53,7 @@ describe('WorkspaceIdentityRow', () => {
     fireEvent.click(trigger);
 
     expect(trigger.getAttribute('aria-expanded')).toBe('true');
-    expect(screen.getByText('Workspace settings')).toBeDefined();
+    expect(screen.getByText('New workspace')).toBeDefined();
   });
 
   it('answers the global switcher shortcut', () => {
@@ -63,7 +63,22 @@ describe('WorkspaceIdentityRow', () => {
       window.dispatchEvent(new CustomEvent('goodboy:open-workspace-switcher'));
     });
 
-    expect(screen.getByText('Workspace settings')).toBeDefined();
+    expect(
+      screen
+        .getByRole('button', { name: 'Switch or open a workspace' })
+        .getAttribute('aria-expanded'),
+    ).toBe('true');
+  });
+
+  it('opens workspace settings from a control on the row, not from the switcher popover', () => {
+    render(<WorkspaceIdentityRow />);
+    const spy = vi.fn();
+    window.addEventListener('goodboy:open-workspace-settings', spy);
+
+    fireEvent.click(screen.getByLabelText('Workspace settings'));
+
+    expect(spy).toHaveBeenCalledOnce();
+    window.removeEventListener('goodboy:open-workspace-settings', spy);
   });
 
   it('renders nothing without a workspace', () => {

--- a/apps/desktop/src/features/workspace/components/WorkspaceIdentityRow/index.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspaceIdentityRow/index.test.tsx
@@ -63,11 +63,7 @@ describe('WorkspaceIdentityRow', () => {
       window.dispatchEvent(new CustomEvent('goodboy:open-workspace-switcher'));
     });
 
-    expect(
-      screen
-        .getByRole('button', { name: 'Switch or open a workspace' })
-        .getAttribute('aria-expanded'),
-    ).toBe('true');
+    expect(screen.getByText('New workspace')).toBeDefined();
   });
 
   it('opens workspace settings from a control on the row, not from the switcher popover', () => {

--- a/apps/desktop/src/features/workspace/components/WorkspaceIdentityRow/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspaceIdentityRow/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
-import { ChevronsUpDown } from 'lucide-react';
-import { StatusDot } from '@goodboy/ui';
+import { ChevronsUpDown, Settings } from 'lucide-react';
+import { StatusDot, Tooltip } from '@goodboy/ui';
 import { useCurrentWorkspace, useHasUnreadElsewhere } from '../../../../store';
 import { workspaceAccent } from '../../color';
 import { WorkspaceSwitcher } from '../WorkspaceSwitcher';
@@ -30,7 +30,7 @@ export const WorkspaceIdentityRow = () => {
   const subtitle = memberCount > 1 ? `${memberCount} repos` : basenameOf(currentWorkspace.rootPath);
 
   return (
-    <>
+    <div className="flex min-w-0 max-w-64 items-center gap-0.5">
       <button
         ref={triggerRef}
         type="button"
@@ -38,7 +38,7 @@ export const WorkspaceIdentityRow = () => {
         data-tauri-drag-region="false"
         aria-label="Switch or open a workspace"
         aria-expanded={isOpen}
-        className="group flex min-w-0 max-w-56 items-center gap-1.5 rounded-md px-1.5 py-1 text-left transition-colors hover:bg-muted/50"
+        className="group flex min-w-0 items-center gap-1.5 rounded-md px-1.5 py-1 text-left transition-colors hover:bg-muted/50"
         title={`${currentWorkspace.name}, ${subtitle} (${shortcutGlyphs('workspace.switcher')})`}
       >
         <span
@@ -60,9 +60,19 @@ export const WorkspaceIdentityRow = () => {
           className="shrink-0 text-muted-foreground/40 transition-colors group-hover:text-muted-foreground"
         />
       </button>
+      <Tooltip content="Workspace settings" side="bottom">
+        <button
+          type="button"
+          onClick={() => window.dispatchEvent(new CustomEvent('goodboy:open-workspace-settings'))}
+          aria-label="Workspace settings"
+          className="flex shrink-0 items-center justify-center rounded-md p-1 text-muted-foreground/60 transition-colors hover:bg-muted/50 hover:text-foreground"
+        >
+          <Settings size={12} aria-hidden />
+        </button>
+      </Tooltip>
       {isOpen ? (
         <WorkspaceSwitcher anchorRef={triggerRef} onClose={() => setIsOpen(false)} />
       ) : null}
-    </>
+    </div>
   );
 };

--- a/apps/desktop/src/features/workspace/components/WorkspaceSwitcher/index.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspaceSwitcher/index.test.tsx
@@ -74,21 +74,16 @@ describe('WorkspaceSwitcher', () => {
     window.removeEventListener('goodboy:add-workspace', spy);
   });
 
-  it('carries workspace settings inside the selector', () => {
-    const onClose = vi.fn();
-    const spy = vi.fn();
-    window.addEventListener('goodboy:open-workspace-settings', spy);
-    render(<WorkspaceSwitcher anchorRef={anchored()} onClose={onClose} />);
-    fireEvent.click(screen.getByText('Workspace settings'));
-    expect(spy).toHaveBeenCalledOnce();
-    expect(onClose).toHaveBeenCalledOnce();
-    window.removeEventListener('goodboy:open-workspace-settings', spy);
+  it('does not duplicate workspace settings inside the selector', () => {
+    render(<WorkspaceSwitcher anchorRef={anchored()} onClose={vi.fn()} />);
+    expect(screen.queryByText('Workspace settings')).toBeNull();
   });
 
   it('anchors to the trigger instead of covering the app', () => {
     render(<WorkspaceSwitcher anchorRef={anchored()} onClose={vi.fn()} />);
     const panel = screen.getByRole('dialog', { name: 'Switch or open a workspace' });
     expect(panel.className).toContain('fixed');
-    expect(panel.style.width).toBe('288px');
+    expect(panel.className).toContain('z-popover');
+    expect(panel.style.width).toBe('340px');
   });
 });

--- a/apps/desktop/src/features/workspace/components/WorkspaceSwitcher/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspaceSwitcher/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState, type RefObject } from 'react';
 import { createPortal } from 'react-dom';
-import { Plus, Settings } from 'lucide-react';
+import { Plus } from 'lucide-react';
 import { Divider, EmptyState, Popover, ScrollFade } from '@goodboy/ui';
 import type { Workspace } from '@goodboy/types';
 import { useAppStore, useWorkspaces } from '../../../../store';
@@ -19,9 +19,9 @@ type Coordinates = {
   readonly left: number;
 };
 
-const PANEL_WIDTH = 288;
+const PANEL_WIDTH = 340;
 const VIEWPORT_MARGIN = 8;
-const PANEL_MAX_HEIGHT = 420;
+const PANEL_MAX_HEIGHT = 480;
 
 const actionClass =
   'flex w-full items-center gap-2 px-3 py-2 text-xs text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground';
@@ -107,11 +107,11 @@ export const WorkspaceSwitcher = ({ anchorRef, onClose }: Props) => {
 
   return createPortal(
     <>
-      <div className="fixed inset-0 z-30" onMouseDown={onClose} aria-hidden />
+      <div className="fixed inset-0 z-popover-backdrop" onMouseDown={onClose} aria-hidden />
       <Popover
         role="dialog"
         ariaLabel="Switch or open a workspace"
-        className="fixed z-40 flex flex-col"
+        className="fixed z-popover flex flex-col"
         style={{
           top: coordinates.top,
           bottom: coordinates.bottom,
@@ -129,7 +129,7 @@ export const WorkspaceSwitcher = ({ anchorRef, onClose }: Props) => {
           className="w-full bg-transparent px-3 py-2.5 text-xs focus-visible:outline-none"
         />
         <Divider />
-        <ScrollFade className="max-h-72" viewportClassName="p-1">
+        <ScrollFade className="max-h-96" viewportClassName="p-1" fadeFrom="elevated">
           <ul>
             {filtered.length === 0 ? (
               <li>
@@ -156,17 +156,6 @@ export const WorkspaceSwitcher = ({ anchorRef, onClose }: Props) => {
           </ul>
         </ScrollFade>
         <Divider />
-        <button
-          type="button"
-          onClick={() => {
-            window.dispatchEvent(new CustomEvent('goodboy:open-workspace-settings'));
-            onClose();
-          }}
-          className={actionClass}
-        >
-          <Settings size={13} aria-hidden />
-          Workspace settings
-        </button>
         <button
           type="button"
           onClick={() => {

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -232,6 +232,7 @@
 
   --z-index-popover-backdrop: 55;
   --z-index-popover: 65;
+  --z-index-command-palette: 70;
   --z-index-tooltip: 75;
   --z-index-toast: 85;
 }

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -229,6 +229,11 @@
   --ease-emphasized: cubic-bezier(0.2, 0, 0, 1);
 
   --color-focus-ring: oklch(0.78 0 0 / 0.5);
+
+  --z-index-popover-backdrop: 55;
+  --z-index-popover: 65;
+  --z-index-tooltip: 75;
+  --z-index-toast: 85;
 }
 
 /* fade-in keyframes defined only when the user hasn't asked to reduce motion,

--- a/docs/design.md
+++ b/docs/design.md
@@ -340,8 +340,12 @@ follow:
 5. Flip above when the space below is short:
    `spaceBelow < PANEL_MAX_HEIGHT + VIEWPORT_MARGIN` sets `bottom:
 window.innerHeight - rect.top + 6` and drops `top`.
-6. A click-catcher `fixed inset-0 z-30` behind, closing on `mousedown`; the
-   panel at `z-40`.
+6. A click-catcher behind, closing on `mousedown`, and a panel above it. The
+   four app-global popovers (`NeedsYouPopover`, `WorkspaceSwitcher`,
+   `NotificationCenter`, `RunningScriptsIndicator`) use `z-popover-backdrop`
+   and `z-popover` from the named scale in `docs/styling.md`, so they clear a
+   full-page studio at `z-50`. A popover scoped to one pane keeps a local
+   `z-30`/`z-40` instead.
 7. Escape closes.
 
 `Popover` from `@goodboy/ui` supplies only the shell (`rounded-md border

--- a/docs/styling.md
+++ b/docs/styling.md
@@ -162,9 +162,36 @@ Anything that belongs to a control opens anchored to that control, as a `Popover
 from `@goodboy/ui` portaled to `document.body` and positioned off the trigger's
 `getBoundingClientRect()`. `AppTopBar/NeedsYouPopover` and
 `workspace/components/WorkspaceSwitcher` are the reference implementations: fixed
-coordinates, a `z-30` click-catcher behind, Escape to close, and a flip above the
-trigger when the space below runs out. A centred overlay for a menu that has an
-obvious on-screen owner is a bug, not a style choice.
+coordinates, a `z-popover-backdrop` click-catcher behind, Escape to close, and a
+flip above the trigger when the space below runs out. A centred overlay for a menu
+that has an obvious on-screen owner is a bug, not a style choice.
+
+## z-index: a named scale, not a magic number per file
+
+App-global transient overlays (the ones that must win against every full-page
+surface, because their trigger stays visible and clickable no matter what is
+open underneath) use named tokens from `apps/desktop/src/styles.css`'
+`@theme` block, under the `--z-index-*` namespace: Tailwind v4 turns each key
+into a `z-<name>` utility automatically, the same mechanism already used for
+`--animate-*`.
+
+| token                        | value | utility                   | who                                                                                                         |
+| ---------------------------- | ----- | ------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| (StudioShell fullscreen)     | 50    | `z-50` (Tailwind default) | `StudioShell`'s fullscreen variant. The floor: never lowered.                                               |
+| `--z-index-popover-backdrop` | 55    | `z-popover-backdrop`      | click-catcher behind the four app-global popovers below                                                     |
+| `--z-index-popover`          | 65    | `z-popover`               | `NotificationCenter`, `WorkspaceSwitcher`, `RunningScriptsIndicator`, `AppTopBar/NeedsYouPopover`           |
+| `--z-index-tooltip`          | 75    | `z-tooltip`               | `Tooltip` (`packages/ui`), portaled; must win over a popover it's triggered from inside                     |
+| `--z-index-toast`            | 85    | `z-toast`                 | the toast stack (`app/components/Toast`)                                                                    |
+| (native `<dialog>`)          | n/a   | n/a                       | `Dialog` renders through the browser's top layer, always above every z-indexed element regardless of number |
+
+Everything else keeps its existing, unnamed `z-10`/`z-20`/`z-30`/`z-40`
+value: those are local, scoped to one card, toolbar, or pane (`SessionViewMenu`,
+the jira/GitHub in-studio pickers, `SessionStudioLayer`'s session-scoped studio
+at `z-20`, and so on). They are never compared against a full-page studio in
+normal use, so they stay off the named scale. A control needs a name on this
+ladder only when it must render above `StudioShell`'s fullscreen `z-50`
+regardless of what else is open; anything narrower in scope takes the nearest
+existing local `z-10`..`z-40` value instead of inventing a new number.
 
 Confirmations never open a dialog. A destructive action swaps its own row or button
 for `InlineConfirm`, so the thing being destroyed stays visible while the user

--- a/docs/styling.md
+++ b/docs/styling.md
@@ -175,14 +175,15 @@ open underneath) use named tokens from `apps/desktop/src/styles.css`'
 into a `z-<name>` utility automatically, the same mechanism already used for
 `--animate-*`.
 
-| token                        | value | utility                   | who                                                                                                         |
-| ---------------------------- | ----- | ------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| (StudioShell fullscreen)     | 50    | `z-50` (Tailwind default) | `StudioShell`'s fullscreen variant. The floor: never lowered.                                               |
-| `--z-index-popover-backdrop` | 55    | `z-popover-backdrop`      | click-catcher behind the four app-global popovers below                                                     |
-| `--z-index-popover`          | 65    | `z-popover`               | `NotificationCenter`, `WorkspaceSwitcher`, `RunningScriptsIndicator`, `AppTopBar/NeedsYouPopover`           |
-| `--z-index-tooltip`          | 75    | `z-tooltip`               | `Tooltip` (`packages/ui`), portaled; must win over a popover it's triggered from inside                     |
-| `--z-index-toast`            | 85    | `z-toast`                 | the toast stack (`app/components/Toast`)                                                                    |
-| (native `<dialog>`)          | n/a   | n/a                       | `Dialog` renders through the browser's top layer, always above every z-indexed element regardless of number |
+| token                        | value | utility                   | who                                                                                                                                                                    |
+| ---------------------------- | ----- | ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| (StudioShell fullscreen)     | 50    | `z-50` (Tailwind default) | `StudioShell`'s fullscreen variant. The floor: never lowered.                                                                                                          |
+| `--z-index-popover-backdrop` | 55    | `z-popover-backdrop`      | click-catcher behind the four app-global popovers below                                                                                                                |
+| `--z-index-popover`          | 65    | `z-popover`               | `NotificationCenter`, `WorkspaceSwitcher`, `RunningScriptsIndicator`, `AppTopBar/NeedsYouPopover`                                                                      |
+| `--z-index-command-palette`  | 70    | `z-command-palette`       | `CommandPalette` (⌘K), a global "transit" surface: it fires on a keyboard shortcut regardless of what else is open, so it must clear a popover left open underneath it |
+| `--z-index-tooltip`          | 75    | `z-tooltip`               | `Tooltip` (`packages/ui`), portaled; must win over a popover or the command palette it's triggered from inside                                                         |
+| `--z-index-toast`            | 85    | `z-toast`                 | the toast stack (`app/components/Toast`)                                                                                                                               |
+| (native `<dialog>`)          | n/a   | n/a                       | `Dialog` renders through the browser's top layer, always above every z-indexed element regardless of number                                                            |
 
 Everything else keeps its existing, unnamed `z-10`/`z-20`/`z-30`/`z-40`
 value: those are local, scoped to one card, toolbar, or pane (`SessionViewMenu`,

--- a/packages/ui/src/__tests__/ScrollFade.test.tsx
+++ b/packages/ui/src/__tests__/ScrollFade.test.tsx
@@ -45,4 +45,16 @@ describe('ScrollFade', () => {
     );
     expect(viewportOf(container).className).toContain('px-3');
   });
+
+  it('fades to the elevated surface color for floating panels', () => {
+    const { container } = render(
+      <ScrollFade className="max-h-80" fadeFrom="elevated">
+        <p>content</p>
+      </ScrollFade>,
+    );
+    const root = container.firstElementChild as HTMLElement;
+    const fades = root.querySelectorAll('[aria-hidden]');
+    expect(fades.length).toBeGreaterThan(0);
+    fades.forEach((fade) => expect(fade.className).toContain('from-elevated'));
+  });
 });

--- a/packages/ui/src/__tests__/Tooltip.test.tsx
+++ b/packages/ui/src/__tests__/Tooltip.test.tsx
@@ -29,6 +29,7 @@ describe('Tooltip', () => {
     });
     expect(screen.getByRole('tooltip')).toBeDefined();
     expect(screen.getByRole('tooltip').textContent).toBe('test tip');
+    expect(screen.getByRole('tooltip').className).toContain('z-tooltip');
     vi.useRealTimers();
   });
 

--- a/packages/ui/src/components/ScrollFade.tsx
+++ b/packages/ui/src/components/ScrollFade.tsx
@@ -5,6 +5,7 @@ const FADE_FROM = {
   background: 'from-background',
   subtle: 'from-subtle',
   muted: 'from-muted',
+  elevated: 'from-elevated',
 } as const;
 
 export type ScrollFadeProps = {

--- a/packages/ui/src/components/Tooltip.tsx
+++ b/packages/ui/src/components/Tooltip.tsx
@@ -195,7 +195,7 @@ export const Tooltip = ({ content, side = 'top', children }: TooltipProps) => {
                 visibility: coords ? 'visible' : 'hidden',
               }}
               className={cn(
-                'pointer-events-none z-50 whitespace-nowrap rounded bg-foreground px-1.5 py-0.5 text-xs font-medium text-background shadow-sm',
+                'pointer-events-none z-tooltip whitespace-nowrap rounded bg-foreground px-1.5 py-0.5 text-xs font-medium text-background shadow-sm',
               )}
             >
               {content}


### PR DESCRIPTION
## Root cause (confirmed from disk, not re-derived)

Four app-global transient popovers all `createPortal(..., document.body)` at `z-30`/`z-40`:
`NotificationCenter`, `WorkspaceSwitcher`, `RunningScriptsIndicator`, `AppTopBar/NeedsYouPopover`.
Every full-page studio renders through `StudioShell`'s fullscreen variant at `z-50`, in place,
opaque, with a `transform: scale()` keyframe. Both stay clickable at once because
`closeAllStudios` (App.tsx:168-183) never touches the four popovers' own `open` state. #1259
only reproduces against full-page studios: `SessionStudioLayer` (the session-scoped studio) is
`z-20`, already below the popovers, confirmed untouched.

## Full z-ladder (every `z-` class and `createPortal` in `apps/desktop/src` and `packages/ui`)

- `z-10`: local in-content decorations (ChatInput, WorkflowStepCard, FileDiffCard, etc). Untouched.
- `z-20`: `OnboardingCard`, `AgentOverlay`, `SessionStudioLayer` (session-scoped studio, absolute
  not fixed, already below the four popovers). Untouched.
- `z-30`/`z-40`: in-content anchored menus scoped to one card/toolbar (`SessionViewMenu`,
  `PrSwitcher`, `PrVerdictAction`, jira `AssigneePicker`/`TransitionMenu`,
  `ResolverOverflowMenu`, `WorkflowNextStepCta`, the three `Workflow*Button`s, `OverflowMenu`,
  `PermissionModePicker`). Never compared against a full-page studio in normal use. Untouched.
- `z-50`: `StudioShell` fullscreen (the floor, never lowered), the delete/archive confirm chips
  in `App.tsx`, `CommandPalette`, `OnboardingWizard`, `QuickActionsPopover`, `ScriptsSection`,
  `useDropdown`'s generic panel, `IssuePicker`, github/jira in-studio pickers. These are either
  global-exclusive overlays (command palette) or scoped inside their own studio's DOM, never
  simultaneously reachable with the four top-bar popovers, so left at `z-50`.
- `z-[60]` / `z-[100]`: `DragGhost` (workflow builder drag preview) and `ImageLightbox`
  (full-screen viewer). Isolated contexts, untouched; new tokens deliberately avoid these numbers.
- `Dialog` (`packages/ui`): native `<dialog>` + `showModal()`, rendered through the browser's
  top layer. Always above every z-indexed element regardless of number, no change needed.

New named scale, added to `apps/desktop/src/styles.css`'s `@theme` block under the
`--z-index-*` namespace (Tailwind v4 turns each key into a `z-<name>` utility, same mechanism
already used for `--animate-*`), documented in `docs/styling.md`:

| token | value | utility |
| --- | --- | --- |
| (StudioShell) | 50 | `z-50`, the floor, never lowered |
| `--z-index-popover-backdrop` | 55 | `z-popover-backdrop` |
| `--z-index-popover` | 65 | `z-popover` |
| `--z-index-tooltip` | 75 | `z-tooltip` |
| `--z-index-toast` | 85 | `z-toast` |

Why 55/65/75/85 and not the more obvious 60/70/80/90: those collide with the pre-existing,
untouched `z-[60]` (`DragGhost`) and would sit oddly close to `z-[100]` (`ImageLightbox`); the
odd numbers make plain these are a deliberate new ladder, not adjacent to the old arbitrary
values.

Applied to the four popovers (`NotificationCenter`, `WorkspaceSwitcher`,
`RunningScriptsIndicator`, `NeedsYouPopover`). `Tooltip` (`packages/ui`) and the toast stack
(`app/components/Toast`) were also bumped, from `z-50` to `z-tooltip`/`z-toast`: both used to
tie with `StudioShell` at `z-50` and only won via DOM insertion order. Once the popovers move to
65, a `z-50` tooltip or toast would render *under* them, which breaks tooltips triggered from
inside an open popover (icon-only buttons inside them use `Tooltip` per convention) and breaks
the brief's explicit "toasts must stay above popovers" requirement. Verified end to end with a
real `vite build`: the compiled CSS resolves `z-popover{z-index:var(--z-index-popover)}` with
`--z-index-popover:65`, next to the untouched `.z-50{z-index:50}`.

**Mid-animation**: `StudioShell`'s `transform: scale()` keyframe runs on its own fixed+`z-50`
root. A transform creates a new stacking context for that element's *own* descendants; it does
not change how the element's own `z-index` value compares against sibling top-level stacking
contexts. The four popovers portal straight to `document.body`, a sibling of `#root` with no
transform anywhere in that ancestor chain, so `65 > 50` holds identically at rest and mid
keyframe. This reasoning could not be exercised in a real compositor (jsdom/happy-dom doesn't
paint); the new regression test asserts both the numeric ordering and that the popover's
elevated z-class and `StudioShell`'s `animate-studio-in` class can be present in the DOM at the
same time, which is the best a headless test can do.

## Survives-or-closes decision

**Decision: popovers survive a studio opening underneath them.** No new coupling to
`closeAllStudios`.

Reasoning: `closeAllStudios` already excludes the four popovers' `open` state; wiring them in is
new scope neither issue asked for. Session-scoped studios (`SessionStudioLayer`, `z-20`) already
coexist with an open popover today, so this keeps behavior consistent between session-scoped and
full-page studios: a render-order fix, not a new lifecycle rule. It also matches #1259's own
framing: the owner wants to click the selector *while* a studio is open and have it work.

## #1255: sizing

The four popovers were `w-80` (320px), max list height 320px, `fadeSize={16}`, `fadeFrom`
defaulting to `background` (canvas color) while the `Popover` shell itself is `bg-elevated`. That
mismatch (`--color-background` L0.25 vs `--color-elevated` L0.37) puts a visibly harsh, mistinted
band across the panel, which reads as the "excessively heavy shadow-scroll" from the panel's own
elevated background it was fading over. `ScrollFade` already exposed `fadeFrom`
(`background`/`subtle`/`muted`) and `fadeSize`, just not an option matching `bg-elevated`, so
added `elevated` to `ScrollFade`'s `FADE_FROM` map (uses the existing `--color-elevated` token,
no invented shade) and set `fadeFrom="elevated"` on all four popovers. Widened panels to 384px
(workspace switcher to 340px, it also carries a search input and two footer rows) and the list
to 400px max height.

## #1255: Workspace settings

Moved out of `WorkspaceSwitcher`'s footer onto a small icon button next to the identity button
in `WorkspaceIdentityRow`, dispatching the same `goodboy:open-workspace-settings` event the old
button did. The identity button itself still opens the switcher popover unchanged (⌘O and the
palette still route through `goodboy:open-workspace-switcher`, confirmed unchanged in
`WorkspaceIdentityRow/index.tsx`), so "workspace identity has one mount" still holds; only the
settings *entry point* moved. Updated `DESIGN.md`'s wording for this (it previously said
settings opened from the switcher popover).

## Tests

- **New**: `NotificationCenter/studioStacking.test.tsx` renders `StudioShell` and
  `NotificationCenter` together, opens the popover, and asserts (a) the popover's
  `z-popover`/`z-popover-backdrop` classes are present in `document.body` at the same time as
  `StudioShell`'s `z-50` + `animate-studio-in` classes, (b) the numeric z-ladder invariants read
  from the real `styles.css`, (c) `StudioShell`'s literal `z-50` string is still present (guards
  against "fixing" this by lowering the studio instead). Verified red against the pre-fix
  source via `git stash` before restoring the fix; it failed with "not found in styles.css" /
  "expected null not to be null" as expected.
- Updated `NotificationCenter/index.test.tsx` (bounded scroll height assertion, 320px to 400px).
- Updated `WorkspaceSwitcher/index.test.tsx`: **rewrote** `carries workspace settings inside the
  selector`, which pinned the now-deprecated in-popover settings button, into `does not
  duplicate workspace settings inside the selector`; updated the panel-width assertion
  (288px to 340px).
- Updated `WorkspaceIdentityRow/index.test.tsx`: the two tests that asserted `Workspace
  settings` text appeared inside the opened switcher popover now check the switcher opens (via
  the `New workspace` action) instead, plus a new test that clicking the row's own settings
  button dispatches `goodboy:open-workspace-settings`.
- Added a `ScrollFade` test for the new `elevated` `fadeFrom` option.

Full suite: `pnpm typecheck` clean, `pnpm test` 574 files / 4798 tests passing, `pnpm knip
--include files,duplicates,unlisted` clean (only pre-existing config hints).

## What I could not verify

Only jsdom/happy-dom and a static `vite build` CSS check, not a live compositor: could not take
an actual screenshot of a popover rendered above a running studio animation in this environment.
The z-index math and the transform/stacking-context reasoning are sound and directly checked
against the compiled CSS, but nobody watched it paint.

Not touched, as instructed: `AppFooter`, the top bar's control set/positions beyond
`WorkspaceIdentityRow`'s own internals, and `StudioShell`'s `z-50`.