### PR TITLE
perf(desktop): open the window before the cli probes finish

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -62,11 +62,21 @@ pub fn run() {
     suppress_webkit_media_remote();
     let database = db::open().expect("failed to open Goodboy database");
     let bridge_state = bridge::BridgeState::new().expect("failed to init companion bridge");
-    let provider_state = providers::ProviderState(Mutex::new(providers::detect_claude()));
-    let cursor_state = providers::CursorState(Mutex::new(providers::detect_cursor()));
-    let codex_state = providers::CodexState(Mutex::new(providers::detect_codex()));
-    let gemini_state = providers::GeminiState(Mutex::new(providers::detect_gemini()));
-    let opencode_state = providers::OpencodeState(Mutex::new(providers::detect_opencode()));
+    let (detection_gate, detection_opener) = providers::detection_gate();
+    let provider_state = providers::ProviderState(Mutex::new(providers::initial_status(
+        "anthropic", "claude",
+    )));
+    let cursor_state = providers::CursorState(Mutex::new(providers::initial_status(
+        "cursor",
+        "cursor-agent",
+    )));
+    let codex_state =
+        providers::CodexState(Mutex::new(providers::initial_status("codex", "codex")));
+    let gemini_state =
+        providers::GeminiState(Mutex::new(providers::initial_status("gemini", "agy")));
+    let opencode_state = providers::OpencodeState(Mutex::new(providers::initial_status(
+        "opencode", "opencode",
+    )));
     let turn_registry = turn::TurnRegistry::new();
     let summarize_registry = summarize::SummarizeRegistry::new();
     let script_registry = scripts::ScriptRegistry::new();
@@ -89,6 +99,7 @@ pub fn run() {
         .manage(codex_state)
         .manage(gemini_state)
         .manage(opencode_state)
+        .manage(detection_gate)
         .manage(turn_registry)
         .manage(summarize_registry)
         .manage(script_registry)
@@ -100,7 +111,8 @@ pub fn run() {
         .manage(jira_token_cache)
         .manage(bitbucket_token_cache)
         .manage(slack_token_cache)
-        .setup(|app| {
+        .setup(move |app| {
+            providers::spawn_startup_detection(app.handle().clone(), detection_opener);
             #[cfg(desktop)]
             app.handle()
                 .plugin(tauri_plugin_updater::Builder::new().build())?;

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -63,9 +63,8 @@ pub fn run() {
     let database = db::open().expect("failed to open Goodboy database");
     let bridge_state = bridge::BridgeState::new().expect("failed to init companion bridge");
     let (detection_gate, detection_opener) = providers::detection_gate();
-    let provider_state = providers::ProviderState(Mutex::new(providers::initial_status(
-        "anthropic", "claude",
-    )));
+    let provider_state =
+        providers::ProviderState(Mutex::new(providers::initial_status("anthropic", "claude")));
     let cursor_state = providers::CursorState(Mutex::new(providers::initial_status(
         "cursor",
         "cursor-agent",

--- a/apps/desktop/src-tauri/src/providers.rs
+++ b/apps/desktop/src-tauri/src/providers.rs
@@ -3,7 +3,8 @@ use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
-use tauri::State;
+use tauri::{AppHandle, Manager, State};
+use tokio::sync::watch;
 
 use crate::path_env;
 
@@ -30,6 +31,128 @@ pub struct CodexState(pub Mutex<ProviderStatus>);
 pub struct GeminiState(pub Mutex<ProviderStatus>);
 
 pub struct OpencodeState(pub Mutex<ProviderStatus>);
+
+pub struct DetectionGate(watch::Receiver<bool>);
+
+pub struct DetectionGateOpener(watch::Sender<bool>);
+
+pub fn detection_gate() -> (DetectionGate, DetectionGateOpener) {
+    let (tx, rx) = watch::channel(false);
+    (DetectionGate(rx), DetectionGateOpener(tx))
+}
+
+impl DetectionGate {
+    pub async fn wait(&self) {
+        let mut rx = self.0.clone();
+        loop {
+            if *rx.borrow_and_update() {
+                return;
+            }
+            if rx.changed().await.is_err() {
+                return;
+            }
+        }
+    }
+}
+
+impl DetectionGateOpener {
+    pub fn open(self) {
+        let _ = self.0.send(true);
+    }
+}
+
+pub fn initial_status(id: &str, binary: &str) -> ProviderStatus {
+    ProviderStatus {
+        id: id.to_string(),
+        binary: binary.to_string(),
+        available: false,
+        version: None,
+        error: None,
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DetectedProviders {
+    pub claude: ProviderStatus,
+    pub cursor: ProviderStatus,
+    pub codex: ProviderStatus,
+    pub gemini: ProviderStatus,
+    pub opencode: ProviderStatus,
+}
+
+type Detector = fn() -> ProviderStatus;
+
+#[derive(Clone, Copy)]
+struct Detectors {
+    claude: Detector,
+    cursor: Detector,
+    codex: Detector,
+    gemini: Detector,
+    opencode: Detector,
+}
+
+const DEFAULT_DETECTORS: Detectors = Detectors {
+    claude: detect_claude,
+    cursor: detect_cursor,
+    codex: detect_codex,
+    gemini: detect_gemini,
+    opencode: detect_opencode,
+};
+
+async fn detect_isolated(detect: Detector, id: &'static str, binary: &'static str) -> ProviderStatus {
+    tauri::async_runtime::spawn_blocking(detect)
+        .await
+        .unwrap_or_else(|err| ProviderStatus {
+            id: id.to_string(),
+            binary: binary.to_string(),
+            available: false,
+            version: None,
+            error: Some(err.to_string()),
+        })
+}
+
+async fn detect_all_with(detectors: Detectors) -> DetectedProviders {
+    let (claude, cursor, codex, gemini, opencode) = tokio::join!(
+        detect_isolated(detectors.claude, "anthropic", "claude"),
+        detect_isolated(detectors.cursor, "cursor", "cursor-agent"),
+        detect_isolated(detectors.codex, "codex", "codex"),
+        detect_isolated(detectors.gemini, "gemini", "agy"),
+        detect_isolated(detectors.opencode, "opencode", "opencode"),
+    );
+    DetectedProviders {
+        claude,
+        cursor,
+        codex,
+        gemini,
+        opencode,
+    }
+}
+
+pub async fn detect_all() -> DetectedProviders {
+    detect_all_with(DEFAULT_DETECTORS).await
+}
+
+pub fn spawn_startup_detection(app: AppHandle, opener: DetectionGateOpener) {
+    tauri::async_runtime::spawn(async move {
+        let detected = detect_all().await;
+        store_detected(&app, detected);
+        opener.open();
+    });
+}
+
+fn store_detected(app: &AppHandle, detected: DetectedProviders) {
+    store_status(&app.state::<ProviderState>().0, detected.claude);
+    store_status(&app.state::<CursorState>().0, detected.cursor);
+    store_status(&app.state::<CodexState>().0, detected.codex);
+    store_status(&app.state::<GeminiState>().0, detected.gemini);
+    store_status(&app.state::<OpencodeState>().0, detected.opencode);
+}
+
+fn store_status(state: &Mutex<ProviderStatus>, next: ProviderStatus) {
+    if let Ok(mut current) = state.lock() {
+        *current = next;
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
@@ -647,8 +770,12 @@ fn parse_codex_auth_output(output: &str) -> AuthState {
 }
 
 #[tauri::command]
-pub fn get_provider_status(state: State<'_, ProviderState>) -> ProviderStatus {
-    get_status(&state.0, "anthropic", "claude")
+pub async fn get_provider_status(
+    gate: State<'_, DetectionGate>,
+    state: State<'_, ProviderState>,
+) -> Result<ProviderStatus, String> {
+    gate.wait().await;
+    Ok(get_status(&state.0, "anthropic", "claude"))
 }
 
 #[tauri::command]
@@ -659,8 +786,12 @@ pub async fn refresh_provider_status(
 }
 
 #[tauri::command]
-pub fn get_cursor_status(state: State<'_, CursorState>) -> ProviderStatus {
-    get_status(&state.0, "cursor", "cursor-agent")
+pub async fn get_cursor_status(
+    gate: State<'_, DetectionGate>,
+    state: State<'_, CursorState>,
+) -> Result<ProviderStatus, String> {
+    gate.wait().await;
+    Ok(get_status(&state.0, "cursor", "cursor-agent"))
 }
 
 #[tauri::command]
@@ -671,8 +802,12 @@ pub async fn refresh_cursor_status(
 }
 
 #[tauri::command]
-pub fn get_codex_status(state: State<'_, CodexState>) -> ProviderStatus {
-    get_status(&state.0, "codex", "codex")
+pub async fn get_codex_status(
+    gate: State<'_, DetectionGate>,
+    state: State<'_, CodexState>,
+) -> Result<ProviderStatus, String> {
+    gate.wait().await;
+    Ok(get_status(&state.0, "codex", "codex"))
 }
 
 #[tauri::command]
@@ -681,8 +816,12 @@ pub async fn refresh_codex_status(state: State<'_, CodexState>) -> Result<Provid
 }
 
 #[tauri::command]
-pub fn get_gemini_status(state: State<'_, GeminiState>) -> ProviderStatus {
-    get_status(&state.0, "gemini", "agy")
+pub async fn get_gemini_status(
+    gate: State<'_, DetectionGate>,
+    state: State<'_, GeminiState>,
+) -> Result<ProviderStatus, String> {
+    gate.wait().await;
+    Ok(get_status(&state.0, "gemini", "agy"))
 }
 
 #[tauri::command]
@@ -693,22 +832,43 @@ pub async fn refresh_gemini_status(
 }
 
 #[tauri::command]
-pub fn get_opencode_status(state: State<'_, OpencodeState>) -> ProviderStatus {
-    get_status(&state.0, "opencode", "opencode")
+pub async fn get_opencode_status(
+    gate: State<'_, DetectionGate>,
+    state: State<'_, OpencodeState>,
+) -> Result<ProviderStatus, String> {
+    gate.wait().await;
+    Ok(get_status(&state.0, "opencode", "opencode"))
 }
 
 #[tauri::command]
-pub fn get_openrouter_status(state: State<'_, OpencodeState>) -> ProviderStatus {
-    let mut status = get_status(&state.0, "openrouter", "opencode");
-    status.id = "openrouter".to_string();
-    status
+pub async fn get_openrouter_status(
+    gate: State<'_, DetectionGate>,
+    state: State<'_, OpencodeState>,
+) -> Result<ProviderStatus, String> {
+    gate.wait().await;
+    Ok(aliased(
+        get_status(&state.0, "openrouter", "opencode"),
+        "openrouter",
+    ))
 }
 
 #[tauri::command]
-pub fn get_moonshot_status(state: State<'_, OpencodeState>) -> ProviderStatus {
-    let mut status = get_status(&state.0, "moonshot", "opencode");
-    status.id = "moonshot".to_string();
-    status
+pub async fn get_moonshot_status(
+    gate: State<'_, DetectionGate>,
+    state: State<'_, OpencodeState>,
+) -> Result<ProviderStatus, String> {
+    gate.wait().await;
+    Ok(aliased(
+        get_status(&state.0, "moonshot", "opencode"),
+        "moonshot",
+    ))
+}
+
+fn aliased(status: ProviderStatus, id: &str) -> ProviderStatus {
+    ProviderStatus {
+        id: id.to_string(),
+        ..status
+    }
 }
 
 #[tauri::command]

--- a/apps/desktop/src-tauri/src/providers.rs
+++ b/apps/desktop/src-tauri/src/providers.rs
@@ -99,7 +99,11 @@ const DEFAULT_DETECTORS: Detectors = Detectors {
     opencode: detect_opencode,
 };
 
-async fn detect_isolated(detect: Detector, id: &'static str, binary: &'static str) -> ProviderStatus {
+async fn detect_isolated(
+    detect: Detector,
+    id: &'static str,
+    binary: &'static str,
+) -> ProviderStatus {
     tauri::async_runtime::spawn_blocking(detect)
         .await
         .unwrap_or_else(|err| ProviderStatus {

--- a/apps/desktop/src-tauri/src/providers.rs
+++ b/apps/desktop/src-tauri/src/providers.rs
@@ -13,7 +13,7 @@ const AUTH_TIMEOUT: Duration = Duration::from_secs(5);
 const CODEX_AUTH_TIMEOUT: Duration = Duration::from_secs(8);
 const POLL_INTERVAL: Duration = Duration::from_millis(50);
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct ProviderStatus {
     pub id: String,
     pub binary: String,
@@ -1197,6 +1197,240 @@ mod tests {
             openrouter_credential(&names),
             Some(&"OpenRouter".to_string())
         );
+    }
+
+    fn fake(id: &str) -> ProviderStatus {
+        ProviderStatus {
+            id: id.to_string(),
+            binary: format!("{}-bin", id),
+            available: true,
+            version: Some(format!("{}-1.0", id)),
+            error: None,
+        }
+    }
+
+    const FAKE_DETECTORS: Detectors = Detectors {
+        claude: || fake("anthropic"),
+        cursor: || fake("cursor"),
+        codex: || fake("codex"),
+        gemini: || fake("gemini"),
+        opencode: || fake("opencode"),
+    };
+
+    #[tokio::test]
+    async fn gate_releases_waiters_once_opened() {
+        let (gate, opener) = detection_gate();
+        opener.open();
+        gate.wait().await;
+    }
+
+    #[tokio::test]
+    async fn gate_releases_waiters_when_the_task_panics() {
+        let (gate, opener) = detection_gate();
+        let task = tokio::spawn(async move {
+            let _held = opener;
+            panic!("detection task died");
+        });
+        assert!(task.await.is_err());
+        gate.wait().await;
+    }
+
+    #[tokio::test]
+    async fn gate_releases_waiters_when_the_opener_is_dropped_unused() {
+        let (gate, opener) = detection_gate();
+        drop(opener);
+        gate.wait().await;
+    }
+
+    #[tokio::test]
+    async fn concurrent_detection_routes_every_result_to_its_own_slot() {
+        let detected = detect_all_with(FAKE_DETECTORS).await;
+        assert_eq!(detected.claude.id, "anthropic");
+        assert_eq!(detected.cursor.id, "cursor");
+        assert_eq!(detected.codex.id, "codex");
+        assert_eq!(detected.gemini.id, "gemini");
+        assert_eq!(detected.opencode.id, "opencode");
+        assert_eq!(detected.claude.version.as_deref(), Some("anthropic-1.0"));
+        assert_eq!(detected.opencode.version.as_deref(), Some("opencode-1.0"));
+    }
+
+    #[tokio::test]
+    async fn concurrent_detection_matches_the_serial_result() {
+        let serial = DetectedProviders {
+            claude: (FAKE_DETECTORS.claude)(),
+            cursor: (FAKE_DETECTORS.cursor)(),
+            codex: (FAKE_DETECTORS.codex)(),
+            gemini: (FAKE_DETECTORS.gemini)(),
+            opencode: (FAKE_DETECTORS.opencode)(),
+        };
+        let concurrent = detect_all_with(FAKE_DETECTORS).await;
+        assert_eq!(serial.claude, concurrent.claude);
+        assert_eq!(serial.cursor, concurrent.cursor);
+        assert_eq!(serial.codex, concurrent.codex);
+        assert_eq!(serial.gemini, concurrent.gemini);
+        assert_eq!(serial.opencode, concurrent.opencode);
+    }
+
+    #[tokio::test]
+    async fn a_panicking_detection_still_produces_a_status_for_every_provider() {
+        let detectors = Detectors {
+            codex: || panic!("codex detector blew up"),
+            ..FAKE_DETECTORS
+        };
+        let detected = detect_all_with(detectors).await;
+        assert_eq!(detected.codex.id, "codex");
+        assert_eq!(detected.codex.binary, "codex");
+        assert!(!detected.codex.available);
+        assert!(detected.codex.error.is_some());
+        assert!(detected.claude.available);
+        assert!(detected.opencode.available);
+    }
+
+    #[tokio::test]
+    async fn the_gate_opens_after_a_panicking_detection() {
+        let (gate, opener) = detection_gate();
+        let detectors = Detectors {
+            gemini: || panic!("gemini detector blew up"),
+            ..FAKE_DETECTORS
+        };
+        tokio::spawn(async move {
+            let _ = detect_all_with(detectors).await;
+            opener.open();
+        });
+        gate.wait().await;
+    }
+
+    #[tokio::test]
+    async fn detections_run_concurrently_rather_than_one_after_another() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::{Condvar, Mutex as StdMutex};
+
+        static IN_FLIGHT: StdMutex<usize> = StdMutex::new(0);
+        static ALL_ARRIVED: Condvar = Condvar::new();
+        static PEAK: AtomicUsize = AtomicUsize::new(0);
+
+        fn rendezvous(id: &str) -> ProviderStatus {
+            let deadline = Instant::now() + Duration::from_secs(3);
+            let mut count = IN_FLIGHT.lock().unwrap();
+            *count += 1;
+            PEAK.fetch_max(*count, Ordering::SeqCst);
+            ALL_ARRIVED.notify_all();
+            while *count < 5 {
+                let now = Instant::now();
+                if now >= deadline {
+                    break;
+                }
+                let (next, _) = ALL_ARRIVED.wait_timeout(count, deadline - now).unwrap();
+                count = next;
+                PEAK.fetch_max(*count, Ordering::SeqCst);
+            }
+            *count -= 1;
+            fake(id)
+        }
+
+        let detectors = Detectors {
+            claude: || rendezvous("anthropic"),
+            cursor: || rendezvous("cursor"),
+            codex: || rendezvous("codex"),
+            gemini: || rendezvous("gemini"),
+            opencode: || rendezvous("opencode"),
+        };
+        let _ = detect_all_with(detectors).await;
+        assert_eq!(
+            PEAK.load(Ordering::SeqCst),
+            5,
+            "all five detections must be in flight at the same time"
+        );
+    }
+
+    #[test]
+    fn aliased_rewrites_only_the_id() {
+        let base = ProviderStatus {
+            id: "opencode".to_string(),
+            binary: "opencode".to_string(),
+            available: true,
+            version: Some("1.2.3".to_string()),
+            error: None,
+        };
+        let router = aliased(base.clone(), "openrouter");
+        assert_eq!(router.id, "openrouter");
+        assert_eq!(router.binary, "opencode");
+        assert!(router.available);
+        assert_eq!(router.version.as_deref(), Some("1.2.3"));
+        let moonshot = aliased(base, "moonshot");
+        assert_eq!(moonshot.id, "moonshot");
+        assert_eq!(moonshot.binary, "opencode");
+    }
+
+    #[test]
+    fn initial_status_is_unavailable_without_an_error() {
+        let s = initial_status("anthropic", "claude");
+        assert_eq!(s.id, "anthropic");
+        assert_eq!(s.binary, "claude");
+        assert!(!s.available);
+        assert_eq!(s.version, None);
+        assert_eq!(s.error, None);
+    }
+
+    fn detect_all_serial() -> DetectedProviders {
+        DetectedProviders {
+            claude: detect_claude(),
+            cursor: detect_cursor(),
+            codex: detect_codex(),
+            gemini: detect_gemini(),
+            opencode: detect_opencode(),
+        }
+    }
+
+    fn print_detected(label: &str, detected: &DetectedProviders, elapsed: Duration) {
+        println!("{label} total {:?}", elapsed);
+        for status in [
+            &detected.claude,
+            &detected.cursor,
+            &detected.codex,
+            &detected.gemini,
+            &detected.opencode,
+        ] {
+            println!(
+                "  {:<10} available={} version={:?} error={:?}",
+                status.id, status.available, status.version, status.error
+            );
+        }
+    }
+
+    #[test]
+    #[ignore = "timing harness, run one mode per process: cargo test --lib bench_serial_detection -- --ignored --nocapture"]
+    fn bench_serial_detection() {
+        let started = Instant::now();
+        let detected = detect_all_serial();
+        print_detected("serial", &detected, started.elapsed());
+    }
+
+    #[test]
+    #[ignore = "timing harness, run one mode per process: cargo test --lib bench_concurrent_detection -- --ignored --nocapture"]
+    fn bench_concurrent_detection() {
+        let started = Instant::now();
+        let detected = tauri::async_runtime::block_on(detect_all());
+        print_detected("concurrent", &detected, started.elapsed());
+    }
+
+    #[test]
+    #[ignore = "requires the real provider binaries; opt in with --ignored"]
+    fn concurrent_and_serial_detection_agree_on_the_real_binaries() {
+        let serial = detect_all_serial();
+        let concurrent = tauri::async_runtime::block_on(detect_all());
+        for (a, b) in [
+            (&serial.claude, &concurrent.claude),
+            (&serial.cursor, &concurrent.cursor),
+            (&serial.codex, &concurrent.codex),
+            (&serial.gemini, &concurrent.gemini),
+            (&serial.opencode, &concurrent.opencode),
+        ] {
+            assert_eq!(a.id, b.id);
+            assert_eq!(a.binary, b.binary);
+            assert_eq!(a.available, b.available);
+            assert_eq!(a.version, b.version);
+        }
     }
 
     #[test]

--- a/apps/desktop/src/__tests__/snapshots/boot-recovery.test.tsx
+++ b/apps/desktop/src/__tests__/snapshots/boot-recovery.test.tsx
@@ -29,15 +29,9 @@ describe('BootSplash error recovery', () => {
     expect(onRetry).toHaveBeenCalledOnce();
   });
 
-  it('shows skip provider detection when phase is detecting-cli', () => {
-    const onSkip = vi.fn();
-    render(
-      <BootSplash phase="detecting-cli" error="cli not found" onSkipProviderDetection={onSkip} />,
-    );
-    const skipBtn = screen.getByRole('button', { name: /skip provider detection/i });
-    expect(skipBtn).toBeDefined();
-    fireEvent.click(skipBtn);
-    expect(onSkip).toHaveBeenCalledOnce();
+  it('offers no skip affordance while detecting agents', () => {
+    render(<BootSplash phase="detecting-cli" error="cli not found" />);
+    expect(screen.queryByRole('button', { name: /skip provider detection/i })).toBeNull();
   });
 
   it('renders the report issue button', () => {

--- a/apps/desktop/src/app/components/BootSplash/index.tsx
+++ b/apps/desktop/src/app/components/BootSplash/index.tsx
@@ -21,17 +21,10 @@ type BootSplashProps = {
   phase: BootPhase;
   error: string | null;
   onRetry?: () => void;
-  onSkipProviderDetection?: () => void;
   onFinished?: () => void;
 };
 
-export const BootSplash = ({
-  phase,
-  error,
-  onRetry,
-  onSkipProviderDetection,
-  onFinished,
-}: BootSplashProps) => {
+export const BootSplash = ({ phase, error, onRetry, onFinished }: BootSplashProps) => {
   const hasError = error != null;
   const finishedRef = useRef(false);
 
@@ -49,12 +42,7 @@ export const BootSplash = ({
     return (
       <div className="relative flex h-screen flex-col items-center justify-center gap-10 bg-background text-foreground">
         <BootBrand />
-        <BootErrorRecovery
-          error={error}
-          phase={phase}
-          onRetry={onRetry}
-          onSkipProviderDetection={onSkipProviderDetection}
-        />
+        <BootErrorRecovery error={error} phase={phase} onRetry={onRetry} />
       </div>
     );
   }
@@ -95,15 +83,11 @@ function BootErrorRecovery({
   error,
   phase,
   onRetry,
-  onSkipProviderDetection,
 }: {
   error: string;
   phase: BootPhase;
   onRetry?: () => void;
-  onSkipProviderDetection?: () => void;
 }) {
-  const isDetectingCli = phase === 'detecting-cli' || phase === 'error';
-
   const openIssue = useCallback(() => {
     const url = `${GITHUB_NEW_ISSUE_URL}&body=${encodeURIComponent(`**phase:** ${phase}\n\n**error:**\n\`\`\`\n${error}\n\`\`\``)}`;
     void openUrl(url);
@@ -140,16 +124,6 @@ function BootErrorRecovery({
             className="rounded border border-danger/30 bg-background px-3 py-1.5 text-danger motion-safe:transition-colors hover:bg-danger/10"
           >
             › retry
-          </button>
-        ) : null}
-
-        {isDetectingCli && onSkipProviderDetection ? (
-          <button
-            type="button"
-            onClick={onSkipProviderDetection}
-            className="rounded border border-border px-3 py-1.5 text-muted-foreground motion-safe:transition-colors hover:bg-muted"
-          >
-            › skip provider detection
           </button>
         ) : null}
 


### PR DESCRIPTION
## What changed

`run()` used to call `db::open()`, `BridgeState::new()` and then the five
provider detections **before `tauri::Builder::default()` existed**. Each
detection spawns `<binary> --version` and polls against a 2s timeout, and the
first one pays a 3s-capped `/bin/zsh -ilc` login-shell probe. The window is
created at the end of the builder chain and `tauri.conf.json` sets no
`show: false`, so all of that happened with nothing on screen.

Now:

- the five detections run **concurrently in a background task** started as the
  first statement of the `setup` hook, so the builder is constructed and the
  window created without waiting on any subprocess;
- a single completion gate (`tokio::sync::watch`) is `manage`d alongside the
  provider states, and the seven `get_*_status` commands `await` it before
  reading their `Mutex`, so the frontend observes exactly the values it
  observes today, just later and faster;
- `db::open()` and `BridgeState::new()` stay where they were: fast, no
  subprocess.

The seven commands became `async fn` returning `Result<ProviderStatus, String>`
(Tauri requires `Result` for an async command with a borrowed `State`, the same
shape `refresh_*_status` already uses). They always return `Ok`, and
`hydrate.ts` already awaits all seven inside a `Promise.all`, so **no
TypeScript change was needed for this part** and no new frontend state exists.
`get_openrouter_status` and `get_moonshot_status` still alias the opencode
state and wait on the same gate, which is why one gate rather than five.

No new dependency: tokio is already a direct dependency with `sync`, `macros`
and `rt-multi-thread`.

## Numbers, and how to reproduce them

Method: two ignored harnesses, each run in a **fresh process** so the
login-shell probe is cold exactly as it is at launch. From
`apps/desktop/src-tauri`, with the shared target dir:

```
cargo test --locked --lib bench_serial_detection     -- --ignored --nocapture
cargo test --locked --lib bench_concurrent_detection -- --ignored --nocapture
```

Three runs each on macOS, all five CLIs installed and detected `available=true`
with identical versions in both modes:

| mode | runs | median |
| --- | --- | --- |
| serial (what shipped) | 3.008s, 1.743s, 1.752s | **1.75s** |
| concurrent (this PR) | 1.239s, 1.279s, 1.250s | **1.25s** |

The first serial run is the OS-cold outlier. The concurrent floor is the login
shell probe itself, measured separately at 0.86s / 1.01s / 0.99s with
`/usr/bin/time -p /bin/zsh -ilc <probe script>`; the five detections now hide
almost entirely behind it, and the `OnceLock` still runs the probe once.

**On the window-creation path the removal is the full 1.75s**, because the work
moved off that path entirely rather than getting faster. The old worst case if
one CLI hung was 3 + (5 x 2) = 13s of no window; it is now 0 either way, and a
hung CLI only delays the provider values.

`concurrent_and_serial_detection_agree_on_the_real_binaries` (ignored, opt in
with `--ignored`) asserts the two modes return identical id, binary,
availability and version for all five.

## How the gate cannot hang

`DetectionGate::wait` returns on **either** the watched value turning true
**or** `changed()` returning `Err`, which tokio's `watch` produces when every
sender is dropped. The only sender lives inside the spawned task's future, so:

- normal completion sends `true`;
- a panic, a cancellation, or the future being dropped before `open()` drops
  the sender and releases every waiter.

There is no path that keeps the sender alive without opening the gate. On top
of that, an individual detection cannot panic the batch: each runs in its own
`spawn_blocking`, and a `JoinError` is turned into a `ProviderStatus` carrying
the error, which is the same failure shape `detect_binary` already produces for
a missing or timed-out binary. Three tests pin this: open, panicking task,
dropped opener.

## Evidence the five actually overlap

`tokio::join!` polls every branch on its first poll pass, and each branch's
first action is `spawn_blocking`, which dispatches to a blocking-pool thread at
call time rather than at await time. Awaiting five handles in order would have
been the same wall clock as today, so this is asserted, not assumed:
`detections_run_concurrently_rather_than_one_after_another` has the five fake
detectors rendezvous on a `Condvar` with an in-flight counter and asserts the
**peak in-flight count is 5**. Each waiter gives up after 3s, so a serialized
implementation fails the assertion instead of hanging the suite. It is a
concurrency assertion, not a timing one, so a busy machine cannot flake it.

## Boot splash skip affordance: deleted

`BootSplash` rendered a "skip provider detection" button only when
`onSkipProviderDetection` was passed, and `App.tsx` passed `phase`, `error`,
`onRetry` and `onFinished` and never that. The button could not render for any
user. After this change the `detecting-cli` phase no longer holds the window
back at all, so wiring it would mean inventing a skip destination for a wait
that no longer blocks anything visible. Deleted the prop from both components
and the now-orphaned `isDetectingCli`, and turned the test that asserted the
button appears into one asserting it does not.

## Test plan

New Rust coverage (there was none over this path before):

- gate releases waiters after `open()`
- gate releases waiters when the task holding the opener panics
- gate releases waiters when the opener is dropped unused
- concurrent detection routes each result to its own provider slot
- concurrent result equals the serial result
- one panicking detector still yields a status for all five providers
- the gate opens after a panicking detection
- the five detections are in flight simultaneously
- `aliased` rewrites only the id (openrouter/moonshot over opencode)
- `initial_status` is unavailable with no error
- ignored: serial and concurrent agree on the real binaries; two timing
  harnesses

No timing assertion is committed as a test; the numbers live in this body with
the method beside them. No timer reports anywhere off the machine.

Checks: `pnpm typecheck` green; `pnpm exec turbo run test --force` 604 files /
5110 tests passing (the baseline exactly, one test replaced by one test);
`pnpm knip --include files,duplicates,unlisted` clean; `cargo test --locked`
384 passed / 0 failed / 5 ignored. `cargo clippy --all-targets` adds no
warnings and `cargo fmt --check` leaves only the pre-existing
`provider_credentials.rs` hunk untouched.

## Not verified

The window appearing immediately was not observed in a running app; no full
Tauri build was produced. The claim rests on the code path: nothing between
process start and `Builder::default()` spawns a subprocess any more.
