### PR TITLE
fix(desktop): stop pairing a stale provider with a new model

### DIFF
--- a/apps/desktop/src/features/workflows/components/LibraryStepForm/index.test.tsx
+++ b/apps/desktop/src/features/workflows/components/LibraryStepForm/index.test.tsx
@@ -2,7 +2,8 @@
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
-import type { ProviderId, WorkspaceId } from '@goodboy/types';
+import { getModelProvider } from '@goodboy/core';
+import type { IsoDateTime, ProviderId, StepDef, StepDefId, WorkspaceId } from '@goodboy/types';
 
 type Store = {
   readonly workspaceOverrides: null;
@@ -43,5 +44,42 @@ describe('LibraryStepForm', () => {
         verbosityDefault: 'verbose',
       }),
     );
+  });
+
+  it('never pairs a model with a provider that does not own it', () => {
+    const onCommit = vi.fn();
+    const def: StepDef = {
+      id: 'step-1' as StepDefId,
+      workspaceId: 'workspace-1' as WorkspaceId,
+      role: 'custom',
+      name: 'Draft the summary',
+      promptPrefix: '',
+      providerDefault: 'anthropic' as ProviderId,
+      modelDefault: 'claude-sonnet-4-6',
+      createdAt: '2025-01-01T00:00:00.000Z' as IsoDateTime,
+      updatedAt: '2025-01-01T00:00:00.000Z' as IsoDateTime,
+    };
+    render(
+      <LibraryStepForm
+        def={def}
+        workspaceId={'workspace-1' as WorkspaceId}
+        connectedProviders={['anthropic', 'cursor'] as ReadonlyArray<ProviderId>}
+        onCommit={onCommit}
+        onClose={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /^Step routing:/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'Cursor' }));
+
+    expect(onCommit.mock.calls.length).toBeGreaterThan(0);
+    const last = onCommit.mock.calls.at(-1)?.[0];
+    expect(last?.providerDefault).toBe('cursor');
+    expect(getModelProvider(last?.modelDefault ?? '')).toBe('cursor');
+    for (const [args] of onCommit.mock.calls) {
+      expect(args.providerDefault === 'anthropic' && args.modelDefault !== def.modelDefault).toBe(
+        false,
+      );
+    }
   });
 });

--- a/apps/desktop/src/features/workflows/components/LibraryStepForm/index.tsx
+++ b/apps/desktop/src/features/workflows/components/LibraryStepForm/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { Input, Textarea, Tooltip } from '@goodboy/ui';
 import { X } from 'lucide-react';
 import { recommendedModelForRole } from '@goodboy/core';
@@ -41,6 +41,9 @@ export const LibraryStepForm = ({
   const [role, setRole] = useState<AgentRole>(def?.role ?? 'custom');
   const [promptPrefix, setPromptPrefix] = useState(def?.promptPrefix ?? '');
   const [providerOverride, setProviderOverride] = useState<ProviderId | ''>(
+    (def?.providerDefault as ProviderId | undefined) ?? '',
+  );
+  const pendingProvider = useRef<ProviderId | ''>(
     (def?.providerDefault as ProviderId | undefined) ?? '',
   );
   const [modelOverride, setModelOverride] = useState(def?.modelDefault ?? '');
@@ -172,13 +175,17 @@ export const LibraryStepForm = ({
               verbosity={verbosity}
               disabled={false}
               onProvider={(p) => {
+                pendingProvider.current = p;
                 setProviderOverride(p);
                 commit({ providerOverride: p });
               }}
               onModel={(m) => {
                 const clamped = clampEffort(m === '' ? recommendedMod : m, effort);
                 setModelOverride(m);
-                const over: Partial<FormState> = { modelOverride: m };
+                const over: Partial<FormState> = {
+                  modelOverride: m,
+                  providerOverride: pendingProvider.current,
+                };
                 if (clamped !== effort) {
                   setEffort(clamped);
                   over.effort = clamped;

--- a/apps/desktop/src/features/workflows/components/OrchestratorPanel/OrchestratorRoutingRow/index.test.tsx
+++ b/apps/desktop/src/features/workflows/components/OrchestratorPanel/OrchestratorRoutingRow/index.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { getModelProvider } from '@goodboy/core';
+import type {
+  OrchestratorRouting,
+  Session,
+  SessionId,
+  WorkflowId,
+  WorkflowRun,
+  WorkflowRunId,
+} from '@goodboy/types';
+
+const { storeState } = vi.hoisted(() => ({
+  storeState: {} as Record<string, unknown>,
+}));
+
+vi.mock('../../../../../store/store', () => ({
+  useAppStore: (selector: (state: Record<string, unknown>) => unknown) => selector(storeState),
+}));
+
+import { OrchestratorRoutingRow } from './index';
+
+const SESSION_ID = 'session-1' as SessionId;
+const RUN_ID = 'run-1' as WorkflowRunId;
+const WORKFLOW_ID = 'workflow-1' as WorkflowId;
+
+const session = (): Session =>
+  ({
+    id: SESSION_ID,
+    workspaceId: 'workspace-1',
+    providerPreference: { defaultProvider: 'anthropic' },
+  }) as Session;
+
+const run = (orchestratorRouting?: OrchestratorRouting): WorkflowRun =>
+  ({
+    id: RUN_ID,
+    workflowId: WORKFLOW_ID,
+    ordinal: 0,
+    currentStep: 0,
+    autoRun: false,
+    triggerMode: 'immediate',
+    executionMode: 'dynamic',
+    ...(orchestratorRouting != null && { orchestratorRouting }),
+  }) as WorkflowRun;
+
+const setWorkflowOrchestratorRouting = vi.fn<
+  (
+    sessionId: SessionId,
+    workflowRunId: WorkflowRunId,
+    routing: OrchestratorRouting | null,
+  ) => Promise<void>
+>(async () => undefined);
+
+const renderRow = (runOverride: WorkflowRun) =>
+  render(<OrchestratorRoutingRow sessionId={SESSION_ID} run={runOverride} disabled={false} />);
+
+const openPicker = () =>
+  fireEvent.click(screen.getByRole('button', { name: /^Orchestrator routing:/ }));
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+  vi.clearAllMocks();
+});
+
+describe('OrchestratorRoutingRow', () => {
+  beforeEach(() => {
+    Object.assign(storeState, {
+      sessions: [session()],
+      providers: [
+        { id: 'anthropic', connection: 'connected' },
+        { id: 'cursor', connection: 'connected' },
+      ],
+      workspaceOverrides: {},
+      setWorkflowOrchestratorRouting,
+    });
+  });
+
+  it('never pairs a model with a provider that does not own it', () => {
+    renderRow(run());
+
+    openPicker();
+    fireEvent.click(screen.getByRole('button', { name: 'Cursor' }));
+
+    expect(setWorkflowOrchestratorRouting.mock.calls.length).toBeGreaterThan(0);
+    for (const [, , routing] of setWorkflowOrchestratorRouting.mock.calls) {
+      expect(routing?.providerId).toBe('cursor');
+      expect(getModelProvider(routing?.model ?? '')).toBe('cursor');
+    }
+  });
+
+  it('commits the provider just picked, not the one pinned before', () => {
+    renderRow(run({ providerId: 'anthropic', model: 'claude-sonnet-4-6' }));
+
+    openPicker();
+    fireEvent.click(screen.getByRole('button', { name: 'Cursor' }));
+
+    expect(setWorkflowOrchestratorRouting).toHaveBeenLastCalledWith(
+      SESSION_ID,
+      RUN_ID,
+      expect.objectContaining({ providerId: 'cursor' }),
+    );
+    const last = setWorkflowOrchestratorRouting.mock.calls.at(-1)?.[2];
+    expect(getModelProvider(last?.model ?? '')).toBe('cursor');
+  });
+});

--- a/apps/desktop/src/features/workflows/components/OrchestratorPanel/OrchestratorRoutingRow/index.tsx
+++ b/apps/desktop/src/features/workflows/components/OrchestratorPanel/OrchestratorRoutingRow/index.tsx
@@ -1,14 +1,20 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { PROVIDER_CAPABILITIES, resolveTaskModel } from '@goodboy/core';
 import type { ModelEffort, ProviderId, SessionId, WorkflowRun } from '@goodboy/types';
-import { clampEffort, modelEffortLevels } from '../../../chat/utils/chat-constants';
-import { RoutingPicker } from '../../../../shared/components/RoutingPicker';
-import { useAppStore } from '../../../../store/store';
+import { clampEffort, modelEffortLevels } from '../../../../chat/utils/chat-constants';
+import { RoutingPicker } from '../../../../../shared/components/RoutingPicker';
+import { useAppStore } from '../../../../../store/store';
 
 type Props = {
   readonly sessionId: SessionId;
   readonly run: WorkflowRun;
   readonly disabled: boolean;
+};
+
+type ApplyParams = {
+  readonly providerId: ProviderId;
+  readonly model: string;
+  readonly effort?: ModelEffort;
 };
 
 const DEFAULT_EFFORT: ModelEffort = 'medium';
@@ -32,9 +38,9 @@ export const OrchestratorRoutingRow = ({ sessionId, run, disabled }: Props) => {
     'anthropic') as ProviderId;
   const automatic = resolveTaskModel('workflow_orchestrator', taskModels, defaultProvider);
   const pinned = run.orchestratorRouting ?? null;
-  const [providerId, setProviderId] = useState<ProviderId>(
-    pinned?.providerId ?? automatic.providerId,
-  );
+  const preferredProviderId = pinned?.providerId ?? automatic.providerId;
+  const [providerId, setProviderId] = useState<ProviderId>(preferredProviderId);
+  const pendingProvider = useRef<ProviderId>(preferredProviderId);
   const model = pinned?.model ?? '';
   const recommendedModel = resolveTaskModel('workflow_orchestrator', taskModels, providerId).model;
   const effortModel = model === '' ? recommendedModel : model;
@@ -44,11 +50,16 @@ export const OrchestratorRoutingRow = ({ sessionId, run, disabled }: Props) => {
     .map((provider) => provider.id)
     .filter((candidate) => PROVIDER_CAPABILITIES[candidate].models.length > 0);
 
-  const apply = (next: { readonly model: string; readonly effort?: ModelEffort }) => {
+  useEffect(() => {
+    setProviderId(preferredProviderId);
+    pendingProvider.current = preferredProviderId;
+  }, [preferredProviderId]);
+
+  const apply = ({ providerId: nextProvider, model: nextModel, effort }: ApplyParams) => {
     void setWorkflowOrchestratorRouting(sessionId, run.id, {
-      providerId,
-      model: next.model,
-      ...(next.effort != null && { effort: next.effort }),
+      providerId: nextProvider,
+      model: nextModel,
+      ...(effort != null && { effort }),
     });
   };
 
@@ -69,6 +80,7 @@ export const OrchestratorRoutingRow = ({ sessionId, run, disabled }: Props) => {
           onChange: (effort) => {
             const applied = effortForModel(effortModel, effort);
             apply({
+              providerId: pendingProvider.current,
               model: effortModel,
               ...(applied != null && { effort: applied }),
             });
@@ -84,6 +96,7 @@ export const OrchestratorRoutingRow = ({ sessionId, run, disabled }: Props) => {
             return;
           }
           setProviderId(next);
+          pendingProvider.current = next;
           if (pinned == null) {
             return;
           }
@@ -95,7 +108,11 @@ export const OrchestratorRoutingRow = ({ sessionId, run, disabled }: Props) => {
             return;
           }
           const carried = pinned?.effort == null ? null : effortForModel(nextModel, pinned.effort);
-          apply({ model: nextModel, ...(carried != null && { effort: carried }) });
+          apply({
+            providerId: pendingProvider.current,
+            model: nextModel,
+            ...(carried != null && { effort: carried }),
+          });
         }}
       />
     </div>


### PR DESCRIPTION
## What

Two RoutingPicker consumers that persist directly to SQLite still carried the provider/model race PR #1295 fixed for `RoleModelRow` and `TaskModelRow`:

- `OrchestratorPanel/OrchestratorRoutingRow.tsx`: `apply()` closed over the `providerId` state. `onModel` called `apply({ model })` with no provider override, so a cross-provider model pick wrote the old provider with the new model through `setWorkflowOrchestratorRouting` into `session_workflows`.
- `LibraryStepForm/index.tsx`: `onProvider` and `onModel` both call `commit()` synchronously off state captured at that render. Picking a model on a different provider fired two immediate `onCommit` calls; the second (from `onModel`) still read the pre-pick `providerOverride`, overwriting the row with the old provider and the new model.

## Why

RoutingPicker's `onPickProvider` calls `onProvider(next)` and, for a connected provider, `onModel(remappedModelId)` synchronously in the same handler. A consumer that rebuilds its persisted value from React state read in that same render sees the state from before either call landed, so the write commits a provider/model pair that never existed on screen.

Both files now hold the picked provider in a ref (`pendingProvider`), updated synchronously inside `onProvider`, and read that ref instead of the closed-over state anywhere a persisted payload is built. This mirrors the pattern already shipped for `RoleModelRow`/`TaskModelRow` verbatim: no new abstraction, no change to the `RoutingPicker` contract.

`OrchestratorRoutingRow.tsx` moved to `OrchestratorRoutingRow/index.tsx` because it now has a co-located test, per the folder convention in `docs/file-system.md` (no flat `Name.tsx` + `Name.test.tsx` pairs). No import paths outside the file changed; `./OrchestratorRoutingRow` still resolves to the folder's `index.tsx`.

### On the `LibraryStepForm` database-write claim

PR #1295's own body categorized `LibraryStepForm` as a stale-read bug **without** a database write. That is wrong on the current code: `onCommit` calls `saveStepDef` → `invokeStepDefUpsert` → the Tauri command `step_def_upsert`, which runs a real `INSERT ... ON CONFLICT DO UPDATE` against the `step_library` table (`apps/desktop/src-tauri/src/workflows.rs`). Verified by reading that Rust command directly, not by re-trusting the earlier PR description.

## Out of scope, on purpose

- `RoutingPicker`'s `onModel(model)` contract is unchanged. Threading the provider through it touches 11 mount sites across 10 files and is a separate item.
- `DiffViewerContent.tsx` and `AgentSpawnConfig/index.tsx` carry the same class of bug but persist nothing; not touched.
- **No backfill.** Rows already written with a mismatched provider/model pair on a user's machine are not corrected by this change. Rewriting existing data is an irreversible operation that needs an explicit owner decision this item does not have; this PR only fixes the write path going forward.
- No schema change: both `session_workflows` and `step_library` already had the columns this bug was writing into.

## Test plan

- `apps/desktop/src/features/workflows/components/OrchestratorPanel/OrchestratorRoutingRow/index.test.tsx` (new): picking a connected provider different from the pinned one asserts every `setWorkflowOrchestratorRouting` call carries the newly picked provider paired with a model that provider owns, and that the final persisted call is never `anthropic` with a model that isn't the originally pinned one.
- `apps/desktop/src/features/workflows/components/LibraryStepForm/index.test.tsx`: added a test with the same shape for `onCommit`/`step_def_upsert`.
- Confirmed both new tests fail on the pre-fix code (verified via a local revert): `LibraryStepForm`'s failed with `expected 'anthropic' to be 'cursor'`.
- `pnpm typecheck`: green.
- `pnpm test`: 599 files / 5071 tests green. One run hit 4 unrelated `Hook timed out in 15000ms` failures in `store/slices/{github,integrations,session-view,workspaces}/index.test.ts` under concurrent worktree load; all four pass individually and the full suite passed clean on a second run.
- `pnpm knip --include files,duplicates,unlisted`: green (only pre-existing config hints).

Not verified: behavior against a real Tauri/SQLite runtime (tests mock the store and the Tauri invoke boundary); manual click-through in the built app.