### PR TITLE
fix(desktop): surface git index.lock tool failures as visible errors

### DIFF
--- a/apps/desktop/src/store/slices/turn/classifyToolCallFailure.test.ts
+++ b/apps/desktop/src/store/slices/turn/classifyToolCallFailure.test.ts
@@ -36,6 +36,33 @@ describe('classifyToolCallFailure', () => {
     ).toEqual({ kind: 'other' });
   });
 
+  it('reads the lock only out of aggregated_output on a codex payload', () => {
+    expect(
+      classifyToolCallFailure({
+        output: {
+          aggregated_output: 'nothing to commit, working tree clean',
+          exit_code: 1,
+          command: [
+            'bash',
+            '-lc',
+            'rm -f .git/index.lock # Another git process seems to be running',
+          ],
+        },
+      }),
+    ).toEqual({ kind: 'other' });
+  });
+
+  it('unwraps a codex lock message that wraps across lines', () => {
+    expect(
+      classifyToolCallFailure({
+        output: {
+          aggregated_output: "fatal: Unable to create '/repo/.git/index.lock':\nFile exists.",
+          exit_code: 128,
+        },
+      }),
+    ).toEqual({ kind: 'git_index_lock' });
+  });
+
   it('handles a null output without throwing', () => {
     expect(classifyToolCallFailure({ output: null })).toEqual({ kind: 'other' });
   });

--- a/apps/desktop/src/store/slices/turn/classifyToolCallFailure.test.ts
+++ b/apps/desktop/src/store/slices/turn/classifyToolCallFailure.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { classifyToolCallFailure, toolCallFailureMessage } from './classifyToolCallFailure';
+
+const LOCK_MESSAGE =
+  "fatal: Unable to create '/repo/.git/index.lock': File exists.\n\n" +
+  'Another git process seems to be running in this repository, e.g.\n' +
+  "an editor opened by 'git commit'. Please make sure all processes\n" +
+  'are terminated then try again. If it still fails, a git process\n' +
+  'may have crashed in this repository earlier:\n' +
+  'remove the file manually to continue.';
+
+describe('classifyToolCallFailure', () => {
+  it('detects a git index.lock failure from a string output (anthropic, cursor, opencode)', () => {
+    expect(classifyToolCallFailure({ output: LOCK_MESSAGE })).toEqual({ kind: 'git_index_lock' });
+  });
+
+  it('detects a git index.lock failure from codex structured output', () => {
+    expect(
+      classifyToolCallFailure({
+        output: { aggregated_output: LOCK_MESSAGE, exit_code: 128 },
+      }),
+    ).toEqual({ kind: 'git_index_lock' });
+  });
+
+  it('ignores an unrelated string tool failure', () => {
+    expect(classifyToolCallFailure({ output: 'command not found: foo' })).toEqual({
+      kind: 'other',
+    });
+  });
+
+  it('ignores an unrelated codex structured failure', () => {
+    expect(
+      classifyToolCallFailure({
+        output: { aggregated_output: 'npm ERR! missing script: build', exit_code: 1 },
+      }),
+    ).toEqual({ kind: 'other' });
+  });
+
+  it('handles a null output without throwing', () => {
+    expect(classifyToolCallFailure({ output: null })).toEqual({ kind: 'other' });
+  });
+
+  it('builds an actionable message for the git index.lock case', () => {
+    expect(toolCallFailureMessage({ kind: 'git_index_lock' })).toBe(
+      'Git could not commit because another process is holding .git/index.lock. Close any other Git client, editor, or terminal running a commit in this repository, then retry.',
+    );
+  });
+
+  it('returns null for a non-lock classification', () => {
+    expect(toolCallFailureMessage({ kind: 'other' })).toBeNull();
+  });
+});

--- a/apps/desktop/src/store/slices/turn/classifyToolCallFailure.ts
+++ b/apps/desktop/src/store/slices/turn/classifyToolCallFailure.ts
@@ -1,0 +1,54 @@
+type ToolCallFailureClassification =
+  { readonly kind: 'git_index_lock' } | { readonly kind: 'other' };
+
+type Params = {
+  readonly output: unknown;
+};
+
+const GIT_INDEX_LOCK_PATTERNS: ReadonlyArray<RegExp> = [
+  /Another git process seems to be running/i,
+  /index\.lock['"]?:\s*File exists/i,
+];
+
+const hasAggregatedOutput = (value: unknown): value is { aggregated_output: string } => {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  if (!('aggregated_output' in value)) {
+    return false;
+  }
+  return typeof (value as Record<string, unknown>).aggregated_output === 'string';
+};
+
+const normalizeToolCallOutput = (output: unknown): string => {
+  if (typeof output === 'string') {
+    return output;
+  }
+  if (hasAggregatedOutput(output)) {
+    return output.aggregated_output;
+  }
+  return JSON.stringify(output);
+};
+
+export const classifyToolCallFailure = ({ output }: Params): ToolCallFailureClassification => {
+  const normalized = normalizeToolCallOutput(output);
+  if (GIT_INDEX_LOCK_PATTERNS.some((pattern) => pattern.test(normalized))) {
+    return { kind: 'git_index_lock' };
+  }
+  return { kind: 'other' };
+};
+
+export const toolCallFailureMessage = (
+  classification: ToolCallFailureClassification,
+): string | null => {
+  switch (classification.kind) {
+    case 'git_index_lock':
+      return 'Git could not commit because another process is holding .git/index.lock. Close any other Git client, editor, or terminal running a commit in this repository, then retry.';
+    case 'other':
+      return null;
+    default: {
+      const exhaustive: never = classification;
+      return exhaustive;
+    }
+  }
+};

--- a/apps/desktop/src/store/slices/turn/sendTurn.ts
+++ b/apps/desktop/src/store/slices/turn/sendTurn.ts
@@ -98,6 +98,7 @@ import { auditToolCall } from './auditToolCall';
 import { resolveErrorTurnMessage } from './resolveErrorTurnMessage';
 import { fallbackNoticeMessage } from './fallbackNoticeMessage';
 import { budgetRoutingNoticeMessage, budgetRoutingReason } from './budgetRoutingNoticeMessage';
+import { classifyToolCallFailure, toolCallFailureMessage } from './classifyToolCallFailure';
 import { cursorMaxModeMessage, matchCursorMaxModeFailure } from './matchCursorMaxModeFailure';
 import { recordUsageTelemetry } from './recordUsageTelemetry';
 import { resolveTurnModelSelection } from './resolveTurnModelSelection';
@@ -908,6 +909,20 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
         get().appendTurnEvent(activeAgentId, sessionId, event);
         if (event.kind === 'error') {
           receivedProviderError = true;
+        }
+        if (event.kind === 'tool_call_end' && event.isError === true) {
+          const toolCallFailure = classifyToolCallFailure({ output: event.output });
+          const toolCallFailureText = toolCallFailureMessage(toolCallFailure);
+          if (toolCallFailureText !== null) {
+            get().appendTurnEvent(activeAgentId, sessionId, {
+              kind: 'error',
+              runId,
+              message: toolCallFailureText,
+              retryable: true,
+              at: now(),
+            });
+            receivedProviderError = true;
+          }
         }
         if (event.kind === 'assistant_text') {
           assistantText += event.delta;

--- a/apps/desktop/src/store/store.turn-fallback.test.ts
+++ b/apps/desktop/src/store/store.turn-fallback.test.ts
@@ -302,4 +302,54 @@ describe('sendTurn, provider failure fallback', () => {
     expect(runTurnSpy).toHaveBeenCalledOnce();
     expect(useAppStore.getState().agentTurnState[AGENT_A]?.kind).toBe('error');
   });
+
+  const LOCK_OUTPUT =
+    "fatal: Unable to create '/tmp/wt/.git/index.lock': File exists.\n\n" +
+    'Another git process seems to be running in this repository.';
+
+  const streamToolCallEnd = ({ output }: { readonly output: unknown }) =>
+    async function* () {
+      yield {
+        kind: 'tool_call_end',
+        runId: 'run-lock-1',
+        toolUseId: 'tu-1',
+        output,
+        isError: true,
+        at: NOW,
+      };
+    };
+
+  it('surfaces a git index.lock tool failure as a retryable transcript error', async () => {
+    const useAppStore = await importStore();
+    setup(useAppStore);
+    runTurnSpy.mockImplementation(streamToolCallEnd({ output: LOCK_OUTPUT }));
+
+    await useAppStore
+      .getState()
+      .sendTurn({ sessionId: SESSION_ID, agentId: AGENT_A, content: 'commit it' });
+
+    const transcript = useAppStore.getState().transcripts[AGENT_A] ?? [];
+    const failure = transcript.find(
+      (event) => event.kind === 'error' && event.message.includes('.git/index.lock'),
+    );
+    expect(failure).toBeDefined();
+    expect(failure).toMatchObject({ retryable: true });
+  });
+
+  it('leaves an ordinary tool failure out of the transcript', async () => {
+    const useAppStore = await importStore();
+    setup(useAppStore);
+    runTurnSpy.mockImplementation(streamToolCallEnd({ output: 'command not found: foo' }));
+
+    await useAppStore
+      .getState()
+      .sendTurn({ sessionId: SESSION_ID, agentId: AGENT_A, content: 'run it' });
+
+    const transcript = useAppStore.getState().transcripts[AGENT_A] ?? [];
+    expect(
+      transcript.filter(
+        (event) => event.kind === 'error' && event.message.includes('.git/index.lock'),
+      ),
+    ).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
## What

A resolver's `git commit` failing because an IDE holds `.git/index.lock` reached the user only as text buried in the transcript. `sendTurn`'s `for await` loop parsed `tool_call_end` events but never inspected `isError`, so nothing promoted the failure to a visible turn error unless the provider process also exited non-zero with no assistant text at all (the existing synthesis at the end of the loop, gated on `assistantText.length === 0 && !receivedProviderError`).

## Why

`.git/index.lock` failures are silent and confusing: the commit tool call fails, the agent may keep going, and the user has no visible signal that anything went wrong or what to do about it.

## How

- `classifyToolCallFailure` (new, `apps/desktop/src/store/slices/turn/classifyToolCallFailure.ts`): a pure classifier following `classifyProviderError`'s shape (a `Params` type, a `RegExp` pattern array, an exhaustive switch over a discriminated union). It normalizes `tool_call_end`'s `output: unknown` before matching, because the three emitting parsers do not share one shape: `output` is a plain string for anthropic, cursor, and opencode, but a structured `{ aggregated_output, exit_code }` object for codex.
- `sendTurn.ts`'s `for await` loop gets its own conditional, independent of the existing `assistantText.length === 0` synthesis, firing on every `tool_call_end` event with `isError === true`. On a match it appends a visible `error` turn event (`retryable: true`, so the transcript's retry action re-sends the turn once the lock is gone) and marks `receivedProviderError` so the generic "provider exited without a response" message does not also fire.
- Detection reads data already flowing through the existing TypeScript event pipeline (`TurnEvent`'s `tool_call_end` variant, `packages/types/src/adapter.ts:67-74`). No new Tauri command, no new IPC surface, no new capability grant. `apps/desktop/src-tauri/capabilities/default.json` grants no `fs:` permission and none was added; `src-tauri/src/turn.rs` / `worktree.rs` are untouched.

## Provider coverage: 6 of 7

`tool_call_end` is emitted by exactly three parser modules: `providers/codex/parser.ts`, `providers/shared/anthropic-envelope-parser.ts` (shared by `providers/claude` and `providers/cursor`), and `providers/opencode/parser.ts`. `moonshot` and `openrouter` have no `parser.ts`/`adapter.ts` of their own; `packages/core/src/providers/opencode/adapter.ts` routes both through the opencode adapter/parser, so they inherit coverage rather than being separate gaps. Covered: anthropic, cursor, codex, opencode, openrouter, moonshot. Not covered: **gemini**, whose parser emits no `tool_call_end` at all.

## Match pattern and confidence

Proposed and used: `/Another git process seems to be running/i` (distinctive, low false-positive risk), with `/index\.lock['"]?:\s*File exists/i` as a second pattern covering the `fatal:` line on its own.

Confidence: **measured, not just general knowledge**. Reproduced locally in a throwaway repo (`git init`, then manually creating `.git/index.lock` before `git commit`) against the installed `git version 2.50.1 (Apple Git-155)`. Output matched exactly:

```
fatal: Unable to create '<path>/.git/index.lock': File exists.

Another git process seems to be running in this repository, e.g.
an editor opened by 'git commit'. Please make sure all processes
are terminated then try again. If it still fails, a git process
may have crashed in this repository earlier:
remove the file manually to continue.
```

## Test plan

- New `classifyToolCallFailure.test.ts`: synthetic `tool_call_end`-shaped fixtures per provider output shape (string for anthropic/cursor/opencode, `{ aggregated_output, exit_code }` object for codex), a positive and negative case for each, plus a null-output case and the message builder. No real lock, no real CLI, no real git process.
- `pnpm --filter @goodboy/desktop exec tsc --noEmit` clean.
- `pnpm exec turbo run test --filter=@goodboy/desktop --force`: 647 test files, 5535 tests, all green, `0 cached`.

Closes #1383


## Gate repair

The wave gate blocked on two pinning gaps in this PR:

1. `classifyToolCallFailure.test.ts` covered the codex `aggregated_output` unwrap only with fixtures where the fallback `JSON.stringify(output)` path also happened to match the lock regex, so deleting the unwrap branch left every test green. Added a case where the fallback matches the wrong field (a `command` string containing the trigger phrase, with the real signal buried in `aggregated_output` alone) and a case where the fallback's escaped newline breaks the `\s*`-sensitive second pattern. Both fail if the unwrap branch is removed.
2. `sendTurn.ts`'s `tool_call_end` handler that promotes a matched failure into a visible transcript error had no test driving it end to end. Added two cases to `store.turn-fallback.test.ts` that stream a `tool_call_end` event through `sendTurn` and assert the resulting transcript: a lock failure surfaces as a retryable error event, an ordinary failure does not. Verified both fail if the `isError` guard is inverted or if the classification result is computed but never appended to the transcript.

`pnpm exec turbo run test --force`: 647 test files, 5539 tests, all green, `0 cached`.
