### PR TITLE
fix(desktop): let a failed integration inbox retry itself

### DIFF
--- a/apps/desktop/src/features/github/components/GitHubStudio/IssueInbox.test.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/IssueInbox.test.tsx
@@ -1,0 +1,23 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { IssueInbox } from './IssueInbox';
+
+afterEach(cleanup);
+
+describe('IssueInbox', () => {
+  it('offers a retry when the issue fetch fails', () => {
+    const onRefresh = vi.fn();
+    render(
+      <IssueInbox
+        groups={[]}
+        focusedIssueNumber={null}
+        onSelect={vi.fn()}
+        loading={false}
+        error="Network error"
+        onRefresh={onRefresh}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/features/github/components/GitHubStudio/IssueInbox.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/IssueInbox.tsx
@@ -10,6 +10,7 @@ import {
 import { MessagesSquare, Search } from 'lucide-react';
 import type { GithubIssue } from '@goodboy/types';
 import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../shared/components/conceptIcons';
+import { ErrorStrip } from '../../../../shared/components/ErrorStrip';
 import { formatAdaptiveAge } from '../../../../shared/utils/relativeDate';
 import type { GithubIssueGroup } from './useGithubIssues';
 import { InboxStatusIcons } from '../../../integrations/components/InboxStatusIcons';
@@ -82,9 +83,7 @@ export const IssueInbox = ({
         </div>
       ) : error != null ? (
         <div className="px-3 pb-3">
-          <div className="rounded-lg border border-danger/30 bg-danger/10 px-3 py-2 text-xs text-danger">
-            {error}
-          </div>
+          <ErrorStrip label="issues" error={new Error(error)} onRetry={onRefresh} />
         </div>
       ) : filtered.length === 0 ? (
         <div className="flex min-h-0 flex-1 items-center justify-center px-3">

--- a/apps/desktop/src/features/integrations/bitbucket/BitbucketStudio/PrInbox.test.tsx
+++ b/apps/desktop/src/features/integrations/bitbucket/BitbucketStudio/PrInbox.test.tsx
@@ -1,0 +1,23 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { PrInbox } from './PrInbox';
+
+afterEach(cleanup);
+
+describe('PrInbox', () => {
+  it('offers a retry when the pull request fetch fails', () => {
+    const onRefresh = vi.fn();
+    render(
+      <PrInbox
+        groups={[]}
+        focusedPrId={null}
+        onSelect={vi.fn()}
+        loading={false}
+        error="Network error"
+        onRefresh={onRefresh}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/features/integrations/bitbucket/BitbucketStudio/PrInbox.tsx
+++ b/apps/desktop/src/features/integrations/bitbucket/BitbucketStudio/PrInbox.tsx
@@ -9,6 +9,7 @@ import {
 } from '@goodboy/ui';
 import { GitPullRequest, Search } from 'lucide-react';
 import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../shared/components/conceptIcons';
+import { ErrorStrip } from '../../../../shared/components/ErrorStrip';
 import { formatAdaptiveAge } from '../../../../shared/utils/relativeDate';
 import { InboxStatusIcons } from '../../components/InboxStatusIcons';
 import type { BitbucketPullRequest } from '../client';
@@ -77,9 +78,7 @@ export const PrInbox = ({ groups, focusedPrId, onSelect, loading, error, onRefre
         </div>
       ) : error != null ? (
         <div className="px-3 pb-3">
-          <div className="rounded-lg border border-danger/30 bg-danger/10 px-3 py-2 text-xs text-danger">
-            {error}
-          </div>
+          <ErrorStrip label="pull requests" error={new Error(error)} onRetry={onRefresh} />
         </div>
       ) : filtered.length === 0 ? (
         <div className="flex min-h-0 flex-1 items-center justify-center px-3">

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrInbox.test.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrInbox.test.tsx
@@ -1,0 +1,23 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { MrInbox } from './MrInbox';
+
+afterEach(cleanup);
+
+describe('MrInbox', () => {
+  it('offers a retry when the merge request fetch fails', () => {
+    const onRefresh = vi.fn();
+    render(
+      <MrInbox
+        groups={[]}
+        focusedMrId={null}
+        onSelect={vi.fn()}
+        loading={false}
+        error="Network error"
+        onRefresh={onRefresh}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrInbox.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrInbox.tsx
@@ -10,6 +10,7 @@ import {
 import { GitMerge, Search } from 'lucide-react';
 import type { GitlabMergeRequest } from '../client';
 import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../shared/components/conceptIcons';
+import { ErrorStrip } from '../../../../shared/components/ErrorStrip';
 import { formatAdaptiveAge } from '../../../../shared/utils/relativeDate';
 import type { GitlabMrGroup } from './useGitlabMrs';
 import { InboxStatusIcons } from '../../components/InboxStatusIcons';
@@ -75,9 +76,7 @@ export const MrInbox = ({ groups, focusedMrId, onSelect, loading, error, onRefre
         </div>
       ) : error != null ? (
         <div className="px-3 pb-3">
-          <div className="rounded-lg border border-danger/30 bg-danger/10 px-3 py-2 text-xs text-danger">
-            {error}
-          </div>
+          <ErrorStrip label="merge requests" error={new Error(error)} onRetry={onRefresh} />
         </div>
       ) : filtered.length === 0 ? (
         <div className="flex min-h-0 flex-1 items-center justify-center px-3">

--- a/apps/desktop/src/features/integrations/jira/JiraStudio/IssueInbox.test.tsx
+++ b/apps/desktop/src/features/integrations/jira/JiraStudio/IssueInbox.test.tsx
@@ -1,0 +1,24 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { IssueInbox } from './IssueInbox';
+
+afterEach(cleanup);
+
+describe('IssueInbox', () => {
+  it('offers a retry when the issue fetch fails', () => {
+    const onRefresh = vi.fn();
+    render(
+      <IssueInbox
+        groups={[]}
+        focusedIssueId={null}
+        onSelect={vi.fn()}
+        isLoading={false}
+        error="Network error"
+        onRefresh={onRefresh}
+        emptyDescription="No open issues assigned to you."
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/features/integrations/jira/JiraStudio/IssueInbox.tsx
+++ b/apps/desktop/src/features/integrations/jira/JiraStudio/IssueInbox.tsx
@@ -9,6 +9,7 @@ import {
 } from '@goodboy/ui';
 import { MessagesSquare, Search } from 'lucide-react';
 import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../shared/components/conceptIcons';
+import { ErrorStrip } from '../../../../shared/components/ErrorStrip';
 import { formatAdaptiveAge } from '../../../../shared/utils/relativeDate';
 import { InboxStatusIcons } from '../../components/InboxStatusIcons';
 import type { JiraIssue } from '../client';
@@ -87,9 +88,7 @@ export const IssueInbox = ({
         </div>
       ) : error != null ? (
         <div className="px-3 pb-3">
-          <div className="flex items-start gap-2.5 rounded-lg border border-danger/30 bg-danger/10 px-3 py-2 text-xs text-danger">
-            {error}
-          </div>
+          <ErrorStrip label="issues" error={new Error(error)} onRetry={onRefresh} />
         </div>
       ) : filtered.length === 0 ? (
         <div className="flex min-h-0 flex-1 items-center justify-center px-3">

--- a/apps/desktop/src/features/integrations/linear/useLinearIssue.test.ts
+++ b/apps/desktop/src/features/integrations/linear/useLinearIssue.test.ts
@@ -1,0 +1,51 @@
+import { cleanup, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { WorkspaceId } from '@goodboy/types';
+import { linearFetchIssue, type LinearIssue } from './client';
+import { useLinearIssue } from './useLinearIssue';
+
+vi.mock('./client', () => ({
+  linearFetchIssue: vi.fn(),
+}));
+
+const fetchIssue = vi.mocked(linearFetchIssue);
+const WORKSPACE_ID = 'workspace-1' as WorkspaceId;
+const ISSUE_ID = 'issue-7';
+
+const ISSUE: LinearIssue = {
+  id: ISSUE_ID,
+  identifier: 'ACME-7',
+  title: 'Fix the thing',
+  description: 'Details',
+  url: 'https://linear.app/acme/issue/ACME-7',
+  state: { name: 'Todo', type: 'unstarted' },
+  team: { key: 'ACME' },
+  updatedAt: '2026-05-21T10:00:00Z',
+};
+
+beforeEach(() => {
+  fetchIssue.mockReset();
+});
+
+afterEach(cleanup);
+
+describe('useLinearIssue', () => {
+  it('surfaces the fetch error and recovers on retry', async () => {
+    fetchIssue.mockRejectedValueOnce(new Error('request failed'));
+
+    const { result } = renderHook(() =>
+      useLinearIssue({ workspaceId: WORKSPACE_ID, issueId: ISSUE_ID }),
+    );
+
+    await waitFor(() => expect(result.current.error).toBe('request failed'));
+    expect(result.current.issue).toBeNull();
+    expect(fetchIssue).toHaveBeenCalledTimes(1);
+
+    fetchIssue.mockResolvedValueOnce(ISSUE);
+    result.current.refetch();
+
+    await waitFor(() => expect(result.current.issue).toEqual(ISSUE));
+    expect(result.current.error).toBeNull();
+    expect(fetchIssue).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/desktop/src/features/integrations/linear/useLinearIssue.ts
+++ b/apps/desktop/src/features/integrations/linear/useLinearIssue.ts
@@ -12,12 +12,14 @@ type Result = {
   readonly issue: LinearIssue | null;
   readonly isLoading: boolean;
   readonly error: string | null;
+  readonly refetch: () => void;
 };
 
 export const useLinearIssue = ({ workspaceId, issueId }: Params): Result => {
   const [issue, setIssue] = useState<LinearIssue | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [attempt, setAttempt] = useState(0);
 
   useEffect(() => {
     let isCancelled = false;
@@ -47,7 +49,7 @@ export const useLinearIssue = ({ workspaceId, issueId }: Params): Result => {
     return () => {
       isCancelled = true;
     };
-  }, [issueId, workspaceId]);
+  }, [issueId, workspaceId, attempt]);
 
-  return { issue, isLoading, error };
+  return { issue, isLoading, error, refetch: () => setAttempt((count) => count + 1) };
 };

--- a/apps/desktop/src/features/integrations/slack/SlackStudio/ThreadInbox.test.tsx
+++ b/apps/desktop/src/features/integrations/slack/SlackStudio/ThreadInbox.test.tsx
@@ -1,0 +1,24 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { ThreadInbox } from './ThreadInbox';
+
+afterEach(cleanup);
+
+describe('ThreadInbox', () => {
+  it('offers a retry when the thread fetch fails', () => {
+    const onRefresh = vi.fn();
+    render(
+      <ThreadInbox
+        groups={[]}
+        focusedThreadTs={null}
+        onSelect={vi.fn()}
+        isLoading={false}
+        error="Network error"
+        onRefresh={onRefresh}
+        hiddenChannelCount={0}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/features/integrations/slack/SlackStudio/ThreadInbox.tsx
+++ b/apps/desktop/src/features/integrations/slack/SlackStudio/ThreadInbox.tsx
@@ -9,6 +9,7 @@ import {
 } from '@goodboy/ui';
 import { MessagesSquare, Search } from 'lucide-react';
 import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../shared/components/conceptIcons';
+import { ErrorStrip } from '../../../../shared/components/ErrorStrip';
 import { formatAdaptiveAge } from '../../../../shared/utils/relativeDate';
 import { InboxStatusIcons } from '../../components/InboxStatusIcons';
 import { slackThreadFirstLine } from '../threadFormulas';
@@ -86,9 +87,7 @@ export const ThreadInbox = ({
         </div>
       ) : error != null ? (
         <div className="px-3 pb-3">
-          <div className="flex items-start gap-2.5 rounded-lg border border-danger/30 bg-danger/10 px-3 py-2 text-xs text-danger">
-            {error}
-          </div>
+          <ErrorStrip label="threads" error={new Error(error)} onRetry={onRefresh} />
         </div>
       ) : filtered.length === 0 ? (
         <div className="flex min-h-0 flex-1 items-center justify-center px-3">

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/LinearTaskDetail.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/LinearTaskDetail.test.tsx
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { IsoDateTime, SessionExternalTask, SessionId, WorkspaceId } from '@goodboy/types';
+import { useLinearIssue } from '../../../../../integrations/linear/useLinearIssue';
+import { LinearTaskDetail } from './LinearTaskDetail';
+
+vi.mock('../../../../../integrations/linear/useLinearIssue', () => ({
+  useLinearIssue: vi.fn(),
+}));
+
+const useLinearIssueMock = vi.mocked(useLinearIssue);
+const WORKSPACE_ID = 'workspace-1' as WorkspaceId;
+
+const TASK: SessionExternalTask = {
+  sessionId: 'session-1' as SessionId,
+  provider: 'linear',
+  externalId: 'ISSUE-7',
+  identifier: 'ACME-7',
+  title: 'Fix the thing',
+  url: 'https://linear.app/acme/issue/ACME-7',
+  createdAt: '2026-07-22T12:00:00.000Z' as IsoDateTime,
+};
+
+afterEach(cleanup);
+
+describe('LinearTaskDetail', () => {
+  it('shows an error with a retry action that calls refetch', () => {
+    const refetch = vi.fn();
+    useLinearIssueMock.mockReturnValue({
+      issue: null,
+      isLoading: false,
+      error: 'request failed',
+      refetch,
+    });
+
+    render(<LinearTaskDetail workspaceId={WORKSPACE_ID} task={TASK} />);
+
+    expect(screen.getByRole('alert')).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    expect(refetch).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/LinearTaskDetail.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/LinearTaskDetail.tsx
@@ -1,5 +1,6 @@
 import { Skeleton } from '@goodboy/ui';
 import type { SessionExternalTask, WorkspaceId } from '@goodboy/types';
+import { ErrorStrip } from '../../../../../../shared/components/ErrorStrip';
 import { HeaderBand, StudioDetailLayout } from '../../../../../../shared/components/StudioDetail';
 import { LinearIssueDetail } from '../../../../../integrations/linear/LinearIssueDetail';
 import { useLinearIssue } from '../../../../../integrations/linear/useLinearIssue';
@@ -10,7 +11,7 @@ type Props = {
 };
 
 export const LinearTaskDetail = ({ workspaceId, task }: Props) => {
-  const { issue, isLoading, error } = useLinearIssue({
+  const { issue, isLoading, error, refetch } = useLinearIssue({
     workspaceId,
     issueId: task.externalId,
   });
@@ -40,7 +41,9 @@ export const LinearTaskDetail = ({ workspaceId, task }: Props) => {
           <Skeleton className="h-3 w-3/4 rounded" />
         </div>
       ) : null}
-      {error != null ? <p className="text-sm text-danger">{error}</p> : null}
+      {error != null ? (
+        <ErrorStrip label="the Linear issue" error={new Error(error)} onRetry={refetch} />
+      ) : null}
     </StudioDetailLayout>
   );
 };


### PR DESCRIPTION
## What and why

When an integration studio's list fetch fails, the list column collapsed to a bare red box with the raw error string and nothing to click. In three of the five studios (GitLab, GitHub, Bitbucket) there was no reachable retry at all: the header refresh sits in the studio's parent and is gated on having results, which is exactly what a failed fetch does not have. Jira and Slack keep an ungated header refresh, so those two already had a working, if distant, way out.

`ErrorStrip` (`shared/components/ErrorStrip`) already exists and is used correctly next door (`GitlabIssueConversation`, `JiraTaskDetail`, `GitlabTaskDetail`). This PR swaps the bare error `div` for `ErrorStrip` in the five inbox list components plus `LinearTaskDetail`, wiring each to the refresh callback that was already sitting unused in scope.

`useLinearIssue` did not expose a `refetch`, unlike its sibling hooks (`useJiraIssue`, `useGitlabIssue`). Added an `attempt` counter mirroring `useJiraIssue`'s shape; its only consumer, `LinearTaskDetail`, is updated to use it.

Dead ends fixed (no retry reachable before this PR):
- `apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrInbox.tsx`
- `apps/desktop/src/features/integrations/bitbucket/BitbucketStudio/PrInbox.tsx`
- `apps/desktop/src/features/github/components/GitHubStudio/IssueInbox.tsx`

Also fixed for co-location even though a (gated-elsewhere or ungated) header refresh already existed:
- `apps/desktop/src/features/integrations/jira/JiraStudio/IssueInbox.tsx`
- `apps/desktop/src/features/integrations/slack/SlackStudio/ThreadInbox.tsx`
- `apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/LinearTaskDetail.tsx`

## ReviewBoardPane

Checked `apps/desktop/src/features/review/components/ReviewBoardPane/index.tsx` under the same rule. Its header `RefreshIconButton` (bound to the same `refresh` used by the error branch) is not gated on `files.length`, so it stays visible and clickable through an error, unlike the three genuine dead ends above. Left unchanged: it is not a dead end, and folding `ErrorStrip` into the `LensEmptyState` there is a separate, un-scouted change.

## Test plan

From the worktree root:
- `CI=1 corepack pnpm exec turbo run typecheck` — green, 5/5 packages.
- `CI=1 corepack pnpm exec turbo run test --force` — green, 615 test files / 5156 tests, including the 6 new/changed test files (`MrInbox.test.tsx`, `IssueInbox.test.tsx` x2, `ThreadInbox.test.tsx`, `PrInbox.test.tsx`, `LinearTaskDetail.test.tsx`), each asserting the retry control renders on error and clicking it calls the refresh function.
- `CI=1 corepack pnpm knip --include files,duplicates,unlisted` — clean (only pre-existing config hints unrelated to this change).

## Out of scope

`ReviewBoardPane`'s error empty state, left as-is per the reasoning above. `packages/ui/src/components/Button.tsx` is not touched, a sibling item owns its busy-state change.