### PR TITLE
feat(desktop): user-configurable run spend limits

### DIFF
--- a/apps/desktop/src/features/session/components/WorkflowBuilderView/index.test.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowBuilderView/index.test.tsx
@@ -478,6 +478,46 @@ describe('WorkflowBuilderView (orchestrated mode)', () => {
     );
   });
 
+  it('caps what the run may spend, from the form that creates it', async () => {
+    render(<WorkflowBuilderView session={session} onClose={vi.fn()} />);
+    setGoal();
+    fireEvent.click(screen.getByRole('tab', { name: /orchestrated/i }));
+    fireEvent.change(screen.getByPlaceholderText(/describe the intent/i), {
+      target: { value: 'Inspect each result and stop after tests pass.' },
+    });
+    fireEvent.change(screen.getByTestId('spend-limit-amount'), { target: { value: '15' } });
+    fireEvent.click(screen.getByRole('tab', { name: /notify/i }));
+    fireEvent.click(startBtn());
+
+    await waitFor(() => expect(mockAttach).toHaveBeenCalledOnce());
+    expect(mockAttach).toHaveBeenCalledWith('sess-1', expect.any(String), {
+      autoRun: true,
+      navigate: true,
+      goal: 'test goal',
+      executionMode: 'dynamic',
+      spendLimitUsd: 15,
+      spendLimitMode: 'notify',
+    });
+  });
+
+  it('leaves the run uncapped when the spend limit is left empty', async () => {
+    render(<WorkflowBuilderView session={session} onClose={vi.fn()} />);
+    setGoal();
+    fireEvent.click(screen.getByRole('tab', { name: /orchestrated/i }));
+    fireEvent.change(screen.getByPlaceholderText(/describe the intent/i), {
+      target: { value: 'Inspect each result and stop after tests pass.' },
+    });
+    fireEvent.click(startBtn());
+
+    await waitFor(() => expect(mockAttach).toHaveBeenCalledOnce());
+    expect(mockAttach).toHaveBeenCalledWith('sess-1', expect.any(String), {
+      autoRun: true,
+      navigate: true,
+      goal: 'test goal',
+      executionMode: 'dynamic',
+    });
+  });
+
   it('starts and closes even when title generation never resolves', async () => {
     mockGenerateWorkflowTitle.mockImplementationOnce(() => new Promise(() => {}));
     const onClose = vi.fn();

--- a/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
@@ -735,7 +735,9 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
       : mode === 'dynamic'
         ? processText.trim().length === 0
         : steps.length === 0;
-  const startDisabled = blocked || goalMissing || approachMissing;
+  const spendLimitInvalid =
+    mode === 'dynamic' && spendLimitDraft.trim() !== '' && parseSpendLimit(spendLimitDraft) == null;
+  const startDisabled = blocked || goalMissing || approachMissing || spendLimitInvalid;
   const startHint = goalMissing
     ? 'Set a goal to start'
     : approachMissing
@@ -1182,11 +1184,14 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
                             amount={spendLimitDraft}
                             mode={spendLimitMode}
                             inputId="builder-spend-limit-amount"
+                            invalid={spendLimitInvalid}
                             onAmount={setSpendLimitDraft}
                             onMode={setSpendLimitMode}
                           />
                           <p className="text-2xs leading-relaxed text-muted-foreground">
-                            Leave it empty and the run spends whatever it needs.
+                            {spendLimitInvalid
+                              ? 'Enter an amount above zero, or clear the field for no limit.'
+                              : 'Leave it empty and the run spends whatever it needs.'}
                           </p>
                         </div>
                       </div>

--- a/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
@@ -56,6 +56,7 @@ import type {
   Workflow,
   WorkflowId,
   WorkflowRunId,
+  WorkflowSpendLimitMode,
   WorkflowTriggerMode,
 } from '@goodboy/types';
 import { EMPTY_ARRAY, useAppStore, useCurrentWorkspace, useSessionSlots } from '../../../../store';
@@ -71,6 +72,10 @@ import { RoutingPicker } from '../../../../shared/components/RoutingPicker';
 import { type EffortLevel, clampEffort } from '../../../chat/utils/chat-constants';
 import { useWorkflowDrag } from '../../../workflows/hooks/useWorkflowDrag';
 import { StepFlowConnector } from '../../../workflows/components/WorkflowStudio/StepFlowConnector';
+import {
+  SpendLimitFields,
+  parseSpendLimit,
+} from '../../../workflows/components/RunSpendLimitPopover/SpendLimitFields';
 import { DragGhost } from '../../../workflows/components/WorkflowStudio/DragGhost';
 import { formatError } from '../../../../shared/lib/errors';
 import { useToast } from '../../../../app/components/Toast';
@@ -245,6 +250,8 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
   const [autoRun, setAutoRun] = useState(initialDraft?.autoRun ?? false);
   const [triggerMode, setTriggerMode] = useState<WorkflowTriggerMode>('immediate');
   const [chainAfterId, setChainAfterId] = useState<WorkflowRunId | null>(null);
+  const [spendLimitDraft, setSpendLimitDraft] = useState('');
+  const [spendLimitMode, setSpendLimitMode] = useState<WorkflowSpendLimitMode>('pause');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [confirmDeleteId, setConfirmDeleteId] = useState<WorkflowId | null>(null);
@@ -566,6 +573,7 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
   const attachOptions = () => {
     const goal = goalText.trim();
     const after = triggerMode === 'after_run' ? resolvedChainId : null;
+    const spendLimitUsd = mode === 'dynamic' ? parseSpendLimit(spendLimitDraft) : null;
     return {
       autoRun,
       navigate: true,
@@ -574,6 +582,7 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
       ...(triggerMode === 'after_run' && after && { chainAfterId: after }),
       ...(attachments.length > 0 && { attachmentInputs: attachments.map(toAttachmentInput) }),
       ...(mode === 'dynamic' && { executionMode: 'dynamic' as const }),
+      ...(spendLimitUsd != null && { spendLimitUsd, spendLimitMode }),
     };
   };
 
@@ -1162,6 +1171,24 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
                         <p className="text-2xs leading-relaxed text-muted-foreground">
                           Each step runs on the model configured for its role.
                         </p>
+                        <div className="mt-1 flex flex-col gap-1.5 border-t border-border-soft pt-3">
+                          <label
+                            htmlFor="builder-spend-limit-amount"
+                            className="text-2xs font-medium text-foreground"
+                          >
+                            Spend limit
+                          </label>
+                          <SpendLimitFields
+                            amount={spendLimitDraft}
+                            mode={spendLimitMode}
+                            inputId="builder-spend-limit-amount"
+                            onAmount={setSpendLimitDraft}
+                            onMode={setSpendLimitMode}
+                          />
+                          <p className="text-2xs leading-relaxed text-muted-foreground">
+                            Leave it empty and the run spends whatever it needs.
+                          </p>
+                        </div>
                       </div>
                     ) : showSteps ? (
                       <div className="flex flex-col gap-3">

--- a/apps/desktop/src/features/workflows/components/OrchestratorPanel/index.test.tsx
+++ b/apps/desktop/src/features/workflows/components/OrchestratorPanel/index.test.tsx
@@ -123,8 +123,12 @@ beforeEach(() => {
     skipStuckStepAndAdvance: vi.fn(async () => undefined),
     setWorkflowRunAutoRun: vi.fn(async () => undefined),
     stopWorkflowRunNow: vi.fn(async () => undefined),
+    setWorkflowRunSpendLimit: vi.fn(async () => undefined),
     setActiveLens: vi.fn(),
     sessionOpenQuestions: {},
+    sessionTelemetry: {},
+    sessionPhaseRuns: {},
+    agentRunHistory: {},
     sessions: [],
     workspaceOverrides: {},
     providers: [
@@ -239,14 +243,11 @@ describe('OrchestratorPanel state ladder', () => {
       }),
     });
 
-    expect(sentence()).toContain('Paused · session budget cap reached');
+    expect(sentence()).toContain('Paused · budget cap reached');
     expect(screen.queryByTestId('orchestrator-retry')).toBeNull();
-    const opened = vi.fn();
-    window.addEventListener('goodboy:open-budget-studio', opened);
-    fireEvent.click(screen.getByTestId('orchestrator-review-budget'));
-    window.removeEventListener('goodboy:open-budget-studio', opened);
+    fireEvent.click(screen.getByTestId('run-spend-limit-trigger'));
 
-    expect(opened).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('dialog', { name: 'Spend limit for this run' })).toBeDefined();
   });
 
   it('reads a budget pause worded differently as a pause all the same', () => {
@@ -254,8 +255,10 @@ describe('OrchestratorPanel state ladder', () => {
       runOverride: run({ orchestrationStop: { kind: 'budget', message: 'any other wording' } }),
     });
 
-    expect(sentence()).toContain('Paused · session budget cap reached');
-    expect(screen.getByTestId('orchestrator-review-budget')).toBeDefined();
+    expect(sentence()).toContain('Paused · budget cap reached');
+    expect(screen.getByTestId('run-spend-limit-trigger').textContent).toContain(
+      'Raise the spend limit',
+    );
   });
 
   it('reads a question stop as a question to answer, with no retry on offer', () => {
@@ -523,13 +526,37 @@ describe('OrchestratorPanel strip', () => {
     expect(opened).toHaveBeenCalledTimes(1);
   });
 
-  it('drops the budget shortcut while a budget pause already owns the primary action', () => {
+  it('leaves one spend limit control on a budget pause, with the session budget still reachable', () => {
     renderPanel({
       runOverride: run({ orchestrationStop: { kind: 'budget', message: 'cap reached' } }),
     });
 
-    expect(screen.queryByTestId('orchestrator-budget')).toBeNull();
-    expect(screen.getByTestId('orchestrator-review-budget')).toBeDefined();
+    expect(screen.getAllByTestId('run-spend-limit-trigger')).toHaveLength(1);
+    expect(screen.getByTestId('orchestrator-budget')).toBeDefined();
+  });
+
+  it('says what the run is allowed to spend and what happens at the limit', () => {
+    renderPanel({ runOverride: run({ spendLimitUsd: 12, spendLimitMode: 'notify' }) });
+
+    expect(screen.getByTestId('orchestrator-spend-limit').textContent).toContain(
+      'Spend limit $12.00 · notify',
+    );
+  });
+
+  it('saves a spend limit for the run from the strip', () => {
+    renderPanel();
+
+    fireEvent.click(screen.getByTestId('run-spend-limit-trigger'));
+    fireEvent.change(screen.getByTestId('spend-limit-amount'), { target: { value: '8' } });
+    fireEvent.click(screen.getByRole('tab', { name: /notify/i }));
+    fireEvent.click(screen.getByTestId('run-spend-limit-save'));
+
+    expect(storeState['setWorkflowRunSpendLimit']).toHaveBeenCalledWith(
+      SESSION_ID,
+      RUN_ID,
+      8,
+      'notify',
+    );
   });
 
   it('folds the decisions into the strip behind a count', () => {

--- a/apps/desktop/src/features/workflows/components/OrchestratorPanel/index.test.tsx
+++ b/apps/desktop/src/features/workflows/components/OrchestratorPanel/index.test.tsx
@@ -126,6 +126,7 @@ beforeEach(() => {
     setWorkflowRunSpendLimit: vi.fn(async () => undefined),
     setActiveLens: vi.fn(),
     sessionOpenQuestions: {},
+    budgetAlerts: [],
     sessionTelemetry: {},
     sessionPhaseRuns: {},
     agentRunHistory: {},
@@ -539,8 +540,22 @@ describe('OrchestratorPanel strip', () => {
     renderPanel({ runOverride: run({ spendLimitUsd: 12, spendLimitMode: 'notify' }) });
 
     expect(screen.getByTestId('orchestrator-spend-limit').textContent).toContain(
-      'Spend limit $12.00 · notify',
+      'Spend limit $12.00 · notifies at the limit',
     );
+  });
+
+  it('sends a session budget pause to the session budget, not to the run limit', () => {
+    storeState['budgetAlerts'] = [{ kind: 'session-exceeded', sessionId: SESSION_ID }];
+    renderPanel({
+      runOverride: run({ orchestrationStop: { kind: 'budget', message: 'cap reached' } }),
+    });
+    const opened = vi.fn();
+    window.addEventListener('goodboy:open-budget-studio', opened);
+    fireEvent.click(screen.getByTestId('orchestrator-review-budget'));
+    window.removeEventListener('goodboy:open-budget-studio', opened);
+
+    expect(opened).toHaveBeenCalledTimes(1);
+    expect(screen.queryByTestId('run-spend-limit-trigger')).toBeNull();
   });
 
   it('saves a spend limit for the run from the strip', () => {

--- a/apps/desktop/src/features/workflows/components/OrchestratorPanel/index.tsx
+++ b/apps/desktop/src/features/workflows/components/OrchestratorPanel/index.tsx
@@ -2,10 +2,18 @@ import { useState } from 'react';
 import { CircleHelp, Eraser, PenLine, Play, RotateCcw, SkipForward, Wallet } from 'lucide-react';
 import { Eyebrow, Markdown, StatusDot, cn, formatUsd, tintClasses } from '@goodboy/ui';
 import { CONCEPT_ICONS } from '../../../../shared/components/conceptIcons';
-import type { Agent, OpenQuestion, SessionId, Step, WorkflowRun } from '@goodboy/types';
+import type {
+  Agent,
+  BudgetAlert,
+  OpenQuestion,
+  SessionId,
+  Step,
+  WorkflowRun,
+} from '@goodboy/types';
 import { useAppStore } from '../../../../store/store';
 import { workflowRunHasOpenQuestions } from '../../../context/openQuestionsGate';
 import { openBudgetStudio } from '../../../budget/openBudgetStudio';
+import { isBudgetBlocked } from '../../../../store/slices/workflows/budgetBlock';
 import { WorkflowAutorunToggle } from '../WorkflowAutorunToggle';
 import { WorkflowOrchestratorTldr } from '../WorkflowOrchestratorTldr';
 import { RunSpendLimitPopover } from '../RunSpendLimitPopover';
@@ -25,6 +33,7 @@ type Props = {
 };
 
 const EMPTY_QUESTIONS: ReadonlyArray<OpenQuestion> = [];
+const EMPTY_ALERTS: ReadonlyArray<BudgetAlert> = [];
 
 export const OrchestratorPanel = ({
   sessionId,
@@ -44,6 +53,9 @@ export const OrchestratorPanel = ({
   const setActiveLens = useAppStore((state) => state.setActiveLens);
   const openQuestions = useAppStore(
     (state) => state.sessionOpenQuestions[sessionId] ?? EMPTY_QUESTIONS,
+  );
+  const sessionBudgetBlocked = useAppStore((state) =>
+    isBudgetBlocked({ alerts: state.budgetAlerts ?? EMPTY_ALERTS, sessionId }),
   );
   const [openDrawer, setOpenDrawer] = useState<'none' | 'continue' | 'hints'>('none');
   const [hintsDraft, setHintsDraft] = useState(run.orchestratorHints ?? '');
@@ -111,7 +123,19 @@ export const OrchestratorPanel = ({
           />
         );
       case 'paused-budget':
-        return <RunSpendLimitPopover sessionId={sessionId} run={run} variant="primary" />;
+        return sessionBudgetBlocked ? (
+          <OrchestratorAction
+            icon={Wallet}
+            label="Review budget"
+            variant="primary"
+            tone="warning"
+            testId="orchestrator-review-budget"
+            title="The session budget cap is what stopped this run"
+            onClick={() => openBudgetStudio({ scope: { kind: 'session', sessionId } })}
+          />
+        ) : (
+          <RunSpendLimitPopover sessionId={sessionId} run={run} variant="primary" />
+        );
       case 'step-failed':
         return (
           <OrchestratorAction
@@ -223,7 +247,8 @@ export const OrchestratorPanel = ({
                 data-testid="orchestrator-spend-limit"
                 className="font-normal text-muted-foreground"
               >
-                · Spend limit {formatUsd(run.spendLimitUsd)} · {run.spendLimitMode ?? 'pause'}
+                · Spend limit {formatUsd(run.spendLimitUsd)} ·{' '}
+                {run.spendLimitMode === 'notify' ? 'notifies at the limit' : 'pauses at the limit'}
               </span>
             )}
           </p>

--- a/apps/desktop/src/features/workflows/components/OrchestratorPanel/index.tsx
+++ b/apps/desktop/src/features/workflows/components/OrchestratorPanel/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { CircleHelp, Eraser, PenLine, Play, RotateCcw, SkipForward, Wallet } from 'lucide-react';
-import { Eyebrow, Markdown, StatusDot, cn, tintClasses } from '@goodboy/ui';
+import { Eyebrow, Markdown, StatusDot, cn, formatUsd, tintClasses } from '@goodboy/ui';
 import { CONCEPT_ICONS } from '../../../../shared/components/conceptIcons';
 import type { Agent, OpenQuestion, SessionId, Step, WorkflowRun } from '@goodboy/types';
 import { useAppStore } from '../../../../store/store';
@@ -8,6 +8,7 @@ import { workflowRunHasOpenQuestions } from '../../../context/openQuestionsGate'
 import { openBudgetStudio } from '../../../budget/openBudgetStudio';
 import { WorkflowAutorunToggle } from '../WorkflowAutorunToggle';
 import { WorkflowOrchestratorTldr } from '../WorkflowOrchestratorTldr';
+import { RunSpendLimitPopover } from '../RunSpendLimitPopover';
 import { OrchestratorAction } from './OrchestratorAction';
 import { OrchestratorDrawer } from './OrchestratorDrawer';
 import { OrchestratorRoutingRow } from './OrchestratorRoutingRow';
@@ -110,16 +111,7 @@ export const OrchestratorPanel = ({
           />
         );
       case 'paused-budget':
-        return (
-          <OrchestratorAction
-            icon={Wallet}
-            label="Review budget"
-            variant="primary"
-            tone="warning"
-            testId="orchestrator-review-budget"
-            onClick={() => openBudgetStudio({ scope: { kind: 'session', sessionId } })}
-          />
-        );
+        return <RunSpendLimitPopover sessionId={sessionId} run={run} variant="primary" />;
       case 'step-failed':
         return (
           <OrchestratorAction
@@ -226,6 +218,14 @@ export const OrchestratorPanel = ({
             {savedHints === '' ? null : (
               <span className="font-normal text-muted-foreground">· Standing hints on</span>
             )}
+            {run.spendLimitUsd == null ? null : (
+              <span
+                data-testid="orchestrator-spend-limit"
+                className="font-normal text-muted-foreground"
+              >
+                · Spend limit {formatUsd(run.spendLimitUsd)} · {run.spendLimitMode ?? 'pause'}
+              </span>
+            )}
           </p>
 
           {state.detail != null && state.detail !== '' ? (
@@ -256,15 +256,16 @@ export const OrchestratorPanel = ({
             onClick={() => toggleDrawer('hints')}
           />
           {state.phase === 'paused-budget' ? null : (
-            <OrchestratorAction
-              icon={Wallet}
-              label="Budget"
-              variant="ghost"
-              testId="orchestrator-budget"
-              title="Open the budget for this session"
-              onClick={() => openBudgetStudio({ scope: { kind: 'session', sessionId } })}
-            />
+            <RunSpendLimitPopover sessionId={sessionId} run={run} variant="ghost" />
           )}
+          <OrchestratorAction
+            icon={Wallet}
+            label="Budget"
+            variant="ghost"
+            testId="orchestrator-budget"
+            title="Open the budget for this session"
+            onClick={() => openBudgetStudio({ scope: { kind: 'session', sessionId } })}
+          />
         </div>
       </div>
 

--- a/apps/desktop/src/features/workflows/components/OrchestratorPanel/orchestratorState.test.ts
+++ b/apps/desktop/src/features/workflows/components/OrchestratorPanel/orchestratorState.test.ts
@@ -128,7 +128,7 @@ describe('resolveOrchestratorState', () => {
 
   it('maps every stop kind to its presentation', () => {
     const kinds: ReadonlyArray<[WorkflowOrchestrationStop['kind'], string, boolean]> = [
-      ['budget', 'paused-budget', false],
+      ['budget', 'paused-budget', true],
       ['failure', 'failed', true],
       ['questions', 'needs-answer', false],
       ['operator', 'stopped', true],

--- a/apps/desktop/src/features/workflows/components/OrchestratorPanel/orchestratorState.ts
+++ b/apps/desktop/src/features/workflows/components/OrchestratorPanel/orchestratorState.ts
@@ -49,8 +49,8 @@ const STOP_PRESENTATION: Record<WorkflowOrchestrationStopKind, StopPresentation>
   budget: {
     phase: 'paused-budget',
     tone: 'warning',
-    sentence: 'Paused · session budget cap reached',
-    showsMessage: false,
+    sentence: 'Paused · budget cap reached',
+    showsMessage: true,
   },
   failure: {
     phase: 'failed',

--- a/apps/desktop/src/features/workflows/components/RunSpendLimitPopover/SpendLimitFields.tsx
+++ b/apps/desktop/src/features/workflows/components/RunSpendLimitPopover/SpendLimitFields.tsx
@@ -1,11 +1,13 @@
 import { Bell, Pause } from 'lucide-react';
-import { Input, SegmentedTabs, type SegmentedTabOption } from '@goodboy/ui';
+import { Input, SegmentedTabs, cn, type SegmentedTabOption } from '@goodboy/ui';
 import type { WorkflowSpendLimitMode } from '@goodboy/types';
 
 const MODE_OPTIONS: ReadonlyArray<SegmentedTabOption<WorkflowSpendLimitMode>> = [
   { value: 'notify', label: 'Notify', hint: 'keep going, warn me', icon: Bell },
   { value: 'pause', label: 'Pause', hint: 'stop the run', icon: Pause },
 ];
+
+const DISABLED_MODE_OPTIONS = MODE_OPTIONS.map((option) => ({ ...option, disabled: true }));
 
 export const parseSpendLimit = (draft: string): number | null => {
   const amount = Number.parseFloat(draft.trim());
@@ -16,11 +18,19 @@ type Props = {
   readonly amount: string;
   readonly mode: WorkflowSpendLimitMode;
   readonly inputId: string;
+  readonly invalid?: boolean;
   readonly onAmount: (amount: string) => void;
   readonly onMode: (mode: WorkflowSpendLimitMode) => void;
 };
 
-export const SpendLimitFields = ({ amount, mode, inputId, onAmount, onMode }: Props) => (
+export const SpendLimitFields = ({
+  amount,
+  mode,
+  inputId,
+  invalid = false,
+  onAmount,
+  onMode,
+}: Props) => (
   <div className="flex flex-col gap-2">
     <div className="relative">
       <span
@@ -38,16 +48,17 @@ export const SpendLimitFields = ({ amount, mode, inputId, onAmount, onMode }: Pr
         value={amount}
         placeholder="no limit"
         aria-label="Spend limit in dollars"
+        aria-invalid={invalid}
         data-testid="spend-limit-amount"
         onChange={(event) => onAmount(event.target.value)}
-        className="pl-6 text-xs"
+        className={cn('pl-6 text-xs', invalid && 'border-danger')}
       />
     </div>
     <SegmentedTabs
       fill
       size="sm"
       ariaLabel="What happens at the limit"
-      options={MODE_OPTIONS}
+      options={parseSpendLimit(amount) == null ? DISABLED_MODE_OPTIONS : MODE_OPTIONS}
       value={mode}
       onChange={onMode}
     />

--- a/apps/desktop/src/features/workflows/components/RunSpendLimitPopover/SpendLimitFields.tsx
+++ b/apps/desktop/src/features/workflows/components/RunSpendLimitPopover/SpendLimitFields.tsx
@@ -1,0 +1,55 @@
+import { Bell, Pause } from 'lucide-react';
+import { Input, SegmentedTabs, type SegmentedTabOption } from '@goodboy/ui';
+import type { WorkflowSpendLimitMode } from '@goodboy/types';
+
+const MODE_OPTIONS: ReadonlyArray<SegmentedTabOption<WorkflowSpendLimitMode>> = [
+  { value: 'notify', label: 'Notify', hint: 'keep going, warn me', icon: Bell },
+  { value: 'pause', label: 'Pause', hint: 'stop the run', icon: Pause },
+];
+
+export const parseSpendLimit = (draft: string): number | null => {
+  const amount = Number.parseFloat(draft.trim());
+  return Number.isFinite(amount) && amount > 0 ? amount : null;
+};
+
+type Props = {
+  readonly amount: string;
+  readonly mode: WorkflowSpendLimitMode;
+  readonly inputId: string;
+  readonly onAmount: (amount: string) => void;
+  readonly onMode: (mode: WorkflowSpendLimitMode) => void;
+};
+
+export const SpendLimitFields = ({ amount, mode, inputId, onAmount, onMode }: Props) => (
+  <div className="flex flex-col gap-2">
+    <div className="relative">
+      <span
+        aria-hidden
+        className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-xs text-muted-foreground"
+      >
+        $
+      </span>
+      <Input
+        id={inputId}
+        type="number"
+        min="0"
+        step="1"
+        inputMode="decimal"
+        value={amount}
+        placeholder="no limit"
+        aria-label="Spend limit in dollars"
+        data-testid="spend-limit-amount"
+        onChange={(event) => onAmount(event.target.value)}
+        className="pl-6 text-xs"
+      />
+    </div>
+    <SegmentedTabs
+      fill
+      size="sm"
+      ariaLabel="What happens at the limit"
+      options={MODE_OPTIONS}
+      value={mode}
+      onChange={onMode}
+    />
+  </div>
+);

--- a/apps/desktop/src/features/workflows/components/RunSpendLimitPopover/index.test.tsx
+++ b/apps/desktop/src/features/workflows/components/RunSpendLimitPopover/index.test.tsx
@@ -1,0 +1,128 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { SessionId, WorkflowId, WorkflowRun, WorkflowRunId } from '@goodboy/types';
+
+const { storeState } = vi.hoisted(() => ({
+  storeState: {} as Record<string, unknown>,
+}));
+
+vi.mock('../../../../store/store', () => ({
+  useAppStore: (selector: (state: Record<string, unknown>) => unknown) => selector(storeState),
+}));
+
+import { RunSpendLimitPopover } from './index';
+
+const SESSION_ID = 'session-1' as SessionId;
+const RUN_ID = 'run-1' as WorkflowRunId;
+
+const run = (overrides: Partial<WorkflowRun> = {}): WorkflowRun => ({
+  id: RUN_ID,
+  workflowId: 'workflow-1' as WorkflowId,
+  ordinal: 0,
+  currentStep: 0,
+  autoRun: false,
+  triggerMode: 'immediate',
+  executionMode: 'dynamic',
+  ...overrides,
+});
+
+const renderPopover = (runOverride: WorkflowRun = run()) =>
+  render(<RunSpendLimitPopover sessionId={SESSION_ID} run={runOverride} variant="meta" />);
+
+const openPopover = () => fireEvent.click(screen.getByTestId('run-spend-limit-trigger'));
+
+beforeEach(() => {
+  Object.assign(storeState, {
+    setWorkflowRunSpendLimit: vi.fn(async () => undefined),
+    sessionTelemetry: {},
+    sessionPhaseRuns: {},
+    agentRunHistory: {},
+  });
+});
+
+afterEach(cleanup);
+
+describe('RunSpendLimitPopover', () => {
+  it('offers to set a limit on a run that has none, and reads no limit as infinite', () => {
+    renderPopover();
+
+    expect(screen.getByTestId('run-spend-limit-trigger').textContent).toContain(
+      'Set a spend limit',
+    );
+    openPopover();
+
+    const field = screen.getByTestId('spend-limit-amount') as HTMLInputElement;
+    expect(field.value).toBe('');
+    expect(field.getAttribute('placeholder')).toBe('no limit');
+    expect(screen.queryByTestId('run-spend-limit-remove')).toBeNull();
+  });
+
+  it('saves the amount with the mode that says what happens at the limit', async () => {
+    renderPopover();
+
+    openPopover();
+    fireEvent.change(screen.getByTestId('spend-limit-amount'), { target: { value: '25' } });
+    fireEvent.click(screen.getByRole('tab', { name: /notify/i }));
+    fireEvent.click(screen.getByTestId('run-spend-limit-save'));
+
+    expect(storeState['setWorkflowRunSpendLimit']).toHaveBeenCalledWith(
+      SESSION_ID,
+      RUN_ID,
+      25,
+      'notify',
+    );
+    await screen.findByTestId('run-spend-limit-trigger');
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('carries the limit already set into the trigger and the field', () => {
+    renderPopover(run({ spendLimitUsd: 12.5, spendLimitMode: 'notify' }));
+
+    expect(screen.getByTestId('run-spend-limit-trigger').textContent).toContain(
+      'Spend limit $12.50',
+    );
+    openPopover();
+
+    expect((screen.getByTestId('spend-limit-amount') as HTMLInputElement).value).toBe('12.5');
+    expect(screen.getByRole('tab', { name: /notify/i }).getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('takes the limit off without touching the amount left in the field', () => {
+    renderPopover(run({ spendLimitUsd: 12.5, spendLimitMode: 'pause' }));
+
+    openPopover();
+    fireEvent.click(screen.getByTestId('run-spend-limit-remove'));
+
+    expect(storeState['setWorkflowRunSpendLimit']).toHaveBeenCalledWith(
+      SESSION_ID,
+      RUN_ID,
+      null,
+      'pause',
+    );
+  });
+
+  it('reads an emptied field as no limit at all', () => {
+    renderPopover(run({ spendLimitUsd: 12.5 }));
+
+    openPopover();
+    fireEvent.change(screen.getByTestId('spend-limit-amount'), { target: { value: '' } });
+    fireEvent.click(screen.getByTestId('run-spend-limit-save'));
+
+    expect(storeState['setWorkflowRunSpendLimit']).toHaveBeenCalledWith(
+      SESSION_ID,
+      RUN_ID,
+      null,
+      'pause',
+    );
+  });
+
+  it('says what the run has spent so far, so the limit is not set blind', () => {
+    renderPopover();
+
+    openPopover();
+
+    expect(screen.getByRole('dialog').textContent).toContain('$0 spent so far');
+  });
+});

--- a/apps/desktop/src/features/workflows/components/RunSpendLimitPopover/index.tsx
+++ b/apps/desktop/src/features/workflows/components/RunSpendLimitPopover/index.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Wallet } from 'lucide-react';
+import { CircleDollarSign } from 'lucide-react';
 import { Button, Divider, Popover, cn, formatUsd } from '@goodboy/ui';
 import type { SessionId, WorkflowRun, WorkflowSpendLimitMode } from '@goodboy/types';
 import { useDropdown } from '../../../../shared/hooks/useDropdown';
@@ -53,6 +53,8 @@ export const RunSpendLimitPopover = ({ sessionId, run, variant }: Props) => {
   };
 
   const metaLabel = limitUsd == null ? 'Set a spend limit' : `Spend limit ${formatUsd(limitUsd)}`;
+  const isBlank = amount.trim() === '';
+  const isInvalid = !isBlank && parseSpendLimit(amount) == null;
 
   return (
     <div ref={containerRef} className="relative inline-flex">
@@ -69,12 +71,12 @@ export const RunSpendLimitPopover = ({ sessionId, run, variant }: Props) => {
               : 'text-muted-foreground hover:bg-foreground/10 hover:text-foreground',
           )}
         >
-          <Wallet size={11} aria-hidden className="shrink-0" />
+          <CircleDollarSign size={11} aria-hidden className="shrink-0" />
           {metaLabel}
         </button>
       ) : (
         <OrchestratorAction
-          icon={Wallet}
+          icon={CircleDollarSign}
           label={TRIGGER_LABEL[variant]}
           variant={variant}
           tone="warning"
@@ -102,11 +104,14 @@ export const RunSpendLimitPopover = ({ sessionId, run, variant }: Props) => {
               amount={amount}
               mode={mode}
               inputId="run-spend-limit-amount"
+              invalid={isInvalid}
               onAmount={setAmount}
               onMode={setMode}
             />
             <p className="text-2xs leading-relaxed text-muted-foreground">
-              {formatUsd(spentUsd)} spent so far. Leave it empty for no limit.
+              {isInvalid
+                ? 'Enter an amount above zero, or clear the field for no limit.'
+                : `${formatUsd(spentUsd)} spent so far. Leave it empty for no limit.`}
             </p>
           </div>
           <Divider />
@@ -124,7 +129,7 @@ export const RunSpendLimitPopover = ({ sessionId, run, variant }: Props) => {
             )}
             <Button
               size="sm"
-              disabled={busy}
+              disabled={busy || isInvalid}
               data-testid="run-spend-limit-save"
               onClick={() => void commit(parseSpendLimit(amount))}
             >

--- a/apps/desktop/src/features/workflows/components/RunSpendLimitPopover/index.tsx
+++ b/apps/desktop/src/features/workflows/components/RunSpendLimitPopover/index.tsx
@@ -1,0 +1,138 @@
+import { useState } from 'react';
+import { Wallet } from 'lucide-react';
+import { Button, Divider, Popover, cn, formatUsd } from '@goodboy/ui';
+import type { SessionId, WorkflowRun, WorkflowSpendLimitMode } from '@goodboy/types';
+import { useDropdown } from '../../../../shared/hooks/useDropdown';
+import { useAppStore } from '../../../../store/store';
+import { useRunSpendUsd } from '../../../../store/selectors';
+import { OrchestratorAction } from '../OrchestratorPanel/OrchestratorAction';
+import { SpendLimitFields, parseSpendLimit } from './SpendLimitFields';
+
+type Props = {
+  readonly sessionId: SessionId;
+  readonly run: WorkflowRun;
+  readonly variant: 'primary' | 'ghost' | 'meta';
+};
+
+const TRIGGER_LABEL = {
+  primary: 'Raise the spend limit',
+  ghost: 'Spend limit',
+} as const;
+
+export const RunSpendLimitPopover = ({ sessionId, run, variant }: Props) => {
+  const setWorkflowRunSpendLimit = useAppStore((state) => state.setWorkflowRunSpendLimit);
+  const spentUsd = useRunSpendUsd(sessionId, run.id);
+  const limitUsd = run.spendLimitUsd ?? null;
+  const { open, close, toggle, containerRef, popupRef, popupClassName, popupStyle } = useDropdown({
+    align: 'end',
+    expectedHeight: 220,
+    expectedWidth: 264,
+    width: 'w-64',
+  });
+  const [amount, setAmount] = useState('');
+  const [mode, setMode] = useState<WorkflowSpendLimitMode>('pause');
+  const [busy, setBusy] = useState(false);
+
+  const onToggle = () => {
+    setAmount(limitUsd == null ? '' : String(limitUsd));
+    setMode(run.spendLimitMode ?? 'pause');
+    toggle();
+  };
+
+  const commit = async (nextLimit: number | null) => {
+    if (busy) {
+      return;
+    }
+    setBusy(true);
+    try {
+      await setWorkflowRunSpendLimit(sessionId, run.id, nextLimit, mode);
+      close();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const metaLabel = limitUsd == null ? 'Set a spend limit' : `Spend limit ${formatUsd(limitUsd)}`;
+
+  return (
+    <div ref={containerRef} className="relative inline-flex">
+      {variant === 'meta' ? (
+        <button
+          type="button"
+          onClick={onToggle}
+          aria-expanded={open}
+          data-testid="run-spend-limit-trigger"
+          className={cn(
+            'inline-flex items-center gap-1 rounded-md px-1 py-0.5 text-2xs motion-safe:transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]',
+            limitUsd == null
+              ? 'text-muted-foreground/70 hover:bg-foreground/10 hover:text-foreground'
+              : 'text-muted-foreground hover:bg-foreground/10 hover:text-foreground',
+          )}
+        >
+          <Wallet size={11} aria-hidden className="shrink-0" />
+          {metaLabel}
+        </button>
+      ) : (
+        <OrchestratorAction
+          icon={Wallet}
+          label={TRIGGER_LABEL[variant]}
+          variant={variant}
+          tone="warning"
+          testId="run-spend-limit-trigger"
+          title="Cap what this run is allowed to spend"
+          expanded={open}
+          onClick={onToggle}
+        />
+      )}
+
+      {open ? (
+        <Popover
+          innerRef={popupRef}
+          role="dialog"
+          ariaLabel="Spend limit for this run"
+          className={cn(popupClassName, 'flex flex-col bg-subtle')}
+          style={popupStyle}
+        >
+          <header className="px-3 py-2 text-xs font-semibold text-foreground">
+            Spend limit for this run
+          </header>
+          <Divider />
+          <div className="flex flex-col gap-2 px-3 py-3">
+            <SpendLimitFields
+              amount={amount}
+              mode={mode}
+              inputId="run-spend-limit-amount"
+              onAmount={setAmount}
+              onMode={setMode}
+            />
+            <p className="text-2xs leading-relaxed text-muted-foreground">
+              {formatUsd(spentUsd)} spent so far. Leave it empty for no limit.
+            </p>
+          </div>
+          <Divider />
+          <footer className="flex items-center justify-end gap-2 px-3 py-2">
+            {limitUsd == null ? null : (
+              <Button
+                variant="ghost"
+                size="sm"
+                disabled={busy}
+                data-testid="run-spend-limit-remove"
+                onClick={() => void commit(null)}
+              >
+                Remove limit
+              </Button>
+            )}
+            <Button
+              size="sm"
+              disabled={busy}
+              data-testid="run-spend-limit-save"
+              onClick={() => void commit(parseSpendLimit(amount))}
+            >
+              Save
+            </Button>
+          </footer>
+        </Popover>
+      ) : null}
+    </div>
+  );
+};

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.test.tsx
@@ -33,6 +33,7 @@ vi.mock('../../../../../store', () => ({
   useSessionLoading: () => ({ agents: false, transcript: false }),
   useSessionOpenQuestions: () => [],
   useSessionPlans: () => [],
+  useRunSpendUsd: () => 0,
   EMPTY_ARRAY: [] as never[],
   agentHasUnread: (agent: Agent, isCurrentlyViewed: boolean): boolean => {
     if (isCurrentlyViewed || agent.status === 'skipped' || !agent.lastFinishedAt) {

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.test.tsx
@@ -21,10 +21,12 @@ const storeMocks = vi.hoisted(() => ({
   renameWorkflow: vi.fn(async () => undefined),
   stopWorkflowRunNow: vi.fn(async () => undefined),
   orchestratingWorkflowRuns: {} as Record<string, boolean>,
+  runSpendUsd: 0,
 }));
 
 vi.mock('../../../../../store', () => ({
   EMPTY_ARRAY: Object.freeze([]),
+  useRunSpendUsd: () => storeMocks.runSpendUsd,
   useAppStore: <T,>(selector: (state: unknown) => T) =>
     selector({
       renameWorkflow: storeMocks.renameWorkflow,
@@ -211,6 +213,7 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   storeMocks.orchestratingWorkflowRuns = {};
+  storeMocks.runSpendUsd = 0;
 });
 
 describe('WorkflowRow detail dashboard', () => {
@@ -575,6 +578,31 @@ describe('WorkflowRow dynamic runs', () => {
 
     expect(screen.queryByTestId('workflow-orchestrator-failed')).toBeNull();
     expect(screen.getByTestId('orchestrator-state').textContent).toContain('Last decision failed');
+  });
+
+  it('counts the steps a dynamic run took instead of promising a total it never had', () => {
+    renderDetail({ runOverride: dynamicRun, agentsOverride: doneAgents, actionableStepId: null });
+
+    expect(screen.getByText('2 steps')).toBeDefined();
+    expect(screen.queryByText(/step 2 of 2/i)).toBeNull();
+  });
+
+  it('bills a dynamic run on the spend enforcement reads, not on the step aggregates', () => {
+    storeMocks.runSpendUsd = 3.5;
+    renderDetail({ runOverride: dynamicRun, agentsOverride: doneAgents, actionableStepId: null });
+
+    expect(screen.getByTitle('$3.5000 for this run')).toBeDefined();
+  });
+
+  it('offers the spend limit next to what the dynamic run has cost', () => {
+    renderDetail({
+      runOverride: { ...dynamicRun, spendLimitUsd: 20 },
+      agentsOverride: doneAgents,
+      actionableStepId: null,
+    });
+
+    const [trigger] = screen.getAllByTestId('run-spend-limit-trigger');
+    expect(trigger?.textContent).toContain('Spend limit $20.00');
   });
 
   it('marks the dynamic run completed only on a persisted done outcome', () => {

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.tsx
@@ -11,7 +11,7 @@ import type {
   WorkflowRun,
   WorkflowRunId,
 } from '@goodboy/types';
-import { EMPTY_ARRAY, useAppStore } from '../../../../../store';
+import { EMPTY_ARRAY, useAppStore, useRunSpendUsd } from '../../../../../store';
 import type { AppStore } from '../../../../../store/store';
 import { inferAgentKindFromName, type AgentKind } from '../../../../../features/session/agent-kind';
 import { agentRoutingOverrides } from '../../../../../features/workflows/agentRoutingOverrides';
@@ -20,6 +20,7 @@ import { useSessionRoleModels } from '../../../../../shared/hooks/useSessionRole
 import type { AgentAggregate } from '../../../../../features/session/components/AgentMetrics';
 import { WorkflowNextStepCta } from '../../../../../features/workflows/components/WorkflowNextStepCta';
 import { OrchestratorPanel } from '../../../../../features/workflows/components/OrchestratorPanel';
+import { RunSpendLimitPopover } from '../../../../../features/workflows/components/RunSpendLimitPopover';
 import { WorkflowRunSummary } from '../../../../../features/workflows/components/WorkflowRunSummary';
 import { WorkflowAutorunToggle } from '../../../../../features/workflows/components/WorkflowAutorunToggle';
 import { useWorkflowTitleRename } from '../../../../../features/workflows/hooks/useWorkflowTitleRename';
@@ -169,6 +170,8 @@ export const WorkflowRow = ({
     (total, agent) => total + (aggregatesByAgentId.get(agent.id)?.estimatedCostUsd ?? 0),
     0,
   );
+  const runSpendUsd = useRunSpendUsd(task.id, run.id);
+  const costUsd = isDynamic ? runSpendUsd : runCostUsd;
   const stepById = new Map(workflow.steps.map((step) => [step.id, step]));
   const hasOrchestratorStrip = isDynamic && !isDiscarded && expanded;
   const ctaAgent =
@@ -247,13 +250,15 @@ export const WorkflowRow = ({
                 items={[
                   total > 0 ? (
                     <span className="tabular-nums">
-                      Step {Math.min(done + 1, total)} of {total}
+                      {isDynamic
+                        ? `${total} ${total === 1 ? 'step' : 'steps'}`
+                        : `Step ${Math.min(done + 1, total)} of ${total}`}
                     </span>
                   ) : null,
-                  <CostBadge
-                    value={runCostUsd}
-                    title={`${formatUsdPrecise(runCostUsd)} for this run`}
-                  />,
+                  <CostBadge value={costUsd} title={`${formatUsdPrecise(costUsd)} for this run`} />,
+                  isDynamic && !isDiscarded ? (
+                    <RunSpendLimitPopover sessionId={task.id} run={run} variant="meta" />
+                  ) : null,
                 ]}
               />
             </div>
@@ -292,7 +297,7 @@ export const WorkflowRow = ({
             />
             {total > 0 ? (
               <span className="shrink-0 font-mono text-2xs text-muted-foreground/50">
-                {done}/{total}
+                {isDynamic ? total : `${done}/${total}`}
               </span>
             ) : null}
           </button>
@@ -439,7 +444,7 @@ export const WorkflowRow = ({
                   run={run}
                   agents={wfAgents}
                   steps={workflow.steps}
-                  costUsd={runCostUsd}
+                  costUsd={costUsd}
                   isOrchestrating={isOrchestrating}
                 />
               ) : null}

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.tsx
@@ -297,7 +297,7 @@ export const WorkflowRow = ({
             />
             {total > 0 ? (
               <span className="shrink-0 font-mono text-2xs text-muted-foreground/50">
-                {isDynamic ? total : `${done}/${total}`}
+                {isDynamic ? `${total} ${total === 1 ? 'step' : 'steps'}` : `${done}/${total}`}
               </span>
             ) : null}
           </button>

--- a/apps/desktop/src/store/index.ts
+++ b/apps/desktop/src/store/index.ts
@@ -15,6 +15,7 @@ export {
   useNonResolverStandaloneAgents,
   useSessionOpenQuestions,
   useSessionPlans,
+  useRunSpendUsd,
   useSessionPrFetchState,
   useSessionSlots,
   useSessionStageInfo,

--- a/apps/desktop/src/store/selectors.ts
+++ b/apps/desktop/src/store/selectors.ts
@@ -22,6 +22,7 @@ import type {
   SessionStageInfo,
   SessionViewPrefs,
   TelemetryRecord,
+  WorkflowRunId,
   WorkspaceId,
 } from '@goodboy/types';
 import type { Workspace } from '@goodboy/types';
@@ -40,10 +41,12 @@ import { agentHasUnread } from './slices/agents/agentHasUnread';
 import { sessionPrFetchState } from './slices/github/sessionPrFetchState';
 import { isSessionPrFetchable } from './slices/github/resolveSessionPrFetch';
 import { resolveSessionRepo } from './slices/worktrees/resolveSessionRepo';
+import { runSpendUsd } from './slices/workflows/runSpendUsd';
 export { agentHasUnread } from './slices/agents/agentHasUnread';
 
 const DEFAULT_SESSION_VIEW_PREFS: SessionViewPrefs = { sort: 'updatedAt', group: 'stage' };
 const EMPTY_TELEMETRY: ReadonlyArray<TelemetryRecord> = [];
+const EMPTY_AGENTS: ReadonlyArray<Agent> = [];
 const EMPTY_TERMINAL_TABS: ReadonlyArray<TerminalTab> = [];
 
 export const sumSessionCost = (records: readonly TelemetryRecord[]): number => {
@@ -61,6 +64,16 @@ export const useSessionCost = (sessionId: SessionId): number => {
   const records = useAppStore((state) => state.sessionTelemetry[sessionId] ?? EMPTY_TELEMETRY);
   return useMemo(() => sumSessionCost(records), [records]);
 };
+
+export const useRunSpendUsd = (sessionId: SessionId, workflowRunId: WorkflowRunId): number =>
+  useAppStore((state) =>
+    runSpendUsd({
+      records: state.sessionTelemetry[sessionId] ?? EMPTY_TELEMETRY,
+      agents: state.sessionPhaseRuns[sessionId] ?? EMPTY_AGENTS,
+      agentRunHistory: state.agentRunHistory,
+      workflowRunId,
+    }),
+  );
 
 export const useSessionViewPrefs = (workspaceId: WorkspaceId | null): SessionViewPrefs => {
   const prefs = useAppStore((s) =>
@@ -564,8 +577,6 @@ export const useFilesTouched = (
 
   return state;
 };
-
-const EMPTY_AGENTS: ReadonlyArray<Agent> = [];
 
 const useSessionAgentKindOverrides = (sessionId: SessionId): Readonly<Record<string, AgentKind>> =>
   useAppStore(

--- a/apps/desktop/src/store/slices/workflows/attachWorkflowToSession.ts
+++ b/apps/desktop/src/store/slices/workflows/attachWorkflowToSession.ts
@@ -8,6 +8,7 @@ import type {
   WorkflowExecutionMode,
   WorkflowRun,
   WorkflowRunId,
+  WorkflowSpendLimitMode,
   WorkflowTriggerMode,
 } from '@goodboy/types';
 import { attachWorkflowToSession as attachWorkflowToSessionInDb } from '@goodboy/db';
@@ -25,6 +26,8 @@ type Options = {
   chainAfterId?: WorkflowRunId;
   attachmentInputs?: ReadonlyArray<AttachmentInput>;
   executionMode?: WorkflowExecutionMode;
+  spendLimitUsd?: number;
+  spendLimitMode?: WorkflowSpendLimitMode;
   navigate?: boolean;
 };
 
@@ -46,6 +49,11 @@ export const attachWorkflowToSession = (set: SetFn, get: GetFn) => {
     const executionMode = options?.executionMode ?? 'static';
     const goal = options?.goal?.trim() || undefined;
     const chainAfterId = options?.chainAfterId;
+    const spendLimitUsd =
+      options?.spendLimitUsd != null && options.spendLimitUsd > 0
+        ? options.spendLimitUsd
+        : undefined;
+    const spendLimitMode = options?.spendLimitMode ?? 'pause';
     let triggerMode: WorkflowTriggerMode = options?.triggerMode ?? 'immediate';
     if (triggerMode === 'after_run' && chainAfterId) {
       const predecessor = session.workflowRuns.find((r) => r.id === chainAfterId);
@@ -68,18 +76,20 @@ export const attachWorkflowToSession = (set: SetFn, get: GetFn) => {
     }
     const ordinal = session.workflowRuns.reduce((max, r) => Math.max(max, r.ordinal), -1) + 1;
     const now = new Date().toISOString() as IsoDateTime;
-    await attachWorkflowToSessionInDb(
-      tauriDatabase,
+    await attachWorkflowToSessionInDb({
+      db: tauriDatabase,
       sessionId,
       workflowRunId,
       workflowId,
       autoRun,
-      now,
-      goal,
+      updatedAt: now,
+      ...(goal && { goal }),
       triggerMode,
-      chainAfterId,
+      ...(chainAfterId && { chainAfterRunId: chainAfterId }),
       executionMode,
-    );
+      ...(spendLimitUsd != null && { spendLimitUsd }),
+      spendLimitMode,
+    });
 
     const existingRuns = get().sessionPhaseRuns[sessionId] ?? [];
     const baseOrdinal = existingRuns.reduce((max, r) => Math.max(max, r.ordinal), -1);
@@ -116,6 +126,8 @@ export const attachWorkflowToSession = (set: SetFn, get: GetFn) => {
       createdAt: now,
       ...(chainAfterId && { chainAfterId }),
       ...(goal && { goal }),
+      ...(spendLimitUsd != null && { spendLimitUsd }),
+      spendLimitMode,
     };
 
     const transcriptEntries: Record<string, ReadonlyArray<never>> = {};

--- a/apps/desktop/src/store/slices/workflows/budgetBlock.test.ts
+++ b/apps/desktop/src/store/slices/workflows/budgetBlock.test.ts
@@ -10,7 +10,7 @@ import type {
   WorkflowRun,
   WorkflowRunId,
 } from '@goodboy/types';
-import { resolveSpendLimitStop } from './budgetBlock';
+import { loadSpendLimitTelemetry, resolveSpendLimitStop } from './budgetBlock';
 
 const SESSION_ID = 'ses-1' as SessionId;
 const RUN_ID = 'run-1' as WorkflowRunId;
@@ -55,35 +55,54 @@ const stateWith = (spentUsd: number) => {
 };
 
 describe('resolveSpendLimitStop', () => {
-  it('pauses a run that spent past its limit', async () => {
-    const { state, get } = stateWith(7);
-
-    const stop = await resolveSpendLimitStop({ get, sessionId: SESSION_ID, run: run(5, 'pause') });
-
-    expect(stop).toEqual({ kind: 'pause', limitUsd: 5, message: expect.any(String) });
-    expect(state['loadSessionTelemetry']).toHaveBeenCalledWith(SESSION_ID);
-  });
-
-  it('reports a notify stop instead of swallowing it', async () => {
+  it('pauses a run that spent past its limit', () => {
     const { get } = stateWith(7);
 
-    const stop = await resolveSpendLimitStop({ get, sessionId: SESSION_ID, run: run(5, 'notify') });
+    const stop = resolveSpendLimitStop({ get, sessionId: SESSION_ID, run: run(5, 'pause') });
+
+    expect(stop).toEqual({ kind: 'pause', limitUsd: 5, message: expect.any(String) });
+  });
+
+  it('reports a notify stop instead of swallowing it', () => {
+    const { get } = stateWith(7);
+
+    const stop = resolveSpendLimitStop({ get, sessionId: SESSION_ID, run: run(5, 'notify') });
 
     expect(stop?.kind).toBe('notify');
   });
 
-  it('stays silent while the run is under its limit', async () => {
+  it('stays silent while the run is under its limit', () => {
     const { get } = stateWith(2);
 
-    expect(await resolveSpendLimitStop({ get, sessionId: SESSION_ID, run: run(5, 'pause') })).toBe(
-      null,
-    );
+    expect(resolveSpendLimitStop({ get, sessionId: SESSION_ID, run: run(5, 'pause') })).toBe(null);
   });
 
-  it('never loads telemetry for a run without a limit', async () => {
+  it('stays silent for a run without a limit', () => {
+    const { get } = stateWith(99);
+
+    expect(resolveSpendLimitStop({ get, sessionId: SESSION_ID, run: run() })).toBe(null);
+  });
+});
+
+describe('loadSpendLimitTelemetry', () => {
+  it('reads telemetry once for a batch instead of once per run', async () => {
+    const { state, get } = stateWith(7);
+
+    await loadSpendLimitTelemetry({
+      get,
+      sessionId: SESSION_ID,
+      runs: [run(5, 'pause'), run(9, 'notify'), run()],
+    });
+
+    expect(state['loadSessionTelemetry']).toHaveBeenCalledTimes(1);
+    expect(state['loadSessionTelemetry']).toHaveBeenCalledWith(SESSION_ID);
+  });
+
+  it('never reads telemetry when no run in the batch has a limit', async () => {
     const { state, get } = stateWith(99);
 
-    expect(await resolveSpendLimitStop({ get, sessionId: SESSION_ID, run: run() })).toBe(null);
+    await loadSpendLimitTelemetry({ get, sessionId: SESSION_ID, runs: [run(), run()] });
+
     expect(state['loadSessionTelemetry']).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/store/slices/workflows/budgetBlock.test.ts
+++ b/apps/desktop/src/store/slices/workflows/budgetBlock.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from 'vitest';
+import type {
+  Agent,
+  AgentId,
+  ProviderRunId,
+  SessionId,
+  StepId,
+  TelemetryRecord,
+  WorkflowId,
+  WorkflowRun,
+  WorkflowRunId,
+} from '@goodboy/types';
+import { resolveSpendLimitStop } from './budgetBlock';
+
+const SESSION_ID = 'ses-1' as SessionId;
+const RUN_ID = 'run-1' as WorkflowRunId;
+
+const agent = (): Agent => ({
+  id: 'agent-1' as AgentId,
+  sessionId: SESSION_ID,
+  stepId: 'step-1' as StepId,
+  workflowRunId: RUN_ID,
+  ordinal: 0,
+  name: 'Scout',
+  status: 'completed',
+  runId: 'pr-1' as ProviderRunId,
+});
+
+const run = (spendLimitUsd?: number, spendLimitMode?: 'notify' | 'pause'): WorkflowRun => ({
+  id: RUN_ID,
+  workflowId: 'wf-1' as WorkflowId,
+  ordinal: 0,
+  currentStep: 0,
+  autoRun: true,
+  triggerMode: 'immediate',
+  executionMode: 'dynamic',
+  ...(spendLimitUsd != null && { spendLimitUsd }),
+  ...(spendLimitMode != null && { spendLimitMode }),
+});
+
+type State = Record<string, unknown>;
+
+const stateWith = (spentUsd: number) => {
+  const state: State = {
+    sessionTelemetry: {
+      [SESSION_ID]: [
+        { runId: 'pr-1', kind: 'turn', estimatedCostUsd: spentUsd } as unknown as TelemetryRecord,
+      ],
+    },
+    sessionPhaseRuns: { [SESSION_ID]: [agent()] },
+    agentRunHistory: {},
+    loadSessionTelemetry: vi.fn(async () => undefined),
+  };
+  return { state, get: (() => state) as never };
+};
+
+describe('resolveSpendLimitStop', () => {
+  it('pauses a run that spent past its limit', async () => {
+    const { state, get } = stateWith(7);
+
+    const stop = await resolveSpendLimitStop({ get, sessionId: SESSION_ID, run: run(5, 'pause') });
+
+    expect(stop).toEqual({ kind: 'pause', limitUsd: 5, message: expect.any(String) });
+    expect(state['loadSessionTelemetry']).toHaveBeenCalledWith(SESSION_ID);
+  });
+
+  it('reports a notify stop instead of swallowing it', async () => {
+    const { get } = stateWith(7);
+
+    const stop = await resolveSpendLimitStop({ get, sessionId: SESSION_ID, run: run(5, 'notify') });
+
+    expect(stop?.kind).toBe('notify');
+  });
+
+  it('stays silent while the run is under its limit', async () => {
+    const { get } = stateWith(2);
+
+    expect(await resolveSpendLimitStop({ get, sessionId: SESSION_ID, run: run(5, 'pause') })).toBe(
+      null,
+    );
+  });
+
+  it('never loads telemetry for a run without a limit', async () => {
+    const { state, get } = stateWith(99);
+
+    expect(await resolveSpendLimitStop({ get, sessionId: SESSION_ID, run: run() })).toBe(null);
+    expect(state['loadSessionTelemetry']).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/store/slices/workflows/budgetBlock.ts
+++ b/apps/desktop/src/store/slices/workflows/budgetBlock.ts
@@ -37,24 +37,43 @@ type SpendLimitParams = {
   readonly run: WorkflowRun;
 };
 
-export const resolveSpendLimitStop = async ({
+type TelemetryParams = {
+  readonly get: GetFn;
+  readonly sessionId: SessionId;
+  readonly runs: ReadonlyArray<WorkflowRun>;
+};
+
+export const loadSpendLimitTelemetry = async ({
   get,
   sessionId,
-  run,
-}: SpendLimitParams): Promise<SpendLimitStop | null> => {
-  const limitUsd = run.spendLimitUsd;
-  if (limitUsd == null) {
-    return null;
+  runs,
+}: TelemetryParams): Promise<void> => {
+  if (runs.every((run) => run.spendLimitUsd == null)) {
+    return;
   }
   await get().loadSessionTelemetry(sessionId);
+};
+
+export const spentUsdForRun = ({ get, sessionId, run }: SpendLimitParams): number => {
   const state = get();
-  const spentUsd = runSpendUsd({
+  return runSpendUsd({
     records: state.sessionTelemetry[sessionId] ?? [],
     agents: state.sessionPhaseRuns[sessionId] ?? [],
     agentRunHistory: state.agentRunHistory,
     workflowRunId: run.id,
   });
-  if (spentUsd < limitUsd) {
+};
+
+export const resolveSpendLimitStop = ({
+  get,
+  sessionId,
+  run,
+}: SpendLimitParams): SpendLimitStop | null => {
+  const limitUsd = run.spendLimitUsd;
+  if (limitUsd == null) {
+    return null;
+  }
+  if (spentUsdForRun({ get, sessionId, run }) < limitUsd) {
     return null;
   }
   const kind = run.spendLimitMode ?? 'pause';

--- a/apps/desktop/src/store/slices/workflows/budgetBlock.ts
+++ b/apps/desktop/src/store/slices/workflows/budgetBlock.ts
@@ -1,4 +1,7 @@
-import type { BudgetAlert, SessionId } from '@goodboy/types';
+import type { BudgetAlert, SessionId, WorkflowRun } from '@goodboy/types';
+import { formatUsd } from '@goodboy/ui';
+import { runSpendUsd } from './runSpendUsd';
+import type { GetFn } from './types';
 
 type Params = {
   readonly alerts: ReadonlyArray<BudgetAlert>;
@@ -15,4 +18,45 @@ export const isBudgetBlocked = ({ alerts, sessionId }: Params): boolean => {
       ((alert.kind === 'session-exceeded' && alert.sessionId === sessionId) ||
         alert.kind === 'provider-exceeded'),
   );
+};
+
+export type SpendLimitStop = {
+  readonly kind: 'notify' | 'pause';
+  readonly limitUsd: number;
+  readonly message: string;
+};
+
+const spendLimitMessage = (limitUsd: number, kind: 'notify' | 'pause'): string =>
+  kind === 'pause'
+    ? `the spend limit of ${formatUsd(limitUsd)} for this run is reached, raise it to keep going`
+    : `this run passed its spend limit of ${formatUsd(limitUsd)} and keeps going`;
+
+type SpendLimitParams = {
+  readonly get: GetFn;
+  readonly sessionId: SessionId;
+  readonly run: WorkflowRun;
+};
+
+export const resolveSpendLimitStop = async ({
+  get,
+  sessionId,
+  run,
+}: SpendLimitParams): Promise<SpendLimitStop | null> => {
+  const limitUsd = run.spendLimitUsd;
+  if (limitUsd == null) {
+    return null;
+  }
+  await get().loadSessionTelemetry(sessionId);
+  const state = get();
+  const spentUsd = runSpendUsd({
+    records: state.sessionTelemetry[sessionId] ?? [],
+    agents: state.sessionPhaseRuns[sessionId] ?? [],
+    agentRunHistory: state.agentRunHistory,
+    workflowRunId: run.id,
+  });
+  if (spentUsd < limitUsd) {
+    return null;
+  }
+  const kind = run.spendLimitMode ?? 'pause';
+  return { kind, limitUsd, message: spendLimitMessage(limitUsd, kind) };
 };

--- a/apps/desktop/src/store/slices/workflows/chainTriggers.test.ts
+++ b/apps/desktop/src/store/slices/workflows/chainTriggers.test.ts
@@ -157,6 +157,9 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
+const attachArgs = (): Record<string, unknown> | undefined =>
+  attachInDbSpy.mock.calls[0]?.[0] as Record<string, unknown> | undefined;
+
 describe('maybeAutoAdvanceWorkflow chain detection', () => {
   function baseState(workflowRuns: ReadonlyArray<WorkflowRun>, agents: ReadonlyArray<Agent>) {
     return {
@@ -573,7 +576,7 @@ describe('attachWorkflowToSession trigger modes', () => {
     const state = baseState([], []);
     const { set, get } = harness(state);
     await attachWorkflowToSession(set, get)(SESSION_ID, WF_ID, { autoRun: false });
-    expect(attachInDbSpy.mock.calls[0]?.[7]).toBe('immediate');
+    expect(attachArgs()?.['triggerMode']).toBe('immediate');
     expect(state['activateWorkflowAgent']).toHaveBeenCalled();
   });
 
@@ -584,7 +587,7 @@ describe('attachWorkflowToSession trigger modes', () => {
       autoRun: false,
       triggerMode: 'manual',
     });
-    expect(attachInDbSpy.mock.calls[0]?.[7]).toBe('manual');
+    expect(attachArgs()?.['triggerMode']).toBe('manual');
     expect(state['activateWorkflowAgent']).not.toHaveBeenCalled();
     expect(state['maybeAutoAdvanceWorkflow']).not.toHaveBeenCalled();
   });
@@ -598,8 +601,8 @@ describe('attachWorkflowToSession trigger modes', () => {
       triggerMode: 'after_run',
       chainAfterId: 'pred' as WorkflowRunId,
     });
-    expect(attachInDbSpy.mock.calls[0]?.[7]).toBe('after_run');
-    expect(attachInDbSpy.mock.calls[0]?.[8]).toBe('pred');
+    expect(attachArgs()?.['triggerMode']).toBe('after_run');
+    expect(attachArgs()?.['chainAfterRunId']).toBe('pred');
     expect(state['maybeAutoAdvanceWorkflow']).not.toHaveBeenCalled();
   });
 
@@ -612,7 +615,7 @@ describe('attachWorkflowToSession trigger modes', () => {
       triggerMode: 'after_run',
       chainAfterId: 'pred' as WorkflowRunId,
     });
-    expect(attachInDbSpy.mock.calls[0]?.[7]).toBe('immediate');
+    expect(attachArgs()?.['triggerMode']).toBe('immediate');
     expect(state['maybeAutoAdvanceWorkflow']).toHaveBeenCalledWith(SESSION_ID);
   });
 
@@ -625,7 +628,7 @@ describe('attachWorkflowToSession trigger modes', () => {
       triggerMode: 'after_run',
       chainAfterId: 'pred' as WorkflowRunId,
     });
-    expect(attachInDbSpy.mock.calls[0]?.[7]).toBe('after_run');
+    expect(attachArgs()?.['triggerMode']).toBe('after_run');
     expect(state['maybeAutoAdvanceWorkflow']).not.toHaveBeenCalled();
   });
 
@@ -637,7 +640,7 @@ describe('attachWorkflowToSession trigger modes', () => {
       triggerMode: 'after_run',
       chainAfterId: 'ghost' as WorkflowRunId,
     });
-    expect(attachInDbSpy.mock.calls[0]?.[7]).toBe('after_run');
+    expect(attachArgs()?.['triggerMode']).toBe('after_run');
     expect(state['maybeAutoAdvanceWorkflow']).not.toHaveBeenCalled();
   });
 
@@ -659,7 +662,7 @@ describe('attachWorkflowToSession trigger modes', () => {
     const state = baseState([], []);
     const { set, get } = harness(state);
     await attachWorkflowToSession(set, get)(SESSION_ID, WF_ID, { autoRun: true });
-    expect(attachInDbSpy.mock.calls[0]?.[7]).toBe('immediate');
+    expect(attachArgs()?.['triggerMode']).toBe('immediate');
     expect(state['maybeAutoAdvanceWorkflow']).toHaveBeenCalledWith(SESSION_ID);
     expect(state['activateWorkflowAgent']).not.toHaveBeenCalled();
   });
@@ -697,7 +700,7 @@ describe('attachWorkflowToSession trigger modes', () => {
       executionMode: 'dynamic',
     });
 
-    expect(attachInDbSpy.mock.calls[0]?.[9]).toBe('dynamic');
+    expect(attachArgs()?.['executionMode']).toBe('dynamic');
     expect(invokeAgentInsertSpy).not.toHaveBeenCalled();
     const added = (state.sessions[0] as Session).workflowRuns[0]!;
     expect(added.executionMode).toBe('dynamic');
@@ -716,7 +719,7 @@ describe('attachWorkflowToSession trigger modes', () => {
       triggerMode: 'after_run',
       chainAfterId: 'pred' as WorkflowRunId,
     });
-    expect(attachInDbSpy.mock.calls[0]?.[7]).toBe('immediate');
+    expect(attachArgs()?.['triggerMode']).toBe('immediate');
   });
 
   it('after_run stays queued behind a dynamic predecessor without a persisted outcome', async () => {
@@ -728,6 +731,6 @@ describe('attachWorkflowToSession trigger modes', () => {
       triggerMode: 'after_run',
       chainAfterId: 'pred' as WorkflowRunId,
     });
-    expect(attachInDbSpy.mock.calls[0]?.[7]).toBe('after_run');
+    expect(attachArgs()?.['triggerMode']).toBe('after_run');
   });
 });

--- a/apps/desktop/src/store/slices/workflows/index.ts
+++ b/apps/desktop/src/store/slices/workflows/index.ts
@@ -28,6 +28,7 @@ import { saveStepDef } from './saveStepDef';
 import { advanceScoutTree } from './scoutTree';
 import { skipStuckStepAndAdvance } from './skipStuckStepAndAdvance';
 import { setWorkflowRunAutoRun } from './setWorkflowRunAutoRun';
+import { setWorkflowRunSpendLimit } from './setWorkflowRunSpendLimit';
 import { startWorkflowRun } from './startWorkflowRun';
 import { stopWorkflowRunNow } from './stopWorkflowRunNow';
 import type { GetFn, SetFn } from './types';
@@ -51,6 +52,7 @@ export const createWorkflowsSlice = (set: SetFn, get: GetFn) => {
     restoreWorkflow: restoreWorkflow(set, get),
     reorderSessionWorkflows: reorderSessionWorkflows(set, get),
     setWorkflowRunAutoRun: setWorkflowRunAutoRun(set, get),
+    setWorkflowRunSpendLimit: setWorkflowRunSpendLimit(set, get),
     startWorkflowRun: startWorkflowRun(set, get),
     stopWorkflowRunNow: stopWorkflowRunNow(set, get),
     reprocessGoalForWorkflow: reprocessGoalForWorkflow(set, get),

--- a/apps/desktop/src/store/slices/workflows/maybeAutoAdvanceWorkflow.test.ts
+++ b/apps/desktop/src/store/slices/workflows/maybeAutoAdvanceWorkflow.test.ts
@@ -4,9 +4,11 @@ import type {
   AgentId,
   AgentStatus,
   IsoDateTime,
+  ProviderRunId,
   Session,
   SessionId,
   StepId,
+  TelemetryRecord,
   Workflow,
   WorkflowId,
   WorkflowRun,
@@ -100,6 +102,10 @@ const baseState = (stepIds: ReadonlyArray<string>, agents: ReadonlyArray<Agent>)
   summarizerStatus: {},
   budgetAlerts: [],
   announcedWorkflowBlocks: {},
+  announcedRunBudget: {},
+  sessionTelemetry: {},
+  agentRunHistory: {},
+  loadSessionTelemetry: vi.fn(async () => undefined),
   startWorkflowRun: vi.fn(async () => undefined),
   activateWorkflowAgent: vi.fn(async () => undefined),
   orchestrateNextStep: vi.fn(async () => undefined),
@@ -426,6 +432,52 @@ describe('maybeAutoAdvanceWorkflow', () => {
     await maybeAutoAdvanceWorkflow(set, get)(SESSION_ID);
 
     expect(state['orchestrateNextStep']).not.toHaveBeenCalled();
+  });
+
+  it('pauses the run past its spend limit without holding back its sibling', async () => {
+    const SECOND_ID = 'run-2' as WorkflowRunId;
+    const cappedAgent: Agent = {
+      ...makeAgent('s0', 'pending', 0),
+      runId: 'pr-1' as ProviderRunId,
+    };
+    const siblingAgent: Agent = {
+      id: `${SECOND_ID}-s0` as AgentId,
+      sessionId: SESSION_ID,
+      stepId: 's0' as StepId,
+      workflowRunId: SECOND_ID,
+      ordinal: 0,
+      name: 's0',
+      status: 'pending',
+    };
+    const session = makeSession();
+    const state = baseState(['s0'], [cappedAgent, siblingAgent]);
+    state['sessions'] = [
+      {
+        ...session,
+        workflowRuns: [
+          { ...session.workflowRuns[0]!, spendLimitUsd: 1, spendLimitMode: 'pause' as const },
+          { ...session.workflowRuns[0]!, id: SECOND_ID, ordinal: 1 },
+        ],
+      },
+    ];
+    state['sessionTelemetry'] = {
+      [SESSION_ID]: [
+        { runId: 'pr-1', kind: 'turn', estimatedCostUsd: 4 } as unknown as TelemetryRecord,
+      ],
+    };
+    const { set, get } = harness(state);
+
+    await maybeAutoAdvanceWorkflow(set, get)(SESSION_ID);
+
+    expect(updateOrchestrationStopSpy).toHaveBeenCalledWith({}, RUN_ID, {
+      kind: 'budget',
+      message: expect.stringContaining('spend limit'),
+    });
+    expect(state['activateWorkflowAgent']).toHaveBeenCalledWith({
+      sessionId: SESSION_ID,
+      agentId: `${SECOND_ID}-s0`,
+      focus: 'announce',
+    });
   });
 
   it('records the budget stop once while the cap stays reached', async () => {

--- a/apps/desktop/src/store/slices/workflows/maybeAutoAdvanceWorkflow.ts
+++ b/apps/desktop/src/store/slices/workflows/maybeAutoAdvanceWorkflow.ts
@@ -8,7 +8,12 @@ import {
 } from '@goodboy/core';
 import { tauriDatabase } from '../../../shared/lib/db';
 import { workflowRunHasOpenQuestions } from '../../../features/context/openQuestionsGate';
-import { BUDGET_BLOCK_MESSAGE, isBudgetBlocked, resolveSpendLimitStop } from './budgetBlock';
+import {
+  BUDGET_BLOCK_MESSAGE,
+  isBudgetBlocked,
+  loadSpendLimitTelemetry,
+  resolveSpendLimitStop,
+} from './budgetBlock';
 import { persistOrchestrationStop } from './orchestrateNextStep';
 import { activateWorkflowAgentOrNotify } from './activateWorkflowAgentOrNotify';
 import type { GetFn, SetFn } from './types';
@@ -73,9 +78,12 @@ const runAdvance = async ({ set, get, sessionId }: Params): Promise<void> => {
     return;
   }
   const sessionBlocked = isBudgetBlocked({ alerts: state.budgetAlerts, sessionId });
+  if (!sessionBlocked) {
+    await loadSpendLimitTelemetry({ get, sessionId, runs: activeRuns });
+  }
   const runnableRuns: typeof activeRuns = [];
   for (const run of activeRuns) {
-    const spendStop = sessionBlocked ? null : await resolveSpendLimitStop({ get, sessionId, run });
+    const spendStop = sessionBlocked ? null : resolveSpendLimitStop({ get, sessionId, run });
     const blockMessage = sessionBlocked
       ? BUDGET_BLOCK_MESSAGE
       : spendStop?.kind === 'pause'

--- a/apps/desktop/src/store/slices/workflows/maybeAutoAdvanceWorkflow.ts
+++ b/apps/desktop/src/store/slices/workflows/maybeAutoAdvanceWorkflow.ts
@@ -8,7 +8,7 @@ import {
 } from '@goodboy/core';
 import { tauriDatabase } from '../../../shared/lib/db';
 import { workflowRunHasOpenQuestions } from '../../../features/context/openQuestionsGate';
-import { BUDGET_BLOCK_MESSAGE, isBudgetBlocked } from './budgetBlock';
+import { BUDGET_BLOCK_MESSAGE, isBudgetBlocked, resolveSpendLimitStop } from './budgetBlock';
 import { persistOrchestrationStop } from './orchestrateNextStep';
 import { activateWorkflowAgentOrNotify } from './activateWorkflowAgentOrNotify';
 import type { GetFn, SetFn } from './types';
@@ -72,18 +72,30 @@ const runAdvance = async ({ set, get, sessionId }: Params): Promise<void> => {
   if (state.summarizerStatus[sessionId]?.status === 'running') {
     return;
   }
-  if (isBudgetBlocked({ alerts: state.budgetAlerts, sessionId })) {
-    for (const run of activeRuns) {
-      if (run.orchestrationStop?.kind === 'budget') {
-        continue;
-      }
-      await persistOrchestrationStop({
-        set,
-        sessionId,
-        workflowRunId: run.id,
-        stop: { kind: 'budget', message: BUDGET_BLOCK_MESSAGE },
-      });
+  const sessionBlocked = isBudgetBlocked({ alerts: state.budgetAlerts, sessionId });
+  const runnableRuns: typeof activeRuns = [];
+  for (const run of activeRuns) {
+    const spendStop = sessionBlocked ? null : await resolveSpendLimitStop({ get, sessionId, run });
+    const blockMessage = sessionBlocked
+      ? BUDGET_BLOCK_MESSAGE
+      : spendStop?.kind === 'pause'
+        ? spendStop.message
+        : null;
+    if (blockMessage == null) {
+      runnableRuns.push(run);
+      continue;
     }
+    if (run.orchestrationStop?.kind === 'budget') {
+      continue;
+    }
+    await persistOrchestrationStop({
+      set,
+      sessionId,
+      workflowRunId: run.id,
+      stop: { kind: 'budget', message: blockMessage },
+    });
+  }
+  if (runnableRuns.length === 0) {
     return;
   }
   const templates = state.phaseTemplates[session.workspaceId] ?? [];
@@ -91,7 +103,7 @@ const runAdvance = async ({ set, get, sessionId }: Params): Promise<void> => {
   const openQuestions = await listOpenQuestionsForSession(tauriDatabase, sessionId, 'open');
   let dynamicRunId = null as (typeof activeRuns)[number]['id'] | null;
   const nextPendingAgent = (() => {
-    for (const run of activeRuns) {
+    for (const run of runnableRuns) {
       if (workflowRunHasOpenQuestions(openQuestions, run.id)) {
         continue;
       }
@@ -134,7 +146,7 @@ const runAdvance = async ({ set, get, sessionId }: Params): Promise<void> => {
   if (nextPendingAgent == null) {
     const announced = get().announcedWorkflowBlocks ?? {};
     const fresh: Record<WorkflowRunId, string> = {};
-    for (const run of activeRuns) {
+    for (const run of runnableRuns) {
       const template = templates.find((t) => t.id === run.workflowId);
       if (template == null) {
         continue;

--- a/apps/desktop/src/store/slices/workflows/orchestrateNextStep.test.ts
+++ b/apps/desktop/src/store/slices/workflows/orchestrateNextStep.test.ts
@@ -13,6 +13,7 @@ import type {
   Workflow,
   WorkflowId,
   WorkflowRunId,
+  WorkflowSpendLimitMode,
   WorkspaceId,
 } from '@goodboy/types';
 
@@ -76,12 +77,7 @@ vi.mock('../../../features/workflows/workflows', () => ({
   invokeAgentInsert: invokeAgentInsertSpy,
 }));
 
-import {
-  ORCHESTRATOR_STEP_BUDGET,
-  ORCHESTRATOR_STEP_HARD_CAP,
-  OrchestratorClient,
-  ROLE_DEFAULTS,
-} from '@goodboy/core';
+import { OrchestratorClient, ROLE_DEFAULTS } from '@goodboy/core';
 import { orchestrateNextStep, persistOrchestrationStop } from './orchestrateNextStep';
 import { continueWorkflowRun } from './continueWorkflowRun';
 
@@ -203,10 +199,38 @@ const baseState = (): State => {
     agentKindOverride: {},
     agentProviderOverride: {},
     agentEffortOverride: {},
+    announcedRunBudget: {},
+    loadSessionTelemetry: vi.fn(async () => undefined),
     appendTurnEvent: vi.fn(),
     activateWorkflowAgent: vi.fn(async () => undefined),
     emitNotification: vi.fn(async () => undefined),
   };
+};
+
+type SpendParams = {
+  readonly limitUsd: number;
+  readonly spentUsd: number;
+  readonly mode?: WorkflowSpendLimitMode;
+};
+
+const spendState = ({ limitUsd, spentUsd, mode = 'pause' }: SpendParams): State => {
+  const state = baseState();
+  const base = session();
+  state['sessions'] = [
+    {
+      ...base,
+      workflowRuns: [{ ...base.workflowRuns[0]!, spendLimitUsd: limitUsd, spendLimitMode: mode }],
+    },
+  ];
+  state['sessionPhaseRuns'] = {
+    [SESSION_ID]: [{ ...completedAgent(), runId: 'pr-1' as ProviderRunId }],
+  };
+  state['sessionTelemetry'] = {
+    [SESSION_ID]: [
+      { runId: 'pr-1', kind: 'turn', estimatedCostUsd: spentUsd } as unknown as TelemetryRecord,
+    ],
+  };
+  return state;
 };
 
 const OPERATOR_STOP = {
@@ -1070,37 +1094,6 @@ describe('orchestrateNextStep', () => {
     );
   });
 
-  it('records the note on the hard cap block, not only in the prompt', async () => {
-    const state = baseState();
-    const template = state['phaseTemplates'] as Record<string, ReadonlyArray<Workflow>>;
-    const base = template[WORKSPACE_ID]![0]!;
-    const capped: Workflow = {
-      ...base,
-      steps: Array.from({ length: ORCHESTRATOR_STEP_HARD_CAP }, (_, index) => ({
-        ...base.steps[0]!,
-        id: `step-${index}` as StepId,
-        ordinal: index,
-        name: `Step ${index}`,
-      })),
-    };
-    state['phaseTemplates'] = { [WORKSPACE_ID]: [capped] };
-    const { set, get } = harness(state);
-
-    await orchestrateNextStep(set, get)(SESSION_ID, WORKFLOW_RUN_ID, {
-      extraHints: 'watch for the hard cap',
-    });
-
-    expect(state['appendTurnEvent']).toHaveBeenCalledWith(
-      AGENT_ID,
-      SESSION_ID,
-      expect.objectContaining({
-        kind: 'orchestrator_decision',
-        action: 'blocked',
-        operatorNote: 'watch for the hard cap',
-      }),
-    );
-  });
-
   it('records the note on a provider failure block, not only in the prompt', async () => {
     decideSpy.mockRejectedValueOnce(new Error('orchestrator decision timed out'));
     const state = baseState();
@@ -1202,36 +1195,89 @@ describe('orchestrateNextStep', () => {
 
     await orchestrateNextStep(set, get)(SESSION_ID, WORKFLOW_RUN_ID);
 
+    expect(decideSpy).toHaveBeenCalledWith(expect.objectContaining({ stepsUsed: 1 }));
+  });
+
+  it('tells the orchestrator what the run spent against the limit the operator set', async () => {
+    decideSpy.mockResolvedValueOnce({
+      decision: { action: 'done', reason: 'all set' },
+      usage: NO_USAGE,
+      model: 'claude-haiku-4-5',
+    });
+    const state = spendState({ limitUsd: 20, spentUsd: 3 });
+    const { set, get } = harness(state);
+
+    await orchestrateNextStep(set, get)(SESSION_ID, WORKFLOW_RUN_ID);
+
     expect(decideSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ stepsUsed: 1, stepBudget: ORCHESTRATOR_STEP_BUDGET }),
+      expect.objectContaining({ spendLimitUsd: 20, spentUsd: 3 }),
     );
   });
 
-  it('blocks the run once it reaches the hard step cap instead of asking for more', async () => {
-    const state = baseState();
-    const template = state['phaseTemplates'] as Record<string, ReadonlyArray<Workflow>>;
-    const base = template[WORKSPACE_ID]![0]!;
-    const capped: Workflow = {
-      ...base,
-      steps: Array.from({ length: ORCHESTRATOR_STEP_HARD_CAP }, (_, index) => ({
-        ...base.steps[0]!,
-        id: `step-${index}` as StepId,
-        ordinal: index,
-        name: `Step ${index}`,
-      })),
-    };
-    state['phaseTemplates'] = { [WORKSPACE_ID]: [capped] };
+  it('pauses the run once it spends past the limit', async () => {
+    const state = spendState({ limitUsd: 5, spentUsd: 6 });
     const { set, get } = harness(state);
 
     await orchestrateNextStep(set, get)(SESSION_ID, WORKFLOW_RUN_ID);
 
     expect(decideSpy).not.toHaveBeenCalled();
-    expect(updateOutcomeSpy).toHaveBeenCalledWith(
-      {},
-      WORKFLOW_RUN_ID,
-      'blocked',
-      expect.stringContaining('hard cap'),
+    expect(updateStopSpy).toHaveBeenCalledWith({}, WORKFLOW_RUN_ID, {
+      kind: 'budget',
+      message: expect.stringContaining('spend limit'),
+    });
+  });
+
+  it('keeps deciding past the limit when the operator only asked to be notified', async () => {
+    decideSpy.mockResolvedValueOnce({
+      decision: { action: 'done', reason: 'all set' },
+      usage: NO_USAGE,
+      model: 'claude-haiku-4-5',
+    });
+    const state = spendState({ limitUsd: 5, spentUsd: 6, mode: 'notify' });
+    const { set, get } = harness(state);
+
+    await orchestrateNextStep(set, get)(SESSION_ID, WORKFLOW_RUN_ID);
+
+    expect(decideSpy).toHaveBeenCalledTimes(1);
+    expect(state['emitNotification']).toHaveBeenCalledWith(
+      'budget-cap',
+      'warning',
+      expect.stringContaining('spend limit'),
+      expect.stringContaining('spend limit'),
+      expect.objectContaining({ sessionId: SESSION_ID }),
     );
+  });
+
+  it('announces the same limit once, and again once the operator raises it', async () => {
+    decideSpy.mockResolvedValue({
+      usage: NO_USAGE,
+      model: 'claude-haiku-4-5',
+      decision: {
+        action: 'next',
+        reason: 'keep going',
+        step: {
+          name: 'Implement',
+          role: 'implementer',
+          promptPrefix: 'Implement the mapped change.',
+          expectedOutput: 'A tested implementation.',
+        },
+      },
+    });
+    const state = spendState({ limitUsd: 5, spentUsd: 6, mode: 'notify' });
+    const { set, get } = harness(state);
+    const budgetCalls = () =>
+      (state['emitNotification'] as ReturnType<typeof vi.fn>).mock.calls.filter(
+        (call) => call[0] === 'budget-cap',
+      ).length;
+
+    await orchestrateNextStep(set, get)(SESSION_ID, WORKFLOW_RUN_ID);
+    await orchestrateNextStep(set, get)(SESSION_ID, WORKFLOW_RUN_ID);
+    expect(budgetCalls()).toBe(1);
+
+    state['sessions'] = spendState({ limitUsd: 6, spentUsd: 6, mode: 'notify' })['sessions'];
+    await orchestrateNextStep(set, get)(SESSION_ID, WORKFLOW_RUN_ID);
+
+    expect(budgetCalls()).toBe(2);
   });
 
   it('refuses to start a step while the budget cap is reached', async () => {

--- a/apps/desktop/src/store/slices/workflows/orchestrateNextStep.ts
+++ b/apps/desktop/src/store/slices/workflows/orchestrateNextStep.ts
@@ -40,10 +40,11 @@ import { tauriDatabase } from '../../../shared/lib/db';
 import {
   BUDGET_BLOCK_MESSAGE,
   isBudgetBlocked,
+  loadSpendLimitTelemetry,
   resolveSpendLimitStop,
+  spentUsdForRun,
   type SpendLimitStop,
 } from './budgetBlock';
-import { runSpendUsd } from './runSpendUsd';
 import { roleModelsForSession } from '../overrides/roleModelsForSession';
 import { getSessionRepo } from '../worktrees/getSessionRepo';
 import { preSpawnWorkflowAgents } from './preSpawnWorkflowAgents';
@@ -456,7 +457,8 @@ export const orchestrateNextStep = (set: SetFn, get: GetFn) => {
         });
         return;
       }
-      const spendStop = await resolveSpendLimitStop({ get, sessionId, run });
+      await loadSpendLimitTelemetry({ get, sessionId, runs: [run] });
+      const spendStop = resolveSpendLimitStop({ get, sessionId, run });
       if (spendStop?.kind === 'pause') {
         await persistOrchestrationStop({
           set,
@@ -540,12 +542,7 @@ export const orchestrateNextStep = (set: SetFn, get: GetFn) => {
           stepsUsed: workflow.steps.length,
           ...(run.spendLimitUsd != null && {
             spendLimitUsd: run.spendLimitUsd,
-            spentUsd: runSpendUsd({
-              records: get().sessionTelemetry[sessionId] ?? [],
-              agents: get().sessionPhaseRuns[sessionId] ?? [],
-              agentRunHistory: get().agentRunHistory,
-              workflowRunId,
-            }),
+            spentUsd: spentUsdForRun({ get, sessionId, run }),
           }),
         });
       } catch (error) {
@@ -575,6 +572,7 @@ export const orchestrateNextStep = (set: SetFn, get: GetFn) => {
             get,
             sessionId,
             agentId: null,
+            workflowRunId,
             provider: routing.providerId,
             model: result.model,
             usage: result.usage,
@@ -600,6 +598,7 @@ export const orchestrateNextStep = (set: SetFn, get: GetFn) => {
           get,
           sessionId,
           agentId: unparseableAgentId,
+          workflowRunId,
           provider: routing.providerId,
           model: result.model,
           usage: result.usage,
@@ -619,6 +618,7 @@ export const orchestrateNextStep = (set: SetFn, get: GetFn) => {
           get,
           sessionId,
           agentId: null,
+          workflowRunId,
           provider: routing.providerId,
           model: result.model,
           usage: result.usage,
@@ -681,6 +681,7 @@ export const orchestrateNextStep = (set: SetFn, get: GetFn) => {
           get,
           sessionId,
           agentId: agent.id,
+          workflowRunId,
           provider: routing.providerId,
           model: result.model,
           usage: result.usage,
@@ -713,6 +714,7 @@ export const orchestrateNextStep = (set: SetFn, get: GetFn) => {
         get,
         sessionId,
         agentId: terminalAgentId,
+        workflowRunId,
         provider: routing.providerId,
         model: result.model,
         usage: result.usage,

--- a/apps/desktop/src/store/slices/workflows/orchestrateNextStep.ts
+++ b/apps/desktop/src/store/slices/workflows/orchestrateNextStep.ts
@@ -18,8 +18,6 @@ import type {
   WorkflowRunId,
 } from '@goodboy/types';
 import {
-  ORCHESTRATOR_STEP_BUDGET,
-  ORCHESTRATOR_STEP_HARD_CAP,
   OrchestratorClient,
   OrchestratorProviderError,
   ROLE_DEFAULTS,
@@ -39,7 +37,13 @@ import {
 } from '@goodboy/db';
 import { invokeWorkflowUpsert } from '../../../features/workflows/workflows';
 import { tauriDatabase } from '../../../shared/lib/db';
-import { BUDGET_BLOCK_MESSAGE, isBudgetBlocked } from './budgetBlock';
+import {
+  BUDGET_BLOCK_MESSAGE,
+  isBudgetBlocked,
+  resolveSpendLimitStop,
+  type SpendLimitStop,
+} from './budgetBlock';
+import { runSpendUsd } from './runSpendUsd';
 import { roleModelsForSession } from '../overrides/roleModelsForSession';
 import { getSessionRepo } from '../worktrees/getSessionRepo';
 import { preSpawnWorkflowAgents } from './preSpawnWorkflowAgents';
@@ -145,6 +149,39 @@ const emitDecision = ({
   };
   get().appendTurnEvent(agentId, sessionId, event);
   return agentId;
+};
+
+type AnnounceBudgetParams = {
+  readonly set: SetFn;
+  readonly get: GetFn;
+  readonly sessionId: SessionId;
+  readonly workflowRunId: WorkflowRunId;
+  readonly stop: SpendLimitStop;
+};
+
+const announceRunBudget = ({
+  set,
+  get,
+  sessionId,
+  workflowRunId,
+  stop,
+}: AnnounceBudgetParams): void => {
+  if (get().announcedRunBudget[workflowRunId] === stop.limitUsd) {
+    return;
+  }
+  set((state) => ({
+    announcedRunBudget: { ...state.announcedRunBudget, [workflowRunId]: stop.limitUsd },
+  }));
+  void get().emitNotification(
+    'budget-cap',
+    'warning',
+    'workflow run over its spend limit',
+    stop.message,
+    {
+      sessionId,
+      action: { kind: 'open-budget', sessionId },
+    },
+  );
 };
 
 type PersistOutcomeParams = {
@@ -419,6 +456,19 @@ export const orchestrateNextStep = (set: SetFn, get: GetFn) => {
         });
         return;
       }
+      const spendStop = await resolveSpendLimitStop({ get, sessionId, run });
+      if (spendStop?.kind === 'pause') {
+        await persistOrchestrationStop({
+          set,
+          sessionId,
+          workflowRunId,
+          stop: { kind: 'budget', message: spendStop.message },
+        });
+        return;
+      }
+      if (spendStop != null) {
+        announceRunBudget({ set, get, sessionId, workflowRunId, stop: spendStop });
+      }
       if (options?.bypassGate !== true) {
         const blocked = await findWorkflowActivationBlock({ sessionId, workflowRunId });
         if (blocked !== null) {
@@ -430,25 +480,6 @@ export const orchestrateNextStep = (set: SetFn, get: GetFn) => {
           });
           return;
         }
-      }
-      if (workflow.steps.length >= ORCHESTRATOR_STEP_HARD_CAP) {
-        const reason = `the run reached the hard cap of ${ORCHESTRATOR_STEP_HARD_CAP} steps without closing. Review what the steps produced and start a new run for what is left.`;
-        await persistOrchestrationOutcome({
-          set,
-          sessionId,
-          workflowRunId,
-          outcome: 'blocked',
-          reason,
-        });
-        emitDecision({ get, sessionId, workflowRunId, action: 'blocked', reason, operatorNote });
-        void get().emitNotification(
-          'error',
-          'warning',
-          'dynamic workflow hit the step cap',
-          reason,
-          { sessionId },
-        );
-        return;
       }
       setDeciding({ set, workflowRunId, isDeciding: true });
       if (options?.bypassGate !== true) {
@@ -507,7 +538,15 @@ export const orchestrateNextStep = (set: SetFn, get: GetFn) => {
           modelMenu,
           roleDefaults,
           stepsUsed: workflow.steps.length,
-          stepBudget: ORCHESTRATOR_STEP_BUDGET,
+          ...(run.spendLimitUsd != null && {
+            spendLimitUsd: run.spendLimitUsd,
+            spentUsd: runSpendUsd({
+              records: get().sessionTelemetry[sessionId] ?? [],
+              agents: get().sessionPhaseRuns[sessionId] ?? [],
+              agentRunHistory: get().agentRunHistory,
+              workflowRunId,
+            }),
+          }),
         });
       } catch (error) {
         if (hasOperatorStop({ get, sessionId, workflowRunId })) {

--- a/apps/desktop/src/store/slices/workflows/recordOrchestratorUsage.test.ts
+++ b/apps/desktop/src/store/slices/workflows/recordOrchestratorUsage.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  Agent,
+  AgentId,
+  ProviderRunId,
+  SessionId,
+  StepId,
+  WorkflowId,
+  WorkflowRunId,
+} from '@goodboy/types';
+
+vi.mock('@goodboy/db', () => ({
+  insertProviderRun: vi.fn(async () => undefined),
+  insertTelemetry: vi.fn(async () => undefined),
+  summarizeSessionTelemetry: vi.fn(async () => null),
+  summarizeWorkspaceTelemetry: vi.fn(async () => null),
+  updateProviderRunStatus: vi.fn(async () => undefined),
+}));
+vi.mock('../../../shared/lib/db', () => ({ tauriDatabase: {} }));
+
+import { recordOrchestratorUsage } from './recordOrchestratorUsage';
+
+const SESSION_ID = 'ses-1' as SessionId;
+const RUN_ID = 'run-1' as WorkflowRunId;
+const OTHER_RUN_ID = 'run-2' as WorkflowRunId;
+
+const agent = (ordinal: number, workflowRunId: WorkflowRunId): Agent => ({
+  id: `agent-${ordinal}` as AgentId,
+  sessionId: SESSION_ID,
+  stepId: `step-${ordinal}` as StepId,
+  workflowRunId,
+  ordinal,
+  name: `step ${ordinal}`,
+  status: 'completed',
+  runId: `pr-${ordinal}` as ProviderRunId,
+});
+
+const usage = {
+  inputTokens: 10,
+  outputTokens: 5,
+  cachedInputTokens: 0,
+  cacheCreationInputTokens: 0,
+  estimatedCostUsd: 0.4,
+};
+
+type State = Record<string, unknown>;
+
+const harness = (agents: ReadonlyArray<Agent>) => {
+  const state: State = {
+    sessionTelemetry: {},
+    sessionPhaseRuns: { [SESSION_ID]: agents },
+    agentRunHistory: {},
+    sessions: [{ id: SESSION_ID, workspaceId: 'ws-1' as WorkflowId }],
+  };
+  const set = vi.fn((updater: (current: State) => State) => {
+    Object.assign(state, typeof updater === 'function' ? updater(state) : updater);
+  });
+  return { state, set: set as never, get: (() => state) as never };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('recordOrchestratorUsage', () => {
+  it('charges a decision with no agent of its own to the run it decided for', async () => {
+    const { state, set, get } = harness([agent(0, RUN_ID), agent(1, RUN_ID)]);
+
+    await recordOrchestratorUsage({
+      set,
+      get,
+      sessionId: SESSION_ID,
+      agentId: null,
+      workflowRunId: RUN_ID,
+      provider: 'anthropic',
+      model: 'opus',
+      usage,
+    });
+
+    const history = state['agentRunHistory'] as Record<string, ReadonlyArray<string>>;
+    expect(history['agent-1']).toHaveLength(2);
+  });
+
+  it('never charges a decision to a run that did not make it', async () => {
+    const { state, set, get } = harness([agent(0, OTHER_RUN_ID)]);
+
+    await recordOrchestratorUsage({
+      set,
+      get,
+      sessionId: SESSION_ID,
+      agentId: null,
+      workflowRunId: RUN_ID,
+      provider: 'anthropic',
+      model: 'opus',
+      usage,
+    });
+
+    expect(state['agentRunHistory']).toEqual({});
+  });
+});

--- a/apps/desktop/src/store/slices/workflows/recordOrchestratorUsage.ts
+++ b/apps/desktop/src/store/slices/workflows/recordOrchestratorUsage.ts
@@ -1,4 +1,4 @@
-import type { OrchestratorUsage } from '@goodboy/core';
+import { runsForWorkflowRun, type OrchestratorUsage } from '@goodboy/core';
 import {
   insertProviderRun,
   insertTelemetry,
@@ -14,6 +14,7 @@ import type {
   SessionId,
   TelemetryRecord,
   TelemetryRecordId,
+  WorkflowRunId,
 } from '@goodboy/types';
 import { tauriDatabase } from '../../../shared/lib/db';
 import type { GetFn, SetFn } from './types';
@@ -23,9 +24,21 @@ type Params = {
   readonly get: GetFn;
   readonly sessionId: SessionId;
   readonly agentId: AgentId | null;
+  readonly workflowRunId: WorkflowRunId;
   readonly provider: ProviderId;
   readonly model: string;
   readonly usage: OrchestratorUsage;
+};
+
+type FallbackParams = {
+  readonly get: GetFn;
+  readonly sessionId: SessionId;
+  readonly workflowRunId: WorkflowRunId;
+};
+
+const latestRunAgentId = ({ get, sessionId, workflowRunId }: FallbackParams): AgentId | null => {
+  const runAgents = runsForWorkflowRun(get().sessionPhaseRuns[sessionId] ?? [], workflowRunId);
+  return [...runAgents].sort((left, right) => right.ordinal - left.ordinal)[0]?.id ?? null;
 };
 
 type HistoryParams = {
@@ -50,6 +63,7 @@ export const recordOrchestratorUsage = async ({
   get,
   sessionId,
   agentId,
+  workflowRunId,
   provider,
   model,
   usage,
@@ -57,6 +71,7 @@ export const recordOrchestratorUsage = async ({
   if (usage.inputTokens + usage.outputTokens === 0) {
     return;
   }
+  const attributedAgentId = agentId ?? latestRunAgentId({ get, sessionId, workflowRunId });
   const runId = crypto.randomUUID() as ProviderRunId;
   const startedAt = new Date().toISOString() as IsoDateTime;
   await insertProviderRun(tauriDatabase, {
@@ -89,10 +104,13 @@ export const recordOrchestratorUsage = async ({
       ...state.sessionTelemetry,
       [sessionId]: [...(state.sessionTelemetry[sessionId] ?? []), record],
     },
-    ...(agentId != null && {
+    ...(attributedAgentId != null && {
       agentRunHistory: {
         ...state.agentRunHistory,
-        [agentId]: [...knownRunIds({ get, sessionId, agentId }), runId],
+        [attributedAgentId]: [
+          ...knownRunIds({ get, sessionId, agentId: attributedAgentId }),
+          runId,
+        ],
       },
     }),
   }));

--- a/apps/desktop/src/store/slices/workflows/runSpendUsd.ts
+++ b/apps/desktop/src/store/slices/workflows/runSpendUsd.ts
@@ -1,0 +1,36 @@
+import type { Agent, AgentId, ProviderRunId, TelemetryRecord, WorkflowRunId } from '@goodboy/types';
+
+type RunSpendParams = {
+  readonly records: ReadonlyArray<TelemetryRecord>;
+  readonly agents: ReadonlyArray<Agent>;
+  readonly agentRunHistory: Readonly<Record<AgentId, ReadonlyArray<ProviderRunId>>>;
+  readonly workflowRunId: WorkflowRunId;
+};
+
+export const runSpendUsd = ({
+  records,
+  agents,
+  agentRunHistory,
+  workflowRunId,
+}: RunSpendParams): number => {
+  const providerRunIds = new Set<ProviderRunId>();
+  for (const agent of agents) {
+    if (agent.workflowRunId !== workflowRunId) {
+      continue;
+    }
+    if (agent.runId != null) {
+      providerRunIds.add(agent.runId);
+    }
+    for (const runId of agentRunHistory[agent.id] ?? []) {
+      providerRunIds.add(runId);
+    }
+  }
+  let sum = 0;
+  for (const record of records) {
+    if (record.kind === 'summarizer' || !providerRunIds.has(record.runId)) {
+      continue;
+    }
+    sum += record.estimatedCostUsd;
+  }
+  return sum;
+};

--- a/apps/desktop/src/store/slices/workflows/setWorkflowRunSpendLimit.test.ts
+++ b/apps/desktop/src/store/slices/workflows/setWorkflowRunSpendLimit.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  IsoDateTime,
+  Session,
+  SessionId,
+  WorkflowId,
+  WorkflowRunId,
+  WorkspaceId,
+} from '@goodboy/types';
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
+
+const { updateSpendLimitSpy } = vi.hoisted(() => ({
+  updateSpendLimitSpy: vi.fn(async () => undefined),
+}));
+
+vi.mock('@goodboy/db', () => ({ updateWorkflowRunSpendLimit: updateSpendLimitSpy }));
+vi.mock('../../../shared/lib/db', () => ({ tauriDatabase: {} }));
+
+import { setWorkflowRunSpendLimit } from './setWorkflowRunSpendLimit';
+
+const SESSION_ID = 'ses-1' as SessionId;
+const RUN_ID = 'run-1' as WorkflowRunId;
+const NOW = '2026-08-14T00:00:00.000Z' as IsoDateTime;
+
+const session = (spendLimitUsd?: number): Session => ({
+  id: SESSION_ID,
+  workspaceId: 'ws-1' as WorkspaceId,
+  goal: 'g',
+  state: { kind: 'idle', lastActivityAt: NOW },
+  contextSlots: [],
+  providerPreference: { defaultProvider: 'anthropic', allowTurnOverride: true },
+  permissionMode: 'default',
+  workflowRuns: [
+    {
+      id: RUN_ID,
+      workflowId: 'wf-1' as WorkflowId,
+      ordinal: 0,
+      currentStep: 0,
+      autoRun: true,
+      triggerMode: 'immediate',
+      executionMode: 'dynamic',
+      ...(spendLimitUsd != null && { spendLimitUsd }),
+    },
+  ],
+  autoRun: true,
+  titleUserEdited: false,
+  createdAt: NOW,
+  updatedAt: NOW,
+});
+
+type State = Record<string, unknown>;
+
+const harness = (state: State) => {
+  const set = vi.fn((updater: unknown) => {
+    Object.assign(
+      state,
+      typeof updater === 'function' ? (updater as (s: State) => State)(state) : (updater as State),
+    );
+  });
+  return { set: set as never, get: (() => state) as never };
+};
+
+const runOf = (state: State) => (state['sessions'] as ReadonlyArray<Session>)[0]!.workflowRuns[0]!;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('setWorkflowRunSpendLimit', () => {
+  it('writes the limit and mode the operator picked', async () => {
+    const state: State = { sessions: [session()] };
+    const { set, get } = harness(state);
+
+    await setWorkflowRunSpendLimit(set, get)(SESSION_ID, RUN_ID, 12.5, 'notify');
+
+    expect(updateSpendLimitSpy).toHaveBeenCalledWith({}, RUN_ID, 12.5, 'notify');
+    expect(runOf(state).spendLimitUsd).toBe(12.5);
+    expect(runOf(state).spendLimitMode).toBe('notify');
+  });
+
+  it('drops the limit key entirely when the operator clears it', async () => {
+    const state: State = { sessions: [session(12.5)] };
+    const { set, get } = harness(state);
+
+    await setWorkflowRunSpendLimit(set, get)(SESSION_ID, RUN_ID, null, 'pause');
+
+    expect(updateSpendLimitSpy).toHaveBeenCalledWith({}, RUN_ID, null, 'pause');
+    expect('spendLimitUsd' in runOf(state)).toBe(false);
+    expect(runOf(state).spendLimitMode).toBe('pause');
+  });
+
+  it('reads a non-positive limit as no limit at all', async () => {
+    const state: State = { sessions: [session(12.5)] };
+    const { set, get } = harness(state);
+
+    await setWorkflowRunSpendLimit(set, get)(SESSION_ID, RUN_ID, 0, 'pause');
+
+    expect(updateSpendLimitSpy).toHaveBeenCalledWith({}, RUN_ID, null, 'pause');
+    expect('spendLimitUsd' in runOf(state)).toBe(false);
+  });
+
+  it('touches nothing for a run the session does not have', async () => {
+    const state: State = { sessions: [session()] };
+    const { set, get } = harness(state);
+
+    await setWorkflowRunSpendLimit(set, get)(SESSION_ID, 'run-9' as WorkflowRunId, 5, 'pause');
+
+    expect(updateSpendLimitSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/store/slices/workflows/setWorkflowRunSpendLimit.ts
+++ b/apps/desktop/src/store/slices/workflows/setWorkflowRunSpendLimit.ts
@@ -1,0 +1,31 @@
+import type { SessionId, WorkflowRunId, WorkflowSpendLimitMode } from '@goodboy/types';
+import { updateWorkflowRunSpendLimit } from '@goodboy/db';
+import { tauriDatabase } from '../../../shared/lib/db';
+import { patchWorkflowRun, withoutKeys } from './patchWorkflowRun';
+import type { GetFn, SetFn } from './types';
+
+export const setWorkflowRunSpendLimit = (set: SetFn, get: GetFn) => {
+  return async (
+    sessionId: SessionId,
+    workflowRunId: WorkflowRunId,
+    limitUsd: number | null,
+    mode: WorkflowSpendLimitMode,
+  ) => {
+    const session = get().sessions.find((candidate) => candidate.id === sessionId);
+    const run = session?.workflowRuns.find((candidate) => candidate.id === workflowRunId);
+    if (run == null) {
+      return;
+    }
+    const nextLimit = limitUsd != null && limitUsd > 0 ? limitUsd : null;
+    await updateWorkflowRunSpendLimit(tauriDatabase, workflowRunId, nextLimit, mode);
+    patchWorkflowRun({
+      set,
+      sessionId,
+      workflowRunId,
+      patch: (current) =>
+        nextLimit == null
+          ? { ...withoutKeys(current, ['spendLimitUsd']), spendLimitMode: mode }
+          : { ...current, spendLimitUsd: nextLimit, spendLimitMode: mode },
+    });
+  };
+};

--- a/apps/desktop/src/store/slices/workflows/setWorkflowRunSpendLimit.ts
+++ b/apps/desktop/src/store/slices/workflows/setWorkflowRunSpendLimit.ts
@@ -27,5 +27,9 @@ export const setWorkflowRunSpendLimit = (set: SetFn, get: GetFn) => {
           ? { ...withoutKeys(current, ['spendLimitUsd']), spendLimitMode: mode }
           : { ...current, spendLimitUsd: nextLimit, spendLimitMode: mode },
     });
+    set((state) => {
+      const { [workflowRunId]: _cleared, ...announcedRunBudget } = state.announcedRunBudget ?? {};
+      return { announcedRunBudget };
+    });
   };
 };

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -34,6 +34,7 @@ import type {
   WorkflowRunId,
   WorkflowTriggerMode,
   WorkflowExecutionMode,
+  WorkflowSpendLimitMode,
   ProviderId,
   ProviderCredential,
   CredentialId,
@@ -377,6 +378,12 @@ export type AppActions = {
     sessionId: SessionId,
     workflowRunId: WorkflowRunId,
     routing: OrchestratorRouting | null,
+  ): Promise<void>;
+  setWorkflowRunSpendLimit(
+    sessionId: SessionId,
+    workflowRunId: WorkflowRunId,
+    limitUsd: number | null,
+    mode: WorkflowSpendLimitMode,
   ): Promise<void>;
   reprocessGoalForWorkflow(sessionId: SessionId): Promise<void>;
   loadTranscript(agentId: AgentId, sessionId: SessionId): Promise<void>;
@@ -818,6 +825,7 @@ export const initialState: AppState = {
   sessionPhaseRuns: {},
   orchestratingWorkflowRuns: {},
   announcedWorkflowBlocks: {},
+  announcedRunBudget: {},
   selectedAgentId: {},
   agentRunHistory: {},
   agentTurnState: {},

--- a/apps/desktop/src/store/types.ts
+++ b/apps/desktop/src/store/types.ts
@@ -228,6 +228,7 @@ export type AppState = AppSliceState & {
   readonly sessionPhaseRuns: Readonly<Record<SessionId, ReadonlyArray<Agent>>>;
   readonly orchestratingWorkflowRuns: Readonly<Record<WorkflowRunId, boolean>>;
   readonly announcedWorkflowBlocks: Readonly<Record<WorkflowRunId, string>>;
+  readonly announcedRunBudget: Readonly<Record<WorkflowRunId, number>>;
   readonly selectedAgentId: Readonly<Record<SessionId, AgentId | null>>;
   readonly agentRunHistory: Readonly<Record<AgentId, ReadonlyArray<ProviderRunId>>>;
   readonly agentTurnState: Readonly<Record<AgentId, TurnState>>;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -361,8 +361,6 @@ export {
   buildOrchestratorUserPrompt,
   enforceOrchestratorModelPool,
   orchestratorModelPool,
-  ORCHESTRATOR_STEP_BUDGET,
-  ORCHESTRATOR_STEP_HARD_CAP,
   ORCHESTRATOR_SYSTEM_PROMPT,
   OrchestratorClient,
   OrchestratorClientSpawnError,

--- a/packages/core/src/orchestrator/client.provider-error.test.ts
+++ b/packages/core/src/orchestrator/client.provider-error.test.ts
@@ -10,7 +10,6 @@ const input = {
   modelMenu: [],
   roleDefaults: [],
   stepsUsed: 0,
-  stepBudget: 8,
 };
 
 describe('OrchestratorClient provider errors', () => {

--- a/packages/core/src/orchestrator/client.test.ts
+++ b/packages/core/src/orchestrator/client.test.ts
@@ -31,7 +31,6 @@ describe('OrchestratorClient', () => {
       modelMenu: [{ id: 'haiku-4.5', label: 'Haiku 4.5', note: 'cheap, fast' }],
       roleDefaults: [{ role: 'implementer', model: 'sonnet-5', effort: 'medium' }],
       stepsUsed: 0,
-      stepBudget: 8,
     });
 
     const args = request?.['args'] as Record<string, unknown> | undefined;
@@ -68,7 +67,6 @@ describe('OrchestratorClient', () => {
       modelMenu: [{ id: 'haiku-4.5', label: 'Haiku 4.5', note: 'cheap, fast' }],
       roleDefaults: [{ role: 'implementer', model: 'sonnet-5', effort: 'medium' }],
       stepsUsed: 0,
-      stepBudget: 8,
     });
 
     const args = request?.['args'] as Record<string, unknown> | undefined;
@@ -93,7 +91,6 @@ describe('OrchestratorClient', () => {
       modelMenu: [],
       roleDefaults: [],
       stepsUsed: 0,
-      stepBudget: 8,
     });
 
     expect(result.decision).toBeNull();
@@ -119,7 +116,6 @@ describe('OrchestratorClient', () => {
         modelMenu: [],
         roleDefaults: [],
         stepsUsed: 0,
-        stepBudget: 8,
       }),
     ).rejects.toThrow('orchestrator decision timed out');
   });

--- a/packages/core/src/orchestrator/index.ts
+++ b/packages/core/src/orchestrator/index.ts
@@ -1,6 +1,5 @@
 export { parseOrchestratorDecision } from './parser';
 export { buildOrchestratorUserPrompt, ORCHESTRATOR_SYSTEM_PROMPT } from './prompt';
-export { ORCHESTRATOR_STEP_BUDGET, ORCHESTRATOR_STEP_HARD_CAP } from './limits';
 export { orchestratorModelPool } from './orchestratorModelPool';
 export {
   enforceOrchestratorModelPool,

--- a/packages/core/src/orchestrator/limits.ts
+++ b/packages/core/src/orchestrator/limits.ts
@@ -1,3 +1,0 @@
-export const ORCHESTRATOR_STEP_BUDGET = 8;
-
-export const ORCHESTRATOR_STEP_HARD_CAP = 12;

--- a/packages/core/src/orchestrator/prompt.test.ts
+++ b/packages/core/src/orchestrator/prompt.test.ts
@@ -11,7 +11,6 @@ const input = (overrides: Partial<OrchestratorInput> = {}): OrchestratorInput =>
   modelMenu: [],
   roleDefaults: [],
   stepsUsed: 0,
-  stepBudget: 8,
   ...overrides,
 });
 
@@ -31,10 +30,21 @@ describe('buildOrchestratorUserPrompt', () => {
     );
   });
 
-  it('states how much of the step budget is already spent', () => {
-    const prompt = buildOrchestratorUserPrompt(input({ stepsUsed: 5, stepBudget: 8 }));
+  it('states the steps spent without any cap to close on', () => {
+    const prompt = buildOrchestratorUserPrompt(input({ stepsUsed: 5 }));
 
-    expect(prompt).toContain('Step budget: 5 used of 8');
+    expect(prompt).toContain('Steps used: 5');
+    expect(prompt).not.toContain('Hard cap');
+  });
+
+  it('states the spend against the limit the operator allowed', () => {
+    const prompt = buildOrchestratorUserPrompt(input({ spendLimitUsd: 20, spentUsd: 8.4 }));
+
+    expect(prompt).toContain('Spend: $8.40 of the $20.00 the operator allowed');
+  });
+
+  it('leaves the spend line out when the run is uncapped', () => {
+    expect(buildOrchestratorUserPrompt(input({ spentUsd: 8.4 }))).not.toContain('Spend:');
   });
 
   it('presents the model menu as the routing pool rather than a catalog', () => {
@@ -57,11 +67,19 @@ describe('buildOrchestratorUserPrompt', () => {
 
 describe('ORCHESTRATOR_SYSTEM_PROMPT', () => {
   it('dictates the flow rules that keep a run from running forever', () => {
-    expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain('Stay inside the step budget');
+    expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain('treat that estimate as your own soft cap');
+    expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain('never because a count was reached');
+    expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain('unless the operator explicitly asks for more');
     expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain(
       'Never reopen work a completed step already covers',
     );
     expect(ORCHESTRATOR_SYSTEM_PROMPT).toContain('planner step');
+  });
+
+  it('never gives the orchestrator a count to close on', () => {
+    expect(ORCHESTRATOR_SYSTEM_PROMPT).not.toContain('step budget');
+    expect(ORCHESTRATOR_SYSTEM_PROMPT).not.toContain('reaches the budget');
+    expect(ORCHESTRATOR_SYSTEM_PROMPT).not.toContain('hard cap');
   });
 
   it('makes the operator role defaults the routing baseline', () => {

--- a/packages/core/src/orchestrator/prompt.ts
+++ b/packages/core/src/orchestrator/prompt.ts
@@ -5,10 +5,10 @@ const OLDER_SUMMARY_PREVIEW_LENGTH = 280;
 
 export const ORCHESTRATOR_SYSTEM_PROMPT = `You are the workflow orchestrator for an AI coding workspace. You never execute the work yourself: dedicated agents run each step and report back. You have no tools and no repository access, and you must not ask for either. Your only job is to emit the next decision from the information given.
 
-After each completed step, including kickoff when no steps exist, decide the single next step or end the run. Keep steps small and purposeful.
+After each completed step, including kickoff when no steps exist, decide the single next step or end the run. Keep steps small and purposeful. Most runs land in a handful of steps, so a long run has to be a deliberate choice you can justify in reason, never drift.
 
 Flow rules, in this order of precedence:
-1. Stay inside the step budget given in the request. Once the used count reaches the budget, return done and name what is left instead of opening another step.
+1. From the goal and the operator process, estimate roughly how many steps this run should take and treat that estimate as your own soft cap. Exceed it only when what the run discovered justifies the extra work, and say so in reason. The run closes when the goal and the operator process are satisfied, never because a count was reached, and once they are satisfied you never keep going unless the operator explicitly asks for more.
 2. Discovery, then a decision, then work. Unless the goal is already a located one-file fix or the operator process says otherwise, the run starts with a scout or investigator step and the step after it is a planner step that turns those findings into the work to do. Do not go from discovery straight to an implementer.
 3. Never reopen work a completed step already covers. If the gap left behind is small, return done and name that gap in the reason.
 4. One review or test pass per implementation. Wanting a second review of the same work means the run should end.
@@ -50,7 +50,8 @@ export const buildOrchestratorUserPrompt = ({
   modelMenu,
   roleDefaults,
   stepsUsed,
-  stepBudget,
+  spendLimitUsd,
+  spentUsd,
 }: OrchestratorInput): string => {
   const lines = [
     'Goal:',
@@ -61,10 +62,14 @@ export const buildOrchestratorUserPrompt = ({
     '',
     `Open questions: ${openQuestionCount}`,
     '',
-    `Step budget: ${stepsUsed} used of ${stepBudget}`,
-    '',
-    `Routing pool, the only models you may pick (provider ${providerId}):`,
+    `Steps used: ${stepsUsed}`,
   ];
+  if (spendLimitUsd != null) {
+    lines.push(
+      `Spend: $${(spentUsd ?? 0).toFixed(2)} of the $${spendLimitUsd.toFixed(2)} the operator allowed. As you approach it, consolidate what is left into fewer steps.`,
+    );
+  }
+  lines.push('', `Routing pool, the only models you may pick (provider ${providerId}):`);
   if (modelMenu.length === 0) {
     lines.push('(none, omit model)');
   } else {

--- a/packages/core/src/orchestrator/types.ts
+++ b/packages/core/src/orchestrator/types.ts
@@ -54,5 +54,6 @@ export type OrchestratorInput = {
   readonly modelMenu: ReadonlyArray<OrchestratorModelOption>;
   readonly roleDefaults: ReadonlyArray<OrchestratorRoleDefault>;
   readonly stepsUsed: number;
-  readonly stepBudget: number;
+  readonly spendLimitUsd?: number;
+  readonly spentUsd?: number;
 };

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -67,6 +67,7 @@ export {
   updateWorkflowRunOrchestratorHints,
   updateWorkflowRunOrchestratorRouting,
   updateWorkflowRunOrchestratorSummary,
+  updateWorkflowRunSpendLimit,
 } from './queries/session-workflow';
 export { insertMessage, listMessagesForAgent, listMessagesForSession } from './queries/message';
 export {

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -107,6 +107,7 @@ import { m106MoonshotProviderRuns } from './m106-moonshot-provider-runs';
 import { m107IntegrationBitbucketProvider } from './m107-integration-bitbucket-provider';
 import { m108IntegrationSlackProvider } from './m108-integration-slack-provider';
 import { m109WorkflowRunSummary } from './m109-workflow-run-summary';
+import { m110WorkflowRunSpendLimit } from './m110-workflow-run-spend-limit';
 
 export type Migration = {
   readonly version: number;
@@ -223,4 +224,5 @@ export const migrations: ReadonlyArray<Migration> = [
   { version: 107, sql: m107IntegrationBitbucketProvider },
   { version: 108, sql: m108IntegrationSlackProvider },
   { version: 109, sql: m109WorkflowRunSummary },
+  { version: 110, sql: m110WorkflowRunSpendLimit },
 ];

--- a/packages/db/src/migrations/m110-workflow-run-spend-limit.test.ts
+++ b/packages/db/src/migrations/m110-workflow-run-spend-limit.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import type { Database } from '../client';
+import { makeTestDatabase } from '../test-helpers/test-db';
+import { migrate } from './runner';
+import { migrations } from './index';
+
+const workspaceId = 'ws-1';
+const sessionId = 's-1';
+const workflowId = 'wf-1';
+
+const seedThrough109 = async (): Promise<Database> => {
+  const db = makeTestDatabase();
+  await migrate(
+    db,
+    migrations.filter((migration) => migration.version <= 109),
+  );
+  const now = Date.now();
+  await db.execute(
+    'INSERT INTO workspaces (id, name, root_path, created_at, updated_at) VALUES (?, ?, ?, ?, ?)',
+    [workspaceId, 'ws', '/tmp/ws', now, now],
+  );
+  await db.execute(
+    'INSERT INTO sessions (id, workspace_id, goal, state_kind, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)',
+    [sessionId, workspaceId, 'goal', 'idle', now, now],
+  );
+  await db.execute(
+    `INSERT INTO workflows (id, workspace_id, name, description, created_at, updated_at, is_preset)
+     VALUES (?, ?, 'wf', '', ?, ?, 1)`,
+    [workflowId, workspaceId, new Date().toISOString(), new Date().toISOString()],
+  );
+  return db;
+};
+
+type RunParams = {
+  readonly db: Database;
+  readonly runId: string;
+  readonly ordinal: number;
+};
+
+const insertRun = async ({ db, runId, ordinal }: RunParams): Promise<void> => {
+  await db.execute(
+    `INSERT INTO session_workflows
+       (workflow_run_id, session_id, workflow_id, ordinal, current_step_ordinal, auto_run,
+        trigger_mode, execution_mode)
+     VALUES (?, ?, ?, ?, 0, 1, 'immediate', 'dynamic')`,
+    [runId, sessionId, workflowId, ordinal],
+  );
+};
+
+type SpendRow = {
+  readonly workflow_run_id: string;
+  readonly spend_limit_usd: number | null;
+  readonly spend_limit_mode: string;
+};
+
+type DbParams = {
+  readonly db: Database;
+};
+
+const spendRows = async ({ db }: DbParams): Promise<ReadonlyArray<SpendRow>> =>
+  db.select<SpendRow>(
+    'SELECT workflow_run_id, spend_limit_usd, spend_limit_mode FROM session_workflows ORDER BY workflow_run_id',
+  );
+
+describe('m110 workflow run spend limit', () => {
+  it('leaves an existing run uncapped and in pause mode', async () => {
+    const db = await seedThrough109();
+    await insertRun({ db, runId: 'run-old', ordinal: 0 });
+
+    await migrate(db, migrations);
+
+    expect(await spendRows({ db })).toEqual([
+      { workflow_run_id: 'run-old', spend_limit_usd: null, spend_limit_mode: 'pause' },
+    ]);
+  });
+
+  it('stores a notifying limit written after the migration', async () => {
+    const db = await seedThrough109();
+
+    await migrate(db, migrations);
+    await insertRun({ db, runId: 'run-new', ordinal: 0 });
+    await db.execute(
+      'UPDATE session_workflows SET spend_limit_usd = ?, spend_limit_mode = ? WHERE workflow_run_id = ?',
+      [12.5, 'notify', 'run-new'],
+    );
+
+    expect(await spendRows({ db })).toEqual([
+      { workflow_run_id: 'run-new', spend_limit_usd: 12.5, spend_limit_mode: 'notify' },
+    ]);
+  });
+
+  it('keeps the indexes and the foreign keys of the table', async () => {
+    const db = await seedThrough109();
+    await insertRun({ db, runId: 'run-old', ordinal: 0 });
+
+    await migrate(db, migrations);
+
+    const indexes = await db.select<{ name: string }>(
+      "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'session_workflows' AND sql IS NOT NULL ORDER BY name",
+    );
+    expect(indexes.map((index) => index.name)).toEqual([
+      'idx_session_workflows_session_id',
+      'idx_session_workflows_workflow_id',
+    ]);
+    expect(await db.select<{ rowid: number }>('PRAGMA foreign_key_check')).toEqual([]);
+  });
+});

--- a/packages/db/src/migrations/m110-workflow-run-spend-limit.ts
+++ b/packages/db/src/migrations/m110-workflow-run-spend-limit.ts
@@ -1,0 +1,4 @@
+export const m110WorkflowRunSpendLimit = /* sql */ `
+ALTER TABLE session_workflows ADD COLUMN spend_limit_usd REAL;
+ALTER TABLE session_workflows ADD COLUMN spend_limit_mode TEXT NOT NULL DEFAULT 'pause';
+`;

--- a/packages/db/src/queries/session-workflow.test.ts
+++ b/packages/db/src/queries/session-workflow.test.ts
@@ -19,6 +19,7 @@ import {
   updateWorkflowRunOrchestrationOutcome,
   updateWorkflowRunOrchestrationStop,
   updateWorkflowRunOrchestratorRouting,
+  updateWorkflowRunSpendLimit,
 } from './session-workflow';
 import { listSessionsForWorkspace } from './session';
 
@@ -60,7 +61,14 @@ describe('session_workflows trigger-mode queries', () => {
 
   describe('attachWorkflowToSession + toWorkflowRun mapping', () => {
     it('defaults trigger_mode to immediate and omits chainAfterId when none given', async () => {
-      await attachWorkflowToSession(db, sessionId, 'run-1' as WorkflowRunId, workflowId, true, NOW);
+      await attachWorkflowToSession({
+        db,
+        sessionId,
+        workflowRunId: 'run-1' as WorkflowRunId,
+        workflowId,
+        autoRun: true,
+        updatedAt: NOW,
+      });
       const runs = await listWorkflowsForSession(db, sessionId);
       expect(runs).toHaveLength(1);
       expect(runs[0]!.triggerMode).toBe('immediate');
@@ -69,51 +77,54 @@ describe('session_workflows trigger-mode queries', () => {
     });
 
     it('persists manual trigger mode', async () => {
-      await attachWorkflowToSession(
+      await attachWorkflowToSession({
         db,
         sessionId,
-        'run-1' as WorkflowRunId,
+        workflowRunId: 'run-1' as WorkflowRunId,
         workflowId,
-        false,
-        NOW,
-        undefined,
-        'manual',
-      );
+        autoRun: false,
+        updatedAt: NOW,
+        triggerMode: 'manual',
+      });
       const runs = await listWorkflowsForSession(db, sessionId);
       expect(runs[0]!.triggerMode).toBe('manual');
       expect(runs[0]!.autoRun).toBe(false);
     });
 
     it('persists dynamic execution mode', async () => {
-      await attachWorkflowToSession(
+      await attachWorkflowToSession({
         db,
         sessionId,
-        'run-1' as WorkflowRunId,
+        workflowRunId: 'run-1' as WorkflowRunId,
         workflowId,
-        true,
-        NOW,
-        undefined,
-        'immediate',
-        undefined,
-        'dynamic',
-      );
+        autoRun: true,
+        updatedAt: NOW,
+        triggerMode: 'immediate',
+        executionMode: 'dynamic',
+      });
       const runs = await listWorkflowsForSession(db, sessionId);
       expect(runs[0]!.executionMode).toBe('dynamic');
     });
 
     it('persists after_run mode with chain_after_run_id round-trip', async () => {
-      await attachWorkflowToSession(db, sessionId, 'pred' as WorkflowRunId, workflowId, true, NOW);
-      await attachWorkflowToSession(
+      await attachWorkflowToSession({
         db,
         sessionId,
-        'chained' as WorkflowRunId,
-        workflowId2,
-        true,
-        NOW,
-        undefined,
-        'after_run',
-        'pred' as WorkflowRunId,
-      );
+        workflowRunId: 'pred' as WorkflowRunId,
+        workflowId,
+        autoRun: true,
+        updatedAt: NOW,
+      });
+      await attachWorkflowToSession({
+        db,
+        sessionId,
+        workflowRunId: 'chained' as WorkflowRunId,
+        workflowId: workflowId2,
+        autoRun: true,
+        updatedAt: NOW,
+        triggerMode: 'after_run',
+        chainAfterRunId: 'pred' as WorkflowRunId,
+      });
       const runs = await listWorkflowsForSession(db, sessionId);
       const chained = runs.find((r) => r.id === ('chained' as WorkflowRunId));
       expect(chained!.triggerMode).toBe('after_run');
@@ -121,8 +132,22 @@ describe('session_workflows trigger-mode queries', () => {
     });
 
     it('auto-increments ordinal across attaches', async () => {
-      await attachWorkflowToSession(db, sessionId, 'r0' as WorkflowRunId, workflowId, true, NOW);
-      await attachWorkflowToSession(db, sessionId, 'r1' as WorkflowRunId, workflowId2, true, NOW);
+      await attachWorkflowToSession({
+        db,
+        sessionId,
+        workflowRunId: 'r0' as WorkflowRunId,
+        workflowId,
+        autoRun: true,
+        updatedAt: NOW,
+      });
+      await attachWorkflowToSession({
+        db,
+        sessionId,
+        workflowRunId: 'r1' as WorkflowRunId,
+        workflowId: workflowId2,
+        autoRun: true,
+        updatedAt: NOW,
+      });
       const runs = await listWorkflowsForSession(db, sessionId);
       expect(runs.map((r) => [r.id, r.ordinal])).toEqual([
         ['r1', 1],
@@ -147,7 +172,14 @@ describe('session_workflows trigger-mode queries', () => {
     });
 
     it('reads the SQLite datetime text as UTC, not as host local time', async () => {
-      await attachWorkflowToSession(db, sessionId, 'r0' as WorkflowRunId, workflowId, true, NOW);
+      await attachWorkflowToSession({
+        db,
+        sessionId,
+        workflowRunId: 'r0' as WorkflowRunId,
+        workflowId,
+        autoRun: true,
+        updatedAt: NOW,
+      });
       await db.execute('UPDATE session_workflows SET created_at = ? WHERE workflow_run_id = ?', [
         '2026-08-05 09:14:22',
         'r0',
@@ -157,7 +189,14 @@ describe('session_workflows trigger-mode queries', () => {
     });
 
     it('omits createdAt when the column is empty', async () => {
-      await attachWorkflowToSession(db, sessionId, 'r0' as WorkflowRunId, workflowId, true, NOW);
+      await attachWorkflowToSession({
+        db,
+        sessionId,
+        workflowRunId: 'r0' as WorkflowRunId,
+        workflowId,
+        autoRun: true,
+        updatedAt: NOW,
+      });
       await db.execute('UPDATE session_workflows SET created_at = ? WHERE workflow_run_id = ?', [
         '',
         'r0',
@@ -167,8 +206,22 @@ describe('session_workflows trigger-mode queries', () => {
     });
 
     it('keeps the attach timestamp across a reorder', async () => {
-      await attachWorkflowToSession(db, sessionId, 'r0' as WorkflowRunId, workflowId, true, NOW);
-      await attachWorkflowToSession(db, sessionId, 'r1' as WorkflowRunId, workflowId2, true, NOW);
+      await attachWorkflowToSession({
+        db,
+        sessionId,
+        workflowRunId: 'r0' as WorkflowRunId,
+        workflowId,
+        autoRun: true,
+        updatedAt: NOW,
+      });
+      await attachWorkflowToSession({
+        db,
+        sessionId,
+        workflowRunId: 'r1' as WorkflowRunId,
+        workflowId: workflowId2,
+        autoRun: true,
+        updatedAt: NOW,
+      });
       await db.execute('UPDATE session_workflows SET created_at = ? WHERE workflow_run_id = ?', [
         '2026-08-05 09:14:22',
         'r0',
@@ -183,8 +236,22 @@ describe('session_workflows trigger-mode queries', () => {
 
   describe('listWorkflowsForSession ordering', () => {
     it('returns runs newest first, by ordinal descending', async () => {
-      await attachWorkflowToSession(db, sessionId, 'r0' as WorkflowRunId, workflowId, true, NOW);
-      await attachWorkflowToSession(db, sessionId, 'r1' as WorkflowRunId, workflowId2, true, NOW);
+      await attachWorkflowToSession({
+        db,
+        sessionId,
+        workflowRunId: 'r0' as WorkflowRunId,
+        workflowId,
+        autoRun: true,
+        updatedAt: NOW,
+      });
+      await attachWorkflowToSession({
+        db,
+        sessionId,
+        workflowRunId: 'r1' as WorkflowRunId,
+        workflowId: workflowId2,
+        autoRun: true,
+        updatedAt: NOW,
+      });
       const runs = await listWorkflowsForSession(db, sessionId);
       expect(runs.map((r) => r.id)).toEqual(['r1', 'r0']);
     });
@@ -197,17 +264,16 @@ describe('session_workflows trigger-mode queries', () => {
 
   describe('updateSessionWorkflowTriggerMode', () => {
     it('flips an after_run run to immediate', async () => {
-      await attachWorkflowToSession(
+      await attachWorkflowToSession({
         db,
         sessionId,
-        'run-1' as WorkflowRunId,
+        workflowRunId: 'run-1' as WorkflowRunId,
         workflowId,
-        true,
-        NOW,
-        undefined,
-        'after_run',
-        'pred' as WorkflowRunId,
-      );
+        autoRun: true,
+        updatedAt: NOW,
+        triggerMode: 'after_run',
+        chainAfterRunId: 'pred' as WorkflowRunId,
+      });
       await updateSessionWorkflowTriggerMode(
         db,
         sessionId,
@@ -220,17 +286,16 @@ describe('session_workflows trigger-mode queries', () => {
     });
 
     it('flips a chained run to manual without clearing chain_after_run_id', async () => {
-      await attachWorkflowToSession(
+      await attachWorkflowToSession({
         db,
         sessionId,
-        'run-1' as WorkflowRunId,
+        workflowRunId: 'run-1' as WorkflowRunId,
         workflowId,
-        true,
-        NOW,
-        undefined,
-        'after_run',
-        'pred' as WorkflowRunId,
-      );
+        autoRun: true,
+        updatedAt: NOW,
+        triggerMode: 'after_run',
+        chainAfterRunId: 'pred' as WorkflowRunId,
+      });
       await updateSessionWorkflowTriggerMode(
         db,
         sessionId,
@@ -246,18 +311,24 @@ describe('session_workflows trigger-mode queries', () => {
 
   describe('updateWorkflowOrder preserves chain metadata', () => {
     it('keeps trigger_mode and chain_after_run_id after reorder', async () => {
-      await attachWorkflowToSession(db, sessionId, 'pred' as WorkflowRunId, workflowId, true, NOW);
-      await attachWorkflowToSession(
+      await attachWorkflowToSession({
         db,
         sessionId,
-        'chained' as WorkflowRunId,
-        workflowId2,
-        false,
-        NOW,
-        undefined,
-        'after_run',
-        'pred' as WorkflowRunId,
-      );
+        workflowRunId: 'pred' as WorkflowRunId,
+        workflowId,
+        autoRun: true,
+        updatedAt: NOW,
+      });
+      await attachWorkflowToSession({
+        db,
+        sessionId,
+        workflowRunId: 'chained' as WorkflowRunId,
+        workflowId: workflowId2,
+        autoRun: false,
+        updatedAt: NOW,
+        triggerMode: 'after_run',
+        chainAfterRunId: 'pred' as WorkflowRunId,
+      });
       await updateWorkflowOrder(
         db,
         sessionId,
@@ -276,53 +347,120 @@ describe('session_workflows trigger-mode queries', () => {
     });
   });
 
-  describe('per-run goal', () => {
-    it('round-trips the goal typed in the builder', async () => {
-      await attachWorkflowToSession(
+  describe('per-run spend limit', () => {
+    it('leaves a fresh run uncapped and pausing', async () => {
+      await attachWorkflowToSession({
         db,
         sessionId,
-        'run-1' as WorkflowRunId,
+        workflowRunId: 'run-1' as WorkflowRunId,
         workflowId,
-        false,
+        autoRun: true,
+        updatedAt: NOW,
+      });
+      const run = (await listWorkflowsForSession(db, sessionId))[0]!;
+      expect(run.spendLimitUsd).toBeUndefined();
+      expect(run.spendLimitMode).toBe('pause');
+    });
+
+    it('round-trips the limit set on the run and clears it', async () => {
+      await attachWorkflowToSession({
+        db,
+        sessionId,
+        workflowRunId: 'run-1' as WorkflowRunId,
+        workflowId,
+        autoRun: true,
+        updatedAt: NOW,
+      });
+      await updateWorkflowRunSpendLimit(db, 'run-1' as WorkflowRunId, 7.5, 'notify');
+      const capped = (await listWorkflowsForSession(db, sessionId))[0]!;
+      expect(capped.spendLimitUsd).toBe(7.5);
+      expect(capped.spendLimitMode).toBe('notify');
+
+      await updateWorkflowRunSpendLimit(db, 'run-1' as WorkflowRunId, null, 'pause');
+      const uncapped = (await listWorkflowsForSession(db, sessionId))[0]!;
+      expect(uncapped.spendLimitUsd).toBeUndefined();
+      expect(uncapped.spendLimitMode).toBe('pause');
+    });
+
+    it('keeps the limit when runs are reordered', async () => {
+      await attachWorkflowToSession({
+        db,
+        sessionId,
+        workflowRunId: 'run-1' as WorkflowRunId,
+        workflowId,
+        autoRun: true,
+        updatedAt: NOW,
+      });
+      await attachWorkflowToSession({
+        db,
+        sessionId,
+        workflowRunId: 'run-2' as WorkflowRunId,
+        workflowId: workflowId2,
+        autoRun: true,
+        updatedAt: NOW,
+      });
+      await updateWorkflowRunSpendLimit(db, 'run-1' as WorkflowRunId, 12.5, 'notify');
+      await updateWorkflowOrder(
+        db,
+        sessionId,
+        ['run-2' as WorkflowRunId, 'run-1' as WorkflowRunId],
         NOW,
-        'just the auth module',
       );
+      const run = (await listWorkflowsForSession(db, sessionId)).find(
+        (candidate) => candidate.id === ('run-1' as WorkflowRunId),
+      )!;
+      expect(run.spendLimitUsd).toBe(12.5);
+      expect(run.spendLimitMode).toBe('notify');
+    });
+  });
+
+  describe('per-run goal', () => {
+    it('round-trips the goal typed in the builder', async () => {
+      await attachWorkflowToSession({
+        db,
+        sessionId,
+        workflowRunId: 'run-1' as WorkflowRunId,
+        workflowId,
+        autoRun: false,
+        updatedAt: NOW,
+        goal: 'just the auth module',
+      });
       const runs = await listWorkflowsForSession(db, sessionId);
       expect(runs[0]!.goal).toBe('just the auth module');
     });
 
     it('omits the goal when none was typed', async () => {
-      await attachWorkflowToSession(
+      await attachWorkflowToSession({
         db,
         sessionId,
-        'run-1' as WorkflowRunId,
+        workflowRunId: 'run-1' as WorkflowRunId,
         workflowId,
-        false,
-        NOW,
-      );
+        autoRun: false,
+        updatedAt: NOW,
+      });
       const runs = await listWorkflowsForSession(db, sessionId);
       expect(runs[0]!.goal).toBeUndefined();
     });
 
     it('keeps the goal when runs are reordered', async () => {
-      await attachWorkflowToSession(
+      await attachWorkflowToSession({
         db,
         sessionId,
-        'run-1' as WorkflowRunId,
+        workflowRunId: 'run-1' as WorkflowRunId,
         workflowId,
-        false,
-        NOW,
-        'first goal',
-      );
-      await attachWorkflowToSession(
+        autoRun: false,
+        updatedAt: NOW,
+        goal: 'first goal',
+      });
+      await attachWorkflowToSession({
         db,
         sessionId,
-        'run-2' as WorkflowRunId,
-        workflowId2,
-        false,
-        NOW,
-        'second goal',
-      );
+        workflowRunId: 'run-2' as WorkflowRunId,
+        workflowId: workflowId2,
+        autoRun: false,
+        updatedAt: NOW,
+        goal: 'second goal',
+      });
       await updateWorkflowOrder(
         db,
         sessionId,
@@ -339,35 +477,31 @@ describe('session_workflows trigger-mode queries', () => {
 
   describe('updateWorkflowRunOrchestrationOutcome', () => {
     it('attaches with a null outcome by default', async () => {
-      await attachWorkflowToSession(
+      await attachWorkflowToSession({
         db,
         sessionId,
-        'run-1' as WorkflowRunId,
+        workflowRunId: 'run-1' as WorkflowRunId,
         workflowId,
-        true,
-        NOW,
-        undefined,
-        'immediate',
-        undefined,
-        'dynamic',
-      );
+        autoRun: true,
+        updatedAt: NOW,
+        triggerMode: 'immediate',
+        executionMode: 'dynamic',
+      });
       const runs = await listWorkflowsForSession(db, sessionId);
       expect(runs[0]!.orchestrationOutcome).toBeUndefined();
     });
 
     it('round-trips done and blocked outcomes', async () => {
-      await attachWorkflowToSession(
+      await attachWorkflowToSession({
         db,
         sessionId,
-        'run-1' as WorkflowRunId,
+        workflowRunId: 'run-1' as WorkflowRunId,
         workflowId,
-        true,
-        NOW,
-        undefined,
-        'immediate',
-        undefined,
-        'dynamic',
-      );
+        autoRun: true,
+        updatedAt: NOW,
+        triggerMode: 'immediate',
+        executionMode: 'dynamic',
+      });
       await updateWorkflowRunOrchestrationOutcome(db, 'run-1' as WorkflowRunId, 'done');
       expect((await listWorkflowsForSession(db, sessionId))[0]!.orchestrationOutcome).toBe('done');
       await updateWorkflowRunOrchestrationOutcome(db, 'run-1' as WorkflowRunId, 'blocked');
@@ -381,26 +515,24 @@ describe('session_workflows trigger-mode queries', () => {
     });
 
     it('keeps the outcome when runs are reordered', async () => {
-      await attachWorkflowToSession(
+      await attachWorkflowToSession({
         db,
         sessionId,
-        'run-1' as WorkflowRunId,
+        workflowRunId: 'run-1' as WorkflowRunId,
         workflowId,
-        true,
-        NOW,
-        undefined,
-        'immediate',
-        undefined,
-        'dynamic',
-      );
-      await attachWorkflowToSession(
+        autoRun: true,
+        updatedAt: NOW,
+        triggerMode: 'immediate',
+        executionMode: 'dynamic',
+      });
+      await attachWorkflowToSession({
         db,
         sessionId,
-        'run-2' as WorkflowRunId,
-        workflowId2,
-        true,
-        NOW,
-      );
+        workflowRunId: 'run-2' as WorkflowRunId,
+        workflowId: workflowId2,
+        autoRun: true,
+        updatedAt: NOW,
+      });
       await updateWorkflowRunOrchestrationOutcome(db, 'run-1' as WorkflowRunId, 'done');
       await updateWorkflowOrder(
         db,
@@ -416,18 +548,16 @@ describe('session_workflows trigger-mode queries', () => {
 
   describe('updateWorkflowRunOrchestrationStop', () => {
     const attachRun = async (runId: string) =>
-      attachWorkflowToSession(
+      attachWorkflowToSession({
         db,
         sessionId,
-        runId as WorkflowRunId,
+        workflowRunId: runId as WorkflowRunId,
         workflowId,
-        true,
-        NOW,
-        undefined,
-        'immediate',
-        undefined,
-        'dynamic',
-      );
+        autoRun: true,
+        updatedAt: NOW,
+        triggerMode: 'immediate',
+        executionMode: 'dynamic',
+      });
 
     it('round-trips why the run stopped, not only the sentence', async () => {
       await attachRun('run-1');
@@ -455,14 +585,14 @@ describe('session_workflows trigger-mode queries', () => {
 
     it('keeps the budget stop a budget stop when runs are reordered', async () => {
       await attachRun('run-1');
-      await attachWorkflowToSession(
+      await attachWorkflowToSession({
         db,
         sessionId,
-        'run-2' as WorkflowRunId,
-        workflowId2,
-        true,
-        NOW,
-      );
+        workflowRunId: 'run-2' as WorkflowRunId,
+        workflowId: workflowId2,
+        autoRun: true,
+        updatedAt: NOW,
+      });
       await updateWorkflowRunOrchestrationStop(db, 'run-1' as WorkflowRunId, {
         kind: 'budget',
         message: 'the budget cap is reached, raise it in Budget to keep this run going',
@@ -482,18 +612,16 @@ describe('session_workflows trigger-mode queries', () => {
 
   describe('orchestrator reason and routing', () => {
     const attachDynamic = async () =>
-      attachWorkflowToSession(
+      attachWorkflowToSession({
         db,
         sessionId,
-        'run-1' as WorkflowRunId,
+        workflowRunId: 'run-1' as WorkflowRunId,
         workflowId,
-        true,
-        NOW,
-        undefined,
-        'immediate',
-        undefined,
-        'dynamic',
-      );
+        autoRun: true,
+        updatedAt: NOW,
+        triggerMode: 'immediate',
+        executionMode: 'dynamic',
+      });
 
     it('keeps the reason the orchestrator gave for ending the run', async () => {
       await attachDynamic();
@@ -549,14 +677,14 @@ describe('session_workflows trigger-mode queries', () => {
 
     it('carries the reason and the routing through a reorder', async () => {
       await attachDynamic();
-      await attachWorkflowToSession(
+      await attachWorkflowToSession({
         db,
         sessionId,
-        'run-2' as WorkflowRunId,
-        workflowId2,
-        true,
-        NOW,
-      );
+        workflowRunId: 'run-2' as WorkflowRunId,
+        workflowId: workflowId2,
+        autoRun: true,
+        updatedAt: NOW,
+      });
       await updateWorkflowRunOrchestrationOutcome(db, 'run-1' as WorkflowRunId, 'done', 'all set');
       await updateWorkflowRunOrchestratorRouting(db, 'run-1' as WorkflowRunId, {
         providerId: 'codex',
@@ -578,7 +706,14 @@ describe('session_workflows trigger-mode queries', () => {
 
   describe('discardWorkflowInSession', () => {
     it('sets discarded_at and maps it through', async () => {
-      await attachWorkflowToSession(db, sessionId, 'run-1' as WorkflowRunId, workflowId, true, NOW);
+      await attachWorkflowToSession({
+        db,
+        sessionId,
+        workflowRunId: 'run-1' as WorkflowRunId,
+        workflowId,
+        autoRun: true,
+        updatedAt: NOW,
+      });
       await discardWorkflowInSession(db, sessionId, 'run-1' as WorkflowRunId, NOW);
       const runs = await listWorkflowsForSession(db, sessionId);
       expect(runs[0]!.discardedAt).toBe(NOW);
@@ -587,7 +722,14 @@ describe('session_workflows trigger-mode queries', () => {
 
   describe('restoreWorkflowInSession', () => {
     it('clears discarded_at again', async () => {
-      await attachWorkflowToSession(db, sessionId, 'run-1' as WorkflowRunId, workflowId, true, NOW);
+      await attachWorkflowToSession({
+        db,
+        sessionId,
+        workflowRunId: 'run-1' as WorkflowRunId,
+        workflowId,
+        autoRun: true,
+        updatedAt: NOW,
+      });
       await discardWorkflowInSession(db, sessionId, 'run-1' as WorkflowRunId, NOW);
       await restoreWorkflowInSession(db, sessionId, 'run-1' as WorkflowRunId, NOW);
       const runs = await listWorkflowsForSession(db, sessionId);
@@ -616,18 +758,16 @@ describe('session hydration carries the orchestrator state', () => {
   });
 
   it('reads the reason and the routing on the path the app boots from', async () => {
-    await attachWorkflowToSession(
+    await attachWorkflowToSession({
       db,
       sessionId,
-      'run-1' as WorkflowRunId,
+      workflowRunId: 'run-1' as WorkflowRunId,
       workflowId,
-      true,
-      NOW,
-      undefined,
-      'immediate',
-      undefined,
-      'dynamic',
-    );
+      autoRun: true,
+      updatedAt: NOW,
+      triggerMode: 'immediate',
+      executionMode: 'dynamic',
+    });
     await updateWorkflowRunOrchestrationOutcome(
       db,
       'run-1' as WorkflowRunId,

--- a/packages/db/src/queries/session-workflow.ts
+++ b/packages/db/src/queries/session-workflow.ts
@@ -11,6 +11,7 @@ import type {
   WorkflowOrchestrationStopKind,
   WorkflowRun,
   WorkflowRunId,
+  WorkflowSpendLimitMode,
   WorkflowTriggerMode,
 } from '@goodboy/types';
 import type { Database } from '../client';
@@ -32,6 +33,8 @@ export type SessionWorkflowRow = {
   orchestrator_provider: string | null;
   orchestrator_model: string | null;
   orchestrator_effort: string | null;
+  spend_limit_usd: number | null;
+  spend_limit_mode: string;
   chain_after_run_id: string | null;
   goal: string | null;
   discarded_at: string | null;
@@ -39,7 +42,7 @@ export type SessionWorkflowRow = {
 };
 
 export const SESSION_WORKFLOW_COLS =
-  'workflow_run_id, workflow_id, ordinal, current_step_ordinal, auto_run, trigger_mode, execution_mode, orchestration_outcome, orchestration_reason, orchestration_error, orchestration_stop_kind, orchestrator_hints, orchestrator_summary, orchestrator_provider, orchestrator_model, orchestrator_effort, chain_after_run_id, goal, discarded_at, created_at';
+  'workflow_run_id, workflow_id, ordinal, current_step_ordinal, auto_run, trigger_mode, execution_mode, orchestration_outcome, orchestration_reason, orchestration_error, orchestration_stop_kind, orchestrator_hints, orchestrator_summary, orchestrator_provider, orchestrator_model, orchestrator_effort, spend_limit_usd, spend_limit_mode, chain_after_run_id, goal, discarded_at, created_at';
 
 type RoutingColumns = {
   readonly provider: string | null;
@@ -117,6 +120,8 @@ export function toWorkflowRun(row: SessionWorkflowRow): WorkflowRun {
     ...(row.orchestrator_summary != null &&
       row.orchestrator_summary !== '' && { orchestratorSummary: row.orchestrator_summary }),
     ...(orchestratorRouting != null && { orchestratorRouting }),
+    ...(row.spend_limit_usd != null && { spendLimitUsd: row.spend_limit_usd }),
+    spendLimitMode: (row.spend_limit_mode ?? 'pause') as WorkflowSpendLimitMode,
     ...(row.chain_after_run_id != null && {
       chainAfterId: row.chain_after_run_id as WorkflowRunId,
     }),
@@ -148,18 +153,35 @@ async function bumpSessionUpdatedAt(
   ]);
 }
 
-export const attachWorkflowToSession = async (
-  db: Database,
-  sessionId: SessionId,
-  workflowRunId: WorkflowRunId,
-  workflowId: WorkflowId,
-  autoRun: boolean,
-  updatedAt: IsoDateTime,
-  goal?: string,
-  triggerMode: WorkflowTriggerMode = 'immediate',
-  chainAfterRunId?: WorkflowRunId,
-  executionMode: WorkflowExecutionMode = 'static',
-): Promise<void> => {
+type AttachWorkflowToSessionParams = {
+  readonly db: Database;
+  readonly sessionId: SessionId;
+  readonly workflowRunId: WorkflowRunId;
+  readonly workflowId: WorkflowId;
+  readonly autoRun: boolean;
+  readonly updatedAt: IsoDateTime;
+  readonly goal?: string;
+  readonly triggerMode?: WorkflowTriggerMode;
+  readonly chainAfterRunId?: WorkflowRunId;
+  readonly executionMode?: WorkflowExecutionMode;
+  readonly spendLimitUsd?: number;
+  readonly spendLimitMode?: WorkflowSpendLimitMode;
+};
+
+export const attachWorkflowToSession = async ({
+  db,
+  sessionId,
+  workflowRunId,
+  workflowId,
+  autoRun,
+  updatedAt,
+  goal,
+  triggerMode = 'immediate',
+  chainAfterRunId,
+  executionMode = 'static',
+  spendLimitUsd,
+  spendLimitMode = 'pause',
+}: AttachWorkflowToSessionParams): Promise<void> => {
   const maxOrdinal = await db.select<{ max_ordinal: number | null }>(
     'SELECT MAX(ordinal) as max_ordinal FROM session_workflows WHERE session_id = ?',
     [sessionId],
@@ -167,7 +189,7 @@ export const attachWorkflowToSession = async (
   const nextOrdinal = (maxOrdinal[0]?.max_ordinal ?? -1) + 1;
 
   await db.execute(
-    'INSERT INTO session_workflows (workflow_run_id, session_id, workflow_id, ordinal, current_step_ordinal, auto_run, goal, trigger_mode, chain_after_run_id, execution_mode) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+    'INSERT INTO session_workflows (workflow_run_id, session_id, workflow_id, ordinal, current_step_ordinal, auto_run, goal, trigger_mode, chain_after_run_id, execution_mode, spend_limit_usd, spend_limit_mode) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
     [
       workflowRunId,
       sessionId,
@@ -179,6 +201,8 @@ export const attachWorkflowToSession = async (
       triggerMode,
       chainAfterRunId ?? null,
       executionMode,
+      spendLimitUsd ?? null,
+      spendLimitMode,
     ],
   );
   await bumpSessionUpdatedAt(db, sessionId, updatedAt);
@@ -215,7 +239,7 @@ export const updateWorkflowOrder = async (
         continue;
       }
       await db.execute(
-        'INSERT INTO session_workflows (workflow_run_id, session_id, workflow_id, ordinal, current_step_ordinal, auto_run, goal, discarded_at, trigger_mode, chain_after_run_id, execution_mode, orchestration_outcome, orchestration_reason, orchestration_error, orchestration_stop_kind, orchestrator_hints, orchestrator_summary, orchestrator_provider, orchestrator_model, orchestrator_effort, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+        'INSERT INTO session_workflows (workflow_run_id, session_id, workflow_id, ordinal, current_step_ordinal, auto_run, goal, discarded_at, trigger_mode, chain_after_run_id, execution_mode, orchestration_outcome, orchestration_reason, orchestration_error, orchestration_stop_kind, orchestrator_hints, orchestrator_summary, orchestrator_provider, orchestrator_model, orchestrator_effort, spend_limit_usd, spend_limit_mode, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
         [
           runId,
           sessionId,
@@ -237,6 +261,8 @@ export const updateWorkflowOrder = async (
           prev.orchestrator_provider,
           prev.orchestrator_model,
           prev.orchestrator_effort,
+          prev.spend_limit_usd,
+          prev.spend_limit_mode,
           prev.created_at,
         ],
       );
@@ -358,6 +384,18 @@ export const updateWorkflowRunOrchestratorSummary = async (
   await db.execute(
     'UPDATE session_workflows SET orchestrator_summary = ? WHERE workflow_run_id = ?',
     [summary, workflowRunId],
+  );
+};
+
+export const updateWorkflowRunSpendLimit = async (
+  db: Database,
+  workflowRunId: WorkflowRunId,
+  spendLimitUsd: number | null,
+  mode: WorkflowSpendLimitMode,
+): Promise<void> => {
+  await db.execute(
+    'UPDATE session_workflows SET spend_limit_usd = ?, spend_limit_mode = ? WHERE workflow_run_id = ?',
+    [spendLimitUsd, mode, workflowRunId],
   );
 };
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -54,6 +54,7 @@ export type {
   WorkflowOrchestrationOutcome,
   WorkflowOrchestrationStop,
   WorkflowOrchestrationStopKind,
+  WorkflowSpendLimitMode,
   WorkflowTriggerMode,
   WorkspaceIntegration,
   WorkspaceIntegrationConfig,

--- a/packages/types/src/workspace.ts
+++ b/packages/types/src/workspace.ts
@@ -93,6 +93,8 @@ export type WorkflowOrchestrationStop = Readonly<{
   message: string;
 }>;
 
+export type WorkflowSpendLimitMode = 'notify' | 'pause';
+
 export type OrchestratorRouting = Readonly<{
   providerId: ProviderId;
   model: string;
@@ -113,6 +115,8 @@ export type WorkflowRun = Readonly<{
   orchestratorHints?: string;
   orchestratorSummary?: string;
   orchestratorRouting?: OrchestratorRouting;
+  spendLimitUsd?: number;
+  spendLimitMode?: WorkflowSpendLimitMode;
   chainAfterId?: WorkflowRunId;
   goal?: string;
   discardedAt?: IsoDateTime;


### PR DESCRIPTION
## Summary
- Replaces the hardcoded orchestrator step cap (`stepHardCap`) with a per-run, user-configurable $ spend limit (default infinite), set from a compact spend-limit popover with a notify/pause mode toggle. Wired into the run's meta row, the OrchestratorPanel, and the workflow creation form.
- Orchestrator prompt now self-caps step count by estimating from the goal/process instead of a fixed numeric ceiling; it consolidates remaining work as it approaches the spend limit.
- New DB migration m110 adds `spend_limit_usd` / `spend_limit_mode` to `session_workflows`.
- Bugfix: fixes the "Step X of Y" subtitle for dynamic workflow runs, which is meaningless since dynamic steps are spawned at runtime rather than predefined — now shows the spawned-step count.
- Bugfix: `orchestratorState.ts`'s budget stop was hardcoded to session-level copy with `showsMessage: false`; now uses neutral copy and always surfaces the stop message.

## Test plan
- [x] `pnpm typecheck` clean across all 5 packages
- [x] `pnpm test` — 5549/5549 tests passing
- [x] `pnpm knip` — no new unused exports/files introduced (diffed against main, only pre-existing warnings remain)
- [x] Verified `attachWorkflowToSession` DB call sites, migration round-trip (`updateWorkflowOrder`), and store wiring for stale references to the removed step-cap constants

🤖 Generated with [Claude Code](https://claude.com/claude-code)