### PR TITLE
test(ci): guard release.yml invariants and wire it into affected

### DIFF
--- a/apps/desktop/src/__tests__/regressions/release-workflow-invariants.test.ts
+++ b/apps/desktop/src/__tests__/regressions/release-workflow-invariants.test.ts
@@ -25,12 +25,18 @@ const extractJobBlocks = (content: string): Map<string, string> => {
   return blocks;
 };
 
+const stripComments = (block: string): string =>
+  block
+    .split('\n')
+    .map((line) => line.replace(/(^|\s)#.*$/, '$1'))
+    .join('\n');
+
 const jobBlock = (content: string, name: string): string => {
   const block = extractJobBlocks(content).get(name);
   if (block == null) {
     throw new Error(`release.yml has no top-level "${name}:" job anymore. Update this guard.`);
   }
-  return block;
+  return stripComments(block);
 };
 
 describe('release workflow guardrails', () => {
@@ -69,6 +75,9 @@ describe('release workflow guardrails', () => {
   });
 
   it('serializes the linux job behind macos so it never races the release', () => {
-    expect(/needs:\s*macos/.test(linux), 'linux job must declare needs: macos').toBe(true);
+    expect(
+      /^\s*needs:\s*macos\s*$/m.test(linux),
+      'linux job must declare needs: macos as a real key, not just mention it in prose',
+    ).toBe(true);
   });
 });

--- a/apps/desktop/src/__tests__/regressions/release-workflow-invariants.test.ts
+++ b/apps/desktop/src/__tests__/regressions/release-workflow-invariants.test.ts
@@ -1,0 +1,74 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { describe, expect, it } from 'vitest';
+
+const DESKTOP_SRC = join(__dirname, '..', '..');
+const REPO_ROOT = join(DESKTOP_SRC, '..', '..', '..');
+const RELEASE_WORKFLOW = join(REPO_ROOT, '.github', 'workflows', 'release.yml');
+
+const TAURI_ACTION_SHA = '1deb371b0cd8bd54025b384f1cd735e725c4060f';
+
+const extractJobBlocks = (content: string): Map<string, string> => {
+  const lines = content.split('\n');
+  const headers: Array<{ name: string; index: number }> = [];
+  lines.forEach((line, index) => {
+    const match = /^ {2}([a-zA-Z0-9_-]+):\s*$/.exec(line);
+    if (match?.[1] != null) {
+      headers.push({ name: match[1], index });
+    }
+  });
+  const blocks = new Map<string, string>();
+  headers.forEach((header, i) => {
+    const end = headers[i + 1]?.index ?? lines.length;
+    blocks.set(header.name, lines.slice(header.index, end).join('\n'));
+  });
+  return blocks;
+};
+
+const jobBlock = (content: string, name: string): string => {
+  const block = extractJobBlocks(content).get(name);
+  if (block == null) {
+    throw new Error(`release.yml has no top-level "${name}:" job anymore. Update this guard.`);
+  }
+  return block;
+};
+
+describe('release workflow guardrails', () => {
+  const content = readFileSync(RELEASE_WORKFLOW, 'utf8');
+  const macos = jobBlock(content, 'macos');
+  const linux = jobBlock(content, 'linux');
+
+  it('pins tauri-action to a known sha in both jobs', () => {
+    const pin = new RegExp(`tauri-apps/tauri-action@${TAURI_ACTION_SHA}`);
+    expect(pin.test(macos), 'macos job must pin tauri-action to the reviewed sha').toBe(true);
+    expect(pin.test(linux), 'linux job must pin tauri-action to the reviewed sha').toBe(true);
+  });
+
+  it('drafts the release in both jobs, never publishing straight from CI', () => {
+    const releaseDraft = /releaseDraft:\s*true/;
+    expect(releaseDraft.test(macos), 'macos job must set releaseDraft: true').toBe(true);
+    expect(releaseDraft.test(linux), 'linux job must set releaseDraft: true').toBe(true);
+  });
+
+  it('leaves the macOS-authored updater manifest and signatures alone in the linux job', () => {
+    expect(
+      /uploadUpdaterJson:\s*false/.test(linux),
+      'linux job must set uploadUpdaterJson: false so it never overwrites latest.json',
+    ).toBe(true);
+    expect(
+      /uploadUpdaterSignatures:\s*false/.test(linux),
+      'linux job must set uploadUpdaterSignatures: false',
+    ).toBe(true);
+  });
+
+  it('builds unsigned linux bundles only, never claiming updater signing', () => {
+    expect(
+      /args:\s*--bundles\s+appimage,deb,rpm\s+--no-sign/.test(linux),
+      'linux job must build appimage,deb,rpm with --no-sign',
+    ).toBe(true);
+  });
+
+  it('serializes the linux job behind macos so it never races the release', () => {
+    expect(/needs:\s*macos/.test(linux), 'linux job must declare needs: macos').toBe(true);
+  });
+});

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "ui": "tui",
+  "globalDependencies": [".github/workflows/**"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## What and why

`.github/workflows/release.yml` had no protection of any kind. A verifier applied eight plausible future edits to it and all eight parsed as valid YAML and would have been accepted silently by GitHub; two of them would have blanked the `latest.json` release notes every macOS user reads in the update dialog.

Two files:

1. `apps/desktop/src/__tests__/regressions/release-workflow-invariants.test.ts`, a new regression test that asserts against the raw text of `release.yml`:
   - `tauri-apps/tauri-action` pinned at sha `1deb371b0cd8bd54025b384f1cd735e725c4060f` in both the macos and linux jobs (a sha bump silently reprices all six of that action's inputs).
   - `releaseDraft: true` in both jobs.
   - `uploadUpdaterJson: false` and `uploadUpdaterSignatures: false` on the linux job, so it can never overwrite the macOS-authored `latest.json`.
   - `args: --bundles appimage,deb,rpm --no-sign` on the linux job.
   - `needs: macos` on the linux job, so a broken linux leg can never race the macOS release.

   No YAML parser is a declared dependency anywhere in the repo and CONVENTIONS.md bans phantom transitive deps, so this is a text-assertion test, not a parsed one. Each job's block is sliced out by its 2-space-indent header before matching, so an unrelated reformat inside the other job (or a whitespace change) cannot false-red this guard.

2. `turbo.json` gains `globalDependencies: [".github/workflows/**"]`. Without it, `.github/` belongs to no package, so `turbo run test --affected` (what `ci.yml` runs) would execute nothing for a commit that only touches `release.yml`, and the new guard would never fire on the exact PR it exists to catch. Cost: any workflow edit invalidates the task cache for every package. That's a cache-buster, not a correctness risk.

## Out of scope

`actionlint` is the natural follow-up: it would catch a misspelled input key that a text test cannot. Left out here because it means a third CI file plus a pinned third-party action, and this item is scoped to two files.

## Release safety

Confirmed by reading `release.yml`: it never runs `turbo run test`. It runs `pnpm turbo run build --filter=@goodboy/desktop^...` and then `tauri-apps/tauri-action` directly. This change only affects `ci.yml`'s cache keys; worst case on the very next real release build is a cache miss.

## Test plan

- Sanity-checked the guard can fail: committed first, then mutated `release.yml` in the worktree three ways (bumped the macos sha, dropped `releaseDraft: true`, flipped `uploadUpdaterJson` to `true`) and confirmed the test went red for each, then reverted.
- `CI=1 corepack pnpm exec turbo run typecheck` — 5/5 packages green.
- `CI=1 corepack pnpm exec turbo run test --force` — 610 files / 5155 tests passed.
- `CI=1 corepack pnpm knip --include files,duplicates,unlisted` — clean (only pre-existing config hints).
- `turbo run test --filter='...[HEAD]' --dry=json` with only `release.yml` modified in the working tree showed `@goodboy/desktop#test` (and every other package's test task) in the affected task list, proving the `globalDependencies` line actually makes the guard fire.

## Not verified

Did not run the guard inside actual GitHub Actions CI; only proved the `turbo --affected` mechanism locally via dry-run.