### PR TITLE
chore(repo): disclose website analytics next to the privacy claim

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -149,7 +149,7 @@
             "name": "Is it really free? What is the catch?",
             "acceptedAnswer": {
               "@type": "Answer",
-              "text": "MIT license, no paywall, no account, every feature included from the first launch. Nothing is phoned home: what the app tracks about your work stays in the file on your own computer. The only thing you pay for is the subscription you already have."
+              "text": "MIT license, no paywall, no account, every feature included from the first launch. Nothing in the app is phoned home: what it tracks about your work stays in the file on your own computer. This website runs its own analytics; the app does not. The only thing you pay for is the subscription you already have."
             }
           },
           {
@@ -181,7 +181,7 @@
             "name": "Where does my data go?",
             "acceptedAnswer": {
               "@type": "Answer",
-              "text": "Conversations, plans, decisions and PR state sit in a local SQLite file on your machine. There is no backend and no account. Prompts and responses go straight from you to whichever provider you picked, the same path as running their CLI yourself."
+              "text": "Conversations, plans, decisions and PR state sit in a local SQLite file on your machine. The app itself has no backend and no account. Prompts and responses go straight from you to whichever provider you picked, the same path as running their CLI yourself."
             }
           },
           {

--- a/website/src/sections/Faq.tsx
+++ b/website/src/sections/Faq.tsx
@@ -12,7 +12,7 @@ const FAQS: readonly FaqItem[] = [
   },
   {
     q: 'Is it really free? What is the catch?',
-    a: 'MIT license, no paywall, no account, every feature included from the first launch. Nothing is phoned home: what the app tracks about your work stays in the file on your own computer. The only thing you pay for is the subscription you already have.',
+    a: 'MIT license, no paywall, no account, every feature included from the first launch. Nothing in the app is phoned home: what it tracks about your work stays in the file on your own computer. This website runs its own analytics; the app does not. The only thing you pay for is the subscription you already have.',
   },
   {
     q: 'Will this cost me anything on top of what I already pay?',
@@ -28,7 +28,7 @@ const FAQS: readonly FaqItem[] = [
   },
   {
     q: 'Where does my data go?',
-    a: 'Conversations, plans, decisions and PR state sit in a local SQLite file on your machine. There is no backend and no account. Prompts and responses go straight from you to whichever provider you picked, the same path as running their CLI yourself.',
+    a: 'Conversations, plans, decisions and PR state sit in a local SQLite file on your machine. The app itself has no backend and no account. Prompts and responses go straight from you to whichever provider you picked, the same path as running their CLI yourself.',
   },
   {
     q: 'What if I do not like what the agents did?',

--- a/website/src/sections/Integrations.tsx
+++ b/website/src/sections/Integrations.tsx
@@ -68,8 +68,8 @@ export const Integrations = () => (
           The cards write themselves
         </h2>
         <p className="sub rv" style={delay(80)}>
-          The task usually starts somewhere else, in an issue or a crash report. <b>One click</b>{' '}
-          makes it a card with the goal written for you, done when the PR merges.
+          The task usually starts somewhere else, in an issue, a pull request, or a crash report.{' '}
+          <b>One click</b> makes it a card with the goal written for you, done when the PR merges.
         </p>
       </div>
       <div className="igrid">

--- a/website/src/sections/Privacy.tsx
+++ b/website/src/sections/Privacy.tsx
@@ -12,6 +12,11 @@ export const Privacy = () => (
           Your tasks, chats, plans and stats live in one file on your computer.{' '}
           <b>No account, no server, nothing leaves your computer.</b>
         </p>
+        <p className="caption rv" style={delay(120)}>
+          That is the app. This page is not the app: it runs Google Tag Manager and Vercel's
+          analytics and speed tools to see how the site itself is doing. The desktop app carries no
+          telemetry and never phones home, by policy.
+        </p>
       </div>
 
       <div className="dbcard rv" style={delay(160)}>
@@ -25,7 +30,7 @@ export const Privacy = () => (
         <div className="dtbl">
           <span className="t">workspaces</span>
           <span className="t">sessions</span>
-          <span className="t">agents</span>
+          <span className="t">provider_runs</span>
           <span className="t">messages</span>
           <span className="t">context_slots</span>
           <span className="t">plans</span>


### PR DESCRIPTION
## The disclosure

Privacy.tsx bolds "No account, no server, nothing leaves your computer" on a page that itself loads three collectors: Google Tag Manager (`GTM-5NM3VX7Q`, `index.html:6-19`), `@vercel/analytics`, and `@vercel/speed-insights` (both mounted in `App.tsx:1-2,44-45`). That reading is false as the page is actually read, even though the underlying app claim is true.

- **Adjacency**: a new paragraph sits immediately after the bold claim, inside the Privacy section itself (`website/src/sections/Privacy.tsx:15-19`), not in the footer or another page.
- **All three collectors**: the new sentence names Google Tag Manager and "Vercel's analytics and speed tools" (covering both `@vercel/analytics` and `@vercel/speed-insights`), while keeping the app-level claim strong: "The desktop app carries no telemetry and never phones home, by policy."
- **JSON-LD parity**: the FAQ answers that implied the whole site (not just the app) phones nothing home and has no backend are scoped to the app in both places, so search snippets and AI summaries don't keep serving the old wording:
  - `website/src/sections/Faq.tsx:15` and `website/index.html:152` ("Is it really free?")
  - `website/src/sections/Faq.tsx:31` and `website/index.html:184` ("Where does my data go?")

No tag was removed, no consent banner or cookie policy was added. That is the product owner's call, already in his inbox.

## Two overclaims corrected

- The `~/.goodboy/data.db` table mockup listed an invented `agents` table. No such table exists in `packages/db/src/migrations`; the nearest real one is `provider_runs` (see `m001-initial.ts`, still current through the rename/repair migrations). Fixed in `Privacy.tsx`.
- The Integrations section framed every provider as issue-based ("starts somewhere else, in an issue or a crash report"), which Bitbucket contradicts since it is pull-request only by design. Softened the section-level line to "in an issue, a pull request, or a crash report" in `Integrations.tsx`. The per-card copy, which was already accurate, is untouched.

## Left unchanged, checked

The FAQ line that Claude, Cursor, Codex, Gemini and OpenCode "reuse the login you already have" is correct per `docs/providers.md:200-207`: sign-in happens in the Antigravity app and `agy` reuses `~/.gemini/antigravity-cli/`. Gemini lacks an in-app Connect button, which the site never claims. Left as-is.

## Verification

- `pnpm install --ignore-workspace` in `website/`
- `pnpm run build` (`tsc -b && vite build`) passes clean

Part of the v0.1.77 audit's website copy-group findings. `website/` only, no application code touched.