### PR TITLE
feat(desktop): resolve a merge request thread from the review card

### DIFF
--- a/VISION.md
+++ b/VISION.md
@@ -136,8 +136,8 @@ Where each connected source stands, honestly:
 - **GitHub.** Pull requests read and acted on (approve, request changes,
   comment, reply, resolve threads, merge, close); issues read and commented.
 - **GitLab.** Merge requests read and acted on (approve, state changes,
-  comment, reply); issues read, commented and edited. Thread resolve is read
-  but not yet written.
+  comment, reply, resolve and reopen threads); issues read, commented and
+  edited.
 - **Bitbucket.** Pull requests end to end: description, diff, build statuses
   in plain language, review threads, and eight verbs (approve, revoke,
   request changes, withdraw, comment, reply, merge, decline). No issue

--- a/apps/desktop/src-tauri/src/gitlab.rs
+++ b/apps/desktop/src-tauri/src/gitlab.rs
@@ -750,6 +750,40 @@ pub async fn gitlab_reply_to_mr_discussion(
     Ok(note.id)
 }
 
+fn mr_discussion_resolve_path(
+    project_path: &str,
+    mr_iid: i64,
+    discussion_id: &str,
+    resolved: bool,
+) -> String {
+    let encoded = encode_project_path(project_path);
+    let discussion = percent_encode(discussion_id);
+    format!(
+        "/projects/{encoded}/merge_requests/{mr_iid}/discussions/{discussion}?resolved={resolved}"
+    )
+}
+
+#[tauri::command]
+pub async fn gitlab_resolve_mr_discussion(
+    workspace_id: String,
+    host: String,
+    project_path: String,
+    mr_iid: i64,
+    discussion_id: String,
+    resolved: bool,
+    cache: State<'_, GitlabTokenCache>,
+) -> Result<GitlabMrDiscussion, GitlabError> {
+    let token = read_token(&workspace_id, &cache)?;
+    send_json(
+        reqwest::Method::PUT,
+        &host,
+        &token,
+        &mr_discussion_resolve_path(&project_path, mr_iid, &discussion_id, resolved),
+        &serde_json::json!({ "resolved": resolved }),
+    )
+    .await
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GitlabIssueNote {
     pub id: i64,
@@ -995,6 +1029,58 @@ mod tests {
         assert_eq!(percent_encode("ak/feat-x"), "ak%2Ffeat-x");
         assert_eq!(percent_encode("a b"), "a%20b");
         assert_eq!(percent_encode("keep-._~"), "keep-._~");
+    }
+
+    #[test]
+    fn mr_discussion_resolve_path_encodes_the_project_and_the_discussion_id() {
+        assert_eq!(
+            mr_discussion_resolve_path("group/sub/repo", 11, "6a9c1750b37d513a43987b574953fceb50b03ce7", true),
+            "/projects/group%2Fsub%2Frepo/merge_requests/11/discussions/6a9c1750b37d513a43987b574953fceb50b03ce7?resolved=true"
+        );
+    }
+
+    #[test]
+    fn mr_discussion_resolve_path_escapes_a_discussion_id_that_is_not_url_safe() {
+        let path = mr_discussion_resolve_path("acme/web", 4, "note/7 a+b", false);
+        assert!(
+            !path.contains("note/7 a+b"),
+            "the raw discussion id leaked into the path: {path}"
+        );
+        assert_eq!(
+            path,
+            "/projects/acme%2Fweb/merge_requests/4/discussions/note%2F7%20a%2Bb?resolved=false"
+        );
+    }
+
+    #[test]
+    fn resolve_mr_discussion_is_registered_as_a_tauri_command() {
+        let lib = include_str!("lib.rs");
+        assert!(
+            lib.contains("gitlab::gitlab_resolve_mr_discussion"),
+            "gitlab_resolve_mr_discussion is missing from the generate_handler block"
+        );
+    }
+
+    #[test]
+    fn mr_discussion_deserializes_a_resolved_thread_payload() {
+        let raw = r#"{
+            "id": "6a9c1750b37d",
+            "individual_note": false,
+            "notes": [
+                {
+                    "id": 42,
+                    "body": "one nit",
+                    "system": false,
+                    "created_at": "2026-08-01T10:00:00Z",
+                    "resolvable": true,
+                    "resolved": true
+                }
+            ]
+        }"#;
+        let discussion: GitlabMrDiscussion = serde_json::from_str(raw).unwrap();
+        assert_eq!(discussion.id, "6a9c1750b37d");
+        assert!(!discussion.individual_note);
+        assert_eq!(discussion.notes[0].resolved, Some(true));
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -301,6 +301,7 @@ pub fn run() {
             gitlab::gitlab_create_mr_note,
             gitlab::gitlab_list_mr_discussions,
             gitlab::gitlab_reply_to_mr_discussion,
+            gitlab::gitlab_resolve_mr_discussion,
             gitlab::gitlab_mr_approval_state,
             gitlab::gitlab_approve_mr,
             gitlab::gitlab_unapprove_mr,

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel/MrConversation.test.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel/MrConversation.test.tsx
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { WorkspaceId } from '@goodboy/types';
+import type { GitlabMrDiscussion } from '../../client';
+
+const h = vi.hoisted(() => ({
+  list: vi.fn<() => Promise<ReadonlyArray<GitlabMrDiscussion>>>(),
+  createNote: vi.fn(async () => 1),
+  reply: vi.fn(async () => 2),
+  resolve: vi.fn<() => Promise<GitlabMrDiscussion>>(),
+}));
+
+vi.mock('../../client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../client')>();
+  return {
+    ...actual,
+    gitlabListMrDiscussions: h.list,
+    gitlabCreateMrNote: h.createNote,
+    gitlabReplyToMrDiscussion: h.reply,
+    gitlabResolveMrDiscussion: h.resolve,
+  };
+});
+
+import { useGitlabMrDiscussions } from '../../useGitlabMrDiscussions';
+import { MrConversation } from './MrConversation';
+
+const TARGET = {
+  workspaceId: 'workspace-1' as WorkspaceId,
+  host: 'https://gitlab.com',
+  projectPath: 'acme/web',
+  mrIid: 4,
+};
+
+const DISCUSSION: GitlabMrDiscussion = {
+  id: 'disc-1',
+  individualNote: false,
+  notes: [
+    {
+      id: 1,
+      body: 'one nit',
+      system: false,
+      author: { username: 'ada', name: 'Ada Lovelace', avatarUrl: null },
+      createdAt: '2026-08-01T10:00:00Z',
+      resolvable: true,
+      resolved: false,
+      position: null,
+    },
+  ],
+};
+
+const Harness = () => {
+  const discussions = useGitlabMrDiscussions(TARGET);
+  return (
+    <MrConversation
+      discussions={discussions.discussions}
+      isLoading={discussions.isLoading}
+      error={discussions.error}
+      onRetry={discussions.reload}
+      onPost={null}
+      onReply={null}
+      onResolve={discussions.resolve}
+      resolveError={discussions.resolveError}
+    />
+  );
+};
+
+beforeEach(() => {
+  h.list.mockReset();
+  h.list.mockResolvedValue([DISCUSSION]);
+  h.resolve.mockReset();
+});
+
+afterEach(cleanup);
+
+describe('MrConversation resolve wiring', () => {
+  it('carries the click through to the client with the full merge request target', async () => {
+    h.resolve.mockResolvedValue(DISCUSSION);
+    render(<Harness />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Resolve' })).toBeDefined());
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Resolve' }));
+    });
+
+    expect(h.resolve).toHaveBeenCalledWith({ ...TARGET, discussionId: 'disc-1', resolved: true });
+  });
+
+  it('reopens a resolved thread with the cleared flag', async () => {
+    h.list.mockResolvedValue([
+      { ...DISCUSSION, notes: [{ ...DISCUSSION.notes[0], resolved: true }] },
+    ]);
+    h.resolve.mockResolvedValue(DISCUSSION);
+    render(<Harness />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Unresolve' })).toBeDefined());
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Unresolve' }));
+    });
+
+    expect(h.resolve).toHaveBeenCalledWith({ ...TARGET, discussionId: 'disc-1', resolved: false });
+  });
+
+  it('keeps a rejected resolve visible after the refetch has settled', async () => {
+    h.resolve.mockRejectedValue(new Error('GitLab said 403'));
+    render(<Harness />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Resolve' })).toBeDefined());
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Resolve' }));
+    });
+    await waitFor(() => expect(h.list).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Resolve' })).toBeDefined());
+
+    expect(screen.getByRole('alert').textContent).toBe('GitLab said 403');
+  });
+});

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel/MrConversation.test.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel/MrConversation.test.tsx
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { WorkspaceId } from '@goodboy/types';
-import type { GitlabMrDiscussion } from '../../client';
+import type { GitlabMrDiscussion, GitlabMrNote } from '../../client';
 
 const h = vi.hoisted(() => ({
   list: vi.fn<() => Promise<ReadonlyArray<GitlabMrDiscussion>>>(),
@@ -31,21 +31,21 @@ const TARGET = {
   mrIid: 4,
 };
 
+const NOTE: GitlabMrNote = {
+  id: 1,
+  body: 'one nit',
+  system: false,
+  author: { username: 'ada', name: 'Ada Lovelace', avatarUrl: null },
+  createdAt: '2026-08-01T10:00:00Z',
+  resolvable: true,
+  resolved: false,
+  position: null,
+};
+
 const DISCUSSION: GitlabMrDiscussion = {
   id: 'disc-1',
   individualNote: false,
-  notes: [
-    {
-      id: 1,
-      body: 'one nit',
-      system: false,
-      author: { username: 'ada', name: 'Ada Lovelace', avatarUrl: null },
-      createdAt: '2026-08-01T10:00:00Z',
-      resolvable: true,
-      resolved: false,
-      position: null,
-    },
-  ],
+  notes: [NOTE],
 };
 
 const Harness = () => {
@@ -86,9 +86,7 @@ describe('MrConversation resolve wiring', () => {
   });
 
   it('reopens a resolved thread with the cleared flag', async () => {
-    h.list.mockResolvedValue([
-      { ...DISCUSSION, notes: [{ ...DISCUSSION.notes[0], resolved: true }] },
-    ]);
+    h.list.mockResolvedValue([{ ...DISCUSSION, notes: [{ ...NOTE, resolved: true }] }]);
     h.resolve.mockResolvedValue(DISCUSSION);
     render(<Harness />);
     await waitFor(() => expect(screen.getByRole('button', { name: 'Unresolve' })).toBeDefined());

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel/MrConversation.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel/MrConversation.tsx
@@ -16,6 +16,7 @@ type Props = {
   readonly onReply: ((params: { discussionId: string; body: string }) => Promise<void>) | null;
   readonly onResolve:
     ((params: { discussionId: string; resolved: boolean }) => Promise<void>) | null;
+  readonly resolveError: { readonly discussionId: string; readonly message: string } | null;
 };
 
 export const MrConversation = ({
@@ -26,6 +27,7 @@ export const MrConversation = ({
   onPost,
   onReply,
   onResolve,
+  resolveError,
 }: Props) => {
   const conversation = useMemo(() => buildMrConversation({ discussions }), [discussions]);
 
@@ -73,6 +75,9 @@ export const MrConversation = ({
                   onResolve == null
                     ? null
                     : (resolved: boolean) => onResolve({ discussionId: thread.id, resolved })
+                }
+                resolveError={
+                  resolveError?.discussionId === thread.id ? resolveError.message : null
                 }
               />
             </li>

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel/MrConversation.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel/MrConversation.tsx
@@ -14,6 +14,8 @@ type Props = {
   readonly onRetry: () => void;
   readonly onPost: ((body: string) => Promise<void>) | null;
   readonly onReply: ((params: { discussionId: string; body: string }) => Promise<void>) | null;
+  readonly onResolve:
+    ((params: { discussionId: string; resolved: boolean }) => Promise<void>) | null;
 };
 
 export const MrConversation = ({
@@ -23,6 +25,7 @@ export const MrConversation = ({
   onRetry,
   onPost,
   onReply,
+  onResolve,
 }: Props) => {
   const conversation = useMemo(() => buildMrConversation({ discussions }), [discussions]);
 
@@ -65,6 +68,11 @@ export const MrConversation = ({
                   onReply == null
                     ? null
                     : (body: string) => onReply({ discussionId: thread.id, body })
+                }
+                onResolve={
+                  onResolve == null
+                    ? null
+                    : (resolved: boolean) => onResolve({ discussionId: thread.id, resolved })
                 }
               />
             </li>

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel/MrThreadCard.test.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel/MrThreadCard.test.tsx
@@ -50,31 +50,38 @@ afterEach(() => {
 
 describe('MrThreadCard', () => {
   it('renders a real avatar src and accessible name for the thread head note', () => {
-    render(<MrThreadCard thread={THREAD} onReply={null} onResolve={null} />);
+    render(<MrThreadCard thread={THREAD} onReply={null} onResolve={null} resolveError={null} />);
 
     const avatar = screen.getByRole('img', { name: 'Ada Lovelace' });
     expect(avatar.getAttribute('src')).toBe('https://gitlab.example/avatars/ada.png');
   });
 
   it('falls back to the author initial for a reply note with no avatar url', () => {
-    render(<MrThreadCard thread={THREAD} onReply={null} onResolve={null} />);
+    render(<MrThreadCard thread={THREAD} onReply={null} onResolve={null} resolveError={null} />);
 
     expect(screen.getByText('B')).toBeDefined();
     expect(screen.getAllByRole('img')).toHaveLength(1);
   });
 
   it('renders the resolved pill only when the thread is resolved', () => {
-    const { rerender } = render(<MrThreadCard thread={THREAD} onReply={null} onResolve={null} />);
+    const { rerender } = render(
+      <MrThreadCard thread={THREAD} onReply={null} onResolve={null} resolveError={null} />,
+    );
     expect(screen.queryByText('resolved')).toBeNull();
 
     rerender(
-      <MrThreadCard thread={{ ...THREAD, isResolved: true }} onReply={null} onResolve={null} />,
+      <MrThreadCard
+        thread={{ ...THREAD, isResolved: true }}
+        onReply={null}
+        onResolve={null}
+        resolveError={null}
+      />,
     );
     expect(screen.getByText('resolved')).toBeDefined();
   });
 
   it('offers no resolve action when the card is read only', () => {
-    render(<MrThreadCard thread={THREAD} onReply={null} onResolve={null} />);
+    render(<MrThreadCard thread={THREAD} onReply={null} onResolve={null} resolveError={null} />);
 
     expect(screen.queryByRole('button', { name: 'Resolve' })).toBeNull();
     expect(screen.queryByRole('button', { name: 'Unresolve' })).toBeNull();
@@ -82,7 +89,9 @@ describe('MrThreadCard', () => {
 
   it('reaches the resolve action on an open thread and sends the resolved flag', async () => {
     const onResolve = vi.fn(async () => undefined);
-    render(<MrThreadCard thread={THREAD} onReply={null} onResolve={onResolve} />);
+    render(
+      <MrThreadCard thread={THREAD} onReply={null} onResolve={onResolve} resolveError={null} />,
+    );
 
     const action = screen.getByRole('button', { name: 'Resolve' });
     await act(async () => {
@@ -99,6 +108,7 @@ describe('MrThreadCard', () => {
         thread={{ ...THREAD, isResolved: true }}
         onReply={null}
         onResolve={onResolve}
+        resolveError={null}
       />,
     );
 
@@ -110,22 +120,29 @@ describe('MrThreadCard', () => {
     expect(onResolve).toHaveBeenCalledWith(false);
   });
 
-  it('surfaces a failed resolve without hiding the action', async () => {
-    const onResolve = vi.fn(async () => {
-      throw new Error('GitLab said 403');
-    });
-    render(<MrThreadCard thread={THREAD} onReply={null} onResolve={onResolve} />);
-
-    await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: 'Resolve' }));
-    });
+  it('surfaces the resolve failure it is handed without hiding the action', () => {
+    const onResolve = vi.fn(async () => undefined);
+    render(
+      <MrThreadCard
+        thread={THREAD}
+        onReply={null}
+        onResolve={onResolve}
+        resolveError="GitLab said 403"
+      />,
+    );
 
     expect(screen.getByRole('alert').textContent).toBe('GitLab said 403');
     expect(screen.getByRole('button', { name: 'Resolve' }).hasAttribute('disabled')).toBe(false);
   });
 
+  it('shows no alert while the resolve failure is absent', () => {
+    render(<MrThreadCard thread={THREAD} onReply={null} onResolve={null} resolveError={null} />);
+
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+
   it('renders author name and relative timestamp for the head and reply notes', () => {
-    render(<MrThreadCard thread={THREAD} onReply={null} onResolve={null} />);
+    render(<MrThreadCard thread={THREAD} onReply={null} onResolve={null} resolveError={null} />);
 
     expect(screen.getByText('Ada Lovelace')).toBeDefined();
     expect(screen.getByText('3d ago')).toBeDefined();

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel/MrThreadCard.test.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel/MrThreadCard.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, render, screen } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
 import type { GitlabMrNote } from '../../client';
 import { MrThreadCard } from './MrThreadCard';
 import type { MrThread } from './mrThreads';
@@ -50,29 +50,82 @@ afterEach(() => {
 
 describe('MrThreadCard', () => {
   it('renders a real avatar src and accessible name for the thread head note', () => {
-    render(<MrThreadCard thread={THREAD} onReply={null} />);
+    render(<MrThreadCard thread={THREAD} onReply={null} onResolve={null} />);
 
     const avatar = screen.getByRole('img', { name: 'Ada Lovelace' });
     expect(avatar.getAttribute('src')).toBe('https://gitlab.example/avatars/ada.png');
   });
 
   it('falls back to the author initial for a reply note with no avatar url', () => {
-    render(<MrThreadCard thread={THREAD} onReply={null} />);
+    render(<MrThreadCard thread={THREAD} onReply={null} onResolve={null} />);
 
     expect(screen.getByText('B')).toBeDefined();
     expect(screen.getAllByRole('img')).toHaveLength(1);
   });
 
   it('renders the resolved pill only when the thread is resolved', () => {
-    const { rerender } = render(<MrThreadCard thread={THREAD} onReply={null} />);
+    const { rerender } = render(<MrThreadCard thread={THREAD} onReply={null} onResolve={null} />);
     expect(screen.queryByText('resolved')).toBeNull();
 
-    rerender(<MrThreadCard thread={{ ...THREAD, isResolved: true }} onReply={null} />);
+    rerender(
+      <MrThreadCard thread={{ ...THREAD, isResolved: true }} onReply={null} onResolve={null} />,
+    );
     expect(screen.getByText('resolved')).toBeDefined();
   });
 
+  it('offers no resolve action when the card is read only', () => {
+    render(<MrThreadCard thread={THREAD} onReply={null} onResolve={null} />);
+
+    expect(screen.queryByRole('button', { name: 'Resolve' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Unresolve' })).toBeNull();
+  });
+
+  it('reaches the resolve action on an open thread and sends the resolved flag', async () => {
+    const onResolve = vi.fn(async () => undefined);
+    render(<MrThreadCard thread={THREAD} onReply={null} onResolve={onResolve} />);
+
+    const action = screen.getByRole('button', { name: 'Resolve' });
+    await act(async () => {
+      fireEvent.click(action);
+    });
+
+    expect(onResolve).toHaveBeenCalledWith(true);
+  });
+
+  it('reaches the reverse action on a resolved thread and sends the cleared flag', async () => {
+    const onResolve = vi.fn(async () => undefined);
+    render(
+      <MrThreadCard
+        thread={{ ...THREAD, isResolved: true }}
+        onReply={null}
+        onResolve={onResolve}
+      />,
+    );
+
+    expect(screen.getByText('resolved')).toBeDefined();
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Unresolve' }));
+    });
+
+    expect(onResolve).toHaveBeenCalledWith(false);
+  });
+
+  it('surfaces a failed resolve without hiding the action', async () => {
+    const onResolve = vi.fn(async () => {
+      throw new Error('GitLab said 403');
+    });
+    render(<MrThreadCard thread={THREAD} onReply={null} onResolve={onResolve} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Resolve' }));
+    });
+
+    expect(screen.getByRole('alert').textContent).toBe('GitLab said 403');
+    expect(screen.getByRole('button', { name: 'Resolve' }).hasAttribute('disabled')).toBe(false);
+  });
+
   it('renders author name and relative timestamp for the head and reply notes', () => {
-    render(<MrThreadCard thread={THREAD} onReply={null} />);
+    render(<MrThreadCard thread={THREAD} onReply={null} onResolve={null} />);
 
     expect(screen.getByText('Ada Lovelace')).toBeDefined();
     expect(screen.getByText('3d ago')).toBeDefined();

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel/MrThreadCard.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel/MrThreadCard.tsx
@@ -3,7 +3,6 @@ import { Divider, Markdown } from '@goodboy/ui';
 import { Check, MessageSquareReply, Undo2 } from 'lucide-react';
 import { IssueStateBadge } from '../../../../../shared/components/IssueStateBadge';
 import { NoteComposer } from '../../../../../shared/components/NoteComposer';
-import { formatError } from '../../../../../shared/lib/errors';
 import { MrNoteHeader } from './MrNoteHeader';
 import { threadAnchor, type MrThread } from './mrThreads';
 
@@ -11,12 +10,12 @@ type Props = {
   readonly thread: MrThread;
   readonly onReply: ((body: string) => Promise<void>) | null;
   readonly onResolve: ((resolved: boolean) => Promise<void>) | null;
+  readonly resolveError: string | null;
 };
 
-export const MrThreadCard = ({ thread, onReply, onResolve }: Props) => {
+export const MrThreadCard = ({ thread, onReply, onResolve, resolveError }: Props) => {
   const [isReplyOpen, setIsReplyOpen] = useState(false);
   const [isResolving, setIsResolving] = useState(false);
-  const [resolveError, setResolveError] = useState<string | null>(null);
   const anchor = threadAnchor({ thread });
 
   const toggleResolved = async () => {
@@ -24,11 +23,8 @@ export const MrThreadCard = ({ thread, onReply, onResolve }: Props) => {
       return;
     }
     setIsResolving(true);
-    setResolveError(null);
     try {
       await onResolve(!thread.isResolved);
-    } catch (error: unknown) {
-      setResolveError(formatError(error));
     } finally {
       setIsResolving(false);
     }

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel/MrThreadCard.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel/MrThreadCard.tsx
@@ -1,19 +1,38 @@
 import { useState } from 'react';
 import { Divider, Markdown } from '@goodboy/ui';
-import { MessageSquareReply } from 'lucide-react';
+import { Check, MessageSquareReply, Undo2 } from 'lucide-react';
 import { IssueStateBadge } from '../../../../../shared/components/IssueStateBadge';
 import { NoteComposer } from '../../../../../shared/components/NoteComposer';
+import { formatError } from '../../../../../shared/lib/errors';
 import { MrNoteHeader } from './MrNoteHeader';
 import { threadAnchor, type MrThread } from './mrThreads';
 
 type Props = {
   readonly thread: MrThread;
   readonly onReply: ((body: string) => Promise<void>) | null;
+  readonly onResolve: ((resolved: boolean) => Promise<void>) | null;
 };
 
-export const MrThreadCard = ({ thread, onReply }: Props) => {
+export const MrThreadCard = ({ thread, onReply, onResolve }: Props) => {
   const [isReplyOpen, setIsReplyOpen] = useState(false);
+  const [isResolving, setIsResolving] = useState(false);
+  const [resolveError, setResolveError] = useState<string | null>(null);
   const anchor = threadAnchor({ thread });
+
+  const toggleResolved = async () => {
+    if (onResolve == null) {
+      return;
+    }
+    setIsResolving(true);
+    setResolveError(null);
+    try {
+      await onResolve(!thread.isResolved);
+    } catch (error: unknown) {
+      setResolveError(formatError(error));
+    } finally {
+      setIsResolving(false);
+    }
+  };
 
   return (
     <div className="flex flex-col gap-2 rounded-lg bg-muted/20 p-3">
@@ -23,8 +42,25 @@ export const MrThreadCard = ({ thread, onReply }: Props) => {
           <span className="truncate font-mono text-2xs text-muted-foreground">{anchor}</span>
         )}
         {thread.isResolved && <IssueStateBadge tone="success">resolved</IssueStateBadge>}
+        {onResolve != null && (
+          <button
+            type="button"
+            disabled={isResolving}
+            onClick={() => void toggleResolved()}
+            className="inline-flex w-fit items-center gap-1 rounded-md text-2xs font-medium text-muted-foreground transition-colors hover:text-foreground disabled:opacity-50"
+          >
+            {thread.isResolved ? <Undo2 size={11} aria-hidden /> : <Check size={11} aria-hidden />}
+            {thread.isResolved ? 'Unresolve' : 'Resolve'}
+          </button>
+        )}
       </div>
       <Markdown text={thread.head.body} className="text-sm leading-relaxed" />
+
+      {resolveError != null && (
+        <p role="alert" className="text-2xs text-danger">
+          {resolveError}
+        </p>
+      )}
 
       {thread.replies.length > 0 && (
         <div className="flex gap-2 pl-1">

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel/index.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel/index.tsx
@@ -356,6 +356,7 @@ export const MrDetailPanel = ({
             onRetry={discussions.reload}
             onPost={postNote == null ? null : (body: string) => postNote({ body })}
             onReply={discussions.reply}
+            onResolve={discussions.resolve}
           />
         )}
       </StudioDetailLayout>

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel/index.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel/index.tsx
@@ -357,6 +357,7 @@ export const MrDetailPanel = ({
             onPost={postNote == null ? null : (body: string) => postNote({ body })}
             onReply={discussions.reply}
             onResolve={discussions.resolve}
+            resolveError={discussions.resolveError}
           />
         )}
       </StudioDetailLayout>

--- a/apps/desktop/src/features/integrations/gitlab/client.test.ts
+++ b/apps/desktop/src/features/integrations/gitlab/client.test.ts
@@ -3,10 +3,12 @@ import { invoke } from '@tauri-apps/api/core';
 import type { WorkspaceId } from '@goodboy/types';
 import {
   gitlabFetchIssue,
+  gitlabResolveMrDiscussion,
   gitlabUpdateIssueDescription,
   humanizeMergeStatus,
   issueIdentifier,
   type GitlabIssue,
+  type GitlabMrDiscussion,
 } from './client';
 
 vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
@@ -91,6 +93,51 @@ describe('gitlabUpdateIssueDescription', () => {
       issueIid: 7,
       description: 'Rewritten body',
     });
+  });
+});
+
+describe('gitlabResolveMrDiscussion', () => {
+  it('invokes the registered resolve command with the discussion id and the flag', async () => {
+    const updated: GitlabMrDiscussion = {
+      id: '6a9c1750b37d',
+      individualNote: false,
+      notes: [],
+    };
+    mockInvoke.mockResolvedValueOnce(updated);
+
+    const result = await gitlabResolveMrDiscussion({
+      workspaceId: 'workspace-1' as WorkspaceId,
+      host: 'https://gitlab.com',
+      projectPath: 'group/sub/repo',
+      mrIid: 11,
+      discussionId: '6a9c1750b37d',
+      resolved: true,
+    });
+
+    expect(result).toBe(updated);
+    expect(mockInvoke).toHaveBeenCalledWith('gitlab_resolve_mr_discussion', {
+      workspaceId: 'workspace-1',
+      host: 'https://gitlab.com',
+      projectPath: 'group/sub/repo',
+      mrIid: 11,
+      discussionId: '6a9c1750b37d',
+      resolved: true,
+    });
+  });
+
+  it('carries a false flag when a thread is reopened', async () => {
+    mockInvoke.mockResolvedValueOnce({ id: 'd-1', individualNote: false, notes: [] });
+
+    await gitlabResolveMrDiscussion({
+      workspaceId: 'workspace-1' as WorkspaceId,
+      host: 'https://gitlab.example.com',
+      projectPath: 'acme/web',
+      mrIid: 4,
+      discussionId: 'd-1',
+      resolved: false,
+    });
+
+    expect(mockInvoke.mock.calls[0]?.[1]).toMatchObject({ resolved: false });
   });
 });
 

--- a/apps/desktop/src/features/integrations/gitlab/client.ts
+++ b/apps/desktop/src/features/integrations/gitlab/client.ts
@@ -336,6 +336,29 @@ export const gitlabReplyToMrDiscussion = async ({
   });
 };
 
+type ResolveDiscussionParams = MrTarget & {
+  readonly discussionId: string;
+  readonly resolved: boolean;
+};
+
+export const gitlabResolveMrDiscussion = async ({
+  workspaceId,
+  host,
+  projectPath,
+  mrIid,
+  discussionId,
+  resolved,
+}: ResolveDiscussionParams): Promise<GitlabMrDiscussion> => {
+  return invoke<GitlabMrDiscussion>('gitlab_resolve_mr_discussion', {
+    workspaceId,
+    host,
+    projectPath,
+    mrIid,
+    discussionId,
+    resolved,
+  });
+};
+
 export type GitlabIssueNote = {
   id: number;
   body: string;

--- a/apps/desktop/src/features/integrations/gitlab/useGitlabMrDiscussions/index.test.ts
+++ b/apps/desktop/src/features/integrations/gitlab/useGitlabMrDiscussions/index.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, renderHook, waitFor } from '@testing-library/react';
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
 import type { WorkspaceId } from '@goodboy/types';
 import type { GitlabMrDiscussion } from '../client';
 
@@ -114,15 +114,36 @@ describe('useGitlabMrDiscussions', () => {
     expect(h.resolve).toHaveBeenCalledWith({ ...TARGET, discussionId: 'disc-1', resolved: false });
   });
 
-  it('refetches even when the resolve write fails, so the card cannot drift', async () => {
+  it('holds a failed resolve on the hook and still refetches, so the card cannot drift', async () => {
     h.resolve.mockRejectedValue(new Error('GitLab said 403'));
     const { result } = renderHook(() => useGitlabMrDiscussions(TARGET));
     await waitFor(() => expect(h.list).toHaveBeenCalledOnce());
 
-    await expect(
-      result.current.resolve?.({ discussionId: 'disc-1', resolved: true }),
-    ).rejects.toThrow('GitLab said 403');
+    await act(async () => {
+      await result.current.resolve?.({ discussionId: 'disc-1', resolved: true });
+    });
 
     await waitFor(() => expect(h.list).toHaveBeenCalledTimes(2));
+    expect(result.current.resolveError).toEqual({
+      discussionId: 'disc-1',
+      message: 'GitLab said 403',
+    });
+  });
+
+  it('clears a held resolve failure once a later write succeeds', async () => {
+    h.resolve.mockRejectedValueOnce(new Error('GitLab said 403'));
+    const { result } = renderHook(() => useGitlabMrDiscussions(TARGET));
+    await waitFor(() => expect(h.list).toHaveBeenCalledOnce());
+
+    await act(async () => {
+      await result.current.resolve?.({ discussionId: 'disc-1', resolved: true });
+    });
+    await waitFor(() => expect(result.current.resolveError).not.toBeNull());
+
+    await act(async () => {
+      await result.current.resolve?.({ discussionId: 'disc-1', resolved: true });
+    });
+
+    await waitFor(() => expect(result.current.resolveError).toBeNull());
   });
 });

--- a/apps/desktop/src/features/integrations/gitlab/useGitlabMrDiscussions/index.test.ts
+++ b/apps/desktop/src/features/integrations/gitlab/useGitlabMrDiscussions/index.test.ts
@@ -7,12 +7,14 @@ const h = vi.hoisted(() => ({
   list: vi.fn<() => Promise<ReadonlyArray<GitlabMrDiscussion>>>(),
   createNote: vi.fn(async () => 1),
   reply: vi.fn(async () => 2),
+  resolve: vi.fn<() => Promise<GitlabMrDiscussion>>(),
 }));
 
 vi.mock('../client', () => ({
   gitlabListMrDiscussions: h.list,
   gitlabCreateMrNote: h.createNote,
   gitlabReplyToMrDiscussion: h.reply,
+  gitlabResolveMrDiscussion: h.resolve,
 }));
 
 import { useGitlabMrDiscussions } from './index';
@@ -35,6 +37,8 @@ beforeEach(() => {
   h.list.mockResolvedValue([discussion]);
   h.createNote.mockClear();
   h.reply.mockClear();
+  h.resolve.mockReset();
+  h.resolve.mockResolvedValue({ ...discussion, notes: [] });
 });
 
 afterEach(cleanup);
@@ -55,6 +59,7 @@ describe('useGitlabMrDiscussions', () => {
     expect(h.list).not.toHaveBeenCalled();
     expect(result.current.post).toBeNull();
     expect(result.current.reply).toBeNull();
+    expect(result.current.resolve).toBeNull();
   });
 
   it('surfaces a load failure', async () => {
@@ -87,6 +92,37 @@ describe('useGitlabMrDiscussions', () => {
     await result.current.reply?.({ discussionId: 'disc-1', body: 'fixed' });
 
     expect(h.reply).toHaveBeenCalledWith({ ...TARGET, discussionId: 'disc-1', body: 'fixed' });
+    await waitFor(() => expect(h.list).toHaveBeenCalledTimes(2));
+  });
+
+  it('refetches after resolving a thread', async () => {
+    const { result } = renderHook(() => useGitlabMrDiscussions(TARGET));
+    await waitFor(() => expect(h.list).toHaveBeenCalledOnce());
+
+    await result.current.resolve?.({ discussionId: 'disc-1', resolved: true });
+
+    expect(h.resolve).toHaveBeenCalledWith({ ...TARGET, discussionId: 'disc-1', resolved: true });
+    await waitFor(() => expect(h.list).toHaveBeenCalledTimes(2));
+  });
+
+  it('carries the cleared flag when a thread is reopened', async () => {
+    const { result } = renderHook(() => useGitlabMrDiscussions(TARGET));
+    await waitFor(() => expect(h.list).toHaveBeenCalledOnce());
+
+    await result.current.resolve?.({ discussionId: 'disc-1', resolved: false });
+
+    expect(h.resolve).toHaveBeenCalledWith({ ...TARGET, discussionId: 'disc-1', resolved: false });
+  });
+
+  it('refetches even when the resolve write fails, so the card cannot drift', async () => {
+    h.resolve.mockRejectedValue(new Error('GitLab said 403'));
+    const { result } = renderHook(() => useGitlabMrDiscussions(TARGET));
+    await waitFor(() => expect(h.list).toHaveBeenCalledOnce());
+
+    await expect(
+      result.current.resolve?.({ discussionId: 'disc-1', resolved: true }),
+    ).rejects.toThrow('GitLab said 403');
+
     await waitFor(() => expect(h.list).toHaveBeenCalledTimes(2));
   });
 });

--- a/apps/desktop/src/features/integrations/gitlab/useGitlabMrDiscussions/index.ts
+++ b/apps/desktop/src/features/integrations/gitlab/useGitlabMrDiscussions/index.ts
@@ -30,10 +30,16 @@ type ResolveParams = {
   readonly resolved: boolean;
 };
 
+type ResolveFailure = {
+  readonly discussionId: string;
+  readonly message: string;
+};
+
 type Result = {
   readonly discussions: ReadonlyArray<GitlabMrDiscussion>;
   readonly isLoading: boolean;
   readonly error: string | null;
+  readonly resolveError: ResolveFailure | null;
   readonly reload: () => void;
   readonly post: ((params: PostParams) => Promise<void>) | null;
   readonly reply: ((params: ReplyParams) => Promise<void>) | null;
@@ -49,8 +55,13 @@ export const useGitlabMrDiscussions = ({
   const [discussions, setDiscussions] = useState<ReadonlyArray<GitlabMrDiscussion>>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [resolveError, setResolveError] = useState<ResolveFailure | null>(null);
   const [reloadToken, setReloadToken] = useState(0);
   const isReady = workspaceId != null && host != null && projectPath != null && mrIid != null;
+
+  useEffect(() => {
+    setResolveError(null);
+  }, [workspaceId, host, projectPath, mrIid]);
 
   useEffect(() => {
     setDiscussions([]);
@@ -125,6 +136,7 @@ export const useGitlabMrDiscussions = ({
       if (workspaceId == null || host == null || projectPath == null || mrIid == null) {
         return;
       }
+      setResolveError(null);
       try {
         await gitlabResolveMrDiscussion({
           workspaceId,
@@ -134,6 +146,8 @@ export const useGitlabMrDiscussions = ({
           discussionId,
           resolved,
         });
+      } catch (writeError: unknown) {
+        setResolveError({ discussionId, message: formatError(writeError) });
       } finally {
         setReloadToken((token) => token + 1);
       }
@@ -145,6 +159,7 @@ export const useGitlabMrDiscussions = ({
     discussions,
     isLoading,
     error,
+    resolveError,
     reload,
     post: isReady ? post : null,
     reply: isReady ? reply : null,

--- a/apps/desktop/src/features/integrations/gitlab/useGitlabMrDiscussions/index.ts
+++ b/apps/desktop/src/features/integrations/gitlab/useGitlabMrDiscussions/index.ts
@@ -5,6 +5,7 @@ import {
   gitlabCreateMrNote,
   gitlabListMrDiscussions,
   gitlabReplyToMrDiscussion,
+  gitlabResolveMrDiscussion,
   type GitlabMrDiscussion,
 } from '../client';
 
@@ -24,6 +25,11 @@ type ReplyParams = {
   readonly body: string;
 };
 
+type ResolveParams = {
+  readonly discussionId: string;
+  readonly resolved: boolean;
+};
+
 type Result = {
   readonly discussions: ReadonlyArray<GitlabMrDiscussion>;
   readonly isLoading: boolean;
@@ -31,6 +37,7 @@ type Result = {
   readonly reload: () => void;
   readonly post: ((params: PostParams) => Promise<void>) | null;
   readonly reply: ((params: ReplyParams) => Promise<void>) | null;
+  readonly resolve: ((params: ResolveParams) => Promise<void>) | null;
 };
 
 export const useGitlabMrDiscussions = ({
@@ -113,6 +120,27 @@ export const useGitlabMrDiscussions = ({
     [workspaceId, host, projectPath, mrIid],
   );
 
+  const resolve = useCallback(
+    async ({ discussionId, resolved }: ResolveParams) => {
+      if (workspaceId == null || host == null || projectPath == null || mrIid == null) {
+        return;
+      }
+      try {
+        await gitlabResolveMrDiscussion({
+          workspaceId,
+          host,
+          projectPath,
+          mrIid,
+          discussionId,
+          resolved,
+        });
+      } finally {
+        setReloadToken((token) => token + 1);
+      }
+    },
+    [workspaceId, host, projectPath, mrIid],
+  );
+
   return {
     discussions,
     isLoading,
@@ -120,5 +148,6 @@ export const useGitlabMrDiscussions = ({
     reload,
     post: isReady ? post : null,
     reply: isReady ? reply : null,
+    resolve: isReady ? resolve : null,
   };
 };


### PR DESCRIPTION
## What

A GitLab merge request review thread can now be marked resolved, and reopened, from the thread card itself. No more leaving Goodboy to tick a checkbox on gitlab.com.

- New Tauri command `gitlab_resolve_mr_discussion` (`apps/desktop/src-tauri/src/gitlab.rs`), registered in `generate_handler!`.
- New client wrapper `gitlabResolveMrDiscussion`.
- New `resolve` action on `useGitlabMrDiscussions`, next to the existing `reply`. Discussion state stays component-local: no store slice.
- `MrThreadCard` gains a two-way action. The `resolved` pill stays a status indicator, and the button next to it reads `Resolve` on an open thread and `Unresolve` on a closed one.
- `VISION.md` no longer claims thread resolve is read-only for GitLab. That was the only place in the repo repeating the claim; `website/` says nothing about it, so no website change and no separate lockfile run.

## Why

`VISION.md` admitted the gap in writing: merge request threads were readable and repliable inside Goodboy, but resolving one meant opening the browser. That is exactly the tab this product exists to remove, and it had been deferred for seven release cycles.

## The request shape, and what has not been verified

The command issues:

```
PUT /projects/{encoded_path}/merge_requests/{iid}/discussions/{encoded_discussion_id}?resolved={true|false}
Content-Type: application/json
{"resolved": true|false}
```

The brief for this work suggested following the local `gitlab_update_issue` precedent and sending `resolved` as a JSON body field only. The GitLab REST documentation for discussions contradicts that: it documents `resolved` as a query parameter on `PUT /projects/:id/merge_requests/:merge_request_iid/discussions/:discussion_id`, and its own curl example appends `?resolved=true`. So the query parameter is the primary, documented shape here.

The JSON body carries the same field as a deliberate compatibility hedge, because older self-hosted versions are reported to read it from the body. Both carry the identical value, so there is nothing for the server to disambiguate.

The discussion id is percent-encoded with the same helper `gitlab_reply_to_mr_discussion` uses. A GitLab discussion id is not URL-safe in general and an unencoded id silently produces the wrong path.

**No call in this PR has ever run against a live GitLab tenant.** Every assertion here comes from the documentation and from unit tests over the constructed request. The endpoint, the parameter placement, and the response shape are unverified in practice.

## The optimistic update

There is none, on purpose. The loader in `useGitlabMrDiscussions` clears the list at the start of every reload, so any optimistic patch would be wiped a frame later and would only add a way to drift from the server. Instead `resolve` refetches in a `finally`, so success and failure both reconcile against GitLab. A failed write cannot leave the card showing a state the server never accepted. The card holds a local pending flag so the button disables during the round trip, and surfaces the error inline if the write fails.

## Test plan

Run from the worktree.

- `pnpm typecheck`: 5 tasks, 5 successful.
- `pnpm test --force`: 740 files, 6301 tests passed, 0 failed, 4 skipped, across all four packages (ui 20/103, db 29/196, core 102/1065, desktop 589/4937).
- `pnpm knip --include files,duplicates,unlisted`: exit 0, no findings.
- `cargo test --locked` from `apps/desktop/src-tauri`: 366 passed, 0 failed, 2 ignored.

New coverage:

- Rust: the resolve path encodes the namespaced project and the discussion id, an id containing `/`, a space and a `+` never reaches the URL raw, the payload deserializes a resolved thread, and a guard asserts the command appears in `generate_handler!`.
- Client: the wrapper invokes `gitlab_resolve_mr_discussion` with the discussion id and the flag, in both directions.
- Hook: `resolve` forwards the target and refetches, carries a cleared flag when reopening, and still refetches when the write throws.
- Card: the action is absent when read only, reachable and correctly signed in both states, and a failure is surfaced without disabling the button.

Each new test was sabotage-checked: dropping the `generate_handler!` line, dropping the percent encoding, inverting the toggle, and removing the refetch each turn the matching test red.

## Note on the commit scope

The brief asked for `feat(gitlab):`. `commitlint.config.js` restricts scopes to `desktop, ui, core, db, types, repo, ci`, so `gitlab` fails the commit-msg hook. Shipped as `feat(desktop):`.


## Verification pass, and the repair it required

The claim above that the card "surfaces the error inline if the write fails" was
wrong in the composed app, and the test that backed it could never have caught it.

`useGitlabMrDiscussions` clears the discussion list and flips `isLoading` on every
refetch. `MrConversation` renders its skeleton whenever `isLoading` is true, so the
moment the failed write bumps the reload token the whole thread list unmounts and
takes the card's local `resolveError` state with it. The user clicked Resolve on a
thread they could not resolve, saw a flash of skeleton, and got the thread back
unresolved with no explanation. A silent failure, not an inline error.

`MrThreadCard.test.tsx` passed because it drove the card in isolation with a stub
`onResolve`. Nothing in the isolated card triggers the refetch that destroys the
state, so the test asserted a behaviour that only exists outside the app.

Fixed by moving the write error onto the hook, keyed by discussion id, the way the
sibling `useGitlabMrApprovals` already holds its submit error. It outlives the
remount and reaches the card as a prop. The card keeps only its in-flight flag,
which is safe because the card is still mounted for the duration of the write.

Tests changed, and why:

- `MrThreadCard.test.tsx` > `surfaces a failed resolve without hiding the action`
  was rewritten. It pinned the broken design (card-local error state), so keeping it
  would have locked in the defect. It now asserts the card renders the failure it is
  handed, plus a companion case for the absent failure.
- `useGitlabMrDiscussions` > `refetches even when the resolve write fails` was
  rewritten. It asserted the promise rejects, which was the mechanism feeding the
  doomed card state. It now asserts the hook holds the failure and still refetches,
  and a new case covers the failure clearing on a later successful write.
- New `MrConversation.test.tsx` mounts the conversation over the real hook. This is
  the test that was missing: it proves the click reaches the client with the full
  merge request target in both directions, and that a rejected resolve is still on
  screen after the refetch settles.

Gates after the repair, from the worktree:

- `pnpm typecheck`: 5 tasks, 5 successful.
- `pnpm test --force`: 4 tasks successful, 741 files, 6306 tests passed, 0 failed,
  4 skipped (ui 20/103, db 29/196, core 102/1065, desktop 590/4942).
- `pnpm knip --include files,duplicates,unlisted`: no findings.
- `cargo test --locked`: 366 passed, 0 failed, 2 ignored.

Sabotage checks re-run independently, each one red: dropping the `generate_handler!`
line, dropping the percent encoding, inverting the toggle, pointing the URL at the
wrong iid, pointing it at the issues endpoint, removing the refetch, and making the
button render without calling its handler. The repair was sabotaged too: swallowing
the write error, refusing to hand it to the card, and dropping the clear on retry
each turn a test red.

Still true, and worth repeating: no call in this PR has run against a live GitLab
tenant. The endpoint, the placement of `resolved`, and the response shape remain
unverified in practice.
