### PR TITLE
fix(desktop): stop workflow attach from stealing the active lens

### DIFF
--- a/apps/desktop/src/features/chat/components/ChatInput/hooks/useChatPrefix.ts
+++ b/apps/desktop/src/features/chat/components/ChatInput/hooks/useChatPrefix.ts
@@ -90,7 +90,7 @@ export function useChatPrefix({
       setValue('');
       setShowPopover(false);
       try {
-        await attachWorkflowToSession(session.id, workflow.id);
+        await attachWorkflowToSession(session.id, workflow.id, { navigate: true });
         showToast('success', `workflow "${workflow.name}" started`);
       } catch (err) {
         showToast('error', formatError(err));

--- a/apps/desktop/src/features/chat/components/ChatInput/hooks/useChatPrefix/index.test.tsx
+++ b/apps/desktop/src/features/chat/components/ChatInput/hooks/useChatPrefix/index.test.tsx
@@ -1,0 +1,88 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Session, SessionId, StepId, Workflow, WorkflowId, WorkspaceId } from '@goodboy/types';
+import { useAppStore } from '../../../../../../store';
+import { useChatPrefix } from './index';
+
+const WS_ID = 'ws-1' as WorkspaceId;
+const WF_ID = 'wf-1' as WorkflowId;
+const SESSION_ID = 'session-1' as SessionId;
+
+const workflow: Workflow = {
+  id: WF_ID,
+  workspaceId: WS_ID,
+  name: 'ship it',
+  description: '',
+  steps: [
+    {
+      id: 'step-0' as StepId,
+      workflowId: WF_ID,
+      ordinal: 0,
+      name: 'Step',
+      role: 'engineer',
+      effort: 'medium',
+      verbosity: 'normal',
+    },
+  ],
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+} as unknown as Workflow;
+
+const session: Session = {
+  id: SESSION_ID,
+  workspaceId: WS_ID,
+  goal: 'g',
+  workflowRuns: [],
+  autoRun: false,
+} as unknown as Session;
+
+const mockAttach = vi.fn(async () => undefined);
+
+const initialState = useAppStore.getState();
+
+function renderChatPrefix() {
+  return renderHook(() =>
+    useChatPrefix({
+      session,
+      value: '~',
+      setValue: vi.fn(),
+      sessionWorktree: null,
+      showToast: vi.fn(),
+      wrapperRef: { current: null },
+    }),
+  );
+}
+
+beforeEach(() => {
+  mockAttach.mockClear();
+  useAppStore.setState({
+    ...initialState,
+    skills: {},
+    workspaceScripts: {},
+    phaseTemplates: { [WS_ID]: [workflow] },
+    sessionPhaseRuns: {},
+    agentKindOverride: {},
+    attachWorkflowToSession: mockAttach,
+  });
+});
+
+afterEach(() => {
+  useAppStore.setState(initialState, true);
+});
+
+describe('useChatPrefix, workflow quick action', () => {
+  it('attaches the workflow with navigate: true so the picked workflow is shown', async () => {
+    const { result } = renderChatPrefix();
+
+    const item = result.current.filteredQuickItems.find((it) => it.id === `workflow:${WF_ID}`);
+    expect(item).toBeDefined();
+
+    act(() => {
+      result.current.onQuickActionSelect(item!);
+    });
+
+    await waitFor(() =>
+      expect(mockAttach).toHaveBeenCalledWith(SESSION_ID, WF_ID, { navigate: true }),
+    );
+  });
+});

--- a/apps/desktop/src/features/chat/components/ChatInput/hooks/useChatPrefix/index.ts
+++ b/apps/desktop/src/features/chat/components/ChatInput/hooks/useChatPrefix/index.ts
@@ -1,10 +1,10 @@
 import { useCallback, useMemo, useState, type RefObject } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import type { Agent, Session, Skill, Workflow, WorkspaceScript } from '@goodboy/types';
-import { EMPTY_ARRAY, useAppStore } from '../../../../../store';
-import { formatError } from '../../../../../shared/lib/errors';
-import { WORKSPACE_FEATURES } from '../../../../../shared/lib/features';
-import type { ToastKind } from '../../../../../app/components/Toast';
+import { EMPTY_ARRAY, useAppStore } from '../../../../../../store';
+import { formatError } from '../../../../../../shared/lib/errors';
+import { WORKSPACE_FEATURES } from '../../../../../../shared/lib/features';
+import type { ToastKind } from '../../../../../../app/components/Toast';
 import {
   QuickActionsPopover,
   buildAgentActions,
@@ -13,8 +13,8 @@ import {
   buildWorkflowActions,
   parseQuery,
   type QuickActionItem,
-} from '../../../../quick-actions';
-import { CHAT_PREFIX_RE } from '../lib';
+} from '../../../../../quick-actions';
+import { CHAT_PREFIX_RE } from '../../lib';
 
 export { QuickActionsPopover };
 

--- a/apps/desktop/src/features/companion/commandExecutor.commands.test.ts
+++ b/apps/desktop/src/features/companion/commandExecutor.commands.test.ts
@@ -14,6 +14,7 @@ const h = vi.hoisted(() => ({
   activateNextResolver: vi.fn(() => Promise.resolve()),
   upsertSessionSlot: vi.fn(() => Promise.resolve()),
   mergePr: vi.fn(() => Promise.resolve()),
+  attachWorkflowToSession: vi.fn(() => Promise.resolve()),
   createSession: vi.fn(
     async (input: { workspaceId: string; goal: string }) =>
       ({ session: { id: 'new-session-1', goal: input.goal }, worktree: {} }) as unknown,
@@ -168,6 +169,7 @@ function makeStore(over: Record<string, unknown> = {}) {
     upsertSessionSlot: h.upsertSessionSlot,
     mergePr: h.mergePr,
     createSession: h.createSession,
+    attachWorkflowToSession: h.attachWorkflowToSession,
     ...over,
   };
 }
@@ -1005,5 +1007,24 @@ describe('createSessionFromIssue (security-gated write)', () => {
       );
       expect(res.ok).toBe(true);
     }
+  });
+});
+
+describe('spawnWorkflow (mobile companion bridge)', () => {
+  it('attaches in the background with navigate: false so it never yanks a desktop viewer', async () => {
+    h.state.value = makeStore({
+      phaseTemplates: { w1: [{ id: 'wf-a' }] },
+    });
+
+    const res = await executeBridgeCommand(
+      cmd('spawnWorkflow', { sessionId: 's1', workflowId: 'wf-a' }),
+    );
+
+    expect(res.ok).toBe(true);
+    expect(h.attachWorkflowToSession).toHaveBeenCalledWith('s1', 'wf-a', {
+      autoRun: false,
+      triggerMode: 'manual',
+      navigate: false,
+    });
   });
 });

--- a/apps/desktop/src/features/companion/commandExecutor.ts
+++ b/apps/desktop/src/features/companion/commandExecutor.ts
@@ -633,6 +633,7 @@ async function dispatchMobile(cmd: BridgeCommand): Promise<unknown> {
       await store.attachWorkflowToSession(gate.sessionId, gate.workflowId, {
         autoRun: false,
         triggerMode: 'manual',
+        navigate: false,
       });
       return undefined;
     }

--- a/apps/desktop/src/features/session/components/WorkflowBuilderView/index.test.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowBuilderView/index.test.tsx
@@ -291,6 +291,7 @@ describe('WorkflowBuilderView (custom mode, no presets)', () => {
     await waitFor(() =>
       expect(mockAttach).toHaveBeenCalledWith('sess-1', saved.id, {
         autoRun: false,
+        navigate: true,
         goal: 'test goal',
       }),
     );
@@ -309,6 +310,7 @@ describe('WorkflowBuilderView (custom mode, no presets)', () => {
     await waitFor(() =>
       expect(mockAttach).toHaveBeenCalledWith('sess-1', expect.any(String), {
         autoRun: false,
+        navigate: true,
         goal: 'just the auth module',
       }),
     );
@@ -389,6 +391,7 @@ describe('WorkflowBuilderView (custom mode, no presets)', () => {
     await waitFor(() =>
       expect(mockAttach).toHaveBeenCalledWith('sess-1', expect.any(String), {
         autoRun: true,
+        navigate: true,
         goal: 'test goal',
       }),
     );
@@ -459,6 +462,7 @@ describe('WorkflowBuilderView (orchestrated mode)', () => {
     await waitFor(() =>
       expect(mockAttach).toHaveBeenCalledWith('sess-1', saved.id, {
         autoRun: true,
+        navigate: true,
         goal: 'test goal',
         executionMode: 'dynamic',
       }),
@@ -566,6 +570,7 @@ describe('WorkflowBuilderView (preset mode)', () => {
     await waitFor(() =>
       expect(mockAttach).toHaveBeenCalledWith('sess-1', 'wf-preset-1', {
         autoRun: false,
+        navigate: true,
         goal: 'review only the db layer',
       }),
     );
@@ -604,6 +609,7 @@ describe('WorkflowBuilderView (trigger modes)', () => {
     await waitFor(() =>
       expect(mockAttach).toHaveBeenCalledWith('sess-1', expect.any(String), {
         autoRun: false,
+        navigate: true,
         goal: 'test goal',
         triggerMode: 'manual',
       }),
@@ -641,6 +647,7 @@ describe('WorkflowBuilderView (trigger modes)', () => {
     await waitFor(() =>
       expect(mockAttach).toHaveBeenCalledWith('sess-1', 'wf-next', {
         autoRun: false,
+        navigate: true,
         goal: 'test goal',
         triggerMode: 'after_run',
         chainAfterId: 'run-prev',

--- a/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
@@ -563,6 +563,7 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
     const after = triggerMode === 'after_run' ? resolvedChainId : null;
     return {
       autoRun,
+      navigate: true,
       ...(goal.length > 0 && { goal }),
       ...(triggerMode !== 'immediate' && { triggerMode }),
       ...(triggerMode === 'after_run' && after && { chainAfterId: after }),

--- a/apps/desktop/src/store/slices/workflows/attachWorkflowToSession.navigation.test.ts
+++ b/apps/desktop/src/store/slices/workflows/attachWorkflowToSession.navigation.test.ts
@@ -91,7 +91,7 @@ beforeEach(() => {
   );
 });
 
-const buildState = (set: SetFn): StoreState => ({
+const buildState = (set: SetFn, activeLens: Record<SessionId, string | null>): StoreState => ({
   sessions: [session],
   phaseTemplates: { [WS_ID]: [workflow] },
   sessionPhaseRuns: {},
@@ -103,7 +103,7 @@ const buildState = (set: SetFn): StoreState => ({
   agentProviderOverride: {},
   agentEffortOverride: {},
   focusedWorkflowRunId: {},
-  activeLens: {},
+  activeLens,
   sessionStudio: {},
   selectedAgentId: { [SESSION_ID]: 'agent-elsewhere' },
   diffFocus: {},
@@ -113,11 +113,23 @@ const buildState = (set: SetFn): StoreState => ({
   setActiveLens: setActiveLens(set),
 });
 
-describe('starting a workflow lands on the workflow detail', () => {
-  it('opens the workflows lens on the new run without selecting a step agent', async () => {
+describe('starting a workflow focuses the run without hijacking the lens', () => {
+  it('leaves activeLens untouched when the user is reading a different lens', async () => {
     const state: StoreState = {};
     const { set, get } = harness(state);
-    Object.assign(state, buildState(set), {
+    Object.assign(state, buildState(set, { [SESSION_ID]: 'plans' }), {
+      activateWorkflowAgent: vi.fn(async () => undefined),
+    });
+
+    await attachWorkflowToSession(set, get)(SESSION_ID, WF_ID);
+
+    expect((state['activeLens'] as Record<SessionId, string | null>)[SESSION_ID]).toBe('plans');
+  });
+
+  it('still sets focusedWorkflowRunId while leaving a different lens untouched', async () => {
+    const state: StoreState = {};
+    const { set, get } = harness(state);
+    Object.assign(state, buildState(set, { [SESSION_ID]: 'plans' }), {
       activateWorkflowAgent: vi.fn(async () => undefined),
     });
 
@@ -125,6 +137,31 @@ describe('starting a workflow lands on the workflow detail', () => {
 
     const runId = (state['focusedWorkflowRunId'] as Record<SessionId, string | null>)[SESSION_ID];
     expect(runId).not.toBeNull();
+  });
+
+  it('still focuses the new run when already on the workflows lens', async () => {
+    const state: StoreState = {};
+    const { set, get } = harness(state);
+    Object.assign(state, buildState(set, { [SESSION_ID]: 'workflows' }), {
+      activateWorkflowAgent: vi.fn(async () => undefined),
+    });
+
+    await attachWorkflowToSession(set, get)(SESSION_ID, WF_ID);
+
+    const runId = (state['focusedWorkflowRunId'] as Record<SessionId, string | null>)[SESSION_ID];
+    expect(runId).not.toBeNull();
+    expect((state['activeLens'] as Record<SessionId, string | null>)[SESSION_ID]).toBe('workflows');
+  });
+
+  it('navigates to the workflows lens when the caller opts in', async () => {
+    const state: StoreState = {};
+    const { set, get } = harness(state);
+    Object.assign(state, buildState(set, { [SESSION_ID]: 'plans' }), {
+      activateWorkflowAgent: vi.fn(async () => undefined),
+    });
+
+    await attachWorkflowToSession(set, get)(SESSION_ID, WF_ID, { navigate: true });
+
     expect((state['activeLens'] as Record<SessionId, string | null>)[SESSION_ID]).toBe('workflows');
     expect((state['selectedAgentId'] as Record<SessionId, unknown>)[SESSION_ID]).toBeNull();
     expect((state['sessionStudio'] as Record<SessionId, unknown>)[SESSION_ID]).toBeNull();
@@ -134,7 +171,7 @@ describe('starting a workflow lands on the workflow detail', () => {
     const state: StoreState = {};
     const { set, get } = harness(state);
     const activateWorkflowAgent = vi.fn(async () => undefined);
-    Object.assign(state, buildState(set), { activateWorkflowAgent });
+    Object.assign(state, buildState(set, {}), { activateWorkflowAgent });
 
     await attachWorkflowToSession(set, get)(SESSION_ID, WF_ID);
 

--- a/apps/desktop/src/store/slices/workflows/attachWorkflowToSession.ts
+++ b/apps/desktop/src/store/slices/workflows/attachWorkflowToSession.ts
@@ -25,6 +25,7 @@ type Options = {
   chainAfterId?: WorkflowRunId;
   attachmentInputs?: ReadonlyArray<AttachmentInput>;
   executionMode?: WorkflowExecutionMode;
+  navigate?: boolean;
 };
 
 export const attachWorkflowToSession = (set: SetFn, get: GetFn) => {
@@ -149,7 +150,9 @@ export const attachWorkflowToSession = (set: SetFn, get: GetFn) => {
       focusedWorkflowRunId: { ...state.focusedWorkflowRunId, [sessionId]: workflowRunId },
     }));
 
-    get().setActiveLens(sessionId, 'workflows');
+    if (options?.navigate === true) {
+      get().setActiveLens(sessionId, 'workflows');
+    }
 
     const attachmentInputs = options?.attachmentInputs;
     if (attachmentInputs && attachmentInputs.length > 0) {

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -316,6 +316,7 @@ export type AppActions = {
       chainAfterId?: WorkflowRunId;
       attachmentInputs?: ReadonlyArray<AttachmentInput>;
       executionMode?: WorkflowExecutionMode;
+      navigate?: boolean;
     },
   ): Promise<void>;
   detachWorkflowFromSession(sessionId: SessionId, workflowRunId: WorkflowRunId): Promise<void>;


### PR DESCRIPTION
## Summary

`attachWorkflowToSession` unconditionally called `setActiveLens(sessionId, 'workflows')` on every attach. Any workflow that started while the user was reading a different lens (plans, terminal, files, etc.) silently yanked them into the workflows lens with no explanation.

- Added an opt-in `navigate?: boolean` field to the action's options. The lens switch only happens when a caller explicitly passes `navigate: true`.
- `focusedWorkflowRunId` is still set unconditionally on every attach, including when `navigate` is not requested, so the new run is already focused whenever the user does open the workflows lens (including when they're already on it).
- Updated every caller:
  - `WorkflowBuilderView` (`onStart`, both the preset-as-is and the newly-created-workflow paths) passes `navigate: true`. The user explicitly opened the builder and clicked start, and already gets a success toast, so navigating to show the result is expected.
  - `useChatPrefix`'s `onPickWorkflow` (the `~workflow` quick action in chat) passes `navigate: true` for the same reason: explicit pick, existing success toast.
  - `commandExecutor.ts`'s `spawnWorkflow` mobile-bridge command passes `navigate: false` explicitly. This is a background/remote trigger with no local toast or other affordance, so it must not steal the desktop user's current lens. This is very likely the exact path behind the reported bug.

No toast was added. Per `DESIGN.md`, toasts are reserved for errors and previews; this isn't either. The workflows lens row (and the run being pre-focused there) is the existing affordance. If a stronger signal for the background-attach case is wanted later, that's a separate decision outside this PR's scope.

## Test plan

- Added/rewrote `attachWorkflowToSession.navigation.test.ts`:
  - attaching while on a different lens leaves `activeLens` untouched
  - `focusedWorkflowRunId` is still set in that case
  - attaching while already on the workflows lens still (re-)focuses the new run
  - the explicit `navigate: true` caller does still switch to the workflows lens
  - the existing "activates the first step without taking focus" behavior is unaffected
- Updated `WorkflowBuilderView/index.test.tsx` exact-arg assertions on the mocked `attachWorkflowToSession` to include `navigate: true` for the builder's start flow.
- `pnpm typecheck`: green
- `pnpm test`: green (598 files, 5071 tests)
- `pnpm knip --include files,duplicates,unlisted`: clean (no new findings)

Closes #1298