### PR TITLE
fix(desktop): mark and notify on degraded step summaries

### DIFF
--- a/apps/desktop/src/__tests__/parallel-e2e.test.ts
+++ b/apps/desktop/src/__tests__/parallel-e2e.test.ts
@@ -163,6 +163,7 @@ function makeEffects(): { effects: ParallelBranchEffects; events: TurnEvent[] } 
       appendTurnEvent: (_agentId: AgentId, _sid: SessionId, e: TurnEvent) => events.push(e),
       refreshPhaseRuns: vi.fn(async () => undefined),
       setMergeConflicts: vi.fn(),
+      notifyDegradedStepSummary: vi.fn(),
     },
     events,
   };
@@ -359,6 +360,38 @@ describe('parallel e2e, fan-out/fan-in', () => {
       expect.objectContaining({
         outputSummary: `${'h'.repeat(1500)}\n...\n${'t'.repeat(400)}`,
       }),
+    );
+    expect(effects.notifyDegradedStepSummary).toHaveBeenCalledTimes(1);
+    expect(effects.notifyDegradedStepSummary).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: 'pr-d-b', agentName: 'd-b' }),
+    );
+  });
+
+  it('does not mark the representative branch as degraded', async () => {
+    const insertedPhaseRuns: Parameters<typeof wirePhaseRunSpies>[0] = [];
+    wirePhaseRunSpies(insertedPhaseRuns);
+    const { effects } = makeEffects();
+    const inputs = makeInputs([makeDef('d-a', 1), makeDef('d-b', 2)]);
+    const branchPromise = runParallelBranch(inputs, makeDeps(effects));
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    const spawnedRunIds = (
+      invokeParallelPhaseRunSpawnSpy.mock.calls as unknown as ReadonlyArray<
+        [{ runs: ReadonlyArray<{ runId: string }> }]
+      >
+    ).map(([args]) => args.runs[0]!.runId) as [string, string];
+    const [representativeRunId, otherRunId] = spawnedRunIds;
+    emitLine(representativeRunId, 'representative output');
+    emitLine(otherRunId, 'other output');
+    emitEnd(representativeRunId, 0);
+    emitEnd(otherRunId, 0);
+
+    await branchPromise;
+
+    expect(effects.notifyDegradedStepSummary).toHaveBeenCalledTimes(1);
+    expect(effects.notifyDegradedStepSummary).not.toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: 'pr-d-a' }),
     );
   });
 

--- a/apps/desktop/src/shared/utils/degradedNotifiedAgents.ts
+++ b/apps/desktop/src/shared/utils/degradedNotifiedAgents.ts
@@ -1,0 +1,3 @@
+import type { AgentId } from '@goodboy/types';
+
+export const degradedNotifiedAgents = new Set<AgentId>();

--- a/apps/desktop/src/store/parallel-turn.ts
+++ b/apps/desktop/src/store/parallel-turn.ts
@@ -69,6 +69,11 @@ export type ParallelBranchEffects = {
   appendTurnEvent: (agentId: AgentId, sessionId: SessionId, event: TurnEvent) => void;
   refreshPhaseRuns: (sessionId: SessionId) => Promise<void>;
   setMergeConflicts: (sessionId: SessionId, conflicts: ReadonlyArray<FileConflict>) => void;
+  notifyDegradedStepSummary: (params: {
+    readonly agentId: AgentId;
+    readonly sessionId: SessionId;
+    readonly agentName: string;
+  }) => void;
 };
 
 export type ParallelBranchResult = {
@@ -429,15 +434,24 @@ export const runParallelBranch = async (
       const phaseRunsAfter = await invokeAgentList(session.id);
       const row = phaseRunsAfter.find((r) => r.runId === runId && r.stepId === def.id);
       if (row) {
+        const isRepresentative =
+          status?.runId === representativeRunId && carryForwardContext.length > 0;
         await invokeAgentUpdateStatus(row.id, {
           status: (status?.status ?? 'failed') as AgentStatus,
           completedAt: now(),
-          ...(status?.runId === representativeRunId && carryForwardContext.length > 0
+          ...(isRepresentative
             ? { outputSummary: carryForwardContext }
             : status?.outputSummary != null
               ? { outputSummary: fallbackStepOutputSummary({ output: status.outputSummary }) }
               : {}),
         });
+        if (!isRepresentative && status?.outputSummary != null) {
+          effects.notifyDegradedStepSummary({
+            agentId: row.id,
+            sessionId: session.id,
+            agentName: def.name,
+          });
+        }
       }
     }
     await effects.refreshPhaseRuns(session.id);

--- a/apps/desktop/src/store/slices/turn/completeResolvedAgent.test.ts
+++ b/apps/desktop/src/store/slices/turn/completeResolvedAgent.test.ts
@@ -15,6 +15,7 @@ vi.mock('../../../features/workflows/workflows', () => ({
 }));
 
 import { completeResolvedAgent } from './completeResolvedAgent';
+import { degradedNotifiedAgents } from '../../../shared/utils/degradedNotifiedAgents';
 
 const SESSION_ID = 'session-1' as SessionId;
 const AGENT_ID = 'agent-1' as AgentId;
@@ -37,6 +38,7 @@ type Harness = {
     resolverThreadOutcomes: Record<AgentId, Record<string, ResolverThreadOutcome>>;
     refreshUnreadWorkspaces: ReturnType<typeof vi.fn>;
     activateNextResolver: ReturnType<typeof vi.fn>;
+    emitNotification: ReturnType<typeof vi.fn>;
   };
   readonly set: SetFn;
   readonly get: GetFn;
@@ -52,6 +54,7 @@ const createHarness = ({}: HarnessParams): Harness => {
     resolverThreadOutcomes: {},
     refreshUnreadWorkspaces: vi.fn(async () => undefined),
     activateNextResolver: vi.fn(async () => undefined),
+    emitNotification: vi.fn(async () => undefined),
   };
   const set = ((update: unknown) => {
     if (typeof update === 'function') {
@@ -178,5 +181,29 @@ describe('completeResolvedAgent', () => {
       kind: 'resolved',
       commitSha: 'abcdef1234567890',
     });
+  });
+
+  it('completes a plain non-workflow agent via raw fallback without notifying the inbox', async () => {
+    const { state, set, get } = createHarness({});
+    state.sessionPhaseRuns = {
+      [SESSION_ID]: [{ ...agent, kind: 'implementer', sourceThreadIds: undefined }],
+    };
+    degradedNotifiedAgents.clear();
+
+    await completeResolvedAgent({
+      set,
+      get,
+      sessionId: SESSION_ID,
+      resolvedAgentId: AGENT_ID,
+      assistantText: 'did the thing, no markers here',
+      now: () => NOW,
+    });
+
+    expect(h.invokeAgentUpdateStatus).toHaveBeenCalledWith(
+      AGENT_ID,
+      expect.objectContaining({ status: 'completed' }),
+    );
+    expect(state.emitNotification).not.toHaveBeenCalled();
+    expect(degradedNotifiedAgents.has(AGENT_ID)).toBe(false);
   });
 });

--- a/apps/desktop/src/store/slices/turn/dispatchParallelTurn.test.ts
+++ b/apps/desktop/src/store/slices/turn/dispatchParallelTurn.test.ts
@@ -1,0 +1,224 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  AgentId,
+  IsoDateTime,
+  ParallelGroupId,
+  ProviderId,
+  ProviderRunId,
+  Session,
+  SessionId,
+  Step,
+  Workflow,
+  WorkflowId,
+  WorkspaceId,
+} from '@goodboy/types';
+import type { ParallelBranchEffects, ParallelBranchInputs } from '../../parallel-turn';
+import type { GetFn, SetFn } from './types';
+
+const h = vi.hoisted(() => ({
+  runParallelBranch: vi.fn(),
+  insertMessage: vi.fn(async () => undefined),
+  updateSessionState: vi.fn(async () => undefined),
+  invokeAgentList: vi.fn(async () => []),
+  flushTurnEvents: vi.fn(),
+  beginTurnFileVersionCapture: vi.fn(async () => null),
+  finalizeTurnFileVersionCapture: vi.fn(async () => undefined),
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
+
+vi.mock('@goodboy/db', () => ({
+  insertMessage: h.insertMessage,
+  updateSessionState: h.updateSessionState,
+}));
+
+vi.mock('../../../shared/lib/db', () => ({
+  tauriDatabase: { execute: vi.fn(), select: vi.fn() },
+}));
+
+vi.mock('../../parallel-turn', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../parallel-turn')>();
+  return { ...actual, runParallelBranch: h.runParallelBranch };
+});
+
+vi.mock('../../../features/workflows/workflows', () => ({
+  invokeAgentList: h.invokeAgentList,
+}));
+
+vi.mock('../transcripts/buffer', () => ({ flushTurnEvents: h.flushTurnEvents }));
+
+vi.mock('../file-versions/captureTurnFileVersions', () => ({
+  beginTurnFileVersionCapture: h.beginTurnFileVersionCapture,
+  finalizeTurnFileVersionCapture: h.finalizeTurnFileVersionCapture,
+}));
+
+import { dispatchParallelTurn } from './dispatchParallelTurn';
+import { degradedNotifiedAgents } from '../../../shared/utils/degradedNotifiedAgents';
+
+const SESSION_ID = 'session-1' as SessionId;
+const WORKSPACE_ID = 'workspace-1' as WorkspaceId;
+const AGENT_ID = 'agent-1' as AgentId;
+const TEMPLATE_ID = 'tpl-1' as WorkflowId;
+const NOW = '2026-08-08T00:00:00.000Z' as IsoDateTime;
+
+const makeStep = (id: string, ordinal: number): Step =>
+  ({
+    id: id as Step['id'],
+    workflowId: TEMPLATE_ID,
+    ordinal,
+    name: id,
+    promptPrefix: `[${id}]`,
+    parallelGroup: 1,
+  }) as Step;
+
+const session: Session = {
+  id: SESSION_ID,
+  workspaceId: WORKSPACE_ID,
+  goal: 'ship it',
+  state: { kind: 'idle', lastActivityAt: NOW },
+  contextSlots: [],
+  providerPreference: { defaultProvider: 'anthropic', allowTurnOverride: true },
+  permissionMode: 'default',
+  workflowRuns: [],
+  autoRun: true,
+  titleUserEdited: false,
+  createdAt: NOW,
+  updatedAt: NOW,
+};
+
+const template: Workflow = {
+  id: TEMPLATE_ID,
+  workspaceId: WORKSPACE_ID,
+  name: 'tpl',
+  origin: 'custom',
+  steps: [makeStep('d-a', 1), makeStep('d-b', 2)],
+} as unknown as Workflow;
+
+type Harness = {
+  readonly state: Record<string, unknown>;
+  readonly set: SetFn;
+  readonly get: GetFn;
+};
+
+const buildHarness = (): Harness => {
+  const state: Record<string, unknown> = {
+    sessions: [session],
+    workspaces: [{ id: WORKSPACE_ID, rootPath: '/tmp/repo', kind: 'repo' }],
+    sessionBudgets: {},
+    sessionTelemetry: {},
+    sessionSummary: null,
+    sessionBranches: { [SESSION_ID]: 'ak/workflow' },
+    sessionFileVersions: {},
+    authResults: {},
+    appendTurnEvent: vi.fn(),
+    emitNotification: vi.fn(),
+    setSessionMergeConflicts: vi.fn(),
+  };
+  const set = ((update: unknown) => {
+    const patch =
+      typeof update === 'function'
+        ? (update as (s: Record<string, unknown>) => Record<string, unknown>)(state)
+        : (update as Record<string, unknown>);
+    Object.assign(state, patch);
+  }) as unknown as SetFn;
+  const get = (() => state) as unknown as GetFn;
+  return { state, set, get };
+};
+
+describe('dispatchParallelTurn notifyDegradedStepSummary effect', () => {
+  beforeEach(() => {
+    degradedNotifiedAgents.clear();
+    h.runParallelBranch.mockReset();
+    h.insertMessage.mockClear();
+    h.updateSessionState.mockClear();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const runDispatch = async (harness: Harness): Promise<ParallelBranchEffects> => {
+    let capturedEffects: ParallelBranchEffects | null = null;
+    h.runParallelBranch.mockImplementation(
+      async (_inputs: ParallelBranchInputs, deps: { effects: ParallelBranchEffects }) => {
+        capturedEffects = deps.effects;
+        return {
+          groupId: 'group-1' as ParallelGroupId,
+          merge: { runStatuses: [] },
+          runIds: [] as ReadonlyArray<ProviderRunId>,
+          anyFailed: false,
+          allFailed: false,
+        };
+      },
+    );
+
+    await dispatchParallelTurn(harness.set, harness.get, {
+      session,
+      sessionId: SESSION_ID,
+      activeAgentId: AGENT_ID,
+      provider: 'anthropic' as ProviderId,
+      model: 'claude-sonnet-4-6',
+      effort: undefined,
+      cursorMaxMode: undefined,
+      parallelDispatch: {
+        template,
+        currentDef: template.steps[0]!,
+        groupDefs: template.steps,
+      },
+      claudeFlags: {},
+      apiKeyBinding: undefined,
+      providerBinary: undefined,
+      workingDir: '/tmp/wt',
+      userTurnText: 'go',
+      userPromptForPhase: 'go',
+      phasePromptCarryForward: '',
+      phaseWorkflowRunId: null,
+      now: () => NOW,
+    });
+
+    if (capturedEffects == null) {
+      throw new Error('runParallelBranch was not called');
+    }
+    return capturedEffects;
+  };
+
+  it('emits a summarizer-degraded notification for a branch reported as degraded', async () => {
+    const harness = buildHarness();
+    const effects = await runDispatch(harness);
+
+    effects.notifyDegradedStepSummary({
+      agentId: AGENT_ID,
+      sessionId: SESSION_ID,
+      agentName: 'd-b',
+    });
+
+    expect(harness.state.emitNotification).toHaveBeenCalledWith(
+      'summarizer-degraded',
+      'warning',
+      expect.stringContaining('d-b'),
+      expect.any(String),
+      {
+        sessionId: SESSION_ID,
+        action: { kind: 'retry-step-summary', sessionId: SESSION_ID, agentId: AGENT_ID },
+      },
+    );
+  });
+
+  it('suppresses a second notification for the same agent (dedupe)', async () => {
+    const harness = buildHarness();
+    const effects = await runDispatch(harness);
+
+    effects.notifyDegradedStepSummary({
+      agentId: AGENT_ID,
+      sessionId: SESSION_ID,
+      agentName: 'd-b',
+    });
+    effects.notifyDegradedStepSummary({
+      agentId: AGENT_ID,
+      sessionId: SESSION_ID,
+      agentName: 'd-b',
+    });
+
+    expect(harness.state.emitNotification).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/store/slices/turn/dispatchParallelTurn.ts
+++ b/apps/desktop/src/store/slices/turn/dispatchParallelTurn.ts
@@ -19,6 +19,7 @@ import { tauriDatabase } from '../../../shared/lib/db';
 import { formatError } from '../../../shared/lib/errors';
 import { AGENT_FEATURES } from '../../../shared/lib/features';
 import { isBranchlessSession } from '../../../shared/utils/isBranchlessSession';
+import { degradedNotifiedAgents } from '../../../shared/utils/degradedNotifiedAgents';
 import { createTranscriptOwnedTurnError } from '../../../features/chat/turn-errors';
 import { runParallelBranch, type ParallelBranchEffects } from '../../parallel-turn';
 import { applySessionUpdate } from '../../session-mutators';
@@ -178,6 +179,19 @@ export const dispatchParallelTurn = async (
       }));
     },
     setMergeConflicts: (sid, conflicts) => get().setSessionMergeConflicts(sid, conflicts),
+    notifyDegradedStepSummary: ({ agentId, sessionId: sid, agentName }) => {
+      if (degradedNotifiedAgents.has(agentId)) {
+        return;
+      }
+      degradedNotifiedAgents.add(agentId);
+      void get().emitNotification(
+        'summarizer-degraded',
+        'warning',
+        `step summary degraded: ${agentName}`,
+        'parallel branch output is not summarized, showing raw output instead.',
+        { sessionId: sid, action: { kind: 'retry-step-summary', sessionId: sid, agentId } },
+      );
+    },
   };
 
   try {

--- a/apps/desktop/src/store/slices/workflows/clusterImplementation.test.ts
+++ b/apps/desktop/src/store/slices/workflows/clusterImplementation.test.ts
@@ -634,9 +634,14 @@ describe('advanceClusterImplementation', () => {
   });
 
   it('stores deterministic head and tail output for a completed cluster', async () => {
-    const child = childAgent({ id: 'summary-child', ordinal: 0, status: 'running' });
+    const child = childAgent({
+      id: 'summary-child',
+      ordinal: 0,
+      status: 'running',
+      name: 'summary-child',
+    });
     const assistantText = `${'h'.repeat(1500)}middle${'t'.repeat(400)}`;
-    const { get, set } = makeStore({
+    const { get, set, emitNotification } = makeStore({
       sessionPhaseRuns: { [SID]: [container({ status: 'running' }), child] },
       sessionPlans: { [SID]: [plan({})] },
     });
@@ -652,6 +657,56 @@ describe('advanceClusterImplementation', () => {
       expect.objectContaining({
         outputSummary: `${'h'.repeat(1500)}\n...\n${'t'.repeat(400)}`,
       }),
+    );
+    expect(emitNotification).toHaveBeenCalledWith(
+      'summarizer-degraded',
+      'warning',
+      expect.stringContaining('summary-child'),
+      expect.any(String),
+      { sessionId: SID, action: { kind: 'retry-step-summary', sessionId: SID, agentId: child.id } },
+    );
+  });
+
+  it('notifies the degraded summary only once for the same child (dedupe)', async () => {
+    const child = childAgent({ id: 'dedupe-child', ordinal: 0, status: 'running' });
+    const { get, set, emitNotification } = makeStore({
+      sessionPhaseRuns: { [SID]: [container({ status: 'running' }), child] },
+    });
+    hoisted.invokeAgentList.mockResolvedValue([
+      container({ status: 'running' }),
+      childAgent({ id: 'dedupe-child', ordinal: 0, status: 'completed' }),
+    ]);
+    const advance = advanceClusterImplementation(set, get);
+
+    await advance(SID, child.id, 'raw output', { force: true });
+    await advance(SID, child.id, 'raw output again', { force: true });
+
+    expect(emitNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not notify degraded when the child advances with no output to summarize', async () => {
+    const child = childAgent({ id: 'manual-advance', ordinal: 0, status: 'running' });
+    const { get, set, emitNotification } = makeStore({
+      sessionPhaseRuns: { [SID]: [container({ status: 'running' }), child] },
+      sessionPlans: { [SID]: [plan({})] },
+    });
+    hoisted.invokeAgentList.mockResolvedValue([
+      container({ status: 'running' }),
+      childAgent({ id: 'manual-advance', ordinal: 0, status: 'completed' }),
+    ]);
+
+    await advanceClusterImplementation(set, get)(SID, child.id, '', { force: true });
+
+    expect(hoisted.invokeAgentUpdateStatus).toHaveBeenCalledWith(
+      child.id,
+      expect.objectContaining({ outputSummary: 'advanced to next cluster manually' }),
+    );
+    expect(emitNotification).not.toHaveBeenCalledWith(
+      'summarizer-degraded',
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
     );
   });
 

--- a/apps/desktop/src/store/slices/workflows/clusterImplementation.ts
+++ b/apps/desktop/src/store/slices/workflows/clusterImplementation.ts
@@ -14,6 +14,7 @@ import {
   invokeAgentUpdateStatus,
 } from '../../../features/workflows/workflows';
 import { listConsumptionsForPlan as invokeListConsumptionsForPlan } from '../../../features/plans/plans';
+import { degradedNotifiedAgents } from '../../../shared/utils/degradedNotifiedAgents';
 import { composeKickoff, composeUnitBoundary } from '../../kickoff';
 import { childRoutingFromParent } from './childRoutingFromParent';
 import { isHandsFree } from './handsFree';
@@ -352,10 +353,20 @@ export const advanceClusterImplementation = (set: SetFn, get: GetFn) => {
     }
 
     continueAttempts.delete(childAgentId);
-    const outputSummary =
-      assistantText.length > 0
-        ? fallbackStepOutputSummary({ output: assistantText })
-        : 'advanced to next cluster manually';
+    const usesFallbackSummary = assistantText.length > 0;
+    const outputSummary = usesFallbackSummary
+      ? fallbackStepOutputSummary({ output: assistantText })
+      : 'advanced to next cluster manually';
+    if (usesFallbackSummary && !degradedNotifiedAgents.has(childAgentId)) {
+      degradedNotifiedAgents.add(childAgentId);
+      void get().emitNotification(
+        'summarizer-degraded',
+        'warning',
+        `step summary degraded: ${child.name}`,
+        'cluster continuation summaries skip the LLM summarizer, showing raw output instead.',
+        { sessionId, action: { kind: 'retry-step-summary', sessionId, agentId: childAgentId } },
+      );
+    }
     await invokeAgentUpdateStatus(childAgentId, {
       status: 'completed',
       outputSummary,

--- a/apps/desktop/src/store/slices/workflows/finalizeWorkflowStep.test.ts
+++ b/apps/desktop/src/store/slices/workflows/finalizeWorkflowStep.test.ts
@@ -37,8 +37,9 @@ vi.mock('../../../features/workflows/workflows', () => ({
   invokeAgentUpdateStatus: invokeAgentUpdateStatusSpy,
 }));
 
-import { finalizeWorkflowStep, degradedNotifiedAgents } from './finalizeWorkflowStep';
+import { finalizeWorkflowStep } from './finalizeWorkflowStep';
 import { SUMMARY_TIMEOUT_MS, stepSummaryDegraded } from '../../summarizeAgentOutput';
+import { degradedNotifiedAgents } from '../../../shared/utils/degradedNotifiedAgents';
 
 const SESSION_ID = 'session-1' as SessionId;
 const AGENT_ID = 'agent-1' as AgentId;
@@ -317,5 +318,31 @@ describe('finalizeWorkflowStep output summary', () => {
       }),
     );
     expect(result).toEqual({ shouldAutoAdvance: true });
+  });
+
+  it('does not notify the inbox for the session-missing guard fallback (excluded from I6)', async () => {
+    const state = {
+      sessionPhaseRuns: { [SESSION_ID]: [agent] },
+      sessions: [],
+      workspaces: [{ id: WORKSPACE_ID, rootPath: '/tmp/repo', kind: 'repo' }],
+      sessionMounts: {},
+      sessionActiveMount: {},
+      sessionWorktrees: { [SESSION_ID]: ['/tmp/worktree'] },
+      sessionBranches: { [SESSION_ID]: 'ak/workflow' },
+      refreshUnreadWorkspaces: vi.fn(),
+      emitNotification: vi.fn(),
+      sendTurn: vi.fn(),
+    };
+    const set = vi.fn();
+    const get = (() => state) as unknown as Parameters<typeof finalizeWorkflowStep>[1];
+    const finalize = finalizeWorkflowStep(
+      set as unknown as Parameters<typeof finalizeWorkflowStep>[0],
+      get,
+    );
+
+    await finalize(SESSION_ID, AGENT_ID, 'short output', false, { force: true });
+
+    expect(state.emitNotification).not.toHaveBeenCalled();
+    expect(degradedNotifiedAgents.has(AGENT_ID)).toBe(false);
   });
 });

--- a/apps/desktop/src/store/slices/workflows/finalizeWorkflowStep.ts
+++ b/apps/desktop/src/store/slices/workflows/finalizeWorkflowStep.ts
@@ -12,6 +12,7 @@ import { invokeAgentList, invokeAgentUpdateStatus } from '../../../features/work
 import { stepForAgent } from '../../../features/workflows/stepForAgent';
 import { composeStepBoundary } from '../../kickoff';
 import { summarizeAgentOutput } from '../../summarizeAgentOutput';
+import { degradedNotifiedAgents } from '../../../shared/utils/degradedNotifiedAgents';
 import { getSessionRepo } from '../worktrees/getSessionRepo';
 import { isHandsFree } from './handsFree';
 import type { GetFn, SetFn } from './types';
@@ -19,7 +20,6 @@ import type { GetFn, SetFn } from './types';
 const MAX_CONTINUE = 1;
 
 const continueAttempts = new Map<string, number>();
-export const degradedNotifiedAgents = new Set<AgentId>();
 
 const nowIso = (): IsoDateTime => new Date().toISOString() as IsoDateTime;
 

--- a/apps/desktop/src/store/slices/workflows/scoutTree.fanout.test.ts
+++ b/apps/desktop/src/store/slices/workflows/scoutTree.fanout.test.ts
@@ -176,7 +176,7 @@ function makeAdvanceStore(runs: ReadonlyArray<Agent>, fanout: boolean) {
         : (u as Record<string, unknown>);
     Object.assign(state, patch);
   }) as unknown as SetFn;
-  return { state, get, set, sendTurn };
+  return { state, get, set, sendTurn, emitNotification };
 }
 
 const scoutAgent = (over: Partial<Agent> = {}): Agent => ({
@@ -234,9 +234,9 @@ describe('advanceScoutTree split decision', () => {
   });
 
   it('stores deterministic head and tail output for a completed scout', async () => {
-    const scout = scoutAgent({ id: 'summary-scout' as AgentId });
+    const scout = scoutAgent({ id: 'summary-scout' as AgentId, name: 'summary-scout' });
     const assistantText = `${'h'.repeat(1500)}middle${'t'.repeat(400)}`;
-    const { get, set } = makeAdvanceStore([scout], true);
+    const { get, set, emitNotification } = makeAdvanceStore([scout], true);
 
     await advanceScoutTree(set, get)(SID, scout.id, assistantText);
 
@@ -246,5 +246,26 @@ describe('advanceScoutTree split decision', () => {
         outputSummary: `${'h'.repeat(1500)}\n...\n${'t'.repeat(400)}`,
       }),
     );
+    expect(emitNotification).toHaveBeenCalledWith(
+      'summarizer-degraded',
+      'warning',
+      expect.stringContaining('summary-scout'),
+      expect.any(String),
+      {
+        sessionId: SID,
+        action: { kind: 'retry-step-summary', sessionId: SID, agentId: scout.id },
+      },
+    );
+  });
+
+  it('notifies the degraded summary only once for the same scout (dedupe)', async () => {
+    const scout = scoutAgent({ id: 'dedupe-scout' as AgentId });
+    const { get, set, emitNotification } = makeAdvanceStore([scout], true);
+    const advance = advanceScoutTree(set, get);
+
+    await advance(SID, scout.id, 'raw output');
+    await advance(SID, scout.id, 'raw output again');
+
+    expect(emitNotification).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/desktop/src/store/slices/workflows/scoutTree.ts
+++ b/apps/desktop/src/store/slices/workflows/scoutTree.ts
@@ -18,6 +18,7 @@ import {
   type AgentKind,
 } from '../../../features/session/agent-kind';
 import { roleModelsForSession } from '../overrides/roleModelsForSession';
+import { degradedNotifiedAgents } from '../../../shared/utils/degradedNotifiedAgents';
 import type { GetFn, SetFn } from './types';
 
 export const SCOUT_DEPTH_CAP = 2;
@@ -457,14 +458,26 @@ const settleAgent = async ({
   get,
   sessionId,
   agentId,
+  agentName,
   summary,
 }: {
   readonly set: SetFn;
   readonly get: GetFn;
   readonly sessionId: SessionId;
   readonly agentId: AgentId;
+  readonly agentName: string;
   readonly summary: string;
 }): Promise<void> => {
+  if (!degradedNotifiedAgents.has(agentId)) {
+    degradedNotifiedAgents.add(agentId);
+    void get().emitNotification(
+      'summarizer-degraded',
+      'warning',
+      `step summary degraded: ${agentName}`,
+      'fan-out branch summaries skip the LLM summarizer, showing raw output instead.',
+      { sessionId, action: { kind: 'retry-step-summary', sessionId, agentId } },
+    );
+  }
   await invokeAgentUpdateStatus(agentId, {
     status: 'completed',
     outputSummary: summary,
@@ -525,6 +538,7 @@ export const advanceScoutTree = (set: SetFn, get: GetFn) => {
       get,
       sessionId,
       agentId,
+      agentName: agent.name,
       summary: fallbackStepOutputSummary({ output: assistantText }),
     });
   };


### PR DESCRIPTION
## What a user notices

When a workflow step's output could not be summarized, some paths quietly showed the raw, truncated output as the step summary instead of an LLM digest, with no record of it and no inbox notification. The one path that already handled this correctly (sequential step completion via `finalizeWorkflowStep`) marks the summary degraded, dedupes per agent, and puts a `summarizer-degraded` notification in the inbox with a retry action. Three other paths skipped all of that. Now they don't.

## The three sites, wired into the existing mechanism

1. `clusterImplementation.ts` (`advanceClusterImplementation`) — a cluster child that reaches its done marker gets its output summarized via `fallbackStepOutputSummary` unconditionally (never through the LLM summarizer). Now emits `summarizer-degraded` (deduped per child) whenever that fallback branch actually runs. The empty-text "advanced to next cluster manually" placeholder is not a fallback and does not notify.
2. `scoutTree.ts` (`settleAgent`, the terminal branch of `advanceScoutTree`) — every scout/reviewer/tester/investigator leaf that finishes without a further fan-out always used the raw fallback. Now notifies once per agent before completing it.
3. `parallel-turn.ts` (`runParallelBranch`) — every non-representative completed branch in a parallel group gets its raw output truncated via `fallbackStepOutputSummary`. Now notifies once per branch agent.

## Two sites deliberately excluded (untouched, now pinned by tests)

- `completeResolvedAgent.ts`'s plain fallback (non-workflow agent completion) is by design: marking it would fire the inbox on the app's most common completion path (cost + latency on every ordinary agent). Separate work item.
- `finalizeWorkflowStep.ts`'s `session == null` branch is a defensive guard, not a fallback path a user should be notified about.

Both now have a test asserting they emit nothing.

## The parallel-turn site is two files, not one

`runParallelBranch` in `parallel-turn.ts` is a plain function, not a zustand slice: no `get()`, no `emitNotification`, no `resolveTaskModel`. Its caller, `dispatchParallelTurn.ts`, is a slice and builds `ParallelBranchEffects` inline. So this required extending `ParallelBranchEffects` with a `notifyDegradedStepSummary` effect in `parallel-turn.ts`, and implementing it in `dispatchParallelTurn.ts` using `get().emitNotification` and the shared dedupe set.

## Structural move

`degradedNotifiedAgents` (the dedupe `Set<AgentId>`) moved out of `finalizeWorkflowStep.ts` into its own module, `apps/desktop/src/shared/utils/degradedNotifiedAgents.ts`. One notification kind should not have its dedupe state split across call sites. `finalizeWorkflowStep.ts` and its test now import from there; the three new sites (and `dispatchParallelTurn.ts`) share the same instance.

## Scope

No database schema change: `summarizer-degraded` is an existing `NotificationKind` value and the column has no CHECK constraint.

## Not exercised against a live service

All coverage is unit-level against mocked store/effects, matching the existing pattern in this codebase (no live provider or Tauri runtime in tests). `parallel-turn.test.ts` and `dispatchParallelTurn.test.ts` did not exist before this change; both are new.

## Test plan

- `pnpm typecheck` green.
- `pnpm test`: 621 test files, 5208 tests, all green.
- `pnpm knip --include files,duplicates,unlisted` clean (only pre-existing config hints).
- `pnpm exec turbo run test --force` confirms `Cached: 0 cached, 4 total` (a real run, not a replayed sibling log).
- New/extended coverage: each of the three sites emits `summarizer-degraded` exactly once per agent; a second completion for the same agent is suppressed (dedupe); `completeResolvedAgent`'s plain fallback and `finalizeWorkflowStep`'s `session == null` guard emit nothing.