### PR TITLE
chore(repo): bump version to 0.1.77

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ scrolled, so the controls went off-surface at any sidebar width.
 That row now scrolls horizontally, with a fade at each edge when there is more
 to reach. With a single mount it looks exactly as it did.
 
-### [#1363] The board says it is checking GitHub instead of saying there is no pull request
+### [#1363] An unfetched pull request reads as checking, not missing
 
 At launch the board placed every session it had not yet asked GitHub about as
 though the answer were already in, then moved cards between columns one at a
@@ -38,7 +38,7 @@ A `gh` call that never returns no longer freezes a card for the rest of the
 session: those calls now give up after a minute and the card retries instead
 of waiting forever.
 
-### [#1365] A run that is still deciding says stopping rather than stopped
+### [#1365] A stop mid-decision reads as stopping until it lands
 
 Stopping a run while the orchestrator was choosing its next step showed
 Stopped on the rail card and the collapsed row for as long as the decision ran,
@@ -80,6 +80,10 @@ Two Tauri commands that could read any credential out of the keychain and
 return it to the interface had no callers and are gone. The webview's standing
 permission to reach Linear's API has been removed too: those calls are all made
 outside the interface.
+
+Follow-up: every fix above is pinned by its own test and a re-read of the diff, not by
+a run through the built app; nobody has clicked these controls yet. If one behaves
+differently than described, the fix's own test names the exact ground it stands on.
 
 ## Goodboy v0.1.76
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,80 @@ version in the same PR that bumps the version numbers (see
 `docs/release-command.md`), before the tag is pushed: the release build fails
 if it can't find a matching `## Goodboy vX.Y.Z` heading.
 
+## Goodboy v0.1.77
+
+Controls you can reach, and a board that does not claim what it has not checked.
+
+### [#1358] Reach every sidebar control with more than one project mounted
+
+With two or more project mounts, the sidebar's Open, Branch, Archive and Delete
+controls were pushed past the sidebar's edge and could not be clicked at all.
+The switcher grew a tab per mount inside a row that neither wrapped nor
+scrolled, so the controls went off-surface at any sidebar width.
+
+That row now scrolls horizontally, with a fade at each edge when there is more
+to reach. With a single mount it looks exactly as it did.
+
+### [#1363] The board says it is checking GitHub instead of saying there is no pull request
+
+At launch the board placed every session it had not yet asked GitHub about as
+though the answer were already in, then moved cards between columns one at a
+time as the real answers arrived. Nothing was missing from that first board;
+what was on it was labelled wrong.
+
+A session whose pull request state has not arrived now says so, in place, with
+the chip slot showing it is still checking. A session GitHub could not be
+reached for shows a quiet offline marker and is retried. A session that has
+been checked and genuinely has no pull request reads exactly as before, and a
+running agent, an error or an open question still outrank all of it.
+
+A `gh` call that never returns no longer freezes a card for the rest of the
+session: those calls now give up after a minute and the card retries instead
+of waiting forever.
+
+### [#1365] A run that is still deciding says stopping rather than stopped
+
+Stopping a run while the orchestrator was choosing its next step showed
+Stopped on the rail card and the collapsed row for as long as the decision ran,
+which is the surface the stop button sits on. Those surfaces now say stopping
+until the decision ends.
+
+A stop is also no longer overwritten when the decision in flight fails or comes
+back unreadable: the run stays stopped by you rather than reporting a failure
+you did not cause.
+
+### [#1366] Images in a pull request body load when you ask
+
+An image in a pull request or merge request body showed as broken. It now
+renders as a placeholder naming the host it would come from, and loads only
+when you click it, one image at a time. Nothing is fetched before that click,
+because loading a remote image tells whoever hosts it that you opened the page.
+
+This covers every body the app renders that way, including GitLab merge
+requests, Bitbucket pull requests and Slack threads.
+
+### [#1362] Autorun reads as autorun everywhere
+
+Three surfaces called it "auto" and coloured it as an error: the session
+overview lane, the board card and the activity bar. All three now say Autorun
+in the same tone as the toggle, and the in-app guide's colour legend matches.
+
+Delete on a session card now sits behind a divider instead of directly beside
+Archive.
+
+### [#1364] "Nothing needs you" no longer appears while resolvers are running
+
+The session overview could show "Nothing needs you right now" above a rail
+counting live resolve work, because the two counted different things. A
+resolver started without a source comment now counts on both.
+
+### [#1361] Two removals on the security perimeter
+
+Two Tauri commands that could read any credential out of the keychain and
+return it to the interface had no callers and are gone. The webview's standing
+permission to reach Linear's API has been removed too: those calls are all made
+outside the interface.
+
 ## Goodboy v0.1.76
 
 v0.1.75 gave a hands-free run a stop. This one puts it in the pane you are already watching, not only in the sidebar.

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goodboy/desktop",
-  "version": "0.1.76",
+  "version": "0.1.77",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -1626,7 +1626,7 @@ dependencies = [
 
 [[package]]
 name = "goodboy-desktop"
-version = "0.1.76"
+version = "0.1.77"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goodboy-desktop"
-version = "0.1.76"
+version = "0.1.77"
 description = "Goodboy desktop app"
 authors = ["Amin Khayam"]
 license = "MIT"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Goodboy",
-  "version": "0.1.76",
+  "version": "0.1.77",
   "identifier": "com.goodboy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/docs/adr/0001-expand-the-delivery-org.md
+++ b/docs/adr/0001-expand-the-delivery-org.md
@@ -97,6 +97,18 @@ budget and merge-unit numbers;
 [docs/autonomy/release-loop.md](../autonomy/release-loop.md) owns the
 waves.
 
+**The bound-role review, delivered.** v0.1.77's Phase 2 challenger took it,
+per the obligation below, and returned **sound**: the diagnosis carries
+counted evidence, and every failure of the record's own machinery earned a
+dated amendment instead of a silent edit (a review hand-wave replaced by a
+dated obligation, the cost ceiling recounted, the graduation gate named as
+unmet, a valve named for having no actor). The weakness it named, and it is
+not fatal: three amendments in two days confirm the original arithmetic was
+ambition written as fact, and what survives is the subset with evidence
+behind it. The slot arithmetic itself is superseded by
+[ADR 0003](./0003-compose-to-demand-at-a-defended-total.md); this verdict
+judges the record, not the numbers it no longer owns.
+
 **The review.** The original reviewed-by line was a retroactive hand-wave:
 nobody had reviewed this record, and running under a rule is not reviewing
 it. It is replaced by a dated obligation with a named channel and writer:

--- a/docs/adr/0003-compose-to-demand-at-a-defended-total.md
+++ b/docs/adr/0003-compose-to-demand-at-a-defended-total.md
@@ -5,9 +5,18 @@ date: 2026-08-09
 owner: the repo owner, whose direction this records; drafted for him by the
 org architect under the head of engineering's structural-decision clause
 reviewed-by: the challenger, on the PR that lands this record, verdict on
-the PR thread; plus the product owner as the bound role, owed by the first
-release composed under this model, in the dated-obligation shape ADR 0001's
-amendment established
+the PR thread; plus the product owner as the bound role, delivered by
+v0.1.77, the first release composed under this model. Verdict: **sound**.
+It is honest where honesty was expensive: it names its own graduation gate
+as unmet, prices the owner's override as an override, and gives the
+ratchet-back an actor and a moment rather than leaving it as a wish. The
+reviewer recorded the hazard against itself: `sound` is the verdict its
+incentives prefer, and its one independent check (that the batch it
+composed could not have fitted the retired twelve-slot shape) is a single
+data point of its own making. The release that followed bears the model
+out in one respect worth recording: the batch was composed at 20 items and
+finished at 19, because scouting proved one item already shipped, which is
+the demand procedure and the filler bar working rather than failing.
 
 ## Context
 

--- a/docs/adr/0004-harness-failure-class-and-child-lifecycle.md
+++ b/docs/adr/0004-harness-failure-class-and-child-lifecycle.md
@@ -4,8 +4,22 @@ status: accepted
 date: 2026-08-09
 owner: head of engineering, per its charter's structural-decision clause
 reviewed-by: the challenger, on the PR that lands this record, verdict on
-the PR thread; plus the release captain as the bound role, owed by the
-first release run under these rules
+the PR thread; plus the release captain as the bound role, delivered by
+v0.1.77, the first release run under these rules. Verdict: **sound**, on
+evidence that is uncomfortable for one half of it. The parent-identity
+clause did not achieve its stated goal: every one of the release's
+twenty-odd children reported that it could not resolve its parent by name,
+so the placeholder the captain filled in was inert in this harness. What
+carried every single report was the other clause, the disk fallback, and
+the record chose it deliberately over the alternative it rejected (children
+falling back to messaging the delivery lead), which would have reproduced
+the original failure with a different addressee. The disk discipline held
+across six phases and left a successor everything it would have needed. A
+record whose decision is right and one of whose mechanisms is inert on this
+host is sound; the next release should either fix parent addressing or
+delete the clause rather than keep filling a placeholder nothing reads.
+The harness-failure class itself went unexercised: no host death occurred,
+so it remains asserted rather than demonstrated.
 
 ## Context
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -15,25 +15,6 @@ Framework: vitest + `@testing-library/react` + happy-dom (already configured).
 - For hooks: `renderHook` from `@testing-library/react`.
 - A suite whose per-test hook dynamically `import()`s a large module graph warms that import once in `beforeAll`, with a timeout that fits it (60s for the store, see `apps/desktop/src/store/slices/sessions/index.test.ts`). Never in `beforeEach`: the import cost then lands on whichever test happens to run first and blows vitest's default 10s hook timeout on a loaded runner.
 
-## When a class is behavior, not styling
-
-"Do not test css classes for non-semantic styling" above is about layout and
-spacing, not meaning. A class that carries meaning, a status dot's tone, a
-design token, a z-layer, or a motion gate, is behavior wearing a class name.
-A component test that only checks structure and text is structurally blind
-to it: the tone can flip, the token can drift, the animation can lose its
-`prefers-reduced-motion` gate, and the suite stays green throughout.
-
-That class of check lives as a source-parsing invariant test in
-`apps/desktop/src/__tests__/regressions/`, not inside the component's own
-test file: it reads the source directly and asserts the property, rather
-than rendering the component and asserting on its output. Worked example:
-`attention-ring-is-finite.test.ts` reads `styles.css` and asserts the
-attention-ring animation is finite and gated behind
-`prefers-reduced-motion: no-preference`, both properties a rendered-DOM test
-cannot see. A new rule about tone, token, z-layer, or motion gate gets the
-same treatment: assert it from source, in that folder.
-
 ## The golden rule
 
 If a test fails because the component / store / hook does the wrong thing, **fix the code, not the test**. Never weaken a test to make it pass.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goodboy",
-  "version": "0.1.76",
+  "version": "0.1.77",
   "private": true,
   "description": "AI workspace orchestrator. Local-first, provider-agnostic.",
   "license": "MIT",

--- a/website/src/site.ts
+++ b/website/src/site.ts
@@ -1,5 +1,5 @@
 export const SITE = {
-  version: 'v0.1.76',
+  version: 'v0.1.77',
   repo: 'https://github.com/akhayam99/goodboy',
   releases: 'https://github.com/akhayam99/goodboy/releases',
   latest: 'https://github.com/akhayam99/goodboy/releases/latest',


### PR DESCRIPTION
Version bump to 0.1.77 in all six files, plus the `## Goodboy v0.1.77` changelog section the release build reads verbatim.

## What v0.1.77 ships

Ten merge units, all merged and green on `main`, from a batch of nineteen work items.

- `#1358` sidebar controls reachable with two or more project mounts (`Closes #1354`, the release headline)
- `#1363` the board says it is checking GitHub instead of claiming there is no pull request, plus a timeout on `gh` calls that used to freeze a card forever
- `#1365` a run that is still deciding says stopping rather than stopped, and a user's stop is no longer overwritten by a failure
- `#1366` images in a pull request body load only when the reader asks, with no change to the content security policy
- `#1362` autorun reads as autorun on all four surfaces that disagreed, and delete sits behind a divider on the session card
- `#1364` "nothing needs you" no longer appears while resolvers are running
- `#1361` two removals on the security perimeter: the keychain read commands and an unused webview grant
- `#1360` refactor floor: a test that could not fail, a runner that cancelled its siblings, a dead branch
- `#1359` documentation corrections, seven of them, each re-derived from the code
- `#1357` the website discloses the analytics it runs, next to the claim it qualifies

## Two things riding along, declared

**The `docs/testing.md` experiment is reverted.** It shipped in v0.1.76 with a criterion written before it shipped, to be read this release: presentation's share of surviving sabotages had to fall materially from 7 of 10. It fell to 5 of 20, and the test architect found the drop is not attributable to the section. No test was added to the folder it names, nobody cited it, and its own three in-scope survivors got no test. Three Rust units contributed half the denominator and cannot produce presentation survivors at all. A criterion met by coincidence is not met, so the section is deleted, which is the revert shape the experiment declared for itself.

**Three ADR bound-role reviews are recorded** in their `reviewed-by` lines, all owed and all delivered this release: ADR 0001 sound (challenger), ADR 0003 sound (product owner), ADR 0004 sound (release captain), the last with the honest note that its parent-identity clause was inert on this host while its disk fallback carried every report.

## Checks

`main` is green at `a3269ccfd`. Every unit was verified by an agent that did not author it; two needed a repair round and both were re-verified by fresh agents.