### PR TITLE
feat(desktop): mark outdated review comments on thread heads

### DIFF
--- a/apps/desktop/src/features/github/components/GitHubStudio/OpenThread.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/OpenThread.tsx
@@ -1,4 +1,5 @@
 import { ExternalLink } from 'lucide-react';
+import { Chip } from '@goodboy/ui';
 import type { CommentThread } from '../../comment-threads';
 import { isBot } from '../../comment-threads';
 import {
@@ -42,6 +43,14 @@ export const OpenThread = ({ thread, link, onOpenUrl }: Props) => {
         ) : null}
         {link ? (
           <ResolverStateBadge state={resolverBadgeState(link.status)} className="ml-1" />
+        ) : null}
+        {head.outdated === true ? (
+          <Chip
+            tone="neutral"
+            size="xs"
+            label="Outdated"
+            title="This comment is anchored to code that later commits changed"
+          />
         ) : null}
         <button
           type="button"

--- a/apps/desktop/src/features/github/components/GitHubStudio/PrConversation.test.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/PrConversation.test.tsx
@@ -75,4 +75,9 @@ describe('PrConversation', () => {
     ]);
     expect(screen.getAllByText('Outdated').length).toBe(1);
   });
+
+  it('marks an outdated resolved thread', () => {
+    renderConversation([comment({ resolved: true, outdated: true })]);
+    expect(screen.getByText('Outdated')).toBeDefined();
+  });
 });

--- a/apps/desktop/src/features/github/components/GitHubStudio/PrConversation.test.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/PrConversation.test.tsx
@@ -67,4 +67,12 @@ describe('PrConversation', () => {
     fireEvent.click(screen.getByRole('button', { name: '3 replies' }));
     expect(screen.getByText('third reply')).toBeDefined();
   });
+
+  it('marks an outdated open thread but not a fresh one', () => {
+    renderConversation([
+      comment({ id: 'c1', threadId: 't1', outdated: true }),
+      comment({ id: 'c2', threadId: 't2', outdated: false }),
+    ]);
+    expect(screen.getAllByText('Outdated').length).toBe(1);
+  });
 });

--- a/apps/desktop/src/features/github/components/GitHubStudio/ResolveBoard/ResolveCard.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/ResolveBoard/ResolveCard.tsx
@@ -1,5 +1,5 @@
 import type { AgentId, ProviderId } from '@goodboy/types';
-import { Checkbox, cn } from '@goodboy/ui';
+import { Checkbox, Chip, cn } from '@goodboy/ui';
 import { ArrowUpRight, ChevronDown, ExternalLink, RotateCcw, Sparkles } from 'lucide-react';
 import { modelEffortLevels } from '../../../../chat/utils/chat-constants';
 import { RoutingBadge } from '../../../../../shared/components/RoutingBadge';
@@ -62,6 +62,14 @@ export const ResolveCard = ({
             <span className="font-medium text-foreground">{head.author}</span>
             <span className="opacity-50">·</span>
             <span className="min-w-0 truncate font-mono text-2xs">{loc}</span>
+            {head.outdated === true ? (
+              <Chip
+                tone="neutral"
+                size="xs"
+                label="Outdated"
+                title="This comment is anchored to code that later commits changed"
+              />
+            ) : null}
             <div className="ml-auto flex shrink-0 items-center gap-1.5">
               {link ? <ResolverStateBadge state={resolverBadgeState(link.status)} /> : null}
               {onOpenThread ? (

--- a/apps/desktop/src/features/github/components/GitHubStudio/ResolveBoard/index.test.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/ResolveBoard/index.test.tsx
@@ -288,6 +288,23 @@ describe('ResolveBoard', () => {
     expect(screen.getByText('bob')).toBeDefined();
   });
 
+  it('marks an outdated thread but not a fresh one', () => {
+    render(
+      <ResolveBoard
+        roleModels={null}
+        threads={[
+          thread({ id: 'c1', outdated: true }),
+          thread({ id: 'c2', threadId: 'PRRT_2', outdated: false }),
+        ]}
+        onSpawnOne={vi.fn()}
+        onSpawnBatch={vi.fn()}
+        onSpawnCombined={vi.fn()}
+        onOpenThread={vi.fn()}
+      />,
+    );
+    expect(screen.getAllByText('Outdated').length).toBe(1);
+  });
+
   it('renders an empty state when there are no open comments', () => {
     render(
       <ResolveBoard

--- a/apps/desktop/src/features/github/components/GitHubStudio/ResolvedThread.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/ResolvedThread.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { CheckCheck, ExternalLink } from 'lucide-react';
+import { Chip } from '@goodboy/ui';
 import type { CommentThread } from '../../comment-threads';
 import { isBot } from '../../comment-threads';
 import { TranscriptDisclosure } from '../../../chat/components/TranscriptDisclosure';
@@ -32,7 +33,17 @@ export const ResolvedThread = ({ thread, onOpenUrl }: Props) => {
           icon={<CheckCheck size={12} aria-hidden />}
           eyebrow="resolved"
           badge={
-            <span className="shrink-0 text-2xs font-medium text-foreground/70">{head.author}</span>
+            <span className="flex shrink-0 items-center gap-1.5">
+              <span className="text-2xs font-medium text-foreground/70">{head.author}</span>
+              {head.outdated === true ? (
+                <Chip
+                  tone="neutral"
+                  size="xs"
+                  label="Outdated"
+                  title="This comment is anchored to code that later commits changed"
+                />
+              ) : null}
+            </span>
           }
           preview={threadPreview({ body: head.body })}
           meta={formatRelativeAge({ fromIso: head.createdAt })}

--- a/packages/core/src/github/__tests__/details.test.ts
+++ b/packages/core/src/github/__tests__/details.test.ts
@@ -115,7 +115,7 @@ describe('fetchPrDetail', () => {
                     {
                       id: 'PRT_X',
                       isResolved: true,
-                      isOutdated: false,
+                      isOutdated: true,
                       path: 'pkg/a.ts',
                       line: 10,
                       comments: {
@@ -156,6 +156,7 @@ describe('fetchPrDetail', () => {
     const detail = await fetchPrDetail(runner, 'org/repo', 1);
     expect(detail.comments).toHaveLength(2);
     expect(detail.comments.every((c) => c.resolved === true)).toBe(true);
+    expect(detail.comments.every((c) => c.outdated === true)).toBe(true);
     expect(detail.comments[1]!.inReplyToId).toBe('review-1');
   });
 

--- a/packages/core/src/github/__tests__/details.test.ts
+++ b/packages/core/src/github/__tests__/details.test.ts
@@ -98,6 +98,7 @@ describe('fetchPrDetail', () => {
     expect(detail.comments[1]!.path).toBe('src/foo.ts');
     expect(detail.comments[1]!.line).toBe(42);
     expect(detail.comments[1]!.resolved).toBe(false);
+    expect(detail.comments[1]!.outdated).toBe(false);
     expect(detail.comments[1]!.threadId).toBe('PRT_1');
   });
 

--- a/packages/core/src/github/details.ts
+++ b/packages/core/src/github/details.ts
@@ -267,6 +267,7 @@ async function fetchReviewThreads(
           path: t.path ?? undefined,
           line: t.line ?? undefined,
           resolved: t.isResolved,
+          outdated: t.isOutdated,
           inReplyToId: c.replyTo?.id
             ? (nodeIdToCommentId.get(c.replyTo.id) ?? undefined)
             : undefined,

--- a/packages/types/src/github.ts
+++ b/packages/types/src/github.ts
@@ -129,16 +129,13 @@ export type PrComment = {
   path?: string;
   line?: number;
   resolved?: boolean;
+  outdated?: boolean;
   inReplyToId?: string;
   threadId?: string;
 };
 
 export type PrReviewState =
-  | 'approved'
-  | 'changes_requested'
-  | 'commented'
-  | 'dismissed'
-  | 'pending';
+  'approved' | 'changes_requested' | 'commented' | 'dismissed' | 'pending';
 
 export type PrReview = {
   id: string;


### PR DESCRIPTION
## What

GitHub already tells us when a review thread is anchored to code a later commit superseded (`isOutdated` on the GraphQL review thread node, already fetched in `packages/core/src/github/details.ts`). Until now that fact was fetched and dropped: no surface in Goodboy could show it.

This PR:
- adds `outdated?: boolean` to `PrComment` (`packages/types/src/github.ts`)
- maps `t.isOutdated` onto it in the review-thread push loop (`packages/core/src/github/details.ts`)
- renders a neutral, labelled "Outdated" mark on the thread head on the two surfaces a user lands on: the PR conversation (`OpenThread.tsx`, `ResolvedThread.tsx`) and the resolve board (`ResolveBoard/ResolveCard.tsx`)

## Why

GitHub's own review UI has marked outdated threads for years. A user coming from that tab and not seeing the same signal here reads the absence as concealment, and has no way to tell a live comment from a stale one before spending a resolver agent on it.

## Design

Shared `Chip` from `packages/ui`, `tone="neutral"` (the same `bg-muted text-muted-foreground` treatment as the "previously reviewed" pill in `DiffViewerDialog/FileDiffCard.tsx`), word label ("Outdated", never icon-only, never all caps), with a tooltip explaining what it means. Not `warning`: outdated is informational, not an error.

## Scope

Marking only. Deliberately did not:
- feed `outdated` into the resolver agent's prompt
- collapse or hide outdated threads
- change the resolve-all default selection (excluding outdated threads there was argued and deliberately deferred elsewhere)
- touch GitLab/Bitbucket, `AgentInspector` resolver cards, or `chat/components/ResolverThreadsCard`

## Tests

- `packages/core/src/github/__tests__/details.test.ts`: extended "propagates resolved status and reply threading from review threads" to set `isOutdated: true` on the fixture and assert `outdated === true` on the mapped comments.
- `apps/desktop/.../PrConversation.test.tsx`: new case rendering one outdated and one fresh open thread, asserting exactly one "Outdated" mark.
- `apps/desktop/.../ResolveBoard/index.test.tsx`: new case, same assertion on the resolve board.

## Verification

- `pnpm typecheck`: pass (5/5 packages)
- `pnpm exec turbo run test --force`: pass (4/4 packages, no cache reuse)
- `pnpm knip --include files,duplicates,unlisted`: pass, no new violations

## Not verified

No manual run against a live PR with an actual outdated thread; verified via unit/render tests only.