### PR TITLE
fix(ui): replace busy button spinner with pulsing dot

### DIFF
--- a/apps/desktop/src/__tests__/regressions/no-loader2-in-ui-package.test.ts
+++ b/apps/desktop/src/__tests__/regressions/no-loader2-in-ui-package.test.ts
@@ -1,0 +1,41 @@
+import { readdirSync, readFileSync, statSync } from 'fs';
+import { join, relative } from 'path';
+import { describe, expect, it } from 'vitest';
+
+const UI_SRC = join(__dirname, '..', '..', '..', '..', '..', 'packages', 'ui', 'src');
+const SKIP_SEGMENTS = new Set(['__tests__', 'node_modules', 'dist']);
+
+const LOADER2_REFERENCE = /\bLoader2\b/;
+
+const listSourceFiles = (dir: string, acc: string[] = []): string[] => {
+  for (const entry of readdirSync(dir)) {
+    if (SKIP_SEGMENTS.has(entry)) {
+      continue;
+    }
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      listSourceFiles(full, acc);
+    } else if (entry.endsWith('.tsx') || entry.endsWith('.ts')) {
+      acc.push(full);
+    }
+  }
+  return acc;
+};
+
+describe('shared ui package', () => {
+  it('never imports the banned Loader2 spinner', () => {
+    const offenders: string[] = [];
+    for (const file of listSourceFiles(UI_SRC)) {
+      const source = readFileSync(file, 'utf8');
+      source.split('\n').forEach((line, idx) => {
+        if (LOADER2_REFERENCE.test(line)) {
+          offenders.push(`${relative(UI_SRC, file)}:${idx + 1} ${line.trim()}`);
+        }
+      });
+    }
+    expect(
+      offenders,
+      `DESIGN.md forbids spinners: loading is a skeleton, running is a moving border or a pulsing StatusDot. Remove Loader2 from:\n${offenders.join('\n')}`,
+    ).toEqual([]);
+  });
+});

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -446,8 +446,13 @@ dialog[open]::backdrop {
     linear-gradient(#000 0 0);
   -webkit-mask-composite: xor;
   mask-composite: exclude;
-  animation: spin-border 3.6s linear infinite;
   pointer-events: none;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .spin-border::before {
+    animation: spin-border 3.6s linear infinite;
+  }
 }
 
 .spin-border-info {
@@ -460,8 +465,10 @@ dialog[open]::backdrop {
   --spin-border-color: var(--color-primary);
 }
 
-.animate-border-pulse {
-  animation: border-pulse 2.8s ease-in-out infinite;
+@media (prefers-reduced-motion: no-preference) {
+  .animate-border-pulse {
+    animation: border-pulse 2.8s ease-in-out infinite;
+  }
 }
 
 .density-trigger-label {

--- a/packages/ui/src/__tests__/Button.test.tsx
+++ b/packages/ui/src/__tests__/Button.test.tsx
@@ -1,0 +1,32 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { Button } from '../components/Button';
+
+describe('Button', () => {
+  afterEach(cleanup);
+
+  it('shows a pulsing status dot while busy, never a spinner', () => {
+    const { container } = render(<Button isBusy>Save</Button>);
+    const button = screen.getByRole('button', { name: 'Save' });
+
+    expect(button.getAttribute('aria-busy')).toBe('true');
+    expect(container.querySelector('svg')).toBeNull();
+    expect(container.querySelector('.motion-safe\\:animate-pulse')).not.toBeNull();
+  });
+
+  it('keeps the busy label instead of the children when given one', () => {
+    render(
+      <Button isBusy busyLabel="Saving">
+        Save
+      </Button>,
+    );
+    expect(screen.getByRole('button', { name: 'Saving' })).toBeDefined();
+  });
+
+  it('disables the button while busy', () => {
+    render(<Button isBusy>Save</Button>);
+    expect(screen.getByRole('button', { name: 'Save' }).hasAttribute('disabled')).toBe(true);
+  });
+});

--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -1,6 +1,6 @@
 import type { ComponentProps } from 'react';
-import { Loader2 } from 'lucide-react';
 import { cn } from '../cn';
+import { StatusDot } from './StatusDot';
 
 export type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger' | 'warning';
 export type ButtonSize = 'sm' | 'md';
@@ -24,11 +24,6 @@ const variantClasses: Record<ButtonVariant, string> = {
 const sizeClasses: Record<ButtonSize, string> = {
   sm: 'h-7 px-2.5 text-xs',
   md: 'h-8 px-3 text-sm',
-};
-
-const spinnerSize: Record<ButtonSize, number> = {
-  sm: 11,
-  md: 13,
 };
 
 export const Button = ({
@@ -57,11 +52,7 @@ export const Button = ({
     >
       {isBusy ? (
         <>
-          <Loader2
-            size={spinnerSize[size]}
-            aria-hidden
-            className="motion-safe:animate-spin opacity-80"
-          />
+          <StatusDot tone="neutral" size={size} pulsing className="bg-current" />
           {busyLabel ?? children}
         </>
       ) : (


### PR DESCRIPTION
## What changed and why

`Button.isBusy` rendered `Loader2` with `motion-safe:animate-spin`, exactly the pattern `DESIGN.md` forbids: "Loading is a skeleton; running is a moving border. Spinners are forbidden. No `Loader2`."

Replaced it with the pulsing `StatusDot` primitive, the same one `DESIGN.md` names as the sanctioned "running" signal and the one already used in production at `WorkspaceRollupStrip`.

The other sanctioned primitive, a moving border (`.spin-border`), was ruled out deliberately: the button's disabled state already applies 50% opacity, and a 1px animated border on top of that pulses between roughly 37.5% and 10% effective opacity, near-invisible for a hairline stroke. The `ghost` variant is also borderless at rest (`border-0`), so a border animation would draw a ring that doesn't exist otherwise. A filled 8px dot stays legible through the same opacity range.

The dot uses `bg-current` so it inherits the button's own text color per variant (`primary-foreground` on solid fills, `foreground` on `secondary`/`ghost`), the same color the label already reads against, rather than hardcoding a tone that would wash out on some variants.

Separately, `apps/desktop/src/styles.css` defined `border-pulse` and `spin-border` unconditionally while their siblings (`attention-ring`, `fade-in`) were gated behind `prefers-reduced-motion`. Gated both the same way `.attention-ring` is gated: the class rule that applies the `animation` property now lives inside `@media (prefers-reduced-motion: no-preference)`, so a reduced-motion user gets no animation at all rather than the existing blanket 0.01ms flash-on-mount.

## Test plan

Ran verbatim from the worktree:

- `CI=1 corepack pnpm exec turbo run typecheck` → 5/5 packages successful.
- `CI=1 corepack pnpm exec turbo run test --force` → desktop: 610 test files / 5151 tests passed, 0 failed. ui: 21 test files / 106 tests passed, 0 failed (includes the new `Button.test.tsx`, 3/3).
- `CI=1 corepack pnpm knip --include files,duplicates,unlisted` → clean, only pre-existing config hints unrelated to this change.

Added `packages/ui/src/__tests__/Button.test.tsx`: asserts `isBusy` renders no `<svg>`, renders the pulsing dot (`.motion-safe\:animate-pulse`), sets `aria-busy`, respects `busyLabel`, and disables the button.

Added `apps/desktop/src/__tests__/regressions/no-loader2-in-ui-package.test.ts`: walks `packages/ui/src` and fails if any file references `Loader2`, so a reintroduced spinner in the shared `Button` primitive goes red immediately.

## What I could not verify

Did not run the app itself, no visual confirmation of the dot in a live window. Reasoned from `StatusDot`'s existing production usage and the `bg-current` override; both are mechanically sound but unobserved on screen.

## Deliberately left out of scope

- Did not sweep the ~52 `animate-border-pulse` call sites for `motion-safe:` — the class itself is now gated, and the call-site sweep was explicitly out of scope for this item.
- Did not touch `GhostActionButton` or `AssigneePicker`'s own `Loader2` usage; those are a separate concern per the item brief, and the regression test is scoped to `packages/ui/src` only for that reason (a blanket ban across `apps/desktop/src` would go red today on those two files, which is a different fix).
- Considered a moving-border approach first, per `DESIGN.md`'s naming both options; measured it out (see above) and judged the dot strictly better here, not just easier.