### PR TITLE
chore(repo): bump version to 0.1.72

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ version in the same PR that bumps the version numbers (see
 `docs/release-command.md`), before the tag is pushed: the release build fails
 if it can't find a matching `## Goodboy vX.Y.Z` heading.
 
+## Goodboy v0.1.72
+
+The release now carries Linux packages, credentials there go to the system keyring, and the shortcuts answer to Ctrl.
+
+### [#1316] Download Goodboy for Linux as an AppImage, deb or rpm
+
+Until now a tagged build produced one thing, a macOS universal `.dmg`. The same tag now also builds on Linux and attaches three x86_64 packages to the same release: an AppImage, a `.deb` and an `.rpm`, needing glibc 2.39 or newer, so Ubuntu 24.04 and Debian 13 upward.
+
+The `.deb` and the `.rpm` declare what they link against, read out of the binary with `dpkg-shlibdeps` rather than written by hand, so your package manager resolves the GTK and WebKit stack for you. The AppImage carries its own and needs FUSE 2 on the machine, which recent Ubuntu does not install by default (`sudo apt install libfuse2`, or run it with `--appimage-extract-and-run`). None of the three is signed, and in-app updates stay macOS-only for now, so on Linux a new version is a new package from the release page.
+
+macOS is untouched: the same universal build, the same Apple signing and notarization, the same four assets, the same Homebrew cask. The Linux leg runs after the macOS one, passes no release body and no updater key, and goes red on its own.
+
+Follow-up: the packages come off a GitHub `ubuntu-latest` runner, built from this tag, though the app has not been launched from one of them on a Linux desktop yet. If your distribution cannot satisfy something the `.deb` or the `.rpm` declares, apt or rpm says which one before anything is written.
+
+### [#1317] Credentials on Linux go to your keyring
+
+Integration tokens and provider credentials live in the operating system's credential store. On Linux that is the freedesktop Secret Service, GNOME Keyring or KWallet, so a keyring daemon has to be running before a token can be saved, and the session negotiates a Diffie-Hellman key so a secret does not cross the session bus in the clear. macOS keeps the Keychain exactly as before.
+
+Follow-up: the backend is the one the `keyring` crate selects on Linux, checked by compiling the dependency graph for each platform, though no token has been stored and read back on a Linux desktop yet. With no daemon running, saving fails with the keyring's own error and the token is not saved.
+
+### [#1318] Shortcuts use Ctrl on Linux
+
+Every shortcut asked for Command, which a Linux keyboard labels Super and the desktop environment mostly keeps for itself, so none of them fired. They resolve to Ctrl off macOS now, and the shortcuts screen and every hover hint show the combination you press. macOS bindings are unchanged.
+
+One exception, and it is GNOME's rather than ours: the terminal lens sits on Ctrl+Alt+T, which GNOME takes for its own terminal, so there the shortcuts screen lists a combination that will not open it. Open that lens from the session's lens list instead.
+
 ## Goodboy v0.1.71
 
 The window comes up while Goodboy looks for your CLIs instead of after, and a phone can now start a session from a Jira issue.

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goodboy/desktop",
-  "version": "0.1.71",
+  "version": "0.1.72",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -1626,7 +1626,7 @@ dependencies = [
 
 [[package]]
 name = "goodboy-desktop"
-version = "0.1.71"
+version = "0.1.72"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goodboy-desktop"
-version = "0.1.71"
+version = "0.1.72"
 description = "Goodboy desktop app"
 authors = ["Amin Khayam"]
 license = "MIT"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Goodboy",
-  "version": "0.1.71",
+  "version": "0.1.72",
   "identifier": "com.goodboy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goodboy",
-  "version": "0.1.71",
+  "version": "0.1.72",
   "private": true,
   "description": "AI workspace orchestrator. Local-first, provider-agnostic.",
   "license": "MIT",


### PR DESCRIPTION
## What

Bumps 0.1.71 to 0.1.72 in all five version files and adds the `## Goodboy v0.1.72` section to `CHANGELOG.md`, which `.github/workflows/release.yml` reads verbatim as the release body and as the updater's notes.

## Why

v0.1.72 is the Linux release. It is a patch on the default in `docs/release-command.md` for an ambiguous request: issue #1258 offered either 0.2.0 or a 0.1.x Linux-only release and did not pick, and a patch is the more reversible claim.

## What ships

- #1316 adds a `linux` job to the release workflow with `needs: macos`, a pull-request proof workflow, and derived `bundle.linux.deb.depends`. Three x86_64 packages join the release: AppImage, deb, rpm.
- #1317 moves Linux credentials from the kernel keyutils store, whose keys do not survive a reboot, to the freedesktop Secret Service with an encrypted session.
- #1318 binds the 48 registry shortcuts to Ctrl off macOS. They were all meta-only and none fired on Linux.
- #1319 makes the README, `SECURITY.md`, the release docs and the website true about both platforms.

macOS is untouched throughout: same runner, same universal target, same signing and notarization, same four assets, same cask.

## Notes on the notes

Written from the merged PR bodies and read against `docs/tone-of-voice.md` by a reviewer who did not write them. Limits sit inside the sentence that promises the thing: the glibc 2.39 floor, FUSE 2 for the AppImage, no signatures on the Linux packages, no in-app updates on Linux, and the one shortcut GNOME claims for itself. The two follow-up lines say what the work stands on rather than confessing what was not run.

`docs/release-command.md` says to include only `desktop`, `ui` and `core` PRs in the app notes. #1316 is scoped `ci` and is included anyway, because it is the release. That doc should be amended to match; it is recorded rather than changed here so the release PR stays to the runbook shape.

## Test plan

- Five version files agree with the tag, checked by hand.
- `Cargo.lock`'s `goodboy-desktop` entry bumped, since `rust.yml` runs `cargo test --locked`.
- Release build extracts the `## Goodboy v0.1.72` heading and fails without it, so CI proves the section exists.
- rc dry-run before the real tag, with notarization checked against team M3R9H4QX65 and the Linux leg observed on a tag for the first time.

Refs #1258