### PR TITLE
fix(desktop): bring resolve and diff surfaces to the design floor

### DIFF
--- a/apps/desktop/src/__tests__/regressions/attention-ring-is-finite.test.ts
+++ b/apps/desktop/src/__tests__/regressions/attention-ring-is-finite.test.ts
@@ -11,7 +11,7 @@ const findNoPreferenceRanges = ({ lines }: { lines: ReadonlyArray<string> }) => 
   let depth = 0;
   let activeStart: number | null = null;
   for (let index = 0; index < lines.length; index += 1) {
-    const line = lines[index];
+    const line = lines[index] ?? '';
     const opensNoPreference =
       depth === 0 &&
       line.includes('@media') &&

--- a/apps/desktop/src/__tests__/regressions/attention-ring-is-finite.test.ts
+++ b/apps/desktop/src/__tests__/regressions/attention-ring-is-finite.test.ts
@@ -4,6 +4,48 @@ import { describe, expect, it } from 'vitest';
 
 const STYLES_CSS = join(__dirname, '..', '..', 'styles.css');
 
+type NoPreferenceRange = { readonly start: number; readonly end: number };
+
+const findNoPreferenceRanges = ({ lines }: { lines: ReadonlyArray<string> }) => {
+  const ranges: NoPreferenceRange[] = [];
+  let depth = 0;
+  let activeStart: number | null = null;
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    const opensNoPreference =
+      depth === 0 &&
+      line.includes('@media') &&
+      line.includes('prefers-reduced-motion: no-preference');
+    if (opensNoPreference) {
+      activeStart = index;
+    }
+    const opens = (line.match(/{/g) ?? []).length;
+    const closes = (line.match(/}/g) ?? []).length;
+    depth += opens - closes;
+    if (activeStart !== null && depth === 0) {
+      ranges.push({ start: activeStart, end: index });
+      activeStart = null;
+    }
+  }
+  return ranges;
+};
+
+const findDeclarationLine = ({
+  lines,
+  animationName,
+}: {
+  lines: ReadonlyArray<string>;
+  animationName: string;
+}) => lines.findIndex((line) => line.includes('animation:') && line.includes(animationName));
+
+const isInsideAnyRange = ({
+  lineIndex,
+  ranges,
+}: {
+  lineIndex: number;
+  ranges: ReadonlyArray<NoPreferenceRange>;
+}) => ranges.some((range) => lineIndex >= range.start && lineIndex <= range.end);
+
 describe('attention-ring animation', () => {
   it('runs a finite number of cycles, never infinite', () => {
     const source = readFileSync(STYLES_CSS, 'utf8');
@@ -17,4 +59,25 @@ describe('attention-ring animation', () => {
       `.attention-ring must not loop forever, an update waiting for the user does not stay in motion: ${rule?.trim()}`,
     ).toBe(false);
   });
+});
+
+describe('motion-gated animation declarations', () => {
+  const source = readFileSync(STYLES_CSS, 'utf8');
+  const lines = source.split('\n');
+  const ranges = findNoPreferenceRanges({ lines });
+
+  it.each(['spin-border', 'border-pulse', 'attention-ring'])(
+    '%s is declared only inside a prefers-reduced-motion: no-preference block',
+    (animationName) => {
+      const lineIndex = findDeclarationLine({ lines, animationName });
+      expect(
+        lineIndex,
+        `expected an "animation:" declaration referencing ${animationName} in styles.css`,
+      ).toBeGreaterThanOrEqual(0);
+      expect(
+        isInsideAnyRange({ lineIndex, ranges }),
+        `${animationName} must be wrapped in @media (prefers-reduced-motion: no-preference), found unwrapped at line ${lineIndex + 1}: ${lines[lineIndex]?.trim()}`,
+      ).toBe(true);
+    },
+  );
 });

--- a/apps/desktop/src/features/permissions/components/DiffViewerDialog/DiffViewerContent.tsx
+++ b/apps/desktop/src/features/permissions/components/DiffViewerDialog/DiffViewerContent.tsx
@@ -24,6 +24,7 @@ import type {
 import { ghPrDiff } from '../../../../features/github/github';
 import { openFileInWorkspace } from '../../../../shared/lib/editor';
 import { formatError } from '../../../../shared/lib/errors';
+import { ErrorStrip } from '../../../../shared/components/ErrorStrip';
 import {
   DEFAULT_EDITOR_BINARY,
   SETTING_DEFAULT_EDITOR,
@@ -993,7 +994,13 @@ export const DiffViewerContent = ({
             ))}
           </div>
         ) : error ? (
-          <div className="flex flex-1 items-center justify-center text-xs text-danger">{error}</div>
+          <div className="flex flex-1 items-center justify-center p-4">
+            <ErrorStrip
+              label="the diff"
+              error={new Error(error)}
+              onRetry={() => setRefreshTick((t) => t + 1)}
+            />
+          </div>
         ) : files.length === 0 ? (
           <ScrollFade className="min-h-0 min-w-0 flex-1">
             <div className={cn('mx-auto w-full max-w-5xl', !isPane && 'px-6 py-5')}>

--- a/apps/desktop/src/features/permissions/components/DiffViewerDialog/FileTree/TreeNodeView.tsx
+++ b/apps/desktop/src/features/permissions/components/DiffViewerDialog/FileTree/TreeNodeView.tsx
@@ -86,7 +86,11 @@ export const TreeNodeView = ({
           value={file.path}
           label="copy file path"
           size={10}
-          className="shrink-0 rounded-md p-0.5 text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground group-hover:opacity-100"
+          className={cn(
+            'shrink-0 rounded-md p-0.5 text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground',
+            'focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]',
+            'group-hover:opacity-100 motion-reduce:opacity-60',
+          )}
         />
       </div>
     );

--- a/apps/desktop/src/features/permissions/components/DiffViewerDialog/comments/CommentItem.tsx
+++ b/apps/desktop/src/features/permissions/components/DiffViewerDialog/comments/CommentItem.tsx
@@ -53,7 +53,7 @@ export const CommentItem = ({
             {statusPill.label}
           </span>
         ) : null}
-        <div className="ml-auto flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
+        <div className="ml-auto flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
           {comment.status === 'open' && (
             <button
               type="button"

--- a/apps/desktop/src/features/permissions/components/DiffViewerDialog/index.test.tsx
+++ b/apps/desktop/src/features/permissions/components/DiffViewerDialog/index.test.tsx
@@ -167,6 +167,38 @@ describe('DiffViewerDialog', () => {
     render(<DiffViewerDialog open onClose={vi.fn()} />);
     expect(screen.getByRole('button', { name: /^close$/i })).toBeDefined();
   });
+
+  it('renders a load failure as an alert strip with a retry action', async () => {
+    const loader = vi.fn(async () => {
+      throw new Error('boom');
+    });
+    render(<DiffViewerDialog open loader={loader} onClose={vi.fn()} />);
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toContain('boom');
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeDefined();
+  });
+
+  it('refetches the diff when the retry action is clicked', async () => {
+    let attempt = 0;
+    const loader = vi.fn(async () => {
+      attempt += 1;
+      if (attempt === 1) {
+        throw new Error('boom');
+      }
+      return '';
+    });
+    fixtures.files = fileFixture();
+    render(<DiffViewerDialog open loader={loader} onClose={vi.fn()} />);
+
+    await screen.findByRole('alert');
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+
+    await waitFor(() => {
+      expect(loader).toHaveBeenCalledTimes(2);
+    });
+    expect(await screen.findByText('alpha')).toBeDefined();
+  });
 });
 
 describe('DiffViewerPane', () => {

--- a/apps/desktop/src/features/review/components/ReviewBoardPane/ReviewFileDiff.test.tsx
+++ b/apps/desktop/src/features/review/components/ReviewBoardPane/ReviewFileDiff.test.tsx
@@ -76,6 +76,14 @@ describe('ReviewFileDiff unified layout', () => {
     expect(screen.getByRole('button', { name: 'Draft a comment on line 1' })).toBeDefined();
     expect(screen.getByRole('button', { name: 'Draft a comment on line 2' })).toBeDefined();
   });
+
+  it('reveals the line actions on keyboard focus, not only on hover', () => {
+    renderDiff({ file: fileOf([del(1, 'gone')]), layoutMode: 'unified' });
+    const draftButton = screen.getByRole('button', { name: 'Draft a comment on line 1' });
+    const askAgentButton = screen.getByRole('button', { name: 'Ask the agent about line 1' });
+    expect(draftButton.className).toContain('focus-visible:opacity-100');
+    expect(askAgentButton.className).toContain('focus-visible:opacity-100');
+  });
 });
 
 describe('ReviewFileDiff split layout', () => {

--- a/apps/desktop/src/features/review/components/ReviewBoardPane/ReviewFileDiff.tsx
+++ b/apps/desktop/src/features/review/components/ReviewBoardPane/ReviewFileDiff.tsx
@@ -300,7 +300,7 @@ export const ReviewFileDiff = ({ file, layoutMode, drafts, onAddDraft, onAskAgen
                                     title="Draft a comment on this line"
                                     aria-label={`Draft a comment on line ${target.line}`}
                                     className={cn(
-                                      'flex h-4 w-4 items-center justify-center rounded-sm text-muted-foreground transition-opacity hover:bg-muted hover:text-foreground',
+                                      'flex h-4 w-4 items-center justify-center rounded-sm text-muted-foreground transition-opacity hover:bg-muted hover:text-foreground focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]',
                                       isActive
                                         ? 'opacity-100'
                                         : 'opacity-0 group-hover:opacity-100',
@@ -313,7 +313,7 @@ export const ReviewFileDiff = ({ file, layoutMode, drafts, onAddDraft, onAskAgen
                                     onClick={() => onAskAgent?.(target)}
                                     title="Ask the agent about this line"
                                     aria-label={`Ask the agent about line ${target.line}`}
-                                    className="flex h-4 w-4 items-center justify-center rounded-sm text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground group-hover:opacity-100"
+                                    className="flex h-4 w-4 items-center justify-center rounded-sm text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
                                   >
                                     <Bot size={9} aria-hidden />
                                   </button>

--- a/apps/desktop/src/features/review/components/ReviewBoardPane/ReviewLineActions.test.tsx
+++ b/apps/desktop/src/features/review/components/ReviewBoardPane/ReviewLineActions.test.tsx
@@ -1,0 +1,46 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import type { ReviewLineTarget } from './ReviewFileDiff';
+import { ReviewLineActions } from './ReviewLineActions';
+
+const TARGET: ReviewLineTarget = {
+  path: 'src/a.ts',
+  line: 4,
+  side: 'new',
+  text: 'retry(session);',
+};
+
+afterEach(cleanup);
+
+describe('ReviewLineActions', () => {
+  it('reveals both actions on keyboard focus, not only on hover', () => {
+    render(
+      <ReviewLineActions
+        target={TARGET}
+        isActive={false}
+        onToggleComposer={vi.fn()}
+        onAskAgent={vi.fn()}
+      />,
+    );
+
+    const draftButton = screen.getByRole('button', { name: 'Draft a comment on new line 4' });
+    const askAgentButton = screen.getByRole('button', { name: 'Ask the agent about new line 4' });
+    expect(draftButton.className).toContain('focus-visible:opacity-100');
+    expect(askAgentButton.className).toContain('focus-visible:opacity-100');
+  });
+
+  it('renders nothing without a target', () => {
+    const { container } = render(
+      <ReviewLineActions
+        target={null}
+        isActive={false}
+        onToggleComposer={vi.fn()}
+        onAskAgent={vi.fn()}
+      />,
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/apps/desktop/src/features/review/components/ReviewBoardPane/ReviewLineActions.tsx
+++ b/apps/desktop/src/features/review/components/ReviewBoardPane/ReviewLineActions.tsx
@@ -10,7 +10,7 @@ type Props = {
 };
 
 const ACTION_BTN =
-  'flex h-4 w-4 items-center justify-center rounded-sm text-muted-foreground transition-opacity hover:bg-muted hover:text-foreground';
+  'flex h-4 w-4 items-center justify-center rounded-sm text-muted-foreground transition-opacity hover:bg-muted hover:text-foreground focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]';
 
 export const ReviewLineActions = ({ target, isActive, onToggleComposer, onAskAgent }: Props) => {
   if (target === null || onToggleComposer === null || onAskAgent === null) {

--- a/apps/desktop/src/features/review/components/ReviewBoardPane/index.test.tsx
+++ b/apps/desktop/src/features/review/components/ReviewBoardPane/index.test.tsx
@@ -124,6 +124,7 @@ beforeEach(() => {
   });
   h.state.setAgentDraft.mockClear();
   h.showToast.mockClear();
+  h.diff.refresh.mockClear();
   localStorage.clear();
 });
 

--- a/apps/desktop/src/features/review/components/ReviewBoardPane/index.test.tsx
+++ b/apps/desktop/src/features/review/components/ReviewBoardPane/index.test.tsx
@@ -261,4 +261,14 @@ describe('ReviewBoardPane', () => {
     expect(screen.getByRole('heading', { name: 'Review board' })).toBeDefined();
     expect(screen.queryByText('acme/web #41')).toBeNull();
   });
+
+  it('offers a retry when the diff fails to load', () => {
+    h.diff.error = 'network unreachable';
+    render(<ReviewBoardPane session={SESSION} />);
+
+    expect(screen.getByText(/network unreachable/)).toBeDefined();
+    const retry = screen.getByRole('button', { name: 'Retry' });
+    fireEvent.click(retry);
+    expect(h.diff.refresh).toHaveBeenCalled();
+  });
 });

--- a/apps/desktop/src/features/review/components/ReviewBoardPane/index.tsx
+++ b/apps/desktop/src/features/review/components/ReviewBoardPane/index.tsx
@@ -9,6 +9,7 @@ import { classifyAgent } from '../../../session/agent-kind';
 import { RefreshIconButton } from '../../../../shared/components/RefreshIconButton';
 import { StudioDetailLayout } from '../../../../shared/components/StudioDetail';
 import { LensEmptyState } from '../../../../shared/components/LensEmptyState';
+import { ErrorStrip } from '../../../../shared/components/ErrorStrip';
 import { DraftsPanel } from './DraftsPanel';
 import { PublishBar } from './PublishBar';
 import { ReviewFileDiff, type ReviewLineTarget } from './ReviewFileDiff';
@@ -177,12 +178,7 @@ export const ReviewBoardPane = ({ session }: Props) => {
             </div>
           ) : error != null ? (
             <div className="flex min-h-0 flex-1 flex-col px-6 py-5">
-              <LensEmptyState
-                tone={CONCEPT_TONE.errors}
-                icon={CONCEPT_ICONS.errors}
-                title="Could not load the diff"
-                description={error}
-              />
+              <ErrorStrip label="the diff" error={new Error(error)} onRetry={refresh} />
             </div>
           ) : files.length === 0 ? (
             <div className="flex min-h-0 flex-1 flex-col px-6 py-5">

--- a/apps/desktop/src/features/session/components/AgentInspector/ResolverOutcomeChip.tsx
+++ b/apps/desktop/src/features/session/components/AgentInspector/ResolverOutcomeChip.tsx
@@ -39,7 +39,7 @@ export const ResolverOutcomeChip = ({ kind, isClosed }: Props) => {
   return (
     <span
       className={cn(
-        'inline-flex min-w-24 shrink-0 items-center justify-center gap-1 rounded-full px-1.5 py-0.5 text-2xs font-medium uppercase tracking-wide',
+        'inline-flex min-w-24 shrink-0 items-center justify-center gap-1 rounded-full px-1.5 py-0.5 text-2xs font-medium',
         tint.bgSoft,
         tint.text,
       )}

--- a/apps/desktop/src/features/session/components/ResolverStateBadge/index.tsx
+++ b/apps/desktop/src/features/session/components/ResolverStateBadge/index.tsx
@@ -62,7 +62,7 @@ const TINT: Record<ResolverBadgeState, string> = {
 export const ResolverStateBadge = ({ state, className }: ResolverStateBadgeProps) => (
   <span
     className={cn(
-      'inline-flex shrink-0 items-center gap-1 rounded-full px-1.5 py-0.5 text-3xs font-medium uppercase tracking-wide',
+      'inline-flex shrink-0 items-center gap-1 rounded-full px-1.5 py-0.5 text-3xs font-medium',
       TINT[state],
       className,
     )}


### PR DESCRIPTION
## Summary

Four riders on one spine: resolve/diff surfaces obeying the design floor.

- **Errors that offer a way out**: `DiffViewerContent.tsx` and `ReviewBoardPane/index.tsx` both surfaced a load failure as a dead-end message. Both now render `ErrorStrip` (wrapping the existing `string | null` error in `new Error(...)` to match its `Error | null` prop) with a retry wired to the existing refresh path (`setRefreshTick` in the dialog, the `refresh` from `useReviewDiff` in the board pane).
- **Keyboard focus reveals hover-only actions**: added `focus-visible:opacity-100` (plus a focus ring, matching `BranchChip`'s precedent) to the file-tree copy button, the review line-comment/ask-agent buttons (both the shared `ReviewLineActions` component and the duplicated inline copy in `ReviewFileDiff.tsx`). `CommentItem.tsx`'s action row sits on a non-button wrapper, so it gets `group-focus-within:opacity-100` instead, matching the pattern already used in `ExplorePane` and `PrPane`.
- **Sentence case on the two loudest resolve chips**: dropped `uppercase tracking-wide` from `ResolverOutcomeChip.tsx` and `ResolverStateBadge/index.tsx`. Their copy dictionaries are already lowercase, so no string changes were needed. `PullRequestChip` was left untouched, out of scope.
- **Pinned the motion gate**: `attention-ring-is-finite.test.ts` only ever grepped the `attention-ring` line for `infinite`. Added an `it.each` that parses `styles.css`'s `@media` block structure and asserts all three motion-gated declarations (`spin-border`, `border-pulse`, `attention-ring`) live inside a `prefers-reduced-motion: no-preference` block. Verified locally that removing one of the wraps turns the corresponding assertion red, then restored the file (not committed).

## Net-new test

- `ReviewBoardPane/index.test.tsx`: new case exercising the error branch — asserts the error text renders and clicking Retry calls the mock `refresh`. No prior test exercised this branch even though the mock harness already had an `error` field.
- `ReviewFileDiff.test.tsx`: new case asserting the unified-layout line action buttons carry `focus-visible:opacity-100`.
- `attention-ring-is-finite.test.ts`: new `describe` block, three cases (see above).

## What I could not verify

- Visual/manual keyboard-tab verification in a running app; verification here is CSS-class assertions in RTL tests plus reading the rendered className, consistent with this codebase's existing convention for that kind of check (e.g. `DiffViewerDialog/index.test.tsx` asserting `heading.className`).

## Deviations

None from the brief. `@goodboy/db`'s `registry.test.ts` timed out once at 30s inside the shared `turbo run test --force` under sibling worktree load; re-ran `@goodboy/db` standalone and it passed in ~23s (known flake, not touched).

## Out of scope, surfaced not fixed

`text-shimmer` (`apps/desktop/src/styles.css:565`, `2.6s linear infinite`) is an ungated infinite animation, outside this item's footprint. Left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)