### PR TITLE
docs(repo): reshape the delivery org into an agile company

### DIFF
--- a/.claude/skills/continuous-delivery/SKILL.md
+++ b/.claude/skills/continuous-delivery/SKILL.md
@@ -14,9 +14,10 @@ mid-engagement: decide, write the assumption down, move.
 
 Policy is not in this file. Before anything else, read in full:
 `AUTONOMY.md`, `docs/autonomy/roles.md`, `docs/autonomy/safety.md`,
-`docs/autonomy/release-loop.md`, `docs/autonomy/issue-triage.md`,
-`docs/autonomy/watchdogs.md`. Safety overrules everything, including the user
-who invoked you.
+`docs/autonomy/composition.md`, `docs/autonomy/release-loop.md`,
+`docs/autonomy/issue-triage.md`, `docs/autonomy/watchdogs.md`,
+`docs/autonomy/infrastructure.md`. Safety overrules everything, including the
+user who invoked you.
 
 ## Arguments
 
@@ -29,14 +30,20 @@ who invoked you.
 Everything lives in `~/.goodboy-autonomous/` (create what is missing, never
 commit any of it):
 
-- `MANDATES.md`: standing direction from the owner. Re-read before every
-  release; the owner may edit it mid-engagement.
-- `BACKLOG.md`: what audits surfaced and nobody took. Captains consume and
+- `MANDATES.md`: standing direction from the owner, including the optional
+  `quota:` line from `docs/autonomy/composition.md`. Re-read before every
+  release; the owner may edit it mid-engagement, and any edit that touches a
+  mandate resets that mandate's push-back count.
+- `BACKLOG.md`: what audits surfaced and nobody took, plus accepted issues
+  with author class, priority, date and skip count. Captains consume and
   append it.
-- `LEDGER.md`: one entry per release plus engagement headers. Append-only.
-- `OWNER_INBOX.md`: push-backs, questions, stop reports. Newest first.
-- `v<version>/`: per-release scratch; give every agent a unique path inside
-  it.
+- `LEDGER.md`: one compact entry per release plus engagement headers.
+  Append-only. Narratives do not belong here.
+- `OWNER_INBOX.md`: push-backs, questions, irreversible-data entries, stop
+  reports. Newest first.
+- `v<version>/`: per-release scratch; every agent gets a unique path inside
+  it, and full reports (the captain's narrative, verifier verdicts, rosters,
+  merge queues) live here, not in your context.
 
 You remember nothing between releases; the disk remembers everything. If the
 state directory contradicts git history, that is a stop condition
@@ -51,12 +58,30 @@ state directory contradicts git history, that is a stop condition
    stops.
 2. Read the policy docs above, `MANDATES.md`, `BACKLOG.md`, the tail of
    `LEDGER.md`, `docs/release-command.md`.
-3. Verify: `main` green on its own CI; no tag build in flight (previous
-   release's `release.yml` and `homebrew.yml` finished); no leftover draft
-   releases or rc tags; which PRs are open (dependabot is left alone).
-4. Append an engagement header to `LEDGER.md`: date, target count, standing
-   instructions, starting version.
-5. Run one issue triage sweep (below) so the first captain's backlog is warm.
+3. Verify per `docs/autonomy/infrastructure.md`: `main` green on its own CI;
+   no tag build in flight (previous release's `release.yml` and
+   `homebrew.yml` finished); no leftover draft releases or rc tags; which
+   PRs are open (dependabot is left alone); and, if anything looks slow,
+   the `Actions` component on githubstatus.com. Do not start into a
+   declared major outage. Clean up leftover rc tags and rc draft
+   pre-releases per `docs/release-command.md`; a leftover non-rc draft
+   release is a stop-and-report. A held class B PR from a prior engagement
+   is adopted, not closed: list it in the next captain's brief, that
+   captain keeps it green, and once the owner has answered it merges first
+   in that release's Phase 6.
+4. Compute mandate push-back counts from the ledger, and mark any mandate at
+   three unanswered push-backs as suspended per
+   `docs/autonomy/composition.md` (inbox entry plus report line) so no
+   captain re-argues it.
+5. Append an engagement header to `LEDGER.md`: date, target count, standing
+   instructions, starting version, quota in effect (the `quota:` line or the
+   default), suspended mandates, and the concurrency mode: probe whether
+   the harness supports background children with completion notifications
+   by spawning one trivial background child and seeing whether the
+   notification arrives (the degraded-mode call in
+   `docs/autonomy/watchdogs.md`); the verdict goes in the header and in
+   every captain's brief.
+6. Run one issue triage sweep (below) so the first captain's backlog is warm.
 
 ## Per release, in order
 
@@ -65,95 +90,120 @@ state directory contradicts git history, that is a stop condition
 2. **Compose the captain's brief** from
    [references/release-captain-prompt.md](references/release-captain-prompt.md):
    fill every `{{placeholder}}` (predecessor state is "none" except on a
-   retry), including what the previous release covered
-   (from the ledger, so it is not repeated) and the focus area chosen per the
-   rotation in `docs/autonomy/release-loop.md` (pick the area least recently
-   visited per the ledger; note it in the brief and the ledger).
-3. **Spawn the release captain** on the reasoning tier,
-   `run_in_background: false`, with the brief. Tell it: its final message is
-   its report, it has no peers, it must not message anyone, it stops at a
-   reviewed draft.
+   retry), including what the previous release covered (from the ledger, so
+   it is not repeated), the focus area chosen per the rotation in
+   `docs/autonomy/release-loop.md` (least recently visited per the ledger),
+   the quota in effect, the issue-share candidates from `BACKLOG.md` (with
+   author class, priority, age, skip count), the concurrency mode from
+   preflight, any adopted held PR, and the suspended mandates so the
+   captain treats them as inert. When you declare a queue-drain batch per
+   `docs/autonomy/composition.md`, say so in the quota placeholder.
+3. **Spawn the release captain** on the reasoning tier with the brief. When
+   the harness supports background tasks with notifications, spawn it in the
+   background and use the waiting time for the triage sweep and the watchdog
+   checks below; otherwise spawn it foreground. Tell it: its final message
+   is its compact report block, its narrative goes to its scratch dir, it
+   has no peers, it must not message anyone, it stops at a reviewed draft.
+   Never start the next release before this one is published or abandoned:
+   releases are serial even when their internals are not.
 4. **Verify the report against the world**, not against itself: the draft
    release exists with all four assets (dmg, app.tar.gz, .sig, latest.json),
    `main` is green at the release SHA, the ledger-relevant claims match `gh`
-   output. Read the release notes against `docs/tone-of-voice.md` and check
-   the unverified calls are named.
+   output, the composition line matches the plan, and any class B hold is
+   real (PR open, verified, unmerged, inbox entry present). Read the release
+   notes against `docs/tone-of-voice.md` and check the unverified calls are
+   named. Open the captain's disk narrative only when a claim fails or the
+   verdict is not `draft-ready`; your context is for decisions.
 5. **Publish**: `gh release edit v<version> --draft=false`, confirm
    `homebrew.yml` fires and succeeds. Publication is yours alone; a captain
    that published on its own is an incident, record it.
-6. **Ledger**: append the captain's report block, plus your own line on
+6. **Ledger**: append the captain's compact block, plus your own line on
    anything you overruled or observed.
 7. **Issue triage sweep** (below), so decisions land while the release is
    fresh and the next backlog is warm.
 8. **Between releases**: re-read `MANDATES.md` and `OWNER_INBOX.md`; the
-   owner may have answered an escalation. Then loop.
+   owner may have answered an escalation, an irreversible-data question, or
+   edited a mandate (which resets its push-back count). Update suspension
+   state, then loop.
 
-If a captain returns `abandoned` or dies (see the watchdog ladder in
+If a captain returns `abandoned` or `merged-partial` (some PRs merged for
+the version but no draft cut) or dies (see the watchdog ladder in
 `docs/autonomy/watchdogs.md`: nudge, replace, drop, stop), one retry with a
 fresh captain, filling the brief's predecessor-state block from the world:
-PRs already merged for this version, PRs open, phase reached, scratch path.
-Two failures on one version, or two failed releases in a row, is a stop
-condition: write the handoff and end the engagement early with an honest
-report.
+PRs already merged for this version, PRs open, phase reached, the roster and
+merge queue in its scratch dir. A retry that fails is a failed release. Two failures on one version, or two failed
+releases in a row, is a stop condition: write the handoff and end the
+engagement early with an honest report.
 
-Distinguish the work failing from the infrastructure failing. When failures
-trace to a provider outage or model rate limits (the same infrastructure
-error across unrelated agents), pause and retry later instead of burning the
-stop budget; note the pause in the ledger. When a release build fails for
-runner or Actions-quota reasons (read the run logs), that is a pause plus an
-owner-inbox entry naming the quota, not a notarization stop. A true
-signing or notarization stop report names the failing step and the
-credential to check first (certificate expiry, app-specific password, team
-membership).
+Distinguish the work failing from the infrastructure failing, per
+`docs/autonomy/infrastructure.md`: outages pause, they never burn the stop
+budget, and a captain in build-ahead mode that reports
+`paused (infrastructure)` left a verified merge queue on disk that the
+resume executes first, before any new audit. A true signing or notarization
+stop report names the failing step and the credential to check first
+(certificate expiry, app-specific password, team membership).
 
-You share one context across the whole engagement. When you feel it nearing
-exhaustion, finish the current release through its publish step, write the
-engagement state to the ledger, and report `stopped-early (context)`: the
-disk is the memory, and a re-invocation of this skill resumes from the
-ledger. Never start a release you cannot see through to publish.
+You share one context across the whole engagement. Reports living on disk is
+what makes five releases fit in it; do not defeat that by reading
+narratives you do not need. When you feel context nearing exhaustion, finish
+the current release through its publish step, write the engagement state to
+the ledger, and report `stopped-early (context)`: the disk is the memory,
+and a re-invocation of this skill resumes from the ledger. Never start a
+release you cannot see through to publish.
 
 ## Issue triage sweep
 
-Spawn an issue triage officer (mid tier), `run_in_background: false`, brief:
-follow `docs/autonomy/issue-triage.md` exactly; sweep every open issue plus
-new comments since the last sweep (timestamp in the ledger header); post
-replies under your own identity with the disclosure line; append accepted
-work to `BACKLOG.md` with issue numbers; escalations to `OWNER_INBOX.md`;
-final message is a compact list of issue -> decision. You spot-check its
-replies against the trust model in `docs/autonomy/safety.md` before counting
-the sweep done. If the harness supports scheduled or background tasks, you
-may additionally schedule a light new-issue check on a ~30 minute cadence;
-never let a scheduled check replace the per-release sweep.
+Spawn an issue triage officer (mid tier), brief: follow
+`docs/autonomy/issue-triage.md` exactly; sweep every open issue plus new
+comments since the last sweep (timestamp in the ledger header); post replies
+under your own identity with the disclosure line; append accepted work to
+`BACKLOG.md` with issue number, author class, priority, date and skip count;
+increment the skip count of accepted items passed over by batches not yet
+swept (keyed on the sweep timestamp in the ledger header, so an engagement
+boundary never double-counts a skip), and say so on their threads;
+escalations to `OWNER_INBOX.md`; final message is a
+compact list of issue -> decision. You spot-check its replies against the
+trust model in `docs/autonomy/safety.md` before counting the sweep done. The
+sweep may run concurrently with a background captain; it touches issues and
+state files, never the release's branches. If the harness supports scheduled
+tasks, you may additionally schedule a light new-issue check on a ~30 minute
+cadence; never let a scheduled check replace the per-release sweep.
 
 ## Watchdogs
 
-Captains watch their own children per `docs/autonomy/watchdogs.md`. You watch
-captains: if the harness runs them foreground, your watch is the retry ladder
-above; if the harness supports background tasks with notifications, check any
-captain silent for 2 hours by inspecting worktrees, branches, PRs and CI
-runs, and apply the ladder. Watchdog reports are one line each in the ledger.
+Captains watch their own children per `docs/autonomy/watchdogs.md`. You
+watch captains: check any captain silent for 2 hours by inspecting
+worktrees, branches, PRs and CI runs, and apply the ladder. When the captain
+runs foreground, your watch is the retry ladder above applied to its return.
+Watchdog reports are one line each in the ledger.
 
 ## Token discipline
 
 Cheapest tier that can do the job, disjoint slices, compact structured
 reports, no speculative reads, no re-reading what a report already
 established. You are the most expensive agent in the system: your context is
-for decisions, not for file contents.
+for decisions, not for file contents, and the batch and tier rules in
+`docs/autonomy/composition.md` and `docs/autonomy/roles.md` are cost
+controls, not ceremony.
 
 ## Report and exit
 
 After the last release (or a stop): remove the engagement lock you wrote
 (never a foreign one found at preflight), delete the
 per-version scratch dirs and builder worktrees of published releases (the
-ledger, mandates, backlog and inbox stay), then append to `LEDGER.md` and
-return exactly one block:
+ledger, mandates, backlog and inbox stay; a paused release's scratch and
+worktrees stay too), then append to `LEDGER.md` and return exactly one
+block:
 
 ```
 ## Engagement <date>: <n> releases
 verdict: completed | stopped-early (<reason>)
 released: v<a>..v<b>, one line per version: theme, PR count, closed-tab
+composition: <issue-backed vs internal across the engagement, against the quota in effect>
 issues: <triaged/answered/accepted counts>
 pushbacks: <PO push-backs and escalations awaiting the owner, or "none">
+suspended-mandates: <mandates that decayed and await the owner, or "none">
+held: <class B data changes awaiting the owner, or "none">
 risks: <what to watch, or "none">
 next: <what the following engagement should take first>
 ```

--- a/.claude/skills/continuous-delivery/SKILL.md
+++ b/.claude/skills/continuous-delivery/SKILL.md
@@ -32,8 +32,7 @@ commit any of it):
 
 - `MANDATES.md`: standing direction from the owner, including the optional
   `quota:` line from `docs/autonomy/composition.md`. Re-read before every
-  release; the owner may edit it mid-engagement, and any edit that touches a
-  mandate resets that mandate's push-back count.
+  release; the owner may edit it mid-engagement.
 - `BACKLOG.md`: what audits surfaced and nobody took, plus accepted issues
   with author class, priority, date and skip count. Captains consume and
   append it.
@@ -53,59 +52,64 @@ state directory contradicts git history, that is a stop condition
 
 1. Take the engagement lock: if `~/.goodboy-autonomous/ENGAGEMENT.lock`
    exists and is younger than 24 hours, another engagement may be live; stop
-   with a one-line report instead of racing it. Otherwise write the lock
-   (date, invoker) and remove it in the report step, including on early
-   stops.
+   with a one-line report instead of racing it. A lock older than 24 hours
+   is stale: replace it with your own and note the replacement in the ledger
+   header. Write the lock (date, invoker) and remove it in the report step,
+   including on early stops.
 2. Read the policy docs above, `MANDATES.md`, `BACKLOG.md`, the tail of
    `LEDGER.md`, `docs/release-command.md`.
-3. Verify per `docs/autonomy/infrastructure.md`: `main` green on its own CI;
-   no tag build in flight (previous release's `release.yml` and
-   `homebrew.yml` finished); no leftover draft releases or rc tags; which
-   PRs are open (dependabot is left alone); and, if anything looks slow,
-   the `Actions` component on githubstatus.com. Do not start into a
-   declared major outage. Clean up leftover rc tags and rc draft
-   pre-releases per `docs/release-command.md`; a leftover non-rc draft
-   release is a stop-and-report. A held class B PR from a prior engagement
-   is adopted, not closed: list it in the next captain's brief, that
-   captain keeps it green, and once the owner has answered it merges first
-   in that release's Phase 6.
-4. Compute mandate push-back counts from the ledger, and mark any mandate at
+3. **Verify the world** per `docs/autonomy/infrastructure.md`: `main` green
+   on its own CI; no tag build in flight (previous release's `release.yml`
+   and `homebrew.yml` finished); which PRs are open (dependabot is left
+   alone); and, if anything looks slow, the `Actions` component on
+   githubstatus.com. Do not start into a declared major outage.
+4. **Clean up** leftover rc tags and rc draft pre-releases per
+   `docs/release-command.md`. A leftover non-rc draft release is a
+   stop-and-report.
+5. **Adopt held PRs**: a held class B PR from a prior engagement is adopted,
+   not closed. List it in the next captain's brief; that captain keeps it
+   green, and once the owner has answered it merges first in that release's
+   Phase 6.
+6. Compute mandate push-back counts from the ledger, and mark any mandate at
    three unanswered push-backs as suspended per
    `docs/autonomy/composition.md` (inbox entry plus report line) so no
    captain re-argues it.
-5. Append an engagement header to `LEDGER.md`: date, target count, standing
-   instructions, starting version, quota in effect (the `quota:` line or the
-   default), suspended mandates, and the concurrency mode: probe whether
-   the harness supports background children with completion notifications
-   by spawning one trivial background child and seeing whether the
-   notification arrives (the degraded-mode call in
-   `docs/autonomy/watchdogs.md`); the verdict goes in the header and in
-   every captain's brief.
-6. Run one issue triage sweep (below) so the first captain's backlog is warm.
+7. Decide the concurrency mode with the degraded-mode probe in
+   `docs/autonomy/watchdogs.md`: spawn one trivial background child and see
+   whether its completion notification arrives. Then append an engagement
+   header to `LEDGER.md`: date, target count, standing instructions,
+   starting version, quota in effect (the `quota:` line or the default),
+   suspended mandates, and the concurrency mode. The mode also goes in every
+   captain's brief.
+8. Run one issue triage sweep (below) so the first captain's backlog is warm.
 
 ## Per release, in order
 
 1. **Compute the version**: current latest plus a patch bump unless a mandate
    says otherwise.
 2. **Compose the captain's brief** from
-   [references/release-captain-prompt.md](references/release-captain-prompt.md):
-   fill every `{{placeholder}}` (predecessor state is "none" except on a
-   retry), including what the previous release covered (from the ledger, so
-   it is not repeated), the focus area chosen per the rotation in
-   `docs/autonomy/release-loop.md` (least recently visited per the ledger),
-   the quota in effect, the issue-share candidates from `BACKLOG.md` (with
-   author class, priority, age, skip count), the concurrency mode from
-   preflight, any adopted held PR, and the suspended mandates so the
-   captain treats them as inert. When you declare a queue-drain batch per
-   `docs/autonomy/composition.md`, say so in the quota placeholder.
+   [references/release-captain-prompt.md](references/release-captain-prompt.md).
+   Fill every `{{placeholder}}`:
+   - what the previous release covered, from the ledger, so it is not
+     repeated;
+   - the focus area, per the rotation in `docs/autonomy/release-loop.md`,
+     least recently visited per the ledger;
+   - the quota in effect, saying so there when you declare a queue-drain
+     batch per `docs/autonomy/composition.md`;
+   - the issue-share candidates from `BACKLOG.md`, with author class,
+     priority, age and skip count;
+   - the concurrency mode from preflight;
+   - any adopted held PR;
+   - the suspended mandates, so the captain treats them as inert;
+   - predecessor state, which is "none" except on a retry or a resume.
 3. **Spawn the release captain** on the reasoning tier with the brief. When
    the harness supports background tasks with notifications, spawn it in the
    background and use the waiting time for the triage sweep and the watchdog
    checks below; otherwise spawn it foreground. Tell it: its final message
    is its compact report block, its narrative goes to its scratch dir, it
    has no peers, it must not message anyone, it stops at a reviewed draft.
-   Never start the next release before this one is published or abandoned:
-   releases are serial even when their internals are not.
+   Never start the next release before this one is published, paused or
+   abandoned: releases are serial even when their internals are not.
 4. **Verify the report against the world**, not against itself: the draft
    release exists with all four assets (dmg, app.tar.gz, .sig, latest.json),
    `main` is green at the release SHA, the ledger-relevant claims match `gh`
@@ -113,7 +117,7 @@ state directory contradicts git history, that is a stop condition
    real (PR open, verified, unmerged, inbox entry present). Read the release
    notes against `docs/tone-of-voice.md` and check the unverified calls are
    named. Open the captain's disk narrative only when a claim fails or the
-   verdict is not `draft-ready`; your context is for decisions.
+   verdict is not `draft-ready`.
 5. **Publish**: `gh release edit v<version> --draft=false`, confirm
    `homebrew.yml` fires and succeeds. Publication is yours alone; a captain
    that published on its own is an incident, record it.
@@ -124,48 +128,57 @@ state directory contradicts git history, that is a stop condition
 8. **Between releases**: re-read `MANDATES.md` and `OWNER_INBOX.md`; the
    owner may have answered an escalation, an irreversible-data question, or
    edited a mandate (which resets its push-back count). Update suspension
-   state, then loop.
+   state, re-run the world check from preflight step 3, then loop.
 
 If a captain returns `abandoned` or `merged-partial` (some PRs merged for
 the version but no draft cut) or dies (see the watchdog ladder in
 `docs/autonomy/watchdogs.md`: nudge, replace, drop, stop), one retry with a
 fresh captain, filling the brief's predecessor-state block from the world:
 PRs already merged for this version, PRs open, phase reached, the roster and
-merge queue in its scratch dir. A retry that fails is a failed release. Two failures on one version, or two failed
-releases in a row, is a stop condition: write the handoff and end the
-engagement early with an honest report.
+merge queue in its scratch dir. A retry that fails is a failed release, and
+the stop conditions in `docs/autonomy/safety.md` take it from there: write
+the handoff and end the engagement early with an honest report.
 
 Distinguish the work failing from the infrastructure failing, per
 `docs/autonomy/infrastructure.md`: outages pause, they never burn the stop
-budget, and a captain in build-ahead mode that reports
-`paused (infrastructure)` left a verified merge queue on disk that the
-resume executes first, before any new audit. A true signing or notarization
-stop report names the failing step and the credential to check first
-(certificate expiry, app-specific password, team membership).
+budget. A true signing or notarization stop report names the failing step
+and the credential to check first (certificate expiry, app-specific
+password, team membership).
 
-You share one context across the whole engagement. Reports living on disk is
-what makes five releases fit in it; do not defeat that by reading
-narratives you do not need. When you feel context nearing exhaustion, finish
-the current release through its publish step, write the engagement state to
-the ledger, and report `stopped-early (context)`: the disk is the memory,
-and a re-invocation of this skill resumes from the ledger. Never start a
-release you cannot see through to publish.
+On `paused (infrastructure)` the captain left a verified merge queue on
+disk. Re-check the outage at each boundary; when it clears, spawn a fresh
+captain with the predecessor-state block filled, and that queue executes
+first, before any new audit. A resume is not a retry and burns no failure
+budget. A pause that outlasts the engagement's remaining budget ends the
+engagement as `stopped-early (infrastructure)`, with the queue's location in
+the handoff.
+
+You share one context across the whole engagement. When you feel it nearing
+exhaustion, finish the current release through its publish step, write the
+engagement state to the ledger, and report `stopped-early (context)`: the
+disk is the memory, and a re-invocation of this skill resumes from the
+ledger. Never start a release you cannot see through to publish.
 
 ## Issue triage sweep
 
 Spawn an issue triage officer (mid tier), brief: follow
 `docs/autonomy/issue-triage.md` exactly; sweep every open issue plus new
 comments since the last sweep (timestamp in the ledger header); post replies
-under your own identity with the disclosure line; append accepted work to
-`BACKLOG.md` with issue number, author class, priority, date and skip count;
-increment the skip count of accepted items passed over by batches not yet
-swept (keyed on the sweep timestamp in the ledger header, so an engagement
-boundary never double-counts a skip), and say so on their threads;
-escalations to `OWNER_INBOX.md`; final message is a
-compact list of issue -> decision. You spot-check its replies against the
+under your own identity with the disclosure line; carry accepted work into
+`BACKLOG.md` with issue number, author class, priority, date and skip count,
+by the writer rule below; increment the skip count of accepted items passed
+over by batches not yet swept (keyed on the sweep timestamp in the ledger
+header, so an engagement boundary never double-counts a skip), and say so on
+their threads; escalations to `OWNER_INBOX.md`; final message is a
+compact list of issue -> decision plus the backlog mutations it made or is
+handing back. You spot-check its replies against the
 trust model in `docs/autonomy/safety.md` before counting the sweep done. The
 sweep may run concurrently with a background captain; it touches issues and
-state files, never the release's branches. If the harness supports scheduled
+state files, never the release's branches. While a captain is live the sweep
+never edits `BACKLOG.md` itself: it returns its backlog mutations (accepted
+items, skip increments) in its report and you apply them once the captain's
+report lands, so the file has one writer per window. It edits the file
+directly only when no captain is running. If the harness supports scheduled
 tasks, you may additionally schedule a light new-issue check on a ~30 minute
 cadence; never let a scheduled check replace the per-release sweep.
 

--- a/.claude/skills/continuous-delivery/references/release-captain-prompt.md
+++ b/.claude/skills/continuous-delivery/references/release-captain-prompt.md
@@ -67,13 +67,12 @@ reading it.
 Run the seven phases of `docs/autonomy/release-loop.md`, with these
 operational specifics:
 
-- **Phase 1, archaeology**: 3 to 5 cheap agents spawned in one message as a
-  concurrent batch under the roster contract in
-  `docs/autonomy/watchdogs.md`, disjoint slices, compact structured lists.
-  Audit from a detached worktree pinned at `origin/main`. Feed them
-  `docs/file-system.md`. They report, fix nothing, never touch git.
-- **Phase 2, product decision**: one agent on the strongest reasoning tier,
-  effort high, with the merged audit, the mandates, VISION and the backlog.
+- **Phase 1, archaeology**: cheap agents per release-loop.md Phase 1,
+  spawned in one message as a concurrent batch under the roster contract in
+  `docs/autonomy/watchdogs.md`. Feed them `docs/file-system.md`. They
+  report, fix nothing, never touch git.
+- **Phase 2, product decision**: one agent on the reasoning tier, effort
+  high, with the merged audit, the mandates, VISION and the backlog.
   It composes the batch to the quota above, tags every item with
   provenance, author class and data class, and declares any deviation. It
   has the explicit right of push-back defined in safety.md: an item that
@@ -92,43 +91,42 @@ operational specifics:
 - **Phase 4, build**: one item = one agent = one branch
   (`ak/<type>-<kebab-desc>`, never a worktree codename) = one PR. Each
   builder gets its own fresh worktree under `.claude/worktrees/`, cut from
-  `origin/main`, never from a sibling's branch: no stacked PRs, ever.
-  Footprint-disjoint items spawn as one concurrent batch, at most three at
-  once (four only when the items are docs- or UI-light); overlapping items
-  collapse or serialize per release-loop.md. Mid tier for mechanical or
-  localized work, strong tier for cross-cutting, state-machine, migration,
-  protocol, OAuth, or Rust work. Every builder brief carries: the item's
-  footprint and the stop-and-report rule on leaving it; the heartbeat
-  journal duty from watchdogs.md; commit before any sabotage or risky
-  operation; and the house rules: zero code comments, no em-dashes, English
-  only, `type` never `interface`, arrow exports, one object param, guard
-  clauses, `satisfies` over `as`, store changes as slice packages, hooks as
-  `useFoo/index.ts`, no `--no-verify`, never touch local `main`, and never
-  quote or reference the state directory, the mandates or the owner inbox
-  in code, commits or PR bodies. Update
-  README, docs and website in the PR that makes them wrong (`website/`
-  installs with `pnpm install --ignore-workspace`, scope `repo`).
+  `origin/main`. Footprint-disjoint items spawn as one concurrent batch;
+  the concurrency cap, the stacking ban and the rule for overlapping items
+  are release-loop.md Phase 4 and are not yours to relax. Mid tier for
+  mechanical or localized work, strong tier for cross-cutting,
+  state-machine, migration, protocol, OAuth, or Rust work. Every builder
+  brief carries: the item's footprint and the stop-and-report rule on
+  leaving it; the heartbeat journal duty from watchdogs.md; commit before
+  any risky operation; and the house rules: zero code comments, no
+  em-dashes, English only, `type` never `interface`, arrow exports, one
+  object param, guard clauses, `satisfies` over `as`, store changes as slice
+  packages, hooks as `useFoo/index.ts`, no `--no-verify`, never touch local
+  `main`, and never quote or reference the state directory, the mandates or
+  the owner inbox in code, commits or PR bodies. Update README, docs and
+  website in the PR that makes them wrong (`website/` installs with
+  `pnpm install --ignore-workspace`, scope `repo`).
 - **Phase 5, verify**: a different agent per PR, spawned as each build
   lands, in its own worktree checked out at the PR branch (never the
   builder's), running the full standard in release-loop.md, sabotage table
-  included. A migration-touching PR gets a second verifier running the data
-  playbook. A verifier's verdict outranks the builder and CI; full verdicts
-  go to its scratch path, you read the verdict line and the exceptions.
-- **Phase 6, merge**: serialized, server-side, and serial no matter how
-  parallel the builds were. `gh pr merge --squash` for
-  single-concern PRs; a multi-commit PR whose commits matter individually
-  merges per CONVENTIONS.md. Re-fetch `origin/main` before each merge (a
-  human or dependabot may have landed something), then poll `main`'s own CI
-  green (foreground until-loop, 60-120s) before the next merge. When the
-  just-merged PR and the next one touch the same package, refresh the next
-  branch with `git merge origin/main` and let its CI re-run first. Never
-  advance local `main`; `git fetch origin main` for SHAs. A PR red after two
-  honest repairs is closed and reported as dropped. A CI failure unrelated
-  to the diff gets one re-run; the same test failing twice is red, not
-  flake; before blaming any diff, check the outage signals in
-  `docs/autonomy/infrastructure.md`, and when merging is blocked by an
+  included, committing the checked-out state before it sabotages anything.
+  A PR touching schema or stored data gets a second verifier running the
+  data playbook. A verifier's verdict outranks the builder and CI; full
+  verdicts go to its scratch path, you read the verdict line and the
+  exceptions.
+- **Phase 6, merge**: the merge discipline is release-loop.md Phase 6 and
+  stays serial no matter how parallel the builds were. Squash-merge
+  single-concern PRs; a multi-commit PR whose commits matter
+  individually merges per CONVENTIONS.md. Re-fetch `origin/main` before each
+  merge (a human or dependabot may have landed something), and poll `main`'s
+  own CI green in a foreground until-loop on a 60-120s interval before the
+  next merge. Never advance local `main`; `git fetch origin main` for SHAs.
+  A CI failure unrelated to the diff gets one re-run; the same test failing
+  twice is red, not flake; before blaming any diff, check the outage signals
+  in `docs/autonomy/infrastructure.md`, and when merging is blocked by an
   outage, switch to build-ahead mode from that file instead of idling. A
-  class B item with no owner answer stays unmerged and is reported as held.
+  class B item the owner has not answered stays unmerged and is reported as
+  held.
 - **Phase 7, cut**: hand the draft notes to the challenger for review
   first, then follow `docs/release-command.md` up to and including the
   draft, with the rc dry-run and notarization check (team M3R9H4QX65; any
@@ -190,5 +188,9 @@ next: <one line for the next captain>
 `merged-partial` means some PRs merged for this version but no draft could
 be cut and you cannot honestly continue; your caller retries the version
 with a fresh captain resuming from your scratch dir.
+`paused (infrastructure)` means the work is sound and the world is not: an
+outage you verified per `docs/autonomy/infrastructure.md` outlasted the
+useful local work, and you left a merge queue on disk for the resume. A
+pause is not a failure and your caller does not count it as one.
 
 No progress narration, no questions. One report, at the end.

--- a/.claude/skills/continuous-delivery/references/release-captain-prompt.md
+++ b/.claude/skills/continuous-delivery/references/release-captain-prompt.md
@@ -1,7 +1,7 @@
 # Release captain brief (template)
 
 The delivery lead fills every `{{placeholder}}` and hands the whole thing to
-one agent on the reasoning tier, `run_in_background: false`.
+one agent on the reasoning tier.
 
 ---
 
@@ -16,11 +16,15 @@ report, move.
 
 Working root: `{{repo_root}}`. Your scratch dir:
 `~/.goodboy-autonomous/v{{version}}/`. Give every agent you spawn a unique
-path inside it.
+path inside it. Your full narrative (decisions, evidence, verifier verdicts,
+the roster, the merge queue) lives there; your final message is only the
+compact block below.
 
 **Read first, in full**: `AGENTS.md`, `CONVENTIONS.md`, `VISION.md`,
-`DESIGN.md`, `AUTONOMY.md`, `docs/autonomy/release-loop.md`,
-`docs/autonomy/safety.md`, `docs/autonomy/watchdogs.md`,
+`DESIGN.md`, `AUTONOMY.md`, `docs/autonomy/roles.md`,
+`docs/autonomy/composition.md`,
+`docs/autonomy/release-loop.md`, `docs/autonomy/safety.md`,
+`docs/autonomy/watchdogs.md`, `docs/autonomy/infrastructure.md`,
 `docs/release-command.md`, `~/.goodboy-autonomous/MANDATES.md`,
 `~/.goodboy-autonomous/BACKLOG.md`, and the repo gotchas file the skill ships
 (`.claude/skills/continuous-delivery/references/repo-gotchas.md`). Read
@@ -34,59 +38,99 @@ path inside it.
 elsewhere.
 
 **Standing mandates**: whatever `MANDATES.md` says binds you. Current
-extract, as constraints not inputs: {{mandate_extract}}.
+extract, as constraints not inputs: {{mandate_extract}}. Suspended mandates,
+inert until the owner answers, never re-argued: {{suspended_mandates}}.
 
-**Backlog items with issue provenance**: take or explicitly decline the ones
-tagged for this cycle: {{issue_backed_items}}.
+**Composition**: the quota in effect is {{quota}} (see
+`docs/autonomy/composition.md` for the ordering, the aging promotion and
+the declared-deviation rules). Issue-share candidates, with author class,
+priority, age and skip count: {{issue_candidates}}. Take or explicitly
+decline each candidate listed.
 
-**Predecessor state** (only when a previous captain died on this version):
-{{predecessor_state}}. When present: PRs it already merged are on `main` and
-in scope for the notes, resume from the phase it reached instead of
-re-planning a different theme, and reuse its scratch dir after reading it.
+**Concurrency mode**: {{concurrency_mode}}, from the lead's preflight probe
+per `docs/autonomy/watchdogs.md`; degraded means every child spawns
+foreground, one at a time.
+
+**Adopted held PRs** (class B changes a prior release built and held):
+{{held_prs}}. Keep each one green; one the owner has answered merges first
+in Phase 6; the rest stay held and are reported as such.
+
+**Predecessor state** (only when a previous captain died on or paused this
+version): {{predecessor_state}}. When present: PRs it already merged are on
+`main` and in scope for the notes, a verified merge queue in its scratch dir
+is executed before any new planning, resume from the phase it reached
+instead of re-planning a different theme, and reuse its scratch dir after
+reading it.
 
 ## Process
 
 Run the seven phases of `docs/autonomy/release-loop.md`, with these
 operational specifics:
 
-- **Phase 1, archaeology**: 3 to 5 cheap agents in one message, foreground,
-  disjoint slices, compact structured lists. Audit from a detached worktree
-  pinned at `origin/main`. Feed them `docs/file-system.md`. They report, fix
-  nothing, never touch git.
+- **Phase 1, archaeology**: 3 to 5 cheap agents spawned in one message as a
+  concurrent batch under the roster contract in
+  `docs/autonomy/watchdogs.md`, disjoint slices, compact structured lists.
+  Audit from a detached worktree pinned at `origin/main`. Feed them
+  `docs/file-system.md`. They report, fix nothing, never touch git.
 - **Phase 2, product decision**: one agent on the strongest reasoning tier,
   effort high, with the merged audit, the mandates, VISION and the backlog.
-  It has the explicit right of push-back defined in safety.md: an item that
+  It composes the batch to the quota above, tags every item with
+  provenance, author class and data class, and declares any deviation. It
+  has the explicit right of push-back defined in safety.md: an item that
   does not move anything for a real user gets rejected in writing, mandates
   included; rejected mandate items go to `OWNER_INBOX.md` and your report,
   and the release proceeds smaller. Then hand the plan cold to a second
-  reasoning-tier **challenger** with no shared context; reconcile, and
+  reasoning-tier **challenger** with no shared context; an item tagged
+  irreversible gets its schema design challenged on its own. Reconcile, and
   re-read the result against the mandates, not only against the objections.
-- **Phase 3, scouts**: cheap, against the real code. Feed contradictions back
-  to the product owner at most twice, then take its last answer.
+  **Before any builder spawns**, write the owner-inbox entry for every
+  class A or B item per the gate in safety.md.
+- **Phase 3, scouts**: cheap, one concurrent batch, against the real code.
+  Each returns its item's predicted file footprint including shared
+  hotspots. Feed contradictions back to the product owner at most twice,
+  then take its last answer.
 - **Phase 4, build**: one item = one agent = one branch
   (`ak/<type>-<kebab-desc>`, never a worktree codename) = one PR. Each
-  builder gets its own worktree under `.claude/worktrees/`. Mid tier for
-  mechanical or localized work, strong tier for cross-cutting, state-machine,
-  migration, protocol, OAuth, or Rust work. House rules in every brief: zero
-  code comments, no em-dashes, English only, `type` never `interface`, arrow
-  exports, one object param, guard clauses, `satisfies` over `as`, store
-  changes as slice packages, hooks as `useFoo/index.ts`, no `--no-verify`,
-  never touch local `main`. Update README, docs and website in the PR that
-  makes them wrong (`website/` installs with `pnpm install
---ignore-workspace`, scope `repo`).
-- **Phase 5, verify**: a different agent per PR, running the full standard in
-  release-loop.md, sabotage included. Its verdict outranks the builder and
-  CI.
-- **Phase 6, merge**: serialized, server-side. `gh pr merge --squash` for
+  builder gets its own fresh worktree under `.claude/worktrees/`, cut from
+  `origin/main`, never from a sibling's branch: no stacked PRs, ever.
+  Footprint-disjoint items spawn as one concurrent batch, at most three at
+  once (four only when the items are docs- or UI-light); overlapping items
+  collapse or serialize per release-loop.md. Mid tier for mechanical or
+  localized work, strong tier for cross-cutting, state-machine, migration,
+  protocol, OAuth, or Rust work. Every builder brief carries: the item's
+  footprint and the stop-and-report rule on leaving it; the heartbeat
+  journal duty from watchdogs.md; commit before any sabotage or risky
+  operation; and the house rules: zero code comments, no em-dashes, English
+  only, `type` never `interface`, arrow exports, one object param, guard
+  clauses, `satisfies` over `as`, store changes as slice packages, hooks as
+  `useFoo/index.ts`, no `--no-verify`, never touch local `main`, and never
+  quote or reference the state directory, the mandates or the owner inbox
+  in code, commits or PR bodies. Update
+  README, docs and website in the PR that makes them wrong (`website/`
+  installs with `pnpm install --ignore-workspace`, scope `repo`).
+- **Phase 5, verify**: a different agent per PR, spawned as each build
+  lands, in its own worktree checked out at the PR branch (never the
+  builder's), running the full standard in release-loop.md, sabotage table
+  included. A migration-touching PR gets a second verifier running the data
+  playbook. A verifier's verdict outranks the builder and CI; full verdicts
+  go to its scratch path, you read the verdict line and the exceptions.
+- **Phase 6, merge**: serialized, server-side, and serial no matter how
+  parallel the builds were. `gh pr merge --squash` for
   single-concern PRs; a multi-commit PR whose commits matter individually
   merges per CONVENTIONS.md. Re-fetch `origin/main` before each merge (a
   human or dependabot may have landed something), then poll `main`'s own CI
-  green (foreground until-loop, 60-120s) before the next merge. Never
+  green (foreground until-loop, 60-120s) before the next merge. When the
+  just-merged PR and the next one touch the same package, refresh the next
+  branch with `git merge origin/main` and let its CI re-run first. Never
   advance local `main`; `git fetch origin main` for SHAs. A PR red after two
   honest repairs is closed and reported as dropped. A CI failure unrelated
   to the diff gets one re-run; the same test failing twice is red, not
-  flake.
-- **Phase 7, cut**: follow `docs/release-command.md` up to and including the
+  flake; before blaming any diff, check the outage signals in
+  `docs/autonomy/infrastructure.md`, and when merging is blocked by an
+  outage, switch to build-ahead mode from that file instead of idling. A
+  class B item with no owner answer stays unmerged and is reported as held.
+- **Phase 7, cut**: hand the draft notes to the challenger for review
+  first, then follow `docs/release-command.md` up to and including the
   draft, with the rc dry-run and notarization check (team M3R9H4QX65; any
   other team fails the check). Immediately before tagging, re-check
   `gh release list`: if v{{version}} or later already exists, a human
@@ -99,29 +143,39 @@ operational specifics:
   follow-up, never as a confession. Your report to the caller stays flat and
   unvarnished.
 
-**Watchdog duty**: every ~30 minutes of a running phase, spawn the cheap
-sibling-checker from `docs/autonomy/watchdogs.md` and act on its report.
+**Watchdog duty**: every ~30 minutes while children run, spawn the cheap
+sibling-checker from `docs/autonomy/watchdogs.md` against your roster and
+act on its report.
 
-**Every agent you spawn**: `run_in_background: false`; its final message is
-its report; it has no peers; it must not message anyone; unique scratch path.
+**Every agent you spawn**: unique scratch path; its final message is a
+compact report, its narrative stays on disk; it has no peers; it must not
+message anyone. Concurrent children follow the roster contract in
+`docs/autonomy/watchdogs.md` (roster before spawning, heartbeat journals,
+first-activity check, never proceed past an unresolved entry); where the
+harness cannot notify on background completion, spawn foreground one at a
+time instead.
 
 **Not authorized**: publishing, force-push, pushing to `main`, bypassing
 hooks, deleting a published release, touching signing secrets, telemetry of
-any kind, leaving `main` red, guessing at unidentifiable vendors.
+any kind, leaving `main` red, merging a class B data change without an owner
+answer, merging without an observable required check, guessing at
+unidentifiable vendors.
 
 ## Report and exit
 
 Update `BACKLOG.md` (remove what you took, add what you surfaced and left)
-and append to nothing else; the ledger is your caller's to write. Return
-only:
+and append to no state file except `BACKLOG.md` and `OWNER_INBOX.md`; the
+ledger is your caller's to write. Return only:
 
 ```
 ## v{{version}}: <theme in six words>
-verdict: draft-ready | merged-partial | abandoned
+verdict: draft-ready | merged-partial | paused (infrastructure) | abandoned
 focus-area: <area>: <what the dig found, one line>
 pick: <headline choice and why, two lines>       (when the theme was yours to pick)
 proposed: <n items in the plan after the challenge>
+composition: <issue-backed/internal against the quota, deviations declared>
 prs: #NNNN <title>   (one line each, merged only)
+held: #NNNN <class B change awaiting the owner>  (omit if none)
 dropped: <item>: <why>                          (omit if none)
 pushback: <what the PO refused and why>          (omit if none)
 changed: <3-6 lines, what a user would notice>
@@ -132,5 +186,9 @@ draft: <state of the draft release and its assets>
 risk: <what you would watch, or "none">
 next: <one line for the next captain>
 ```
+
+`merged-partial` means some PRs merged for this version but no draft could
+be cut and you cannot honestly continue; your caller retries the version
+with a fresh captain resuming from your scratch dir.
 
 No progress narration, no questions. One report, at the end.

--- a/.claude/skills/continuous-delivery/references/repo-gotchas.md
+++ b/.claude/skills/continuous-delivery/references/repo-gotchas.md
@@ -46,6 +46,17 @@ done` works; nested-quote jq inside single quotes does not.
 - commitlint rejects camelCase identifiers in the commit subject: plain
   lowercase prose in the subject, identifiers in the body. Subjects over 72
   chars do not land.
+- A stacked PR whose parent is squash-merged does NOT auto-retarget: it
+  keeps pointing at the dead branch, and once retargeted to `main` it can go
+  `CONFLICTING` (a modify/delete needing hand resolution). Stacking is
+  banned by release-loop.md; if you inherit one, retarget it BEFORE merging
+  it and expect one conflict per squashed parent.
+- Neither `ci.yml` nor `rust.yml` has a `workflow_dispatch` trigger. When
+  webhooks are throttled or a run was never dispatched, the only way to
+  summon one for an open PR is closing and reopening it.
+- Turbo caches are shared across worktrees: a `FULL TURBO` green can be a
+  sibling's replayed log, not a run. `pnpm exec turbo run test --force` and
+  a log saying `0 cached` is what a verifier's green claim rests on.
 
 ## Git hygiene
 

--- a/.claude/skills/continuous-delivery/references/repo-gotchas.md
+++ b/.claude/skills/continuous-delivery/references/repo-gotchas.md
@@ -46,14 +46,16 @@ done` works; nested-quote jq inside single quotes does not.
 - commitlint rejects camelCase identifiers in the commit subject: plain
   lowercase prose in the subject, identifiers in the body. Subjects over 72
   chars do not land.
-- A stacked PR whose parent is squash-merged does NOT auto-retarget: it
+- A stacked PR whose parent is squash-merged does **not** auto-retarget: it
   keeps pointing at the dead branch, and once retargeted to `main` it can go
   `CONFLICTING` (a modify/delete needing hand resolution). Stacking is
-  banned by release-loop.md; if you inherit one, retarget it BEFORE merging
-  it and expect one conflict per squashed parent.
+  banned by release-loop.md; if you inherit one, retarget it **before**
+  merging it and expect one conflict per squashed parent.
 - Neither `ci.yml` nor `rust.yml` has a `workflow_dispatch` trigger. When
   webhooks are throttled or a run was never dispatched, the only way to
-  summon one for an open PR is closing and reopening it.
+  summon one for an open PR is closing and reopening it. Adding the trigger
+  is a one-line `ci`-scoped change worth proposing as backlog work; until it
+  lands, close and reopen is the only lever.
 - Turbo caches are shared across worktrees: a `FULL TURBO` green can be a
   sibling's replayed log, not a run. `pnpm exec turbo run test --force` and
   a log saying `0 cached` is what a verifier's green claim rests on.

--- a/AUTONOMY.md
+++ b/AUTONOMY.md
@@ -5,9 +5,11 @@ an autonomous delivery organization made of agents; a human reviews after, not
 before. This hub holds the model and the floor. The deep dives live in the
 [autonomy cluster](./docs/autonomy.md): [roles](./docs/autonomy/roles.md),
 [safety](./docs/autonomy/safety.md),
+[composition](./docs/autonomy/composition.md),
 [release loop](./docs/autonomy/release-loop.md),
 [issue triage](./docs/autonomy/issue-triage.md),
-[watchdogs](./docs/autonomy/watchdogs.md).
+[watchdogs](./docs/autonomy/watchdogs.md),
+[infrastructure](./docs/autonomy/infrastructure.md).
 
 ## Control lives in the documentation
 
@@ -28,18 +30,29 @@ Same queue, weighed by the [trust model](./docs/autonomy/safety.md).
 - A **delivery lead** runs an engagement of up to five releases: spawns one
   **release captain** per version, reviews and publishes each draft, keeps
   the ledger, runs the issue loop, watches for stalls. It never reads or
-  writes code.
+  writes code, and it reads verdicts and exceptions from disk, not
+  narratives.
 - A **release captain** owns one version through seven phases (audit, product
   decision, scouting, build, verify, serialized merge, draft), then dies.
   State survives on disk, not in agents.
-- A **product owner** on the strongest reasoning tier decides each release
-  and holds the right of push-back: work ships because it moves something for
-  a real user, never because it is possible. A **challenger** attacks every
-  plan cold, because one strong opinion is not a review.
+- A **product owner** on the strongest reasoning tier composes each release's
+  **batch** per [composition](./docs/autonomy/composition.md): by default
+  60% issue-backed and 40% internal work, owner-tunable in one line, with
+  authors weighed and contributors floored. It holds the right of push-back:
+  work ships because it moves something for a real user, never because it is
+  possible. A **challenger** assumes every plan is bad and attacks it cold,
+  because one strong opinion is not a review.
+- **Builds run concurrently when items share no files; merges never do.**
+  One PR merges, `main`'s own CI goes green, the next merges. The serial
+  merge lane pays for the parallel build lanes.
 - Nothing merges on its author's word: every PR is verified by a **different
-  agent** whose verdict outranks the builder's report and green CI.
+  agent** whose verdict outranks the builder's report and green CI. An
+  irreversible data change gets a second verifier, an owner question before
+  the build, and never merges on silence
+  ([safety](./docs/autonomy/safety.md)).
 - Every open issue gets a decision and a reply every cycle. No issue goes
-  dark.
+  dark, and a mandate nobody answers suspends itself loudly after three
+  written push-backs instead of being re-argued forever.
 
 ## The floor
 
@@ -60,13 +73,16 @@ everything else:
 
 Agents remember nothing between releases; the disk remembers everything.
 State lives outside the repo in `~/.goodboy-autonomous/`: `MANDATES.md`
-(standing direction from the owner), `BACKLOG.md` (what audits surfaced and
-nobody took yet), `LEDGER.md` (one entry per release:
-theme, PRs, verdict, risks), `OWNER_INBOX.md` (push-backs, questions, stop
+(standing direction from the owner, including the composition quota),
+`BACKLOG.md` (what audits surfaced and
+nobody took yet), `LEDGER.md` (one compact entry per release:
+theme, PRs, composition, verdict, risks; full narratives stay in the
+per-release scratch dirs), `OWNER_INBOX.md` (push-backs, questions, stop
 reports). The ledger doubles as the metric: items proposed versus shipped
 versus dropped per cycle (the captain's report records all three) is how the
 loop earns more frequency, per release and over time. The ratio is always
-read alongside `closed-tab`, the value actually shipped: inflating PR counts,
+read alongside `closed-tab` (the reason to open another tool that the
+release removed), the value actually shipped: inflating PR counts,
 splitting one feature into many PRs, or sandbagging proposals to look
 reliable is exactly the failure this metric exists to catch, not a way to
 score on it.

--- a/AUTONOMY.md
+++ b/AUTONOMY.md
@@ -35,7 +35,7 @@ Same queue, weighed by the [trust model](./docs/autonomy/safety.md).
 - A **release captain** owns one version through seven phases (audit, product
   decision, scouting, build, verify, serialized merge, draft), then dies.
   State survives on disk, not in agents.
-- A **product owner** on the strongest reasoning tier composes each release's
+- A **product owner** on the reasoning tier composes each release's
   **batch** per [composition](./docs/autonomy/composition.md): by default
   60% issue-backed and 40% internal work, owner-tunable in one line, with
   authors weighed and contributors floored. It holds the right of push-back:
@@ -46,9 +46,9 @@ Same queue, weighed by the [trust model](./docs/autonomy/safety.md).
   One PR merges, `main`'s own CI goes green, the next merges. The serial
   merge lane pays for the parallel build lanes.
 - Nothing merges on its author's word: every PR is verified by a **different
-  agent** whose verdict outranks the builder's report and green CI. An
-  irreversible data change gets a second verifier, an owner question before
-  the build, and never merges on silence
+  agent** whose verdict outranks the builder's report and green CI. A change
+  touching schema or stored data gets a second verifier and an owner
+  question before the build; the irreversible kind never merges on silence
   ([safety](./docs/autonomy/safety.md)).
 - Every open issue gets a decision and a reply every cycle. No issue goes
   dark, and a mandate nobody answers suspends itself loudly after three
@@ -81,8 +81,8 @@ per-release scratch dirs), `OWNER_INBOX.md` (push-backs, questions, stop
 reports). The ledger doubles as the metric: items proposed versus shipped
 versus dropped per cycle (the captain's report records all three) is how the
 loop earns more frequency, per release and over time. The ratio is always
-read alongside `closed-tab` (the reason to open another tool that the
-release removed), the value actually shipped: inflating PR counts,
+read alongside `closed-tab`, the reason to open another tool that the
+release removed: that is the value actually shipped. Inflating PR counts,
 splitting one feature into many PRs, or sandbagging proposals to look
 reliable is exactly the failure this metric exists to catch, not a way to
 score on it.

--- a/docs/autonomy.md
+++ b/docs/autonomy.md
@@ -6,10 +6,18 @@ read it first for the model and the floor. One line per file:
 - [autonomy/roles.md](./autonomy/roles.md): the role charter of the delivery
   organization, model tiers, and the rules that bind every role.
 - [autonomy/safety.md](./autonomy/safety.md): authorized and forbidden
-  actions, the trust model, push-back, stop conditions, escalation.
+  actions, the trust model, push-back, the irreversible-data gate, stop
+  conditions, escalation.
+- [autonomy/composition.md](./autonomy/composition.md): the batch, the
+  issue/internal quota, author weighting, the contributor floor, mandate
+  decay.
 - [autonomy/release-loop.md](./autonomy/release-loop.md): the seven phases of
-  one release, the area rotation, the verification standard.
+  one release, concurrency and merge discipline, the area rotation, the
+  verification standard.
 - [autonomy/issue-triage.md](./autonomy/issue-triage.md): the issue loop,
   decision tree, voice and identity of replies.
-- [autonomy/watchdogs.md](./autonomy/watchdogs.md): liveness checks and the
-  recovery ladder for stalled agents.
+- [autonomy/watchdogs.md](./autonomy/watchdogs.md): liveness checks, the
+  roster contract for concurrent children, and the recovery ladder for
+  stalled agents.
+- [autonomy/infrastructure.md](./autonomy/infrastructure.md): outage versus
+  work failure, the preflight, and build-ahead mode.

--- a/docs/autonomy/composition.md
+++ b/docs/autonomy/composition.md
@@ -26,8 +26,9 @@ Every work item carries three tags from the moment it enters the plan:
 - **Author class**, for issue-backed items: owner or contributor, read from
   the GitHub record per the trust model.
 - **Data class**: reversible or irreversible, per the gate in
-  [safety.md](./safety.md). An irreversible item files its owner question
-  before any builder spawns and may hold its merge; it still occupies a
+  [safety.md](./safety.md). Either class files its owner-inbox entry before
+  any builder spawns, informational for a reversible item and a
+  merge-holding question for an irreversible one; it still occupies a
   normal batch slot and counts against its share whether or not it merges
   this release, because composition measures what was committed, not what
   survived.
@@ -59,15 +60,20 @@ releases where an audit-found release blocker was deferred for quota reasons
 `~/.goodboy-autonomous/MANDATES.md`, for example
 `quota: 8 issues / 2 internal per 10`. When the line exists it replaces the
 default; when it does not, the default above applies. No other surface sets
-it, and no agent edits it.
+it, and no agent edits it. The line is read as a ratio, not as a batch size:
+`8 / 2 per 10` against a four-item batch is three issue-backed items and
+one internal, rounded toward the issue share like the default. A line the
+lead cannot read as a ratio is an owner-inbox escalation, and the default
+applies until the owner fixes it.
 
 The quota is a target with declared deviations, not a hard constraint:
 
 - **Precedence, highest first**: safety, explicit mandates, the product
   owner's filler ban and push-back right, the quota, the area rotation. A
   mandate that eats slots beats the quota. An item that fails the filler bar
-  is never forced in to satisfy a ratio: a quota-mandated weak item is
-  exactly the filler the PO exists to refuse.
+  (it must move something for a real user, per the PO's charter in
+  [roles.md](./roles.md)) is never forced in to satisfy a ratio: a
+  quota-mandated weak item is exactly the filler the PO exists to refuse.
 - **Empty queues flow.** When a share's queue holds nothing that passes the
   filler bar, the unfilled share flows to the other source, and the plan
   states the shortfall and why.
@@ -93,10 +99,10 @@ Issue-backed candidates are ordered by, in this order:
    prioritization, two is a pattern, and the third batch acts. Triage keeps
    the skip count on the backlog entry.
 3. **Author.** The owner's issue outranks a contributor issue of the same
-   priority and comparable size. This is the trust model applied to
-   composition, not a wall: contributor work is protected by the aging step
-   above and by triage's no-issue-goes-dark contract.
-4. **Age.** Older first.
+   priority. This is the trust model applied to composition, not a wall:
+   contributor work is protected by the aging step above and by triage's
+   no-issue-goes-dark contract.
+4. **Age.** Older accepted date first.
 
 That aging step is the contributor floor. Not a reserved slot, which would
 force weak work in thin queues, but a starvation bound: an actionable
@@ -104,10 +110,18 @@ contributor item cannot be passed over indefinitely on author weight alone,
 and every skip is visible on the issue thread through the per-release triage
 sweep, with the reason it was passed over.
 
+Aging deliberately protects contributor items only. An owner item can sit
+skipped forever without a counter promoting it, because the owner already
+has a faster lever for anything he wants sooner: the mandates. That
+asymmetry is the design, not a gap in it.
+
 ## Mandate decay
 
-A standing mandate the product owner has pushed back on, in writing, for
-**three consecutive batches without an owner answer suspends itself**. One
+A standing mandate the product owner has pushed back on, in writing, in
+**three batches without an owner answer suspends itself**. The three need
+not be consecutive: the count is the raw number of unanswered push-backs the
+ledger records for that mandate, which is what the delivery lead can
+actually derive. One
 push-back is a question, two is a disagreement, three unanswered is a
 deadlock, and re-litigating a deadlock every cycle burns reasoning-tier
 tokens to produce no new information; this organization has argued one

--- a/docs/autonomy/composition.md
+++ b/docs/autonomy/composition.md
@@ -1,0 +1,133 @@
+# Autonomy: composition
+
+Part of the [autonomy cluster](../autonomy.md). This file owns what goes into
+a release: the batch, the split between issue-backed and internal work, how
+authors are weighed inside the issue share, and what happens to standing
+direction nobody answers. The trust model that weighs authors in triage lives
+in [safety.md](./safety.md); the phases that consume the batch live in
+[release-loop.md](./release-loop.md).
+
+## The batch
+
+The unit of commitment is the **batch**: the 3 to 6 work items the product
+owner commits to one release after the challenge round. The release is the
+shipping vehicle; the batch is what the organization takes on, consumes,
+ships, and only then replaces with the next one. There is no timebox: a batch
+ends when its release is drafted, not when a clock says so, because wall
+clock has never been the binding constraint here; tokens and attention are.
+
+Every work item carries three tags from the moment it enters the plan:
+
+- **Provenance**: `issue #N` (the item exists because a human filed an
+  issue) or `internal` (it exists because an audit, the backlog, or the
+  org's own process surfaced it). Set at plan time, never reclassified: an
+  internal item that later turns out to close an issue stays internal, so
+  the count cannot be laundered by stamping `Closes #N` onto debt work.
+- **Author class**, for issue-backed items: owner or contributor, read from
+  the GitHub record per the trust model.
+- **Data class**: reversible or irreversible, per the gate in
+  [safety.md](./safety.md). An irreversible item files its owner question
+  before any builder spawns and may hold its merge; it still occupies a
+  normal batch slot and counts against its share whether or not it merges
+  this release, because composition measures what was committed, not what
+  survived.
+
+Composition is measured over work items at plan time, never over merged PRs.
+PR counts are the metric this organization already refuses to steer by (see
+AUTONOMY.md): a verifier dropping a PR later changes what shipped, not what
+was composed, and the product owner answers only for the latter.
+
+## The quota
+
+Default composition target: **60% issue-backed, 40% internal**, applied to
+each batch, fractional slots rounding toward the issue share. A five-item
+batch is three issue-backed items and two internal ones; a three-item batch
+is two and one.
+
+Why 60/40. Issues are the owner's sanctioned steering channel and the side
+that has actually starved: seventeen owner issues once waited while a
+standing mandate spent every headline elsewhere. But the internal share
+earns its 40% too: audit-driven work has caught defects no issue ever named,
+including a cost engine that recorded zero spend for three providers while
+looking fully configured. 60/40 keeps the front door first without going
+blind to what only the audit can see. What would change the number: a
+sustained empty issue queue (the share flows, see below), or two consecutive
+releases where an audit-found release blocker was deferred for quota reasons
+(then the internal share is too small and the lead says so in the report).
+
+**The owner tunes it in one place**: a `quota:` line in
+`~/.goodboy-autonomous/MANDATES.md`, for example
+`quota: 8 issues / 2 internal per 10`. When the line exists it replaces the
+default; when it does not, the default above applies. No other surface sets
+it, and no agent edits it.
+
+The quota is a target with declared deviations, not a hard constraint:
+
+- **Precedence, highest first**: safety, explicit mandates, the product
+  owner's filler ban and push-back right, the quota, the area rotation. A
+  mandate that eats slots beats the quota. An item that fails the filler bar
+  is never forced in to satisfy a ratio: a quota-mandated weak item is
+  exactly the filler the PO exists to refuse.
+- **Empty queues flow.** When a share's queue holds nothing that passes the
+  filler bar, the unfilled share flows to the other source, and the plan
+  states the shortfall and why.
+- **A release blocker outranks the quota.** A confirmed regression takes a
+  slot from whichever share it must.
+- Every deviation is declared in the plan and lands in the ledger's
+  `composition:` line. A silent deviation is a defect; a declared one is the
+  system working.
+- When accepted, unshipped issues pile past ten, the delivery lead may
+  declare the next batch a **queue-drain batch**: composed entirely from
+  issues, said so in the ledger, then back to the target.
+
+## Author weighting, inside the issue share
+
+Issue-backed candidates are ordered by, in this order:
+
+1. **Priority band** (`p0` > `p1` > `p2` > `p3`). Priority describes user
+   impact and is set at triage time; it is never inflated to smuggle
+   authorship past this step, because authorship gets its own step next.
+2. **Aging promotion.** An accepted contributor item skipped by two
+   consecutive batches outranks author weight in the third: it beats owner
+   items of the same or lower priority, never a higher one. One skip is
+   prioritization, two is a pattern, and the third batch acts. Triage keeps
+   the skip count on the backlog entry.
+3. **Author.** The owner's issue outranks a contributor issue of the same
+   priority and comparable size. This is the trust model applied to
+   composition, not a wall: contributor work is protected by the aging step
+   above and by triage's no-issue-goes-dark contract.
+4. **Age.** Older first.
+
+That aging step is the contributor floor. Not a reserved slot, which would
+force weak work in thin queues, but a starvation bound: an actionable
+contributor item cannot be passed over indefinitely on author weight alone,
+and every skip is visible on the issue thread through the per-release triage
+sweep, with the reason it was passed over.
+
+## Mandate decay
+
+A standing mandate the product owner has pushed back on, in writing, for
+**three consecutive batches without an owner answer suspends itself**. One
+push-back is a question, two is a disagreement, three unanswered is a
+deadlock, and re-litigating a deadlock every cycle burns reasoning-tier
+tokens to produce no new information; this organization has argued one
+mandate from scratch four cycles running with nothing to show for it.
+
+Suspension is loud, never quiet:
+
+- The suspension is announced in the cycle's report, in the engagement
+  report, and in a dated owner-inbox entry that names the mandate, the three
+  push-backs, and the single sentence from the owner that would settle it.
+- A suspended mandate stops binding the product owner and stops being
+  re-costed. Every subsequent engagement report lists it under
+  `suspended-mandates:` until the owner resolves it.
+- Only the owner reactivates it, by editing `MANDATES.md`. Any edit that
+  touches the mandate resets its push-back count to zero: a mandate the
+  owner has re-affirmed is live direction again, and earns three fresh
+  push-backs before it can suspend again.
+- The delivery lead keeps the count, from the ledger's push-back records,
+  and writes the current count into every captain's brief so no captain
+  re-argues a settled or suspended mandate.
+
+Decay applies to mandates only. Safety rules are not mandates: they answer
+to [safety.md](./safety.md) alone and never decay.

--- a/docs/autonomy/infrastructure.md
+++ b/docs/autonomy/infrastructure.md
@@ -1,0 +1,94 @@
+# Autonomy: infrastructure failures
+
+Part of the [autonomy cluster](../autonomy.md). This file owns the difference
+between the work failing and the world failing: how the organization
+recognizes a GitHub or provider outage, what it keeps doing during one, and
+what it never does to route around one. Liveness of our own agents lives in
+[watchdogs.md](./watchdogs.md); stop conditions live in
+[safety.md](./safety.md).
+
+The rule this file exists for: **an infrastructure failure never burns the
+stop budget, and never lowers the bar.** A release that cannot merge because
+GitHub Actions is down is paused, not failed. A merge without an observable
+required check is not a merge, it is a guess, and it stays forbidden even
+when the outage is GitHub's fault.
+
+## Telling them apart
+
+Read the evidence before assigning blame:
+
+- **Infrastructure**: the same failure across unrelated agents or PRs
+  (provider rate limits, auth errors on every spawn); workflow runs
+  cancelled with zero steps executed; workflows never dispatched at all for
+  a pushed SHA; runs sitting `queued` with no runner while earlier identical
+  runs started immediately; a declared incident on githubstatus.com. The
+  component to check for CI is `Actions`, and its incident notices name
+  webhook throttling explicitly when that is the mechanism.
+- **The work**: a named test failing, the same one, twice; a typecheck error
+  pointing into the diff; one PR red while its siblings pass the same
+  checks.
+
+Check the status page before diagnosing a CI failure, not after two repair
+attempts. The two-repair budget in [release-loop.md](./release-loop.md) is
+for the work; spending it on an outage wastes it and can trip a stop
+condition nothing in the repo earned.
+
+## Preflight
+
+The delivery lead checks at engagement start and at every release boundary:
+`main` green on its own CI, no tag build in flight, and, whenever anything
+looks slow or silent, the `Actions` component on githubstatus.com. A new
+release is not started into a declared major outage; a release already
+running continues under build-ahead mode.
+
+## Build-ahead mode
+
+When merging is blocked but building is not (checks never dispatch, runners
+starved, webhooks throttled), the captain declares build-ahead mode in its
+scratch state and keeps going:
+
+- Phases 1 through 5 continue: audit, decide, scout, build, verify. All of
+  that is local work plus plain git pushes, which this class of outage does
+  not block.
+- Verified PRs queue instead of merging. The captain writes
+  `merge-queue.md` in its release scratch dir: one line per PR, in merge
+  order, with the PR number, the branch, any package overlap with earlier
+  queue entries (which triggers the refresh rule in
+  [release-loop.md](./release-loop.md)), and a pointer to the verifier
+  verdict. A successor or the delivery lead executes the queue from that
+  file without re-deriving anything.
+- Nothing is tagged and nothing merges blind. Merging without an observable
+  required check, or without the ability to poll `main`'s own CI afterwards,
+  stays forbidden. A streak of never leaving `main` red is not traded for
+  one outage.
+- **No idle polling.** Waiting happens at boundaries: check the incident
+  page and the queued runs when a phase ends, not in a sleep loop. When the
+  outage outlasts the useful local work, the captain reports
+  `paused (infrastructure)` with the queue on disk and exits; the delivery
+  lead resumes it or hands it to the next engagement through the ledger.
+
+The most valuable hours of one real outage were spent exactly this way:
+building and verifying the next fix while the merges waited. Build-ahead is
+the institutional version of that improvisation.
+
+## Facts about this repo's pipelines
+
+- Neither `ci.yml` nor `rust.yml` has a `workflow_dispatch` trigger. When
+  webhooks are throttled, the only way to summon a run for an open PR is
+  closing and reopening it, which forces a fresh `pull_request` event.
+  Adding the trigger is a one-line `ci`-scoped change worth proposing as
+  backlog work; until it lands, close/reopen is the only lever.
+- A release build takes roughly 9 to 12 minutes. The homebrew cask bump is
+  its own workflow after publish and can lag a recovered outage: a
+  published release with all four assets is complete even while the cask is
+  stale. Re-run the cask workflow; never re-release for it.
+- Jobs cancelled at the runner timeout with zero steps executed are the
+  outage signature, not the diff's.
+
+## Provider outages
+
+Model-provider failures (rate limits, 5xx across unrelated agents) pause the
+affected role, which retries later on the same brief; the pause is noted in
+the ledger. Releases that fail for provider or Actions reasons do not count
+toward the two-failed-releases stop condition; releases that fail for
+reasons the evidence cannot pin on infrastructure do.

--- a/docs/autonomy/infrastructure.md
+++ b/docs/autonomy/infrastructure.md
@@ -19,7 +19,8 @@ Read the evidence before assigning blame:
 
 - **Infrastructure**: the same failure across unrelated agents or PRs
   (provider rate limits, auth errors on every spawn); workflow runs
-  cancelled with zero steps executed; workflows never dispatched at all for
+  cancelled with zero steps executed, including at the runner timeout;
+  workflows never dispatched at all for
   a pushed SHA; runs sitting `queued` with no runner while earlier identical
   runs started immediately; a declared incident on githubstatus.com. The
   component to check for CI is `Actions`, and its incident notices name
@@ -35,11 +36,10 @@ condition nothing in the repo earned.
 
 ## Preflight
 
-The delivery lead checks at engagement start and at every release boundary:
-`main` green on its own CI, no tag build in flight, and, whenever anything
-looks slow or silent, the `Actions` component on githubstatus.com. A new
-release is not started into a declared major outage; a release already
-running continues under build-ahead mode.
+These checks run at engagement start and again at every release boundary;
+the checklist itself is the skill's preflight step. A new release is not
+started into a declared major outage; a release already running continues
+under build-ahead mode.
 
 ## Build-ahead mode
 
@@ -71,19 +71,15 @@ The most valuable hours of one real outage were spent exactly this way:
 building and verifying the next fix while the merges waited. Build-ahead is
 the institutional version of that improvisation.
 
-## Facts about this repo's pipelines
+## Pipeline facts
 
-- Neither `ci.yml` nor `rust.yml` has a `workflow_dispatch` trigger. When
-  webhooks are throttled, the only way to summon a run for an open PR is
-  closing and reopening it, which forces a fresh `pull_request` event.
-  Adding the trigger is a one-line `ci`-scoped change worth proposing as
-  backlog work; until it lands, close/reopen is the only lever.
-- A release build takes roughly 9 to 12 minutes. The homebrew cask bump is
-  its own workflow after publish and can lag a recovered outage: a
-  published release with all four assets is complete even while the cask is
-  stale. Re-run the cask workflow; never re-release for it.
-- Jobs cancelled at the runner timeout with zero steps executed are the
-  outage signature, not the diff's.
+Build timings, the missing `workflow_dispatch` trigger and the close/reopen
+lever it forces live in the skill's repo-gotchas file, which is where this
+repo's pipeline trivia is maintained and kept true. One fact belongs here
+instead, because it is outage recovery rather than trivia: the homebrew cask
+bump is its own workflow after publish and can lag a recovered outage. A
+published release with all four assets is complete even while the cask is
+stale, so re-run the cask workflow and never re-release for it.
 
 ## Provider outages
 

--- a/docs/autonomy/issue-triage.md
+++ b/docs/autonomy/issue-triage.md
@@ -90,12 +90,22 @@ machine's writing.
 
 ## From issue to work
 
-- Accepted items land in `~/.goodboy-autonomous/BACKLOG.md` with the issue
-  number, so the next release captain sees them in Phase 1 with provenance.
+- Accepted items land in `~/.goodboy-autonomous/BACKLOG.md` carrying the
+  fields composition needs: the issue number, the author class (owner or
+  contributor, read from the GitHub record), the priority label, the date
+  accepted, and a skip count that the per-release sweep increments each time
+  a batch passes the item over. The next release captain sees all of it in
+  Phase 1 with provenance.
 - A PR that resolves an issue says `Closes #N`, and the triage sweep comments
   on the issue when the fix ships in a published release, naming the version.
+  When a batch passes over an accepted contributor item, the sweep's
+  follow-up comment says it was considered and what outranked it; the skip
+  count drives the aging promotion in
+  [composition.md](./composition.md).
 - Priorities: a confirmed regression outranks a feature request; a request
-  from the owner outranks a same-sized request from a contributor; neither
+  from the owner outranks a same-sized request from a contributor (the full
+  ordering, including the contributor floor, is
+  [composition.md](./composition.md)); neither
   outranks a stop condition or the safety file.
 
 ## Floods and rate limits

--- a/docs/autonomy/release-loop.md
+++ b/docs/autonomy/release-loop.md
@@ -40,9 +40,9 @@ raw diff.
    explicit non-goals and per-item risk. Items touching schema or stored
    data carry their data class per the gate in [safety.md](./safety.md),
    and the owner question for any class A or B item is written **before
-   Phase 4 starts**. The challenger attacks the plan cold; any
-   migration-touching item's schema design gets its own dedicated
-   challenge. The captain
+   Phase 4 starts**. The challenger attacks the plan cold; any item
+   touching schema or stored data gets its schema design challenged on its
+   own. The captain
    reconciles, re-reading the result against the mandates, not only against
    the objections.
 3. **Scouting.** Cheap agents, one concurrent batch, pressure-test every
@@ -146,7 +146,9 @@ Every PR, before merge:
   present, otherwise the "green" claim covers one package), and the CI knip
   gate `pnpm knip --include files,duplicates,unlisted`.
 - Read the diff against the work item, not against the PR body.
-- **Sabotage the implementation and confirm a test fails.** Sabotage the
+- **Sabotage the implementation and confirm a test fails.** Commit the
+  checked-out state first, so an interrupted verifier leaves a branch and
+  not a wreck. Sabotage the
   wrapper as well as the pure function; builders' helpers have survived
   sabotage while the commands calling them did not. A test nobody can make
   fail is not a test. Report sabotages as a table with a survived column:

--- a/docs/autonomy/release-loop.md
+++ b/docs/autonomy/release-loop.md
@@ -2,14 +2,19 @@
 
 Part of the [autonomy cluster](../autonomy.md). This file owns the shape of
 one autonomous release: the phases, the area rotation that keeps the whole
-product scouted, the verification standard, and the merge discipline. The
+product scouted, the verification standard, and the merge discipline. What
+goes into the batch is owned by [composition.md](./composition.md); outages
+and the build-ahead mode by [infrastructure.md](./infrastructure.md). The
 mechanics of tagging and notarization live in
 [release-command.md](../release-command.md) and [release.md](../release.md);
 the repo-specific gotchas live with the `continuous-delivery` skill.
 
 One release captain owns one version, runs these phases in order, stops at a
 reviewed draft, and exits. The next version gets a fresh captain: state lives
-on disk (ledger, backlog, mandates), never in a surviving agent.
+on disk (ledger, backlog, mandates), never in a surviving agent. The phases
+are ordered but not barriered: build and verify stream, so a verifier starts
+the moment its build lands while other builds still run. Only the merge
+phase is a true barrier, because `main` is one resource.
 
 ## The thesis every release is measured against
 
@@ -21,45 +26,87 @@ raw diff.
 
 ## The phases
 
-1. **Archaeology.** 3 to 5 cheap read-only agents in parallel, disjoint
-   slices, compact structured findings: recent intent (last 15 to 25 merged
-   PRs against `origin/main`), the focus area of the cycle (see rotation),
-   debt and seams, plus whatever the theme needs (scaffolding checklists,
-   feasibility of the candidate headline). Audit from a worktree pinned at
-   `origin/main`, never a possibly stale local checkout.
+1. **Archaeology.** 3 to 5 cheap read-only agents spawned as one concurrent
+   batch, disjoint slices, compact structured findings: recent intent (last
+   15 to 25 merged PRs against `origin/main`), the focus area of the cycle
+   (see rotation), debt and seams, plus whatever the theme needs
+   (scaffolding checklists, feasibility of the candidate headline). Audit
+   from a worktree pinned at `origin/main`, never a possibly stale local
+   checkout.
 2. **Product decision.** The product owner turns audit, mandates, VISION and
-   backlog into a theme plus 3 to 6 one-PR work items, sized, persona-tagged,
-   with explicit non-goals and per-item risk. The challenger attacks the plan
-   cold. The captain reconciles, re-reading the result against the mandates,
-   not only against the objections.
-3. **Scouting.** Cheap agents pressure-test every surviving item against the
-   real code: prior implementations to extend, migration numbers free
+   backlog into a theme plus a batch of 3 to 6 one-PR work items, sized,
+   persona-tagged, composed per [composition.md](./composition.md) (the
+   issue/internal split, author weighting, declared deviations), with
+   explicit non-goals and per-item risk. Items touching schema or stored
+   data carry their data class per the gate in [safety.md](./safety.md),
+   and the owner question for any class A or B item is written **before
+   Phase 4 starts**. The challenger attacks the plan cold; any
+   migration-touching item's schema design gets its own dedicated
+   challenge. The captain
+   reconciles, re-reading the result against the mandates, not only against
+   the objections.
+3. **Scouting.** Cheap agents, one concurrent batch, pressure-test every
+   surviving item against the real code: prior implementations to extend,
+   migration numbers free
    (`packages/db/src/migrations/registry.test.ts` enforces contiguity),
    gating lists and switches a change must touch, test coverage over the
-   path. Contradictions go back to the PO once, at most twice, then the PO's
-   last answer stands.
-4. **Build.** One item, one builder, one branch (`ak/<type>-<kebab-desc>`),
-   one PR, one fresh worktree per builder. Parallel only when items do not
-   overlap in files; overlapping items serialize. House rules travel in every
-   builder brief. Docs, README and website are updated in the same PR that
-   makes them wrong.
-5. **Verify.** A different agent per PR, always. See the standard below. The
+   path. Each scout also returns its item's **predicted file footprint**:
+   the files it expects to touch, plus any shared hotspot it crosses (the
+   app shell, store slice barrels, provider gating lists, shared registries;
+   the places most items meet). Contradictions go back to the PO once, at
+   most twice, then the PO's last answer stands.
+4. **Build, concurrently where footprints allow.** One item, one builder,
+   one branch (`ak/<type>-<kebab-desc>`), one PR, one fresh worktree per
+   builder, every branch cut from `origin/main`.
+   - Items whose footprints share no file and no hotspot build
+     concurrently, spawned as one batch under the roster contract in
+     [watchdogs.md](./watchdogs.md), **at most three at once**: whole
+     workspace test runs and cargo builds contend on one machine, and
+     load-induced flakes read as red, which the two-repair rule then turns
+     into dropped healthy PRs. The captain may raise to four only when the
+     concurrent items are docs- or UI-light.
+   - Overlapping items either collapse into one item at plan time (when
+     they are honestly one concern) or serialize: the second builder starts
+     from a fresh `origin/main` after the first item's PR merges.
+   - **Never stack a PR on an unmerged branch.** A stacked child does not
+     retarget when its parent is squash-merged, and it lands conflicting
+     the moment it is retargeted; both have cost real repair time.
+     Independent branches from `main` are faster and safer.
+   - A builder that finds it must touch a file another live item claims
+     stops and reports; the captain serializes the remainder rather than
+     letting two agents race on one file.
+   - House rules travel in every builder brief. Docs, README and website
+     are updated in the same PR that makes them wrong.
+5. **Verify, streaming.** A different agent per PR, always, spawned as each
+   build lands rather than after all of them, in its own worktree checked
+   out at the PR branch, never the builder's. See the standard below. The
    verifier's verdict is the one the captain trusts, over the builder's
-   report and over green CI.
-6. **Merge.** Serialized, never parallel: merge one PR server-side, then poll
-   `main`'s own CI to green before merging the next. Two PRs each green alone
-   have broken `main` together twice (an exhaustiveness guard meeting a
-   widened union; a deleted shared component meeting a new importer). A PR
-   red after two honest repair attempts is closed and recorded as dropped.
-7. **Cut the draft.** Version bump in all five files plus the changelog
+   report and over green CI. Repairs loop per PR (builder or a fresh
+   repair agent, then re-verify) without holding the other lanes.
+6. **Merge.** Serialized, never parallel, and this survives every speedup:
+   merge one PR server-side, then poll `main`'s own CI to green before
+   merging the next. Two PRs each green alone have broken `main` together
+   twice (an exhaustiveness guard meeting a widened union; a deleted shared
+   component meeting a new importer), and concurrent builds widen exactly
+   that window, so the serial merge lane is what pays for the parallel
+   build lanes. When the just-merged PR and the next in the queue touch the
+   same package, refresh the next branch with `git merge origin/main` and
+   let its CI re-run before merging it. A PR red after two honest repair
+   attempts is closed and recorded as dropped. A class B data change with
+   no owner answer does not merge; the release ships without it per
+   [safety.md](./safety.md).
+7. **Cut the draft.** The challenger reviews the release notes first, per
+   its charter in [roles.md](./roles.md). Then: version bump in all five
+   files plus the changelog
    section in one commit, release PR, merge, rc dry-run with notarization
    verified, then the real tag and the draft release. Stop there: the
    delivery lead publishes after review. Never tag while another tag build is
    in flight.
 
 Afterwards the captain updates the backlog (what it took, what it surfaced
-and left) and returns its report block; the delivery lead is the only writer
-of the ledger and appends the block there.
+and left), writes its full narrative to its scratch dir, and returns its
+compact report block; the delivery lead is the only writer of the ledger and
+appends the block there.
 
 ## Area rotation
 
@@ -102,7 +149,8 @@ Every PR, before merge:
 - **Sabotage the implementation and confirm a test fails.** Sabotage the
   wrapper as well as the pure function; builders' helpers have survived
   sabotage while the commands calling them did not. A test nobody can make
-  fail is not a test.
+  fail is not a test. Report sabotages as a table with a survived column:
+  "all tests green" and "the fix is pinned" are different claims.
 - Re-derive the builder's claims instead of checking them: enumerate the call
   sites yourself, count the live symbols yourself.
 - Tests are not sacred. A test pinning deprecated behavior gets deleted or
@@ -124,7 +172,27 @@ Regression classes to hunt, all shipped in this repo at least once:
    consumes it, falling through to the wrong host. Enumerate the gating
    lists.
 5. Two PRs green alone that break `main` together. Answered by serialized
-   merges, hunted anyway.
+   merges, hunted anyway, and hunted harder now that builds run
+   concurrently: before each merge, re-run `git merge-tree` against current
+   `main` and ask what the just-merged diff changed that this one consumes.
+
+### The data playbook
+
+For any PR that touches the schema or stored data, on top of everything
+above, run by the second verifier the gate in [safety.md](./safety.md)
+assigns:
+
+- Run the migration against a `VACUUM INTO` copy of a production-shaped
+  database, never a synthetic empty one and never a `copyFileSync` of a
+  live file.
+- Kill the migration partway through and prove the app recovers on next
+  launch: resumes, or rolls back clean. A crash mid-migration is a state a
+  real user will hit.
+- Prove the previous app version against the migrated database does what
+  the item claims: for class A, opens and runs; for class B, state exactly
+  what breaks, because that is what the owner is being asked to accept.
+- Verify the migration number is still free at merge time, not just at
+  scout time: two concurrent migration PRs must land in numeric order.
 
 ## Honesty in the notes
 

--- a/docs/autonomy/roles.md
+++ b/docs/autonomy/roles.md
@@ -27,10 +27,12 @@ delivery lead (one per engagement, up to 5 releases)
 │   ├── builders (one per PR, mid or strong tier)
 │   ├── verifiers (one per PR, never the builder)
 │   └── watchdog (periodic, checks siblings)
-├── issue triage officer (periodic loop)
-│   └── responder (per issue, drafts the reply)
-└── watchdog (checks the release captain)
+└── issue triage officer (periodic loop)
+    └── responder (per issue, drafts the reply)
 ```
+
+The lead has no watchdog of its own: it inspects its captains directly, from
+git and the PR list, per [watchdogs.md](./watchdogs.md).
 
 Roles with no data dependency on each other run concurrently:
 archaeologists as one batch, scouts as one batch, builders on disjoint items
@@ -45,12 +47,12 @@ The tier names used across this cluster and the skill, mapped once here.
 Examples are the current best fit, not a lock-in: when the provider landscape
 moves, update this table, not every brief.
 
-| Tier      | Meaning                                            | Current example    |
-| --------- | -------------------------------------------------- | ------------------ |
-| cheap     | read, list, grep, summarize; disposable            | Haiku class        |
-| mid       | mechanical or localized build work, triage replies | Sonnet class       |
-| strong    | cross-cutting build, migrations, protocols, Rust   | Opus class         |
-| reasoning | product decisions, challenges, orchestration       | Fable / Opus class |
+| Tier      | Meaning                                            | Current example  |
+| --------- | -------------------------------------------------- | ---------------- |
+| cheap     | read, list, grep, summarize; disposable            | Haiku class      |
+| mid       | mechanical or localized build work, triage replies | Sonnet class     |
+| strong    | cross-cutting build, migrations, protocols, Rust   | Opus class       |
+| reasoning | product decisions, challenges, orchestration       | Fable, then Opus |
 
 ## The roles
 
@@ -79,8 +81,9 @@ touches git. Model: cheap tier.
 
 ### Product owner
 
-The role that decides what the release is. Runs on the strongest reasoning
-tier available, with the audit, the mandates, VISION and the backlog in hand.
+The role that decides what the release is. Runs on the reasoning tier, first
+example in the table above, with the audit, the mandates, VISION and the
+backlog in hand.
 Its output is a theme plus a batch of 3 to 6 sized work items, each tagged
 with a persona, the three questions (what do I see, what can I do, where
 does it take me next), and the three composition tags (provenance, author
@@ -109,8 +112,8 @@ to the same user value, and anything that contradicts VISION or the audit. The
 release captain reconciles PO and challenger; on an unresolved disagreement
 the safer scope wins and the disagreement is recorded in the ledger. The
 challenger also reviews the release notes before the draft is cut, and any
-migration-touching plan item ([safety.md](./safety.md)) gets a dedicated
-challenge of its schema design on top of the plan-level attack.
+plan item touching schema or stored data ([safety.md](./safety.md)) gets a
+dedicated challenge of its schema design on top of the plan-level attack.
 
 ### Scout
 
@@ -143,10 +146,12 @@ A different agent from the builder, always. Runs the full workspace checks,
 reads the diff against the work item, hunts the known regression classes, and
 sabotages the implementation to prove the tests can fail. The verifier's
 verdict outranks the builder's report and CI. The full playbook is in
-[release-loop.md](./release-loop.md). Any migration-touching PR
+[release-loop.md](./release-loop.md). Any PR touching schema or stored data
 ([safety.md](./safety.md)) takes two independent verifiers, the
-second running the data playbook. Model: the tier of the build it checks,
-never below mid; a cheap verifier is not a verifier.
+second running the data playbook. It commits the checked-out state before
+sabotaging anything, so the branch survives its own experiments. Model: the
+tier of the build it checks, never below mid; a cheap verifier is not a
+verifier.
 
 ### Issue triage officer
 

--- a/docs/autonomy/roles.md
+++ b/docs/autonomy/roles.md
@@ -5,9 +5,15 @@ of the delivery organization: who exists, what each role decides, which model
 tier it runs on, and how the roles check each other. The rules every role obeys
 live in [safety.md](./safety.md).
 
-Goodboy is built by a simulated company. Each role is an agent with a bounded
-mandate, and no role reviews its own work. The org is deliberately small: a
-role earns its place by owning a decision nobody else can make.
+Goodboy is built by a simulated company, and the shape is a working delivery
+org, not a metaphor: a product owner decides what a batch is worth, a
+challenger assumes every plan is wrong, builders build, verifiers assume
+every build is broken, and a lead ships. The company takes a batch of work
+([composition.md](./composition.md)), consumes it, ships it, then takes the
+next one; it does not run forever, and quality is the point of the shape,
+not a tax on it. Each role is an agent with a bounded mandate, and no role
+reviews its own work. The org is deliberately small: a role earns its place
+by owning a decision nobody else can make.
 
 ## Org chart
 
@@ -25,6 +31,13 @@ delivery lead (one per engagement, up to 5 releases)
 │   └── responder (per issue, drafts the reply)
 └── watchdog (checks the release captain)
 ```
+
+Roles with no data dependency on each other run concurrently:
+archaeologists as one batch, scouts as one batch, builders on disjoint items
+together, a verifier the moment its build lands. The PO, the challenger and
+the merge phase are serial by nature: one feeds the next, or the resource is
+shared. The concurrency contract is in the binding rules below; the liveness
+answer that makes it safe is [watchdogs.md](./watchdogs.md).
 
 ## Model tiers
 
@@ -52,7 +65,8 @@ to publish a release. Model: reasoning tier.
 
 ### Release captain
 
-Owns one version end to end: audit, decision, build, verify, merge, draft.
+Owns one version end to end: audit, decision, scouting, build, verify,
+merge, draft.
 Stops at a reviewed draft release; publication belongs to the delivery lead.
 Follows [release-loop.md](./release-loop.md). Model: reasoning tier.
 
@@ -67,9 +81,11 @@ touches git. Model: cheap tier.
 
 The role that decides what the release is. Runs on the strongest reasoning
 tier available, with the audit, the mandates, VISION and the backlog in hand.
-Its output is a theme plus 3 to 6 sized work items, each tagged with a persona
-and the three questions (what do I see, what can I do, where does it take me
-next).
+Its output is a theme plus a batch of 3 to 6 sized work items, each tagged
+with a persona, the three questions (what do I see, what can I do, where
+does it take me next), and the three composition tags (provenance, author
+class, data class) defined in [composition.md](./composition.md). The batch
+meets the composition target there, or declares why it deviates.
 
 The PO has an explicit right and duty of push-back. It does not accept work
 just because the work is possible and on-vision: an item earns its place only
@@ -85,27 +101,39 @@ by house rule.
 
 ### Challenger
 
-The unbiased third party. A second reasoning-tier agent that receives the
+The role whose job is to assume the plan is bad and prove it. A second
+reasoning-tier agent that receives the
 PO's plan cold (no shared conversation) and attacks it: wrong priorities, missed
 regressions of the non-coder read, items that fail see/do/next, cheaper paths
 to the same user value, and anything that contradicts VISION or the audit. The
 release captain reconciles PO and challenger; on an unresolved disagreement
 the safer scope wins and the disagreement is recorded in the ledger. The
-challenger also reviews the release notes before the draft is cut.
+challenger also reviews the release notes before the draft is cut, and any
+migration-touching plan item ([safety.md](./safety.md)) gets a dedicated
+challenge of its schema design on top of the plan-level attack.
 
 ### Scout
 
 Pressure-tests the plan before a line is written: does the assumed code exist,
 is there a prior implementation to extend instead of duplicate, is a migration
 number free, which gating lists a change must touch, what tests cover the
-path. Scouts have contradicted every first plan so far; a plan that skipped
-scouting has shipped wrong items. Model: cheap tier, read-only.
+path. Scouts also produce each item's **predicted file footprint** (the
+files and shared hotspots it will touch), which decides what builds
+concurrently, and confirm the item's data class against the gate in
+[safety.md](./safety.md). Scouts have contradicted every first plan so far;
+a plan that skipped scouting has shipped wrong items. Model: cheap tier,
+read-only.
 
 ### Builder
 
-One work item, one branch, one PR. Follows AGENTS.md and the repo conventions
+One work item, one branch, one PR, one fresh worktree, always cut from
+`origin/main`, never from a sibling's unmerged branch. Follows AGENTS.md and
+the repo conventions
 without exception, writes the PR body it would want to review, and reports
-honestly, including what it could not verify. Mechanical or localized work
+honestly, including what it could not verify. A builder receives its item's
+declared file footprint; when the work genuinely demands a file another live
+item claims, it stops and reports instead of improvising, and the captain
+serializes the remainder. Mechanical or localized work
 runs on the mid tier; cross-cutting, state-machine, migration, protocol or
 Rust work runs on the strong tier.
 
@@ -115,7 +143,9 @@ A different agent from the builder, always. Runs the full workspace checks,
 reads the diff against the work item, hunts the known regression classes, and
 sabotages the implementation to prove the tests can fail. The verifier's
 verdict outranks the builder's report and CI. The full playbook is in
-[release-loop.md](./release-loop.md). Model: the tier of the build it checks,
+[release-loop.md](./release-loop.md). Any migration-touching PR
+([safety.md](./safety.md)) takes two independent verifiers, the
+second running the data playbook. Model: the tier of the build it checks,
 never below mid; a cheap verifier is not a verifier.
 
 ### Issue triage officer
@@ -137,14 +167,31 @@ ladder live in [watchdogs.md](./watchdogs.md).
 - No role reviews its own work. Builder and verifier are always different
   agents; the PO's plan always meets a challenger; the delivery lead reviews
   the captain's draft before publishing.
-- Every role reports in its final message, works alone, and never messages
-  peers. Coordination is the parent's job.
-- Every role gets a unique scratch path and runs foreground
-  (`run_in_background: false`), a rule earned from stalled chains.
+- Every role works alone and never messages peers. Coordination is the
+  parent's job.
+- **Reports live on disk.** A role writes its full narrative to its scratch
+  path and returns a compact structured block as its final message: verdict,
+  exceptions, pointers. A parent reads verdicts and exceptions, and opens
+  the narrative only when something needs explaining. One real engagement's
+  release count was capped by a lead whose context filled with narratives it
+  never needed; a role that dumps a narrative or raw file contents into its
+  final message is doing it wrong.
+- Every role gets a unique scratch path. Children with no data dependency on
+  each other are spawned together, in one message, as concurrent background
+  tasks with completion notifications; five builders once ran as the sum of
+  their durations instead of the longest one, and that time bought nothing.
+  Concurrency is bounded by the roster contract in
+  [watchdogs.md](./watchdogs.md): roster before spawning, heartbeat
+  journals, first-activity check, and a parent that never proceeds past an
+  unresolved child. Where the harness cannot notify on background
+  completion, the degraded mode is foreground spawning, one child at a time:
+  slower, never silent.
+- Every builder and verifier keeps the heartbeat journal defined in
+  [watchdogs.md](./watchdogs.md). Watchdogs read journals and git, never
+  self-descriptions.
 - Token discipline is part of the job: load only what the current step needs,
   keep reports compact and structured, and use the cheapest tier that can do
-  the work. A role that dumps raw file contents into its report is doing it
-  wrong.
+  the work.
 - The current code is a strong precedent, not scripture. Copy the existing
   pattern by default; when a pattern is the problem, restructuring it is in
   scope, stated as such in the plan and sized honestly.

--- a/docs/autonomy/safety.md
+++ b/docs/autonomy/safety.md
@@ -98,12 +98,62 @@ Judgment is the point of the system: not everything possible is worth doing.
   proceeds smaller, and the owner overrules or confirms asynchronously by
   editing the mandates.
 
+## The irreversible-data gate
+
+Most of what ships can be taken back by shipping again. Schema and stored
+data are the exception, and the gate keys on **irreversibility, not on the
+word "migration"**: what matters is what the change does to data that
+already exists on users' machines, and whether updating the app again can
+undo it.
+
+Two classes, tagged on the work item at plan time and checked by the scouts:
+
+- **Reversible (class A)**: a new migration that only adds (a new table, a
+  new nullable column, an index). Every new migration is at least class A by
+  definition.
+- **Irreversible (class B)**: `NOT NULL` or `UNIQUE` added to an existing
+  table, a column or table dropped or renamed, a backfill or rewrite of
+  existing rows, data deleted, or any change the previous app version plus
+  the user's existing database cannot survive. When in doubt, class B.
+
+What the gate does:
+
+- **The question reaches the owner before the build.** When the plan commits
+  a class A or B item, the captain writes a dated owner-inbox entry before
+  any builder spawns: what changes in the schema or the data, why, the
+  rollback story, and, for class B, the explicit default that applies if the
+  entry goes unanswered. For class B that default is always the hold below,
+  named as a consequence, never a choice the captain invents. The release
+  never stalls on the answer; the machine continues per the push-back
+  protocol above.
+- **More adversaries.** Any migration-touching item gets a dedicated
+  challenge of its schema design at plan time (is the shape right, is there
+  a reversible way to the same value, what does a crash halfway through
+  leave behind), and two independent verifiers at verify time, the second
+  running the data playbook in [release-loop.md](./release-loop.md).
+- **Class A merges** once both verifiers pass. Its inbox entry is
+  informational and needs no answer.
+- **Class B holds its merge for the owner.** The PR is built, verified and
+  kept green, but it does not merge until the owner answers: an edit to the
+  mandates, or a comment on the PR or its issue from the owner's handle.
+  Unanswered at merge time, the release ships without it; the PR stays open
+  and verified, the branch survives, and the hold is recorded in the report
+  and the handoff. A held PR survives engagements: successors adopt it, keep
+  it green, and merge it first once the owner answers. Silence never ships
+  an irreversible change.
+
+The gate strengthens the floor and never relaxes it: nothing here authorizes
+anything the Forbidden list refuses.
+
 ## Stop conditions
 
 The machine stops itself, mid-engagement, when any of these holds:
 
 - `main` is red and two honest repair attempts have failed.
-- Two consecutive releases failed to reach a publishable draft.
+- Two consecutive releases failed to reach a publishable draft. A release
+  paused for a verified infrastructure outage
+  ([infrastructure.md](./infrastructure.md)) is a pause, not a failure; a
+  failure the evidence cannot pin on infrastructure counts.
 - Notarization failed twice on the same version.
 - A verifier found evidence of data leaving the machine that the diff cannot
   explain.

--- a/docs/autonomy/safety.md
+++ b/docs/autonomy/safety.md
@@ -126,16 +126,20 @@ What the gate does:
   named as a consequence, never a choice the captain invents. The release
   never stalls on the answer; the machine continues per the push-back
   protocol above.
-- **More adversaries.** Any migration-touching item gets a dedicated
-  challenge of its schema design at plan time (is the shape right, is there
-  a reversible way to the same value, what does a crash halfway through
-  leave behind), and two independent verifiers at verify time, the second
-  running the data playbook in [release-loop.md](./release-loop.md).
+- **More adversaries.** Any class A or B item, which is to say anything
+  touching schema or stored data whether or not a migration file is
+  involved, gets a dedicated challenge of its schema design at plan time (is
+  the shape right, is there a reversible way to the same value, what does a
+  crash halfway through leave behind), and two independent verifiers at
+  verify time, the second running the data playbook in
+  [release-loop.md](./release-loop.md).
 - **Class A merges** once both verifiers pass. Its inbox entry is
   informational and needs no answer.
 - **Class B holds its merge for the owner.** The PR is built, verified and
   kept green, but it does not merge until the owner answers: an edit to the
-  mandates, or a comment on the PR or its issue from the owner's handle.
+  mandates, or a comment on the PR or its issue from the owner's handle. A
+  comment that asks something back rather than approving is not an answer:
+  the hold stands and the question gets a reply.
   Unanswered at merge time, the release ships without it; the PR stays open
   and verified, the branch survives, and the hold is recorded in the report
   and the handoff. A held PR survives engagements: successors adopt it, keep
@@ -150,7 +154,8 @@ anything the Forbidden list refuses.
 The machine stops itself, mid-engagement, when any of these holds:
 
 - `main` is red and two honest repair attempts have failed.
-- Two consecutive releases failed to reach a publishable draft. A release
+- Two consecutive releases failed to reach a publishable draft, or one
+  version failed twice (the captain's retry included). A release
   paused for a verified infrastructure outage
   ([infrastructure.md](./infrastructure.md)) is a pause, not a failure; a
   failure the evidence cannot pin on infrastructure counts.

--- a/docs/autonomy/watchdogs.md
+++ b/docs/autonomy/watchdogs.md
@@ -3,38 +3,56 @@
 Part of the [autonomy cluster](../autonomy.md). This file owns liveness: how
 the delivery organization notices a dead or stalled agent and what it does
 about it. Chains have stalled before with zero progress because an agent was
-backgrounded and its turn ended; these rules exist so that never silently
-repeats.
+backgrounded and its turn ended silently; concurrency is now the default, so
+these rules are what make that failure impossible to repeat quietly.
 
 ## The principle
 
 Every long-running parent watches its children, and no watcher trusts a
 report it could verify from disk. Progress is measured by observable facts
-(commits, PR states, CI runs, files in the scratch path, ledger lines), never
-by an agent's self-description.
+(commits, PR states, CI runs, journal lines in the scratch path, ledger
+lines), never by an agent's self-description. A parent never fabricates a
+pending child's result, and never reports success past a child it has lost
+track of.
 
-## The ladder
+## The roster contract
 
-Cadences are targets, bounded by the harness: every role spawns its children
-foreground, so a parent blocked inside a synchronous call checks liveness at
-the next boundary it owns (between spawns, between phases, between poll
-iterations), not on a wall clock. When the harness offers background tasks
-with notifications or scheduled checks, the cadences below apply literally;
-otherwise they mean "at the first boundary after this much time has passed".
+Before spawning any batch of concurrent children, the parent writes a roster
+to its scratch state: one line per child (role, work item, branch, worktree,
+scratch path, spawn time). The roster is a crash-recovery manifest keyed on
+git state, never on harness task ids: a replacement parent resumes from
+branches, worktrees and journals, because task ids die with the parent that
+held them.
 
-- **Release captain, ~30 minutes into any running phase**: at the next
-  boundary, spawn a cheap watchdog that checks each active sibling's output
-  for observable progress since the last check (and, in a parallel batch,
-  ride one watchdog alongside the builders). A builder with no new commit, no
-  test run and no scratch notes across two checks is presumed stuck. The
-  watchdog only reports; the captain acts.
-- **Delivery lead, 1 to 2 hours without news from a captain**: when the
-  captain runs foreground, this check is the retry ladder applied to its
-  eventual return; when it runs as a background task, spawn a watchdog that
-  inspects the release's worktrees, branches, open PRs and CI runs. A captain
-  quiet past two hours with no observable movement is presumed dead.
-- **Issue triage officer**: its polling loop doubles as its own heartbeat;
-  the delivery lead applies the same 2 hour rule to it.
+- Every builder and verifier keeps a **heartbeat journal** in its scratch
+  path: one appended line at each real boundary (reading done, a commit
+  made, a test run started or finished). The brief says so explicitly; a
+  child that was never told to journal cannot be judged by its silence.
+- **First-activity check**: within about ten minutes of a spawn, every
+  child's journal must exist. A child with no first activity is a failed
+  spawn, not a slow thinker; respawn it foreground, once.
+- A completion notification resolves a roster entry. A parent reaching a
+  phase boundary with unresolved entries either waits there doing bounded
+  work (watchdog passes, reading finished verdicts, merge-tree checks),
+  applies the ladder below, or writes the roster state to disk and reports
+  `paused`; it never proceeds as if the entry were resolved.
+- Notification loss and a slow child look identical from the parent's
+  chair; journals and git tell them apart. A child whose journal or branch
+  has advanced is alive regardless of notification silence. A child with
+  neither across two checks is presumed dead.
+
+## The cadence
+
+- **Release captain, ~every 30 minutes while children run**: spawn a cheap
+  watchdog that reads each live child's journal, branch and worktree for
+  progress since the last check. No new journal line, no commit and no test
+  run across two consecutive checks: presumed stuck. The watchdog only
+  reports; the captain acts.
+- **Delivery lead, 2 hours without news from a captain**: inspect the
+  release's worktrees, branches, open PRs and CI runs. Quiet plus no
+  observable movement is presumed dead.
+- **Issue triage officer**: its polling loop doubles as its heartbeat; the
+  delivery lead applies the same 2 hour rule.
 
 ## Recovery, in order
 
@@ -43,18 +61,33 @@ otherwise they mean "at the first boundary after this much time has passed".
 2. **Replace**: kill the stuck agent, spawn a fresh one on the same brief
    plus a note of what the predecessor left on disk. Worktrees and branches
    survive agents; a replacement resumes from git state, not from memory.
+   Before a replacement reuses a branch or worktree, confirm no new commits
+   for a full check interval: the predecessor may still be writing, and two
+   agents in one worktree destroy each other.
 3. **Drop**: if the same item kills two agents, the item is the problem.
    Drop it, record it in the backlog with what was observed, move on.
-4. **Stop**: if the captain itself dies twice on one version, that counts
-   toward the two-failed-releases stop condition in
-   [safety.md](./safety.md).
+4. **Stop**: if the captain itself dies twice on one version, the
+   engagement stops, per the two-failed-releases family of stop conditions
+   in [safety.md](./safety.md) and the skill.
 
 ## Rules for the watchers themselves
 
 - Watchdogs are cheap, read-only, and bounded: one pass, one compact report,
   then gone. A watchdog never fixes anything and never messages the watched
   agent's siblings.
-- Watchdogs run foreground like everyone else. A backgrounded watchdog is the
-  failure mode it was hired to catch.
-- Every check is logged in one line to the engagement's scratch state, so the
-  next watchdog can tell "still slow" from "newly dead".
+- Watchdogs spawn foreground: they run for seconds, and the liveness answer
+  must not depend on the mechanism it exists to check.
+- Every check is logged in one line to the engagement's scratch state, so
+  the next watchdog can tell "still slow" from "newly dead".
+
+## Degraded mode
+
+When the harness cannot run background children with completion
+notifications, everything above collapses to the older rule: children spawn
+foreground, one at a time, and the cadences mean "at the first boundary
+after this much time has passed". Slower, never silent. The delivery lead
+decides which world the engagement is in once, at preflight, by probing:
+spawn one trivial background child and see whether its completion
+notification arrives. The verdict goes in the ledger header and in every
+captain's brief, and each parent writes it into its scratch state so its
+watchdogs and any successor know which rules apply.

--- a/docs/autonomy/watchdogs.md
+++ b/docs/autonomy/watchdogs.md
@@ -30,7 +30,8 @@ held them.
   child that was never told to journal cannot be judged by its silence.
 - **First-activity check**: within about ten minutes of a spawn, every
   child's journal must exist. A child with no first activity is a failed
-  spawn, not a slow thinker; respawn it foreground, once.
+  spawn, not a slow thinker; respawn it foreground, once. A respawn that
+  also produces no first activity drops the item per the ladder below.
 - A completion notification resolves a roster entry. A parent reaching a
   phase boundary with unresolved entries either waits there doing bounded
   work (watchdog passes, reading finished verdicts, merge-tree checks),
@@ -67,8 +68,8 @@ held them.
 3. **Drop**: if the same item kills two agents, the item is the problem.
    Drop it, record it in the backlog with what was observed, move on.
 4. **Stop**: if the captain itself dies twice on one version, the
-   engagement stops, per the two-failed-releases family of stop conditions
-   in [safety.md](./safety.md) and the skill.
+   engagement stops, per the stop conditions in
+   [safety.md](./safety.md).
 
 ## Rules for the watchers themselves
 


### PR DESCRIPTION
Redesigns the autonomous delivery organization around what the last engagement actually cost: serialized child spawning that made five builders run as the sum of their durations, stacked PRs that needed hand repair at merge time, a delivery lead whose context filled with narratives it never needed, a mandate re-argued four cycles with no answer, and a GitHub Actions outage that found no doctrine waiting for it. The org is now written as a small agile company: it takes a batch, consumes it, ships it, takes the next one, and quality roles (challenger, independent verifiers) are the shape, not a tax on it.

## What changed and why

**New: `docs/autonomy/composition.md`.** Owns the batch (3 to 6 work items, one release), the issue/internal quota, author weighting with a contributor floor, and mandate decay. Wired into `AUTONOMY.md` and `docs/autonomy.md`.

**New: `docs/autonomy/infrastructure.md`.** Owns outage-versus-work diagnosis, an infra preflight, build-ahead mode (keep auditing, building and verifying while merges are blocked; queue verified PRs in a specified `merge-queue.md`; never merge blind, never idle-poll), and the fact that neither `ci.yml` nor `rust.yml` has a `workflow_dispatch` trigger, so close/reopen is the only way to summon a run.

**`docs/autonomy/release-loop.md`.** Build and verify now stream: footprint-disjoint items build concurrently (scouts predict per-item file footprints, shared hotspots count as overlap, builders stop and report on leaving their footprint), verifiers spawn per finished build in their own worktrees. Stacked PRs are banned outright (a squash-merged parent does not retarget its child; the child conflicts on retarget). Merges stay strictly serialized with `main`'s own CI polled green between, plus a refresh rule when consecutive queue entries share a package. Adds the data playbook (migration against a `VACUUM INTO` copy, crash-mid-migration recovery, previous-version behavior, number free at merge time).

**`docs/autonomy/safety.md`.** Strengthened only. New irreversible-data gate keyed on irreversibility, not the word "migration": class A (additive) versus class B (`NOT NULL`/`UNIQUE` on existing tables, drops, backfills, anything the previous app plus the existing database cannot survive). Owner question filed before any builder spawns; any migration-touching item gets a dedicated schema challenge and a second verifier; class B holds its merge until the owner answers and never ships on silence, while the release ships without it. Also: an infra-paused release is explicitly a pause, not a failed release.

**`docs/autonomy/watchdogs.md`.** The liveness answer for concurrency, replacing the blanket foreground rule: roster written to disk before any batch (a crash manifest keyed on git state, not harness task ids), mandatory heartbeat journals for builders and verifiers, a ten-minute first-activity check, a parent that never proceeds past an unresolved roster entry, 30-minute watchdog passes with a two-check stuck threshold, and a probed foreground degraded mode when notifications are unavailable. Strictly stronger than the old rule: the old failure (a backgrounded child ending its turn silently) is now detectable from disk within one check interval instead of prevented by giving up concurrency.

**`docs/autonomy/roles.md`.** Company framing, concurrency and disk-reporting contracts in the binding rules, challenger recast as the role that assumes the work is bad, scout footprint duty, builder footprint/stop rule, verifier doubling on migration PRs.

**`docs/autonomy/issue-triage.md`.** Backlog entries now carry author class, priority, date and skip count; skipped contributor items get told what outranked them on their thread.

**Skill (`SKILL.md` + captain brief).** Lead probes the concurrency mode at preflight, composes briefs with quota, candidates, held PRs and suspended mandates, may run the captain in background with the triage sweep concurrent, reads verdicts and exceptions from disk instead of narratives, and handles `merged-partial` and `paused (infrastructure)` verdicts explicitly. Releases stay serial even when their internals are not. `repo-gotchas.md` gains the stacked-PR retarget trap, the missing `workflow_dispatch`, and the turbo shared-cache false green.

## Every default number and why

- **Quota 60% issue-backed / 40% internal, per batch, at plan time.** Issues are the owner's sanctioned steering channel and the side that has starved; the internal share is what caught defects no issue named (a cost engine recording zero for three providers). Measured over plan-time work items, never merged PRs, because PR counts are the metric `AUTONOMY.md` already refuses to steer by. Owner tunes it with one `quota:` line in the mandates file.
- **Contributor floor: aging promotion after 2 skipped batches, acting in the third.** One skip is prioritization, two is a pattern. Promotion beats author weight, never a higher priority band, so the floor cannot force weak work over a release blocker.
- **Mandate decay: 3 written, unanswered push-backs, then loud self-suspension.** One is a question, two a disagreement, three a deadlock; re-litigating past that burned reasoning-tier tokens for zero new information. Any owner edit to the mandate resets the count.
- **Builder concurrency cap 3 (4 for docs/UI-light items).** Whole-workspace test runs and cargo builds contend on one machine; load flakes read as red and the two-repair rule then drops healthy PRs.
- **Watchdog: 30-minute passes, stuck after 2 silent checks, 10-minute first-activity check, 2-hour lead rule.** Cadences carried over from the previous doc; the heartbeat journal is what makes the silence heuristic meaningful, and the first-activity check separates spawn failure from slow thinking.
- **Batch 3 to 6 items and the 5-release engagement cap: unchanged.** Disk reporting attacks the real cap (lead context) rather than raising the number on faith.

## The two challenge rounds and what they moved

A cold adversarial agent attacked the two decisions most likely to be wrong; a second cold agent then reviewed the finished docs for contradictions and executability.

**Parallelism.** The challenger argued the roster-plus-notifications liveness answer was weaker than foreground (notification loss is indistinguishable from slowness; a dead captain orphans a whole batch; file disjointness is blind to the two recorded semantic main-breakers; no concurrency cap ignores the machine). It moved: the batch-barrier became a streamed pipeline (verify per finished build), the cap of 3 exists, heartbeat journals and the first-activity check exist, the roster became a git-state crash manifest with an explicit replacement protocol, hotspot files count as overlap, builders carry a stop-on-breach rule, and the between-merge branch-refresh rule was added. Rejected from the challenge: dropping builder concurrency entirely, because serial building never protected against semantic conflicts anyway (all branches were cut from the same base and merged at the end; the serial merge lane plus main-CI polling is the mechanism that held, and it is untouched).

**Quota.** The challenger argued a rolling merged-PR window oscillates (one batch replaces half the window), counts the metric the constitution disavows, and quotas a distinction the backlog does not maintain. It moved: the window is gone (per-batch target at plan time), items not PRs are counted, provenance is defined and immutable at plan time, an explicit precedence chain (safety > mandates > filler ban > quota > rotation) resolves the steering-channel conflict, and the forced contributor slot became aging promotion. Rejected from the challenge: deleting the quota in favor of aging pressure alone, because an explicit tunable number is the owner's stated requirement; the declared-deviation rule is what keeps it a target instead of Goodhart bait.

## Deliberately left alone

- Adding `workflow_dispatch` to `ci.yml`/`rust.yml`: a `ci`-scoped change out of place in a docs PR; recorded as a fact plus a proposed backlog item in `infrastructure.md` and `repo-gotchas.md`.
- The serialized merge discipline, the verification standard (sabotage included), the publication boundary, the area rotation list, the issue decision tree, the triage voice and disclosure line, and every entry in safety.md's Forbidden list: intact or strengthened, nothing softened.
- The 5-release engagement cap and 3-to-6 item batch size.
- The release-notes honesty rules in `release-loop.md` and `tone-of-voice.md`.

## Test plan

Docs-only. Prettier clean on all twelve files; lefthook pre-commit and commitlint ran green. Cross-references checked file-by-file (all relative links resolve; new files indexed from both `AUTONOMY.md` and `docs/autonomy.md`; every brief placeholder is filled by the skill). No em-dashes, English only. An independent cold review verified a fresh agent can execute an engagement from these files alone; its findings (an undefined report verdict, a tier table the captain could not reach, the held-PR adoption path, the merge-queue format) are fixed in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
