### PR TITLE
docs(repo): bind the release captain's turn to its report block

### DIFF
--- a/.claude/skills/continuous-delivery/references/briefs/_contract.md
+++ b/.claude/skills/continuous-delivery/references/briefs/_contract.md
@@ -14,3 +14,8 @@ in this directory assumes it and repeats none of it.
   decide, state the assumption in your report, move on.
 - Your soul shapes what you notice and how you write, never what you may
   approve or block ([souls.md](../../../../../docs/autonomy/souls.md)).
+- Your parent's turn does not end while you are live: it waits on you, runs
+  the watchdog cadence
+  ([watchdogs.md](../../../../../docs/autonomy/watchdogs.md)), and does not
+  spawn children and hand off to its own caller until your roster entry
+  resolves.

--- a/.claude/skills/continuous-delivery/references/release-captain-prompt.md
+++ b/.claude/skills/continuous-delivery/references/release-captain-prompt.md
@@ -13,6 +13,14 @@ never ask one. Decide, state the assumption in your report, move.
 **Publication boundary.** You stop at a reviewed draft. Never run
 `gh release edit --draft=false`. Your caller publishes.
 
+**Turn boundary.** Your turn ends only at the report block below, never
+earlier. While any child on your roster is live, you wait on it, run the
+watchdog cadence in `docs/autonomy/watchdogs.md`, and continue; you do not
+spawn children and hand control back to your caller before every entry
+resolves. That handoff is the silent-stall failure `docs/autonomy/watchdogs.md`
+exists to prevent: a captain once did exactly that after spawning its
+Phase 1 archaeologists, with five children still live.
+
 **Working root and write scope.** Working root: `{{repo_root}}`. You write
 `~/.goodboy-autonomous/v{{version}}/` (run log and scratch; every child
 gets a unique path inside it) and, among engagement-level state files,
@@ -194,7 +202,9 @@ run-log line in `~/.goodboy-autonomous/v{{version}}/run-log.md` when its
 roster entry resolves, per `docs/autonomy/visibility.md`. Concurrent
 children follow the roster contract in `docs/autonomy/watchdogs.md`; run
 that file's sibling-check cadence against your roster while children run
-and act on its reports.
+and act on its reports. The turn-boundary rule above binds this literally:
+you do not cross a phase boundary, let alone report and exit, with any
+roster entry unresolved.
 
 **Not authorized**: publishing, force-push, pushing to `main`, bypassing
 hooks, deleting a published release, touching signing secrets, telemetry of

--- a/docs/adr/0002-captain-turn-boundary.md
+++ b/docs/adr/0002-captain-turn-boundary.md
@@ -1,0 +1,129 @@
+# 0002. Bind the release captain's turn to its report block
+
+status: accepted
+date: 2026-08-08
+owner: head of engineering, per its charter's structural-decision clause
+(`docs/autonomy/roles/head-of-engineering.md:13-14`: "it writes the ADR for
+structural decisions")
+reviewed-by: the challenger, who located this gap against the captain
+template, the shared spawn contract and watchdogs.md; and the release
+captain, the role this rule binds. Per the review rule in
+`docs/adr/README.md:38-39` ("the challenger reviews every ADR, plus one
+role that would be bound by it").
+
+## Context
+
+`docs/autonomy/watchdogs.md:27-30` records the incident this decision
+closes: "one captain ended its turn with five children still live at
+6-item scale, having lost track of them." A release captain spawned
+children and returned control to its caller while they were still running,
+which is the silent-stall failure the watchdog cadence in that same file
+exists to catch, not to prevent at the source.
+
+The rule that would have prevented it already exists in one place: the
+captain's own role charter, `docs/autonomy/roles/release-captain.md:32-36`,
+states "A captain's turn ends only at its report block, never with children
+still live" and points to `watchdogs.md` for the incident. But the
+captain's actual reading list, in
+`.claude/skills/continuous-delivery/references/release-captain-prompt.md`,
+never includes that charter file: the brief's phase-triggered-reads
+paragraph (its lines 48-49, before this PR) names a role's charter as read
+"when you spawn that role," and a captain never spawns itself. A rule that
+lives only in a
+document the bound role never reads is not a rule that role follows, it is
+a rule that role happens to satisfy until it does not.
+
+Checking where the gap actually was, rather than assuming the prompt was
+the whole fix, found it was narrower and wider than expected:
+
+- `release-captain-prompt.md:10-11` and `:243` (base `a2d5066b5`, before
+  this PR) describe the report's shape ("report one block and exit," "No
+  progress narration, no questions. One report, at the end."): they say
+  what the report looks like, not that nothing may end the turn before it.
+- `release-captain-prompt.md:195-197` (same base) reads "children follow
+  the roster contract in `docs/autonomy/watchdogs.md`; run that file's
+  sibling-check cadence against your roster while children run and act on
+  its reports": grammatically this **assumes** the captain is still
+  running when children run; it does not **require** that it stay running.
+- `references/briefs/_contract.md` (same base), the file prepended to
+  every specialist spawn, bound the spawned child (scratch path, work-alone
+  rule, soul) but said nothing about what its parent owes it while it is
+  alive.
+
+So the rule survived only by being hand-pasted into each captain's filled
+brief by its caller (the delivery lead), each release, which does not
+scale and fails silently the one time it is forgotten. Per
+`docs/autonomy/item-classes.md:97-100`, an org item must cite one incident
+in two distinct releases or a single severe one; the incident above is
+severe on its own terms (five live children, one captain, complete loss of
+tracking) and is the only citation this record relies on.
+
+## Decision
+
+Carry the turn-boundary rule into every place a captain's behavior is
+actually assembled from at spawn time, each in that file's own voice, and
+touch nothing else:
+
+- `.claude/skills/continuous-delivery/references/release-captain-prompt.md`
+  (the read captains actually run on): a new **Turn boundary** paragraph at
+  lines 16-22, next to the existing Publication boundary, stating the turn
+  ends only at the report block and that spawning children then handing
+  back to the caller is the failure watchdogs.md exists to prevent. The
+  roster-contract paragraph at lines 199-207 gained one sentence (205-207)
+  tying the rule to the phase-boundary mechanics already in
+  `docs/autonomy/watchdogs.md`.
+- `.claude/skills/continuous-delivery/references/briefs/_contract.md` (the
+  contract every spawned child receives): a new bullet at lines 17-21
+  stating, from the child's side, that its parent's turn does not end
+  while it is live.
+- `docs/autonomy/watchdogs.md` (the file that owns liveness policy): a new
+  **The turn boundary** paragraph at lines 35-40, inside the roster
+  contract section, stating the rule as policy and naming it as the direct
+  fix for the incident the same section already narrates.
+
+The role charter (`docs/autonomy/roles/release-captain.md:32-36`) already
+carried this rule and is left unchanged; it was never the gap.
+`docs/autonomy/roles.md` and `AUTONOMY.md` are pure indexes (one line per
+role, or an enumeration with an explicit "not agent read material" notice)
+and carry no rule text for any role, so neither needed a fourth copy of
+this one.
+
+## Consequences
+
+A captain reading its own brief, its own roster-contract paragraph, and
+the contract prepended to every child it spawns now meets this rule three
+times before it can miss it once, without depending on the delivery lead
+remembering to hand-paste it into a filled brief. That closes the
+mechanical gap.
+
+It does not close the verification gap: this is an org item, and
+`docs/autonomy/item-classes.md:69-74` is explicit that an org item "cannot
+be verified in the cycle that writes it," because the rule has not run
+yet. This record ships `pending-verification`. The next release's captain
+is the first one to actually run under a template that carries this rule
+inline, and it is the next release's ledger entry, not this one, that can
+say whether a captain still ended its turn early. Until that judgment
+lands, this ADR records a decision, not a result.
+
+## Alternatives considered
+
+- **Patch only the prompt template.** Rejected: the prompt is what a
+  captain reads, but `_contract.md` is what every child was spawned under,
+  and a rule the parent follows that the child's own contract is silent on
+  is only carried from one side. Both needed it, in each one's own voice.
+- **Rely on the existing charter and stop.** Rejected: the charter already
+  states the rule (`roles/release-captain.md:32-36`) and the incident
+  still happened, because the charter is not on the captain's own reading
+  list. A rule nobody reads at the moment it matters is not a rule.
+- **A fourth copy in `AUTONOMY.md` or `docs/autonomy/roles.md` for
+  visibility.** Rejected: both files are explicitly indexes, not rule
+  text (`AUTONOMY.md:6`: "nothing else"; `roles.md`'s role list is one
+  line of mandate per role). A fourth copy of a rule that already lives in
+  three places, each at its own altitude, is the third-copy drift this
+  cluster warns against elsewhere, not a safety margin.
+- **Widen this ADR to also fix the underlying reading-list gap** (the
+  charter a captain never reads). Rejected as its own item: the footprint
+  discipline in `docs/autonomy/item-classes.md:22-26` treats a crossed
+  class or scope boundary as two items, and reworking the captain's
+  read-first list is a different, larger change than restating one rule in
+  three files.

--- a/docs/adr/0002-captain-turn-boundary.md
+++ b/docs/adr/0002-captain-turn-boundary.md
@@ -13,12 +13,13 @@ role that would be bound by it").
 
 ## Context
 
-`docs/autonomy/watchdogs.md:27-30` records the incident this decision
-closes: "one captain ended its turn with five children still live at
-6-item scale, having lost track of them." A release captain spawned
-children and returned control to its caller while they were still running,
-which is the silent-stall failure the watchdog cadence in that same file
-exists to catch, not to prevent at the source.
+`docs/autonomy/watchdogs.md`'s roster-contract section (lines 27-30)
+records the incident this decision closes: "one captain ended its turn
+with five children still live at 6-item scale, having lost track of
+them." A release captain spawned children and returned control to its
+caller while they were still running, which is the silent-stall failure
+the watchdog cadence in that same file exists to catch, not to prevent at
+the source.
 
 The rule that would have prevented it already exists in one place: the
 captain's own role charter, `docs/autonomy/roles/release-captain.md:32-36`,
@@ -27,9 +28,9 @@ still live" and points to `watchdogs.md` for the incident. But the
 captain's actual reading list, in
 `.claude/skills/continuous-delivery/references/release-captain-prompt.md`,
 never includes that charter file: the brief's phase-triggered-reads
-paragraph (its lines 48-49, before this PR) names a role's charter as read
-"when you spawn that role," and a captain never spawns itself. A rule that
-lives only in a
+paragraph's closing clause (base `a2d5066b5`, lines 46-47, before this PR)
+names a role's charter as read "when you spawn that role," and a captain
+never spawns itself. A rule that lives only in a
 document the bound role never reads is not a rule that role follows, it is
 a rule that role happens to satisfy until it does not.
 
@@ -69,13 +70,14 @@ touch nothing else:
   lines 16-22, next to the existing Publication boundary, stating the turn
   ends only at the report block and that spawning children then handing
   back to the caller is the failure watchdogs.md exists to prevent. The
-  roster-contract paragraph at lines 199-207 gained one sentence (205-207)
-  tying the rule to the phase-boundary mechanics already in
-  `docs/autonomy/watchdogs.md`.
+  **Every agent you spawn** paragraph (lines 199-207, the roster-contract
+  paragraph) gained one sentence (205-207) tying the rule to the
+  phase-boundary mechanics already in `docs/autonomy/watchdogs.md`.
 - `.claude/skills/continuous-delivery/references/briefs/_contract.md` (the
-  contract every spawned child receives): a new bullet at lines 17-21
-  stating, from the child's side, that its parent's turn does not end
-  while it is live.
+  contract every spawned child receives): a new bullet at lines 17-21,
+  opening "Your parent's turn does not end while you are live," stating,
+  from the child's side, that its parent's turn does not end while it is
+  live.
 - `docs/autonomy/watchdogs.md` (the file that owns liveness policy): a new
   **The turn boundary** paragraph at lines 35-40, inside the roster
   contract section, stating the rule as policy and naming it as the direct

--- a/docs/autonomy/watchdogs.md
+++ b/docs/autonomy/watchdogs.md
@@ -32,6 +32,13 @@ git state, never on harness task ids: a replacement parent resumes from
 branches, worktrees and journals, because task ids die with the parent that
 held them.
 
+**The turn boundary.** A release captain's turn ends only at its report
+block. While any child on its roster is live, it waits on the child, runs
+the cadence below, and continues; it does not spawn children and hand
+control back to its caller before every entry resolves. That handoff is
+exactly the incident above: a captain spawned its Phase 1 archaeologists,
+then ended its turn with five children still live.
+
 - Every builder and verifier keeps a **heartbeat journal** in its scratch
   path: one appended line at each real boundary (reading done, a commit
   made, a test run started or finished). The brief says so explicitly; a


### PR DESCRIPTION
## Summary

Adds ADR 0002 and carries the release captain's turn-boundary rule into
every place a captain's spawn-time behavior is actually assembled from,
so the rule survives on its own instead of depending on being hand-pasted
into a filled brief each release.

**The rule:** a release captain's turn ends only at its report block.
While any of its children are live it waits on them, runs the watchdog
cadence, and continues; it never spawns children and hands control back
to its caller. That handoff is the silent-stall failure `watchdogs.md`
exists to prevent, and it happened once: a captain did exactly that after
spawning its Phase 1 archaeologists, with five children still live.

**Where it landed, and why not where first assumed.** The captain's own
role charter (`docs/autonomy/roles/release-captain.md:32-36`) already
states this rule, so the charter was left untouched. The actual gap is
that the charter is not on a captain's own reading list (a role's charter
is read "when you spawn that role," and a captain never spawns itself),
so the rule never reached the agent it binds. Checking where it needed to
land, rather than assuming one file was the whole fix, found three spots,
each in its own voice:

1. `.claude/skills/continuous-delivery/references/release-captain-prompt.md`,
   the file a captain actually reads: a new **Turn boundary** paragraph,
   plus one sentence tightening the existing roster-contract paragraph
   from assuming the captain stays live to requiring it.
2. `.claude/skills/continuous-delivery/references/briefs/_contract.md`,
   the contract prepended to every spawned child: a new bullet stating,
   from the child's side, that its parent's turn does not end while it is
   live. This file previously bound children only, never the captain.
3. `docs/autonomy/watchdogs.md`, the file that owns liveness policy: a new
   **The turn boundary** paragraph inside the roster contract section,
   naming the rule as the direct fix for the incident that section already
   narrates.

A rule present in only one of the three would be the exact defect it
exists to fix, so no fourth copy was added anywhere (checked
`AUTONOMY.md` and `docs/autonomy/roles.md`: both are pure indexes with no
rule text for any role, so neither needed touching).

**ADR 0002** (`docs/adr/0002-captain-turn-boundary.md`) records the
decision per `docs/adr/README.md`'s skeleton and status model: `status:
accepted`, `owner: head of engineering` (per its charter's
structural-decision clause), `reviewed-by:` naming both the challenger and
the release captain, the role this rule binds, per the README's review
rule. It does not repeat 0001's two flagged issues: no invented
"Amendment" section, and the `reviewed-by:` line names both required
roles up front.

This is the release's org-class item and ships **pending-verification**:
the rule has not run under a live captain yet, so this record cannot claim
it works. The next release's captain judges it against what actually
happened.

## Test plan

- [x] Read `docs/autonomy/item-classes.md`, `docs/adr/README.md`,
      `docs/autonomy/watchdogs.md`, `docs/autonomy/release-loop.md`,
      `CONVENTIONS.md` before writing.
- [x] Every line number cited in the ADR and in this body was verified by
      opening the actual file (pre-edit content confirmed byte-identical
      between the base commit and this branch's starting point).
- [x] `prettier --check` clean on all four changed/added files.
- [x] Commit passed the repo's pre-commit (prettier) and commit-msg
      (commitlint) hooks, no `--no-verify`.
- [x] Docs-only change; did not run the full workspace test suite per
      sibling-builder concurrency constraints.