### PR TITLE
fix(desktop): give the budget dead end a way out

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -296,7 +296,9 @@ before sending, a running total after.
 - **Caps are authored where they are shown.** A budget cap is edited on the
   same surface that displays it; you don't hunt for a separate settings screen
   to change a number you're looking at. Budget alerts are toasts, never pinned
-  banners.
+  banners. The one exception is the composer's pre-send routing line carved out
+  under [Status & signals](#status--signals), which is live state attached to an
+  unsent turn rather than an alert.
 
 ## Components & interaction
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -250,7 +250,12 @@ Compaction for the full exemption list.
   inbox; nothing lives only in a toast.
 - **Errors are toasts, never pinned banners.** An error surfaces as a
   transient, dismissible toast owned by the notification system, not an inline
-  banner wired into the view that lingers after the cause is gone.
+  banner wired into the view that lingers after the cause is gone. The one
+  exception, which also carves out the budget-alert rule under
+  [Spend](#spend): the composer's pre-send routing line states where the next
+  turn is about to go and clears itself the moment routing changes, so it is
+  live state attached to an unsent turn rather than an alert or an error, and
+  it belongs inline where the turn is composed.
 - **Chips carry a word.** Status chips (PR state, CI, agent kind) pair an
   icon with a label. Icon-only is allowed only where space is truly gone, and
   then the label survives as a tooltip.

--- a/VISION.md
+++ b/VISION.md
@@ -250,7 +250,9 @@ what you're spending and where, in real time.
 - **Session lifecycle metrics**: when a session starts, resets, hits a
   threshold, switches provider, ends.
 - **Budgets**: per-provider monthly cap, per-session soft cap. Visual alerts
-  before you hit limits.
+  before you hit limits. Caps steer routing rather than lock you out: when
+  every provider is over cap the composer says so and you can still send the
+  turn on the provider you picked.
 
 All metrics are computed and stored locally. Nothing transmitted.
 

--- a/apps/desktop/src/features/chat/components/ChatInput/hooks/useMessageQueue.test.ts
+++ b/apps/desktop/src/features/chat/components/ChatInput/hooks/useMessageQueue.test.ts
@@ -17,7 +17,7 @@ const makeTurn = (id: string, content = 'hi'): QueuedTurn => ({
 });
 
 const noop = () => {};
-const resolved = () => Promise.resolve();
+const resolved = () => Promise.resolve({ blockedOverBudget: false });
 
 beforeEach(() => {
   useAppStore.setState({ agentQueue: {} });
@@ -135,7 +135,7 @@ describe('useMessageQueue', () => {
   });
 
   it('dispatches the head turn when the agent goes from running to idle', () => {
-    const dispatchTurn = vi.fn().mockResolvedValue(undefined);
+    const dispatchTurn = vi.fn().mockResolvedValue({ blockedOverBudget: false });
     const { result, rerender } = renderHook(
       ({ isRunning }) => useMessageQueue({ agentId: AGENT, isRunning, dispatchTurn, onEdit: noop }),
       { initialProps: { isRunning: true } },
@@ -144,12 +144,17 @@ describe('useMessageQueue', () => {
       result.current.enqueue(makeTurn('t1', 'queued'));
     });
     rerender({ isRunning: false });
-    expect(dispatchTurn).toHaveBeenCalledWith('queued', [], undefined, AGENT);
+    expect(dispatchTurn).toHaveBeenCalledWith({
+      content: 'queued',
+      atts: [],
+      override: undefined,
+      agentId: AGENT,
+    });
     expect(result.current.queue).toEqual([]);
   });
 
   it('dispatches the exact routing override captured by the queued turn', () => {
-    const dispatchTurn = vi.fn().mockResolvedValue(undefined);
+    const dispatchTurn = vi.fn().mockResolvedValue({ blockedOverBudget: false });
     const override = {
       providerId: 'anthropic',
       model: 'claude-opus-5',
@@ -165,12 +170,17 @@ describe('useMessageQueue', () => {
 
     rerender({ isRunning: false });
 
-    expect(dispatchTurn).toHaveBeenCalledWith('queued with override', [], override, AGENT);
-    expect(dispatchTurn.mock.calls[0]?.[2]).toBe(override);
+    expect(dispatchTurn).toHaveBeenCalledWith({
+      content: 'queued with override',
+      atts: [],
+      override,
+      agentId: AGENT,
+    });
+    expect(dispatchTurn.mock.calls[0]?.[0]?.override).toBe(override);
   });
 
   it('dispatches to the agent captured by the queued turn', () => {
-    const dispatchTurn = vi.fn().mockResolvedValue(undefined);
+    const dispatchTurn = vi.fn().mockResolvedValue({ blockedOverBudget: false });
     const { result, rerender } = renderHook(
       ({ isRunning }) => useMessageQueue({ agentId: AGENT, isRunning, dispatchTurn, onEdit: noop }),
       { initialProps: { isRunning: true } },
@@ -184,16 +194,16 @@ describe('useMessageQueue', () => {
 
     rerender({ isRunning: false });
 
-    expect(dispatchTurn).toHaveBeenCalledWith(
-      'queued for another agent',
-      [],
-      undefined,
-      OTHER_AGENT,
-    );
+    expect(dispatchTurn).toHaveBeenCalledWith({
+      content: 'queued for another agent',
+      atts: [],
+      override: undefined,
+      agentId: OTHER_AGENT,
+    });
   });
 
   it('holds turns queued while idle without a running-to-idle transition', () => {
-    const dispatchTurn = vi.fn().mockResolvedValue(undefined);
+    const dispatchTurn = vi.fn().mockResolvedValue({ blockedOverBudget: false });
     const { result } = renderHook(() =>
       useMessageQueue({ agentId: AGENT, isRunning: false, dispatchTurn, onEdit: noop }),
     );

--- a/apps/desktop/src/features/chat/components/ChatInput/hooks/useMessageQueue.ts
+++ b/apps/desktop/src/features/chat/components/ChatInput/hooks/useMessageQueue.ts
@@ -1,17 +1,14 @@
 import { useCallback, useEffect, useRef } from 'react';
 import type { AgentId } from '@goodboy/types';
 import { useAppStore } from '../../../../../store';
-import type { PendingAttachment, QueuedTurn } from '../lib';
+import type { QueuedTurn } from '../lib';
+import type { SendTurnResult } from '../../../../../store/slices/turn/types';
+import type { DispatchTurnParams } from './useTurnDispatch';
 
 type UseMessageQueueArgs = {
   readonly agentId: AgentId | null;
   readonly isRunning: boolean;
-  readonly dispatchTurn: (
-    content: string,
-    atts: ReadonlyArray<PendingAttachment>,
-    override: QueuedTurn['override'],
-    agentId: AgentId,
-  ) => Promise<void>;
+  readonly dispatchTurn: (params: DispatchTurnParams) => Promise<SendTurnResult>;
   readonly onEdit: (item: QueuedTurn) => void;
 };
 
@@ -32,7 +29,12 @@ export function useMessageQueue({ agentId, isRunning, dispatchTurn, onEdit }: Us
       const [next, ...rest] = queue;
       setAgentQueue(agentId, rest);
       if (next) {
-        void dispatchTurn(next.content, next.attachments, next.override, next.agentId);
+        void dispatchTurn({
+          content: next.content,
+          atts: next.attachments,
+          override: next.override,
+          agentId: next.agentId,
+        });
       }
     }
   }, [agentId, isRunning, queue, dispatchTurn, setAgentQueue]);

--- a/apps/desktop/src/features/chat/components/ChatInput/hooks/useTurnDispatch.ts
+++ b/apps/desktop/src/features/chat/components/ChatInput/hooks/useTurnDispatch.ts
@@ -5,10 +5,19 @@ import { formatError } from '../../../../../shared/lib/errors';
 import { isTranscriptOwnedTurnError } from '../../../turn-errors';
 import { toAttachmentInput } from '../lib';
 import type { PendingAttachment, QueuedTurn } from '../lib';
+import type { SendTurnResult } from '../../../../../store/slices/turn/types';
 
 type UseTurnDispatchArgs = {
   readonly sessionId: SessionId;
   readonly cleanupSentAttachments: (atts: ReadonlyArray<PendingAttachment>) => void;
+};
+
+export type DispatchTurnParams = {
+  readonly content: string;
+  readonly atts: ReadonlyArray<PendingAttachment>;
+  readonly override: TurnProviderOverride | undefined;
+  readonly agentId: AgentId;
+  readonly force?: boolean;
 };
 
 export const useTurnDispatch = ({ sessionId, cleanupSentAttachments }: UseTurnDispatchArgs) => {
@@ -18,30 +27,37 @@ export const useTurnDispatch = ({ sessionId, cleanupSentAttachments }: UseTurnDi
   const [lastFailedTurn, setLastFailedTurn] = useState<Omit<QueuedTurn, 'id'> | null>(null);
 
   const dispatchTurn = useCallback(
-    async (
-      content: string,
-      atts: ReadonlyArray<PendingAttachment>,
-      override: TurnProviderOverride | undefined,
-      agentId: AgentId,
-    ) => {
+    async ({
+      content,
+      atts,
+      override,
+      agentId,
+      force = false,
+    }: DispatchTurnParams): Promise<SendTurnResult> => {
       try {
-        await sendTurn({
+        const result = await sendTurn({
           sessionId,
           agentId,
           content,
           ...(atts.length > 0 ? { attachments: atts.map(toAttachmentInput) } : {}),
           override,
+          ...(force ? { force: true } : {}),
         });
+        if (result.blockedOverBudget) {
+          return result;
+        }
         setLastFailedTurn(null);
         cleanupSentAttachments(atts);
+        return result;
       } catch (err) {
         if (isTranscriptOwnedTurnError({ error: err })) {
           setError(null);
           setLastFailedTurn(null);
-          return;
+          return { blockedOverBudget: false };
         }
         setError(formatError(err));
         setLastFailedTurn({ agentId, content, attachments: atts, override });
+        return { blockedOverBudget: false };
       }
     },
     [sendTurn, sessionId, cleanupSentAttachments],

--- a/apps/desktop/src/features/chat/components/ChatInput/hooks/useTurnRouting.test.ts
+++ b/apps/desktop/src/features/chat/components/ChatInput/hooks/useTurnRouting.test.ts
@@ -63,6 +63,24 @@ describe('useTurnRouting', () => {
     });
   });
 
+  it('keeps the routing override and the connected provider list referentially stable', () => {
+    useAppStore.setState({
+      providers: [
+        { id: 'anthropic', connection: 'connected' },
+        { id: 'cursor', connection: 'connected' },
+      ] as never,
+    });
+    const session = makeSession();
+    const { result, rerender } = renderHook(() => useTurnRouting({ session }));
+
+    const firstOverride = result.current.routingOverride;
+    const firstProviderIds = result.current.connectedProviderIds;
+    rerender();
+
+    expect(result.current.routingOverride).toBe(firstOverride);
+    expect(result.current.connectedProviderIds).toBe(firstProviderIds);
+  });
+
   it('clears the session model when the provider changes', () => {
     const { result } = renderHook(() => useTurnRouting({ session: makeSession() }));
 

--- a/apps/desktop/src/features/chat/components/ChatInput/hooks/useTurnRouting.ts
+++ b/apps/desktop/src/features/chat/components/ChatInput/hooks/useTurnRouting.ts
@@ -105,29 +105,38 @@ export const useTurnRouting = ({ session }: Params) => {
     modelId: effectiveModelId,
   });
   const effectiveEffort = clampEffort(effectiveModel, effort);
-  const storedSelection = resolveStoredModelSelection({
-    provider: effectiveProvider,
-    id: effectiveModelId,
-    effort: effectiveEffort,
-  });
-  const effectiveSelection =
-    storedSelection.report?.kind === 'unknown'
-      ? resolveStoredModelSelection({
-          provider: effectiveProvider,
-          id: effectiveModel,
-          effort: effectiveEffort,
-        }).selection
-      : storedSelection.selection;
-  const routingOverride: TurnProviderOverride | undefined = allowOverride
-    ? {
-        providerId: effectiveProvider,
-        model: effectiveModel,
-        selection: effectiveSelection,
-        explicit: isPicked,
-      }
-    : undefined;
+  const effectiveSelection = useMemo(() => {
+    const stored = resolveStoredModelSelection({
+      provider: effectiveProvider,
+      id: effectiveModelId,
+      effort: effectiveEffort,
+    });
+    if (stored.report?.kind !== 'unknown') {
+      return stored.selection;
+    }
+    return resolveStoredModelSelection({
+      provider: effectiveProvider,
+      id: effectiveModel,
+      effort: effectiveEffort,
+    }).selection;
+  }, [effectiveProvider, effectiveModelId, effectiveModel, effectiveEffort]);
 
-  const connectedProviderIds = connectedProviders.map((p) => p.id);
+  const routingOverride: TurnProviderOverride | undefined = useMemo(() => {
+    if (!allowOverride) {
+      return undefined;
+    }
+    return {
+      providerId: effectiveProvider,
+      model: effectiveModel,
+      selection: effectiveSelection,
+      explicit: isPicked,
+    };
+  }, [allowOverride, effectiveProvider, effectiveModel, effectiveSelection, isPicked]);
+
+  const connectedProviderIds = useMemo(
+    () => connectedProviders.map((p) => p.id),
+    [connectedProviders],
+  );
   const providerModels = PROVIDER_CAPABILITIES[effectiveProvider].models;
   const modelCandidates = useMemo<ReadonlyArray<string>>(() => {
     const ids = new Set(providerModels.map((m) => m.id));

--- a/apps/desktop/src/features/chat/components/ChatInput/index.test.tsx
+++ b/apps/desktop/src/features/chat/components/ChatInput/index.test.tsx
@@ -46,7 +46,7 @@ const {
     agentTurnState: Record<string, never>;
     agentModelOverride: Record<string, string>;
     agentProviderOverride: Record<string, never>;
-    agentKindOverride: Record<string, never>;
+    agentKindOverride: Record<string, string>;
     agentRunHistory: Record<string, never>;
     agentDraft: Record<string, string>;
     agentAttachments: Record<string, ReadonlyArray<never>>;
@@ -160,6 +160,7 @@ function resetMockStore() {
     agentDraft: {},
     agentAttachments: {},
     agentQueue: {},
+    agentKindOverride: {},
     sessionWorktrees: {},
     sessionTelemetry: {},
   });
@@ -687,5 +688,66 @@ describe('ChatInput, all providers over budget', () => {
         expect.objectContaining({ content: 'over cap but urgent', force: true }),
       );
     });
+  });
+
+  it('offers the escape hatch to an attachment-only message with no text', async () => {
+    mockStore.setState({ sessionWorktrees: { 'session-1': ['/wt'] } });
+    resolveProviderMock.mockResolvedValue({
+      selectedProvider: 'anthropic',
+      selectedModel: 'claude-sonnet-4-6',
+      reason: 'all-exceeded',
+    });
+    const user = userEvent.setup();
+    const { container } = render(<ChatInput session={makeSession()} />);
+
+    await user.upload(fileInput(container), pngFile());
+    await screen.findByAltText('pic.png');
+    await waitFor(() => {
+      expect(mockStore.getState().agentAttachments['agent-1']?.length).toBe(1);
+    });
+
+    const sendAnyway = await screen.findByRole('button', { name: 'Send anyway' });
+    await user.click(sendAnyway);
+
+    await waitFor(() => {
+      expect(sendTurnMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: '',
+          force: true,
+          attachments: expect.arrayContaining([expect.objectContaining({ fileName: 'pic.png' })]),
+        }),
+      );
+    });
+  });
+
+  it('a forced send retires the pending scope nudge instead of leaving it armed', async () => {
+    mockStore.setState({ agentKindOverride: { 'agent-1': 'planner' } });
+    resolveProviderMock.mockResolvedValue({
+      selectedProvider: 'anthropic',
+      selectedModel: 'claude-sonnet-4-6',
+      reason: 'all-exceeded',
+    });
+    const user = userEvent.setup();
+    render(<ChatInput session={makeSession()} />);
+
+    const textarea = screen.getByRole('textbox');
+    await user.type(textarea, 'implement the retry');
+    await user.keyboard('{Enter}');
+
+    expect(await screen.findByTestId('scope-mismatch-nudge')).toBeTruthy();
+    expect(sendTurnMock).not.toHaveBeenCalled();
+
+    const sendAnyway = await screen.findByRole('button', { name: 'Send anyway' });
+    await user.click(sendAnyway);
+
+    await waitFor(() => {
+      expect(sendTurnMock).toHaveBeenCalledWith(
+        expect.objectContaining({ content: 'implement the retry', force: true }),
+      );
+    });
+    await waitFor(() => {
+      expect(screen.queryByTestId('scope-mismatch-nudge')).toBeNull();
+    });
+    expect(sendTurnMock).toHaveBeenCalledOnce();
   });
 });

--- a/apps/desktop/src/features/chat/components/ChatInput/index.test.tsx
+++ b/apps/desktop/src/features/chat/components/ChatInput/index.test.tsx
@@ -6,6 +6,7 @@ import type { IsoDateTime, ProviderRunId, Session } from '@goodboy/types';
 
 const {
   sendTurnMock,
+  resolveProviderMock,
   cancelCurrentTurnMock,
   mockStore,
   writeAttachmentMock,
@@ -14,7 +15,12 @@ const {
   readDroppedAttachmentMock,
 } = await vi.hoisted(async () => {
   const { create } = await import('zustand');
-  const send = vi.fn(async () => undefined);
+  const send = vi.fn(async (_input: unknown) => ({ blockedOverBudget: false }));
+  const resolveProvider = vi.fn(async (_input: unknown) => ({
+    selectedProvider: 'anthropic',
+    selectedModel: 'claude-sonnet-4-6',
+    reason: 'preference',
+  }));
   const cancel = vi.fn();
   const writeAttachment = vi.fn(async () => 'attachments/att-pic.png');
   const readAttachment = vi.fn(async () => 'data:image/png;base64,QUJD');
@@ -139,6 +145,7 @@ const {
   }));
   return {
     sendTurnMock: send,
+    resolveProviderMock: resolveProvider,
     cancelCurrentTurnMock: cancel,
     mockStore: store,
     writeAttachmentMock: writeAttachment,
@@ -190,11 +197,7 @@ vi.mock('@goodboy/core', async (importOriginal) => {
   return {
     ...actual,
     buildClaudeFlags: () => ({ allowedTools: [], disallowedTools: [] }),
-    resolveProvider: vi.fn(async () => ({
-      selectedProvider: 'anthropic',
-      selectedModel: 'claude-sonnet-4-6',
-      reason: 'preference',
-    })),
+    resolveProvider: resolveProviderMock,
     assessTurnWeight: () => 'small',
   };
 });
@@ -226,6 +229,12 @@ afterEach(() => {
   cleanup();
   vi.clearAllMocks();
   resetMockStore();
+  sendTurnMock.mockResolvedValue({ blockedOverBudget: false });
+  resolveProviderMock.mockResolvedValue({
+    selectedProvider: 'anthropic',
+    selectedModel: 'claude-sonnet-4-6',
+    reason: 'preference',
+  });
 });
 
 describe('ChatInput, input wiring', () => {
@@ -595,6 +604,88 @@ describe('ChatInput, attachment persistence', () => {
     });
     await waitFor(() => {
       expect(mockStore.getState().agentAttachments['agent-1']).toBeUndefined();
+    });
+  });
+});
+
+describe('ChatInput, all providers over budget', () => {
+  const pngFile = () => new File(['abc'], 'pic.png', { type: 'image/png' });
+
+  function fileInput(container: HTMLElement): HTMLInputElement {
+    const input = container.querySelector('input[type="file"]');
+    if (!input) {
+      throw new Error('file input not found');
+    }
+    return input as HTMLInputElement;
+  }
+
+  it('restores the typed message into the composer when the send is blocked', async () => {
+    sendTurnMock.mockResolvedValue({ blockedOverBudget: true });
+    const user = userEvent.setup();
+    render(<ChatInput session={makeSession()} />);
+
+    const textarea = screen.getByRole('textbox');
+    await user.type(textarea, 'do not lose me');
+    await user.keyboard('{Enter}');
+
+    expect(sendTurnMock).toHaveBeenCalledOnce();
+    await waitFor(() => {
+      expect((screen.getByRole('textbox') as HTMLTextAreaElement).value).toBe('do not lose me');
+    });
+    expect(mockStore.getState().agentDraft['agent-1']).toBe('do not lose me');
+  });
+
+  it('keeps the attachments and never deletes them from disk when the send is blocked', async () => {
+    mockStore.setState({ sessionWorktrees: { 'session-1': ['/wt'] } });
+    sendTurnMock.mockResolvedValue({ blockedOverBudget: true });
+    const user = userEvent.setup();
+    const { container } = render(<ChatInput session={makeSession()} />);
+
+    await user.upload(fileInput(container), pngFile());
+    await screen.findByAltText('pic.png');
+    await waitFor(() => {
+      expect(mockStore.getState().agentAttachments['agent-1']?.length).toBe(1);
+    });
+
+    const textarea = screen.getByRole('textbox');
+    await user.type(textarea, 'with attachment');
+    await user.keyboard('{Enter}');
+
+    expect(sendTurnMock).toHaveBeenCalledOnce();
+    await waitFor(() => {
+      expect(screen.getByAltText('pic.png')).toBeTruthy();
+    });
+    expect(deleteAttachmentMock).not.toHaveBeenCalled();
+    expect(mockStore.getState().agentAttachments['agent-1']?.length).toBe(1);
+  });
+
+  it('sends the turn with force when the escape hatch is used, unlike a plain send', async () => {
+    resolveProviderMock.mockResolvedValue({
+      selectedProvider: 'anthropic',
+      selectedModel: 'claude-sonnet-4-6',
+      reason: 'all-exceeded',
+    });
+    sendTurnMock.mockResolvedValue({ blockedOverBudget: true });
+    const user = userEvent.setup();
+    render(<ChatInput session={makeSession()} />);
+
+    const textarea = screen.getByRole('textbox');
+    await user.type(textarea, 'over cap but urgent');
+    await user.keyboard('{Enter}');
+
+    expect(sendTurnMock).toHaveBeenCalledWith(
+      expect.objectContaining({ content: 'over cap but urgent' }),
+    );
+    expect(sendTurnMock.mock.calls[0]?.[0]).not.toHaveProperty('force');
+
+    sendTurnMock.mockResolvedValue({ blockedOverBudget: false });
+    const sendAnyway = await screen.findByRole('button', { name: 'Send anyway' });
+    await user.click(sendAnyway);
+
+    await waitFor(() => {
+      expect(sendTurnMock).toHaveBeenCalledWith(
+        expect.objectContaining({ content: 'over cap but urgent', force: true }),
+      );
     });
   });
 });

--- a/apps/desktop/src/features/chat/components/ChatInput/index.tsx
+++ b/apps/desktop/src/features/chat/components/ChatInput/index.tsx
@@ -182,11 +182,17 @@ export const ChatInput = ({ session, providerDisconnected = false }: Props) => {
   }, []);
 
   const sendWith = useCallback(
-    async (
-      content: string,
-      atts: ReadonlyArray<PendingAttachment>,
-      modelOverrideId: string | null,
-    ) => {
+    async ({
+      content,
+      atts,
+      modelOverrideId,
+      force = false,
+    }: {
+      readonly content: string;
+      readonly atts: ReadonlyArray<PendingAttachment>;
+      readonly modelOverrideId: string | null;
+      readonly force?: boolean;
+    }) => {
       const override: TurnProviderOverride | undefined = routing.allowOverride
         ? modelOverrideId == null
           ? routing.routingOverride
@@ -218,7 +224,18 @@ export const ChatInput = ({ session, providerDisconnected = false }: Props) => {
       if (selectedAgentId == null) {
         return;
       }
-      await dispatch.dispatchTurn(content, atts, override, selectedAgentId);
+      const result = await dispatch.dispatchTurn({
+        content,
+        atts,
+        override,
+        agentId: selectedAgentId,
+        force,
+      });
+      if (!result.blockedOverBudget) {
+        return;
+      }
+      setValue(content);
+      setAttachments(atts);
     },
     [
       routing.allowOverride,
@@ -229,23 +246,31 @@ export const ChatInput = ({ session, providerDisconnected = false }: Props) => {
       selectedAgentId,
       enqueue,
       dispatch.dispatchTurn,
+      setValue,
+      setAttachments,
     ],
   );
 
-  const onSend = async () => {
+  const submitDraft = async ({ force }: { readonly force: boolean }) => {
     const content = value.trim();
     const atts = attachments;
     if ((!content && atts.length === 0) || providerDisconnected) return;
     dispatch.setError(null);
     dispatch.setLastFailedTurn(null);
 
-    if (await scope.checkAndInterceptScope(content, atts)) return;
-    if (!isRunning && (await rightSize.checkAndInterceptRightSize(content, atts))) return;
+    if (!force) {
+      if (await scope.checkAndInterceptScope(content, atts)) return;
+      if (!isRunning && (await rightSize.checkAndInterceptRightSize(content, atts))) return;
+    }
 
     setValue('');
     setAttachments([]);
-    await sendWith(content, atts, null);
+    await sendWith({ content, atts, modelOverrideId: null, force });
   };
+
+  const onSend = async () => submitDraft({ force: false });
+
+  const onSendAnyway = async () => submitDraft({ force: true });
 
   const onScopeSpawn = async () => {
     if (!scope.scopePending) return;
@@ -275,7 +300,7 @@ export const ChatInput = ({ session, providerDisconnected = false }: Props) => {
     setValue('');
     setAttachments([]);
     await scope.recordScopeOutcome('overridden');
-    await sendWith(content, atts, null);
+    await sendWith({ content, atts, modelOverrideId: null });
   };
 
   const onScopeDismiss = async () => {
@@ -293,7 +318,11 @@ export const ChatInput = ({ session, providerDisconnected = false }: Props) => {
     setAttachments([]);
     if (suggested !== null) routing.setSelectedModel(suggested);
     await rightSize.recordRightSizeOutcome({ outcome: 'accepted' });
-    await sendWith(pending.content, pending.attachments, suggested);
+    await sendWith({
+      content: pending.content,
+      atts: pending.attachments,
+      modelOverrideId: suggested,
+    });
   };
 
   const onKeepCurrent = async () => {
@@ -304,7 +333,11 @@ export const ChatInput = ({ session, providerDisconnected = false }: Props) => {
     setValue('');
     setAttachments([]);
     await rightSize.recordRightSizeOutcome({ outcome: 'overridden' });
-    await sendWith(pending.content, pending.attachments, null);
+    await sendWith({
+      content: pending.content,
+      atts: pending.attachments,
+      modelOverrideId: null,
+    });
   };
 
   const onChangeModel = async () => {
@@ -369,7 +402,7 @@ export const ChatInput = ({ session, providerDisconnected = false }: Props) => {
             sessionPreference={session.providerPreference}
             turnOverride={routing.routingOverride}
             connectedProviders={routing.connectedProviderIds}
-            onSendAnyway={value.trim().length > 0 ? () => void onSend() : undefined}
+            onSendAnyway={value.trim().length > 0 ? () => void onSendAnyway() : undefined}
           />
         )}
         <SuggestionStack items={suggestions} />
@@ -553,12 +586,12 @@ export const ChatInput = ({ session, providerDisconnected = false }: Props) => {
                       const failed = dispatch.lastFailedTurn;
                       if (!failed) return;
                       dispatch.setError(null);
-                      void dispatch.dispatchTurn(
-                        failed.content,
-                        failed.attachments,
-                        failed.override,
-                        failed.agentId,
-                      );
+                      void dispatch.dispatchTurn({
+                        content: failed.content,
+                        atts: failed.attachments,
+                        override: failed.override,
+                        agentId: failed.agentId,
+                      });
                     },
                   }
                 : undefined

--- a/apps/desktop/src/features/chat/components/ChatInput/index.tsx
+++ b/apps/desktop/src/features/chat/components/ChatInput/index.tsx
@@ -263,6 +263,15 @@ export const ChatInput = ({ session, providerDisconnected = false }: Props) => {
       if (!isRunning && (await rightSize.checkAndInterceptRightSize(content, atts))) return;
     }
 
+    if (force && scope.scopePending !== null) {
+      scope.setScopePending(null);
+      await scope.recordScopeOutcome('overridden');
+    }
+    if (force && rightSize.rightSizePending !== null) {
+      rightSize.setRightSizePending(null);
+      await rightSize.recordRightSizeOutcome({ outcome: 'overridden' });
+    }
+
     setValue('');
     setAttachments([]);
     await sendWith({ content, atts, modelOverrideId: null, force });
@@ -402,7 +411,7 @@ export const ChatInput = ({ session, providerDisconnected = false }: Props) => {
             sessionPreference={session.providerPreference}
             turnOverride={routing.routingOverride}
             connectedProviders={routing.connectedProviderIds}
-            onSendAnyway={value.trim().length > 0 ? () => void onSendAnyway() : undefined}
+            onSendAnyway={canSend ? () => void onSendAnyway() : undefined}
           />
         )}
         <SuggestionStack items={suggestions} />

--- a/apps/desktop/src/features/chat/components/RoutingIndicator/index.test.tsx
+++ b/apps/desktop/src/features/chat/components/RoutingIndicator/index.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 const { resolveMock, featuresState } = vi.hoisted(() => ({
   resolveMock: vi.fn(),
@@ -44,6 +44,35 @@ describe('RoutingIndicator', () => {
       />,
     );
     await waitFor(() => screen.getByText(/all provider budgets exceeded/i));
+  });
+
+  it('wires the send anyway button when the escape hatch is passed', async () => {
+    const onSendAnyway = vi.fn();
+    resolveMock.mockResolvedValue({ reason: 'all-exceeded' });
+    render(
+      <RoutingIndicator
+        sessionPreference={null as never}
+        turnOverride={undefined}
+        connectedProviders={[]}
+        onSendAnyway={onSendAnyway}
+      />,
+    );
+    const button = await waitFor(() => screen.getByRole('button', { name: 'Send anyway' }));
+    fireEvent.click(button);
+    expect(onSendAnyway).toHaveBeenCalledTimes(1);
+  });
+
+  it('omits the send anyway button when no escape hatch is passed', async () => {
+    resolveMock.mockResolvedValue({ reason: 'all-exceeded' });
+    render(
+      <RoutingIndicator
+        sessionPreference={null as never}
+        turnOverride={undefined}
+        connectedProviders={[]}
+      />,
+    );
+    await waitFor(() => screen.getByText(/all provider budgets exceeded/i));
+    expect(screen.queryByRole('button')).toBeNull();
   });
 
   it('renders the fallback-budget warning with the selected provider', async () => {

--- a/apps/desktop/src/features/chat/components/RoutingIndicator/index.tsx
+++ b/apps/desktop/src/features/chat/components/RoutingIndicator/index.tsx
@@ -10,11 +10,10 @@ import type {
 import { resolveProviderForTurn } from '../../../../features/providers/routing';
 import { RoutingBadge } from '../../../../shared/components/RoutingBadge';
 import { SESSION_FEATURES } from '../../../../shared/lib/features';
-import { PROVIDER_LABEL_LOWER } from '../../../providers/providers';
+import { PROVIDER_LABEL } from '../../utils/chat-constants';
 import { tintClasses } from '@goodboy/ui';
 import { TranscriptShell } from '../TranscriptShell';
 
-const dangerAccent = tintClasses('danger');
 const warningAccent = tintClasses('warning');
 
 type Props = {
@@ -34,7 +33,11 @@ export const RoutingIndicator = ({
 
   useEffect(() => {
     let cancelled = false;
-    resolveProviderForTurn(sessionPreference, turnOverride, [...connectedProviders]).then((d) => {
+    void resolveProviderForTurn({
+      sessionPreference,
+      turnOverride,
+      connectedProviders: [...connectedProviders],
+    }).then((d) => {
       if (!cancelled) {
         setDecision(d);
       }
@@ -54,19 +57,19 @@ export const RoutingIndicator = ({
   if (decision.reason === 'all-exceeded') {
     return (
       <TranscriptShell
-        tone="danger"
+        tone="warning"
         variant="boxed"
-        className={`flex items-center gap-2 text-xs ${dangerAccent.text}`}
+        className={`flex items-center gap-2 text-xs ${warningAccent.text}`}
       >
         <AlertTriangle size={13} aria-hidden className="shrink-0" />
-        <span className="flex-1">all provider budgets exceeded</span>
+        <span className="flex-1">All provider budgets exceeded</span>
         {onSendAnyway ? (
           <button
             type="button"
             onClick={onSendAnyway}
-            className={`shrink-0 rounded-md border px-2 py-0.5 font-medium transition-colors ${dangerAccent.border} ${dangerAccent.hoverBg} ${dangerAccent.text}`}
+            className={`shrink-0 rounded-md border px-2 py-0.5 font-medium transition-colors ${warningAccent.border} ${warningAccent.hoverBg} ${warningAccent.text}`}
           >
-            send anyway
+            Send anyway
           </button>
         ) : null}
       </TranscriptShell>
@@ -81,9 +84,9 @@ export const RoutingIndicator = ({
     return null;
   }
 
-  const fromLabel = PROVIDER_LABEL_LOWER[decision.fallbackFrom];
+  const fromLabel = PROVIDER_LABEL[decision.fallbackFrom];
   const causeByReason: Partial<Record<RoutingReason, string>> = {
-    'fallback-budget': `budget exceeded for ${fromLabel}`,
+    'fallback-budget': `Budget exceeded for ${fromLabel}`,
     'fallback-threshold': `${fromLabel} past its budget threshold`,
     'fallback-disconnected': `${fromLabel} disconnected`,
   };
@@ -97,7 +100,7 @@ export const RoutingIndicator = ({
     >
       <AlertTriangle size={13} aria-hidden className="shrink-0" />
       <span className="flex items-center gap-1.5">
-        fallback to
+        Fallback to
         <RoutingBadge provider={decision.selectedProvider} model={decision.selectedModel} />
         <span>({cause})</span>
       </span>

--- a/apps/desktop/src/features/chat/components/RoutingIndicator/index.tsx
+++ b/apps/desktop/src/features/chat/components/RoutingIndicator/index.tsx
@@ -63,7 +63,7 @@ export const RoutingIndicator = ({
       >
         <AlertTriangle size={13} aria-hidden className="shrink-0" />
         <span className="flex-1">All provider budgets exceeded</span>
-        {onSendAnyway ? (
+        {onSendAnyway !== undefined ? (
           <button
             type="button"
             onClick={onSendAnyway}

--- a/apps/desktop/src/features/providers/routing.test.ts
+++ b/apps/desktop/src/features/providers/routing.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { RoutingDecision, SessionProviderPreference } from '@goodboy/types';
+
+const { resolveProviderMock, checkProviderBudgetMock } = vi.hoisted(() => ({
+  resolveProviderMock: vi.fn(),
+  checkProviderBudgetMock: vi.fn(),
+}));
+
+vi.mock('@goodboy/core', () => ({
+  resolveProvider: resolveProviderMock,
+  getDefaultTurnModel: () => 'claude-opus-5',
+}));
+
+vi.mock('../budget/budget', () => ({
+  invokeCheckProviderBudget: checkProviderBudgetMock,
+}));
+
+import { resolveProviderForTurn } from './routing';
+
+const DECISION = {
+  selectedProvider: 'anthropic',
+  selectedModel: 'claude-opus-5',
+  reason: 'preferred',
+  fallbackUsed: false,
+} satisfies RoutingDecision;
+
+const PREFERENCE = {
+  defaultProvider: 'anthropic',
+  allowTurnOverride: false,
+} satisfies SessionProviderPreference;
+
+beforeEach(() => {
+  resolveProviderMock.mockReset();
+  resolveProviderMock.mockResolvedValue(DECISION);
+  checkProviderBudgetMock.mockReset();
+});
+
+describe('resolveProviderForTurn', () => {
+  it('forwards a forced turn into the budget resolver', async () => {
+    await resolveProviderForTurn({
+      sessionPreference: PREFERENCE,
+      turnOverride: undefined,
+      connectedProviders: ['anthropic'],
+      force: true,
+    });
+
+    expect(resolveProviderMock).toHaveBeenCalledWith(expect.objectContaining({ force: true }));
+  });
+
+  it('omits force for a plain turn', async () => {
+    await resolveProviderForTurn({
+      sessionPreference: PREFERENCE,
+      turnOverride: undefined,
+      connectedProviders: ['anthropic'],
+    });
+
+    expect(resolveProviderMock.mock.calls[0]?.[0]).not.toHaveProperty('force');
+  });
+});

--- a/apps/desktop/src/features/providers/routing.ts
+++ b/apps/desktop/src/features/providers/routing.ts
@@ -7,15 +7,24 @@ import type {
 } from '@goodboy/types';
 import { invokeCheckProviderBudget } from '../budget/budget';
 
-export const resolveProviderForTurn = async (
-  sessionPreference: SessionProviderPreference,
-  turnOverride: TurnProviderOverride | undefined,
-  connectedProviders: ProviderId[],
-): Promise<RoutingDecision> => {
+type Params = {
+  readonly sessionPreference: SessionProviderPreference;
+  readonly turnOverride: TurnProviderOverride | undefined;
+  readonly connectedProviders: ProviderId[];
+  readonly force?: boolean;
+};
+
+export const resolveProviderForTurn = async ({
+  sessionPreference,
+  turnOverride,
+  connectedProviders,
+  force,
+}: Params): Promise<RoutingDecision> => {
   return resolveProvider({
     sessionPreference,
     turnOverride,
     connectedProviders,
+    ...(force === true ? { force: true } : {}),
     budgetChecker: {
       checkProviderBudget: (provider, period) => invokeCheckProviderBudget(provider, period),
     },

--- a/apps/desktop/src/features/settings/components/GuideStudio/parts/SessionsSection.tsx
+++ b/apps/desktop/src/features/settings/components/GuideStudio/parts/SessionsSection.tsx
@@ -42,7 +42,7 @@ export const SessionsSection = ({}: Props) => (
             ? [
                 {
                   term: 'budget (optional)',
-                  desc: 'Soft cap in USD. Warning at 80%, error at 100%. The session keeps running.',
+                  desc: 'Soft cap in USD. Warning at 80%, error at 100%. Turns you send keep running, auto-run workflows stop.',
                   icon: <CONCEPT_ICONS.budget size={11} aria-hidden />,
                   tone: 'warning' as const,
                 },

--- a/apps/desktop/src/shared/lib/features.ts
+++ b/apps/desktop/src/shared/lib/features.ts
@@ -6,7 +6,7 @@ export const WORKSPACE_FEATURES = {
 } as const;
 
 export const SESSION_FEATURES = {
-  budget: false,
+  budget: true,
   sessionArchival: true,
   branchSwitching: true,
   verbosity: true,

--- a/apps/desktop/src/store/slices/turn/sendTurn.ts
+++ b/apps/desktop/src/store/slices/turn/sendTurn.ts
@@ -122,7 +122,7 @@ type Input = {
   };
 };
 
-const DISPATCHED: SendTurnResult = { blockedOverBudget: false };
+const NOT_BLOCKED: SendTurnResult = { blockedOverBudget: false };
 
 // Machine-derived context slot carrying `git diff --numstat` lines for the
 // session's changed files (vs the same merge-base as the desktop file-changes
@@ -211,7 +211,7 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
       now,
     });
     if (!slashResult.ok) {
-      return DISPATCHED;
+      return NOT_BLOCKED;
     }
     let resolvedPrompt = slashResult.resolvedPrompt;
 
@@ -236,7 +236,7 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
             now,
           });
     if (!attachmentResult.ok) {
-      return DISPATCHED;
+      return NOT_BLOCKED;
     }
     const attachmentRefs = attachmentResult.attachmentRefs;
     resolvedPrompt = attachmentResult.resolvedPrompt;
@@ -523,7 +523,7 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
         message: encodeAuthRequiredMessage({ providerId: provider, identity: authState.identity }),
         at: now(),
       });
-      return DISPATCHED;
+      return NOT_BLOCKED;
     }
 
     const resolvedOverride =
@@ -684,7 +684,7 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
         phaseWorkflowRunId,
         now,
       });
-      return DISPATCHED;
+      return NOT_BLOCKED;
     }
 
     const sharedSlots = get().sessionSlots[sessionId] ?? [];
@@ -1266,7 +1266,7 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
     if (lastError) {
       throw lastError;
     }
-    return DISPATCHED;
+    return NOT_BLOCKED;
   };
   return run;
 };

--- a/apps/desktop/src/store/slices/turn/sendTurn.ts
+++ b/apps/desktop/src/store/slices/turn/sendTurn.ts
@@ -95,7 +95,7 @@ import { budgetRoutingNoticeMessage, budgetRoutingReason } from './budgetRouting
 import { cursorMaxModeMessage, matchCursorMaxModeFailure } from './matchCursorMaxModeFailure';
 import { recordUsageTelemetry } from './recordUsageTelemetry';
 import { resolveTurnModelSelection } from './resolveTurnModelSelection';
-import type { GetFn, SetFn } from './types';
+import type { GetFn, SendTurnResult, SetFn } from './types';
 
 const EFFORT_FLAG_BY_PROVIDER = {
   anthropic: '--effort',
@@ -113,6 +113,7 @@ type Input = {
   content: string;
   attachments?: ReadonlyArray<AttachmentInput>;
   override?: TurnProviderOverride;
+  force?: boolean;
   retry?: {
     readonly attempt: number;
     readonly provider: ProviderId;
@@ -120,6 +121,8 @@ type Input = {
     readonly attachmentRefs: ReadonlyArray<MessageAttachment>;
   };
 };
+
+const DISPATCHED: SendTurnResult = { blockedOverBudget: false };
 
 // Machine-derived context slot carrying `git diff --numstat` lines for the
 // session's changed files (vs the same merge-base as the desktop file-changes
@@ -134,8 +137,9 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
     content,
     attachments,
     override,
+    force,
     retry,
-  }: Input): Promise<void> => {
+  }: Input): Promise<SendTurnResult> => {
     const before = get();
     const session = before.sessions.find((s) => s.id === sessionId);
     if (!session) {
@@ -207,7 +211,7 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
       now,
     });
     if (!slashResult.ok) {
-      return;
+      return DISPATCHED;
     }
     let resolvedPrompt = slashResult.resolvedPrompt;
 
@@ -232,7 +236,7 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
             now,
           });
     if (!attachmentResult.ok) {
-      return;
+      return DISPATCHED;
     }
     const attachmentRefs = attachmentResult.attachmentRefs;
     resolvedPrompt = attachmentResult.resolvedPrompt;
@@ -404,11 +408,12 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
         ? { ...session.providerPreference, allowTurnOverride: true }
         : session.providerPreference;
 
-    const routingDecision = await resolveProviderForTurn(
-      routingPreference,
-      effectiveOverride,
+    const routingDecision = await resolveProviderForTurn({
+      sessionPreference: routingPreference,
+      turnOverride: effectiveOverride,
       connectedProviders,
-    );
+      ...(force === true ? { force: true } : {}),
+    });
 
     if (routingDecision.reason === 'all-exceeded') {
       const runId = crypto.randomUUID() as ProviderRunId;
@@ -419,7 +424,7 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
           'All providers have exceeded their budget cap. Adjust budget rules or wait for the next billing period.',
         at: now(),
       });
-      return;
+      return { blockedOverBudget: true };
     }
 
     const movedForBudget = budgetRoutingReason({ reason: routingDecision.reason });
@@ -518,7 +523,7 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
         message: encodeAuthRequiredMessage({ providerId: provider, identity: authState.identity }),
         at: now(),
       });
-      return;
+      return DISPATCHED;
     }
 
     const resolvedOverride =
@@ -679,7 +684,7 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
         phaseWorkflowRunId,
         now,
       });
-      return;
+      return DISPATCHED;
     }
 
     const sharedSlots = get().sessionSlots[sessionId] ?? [];
@@ -1138,12 +1143,13 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
         const retryState: TurnState = { kind: 'idle', lastActivityAt: now() };
         const retryDerived = applyAgentTurnState(set, sessionId, activeAgentId, retryState, now());
         await updateSessionState(tauriDatabase, sessionId, retryDerived, now());
-        await run({
+        return await run({
           sessionId,
           agentId: activeAgentId,
           content,
           ...(attachments !== undefined && { attachments }),
           ...(override !== undefined && { override }),
+          ...(force === true ? { force: true } : {}),
           retry: {
             attempt: (retry?.attempt ?? 0) + 1,
             provider: fallbackPlan.provider,
@@ -1151,7 +1157,6 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
             attachmentRefs,
           },
         });
-        return;
       }
       const errorState: TurnState = {
         kind: 'error',
@@ -1261,6 +1266,7 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
     if (lastError) {
       throw lastError;
     }
+    return DISPATCHED;
   };
   return run;
 };

--- a/apps/desktop/src/store/slices/turn/types.ts
+++ b/apps/desktop/src/store/slices/turn/types.ts
@@ -1,1 +1,5 @@
 export type { SetFn, GetFn } from '../../slice-types';
+
+export type SendTurnResult = Readonly<{
+  blockedOverBudget: boolean;
+}>;

--- a/apps/desktop/src/store/store.permissions.test.ts
+++ b/apps/desktop/src/store/store.permissions.test.ts
@@ -104,7 +104,7 @@ vi.mock('../features/providers/providers', () => ({
 }));
 
 vi.mock('../features/providers/routing', () => ({
-  resolveProviderForTurn: vi.fn(async (_pref, _override, _connected) => ({
+  resolveProviderForTurn: vi.fn(async () => ({
     selectedProvider: 'anthropic',
     selectedModel: 'claude-3-5-sonnet-latest',
     reason: 'preference',

--- a/apps/desktop/src/store/store.sendturn-agent-routing.test.ts
+++ b/apps/desktop/src/store/store.sendturn-agent-routing.test.ts
@@ -1843,6 +1843,58 @@ describe('sendTurn, budget routing notice', () => {
     expect(messages.join(' ')).not.toContain('running this turn on');
   });
 
+  it('blocks the turn and says so in the transcript when every provider is over cap', async () => {
+    const useAppStore = await importStore();
+    setupNoticeAgent(useAppStore);
+    const routingMod = await import('../features/providers/routing');
+    (routingMod.resolveProviderForTurn as ReturnType<typeof vi.fn>).mockResolvedValue({
+      selectedProvider: 'anthropic',
+      selectedModel: 'claude-sonnet-4-5',
+      reason: 'all-exceeded',
+      fallbackUsed: false,
+    });
+
+    const result = await useAppStore
+      .getState()
+      .sendTurn({ sessionId: SESSION_ID, agentId: AGENT_A, content: 'go' });
+
+    expect(result.blockedOverBudget).toBe(true);
+    expect(runTurnSpy).not.toHaveBeenCalled();
+    const messages = (useAppStore.getState().transcripts[AGENT_A] ?? [])
+      .filter((event) => event.kind === 'error')
+      .map((event) => ('message' in event ? event.message : ''));
+    expect(messages).toContain(
+      'All providers have exceeded their budget cap. Adjust budget rules or wait for the next billing period.',
+    );
+  });
+
+  it('forwards a forced send into the routing resolver, unlike a plain send', async () => {
+    const useAppStore = await importStore();
+    setupNoticeAgent(useAppStore);
+    const routingMod = await import('../features/providers/routing');
+    const routingSpy = routingMod.resolveProviderForTurn as ReturnType<typeof vi.fn>;
+    routingSpy.mockResolvedValue({
+      selectedProvider: 'anthropic',
+      selectedModel: 'claude-sonnet-4-5',
+      reason: 'forced-over-budget',
+      fallbackUsed: false,
+    });
+
+    await useAppStore
+      .getState()
+      .sendTurn({ sessionId: SESSION_ID, agentId: AGENT_A, content: 'go', force: true });
+
+    expect(routingSpy).toHaveBeenCalledWith(expect.objectContaining({ force: true }));
+    expect(runTurnSpy).toHaveBeenCalledOnce();
+
+    routingSpy.mockClear();
+    await useAppStore
+      .getState()
+      .sendTurn({ sessionId: SESSION_ID, agentId: AGENT_A, content: 'go again' });
+
+    expect(routingSpy.mock.calls[0]?.[0]).not.toHaveProperty('force');
+  });
+
   it('stays quiet when the turn never left the preferred provider', async () => {
     const useAppStore = await importStore();
     setupNoticeAgent(useAppStore);

--- a/apps/desktop/src/store/store.sendturn-agent-routing.test.ts
+++ b/apps/desktop/src/store/store.sendturn-agent-routing.test.ts
@@ -1133,9 +1133,9 @@ describe('sendTurn, resolver config (provider pin + effort)', () => {
       .sendTurn({ sessionId: SESSION_ID, agentId: AGENT_A, content: 'go' });
 
     expect(spy).toHaveBeenCalled();
-    const [preference, override] = spy.mock.calls[0]!;
-    expect(preference.allowTurnOverride).toBe(true);
-    expect(override).toEqual({ providerId: 'codex', model: 'gpt-5-codex' });
+    const [params] = spy.mock.calls[0]!;
+    expect(params.sessionPreference.allowTurnOverride).toBe(true);
+    expect(params.turnOverride).toEqual({ providerId: 'codex', model: 'gpt-5-codex' });
   });
 
   it('a resolver that emits a resolution marker records committed and advances the queue', async () => {

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -153,6 +153,7 @@ import { createSessionsSlice } from './slices/sessions';
 import { createWorkspacesSlice } from './slices/workspaces';
 import { createPresenceSlice } from './slices/presence';
 import { createTurnSlice } from './slices/turn';
+import type { SendTurnResult } from './slices/turn/types';
 import { createWorktreesSlice } from './slices/worktrees';
 import { createBootSlice } from './slices/boot';
 import { createUpdaterSlice } from './slices/updater';
@@ -376,7 +377,8 @@ export type AppActions = {
     content: string;
     attachments?: ReadonlyArray<AttachmentInput>;
     override?: TurnProviderOverride;
-  }): Promise<void>;
+    force?: boolean;
+  }): Promise<SendTurnResult>;
   cancelCurrentTurn(sessionId: SessionId, agentId?: AgentId): Promise<void>;
   retrySummarizer(sessionId: SessionId, taskModelOverride?: TaskModelPreference): void;
   refreshWorkspaceSummary(workspaceId: WorkspaceId): Promise<void>;

--- a/packages/core/src/budget/__tests__/router.test.ts
+++ b/packages/core/src/budget/__tests__/router.test.ts
@@ -102,6 +102,44 @@ describe('resolveProvider', () => {
     expect(decision.fallbackUsed).toBe(false);
   });
 
+  it('all providers exceeded with force → returns preferred with reason forced-over-budget', async () => {
+    const checkMock = vi.fn().mockResolvedValue(exceeded());
+
+    const input = makeInput({
+      budgetChecker: { checkProviderBudget: checkMock },
+      force: true,
+    });
+    const decision = await resolveProvider(input);
+
+    expect(decision.selectedProvider).toBe('anthropic');
+    expect(decision.selectedModel).toBe('claude-3-5-sonnet');
+    expect(decision.reason).toBe('forced-over-budget');
+    expect(decision.fallbackUsed).toBe(false);
+  });
+
+  it('force keeps the turn override provider when everything is over cap', async () => {
+    const checkMock = vi.fn().mockResolvedValue(exceeded());
+
+    const input = makeInput({
+      turnOverride: { providerId: 'cursor', model: 'composer-2.5' },
+      budgetChecker: { checkProviderBudget: checkMock },
+      force: true,
+    });
+    const decision = await resolveProvider(input);
+
+    expect(decision.selectedProvider).toBe('cursor');
+    expect(decision.selectedModel).toBe('composer-2.5');
+    expect(decision.reason).toBe('forced-over-budget');
+  });
+
+  it('force does not change a decision that was never all-exceeded', async () => {
+    const input = makeInput({ force: true });
+    const decision = await resolveProvider(input);
+
+    expect(decision.reason).toBe('preferred');
+    expect(decision.selectedProvider).toBe('anthropic');
+  });
+
   it('only one connected provider → no fallback, returns all-exceeded when over', async () => {
     const checkMock = vi.fn().mockResolvedValue(exceeded());
 

--- a/packages/core/src/budget/__tests__/router.test.ts
+++ b/packages/core/src/budget/__tests__/router.test.ts
@@ -379,6 +379,26 @@ describe('resolveProvider, enabledProviders gate', () => {
     expect(decision.fallbackFrom).toBe('anthropic');
   });
 
+  it('force never runs on a provider the session disabled', async () => {
+    const checkMock = vi.fn(async (provider: string) =>
+      provider === 'anthropic' ? notExceeded() : exceeded(),
+    );
+    const input = makeInput({
+      connectedProviders: ['anthropic', 'cursor'],
+      sessionPreference: {
+        defaultProvider: 'anthropic',
+        defaultModel: 'claude-3-5-sonnet',
+        allowTurnOverride: true,
+        enabledProviders: ['cursor'],
+      },
+      budgetChecker: { checkProviderBudget: checkMock },
+      force: true,
+    });
+    const decision = await resolveProvider(input);
+
+    expect(decision.reason).toBe('all-exceeded');
+  });
+
   it('turn override bypasses the enabled gate (explicit pin wins)', async () => {
     const input = makeInput({
       connectedProviders: ['anthropic', 'cursor'],

--- a/packages/core/src/budget/router.ts
+++ b/packages/core/src/budget/router.ts
@@ -126,7 +126,7 @@ export const resolveProvider = async (input: ResolveProviderInput): Promise<Rout
   return {
     selectedProvider: preferredProvider,
     selectedModel: preferredModel,
-    reason: force ? 'forced-over-budget' : 'all-exceeded',
+    reason: force && preferredAllowed ? 'forced-over-budget' : 'all-exceeded',
     fallbackUsed: false,
   };
 };

--- a/packages/core/src/budget/router.ts
+++ b/packages/core/src/budget/router.ts
@@ -20,6 +20,7 @@ export type ResolveProviderInput = {
     ) => Promise<BudgetCheckResult>;
   };
   getDefaultModel: (provider: ProviderId) => string;
+  force?: boolean;
 };
 
 const PROVIDER_ID_TO_NAME: Readonly<Record<ProviderId, ProviderName>> = {
@@ -35,6 +36,7 @@ const PROVIDER_ID_TO_NAME: Readonly<Record<ProviderId, ProviderName>> = {
 export const resolveProvider = async (input: ResolveProviderInput): Promise<RoutingDecision> => {
   const { sessionPreference, turnOverride, connectedProviders, budgetChecker, getDefaultModel } =
     input;
+  const force = input.force === true;
 
   const useOverride = turnOverride !== undefined && sessionPreference.allowTurnOverride;
 
@@ -124,7 +126,7 @@ export const resolveProvider = async (input: ResolveProviderInput): Promise<Rout
   return {
     selectedProvider: preferredProvider,
     selectedModel: preferredModel,
-    reason: 'all-exceeded',
+    reason: force ? 'forced-over-budget' : 'all-exceeded',
     fallbackUsed: false,
   };
 };

--- a/packages/types/src/budget.ts
+++ b/packages/types/src/budget.ts
@@ -32,6 +32,7 @@ export type RoutingReason =
   | 'fallback-threshold'
   | 'fallback-disconnected'
   | 'all-exceeded'
+  | 'forced-over-budget'
   | 'override';
 
 export type RoutingDecision = Readonly<{


### PR DESCRIPTION
## What

When every connected provider was over its budget cap, the user's typed message was destroyed and there was no way to send anything at all. This makes the dead end recoverable.

- `resolveProvider` takes an optional `force`. In an all-exceeded scenario it returns the preferred or overridden provider under a new `RoutingReason` member `forced-over-budget` rather than `all-exceeded`.
- `resolveProviderForTurn` moves from three positional args to a single object param, which is the house rule and avoids a fourth positional.
- `sendTurn` returns `{ blockedOverBudget: boolean }` instead of `Promise<void>`. It does not throw: eight of the eighteen call sites are fire-and-forget `void`, so a throw would produce unhandled rejections. The blocked branch keeps appending its transcript error event, so all seventeen non-composer callers see exactly what they saw before.
- `useTurnDispatch` branches on the result.
- The composer restores the text and the attachments on a blocked send. All four clear-then-send paths funnel through `sendWith`, so the restore lives there once. `onScopeSpawn` does not call `sendWith` and is untouched.
- `Send anyway` threads `force` through to the router instead of re-entering the same blocked branch, where it was a no-op.
- `SESSION_FEATURES.budget` is now `true`. This is load-bearing: `onSendAnyway` only mounts inside `RoutingIndicator`, which returned `null` behind the flag.
- `useTurnRouting` memoizes `connectedProviderIds` and `routingOverride`.

## Why

Verified against the code before touching it:

1. `ChatInput` called `setValue('')` and `setAttachments([])` unconditionally *before* awaiting the send.
2. The all-exceeded branch did a bare `return`, not a throw.
3. Because it resolved, `useTurnDispatch` treated it as success.
4. The first `insertMessage` sits after the early return, so nothing reached SQLite. The draft is in-memory Zustand and had been cleared. The message was gone.

### The live data-loss bug this also fixes

`cleanupSentAttachments` deletes the attachment files from disk and clears the agent's attachment draft. It was called unconditionally after `sendTurn` resolved. Since the all-exceeded path resolved, **the app was already deleting the attachments of a message it never sent.** That call is now gated on the blocked result, and there is a test asserting it is not called.

## Decisions I owned

**Strip tone: `warning`, not `danger`.** `DESIGN.md` says errors are toasts and budget alerts are toasts, never pinned banners. This strip is neither: it is pre-send state that says where this turn is about to go and disappears the moment routing changes. `danger` overstated a recoverable condition that now has a button next to it. I added one sentence to `DESIGN.md` carving out the pre-send routing line from **both** rules, cross-referenced so neither reads as contradicted.

**No new notification.** An earlier revision of this body justified this by claiming the inbox already holds a budget entry by the time every provider is exceeded. That is false, and the correction is worth stating: `notifyBudgetAlerts` fires only from `recordUsageTelemetry`, which needs a turn's usage event to land, and `saveBudgetRule` emits nothing. Open Budget Studio, author or lower a monthly cap below the month's existing spend for each connected provider, run no turn, and the very next composer render resolves `all-exceeded` with an empty inbox. The decision to ship no notification still holds, on the other reason: the block is synchronous and fully signalled where the user is already looking. The strip is visible, the composer keeps its text and its attachments, the transcript event is appended. An inbox entry per blocked keystroke would be noise arriving after the fact, and the repo already has seven user-facing budget strings without adding an eighth phrasing.

**Result shape: `Readonly<{ blockedOverBudget: boolean }>`.** Minimal and honest. A `sent`/`blocked` union would have forced the slash-command and attachment-failure early returns to claim `sent`, which is false. A boolean field named for the one condition callers act on lets those paths return `{ blockedOverBudget: false }` truthfully, and the object is extensible.

## Claims in the brief that were wrong

- **`SessionsSection` copy was false.** The brief said to re-verify the copy the flag turns on and correct it rather than turn on a false claim. `budget (optional): Soft cap in USD. Warning at 80%, error at 100%. The session keeps running.` The last sentence is contradicted by `store/slices/workflows/budgetBlock.ts:15`, where `session-exceeded` is blocking and `maybeAutoAdvanceWorkflow` halts the run with `BUDGET_BLOCK_MESSAGE`. A session running an auto-run workflow stops at 100%. Corrected to `Turns you send keep running, auto-run workflows stop.` The other two copy sites (`OverviewSection`, `ImportConfigDialog`) verified true.
- **File paths in the brief were off by one segment.** Everything cited as `features/chat/ChatInput/...` and `features/chat/RoutingIndicator/...` actually lives under `features/chat/components/...`.
- **The per-session cap chain has an extra hop.** The brief routed `SessionCostChip -> BudgetStudio/SessionPanel.tsx:54 -> CapEditor`. `SessionPanel` renders `SessionBudgetContent`, and `CapEditor` lives there. The claim that a per-session soft cap is authorable today is nonetheless **true**, and reachable by three entry points, none flag-gated.
- **An undocumented test pinned the old positional signature.** `store.sendturn-agent-routing.test.ts:1136` destructured `spy.mock.calls[0]` as `[preference, override]`. The brief listed only two callers of `resolveProviderForTurn`; this test was a third consumer of its shape. Updated.
- **`useMessageQueue.test.ts` was not mentioned** and hard-coded `dispatchTurn` mocks returning `Promise<void>` plus three positional call assertions. Updated.
- **`README.md` contains zero occurrences of "budget"** - confirmed, so no doc edit was invented there. `VISION.md:252-253` is real and was updated.

Everything else in the brief checked out: the `RoutingReason` consumer audit was correct (no unguarded `switch` over the full union), `onScopeSpawn` genuinely does not call `sendWith`, and both memoized expressions sit outside any `useAppStore(` call so the `no-unstable-zustand-selectors` regression test stays green.

## Test plan

- `packages/core/src/budget/__tests__/router.test.ts`: three new cases. Force returns `forced-over-budget`, force preserves the turn override provider, and force does not alter a decision that was never all-exceeded.
- `ChatInput/index.test.tsx`: composer restore on a blocked send, attachment restore plus `deleteAttachment` never called on a blocked send, and `Send anyway` reaching a distinct forced path (asserts the plain send carries no `force` key and the escape hatch carries `force: true`).
- `RoutingIndicator/index.test.tsx`: the button is present and wired when `onSendAnyway` is passed, and absent when it is not. The pre-existing all-exceeded case never passed the prop, which is why the no-op survived.

## Repair pass after review

A verifier returned `merge after these fixes`. All of them are in.

- **A forced send left the scope nudge armed.** `submitDraft({ force: true })` skipped the nudge checks and cleared nothing, so a mounted scope card survived the send holding the same content, its own `send anyway` could dispatch the identical turn a second time, and its telemetry row stayed at `outcome: null` forever. The forced path now clears both pending nudges and records `overridden`.
- **An attachment-only message had no escape hatch.** The button was gated on `value.trim().length > 0` while sending is gated on `canSend`, so a screenshot with no text hit the block with no way out. The gates match now.
- **`force` was too wide.** See the `fix(core)` commit: it waived the enabled-provider allowlist along with the cap.
- **Five sabotages survived the green suite.** Each now fails a test: the blocked `sendTurn` return, the `force` spread in `resolveProviderForTurn`, the `force` spread in `sendTurn`'s call to it, and both `useTurnRouting` memos. `features/providers/routing.ts` had no test file at all and now has one.
- **`DISPATCHED` renamed to `NOT_BLOCKED`.** Three of its five return sites dispatch nothing.
- **`DESIGN.md` cross-reference made two-way.** The Spend bullet now points back at the carve-out, so a reader landing there does not see an absolute rule with no pointer to its exception.

New coverage: the forced send retiring a pending scope nudge and dispatching once, the escape hatch on an attachment-only message, `resolveProviderForTurn` forwarding `force`, `sendTurn` returning `blockedOverBudget: true` with its transcript event on `all-exceeded`, `sendTurn` forwarding `force`, referential stability of both routing memos, and `force` declining to select a disabled provider.

`pnpm typecheck` green. `pnpm exec turbo run test --force` green across the whole workspace: **6377 passed, 4 skipped** (ui 103, core 1087, db 202, desktop 4985). `pnpm knip --include files,duplicates,unlisted` clean, only the pre-existing config hints that are also on `main`.

## Not verified against a live provider

**Nothing here was exercised against a real provider, a real budget rule, or a real tenant.** Specifically unverified end to end:

- No real turn was ever run over a real exceeded cap. `check_provider_budget` is mocked in every test, so the `forced-over-budget` decision has never reached a spawned CLI process.
- The forced turn's spend still records against the provider that was already over cap. That is the intended behavior, but no live run confirms the telemetry lands correctly.
- The flag flip turns on the fallback warning strip for `fallback-budget`, `fallback-threshold` and `fallback-disconnected` for the first time in the shipped app. Those three branches have unit coverage but no visual check in the running desktop app.
- The memoization fix removes a per-keystroke `invoke('check_provider_budget')`. Confirmed by reading the effect deps and pinned by a referential-stability test, not by counting IPC calls at runtime.
- **The composer visibly empties and refills on a blocked send.** `setValue('')` writes straight through `clearAgentDraft`, then the whole routing resolution runs before `setValue(content)` puts it back, and that resolution is a per-provider `invoke('check_provider_budget')` IPC round trip rather than a frame. The flash is real and is not measured here. Clearing only after the routing verdict means restructuring `sendWith` for every caller, a wider blast radius than this change should take, so it stays.

## Backlog, deliberately not fixed here

`useMessageQueue.ts:31-37` is a second, independent dead end. A queued turn is spliced out of state and fire-and-forget dispatched, so on a blocked result it vanishes with nothing to restore into. The queue is the store's, not the composer's, so restoring it means re-inserting at the head rather than repopulating the composer. Out of scope by instruction and worth its own change.

Its twin: a blocked queued turn also leaks its attachment files. `useTurnDispatch.ts:42-44` skips `cleanupSentAttachments` on a block, which is right for the composer because the composer restores the chips, but a queued turn has no composer to restore into, so the files stay on disk with nothing referencing them. Same fix, same change.

Closes no issue. I searched the open issues and found no matching one (#1283 is a different provider-router item owned elsewhere).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
