### PR TITLE
chore(repo): bump version to 0.1.75

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ version in the same PR that bumps the version numbers (see
 `docs/release-command.md`), before the tag is pushed: the release build fails
 if it can't find a matching `## Goodboy vX.Y.Z` heading.
 
+## Goodboy v0.1.75
+
+Turning autorun off now stops the step in flight, raw output standing in for a summary is labeled as such, and controls that only showed on hover now show on keyboard focus.
+
+### [#1339] Stop an orchestrated run, then resume it
+
+The autorun toggle sits on the workflow's row, in the sidebar and on the workflow detail. Turning it off while a step is still running now asks first: "Stop this run?" Confirm, and the turn is canceled, the step in flight is marked skipped, and everything it already wrote is kept. Turning autorun off when nothing is running is unchanged, with no confirm and no extra write.
+
+A run you stopped reads as stopped rather than "Orchestrator failed", both in the orchestrator panel and in the sidebar. Resume clears the stop, turns autorun back on and asks for the next step, rather than advancing one step and stopping again.
+
+A stop you send while the orchestrator is choosing the next step is no longer erased when that choice lands.
+
+Follow-up: a stop sent while a decision is in flight is honored, though the panel keeps reading "Choosing the next step" until the model returns, which can take a couple of minutes. Nothing advances in the meantime.
+
+### [#1337] Steps that could not be summarized are flagged everywhere
+
+When a step's output cannot be summarized, Goodboy shows the raw truncated output in its place. Sequential steps already labeled that substitution and put a notification in the inbox with a retry action. Steps inside a cluster, a scout's branches, and parallel steps made the same substitution silently. All four now behave the same way, one notification per agent, so raw output is labeled as raw output rather than passing for a summary.
+
+### [#1340] Hover-only controls stay visible under keyboard focus
+
+The remove and delete buttons on chat attachments, goal attachments and provider credentials only appeared on hover. They were always in the tab order, so a keyboard user could land on an invisible control and press it. They now appear on focus, as does the copy affordance on an assistant message.
+
+### Fixes
+
+- Counts read "1 agent", "1 session" and "1 folder", not "1 agents" [#1341]
+- The pull request pane calls linked work "Linked work" and "Completed linked work", one name where it used to carry two [#1341]
+- The routing status chip reads in sentence case rather than all caps, and its label and its screen-reader label now match [#1341]
+- The permission, issue, reviewer and resolver menus close on Escape and flip upward when there is no room below them [#1338]
+- The stage reason and the edit-branch control on the session overview use Goodboy's own tooltip, not the browser's [#1340]
+- A provider added without a routing priority is caught before it ships, rather than dropping out of the priority list unnoticed [#1343]
+
 ## Goodboy v0.1.74
 
 Review threads carry GitHub's outdated mark, the note you send the orchestrator is kept with its decision, and a failed comment push names what broke.

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goodboy/desktop",
-  "version": "0.1.74",
+  "version": "0.1.75",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -1626,7 +1626,7 @@ dependencies = [
 
 [[package]]
 name = "goodboy-desktop"
-version = "0.1.74"
+version = "0.1.75"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goodboy-desktop"
-version = "0.1.74"
+version = "0.1.75"
 description = "Goodboy desktop app"
 authors = ["Amin Khayam"]
 license = "MIT"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Goodboy",
-  "version": "0.1.74",
+  "version": "0.1.75",
   "identifier": "com.goodboy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/docs/adr/0001-expand-the-delivery-org.md
+++ b/docs/adr/0001-expand-the-delivery-org.md
@@ -3,11 +3,21 @@
 status: accepted
 date: 2026-08-08
 owner: the repo owner, acting as product owner for the org itself
-reviewed-by: pending; the first engagement's challenger reviews this record
-explicitly. The channel: the delivery lead includes this record in the
-first captain's pending-deferred-items block, the captain hands it to its
-Phase 2 challenger, and the captain updates this line with the review's
-pointer in the release PR (see the amendment of 2026-08-08)
+reviewed-by: the first engagement's challenger, during the v0.1.75 release
+cycle. Verdict: **sound-with-reservations**. The diagnosis and its counted
+evidence justify item classes, the refactor floor and the impact bar
+completely; the reservations are about derivation and self-compliance, not
+direction. Five claims named as thin: (1) the resize to twelve replaces one
+untested number with another and derives neither; (2) the graduation gate
+fires on "two green engagements", a phrase nothing in this repo defines;
+(3) moving the headline numbers down by amendment contradicts the
+supersession rule in README.md, which the graduation clause itself relies on
+for moving them up; (4) this very line named one reviewer where README.md
+requires the challenger **plus one role that would be bound**, so the review
+it demanded was under-specified; (5) the cost control asserted in
+Consequences was replaced by this record's own second amendment before a
+single release ran. The bound-role reviewer remains unsupplied and is owed
+by a later cycle
 
 ## Context
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goodboy",
-  "version": "0.1.74",
+  "version": "0.1.75",
   "private": true,
   "description": "AI workspace orchestrator. Local-first, provider-agnostic.",
   "license": "MIT",

--- a/website/src/site.ts
+++ b/website/src/site.ts
@@ -1,5 +1,5 @@
 export const SITE = {
-  version: 'v0.1.74',
+  version: 'v0.1.75',
   repo: 'https://github.com/akhayam99/goodboy',
   releases: 'https://github.com/akhayam99/goodboy/releases',
   latest: 'https://github.com/akhayam99/goodboy/releases/latest',


### PR DESCRIPTION
Version bump to 0.1.75 across all six version files, plus the changelog section the release build reads verbatim.

## What is in this release

Seven work PRs, range `0dcea3df8..0726b3279`:

- #1339 stop an orchestrated run from the autorun toggle (headline)
- #1337 mark and notify on degraded step summaries
- #1340 focus-reveal fixes and a house tooltip on truncated stage text
- #1341 plurals, one noun for linked work, sentence-case status chip
- #1338 four anchored popovers converged onto the shared dropdown hook
- #1343 provider-priority tether and exhaustiveness guards
- #1342 the captain turn-boundary rule and ADR 0002

## Notes provenance

The changelog section was written from the merged PR bodies, reviewed by the voice steward against `docs/tone-of-voice.md` and then rewritten by the challenger, which caught two false claims in an earlier draft: the stage-reason tooltip is unconditional rather than clip-triggered, and it duplicates its text rather than adding to it the way the board's equivalent does. Both were corrected before this commit.

## ADR 0001

Its `reviewed-by:` line was `pending` and is now filled in. Verdict: sound-with-reservations, with five thin claims named. The bound-role reviewer that `docs/adr/README.md` requires alongside the challenger is still unsupplied and is recorded as owed.