### PR TITLE
docs(repo): make the published claims true

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@ task. By evening you've spent more time pasting the goal back into the
 next chat than actually building.
 
 Goodboy is a desktop app that holds the goal, the plan and the context once,
-then hands them to whichever agent you want to run next. Same brief, same
-memory, different model. Conversation, plans, decisions and PR state live in
+then hands them to whichever agent you want to run next. Same brief, different
+model: each agent keeps its own transcript and inherits the shared context, so
+nothing gets pasted twice and nothing gets crossed. Conversation, plans, decisions and PR state live in
 a local SQLite on your machine, scoped to Goodboy alone: a local reset clears
 that database without touching anything outside it. Your keys, your data,
 your bandwidth.
@@ -166,16 +167,19 @@ pnpm + Turborepo monorepo: `apps/desktop` plus `packages/{ui,core,db,types}`.
 
 Goodboy is a pure orchestration layer. We do not run servers. We do not have
 accounts. We do not store, log, or transmit your data anywhere except to the
-AI providers you choose.
+services you connected yourself.
 
 - No backend. Ever.
 - No telemetry. Not now, not later, not opt-in.
-- API keys stay on your machine, in your OS credential store.
+- API keys and tokens stay on your machine, in your OS credential store.
 - Conversations, prompts, and responses flow directly between you and the
   provider.
+- What you send to a connected integration reaches that integration: a
+  comment posted to GitHub is a comment on GitHub, and its token travels with
+  every request. Local storage does not mean nothing leaves.
 - Local persistence is SQLite (`~/.goodboy/data.db`): workspaces, sessions,
   agents, messages, context slots, plans, local usage records, skills,
-  settings. All yours, all local.
+  settings. All yours, all local, and cleared only when you ask.
 
 If Goodboy disappeared tomorrow, your data would be untouched, because it was
 never ours.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,8 +27,10 @@ Caveat: a token you paste for an integration (GitHub, GitLab, Jira,
 Bitbucket, Linear, Sentry) is stored locally but sent to that provider on
 every request. Local-only storage does not mean the token never travels.
 
-Application initialization deletes the local database contents and reruns the
-schema. It never deletes API keys from the OS credential store.
+Starting the app only runs pending migrations; it never clears anything. A
+local reset is an explicit action: it drops the database contents and replays
+the schema from scratch, and it touches nothing outside that file. It never
+deletes API keys from the OS credential store.
 
 ## Releases
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -8,6 +8,43 @@
 What the app does today, defined once. Every other document links here rather
 than restating a definition.
 
+## The object model
+
+Four nested things, and everything else hangs off them.
+
+- A **workspace** is the detail view of a project plus the integrations
+  specific to it. It aggregates every piece of work on that project, not just
+  the sessions you opened today. Workspaces have three kinds: a **repo** owns
+  one project directory and gives each session a git worktree, a **composite**
+  links repo workspaces so one session can span them, and a **simple**
+  workspace is a standalone non-developer folder whose sessions use plain
+  directories without git.
+- A **session** is a container for a goal: its own git worktree, branch,
+  budget and shared context. Its stage (attention / running / review /
+  building / done) is derived from what the session actually holds, never set
+  by hand. "Refactor authentication domain" is a session.
+- An **agent** is an independent chat thread inside a session. You spawn as
+  many as you want, switch between them by clicking, and rename them inline.
+  Each agent has its own provider, model, effort level, verbosity and kind.
+- A **task** is the thing you are actually doing, and it is what the product
+  is organized around. It has an origin (an issue, an alert, a review comment,
+  an idea), a goal, a budget, a state and a definition of done. A task is not
+  finished when the code compiles, it is finished when the issue closes, the
+  PR merges, the alert resolves.
+
+A session always has at least one agent, auto-spawned at creation. Spawning
+more needs no workflow. Attaching a workflow preset pre-spawns one agent per
+step, and those agents then live alongside any free agents you add.
+
+A repo workspace must already have usable git state before a session can
+create its worktree. **Goodboy never runs git init, never commits, never adds
+a remote on your behalf.**
+
+The order matters, and it is why the app looks the way it does: task first,
+then the integrations a task comes from and returns to, then the code as the
+artifact it produces, then chat as the last mile. Every surface follows that
+order. One that shows chat before it shows the task is built upside down.
+
 ## Integration surface
 
 The workspace is the aggregator of the project, so every integration surface

--- a/docs/traps.md
+++ b/docs/traps.md
@@ -9,49 +9,75 @@ Comments are forbidden repo-wide, so a deliberate dead end cannot explain
 itself where it sits. This file is where those explanations live. Everything
 below has been "fixed" at least once and had to be put back.
 
-## Deliberate dead ends in the code
+## Deliberate dead ends
 
-- `fetchIssueCandidates` has a dead `case 'bitbucket': return []` arm, and
-  `issueSources.ts` deliberately has no bitbucket entry. Bitbucket has no
-  issue tracking by design, so wiring either one ships a picker that lists
-  nothing forever.
-- `RemoteHostKind` deliberately has no `'bitbucket'`. Adding it breaks the
-  `never` check in `resolveSessionStudioOpenEvent` and `remoteHost.test.ts`.
-- The mobile companion's `fetchIssuesFor` and `resolveIssueForSession` are
-  exhaustive switches over `WorkspaceIntegrationProvider` with a `never`
-  checked default, and neither falls through to another provider:
-  `fetchIssuesFor` returns `[]` where there is no mobile fetch, and
-  `resolveIssueForSession` throws a named refusal. The gating lists
-  (`ALL_ISSUE_PROVIDERS`, `CREATE_SESSION_PROVIDERS`) are hand-enumerated
-  separately from those switches, so the compiler forces a switch arm for a
-  new provider while nothing forces a gating-list entry. A provider can
-  compile clean and stay silently absent from mobile issue queries and
-  session creation. Add it to both.
-- `pending_resolutions` is a transient push queue, not a durable verdict log.
-  Making it durable was investigated and rejected; the durable source is
-  message replay through `hydrateResolverOutcomes`.
-- `LENS_KINDS` is a hand-maintained set whose only consumer is
-  `readPersistedLens`. A missing entry breaks lens restore silently, with no
-  compile error.
+- `fetchIssueCandidates` returns `[]` for Bitbucket, and `issueSources.ts`
+  has no Bitbucket entry. Goodboy deliberately does not expose Bitbucket
+  issues, because Atlassian points issues at Jira. Adding the source entry
+  alone ships a picker that lists nothing forever; the mobile companion
+  refuses the same provider explicitly, in `commandExecutor.ts`.
+- `RemoteHostKind` deliberately has no `'bitbucket'`: a Bitbucket remote
+  classifies as `'other'`, and `remoteHost.test.ts` asserts exactly that.
+  Adding the member changes that classification and fails the test. It is
+  also not the union the pull-request surfaces switch on. That one is
+  `PullRequestProvider`, which already carries `'bitbucket'`, so Bitbucket
+  pull requests do not need a `RemoteHostKind` member to work.
+- `pending_resolutions` is a durable SQLite queue (migration `m052`), not the
+  canonical verdict history. Rows survive a restart and are deleted once
+  consumed, so do not read a row's absence as a verdict. The canonical source
+  is message replay through `hydrateResolverOutcomes`.
 - `LinkedPrChip` and `NewSessionView` read `[data-studio-overlay]` out of the
-  DOM. Do not tidy this without first centralizing fullscreen-studio state:
-  `sessionStudio` tracks three kinds and `StudioShell` backs seventeen
-  studios, and the sniff is what bridges them.
+  DOM to tell whether a fullscreen studio is open, which decides in-session
+  navigation in one and Escape handling in the other. The sniff exists
+  because that state is split between the `sessionStudio` union in the store
+  and the shell that renders every studio. Do not tidy it without
+  centralizing fullscreen-studio state first.
+
+## Hand-maintained lists the compiler does not check
+
+Each of these is a set or array enumerated by hand alongside an exhaustive
+type. Adding a member to the type forces the switch arms to be updated; it
+never forces the list. Omission compiles clean and fails silently at runtime.
+
+- `LENS_KINDS`, consumed in production only by `readPersistedLens`: a missing
+  entry breaks lens restore with no error. A test asserts the set matches
+  `LENS_LABEL`, so an omission is caught only once the label entry exists.
+- `ALL_ISSUE_PROVIDERS` and `CREATE_SESSION_PROVIDERS` gate the mobile
+  companion. Their `WorkspaceIntegrationProvider` switches (`fetchIssuesFor`,
+  `resolveIssueForSession`) are `never`-checked and will demand an arm for a
+  new provider, while the gating lists will not, leaving the provider absent
+  from mobile issue queries and session creation.
+- `PROVIDER_PRIORITY` ranks pull-request providers and also drives review
+  target resolution. A provider missing from it still compiles, then vanishes
+  from availability counts and fallback selection.
+- `VALID_SORTS` and `VALID_GROUPS` validate persisted session-list
+  preferences. A new sort or group key not listed here is read back as
+  invalid, silently replaced by the default and written over.
+- `SIMPLE_LENSES` marks the lenses that survive without a branch. A lens
+  omitted from it is hidden or cleared for branchless sessions.
+- `GITHUB_ONLY_KINDS` strips GitHub-only resolver actions from other hosts. A
+  new GitHub-only action kind left out of it is offered where it cannot work.
+- `MARKDOWN_SLOTS` decides which context slots render as markdown. A new
+  prose slot left out renders through the plain path.
 
 ## Traps in the toolchain
 
-- A new worktree needs `pnpm install`, and that install exits 1 at the
-  `prepare` step: lefthook refuses when `core.hooksPath` points at the shared
-  `.git/hooks`. It is harmless. Dependencies and native bindings install
-  before `prepare`, so check that `node_modules` and `better_sqlite3.node`
-  exist and carry on. Do not repoint `core.hooksPath`.
+- A new worktree needs `pnpm install`, and in this checkout that install
+  exits 1 at the `prepare` step: `prepare` runs `lefthook install`, which
+  refuses while `core.hooksPath` points at the shared `.git/hooks`. It is
+  harmless. Dependencies and native bindings install before `prepare`, so
+  check that `node_modules` and `better_sqlite3.node` exist and carry on. Do
+  not repoint `core.hooksPath`: the hooks resolve their tools through the
+  common git directory on purpose.
 - A worktree installed with `--ignore-scripts` has no `better-sqlite3`
-  bindings, so `@goodboy/db` tests error out and a green run covers only the
-  desktop package.
-- Turbo caches are shared across worktrees, so a `FULL TURBO` green can be a
-  sibling's replayed log rather than a run. When the green has to mean
-  something, `pnpm exec turbo run test --force` and a log line reading
-  `0 cached`.
-- Neither `ci.yml` nor `rust.yml` has a `workflow_dispatch` trigger. When a
-  run was never dispatched, closing and reopening the PR is the only way to
-  summon one.
+  binding, which `@goodboy/db` and `@goodboy/core` both need. The root test
+  script runs `turbo run test --continue`, so every other package still runs
+  and the tail of the output can look healthy while both of those suites
+  errored out. Read the summary, not the last lines.
+- Turbo replays cached task results, so a `FULL TURBO` green can be a replay
+  rather than a run. When the green has to mean something,
+  `pnpm exec turbo run test --force` and a log line reading `0 cached`.
+- Neither `ci.yml` nor `rust.yml` has a `workflow_dispatch` trigger, so there
+  is no "run workflow" button. Pushing another commit to the PR re-triggers
+  them, and a finished run can be re-run from the Actions UI; closing and
+  reopening the PR is the last resort, not the only route.

--- a/website/src/sections/Context.tsx
+++ b/website/src/sections/Context.tsx
@@ -104,7 +104,7 @@ export const Context = () => {
             </div>
           </div>
         </div>
-        <a className="more rv" style={delay(220)} href={SITE.repo}>
+        <a className="more rv" style={delay(220)} href={`${SITE.concepts}#the-object-model`}>
           Why the task comes first <span className="arr">→</span>
         </a>
       </div>


### PR DESCRIPTION
Five independent reviewers checked yesterday's documentation against the code it describes. They found real errors. This fixes them.

## docs/traps.md was not trustworthy

The file was assembled from private operations notes and I verified the symbols existed, not that the claims were true. Four were wrong:

- Adding `'bitbucket'` to `RemoteHostKind` does not break the cited `never` check. That check is over `PullRequestProvider`, which already carries `'bitbucket'`. What it does break is `remoteHost.test.ts`, which asserts a Bitbucket remote classifies as `'other'`.
- `pending_resolutions` is not transient. It is a SQLite table (migration `m052`) whose rows survive a restart. It is not the canonical verdict history, which is the real point.
- Turbo caches are not shared across worktrees: `turbo.json` configures no shared or remote cache. A `FULL TURBO` green can still be a replay, so the advice stands and the stated cause does not.
- Closing and reopening a PR is not the only way to retrigger a workflow. Pushing a commit does it, and a finished run can be re-run.

Two more were stale, and the exact counts in them have been dropped rather than corrected, because counts rot. The hand-maintained lists that compile clean and fail silently are now one section, with five more the reviewers found: `PROVIDER_PRIORITY`, `VALID_SORTS`, `VALID_GROUPS`, `SIMPLE_LENSES`, `GITHUB_ONLY_KINDS`, `MARKDOWN_SLOTS`.

## SECURITY.md claimed the app deletes your data on every start

It said application initialization deletes the local database contents. It does not. Boot calls `runDbMigrations`; the wipe lives in `wipeDb`, whose only caller is `wipeLocalDatabase`, an explicit user action.

## The privacy pledge was narrower than the product

It promised data goes nowhere except the AI providers you choose, while a comment posted to GitHub is a comment on GitHub and its token travels with every request. SECURITY.md already carried that caveat; the README now does too.

## concepts.md used words it never defined

It described sessions and workspaces without saying what they are, because those definitions had left with the split. They describe what ships, so they are back, together with the task-first ordering that explains why the app is shaped the way it is.

## Verification

Every corrected claim checked against the source, file and line. Links resolve, anchors resolve, `tsc --noEmit` green for the website. No application code changes.
