### PR TITLE
fix(desktop): skip stage board regroup when grouping is unchanged

### DIFF
--- a/apps/desktop/src/store/selectors.test.ts
+++ b/apps/desktop/src/store/selectors.test.ts
@@ -300,4 +300,48 @@ describe('useStageGroupedSessions', () => {
 
     expect(result.current).toEqual([{ key: 'building', sessions }]);
   });
+
+  it('keeps the same array reference when an unrelated store field changes', () => {
+    store.state.workspaces = [createWorkspace('repo')];
+    store.state.sessionBranches = { [SESSION_ID]: 'ak/feat-thing' };
+    const sessions = [createSession(SESSION_ID)];
+
+    const { result, rerender } = renderHook(() => useStageGroupedSessions(WORKSPACE_ID, sessions));
+    const first = result.current;
+
+    store.state.currentSessionId = 'unrelated-session' as SessionId;
+    rerender();
+
+    expect(result.current).toBe(first);
+  });
+
+  it('returns a new reference when a session object is replaced under the same id', () => {
+    store.state.workspaces = [createWorkspace('repo')];
+    store.state.sessionBranches = { [SESSION_ID]: 'ak/feat-thing' };
+    let sessions = [createSession(SESSION_ID)];
+
+    const { result, rerender } = renderHook(() => useStageGroupedSessions(WORKSPACE_ID, sessions));
+    const first = result.current;
+
+    sessions = [{ ...createSession(SESSION_ID), goal: 'renamed goal' }];
+    rerender();
+
+    expect(result.current).not.toBe(first);
+    expect(result.current[0]?.sessions[0]?.goal).toBe('renamed goal');
+  });
+
+  it('returns a new reference when a session is added', () => {
+    const otherId = 'session-2' as SessionId;
+    store.state.workspaces = [createWorkspace('repo')];
+    store.state.sessionBranches = { [SESSION_ID]: 'ak/feat-thing', [otherId]: 'ak/feat-two' };
+    let sessions = [createSession(SESSION_ID)];
+
+    const { result, rerender } = renderHook(() => useStageGroupedSessions(WORKSPACE_ID, sessions));
+    const first = result.current;
+
+    sessions = [...sessions, createSession(otherId)];
+    rerender();
+
+    expect(result.current).not.toBe(first);
+  });
 });

--- a/apps/desktop/src/store/selectors.ts
+++ b/apps/desktop/src/store/selectors.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { worktreeChangedFiles } from '../features/worktree/worktree';
 import {
@@ -200,6 +200,34 @@ export const useSortedGroupedSessions = (
   ]);
 };
 
+function groupedSessionsEqual(
+  next: ReadonlyArray<GroupedSessions>,
+  prev: ReadonlyArray<GroupedSessions>,
+): boolean {
+  if (next.length !== prev.length) {
+    return false;
+  }
+  for (let i = 0; i < next.length; i++) {
+    const nextGroup = next[i];
+    const prevGroup = prev[i];
+    if (nextGroup === undefined || prevGroup === undefined) {
+      return false;
+    }
+    if (nextGroup.key !== prevGroup.key) {
+      return false;
+    }
+    if (nextGroup.sessions.length !== prevGroup.sessions.length) {
+      return false;
+    }
+    for (let j = 0; j < nextGroup.sessions.length; j++) {
+      if (nextGroup.sessions[j] !== prevGroup.sessions[j]) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
 export const useStageGroupedSessions = (
   workspaceId: WorkspaceId | null,
   sessions: ReadonlyArray<Session>,
@@ -213,7 +241,8 @@ export const useStageGroupedSessions = (
   const currentSessionId = useAppStore((s) => s.currentSessionId);
   const workspaces = useAppStore((s) => s.workspaces);
   const sessionBranches = useAppStore((s) => s.sessionBranches);
-  return useMemo(() => {
+  const previousRef = useRef<ReadonlyArray<GroupedSessions> | null>(null);
+  const grouped = useMemo(() => {
     const partial: StageInfoState = {
       workspaces,
       sessionBranches,
@@ -246,6 +275,11 @@ export const useStageGroupedSessions = (
     selectedAgentId,
     currentSessionId,
   ]);
+  if (previousRef.current !== null && groupedSessionsEqual(grouped, previousRef.current)) {
+    return previousRef.current;
+  }
+  previousRef.current = grouped;
+  return grouped;
 };
 
 export type WorkspaceRollup = {


### PR DESCRIPTION
## What changed

`useStageGroupedSessions` (`apps/desktop/src/store/selectors.ts`) keeps all eight of its existing `useAppStore` subscriptions (`sessionGithub`, `sessionGitlabMr`, `sessionOpenQuestions`, `sessionPhaseRuns`, `selectedAgentId`, `currentSessionId`, `workspaces`, `sessionBranches`) and the `useMemo` that runs `sortAndGroupSessions` over them, unchanged. What is new: the memo's output is now compared against the previous result held in a `useRef`, and when the two are value-equal the hook returns the previous array reference instead of the freshly computed one.

The comparison, in `groupedSessionsEqual`, bails on the first difference in this order: outer array length, `key` at each index, `sessions.length` per group, then every session compared by object reference (`next[i].sessions[j] === prev[i].sessions[j]`).

Deliberately out of scope, left alone: the eight subscriptions themselves, `StageColumn` (not memoized: it receives `spec={{ kind: 'stage', stage }}` / `spec={{ kind: 'archived' }}`, fresh object literals every render, so wrapping it would be a no-op), and `no-unstable-zustand-selectors.test.ts` (not widened).

## Why reference comparison, not id comparison

The hook returns `ReadonlyArray<{ key: string; sessions: ReadonlyArray<Session> }>`. That shape contains nothing but stage keys and `Session` object references. If every reference in the new result is identical to the corresponding reference in the previous result, the previous array is observationally indistinguishable from the new one for anything reading through this hook, so returning the previous reference cannot surface stale data.

Comparing by session id instead would break that argument: the store replaces a `Session` object wholesale whenever any of its fields changes, so two `Session` objects can share an id while differing in title, stage, or any other field. An id-only comparison would treat those as equal and return the stale array, silently freezing the board on an old title. Everything the cards need that is not carried in this shape (phase runs, for instance) they subscribe to directly, so it is unaffected by this hook returning a stale-but-equivalent reference.

## The numbers, and how they were produced

Measured in the project's own vitest plus happy-dom environment, mounting the real `StageBoard` component tree at N=300 sessions:

- Initial mount: 313.59 ms across 11,265 DOM nodes.
- Re-render with the identical `sessions` array reference and only one unrelated store field touched: 86.92 ms.
- `sortAndGroupSessions` itself, called directly: 0.13 ms per call at N=300.

The gap between 86.92 ms and 0.13 ms is React reconciliation cost from `useStageGroupedSessions` returning a fresh array on every one of the eight subscriptions changing, not the grouping computation itself. That is the problem this PR targets.

Honest caveats: happy-dom under V8 is not WKWebView under JSC, so these are an order-of-magnitude signal that the invalidation is too broad, not a millisecond budget for a user's machine. I did not re-run this timing harness myself as part of this change; the numbers above are the pre-existing measurement that motivated the fix, and a timing assertion is deliberately not committed to the test suite (it would be a flake generator on a loaded CI runner). Behavior is pinned in tests instead; a post-fix timing re-measurement is for whoever verifies this independently.

## Frequency correction

An earlier framing of this problem implied the 86.92 ms re-render fires on every streamed token. It does not: `apps/desktop/src/store/slices/transcripts/buffer.ts` returns `sessionPhaseRuns` by the same reference for `assistant_text` bursts (it only replaces that map on `unknown_payload` or `provider_session_init` events), so token streaming does not invalidate the board. The re-render class this PR addresses is real, but it is tied to genuine `sessionGithub` / `sessionGitlabMr` / `sessionOpenQuestions` / `selectedAgentId` / `currentSessionId` / `workspaces` / `sessionBranches` writes elsewhere in the app, not to every streamed chunk.

## Test plan

Added to `apps/desktop/src/store/selectors.test.ts`, inside the existing `useStageGroupedSessions` describe block:

- an unrelated store field change (`currentSessionId` flipped to an id that does not affect any session's derived stage) yields the same array reference across a re-render
- a session replaced by a new object under the same id (simulating the store's own update pattern) yields a new reference, and the new content is reflected
- a session added to the input array yields a new reference

The second and third cases matter more than the first: a memo that never invalidates is worse than no memo, and the second case is specifically the id-vs-reference distinction called out above.

Kept green, unmodified: `apps/desktop/src/store/selectors.test.ts` (17/17), `features/workspace/components/StageBoard/index.test.tsx` (13/13 combined with StageColumn below), `features/workspace/components/StageBoard/StageColumn/index.test.tsx`, and `__tests__/regressions/no-unstable-zustand-selectors.test.ts` (2/2, no `useShallow not needed` escape hatch needed since the new code never calls `useAppStore` and the eight existing calls are unchanged single-key selectors).

Full verification from the worktree root:

- `pnpm typecheck`: clean across all 5 packages
- `pnpm exec turbo run test --force`: 604 test files, 5113 tests, all passing (baseline was 604 files / 5110 tests; the 3 new tests account for the delta exactly)
- `pnpm knip --include files,duplicates,unlisted`: clean, only pre-existing `knip.json` config hints

## Not verified

I did not independently re-measure the re-render cost after this change with the timing harness that produced the numbers above; that harness was not part of my scope, and a timing assertion is intentionally not part of this PR's test suite.
