### PR TITLE
refactor(desktop): converge four anchored popovers on the shared dropdown hook

### DIFF
--- a/apps/desktop/src/features/github/components/GitHubStudio/ReviewerPicker.test.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/ReviewerPicker.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+const { collaboratorsMock } = vi.hoisted(() => ({
+  collaboratorsMock: vi.fn(async (): Promise<ReadonlyArray<string>> => ['octocat', 'hubot']),
+}));
+
+vi.mock('../../github', () => ({ ghRepoCollaborators: collaboratorsMock }));
+vi.mock('../../../../store', () => ({ useCurrentWorkspace: () => ({ id: 'ws-1' }) }));
+
+import { ReviewerPicker } from './ReviewerPicker';
+
+const renderPicker = ({ onAdd = vi.fn() }: { readonly onAdd?: () => void } = {}) => {
+  render(<ReviewerPicker workspaceRoot="/tmp/repo" exclude={new Set<string>()} onAdd={onAdd} />);
+  return { onAdd };
+};
+
+const openPanel = () => fireEvent.click(screen.getByRole('button', { name: /request review/i }));
+
+beforeEach(() => {
+  collaboratorsMock.mockClear();
+});
+afterEach(cleanup);
+
+describe('ReviewerPicker', () => {
+  it('lists the repo collaborators once opened', async () => {
+    renderPicker();
+    openPanel();
+    await waitFor(() => expect(screen.getByText('octocat')).toBeDefined());
+    expect(screen.getByText('hubot')).toBeDefined();
+  });
+
+  it('filters the collaborators by the typed query', async () => {
+    renderPicker();
+    openPanel();
+    await waitFor(() => expect(screen.getByText('octocat')).toBeDefined());
+    fireEvent.change(screen.getByPlaceholderText('filter collaborators'), {
+      target: { value: 'hub' },
+    });
+    expect(screen.queryByText('octocat')).toBeNull();
+    expect(screen.getByText('hubot')).toBeDefined();
+  });
+
+  it('adds the picked login and closes', async () => {
+    const { onAdd } = renderPicker();
+    openPanel();
+    await waitFor(() => expect(screen.getByText('octocat')).toBeDefined());
+    fireEvent.click(screen.getByText('octocat'));
+    expect(onAdd).toHaveBeenCalledWith(['octocat']);
+    expect(screen.queryByPlaceholderText('filter collaborators')).toBeNull();
+  });
+
+  it('closes on a mousedown outside the picker', async () => {
+    renderPicker();
+    openPanel();
+    await waitFor(() => expect(screen.getByText('octocat')).toBeDefined());
+    fireEvent.mouseDown(document.body);
+    expect(screen.queryByPlaceholderText('filter collaborators')).toBeNull();
+  });
+});

--- a/apps/desktop/src/features/github/components/GitHubStudio/ReviewerPicker.test.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/ReviewerPicker.test.tsx
@@ -52,6 +52,22 @@ describe('ReviewerPicker', () => {
     expect(screen.queryByPlaceholderText('filter collaborators')).toBeNull();
   });
 
+  it('closes on Escape', async () => {
+    renderPicker();
+    openPanel();
+    await waitFor(() => expect(screen.getByText('octocat')).toBeDefined());
+    fireEvent.keyDown(document.body, { key: 'Escape' });
+    expect(screen.queryByPlaceholderText('filter collaborators')).toBeNull();
+  });
+
+  it('anchors the panel by measured direction instead of a hardcoded offset', async () => {
+    renderPicker();
+    openPanel();
+    const panel = await screen.findByPlaceholderText('filter collaborators');
+    const popup = panel.closest('div.absolute');
+    expect(popup?.className).toContain('top-[calc(100%+0.25rem)]');
+  });
+
   it('closes on a mousedown outside the picker', async () => {
     renderPicker();
     openPanel();

--- a/apps/desktop/src/features/github/components/GitHubStudio/ReviewerPicker.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/ReviewerPicker.tsx
@@ -1,11 +1,12 @@
-import { useEffect, useRef, useState } from 'react';
-import { EmptyState, ScrollFade, Skeleton } from '@goodboy/ui';
+import { useEffect, useState } from 'react';
+import { cn, EmptyState, ScrollFade, Skeleton } from '@goodboy/ui';
 import { Plus, Search } from 'lucide-react';
 import { useCurrentWorkspace } from '../../../../store';
 import type { WorkspaceId } from '@goodboy/types';
 import { ghRepoCollaborators } from '../../github';
 import { NoteAvatar } from '../../../../shared/components/NoteAvatar';
 import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../shared/components/conceptIcons';
+import { useDropdown } from '../../../../shared/hooks/useDropdown';
 
 type Props = {
   readonly workspaceRoot: string | null;
@@ -15,27 +16,17 @@ type Props = {
 };
 
 export const ReviewerPicker = ({ workspaceRoot, memberWorkspaceId, exclude, onAdd }: Props) => {
-  const [isOpen, setIsOpen] = useState(false);
   const [query, setQuery] = useState('');
   const [logins, setLogins] = useState<ReadonlyArray<string> | null>(null);
   const [isLoading, setIsLoading] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
   const workspaceId = useCurrentWorkspace()?.id;
-
-  useEffect(() => {
-    if (isOpen === false) {
-      return;
-    }
-
-    const onDocumentMouseDown = (event: MouseEvent) => {
-      if (ref.current != null && ref.current.contains(event.target as Node) === false) {
-        setIsOpen(false);
-      }
-    };
-
-    document.addEventListener('mousedown', onDocumentMouseDown);
-    return () => document.removeEventListener('mousedown', onDocumentMouseDown);
-  }, [isOpen]);
+  const {
+    open: isOpen,
+    close,
+    toggle,
+    containerRef,
+    popupClassName,
+  } = useDropdown({ width: 'w-52', expectedHeight: 220 });
 
   useEffect(() => {
     if (isOpen === false || logins !== null || workspaceRoot == null || workspaceRoot === '') {
@@ -55,10 +46,10 @@ export const ReviewerPicker = ({ workspaceRoot, memberWorkspaceId, exclude, onAd
     .slice(0, 8);
 
   return (
-    <div ref={ref} className="relative">
+    <div ref={containerRef} className="relative">
       <button
         type="button"
-        onClick={() => setIsOpen((value) => value === false)}
+        onClick={toggle}
         title="Request review"
         aria-label="Request review"
         className="inline-flex items-center gap-0.5 rounded-md border border-border-soft px-1.5 py-0.5 text-3xs font-medium text-muted-foreground transition-colors hover:border-border hover:text-foreground"
@@ -67,7 +58,12 @@ export const ReviewerPicker = ({ workspaceRoot, memberWorkspaceId, exclude, onAd
         Add
       </button>
       {isOpen ? (
-        <div className="absolute left-0 top-6 z-10 flex w-52 flex-col gap-1 rounded-md border border-border-soft bg-background p-1.5 shadow-lg">
+        <div
+          className={cn(
+            popupClassName,
+            'flex flex-col gap-1 rounded-md border border-border-soft bg-background p-1.5 shadow-lg',
+          )}
+        >
           <div className="flex items-center gap-1.5 px-1.5 py-1">
             <Search size={12} aria-hidden className="shrink-0 text-muted-foreground" />
             <input
@@ -104,7 +100,7 @@ export const ReviewerPicker = ({ workspaceRoot, memberWorkspaceId, exclude, onAd
                       type="button"
                       onClick={() => {
                         onAdd([login]);
-                        setIsOpen(false);
+                        close();
                         setQuery('');
                       }}
                       className="flex w-full items-center gap-1.5 rounded-md px-1.5 py-1 text-left text-xs text-foreground hover:bg-muted/60"

--- a/apps/desktop/src/features/integrations/components/IssuePicker/index.test.tsx
+++ b/apps/desktop/src/features/integrations/components/IssuePicker/index.test.tsx
@@ -1,0 +1,122 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { IssueCandidate } from '../../fetchIssueCandidates';
+
+vi.mock('../../../../shared/lib/editor', () => ({
+  openUrl: vi.fn(async () => undefined),
+}));
+
+import { IssuePicker } from './index';
+
+const ROWS = [
+  {
+    provider: 'github',
+    externalId: '101',
+    identifier: '#101',
+    title: 'Converge the anchored popovers',
+    url: 'https://example.test/101',
+    goal: 'Converge the anchored popovers',
+    branchSlug: 'converge-anchored-popovers',
+  },
+  {
+    provider: 'github',
+    externalId: '102',
+    identifier: '#102',
+    title: 'Retire the hand rolled outside click',
+    url: 'https://example.test/102',
+    goal: 'Retire the hand rolled outside click',
+    branchSlug: 'retire-hand-rolled-outside-click',
+  },
+] satisfies ReadonlyArray<IssueCandidate>;
+
+type Params = {
+  readonly rows?: ReadonlyArray<IssueCandidate>;
+  readonly disabled?: boolean;
+  readonly onOpen?: () => void;
+  readonly onPick?: (candidate: IssueCandidate) => void;
+  readonly onClear?: () => void;
+};
+
+const renderPicker = ({
+  rows = ROWS,
+  disabled = false,
+  onOpen = vi.fn(),
+  onPick = vi.fn(),
+  onClear = vi.fn(),
+}: Params = {}) => {
+  render(
+    <IssuePicker
+      rows={rows}
+      isLoading={false}
+      isLoaded
+      error={null}
+      value={null}
+      placeholder="Search issues"
+      disabled={disabled}
+      onOpen={onOpen}
+      onPick={onPick}
+      onClear={onClear}
+    />,
+  );
+  return { onOpen, onPick, onClear };
+};
+
+const input = () => screen.getByRole('combobox');
+
+afterEach(cleanup);
+
+describe('IssuePicker', () => {
+  it('opens the list on focus and reports the open', () => {
+    const { onOpen } = renderPicker();
+    fireEvent.focus(input());
+    expect(onOpen).toHaveBeenCalled();
+    expect(screen.getAllByRole('option')).toHaveLength(2);
+  });
+
+  it('opens the list from the chevron trigger and closes it again', () => {
+    renderPicker();
+    fireEvent.click(screen.getByRole('button', { name: /open issue list/i }));
+    expect(screen.getByRole('listbox')).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: /close issue list/i }));
+    expect(screen.queryByRole('listbox')).toBeNull();
+  });
+
+  it('stays closed while disabled', () => {
+    renderPicker({ disabled: true });
+    fireEvent.click(screen.getByRole('button', { name: /open issue list/i }));
+    expect(screen.queryByRole('listbox')).toBeNull();
+  });
+
+  it('filters rows by the typed query', () => {
+    renderPicker();
+    fireEvent.change(input(), { target: { value: 'retire' } });
+    expect(screen.getAllByRole('option')).toHaveLength(1);
+    expect(screen.getByText('Retire the hand rolled outside click')).toBeDefined();
+  });
+
+  it('picks the highlighted row on Enter and closes', () => {
+    const { onPick } = renderPicker();
+    fireEvent.focus(input());
+    fireEvent.keyDown(input(), { key: 'ArrowDown' });
+    fireEvent.keyDown(input(), { key: 'Enter' });
+    expect(onPick).toHaveBeenCalledWith(ROWS[1]);
+    expect(screen.queryByRole('listbox')).toBeNull();
+  });
+
+  it('closes on Escape typed in the input', () => {
+    renderPicker();
+    fireEvent.focus(input());
+    expect(screen.getByRole('listbox')).toBeDefined();
+    fireEvent.keyDown(input(), { key: 'Escape' });
+    expect(screen.queryByRole('listbox')).toBeNull();
+  });
+
+  it('closes on a mousedown outside the picker', () => {
+    renderPicker();
+    fireEvent.focus(input());
+    fireEvent.mouseDown(document.body);
+    expect(screen.queryByRole('listbox')).toBeNull();
+  });
+});

--- a/apps/desktop/src/features/integrations/components/IssuePicker/index.test.tsx
+++ b/apps/desktop/src/features/integrations/components/IssuePicker/index.test.tsx
@@ -113,6 +113,21 @@ describe('IssuePicker', () => {
     expect(screen.queryByRole('listbox')).toBeNull();
   });
 
+  it('closes on Escape pressed while focus sits outside the input', () => {
+    renderPicker();
+    fireEvent.focus(input());
+    expect(screen.getByRole('listbox')).toBeDefined();
+    fireEvent.keyDown(document.body, { key: 'Escape' });
+    expect(screen.queryByRole('listbox')).toBeNull();
+  });
+
+  it('anchors the list by measured direction instead of a hardcoded offset', () => {
+    renderPicker();
+    fireEvent.focus(input());
+    const popup = screen.getByRole('listbox').closest('div.absolute');
+    expect(popup?.className).toContain('top-[calc(100%+0.25rem)]');
+  });
+
   it('closes on a mousedown outside the picker', () => {
     renderPicker();
     fireEvent.focus(input());

--- a/apps/desktop/src/features/integrations/components/IssuePicker/index.tsx
+++ b/apps/desktop/src/features/integrations/components/IssuePicker/index.tsx
@@ -4,6 +4,7 @@ import { ChevronDown, ExternalLink } from 'lucide-react';
 import type { IssueCandidate } from '../../fetchIssueCandidates';
 import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../shared/components/conceptIcons';
 import { openUrl } from '../../../../shared/lib/editor';
+import { useDropdown } from '../../../../shared/hooks/useDropdown';
 
 type Props = {
   readonly inputId?: string;
@@ -35,18 +36,25 @@ export const IssuePicker = ({
   onClear,
 }: Props) => {
   const [query, setQuery] = useState('');
-  const [isOpen, setIsOpen] = useState(false);
   const [highlightIdx, setHighlightIdx] = useState(0);
-  const containerRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLUListElement>(null);
+  const {
+    open: isOpen,
+    close,
+    toggle,
+    containerRef,
+    popupClassName,
+  } = useDropdown({ disabled, width: 'w-full', expectedHeight: 288 });
 
   useEffect(() => {
     setQuery(value == null ? '' : `${value.identifier} ${value.title}`);
   }, [value]);
 
   const openPanel = () => {
-    setIsOpen(true);
+    if (!isOpen) {
+      toggle();
+    }
     onOpen();
   };
 
@@ -54,9 +62,14 @@ export const IssuePicker = ({
     if (disabled) {
       return;
     }
-    setIsOpen(!isOpen);
-    if (!isOpen) {
-      onOpen();
+    if (isOpen) {
+      close();
+      inputRef.current?.focus();
+      return;
+    }
+    if (document.activeElement === inputRef.current) {
+      openPanel();
+      return;
     }
     inputRef.current?.focus();
   };
@@ -82,27 +95,14 @@ export const IssuePicker = ({
     (candidate: IssueCandidate) => {
       onPick(candidate);
       setQuery(`${candidate.identifier} ${candidate.title}`);
-      setIsOpen(false);
+      close();
     },
-    [onPick],
+    [close, onPick],
   );
 
   useEffect(() => {
     setHighlightIdx(0);
   }, [query]);
-
-  useEffect(() => {
-    if (!isOpen) {
-      return;
-    }
-    const handler = (event: MouseEvent) => {
-      if (containerRef.current != null && !containerRef.current.contains(event.target as Node)) {
-        setIsOpen(false);
-      }
-    };
-    document.addEventListener('mousedown', handler);
-    return () => document.removeEventListener('mousedown', handler);
-  }, [isOpen]);
 
   useEffect(() => {
     if (!isOpen || listRef.current == null) {
@@ -140,7 +140,7 @@ export const IssuePicker = ({
       }
       case 'Escape':
         event.preventDefault();
-        setIsOpen(false);
+        close();
         break;
     }
   };
@@ -168,7 +168,9 @@ export const IssuePicker = ({
           className="flex-1 truncate bg-transparent px-2 text-sm text-foreground outline-none placeholder:text-muted-foreground/50 disabled:cursor-not-allowed"
           onChange={(event) => {
             setQuery(event.target.value);
-            setIsOpen(true);
+            if (!isOpen) {
+              toggle();
+            }
             if (event.target.value === '') {
               onClear();
             }
@@ -209,7 +211,10 @@ export const IssuePicker = ({
         <div
           role="status"
           aria-label="Loading issues"
-          className="absolute left-0 top-full z-50 mt-1 w-full rounded-md border border-border bg-subtle py-0.5 shadow-lg"
+          className={cn(
+            popupClassName,
+            'rounded-md border border-border bg-subtle py-0.5 shadow-lg',
+          )}
         >
           {Array.from({ length: 5 }).map((_, index) => (
             <div key={index} className="flex items-center gap-2 px-2.5 py-1.5">
@@ -221,14 +226,22 @@ export const IssuePicker = ({
       )}
 
       {isOpen && pasted == null && error != null && (
-        <div className="absolute left-0 top-full z-50 mt-1 w-full rounded-md border border-danger/40 bg-danger/5 px-3 py-2 text-xs text-danger shadow-lg">
+        <div
+          className={cn(
+            popupClassName,
+            'rounded-md border border-danger/40 bg-danger/5 px-3 py-2 text-xs text-danger shadow-lg',
+          )}
+        >
           {error}
         </div>
       )}
 
       {isOpen && (pasted != null || error == null) && options.length > 0 && (
         <ScrollFade
-          className="absolute left-0 top-full z-50 mt-1 max-h-72 w-full rounded-md border border-border bg-subtle shadow-lg"
+          className={cn(
+            popupClassName,
+            'max-h-72 rounded-md border border-border bg-subtle shadow-lg',
+          )}
           viewportClassName="py-0.5"
           fadeFrom="subtle"
         >
@@ -269,7 +282,12 @@ export const IssuePicker = ({
       )}
 
       {isOpen && error == null && !isLoading && isLoaded && options.length === 0 && (
-        <div className="absolute left-0 top-full z-50 mt-1 w-full rounded-md border border-border bg-subtle px-3 py-2 text-xs text-muted-foreground shadow-lg">
+        <div
+          className={cn(
+            popupClassName,
+            'rounded-md border border-border bg-subtle px-3 py-2 text-xs text-muted-foreground shadow-lg',
+          )}
+        >
           <EmptyState
             icon={CONCEPT_ICONS.search}
             tone={CONCEPT_TONE.search}

--- a/apps/desktop/src/features/permissions/components/PermissionModePicker/index.test.tsx
+++ b/apps/desktop/src/features/permissions/components/PermissionModePicker/index.test.tsx
@@ -76,6 +76,14 @@ describe('PermissionModePicker', () => {
     expect(screen.queryByRole('dialog', { name: /permission mode/i })).toBeNull();
   });
 
+  it('anchors the panel by measured direction instead of a hardcoded one', () => {
+    render(<PermissionModePicker session={makeSession()} activeProvider="anthropic" />);
+    fireEvent.click(screen.getByRole('button', { name: /default/i }));
+    const panel = screen.getByRole('dialog', { name: /permission mode/i });
+    expect(panel.className).toContain('top-[calc(100%+0.25rem)]');
+    expect(panel.className).not.toContain('bottom-full');
+  });
+
   it('opens on the goodboy:open-permission-picker event', () => {
     render(<PermissionModePicker session={makeSession()} activeProvider="anthropic" />);
     act(() => {

--- a/apps/desktop/src/features/permissions/components/PermissionModePicker/index.test.tsx
+++ b/apps/desktop/src/features/permissions/components/PermissionModePicker/index.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
 import type { Session } from '@goodboy/types';
 
 const { setModeMock } = vi.hoisted(() => ({
@@ -59,6 +59,29 @@ describe('PermissionModePicker', () => {
     render(<PermissionModePicker session={makeSession()} activeProvider={provider} />);
     fireEvent.click(screen.getByRole('button', { name: /default/i }));
     expect(screen.queryByText(/not enforced for cursor and gemini/i)).toBeNull();
+  });
+
+  it('closes on Escape', () => {
+    render(<PermissionModePicker session={makeSession()} activeProvider="anthropic" />);
+    fireEvent.click(screen.getByRole('button', { name: /default/i }));
+    expect(screen.getByRole('dialog', { name: /permission mode/i })).toBeDefined();
+    fireEvent.keyDown(document.body, { key: 'Escape' });
+    expect(screen.queryByRole('dialog', { name: /permission mode/i })).toBeNull();
+  });
+
+  it('closes on a mousedown outside the picker', () => {
+    render(<PermissionModePicker session={makeSession()} activeProvider="anthropic" />);
+    fireEvent.click(screen.getByRole('button', { name: /default/i }));
+    fireEvent.mouseDown(document.body);
+    expect(screen.queryByRole('dialog', { name: /permission mode/i })).toBeNull();
+  });
+
+  it('opens on the goodboy:open-permission-picker event', () => {
+    render(<PermissionModePicker session={makeSession()} activeProvider="anthropic" />);
+    act(() => {
+      window.dispatchEvent(new CustomEvent('goodboy:open-permission-picker'));
+    });
+    expect(screen.getByRole('dialog', { name: /permission mode/i })).toBeDefined();
   });
 });
 

--- a/apps/desktop/src/features/permissions/components/PermissionModePicker/index.tsx
+++ b/apps/desktop/src/features/permissions/components/PermissionModePicker/index.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useRef, useState } from 'react';
 import { ChevronDown } from 'lucide-react';
 import { cn, StatusDot, type Tone } from '@goodboy/ui';
 import type { ClaudePermissionMode, ProviderId, Session } from '@goodboy/types';
 import { useAppStore } from '../../../../store';
+import { useDropdown } from '../../../../shared/hooks/useDropdown';
 
 const MODE_UNENFORCED_PROVIDERS: ReadonlyArray<ProviderId> = ['cursor', 'gemini'];
 
@@ -55,50 +55,25 @@ type Props = {
 };
 
 export const PermissionModePicker = ({ session, activeProvider }: Props) => {
-  const [open, setOpen] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
+  const { open, close, toggle, containerRef, popupClassName } = useDropdown({
+    width: 'w-64',
+    expectedHeight: 240,
+    openEvent: 'goodboy:open-permission-picker',
+  });
   const setSessionPermissionMode = useAppStore((s) => s.setSessionPermissionMode);
   const current = permissionModeMeta(session.permissionMode);
   const unenforced = MODE_UNENFORCED_PROVIDERS.includes(activeProvider);
 
-  useEffect(() => {
-    if (!open) {
-      return;
-    }
-    const onClick = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
-    };
-    const onEsc = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        setOpen(false);
-      }
-    };
-    window.addEventListener('mousedown', onClick);
-    window.addEventListener('keydown', onEsc);
-    return () => {
-      window.removeEventListener('mousedown', onClick);
-      window.removeEventListener('keydown', onEsc);
-    };
-  }, [open]);
-
-  useEffect(() => {
-    const handler = () => setOpen(true);
-    window.addEventListener('goodboy:open-permission-picker', handler);
-    return () => window.removeEventListener('goodboy:open-permission-picker', handler);
-  }, []);
-
   const onPick = (mode: ClaudePermissionMode) => {
     void setSessionPermissionMode(session.id, mode);
-    setOpen(false);
+    close();
   };
 
   return (
-    <div className="relative" ref={ref}>
+    <div className="relative" ref={containerRef}>
       <button
         type="button"
-        onClick={() => setOpen((v) => !v)}
+        onClick={toggle}
         title={unenforced ? 'Not enforced for cursor and gemini' : current.description}
         aria-haspopup="dialog"
         aria-expanded={open}
@@ -112,7 +87,10 @@ export const PermissionModePicker = ({ session, activeProvider }: Props) => {
         <div
           role="dialog"
           aria-label="Permission mode"
-          className="absolute bottom-full left-0 z-30 mb-1.5 w-64 overflow-hidden rounded-lg bg-subtle py-1.5 text-xs shadow-lg ring-1 ring-border-soft"
+          className={cn(
+            popupClassName,
+            'overflow-hidden rounded-lg bg-subtle py-1.5 text-xs shadow-lg ring-1 ring-border-soft',
+          )}
         >
           <div className="flex items-center px-2.5 pb-0.5 pt-1">
             <span className="text-2xs uppercase tracking-wide text-muted-foreground/70">

--- a/apps/desktop/src/features/session/components/AgentInspector/ResolverOverflowMenu.test.tsx
+++ b/apps/desktop/src/features/session/components/AgentInspector/ResolverOverflowMenu.test.tsx
@@ -1,0 +1,109 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { Agent } from '@goodboy/types';
+import type { ResolverAction } from '../../resolverActions';
+import type { ResolverActionsController } from '../../hooks/useResolverActions';
+import { ResolverOverflowMenu } from './ResolverOverflowMenu';
+
+const FORCE_CLOSE = {
+  kind: 'forceClose',
+  label: 'Force close threads',
+  role: 'danger',
+  isEnabled: true,
+  confirm: {
+    role: 'danger',
+    title: 'Force close every thread',
+    description: 'The remaining threads are marked resolved without a verdict.',
+    confirmLabel: 'Force close',
+  },
+  opensInspector: false,
+} satisfies ResolverAction;
+
+const REWORK = {
+  kind: 'rework',
+  label: 'Rework the resolution',
+  role: 'neutral',
+  isEnabled: true,
+  confirm: null,
+  opensInspector: false,
+} satisfies ResolverAction;
+
+const AGENT = { id: 'agent-1' } as Agent;
+
+type Params = {
+  readonly overflow?: ReadonlyArray<ResolverAction>;
+  readonly run?: (kind: ResolverAction['kind']) => Promise<void>;
+};
+
+const renderMenu = ({
+  overflow = [FORCE_CLOSE, REWORK],
+  run = vi.fn(async () => undefined),
+}: Params = {}) => {
+  const actions = {
+    plan: { primary: null, secondary: null, overflow, note: null },
+    run,
+  } as unknown as ResolverActionsController;
+  render(
+    <ResolverOverflowMenu
+      agent={AGENT}
+      actions={actions}
+      commits={[]}
+      headSha={null}
+      onAmend={vi.fn(async () => undefined)}
+      onSquash={vi.fn(async () => undefined)}
+    />,
+  );
+  return { run };
+};
+
+const trigger = () => screen.getByRole('button', { name: /more resolver actions/i });
+
+afterEach(cleanup);
+
+describe('ResolverOverflowMenu', () => {
+  it('renders nothing without overflow actions or commits', () => {
+    renderMenu({ overflow: [] });
+    expect(screen.queryByRole('button', { name: /more resolver actions/i })).toBeNull();
+  });
+
+  it('opens a menu listing every overflow action', () => {
+    renderMenu();
+    fireEvent.click(trigger());
+    expect(screen.getByRole('menu', { name: /more resolver actions/i })).toBeDefined();
+    expect(screen.getAllByRole('menuitem')).toHaveLength(2);
+  });
+
+  it('arms an action into its confirm and runs it', async () => {
+    const { run } = renderMenu();
+    fireEvent.click(trigger());
+    fireEvent.click(screen.getByRole('menuitem', { name: /force close threads/i }));
+    expect(screen.queryAllByRole('menuitem')).toHaveLength(0);
+    fireEvent.click(screen.getByRole('button', { name: 'Force close' }));
+    await waitFor(() => expect(run).toHaveBeenCalledWith('forceClose'));
+    await waitFor(() =>
+      expect(screen.queryByRole('menu', { name: /more resolver actions/i })).toBeNull(),
+    );
+  });
+
+  it('closes on Escape and drops the armed action', () => {
+    renderMenu();
+    fireEvent.click(trigger());
+    fireEvent.click(screen.getByRole('menuitem', { name: /force close threads/i }));
+    fireEvent.keyDown(document.body, { key: 'Escape' });
+    expect(screen.queryByRole('menu', { name: /more resolver actions/i })).toBeNull();
+    fireEvent.click(trigger());
+    expect(screen.getAllByRole('menuitem')).toHaveLength(2);
+  });
+
+  it('closes on a mousedown outside the menu and drops the armed action', () => {
+    renderMenu();
+    fireEvent.click(trigger());
+    fireEvent.click(screen.getByRole('menuitem', { name: /force close threads/i }));
+    fireEvent.mouseDown(document.body);
+    expect(screen.queryByRole('menu', { name: /more resolver actions/i })).toBeNull();
+    fireEvent.click(trigger());
+    expect(screen.getAllByRole('menuitem')).toHaveLength(2);
+  });
+});

--- a/apps/desktop/src/features/session/components/AgentInspector/ResolverOverflowMenu.test.tsx
+++ b/apps/desktop/src/features/session/components/AgentInspector/ResolverOverflowMenu.test.tsx
@@ -87,6 +87,14 @@ describe('ResolverOverflowMenu', () => {
     );
   });
 
+  it('anchors the menu by measured direction instead of a hardcoded offset', () => {
+    renderMenu();
+    fireEvent.click(trigger());
+    const menu = screen.getByRole('menu', { name: /more resolver actions/i });
+    expect(menu.className).toContain('top-[calc(100%+0.25rem)]');
+    expect(menu.className).toContain('right-0');
+  });
+
   it('closes on Escape and drops the armed action', () => {
     renderMenu();
     fireEvent.click(trigger());

--- a/apps/desktop/src/features/session/components/AgentInspector/ResolverOverflowMenu.tsx
+++ b/apps/desktop/src/features/session/components/AgentInspector/ResolverOverflowMenu.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { MoreHorizontal } from 'lucide-react';
 import { Divider, Popover, cn } from '@goodboy/ui';
+import { useDropdown } from '../../../../shared/hooks/useDropdown';
 import type { Agent, BranchCommit } from '@goodboy/types';
 import { RESOLVER_ACTION_ICON } from '../../resolverActionIcon';
 import type { ResolverAction, ResolverActionKind } from '../../resolverActions';
@@ -30,48 +31,28 @@ export const ResolverOverflowMenu = ({
   onAmend,
   onSquash,
 }: Props) => {
-  const [isOpen, setIsOpen] = useState(false);
   const [armed, setArmed] = useState<Armed | null>(null);
-  const containerRef = useRef<HTMLDivElement>(null);
+  const {
+    open: isOpen,
+    close,
+    toggle,
+    containerRef,
+    popupClassName,
+  } = useDropdown({ align: 'end', width: 'w-72', expectedHeight: 320 });
 
   useEffect(() => {
-    if (!isOpen) {
+    if (isOpen) {
       return;
     }
-    const onPointerDown = (event: MouseEvent) => {
-      if (containerRef.current?.contains(event.target as Node) === true) {
-        return;
-      }
-      setIsOpen(false);
-      setArmed(null);
-    };
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key !== 'Escape') {
-        return;
-      }
-      setIsOpen(false);
-      setArmed(null);
-    };
-    window.addEventListener('mousedown', onPointerDown);
-    window.addEventListener('keydown', onKeyDown);
-    return () => {
-      window.removeEventListener('mousedown', onPointerDown);
-      window.removeEventListener('keydown', onKeyDown);
-    };
+    setArmed(null);
   }, [isOpen]);
 
   useEffect(() => {
-    setIsOpen(false);
-    setArmed(null);
-  }, [agent.id]);
+    close();
+  }, [agent.id, close]);
 
   const armedAction: ResolverAction | null =
     actions.plan.overflow.find((action) => action.kind === armed) ?? null;
-
-  const close = () => {
-    setArmed(null);
-    setIsOpen(false);
-  };
 
   if (actions.plan.overflow.length === 0 && commits.length === 0) {
     return null;
@@ -81,7 +62,7 @@ export const ResolverOverflowMenu = ({
     <div className="relative" ref={containerRef}>
       <button
         type="button"
-        onClick={() => setIsOpen((value) => !value)}
+        onClick={toggle}
         aria-label="More resolver actions"
         aria-haspopup="menu"
         aria-expanded={isOpen}
@@ -96,7 +77,7 @@ export const ResolverOverflowMenu = ({
         <Popover
           role="menu"
           ariaLabel="More resolver actions"
-          className="absolute right-0 top-full z-40 mt-1 w-72 py-1"
+          className={cn(popupClassName, 'py-1')}
         >
           {armedAction !== null && (
             <div className="p-2">


### PR DESCRIPTION
## What

Four hand-rolled anchored popovers now run on `shared/hooks/useDropdown`, the
hook that already backs 19 other surfaces. Each site previously carried its own
`useState` open flag, its own outside-mousedown listener, its own escape
handling (or none), and a hardcoded placement class.

`useDropdown` itself is unchanged. Its existing `align`, `width` and
`expectedHeight` options covered all four sites.

## Why this is a refactor and not a behavior change

No site in this repo converts with literally zero observable difference, so the
rule applied here is: a conversion that **loses** behavior drops the site, a
conversion that **gains** behavior keeps it only if the gain is named and pinned
by a test.

The characterization tests landed **first**, in `757c123e0`, and every one of
their 27 assertions passes against the unconverted components. After the
conversion in `a8e8f1e71` all 27 still pass, unweakened. The 6 added assertions
that pin the gains were run against the pre-conversion components as a check:
exactly those 6 fail there and nothing else does, so they pin real gains rather
than restating what already worked.

## Per-site provenance

| Site | Delta | Test that pins it |
| --- | --- | --- |
| `PermissionModePicker` | Gains measured up/down placement; it was hardcoded to `bottom-full`. Escape and outside-click were already equivalent. | `anchors the panel by measured direction instead of a hardcoded one`, plus new `closes on Escape` and `closes on a mousedown outside the picker` covering what the existing suite never did |
| `IssuePicker` | Gains a window-level Escape **in addition to** the input-scoped one, which is kept so a picker inside a modal dialog still swallows the key. Gains measured placement; it was hardcoded to `top-full`. | `closes on Escape pressed while focus sits outside the input`, `closes on Escape typed in the input`, `anchors the list by measured direction instead of a hardcoded offset` |
| `ReviewerPicker` | **Gains Escape, which it never had.** Only mousedown-outside closed it before, so this is a real user-visible improvement, not a wash. Also gains measured placement; it was hardcoded to `top-6`. | `closes on Escape`, `anchors the panel by measured direction instead of a hardcoded offset` |
| `ResolverOverflowMenu` | Gains measured placement only; escape and mousedown were already hook-equivalent. | `anchors the menu by measured direction instead of a hardcoded offset`, plus `closes on Escape and drops the armed action` pinning that the armed confirm still resets on every close path |

## Smaller deltas, declared

- The popup `z-index` at each site becomes the hook's `z-50` (was `z-30`, `z-40`, `z-10`, `z-50`). All four are popovers over local content, none over a modal.
- The trigger-to-popup gap becomes the hook's `0.25rem`. `PermissionModePicker` had `mb-1.5` (6px); the other three already had 4px.
- `IssuePicker` needed one call-site guard. Its chevron trigger toggles and then focuses the input, and the input's focus handler is itself an open-trigger, so a plain `if (!open) toggle()` fired twice inside one event and cancelled itself. The trigger now branches on whether the input already holds focus. A side effect: clicking the chevron to close while the input is unfocused now actually closes, where before the refocus reopened it.

## Deliberately not converted

- `ScriptsSection` / `LogFlyout`: portalled to `document.body` with its own `computePosition()` edge-flip keyed to a captured `DOMRect`, and its trigger lives in a different component. There is no live container/popup ref pair to attach the hook to. Converting it is a DOM restructure.
- `OverflowMenu`: takes a caller-forced `side="top" | "bottom"`, used by six sites, and its own test pins the forced placement. The hook has no forced-direction override, only auto-flip, so converting would **lose** deterministic placement. A refactor that removes behavior is not a refactor.
- `shared/hooks/useClickOutside` is kept. It is not a duplicate of `useDropdown`: its single consumer collapses an inline card, it does not anchor a popover.

## Test plan

- `pnpm typecheck` green.
- `pnpm exec turbo run test --force`: 623 files, 5225 tests passing, log reports `0 cached`.
- `pnpm knip --include files,duplicates,unlisted`: exit 0.
- Characterization suite replayed against the pre-conversion components to confirm no assertion silently weakened.

Footprint: four components and their four test files. No shared hook, barrel, store slice or registry touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
