### PR TITLE
fix(desktop): reveal focus-hidden controls, tooltip long stage text

### DIFF
--- a/apps/desktop/src/features/chat/components/ChatInput/parts/AttachmentChip.test.tsx
+++ b/apps/desktop/src/features/chat/components/ChatInput/parts/AttachmentChip.test.tsx
@@ -1,0 +1,27 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { AttachmentChip } from './AttachmentChip';
+import type { PendingAttachment } from '../lib';
+
+afterEach(cleanup);
+
+const attachment: PendingAttachment = {
+  id: 'att-1',
+  fileName: 'notes.txt',
+  mimeType: 'text/plain',
+  dataUrl: 'data:text/plain;base64,aGVsbG8=',
+  relPath: null,
+};
+
+describe('AttachmentChip', () => {
+  it('reveals the remove control on keyboard focus, not only on hover', () => {
+    render(<AttachmentChip attachment={attachment} onRemove={() => {}} />);
+    const remove = screen.getByRole('button', { name: 'Remove notes.txt' });
+
+    expect(remove.className).toContain('opacity-0');
+    expect(remove.className).toContain('focus-visible:opacity-100');
+    expect(remove.className).toContain('group-hover:opacity-100');
+  });
+});

--- a/apps/desktop/src/features/chat/components/ChatInput/parts/AttachmentChip.tsx
+++ b/apps/desktop/src/features/chat/components/ChatInput/parts/AttachmentChip.tsx
@@ -18,7 +18,7 @@ export function AttachmentChip({
       onClick={onRemove}
       title={`Remove ${attachment.fileName}`}
       aria-label={`Remove ${attachment.fileName}`}
-      className="absolute right-0.5 top-0.5 inline-flex h-4 w-4 items-center justify-center rounded-full bg-foreground/70 text-background opacity-0 transition-opacity hover:bg-foreground group-hover:opacity-100"
+      className="absolute right-0.5 top-0.5 inline-flex h-4 w-4 items-center justify-center rounded-full bg-foreground/70 text-background opacity-0 transition-opacity hover:bg-foreground focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] group-hover:opacity-100"
     >
       <X size={10} aria-hidden />
     </button>

--- a/apps/desktop/src/features/chat/components/TranscriptCards/AssistantText.test.tsx
+++ b/apps/desktop/src/features/chat/components/TranscriptCards/AssistantText.test.tsx
@@ -3,11 +3,12 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, render, screen } from '@testing-library/react';
 
+const { extractAllCommentResolvedMock } = vi.hoisted(() => ({
+  extractAllCommentResolvedMock: vi.fn(() => [] as ReadonlyArray<{ threadId: string }>),
+}));
+
 vi.mock('@goodboy/core', () => ({
-  extractAllCommentResolved: () => [
-    { threadId: 'local-1', commitSha: 'abcdef1' },
-    { threadId: 'PRRT_2', commitSha: 'abcdef2' },
-  ],
+  extractAllCommentResolved: extractAllCommentResolvedMock,
   isReviewThreadId: (threadId: string) => threadId.startsWith('PRRT_'),
   stripControlMarkers: (text: string) => text,
 }));
@@ -34,8 +35,21 @@ describe('AssistantText', () => {
   });
 
   it('hides copy when a non-first resolved marker belongs to a review thread', () => {
+    extractAllCommentResolvedMock.mockReturnValueOnce([
+      { threadId: 'local-1' },
+      { threadId: 'PRRT_2' },
+    ]);
     render(<AssistantText text="assistant response" sessionId={null} />);
 
     expect(screen.queryByRole('button', { name: 'copy' })).toBeNull();
+  });
+
+  it('reveals copy when focus lands anywhere inside the message, not on copy itself', () => {
+    render(<AssistantText text="hello" sessionId={null} />);
+    const copyButton = screen.getByRole('button', { name: 'copy' });
+    const revealWrapper = copyButton.parentElement as HTMLElement;
+
+    expect(revealWrapper.className).toContain('group-focus-within:opacity-100');
+    expect(revealWrapper.className).not.toContain('focus-visible:');
   });
 });

--- a/apps/desktop/src/features/chat/components/TranscriptCards/AssistantText.tsx
+++ b/apps/desktop/src/features/chat/components/TranscriptCards/AssistantText.tsx
@@ -20,7 +20,7 @@ export const AssistantText = ({ text, sessionId, agentId = null }: Props) => {
   return (
     <div className="group relative flex flex-col gap-2 text-sm leading-relaxed">
       {hasCommentResolvedMarker ? null : (
-        <div className="absolute -right-1 -top-1 opacity-0 motion-safe:transition-opacity group-hover:opacity-100">
+        <div className="absolute -right-1 -top-1 opacity-0 motion-safe:transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
           <CopyButton value={text} label="message" />
         </div>
       )}

--- a/apps/desktop/src/features/context/components/ContextPanel/strips/GoalAttachmentsStrip.test.tsx
+++ b/apps/desktop/src/features/context/components/ContextPanel/strips/GoalAttachmentsStrip.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+
+type Attachment = {
+  id: string;
+  fileName: string;
+  mimeType: string;
+  kind: 'image' | 'file';
+  relPath: string;
+};
+
+type MockState = {
+  sessionAttachments: Record<string, ReadonlyArray<Attachment>>;
+  workflowRunAttachments: Record<string, ReadonlyArray<Attachment>>;
+  sessionWorktrees: Record<string, ReadonlyArray<string>>;
+  currentSessionId: string | null;
+  loadGoalAttachments: ReturnType<typeof vi.fn>;
+  removeGoalAttachment: ReturnType<typeof vi.fn>;
+};
+
+const { state } = vi.hoisted<{ state: MockState }>(() => ({
+  state: {
+    sessionAttachments: {
+      'sess-1': [
+        { id: 'att-1', fileName: 'notes.txt', mimeType: 'text/plain', kind: 'file', relPath: '' },
+      ],
+    },
+    workflowRunAttachments: {},
+    sessionWorktrees: {},
+    currentSessionId: 'sess-1',
+    loadGoalAttachments: vi.fn(async () => undefined),
+    removeGoalAttachment: vi.fn(async () => undefined),
+  },
+}));
+
+vi.mock('../../../../../store', () => ({
+  EMPTY_ARRAY: [],
+  useAppStore: <T,>(selector: (s: MockState) => T) => selector(state),
+}));
+
+vi.mock('../../../../chat/attachment-kinds', () => ({
+  fileIconFor: () => () => null,
+}));
+
+vi.mock('../../../../chat/turn', () => ({
+  readAttachment: vi.fn(async () => ''),
+}));
+
+vi.mock('../../../../chat/components/ImageLightbox', () => ({
+  ImageLightbox: () => null,
+}));
+
+vi.mock('../../../../providers/attachment-routing', () => ({
+  ATTACHMENT_KIND_ROUTING: { file: ['claude'], image: ['claude'] },
+}));
+
+import { GoalAttachmentsStrip } from './GoalAttachmentsStrip';
+
+afterEach(cleanup);
+
+describe('GoalAttachmentsStrip', () => {
+  it('reveals the remove control on keyboard focus, not only on hover', () => {
+    render(<GoalAttachmentsStrip owner={{ type: 'session', id: 'sess-1' as never }} />);
+    const remove = screen.getByRole('button', { name: 'Remove notes.txt' });
+
+    expect(remove.className).toContain('opacity-0');
+    expect(remove.className).toContain('focus-visible:opacity-100');
+    expect(remove.className).toContain('group-hover:opacity-100');
+  });
+});

--- a/apps/desktop/src/features/context/components/ContextPanel/strips/GoalAttachmentsStrip.tsx
+++ b/apps/desktop/src/features/context/components/ContextPanel/strips/GoalAttachmentsStrip.tsx
@@ -68,7 +68,7 @@ function AttachmentChip({
       onClick={onRemove}
       title={`Remove ${attachment.fileName}`}
       aria-label={`Remove ${attachment.fileName}`}
-      className="absolute right-0.5 top-0.5 inline-flex h-4 w-4 items-center justify-center rounded-full bg-foreground/70 text-background opacity-0 transition-opacity hover:bg-foreground group-hover:opacity-100"
+      className="absolute right-0.5 top-0.5 inline-flex h-4 w-4 items-center justify-center rounded-full bg-foreground/70 text-background opacity-0 transition-opacity hover:bg-foreground focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] group-hover:opacity-100"
     >
       <X size={10} aria-hidden />
     </button>

--- a/apps/desktop/src/features/providers/components/ProviderStudio/ProviderCredentialsSection.test.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/ProviderCredentialsSection.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import type { CredentialId, ProviderId } from '@goodboy/types';
+
+type Credential = { id: CredentialId; providerId: ProviderId; label: string; hint: string };
+
+type MockState = {
+  providerCredentials: ReadonlyArray<Credential>;
+  createCredential: ReturnType<typeof vi.fn>;
+  deleteCredential: ReturnType<typeof vi.fn>;
+  refreshProviders: ReturnType<typeof vi.fn>;
+};
+
+const { state } = vi.hoisted<{ state: MockState }>(() => ({
+  state: {
+    providerCredentials: [
+      {
+        id: 'cred-1' as CredentialId,
+        providerId: 'anthropic' as ProviderId,
+        label: 'work',
+        hint: '••••1234',
+      },
+    ],
+    createCredential: vi.fn(async () => undefined),
+    deleteCredential: vi.fn(async () => undefined),
+    refreshProviders: vi.fn(async () => undefined),
+  },
+}));
+
+vi.mock('../../../../store', () => ({
+  useAppStore: <T,>(selector: (s: MockState) => T) => selector(state),
+}));
+
+const { toastMock } = vi.hoisted(() => ({ toastMock: vi.fn() }));
+vi.mock('../../../../app/components/Toast', () => ({
+  useToast: () => ({ showToast: toastMock }),
+}));
+
+import { ProviderCredentialsSection } from './ProviderCredentialsSection';
+
+afterEach(cleanup);
+
+describe('ProviderCredentialsSection', () => {
+  it('reveals the remove control on keyboard focus, not only on hover', () => {
+    render(<ProviderCredentialsSection providerId={'anthropic' as ProviderId} />);
+    const remove = screen.getByRole('button', { name: 'Remove work' });
+
+    expect(remove.className).toContain('opacity-0');
+    expect(remove.className).toContain('focus-visible:opacity-100');
+    expect(remove.className).toContain('group-hover:opacity-100');
+  });
+});

--- a/apps/desktop/src/features/providers/components/ProviderStudio/ProviderCredentialsSection.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/ProviderCredentialsSection.tsx
@@ -130,7 +130,7 @@ export const ProviderCredentialsSection = ({ providerId }: Props) => {
                   type="button"
                   aria-label={`Remove ${c.label}`}
                   onClick={() => setArmedId(c.id)}
-                  className="inline-flex size-7 items-center justify-center rounded-md text-muted-foreground opacity-0 transition-opacity hover:bg-danger/10 hover:text-danger group-hover:opacity-100"
+                  className="inline-flex size-7 items-center justify-center rounded-md text-muted-foreground opacity-0 transition-opacity hover:bg-danger/10 hover:text-danger focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] group-hover:opacity-100"
                 >
                   <Trash2 size={13} aria-hidden />
                 </button>

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/BranchChip.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/BranchChip.test.tsx
@@ -59,6 +59,7 @@ describe('BranchChip', () => {
     const edit = screen.getByRole('button', { name: 'Edit branch' });
 
     expect(edit.className).toContain('opacity-0');
+    expect(edit.className).toContain('focus-visible:opacity-100');
     fireEvent.click(edit);
     expect(screen.getByRole('dialog', { name: 'Switch branch' })).toBeDefined();
 
@@ -70,5 +71,12 @@ describe('BranchChip', () => {
     render(<BranchChip branch="ak/feat-thing" sessionId={'sess-1' as never} canEdit={false} />);
 
     expect(screen.queryByRole('button', { name: 'Edit branch' })).toBeNull();
+  });
+
+  it('drops the native title in favor of the house tooltip on the edit control', () => {
+    render(<BranchChip branch="ak/feat-thing" sessionId={'sess-1' as never} canEdit />);
+    const edit = screen.getByRole('button', { name: 'Edit branch' });
+
+    expect(edit.getAttribute('title')).toBeNull();
   });
 });

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/BranchChip.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/BranchChip.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Check, GitBranch, Pencil } from 'lucide-react';
-import { cn, Popover } from '@goodboy/ui';
+import { cn, Popover, Tooltip } from '@goodboy/ui';
 import type { SessionId } from '@goodboy/types';
 import { formatError } from '../../../../shared/lib/errors';
 import { useDropdown } from '../../../../shared/hooks/useDropdown';
@@ -65,22 +65,23 @@ export const BranchChip = ({ branch, mountName = null, sessionId, canEdit }: Pro
       </button>
 
       {canEdit ? (
-        <button
-          type="button"
-          onClick={toggle}
-          aria-label="Edit branch"
-          title="Edit branch"
-          aria-haspopup="dialog"
-          aria-expanded={open}
-          className={cn(
-            'inline-flex size-5 shrink-0 items-center justify-center rounded text-muted-foreground/50',
-            'opacity-0 transition-[opacity,color,background-color] hover:bg-muted hover:text-foreground',
-            'focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]',
-            'group-hover/branch:opacity-100 motion-reduce:opacity-60',
-          )}
-        >
-          <Pencil size={10} aria-hidden />
-        </button>
+        <Tooltip content="Edit branch" side="top">
+          <button
+            type="button"
+            onClick={toggle}
+            aria-label="Edit branch"
+            aria-haspopup="dialog"
+            aria-expanded={open}
+            className={cn(
+              'inline-flex size-5 shrink-0 items-center justify-center rounded text-muted-foreground/50',
+              'opacity-0 transition-[opacity,color,background-color] hover:bg-muted hover:text-foreground',
+              'focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]',
+              'group-hover/branch:opacity-100 motion-reduce:opacity-60',
+            )}
+          >
+            <Pencil size={10} aria-hidden />
+          </button>
+        </Tooltip>
       ) : null}
 
       {open ? (

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/HeaderBand.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/HeaderBand.tsx
@@ -1,6 +1,6 @@
 import { CheckCheck, Pencil } from 'lucide-react';
 import { useShallow } from 'zustand/react/shallow';
-import { Button, cn, Input, StatusDot } from '@goodboy/ui';
+import { Button, cn, Input, StatusDot, Tooltip } from '@goodboy/ui';
 import type { Session, SessionId, SessionStageInfo } from '@goodboy/types';
 import { agentHasUnread, EMPTY_ARRAY, useAppStore, useCurrentWorkspace } from '../../../../store';
 import { SESSION_STAGE_META, STAGE_TONE } from '../../session-stage';
@@ -49,9 +49,11 @@ export const HeaderBand = ({ session, stage }: Props) => {
             {SESSION_STAGE_META[stage.stage].label}
           </span>
           {stage.reason !== '' ? (
-            <span className="min-w-0 truncate text-xs text-muted-foreground/70">
-              {stage.reason}
-            </span>
+            <Tooltip content={stage.reason} side="top">
+              <span className="min-w-0 truncate text-xs text-muted-foreground/70">
+                {stage.reason}
+              </span>
+            </Tooltip>
           ) : null}
         </div>
         <div className="flex shrink-0 items-center gap-2">


### PR DESCRIPTION
## I4: keyboard focus reveals what hover reveals

Buttons held at `opacity-0` until `group-hover` were focus-invisible to a keyboard user: `opacity-0` keeps tab order, so the control was already focusable and activatable, it just couldn't be seen. This repo has four focus-reveal patterns; the shape of each site decides which applies.

**Self `focus-visible:` + `group-hover`** (precedent `BranchChip.tsx:75-80`), the target is itself the focusable element:
- `AttachmentChip.tsx:21` (chat input attachment remove button)
- `GoalAttachmentsStrip.tsx:71` (goal attachment remove button)
- `ProviderCredentialsSection.tsx:133` (credential delete button)

**`group-focus-within`** (precedent `CommentItem.tsx:56`, `PrPane.tsx:660`), the revealed thing wraps a focusable element it doesn't own:
- `AssistantText.tsx:23`, the copy affordance wraps a sealed `CopyButton`. Self `focus-visible:` here would be a no-op since the wrapper div itself is never focused; `group-focus-within` on the wrapper, keyed off the outer `group` container, is the only pattern that actually reveals it on tab.

**Dropped, not fixed here:**
- `SessionActivityBar.tsx:190` and `WorkspacesSidebar.tsx:73` need a DOM or wrapper change; this item stays className-only.
- `FileEditBlock.tsx:36` is an `aria-hidden` decorative svg inside an already-focusable, already-labelled `TranscriptShell as="button"`. Revealing decoration gains a keyboard user nothing when the whole control is one labelled button.

Untouched, already correct: `QuestionCard.tsx:91`, `ThreadReactions.tsx:31`, `PrPane.tsx:660`, `CommentItem.tsx:56`.

Each site has a test asserting the reveal class is present on the right element, so removing it goes red. `AssistantText.test.tsx` specifically asserts the wrapper carries `group-focus-within:opacity-100` and does *not* carry any `focus-visible:` class, to catch a silent no-op if someone "fixes" it the naive way.

## I7: truncated text gets its full text

`SessionOverviewPane/HeaderBand.tsx:52` truncates the derived stage reason with no way to read the full text. Wrapped it in the house `Tooltip` (`packages/ui/src/index.ts`), matching the pattern already shipped for this same datum on `StageBoardCard/index.tsx:167-171`.

**Honesty note**: `HeaderBand.tsx:52` is a plain non-focusable span, so `Tooltip`'s focus/blur handlers never fire there in practice, this is a mouse-only reveal, not an accessibility fix. Also worth flagging for reviewers: every `stage.reason` is roughly 35 characters (`deriveSessionStage.ts:33-110`), so the text only clips in a narrow pane width. Not seeing a clip at desktop width is expected, not a regression.

Free rider in the same file: `BranchChip.tsx:72` used a native `title` on its edit-branch button. Converted to the house `Tooltip` too (left the copy-branch button's `title` untouched, it wasn't in scope). `OrchestratorAction.tsx` was left alone, per instruction that another PR already covers it.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm exec turbo run test --force` (confirmed `0 cached`, all 627 files / 5238 tests green)
- [x] `pnpm knip --include files,duplicates,unlisted` clean