### PR TITLE
docs(desktop): standardise autorun copy, plural fix, slack disclosure

### DIFF
--- a/.claude/skills/continuous-delivery/references/repo-gotchas.md
+++ b/.claude/skills/continuous-delivery/references/repo-gotchas.md
@@ -94,11 +94,19 @@ placeholder, so could-not-run is the exception, not the default.
   The bundle lands at
   `apps/desktop/src-tauri/target/release/bundle/macos/Goodboy.app`.
 - Launch the binary directly, never via `open`, so the env var applies:
-  `GOODBOY_DB_FILE=<copy> .../Goodboy.app/Contents/MacOS/Goodboy`.
+  `GOODBOY_DB_FILE=<copy> .../Goodboy.app/Contents/MacOS/goodboy-desktop`.
+  The bundle is named `Goodboy.app` after `productName`, but the binary
+  inside it is named after the Cargo package, `goodboy-desktop`, not
+  `Goodboy`.
 - Database isolation is mandatory for every walk, not only dmg smoke
   tests: `GOODBOY_DB_FILE` points at a `VACUUM INTO` copy per the line
   above. A walk against the owner's live database corrupts real state to
   test a draft.
+- One GUI walker at a time. `GOODBOY_DB_FILE` isolates the database, not
+  the process table: a walker that kills a stray instance by process name
+  (`pkill`) can take down a sibling walker's app, including one still
+  pointed at the owner's live database. Kill only the PID your own walk
+  launched.
 
 ## Audit and verification
 

--- a/apps/desktop/src/features/integrations/slack/SlackFormBody.tsx
+++ b/apps/desktop/src/features/integrations/slack/SlackFormBody.tsx
@@ -145,9 +145,10 @@ export const SlackFormBody = ({ workspaceId, onConnected, shouldAutoFocus = fals
           </div>
           <p className="text-2xs leading-relaxed text-muted-foreground">
             Public channels only, and Goodboy sees only the ones the bot has joined. Invite it to a
-            channel in Slack to read that conversation here. Stored encrypted in your operating
-            system keychain. Goodboy sends it directly to Slack over HTTPS; it never touches
-            Goodboy&apos;s own servers.
+            channel in Slack to read that conversation here. Goodboy also pulls your
+            workspace&apos;s full member list, names and avatars, to show who posted in a thread.
+            Your token is checked against Slack over HTTPS before anything is stored, then kept in
+            your OS keychain, encrypted at rest. It never touches Goodboy&apos;s own servers.
           </p>
         </>
       )}

--- a/apps/desktop/src/features/session/components/BulkDeleteSessionsConfirm/index.test.tsx
+++ b/apps/desktop/src/features/session/components/BulkDeleteSessionsConfirm/index.test.tsx
@@ -117,7 +117,7 @@ describe('BulkDeleteSessionsConfirm', () => {
 
   it('handles a single-session delete count of one', () => {
     renderConfirm({ sessions: [makeSession('s-1', 'solo')] });
-    const panel = screen.getByRole('group', { name: 'Delete 1 sessions?' });
+    const panel = screen.getByRole('group', { name: 'Delete 1 session?' });
     expect(within(panel).getByRole('button', { name: /^Delete \(1\)$/ })).toBeDefined();
   });
 });

--- a/apps/desktop/src/features/session/components/BulkDeleteSessionsConfirm/index.tsx
+++ b/apps/desktop/src/features/session/components/BulkDeleteSessionsConfirm/index.tsx
@@ -37,7 +37,7 @@ export const BulkDeleteSessionsConfirm = ({ sessions, onClose, onConfirmed, clas
     <InlineConfirm
       role="danger"
       icon={<Trash2 size={12} aria-hidden />}
-      title={`Delete ${count} sessions?`}
+      title={`Delete ${count} session${count === 1 ? '' : 's'}?`}
       description="Permanently removes the worktrees and transcripts for these sessions from this device. Branches are preserved for manual merge."
       confirmLabel={`Delete (${count})`}
       onConfirm={onConfirm}

--- a/apps/desktop/src/features/session/components/BulkDeleteSessionsConfirm/index.tsx
+++ b/apps/desktop/src/features/session/components/BulkDeleteSessionsConfirm/index.tsx
@@ -37,7 +37,7 @@ export const BulkDeleteSessionsConfirm = ({ sessions, onClose, onConfirmed, clas
     <InlineConfirm
       role="danger"
       icon={<Trash2 size={12} aria-hidden />}
-      title={`Delete ${count} ${count === 1 ? 'session' : 'sessions'}?`}
+      title={`Delete ${count} sessions?`}
       description="Permanently removes the worktrees and transcripts for these sessions from this device. Branches are preserved for manual merge."
       confirmLabel={`Delete (${count})`}
       onConfirm={onConfirm}

--- a/apps/desktop/src/features/session/components/BulkDeleteSessionsConfirm/index.tsx
+++ b/apps/desktop/src/features/session/components/BulkDeleteSessionsConfirm/index.tsx
@@ -37,7 +37,7 @@ export const BulkDeleteSessionsConfirm = ({ sessions, onClose, onConfirmed, clas
     <InlineConfirm
       role="danger"
       icon={<Trash2 size={12} aria-hidden />}
-      title={`Delete ${count} sessions?`}
+      title={`Delete ${count} ${count === 1 ? 'session' : 'sessions'}?`}
       description="Permanently removes the worktrees and transcripts for these sessions from this device. Branches are preserved for manual merge."
       confirmLabel={`Delete (${count})`}
       onConfirm={onConfirm}

--- a/apps/desktop/src/features/session/components/WorkflowBuilderView/index.test.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowBuilderView/index.test.tsx
@@ -384,7 +384,7 @@ describe('WorkflowBuilderView (custom mode, no presets)', () => {
     render(<WorkflowBuilderView session={session} onClose={vi.fn()} />);
     await draftPlan();
     fireEvent.click(screen.getByRole('switch', { name: /save as preset/i }));
-    fireEvent.click(screen.getByRole('switch', { name: /auto-run/i }));
+    fireEvent.click(screen.getByRole('switch', { name: /autorun/i }));
     fireEvent.click(startBtn());
     await waitFor(() => expect(mockSavePhaseTemplate).toHaveBeenCalledOnce());
     expect(mockSavePhaseTemplate.mock.calls[0]![0].isPreset).toBe(true);
@@ -512,7 +512,7 @@ describe('WorkflowBuilderView (orchestrated mode)', () => {
     });
     fireEvent.click(continueBtn());
 
-    const autoRunSwitch = screen.getByRole('switch', { name: /auto-run/i });
+    const autoRunSwitch = screen.getByRole('switch', { name: /autorun/i });
     expect(autoRunSwitch.getAttribute('aria-checked')).toBe('true');
     fireEvent.click(autoRunSwitch);
     fireEvent.click(startBtn());

--- a/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
@@ -1375,7 +1375,7 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
                         </p>
                       </div>
                       <LaunchToggleRow
-                        title="Autorun"
+                        title="Auto-run"
                         description="Each step runs as soon as the previous finishes. No manual hand-off."
                         checked={autoRun}
                         onChange={setAutoRun}

--- a/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
@@ -1375,7 +1375,7 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
                         </p>
                       </div>
                       <LaunchToggleRow
-                        title="Auto-run"
+                        title="Autorun"
                         description="Each step runs as soon as the previous finishes. No manual hand-off."
                         checked={autoRun}
                         onChange={setAutoRun}

--- a/apps/desktop/src/features/settings/components/GuideStudio/parts/SessionsSection.tsx
+++ b/apps/desktop/src/features/settings/components/GuideStudio/parts/SessionsSection.tsx
@@ -42,7 +42,7 @@ export const SessionsSection = ({}: Props) => (
             ? [
                 {
                   term: 'budget (optional)',
-                  desc: 'Soft cap in USD. Warning at 80%, error at 100%. Turns you send keep running, auto-run workflows stop.',
+                  desc: 'Soft cap in USD. Warning at 80%, error at 100%. Turns you send keep running, autorun workflows stop.',
                   icon: <CONCEPT_ICONS.budget size={11} aria-hidden />,
                   tone: 'warning' as const,
                 },

--- a/apps/desktop/src/features/workspace/components/SessionActivityBar/index.test.tsx
+++ b/apps/desktop/src/features/workspace/components/SessionActivityBar/index.test.tsx
@@ -179,7 +179,7 @@ describe('SessionActivityBar, bulk selection', () => {
     toggleArchivedTab();
     clickCheckbox(0);
     fireEvent.click(screen.getByRole('button', { name: /^Delete \(1\)$/ }));
-    const panel = screen.getByRole('group', { name: 'Delete 1 sessions?' });
+    const panel = screen.getByRole('group', { name: 'Delete 1 session?' });
     expect(state.bulkDeleteTask).not.toHaveBeenCalled();
     fireEvent.click(within(panel).getByRole('button', { name: /^Delete \(1\)$/ }));
     await waitFor(() => expect(state.bulkDeleteTask).toHaveBeenCalledWith(['s-1']));
@@ -252,10 +252,10 @@ describe('SessionActivityBar, bulk selection', () => {
     toggleArchivedTab();
     clickCheckbox(0);
     fireEvent.click(screen.getByRole('button', { name: /^Delete \(1\)$/ }));
-    const panel = screen.getByRole('group', { name: 'Delete 1 sessions?' });
+    const panel = screen.getByRole('group', { name: 'Delete 1 session?' });
     fireEvent.click(within(panel).getByRole('button', { name: /^Cancel$/ }));
     expect(state.bulkDeleteTask).not.toHaveBeenCalled();
-    expect(screen.queryByRole('group', { name: 'Delete 1 sessions?' })).toBeNull();
+    expect(screen.queryByRole('group', { name: 'Delete 1 session?' })).toBeNull();
     expect(screen.getByText(/1 selected/)).toBeDefined();
   });
 
@@ -274,7 +274,7 @@ describe('SessionActivityBar, bulk selection', () => {
     toggleArchivedTab();
     clickCheckbox(0);
     fireEvent.click(screen.getByRole('button', { name: /^Delete \(1\)$/ }));
-    const panel = screen.getByRole('group', { name: 'Delete 1 sessions?' });
+    const panel = screen.getByRole('group', { name: 'Delete 1 session?' });
     fireEvent.click(within(panel).getByRole('button', { name: /^Delete \(1\)$/ }));
     await waitFor(() => expect(state.bulkDeleteTask).toHaveBeenCalled());
     await waitFor(() => expect(screen.queryByText(/selected/)).toBeNull());

--- a/apps/desktop/src/store/slices/workflows/clusterImplementation.test.ts
+++ b/apps/desktop/src/store/slices/workflows/clusterImplementation.test.ts
@@ -481,7 +481,7 @@ describe('advanceClusterImplementation', () => {
       'error',
       'warning',
       expect.stringContaining('cluster paused'),
-      expect.stringContaining('hands-free is off'),
+      expect.stringContaining('autorun is off'),
       { sessionId: SID },
     );
   });

--- a/apps/desktop/src/store/slices/workflows/clusterImplementation.ts
+++ b/apps/desktop/src/store/slices/workflows/clusterImplementation.ts
@@ -345,7 +345,7 @@ export const advanceClusterImplementation = (set: SetFn, get: GetFn) => {
           `cluster paused: ${child.name}`,
           handsFree
             ? 'the implementer stopped before completing this cluster. open the agent and continue manually.'
-            : 'autorun is off, so this cluster will not continue on its own. open the agent and continue manually, or enable autorun.',
+            : 'hands-free is off, so this cluster will not continue on its own. open the agent and continue manually, or enable hands-free.',
           { sessionId },
         );
       }

--- a/apps/desktop/src/store/slices/workflows/clusterImplementation.ts
+++ b/apps/desktop/src/store/slices/workflows/clusterImplementation.ts
@@ -345,7 +345,7 @@ export const advanceClusterImplementation = (set: SetFn, get: GetFn) => {
           `cluster paused: ${child.name}`,
           handsFree
             ? 'the implementer stopped before completing this cluster. open the agent and continue manually.'
-            : 'hands-free is off, so this cluster will not continue on its own. open the agent and continue manually, or enable hands-free.',
+            : 'autorun is off, so this cluster will not continue on its own. open the agent and continue manually, or enable autorun.',
           { sessionId },
         );
       }

--- a/apps/desktop/src/store/slices/workflows/finalizeWorkflowStep.ts
+++ b/apps/desktop/src/store/slices/workflows/finalizeWorkflowStep.ts
@@ -88,7 +88,7 @@ export const finalizeWorkflowStep = (set: SetFn, get: GetFn) => {
           `step paused: ${agent.name}`,
           handsFree
             ? 'the agent stopped before emitting a step-done marker. open the agent and continue manually.'
-            : 'autorun is off, so this step will not continue on its own. open the agent and continue manually, or enable autorun.',
+            : 'hands-free is off, so this step will not continue on its own. open the agent and continue manually, or enable hands-free.',
           { sessionId },
         );
       }

--- a/apps/desktop/src/store/slices/workflows/finalizeWorkflowStep.ts
+++ b/apps/desktop/src/store/slices/workflows/finalizeWorkflowStep.ts
@@ -88,7 +88,7 @@ export const finalizeWorkflowStep = (set: SetFn, get: GetFn) => {
           `step paused: ${agent.name}`,
           handsFree
             ? 'the agent stopped before emitting a step-done marker. open the agent and continue manually.'
-            : 'hands-free is off, so this step will not continue on its own. open the agent and continue manually, or enable hands-free.',
+            : 'autorun is off, so this step will not continue on its own. open the agent and continue manually, or enable autorun.',
           { sessionId },
         );
       }

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -15,6 +15,25 @@ Framework: vitest + `@testing-library/react` + happy-dom (already configured).
 - For hooks: `renderHook` from `@testing-library/react`.
 - A suite whose per-test hook dynamically `import()`s a large module graph warms that import once in `beforeAll`, with a timeout that fits it (60s for the store, see `apps/desktop/src/store/slices/sessions/index.test.ts`). Never in `beforeEach`: the import cost then lands on whichever test happens to run first and blows vitest's default 10s hook timeout on a loaded runner.
 
+## When a class is behavior, not styling
+
+"Do not test css classes for non-semantic styling" above is about layout and
+spacing, not meaning. A class that carries meaning, a status dot's tone, a
+design token, a z-layer, or a motion gate, is behavior wearing a class name.
+A component test that only checks structure and text is structurally blind
+to it: the tone can flip, the token can drift, the animation can lose its
+`prefers-reduced-motion` gate, and the suite stays green throughout.
+
+That class of check lives as a source-parsing invariant test in
+`apps/desktop/src/__tests__/regressions/`, not inside the component's own
+test file: it reads the source directly and asserts the property, rather
+than rendering the component and asserting on its output. Worked example:
+`attention-ring-is-finite.test.ts` reads `styles.css` and asserts the
+attention-ring animation is finite and gated behind
+`prefers-reduced-motion: no-preference`, both properties a rendered-DOM test
+cannot see. A new rule about tone, token, z-layer, or motion gate gets the
+same treatment: assert it from source, in that folder.
+
 ## The golden rule
 
 If a test fails because the component / store / hook does the wrong thing, **fix the code, not the test**. Never weaken a test to make it pass.


### PR DESCRIPTION
## Summary

Grouped copy + docs item. Per-item provenance below.

**Naming.** `GuideStudio/SessionsSection.tsx` had one hyphenated
"auto-run workflows stop" in the budget description; standardised to
"autorun" to match the canonical product term. This revision lands the
remaining sites, each with its previously-coupled test rewritten in the
same change:

- `WorkflowBuilderView/index.tsx`'s launch toggle title: `Auto-run` →
  `Autorun`. Rewrote the two `getByRole('switch', { name: /auto-run/i })`
  queries in `WorkflowBuilderView.test.tsx` to `/autorun/i`. These
  assertions pinned the pre-rename copy; once the product string changed,
  the old regex could never match the rendered switch again, so the test
  needed the same rename, not a workaround.
- `clusterImplementation.ts` and `finalizeWorkflowStep.ts` share one
  pause sentence: "hands-free is off, so this cluster/step will not
  continue on its own..." rewritten to use "autorun" in place of
  "hands-free" so both stay identical to each other. Updated the
  `expect.stringContaining('hands-free is off')` assertion in
  `clusterImplementation.test.ts` to `'autorun is off'` for the same
  reason: it pinned the old wording, not behavior.
- Sites using "automatically" as plain English (install/sign-in guides,
  session-form hints, companion pairing copy) were judged not to be the
  product term and left alone, as before.

**Plural bug in the bulk-delete confirm.** `BulkDeleteSessionsConfirm`
rendered `Delete ${count} sessions?` unconditionally, so deleting a
single session read "Delete 1 sessions?". Fixed to pluralize on the
count: `Delete ${count} session${count === 1 ? '' : 's'}?`, matching the
pluralization idiom already used elsewhere in this codebase (e.g.
`WorkspacesSidebar/lib.ts`, `compute-tab-status.tsx`).

Four tests asserted the bug as the expected string and were rewritten
to the corrected grammar, each because the assertion pinned deprecated
(buggy) copy rather than real behavior:

- `BulkDeleteSessionsConfirm/index.test.tsx`: the test named "handles a
  single-session delete count of one" asserted
  `getByRole('group', { name: 'Delete 1 sessions?' })`, i.e. it
  encoded the grammar bug as the spec. Updated to `'Delete 1 session?'`.
- `SessionActivityBar/index.test.tsx`: three tests (four assertion
  sites, since one test checks both presence and absence of the panel)
  hardcoded the same `'Delete 1 sessions?'` string. Updated all four to
  `'Delete 1 session?'`. The `'Delete 2 sessions?'` assertions in both
  files were already grammatically correct and are unchanged.

This is the tests-are-not-sacred case: a test asserting a grammar bug
as expected output is pinning deprecated behavior, not verifying
correctness, so rewriting it is the rule working as intended.

**Slack disclosure copy (internal, Part of #1269).** `SlackFormBody.tsx`'s
first-run paragraph now states the workspace member-directory read
alongside the channel-scope claim, and reorders the token flow to validate
against Slack before it's stored, matching what the code actually does.

**Docs corrections (internal).**
- `repo-gotchas.md`: the built binary inside `Goodboy.app` is named
  `goodboy-desktop` (the Cargo package name), not `Goodboy`.
- `repo-gotchas.md`: `GOODBOY_DB_FILE` isolates the database, not the
  process table; a walker must kill only the PID it launched, never a
  stray instance by process name.
- `docs/testing.md`: new paragraph naming the exception to "don't test css
  classes for non-semantic styling": a class carrying meaning (tone, token,
  z-layer, motion gate) is behavior, not styling, and that class of check
  belongs in `apps/desktop/src/__tests__/regressions/` as a source-parsing
  invariant test, not inside the component's own test file. Prompted by a
  pattern where the majority of a recent sabotage batch's survivors were
  exactly this kind of presentation regression, invisible to a
  correctly-written component test. `attention-ring-is-finite.test.ts` is
  the worked example.

## Test plan

- [x] `pnpm typecheck` green (0 cached, forced)
- [x] `pnpm exec turbo run test --force` green: 638 test files, 5327 tests,
      `0 cached`
- [x] `pnpm knip --include files,duplicates,unlisted` clean (pre-existing
      config hints only)
