### PR TITLE
fix(desktop): say a run is stopping when stopped mid-decision

### DIFF
--- a/apps/desktop/src/features/workflows/components/OrchestratorPanel/index.test.tsx
+++ b/apps/desktop/src/features/workflows/components/OrchestratorPanel/index.test.tsx
@@ -322,6 +322,10 @@ describe('OrchestratorPanel state ladder', () => {
     expect(screen.getByTestId('orchestrator-panel').getAttribute('data-phase')).toBe('stopping');
     expect(screen.getByTestId('orchestrator-panel').className).not.toContain('spin-border');
     expect(screen.queryByTestId('orchestrator-resume')).toBeNull();
+
+    const dot = screen.getByRole('img', { name: sentence() });
+    expect(dot.className).toContain('bg-warning');
+    expect(dot.className).not.toContain('bg-info');
   });
 
   it('falls back to a generic presentation for a stop kind it does not recognize', () => {

--- a/apps/desktop/src/features/workflows/components/OrchestratorPanel/index.test.tsx
+++ b/apps/desktop/src/features/workflows/components/OrchestratorPanel/index.test.tsx
@@ -305,6 +305,25 @@ describe('OrchestratorPanel state ladder', () => {
     expect(storeState['retryWorkflowOrchestration']).toHaveBeenCalledWith(SESSION_ID, RUN_ID);
   });
 
+  it('says it is stopping instead of still choosing, when stopped mid-decision', () => {
+    renderPanel({
+      runOverride: run({
+        orchestrationStop: {
+          kind: 'operator',
+          message: 'You stopped this run. The step in flight was skipped.',
+        },
+      }),
+      agents: [agent(0, 'skipped')],
+      isOrchestrating: true,
+    });
+
+    expect(sentence()).not.toContain('Choosing the next step');
+    expect(sentence()).toContain('Stopping');
+    expect(screen.getByTestId('orchestrator-panel').getAttribute('data-phase')).toBe('stopping');
+    expect(screen.getByTestId('orchestrator-panel').className).not.toContain('spin-border');
+    expect(screen.queryByTestId('orchestrator-resume')).toBeNull();
+  });
+
   it('falls back to a generic presentation for a stop kind it does not recognize', () => {
     renderPanel({
       runOverride: run({

--- a/apps/desktop/src/features/workflows/components/OrchestratorPanel/index.tsx
+++ b/apps/desktop/src/features/workflows/components/OrchestratorPanel/index.tsx
@@ -71,7 +71,8 @@ export const OrchestratorPanel = ({
   const elapsed = useElapsedLabel({ since: state.waitingSince });
   const tint = tintClasses(state.tone);
   const isDeciding = state.phase === 'deciding';
-  const isPulsing = isDeciding || state.phase === 'automatic';
+  const isPulsing = isDeciding || state.phase === 'automatic' || state.phase === 'stopping';
+  const pulseTone = state.tone === 'neutral' ? 'info' : state.tone;
 
   const guard = async (action: () => Promise<void>) => {
     if (busy) {
@@ -128,7 +129,7 @@ export const OrchestratorPanel = ({
             )}
           >
             {isPulsing ? (
-              <StatusDot tone="info" size="sm" pulsing ariaLabel={state.sentence} />
+              <StatusDot tone={pulseTone} size="sm" pulsing ariaLabel={state.sentence} />
             ) : null}
             <span className="min-w-0">{state.sentence}</span>
             {elapsed != null ? (

--- a/apps/desktop/src/features/workflows/components/OrchestratorPanel/orchestratorState.test.ts
+++ b/apps/desktop/src/features/workflows/components/OrchestratorPanel/orchestratorState.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  Agent,
+  AgentId,
+  IsoDateTime,
+  SessionId,
+  StepId,
+  WorkflowId,
+  WorkflowOrchestrationStop,
+  WorkflowRun,
+  WorkflowRunId,
+} from '@goodboy/types';
+import { resolveOrchestratorState } from './orchestratorState';
+
+const SESSION_ID = 'session-1' as SessionId;
+const RUN_ID = 'run-1' as WorkflowRunId;
+const WORKFLOW_ID = 'workflow-1' as WorkflowId;
+
+const makeRun = (overrides: Partial<WorkflowRun> = {}): WorkflowRun => ({
+  id: RUN_ID,
+  workflowId: WORKFLOW_ID,
+  ordinal: 0,
+  currentStep: 0,
+  autoRun: false,
+  triggerMode: 'immediate',
+  executionMode: 'dynamic',
+  ...overrides,
+});
+
+const makeAgent = (
+  ordinal: number,
+  status: Agent['status'],
+  overrides: Partial<Agent> = {},
+): Agent => ({
+  id: `agent-${ordinal}` as AgentId,
+  sessionId: SESSION_ID,
+  stepId: `step-${ordinal}` as StepId,
+  workflowRunId: RUN_ID,
+  ordinal,
+  name: `step ${ordinal}`,
+  status,
+  ...overrides,
+});
+
+type ResolveParams = {
+  readonly run?: WorkflowRun;
+  readonly agents?: ReadonlyArray<Agent>;
+  readonly isOrchestrating?: boolean;
+  readonly hasOpenQuestions?: boolean;
+  readonly costUsd?: number;
+};
+
+const resolve = ({
+  run = makeRun(),
+  agents = [],
+  isOrchestrating = false,
+  hasOpenQuestions = false,
+  costUsd = 0,
+}: ResolveParams = {}) =>
+  resolveOrchestratorState({ run, agents, isOrchestrating, hasOpenQuestions, costUsd });
+
+describe('resolveOrchestratorState', () => {
+  it('reports deciding while the orchestrator is choosing', () => {
+    const state = resolve({ isOrchestrating: true });
+
+    expect(state.phase).toBe('deciding');
+    expect(state.tone).toBe('info');
+    expect(state.sentence).toBe('Choosing the next step');
+  });
+
+  it('reports done with the step count and the run cost', () => {
+    const state = resolve({
+      run: makeRun({ orchestrationOutcome: 'done' }),
+      agents: [makeAgent(0, 'completed'), makeAgent(1, 'completed')],
+      costUsd: 1.5,
+    });
+
+    expect(state.phase).toBe('done');
+    expect(state.tone).toBe('success');
+    expect(state.sentence).toContain('2 steps');
+  });
+
+  it('reports blocked with the orchestration reason as detail', () => {
+    const state = resolve({
+      run: makeRun({ orchestrationOutcome: 'blocked', orchestrationReason: 'needs a decision' }),
+    });
+
+    expect(state.phase).toBe('blocked');
+    expect(state.tone).toBe('warning');
+    expect(state.detail).toBe('needs a decision');
+  });
+
+  it('maps every stop kind to its presentation', () => {
+    const kinds: ReadonlyArray<[WorkflowOrchestrationStop['kind'], string, boolean]> = [
+      ['budget', 'paused-budget', false],
+      ['failure', 'failed', true],
+      ['questions', 'needs-answer', false],
+      ['operator', 'stopped', true],
+    ];
+
+    const resolved = kinds.map(([kind]) =>
+      resolve({
+        run: makeRun({ orchestrationStop: { kind, message: 'stop message' } }),
+        hasOpenQuestions: kind === 'questions',
+      }),
+    );
+
+    expect(resolved.map((state) => state.phase)).toEqual(kinds.map(([, phase]) => phase));
+    expect(resolved.map((state) => state.detail !== null)).toEqual(
+      kinds.map(([, , showsMessage]) => showsMessage),
+    );
+  });
+
+  it('ignores a question stop once the question is answered', () => {
+    const state = resolve({
+      run: makeRun({ orchestrationStop: { kind: 'questions', message: 'answer me' } }),
+      agents: [makeAgent(0, 'completed')],
+      hasOpenQuestions: false,
+    });
+
+    expect(state.phase).toBe('ready-mid');
+    expect(state.sentence).toBe('Step 1 done · ready to continue');
+  });
+
+  it('waits on the running step and carries its start time', () => {
+    const startedAt = '2025-01-01T00:00:00.000Z' as IsoDateTime;
+    const state = resolve({
+      agents: [makeAgent(0, 'completed'), makeAgent(1, 'running', { startedAt })],
+    });
+
+    expect(state.phase).toBe('waiting');
+    expect(state.sentence).toBe('Waiting on step 2 · step 1');
+    expect(state.waitingSince).toBe(startedAt);
+  });
+
+  it('asks for an answer when a question is open and nothing runs', () => {
+    const state = resolve({ agents: [makeAgent(0, 'completed')], hasOpenQuestions: true });
+
+    expect(state.phase).toBe('needs-answer');
+    expect(state.tone).toBe('warning');
+  });
+
+  it('reports a failed step ahead of a pending one', () => {
+    const state = resolve({ agents: [makeAgent(0, 'failed'), makeAgent(1, 'pending')] });
+
+    expect(state.phase).toBe('step-failed');
+    expect(state.sentence).toBe('Stopped · step 1 failed · step 0');
+    expect(state.detail).toBe('Nothing advances until this step is skipped.');
+  });
+
+  it('waits on a pending step without a start time', () => {
+    const state = resolve({ agents: [makeAgent(0, 'completed'), makeAgent(1, 'pending')] });
+
+    expect(state.phase).toBe('waiting');
+    expect(state.sentence).toBe('Waiting on step 2 · step 1');
+    expect(state.waitingSince).toBeNull();
+  });
+
+  it('continues automatically when autorun drives an idle run', () => {
+    const state = resolve({
+      run: makeRun({ autoRun: true }),
+      agents: [makeAgent(0, 'completed')],
+    });
+
+    expect(state.phase).toBe('automatic');
+    expect(state.sentence).toBe('Continuing automatically');
+  });
+
+  it('offers the first step when the run has no agents', () => {
+    const state = resolve();
+
+    expect(state.phase).toBe('ready-first');
+    expect(state.sentence).toBe('Ready to plan the first step');
+  });
+
+  it('sorts agents by ordinal before numbering the steps', () => {
+    const state = resolve({
+      agents: [makeAgent(2, 'pending'), makeAgent(0, 'completed'), makeAgent(1, 'completed')],
+    });
+
+    expect(state.sentence).toBe('Waiting on step 3 · step 2');
+  });
+});

--- a/apps/desktop/src/features/workflows/components/OrchestratorPanel/orchestratorState.test.ts
+++ b/apps/desktop/src/features/workflows/components/OrchestratorPanel/orchestratorState.test.ts
@@ -68,6 +68,42 @@ describe('resolveOrchestratorState', () => {
     expect(state.sentence).toBe('Choosing the next step');
   });
 
+  it('reports stopping when the user stops while a decision is in flight', () => {
+    const state = resolve({
+      run: makeRun({ orchestrationStop: { kind: 'operator', message: 'you stopped this run' } }),
+      agents: [makeAgent(0, 'skipped')],
+      isOrchestrating: true,
+    });
+
+    expect(state.phase).toBe('stopping');
+    expect(state.tone).toBe('warning');
+    expect(state.sentence).toBe('Stopping · waiting for the decision already in flight');
+  });
+
+  it('never claims the run is stopped before the decision returns', () => {
+    const stopped = resolve({
+      run: makeRun({ orchestrationStop: { kind: 'operator', message: 'you stopped this run' } }),
+      isOrchestrating: false,
+    });
+    const stopping = resolve({
+      run: makeRun({ orchestrationStop: { kind: 'operator', message: 'you stopped this run' } }),
+      isOrchestrating: true,
+    });
+
+    expect(stopped.phase).toBe('stopped');
+    expect(stopping.phase).not.toBe('stopped');
+    expect(stopping.detail).toBeNull();
+  });
+
+  it('keeps deciding for stops the orchestrator raises about itself', () => {
+    const state = resolve({
+      run: makeRun({ orchestrationStop: { kind: 'failure', message: 'provider refused' } }),
+      isOrchestrating: true,
+    });
+
+    expect(state.phase).toBe('deciding');
+  });
+
   it('reports done with the step count and the run cost', () => {
     const state = resolve({
       run: makeRun({ orchestrationOutcome: 'done' }),

--- a/apps/desktop/src/features/workflows/components/OrchestratorPanel/orchestratorState.ts
+++ b/apps/desktop/src/features/workflows/components/OrchestratorPanel/orchestratorState.ts
@@ -9,6 +9,7 @@ import type {
 
 type OrchestratorPhase =
   | 'deciding'
+  | 'stopping'
   | 'waiting'
   | 'automatic'
   | 'ready-first'
@@ -71,6 +72,13 @@ const STOP_PRESENTATION: Record<WorkflowOrchestrationStopKind, StopPresentation>
   },
 };
 
+const OPERATOR_STOP_IN_FLIGHT: StopPresentation = {
+  phase: 'stopping',
+  tone: 'warning',
+  sentence: 'Stopping · waiting for the decision already in flight',
+  showsMessage: false,
+};
+
 const UNKNOWN_STOP: StopPresentation = {
   phase: 'failed',
   tone: 'danger',
@@ -92,6 +100,14 @@ export const resolveOrchestratorState = ({
   const doneCount = ordered.filter(isDone).length;
   const base = { detail: null, waitingSince: null };
 
+  if (isOrchestrating && run.orchestrationStop?.kind === 'operator') {
+    return {
+      ...base,
+      phase: OPERATOR_STOP_IN_FLIGHT.phase,
+      tone: OPERATOR_STOP_IN_FLIGHT.tone,
+      sentence: OPERATOR_STOP_IN_FLIGHT.sentence,
+    };
+  }
   if (isOrchestrating) {
     return { ...base, phase: 'deciding', tone: 'info', sentence: 'Choosing the next step' };
   }


### PR DESCRIPTION
## What changed

Stopping a workflow run persists the operator stop into the store immediately, but the
orchestrator panel derived its phase from the in-flight decision **before** it ever read
`run.orchestrationStop`. The panel therefore kept saying "Choosing the next step" until the
orchestrator client returned, which is bounded by its own 120s timeout. That is not a blank
state, it is a misleading one: the user had already stopped the run and the panel told them
the orchestrator was still picking their next step.

A new `stopping` phase reads the operator stop while the decision is still in flight and says
"Stopping · waiting for the decision already in flight".

It **never claims the run is `stopped`**. The decision has not returned, the run is not stopped
until it does, and a panel that says otherwise is something the user would act on.

The phase is scoped to the `operator` stop kind on purpose. It is the only stop that can
coexist with a decision in flight from the outside; the budget, questions and failure stops are
raised by the orchestrator about itself, and widening the rule would let a provider failure
flash a stop the user never asked for. A test pins that.

## Phase arms touched

`OrchestratorPanel/index.tsx` is the sole consumer and hand-enumerates every phase, so nothing
is compiler-forced. I walked all of them:

- `isDeciding` (`:73`) unchanged: `stopping` is deliberately not `deciding`, so the panel does
  not run the `spin-border` decide animation on a run the user has stopped.
- `isPulsing` (`:74`) now includes `stopping`. The run really is still doing something, and the
  pulsing dot is the honest signal for that.
- The status dot tone now follows `state.tone` instead of being hardcoded `info`. For every
  existing pulsing phase (`deciding`, `automatic`) the tone already resolves to `info`, so this
  is behavior-identical there; it exists so `stopping` does not render an info-blue dot beside
  warning-toned text.
- Action ternaries (`:148-230`): `ready-first`/`ready-mid`, `needs-answer`, `paused-budget`,
  `step-failed`, `stopped`, `failed`/`blocked`, `done`. `stopping` matches none, which is the
  intended outcome: resuming mid-decision would clear the stop the in-flight decision is about
  to check, and the retry it triggers is dropped by the in-flight guard anyway. Transitional
  state, no control, asserted by a test.

## The characterization test, written first

`resolveOrchestratorState` had zero unit coverage, so "behavior unchanged except the one
branch" would have been an unbacked claim. The first commit adds
`orchestratorState.test.ts` and nothing else: 12 tests pinning all twelve phases, the four
stop-kind presentations and which of them surface the stop message, the answered-question
exemption, the failed-step-before-pending-step ordering, and the ordinal sort. It passes on
unchanged code, and the second commit adds the fix on top of it.

## Test plan

- `pnpm typecheck` green.
- `pnpm exec turbo run test --force`: 5280 tests, 634 files, `0 cached`.
- `pnpm knip --include files,duplicates,unlisted` green.
- `stopWorkflowRunNow.test.ts` and `orchestrateNextStep.test.ts` still green.
- `commandExecutor.commands.test.ts` still green: bridge-originated workflows stay pinned to
  `autoRun: false, triggerMode: 'manual'`, untouched by this change.

Part of #1333
