### PR TITLE
refactor(repo): fix a fake test, add turbo continue, drop dead branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         run: pnpm knip --include files,duplicates,unlisted
 
       - name: test
-        run: pnpm turbo run test --affected
+        run: pnpm turbo run test --affected --continue
 
       - name: build
         run: pnpm turbo run build --affected

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/index.tsx
@@ -12,7 +12,6 @@ import { EMPTY_ARRAY, useAppStore } from '../../../../../../store';
 import { formatError } from '../../../../../../shared/lib/errors';
 import { ConnectIntegrationEmptyState } from '../../../../../integrations/ConnectIntegrationEmptyState';
 import { resolveIntegrationConnection } from '../../../../../integrations/connection';
-import { GithubConnectionEmptyState } from '../../../../../github/components/GithubConnectionEmptyState';
 import { useGithubConnection } from '../../../../../integrations/github/useGithubConnection';
 import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../../../shared/components/conceptIcons';
 import { GhostActionButton } from '../../../../../../shared/components/GhostActionButton';
@@ -30,7 +29,7 @@ import { WorkItemList } from './WorkItemList';
 type Props = {
   readonly sessionId: SessionId;
   readonly workspaceId: WorkspaceId;
-  readonly provider: SessionExternalTaskProvider;
+  readonly provider: Exclude<SessionExternalTaskProvider, 'github'>;
 };
 
 type ProviderMeta = Readonly<{
@@ -134,9 +133,7 @@ export const IntegrationPane = ({ sessionId, workspaceId, provider }: Props) => 
     integrations,
     externalTasks,
     isGithubAuthenticated:
-      provider !== 'github' ||
-      githubConnection.isResolved === false ||
-      githubConnection.isAuthenticated,
+      githubConnection.isResolved === false || githubConnection.isAuthenticated,
   });
   const hasTasks = tasks.length > 0;
   const linkAction = (
@@ -242,16 +239,7 @@ export const IntegrationPane = ({ sessionId, workspaceId, provider }: Props) => 
       actions={connection.isConnected && hasTasks ? linkAction : undefined}
     >
       {!connection.isConnected ? (
-        provider === 'github' ? (
-          <GithubConnectionEmptyState
-            workspaceId={workspaceId}
-            isConnected={connection.isConnected}
-            compact
-            onConnected={() => void githubConnection.refresh()}
-          />
-        ) : (
-          <ConnectIntegrationEmptyState provider={provider} workspaceId={workspaceId} compact />
-        )
+        <ConnectIntegrationEmptyState provider={provider} workspaceId={workspaceId} compact />
       ) : null}
       {connection.isConnected && !hasTasks ? (
         <LensEmptyState

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "dev": "turbo run dev",
     "lint": "turbo run lint",
     "typecheck": "turbo run typecheck",
-    "test": "turbo run test",
+    "test": "turbo run test --continue",
     "tauri:dev": "pnpm --filter @goodboy/desktop tauri:dev",
     "tauri:build": "pnpm --filter @goodboy/desktop tauri:build",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json,md}\"",

--- a/packages/ui/src/__tests__/tint.test.ts
+++ b/packages/ui/src/__tests__/tint.test.ts
@@ -33,8 +33,8 @@ describe('tintClasses', () => {
     });
   });
 
-  it('pins draft to the SEMANTIC_TONES coverage list', () => {
-    expect(SEMANTIC_TONES).toContain('draft');
+  it('reads the draft tone from the TINT record, not a hardcoded coverage list', () => {
+    expect(tintClasses('draft').bg).toBe('bg-draft/10');
   });
 
   it('exposes a draft tone bound to the draft token, not indigo hardcodes', () => {


### PR DESCRIPTION
Refactor floor for v0.1.77 (MU8), three unrelated same-class items, unchanged behaviour throughout.

## (a) tautological test — packages/ui/src/__tests__/tint.test.ts

`SEMANTIC_TONES.toContain('draft')` asserted a literal array against itself: `SEMANTIC_TONES` is declared four lines above in the same file with `'draft'` already in it, so the assertion could never fail on a product change, only on an edit to its own fixture. It shipped in v0.1.76's #1350 and its verifier scored the matching sabotage as caught only because the sabotage edited the test's own fixture.

Replaced it with `expect(tintClasses('draft').bg).toBe('bg-draft/10')`, which reads the real `TINT` record in `packages/ui/src/tint.ts` through the exported `tintClasses` function (`TINT` itself is not exported).

Proof it actually breaks: edited `tint.ts`'s `draft.bg` from `'bg-draft/10'` to `'bg-indigo-500/10'`, ran `npx vitest run src/__tests__/tint.test.ts`, watched the new assertion fail with a real diff, then reverted the source edit (`git diff` on `tint.ts` is empty).

Swept the rest of the file for the same shape; no sibling tautology found.

## (b) turbo run test has no --continue

`package.json`'s `test` script and `.github/workflows/ci.yml`'s test step both lacked `--continue`. Without it, a `packages/db` timeout cancels the desktop task before it reports, and a cancelled sibling reads as a failure in the merge lane.

Added `--continue` to both `package.json:22` and `.github/workflows/ci.yml`'s test step.

Verified a genuine failure still fails the run: added a deliberately failing test to `packages/ui`, ran `pnpm exec turbo run test --continue --force` at the repo root, and got exit code 1 with `0 cached, 4 total` (forced) and `3 successful, 4 total` tasks — the other three packages (core, db, desktop) ran to completion instead of being cancelled by the ui failure, and the overall run still failed correctly. Removed the sabotage test afterward (`git diff` on the test file shows only the item (a) change).

## (c) dead IntegrationPane github branch

`apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/index.tsx`'s `provider === 'github'` branch (rendering `GithubConnectionEmptyState`) was unreachable: `IntegrationPane`'s only call site, `SessionWorkspace/index.tsx`, never passes `provider="github"` — only `linear`, `sentry`, `gitlab`, `jira`, `slack`.

Re-verified before touching anything that these three stay untouched, all confirmed still true on this branch:
- `fetchIssueCandidates.ts` still has its deliberate `case 'bitbucket': return []` arm.
- `issueSources.ts` still has no bitbucket entry.
- `RemoteHostKind` still has no `'bitbucket'` member.

Narrowed only `IntegrationPane`'s local `Props.provider` type (`index.tsx:33`) to `Exclude<SessionExternalTaskProvider, 'github'>`. The shared `SessionExternalTaskProvider` union is untouched, and `PROVIDER_META`'s `github`/`bitbucket` entries in this file and in `ExternalTaskChip` are untouched — both stay reachable through `ExternalTaskChip`.

With the type narrowed, `tsc` flagged two now-impossible `provider === 'github'` / `provider !== 'github'` comparisons (TS2367, no overlap). Removed the dead render branch and its now-unused `GithubConnectionEmptyState` import, and dropped the always-true `provider !== 'github' ||` guard from the `isGithubAuthenticated` computation (for every provider this component is ever called with, that guard was always true anyway, so the computed boolean's value is unchanged for every reachable call).

Behaviour unchanged: the `useGithubConnection` hook call and its side effects (the `ghStatus` poll on mount and the `goodboy:github-connection-changed` listener) are left exactly where they were — only the render branch and the dead comparisons were removed, not the hook call, so no side effect that currently fires on mount stops firing.

Confirmed both scout predictions empirically rather than trusting them: `pnpm knip --include files,duplicates,unlisted` exits 0 (only pre-existing configuration hints, no new findings), and `IntegrationPane`'s existing test suite (`index.test.tsx`) has no reference to `provider === 'github'` and needed no changes.

## Verification

- `pnpm typecheck`: pass, 5/5 packages, 0 cached.
- `pnpm exec turbo run test --force`: pass, 4/4 packages, 0 cached (21+103+29+638 test files, all green).
- `pnpm knip --include files,duplicates,unlisted`: pass, only pre-existing configuration hints.
- `pnpm exec turbo run test --continue --force` with a deliberate failure: exit code 1, confirmed above.
- `prettier --check` on all four touched files: pass.

## Not done

`registry.test.ts`, `selectors.ts` style conversion, raw z-index values, and popover-hook convergence are explicitly out of scope for this unit and were not touched.