### PR TITLE
feat(desktop): keep the note you send the orchestrator

### DIFF
--- a/apps/desktop/src/__tests__/transcript-items.test.ts
+++ b/apps/desktop/src/__tests__/transcript-items.test.ts
@@ -176,6 +176,49 @@ describe('reduceTranscript, step_transition', () => {
   });
 });
 
+describe('reduceTranscript, orchestrator_decision', () => {
+  it('carries the operator note through to the transcript item', () => {
+    const event = {
+      kind: 'orchestrator_decision',
+      runId: RUN,
+      action: 'next',
+      reason: 'the gate landed so the tests come next',
+      stepName: 'write the gate tests',
+      operatorNote: 'the gate is in place but its tests are missing',
+      at: AT,
+    } satisfies TurnEvent;
+
+    expect(reduceTranscript([event])).toEqual([
+      {
+        kind: 'orchestrator_decision',
+        key: 'orchestrator-0',
+        action: 'next',
+        reason: event.reason,
+        stepName: event.stepName,
+        operatorNote: event.operatorNote,
+        at: AT,
+      },
+    ]);
+  });
+
+  it('omits the operator note when the decision has none', () => {
+    const event = {
+      kind: 'orchestrator_decision',
+      runId: RUN,
+      action: 'done',
+      reason: 'nothing is left to do',
+      at: AT,
+    } satisfies TurnEvent;
+
+    const item = reduceTranscript([event])[0]!;
+    expect(item.kind).toBe('orchestrator_decision');
+    if (item.kind !== 'orchestrator_decision') {
+      return;
+    }
+    expect(item.operatorNote).toBeUndefined();
+  });
+});
+
 function userTextEvent(text: string): TurnEvent {
   return { kind: 'user_text', runId: RUN, text, at: AT };
 }

--- a/apps/desktop/src/features/chat/components/OrchestratorDecisionCard/index.test.tsx
+++ b/apps/desktop/src/features/chat/components/OrchestratorDecisionCard/index.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { IsoDateTime } from '@goodboy/types';
+import type { TranscriptItem } from '../../utils/transcript-items';
+import { OrchestratorDecisionCard } from './index';
+
+afterEach(cleanup);
+
+const item = {
+  kind: 'orchestrator_decision',
+  key: 'orchestrator-1',
+  action: 'next',
+  reason: 'the gate landed so the tests come next',
+  stepName: 'write the gate tests',
+  at: '2026-05-28T03:00:00Z' as IsoDateTime,
+} satisfies Extract<TranscriptItem, { kind: 'orchestrator_decision' }>;
+
+const withNote = {
+  ...item,
+  operatorNote: 'the gate is in place but its tests are missing',
+} satisfies Extract<TranscriptItem, { kind: 'orchestrator_decision' }>;
+
+describe('OrchestratorDecisionCard', () => {
+  it('renders the operator note when the decision carries one', () => {
+    render(<OrchestratorDecisionCard item={withNote} />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(screen.getByText('the gate is in place but its tests are missing')).toBeDefined();
+  });
+
+  it('keeps the operator note separate from the orchestrator reason', () => {
+    render(<OrchestratorDecisionCard item={withNote} />);
+    fireEvent.click(screen.getByRole('button'));
+    const note = screen.getByTestId('orchestrator-decision-note');
+    expect(note.textContent).toContain('the gate is in place but its tests are missing');
+    expect(note.textContent).not.toContain('the gate landed so the tests come next');
+    expect(screen.getByText('the gate landed so the tests come next')).toBeDefined();
+  });
+
+  it('flags a decision that carries a note while it is still collapsed', () => {
+    render(<OrchestratorDecisionCard item={withNote} />);
+    expect(screen.getByTestId('orchestrator-decision-note-badge')).toBeDefined();
+  });
+
+  it('renders no note surface when the decision has none', () => {
+    render(<OrchestratorDecisionCard item={item} />);
+    expect(screen.queryByTestId('orchestrator-decision-note-badge')).toBeNull();
+    fireEvent.click(screen.getByRole('button'));
+    expect(screen.queryByTestId('orchestrator-decision-note')).toBeNull();
+    expect(screen.getByText('the gate landed so the tests come next')).toBeDefined();
+  });
+
+  it('ignores a note that is only whitespace', () => {
+    const blank = {
+      ...item,
+      operatorNote: '   ',
+    } satisfies Extract<TranscriptItem, { kind: 'orchestrator_decision' }>;
+    render(<OrchestratorDecisionCard item={blank} />);
+    expect(screen.queryByTestId('orchestrator-decision-note-badge')).toBeNull();
+  });
+});

--- a/apps/desktop/src/features/chat/components/OrchestratorDecisionCard/index.tsx
+++ b/apps/desktop/src/features/chat/components/OrchestratorDecisionCard/index.tsx
@@ -1,10 +1,15 @@
 import { useState } from 'react';
 import { Route } from 'lucide-react';
-import { Markdown } from '@goodboy/ui';
+import { Markdown, cn, tintClasses } from '@goodboy/ui';
 import type { TranscriptItem } from '../../utils/transcript-items';
 import { formatCardTime } from '../../utils/format-card-time';
 import { TranscriptDisclosure } from '../TranscriptDisclosure';
 import { TranscriptRowHeader } from '../TranscriptRowHeader';
+import { TranscriptShell } from '../TranscriptShell';
+
+const infoTint = tintClasses('info');
+
+const LABEL_CLASS = 'text-2xs font-medium uppercase tracking-wide text-muted-foreground';
 
 type Props = {
   readonly item: Extract<TranscriptItem, { kind: 'orchestrator_decision' }>;
@@ -12,6 +17,9 @@ type Props = {
 
 export const OrchestratorDecisionCard = ({ item }: Props) => {
   const [open, setOpen] = useState(false);
+  const note = item.operatorNote?.trim() ?? '';
+  const hasNote = note !== '';
+
   return (
     <TranscriptDisclosure
       tone="primary"
@@ -23,6 +31,20 @@ export const OrchestratorDecisionCard = ({ item }: Props) => {
           tone="primary"
           icon={<Route size={12} aria-hidden />}
           eyebrow="orchestrator"
+          badge={
+            hasNote ? (
+              <span
+                data-testid="orchestrator-decision-note-badge"
+                className={cn(
+                  'shrink-0 rounded-md px-1 py-px text-2xs font-medium',
+                  infoTint.bg,
+                  infoTint.text,
+                )}
+              >
+                your note
+              </span>
+            ) : null
+          }
           preview={item.stepName ?? item.action}
           meta={formatCardTime(item.at)}
           open={open}
@@ -30,7 +52,26 @@ export const OrchestratorDecisionCard = ({ item }: Props) => {
         />
       }
     >
-      <Markdown text={item.reason} />
+      {hasNote ? (
+        <>
+          <div className="flex min-w-0 flex-col gap-1" data-testid="orchestrator-decision-note">
+            <span className={LABEL_CLASS}>your note</span>
+            <TranscriptShell
+              tone="info"
+              variant="boxed"
+              className="min-w-0 text-xs text-foreground"
+            >
+              <Markdown text={note} />
+            </TranscriptShell>
+          </div>
+          <div className="flex min-w-0 flex-col gap-1">
+            <span className={LABEL_CLASS}>what the orchestrator decided</span>
+            <Markdown text={item.reason} />
+          </div>
+        </>
+      ) : (
+        <Markdown text={item.reason} />
+      )}
     </TranscriptDisclosure>
   );
 };

--- a/apps/desktop/src/features/chat/utils/transcript-items.ts
+++ b/apps/desktop/src/features/chat/utils/transcript-items.ts
@@ -61,6 +61,7 @@ export type TranscriptItem =
       action: 'next' | 'done' | 'blocked';
       reason: string;
       stepName?: string;
+      operatorNote?: string;
       at: IsoDateTime;
     }
   | {
@@ -286,6 +287,8 @@ export const reduceTranscript = (
           action: event.action,
           reason: event.reason,
           ...(event.stepName != null && { stepName: event.stepName }),
+          ...(event.operatorNote != null &&
+            event.operatorNote !== '' && { operatorNote: event.operatorNote }),
           at: event.at,
         });
         break;

--- a/apps/desktop/src/features/workflows/components/OrchestratorPanel/index.tsx
+++ b/apps/desktop/src/features/workflows/components/OrchestratorPanel/index.tsx
@@ -231,7 +231,7 @@ export const OrchestratorPanel = ({
             <OrchestratorDrawer
               inputId="orchestrator-continue-note-field"
               title="Not done? Say what is missing"
-              help="Optional. Leave it empty and the orchestrator decides what comes next on its own."
+              help="Optional. Leave it empty and the orchestrator decides what comes next. What you write stays on the decision it triggers."
             >
               <textarea
                 id="orchestrator-continue-note-field"

--- a/apps/desktop/src/store/slices/workflows/orchestrateNextStep.test.ts
+++ b/apps/desktop/src/store/slices/workflows/orchestrateNextStep.test.ts
@@ -928,6 +928,81 @@ describe('orchestrateNextStep', () => {
     );
   });
 
+  it('records the note on the hard cap block, not only in the prompt', async () => {
+    const state = baseState();
+    const template = state['phaseTemplates'] as Record<string, ReadonlyArray<Workflow>>;
+    const base = template[WORKSPACE_ID]![0]!;
+    const capped: Workflow = {
+      ...base,
+      steps: Array.from({ length: ORCHESTRATOR_STEP_HARD_CAP }, (_, index) => ({
+        ...base.steps[0]!,
+        id: `step-${index}` as StepId,
+        ordinal: index,
+        name: `Step ${index}`,
+      })),
+    };
+    state['phaseTemplates'] = { [WORKSPACE_ID]: [capped] };
+    const { set, get } = harness(state);
+
+    await orchestrateNextStep(set, get)(SESSION_ID, WORKFLOW_RUN_ID, {
+      extraHints: 'watch for the hard cap',
+    });
+
+    expect(state['appendTurnEvent']).toHaveBeenCalledWith(
+      AGENT_ID,
+      SESSION_ID,
+      expect.objectContaining({
+        kind: 'orchestrator_decision',
+        action: 'blocked',
+        operatorNote: 'watch for the hard cap',
+      }),
+    );
+  });
+
+  it('records the note on a provider failure block, not only in the prompt', async () => {
+    decideSpy.mockRejectedValueOnce(new Error('orchestrator decision timed out'));
+    const state = baseState();
+    const { set, get } = harness(state);
+
+    await orchestrateNextStep(set, get)(SESSION_ID, WORKFLOW_RUN_ID, {
+      extraHints: 'this was already flaky yesterday',
+    });
+
+    expect(state['appendTurnEvent']).toHaveBeenCalledWith(
+      AGENT_ID,
+      SESSION_ID,
+      expect.objectContaining({
+        kind: 'orchestrator_decision',
+        action: 'blocked',
+        operatorNote: 'this was already flaky yesterday',
+      }),
+    );
+  });
+
+  it('records the note on an unparseable-reply block, not only in the prompt', async () => {
+    decideSpy.mockResolvedValueOnce({
+      decision: null,
+      usage: BILLED_USAGE,
+      model: 'claude-haiku-4-5',
+    });
+    const state = baseState();
+    const { set, get } = harness(state);
+
+    await orchestrateNextStep(set, get)(SESSION_ID, WORKFLOW_RUN_ID, {
+      extraHints: 'retry with more context',
+    });
+
+    expect(state['appendTurnEvent']).toHaveBeenCalledWith(
+      AGENT_ID,
+      SESSION_ID,
+      expect.objectContaining({
+        kind: 'orchestrator_decision',
+        action: 'blocked',
+        operatorNote: 'retry with more context',
+      }),
+    );
+  });
+
   it('routes the decision through the provider handed by the caller', async () => {
     decideSpy.mockResolvedValueOnce({
       decision: { action: 'done', reason: 'all set' },

--- a/apps/desktop/src/store/slices/workflows/orchestrateNextStep.test.ts
+++ b/apps/desktop/src/store/slices/workflows/orchestrateNextStep.test.ts
@@ -836,6 +836,98 @@ describe('orchestrateNextStep', () => {
     );
   });
 
+  it('records the note on the decision it triggered, not only in the prompt', async () => {
+    decideSpy.mockResolvedValueOnce({
+      usage: NO_USAGE,
+      decision: {
+        action: 'next',
+        reason: 'The tests come next.',
+        step: {
+          name: 'Implement',
+          role: 'implementer',
+          promptPrefix: 'Write the missing tests.',
+        },
+      },
+      model: 'claude-haiku-4-5',
+    });
+    const state = baseState();
+    const { set, get } = harness(state);
+
+    await orchestrateNextStep(set, get)(SESSION_ID, WORKFLOW_RUN_ID, {
+      extraHints: '  the gate is in place but its tests are missing  ',
+    });
+
+    expect(state['appendTurnEvent']).toHaveBeenCalledWith(
+      'agent-2',
+      SESSION_ID,
+      expect.objectContaining({
+        kind: 'orchestrator_decision',
+        operatorNote: 'the gate is in place but its tests are missing',
+      }),
+    );
+  });
+
+  it('records the note on a terminal decision too', async () => {
+    decideSpy.mockResolvedValueOnce({
+      decision: { action: 'done', reason: 'all set' },
+      usage: NO_USAGE,
+      model: 'claude-haiku-4-5',
+    });
+    const state = baseState();
+    const { set, get } = harness(state);
+
+    await orchestrateNextStep(set, get)(SESSION_ID, WORKFLOW_RUN_ID, {
+      extraHints: 'ship the changelog as well',
+    });
+
+    expect(state['appendTurnEvent']).toHaveBeenCalledWith(
+      AGENT_ID,
+      SESSION_ID,
+      expect.objectContaining({
+        kind: 'orchestrator_decision',
+        action: 'done',
+        operatorNote: 'ship the changelog as well',
+      }),
+    );
+  });
+
+  it('leaves the note off a decision the operator did not write one for', async () => {
+    decideSpy.mockResolvedValueOnce({
+      decision: { action: 'done', reason: 'all set' },
+      usage: NO_USAGE,
+      model: 'claude-haiku-4-5',
+    });
+    const state = baseState();
+    const { set, get } = harness(state);
+
+    await orchestrateNextStep(set, get)(SESSION_ID, WORKFLOW_RUN_ID);
+
+    const appended = state['appendTurnEvent'] as ReturnType<typeof vi.fn>;
+    expect(appended.mock.calls[0]![2]).not.toHaveProperty('operatorNote');
+  });
+
+  it('carries the note from the continue drawer all the way onto the decision', async () => {
+    decideSpy.mockResolvedValueOnce({
+      decision: { action: 'done', reason: 'all set' },
+      usage: NO_USAGE,
+      model: 'claude-haiku-4-5',
+    });
+    const state = baseState();
+    const { set, get } = harness(state);
+    state['orchestrateNextStep'] = orchestrateNextStep(set, get);
+
+    await continueWorkflowRun(set, get)(SESSION_ID, WORKFLOW_RUN_ID, '  say what is missing  ');
+
+    expect(state['appendTurnEvent']).toHaveBeenCalledWith(
+      AGENT_ID,
+      SESSION_ID,
+      expect.objectContaining({
+        kind: 'orchestrator_decision',
+        operatorNote: 'say what is missing',
+      }),
+    );
+  });
+
   it('routes the decision through the provider handed by the caller', async () => {
     decideSpy.mockResolvedValueOnce({
       decision: { action: 'done', reason: 'all set' },

--- a/apps/desktop/src/store/slices/workflows/orchestrateNextStep.ts
+++ b/apps/desktop/src/store/slices/workflows/orchestrateNextStep.ts
@@ -113,6 +113,7 @@ type EmitParams = {
   readonly action: 'next' | 'done' | 'blocked';
   readonly reason: string;
   readonly stepName?: string;
+  readonly operatorNote?: string;
   readonly preferredAgentId?: AgentId;
 };
 
@@ -123,6 +124,7 @@ const emitDecision = ({
   action,
   reason,
   stepName,
+  operatorNote,
   preferredAgentId,
 }: EmitParams): AgentId | null => {
   const runAgents = runsForWorkflowRun(get().sessionPhaseRuns[sessionId] ?? [], workflowRunId);
@@ -137,6 +139,7 @@ const emitDecision = ({
     action,
     reason,
     ...(stepName != null && { stepName }),
+    ...(operatorNote != null && operatorNote !== '' && { operatorNote }),
     at: new Date().toISOString() as IsoDateTime,
   };
   get().appendTurnEvent(agentId, sessionId, event);
@@ -348,6 +351,7 @@ export const orchestrateNextStep = (set: SetFn, get: GetFn) => {
       return;
     }
     orchestrationInFlight.add(workflowRunId);
+    const operatorNote = options?.extraHints?.trim() ?? '';
     try {
       const session = get().sessions.find((candidate) => candidate.id === sessionId);
       const run = session?.workflowRuns.find((candidate) => candidate.id === workflowRunId);
@@ -396,7 +400,7 @@ export const orchestrateNextStep = (set: SetFn, get: GetFn) => {
           outcome: 'blocked',
           reason,
         });
-        emitDecision({ get, sessionId, workflowRunId, action: 'blocked', reason });
+        emitDecision({ get, sessionId, workflowRunId, action: 'blocked', reason, operatorNote });
         void get().emitNotification(
           'error',
           'warning',
@@ -439,7 +443,7 @@ export const orchestrateNextStep = (set: SetFn, get: GetFn) => {
         defaultProvider,
       );
       const routing = options?.routing ?? run.orchestratorRouting ?? taskModel;
-      const hints = [run.orchestratorHints, options?.extraHints]
+      const hints = [run.orchestratorHints, operatorNote]
         .map((entry) => entry?.trim() ?? '')
         .filter((entry) => entry !== '')
         .join('\n');
@@ -474,6 +478,7 @@ export const orchestrateNextStep = (set: SetFn, get: GetFn) => {
           workflowRunId,
           action: 'blocked',
           reason: `orchestrator failed: ${message}`,
+          operatorNote,
         });
         void get().emitNotification('error', 'warning', 'orchestrator failed', message, {
           sessionId,
@@ -494,6 +499,7 @@ export const orchestrateNextStep = (set: SetFn, get: GetFn) => {
           workflowRunId,
           action: 'blocked',
           reason: 'the orchestrator reply could not be parsed, retry to continue',
+          operatorNote,
         });
         await recordOrchestratorUsage({
           set,
@@ -548,6 +554,7 @@ export const orchestrateNextStep = (set: SetFn, get: GetFn) => {
           action: decision.action,
           reason,
           stepName: agent.name,
+          operatorNote,
           preferredAgentId: agent.id,
         });
         if (enforced.rejection != null) {
@@ -590,6 +597,7 @@ export const orchestrateNextStep = (set: SetFn, get: GetFn) => {
         workflowRunId,
         action: decision.action,
         reason: decision.reason,
+        operatorNote,
       });
       await recordOrchestratorUsage({
         set,

--- a/packages/db/src/queries/turn-event.test.ts
+++ b/packages/db/src/queries/turn-event.test.ts
@@ -11,7 +11,7 @@ import type { Database } from '../client';
 import { migrate } from '../migrations/runner';
 import { makeTestDatabase } from '../test-helpers/test-db';
 import { insertAgent } from './agent';
-import { countUserTextEvents, insertTurnEvent } from './turn-event';
+import { countUserTextEvents, insertTurnEvent, listTurnEventsForAgent } from './turn-event';
 
 const workspaceId = 'workspace-1' as WorkspaceId;
 const sessionId = 'session-1' as SessionId;
@@ -84,5 +84,30 @@ describe('turn event queries', () => {
 
     await expect(countUserTextEvents({ db, agentId })).resolves.toBe(2);
     await expect(countUserTextEvents({ db, agentId: otherAgentId })).resolves.toBe(1);
+  });
+
+  it('round-trips the operator note stored on an orchestrator decision', async () => {
+    await insertTurnEvent(db, {
+      id: 'event-5',
+      sessionId,
+      agentId,
+      event: {
+        kind: 'orchestrator_decision',
+        runId,
+        action: 'next',
+        reason: 'the tests come next',
+        stepName: 'write the gate tests',
+        operatorNote: 'the gate is in place but its tests are missing',
+        at,
+      },
+    });
+
+    const events = await listTurnEventsForAgent(db, agentId);
+    const decision = events.find((event) => event.kind === 'orchestrator_decision');
+    expect(decision).toBeDefined();
+    if (decision?.kind !== 'orchestrator_decision') {
+      return;
+    }
+    expect(decision.operatorNote).toBe('the gate is in place but its tests are missing');
   });
 });

--- a/packages/types/src/adapter.ts
+++ b/packages/types/src/adapter.ts
@@ -119,6 +119,7 @@ export type TurnEvent =
       action: 'next' | 'done' | 'blocked';
       reason: string;
       stepName?: string;
+      operatorNote?: string;
       at: IsoDateTime;
     }
   | {


### PR DESCRIPTION
## What

The note you type in "Not done? Say what is missing" now stays with the decision it triggered. It used to be forwarded to the model for that one call and dropped: it lived in React state, was sent as `extraHints`, was folded into the prompt, and the field was cleared on submit. Nothing wrote it anywhere, so afterwards there was no way to see what you had told the orchestrator.

## Shape

The note rides the channel the orchestrator's own decisions already use: `emitDecision` -> `appendTurnEvent` -> `queueTurnEventInsert` -> `turn_events` -> the decision card in the transcript.

It is a new **optional field** on the existing `orchestrator_decision` payload (`operatorNote?: string`), not a new discriminant and not a new column:

- `turn_events` stores the payload as schema-free JSON in one `payload TEXT` column and reads it back with an unchecked `JSON.parse(...) as TurnEvent`. An optional field costs nothing, and an older app reading a newer database just ignores it.
- A new column would be a migration. This way there is none, and no schema change of any kind.
- Reusing `orchestrationReason` was rejected: it is overwritten on every decide call rather than appended, and it would blend the model's reasoning with the operator's own words, which is exactly the distinction the request is about.

Every decision produced by an orchestration call that carried a note gets the note, terminal ones included, so a `done` or `blocked` verdict also shows what it was answering.

## Where you see it

On the orchestrator decision card in the agent transcript. Collapsed, the card takes a small `your note` chip so a decision that answers something you wrote is visible without opening it. Expanded, the note is rendered in its own info-toned block under a `your note` label, above the orchestrator's own text under `what the orchestrator decided`, so the two never read as one voice. No clamp, no truncation: the note is shown whole. When there is no note the card is exactly what it was before.

The continue drawer's help text now says the note is kept.

## Not in scope

Standing hints (`run.orchestratorHints`) are untouched. They already persist, are re-read before every decided step, and have their own `Clear hints` control. The issue's first question is about them and is answered on the thread, not here.

## Test plan

- `pnpm typecheck` green.
- `pnpm exec turbo run test --force` green. `@goodboy/db`'s `registry.test.ts` timed out at 30s under concurrent sibling load in the turbo run and passes standalone (203/203); it is untouched by this change.
- `pnpm knip --include files,duplicates,unlisted` clean.

Added:

- `orchestrateNextStep.test.ts`: the note reaches the emitted decision event on a `next` decision, on a terminal `done` decision, and end to end when it enters through `continueWorkflowRun`; a decision with no note carries no `operatorNote` key.
- `turn-event.test.ts`: an `orchestrator_decision` with a note round-trips through real SQLite, which is the claim that it survives a restart.
- `OrchestratorDecisionCard/index.test.tsx` (new file): the note renders when expanded, stays in its own block away from the orchestrator's reason, flags itself while collapsed, and is absent (badge and block) when the decision has none or when it is only whitespace.
- `transcript-items.test.ts`: `reduceTranscript` carries the note onto the item, and omits it when absent.

`continueWorkflowRun.test.ts` pins `orchestrateNextStep` being called with `{ extraHints: ... }` exactly. It did not need rewriting: `continueWorkflowRun` forwards the same option it always did, and the note is picked up on the other side.

## Issue

Refs #1303. Deliberately not auto-closing: the issue asks two things, and this ships the second (the note persists and is visible later). The first, whether standing hints are meant to persist, is answered as intended-by-design on the thread, so closing the issue is the owner's call once that answer lands.
