### PR TITLE
refactor(desktop): total-check the seven provider lists

### DIFF
--- a/apps/desktop/src/features/budget/components/BudgetStudio/lib.test.ts
+++ b/apps/desktop/src/features/budget/components/BudgetStudio/lib.test.ts
@@ -7,7 +7,7 @@ import type {
   TelemetryRecord,
   TelemetryRecordId,
 } from '@goodboy/types';
-import { buildModelBreakdown, coverageTurnCounts } from './lib';
+import { buildModelBreakdown, coverageTurnCounts, PROVIDER_IDS } from './lib';
 
 type RecordParams = {
   readonly id: string;
@@ -27,6 +27,20 @@ const record = ({ id, provider, model, costUsd = 1 }: RecordParams): TelemetryRe
   outputTokens: 20,
   estimatedCostUsd: costUsd,
   recordedAt: '2026-08-01T00:00:00.000Z' as IsoDateTime,
+});
+
+describe('PROVIDER_IDS', () => {
+  it('keeps its order', () => {
+    expect(PROVIDER_IDS).toEqual([
+      'anthropic',
+      'cursor',
+      'codex',
+      'gemini',
+      'opencode',
+      'openrouter',
+      'moonshot',
+    ]);
+  });
 });
 
 describe('buildModelBreakdown', () => {

--- a/apps/desktop/src/features/budget/components/BudgetStudio/lib.ts
+++ b/apps/desktop/src/features/budget/components/BudgetStudio/lib.ts
@@ -50,7 +50,7 @@ export type CoverageTurnCounts = {
   readonly unpriced: number;
 };
 
-const PROVIDER_IDS: ReadonlyArray<ProviderId> = [
+export const PROVIDER_IDS = [
   'anthropic',
   'cursor',
   'codex',
@@ -58,7 +58,13 @@ const PROVIDER_IDS: ReadonlyArray<ProviderId> = [
   'opencode',
   'openrouter',
   'moonshot',
-];
+] satisfies ReadonlyArray<ProviderId>;
+
+type Expect<T extends true> = T;
+type ProviderIdsAreTotal =
+  Exclude<ProviderId, (typeof PROVIDER_IDS)[number]> extends never ? true : false;
+type _ProviderIdsTotalCheck = Expect<ProviderIdsAreTotal>;
+
 export const toProviderId = (provider: string): ProviderId | null => {
   return PROVIDER_IDS.includes(provider as ProviderId) ? (provider as ProviderId) : null;
 };

--- a/apps/desktop/src/features/chat/components/ChatInput/lib.test.ts
+++ b/apps/desktop/src/features/chat/components/ChatInput/lib.test.ts
@@ -7,6 +7,7 @@ import {
   extFromMime,
   readFileAsDataUrl,
   toAttachmentInput,
+  VALID_PROVIDERS,
   type PendingAttachment,
 } from './lib';
 
@@ -83,6 +84,20 @@ describe('asProvider', () => {
 
   it('rejects null input', () => {
     expect(asProvider(null)).toBeNull();
+  });
+});
+
+describe('VALID_PROVIDERS', () => {
+  it('keeps its order', () => {
+    expect(VALID_PROVIDERS).toEqual([
+      'anthropic',
+      'cursor',
+      'codex',
+      'gemini',
+      'opencode',
+      'openrouter',
+      'moonshot',
+    ]);
   });
 });
 

--- a/apps/desktop/src/features/chat/components/ChatInput/lib.ts
+++ b/apps/desktop/src/features/chat/components/ChatInput/lib.ts
@@ -7,7 +7,7 @@ export const CHAT_PREFIX_RE = /^\s*[$/~@][^\s]*$/;
 
 export const CHAT_PLACEHOLDER = 'Message Claude · $ scripts · ~ workflows · @ agents';
 
-export const VALID_PROVIDERS: ReadonlyArray<ProviderId> = [
+export const VALID_PROVIDERS = [
   'anthropic',
   'cursor',
   'codex',
@@ -15,7 +15,12 @@ export const VALID_PROVIDERS: ReadonlyArray<ProviderId> = [
   'opencode',
   'openrouter',
   'moonshot',
-];
+] satisfies ReadonlyArray<ProviderId>;
+
+type Expect<T extends true> = T;
+type ValidProvidersAreTotal =
+  Exclude<ProviderId, (typeof VALID_PROVIDERS)[number]> extends never ? true : false;
+type _ValidProvidersTotalCheck = Expect<ValidProvidersAreTotal>;
 
 export const MAX_ATTACHMENT_BYTES = 15 * 1024 * 1024;
 export const ATTACHMENT_LIMIT = 10;

--- a/apps/desktop/src/features/companion/commandExecutor.commands.test.ts
+++ b/apps/desktop/src/features/companion/commandExecutor.commands.test.ts
@@ -161,7 +161,11 @@ vi.mock('../integrations/jira/goal-from-issue', () => ({
     `[${i.issue.key}] ${i.issue.summary}`,
 }));
 
-import { executeBridgeCommand } from './commandExecutor';
+import {
+  BRIDGE_PROVIDER_ALLOWLIST,
+  PROVIDER_MENU_ORDER,
+  executeBridgeCommand,
+} from './commandExecutor';
 import { invoke } from '@tauri-apps/api/core';
 import {
   clearMobileCreateRateState,
@@ -400,6 +404,29 @@ describe('provider/model override coercion', () => {
       expect((arg.override as { providerId: string }).providerId).toBe(providerId);
     },
   );
+
+  it('keeps the bridge allowlist and the menu order as separate arrays', () => {
+    expect(BRIDGE_PROVIDER_ALLOWLIST).not.toBe(PROVIDER_MENU_ORDER);
+  });
+
+  it('rejects a provider still listed in the menu order once removed from the bridge allowlist', async () => {
+    const original = [...BRIDGE_PROVIDER_ALLOWLIST];
+    BRIDGE_PROVIDER_ALLOWLIST.splice(
+      0,
+      BRIDGE_PROVIDER_ALLOWLIST.length,
+      ...original.filter((id) => id !== 'openrouter'),
+    );
+    try {
+      expect(PROVIDER_MENU_ORDER).toContain('openrouter');
+      await executeBridgeCommand(
+        cmd('send', { sessionId: 's1', content: 'go', providerId: 'openrouter' }),
+      );
+      const arg = lastCall(h.sendTurn)[0] as Record<string, unknown>;
+      expect(arg.override).toBeUndefined();
+    } finally {
+      BRIDGE_PROVIDER_ALLOWLIST.splice(0, BRIDGE_PROVIDER_ALLOWLIST.length, ...original);
+    }
+  });
 });
 
 describe('spawnAgent option mapping', () => {

--- a/apps/desktop/src/features/companion/commandExecutor.commands.test.ts
+++ b/apps/desktop/src/features/companion/commandExecutor.commands.test.ts
@@ -391,6 +391,15 @@ describe('provider/model override coercion', () => {
       expect.objectContaining({ override: { providerId: 'gemini' } }),
     );
   });
+
+  it.each(['anthropic', 'cursor', 'codex', 'gemini', 'opencode', 'openrouter', 'moonshot'])(
+    'accepts %s as a whitelisted override provider',
+    async (providerId) => {
+      await executeBridgeCommand(cmd('send', { sessionId: 's1', content: 'go', providerId }));
+      const arg = lastCall(h.sendTurn)[0] as Record<string, unknown>;
+      expect((arg.override as { providerId: string }).providerId).toBe(providerId);
+    },
+  );
 });
 
 describe('spawnAgent option mapping', () => {

--- a/apps/desktop/src/features/companion/commandExecutor.ts
+++ b/apps/desktop/src/features/companion/commandExecutor.ts
@@ -52,7 +52,7 @@ import { goalFromIssue as gitlabGoalFromIssue } from '../integrations/gitlab/goa
 import { jiraListIssues, jiraGetIssue, type JiraIssue } from '../integrations/jira/client';
 import { goalFromIssue as jiraGoalFromIssue } from '../integrations/jira/goal-from-issue';
 
-const BRIDGE_PROVIDER_ALLOWLIST = [
+export const BRIDGE_PROVIDER_ALLOWLIST = [
   'anthropic',
   'cursor',
   'codex',
@@ -62,7 +62,7 @@ const BRIDGE_PROVIDER_ALLOWLIST = [
   'moonshot',
 ] satisfies ReadonlyArray<ProviderId>;
 
-const PROVIDER_MENU_ORDER = [
+export const PROVIDER_MENU_ORDER = [
   'anthropic',
   'cursor',
   'codex',

--- a/apps/desktop/src/features/companion/commandExecutor.ts
+++ b/apps/desktop/src/features/companion/commandExecutor.ts
@@ -52,7 +52,7 @@ import { goalFromIssue as gitlabGoalFromIssue } from '../integrations/gitlab/goa
 import { jiraListIssues, jiraGetIssue, type JiraIssue } from '../integrations/jira/client';
 import { goalFromIssue as jiraGoalFromIssue } from '../integrations/jira/goal-from-issue';
 
-const PROVIDER_IDS: ReadonlyArray<ProviderId> = [
+const BRIDGE_PROVIDER_ALLOWLIST = [
   'anthropic',
   'cursor',
   'codex',
@@ -60,7 +60,25 @@ const PROVIDER_IDS: ReadonlyArray<ProviderId> = [
   'opencode',
   'openrouter',
   'moonshot',
-];
+] satisfies ReadonlyArray<ProviderId>;
+
+const PROVIDER_MENU_ORDER = [
+  'anthropic',
+  'cursor',
+  'codex',
+  'gemini',
+  'opencode',
+  'openrouter',
+  'moonshot',
+] satisfies ReadonlyArray<ProviderId>;
+
+type Expect<T extends true> = T;
+type BridgeProviderAllowlistIsTotal =
+  Exclude<ProviderId, (typeof BRIDGE_PROVIDER_ALLOWLIST)[number]> extends never ? true : false;
+type _BridgeProviderAllowlistTotalCheck = Expect<BridgeProviderAllowlistIsTotal>;
+type ProviderMenuOrderIsTotal =
+  Exclude<ProviderId, (typeof PROVIDER_MENU_ORDER)[number]> extends never ? true : false;
+type _ProviderMenuOrderTotalCheck = Expect<ProviderMenuOrderIsTotal>;
 
 const MOBILE_EDITABLE_SLOTS: ReadonlySet<SlotKey> = new Set<SlotKey>([
   'goal',
@@ -140,7 +158,7 @@ function coerceAttachments(v: unknown): ReadonlyArray<AttachmentInput> {
 
 function coerceOverride(data: Record<string, unknown>): TurnProviderOverride | undefined {
   const providerId = asString(data.providerId);
-  if (!providerId || !PROVIDER_IDS.includes(providerId as ProviderId)) {
+  if (!providerId || !BRIDGE_PROVIDER_ALLOWLIST.includes(providerId as ProviderId)) {
     return undefined;
   }
   const model = asString(data.model);
@@ -157,7 +175,7 @@ function buildProviderMenu(): {
   }>;
 } {
   const known = useAppStore.getState().providers;
-  const providers = PROVIDER_IDS.map((id) => {
+  const providers = PROVIDER_MENU_ORDER.map((id) => {
     const info = known.find((p) => p.id === id);
     return {
       id,

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/steps/ProvidersStep.test.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/steps/ProvidersStep.test.tsx
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { PROVIDER_ORDER } from './ProvidersStep';
+
+describe('PROVIDER_ORDER', () => {
+  it('swaps codex and cursor relative to the canonical registry order', () => {
+    expect(PROVIDER_ORDER).toEqual([
+      'anthropic',
+      'codex',
+      'cursor',
+      'gemini',
+      'opencode',
+      'openrouter',
+      'moonshot',
+    ]);
+  });
+});

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/steps/ProvidersStep.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/steps/ProvidersStep.tsx
@@ -8,7 +8,7 @@ import { PROVIDER_BRAND, brandColor } from '../../../providers/components/provid
 import { StatusPill } from '../../../providers/components/ProviderLifecycleTile/StatusPill';
 import { ProviderConnectModal } from '../../../providers/components/ProviderConnectModal';
 
-const PROVIDER_ORDER: ReadonlyArray<ProviderId> = [
+export const PROVIDER_ORDER = [
   'anthropic',
   'codex',
   'cursor',
@@ -16,7 +16,12 @@ const PROVIDER_ORDER: ReadonlyArray<ProviderId> = [
   'opencode',
   'openrouter',
   'moonshot',
-];
+] satisfies ReadonlyArray<ProviderId>;
+
+type Expect<T extends true> = T;
+type ProviderOrderIsTotal =
+  Exclude<ProviderId, (typeof PROVIDER_ORDER)[number]> extends never ? true : false;
+type _ProviderOrderTotalCheck = Expect<ProviderOrderIsTotal>;
 
 export const ProvidersStep = () => {
   const providers = useAppStore((s) => s.providers);

--- a/apps/desktop/src/features/providers/components/ProviderStudio/providerOrder.test.ts
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/providerOrder.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { PROVIDER_IDS } from '@goodboy/types';
 import { PROVIDER_ORDER } from './providerOrder';
 
 describe('PROVIDER_ORDER', () => {
@@ -12,5 +13,9 @@ describe('PROVIDER_ORDER', () => {
       'openrouter',
       'moonshot',
     ]);
+  });
+
+  it('covers every id the registry declares', () => {
+    expect(new Set(PROVIDER_ORDER)).toEqual(new Set(PROVIDER_IDS));
   });
 });

--- a/apps/desktop/src/features/providers/components/ProviderStudio/providerOrder.test.ts
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/providerOrder.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { PROVIDER_ORDER } from './providerOrder';
+
+describe('PROVIDER_ORDER', () => {
+  it('keeps its order', () => {
+    expect(PROVIDER_ORDER).toEqual([
+      'anthropic',
+      'cursor',
+      'codex',
+      'gemini',
+      'opencode',
+      'openrouter',
+      'moonshot',
+    ]);
+  });
+});

--- a/apps/desktop/src/features/providers/components/ProviderStudio/providerOrder.ts
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/providerOrder.ts
@@ -1,6 +1,6 @@
 import type { ProviderId } from '@goodboy/types';
 
-export const PROVIDER_ORDER: ReadonlyArray<ProviderId> = [
+export const PROVIDER_ORDER = [
   'anthropic',
   'cursor',
   'codex',
@@ -8,4 +8,9 @@ export const PROVIDER_ORDER: ReadonlyArray<ProviderId> = [
   'opencode',
   'openrouter',
   'moonshot',
-];
+] satisfies ReadonlyArray<ProviderId>;
+
+type Expect<T extends true> = T;
+type ProviderOrderIsTotal =
+  Exclude<ProviderId, (typeof PROVIDER_ORDER)[number]> extends never ? true : false;
+type _ProviderOrderTotalCheck = Expect<ProviderOrderIsTotal>;

--- a/packages/core/src/providers/model-map.test.ts
+++ b/packages/core/src/providers/model-map.test.ts
@@ -1,5 +1,34 @@
 import { describe, expect, it } from 'vitest';
-import { resolveModelForProvider } from './model-map';
+import { PROVIDER_IDS } from '@goodboy/types';
+import { PROVIDERS, resolveModelForProvider } from './model-map';
+
+describe('PROVIDERS', () => {
+  it('keeps its order', () => {
+    expect(PROVIDERS).toEqual([
+      'anthropic',
+      'cursor',
+      'codex',
+      'gemini',
+      'opencode',
+      'openrouter',
+      'moonshot',
+    ]);
+  });
+});
+
+describe('PROVIDER_IDS (packages/types/src/provider-registry.ts)', () => {
+  it('keeps the canonical registry order', () => {
+    expect(PROVIDER_IDS).toEqual([
+      'anthropic',
+      'cursor',
+      'codex',
+      'gemini',
+      'opencode',
+      'openrouter',
+      'moonshot',
+    ]);
+  });
+});
 
 describe('resolveModelForProvider', () => {
   it('keeps current ids and migrates retired ids for the same provider', () => {

--- a/packages/core/src/providers/model-map.ts
+++ b/packages/core/src/providers/model-map.ts
@@ -10,7 +10,7 @@ type Params = {
   readonly modelId: string;
 };
 
-const PROVIDERS = [
+export const PROVIDERS = [
   'anthropic',
   'cursor',
   'codex',
@@ -19,6 +19,11 @@ const PROVIDERS = [
   'openrouter',
   'moonshot',
 ] satisfies ReadonlyArray<ProviderId>;
+
+type Expect<T extends true> = T;
+type ProvidersAreTotal =
+  Exclude<ProviderId, (typeof PROVIDERS)[number]> extends never ? true : false;
+type _ProvidersTotalCheck = Expect<ProvidersAreTotal>;
 
 export const resolveModelForProvider = ({ provider, modelId }: Params): string => {
   const keyed = MODEL_CATALOGS[provider].find((model) => model.key === modelId);

--- a/packages/types/src/provider-registry.ts
+++ b/packages/types/src/provider-registry.ts
@@ -1,11 +1,5 @@
 export type ProviderId =
-  | 'anthropic'
-  | 'cursor'
-  | 'codex'
-  | 'gemini'
-  | 'opencode'
-  | 'openrouter'
-  | 'moonshot';
+  'anthropic' | 'cursor' | 'codex' | 'gemini' | 'opencode' | 'openrouter' | 'moonshot';
 
 export const PROVIDER_IDS = [
   'anthropic',
@@ -17,16 +11,15 @@ export const PROVIDER_IDS = [
   'moonshot',
 ] as const satisfies readonly ProviderId[];
 
+type Expect<T extends true> = T;
+type ProviderIdsAreTotal =
+  Exclude<ProviderId, (typeof PROVIDER_IDS)[number]> extends never ? true : false;
+type _ProviderIdsTotalCheck = Expect<ProviderIdsAreTotal>;
+
 export type ProviderConnectionState = 'connected' | 'installed_disconnected' | 'missing' | 'error';
 
 export type ModelFamily =
-  | 'claude'
-  | 'gpt'
-  | 'codex'
-  | 'gemini'
-  | 'composer'
-  | 'cursor-auto'
-  | 'other';
+  'claude' | 'gpt' | 'codex' | 'gemini' | 'composer' | 'cursor-auto' | 'other';
 
 export type ModelCostTier = 'cheap' | 'mid' | 'expensive';
 


### PR DESCRIPTION
## What

Seven hand-maintained provider lists become total-checked against `ProviderId` from `packages/types/src/provider-registry.ts`, so an eighth provider cannot silently drop a surface. Each list gets the same mechanism: a type-only exhaustiveness assert next to the array,

```ts
type Expect<T extends true> = T;
type XIsTotal = Exclude<ProviderId, (typeof X)[number]> extends never ? true : false;
type _XTotalCheck = Expect<XIsTotal>;
```

This is a compile-time-only check. No `.map`/`.filter` over the registry, no runtime derivation: the array literal itself is untouched in every file, so a diff of the array lines is empty. Verified for real: dropped `moonshot` from `provider-registry.ts`'s `PROVIDER_IDS`, ran `tsc --noEmit`, got `error TS2344: Type 'false' does not satisfy the constraint 'true'`, then restored it and confirmed clean again.

Seven lists:
- `packages/types/src/provider-registry.ts:10-18` (`PROVIDER_IDS`, canonical)
- `apps/desktop/src/features/chat/components/ChatInput/lib.ts:10` (`VALID_PROVIDERS`)
- `apps/desktop/src/features/providers/components/ProviderStudio/providerOrder.ts:3` (`PROVIDER_ORDER`)
- `apps/desktop/src/features/onboarding/OnboardingWizard/steps/ProvidersStep.tsx:11` (`PROVIDER_ORDER`, now exported for its snapshot test)
- `apps/desktop/src/features/companion/commandExecutor.ts:55` (was one `PROVIDER_IDS`, see split below)
- `apps/desktop/src/features/budget/components/BudgetStudio/lib.ts:53` (`PROVIDER_IDS`, now exported for its snapshot test)
- `packages/core/src/providers/model-map.ts:14-21` (`PROVIDERS`, now exported for its snapshot test)

`model-display.ts` is correctly untouched: `PROVIDER_RANK` is already `Record<ProviderId, number>`, which TypeScript already treats as total.

## Order snapshots

Every list keeps its exact order; nothing was reordered. A snapshot test per list pins the pre-existing order so "unchanged" is evidence, not a claim:
- `ChatInput/lib.test.ts`, `ProviderStudio/providerOrder.test.ts`, `BudgetStudio/lib.test.ts`, `core/providers/model-map.test.ts`: `anthropic, cursor, codex, gemini, opencode, openrouter, moonshot`
- `OnboardingWizard/steps/ProvidersStep.test.tsx`: `anthropic, codex, cursor, gemini, opencode, openrouter, moonshot` — deliberately swaps codex and cursor relative to the others, preserved as-is
- `commandExecutor.commands.test.ts`: the existing `queryProviders` test already pinned `PROVIDER_MENU_ORDER`'s order; added an `it.each` over all seven providers confirming `BRIDGE_PROVIDER_ALLOWLIST` accepts each one (membership, not order — order was never semantically load-bearing there)
- `packages/types` has no test runner wired up at all (no vitest devDependency, no `test` script), so the registry's own `PROVIDER_IDS` order is snapshotted from `packages/core/src/providers/model-map.test.ts` instead, which already imports from `@goodboy/types` and already runs in CI

## commandExecutor.ts

Split, not shared. The single `PROVIDER_IDS` const at `:55` fed both `coerceOverride` (`:143`, validates a `providerId` arriving over the LAN bridge socket, `src-tauri/src/bridge/mod.rs:107` binds `0.0.0.0`) and `buildProviderMenu` (`:160`, builds the mobile display menu). Now two named consts: `BRIDGE_PROVIDER_ALLOWLIST` for the validation path, `PROVIDER_MENU_ORDER` for the display path. Both are total-checked independently. This keeps the validation-allowlist semantic distinct from the display-list semantic for the next reader, without collapsing anything further than it already was.

## Provenance

Declared continuation of #1343 (shipped in v0.1.75), which tethered `PROVIDER_PRIORITY` to a total `Record<ProviderId, number>` with a never-guard. That PR covered the one list whose miss had real consequences (a codex/cursor model-key collision). These seven are the remainder: `PROVIDER_IDS` in the registry is iterated by six test files that already fail on a drop (`catalog.test.ts`, `task-models.test.ts`, `catalogDescriptor.test.ts`, `aux-spawn.test.ts`, `resolveRouting.test.ts`, `connectProvider.test.ts`); these seven had no such coverage anywhere, compiled cleanly, and could silently miss a new provider.

## Behavior unchanged

- Every array literal is byte-identical to before (order and values); the totality mechanism is additive, adjacent type-only declarations.
- `typecheck`, the full `turbo run test --force` suite, and `knip --include files,duplicates,unlisted` all pass (details below).
- The only non-mechanical change is exporting three previously-module-local consts (`ProvidersStep.tsx`'s `PROVIDER_ORDER`, `BudgetStudio/lib.ts`'s `PROVIDER_IDS`, `model-map.ts`'s `PROVIDERS`) so their snapshot tests can import them. No consumer or runtime behavior changes; these files already had multiple exports each.

## Tests

- `pnpm typecheck`: 5/5 packages green
- `pnpm exec turbo run test --force`: 4/4 tasks, 0 cached — `@goodboy/ui` 106 passed, `@goodboy/core` 1114 passed / 4 skipped (pre-existing), `@goodboy/db` 203 passed, `@goodboy/desktop` 5275 passed
- `pnpm knip --include files,duplicates,unlisted`: clean (only pre-existing config hints, unrelated to this change)