### PR TITLE
feat(desktop): show what the work you shipped cost

### DIFF
--- a/apps/desktop/src/features/impact/components/ImpactStudio/OverviewPanel.tsx
+++ b/apps/desktop/src/features/impact/components/ImpactStudio/OverviewPanel.tsx
@@ -1,6 +1,6 @@
 import type { ImpactOverview, PullRequestOutcomes, ReviewOutcomes } from '@goodboy/db';
 import type { SessionId } from '@goodboy/types';
-import { EmptyState } from '@goodboy/ui';
+import { EmptyState, formatUsd, formatUsdPrecise } from '@goodboy/ui';
 import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../shared/components/conceptIcons';
 import { ErrorStrip } from '../../../../shared/components/ErrorStrip';
 import { PanelLoading } from '../../../../shared/components/PanelLoading';
@@ -118,14 +118,39 @@ export const OverviewPanel = ({
               }
             />
           </div>
-          <StudioWidget label="longest session wall-clock" hint="open a session to inspect its run">
-            <SessionRows
-              sessions={data.sessions}
-              valueLabel=""
-              formatValue={(value) => formatHours({ hours: value })}
-              onOpenSession={onOpenSession}
-            />
-          </StudioWidget>
+          <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+            <StudioWidget
+              label="longest session wall-clock"
+              hint="open a session to inspect its run"
+            >
+              <SessionRows
+                sessions={data.sessions}
+                valueLabel=""
+                formatValue={(value) => formatHours({ hours: value })}
+                onOpenSession={onOpenSession}
+              />
+            </StudioWidget>
+            <StudioWidget label="spend this window" hint="highest-cost sessions">
+              <div className="flex flex-col gap-3">
+                {data.spendUsd != null ? (
+                  <div
+                    title={formatUsdPrecise(data.spendUsd)}
+                    className="font-mono text-2xl tabular-nums text-foreground"
+                  >
+                    {formatUsd(data.spendUsd)}
+                  </div>
+                ) : (
+                  <span className="text-xs text-muted-foreground">No spend recorded</span>
+                )}
+                <SessionRows
+                  sessions={data.spendSessions}
+                  valueLabel=""
+                  formatValue={(value) => formatUsd(value)}
+                  onOpenSession={onOpenSession}
+                />
+              </div>
+            </StudioWidget>
+          </div>
         </>
       ) : null}
     </StudioPanel>

--- a/apps/desktop/src/features/impact/components/ImpactStudio/OverviewPanel.tsx
+++ b/apps/desktop/src/features/impact/components/ImpactStudio/OverviewPanel.tsx
@@ -131,24 +131,26 @@ export const OverviewPanel = ({
               />
             </StudioWidget>
             <StudioWidget label="spend this window" hint="highest-cost sessions">
-              <div className="flex flex-col gap-3">
-                {data.spendUsd != null ? (
+              {data.spendUsd === null ? (
+                <span className="text-xs text-muted-foreground">
+                  No spend recorded in this window
+                </span>
+              ) : (
+                <div className="flex flex-col gap-3">
                   <div
                     title={formatUsdPrecise(data.spendUsd)}
                     className="font-mono text-2xl tabular-nums text-foreground"
                   >
                     {formatUsd(data.spendUsd)}
                   </div>
-                ) : (
-                  <span className="text-xs text-muted-foreground">No spend recorded</span>
-                )}
-                <SessionRows
-                  sessions={data.spendSessions}
-                  valueLabel=""
-                  formatValue={(value) => formatUsd(value)}
-                  onOpenSession={onOpenSession}
-                />
-              </div>
+                  <SessionRows
+                    sessions={data.spendSessions}
+                    valueLabel=""
+                    formatValue={(value) => formatUsd(value)}
+                    onOpenSession={onOpenSession}
+                  />
+                </div>
+              )}
             </StudioWidget>
           </div>
         </>

--- a/apps/desktop/src/features/impact/components/ImpactStudio/ShippedPanel.tsx
+++ b/apps/desktop/src/features/impact/components/ImpactStudio/ShippedPanel.tsx
@@ -87,14 +87,14 @@ export const ShippedPanel = ({
                 <span className="min-w-0 flex-1 truncate">
                   #{entry.number} {entry.title}
                 </span>
-                {entry.spendUsd != null ? (
+                {entry.spendUsd === null ? null : (
                   <span
                     title={formatUsdPrecise(entry.spendUsd)}
                     className="shrink-0 font-mono tabular-nums text-muted-foreground"
                   >
                     {formatUsd(entry.spendUsd)}
                   </span>
-                ) : null}
+                )}
                 <span className="shrink-0 capitalize text-muted-foreground">{entry.state}</span>
                 <ArrowUpRight size={12} aria-hidden />
               </button>

--- a/apps/desktop/src/features/impact/components/ImpactStudio/ShippedPanel.tsx
+++ b/apps/desktop/src/features/impact/components/ImpactStudio/ShippedPanel.tsx
@@ -10,7 +10,7 @@ import { SessionRows } from './SessionRows';
 import { StackedBar } from './StackedBar';
 import { TrendStatCard } from './TrendStatCard';
 import { StudioWidget } from '../../../../shared/components/StudioWidget';
-import { EmptyState } from '@goodboy/ui';
+import { EmptyState, formatUsd, formatUsdPrecise } from '@goodboy/ui';
 import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../shared/components/conceptIcons';
 
 type Props = {
@@ -87,6 +87,14 @@ export const ShippedPanel = ({
                 <span className="min-w-0 flex-1 truncate">
                   #{entry.number} {entry.title}
                 </span>
+                {entry.spendUsd != null ? (
+                  <span
+                    title={formatUsdPrecise(entry.spendUsd)}
+                    className="shrink-0 font-mono tabular-nums text-muted-foreground"
+                  >
+                    {formatUsd(entry.spendUsd)}
+                  </span>
+                ) : null}
                 <span className="shrink-0 capitalize text-muted-foreground">{entry.state}</span>
                 <ArrowUpRight size={12} aria-hidden />
               </button>

--- a/apps/desktop/src/features/impact/components/ImpactStudio/index.test.tsx
+++ b/apps/desktop/src/features/impact/components/ImpactStudio/index.test.tsx
@@ -37,8 +37,7 @@ const buildMetrics = (): ImpactMetrics => ({
     previousMedianSessionHours: 3,
     sessions: [{ sessionId, goal: 'Ship impact studio', value: 2 }],
     spendUsd: 12.5,
-    previousSpendUsd: 8,
-    spendSessions: [{ sessionId, goal: 'Ship impact studio', value: 12.5 }],
+    spendSessions: [{ sessionId, goal: 'Ship impact studio', value: 7.25 }],
   }),
   pullRequests: result({
     open: 2,
@@ -53,7 +52,7 @@ const buildMetrics = (): ImpactMetrics => ({
         number: 42,
         title: 'Outcome and tempo',
         state: 'merged',
-        spendUsd: 12.5,
+        spendUsd: 3.5,
       },
     ],
   }),
@@ -137,10 +136,33 @@ describe('ImpactStudio', () => {
     expect(screen.getByText('75%')).toBeDefined();
     expect(screen.getByText(/longest session wall-clock/i)).toBeDefined();
     expect(screen.getByText(/spend this window/i)).toBeDefined();
-    expect(screen.getAllByText('$12.50').length).toBeGreaterThan(0);
-    fireEvent.click(screen.getAllByRole('button', { name: /ship impact studio/i })[0]!);
+    expect(screen.getByText('$12.50')).toBeDefined();
+    expect(screen.getByText('$7.25')).toBeDefined();
+    const drillDowns = screen.getAllByRole('button', { name: /ship impact studio/i });
+    expect(drillDowns).toHaveLength(2);
+    fireEvent.click(drillDowns[0]!);
     expect(mocks.setCurrentSession).toHaveBeenCalledWith('session-1');
     expect(onClose).toHaveBeenCalled();
+  });
+
+  it('renders the spend widget as absent rather than zero when nothing was measured', () => {
+    const base = buildMetrics();
+    mocks.metrics = {
+      ...base,
+      overview: result({ ...base.overview.data!, spendUsd: null, spendSessions: [] }),
+    };
+    render(
+      <ImpactStudio
+        workspaceId={'workspace-1' as never}
+        workspaceName="Goodboy"
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('No spend recorded in this window')).toBeDefined();
+    expect(screen.queryByText('$0')).toBeNull();
+    expect(screen.queryByText('$0.00')).toBeNull();
+    expect(screen.queryByText('$12.50')).toBeNull();
   });
 
   it('switches to Shipped and renders its key outcome rows', () => {
@@ -156,6 +178,31 @@ describe('ImpactStudio', () => {
     expect(screen.getByText('PR funnel')).toBeDefined();
     expect(screen.getByText('Published drafts: 4')).toBeDefined();
     expect(screen.getByText('src/hot.ts')).toBeDefined();
+    expect(screen.getByText('$3.50')).toBeDefined();
+  });
+
+  it('omits the pull request spend figure when the pull request has no telemetry', () => {
+    const base = buildMetrics();
+    const prs = base.pullRequests.data!;
+    mocks.metrics = {
+      ...base,
+      pullRequests: result({
+        ...prs,
+        entries: prs.entries.map((entry) => ({ ...entry, spendUsd: null })),
+      }),
+    };
+    render(
+      <ImpactStudio
+        workspaceId={'workspace-1' as never}
+        workspaceName="Goodboy"
+        onClose={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Shipped' }));
+    expect(screen.getByText('PR funnel')).toBeDefined();
+    expect(screen.queryByText('$3.50')).toBeNull();
+    expect(screen.queryByText('$0')).toBeNull();
   });
 
   it('switches to Flow and renders tempo and blocker rows', () => {

--- a/apps/desktop/src/features/impact/components/ImpactStudio/index.test.tsx
+++ b/apps/desktop/src/features/impact/components/ImpactStudio/index.test.tsx
@@ -36,6 +36,9 @@ const buildMetrics = (): ImpactMetrics => ({
     medianSessionHours: 2,
     previousMedianSessionHours: 3,
     sessions: [{ sessionId, goal: 'Ship impact studio', value: 2 }],
+    spendUsd: 12.5,
+    previousSpendUsd: 8,
+    spendSessions: [{ sessionId, goal: 'Ship impact studio', value: 12.5 }],
   }),
   pullRequests: result({
     open: 2,
@@ -50,6 +53,7 @@ const buildMetrics = (): ImpactMetrics => ({
         number: 42,
         title: 'Outcome and tempo',
         state: 'merged',
+        spendUsd: 12.5,
       },
     ],
   }),
@@ -132,7 +136,9 @@ describe('ImpactStudio', () => {
     expect(screen.getByText('orchestrated')).toBeDefined();
     expect(screen.getByText('75%')).toBeDefined();
     expect(screen.getByText(/longest session wall-clock/i)).toBeDefined();
-    fireEvent.click(screen.getByRole('button', { name: /ship impact studio/i }));
+    expect(screen.getByText(/spend this window/i)).toBeDefined();
+    expect(screen.getAllByText('$12.50').length).toBeGreaterThan(0);
+    fireEvent.click(screen.getAllByRole('button', { name: /ship impact studio/i })[0]!);
     expect(mocks.setCurrentSession).toHaveBeenCalledWith('session-1');
     expect(onClose).toHaveBeenCalled();
   });

--- a/packages/db/src/queries/impact.test.ts
+++ b/packages/db/src/queries/impact.test.ts
@@ -203,13 +203,33 @@ describe('impact overview', () => {
     expect(result.medianSessionHours).toBe(2);
     expect(result.sessions[0]?.sessionId).toBe('recent');
     expect(result.spendUsd).toBeCloseTo(4, 4);
-    expect(result.previousSpendUsd).toBeCloseTo(3, 4);
     expect(result.spendSessions[0]).toMatchObject({ sessionId: 'recent', value: 2.5 });
   });
 
   it('reports spend as absent rather than zero when no telemetry was recorded', async () => {
     const db = await seedDb();
     await addSession({ db, seed: { id: 'untelemetered', createdAt: RECENT } });
+
+    const result = await getImpactOverview(params({ db, sinceMs: SINCE }));
+
+    expect(result.spendUsd).toBeNull();
+    expect(result.spendSessions).toEqual([]);
+  });
+
+  it('reports spend as absent when every telemetry row priced the work at zero', async () => {
+    const db = await seedDb();
+    await addSession({ db, seed: { id: 'unpriced', createdAt: RECENT } });
+    await addTelemetry({
+      db,
+      seed: {
+        id: 't-unpriced',
+        runId: 'r-unpriced',
+        sessionId: 'unpriced',
+        at: RECENT,
+        provider: 'opencode',
+        cost: 0,
+      },
+    });
 
     const result = await getImpactOverview(params({ db, sinceMs: SINCE }));
 
@@ -329,6 +349,88 @@ describe('pull request outcomes', () => {
     const result = await getPullRequestOutcomes(params({ db, sinceMs: SINCE }));
 
     expect(result.entries[0]).toMatchObject({ number: 30, spendUsd: null });
+  });
+
+  it('leaves another workspace spend out of a pull request that shares its branch name', async () => {
+    const db = await seedDb();
+    await addSession({ db, seed: { id: 'mine', createdAt: RECENT } });
+    await addSession({
+      db,
+      seed: { id: 'theirs', createdAt: RECENT, workspace: otherWorkspaceId },
+    });
+    await db.execute(
+      `INSERT INTO session_worktrees
+         (id, session_id, worktree_path, branch, parallel_index, created_at)
+       VALUES ('wt-mine', 'mine', '/tmp/mine', 'ak/shared-slug', 0, ?),
+              ('wt-theirs', 'theirs', '/tmp/theirs', 'ak/shared-slug', 0, ?)`,
+      [RECENT, RECENT],
+    );
+    await db.execute(
+      `INSERT INTO github_pr_cache (branch, repo_slug, pr_json, fetched_at)
+       VALUES (?, 'repo', ?, ?)`,
+      [
+        'ak/shared-slug',
+        JSON.stringify({
+          number: 44,
+          title: 'shared branch name',
+          state: 'open',
+          updatedAt: iso(RECENT),
+        }),
+        iso(RECENT),
+      ],
+    );
+    await addTelemetry({
+      db,
+      seed: { id: 't-mine', runId: 'r-mine', sessionId: 'mine', at: RECENT, cost: 2 },
+    });
+    await addTelemetry({
+      db,
+      seed: { id: 't-theirs', runId: 'r-theirs', sessionId: 'theirs', at: RECENT, cost: 9 },
+    });
+
+    const result = await getPullRequestOutcomes(params({ db, sinceMs: SINCE }));
+
+    expect(result.entries[0]).toMatchObject({ number: 44, spendUsd: 2 });
+  });
+
+  it('reports a pull request priced at zero as having no spend', async () => {
+    const db = await seedDb();
+    await addSession({ db, seed: { id: 'freebie', createdAt: RECENT } });
+    await db.execute(
+      `INSERT INTO session_worktrees
+         (id, session_id, worktree_path, branch, parallel_index, created_at)
+       VALUES ('wt-freebie', 'freebie', '/tmp/freebie', 'ak/freebie', 0, ?)`,
+      [RECENT],
+    );
+    await db.execute(
+      `INSERT INTO github_pr_cache (branch, repo_slug, pr_json, fetched_at)
+       VALUES (?, 'repo', ?, ?)`,
+      [
+        'ak/freebie',
+        JSON.stringify({
+          number: 51,
+          title: 'unpriced provider run',
+          state: 'open',
+          updatedAt: iso(RECENT),
+        }),
+        iso(RECENT),
+      ],
+    );
+    await addTelemetry({
+      db,
+      seed: {
+        id: 't-freebie',
+        runId: 'r-freebie',
+        sessionId: 'freebie',
+        at: RECENT,
+        provider: 'opencode',
+        cost: 0,
+      },
+    });
+
+    const result = await getPullRequestOutcomes(params({ db, sinceMs: SINCE }));
+
+    expect(result.entries[0]).toMatchObject({ number: 51, spendUsd: null });
   });
 });
 

--- a/packages/db/src/queries/impact.test.ts
+++ b/packages/db/src/queries/impact.test.ts
@@ -112,6 +112,7 @@ type TelemetrySeed = {
   readonly cached?: number;
   readonly created?: number;
   readonly context?: number | null;
+  readonly cost?: number;
 };
 
 const addTelemetry = async ({
@@ -136,13 +137,14 @@ const addTelemetry = async ({
        (id, run_id, session_id, kind, provider, model, input_tokens, output_tokens,
         estimated_cost_usd, recorded_at, cached_input_tokens, cache_creation_input_tokens,
         context_tokens)
-     VALUES (?, ?, ?, 'turn', ?, 'opus', ?, 10, 0.1, ?, ?, ?, ?)`,
+     VALUES (?, ?, ?, 'turn', ?, 'opus', ?, 10, ?, ?, ?, ?, ?)`,
     [
       seed.id,
       seed.runId,
       seed.sessionId,
       seed.provider ?? 'anthropic',
       seed.input ?? 100,
+      seed.cost ?? 0.1,
       seed.at,
       seed.cached ?? 0,
       seed.created ?? 0,
@@ -180,6 +182,18 @@ describe('impact overview', () => {
       db,
       seed: { id: 'child', sessionId: 'recent', startedAt: RECENT, parentId: 'parent' },
     });
+    await addTelemetry({
+      db,
+      seed: { id: 't-recent', runId: 'r-recent', sessionId: 'recent', at: RECENT, cost: 2.5 },
+    });
+    await addTelemetry({
+      db,
+      seed: { id: 't-plain', runId: 'r-plain', sessionId: 'plain', at: RECENT, cost: 1.5 },
+    });
+    await addTelemetry({
+      db,
+      seed: { id: 't-old', runId: 'r-old', sessionId: 'old', at: OLD, cost: 3 },
+    });
 
     const result = await getImpactOverview(params({ db, sinceMs: SINCE }));
 
@@ -188,6 +202,19 @@ describe('impact overview', () => {
     expect(result.previousSessionCount).toBe(1);
     expect(result.medianSessionHours).toBe(2);
     expect(result.sessions[0]?.sessionId).toBe('recent');
+    expect(result.spendUsd).toBeCloseTo(4, 4);
+    expect(result.previousSpendUsd).toBeCloseTo(3, 4);
+    expect(result.spendSessions[0]).toMatchObject({ sessionId: 'recent', value: 2.5 });
+  });
+
+  it('reports spend as absent rather than zero when no telemetry was recorded', async () => {
+    const db = await seedDb();
+    await addSession({ db, seed: { id: 'untelemetered', createdAt: RECENT } });
+
+    const result = await getImpactOverview(params({ db, sinceMs: SINCE }));
+
+    expect(result.spendUsd).toBeNull();
+    expect(result.spendSessions).toEqual([]);
   });
 });
 
@@ -233,6 +260,75 @@ describe('pull request outcomes', () => {
 
     expect(result).toMatchObject({ open: 0, merged: 1, closed: 0 });
     expect(result.entries[0]).toMatchObject({ number: 8, sessionId: 's1' });
+  });
+
+  it('does not double-count spend when a composite session has two worktree rows on one branch', async () => {
+    const db = await seedDb();
+    await addSession({ db, seed: { id: 'composite', createdAt: RECENT } });
+    await db.execute(
+      `INSERT INTO session_worktrees
+         (id, session_id, worktree_path, branch, parallel_index, created_at)
+       VALUES ('wt-a', 'composite', '/tmp/repo-a', 'shared/branch', 0, ?),
+              ('wt-b', 'composite', '/tmp/repo-b', 'shared/branch', 1, ?)`,
+      [RECENT, RECENT],
+    );
+    await db.execute(
+      `INSERT INTO github_pr_cache (branch, repo_slug, pr_json, fetched_at)
+       VALUES (?, 'repo', ?, ?)`,
+      [
+        'shared/branch',
+        JSON.stringify({
+          number: 21,
+          title: 'composite ship',
+          state: 'merged',
+          updatedAt: iso(RECENT),
+        }),
+        iso(RECENT),
+      ],
+    );
+    await addTelemetry({
+      db,
+      seed: {
+        id: 't-composite',
+        runId: 'r-composite',
+        sessionId: 'composite',
+        at: RECENT,
+        cost: 5,
+      },
+    });
+
+    const result = await getPullRequestOutcomes(params({ db, sinceMs: SINCE }));
+
+    expect(result.entries[0]).toMatchObject({ number: 21, spendUsd: 5 });
+  });
+
+  it('reports a pull request with no telemetry as having no spend, not zero spend', async () => {
+    const db = await seedDb();
+    await addSession({ db, seed: { id: 'unpriced', createdAt: RECENT } });
+    await db.execute(
+      `INSERT INTO session_worktrees
+         (id, session_id, worktree_path, branch, parallel_index, created_at)
+       VALUES ('wt-unpriced', 'unpriced', '/tmp/unpriced', 'feature/unpriced', 0, ?)`,
+      [RECENT],
+    );
+    await db.execute(
+      `INSERT INTO github_pr_cache (branch, repo_slug, pr_json, fetched_at)
+       VALUES (?, 'repo', ?, ?)`,
+      [
+        'feature/unpriced',
+        JSON.stringify({
+          number: 30,
+          title: 'no telemetry yet',
+          state: 'open',
+          updatedAt: iso(RECENT),
+        }),
+        iso(RECENT),
+      ],
+    );
+
+    const result = await getPullRequestOutcomes(params({ db, sinceMs: SINCE }));
+
+    expect(result.entries[0]).toMatchObject({ number: 30, spendUsd: null });
   });
 });
 

--- a/packages/db/src/queries/impact.ts
+++ b/packages/db/src/queries/impact.ts
@@ -24,7 +24,6 @@ export type ImpactOverview = {
   readonly previousMedianSessionHours: number | null;
   readonly sessions: ReadonlyArray<ImpactSession>;
   readonly spendUsd: number | null;
-  readonly previousSpendUsd: number | null;
   readonly spendSessions: ReadonlyArray<ImpactSession>;
 };
 
@@ -342,10 +341,11 @@ const selectSessionSpend = async ({
 };
 
 const sumSpend = ({ rows }: { readonly rows: ReadonlyArray<SessionSpendRow> }): number | null => {
-  if (rows.length === 0) {
+  const total = rows.reduce((running, row) => running + row.spend_usd, 0);
+  if (total <= 0) {
     return null;
   }
-  return rows.reduce((total, row) => total + row.spend_usd, 0);
+  return total;
 };
 
 export const getImpactOverview = async ({
@@ -354,48 +354,37 @@ export const getImpactOverview = async ({
   sinceMs,
 }: ImpactQueryParams): Promise<ImpactOverview> => {
   const bounds = windowBounds({ sinceMs });
-  const [current, previous, durations, previousDurations, spend, previousSpend] = await Promise.all(
-    [
-      selectOverview({ db, workspaceId, sinceMs, startMs: bounds.currentStart, endMs: null }),
-      sinceMs === null
-        ? Promise.resolve(null)
-        : selectOverview({
-            db,
-            workspaceId,
-            sinceMs,
-            startMs: bounds.previousStart,
-            endMs: bounds.previousEnd,
-          }),
-      selectSessionDurations({
-        db,
-        workspaceId,
-        sinceMs,
-        startMs: bounds.currentStart,
-        endMs: null,
-        limit: null,
-      }),
-      sinceMs === null
-        ? Promise.resolve([])
-        : selectSessionDurations({
-            db,
-            workspaceId,
-            sinceMs,
-            startMs: bounds.previousStart,
-            endMs: bounds.previousEnd,
-            limit: null,
-          }),
-      selectSessionSpend({ db, workspaceId, sinceMs, startMs: bounds.currentStart, endMs: null }),
-      sinceMs === null
-        ? Promise.resolve([])
-        : selectSessionSpend({
-            db,
-            workspaceId,
-            sinceMs,
-            startMs: bounds.previousStart,
-            endMs: bounds.previousEnd,
-          }),
-    ],
-  );
+  const [current, previous, durations, previousDurations, spend] = await Promise.all([
+    selectOverview({ db, workspaceId, sinceMs, startMs: bounds.currentStart, endMs: null }),
+    sinceMs === null
+      ? Promise.resolve(null)
+      : selectOverview({
+          db,
+          workspaceId,
+          sinceMs,
+          startMs: bounds.previousStart,
+          endMs: bounds.previousEnd,
+        }),
+    selectSessionDurations({
+      db,
+      workspaceId,
+      sinceMs,
+      startMs: bounds.currentStart,
+      endMs: null,
+      limit: null,
+    }),
+    sinceMs === null
+      ? Promise.resolve([])
+      : selectSessionDurations({
+          db,
+          workspaceId,
+          sinceMs,
+          startMs: bounds.previousStart,
+          endMs: bounds.previousEnd,
+          limit: null,
+        }),
+    selectSessionSpend({ db, workspaceId, sinceMs, startMs: bounds.currentStart, endMs: null }),
+  ]);
   return {
     sessionCount: readCount({ value: current.session_count }),
     orchestratedSessions: readCount({ value: current.orchestrated_sessions }),
@@ -416,12 +405,14 @@ export const getImpactOverview = async ({
       value: row.duration_hours,
     })),
     spendUsd: sumSpend({ rows: spend }),
-    previousSpendUsd: sinceMs === null ? null : sumSpend({ rows: previousSpend }),
-    spendSessions: spend.slice(0, 5).map((row) => ({
-      sessionId: row.session_id as SessionId,
-      goal: row.goal,
-      value: row.spend_usd,
-    })),
+    spendSessions: spend
+      .filter((row) => row.spend_usd > 0)
+      .slice(0, 5)
+      .map((row) => ({
+        sessionId: row.session_id as SessionId,
+        goal: row.goal,
+        value: row.spend_usd,
+      })),
   };
 };
 
@@ -445,11 +436,19 @@ const selectPullRequests = async ({
        CAST(json_extract(g.pr_json, '$.number') AS INTEGER) AS number,
        COALESCE(json_extract(g.pr_json, '$.title'), 'Untitled pull request') AS title,
        COALESCE(json_extract(g.pr_json, '$.state'), 'open') AS state,
-       (SELECT SUM(tr.estimated_cost_usd)
-          FROM telemetry_records tr
-         WHERE tr.session_id IN (
-           SELECT sw2.session_id FROM session_worktrees sw2 WHERE sw2.branch = g.branch
-         )) AS spend_usd
+       NULLIF(
+         (SELECT SUM(tr.estimated_cost_usd)
+            FROM telemetry_records tr
+           WHERE tr.session_id IN (
+             SELECT sw2.session_id
+               FROM session_worktrees sw2
+               JOIN sessions s2 ON s2.id = sw2.session_id
+              WHERE sw2.branch = g.branch
+                AND s2.workspace_id = s.workspace_id
+                AND s2.deleted_at IS NULL
+           )),
+         0
+       ) AS spend_usd
      FROM github_pr_cache g
      JOIN session_worktrees sw ON sw.branch = g.branch
      JOIN sessions s ON s.id = sw.session_id

--- a/packages/db/src/queries/impact.ts
+++ b/packages/db/src/queries/impact.ts
@@ -23,6 +23,9 @@ export type ImpactOverview = {
   readonly medianSessionHours: number | null;
   readonly previousMedianSessionHours: number | null;
   readonly sessions: ReadonlyArray<ImpactSession>;
+  readonly spendUsd: number | null;
+  readonly previousSpendUsd: number | null;
+  readonly spendSessions: ReadonlyArray<ImpactSession>;
 };
 
 export type PullRequestEntry = {
@@ -31,6 +34,7 @@ export type PullRequestEntry = {
   readonly number: number;
   readonly title: string;
   readonly state: string;
+  readonly spendUsd: number | null;
 };
 
 export type PullRequestOutcomes = {
@@ -138,6 +142,13 @@ type PullRequestRow = {
   number: number;
   title: string;
   state: string;
+  spend_usd: number | null;
+};
+
+type SessionSpendRow = {
+  session_id: string;
+  goal: string;
+  spend_usd: number;
 };
 
 type ReviewDurationRow = {
@@ -300,42 +311,91 @@ const selectSessionDurations = async ({
   );
 };
 
+type SessionSpendParams = ImpactQueryParams & {
+  readonly startMs: number | null;
+  readonly endMs: number | null;
+};
+
+const selectSessionSpend = async ({
+  db,
+  workspaceId,
+  startMs,
+  endMs,
+}: SessionSpendParams): Promise<ReadonlyArray<SessionSpendRow>> => {
+  return db.select<SessionSpendRow>(
+    `SELECT
+       s.id AS session_id,
+       s.goal AS goal,
+       SUM(tr.estimated_cost_usd) AS spend_usd
+     FROM sessions s
+     JOIN telemetry_records tr ON tr.session_id = s.id
+    WHERE s.workspace_id = ?
+      AND s.deleted_at IS NULL
+      AND (? IS NULL OR s.updated_at >= ?)
+      AND (? IS NULL OR s.updated_at < ?)
+      AND (? IS NULL OR tr.recorded_at >= ?)
+      AND (? IS NULL OR tr.recorded_at < ?)
+    GROUP BY s.id
+    ORDER BY spend_usd DESC`,
+    [workspaceId, startMs, startMs, endMs, endMs, startMs, startMs, endMs, endMs],
+  );
+};
+
+const sumSpend = ({ rows }: { readonly rows: ReadonlyArray<SessionSpendRow> }): number | null => {
+  if (rows.length === 0) {
+    return null;
+  }
+  return rows.reduce((total, row) => total + row.spend_usd, 0);
+};
+
 export const getImpactOverview = async ({
   db,
   workspaceId,
   sinceMs,
 }: ImpactQueryParams): Promise<ImpactOverview> => {
   const bounds = windowBounds({ sinceMs });
-  const [current, previous, durations, previousDurations] = await Promise.all([
-    selectOverview({ db, workspaceId, sinceMs, startMs: bounds.currentStart, endMs: null }),
-    sinceMs === null
-      ? Promise.resolve(null)
-      : selectOverview({
-          db,
-          workspaceId,
-          sinceMs,
-          startMs: bounds.previousStart,
-          endMs: bounds.previousEnd,
-        }),
-    selectSessionDurations({
-      db,
-      workspaceId,
-      sinceMs,
-      startMs: bounds.currentStart,
-      endMs: null,
-      limit: null,
-    }),
-    sinceMs === null
-      ? Promise.resolve([])
-      : selectSessionDurations({
-          db,
-          workspaceId,
-          sinceMs,
-          startMs: bounds.previousStart,
-          endMs: bounds.previousEnd,
-          limit: null,
-        }),
-  ]);
+  const [current, previous, durations, previousDurations, spend, previousSpend] = await Promise.all(
+    [
+      selectOverview({ db, workspaceId, sinceMs, startMs: bounds.currentStart, endMs: null }),
+      sinceMs === null
+        ? Promise.resolve(null)
+        : selectOverview({
+            db,
+            workspaceId,
+            sinceMs,
+            startMs: bounds.previousStart,
+            endMs: bounds.previousEnd,
+          }),
+      selectSessionDurations({
+        db,
+        workspaceId,
+        sinceMs,
+        startMs: bounds.currentStart,
+        endMs: null,
+        limit: null,
+      }),
+      sinceMs === null
+        ? Promise.resolve([])
+        : selectSessionDurations({
+            db,
+            workspaceId,
+            sinceMs,
+            startMs: bounds.previousStart,
+            endMs: bounds.previousEnd,
+            limit: null,
+          }),
+      selectSessionSpend({ db, workspaceId, sinceMs, startMs: bounds.currentStart, endMs: null }),
+      sinceMs === null
+        ? Promise.resolve([])
+        : selectSessionSpend({
+            db,
+            workspaceId,
+            sinceMs,
+            startMs: bounds.previousStart,
+            endMs: bounds.previousEnd,
+          }),
+    ],
+  );
   return {
     sessionCount: readCount({ value: current.session_count }),
     orchestratedSessions: readCount({ value: current.orchestrated_sessions }),
@@ -354,6 +414,13 @@ export const getImpactOverview = async ({
       sessionId: row.session_id as SessionId,
       goal: row.goal,
       value: row.duration_hours,
+    })),
+    spendUsd: sumSpend({ rows: spend }),
+    previousSpendUsd: sinceMs === null ? null : sumSpend({ rows: previousSpend }),
+    spendSessions: spend.slice(0, 5).map((row) => ({
+      sessionId: row.session_id as SessionId,
+      goal: row.goal,
+      value: row.spend_usd,
     })),
   };
 };
@@ -377,7 +444,12 @@ const selectPullRequests = async ({
        s.goal AS goal,
        CAST(json_extract(g.pr_json, '$.number') AS INTEGER) AS number,
        COALESCE(json_extract(g.pr_json, '$.title'), 'Untitled pull request') AS title,
-       COALESCE(json_extract(g.pr_json, '$.state'), 'open') AS state
+       COALESCE(json_extract(g.pr_json, '$.state'), 'open') AS state,
+       (SELECT SUM(tr.estimated_cost_usd)
+          FROM telemetry_records tr
+         WHERE tr.session_id IN (
+           SELECT sw2.session_id FROM session_worktrees sw2 WHERE sw2.branch = g.branch
+         )) AS spend_usd
      FROM github_pr_cache g
      JOIN session_worktrees sw ON sw.branch = g.branch
      JOIN sessions s ON s.id = sw.session_id
@@ -432,6 +504,7 @@ export const getPullRequestOutcomes = async ({
       number: entry.number,
       title: entry.title,
       state: entry.state,
+      spendUsd: entry.spend_usd,
     })),
   };
 };


### PR DESCRIPTION
## What

Impact Studio renders delivery and efficiency outcomes and no money at all. `packages/db/src/queries/impact.ts` joins `telemetry_records` three times and never once selects `estimated_cost_usd`. This adds spend in two places:

1. A window spend total plus top-spend drill-down sessions on the Overview panel (own `StudioWidget` row, paired with the existing "longest session wall-clock" widget in a `grid-cols-1 lg:grid-cols-2` row so the existing four-tile `grid-cols-4` stays intact).
2. A per-pull-request spend figure inline in the Shipped panel's PR funnel rows.

Both reuse the existing `formatUsd` / `formatUsdPrecise` formatters from `@goodboy/ui` (precise value in `title`, rounded value visible, matching Budget Studio's precedent) and the existing generic `SessionRows` component for the drill-down.

## Why

The one person who cannot read a diff also could not see what the work cost. This closes that gap without introducing a second "priced vs unpriced" vocabulary — Impact stays a rollup; that distinction belongs to a sibling PR's Budget Studio work.

## SQL shape, and why it cannot fan out

`session_worktrees` has no unique constraint on `branch`. A composite (multi-project) session creates one worktree row per member repo, all sharing the same branch string (`createSession.ts` passes one `dirSlug` for every member repo, and the branch is built from the slug alone). `selectPullRequests` already `JOIN`s `session_worktrees` on `branch` under `GROUP BY g.repo_slug, g.branch`, so a naive `LEFT JOIN telemetry_records ... SUM(...)` would multiply a composite session's cost by its member count.

Both new queries avoid that:
- **Per-PR spend** (`selectPullRequests`): a correlated scalar subquery, `SUM` over `telemetry_records` filtered to `session_id IN (SELECT session_id FROM session_worktrees WHERE branch = g.branch)`. Membership testing cannot duplicate rows the way a join can.
- **Overview window total** (new `selectSessionSpend`): a plain `telemetry_records JOIN sessions GROUP BY s.id` — safe because `telemetry_records.session_id` is a direct FK with no duplicate-mapping table in between (unlike `session_worktrees`).

I proved trap 1 by temporarily swapping the per-PR subquery for the naive `LEFT JOIN + SUM` and re-running the new test: it reported `$10` for a session actually worth `$5` (doubled via two worktree rows on one branch), confirming the test catches the bug. Reverted before committing.

`telemetry_records.recorded_at` is epoch-ms `INTEGER`; both new queries compare it against raw millisecond bind params (matching `getCacheEfficiency`/`getContextGrowth`), never `julianday()` against an ISO string — that comparison would silently rank as always-false against an `INTEGER` column.

A session or PR with zero telemetry rows returns `NULL` from `SUM`/the subquery naturally, and that `NULL` is threaded to the UI unmodified: rendered as absent (no figure), never `$0.00`.

## Test plan

- `pnpm typecheck`: all 5 packages pass.
- `pnpm test --force`: full workspace green. `packages/db`'s `registry.test.ts` timed out at 30s during one parallel-turbo run (as flagged as a known flake) and passed in ~12s alone; four `apps/desktop` store-slice test files flaked under the same parallel run (`integrations`, `workspaces`, `github`, `permission-scope-cta`) and passed in isolation too. Both packages pass 100% standalone: `@goodboy/db` 199/199 (29 files), `@goodboy/desktop` 4928/4928 (589 files). `@goodboy/core` 1065 passed/4 skipped (104 files), `@goodboy/ui` 103/103 (20 files).
- `pnpm knip --include files,duplicates,unlisted`: clean, only pre-existing config hints.
- New DB tests: composite-session double-worktree-row PR (asserts spend is not doubled), PR with no telemetry (asserts `spendUsd: null`, not `0`), overview spend total across current/previous windows, overview with zero telemetry anywhere (asserts `spendUsd: null`, `spendSessions: []`).

## Limit

Spend attributed to a pull request is spend from the sessions on its branch, not a per-commit measurement.

## Verification repair (independent pass)

Three defects were found on verification and fixed in `fix(db): stop impact spend reporting money it never measured`.

1. **Confident `$0` for unmeasured work.** Unpriced providers (`opencode`, `openrouter`, `moonshot`, and any `codex`/`gemini` model absent from the price table) write `estimated_cost_usd = 0`, so `SUM` returns `0` rather than `NULL` and the absent-vs-zero guard never fired. Both surfaces rendered `$0` as a measured figure, which is the exact false precision this release removes. A zero total is now absent, and zero-priced sessions drop out of the drill-down.
2. **Per-pull-request spend was not workspace-scoped.** The subquery matched `session_worktrees` on `branch` alone, with no workspace or soft-delete filter, while every other Impact query is workspace-scoped. Branch names derive from the goal or a user-supplied slug with no session id, so two workspaces can hold the same branch string. The subquery now joins `sessions` and scopes to the outer workspace.
3. **Both UI halves were untested.** Deleting the whole per-pull-request spend render, or the overview total, left the suite green: the Shipped tab test never asserted the figure, and the overview assertion was `getAllByText(...).length > 0`, satisfied by the drill-down row alone. Fixture values are now distinct per element, each figure is pinned, and both panels have absent-case tests.

Also removed: `previousSpendUsd`, computed and asserted but never rendered, costing one extra query per Impact load. **Its test assertion was deleted with it**, since it pinned an unused code path. The spend widget also no longer renders "No sessions in this window" over a window that has sessions but no telemetry.

Every new guard was sabotaged and confirmed red. Gates after the repair: typecheck 5/5, `pnpm test --force` 742 files / 6300 passed / 4 skipped with no flake, knip clean.
