### PR TITLE
feat(desktop): say which spend was measured and which was not

### DIFF
--- a/apps/desktop/src/features/budget/components/BudgetStudio/CoverageChip.tsx
+++ b/apps/desktop/src/features/budget/components/BudgetStudio/CoverageChip.tsx
@@ -22,7 +22,7 @@ export const CoverageChip = ({ coverage }: Props) => {
         tone="neutral"
         shape="badge"
         label="approx"
-        title="Priced from a fallback rate, not this model's own"
+        title="Priced from an estimated rate, not a billed amount"
       />
     );
   }

--- a/apps/desktop/src/features/budget/components/BudgetStudio/CoverageChip.tsx
+++ b/apps/desktop/src/features/budget/components/BudgetStudio/CoverageChip.tsx
@@ -1,0 +1,30 @@
+import { Chip } from '@goodboy/ui';
+import type { CostCoverage } from '@goodboy/core';
+
+type Props = {
+  readonly coverage: CostCoverage;
+};
+
+export const CoverageChip = ({ coverage }: Props) => {
+  if (coverage === 'unpriced') {
+    return (
+      <Chip
+        tone="warning"
+        shape="badge"
+        label="unpriced"
+        title="No price for this model, so this figure is not a measurement"
+      />
+    );
+  }
+  if (coverage === 'approximate') {
+    return (
+      <Chip
+        tone="neutral"
+        shape="badge"
+        label="approx"
+        title="Priced from a fallback rate, not this model's own"
+      />
+    );
+  }
+  return null;
+};

--- a/apps/desktop/src/features/budget/components/BudgetStudio/CoverageNotice.tsx
+++ b/apps/desktop/src/features/budget/components/BudgetStudio/CoverageNotice.tsx
@@ -1,0 +1,21 @@
+import { TriangleAlert } from 'lucide-react';
+import type { CoverageTurnCounts } from './lib';
+
+type Props = {
+  readonly counts: CoverageTurnCounts;
+};
+
+export const CoverageNotice = ({ counts }: Props) => {
+  if (counts.unpriced === 0) {
+    return null;
+  }
+
+  return (
+    <p className="flex items-center gap-2.5 rounded-lg border border-warning/30 bg-warning/10 px-3 py-2 text-xs text-foreground">
+      <TriangleAlert size={14} aria-hidden className="shrink-0 text-warning" />
+      <span>
+        {`No price for ${counts.unpriced} of ${counts.total} turns, so a cap cannot include them`}
+      </span>
+    </p>
+  );
+};

--- a/apps/desktop/src/features/budget/components/BudgetStudio/ModelTable.tsx
+++ b/apps/desktop/src/features/budget/components/BudgetStudio/ModelTable.tsx
@@ -1,5 +1,6 @@
 import { EmptyState, formatTokens, formatUsd, formatUsdPrecise } from '@goodboy/ui';
 import { RoutingBadge } from '../../../../shared/components/RoutingBadge';
+import { CoverageChip } from './CoverageChip';
 import type { ModelBreakdownEntry } from './lib';
 import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../shared/components/conceptIcons';
 
@@ -44,7 +45,10 @@ export const ModelTable = ({
             className="transition-colors hover:bg-muted/30"
           >
             <td className="px-3 py-2">
-              <RoutingBadge provider={entry.provider} model={entry.model} />
+              <span className="flex min-w-0 items-center gap-1.5">
+                <RoutingBadge provider={entry.provider} model={entry.model} />
+                <CoverageChip coverage={entry.coverage} />
+              </span>
             </td>
             <td className="px-3 py-2 text-right font-mono tabular-nums text-muted-foreground">
               {formatTokens(entry.tokensIn)}

--- a/apps/desktop/src/features/budget/components/BudgetStudio/ProviderPanel.tsx
+++ b/apps/desktop/src/features/budget/components/BudgetStudio/ProviderPanel.tsx
@@ -8,11 +8,12 @@ import type { QueryResult } from '../../../../shared/types/queryResult';
 import { ProviderIcon } from '../../../providers/components/ProviderIcon';
 import { CapEditor } from './CapEditor';
 import { CostRing } from './CostRing';
+import { CoverageNotice } from './CoverageNotice';
 import { ModelTable } from './ModelTable';
 import { StudioPanel } from '../../../../shared/components/StudioPanel';
 import { TurnsTable } from './TurnsTable';
 import { StudioWidget } from '../../../../shared/components/StudioWidget';
-import { buildModelBreakdown, providerLabel, type WorkspaceTurn } from './lib';
+import { buildModelBreakdown, coverageTurnCounts, providerLabel, type WorkspaceTurn } from './lib';
 
 type Props = {
   readonly provider: ProviderName;
@@ -55,6 +56,7 @@ export const ProviderPanel = ({
     [turns, provider],
   );
   const models = useMemo(() => buildModelBreakdown(filtered.map((t) => t.record)), [filtered]);
+  const coverage = useMemo(() => coverageTurnCounts(models), [models]);
 
   return (
     <StudioPanel
@@ -89,6 +91,8 @@ export const ProviderPanel = ({
           <StatCard label="models" value={String(models.length)} />
         </section>
       )}
+
+      <CoverageNotice counts={coverage} />
 
       <CapEditor
         label="monthly cap"

--- a/apps/desktop/src/features/budget/components/BudgetStudio/index.test.tsx
+++ b/apps/desktop/src/features/budget/components/BudgetStudio/index.test.tsx
@@ -46,6 +46,33 @@ vi.mock('../../../../store', () => ({
 
 import { BudgetStudio } from './index';
 
+type TelemetryRecordParams = {
+  readonly id: string;
+  readonly model: string;
+  readonly costUsd: number;
+  readonly recordedAt: string;
+  readonly provider?: string;
+};
+
+const telemetryRecord = ({
+  id,
+  model,
+  costUsd,
+  recordedAt,
+  provider = 'codex',
+}: TelemetryRecordParams) => ({
+  id,
+  runId: `run-${id}`,
+  sessionId: 'session-1',
+  kind: 'turn',
+  provider,
+  model,
+  inputTokens: 40,
+  outputTokens: 60,
+  estimatedCostUsd: costUsd,
+  recordedAt,
+});
+
 beforeEach(() => {
   vi.clearAllMocks();
   state.loadBudgetRules.mockResolvedValue(undefined);
@@ -240,6 +267,72 @@ describe('BudgetStudio', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Open session build the feature' }));
     expect(state.setCurrentSession).toHaveBeenCalledWith('session-1');
     expect(onClose).toHaveBeenCalled();
+  });
+
+  it('leaves every model row unmarked and stays silent when the whole provider is priced', () => {
+    render(
+      <BudgetStudio
+        workspaceName="goodboy"
+        initialScope={{ kind: 'provider', provider: 'anthropic' }}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText(/cannot include them/i)).toBeNull();
+    expect(screen.queryByText('unpriced')).toBeNull();
+    expect(screen.queryByText('approx')).toBeNull();
+  });
+
+  it('marks the unpriced model row and names how many turns a cap would miss', () => {
+    const now = new Date().toISOString();
+    state.sessionTelemetry = {
+      'session-1': [
+        telemetryRecord({ id: 'c1', model: 'gpt-5.6-sol', costUsd: 2, recordedAt: now }),
+        telemetryRecord({ id: 'c2', model: 'gpt-5.6-sol', costUsd: 3, recordedAt: now }),
+        telemetryRecord({ id: 'c3', model: 'mystery-codex', costUsd: 0, recordedAt: now }),
+      ],
+    };
+
+    render(
+      <BudgetStudio
+        workspaceName="goodboy"
+        initialScope={{ kind: 'provider', provider: 'codex' }}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByText('No price for 1 of 3 turns, so a cap cannot include them'),
+    ).toBeDefined();
+    expect(screen.getAllByText('unpriced')).toHaveLength(1);
+    expect(screen.queryByText('approx')).toBeNull();
+  });
+
+  it('marks an approximate model row without calling it unpriced or warning about the cap', () => {
+    const now = new Date().toISOString();
+    state.sessionTelemetry = {
+      'session-1': [
+        telemetryRecord({
+          id: 'x1',
+          provider: 'cursor',
+          model: 'composer-2.5',
+          costUsd: 4,
+          recordedAt: now,
+        }),
+      ],
+    };
+
+    render(
+      <BudgetStudio
+        workspaceName="goodboy"
+        initialScope={{ kind: 'provider', provider: 'cursor' }}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getAllByText('approx')).toHaveLength(1);
+    expect(screen.queryByText('unpriced')).toBeNull();
+    expect(screen.queryByText(/cannot include them/i)).toBeNull();
   });
 
   it('filters telemetry with the header window control', () => {

--- a/apps/desktop/src/features/budget/components/BudgetStudio/index.test.tsx
+++ b/apps/desktop/src/features/budget/components/BudgetStudio/index.test.tsx
@@ -335,6 +335,80 @@ describe('BudgetStudio', () => {
     expect(screen.queryByText(/cannot include them/i)).toBeNull();
   });
 
+  it('stays silent for a provider whose turns all carry a cost the cap already counts', () => {
+    const now = new Date().toISOString();
+    state.sessionTelemetry = {
+      'session-1': [
+        telemetryRecord({
+          id: 'o1',
+          provider: 'openrouter',
+          model: 'anthropic/claude-sonnet-4.5',
+          costUsd: 0.4,
+          recordedAt: now,
+        }),
+        telemetryRecord({
+          id: 'o2',
+          provider: 'openrouter',
+          model: 'anthropic/claude-sonnet-4.5',
+          costUsd: 0.6,
+          recordedAt: now,
+        }),
+      ],
+    };
+
+    render(
+      <BudgetStudio
+        workspaceName="goodboy"
+        initialScope={{ kind: 'provider', provider: 'openrouter' }}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText(/cannot include them/i)).toBeNull();
+    expect(screen.queryByText('unpriced')).toBeNull();
+  });
+
+  it('counts only the zero-cost turns when a provider reports cost inconsistently', () => {
+    const now = new Date().toISOString();
+    state.sessionTelemetry = {
+      'session-1': [
+        telemetryRecord({
+          id: 'm1',
+          provider: 'opencode',
+          model: 'big-pickle',
+          costUsd: 0.5,
+          recordedAt: now,
+        }),
+        telemetryRecord({
+          id: 'm2',
+          provider: 'opencode',
+          model: 'big-pickle',
+          costUsd: 0,
+          recordedAt: now,
+        }),
+        telemetryRecord({
+          id: 'm3',
+          provider: 'opencode',
+          model: 'big-pickle',
+          costUsd: 0,
+          recordedAt: now,
+        }),
+      ],
+    };
+
+    render(
+      <BudgetStudio
+        workspaceName="goodboy"
+        initialScope={{ kind: 'provider', provider: 'opencode' }}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByText('No price for 2 of 3 turns, so a cap cannot include them'),
+    ).toBeDefined();
+  });
+
   it('filters telemetry with the header window control', () => {
     state.sessionTelemetry = {
       'session-1': [

--- a/apps/desktop/src/features/budget/components/BudgetStudio/lib.test.ts
+++ b/apps/desktop/src/features/budget/components/BudgetStudio/lib.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  IsoDateTime,
+  ProviderName,
+  ProviderRunId,
+  SessionId,
+  TelemetryRecord,
+  TelemetryRecordId,
+} from '@goodboy/types';
+import { buildModelBreakdown, coverageTurnCounts } from './lib';
+
+type RecordParams = {
+  readonly id: string;
+  readonly provider: ProviderName;
+  readonly model: string;
+  readonly costUsd?: number;
+};
+
+const record = ({ id, provider, model, costUsd = 1 }: RecordParams): TelemetryRecord => ({
+  id: id as TelemetryRecordId,
+  runId: `run-${id}` as ProviderRunId,
+  sessionId: 'session-1' as SessionId,
+  kind: 'turn',
+  provider,
+  model,
+  inputTokens: 10,
+  outputTokens: 20,
+  estimatedCostUsd: costUsd,
+  recordedAt: '2026-08-01T00:00:00.000Z' as IsoDateTime,
+});
+
+describe('buildModelBreakdown', () => {
+  it('tags each model row with its own coverage verdict', () => {
+    const entries = buildModelBreakdown([
+      record({ id: 'a', provider: 'anthropic', model: 'claude-sonnet-4-6', costUsd: 5 }),
+      record({ id: 'b', provider: 'anthropic', model: 'some-future-model', costUsd: 3 }),
+      record({ id: 'c', provider: 'opencode', model: 'big-pickle', costUsd: 0 }),
+    ]);
+
+    expect(entries.map((e) => [e.model, e.coverage])).toEqual([
+      ['claude-sonnet-4-6', 'measured'],
+      ['some-future-model', 'approximate'],
+      ['big-pickle', 'unpriced'],
+    ]);
+  });
+
+  it('counts the turns folded into each model row', () => {
+    const entries = buildModelBreakdown([
+      record({ id: 'a', provider: 'opencode', model: 'big-pickle', costUsd: 0 }),
+      record({ id: 'b', provider: 'opencode', model: 'big-pickle', costUsd: 0 }),
+      record({ id: 'c', provider: 'anthropic', model: 'claude-sonnet-4-6', costUsd: 4 }),
+    ]);
+
+    const byModel = new Map(entries.map((e) => [e.model, e]));
+    expect(byModel.get('big-pickle')?.turnCount).toBe(2);
+    expect(byModel.get('claude-sonnet-4-6')?.turnCount).toBe(1);
+    expect(byModel.get('big-pickle')?.tokensIn).toBe(20);
+  });
+});
+
+describe('coverageTurnCounts', () => {
+  it('keeps approximate and unpriced in separate buckets', () => {
+    const counts = coverageTurnCounts(
+      buildModelBreakdown([
+        record({ id: 'a', provider: 'anthropic', model: 'claude-sonnet-4-6' }),
+        record({ id: 'b', provider: 'anthropic', model: 'some-future-model' }),
+        record({ id: 'c', provider: 'anthropic', model: 'another-future-model' }),
+        record({ id: 'd', provider: 'opencode', model: 'big-pickle' }),
+      ]),
+    );
+
+    expect(counts).toEqual({ total: 4, approximate: 2, unpriced: 1 });
+  });
+
+  it('reports nothing approximate and nothing unpriced when every model is priced', () => {
+    const counts = coverageTurnCounts(
+      buildModelBreakdown([
+        record({ id: 'a', provider: 'anthropic', model: 'claude-sonnet-4-6' }),
+        record({ id: 'b', provider: 'codex', model: 'gpt-5.6-sol' }),
+      ]),
+    );
+
+    expect(counts).toEqual({ total: 2, approximate: 0, unpriced: 0 });
+  });
+
+  it('does not count an approximate model as unpriced', () => {
+    const counts = coverageTurnCounts(
+      buildModelBreakdown([record({ id: 'a', provider: 'cursor', model: 'composer-2.5' })]),
+    );
+
+    expect(counts.approximate).toBe(1);
+    expect(counts.unpriced).toBe(0);
+  });
+
+  it('returns an empty tally for no records', () => {
+    expect(coverageTurnCounts(buildModelBreakdown([]))).toEqual({
+      total: 0,
+      approximate: 0,
+      unpriced: 0,
+    });
+  });
+});

--- a/apps/desktop/src/features/budget/components/BudgetStudio/lib.test.ts
+++ b/apps/desktop/src/features/budget/components/BudgetStudio/lib.test.ts
@@ -65,11 +65,42 @@ describe('coverageTurnCounts', () => {
         record({ id: 'a', provider: 'anthropic', model: 'claude-sonnet-4-6' }),
         record({ id: 'b', provider: 'anthropic', model: 'some-future-model' }),
         record({ id: 'c', provider: 'anthropic', model: 'another-future-model' }),
-        record({ id: 'd', provider: 'opencode', model: 'big-pickle' }),
+        record({ id: 'd', provider: 'opencode', model: 'big-pickle', costUsd: 0 }),
       ]),
     );
 
     expect(counts).toEqual({ total: 4, approximate: 2, unpriced: 1 });
+  });
+
+  it('does not call a turn unpriced when the provider reported its own cost', () => {
+    const entries = buildModelBreakdown([
+      record({
+        id: 'a',
+        provider: 'openrouter',
+        model: 'anthropic/claude-sonnet-4.5',
+        costUsd: 0.4,
+      }),
+      record({
+        id: 'b',
+        provider: 'openrouter',
+        model: 'anthropic/claude-sonnet-4.5',
+        costUsd: 0.6,
+      }),
+    ]);
+
+    expect(entries[0]?.coverage).toBe('measured');
+    expect(coverageTurnCounts(entries)).toEqual({ total: 2, approximate: 0, unpriced: 0 });
+  });
+
+  it('counts only the turns a cap really misses when a model reports cost inconsistently', () => {
+    const entries = buildModelBreakdown([
+      record({ id: 'a', provider: 'opencode', model: 'big-pickle', costUsd: 0.5 }),
+      record({ id: 'b', provider: 'opencode', model: 'big-pickle', costUsd: 0 }),
+      record({ id: 'c', provider: 'opencode', model: 'big-pickle', costUsd: 0 }),
+    ]);
+
+    expect(entries[0]?.coverage).toBe('unpriced');
+    expect(coverageTurnCounts(entries)).toEqual({ total: 3, approximate: 0, unpriced: 2 });
   });
 
   it('reports nothing approximate and nothing unpriced when every model is priced', () => {

--- a/apps/desktop/src/features/budget/components/BudgetStudio/lib.ts
+++ b/apps/desktop/src/features/budget/components/BudgetStudio/lib.ts
@@ -38,6 +38,7 @@ export type ModelBreakdownEntry = {
   readonly model: string;
   readonly coverage: CostCoverage;
   readonly turnCount: number;
+  readonly uncountedTurns: number;
   readonly tokensIn: number;
   readonly tokensOut: number;
   readonly spentUsd: number;
@@ -94,32 +95,72 @@ export const sortTurns = (
   return copy;
 };
 
+type ModelAccumulator = {
+  readonly provider: string;
+  readonly model: string;
+  readonly base: CostCoverage;
+  readonly turnCount: number;
+  readonly uncountedTurns: number;
+  readonly tokensIn: number;
+  readonly tokensOut: number;
+  readonly spentUsd: number;
+};
+
+type EffectiveCoverageParams = {
+  readonly base: CostCoverage;
+  readonly uncountedTurns: number;
+};
+
+const effectiveCoverage = ({ base, uncountedTurns }: EffectiveCoverageParams): CostCoverage => {
+  if (base !== 'unpriced') {
+    return base;
+  }
+  if (uncountedTurns > 0) {
+    return 'unpriced';
+  }
+  return 'measured';
+};
+
 export const buildModelBreakdown = (
   records: ReadonlyArray<TelemetryRecord>,
 ): ReadonlyArray<ModelBreakdownEntry> => {
-  const map = new Map<string, ModelBreakdownEntry>();
+  const map = new Map<string, ModelAccumulator>();
   for (const r of records) {
     const key = `${r.provider}//${r.model}`;
     const prev = map.get(key) ?? {
       provider: r.provider,
       model: r.model,
-      coverage: costCoverage({ provider: r.provider, model: r.model }),
+      base: costCoverage({ provider: r.provider, model: r.model }),
       turnCount: 0,
+      uncountedTurns: 0,
       tokensIn: 0,
       tokensOut: 0,
       spentUsd: 0,
     };
+    const uncounted = prev.base === 'unpriced' && r.estimatedCostUsd === 0 ? 1 : 0;
     map.set(key, {
       provider: prev.provider,
       model: prev.model,
-      coverage: prev.coverage,
+      base: prev.base,
       turnCount: prev.turnCount + 1,
+      uncountedTurns: prev.uncountedTurns + uncounted,
       tokensIn: prev.tokensIn + r.inputTokens,
       tokensOut: prev.tokensOut + r.outputTokens,
       spentUsd: prev.spentUsd + r.estimatedCostUsd,
     });
   }
-  return [...map.values()].sort((a, b) => b.spentUsd - a.spentUsd);
+  return [...map.values()]
+    .map((acc) => ({
+      provider: acc.provider,
+      model: acc.model,
+      coverage: effectiveCoverage({ base: acc.base, uncountedTurns: acc.uncountedTurns }),
+      turnCount: acc.turnCount,
+      uncountedTurns: acc.uncountedTurns,
+      tokensIn: acc.tokensIn,
+      tokensOut: acc.tokensOut,
+      spentUsd: acc.spentUsd,
+    }))
+    .sort((a, b) => b.spentUsd - a.spentUsd);
 };
 
 export const coverageTurnCounts = (
@@ -129,7 +170,7 @@ export const coverageTurnCounts = (
     (acc, entry) => ({
       total: acc.total + entry.turnCount,
       approximate: acc.approximate + (entry.coverage === 'approximate' ? entry.turnCount : 0),
-      unpriced: acc.unpriced + (entry.coverage === 'unpriced' ? entry.turnCount : 0),
+      unpriced: acc.unpriced + entry.uncountedTurns,
     }),
     { total: 0, approximate: 0, unpriced: 0 },
   );

--- a/apps/desktop/src/features/budget/components/BudgetStudio/lib.ts
+++ b/apps/desktop/src/features/budget/components/BudgetStudio/lib.ts
@@ -1,6 +1,7 @@
 import type { ProviderName, SessionId, TelemetryRecord } from '@goodboy/types';
 import type { ProviderId } from '@goodboy/types';
 import type { SegmentedTabOption, Tone } from '@goodboy/ui';
+import { costCoverage, type CostCoverage } from '@goodboy/core';
 import { PROVIDER_LABEL_LOWER } from '../../../providers/providers';
 
 export type BudgetScope =
@@ -35,9 +36,17 @@ export type SessionSpend = {
 export type ModelBreakdownEntry = {
   readonly provider: string;
   readonly model: string;
+  readonly coverage: CostCoverage;
+  readonly turnCount: number;
   readonly tokensIn: number;
   readonly tokensOut: number;
   readonly spentUsd: number;
+};
+
+export type CoverageTurnCounts = {
+  readonly total: number;
+  readonly approximate: number;
+  readonly unpriced: number;
 };
 
 const PROVIDER_IDS: ReadonlyArray<ProviderId> = [
@@ -94,6 +103,8 @@ export const buildModelBreakdown = (
     const prev = map.get(key) ?? {
       provider: r.provider,
       model: r.model,
+      coverage: costCoverage({ provider: r.provider, model: r.model }),
+      turnCount: 0,
       tokensIn: 0,
       tokensOut: 0,
       spentUsd: 0,
@@ -101,12 +112,27 @@ export const buildModelBreakdown = (
     map.set(key, {
       provider: prev.provider,
       model: prev.model,
+      coverage: prev.coverage,
+      turnCount: prev.turnCount + 1,
       tokensIn: prev.tokensIn + r.inputTokens,
       tokensOut: prev.tokensOut + r.outputTokens,
       spentUsd: prev.spentUsd + r.estimatedCostUsd,
     });
   }
   return [...map.values()].sort((a, b) => b.spentUsd - a.spentUsd);
+};
+
+export const coverageTurnCounts = (
+  entries: ReadonlyArray<ModelBreakdownEntry>,
+): CoverageTurnCounts => {
+  return entries.reduce<CoverageTurnCounts>(
+    (acc, entry) => ({
+      total: acc.total + entry.turnCount,
+      approximate: acc.approximate + (entry.coverage === 'approximate' ? entry.turnCount : 0),
+      unpriced: acc.unpriced + (entry.coverage === 'unpriced' ? entry.turnCount : 0),
+    }),
+    { total: 0, approximate: 0, unpriced: 0 },
+  );
 };
 
 export const chronologicalTurnCosts = (


### PR DESCRIPTION
## What

Budget Studio now says which spend it measured and which it did not. This is the consumer half of #1288, whose `costCoverage({ provider, model })` classifier shipped with zero call sites.

Two surfaces, one marker each:

- **Per-model breakdown** (`ModelTable`, so provider scope, overview scope and session scope all get it): a row whose figure is not a real measurement carries a small chip next to the model name. `measured` rows carry nothing, so no third badge lands on every row.
- **Provider scope** (`ProviderPanel`): one warning strip above the cap control, rendered only when the provider has at least one turn the cap genuinely cannot see.

## Why

`checkProviderBudget` sums `estimated_cost_usd`. For `opencode`, `openrouter` and `moonshot` there is no price table at all, so `computeOpenCodeCostUsd` returns whatever the CLI reported, or 0 when it reported nothing. Every turn in that second group is invisible to a monthly cap: the cap looks set and never fires. A user who set that cap is entitled to know before they rely on it.

## Verdict is per turn, not per price table

`costCoverage` answers a question about price tables: does Goodboy know how to price this provider and model. That is not the same question as does this turn reach the cap.

For `opencode`, `openrouter` and `moonshot` the classifier says `unpriced` for every model, but a turn whose CLI reported its own cost carries a real, non zero `estimated_cost_usd` into the same `SUM` the cap reads. Calling that turn unpriced would tell the user their cap is blind when it is not, and would call the provider's own billing figure "not a measurement".

So the row verdict is derived from both facts. A turn counts as missing from the cap only when the classifier has no price for it **and** it recorded zero. A model row is `unpriced` when at least one of its turns is missing that way, and `measured` when the provider priced all of them itself. The warning counts those turns, not whole rows, so a model that reports cost inconsistently is reported honestly.

## Coverage vocabulary shipped

Three verdicts stay three facts. `approximate` is a real calculation off an estimated price table. `unpriced` means the number is not a measurement at all, which is the one that breaks a cap. They never merge into a single "not exact" bucket.

Exact user-facing strings:

| verdict | surface | string |
| --- | --- | --- |
| `unpriced` | model row chip, warning tone | `unpriced` |
| `unpriced` | that chip's tooltip | `No price for this model, so this figure is not a measurement` |
| `approximate` | model row chip, neutral tone | `approx` |
| `approximate` | that chip's tooltip | `Priced from an estimated rate, not a billed amount` |
| `unpriced` | provider warning strip | `No price for {n} of {total} turns, so a cap cannot include them` |
| `measured` | nothing rendered | |

The strip does not appear when nothing is unpriced, so a fully priced provider stays quiet.

The `approx` tooltip names the estimate, not one mechanism that produces it. Anthropic reaches `approximate` through a sonnet fallback rate, but Cursor reaches it with its own per model entry, because Cursor bills by subscription and every Cursor rate in the table is Goodboy's estimate. A tooltip that said "not this model's own" would be false for every Cursor model that has an entry.

## Units

No ratio is computed anywhere in this change. `CoverageTurnCounts` holds three integer turn counts (`total`, `approximate`, `unpriced`) and the copy interpolates them directly, so nothing here can be confused with `BudgetRule.alertThresholdPct` (0 to 100) or `ProviderSpendEntry.pct` (0 to 1).

## How it is computed

`buildModelBreakdown` already reduced client-side over every telemetry row. It now also records the classifier verdict, `turnCount` and `uncountedTurns` per `provider//model` key inside that same reduce, then resolves the effective verdict once per row while materialising the map. `coverageTurnCounts` folds the handful of resulting rows into the per-provider tally, so the raw telemetry array is still walked exactly once.

`TelemetryRecord.provider` is `ProviderName`, the same eight-member union `costCoverage` takes, so the classifier is called with no cast.

No new SQL, no new query, no store action, no migration. `SESSION_FEATURES.budget` is untouched. `packages/core/src/providers/cost-coverage.ts` is untouched. Impact Studio is untouched.

## Test plan

`apps/desktop/.../BudgetStudio/lib.test.ts` (new) covers the reduce: per-row verdicts, per-row turn counts, a tally that keeps `approximate` and `unpriced` apart, a provider-reported turn that is not called unpriced, and a model reporting cost inconsistently where only the zero-cost turns are counted.

`apps/desktop/.../BudgetStudio/index.test.tsx` covers the rendered result through the real `ModelTable`, `CoverageChip` and `CoverageNotice` (only the store is mocked, so nothing asserted here is rendered by a mock):

- a fully priced provider renders no chip and no warning
- a codex provider with one unpriced model renders exactly one `unpriced` chip and the string `No price for 1 of 3 turns, so a cap cannot include them`
- a cursor provider, which is `approximate` for every model, renders `approx`, renders no `unpriced`, and renders no warning
- an openrouter provider whose turns all carry a reported cost renders no chip and no warning
- an opencode model reporting cost inconsistently renders `No price for 2 of 3 turns, so a cap cannot include them`

### Rewritten test

`keeps approximate and unpriced in separate buckets` in `lib.test.ts` pinned the earlier behaviour: its `opencode` fixture used the default `costUsd: 1`, so it asserted that a turn carrying a provider-reported cost still counted as unpriced. That fixture now uses `costUsd: 0`, which is the case the test name describes. Its `total`, `approximate` and `unpriced` expectations are unchanged.

### Sabotage log

Ten sabotages, each reverted, each confirmed red against the shipped code:

| sabotage | tests failed |
| --- | --- |
| coverage notice renders unconditionally | 3 |
| coverage notice never renders | 2 |
| collapse `approximate` and `unpriced` into one label | 1 |
| count approximate turns into the unpriced bucket | 5 |
| delete the chip from the model row | 2 |
| per-provider unpriced count always 0 | 4 |
| return a constant verdict from `costCoverage` | 7 |
| ignore the provider-reported cost when deciding a turn is uncounted | 4 |
| pass the classifier verdict straight through as the row verdict | 2 |
| count whole rows instead of the turns a cap actually misses | 2 |

Gates from the worktree:

- `pnpm typecheck --force`: exit 0
- `pnpm test --force`: 4 packages green. desktop 592 files / 4973 tests, core 103 files / 1083 tests (4 skipped), db 29 files / 202 tests, ui 20 files / 103 tests
- `pnpm knip --include files,duplicates,unlisted`: exit 0, configuration hints only, `cost-coverage.ts` no longer an unused export
- `apps/desktop/src/__tests__/regressions/no-unstable-zustand-selectors.test.ts`: 2 passed

## Follow-up

`OverviewPanel` gets the row chips for free through the shared `ModelTable`, but no warning strip, because the workspace scope has no cap for a strip to warn about. The workspace total on that screen is still a bare number that silently excludes uncounted turns. Naming that exclusion on the overview is worth a separate change.

The verdicts come from the price tables already in `packages/core`, not from a call to any provider's billing API, so a model that a provider silently reprices still reads as `measured` here. The cost figures themselves are unchanged by this PR: it labels what was already being computed.
