### PR TITLE
feat(desktop): open standalone workspaces to developers

### DIFF
--- a/apps/desktop/src/features/onboarding/OnboardingWizard/steps/WorkspaceStep.test.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/steps/WorkspaceStep.test.tsx
@@ -63,15 +63,27 @@ describe('WorkspaceStep', () => {
     window.removeEventListener('goodboy:add-workspace', onAddWorkspace);
   });
 
-  it('offers the repository paths to a developer', () => {
+  it('offers the repository paths and the standalone path to a developer', () => {
     render(<Harness workspace={null} />);
 
     fireEvent.click(screen.getByRole('button', { name: /I write code/ }));
 
     expect(screen.getByRole('heading', { name: 'Add workspace' })).toBeDefined();
     expect(screen.getByTestId('workspace-link-form').getAttribute('data-modes')).toBe(
-      'single,multi',
+      'single,multi,simple',
     );
+  });
+
+  it('tells a developer what standalone gives up until a code host is linked', () => {
+    render(<Harness workspace={null} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /I write code/ }));
+
+    expect(
+      screen.getByText(
+        /Standalone skips git: plain folders, no branch, no diff and no pull requests until you link a code host\./,
+      ),
+    ).toBeDefined();
   });
 
   it('keeps the form open after adding the first single-project workspace', () => {

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/steps/WorkspaceStep.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/steps/WorkspaceStep.tsx
@@ -23,7 +23,7 @@ const WORKSPACE_KIND_LABELS: Record<WorkspaceKind, string> = {
 };
 
 const AUDIENCE_MODES: Record<WorkspaceAudience, ReadonlyArray<WorkspaceLinkMode>> = {
-  developer: ['single', 'multi'],
+  developer: ['single', 'multi', 'simple'],
   'everyone-else': ['simple'],
 };
 
@@ -136,7 +136,7 @@ export const WorkspaceStep = ({
       title={workspace === null ? 'Add workspace' : 'Change workspace'}
       subtitle={
         audience === 'developer'
-          ? 'Point Goodboy at a repository, or link several of them into one workspace.'
+          ? 'Point Goodboy at a repository, or link several of them into one workspace. Standalone skips git: plain folders, no branch, no diff and no pull requests until you link a code host.'
           : 'Name the workspace and pick where its files live.'
       }
     >

--- a/apps/desktop/src/store/slices/worktrees/resolveSessionRepo.test.ts
+++ b/apps/desktop/src/store/slices/worktrees/resolveSessionRepo.test.ts
@@ -133,6 +133,18 @@ describe('resolveSessionRepo', () => {
     expect(result).toBeNull();
   });
 
+  it('keeps a converted workspace from resolving the sessions it created while standalone', () => {
+    const standalone = buildState({
+      workspace: buildWorkspace({ kind: 'simple' }),
+      worktrees: ['/sessions/session-1'],
+      branch: '',
+    });
+    const converted = { ...standalone, workspaces: [buildWorkspace({ kind: 'repo' })] };
+
+    expect(resolveSessionRepo({ state: standalone, sessionId: SESSION_ID })).toBeNull();
+    expect(resolveSessionRepo({ state: converted, sessionId: SESSION_ID })).toBeNull();
+  });
+
   it('uses the first composite mount when no active mount is explicit', () => {
     const result = resolveSessionRepo({
       state: buildState({

--- a/apps/desktop/src/store/slices/worktrees/resolveSessionRepo.ts
+++ b/apps/desktop/src/store/slices/worktrees/resolveSessionRepo.ts
@@ -1,4 +1,5 @@
 import type { SessionId, WorkspaceId } from '@goodboy/types';
+import { isBranchlessSession } from '../../../shared/utils/isBranchlessSession';
 import type { AppState } from '../../types';
 
 export type SessionRepo = Readonly<{
@@ -59,10 +60,14 @@ export const resolveSessionRepo = ({ state, sessionId }: ResolveParams): Session
   if (worktreePath == null) {
     return null;
   }
+  const branch = state.sessionBranches[sessionId];
+  if (isBranchlessSession({ workspaceKind: workspace.kind, branch })) {
+    return null;
+  }
   return {
     repoRoot: workspace.rootPath,
     worktreePath,
-    branch: state.sessionBranches[sessionId] ?? '',
+    branch: branch ?? '',
     mountName: null,
     workspaceId: workspace.id,
   };


### PR DESCRIPTION
A repo-less workspace already runs without git in Goodboy: the `simple` kind
creates sessions as plain directories, and `ConvertWorkspaceDialog` plus
`convertWorkspaceToRepo` are the link-a-code-host transition. It was only
hidden from developers.

## Standalone is on the developer path

`AUDIENCE_MODES` in the onboarding workspace step gave `developer` only
`single` and `multi`. It now gives `simple` too, so a developer who does not
have a repository yet can start anyway.

The step says what that costs, at the moment of the choice rather than after
the fact:

> Point Goodboy at a repository, or link several of them into one workspace.
> Standalone skips git: plain folders, no branch, no diff and no pull requests
> until you link a code host.

The git-ready gate on the stage board was already inert for this kind:
`useWorkspaceGitStatus` returns `null` before polling when the workspace is
`simple`, and `StageBoard` treats a `null` status as ready. No change was
needed there.

## A converted workspace stops mis-resolving its old sessions

`session_dir` returns an empty `branch_name` for a standalone session, and
that empty string lands in `sessionBranches`. `resolveSessionRepo` refused
those sessions by reading `workspace.kind === 'simple'`, which is the current
kind: once `convertWorkspaceToRepo` flips the workspace to `repo`, the older
sessions fell through to the generic branch and came back as a real
`SessionRepo` carrying `branch: ''`.

Fourteen actions reached through `getSessionRepo` drive git or pull request
writes (`createPrForSession`, `pushSessionBranch`, `mergePr`, `closePr`,
`reopenPr`, `editPr`, `requestReview`, `markPrReady`, `convertPrToDraft`,
`reconcileSessionBranch`, `resolveMrContext`, `resolveBitbucketPrContext`,
`publishPrReview` and the branch change path). Each of them already refuses a
`null` repo, so the generic branch now runs `isBranchlessSession` on the
resolved branch and returns `null`, the same answer a standalone session
already got.

## What this does not do

It does not move an existing standalone session into a worktree. Conversion
stays forward-only, which is what the dialog's own copy promises: sessions
created before the link keep working as plain folders and nothing is
auto-committed. New sessions created after the link get a branch and a
worktree. The issue title can read as a per-session migration, and that is not
here.

## Test plan

- `CI=1 corepack pnpm exec turbo run typecheck`: 5 successful, 5 total.
- `CI=1 corepack pnpm exec turbo run test --force`: 5152 desktop tests, 5141
  passed and 11 failed on a loaded machine, all of them 15s timeouts in
  `store.sendturn-agent-routing`, `github`, `integrations`, `session-view` and
  `workspaces` store contract files. Re-running those five files alone:
  186 passed, 0 failed. `packages/db` `registry.test.ts` times out the same
  way (30s limit, 107s elapsed) on this machine; that file is untouched here
  and the branch changes nothing under `packages/db`.
- `CI=1 corepack pnpm knip --include files,duplicates,unlisted`: no findings,
  only the six pre-existing configuration hints.
- `resolveSessionRepo.test.ts` gained a case that walks a session through the
  kind flip. Reverting the resolver and keeping the test makes it fail on the
  converted state, which is the shape the fix is for.

## Not verified

The app was not launched. The onboarding copy and the standalone tab on the
developer path were checked through the step's tests, not on screen. No
conversion was run against a real folder.

Closes #1300
