### PR TITLE
fix(ui): add draft tone, fix indigo badge contrast on dark theme

### DIFF
--- a/apps/desktop/src/features/review/components/ReviewBoardPane/DraftCard.tsx
+++ b/apps/desktop/src/features/review/components/ReviewBoardPane/DraftCard.tsx
@@ -1,8 +1,10 @@
 import { useState } from 'react';
 import { Trash2 } from 'lucide-react';
-import { Textarea, cn } from '@goodboy/ui';
+import { Textarea, cn, tintClasses } from '@goodboy/ui';
 import type { PrReviewDraft } from '@goodboy/types';
 import { ComposerActionRow } from './ComposerActionRow';
+
+const draftTint = tintClasses('draft');
 
 type Props = {
   readonly draft: PrReviewDraft;
@@ -32,7 +34,7 @@ export const DraftCard = ({ draft, onEdit, onDiscard }: Props) => {
     <div
       className={cn(
         'flex flex-col gap-1.5 rounded-md border-l-2 bg-muted/20 px-3 py-2',
-        draft.stale ? 'border-warning/70 opacity-70' : 'border-indigo-400/70',
+        draft.stale ? 'border-warning/70 opacity-70' : 'border-draft/50',
       )}
     >
       <div className="flex items-center gap-1.5">
@@ -43,7 +45,7 @@ export const DraftCard = ({ draft, onEdit, onDiscard }: Props) => {
           className={cn(
             'shrink-0 rounded-full px-1.5 py-0.5 text-3xs font-medium',
             draft.origin === 'agent'
-              ? 'bg-indigo-400/15 text-indigo-600'
+              ? cn(draftTint.bg, draftTint.text)
               : 'bg-muted text-muted-foreground',
           )}
         >

--- a/apps/desktop/src/features/review/components/ReviewBoardPane/LineComposer.tsx
+++ b/apps/desktop/src/features/review/components/ReviewBoardPane/LineComposer.tsx
@@ -1,10 +1,11 @@
 import { useState } from 'react';
 import { MessageSquarePlus } from 'lucide-react';
-import { Textarea } from '@goodboy/ui';
+import { Textarea, cn, tintClasses } from '@goodboy/ui';
 import { formatCombo } from '../../../../shared/keyboard/registry';
 import { ComposerActionRow } from './ComposerActionRow';
 
 const SUBMIT_HINT = formatCombo('cmd+Enter');
+const draftTint = tintClasses('draft');
 
 type Props = {
   readonly label: string;
@@ -17,7 +18,7 @@ export const LineComposer = ({ label, onSubmit, onCancel }: Props) => {
   const trimmed = body.trim();
   return (
     <div className="flex gap-2">
-      <MessageSquarePlus size={13} aria-hidden className="shrink-0 text-indigo-500" />
+      <MessageSquarePlus size={13} aria-hidden className={cn('shrink-0', draftTint.icon)} />
       <div className="flex min-w-0 flex-1 flex-col gap-1">
         <span className="text-3xs font-medium text-muted-foreground">{label}</span>
         <Textarea

--- a/apps/desktop/src/features/review/components/ReviewBoardPane/ReviewFileDiff.tsx
+++ b/apps/desktop/src/features/review/components/ReviewBoardPane/ReviewFileDiff.tsx
@@ -1,6 +1,6 @@
 import { Fragment, useMemo, useState } from 'react';
 import { Bot, ChevronRight, MessageSquarePlus } from 'lucide-react';
-import { Divider, EmptyState, cn } from '@goodboy/ui';
+import { Divider, EmptyState, cn, tintClasses } from '@goodboy/ui';
 import type { DiffHunkLine, FileDiff, PrReviewDraft, ReviewDraftSide } from '@goodboy/types';
 import {
   INITIAL_VISIBLE_LINES,
@@ -23,6 +23,8 @@ import type { DiffLayoutMode } from '../../../../shared/utils/diffLayoutMode';
 import { buildDiffPairRows, type DiffPairRow } from '../../../../shared/utils/diffPairRows';
 import { buildDiffRows, type DiffRow } from '../../../../shared/utils/diffRows';
 import { visibleDiffRows } from '../../../../shared/utils/visibleDiffRows';
+
+const draftTint = tintClasses('draft');
 
 export type ReviewLineTarget = {
   readonly path: string;
@@ -155,7 +157,13 @@ export const ReviewFileDiff = ({ file, layoutMode, drafts, onAddDraft, onAskAgen
             {file.path}
           </button>
           {drafts.length > 0 ? (
-            <span className="shrink-0 rounded-full bg-indigo-400/15 px-1.5 py-0.5 text-3xs font-medium text-indigo-600">
+            <span
+              className={cn(
+                'shrink-0 rounded-full px-1.5 py-0.5 text-3xs font-medium',
+                draftTint.bg,
+                draftTint.text,
+              )}
+            >
               {drafts.length} {drafts.length === 1 ? 'draft' : 'drafts'}
             </span>
           ) : null}
@@ -275,14 +283,14 @@ export const ReviewFileDiff = ({ file, layoutMode, drafts, onAddDraft, onAskAgen
                               'group',
                               line.kind === 'add' && 'bg-success/[0.07]',
                               line.kind === 'del' && 'bg-danger/[0.07]',
-                              hasDraft && 'bg-indigo-400/[0.08]',
+                              hasDraft && 'bg-draft/[0.07]',
                             )}
                           >
                             <td
                               className={cn(
                                 'w-11 select-none border-l-2 px-0.5 align-top',
                                 hasDraft
-                                  ? 'border-indigo-400/70'
+                                  ? 'border-draft/50'
                                   : line.kind === 'add'
                                     ? 'border-success/50'
                                     : line.kind === 'del'

--- a/apps/desktop/src/features/review/components/ReviewBoardPane/ReviewPairCells.tsx
+++ b/apps/desktop/src/features/review/components/ReviewBoardPane/ReviewPairCells.tsx
@@ -29,7 +29,7 @@ const sideTone = ({ line, hasDraft }: SideStateParams): string => {
     return 'bg-muted/20';
   }
   if (hasDraft) {
-    return 'bg-indigo-400/[0.08]';
+    return 'bg-draft/[0.07]';
   }
   if (line.kind === 'add') {
     return 'bg-success/[0.07]';
@@ -42,7 +42,7 @@ const sideTone = ({ line, hasDraft }: SideStateParams): string => {
 
 const sideAccent = ({ line, hasDraft }: SideStateParams): string => {
   if (hasDraft) {
-    return 'border-indigo-400/70';
+    return 'border-draft/50';
   }
   if (line?.kind === 'add') {
     return 'border-success/50';

--- a/apps/desktop/src/features/review/components/ReviewInboxList/index.tsx
+++ b/apps/desktop/src/features/review/components/ReviewInboxList/index.tsx
@@ -2,12 +2,14 @@ import { useEffect, useMemo } from 'react';
 import {
   Button,
   Chip,
+  cn,
   Divider,
   EmptyState,
   Eyebrow,
   ScrollFade,
   SelectableRow,
   Skeleton,
+  tintClasses,
 } from '@goodboy/ui';
 import type { ReviewablePr, ReviewablePrProvider, WorkspaceId } from '@goodboy/types';
 import { useAppStore } from '../../../../store';
@@ -18,6 +20,8 @@ import { PullRequestChip } from '../../../github/components/PullRequestChip';
 import { NoteAvatar } from '../../../../shared/components/NoteAvatar';
 import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../shared/components/conceptIcons';
 import { buildReviewInboxRows, type ReviewInboxScope } from './buildReviewInboxRows';
+
+const draftTint = tintClasses('draft');
 
 type Props = {
   readonly workspaceId: WorkspaceId;
@@ -169,7 +173,14 @@ export const ReviewInboxList = ({ workspaceId, provider, scope, focusedPrId, onS
                         </span>
                       ) : null}
                       {pr.reviewRequested ? (
-                        <span className="shrink-0 rounded-full bg-indigo-400/15 px-1.5 py-0.5 text-3xs font-semibold text-indigo-600 ring-1 ring-indigo-400/30">
+                        <span
+                          className={cn(
+                            'shrink-0 rounded-full px-1.5 py-0.5 text-3xs font-semibold ring-1',
+                            draftTint.bg,
+                            draftTint.text,
+                            draftTint.ring,
+                          )}
+                        >
                           Review requested
                         </span>
                       ) : null}

--- a/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.tsx
@@ -9,7 +9,7 @@ import {
   SquareTerminal,
   Trash2,
 } from 'lucide-react';
-import { Chip, cn, formatUsd, Tooltip } from '@goodboy/ui';
+import { Chip, cn, formatUsd, tintClasses, Tooltip } from '@goodboy/ui';
 import type { Session, SessionId } from '@goodboy/types';
 import {
   EMPTY_ARRAY,
@@ -28,6 +28,8 @@ import { CardActionSlot } from '../../../../../shared/components/CardActionSlot'
 import type { BoardNavigation } from '../useBoardNavigation';
 import { getLinkedRequest } from './getLinkedRequest';
 import { useDynamicActions } from './useDynamicActions';
+
+const draftTint = tintClasses('draft');
 
 export type CardSelectionEvent = {
   readonly shiftKey: boolean;
@@ -185,7 +187,13 @@ export const StageBoardCard = memo(function StageBoardCard({
             </Tooltip>
           )}
           {reviewDraftCount > 0 && (
-            <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-indigo-400/15 px-1.5 py-0.5 text-3xs font-medium text-indigo-600">
+            <span
+              className={cn(
+                'inline-flex shrink-0 items-center gap-1 rounded-full px-1.5 py-0.5 text-3xs font-medium',
+                draftTint.bg,
+                draftTint.text,
+              )}
+            >
               <MessageSquareDiff size={10} aria-hidden />
               <span className="tabular-nums">{reviewDraftCount}</span>
               <span>draft {reviewDraftCount === 1 ? 'comment' : 'comments'}</span>

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -35,6 +35,8 @@
   --color-accent-foreground: oklch(0.15 0.02 200);
   --color-merged: oklch(0.7 0.15 305);
   --color-merged-foreground: oklch(0.15 0.02 305);
+  --color-draft: oklch(0.7 0.14 277);
+  --color-draft-foreground: oklch(0.15 0.02 277);
 
   /* Per-provider accent. */
   --color-provider-anthropic: oklch(0.74 0.15 55);
@@ -282,6 +284,8 @@ html[data-theme='light'] {
   --color-accent-foreground: oklch(0.99 0.003 200);
   --color-merged: oklch(0.5 0.18 305);
   --color-merged-foreground: oklch(0.99 0.003 305);
+  --color-draft: oklch(0.5 0.17 277);
+  --color-draft-foreground: oklch(0.99 0.003 277);
   --color-provider-anthropic: oklch(0.54 0.16 55);
   --color-provider-cursor: oklch(0.5 0.17 290);
   --color-provider-codex: oklch(0.48 0.15 148);

--- a/packages/ui/src/__tests__/tint.test.ts
+++ b/packages/ui/src/__tests__/tint.test.ts
@@ -9,6 +9,7 @@ const SEMANTIC_TONES: ReadonlyArray<Tone> = [
   'primary',
   'accent',
   'merged',
+  'draft',
 ];
 
 describe('tintClasses', () => {
@@ -29,6 +30,28 @@ describe('tintClasses', () => {
       border: 'border-primary/20',
       bg: 'bg-muted/30',
       icon: 'text-primary/60',
+    });
+  });
+
+  it('pins draft to the SEMANTIC_TONES coverage list', () => {
+    expect(SEMANTIC_TONES).toContain('draft');
+  });
+
+  it('exposes a draft tone bound to the draft token, not indigo hardcodes', () => {
+    expect(tintClasses('draft')).toMatchObject({
+      bg: 'bg-draft/10',
+      bgSoft: 'bg-draft/5',
+      ring: 'ring-draft/20',
+      border: 'border-draft/40',
+      borderSoft: 'border-draft/20',
+      hoverBorder: 'hover:border-draft/40',
+      hoverBg: 'hover:bg-draft/20',
+      hoverBgSoft: 'hover:bg-draft/5',
+      hoverText: 'hover:text-draft',
+      text: 'text-draft',
+      icon: 'text-draft',
+      dot: 'bg-draft',
+      solid: 'bg-draft text-draft-foreground',
     });
   });
 });

--- a/packages/ui/src/components/Chip.tsx
+++ b/packages/ui/src/components/Chip.tsx
@@ -41,6 +41,7 @@ const strongRing: Record<Tone, string> = {
   primary: 'ring-primary/40',
   accent: 'ring-accent/40',
   merged: 'ring-merged/40',
+  draft: 'ring-draft/40',
   operations: 'ring-primary/40',
   neutral: 'ring-border-soft',
 };

--- a/packages/ui/src/tint.ts
+++ b/packages/ui/src/tint.ts
@@ -6,6 +6,7 @@ export type Tone =
   | 'primary'
   | 'accent'
   | 'merged'
+  | 'draft'
   | 'operations'
   | 'neutral';
 
@@ -130,6 +131,21 @@ const TINT: Record<Tone, TintClasses> = {
     icon: 'text-merged',
     dot: 'bg-merged',
     solid: 'bg-merged text-merged-foreground',
+  },
+  draft: {
+    bg: 'bg-draft/10',
+    bgSoft: 'bg-draft/5',
+    ring: 'ring-draft/20',
+    border: 'border-draft/40',
+    borderSoft: 'border-draft/20',
+    hoverBorder: 'hover:border-draft/40',
+    hoverBg: 'hover:bg-draft/20',
+    hoverBgSoft: 'hover:bg-draft/5',
+    hoverText: 'hover:text-draft',
+    text: 'text-draft',
+    icon: 'text-draft',
+    dot: 'bg-draft',
+    solid: 'bg-draft text-draft-foreground',
   },
   operations: {
     bg: 'bg-muted/30',


### PR DESCRIPTION
## What

draft-comment badges across the review surfaces hand-rolled `indigo-400`/`indigo-600` Tailwind classes instead of going through the shared `tintClasses` token layer, and the dark-theme text computed to **2.54:1** against the dark background, failing WCAG AA at any size. Light theme was fine at **4.89:1**. Method: OKLCH to linear-sRGB via the standard Oklab matrices, then WCAG relative luminance and contrast ratio on the linear values, cross-checked against Tailwind's `indigo-600` hex (`#4f46e5`) for the pre-existing hardcode. Independently reproduced both numbers above and the post-fix numbers below.

## The fix: a tenth tone, `draft`, hue 277

Hue 277 is indigo-600's own oklch hue, sitting in the 67-degree gap between `info` (238) and `merged` (305). Added to `packages/ui/src/tint.ts` and to both theme blocks of `apps/desktop/src/styles.css` (kept byte-position-symmetric with `merged`/`merged-foreground`, directly above them, in both blocks):

| | value | contrast |
| - | ----- | -------- |
| dark | `oklch(0.70 0.14 277)` | **5.82:1** against dark bg |
| light | `oklch(0.50 0.17 277)` | **4.93:1** against light bg |
| foreground, dark | `oklch(0.15 0.02 277)` | mirrors `merged`/`accent` |
| foreground, light | `oklch(0.99 0.003 277)` | same |

Both clear AA with margins comparable to sibling tones.

**Why not an existing tone**: `info` clashes with `StageBoardCard`'s running-stage border and `ReviewFileDiff`'s diff-icon tone; `merged` clashes with `PullRequestChip`'s merged-state chip in the same `ReviewInboxList` row (a draft is precisely not merged); `success`/`danger` clash with the add/delete row backgrounds in `ReviewFileDiff`; `primary`, `accent` and `warning` each fail AA outright in one theme.

## SEMANTIC_TONES

`packages/ui/src/__tests__/tint.test.ts` pins tone coverage with a hardcoded `SEMANTIC_TONES` array that the opacity-scale test iterates. Added `draft` to it, plus two dedicated tests: one asserting the array still contains `draft`, one asserting `tintClasses('draft')` still resolves to the expected class strings. Either dropped tone or dropped array entry now fails a test.

## Twelve literal call sites collapsed onto `tintClasses('draft')`

`StageBoardCard/index.tsx:188`, `ReviewFileDiff.tsx:158,278,285`, `DraftCard.tsx:35,46`, `ReviewInboxList/index.tsx:172`, `ReviewPairCells.tsx:32,45`, `LineComposer.tsx:20`.

`grep -rn "indigo" --include="*.tsx" --include="*.ts" apps packages` after the change: the only survivor is `apps/desktop/src/features/session/agent-kind.ts:166-167`, out of scope (pr-reviewer agent-kind categorization, a different concern).

`packages/ui/src/components/Chip.tsx` needed the same one-line addition to its own `Record<Tone, string>` ring map to keep `tsc` green; not in the original footprint but required by the `Tone` union change.

## Deliberate opacity drift (not canonicalized)

- Accent borders at `/70` (`DraftCard.tsx:35`, `ReviewFileDiff.tsx:285`, `ReviewPairCells.tsx:45`) now match the `/50` add/delete sibling borders in the same files, not `tint.ts`'s canonical `/40` — a framed surface reads differently from an accent bar.
- Backgrounds at `/[0.08]` (`ReviewFileDiff.tsx:278`, `ReviewPairCells.tsx:32`) now match the `/[0.07]` add/delete siblings in the same files.
- Ring at `/30` (`ReviewInboxList/index.tsx:172`) moved onto `tint.ts`'s canonical `/20`, since no sibling motivated keeping it off-scale.
- `LineComposer.tsx:20` was `indigo-500` (not `600`, shade drift on top of the theme bug) and now uses the token's icon class directly.

## Tests

- `pnpm typecheck`: pass
- `pnpm exec turbo run test --force`: pass, `Cached: 0 cached, 4 total` (confirmed fresh, not a replayed sibling-worktree log); `tint.test.ts` 11/11; `packages/db/src/migrations/registry.test.ts` passed on the first run
- `pnpm knip --include files,duplicates,unlisted`: clean