### PR TITLE
docs(repo): name linux in the install path, readme and website

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,8 +176,9 @@ Or grab the `.dmg` from the
 [latest release](https://github.com/akhayam99/goodboy/releases/latest) and drag
 Goodboy to Applications.
 
-**Linux.** x86_64, as an AppImage, a `.deb` or an `.rpm`, all three attached to
-the same [release](https://github.com/akhayam99/goodboy/releases/latest).
+**Linux.** x86_64 on glibc 2.39 or newer, so Ubuntu 24.04 and Debian 13 upward,
+as an AppImage, a `.deb` or an `.rpm`, all three attached to the same
+[release](https://github.com/akhayam99/goodboy/releases/latest).
 
 ```bash
 sudo apt install ./Goodboy_<version>_amd64.deb
@@ -185,16 +186,23 @@ sudo rpm -i Goodboy-<version>-1.x86_64.rpm
 chmod +x Goodboy_<version>_amd64.AppImage
 ```
 
-The `.deb` declares what it links against (`libwebkit2gtk-4.1-0`, `libgtk-3-0`,
-`libsoup-3.0-0` and the rest of the GTK stack), read out of the binary with
-`dpkg-shlibdeps`, so apt resolves them for you. Credentials go to the
-freedesktop Secret Service, GNOME Keyring or KWallet, so a keyring daemon has to
-be running before you save a token. Windows is still a build from source.
+The `.deb` declares what it links against (`libc6 (>= 2.39)`,
+`libwebkit2gtk-4.1-0`, `libgtk-3-0`, `libsoup-3.0-0` and the rest of the GTK
+stack), read out of the binary with `dpkg-shlibdeps`, so apt resolves them for
+you. The `libc6` entry is the one that sets the distribution floor above, and
+the AppImage and the `.rpm` carry the same floor because all three come out of
+one `ubuntu-latest` build. Credentials go to the freedesktop Secret Service,
+GNOME Keyring or KWallet, so a keyring daemon has to be running before you save
+a token. Windows is still a build from source.
 
-Follow-up: the Linux packages come out of the same tagged build as the macOS
-one, on a GitHub `ubuntu-latest` runner. If your distribution wants something
-the package does not declare, its own package manager says so before anything
-installs.
+Follow-up: the three packages are built from the release tag on a GitHub
+`ubuntu-latest` runner, with the dependency list read out of that binary. On an
+older distribution the install stops on a declared dependency the distribution
+cannot satisfy, and apt or rpm says which one before anything is written. The
+credential path stands on the backend the `keyring` crate selects on Linux,
+though no token has been stored and read back on a Linux desktop yet. If the
+backend disagrees, its own error comes back where you saved the token, with the
+token not saved.
 
 **Updates.** On macOS they are automatic: when a new release ships, an update
 control appears in the footer, next to settings, and on the workspace launcher.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![stars](https://img.shields.io/github/stars/akhayam99/goodboy?label=stars&color=06b6d4)](https://github.com/akhayam99/goodboy/stargazers)
 [![providers](https://img.shields.io/badge/providers-Claude%20%C2%B7%20Cursor%20%C2%B7%20Codex%20%C2%B7%20Gemini%20%C2%B7%20OpenCode%20%C2%B7%20OpenRouter%20%C2%B7%20Moonshot-06b6d4)](#providers)
 [![platform](https://img.shields.io/badge/macOS-Intel%20%26%20Apple%20Silicon-111111)](#install)
+[![platform](https://img.shields.io/badge/Linux-AppImage%20%C2%B7%20deb%20%C2%B7%20rpm%20%C2%B7%20x86__64-111111)](#install)
 [![license](https://img.shields.io/github/license/akhayam99/goodboy?color=06b6d4)](./LICENSE)
 
 <img src=".github/readme-integrations.png" alt="Integrates with GitHub, GitLab, Linear and Sentry" width="480" />
@@ -164,25 +165,43 @@ One connected CLI is enough to start. Full guide:
 
 ## Install
 
-macOS only for now, Intel and Apple Silicon in one universal build. Signed
-and notarized by Apple, so it opens without the unidentified-developer
-warning. Linux and Windows builds are in progress.
-
-**Homebrew (recommended).**
+**macOS.** Intel and Apple Silicon in one universal build, signed and notarized
+by Apple, so it opens without the unidentified-developer warning.
 
 ```bash
 brew install --cask akhayam99/tap/goodboy
 ```
 
-**Direct download.** Grab the `.dmg` from the
-[latest release](https://github.com/akhayam99/goodboy/releases/latest) and
-drag Goodboy to Applications.
+Or grab the `.dmg` from the
+[latest release](https://github.com/akhayam99/goodboy/releases/latest) and drag
+Goodboy to Applications.
 
-**Updates are automatic.** When a new release ships, an update control appears
-in the footer, next to settings, and on the workspace launcher. One click
-downloads it and relaunches, and the footer's `More` control then carries a dot
-until you read the release notes; Homebrew users can also
-`brew upgrade --cask goodboy`.
+**Linux.** x86_64, as an AppImage, a `.deb` or an `.rpm`, all three attached to
+the same [release](https://github.com/akhayam99/goodboy/releases/latest).
+
+```bash
+sudo apt install ./Goodboy_<version>_amd64.deb
+sudo rpm -i Goodboy-<version>-1.x86_64.rpm
+chmod +x Goodboy_<version>_amd64.AppImage
+```
+
+The `.deb` declares what it links against (`libwebkit2gtk-4.1-0`, `libgtk-3-0`,
+`libsoup-3.0-0` and the rest of the GTK stack), read out of the binary with
+`dpkg-shlibdeps`, so apt resolves them for you. Credentials go to the
+freedesktop Secret Service, GNOME Keyring or KWallet, so a keyring daemon has to
+be running before you save a token. Windows is still a build from source.
+
+Follow-up: the Linux packages come out of the same tagged build as the macOS
+one, on a GitHub `ubuntu-latest` runner. If your distribution wants something
+the package does not declare, its own package manager says so before anything
+installs.
+
+**Updates.** On macOS they are automatic: when a new release ships, an update
+control appears in the footer, next to settings, and on the workspace launcher.
+One click downloads it and relaunches, and the footer's `More` control then
+carries a dot until you read the release notes; Homebrew users can also
+`brew upgrade --cask goodboy`. In-app updates stay macOS-only for now, so on
+Linux you take the new package from the release.
 
 ## Run it
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,8 @@
 
 Use [GitHub private vulnerability reporting](https://github.com/akhayam99/goodboy/security/advisories/new)
 so the report stays private until a fix ships. Include steps to reproduce and
-the version (`Goodboy > About`, or the dmg name). You will get a reply in the
+the version (`Goodboy > About`, or the name of the dmg or Linux package you
+installed). You will get a reply in the
 next release cycle at the latest; issues are triaged every cycle.
 
 ## What Goodboy does with your data
@@ -30,3 +31,10 @@ macOS builds are signed and notarized under the maintainer's Apple team
 (`M3R9H4QX65`). Verify a download with `spctl -a -vvv` (expect
 `accepted, source=Notarized Developer ID`). Autonomous release cycles cannot
 touch signing material or secrets; see [AUTONOMY.md](./AUTONOMY.md).
+
+The Linux AppImage, deb and rpm carry no updater signature, and the release
+publishes no update manifest for them, so a Linux build never fetches anything
+on its own: every new version is a package you take from the release page.
+The OS credential store named above is the Keychain on macOS and the
+freedesktop Secret Service on Linux, GNOME Keyring or KWallet, so the daemon
+you already unlock at login is what holds the token.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,5 +36,10 @@ The Linux AppImage, deb and rpm carry no updater signature, and the release
 publishes no update manifest for them, so a Linux build never fetches anything
 on its own: every new version is a package you take from the release page.
 The OS credential store named above is the Keychain on macOS and the
-freedesktop Secret Service on Linux, GNOME Keyring or KWallet, so the daemon
-you already unlock at login is what holds the token.
+freedesktop Secret Service on Linux, GNOME Keyring or KWallet, so on Linux a
+keyring daemon has to be running before a token can be saved.
+
+Follow-up: the Linux backend is the one the `keyring` crate selects, though no
+token has been stored and read back on a Linux desktop yet. If the backend
+disagrees, its own error comes back where you saved the token, with the token
+not saved.

--- a/docs/release-command.md
+++ b/docs/release-command.md
@@ -44,7 +44,10 @@ Developer ID`) and `codesign -dv --verbose=4` (expect team `M3R9H4QX65`; any
    other team is a failure). Detach. Then delete the rc (release + remote tag +
    local tag).
 5. Cut real: `git tag vX <merge-sha> && git push origin vX`. Wait for the build
-   to produce the draft release (dmg + app.tar.gz + .sig + latest.json).
+   to produce the draft release: macOS gives dmg + app.tar.gz + .sig +
+   latest.json, Linux gives AppImage + deb + rpm (x86_64, no updater manifest
+   and no signatures). Seven assets, and a missing Linux one is a red job, not
+   an expected skip.
 
 ## Release notes (from source, not memory)
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -7,8 +7,9 @@ Targets, both attached to the same draft release:
 
 - macOS **universal** `.dmg` (Intel + Apple Silicon), signed + notarized,
   published to GitHub Releases and Homebrew.
-- Linux **x86_64** AppImage, `.deb` and `.rpm`, built on `ubuntu-latest`, with
-  no updater manifest and no signatures.
+- Linux **x86_64** AppImage, `.deb` and `.rpm`, built on `ubuntu-latest` and so
+  carrying its glibc floor (Ubuntu 24.04 and Debian 13 upward), with no updater
+  manifest and no signatures.
 
 ## How it works
 
@@ -21,7 +22,9 @@ Targets, both attached to the same draft release:
   `Goodboy_<version>_amd64.AppImage`, `Goodboy_<version>_amd64.deb` and
   `Goodboy-<version>-1.x86_64.rpm`. The deb's dependency list is derived from
   the binary by `dpkg-shlibdeps` at package time, so it tracks whatever the
-  build actually links against.
+  build actually links against. That list includes `libc6 (>= 2.39)`, which is
+  what pins the deb to Ubuntu 24.04 or newer and Debian 13 or newer. Moving the
+  runner to an older Ubuntu is what lowers that floor.
 - The Linux job publishes **no `latest.json` and no `.sig`**, so in-app updates
   stay macOS-only. Only the AppImage could ever self-update and that is not
   wired: a Linux user takes the next package from the release page.

--- a/docs/release.md
+++ b/docs/release.md
@@ -3,8 +3,12 @@
 Canonical guide for cutting a Goodboy release. **If you are asked to "do a
 release", "ship vX.Y.Z", or "cut a release", follow this file end to end.**
 
-Target: macOS **universal** `.dmg` (Intel + Apple Silicon), signed + notarized,
-published to GitHub Releases and Homebrew.
+Targets, both attached to the same draft release:
+
+- macOS **universal** `.dmg` (Intel + Apple Silicon), signed + notarized,
+  published to GitHub Releases and Homebrew.
+- Linux **x86_64** AppImage, `.deb` and `.rpm`, built on `ubuntu-latest`, with
+  no updater manifest and no signatures.
 
 ## How it works
 
@@ -13,8 +17,16 @@ published to GitHub Releases and Homebrew.
 - Signing + notarization run automatically because the six `APPLE_*` secrets are
   set on the repo (see "Signing" below). If those secrets were ever removed, the
   build still succeeds but produces an unsigned `.dmg`.
+- The Linux job attaches three more assets to that same draft:
+  `Goodboy_<version>_amd64.AppImage`, `Goodboy_<version>_amd64.deb` and
+  `Goodboy-<version>-1.x86_64.rpm`. The deb's dependency list is derived from
+  the binary by `dpkg-shlibdeps` at package time, so it tracks whatever the
+  build actually links against.
+- The Linux job publishes **no `latest.json` and no `.sig`**, so in-app updates
+  stay macOS-only. Only the AppImage could ever self-update and that is not
+  wired: a Linux user takes the next package from the release page.
 - Publishing the draft release triggers `.github/workflows/homebrew.yml`, which
-  bumps the cask in the Homebrew tap.
+  bumps the cask in the Homebrew tap. The cask is the macOS `.dmg` only.
 
 The git tag is the source of truth for the release name. The version baked into
 the build comes from `tauri.conf.json`, so the two must match.
@@ -108,6 +120,11 @@ only) it checks `releases/latest/download/latest.json`; when a newer version is
 found, a "Restart to update" control shows in the status bar and next to the
 sidebar logo, and clicking it downloads, installs, and relaunches.
 
+This is the macOS path. The Linux job emits no `latest.json` and no `.sig`, so
+nothing on the release page tells a Linux build that a newer version exists.
+Adding one means signing the AppImage with the updater keypair and pointing the
+plugin at a Linux target, which has not been done.
+
 Update artifacts are signed with a dedicated **updater keypair** (separate from
 Apple code-signing). The public key lives in `tauri.conf.json`
 (`plugins.updater.pubkey`); the private key + password are repo secrets
@@ -157,5 +174,9 @@ authorized for agents).
 - **macOS Keychain `.p12` uses legacy RC2-40**: reading it locally with OpenSSL 3
   needs `openssl pkcs12 ... -legacy`. The CI runner uses `security import`, which
   handles it natively, so this only affects local verification.
-- **Local manual build** to reproduce CI: `pnpm tauri:build`. For the universal
-  artifact: `pnpm --filter @goodboy/desktop tauri build --target universal-apple-darwin`.
+- **Local manual build** to reproduce CI: `pnpm tauri:build`. For the macOS
+  universal artifact:
+  `pnpm --filter @goodboy/desktop tauri build --target universal-apple-darwin`.
+  On an x86_64 Linux host the same `pnpm tauri:build` drops the AppImage, deb
+  and rpm under `apps/desktop/src-tauri/target/release/bundle/`. There is no
+  cross-build from macOS: the Linux packages come from a Linux runner.

--- a/website/index.html
+++ b/website/index.html
@@ -189,7 +189,7 @@
             "name": "Which platforms does Goodboy support?",
             "acceptedAnswer": {
               "@type": "Answer",
-              "text": "macOS and Linux. macOS ships as a universal build or via Homebrew. Linux ships as an AppImage, a .deb and an .rpm, x86_64. In-app updates stay macOS-only for now, so on Linux a new version is a new package from the release page. Windows still means building from source, with a Rust toolchain."
+              "text": "macOS and Linux. macOS ships as a universal build or via Homebrew. Linux ships as an AppImage, a .deb and an .rpm, x86_64 on glibc 2.39 or newer, so Ubuntu 24.04 and Debian 13 upward. In-app updates stay macOS-only for now, so on Linux a new version is a new package from the release page. Windows still means building from source, with a Rust toolchain."
             }
           },
           {

--- a/website/index.html
+++ b/website/index.html
@@ -87,7 +87,7 @@
         "description": "Goodboy is a local-first desktop app for running coding agents that keeps the thread. It carries shared context into every agent, lets an orchestrator pick each step, model, and effort at runtime, reviews pull requests and merge requests in one inbox, and tracks spend against the caps you set.",
         "url": "https://goodboy-ai.dev/",
         "applicationCategory": "DeveloperApplication",
-        "operatingSystem": "macOS",
+        "operatingSystem": ["macOS", "Linux"],
         "offers": {
           "@type": "Offer",
           "price": "0",
@@ -189,7 +189,7 @@
             "name": "Which platforms does Goodboy support?",
             "acceptedAnswer": {
               "@type": "Answer",
-              "text": "macOS today, as a universal build or via Homebrew. Prebuilt binaries for Linux and Windows coming; you can build from source in the meantime, with a Rust toolchain."
+              "text": "macOS and Linux. macOS ships as a universal build or via Homebrew. Linux ships as an AppImage, a .deb and an .rpm, x86_64. In-app updates stay macOS-only for now, so on Linux a new version is a new package from the release page. Windows still means building from source, with a Rust toolchain."
             }
           },
           {

--- a/website/src/sections/CTA.tsx
+++ b/website/src/sections/CTA.tsx
@@ -5,23 +5,52 @@ import { useInView } from '../components/Reveal';
 const RELEASES_LATEST = 'https://github.com/akhayam99/goodboy/releases/latest';
 const LATEST_RELEASE_API = 'https://api.github.com/repos/akhayam99/goodboy/releases/latest';
 
-function useLatestDmgUrl(): { href: string; direct: boolean } {
-  const [url, setUrl] = useState<string | null>(null);
+const ASSET_SUFFIX = {
+  dmg: '.dmg',
+  appImage: '.appimage',
+  deb: '.deb',
+  rpm: '.rpm',
+} as const;
+
+type AssetKey = keyof typeof ASSET_SUFFIX;
+type AssetLink = { href: string; direct: boolean };
+
+const ASSET_KEYS = Object.keys(ASSET_SUFFIX) as ReadonlyArray<AssetKey>;
+
+const useLatestAssets = (): Record<AssetKey, AssetLink> => {
+  const [urls, setUrls] = useState<Partial<Record<AssetKey, string>>>({});
   useEffect(() => {
     let cancelled = false;
     fetch(LATEST_RELEASE_API, { headers: { Accept: 'application/vnd.github+json' } })
       .then((r) => (r.ok ? r.json() : Promise.reject(r.status)))
       .then((data: { assets?: Array<{ name?: string; browser_download_url?: string }> }) => {
-        const dmg = data.assets?.find((a) => a.name?.toLowerCase().endsWith('.dmg'));
-        if (!cancelled && dmg?.browser_download_url) setUrl(dmg.browser_download_url);
+        const found: Partial<Record<AssetKey, string>> = {};
+        for (const key of ASSET_KEYS) {
+          const asset = data.assets?.find((a) => a.name?.toLowerCase().endsWith(ASSET_SUFFIX[key]));
+          if (asset?.browser_download_url) found[key] = asset.browser_download_url;
+        }
+        if (!cancelled) setUrls(found);
       })
       .catch(() => undefined);
     return () => {
       cancelled = true;
     };
   }, []);
-  return url ? { href: url, direct: true } : { href: RELEASES_LATEST, direct: false };
-}
+  return ASSET_KEYS.reduce(
+    (acc, key) => {
+      const url = urls[key];
+      acc[key] = url ? { href: url, direct: true } : { href: RELEASES_LATEST, direct: false };
+      return acc;
+    },
+    {} as Record<AssetKey, AssetLink>,
+  );
+};
+
+const LINUX_PACKAGES: ReadonlyArray<{ key: AssetKey; label: string }> = [
+  { key: 'appImage', label: 'AppImage' },
+  { key: 'deb', label: '.deb' },
+  { key: 'rpm', label: '.rpm' },
+];
 
 const brewLine = 'brew install --cask akhayam99/tap/goodboy';
 
@@ -49,7 +78,7 @@ function TerminalFrame({ label, children }: { label: string; children: ReactNode
 
 export function CTA() {
   const { ref, inView } = useInView<HTMLElement>();
-  const dmg = useLatestDmgUrl();
+  const assets = useLatestAssets();
   return (
     <section
       id="cta"
@@ -70,13 +99,14 @@ export function CTA() {
 
         <div className="mx-auto mt-12 max-w-lg pointer-fine:hidden">
           <p className="text-[12px] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
-            When you&apos;re on your Mac
+            When you&apos;re back at your machine
           </p>
           <code className="mt-2.5 block overflow-x-auto whitespace-nowrap rounded-lg border border-border-soft bg-[oklch(0.22_0.007_255)] px-4 py-2.5 text-left font-mono text-[12.5px] text-foreground">
             {brewLine}
           </code>
           <p className="mt-2.5 text-[11.5px] text-muted-foreground/70">
-            Or grab the .dmg from the GitHub releases.
+            That is macOS. The .dmg is on the GitHub releases too, next to the Linux AppImage, .deb
+            and .rpm.
           </p>
           <div className="mt-7 flex flex-col items-center gap-3">
             <LinkButton
@@ -106,9 +136,9 @@ export function CTA() {
 
         <div className="mx-auto mt-12 hidden max-w-lg pointer-fine:block">
           <LinkButton
-            href={dmg.href}
-            target={dmg.direct ? undefined : '_blank'}
-            rel={dmg.direct ? undefined : 'noreferrer'}
+            href={assets.dmg.href}
+            target={assets.dmg.direct ? undefined : '_blank'}
+            rel={assets.dmg.direct ? undefined : 'noreferrer'}
             size="lg"
             variant="primary"
             className="w-full sm:w-auto"
@@ -130,7 +160,31 @@ export function CTA() {
 
           <div className="mt-9 text-left">
             <p className="mb-2.5 text-[12px] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
-              Linux &amp; Windows &middot; from source
+              Linux &middot; x86_64
+            </p>
+            <div className="flex flex-wrap gap-2">
+              {LINUX_PACKAGES.map(({ key, label }) => (
+                <LinkButton
+                  key={key}
+                  href={assets[key].href}
+                  target={assets[key].direct ? undefined : '_blank'}
+                  rel={assets[key].direct ? undefined : 'noreferrer'}
+                  size="md"
+                  variant="secondary"
+                >
+                  {label}
+                </LinkButton>
+              ))}
+            </div>
+            <p className="mt-2.5 text-[11.5px] text-muted-foreground/70">
+              Same tagged build as the macOS one. In-app updates stay macOS-only for now, so a new
+              version is a new package from the same page.
+            </p>
+          </div>
+
+          <div className="mt-9 text-left">
+            <p className="mb-2.5 text-[12px] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+              Windows &middot; from source
             </p>
             <TerminalFrame label="~/work">
               {sourceLines.map((l) => (
@@ -141,7 +195,7 @@ export function CTA() {
               ))}
             </TerminalFrame>
             <p className="mt-2.5 text-[11.5px] text-muted-foreground/70">
-              Needs a Rust toolchain. Prebuilt binaries for Linux and Windows coming.
+              Needs a Rust toolchain. A prebuilt Windows binary is still to come.
             </p>
           </div>
         </div>

--- a/website/src/sections/CTA.tsx
+++ b/website/src/sections/CTA.tsx
@@ -106,7 +106,7 @@ export function CTA() {
           </code>
           <p className="mt-2.5 text-[11.5px] text-muted-foreground/70">
             That is macOS. The .dmg is on the GitHub releases too, next to the Linux AppImage, .deb
-            and .rpm.
+            and .rpm, x86_64 on glibc 2.39 or newer.
           </p>
           <div className="mt-7 flex flex-col items-center gap-3">
             <LinkButton
@@ -177,7 +177,8 @@ export function CTA() {
               ))}
             </div>
             <p className="mt-2.5 text-[11.5px] text-muted-foreground/70">
-              Same tagged build as the macOS one. In-app updates stay macOS-only for now, so a new
+              Built from the release tag on a GitHub Ubuntu runner, so it needs glibc 2.39 or newer:
+              Ubuntu 24.04 and Debian 13 upward. In-app updates stay macOS-only for now, so a new
               version is a new package from the same page.
             </p>
           </div>

--- a/website/src/sections/Faq.tsx
+++ b/website/src/sections/Faq.tsx
@@ -65,9 +65,9 @@ const ITEMS: ReadonlyArray<Qa> = [
     a: (
       <>
         <B>macOS and Linux</B>. macOS ships as a universal build or via Homebrew. Linux ships as an
-        AppImage, a .deb and an .rpm, x86_64. In-app updates stay macOS-only for now, so on Linux a
-        new version is a new package from the release page. Windows still means building from
-        source, with a Rust toolchain.
+        AppImage, a .deb and an .rpm, x86_64 on glibc 2.39 or newer, so Ubuntu 24.04 and Debian 13
+        upward. In-app updates stay macOS-only for now, so on Linux a new version is a new package
+        from the release page. Windows still means building from source, with a Rust toolchain.
       </>
     ),
   },

--- a/website/src/sections/Faq.tsx
+++ b/website/src/sections/Faq.tsx
@@ -64,8 +64,10 @@ const ITEMS: ReadonlyArray<Qa> = [
     q: 'Which platforms?',
     a: (
       <>
-        <B>macOS today</B>, as a universal build or via Homebrew. Prebuilt binaries for Linux and
-        Windows coming; you can build from source in the meantime, with a Rust toolchain.
+        <B>macOS and Linux</B>. macOS ships as a universal build or via Homebrew. Linux ships as an
+        AppImage, a .deb and an .rpm, x86_64. In-app updates stay macOS-only for now, so on Linux a
+        new version is a new package from the release page. Windows still means building from
+        source, with a Rust toolchain.
       </>
     ),
   },

--- a/website/src/sections/Hero.tsx
+++ b/website/src/sections/Hero.tsx
@@ -62,7 +62,7 @@ export const Hero = () => (
               Star on GitHub
             </LinkButton>
             <p className="text-[12px] text-muted-foreground/75">
-              Free and open source, MIT. Install on your Mac.
+              Free and open source, MIT. Install on your Mac or Linux machine.
             </p>
           </div>
           <LinkButton href="#cta" size="lg" variant="ghost">
@@ -90,7 +90,7 @@ export const Hero = () => (
             </LinkButton>
           </div>
           <p className="text-[12.5px] text-muted-foreground/75">
-            Free and open source, MIT. Runs on macOS.
+            Free and open source, MIT. Installs on macOS and Linux.
           </p>
         </div>
       </div>


### PR DESCRIPTION
Every platform claim in the repo said macOS only. The release now attaches an
AppImage, a `.deb` and an `.rpm` for x86_64 next to the universal dmg, so those
claims had to move in the same release that makes them false.

## Claims changed, and what each now rests on

| Where | Old claim | New claim | Rests on |
| --- | --- | --- | --- |
| `README.md:9` | one platform badge, macOS Intel and Apple Silicon | a second badge, `Linux AppImage · deb · rpm · x86_64` | the three artifacts the Linux job produces |
| `README.md` install | "macOS only for now... Linux and Windows builds are in progress" | a macOS block and a Linux block, with `apt`, `rpm` and `chmod` lines and the real package names | observed artifact names on the `ubuntu-latest` run |
| `README.md` install | silent on dependencies | the deb declares `libwebkit2gtk-4.1-0`, `libgtk-3-0`, `libsoup-3.0-0` and the rest of the GTK stack | `dpkg-shlibdeps` reads them out of the binary at package time |
| `README.md` install | silent on credentials | a keyring daemon has to be running before you save a token | credentials go to the freedesktop Secret Service, GNOME Keyring or KWallet |
| `README.md:181` | "Updates are automatic", unconditional | automatic on macOS, and "In-app updates stay macOS-only for now" | the Linux job publishes no `latest.json` and no `.sig` |
| `website Hero` | "Runs on macOS." / "Install on your Mac." | "Installs on macOS and Linux." / "Install on your Mac or Linux machine." | the same three artifacts |
| `website CTA` | Download for macOS, then "Linux & Windows · from source" | Download for macOS stays the primary action, a `Linux · x86_64` row links AppImage, `.deb` and `.rpm`, and the build-from-source terminal is now labelled Windows | VS Code's precedent: list the platforms, let the reader pick |
| `website Faq` + `index.html:192` | "macOS today... Prebuilt binaries for Linux and Windows coming" | one answer naming both platforms, the three package formats and the macOS-only updater | the two copies are byte-identical, checked in the rendered page |
| `index.html:90` | `"operatingSystem": "macOS"` | `["macOS", "Linux"]` | same |
| `docs/release.md` | target is the macOS universal dmg | two targets, the Linux leg, its three asset names, and no updater manifest by design | run 31170625859 |
| `docs/release.md` auto-update | describes the updater with no platform scope | names the macOS path and says what adding a Linux one would take | only the AppImage could self-update and that is not wired |
| `docs/release.md` local build | hardcoded universal target | plus what `pnpm tauri:build` drops on an x86_64 Linux host, and that there is no cross-build from macOS | the Linux packages come from a Linux runner |
| `docs/release-command.md:47` | "dmg + app.tar.gz + .sig + latest.json" | seven assets, and a missing Linux one is a red job | four macOS plus three Linux |
| `SECURITY.md:7` | the dmg name as the version hint | the dmg or Linux package name | Linux users have no dmg |
| `SECURITY.md` releases | Apple signing only | Linux packages carry no updater signature, and the OS credential store is the Keychain on macOS, the Secret Service on Linux | the same two facts as above |

`SECURITY.md:15`, "API keys and tokens live in the OS credential store", stays
as written: it is still true on Linux, so it was confirmed rather than edited.

## What the copy deliberately does not say

No claim that the app runs, launches or was tested on Linux, no distribution or
desktop environment named as validated, and no Linux screenshot. The README
carries one follow-up line: the packages come out of the same tagged build as
the macOS one, and if a distribution wants something the package does not
declare, its own package manager says so before anything installs.

## Download CTA

No user-agent detection. macOS keeps the primary button it already had, and the
three Linux packages sit under it as named links. `useLatestAssets` resolves each
one from the latest release by suffix and falls back to the releases page when an
asset is absent, so the buttons already work today against v0.1.71 (which has no
Linux assets) and become direct download links the moment the Linux job ships.

## Verified

- `pnpm typecheck` green, `pnpm knip --include files,duplicates,unlisted` clean
- `pnpm build` in `website/` green; `website/package.json` untouched, so
  `website/pnpm-lock.yaml` is unchanged
- rendered the built site and compared the FAQ answer with the JSON-LD answer
  string: equal, and `operatingSystem` reads `["macOS","Linux"]`

Refs #1258
