### PR TITLE
fix: keep a usable step summary and tell the truth about degraded handoffs

### DIFF
--- a/apps/desktop/src/store/slices/turn/sendTurn.ts
+++ b/apps/desktop/src/store/slices/turn/sendTurn.ts
@@ -71,6 +71,7 @@ import { isBranchlessSession } from '../../../shared/utils/isBranchlessSession';
 import { detectParallelGroup } from '../../parallel-turn';
 import { buildContextPreamble, buildPriorTurnsBlock, getModelContextWindow } from '../../preamble';
 import { applyAgentTurnState, cancelledRunIds } from '../../session-mutators';
+import { stepSummaryDegraded } from '../../summarizeAgentOutput';
 import { relinkSimpleSessionDirectories } from '../workspaces/relinkSimpleSessionDirectories';
 import { flushTurnEvents } from '../transcripts/buffer';
 import {
@@ -333,9 +334,11 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
               })),
             });
             const predecessorSummary = immediatePredecessor.outputSummary ?? '';
+            const recordedDegraded = stepSummaryDegraded.get(immediatePredecessor.id);
             const isDegraded =
-              predecessorSummary.trim().length === 0 ||
-              isFallbackStepOutputSummary({ summary: predecessorSummary });
+              recordedDegraded ??
+              (predecessorSummary.trim().length === 0 ||
+                isFallbackStepOutputSummary({ summary: predecessorSummary }));
             const durationMs =
               immediatePredecessor.startedAt != null && immediatePredecessor.completedAt != null
                 ? new Date(immediatePredecessor.completedAt).getTime() -

--- a/apps/desktop/src/store/slices/workflows/finalizeWorkflowStep.test.ts
+++ b/apps/desktop/src/store/slices/workflows/finalizeWorkflowStep.test.ts
@@ -38,7 +38,7 @@ vi.mock('../../../features/workflows/workflows', () => ({
 }));
 
 import { finalizeWorkflowStep, degradedNotifiedAgents } from './finalizeWorkflowStep';
-import { SUMMARY_TIMEOUT_MS } from '../../summarizeAgentOutput';
+import { SUMMARY_TIMEOUT_MS, stepSummaryDegraded } from '../../summarizeAgentOutput';
 
 const SESSION_ID = 'session-1' as SessionId;
 const AGENT_ID = 'agent-1' as AgentId;
@@ -111,6 +111,7 @@ describe('finalizeWorkflowStep output summary', () => {
     invokeAgentListSpy.mockResolvedValue([{ ...agent, status: 'completed' }]);
     invokeAgentUpdateStatusSpy.mockResolvedValue({ ...agent, status: 'completed' });
     degradedNotifiedAgents.clear();
+    stepSummaryDegraded.clear();
   });
 
   afterEach(() => {

--- a/apps/desktop/src/store/slices/workflows/retryStepSummary.test.ts
+++ b/apps/desktop/src/store/slices/workflows/retryStepSummary.test.ts
@@ -18,7 +18,11 @@ vi.mock('../../../features/workflows/workflows', () => ({
 }));
 
 import { retryStepSummary } from './retryStepSummary';
-import { summarizeAgentOutput, summarizedStepOutputs } from '../../summarizeAgentOutput';
+import {
+  stepSummaryDegraded,
+  summarizeAgentOutput,
+  summarizedStepOutputs,
+} from '../../summarizeAgentOutput';
 
 const SESSION_ID = 'session-1' as SessionId;
 const AGENT_ID = 'agent-1' as AgentId;
@@ -94,6 +98,7 @@ describe('retryStepSummary', () => {
   beforeEach(() => {
     invokeAgentUpdateStatusSpy.mockResolvedValue({ ...agent });
     summarizedStepOutputs.clear();
+    stepSummaryDegraded.clear();
   });
 
   afterEach(() => {

--- a/apps/desktop/src/store/store.sendturn-agent-routing.test.ts
+++ b/apps/desktop/src/store/store.sendturn-agent-routing.test.ts
@@ -240,6 +240,8 @@ vi.mock('../features/plans/plans', () => ({
   listConsumptionsForPlan: vi.fn(async () => []),
 }));
 
+import { stepSummaryDegraded } from './summarizeAgentOutput';
+
 const SESSION_ID = 'session-rt-1' as SessionId;
 const AGENT_A = 'agent-a' as AgentId;
 const AGENT_B = 'agent-b' as AgentId;
@@ -916,19 +918,131 @@ describe('sendTurn, workflow carry-forward', () => {
       expect.stringContaining(expectedCarryForward),
     ]);
 
-    const fallbackSummary = `${'h'.repeat(1500)}\n...\n${'t'.repeat(400)}`;
+    const lastStepTransition = () =>
+      (useAppStore.getState().transcripts[reviewAgentId] ?? [])
+        .filter((event) => event.kind === 'step_transition')
+        .at(-1);
+
+    const shortDegradedSummary = 'the step died before it wrote anything worth carrying';
     agents = agents.map((agent) =>
-      agent.id === implementAgentId ? { ...agent, outputSummary: fallbackSummary } : agent,
+      agent.id === implementAgentId ? { ...agent, outputSummary: shortDegradedSummary } : agent,
     );
+
+    stepSummaryDegraded.clear();
+    await useAppStore
+      .getState()
+      .sendTurn({ sessionId: SESSION_ID, agentId: reviewAgentId, content: 'short summary retry' });
+
+    expect(lastStepTransition()).toEqual(
+      expect.objectContaining({
+        carryForwardContext: expect.stringContaining(shortDegradedSummary),
+      }),
+    );
+    expect(lastStepTransition()?.degraded).toBeUndefined();
+
+    stepSummaryDegraded.set(implementAgentId, true);
+    await useAppStore
+      .getState()
+      .sendTurn({ sessionId: SESSION_ID, agentId: reviewAgentId, content: 'ground truth retry' });
+
+    expect(lastStepTransition()).toEqual(
+      expect.objectContaining({
+        degraded: true,
+        carryForwardContext: expect.stringContaining(shortDegradedSummary),
+      }),
+    );
+  });
+
+  it('falls back to the fallback shape when no ground truth survived a restart', async () => {
+    const useAppStore = await importStore();
+    const workflowId = 'workflow-restart' as WorkflowId;
+    const workflowRunId = 'workflow-run-restart' as WorkflowRunId;
+    const implementStepId = 'step-restart-implement' as StepId;
+    const reviewStepId = 'step-restart-review' as StepId;
+    const implementAgentId = 'agent-restart-implement' as AgentId;
+    const reviewAgentId = 'agent-restart-review' as AgentId;
+    const fallbackSummary = `${'h'.repeat(1500)}\n...\n${'t'.repeat(400)}`;
+    const workflow: Workflow = {
+      id: workflowId,
+      workspaceId: WORKSPACE_ID,
+      name: 'restart workflow',
+      description: '',
+      steps: [
+        { id: implementStepId, workflowId, ordinal: 0, name: 'Implement', promptPrefix: '' },
+        { id: reviewStepId, workflowId, ordinal: 1, name: 'Review', promptPrefix: 'review' },
+      ],
+      createdAt: NOW,
+      updatedAt: NOW,
+    };
+    const agents: Agent[] = [
+      {
+        ...buildAgent(implementAgentId, 0),
+        stepId: implementStepId,
+        workflowRunId,
+        name: 'Implement',
+        status: 'completed',
+        outputSummary: fallbackSummary,
+      },
+      {
+        ...buildAgent(reviewAgentId, 1),
+        stepId: reviewStepId,
+        workflowRunId,
+        name: 'Review',
+      },
+    ];
+    const workflowsMod = await import('../features/workflows/workflows');
+    (workflowsMod.invokeAgentList as ReturnType<typeof vi.fn>).mockImplementation(
+      async () => agents,
+    );
+    invokeAgentUpdateStatusSpy.mockImplementation(
+      async (id: AgentId) => agents.find((agent) => agent.id === id) ?? agents[0]!,
+    );
+    useAppStore.setState({
+      sessions: [
+        {
+          ...buildSession(),
+          workflowRuns: [
+            {
+              id: workflowRunId,
+              workflowId,
+              ordinal: 0,
+              currentStep: 1,
+              autoRun: false,
+              triggerMode: 'immediate',
+              executionMode: 'static',
+            },
+          ],
+        },
+      ],
+      sessionWorktrees: { [SESSION_ID]: ['/tmp/wt'] },
+      sessionPhaseRuns: { [SESSION_ID]: agents },
+      selectedAgentId: { [SESSION_ID]: reviewAgentId },
+      transcripts: { [reviewAgentId]: [] },
+      phaseTemplates: { [WORKSPACE_ID]: [workflow] },
+      providers: [
+        {
+          id: 'anthropic',
+          binary: 'claude',
+          connection: 'connected',
+          name: 'Claude',
+          installation: 'installed',
+        } as never,
+      ],
+      authResults: { anthropic: { state: 'connected', identity: 'test' } } as never,
+      workspaces: [
+        { id: WORKSPACE_ID, name: 'ws', rootPath: '/tmp', createdAt: NOW, updatedAt: NOW },
+      ],
+    });
+    stepSummaryDegraded.clear();
 
     await useAppStore
       .getState()
-      .sendTurn({ sessionId: SESSION_ID, agentId: reviewAgentId, content: 'fallback retry' });
+      .sendTurn({ sessionId: SESSION_ID, agentId: reviewAgentId, content: 'after restart' });
 
-    const fallbackTransition = (useAppStore.getState().transcripts[reviewAgentId] ?? [])
+    const transition = (useAppStore.getState().transcripts[reviewAgentId] ?? [])
       .filter((event) => event.kind === 'step_transition')
       .at(-1);
-    expect(fallbackTransition).toEqual(
+    expect(transition).toEqual(
       expect.objectContaining({
         degraded: true,
         carryForwardContext: expect.stringContaining(fallbackSummary),

--- a/apps/desktop/src/store/summarizeAgentOutput.test.ts
+++ b/apps/desktop/src/store/summarizeAgentOutput.test.ts
@@ -7,6 +7,7 @@ vi.mock('@tauri-apps/api/core', () => ({ invoke: invokeSpy }));
 
 import {
   SUMMARY_TIMEOUT_MS,
+  stepSummaryDegraded,
   summarizeAgentOutput,
   summarizedStepOutputs,
 } from './summarizeAgentOutput';
@@ -36,6 +37,7 @@ describe('summarizeAgentOutput', () => {
     vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     invokeSpy.mockReset();
     summarizedStepOutputs.clear();
+    stepSummaryDegraded.clear();
   });
 
   afterEach(() => {
@@ -184,5 +186,35 @@ describe('summarizeAgentOutput', () => {
       taskModel: TASK_MODEL,
     });
     expect(summarizedStepOutputs.has(AGENT_ONE)).toBe(false);
+  });
+
+  it('records whether each agent summary degraded, and leaves unseen agents unknown', async () => {
+    invokeSpy.mockResolvedValueOnce({ stdout: '', stderr: 'cli exploded', exitCode: 1 });
+    await summarizeAgentOutput({
+      agentId: AGENT_ONE,
+      output: 'raw output',
+      taskModel: TASK_MODEL,
+    });
+    expect(stepSummaryDegraded.get(AGENT_ONE)).toBe(true);
+
+    invokeSpy.mockResolvedValueOnce(successEnvelope('a good summary'));
+    await summarizeAgentOutput({
+      agentId: AGENT_TWO,
+      output: 'raw output',
+      taskModel: TASK_MODEL,
+    });
+    expect(stepSummaryDegraded.get(AGENT_TWO)).toBe(false);
+    expect(stepSummaryDegraded.get('agent-never-run' as AgentId)).toBeUndefined();
+  });
+
+  it('clears the degraded record once a retry succeeds', async () => {
+    invokeSpy.mockResolvedValueOnce({ stdout: '', stderr: 'cli exploded', exitCode: 1 });
+    await summarizeAgentOutput({ agentId: AGENT_ONE, output: 'raw', taskModel: TASK_MODEL });
+    expect(stepSummaryDegraded.get(AGENT_ONE)).toBe(true);
+
+    invokeSpy.mockResolvedValueOnce(successEnvelope('a good summary'));
+    await summarizeAgentOutput({ agentId: AGENT_ONE, output: 'raw', taskModel: TASK_MODEL });
+
+    expect(stepSummaryDegraded.get(AGENT_ONE)).toBe(false);
   });
 });

--- a/apps/desktop/src/store/summarizeAgentOutput.ts
+++ b/apps/desktop/src/store/summarizeAgentOutput.ts
@@ -23,6 +23,8 @@ export type SummarizeAgentOutputResult = {
 
 export const summarizedStepOutputs = new Map<AgentId, string>();
 
+export const stepSummaryDegraded = new Map<AgentId, boolean>();
+
 const inFlightSummaries = new Map<AgentId, Promise<SummarizeAgentOutputResult>>();
 
 const runSummarization = async ({
@@ -84,6 +86,7 @@ export const summarizeAgentOutput = ({
     ...(expectedOutput != null && { expectedOutput }),
   })
     .then((result) => {
+      stepSummaryDegraded.set(agentId, result.degraded);
       if (!result.degraded) {
         summarizedStepOutputs.delete(agentId);
       }

--- a/packages/core/src/summarizer/step-output.test.ts
+++ b/packages/core/src/summarizer/step-output.test.ts
@@ -108,7 +108,7 @@ describe('summarizeStepOutput', () => {
     ).resolves.toBe('Review passed.\n- No blockers');
   });
 
-  it('rejects summaries that violate the output contract', async () => {
+  it('rejects a summary whose outcome line runs past its own budget', async () => {
     const invokeFn: SummarizerDeps['invokeFn'] = async <T>(): Promise<T> => {
       return { stdout: 'x'.repeat(121), stderr: '', exitCode: 0 } as T;
     };
@@ -121,6 +121,67 @@ describe('summarizeStepOutput', () => {
         output: 'raw',
       }),
     ).rejects.toBeInstanceOf(SummarizerParseError);
+  });
+
+  it('rejects an empty summary', async () => {
+    const invokeFn: SummarizerDeps['invokeFn'] = async <T>(): Promise<T> => {
+      return { stdout: '   \n  ', stderr: '', exitCode: 0 } as T;
+    };
+
+    await expect(
+      summarizeStepOutput({
+        providerId: 'cursor',
+        model: 'composer-2-fast',
+        invokeFn,
+        output: 'raw',
+      }),
+    ).rejects.toBeInstanceOf(SummarizerParseError);
+  });
+
+  it('keeps a summary that lands exactly on the budget', async () => {
+    const exact = `ok\n${'x'.repeat(1197)}`;
+    const invokeFn: SummarizerDeps['invokeFn'] = async <T>(): Promise<T> => {
+      return { stdout: exact, stderr: '', exitCode: 0 } as T;
+    };
+
+    await expect(
+      summarizeStepOutput({
+        providerId: 'cursor',
+        model: 'composer-2-fast',
+        invokeFn,
+        output: 'raw',
+      }),
+    ).resolves.toBe(exact);
+  });
+
+  it('clamps an over-budget summary on a line boundary and says it clamped', async () => {
+    const outcome = 'Wired the workflow handoff.';
+    const bullets = Array.from(
+      { length: 40 },
+      (_value, index) => `- note ${index}: ${'d'.repeat(40)}`,
+    );
+    const overBudget = [outcome, ...bullets].join('\n');
+    const invokeFn: SummarizerDeps['invokeFn'] = async <T>(): Promise<T> => {
+      return { stdout: overBudget, stderr: '', exitCode: 0 } as T;
+    };
+
+    const result = await summarizeStepOutput({
+      providerId: 'cursor',
+      model: 'composer-2-fast',
+      invokeFn,
+      output: 'raw',
+    });
+    const notice =
+      '(clamped to the handoff budget, the full step output is in the step transcript)';
+    const kept = result.slice(0, result.length - notice.length).trimEnd();
+
+    expect(overBudget.length).toBeGreaterThan(1200);
+    expect(result.length).toBeLessThanOrEqual(1200);
+    expect(result.endsWith(notice)).toBe(true);
+    expect(kept.startsWith(outcome)).toBe(true);
+    expect(kept).toContain(bullets[0]);
+    expect(kept).not.toContain(bullets[39]);
+    expect(kept.split('\n').every((line) => overBudget.split('\n').includes(line))).toBe(true);
   });
 });
 

--- a/packages/core/src/summarizer/step-output.ts
+++ b/packages/core/src/summarizer/step-output.ts
@@ -9,6 +9,8 @@ const MAX_FIRST_LINE_LENGTH = 120;
 const FALLBACK_HEAD_LENGTH = 1500;
 const FALLBACK_TAIL_LENGTH = 400;
 const FALLBACK_JOINER = '\n...\n';
+const CLAMP_NOTICE =
+  '\n\n(clamped to the handoff budget, the full step output is in the step transcript)';
 
 const STEP_OUTPUT_SYSTEM_PROMPT = `Condense an AI coding agent step output into compact markdown for the next workflow step.
 
@@ -54,6 +56,26 @@ type FallbackDetection = {
   readonly summary: string;
 };
 
+type ClampParams = {
+  readonly summary: string;
+};
+
+const clampToSummaryBudget = ({ summary }: ClampParams): string => {
+  const [outcomeLine = '', ...remainingLines] = summary.split(/\r?\n/);
+  const budget = MAX_SUMMARY_LENGTH - CLAMP_NOTICE.length;
+  const kept = [outcomeLine];
+  let used = outcomeLine.length;
+  for (const line of remainingLines) {
+    const grown = used + line.length + 1;
+    if (grown > budget) {
+      break;
+    }
+    kept.push(line);
+    used = grown;
+  }
+  return `${kept.join('\n').trimEnd()}${CLAMP_NOTICE}`;
+};
+
 export const summarizeStepOutput = async ({
   providerId,
   binary,
@@ -95,12 +117,11 @@ export const summarizeStepOutput = async ({
   }
   const summary = extracted.text.trim();
   const firstLine = summary.split(/\r?\n/, 1)[0] ?? '';
-  if (
-    summary.length === 0 ||
-    summary.length > MAX_SUMMARY_LENGTH ||
-    firstLine.length > MAX_FIRST_LINE_LENGTH
-  ) {
+  if (summary.length === 0 || firstLine.length > MAX_FIRST_LINE_LENGTH) {
     throw new SummarizerParseError('step output summary violated the response contract', summary);
+  }
+  if (summary.length > MAX_SUMMARY_LENGTH) {
+    return clampToSummaryBudget({ summary });
   }
   return summary;
 };


### PR DESCRIPTION
Two defects sit behind the "degraded handoff" a user reported on #1299. One makes the fallback fire far more often than it should; the other hides the badge when it does fire.

## The frequency, stated as a hypothesis

`summarizeStepOutput` threw a contract violation when the model's summary ran past 1200 characters, and the caller then replaced it with `fallbackStepOutputSummary`: a raw head-and-tail truncation of the **unsummarized** agent output. A perfectly usable summary at 1250 characters was discarded and swapped for 1900 characters of raw narration, which is worse than the thing the check protects against.

Nobody reproduced a production instance of this, and nothing here measures how often it happens. What is proven is the mechanism: a usable artifact was being thrown away. That this is the dominant cause of the reporter's "often" is a reasonable inference, not a measurement.

A prompt fix was not available: the system prompt already states both budgets in plain words.

### Why clamp, and not retry or accept

- **Clamp (chosen).** The summary is kept and trimmed to the last whole line that fits, so nothing is cut mid-word or mid-bullet. The priority order in the prompt puts file paths and decisions first, so trimming from the tail drops the least load-bearing lines.
- **Retry once with a tightening instruction.** Costs a provider round-trip on every violation, and the retry can overshoot too, so it still needs a clamp underneath it. Not worth the latency on every handoff when the clamp already preserves the artifact.
- **Accept over-budget as-is.** Rejected. `buildChainCarryForward` uses the immediate predecessor's summary in full, unbounded, with no re-truncation, so an over-budget summary flows straight into the next step's prompt with no other guard.

A clamped summary says so. It ends with `(clamped to the handoff budget, the full step output is in the step transcript)`, which satisfies the "truncation is honest" rule in `DESIGN.md`: the clamp announces there is more and names where to reach it. The notice travels with the summary, so both the next step's model and the reader of the transition card see it. The 1200 budget still holds: the notice is charged against it.

An empty summary is still a genuine failure and still degrades. So is an outcome line past its own 120-character budget: no line-boundary trim can honestly repair a first line, and cutting it at 120 would be exactly the silent mid-word cut the rule forbids. That case is deliberately left alone.

## The badge

`sendTurn` re-derived `degraded` by matching the exact string shape of the fallback. `isFallbackStepOutputSummary` only matches a string of exactly 1500 + joiner + 400 characters, but `fallbackStepOutputSummary` returns short output unchanged. A genuinely degraded short output could never match, so the transcript badge silently did not show while the notification for the same event was correct.

The real boolean is now carried instead of guessed at. `summarizeAgentOutput` records the outcome it actually returned in `stepSummaryDegraded`, keyed by agent id, next to the `summarizedStepOutputs` map that already lives there. `sendTurn` reads it. A successful retry overwrites the record, so the badge clears on the next transition.

**Across an app restart** the map is gone, because it is module state in the renderer. An agent with no record falls back to the old shape heuristic rather than reporting a clean handoff, so an unknown answer is never reported as "not degraded". Nothing new is persisted: no column, no new field on a persisted row.

## Tests

Rewritten, not extended: the tail of `injects the same full chain on retry without duplicating slots` built a synthetic exact-fallback string (`'h'.repeat(1500) + '\n...\n' + 't'.repeat(400)`) purely to make `isDegraded` fire. That test pinned the heuristic this PR deliberately invalidates, so keeping it would have pinned the bug. It now asserts the case it never had: a **short** degraded output, whose badge stays hidden until the recorded outcome says it degraded.

The fallback-shape path did not go untested. It moved to its own case, `falls back to the fallback shape when no ground truth survived a restart`, which is what that string now actually stands for.

Added:
- `packages/core`: an over-budget summary is clamped on a line boundary, ends with the notice, stays inside 1200, and every kept line is a whole line from the original. Also: a summary landing exactly on the budget is returned untouched, and an empty summary still rejects.
- `apps/desktop`: `stepSummaryDegraded` records true on failure and false on success, leaves an agent it never saw undefined, and flips back to false when a retry succeeds.

Each half has a test that fails when that half is reverted:
- revert the clamp: `clamps an over-budget summary on a line boundary and says it clamped` fails.
- revert the ground-truth read: `injects the same full chain on retry without duplicating slots` fails.

Both were confirmed by reverting each change in place and watching the test go red.

Reset hygiene: `stepSummaryDegraded.clear()` joins the existing `beforeEach` resets in `summarizeAgentOutput.test.ts`, `finalizeWorkflowStep.test.ts` and `retryStepSummary.test.ts`, alongside `degradedNotifiedAgents` and `summarizedStepOutputs`.

## Test plan

```
CI=1 corepack pnpm exec turbo run typecheck
  Tasks: 5 successful, 5 total

CI=1 corepack pnpm exec turbo run test --force
  @goodboy/desktop:test:  Test Files  609 passed (609)
  @goodboy/desktop:test:       Tests  5153 passed (5153)
  Tasks: 4 successful, 4 total, 0 cached

CI=1 corepack pnpm knip --include files,duplicates,unlisted
  no unused files, duplicates or unlisted dependencies
  (6 pre-existing configuration hints, unchanged by this branch)
```

## Not verified

- No production repro of the reporter's case, before or after. The frequency claim rests on the mechanism, not on a measurement.
- The clamp was not exercised against a real provider response. Every test drives it through a stubbed `invokeFn`.
- Nothing here was run in the built app, so the badge was checked in the store and the card, not on screen.
- A summary whose overshoot sits in one very long line keeps only the outcome line plus the notice, because there is no second whole line to keep. Realistic markdown summaries are many short lines, so this is expected to be rare, but it is untested against real model output.

## Out of scope

- The 120-character outcome-line rule, for the reason given above.
- The `propagator.ts` carry-forward, which reads the predecessor summary unbounded. The clamp means what reaches it is bounded again; adding a second truncation there would double-cut the same text.

Closes #1299
