### PR TITLE
fix(desktop): count threadless resolvers in next up's empty state

### DIFF
--- a/apps/desktop/src/features/session/components/SessionOverviewPane/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/index.test.tsx
@@ -99,6 +99,7 @@ const { store, hooks, runs } = vi.hoisted(() => ({
     openQuestions: [] as ReadonlyArray<OpenQuestion>,
     stage: { stage: 'building', reason: '' } as SessionStageInfo,
     unreadLens: null as 'agents' | 'resolve' | 'workflows' | null,
+    resolverLinks: [] as ReadonlyArray<unknown>,
   },
   runs: {
     lanes: [],
@@ -140,6 +141,10 @@ vi.mock('../../../../store', () => ({
 
 vi.mock('../../../orchestration/hooks/useWorkspaceRuns', () => ({
   useWorkspaceRuns: () => runs,
+}));
+
+vi.mock('../../hooks/useResolverIndex', () => ({
+  useResolverIndex: () => ({ links: hooks.resolverLinks, byThreadId: new Map() }),
 }));
 
 vi.mock('@goodboy/ui', async (importOriginal) => {
@@ -273,6 +278,7 @@ beforeEach(() => {
   hooks.openQuestions = [];
   hooks.stage = { stage: 'building', reason: '' } as SessionStageInfo;
   hooks.unreadLens = null;
+  hooks.resolverLinks = [];
   runs.lanes = [];
   runs.freeAgents = [];
   runs.resolveQueue = [];
@@ -517,6 +523,28 @@ describe('SessionOverviewPane next up', () => {
     store.sessionPhaseRuns = { 'sess-1': [standaloneAgent('completed')] };
     renderPane();
     expect(screen.getByText('Nothing needs you right now')).toBeDefined();
+  });
+
+  it('surfaces a resolver that has no source thread instead of claiming nothing needs you', () => {
+    hooks.resolverLinks = [
+      {
+        agent: {
+          id: 'resolver-no-thread',
+          name: 'resolve the flaky test',
+          status: 'pending',
+          doneAt: null,
+          ordinal: 0,
+          sourceThreadId: null,
+          sourceThreadIds: null,
+        },
+        status: 'pending',
+      },
+    ];
+    const { onSelectLens } = renderPane();
+    expect(screen.queryByText('Nothing needs you right now')).toBeNull();
+    expect(screen.getByText('1 comment to resolve')).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: 'Resolve' }));
+    expect(onSelectLens).toHaveBeenCalledWith('resolve');
   });
 });
 

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/index.tsx
@@ -19,7 +19,10 @@ import {
   selectStandaloneAgents,
   type AgentHomeLens,
 } from '../../agent-kind';
+import { agentThreadIds } from '../../agentThreadIds';
 import { useResolvableCount } from '../../hooks/useResolvableCount';
+import { useResolverIndex } from '../../hooks/useResolverIndex';
+import { resolverLaneEntries } from '../ResolverAgentsLane/resolverLaneEntries';
 import { selectOpenQuestions } from './lib';
 import {
   selectNextUp,
@@ -54,6 +57,14 @@ export const SessionOverviewPane = ({ session, onSelectLens }: Props) => {
   const agentKindOverride = useAppStore((s) => s.agentKindOverride);
   const nonResolverAgents = useNonResolverStandaloneAgents(sessionId);
   const resolvable = useResolvableCount(sessionId);
+  const resolverIndex = useResolverIndex(sessionId);
+  const threadlessActiveResolverCount = useMemo(
+    () =>
+      resolverLaneEntries({ links: resolverIndex.links }).active.filter(
+        (link) => agentThreadIds(link.agent).length === 0,
+      ).length,
+    [resolverIndex.links],
+  );
   const selectAgent = useAppStore((s) => s.selectAgent);
   const setFocusedWorkflowRun = useAppStore((s) => s.setFocusedWorkflowRun);
   const loadPendingResolutions = useAppStore((s) => s.loadPendingResolutions);
@@ -69,7 +80,8 @@ export const SessionOverviewPane = ({ session, onSelectLens }: Props) => {
     resolvable.diffComments +
     resolvable.pending +
     runs.resolveQueue.length +
-    (runs.completedResolveQueue?.length ?? 0);
+    (runs.completedResolveQueue?.length ?? 0) +
+    threadlessActiveResolverCount;
   const questionBlocksRun = openQuestions.some(
     (question) =>
       question.workflowRunId != null && activeRuns.some((run) => run.id === question.workflowRunId),


### PR DESCRIPTION
## Problem

A screenshot from the product critic's walk showed two answers to the same question: NEXT UP said "Nothing needs you right now" directly above a rail reading "Resolve 2" and "Agents 4".

The two predicates as they were:

- **NEXT UP** (`SessionOverviewPane/index.tsx`, via `selectNextUp.ts`): `resolveCount = resolvable.prComments + resolvable.diffComments + resolvable.pending + runs.resolveQueue.length + runs.completedResolveQueue.length`. `runs.resolveQueue` (`useWorkspaceRuns`) only includes standalone agents (no parent, no workflow run) that carry a `sourceThreadId`/`sourceThreadIds`. Kind is irrelevant to that split, only `agentThreadIds(agent).length > 0`.
- **Rail "Resolve N"** (`LensColumn/index.tsx`, via `resolverLaneEntries` over `useResolverIndex`): counts every agent classified `resolver` (by kind or by name) that is not settled (`doneAt == null` and resolver status not `resolved`/`stopped`), independent of whether it has a thread id.

A resolver agent spawned without a source thread (e.g. not from a PR/diff comment) is counted by the rail but invisible to NEXT UP's `resolveCount`, so the empty state fired while the rail was non-zero.

## What changed

`SessionOverviewPane/index.tsx` now also pulls `useResolverIndex(sessionId)` and adds `threadlessActiveResolverCount` to `resolveCount`: the rail's own `resolverLaneEntries({ links }).active` list, filtered to agents with `agentThreadIds(agent).length === 0`. That filter is deliberate: agents with a thread id are already counted through `runs.resolveQueue`, so this only adds the delta the rail was already seeing and NEXT UP wasn't. The empty state ("Nothing needs you right now") is now reachable only when the rail's Resolve count is also zero.

Checked renderability before extending the count: the "N comments to resolve" card carries no `itemId` and its action just opens the Resolve lens (`onSelectLens('resolve')`). That lens already renders resolver agents without a thread id through the same `resolverLaneEntries`/`useResolverIndex` pair the rail uses, so a threadless resolver is fully actionable once NEXT UP points there.

## Shared predicate

Did not introduce a new selector. NEXT UP now calls the exact same `resolverLaneEntries`/`useResolverIndex` combination the rail already uses (just with an additional threadless filter to avoid double-counting against `resolveQueue`), so the two surfaces read from one source of truth for "what counts as an active resolver" rather than drifting independently.

## What this does not do

- Does not change what the rail counts.
- Does not touch `SessionWorkspace/index.tsx` or `StageBoardCard/index.tsx`.
- Does not redesign either surface, only reconciles the count.

## Tests

`SessionOverviewPane/index.test.tsx`: new case "surfaces a resolver that has no source thread instead of claiming nothing needs you" seeds a resolver-classified agent (`status: 'pending'`, no `sourceThreadId`/`sourceThreadIds`) through the same `useResolverIndex` mock the rail's own test file uses. Asserts the empty state text is gone, the "1 comment to resolve" card is shown, and clicking Resolve routes to the resolve lens. Verified by hand that reverting only the production change makes this test fail (it falls through to the fresh-session empty state instead).

No issue filed this; it came from the product critic's walk, so no `Closes` keyword.