### PR TITLE
fix(desktop): link a github issue to a session by hand

### DIFF
--- a/apps/desktop/src/features/session/components/SessionOverviewPane/LinkedWorkSection.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/LinkedWorkSection.test.tsx
@@ -176,6 +176,8 @@ describe('LinkedWorkSection', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Link work' }));
     fireEvent.click(screen.getByRole('menuitem', { name: 'GitLab issues' }));
     fireEvent.click(screen.getByRole('button', { name: 'Link work' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: 'GitHub issues' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Link work' }));
     fireEvent.click(screen.getByRole('menuitem', { name: 'Jira issues' }));
     fireEvent.click(screen.getByRole('button', { name: 'Link work' }));
     fireEvent.click(screen.getByRole('menuitem', { name: 'Slack threads' }));
@@ -184,6 +186,7 @@ describe('LinkedWorkSection', () => {
       ['linear'],
       ['sentry'],
       ['gitlab_issues'],
+      ['github_issue'],
       ['jira_issues'],
       ['slack_threads'],
     ]);

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/LinkedWorkSection.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/LinkedWorkSection.tsx
@@ -62,6 +62,13 @@ export const LinkedWorkSection = ({ sessionId, onSelectLens }: Props) => {
     },
     {
       kind: 'item',
+      key: 'github',
+      label: 'GitHub issues',
+      icon: CONCEPT_ICONS.github,
+      onClick: () => onSelectLens('github_issue'),
+    },
+    {
+      kind: 'item',
       key: 'jira',
       label: 'Jira issues',
       icon: CONCEPT_ICONS.jira,

--- a/apps/desktop/src/features/session/components/SessionWorkspace/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/index.test.tsx
@@ -188,6 +188,13 @@ vi.mock('./parts/IntegrationPane/GithubTaskDetail', () => ({
     <div data-testid="github-task-detail">{issueNumber}</div>
   ),
 }));
+vi.mock('./parts/IntegrationPane/LinkTicketPopover', () => ({
+  LinkTicketPopover: ({ provider }: { provider: string }) => (
+    <button type="button" data-testid="link-ticket-popover">
+      {`Link ${provider} issue`}
+    </button>
+  ),
+}));
 vi.mock('../../../../shared/components/PaneShell', () => ({
   PaneShell: ({ title, meta, children }: PaneShellMockProps) => (
     <div>
@@ -858,6 +865,24 @@ describe('SessionWorkspace github issue lens', () => {
 
     expect(screen.getByText('No GitHub issue linked')).toBeDefined();
     expect(screen.queryByTestId('github-task-detail')).toBeNull();
+    expect(screen.getByTestId('link-ticket-popover').textContent).toBe('Link github issue');
+  });
+
+  it('swaps the empty state for the linked issue once linking writes an external task', () => {
+    store.activeLens = { [SESSION_ID]: 'github_issue' };
+    store.selectedAgentId = {};
+    store.sessionExternalTasks = {};
+
+    const { rerender } = render(<SessionWorkspace session={session} isActive />);
+
+    expect(screen.getByText('No GitHub issue linked')).toBeDefined();
+    fireEvent.click(screen.getByTestId('link-ticket-popover'));
+
+    store.sessionExternalTasks = { [SESSION_ID]: [githubTask] };
+    rerender(<SessionWorkspace session={session} isActive />);
+
+    expect(screen.queryByText('No GitHub issue linked')).toBeNull();
+    expect(screen.getByTestId('github-task-detail').textContent).toBe('42');
   });
 
   it('renders the focused issue with no linked task at all', () => {

--- a/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
@@ -33,6 +33,7 @@ import { resolveOverlayHome } from './resolveOverlayHome';
 import { WorkflowsPane } from './parts/WorkflowsPane';
 import { IntegrationPane } from './parts/IntegrationPane';
 import { GithubTaskDetail } from './parts/IntegrationPane/GithubTaskDetail';
+import { LinkTicketPopover } from './parts/IntegrationPane/LinkTicketPopover';
 import { useAttachedWorkflowRuns } from '../../../workflows/useAttachedWorkflowRuns';
 import { isStandaloneAgent, resolveRootAgent } from '../../agent-kind';
 import { useResolverIndex } from '../../hooks/useResolverIndex';
@@ -404,6 +405,17 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
                         tone={CONCEPT_TONE.github}
                         title="No GitHub issue linked"
                         description="Link a GitHub issue to this session to see it here."
+                        action={
+                          <LinkTicketPopover
+                            sessionId={sessionId}
+                            workspaceId={session.workspaceId}
+                            provider="github"
+                            providerLabel="GitHub"
+                            noun="issue"
+                            nounPhrase="an issue"
+                            nounPlural="issues"
+                          />
+                        }
                       />
                     </PaneShell>
                   )


### PR DESCRIPTION
## What changed

- `LinkedWorkSection`'s link menu now includes a GitHub item, alongside Linear, Sentry, GitLab, Jira, and Slack.
- The `github_issue` lens empty state now renders one action: `LinkTicketPopover` with `provider="github"`, used exactly as every other provider uses it in `IntegrationPane`.

## Why

Today a GitHub issue can only become linked work through automatic PR "Closes #N" detection. The link menu omitted GitHub, and the `github_issue` lens empty state told the user to "Link a GitHub issue to this session" while offering no way to do it. Everything downstream (`LinkTicketPopover`, `LinkIssueForm`, `fetchIssueCandidates`, `parseIntegrationTaskUrl`, `issueSources`, `linkSessionExternalTask`, the `githubTask` memo feeding `GithubTaskDetail`) was already provider-generic and already worked for GitHub; only the entry points were missing.

This builds on the persisted `sessionExternalTasks` model (`linkSessionExternalTask` writes to SQLite via `upsertSessionExternalTask`), never on `sessionGithub.linkedIssues`. That in-memory field has zero database writes and is overwritten wholesale on every PR poll (`refreshSessionPr.ts`, `linkedIssues: linked`, no merge logic). A hand-linked issue written there would silently vanish on the next PR refresh.

Non-goals (intentionally not touched): retiring `sessionGithub.linkedIssues`, the broader external-task state-model unification, adding bitbucket to the link menu (bitbucket has no issue tracking, `issueSources.ts` deliberately excludes it), and tethering `linkItems` to the `SessionExternalTaskProvider` type (a separate refactor since each entry also carries a label/icon/lens choice).

## Test plan

- `pnpm typecheck` (desktop package rebuilt, all packages green)
- `pnpm test` (598 test files, 5069 tests, all green)
- `pnpm knip --include files,duplicates,unlisted` (clean, only pre-existing unrelated config hints)
- `LinkedWorkSection.test.tsx`: extended the five-provider link-menu navigation test to six, covering the new GitHub entry
- `SessionWorkspace/index.test.tsx`: extended the empty-state test to assert the link action renders, and added a new test that the empty state swaps for `GithubTaskDetail` once `sessionExternalTasks` picks up a linked GitHub task

No issue to close.