### PR TITLE
fix(desktop): rename autorun holdouts and separate delete on cards

### DIFF
--- a/apps/desktop/src/features/session/components/SessionOverviewPane/PipelineLane.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/PipelineLane.tsx
@@ -35,7 +35,7 @@ export const PipelineLane = ({ lane, onOpen, advance }: Props) => {
         <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
           {lane.workflowName}
         </span>
-        {lane.autoRun ? <Chip tone="danger" size="sm" label="auto" /> : null}
+        {lane.autoRun ? <Chip tone="primary" size="sm" label="Autorun" /> : null}
         <span className="shrink-0 tabular-nums text-2xs text-muted-foreground/60">
           {done}/{lane.steps.length}
         </span>

--- a/apps/desktop/src/features/settings/components/GuideStudio/parts/LegendSection.tsx
+++ b/apps/desktop/src/features/settings/components/GuideStudio/parts/LegendSection.tsx
@@ -103,12 +103,12 @@ export const LegendSection = ({}: Props) => (
       />
     </LegendBlock>
 
-    <LegendBlock title="Auto badge">
+    <LegendBlock title="Autorun badge">
       <LegendaGrid
         rows={[
           {
-            dot: 'bg-warning',
-            label: 'AUTO',
+            dot: 'bg-primary',
+            label: 'Autorun',
             desc: 'autorun mode: next action fires without user confirmation',
           },
         ]}

--- a/apps/desktop/src/features/workspace/components/SessionActivityBar/index.tsx
+++ b/apps/desktop/src/features/workspace/components/SessionActivityBar/index.tsx
@@ -339,7 +339,7 @@ const SessionActivityItem = memo(function SessionActivityItem({
       <span className="flex w-full items-start gap-2">
         <span className="inline-flex h-5 shrink-0 items-center">
           <StatusDot
-            tone={isAutoMode ? 'danger' : STAGE_TONE[stage]}
+            tone={isAutoMode ? 'primary' : STAGE_TONE[stage]}
             size="sm"
             pulsing={stage === 'running'}
           />

--- a/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.test.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.test.tsx
@@ -276,6 +276,16 @@ describe('StageBoardCard actions visibility', () => {
     expect(nonAttention.className).not.toContain('bg-warning/5');
     expect(nonAttention.className.includes(' bg-primary/5')).toBe(false);
   });
+
+  it('separates delete from archive with a divider in the lifecycle group', () => {
+    render(<StageBoardCard session={session} nav={nav} />);
+    const group = screen.getByRole('group', { name: 'Session lifecycle actions' });
+    const archive = screen.getByLabelText('Archive').closest('[data-tooltip]');
+    const del = screen.getByLabelText('Delete').closest('[data-tooltip]');
+    const divider = group.querySelector('[role="separator"]');
+    expect(divider).not.toBeNull();
+    expect(Array.from(group.children)).toEqual([archive, divider, del]);
+  });
 });
 
 describe('StageBoardCard review drafts', () => {
@@ -327,12 +337,14 @@ describe('StageBoardCard footer', () => {
     const agents = screen.getByLabelText('2 agents');
     const task = screen.getByLabelText('GB-123 from Linear');
     const cost = document.querySelector('[title="Session spend: $1.25 (excludes summarizer)"]');
-    const auto = screen.getByText('Auto');
+    const auto = screen.getByText('Autorun');
     const footer = agents.closest('[data-tooltip]')?.parentElement;
     expect(agents.querySelector('.lucide-bot')).not.toBeNull();
     expect(screen.queryByText('GB-123')).toBeNull();
     expect(cost).not.toBeNull();
     expect(auto).toBeDefined();
+    expect(auto.className).toContain('text-primary');
+    expect(auto.className).not.toContain('text-danger');
     expect(Array.from(footer?.children ?? [])).toEqual([
       agents.closest('[data-tooltip]'),
       task,

--- a/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.tsx
@@ -9,7 +9,7 @@ import {
   SquareTerminal,
   Trash2,
 } from 'lucide-react';
-import { Chip, cn, formatUsd, tintClasses, Tooltip } from '@goodboy/ui';
+import { Chip, cn, Divider, formatUsd, tintClasses, Tooltip } from '@goodboy/ui';
 import type { Session, SessionId } from '@goodboy/types';
 import {
   EMPTY_ARRAY,
@@ -181,7 +181,7 @@ export const StageBoardCard = memo(function StageBoardCard({
                 aria-label={agentCountLabel}
                 className="inline-flex shrink-0 items-center gap-1 text-2xs text-muted-foreground"
               >
-                <Bot size={12} aria-hidden />
+                <Bot size={14} aria-hidden />
                 <span className="tabular-nums">{agentCount}</span>
               </span>
             </Tooltip>
@@ -213,7 +213,7 @@ export const StageBoardCard = memo(function StageBoardCard({
               className="shrink-0 text-2xs font-medium tabular-nums text-muted-foreground"
             />
           )}
-          {isAutoMode && <Chip tone="danger" size="sm" label="Auto" className="shrink-0" />}
+          {isAutoMode && <Chip tone="primary" size="sm" label="Autorun" className="shrink-0" />}
         </span>
       </span>
 
@@ -299,6 +299,7 @@ export const StageBoardCard = memo(function StageBoardCard({
         ) : (
           <CardAction icon={Archive} label="Archive" onClick={() => onArchive?.(session)} />
         )}
+        <Divider orientation="vertical" className="mx-0.5 h-4 shrink-0 self-center" />
         <CardAction
           icon={Trash2}
           tone="danger"


### PR DESCRIPTION
## What and why

Grouped S unit, three items, per-item provenance below.

### Item A — autorun naming holdouts

Every surface says "Autorun" with tone="primary" except three that said a different word and used tone="danger" for a normal on-state (danger means error/destructive in this design system, and autorun-on is neither). Reference confirmed by scout and design system steward: `WorkflowAutorunToggle/index.tsx` ("Autorun on" / "Autorun off", tone="primary").

Fixed:
- `apps/desktop/src/features/session/components/SessionOverviewPane/PipelineLane.tsx:38` — `label="auto"` tone="danger" to `label="Autorun"` tone="primary"
- `apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.tsx:216` — `label="Auto"` tone="danger" to `label="Autorun"` tone="primary"
- `apps/desktop/src/features/workspace/components/SessionActivityBar/index.tsx:342` — a `StatusDot` picked tone="danger" for the same on-state (no text label here, only color); fixed to tone="primary"

Case-insensitive repo sweep for `auto`, `Auto`, `autorun`, `Autorun`, `hands-free`, `automation` as user-visible rendering turned up a fourth site not in the original three: `apps/desktop/src/features/settings/components/GuideStudio/parts/LegendSection.tsx` — the in-app Guide's color legend documented this exact badge as `label: 'AUTO'` with `dot: 'bg-warning'`. Once the real badge became "Autorun" / primary, this legend entry was actively wrong, so it is fixed in the same PR (title "Autorun badge", label "Autorun", dot "bg-primary") per the docs-travel-with-change rule. No other site was found; `docs/workflows.md` uses "hands-free" and "autorun" as prose describing the `auto_run` field, not as UI text, so it was left alone.

### Item B — session card action row

The lifecycle slot (`StageBoardCard/index.tsx:288-309`) put Delete directly after Archive/Restore with no separation. Every glyph already had an `aria-label` and tooltip via the shared `CardAction` wrapper, and both Archive and Delete already confirm, so relabeling was not the fix. Per the ux designer's decision: inserted a `Divider` (orientation="vertical") between Archive/Restore and Delete inside the lifecycle slot, matching the existing vertical-divider pattern already used in `AppTopBar/index.tsx:91` and `AppFooter/index.tsx:102`. No new component invented, nothing relabeled, nothing reordered beyond that separation, quick-actions slot untouched.

### Item C — counter: no change

Both scouting and the ux designer concluded no change: the unit already lives in the `aria-label` and tooltip, glyph-plus-number is the established metadata grammar, and `Bot` is the app-wide agent mark shared with `AgentCard`, `QuestionClusterHeader` and `NextUpCard` — swapping it here would fork the vocabulary. Deliberately left unchanged. The one thing allowed, taken since that row was already touched for the autorun fix: the `Bot` glyph size in `StageBoardCard/index.tsx:184` grew from 12 to 14 to match the PR chip icon size.

## Tests

- `StageBoardCard/index.test.tsx:330` pinned the deprecated string `'Auto'`. Updated to assert the rendered text `'Autorun'` plus its tone (`text-primary`, not `text-danger`) so the test reads the real product value instead of only a literal.
- Added `StageBoardCard/index.test.tsx` — "separates delete from archive with a divider in the lifecycle group": asserts the lifecycle action group renders Archive, then a `role="separator"` element, then Delete, in that DOM order. Fails without the change.

## Verification

- `pnpm typecheck` — pass
- `pnpm exec turbo run test --force` — pass, 0 cached across all 4 packages (ui, db, core, desktop), 638 files / 5328 tests in desktop
- `pnpm knip --include files,duplicates,unlisted` — clean (only pre-existing config hints)

## Not done

No relabeling of any action glyph, no reordering beyond the Archive/Restore-Delete separation, no touch to the quick-actions slot, no new separator component.