### PR TITLE
fix(desktop): keep sidebar footer controls reachable with 2+ mounts

### DIFF
--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumnFooter.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumnFooter.test.tsx
@@ -134,4 +134,16 @@ describe('LensColumnFooter', () => {
     expect(state.unarchiveTask).toHaveBeenCalledWith('sess-1');
     expect(screen.queryByRole('button', { name: /^archive session$/i })).toBeNull();
   });
+
+  it('wraps every control in a horizontal scroll container so an unbounded project switcher cannot push archive or delete out of reach', () => {
+    render(<LensColumnFooter session={session()} />);
+    const project = screen.getByRole('button', { name: /active project/i });
+    const archive = screen.getByRole('button', { name: /archive session/i });
+    const remove = screen.getByRole('button', { name: /delete session/i });
+
+    const scrollContainer = project.closest('[class*="overflow-x-auto"]');
+    expect(scrollContainer).not.toBeNull();
+    expect(scrollContainer?.contains(archive)).toBe(true);
+    expect(scrollContainer?.contains(remove)).toBe(true);
+  });
 });

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumnFooter.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumnFooter.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Archive, ArchiveRestore, Trash2 } from 'lucide-react';
+import { ScrollFade } from '@goodboy/ui';
 import type { Session, SessionId } from '@goodboy/types';
 import { ConfirmPill } from '../../../../../shared/components/ConfirmPill';
 import { useAppStore } from '../../../../../store';
@@ -76,12 +77,17 @@ export const LensColumnFooter = ({ session }: Props) => {
   };
 
   return (
-    <div className="flex shrink-0 items-center gap-2 px-2 py-2">
+    <ScrollFade
+      orientation="horizontal"
+      className="shrink-0"
+      viewportClassName="flex items-center gap-2 px-2 py-2"
+      fadeSize={16}
+    >
       <ProjectSwitcher sessionId={sessionId} density={density} />
       <EditorMenu sessionId={sessionId} density={density} />
       <SessionGitActions session={session} density={density} />
       <span className="flex-1" />
-      <div className="flex items-center gap-1">
+      <div className="flex shrink-0 items-center gap-1">
         {archived ? (
           <button
             type="button"
@@ -132,6 +138,6 @@ export const LensColumnFooter = ({ session }: Props) => {
           </button>
         )}
       </div>
-    </div>
+    </ScrollFade>
   );
 };


### PR DESCRIPTION
## What changed

`LensColumnFooter` wrapped its Open / Branch / Archive / Delete row in a
plain `flex` container with every child forced `shrink-0`. `ProjectSwitcher`
renders one `SegmentedTabs` tab per project mount with no width bound, so
its intrinsic width grows with mount count. With two or more mounts that
pushed the trailing controls past the sidebar's 200-400px clamp with no
scroll or wrap, making them unreachable.

The row now wraps its children in `ScrollFade` with `orientation="horizontal"`
instead of a bare `div`. When content fits, this is visually identical to
before (edge fades render at `opacity-0`). When it overflows, the row
becomes horizontally scrollable with fade affordances at each edge, so
every control stays reachable at any mount count and at the sidebar's
minimum width.

## Precedent

`ScrollFade` is existing prior art already used for horizontal and vertical
scroll elsewhere in this codebase (`LensColumn`, `WorkflowRunDetail`), so
this reuses that primitive instead of inventing a new one. The behavior
mirrors VS Code's activity bar: an overflowing row scrolls into an overflow
affordance rather than clipping content off-surface.

## Test

`apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumnFooter.test.tsx`
adds "wraps every control in a horizontal scroll container so an unbounded
project switcher cannot push archive or delete out of reach". It asserts
the actual mechanism introduced: the project switcher, archive and delete
buttons all live inside an ancestor carrying the `overflow-x-auto` class
that `ScrollFade`'s viewport renders. Verified this test fails on the
pre-fix code (plain `flex` row, no scroll container) and passes after.

## What I deliberately did not do

- Did not touch `SegmentedTabs` or its default rendering; `ProjectSwitcher`
  is unmodified.
- Did not change the sidebar's 200-400px width clamp.
- Did not redesign the footer beyond wrapping it for overflow.

Closes #1354