### PR TITLE
feat(desktop): move work off a provider before its cap is spent

### DIFF
--- a/VISION.md
+++ b/VISION.md
@@ -227,7 +227,8 @@ OpenRouter, Moonshot). Set priorities. Set budgets. Enable or disable
 providers per session. Goodboy routes work to the right provider
 automatically.
 
-- Provider 1 hits 75% budget, fall back to provider 2.
+- Provider 1 passes its budget threshold, work moves to provider 2. You pick the
+  threshold; it defaults to 80% of the cap.
 - Quick task, fast cheap model. Complex architecture, best available model.
 - Each workflow step picks its model automatically by role, tier, and cost; an
   explicit pin overrides the auto choice.

--- a/apps/desktop/src-tauri/src/budget.rs
+++ b/apps/desktop/src-tauri/src/budget.rs
@@ -173,6 +173,8 @@ pub struct BudgetCheckResult {
     pub remaining_usd: f64,
     pub pct: f64,
     pub exceeded: bool,
+    #[serde(rename = "overThreshold")]
+    pub over_threshold: bool,
 }
 
 fn current_month_window_ms() -> (i64, i64) {
@@ -351,20 +353,17 @@ pub fn budget_emit_alerts(
     Ok(created)
 }
 
-#[tauri::command]
-pub fn check_provider_budget(
-    state: State<'_, Db>,
-    provider: String,
-    period: String,
+fn provider_budget_status(
+    conn: &rusqlite::Connection,
+    provider: &str,
+    period: &str,
 ) -> Result<BudgetCheckResult, DbError> {
-    let conn = state.0.lock().map_err(|_| DbError::Poisoned)?;
-
-    let rule: Option<(f64,)> = {
+    let rule: Option<(f64, f64)> = {
         let mut stmt = conn.prepare(
-            "SELECT cap_usd FROM budget_rules WHERE provider = ?1 AND period = ?2 LIMIT 1",
+            "SELECT cap_usd, alert_threshold_pct FROM budget_rules WHERE provider = ?1 AND period = ?2 LIMIT 1",
         )?;
         let mut rows = stmt.query_map(rusqlite::params![provider, period], |row| {
-            Ok((row.get::<_, f64>(0)?,))
+            Ok((row.get::<_, f64>(0)?, row.get::<_, f64>(1)?))
         })?;
         match rows.next() {
             Some(r) => Some(r.map_err(DbError::Sqlite)?),
@@ -372,11 +371,12 @@ pub fn check_provider_budget(
         }
     };
 
-    let Some((cap_usd,)) = rule else {
+    let Some((cap_usd, threshold_pct)) = rule else {
         return Ok(BudgetCheckResult {
             remaining_usd: f64::INFINITY,
             pct: 0.0,
             exceeded: false,
+            over_threshold: false,
         });
     };
 
@@ -395,12 +395,24 @@ pub fn check_provider_budget(
     } else {
         0.0
     };
+    let exceeded = spent > cap_usd;
 
     Ok(BudgetCheckResult {
         remaining_usd: remaining,
         pct,
-        exceeded: spent > cap_usd,
+        exceeded,
+        over_threshold: !exceeded && pct >= threshold_pct,
     })
+}
+
+#[tauri::command]
+pub fn check_provider_budget(
+    state: State<'_, Db>,
+    provider: String,
+    period: String,
+) -> Result<BudgetCheckResult, DbError> {
+    let conn = state.0.lock().map_err(|_| DbError::Poisoned)?;
+    provider_budget_status(&conn, &provider, &period)
 }
 
 #[tauri::command]
@@ -425,6 +437,7 @@ pub fn check_session_budget(
             remaining_usd: f64::INFINITY,
             pct: 0.0,
             exceeded: false,
+            over_threshold: false,
         });
     };
 
@@ -445,5 +458,127 @@ pub fn check_session_budget(
         remaining_usd: remaining,
         pct,
         exceeded: spent > cap_usd,
+        over_threshold: false,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn budget_conn() -> rusqlite::Connection {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE budget_rules (
+                id TEXT PRIMARY KEY, provider TEXT, period TEXT,
+                cap_usd REAL, alert_threshold_pct REAL
+            );
+            CREATE TABLE telemetry_records (
+                id TEXT PRIMARY KEY, provider TEXT, estimated_cost_usd REAL, recorded_at INTEGER
+            );",
+        )
+        .unwrap();
+        conn
+    }
+
+    fn insert_rule(conn: &rusqlite::Connection, cap_usd: f64, threshold_pct: f64) {
+        conn.execute(
+            "INSERT INTO budget_rules (id, provider, period, cap_usd, alert_threshold_pct)
+             VALUES ('r1', 'anthropic', 'monthly', ?1, ?2)",
+            rusqlite::params![cap_usd, threshold_pct],
+        )
+        .unwrap();
+    }
+
+    fn insert_spend(conn: &rusqlite::Connection, id: &str, cost_usd: f64) {
+        let (start_ms, _) = current_month_window_ms();
+        conn.execute(
+            "INSERT INTO telemetry_records (id, provider, estimated_cost_usd, recorded_at)
+             VALUES (?1, 'anthropic', ?2, ?3)",
+            rusqlite::params![id, cost_usd, start_ms],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn no_rule_leaves_the_provider_unbounded() {
+        let conn = budget_conn();
+        let result = provider_budget_status(&conn, "anthropic", "monthly").unwrap();
+
+        assert!(result.remaining_usd.is_infinite());
+        assert_eq!(result.pct, 0.0);
+        assert!(!result.exceeded);
+        assert!(!result.over_threshold);
+    }
+
+    #[test]
+    fn under_threshold_is_not_flagged() {
+        let conn = budget_conn();
+        insert_rule(&conn, 100.0, 80.0);
+        insert_spend(&conn, "t1", 50.0);
+
+        let result = provider_budget_status(&conn, "anthropic", "monthly").unwrap();
+
+        assert_eq!(result.pct, 50.0);
+        assert_eq!(result.remaining_usd, 50.0);
+        assert!(!result.exceeded);
+        assert!(!result.over_threshold);
+    }
+
+    #[test]
+    fn over_threshold_but_under_cap_is_flagged_without_exceeding() {
+        let conn = budget_conn();
+        insert_rule(&conn, 100.0, 80.0);
+        insert_spend(&conn, "t1", 85.0);
+
+        let result = provider_budget_status(&conn, "anthropic", "monthly").unwrap();
+
+        assert_eq!(result.pct, 85.0);
+        assert_eq!(result.remaining_usd, 15.0);
+        assert!(!result.exceeded);
+        assert!(result.over_threshold);
+    }
+
+    #[test]
+    fn over_cap_exceeds_and_clears_the_threshold_flag() {
+        let conn = budget_conn();
+        insert_rule(&conn, 100.0, 80.0);
+        insert_spend(&conn, "t1", 120.0);
+
+        let result = provider_budget_status(&conn, "anthropic", "monthly").unwrap();
+
+        assert_eq!(result.pct, 120.0);
+        assert!(result.exceeded);
+        assert!(!result.over_threshold);
+    }
+
+    #[test]
+    fn a_custom_threshold_moves_the_flag_point() {
+        let conn = budget_conn();
+        insert_rule(&conn, 100.0, 50.0);
+        insert_spend(&conn, "t1", 60.0);
+
+        let result = provider_budget_status(&conn, "anthropic", "monthly").unwrap();
+
+        assert!(!result.exceeded);
+        assert!(result.over_threshold);
+    }
+
+    #[test]
+    fn spend_outside_the_month_window_is_ignored() {
+        let conn = budget_conn();
+        insert_rule(&conn, 100.0, 80.0);
+        let (start_ms, _) = current_month_window_ms();
+        conn.execute(
+            "INSERT INTO telemetry_records (id, provider, estimated_cost_usd, recorded_at)
+             VALUES ('old', 'anthropic', 90.0, ?1)",
+            rusqlite::params![start_ms - 1],
+        )
+        .unwrap();
+
+        let result = provider_budget_status(&conn, "anthropic", "monthly").unwrap();
+
+        assert_eq!(result.pct, 0.0);
+        assert!(!result.over_threshold);
+    }
 }

--- a/apps/desktop/src/features/budget/components/BudgetStudio/CapEditor.test.tsx
+++ b/apps/desktop/src/features/budget/components/BudgetStudio/CapEditor.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { CapEditor } from './CapEditor';
 
@@ -28,5 +28,63 @@ describe('CapEditor', () => {
     view.rerender(<CapEditor label="session soft cap" currentCapUsd={5} onSave={vi.fn()} />);
 
     expect(input.value).toBe('5');
+  });
+});
+
+describe('CapEditor, alert threshold', () => {
+  it('saves the edited threshold through the threshold save path', async () => {
+    const onSaveThreshold = vi.fn(async () => undefined);
+    render(
+      <CapEditor
+        label="monthly cap"
+        currentCapUsd={50}
+        threshold={{ pct: 80, onSave: onSaveThreshold }}
+        onSave={vi.fn()}
+      />,
+    );
+    const input = screen.getByLabelText('alert threshold percent') as HTMLInputElement;
+    expect(input.value).toBe('80');
+
+    fireEvent.change(input, { target: { value: '60' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Update threshold' }));
+
+    await waitFor(() => expect(onSaveThreshold).toHaveBeenCalledWith(60));
+  });
+
+  it('refuses a threshold outside 1 to 100', () => {
+    const onSaveThreshold = vi.fn(async () => undefined);
+    render(
+      <CapEditor
+        label="monthly cap"
+        currentCapUsd={50}
+        threshold={{ pct: 80, onSave: onSaveThreshold }}
+        onSave={vi.fn()}
+      />,
+    );
+    const input = screen.getByLabelText('alert threshold percent');
+
+    fireEvent.change(input, { target: { value: '150' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Update threshold' }));
+
+    expect(onSaveThreshold).not.toHaveBeenCalled();
+  });
+
+  it('hides the control on the session mount, which has no threshold', () => {
+    render(<CapEditor label="session soft cap" currentCapUsd={50} onSave={vi.fn()} />);
+
+    expect(screen.queryByLabelText('alert threshold percent')).toBeNull();
+  });
+
+  it('hides the control until a cap exists to measure against', () => {
+    render(
+      <CapEditor
+        label="monthly cap"
+        currentCapUsd={null}
+        threshold={{ pct: 80, onSave: vi.fn() }}
+        onSave={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByLabelText('alert threshold percent')).toBeNull();
   });
 });

--- a/apps/desktop/src/features/budget/components/BudgetStudio/CapEditor.tsx
+++ b/apps/desktop/src/features/budget/components/BudgetStudio/CapEditor.tsx
@@ -4,13 +4,31 @@ import { Button, InlineConfirm, Input, formatUsd } from '@goodboy/ui';
 import { parseCap } from '../../../../shared/lib/parse-cap';
 import { StudioWidget } from '../../../../shared/components/StudioWidget';
 
+type Threshold = {
+  readonly pct: number;
+  readonly onSave: (thresholdPct: number) => Promise<void>;
+};
+
 type Props = {
   readonly label: string;
   readonly hint?: string;
   readonly currentCapUsd: number | null;
   readonly placeholder?: string;
+  readonly threshold?: Threshold;
   readonly onSave: (capUsd: number) => Promise<void>;
   readonly onRemove?: () => Promise<void>;
+};
+
+const parseThresholdPct = (raw: string): number | null => {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+  const parsed = Number(trimmed);
+  if (!Number.isFinite(parsed) || parsed <= 0 || parsed > 100) {
+    return null;
+  }
+  return Math.round(parsed);
 };
 
 export const CapEditor = ({
@@ -18,6 +36,7 @@ export const CapEditor = ({
   hint,
   currentCapUsd,
   placeholder = 'e.g. 50',
+  threshold,
   onSave,
   onRemove,
 }: Props) => {
@@ -25,6 +44,10 @@ export const CapEditor = ({
   const [busy, setBusy] = useState(false);
   const [removeArmed, setRemoveArmed] = useState(false);
   const previousCapRef = useRef(currentCapUsd);
+  const [thresholdDraft, setThresholdDraft] = useState(
+    threshold !== undefined ? String(threshold.pct) : '',
+  );
+  const previousThresholdRef = useRef(threshold?.pct ?? null);
 
   useEffect(() => {
     const previousCap = previousCapRef.current;
@@ -34,9 +57,36 @@ export const CapEditor = ({
     previousCapRef.current = currentCapUsd;
   }, [currentCapUsd]);
 
+  useEffect(() => {
+    const nextPct = threshold?.pct ?? null;
+    const previousPct = previousThresholdRef.current;
+    const previousValue = previousPct !== null ? String(previousPct) : '';
+    const nextValue = nextPct !== null ? String(nextPct) : '';
+    setThresholdDraft((currentValue) =>
+      currentValue === previousValue ? nextValue : currentValue,
+    );
+    previousThresholdRef.current = nextPct;
+  }, [threshold?.pct]);
+
   const parsed = parseCap(draft);
   const unchanged = parsed !== null && parsed === currentCapUsd;
   const canSave = parsed !== null && !unchanged && !busy;
+
+  const parsedThreshold = parseThresholdPct(thresholdDraft);
+  const canSaveThreshold =
+    threshold !== undefined && parsedThreshold !== null && parsedThreshold !== threshold.pct;
+
+  const saveThreshold = async () => {
+    if (threshold === undefined || parsedThreshold === null) {
+      return;
+    }
+    setBusy(true);
+    try {
+      await threshold.onSave(parsedThreshold);
+    } finally {
+      setBusy(false);
+    }
+  };
 
   const save = async () => {
     if (parsed === null) {
@@ -113,6 +163,41 @@ export const CapEditor = ({
           </span>
         ) : null}
       </div>
+      {threshold !== undefined && currentCapUsd !== null ? (
+        <div className="flex flex-col gap-2 border-t border-border-soft pt-3">
+          <div className="flex items-center gap-2">
+            <span className="text-sm text-muted-foreground">at</span>
+            <Input
+              type="text"
+              inputMode="numeric"
+              value={thresholdDraft}
+              placeholder="80"
+              disabled={busy}
+              onChange={(e) => setThresholdDraft(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && canSaveThreshold && !busy) {
+                  void saveThreshold();
+                }
+              }}
+              className="max-w-20 font-mono tabular-nums"
+              aria-label="alert threshold percent"
+            />
+            <span className="text-sm text-muted-foreground">% of the cap</span>
+            <Button
+              variant="secondary"
+              size="sm"
+              disabled={!canSaveThreshold || busy}
+              onClick={() => void saveThreshold()}
+            >
+              Update threshold
+            </Button>
+          </div>
+          <p className="text-2xs text-muted-foreground">
+            this number does two things: it raises the budget alert, and it moves the next turn to
+            another provider. spend above it still runs here if no other provider has room.
+          </p>
+        </div>
+      ) : null}
     </StudioWidget>
   );
 };

--- a/apps/desktop/src/features/budget/components/BudgetStudio/ProviderPanel.tsx
+++ b/apps/desktop/src/features/budget/components/BudgetStudio/ProviderPanel.tsx
@@ -23,6 +23,7 @@ type Props = {
   readonly telemetryResult: QueryResult<void>;
   readonly isLoading: boolean;
   readonly onSaveCap: (capUsd: number) => Promise<void>;
+  readonly onSaveThreshold: (thresholdPct: number) => Promise<void>;
   readonly onRemoveCap: () => Promise<void>;
   readonly onRetryRules: () => void;
   readonly onRetryTelemetry: () => void;
@@ -38,6 +39,7 @@ export const ProviderPanel = ({
   telemetryResult,
   isLoading,
   onSaveCap,
+  onSaveThreshold,
   onRemoveCap,
   onRetryRules,
   onRetryTelemetry,
@@ -92,6 +94,9 @@ export const ProviderPanel = ({
         label="monthly cap"
         hint="cap monthly spend for this provider"
         currentCapUsd={rule?.capUsd ?? null}
+        {...(rule !== null
+          ? { threshold: { pct: rule.alertThresholdPct, onSave: onSaveThreshold } }
+          : {})}
         onSave={onSaveCap}
         onRemove={onRemoveCap}
       />

--- a/apps/desktop/src/features/budget/components/BudgetStudio/index.test.tsx
+++ b/apps/desktop/src/features/budget/components/BudgetStudio/index.test.tsx
@@ -152,6 +152,40 @@ describe('BudgetStudio', () => {
     });
   });
 
+  it('edits the threshold as delete then save, keeping the cap intact', async () => {
+    state.budgetRules = [
+      {
+        id: 'rule-1',
+        provider: 'anthropic',
+        period: 'monthly',
+        capUsd: 10,
+        alertThresholdPct: 90,
+        extraTokensBudget: 5,
+        createdAt: '2026-06-01T00:00:00.000Z',
+      },
+    ];
+    render(
+      <BudgetStudio
+        workspaceName="goodboy"
+        initialScope={{ kind: 'provider', provider: 'anthropic' }}
+        onClose={vi.fn()}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText('alert threshold percent'), {
+      target: { value: '60' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /update threshold/i }));
+    await Promise.resolve();
+    expect(state.deleteBudgetRule).toHaveBeenCalledWith('rule-1');
+    expect(state.saveBudgetRule).toHaveBeenCalledWith({
+      provider: 'anthropic',
+      period: 'monthly',
+      capUsd: 10,
+      alertThresholdPct: 60,
+      extraTokensBudget: 5,
+    });
+  });
+
   it('removes a provider cap via deleteBudgetRule', () => {
     state.budgetRules = [
       {

--- a/apps/desktop/src/features/budget/components/BudgetStudio/index.tsx
+++ b/apps/desktop/src/features/budget/components/BudgetStudio/index.tsx
@@ -84,6 +84,26 @@ export const BudgetStudio = ({ workspaceName, initialScope, onClose }: Props) =>
     [budgetRules, deleteBudgetRule, saveBudgetRule, refreshBreakdown],
   );
 
+  const saveProviderThreshold = useCallback(
+    async (provider: ProviderName, thresholdPct: number) => {
+      const existing = budgetRules.find((r) => r.provider === provider) ?? null;
+      if (existing === null) {
+        return;
+      }
+      await deleteBudgetRule(existing.id);
+      const next: Omit<BudgetRule, 'id' | 'createdAt'> = {
+        provider,
+        period: existing.period,
+        capUsd: existing.capUsd,
+        alertThresholdPct: thresholdPct,
+        extraTokensBudget: existing.extraTokensBudget,
+      };
+      await saveBudgetRule(next);
+      await refreshBreakdown();
+    },
+    [budgetRules, deleteBudgetRule, saveBudgetRule, refreshBreakdown],
+  );
+
   const removeProviderCap = useCallback(
     async (provider: ProviderName) => {
       const existing = budgetRules.find((r) => r.provider === provider) ?? null;
@@ -238,6 +258,7 @@ export const BudgetStudio = ({ workspaceName, initialScope, onClose }: Props) =>
                 telemetryResult={budgetData.telemetry}
                 isLoading={budgetData.loading.rules || budgetData.loading.telemetry}
                 onSaveCap={(capUsd) => saveProviderCap(scope.provider, capUsd)}
+                onSaveThreshold={(pct) => saveProviderThreshold(scope.provider, pct)}
                 onRemoveCap={() => removeProviderCap(scope.provider)}
                 onRetryRules={() => budgetData.retry('rules')}
                 onRetryTelemetry={() => budgetData.retry('telemetry')}

--- a/apps/desktop/src/features/chat/components/RoutingIndicator/index.test.tsx
+++ b/apps/desktop/src/features/chat/components/RoutingIndicator/index.test.tsx
@@ -63,4 +63,23 @@ describe('RoutingIndicator', () => {
     await waitFor(() => screen.getByTitle('Model: cursor-pro'));
     expect(screen.getByText(/budget exceeded for claude/i)).toBeTruthy();
   });
+
+  it('renders the threshold warning, worded apart from the over-cap one', async () => {
+    resolveMock.mockResolvedValue({
+      reason: 'fallback-threshold',
+      fallbackFrom: 'anthropic',
+      selectedProvider: 'cursor',
+      selectedModel: 'cursor-pro',
+    });
+    render(
+      <RoutingIndicator
+        sessionPreference={null as never}
+        turnOverride={undefined}
+        connectedProviders={[]}
+      />,
+    );
+    await waitFor(() => screen.getByTitle('Model: cursor-pro'));
+    expect(screen.getByText(/claude past its budget threshold/i)).toBeTruthy();
+    expect(screen.queryByText(/budget exceeded/i)).toBeNull();
+  });
 });

--- a/apps/desktop/src/features/chat/components/RoutingIndicator/index.tsx
+++ b/apps/desktop/src/features/chat/components/RoutingIndicator/index.tsx
@@ -3,6 +3,7 @@ import { AlertTriangle } from 'lucide-react';
 import type {
   ProviderId,
   RoutingDecision,
+  RoutingReason,
   SessionProviderPreference,
   TurnProviderOverride,
 } from '@goodboy/types';
@@ -73,16 +74,20 @@ export const RoutingIndicator = ({
   }
 
   const isFallback =
-    decision.reason === 'fallback-budget' || decision.reason === 'fallback-disconnected';
+    decision.reason === 'fallback-budget' ||
+    decision.reason === 'fallback-threshold' ||
+    decision.reason === 'fallback-disconnected';
   if (!isFallback || !decision.fallbackFrom) {
     return null;
   }
 
   const fromLabel = PROVIDER_LABEL_LOWER[decision.fallbackFrom];
-  const cause =
-    decision.reason === 'fallback-budget'
-      ? `budget exceeded for ${fromLabel}`
-      : `${fromLabel} disconnected`;
+  const causeByReason: Partial<Record<RoutingReason, string>> = {
+    'fallback-budget': `budget exceeded for ${fromLabel}`,
+    'fallback-threshold': `${fromLabel} past its budget threshold`,
+    'fallback-disconnected': `${fromLabel} disconnected`,
+  };
+  const cause = causeByReason[decision.reason] ?? `${fromLabel} disconnected`;
 
   return (
     <TranscriptShell

--- a/apps/desktop/src/store/slices/turn/budgetRoutingNoticeMessage.test.ts
+++ b/apps/desktop/src/store/slices/turn/budgetRoutingNoticeMessage.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { budgetRoutingNoticeMessage, budgetRoutingReason } from './budgetRoutingNoticeMessage';
+
+describe('budgetRoutingNoticeMessage', () => {
+  it('names the threshold when the cap is not spent yet', () => {
+    const message = budgetRoutingNoticeMessage({
+      from: 'anthropic',
+      to: 'codex',
+      reason: 'fallback-threshold',
+    });
+
+    expect(message).toBe('anthropic is past its budget threshold. running this turn on codex.');
+  });
+
+  it('names the cap when the cap is spent', () => {
+    const message = budgetRoutingNoticeMessage({
+      from: 'anthropic',
+      to: 'gemini',
+      reason: 'fallback-budget',
+    });
+
+    expect(message).toBe('anthropic is over its monthly cap. running this turn on gemini.');
+  });
+
+  it('reads the two cases differently', () => {
+    const threshold = budgetRoutingNoticeMessage({
+      from: 'anthropic',
+      to: 'codex',
+      reason: 'fallback-threshold',
+    });
+    const cap = budgetRoutingNoticeMessage({
+      from: 'anthropic',
+      to: 'codex',
+      reason: 'fallback-budget',
+    });
+
+    expect(threshold).not.toBe(cap);
+  });
+
+  it('carries no em-dash', () => {
+    const message = budgetRoutingNoticeMessage({
+      from: 'anthropic',
+      to: 'codex',
+      reason: 'fallback-threshold',
+    });
+
+    expect(message).not.toContain('\u2014');
+  });
+});
+
+describe('budgetRoutingReason', () => {
+  it('keeps the two budget reasons', () => {
+    expect(budgetRoutingReason({ reason: 'fallback-budget' })).toBe('fallback-budget');
+    expect(budgetRoutingReason({ reason: 'fallback-threshold' })).toBe('fallback-threshold');
+  });
+
+  it('drops the reasons that are not about budget', () => {
+    expect(budgetRoutingReason({ reason: 'preferred' })).toBeNull();
+    expect(budgetRoutingReason({ reason: 'override' })).toBeNull();
+    expect(budgetRoutingReason({ reason: 'fallback-disconnected' })).toBeNull();
+    expect(budgetRoutingReason({ reason: 'all-exceeded' })).toBeNull();
+  });
+});

--- a/apps/desktop/src/store/slices/turn/budgetRoutingNoticeMessage.ts
+++ b/apps/desktop/src/store/slices/turn/budgetRoutingNoticeMessage.ts
@@ -1,0 +1,36 @@
+import type { ProviderId, RoutingReason } from '@goodboy/types';
+
+export type BudgetRoutingReason = Extract<RoutingReason, 'fallback-budget' | 'fallback-threshold'>;
+
+type Params = {
+  readonly from: ProviderId;
+  readonly to: ProviderId;
+  readonly reason: BudgetRoutingReason;
+};
+
+const causeFor = ({ reason }: { readonly reason: BudgetRoutingReason }): string => {
+  switch (reason) {
+    case 'fallback-threshold':
+      return 'is past its budget threshold';
+    case 'fallback-budget':
+      return 'is over its monthly cap';
+    default: {
+      const exhaustive: never = reason;
+      throw new Error(`unknown budget routing reason: ${String(exhaustive)}`);
+    }
+  }
+};
+
+export const budgetRoutingReason = ({
+  reason,
+}: {
+  readonly reason: RoutingReason;
+}): BudgetRoutingReason | null => {
+  if (reason === 'fallback-budget' || reason === 'fallback-threshold') {
+    return reason;
+  }
+  return null;
+};
+
+export const budgetRoutingNoticeMessage = ({ from, to, reason }: Params): string =>
+  `${from} ${causeFor({ reason })}. running this turn on ${to}.`;

--- a/apps/desktop/src/store/slices/turn/sendTurn.ts
+++ b/apps/desktop/src/store/slices/turn/sendTurn.ts
@@ -91,6 +91,7 @@ import { dispatchParallelTurn } from './dispatchParallelTurn';
 import { auditToolCall } from './auditToolCall';
 import { resolveErrorTurnMessage } from './resolveErrorTurnMessage';
 import { fallbackNoticeMessage } from './fallbackNoticeMessage';
+import { budgetRoutingNoticeMessage, budgetRoutingReason } from './budgetRoutingNoticeMessage';
 import { cursorMaxModeMessage, matchCursorMaxModeFailure } from './matchCursorMaxModeFailure';
 import { recordUsageTelemetry } from './recordUsageTelemetry';
 import { resolveTurnModelSelection } from './resolveTurnModelSelection';
@@ -419,6 +420,25 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
         at: now(),
       });
       return;
+    }
+
+    const movedForBudget = budgetRoutingReason({ reason: routingDecision.reason });
+
+    if (
+      routingDecision.fallbackUsed &&
+      routingDecision.fallbackFrom !== undefined &&
+      movedForBudget !== null
+    ) {
+      get().appendTurnEvent(activeAgentId, sessionId, {
+        kind: 'error',
+        runId: crypto.randomUUID() as ProviderRunId,
+        message: budgetRoutingNoticeMessage({
+          from: routingDecision.fallbackFrom,
+          to: routingDecision.selectedProvider,
+          reason: movedForBudget,
+        }),
+        at: now(),
+      });
     }
 
     const provider: ProviderId = routingDecision.selectedProvider;

--- a/apps/desktop/src/store/store.sendturn-agent-routing.test.ts
+++ b/apps/desktop/src/store/store.sendturn-agent-routing.test.ts
@@ -1727,3 +1727,133 @@ describe('sendTurn, resolver config (provider pin + effort)', () => {
     expect(runTurnSpy.mock.calls[0]?.[0]?.prompt).toContain('kick A');
   });
 });
+
+describe('sendTurn, budget routing notice', () => {
+  beforeEach(async () => {
+    runTurnSpy.mockReset();
+    invokeSpy.mockReset();
+    invokeAgentUpdateStatusSpy.mockReset();
+    runTurnSpy.mockImplementation(() => emptyStream());
+    invokeSpy.mockResolvedValue({
+      stdout: JSON.stringify({ result: JSON.stringify({ upserts: [] }) }),
+      stderr: '',
+      exitCode: 0,
+    });
+    const workflowsMod = await import('../features/workflows/workflows');
+    (workflowsMod.invokeAgentList as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+  });
+
+  afterEach(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    vi.clearAllMocks();
+  });
+
+  function setupNoticeAgent(useAppStore: Awaited<ReturnType<typeof importStore>>) {
+    useAppStore.setState({
+      sessions: [buildSession()],
+      sessionWorktrees: { [SESSION_ID]: ['/tmp/wt'] },
+      sessionPhaseRuns: { [SESSION_ID]: [buildAgent(AGENT_A, 0)] },
+      selectedAgentId: { [SESSION_ID]: AGENT_A },
+      agentEffortOverride: {},
+      agentProviderOverride: {},
+      agentModelOverride: {},
+      pendingResolverKickoff: {},
+      transcripts: { [AGENT_A]: [] },
+      providers: [
+        {
+          id: 'anthropic',
+          binary: 'claude',
+          connection: 'connected',
+          name: 'Claude',
+          installation: 'installed',
+        } as never,
+      ],
+      authResults: {
+        anthropic: { state: 'connected', identity: 'test' },
+        cursor: { state: 'connected', identity: 'test' },
+      } as never,
+      workspaces: [
+        { id: WORKSPACE_ID, name: 'ws', rootPath: '/tmp', createdAt: NOW, updatedAt: NOW },
+      ],
+    });
+  }
+
+  async function sendWithDecision(
+    useAppStore: Awaited<ReturnType<typeof importStore>>,
+    decision: Record<string, unknown>,
+  ) {
+    const routingMod = await import('../features/providers/routing');
+    (routingMod.resolveProviderForTurn as ReturnType<typeof vi.fn>).mockResolvedValue(decision);
+
+    await useAppStore
+      .getState()
+      .sendTurn({ sessionId: SESSION_ID, agentId: AGENT_A, content: 'go' });
+
+    return (useAppStore.getState().transcripts[AGENT_A] ?? [])
+      .filter((event) => event.kind === 'error')
+      .map((event) => ('message' in event ? event.message : ''));
+  }
+
+  it('tells the transcript where a threshold move went and why', async () => {
+    const useAppStore = await importStore();
+    setupNoticeAgent(useAppStore);
+
+    const messages = await sendWithDecision(useAppStore, {
+      selectedProvider: 'cursor',
+      selectedModel: 'composer-2.5',
+      reason: 'fallback-threshold',
+      fallbackUsed: true,
+      fallbackFrom: 'anthropic',
+    });
+
+    expect(messages).toContain(
+      'anthropic is past its budget threshold. running this turn on cursor.',
+    );
+  });
+
+  it('names the cap, not the threshold, when the cap is already spent', async () => {
+    const useAppStore = await importStore();
+    setupNoticeAgent(useAppStore);
+
+    const messages = await sendWithDecision(useAppStore, {
+      selectedProvider: 'cursor',
+      selectedModel: 'composer-2.5',
+      reason: 'fallback-budget',
+      fallbackUsed: true,
+      fallbackFrom: 'anthropic',
+    });
+
+    expect(messages).toContain('anthropic is over its monthly cap. running this turn on cursor.');
+    expect(messages.join(' ')).not.toContain('threshold');
+  });
+
+  it('stays quiet when the move was not about budget', async () => {
+    const useAppStore = await importStore();
+    setupNoticeAgent(useAppStore);
+
+    const messages = await sendWithDecision(useAppStore, {
+      selectedProvider: 'cursor',
+      selectedModel: 'composer-2.5',
+      reason: 'fallback-disconnected',
+      fallbackUsed: true,
+      fallbackFrom: 'anthropic',
+    });
+
+    expect(messages.join(' ')).not.toContain('running this turn on');
+  });
+
+  it('stays quiet when the turn never left the preferred provider', async () => {
+    const useAppStore = await importStore();
+    setupNoticeAgent(useAppStore);
+
+    const messages = await sendWithDecision(useAppStore, {
+      selectedProvider: 'anthropic',
+      selectedModel: 'claude-sonnet-4-5',
+      reason: 'preferred',
+      fallbackUsed: false,
+    });
+
+    expect(messages.join(' ')).not.toContain('running this turn on');
+  });
+});

--- a/packages/core/src/budget/__tests__/alert-emitter.test.ts
+++ b/packages/core/src/budget/__tests__/alert-emitter.test.ts
@@ -36,10 +36,12 @@ const RULE: BudgetRule = {
 function makeResult(pct: number): BudgetCheckResult {
   const capUsd = 100;
   const spent = pct;
+  const exceeded = spent > capUsd;
   return {
     remainingUsd: capUsd - spent,
     pct,
-    exceeded: spent > capUsd,
+    exceeded,
+    overThreshold: !exceeded && pct >= RULE.alertThresholdPct,
   };
 }
 
@@ -64,7 +66,12 @@ beforeEach(() => {
 
 describe('emitBudgetAlerts', () => {
   it('provider at 80% → emits provider-threshold alert', async () => {
-    const deps = makeDeps(makeResult(80), { remainingUsd: Infinity, pct: 0, exceeded: false });
+    const deps = makeDeps(makeResult(80), {
+      remainingUsd: Infinity,
+      pct: 0,
+      exceeded: false,
+      overThreshold: false,
+    });
 
     const alerts = await emitBudgetAlerts(deps, { provider: 'anthropic', sessionId: SESSION_ID });
 
@@ -74,7 +81,12 @@ describe('emitBudgetAlerts', () => {
   });
 
   it('provider at 100% → emits provider-exceeded alert', async () => {
-    const deps = makeDeps(makeResult(100), { remainingUsd: Infinity, pct: 0, exceeded: false });
+    const deps = makeDeps(makeResult(100), {
+      remainingUsd: Infinity,
+      pct: 0,
+      exceeded: false,
+      overThreshold: false,
+    });
 
     const alerts = await emitBudgetAlerts(deps, { provider: 'anthropic', sessionId: SESSION_ID });
 
@@ -83,7 +95,12 @@ describe('emitBudgetAlerts', () => {
   });
 
   it('provider under threshold → no alert emitted', async () => {
-    const deps = makeDeps(makeResult(50), { remainingUsd: Infinity, pct: 0, exceeded: false });
+    const deps = makeDeps(makeResult(50), {
+      remainingUsd: Infinity,
+      pct: 0,
+      exceeded: false,
+      overThreshold: false,
+    });
 
     const alerts = await emitBudgetAlerts(deps, { provider: 'anthropic', sessionId: SESSION_ID });
 
@@ -95,7 +112,12 @@ describe('emitBudgetAlerts', () => {
     const sessionBudget: SessionBudget = { sessionId: SESSION_ID, softCapUsd: 50 };
     vi.mocked(getSessionBudget).mockResolvedValue(sessionBudget);
 
-    const deps = makeDeps(makeResult(50), { remainingUsd: -10, pct: 120, exceeded: true });
+    const deps = makeDeps(makeResult(50), {
+      remainingUsd: -10,
+      pct: 120,
+      exceeded: true,
+      overThreshold: false,
+    });
 
     const alerts = await emitBudgetAlerts(deps, { provider: 'anthropic', sessionId: SESSION_ID });
 
@@ -114,7 +136,12 @@ describe('emitBudgetAlerts', () => {
     };
     vi.mocked(listBudgetAlerts).mockResolvedValue([existingAlert]);
 
-    const deps = makeDeps(makeResult(80), { remainingUsd: Infinity, pct: 0, exceeded: false });
+    const deps = makeDeps(makeResult(80), {
+      remainingUsd: Infinity,
+      pct: 0,
+      exceeded: false,
+      overThreshold: false,
+    });
 
     const alerts = await emitBudgetAlerts(deps, { provider: 'anthropic', sessionId: SESSION_ID });
 
@@ -134,7 +161,12 @@ describe('emitBudgetAlerts', () => {
     };
     vi.mocked(listBudgetAlerts).mockResolvedValue([]);
 
-    const deps = makeDeps(makeResult(80), { remainingUsd: Infinity, pct: 0, exceeded: false });
+    const deps = makeDeps(makeResult(80), {
+      remainingUsd: Infinity,
+      pct: 0,
+      exceeded: false,
+      overThreshold: false,
+    });
 
     const alerts = await emitBudgetAlerts(deps, { provider: 'anthropic', sessionId: SESSION_ID });
 

--- a/packages/core/src/budget/__tests__/checker.test.ts
+++ b/packages/core/src/budget/__tests__/checker.test.ts
@@ -28,7 +28,12 @@ describe('checkProviderBudget', () => {
   it('no budget rule → Infinity remaining, pct 0, not exceeded', async () => {
     const db = makeDb({ select: vi.fn().mockResolvedValue([]) });
     const result = await checkProviderBudget(db, 'anthropic', 'monthly');
-    expect(result).toEqual({ remainingUsd: Infinity, pct: 0, exceeded: false });
+    expect(result).toEqual({
+      remainingUsd: Infinity,
+      pct: 0,
+      exceeded: false,
+      overThreshold: false,
+    });
   });
 
   it('rule exists, 0% spent → remaining = cap, pct = 0', async () => {
@@ -142,6 +147,74 @@ describe('checkProviderBudget', () => {
     expect(result.remainingUsd).toBe(-1);
     expect(result.pct).toBe(101);
     expect(result.exceeded).toBe(true);
+    expect(result.overThreshold).toBe(false);
+  });
+
+  it('spend at the alert threshold but under the cap → overThreshold, not exceeded', async () => {
+    const selectMock = vi
+      .fn()
+      .mockResolvedValueOnce([
+        {
+          id: 'r1',
+          provider: 'anthropic',
+          period: 'monthly',
+          cap_usd: 100,
+          alert_threshold_pct: 80,
+          created_at: '2026-05-01T00:00:00.000Z',
+        },
+      ])
+      .mockResolvedValueOnce([{ total: 80 }]);
+
+    const db = makeDb({ select: selectMock });
+    const result = await checkProviderBudget(db, 'anthropic', 'monthly');
+
+    expect(result.overThreshold).toBe(true);
+    expect(result.exceeded).toBe(false);
+    expect(result.remainingUsd).toBe(20);
+  });
+
+  it('a custom threshold moves the flag point, the cap stays at 100%', async () => {
+    const selectMock = vi
+      .fn()
+      .mockResolvedValueOnce([
+        {
+          id: 'r1',
+          provider: 'anthropic',
+          period: 'monthly',
+          cap_usd: 100,
+          alert_threshold_pct: 50,
+          created_at: '2026-05-01T00:00:00.000Z',
+        },
+      ])
+      .mockResolvedValueOnce([{ total: 60 }]);
+
+    const db = makeDb({ select: selectMock });
+    const result = await checkProviderBudget(db, 'anthropic', 'monthly');
+
+    expect(result.overThreshold).toBe(true);
+    expect(result.exceeded).toBe(false);
+  });
+
+  it('spend just under the threshold → neither flag is set', async () => {
+    const selectMock = vi
+      .fn()
+      .mockResolvedValueOnce([
+        {
+          id: 'r1',
+          provider: 'anthropic',
+          period: 'monthly',
+          cap_usd: 100,
+          alert_threshold_pct: 80,
+          created_at: '2026-05-01T00:00:00.000Z',
+        },
+      ])
+      .mockResolvedValueOnce([{ total: 79.99 }]);
+
+    const db = makeDb({ select: selectMock });
+    const result = await checkProviderBudget(db, 'anthropic', 'monthly');
+
+    expect(result.overThreshold).toBe(false);
+    expect(result.exceeded).toBe(false);
   });
 });
 
@@ -149,7 +222,12 @@ describe('checkSessionBudget', () => {
   it('no session budget row → Infinity remaining, pct 0, not exceeded', async () => {
     const db = makeDb({ select: vi.fn().mockResolvedValue([]) });
     const result = await checkSessionBudget(db, 'sess-1' as SessionId);
-    expect(result).toEqual({ remainingUsd: Infinity, pct: 0, exceeded: false });
+    expect(result).toEqual({
+      remainingUsd: Infinity,
+      pct: 0,
+      exceeded: false,
+      overThreshold: false,
+    });
   });
 
   it('cap set, under cap → correct values', async () => {

--- a/packages/core/src/budget/__tests__/router.test.ts
+++ b/packages/core/src/budget/__tests__/router.test.ts
@@ -4,11 +4,15 @@ import type { ResolveProviderInput } from '../router';
 import type { BudgetCheckResult } from '@goodboy/types';
 
 function notExceeded(overrides: Partial<BudgetCheckResult> = {}): BudgetCheckResult {
-  return { remainingUsd: 100, pct: 50, exceeded: false, ...overrides };
+  return { remainingUsd: 100, pct: 50, exceeded: false, overThreshold: false, ...overrides };
 }
 
 function exceeded(): BudgetCheckResult {
-  return { remainingUsd: -1, pct: 101, exceeded: true };
+  return { remainingUsd: -1, pct: 101, exceeded: true, overThreshold: false };
+}
+
+function overThreshold(): BudgetCheckResult {
+  return { remainingUsd: 15, pct: 85, exceeded: false, overThreshold: true };
 }
 
 function makeInput(overrides: Partial<ResolveProviderInput> = {}): ResolveProviderInput {
@@ -151,6 +155,121 @@ describe('resolveProvider', () => {
     expect(decision.selectedProvider).toBe('anthropic');
     expect(decision.reason).toBe('preferred');
     expect(decision.fallbackUsed).toBe(false);
+  });
+});
+
+describe('resolveProvider, budget threshold tier', () => {
+  it('preferred past its threshold and a candidate is clear → moves with reason fallback-threshold', async () => {
+    const checkMock = vi.fn(async (provider: string) =>
+      provider === 'anthropic' ? overThreshold() : notExceeded(),
+    );
+    const input = makeInput({
+      budgetChecker: { checkProviderBudget: checkMock },
+    });
+    const decision = await resolveProvider(input);
+
+    expect(decision.selectedProvider).toBe('cursor');
+    expect(decision.reason).toBe('fallback-threshold');
+    expect(decision.fallbackUsed).toBe(true);
+    expect(decision.fallbackFrom).toBe('anthropic');
+  });
+
+  it('preferred past its threshold and every candidate is too → stays put, no fallback', async () => {
+    const checkMock = vi.fn().mockResolvedValue(overThreshold());
+    const input = makeInput({
+      connectedProviders: ['anthropic', 'cursor', 'gemini'],
+      budgetChecker: { checkProviderBudget: checkMock },
+    });
+    const decision = await resolveProvider(input);
+
+    expect(decision.selectedProvider).toBe('anthropic');
+    expect(decision.reason).toBe('preferred');
+    expect(decision.fallbackUsed).toBe(false);
+  });
+
+  it('preferred past its threshold with no other provider connected → stays put', async () => {
+    const checkMock = vi.fn().mockResolvedValue(overThreshold());
+    const input = makeInput({
+      connectedProviders: ['anthropic'],
+      budgetChecker: { checkProviderBudget: checkMock },
+    });
+    const decision = await resolveProvider(input);
+
+    expect(decision.selectedProvider).toBe('anthropic');
+    expect(decision.reason).toBe('preferred');
+    expect(decision.fallbackUsed).toBe(false);
+  });
+
+  it('a clear provider beats one that is past its threshold', async () => {
+    const checkMock = vi.fn(async (provider: string) => {
+      if (provider === 'anthropic') {
+        return overThreshold();
+      }
+      return provider === 'openai' ? overThreshold() : notExceeded();
+    });
+    const input = makeInput({
+      connectedProviders: ['anthropic', 'codex', 'gemini'],
+      budgetChecker: { checkProviderBudget: checkMock },
+    });
+    const decision = await resolveProvider(input);
+
+    expect(decision.selectedProvider).toBe('gemini');
+    expect(decision.reason).toBe('fallback-threshold');
+  });
+
+  it('preferred over cap → a past-threshold provider is still accepted, reason fallback-budget', async () => {
+    const checkMock = vi.fn(async (provider: string) =>
+      provider === 'anthropic' ? exceeded() : overThreshold(),
+    );
+    const input = makeInput({
+      budgetChecker: { checkProviderBudget: checkMock },
+    });
+    const decision = await resolveProvider(input);
+
+    expect(decision.selectedProvider).toBe('cursor');
+    expect(decision.reason).toBe('fallback-budget');
+    expect(decision.fallbackUsed).toBe(true);
+  });
+
+  it('over cap still blocks: a past-threshold preferred never yields all-exceeded', async () => {
+    const checkMock = vi.fn().mockResolvedValue(overThreshold());
+    const input = makeInput({
+      connectedProviders: ['anthropic'],
+      budgetChecker: { checkProviderBudget: checkMock },
+    });
+    const decision = await resolveProvider(input);
+
+    expect(decision.reason).not.toBe('all-exceeded');
+  });
+
+  it('preferred disconnected and past its threshold → reason stays fallback-disconnected', async () => {
+    const checkMock = vi.fn(async (provider: string) =>
+      provider === 'anthropic' ? overThreshold() : notExceeded(),
+    );
+    const input = makeInput({
+      connectedProviders: ['cursor'],
+      budgetChecker: { checkProviderBudget: checkMock },
+    });
+    const decision = await resolveProvider(input);
+
+    expect(decision.selectedProvider).toBe('cursor');
+    expect(decision.reason).toBe('fallback-disconnected');
+  });
+
+  it('a turn override past its threshold still moves, keeping the threshold reason', async () => {
+    const checkMock = vi.fn(async (provider: string) =>
+      provider === 'openai' ? overThreshold() : notExceeded(),
+    );
+    const input = makeInput({
+      connectedProviders: ['anthropic', 'codex'],
+      turnOverride: { providerId: 'codex', model: 'gpt-5' },
+      budgetChecker: { checkProviderBudget: checkMock },
+    });
+    const decision = await resolveProvider(input);
+
+    expect(decision.selectedProvider).toBe('anthropic');
+    expect(decision.reason).toBe('fallback-threshold');
+    expect(decision.fallbackFrom).toBe('codex');
   });
 });
 

--- a/packages/core/src/budget/checker.ts
+++ b/packages/core/src/budget/checker.ts
@@ -37,7 +37,12 @@ export const getPeriodWindow = (period: BudgetPeriod): { start: string; end: str
   return { start, end };
 };
 
-const UNSET_RESULT: BudgetCheckResult = { remainingUsd: Infinity, pct: 0, exceeded: false };
+const UNSET_RESULT: BudgetCheckResult = {
+  remainingUsd: Infinity,
+  pct: 0,
+  exceeded: false,
+  overThreshold: false,
+};
 
 export const checkProviderBudget = async (
   db: Database,
@@ -83,11 +88,13 @@ export const checkProviderBudget = async (
   const spent = costRows[0]?.total ?? 0;
   const remaining = rule.capUsd - spent;
   const pct = rule.capUsd > 0 ? (spent / rule.capUsd) * 100 : 0;
+  const exceeded = spent > rule.capUsd;
 
   return {
     remainingUsd: remaining,
     pct,
-    exceeded: spent > rule.capUsd,
+    exceeded,
+    overThreshold: !exceeded && pct >= rule.alertThresholdPct,
   };
 };
 
@@ -128,5 +135,6 @@ export const checkSessionBudget = async (
     remainingUsd: remaining,
     pct,
     exceeded: spent > budget.softCapUsd,
+    overThreshold: false,
   };
 };

--- a/packages/core/src/budget/router.ts
+++ b/packages/core/src/budget/router.ts
@@ -4,6 +4,7 @@ import type {
   ProviderId,
   ProviderName,
   RoutingDecision,
+  RoutingReason,
   SessionProviderPreference,
   TurnProviderOverride,
 } from '@goodboy/types';
@@ -58,14 +59,33 @@ export const resolveProvider = async (input: ResolveProviderInput): Promise<Rout
   const preferredAllowed = useOverride || isEnabled(preferredProvider);
   const preferredResult = await budgetChecker.checkProviderBudget(preferredName, 'monthly');
 
-  if (preferredConnected && preferredAllowed && !preferredResult.exceeded) {
-    return {
-      selectedProvider: preferredProvider,
-      selectedModel: preferredModel,
-      reason: useOverride ? 'override' : 'preferred',
-      fallbackUsed: false,
-    };
+  const keepPreferred: RoutingDecision = {
+    selectedProvider: preferredProvider,
+    selectedModel: preferredModel,
+    reason: useOverride ? 'override' : 'preferred',
+    fallbackUsed: false,
+  };
+
+  const preferredUsable = preferredConnected && preferredAllowed && !preferredResult.exceeded;
+
+  if (preferredUsable && !preferredResult.overThreshold) {
+    return keepPreferred;
   }
+
+  const movedForThreshold = preferredUsable && preferredResult.overThreshold;
+  const budgetReason: RoutingReason = movedForThreshold ? 'fallback-threshold' : 'fallback-budget';
+  const fallbackReason: RoutingReason =
+    preferredConnected && preferredAllowed ? budgetReason : 'fallback-disconnected';
+
+  const moveTo = (candidate: ProviderId): RoutingDecision => ({
+    selectedProvider: candidate,
+    selectedModel: getDefaultModel(candidate),
+    reason: fallbackReason,
+    fallbackUsed: true,
+    fallbackFrom: preferredProvider,
+  });
+
+  let overThresholdCandidate: ProviderId | null = null;
 
   for (const candidate of connectedProviders) {
     if (candidate === preferredProvider) {
@@ -78,25 +98,27 @@ export const resolveProvider = async (input: ResolveProviderInput): Promise<Rout
     const candidateName = PROVIDER_ID_TO_NAME[candidate];
     const candidateResult = await budgetChecker.checkProviderBudget(candidateName, 'monthly');
 
-    if (!candidateResult.exceeded) {
-      return {
-        selectedProvider: candidate,
-        selectedModel: getDefaultModel(candidate),
-        reason:
-          preferredConnected && preferredAllowed ? 'fallback-budget' : 'fallback-disconnected',
-        fallbackUsed: true,
-        fallbackFrom: preferredProvider,
-      };
+    if (candidateResult.exceeded) {
+      continue;
+    }
+    if (!candidateResult.overThreshold) {
+      return moveTo(candidate);
+    }
+    if (overThresholdCandidate === null) {
+      overThresholdCandidate = candidate;
     }
   }
 
+  if (movedForThreshold) {
+    return keepPreferred;
+  }
+
+  if (overThresholdCandidate !== null) {
+    return moveTo(overThresholdCandidate);
+  }
+
   if (!preferredConnected) {
-    return {
-      selectedProvider: preferredProvider,
-      selectedModel: preferredModel,
-      reason: useOverride ? 'override' : 'preferred',
-      fallbackUsed: false,
-    };
+    return keepPreferred;
   }
 
   return {

--- a/packages/types/src/budget.ts
+++ b/packages/types/src/budget.ts
@@ -23,11 +23,13 @@ export type BudgetCheckResult = Readonly<{
   remainingUsd: number;
   pct: number;
   exceeded: boolean;
+  overThreshold: boolean;
 }>;
 
 export type RoutingReason =
   | 'preferred'
   | 'fallback-budget'
+  | 'fallback-threshold'
   | 'fallback-disconnected'
   | 'all-exceeded'
   | 'override';
@@ -41,10 +43,7 @@ export type RoutingDecision = Readonly<{
 }>;
 
 export type BudgetAlertKind =
-  | 'provider-threshold'
-  | 'provider-exceeded'
-  | 'session-threshold'
-  | 'session-exceeded';
+  'provider-threshold' | 'provider-exceeded' | 'session-threshold' | 'session-exceeded';
 
 export type BudgetAlert = Readonly<{
   id: string;


### PR DESCRIPTION
## What

A provider budget cap only diverted work once spending went past 100% of the cap, and when routing did divert, the app said nothing at all. `VISION.md` promised a fallback before the cap is spent. Now it happens.

- **Rust** (`budget.rs`): `check_provider_budget` also reads `alert_threshold_pct` and returns a new `overThreshold` boolean, meaning past the configured threshold but still under the cap. The query-and-compute step moved into a plain `provider_budget_status(&Connection, ...)` so it can be unit tested.
- **Routing** (`packages/core/src/budget/router.ts`): three tiers instead of a binary partition. Under threshold is preferred, past threshold is still usable as a second choice, over cap is excluded exactly as before. A move triggered by the threshold carries the new `fallback-threshold` reason.
- **Transcript** (`sendTurn.ts`): a turn moved off the preferred provider for a budget reason now appends a turn event naming where it went and why. This covers the new threshold case and the pre-existing `fallback-budget` case, which was also silent until now.
- **Control** (`CapEditor.tsx`): the threshold is editable next to the cap, wired through the same save path that already preserved `alertThresholdPct`.

## `exceeded` still means over cap

`exceeded` was left at `spent > cap_usd`. It is not redefined to mean over threshold, on purpose: `resolveProvider` excludes every candidate whose `exceeded` is true and then returns `all-exceeded`, which `sendTurn` turns into a hard block where the turn never runs. Redefining it would hard-block every turn at 80% of budget with a fifth of the cap unspent. The new state is a separate flag.

The over-cap tier is also still reachable as a destination: if the preferred provider is over its cap and the only alternative is past its threshold, the turn moves there rather than blocking.

## Session budgets

`check_session_budget` sets `overThreshold` to `false`. `session_budgets` has only `session_id` and `soft_cap_usd`, with no threshold column, and this PR adds no migration. m109 stays free.

## Test plan

- `cargo test --locked`: 368 passed, 0 failed, 2 ignored. `budget.rs` had no test module before this PR; it now has six covering no rule, under threshold, past threshold under cap, over cap, a custom threshold, and spend outside the month window.
- `pnpm test --force`: 6309 passed, 4 skipped across all four packages (ui 103, db 196, core 1076, desktop 4934).
- `pnpm typecheck`: 5 tasks successful.
- `pnpm knip --include files,duplicates,unlisted`: clean, configuration hints only.
- Both new behaviors were sabotage-checked: forcing `over_threshold` to `false` in Rust fails 2 of the new tests, and dropping the threshold gate in the router fails 3 of the new routing tests.

## Not verified

None of this was exercised against a live provider or a real budget. Every check ran against in-memory SQLite and mocked budget results, so the threshold-to-routing path has never moved an actual turn between two real CLIs.


## Verification repair (841b386)

Independent verification confirmed the router logic, the Rust arm, the serde name, and that `exceeded` still means over cap. It found the change correct but unguarded at the points where it reaches the user, and one consumer that ignored the new reason.

- `RoutingIndicator` ignored `fallback-threshold` and rendered nothing for it. Every consumer of `RoutingDecision.reason` is an if-chain, not an exhaustive switch, so the omission compiled clean. It now has wording of its own, separate from the over-cap case. The component sits behind `SESSION_FEATURES.budget`, which is still `false`, so this was latent rather than user-visible.
- Four sabotage-verified tests added at the call sites the original PR left uncovered. Before them, all of the following passed a green 4934-test suite: inverting the reason gate in `sendTurn`, deleting the `appendTurnEvent` call outright, disconnecting `threshold.onSave` in `CapEditor`, and keeping the old threshold on `saveProviderThreshold`'s delete-then-save. Each now fails.

Gates after the repair: `pnpm typecheck` 5 tasks successful, desktop 4944 passed across 590 files, db 196, core 1076, ui 103, `cargo test --locked` 368 passed with 2 ignored, `pnpm knip --include files,duplicates,unlisted` clean. `git merge-tree` against `origin/main` and against the three sibling branches in this release is conflict free, and none of them touch budget routing, `RoutingReason`, or `sendTurn`.

Still not covered: the `#[tauri::command]` wrapper around `provider_budget_status` takes no test, so swapping its two string arguments stays green. That matches every other command in the crate and was not introduced here.
