### PR TITLE
fix(desktop): bind shortcuts to ctrl on non-macos platforms

### DIFF
--- a/apps/desktop/src/__tests__/footer-studio-reachability.test.tsx
+++ b/apps/desktop/src/__tests__/footer-studio-reachability.test.tsx
@@ -7,6 +7,8 @@ import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 
 const { githubAuth } = vi.hoisted(() => ({ githubAuth: { isAuthenticated: false } }));
 
+vi.mock('../shared/platform', () => ({ currentPlatform: () => 'darwin' }));
+
 const { state, workspace } = vi.hoisted(() => {
   const currentWorkspace = {
     id: 'workspace-1',

--- a/apps/desktop/src/__tests__/keyboard/lens-shortcuts.test.tsx
+++ b/apps/desktop/src/__tests__/keyboard/lens-shortcuts.test.tsx
@@ -3,6 +3,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, cleanup, render } from '@testing-library/react';
 
+const { platform } = vi.hoisted(() => ({ platform: { current: 'darwin' as 'darwin' | 'linux' } }));
+
+vi.mock('../../shared/platform', () => ({ currentPlatform: () => platform.current }));
+
 const { setActiveLens, sessionList, state } = vi.hoisted(() => {
   const activeLensSetter = vi.fn();
   const sessions = [
@@ -159,6 +163,7 @@ const press = (init: KeyInit): void => {
 };
 
 beforeEach(() => {
+  platform.current = 'darwin';
   state.workspaces = [{ id: 'workspace-1', name: 'Workspace', rootPath: '/repo', kind: 'repo' }];
   state.sessions = [
     { id: 'session-0', workspaceId: 'workspace-1' },
@@ -183,7 +188,47 @@ afterEach(() => {
   setActiveLens.mockClear();
 });
 
-describe('App lens shortcuts', () => {
+describe('App lens shortcuts off darwin', () => {
+  beforeEach(() => {
+    platform.current = 'linux';
+  });
+
+  it('jumps to the agents lens on ctrl, where the command key does not exist', () => {
+    render(<App />);
+
+    press({ code: 'KeyA', key: 'a', ctrlKey: true, altKey: true });
+
+    expect(setActiveLens).toHaveBeenCalledWith('session-1', 'agents');
+  });
+
+  it('walks to the previous session on ctrl', () => {
+    render(<App />);
+
+    press({ code: 'BracketLeft', key: '{', ctrlKey: true, shiftKey: true });
+
+    expect(state.setCurrentSession).toHaveBeenCalledWith('session-0');
+  });
+
+  it('reloads on ctrl', () => {
+    render(<App />);
+
+    press({ code: 'KeyR', key: 'r', ctrlKey: true });
+
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves the command key inert, so nothing double-fires', () => {
+    render(<App />);
+
+    press({ code: 'KeyA', key: 'a', metaKey: true, altKey: true });
+    press({ code: 'KeyR', key: 'r', metaKey: true });
+
+    expect(setActiveLens).not.toHaveBeenCalled();
+    expect(reload).not.toHaveBeenCalled();
+  });
+});
+
+describe('App lens shortcuts on darwin', () => {
   it('jumps to the agents lens on the lens plane modifier', () => {
     render(<App />);
 

--- a/apps/desktop/src/features/permissions/components/DiffViewerDialog/comments/InlineComposer.test.tsx
+++ b/apps/desktop/src/features/permissions/components/DiffViewerDialog/comments/InlineComposer.test.tsx
@@ -1,0 +1,35 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+
+const { platform } = vi.hoisted(() => ({ platform: { current: 'darwin' as 'darwin' | 'linux' } }));
+
+vi.mock('../../../../../shared/platform', () => ({ currentPlatform: () => platform.current }));
+
+const mountComposer = async () => {
+  vi.resetModules();
+  const { InlineComposer } = await import('./InlineComposer');
+  render(<InlineComposer onSubmit={() => undefined} onCancel={() => undefined} />);
+};
+
+afterEach(() => {
+  cleanup();
+  platform.current = 'darwin';
+});
+
+describe('InlineComposer submit hint', () => {
+  it('spells the submit combo with command glyphs on darwin', async () => {
+    platform.current = 'darwin';
+    await mountComposer();
+
+    expect(screen.getByPlaceholderText('Note for the agent… (⌘↵ to save)')).toBeTruthy();
+  });
+
+  it('spells the submit combo with named ctrl keys off darwin', async () => {
+    platform.current = 'linux';
+    await mountComposer();
+
+    expect(screen.getByPlaceholderText('Note for the agent… (Ctrl+Enter to save)')).toBeTruthy();
+  });
+});

--- a/apps/desktop/src/features/permissions/components/DiffViewerDialog/comments/InlineComposer.tsx
+++ b/apps/desktop/src/features/permissions/components/DiffViewerDialog/comments/InlineComposer.tsx
@@ -1,6 +1,9 @@
 import { useState } from 'react';
 import { MessageSquarePlus } from 'lucide-react';
 import { Textarea } from '@goodboy/ui';
+import { formatCombo } from '../../../../../shared/keyboard/registry';
+
+const SUBMIT_HINT = formatCombo('cmd+Enter');
 
 type Props = {
   onSubmit: (body: string) => void;
@@ -20,7 +23,7 @@ export const InlineComposer = ({ onSubmit, onCancel, label }: Props) => {
           autoFocus
           value={body}
           onChange={(e) => setBody(e.target.value)}
-          placeholder="note for the agent… (⌘↵ to save)"
+          placeholder={`Note for the agent… (${SUBMIT_HINT} to save)`}
           className="text-xs"
           autoGrow
           maxRows={6}

--- a/apps/desktop/src/features/providers/components/ProviderConnectModal/guides.ts
+++ b/apps/desktop/src/features/providers/components/ProviderConnectModal/guides.ts
@@ -31,7 +31,7 @@ const INSTALL_GUIDES: Partial<Record<ProviderId, ProviderGuide>> = {
       },
       {
         title: 'If it asks for your password',
-        body: 'A global npm install can need sudo on macOS without nvm. Click in the terminal and type your password, the prompt accepts input directly.',
+        body: 'A global npm install can need sudo when node is not managed by nvm or a similar tool. Click in the terminal and type your password, the prompt accepts input directly.',
       },
       {
         title: 'After install',

--- a/apps/desktop/src/features/providers/provider-lifecycle.ts
+++ b/apps/desktop/src/features/providers/provider-lifecycle.ts
@@ -6,6 +6,7 @@ import {
   type ProviderLifecycleAction,
   type ProviderPlatform,
 } from '@goodboy/types';
+import { currentPlatform } from '../../shared/platform';
 import type { AuthState, ProviderStatus } from './providers';
 
 export type LifecycleOutputPayload = {
@@ -22,20 +23,6 @@ export type LifecycleExitPayload = {
   readonly exitCode: number;
   readonly status: ProviderStatus;
   readonly auth: AuthState;
-};
-
-export const currentPlatform = (): ProviderPlatform => {
-  if (typeof navigator === 'undefined') {
-    return 'linux';
-  }
-  const ua = navigator.userAgent.toLowerCase();
-  if (ua.includes('mac')) {
-    return 'darwin';
-  }
-  if (ua.includes('win')) {
-    return 'win32';
-  }
-  return 'linux';
 };
 
 export const resolveLifecycleCommand = (

--- a/apps/desktop/src/features/review/components/ReviewBoardPane/LineComposer.test.tsx
+++ b/apps/desktop/src/features/review/components/ReviewBoardPane/LineComposer.test.tsx
@@ -1,0 +1,35 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+
+const { platform } = vi.hoisted(() => ({ platform: { current: 'darwin' as 'darwin' | 'linux' } }));
+
+vi.mock('../../../../shared/platform', () => ({ currentPlatform: () => platform.current }));
+
+const mountComposer = async () => {
+  vi.resetModules();
+  const { LineComposer } = await import('./LineComposer');
+  render(<LineComposer label="Line 12" onSubmit={() => undefined} onCancel={() => undefined} />);
+};
+
+afterEach(() => {
+  cleanup();
+  platform.current = 'darwin';
+});
+
+describe('LineComposer submit hint', () => {
+  it('spells the submit combo with command glyphs on darwin', async () => {
+    platform.current = 'darwin';
+    await mountComposer();
+
+    expect(screen.getByPlaceholderText('Draft a review comment… (⌘↵ to add)')).toBeTruthy();
+  });
+
+  it('spells the submit combo with named ctrl keys off darwin', async () => {
+    platform.current = 'linux';
+    await mountComposer();
+
+    expect(screen.getByPlaceholderText('Draft a review comment… (Ctrl+Enter to add)')).toBeTruthy();
+  });
+});

--- a/apps/desktop/src/features/review/components/ReviewBoardPane/LineComposer.tsx
+++ b/apps/desktop/src/features/review/components/ReviewBoardPane/LineComposer.tsx
@@ -1,7 +1,10 @@
 import { useState } from 'react';
 import { MessageSquarePlus } from 'lucide-react';
 import { Textarea } from '@goodboy/ui';
+import { formatCombo } from '../../../../shared/keyboard/registry';
 import { ComposerActionRow } from './ComposerActionRow';
+
+const SUBMIT_HINT = formatCombo('cmd+Enter');
 
 type Props = {
   readonly label: string;
@@ -21,7 +24,7 @@ export const LineComposer = ({ label, onSubmit, onCancel }: Props) => {
           autoFocus
           value={body}
           onChange={(event) => setBody(event.target.value)}
-          placeholder="Draft a review comment… (⌘↵ to add)"
+          placeholder={`Draft a review comment… (${SUBMIT_HINT} to add)`}
           aria-label="Draft comment body"
           className="text-xs"
           autoGrow

--- a/apps/desktop/src/features/settings/components/SettingsStudio/AppScopePanel.tsx
+++ b/apps/desktop/src/features/settings/components/SettingsStudio/AppScopePanel.tsx
@@ -124,7 +124,7 @@ export const AppScopePanel = ({ initialSection, requestClose }: Props) => {
       <div className="mx-auto flex w-full max-w-2xl flex-col">
         <div className="flex flex-col gap-6">
           <section id="appearance" ref={anchor('appearance')} className="flex flex-col gap-4">
-            <SectionHeader label="Appearance" hint="How the app looks on this Mac." />
+            <SectionHeader label="Appearance" hint="How the app looks on this computer." />
             <div className="flex flex-col">
               <FieldRow label="Theme" help="Applies to every window.">
                 <Select

--- a/apps/desktop/src/features/settings/components/SettingsStudio/StorageSection.tsx
+++ b/apps/desktop/src/features/settings/components/SettingsStudio/StorageSection.tsx
@@ -67,7 +67,7 @@ export const StorageSection = () => {
     <div className="flex flex-col gap-4">
       <SectionHeader
         label="Storage"
-        hint="What the local database and archived sessions hold on this Mac."
+        hint="What the local database and archived sessions hold on this computer."
       />
       <div className="flex flex-col">
         <FieldRow label="Database" help="Every workspace, session, message, and streamed event.">

--- a/apps/desktop/src/features/terminal/components/TerminalDock/index.test.tsx
+++ b/apps/desktop/src/features/terminal/components/TerminalDock/index.test.tsx
@@ -1,0 +1,114 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { SessionId } from '@goodboy/types';
+import type { TerminalTab, TerminalTabId } from '../../../../shared/types/terminal';
+
+const { platform } = vi.hoisted(() => ({ platform: { current: 'darwin' as 'darwin' | 'linux' } }));
+
+vi.mock('../../../../shared/platform', () => ({ currentPlatform: () => platform.current }));
+
+const { addTerminalTab, state } = vi.hoisted(() => {
+  const spawn = vi.fn();
+  return {
+    addTerminalTab: spawn,
+    state: {
+      terminalTabs: {} as Record<string, ReadonlyArray<unknown>>,
+      activeTerminalTab: {} as Record<string, string | null>,
+      addTerminalTab: spawn,
+      closeTerminalTab: vi.fn(),
+      setActiveTerminalTab: vi.fn(),
+      setTerminalTabStatus: vi.fn(),
+    },
+  };
+});
+
+vi.mock('../../../../store', () => ({
+  useAppStore: <T,>(selector: (s: typeof state) => T) => selector(state),
+}));
+
+vi.mock('../../../../shared/components/GenericTerminalPanel', () => ({
+  GenericTerminalPanel: () => null,
+}));
+
+vi.mock('../../terminal', () => ({
+  invokeTerminalOpen: vi.fn(async () => undefined),
+  invokeTerminalResize: vi.fn(async () => undefined),
+  invokeTerminalWrite: vi.fn(async () => undefined),
+  listenTerminalExit: vi.fn(async () => () => undefined),
+  listenTerminalOutput: vi.fn(async () => () => undefined),
+}));
+
+vi.mock('../../closeTab', () => ({ disposeTerminalPty: vi.fn() }));
+
+import { TerminalDock } from './index';
+
+const SESSION_ID = 'session-1' as SessionId;
+const TAB_ID = 'terminal-1' as TerminalTabId;
+
+const tab = {
+  id: TAB_ID,
+  sessionId: SESSION_ID,
+  title: 'zsh',
+  cwd: '/repo',
+  status: 'running',
+  createdAt: 0,
+} satisfies TerminalTab;
+
+const mountDock = () => {
+  render(<TerminalDock sessionId={SESSION_ID} isActive cwd="/repo" />);
+  return screen.getByRole('tab');
+};
+
+beforeEach(() => {
+  state.terminalTabs = { [SESSION_ID]: [tab] };
+  state.activeTerminalTab = { [SESSION_ID]: TAB_ID };
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  platform.current = 'darwin';
+});
+
+describe('TerminalDock new tab shortcut', () => {
+  it('spawns a tab on the command combo on darwin', () => {
+    platform.current = 'darwin';
+    const target = mountDock();
+
+    fireEvent.keyDown(target, { code: 'KeyT', metaKey: true });
+
+    expect(addTerminalTab).toHaveBeenCalledTimes(1);
+    expect(addTerminalTab).toHaveBeenCalledWith(SESSION_ID, '/repo');
+  });
+
+  it('leaves the control combos to the pty on darwin', () => {
+    platform.current = 'darwin';
+    const target = mountDock();
+
+    fireEvent.keyDown(target, { code: 'KeyT', ctrlKey: true });
+    fireEvent.keyDown(target, { code: 'KeyT', ctrlKey: true, shiftKey: true });
+
+    expect(addTerminalTab).not.toHaveBeenCalled();
+  });
+
+  it('spawns a tab on control shift off darwin', () => {
+    platform.current = 'linux';
+    const target = mountDock();
+
+    fireEvent.keyDown(target, { code: 'KeyT', ctrlKey: true, shiftKey: true });
+
+    expect(addTerminalTab).toHaveBeenCalledTimes(1);
+    expect(addTerminalTab).toHaveBeenCalledWith(SESSION_ID, '/repo');
+  });
+
+  it('leaves plain control to the pty off darwin', () => {
+    platform.current = 'linux';
+    const target = mountDock();
+
+    fireEvent.keyDown(target, { code: 'KeyT', ctrlKey: true });
+
+    expect(addTerminalTab).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/features/terminal/components/TerminalDock/index.tsx
+++ b/apps/desktop/src/features/terminal/components/TerminalDock/index.tsx
@@ -9,6 +9,7 @@ import {
   GenericTerminalPanel,
   type TerminalDriver,
 } from '../../../../shared/components/GenericTerminalPanel';
+import { currentPlatform } from '../../../../shared/platform';
 import type { TerminalTabId } from '../../../../shared/types/terminal';
 import {
   invokeTerminalOpen,
@@ -112,10 +113,14 @@ export const TerminalDock = ({ sessionId, isActive, cwd }: Props) => {
 
   const handleKeyDown = useCallback(
     (event: ReactKeyboardEvent<HTMLDivElement>) => {
-      if (!isActive || !event.metaKey || event.shiftKey || event.altKey || event.ctrlKey) {
+      if (!isActive || event.code !== 'KeyT' || event.altKey) {
         return;
       }
-      if (event.code !== 'KeyT') {
+      const onMac = currentPlatform() === 'darwin';
+      const matches = onMac
+        ? event.metaKey && !event.ctrlKey && !event.shiftKey
+        : event.ctrlKey && event.shiftKey && !event.metaKey;
+      if (!matches) {
         return;
       }
       event.preventDefault();

--- a/apps/desktop/src/shared/keyboard/dispatcher.test.ts
+++ b/apps/desktop/src/shared/keyboard/dispatcher.test.ts
@@ -1,6 +1,11 @@
 // @vitest-environment happy-dom
 
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { platform } = vi.hoisted(() => ({ platform: { current: 'darwin' as 'darwin' | 'linux' } }));
+
+vi.mock('../platform', () => ({ currentPlatform: () => platform.current }));
+
 import { eventMatches, registerShortcut } from './dispatcher';
 import { SHORTCUTS } from './registry';
 
@@ -11,6 +16,7 @@ afterEach(() => {
     cleanups.pop()?.();
   }
   document.body.innerHTML = '';
+  platform.current = 'darwin';
 });
 
 const bind = (id: Parameters<typeof registerShortcut>[0], handler: () => void) => {
@@ -23,7 +29,11 @@ const press = (init: KeyboardEventInit): KeyboardEvent => {
   return event;
 };
 
-describe('shortcut dispatcher', () => {
+describe('shortcut dispatcher on darwin', () => {
+  beforeEach(() => {
+    platform.current = 'darwin';
+  });
+
   it('fires a shifted bracket, which the character-based matcher could never see', () => {
     const onPrev = vi.fn();
     bind('session.prev', onPrev);
@@ -94,5 +104,85 @@ describe('shortcut dispatcher', () => {
         SHORTCUTS['palette.open'].combo,
       ),
     ).toBe(false);
+  });
+
+  it('ignores the ctrl spelling of a combo, which belongs to the terminal here', () => {
+    const onPalette = vi.fn();
+    bind('palette.open', onPalette);
+
+    press({ key: 'k', code: 'KeyK', ctrlKey: true });
+
+    expect(onPalette).not.toHaveBeenCalled();
+  });
+});
+
+describe('shortcut dispatcher off darwin', () => {
+  beforeEach(() => {
+    platform.current = 'linux';
+  });
+
+  it('fires the command plane on ctrl, which is the only modifier the platform sends', () => {
+    const onPalette = vi.fn();
+    bind('palette.open', onPalette);
+
+    press({ key: 'k', code: 'KeyK', ctrlKey: true });
+
+    expect(onPalette).toHaveBeenCalledOnce();
+  });
+
+  it('never fires on the command key, which no keyboard here carries', () => {
+    const onPalette = vi.fn();
+    bind('palette.open', onPalette);
+
+    press({ key: 'k', code: 'KeyK', metaKey: true });
+
+    expect(onPalette).not.toHaveBeenCalled();
+  });
+
+  it('keeps the session and lens planes on their own modifiers', () => {
+    const onPrev = vi.fn();
+    const onAgents = vi.fn();
+    bind('session.prev', onPrev);
+    bind('lens.agents', onAgents);
+
+    press({ key: '{', code: 'BracketLeft', ctrlKey: true, shiftKey: true });
+    press({ key: 'a', code: 'KeyA', ctrlKey: true, altKey: true });
+
+    expect(onPrev).toHaveBeenCalledOnce();
+    expect(onAgents).toHaveBeenCalledOnce();
+  });
+
+  it('still separates two combos that differ only by a modifier', () => {
+    const onResolve = vi.fn();
+    const onReload = vi.fn();
+    bind('lens.resolve', onResolve);
+    bind('app.reload', onReload);
+
+    press({ key: 'r', code: 'KeyR', ctrlKey: true });
+
+    expect(onReload).toHaveBeenCalledOnce();
+    expect(onResolve).not.toHaveBeenCalled();
+  });
+
+  it('resolves every registry combo to ctrl and never to the command key', () => {
+    for (const entry of Object.values(SHORTCUTS)) {
+      const code = entry.combo.split('+').at(-1) ?? '';
+      const shiftKey = entry.combo.includes('shift');
+      const altKey = entry.combo.includes('alt');
+      expect(
+        eventMatches(
+          new KeyboardEvent('keydown', { code, ctrlKey: true, shiftKey, altKey }),
+          entry.combo,
+        ),
+        `${entry.combo} does not resolve to ctrl`,
+      ).toBe(true);
+      expect(
+        eventMatches(
+          new KeyboardEvent('keydown', { code, metaKey: true, shiftKey, altKey }),
+          entry.combo,
+        ),
+        `${entry.combo} still answers to the command key`,
+      ).toBe(false);
+    }
   });
 });

--- a/apps/desktop/src/shared/keyboard/dispatcher.ts
+++ b/apps/desktop/src/shared/keyboard/dispatcher.ts
@@ -1,3 +1,4 @@
+import { currentPlatform } from '../platform';
 import { SHORTCUTS, type ShortcutId } from './registry';
 
 type Parsed = {
@@ -21,10 +22,13 @@ export const parseCombo = (combo: string): Parsed => {
 
 export const eventMatches = (event: KeyboardEvent, combo: string): boolean => {
   const parsed = parseCombo(combo);
+  const onMac = currentPlatform() === 'darwin';
+  const wantsMeta = onMac ? parsed.meta : false;
+  const wantsCtrl = onMac ? parsed.ctrl : parsed.ctrl || parsed.meta;
   return (
     event.code === parsed.code &&
-    event.metaKey === parsed.meta &&
-    event.ctrlKey === parsed.ctrl &&
+    event.metaKey === wantsMeta &&
+    event.ctrlKey === wantsCtrl &&
     event.shiftKey === parsed.shift &&
     event.altKey === parsed.alt
   );

--- a/apps/desktop/src/shared/keyboard/registry.test.ts
+++ b/apps/desktop/src/shared/keyboard/registry.test.ts
@@ -1,7 +1,16 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const { platform } = vi.hoisted(() => ({ platform: { current: 'darwin' as 'darwin' | 'linux' } }));
+
+vi.mock('../platform', () => ({ currentPlatform: () => platform.current }));
+
 import { RESERVED_COMBOS, SHORTCUTS, formatCombo, shortcutGlyphs } from './registry';
 
 const entries = Object.entries(SHORTCUTS);
+
+afterEach(() => {
+  platform.current = 'darwin';
+});
 
 describe('shortcut registry', () => {
   it('binds every combo exactly once', () => {
@@ -13,7 +22,7 @@ describe('shortcut registry', () => {
     }
   });
 
-  it('never binds a combo macOS or the text field owns', () => {
+  it('never binds a combo macOS reserves, or the text field owns', () => {
     for (const [id, entry] of entries) {
       expect(RESERVED_COMBOS, `${id} binds the reserved ${entry.combo}`).not.toContain(entry.combo);
     }
@@ -40,11 +49,35 @@ describe('shortcut registry', () => {
     }
   });
 
-  it('renders combos as macOS glyphs', () => {
+  it('renders combos as macOS glyphs on darwin', () => {
+    platform.current = 'darwin';
+
     expect(shortcutGlyphs('palette.open')).toBe('⌘K');
     expect(shortcutGlyphs('session.delete')).toBe('⌘⇧⌫');
     expect(shortcutGlyphs('lens.agents')).toBe('⌘⌥A');
     expect(shortcutGlyphs('workspace.1')).toBe('⌘1');
     expect(formatCombo('cmd+BracketLeft')).toBe('⌘[');
+    expect(formatCombo('cmd+Enter')).toBe('⌘↵');
+  });
+
+  it('renders combos as named ctrl keys off darwin', () => {
+    platform.current = 'linux';
+
+    expect(shortcutGlyphs('palette.open')).toBe('Ctrl+K');
+    expect(shortcutGlyphs('session.delete')).toBe('Ctrl+Shift+Backspace');
+    expect(shortcutGlyphs('lens.agents')).toBe('Ctrl+Alt+A');
+    expect(shortcutGlyphs('workspace.1')).toBe('Ctrl+1');
+    expect(formatCombo('cmd+BracketLeft')).toBe('Ctrl+[');
+    expect(formatCombo('cmd+Enter')).toBe('Ctrl+Enter');
+  });
+
+  it('never shows the command glyph off darwin', () => {
+    platform.current = 'linux';
+
+    for (const [id, entry] of entries) {
+      expect(formatCombo(entry.combo), `${id} still renders a macOS glyph`).not.toMatch(
+        /[⌘⌥⇧⌃⌫⎋↵␣]/,
+      );
+    }
   });
 });

--- a/apps/desktop/src/shared/keyboard/registry.ts
+++ b/apps/desktop/src/shared/keyboard/registry.ts
@@ -1,3 +1,5 @@
+import { currentPlatform } from '../platform';
+
 export type ShortcutPlane = 'app' | 'session' | 'lens';
 
 export type ShortcutEntry = {
@@ -95,7 +97,7 @@ export const RESERVED_COMBOS: ReadonlyArray<string> = [
   'cmd+ArrowDown',
 ];
 
-const GLYPH: Record<string, string> = {
+const MAC_GLYPH: Record<string, string> = {
   cmd: '⌘',
   shift: '⇧',
   alt: '⌥',
@@ -114,9 +116,28 @@ const GLYPH: Record<string, string> = {
   Backquote: '`',
 };
 
-const codeGlyph = (code: string): string => {
-  if (GLYPH[code] != null) {
-    return GLYPH[code];
+const KEY_LABEL: Record<string, string> = {
+  cmd: 'Ctrl',
+  shift: 'Shift',
+  alt: 'Alt',
+  ctrl: 'Ctrl',
+  Comma: ',',
+  Period: '.',
+  Slash: '/',
+  Minus: '-',
+  Equal: '=',
+  BracketLeft: '[',
+  BracketRight: ']',
+  Backspace: 'Backspace',
+  Escape: 'Esc',
+  Enter: 'Enter',
+  Space: 'Space',
+  Backquote: '`',
+};
+
+const codeGlyph = ({ code, glyphs }: { code: string; glyphs: Record<string, string> }): string => {
+  if (glyphs[code] != null) {
+    return glyphs[code];
   }
   if (code.startsWith('Key')) {
     return code.slice(3);
@@ -127,12 +148,15 @@ const codeGlyph = (code: string): string => {
   return code;
 };
 
-export const formatCombo = (combo: string): string =>
-  combo
+export const formatCombo = (combo: string): string => {
+  const onMac = currentPlatform() === 'darwin';
+  const glyphs = onMac ? MAC_GLYPH : KEY_LABEL;
+  return combo
     .split('+')
     .map((part, index, parts) =>
-      index === parts.length - 1 ? codeGlyph(part) : (GLYPH[part] ?? part),
+      index === parts.length - 1 ? codeGlyph({ code: part, glyphs }) : (glyphs[part] ?? part),
     )
-    .join('');
+    .join(onMac ? '' : '+');
+};
 
 export const shortcutGlyphs = (id: ShortcutId): string => formatCombo(SHORTCUTS[id].combo);

--- a/apps/desktop/src/shared/platform/index.test.ts
+++ b/apps/desktop/src/shared/platform/index.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { currentPlatform } from './index';
+
+const stubUserAgent = (ua: string): void => {
+  vi.stubGlobal('navigator', { userAgent: ua });
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('currentPlatform', () => {
+  it('reads darwin from a real macOS webview user agent', () => {
+    stubUserAgent(
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15',
+    );
+
+    expect(currentPlatform()).toBe('darwin');
+  });
+
+  it('reads linux from a real webkitgtk user agent', () => {
+    stubUserAgent(
+      'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15',
+    );
+
+    expect(currentPlatform()).toBe('linux');
+  });
+
+  it('reads win32 from a real windows webview user agent', () => {
+    stubUserAgent(
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+    );
+
+    expect(currentPlatform()).toBe('win32');
+  });
+
+  it('falls back to linux when there is no navigator to read', () => {
+    vi.stubGlobal('navigator', undefined);
+
+    expect(currentPlatform()).toBe('linux');
+  });
+
+  it('never reads darwin from the ambient test-runner user agent, even on a mac', () => {
+    expect(navigator.userAgent.toLowerCase().includes('mac')).toBe(false);
+    expect(currentPlatform()).not.toBe('darwin');
+  });
+});

--- a/apps/desktop/src/shared/platform/index.ts
+++ b/apps/desktop/src/shared/platform/index.ts
@@ -1,0 +1,15 @@
+import type { ProviderPlatform } from '@goodboy/types';
+
+export const currentPlatform = (): ProviderPlatform => {
+  if (typeof navigator === 'undefined') {
+    return 'linux';
+  }
+  const ua = navigator.userAgent.toLowerCase();
+  if (ua.includes('mac')) {
+    return 'darwin';
+  }
+  if (ua.includes('win')) {
+    return 'win32';
+  }
+  return 'linux';
+};


### PR DESCRIPTION
## What

Every keyboard shortcut in the app was dead outside macOS. `eventMatches` compared `event.metaKey === parsed.meta` with no platform branch, and every combo in `SHORTCUTS` is spelled `cmd+...`. On Linux `metaKey` is never set, so the command palette, settings, session navigation, all 15 lens bindings, workspace 1-9, zoom and reload never fired. The glyph map was macOS-only, so every hover pill and the shortcuts help screen showed `⌘` on a machine with no command key.

The registry keeps writing combos in the `cmd+` form. That spelling is the canonical, platform-neutral one in this codebase, and none of the 41 combo strings changed. Resolution to meta or ctrl now happens at the only two places that need it:

- `eventMatches` in `dispatcher.ts`: on darwin, `cmd` means `metaKey`; off darwin, `cmd` means `ctrlKey`.
- `formatCombo` in `registry.ts`: on darwin it renders glyphs joined tight (`⌘⇧⌫`); off darwin it renders named keys joined with `+` (`Ctrl+Shift+Backspace`), which is what VS Code, Chrome and GNOME apps show on Linux.

All 14 display-side consumers route through `shortcutGlyphs`/`formatCombo`, so none of them needed an edit.

### One platform module

`apps/desktop/src/shared/platform/index.ts` now owns the single `currentPlatform()`. It keeps the user-agent sniff as the production mechanism, which is correct in a real webview (macOS carries `Mac OS X`, webkitgtk carries `X11; Linux`), and it stays synchronous. That is load-bearing: `AppTopBar`, `AppFooter` and `LensColumnFooter` build their label constants at module scope, so an async resolution (a Tauri command, `@tauri-apps/plugin-os`) would break all three. No new dependency was added.

`provider-lifecycle.ts` had a second copy of the same sniff. It now imports the shared one, so there is a single source of truth.

## Decisions on the named collisions

- **New terminal tab, `TerminalDock`**: this binding lives in the dock's own React handler, not the registry, and it explicitly disqualified `ctrlKey` because ctrl belongs to the pty and readline. A plain `Ctrl+T` would be swallowed by the terminal. Off darwin it is now **`Ctrl+Shift+T`**, matching GNOME Terminal and VS Code. On darwin it is unchanged.
- **`session.new` (`cmd+KeyN` → `Ctrl+N`)**: **accepted, not rebound.** The collision is with a browser chrome action ("new window") that a Tauri webview does not have: there is no browser UI to open a window into, and the dispatcher calls `preventDefault()` on a match. Rebinding would have changed the macOS binding too, which is the one blast radius this change must not have.
- **`app.reload` (`Ctrl+R`) and the zoom trio (`Ctrl+=`, `Ctrl+-`, `Ctrl+0`)**: **accepted.** These are same-intent collisions with webkitgtk's own reload and zoom. The app handles them itself and prevents the default, so the user gets one reload or one zoom step, which is what they asked for either way. Low risk.
- **`lens.terminal` (`cmd+alt+KeyT` → `Ctrl+Alt+T`)**: **real collision, accepted as a known limitation.** GNOME grabs `Ctrl+Alt+T` at the window-manager level, so the event never reaches the webview. On a default GNOME install the terminal lens will not be reachable by keyboard; it stays reachable by clicking it in the lens column. Rebinding it in the registry would move the macOS binding as well, so the honest fix is a per-platform combo override, which is follow-up work and not part of this change.
- **`RESERVED_COMBOS`**: it is a list of 26 macOS reservations, and its guard test only ever asserted that no shortcut binds one of them. That assertion stays valid, so the list is kept and the guard test is retitled to name macOS explicitly rather than describing itself as platform-neutral. **A Linux/GNOME reservation list is deliberately not added here**: the obvious entries (`Ctrl+N`, `Ctrl+Alt+T`) would fail the guard on day one and force exactly the cross-platform rebinds this change avoids. It belongs with the per-platform override work.

## Copy

The two composer placeholders (`InlineComposer`, `LineComposer`) hardcoded `⌘↵` and bypassed the registry entirely. They now build the hint with `formatCombo('cmd+Enter')`, so they read `Ctrl+Enter` off darwin. Both handlers already accepted `metaKey || ctrlKey`, so only the label was wrong.

Three in-app strings named macOS for something that is not macOS-specific: two settings hints ("this Mac" → "this computer") and the npm sudo caveat in the provider connect guide, which now names the actual cause (node not managed by a version manager) instead of the operating system.

## Test strategy, and why the macOS-unchanged claim is believable

`apps/desktop/vitest.config.ts` uses happy-dom, whose default user agent is `X11; <process.platform> <arch>`. On a Mac that contains neither `mac` nor `win`, so **any test resolving the platform from the ambient user agent reads `linux` on every machine**. A test written that way would be worthless here, and a label-comparing test would silently self-adjust and pin the wrong platform forever.

So no test in this change reads the ambient user agent to decide behavior:

- `shared/platform/index.test.ts` stubs `navigator` with real macOS, webkitgtk and Windows user agent strings and asserts each mapping by name, plus the no-navigator fallback. One test pins the trap itself: under the ambient runner user agent, `currentPlatform()` is never `darwin`.
- `dispatcher.test.ts` mocks `../platform` through a `vi.hoisted` handle and splits into two suites, `on darwin` and `off darwin`. The 8 pre-existing metaKey assertions all live in the darwin suite and are unchanged, which is the direct evidence that macOS behavior did not move. The darwin suite also gains an assertion that a ctrl press does **not** fire a shortcut, so ctrl stays the terminal's on macOS. The linux suite asserts the mirror image, and one loop walks all 41 registry combos asserting each resolves to ctrl and none answers to the command key.
- `registry.test.ts` mocks the same module. The glyph assertions are now explicitly pinned to darwin, a second set pins the Linux rendering by name, and a loop asserts no combo renders a macOS glyph off darwin.
- `__tests__/keyboard/lens-shortcuts.test.tsx` pins darwin explicitly, so all 23 existing lens assertions keep meaning what they say, and adds an `off darwin` suite proving the same lenses, session walk and reload fire on ctrl while the command key stays inert.
- `__tests__/footer-studio-reachability.test.tsx` pins darwin for its palette keypress.

Verified from the worktree: `pnpm typecheck` green, `pnpm exec turbo run test --force` green with `0 cached` (606 files, 5142 tests), `pnpm knip --include files,duplicates,unlisted` clean.

Not verified: no Linux machine was available, so the ctrl behavior is proven by test and by reading, not by running the app on webkitgtk.

Refs #1258
