### PR TITLE
refactor(desktop): converge six backdrop popovers on the dropdown hook

### DIFF
--- a/apps/desktop/src/app/components/AppFooter/IntegrationAddPopover.tsx
+++ b/apps/desktop/src/app/components/AppFooter/IntegrationAddPopover.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useLayoutEffect, useRef, useState } from 'react';
-import { createPortal } from 'react-dom';
 import { cn, Popover, ScrollFade, Tooltip } from '@goodboy/ui';
 import { Plus } from 'lucide-react';
 import type { IntegrationGlyphProvider } from '../../../features/integrations/components/IntegrationGlyph';
+import { DropdownBackdrop } from '../../../shared/hooks/useDropdown/DropdownBackdrop';
+import { DropdownPortal } from '../../../shared/hooks/useDropdown/DropdownPortal';
+import { useDropdown } from '../../../shared/hooks/useDropdown';
 import type { FooterIntegrationEntry } from './categories';
 import { IntegrationAddRow } from './IntegrationAddRow';
 
@@ -19,15 +20,8 @@ type Props = {
   readonly active: boolean;
 };
 
-type PopoverCoordinates = {
-  readonly top?: number;
-  readonly bottom?: number;
-  readonly left: number;
-};
-
 const PANEL_WIDTH = 224;
 const PANEL_MAX_HEIGHT = 240;
-const VIEWPORT_MARGIN = 8;
 
 export const IntegrationAddPopover = ({
   addLabel,
@@ -41,72 +35,35 @@ export const IntegrationAddPopover = ({
   showLabel,
   active,
 }: Props) => {
-  const [isOpen, setIsOpen] = useState(false);
-  const triggerRef = useRef<HTMLButtonElement>(null);
-  const [coordinates, setCoordinates] = useState<PopoverCoordinates | null>(null);
-
-  useEffect(() => {
-    if (!isOpen) {
-      return;
-    }
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        setIsOpen(false);
-      }
-    };
-    window.addEventListener('keydown', onKeyDown);
-    return () => window.removeEventListener('keydown', onKeyDown);
-  }, [isOpen]);
-
-  useLayoutEffect(() => {
-    if (!isOpen) {
-      return;
-    }
-
-    const updatePosition = () => {
-      const trigger = triggerRef.current;
-      if (trigger == null) {
-        return;
-      }
-
-      const rect = trigger.getBoundingClientRect();
-      const centerX = rect.left + rect.width / 2;
-      const desiredLeft = centerX - PANEL_WIDTH / 2;
-      const maxLeft = window.innerWidth - PANEL_WIDTH - VIEWPORT_MARGIN;
-      const left = Math.min(Math.max(desiredLeft, VIEWPORT_MARGIN), maxLeft);
-      const spaceBelow = window.innerHeight - rect.bottom;
-      const shouldOpenAbove = spaceBelow < PANEL_MAX_HEIGHT + VIEWPORT_MARGIN;
-      const top = shouldOpenAbove ? undefined : rect.bottom + 6;
-      const bottom = shouldOpenAbove ? window.innerHeight - rect.top + 6 : undefined;
-      setCoordinates({ top, bottom, left });
-    };
-
-    updatePosition();
-    window.addEventListener('resize', updatePosition);
-    window.addEventListener('scroll', updatePosition, true);
-    return () => {
-      window.removeEventListener('resize', updatePosition);
-      window.removeEventListener('scroll', updatePosition, true);
-    };
-  }, [isOpen]);
-
-  const toggle = () => {
-    if (isExhausted) {
-      return;
-    }
-    setIsOpen((current) => !current);
-  };
+  const {
+    open: isOpen,
+    close,
+    toggle,
+    containerRef,
+    popupRef,
+    popupStyle,
+    popupClassName,
+    portal,
+    portalTarget,
+  } = useDropdown({
+    disabled: isExhausted,
+    align: 'center',
+    width: 'w-56',
+    expectedWidth: PANEL_WIDTH,
+    expectedHeight: PANEL_MAX_HEIGHT,
+    strategy: 'fixed',
+    hasBackdrop: true,
+  });
 
   const select = (provider: IntegrationGlyphProvider) => {
-    setIsOpen(false);
+    close();
     openers[provider]();
   };
 
   return (
-    <>
+    <div ref={containerRef} className="relative">
       <Tooltip content={isExhausted ? exhaustedLabel : addLabel}>
         <button
-          ref={triggerRef}
           type="button"
           onClick={toggle}
           aria-label={isExhausted ? exhaustedLabel : addLabel}
@@ -127,41 +84,37 @@ export const IntegrationAddPopover = ({
         </button>
       </Tooltip>
 
-      {isOpen && coordinates != null
-        ? createPortal(
-            <>
-              <div
-                className="fixed inset-0 z-popover-backdrop"
-                onMouseDown={() => setIsOpen(false)}
-                aria-hidden
-              />
-              <Popover
-                role="dialog"
-                ariaLabel={panelLabel}
-                className="fixed z-popover flex max-h-60 w-56 flex-col"
-                style={{
-                  top: coordinates.top,
-                  bottom: coordinates.bottom,
-                  left: coordinates.left,
-                }}
+      <DropdownPortal portal={portal} portalTarget={portalTarget}>
+        {isOpen && (
+          <>
+            <DropdownBackdrop onClose={close} />
+            <Popover
+              innerRef={popupRef}
+              role="dialog"
+              ariaLabel={panelLabel}
+              className={cn(popupClassName, 'flex flex-col')}
+              style={popupStyle}
+            >
+              <ScrollFade
+                className="max-h-60 min-h-0 flex-1"
+                viewportClassName="py-1"
+                fadeSize={12}
               >
-                <ScrollFade className="min-h-0 flex-1" viewportClassName="py-1" fadeSize={12}>
-                  <ul aria-label={panelLabel} className="flex flex-col">
-                    {members.map((member) => (
-                      <IntegrationAddRow
-                        key={member.provider}
-                        member={member}
-                        connected={enabled[member.provider]}
-                        onSelect={() => select(member.provider)}
-                      />
-                    ))}
-                  </ul>
-                </ScrollFade>
-              </Popover>
-            </>,
-            document.body,
-          )
-        : null}
-    </>
+                <ul aria-label={panelLabel} className="flex flex-col">
+                  {members.map((member) => (
+                    <IntegrationAddRow
+                      key={member.provider}
+                      member={member}
+                      connected={enabled[member.provider]}
+                      onSelect={() => select(member.provider)}
+                    />
+                  ))}
+                </ul>
+              </ScrollFade>
+            </Popover>
+          </>
+        )}
+      </DropdownPortal>
+    </div>
   );
 };

--- a/apps/desktop/src/app/components/AppFooter/MoreStudiosPopover.tsx
+++ b/apps/desktop/src/app/components/AppFooter/MoreStudiosPopover.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useLayoutEffect, useRef, useState } from 'react';
-import { createPortal } from 'react-dom';
 import { cn, Popover, tintClasses, Tooltip } from '@goodboy/ui';
 import { MoreHorizontal } from 'lucide-react';
 import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../shared/components/conceptIcons';
+import { DropdownBackdrop } from '../../../shared/hooks/useDropdown/DropdownBackdrop';
+import { DropdownPortal } from '../../../shared/hooks/useDropdown/DropdownPortal';
+import { useDropdown } from '../../../shared/hooks/useDropdown';
 import { MORE_STUDIOS, type MoreStudioId } from './moreStudios';
 
 type Props = {
@@ -11,70 +12,34 @@ type Props = {
   readonly openers: Record<MoreStudioId, () => void>;
 };
 
-type PopoverCoordinates = {
-  readonly top?: number;
-  readonly bottom?: number;
-  readonly left: number;
-};
-
 const PANEL_WIDTH = 208;
 const PANEL_MAX_HEIGHT = 200;
-const VIEWPORT_MARGIN = 8;
 const PANEL_LABEL = 'More studios';
 const REST_LABEL = 'More studios: budget, impact and changelog';
 const UNSEEN_LABEL = 'More studios: budget, impact and changelog, new release notes to read';
 
 export const MoreStudiosPopover = ({ activeStudio, hasUnseenRelease, openers }: Props) => {
-  const [isOpen, setIsOpen] = useState(false);
-  const triggerRef = useRef<HTMLButtonElement>(null);
-  const [coordinates, setCoordinates] = useState<PopoverCoordinates | null>(null);
-
-  useEffect(() => {
-    if (!isOpen) {
-      return;
-    }
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        setIsOpen(false);
-      }
-    };
-    window.addEventListener('keydown', onKeyDown);
-    return () => window.removeEventListener('keydown', onKeyDown);
-  }, [isOpen]);
-
-  useLayoutEffect(() => {
-    if (!isOpen) {
-      return;
-    }
-
-    const updatePosition = () => {
-      const trigger = triggerRef.current;
-      if (trigger == null) {
-        return;
-      }
-
-      const rect = trigger.getBoundingClientRect();
-      const desiredLeft = rect.right - PANEL_WIDTH;
-      const maxLeft = window.innerWidth - PANEL_WIDTH - VIEWPORT_MARGIN;
-      const left = Math.min(Math.max(desiredLeft, VIEWPORT_MARGIN), maxLeft);
-      const spaceBelow = window.innerHeight - rect.bottom;
-      const shouldOpenAbove = spaceBelow < PANEL_MAX_HEIGHT + VIEWPORT_MARGIN;
-      const top = shouldOpenAbove ? undefined : rect.bottom + 6;
-      const bottom = shouldOpenAbove ? window.innerHeight - rect.top + 6 : undefined;
-      setCoordinates({ top, bottom, left });
-    };
-
-    updatePosition();
-    window.addEventListener('resize', updatePosition);
-    window.addEventListener('scroll', updatePosition, true);
-    return () => {
-      window.removeEventListener('resize', updatePosition);
-      window.removeEventListener('scroll', updatePosition, true);
-    };
-  }, [isOpen]);
+  const {
+    open: isOpen,
+    close,
+    toggle,
+    containerRef,
+    popupRef,
+    popupStyle,
+    popupClassName,
+    portal,
+    portalTarget,
+  } = useDropdown({
+    align: 'end',
+    width: 'w-52',
+    expectedWidth: PANEL_WIDTH,
+    expectedHeight: PANEL_MAX_HEIGHT,
+    strategy: 'fixed',
+    hasBackdrop: true,
+  });
 
   const select = (id: MoreStudioId) => {
-    setIsOpen(false);
+    close();
     openers[id]();
   };
 
@@ -82,12 +47,11 @@ export const MoreStudiosPopover = ({ activeStudio, hasUnseenRelease, openers }: 
   const label = hasUnseenRelease ? UNSEEN_LABEL : REST_LABEL;
 
   return (
-    <>
+    <div ref={containerRef} className="relative">
       <Tooltip content={label}>
         <button
-          ref={triggerRef}
           type="button"
-          onClick={() => setIsOpen((current) => !current)}
+          onClick={toggle}
           aria-label={label}
           aria-expanded={isOpen}
           className={cn(
@@ -109,61 +73,53 @@ export const MoreStudiosPopover = ({ activeStudio, hasUnseenRelease, openers }: 
         </button>
       </Tooltip>
 
-      {isOpen && coordinates != null
-        ? createPortal(
-            <>
-              <div
-                className="fixed inset-0 z-popover-backdrop"
-                onMouseDown={() => setIsOpen(false)}
-                aria-hidden
-              />
-              <Popover
-                role="dialog"
-                ariaLabel={PANEL_LABEL}
-                className="fixed z-popover w-52"
-                style={{
-                  top: coordinates.top,
-                  bottom: coordinates.bottom,
-                  left: coordinates.left,
-                }}
-              >
-                <ul aria-label={PANEL_LABEL} className="flex flex-col py-1">
-                  {MORE_STUDIOS.map((entry) => {
-                    const Icon = CONCEPT_ICONS[entry.id];
-                    const isActive = activeStudio === entry.id;
-                    return (
-                      <li key={entry.id}>
-                        <button
-                          type="button"
-                          onClick={() => select(entry.id)}
-                          aria-label={entry.title}
-                          className={cn(
-                            'flex w-full items-center gap-2 px-3 py-1.5 text-left transition-colors hover:bg-muted/50',
-                            isActive && 'bg-muted',
-                          )}
-                        >
-                          <Icon
-                            size={12}
-                            aria-hidden
-                            className={
-                              isActive
-                                ? tintClasses(CONCEPT_TONE[entry.id]).icon
-                                : 'text-muted-foreground'
-                            }
-                          />
-                          <span className="flex-1 truncate text-xs text-foreground">
-                            {entry.label}
-                          </span>
-                        </button>
-                      </li>
-                    );
-                  })}
-                </ul>
-              </Popover>
-            </>,
-            document.body,
-          )
-        : null}
-    </>
+      <DropdownPortal portal={portal} portalTarget={portalTarget}>
+        {isOpen && (
+          <>
+            <DropdownBackdrop onClose={close} />
+            <Popover
+              innerRef={popupRef}
+              role="dialog"
+              ariaLabel={PANEL_LABEL}
+              className={popupClassName}
+              style={popupStyle}
+            >
+              <ul aria-label={PANEL_LABEL} className="flex flex-col py-1">
+                {MORE_STUDIOS.map((entry) => {
+                  const Icon = CONCEPT_ICONS[entry.id];
+                  const isActive = activeStudio === entry.id;
+                  return (
+                    <li key={entry.id}>
+                      <button
+                        type="button"
+                        onClick={() => select(entry.id)}
+                        aria-label={entry.title}
+                        className={cn(
+                          'flex w-full items-center gap-2 px-3 py-1.5 text-left transition-colors hover:bg-muted/50',
+                          isActive && 'bg-muted',
+                        )}
+                      >
+                        <Icon
+                          size={12}
+                          aria-hidden
+                          className={
+                            isActive
+                              ? tintClasses(CONCEPT_TONE[entry.id]).icon
+                              : 'text-muted-foreground'
+                          }
+                        />
+                        <span className="flex-1 truncate text-xs text-foreground">
+                          {entry.label}
+                        </span>
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            </Popover>
+          </>
+        )}
+      </DropdownPortal>
+    </div>
   );
 };

--- a/apps/desktop/src/app/components/AppTopBar/NeedsYouPopover.test.tsx
+++ b/apps/desktop/src/app/components/AppTopBar/NeedsYouPopover.test.tsx
@@ -24,4 +24,57 @@ describe('NeedsYouPopover', () => {
     expect(document.body.querySelector('.z-popover-backdrop')).not.toBeNull();
     expect(document.body.querySelector('.z-popover')).not.toBeNull();
   });
+
+  it('closes on escape without pulling focus back to the trigger', async () => {
+    render(<NeedsYouPopover sessions={[]} count={1} />);
+    const trigger = screen.getByRole('button', { name: /needs you/i });
+
+    await act(async () => {
+      fireEvent.click(trigger);
+    });
+    expect(screen.getByRole('dialog', { name: 'Sessions needing attention' })).toBeDefined();
+
+    await act(async () => {
+      fireEvent.keyDown(window, { key: 'Escape' });
+    });
+
+    expect(screen.queryByRole('dialog', { name: 'Sessions needing attention' })).toBeNull();
+    expect(document.activeElement).not.toBe(trigger);
+  });
+
+  it('closes when the backdrop is clicked', async () => {
+    render(<NeedsYouPopover sessions={[]} count={1} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /needs you/i }));
+    });
+    const backdrop = document.body.querySelector('.z-popover-backdrop');
+    expect(backdrop).not.toBeNull();
+
+    await act(async () => {
+      fireEvent.click(backdrop as Element);
+    });
+
+    expect(screen.queryByRole('dialog', { name: 'Sessions needing attention' })).toBeNull();
+  });
+
+  it('reopens after a second click on the trigger', async () => {
+    render(<NeedsYouPopover sessions={[]} count={1} />);
+    const trigger = screen.getByRole('button', { name: /needs you/i });
+
+    await act(async () => {
+      fireEvent.click(trigger);
+    });
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+
+    await act(async () => {
+      fireEvent.click(trigger);
+    });
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+
+    await act(async () => {
+      fireEvent.click(trigger);
+    });
+    expect(screen.getByRole('dialog', { name: 'Sessions needing attention' })).toBeDefined();
+  });
 });

--- a/apps/desktop/src/app/components/AppTopBar/NeedsYouPopover.tsx
+++ b/apps/desktop/src/app/components/AppTopBar/NeedsYouPopover.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useLayoutEffect, useRef, useState } from 'react';
-import { createPortal } from 'react-dom';
 import { Divider, Popover, ScrollFade, StatusDot } from '@goodboy/ui';
 import type { Session, SessionId } from '@goodboy/types';
+import { DropdownBackdrop } from '../../../shared/hooks/useDropdown/DropdownBackdrop';
+import { DropdownPortal } from '../../../shared/hooks/useDropdown/DropdownPortal';
+import { useDropdown } from '../../../shared/hooks/useDropdown';
 import { useAppStore } from '../../../store';
 import { NeedsYouSessionRow } from './NeedsYouSessionRow';
 
@@ -10,18 +11,11 @@ type Props = {
   readonly count: number;
 };
 
-type PopoverCoordinates = {
-  readonly top?: number;
-  readonly bottom?: number;
-  readonly left: number;
-};
-
 type SelectParams = {
   readonly sessionId: SessionId;
 };
 
 const DROPDOWN_WIDTH = 384;
-const VIEWPORT_MARGIN = 8;
 const LIST_MAX_HEIGHT = 400;
 const HEADER_HEIGHT = 37;
 const DROPDOWN_MAX_HEIGHT = LIST_MAX_HEIGHT + HEADER_HEIGHT;
@@ -29,68 +23,37 @@ const DROPDOWN_MAX_HEIGHT = LIST_MAX_HEIGHT + HEADER_HEIGHT;
 export const NeedsYouPopover = ({ sessions, count }: Props) => {
   const setCurrentSession = useAppStore((state) => state.setCurrentSession);
   const setActiveLens = useAppStore((state) => state.setActiveLens);
-  const [isOpen, setIsOpen] = useState(false);
-  const triggerRef = useRef<HTMLButtonElement>(null);
-  const [coordinates, setCoordinates] = useState<PopoverCoordinates | null>(null);
-
-  useEffect(() => {
-    if (!isOpen) {
-      return;
-    }
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        setIsOpen(false);
-      }
-    };
-    window.addEventListener('keydown', onKeyDown);
-    return () => window.removeEventListener('keydown', onKeyDown);
-  }, [isOpen]);
-
-  useLayoutEffect(() => {
-    if (!isOpen) {
-      return;
-    }
-
-    const updatePosition = () => {
-      const trigger = triggerRef.current;
-      if (trigger == null) {
-        return;
-      }
-
-      const rect = trigger.getBoundingClientRect();
-      const centerX = rect.left + rect.width / 2;
-      const desiredLeft = centerX - DROPDOWN_WIDTH / 2;
-      const maxLeft = window.innerWidth - DROPDOWN_WIDTH - VIEWPORT_MARGIN;
-      const left = Math.min(Math.max(desiredLeft, VIEWPORT_MARGIN), maxLeft);
-      const spaceBelow = window.innerHeight - rect.bottom;
-      const shouldOpenAbove = spaceBelow < DROPDOWN_MAX_HEIGHT + VIEWPORT_MARGIN;
-      const top = shouldOpenAbove ? undefined : rect.bottom + 6;
-      const bottom = shouldOpenAbove ? window.innerHeight - rect.top + 6 : undefined;
-      setCoordinates({ top, bottom, left });
-    };
-
-    updatePosition();
-    window.addEventListener('resize', updatePosition);
-    window.addEventListener('scroll', updatePosition, true);
-    return () => {
-      window.removeEventListener('resize', updatePosition);
-      window.removeEventListener('scroll', updatePosition, true);
-    };
-  }, [isOpen]);
+  const {
+    open: isOpen,
+    close,
+    toggle,
+    containerRef,
+    popupRef,
+    popupStyle,
+    popupClassName,
+    portal,
+    portalTarget,
+  } = useDropdown({
+    align: 'center',
+    width: 'w-96',
+    expectedWidth: DROPDOWN_WIDTH,
+    expectedHeight: DROPDOWN_MAX_HEIGHT,
+    strategy: 'fixed',
+    hasBackdrop: true,
+  });
 
   const selectSession = ({ sessionId }: SelectParams) => {
-    setIsOpen(false);
+    close();
     void setCurrentSession(sessionId).then(() => {
       setActiveLens(sessionId, null);
     });
   };
 
   return (
-    <>
+    <div ref={containerRef} className="relative">
       <button
-        ref={triggerRef}
         type="button"
-        onClick={() => setIsOpen((current) => !current)}
+        onClick={toggle}
         aria-label={`${count} ${count === 1 ? 'session needs' : 'sessions need'} you`}
         aria-expanded={isOpen}
         className="flex items-center gap-1 rounded px-1.5 py-1 transition-colors hover:bg-muted/50"
@@ -100,48 +63,38 @@ export const NeedsYouPopover = ({ sessions, count }: Props) => {
         <span className="text-muted-foreground">need you</span>
       </button>
 
-      {isOpen && coordinates != null
-        ? createPortal(
-            <>
-              <div
-                className="fixed inset-0 z-popover-backdrop"
-                onClick={() => setIsOpen(false)}
-                aria-hidden
-              />
-              <Popover
-                role="dialog"
-                ariaLabel="Sessions needing attention"
-                className="fixed z-popover w-96"
-                style={{
-                  top: coordinates.top,
-                  bottom: coordinates.bottom,
-                  left: coordinates.left,
-                }}
-              >
-                <header className="flex items-center gap-2 px-3 py-2">
-                  <StatusDot tone="warning" size="sm" />
-                  <span className="text-xs font-semibold text-foreground">Needs you</span>
-                  <span className="ml-auto text-2xs tabular-nums text-muted-foreground">
-                    {count}
-                  </span>
-                </header>
-                <Divider />
-                <ScrollFade className="max-h-[25rem]" fadeSize={16} fadeFrom="elevated">
-                  <ul aria-label="Sessions needing attention">
-                    {sessions.map((session) => (
-                      <NeedsYouSessionRow
-                        key={session.id}
-                        session={session}
-                        onSelect={selectSession}
-                      />
-                    ))}
-                  </ul>
-                </ScrollFade>
-              </Popover>
-            </>,
-            document.body,
-          )
-        : null}
-    </>
+      <DropdownPortal portal={portal} portalTarget={portalTarget}>
+        {isOpen && (
+          <>
+            <DropdownBackdrop onClose={close} />
+            <Popover
+              innerRef={popupRef}
+              role="dialog"
+              ariaLabel="Sessions needing attention"
+              className={popupClassName}
+              style={popupStyle}
+            >
+              <header className="flex items-center gap-2 px-3 py-2">
+                <StatusDot tone="warning" size="sm" />
+                <span className="text-xs font-semibold text-foreground">Needs you</span>
+                <span className="ml-auto text-2xs tabular-nums text-muted-foreground">{count}</span>
+              </header>
+              <Divider />
+              <ScrollFade className="max-h-[25rem]" fadeSize={16} fadeFrom="elevated">
+                <ul aria-label="Sessions needing attention">
+                  {sessions.map((session) => (
+                    <NeedsYouSessionRow
+                      key={session.id}
+                      session={session}
+                      onSelect={selectSession}
+                    />
+                  ))}
+                </ul>
+              </ScrollFade>
+            </Popover>
+          </>
+        )}
+      </DropdownPortal>
+    </div>
   );
 };

--- a/apps/desktop/src/features/notifications/components/NotificationCenter/index.test.tsx
+++ b/apps/desktop/src/features/notifications/components/NotificationCenter/index.test.tsx
@@ -96,6 +96,53 @@ describe('NotificationCenter', () => {
     expect(state.markNotificationsRead).toHaveBeenCalled();
   });
 
+  it('leaves the popover open on escape, because it has no escape handler', async () => {
+    render(<NotificationCenter />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^notifications$/i }));
+    });
+    expect(screen.getByText(/nothing to catch up on/i)).toBeDefined();
+
+    await act(async () => {
+      fireEvent.keyDown(window, { key: 'Escape' });
+    });
+
+    expect(screen.getByText(/nothing to catch up on/i)).toBeDefined();
+  });
+
+  it('closes when the backdrop is clicked', async () => {
+    render(<NotificationCenter />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^notifications$/i }));
+    });
+    const backdrop = document.body.querySelector('.z-popover-backdrop');
+    expect(backdrop).not.toBeNull();
+
+    await act(async () => {
+      fireEvent.click(backdrop as Element);
+    });
+
+    expect(screen.queryByText(/nothing to catch up on/i)).toBeNull();
+  });
+
+  it('marks read on the first open request only, not on one that finds it already open', async () => {
+    render(<NotificationCenter />);
+
+    await act(async () => {
+      window.dispatchEvent(new CustomEvent('goodboy:open-notifications'));
+    });
+    expect(state.markNotificationsRead).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      window.dispatchEvent(new CustomEvent('goodboy:open-notifications'));
+    });
+
+    expect(state.markNotificationsRead).toHaveBeenCalledTimes(1);
+    expect(screen.getByText(/nothing to catch up on/i)).toBeDefined();
+  });
+
   it('shows the unread badge when there are unread notifications', () => {
     state.notifications = [
       {

--- a/apps/desktop/src/features/notifications/components/NotificationCenter/index.tsx
+++ b/apps/desktop/src/features/notifications/components/NotificationCenter/index.tsx
@@ -1,5 +1,4 @@
-import { useEffect, useLayoutEffect, useRef, useState } from 'react';
-import { createPortal } from 'react-dom';
+import { useEffect, useRef, useState } from 'react';
 import { ArrowRight, Bell, Trash2 } from 'lucide-react';
 import {
   Button,
@@ -17,6 +16,9 @@ import { useShallow } from 'zustand/react/shallow';
 import type { Notification, NotificationAction } from '@goodboy/db';
 import { PROVIDER_CAPABILITIES, resolveTaskModel } from '@goodboy/core';
 import type { ModelEffort, ProviderId, TaskModelPreference } from '@goodboy/types';
+import { DropdownBackdrop } from '../../../../shared/hooks/useDropdown/DropdownBackdrop';
+import { DropdownPortal } from '../../../../shared/hooks/useDropdown/DropdownPortal';
+import { useDropdown } from '../../../../shared/hooks/useDropdown';
 import { useAppStore } from '../../../../store';
 import { mapNotificationAction } from '../NotificationToastBridge';
 import { RoutingPicker } from '../../../../shared/components/RoutingPicker';
@@ -26,10 +28,10 @@ import { NOTIFICATION_SEVERITY } from '../../severity';
 import { NOTIFICATIONS_STUDIO_EVENT } from '../../studioEvent';
 
 const DROPDOWN_WIDTH = 384;
-const VIEWPORT_MARGIN = 8;
 const LIST_MAX_HEIGHT = 400;
 const HEADER_HEIGHT = 37;
 const DROPDOWN_MAX_HEIGHT = LIST_MAX_HEIGHT + HEADER_HEIGHT;
+const OPEN_EVENT = 'goodboy:open-notifications';
 
 export const NotificationCenter = () => {
   const notifications = useAppStore((s) => s.notifications);
@@ -38,11 +40,31 @@ export const NotificationCenter = () => {
   const loadNotifications = useAppStore((s) => s.loadNotifications);
   const markNotificationsRead = useAppStore((s) => s.markNotificationsRead);
   const clearNotifications = useAppStore((s) => s.clearNotifications);
-  const [open, setOpen] = useState(false);
-  const triggerRef = useRef<HTMLButtonElement>(null);
-  const [coords, setCoords] = useState<{ top?: number; bottom?: number; left: number } | null>(
-    null,
-  );
+  const {
+    open,
+    close,
+    toggle,
+    containerRef,
+    popupRef,
+    popupStyle,
+    popupClassName,
+    portal,
+    portalTarget,
+  } = useDropdown({
+    align: 'center',
+    width: 'w-96',
+    expectedWidth: DROPDOWN_WIDTH,
+    expectedHeight: DROPDOWN_MAX_HEIGHT,
+    strategy: 'fixed',
+    openEvent: OPEN_EVENT,
+    isEscapeEnabled: false,
+    hasBackdrop: true,
+  });
+  const openRef = useRef(open);
+
+  useEffect(() => {
+    openRef.current = open;
+  }, [open]);
 
   useEffect(() => {
     void loadNotifications();
@@ -50,50 +72,19 @@ export const NotificationCenter = () => {
 
   useEffect(() => {
     const handleOpenRequest = () => {
-      setOpen((prev) => {
-        if (!prev) {
-          void markNotificationsRead();
-        }
-        return true;
-      });
+      if (openRef.current) {
+        return;
+      }
+      void markNotificationsRead();
     };
-    window.addEventListener('goodboy:open-notifications', handleOpenRequest);
+    window.addEventListener(OPEN_EVENT, handleOpenRequest);
     return () => {
-      window.removeEventListener('goodboy:open-notifications', handleOpenRequest);
+      window.removeEventListener(OPEN_EVENT, handleOpenRequest);
     };
   }, [markNotificationsRead]);
 
-  useLayoutEffect(() => {
-    if (!open) {
-      return;
-    }
-    const updatePosition = () => {
-      const el = triggerRef.current;
-      if (!el) {
-        return;
-      }
-      const rect = el.getBoundingClientRect();
-      const centerX = rect.left + rect.width / 2;
-      const desiredLeft = centerX - DROPDOWN_WIDTH / 2;
-      const maxLeft = window.innerWidth - DROPDOWN_WIDTH - VIEWPORT_MARGIN;
-      const left = Math.min(Math.max(desiredLeft, VIEWPORT_MARGIN), maxLeft);
-      const spaceBelow = window.innerHeight - rect.bottom;
-      const openAbove = spaceBelow < DROPDOWN_MAX_HEIGHT + VIEWPORT_MARGIN;
-      const top = openAbove ? undefined : rect.bottom + 6;
-      const bottom = openAbove ? window.innerHeight - rect.top + 6 : undefined;
-      setCoords({ top, bottom, left });
-    };
-    updatePosition();
-    window.addEventListener('resize', updatePosition);
-    window.addEventListener('scroll', updatePosition, true);
-    return () => {
-      window.removeEventListener('resize', updatePosition);
-      window.removeEventListener('scroll', updatePosition, true);
-    };
-  }, [open]);
-
   const handleOpen = () => {
-    setOpen((v) => !v);
+    toggle();
     if (!open) {
       void markNotificationsRead();
     }
@@ -102,10 +93,9 @@ export const NotificationCenter = () => {
   const { total, unread } = notificationCounts;
 
   return (
-    <div role="region" aria-label="Notifications" aria-live="polite">
+    <div ref={containerRef} role="region" aria-label="Notifications" aria-live="polite">
       <Tooltip content="notifications" side="top">
         <button
-          ref={triggerRef}
           type="button"
           onClick={handleOpen}
           className={cn(
@@ -130,112 +120,104 @@ export const NotificationCenter = () => {
         </button>
       </Tooltip>
 
-      {open && coords
-        ? createPortal(
-            <>
-              <div
-                className="fixed inset-0 z-popover-backdrop"
-                onClick={() => setOpen(false)}
-                aria-hidden
-              />
-              <Popover
-                className="fixed z-popover w-96"
-                style={{ top: coords.top, bottom: coords.bottom, left: coords.left }}
-              >
-                <header className="flex items-center justify-between gap-2 px-3 py-2">
-                  <span className="text-xs font-semibold text-foreground">
-                    {total} {total === 1 ? 'notification' : 'notifications'}
-                  </span>
-                  {notifications.length > 0 && (
+      <DropdownPortal portal={portal} portalTarget={portalTarget}>
+        {open && (
+          <>
+            <DropdownBackdrop onClose={close} />
+            <Popover innerRef={popupRef} className={popupClassName} style={popupStyle}>
+              <header className="flex items-center justify-between gap-2 px-3 py-2">
+                <span className="text-xs font-semibold text-foreground">
+                  {total} {total === 1 ? 'notification' : 'notifications'}
+                </span>
+                {notifications.length > 0 && (
+                  <button
+                    type="button"
+                    onClick={() => void clearNotifications()}
+                    className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-2xs text-muted-foreground transition-colors hover:bg-danger/10 hover:text-danger"
+                    aria-label="Clear all notifications"
+                    title="Clear all notifications"
+                  >
+                    <Trash2 size={11} aria-hidden />
+                    Clear all
+                  </button>
+                )}
+              </header>
+              <Divider />
+              {notificationsLoading && notifications.length === 0 ? (
+                <div
+                  className="flex flex-col gap-3 px-3 py-2.5"
+                  role="status"
+                  aria-label="Loading notifications"
+                >
+                  {Array.from({ length: 4 }).map((_, index) => (
+                    <div key={index} className="flex items-start gap-2">
+                      <Skeleton className="mt-0.5 size-3.5 shrink-0 rounded-full" />
+                      <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+                        <Skeleton className="h-3 w-2/3 rounded" />
+                        <Skeleton className="h-2.5 w-1/3 rounded" />
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              ) : notifications.length === 0 ? (
+                <EmptyState
+                  icon={CONCEPT_ICONS.notifications}
+                  tone={CONCEPT_TONE.notifications}
+                  title="Nothing to catch up on"
+                  description="Session milestones, retries, and budget alerts land here as they happen, so you don't have to babysit a running session."
+                  size="inline"
+                  action={
+                    <Button
+                      size="sm"
+                      variant="secondary"
+                      onClick={() => {
+                        close();
+                        window.dispatchEvent(new CustomEvent('goodboy:new-session'));
+                      }}
+                    >
+                      Start a session
+                    </Button>
+                  }
+                  className="px-3 py-6"
+                />
+              ) : (
+                <ScrollFade className="max-h-[25rem]" fadeSize={16} fadeFrom="elevated">
+                  <ul>
+                    {notifications.map((n, i) => (
+                      <Fragment key={n.id}>
+                        {i > 0 && (
+                          <li aria-hidden className="px-3">
+                            <Divider />
+                          </li>
+                        )}
+                        <NotificationItem notification={n} onNavigated={close} />
+                      </Fragment>
+                    ))}
+                  </ul>
+                </ScrollFade>
+              )}
+              {notifications.length > 0 && (
+                <>
+                  <Divider />
+                  <footer className="flex items-center justify-end px-3 py-2">
                     <button
                       type="button"
-                      onClick={() => void clearNotifications()}
-                      className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-2xs text-muted-foreground transition-colors hover:bg-danger/10 hover:text-danger"
-                      aria-label="Clear all notifications"
-                      title="Clear all notifications"
+                      onClick={() => {
+                        close();
+                        window.dispatchEvent(new CustomEvent(NOTIFICATIONS_STUDIO_EVENT));
+                      }}
+                      className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-2xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
                     >
-                      <Trash2 size={11} aria-hidden />
-                      Clear all
+                      Show more
+                      <ArrowRight size={11} aria-hidden />
                     </button>
-                  )}
-                </header>
-                <Divider />
-                {notificationsLoading && notifications.length === 0 ? (
-                  <div
-                    className="flex flex-col gap-3 px-3 py-2.5"
-                    role="status"
-                    aria-label="Loading notifications"
-                  >
-                    {Array.from({ length: 4 }).map((_, index) => (
-                      <div key={index} className="flex items-start gap-2">
-                        <Skeleton className="mt-0.5 size-3.5 shrink-0 rounded-full" />
-                        <div className="flex min-w-0 flex-1 flex-col gap-1.5">
-                          <Skeleton className="h-3 w-2/3 rounded" />
-                          <Skeleton className="h-2.5 w-1/3 rounded" />
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                ) : notifications.length === 0 ? (
-                  <EmptyState
-                    icon={CONCEPT_ICONS.notifications}
-                    tone={CONCEPT_TONE.notifications}
-                    title="Nothing to catch up on"
-                    description="Session milestones, retries, and budget alerts land here as they happen, so you don't have to babysit a running session."
-                    size="inline"
-                    action={
-                      <Button
-                        size="sm"
-                        variant="secondary"
-                        onClick={() => {
-                          setOpen(false);
-                          window.dispatchEvent(new CustomEvent('goodboy:new-session'));
-                        }}
-                      >
-                        Start a session
-                      </Button>
-                    }
-                    className="px-3 py-6"
-                  />
-                ) : (
-                  <ScrollFade className="max-h-[25rem]" fadeSize={16} fadeFrom="elevated">
-                    <ul>
-                      {notifications.map((n, i) => (
-                        <Fragment key={n.id}>
-                          {i > 0 && (
-                            <li aria-hidden className="px-3">
-                              <Divider />
-                            </li>
-                          )}
-                          <NotificationItem notification={n} onNavigated={() => setOpen(false)} />
-                        </Fragment>
-                      ))}
-                    </ul>
-                  </ScrollFade>
-                )}
-                {notifications.length > 0 && (
-                  <>
-                    <Divider />
-                    <footer className="flex items-center justify-end px-3 py-2">
-                      <button
-                        type="button"
-                        onClick={() => {
-                          setOpen(false);
-                          window.dispatchEvent(new CustomEvent(NOTIFICATIONS_STUDIO_EVENT));
-                        }}
-                        className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-2xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-                      >
-                        Show more
-                        <ArrowRight size={11} aria-hidden />
-                      </button>
-                    </footer>
-                  </>
-                )}
-              </Popover>
-            </>,
-            document.body,
-          )
-        : null}
+                  </footer>
+                </>
+              )}
+            </Popover>
+          </>
+        )}
+      </DropdownPortal>
     </div>
   );
 };

--- a/apps/desktop/src/features/scripts/components/RunningScriptsIndicator/index.test.tsx
+++ b/apps/desktop/src/features/scripts/components/RunningScriptsIndicator/index.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 
 const { state } = vi.hoisted(() => ({
   state: {
@@ -42,5 +42,55 @@ describe('RunningScriptsIndicator', () => {
 
     expect(document.body.querySelector('.z-popover-backdrop')).not.toBeNull();
     expect(document.body.querySelector('.z-popover')).not.toBeNull();
+  });
+
+  it('closes on escape without pulling focus back to the trigger', async () => {
+    render(<RunningScriptsIndicator />);
+    const trigger = screen.getByRole('button', { name: /running/i });
+
+    await act(async () => {
+      fireEvent.click(trigger);
+    });
+    expect(screen.getByRole('dialog', { name: 'Running scripts' })).toBeDefined();
+
+    await act(async () => {
+      fireEvent.keyDown(window, { key: 'Escape' });
+    });
+
+    expect(screen.queryByRole('dialog', { name: 'Running scripts' })).toBeNull();
+    expect(document.activeElement).not.toBe(trigger);
+  });
+
+  it('closes when the backdrop is clicked', async () => {
+    render(<RunningScriptsIndicator />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /running/i }));
+    });
+    const backdrop = document.body.querySelector('.z-popover-backdrop');
+    expect(backdrop).not.toBeNull();
+
+    await act(async () => {
+      fireEvent.click(backdrop as Element);
+    });
+
+    expect(screen.queryByRole('dialog', { name: 'Running scripts' })).toBeNull();
+  });
+
+  it('lists every running script and closes when one is opened', async () => {
+    render(<RunningScriptsIndicator />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /running/i }));
+    });
+    const panel = screen.getByRole('dialog', { name: 'Running scripts' });
+    expect(within(panel).getAllByRole('listitem').length).toBe(1);
+
+    await act(async () => {
+      fireEvent.click(within(panel).getByRole('button', { name: 'Go to lint in ship it' }));
+    });
+
+    expect(state.setCurrentSession).toHaveBeenCalledWith('session-1');
+    expect(screen.queryByRole('dialog', { name: 'Running scripts' })).toBeNull();
   });
 });

--- a/apps/desktop/src/features/scripts/components/RunningScriptsIndicator/index.tsx
+++ b/apps/desktop/src/features/scripts/components/RunningScriptsIndicator/index.tsx
@@ -1,19 +1,14 @@
-import { useEffect, useLayoutEffect, useRef, useState } from 'react';
-import { createPortal } from 'react-dom';
+import { useEffect, useState } from 'react';
 import { Divider, Popover, ScrollFade, Tooltip, cn } from '@goodboy/ui';
 import { Terminal } from 'lucide-react';
+import { DropdownBackdrop } from '../../../../shared/hooks/useDropdown/DropdownBackdrop';
+import { DropdownPortal } from '../../../../shared/hooks/useDropdown/DropdownPortal';
+import { useDropdown } from '../../../../shared/hooks/useDropdown';
 import { useAppStore } from '../../../../store';
 import { RunningScriptRow } from './RunningScriptRow';
 import { useRunningScripts, type RunningScript } from './useRunningScripts';
 
-type PopoverCoordinates = {
-  readonly top?: number;
-  readonly bottom?: number;
-  readonly left: number;
-};
-
 const DROPDOWN_WIDTH = 384;
-const VIEWPORT_MARGIN = 8;
 const DROPDOWN_MAX_HEIGHT = 437;
 
 export const RunningScriptsIndicator = () => {
@@ -21,17 +16,32 @@ export const RunningScriptsIndicator = () => {
   const setCurrentSession = useAppStore((state) => state.setCurrentSession);
   const setActiveLens = useAppStore((state) => state.setActiveLens);
   const cancelScript = useAppStore((state) => state.cancelScript);
-  const [isOpen, setIsOpen] = useState(false);
   const [now, setNow] = useState(() => Date.now());
-  const triggerRef = useRef<HTMLButtonElement>(null);
-  const [coordinates, setCoordinates] = useState<PopoverCoordinates | null>(null);
+  const {
+    open: isOpen,
+    close,
+    toggle,
+    containerRef,
+    popupRef,
+    popupStyle,
+    popupClassName,
+    portal,
+    portalTarget,
+  } = useDropdown({
+    align: 'center',
+    width: 'w-96',
+    expectedWidth: DROPDOWN_WIDTH,
+    expectedHeight: DROPDOWN_MAX_HEIGHT,
+    strategy: 'fixed',
+    hasBackdrop: true,
+  });
   const count = running.length;
 
   useEffect(() => {
     if (count === 0) {
-      setIsOpen(false);
+      close();
     }
-  }, [count]);
+  }, [close, count]);
 
   useEffect(() => {
     if (!isOpen) {
@@ -42,56 +52,12 @@ export const RunningScriptsIndicator = () => {
     return () => window.clearInterval(id);
   }, [isOpen]);
 
-  useEffect(() => {
-    if (!isOpen) {
-      return;
-    }
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        setIsOpen(false);
-      }
-    };
-    window.addEventListener('keydown', onKeyDown);
-    return () => window.removeEventListener('keydown', onKeyDown);
-  }, [isOpen]);
-
-  useLayoutEffect(() => {
-    if (!isOpen) {
-      return;
-    }
-    const updatePosition = () => {
-      const trigger = triggerRef.current;
-      if (trigger == null) {
-        return;
-      }
-      const rect = trigger.getBoundingClientRect();
-      const centerX = rect.left + rect.width / 2;
-      const desiredLeft = centerX - DROPDOWN_WIDTH / 2;
-      const maxLeft = window.innerWidth - DROPDOWN_WIDTH - VIEWPORT_MARGIN;
-      const left = Math.min(Math.max(desiredLeft, VIEWPORT_MARGIN), maxLeft);
-      const spaceBelow = window.innerHeight - rect.bottom;
-      const shouldOpenAbove = spaceBelow < DROPDOWN_MAX_HEIGHT + VIEWPORT_MARGIN;
-      setCoordinates({
-        top: shouldOpenAbove ? undefined : rect.bottom + 6,
-        bottom: shouldOpenAbove ? window.innerHeight - rect.top + 6 : undefined,
-        left,
-      });
-    };
-    updatePosition();
-    window.addEventListener('resize', updatePosition);
-    window.addEventListener('scroll', updatePosition, true);
-    return () => {
-      window.removeEventListener('resize', updatePosition);
-      window.removeEventListener('scroll', updatePosition, true);
-    };
-  }, [isOpen]);
-
   if (count === 0) {
     return null;
   }
 
   const onOpen = (run: RunningScript) => {
-    setIsOpen(false);
+    close();
     void setCurrentSession(run.sessionId).then(() => {
       setActiveLens(run.sessionId, 'scripts');
     });
@@ -104,12 +70,11 @@ export const RunningScriptsIndicator = () => {
   const label = `${count} ${count === 1 ? 'script' : 'scripts'} running`;
 
   return (
-    <>
+    <div ref={containerRef} className="relative">
       <Tooltip content={label} side="top">
         <button
-          ref={triggerRef}
           type="button"
-          onClick={() => setIsOpen((current) => !current)}
+          onClick={toggle}
           aria-label={label}
           aria-expanded={isOpen}
           className={cn(
@@ -122,46 +87,38 @@ export const RunningScriptsIndicator = () => {
         </button>
       </Tooltip>
 
-      {isOpen && coordinates != null
-        ? createPortal(
-            <>
-              <div
-                className="fixed inset-0 z-popover-backdrop"
-                onClick={() => setIsOpen(false)}
-                aria-hidden
-              />
-              <Popover
-                role="dialog"
-                ariaLabel="Running scripts"
-                className="fixed z-popover w-96"
-                style={{
-                  top: coordinates.top,
-                  bottom: coordinates.bottom,
-                  left: coordinates.left,
-                }}
-              >
-                <header className="px-3 py-2">
-                  <span className="text-xs font-semibold text-foreground">Running scripts</span>
-                </header>
-                <Divider />
-                <ScrollFade className="max-h-[25rem]" fadeSize={16} fadeFrom="elevated">
-                  <ul aria-label="Running scripts">
-                    {running.map((run) => (
-                      <RunningScriptRow
-                        key={`${run.sessionId}:${run.scriptId}`}
-                        run={run}
-                        now={now}
-                        onOpen={onOpen}
-                        onStop={onStop}
-                      />
-                    ))}
-                  </ul>
-                </ScrollFade>
-              </Popover>
-            </>,
-            document.body,
-          )
-        : null}
-    </>
+      <DropdownPortal portal={portal} portalTarget={portalTarget}>
+        {isOpen && (
+          <>
+            <DropdownBackdrop onClose={close} />
+            <Popover
+              innerRef={popupRef}
+              role="dialog"
+              ariaLabel="Running scripts"
+              className={popupClassName}
+              style={popupStyle}
+            >
+              <header className="px-3 py-2">
+                <span className="text-xs font-semibold text-foreground">Running scripts</span>
+              </header>
+              <Divider />
+              <ScrollFade className="max-h-[25rem]" fadeSize={16} fadeFrom="elevated">
+                <ul aria-label="Running scripts">
+                  {running.map((run) => (
+                    <RunningScriptRow
+                      key={`${run.sessionId}:${run.scriptId}`}
+                      run={run}
+                      now={now}
+                      onOpen={onOpen}
+                      onStop={onStop}
+                    />
+                  ))}
+                </ul>
+              </ScrollFade>
+            </Popover>
+          </>
+        )}
+      </DropdownPortal>
+    </div>
   );
 };

--- a/apps/desktop/src/features/workspace/components/SessionActivityBar/SessionViewMenu/index.test.tsx
+++ b/apps/desktop/src/features/workspace/components/SessionActivityBar/SessionViewMenu/index.test.tsx
@@ -62,7 +62,7 @@ describe('SessionViewMenu', () => {
     render(<SessionViewMenu workspaceId={'ws-1' as never} />);
 
     fireEvent.click(screen.getByLabelText(/display options/i));
-    const backdrop = document.body.querySelector('.inset-0');
+    const backdrop = document.body.querySelector('.z-popover-backdrop');
     expect(backdrop).not.toBeNull();
 
     fireEvent.click(backdrop as Element);
@@ -70,13 +70,14 @@ describe('SessionViewMenu', () => {
     expect(screen.queryByRole('menu', { name: 'Session display options' })).toBeNull();
   });
 
-  it('stays on the local z-30 and z-40 layers rather than the app-global popover scale', () => {
+  it('opens on the named popover scale rather than the raw z-30 and z-40 it carried before', () => {
     render(<SessionViewMenu workspaceId={'ws-1' as never} />);
 
     fireEvent.click(screen.getByLabelText(/display options/i));
 
-    expect(document.body.querySelector('.z-30')).not.toBeNull();
-    expect(document.body.querySelector('.z-40')).not.toBeNull();
-    expect(document.body.querySelector('.z-popover')).toBeNull();
+    expect(document.body.querySelector('.z-popover-backdrop')).not.toBeNull();
+    expect(document.body.querySelector('.z-popover')).not.toBeNull();
+    expect(document.body.querySelector('.z-30')).toBeNull();
+    expect(document.body.querySelector('.z-40')).toBeNull();
   });
 });

--- a/apps/desktop/src/features/workspace/components/SessionActivityBar/SessionViewMenu/index.test.tsx
+++ b/apps/desktop/src/features/workspace/components/SessionActivityBar/SessionViewMenu/index.test.tsx
@@ -44,4 +44,39 @@ describe('SessionViewMenu', () => {
     fireEvent.click(screen.getByText('A–Z'));
     expect(state.setSessionSort).toHaveBeenCalledWith('ws-1', 'goal');
   });
+
+  it('closes on escape and returns focus to the trigger', () => {
+    render(<SessionViewMenu workspaceId={'ws-1' as never} />);
+    const trigger = screen.getByLabelText(/display options/i);
+
+    fireEvent.click(trigger);
+    expect(screen.getByRole('menu', { name: 'Session display options' })).toBeDefined();
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+
+    expect(screen.queryByRole('menu', { name: 'Session display options' })).toBeNull();
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it('closes when the backdrop is clicked', () => {
+    render(<SessionViewMenu workspaceId={'ws-1' as never} />);
+
+    fireEvent.click(screen.getByLabelText(/display options/i));
+    const backdrop = document.body.querySelector('.inset-0');
+    expect(backdrop).not.toBeNull();
+
+    fireEvent.click(backdrop as Element);
+
+    expect(screen.queryByRole('menu', { name: 'Session display options' })).toBeNull();
+  });
+
+  it('stays on the local z-30 and z-40 layers rather than the app-global popover scale', () => {
+    render(<SessionViewMenu workspaceId={'ws-1' as never} />);
+
+    fireEvent.click(screen.getByLabelText(/display options/i));
+
+    expect(document.body.querySelector('.z-30')).not.toBeNull();
+    expect(document.body.querySelector('.z-40')).not.toBeNull();
+    expect(document.body.querySelector('.z-popover')).toBeNull();
+  });
 });

--- a/apps/desktop/src/features/workspace/components/SessionActivityBar/SessionViewMenu/index.tsx
+++ b/apps/desktop/src/features/workspace/components/SessionActivityBar/SessionViewMenu/index.tsx
@@ -1,8 +1,10 @@
-import { useEffect, useLayoutEffect, useRef, useState } from 'react';
-import { createPortal } from 'react-dom';
+import { useEffect, useRef } from 'react';
 import { Check, SlidersHorizontal } from 'lucide-react';
 import { Divider, Eyebrow, Popover, Tooltip, cn } from '@goodboy/ui';
 import type { SessionGroupKey, SessionSortKey, WorkspaceId } from '@goodboy/types';
+import { DropdownBackdrop } from '../../../../../shared/hooks/useDropdown/DropdownBackdrop';
+import { DropdownPortal } from '../../../../../shared/hooks/useDropdown/DropdownPortal';
+import { useDropdown } from '../../../../../shared/hooks/useDropdown';
 import { useAppStore, useSessionViewPrefs } from '../../../../../store';
 import { useSidebarPeekHold } from '../../SidebarPeekOverlay/hold';
 
@@ -31,7 +33,6 @@ const GROUP_OPTIONS: ReadonlyArray<GroupOption> = [
 ];
 
 const MENU_WIDTH = 200;
-const VIEWPORT_MARGIN = 8;
 
 type SessionViewMenuProps = {
   readonly workspaceId: WorkspaceId;
@@ -43,34 +44,26 @@ export const SessionViewMenu = ({ workspaceId }: SessionViewMenuProps) => {
   const setSessionGroup = useAppStore((s) => s.setSessionGroup);
 
   const { hold, release } = useSidebarPeekHold();
-  const [open, setOpen] = useState(false);
   const triggerRef = useRef<HTMLButtonElement>(null);
-  const [coords, setCoords] = useState<{ top: number; left: number } | null>(null);
-
-  useLayoutEffect(() => {
-    if (!open) {
-      return;
-    }
-    const updatePosition = () => {
-      const el = triggerRef.current;
-      if (!el) {
-        return;
-      }
-      const rect = el.getBoundingClientRect();
-      const desiredLeft = rect.left;
-      const maxLeft = window.innerWidth - MENU_WIDTH - VIEWPORT_MARGIN;
-      const left = Math.min(Math.max(desiredLeft, VIEWPORT_MARGIN), maxLeft);
-      const top = rect.bottom + 6;
-      setCoords({ top, left });
-    };
-    updatePosition();
-    window.addEventListener('resize', updatePosition);
-    window.addEventListener('scroll', updatePosition, true);
-    return () => {
-      window.removeEventListener('resize', updatePosition);
-      window.removeEventListener('scroll', updatePosition, true);
-    };
-  }, [open]);
+  const {
+    open,
+    close,
+    toggle,
+    containerRef,
+    popupRef,
+    popupStyle,
+    popupClassName,
+    portal,
+    portalTarget,
+  } = useDropdown({
+    align: 'start',
+    width: 'w-[200px]',
+    expectedWidth: MENU_WIDTH,
+    expectedHeight: 220,
+    strategy: 'fixed',
+    isEscapeEnabled: false,
+    hasBackdrop: true,
+  });
 
   useEffect(() => {
     if (!open) {
@@ -79,13 +72,13 @@ export const SessionViewMenu = ({ workspaceId }: SessionViewMenuProps) => {
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
         e.preventDefault();
-        setOpen(false);
+        close();
         triggerRef.current?.focus();
       }
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [open]);
+  }, [close, open]);
 
   useEffect(() => {
     if (!open) {
@@ -96,12 +89,12 @@ export const SessionViewMenu = ({ workspaceId }: SessionViewMenuProps) => {
   }, [hold, open, release]);
 
   return (
-    <>
+    <div ref={containerRef} className="relative">
       <Tooltip content="Display options" side="bottom">
         <button
           ref={triggerRef}
           type="button"
-          onClick={() => setOpen((v) => !v)}
+          onClick={toggle}
           aria-haspopup="menu"
           aria-expanded={open}
           aria-label="Display options"
@@ -116,49 +109,49 @@ export const SessionViewMenu = ({ workspaceId }: SessionViewMenuProps) => {
         </button>
       </Tooltip>
 
-      {open && coords
-        ? createPortal(
-            <>
-              <div className="fixed inset-0 z-30" onClick={() => setOpen(false)} aria-hidden />
-              <Popover
-                role="menu"
-                ariaLabel="Session display options"
-                className="fixed z-40 py-1"
-                style={{ top: coords.top, left: coords.left, width: MENU_WIDTH }}
-              >
-                <MenuSection title="Sort by">
-                  {SORT_OPTIONS.map((opt) => (
-                    <MenuItem
-                      key={opt.key}
-                      label={opt.label}
-                      hint={opt.hint}
-                      selected={prefs.sort === opt.key}
-                      onClick={() => {
-                        setSessionSort(workspaceId, opt.key);
-                      }}
-                    />
-                  ))}
-                </MenuSection>
-                <Divider />
-                <MenuSection title="Group by">
-                  {GROUP_OPTIONS.map((opt) => (
-                    <MenuItem
-                      key={opt.key}
-                      label={opt.label}
-                      hint={opt.hint}
-                      selected={prefs.group === opt.key}
-                      onClick={() => {
-                        setSessionGroup(workspaceId, opt.key);
-                      }}
-                    />
-                  ))}
-                </MenuSection>
-              </Popover>
-            </>,
-            document.body,
-          )
-        : null}
-    </>
+      <DropdownPortal portal={portal} portalTarget={portalTarget}>
+        {open && (
+          <>
+            <DropdownBackdrop onClose={close} />
+            <Popover
+              innerRef={popupRef}
+              role="menu"
+              ariaLabel="Session display options"
+              className={cn(popupClassName, 'py-1')}
+              style={popupStyle}
+            >
+              <MenuSection title="Sort by">
+                {SORT_OPTIONS.map((opt) => (
+                  <MenuItem
+                    key={opt.key}
+                    label={opt.label}
+                    hint={opt.hint}
+                    selected={prefs.sort === opt.key}
+                    onClick={() => {
+                      setSessionSort(workspaceId, opt.key);
+                    }}
+                  />
+                ))}
+              </MenuSection>
+              <Divider />
+              <MenuSection title="Group by">
+                {GROUP_OPTIONS.map((opt) => (
+                  <MenuItem
+                    key={opt.key}
+                    label={opt.label}
+                    hint={opt.hint}
+                    selected={prefs.group === opt.key}
+                    onClick={() => {
+                      setSessionGroup(workspaceId, opt.key);
+                    }}
+                  />
+                ))}
+              </MenuSection>
+            </Popover>
+          </>
+        )}
+      </DropdownPortal>
+    </div>
   );
 };
 

--- a/apps/desktop/src/shared/hooks/useDropdown/DropdownBackdrop.tsx
+++ b/apps/desktop/src/shared/hooks/useDropdown/DropdownBackdrop.tsx
@@ -1,0 +1,7 @@
+type Props = {
+  readonly onClose: () => void;
+};
+
+export const DropdownBackdrop = ({ onClose }: Props) => (
+  <div className="fixed inset-0 z-popover-backdrop" onClick={onClose} aria-hidden />
+);

--- a/apps/desktop/src/shared/hooks/useDropdown/index.test.ts
+++ b/apps/desktop/src/shared/hooks/useDropdown/index.test.ts
@@ -49,6 +49,38 @@ describe('useDropdown', () => {
     expect(result.current.popupClassName).toContain('w-80');
   });
 
+  it('keeps a backdrop-less dropdown off the app-global scale', () => {
+    const { result } = renderHook(() => useDropdown({}));
+    expect(result.current.popupClassName).toContain('z-50');
+    expect(result.current.popupClassName).not.toContain('z-popover');
+  });
+
+  it('lifts a dropdown that renders a backdrop onto the named popover layer', () => {
+    const { result } = renderHook(() => useDropdown({ hasBackdrop: true }));
+    expect(result.current.popupClassName).toContain('z-popover');
+    expect(result.current.popupClassName).not.toContain('z-50');
+  });
+
+  it('centres a fixed popup on its trigger when asked', () => {
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1024 });
+    Object.defineProperty(window, 'innerHeight', { configurable: true, value: 768 });
+    const trigger = document.createElement('div');
+    document.body.append(trigger);
+    trigger.getBoundingClientRect = () =>
+      DOMRect.fromRect({ x: 500, y: 40, width: 40, height: 24 });
+    const { result } = renderHook(() =>
+      useDropdown({ align: 'center', expectedWidth: 384, strategy: 'fixed' }),
+    );
+
+    act(() => {
+      result.current.containerRef.current = trigger;
+      result.current.toggle();
+    });
+
+    expect(result.current.popupStyle).toMatchObject({ left: 328 });
+    trigger.remove();
+  });
+
   it('clamps a fixed popup within the viewport and updates on ancestor scroll', () => {
     Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1024 });
     Object.defineProperty(window, 'innerHeight', { configurable: true, value: 768 });

--- a/apps/desktop/src/shared/hooks/useDropdown/index.ts
+++ b/apps/desktop/src/shared/hooks/useDropdown/index.ts
@@ -2,15 +2,24 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { cn } from '@goodboy/ui';
 import { useDropdownDirection } from '../useDropdownDirection';
 
+type Align = 'start' | 'end' | 'center';
+
+const ALIGN_CLASS = {
+  start: 'left-0',
+  end: 'right-0',
+  center: 'left-1/2 -translate-x-1/2',
+} satisfies Record<Align, string>;
+
 type Params = {
   readonly disabled?: boolean;
-  readonly align?: 'start' | 'end';
+  readonly align?: Align;
   readonly width?: string;
   readonly expectedHeight?: number;
   readonly expectedWidth?: number;
   readonly openEvent?: string;
   readonly strategy?: 'absolute' | 'fixed';
   readonly isEscapeEnabled?: boolean;
+  readonly hasBackdrop?: boolean;
 };
 
 export const useDropdown = ({
@@ -22,6 +31,7 @@ export const useDropdown = ({
   openEvent,
   strategy = 'absolute',
   isEscapeEnabled = true,
+  hasBackdrop = false,
 }: Params) => {
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -99,9 +109,10 @@ export const useDropdown = ({
     portal: strategy === 'fixed',
     portalTarget,
     popupClassName: cn(
-      strategy === 'fixed' ? 'fixed z-50' : 'absolute z-50',
+      strategy === 'fixed' ? 'fixed' : 'absolute',
+      hasBackdrop ? 'z-popover' : 'z-50',
       width,
-      strategy === 'absolute' && (align === 'end' ? 'right-0' : 'left-0'),
+      strategy === 'absolute' && ALIGN_CLASS[align],
       strategy === 'absolute' &&
         (position.direction === 'up' ? 'bottom-[calc(100%+0.25rem)]' : 'top-[calc(100%+0.25rem)]'),
     ),

--- a/apps/desktop/src/shared/hooks/useDropdownDirection/index.ts
+++ b/apps/desktop/src/shared/hooks/useDropdownDirection/index.ts
@@ -5,13 +5,15 @@ type Direction = 'up' | 'down';
 
 type Strategy = 'absolute' | 'fixed';
 
+type Align = 'start' | 'end' | 'center';
+
 type Params = {
   readonly triggerRef: RefObject<HTMLElement | null>;
   readonly popupRef: RefObject<HTMLElement | null>;
   readonly open: boolean;
   readonly expectedHeight: number;
   readonly expectedWidth: number;
-  readonly align: 'start' | 'end';
+  readonly align: Align;
   readonly strategy: Strategy;
 };
 
@@ -24,8 +26,24 @@ type FindClippingAncestorParams = {
   readonly element: HTMLElement;
 };
 
+type ResolveDesiredLeftParams = {
+  readonly rect: DOMRect;
+  readonly popupWidth: number;
+  readonly align: Align;
+};
+
 const VIEWPORT_MARGIN = 8;
 const DROPDOWN_GAP = 4;
+
+const resolveDesiredLeft = ({ rect, popupWidth, align }: ResolveDesiredLeftParams): number => {
+  if (align === 'end') {
+    return rect.right - popupWidth;
+  }
+  if (align === 'center') {
+    return rect.left + rect.width / 2 - popupWidth / 2;
+  }
+  return rect.left;
+};
 
 const findClippingAncestor = ({ element }: FindClippingAncestorParams): HTMLElement | null => {
   let current = element.parentElement;
@@ -78,7 +96,7 @@ export const useDropdownDirection = ({
       const measuredWidth = popupRef.current?.getBoundingClientRect().width ?? 0;
       const viewportWidth = Math.max(window.innerWidth - VIEWPORT_MARGIN * 2, 0);
       const popupWidth = Math.min(measuredWidth > 0 ? measuredWidth : expectedWidth, viewportWidth);
-      const desiredLeft = align === 'end' ? rect.right - popupWidth : rect.left;
+      const desiredLeft = resolveDesiredLeft({ rect, popupWidth, align });
       const maxLeft = Math.max(window.innerWidth - popupWidth - VIEWPORT_MARGIN, VIEWPORT_MARGIN);
       const left = Math.min(Math.max(desiredLeft, VIEWPORT_MARGIN), maxLeft);
       const spaceBelow = Math.max(

--- a/docs/styling.md
+++ b/docs/styling.md
@@ -160,11 +160,15 @@ define a control's own shape (buttons, inputs, popovers, chips) are fine.
 
 Anything that belongs to a control opens anchored to that control, as a `Popover`
 from `@goodboy/ui` portaled to `document.body` and positioned off the trigger's
-`getBoundingClientRect()`. `AppTopBar/NeedsYouPopover` and
-`workspace/components/WorkspaceSwitcher` are the reference implementations: fixed
-coordinates, a `z-popover-backdrop` click-catcher behind, Escape to close, and a
-flip above the trigger when the space below runs out. A centred overlay for a menu
-that has an obvious on-screen owner is a bug, not a style choice.
+`getBoundingClientRect()`. The mechanism lives in the
+`shared/hooks/useDropdown` hook, which owns all of it: fixed coordinates, the
+`DropdownBackdrop` click-catcher, the `DropdownPortal`, Escape to close, and a flip
+above the trigger when the space below runs out. Reach for the hook rather than
+hand-rolling any of those pieces; `AppTopBar/NeedsYouPopover` is a worked example of
+a full app-global popover on it (`hasBackdrop`, `strategy: 'fixed'`), and
+`workspace/components/WorkspaceSwitcher` is the one still hand-rolled, because it is
+props-controlled. A centred overlay for a menu that has an obvious on-screen owner is
+a bug, not a style choice.
 
 ## z-index: a named scale, not a magic number per file
 
@@ -175,20 +179,20 @@ open underneath) use named tokens from `apps/desktop/src/styles.css`'
 into a `z-<name>` utility automatically, the same mechanism already used for
 `--animate-*`.
 
-| token                        | value | utility                   | who                                                                                                                                                                    |
-| ---------------------------- | ----- | ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| (StudioShell fullscreen)     | 50    | `z-50` (Tailwind default) | `StudioShell`'s fullscreen variant. The floor: never lowered.                                                                                                          |
-| `--z-index-popover-backdrop` | 55    | `z-popover-backdrop`      | click-catcher behind the six app-global popovers below                                                                                                                 |
-| `--z-index-popover`          | 65    | `z-popover`               | `NotificationCenter`, `WorkspaceSwitcher`, `RunningScriptsIndicator`, `AppTopBar/NeedsYouPopover`, `AppFooter/IntegrationAddPopover`, `AppFooter/MoreStudiosPopover`   |
-| `--z-index-command-palette`  | 70    | `z-command-palette`       | `CommandPalette` (⌘K), a global "transit" surface: it fires on a keyboard shortcut regardless of what else is open, so it must clear a popover left open underneath it |
-| `--z-index-tooltip`          | 75    | `z-tooltip`               | `Tooltip` (`packages/ui`), portaled; must win over a popover or the command palette it's triggered from inside                                                         |
-| `--z-index-toast`            | 85    | `z-toast`                 | the toast stack (`app/components/Toast`)                                                                                                                               |
-| (native `<dialog>`)          | n/a   | n/a                       | `Dialog` renders through the browser's top layer, always above every z-indexed element regardless of number                                                            |
+| token                        | value | utility                   | who                                                                                                                                                                                                                                                                         |
+| ---------------------------- | ----- | ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| (StudioShell fullscreen)     | 50    | `z-50` (Tailwind default) | `StudioShell`'s fullscreen variant. The floor: never lowered.                                                                                                                                                                                                               |
+| `--z-index-popover-backdrop` | 55    | `z-popover-backdrop`      | click-catcher behind the seven app-global popovers below, rendered by `DropdownBackdrop`                                                                                                                                                                                    |
+| `--z-index-popover`          | 65    | `z-popover`               | `NotificationCenter`, `WorkspaceSwitcher`, `RunningScriptsIndicator`, `AppTopBar/NeedsYouPopover`, `AppFooter/IntegrationAddPopover`, `AppFooter/MoreStudiosPopover`, `SessionViewMenu`. Every one but `WorkspaceSwitcher` gets there through `useDropdown`'s `hasBackdrop` |
+| `--z-index-command-palette`  | 70    | `z-command-palette`       | `CommandPalette` (⌘K), a global "transit" surface: it fires on a keyboard shortcut regardless of what else is open, so it must clear a popover left open underneath it                                                                                                      |
+| `--z-index-tooltip`          | 75    | `z-tooltip`               | `Tooltip` (`packages/ui`), portaled; must win over a popover or the command palette it's triggered from inside                                                                                                                                                              |
+| `--z-index-toast`            | 85    | `z-toast`                 | the toast stack (`app/components/Toast`)                                                                                                                                                                                                                                    |
+| (native `<dialog>`)          | n/a   | n/a                       | `Dialog` renders through the browser's top layer, always above every z-indexed element regardless of number                                                                                                                                                                 |
 
 Everything else keeps its existing, unnamed `z-10`/`z-20`/`z-30`/`z-40`
-value: those are local, scoped to one card, toolbar, or pane (`SessionViewMenu`,
-the jira/GitHub in-studio pickers, `SessionStudioLayer`'s session-scoped studio
-at `z-20`, and so on). They are never compared against a full-page studio in
+value: those are local, scoped to one card, toolbar, or pane (the jira/GitHub
+in-studio pickers, `SessionStudioLayer`'s session-scoped studio at `z-20`, and so
+on). They are never compared against a full-page studio in
 normal use, so they stay off the named scale. A control needs a name on this
 ladder only when it must render above `StudioShell`'s fullscreen `z-50`
 regardless of what else is open; anything narrower in scope takes the nearest


### PR DESCRIPTION
Six backdrop-portal popovers each carried their own open state, escape listener, `createPortal` call, backdrop div and a near-identical copy of the same `getBoundingClientRect` placement maths. They now run on the shared `useDropdown` hook. This continues the v0.1.75 pass (#1338) that converted the first four sites.

**Behavior is unchanged**, with three exceptions that are declared below rather than left to be discovered.

## The six sites

| site | alignment | escape | notes |
| --- | --- | --- | --- |
| `AppFooter/IntegrationAddPopover` | centre | hook | `disabled` now carries the exhausted-category guard |
| `AppFooter/MoreStudiosPopover` | end | hook | |
| `AppTopBar/NeedsYouPopover` | centre | hook | |
| `notifications/NotificationCenter` | centre | **opted out** | keeps its open-request event and mark-read side effect |
| `scripts/RunningScriptsIndicator` | centre | hook | still closes itself when the running count drops to zero |
| `SessionActivityBar/SessionViewMenu` | start | **opted out, local** | keeps focus-return; joins the named z scale |

## Characterization tests first

`IntegrationAddPopover` and `MoreStudiosPopover` already had escape and outside-click coverage in `AppFooter/index.test.tsx`. The other four had none: their tests asserted z-layers or nothing relevant to this change, and a refactor of an uncovered surface has no way to prove behavior unchanged.

So the first commit adds twelve assertions across those four, and **every one of them passed against the unconverted components** before a single line of production code moved:

- `NeedsYouPopover`: opens, escape closes, backdrop closes, reopens on a second trigger click, and escape does **not** return focus to the trigger.
- `RunningScriptsIndicator`: same four, plus the list contents and close-on-open-a-script.
- `SessionViewMenu`: escape closes **and** returns focus to the trigger, backdrop closes.
- `NotificationCenter`: escape leaves it open, backdrop closes, and the open-request event marks read only when it finds the panel closed.

The "escape does not return focus" assertions are guards, not wishes. See below.

## What the hook carried, and what it did not

Reused as-is: anchoring through `useDropdownDirection` with its viewport-edge flip, the portal, outside-click on mousedown, escape (configurable), the custom open event, toggle/close state.

Extended, because two things the six sites depend on did not exist:

- **A backdrop.** The hook only had a document-level `mousedown` listener. That closes the popup but does not *absorb* the click, so the click still reaches whatever sits underneath. All six render an absorbing click-catcher today, and dropping it would have been a behavior change wearing a refactor's clothes. `DropdownBackdrop` is that node, a sibling of the existing `DropdownPortal` in the same folder.
- **Named-scale z-index.** The hook hardcoded `z-50`, which is `StudioShell`'s fullscreen floor, not the popover scale. It now takes `hasBackdrop`, which lifts the popup to `z-popover` (65) and pairs it with the backdrop at `z-popover-backdrop` (55). The default is unchanged, so **none of the twenty-three existing consumers move**, and two new hook tests pin both directions.

Placement also gained a `center` alignment, because four of the six centre their panel on the trigger and the hook only knew `start` and `end`. Default stays `start`. Without it, those four would have jumped roughly half a panel width sideways, which is not something a refactor gets to do quietly.

Not carried: **focus-return**. See below.

## How SessionViewMenu's focus-return survived

`SessionViewMenu` is the only one of the six that returns focus to its trigger on escape (`e.preventDefault()`, close, `triggerRef.current?.focus()`). The hook does not do this, and teaching it to would have handed the behavior to the other five as well.

So it keeps its own escape handler verbatim and opts out of the hook's via `isEscapeEnabled: false`. Byte-identical to what it did before, and its characterization test asserts `document.activeElement` is the trigger.

**The other five did not gain focus-return.** `NeedsYouPopover` and `RunningScriptsIndicator` carry an explicit assertion that focus is *not* pulled back, so a later well-meaning change has to argue with a test.

## NotificationCenter's escape is untouched

`NotificationCenter` has no escape handling today. Adopting the hook would have handed it escape for free, and that is new behavior, not a refactor. It passes `isEscapeEnabled: false`, and a characterization test asserts the panel is still open after an escape keydown, written before the conversion and unchanged by it.

**This is a real gap, deliberately left open.** It wants its own item.

Its open-request event needed the same care: the hook's `openEvent` opens the panel, but the mark-read side effect fires only when the request finds the panel closed. That stayed a local listener, and a test pins that a second request does not mark read twice.

## z-index and docs/styling.md

`SessionViewMenu` moves from a raw `z-30`/`z-40` pair onto the named popover scale, per the design system steward's verdict.

Note this **is** a behavior change: the menu now renders above a full-page studio where it previously sat below one. It is small in practice (the studio overlay covers the trigger, so the menu cannot be opened while one is up) but it is not nothing, and it is why it is called out here rather than buried as a cleanup.

`docs/styling.md` is corrected in the same PR, in four places, because the old text goes false the moment this lands:

- The "dialog is the last resort" section cited `NeedsYouPopover` as the hand-rolled reference implementation. The mechanism now lives in the hook, so the doc points there and keeps `NeedsYouPopover` as a worked example. `WorkspaceSwitcher` stays cited as the still-hand-rolled one, since it is props-controlled and out of scope.
- The `z-popover` table row gains `SessionViewMenu`: six members become seven.
- The `z-popover-backdrop` row's prose said "six app-global popovers". Seven.
- The paragraph 24 lines below the table still named `SessionViewMenu` as an example of a control that stays on the unnamed local `z-10`..`z-40` scale. That name is removed.

## One test rewritten

`SessionViewMenu`'s z-layer characterization test asserted the raw `z-30`/`z-40` pair. That is exactly what the steward's verdict replaces, so the test was rewritten rather than deleted: it now asserts the named scale is present **and** that the raw values are gone. Stated here because a rewritten test is the usual place a behavior change hides.

No assertion anywhere else was weakened.

## The three declared behavior deltas, in one place

1. `SessionViewMenu` on the named z scale rather than raw `z-30`/`z-40`.
2. Trigger-to-panel gap goes from 6px to the hook's 4px at all six sites, and the panel is now clamped to the viewport, which the hand-rolled copies never did.
3. `SessionViewMenu` can now flip above its trigger when the space below runs out. It previously always opened downward.

## Checks

- `pnpm typecheck`: pass.
- `pnpm exec turbo run test --force`: pass, 633 files / 5279 tests, log reports `0 cached` so this is a real run and not a replayed sibling log.
- `pnpm knip --include files,duplicates,unlisted`: pass, exit 0.
