### PR TITLE
fix(desktop): read a linked sentry issue whole in the session

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -282,6 +282,7 @@ pub fn run() {
             sentry::sentry_connect,
             sentry::sentry_disconnect,
             sentry::sentry_fetch_issues,
+            sentry::sentry_fetch_issue,
             sentry::sentry_fetch_issue_detail,
             gitlab::gitlab_connect,
             gitlab::gitlab_disconnect,

--- a/apps/desktop/src-tauri/src/sentry.rs
+++ b/apps/desktop/src-tauri/src/sentry.rs
@@ -363,6 +363,29 @@ pub async fn sentry_fetch_issues(
 }
 
 #[tauri::command]
+pub async fn sentry_fetch_issue(
+    workspace_id: String,
+    issue_id: String,
+    cache: State<'_, SentryTokenCache>,
+) -> Result<SentryIssue, SentryError> {
+    let cfg = read_config(&workspace_id, &cache)?;
+    let url = format!("{}/issues/{}/", BASE_URL, issue_id);
+    let res = http_client()
+        .get(&url)
+        .bearer_auth(&cfg.token)
+        .send()
+        .await?;
+    let status = res.status();
+    if !status.is_success() {
+        let body = res.text().await.unwrap_or_default();
+        return Err(SentryError::Http(format!("status {}: {}", status, body)));
+    }
+    let body = res.text().await?;
+    let issue: SentryIssue = serde_json::from_str(&body)?;
+    Ok(issue)
+}
+
+#[tauri::command]
 pub async fn sentry_fetch_issue_detail(
     workspace_id: String,
     issue_id: String,
@@ -447,6 +470,37 @@ mod tests {
     fn extract_frames_empty_without_entries() {
         let event = serde_json::json!({ "title": "x" });
         assert!(extract_frames(&event).is_empty());
+    }
+
+    #[test]
+    fn issue_deserializes_counts_and_seen_timestamps() {
+        let payload = serde_json::json!({
+            "id": "42",
+            "shortId": "GOODBOY-42",
+            "title": "TypeError: request failed",
+            "culprit": "api/items",
+            "level": "error",
+            "status": "unresolved",
+            "count": "128",
+            "userCount": 9,
+            "firstSeen": "2026-07-01T09:00:00Z",
+            "lastSeen": "2026-07-23T10:00:00Z",
+            "permalink": "https://sentry.io/issues/42"
+        });
+        let issue: SentryIssue = serde_json::from_value(payload).unwrap();
+        assert_eq!(issue.count.as_deref(), Some("128"));
+        assert_eq!(issue.user_count, Some(9));
+        assert_eq!(issue.first_seen.as_deref(), Some("2026-07-01T09:00:00Z"));
+        assert_eq!(issue.last_seen.as_deref(), Some("2026-07-23T10:00:00Z"));
+    }
+
+    #[test]
+    fn issue_deserializes_when_optional_fields_are_absent() {
+        let payload = serde_json::json!({ "id": "42", "title": "Boom" });
+        let issue: SentryIssue = serde_json::from_value(payload).unwrap();
+        assert_eq!(issue.id, "42");
+        assert!(issue.count.is_none());
+        assert!(issue.metadata.is_none());
     }
 
     #[test]

--- a/apps/desktop/src/features/integrations/sentry/SentryIssueDetail/index.test.tsx
+++ b/apps/desktop/src/features/integrations/sentry/SentryIssueDetail/index.test.tsx
@@ -1,21 +1,43 @@
 // @vitest-environment happy-dom
 
 import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { formatAbsoluteDateTime } from '../../../../shared/utils/relativeDate';
 import { SentryIssueDetail } from '.';
 
 afterEach(cleanup);
+
+const FIRST_SEEN = '2026-07-01T09:00:00Z';
+const LAST_SEEN = '2026-07-23T10:00:00Z';
+
+const BASE_PROPS = {
+  identifier: 'GOODBOY-42',
+  title: 'Request failed',
+  culprit: 'list/culprit',
+  level: 'error',
+  status: 'unresolved',
+  permalink: 'https://sentry.io/issues/42',
+  detail: null,
+  isLoading: false,
+  error: null,
+  summaryIsLoading: false,
+  summaryError: null,
+  onRetrySummary: () => {},
+} as const;
+
+const termValuePairs = (panel: HTMLElement) => {
+  return Object.fromEntries(
+    within(panel)
+      .getAllByRole('term')
+      .map((term) => [term.textContent, term.nextElementSibling?.textContent ?? '']),
+  );
+};
 
 describe('SentryIssueDetail', () => {
   it('surfaces the culprit, the status and the event tags, keeping breadcrumbs behind a tab', () => {
     render(
       <SentryIssueDetail
-        identifier="GOODBOY-42"
-        title="Request failed"
-        culprit="list/culprit"
-        level="error"
-        status="unresolved"
-        permalink="https://sentry.io/issues/42"
+        {...BASE_PROPS}
         detail={{
           title: 'TypeError: request failed',
           culprit: 'api/items',
@@ -33,8 +55,6 @@ describe('SentryIssueDetail', () => {
             },
           ],
         }}
-        isLoading={false}
-        error={null}
       />,
     );
 
@@ -56,5 +76,71 @@ describe('SentryIssueDetail', () => {
 
     fireEvent.click(screen.getByRole('tab', { name: 'Breadcrumbs 1' }));
     expect(screen.getByText('GET /api/items')).toBeDefined();
+  });
+
+  it('pins events, users, first seen and last seen to their own distinct values', () => {
+    render(
+      <SentryIssueDetail
+        {...BASE_PROPS}
+        count="128"
+        userCount={9}
+        firstSeen={FIRST_SEEN}
+        lastSeen={LAST_SEEN}
+      />,
+    );
+
+    const panel = screen.getByTestId('detail-properties');
+    const pairs = termValuePairs(panel);
+    expect(pairs.Events).toBe('128');
+    expect(pairs.Users).toBe('9');
+    expect(pairs['First seen']).toBe(formatAbsoluteDateTime({ iso: FIRST_SEEN }));
+    expect(pairs['Last seen']).toBe(formatAbsoluteDateTime({ iso: LAST_SEEN }));
+    expect(pairs.Events).not.toBe(pairs.Users);
+    expect(pairs['First seen']).not.toBe(pairs['Last seen']);
+  });
+
+  it('keeps the stack trace visible with a skeleton while the summary is still loading', () => {
+    render(
+      <SentryIssueDetail
+        {...BASE_PROPS}
+        summaryIsLoading
+        detail={{
+          title: null,
+          culprit: null,
+          frames: [{ filename: 'items.ts', function: 'loadItems', line_no: 12, in_app: true }],
+          tags: [],
+          breadcrumbs: [],
+        }}
+      />,
+    );
+
+    expect(screen.getByRole('status', { name: 'Loading Sentry issue details' })).toBeDefined();
+    expect(screen.getByRole('heading', { name: 'Request failed' })).toBeDefined();
+    expect(screen.getByText(/loadItems/)).toBeDefined();
+  });
+
+  it('keeps the stack trace visible with a retryable error strip when the summary fetch fails', () => {
+    const onRetrySummary = vi.fn();
+    render(
+      <SentryIssueDetail
+        {...BASE_PROPS}
+        summaryError="invalid response shape"
+        onRetrySummary={onRetrySummary}
+        detail={{
+          title: null,
+          culprit: null,
+          frames: [{ filename: 'items.ts', function: 'loadItems', line_no: 12, in_app: true }],
+          tags: [],
+          breadcrumbs: [],
+        }}
+      />,
+    );
+
+    expect(screen.getByRole('alert')).toBeDefined();
+    expect(screen.getByRole('heading', { name: 'Request failed' })).toBeDefined();
+    expect(screen.getByText(/loadItems/)).toBeDefined();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    expect(onRetrySummary).toHaveBeenCalledOnce();
   });
 });

--- a/apps/desktop/src/features/integrations/sentry/SentryIssueDetail/index.tsx
+++ b/apps/desktop/src/features/integrations/sentry/SentryIssueDetail/index.tsx
@@ -25,6 +25,10 @@ type Props = {
   readonly level: string | null;
   readonly status: string | null;
   readonly permalink: string | null;
+  readonly count?: string | null;
+  readonly userCount?: number | null;
+  readonly firstSeen?: string | null;
+  readonly lastSeen?: string | null;
   readonly detail: Detail | null;
   readonly isLoading: boolean;
   readonly error: string | null;
@@ -39,6 +43,10 @@ export const SentryIssueDetail = ({
   level,
   status,
   permalink,
+  count = null,
+  userCount = null,
+  firstSeen = null,
+  lastSeen = null,
   detail,
   isLoading,
   error,
@@ -53,6 +61,10 @@ export const SentryIssueDetail = ({
     level,
     status,
     permalink,
+    count,
+    userCount,
+    firstSeen,
+    lastSeen,
     detail,
     isLoading,
     error,

--- a/apps/desktop/src/features/integrations/sentry/SentryIssueDetail/index.tsx
+++ b/apps/desktop/src/features/integrations/sentry/SentryIssueDetail/index.tsx
@@ -1,5 +1,5 @@
 import { useState, type ReactNode } from 'react';
-import type { SegmentedTabOption } from '@goodboy/ui';
+import { Skeleton, type SegmentedTabOption } from '@goodboy/ui';
 import { Footprints, ListTree } from 'lucide-react';
 import type { SentryIssueDetail as Detail } from '../client';
 import {
@@ -9,6 +9,7 @@ import {
   StudioDetailTabs,
 } from '../../../../shared/components/StudioDetail';
 import { resolveDetailFields, sentryIssueFields } from '../../../../shared/detail-fields';
+import { ErrorStrip } from '../../../../shared/components/ErrorStrip';
 import { ExternalRefActions } from '../../../../shared/components/ExternalRefActions';
 import { SentryBreadcrumbs } from '../SentryBreadcrumbs';
 import { SentryLevelBadge } from '../SentryLevelBadge';
@@ -32,6 +33,9 @@ type Props = {
   readonly detail: Detail | null;
   readonly isLoading: boolean;
   readonly error: string | null;
+  readonly summaryIsLoading: boolean;
+  readonly summaryError: string | null;
+  readonly onRetrySummary: () => void;
   readonly headerActions?: ReactNode;
   readonly fit?: Fit;
 };
@@ -50,6 +54,9 @@ export const SentryIssueDetail = ({
   detail,
   isLoading,
   error,
+  summaryIsLoading,
+  summaryError,
+  onRetrySummary,
   headerActions,
   fit = 'fill',
 }: Props) => {
@@ -119,6 +126,23 @@ export const SentryIssueDetail = ({
       }
       properties={resolveDetailFields({ registry: sentryIssueFields, entity: view })}
     >
+      {summaryIsLoading ? (
+        <div
+          role="status"
+          aria-label="Loading Sentry issue details"
+          className="flex flex-col gap-2"
+        >
+          <Skeleton className="h-3 w-1/2 rounded" />
+          <Skeleton className="h-3 w-1/3 rounded" />
+        </div>
+      ) : null}
+      {summaryError != null ? (
+        <ErrorStrip
+          label="the Sentry issue details"
+          error={new Error(summaryError)}
+          onRetry={onRetrySummary}
+        />
+      ) : null}
       {activeSection === 'stack' ? (
         <DetailSection label="stack trace">
           <SentryStackTrace frames={view.frames} isLoading={isLoading} error={error} />

--- a/apps/desktop/src/features/integrations/sentry/client.test.ts
+++ b/apps/desktop/src/features/integrations/sentry/client.test.ts
@@ -4,6 +4,7 @@ import type { WorkspaceId } from '@goodboy/types';
 import {
   sentryConnect,
   sentryDisconnect,
+  sentryFetchIssue,
   sentryFetchIssueDetail,
   sentryFetchIssues,
 } from './client';
@@ -56,6 +57,17 @@ describe('sentryFetchIssues', () => {
       workspaceId: WS,
       query: 'is:unresolved',
       cursor: 'cur-1',
+    });
+  });
+});
+
+describe('sentryFetchIssue', () => {
+  it('invokes sentry_fetch_issue with issue id', async () => {
+    mockInvoke.mockResolvedValue({ id: 'issue-9', title: 'Boom' });
+    await sentryFetchIssue({ workspaceId: WS, issueId: 'issue-9' });
+    expect(mockInvoke).toHaveBeenCalledWith('sentry_fetch_issue', {
+      workspaceId: WS,
+      issueId: 'issue-9',
     });
   });
 });

--- a/apps/desktop/src/features/integrations/sentry/client.ts
+++ b/apps/desktop/src/features/integrations/sentry/client.ts
@@ -89,6 +89,18 @@ export const sentryFetchIssues = async (
   });
 };
 
+type FetchIssueParams = {
+  readonly workspaceId: WorkspaceId;
+  readonly issueId: string;
+};
+
+export const sentryFetchIssue = async ({
+  workspaceId,
+  issueId,
+}: FetchIssueParams): Promise<SentryIssue> => {
+  return invoke<SentryIssue>('sentry_fetch_issue', { workspaceId, issueId });
+};
+
 export const sentryFetchIssueDetail = async (
   workspaceId: WorkspaceId,
   issueId: string,

--- a/apps/desktop/src/features/integrations/sentry/sentryIssueView/index.test.ts
+++ b/apps/desktop/src/features/integrations/sentry/sentryIssueView/index.test.ts
@@ -10,6 +10,13 @@ const listValues = {
   permalink: 'https://sentry.io/issues/42',
 };
 
+const emptyCounts = {
+  count: null,
+  userCount: null,
+  firstSeen: null,
+  lastSeen: null,
+};
+
 describe('sentryIssueView', () => {
   it('resolves fetched detail over list values', () => {
     const frame = {
@@ -42,6 +49,7 @@ describe('sentryIssueView', () => {
 
     expect(view).toEqual({
       ...listValues,
+      ...emptyCounts,
       title: 'Detail title',
       culprit: 'detail/culprit',
       tags: [{ key: 'release', value: 'desktop@1.2.3' }],
@@ -62,12 +70,31 @@ describe('sentryIssueView', () => {
 
     expect(view).toEqual({
       ...listValues,
+      ...emptyCounts,
       tags: [],
       frames: [],
       breadcrumbs: [],
       breadcrumbCount: 0,
       hasBreadcrumbs: false,
     });
+  });
+
+  it('carries the issue counts and seen timestamps through untouched', () => {
+    const view = sentryIssueView({
+      ...listValues,
+      count: '128',
+      userCount: 9,
+      firstSeen: '2026-07-01T09:00:00Z',
+      lastSeen: '2026-07-23T10:00:00Z',
+      detail: null,
+      isLoading: false,
+      error: null,
+    });
+
+    expect(view.count).toBe('128');
+    expect(view.userCount).toBe(9);
+    expect(view.firstSeen).toBe('2026-07-01T09:00:00Z');
+    expect(view.lastSeen).toBe('2026-07-23T10:00:00Z');
   });
 
   it.each([

--- a/apps/desktop/src/features/integrations/sentry/sentryIssueView/index.ts
+++ b/apps/desktop/src/features/integrations/sentry/sentryIssueView/index.ts
@@ -8,6 +8,10 @@ type Params = {
   readonly culprit: string | null;
   readonly status: string | null;
   readonly permalink: string | null;
+  readonly count?: string | null;
+  readonly userCount?: number | null;
+  readonly firstSeen?: string | null;
+  readonly lastSeen?: string | null;
   readonly detail: SentryIssueDetail | null;
   readonly isLoading: boolean;
   readonly error: string | null;
@@ -20,6 +24,10 @@ export const sentryIssueView = ({
   culprit,
   status,
   permalink,
+  count = null,
+  userCount = null,
+  firstSeen = null,
+  lastSeen = null,
   detail,
   isLoading,
   error,
@@ -33,6 +41,10 @@ export const sentryIssueView = ({
     culprit: detail?.culprit ?? culprit,
     status,
     permalink,
+    count,
+    userCount,
+    firstSeen,
+    lastSeen,
     tags: visibleSentryTags({ detail }),
     frames: detail?.frames ?? [],
     breadcrumbs,

--- a/apps/desktop/src/features/integrations/sentry/useSentryIssue/index.test.ts
+++ b/apps/desktop/src/features/integrations/sentry/useSentryIssue/index.test.ts
@@ -1,0 +1,74 @@
+import { cleanup, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { WorkspaceId } from '@goodboy/types';
+import { sentryFetchIssue, type SentryIssue } from '../client';
+import { useSentryIssue } from '.';
+
+vi.mock('../client', () => ({
+  sentryFetchIssue: vi.fn(),
+}));
+
+const fetchIssue = vi.mocked(sentryFetchIssue);
+const WORKSPACE_ID = 'workspace-1' as WorkspaceId;
+
+const ISSUE: SentryIssue = {
+  id: '42',
+  shortId: 'GOODBOY-42',
+  title: 'TypeError: request failed',
+  culprit: 'api/items',
+  level: 'error',
+  status: 'unresolved',
+  count: '128',
+  userCount: 9,
+  firstSeen: '2026-07-01T09:00:00Z',
+  lastSeen: '2026-07-23T10:00:00Z',
+  permalink: 'https://sentry.io/issues/42',
+  metadata: null,
+};
+
+beforeEach(() => {
+  fetchIssue.mockReset();
+});
+
+afterEach(cleanup);
+
+describe('useSentryIssue', () => {
+  it('fetches the issue by id', async () => {
+    fetchIssue.mockResolvedValueOnce(ISSUE);
+
+    const { result } = renderHook(() =>
+      useSentryIssue({ workspaceId: WORKSPACE_ID, issueId: '42' }),
+    );
+
+    await waitFor(() => expect(result.current.issue).toEqual(ISSUE));
+    expect(fetchIssue).toHaveBeenCalledWith({ workspaceId: WORKSPACE_ID, issueId: '42' });
+  });
+
+  it('surfaces the fetch error and recovers on retry', async () => {
+    fetchIssue.mockRejectedValueOnce(new Error('invalid response shape: missing field `title`'));
+
+    const { result } = renderHook(() =>
+      useSentryIssue({ workspaceId: WORKSPACE_ID, issueId: '42' }),
+    );
+
+    await waitFor(() =>
+      expect(result.current.error).toBe('invalid response shape: missing field `title`'),
+    );
+    expect(result.current.issue).toBeNull();
+
+    fetchIssue.mockResolvedValueOnce(ISSUE);
+    result.current.refetch();
+
+    await waitFor(() => expect(result.current.issue).toEqual(ISSUE));
+    expect(result.current.error).toBeNull();
+  });
+
+  it('does not fetch without an issue id', async () => {
+    const { result } = renderHook(() =>
+      useSentryIssue({ workspaceId: WORKSPACE_ID, issueId: null }),
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(fetchIssue).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/features/integrations/sentry/useSentryIssue/index.ts
+++ b/apps/desktop/src/features/integrations/sentry/useSentryIssue/index.ts
@@ -1,0 +1,60 @@
+import { useEffect, useState } from 'react';
+import type { WorkspaceId } from '@goodboy/types';
+import { formatError } from '../../../../shared/lib/errors';
+import { sentryFetchIssue, type SentryIssue } from '../client';
+
+type Params = {
+  readonly workspaceId: WorkspaceId;
+  readonly issueId: string | null;
+};
+
+type Result = {
+  readonly issue: SentryIssue | null;
+  readonly isLoading: boolean;
+  readonly error: string | null;
+  readonly refetch: () => void;
+};
+
+export const useSentryIssue = ({ workspaceId, issueId }: Params): Result => {
+  const [issue, setIssue] = useState<SentryIssue | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [attempt, setAttempt] = useState(0);
+
+  useEffect(() => {
+    setIssue(null);
+    setError(null);
+    if (issueId == null || issueId === '') {
+      setIsLoading(false);
+      return;
+    }
+
+    let isCancelled = false;
+    setIsLoading(true);
+    sentryFetchIssue({ workspaceId, issueId })
+      .then((nextIssue) => {
+        if (isCancelled) {
+          return;
+        }
+        setIssue(nextIssue);
+      })
+      .catch((fetchError: unknown) => {
+        if (isCancelled) {
+          return;
+        }
+        setError(formatError(fetchError));
+      })
+      .finally(() => {
+        if (isCancelled) {
+          return;
+        }
+        setIsLoading(false);
+      });
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [workspaceId, issueId, attempt]);
+
+  return { issue, isLoading, error, refetch: () => setAttempt((n) => n + 1) };
+};

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/SentryTaskDetail.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/SentryTaskDetail.test.tsx
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import type { IsoDateTime, SessionExternalTask, SessionId, WorkspaceId } from '@goodboy/types';
 import type { SentryIssue } from '../../../../../integrations/sentry/client';
+import { formatAbsoluteDateTime } from '../../../../../../shared/utils/relativeDate';
 import { useSentryIssue } from '../../../../../integrations/sentry/useSentryIssue';
 import { useSentryIssueDetail } from '../../../../../integrations/sentry/useSentryIssueDetail';
 import { SentryTaskDetail } from './SentryTaskDetail';
@@ -47,11 +48,34 @@ const noDetail = () => {
   useSentryIssueDetailMock.mockReturnValue({ detail: null, isLoading: false, error: null });
 };
 
+const detailWithFrames = () => {
+  useSentryIssueDetailMock.mockReturnValue({
+    detail: {
+      issueId: '42',
+      title: 'TypeError: request failed',
+      culprit: 'api/items',
+      frames: [{ filename: 'items.ts', function: 'loadItems', line_no: 12, in_app: true }],
+      tags: [],
+      breadcrumbs: [],
+    },
+    isLoading: false,
+    error: null,
+  });
+};
+
+const termValuePairs = (panel: HTMLElement) => {
+  return Object.fromEntries(
+    within(panel)
+      .getAllByRole('term')
+      .map((term) => [term.textContent, term.nextElementSibling?.textContent ?? '']),
+  );
+};
+
 afterEach(cleanup);
 
 describe('SentryTaskDetail', () => {
-  it('shows a loading skeleton while the issue is being fetched', () => {
-    noDetail();
+  it('shows a loading skeleton for the summary while the stack trace keeps rendering', () => {
+    detailWithFrames();
     useSentryIssueMock.mockReturnValue({
       issue: null,
       isLoading: true,
@@ -61,12 +85,14 @@ describe('SentryTaskDetail', () => {
 
     render(<SentryTaskDetail workspaceId={WORKSPACE_ID} task={TASK} />);
 
-    expect(screen.getByRole('status', { name: 'Loading Sentry issue' })).toBeDefined();
+    expect(screen.getByRole('status', { name: 'Loading Sentry issue details' })).toBeDefined();
+    expect(screen.getByRole('heading', { name: 'TypeError: request failed' })).toBeDefined();
+    expect(screen.getByText(/loadItems/)).toBeDefined();
   });
 
-  it('shows a retryable error when the issue cannot be read', () => {
+  it('shows a retryable error for the summary while the stack trace keeps rendering', () => {
     const refetch = vi.fn();
-    noDetail();
+    detailWithFrames();
     useSentryIssueMock.mockReturnValue({
       issue: null,
       isLoading: false,
@@ -79,6 +105,8 @@ describe('SentryTaskDetail', () => {
     expect(screen.getByRole('alert')).toBeDefined();
     fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
     expect(refetch).toHaveBeenCalledOnce();
+    expect(screen.getByRole('heading', { name: 'TypeError: request failed' })).toBeDefined();
+    expect(screen.getByText(/loadItems/)).toBeDefined();
   });
 
   it('renders level, culprit, status, counts and seen timestamps for the linked issue', () => {
@@ -93,15 +121,23 @@ describe('SentryTaskDetail', () => {
     render(<SentryTaskDetail workspaceId={WORKSPACE_ID} task={TASK} />);
 
     const panel = screen.getByTestId('detail-properties');
-    expect(
-      within(panel)
-        .getAllByRole('term')
-        .map((term) => term.textContent),
-    ).toEqual(['Culprit', 'Status', 'Events', 'Users', 'First seen', 'Last seen']);
-    expect(within(panel).getByText('api/items')).toBeDefined();
-    expect(within(panel).getByText('unresolved')).toBeDefined();
-    expect(within(panel).getByText('128')).toBeDefined();
-    expect(within(panel).getByText('9')).toBeDefined();
+    const pairs = termValuePairs(panel);
+    expect(Object.keys(pairs)).toEqual([
+      'Culprit',
+      'Status',
+      'Events',
+      'Users',
+      'First seen',
+      'Last seen',
+    ]);
+    expect(pairs.Culprit).toBe('api/items');
+    expect(pairs.Status).toBe('unresolved');
+    expect(pairs.Events).toBe('128');
+    expect(pairs.Users).toBe('9');
+    expect(pairs['First seen']).toBe(formatAbsoluteDateTime({ iso: ISSUE.firstSeen ?? '' }));
+    expect(pairs['Last seen']).toBe(formatAbsoluteDateTime({ iso: ISSUE.lastSeen ?? '' }));
+    expect(pairs['First seen']).not.toBe(pairs['Last seen']);
+    expect(pairs.Events).not.toBe(pairs.Users);
     expect(screen.getByText('error')).toBeDefined();
   });
 });

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/SentryTaskDetail.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/SentryTaskDetail.test.tsx
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import type { IsoDateTime, SessionExternalTask, SessionId, WorkspaceId } from '@goodboy/types';
+import type { SentryIssue } from '../../../../../integrations/sentry/client';
+import { useSentryIssue } from '../../../../../integrations/sentry/useSentryIssue';
+import { useSentryIssueDetail } from '../../../../../integrations/sentry/useSentryIssueDetail';
+import { SentryTaskDetail } from './SentryTaskDetail';
+
+vi.mock('../../../../../integrations/sentry/useSentryIssue', () => ({
+  useSentryIssue: vi.fn(),
+}));
+
+vi.mock('../../../../../integrations/sentry/useSentryIssueDetail', () => ({
+  useSentryIssueDetail: vi.fn(),
+}));
+
+const useSentryIssueMock = vi.mocked(useSentryIssue);
+const useSentryIssueDetailMock = vi.mocked(useSentryIssueDetail);
+const WORKSPACE_ID = 'workspace-1' as WorkspaceId;
+
+const TASK: SessionExternalTask = {
+  sessionId: 'session-1' as SessionId,
+  provider: 'sentry',
+  externalId: '42',
+  identifier: 'GOODBOY-42',
+  title: 'Request failed',
+  url: 'https://sentry.io/issues/42',
+  createdAt: '2026-07-22T12:00:00.000Z' as IsoDateTime,
+};
+
+const ISSUE: SentryIssue = {
+  id: '42',
+  shortId: 'GOODBOY-42',
+  title: 'TypeError: request failed',
+  culprit: 'api/items',
+  level: 'error',
+  status: 'unresolved',
+  count: '128',
+  userCount: 9,
+  firstSeen: '2026-07-01T09:00:00Z',
+  lastSeen: '2026-07-23T10:00:00Z',
+  permalink: 'https://sentry.io/issues/42',
+  metadata: null,
+};
+
+const noDetail = () => {
+  useSentryIssueDetailMock.mockReturnValue({ detail: null, isLoading: false, error: null });
+};
+
+afterEach(cleanup);
+
+describe('SentryTaskDetail', () => {
+  it('shows a loading skeleton while the issue is being fetched', () => {
+    noDetail();
+    useSentryIssueMock.mockReturnValue({
+      issue: null,
+      isLoading: true,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(<SentryTaskDetail workspaceId={WORKSPACE_ID} task={TASK} />);
+
+    expect(screen.getByRole('status', { name: 'Loading Sentry issue' })).toBeDefined();
+  });
+
+  it('shows a retryable error when the issue cannot be read', () => {
+    const refetch = vi.fn();
+    noDetail();
+    useSentryIssueMock.mockReturnValue({
+      issue: null,
+      isLoading: false,
+      error: 'invalid response shape',
+      refetch,
+    });
+
+    render(<SentryTaskDetail workspaceId={WORKSPACE_ID} task={TASK} />);
+
+    expect(screen.getByRole('alert')).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    expect(refetch).toHaveBeenCalledOnce();
+  });
+
+  it('renders level, culprit, status, counts and seen timestamps for the linked issue', () => {
+    noDetail();
+    useSentryIssueMock.mockReturnValue({
+      issue: ISSUE,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(<SentryTaskDetail workspaceId={WORKSPACE_ID} task={TASK} />);
+
+    const panel = screen.getByTestId('detail-properties');
+    expect(
+      within(panel)
+        .getAllByRole('term')
+        .map((term) => term.textContent),
+    ).toEqual(['Culprit', 'Status', 'Events', 'Users', 'First seen', 'Last seen']);
+    expect(within(panel).getByText('api/items')).toBeDefined();
+    expect(within(panel).getByText('unresolved')).toBeDefined();
+    expect(within(panel).getByText('128')).toBeDefined();
+    expect(within(panel).getByText('9')).toBeDefined();
+    expect(screen.getByText('error')).toBeDefined();
+  });
+});

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/SentryTaskDetail.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/SentryTaskDetail.tsx
@@ -1,7 +1,4 @@
-import { Skeleton } from '@goodboy/ui';
 import type { SessionExternalTask, WorkspaceId } from '@goodboy/types';
-import { ErrorStrip } from '../../../../../../shared/components/ErrorStrip';
-import { HeaderBand, StudioDetailLayout } from '../../../../../../shared/components/StudioDetail';
 import { SentryIssueDetail } from '../../../../../integrations/sentry/SentryIssueDetail';
 import { useSentryIssue } from '../../../../../integrations/sentry/useSentryIssue';
 import { useSentryIssueDetail } from '../../../../../integrations/sentry/useSentryIssueDetail';
@@ -26,51 +23,25 @@ export const SentryTaskDetail = ({ workspaceId, task }: Props) => {
     issueId: task.externalId,
   });
 
-  if (issue != null) {
-    return (
-      <SentryIssueDetail
-        identifier={issue.shortId ?? task.identifier}
-        title={task.title}
-        culprit={issue.culprit}
-        level={issue.level}
-        status={issue.status}
-        permalink={issue.permalink ?? task.url}
-        count={issue.count}
-        userCount={issue.userCount}
-        firstSeen={issue.firstSeen}
-        lastSeen={issue.lastSeen}
-        detail={detail}
-        isLoading={isLoading}
-        error={error}
-        fit="fill"
-      />
-    );
-  }
-
   return (
-    <StudioDetailLayout
+    <SentryIssueDetail
+      identifier={issue?.shortId ?? task.identifier}
+      title={task.title}
+      culprit={issue?.culprit ?? null}
+      level={issue?.level ?? null}
+      status={issue?.status ?? null}
+      permalink={issue?.permalink ?? task.url}
+      count={issue?.count ?? null}
+      userCount={issue?.userCount ?? null}
+      firstSeen={issue?.firstSeen ?? null}
+      lastSeen={issue?.lastSeen ?? null}
+      detail={detail}
+      isLoading={isLoading}
+      error={error}
+      summaryIsLoading={isIssueLoading}
+      summaryError={issueError}
+      onRetrySummary={refetch}
       fit="fill"
-      header={
-        <HeaderBand
-          meta={
-            <span className="font-mono text-2xs tabular-nums text-muted-foreground">
-              {task.identifier}
-            </span>
-          }
-          title={task.title}
-        />
-      }
-    >
-      {isIssueLoading ? (
-        <div role="status" aria-label="Loading Sentry issue" className="flex flex-col gap-3">
-          <Skeleton className="h-4 w-2/3 rounded" />
-          <Skeleton className="h-3 w-full rounded" />
-          <Skeleton className="h-3 w-3/4 rounded" />
-        </div>
-      ) : null}
-      {issueError != null ? (
-        <ErrorStrip label="the Sentry issue" error={new Error(issueError)} onRetry={refetch} />
-      ) : null}
-    </StudioDetailLayout>
+    />
   );
 };

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/SentryTaskDetail.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/SentryTaskDetail.tsx
@@ -1,5 +1,9 @@
+import { Skeleton } from '@goodboy/ui';
 import type { SessionExternalTask, WorkspaceId } from '@goodboy/types';
+import { ErrorStrip } from '../../../../../../shared/components/ErrorStrip';
+import { HeaderBand, StudioDetailLayout } from '../../../../../../shared/components/StudioDetail';
 import { SentryIssueDetail } from '../../../../../integrations/sentry/SentryIssueDetail';
+import { useSentryIssue } from '../../../../../integrations/sentry/useSentryIssue';
 import { useSentryIssueDetail } from '../../../../../integrations/sentry/useSentryIssueDetail';
 
 type Props = {
@@ -8,23 +12,65 @@ type Props = {
 };
 
 export const SentryTaskDetail = ({ workspaceId, task }: Props) => {
+  const {
+    issue,
+    isLoading: isIssueLoading,
+    error: issueError,
+    refetch,
+  } = useSentryIssue({
+    workspaceId,
+    issueId: task.externalId,
+  });
   const { detail, isLoading, error } = useSentryIssueDetail({
     workspaceId,
     issueId: task.externalId,
   });
 
+  if (issue != null) {
+    return (
+      <SentryIssueDetail
+        identifier={issue.shortId ?? task.identifier}
+        title={task.title}
+        culprit={issue.culprit}
+        level={issue.level}
+        status={issue.status}
+        permalink={issue.permalink ?? task.url}
+        count={issue.count}
+        userCount={issue.userCount}
+        firstSeen={issue.firstSeen}
+        lastSeen={issue.lastSeen}
+        detail={detail}
+        isLoading={isLoading}
+        error={error}
+        fit="fill"
+      />
+    );
+  }
+
   return (
-    <SentryIssueDetail
-      identifier={task.identifier}
-      title={task.title}
-      culprit={null}
-      level={null}
-      status={null}
-      permalink={task.url}
-      detail={detail}
-      isLoading={isLoading}
-      error={error}
+    <StudioDetailLayout
       fit="fill"
-    />
+      header={
+        <HeaderBand
+          meta={
+            <span className="font-mono text-2xs tabular-nums text-muted-foreground">
+              {task.identifier}
+            </span>
+          }
+          title={task.title}
+        />
+      }
+    >
+      {isIssueLoading ? (
+        <div role="status" aria-label="Loading Sentry issue" className="flex flex-col gap-3">
+          <Skeleton className="h-4 w-2/3 rounded" />
+          <Skeleton className="h-3 w-full rounded" />
+          <Skeleton className="h-3 w-3/4 rounded" />
+        </div>
+      ) : null}
+      {issueError != null ? (
+        <ErrorStrip label="the Sentry issue" error={new Error(issueError)} onRetry={refetch} />
+      ) : null}
+    </StudioDetailLayout>
   );
 };

--- a/apps/desktop/src/shared/detail-fields/index.test.tsx
+++ b/apps/desktop/src/shared/detail-fields/index.test.tsx
@@ -40,6 +40,10 @@ const LINEAR_ISSUE: LinearIssue = {
 const SENTRY_ISSUE: SentryIssueProperties = {
   culprit: 'api/items',
   status: 'unresolved',
+  count: '128',
+  userCount: 9,
+  firstSeen: '2026-07-01T09:00:00Z',
+  lastSeen: '2026-07-23T10:00:00Z',
   tags: [
     { key: 'release', value: 'desktop@1.2.3' },
     { key: 'environment', value: 'production' },
@@ -112,7 +116,15 @@ describe('detail field registries', () => {
       'linkedPullRequests',
       'updated',
     ]);
-    expect(sentryIssueFields.map((field) => field.key)).toEqual(['culprit', 'status', 'tags']);
+    expect(sentryIssueFields.map((field) => field.key)).toEqual([
+      'culprit',
+      'status',
+      'events',
+      'users',
+      'firstSeen',
+      'lastSeen',
+      'tags',
+    ]);
     expect(githubIssueFields.map((field) => field.key)).toEqual(['labels', 'updated']);
     expect(githubPullRequestFields.map((field) => field.key)).toEqual(['baseBranch', 'updated']);
     expect(gitlabIssueFields.map((field) => field.key)).toEqual(['milestone', 'labels', 'updated']);
@@ -135,7 +147,16 @@ describe('detail field registries', () => {
       resolveDetailFields({ registry: sentryIssueFields, entity: SENTRY_ISSUE }).map(
         (entry) => entry.label,
       ),
-    ).toEqual(['Culprit', 'Status', 'release', 'environment']);
+    ).toEqual([
+      'Culprit',
+      'Status',
+      'Events',
+      'Users',
+      'First seen',
+      'Last seen',
+      'release',
+      'environment',
+    ]);
     expect(
       resolveDetailFields({ registry: githubIssueFields, entity: GITHUB_ISSUE }).map(
         (entry) => entry.label,

--- a/apps/desktop/src/shared/detail-fields/index.test.tsx
+++ b/apps/desktop/src/shared/detail-fields/index.test.tsx
@@ -1,9 +1,11 @@
 // @vitest-environment happy-dom
 
+import { isValidElement, type ReactNode } from 'react';
 import { describe, expect, it } from 'vitest';
 import type { GithubIssue, PullRequestState } from '@goodboy/types';
 import type { LinearIssue } from '../../features/integrations/linear/client';
 import type { GitlabIssue, GitlabMergeRequest } from '../../features/integrations/gitlab/client';
+import { formatAbsoluteDateTime } from '../utils/relativeDate';
 import {
   githubIssueFields,
   githubPullRequestFields,
@@ -16,6 +18,24 @@ import {
   type ResolvedDetailFields,
   type SentryIssueProperties,
 } from '.';
+
+type NodeChildren = {
+  readonly children?: ReactNode;
+};
+
+const nodeText = (node: ReactNode): string => {
+  if (typeof node === 'string' || typeof node === 'number') {
+    return String(node);
+  }
+  if (isValidElement<NodeChildren>(node)) {
+    return nodeText(node.props.children);
+  }
+  return '';
+};
+
+const entryTextByKey = (entries: ResolvedDetailFields): Record<string, string> => {
+  return Object.fromEntries(entries.map((entry) => [entry.key, nodeText(entry.node)]));
+};
 
 type ForgedDetailFields = ReadonlyArray<DetailEntry> & {
   readonly __brand: 'ResolvedDetailFields';
@@ -177,6 +197,21 @@ describe('detail field registries', () => {
         (entry) => entry.label,
       ),
     ).toEqual(['Source branch', 'Target branch', 'Merge status', 'Updated']);
+  });
+
+  it('pins every sentry field to its own value, never a neighboring one', () => {
+    const text = entryTextByKey(
+      resolveDetailFields({ registry: sentryIssueFields, entity: SENTRY_ISSUE }),
+    );
+
+    expect(text.culprit).toBe(SENTRY_ISSUE.culprit);
+    expect(text.status).toBe(SENTRY_ISSUE.status);
+    expect(text.events).toBe(SENTRY_ISSUE.count);
+    expect(text.users).toBe(String(SENTRY_ISSUE.userCount));
+    expect(text.firstSeen).toBe(formatAbsoluteDateTime({ iso: SENTRY_ISSUE.firstSeen ?? '' }));
+    expect(text.lastSeen).toBe(formatAbsoluteDateTime({ iso: SENTRY_ISSUE.lastSeen ?? '' }));
+    expect(text.events).not.toBe(text.users);
+    expect(text.firstSeen).not.toBe(text.lastSeen);
   });
 
   it('only a resolver run carries the resolved brand', () => {

--- a/apps/desktop/src/shared/detail-fields/sentryIssueFields.tsx
+++ b/apps/desktop/src/shared/detail-fields/sentryIssueFields.tsx
@@ -1,9 +1,14 @@
 import type { SentryTag } from '../../features/integrations/sentry/client';
+import { formatAbsoluteDateTime } from '../utils/relativeDate';
 import type { DetailFieldRegistry } from './types';
 
 export type SentryIssueProperties = {
   readonly culprit: string | null;
   readonly status: string | null;
+  readonly count: string | null;
+  readonly userCount: number | null;
+  readonly firstSeen: string | null;
+  readonly lastSeen: string | null;
   readonly tags: ReadonlyArray<SentryTag>;
 };
 
@@ -19,6 +24,45 @@ export const sentryIssueFields: DetailFieldRegistry<SentryIssueProperties> = [
     key: 'status',
     label: 'Status',
     render: ({ entity }) => entity.status,
+  },
+  {
+    kind: 'field',
+    key: 'events',
+    label: 'Events',
+    render: ({ entity }) => <span className="tabular-nums">{entity.count}</span>,
+  },
+  {
+    kind: 'field',
+    key: 'users',
+    label: 'Users',
+    render: ({ entity }) => {
+      if (entity.userCount == null) {
+        return null;
+      }
+      return <span className="tabular-nums">{String(entity.userCount)}</span>;
+    },
+  },
+  {
+    kind: 'field',
+    key: 'firstSeen',
+    label: 'First seen',
+    render: ({ entity }) => {
+      if (entity.firstSeen == null) {
+        return null;
+      }
+      return formatAbsoluteDateTime({ iso: entity.firstSeen });
+    },
+  },
+  {
+    kind: 'field',
+    key: 'lastSeen',
+    label: 'Last seen',
+    render: ({ entity }) => {
+      if (entity.lastSeen == null) {
+        return null;
+      }
+      return formatAbsoluteDateTime({ iso: entity.lastSeen });
+    },
   },
   {
     kind: 'group',


### PR DESCRIPTION
## What changed

A Sentry issue linked to a session rendered thinner in the session lens than the same object renders in the Sentry studio. `SentryTaskDetail` hardcoded `culprit={null} level={null} status={null}` and only ever fetched the latest **event**, never the issue itself.

- **Rust**: new `sentry_fetch_issue` command reading `GET /issues/{id}/`, registered in `lib.rs`. It follows the `gitlab_fetch_issue` by-id precedent and deserializes into the **existing `SentryIssue` struct that the list endpoint already parses**. No new struct, no new field names.
- **Hook**: `features/integrations/sentry/useSentryIssue/index.ts`, returning `{ issue, isLoading, error, refetch }`. A new hook rather than a reuse: `useSentryIssues` is paginated and filtered to `is:unresolved`, so it drops resolved issues, and `useSentryIssueDetail` is event data.
- **Fields**: `count`, `userCount`, `firstSeen` and `lastSeen` had zero plumbing anywhere. They now flow through `sentryIssueView` into the `sentryIssueFields` registry as Events, Users, First seen, Last seen. The new view params default to `null`, and `resolveDetailFields` null-filters absent entries, so the addition is purely additive.
- **States**: loading is the `Skeleton` primitive (no spinner), failure is a retryable `ErrorStrip`, both copied from the `GitlabTaskDetail` pattern. Before this there was no `ErrorStrip` anywhere in the Sentry integration.

The session pane now shows level, culprit, status, events, users, first seen and last seen.

## Deliberately untouched

`SentryStudio/IssueDetailPanel.tsx` and its `stats` block are unchanged. Converging its four headline `StatCard` tiles onto the shared registry would demote them into compact sidebar rows, which is a real and unrequested visual change. That convergence is a separate item.

## Not verified against a live Sentry

**The new endpoint has not been exercised against a live Sentry workspace.** Nobody ran this against real credentials.

- **What the shape rests on**: the response is deserialized with the same `SentryIssue` struct the already-shipped `sentry_fetch_issues` list endpoint parses. Every field is one the repo already reads, and all of them are `#[serde(default)]` optionals except `id` and `title`. Two new Rust tests pin that the struct parses both a full payload and a payload with every optional absent.
- **What happens if the shape differs**: the command reads the body as text and runs `serde_json::from_str`, so a mismatch becomes `SentryError::InvalidShape` rather than a panic. The hook catches it into `error`, and `SentryTaskDetail` renders the `ErrorStrip` with a working Retry that re-runs the fetch. No crash, and no blank pane that could pass for data.

## Test plan

- `pnpm typecheck` green.
- `pnpm test` green: 600 files, 5076 tests.
- `pnpm knip --include files,duplicates,unlisted` clean (only the configuration hints already present on `main`).
- `cargo test --locked` from `apps/desktop/src-tauri` green: 374 passed, 0 failed, including the two new `SentryIssue` deserialization tests.
- New tests: `useSentryIssue/index.test.ts` (fetch by id, error then recovery via `refetch`, no fetch without an id), `SentryTaskDetail.test.tsx` (skeleton while pending, retryable error strip, and the full property row set on a loaded issue). `SentryTaskDetail` had zero coverage before.
- Extended: the `sentryIssueView` test for the four carried fields, and the detail-field registry test for the pinned key and label order.

Manual check a reviewer can run: link a Sentry issue to a session, open the session lens, and confirm the properties rail lists Culprit, Status, Events, Users, First seen, Last seen alongside the level badge, and that the Sentry studio panel still shows its four `StatCard` tiles unchanged.