### PR TITLE
fix(desktop): restore layout rules on five creation surfaces

### DIFF
--- a/apps/desktop/src/app/components/AppFooter/IntegrationAddPopover.tsx
+++ b/apps/desktop/src/app/components/AppFooter/IntegrationAddPopover.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { cn, Popover, Tooltip } from '@goodboy/ui';
+import { cn, Popover, ScrollFade, Tooltip } from '@goodboy/ui';
 import { Plus } from 'lucide-react';
 import type { IntegrationGlyphProvider } from '../../../features/integrations/components/IntegrationGlyph';
 import type { FooterIntegrationEntry } from './categories';
@@ -138,27 +138,25 @@ export const IntegrationAddPopover = ({
               <Popover
                 role="dialog"
                 ariaLabel={panelLabel}
-                className="fixed z-popover w-56"
+                className="fixed z-popover flex max-h-60 w-56 flex-col"
                 style={{
                   top: coordinates.top,
                   bottom: coordinates.bottom,
                   left: coordinates.left,
                 }}
               >
-                <ul
-                  aria-label={panelLabel}
-                  className="flex flex-col overflow-y-auto py-1"
-                  style={{ maxHeight: PANEL_MAX_HEIGHT }}
-                >
-                  {members.map((member) => (
-                    <IntegrationAddRow
-                      key={member.provider}
-                      member={member}
-                      connected={enabled[member.provider]}
-                      onSelect={() => select(member.provider)}
-                    />
-                  ))}
-                </ul>
+                <ScrollFade className="min-h-0 flex-1" viewportClassName="py-1" fadeSize={12}>
+                  <ul aria-label={panelLabel} className="flex flex-col">
+                    {members.map((member) => (
+                      <IntegrationAddRow
+                        key={member.provider}
+                        member={member}
+                        connected={enabled[member.provider]}
+                        onSelect={() => select(member.provider)}
+                      />
+                    ))}
+                  </ul>
+                </ScrollFade>
               </Popover>
             </>,
             document.body,

--- a/apps/desktop/src/features/budget/components/BudgetStudio/CapEditor.tsx
+++ b/apps/desktop/src/features/budget/components/BudgetStudio/CapEditor.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { Trash2 } from 'lucide-react';
-import { Button, InlineConfirm, Input, formatUsd } from '@goodboy/ui';
+import { Button, Divider, InlineConfirm, Input, formatUsd } from '@goodboy/ui';
 import { parseCap } from '../../../../shared/lib/parse-cap';
 import { StudioWidget } from '../../../../shared/components/StudioWidget';
 
@@ -164,39 +164,42 @@ export const CapEditor = ({
         ) : null}
       </div>
       {threshold !== undefined && currentCapUsd !== null ? (
-        <div className="flex flex-col gap-2 border-t border-border-soft pt-3">
-          <div className="flex items-center gap-2">
-            <span className="text-sm text-muted-foreground">at</span>
-            <Input
-              type="text"
-              inputMode="numeric"
-              value={thresholdDraft}
-              placeholder="80"
-              disabled={busy}
-              onChange={(e) => setThresholdDraft(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' && canSaveThreshold && !busy) {
-                  void saveThreshold();
-                }
-              }}
-              className="max-w-20 font-mono tabular-nums"
-              aria-label="alert threshold percent"
-            />
-            <span className="text-sm text-muted-foreground">% of the cap</span>
-            <Button
-              variant="secondary"
-              size="sm"
-              disabled={!canSaveThreshold || busy}
-              onClick={() => void saveThreshold()}
-            >
-              Update threshold
-            </Button>
+        <>
+          <Divider />
+          <div className="flex flex-col gap-2">
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-muted-foreground">at</span>
+              <Input
+                type="text"
+                inputMode="numeric"
+                value={thresholdDraft}
+                placeholder="80"
+                disabled={busy}
+                onChange={(e) => setThresholdDraft(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && canSaveThreshold && !busy) {
+                    void saveThreshold();
+                  }
+                }}
+                className="max-w-20 font-mono tabular-nums"
+                aria-label="alert threshold percent"
+              />
+              <span className="text-sm text-muted-foreground">% of the cap</span>
+              <Button
+                variant="secondary"
+                size="sm"
+                disabled={!canSaveThreshold || busy}
+                onClick={() => void saveThreshold()}
+              >
+                Update threshold
+              </Button>
+            </div>
+            <p className="text-2xs text-muted-foreground">
+              this number does two things: it raises the budget alert, and it moves the next turn to
+              another provider. spend above it still runs here if no other provider has room.
+            </p>
           </div>
-          <p className="text-2xs text-muted-foreground">
-            this number does two things: it raises the budget alert, and it moves the next turn to
-            another provider. spend above it still runs here if no other provider has room.
-          </p>
-        </div>
+        </>
       ) : null}
     </StudioWidget>
   );

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel/CreateMrForm.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel/CreateMrForm.tsx
@@ -5,6 +5,7 @@ import {
   Divider,
   FieldRow,
   Input,
+  ScrollFade,
   SectionHeader,
   SegmentedTabs,
   Textarea,
@@ -137,88 +138,95 @@ export const CreateMrForm = ({ sessionId, branch, error, onClose }: Props) => {
   };
 
   return (
-    <section className="flex flex-col gap-6">
-      <section className="flex flex-col">
-        <SectionHeader
-          label="How"
-          hint="Fill the merge request yourself, or hand it to an agent that drafts and opens it."
-          action={
-            <SegmentedTabs
-              ariaLabel="Creation mode"
-              size="sm"
-              options={[
-                { value: 'manual', label: 'Manual', icon: PenLine },
-                { value: 'agent', label: 'With an agent', icon: Sparkles },
-              ]}
-              value={mode}
-              onChange={setMode}
+    <div className="flex min-h-0 flex-1 flex-col">
+      <ScrollFade className="min-h-0 flex-1" viewportClassName="px-6 py-5" fadeSize={24}>
+        <section className="mx-auto flex w-full max-w-2xl flex-col gap-6">
+          <section className="flex flex-col">
+            <SectionHeader
+              label="How"
+              hint="Fill the merge request yourself, or hand it to an agent that drafts and opens it."
+              action={
+                <SegmentedTabs
+                  ariaLabel="Creation mode"
+                  size="sm"
+                  options={[
+                    { value: 'manual', label: 'Manual', icon: PenLine },
+                    { value: 'agent', label: 'With an agent', icon: Sparkles },
+                  ]}
+                  value={mode}
+                  onChange={setMode}
+                />
+              }
             />
-          }
-        />
-        {mode === 'manual' ? (
-          <>
-            <FieldRow label="Title" help="A short summary of the change.">
-              <Input
-                value={title}
-                onChange={(e) => setTitle(e.target.value)}
-                disabled={busy !== null}
-                aria-label="Merge request title"
-                className="h-8 w-full text-sm sm:w-96"
-              />
-            </FieldRow>
+            {mode === 'manual' ? (
+              <>
+                <FieldRow label="Title" help="A short summary of the change.">
+                  <Input
+                    value={title}
+                    onChange={(e) => setTitle(e.target.value)}
+                    disabled={busy !== null}
+                    aria-label="Merge request title"
+                    className="h-8 w-full text-sm sm:w-96"
+                  />
+                </FieldRow>
+                <Divider />
+                <FieldRow label="Description" help="What changed and why. Markdown supported.">
+                  <Textarea
+                    value={description}
+                    onChange={(e) => setDescription(e.target.value)}
+                    autoGrow
+                    minRows={3}
+                    maxRows={10}
+                    disabled={busy !== null}
+                    aria-label="Merge request description"
+                    className="w-full text-sm sm:w-96"
+                  />
+                </FieldRow>
+                <Divider />
+                <FieldRow label="Target branch" help="The branch this merge request merges into.">
+                  <Input
+                    value={targetBranch}
+                    onChange={(e) => setTargetBranch(e.target.value)}
+                    placeholder="main"
+                    className="h-8 w-full font-mono text-sm sm:w-96"
+                    disabled={busy !== null}
+                    autoCapitalize="off"
+                    autoCorrect="off"
+                    spellCheck={false}
+                    aria-label="Target branch"
+                  />
+                </FieldRow>
+              </>
+            ) : (
+              <FieldRow
+                label="Agent"
+                layout="stacked"
+                help="Routing and optional notes for the agent that drafts the title and description, then opens the merge request."
+              >
+                <AgentSpawnConfig
+                  value={agentConfig}
+                  onChange={(value) => {
+                    setAgentConfigUserTouched(true);
+                    setAgentConfig(value);
+                  }}
+                  disabled={busy !== null}
+                />
+              </FieldRow>
+            )}
             <Divider />
-            <FieldRow label="Description" help="What changed and why. Markdown supported.">
-              <Textarea
-                value={description}
-                onChange={(e) => setDescription(e.target.value)}
-                autoGrow
-                minRows={3}
-                maxRows={10}
-                disabled={busy !== null}
-                aria-label="Merge request description"
-                className="w-full text-sm sm:w-96"
-              />
+            <FieldRow
+              label="Open as draft"
+              help="Creates the merge request in GitLab's draft state."
+            >
+              <Checkbox checked={draft} onChange={setDraft} disabled={busy !== null} />
             </FieldRow>
-            <Divider />
-            <FieldRow label="Target branch" help="The branch this merge request merges into.">
-              <Input
-                value={targetBranch}
-                onChange={(e) => setTargetBranch(e.target.value)}
-                placeholder="main"
-                className="h-8 w-full font-mono text-sm sm:w-96"
-                disabled={busy !== null}
-                autoCapitalize="off"
-                autoCorrect="off"
-                spellCheck={false}
-                aria-label="Target branch"
-              />
-            </FieldRow>
-          </>
-        ) : (
-          <FieldRow
-            label="Agent"
-            layout="stacked"
-            help="Routing and optional notes for the agent that drafts the title and description, then opens the merge request."
-          >
-            <AgentSpawnConfig
-              value={agentConfig}
-              onChange={(value) => {
-                setAgentConfigUserTouched(true);
-                setAgentConfig(value);
-              }}
-              disabled={busy !== null}
-            />
-          </FieldRow>
-        )}
-        <Divider />
-        <FieldRow label="Open as draft" help="Creates the merge request in GitLab's draft state.">
-          <Checkbox checked={draft} onChange={setDraft} disabled={busy !== null} />
-        </FieldRow>
-      </section>
+          </section>
+        </section>
+      </ScrollFade>
 
       <Divider />
 
-      <footer className="flex shrink-0 items-center gap-3">
+      <footer className="flex shrink-0 items-center gap-3 px-6 py-3">
         <div className="flex min-w-0 flex-1 items-center gap-3">
           {error != null ? (
             <span
@@ -263,6 +271,6 @@ export const CreateMrForm = ({ sessionId, branch, error, onClose }: Props) => {
           </Button>
         )}
       </footer>
-    </section>
+    </div>
   );
 };

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel/index.test.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel/index.test.tsx
@@ -177,6 +177,23 @@ describe('MrDetailPanel', () => {
     );
   });
 
+  it('keeps the create button outside the scrolling region', () => {
+    render(<MrDetailPanel sessionId={SESSION_ID} onClose={vi.fn()} />);
+
+    const button = screen.getByRole('button', { name: 'Create MR' });
+    const scrollAncestors: Array<HTMLElement> = [];
+    let current: HTMLElement | null = button.parentElement;
+    while (current != null) {
+      if (current.className.includes('overflow-y-auto')) {
+        scrollAncestors.push(current);
+      }
+      current = current.parentElement;
+    }
+
+    expect(scrollAncestors).toEqual([]);
+    expect(button.closest('footer')).not.toBeNull();
+  });
+
   it('respects the draft toggle on manual create', async () => {
     render(<MrDetailPanel sessionId={SESSION_ID} onClose={vi.fn()} />);
     fireEvent.change(screen.getByRole('textbox', { name: 'Merge request title' }), {

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel/index.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel/index.tsx
@@ -5,7 +5,6 @@ import type { GitlabWorkspaceIntegration, SessionId, WorkspaceId } from '@goodbo
 import {
   DetailSection,
   HeaderBand,
-  RailBlock,
   StudioDetailLayout,
   StudioDetailTabs,
 } from '../../../../../shared/components/StudioDetail';
@@ -378,11 +377,7 @@ export const MrDetailPanel = ({
           actions={refreshButton}
         />
       }
-      rail={
-        <RailBlock label="Branch">
-          <span className="font-mono">{branch ?? 'no branch'}</span>
-        </RailBlock>
-      }
+      fit="bleed"
     >
       {sessionId != null && (
         <CreateMrForm sessionId={sessionId} branch={branch} error={error} onClose={onClose} />

--- a/apps/desktop/src/features/scripts/components/ScriptsPanel/NewScriptCard.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsPanel/NewScriptCard.tsx
@@ -20,33 +20,35 @@ export const NewScriptCard = ({
   onSave,
   onCancel,
 }: Props) => (
-  <div className="flex flex-col rounded-lg border border-border-soft bg-background px-3">
-    <FieldRow label="Name">
-      <Input
-        value={name}
-        onChange={(event) => onNameChange(event.target.value)}
-        placeholder="Script name (e.g. copy environments)"
-        autoFocus
-        className="w-full sm:w-72"
-      />
-    </FieldRow>
+  <section className="flex flex-col gap-6">
+    <section className="flex flex-col">
+      <FieldRow label="Name">
+        <Input
+          value={name}
+          onChange={(event) => onNameChange(event.target.value)}
+          placeholder="Script name (e.g. copy environments)"
+          autoFocus
+          className="w-full sm:w-72"
+        />
+      </FieldRow>
+      <Divider />
+      <FieldRow label="Command" help="Runs from the session worktree.">
+        <Textarea
+          value={body}
+          onChange={(event) => onBodyChange(event.target.value)}
+          placeholder={'#!/bin/bash\ncp ../main/.env .env'}
+          className="w-full font-mono text-xs sm:w-96"
+          autoGrow
+          minRows={5}
+          maxRows={24}
+          spellCheck={false}
+          autoCorrect="off"
+          autoCapitalize="off"
+        />
+      </FieldRow>
+    </section>
     <Divider />
-    <FieldRow label="Command" help="Runs from the session worktree.">
-      <Textarea
-        value={body}
-        onChange={(event) => onBodyChange(event.target.value)}
-        placeholder={'#!/bin/bash\ncp ../main/.env .env'}
-        className="w-full font-mono text-xs sm:w-96"
-        autoGrow
-        minRows={5}
-        maxRows={24}
-        spellCheck={false}
-        autoCorrect="off"
-        autoCapitalize="off"
-      />
-    </FieldRow>
-    <Divider />
-    <footer className="flex shrink-0 items-center gap-3 py-3">
+    <footer className="flex shrink-0 items-center gap-3">
       <div className="min-w-0 flex-1">
         {error !== null ? (
           <span role="alert" className="inline-flex items-center gap-1 text-xs text-danger">
@@ -62,5 +64,5 @@ export const NewScriptCard = ({
         Save
       </Button>
     </footer>
-  </div>
+  </section>
 );

--- a/apps/desktop/src/features/settings/components/GuideStudio/parts/TokensSection.tsx
+++ b/apps/desktop/src/features/settings/components/GuideStudio/parts/TokensSection.tsx
@@ -60,7 +60,7 @@ export const TokensSection = ({}: Props) => (
           Reserve for hard reasoning, refactors, last-resort fixes.
         </Tile>
       </div>
-      <p className="mt-3 text-2xs leading-relaxed text-muted-foreground/70">
+      <p className="text-2xs leading-relaxed text-muted-foreground/70">
         The picker sorts <strong className="font-semibold text-foreground">cheapest first</strong>{' '}
         on purpose. Switching down a tier often costs nothing in quality on routine tasks.
       </p>


### PR DESCRIPTION
## What changed and why

Five places where the code drifted from a layout rule the repo already writes down. Each fix restores the documented rule, not a taste call.

1. **GitLab merge-request form loses its submit button.** `MrDetailPanel`'s "New merge request" state mounted `CreateMrForm` inside `StudioDetailLayout` with no `fit`, defaulting to `fit="fill"`. That put the footer inside the scrolling body, so on a long form (agent routing expanded, draft checkbox) the Create button scrolled out of reach. `CreateMrForm` now owns its own `ScrollFade` and renders the footer as a sibling after it, mirroring `CreatePrPanel` (`apps/desktop/src/features/github/components/GitHubStudio/CreatePrPanel.tsx`), and `MrDetailPanel` mounts it with `fit="bleed"`, same as `PrDetailPanel.tsx:458`. The redundant `rail` (a `RailBlock` repeating the branch already shown in the header meta) was dropped since `fit="bleed"` doesn't render `rail`, matching the GitHub precedent.
   Rule: DESIGN.md, "One creation grammar" — *"One footer closes the surface: the error on the left, exactly one primary button on the right."*

2. **New-script form wrapped in the bordered box the doc forbids by name.** `NewScriptCard` was `<div className="... rounded-lg border border-border-soft bg-background px-3">`. Unwrapped to bare stacked sections (`<section className="flex flex-col gap-6">` with an inner fields section), matching `CreateMrForm`/`CreatePrPanel`.
   Rule: DESIGN.md, "One creation grammar" — *"The form is bare sections stacked in one column, never a bordered box wrapped around the whole thing."*

3. **A container border doing a divider's job.** `CapEditor`'s alert-threshold block used `border-t border-border-soft pt-3` to separate itself from the cap-input row, on top of the parent's own `gap-3`. Replaced with a `<Divider />` sibling.
   Rule: `docs/styling.md`, "Dividers between regions, never container borders."

4. **A raw scroller where `ScrollFade` is the rule.** `IntegrationAddPopover`'s member list was a bare `<ul className="... overflow-y-auto ...">` with an inline `maxHeight`. `ScrollFade` has no max-height prop, so the height bound moved to the `Popover` parent (`className="flex max-h-60 flex-col"`, matching the existing `PlanProvenance.tsx` popover pattern), with `ScrollFade` filling it via `min-h-0 flex-1`.
   Rule: `docs/styling.md`, "Scroll edges fade, never hard-cut" — *"Raw `overflow-y-auto` is forbidden."*

5. **A margin doubling the parent's gap.** `TokensSection`'s cost-colors caption had `mt-3` while already living inside `Block`'s `flex flex-col gap-3`. Dropped the margin.
   Rule: `docs/styling.md`, "Separation: `gap`, never margin" (also `AGENTS.md`/house rules: "Separation is `gap` on the parent. No margins... for separation.").

## Test plan

Added a structural test to `MrDetailPanel/index.test.tsx`: `keeps the create button outside the scrolling region`, which walks the Create MR button's ancestor chain and asserts none carries `overflow-y-auto`, and that the button is inside a `<footer>`. This mirrors the existing precedent in `apps/desktop/src/shared/components/StudioDetail/index.test.tsx` (`scrollAncestors` pattern), which is the same technique used to assert `StudioDetailLayout`'s dock stays outside scroll regions.

No test was added for `NewScriptCard`, `IntegrationAddPopover`, or `TokensSection`: each of those changes is purely visual (container vs. bare section, divider vs. border, margin vs. gap) with no behavioral surface to assert without testing a class name, which the repo bans.

Ran, verbatim:
- `CI=1 corepack pnpm exec turbo run typecheck` → 5 successful, 5 total.
- `CI=1 corepack pnpm exec turbo run test --force` → 608 test files passed, 1 failed on first run (`ReviewFileDiff.test.tsx > still truncates a long file behind the show more bar`, a 15s timeout under full-suite parallel load). Re-ran that file alone: `CI=1 corepack pnpm exec vitest run src/features/review/components/ReviewBoardPane/ReviewFileDiff.test.tsx` → 8 passed. That file is untouched by this PR (review diff rendering, unrelated feature); the timeout is a load flake, not a regression from this change.
- `CI=1 corepack pnpm knip --include files,duplicates,unlisted` → clean, only pre-existing config hints.

## What I could not verify

Did not run the app; cannot confirm visually that the GitLab Create button stays pinned or that the popover scrolls correctly on a real screen. The structural test is the verification available in this environment.

## Left out of scope

Nothing else in the five target files was touched. `MrInbox.tsx` and the other four sibling-owned files (`Button.tsx`, `styles.css`, `summarizer/`, `sendTurn.ts`, `resolveSessionRepo.ts`, `WorkspaceStep.tsx`) were not touched.