### PR TITLE
docs(repo): correct providers, conventions and security claims

### DIFF
--- a/.claude/skills/continuous-delivery/references/repo-gotchas.md
+++ b/.claude/skills/continuous-delivery/references/repo-gotchas.md
@@ -80,8 +80,9 @@ only what it does not say.
   each version file in its own invocation.
 - `hdiutil` mounts a second copy at `/Volumes/Goodboy 1` when one is already
   mounted; detach before asserting paths.
-- To smoke-test a dmg against real data safely, point `GOODBOY_DB_FILE` at a
-  `VACUUM INTO` copy, never `copyFileSync` of the live DB.
+- Never point `GOODBOY_DB_FILE` at a copy of the real database, whether made
+  with `cp`, `copyFileSync` or `VACUUM INTO`. See "Running the built app"
+  below for the binding recipe.
 
 ## Running the built app
 
@@ -94,19 +95,32 @@ placeholder, so could-not-run is the exception, not the default.
   The bundle lands at
   `apps/desktop/src-tauri/target/release/bundle/macos/Goodboy.app`.
 - Launch the binary directly, never via `open`, so the env var applies:
-  `GOODBOY_DB_FILE=<copy> .../Goodboy.app/Contents/MacOS/goodboy-desktop`.
+  `GOODBOY_DB_FILE=<new-empty-path> .../Goodboy.app/Contents/MacOS/goodboy-desktop`.
   The bundle is named `Goodboy.app` after `productName`, but the binary
   inside it is named after the Cargo package, `goodboy-desktop`, not
   `Goodboy`.
-- Database isolation is mandatory for every walk, not only dmg smoke
-  tests: `GOODBOY_DB_FILE` points at a `VACUUM INTO` copy per the line
-  above. A walk against the owner's live database corrupts real state to
-  test a draft.
+- No agent walks the app against a copy of the production database. Point
+  `GOODBOY_DB_FILE` at a path that does not exist yet, let the app's own
+  migrations build the schema on first launch, and seed exactly the rows
+  the pass needs with SQL. Never `cp`, never `VACUUM INTO` from `data.db`,
+  never reuse a walk file from a previous release. If a claim cannot be
+  reached from an empty database plus deliberate seed rows, that is a
+  finding about the app's testability, not something to work around.
 - One GUI walker at a time. `GOODBOY_DB_FILE` isolates the database, not
   the process table: a walker that kills a stray instance by process name
   (`pkill`) can take down a sibling walker's app, including one still
   pointed at the owner's live database. Kill only the PID your own walk
   launched.
+- The app can be seen. Bash `screencapture` fails on this machine
+  ("could not create image from display"), but the computer-use interface's
+  screenshot and zoom actions render the display fine. One release
+  concluded there was no display access at all and skipped its visual
+  work; the next proved that wrong.
+- Keystrokes are blocked on this machine, and the mouse is not: the
+  computer-use `key`, `type`, `computer_batch` and `wait` actions all abort
+  with `user interrupt` before executing, while every mouse action
+  (clicks, drags, scrolls) succeeds. Any Escape-to-close or
+  focus-then-type claim rests on class assertions until that is solved.
 
 ## Audit and verification
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -32,12 +32,13 @@ goodboy/
 - Use `pnpm --filter <pkg>` for scoped scripts. Use `pnpm --filter "...<pkg>"` to include dependents.
 - `website/` is outside the workspace and keeps its own `website/pnpm-lock.yaml`. Any change to `website/package.json` must regenerate it with `pnpm install --ignore-workspace` from `website/`: a plain root `pnpm install` never touches that lockfile, and Vercel installs with `--frozen-lockfile`, so a stale lockfile fails every website build.
 
-## TypeScript (project references)
+## TypeScript
 
-- Every package has `composite: true`, `declaration: true`, `declarationMap: true`.
-- Root `tsconfig.json` declares `references` to all packages.
-- Build with `tsc -b` (incremental, cached). Never plain `tsc` in CI.
-- `noEmit: true` in app packages, `emitDeclarationOnly: true` for libraries that ship types only.
+- No root `tsconfig.json` and no project references. Every package's
+  `tsconfig.json` extends the shared `tsconfig.base.json` directly.
+- Typecheck is `tsc --noEmit` per package, run through `turbo run typecheck`
+  at the root. No package sets `composite` or `declaration`.
+- `noEmit: true` in every package's own `tsconfig.json`.
 - `skipLibCheck: true` everywhere. `strict: true` everywhere. `noUncheckedIndexedAccess: true`.
 - `verbatimModuleSyntax: true`: explicit `import type` for type-only imports.
 - Path aliases: per-package only. No global `@/` aliases that span workspaces (use package names).

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -343,14 +343,20 @@ before sending, a running total after.
   compact default or inline size and do not add a heading to the document
   outline.
 - **Loading is a skeleton; running is a moving border. Spinners are
-  forbidden.** No `Loader2`, no hand-built dot loaders, no parked spinner
-  anywhere. _Loading_ uses the Skeleton primitive, a greyed placeholder
-  mirroring the real layout (image block, title, chips), so the surface does
-  not jump when content lands. _Running_ is expressed intrinsically by the
-  element: a moving border (the `.spin-border` family) or a pulsing StatusDot,
-  never a spinner beside it. The skeleton is part of the component: change the
-  layout, update the skeleton in the same change. All of it stays motion-safe
-  and reduced-motion gated.
+  forbidden.** No `Loader2`, no hand-built dot loaders, no parked spinner in
+  the shared `packages/ui` package; `no-loader2-in-ui-package.test.ts`
+  enforces that boundary in CI. Two feature-level exceptions still exist in
+  `apps/desktop` pending cleanup: `GhostActionButton`
+  (`apps/desktop/src/shared/components/GhostActionButton/index.tsx`) and
+  `AssigneePicker` (`apps/desktop/src/features/integrations/jira/AssigneePicker.tsx`)
+  both render a spinning `Loader2` for a busy state. _Loading_ uses the
+  Skeleton primitive, a greyed placeholder mirroring the real layout (image
+  block, title, chips), so the surface does not jump when content lands.
+  _Running_ is expressed intrinsically by the element: a moving border (the
+  `.spin-border` family) or a pulsing StatusDot, never a spinner beside it.
+  The skeleton is part of the component: change the layout, update the
+  skeleton in the same change. All of it stays motion-safe and
+  reduced-motion gated.
 - **Confirm what is destructive, nothing else.** Two-step confirms are for
   irreversible actions only; they must not tax routine clicks. The confirm
   happens in place: the row or button being acted on swaps itself for it, so

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,11 +2,16 @@
 
 ## Reporting a vulnerability
 
-Use [GitHub private vulnerability reporting](https://github.com/akhayam99/goodboy/security/advisories/new)
-so the report stays private until a fix ships. Include steps to reproduce and
-the version (`Goodboy > About`, or the name of the dmg or Linux package you
-installed). You will get a reply in the
-next release cycle at the latest; issues are triaged every cycle.
+GitHub private vulnerability reporting is not enabled on this repository yet.
+Until it is, reach the maintainer through the contact info on the
+[GitHub profile](https://github.com/akhayam99). Include steps to reproduce
+and the version (`Goodboy > About`, or the name of the dmg or Linux package
+you installed). You will get a reply in the next release cycle at the
+latest; issues are triaged every cycle.
+
+Private advisory reporting is being enabled for this repository. Once
+[GitHub private vulnerability reporting](https://github.com/akhayam99/goodboy/security/advisories/new)
+is live, prefer it: the report stays private until a fix ships.
 
 ## What Goodboy does with your data
 

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -263,14 +263,21 @@ anchored popover so the header never grows, and confirming clears the
 workspace credential (keychain entry, database row, and any in-memory cache)
 without leaving the studio. This is the only way to disconnect an integration
 short of Settings' "Run setup again", which re-opens the onboarding wizard and
-does not cover Slack. GitHub only shows the control when the workspace has its
-own token (`gh_status`'s `scoped` flag): a workspace falling back to the
-system `gh` CLI has nothing workspace-scoped to clear, and disconnecting never
-touches that system session. The GitHub control is gated on that credential
-state alone, not on whether the workspace's git remote is GitHub, so a mixed
-workspace (a GitLab or Bitbucket remote that still carries a leftover scoped
-GitHub token) still shows a way to clear it even though the pull request and
-issue browsing panes stay hidden.
+does not cover Slack. GitHub only renders that Disconnect control when the workspace is
+authenticated via its own PAT (`status.mode === 'pat'` in
+`apps/desktop/src/features/github/components/Panel/index.tsx`). A workspace
+falling back to the system `gh` CLI has nothing workspace-scoped to clear, so
+the panel shows no Disconnect button there; instead it tells the user to run
+`gh auth logout` in a terminal, and offers a field to connect a PAT instead.
+Either way, disconnecting through the GitHub studio only clears the
+workspace-scoped credential (`gh_clear_token` in
+`apps/desktop/src-tauri/src/github.rs:368-372`, which removes the keychain
+entry for that workspace); it never touches the system `gh` session. The
+GitHub control is gated on that credential state alone, not on whether the
+workspace's git remote is GitHub, so a mixed workspace (a GitLab or
+Bitbucket remote that still carries a leftover scoped GitHub token) still
+shows a way to clear it even though the pull request and issue browsing
+panes stay hidden.
 
 ### Workspace creation
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -58,10 +58,10 @@ Requires **Claude Max** (or Claude Pro). Goodboy uses your subscription cap, not
 
 Per the compiled registry in `packages/core/src/providers/capabilities.ts`:
 
-- **Turn**: `claude-opus-5` (default), `claude-opus-4-8`, `claude-fable-5`, `claude-opus-4-7`, `claude-opus-4-6`, `claude-sonnet-4-6`, `claude-sonnet-4-5`.
+- **Turn**: `claude-opus-5` (default), `claude-opus-4-8`, `claude-fable-5`, `claude-opus-4-7`, `claude-opus-4-6`, `claude-sonnet-5`, `claude-sonnet-4-6`, `claude-sonnet-4-5`.
 - **Cheap**: `claude-haiku-4-5`.
 
-Fable 5, Opus 5, Opus 4.8, Opus 4.7, and Sonnet 4.6 carry a 1M-token context window. Sonnet 4.5, Haiku 4.5, Opus 4.6, and older Opus models carry a 200k-token context window. Auxiliary operations (summaries, branch names, planning, agent titles) default to the cheap tier of the workspace default provider. See Defaults and task models below to pin a different model.
+Fable 5, Opus 5, Opus 4.8, Opus 4.7, Sonnet 5, and Sonnet 4.6 carry a 1M-token context window. Sonnet 4.5, Haiku 4.5, Opus 4.6, and older Opus models carry a 200k-token context window. Auxiliary operations (summaries, branch names, planning, agent titles) default to the cheap tier of the workspace default provider. See Defaults and task models below to pin a different model.
 
 ### Setting sources
 
@@ -147,10 +147,12 @@ Requires **ChatGPT Plus/Pro/Business/Edu/Enterprise** (preferred) or an `OPENAI_
 
 ### Default models
 
-Per <https://developers.openai.com/codex/models> (May 2026):
+Per `packages/core/src/providers/codex/catalog.ts`:
 
-- **Turn**: `gpt-5.6` (default), `gpt-5.5`, `gpt-5.4`, `gpt-5.2`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`.
+- **Turn**: `gpt-5.6` (default), `gpt-5.5`, `gpt-5.4`.
 - **Cheap**: `gpt-5.4-mini`.
+
+`gpt-5.2`, `gpt-5.3-codex` and `gpt-5.3-codex-spark` are retired ids: a session created on one of them still resolves through `parseLegacyId.ts`, which remaps `gpt-5.2` and `gpt-5.3-codex` to `gpt-5.4` and `gpt-5.3-codex-spark` to `gpt-5.4-mini`.
 
 ### Turn spawn args
 
@@ -293,8 +295,8 @@ Effort is the third axis of every model picker, next to provider and model. How 
 
 - **Claude Opus and Fable**: `low`, `medium`, `high`, `extra-high`, `max`.
 - **Claude Sonnet**: `low`, `medium`, `high`.
-- **Codex turn models**: `minimal`, `low`, `medium`, `high`.
-- **`gpt-5.4-mini`**: `minimal`, `low`, `medium`.
+- **Codex turn models**: `low`, `medium`, `high`, `xhigh`; `gpt-5.6` additionally accepts `max`.
+- **`gpt-5.4-mini`**: `low`, `medium`, `high`, `xhigh`, the same ladder as `gpt-5.5` and `gpt-5.4`.
 
 Cursor is the exception to the ladder shape: effort is baked into the model slug, so each catalog entry lists the combos it has and the reachable levels depend on the Thinking and Fast toggles. `claude-haiku-4-5` and every Gemini model have no ladder at all and emit no effort arg. Picking a level a model does not support clamps to the top of what it supports (`clampEffort` in `packages/core/src/providers/clampEffort.ts`).
 


### PR DESCRIPTION
Docs-only pass fixing sentences that no longer match the shipped code. No `Closes` keyword; not a resolution of any tracked issue.

- `docs/providers.md:152` listed retired codex ids (`gpt-5.2`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`) as current. `packages/core/src/providers/codex/catalog.ts:6-79` defines only `gpt-5.6`, `gpt-5.5`, `gpt-5.4` (turn) and `gpt-5.4-mini` (cheap); the retired ids remap through `packages/core/src/providers/parseLegacyId.ts:60-66`.
- `docs/providers.md:296-297` said the codex effort ladder was `minimal, low, medium, high` and gave `gpt-5.4-mini` a narrower `minimal, low, medium`. `packages/core/src/providers/codex/catalog.ts:3-4` has no `minimal` level anywhere; `STANDARD_EFFORTS` (`gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`) is `low, medium, high, xhigh`, and `FULL_EFFORTS` (`gpt-5.6`) adds `max`.
- `docs/providers.md:61-64` omitted `claude-sonnet-5` from the turn model list. It's defined at `packages/core/src/providers/claude/catalog.ts:92-108` with `tier: 'turn'` and a 1M `contextWindow`.
- `CONVENTIONS.md:35-43` documented a TypeScript project-references setup (root `tsconfig.json` with `references`, `composite`/`declaration` per package, `tsc -b` builds) that doesn't exist in this repo: there is no root `tsconfig.json`, no package sets `composite` or `declaration`, and `packages/{core,db,types,ui}/package.json` and `apps/desktop/package.json` all run `typecheck: "tsc --noEmit"` against a shared `tsconfig.base.json`.
- `DESIGN.md:345-347` said "No `Loader2` ... anywhere," which is false: `Loader2` is used at `apps/desktop/src/shared/components/GhostActionButton/index.tsx:51` and `apps/desktop/src/features/integrations/jira/AssigneePicker.tsx:105,120`. The design rule itself is unchanged; the doc now says the ban is enforced for `packages/ui` (via `no-loader2-in-ui-package.test.ts`, which only walks `packages/ui/src`) and names the two known `apps/desktop` exceptions.
- `SECURITY.md` pointed reporters at GitHub private vulnerability reporting, which `gh api repos/akhayam99/goodboy/private-vulnerability-reporting` returns as `{"enabled": false}` for. Per the security officer's ruling, the section now points to the maintainer's GitHub profile as the contact channel and states, honestly, that private advisory reporting is being enabled and should be preferred once live. It does not invite a public zero-detail issue.
- `docs/navigation.md:259-270` described GitHub disconnect as binary (control shown only for a scoped PAT, "nothing" otherwise) and omitted that the gh-CLI fallback path in `apps/desktop/src/features/github/components/Panel/index.tsx:228-245` actually surfaces a "run `gh auth logout`" instruction and a field to connect a PAT instead. Also names `gh_clear_token` (`apps/desktop/src-tauri/src/github.rs:368-372`) as only clearing the workspace-scoped keychain entry, never the system `gh` session.
- `.claude/skills/continuous-delivery/references/repo-gotchas.md`: replaced the `VACUUM INTO`-a-copy-of-prod-db recipe for walking the built app (superseded mid-release) with the current rule: point `GOODBOY_DB_FILE` at a path that doesn't exist yet, let migrations build the schema, seed only what the pass needs with SQL, never reuse a walk file across releases. Added two facts two consecutive releases each had to rediscover on their own: computer-use screenshot/zoom work even though bash `screencapture` fails on this machine, and computer-use `key`/`type`/`computer_batch`/`wait` currently abort with a user interrupt before executing while mouse actions succeed. The existing pid-kill rule is untouched.

## Not done

Two items from the audit were checked and found not to need a doc change, so nothing was written for them:
- The Cursor turn model list (`docs/providers.md:110`) still lists `gpt-5.3-codex` — that's a separate Cursor-specific catalog and legacy mapping, unrelated to the Codex provider's retired ids above, and it's what `cursor-agent --list-models` still exposes.
- `docs/navigation.md`'s claim that GitHub only shows a Disconnect control when the workspace has its own token is true as stated; only the missing gh-CLI-fallback behavior needed adding.

## What this PR does not do

Docs-class item: no application code was touched. If any of these facts is wrong going forward, that's a code change in a different PR, not this one.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>