### PR TITLE
feat(desktop): let a phone start a session from a jira issue

### DIFF
--- a/.claude/skills/continuous-delivery/references/repo-gotchas.md
+++ b/.claude/skills/continuous-delivery/references/repo-gotchas.md
@@ -106,11 +106,17 @@ return []` arm, and `issueSources.ts` deliberately has no bitbucket entry.
   "Fixing" either ships a picker that lists nothing forever.
 - `RemoteHostKind` deliberately has no `'bitbucket'`; adding it breaks the
   `never`-checked `resolveSessionStudioOpenEvent` and `remoteHost.test.ts`.
-- The mobile companion's `fetchIssuesFor` and `resolveIssueForSession` fall
-  through to GitLab for unknown providers; the gating lists
-  (`ALL_ISSUE_PROVIDERS`, `CREATE_SESSION_PROVIDERS`) are hand-enumerated.
-  Adding a provider to a list without a matching arm silently queries
-  GitLab.
+- The mobile companion's `fetchIssuesFor` and `resolveIssueForSession` are
+  exhaustive switches over `WorkspaceIntegrationProvider` with a
+  `never`-checked default, and neither falls through to another provider:
+  `fetchIssuesFor` returns `[]` for providers with no mobile fetch
+  (currently bitbucket, slack) and `resolveIssueForSession` throws a named
+  refusal for each. The gating lists (`ALL_ISSUE_PROVIDERS`,
+  `CREATE_SESSION_PROVIDERS`) are still hand-enumerated separately from
+  those switches: the compiler forces a switch arm for every provider, but
+  nothing forces a gating-list entry, so a provider can compile cleanly
+  while staying silently absent from mobile issue queries and session
+  creation.
 - `pending_resolutions` is a transient push queue, not a durable verdict
   log; making it durable was investigated and rejected. The durable source
   is message replay via `hydrateResolverOutcomes`.

--- a/apps/desktop/src/features/companion/commandExecutor.commands.test.ts
+++ b/apps/desktop/src/features/companion/commandExecutor.commands.test.ts
@@ -90,25 +90,46 @@ vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn() }));
 // Integration clients + goal derivation: the executor fetches issues + resolves
 // them through these. Stub with faithful shapes so queryIssues normalization and
 // createSessionFromIssue resolution are exercised without any real network.
-const integ = vi.hoisted(() => ({
-  linearFetch: vi.fn(
-    async () =>
-      [
-        {
-          id: 'lin-uuid-1',
-          identifier: 'ENG-1',
-          title: 'Fix the thing',
-          description: 'desc',
-          url: 'https://linear.app/x/issue/ENG-1',
-          state: { name: 'In Progress', type: 'started' },
-          team: { key: 'ENG' },
-          updatedAt: '2026-06-22T00:00:00Z',
-        },
-      ] as unknown[],
-  ),
-  gitlabFetch: vi.fn(async () => [] as unknown[]),
-  sentryFetch: vi.fn(async () => ({ issues: [], next_cursor: null })),
-}));
+const integ = vi.hoisted(() => {
+  const jiraIssueFixture = {
+    id: 'jira-10001',
+    key: 'PROJ-1',
+    summary: 'Fix the thing',
+    description: 'desc',
+    status: 'To Do',
+    statusCategory: 'new',
+    issueType: 'Task',
+    priority: null,
+    assignee: null,
+    reporter: null,
+    labels: [] as string[],
+    created: '2026-06-22T00:00:00Z',
+    updated: '2026-06-22T00:00:00Z',
+    url: 'https://example.atlassian.net/browse/PROJ-1',
+  };
+  return {
+    linearFetch: vi.fn(
+      async () =>
+        [
+          {
+            id: 'lin-uuid-1',
+            identifier: 'ENG-1',
+            title: 'Fix the thing',
+            description: 'desc',
+            url: 'https://linear.app/x/issue/ENG-1',
+            state: { name: 'In Progress', type: 'started' },
+            team: { key: 'ENG' },
+            updatedAt: '2026-06-22T00:00:00Z',
+          },
+        ] as unknown[],
+    ),
+    gitlabFetch: vi.fn(async () => [] as unknown[]),
+    sentryFetch: vi.fn(async () => ({ issues: [], next_cursor: null })),
+    jiraIssueFixture,
+    jiraListFetch: vi.fn(async () => [jiraIssueFixture]),
+    jiraGetFetch: vi.fn(async () => jiraIssueFixture),
+  };
+});
 
 vi.mock('../integrations/linear/client', () => ({
   linearFetchAssignedIssues: integ.linearFetch,
@@ -130,6 +151,14 @@ vi.mock('../integrations/gitlab/client', () => ({
 }));
 vi.mock('../integrations/gitlab/goal-from-issue', () => ({
   goalFromIssue: (i: { title: string }) => i.title,
+}));
+vi.mock('../integrations/jira/client', () => ({
+  jiraListIssues: integ.jiraListFetch,
+  jiraGetIssue: integ.jiraGetFetch,
+}));
+vi.mock('../integrations/jira/goal-from-issue', () => ({
+  goalFromIssue: (i: { issue: { key: string; summary: string } }) =>
+    `[${i.issue.key}] ${i.issue.summary}`,
 }));
 
 import { executeBridgeCommand } from './commandExecutor';
@@ -706,6 +735,62 @@ describe('queryIssues (read-only issue inbox RPC)', () => {
     expect(integ.linearFetch).not.toHaveBeenCalled();
   });
 
+  it('returns normalized jira issues when jira is connected for a workspace', async () => {
+    h.state.value = makeStore({
+      workspaceIntegrations: {
+        w1: [
+          {
+            provider: 'jira',
+            config: {
+              siteUrl: 'https://example.atlassian.net',
+              email: 'pm@example.com',
+              projectKey: 'PROJ',
+            },
+          },
+        ],
+      },
+    });
+    const res = await executeBridgeCommand(cmd('queryIssues', { provider: 'jira' }));
+    expect(res.ok).toBe(true);
+    expect((res.data as { issues: Array<Record<string, unknown>> }).issues).toEqual([
+      {
+        provider: 'jira',
+        identifier: 'PROJ-1',
+        title: 'Fix the thing',
+        url: 'https://example.atlassian.net/browse/PROJ-1',
+        state: 'To Do',
+        description: 'desc',
+      },
+    ]);
+    expect(integ.jiraListFetch).toHaveBeenCalledWith({
+      workspaceId: 'w1',
+      siteUrl: 'https://example.atlassian.net',
+      email: 'pm@example.com',
+      projectKey: 'PROJ',
+      assignedOnly: true,
+    });
+  });
+
+  // The fix under test: an unsupported filter must REFUSE, not silently widen to
+  // "every connected provider". Before the fix this call returned every issue
+  // from every connected provider instead of erroring.
+  it('refuses an unsupported provider filter instead of silently answering with everything', async () => {
+    const res = await executeBridgeCommand(cmd('queryIssues', { provider: 'bitbucket' }));
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/unsupported provider: bitbucket/i);
+    // Nothing was fetched: the filter was refused before any provider query ran.
+    expect(integ.linearFetch).not.toHaveBeenCalled();
+    expect(integ.sentryFetch).not.toHaveBeenCalled();
+    expect(integ.gitlabFetch).not.toHaveBeenCalled();
+    expect(integ.jiraListFetch).not.toHaveBeenCalled();
+  });
+
+  it('refuses a slack provider filter the same way it refuses bitbucket', async () => {
+    const res = await executeBridgeCommand(cmd('queryIssues', { provider: 'slack' }));
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/unsupported provider: slack/i);
+  });
+
   it('does not need a session and never leaks a provider token', async () => {
     const res = await executeBridgeCommand(cmd('queryIssues', {}));
     expect(JSON.stringify(res)).not.toMatch(/token|credential|secret/i);
@@ -808,6 +893,87 @@ describe('createSessionFromIssue (security-gated write)', () => {
     });
     // The new session is mobile-shared so its turns clamp at sendTurn.
     expect(isSessionMobileShared('new-session-1' as SessionId)).toBe(true);
+  });
+
+  it('resolves a jira issue server-side, creates the session, and confines it', async () => {
+    h.state.value = makeStore({
+      workspaceIntegrations: {
+        w1: [
+          {
+            provider: 'jira',
+            config: {
+              siteUrl: 'https://example.atlassian.net',
+              email: 'pm@example.com',
+              projectKey: 'PROJ',
+            },
+          },
+        ],
+      },
+    });
+    const res = await executeBridgeCommand(
+      cmd('createSessionFromIssue', {
+        workspaceId: 'w1',
+        provider: 'jira',
+        issueIdentifier: 'PROJ-1',
+        setupWorkflow: false,
+      }),
+    );
+    expect(res.ok).toBe(true);
+    expect(res.data).toEqual({ sessionId: 'new-session-1' });
+    expect(h.createSession).toHaveBeenCalledWith({
+      workspaceId: 'w1',
+      goal: '[PROJ-1] Fix the thing',
+      externalTask: {
+        provider: 'jira',
+        externalId: 'jira-10001',
+        identifier: 'PROJ-1',
+        url: 'https://example.atlassian.net/browse/PROJ-1',
+        title: 'Fix the thing',
+      },
+      mobileShared: true,
+    });
+    expect(integ.jiraGetFetch).toHaveBeenCalledWith({
+      workspaceId: 'w1',
+      siteUrl: 'https://example.atlassian.net',
+      email: 'pm@example.com',
+      issueKey: 'PROJ-1',
+    });
+    expect(isSessionMobileShared('new-session-1' as SessionId)).toBe(true);
+  });
+
+  it('masks a raw jira client error when resolving the issue (no body leaks to phone)', async () => {
+    h.state.value = makeStore({
+      workspaceIntegrations: {
+        w1: [
+          {
+            provider: 'jira',
+            config: {
+              siteUrl: 'https://example.atlassian.net',
+              email: 'pm@example.com',
+              projectKey: 'PROJ',
+            },
+          },
+        ],
+      },
+    });
+    const secret = 'HTTP 401 {"token":"sk-live-JIRA","trace":"/Users/ak/secret"}';
+    integ.jiraGetFetch.mockRejectedValueOnce(new Error(secret));
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const res = await executeBridgeCommand(
+      cmd('createSessionFromIssue', {
+        workspaceId: 'w1',
+        provider: 'jira',
+        issueIdentifier: 'PROJ-1',
+      }),
+    );
+
+    expect(res.ok).toBe(false);
+    expect(res.error).toBe('could not resolve issue PROJ-1');
+    expect(JSON.stringify(res)).not.toMatch(/sk-live|JIRA|secret/i);
+    expect(errSpy).toHaveBeenCalled();
+    expect(h.createSession).not.toHaveBeenCalled();
+    errSpy.mockRestore();
   });
 
   // FINDING 2 (ordering): the executor MUST pass mobileShared so createSession

--- a/apps/desktop/src/features/companion/commandExecutor.ts
+++ b/apps/desktop/src/features/companion/commandExecutor.ts
@@ -30,6 +30,7 @@ import {
 } from './mobileConfinement';
 import type { AgentKind } from '../session/agent-kind';
 import type {
+  JiraIntegrationConfig,
   SessionExternalTaskProvider,
   WorkspaceId,
   WorkspaceIntegrationProvider,
@@ -48,6 +49,8 @@ import {
   type GitlabIssue,
 } from '../integrations/gitlab/client';
 import { goalFromIssue as gitlabGoalFromIssue } from '../integrations/gitlab/goal-from-issue';
+import { jiraListIssues, jiraGetIssue, type JiraIssue } from '../integrations/jira/client';
+import { goalFromIssue as jiraGoalFromIssue } from '../integrations/jira/goal-from-issue';
 
 const PROVIDER_IDS: ReadonlyArray<ProviderId> = [
   'anthropic',
@@ -184,6 +187,7 @@ const ALL_ISSUE_PROVIDERS: ReadonlyArray<WorkspaceIntegrationProvider> = [
   'linear',
   'sentry',
   'gitlab',
+  'jira',
 ];
 
 const normalizeLinear = (i: LinearIssue): NormalizedIssue => ({
@@ -213,10 +217,25 @@ const normalizeGitlab = (i: GitlabIssue): NormalizedIssue => ({
   description: i.description ?? null,
 });
 
+const normalizeJira = (i: JiraIssue): NormalizedIssue => ({
+  provider: 'jira',
+  identifier: i.key,
+  title: i.summary,
+  url: i.url,
+  state: i.status ?? null,
+  description: i.description,
+});
+
 function gitlabHostFor(workspaceId: WorkspaceId): string | undefined {
   const rows = useAppStore.getState().workspaceIntegrations[workspaceId] ?? [];
   const row = rows.find((r) => r.provider === 'gitlab');
   return row && row.provider === 'gitlab' ? row.config.host : undefined;
+}
+
+function jiraConfigFor(workspaceId: WorkspaceId): JiraIntegrationConfig | undefined {
+  const rows = useAppStore.getState().workspaceIntegrations[workspaceId] ?? [];
+  const row = rows.find((r) => r.provider === 'jira');
+  return row && row.provider === 'jira' ? row.config : undefined;
 }
 
 function connectedProviders(workspaceId: WorkspaceId): ReadonlySet<WorkspaceIntegrationProvider> {
@@ -243,7 +262,20 @@ async function fetchIssuesFor(
         }
         return (await gitlabFetchAssignedIssues(workspaceId, host)).map(normalizeGitlab);
       }
-      case 'jira':
+      case 'jira': {
+        const config = jiraConfigFor(workspaceId);
+        if (config == null) {
+          return [];
+        }
+        const issues = await jiraListIssues({
+          workspaceId,
+          siteUrl: config.siteUrl,
+          email: config.email,
+          projectKey: config.projectKey,
+          assignedOnly: true,
+        });
+        return issues.map(normalizeJira);
+      }
       case 'bitbucket':
       case 'slack':
         return [];
@@ -349,8 +381,28 @@ async function resolveIssueForSession(
         },
       };
     }
-    case 'jira':
-      throw new BridgeSafeError(`jira issue creation is not available from mobile: ${identifier}`);
+    case 'jira': {
+      const config = jiraConfigFor(workspaceId);
+      if (config == null) {
+        throw new BridgeSafeError('jira is not configured for this workspace');
+      }
+      const issue = await jiraGetIssue({
+        workspaceId,
+        siteUrl: config.siteUrl,
+        email: config.email,
+        issueKey: identifier,
+      });
+      return {
+        goal: jiraGoalFromIssue({ issue }),
+        externalTask: {
+          provider: 'jira',
+          externalId: issue.id,
+          identifier: issue.key,
+          url: issue.url,
+          title: issue.summary,
+        },
+      };
+    }
     case 'bitbucket':
       throw new BridgeSafeError(`bitbucket does not expose issues to Goodboy: ${identifier}`);
     case 'slack':
@@ -438,11 +490,13 @@ async function dispatchMobile(cmd: BridgeCommand): Promise<unknown> {
 
     case 'queryIssues': {
       const rawProvider = asString(data.provider);
-      const filter =
-        rawProvider && ALL_ISSUE_PROVIDERS.includes(rawProvider as WorkspaceIntegrationProvider)
-          ? (rawProvider as WorkspaceIntegrationProvider)
-          : undefined;
-      return queryIssuesForMobile(filter);
+      if (rawProvider === undefined) {
+        return queryIssuesForMobile(undefined);
+      }
+      if (!ALL_ISSUE_PROVIDERS.includes(rawProvider as WorkspaceIntegrationProvider)) {
+        throw new BridgeSafeError(`unsupported provider: ${rawProvider}`);
+      }
+      return queryIssuesForMobile(rawProvider as WorkspaceIntegrationProvider);
     }
 
     case 'queryFileDiff': {

--- a/apps/desktop/src/features/companion/mobileConfinement.test.ts
+++ b/apps/desktop/src/features/companion/mobileConfinement.test.ts
@@ -197,6 +197,51 @@ describe('evaluateMobileCreateSession', () => {
     if (!gate.ok) expect(gate.reason).toMatch(/not connected/i);
   });
 
+  // PARITY: jira must pass through the exact same gate shape as linear —
+  // adding a provider to the allowlist is not a special case, it is another
+  // member of the same set.
+  it('accepts jira exactly as it accepts linear (same connected-workspace shape)', () => {
+    const gate = evaluateMobileCreateSession({
+      workspaceId: 'w1',
+      provider: 'jira',
+      workspaces,
+      integrations: [{ provider: 'jira' as const }],
+    });
+    expect(gate.ok).toBe(true);
+    if (gate.ok) {
+      expect(gate.workspaceId).toBe('w1');
+      expect(gate.provider).toBe('jira');
+    }
+  });
+
+  // PARITY: an unconnected jira integration is refused the same way an
+  // unconnected linear integration is refused above.
+  it('refuses jira when it is not connected for the target workspace', () => {
+    const gate = evaluateMobileCreateSession({
+      workspaceId: 'w1',
+      provider: 'jira',
+      workspaces,
+      integrations: linearOnW1, // only linear connected on w1
+    });
+    expect(gate.ok).toBe(false);
+    if (!gate.ok) expect(gate.reason).toMatch(/not connected/i);
+  });
+
+  // PARITY: bitbucket and slack remain outside the create-session allowlist,
+  // same refusal shape as any other unsupported provider (e.g. github).
+  it('refuses bitbucket and slack exactly as it refuses github', () => {
+    for (const provider of ['bitbucket', 'slack']) {
+      const gate = evaluateMobileCreateSession({
+        workspaceId: 'w1',
+        provider,
+        workspaces,
+        integrations: [{ provider: provider as never }],
+      });
+      expect(gate.ok).toBe(false);
+      if (!gate.ok) expect(gate.reason).toMatch(/unsupported provider/i);
+    }
+  });
+
   // ADVERSARIAL: w2 exists but has no integrations at all — can't launch from it.
   it('refuses a workspace with no integrations connected', () => {
     const gate = evaluateMobileCreateSession({

--- a/apps/desktop/src/features/companion/mobileConfinement.ts
+++ b/apps/desktop/src/features/companion/mobileConfinement.ts
@@ -68,6 +68,7 @@ const CREATE_SESSION_PROVIDERS: ReadonlySet<string> = new Set<WorkspaceIntegrati
   'linear',
   'sentry',
   'gitlab',
+  'jira',
 ]);
 
 export const isCreateSessionProvider = (v: unknown): v is WorkspaceIntegrationProvider =>


### PR DESCRIPTION
## What

A phone can now start a session from a jira issue, the same way it already can from linear, sentry, and gitlab.

- `ALL_ISSUE_PROVIDERS` (`apps/desktop/src/features/companion/commandExecutor.ts`) and `CREATE_SESSION_PROVIDERS` (`apps/desktop/src/features/companion/mobileConfinement.ts`) each gained jira.
- `fetchIssuesFor` and `resolveIssueForSession` got real jira arms, replacing the placeholder `return []` and the "jira issue creation is not available from mobile" refusal.
- Both arms reuse the jira client the desktop issue picker already runs in production: `jiraListIssues` and `jiraGetIssue` from `apps/desktop/src/features/integrations/jira/client.ts`, plus the existing `goalFromIssue` helper from `jira/goal-from-issue.ts`. No second jira implementation was written.

## Why jira alone

The work item started as "add the four missing providers". Three of those four are not addable here:

- GitHub is not a member of `WorkspaceIntegrationProvider` at all, it only exists in `SessionExternalTaskProvider`. GitHub sessions start from the pull request path, not the issue picker. Widening the union to force it in would be out of scope for this change.
- Slack is not an issue tracker. `resolveIssueForSession` already refuses it with "slack threads cannot start a session from mobile", and that refusal is correct by design. Left untouched.
- Bitbucket is deliberately dead in this surface. `fetchIssueCandidates` carries a deliberate `case 'bitbucket': return []`, and `issueSources.ts` deliberately has no bitbucket entry, because Atlassian points issue tracking at jira and Goodboy follows that. Implementing either would ship a picker that lists nothing forever. Left untouched.

Jira is the one provider where a PM's team can plausibly run their whole workflow, and `VISION.md` treats the non-coder PM persona as first-class. That is the gap this closes.

## The silent-filter fix

`queryIssuesForMobile` takes an optional provider filter. Before this change, a filter value outside `ALL_ISSUE_PROVIDERS` was silently dropped and the phone received every issue from every connected provider instead, no error, no signal that its request was ignored. That was asymmetric with `createSessionFromIssue`, which already refuses cleanly with "unsupported provider: <provider>".

The `queryIssues` dispatch case in `commandExecutor.ts` now refuses an unrecognized filter with the same "unsupported provider: <provider>" message instead of silently answering a different question.

## Docs correction

`.claude/skills/continuous-delivery/references/repo-gotchas.md` claimed `fetchIssuesFor` and `resolveIssueForSession` "fall through to GitLab for unknown providers". That was never true: both are exhaustive switches over `WorkspaceIntegrationProvider` with a `never`-checked default, `fetchIssuesFor` returns `[]` for providers with no mobile fetch and `resolveIssueForSession` throws a named refusal for each. The entry is corrected to describe that behavior, while keeping the real hazard: the gating lists are hand-maintained separately from those switches, so a provider can compile cleanly while staying silently absent from mobile results because nobody added it to the list.

## Test plan

- `apps/desktop/src/features/companion/commandExecutor.commands.test.ts`: a jira issue reaching the phone through `queryIssues` with the exact `jiraListIssues` params asserted, `queryIssues` now refusing an unsupported filter (bitbucket, slack) instead of silently merging in every provider, a session created from a jira issue through `createSessionFromIssue` with the exact `jiraGetIssue` params and resulting `externalTask` asserted, and a raw jira client error masked before it reaches the phone.
- `apps/desktop/src/features/companion/mobileConfinement.test.ts`: jira accepted through `evaluateMobileCreateSession` with the identical shape linear already gets, jira refused when not connected for the target workspace with the identical shape linear's not-connected case gets, and bitbucket/slack still refused as unsupported providers.
- Full suite: `pnpm typecheck`, `pnpm exec turbo run test --force` (604 files, 5118 tests, all green; baseline was 604/5110, the 8 new tests are the ones listed above), `pnpm knip --include files,duplicates,unlisted` (clean).

## What this stands on, and what is not verified

No call has gone out to a live jira workspace from this machine. The jira arms reuse `jiraListIssues` and `jiraGetIssue`, the same Tauri-backed client the desktop jira issue picker already runs in production, so the request/response shapes are the ones already exercised there. If a real jira workspace ever returns a shape those calls do not expect, `fetchIssuesFor` swallows the error per-integration and just omits jira from the phone's issue list (same as any other provider fetch failure), and `resolveIssueForSession` surfaces a masked "could not resolve issue <id>" to the phone with the real error logged desktop-side only.
