### PR TITLE
docs(repo): correct one release-note claim before the tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,14 +76,15 @@ resolver started without a source comment now counts on both.
 
 ### [#1361] Two removals on the security perimeter
 
-Two Tauri commands that could read any credential out of the keychain and
-return it to the interface had no callers and are gone. The webview's standing
+Two Tauri commands were removed: one could return any credential from the
+keychain to the interface, the other reported whether one existed. Neither
+had a caller. The webview's standing
 permission to reach Linear's API has been removed too: those calls are all made
 outside the interface.
 
-Follow-up: every fix above is pinned by its own test and a re-read of the diff, not by
-a run through the built app; nobody has clicked these controls yet. If one behaves
-differently than described, the fix's own test names the exact ground it stands on.
+Follow-up: every fix above is pinned by its own test, and none of them has been walked
+in the built app yet. If one behaves differently from what is written here, that
+difference is new, and worth reporting.
 
 ## Goodboy v0.1.76
 


### PR DESCRIPTION
The challenger's notes-and-impact review found one claim in the v0.1.77 section half true.

The line said two removed Tauri commands `could read any credential out of the keychain and return it to the interface`. That is true of `secret_get`; `secret_has` returned a boolean (`Ok(read(&key)?.is_some())`, `secrets.rs:66-68` before #1361). Corrected, because `release.yml` reads this section verbatim as both the GitHub release body and the in-app updater's notes, so an inaccurate sentence about a security change would ship to every user twice.

The follow-up line is rewritten on the same review: it carried process jargon (`a re-read of the diff`) and closed on a circular sentence describing what a test does rather than what the reader should do.

Every other claim in the section was re-derived from the merged code and confirmed true, by both the voice steward's standing pass and this review.