### PR TITLE
fix(desktop): say stopping while the run is still deciding

### DIFF
--- a/.claude/skills/continuous-delivery/references/repo-gotchas.md
+++ b/.claude/skills/continuous-delivery/references/repo-gotchas.md
@@ -106,6 +106,10 @@ placeholder, so could-not-run is the exception, not the default.
   never reuse a walk file from a previous release. If a claim cannot be
   reached from an empty database plus deliberate seed rows, that is a
   finding about the app's testability, not something to work around.
+- A state that only exists in memory while a call is in flight has an env
+  var to reach it: `GOODBOY_QA_DECIDING_RUNS` marks workflow runs as
+  deciding at boot, so the orchestrator "stopping" state is reachable from a
+  seeded database with no provider agent. See `docs/testing.md`.
 - One GUI walker at a time. `GOODBOY_DB_FILE` isolates the database, not
   the process table: a walker that kills a stray instance by process name
   (`pkill`) can take down a sibling walker's app, including one still

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -21,6 +21,7 @@ mod planner;
 mod provider_credentials;
 mod provider_lifecycle;
 mod providers;
+mod qa_preview;
 mod releases;
 mod repo;
 mod scripts;
@@ -356,6 +357,7 @@ pub fn run() {
             slack::slack_list_users,
             slack::slack_post_reply,
             slack::slack_add_reaction,
+            qa_preview::qa_deciding_workflow_runs,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/apps/desktop/src-tauri/src/qa_preview.rs
+++ b/apps/desktop/src-tauri/src/qa_preview.rs
@@ -17,7 +17,7 @@ pub fn qa_deciding_workflow_runs() -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_run_ids;
+    use super::{parse_run_ids, qa_deciding_workflow_runs, DECIDING_RUNS_ENV};
 
     #[test]
     fn reads_nothing_from_an_empty_value() {
@@ -35,5 +35,16 @@ mod tests {
                 "run-3".to_string()
             ]
         );
+    }
+
+    #[test]
+    fn command_reads_the_process_environment_at_call_time() {
+        std::env::remove_var(DECIDING_RUNS_ENV);
+        assert!(qa_deciding_workflow_runs().is_empty());
+
+        std::env::set_var(DECIDING_RUNS_ENV, "run-9,run-10");
+        let result = qa_deciding_workflow_runs();
+        std::env::remove_var(DECIDING_RUNS_ENV);
+        assert_eq!(result, vec!["run-9".to_string(), "run-10".to_string()]);
     }
 }

--- a/apps/desktop/src-tauri/src/qa_preview.rs
+++ b/apps/desktop/src-tauri/src/qa_preview.rs
@@ -1,0 +1,39 @@
+const DECIDING_RUNS_ENV: &str = "GOODBOY_QA_DECIDING_RUNS";
+
+fn parse_run_ids(raw: &str) -> Vec<String> {
+    raw.split(',')
+        .map(|entry| entry.trim().to_string())
+        .filter(|entry| !entry.is_empty())
+        .collect()
+}
+
+#[tauri::command]
+pub fn qa_deciding_workflow_runs() -> Vec<String> {
+    match std::env::var(DECIDING_RUNS_ENV) {
+        Ok(raw) => parse_run_ids(&raw),
+        Err(_) => Vec::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_run_ids;
+
+    #[test]
+    fn reads_nothing_from_an_empty_value() {
+        assert!(parse_run_ids("").is_empty());
+        assert!(parse_run_ids("  ,  ").is_empty());
+    }
+
+    #[test]
+    fn reads_every_trimmed_run_id() {
+        assert_eq!(
+            parse_run_ids(" run-1 , run-2,run-3 "),
+            vec![
+                "run-1".to_string(),
+                "run-2".to_string(),
+                "run-3".to_string()
+            ]
+        );
+    }
+}

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowRailCard.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowRailCard.tsx
@@ -17,6 +17,7 @@ type Props = {
   readonly agents: ReadonlyArray<Agent>;
   readonly costUsd: number | null;
   readonly predecessorName: string;
+  readonly isOrchestrating: boolean;
   readonly onSelect: () => void;
   readonly onRestore: () => void;
 };
@@ -27,6 +28,7 @@ export const WorkflowRailCard = ({
   agents,
   costUsd,
   predecessorName,
+  isOrchestrating,
   onSelect,
   onRestore,
 }: Props) => {
@@ -80,6 +82,7 @@ export const WorkflowRailCard = ({
               workflow={workflow}
               agents={agents}
               predecessorName={predecessorName}
+              isOrchestrating={isOrchestrating}
             />
             {stepLine != null ? (
               <span className="line-clamp-1 text-2xs text-muted-foreground">{stepLine}</span>

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowsPane.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowsPane.test.tsx
@@ -12,6 +12,7 @@ type Store = {
   messages: Record<string, ReadonlyArray<never>>;
   agentRunHistory: Record<string, ReadonlyArray<never>>;
   focusedWorkflowRunId: Record<string, string | null>;
+  orchestratingWorkflowRuns: Record<string, boolean>;
   lensHistory: Record<string, { readonly index: number }>;
   lensGo: ReturnType<typeof vi.fn>;
   setFocusedWorkflowRun: ReturnType<typeof vi.fn>;
@@ -45,6 +46,7 @@ const store: Store = {
   messages: {},
   agentRunHistory: {},
   focusedWorkflowRunId: {},
+  orchestratingWorkflowRuns: {},
   lensHistory: {},
   lensGo: vi.fn(),
   setFocusedWorkflowRun: vi.fn(),
@@ -155,6 +157,7 @@ beforeEach(() => {
   store.messages = {};
   store.agentRunHistory = {};
   store.focusedWorkflowRunId = {};
+  store.orchestratingWorkflowRuns = {};
   store.setFocusedWorkflowRun.mockReset();
   store.makeWorkflowPreset.mockReset();
   store.restoreWorkflow.mockReset();
@@ -437,6 +440,45 @@ describe('WorkflowsPane', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Restore' }));
 
     expect(store.restoreWorkflow).toHaveBeenCalledWith(SESSION_ID, 'run-1');
+  });
+
+  it('reads a stopped run as stopping while the decision it started is still in flight', () => {
+    store.orchestratingWorkflowRuns = { 'run-1': true };
+    render(
+      <WorkflowsPane
+        session={buildSession({
+          runIds: ['run-1'],
+          runOverrides: {
+            'run-1': {
+              executionMode: 'dynamic',
+              orchestrationStop: { kind: 'operator', message: 'you stopped it' },
+            },
+          },
+        })}
+      />,
+    );
+
+    expect(screen.getByText('Stopping')).toBeDefined();
+    expect(screen.queryByText('Stopped')).toBeNull();
+  });
+
+  it('reads a stopped run as stopped once no decision is in flight', () => {
+    render(
+      <WorkflowsPane
+        session={buildSession({
+          runIds: ['run-1'],
+          runOverrides: {
+            'run-1': {
+              executionMode: 'dynamic',
+              orchestrationStop: { kind: 'operator', message: 'you stopped it' },
+            },
+          },
+        })}
+      />,
+    );
+
+    expect(screen.getByText('Stopped')).toBeDefined();
+    expect(screen.queryByText('Stopping')).toBeNull();
   });
 
   it('files a completed dynamic run under the completed toggle', () => {

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowsPane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowsPane.tsx
@@ -33,6 +33,7 @@ export const WorkflowsPane = ({ session }: Props) => {
   const focusedWorkflowRunId = useAppStore(
     (state) => state.focusedWorkflowRunId[sessionId] ?? null,
   );
+  const orchestratingWorkflowRuns = useAppStore((state) => state.orchestratingWorkflowRuns);
   const setFocusedWorkflowRun = useAppStore((state) => state.setFocusedWorkflowRun);
   const restoreWorkflow = useAppStore((state) => state.restoreWorkflow);
   const [showFiled, setShowFiled] = useState(false);
@@ -67,6 +68,7 @@ export const WorkflowsPane = ({ session }: Props) => {
           agents={agents}
           costUsd={costUsd}
           predecessorName={predecessorName}
+          isOrchestrating={orchestratingWorkflowRuns?.[run.id] ?? false}
           onSelect={() => setFocusedWorkflowRun(sessionId, run.id)}
           onRestore={() => void restoreWorkflow(sessionId, run.id)}
         />

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.test.tsx
@@ -137,6 +137,7 @@ type RenderParams = {
     autoRun: boolean,
   ) => Promise<void>;
   readonly variant?: 'sidebar' | 'detail';
+  readonly focusedWorkflowRunId?: WorkflowRunId | null;
 };
 
 const renderDetail = ({
@@ -151,6 +152,7 @@ const renderDetail = ({
   startWorkflowRun = vi.fn(async () => undefined),
   setWorkflowRunAutoRun = vi.fn(async () => undefined),
   variant = 'detail',
+  focusedWorkflowRunId = null,
 }: RenderParams = {}) =>
   render(
     <WorkflowRow
@@ -163,7 +165,7 @@ const renderDetail = ({
       actionableStepIdByRunId={new Map([[RUN_ID, actionableStepId]])}
       blockReasonByRunId={new Map([[RUN_ID, blockReason]])}
       countUnread={() => 0}
-      focusedWorkflowRunId={null}
+      focusedWorkflowRunId={focusedWorkflowRunId}
       workflowExpand={undefined}
       workflowNameByRunId={new Map()}
       forceExpanded
@@ -414,6 +416,37 @@ describe('WorkflowRow step-in-flight predicate', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Autorun on' }));
 
     expect(screen.getByRole('group', { name: 'Stop this run?' })).toBeDefined();
+  });
+
+  it('reads the collapsed row as stopping while the decision is still in flight', () => {
+    storeMocks.orchestratingWorkflowRuns[RUN_ID] = true;
+    renderDetail({
+      runOverride: {
+        ...run,
+        executionMode: 'dynamic',
+        orchestrationStop: { kind: 'operator', message: 'you stopped it' },
+      },
+      variant: 'sidebar',
+      focusedWorkflowRunId: 'run-2' as WorkflowRunId,
+    });
+
+    expect(screen.getByText('Stopping')).toBeDefined();
+    expect(screen.queryByText('Stopped')).toBeNull();
+  });
+
+  it('reads the collapsed row as stopped once nothing is in flight', () => {
+    renderDetail({
+      runOverride: {
+        ...run,
+        executionMode: 'dynamic',
+        orchestrationStop: { kind: 'operator', message: 'you stopped it' },
+      },
+      variant: 'sidebar',
+      focusedWorkflowRunId: 'run-2' as WorkflowRunId,
+    });
+
+    expect(screen.getByText('Stopped')).toBeDefined();
+    expect(screen.queryByText('Stopping')).toBeNull();
   });
 });
 

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.tsx
@@ -236,6 +236,7 @@ export const WorkflowRow = ({
                   workflow={workflow}
                   agents={wfAgents}
                   predecessorName={predecessorName}
+                  isOrchestrating={isOrchestrating}
                   hasOrchestratorStrip={hasOrchestratorStrip}
                 />
               </div>
@@ -283,6 +284,7 @@ export const WorkflowRow = ({
               workflow={workflow}
               agents={wfAgents}
               predecessorName={predecessorName}
+              isOrchestrating={isOrchestrating}
               hasOrchestratorStrip={hasOrchestratorStrip}
             />
             {total > 0 ? (

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRunStatus.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRunStatus.test.tsx
@@ -44,12 +44,14 @@ const EMPTY_AGENTS: ReadonlyArray<Agent> = [];
 type RenderParams = {
   readonly runOverride: WorkflowRun;
   readonly hasOrchestratorStrip?: boolean;
+  readonly isOrchestrating?: boolean;
   readonly predecessorName?: string;
 };
 
 const renderStatus = ({
   runOverride,
   hasOrchestratorStrip = false,
+  isOrchestrating = false,
   predecessorName = '',
 }: RenderParams) =>
   render(
@@ -58,6 +60,7 @@ const renderStatus = ({
       workflow={workflow}
       agents={EMPTY_AGENTS}
       predecessorName={predecessorName}
+      isOrchestrating={isOrchestrating}
       hasOrchestratorStrip={hasOrchestratorStrip}
     />,
   );
@@ -96,6 +99,37 @@ describe('WorkflowRunStatus', () => {
     expect(screen.queryByTestId('workflow-orchestrator-failed')).toBeNull();
   });
 
+  it('says stopping, not stopped, while the decision it interrupted is in flight', () => {
+    renderStatus({
+      runOverride: { ...run, orchestrationStop: { kind: 'operator', message: 'you stopped it' } },
+      isOrchestrating: true,
+    });
+
+    expect(screen.getByText('Stopping')).toBeDefined();
+    expect(screen.queryByTestId('workflow-orchestrator-stopped')).toBeNull();
+    expect(screen.queryByTestId('workflow-orchestrator-failed')).toBeNull();
+  });
+
+  it('settles on stopped once the decision in flight has landed', () => {
+    renderStatus({
+      runOverride: { ...run, orchestrationStop: { kind: 'operator', message: 'you stopped it' } },
+      isOrchestrating: false,
+    });
+
+    expect(screen.getByText('Stopped')).toBeDefined();
+    expect(screen.queryByTestId('workflow-orchestrator-stopping')).toBeNull();
+  });
+
+  it('leaves the stopping sentence to the strip when the strip is there', () => {
+    const { container } = renderStatus({
+      runOverride: { ...run, orchestrationStop: { kind: 'operator', message: 'you stopped it' } },
+      isOrchestrating: true,
+      hasOrchestratorStrip: true,
+    });
+
+    expect(container.textContent).toBe('');
+  });
+
   it('says a run was stopped even while an agent still reads as running', () => {
     const stillRunning: ReadonlyArray<Agent> = [
       {
@@ -113,6 +147,7 @@ describe('WorkflowRunStatus', () => {
         workflow={workflow}
         agents={stillRunning}
         predecessorName=""
+        isOrchestrating={false}
       />,
     );
 

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRunStatus.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRunStatus.tsx
@@ -7,6 +7,7 @@ type Props = {
   readonly workflow: Workflow;
   readonly agents: ReadonlyArray<Agent>;
   readonly predecessorName: string;
+  readonly isOrchestrating: boolean;
   readonly hasOrchestratorStrip?: boolean;
 };
 
@@ -15,6 +16,7 @@ export const WorkflowRunStatus = ({
   workflow,
   agents,
   predecessorName,
+  isOrchestrating,
   hasOrchestratorStrip = false,
 }: Props) => {
   const completedSteps = agents.filter(
@@ -59,6 +61,18 @@ export const WorkflowRunStatus = ({
     );
   }
   const stop = run.orchestrationStop;
+  if (stop?.kind === 'operator' && isOrchestrating && !hasOrchestratorStrip) {
+    return (
+      <span
+        className={cn(baseClass, 'bg-warning/10 text-warning')}
+        title="Waiting for the decision already in flight"
+        data-testid="workflow-orchestrator-stopping"
+      >
+        <CircleStop size={10} aria-hidden />
+        Stopping
+      </span>
+    );
+  }
   if (stop?.kind === 'operator' && !hasOrchestratorStrip) {
     return (
       <span

--- a/apps/desktop/src/store/slices/boot/hydrate.ts
+++ b/apps/desktop/src/store/slices/boot/hydrate.ts
@@ -26,6 +26,7 @@ import {
 } from '../../../features/settings/settings';
 import { formatError } from '../../../shared/lib/errors';
 import { recoverStagedFileVersions } from '../file-versions/recoverStagedFileVersions';
+import { applyQaDecidingPreview } from '../workflows/applyQaDecidingPreview';
 import { drainAuditRetryQueue } from './auditRetryQueue';
 import type { GetFn, SetFn } from './types';
 
@@ -173,6 +174,8 @@ export const hydrate = (set: SetFn, get: GetFn) => {
             formatError(error),
           );
         }
+
+        await applyQaDecidingPreview({ set }).catch(() => {});
 
         set({ bootPhase: 'restoring-session' });
         const reloadIntent = consumeReloadIntent();

--- a/apps/desktop/src/store/slices/boot/index.test.ts
+++ b/apps/desktop/src/store/slices/boot/index.test.ts
@@ -33,8 +33,12 @@ import type {
   WorkspaceScriptId,
 } from '@goodboy/types';
 
+const { invokeSpy } = vi.hoisted(() => ({
+  invokeSpy: vi.fn(async (_command?: unknown) => null as unknown),
+}));
+
 vi.mock('@tauri-apps/api/core', () => ({
-  invoke: vi.fn(async () => null),
+  invoke: invokeSpy,
 }));
 
 vi.mock('@tauri-apps/api/event', () => ({
@@ -439,6 +443,7 @@ let resetState: Record<string, unknown> | null = null;
 describe('store contract', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
+    invokeSpy.mockImplementation(async () => null);
     invokeBudgetRuleListSpy.mockResolvedValue([]);
     invokeBudgetAlertsListSpy.mockResolvedValue([]);
     invokeSessionBudgetGetSpy.mockResolvedValue(null);
@@ -571,6 +576,21 @@ describe('store contract', () => {
 
       expect(bootPhaseAtCall).not.toBeNull();
       expect(bootPhaseAtCall).not.toBe('ready');
+    });
+
+    it('applies the qa deciding preview named by the environment at boot', async () => {
+      const store = await getStore();
+      store.setState({ orchestratingWorkflowRuns: {} } as never);
+      invokeSpy.mockImplementation(async (command: unknown) => {
+        if (command === 'qa_deciding_workflow_runs') {
+          return ['run-qa-preview'];
+        }
+        return null;
+      });
+
+      await store.getState().hydrate();
+
+      expect(store.getState().orchestratingWorkflowRuns).toEqual({ 'run-qa-preview': true });
     });
 
     it('offers to clean the session folders left behind on disk', async () => {

--- a/apps/desktop/src/store/slices/workflows/applyQaDecidingPreview.test.ts
+++ b/apps/desktop/src/store/slices/workflows/applyQaDecidingPreview.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { invokeSpy } = vi.hoisted(() => ({ invokeSpy: vi.fn() }));
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: invokeSpy }));
+
+import { applyQaDecidingPreview } from './applyQaDecidingPreview';
+
+type State = Record<string, unknown>;
+
+const harness = (state: State) => {
+  const set = vi.fn((updater: unknown) => {
+    if (typeof updater === 'function') {
+      Object.assign(state, (updater as (current: State) => State)(state));
+      return;
+    }
+    Object.assign(state, updater as State);
+  });
+  return { set: set as never, state };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('applyQaDecidingPreview', () => {
+  it('marks the named runs as deciding without touching the rest', async () => {
+    const state: State = { orchestratingWorkflowRuns: { 'run-9': true } };
+    const { set } = harness(state);
+    invokeSpy.mockResolvedValueOnce(['run-1', 'run-2']);
+
+    await applyQaDecidingPreview({ set });
+
+    expect(invokeSpy).toHaveBeenCalledWith('qa_deciding_workflow_runs');
+    expect(state['orchestratingWorkflowRuns']).toEqual({
+      'run-9': true,
+      'run-1': true,
+      'run-2': true,
+    });
+  });
+
+  it('leaves the store alone when the environment names no run', async () => {
+    const state: State = { orchestratingWorkflowRuns: {} };
+    const { set } = harness(state);
+    invokeSpy.mockResolvedValueOnce([]);
+
+    await applyQaDecidingPreview({ set });
+
+    expect(set).not.toHaveBeenCalled();
+    expect(state['orchestratingWorkflowRuns']).toEqual({});
+  });
+});

--- a/apps/desktop/src/store/slices/workflows/applyQaDecidingPreview.ts
+++ b/apps/desktop/src/store/slices/workflows/applyQaDecidingPreview.ts
@@ -1,0 +1,20 @@
+import { invoke } from '@tauri-apps/api/core';
+import type { SetFn } from './types';
+
+type Params = {
+  readonly set: SetFn;
+};
+
+export const applyQaDecidingPreview = async ({ set }: Params): Promise<void> => {
+  const runIds = await invoke<ReadonlyArray<string>>('qa_deciding_workflow_runs');
+  if (runIds.length === 0) {
+    return;
+  }
+  const seeded: Record<string, boolean> = {};
+  for (const runId of runIds) {
+    seeded[runId] = true;
+  }
+  set((state) => ({
+    orchestratingWorkflowRuns: { ...state.orchestratingWorkflowRuns, ...seeded },
+  }));
+};

--- a/apps/desktop/src/store/slices/workflows/orchestrateNextStep.test.ts
+++ b/apps/desktop/src/store/slices/workflows/orchestrateNextStep.test.ts
@@ -79,7 +79,7 @@ import {
   OrchestratorClient,
   ROLE_DEFAULTS,
 } from '@goodboy/core';
-import { orchestrateNextStep } from './orchestrateNextStep';
+import { orchestrateNextStep, persistOrchestrationStop } from './orchestrateNextStep';
 import { continueWorkflowRun } from './continueWorkflowRun';
 
 const WORKSPACE_ID = 'workspace-1' as WorkspaceId;
@@ -205,6 +205,19 @@ const baseState = (): State => {
     emitNotification: vi.fn(async () => undefined),
   };
 };
+
+const OPERATOR_STOP = {
+  kind: 'operator',
+  message: 'You stopped this run. The step in flight was skipped.',
+} as const;
+
+const stopFromOperator = async (set: never): Promise<void> =>
+  persistOrchestrationStop({
+    set,
+    sessionId: SESSION_ID,
+    workflowRunId: WORKFLOW_RUN_ID,
+    stop: OPERATOR_STOP,
+  });
 
 const harness = (state: State) => {
   const set = vi.fn((updater: unknown) => {
@@ -852,6 +865,43 @@ describe('orchestrateNextStep', () => {
     expect(updateStopSpy).not.toHaveBeenCalledWith({}, WORKFLOW_RUN_ID, null);
     expect(invokeWorkflowUpsertSpy).not.toHaveBeenCalled();
     expect(state['activateWorkflowAgent']).not.toHaveBeenCalled();
+  });
+
+  it('reads as stopped by you when the decision in flight then throws', async () => {
+    const state = baseState();
+    const { set, get } = harness(state);
+    decideSpy.mockImplementationOnce(async () => {
+      await stopFromOperator(set);
+      throw new Error('the orchestrator timed out after 120s');
+    });
+
+    await orchestrateNextStep(set, get)(SESSION_ID, WORKFLOW_RUN_ID);
+
+    const stopped = (state['sessions'] as ReadonlyArray<Session>)[0]!.workflowRuns[0]!;
+    expect(stopped.orchestrationStop).toEqual(OPERATOR_STOP);
+    expect(updateStopSpy).toHaveBeenLastCalledWith({}, WORKFLOW_RUN_ID, OPERATOR_STOP);
+    expect(state['appendTurnEvent']).not.toHaveBeenCalled();
+    expect(state['emitNotification']).not.toHaveBeenCalled();
+  });
+
+  it('reads as stopped by you when the reply in flight is not a decision', async () => {
+    const state = baseState();
+    const { set, get } = harness(state);
+    decideSpy.mockImplementationOnce(async () => {
+      await stopFromOperator(set);
+      return { decision: null, usage: BILLED_USAGE, model: 'claude-haiku-4-5' };
+    });
+
+    await orchestrateNextStep(set, get)(SESSION_ID, WORKFLOW_RUN_ID);
+
+    const stopped = (state['sessions'] as ReadonlyArray<Session>)[0]!.workflowRuns[0]!;
+    expect(stopped.orchestrationStop).toEqual(OPERATOR_STOP);
+    expect(updateStopSpy).toHaveBeenLastCalledWith({}, WORKFLOW_RUN_ID, OPERATOR_STOP);
+    expect(state['appendTurnEvent']).not.toHaveBeenCalled();
+    expect(insertTelemetrySpy).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({ kind: 'orchestrator', estimatedCostUsd: 0.0123 }),
+    );
   });
 
   it('hands the operator hints of the run to the orchestrator', async () => {

--- a/apps/desktop/src/store/slices/workflows/orchestrateNextStep.ts
+++ b/apps/desktop/src/store/slices/workflows/orchestrateNextStep.ts
@@ -222,6 +222,19 @@ const persistOrchestrationFailure = async ({
     stop: { kind: 'failure', message },
   });
 
+type OperatorStopParams = {
+  readonly get: GetFn;
+  readonly sessionId: SessionId;
+  readonly workflowRunId: WorkflowRunId;
+};
+
+const hasOperatorStop = ({ get, sessionId, workflowRunId }: OperatorStopParams): boolean => {
+  const current = get()
+    .sessions.find((candidate) => candidate.id === sessionId)
+    ?.workflowRuns.find((candidate) => candidate.id === workflowRunId);
+  return current?.orchestrationStop?.kind === 'operator';
+};
+
 const failureLabel = (error: unknown): string => {
   if (error instanceof OrchestratorProviderError) {
     return `provider refused the request: ${error.detail}`;
@@ -470,6 +483,9 @@ export const orchestrateNextStep = (set: SetFn, get: GetFn) => {
           stepBudget: ORCHESTRATOR_STEP_BUDGET,
         });
       } catch (error) {
+        if (hasOperatorStop({ get, sessionId, workflowRunId })) {
+          return;
+        }
         const message = `${failureLabel(error)} (${routing.providerId}/${routing.model})`;
         await persistOrchestrationFailure({ set, sessionId, workflowRunId, message });
         emitDecision({
@@ -487,6 +503,18 @@ export const orchestrateNextStep = (set: SetFn, get: GetFn) => {
       }
       const decision = result.decision;
       if (decision == null) {
+        if (hasOperatorStop({ get, sessionId, workflowRunId })) {
+          await recordOrchestratorUsage({
+            set,
+            get,
+            sessionId,
+            agentId: null,
+            provider: routing.providerId,
+            model: result.model,
+            usage: result.usage,
+          });
+          return;
+        }
         await persistOrchestrationFailure({
           set,
           sessionId,
@@ -519,10 +547,7 @@ export const orchestrateNextStep = (set: SetFn, get: GetFn) => {
         );
         return;
       }
-      const afterDecide = get()
-        .sessions.find((candidate) => candidate.id === sessionId)
-        ?.workflowRuns.find((candidate) => candidate.id === workflowRunId);
-      if (afterDecide?.orchestrationStop?.kind === 'operator') {
+      if (hasOperatorStop({ get, sessionId, workflowRunId })) {
         await recordOrchestratorUsage({
           set,
           get,

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -37,3 +37,27 @@ same treatment: assert it from source, in that folder.
 ## The golden rule
 
 If a test fails because the component / store / hook does the wrong thing, **fix the code, not the test**. Never weaken a test to make it pass.
+
+## Reaching a state that only exists in memory
+
+Some run states live only in the store while an async call is in flight, so
+no database row reaches them and only a live provider run produces them. The
+orchestrator "stopping" state is one: it needs an operator stop on the run
+plus a decision still in flight, and the in-flight flag
+(`orchestratingWorkflowRuns`) is never persisted, because a decision does not
+survive the process that started it.
+
+To see that state in a real build without spawning agents, name the run ids
+in `GOODBOY_QA_DECIDING_RUNS` when launching the binary:
+
+```
+GOODBOY_QA_DECIDING_RUNS=<run-id>[,<run-id>] \
+  GOODBOY_DB_FILE=<path> .../Goodboy.app/Contents/MacOS/goodboy-desktop
+```
+
+Boot marks those runs as deciding in memory only. Seed the operator stop
+itself as a normal row (`workflow_runs.orchestration_stop`) and the run
+reports **Stopping** on the rail card, the collapsed sidebar row and the
+orchestrator strip. Nothing is written back, so a relaunch without the
+variable reports **Stopped** again. Never persist the in-flight flag: a
+stored "deciding right now" is false the moment the app restarts.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -56,8 +56,16 @@ GOODBOY_QA_DECIDING_RUNS=<run-id>[,<run-id>] \
 ```
 
 Boot marks those runs as deciding in memory only. Seed the operator stop
-itself as a normal row (`workflow_runs.orchestration_stop`) and the run
-reports **Stopping** on the rail card, the collapsed sidebar row and the
-orchestrator strip. Nothing is written back, so a relaunch without the
-variable reports **Stopped** again. Never persist the in-flight flag: a
-stored "deciding right now" is false the moment the app restarts.
+itself as an ordinary row in `session_workflows`, keyed by
+`workflow_run_id`: a non-empty `orchestration_error` carries the message
+(an empty value means no stop exists at all, see `toStop` in
+`packages/db/src/queries/session-workflow.ts`) and `orchestration_stop_kind`
+must be `'operator'`. With that row and the run named in
+`GOODBOY_QA_DECIDING_RUNS`, the plain **Stopping** pill shows on the rail
+card and on the collapsed sidebar row. To see it on the richer orchestrator
+strip instead, the row also needs `execution_mode = 'dynamic'` and the
+sidebar row expanded: the strip only renders in that combination, and the
+plain pill hides itself in favor of it. Nothing is written back, so a
+relaunch without the variable reports **Stopped** again. Never persist the
+in-flight flag: a stored "deciding right now" is false the moment the app
+restarts.


### PR DESCRIPTION
A run said a thing that was not true for about two minutes, on the exact
surface a user acts from. Three defects, one concern.

## (a) A Stopped badge rendered the instant a stop persisted

Surfaced by v0.1.76's own verification, confirmed by a read of `origin/main`.
`WorkflowRunStatus` took no `isOrchestrating` prop at all, so its operator
stop branch fired the moment `orchestrationStop.kind === 'operator'` landed,
while the decision already in flight kept running for its full window. The
expanded dynamic row was fine: `hasOrchestratorStrip` handed the sentence to
`OrchestratorPanel`, which is `isOrchestrating` aware and already had a
`stopping` phase nobody could see. Every other surface lied. The stop button
sits on the collapsed row, so a user could stop from the surface that then
told them it was done.

The failure class here is a gate wired at one entry point with sibling call
sites left behind, so every render site is wired, and `isOrchestrating` is a
**required** prop on both `WorkflowRunStatus` and `WorkflowRailCard`: a call
site that forgets it now fails typecheck.

Render sites:

| site | before | after |
| --- | --- | --- |
| `WorkflowRow.tsx:235` (detail) | strip owns it when dynamic and expanded, badge otherwise | passes `isOrchestrating` |
| `WorkflowRow.tsx:283` (collapsed sidebar) | `Stopped`, always | `Stopping` while deciding |
| `WorkflowRailCard.tsx:80` (rail card) | `Stopped`, always, no strip prop at all | `Stopping` while deciding |
| `WorkflowsPane.tsx:64` (feeds the rail card) | never read `orchestratingWorkflowRuns` | reads it per run |
| `OrchestratorPanel/orchestratorState.ts:103` | already correct | untouched |

## (b) A user's stop got overwritten by a failure

If the decision in flight **threw** after a user stop,
`persistOrchestrationFailure` overwrote the operator stop, so `Stopping`
resolved to `Last decision failed` instead of `Stopped by you`, on exactly
the timeout path the stop exists for. The success path at `:525` already
guarded against this by re-reading the run; the catch block did not.

The scout found a sibling the brief did not have: the `decision === null`
branch (a decision that lands but cannot be parsed) had the identical
missing guard, one call earlier than the existing re-read. Fixing only the
throw path would have let the same bug back in through a different trigger,
so **both** branches are guarded:

- `catch` on a thrown decide: re-reads the run, and if the operator stopped
  it, returns and leaves the stop alone. No failure stop, no blocked
  decision event, no error notification for a call the user cancelled.
- `decision === null`: same re-read, but the provider did bill for the reply,
  so it records the usage with no agent to attach it to, exactly as the
  success-path guard does, then returns.

Both now go through one `hasOperatorStop` helper, and the success path's
inline re-read moves onto it too, so the three branches cannot drift.

## (c) The stopping state was structurally unverifiable

Standing follow-through, two releases old. `isOrchestrating` reads
`orchestratingWorkflowRuns`, an in-memory store map with no database column
and one writer. No amount of seeding reaches it; only a live orchestrated
run does, which spawns billed provider agents against real directories. The
`stopping` sentence has therefore never been seen by anyone.

**What this adds**: a `qa_deciding_workflow_runs` command reads
`GOODBOY_QA_DECIDING_RUNS` from the process environment, and boot marks
those run ids as deciding in memory. Seed the operator stop as an ordinary
row in `session_workflows`, keyed by `workflow_run_id`, with a non-empty
`orchestration_error` and `orchestration_stop_kind = 'operator'`. Launch
with the variable and the run reports `Stopping` on the rail card and the
collapsed row; seeing it on the richer orchestrator strip also needs
`execution_mode = 'dynamic'` and the sidebar row expanded.

**Why that shape.** The cheapest option on the table was an
`import.meta.env.DEV` gate, and it does not work: the documented QA recipe
runs a release build, where that gate is compiled out and there is no
console, no URL bar and no keyboard. An environment variable is the one
channel that build already accepts, and it satisfies the three constraints:
it cannot be reached by accident, since an unset variable is an empty list
and the ids must be named exactly; it does not change what a real run does,
since `setDeciding` overwrites the seeded value on the first real decide;
and **nothing is persisted**. That last point is the whole design. A
decision dies with the process that started it, so a stored "deciding right
now" would be false the moment the app relaunched. Relaunching without the
variable reports `Stopped` again.

Documented in `docs/testing.md`, with a pointer from the QA walk recipe.

## Tests

- `WorkflowRunStatus.test.tsx`: `Stopping` while a decide is in flight,
  `Stopped` once it is not, and nothing at all when the strip owns the
  sentence. Rendered text, not `aria-label`, so text and accessible name
  cannot drift unwatched.
- `WorkflowRow.test.tsx`: the collapsed row reads `Stopping` from the store
  flag, and `Stopped` without it. This is the surface the stop button sits
  on and it had no badge coverage.
- `WorkflowsPane.test.tsx`: the rail card reads it too. `WorkflowRailCard`
  had no test file, so a call site left un-wired there was invisible to CI.
- `orchestrateNextStep.test.ts`: a stop written mid-flight survives a thrown
  decide, and survives an unparseable reply with the usage still recorded.
  Both write the stop through the real `persistOrchestrationStop` and assert
  the persisted row was never replaced.
- `applyQaDecidingPreview.test.ts` and two Rust unit tests for the parsing.

Each of these was checked against a deliberate break of the code it covers
and each went red.

**No test was rewritten.** The existing
`never reads an operator stop as an orchestrator failure` still describes
intended behaviour for a run with nothing in flight and keeps passing
unchanged.

## Not done

The orchestrator surface is not redesigned: a separate spike this release
proposed consolidating it and its conclusion is still with the owner.

One thing found and deliberately left: while a decide is in flight, a stale
`budget` or `failure` stop from an earlier attempt still renders its own
badge, though `OrchestratorPanel` reports `deciding` for the same state.
Same class of lie, different trigger, not named in this item and not
scouted. Worth its own look.

Part of #1333



## Repair (post pass-with-notes)

The verifier passed this with one blocking note: `docs/testing.md` told the
reader to seed the operator stop as `workflow_runs.orchestration_stop`, a
table and column that do not exist. Verified against
`packages/db/src/migrations/m094-workflow-orchestration-state.ts`,
`m102-workflow-orchestration-stop-kind.ts` and the `toStop` reader in
`packages/db/src/queries/session-workflow.ts`: the real shape is
`session_workflows.orchestration_error` (message, empty means no stop) and
`session_workflows.orchestration_stop_kind = 'operator'`, keyed by
`workflow_run_id`. Fixed in the doc and above, plus the unstated
precondition that the orchestrator strip (as opposed to the plain rail
card / collapsed row pill) only shows for `execution_mode = 'dynamic'` with
the row expanded.

Also hardened the two wrapper boundaries the verifier's sabotages S10 and
S11 both slipped past: `applyQaDecidingPreview` and
`qa_deciding_workflow_runs` were pure-function tested but nothing tested the
`hydrate.ts:178` call site or the Tauri command itself. Added one test per
boundary (`apps/desktop/src/store/slices/boot/index.test.ts`,
`apps/desktop/src-tauri/src/qa_preview.rs`), each confirmed red when its
wrapper was neutered and green once restored.

Not fixed, reported instead: `WorkflowRunStatus.tsx:88`/`:100` name their
`budget`/generic-failure badges without an `isOrchestrating` term while
`orchestratorState.ts:111` reports `deciding` for the same underlying state
(the sibling lie called out below); and `orchestratorState.ts` checks its
`isOrchestrating` arms (`:103`, `:111`) before the `outcome === 'done'` arm
(`:114`), a pre-existing precedence issue. Both out of scope for this
repair.