### PR TITLE
fix(desktop): name the failed stage on resolve push queue read

### DIFF
--- a/apps/desktop/src/features/notifications/components/NotificationToastBridge/index.tsx
+++ b/apps/desktop/src/features/notifications/components/NotificationToastBridge/index.tsx
@@ -82,6 +82,15 @@ export const mapNotificationAction = (
       },
     };
   }
+  if (action.kind === 'retry-push-resolutions') {
+    const { sessionId } = action;
+    return {
+      label: 'Retry',
+      onClick: () => {
+        void store.pushAllResolutions(sessionId);
+      },
+    };
+  }
   if (action.kind === 'open-orphan-worktrees') {
     const { workspaceId } = action;
     return {

--- a/apps/desktop/src/features/notifications/components/NotificationToastBridge/notificationAction.test.ts
+++ b/apps/desktop/src/features/notifications/components/NotificationToastBridge/notificationAction.test.ts
@@ -9,6 +9,7 @@ import { mapNotificationAction } from './';
 
 const retrySummarizerSpy = vi.fn();
 const retryStepSummarySpy = vi.fn(async () => undefined);
+const pushAllResolutionsSpy = vi.fn(async () => ({ pushed: true, resolved: 0, failed: 0 }));
 
 type FakeStore = {
   summarizerStatus: Record<
@@ -17,6 +18,7 @@ type FakeStore = {
   >;
   retrySummarizer: typeof retrySummarizerSpy;
   retryStepSummary: typeof retryStepSummarySpy;
+  pushAllResolutions: typeof pushAllResolutionsSpy;
 };
 
 function buildStore(overrides: Partial<FakeStore> = {}): FakeStore {
@@ -24,6 +26,7 @@ function buildStore(overrides: Partial<FakeStore> = {}): FakeStore {
     summarizerStatus: {},
     retrySummarizer: retrySummarizerSpy,
     retryStepSummary: retryStepSummarySpy,
+    pushAllResolutions: pushAllResolutionsSpy,
     ...overrides,
   };
 }
@@ -78,5 +81,20 @@ describe('mapNotificationAction', () => {
     const toastAction = mapNotificationAction(action, store as never);
     toastAction?.onClick();
     expect(retryStepSummarySpy).toHaveBeenCalledWith({ sessionId: SESSION_ID, agentId: AGENT_ID });
+  });
+
+  it('retry-push-resolutions: returns action with Retry label', () => {
+    const action: NotificationAction = { kind: 'retry-push-resolutions', sessionId: SESSION_ID };
+    const store = buildStore();
+    const toastAction = mapNotificationAction(action, store as never);
+    expect(toastAction?.label).toBe('Retry');
+  });
+
+  it('retry-push-resolutions: onClick calls pushAllResolutions with sessionId', () => {
+    const action: NotificationAction = { kind: 'retry-push-resolutions', sessionId: SESSION_ID };
+    const store = buildStore();
+    const toastAction = mapNotificationAction(action, store as never);
+    toastAction?.onClick();
+    expect(pushAllResolutionsSpy).toHaveBeenCalledWith(SESSION_ID);
   });
 });

--- a/apps/desktop/src/store/slices/github/index.test.ts
+++ b/apps/desktop/src/store/slices/github/index.test.ts
@@ -1959,7 +1959,12 @@ describe('store contract', () => {
       expect(deletePendingResolutionSpy).toHaveBeenCalledOnce();
       const notification = store.getState().notifications[0];
       expect(notification?.title).toBe('queue refresh failed after push');
-      expect(notification?.body).toContain('database is locked');
+      expect(notification?.body).toBe(
+        'database is locked. some comments may still show as pending until you retry.',
+      );
+      expect(notification?.body?.split('. ')).toHaveLength(2);
+      expect(notification?.sessionId).toBe(SESSION_ID);
+      expect(notification?.workspaceId).toBe(WS_ID);
       expect(notification?.action).toEqual({
         kind: 'retry-push-resolutions',
         sessionId: SESSION_ID,

--- a/apps/desktop/src/store/slices/github/index.test.ts
+++ b/apps/desktop/src/store/slices/github/index.test.ts
@@ -1901,6 +1901,110 @@ describe('store contract', () => {
       expect(result).toEqual({ pushed: false, resolved: 0, failed: 0 });
     });
 
+    it('pushAllResolutions surfaces the initial queue read failure instead of rejecting', async () => {
+      const store = await getStore();
+      store.setState({
+        workspaces: [buildWorkspace()],
+        sessions: [buildSession()],
+        notifications: [],
+        resolverThreadOutcomes: {},
+        sessionPendingResolutions: {},
+        refreshSessionPrDetail: vi.fn(async () => undefined),
+      });
+      listPendingResolutionsForSessionSpy.mockRejectedValueOnce(new Error('database is locked'));
+
+      const result = await store.getState().pushAllResolutions(SESSION_ID);
+
+      expect(result).toEqual({ pushed: false, resolved: 0, failed: 0 });
+      expect(gitPushSpy).not.toHaveBeenCalled();
+      const notification = store.getState().notifications[0];
+      expect(notification?.title).toBe("couldn't read the comment queue, nothing pushed");
+      expect(notification?.body).toBe('database is locked');
+      expect(notification?.action).toEqual({
+        kind: 'retry-push-resolutions',
+        sessionId: SESSION_ID,
+      });
+    });
+
+    it('pushAllResolutions surfaces the post-push queue refresh failure instead of rejecting', async () => {
+      const store = await getStore();
+      const fix = {
+        id: 'pending-fix',
+        sessionId: SESSION_ID,
+        prNumber: 1,
+        threadId: 'PRRT_1',
+        commitSha: 'abcdef1234567890',
+        reply: 'fixed it',
+        outcome: 'resolved',
+        replyPostedAt: null,
+        createdAt: NOW,
+      } satisfies PendingResolution;
+      store.setState({
+        workspaces: [buildWorkspace()],
+        sessions: [buildSession()],
+        sessionBranches: { [SESSION_ID]: 'ak/feat-x' },
+        sessionWorktrees: { [SESSION_ID]: ['/tmp/repo/.wt/x'] },
+        notifications: [],
+        resolverThreadOutcomes: {},
+        sessionPendingResolutions: { [SESSION_ID]: [fix] },
+        refreshSessionPrDetail: vi.fn(async () => undefined),
+      });
+      listPendingResolutionsForSessionSpy
+        .mockResolvedValueOnce([fix])
+        .mockRejectedValueOnce(new Error('database is locked'));
+
+      const result = await store.getState().pushAllResolutions(SESSION_ID);
+
+      expect(result).toEqual({ pushed: true, resolved: 1, failed: 0 });
+      expect(deletePendingResolutionSpy).toHaveBeenCalledOnce();
+      const notification = store.getState().notifications[0];
+      expect(notification?.title).toBe('queue refresh failed after push');
+      expect(notification?.body).toContain('database is locked');
+      expect(notification?.action).toEqual({
+        kind: 'retry-push-resolutions',
+        sessionId: SESSION_ID,
+      });
+    });
+
+    it('resolveAgentThreads surfaces the queue read failure instead of rejecting', async () => {
+      const store = await getStore();
+      store.setState({
+        workspaces: [buildWorkspace()],
+        sessions: [buildSession()],
+        notifications: [],
+        sessionPhaseRuns: {
+          [SESSION_ID]: [
+            {
+              id: AGENT_ID,
+              sessionId: SESSION_ID,
+              ordinal: 0,
+              name: 'combined resolver',
+              status: 'completed',
+              sourceThreadIds: ['PRRT_1'],
+            },
+          ],
+        },
+        resolverThreadOutcomes: {
+          [AGENT_ID]: {
+            PRRT_1: { kind: 'resolved', commitSha: 'abcdef1234567890' },
+          },
+        },
+      });
+      listPendingResolutionsForSessionSpy.mockRejectedValueOnce(new Error('database is locked'));
+
+      const didResolve = await store.getState().resolveAgentThreads(SESSION_ID, AGENT_ID);
+
+      expect(didResolve).toBe(false);
+      expect(gitPushSpy).not.toHaveBeenCalled();
+      const notification = store.getState().notifications[0];
+      expect(notification?.title).toBe("couldn't read the comment queue, threads left open");
+      expect(notification?.body).toBe('database is locked');
+      expect(notification?.action).toEqual({
+        kind: 'retry-push-resolutions',
+        sessionId: SESSION_ID,
+      });
+    });
+
     it('resolveAgentThreads keeps closing after one thread throws and still refreshes', async () => {
       const store = await getStore();
       const refresh = vi.fn(async () => undefined);

--- a/apps/desktop/src/store/slices/github/pushAllResolutions.ts
+++ b/apps/desktop/src/store/slices/github/pushAllResolutions.ts
@@ -183,7 +183,7 @@ export const pushAllResolutions = (set: SetFn, get: GetFn) => {
             'error',
             'warning',
             'queue refresh failed after push',
-            `${formatError(err)} some comments may still show as pending until you retry.`,
+            `${formatError(err)}. some comments may still show as pending until you retry.`,
             { ...notifyTarget, action: { kind: 'retry-push-resolutions', sessionId } },
           );
         }

--- a/apps/desktop/src/store/slices/github/pushAllResolutions.ts
+++ b/apps/desktop/src/store/slices/github/pushAllResolutions.ts
@@ -1,5 +1,5 @@
 import { deletePendingResolution, listPendingResolutionsForSession } from '@goodboy/db';
-import type { PendingResolutionOutcome, SessionId } from '@goodboy/types';
+import type { PendingResolution, PendingResolutionOutcome, SessionId } from '@goodboy/types';
 import { tauriDatabase } from '../../../shared/lib/db';
 import { formatError } from '../../../shared/lib/errors';
 import { markThreadResolvedNoPush } from './markThreadResolvedNoPush';
@@ -40,7 +40,19 @@ export const pushAllResolutions = (set: SetFn, get: GetFn) => {
           ...(workspace !== undefined && { workspaceId: workspace.id }),
         };
 
-        const pending = await listPendingResolutionsForSession({ db: tauriDatabase, sessionId });
+        let pending: ReadonlyArray<PendingResolution>;
+        try {
+          pending = await listPendingResolutionsForSession({ db: tauriDatabase, sessionId });
+        } catch (err) {
+          void get().emitNotification(
+            'error',
+            'error',
+            "couldn't read the comment queue, nothing pushed",
+            formatError(err),
+            { ...notifyTarget, action: { kind: 'retry-push-resolutions', sessionId } },
+          );
+          return { pushed: false, resolved: 0, failed: 0 };
+        }
         if (pending.length === 0) {
           return { pushed: false, resolved: 0, failed: 0 };
         }
@@ -161,10 +173,20 @@ export const pushAllResolutions = (set: SetFn, get: GetFn) => {
           }
         }
 
-        const rows = await listPendingResolutionsForSession({ db: tauriDatabase, sessionId });
-        set((state) => ({
-          sessionPendingResolutions: { ...state.sessionPendingResolutions, [sessionId]: rows },
-        }));
+        try {
+          const rows = await listPendingResolutionsForSession({ db: tauriDatabase, sessionId });
+          set((state) => ({
+            sessionPendingResolutions: { ...state.sessionPendingResolutions, [sessionId]: rows },
+          }));
+        } catch (err) {
+          void get().emitNotification(
+            'error',
+            'warning',
+            'queue refresh failed after push',
+            `${formatError(err)} some comments may still show as pending until you retry.`,
+            { ...notifyTarget, action: { kind: 'retry-push-resolutions', sessionId } },
+          );
+        }
         await get().refreshSessionPrDetail(sessionId, { force: true });
 
         if (failed > 0) {

--- a/apps/desktop/src/store/slices/github/resolveAgentThreads.ts
+++ b/apps/desktop/src/store/slices/github/resolveAgentThreads.ts
@@ -3,7 +3,12 @@ import {
   listPendingResolutionsForSession,
   queuePendingResolution,
 } from '@goodboy/db';
-import type { AgentId, PendingResolutionOutcome, SessionId } from '@goodboy/types';
+import type {
+  AgentId,
+  PendingResolution,
+  PendingResolutionOutcome,
+  SessionId,
+} from '@goodboy/types';
 import { agentThreadIds } from '../../../features/session/agentThreadIds';
 import { closedThreadIds } from '../../../features/session/closedThreadIds';
 import { resolverThreadSettlements } from '../../../features/session/resolverThreadSettlements';
@@ -79,7 +84,19 @@ export const resolveAgentThreads = (set: SetFn, get: GetFn) => {
           ...(workspace !== undefined && { workspaceId: workspace.id }),
         };
         const outcomes = get().resolverThreadOutcomes[agentId] ?? {};
-        const persisted = await listPendingResolutionsForSession({ db: tauriDatabase, sessionId });
+        let persisted: ReadonlyArray<PendingResolution>;
+        try {
+          persisted = await listPendingResolutionsForSession({ db: tauriDatabase, sessionId });
+        } catch (err) {
+          void get().emitNotification(
+            'error',
+            'error',
+            "couldn't read the comment queue, threads left open",
+            formatError(err),
+            { ...notifyTarget, action: { kind: 'retry-push-resolutions', sessionId } },
+          );
+          return false;
+        }
         const threadIds = [...new Set([...agentThreadIds(agent), ...Object.keys(outcomes)])];
         if (threadIds.length === 0) {
           void get().emitNotification(

--- a/packages/db/src/queries/notification.ts
+++ b/packages/db/src/queries/notification.ts
@@ -26,7 +26,8 @@ export type NotificationAction =
       readonly agentId: AgentId;
     }
   | { readonly kind: 'open-budget'; readonly sessionId: SessionId | null }
-  | { readonly kind: 'open-orphan-worktrees'; readonly workspaceId: WorkspaceId };
+  | { readonly kind: 'open-orphan-worktrees'; readonly workspaceId: WorkspaceId }
+  | { readonly kind: 'retry-push-resolutions'; readonly sessionId: SessionId };
 
 export type Notification = {
   readonly id: string;


### PR DESCRIPTION
## What was already true today

A global unhandled-rejection boundary is mounted (`App.tsx:61,210` -> `useUnhandledRejectionNotice` -> `emitNotification`), so a failure in the pending-resolution queue read was already surfacing as a persisted, warning-severity inbox row with the raw error. The user was not left with nothing. What that generic boundary could not do: name the batch, say what stage failed, say what was still queued, carry a `sessionId`/`workspaceId` to deep-link, or offer a retry. The strip's `busy` also just reset with no error state, so the button looked idle again with no signal anything happened.

## What changed

Two real risks guarded with `try/catch`, matching the notification shape already used at `pushAllResolutions.ts:67-73`:

- `pushAllResolutions.ts` line 43 (initial `listPendingResolutionsForSession`, before anything runs): on failure, emits `"couldn't read the comment queue, nothing pushed"` with the formatted error and a `retry-push-resolutions` action, then returns `{ pushed: false, resolved: 0, failed: 0 }` instead of throwing.
- `pushAllResolutions.ts` line 164 (post-loop re-list, after per-item deletes already committed): on failure, emits `"queue refresh failed after push"` and continues into the existing tail logic (`refreshSessionPrDetail`, the `failed > 0` / `commented > 0` notifications), since those don't depend on the stale read.
- `resolveAgentThreads.ts` line 82 has the identical unguarded shape, reached from `useResolverActions.run` (no catch), which is `void`-invoked from `ResolverActionBlock/index.tsx:61,84` and `ResolverCardAction.tsx:74`, plus the confirm-gated paths at `ResolverActionBlock/index.tsx:31`, `ResolverCardAction.tsx:90`, and `ResolverOverflowMenu.tsx:106` that bottom out in `packages/ui/src/components/InlineConfirm.tsx:112`'s `void confirm()`. Guarding at the store-slice level fixes every one of those call sites at once, since none of them can see past the slice function's return.

Line 168 (`refreshSessionPrDetail`) was left alone: it self-catches internally (`refreshSessionPrDetail.ts:117`) and writes `detailError` to state rather than throwing, so wrapping it again would be redundant.

## Retry action

Added `retry-push-resolutions` to the `NotificationAction` union (`packages/db/src/queries/notification.ts`), following `retry-summarizer`'s shape exactly. Wired in `NotificationToastBridge`'s `mapNotificationAction` (the exhaustive `never` check forces this): `onClick` re-runs `pushAllResolutions(sessionId)`, which is session-scoped and safe to retry since `pending_resolutions` is a shared, idempotent queue regardless of which entry point originally populated it.

## Out of scope, left alone

- `pending_resolutions` durability: it's a transient write-ahead queue by design, the durable verdict source is message replay.
- The per-item try/catch inside the processing loop: partial failure is already handled correctly.
- `withResolutionLock`: already releases in a `finally`.

## Tests

`apps/desktop/src/store/slices/github/index.test.ts`: covers the line-43 failure (returns early, notification fires with the retry action, no push attempted), the line-164 failure (result still reflects the completed work, notification fires, no throw), and the sibling `resolveAgentThreads` line-82 failure (returns `false`, notification fires, no push attempted). `notificationAction.test.ts`: covers the new mapping returning a Retry action that calls `pushAllResolutions` with the session id.
