### PR TITLE
feat(desktop): turn the beta badge into a support popover

### DIFF
--- a/apps/desktop/src/app/components/AppFooter/index.test.tsx
+++ b/apps/desktop/src/app/components/AppFooter/index.test.tsx
@@ -229,8 +229,8 @@ describe('AppFooter', () => {
     storeState.updaterStatus = 'available';
     render(<AppFooter {...footerProps()} />);
 
-    const beta = screen.getByText('Beta');
-    const row = beta.parentElement;
+    const beta = screen.getByRole('button', { name: 'Beta' });
+    const row = beta.parentElement?.parentElement;
     const cluster = row?.children[2];
     const buttons = Array.from(cluster?.querySelectorAll('button') ?? []).filter(
       (button) => button.closest('dialog') == null,
@@ -261,11 +261,11 @@ describe('AppFooter', () => {
     expect(providers().className).not.toContain('animate-soft-pulse');
   });
 
-  it('lays the row out as three grid regions so the beta chip cannot overlap a cluster', () => {
+  it('lays the row out as three grid regions so the beta badge cannot overlap a cluster', () => {
     render(<AppFooter {...footerProps()} />);
 
-    const beta = screen.getByText('Beta');
-    const row = beta.parentElement;
+    const beta = screen.getByRole('button', { name: 'Beta' });
+    const row = beta.parentElement?.parentElement;
 
     expect(row?.className).toContain('grid');
     expect(row?.className).toContain('grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)]');

--- a/apps/desktop/src/shared/components/BetaPill/index.test.tsx
+++ b/apps/desktop/src/shared/components/BetaPill/index.test.tsx
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+
+const { openUrlMock } = vi.hoisted(() => ({
+  openUrlMock: vi.fn(async () => undefined),
+}));
+
+vi.mock('../../lib/editor', () => ({
+  openUrl: openUrlMock,
+}));
+
+import { BetaPill } from './index';
+
+afterEach(() => {
+  cleanup();
+  openUrlMock.mockClear();
+});
+
+describe('BetaPill', () => {
+  it('still reads Beta on the trigger', () => {
+    render(<BetaPill />);
+
+    expect(screen.getByRole('button', { name: 'Beta' })).toBeTruthy();
+  });
+
+  it('opens the support popover on click', () => {
+    render(<BetaPill />);
+
+    expect(screen.queryByRole('dialog', { name: 'Support Goodboy' })).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Beta' }));
+
+    expect(screen.getByRole('dialog', { name: 'Support Goodboy' })).toBeTruthy();
+  });
+
+  it('opens the exact sponsor URL and nothing else when the action is clicked', () => {
+    render(<BetaPill />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Beta' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Sponsor on GitHub' }));
+
+    expect(openUrlMock).toHaveBeenCalledTimes(1);
+    expect(openUrlMock).toHaveBeenCalledWith('https://github.com/sponsors/akhayam99');
+  });
+
+  it('closes on escape', () => {
+    render(<BetaPill />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Beta' }));
+    expect(screen.getByRole('dialog', { name: 'Support Goodboy' })).toBeTruthy();
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+
+    expect(screen.queryByRole('dialog', { name: 'Support Goodboy' })).toBeNull();
+  });
+});

--- a/apps/desktop/src/shared/components/BetaPill/index.tsx
+++ b/apps/desktop/src/shared/components/BetaPill/index.tsx
@@ -1,9 +1,61 @@
-import { Chip } from '@goodboy/ui';
+import { ExternalLink } from 'lucide-react';
+import { Button, Chip, Popover, cn } from '@goodboy/ui';
+import { useDropdown } from '../../hooks/useDropdown';
+import { DropdownPortal } from '../../hooks/useDropdown/DropdownPortal';
+import { openUrl } from '../../lib/editor';
+
+const SPONSOR_URL = 'https://github.com/sponsors/akhayam99';
 
 type Props = {
   readonly className?: string;
 };
 
 export const BetaPill = ({ className }: Props) => {
-  return <Chip tone="primary" label="Beta" className={className} />;
+  const { open, toggle, containerRef, popupRef, popupClassName, popupStyle, portal, portalTarget } =
+    useDropdown({
+      align: 'start',
+      expectedHeight: 132,
+      expectedWidth: 288,
+      width: 'w-72',
+      strategy: 'fixed',
+    });
+
+  const openSponsorPage = () => {
+    void openUrl(SPONSOR_URL);
+  };
+
+  return (
+    <div ref={containerRef} className="relative">
+      <Chip
+        as="button"
+        tone="primary"
+        label="Beta"
+        onClick={toggle}
+        testId="beta-badge-trigger"
+        className={cn(
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]',
+          className,
+        )}
+      />
+      <DropdownPortal portal={portal} portalTarget={portalTarget}>
+        {open && (
+          <Popover
+            innerRef={popupRef}
+            role="dialog"
+            ariaLabel="Support Goodboy"
+            className={cn(popupClassName, 'flex flex-col gap-3 p-3')}
+            style={popupStyle}
+          >
+            <p className="text-2xs leading-relaxed text-muted-foreground">
+              Goodboy is free and open source. A sponsorship helps keep it maintained.
+            </p>
+            <Button size="sm" onClick={openSponsorPage} className="self-start">
+              <ExternalLink size={12} aria-hidden />
+              Sponsor on GitHub
+            </Button>
+          </Popover>
+        )}
+      </DropdownPortal>
+    </div>
+  );
 };


### PR DESCRIPTION
## What changed

The footer beta badge is now clickable. Clicking it opens an anchored popover with a short message about Goodboy being free and open source, and one action that opens `https://github.com/sponsors/akhayam99` in the system browser via `openUrl`. The badge itself keeps reading "Beta"; only the click behavior is new.

## Why this shape

`DESIGN.md` reserves `Dialog` for the three jobs an anchor cannot do, and confirming a chip click is not one of them, so an anchored popover is the default. The codebase already has `useDropdown` (`apps/desktop/src/shared/hooks/useDropdown`) as the shared positioning/escape/outside-click primitive, with `strategy: 'fixed'` used at roughly a dozen call sites. I used it instead of hand-rolling another `getBoundingClientRect` implementation like `NeedsYouPopover` and `WorkspaceSwitcher` do; the backlog already carries about fourteen of those as debt and this PR had no reason to add a fifteenth. I copied the composition shape most closely from `ReportIssuePopover` (`apps/desktop/src/features/settings/components/ReportIssuePopover`), which is the closest existing example of a small footer-adjacent popover built on `useDropdown` + `DropdownPortal`.

## Copy

> Goodboy is free and open source. A sponsorship helps keep it maintained.

Button label: `Sponsor on GitHub`

Against `docs/tone-of-voice.md`: no "AI", no minimizers ("simply"/"just"), no sales verbs ("unlock"/"empower"/"leverage"), no superlatives, no exclamation marks, sentence case, no em-dashes, no trailing period on the button label (the message keeps its period as a body sentence). The reassurance sits directly above the action, per the "put the reassurance next to the action" rule.

## File-layout fix

`shared/components/BetaPill/` held only `index.tsx`, which `docs/file-system.md` forbids. Since the component now carries real behavior, I earned the folder by adding `index.test.tsx` next to it rather than flattening.

## Test plan

New `apps/desktop/src/shared/components/BetaPill/index.test.tsx`:
- the trigger still reads "Beta"
- clicking it opens the "Support Goodboy" popover
- clicking the action calls the mocked `openUrl` exactly once with `https://github.com/sponsors/akhayam99` and nothing else
- Escape closes the popover

Updated `apps/desktop/src/app/components/AppFooter/index.test.tsx`: the two assertions that located the beta chip via `screen.getByText('Beta').parentElement` now go through `getByRole('button', { name: 'Beta' })` and one more `.parentElement` hop, since the trigger is now wrapped in the `useDropdown` container div. Layout invariants (three grid regions, no absolute positioning) are unchanged. Left the soft-pulse providers-launcher test alone.

Verified: `pnpm typecheck`, `pnpm exec turbo run test --force` (605 files / 5114 tests, up from the 604/5110 baseline by exactly this PR's new test file), `pnpm knip --include files,duplicates,unlisted` (clean, only pre-existing config hints).

Closes #1254