### PR TITLE
fix(desktop): confirm disconnects, autorun label, honest tooltip

### DIFF
--- a/apps/desktop/src/features/integrations/bitbucket/BitbucketFormBody.test.tsx
+++ b/apps/desktop/src/features/integrations/bitbucket/BitbucketFormBody.test.tsx
@@ -101,9 +101,17 @@ describe('BitbucketFormBody', () => {
       expect(screen.queryByRole('button', { name: /^connect$/i })).toBeNull();
     });
 
-    it('disconnects Bitbucket for the workspace', () => {
+    it('arms the disconnect confirm instead of disconnecting immediately', () => {
       render(<BitbucketFormBody workspaceId={WS_ID} />);
       fireEvent.click(screen.getByRole('button', { name: /^disconnect$/i }));
+      expect(screen.getByText(/Disconnect Bitbucket\?/i)).toBeDefined();
+      expect(state.disconnectBitbucket).not.toHaveBeenCalled();
+    });
+
+    it('disconnects Bitbucket for the workspace once the confirm is confirmed', () => {
+      render(<BitbucketFormBody workspaceId={WS_ID} />);
+      fireEvent.click(screen.getByRole('button', { name: /^disconnect$/i }));
+      fireEvent.click(screen.getByRole('button', { name: /^disconnect bitbucket$/i }));
       expect(state.disconnectBitbucket).toHaveBeenCalledWith({ workspaceId: WS_ID });
     });
   });

--- a/apps/desktop/src/features/integrations/bitbucket/BitbucketFormBody.tsx
+++ b/apps/desktop/src/features/integrations/bitbucket/BitbucketFormBody.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import type { BitbucketWorkspaceIntegration, WorkspaceId } from '@goodboy/types';
-import { Button, Input } from '@goodboy/ui';
+import { Button, InlineConfirm, Input } from '@goodboy/ui';
 import { CheckCircle2, ExternalLink, Unplug } from 'lucide-react';
 import { useAppStore } from '../../../store';
 import { formatError } from '../../../shared/lib/errors';
@@ -32,6 +32,7 @@ export const BitbucketFormBody = ({ workspaceId, onConnected, shouldAutoFocus = 
   const [apiToken, setApiToken] = useState('');
   const [isBusy, setIsBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [isDisconnectArmed, setIsDisconnectArmed] = useState(false);
 
   const normalizedSlug = normalizeWorkspaceSlug({ input: workspaceSlug });
   const trimmedEmail = email.trim();
@@ -83,10 +84,28 @@ export const BitbucketFormBody = ({ workspaceId, onConnected, shouldAutoFocus = 
             <dt className="text-muted-foreground">account</dt>
             <dd className="font-mono text-foreground">{bitbucket.config.email}</dd>
           </dl>
-          <Button variant="danger" size="sm" onClick={() => void onDisconnect()} disabled={isBusy}>
-            <Unplug size={12} aria-hidden />
-            {isBusy ? 'Disconnecting…' : 'Disconnect'}
-          </Button>
+          {isDisconnectArmed ? (
+            <InlineConfirm
+              role="danger"
+              icon={<Unplug size={12} aria-hidden />}
+              title="Disconnect Bitbucket?"
+              description="Deletes the saved Bitbucket API token from your keychain and forgets this workspace's connection. Reconnect anytime."
+              confirmLabel="Disconnect Bitbucket"
+              autoDisarmMs={4000}
+              onConfirm={onDisconnect}
+              onCancel={() => setIsDisconnectArmed(false)}
+            />
+          ) : (
+            <Button
+              variant="danger"
+              size="sm"
+              onClick={() => setIsDisconnectArmed(true)}
+              disabled={isBusy}
+            >
+              <Unplug size={12} aria-hidden />
+              Disconnect
+            </Button>
+          )}
         </div>
       ) : (
         <>

--- a/apps/desktop/src/features/integrations/github/GithubFormBody.test.tsx
+++ b/apps/desktop/src/features/integrations/github/GithubFormBody.test.tsx
@@ -161,9 +161,17 @@ describe('GithubFormBody', () => {
       expect(screen.queryByRole('button', { name: /^connect$/i })).toBeNull();
     });
 
-    it('clears the token for the workspace on Disconnect', async () => {
+    it('arms the disconnect confirm instead of clearing the token immediately', async () => {
       render(<GithubFormBody workspaceId={WS_ID} />);
       fireEvent.click(await screen.findByRole('button', { name: /^disconnect$/i }));
+      expect(await screen.findByText(/Disconnect GitHub\?/i)).toBeDefined();
+      expect(ghClearTokenMock).not.toHaveBeenCalled();
+    });
+
+    it('clears the token for the workspace once the confirm is confirmed', async () => {
+      render(<GithubFormBody workspaceId={WS_ID} />);
+      fireEvent.click(await screen.findByRole('button', { name: /^disconnect$/i }));
+      fireEvent.click(await screen.findByRole('button', { name: /^disconnect github$/i }));
       await waitFor(() => expect(ghClearTokenMock).toHaveBeenCalledWith(WS_ID));
     });
   });

--- a/apps/desktop/src/features/integrations/github/GithubFormBody.tsx
+++ b/apps/desktop/src/features/integrations/github/GithubFormBody.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import { Button, Input } from '@goodboy/ui';
+import { Button, InlineConfirm, Input } from '@goodboy/ui';
 import { CheckCircle2, Unplug } from 'lucide-react';
 import type { GhTokenStatus, WorkspaceId } from '@goodboy/types';
 import { ghClearToken, ghSetToken, ghStatus } from '../../github/github';
@@ -18,6 +18,7 @@ export const GithubFormBody = ({ workspaceId, onConnected, shouldAutoFocus = fal
   const [token, setToken] = useState('');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [isDisconnectArmed, setIsDisconnectArmed] = useState(false);
 
   const refresh = useCallback(async () => {
     try {
@@ -74,10 +75,28 @@ export const GithubFormBody = ({ workspaceId, onConnected, shouldAutoFocus = fal
           <p className="text-2xs leading-relaxed text-muted-foreground">
             This workspace uses its own token for every gh call.
           </p>
-          <Button variant="danger" size="sm" onClick={() => void onDisconnect()} disabled={busy}>
-            <Unplug size={12} aria-hidden />
-            {busy ? 'Disconnecting…' : 'Disconnect'}
-          </Button>
+          {isDisconnectArmed ? (
+            <InlineConfirm
+              role="danger"
+              icon={<Unplug size={12} aria-hidden />}
+              title="Disconnect GitHub?"
+              description="Deletes this workspace's GitHub token from your keychain. This does not sign you out of the system gh CLI."
+              confirmLabel="Disconnect GitHub"
+              autoDisarmMs={4000}
+              onConfirm={onDisconnect}
+              onCancel={() => setIsDisconnectArmed(false)}
+            />
+          ) : (
+            <Button
+              variant="danger"
+              size="sm"
+              onClick={() => setIsDisconnectArmed(true)}
+              disabled={busy}
+            >
+              <Unplug size={12} aria-hidden />
+              Disconnect
+            </Button>
+          )}
         </div>
       ) : (
         <>

--- a/apps/desktop/src/features/integrations/gitlab/GitlabFormBody.test.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabFormBody.test.tsx
@@ -130,9 +130,17 @@ describe('GitlabFormBody', () => {
       expect(screen.queryByRole('button', { name: /^connect$/i })).toBeNull();
     });
 
-    it('disconnects GitLab for the workspace', async () => {
+    it('arms the disconnect confirm instead of disconnecting immediately', async () => {
       render(<GitlabFormBody workspaceId={WS_ID} />);
       fireEvent.click(await screen.findByRole('button', { name: /^disconnect$/i }));
+      expect(await screen.findByText(/Disconnect GitLab\?/i)).toBeDefined();
+      expect(state.disconnectGitlab).not.toHaveBeenCalled();
+    });
+
+    it('disconnects GitLab for the workspace once the confirm is confirmed', async () => {
+      render(<GitlabFormBody workspaceId={WS_ID} />);
+      fireEvent.click(await screen.findByRole('button', { name: /^disconnect$/i }));
+      fireEvent.click(await screen.findByRole('button', { name: /^disconnect gitlab$/i }));
       expect(state.disconnectGitlab).toHaveBeenCalledWith(WS_ID);
     });
   });

--- a/apps/desktop/src/features/integrations/gitlab/GitlabFormBody.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabFormBody.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import type { GitlabWorkspaceIntegration, WorkspaceId } from '@goodboy/types';
-import { Button, Input } from '@goodboy/ui';
+import { Button, InlineConfirm, Input } from '@goodboy/ui';
 import { CheckCircle2, ExternalLink, Unplug } from 'lucide-react';
 import { useAppStore } from '../../../store';
 import { formatError } from '../../../shared/lib/errors';
@@ -43,6 +43,7 @@ export const GitlabFormBody = ({ workspaceId, onConnected, shouldAutoFocus = fal
   const [token, setToken] = useState('');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [isDisconnectArmed, setIsDisconnectArmed] = useState(false);
 
   const onConnect = async () => {
     setBusy(true);
@@ -84,10 +85,28 @@ export const GitlabFormBody = ({ workspaceId, onConnected, shouldAutoFocus = fal
             <dt className="text-muted-foreground">host</dt>
             <dd className="font-mono text-foreground">{config.host}</dd>
           </dl>
-          <Button variant="danger" size="sm" onClick={() => void onDisconnect()} disabled={busy}>
-            <Unplug size={12} aria-hidden />
-            {busy ? 'Disconnecting…' : 'Disconnect'}
-          </Button>
+          {isDisconnectArmed ? (
+            <InlineConfirm
+              role="danger"
+              icon={<Unplug size={12} aria-hidden />}
+              title="Disconnect GitLab?"
+              description="Deletes the saved GitLab token from your keychain and forgets this workspace's connection. Reconnect anytime."
+              confirmLabel="Disconnect GitLab"
+              autoDisarmMs={4000}
+              onConfirm={onDisconnect}
+              onCancel={() => setIsDisconnectArmed(false)}
+            />
+          ) : (
+            <Button
+              variant="danger"
+              size="sm"
+              onClick={() => setIsDisconnectArmed(true)}
+              disabled={busy}
+            >
+              <Unplug size={12} aria-hidden />
+              Disconnect
+            </Button>
+          )}
         </div>
       ) : (
         <>

--- a/apps/desktop/src/features/integrations/jira/JiraFormBody.test.tsx
+++ b/apps/desktop/src/features/integrations/jira/JiraFormBody.test.tsx
@@ -104,9 +104,17 @@ describe('JiraFormBody', () => {
       expect(screen.queryByRole('button', { name: /^connect$/i })).toBeNull();
     });
 
-    it('disconnects Jira for the workspace', () => {
+    it('arms the disconnect confirm instead of disconnecting immediately', () => {
       render(<JiraFormBody workspaceId={WS_ID} />);
       fireEvent.click(screen.getByRole('button', { name: /^disconnect$/i }));
+      expect(screen.getByText(/Disconnect Jira\?/i)).toBeDefined();
+      expect(state.disconnectJira).not.toHaveBeenCalled();
+    });
+
+    it('disconnects Jira for the workspace once the confirm is confirmed', () => {
+      render(<JiraFormBody workspaceId={WS_ID} />);
+      fireEvent.click(screen.getByRole('button', { name: /^disconnect$/i }));
+      fireEvent.click(screen.getByRole('button', { name: /^disconnect jira$/i }));
       expect(state.disconnectJira).toHaveBeenCalledWith({ workspaceId: WS_ID });
     });
   });

--- a/apps/desktop/src/features/integrations/jira/JiraFormBody.tsx
+++ b/apps/desktop/src/features/integrations/jira/JiraFormBody.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import type { JiraWorkspaceIntegration, WorkspaceId } from '@goodboy/types';
-import { Button, Input } from '@goodboy/ui';
+import { Button, InlineConfirm, Input } from '@goodboy/ui';
 import { CheckCircle2, ExternalLink, Unplug } from 'lucide-react';
 import { useAppStore } from '../../../store';
 import { formatError } from '../../../shared/lib/errors';
@@ -32,6 +32,7 @@ export const JiraFormBody = ({ workspaceId, onConnected, shouldAutoFocus = false
   const [apiToken, setApiToken] = useState('');
   const [isBusy, setIsBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [isDisconnectArmed, setIsDisconnectArmed] = useState(false);
 
   const normalizedSiteUrl = normalizeSiteUrl({ input: siteUrl });
   const trimmedEmail = email.trim();
@@ -89,10 +90,28 @@ export const JiraFormBody = ({ workspaceId, onConnected, shouldAutoFocus = false
             <dt className="text-muted-foreground">project</dt>
             <dd className="font-mono text-foreground">{jira.config.projectKey}</dd>
           </dl>
-          <Button variant="danger" size="sm" onClick={() => void onDisconnect()} disabled={isBusy}>
-            <Unplug size={12} aria-hidden />
-            {isBusy ? 'Disconnecting…' : 'Disconnect'}
-          </Button>
+          {isDisconnectArmed ? (
+            <InlineConfirm
+              role="danger"
+              icon={<Unplug size={12} aria-hidden />}
+              title="Disconnect Jira?"
+              description="Deletes the saved Jira API token from your keychain and forgets this workspace's connection. Reconnect anytime."
+              confirmLabel="Disconnect Jira"
+              autoDisarmMs={4000}
+              onConfirm={onDisconnect}
+              onCancel={() => setIsDisconnectArmed(false)}
+            />
+          ) : (
+            <Button
+              variant="danger"
+              size="sm"
+              onClick={() => setIsDisconnectArmed(true)}
+              disabled={isBusy}
+            >
+              <Unplug size={12} aria-hidden />
+              Disconnect
+            </Button>
+          )}
         </div>
       ) : (
         <>

--- a/apps/desktop/src/features/integrations/linear/LinearFormBody.test.tsx
+++ b/apps/desktop/src/features/integrations/linear/LinearFormBody.test.tsx
@@ -87,9 +87,17 @@ describe('LinearFormBody', () => {
       expect(screen.queryByRole('button', { name: /^connect$/i })).toBeNull();
     });
 
-    it('disconnects Linear for the workspace', () => {
+    it('arms the disconnect confirm instead of disconnecting immediately', () => {
       render(<LinearFormBody workspaceId={WS_ID} />);
       fireEvent.click(screen.getByRole('button', { name: /^disconnect$/i }));
+      expect(screen.getByText(/Disconnect Linear\?/i)).toBeDefined();
+      expect(state.disconnectLinear).not.toHaveBeenCalled();
+    });
+
+    it('disconnects Linear for the workspace once the confirm is confirmed', () => {
+      render(<LinearFormBody workspaceId={WS_ID} />);
+      fireEvent.click(screen.getByRole('button', { name: /^disconnect$/i }));
+      fireEvent.click(screen.getByRole('button', { name: /^disconnect linear$/i }));
       expect(state.disconnectLinear).toHaveBeenCalledWith(WS_ID);
     });
   });

--- a/apps/desktop/src/features/integrations/linear/LinearFormBody.tsx
+++ b/apps/desktop/src/features/integrations/linear/LinearFormBody.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import type { LinearIntegrationConfig, WorkspaceId } from '@goodboy/types';
-import { Button, Input } from '@goodboy/ui';
+import { Button, InlineConfirm, Input } from '@goodboy/ui';
 import { CheckCircle2, ExternalLink, Unplug } from 'lucide-react';
 import { useAppStore } from '../../../store';
 import { formatError } from '../../../shared/lib/errors';
@@ -22,6 +22,7 @@ export const LinearFormBody = ({ workspaceId, onConnected, shouldAutoFocus = fal
   const [token, setToken] = useState('');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [isDisconnectArmed, setIsDisconnectArmed] = useState(false);
 
   const onConnect = async () => {
     setBusy(true);
@@ -63,10 +64,28 @@ export const LinearFormBody = ({ workspaceId, onConnected, shouldAutoFocus = fal
               linear.app/{linearConfig?.workspaceUrlKey}
             </dd>
           </dl>
-          <Button variant="danger" size="sm" onClick={() => void onDisconnect()} disabled={busy}>
-            <Unplug size={12} aria-hidden />
-            {busy ? 'Disconnecting…' : 'Disconnect'}
-          </Button>
+          {isDisconnectArmed ? (
+            <InlineConfirm
+              role="danger"
+              icon={<Unplug size={12} aria-hidden />}
+              title="Disconnect Linear?"
+              description="Deletes the saved Linear token from your keychain and forgets this workspace's connection. Reconnect anytime."
+              confirmLabel="Disconnect Linear"
+              autoDisarmMs={4000}
+              onConfirm={onDisconnect}
+              onCancel={() => setIsDisconnectArmed(false)}
+            />
+          ) : (
+            <Button
+              variant="danger"
+              size="sm"
+              onClick={() => setIsDisconnectArmed(true)}
+              disabled={busy}
+            >
+              <Unplug size={12} aria-hidden />
+              Disconnect
+            </Button>
+          )}
         </div>
       ) : (
         <>

--- a/apps/desktop/src/features/integrations/sentry/SentryFormBody.test.tsx
+++ b/apps/desktop/src/features/integrations/sentry/SentryFormBody.test.tsx
@@ -94,9 +94,17 @@ describe('SentryFormBody', () => {
       expect(screen.queryByRole('button', { name: /^connect$/i })).toBeNull();
     });
 
-    it('disconnects Sentry for the workspace', () => {
+    it('arms the disconnect confirm instead of disconnecting immediately', () => {
       render(<SentryFormBody workspaceId={WS_ID} />);
       fireEvent.click(screen.getByRole('button', { name: /^disconnect$/i }));
+      expect(screen.getByText(/Disconnect Sentry\?/i)).toBeDefined();
+      expect(state.disconnectSentry).not.toHaveBeenCalled();
+    });
+
+    it('disconnects Sentry for the workspace once the confirm is confirmed', () => {
+      render(<SentryFormBody workspaceId={WS_ID} />);
+      fireEvent.click(screen.getByRole('button', { name: /^disconnect$/i }));
+      fireEvent.click(screen.getByRole('button', { name: /^disconnect sentry$/i }));
       expect(state.disconnectSentry).toHaveBeenCalledWith(WS_ID);
     });
   });

--- a/apps/desktop/src/features/integrations/sentry/SentryFormBody.tsx
+++ b/apps/desktop/src/features/integrations/sentry/SentryFormBody.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import type { SentryIntegrationConfig, WorkspaceId } from '@goodboy/types';
-import { Button, Input } from '@goodboy/ui';
+import { Button, InlineConfirm, Input } from '@goodboy/ui';
 import { CheckCircle2, ExternalLink, Unplug } from 'lucide-react';
 import { useAppStore } from '../../../store';
 import { formatError } from '../../../shared/lib/errors';
@@ -24,6 +24,7 @@ export const SentryFormBody = ({ workspaceId, onConnected, shouldAutoFocus = fal
   const [project, setProject] = useState('');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [isDisconnectArmed, setIsDisconnectArmed] = useState(false);
 
   const onConnect = async () => {
     setBusy(true);
@@ -69,10 +70,28 @@ export const SentryFormBody = ({ workspaceId, onConnected, shouldAutoFocus = fal
             <dt className="text-muted-foreground">project</dt>
             <dd className="font-mono text-foreground">{sentryConfig.project}</dd>
           </dl>
-          <Button variant="danger" size="sm" onClick={() => void onDisconnect()} disabled={busy}>
-            <Unplug size={12} aria-hidden />
-            {busy ? 'Disconnecting…' : 'Disconnect'}
-          </Button>
+          {isDisconnectArmed ? (
+            <InlineConfirm
+              role="danger"
+              icon={<Unplug size={12} aria-hidden />}
+              title="Disconnect Sentry?"
+              description="Deletes the saved Sentry token from your keychain and forgets this workspace's connection. Reconnect anytime."
+              confirmLabel="Disconnect Sentry"
+              autoDisarmMs={4000}
+              onConfirm={onDisconnect}
+              onCancel={() => setIsDisconnectArmed(false)}
+            />
+          ) : (
+            <Button
+              variant="danger"
+              size="sm"
+              onClick={() => setIsDisconnectArmed(true)}
+              disabled={busy}
+            >
+              <Unplug size={12} aria-hidden />
+              Disconnect
+            </Button>
+          )}
         </div>
       ) : (
         <>

--- a/apps/desktop/src/features/integrations/slack/SlackFormBody.test.tsx
+++ b/apps/desktop/src/features/integrations/slack/SlackFormBody.test.tsx
@@ -101,9 +101,17 @@ describe('SlackFormBody', () => {
       expect(screen.queryByRole('button', { name: /^connect$/i })).toBeNull();
     });
 
-    it('disconnects Slack for the workspace', () => {
+    it('arms the disconnect confirm instead of disconnecting immediately', () => {
       render(<SlackFormBody workspaceId={WS_ID} />);
       fireEvent.click(screen.getByRole('button', { name: /^disconnect$/i }));
+      expect(screen.getByText(/Disconnect Slack\?/i)).toBeDefined();
+      expect(state.disconnectSlack).not.toHaveBeenCalled();
+    });
+
+    it('disconnects Slack for the workspace once the confirm is confirmed', () => {
+      render(<SlackFormBody workspaceId={WS_ID} />);
+      fireEvent.click(screen.getByRole('button', { name: /^disconnect$/i }));
+      fireEvent.click(screen.getByRole('button', { name: /^disconnect slack$/i }));
       expect(state.disconnectSlack).toHaveBeenCalledWith({ workspaceId: WS_ID });
     });
   });

--- a/apps/desktop/src/features/integrations/slack/SlackFormBody.tsx
+++ b/apps/desktop/src/features/integrations/slack/SlackFormBody.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import type { SlackWorkspaceIntegration, WorkspaceId } from '@goodboy/types';
-import { Button, Input } from '@goodboy/ui';
+import { Button, InlineConfirm, Input } from '@goodboy/ui';
 import { CheckCircle2, ExternalLink, Unplug } from 'lucide-react';
 import { useAppStore } from '../../../store';
 import { formatError } from '../../../shared/lib/errors';
@@ -30,6 +30,7 @@ export const SlackFormBody = ({ workspaceId, onConnected, shouldAutoFocus = fals
   const [botToken, setBotToken] = useState('');
   const [isBusy, setIsBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [isDisconnectArmed, setIsDisconnectArmed] = useState(false);
 
   const trimmedToken = botToken.trim();
   const canConnect = trimmedToken !== '';
@@ -76,10 +77,28 @@ export const SlackFormBody = ({ workspaceId, onConnected, shouldAutoFocus = fals
               {slack.config.botUserName ?? slack.config.botUserId}
             </dd>
           </dl>
-          <Button variant="danger" size="sm" onClick={() => void onDisconnect()} disabled={isBusy}>
-            <Unplug size={12} aria-hidden />
-            {isBusy ? 'Disconnecting…' : 'Disconnect'}
-          </Button>
+          {isDisconnectArmed ? (
+            <InlineConfirm
+              role="danger"
+              icon={<Unplug size={12} aria-hidden />}
+              title="Disconnect Slack?"
+              description="Deletes the saved Slack bot token from your keychain and forgets this workspace's connection. Reconnect anytime."
+              confirmLabel="Disconnect Slack"
+              autoDisarmMs={4000}
+              onConfirm={onDisconnect}
+              onCancel={() => setIsDisconnectArmed(false)}
+            />
+          ) : (
+            <Button
+              variant="danger"
+              size="sm"
+              onClick={() => setIsDisconnectArmed(true)}
+              disabled={isBusy}
+            >
+              <Unplug size={12} aria-hidden />
+              Disconnect
+            </Button>
+          )}
         </div>
       ) : (
         <>

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/HeaderBand.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/HeaderBand.test.tsx
@@ -1,0 +1,113 @@
+// @vitest-environment happy-dom
+
+import type { ReactElement, ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import type { Session, SessionId, SessionStageInfo } from '@goodboy/types';
+
+type Store = {
+  sessions: ReadonlyArray<Session>;
+  workspaces: ReadonlyArray<unknown>;
+  sessionBranches: Record<string, string>;
+  sessionWorktrees: Record<string, ReadonlyArray<string>>;
+  sessionMounts: Record<string, ReadonlyArray<never>>;
+  sessionActiveMount: Record<string, string>;
+  sessionGithub: Record<string, { pr?: unknown; linkedIssues?: ReadonlyArray<unknown> }>;
+  sessionGitlabMr: Record<string, { mr?: unknown }>;
+  sessionExternalTasks: Record<string, ReadonlyArray<unknown>>;
+  sessionPhaseRuns: Record<string, ReadonlyArray<unknown>>;
+  markAllAgentsSeen: ReturnType<typeof vi.fn>;
+  renameTask: ReturnType<typeof vi.fn>;
+};
+
+const { store } = vi.hoisted(() => ({
+  store: {
+    sessions: [] as ReadonlyArray<Session>,
+    workspaces: [] as ReadonlyArray<unknown>,
+    sessionBranches: {} as Record<string, string>,
+    sessionWorktrees: {} as Record<string, ReadonlyArray<string>>,
+    sessionMounts: {} as Record<string, ReadonlyArray<never>>,
+    sessionActiveMount: {} as Record<string, string>,
+    sessionGithub: {} as Record<string, { pr?: unknown; linkedIssues?: ReadonlyArray<unknown> }>,
+    sessionGitlabMr: {} as Record<string, { mr?: unknown }>,
+    sessionExternalTasks: {} as Record<string, ReadonlyArray<unknown>>,
+    sessionPhaseRuns: {} as Record<string, ReadonlyArray<unknown>>,
+    markAllAgentsSeen: vi.fn(async () => undefined),
+    renameTask: vi.fn(async () => undefined),
+  } as Store,
+}));
+
+vi.mock('../../../../store', () => ({
+  EMPTY_ARRAY: Object.freeze([]),
+  agentHasUnread: () => false,
+  useAppStore: <T,>(selector: (s: Store) => T) => selector(store),
+  useCurrentWorkspace: () => null,
+}));
+
+vi.mock('../SummarizerBadge', () => ({
+  SummarizerBadge: () => <span data-testid="summarizer-badge" />,
+}));
+
+vi.mock('./BranchChip', () => ({
+  BranchChip: () => <span data-testid="branch-chip" />,
+}));
+
+vi.mock('./SessionCostChip', () => ({
+  SessionCostChip: () => <span data-testid="cost-chip" />,
+}));
+
+vi.mock('@goodboy/ui', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@goodboy/ui')>();
+  return {
+    ...actual,
+    Tooltip: ({ content, children }: { content: string; children: ReactElement }) => (
+      <span data-tooltip={content}>{children as ReactNode}</span>
+    ),
+  };
+});
+
+import { HeaderBand } from './HeaderBand';
+
+const SESSION_ID = 'sess-1' as SessionId;
+
+const baseSession = (): Session =>
+  ({
+    id: SESSION_ID,
+    workspaceId: 'ws-1',
+    goal: 'refactor auth',
+    state: { kind: 'idle' },
+    createdAt: '2026-06-22T10:00:00.000Z',
+    workflowRuns: [],
+  }) as unknown as Session;
+
+beforeEach(() => {
+  store.sessions = [];
+  store.workspaces = [];
+  store.sessionBranches = {};
+  store.sessionWorktrees = {};
+  store.sessionMounts = {};
+  store.sessionActiveMount = {};
+  store.sessionGithub = {};
+  store.sessionGitlabMr = {};
+  store.sessionExternalTasks = {};
+  store.sessionPhaseRuns = {};
+  store.markAllAgentsSeen.mockReset();
+  store.renameTask.mockReset();
+});
+afterEach(cleanup);
+
+describe('HeaderBand', () => {
+  it('states the stage label and the reason together, not the reason alone', () => {
+    const stage: SessionStageInfo = { stage: 'attention', reason: 'PR needs review' };
+    render(<HeaderBand session={baseSession()} stage={stage} />);
+    const tooltip = screen.getByText('PR needs review').closest('[data-tooltip]');
+    expect(tooltip?.getAttribute('data-tooltip')).toBe('needs you · PR needs review');
+  });
+
+  it('renders no tooltip at all when there is no reason to say more', () => {
+    const stage: SessionStageInfo = { stage: 'building', reason: '' };
+    render(<HeaderBand session={baseSession()} stage={stage} />);
+    expect(screen.queryByText('', { selector: '[data-tooltip]' })).toBeNull();
+    expect(document.querySelector('[data-tooltip]')).toBeNull();
+  });
+});

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/HeaderBand.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/HeaderBand.tsx
@@ -49,7 +49,10 @@ export const HeaderBand = ({ session, stage }: Props) => {
             {SESSION_STAGE_META[stage.stage].label}
           </span>
           {stage.reason !== '' ? (
-            <Tooltip content={stage.reason} side="top">
+            <Tooltip
+              content={`${SESSION_STAGE_META[stage.stage].label} · ${stage.reason}`}
+              side="top"
+            >
               <span className="min-w-0 truncate text-xs text-muted-foreground/70">
                 {stage.reason}
               </span>

--- a/apps/desktop/src/features/workflows/components/WorkflowAutorunToggle/index.test.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowAutorunToggle/index.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { WorkflowAutorunToggle } from './index';
+
+afterEach(cleanup);
+
+describe('WorkflowAutorunToggle', () => {
+  it('shows the computed on/off label in the detail variant instead of a static word', () => {
+    render(
+      <WorkflowAutorunToggle
+        isOn={false}
+        isStepInFlight={false}
+        onToggle={vi.fn()}
+        onStopNow={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'Autorun off' })).toBeDefined();
+    expect(screen.queryByRole('button', { name: 'Autorun' })).toBeNull();
+  });
+
+  it('toggles immediately when no step is in flight', () => {
+    const onToggle = vi.fn();
+    render(
+      <WorkflowAutorunToggle
+        isOn={false}
+        isStepInFlight={false}
+        onToggle={onToggle}
+        onStopNow={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Autorun off' }));
+    expect(onToggle).toHaveBeenCalledOnce();
+  });
+
+  it('arms a stop confirm instead of toggling while a step is in flight', () => {
+    const onToggle = vi.fn();
+    const onStopNow = vi.fn();
+    render(<WorkflowAutorunToggle isOn isStepInFlight onToggle={onToggle} onStopNow={onStopNow} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Autorun on' }));
+    expect(screen.getByText('Stop this run?')).toBeDefined();
+    expect(onToggle).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Stop the run' }));
+    expect(onStopNow).toHaveBeenCalledOnce();
+  });
+
+  it('keeps the sidebar variant as an icon with the same computed label as its tooltip', () => {
+    render(
+      <WorkflowAutorunToggle
+        variant="sidebar"
+        isOn
+        isStepInFlight={false}
+        onToggle={vi.fn()}
+        onStopNow={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'Autorun on' })).toBeDefined();
+  });
+});

--- a/apps/desktop/src/features/workflows/components/WorkflowAutorunToggle/index.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowAutorunToggle/index.tsx
@@ -50,14 +50,14 @@ export const WorkflowAutorunToggle = ({
           data-testid="workflow-autorun-toggle"
           onClick={press}
           className={cn(
-            'inline-flex min-h-7 shrink-0 items-center gap-1 rounded-full border px-2.5 text-2xs font-semibold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] motion-safe:transition-colors',
+            'inline-flex min-h-7 min-w-[6.5rem] shrink-0 items-center justify-center gap-1 rounded-full border px-2.5 text-2xs font-semibold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] motion-safe:transition-colors',
             isOn
               ? 'border-primary/40 bg-primary/10 text-primary hover:border-primary'
               : 'border-border-soft text-muted-foreground hover:border-border hover:text-foreground',
           )}
         >
           {isOn ? <Zap size={12} aria-hidden /> : <ZapOff size={12} aria-hidden />}
-          Autorun
+          {label}
         </button>
       )}
       {isArmed ? (


### PR DESCRIPTION
## Summary

Three small S items, grouped as one merge unit; provenance kept separate below.

**I2** (Part of #1269): the Disconnect button inside each integration's form body no longer wipes the stored credential on click. It now arms an `InlineConfirm` row in place of the button (the same row-swap `ProviderCredentialsSection.tsx` already uses), matching the studio header's existing confirm behavior. Each form reuses its own studio's per-provider disconnect description verbatim (GitHub's is deliberately different, since `disconnectGithub.ts`/`ghClearToken` never deletes a `workspace_integrations` row). The `onDisconnect` callback bodies are untouched byte-for-byte; the confirm only arms and disarms around them. `InlineConfirm` now owns the busy state during `onConfirm`, so each form's own "Disconnecting…" text is dropped.

Touches: `GitlabFormBody.tsx`, `LinearFormBody.tsx`, `JiraFormBody.tsx`, `GithubFormBody.tsx`, `BitbucketFormBody.tsx`, `SentryFormBody.tsx`, `SlackFormBody.tsx`.

All seven form-body test files asserted the disconnect fired immediately on click, which this item deliberately changes. Every one is rewritten (not deleted) into an "arms the confirm without disconnecting" test plus a "disconnects once the confirm is confirmed" test.

**B1** (internal): `SessionOverviewPane/HeaderBand.tsx`'s stage-reason tooltip repeated the visible truncated text verbatim, which said nothing the span didn't already say. Content is now `{stage label} · {reason}`, the same `a · b` grammar the stage board card already uses, so the tooltip always adds information over the clamp. No overflow measurement was added (ruled out: it would go stale on resize/text change). No test existed for `HeaderBand.tsx`; this PR adds the first one.

**U1** (internal): `WorkflowAutorunToggle`'s detail variant rendered the static word "Autorun" while the sidebar variant already used the computed "Autorun on"/"Autorun off" label. Both variants now render the same computed label. The detail pill also takes a min-width sized to "Autorun off" so toggling never shifts the divider and kill/delete cluster beside it in `WorkflowRow.tsx`. The sidebar icon-plus-tooltip variant (`CardAction`) is untouched. `WorkflowAutorunToggle` had no test file; this PR adds the first one.

## Test plan

- [x] `pnpm exec turbo run typecheck --force` — 5/5 packages, 0 cached, all pass
- [x] `pnpm exec turbo run test --force` — desktop 636 files / 5308 tests pass (0 cached); db 29 files / 203 tests pass (0 cached), including `registry.test.ts` 8/8 in ~17s
- [x] `pnpm knip --include files,duplicates,unlisted` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)