### PR TITLE
feat(desktop): file an issue from a top bar popover

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -35,7 +35,8 @@ functional. One register per surface; let the other supply only texture.
 - **App chrome**: a single top bar (`AppTopBar`), one 36px row closed by a
   hairline, holds context on the left (mascot, the sessions-column control,
   workspace identity, the session breadcrumb) and state on the right (cost
-  rollup, attention count, running scripts, notifications, theme, onboarding).
+  rollup, attention count, running scripts, the report control, notifications,
+  theme, onboarding).
   The top bar carries state and identity, not destinations: what it holds
   reports something happening right now. Theme is the one set-once preference
   exposed there, next to notifications, because it is reached often enough to
@@ -57,7 +58,15 @@ functional. One register per surface; let the other supply only texture.
   yet. Every shipped integration belongs to exactly one group: that group is
   where a workspace connects it, so an integration in no group is unreachable.
   The top bar is context, never content: every control in it opens
-  something elsewhere, none of them edits a record in place. See
+  something elsewhere, none of them edits a record in place. The report control
+  is the one carve-out, and a narrow one: its popover drafts a bug report, which
+  is not a record and reaches nothing until the report is filed, and its primary
+  action still opens the full report form. Unsent input held in chrome is the
+  same exception the composer's pre-send routing line earns under
+  [Status & signals](#status--signals). VS Code hangs its issue reporter off a
+  top-level menu for the same reason: the moment worth capturing a bug is the
+  moment you hit it, and the type and the description are what you can write
+  before you lose it. See
   [docs/design.md](docs/design.md) for what each surface is made of and
   [docs/navigation.md](docs/navigation.md) for the full IA and breadcrumb
   derivation rules.

--- a/README.md
+++ b/README.md
@@ -213,9 +213,10 @@ model, including what the loop is never allowed to do, is in
 ## Help out
 
 Try it. If something breaks, feels weird or is missing, open an issue.
-Report it from inside the app (Settings, or "Report an issue" in the command
-palette) or straight on GitHub. The in-app form sends four things: the version
-you are running, the area you pick, your title and your notes. Nothing else.
+Report it from inside the app (the bug control in the top right, Settings, or
+"Report an issue" in the command palette) or straight on GitHub. The in-app form
+sends five things: the version you are running, the type and the area you pick,
+your title and your notes. Nothing else.
 It can't attach screenshots yet. Drag one onto the issue once it opens on
 GitHub. Half-formed thoughts welcome. "This feels off" is a perfectly valid
 bug report.

--- a/apps/desktop/src/app/components/AppTopBar/index.test.tsx
+++ b/apps/desktop/src/app/components/AppTopBar/index.test.tsx
@@ -49,7 +49,11 @@ vi.mock('../../../store', () => ({
 }));
 
 vi.mock('../../../features/notifications/components/NotificationCenter', () => ({
-  NotificationCenter: () => null,
+  NotificationCenter: () => <span data-testid="notification-center" />,
+}));
+
+vi.mock('../../../features/settings/components/ReportIssuePopover', () => ({
+  ReportIssuePopover: () => <span data-testid="report-issue-popover" />,
 }));
 
 vi.mock('../../../features/onboarding/OnboardingCard', () => ({
@@ -117,6 +121,19 @@ describe('AppTopBar', () => {
     renderBar({ onOpenBudget: vi.fn() });
 
     expect(screen.getByTestId('onboarding-chip')).toBeDefined();
+  });
+
+  it('seats the report control ahead of notifications, leaving theme beside them', () => {
+    renderBar();
+
+    const report = screen.getByTestId('report-issue-popover');
+    const notifications = screen.getByTestId('notification-center');
+    const themeToggle = screen.getByRole('button', { name: /switch to (light|dark) mode/i });
+
+    expect(report.compareDocumentPosition(notifications)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    expect(notifications.compareDocumentPosition(themeToggle)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
   });
 
   it('keeps set-once preferences out of the bar, except theme', () => {

--- a/apps/desktop/src/app/components/AppTopBar/index.tsx
+++ b/apps/desktop/src/app/components/AppTopBar/index.tsx
@@ -2,6 +2,7 @@ import { Moon, PanelLeft, PanelLeftClose, Sun } from 'lucide-react';
 import { cn, Divider, Tooltip } from '@goodboy/ui';
 import { DogMascot } from '../../../shared/components/DogMascot';
 import { NotificationCenter } from '../../../features/notifications/components/NotificationCenter';
+import { ReportIssuePopover } from '../../../features/settings/components/ReportIssuePopover';
 import { RunningScriptsIndicator } from '../../../features/scripts/components/RunningScriptsIndicator';
 import { OnboardingChip } from '../../../features/onboarding/OnboardingCard';
 import { WorkspaceIdentityRow } from '../../../features/workspace/components/WorkspaceIdentityRow';
@@ -91,6 +92,7 @@ export const AppTopBar = ({
 
         <div className="flex shrink-0 items-center gap-0.5">
           <RunningScriptsIndicator />
+          <ReportIssuePopover />
           <NotificationCenter />
           <Tooltip content={themeActionLabel}>
             <button

--- a/apps/desktop/src/features/settings/components/ReportIssuePopover/index.test.tsx
+++ b/apps/desktop/src/features/settings/components/ReportIssuePopover/index.test.tsx
@@ -92,4 +92,19 @@ describe('ReportIssuePopover', () => {
     expect(screen.queryByRole('dialog', { name: 'Report an issue' })).toBeNull();
     expect(useAppStore.getState().bugReportDraft.description).toBe('Session cost is stale');
   });
+
+  it('shows a dot on the trigger while a draft is waiting, and hides it once reset', () => {
+    render(<ReportIssuePopover />);
+
+    expect(screen.queryByTestId('report-issue-draft-dot')).toBeNull();
+
+    openPopover();
+    describeIssue('Session cost is stale');
+
+    expect(screen.getByTestId('report-issue-draft-dot')).toBeDefined();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reset' }));
+
+    expect(screen.queryByTestId('report-issue-draft-dot')).toBeNull();
+  });
 });

--- a/apps/desktop/src/features/settings/components/ReportIssuePopover/index.test.tsx
+++ b/apps/desktop/src/features/settings/components/ReportIssuePopover/index.test.tsx
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+
+vi.mock('../../../../store', async () => {
+  const { create } = await import('zustand');
+  const { createBugReportDraftSlice } = await import('../../../../store/slices/bugReportDraft');
+  const { initialBugReportDraftState } =
+    await import('../../../../store/slices/bugReportDraft/state');
+  const useAppStore = create((set, get) => ({
+    ...initialBugReportDraftState,
+    ...createBugReportDraftSlice(set as never, get as never),
+  }));
+  return { useAppStore };
+});
+
+import { ReportIssuePopover } from './index';
+import { REPORT_ISSUE_STUDIO_EVENT } from '../../reportIssueStudioEvent';
+import { useAppStore } from '../../../../store';
+import { initialBugReportDraftState } from '../../../../store/slices/bugReportDraft/state';
+
+const openPopover = () => {
+  fireEvent.click(screen.getByRole('button', { name: /^Report an issue/ }));
+};
+
+const describeIssue = (description: string) => {
+  fireEvent.change(screen.getByLabelText('Description'), { target: { value: description } });
+};
+
+beforeEach(() => {
+  useAppStore.setState(initialBugReportDraftState);
+});
+
+afterEach(cleanup);
+
+describe('ReportIssuePopover', () => {
+  it('keeps what was typed when the popover closes and opens again', () => {
+    render(<ReportIssuePopover />);
+
+    openPopover();
+    fireEvent.click(screen.getByRole('tab', { name: 'Idea' }));
+    describeIssue('The board keeps the archived session');
+    fireEvent.keyDown(window, { key: 'Escape' });
+
+    expect(screen.queryByRole('dialog', { name: 'Report an issue' })).toBeNull();
+
+    openPopover();
+
+    expect((screen.getByLabelText('Description') as HTMLTextAreaElement).value).toBe(
+      'The board keeps the archived session',
+    );
+    expect(screen.getByRole('tab', { name: 'Idea' }).getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('holds the draft in the store, so a fresh mount still carries it', () => {
+    const first = render(<ReportIssuePopover />);
+    openPopover();
+    describeIssue('Terminal loses focus on resize');
+    first.unmount();
+
+    render(<ReportIssuePopover />);
+    openPopover();
+
+    expect((screen.getByLabelText('Description') as HTMLTextAreaElement).value).toBe(
+      'Terminal loses focus on resize',
+    );
+  });
+
+  it('empties the draft on a reset', () => {
+    render(<ReportIssuePopover />);
+
+    openPopover();
+    describeIssue('Diff shows the wrong file');
+    fireEvent.click(screen.getByRole('button', { name: 'Reset' }));
+
+    expect((screen.getByLabelText('Description') as HTMLTextAreaElement).value).toBe('');
+    expect((screen.getByRole('button', { name: 'Reset' }) as HTMLButtonElement).disabled).toBe(
+      true,
+    );
+  });
+
+  it('hands the draft to the full report form and closes', () => {
+    const onOpenStudio = vi.fn();
+    window.addEventListener(REPORT_ISSUE_STUDIO_EVENT, onOpenStudio);
+    render(<ReportIssuePopover />);
+
+    openPopover();
+    describeIssue('Session cost is stale');
+    fireEvent.click(screen.getByRole('button', { name: 'Add details and send' }));
+    window.removeEventListener(REPORT_ISSUE_STUDIO_EVENT, onOpenStudio);
+
+    expect(onOpenStudio).toHaveBeenCalledOnce();
+    expect(screen.queryByRole('dialog', { name: 'Report an issue' })).toBeNull();
+    expect(useAppStore.getState().bugReportDraft.description).toBe('Session cost is stale');
+  });
+});

--- a/apps/desktop/src/features/settings/components/ReportIssuePopover/index.tsx
+++ b/apps/desktop/src/features/settings/components/ReportIssuePopover/index.tsx
@@ -1,0 +1,117 @@
+import { Button, Divider, Popover, SegmentedTabs, Textarea, Tooltip, cn } from '@goodboy/ui';
+import { CONCEPT_ICONS } from '../../../../shared/components/conceptIcons';
+import { DropdownPortal } from '../../../../shared/hooks/useDropdown/DropdownPortal';
+import { useDropdown } from '../../../../shared/hooks/useDropdown';
+import { useAppStore } from '../../../../store';
+import { emptyBugReportDraft } from '../../../../store/slices/bugReportDraft/state';
+import { ISSUE_TYPE_OPTIONS, type IssueTypeValue } from '../../reportIssueTypes';
+import { REPORT_ISSUE_STUDIO_EVENT } from '../../reportIssueStudioEvent';
+
+const TRIGGER_LABEL = 'Report an issue';
+const DRAFT_TRIGGER_LABEL = 'Report an issue, draft saved';
+
+export const ReportIssuePopover = () => {
+  const {
+    open,
+    close,
+    toggle,
+    containerRef,
+    popupRef,
+    popupClassName,
+    popupStyle,
+    portal,
+    portalTarget,
+  } = useDropdown({
+    align: 'end',
+    expectedHeight: 340,
+    expectedWidth: 384,
+    width: 'w-96 max-w-[calc(100vw-2rem)]',
+    strategy: 'fixed',
+  });
+  const draft = useAppStore((s) => s.bugReportDraft);
+  const setBugReportDraft = useAppStore((s) => s.setBugReportDraft);
+  const clearBugReportDraft = useAppStore((s) => s.clearBugReportDraft);
+
+  const hasDraft = draft.description !== '' || draft.issueType !== emptyBugReportDraft.issueType;
+  const triggerLabel = hasDraft ? DRAFT_TRIGGER_LABEL : TRIGGER_LABEL;
+  const ReportIssueIcon = CONCEPT_ICONS.reportIssue;
+
+  const openFullForm = () => {
+    close();
+    window.dispatchEvent(new CustomEvent(REPORT_ISSUE_STUDIO_EVENT));
+  };
+
+  return (
+    <div ref={containerRef} className="relative">
+      <Tooltip content={TRIGGER_LABEL} side="top">
+        <button
+          type="button"
+          onClick={toggle}
+          aria-label={triggerLabel}
+          className={cn(
+            'relative flex items-center justify-center rounded p-1.5 motion-safe:transition-colors',
+            open
+              ? 'bg-muted text-foreground'
+              : 'text-muted-foreground hover:bg-muted/50 hover:text-foreground',
+          )}
+        >
+          <ReportIssueIcon size={14} aria-hidden />
+          {hasDraft && (
+            <span
+              aria-hidden
+              className="absolute -right-0.5 -top-0.5 size-1.5 rounded-full bg-info"
+            />
+          )}
+        </button>
+      </Tooltip>
+
+      <DropdownPortal portal={portal} portalTarget={portalTarget}>
+        {open && (
+          <Popover
+            innerRef={popupRef}
+            role="dialog"
+            ariaLabel={TRIGGER_LABEL}
+            className={cn(popupClassName, 'flex flex-col bg-subtle')}
+            style={popupStyle}
+          >
+            <header className="flex items-center gap-2 px-3 py-2">
+              <span className="text-xs font-semibold text-foreground">{TRIGGER_LABEL}</span>
+            </header>
+            <Divider />
+            <div className="flex flex-col gap-3 px-3 py-3">
+              <SegmentedTabs
+                fill
+                size="sm"
+                ariaLabel="Issue type"
+                options={ISSUE_TYPE_OPTIONS}
+                value={draft.issueType}
+                onChange={(issueType: IssueTypeValue) => setBugReportDraft({ issueType })}
+              />
+              <Textarea
+                autoGrow
+                minRows={4}
+                maxRows={10}
+                aria-label="Description"
+                value={draft.description}
+                onChange={(e) => setBugReportDraft({ description: e.target.value })}
+                placeholder="What happened, and what you expected instead"
+              />
+              <p className="text-2xs leading-relaxed text-muted-foreground">
+                Kept as a draft until you send it from the report form.
+              </p>
+            </div>
+            <Divider />
+            <footer className="flex items-center justify-end gap-2 px-3 py-2">
+              <Button variant="ghost" size="sm" onClick={clearBugReportDraft} disabled={!hasDraft}>
+                Reset
+              </Button>
+              <Button size="sm" onClick={openFullForm}>
+                Add details and send
+              </Button>
+            </footer>
+          </Popover>
+        )}
+      </DropdownPortal>
+    </div>
+  );
+};

--- a/apps/desktop/src/features/settings/components/ReportIssuePopover/index.tsx
+++ b/apps/desktop/src/features/settings/components/ReportIssuePopover/index.tsx
@@ -58,6 +58,7 @@ export const ReportIssuePopover = () => {
           <ReportIssueIcon size={14} aria-hidden />
           {hasDraft && (
             <span
+              data-testid="report-issue-draft-dot"
               aria-hidden
               className="absolute -right-0.5 -top-0.5 size-1.5 rounded-full bg-info"
             />

--- a/apps/desktop/src/features/settings/components/ReportIssueStudio/index.test.tsx
+++ b/apps/desktop/src/features/settings/components/ReportIssueStudio/index.test.tsx
@@ -163,6 +163,27 @@ describe('ReportIssueStudio', () => {
     );
   });
 
+  it('empties the draft and leaves the form once the fallback link opens', async () => {
+    setGithubStatus({ available: false, mode: 'absent' });
+    const onClose = vi.fn();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    render(<ReportIssueStudio onClose={onClose} />);
+
+    fillReport({ area: 'board-sessions', title: 'Board freeze', notes: 'Freezes on archive.' });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Open on GitHub' }));
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(400);
+    });
+    vi.useRealTimers();
+
+    expect(onClose).toHaveBeenCalledOnce();
+    expect(useAppStore.getState().bugReportDraft).toEqual(
+      initialBugReportDraftState.bugReportDraft,
+    );
+  });
+
   it('keeps the draft when the send fails, so nothing typed is lost', async () => {
     setGithubStatus({ available: true, mode: 'gh-cli' });
     mocks.run.mockImplementation(async () => ({

--- a/apps/desktop/src/features/settings/components/ReportIssueStudio/index.test.tsx
+++ b/apps/desktop/src/features/settings/components/ReportIssueStudio/index.test.tsx
@@ -7,23 +7,25 @@ import type { GhTokenStatus } from '@goodboy/types';
 type GhRunResult = { stdout: string; stderr: string; exitCode: number };
 
 const mocks = vi.hoisted(() => ({
-  githubStatus: null as GhTokenStatus | null,
-  refreshGithubStatus: vi.fn(async () => undefined),
   run: vi.fn<
     (args: ReadonlyArray<string>, opts: Readonly<Record<string, unknown>>) => Promise<GhRunResult>
   >(async () => ({ stdout: '', stderr: '', exitCode: 0 })),
   openUrl: vi.fn<(url: string) => Promise<void>>(async () => undefined),
 }));
 
-vi.mock('../../../../store', () => ({
-  useAppStore: <T,>(
-    selector: (state: {
-      githubStatus: GhTokenStatus | null;
-      refreshGithubStatus: typeof mocks.refreshGithubStatus;
-    }) => T,
-  ) =>
-    selector({ githubStatus: mocks.githubStatus, refreshGithubStatus: mocks.refreshGithubStatus }),
-}));
+vi.mock('../../../../store', async () => {
+  const { create } = await import('zustand');
+  const { createBugReportDraftSlice } = await import('../../../../store/slices/bugReportDraft');
+  const { initialBugReportDraftState } =
+    await import('../../../../store/slices/bugReportDraft/state');
+  const useAppStore = create((set, get) => ({
+    ...initialBugReportDraftState,
+    ...createBugReportDraftSlice(set as never, get as never),
+    githubStatus: null,
+    refreshGithubStatus: async () => undefined,
+  }));
+  return { useAppStore };
+});
 
 vi.mock('../../../changelog/hooks/useInstalledVersion', () => ({
   useInstalledVersion: () => '0.1.69',
@@ -38,6 +40,12 @@ vi.mock('../../../../shared/lib/editor', () => ({
 }));
 
 import { ReportIssueStudio } from './index';
+import { useAppStore } from '../../../../store';
+import { initialBugReportDraftState } from '../../../../store/slices/bugReportDraft/state';
+
+const setGithubStatus = (githubStatus: GhTokenStatus | null) => {
+  useAppStore.setState({ githubStatus });
+};
 
 const fillReport = ({ area, title, notes }: { area?: string; title?: string; notes?: string }) => {
   if (area != null) {
@@ -57,8 +65,7 @@ const fillReport = ({ area, title, notes }: { area?: string; title?: string; not
 };
 
 beforeEach(() => {
-  mocks.githubStatus = null;
-  mocks.refreshGithubStatus = vi.fn(async () => undefined);
+  useAppStore.setState({ ...initialBugReportDraftState, githubStatus: null });
   mocks.run.mockReset();
   mocks.run.mockImplementation(async () => ({ stdout: '', stderr: '', exitCode: 0 }));
   mocks.openUrl.mockReset();
@@ -68,7 +75,7 @@ afterEach(cleanup);
 
 describe('ReportIssueStudio', () => {
   it('keeps send disabled until version, area and title are all filled', () => {
-    mocks.githubStatus = { available: true, mode: 'gh-cli' };
+    setGithubStatus({ available: true, mode: 'gh-cli' });
     render(<ReportIssueStudio onClose={vi.fn()} />);
 
     const send = () => screen.getByRole('button', { name: 'Send' }) as HTMLButtonElement;
@@ -82,7 +89,7 @@ describe('ReportIssueStudio', () => {
   });
 
   it('shows exactly the version, area label, title and notes in the preview, nothing else', () => {
-    mocks.githubStatus = { available: true, mode: 'gh-cli' };
+    setGithubStatus({ available: true, mode: 'gh-cli' });
     render(<ReportIssueStudio onClose={vi.fn()} />);
 
     fillReport({
@@ -94,14 +101,14 @@ describe('ReportIssueStudio', () => {
     expect(screen.getByText('Agent reply is cut off')).toBeDefined();
     expect(
       screen.getByText(
-        'Area: Chat and agents\nVersion: 0.1.69\n\nThe reply stops mid-sentence after a tool call.',
+        'Type: Bug\nArea: Chat and agents\nVersion: 0.1.69\n\nThe reply stops mid-sentence after a tool call.',
         { normalizer: (text) => text },
       ),
     ).toBeDefined();
   });
 
-  it('sends directly through gh when connected, and offers the created issue link', async () => {
-    mocks.githubStatus = { available: true, mode: 'gh-cli' };
+  it('sends directly through gh when connected, and opens the created issue', async () => {
+    setGithubStatus({ available: true, mode: 'gh-cli' });
     mocks.run.mockImplementation(async () => ({
       stdout: 'https://github.com/akhayam99/goodboy/issues/99\n',
       stderr: '',
@@ -123,15 +130,58 @@ describe('ReportIssueStudio', () => {
         '--title',
         'Board freeze',
         '--body',
-        'Area: Board and sessions\nVersion: 0.1.69\n\nFreezes on archive.',
+        'Type: Bug\nArea: Board and sessions\nVersion: 0.1.69\n\nFreezes on archive.',
       ],
       {},
     );
-    expect(screen.getByRole('button', { name: /open on github/i })).toBeDefined();
+    expect(mocks.openUrl).toHaveBeenCalledWith('https://github.com/akhayam99/goodboy/issues/99');
+  });
+
+  it('empties the draft and leaves the form once the issue is filed', async () => {
+    setGithubStatus({ available: true, mode: 'gh-cli' });
+    mocks.run.mockImplementation(async () => ({
+      stdout: 'https://github.com/akhayam99/goodboy/issues/99\n',
+      stderr: '',
+      exitCode: 0,
+    }));
+    const onClose = vi.fn();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    render(<ReportIssueStudio onClose={onClose} />);
+
+    fillReport({ area: 'board-sessions', title: 'Board freeze', notes: 'Freezes on archive.' });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Send' }));
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(400);
+    });
+    vi.useRealTimers();
+
+    expect(onClose).toHaveBeenCalledOnce();
+    expect(useAppStore.getState().bugReportDraft).toEqual(
+      initialBugReportDraftState.bugReportDraft,
+    );
+  });
+
+  it('keeps the draft when the send fails, so nothing typed is lost', async () => {
+    setGithubStatus({ available: true, mode: 'gh-cli' });
+    mocks.run.mockImplementation(async () => ({
+      stdout: '',
+      stderr: 'HTTP 403: Resource not accessible',
+      exitCode: 1,
+    }));
+    render(<ReportIssueStudio onClose={vi.fn()} />);
+
+    fillReport({ area: 'board-sessions', title: 'Board freeze', notes: 'Freezes on archive.' });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Send' }));
+    });
+
+    expect(useAppStore.getState().bugReportDraft.description).toBe('Freezes on archive.');
   });
 
   it('surfaces the gh stderr message when the direct send fails', async () => {
-    mocks.githubStatus = { available: true, mode: 'gh-cli' };
+    setGithubStatus({ available: true, mode: 'gh-cli' });
     mocks.run.mockImplementation(async () => ({
       stdout: '',
       stderr: 'HTTP 403: Resource not accessible',
@@ -148,7 +198,7 @@ describe('ReportIssueStudio', () => {
   });
 
   it('opens a url the native validator would accept when github is not connected', async () => {
-    mocks.githubStatus = { available: false, mode: 'absent' };
+    setGithubStatus({ available: false, mode: 'absent' });
     render(<ReportIssueStudio onClose={vi.fn()} />);
 
     fillReport({ area: 'board-sessions', title: 'Board freeze', notes: 'Freezes on archive.' });
@@ -164,7 +214,7 @@ describe('ReportIssueStudio', () => {
   });
 
   it('truncates an overlong note visibly on the fallback path', async () => {
-    mocks.githubStatus = { available: false, mode: 'absent' };
+    setGithubStatus({ available: false, mode: 'absent' });
     render(<ReportIssueStudio onClose={vi.fn()} />);
 
     const longNotes = 'x'.repeat(6000);
@@ -182,7 +232,7 @@ describe('ReportIssueStudio', () => {
   });
 
   it('trims an overlong title, says so, and still opens a url under the cap', async () => {
-    mocks.githubStatus = { available: false, mode: 'absent' };
+    setGithubStatus({ available: false, mode: 'absent' });
     render(<ReportIssueStudio onClose={vi.fn()} />);
 
     fillReport({ area: 'board-sessions', title: 'T'.repeat(5000), notes: 'Freezes on archive.' });
@@ -190,9 +240,12 @@ describe('ReportIssueStudio', () => {
     expect(screen.getByText(/title trimmed to fit the github link/i)).toBeDefined();
     expect(screen.getByText(/^T+…$/)).toBeDefined();
     expect(
-      screen.getByText('Area: Board and sessions\nVersion: 0.1.69\n\nFreezes on archive.', {
-        normalizer: (text) => text,
-      }),
+      screen.getByText(
+        'Type: Bug\nArea: Board and sessions\nVersion: 0.1.69\n\nFreezes on archive.',
+        {
+          normalizer: (text) => text,
+        },
+      ),
     ).toBeDefined();
 
     await act(async () => {
@@ -206,7 +259,7 @@ describe('ReportIssueStudio', () => {
   });
 
   it('renders a lone surrogate in the notes instead of crashing, on the fallback path', () => {
-    mocks.githubStatus = { available: false, mode: 'absent' };
+    setGithubStatus({ available: false, mode: 'absent' });
     render(<ReportIssueStudio onClose={vi.fn()} />);
 
     fillReport({ area: 'board-sessions', title: 'Board freeze', notes: 'a\uD83D b' });
@@ -215,7 +268,7 @@ describe('ReportIssueStudio', () => {
   });
 
   it('renders a lone surrogate in the notes instead of crashing, on the direct path', () => {
-    mocks.githubStatus = { available: true, mode: 'gh-cli' };
+    setGithubStatus({ available: true, mode: 'gh-cli' });
     render(<ReportIssueStudio onClose={vi.fn()} />);
 
     fillReport({ area: 'board-sessions', title: 'Board freeze', notes: 'a\uD83D b' });
@@ -224,14 +277,14 @@ describe('ReportIssueStudio', () => {
   });
 
   it('names the CLI login only when the CLI is what sends it', () => {
-    mocks.githubStatus = { available: true, mode: 'gh-cli' };
+    setGithubStatus({ available: true, mode: 'gh-cli' });
     render(<ReportIssueStudio onClose={vi.fn()} />);
 
     expect(screen.getByText('Sent directly, using your GitHub CLI login.')).toBeDefined();
   });
 
   it('says token, not CLI login, when a personal access token is what sends it', () => {
-    mocks.githubStatus = { available: true, mode: 'pat' };
+    setGithubStatus({ available: true, mode: 'pat' });
     render(<ReportIssueStudio onClose={vi.fn()} />);
 
     expect(screen.getByText('Sent directly, using your GitHub token.')).toBeDefined();
@@ -240,7 +293,7 @@ describe('ReportIssueStudio', () => {
   });
 
   it('never claims a CLI login in the truncation notice', () => {
-    mocks.githubStatus = { available: false, mode: 'absent' };
+    setGithubStatus({ available: false, mode: 'absent' });
     render(<ReportIssueStudio onClose={vi.fn()} />);
 
     fillReport({ area: 'board-sessions', title: 'Board freeze', notes: 'x'.repeat(6000) });
@@ -250,7 +303,7 @@ describe('ReportIssueStudio', () => {
   });
 
   it('discloses that the report is posted publicly under the reporter account', () => {
-    mocks.githubStatus = { available: true, mode: 'gh-cli' };
+    setGithubStatus({ available: true, mode: 'gh-cli' });
     render(<ReportIssueStudio onClose={vi.fn()} />);
 
     expect(

--- a/apps/desktop/src/features/settings/components/ReportIssueStudio/index.tsx
+++ b/apps/desktop/src/features/settings/components/ReportIssueStudio/index.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useMemo, useState } from 'react';
-import { AlertTriangle, ExternalLink } from 'lucide-react';
+import { AlertTriangle } from 'lucide-react';
 import {
   Button,
   Divider,
   FieldRow,
   ScrollFade,
   SectionHeader,
+  SegmentedTabs,
   Select,
   Skeleton,
   Textarea,
@@ -19,6 +20,7 @@ import { openUrl } from '../../../../shared/lib/editor';
 import { useAppStore } from '../../../../store';
 import { tauriGhRunner } from '../../../github/github';
 import { useInstalledVersion } from '../../../changelog/hooks/useInstalledVersion';
+import { ISSUE_TYPE_OPTIONS, issueTypeLabel, type IssueTypeValue } from '../../reportIssueTypes';
 import { AREA_OPTIONS, type AreaValue } from './areas';
 import {
   buildFallbackIssue,
@@ -34,19 +36,24 @@ type Props = {
   readonly onClose: () => void;
 };
 
-type SendState = 'idle' | 'sending' | 'success' | 'error';
+type Params = {
+  readonly requestClose: () => void;
+};
+
+type SendState = 'idle' | 'sending' | 'error';
 
 export const ReportIssueStudio = ({ onClose }: Props) => {
   const version = useInstalledVersion();
   const status = useAppStore((s) => s.githubStatus);
   const refreshGithubStatus = useAppStore((s) => s.refreshGithubStatus);
+  const draft = useAppStore((s) => s.bugReportDraft);
+  const setBugReportDraft = useAppStore((s) => s.setBugReportDraft);
+  const clearBugReportDraft = useAppStore((s) => s.clearBugReportDraft);
 
   const [area, setArea] = useState<AreaValue | ''>('');
   const [title, setTitle] = useState('');
-  const [notes, setNotes] = useState('');
   const [sendState, setSendState] = useState<SendState>('idle');
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const [issueUrl, setIssueUrl] = useState<string | null>(null);
 
   useEffect(() => {
     if (status == null) {
@@ -58,25 +65,27 @@ export const ReportIssueStudio = ({ onClose }: Props) => {
   const sendsDirectly = mode === 'gh-cli' || mode === 'pat';
 
   const trimmedTitle = title.trim();
-  const trimmedNotes = notes.trim();
+  const trimmedNotes = draft.description.trim();
   const areaLabel = useMemo(
     () => AREA_OPTIONS.find((option) => option.value === area)?.label ?? '',
     [area],
   );
+  const typeLabel = issueTypeLabel({ issueType: draft.issueType });
 
   const directBody = useMemo(
-    () => buildIssueBody({ version: version ?? '', areaLabel, notes: trimmedNotes }),
-    [version, areaLabel, trimmedNotes],
+    () => buildIssueBody({ typeLabel, version: version ?? '', areaLabel, notes: trimmedNotes }),
+    [typeLabel, version, areaLabel, trimmedNotes],
   );
   const fallback = useMemo(
     () =>
       buildFallbackIssue({
         title: trimmedTitle,
+        typeLabel,
         version: version ?? '',
         areaLabel,
         notes: trimmedNotes,
       }),
-    [trimmedTitle, version, areaLabel, trimmedNotes],
+    [trimmedTitle, typeLabel, version, areaLabel, trimmedNotes],
   );
 
   const previewBody = sendsDirectly ? directBody : fallback.body;
@@ -95,13 +104,12 @@ export const ReportIssueStudio = ({ onClose }: Props) => {
     mode != null &&
     sendState !== 'sending';
 
-  const onSend = async () => {
+  const onSend = async ({ requestClose }: Params) => {
     if (!canSend) {
       return;
     }
     setSendState('sending');
     setErrorMessage(null);
-    setIssueUrl(null);
 
     if (sendsDirectly) {
       try {
@@ -124,8 +132,11 @@ export const ReportIssueStudio = ({ onClose }: Props) => {
           setErrorMessage(parsed.message);
           return;
         }
-        setIssueUrl(parsed.url);
-        setSendState('success');
+        if (parsed.url != null) {
+          await openUrl(parsed.url);
+        }
+        clearBugReportDraft();
+        requestClose();
       } catch (err) {
         setSendState('error');
         setErrorMessage(formatError(err));
@@ -142,7 +153,8 @@ export const ReportIssueStudio = ({ onClose }: Props) => {
     }
     try {
       await openUrl(fallback.url);
-      setSendState('success');
+      clearBugReportDraft();
+      requestClose();
     } catch (err) {
       setSendState('error');
       setErrorMessage(formatError(err));
@@ -174,6 +186,15 @@ export const ReportIssueStudio = ({ onClose }: Props) => {
                   ) : (
                     <Skeleton className="h-4 w-14" />
                   )}
+                </FieldRow>
+                <FieldRow label="Type" help="What kind of report this is.">
+                  <SegmentedTabs
+                    size="sm"
+                    ariaLabel="Issue type"
+                    options={ISSUE_TYPE_OPTIONS}
+                    value={draft.issueType}
+                    onChange={(issueType: IssueTypeValue) => setBugReportDraft({ issueType })}
+                  />
                 </FieldRow>
                 <FieldRow label="Area" help="Which part of the app this is about.">
                   <Select
@@ -209,8 +230,8 @@ export const ReportIssueStudio = ({ onClose }: Props) => {
                     autoGrow
                     minRows={4}
                     maxRows={12}
-                    value={notes}
-                    onChange={(e) => setNotes(e.target.value)}
+                    value={draft.description}
+                    onChange={(e) => setBugReportDraft({ description: e.target.value })}
                     placeholder="Steps to reproduce, what you expected, what happened instead"
                   />
                 </FieldRow>
@@ -233,28 +254,6 @@ export const ReportIssueStudio = ({ onClose }: Props) => {
                 <p className="text-2xs leading-relaxed text-muted-foreground">
                   This posts publicly on GitHub, under your own account.
                 </p>
-                {sendState === 'success' ? (
-                  <div className="flex items-center gap-2 text-2xs text-success">
-                    {sendsDirectly ? (
-                      issueUrl != null ? (
-                        <>
-                          <span>Issue filed.</span>
-                          <Button
-                            variant="secondary"
-                            size="sm"
-                            onClick={() => void openUrl(issueUrl)}
-                          >
-                            <ExternalLink size={12} aria-hidden /> Open on GitHub
-                          </Button>
-                        </>
-                      ) : (
-                        <span>Issue filed. Check your GitHub account for the link.</span>
-                      )
-                    ) : (
-                      <span>Opened in your browser. Finish submitting it there.</span>
-                    )}
-                  </div>
-                ) : null}
               </section>
             </div>
           </ScrollFade>
@@ -272,7 +271,7 @@ export const ReportIssueStudio = ({ onClose }: Props) => {
               Cancel
             </Button>
             <Button
-              onClick={() => void onSend()}
+              onClick={() => void onSend({ requestClose })}
               disabled={!canSend}
               className={cn(sendState === 'sending' && 'animate-border-pulse')}
             >

--- a/apps/desktop/src/features/settings/components/ReportIssueStudio/issuePayload.test.ts
+++ b/apps/desktop/src/features/settings/components/ReportIssueStudio/issuePayload.test.ts
@@ -14,14 +14,15 @@ const decode = (url: string): { title: string; body: string } => {
 };
 
 describe('buildIssueBody', () => {
-  it('contains only the version, area label and notes', () => {
+  it('contains only the type, version, area label and notes', () => {
     const body = buildIssueBody({
+      typeLabel: 'Bug',
       version: '0.1.69',
       areaLabel: 'Board and sessions',
       notes: 'The board freezes after archiving a session.',
     });
     expect(body).toBe(
-      'Area: Board and sessions\nVersion: 0.1.69\n\nThe board freezes after archiving a session.',
+      'Type: Bug\nArea: Board and sessions\nVersion: 0.1.69\n\nThe board freezes after archiving a session.',
     );
   });
 });
@@ -30,6 +31,7 @@ describe('buildFallbackIssue', () => {
   it('does not truncate short notes', () => {
     const result = buildFallbackIssue({
       title: 'Board freeze',
+      typeLabel: 'Bug',
       version: '0.1.69',
       areaLabel: 'Board and sessions',
       notes: 'Short repro.',
@@ -43,6 +45,7 @@ describe('buildFallbackIssue', () => {
   it('targets the fixed repo and percent-encodes title and body', () => {
     const result = buildFallbackIssue({
       title: 'Board freeze',
+      typeLabel: 'Bug',
       version: '0.1.69',
       areaLabel: 'Board and sessions',
       notes: 'Steps & details',
@@ -55,6 +58,7 @@ describe('buildFallbackIssue', () => {
   it('encodes exactly the previewed title and body into an untruncated url', () => {
     const result = buildFallbackIssue({
       title: 'Board freeze',
+      typeLabel: 'Bug',
       version: '0.1.69',
       areaLabel: 'Board and sessions',
       notes: 'Steps & details, with a "quote" and a #hash.',
@@ -66,6 +70,7 @@ describe('buildFallbackIssue', () => {
   it('encodes exactly the previewed title and body into a truncated url too', () => {
     const result = buildFallbackIssue({
       title: 'Board freeze',
+      typeLabel: 'Bug',
       version: '0.1.69',
       areaLabel: 'Board and sessions',
       notes: 'x'.repeat(6000),
@@ -78,6 +83,7 @@ describe('buildFallbackIssue', () => {
     const longNotes = 'x'.repeat(6000);
     const result = buildFallbackIssue({
       title: 'Board freeze',
+      typeLabel: 'Bug',
       version: '0.1.69',
       areaLabel: 'Board and sessions',
       notes: longNotes,
@@ -93,6 +99,7 @@ describe('buildFallbackIssue', () => {
     const longNotes = '🐛'.repeat(2000);
     const result = buildFallbackIssue({
       title: 'Board freeze',
+      typeLabel: 'Bug',
       version: '0.1.69',
       areaLabel: 'Board and sessions',
       notes: longNotes,
@@ -104,6 +111,7 @@ describe('buildFallbackIssue', () => {
   it('caps a title that blows the URL on its own, and keeps the notes intact', () => {
     const result = buildFallbackIssue({
       title: 'T'.repeat(5000),
+      typeLabel: 'Bug',
       version: '0.1.69',
       areaLabel: 'Board and sessions',
       notes: 'short',
@@ -119,6 +127,7 @@ describe('buildFallbackIssue', () => {
   it('caps a wide unicode title too', () => {
     const result = buildFallbackIssue({
       title: '🐛'.repeat(2000),
+      typeLabel: 'Bug',
       version: '0.1.69',
       areaLabel: 'Board and sessions',
       notes: 'short',
@@ -131,6 +140,7 @@ describe('buildFallbackIssue', () => {
   it('caps both the title and the notes when both are overlong', () => {
     const result = buildFallbackIssue({
       title: 'T'.repeat(5000),
+      typeLabel: 'Bug',
       version: '0.1.69',
       areaLabel: 'Board and sessions',
       notes: 'x'.repeat(6000),
@@ -148,6 +158,7 @@ describe('buildFallbackIssue', () => {
         !isOpenableUrl(
           buildFallbackIssue({
             title: 'T'.repeat(length),
+            typeLabel: 'Bug',
             version: '0.1.69',
             areaLabel: 'Board and sessions',
             notes: 'Freezes on archive.',
@@ -160,6 +171,7 @@ describe('buildFallbackIssue', () => {
   it('replaces a lone surrogate in the notes instead of throwing', () => {
     const result = buildFallbackIssue({
       title: 'Board freeze',
+      typeLabel: 'Bug',
       version: '0.1.69',
       areaLabel: 'Board and sessions',
       notes: 'a\uD83D b',
@@ -171,6 +183,7 @@ describe('buildFallbackIssue', () => {
   it('replaces a lone surrogate in the title instead of throwing', () => {
     const result = buildFallbackIssue({
       title: 'Board\uDC00freeze',
+      typeLabel: 'Bug',
       version: '0.1.69',
       areaLabel: 'Board and sessions',
       notes: 'Freezes on archive.',
@@ -182,6 +195,7 @@ describe('buildFallbackIssue', () => {
   it('leaves a valid surrogate pair alone', () => {
     const result = buildFallbackIssue({
       title: 'Board freeze 🐛',
+      typeLabel: 'Bug',
       version: '0.1.69',
       areaLabel: 'Board and sessions',
       notes: 'Freezes on archive 🐛',
@@ -193,6 +207,7 @@ describe('buildFallbackIssue', () => {
   it('survives a long note that ends on a lone high surrogate', () => {
     const result = buildFallbackIssue({
       title: 'Board freeze',
+      typeLabel: 'Bug',
       version: '0.1.69',
       areaLabel: 'Board and sessions',
       notes: `${'x'.repeat(6000)}\uD83D`,
@@ -226,6 +241,7 @@ describe('isOpenableUrl', () => {
   it('accepts every fallback url this module can produce', () => {
     const result = buildFallbackIssue({
       title: 'Board freeze',
+      typeLabel: 'Bug',
       version: '0.1.69',
       areaLabel: 'Board and sessions',
       notes: 'x'.repeat(6000),

--- a/apps/desktop/src/features/settings/components/ReportIssueStudio/issuePayload.ts
+++ b/apps/desktop/src/features/settings/components/ReportIssueStudio/issuePayload.ts
@@ -16,13 +16,19 @@ const REPLACEMENT_CHAR = '�';
 const SURROGATE_SCAN = /[\uD800-\uDBFF][\uDC00-\uDFFF]|([\uD800-\uDFFF])/g;
 
 type BuildIssueBodyParams = {
+  readonly typeLabel: string;
   readonly version: string;
   readonly areaLabel: string;
   readonly notes: string;
 };
 
-export const buildIssueBody = ({ version, areaLabel, notes }: BuildIssueBodyParams): string =>
-  `Area: ${areaLabel}\nVersion: ${version}\n\n${notes}`;
+export const buildIssueBody = ({
+  typeLabel,
+  version,
+  areaLabel,
+  notes,
+}: BuildIssueBodyParams): string =>
+  `Type: ${typeLabel}\nArea: ${areaLabel}\nVersion: ${version}\n\n${notes}`;
 
 type SanitizeParams = {
   readonly text: string;
@@ -86,6 +92,7 @@ const capFallbackTitle = ({ title }: CapFallbackTitleParams): string => {
 
 type BuildFallbackIssueParams = {
   readonly title: string;
+  readonly typeLabel: string;
   readonly version: string;
   readonly areaLabel: string;
   readonly notes: string;
@@ -101,6 +108,7 @@ type FallbackIssue = {
 
 export const buildFallbackIssue = ({
   title,
+  typeLabel,
   version,
   areaLabel,
   notes,
@@ -110,7 +118,7 @@ export const buildFallbackIssue = ({
   const fallbackTitle = capFallbackTitle({ title: safeTitle });
   const titleTruncated = fallbackTitle !== safeTitle;
 
-  const fullBody = buildIssueBody({ version, areaLabel, notes: safeNotes });
+  const fullBody = buildIssueBody({ typeLabel, version, areaLabel, notes: safeNotes });
   if (fitsFallbackUrl({ title: fallbackTitle, body: fullBody })) {
     return {
       url: buildFallbackIssueUrl({ title: fallbackTitle, body: fullBody }),
@@ -127,10 +135,10 @@ export const buildFallbackIssue = ({
     fits: ({ candidate }) =>
       fitsFallbackUrl({
         title: fallbackTitle,
-        body: buildIssueBody({ version, areaLabel, notes: candidate }),
+        body: buildIssueBody({ typeLabel, version, areaLabel, notes: candidate }),
       }),
   });
-  const truncatedBody = buildIssueBody({ version, areaLabel, notes: truncatedNotes });
+  const truncatedBody = buildIssueBody({ typeLabel, version, areaLabel, notes: truncatedNotes });
   return {
     url: buildFallbackIssueUrl({ title: fallbackTitle, body: truncatedBody }),
     title: fallbackTitle,

--- a/apps/desktop/src/features/settings/reportIssueTypes.ts
+++ b/apps/desktop/src/features/settings/reportIssueTypes.ts
@@ -1,0 +1,23 @@
+import { Bug, CircleQuestionMark, Lightbulb } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+
+export const ISSUE_TYPE_OPTIONS = [
+  { value: 'bug', label: 'Bug', icon: Bug },
+  { value: 'idea', label: 'Idea', icon: Lightbulb },
+  { value: 'question', label: 'Question', icon: CircleQuestionMark },
+] as const satisfies ReadonlyArray<{
+  readonly value: string;
+  readonly label: string;
+  readonly icon: LucideIcon;
+}>;
+
+export type IssueTypeValue = (typeof ISSUE_TYPE_OPTIONS)[number]['value'];
+
+export const DEFAULT_ISSUE_TYPE: IssueTypeValue = 'bug';
+
+type IssueTypeLabelParams = {
+  readonly issueType: IssueTypeValue;
+};
+
+export const issueTypeLabel = ({ issueType }: IssueTypeLabelParams): string =>
+  ISSUE_TYPE_OPTIONS.find((option) => option.value === issueType)?.label ?? '';

--- a/apps/desktop/src/store/slices/bugReportDraft/clearBugReportDraft.ts
+++ b/apps/desktop/src/store/slices/bugReportDraft/clearBugReportDraft.ts
@@ -1,0 +1,8 @@
+import { emptyBugReportDraft } from './state';
+import type { SetFn } from './types';
+
+export const clearBugReportDraft = (set: SetFn) => {
+  return (): void => {
+    set({ bugReportDraft: emptyBugReportDraft });
+  };
+};

--- a/apps/desktop/src/store/slices/bugReportDraft/index.test.ts
+++ b/apps/desktop/src/store/slices/bugReportDraft/index.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { createBugReportDraftSlice } from './index';
+import { initialBugReportDraftState, type BugReportDraftState } from './state';
+
+const harness = () => {
+  let state: BugReportDraftState = { ...initialBugReportDraftState };
+  const set = (
+    p: Partial<BugReportDraftState> | ((s: BugReportDraftState) => Partial<BugReportDraftState>),
+  ) => {
+    state = { ...state, ...(typeof p === 'function' ? p(state) : p) };
+  };
+  const slice = createBugReportDraftSlice(set as never, (() => state) as never);
+  return { slice, getState: () => state };
+};
+
+describe('bug report draft slice', () => {
+  let harnessed = harness();
+
+  beforeEach(() => {
+    harnessed = harness();
+  });
+
+  it('starts on the bug type with nothing written', () => {
+    expect(harnessed.getState().bugReportDraft).toEqual({ issueType: 'bug', description: '' });
+  });
+
+  it('keeps the type when only the description is written', () => {
+    harnessed.slice.setBugReportDraft({ issueType: 'idea' });
+    harnessed.slice.setBugReportDraft({ description: 'The board keeps the old goal' });
+
+    expect(harnessed.getState().bugReportDraft).toEqual({
+      issueType: 'idea',
+      description: 'The board keeps the old goal',
+    });
+  });
+
+  it('treats an emptied description as written, not as absent', () => {
+    harnessed.slice.setBugReportDraft({ description: 'typed then deleted' });
+    harnessed.slice.setBugReportDraft({ description: '' });
+
+    expect(harnessed.getState().bugReportDraft.description).toBe('');
+  });
+
+  it('drops both fields back to the start on a reset', () => {
+    harnessed.slice.setBugReportDraft({ issueType: 'question', description: 'Where do plans go' });
+    harnessed.slice.clearBugReportDraft();
+
+    expect(harnessed.getState().bugReportDraft).toEqual(initialBugReportDraftState.bugReportDraft);
+  });
+});

--- a/apps/desktop/src/store/slices/bugReportDraft/index.ts
+++ b/apps/desktop/src/store/slices/bugReportDraft/index.ts
@@ -1,0 +1,10 @@
+import { clearBugReportDraft } from './clearBugReportDraft';
+import { setBugReportDraft } from './setBugReportDraft';
+import type { GetFn, SetFn } from './types';
+
+export const createBugReportDraftSlice = (set: SetFn, get: GetFn) => {
+  return {
+    setBugReportDraft: setBugReportDraft(set, get),
+    clearBugReportDraft: clearBugReportDraft(set),
+  };
+};

--- a/apps/desktop/src/store/slices/bugReportDraft/setBugReportDraft.ts
+++ b/apps/desktop/src/store/slices/bugReportDraft/setBugReportDraft.ts
@@ -1,0 +1,19 @@
+import type { IssueTypeValue } from '../../../features/settings/reportIssueTypes';
+import type { GetFn, SetFn } from './types';
+
+export type Params = {
+  readonly issueType?: IssueTypeValue;
+  readonly description?: string;
+};
+
+export const setBugReportDraft = (set: SetFn, get: GetFn) => {
+  return ({ issueType, description }: Params): void => {
+    const current = get().bugReportDraft;
+    set({
+      bugReportDraft: {
+        issueType: issueType ?? current.issueType,
+        description: description ?? current.description,
+      },
+    });
+  };
+};

--- a/apps/desktop/src/store/slices/bugReportDraft/state.ts
+++ b/apps/desktop/src/store/slices/bugReportDraft/state.ts
@@ -1,0 +1,22 @@
+import {
+  DEFAULT_ISSUE_TYPE,
+  type IssueTypeValue,
+} from '../../../features/settings/reportIssueTypes';
+
+export type BugReportDraft = {
+  readonly issueType: IssueTypeValue;
+  readonly description: string;
+};
+
+export const emptyBugReportDraft: BugReportDraft = {
+  issueType: DEFAULT_ISSUE_TYPE,
+  description: '',
+};
+
+export type BugReportDraftState = {
+  readonly bugReportDraft: BugReportDraft;
+};
+
+export const initialBugReportDraftState: BugReportDraftState = {
+  bugReportDraft: emptyBugReportDraft,
+};

--- a/apps/desktop/src/store/slices/bugReportDraft/types.ts
+++ b/apps/desktop/src/store/slices/bugReportDraft/types.ts
@@ -1,0 +1,1 @@
+export type { SetFn, GetFn } from '../../slice-types';

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -161,6 +161,9 @@ import { initialUpdaterState } from './slices/updater/state';
 import { createChangelogSlice } from './slices/changelog';
 import { initialChangelogState } from './slices/changelog/state';
 import type { Params as MarkChangelogSeenParams } from './slices/changelog/markChangelogSeen';
+import { createBugReportDraftSlice } from './slices/bugReportDraft';
+import { initialBugReportDraftState } from './slices/bugReportDraft/state';
+import type { Params as SetBugReportDraftParams } from './slices/bugReportDraft/setBugReportDraft';
 import type { LinearViewer } from '../features/integrations/linear/client';
 import type { SentryProject } from '../features/integrations/sentry/client';
 import type { GitlabUser } from '../features/integrations/gitlab/client';
@@ -190,6 +193,8 @@ export type AppActions = {
   reloadChangelog(): Promise<void>;
   hydrateChangelogSeen(): Promise<void>;
   markChangelogSeen(params: MarkChangelogSeenParams): Promise<void>;
+  setBugReportDraft(params: SetBugReportDraftParams): void;
+  clearBugReportDraft(): void;
   loadDetectedEditors(): Promise<void>;
   setCurrentWorkspace(id: WorkspaceId | null): Promise<void>;
   openWorkspace(id: WorkspaceId, title: string): Promise<void>;
@@ -747,6 +752,7 @@ export type AppStore = AppState & AppActions;
 export const initialState: AppState = {
   ...initialUpdaterState,
   ...initialChangelogState,
+  ...initialBugReportDraftState,
   ...createInitialSessionViewState({}),
   workspaces: [],
   workspaceIntegrations: {},
@@ -913,6 +919,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
   ...createBootSlice(set, get),
   ...createUpdaterSlice(set, get),
   ...createChangelogSlice(set, get),
+  ...createBugReportDraftSlice(set, get),
 }));
 
 export const useResolvedSettings = (sessionId: SessionId | null): ResolvedSettings => {

--- a/apps/desktop/src/store/types.ts
+++ b/apps/desktop/src/store/types.ts
@@ -66,6 +66,7 @@ import type { TerminalTab, TerminalTabId } from '../shared/types/terminal';
 import type { DraftAttachment } from './slices/agents/setAgentAttachments';
 import type { AgentQueuedTurn } from './slices/agents/setAgentQueue';
 import type { ProviderSpendEntry } from './slices/budget';
+import type { BugReportDraftState } from './slices/bugReportDraft/state';
 import type { ChangelogState } from './slices/changelog/state';
 import type { ProviderConnectMap, ProviderLifecycleMap } from './slices/providers';
 import type { ReviewPrsState } from './slices/review-prs/types';
@@ -166,7 +167,7 @@ export type SummarizerSessionStatus = {
   } | null;
 };
 
-type AppSliceState = UpdaterState & ChangelogState & SlackThreadsSliceState;
+type AppSliceState = UpdaterState & ChangelogState & SlackThreadsSliceState & BugReportDraftState;
 
 export type AppState = AppSliceState & {
   readonly workspaces: ReadonlyArray<Workspace>;

--- a/docs/design.md
+++ b/docs/design.md
@@ -25,7 +25,8 @@ An app window is a strip, a set of columns, and a pane. Each owns one thing.
 
 Composition, left to right: mascot, collapse toggle (session only), workspace
 identity, crumbs, workspace rollup, vertical divider, then the global control
-cluster (running scripts, notifications, theme, onboarding). Settings and the
+cluster (running scripts, the report control, notifications, theme,
+onboarding). Settings and the
 update control are not here: they moved to the footer's launcher cluster, which
 is where a destination belongs.
 
@@ -34,6 +35,11 @@ a crumb, or a trigger that opens something elsewhere. No editor, no form, no
 list is rendered inline in the strip. `WorkspaceRollupStrip` opens the budget
 studio, `WorkspaceIdentityRow` opens a popover, `SessionStripCrumbs` changes
 the active lens. None of them mutates a record in place.
+
+`ReportIssuePopover` is the one control that takes typing, and the carve-out is
+argued in [DESIGN.md](../DESIGN.md): a bug report is not a record until it is
+filed, its two fields live in the `bugReportDraft` slice, and the popover's
+primary action opens the full form rather than sending anything itself.
 
 Exactly one child carries `flex-1`, the crumb region:
 
@@ -105,14 +111,14 @@ Board button and `SessionActivityBar`.
 
 Current mounts, one each:
 
-| Thing                           | Sole mount                                                     |
-| ------------------------------- | -------------------------------------------------------------- |
-| Workspace identity and switcher | `features/workspace/components/WorkspaceIdentityRow/index.tsx` |
-| Session title (read)            | `features/session/components/SessionStripCrumbs/index.tsx`     |
-| Session title (rename)          | `SessionOverviewPane/HeaderBand.tsx`                           |
-| Collapse the sessions column    | the toggle in `AppTopBar/index.tsx`, plus ⌘B                   |
-| Open app settings               | the launcher in `AppFooter/index.tsx`, plus ⌘, and the palette |
-| Report an issue                 | the button in Settings' App scope panel, and the palette       |
+| Thing                           | Sole mount                                                                                            |
+| ------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| Workspace identity and switcher | `features/workspace/components/WorkspaceIdentityRow/index.tsx`                                        |
+| Session title (read)            | `features/session/components/SessionStripCrumbs/index.tsx`                                            |
+| Session title (rename)          | `SessionOverviewPane/HeaderBand.tsx`                                                                  |
+| Collapse the sessions column    | the toggle in `AppTopBar/index.tsx`, plus ⌘B                                                          |
+| Open app settings               | the launcher in `AppFooter/index.tsx`, plus ⌘, and the palette                                        |
+| Report an issue                 | the report control in `AppTopBar/index.tsx`, the button in Settings' App scope panel, and the palette |
 
 `WorkspaceIdentityRow` is the trigger and the anchor at once: it holds the
 `triggerRef`, and `WorkspaceSwitcher` mounts as its child when open. The command

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -116,7 +116,12 @@ its switcher popover, then the session breadcrumb, which does render here and is
 rooted at the session title.
 
 Right side: workspace rollup (attention count and today's spend), a divider,
-then running scripts, notifications, the theme toggle and onboarding. Theme is
+then running scripts, the report control, notifications, the theme toggle and
+onboarding. The report control (`ReportIssuePopover`) opens a popover holding an
+issue type and a description, both kept in the `bugReportDraft` store slice, so
+closing the popover keeps what was typed and a `Reset` empties it. Its primary
+action dispatches `goodboy:open-report-issue`, which opens the full form on the
+same draft. Theme is
 the one set-once preference kept here, because it is flipped often enough to
 earn the slot; the guide and pair-device left this row and live in the settings
 studio and the command palette. Settings and the update control left it too,
@@ -240,9 +245,11 @@ the top bar, which dispatches `goodboy:open-notifications-studio`. There is no
 footer button, no shortcut, and no command palette entry for it, because the
 bell already carries the unread count that makes the page worth opening.
 
-Report an issue has no footer entry either. It opens from Settings' App scope
-panel (a `FieldRow` button dispatching `goodboy:open-report-issue`, next to
-"Config backup") and from the command palette. It does not belong on the
+Report an issue has no footer entry either. It opens from the top bar's report
+control, from Settings' App scope panel (a `FieldRow` button dispatching
+`goodboy:open-report-issue`, next to "Config backup") and from the command
+palette. All three land on the same form, and the form sends the draft the
+popover holds. It does not belong on the
 footer's studio row or inside the `More` popover: it is not something you
 reach for by workspace or by session, and adding a slot there would grow
 `MORE_STUDIOS` for a surface that is genuinely settings-adjacent, not a peer


### PR DESCRIPTION
Reporting a bug meant opening Settings, finding "Report an issue" and landing on
a full page. This puts a bug control in the top bar, between running scripts and
notifications, and gives it a popover that captures the report where you hit it.

## What changed

- `ReportIssuePopover` in the top bar: an issue type (`Bug` / `Idea` /
  `Question`) and a description. It uses the shared `useDropdown` hook with
  `strategy: 'fixed'`, not a second hand-rolled anchor.
- A `bugReportDraft` store slice holds both fields, so closing the popover keeps
  the draft and reopening it finds the text still there. `Reset` empties it, and
  the trigger takes a dot while a draft is waiting.
- The primary action opens the existing full form on the same draft, which is
  where the title, the area and the preview live.
- Issue type is a new axis, not a rename of Area, and it reaches the issue:
  the body now opens with `Type: <label>`.
- The full form closes and empties the draft once the report is filed, which it
  never did before: it set a success state and sat there with the draft intact.
  On the direct path the created issue now opens in the browser, which is what
  the form's own screenshot line already promised.
- Settings keeps its entry and the palette keeps its command. All three
  entrances dispatch `goodboy:open-report-issue` and land on the same form.

## The top bar tension

`DESIGN.md` says the top bar is context, never content: every control opens
something elsewhere and none of them edits a record in place. Typing a
description into a popover is the first thing in that row that takes input.

The resolution is that a bug report is not a record until it is filed. The two
fields live in an in-memory draft, nothing is written anywhere, and the primary
action still opens something elsewhere. That is the same carve-out the
composer's pre-send routing line already earns in the same document: unsent
input attached to an action, not a record being edited in chrome. The precedent
is VS Code, whose issue reporter hangs off a top-level menu and captures the
type and the description before handing off to GitHub, because the moment worth
reporting a bug is the moment you hit it.

`DESIGN.md`, `docs/design.md`, `docs/navigation.md` and `README.md` are updated
in this PR, since the change is what makes their old text wrong.

## Deliberately out of scope: screenshots

The issue asks for a screenshot attachment. There is no screen capture
primitive anywhere in the app, and the full form that shipped in #1293 already
rejected attachments because no attach-by-URL path survives GitHub's issue
renderer. It needs a native command plus somewhere to host an image, and where
the image goes is an open product question. No stub and no disabled control
ships here.

## Test plan

- `pnpm typecheck`, `pnpm exec turbo run test --force` (5082 desktop tests,
  everything green), `pnpm knip --include files,duplicates,unlisted` (clean,
  only the configuration hints `main` already carries).
- New: the slice contract test; a popover test that unmounts the component
  between typing and reading it back, so the draft is proven to survive through
  the store and not through component state; a top bar test pinning the control
  ahead of notifications with theme still beside them; a form test that the
  draft is empty and the surface closed after a successful file, and another
  that a failed send keeps the draft.
- By hand: not run against a live GitHub account. The `gh issue create`
  arguments and the fallback URL are unchanged apart from the `Type:` line, and
  both paths are covered by the existing tests.

Closes #1301
