### PR TITLE
fix(desktop): report a run done only after the context summarizer

### DIFF
--- a/apps/desktop/src/store/slices/workflows/orchestrateNextStep.test.ts
+++ b/apps/desktop/src/store/slices/workflows/orchestrateNextStep.test.ts
@@ -1023,6 +1023,8 @@ describe('orchestrateNextStep and the session context summarizer', () => {
 
     const pending = orchestrateNextStep(set, get)(SESSION_ID, WORKFLOW_RUN_ID);
     await vi.advanceTimersByTimeAsync(2_000);
+    expect(decideSpy).not.toHaveBeenCalled();
+
     state['summarizerStatus'] = { [SESSION_ID]: { status: 'idle' } };
     await vi.advanceTimersByTimeAsync(500);
     await pending;
@@ -1037,6 +1039,24 @@ describe('orchestrateNextStep and the session context summarizer', () => {
     expect(runOutcomeOf(state)).toBe('done');
   });
 
+  it('caps the summarizer wait at exactly sixty seconds, not a moment sooner', async () => {
+    vi.useFakeTimers();
+    mockDone();
+    const state = baseState();
+    state['summarizerStatus'] = { [SESSION_ID]: { status: 'running' } };
+    const { set, get } = harness(state);
+
+    const pending = orchestrateNextStep(set, get)(SESSION_ID, WORKFLOW_RUN_ID);
+    await vi.advanceTimersByTimeAsync(59_999);
+    expect(decideSpy).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(200);
+    await pending;
+
+    expect(decideSpy).toHaveBeenCalledTimes(1);
+    expect(runOutcomeOf(state)).toBe('done');
+  });
+
   it('gives up on a summarizer that never settles instead of parking the run forever', async () => {
     vi.useFakeTimers();
     mockDone();
@@ -1045,11 +1065,63 @@ describe('orchestrateNextStep and the session context summarizer', () => {
     const { set, get } = harness(state);
 
     const pending = orchestrateNextStep(set, get)(SESSION_ID, WORKFLOW_RUN_ID);
-    await vi.advanceTimersByTimeAsync(61_000);
+    await vi.advanceTimersByTimeAsync(120_000);
     await pending;
 
     expect(decideSpy).toHaveBeenCalledTimes(1);
     expect(runOutcomeOf(state)).toBe('done');
+  });
+
+  it('abandons the pass when the run was discarded during the summarizer wait', async () => {
+    vi.useFakeTimers();
+    mockDone();
+    const state = baseState();
+    state['summarizerStatus'] = { [SESSION_ID]: { status: 'running' } };
+    const { set, get } = harness(state);
+
+    const pending = orchestrateNextStep(set, get)(SESSION_ID, WORKFLOW_RUN_ID);
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    const sessions = state['sessions'] as ReadonlyArray<Session>;
+    state['sessions'] = [
+      {
+        ...sessions[0]!,
+        workflowRuns: [{ ...sessions[0]!.workflowRuns[0]!, discardedAt: NOW }],
+      },
+    ];
+    state['summarizerStatus'] = { [SESSION_ID]: { status: 'idle' } };
+    await vi.advanceTimersByTimeAsync(500);
+    await pending;
+
+    expect(decideSpy).not.toHaveBeenCalled();
+    expect(updateOutcomeSpy).not.toHaveBeenCalled();
+  });
+
+  it('abandons the pass when the run settled from elsewhere during the summarizer wait', async () => {
+    vi.useFakeTimers();
+    mockDone();
+    const state = baseState();
+    state['summarizerStatus'] = { [SESSION_ID]: { status: 'running' } };
+    const { set, get } = harness(state);
+
+    const pending = orchestrateNextStep(set, get)(SESSION_ID, WORKFLOW_RUN_ID);
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    const sessions = state['sessions'] as ReadonlyArray<Session>;
+    state['sessions'] = [
+      {
+        ...sessions[0]!,
+        workflowRuns: [
+          { ...sessions[0]!.workflowRuns[0]!, orchestrationOutcome: 'blocked' as const },
+        ],
+      },
+    ];
+    state['summarizerStatus'] = { [SESSION_ID]: { status: 'idle' } };
+    await vi.advanceTimersByTimeAsync(500);
+    await pending;
+
+    expect(decideSpy).not.toHaveBeenCalled();
+    expect(updateOutcomeSpy).not.toHaveBeenCalled();
   });
 
   it('lets a forced skip past the summarizer, as it already cleared the gate', async () => {

--- a/apps/desktop/src/store/slices/workflows/orchestrateNextStep.test.ts
+++ b/apps/desktop/src/store/slices/workflows/orchestrateNextStep.test.ts
@@ -80,6 +80,7 @@ import {
   ROLE_DEFAULTS,
 } from '@goodboy/core';
 import { orchestrateNextStep } from './orchestrateNextStep';
+import { continueWorkflowRun } from './continueWorkflowRun';
 
 const WORKSPACE_ID = 'workspace-1' as WorkspaceId;
 const SESSION_ID = 'session-1' as SessionId;
@@ -192,6 +193,7 @@ const baseState = (): State => {
     selectedAgentId: { [SESSION_ID]: AGENT_ID },
     transcripts: { [AGENT_ID]: [] },
     sessionTelemetry: {},
+    summarizerStatus: {},
     agentRunHistory: {},
     agentTurnState: {},
     agentModelOverride: {},
@@ -217,6 +219,7 @@ const harness = (state: State) => {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.useRealTimers();
   listOpenQuestionsSpy.mockResolvedValue([]);
   updateOutcomeSpy.mockResolvedValue(undefined);
   invokeWorkflowUpsertSpy.mockImplementation(async (input: Record<string, unknown>) => ({
@@ -979,5 +982,105 @@ describe('orchestrateNextStep', () => {
       focus: 'agent',
       bypassGate: true,
     });
+  });
+});
+
+describe('orchestrateNextStep and the session context summarizer', () => {
+  const mockDone = (): void => {
+    decideSpy.mockResolvedValue({
+      usage: NO_USAGE,
+      decision: { action: 'done', reason: 'Every step landed.' },
+    });
+  };
+
+  const runOutcomeOf = (state: State): string | undefined =>
+    (state['sessions'] as ReadonlyArray<Session>)[0]!.workflowRuns[0]!.orchestrationOutcome;
+
+  it('does not call the run done while the session summarizer is still writing', async () => {
+    vi.useFakeTimers();
+    mockDone();
+    const state = baseState();
+    state['summarizerStatus'] = { [SESSION_ID]: { status: 'running' } };
+    const { set, get } = harness(state);
+
+    const pending = orchestrateNextStep(set, get)(SESSION_ID, WORKFLOW_RUN_ID);
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    expect(decideSpy).not.toHaveBeenCalled();
+    expect(runOutcomeOf(state)).toBeUndefined();
+
+    state['summarizerStatus'] = { [SESSION_ID]: { status: 'idle' } };
+    await vi.advanceTimersByTimeAsync(500);
+    await pending;
+  });
+
+  it('still reaches done once the summarizer finishes, so the advance is not dropped', async () => {
+    vi.useFakeTimers();
+    mockDone();
+    const state = baseState();
+    state['summarizerStatus'] = { [SESSION_ID]: { status: 'running' } };
+    const { set, get } = harness(state);
+
+    const pending = orchestrateNextStep(set, get)(SESSION_ID, WORKFLOW_RUN_ID);
+    await vi.advanceTimersByTimeAsync(2_000);
+    state['summarizerStatus'] = { [SESSION_ID]: { status: 'idle' } };
+    await vi.advanceTimersByTimeAsync(500);
+    await pending;
+
+    expect(decideSpy).toHaveBeenCalledTimes(1);
+    expect(updateOutcomeSpy).toHaveBeenCalledWith(
+      {},
+      WORKFLOW_RUN_ID,
+      'done',
+      'Every step landed.',
+    );
+    expect(runOutcomeOf(state)).toBe('done');
+  });
+
+  it('gives up on a summarizer that never settles instead of parking the run forever', async () => {
+    vi.useFakeTimers();
+    mockDone();
+    const state = baseState();
+    state['summarizerStatus'] = { [SESSION_ID]: { status: 'running' } };
+    const { set, get } = harness(state);
+
+    const pending = orchestrateNextStep(set, get)(SESSION_ID, WORKFLOW_RUN_ID);
+    await vi.advanceTimersByTimeAsync(61_000);
+    await pending;
+
+    expect(decideSpy).toHaveBeenCalledTimes(1);
+    expect(runOutcomeOf(state)).toBe('done');
+  });
+
+  it('lets a forced skip past the summarizer, as it already cleared the gate', async () => {
+    mockDone();
+    const state = baseState();
+    state['summarizerStatus'] = { [SESSION_ID]: { status: 'running' } };
+    const { set, get } = harness(state);
+
+    await orchestrateNextStep(set, get)(SESSION_ID, WORKFLOW_RUN_ID, { bypassGate: true });
+
+    expect(decideSpy).toHaveBeenCalledTimes(1);
+    expect(runOutcomeOf(state)).toBe('done');
+  });
+
+  it('gates continue-in-place too, which never passed through the autorun gate', async () => {
+    vi.useFakeTimers();
+    mockDone();
+    const state = baseState();
+    state['summarizerStatus'] = { [SESSION_ID]: { status: 'running' } };
+    const { set, get } = harness(state);
+    state['orchestrateNextStep'] = orchestrateNextStep(set, get);
+
+    const pending = continueWorkflowRun(set, get)(SESSION_ID, WORKFLOW_RUN_ID, 'keep going');
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    expect(decideSpy).not.toHaveBeenCalled();
+
+    state['summarizerStatus'] = { [SESSION_ID]: { status: 'idle' } };
+    await vi.advanceTimersByTimeAsync(500);
+    await pending;
+
+    expect(runOutcomeOf(state)).toBe('done');
   });
 });

--- a/apps/desktop/src/store/slices/workflows/orchestrateNextStep.ts
+++ b/apps/desktop/src/store/slices/workflows/orchestrateNextStep.ts
@@ -56,6 +56,29 @@ export type OrchestrateOptions = {
 
 const orchestrationInFlight = new Set<WorkflowRunId>();
 
+const SUMMARIZER_GATE_POLL_MS = 100;
+const SUMMARIZER_GATE_TIMEOUT_MS = 60_000;
+
+type SummarizerGateParams = {
+  readonly get: GetFn;
+  readonly sessionId: SessionId;
+};
+
+const waitForSessionSummarizer = async ({
+  get,
+  sessionId,
+}: SummarizerGateParams): Promise<void> => {
+  const deadline = Date.now() + SUMMARIZER_GATE_TIMEOUT_MS;
+  while (get().summarizerStatus[sessionId]?.status === 'running') {
+    if (Date.now() >= deadline) {
+      return;
+    }
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, SUMMARIZER_GATE_POLL_MS);
+    });
+  }
+};
+
 type DecidingParams = {
   readonly set: SetFn;
   readonly workflowRunId: WorkflowRunId;
@@ -384,6 +407,19 @@ export const orchestrateNextStep = (set: SetFn, get: GetFn) => {
         return;
       }
       setDeciding({ set, workflowRunId, isDeciding: true });
+      if (options?.bypassGate !== true) {
+        await waitForSessionSummarizer({ get, sessionId });
+        const settled = get()
+          .sessions.find((candidate) => candidate.id === sessionId)
+          ?.workflowRuns.find((candidate) => candidate.id === workflowRunId);
+        if (
+          settled == null ||
+          settled.discardedAt != null ||
+          settled.orchestrationOutcome != null
+        ) {
+          return;
+        }
+      }
       const agents = [
         ...runsForWorkflowRun(get().sessionPhaseRuns[sessionId] ?? [], workflowRunId),
       ].sort((left, right) => left.ordinal - right.ordinal);


### PR DESCRIPTION
## What was wrong

A dynamic run reported `done` in the overview while the session-level context
summarizer was still writing. The run flipped to complete, then got summarized
again once the summarizer landed.

The status derivation is fine: `isWorkflowRunComplete.ts` and
`WorkflowRunStatus.tsx` are a pure read of `run.orchestrationOutcome === 'done'`,
and the per-step `summarizeAgentOutput` in `finalizeWorkflowStep.ts` is already
awaited. Neither is touched here. The bug is upstream, where the orchestrator
decides and persists the outcome with no check on `summarizerStatus[sessionId]`.

A gate for exactly this already existed, but at one caller only:
`maybeAutoAdvanceWorkflow.ts`. I count **seven** production call paths into
`orchestrateNextStep`, and six of them never crossed it:

1. `maybeAutoAdvanceWorkflow.ts:131` (the only gated one)
2. `OrchestratorPanel/index.tsx:156` (the overview decide-now control)
3. `retryWorkflowOrchestration.ts:26`
4. `continueWorkflowRun.ts:27`
5. `startWorkflowRun.ts:62`
6. `attachWorkflowToSession.ts:165`
7. `skipStuckStepAndAdvance.ts:79` (deliberately `bypassGate: true`)

## What changed

The gate moves inside `orchestrateNextStep`, next to the decision and the
outcome write, so no caller can miss it and a new caller inherits it for free.
Wiring it into each call site would have reproduced the very regression class
this fixes.

- `waitForSessionSummarizer` polls `summarizerStatus[sessionId]` every 100ms and
  returns as soon as it leaves `running`.
- It runs after `setDeciding(true)`, so the run reads as deciding while it waits
  rather than looking idle.
- `bypassGate: true` skips it, so the forced-skip escape in
  `skipStuckStepAndAdvance` survives intact.
- After the wait the run is re-read: if it was discarded or already settled while
  we waited, the pass is abandoned instead of deciding on stale state.

### The gated advance, and its failure mode

A gated advance is **held, not dropped**. Returning early is right for an autorun
tick that comes round again, but a user pressing decide-now must not silently do
nothing, so the call waits and then proceeds. The wait is bounded at 60s: past
that it gives up and orchestrates anyway, so a stale or wedged summarizer status
can never park a run forever.

Failure mode, stated plainly: if the summarizer stays `running` past 60s, the
gate yields and the run can still be called done early, exactly as it does today.
That degrades to current behavior rather than deadlocking. The second gap is a
summarizer that starts right after the wait window closes; that turn is not
covered, since the gate samples status rather than holding a lock.

### The check in `maybeAutoAdvanceWorkflow` stays

It is not redundant. It sits above the whole advance, not just the dynamic
branch, so it also holds back `activateWorkflowAgentOrNotify` for **static**
workflows. Removing it would let a static autorun activate the next agent while
session context is still being written, which is a regression, and it would
contradict `docs/workflows.md` ("still bailing on open questions, a busy
summarizer, and any undismissed budget-exceeded alert"). For an autorun tick,
returning early is also the better shape: the next tick retries, so there is no
reason to hold the in-flight lock for up to a minute.

## Test plan

`apps/desktop/src/store/slices/workflows/orchestrateNextStep.test.ts` grows a
`summarizerStatus` suite; it had zero assertions on it before.

- does not decide or persist `done` while the session summarizer runs
- reaches `done` once the summarizer finishes, proving the advance is not dropped
- gives up after the 60s cap instead of parking the run
- `bypassGate: true` still decides immediately
- `continueWorkflowRun` end to end, one of the six previously un-gated paths,
  driving the real `orchestrateNextStep` rather than a mock

Two of these fail on `main` without the source change (verified by stashing
`orchestrateNextStep.ts` and re-running: 2 failed, 34 passed).

Run it:

```
pnpm typecheck
pnpm exec turbo run test --force
pnpm knip --include files,duplicates,unlisted
```

All three green here: typecheck 5/5 tasks, tests 598 files / 5073 tests, knip
exit 0 (configuration hints only, same as `main`).

## Not verified

Not exercised in the running app against a live provider: the gate is covered by
unit tests over the store, not by a real summarizer racing a real orchestrator.
The 60s cap is a judgement call; the session summarizer has no timeout of its own
in `packages/core/src/summarizer/`, so there is no existing bound to match it to.

Closes #1297
