### PR TITLE
fix(core): stop reporting a cost we did not measure

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -146,6 +146,7 @@ export { computeProviderCostUsd } from './providers/provider-cost';
 export { contextTokensForUsage, inputTokensForUsage } from './providers/context-tokens';
 
 export { assessTurnWeight, type TurnWeight } from './providers/turn-weight';
+export { costCoverage, type CostCoverage } from './providers/cost-coverage';
 
 export { computeCursorCostUsd } from './providers/cursor/cost';
 export { CURSOR_AUTO_MODEL, CURSOR_DEFAULT_MODEL, CURSOR_MODELS } from './providers/cursor/models';

--- a/packages/core/src/providers/cost-coverage.test.ts
+++ b/packages/core/src/providers/cost-coverage.test.ts
@@ -1,10 +1,29 @@
 import { describe, expect, it } from 'vitest';
+import type { ProviderUsage } from '@goodboy/types';
 import { costCoverage } from './cost-coverage';
+import { computeCostUsd } from './claude/cost';
+
+const usage: ProviderUsage = {
+  inputTokens: 1_000_000,
+  outputTokens: 1_000_000,
+  cachedInputTokens: 0,
+  estimatedCostUsd: 0,
+};
 
 describe('costCoverage', () => {
-  it('reports anthropic as measured regardless of model', () => {
+  it('reports anthropic as measured for a priced model', () => {
     expect(costCoverage({ provider: 'anthropic', model: 'claude-sonnet-4-6' })).toBe('measured');
-    expect(costCoverage({ provider: 'anthropic', model: 'some-future-model' })).toBe('measured');
+    expect(costCoverage({ provider: 'anthropic', model: 'claude-fable-5' })).toBe('measured');
+  });
+
+  it('reports anthropic as approximate for a model priced only by the sonnet fallback', () => {
+    expect(costCoverage({ provider: 'anthropic', model: 'some-future-model' })).toBe('approximate');
+    expect(computeCostUsd({ usage, model: 'some-future-model' })).toBeCloseTo(
+      computeCostUsd({ usage, model: 'claude-sonnet-4-6' }),
+    );
+    expect(computeCostUsd({ usage, model: 'some-future-model' })).not.toBeCloseTo(
+      computeCostUsd({ usage, model: 'claude-fable-5' }),
+    );
   });
 
   it('reports codex as measured for a priced model and unpriced otherwise', () => {

--- a/packages/core/src/providers/cost-coverage.test.ts
+++ b/packages/core/src/providers/cost-coverage.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { costCoverage } from './cost-coverage';
+
+describe('costCoverage', () => {
+  it('reports anthropic as measured regardless of model', () => {
+    expect(costCoverage({ provider: 'anthropic', model: 'claude-sonnet-4-6' })).toBe('measured');
+    expect(costCoverage({ provider: 'anthropic', model: 'some-future-model' })).toBe('measured');
+  });
+
+  it('reports codex as measured for a priced model and unpriced otherwise', () => {
+    expect(costCoverage({ provider: 'codex', model: 'gpt-5.6-sol' })).toBe('measured');
+    expect(costCoverage({ provider: 'codex', model: 'unknown-codex-model' })).toBe('unpriced');
+  });
+
+  it('reports gemini as measured for a priced model and unpriced otherwise', () => {
+    expect(costCoverage({ provider: 'gemini', model: 'gemini-3.1-pro' })).toBe('measured');
+    expect(costCoverage({ provider: 'gemini', model: 'unknown-gemini-model' })).toBe('unpriced');
+  });
+
+  it('reports cursor as approximate regardless of model', () => {
+    expect(costCoverage({ provider: 'cursor', model: 'composer-2.5' })).toBe('approximate');
+    expect(costCoverage({ provider: 'cursor', model: 'totally-unknown' })).toBe('approximate');
+  });
+
+  it('reports opencode, openrouter and moonshot as unpriced regardless of model', () => {
+    expect(costCoverage({ provider: 'opencode', model: 'big-pickle' })).toBe('unpriced');
+    expect(costCoverage({ provider: 'openrouter', model: 'anthropic/claude-sonnet-4.5' })).toBe(
+      'unpriced',
+    );
+    expect(costCoverage({ provider: 'moonshot', model: 'kimi-k3' })).toBe('unpriced');
+  });
+
+  it('reports openai as unpriced, matching the exhaustive ProviderName member with no price table', () => {
+    expect(costCoverage({ provider: 'openai', model: 'gpt-anything' })).toBe('unpriced');
+  });
+});

--- a/packages/core/src/providers/cost-coverage.ts
+++ b/packages/core/src/providers/cost-coverage.ts
@@ -1,0 +1,32 @@
+import type { ProviderName } from '@goodboy/types';
+import { CODEX_PRICES } from './codex/cost';
+import { GEMINI_PRICES } from './gemini/cost';
+
+export type CostCoverage = 'measured' | 'approximate' | 'unpriced';
+
+type Params = {
+  readonly provider: ProviderName;
+  readonly model: string;
+};
+
+export const costCoverage = ({ provider, model }: Params): CostCoverage => {
+  switch (provider) {
+    case 'anthropic':
+      return 'measured';
+    case 'codex':
+      return CODEX_PRICES[model] != null ? 'measured' : 'unpriced';
+    case 'gemini':
+      return GEMINI_PRICES[model] != null ? 'measured' : 'unpriced';
+    case 'cursor':
+      return 'approximate';
+    case 'opencode':
+    case 'openrouter':
+    case 'moonshot':
+    case 'openai':
+      return 'unpriced';
+    default: {
+      const exhaustive: never = provider;
+      return exhaustive;
+    }
+  }
+};

--- a/packages/core/src/providers/cost-coverage.ts
+++ b/packages/core/src/providers/cost-coverage.ts
@@ -1,4 +1,5 @@
 import type { ProviderName } from '@goodboy/types';
+import { CLAUDE_PRICES } from './claude/cost';
 import { CODEX_PRICES } from './codex/cost';
 import { GEMINI_PRICES } from './gemini/cost';
 
@@ -12,7 +13,7 @@ type Params = {
 export const costCoverage = ({ provider, model }: Params): CostCoverage => {
   switch (provider) {
     case 'anthropic':
-      return 'measured';
+      return CLAUDE_PRICES[model] != null ? 'measured' : 'approximate';
     case 'codex':
       return CODEX_PRICES[model] != null ? 'measured' : 'unpriced';
     case 'gemini':

--- a/packages/core/src/providers/cursor/cost.test.ts
+++ b/packages/core/src/providers/cursor/cost.test.ts
@@ -34,9 +34,9 @@ describe('computeCursorCostUsd', () => {
     expect(computeCursorCostUsd({ usage, model: 'gpt-5.5-high' })).toBeCloseTo(5 + 30);
   });
 
-  it('unknown model falls back to composer standard pricing', () => {
+  it('unknown model falls back to the most expensive known tier', () => {
     expect(computeCursorCostUsd({ usage, model: 'mystery-model-9' })).toBeCloseTo(
-      computeCursorCostUsd({ usage, model: 'composer-2.5' }),
+      computeCursorCostUsd({ usage, model: 'gpt-5.6-sol-high' }),
     );
   });
 
@@ -69,9 +69,9 @@ describe('computeCursorCostUsd', () => {
     ).toBeCloseTo(1.125);
   });
 
-  it('cursorPriceFor returns composer standard fallback for unknown model', () => {
+  it('cursorPriceFor returns the most expensive tier as fallback for unknown model', () => {
     const p = cursorPriceFor('totally-unknown');
-    const fallback = cursorPriceFor('composer-2.5');
+    const fallback = cursorPriceFor('gpt-5.6-sol-high');
     expect(p).toEqual(fallback);
   });
 });

--- a/packages/core/src/providers/cursor/cost.test.ts
+++ b/packages/core/src/providers/cursor/cost.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { ProviderUsage } from '@goodboy/types';
-import { computeCursorCostUsd, cursorPriceFor } from './cost';
+import { computeCursorCostUsd, cursorPriceFor, CURSOR_PRICES } from './cost';
 import { computeCostUsd } from '../claude/cost';
 
 const usage: ProviderUsage = {
@@ -34,10 +34,12 @@ describe('computeCursorCostUsd', () => {
     expect(computeCursorCostUsd({ usage, model: 'gpt-5.5-high' })).toBeCloseTo(5 + 30);
   });
 
-  it('unknown model falls back to the most expensive known tier', () => {
-    expect(computeCursorCostUsd({ usage, model: 'mystery-model-9' })).toBeCloseTo(
-      computeCursorCostUsd({ usage, model: 'gpt-5.6-sol-high' }),
-    );
+  it('unknown model costs at least as much as every known model', () => {
+    const unknown = computeCursorCostUsd({ usage, model: 'mystery-model-9' });
+    for (const model of Object.keys(CURSOR_PRICES)) {
+      expect(unknown).toBeGreaterThanOrEqual(computeCursorCostUsd({ usage, model }));
+    }
+    expect(unknown).toBeGreaterThan(computeCursorCostUsd({ usage, model: 'composer-2.5' }));
   });
 
   it('cached tokens are billed at discounted rate', () => {
@@ -69,9 +71,11 @@ describe('computeCursorCostUsd', () => {
     ).toBeCloseTo(1.125);
   });
 
-  it('cursorPriceFor returns the most expensive tier as fallback for unknown model', () => {
-    const p = cursorPriceFor('totally-unknown');
-    const fallback = cursorPriceFor('gpt-5.6-sol-high');
-    expect(p).toEqual(fallback);
+  it('cursorPriceFor falls back to the most expensive rate on every axis', () => {
+    const fallback = cursorPriceFor('totally-unknown');
+    const known = Object.values(CURSOR_PRICES);
+    expect(fallback.inputPerMtok).toBe(Math.max(...known.map((p) => p.inputPerMtok)));
+    expect(fallback.outputPerMtok).toBe(Math.max(...known.map((p) => p.outputPerMtok)));
+    expect(fallback.cachedInputPerMtok).toBe(Math.max(...known.map((p) => p.cachedInputPerMtok)));
   });
 });

--- a/packages/core/src/providers/cursor/cost.ts
+++ b/packages/core/src/providers/cursor/cost.ts
@@ -54,7 +54,7 @@ export const CURSOR_PRICES: Record<string, ModelPrice> = {
   'gpt-5.3-codex': GPT54_PRICE,
 };
 
-const FALLBACK: ModelPrice = COMPOSER_PRICE;
+const FALLBACK: ModelPrice = GPT56_PRICE;
 
 export const cursorPriceFor = (model: string): ModelPrice => {
   return CURSOR_PRICES[model] ?? FALLBACK;


### PR DESCRIPTION
## What

Goodboy reports a cost figure it never measured. This adds `costCoverage`, a pure classifier that says whether a stored cost is `measured`, `approximate`, or `unpriced`, and flips the Cursor unknown-model fallback from the cheapest tier to the most expensive one.

- New `packages/core/src/providers/cost-coverage.ts`, exported from `packages/core/src/index.ts`. Same shape as the existing `turn-weight.ts` plus `turn-weight.test.ts` pair.
- `packages/core/src/providers/cursor/cost.ts`: `FALLBACK` moves from `COMPOSER_PRICE` to `GPT56_PRICE`. `CURSOR_PRICES` itself is untouched, so `agent-model-ids.test.ts` still sees exactly its twelve keys, and `model-price.ts` is unaffected because it spreads the table and not the fallback.

**No new pricing numbers.** Not for Moonshot, OpenRouter, or OpenCode, and not for anything else. The classifier reads the price tables that already exist and reports what it finds.

## Why the classification is what it is

| provider | cost path | verdict |
| --- | --- | --- |
| `anthropic` | `CLAUDE_PRICES` with a sonnet fallback | table hit `measured`, fallback `approximate` |
| `codex` | `CODEX_PRICES`, no fallback, returns 0 on a miss | table hit `measured`, miss `unpriced` |
| `gemini` | `GEMINI_PRICES`, no fallback, returns 0 on a miss | table hit `measured`, miss `unpriced` |
| `cursor` | heuristic token proxy for a request-billed product, plus a fallback | always `approximate` |
| `opencode`, `openrouter`, `moonshot` | pure passthrough of whatever the CLI reported, `?? 0` | always `unpriced` |
| `openai` | no cost path at all, legacy `ProviderName` and schema member | `unpriced` |

The `anthropic` arm is the subtle one. `priceFor` falls back to `SONNET_PRICE` for any model outside the table, so an unrecognised claude id is billed at a guessed rate. Calling that `measured` would be the same overclaim this PR exists to remove, so it is `approximate`. It is not `unpriced`, because a number is still produced.

The `opencode` family is deliberately `unpriced` even when the CLI did report a figure. The classifier keys on provider identity, not on the stored number, because a stored `0` from a CLI that reported nothing is indistinguishable after the fact from a genuine free run. That errs toward underclaiming, which is the safe direction here.

## Parameter type

`costCoverage` takes `ProviderName`, not `ProviderId`. `TelemetryRecord.provider` is `ProviderName` (eight members, including the legacy `openai` that is still valid in the `provider_runs` CHECK constraint), so a stored telemetry row can be fed to the classifier without a cast. The switch is exhaustive over all eight with a `const exhaustive: never` default.

## The Cursor fallback direction

An unknown Cursor model used to be priced at composer rates, 0.5 in and 2.5 out. An unknown Cursor Opus run was therefore understated by roughly ten times, and a budget guard reading that number would fail toward letting the user overspend. The fallback is now the most expensive tier in the file, so an unknown model fails toward protecting the user instead.

## Tests changed

Two existing tests in `packages/core/src/providers/cursor/cost.test.ts` pinned the fallback as composer pricing. That is behaviour this PR deliberately changes, so they are rewritten rather than kept.

Both were first rewritten to compare the unknown model against `gpt-5.6-sol-high`, which is the model that maps to the new fallback. That was self-referential: it still passed when `cursorPriceFor` ignored the table entirely and returned the fallback for everything. They now assert the invariant the title claims:

- `unknown model costs at least as much as every known model` iterates `CURSOR_PRICES` and asserts the unknown-model cost is greater than or equal to each, and strictly greater than composer.
- `cursorPriceFor falls back to the most expensive rate on every axis` asserts the fallback equals the maximum input, output, and cached-input rate across the whole table.

One test written for `cost-coverage.test.ts` in the first commit asserted `anthropic` plus an unknown model is `measured`, pinning the defect described above. It is replaced by a test that pins the fallback verdict and proves the fallback bills at sonnet rather than fable rates.

## Test plan

Run from the worktree with `--force`, since turbo caches are shared across worktrees.

- `pnpm typecheck --force`: 5 tasks, 5 successful.
- `pnpm test --force`: 741 files, 6299 passed, 0 failed, 4 skipped, across all four packages (ui 20/103, core 103/1072, db 29/196, desktop 589/4928).
- `pnpm knip --include files,duplicates,unlisted`: exit 0, only the six pre-existing configuration hints.

Sabotage checks, each confirmed red:

- `opencode` arm returning `measured`.
- Removing the `never` default and dropping a member, which fails typecheck and the moonshot test.
- `anthropic` arm returning `measured` unconditionally.
- `FALLBACK` reverted to `COMPOSER_PRICE`, and separately set to the mid-priced `OPUS_PRICE`.
- `cursorPriceFor` ignoring the table and always returning the fallback.
- `computeCursorCostUsd` returning a constant.

## Known: this ships an unused export

Nothing imports `costCoverage` today. It is consumed in a follow-up that surfaces coverage in Budget Studio. The CI knip gate runs `--include files,duplicates,unlisted`, which does not check unused exports, so this passes exit 0 rather than being suppressed by an ignore rule.
