### PR TITLE
feat(desktop): show autorun stop and resume in the chat workflow header

### DIFF
--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/ChatWorkflowAdvance.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/ChatWorkflowAdvance.test.tsx
@@ -12,25 +12,24 @@ import type {
   StepId,
   Workflow,
   WorkflowId,
+  WorkflowRun,
   WorkflowRunId,
   WorkspaceId,
 } from '@goodboy/types';
-
-type StoreSession = {
-  id: string;
-  workflowRuns: ReadonlyArray<{ id: string; autoRun: boolean }>;
-};
 
 type Store = {
   sessionPhaseRuns: Record<string, ReadonlyArray<Agent>>;
   agentTurnState: Record<string, { kind: string }>;
   summarizerStatus: Record<string, { status: string }>;
-  sessions: ReadonlyArray<StoreSession>;
+  orchestratingWorkflowRuns: Record<string, boolean>;
   agentModelOverride: Record<string, string>;
   agentProviderOverride: Record<string, ProviderId>;
   agentEffortOverride: Record<string, string>;
   activateWorkflowAgent: ReturnType<typeof vi.fn>;
   skipStuckStepAndAdvance: ReturnType<typeof vi.fn>;
+  setWorkflowRunAutoRun: ReturnType<typeof vi.fn>;
+  stopWorkflowRunNow: ReturnType<typeof vi.fn>;
+  retryWorkflowOrchestration: ReturnType<typeof vi.fn>;
   emitNotification: ReturnType<typeof vi.fn>;
 };
 
@@ -39,12 +38,15 @@ const { store, gate } = vi.hoisted(() => ({
     sessionPhaseRuns: {},
     agentTurnState: {},
     summarizerStatus: {},
-    sessions: [],
+    orchestratingWorkflowRuns: {},
     agentModelOverride: {},
     agentProviderOverride: {},
     agentEffortOverride: {},
     activateWorkflowAgent: vi.fn(async () => undefined),
     skipStuckStepAndAdvance: vi.fn(async () => undefined),
+    setWorkflowRunAutoRun: vi.fn(async () => undefined),
+    stopWorkflowRunNow: vi.fn(async () => undefined),
+    retryWorkflowOrchestration: vi.fn(async () => undefined),
     emitNotification: vi.fn(async () => undefined),
   } as Store,
   gate: { hasOpenQuestions: false },
@@ -98,24 +100,37 @@ const agent = (index: number, status: Agent['status']): Agent => ({
   status,
 });
 
-const renderStrip = () =>
-  render(<ChatWorkflowAdvance sessionId={SESSION_ID} workflowRunId={RUN_ID} workflow={workflow} />);
+const buildRun = (overrides: Partial<WorkflowRun> = {}): WorkflowRun => ({
+  id: RUN_ID,
+  workflowId: WORKFLOW_ID,
+  ordinal: 0,
+  currentStep: 0,
+  autoRun: false,
+  triggerMode: 'immediate',
+  executionMode: 'static',
+  ...overrides,
+});
 
-const withAutoRun = (autoRun: boolean): ReadonlyArray<StoreSession> => [
-  { id: SESSION_ID, workflowRuns: [{ id: RUN_ID, autoRun }] },
-];
+const renderStrip = (run: WorkflowRun = buildRun()) =>
+  render(<ChatWorkflowAdvance sessionId={SESSION_ID} run={run} workflow={workflow} />);
 
 beforeEach(() => {
   store.sessionPhaseRuns = {};
   store.agentTurnState = {};
   store.summarizerStatus = {};
-  store.sessions = withAutoRun(false);
+  store.orchestratingWorkflowRuns = {};
   store.agentModelOverride = {};
   store.agentProviderOverride = {};
   store.agentEffortOverride = {};
   store.activateWorkflowAgent.mockReset();
   store.activateWorkflowAgent.mockResolvedValue(undefined);
   store.skipStuckStepAndAdvance.mockReset();
+  store.setWorkflowRunAutoRun.mockReset();
+  store.setWorkflowRunAutoRun.mockResolvedValue(undefined);
+  store.stopWorkflowRunNow.mockReset();
+  store.stopWorkflowRunNow.mockResolvedValue(undefined);
+  store.retryWorkflowOrchestration.mockReset();
+  store.retryWorkflowOrchestration.mockResolvedValue(undefined);
   store.emitNotification.mockReset();
   store.emitNotification.mockResolvedValue(undefined);
   gate.hasOpenQuestions = false;
@@ -180,18 +195,52 @@ describe('ChatWorkflowAdvance', () => {
     });
   });
 
-  it('offers no manual advance while autorun drives the run', () => {
+  it('offers a stop instead of manual advance while autorun drives the run', () => {
     store.sessionPhaseRuns = { [SESSION_ID]: [agent(0, 'completed'), agent(1, 'pending')] };
-    store.sessions = withAutoRun(true);
-    const { container } = renderStrip();
+    renderStrip(buildRun({ autoRun: true }));
 
-    expect(container.innerHTML).toBe('');
+    expect(screen.queryByTestId('workflow-next-step-cta')).toBeNull();
+    const toggle = screen.getByTestId('workflow-autorun-toggle');
+    expect(toggle.getAttribute('aria-pressed')).toBe('true');
+    expect(toggle.textContent).toMatch(/autorun/i);
+  });
+
+  it('lets autorun resume a stopped static run from the same toggle', () => {
+    store.sessionPhaseRuns = { [SESSION_ID]: [agent(0, 'completed'), agent(1, 'pending')] };
+    renderStrip(
+      buildRun({ autoRun: false, orchestrationStop: { kind: 'operator', message: 'stopped' } }),
+    );
+
+    expect(screen.queryByTestId('workflow-next-step-cta')).toBeNull();
+    expect(screen.queryByTestId('chat-workflow-orchestrator-resume')).toBeNull();
+    const toggle = screen.getByTestId('workflow-autorun-toggle');
+    expect(toggle.getAttribute('aria-pressed')).toBe('false');
+
+    fireEvent.click(toggle);
+
+    expect(store.setWorkflowRunAutoRun).toHaveBeenCalledWith(SESSION_ID, RUN_ID, true);
+  });
+
+  it('offers a dedicated resume next to the toggle for a stopped dynamic run', () => {
+    store.sessionPhaseRuns = { [SESSION_ID]: [agent(0, 'completed'), agent(1, 'pending')] };
+    renderStrip(
+      buildRun({
+        autoRun: false,
+        executionMode: 'dynamic',
+        orchestrationStop: { kind: 'operator', message: 'stopped' },
+      }),
+    );
+
+    const resume = screen.getByTestId('chat-workflow-orchestrator-resume');
+    fireEvent.click(resume);
+
+    expect(store.retryWorkflowOrchestration).toHaveBeenCalledWith(SESSION_ID, RUN_ID);
+    expect(store.setWorkflowRunAutoRun).not.toHaveBeenCalled();
   });
 
   it('keeps the skip control under autorun once a step has failed', () => {
     store.sessionPhaseRuns = { [SESSION_ID]: [agent(0, 'failed'), agent(1, 'pending')] };
-    store.sessions = withAutoRun(true);
-    renderStrip();
+    renderStrip(buildRun({ autoRun: true }));
 
     expect(screen.getByTestId('workflow-force-next-step-cta')).toBeDefined();
   });
@@ -219,7 +268,7 @@ describe('ChatWorkflowAdvance', () => {
   it('shows the routing frozen on the pending agent, not the one preferences resolve today', () => {
     store.sessionPhaseRuns = { [SESSION_ID]: [agent(0, 'completed'), agent(1, 'pending')] };
     const withoutOverride = render(
-      <ChatWorkflowAdvance sessionId={SESSION_ID} workflowRunId={RUN_ID} workflow={workflow} />,
+      <ChatWorkflowAdvance sessionId={SESSION_ID} run={buildRun()} workflow={workflow} />,
     );
     const defaultLabel = withoutOverride
       .getByTestId('workflow-next-step-cta')

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/ChatWorkflowAdvance.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/ChatWorkflowAdvance.test.tsx
@@ -205,6 +205,16 @@ describe('ChatWorkflowAdvance', () => {
     expect(toggle.textContent).toMatch(/autorun/i);
   });
 
+  it('renders no advance control of any kind while autorun drives the run', () => {
+    store.sessionPhaseRuns = { [SESSION_ID]: [agent(0, 'completed'), agent(1, 'pending')] };
+    renderStrip(buildRun({ autoRun: true }));
+
+    expect(screen.queryByTestId('workflow-next-step-cta')).toBeNull();
+    expect(screen.queryByTestId('workflow-force-next-step-cta')).toBeNull();
+    expect(screen.queryByTestId('workflow-next-step-blocked')).toBeNull();
+    expect(screen.getByTestId('workflow-autorun-toggle')).toBeDefined();
+  });
+
   it('lets autorun resume a stopped static run from the same toggle', () => {
     store.sessionPhaseRuns = { [SESSION_ID]: [agent(0, 'completed'), agent(1, 'pending')] };
     renderStrip(
@@ -236,6 +246,30 @@ describe('ChatWorkflowAdvance', () => {
 
     expect(store.retryWorkflowOrchestration).toHaveBeenCalledWith(SESSION_ID, RUN_ID);
     expect(store.setWorkflowRunAutoRun).not.toHaveBeenCalled();
+  });
+
+  it('falls through to the manual advance CTA on a provider-failure stop, same as before this PR', () => {
+    store.sessionPhaseRuns = { [SESSION_ID]: [agent(0, 'completed'), agent(1, 'pending')] };
+    renderStrip(
+      buildRun({
+        autoRun: false,
+        orchestrationStop: { kind: 'failure', message: 'provider died' },
+      }),
+    );
+
+    expect(screen.queryByTestId('workflow-autorun-toggle')).toBeNull();
+    expect(screen.queryByTestId('chat-workflow-orchestrator-resume')).toBeNull();
+    expect(screen.getByTestId('workflow-next-step-cta')).toBeDefined();
+  });
+
+  it('falls through to the manual advance CTA on a budget stop, same as before this PR', () => {
+    store.sessionPhaseRuns = { [SESSION_ID]: [agent(0, 'completed'), agent(1, 'pending')] };
+    renderStrip(
+      buildRun({ autoRun: false, orchestrationStop: { kind: 'budget', message: 'cap' } }),
+    );
+
+    expect(screen.queryByTestId('workflow-autorun-toggle')).toBeNull();
+    expect(screen.getByTestId('workflow-next-step-cta')).toBeDefined();
   });
 
   it('keeps the skip control under autorun once a step has failed', () => {

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/ChatWorkflowAdvance.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/ChatWorkflowAdvance.tsx
@@ -1,5 +1,6 @@
-import { useMemo } from 'react';
-import type { Agent, SessionId, Step, Workflow, WorkflowRunId } from '@goodboy/types';
+import { useMemo, useState } from 'react';
+import { Play } from 'lucide-react';
+import type { Agent, SessionId, Step, Workflow, WorkflowRun } from '@goodboy/types';
 import { runsForWorkflowRun } from '@goodboy/core';
 import { EMPTY_ARRAY, useAppStore, useSessionOpenQuestions } from '../../../../../store';
 import { notifyWorkflowGateBlock } from '../../../../../store/slices/workflows/notifyWorkflowGateBlock';
@@ -7,11 +8,14 @@ import { workflowRunHasOpenQuestions } from '../../../../context/openQuestionsGa
 import { agentRoutingOverrides } from '../../../../workflows/agentRoutingOverrides';
 import { resolveWorkflowAdvance } from '../../../../workflows/advanceGate';
 import { WorkflowNextStepCta } from '../../../../workflows/components/WorkflowNextStepCta';
+import { WorkflowAutorunToggle } from '../../../../workflows/components/WorkflowAutorunToggle';
+import { OrchestratorAction } from '../../../../workflows/components/OrchestratorPanel/OrchestratorAction';
+import { resolveOrchestratorState } from '../../../../workflows/components/OrchestratorPanel/orchestratorState';
 import { useSessionRoleModels } from '../../../../../shared/hooks/useSessionRoleModels';
 
 type Props = {
   readonly sessionId: SessionId;
-  readonly workflowRunId: WorkflowRunId;
+  readonly run: WorkflowRun;
   readonly workflow: Workflow;
 };
 
@@ -20,7 +24,8 @@ type AdvanceParams = {
   readonly isConfirmed: boolean;
 };
 
-export const ChatWorkflowAdvance = ({ sessionId, workflowRunId, workflow }: Props) => {
+export const ChatWorkflowAdvance = ({ sessionId, run, workflow }: Props) => {
+  const workflowRunId = run.id;
   const phaseRuns = useAppStore(
     (state) => state.sessionPhaseRuns[sessionId] ?? (EMPTY_ARRAY as ReadonlyArray<Agent>),
   );
@@ -28,16 +33,19 @@ export const ChatWorkflowAdvance = ({ sessionId, workflowRunId, workflow }: Prop
     (state) => state.summarizerStatus?.[sessionId]?.status === 'running',
   );
   const openQuestions = useSessionOpenQuestions(sessionId);
-  const isAutoRun = useAppStore(
-    (state) =>
-      state.sessions
-        .find((session) => session.id === sessionId)
-        ?.workflowRuns.find((run) => run.id === workflowRunId)?.autoRun === true,
+  const hasOpenQuestions = workflowRunHasOpenQuestions(openQuestions, workflowRunId);
+  const isAutoRun = run.autoRun === true;
+  const isOrchestrating = useAppStore(
+    (state) => state.orchestratingWorkflowRuns?.[workflowRunId] ?? false,
   );
   const roleModels = useSessionRoleModels({ sessionId });
   const activateWorkflowAgent = useAppStore((state) => state.activateWorkflowAgent);
   const skipStuckStepAndAdvance = useAppStore((state) => state.skipStuckStepAndAdvance);
+  const setWorkflowRunAutoRun = useAppStore((state) => state.setWorkflowRunAutoRun);
+  const stopWorkflowRunNow = useAppStore((state) => state.stopWorkflowRunNow);
+  const retryWorkflowOrchestration = useAppStore((state) => state.retryWorkflowOrchestration);
   const emitNotification = useAppStore((state) => state.emitNotification);
+  const [isResuming, setIsResuming] = useState(false);
 
   const stepAgents = useMemo(
     () =>
@@ -57,7 +65,7 @@ export const ChatWorkflowAdvance = ({ sessionId, workflowRunId, workflow }: Prop
   const state = resolveWorkflowAdvance({
     workflow,
     agents: stepAgents,
-    hasOpenQuestions: workflowRunHasOpenQuestions(openQuestions, workflowRunId),
+    hasOpenQuestions,
     isSummarizerRunning,
     isTurnRunning,
     isAutoRun,
@@ -80,8 +88,61 @@ export const ChatWorkflowAdvance = ({ sessionId, workflowRunId, workflow }: Prop
     providerOverride,
     effortOverride,
   });
-  if (state.kind === 'complete' || state.kind === 'automatic') {
+
+  const isOperatorStopped = isAutoRun === false && run.orchestrationStop?.kind === 'operator';
+  const showAutorunToggle = state.kind === 'automatic' || isOperatorStopped;
+  const orchestratorPhase =
+    run.executionMode === 'dynamic'
+      ? resolveOrchestratorState({
+          run,
+          agents: stepAgents,
+          isOrchestrating,
+          hasOpenQuestions,
+          costUsd: 0,
+        }).phase
+      : null;
+  const showResume = showAutorunToggle && orchestratorPhase === 'stopped';
+
+  if (state.kind === 'complete') {
     return null;
+  }
+
+  const onResume = async () => {
+    if (isResuming) {
+      return;
+    }
+    setIsResuming(true);
+    try {
+      await retryWorkflowOrchestration(sessionId, workflowRunId);
+    } finally {
+      setIsResuming(false);
+    }
+  };
+
+  if (showAutorunToggle) {
+    return (
+      <div className="ml-auto flex shrink-0 items-center gap-2">
+        {showResume ? (
+          <OrchestratorAction
+            icon={Play}
+            label="Resume the run"
+            variant="primary"
+            tone="warning"
+            testId="chat-workflow-orchestrator-resume"
+            title="Clear the stop, put autorun back on, and ask for the next step"
+            disabled={isResuming}
+            onClick={() => void onResume()}
+          />
+        ) : null}
+        <WorkflowAutorunToggle
+          variant="detail"
+          isOn={isAutoRun}
+          isStepInFlight={isOrchestrating || stepAgents.some((agent) => agent.status === 'running')}
+          onToggle={() => void setWorkflowRunAutoRun(sessionId, workflowRunId, !isAutoRun)}
+          onStopNow={() => void stopWorkflowRunNow(sessionId, workflowRunId)}
+        />
+      </div>
+    );
   }
 
   const onAdvance = async ({ step, isConfirmed }: AdvanceParams) => {

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/ChatWorkflowHeader.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/ChatWorkflowHeader.tsx
@@ -50,7 +50,7 @@ export const ChatWorkflowHeader = ({
         {attached != null && attached.run.discardedAt == null ? (
           <ChatWorkflowAdvance
             sessionId={sessionId}
-            workflowRunId={attached.run.id}
+            run={attached.run}
             workflow={attached.workflow}
           />
         ) : null}


### PR DESCRIPTION
## What changed

`ChatWorkflowAdvance` returned `null` for `state.kind === 'complete' || state.kind === 'automatic'`, so the chat header a user is actually watching during a hands-free run offered no stop control at all, only the sidebar/detail workflow rows did.

**Placement.** The `automatic` branch now renders `WorkflowAutorunToggle` (`variant="detail"`, reused unchanged) in the exact `ml-auto shrink-0` slot the manual advance CTA already occupied. `complete` still returns `null`. Breadcrumb stays left, no new row.

**After a stop.** `stopWorkflowRunNow` sets `autoRun` to `false`, which moves `advanceGate`'s `state.kind` out of `'automatic'` back to `'ready'`/`'blocked'` — so gating the toggle purely on `state.kind === 'automatic'` would make it vanish right after the stop, replaced by the CTA. The toggle's visibility is instead `state.kind === 'automatic' || (autoRun === false && run.orchestrationStop?.kind === 'operator')`, the latter being exactly the signature `stopWorkflowRunNow` leaves behind, so the toggle stays mounted reading "Autorun off" and resume is reachable in place:

- **static run**: the toggle's own click resumes it, calling `setWorkflowRunAutoRun(sessionId, workflowRunId, true)`, same as the sidebar mount.
- **dynamic run**: flipping `autoRun` does not clear the stop by itself, so a separate "Resume the run" action appears to the toggle's left, gated on `resolveOrchestratorState(...).phase === 'stopped'` (imported, not re-derived) and calling `retryWorkflowOrchestration`, same store action, label and tone as `OrchestratorPanel/index.tsx:195-206`.

`ChatWorkflowAdvance` now takes the full `run: WorkflowRun` as a prop instead of a bare `workflowRunId`, since `ChatWorkflowHeader` already has the run in scope via `attached.run` — this avoids a second store lookup for fields (`executionMode`, `orchestrationStop`, `autoRun`) the parent already holds.

## Why this doesn't violate DESIGN.md:381-387

That rule bans manual **advance** controls during autorun, on the grounds that automation is about to press the same button. A stop is not that: automation is never about to press stop. GitHub Actions, GitLab CI and CircleCI all keep cancel on the same page as the live log for the whole run, never gated on automation state. No force-complete and no immediate mid-flight hint were added; both are advance-shaped and out of scope here.

## Test rewrite

`ChatWorkflowAdvance.test.tsx`'s "offers no manual advance while autorun drives the run" asserted `container.innerHTML === ''`, which was correct for the old behavior and is now wrong: autorun renders a stop, not nothing. Renamed to "offers a stop instead of manual advance while autorun drives the run"; the advance half of the original claim survives as its own assertion (`workflow-next-step-cta` does not render), and the stop half is added (`workflow-autorun-toggle` renders, `aria-pressed="true"`). Two new cases cover the resume paths: the toggle resuming a stopped static run, and the separate action resuming a stopped dynamic run.

That surviving assertion is narrower than the one it replaced. The original asserted the absence of every element in the strip (`innerHTML === ''`), which would also have caught any other advance control someone later added inside the autorun branch. The replacement only asserts the absence of one test id (`workflow-next-step-cta`), so a second, different advance control could render alongside the toggle and this test would still pass. Two follow-up cases close both gaps: "renders no advance control of any kind while autorun drives the run" checks all three known advance test ids are absent, restoring the original assertion's strength, and two stop-kind cases ("falls through to the manual advance CTA on a provider-failure stop / a budget stop, same as before this PR") cover the negative half of the visibility rule, which previously had no test at all: only an `operator` stop was ever exercised.

## Bridge invariant

Untouched. `commandExecutor.ts:688` still pins bridge-originated workflows to `autoRun: false, triggerMode: 'manual'`; this PR touches none of that file, and `commandExecutor.commands.test.ts` stays green.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm exec turbo run test --force` — `0 cached`, 633 test files / 5269 tests passed
- [x] `pnpm knip --include files,duplicates,unlisted`

Part of #1333
