### PR TITLE
ci(repo): build linux artifacts on release and prove them on a pr

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -1,0 +1,112 @@
+name: linux build
+
+# release.yml only fires on tags, and a tag build that fails is a failed
+# release that cannot be re-cut. This workflow produces the Linux bundles on a
+# real ubuntu-latest runner before any tag exists, using the same build command
+# the release job runs, so the bundler path is proven on a pull request.
+#
+# Deliberately not a required check: it costs several minutes and guards a leg
+# that changes rarely. It is also deliberately absent from release.yml, which
+# has no workflow_dispatch: no hand-triggered path may mint release assets.
+
+on:
+  pull_request:
+    paths:
+      - 'apps/desktop/src-tauri/**'
+      - '.github/workflows/linux-build.yml'
+      - '.github/workflows/release.yml'
+      - 'pnpm-lock.yaml'
+      - 'apps/desktop/src-tauri/Cargo.lock'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  bundle:
+    name: appimage + deb + rpm
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # Same list as the release job, plus dpkg-dev for dpkg-shlibdeps, which
+      # is how bundle.linux.deb.depends is derived from the real binary instead
+      # of guessed.
+      - name: install tauri system deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev libsoup-3.0-dev patchelf xdg-utils dpkg-dev
+
+      - name: setup pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v4
+
+      - name: setup node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: setup rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
+
+      - name: cache cargo
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            apps/desktop/src-tauri/target
+          key: cargo-linux-bundle-${{ hashFiles('apps/desktop/src-tauri/Cargo.toml') }}
+          restore-keys: |
+            cargo-linux-bundle-
+
+      - name: install
+        run: pnpm install --frozen-lockfile
+
+      - name: build workspace deps
+        run: pnpm turbo run build --filter=@goodboy/desktop^...
+
+      # Identical to the release job's args, invoked directly so the proof runs
+      # the same bundler with the same flags. --no-sign because
+      # bundle.createUpdaterArtifacts is on and no signing key is available here.
+      - name: build bundles
+        run: pnpm --filter @goodboy/desktop exec tauri build --bundles appimage,deb,rpm --no-sign
+
+      - name: list bundles
+        run: |
+          set -euo pipefail
+          find apps/desktop/src-tauri/target/release/bundle -type f \
+            \( -name '*.AppImage' -o -name '*.deb' -o -name '*.rpm' -o -name '*.tar.gz' \) \
+            -printf '%s\t%p\n' | sort -k2
+
+      # Reads the real shared-library dependencies off the binary we just built.
+      # The output of these two commands is the only acceptable source for
+      # bundle.linux.deb.depends in tauri.conf.json.
+      - name: derive deb depends
+        run: |
+          set -euo pipefail
+          binary=apps/desktop/src-tauri/target/release/goodboy-desktop
+          echo "== ldd $binary =="
+          ldd "$binary"
+          echo "== dpkg-shlibdeps -O $binary =="
+          workdir="$(mktemp -d)"
+          mkdir -p "$workdir/debian"
+          printf 'Source: goodboy-desktop\n' > "$workdir/debian/control"
+          (cd "$workdir" && dpkg-shlibdeps -O --ignore-missing-info "$GITHUB_WORKSPACE/$binary")
+          echo "== Depends recorded in the generated deb =="
+          deb="$(find apps/desktop/src-tauri/target/release/bundle/deb -name '*.deb' | head -n1)"
+          dpkg-deb -f "$deb" Depends || echo '(no Depends field)'
+
+      - name: upload bundles
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: goodboy-linux-bundles
+          if-no-files-found: error
+          path: |
+            apps/desktop/src-tauri/target/release/bundle/appimage/*.AppImage
+            apps/desktop/src-tauri/target/release/bundle/deb/*.deb
+            apps/desktop/src-tauri/target/release/bundle/rpm/*.rpm

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -100,6 +100,15 @@ jobs:
           echo "== Depends recorded in the generated deb =="
           deb="$(find apps/desktop/src-tauri/target/release/bundle/deb -name '*.deb' | head -n1)"
           dpkg-deb -f "$deb" Depends || echo '(no Depends field)'
+          # ubuntu-latest is 24.04, where the time_t transition renamed some
+          # packages with a t64 suffix. dpkg-shlibdeps reports the noble names,
+          # which do not exist on Debian 12 or Ubuntu 22.04. Print what the t64
+          # packages Provide so the depends list can use names that resolve on
+          # both, derived rather than assumed.
+          for pkg in libglib2.0-0t64 libgtk-3-0t64; do
+            echo "== apt-cache show $pkg | Provides =="
+            apt-cache show "$pkg" | grep -E '^(Package|Version|Provides):' || true
+          done
 
       - name: upload bundles
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -102,10 +102,13 @@ jobs:
           deb="$(find apps/desktop/src-tauri/target/release/bundle/deb -name '*.deb' | head -n1)"
           dpkg-deb -f "$deb" Depends || echo '(no Depends field)'
           # ubuntu-latest is 24.04, where the time_t transition renamed some
-          # packages with a t64 suffix. dpkg-shlibdeps reports the noble names,
-          # which do not exist on Debian 12 or Ubuntu 22.04. Print what the t64
-          # packages Provide so the depends list can use names that resolve on
-          # both, derived rather than assumed.
+          # packages with a t64 suffix, so dpkg-shlibdeps reports the noble
+          # names. The depends list drops that suffix because the t64 packages
+          # declare versioned Provides for the unsuffixed names, which is what
+          # the printout below shows, so the unsuffixed versioned dependencies
+          # resolve. That is the whole reason, and it is not a portability
+          # claim: the derived list pins libc6 (>= 2.39), which already rules
+          # out Debian 12 and Ubuntu 22.04 regardless of these names.
           for pkg in libglib2.0-0t64 libgtk-3-0t64; do
             echo "== apt-cache show $pkg | Provides =="
             apt-cache show "$pkg" | grep -E '^(Package|Version|Provides):' || true

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -33,11 +33,12 @@ jobs:
 
       # Same list as the release job, plus dpkg-dev for dpkg-shlibdeps, which
       # is how bundle.linux.deb.depends is derived from the real binary instead
-      # of guessed.
+      # of guessed. libdbus-1-dev and pkg-config are there for the keyring
+      # crate's Secret Service backend (see #1317).
       - name: install tauri system deps
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev libsoup-3.0-dev patchelf xdg-utils dpkg-dev
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev libsoup-3.0-dev libdbus-1-dev pkg-config patchelf xdg-utils dpkg-dev
 
       - name: setup pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,11 +183,23 @@ jobs:
         with:
           projectPath: apps/desktop
           tagName: ${{ github.ref_name }}
-          # Do not remove. Default is false, and on the false path the action
-          # looks the tag up with getReleaseByTag, which cannot see drafts. It
-          # would 404 and create a SECOND, published release for the same tag,
-          # repointing releases/latest/download/latest.json at a release with no
-          # macOS assets and firing homebrew.yml against a release with no dmg.
+          # Do not remove, though not for the reason it may look like. On the
+          # true path the action scans listReleases, which does include drafts,
+          # and reuses the macOS job's draft for this tag. Because the release
+          # it finds is a draft, updateRelease is skipped, so the
+          # CHANGELOG-derived body macOS wrote is left exactly as it is.
+          #
+          # Without it, the default false path looks the tag up with
+          # getReleaseByTag, which cannot see drafts, and 404s. This job passes
+          # no releaseName, so nothing is created and the action throws
+          # "Release not found or created." That fails closed: the Linux job
+          # goes red and the macOS release is untouched.
+          #
+          # The real hazard is arming the create path. Adding releaseName or
+          # releaseBody here turns a missed lookup into a SECOND release for
+          # this tag instead of a throw, and with releaseDraft false that one is
+          # published, repointing releases/latest/download/latest.json at a
+          # release with no macOS assets and firing homebrew.yml against it.
           releaseDraft: true
           # No TAURI_SIGNING_PRIVATE_KEY is passed here, and this job needs no
           # secrets at all. --no-sign skips updater signing, which would

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,10 @@ on:
 # secrets are present; if they are unset the build still produces an unsigned
 # .dmg. The release body and the updater's latest.json notes both come from
 # CHANGELOG.md. See docs/release.md.
+#
+# The linux job runs after macos and attaches AppImage/deb/rpm to the same
+# draft. It is deliberately serialized, not parallel: macOS owns the release
+# (body, latest.json, the four assets) and must be banked before Linux starts.
 
 permissions:
   contents: write
@@ -114,3 +118,83 @@ jobs:
           releaseDraft: true
           prerelease: false
           args: --target universal-apple-darwin
+
+  linux:
+    name: build linux bundles
+    runs-on: ubuntu-latest
+    # `needs: macos` is load-bearing, not cosmetic. It guarantees the four macOS
+    # assets and the draft release exist before this job runs, so a red Linux
+    # leg can never cost us the macOS release, and it removes the read-modify-
+    # write race two tauri-action runs would otherwise have on the release.
+    # No `continue-on-error`: a broken Linux bundle must go red loudly.
+    needs: macos
+    timeout-minutes: 60
+    steps:
+      - name: checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # Same list rust.yml installs to build the crate, plus patchelf and
+      # xdg-utils, which the AppImage and deb bundlers shell out to.
+      - name: install tauri system deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev libsoup-3.0-dev patchelf xdg-utils
+
+      - name: setup pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v4
+
+      - name: setup node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: setup rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
+
+      - name: cache cargo
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            apps/desktop/src-tauri/target
+          key: cargo-linux-release-${{ hashFiles('apps/desktop/src-tauri/Cargo.toml') }}
+          restore-keys: |
+            cargo-linux-release-
+
+      - name: install
+        run: pnpm install --frozen-lockfile
+
+      - name: build workspace deps
+        run: pnpm turbo run build --filter=@goodboy/desktop^...
+
+      # This job attaches bundles to the release the macos job already created.
+      # It does not own the release: no releaseName, no releaseBody, so the
+      # CHANGELOG-derived body stays exactly as macOS wrote it.
+      - name: build, release (linux bundles)
+        uses: tauri-apps/tauri-action@1deb371b0cd8bd54025b384f1cd735e725c4060f # v1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          projectPath: apps/desktop
+          tagName: ${{ github.ref_name }}
+          # Do not remove. Default is false, and on the false path the action
+          # looks the tag up with getReleaseByTag, which cannot see drafts. It
+          # would 404 and create a SECOND, published release for the same tag,
+          # repointing releases/latest/download/latest.json at a release with no
+          # macOS assets and firing homebrew.yml against a release with no dmg.
+          releaseDraft: true
+          # No TAURI_SIGNING_PRIVATE_KEY is passed here, and this job needs no
+          # secrets at all. --no-sign skips updater signing, which would
+          # otherwise hard-error because bundle.createUpdaterArtifacts is on.
+          args: --bundles appimage,deb,rpm --no-sign
+          # Default is true. latest.json belongs to macOS: upload-version-json
+          # rewrites version/notes/pub_date wholesale, so a Linux run would blank
+          # the release notes every macOS user reads in the update dialog.
+          uploadUpdaterJson: false
+          # Default is true. Without a manifest referencing them, .sig assets on
+          # the release are orphans.
+          uploadUpdaterSignatures: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,12 +133,14 @@ jobs:
       - name: checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      # Same list rust.yml installs to build the crate, plus patchelf and
-      # xdg-utils, which the AppImage and deb bundlers shell out to.
+      # Same list rust.yml installs to build the crate, plus libdbus-1-dev and
+      # pkg-config for the keyring crate's Secret Service backend (see #1317),
+      # and patchelf plus xdg-utils, which the AppImage and deb bundlers shell
+      # out to.
       - name: install tauri system deps
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev libsoup-3.0-dev patchelf xdg-utils
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev libsoup-3.0-dev libdbus-1-dev pkg-config patchelf xdg-utils
 
       - name: setup pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v4

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,11 +41,17 @@ jobs:
             echo "rust=false" >> "$GITHUB_OUTPUT"
           fi
 
+      # libdbus-1-dev and pkg-config are listed on purpose. The keyring crate's
+      # Secret Service backend pulls dbus-secret-service, which links
+      # libdbus-sys, and that needs both at build time. They already arrive
+      # transitively via libgtk-3-dev -> libatk-bridge2.0-dev -> libatspi2.0-dev,
+      # so this is not a fix for a red build; it stops a real build dependency
+      # from riding on another package's dependency graph.
       - name: install tauri system deps
         if: steps.changes.outputs.rust == 'true'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev libsoup-3.0-dev
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev libsoup-3.0-dev libdbus-1-dev pkg-config
 
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v4
         if: steps.changes.outputs.rust == 'true'

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -39,6 +39,22 @@
     ],
     "android": {
       "debugApplicationIdSuffix": ".debug"
+    },
+    "linux": {
+      "deb": {
+        "depends": [
+          "libc6 (>= 2.39)",
+          "libcairo2 (>= 1.10.0)",
+          "libdbus-1-3 (>= 1.9.14)",
+          "libgcc-s1 (>= 4.2)",
+          "libgdk-pixbuf-2.0-0 (>= 2.36.9)",
+          "libglib2.0-0 (>= 2.66.0)",
+          "libgtk-3-0 (>= 3.21.5)",
+          "libjavascriptcoregtk-4.1-0",
+          "libsoup-3.0-0 (>= 3.0.3)",
+          "libwebkit2gtk-4.1-0 (>= 2.41.90)"
+        ]
+      }
     }
   },
   "plugins": {


### PR DESCRIPTION
Part of #1258 (Linux support).

Adds a `linux` job to `release.yml` that attaches AppImage, deb and rpm to the release the macOS job already created, plus a new `linux-build.yml` that produces those same bundles on every desktop PR so the release leg is proven on a real `ubuntu-latest` runner before any tag exists. Also declares `bundle.linux.deb.depends`, derived from the built binary rather than guessed.

## Artifacts

Produced by run [31170625859](https://github.com/akhayam99/goodboy/actions/runs/31170625859), a GitHub-hosted `ubuntu-latest` runner, from the `list bundles` step:

| file | bytes |
| --- | --- |
| `Goodboy_0.1.71_amd64.AppImage` | 84154872 |
| `Goodboy_0.1.71_amd64.deb` | 10387108 |
| `Goodboy-0.1.71-1.x86_64.rpm` | 10387864 |

All three are uploaded to the workflow run as the `goodboy-linux-bundles` artifact, never to a release.

## Why a failing Linux leg cannot cost us the macOS release

The `linux` job declares `needs: macos`. By the time it starts, the `macos` job has already finished: the draft release exists and the four macOS assets (dmg, app.tar.gz, app.tar.gz.sig, latest.json) are attached. A red Linux job is a red check on an already-produced draft, never a missing dmg. There is deliberately no `continue-on-error`: if Linux breaks it must go red loudly.

The serialization also closes a read-modify-write race. Two `tauri-action` runs against the same release would both look it up and both try to write `latest.json`.

No step in the `macos` job is touched. The change to that job is additive only: a comment at the top of the file.

## The three inputs that are load-bearing, and what their defaults would do

Verified against `action.yml` at the pinned SHA `1deb371b0cd8bd54025b384f1cd735e725c4060f`.

- `releaseDraft: true`. Default is `'false'`. On the false path the action looks the tag up with `getReleaseByTag`, which cannot see draft releases, so it 404s and creates a **second, published release for the same tag**. That would repoint `releases/latest/download/latest.json` at a release with no macOS assets, breaking in-app updates for existing users, and it would fire `homebrew.yml` (`release: types: [released]`) against a release with no dmg. With it set, the action reuses the macOS draft by `tag_name`.
- `uploadUpdaterJson: false`. Default is `'true'`. `upload-version-json` overwrites `version`, `notes` and `pub_date` wholesale while merging only `platforms`, so a Linux run would blank the release notes every macOS user reads in the update dialog. `latest.json` stays owned by macOS. Note the input is spelled `uploadUpdaterJson`; there is no `includeUpdaterJson` input at this version, and Actions silently ignores undeclared `with:` keys.
- `uploadUpdaterSignatures: false`. Default is `'true'`. Without a manifest referencing them, `.sig` assets on the release are orphans.

No `releaseName` and no `releaseBody` are passed: the CHANGELOG-derived body belongs to the macOS job, and the honest expression of "this job does not own the body" is to pass nothing.

## Secrets

The `linux` job receives `GITHUB_TOKEN` and nothing else. `--no-sign` skips updater signing, which would otherwise hard-error because `bundle.createUpdaterArtifacts` is `true` globally. The build log confirms it: `Warn Updater signing is skipped due to --no-sign flag.` No `TAURI_*` or `APPLE_*` env is passed, no new secret is introduced.

`linux-build.yml` holds no secrets at all, and `release.yml` deliberately gains no `workflow_dispatch`.

## deb depends, and how it was derived

Produced inside the workflow by `dpkg-shlibdeps` against the binary we just built:

```
dpkg-shlibdeps -O --ignore-missing-info apps/desktop/src-tauri/target/release/goodboy-desktop
```

Raw output:

```
shlibs:Depends=libc6 (>= 2.39), libcairo2 (>= 1.10.0), libdbus-1-3 (>= 1.9.14), libgcc-s1 (>= 4.2), libgdk-pixbuf-2.0-0 (>= 2.36.9), libglib2.0-0t64 (>= 2.66.0), libgtk-3-0t64 (>= 3.21.5), libjavascriptcoregtk-4.1-0, libsoup-3.0-0 (>= 3.0.3), libwebkit2gtk-4.1-0 (>= 2.41.90)
```

The only edit to that output is the `t64` suffixes. `ubuntu-latest` is 24.04, where the time_t transition renamed those two packages; the noble names do not exist on Debian 12 or Ubuntu 22.04, so a deb depending on them would be uninstallable there. The substitution is derived, not assumed: the same step prints

```
libglib2.0-0t64  Provides: ... libglib2.0-0 (= 2.80.0-6ubuntu3.8) ...
libgtk-3-0t64    Provides: gtk3-binver-3.0.0, libgtk-3-0 (= 3.24.41-4ubuntu1.3)
```

so the non-suffixed names resolve on 24.04 through a versioned `Provides` and resolve directly on older releases. The `libc6 (>= 2.39)` floor is real and comes from the build machine's glibc: the deb genuinely will not run below it.

`dpkg-deb -f Goodboy_0.1.71_amd64.deb Depends` on the artifact from run 31170625859 confirms the list landed:

```
libc6 (>= 2.39), libcairo2 (>= 1.10.0), libdbus-1-3 (>= 1.9.14), libgcc-s1 (>= 4.2), libgdk-pixbuf-2.0-0 (>= 2.36.9), libglib2.0-0 (>= 2.66.0), libgtk-3-0 (>= 3.21.5), libjavascriptcoregtk-4.1-0, libsoup-3.0-0 (>= 3.0.3), libwebkit2gtk-4.1-0 (>= 2.41.90), libwebkit2gtk-4.1-0, libgtk-3-0
```

The trailing `libwebkit2gtk-4.1-0, libgtk-3-0` are appended by Tauri's deb bundler itself, which hardcodes those two regardless of config. They are subsumed by the versioned entries above and apt resolves them without complaint.

## Build dependencies

The apt list starts from what `rust.yml` already installs and passes with, and adds `patchelf` and `xdg-utils` for the AppImage and deb bundlers, plus `libdbus-1-dev` and `pkg-config` for the keyring crate's Secret Service backend (see #1317). Both are harmless on today's `main`.

## Not done, deliberately

The desktop entry `Categories` field is left empty. Tauri exposes it as `bundle.category`, which is a top-level bundle key that also sets `LSApplicationCategoryType` in the macOS `Info.plist`. Setting it would change the macOS artifact, so it is out of scope here and worth a separate, macOS-aware change.

The tag path itself cannot be exercised without cutting a tag. The rc dry-run fires the `linux` job and is that leg's own proof.
