### PR TITLE
docs(repo): tighten the changelog voice

### DIFF
--- a/.claude/skills/continuous-delivery/references/release-captain-prompt.md
+++ b/.claude/skills/continuous-delivery/references/release-captain-prompt.md
@@ -92,9 +92,12 @@ operational specifics:
   `gh release list`: if v{{version}} or later already exists, a human
   shipped mid-engagement; stop and report instead of tagging a collision.
   Never tag while another tag build is in flight; confirm the previous
-  version's homebrew run finished first. Notes
-  from PR bodies you read, never commit messages or memory; name every call
-  that was never sent to a live tenant.
+  version's homebrew run finished first. Notes from PR bodies you read, never
+  commit messages or memory. Obey the release notes rules in
+  `docs/tone-of-voice.md`: capability headings, the paragraph budget, and
+  work never exercised against a live service written as a one-line
+  follow-up, never as a confession. Your report to the caller stays flat and
+  unvarnished.
 
 **Watchdog duty**: every ~30 minutes of a running phase, spawn the cheap
 sibling-checker from `docs/autonomy/watchdogs.md` and act on its report.
@@ -123,7 +126,7 @@ dropped: <item>: <why>                          (omit if none)
 pushback: <what the PO refused and why>          (omit if none)
 changed: <3-6 lines, what a user would notice>
 closed-tab: <which reason to open another tool this release removed, or "none">
-unverified: <calls never exercised against a live tenant>
+unverified: <calls never exercised against a live service; internal, the notes say it as a follow-up>
 broke: <deprecated behavior/tests deliberately removed, or "none">
 draft: <state of the draft release and its assets>
 risk: <what you would watch, or "none">

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ Linear could show you an issue and start a session from it, and write back nothi
 
 You can now comment on an issue from the studio and the session pane, through the same composer the other hosts use, and the comment Linear returns lands in the thread you are reading. Assign and transition are still missing: both need the team and workflow state ids, which Goodboy does not read from Linear yet.
 
-Follow-up: the mutation and its input come from Linear's published schema. If a shape differs, Linear's own error comes back in the composer with your draft still in it.
+Follow-up: the mutation and its input come from Linear's published schema, though no call has gone out to a live Linear workspace yet. If a shape differs, Linear's own error comes back in the composer with your draft still in it.
 
 ### [#1274] Popovers open above full-page surfaces
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,45 +9,35 @@ if it can't find a matching `## Goodboy vX.Y.Z` heading.
 
 ## Goodboy v0.1.66
 
-Seven integrations shipped in five releases, and the surface around them fell behind. This one makes every connected host reachable, and makes the states they report honest.
+Seven hosts are connected. This release makes every one of them reachable from the footer, and makes the states they report honest.
 
-### [#1272] Bitbucket has a way in
+### [#1272] Connect Bitbucket from the footer
 
-Bitbucket shipped whole in v0.1.64: the commands, the connect form, the studio, the eight review verbs. The footer, which is where a workspace connects an integration, never got an entry for it. If you had not already linked a Bitbucket pull request to a session, there was no route to the token field at all, and the only honest description of that is a host we shipped and you could not turn on.
+Bitbucket shipped whole in v0.1.64 except for the way in. The footer, where a workspace connects an integration, had no entry for it, so unless you had already linked a pull request to a session there was no route to the token field.
 
-The footer now carries Bitbucket with the other code hosts. Not connected, it opens the same connect panel every other integration opens. Connected, it opens a workspace view of the repository's pull requests, and Start session works from there.
+It sits with the other code hosts now. Not connected, it opens the same connect panel as everything else. Connected, it opens the repository's pull requests, and Start session works from there. That workspace view is read only: approve, request changes, merge, decline, comment and reply stay inside a session, where they are keyed to its worktree. A composite workspace has no single repository to read outside a session, so it shows an empty state and points you back into one.
 
-The limit, stated plainly: that workspace view is read only. Approve, request changes, merge, decline, comment and reply stay where they were, inside a session, because they are keyed to the session's worktree and this release does not move them. A composite workspace has no single repository to read outside a session, so it shows an empty state and points you back into one. Connecting still works there, which is what the report was about.
+### [#1271] Pull requests carry the queued check state
 
-Bitbucket is gated on the connection you made, not on your git remote. A `bitbucket.org` remote still does not turn anything on by itself.
+A pull request whose checks were queued or still running reported as passed, so Goodboy could tell you CI was green on a run that had not started. The rollup now calls green only on an affirmative pass, reads anything it does not recognise as pending, and treats action required and startup failure as the failures they are.
 
-### [#1271] The pull request tells the truth
+Sending a pull request to the merge queue also read as plain open, with Merge still on the button, so a second click looked like the first had not worked. Goodboy now shows the real placement, "In merge queue #3", and auto-merge keeps its own wording.
 
-Two separate things were wrong, and together they made a merge look like it had failed.
+Follow-up: the queue fields come from GitHub's live schema and the parsing is covered by tests, though no pull request has gone through a populated queue here yet. On a repository with more than 100 open pull requests, one queued outside that window keeps the old behavior.
 
-A pull request whose checks were queued or still running reported as passed. The rollup read a check's conclusion and its status field together, and an unfinished run comes back from GitHub with an empty conclusion rather than an empty value, so it fell through every branch and landed on green. Goodboy told you CI had passed on a run that had not started. The rollup now reads what a check actually reports and calls it green only on an affirmative pass. Anything it does not recognise reads as pending, never as passed. Two conclusions GitHub does return and Goodboy silently passed, action required and startup failure, now read as failures.
+### [#1273] Comment on a Linear issue from the app
 
-The queued state meant auto-merge, not the merge queue. So a pull request you had just sent to the queue read as plain open, Merge stayed on the button, and clicking it again looked like the first click had not worked. Goodboy now asks GitHub for the real queue placement and shows the position, "In merge queue #3". Auto-merge keeps its own wording instead of borrowing the queue's.
+Linear could show you an issue and start a session from it, and write back nothing but the description. Commenting meant opening linear.app, which is the tab this is supposed to remove.
 
-Not verified: no pull request was pushed through a real merge queue, because that needs a ruleset this repository does not have. The fields were checked against GitHub's live schema and the parsing is covered by tests, but a populated queue entry has not been observed. On a repository with more than 100 open pull requests, one queued outside that window keeps the old behaviour.
+You can now comment on an issue from the studio and the session pane, through the same composer the other hosts use, and the comment Linear returns lands in the thread you are reading. Assign and transition are still missing: both need the team and workflow state ids, which Goodboy does not read from Linear yet.
 
-### [#1273] Reply to a Linear issue without leaving
+Follow-up: the mutation and its input come from Linear's published schema. If a shape differs, Linear's own error comes back in the composer with your draft still in it.
 
-Linear could show you an issue and start a session from it, and the only thing it could write back was the description. Commenting meant opening linear.app, which is the tab this is supposed to remove.
+### [#1274] Popovers open above full-page surfaces
 
-You can now write a comment on a Linear issue from inside Goodboy, in the studio and in the session pane, through the same composer the other hosts use. The comment Linear returns is appended to the thread you are reading.
+Notifications and the workspace selector did nothing visible while an integration studio, a studio page or settings was open: the popover was opening a layer too low, behind the page.
 
-Assign and transition are still not there. Both need the issue's team and workflow state identifiers, which Goodboy does not currently read from Linear, so they need a fetch that does not exist yet rather than a button.
-
-Not verified: no call has run against a live Linear workspace. The mutation and its input come from Linear's published schema. If the shape is wrong, Linear's own error comes back into the composer and your draft is kept.
-
-### [#1274] Popovers stay on top
-
-Opening notifications or the workspace selector while an integration studio, a studio page or settings was open did nothing visible. The popover was opening, behind the page, on a layer one step too low. Every full-page surface in the app sat above every transient one.
-
-Layering is now a named scale rather than four numbers that happened to agree, so a studio, a popover, the command palette, a tooltip and a toast each know where they stand. The four popovers are also wider and taller, and their scroll fade matches the surface it sits on instead of darkening it.
-
-Workspace settings moved out of the workspace popover onto the workspace row itself, so the settings that apply to every session in a workspace are visible without opening anything.
+Layering is a named scale now rather than four numbers that happened to agree, so a studio, a popover, the command palette, a tooltip and a toast each know where they stand. The four popovers are wider and taller, and their scroll fade matches the surface it sits on. Workspace settings moved out of the workspace popover onto the workspace row, where settings that apply to every session are visible without opening anything.
 
 ### Fixes
 

--- a/docs/autonomy/release-loop.md
+++ b/docs/autonomy/release-loop.md
@@ -129,7 +129,13 @@ Regression classes to hunt, all shipped in this repo at least once:
 ## Honesty in the notes
 
 Release notes come from the merged PR bodies the captain actually read, in
-the repo's tone of voice. What was never exercised against a live tenant is
-named in plain language in the notes, the PR bodies and the report: shipping
-unverified-but-honest is the house standard, shipping unverified-and-silent
-is a defect.
+the repo's tone of voice, which owns their shape and length
+([tone-of-voice.md](../tone-of-voice.md) sets the heading form, the paragraph
+budget and the follow-up line).
+
+What was never exercised against a live service is still tracked in full, but
+each audience gets it in its own form. The captain's report and the PR bodies
+name it flatly, because the delivery lead and the reviewer need the risk.
+The notes carry it as a **follow-up**: what the work stands on, and what the
+app does if reality disagrees. Never a confession of not having tested.
+Silence is still the defect; self-flagellation is not the cure.

--- a/docs/release-command.md
+++ b/docs/release-command.md
@@ -64,10 +64,16 @@ missing.
   follow-up work or migrations unless the PR itself commits to it.
 - Include only `desktop`/`ui`/`core` PRs in the app notes. Exclude
   `website`/`repo`/`docs` PRs.
-- BEFORE writing, read `docs/tone-of-voice.md` and obey it: no "AI", no em-dashes,
-  no fluff/minimizers/superlatives, no "bring your own X", sentence-case
-  headings, no trailing period on headings/list items, problem-then-fix, name the
-  limits.
+- BEFORE writing, read `docs/tone-of-voice.md` and obey it, in particular its
+  "Release notes" rules: headings name the capability and never personify it
+  ("Pull requests carry the queued check state", not "The pull request tells
+  the truth"); the headline feature gets a lead line plus at most three short
+  paragraphs, every other feature one or two, a fix one line; limits go inside
+  the sentence that promises the thing; work not yet exercised against a live
+  service is a one-line follow-up, never "not verified". Plus the standing
+  rules: no "AI", no em-dashes, no fluff/minimizers/superlatives, no "bring
+  your own X", sentence-case headings, no trailing period on headings/list
+  items.
 
 ### Format (match the curated changelog of v0.1.7 through v0.1.11)
 

--- a/docs/tone-of-voice.md
+++ b/docs/tone-of-voice.md
@@ -109,6 +109,35 @@ the product to one provider or to the person who happened to write it.
   harder than "you babysit". Between two true words, take the one with the most
   edge, never the one that softens it.
 
+### Release notes
+
+The changelog is the one place that gets to sell a little, and it earns that
+by being short. The release lead line is the pitch; everything under it is
+plain fact.
+
+- **The heading names the capability, not a mood.** "Pull requests carry the
+  queued check state" not "The pull request tells the truth". Verb and object,
+  in the words a user would use to ask for the thing. Objects do not tell,
+  know, feel or remember.
+- **Budget the length.** The headline feature gets a lead line plus at most
+  three short paragraphs. Every other feature gets one or two. A fix gets one
+  line. Cut any paragraph that explains why the old behavior existed: the
+  reader never saw it.
+- **State a limit inside the sentence that promises the thing**, not in a
+  paragraph of its own. "Public channels the bot has joined" beats four
+  sentences of scope caveats.
+- **Work that has not been exercised against a live service is a follow-up,
+  never a confession.** Never write "not verified", "this has not run against
+  a live X", or "proves nothing". Write what the work stands on and what the
+  app does when reality disagrees:
+
+  > Follow-up: the mutation and its input come from Linear's published schema.
+  > If a shape differs, Linear's own error comes back in the composer with the
+  > draft still in it.
+
+  One line, at the end of the feature it belongs to, and one line covers
+  several features when they share the same follow-up.
+
 ### Honesty
 
 - **Don't oversell the roadmap.** "A proper Linear Studio is on the way" not

--- a/docs/tone-of-voice.md
+++ b/docs/tone-of-voice.md
@@ -131,8 +131,9 @@ plain fact.
   a live X", or "proves nothing". Write what the work stands on and what the
   app does when reality disagrees:
 
-  > Follow-up: the mutation and its input come from Linear's published schema.
-  > If a shape differs, Linear's own error comes back in the composer with the
+  > Follow-up: the mutation and its input come from Linear's published
+  > schema, though no call has gone out to a live Linear workspace yet. If a
+  > shape differs, Linear's own error comes back in the composer with the
   > draft still in it.
 
   One line, at the end of the feature it belongs to, and one line covers


### PR DESCRIPTION
## What

- `docs/tone-of-voice.md` gains a "Release notes" section: headings name the capability instead of personifying the object, each feature gets a paragraph budget (headline: lead plus three short paragraphs; others: one or two; fixes: one line), limits go inside the sentence that promises the thing, and work not yet exercised against a live service reads as a one-line `Follow-up:` rather than "Not verified".
- `docs/release-command.md`, `docs/autonomy/release-loop.md` and the release captain brief point at those rules. The captain's internal report stays flat and unvarnished; only the user-facing notes change register.
- `CHANGELOG.md`: the v0.1.66 section rewritten to the new rules, 926 words to 666.

## Why

The v0.1.66 notes read as a wall of text with headings like "The pull request tells the truth", and every feature ended on a "Not verified" paragraph that framed shipped work as untested rather than as a follow-up.

## Test plan

- [x] Docs and changelog only
- [ ] The published v0.1.66 release body still carries the old text; syncing it is a separate call

🤖 Generated with [Claude Code](https://claude.com/claude-code)