### PR TITLE
chore(repo): bump version to 0.1.71

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ version in the same PR that bumps the version numbers (see
 `docs/release-command.md`), before the tag is pushed: the release build fails
 if it can't find a matching `## Goodboy vX.Y.Z` heading.
 
+## Goodboy v0.1.71
+
+The window comes up while Goodboy looks for your CLIs instead of after, and a phone can now start a session from a Jira issue.
+
+### [#1314] The window opens before Goodboy has found your CLIs
+
+Launching Goodboy used to mean an empty desktop while it worked out which provider CLIs you have. On a machine with all five installed that was about 2.4 seconds of nothing on screen, most of it the login shell Goodboy runs to resolve your `PATH`.
+
+That work now happens in the background, once the window exists, and the five checks run together rather than one after another, which takes them from about 2.0 seconds to about 1.35 seconds. What you see is unchanged: the splash still names the phase it is in, and the provider list still arrives filled in.
+
+Follow-up: the window's place in the order comes from Tauri's own startup, which builds the window before the app's setup hook runs, and the work that moved was measured where it used to sit, though the app has not been launched from a packaged build with the change in it. If a CLI stalls, the window is already up and only the provider list waits.
+
+### [#1312] Start a session from a Jira issue on your phone
+
+The mobile companion could browse issues and start a session from Linear, Sentry and GitLab, but not Jira, so a team running on Jira had nothing to open. Jira now sits with the other three: its issues reach the phone, and a session starts from one with the goal already written. Every check that guards a Linear issue guards a Jira one identically.
+
+Asking the companion for a provider it does not support used to be answered with every issue from every connected provider instead, with no sign the request had been changed. It now refuses by name. GitHub, Slack and Bitbucket stay out on purpose: a GitHub session starts from a pull request, Slack threads are not issues, and Bitbucket has no issue tracking because Atlassian points that at Jira.
+
+Follow-up: the Jira calls reuse the client the desktop issue picker already runs, though no call has gone out to a live Jira workspace from a phone yet. If a shape differs, the phone's issue list leaves Jira out rather than showing an error, and a failed session start comes back as a plain refusal with the real error kept on your machine.
+
+### [#1313] The Beta badge carries a support message
+
+The Beta badge in the footer opens a popover now: Goodboy is free and open source, and one action opens GitHub Sponsors in your browser. The badge still reads Beta.
+
 ## Goodboy v0.1.70
 
 The session tells you the truth about what it holds, and filing a bug no longer costs you the page you were on.

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goodboy/desktop",
-  "version": "0.1.70",
+  "version": "0.1.71",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -1391,7 +1391,7 @@ dependencies = [
 
 [[package]]
 name = "goodboy-desktop"
-version = "0.1.70"
+version = "0.1.71"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goodboy-desktop"
-version = "0.1.70"
+version = "0.1.71"
 description = "Goodboy desktop app"
 authors = ["Amin Khayam"]
 license = "MIT"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Goodboy",
-  "version": "0.1.70",
+  "version": "0.1.71",
   "identifier": "com.goodboy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goodboy",
-  "version": "0.1.70",
+  "version": "0.1.71",
   "private": true,
   "description": "AI workspace orchestrator. Local-first, provider-agnostic.",
   "license": "MIT",


### PR DESCRIPTION
Version bump to 0.1.71 in all five files (`package.json`, `apps/desktop/package.json`, `apps/desktop/src-tauri/tauri.conf.json`, `apps/desktop/src-tauri/Cargo.toml`, `apps/desktop/src-tauri/Cargo.lock`), plus the `## Goodboy v0.1.71` section in `CHANGELOG.md`, which `release.yml` reads verbatim as the release body and the updater notes.

Notes written from the merged PR bodies (#1314, #1312, #1313) and reviewed against `docs/tone-of-voice.md` before this commit. That review changed four figures and cut two bullets:

- the detection speedup is quoted from the cold-process measurement (about 2.0s to about 1.35s), not the warm-probe pair, because the PATH probe is never warm at launch
- the "under a millisecond" figure is gone: it was true of the measured region and misleading about what a reader would take from it, since window build, webview boot and hydration are all still there and none was measured
- the 13 second ceiling is gone: it needs all five CLIs to stall, not one, and it was arithmetic nobody observed
- the badge label reads `Beta`, not `BETA`
- #1311 gets no line: its performance claim did not reproduce under independent measurement, so a fix line would carry an implicature the evidence does not support
- the removed boot splash button gets no line: it was unreachable by construction, so no user ever had it

Each shipped feature carries its follow-up: #1314 for the window ordering, which rests on Tauri's own startup order and a measurement of the work that moved rather than on a packaged build, and #1312 for the Jira calls, which have not gone out to a live workspace from a phone.