### PR TITLE
refactor(desktop): let github, gitlab and bitbucket coexist

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -68,7 +68,7 @@ import {
 } from './store';
 import { useGithubPolling } from './features/github/hooks/useGithubPolling';
 import { useUpdaterPolling } from './features/updater/hooks/useUpdaterPolling';
-import { useWorkspaceRemoteHostKind } from './features/worktree/useWorkspaceRemoteHostKind';
+import { useGithubConnection } from './features/integrations/github/useGithubConnection';
 import { resolveSessionRepo } from './store/slices/worktrees/resolveSessionRepo';
 import { resolveOpenDiffViewerEvent } from './store/slices/session-view/openDiffViewerEvent';
 import { useSessionSidebarVisibility } from './features/workspace/hooks/useSessionSidebarVisibility';
@@ -89,7 +89,7 @@ export const App = () => {
   const currentSession = useCurrentSession();
   const hasActiveSession = currentSession != null;
   const sessionSidebar = useSessionSidebarVisibility({ hasActiveSession });
-  const remoteKind = useWorkspaceRemoteHostKind({ workspaceId: currentWorkspace?.id ?? null });
+  const githubConnection = useGithubConnection({ workspaceId: currentWorkspace?.id ?? null });
   const hasLinear = useAppStore((s) =>
     (s.workspaceIntegrations?.[currentWorkspace?.id ?? ('' as WorkspaceId)] ?? []).some(
       (i) => i.provider === 'linear',
@@ -779,7 +779,7 @@ export const App = () => {
                 activeStudio={activeStudio}
                 isSimpleWorkspace={currentWorkspace.kind === 'simple'}
                 onConvertToDevProject={() => setConvertWorkspaceOpen(true)}
-                githubEnabled={remoteKind === 'github'}
+                githubEnabled={githubConnection.isAuthenticated}
                 linearEnabled={hasLinear}
                 jiraEnabled={hasJira}
                 sentryEnabled={hasSentry}

--- a/apps/desktop/src/__tests__/footer-studio-reachability.test.tsx
+++ b/apps/desktop/src/__tests__/footer-studio-reachability.test.tsx
@@ -5,6 +5,8 @@ import { useEffect } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 
+const { githubAuth } = vi.hoisted(() => ({ githubAuth: { isAuthenticated: false } }));
+
 const { state, workspace } = vi.hoisted(() => {
   const currentWorkspace = {
     id: 'workspace-1',
@@ -55,10 +57,19 @@ type FooterProps = {
   readonly slackEnabled: boolean;
   readonly onOpenBitbucket: () => void;
   readonly bitbucketEnabled: boolean;
+  readonly onOpenGithub: () => void;
+  readonly githubEnabled: boolean;
 };
 
 vi.mock('../app/components/AppFooter', () => ({
-  AppFooter: ({ onOpenSlack, slackEnabled, onOpenBitbucket, bitbucketEnabled }: FooterProps) => (
+  AppFooter: ({
+    onOpenSlack,
+    slackEnabled,
+    onOpenBitbucket,
+    bitbucketEnabled,
+    onOpenGithub,
+    githubEnabled,
+  }: FooterProps) => (
     <>
       <button type="button" onClick={onOpenSlack}>
         {slackEnabled ? 'Launch a session from a Slack thread' : 'Connect Slack'}
@@ -66,8 +77,19 @@ vi.mock('../app/components/AppFooter', () => ({
       <button type="button" onClick={onOpenBitbucket}>
         {bitbucketEnabled ? 'Review pull requests across this workspace' : 'Connect Bitbucket'}
       </button>
+      <button type="button" onClick={onOpenGithub}>
+        {githubEnabled ? 'Review pull requests and issues' : 'Connect GitHub'}
+      </button>
     </>
   ),
+}));
+
+vi.mock('../features/integrations/github/useGithubConnection', () => ({
+  useGithubConnection: () => ({
+    isAuthenticated: githubAuth.isAuthenticated,
+    isResolved: true,
+    refresh: vi.fn(),
+  }),
 }));
 
 vi.mock('../features/integrations/slack/SlackStudio', () => ({
@@ -128,7 +150,11 @@ vi.mock('../features/workspace/components/WorkspaceSwitcher', () => ({
 vi.mock('../features/workspace/window', () => ({ isMainWindow: () => true }));
 vi.mock('../features/workflows/components/WorkflowStudio', () => ({ WorkflowStudio: () => null }));
 vi.mock('../features/session/components/NewSessionView', () => ({ NewSessionView: () => null }));
-vi.mock('../features/github/components/GitHubStudio', () => ({ GitHubStudio: () => null }));
+vi.mock('../features/github/components/GitHubStudio', () => ({
+  GitHubStudio: ({ workspaceName }: { workspaceName: string }) => (
+    <div data-testid="github-studio">{workspaceName}</div>
+  ),
+}));
 vi.mock('../features/integrations/linear/LinearStudio', () => ({ LinearStudio: () => null }));
 vi.mock('../features/integrations/sentry/SentryStudio', () => ({ SentryStudio: () => null }));
 vi.mock('../features/integrations/gitlab/GitlabStudio', () => ({ GitlabStudio: () => null }));
@@ -179,6 +205,7 @@ import { App } from '../App';
 
 beforeEach(() => {
   state.workspaceIntegrations = {};
+  githubAuth.isAuthenticated = false;
 });
 
 afterEach(cleanup);
@@ -200,6 +227,32 @@ describe('Slack studio reachability', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Connect Slack' }));
 
     expect(screen.getByTestId('slack-studio')).toBeDefined();
+  });
+});
+
+describe('GitHub footer state', () => {
+  it('lights the footer glyph from the workspace credential, whatever the remote is', () => {
+    githubAuth.isAuthenticated = true;
+    state.workspaceIntegrations = { 'workspace-1': [{ provider: 'gitlab' }] };
+    render(<App />);
+
+    expect(screen.getByRole('button', { name: 'Review pull requests and issues' })).toBeDefined();
+    expect(screen.queryByRole('button', { name: 'Connect GitHub' })).toBeNull();
+  });
+
+  it('leaves the glyph unlit when no github credential resolves', () => {
+    render(<App />);
+
+    expect(screen.getByRole('button', { name: 'Connect GitHub' })).toBeDefined();
+    expect(screen.queryByRole('button', { name: 'Review pull requests and issues' })).toBeNull();
+  });
+
+  it('still opens the studio when github is not connected, so the connect form is reachable', () => {
+    render(<App />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Connect GitHub' }));
+
+    expect(screen.getByTestId('github-studio').textContent).toBe('Workspace');
   });
 });
 

--- a/apps/desktop/src/features/github/components/GitHubStudio/index.test.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/index.test.tsx
@@ -201,4 +201,14 @@ describe('GitHubStudio', () => {
     expect(screen.getByLabelText('Personal access token')).toBeDefined();
     expect(screen.queryByText(/does not have a GitHub remote/i)).toBeNull();
   });
+
+  it('offers token controls without a GitHub remote, so the token stays enterable here', () => {
+    h.isGithubAuthenticated = false;
+    h.remoteKind = null;
+
+    renderStudio();
+
+    expect(screen.getByLabelText('Personal access token')).toBeDefined();
+    expect(screen.queryByText(/does not have a GitHub remote/i)).toBeNull();
+  });
 });

--- a/apps/desktop/src/features/github/components/GitHubStudio/index.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/index.tsx
@@ -57,15 +57,16 @@ export const GitHubStudio = ({
   const groups = useGithubInbox();
   const remoteKind = useWorkspaceRemoteHostKind({ workspaceId });
   const githubConnection = useGithubConnection({ workspaceId });
-  const isConnected = resolveIntegrationConnection({
+  const hasGithubRemote = remoteKind === 'github';
+  const isGithubConnected = resolveIntegrationConnection({
     provider: 'github',
     integrations: [],
-    remoteKind,
     externalTasks: [],
     isGithubAuthenticated:
       githubConnection.isResolved === false || githubConnection.isAuthenticated,
   }).isConnected;
-  const issues = useGithubIssues({ workspaceId, rootPath, isEnabled: isConnected });
+  const canBrowseRepo = isGithubConnected && hasGithubRemote;
+  const issues = useGithubIssues({ workspaceId, rootPath, isEnabled: canBrowseRepo });
   const [focused, setFocused] = useState<SessionId | null>(initialSessionId);
   const [focusedIssue, setFocusedIssue] = useState<GithubIssue | null>(null);
   const [tab, setTab] = useState<Tab>(initialIssueExternalId == null ? 'pull-requests' : 'issues');
@@ -133,7 +134,7 @@ export const GitHubStudio = ({
       workspaceName={workspaceName}
       closeLabel="close github studio"
       headerAccessory={
-        isConnected ? (
+        canBrowseRepo ? (
           <div className="flex items-center gap-2">
             <SegmentedTabs
               ariaLabel="GitHub work"
@@ -156,11 +157,11 @@ export const GitHubStudio = ({
       onClose={onClose}
     >
       {(requestClose) =>
-        !isConnected ? (
+        !canBrowseRepo ? (
           <div className="flex min-h-0 flex-1 items-center justify-center p-5">
             <GithubConnectionEmptyState
               workspaceId={workspaceId}
-              hasGithubRemote={remoteKind === 'github'}
+              hasGithubRemote={hasGithubRemote}
               onConnected={() => void githubConnection.refresh()}
               shouldAutoFocus
               wrapped={false}

--- a/apps/desktop/src/features/github/components/GitHubStudio/index.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/index.tsx
@@ -161,7 +161,7 @@ export const GitHubStudio = ({
           <div className="flex min-h-0 flex-1 items-center justify-center p-5">
             <GithubConnectionEmptyState
               workspaceId={workspaceId}
-              hasGithubRemote={hasGithubRemote}
+              isConnected={isGithubConnected}
               onConnected={() => void githubConnection.refresh()}
               shouldAutoFocus
               wrapped={false}

--- a/apps/desktop/src/features/github/components/GithubConnectionEmptyState.tsx
+++ b/apps/desktop/src/features/github/components/GithubConnectionEmptyState.tsx
@@ -4,7 +4,7 @@ import { MissingGithubTokenEmptyState } from './MissingGithubTokenEmptyState';
 
 type Props = {
   readonly workspaceId: WorkspaceId;
-  readonly hasGithubRemote: boolean;
+  readonly isConnected: boolean;
   readonly compact?: boolean;
   readonly onConnected: () => void;
   readonly shouldAutoFocus?: boolean;
@@ -13,23 +13,23 @@ type Props = {
 
 export const GithubConnectionEmptyState = ({
   workspaceId,
-  hasGithubRemote,
+  isConnected,
   compact = false,
   onConnected,
   shouldAutoFocus = false,
   wrapped = true,
 }: Props) => {
-  if (hasGithubRemote === false) {
-    return <MissingGithubRemoteEmptyState compact={compact} wrapped={wrapped} />;
+  if (isConnected === false) {
+    return (
+      <MissingGithubTokenEmptyState
+        workspaceId={workspaceId}
+        compact={compact}
+        onConnected={onConnected}
+        shouldAutoFocus={shouldAutoFocus}
+        wrapped={wrapped}
+      />
+    );
   }
 
-  return (
-    <MissingGithubTokenEmptyState
-      workspaceId={workspaceId}
-      compact={compact}
-      onConnected={onConnected}
-      shouldAutoFocus={shouldAutoFocus}
-      wrapped={wrapped}
-    />
-  );
+  return <MissingGithubRemoteEmptyState compact={compact} wrapped={wrapped} />;
 };

--- a/apps/desktop/src/features/github/components/Panel/index.test.tsx
+++ b/apps/desktop/src/features/github/components/Panel/index.test.tsx
@@ -68,6 +68,14 @@ describe('GithubPanel', () => {
     expect(state.setGithubPat).toHaveBeenCalledWith('ghp_token');
   });
 
+  it('describes where the token goes without claiming it stays on the machine', () => {
+    state.githubStatus = { available: true, mode: 'absent' };
+    render(<GithubPanel />);
+
+    expect(document.body.textContent).toContain('never touches Goodboy');
+    expect(document.body.textContent).not.toContain('never leaves your machine');
+  });
+
   it('shows connected user info when status is connected', () => {
     state.githubStatus = { available: true, mode: 'connected', user: 'amin' };
     render(<GithubPanel />);

--- a/apps/desktop/src/features/github/components/Panel/index.tsx
+++ b/apps/desktop/src/features/github/components/Panel/index.tsx
@@ -183,8 +183,8 @@ function Absent({
       ) : null}
       <CreateTokenLink />
       <p className="text-3xs text-muted-foreground">
-        token is stored in your OS keychain via the system credential store. it never leaves your
-        machine.
+        token is stored in your OS keychain via the system credential store. Goodboy sends it
+        directly to GitHub over HTTPS; it never touches Goodboy&apos;s own servers.
       </p>
     </div>
   );

--- a/apps/desktop/src/features/integrations/bitbucket/BitbucketFormBody.test.tsx
+++ b/apps/desktop/src/features/integrations/bitbucket/BitbucketFormBody.test.tsx
@@ -107,4 +107,11 @@ describe('BitbucketFormBody', () => {
       expect(state.disconnectBitbucket).toHaveBeenCalledWith({ workspaceId: WS_ID });
     });
   });
+
+  it('says where the token travels instead of claiming it never leaves', () => {
+    render(<BitbucketFormBody workspaceId={WS_ID} />);
+    expect(screen.getByText(/never touches Goodboy's own servers/i)).toBeDefined();
+    expect(screen.queryByText(/never leaves this machine/i)).toBeNull();
+    expect(screen.queryByText(/never leaving this machine/i)).toBeNull();
+  });
 });

--- a/apps/desktop/src/features/integrations/bitbucket/BitbucketFormBody.tsx
+++ b/apps/desktop/src/features/integrations/bitbucket/BitbucketFormBody.tsx
@@ -151,8 +151,9 @@ export const BitbucketFormBody = ({ workspaceId, onConnected, shouldAutoFocus = 
           <p className="text-2xs leading-relaxed text-muted-foreground">
             Bitbucket Cloud only, Data Center and Server are not supported. An older Bitbucket app
             password works in the same field while Atlassian keeps it alive. The secret carries your
-            own Bitbucket permissions and is stored encrypted in your operating system keychain,
-            never leaving this machine.
+            own Bitbucket permissions and is stored encrypted in your operating system keychain.
+            Goodboy sends it directly to Bitbucket over HTTPS; it never touches Goodboy&apos;s own
+            servers.
           </p>
         </>
       )}

--- a/apps/desktop/src/features/integrations/bitbucket/BitbucketWorkspaceStudio/index.tsx
+++ b/apps/desktop/src/features/integrations/bitbucket/BitbucketWorkspaceStudio/index.tsx
@@ -27,7 +27,6 @@ export const BitbucketWorkspaceStudio = ({ workspaceId, workspaceName, onClose }
   const isConnected = resolveIntegrationConnection({
     provider: 'bitbucket',
     integrations,
-    remoteKind: null,
     externalTasks: EMPTY_ARRAY,
     isGithubAuthenticated: false,
   }).isConnected;

--- a/apps/desktop/src/features/integrations/connection.test.ts
+++ b/apps/desktop/src/features/integrations/connection.test.ts
@@ -25,28 +25,24 @@ describe('resolveIntegrationConnection', () => {
     const connected = resolveIntegrationConnection({
       provider: 'linear',
       integrations: [integration({ provider: 'linear' })],
-      remoteKind: 'other',
       externalTasks: [],
       isGithubAuthenticated: false,
     });
     const linkedOnly = resolveIntegrationConnection({
       provider: 'sentry',
       integrations: [],
-      remoteKind: 'other',
       externalTasks: [task({ provider: 'sentry' })],
       isGithubAuthenticated: false,
     });
     const jiraConnected = resolveIntegrationConnection({
       provider: 'jira',
       integrations: [integration({ provider: 'jira' })],
-      remoteKind: 'other',
       externalTasks: [],
       isGithubAuthenticated: false,
     });
     const unavailable = resolveIntegrationConnection({
       provider: 'gitlab',
       integrations: [],
-      remoteKind: 'github',
       externalTasks: [],
       isGithubAuthenticated: false,
     });
@@ -59,40 +55,54 @@ describe('resolveIntegrationConnection', () => {
     });
   });
 
-  it('uses workspace remotes for pull request and GitHub availability', () => {
+  it('connects GitHub and GitLab from credentials alone, whatever the remote is', () => {
     const github = resolveIntegrationConnection({
       provider: 'github',
-      integrations: [],
-      remoteKind: 'github',
+      integrations: [integration({ provider: 'gitlab' })],
       externalTasks: [],
       isGithubAuthenticated: true,
     });
+    const gitlab = resolveIntegrationConnection({
+      provider: 'gitlab',
+      integrations: [integration({ provider: 'gitlab' })],
+      externalTasks: [],
+      isGithubAuthenticated: true,
+    });
+    const bothHostsPr = resolveIntegrationConnection({
+      provider: 'pr',
+      integrations: [integration({ provider: 'gitlab' })],
+      externalTasks: [],
+      isGithubAuthenticated: true,
+    });
+
+    expect({ github, gitlab, bothHostsPr }).toEqual({
+      github: { isConnected: true, isAvailable: true },
+      gitlab: { isConnected: true, isAvailable: true },
+      bothHostsPr: { isConnected: true, isAvailable: true },
+    });
+  });
+
+  it('connects the pull request surface from a GitLab credential with no GitLab remote', () => {
     const gitlabPr = resolveIntegrationConnection({
       provider: 'pr',
       integrations: [integration({ provider: 'gitlab' })],
-      remoteKind: 'gitlab',
       externalTasks: [],
       isGithubAuthenticated: false,
     });
 
-    expect({ github, gitlabPr }).toEqual({
-      github: { isConnected: true, isAvailable: true },
-      gitlabPr: { isConnected: true, isAvailable: true },
-    });
+    expect(gitlabPr).toEqual({ isConnected: true, isAvailable: true });
   });
 
   it('connects bitbucket from the workspace integration alone, whatever the remote is', () => {
     const connected = resolveIntegrationConnection({
       provider: 'bitbucket',
       integrations: [integration({ provider: 'bitbucket' })],
-      remoteKind: 'other',
       externalTasks: [],
       isGithubAuthenticated: false,
     });
     const missing = resolveIntegrationConnection({
       provider: 'bitbucket',
       integrations: [],
-      remoteKind: 'other',
       externalTasks: [],
       isGithubAuthenticated: false,
     });
@@ -103,11 +113,10 @@ describe('resolveIntegrationConnection', () => {
     });
   });
 
-  it('does not treat a GitHub remote as an authenticated connection', () => {
+  it('leaves GitHub disconnected without a credential, remote or not', () => {
     const github = resolveIntegrationConnection({
       provider: 'github',
       integrations: [],
-      remoteKind: 'github',
       externalTasks: [],
       isGithubAuthenticated: false,
     });

--- a/apps/desktop/src/features/integrations/connection.ts
+++ b/apps/desktop/src/features/integrations/connection.ts
@@ -3,14 +3,12 @@ import type {
   SessionExternalTaskProvider,
   WorkspaceIntegration,
 } from '@goodboy/types';
-import type { RemoteHostKind } from '../../shared/lib/remoteHost';
 
 type Provider = SessionExternalTaskProvider | 'pr';
 
 type Params = {
   readonly provider: Provider;
   readonly integrations: ReadonlyArray<WorkspaceIntegration>;
-  readonly remoteKind: RemoteHostKind | null;
   readonly externalTasks: ReadonlyArray<SessionExternalTask>;
   readonly isGithubAuthenticated: boolean;
 };
@@ -23,7 +21,6 @@ type Result = {
 export const resolveIntegrationConnection = ({
   provider,
   integrations,
-  remoteKind,
   externalTasks,
   isGithubAuthenticated,
 }: Params): Result => {
@@ -33,8 +30,6 @@ export const resolveIntegrationConnection = ({
   const hasJira = integrations.some((integration) => integration.provider === 'jira');
   const hasBitbucket = integrations.some((integration) => integration.provider === 'bitbucket');
   const hasSlack = integrations.some((integration) => integration.provider === 'slack');
-  const hasGithubRemote = remoteKind === 'github';
-  const hasGitlabRemote = remoteKind === 'gitlab';
 
   let isConnected: boolean;
   let hasLinkedTask: boolean;
@@ -57,7 +52,7 @@ export const resolveIntegrationConnection = ({
       hasLinkedTask = externalTasks.some((task) => task.provider === 'jira');
       break;
     case 'github':
-      isConnected = hasGithubRemote && isGithubAuthenticated;
+      isConnected = isGithubAuthenticated;
       hasLinkedTask = externalTasks.some((task) => task.provider === 'github');
       break;
     case 'bitbucket':
@@ -69,10 +64,7 @@ export const resolveIntegrationConnection = ({
       hasLinkedTask = externalTasks.some((task) => task.provider === 'slack');
       break;
     case 'pr':
-      isConnected =
-        (hasGithubRemote && isGithubAuthenticated) ||
-        (hasGitlabRemote && hasGitlab) ||
-        hasBitbucket;
+      isConnected = isGithubAuthenticated || hasGitlab || hasBitbucket;
       hasLinkedTask = externalTasks.some(
         (task) =>
           task.provider === 'github' || task.provider === 'gitlab' || task.provider === 'bitbucket',

--- a/apps/desktop/src/features/integrations/fetchIssueCandidates.test.ts
+++ b/apps/desktop/src/features/integrations/fetchIssueCandidates.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { WorkspaceId } from '@goodboy/types';
+
+const h = vi.hoisted(() => ({
+  detectRepoSlug: vi.fn(),
+  ghAssignedIssues: vi.fn(),
+}));
+
+vi.mock('@goodboy/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@goodboy/core')>();
+  return { ...actual, detectRepoSlug: h.detectRepoSlug };
+});
+
+vi.mock('../github/github', () => ({
+  tauriGhRunner: {},
+  ghAssignedIssues: h.ghAssignedIssues,
+}));
+
+import { fetchIssueCandidates } from './fetchIssueCandidates';
+
+const WORKSPACE_ID = 'ws-1' as WorkspaceId;
+
+beforeEach(() => {
+  h.detectRepoSlug.mockReset();
+  h.ghAssignedIssues.mockReset();
+  h.ghAssignedIssues.mockResolvedValue([]);
+});
+
+describe('fetchIssueCandidates for github', () => {
+  it('explains itself instead of returning an unexplained empty list off a github remote', async () => {
+    h.detectRepoSlug.mockResolvedValue(null);
+
+    await expect(
+      fetchIssueCandidates({
+        provider: 'github',
+        workspaceId: WORKSPACE_ID,
+        rootPath: '/repo',
+        gitlabHost: null,
+        jiraConfig: null,
+      }),
+    ).rejects.toThrow(/No GitHub repository resolved/);
+    expect(h.ghAssignedIssues).not.toHaveBeenCalled();
+  });
+
+  it('maps assigned issues when the repository resolves', async () => {
+    h.detectRepoSlug.mockResolvedValue('acme/web');
+    h.ghAssignedIssues.mockResolvedValue([
+      {
+        number: 42,
+        title: 'Fix the router',
+        body: '',
+        url: 'https://github.com/acme/web/issues/42',
+        state: 'OPEN',
+        labels: [],
+        updatedAt: '2026-08-01T00:00:00Z',
+      },
+    ]);
+
+    const rows = await fetchIssueCandidates({
+      provider: 'github',
+      workspaceId: WORKSPACE_ID,
+      rootPath: '/repo',
+      gitlabHost: null,
+      jiraConfig: null,
+    });
+
+    expect(rows.map((row) => row.identifier)).toEqual(['#42']);
+  });
+});

--- a/apps/desktop/src/features/integrations/fetchIssueCandidates.ts
+++ b/apps/desktop/src/features/integrations/fetchIssueCandidates.ts
@@ -66,7 +66,9 @@ export const fetchIssueCandidates = async ({
       }
       const slug = await detectRepoSlug(tauriGhRunner, rootPath, workspaceId);
       if (slug == null) {
-        return [];
+        throw new Error(
+          'No GitHub repository resolved for this workspace, so there are no issues to list here.',
+        );
       }
       const issues = await ghAssignedIssues(slug, { cwd: rootPath, workspaceId });
       return issues.map((issue) => ({

--- a/apps/desktop/src/features/integrations/github/GithubFormBody.test.tsx
+++ b/apps/desktop/src/features/integrations/github/GithubFormBody.test.tsx
@@ -129,22 +129,32 @@ describe('GithubFormBody', () => {
     });
   });
 
-  describe('when GitLab is connected (mutual exclusivity)', () => {
+  describe('when GitLab is connected', () => {
     beforeEach(() => {
       state.workspaceIntegrations = { [WS_ID]: [gitlabIntegration] };
     });
 
-    it('shows the mutex banner and no token form', async () => {
+    it('still offers the token form so both hosts can coexist', async () => {
       render(<GithubFormBody workspaceId={WS_ID} />);
-      expect(await screen.findByText(/Disconnect GitLab to use a GitHub token/i)).toBeDefined();
-      expect(screen.queryByLabelText(/GitHub personal access token/i)).toBeNull();
-      expect(screen.queryByRole('button', { name: /^connect$/i })).toBeNull();
+      expect(await screen.findByLabelText(/GitHub personal access token/i)).toBeDefined();
+      expect(screen.getByRole('button', { name: /^connect$/i })).toBeDefined();
+      expect(screen.queryByText(/Disconnect GitLab/i)).toBeNull();
     });
 
-    it('disconnects GitLab when the banner action is clicked', async () => {
+    it('connects GitHub without touching the GitLab integration', async () => {
       render(<GithubFormBody workspaceId={WS_ID} />);
-      fireEvent.click(await screen.findByRole('button', { name: /disconnect gitlab/i }));
-      expect(state.disconnectGitlab).toHaveBeenCalledWith(WS_ID);
+      fireEvent.change(await screen.findByLabelText(/GitHub personal access token/i), {
+        target: { value: 'ghp_abc' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: /^connect$/i }));
+      await waitFor(() => expect(ghSetTokenMock).toHaveBeenCalledWith('ghp_abc', WS_ID));
+      expect(state.disconnectGitlab).not.toHaveBeenCalled();
     });
+  });
+
+  it('does not claim the token never leaves this machine', async () => {
+    render(<GithubFormBody workspaceId={WS_ID} />);
+    await screen.findByLabelText(/GitHub personal access token/i);
+    expect(screen.queryByText(/never leaves this machine/i)).toBeNull();
   });
 });

--- a/apps/desktop/src/features/integrations/github/GithubFormBody.tsx
+++ b/apps/desktop/src/features/integrations/github/GithubFormBody.tsx
@@ -5,6 +5,7 @@ import type { GhTokenStatus, WorkspaceId } from '@goodboy/types';
 import { ghClearToken, ghSetToken, ghStatus } from '../../github/github';
 import { formatError } from '../../../shared/lib/errors';
 import { CreateTokenLink } from './CreateTokenLink';
+import { notifyGithubConnectionChanged } from './useGithubConnection';
 
 type Props = {
   workspaceId: WorkspaceId;
@@ -37,6 +38,7 @@ export const GithubFormBody = ({ workspaceId, onConnected, shouldAutoFocus = fal
       await ghSetToken(token.trim(), workspaceId);
       setToken('');
       await refresh();
+      notifyGithubConnectionChanged();
       onConnected?.();
     } catch (err) {
       setError(formatError(err));
@@ -51,6 +53,7 @@ export const GithubFormBody = ({ workspaceId, onConnected, shouldAutoFocus = fal
     try {
       await ghClearToken(workspaceId);
       await refresh();
+      notifyGithubConnectionChanged();
     } catch (err) {
       setError(formatError(err));
     } finally {

--- a/apps/desktop/src/features/integrations/github/GithubFormBody.tsx
+++ b/apps/desktop/src/features/integrations/github/GithubFormBody.tsx
@@ -1,10 +1,8 @@
 import { useCallback, useEffect, useState } from 'react';
-import { useShallow } from 'zustand/react/shallow';
 import { Button, Input } from '@goodboy/ui';
 import { CheckCircle2, Unplug } from 'lucide-react';
 import type { GhTokenStatus, WorkspaceId } from '@goodboy/types';
 import { ghClearToken, ghSetToken, ghStatus } from '../../github/github';
-import { useAppStore } from '../../../store';
 import { formatError } from '../../../shared/lib/errors';
 import { CreateTokenLink } from './CreateTokenLink';
 
@@ -19,13 +17,6 @@ export const GithubFormBody = ({ workspaceId, onConnected, shouldAutoFocus = fal
   const [token, setToken] = useState('');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
-
-  const gitlabConnected = useAppStore(
-    useShallow((s) =>
-      (s.workspaceIntegrations[workspaceId] ?? []).some((i) => i.provider === 'gitlab'),
-    ),
-  );
-  const disconnectGitlab = useAppStore((s) => s.disconnectGitlab);
 
   const refresh = useCallback(async () => {
     try {
@@ -85,21 +76,6 @@ export const GithubFormBody = ({ workspaceId, onConnected, shouldAutoFocus = fal
             {busy ? 'Disconnecting…' : 'Disconnect'}
           </Button>
         </div>
-      ) : gitlabConnected ? (
-        <div className="flex flex-col gap-3 rounded-lg border border-border-soft bg-subtle/40 p-4">
-          <p className="text-xs leading-relaxed text-muted-foreground">
-            GitLab is connected for this workspace. Disconnect GitLab to use a GitHub token.
-          </p>
-          <Button
-            variant="danger"
-            size="sm"
-            onClick={() => void disconnectGitlab(workspaceId)}
-            disabled={busy}
-          >
-            <Unplug size={12} aria-hidden />
-            Disconnect GitLab
-          </Button>
-        </div>
       ) : (
         <>
           <p className="text-xs leading-relaxed text-muted-foreground">
@@ -120,8 +96,8 @@ export const GithubFormBody = ({ workspaceId, onConnected, shouldAutoFocus = fal
             <CreateTokenLink />
           </div>
           <p className="text-2xs leading-relaxed text-muted-foreground">
-            The token is stored encrypted in your operating system keychain and never leaves this
-            machine.
+            The token is stored encrypted in your operating system keychain. Goodboy sends it
+            directly to GitHub over HTTPS; it never touches Goodboy&apos;s own servers.
           </p>
         </>
       )}
@@ -132,7 +108,7 @@ export const GithubFormBody = ({ workspaceId, onConnected, shouldAutoFocus = fal
         </div>
       ) : null}
 
-      {scoped || gitlabConnected ? null : (
+      {scoped ? null : (
         <div className="flex justify-end">
           <Button
             onClick={() => void onConnect()}

--- a/apps/desktop/src/features/integrations/github/useGithubConnection.events.test.ts
+++ b/apps/desktop/src/features/integrations/github/useGithubConnection.events.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
+import type { WorkspaceId } from '@goodboy/types';
+
+const WORKSPACE_ID = 'workspace-1' as WorkspaceId;
+
+const h = vi.hoisted(() => ({ ghStatus: vi.fn() }));
+
+vi.mock('../../github/github', () => ({ ghStatus: h.ghStatus }));
+
+import { useGithubConnection } from './useGithubConnection';
+
+beforeEach(() => {
+  h.ghStatus.mockReset();
+  h.ghStatus.mockResolvedValue({ available: true, mode: 'absent' });
+});
+
+afterEach(cleanup);
+
+describe('useGithubConnection', () => {
+  it('re-reads every mounted instance when one of them refreshes', async () => {
+    const first = renderHook(() => useGithubConnection({ workspaceId: WORKSPACE_ID }));
+    const second = renderHook(() => useGithubConnection({ workspaceId: WORKSPACE_ID }));
+
+    await waitFor(() => expect(first.result.current.isResolved).toBe(true));
+    await waitFor(() => expect(second.result.current.isResolved).toBe(true));
+    expect(first.result.current.isAuthenticated).toBe(false);
+    expect(second.result.current.isAuthenticated).toBe(false);
+
+    h.ghStatus.mockResolvedValue({ available: true, mode: 'connected', user: 'nbro' });
+    await act(async () => {
+      first.result.current.refresh();
+    });
+
+    await waitFor(() => expect(second.result.current.isAuthenticated).toBe(true));
+    expect(first.result.current.isAuthenticated).toBe(true);
+  });
+
+  it('stops listening once an instance unmounts', async () => {
+    const view = renderHook(() => useGithubConnection({ workspaceId: WORKSPACE_ID }));
+    await waitFor(() => expect(view.result.current.isResolved).toBe(true));
+
+    view.unmount();
+    h.ghStatus.mockClear();
+    await act(async () => {
+      window.dispatchEvent(new CustomEvent('goodboy:github-connection-changed'));
+    });
+
+    expect(h.ghStatus).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/features/integrations/github/useGithubConnection.ts
+++ b/apps/desktop/src/features/integrations/github/useGithubConnection.ts
@@ -2,6 +2,12 @@ import { useCallback, useEffect, useState } from 'react';
 import type { GhTokenStatus, WorkspaceId } from '@goodboy/types';
 import { ghStatus } from '../../github/github';
 
+export const GITHUB_CONNECTION_CHANGED_EVENT = 'goodboy:github-connection-changed';
+
+export const notifyGithubConnectionChanged = () => {
+  window.dispatchEvent(new CustomEvent(GITHUB_CONNECTION_CHANGED_EVENT));
+};
+
 type Params = {
   readonly workspaceId: WorkspaceId | null;
 };
@@ -17,7 +23,7 @@ export const useGithubConnection = ({ workspaceId }: Params) => {
     isResolved: false,
   });
 
-  const refresh = useCallback(async () => {
+  const read = useCallback(async () => {
     if (workspaceId == null) {
       setConnection({ status: null, isResolved: true });
       return;
@@ -32,8 +38,20 @@ export const useGithubConnection = ({ workspaceId }: Params) => {
 
   useEffect(() => {
     setConnection({ status: null, isResolved: false });
-    void refresh();
-  }, [refresh]);
+    void read();
+  }, [read]);
+
+  useEffect(() => {
+    const onChanged = () => {
+      void read();
+    };
+    window.addEventListener(GITHUB_CONNECTION_CHANGED_EVENT, onChanged);
+    return () => window.removeEventListener(GITHUB_CONNECTION_CHANGED_EVENT, onChanged);
+  }, [read]);
+
+  const refresh = useCallback(() => {
+    notifyGithubConnectionChanged();
+  }, []);
 
   return {
     isAuthenticated: connection.status?.mode !== 'absent' && connection.status != null,

--- a/apps/desktop/src/features/integrations/github/useGithubConnection.ts
+++ b/apps/desktop/src/features/integrations/github/useGithubConnection.ts
@@ -3,7 +3,7 @@ import type { GhTokenStatus, WorkspaceId } from '@goodboy/types';
 import { ghStatus } from '../../github/github';
 
 type Params = {
-  readonly workspaceId: WorkspaceId;
+  readonly workspaceId: WorkspaceId | null;
 };
 
 type ConnectionState = {
@@ -18,6 +18,10 @@ export const useGithubConnection = ({ workspaceId }: Params) => {
   });
 
   const refresh = useCallback(async () => {
+    if (workspaceId == null) {
+      setConnection({ status: null, isResolved: true });
+      return;
+    }
     try {
       const status = await ghStatus(workspaceId);
       setConnection({ status, isResolved: true });

--- a/apps/desktop/src/features/integrations/gitlab/GitlabFormBody.test.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabFormBody.test.tsx
@@ -137,22 +137,35 @@ describe('GitlabFormBody', () => {
     });
   });
 
-  describe('when a scoped GitHub token exists (mutual exclusivity)', () => {
+  describe('when a scoped GitHub token exists', () => {
     beforeEach(() => {
       ghStatusMock.mockResolvedValue({ scoped: true });
     });
 
-    it('shows the mutex banner and no connect form', async () => {
+    it('offers the connect form and no cross-host disconnect so both hosts coexist', async () => {
       render(<GitlabFormBody workspaceId={WS_ID} />);
-      expect(await screen.findByText(/Disconnect GitHub to use GitLab/i)).toBeDefined();
-      expect(screen.queryByLabelText(/personal access token/i)).toBeNull();
-      expect(screen.queryByRole('button', { name: /^connect$/i })).toBeNull();
+      expect(await screen.findByLabelText(/personal access token/i)).toBeDefined();
+      expect(screen.getByRole('button', { name: /^connect$/i })).toBeDefined();
+      expect(screen.queryByText(/Disconnect GitHub/i)).toBeNull();
     });
 
-    it('clears the GitHub token when the banner action is clicked', async () => {
+    it('never reads or clears the GitHub token', async () => {
       render(<GitlabFormBody workspaceId={WS_ID} />);
-      fireEvent.click(await screen.findByRole('button', { name: /disconnect github/i }));
-      await waitFor(() => expect(ghClearTokenMock).toHaveBeenCalledWith(WS_ID));
+      fireEvent.change(await screen.findByLabelText(/personal access token/i), {
+        target: { value: 'glpat-x' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: /^connect$/i }));
+      await waitFor(() =>
+        expect(state.connectGitlab).toHaveBeenCalledWith(WS_ID, 'https://gitlab.com', 'glpat-x'),
+      );
+      expect(ghStatusMock).not.toHaveBeenCalled();
+      expect(ghClearTokenMock).not.toHaveBeenCalled();
     });
+  });
+
+  it('does not claim the token never leaves this machine', async () => {
+    render(<GitlabFormBody workspaceId={WS_ID} />);
+    await screen.findByLabelText(/personal access token/i);
+    expect(screen.queryByText(/never leaves this machine/i)).toBeNull();
   });
 });

--- a/apps/desktop/src/features/integrations/gitlab/GitlabFormBody.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabFormBody.tsx
@@ -1,10 +1,9 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import type { GitlabWorkspaceIntegration, WorkspaceId } from '@goodboy/types';
 import { Button, Input } from '@goodboy/ui';
 import { CheckCircle2, ExternalLink, Unplug } from 'lucide-react';
 import { useAppStore } from '../../../store';
-import { ghClearToken, ghStatus } from '../../github/github';
 import { formatError } from '../../../shared/lib/errors';
 
 type Props = {
@@ -44,13 +43,6 @@ export const GitlabFormBody = ({ workspaceId, onConnected, shouldAutoFocus = fal
   const [token, setToken] = useState('');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [githubScoped, setGithubScoped] = useState(false);
-
-  useEffect(() => {
-    void ghStatus(workspaceId)
-      .then((status) => setGithubScoped(status.scoped ?? false))
-      .catch(() => setGithubScoped(false));
-  }, [workspaceId]);
 
   const onConnect = async () => {
     setBusy(true);
@@ -78,19 +70,6 @@ export const GitlabFormBody = ({ workspaceId, onConnected, shouldAutoFocus = fal
     }
   };
 
-  const onDisconnectGithub = async () => {
-    setBusy(true);
-    setError(null);
-    try {
-      await ghClearToken(workspaceId);
-      setGithubScoped(false);
-    } catch (err) {
-      setError(formatError(err));
-    } finally {
-      setBusy(false);
-    }
-  };
-
   const tokenUrl = `${normalizeHost(host)}/-/profile/personal_access_tokens`;
 
   return (
@@ -108,21 +87,6 @@ export const GitlabFormBody = ({ workspaceId, onConnected, shouldAutoFocus = fal
           <Button variant="danger" size="sm" onClick={() => void onDisconnect()} disabled={busy}>
             <Unplug size={12} aria-hidden />
             {busy ? 'Disconnecting…' : 'Disconnect'}
-          </Button>
-        </div>
-      ) : githubScoped ? (
-        <div className="flex flex-col gap-3 rounded-lg border border-border-soft bg-subtle/40 p-4">
-          <p className="text-xs leading-relaxed text-muted-foreground">
-            A GitHub token is connected for this workspace. Disconnect GitHub to use GitLab.
-          </p>
-          <Button
-            variant="danger"
-            size="sm"
-            onClick={() => void onDisconnectGithub()}
-            disabled={busy}
-          >
-            <Unplug size={12} aria-hidden />
-            {busy ? 'Disconnecting…' : 'Disconnect GitHub'}
           </Button>
         </div>
       ) : (
@@ -167,7 +131,8 @@ export const GitlabFormBody = ({ workspaceId, onConnected, shouldAutoFocus = fal
           </div>
           <p className="text-2xs leading-relaxed text-muted-foreground">
             The read_api scope is enough. The token is stored encrypted in your operating system
-            keychain and never leaves this machine.
+            keychain. Goodboy sends it directly to GitLab over HTTPS; it never touches
+            Goodboy&apos;s own servers.
           </p>
         </>
       )}
@@ -178,7 +143,7 @@ export const GitlabFormBody = ({ workspaceId, onConnected, shouldAutoFocus = fal
         </div>
       ) : null}
 
-      {gitlab || githubScoped ? null : (
+      {gitlab != null ? null : (
         <div className="flex justify-end">
           <Button
             onClick={() => void onConnect()}

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/index.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/index.tsx
@@ -47,7 +47,6 @@ export const GitlabStudio = ({ workspaceId, workspaceName, initialIssueId, onClo
   const isConnected = resolveIntegrationConnection({
     provider: 'gitlab',
     integrations,
-    remoteKind: null,
     externalTasks: EMPTY_ARRAY,
     isGithubAuthenticated: false,
   }).isConnected;

--- a/apps/desktop/src/features/integrations/issueSources.test.ts
+++ b/apps/desktop/src/features/integrations/issueSources.test.ts
@@ -10,7 +10,6 @@ describe('resolveIssueSources', () => {
     expect(
       resolveIssueSources({
         integrations: [integration('slack'), integration('linear')],
-        remoteKind: null,
         isGithubAuthenticated: false,
       }).map((source) => source.label),
     ).toEqual(['Linear', 'Slack']);
@@ -20,17 +19,24 @@ describe('resolveIssueSources', () => {
     expect(
       resolveIssueSources({
         integrations: [integration('bitbucket'), integration('jira')],
-        remoteKind: null,
         isGithubAuthenticated: false,
       }).map((source) => source.provider),
     ).toEqual(['jira']);
+  });
+
+  it('keeps GitHub in the picker when a GitLab credential is the only integration', () => {
+    expect(
+      resolveIssueSources({
+        integrations: [integration('gitlab')],
+        isGithubAuthenticated: true,
+      }).map((source) => source.provider),
+    ).toEqual(['github', 'gitlab']);
   });
 
   it('leaves slack out until the workspace connects it', () => {
     expect(
       resolveIssueSources({
         integrations: [integration('linear')],
-        remoteKind: null,
         isGithubAuthenticated: false,
       }).map((source) => source.provider),
     ).toEqual(['linear']);

--- a/apps/desktop/src/features/integrations/issueSources.ts
+++ b/apps/desktop/src/features/integrations/issueSources.ts
@@ -1,5 +1,4 @@
 import type { SessionExternalTaskProvider, WorkspaceIntegration } from '@goodboy/types';
-import type { RemoteHostKind } from '../../shared/lib/remoteHost';
 import { resolveIntegrationConnection } from './connection';
 
 export type IssueSource = {
@@ -9,7 +8,6 @@ export type IssueSource = {
 
 type Params = {
   readonly integrations: ReadonlyArray<WorkspaceIntegration>;
-  readonly remoteKind: RemoteHostKind | null;
   readonly isGithubAuthenticated: boolean;
 };
 
@@ -24,7 +22,6 @@ const SOURCES: ReadonlyArray<IssueSource> = [
 
 export const resolveIssueSources = ({
   integrations,
-  remoteKind,
   isGithubAuthenticated,
 }: Params): ReadonlyArray<IssueSource> =>
   SOURCES.filter(
@@ -32,7 +29,6 @@ export const resolveIssueSources = ({
       resolveIntegrationConnection({
         provider: source.provider,
         integrations,
-        remoteKind,
         externalTasks: [],
         isGithubAuthenticated,
       }).isConnected,

--- a/apps/desktop/src/features/integrations/jira/JiraFormBody.test.tsx
+++ b/apps/desktop/src/features/integrations/jira/JiraFormBody.test.tsx
@@ -110,4 +110,11 @@ describe('JiraFormBody', () => {
       expect(state.disconnectJira).toHaveBeenCalledWith({ workspaceId: WS_ID });
     });
   });
+
+  it('says where the token travels instead of claiming it never leaves', () => {
+    render(<JiraFormBody workspaceId={WS_ID} />);
+    expect(screen.getByText(/never touches Goodboy's own servers/i)).toBeDefined();
+    expect(screen.queryByText(/never leaves this machine/i)).toBeNull();
+    expect(screen.queryByText(/never leaving this machine/i)).toBeNull();
+  });
 });

--- a/apps/desktop/src/features/integrations/jira/JiraFormBody.tsx
+++ b/apps/desktop/src/features/integrations/jira/JiraFormBody.tsx
@@ -171,8 +171,8 @@ export const JiraFormBody = ({ workspaceId, onConnected, shouldAutoFocus = false
           </div>
           <p className="text-2xs leading-relaxed text-muted-foreground">
             Jira Cloud only, Data Center and Server are not supported. The token carries your own
-            Jira permissions and is stored encrypted in your operating system keychain, never
-            leaving this machine.
+            Jira permissions and is stored encrypted in your operating system keychain. Goodboy
+            sends it directly to Jira over HTTPS; it never touches Goodboy&apos;s own servers.
           </p>
         </>
       )}

--- a/apps/desktop/src/features/integrations/jira/JiraStudio/index.tsx
+++ b/apps/desktop/src/features/integrations/jira/JiraStudio/index.tsx
@@ -39,7 +39,6 @@ export const JiraStudio = ({ workspaceId, workspaceName, initialIssueId, onClose
   const isConnected = resolveIntegrationConnection({
     provider: 'jira',
     integrations,
-    remoteKind: null,
     externalTasks: EMPTY_ARRAY,
     isGithubAuthenticated: false,
   }).isConnected;

--- a/apps/desktop/src/features/integrations/linear/LinearFormBody.test.tsx
+++ b/apps/desktop/src/features/integrations/linear/LinearFormBody.test.tsx
@@ -93,4 +93,11 @@ describe('LinearFormBody', () => {
       expect(state.disconnectLinear).toHaveBeenCalledWith(WS_ID);
     });
   });
+
+  it('says where the token travels instead of claiming it never leaves', () => {
+    render(<LinearFormBody workspaceId={WS_ID} />);
+    expect(screen.getByText(/never touches Goodboy's own servers/i)).toBeDefined();
+    expect(screen.queryByText(/never leaves this machine/i)).toBeNull();
+    expect(screen.queryByText(/never leaving this machine/i)).toBeNull();
+  });
 });

--- a/apps/desktop/src/features/integrations/linear/LinearFormBody.tsx
+++ b/apps/desktop/src/features/integrations/linear/LinearFormBody.tsx
@@ -94,7 +94,8 @@ export const LinearFormBody = ({ workspaceId, onConnected, shouldAutoFocus = fal
           </div>
           <p className="text-2xs leading-relaxed text-muted-foreground">
             Read-only scope is enough. The token is stored encrypted in your operating system
-            keychain and never leaves this machine.
+            keychain. Goodboy sends it directly to Linear over HTTPS; it never touches
+            Goodboy&apos;s own servers.
           </p>
         </>
       )}

--- a/apps/desktop/src/features/integrations/linear/LinearStudio/index.tsx
+++ b/apps/desktop/src/features/integrations/linear/LinearStudio/index.tsx
@@ -27,7 +27,6 @@ export const LinearStudio = ({ workspaceId, workspaceName, initialIssueId, onClo
   const isConnected = resolveIntegrationConnection({
     provider: 'linear',
     integrations,
-    remoteKind: null,
     externalTasks: EMPTY_ARRAY,
     isGithubAuthenticated: false,
   }).isConnected;

--- a/apps/desktop/src/features/integrations/sentry/SentryFormBody.test.tsx
+++ b/apps/desktop/src/features/integrations/sentry/SentryFormBody.test.tsx
@@ -100,4 +100,11 @@ describe('SentryFormBody', () => {
       expect(state.disconnectSentry).toHaveBeenCalledWith(WS_ID);
     });
   });
+
+  it('says where the token travels instead of claiming it never leaves', () => {
+    render(<SentryFormBody workspaceId={WS_ID} />);
+    expect(screen.getByText(/never touches Goodboy's own servers/i)).toBeDefined();
+    expect(screen.queryByText(/never leaves this machine/i)).toBeNull();
+    expect(screen.queryByText(/never leaving this machine/i)).toBeNull();
+  });
 });

--- a/apps/desktop/src/features/integrations/sentry/SentryFormBody.tsx
+++ b/apps/desktop/src/features/integrations/sentry/SentryFormBody.tsx
@@ -130,7 +130,8 @@ export const SentryFormBody = ({ workspaceId, onConnected, shouldAutoFocus = fal
           </div>
           <p className="text-2xs leading-relaxed text-muted-foreground">
             A token with issue read scope is enough. It is stored encrypted in your operating system
-            keychain and never leaves this machine.
+            keychain. Goodboy sends it directly to Sentry over HTTPS; it never touches
+            Goodboy&apos;s own servers.
           </p>
         </>
       )}

--- a/apps/desktop/src/features/integrations/sentry/SentryStudio/index.tsx
+++ b/apps/desktop/src/features/integrations/sentry/SentryStudio/index.tsx
@@ -27,7 +27,6 @@ export const SentryStudio = ({ workspaceId, workspaceName, initialIssueId, onClo
   const isConnected = resolveIntegrationConnection({
     provider: 'sentry',
     integrations,
-    remoteKind: null,
     externalTasks: EMPTY_ARRAY,
     isGithubAuthenticated: false,
   }).isConnected;

--- a/apps/desktop/src/features/integrations/slack/SlackStudio/index.tsx
+++ b/apps/desktop/src/features/integrations/slack/SlackStudio/index.tsx
@@ -26,7 +26,6 @@ export const SlackStudio = ({ workspaceId, workspaceName, initialThreadTs, onClo
   const isConnected = resolveIntegrationConnection({
     provider: 'slack',
     integrations,
-    remoteKind: null,
     externalTasks: EMPTY_ARRAY,
     isGithubAuthenticated: false,
   }).isConnected;

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/steps/CodeHostStep.test.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/steps/CodeHostStep.test.tsx
@@ -42,6 +42,21 @@ describe('CodeHostStep', () => {
     expect(screen.getByRole('heading', { name: /connect a code host/i })).toBeDefined();
   });
 
+  it('never tells the user the hosts are mutually exclusive', () => {
+    render(
+      <CodeHostStep
+        workspaceId={WS_ID}
+        githubConnected={false}
+        gitlabConnected={false}
+        bitbucketConnected={false}
+        onConnected={vi.fn()}
+      />,
+    );
+
+    expect(document.body.textContent).toContain('Connect as many as you use');
+    expect(document.body.textContent).not.toContain('only use one at a time');
+  });
+
   describe('with a workspace', () => {
     it('renders only the GitHub form by default', () => {
       render(

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/steps/CodeHostStep.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/steps/CodeHostStep.tsx
@@ -78,7 +78,7 @@ export const CodeHostStep = ({
         </h2>
         <p className="mx-auto max-w-md text-sm leading-relaxed text-muted-foreground">
           Link GitHub, GitLab or Bitbucket so Goodboy can review and resolve pull requests for this
-          workspace. You can only use one at a time.
+          workspace. Connect as many as you use: one host for code, another for tickets.
         </p>
       </div>
 

--- a/apps/desktop/src/features/review/components/ReviewBoardPane/useReviewDiff.test.ts
+++ b/apps/desktop/src/features/review/components/ReviewBoardPane/useReviewDiff.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, renderHook, waitFor } from '@testing-library/react';
+import type {
+  IsoDateTime,
+  Session,
+  SessionExternalTask,
+  SessionId,
+  WorkspaceId,
+} from '@goodboy/types';
+import type { GitlabMergeRequest } from '../../../integrations/gitlab/client';
+import {
+  resolveReviewTarget,
+  type ReviewTargetState,
+} from '../../../../store/slices/review-drafts/resolveReviewTarget';
+
+const SESSION_ID = 'session-1' as SessionId;
+const WORKSPACE_ID = 'workspace-1' as WorkspaceId;
+const NOW = '2026-08-01T00:00:00.000Z' as IsoDateTime;
+
+const h = vi.hoisted(() => ({
+  ghPrDiff: vi.fn(async () => ''),
+  gitlabMrDiff: vi.fn(async () => ''),
+}));
+
+vi.mock('@goodboy/core', () => ({ parseUnifiedDiff: () => [] }));
+vi.mock('../../../github/github', () => ({ ghPrDiff: h.ghPrDiff }));
+vi.mock('../../../integrations/gitlab/client', () => ({ gitlabMrDiff: h.gitlabMrDiff }));
+vi.mock('../../../../store/slices/worktrees/resolveSessionRepo', () => ({
+  resolveSessionRepo: () => ({
+    repoRoot: '/repo',
+    worktreePath: '/repo',
+    branch: 'ak/feature',
+    mountName: null,
+    workspaceId: WORKSPACE_ID,
+  }),
+}));
+
+type MockStore = ReviewTargetState & {
+  readonly workspaces: ReadonlyArray<{ readonly id: WorkspaceId; readonly rootPath: string }>;
+  readonly workspaceIntegrations: Readonly<
+    Record<string, ReadonlyArray<{ readonly provider: string; readonly config: { host: string } }>>
+  >;
+};
+
+vi.mock('../../../../store', () => ({
+  useAppStore: <T>(selector: (store: MockStore) => T) => selector(state),
+}));
+
+const session: Session = {
+  id: SESSION_ID,
+  workspaceId: WORKSPACE_ID,
+  goal: 'Review the merge request',
+  state: { kind: 'idle', lastActivityAt: NOW },
+  contextSlots: [],
+  providerPreference: { defaultProvider: 'anthropic', allowTurnOverride: false },
+  permissionMode: 'bypassPermissions',
+  workflowRuns: [],
+  autoRun: false,
+  titleUserEdited: false,
+  createdAt: NOW,
+  updatedAt: NOW,
+};
+
+const githubTask: SessionExternalTask = {
+  sessionId: SESSION_ID,
+  provider: 'github',
+  externalId: '42',
+  identifier: '#42',
+  url: 'https://github.com/acme/web/pull/42',
+  title: 'PR',
+  createdAt: NOW,
+};
+
+const gitlabTask: SessionExternalTask = {
+  sessionId: SESSION_ID,
+  provider: 'gitlab',
+  externalId: '10',
+  identifier: '!10',
+  url: 'https://gitlab.com/acme/web/-/merge_requests/10',
+  title: 'MR',
+  createdAt: NOW,
+};
+
+const mergeRequest: GitlabMergeRequest = {
+  id: 100,
+  iid: 10,
+  projectId: 3,
+  title: 'MR',
+  description: null,
+  state: 'opened',
+  webUrl: 'https://gitlab.com/acme/web/-/merge_requests/10',
+  sourceBranch: 'ak/feature',
+  targetBranch: 'main',
+  draft: false,
+  hasConflicts: false,
+  mergeStatus: 'can_be_merged',
+  updatedAt: NOW,
+};
+
+const state: MockStore = {
+  sessionExternalTasks: { [SESSION_ID]: [githubTask, gitlabTask] },
+  sessionGithubPrs: { [SESSION_ID]: [] },
+  sessionGitlabMr: {
+    [SESSION_ID]: { mr: mergeRequest, fetchedAt: NOW, loading: false, error: null },
+  },
+  workspaces: [{ id: WORKSPACE_ID, rootPath: '/repo' }],
+  workspaceIntegrations: {
+    [WORKSPACE_ID]: [{ provider: 'gitlab', config: { host: 'https://gitlab.com' } }],
+  },
+};
+
+import { useReviewDiff } from './useReviewDiff';
+
+afterEach(() => {
+  cleanup();
+  h.ghPrDiff.mockClear();
+  h.gitlabMrDiff.mockClear();
+});
+
+describe('useReviewDiff', () => {
+  it('resolves the same target the review draft path stamps on every comment', async () => {
+    const { result } = renderHook(() => useReviewDiff({ session }));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.target).toEqual({
+      provider: 'gitlab',
+      repo: 'acme/web',
+      prNumber: 10,
+    });
+    expect(result.current.target).toEqual(resolveReviewTarget({ state, sessionId: SESSION_ID }));
+  });
+
+  it('fetches the diff of the discovered merge request, not the priority-first candidate', async () => {
+    renderHook(() => useReviewDiff({ session }));
+
+    await waitFor(() => expect(h.gitlabMrDiff).toHaveBeenCalledOnce());
+
+    expect(h.gitlabMrDiff).toHaveBeenCalledWith(WORKSPACE_ID, 'https://gitlab.com', 'acme/web', 10);
+    expect(h.ghPrDiff).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/features/review/components/ReviewBoardPane/useReviewDiff.ts
+++ b/apps/desktop/src/features/review/components/ReviewBoardPane/useReviewDiff.ts
@@ -1,10 +1,10 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { parseUnifiedDiff } from '@goodboy/core';
 import type { FileDiff, GitlabWorkspaceIntegration, Session, SessionId } from '@goodboy/types';
-import { EMPTY_ARRAY, useAppStore } from '../../../../store';
+import { useAppStore } from '../../../../store';
 import {
-  reviewTargetFromTasks,
+  resolveReviewTarget,
   type ReviewTarget,
 } from '../../../../store/slices/review-drafts/resolveReviewTarget';
 import { ghPrDiff } from '../../../github/github';
@@ -26,7 +26,7 @@ type Result = {
 
 export const useReviewDiff = ({ session }: Params): Result => {
   const sessionId = session.id as SessionId;
-  const externalTasks = useAppStore((s) => s.sessionExternalTasks[sessionId] ?? EMPTY_ARRAY);
+  const target = useAppStore(useShallow((state) => resolveReviewTarget({ state, sessionId })));
   const workspace = useAppStore(
     (s) => s.workspaces.find((candidate) => candidate.id === session.workspaceId) ?? null,
   );
@@ -42,8 +42,6 @@ export const useReviewDiff = ({ session }: Params): Result => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [tick, setTick] = useState(0);
-
-  const target = useMemo(() => reviewTargetFromTasks({ tasks: externalTasks }), [externalTasks]);
 
   useEffect(() => {
     if (target == null || workspace == null || repo == null) {

--- a/apps/desktop/src/features/session/components/NewSessionView/index.test.tsx
+++ b/apps/desktop/src/features/session/components/NewSessionView/index.test.tsx
@@ -9,6 +9,7 @@ import type {
 
 const h = vi.hoisted(() => ({
   remoteKind: 'github' as string | null,
+  isGithubAuthenticated: true,
   listLocalBranches: vi.fn(async () => []),
   simpleSessionDirExists: vi.fn(async () => false),
   invoke: vi.fn(),
@@ -53,7 +54,7 @@ vi.mock('../../../../features/worktree/useWorkspaceRemoteHostKind', () => ({
 
 vi.mock('../../../../features/integrations/github/useGithubConnection', () => ({
   useGithubConnection: () => ({
-    isAuthenticated: true,
+    isAuthenticated: h.isGithubAuthenticated,
     isResolved: true,
     refresh: vi.fn(async () => undefined),
   }),
@@ -85,10 +86,16 @@ import { NewSessionView } from './index';
 const WORKSPACE_ID = 'workspace-1' as WorkspaceId;
 
 const integration = (provider: 'linear' | 'sentry' | 'gitlab'): WorkspaceIntegration =>
-  ({ id: `${provider}-1`, workspaceId: WORKSPACE_ID, provider }) as WorkspaceIntegration;
+  ({
+    id: `${provider}-1`,
+    workspaceId: WORKSPACE_ID,
+    provider,
+    config: { host: 'https://gitlab.com' },
+  }) as WorkspaceIntegration;
 
 beforeEach(() => {
   h.remoteKind = 'github';
+  h.isGithubAuthenticated = true;
   h.store.workspaces[0]!.kind = 'repo';
   h.store.workspaceIntegrations = {};
   h.store.workspaceGitStatus = {};
@@ -405,8 +412,20 @@ describe('NewSessionView issue sources', () => {
     expect(screen.queryByRole('tab', { name: /GitLab/ })).toBeNull();
   });
 
+  it('keeps the GitHub tab on a GitLab remote when a GitHub token is connected', () => {
+    h.remoteKind = 'gitlab';
+    h.store.workspaceIntegrations = { [WORKSPACE_ID]: [integration('gitlab')] };
+
+    render(
+      <NewSessionView onClose={vi.fn()} workspaceId={WORKSPACE_ID} onOpenSettings={vi.fn()} />,
+    );
+
+    expect(screen.getByRole('tab', { name: /GitHub/ })).toBeDefined();
+    expect(screen.getByRole('tab', { name: /GitLab/ })).toBeDefined();
+  });
+
   it('drops the section when nothing is connected', () => {
-    h.remoteKind = 'other';
+    h.isGithubAuthenticated = false;
 
     render(
       <NewSessionView onClose={vi.fn()} workspaceId={WORKSPACE_ID} onOpenSettings={vi.fn()} />,

--- a/apps/desktop/src/features/session/components/NewSessionView/index.test.tsx
+++ b/apps/desktop/src/features/session/components/NewSessionView/index.test.tsx
@@ -8,7 +8,6 @@ import type {
 } from '../../../../store/slices/newSessionDrafts/types';
 
 const h = vi.hoisted(() => ({
-  remoteKind: 'github' as string | null,
   isGithubAuthenticated: true,
   listLocalBranches: vi.fn(async () => []),
   simpleSessionDirExists: vi.fn(async () => false),
@@ -46,10 +45,6 @@ vi.mock('../../../../store', () => ({
 
 vi.mock('../../../../app/components/Toast', () => ({
   useToast: () => ({ showToast: h.showToast }),
-}));
-
-vi.mock('../../../../features/worktree/useWorkspaceRemoteHostKind', () => ({
-  useWorkspaceRemoteHostKind: () => h.remoteKind,
 }));
 
 vi.mock('../../../../features/integrations/github/useGithubConnection', () => ({
@@ -94,7 +89,6 @@ const integration = (provider: 'linear' | 'sentry' | 'gitlab'): WorkspaceIntegra
   }) as WorkspaceIntegration;
 
 beforeEach(() => {
-  h.remoteKind = 'github';
   h.isGithubAuthenticated = true;
   h.store.workspaces[0]!.kind = 'repo';
   h.store.workspaceIntegrations = {};
@@ -412,8 +406,7 @@ describe('NewSessionView issue sources', () => {
     expect(screen.queryByRole('tab', { name: /GitLab/ })).toBeNull();
   });
 
-  it('keeps the GitHub tab on a GitLab remote when a GitHub token is connected', () => {
-    h.remoteKind = 'gitlab';
+  it('keeps the GitHub tab next to GitLab when both hosts are connected', () => {
     h.store.workspaceIntegrations = { [WORKSPACE_ID]: [integration('gitlab')] };
 
     render(

--- a/apps/desktop/src/features/session/components/NewSessionView/index.tsx
+++ b/apps/desktop/src/features/session/components/NewSessionView/index.tsx
@@ -16,7 +16,6 @@ import {
 } from '../../../../features/worktree/worktree';
 import { useBranchConflict } from '../../../../features/worktree/useBranchConflict';
 import { useSimpleSessionDirectoryConflict } from '../../../../features/worktree/useSimpleSessionDirectoryConflict';
-import { useWorkspaceRemoteHostKind } from '../../../../features/worktree/useWorkspaceRemoteHostKind';
 import { useWorkspaceGitStatus } from '../../../workspace/hooks/useWorkspaceGitStatus';
 import type { IssueCandidate } from '../../../../features/integrations/fetchIssueCandidates';
 import { resolveIssueSources } from '../../../../features/integrations/issueSources';
@@ -102,13 +101,11 @@ export const NewSessionView = ({ onClose, workspaceId, onOpenSettings }: Props) 
   const workspaceIntegrations = useAppStore(
     useShallow((s) => s.workspaceIntegrations?.[workspaceId] ?? EMPTY_INTEGRATIONS),
   );
-  const remoteKind = useWorkspaceRemoteHostKind({ workspaceId });
   const githubConnection = useGithubConnection({ workspaceId });
   const issueSources = isSimple
     ? []
     : resolveIssueSources({
         integrations: workspaceIntegrations,
-        remoteKind,
         isGithubAuthenticated: githubConnection.isAuthenticated,
       });
 

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/index.tsx
@@ -134,7 +134,6 @@ export const IntegrationPane = ({ sessionId, workspaceId, provider }: Props) => 
   const connection = resolveIntegrationConnection({
     provider,
     integrations,
-    remoteKind,
     externalTasks,
     isGithubAuthenticated:
       provider !== 'github' ||

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/index.tsx
@@ -14,7 +14,6 @@ import { ConnectIntegrationEmptyState } from '../../../../../integrations/Connec
 import { resolveIntegrationConnection } from '../../../../../integrations/connection';
 import { GithubConnectionEmptyState } from '../../../../../github/components/GithubConnectionEmptyState';
 import { useGithubConnection } from '../../../../../integrations/github/useGithubConnection';
-import { useRemoteHostKind } from '../../../../../worktree/useRemoteHostKind';
 import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../../../shared/components/conceptIcons';
 import { GhostActionButton } from '../../../../../../shared/components/GhostActionButton';
 import { PaneShell } from '../../../../../../shared/components/PaneShell';
@@ -121,7 +120,6 @@ export const IntegrationPane = ({ sessionId, workspaceId, provider }: Props) => 
   const integrations = useAppStore(
     (state) => state.workspaceIntegrations[workspaceId] ?? EMPTY_ARRAY,
   );
-  const remoteKind = useRemoteHostKind({ sessionId });
   const githubConnection = useGithubConnection({ workspaceId });
   const sessionBranch = useSessionRepo({ sessionId })?.branch ?? null;
   const branchPrs = useAppStore((state) => state.sessionGithubPrs[sessionId] ?? EMPTY_ARRAY);
@@ -247,7 +245,7 @@ export const IntegrationPane = ({ sessionId, workspaceId, provider }: Props) => 
         provider === 'github' ? (
           <GithubConnectionEmptyState
             workspaceId={workspaceId}
-            hasGithubRemote={remoteKind === 'github'}
+            isConnected={connection.isConnected}
             compact
             onConnected={() => void githubConnection.refresh()}
           />

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn/index.test.tsx
@@ -19,7 +19,10 @@ const { hooks, remote, store } = vi.hoisted(() => {
       attachedRuns: [] as ReadonlyArray<unknown>,
       resolverLinks: [] as ReadonlyArray<unknown>,
     },
-    remote: { kind: 'github' as 'github' | 'gitlab' | 'other' | null },
+    remote: {
+      kind: 'github' as 'github' | 'gitlab' | 'other' | null,
+      isGithubAuthenticated: true,
+    },
     store: {
       sessionMounts: {},
       sessionActiveMount: {},
@@ -101,7 +104,7 @@ vi.mock('../../../../../worktree/useRemoteHostKind', () => ({
 
 vi.mock('../../../../../integrations/github/useGithubConnection', () => ({
   useGithubConnection: () => ({
-    isAuthenticated: true,
+    isAuthenticated: remote.isGithubAuthenticated,
     isResolved: true,
     refresh: vi.fn(async () => undefined),
   }),
@@ -131,6 +134,7 @@ const SESSION = {
 
 beforeEach(() => {
   remote.kind = 'github';
+  remote.isGithubAuthenticated = true;
   hooks.agentCount = 0;
   hooks.doneAgentCount = 0;
   hooks.planCount = 0;
@@ -626,6 +630,7 @@ describe('LensColumn', () => {
     (label, lens, studioEvent) => {
       store.workspaceIntegrations = {};
       remote.kind = null;
+      remote.isGithubAuthenticated = false;
       const listener = vi.fn();
       window.addEventListener(studioEvent, listener);
       const onSelect = vi.fn();

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn/index.tsx
@@ -18,7 +18,6 @@ import {
   useSummarizerStatus,
 } from '../../../../../../store';
 import type { LensKind } from '../../../../../../store';
-import { useRemoteHostKind } from '../../../../../worktree/useRemoteHostKind';
 import { useSessionSidebarCollapsed } from '../../../../../workspace/hooks/useSessionSidebarVisibility/collapsed';
 import { resolveIntegrationConnection } from '../../../../../integrations/connection';
 import { IntegrationGlyph } from '../../../../../integrations/components/IntegrationGlyph';
@@ -102,7 +101,6 @@ export const LensColumn = ({
     [nonResolverStandalone],
   );
   const unreadLens = useSessionUnreadLens(sessionId);
-  const remoteKind = useRemoteHostKind({ sessionId });
   const externalTasks = useAppStore((s) => s.sessionExternalTasks[sessionId] ?? EMPTY_ARRAY);
   const workspaceIntegrations = useAppStore(
     (s) => s.workspaceIntegrations[session.workspaceId] ?? EMPTY_ARRAY,
@@ -186,7 +184,6 @@ export const LensColumn = ({
   const githubConnection = resolveIntegrationConnection({
     provider: 'github',
     integrations: workspaceIntegrations,
-    remoteKind,
     externalTasks,
     isGithubAuthenticated:
       githubAuthentication.isResolved === false || githubAuthentication.isAuthenticated,
@@ -194,35 +191,30 @@ export const LensColumn = ({
   const linearConnection = resolveIntegrationConnection({
     provider: 'linear',
     integrations: workspaceIntegrations,
-    remoteKind,
     externalTasks,
     isGithubAuthenticated: false,
   });
   const sentryConnection = resolveIntegrationConnection({
     provider: 'sentry',
     integrations: workspaceIntegrations,
-    remoteKind,
     externalTasks,
     isGithubAuthenticated: false,
   });
   const gitlabConnection = resolveIntegrationConnection({
     provider: 'gitlab',
     integrations: workspaceIntegrations,
-    remoteKind,
     externalTasks,
     isGithubAuthenticated: false,
   });
   const jiraConnection = resolveIntegrationConnection({
     provider: 'jira',
     integrations: workspaceIntegrations,
-    remoteKind,
     externalTasks,
     isGithubAuthenticated: false,
   });
   const slackConnection = resolveIntegrationConnection({
     provider: 'slack',
     integrations: workspaceIntegrations,
-    remoteKind,
     externalTasks,
     isGithubAuthenticated: false,
   });

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.tsx
@@ -14,8 +14,7 @@ import { ExternalTaskChip } from '../../../../integrations/components/ExternalTa
 import { integrationLabel } from '../../../../integrations/components/IntegrationGlyph';
 import { GitlabMrStrip } from '../../../../context/components/ContextPanel/strips/GitlabMrStrip';
 import { BitbucketPrStrip } from '../../../../context/components/ContextPanel/strips/BitbucketPrStrip';
-import { MissingGithubRemoteEmptyState } from '../../../../github/components/MissingGithubRemoteEmptyState';
-import { MissingGithubTokenEmptyState } from '../../../../github/components/MissingGithubTokenEmptyState';
+import { GithubConnectionEmptyState } from '../../../../github/components/GithubConnectionEmptyState';
 import { resolveIntegrationConnection } from '../../../../integrations/connection';
 import { useGithubConnection } from '../../../../integrations/github/useGithubConnection';
 import { useRemoteHostKind } from '../../../../worktree/useRemoteHostKind';
@@ -422,15 +421,12 @@ const GithubPrCard = ({
     return shell({ children: <PrPaneSkeleton /> });
   }
 
-  if (!pr && remoteKind !== 'github') {
-    return shell({ children: <MissingGithubRemoteEmptyState /> });
-  }
-
-  if (!pr && !isGithubConnected) {
+  if (!pr && (isGithubConnected === false || remoteKind !== 'github')) {
     return shell({
       children: (
-        <MissingGithubTokenEmptyState
+        <GithubConnectionEmptyState
           workspaceId={session.workspaceId}
+          isConnected={isGithubConnected}
           onConnected={() => void githubConnection.refresh()}
         />
       ),

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.tsx
@@ -319,7 +319,6 @@ const GithubPrCard = ({
   const isGithubConnected = resolveIntegrationConnection({
     provider: 'github',
     integrations: workspaceIntegrations,
-    remoteKind,
     externalTasks,
     isGithubAuthenticated:
       githubConnection.isResolved === false || githubConnection.isAuthenticated,

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/resolvePullRequestProvider.ts
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/resolvePullRequestProvider.ts
@@ -4,7 +4,11 @@ export type PullRequestProvider = 'github' | 'gitlab' | 'bitbucket';
 
 export type PullRequestAvailability = Readonly<Record<PullRequestProvider, boolean>>;
 
-const PROVIDER_PRIORITY: ReadonlyArray<PullRequestProvider> = ['github', 'gitlab', 'bitbucket'];
+export const PROVIDER_PRIORITY: ReadonlyArray<PullRequestProvider> = [
+  'github',
+  'gitlab',
+  'bitbucket',
+];
 
 type HintParams = {
   readonly remoteKind: RemoteHostKind | null;

--- a/apps/desktop/src/store/slices/review-drafts/addReviewDraft.ts
+++ b/apps/desktop/src/store/slices/review-drafts/addReviewDraft.ts
@@ -15,7 +15,7 @@ export type AddReviewDraftInput = {
 
 export const addReviewDraft = (set: SetFn, get: GetFn) => {
   return async (input: AddReviewDraftInput): Promise<PrReviewDraft> => {
-    const target = resolveReviewTarget({ get, sessionId: input.sessionId });
+    const target = resolveReviewTarget({ state: get(), sessionId: input.sessionId });
     if (target == null) {
       throw new Error('no linked pull request or merge request for this session');
     }

--- a/apps/desktop/src/store/slices/review-drafts/index.test.ts
+++ b/apps/desktop/src/store/slices/review-drafts/index.test.ts
@@ -139,6 +139,8 @@ const buildHarness = (initial: Record<string, unknown>): Harness => {
     workspaces: [{ id: WS_ID, name: 'ws', rootPath: '/tmp/repo' }],
     workspaceIntegrations: {},
     sessionExternalTasks: { [SESSION_ID]: [githubTask] },
+    sessionGithubPrs: {},
+    sessionGitlabMr: {},
     sessionWorktrees: { [SESSION_ID]: ['/tmp/repo/.goodboy/worktrees/review'] },
     sessionBranches: { [SESSION_ID]: 'review' },
     sessionMounts: {},

--- a/apps/desktop/src/store/slices/review-drafts/publishPrReview.ts
+++ b/apps/desktop/src/store/slices/review-drafts/publishPrReview.ts
@@ -213,7 +213,7 @@ export const publishPrReview = (set: SetFn, get: GetFn) => {
     sessionId: SessionId,
     opts: PublishPrReviewOpts,
   ): Promise<PublishPrReviewResult> => {
-    const target = opts.target ?? resolveReviewTarget({ get, sessionId });
+    const target = opts.target ?? resolveReviewTarget({ state: get(), sessionId });
     if (target == null) {
       throw new Error('no linked pull request or merge request for this session');
     }

--- a/apps/desktop/src/store/slices/review-drafts/queueAgentReviewComments.ts
+++ b/apps/desktop/src/store/slices/review-drafts/queueAgentReviewComments.ts
@@ -14,7 +14,7 @@ export const queueAgentReviewComments = (set: SetFn, get: GetFn) => {
     if (markers.length === 0) {
       return;
     }
-    const target = resolveReviewTarget({ get, sessionId });
+    const target = resolveReviewTarget({ state: get(), sessionId });
     if (target == null) {
       return;
     }

--- a/apps/desktop/src/store/slices/review-drafts/resolveReviewTarget.test.ts
+++ b/apps/desktop/src/store/slices/review-drafts/resolveReviewTarget.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import type { IsoDateTime, SessionExternalTask, SessionId } from '@goodboy/types';
+import { reviewPrKey, reviewTargetFromTasks } from './resolveReviewTarget';
+
+const SESSION_ID = 'session-1' as SessionId;
+const NOW = '2026-08-01T00:00:00.000Z' as IsoDateTime;
+
+const githubTask: SessionExternalTask = {
+  sessionId: SESSION_ID,
+  provider: 'github',
+  externalId: '42',
+  identifier: '#42',
+  url: 'https://github.com/acme/web/pull/42',
+  title: 'PR',
+  createdAt: NOW,
+};
+
+const gitlabTask: SessionExternalTask = {
+  sessionId: SESSION_ID,
+  provider: 'gitlab',
+  externalId: '10',
+  identifier: '!10',
+  url: 'https://gitlab.com/acme/web/-/merge_requests/10',
+  title: 'MR',
+  createdAt: NOW,
+};
+
+const bitbucketTask: SessionExternalTask = {
+  sessionId: SESSION_ID,
+  provider: 'bitbucket',
+  externalId: '5',
+  identifier: '#5',
+  url: 'https://bitbucket.org/acme/web/pull-requests/5',
+  title: 'BB',
+  createdAt: NOW,
+};
+
+describe('reviewTargetFromTasks', () => {
+  it('picks the same target whatever order the candidates arrive in', () => {
+    const forward = reviewTargetFromTasks({ tasks: [gitlabTask, githubTask] });
+    const reversed = reviewTargetFromTasks({ tasks: [githubTask, gitlabTask] });
+
+    expect(forward).toEqual({ provider: 'github', repo: 'acme/web', prNumber: 42 });
+    expect(reversed).toEqual(forward);
+  });
+
+  it('prefers the candidate matching a pull request the store already discovered', () => {
+    const discoveredPrKeys = new Set([reviewPrKey({ provider: 'gitlab', prNumber: 10 })]);
+    const forward = reviewTargetFromTasks({ tasks: [gitlabTask, githubTask], discoveredPrKeys });
+    const reversed = reviewTargetFromTasks({ tasks: [githubTask, gitlabTask], discoveredPrKeys });
+
+    expect(forward).toEqual({ provider: 'gitlab', repo: 'acme/web', prNumber: 10 });
+    expect(reversed).toEqual(forward);
+  });
+
+  it('never routes a bitbucket task through the reviewable providers', () => {
+    expect(reviewTargetFromTasks({ tasks: [bitbucketTask] })).toBeNull();
+    expect(reviewTargetFromTasks({ tasks: [bitbucketTask, gitlabTask] })).toEqual({
+      provider: 'gitlab',
+      repo: 'acme/web',
+      prNumber: 10,
+    });
+  });
+
+  it('skips candidates with an unusable external id or url', () => {
+    const brokenId = { ...githubTask, externalId: 'not-a-number' };
+    const brokenUrl = { ...githubTask, url: 'not a url' };
+
+    expect(reviewTargetFromTasks({ tasks: [brokenId, brokenUrl, gitlabTask] })).toEqual({
+      provider: 'gitlab',
+      repo: 'acme/web',
+      prNumber: 10,
+    });
+  });
+});

--- a/apps/desktop/src/store/slices/review-drafts/resolveReviewTarget.test.ts
+++ b/apps/desktop/src/store/slices/review-drafts/resolveReviewTarget.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import type { IsoDateTime, SessionExternalTask, SessionId } from '@goodboy/types';
-import { reviewPrKey, reviewTargetFromTasks } from './resolveReviewTarget';
+import type { IsoDateTime, PullRequestState, SessionExternalTask, SessionId } from '@goodboy/types';
+import type { GitlabMergeRequest } from '../../../features/integrations/gitlab/client';
+import { reviewPrKey, resolveReviewTarget, type ReviewTargetState } from './resolveReviewTarget';
 
 const SESSION_ID = 'session-1' as SessionId;
 const NOW = '2026-08-01T00:00:00.000Z' as IsoDateTime;
@@ -35,41 +36,117 @@ const bitbucketTask: SessionExternalTask = {
   createdAt: NOW,
 };
 
-describe('reviewTargetFromTasks', () => {
+const mergeRequest: GitlabMergeRequest = {
+  id: 100,
+  iid: 10,
+  projectId: 3,
+  title: 'MR',
+  description: null,
+  state: 'opened',
+  webUrl: 'https://gitlab.com/acme/web/-/merge_requests/10',
+  sourceBranch: 'ak/feature',
+  targetBranch: 'main',
+  draft: false,
+  hasConflicts: false,
+  mergeStatus: 'can_be_merged',
+  updatedAt: NOW,
+};
+
+const pullRequest: PullRequestState = {
+  number: 42,
+  title: 'PR',
+  url: 'https://github.com/acme/web/pull/42',
+  state: 'open',
+  mergeable: true,
+  checks: 'success',
+  baseBranch: 'main',
+  headBranch: 'ak/feature',
+  isDraft: false,
+  reviewDecision: null,
+  body: '',
+  updatedAt: NOW,
+};
+
+type StateParams = {
+  readonly tasks: ReadonlyArray<SessionExternalTask>;
+  readonly prs?: ReadonlyArray<PullRequestState>;
+  readonly mr?: GitlabMergeRequest | null;
+};
+
+const buildState = ({ tasks, prs = [], mr = null }: StateParams): ReviewTargetState => ({
+  sessionExternalTasks: { [SESSION_ID]: tasks },
+  sessionGithubPrs: { [SESSION_ID]: prs },
+  sessionGitlabMr: {
+    [SESSION_ID]: { mr, fetchedAt: NOW, loading: false, error: null },
+  },
+});
+
+describe('resolveReviewTarget', () => {
   it('picks the same target whatever order the candidates arrive in', () => {
-    const forward = reviewTargetFromTasks({ tasks: [gitlabTask, githubTask] });
-    const reversed = reviewTargetFromTasks({ tasks: [githubTask, gitlabTask] });
+    const forward = resolveReviewTarget({
+      state: buildState({ tasks: [gitlabTask, githubTask] }),
+      sessionId: SESSION_ID,
+    });
+    const reversed = resolveReviewTarget({
+      state: buildState({ tasks: [githubTask, gitlabTask] }),
+      sessionId: SESSION_ID,
+    });
 
     expect(forward).toEqual({ provider: 'github', repo: 'acme/web', prNumber: 42 });
     expect(reversed).toEqual(forward);
   });
 
   it('prefers the candidate matching a pull request the store already discovered', () => {
-    const discoveredPrKeys = new Set([reviewPrKey({ provider: 'gitlab', prNumber: 10 })]);
-    const forward = reviewTargetFromTasks({ tasks: [gitlabTask, githubTask], discoveredPrKeys });
-    const reversed = reviewTargetFromTasks({ tasks: [githubTask, gitlabTask], discoveredPrKeys });
+    const state = buildState({ tasks: [githubTask, gitlabTask], mr: mergeRequest });
 
-    expect(forward).toEqual({ provider: 'gitlab', repo: 'acme/web', prNumber: 10 });
-    expect(reversed).toEqual(forward);
-  });
-
-  it('never routes a bitbucket task through the reviewable providers', () => {
-    expect(reviewTargetFromTasks({ tasks: [bitbucketTask] })).toBeNull();
-    expect(reviewTargetFromTasks({ tasks: [bitbucketTask, gitlabTask] })).toEqual({
+    expect(resolveReviewTarget({ state, sessionId: SESSION_ID })).toEqual({
       provider: 'gitlab',
       repo: 'acme/web',
       prNumber: 10,
     });
+  });
+
+  it('falls back to the priority order when both hosts discovered something', () => {
+    const state = buildState({
+      tasks: [gitlabTask, githubTask],
+      prs: [pullRequest],
+      mr: mergeRequest,
+    });
+
+    expect(resolveReviewTarget({ state, sessionId: SESSION_ID })).toEqual({
+      provider: 'github',
+      repo: 'acme/web',
+      prNumber: 42,
+    });
+  });
+
+  it('never routes a bitbucket task through the reviewable providers', () => {
+    expect(
+      resolveReviewTarget({ state: buildState({ tasks: [bitbucketTask] }), sessionId: SESSION_ID }),
+    ).toBeNull();
+    expect(
+      resolveReviewTarget({
+        state: buildState({ tasks: [bitbucketTask, gitlabTask] }),
+        sessionId: SESSION_ID,
+      }),
+    ).toEqual({ provider: 'gitlab', repo: 'acme/web', prNumber: 10 });
   });
 
   it('skips candidates with an unusable external id or url', () => {
     const brokenId = { ...githubTask, externalId: 'not-a-number' };
     const brokenUrl = { ...githubTask, url: 'not a url' };
+    const state = buildState({ tasks: [brokenId, brokenUrl, gitlabTask] });
 
-    expect(reviewTargetFromTasks({ tasks: [brokenId, brokenUrl, gitlabTask] })).toEqual({
+    expect(resolveReviewTarget({ state, sessionId: SESSION_ID })).toEqual({
       provider: 'gitlab',
       repo: 'acme/web',
       prNumber: 10,
     });
+  });
+
+  it('keys a discovered pull request by provider so numbers cannot collide', () => {
+    expect(reviewPrKey({ provider: 'github', prNumber: 10 })).not.toBe(
+      reviewPrKey({ provider: 'gitlab', prNumber: 10 }),
+    );
   });
 });

--- a/apps/desktop/src/store/slices/review-drafts/resolveReviewTarget.ts
+++ b/apps/desktop/src/store/slices/review-drafts/resolveReviewTarget.ts
@@ -1,6 +1,6 @@
 import type { ReviewablePrProvider, SessionExternalTask, SessionId } from '@goodboy/types';
 import { PROVIDER_PRIORITY } from '../../../features/session/components/SessionWorkspace/parts/resolvePullRequestProvider';
-import type { GetFn } from './types';
+import type { AppState } from '../../types';
 
 export type ReviewTarget = {
   readonly provider: ReviewablePrProvider;
@@ -69,10 +69,10 @@ const byProviderThenNumber = (left: ReviewTarget, right: ReviewTarget): number =
 
 type FromTasksParams = {
   readonly tasks: ReadonlyArray<SessionExternalTask>;
-  readonly discoveredPrKeys?: ReadonlySet<string>;
+  readonly discoveredPrKeys: ReadonlySet<string>;
 };
 
-export const reviewTargetFromTasks = ({
+const reviewTargetFromTasks = ({
   tasks,
   discoveredPrKeys,
 }: FromTasksParams): ReviewTarget | null => {
@@ -83,31 +83,34 @@ export const reviewTargetFromTasks = ({
       return target == null ? [] : [target];
     })
     .sort(byProviderThenNumber);
-  const discovered = candidates.find(
-    (candidate) => discoveredPrKeys?.has(reviewPrKey(candidate)) === true,
-  );
+  const discovered = candidates.find((candidate) => discoveredPrKeys.has(reviewPrKey(candidate)));
   return discovered ?? candidates[0] ?? null;
 };
 
+export type ReviewTargetState = Pick<
+  AppState,
+  'sessionExternalTasks' | 'sessionGithubPrs' | 'sessionGitlabMr'
+>;
+
 type Params = {
-  readonly get: GetFn;
+  readonly state: ReviewTargetState;
   readonly sessionId: SessionId;
 };
 
-const discoveredPrKeysForSession = ({ get, sessionId }: Params): ReadonlySet<string> => {
+const discoveredPrKeysForSession = ({ state, sessionId }: Params): ReadonlySet<string> => {
   const keys = new Set<string>();
-  for (const pr of get().sessionGithubPrs?.[sessionId] ?? []) {
+  for (const pr of state.sessionGithubPrs[sessionId] ?? []) {
     keys.add(reviewPrKey({ provider: 'github', prNumber: pr.number }));
   }
-  const mergeRequest = get().sessionGitlabMr?.[sessionId]?.mr ?? null;
+  const mergeRequest = state.sessionGitlabMr[sessionId]?.mr ?? null;
   if (mergeRequest != null) {
     keys.add(reviewPrKey({ provider: 'gitlab', prNumber: mergeRequest.iid }));
   }
   return keys;
 };
 
-export const resolveReviewTarget = ({ get, sessionId }: Params): ReviewTarget | null =>
+export const resolveReviewTarget = ({ state, sessionId }: Params): ReviewTarget | null =>
   reviewTargetFromTasks({
-    tasks: get().sessionExternalTasks?.[sessionId] ?? [],
-    discoveredPrKeys: discoveredPrKeysForSession({ get, sessionId }),
+    tasks: state.sessionExternalTasks[sessionId] ?? [],
+    discoveredPrKeys: discoveredPrKeysForSession({ state, sessionId }),
   });

--- a/apps/desktop/src/store/slices/review-drafts/resolveReviewTarget.ts
+++ b/apps/desktop/src/store/slices/review-drafts/resolveReviewTarget.ts
@@ -1,4 +1,5 @@
 import type { ReviewablePrProvider, SessionExternalTask, SessionId } from '@goodboy/types';
+import { PROVIDER_PRIORITY } from '../../../features/session/components/SessionWorkspace/parts/resolvePullRequestProvider';
 import type { GetFn } from './types';
 
 export type ReviewTarget = {
@@ -7,8 +8,13 @@ export type ReviewTarget = {
   readonly prNumber: number;
 };
 
+type ReviewableTask = SessionExternalTask & { readonly provider: ReviewablePrProvider };
+
+const isReviewableTask = (task: SessionExternalTask): task is ReviewableTask =>
+  task.provider === 'github' || task.provider === 'gitlab';
+
 type RepoFromTaskParams = {
-  readonly task: SessionExternalTask;
+  readonly task: ReviewableTask;
 };
 
 const repoFromTask = ({ task }: RepoFromTaskParams): string | null => {
@@ -29,17 +35,11 @@ const repoFromTask = ({ task }: RepoFromTaskParams): string | null => {
   }
 };
 
-type FromTasksParams = {
-  readonly tasks: ReadonlyArray<SessionExternalTask>;
+type TargetFromTaskParams = {
+  readonly task: ReviewableTask;
 };
 
-export const reviewTargetFromTasks = ({ tasks }: FromTasksParams): ReviewTarget | null => {
-  const task =
-    tasks.find((candidate) => candidate.provider === 'github' || candidate.provider === 'gitlab') ??
-    null;
-  if (task == null) {
-    return null;
-  }
+const targetFromTask = ({ task }: TargetFromTaskParams): ReviewTarget | null => {
   const prNumber = Number.parseInt(task.externalId, 10);
   if (!Number.isInteger(prNumber) || prNumber <= 0) {
     return null;
@@ -48,7 +48,45 @@ export const reviewTargetFromTasks = ({ tasks }: FromTasksParams): ReviewTarget 
   if (repo == null) {
     return null;
   }
-  return { provider: task.provider as ReviewablePrProvider, repo, prNumber };
+  return { provider: task.provider, repo, prNumber };
+};
+
+type PrKeyParams = {
+  readonly provider: ReviewablePrProvider;
+  readonly prNumber: number;
+};
+
+export const reviewPrKey = ({ provider, prNumber }: PrKeyParams): string =>
+  `${provider}#${prNumber}`;
+
+const byProviderThenNumber = (left: ReviewTarget, right: ReviewTarget): number => {
+  const rank = PROVIDER_PRIORITY.indexOf(left.provider) - PROVIDER_PRIORITY.indexOf(right.provider);
+  if (rank !== 0) {
+    return rank;
+  }
+  return left.prNumber - right.prNumber;
+};
+
+type FromTasksParams = {
+  readonly tasks: ReadonlyArray<SessionExternalTask>;
+  readonly discoveredPrKeys?: ReadonlySet<string>;
+};
+
+export const reviewTargetFromTasks = ({
+  tasks,
+  discoveredPrKeys,
+}: FromTasksParams): ReviewTarget | null => {
+  const candidates = tasks
+    .filter(isReviewableTask)
+    .flatMap((task) => {
+      const target = targetFromTask({ task });
+      return target == null ? [] : [target];
+    })
+    .sort(byProviderThenNumber);
+  const discovered = candidates.find(
+    (candidate) => discoveredPrKeys?.has(reviewPrKey(candidate)) === true,
+  );
+  return discovered ?? candidates[0] ?? null;
 };
 
 type Params = {
@@ -56,5 +94,20 @@ type Params = {
   readonly sessionId: SessionId;
 };
 
+const discoveredPrKeysForSession = ({ get, sessionId }: Params): ReadonlySet<string> => {
+  const keys = new Set<string>();
+  for (const pr of get().sessionGithubPrs?.[sessionId] ?? []) {
+    keys.add(reviewPrKey({ provider: 'github', prNumber: pr.number }));
+  }
+  const mergeRequest = get().sessionGitlabMr?.[sessionId]?.mr ?? null;
+  if (mergeRequest != null) {
+    keys.add(reviewPrKey({ provider: 'gitlab', prNumber: mergeRequest.iid }));
+  }
+  return keys;
+};
+
 export const resolveReviewTarget = ({ get, sessionId }: Params): ReviewTarget | null =>
-  reviewTargetFromTasks({ tasks: get().sessionExternalTasks[sessionId] ?? [] });
+  reviewTargetFromTasks({
+    tasks: get().sessionExternalTasks?.[sessionId] ?? [],
+    discoveredPrKeys: discoveredPrKeysForSession({ get, sessionId }),
+  });

--- a/apps/desktop/src/store/slices/review-prs/index.test.ts
+++ b/apps/desktop/src/store/slices/review-prs/index.test.ts
@@ -202,6 +202,28 @@ describe('review-prs slice', () => {
     expect(result.error).toBeNull();
   });
 
+  it('reads the integration host so a self-hosted gitlab remote still fetches', async () => {
+    worktreeRemoteUrlSpy.mockResolvedValue('git@code.acme.dev:acme/web.git');
+    const integration = buildGitlabIntegration();
+    gitlabFetchProjectMrsSpy.mockResolvedValue([buildMr({ iid: 11 })]);
+    const { slice, getState } = buildHarness({
+      workspaceIntegrations: {
+        [WS_ID]: [
+          { ...integration, config: { ...integration.config, host: 'https://code.acme.dev' } },
+        ],
+      },
+    });
+
+    await slice.refreshReviewPrs(WS_ID);
+
+    expect(gitlabFetchProjectMrsSpy).toHaveBeenCalledWith(
+      WS_ID,
+      'https://code.acme.dev',
+      'acme/web',
+    );
+    expect(selectReviewPrs(WS_ID)(getState()).items.map((p) => p.id)).toEqual(['gitlab:11']);
+  });
+
   it('keeps github results when the gitlab provider fails', async () => {
     detectRepoSlugSpy.mockResolvedValue('org/repo');
     listOpenPrsForRepoSpy.mockResolvedValue([buildRepoPr({ number: 7 })]);

--- a/apps/desktop/src/store/slices/review-prs/index.test.ts
+++ b/apps/desktop/src/store/slices/review-prs/index.test.ts
@@ -12,11 +12,13 @@ import type { AppStore } from '../../store';
 import type { SetFn } from './types';
 import { createReviewPrsSlice, selectReviewPrs } from './index';
 
-const { detectRepoSlugSpy, listOpenPrsForRepoSpy, gitlabFetchProjectMrsSpy } = vi.hoisted(() => ({
-  detectRepoSlugSpy: vi.fn(),
-  listOpenPrsForRepoSpy: vi.fn(),
-  gitlabFetchProjectMrsSpy: vi.fn(),
-}));
+const { detectRepoSlugSpy, listOpenPrsForRepoSpy, gitlabFetchProjectMrsSpy, worktreeRemoteUrlSpy } =
+  vi.hoisted(() => ({
+    detectRepoSlugSpy: vi.fn(),
+    listOpenPrsForRepoSpy: vi.fn(),
+    gitlabFetchProjectMrsSpy: vi.fn(),
+    worktreeRemoteUrlSpy: vi.fn(),
+  }));
 
 vi.mock('@goodboy/core', () => ({
   detectRepoSlug: detectRepoSlugSpy,
@@ -32,7 +34,7 @@ vi.mock('../../../features/integrations/gitlab/client', () => ({
 }));
 
 vi.mock('../../../features/worktree/worktree', () => ({
-  worktreeRemoteUrl: vi.fn(async () => 'git@gitlab.com:acme/web.git'),
+  worktreeRemoteUrl: worktreeRemoteUrlSpy,
 }));
 
 const WS_ID = 'workspace-1' as WorkspaceId;
@@ -130,6 +132,7 @@ describe('review-prs slice', () => {
     detectRepoSlugSpy.mockResolvedValue(null);
     listOpenPrsForRepoSpy.mockResolvedValue([]);
     gitlabFetchProjectMrsSpy.mockResolvedValue([]);
+    worktreeRemoteUrlSpy.mockResolvedValue('git@gitlab.com:acme/web.git');
   });
 
   it('classifies github PRs as mine or review-requested case-insensitively', async () => {
@@ -181,6 +184,22 @@ describe('review-prs slice', () => {
     expect(byIid.get(2)?.authorAvatarUrl).toBe('https://gitlab.com/n.png');
     expect(byIid.get(1)?.mine).toBe(false);
     expect(byIid.get(4)?.reviewRequested).toBe(true);
+  });
+
+  it('skips the gitlab fetch on a github remote so the github half stays clean', async () => {
+    worktreeRemoteUrlSpy.mockResolvedValue('git@github.com:org/repo.git');
+    detectRepoSlugSpy.mockResolvedValue('org/repo');
+    listOpenPrsForRepoSpy.mockResolvedValue([buildRepoPr({ number: 7 })]);
+    gitlabFetchProjectMrsSpy.mockRejectedValue(new Error('404 project not found'));
+    const { slice, getState } = buildHarness({
+      githubStatus: { available: true, mode: 'gh-cli', user: 'me' },
+      workspaceIntegrations: { [WS_ID]: [buildGitlabIntegration()] },
+    });
+    await slice.refreshReviewPrs(WS_ID);
+    const result = selectReviewPrs(WS_ID)(getState());
+    expect(gitlabFetchProjectMrsSpy).not.toHaveBeenCalled();
+    expect(result.items.map((p) => p.id)).toEqual(['github:7']);
+    expect(result.error).toBeNull();
   });
 
   it('keeps github results when the gitlab provider fails', async () => {

--- a/apps/desktop/src/store/slices/review-prs/refreshReviewPrs.ts
+++ b/apps/desktop/src/store/slices/review-prs/refreshReviewPrs.ts
@@ -9,7 +9,7 @@ import { tauriGhRunner } from '../../../features/github/github';
 import { gitlabFetchProjectMrs } from '../../../features/integrations/gitlab/client';
 import { worktreeRemoteUrl } from '../../../features/worktree/worktree';
 import { formatError } from '../../../shared/lib/errors';
-import { projectPathFromRemoteUrl } from '../../../shared/lib/remoteHost';
+import { classifyRemoteHost, projectPathFromRemoteUrl } from '../../../shared/lib/remoteHost';
 import { mapGithubPr } from './mapGithubPr';
 import { mapGitlabMr } from './mapGitlabMr';
 import type { GetFn, SetFn } from './types';
@@ -109,7 +109,9 @@ export const refreshReviewPrs = (set: SetFn, get: GetFn) => {
       for (const target of targets) {
         try {
           const remoteUrl = await worktreeRemoteUrl(target.rootPath);
-          const projectPath = projectPathFromRemoteUrl(remoteUrl);
+          const isGitlabRemote =
+            classifyRemoteHost(remoteUrl, [integration.config.host]) === 'gitlab';
+          const projectPath = isGitlabRemote ? projectPathFromRemoteUrl(remoteUrl) : null;
           if (projectPath != null) {
             const mrs = await gitlabFetchProjectMrs(
               workspaceId,


### PR DESCRIPTION
## What shipped

A workspace can now hold a GitHub credential and a GitLab (or Bitbucket) integration at the same time. Use GitHub as your code host and GitLab as your task manager, or any other mix.

The four UI sites named in the issue were only the surface. The real gate lived in `resolveIntegrationConnection`, which derived GitHub's `isConnected` from the workspace **remote**: `hasGithubRemote && isGithubAuthenticated`. Every other provider was gated on credential presence alone. So a valid workspace GitHub PAT reported "not connected" on any workspace whose remote was not GitHub, and GitHub silently vanished from the new-session issue picker. Deleting only the banners would have shipped a release whose headline claim was true in the database and false in the UI.

## Sites changed

**A. The two connect-form exclusions**
- `features/integrations/gitlab/GitlabFormBody.tsx`: removed the "Disconnect GitHub to use GitLab" banner, the connect-button suppression, the `githubScoped` state/effect, and the `onDisconnectGithub` handler. That cross-disconnect existed only to serve the exclusion, so it went with it. The form no longer imports `ghStatus`/`ghClearToken` at all.
- `features/integrations/github/GithubFormBody.tsx`: removed the symmetric banner, the connect suppression, the `gitlabConnected` derivation and the `disconnectGitlab` call.

**B. The real gate**
- `features/integrations/connection.ts`: GitHub's `isConnected` is now `isGithubAuthenticated`. The `pr` surface is now `isGithubAuthenticated || hasGitlab || hasBitbucket` (the GitLab arm no longer requires a GitLab remote, matching what Bitbucket already did). `hasGithubRemote` and `hasGitlabRemote` are gone, and with them the whole `remoteKind` param, which was dead once it stopped deciding anything. That removal cascades through `issueSources.ts` and eleven call sites.
- `features/github/components/GitHubStudio/index.tsx`: the studio browses one repo's PRs and issues, so it still needs a GitHub remote for there to be anything to browse. The connection and the content gate are now separate: `isGithubConnected` (credential) and `canBrowseRepo = isGithubConnected && hasGithubRemote`. Behavior here is unchanged on purpose; the remote decides what content exists, not whether you are connected.
- `App.tsx`: `githubEnabled={remoteKind === 'github'}` on the footer glyph became `githubEnabled={githubConnection.isAuthenticated}`, which is the exact parallel of `hasLinear`/`hasGitlab` next to it. `useGithubConnection` now accepts a null workspace id so the App-level call needs no cast.
- `features/session/.../LensColumn`, `IntegrationPane`, `PrPane`, and the six provider studios: updated for the narrowed signature. `PrPane` keeps `remoteKind` where it genuinely means "can a PR exist for this repo" (the missing-remote empty state, the host title, the tab hint).

**C. The wizard copy**
- `features/onboarding/OnboardingWizard/steps/CodeHostStep.tsx`: "You can only use one at a time." is now false. Replaced with "Connect as many as you use: one host for code, another for tickets."

**D. Deterministic review-target resolution**
- `store/slices/review-drafts/resolveReviewTarget.ts`: rewritten. It filtered nothing and `.find()`-ed the first github-or-gitlab task in an array with no ordering guarantee. That order genuinely flips across an app restart: `linkSessionExternalTask` appends in session, while `packages/db/src/queries/session-external-task.ts` reloads `ORDER BY created_at ASC, provider ASC`, and `'github' < 'gitlab'`. Now: a `ReviewableTask` type predicate narrows to the providers this function can actually review (so the cast through `ReviewablePrProvider` is gone and the GitLab `/-/` parser can no longer receive a non-GitLab url), candidates sort by `PROVIDER_PRIORITY` then pr number, and a candidate matching a pull request the store has already discovered (`sessionGithubPrs`, `sessionGitlabMr`) wins. `PROVIDER_PRIORITY` is now exported from `resolvePullRequestProvider.ts` rather than duplicated. No hook involved: this is a plain slice function.

**E. One host's failure must not poison the other's panel**
- `store/slices/review-prs/refreshReviewPrs.ts`: the GitLab arm fetched merge requests for whatever project path the remote yielded, with no check that the remote was GitLab. With a GitHub remote plus GitLab connected, that was a guaranteed 404 whose message landed in the panel-level error string beside successful GitHub results. Now guarded with `classifyRemoteHost(remoteUrl, [integration.config.host]) === 'gitlab'`. Deliberately narrow: the error-joining behavior for genuine failures is untouched.

**F. Six connect forms made a false claim (seven, actually)**
`GithubFormBody`, `GitlabFormBody`, `LinearFormBody`, `SentryFormBody`, `BitbucketFormBody`, `JiraFormBody` all said the token "never leaves this machine". False for every token-auth host: the token is sent to the vendor on every call. All six now use the statement `SlackFormBody` already used, naming the vendor: stored encrypted in the OS keychain, sent directly to the vendor over HTTPS, never touches Goodboy's own servers. A seventh site not in the brief, `features/github/components/Panel/index.tsx:186` ("it never leaves your machine"), had the same problem and got the same fix.

## Tests rewritten, and why they pinned deprecated behavior

- `GitlabFormBody.test.tsx` "when a scoped GitHub token exists (mutual exclusivity)" asserted the mutex banner rendered and the connect form did not. That is the behavior being removed. Rewritten to assert the form is offered, no cross-host disconnect is present, and the component never calls `ghStatus` or `ghClearToken` at all.
- `GithubFormBody.test.tsx` "when GitLab is connected (mutual exclusivity)" was the mirror image. Rewritten to assert the token form is offered and connecting GitHub does not touch the GitLab integration.
- `connection.test.ts` "uses workspace remotes for pull request and GitHub availability" and "does not treat a GitHub remote as an authenticated connection" both encoded the remote gate. Rewritten to pin credential-based connection, including the case no test covered: a valid GitHub credential on a workspace whose only integration is GitLab.
- `NewSessionView/index.test.tsx` "drops the section when nothing is connected" expressed "GitHub disconnected" as `remoteKind = 'other'`. That is no longer what disconnected means. It now sets the GitHub credential absent. Added a positive case: GitLab remote plus GitHub token keeps both tabs.
- `LensColumn/index.test.tsx` parametrized disconnected-row case expressed the same thing as `remote.kind = null`. Same fix.
- `GitHubStudio/index.test.tsx` needed no change once connection and content gate were separated, which is the check that the separation is right.

New: `resolveReviewTarget.test.ts` (same two candidates in both array orders yield the same target, with and without a discovered PR; a Bitbucket task is never routed through the reviewable parsers), a `refreshReviewPrs` case asserting GitLab is not attempted on a GitHub remote and the panel error stays null, an `issueSources` case keeping GitHub in the picker with a GitLab-only integration, and the Slack "never leaves this machine" absent-assertion copied to all six forms.

## Non-goals, by design

- **A per-workspace "primary code host" model** with its own store and settings surface. Out of scope.
- **`PrPane`'s GitLab tab discovery.** `PrPane.tsx` sets `availability.gitlab = mergeRequest != null`, and the only automatic populator (`GitlabMrStrip.tsx`) bails when the remote is not GitLab. Unlike Bitbucket, which has an explicit discovery effect, GitLab has no equivalent. Known-remaining, not fixed here.
- **`VISION.md:102-104`** ("GitHub, GitLab or Bitbucket for code review") is a list, not a restriction. Left alone.

## Docs

Grepped `VISION.md`, `README.md`, `docs/` and `website/` for one-code-host claims ("one at a time", "only one", "mutual", "exclusiv", "single code host"). **No hits outside `CodeHostStep.tsx`.** No doc references `resolveIntegrationConnection` or the remote-gated GitHub connection, so nothing else needed fixing.

## Corrections to the brief

- The brief said a Bitbucket task yields a nonsense repo through `resolveReviewTarget`. It cannot: the old `.find()` already restricted candidates to github or gitlab, so `repoFromTask` never saw a Bitbucket task on that path. The array-order flip was real; the Bitbucket path was not. The rewrite closes it structurally anyway via the type predicate.
- `LensColumn` is at `SessionWorkspace/parts/LensColumn/`, not `SessionWorkspace/LensColumn/`.
- The consumer list was not exhaustive: six more studios (GitLab, Linear, Jira, Slack, Bitbucket, Sentry) called `resolveIntegrationConnection` with `remoteKind: null`, and `NewSessionView` called `resolveIssueSources`.
- `App.tsx:782` does not call `resolveIntegrationConnection`; it computed `remoteKind === 'github'` inline. Fixed to the credential check regardless.
- The false token claim is on seven surfaces, not six.

## Verification

`pnpm typecheck` green. `pnpm test` green: **6212 tests, 6208 passed, 4 skipped** (desktop 4844, core 1065 + 4 skipped, db 196, ui 103). `pnpm knip --include files,duplicates,unlisted` exits 0.

Not verified: nothing was exercised against a live GitLab or Bitbucket instance, so the runtime behavior of a real mixed-host workspace rests on the unit tests alone.

Refs #1264

## Repair pass after review

**1. Two review-target resolvers could disagree (data corruption).** `useReviewDiff.ts` called `reviewTargetFromTasks({ tasks })` with no `discoveredPrKeys`, while `addReviewDraft`, `publishPrReview` and `queueAgentReviewComments` went through `resolveReviewTarget`, which passes them. On a GitLab-remote workspace with both a linked GitHub PR task and a linked GitLab MR task, `sessionGithubPrs` stays empty (the GitHub poller needs `detectRepoSlug`, which fails on a non-GitHub remote) while `sessionGitlabMr` is populated: the diff pane rendered the GitHub PR's files while every draft written on those files was stamped with the GitLab MR's provider, repo and number.

Fixed by collapsing to one exported entry point. `reviewTargetFromTasks` is no longer exported; `resolveReviewTarget` now takes `{ state, sessionId }` where `state` is `ReviewTargetState = Pick<AppState, 'sessionExternalTasks' | 'sessionGithubPrs' | 'sessionGitlabMr'>`, the same shape convention `resolveSessionRepo` already uses. The store callers pass `get()`; the diff pane selects through `useAppStore(useShallow(...))` so both paths run the identical function over the identical state. `discoveredPrKeys` is now required, not optional, so a caller cannot silently omit it again.

**2. The credential path this PR opens was barely reachable.** Every in-app GitHub token form sat behind a remote check, so the branch that is the main place a user enters a token rendered a state containing no form. The remote gate is right as a content gate (both GitHub studio tabs are repo-scoped) and wrong as an affordance gate. `GithubConnectionEmptyState` now takes `isConnected` instead of `hasGithubRemote` and branches on the credential first: not connected renders the token form whatever the remote is, connected renders the missing-remote explanation. `GitHubStudio` keeps `canBrowseRepo` for the content gate. `PrPane` now routes both cases through the same component instead of ordering the two empty states itself, and `IntegrationPane` no longer needs `useRemoteHostKind` at all.

**3. App-level GitHub connection state was never invalidated (regression).** `useGithubConnection` refreshed only when `workspaceId` changed, so connecting a token from the studio left the footer glyph grey until a workspace switch or a restart. On main this could not happen because the flag was `remoteKind === 'github'`, which does not mutate at runtime. `useGithubConnection` now exports `notifyGithubConnectionChanged()` which dispatches `goodboy:github-connection-changed`, following the existing `window.dispatchEvent(new CustomEvent('goodboy:...'))` convention; every hook instance subscribes and re-reads. `refresh()` broadcasts rather than refreshing only its own copy, and `GithubFormBody` broadcasts after both connect and disconnect so the wizard path is covered too.

**4. The new-session GitHub tab no longer goes silently empty.** `fetchIssueCandidates` returned `[]` when `detectRepoSlug` found no repository, so the tab rendered an empty list with no explanation on any non-GitHub remote. It now throws a named error, which `useIssueCandidates` already surfaces and `IssuePicker` already renders in its error box.

**5. Test gaps closed.** Each of these was proven uncovered by sabotage, then closed and re-proven red before the fix was restored:
- `resolveReviewTarget` dropping `discoveredPrKeys`: now caught by `resolveReviewTarget.test.ts` and the new `useReviewDiff.test.ts`, which asserts the hook's target equals what `resolveReviewTarget` returns for the same state and that the GitLab diff is the one fetched.
- `App.tsx` `githubEnabled={false}`: now caught by a GitHub arm in `footer-studio-reachability.test.tsx`, including the case that carries the headline outcome, a GitHub credential on a GitLab-only workspace.
- Restoring "You can only use one at a time." to `CodeHostStep.tsx`: caught by a copy assertion.
- Restoring "it never leaves your machine." to `features/github/components/Panel/index.tsx`: caught by a copy assertion.
- `classifyRemoteHost(remoteUrl, [])` in `refreshReviewPrs.ts`: the only existing guard test used `gitlab.com`, whose hostname literally contains "gitlab", so the integration host was never read. Added a self-hosted host case.
- The GitHub studio rendering the missing-remote state instead of the token form when disconnected.
- `useGithubConnection` losing the broadcast subscription.

Also removed a dead `useWorkspaceRemoteHostKind` mock (and the now inert `remoteKind` harness field) from `NewSessionView/index.test.tsx`, and gave the `review-drafts` slice harness the `sessionGithubPrs` and `sessionGitlabMr` keys the real store always has.

## Known remaining

- **`mode: 'gh-cli'` satisfies `isAuthenticated`.** The gate is not PAT-only: a machine-wide `gh` login lights GitHub up on every workspace, including workspaces with no GitHub remote and no workspace-scoped token. That is pre-existing `ghStatus` semantics, not something this PR changes, but it is now the thing the footer glyph reflects.
- **`PrPane`'s GitLab tab discovery.** `availability.gitlab = mergeRequest != null`, and the only automatic populator (`GitlabMrStrip.tsx`) bails when the remote is not GitLab. Unlike Bitbucket, GitLab has no explicit discovery effect.
- **The new-session GitHub tab still cannot list issues on a non-GitHub remote.** It now says so instead of showing an empty list, but `detectRepoSlug` runs `gh repo view` in the workspace root and has no way to reach a GitHub repository that is not the workspace remote.
