### PR TITLE
fix(desktop): align three session surfaces with card grammar

### DIFF
--- a/apps/desktop/src/features/plans/components/PlanStudio/index.test.tsx
+++ b/apps/desktop/src/features/plans/components/PlanStudio/index.test.tsx
@@ -155,6 +155,80 @@ describe('PlanStudio', () => {
     await waitFor(() => expect(state.selectAgent).toHaveBeenCalledWith('sess-1', 'agent-impl'));
     expect(state.setActiveLens).toHaveBeenCalledWith('sess-1', 'agents');
   });
+
+  it('renders the consumed toggle as a row beneath Nothing active, not inside the empty state card', () => {
+    state.plans = [
+      {
+        id: 'plan-1',
+        agentId: 'agent-1',
+        sessionId: 'sess-1',
+        title: 'Implement auth module',
+        bodyMd: '## Steps',
+        status: 'consumed',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        runCount: 1,
+      },
+    ];
+    render(<PlanStudio sessionId={'sess-1' as never} />);
+
+    expect(screen.getByText('Nothing active')).toBeDefined();
+    const toggle = screen.getByRole('button', { name: /consumed/i });
+    const emptyCard = screen.getByText('Nothing active').closest('.border-dashed');
+    expect(emptyCard).not.toBeNull();
+    expect(emptyCard?.contains(toggle)).toBe(false);
+
+    fireEvent.click(toggle);
+    expect(screen.getByText('Implement auth module')).toBeDefined();
+  });
+
+  it('shows the consumed toggle alongside active plans too', () => {
+    state.plans = [
+      {
+        id: 'plan-1',
+        agentId: 'agent-1',
+        sessionId: 'sess-1',
+        title: 'Implement auth module',
+        bodyMd: '## Steps',
+        status: 'active',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        runCount: 0,
+      },
+      {
+        id: 'plan-2',
+        agentId: 'agent-2',
+        sessionId: 'sess-1',
+        title: 'Old plan',
+        bodyMd: '## Steps',
+        status: 'consumed',
+        createdAt: '2026-01-02T00:00:00.000Z',
+        runCount: 1,
+      },
+    ];
+    render(<PlanStudio sessionId={'sess-1' as never} />);
+
+    expect(screen.queryByText('Nothing active')).toBeNull();
+    expect(screen.getByRole('button', { name: /consumed/i })).toBeDefined();
+  });
+
+  it('selects a plan from the list, focusing it', () => {
+    state.plans = [
+      {
+        id: 'plan-1',
+        agentId: 'agent-1',
+        sessionId: 'sess-1',
+        title: 'Implement auth module',
+        bodyMd: '## Steps',
+        status: 'active',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        runCount: 0,
+      },
+    ];
+    render(<PlanStudio sessionId={'sess-1' as never} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Implement auth module/i }));
+
+    expect(state.setFocusedPlanId).toHaveBeenCalledWith('sess-1', 'plan-1');
+  });
 });
 
 describe('PlanStudio subpage', () => {

--- a/apps/desktop/src/features/plans/components/PlanStudio/index.tsx
+++ b/apps/desktop/src/features/plans/components/PlanStudio/index.tsx
@@ -340,16 +340,6 @@ export const PlanStudio = ({ sessionId }: Props) => {
           icon={CONCEPT_ICONS.plans}
           title="Nothing active"
           description="Every plan here already ran or was discarded. Show the consumed ones to reread them."
-          action={
-            <CountToggle
-              label="Consumed"
-              itemsLabel="plans"
-              count={consumed.length}
-              isShown={showConsumed}
-              icon={CircleCheck}
-              onChange={setShowConsumed}
-            />
-          }
         />
       ) : null}
       {active.length > 0 ? (
@@ -361,18 +351,16 @@ export const PlanStudio = ({ sessionId }: Props) => {
           ))}
         </ul>
       ) : null}
-      {active.length > 0 ? (
-        <div className="flex justify-center">
-          <CountToggle
-            label="Consumed"
-            itemsLabel="plans"
-            count={consumed.length}
-            isShown={showConsumed}
-            icon={CircleCheck}
-            onChange={setShowConsumed}
-          />
-        </div>
-      ) : null}
+      <div className="flex justify-center">
+        <CountToggle
+          label="Consumed"
+          itemsLabel="plans"
+          count={consumed.length}
+          isShown={showConsumed}
+          icon={CircleCheck}
+          onChange={setShowConsumed}
+        />
+      </div>
       {showConsumed && consumed.length > 0 ? (
         <ul className="flex flex-col gap-2">
           {consumed.map((plan) => (

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn/index.test.tsx
@@ -801,6 +801,43 @@ describe('LensColumn', () => {
     fireEvent.click(backToBoard);
     expect(store.setCurrentSession).toHaveBeenCalledWith(null);
   });
+
+  it('tints the collapsed board escape hatch primary, like its expanded sidebar twin', () => {
+    render(
+      <SessionSidebarCollapsedContext value>
+        <LensColumn
+          session={SESSION}
+          activeLens={null}
+          onSelectOverview={vi.fn()}
+          onSelect={vi.fn()}
+          filesCount={0}
+        />
+      </SessionSidebarCollapsedContext>,
+    );
+
+    const backToBoard = screen.getByRole('button', { name: 'Back to board' });
+    expect(backToBoard.className).toContain('bg-primary/10');
+    expect(backToBoard.className).toContain('text-primary');
+  });
+
+  it('gives the collapsed board escape hatch the same row padding token as the Overview row', () => {
+    render(
+      <SessionSidebarCollapsedContext value>
+        <LensColumn
+          session={SESSION}
+          activeLens={null}
+          onSelectOverview={vi.fn()}
+          onSelect={vi.fn()}
+          filesCount={0}
+        />
+      </SessionSidebarCollapsedContext>,
+    );
+
+    const overviewRow = screen.getByRole('button', { name: 'Overview' });
+    const backToBoard = screen.getByRole('button', { name: 'Back to board' });
+    expect(backToBoard.className).toContain('py-1.5');
+    expect(overviewRow.className).toContain('py-1.5');
+  });
 });
 
 describe('LensColumn footer', () => {

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn/index.tsx
@@ -51,8 +51,17 @@ type AttentionParams = {
   readonly rows: ReadonlyArray<LensRow>;
 };
 
-const BOARD_ICON_BUTTON =
-  'inline-flex shrink-0 items-center justify-center rounded-md p-1.5 text-muted-foreground motion-safe:transition-colors hover:bg-muted/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]';
+const boardIconButtonTint = tintClasses('primary');
+
+const BOARD_ICON_BUTTON = cn(
+  'flex shrink-0 items-center justify-center rounded-md ring-1 motion-safe:transition-colors',
+  PANE_RHYTHM.navRail.row,
+  boardIconButtonTint.bg,
+  boardIconButtonTint.text,
+  boardIconButtonTint.ring,
+  boardIconButtonTint.hoverBg,
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]',
+);
 
 const groupWantsAttention = ({ rows }: AttentionParams): boolean => {
   return rows.some((row) => {
@@ -347,7 +356,9 @@ export const LensColumn = ({
                 title={`Back to board (${shortcutGlyphs('session.board')})`}
                 className={BOARD_ICON_BUTTON}
               >
-                <Kanban size={14} aria-hidden />
+                <span className="flex h-5 w-5 flex-none items-center justify-center">
+                  <Kanban size={14} aria-hidden />
+                </span>
               </button>
             ) : null}
           </div>

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.test.tsx
@@ -544,9 +544,32 @@ describe('PrPane', () => {
 
     expect(screen.getByRole('heading', { name: 'GitHub', level: 2 })).toBeDefined();
     expect(screen.getByText('Pull request on ak/refactor-auth')).toBeDefined();
-    expect(screen.getByRole('button', { name: 'Show pull request #42' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Open pull request #42' })).toBeDefined();
     expect(screen.getByText('No CI')).toBeDefined();
     expect(screen.getByRole('button', { name: /Review this pull request/i })).toBeDefined();
+  });
+
+  it('opens the studio, instead of re-selecting, when the already-selected row is clicked', () => {
+    h.store.sessionGithub = {
+      [SESSION_ID]: {
+        pr: PULL_REQUEST,
+        detail: { checks: [], comments: [] },
+        loading: false,
+        error: null,
+      },
+    };
+    h.store.sessionGithubPrs = { [SESSION_ID]: [PULL_REQUEST] };
+    const githubEvents: Array<CustomEvent> = [];
+    const listener = (event: Event) => githubEvents.push(event as CustomEvent);
+    window.addEventListener('goodboy:open-github-session', listener);
+
+    render(<PrPane session={session} onSelectLens={h.onSelectLens} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Open pull request #42' }));
+    window.removeEventListener('goodboy:open-github-session', listener);
+
+    expect(githubEvents).toHaveLength(1);
+    expect(githubEvents[0]?.detail).toEqual({ sessionId: SESSION_ID });
+    expect(h.store.selectSessionPr).not.toHaveBeenCalled();
   });
 
   it('lists every pull request on the branch and switches on click', () => {
@@ -597,7 +620,7 @@ describe('PrPane', () => {
     expect(screen.getAllByText(closedPr.title).length).toBeGreaterThan(0);
     expect(screen.queryByRole('heading', { name: PULL_REQUEST.title })).toBeNull();
     const selectedRow = screen
-      .getByRole('button', { name: `Show pull request #${closedPr.number}` })
+      .getByRole('button', { name: `Open pull request #${closedPr.number}` })
       .closest('[data-selected]');
     expect(selectedRow).not.toBeNull();
     expect(

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.tsx
@@ -111,9 +111,7 @@ const SessionBranchTag = ({ branch }: { readonly branch: string | null }) =>
   );
 
 type SessionStudioOpenEvent =
-  | 'goodboy:open-github-session'
-  | 'goodboy:open-gitlab-mr'
-  | 'goodboy:open-bitbucket-pr';
+  'goodboy:open-github-session' | 'goodboy:open-gitlab-mr' | 'goodboy:open-bitbucket-pr';
 
 const resolveSessionStudioOpenEvent = ({
   activeProvider,
@@ -533,6 +531,7 @@ const GithubPrCard = ({
         branch={branch}
         selectedNumber={pr.number}
         onSelect={(prNumber) => void selectSessionPr(sessionId, prNumber)}
+        onOpenSelected={onOpenStudio}
       />
       <LinkedIssuesSection
         issues={linkedIssues}
@@ -557,6 +556,7 @@ type LinkedPullRequestsSectionProps = {
   readonly branch: string | null;
   readonly selectedNumber: number;
   readonly onSelect: (prNumber: number) => void;
+  readonly onOpenSelected: () => void;
 };
 
 const branchScopedLabel = ({
@@ -575,6 +575,7 @@ const LinkedPullRequestsSection = ({
   branch,
   selectedNumber,
   onSelect,
+  onOpenSelected,
 }: LinkedPullRequestsSectionProps) => {
   if (prs.length === 0) {
     return null;
@@ -587,32 +588,37 @@ const LinkedPullRequestsSection = ({
         className="px-0.5 font-medium"
       />
       <div className="flex flex-col gap-1">
-        {prs.map((candidate) => (
-          <LinkedWorkRow
-            key={candidate.number}
-            leading={{ kind: 'glyph', provider: codeHostFromUrl({ url: candidate.url }) }}
-            identifier={`#${candidate.number}`}
-            title={candidate.title}
-            isSelected={candidate.number === selectedNumber}
-            ariaLabel={`Show pull request #${candidate.number}`}
-            tooltip={
-              candidate.number === selectedNumber
-                ? 'Showing this pull request'
-                : 'Show this pull request instead'
-            }
-            attribution={
-              <IssueStateBadge>{pullRequestMeta(candidate.state).label}</IssueStateBadge>
-            }
-            onClick={() => onSelect(candidate.number)}
-            actions={
-              <ExternalRefActions
-                url={candidate.url}
-                label={`pull request #${candidate.number}`}
-                hostLabel={integrationLabel({ provider: codeHostFromUrl({ url: candidate.url }) })}
-              />
-            }
-          />
-        ))}
+        {prs.map((candidate) => {
+          const isSelected = candidate.number === selectedNumber;
+          return (
+            <LinkedWorkRow
+              key={candidate.number}
+              leading={{ kind: 'glyph', provider: codeHostFromUrl({ url: candidate.url }) }}
+              identifier={`#${candidate.number}`}
+              title={candidate.title}
+              isSelected={isSelected}
+              ariaLabel={
+                isSelected
+                  ? `Open pull request #${candidate.number}`
+                  : `Show pull request #${candidate.number}`
+              }
+              tooltip={isSelected ? 'Open this pull request' : 'Show this pull request instead'}
+              attribution={
+                <IssueStateBadge>{pullRequestMeta(candidate.state).label}</IssueStateBadge>
+              }
+              onClick={() => (isSelected ? onOpenSelected() : onSelect(candidate.number))}
+              actions={
+                <ExternalRefActions
+                  url={candidate.url}
+                  label={`pull request #${candidate.number}`}
+                  hostLabel={integrationLabel({
+                    provider: codeHostFromUrl({ url: candidate.url }),
+                  })}
+                />
+              }
+            />
+          );
+        })}
       </div>
     </div>
   );

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -216,21 +216,33 @@ the list for `WorkflowRunDetail`, which hosts the run through `AgentsSection`
 is one explicit click from there, never an automatic redirect. The trail back is
 the breadcrumb `Overview > Workflows > {WorkflowName}`.
 
+### The plans lens has two levels
+
+`PlanStudio` reads like the Workflows and Agents lenses, one level at a time,
+never a rail plus a detail at once. The list shows the active plans, then an
+unconditional "Consumed" `CountToggle` row (it self-hides at a zero count,
+same as the Workflows and Resolve lenses), then the revealed consumed plans
+when the toggle is on. A plan with no active siblings still shows the
+"Nothing active" empty state, with the toggle as its own row underneath it,
+never inside the empty state's action slot: the toggle is a lens-wide control,
+not an action scoped to that one empty state. Selecting a card writes
+`focusedPlanId` and swaps the list for the plan body in a `FocusedPane`, with
+`WorkSurfaceBackButton` as its only header action. There is no sibling
+"other plans" panel: the list is the only way back.
+
 ### Sibling panels inside a lens
 
-Five surfaces open their detail to the right of the content instead of taking a
+Four surfaces open their detail to the right of the content instead of taking a
 studio rail: `AgentInspector` (from an agent row's "Details" action in the Agents
 lens and from a resolver row's "Details" action in the Resolve lens, since it is
 one component for both: it adds `ResolverSections` when the agent classifies as a
 resolver), `SlotHistoryPanel` in `SlotPane` (the history trigger in the pane
 header of the Goal, Decisions, and Session summary lenses, rendered only when
-that slot has history), `ScriptDetail`/`ScriptEditor` in `ScriptsPanel` (clicking
-a script row opens `ScriptDetail`, whose Edit button swaps the same panel to
-`ScriptEditor`; that is the only route to the editor), and `PlanListPanel` in
-`PlanStudio` (the "Other plans (N)" trigger in the pane header, rendered only
-when the session holds more than one plan).
+that slot has history), and `ScriptDetail`/`ScriptEditor` in `ScriptsPanel`
+(clicking a script row opens `ScriptDetail`, whose Edit button swaps the same
+panel to `ScriptEditor`; that is the only route to the editor).
 
-`WorkflowStepInspector` in `WorkflowRunDetail` is the fifth.
+`WorkflowStepInspector` in `WorkflowRunDetail` is the fourth.
 
 `AgentInspector`, `SlotHistoryPanel`, and `ScriptDetail`/`ScriptEditor` share one
 primitive, `InspectorSplit`
@@ -238,9 +250,7 @@ primitive, `InspectorSplit`
 a sibling column resizable via a `ResizeHandle` (width persisted at
 `STORAGE_KEYS.inspectorPanelWidth`), open state is local to the pane, the panel
 loads or refreshes its data when it opens, and it closes from its own header.
-`PlanListPanel` predates this primitive and stays a fixed-width column behind a
-plain `<Divider>`. Reuse `InspectorSplit` for the next detail surface rather
-than adding a rail.
+Reuse `InspectorSplit` for the next detail surface rather than adding a rail.
 
 `ScriptsPanel` is the one consumer that nests the split _inside_ its
 `PaneShell` rather than wrapping it, because the same component also mounts in


### PR DESCRIPTION
## What changed

**(a) #1263 Collapsed board control invisible**

`LensColumn/index.tsx`: the collapsed sidebar's icon-only "Back to board" button now uses the same `primary` tint (`tintClasses('primary')`) as its expanded twin in `WorkspacesSidebar/index.tsx`, instead of `text-muted-foreground`.

Measurement for the vertical misalignment: built a static reproduction of the exact Tailwind classes for both buttons (documented below since browser tooling in this environment could not load a local file reliably). The root cause is not a flex/baseline bug: `items-center` on the row centers both buttons' boxes correctly, so their icons land on the same mathematical centerline regardless of box height. The real, visible defect is a **padding-token and content-model mismatch**: `BOARD_ICON_BUTTON` used an ad hoc `p-1.5` around a bare 14px icon (26px total button height), while the Overview row uses the shared `PANE_RHYTHM.navRail.row` (`px-2 py-1.5`) token around an icon-plus-label pair whose label line box is 20px tall (32px total button height). The two buttons therefore had different footprints (26px vs 32px), which reads as misalignment at a glance even though the flexbox math centers them. Fixed by giving the board button the same `PANE_RHYTHM.navRail.row` padding token and wrapping its icon in a `h-5 w-5` slot (matching the Overview icon span's effective height), so both buttons now share an identical 32px box.

Kept the change scoped to the button's classes and the row wrapper; did not otherwise touch `LensColumn`.

**(b) #1262 GitHub PR card is a dead click**

Root cause, verified against the code: `LinkedWorkRow`'s row body was always a real, focusable `<button>` with `onClick`; the "dead click" was that clicking the already-selected PR row called `selectSessionPr` with the number it already had selected, which is a visible no-op. Confirmed the original "no onClick" theory is false and the row already follows the no-nested-button precedent from `GitlabMrStrip.tsx`/`BitbucketPrStrip.tsx` (single button, actions carved out as siblings).

Fix in `PrPane.tsx`: `LinkedPullRequestsSection` now takes an `onOpenSelected` callback (wired to the same `onOpenStudio` the header "Review this pull request" button already uses). When a row's PR number matches the currently selected number, clicking it calls `onOpenSelected()` instead of `onSelect()`. Non-selected rows behave exactly as before (switch selection). Updated the row's `aria-label`/tooltip to say "Open pull request #N" / "Open this pull request" when it is the selected row, versus "Show pull request #N" / "Show this pull request instead" otherwise, so the accessible name matches what the click actually does.

Kept the header "Review this pull request" action: `HeaderBand` is a pane toolbar per the card/pane grammar in DESIGN.md, and removing it would leave the pane with no visible navigation action when reached in isolation.

Did not touch `LinkedWorkRow`, `PullRequestChecks`, `deriveChecks`, `deriveStateKind`, or anything in `packages/core/src/github/`.

**(c) #1265 Plans consumed toggle in the wrong place**

Read all three precedents (`WorkflowsPane.tsx`, `StandaloneAgentsLane`/`AgentsPane.tsx`, `ResolverAgentsLane`/`ResolvePane.tsx`) before touching `PlanStudio`. Copied `WorkflowsPane.tsx`'s literal structure, since `PlanStudio`'s list view has no split inspector panel: empty state(s), then the active list, then an **unconditional** `CountToggle` row (`<div className="flex justify-center">`), then the revealed consumed list. `CountToggle` self-hides at `count === 0`, so no extra visibility gating is needed in the JSX.

`PlanStudio/index.tsx` changes:
- Removed the `CountToggle` from the "Nothing active" `LensEmptyState`'s `action` slot.
- Removed the `active.length > 0` gate around the row-based `CountToggle`, so it always renders (self-hiding at zero count), matching Workflows/Agents/Resolve, both for the "nothing active" empty case and the "one or more active plans" case the owner asked to double check.

## Tests added

- `LensColumn/index.test.tsx`: two new tests, the collapsed board button carries the primary tint classes, and it shares the `py-1.5` row-padding token with the Overview row.
- `PrPane.test.tsx`: one new test clicking the already-selected PR row and asserting it dispatches `goodboy:open-github-session` and does not call `selectSessionPr`. Rewrote three existing assertions (`Show pull request #42` to `Open pull request #42`, twice) because they were asserting on a row that is the selected PR in those fixtures, so their accessible name now differs; this is not a behavior pin, it reflects the label now describing what the click does.
- `PlanStudio/index.test.tsx`: three new tests, the consumed toggle renders outside the "Nothing active" empty-state card (`.border-dashed` wrapper) and still works when clicked, the toggle also renders alongside one or more active plans, and clicking a plan row in the list calls `setFocusedPlanId`. These paths had zero prior coverage.

All three test files, plus the full desktop suite (`apps/desktop`, 573 files / 4800 tests), `pnpm typecheck`, and `pnpm knip --include files,duplicates,unlisted` pass locally.

## Docs

`docs/navigation.md`: `PlanListPanel` and the "Other plans (N)" trigger were deleted in #1234 but still described in the "Sibling panels inside a lens" section (five surfaces, `InspectorSplit` note). Removed those references, renumbered the sibling-panel count from five to four, and added a new "The plans lens has two levels" section describing the current list/`FocusedPane` shape and the unconditional Consumed toggle. Checked the file's "Back to board" description (line 21-22) against change (a): it only describes the expanded `WorkspacesSidebar` control, which did not change behavior, so it needed no edit.

## Honesty

The local file-based browser harness I built to measure the LensColumn alignment issue did not render reliably in this sandbox (navigate/get_page_text calls errored against a `file://` URL), so the measurement above is a manual, exact computation from the Tailwind utility values in play (`px-2 py-1.5`, `p-1.5`, `text-sm` line-height, icon sizes), not a live pixel measurement. I could not exercise this against the running Tauri app (no live tenant/session data in this environment), so the visual result is inferred from the box model, not screenshotted.

Closes #1263
Closes #1262
Closes #1265