### PR TITLE
Give the impact pull request cache a writer and a repository slug

### DIFF
--- a/apps/desktop/src/store/slices/github/index.test.ts
+++ b/apps/desktop/src/store/slices/github/index.test.ts
@@ -104,6 +104,7 @@ vi.mock('@goodboy/db', () => ({
   listAgentsForSessions: vi.fn(async () => new Map()),
   deleteWorktreesForSession: vi.fn(async () => undefined),
   updateSessionWorktreeBranch: vi.fn(async () => undefined),
+  updateSessionWorktreeRepoSlug: vi.fn(async () => undefined),
   listAllSessionWorktrees: vi.fn(async () => []),
   renameSession: vi.fn(async () => undefined),
   deleteSession: vi.fn(async () => undefined),
@@ -645,6 +646,52 @@ describe('store contract', () => {
       expect(store.getState().sessionGithub[SESSION_ID]?.pr?.number).toBe(canonicalPr.number);
       expect(store.getState().sessionSelectedPrNumber[SESSION_ID]).toBe(selectedPr.number);
       expect(listPrsForBranchSpy).toHaveBeenCalledOnce();
+    });
+
+    it('caches the canonical pull request under its repository slug', async () => {
+      const store = await getStore();
+      const db = await import('@goodboy/db');
+      const canonicalPr = {
+        number: 42,
+        title: 'Ship the impact panel',
+        url: 'https://github.com/acme/goodboy/pull/42',
+        state: 'open',
+        mergeable: true,
+        checks: 'success',
+        baseBranch: 'main',
+        headBranch: 'goodboy/topic',
+        isDraft: false,
+        reviewDecision: null,
+        body: 'a body nobody should cache',
+        updatedAt: '2026-07-30T10:00:00Z',
+      } as PullRequestState;
+      detectRepoSlugSpy.mockResolvedValueOnce('acme/goodboy');
+      listPrsForBranchSpy.mockResolvedValueOnce([canonicalPr]);
+      store.setState({
+        workspaces: [buildWorkspace()],
+        sessions: [buildSession()],
+        sessionBranches: { [SESSION_ID]: 'goodboy/topic' },
+        sessionWorktrees: { [SESSION_ID]: ['/tmp/repo/.wt/topic'] },
+      });
+
+      await store.getState().refreshSessionPr(SESSION_ID, { force: true });
+
+      expect(vi.mocked(db.updateSessionWorktreeRepoSlug)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionId: SESSION_ID,
+          worktreePath: '/tmp/repo/.wt/topic',
+          repoSlug: 'acme/goodboy',
+        }),
+      );
+      const entry = vi.mocked(db.upsertGithubPrCache).mock.calls[0]?.[1];
+      expect(entry).toMatchObject({ branch: 'goodboy/topic', repoSlug: 'acme/goodboy' });
+      expect(Object.keys(entry?.pr ?? {}).sort()).toEqual([
+        'number',
+        'state',
+        'title',
+        'updatedAt',
+        'url',
+      ]);
     });
 
     it('keeps the previous pr list and selection when listing fails', async () => {

--- a/apps/desktop/src/store/slices/github/refreshSessionPr.ts
+++ b/apps/desktop/src/store/slices/github/refreshSessionPr.ts
@@ -1,7 +1,14 @@
-import { detectRepoSlug, fetchLinkedIssues, listPrsForBranch } from '@goodboy/core';
+import {
+  detectRepoSlug,
+  fetchLinkedIssues,
+  listPrsForBranch,
+  toCachedPullRequest,
+} from '@goodboy/core';
+import { updateSessionWorktreeRepoSlug, upsertGithubPrCache } from '@goodboy/db';
 import { formatError } from '@goodboy/ui';
-import type { IsoDateTime, SessionId } from '@goodboy/types';
+import type { IsoDateTime, PullRequestState, SessionId } from '@goodboy/types';
 import { tauriGhRunner } from '../../../features/github/github';
+import { tauriDatabase } from '../../../shared/lib/db';
 import { resolveSessionPrFetch } from './resolveSessionPrFetch';
 import type { GetFn, SetFn } from './types';
 
@@ -9,6 +16,39 @@ type Params = {
   force?: boolean;
   silent?: boolean;
   retries?: number;
+};
+
+type PersistParams = {
+  readonly sessionId: SessionId;
+  readonly repoSlug: string;
+  readonly branch: string;
+  readonly worktreePath: string;
+  readonly pr: PullRequestState | null;
+};
+
+const persistSessionPrCache = async ({
+  sessionId,
+  repoSlug,
+  branch,
+  worktreePath,
+  pr,
+}: PersistParams): Promise<void> => {
+  try {
+    await updateSessionWorktreeRepoSlug({
+      db: tauriDatabase,
+      sessionId,
+      worktreePath,
+      repoSlug,
+    });
+    await upsertGithubPrCache(tauriDatabase, {
+      branch,
+      repoSlug,
+      pr: toCachedPullRequest({ pr }),
+      fetchedAt: new Date().toISOString(),
+    });
+  } catch {
+    return;
+  }
 };
 
 export const refreshSessionPr = (set: SetFn, get: GetFn) => {
@@ -24,6 +64,7 @@ export const refreshSessionPr = (set: SetFn, get: GetFn) => {
     const repo = target.repo;
     const repoRoot = repo.repoRoot;
     const repoBranch = repo.branch;
+    const repoWorktreePath = repo.worktreePath;
     const memberWorkspaceId = repo.workspaceId;
     set((state) => ({
       sessionGithub: {
@@ -134,6 +175,13 @@ export const refreshSessionPr = (set: SetFn, get: GetFn) => {
               },
             },
           };
+        });
+        await persistSessionPrCache({
+          sessionId,
+          repoSlug: slug,
+          branch: repoBranch,
+          worktreePath: repoWorktreePath,
+          pr: canonicalPr,
         });
         return;
       } catch (err) {

--- a/apps/desktop/src/store/slices/sessions/createSession.ts
+++ b/apps/desktop/src/store/slices/sessions/createSession.ts
@@ -21,11 +21,14 @@ import {
   insertSession,
   insertSessionWorktree,
   listWorkspaces,
+  updateSessionWorktreeRepoSlug,
   upsertSessionExternalTask,
   setSetting as dbSetSetting,
   upsertContextSlot,
 } from '@goodboy/db';
+import { detectRepoSlug } from '@goodboy/core';
 import { tauriDatabase } from '../../../shared/lib/db';
+import { tauriGhRunner } from '../../../features/github/github';
 import {
   createSessionDir,
   createWorktree,
@@ -43,6 +46,46 @@ import { clampTitle } from './titleLimit';
 import { preSpawnWorkflowAgents } from '../workflows/preSpawnWorkflowAgents';
 import { deriveDefaultSessionDirectoryNameFromGoal } from '../../../shared/utils/deriveDefaultSessionDirectoryNameFromGoal';
 import type { GetFn, SetFn } from './types';
+
+type RepoSlugTarget = {
+  readonly repoRoot: string;
+  readonly worktreePath: string;
+  readonly memberWorkspaceId?: WorkspaceId;
+};
+
+type PopulateRepoSlugsParams = {
+  readonly sessionId: SessionId;
+  readonly workspaceId: WorkspaceId;
+  readonly targets: ReadonlyArray<RepoSlugTarget>;
+};
+
+const populateWorktreeRepoSlugs = async ({
+  sessionId,
+  workspaceId,
+  targets,
+}: PopulateRepoSlugsParams): Promise<void> => {
+  for (const target of targets) {
+    try {
+      const slug = await detectRepoSlug(
+        tauriGhRunner,
+        target.repoRoot,
+        workspaceId,
+        target.memberWorkspaceId,
+      );
+      if (slug == null) {
+        continue;
+      }
+      await updateSessionWorktreeRepoSlug({
+        db: tauriDatabase,
+        sessionId,
+        worktreePath: target.worktreePath,
+        repoSlug: slug,
+      });
+    } catch {
+      continue;
+    }
+  }
+};
 
 const slugifyDir = (raw: string): string =>
   raw
@@ -260,6 +303,16 @@ export const createSession = (set: SetFn, get: GetFn) => {
         createdAt: Date.now(),
       });
     }
+    const repoSlugTargets: ReadonlyArray<RepoSlugTarget> = isComposite
+      ? memberWorktrees.map(({ member, worktree: wt }) => ({
+          repoRoot: member.rootPath,
+          worktreePath: wt.worktreePath,
+          memberWorkspaceId: member.workspaceId,
+        }))
+      : isSimple
+        ? []
+        : [{ repoRoot: workspace.rootPath, worktreePath: worktree.worktreePath }];
+    void populateWorktreeRepoSlugs({ sessionId, workspaceId, targets: repoSlugTargets });
 
     const goalText = goal.trim() || worktree.slug;
     if (goalText.length > 0) {

--- a/apps/desktop/src/store/slices/sessions/index.test.ts
+++ b/apps/desktop/src/store/slices/sessions/index.test.ts
@@ -105,6 +105,7 @@ vi.mock('@goodboy/db', () => ({
   listAgentsForSessions: vi.fn(async () => new Map()),
   deleteWorktreesForSession: vi.fn(async () => undefined),
   updateSessionWorktreeBranch: vi.fn(async () => undefined),
+  updateSessionWorktreeRepoSlug: vi.fn(async () => undefined),
   listAllSessionWorktrees: vi.fn(async () => []),
   renameSession: vi.fn(async () => undefined),
   deleteSession: vi.fn(async () => undefined),

--- a/apps/desktop/src/store/slices/sessions/index.test.ts
+++ b/apps/desktop/src/store/slices/sessions/index.test.ts
@@ -1090,6 +1090,58 @@ describe('store contract', () => {
     });
   });
 
+  describe('createSession repository slug', () => {
+    it('stamps the detected slug on the new worktree row', async () => {
+      const store = await getStore();
+      const db = await import('@goodboy/db');
+      const core = await import('@goodboy/core');
+      vi.mocked(db.listWorkspaces).mockResolvedValueOnce([buildWorkspace()]);
+      createWorktreeSpy.mockResolvedValueOnce({
+        worktreePath: '/tmp/repo/wt-slug',
+        branchName: 'ak/slug',
+        slug: 'slug',
+        reused: false,
+      });
+      vi.mocked(core.detectRepoSlug).mockResolvedValueOnce('acme/goodboy');
+      store.setState({ currentWorkspaceId: WS_ID });
+
+      const { session } = await store
+        .getState()
+        .createSession({ workspaceId: WS_ID, goal: 'Slug it' });
+
+      await vi.waitFor(() => {
+        expect(vi.mocked(db.updateSessionWorktreeRepoSlug)).toHaveBeenCalledWith({
+          db: expect.anything(),
+          sessionId: session.id,
+          worktreePath: '/tmp/repo/wt-slug',
+          repoSlug: 'acme/goodboy',
+        });
+      });
+    });
+
+    it('creates the session anyway when the slug cannot be detected', async () => {
+      const store = await getStore();
+      const db = await import('@goodboy/db');
+      const core = await import('@goodboy/core');
+      vi.mocked(db.listWorkspaces).mockResolvedValueOnce([buildWorkspace()]);
+      createWorktreeSpy.mockResolvedValueOnce({
+        worktreePath: '/tmp/repo/wt-offline',
+        branchName: 'ak/offline',
+        slug: 'offline',
+        reused: false,
+      });
+      vi.mocked(core.detectRepoSlug).mockResolvedValueOnce(null);
+      store.setState({ currentWorkspaceId: WS_ID });
+
+      const { session } = await store
+        .getState()
+        .createSession({ workspaceId: WS_ID, goal: 'Offline' });
+
+      expect(session.id).toBeDefined();
+      expect(vi.mocked(db.updateSessionWorktreeRepoSlug)).not.toHaveBeenCalled();
+    });
+  });
+
   describe('createSession external task', () => {
     const GITLAB_TASK = {
       provider: 'gitlab' as const,

--- a/packages/core/src/github/__tests__/cache.test.ts
+++ b/packages/core/src/github/__tests__/cache.test.ts
@@ -8,6 +8,7 @@ import {
   type PrCacheStore,
   getPrForBranch,
   invalidatePrCache,
+  toCachedPullRequest,
 } from '../cache';
 
 const SAMPLE_PR: PullRequestState = {
@@ -177,6 +178,48 @@ describe('getPrForBranch', () => {
     const result = await getPrForBranch(deps, BASE_INPUT);
     expect(result).toBeNull();
     expect(runner.run).not.toHaveBeenCalled();
+  });
+});
+
+describe('cached pull request payload', () => {
+  it('stores only the five fields the impact panel reads', async () => {
+    const store = makeStore(null);
+    const runner = makeRunner(SAMPLE_PR);
+    const deps: PrCacheDeps = { runner, store, now: () => NOW };
+
+    await getPrForBranch(deps, BASE_INPUT);
+
+    const stored = store.rows.get('org/repo/feature');
+    expect(Object.keys(stored?.pr ?? {}).sort()).toEqual([
+      'number',
+      'state',
+      'title',
+      'updatedAt',
+      'url',
+    ]);
+  });
+
+  it('never writes the token supplied to the fetch into the cached row', async () => {
+    const store = makeStore(null);
+    const runner = makeRunner(SAMPLE_PR);
+    const deps: PrCacheDeps = { runner, store, now: () => NOW };
+    const token = 'token-placeholder-for-this-test';
+
+    await getPrForBranch(deps, { ...BASE_INPUT, token });
+
+    const stored = store.rows.get('org/repo/feature');
+    expect(JSON.stringify(stored)).not.toContain(token);
+  });
+
+  it('trims a full pull request and passes a missing one through', () => {
+    expect(toCachedPullRequest({ pr: SAMPLE_PR })).toEqual({
+      number: SAMPLE_PR.number,
+      title: SAMPLE_PR.title,
+      url: SAMPLE_PR.url,
+      state: SAMPLE_PR.state,
+      updatedAt: SAMPLE_PR.updatedAt,
+    });
+    expect(toCachedPullRequest({ pr: null })).toBeNull();
   });
 });
 

--- a/packages/core/src/github/cache.ts
+++ b/packages/core/src/github/cache.ts
@@ -1,4 +1,4 @@
-import type { GithubPrCacheEntry, PullRequestState } from '@goodboy/types';
+import type { CachedPullRequest, GithubPrCacheEntry, PullRequestState } from '@goodboy/types';
 import type { GhRunner } from './gh';
 import { resolvePrForBranch } from './resolver';
 
@@ -17,6 +17,25 @@ export type PrCacheDeps = {
 
 export const DEFAULT_PR_CACHE_TTL_MS = 60_000;
 
+type ToCachedPullRequestParams = {
+  readonly pr: PullRequestState | null;
+};
+
+export const toCachedPullRequest = ({
+  pr,
+}: ToCachedPullRequestParams): CachedPullRequest | null => {
+  if (pr === null) {
+    return null;
+  }
+  return {
+    number: pr.number,
+    title: pr.title,
+    url: pr.url,
+    state: pr.state,
+    updatedAt: pr.updatedAt,
+  };
+};
+
 export type GetPrInput = {
   repoSlug: string;
   branch: string;
@@ -29,7 +48,7 @@ export type GetPrInput = {
 export const getPrForBranch = async (
   deps: PrCacheDeps,
   input: GetPrInput,
-): Promise<PullRequestState | null> => {
+): Promise<CachedPullRequest | null> => {
   const ttl = deps.ttlMs ?? DEFAULT_PR_CACHE_TTL_MS;
   const now = deps.now ? deps.now() : new Date();
   const cached = await deps.store.get(input.repoSlug, input.branch);
@@ -44,13 +63,14 @@ export const getPrForBranch = async (
     token: input.token,
     workspaceId: input.workspaceId,
   });
+  const trimmed = toCachedPullRequest({ pr: fresh });
   await deps.store.upsert({
     repoSlug: input.repoSlug,
     branch: input.branch,
-    pr: fresh,
+    pr: trimmed,
     fetchedAt: now.toISOString(),
   });
-  return fresh;
+  return trimmed;
 };
 
 export const invalidatePrCache = async (

--- a/packages/core/src/github/index.ts
+++ b/packages/core/src/github/index.ts
@@ -52,6 +52,7 @@ export {
   DEFAULT_PR_CACHE_TTL_MS,
   getPrForBranch,
   invalidatePrCache,
+  toCachedPullRequest,
   type GetPrInput,
   type PrCacheDeps,
   type PrCacheStore,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -323,6 +323,7 @@ export {
   resolvePrForBranch,
   resolveReviewThread,
   runJson as ghRunJson,
+  toCachedPullRequest,
   updateIssueBody,
   type GetPrInput,
   type GhDetectResult,

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -157,6 +157,7 @@ export {
   deleteWorktreesForSession,
   updateSessionWorktreeBranch,
   updateSessionWorktreePath,
+  updateSessionWorktreeRepoSlug,
   listAllSessionWorktrees,
   type SessionWorktree,
 } from './queries/session-worktree';

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -108,6 +108,7 @@ import { m107IntegrationBitbucketProvider } from './m107-integration-bitbucket-p
 import { m108IntegrationSlackProvider } from './m108-integration-slack-provider';
 import { m109WorkflowRunSummary } from './m109-workflow-run-summary';
 import { m110WorkflowRunSpendLimit } from './m110-workflow-run-spend-limit';
+import { m111SessionWorktreeRepoSlug } from './m111-session-worktree-repo-slug';
 
 export type Migration = {
   readonly version: number;
@@ -225,4 +226,5 @@ export const migrations: ReadonlyArray<Migration> = [
   { version: 108, sql: m108IntegrationSlackProvider },
   { version: 109, sql: m109WorkflowRunSummary },
   { version: 110, sql: m110WorkflowRunSpendLimit },
+  { version: 111, sql: m111SessionWorktreeRepoSlug },
 ];

--- a/packages/db/src/migrations/m111-session-worktree-repo-slug.test.ts
+++ b/packages/db/src/migrations/m111-session-worktree-repo-slug.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import type { Database } from '../client';
+import { makeTestDatabase } from '../test-helpers/test-db';
+import { migrate } from './runner';
+import { migrations } from './index';
+
+const workspaceId = 'ws-1';
+const sessionId = 's-1';
+
+const seedThrough110 = async (): Promise<Database> => {
+  const db = makeTestDatabase();
+  await migrate(
+    db,
+    migrations.filter((migration) => migration.version <= 110),
+  );
+  const now = Date.now();
+  await db.execute(
+    'INSERT INTO workspaces (id, name, root_path, created_at, updated_at) VALUES (?, ?, ?, ?, ?)',
+    [workspaceId, 'ws', '/tmp/ws', now, now],
+  );
+  await db.execute(
+    'INSERT INTO sessions (id, workspace_id, goal, state_kind, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)',
+    [sessionId, workspaceId, 'goal', 'idle', now, now],
+  );
+  return db;
+};
+
+type WorktreeParams = {
+  readonly db: Database;
+  readonly id: string;
+  readonly branch: string;
+  readonly parallelIndex: number;
+};
+
+const insertWorktree = async ({ db, id, branch, parallelIndex }: WorktreeParams): Promise<void> => {
+  await db.execute(
+    `INSERT INTO session_worktrees
+       (id, session_id, worktree_path, branch, parallel_index, created_at)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+    [id, sessionId, `/tmp/${id}`, branch, parallelIndex, Date.now()],
+  );
+};
+
+type SlugRow = {
+  readonly id: string;
+  readonly repo_slug: string | null;
+};
+
+type DbParams = {
+  readonly db: Database;
+};
+
+const slugRows = async ({ db }: DbParams): Promise<ReadonlyArray<SlugRow>> =>
+  db.select<SlugRow>('SELECT id, repo_slug FROM session_worktrees ORDER BY id');
+
+describe('m111 session worktree repo slug', () => {
+  it('leaves an existing worktree row without a slug and backfills nothing', async () => {
+    const db = await seedThrough110();
+    await insertWorktree({ db, id: 'wt-old', branch: 'ak/feature', parallelIndex: 0 });
+
+    await migrate(db, migrations);
+
+    expect(await slugRows({ db })).toEqual([{ id: 'wt-old', repo_slug: null }]);
+  });
+
+  it('stores a slug written after the migration', async () => {
+    const db = await seedThrough110();
+
+    await migrate(db, migrations);
+    await insertWorktree({ db, id: 'wt-new', branch: 'ak/feature', parallelIndex: 0 });
+    await db.execute('UPDATE session_worktrees SET repo_slug = ? WHERE id = ?', [
+      'org/repo',
+      'wt-new',
+    ]);
+
+    expect(await slugRows({ db })).toEqual([{ id: 'wt-new', repo_slug: 'org/repo' }]);
+  });
+
+  it('adds the join index and keeps the existing indexes and foreign keys', async () => {
+    const db = await seedThrough110();
+    await insertWorktree({ db, id: 'wt-old', branch: 'ak/feature', parallelIndex: 0 });
+
+    await migrate(db, migrations);
+
+    const indexes = await db.select<{ name: string }>(
+      "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'session_worktrees' AND sql IS NOT NULL ORDER BY name",
+    );
+    expect(indexes.map((index) => index.name)).toEqual([
+      'idx_session_worktrees_path',
+      'idx_session_worktrees_repo_slug_branch',
+      'idx_session_worktrees_session_id',
+    ]);
+    expect(await db.select<{ rowid: number }>('PRAGMA foreign_key_check')).toEqual([]);
+  });
+});

--- a/packages/db/src/migrations/m111-session-worktree-repo-slug.ts
+++ b/packages/db/src/migrations/m111-session-worktree-repo-slug.ts
@@ -1,0 +1,6 @@
+export const m111SessionWorktreeRepoSlug = /* sql */ `
+ALTER TABLE session_worktrees ADD COLUMN repo_slug TEXT;
+
+CREATE INDEX idx_session_worktrees_repo_slug_branch
+  ON session_worktrees(repo_slug, branch);
+`;

--- a/packages/db/src/queries/github-pr-cache.ts
+++ b/packages/db/src/queries/github-pr-cache.ts
@@ -1,4 +1,4 @@
-import type { GithubPrCacheEntry, PullRequestState } from '@goodboy/types';
+import type { CachedPullRequest, GithubPrCacheEntry } from '@goodboy/types';
 import type { Database } from '../client';
 
 type Row = {
@@ -12,7 +12,10 @@ function toDomain(row: Row): GithubPrCacheEntry {
   return {
     branch: row.branch,
     repoSlug: row.repo_slug,
-    pr: row.pr_json ? (JSON.parse(row.pr_json) as PullRequestState) : null,
+    pr:
+      row.pr_json != null && row.pr_json.length > 0
+        ? (JSON.parse(row.pr_json) as CachedPullRequest)
+        : null,
     fetchedAt: row.fetched_at,
   };
 }

--- a/packages/db/src/queries/impact.test.ts
+++ b/packages/db/src/queries/impact.test.ts
@@ -248,9 +248,9 @@ describe('pull request outcomes', () => {
     });
     await db.execute(
       `INSERT INTO session_worktrees
-         (id, session_id, worktree_path, branch, parallel_index, created_at)
-       VALUES ('wt1', 's1', '/tmp/a', 'feature/a', 0, ?),
-              ('wt2', 's2', '/tmp/b', 'feature/b', 0, ?)`,
+         (id, session_id, worktree_path, branch, parallel_index, repo_slug, created_at)
+       VALUES ('wt1', 's1', '/tmp/a', 'feature/a', 0, 'repo', ?),
+              ('wt2', 's2', '/tmp/b', 'feature/b', 0, 'repo', ?)`,
       [RECENT, RECENT],
     );
     await db.execute(
@@ -287,9 +287,9 @@ describe('pull request outcomes', () => {
     await addSession({ db, seed: { id: 'composite', createdAt: RECENT } });
     await db.execute(
       `INSERT INTO session_worktrees
-         (id, session_id, worktree_path, branch, parallel_index, created_at)
-       VALUES ('wt-a', 'composite', '/tmp/repo-a', 'shared/branch', 0, ?),
-              ('wt-b', 'composite', '/tmp/repo-b', 'shared/branch', 1, ?)`,
+         (id, session_id, worktree_path, branch, parallel_index, repo_slug, created_at)
+       VALUES ('wt-a', 'composite', '/tmp/repo-a', 'shared/branch', 0, 'repo', ?),
+              ('wt-b', 'composite', '/tmp/repo-b', 'shared/branch', 1, 'repo', ?)`,
       [RECENT, RECENT],
     );
     await db.execute(
@@ -327,8 +327,8 @@ describe('pull request outcomes', () => {
     await addSession({ db, seed: { id: 'unpriced', createdAt: RECENT } });
     await db.execute(
       `INSERT INTO session_worktrees
-         (id, session_id, worktree_path, branch, parallel_index, created_at)
-       VALUES ('wt-unpriced', 'unpriced', '/tmp/unpriced', 'feature/unpriced', 0, ?)`,
+         (id, session_id, worktree_path, branch, parallel_index, repo_slug, created_at)
+       VALUES ('wt-unpriced', 'unpriced', '/tmp/unpriced', 'feature/unpriced', 0, 'repo', ?)`,
       [RECENT],
     );
     await db.execute(
@@ -360,9 +360,9 @@ describe('pull request outcomes', () => {
     });
     await db.execute(
       `INSERT INTO session_worktrees
-         (id, session_id, worktree_path, branch, parallel_index, created_at)
-       VALUES ('wt-mine', 'mine', '/tmp/mine', 'ak/shared-slug', 0, ?),
-              ('wt-theirs', 'theirs', '/tmp/theirs', 'ak/shared-slug', 0, ?)`,
+         (id, session_id, worktree_path, branch, parallel_index, repo_slug, created_at)
+       VALUES ('wt-mine', 'mine', '/tmp/mine', 'ak/shared-slug', 0, 'repo', ?),
+              ('wt-theirs', 'theirs', '/tmp/theirs', 'ak/shared-slug', 0, 'repo', ?)`,
       [RECENT, RECENT],
     );
     await db.execute(
@@ -398,8 +398,8 @@ describe('pull request outcomes', () => {
     await addSession({ db, seed: { id: 'freebie', createdAt: RECENT } });
     await db.execute(
       `INSERT INTO session_worktrees
-         (id, session_id, worktree_path, branch, parallel_index, created_at)
-       VALUES ('wt-freebie', 'freebie', '/tmp/freebie', 'ak/freebie', 0, ?)`,
+         (id, session_id, worktree_path, branch, parallel_index, repo_slug, created_at)
+       VALUES ('wt-freebie', 'freebie', '/tmp/freebie', 'ak/freebie', 0, 'repo', ?)`,
       [RECENT],
     );
     await db.execute(
@@ -431,6 +431,135 @@ describe('pull request outcomes', () => {
     const result = await getPullRequestOutcomes(params({ db, sinceMs: SINCE }));
 
     expect(result.entries[0]).toMatchObject({ number: 51, spendUsd: null });
+  });
+
+  it('leaves out a worktree that has no repository slug yet', async () => {
+    const db = await seedDb();
+    await addSession({ db, seed: { id: 'unslugged', createdAt: RECENT } });
+    await db.execute(
+      `INSERT INTO session_worktrees
+         (id, session_id, worktree_path, branch, parallel_index, created_at)
+       VALUES ('wt-unslugged', 'unslugged', '/tmp/unslugged', 'ak/pre-upgrade', 0, ?)`,
+      [RECENT],
+    );
+    await db.execute(
+      `INSERT INTO github_pr_cache (branch, repo_slug, pr_json, fetched_at)
+       VALUES (?, 'org/repo', ?, ?)`,
+      [
+        'ak/pre-upgrade',
+        JSON.stringify({
+          number: 60,
+          title: 'pre-upgrade worktree',
+          state: 'open',
+          updatedAt: iso(RECENT),
+        }),
+        iso(RECENT),
+      ],
+    );
+
+    const result = await getPullRequestOutcomes(params({ db, sinceMs: SINCE }));
+
+    expect(result.entries).toEqual([]);
+    expect(result).toMatchObject({ open: 0, merged: 0, closed: 0 });
+  });
+
+  it('keeps two repositories that share a branch name apart', async () => {
+    const db = await seedDb();
+    await addSession({ db, seed: { id: 'api', createdAt: RECENT } });
+    await addSession({ db, seed: { id: 'web', createdAt: RECENT } });
+    await db.execute(
+      `INSERT INTO session_worktrees
+         (id, session_id, worktree_path, branch, parallel_index, repo_slug, created_at)
+       VALUES ('wt-api', 'api', '/tmp/api', 'ak/same-branch', 0, 'org/api', ?),
+              ('wt-web', 'web', '/tmp/web', 'ak/same-branch', 0, 'org/web', ?)`,
+      [RECENT, RECENT],
+    );
+    await db.execute(
+      `INSERT INTO github_pr_cache (branch, repo_slug, pr_json, fetched_at)
+       VALUES (?, 'org/api', ?, ?)`,
+      [
+        'ak/same-branch',
+        JSON.stringify({
+          number: 70,
+          title: 'api pull request',
+          state: 'open',
+          updatedAt: iso(RECENT),
+        }),
+        iso(RECENT),
+      ],
+    );
+    await addTelemetry({
+      db,
+      seed: { id: 't-api', runId: 'r-api', sessionId: 'api', at: RECENT, cost: 3 },
+    });
+    await addTelemetry({
+      db,
+      seed: { id: 't-web', runId: 'r-web', sessionId: 'web', at: RECENT, cost: 11 },
+    });
+
+    const result = await getPullRequestOutcomes(params({ db, sinceMs: SINCE }));
+
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0]).toMatchObject({ number: 70, sessionId: 'api', spendUsd: 3 });
+  });
+
+  it('leaves out a cache row fetched longer ago than the read bound', async () => {
+    const db = await seedDb();
+    const staleFetch = Date.now() - 400 * DAY_MS;
+    await addSession({ db, seed: { id: 'stale', createdAt: RECENT } });
+    await db.execute(
+      `INSERT INTO session_worktrees
+         (id, session_id, worktree_path, branch, parallel_index, repo_slug, created_at)
+       VALUES ('wt-stale', 'stale', '/tmp/stale', 'ak/stale', 0, 'org/repo', ?)`,
+      [RECENT],
+    );
+    await db.execute(
+      `INSERT INTO github_pr_cache (branch, repo_slug, pr_json, fetched_at)
+       VALUES (?, 'org/repo', ?, ?)`,
+      [
+        'ak/stale',
+        JSON.stringify({
+          number: 80,
+          title: 'long forgotten',
+          state: 'open',
+          updatedAt: iso(RECENT),
+        }),
+        iso(staleFetch),
+      ],
+    );
+
+    const result = await getPullRequestOutcomes(params({ db, sinceMs: null }));
+
+    expect(result.entries).toEqual([]);
+  });
+
+  it('keeps a cache row fetched inside the read bound when the window is unbounded', async () => {
+    const db = await seedDb();
+    await addSession({ db, seed: { id: 'kept', createdAt: RECENT } });
+    await db.execute(
+      `INSERT INTO session_worktrees
+         (id, session_id, worktree_path, branch, parallel_index, repo_slug, created_at)
+       VALUES ('wt-kept', 'kept', '/tmp/kept', 'ak/kept', 0, 'org/repo', ?)`,
+      [RECENT],
+    );
+    await db.execute(
+      `INSERT INTO github_pr_cache (branch, repo_slug, pr_json, fetched_at)
+       VALUES (?, 'org/repo', ?, ?)`,
+      [
+        'ak/kept',
+        JSON.stringify({
+          number: 81,
+          title: 'still readable',
+          state: 'merged',
+          updatedAt: iso(RECENT),
+        }),
+        iso(Date.now() - DAY_MS),
+      ],
+    );
+
+    const result = await getPullRequestOutcomes(params({ db, sinceMs: null }));
+
+    expect(result.entries[0]).toMatchObject({ number: 81 });
   });
 });
 

--- a/packages/db/src/queries/impact.ts
+++ b/packages/db/src/queries/impact.ts
@@ -3,6 +3,8 @@ import type { Database } from '../client';
 
 const WINDOW_MS = 30 * 86_400_000;
 
+const PR_CACHE_MAX_READ_AGE_MS = 180 * 86_400_000;
+
 export type ImpactQueryParams = {
   readonly db: Database;
   readonly workspaceId: WorkspaceId;
@@ -429,6 +431,7 @@ const selectPullRequests = async ({
 }: PullRequestRangeParams): Promise<ReadonlyArray<PullRequestRow>> => {
   const startIso = startMs === null ? null : new Date(startMs).toISOString();
   const endIso = endMs === null ? null : new Date(endMs).toISOString();
+  const oldestCacheIso = new Date(Date.now() - PR_CACHE_MAX_READ_AGE_MS).toISOString();
   return db.select<PullRequestRow>(
     `SELECT
        s.id AS session_id,
@@ -444,22 +447,24 @@ const selectPullRequests = async ({
                FROM session_worktrees sw2
                JOIN sessions s2 ON s2.id = sw2.session_id
               WHERE sw2.branch = g.branch
+                AND sw2.repo_slug = g.repo_slug
                 AND s2.workspace_id = s.workspace_id
                 AND s2.deleted_at IS NULL
            )),
          0
        ) AS spend_usd
      FROM github_pr_cache g
-     JOIN session_worktrees sw ON sw.branch = g.branch
+     JOIN session_worktrees sw ON sw.branch = g.branch AND sw.repo_slug = g.repo_slug
      JOIN sessions s ON s.id = sw.session_id
     WHERE s.workspace_id = ?
       AND s.deleted_at IS NULL
       AND g.pr_json IS NOT NULL
+      AND julianday(g.fetched_at) >= julianday(?)
       AND (? IS NULL OR julianday(json_extract(g.pr_json, '$.updatedAt')) >= julianday(?))
       AND (? IS NULL OR julianday(json_extract(g.pr_json, '$.updatedAt')) < julianday(?))
     GROUP BY g.repo_slug, g.branch
     ORDER BY julianday(json_extract(g.pr_json, '$.updatedAt')) DESC`,
-    [workspaceId, startIso, startIso, endIso, endIso],
+    [workspaceId, oldestCacheIso, startIso, startIso, endIso, endIso],
   );
 };
 

--- a/packages/db/src/queries/session-worktree.test.ts
+++ b/packages/db/src/queries/session-worktree.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import type { SessionId, WorkspaceId } from '@goodboy/types';
+import type { Database } from '../client';
+import { makeTestDatabase } from '../test-helpers/test-db';
+import { migrations } from '../migrations';
+import { migrate } from '../migrations/runner';
+import {
+  insertSessionWorktree,
+  listWorktreesForSession,
+  updateSessionWorktreeRepoSlug,
+} from './session-worktree';
+
+const workspaceId = 'w1' as WorkspaceId;
+const sessionId = 's1' as SessionId;
+const otherSessionId = 's2' as SessionId;
+
+const seed = async (): Promise<Database> => {
+  const db = makeTestDatabase();
+  await migrate(db, migrations);
+  const now = Date.now();
+  await db.execute(
+    'INSERT INTO workspaces (id, name, root_path, created_at, updated_at) VALUES (?, ?, ?, ?, ?)',
+    [workspaceId, 'ws', '/tmp/ws', now, now],
+  );
+  for (const id of [sessionId, otherSessionId]) {
+    await db.execute(
+      'INSERT INTO sessions (id, workspace_id, goal, state_kind, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)',
+      [id, workspaceId, 'goal', 'idle', now, now],
+    );
+  }
+  return db;
+};
+
+describe('updateSessionWorktreeRepoSlug', () => {
+  it('stamps only the addressed mount of a composite session', async () => {
+    const db = await seed();
+    await insertSessionWorktree(db, {
+      id: 'wt-api',
+      sessionId,
+      worktreePath: '/tmp/wt/api',
+      branch: 'ak/shared',
+      parallelIndex: 0,
+      createdAt: Date.now(),
+    });
+    await insertSessionWorktree(db, {
+      id: 'wt-web',
+      sessionId,
+      worktreePath: '/tmp/wt/web',
+      branch: 'ak/shared',
+      parallelIndex: 1,
+      createdAt: Date.now(),
+    });
+
+    await updateSessionWorktreeRepoSlug({
+      db,
+      sessionId,
+      worktreePath: '/tmp/wt/api',
+      repoSlug: 'acme/api',
+    });
+
+    const rows = await listWorktreesForSession(db, sessionId);
+    expect(rows.find((row) => row.id === 'wt-api')?.repoSlug).toBe('acme/api');
+    expect(rows.find((row) => row.id === 'wt-web')?.repoSlug).toBeUndefined();
+  });
+
+  it('stamps nothing when the addressed path belongs to another session', async () => {
+    const db = await seed();
+    await insertSessionWorktree(db, {
+      id: 'wt-mine',
+      sessionId,
+      worktreePath: '/tmp/wt/mine',
+      branch: 'ak/mine',
+      parallelIndex: 0,
+      createdAt: Date.now(),
+    });
+    await insertSessionWorktree(db, {
+      id: 'wt-theirs',
+      sessionId: otherSessionId,
+      worktreePath: '/tmp/wt/theirs',
+      branch: 'ak/theirs',
+      parallelIndex: 0,
+      createdAt: Date.now(),
+    });
+
+    await updateSessionWorktreeRepoSlug({
+      db,
+      sessionId,
+      worktreePath: '/tmp/wt/theirs',
+      repoSlug: 'acme/theirs',
+    });
+
+    const theirs = await listWorktreesForSession(db, otherSessionId);
+    const mine = await listWorktreesForSession(db, sessionId);
+    expect(theirs[0]?.repoSlug).toBeUndefined();
+    expect(mine[0]?.repoSlug).toBeUndefined();
+  });
+});
+
+describe('insertSessionWorktree', () => {
+  it('round-trips a repo slug and leaves an unstamped mount undefined', async () => {
+    const db = await seed();
+    await insertSessionWorktree(db, {
+      id: 'wt-stamped',
+      sessionId,
+      worktreePath: '/tmp/wt/stamped',
+      branch: 'ak/stamped',
+      parallelIndex: 0,
+      repoSlug: 'acme/stamped',
+      createdAt: Date.now(),
+    });
+    await insertSessionWorktree(db, {
+      id: 'wt-bare',
+      sessionId,
+      worktreePath: '/tmp/wt/bare',
+      branch: 'ak/bare',
+      parallelIndex: 1,
+      createdAt: Date.now(),
+    });
+
+    const rows = await listWorktreesForSession(db, sessionId);
+    expect(rows.find((row) => row.id === 'wt-stamped')?.repoSlug).toBe('acme/stamped');
+    expect(rows.find((row) => row.id === 'wt-bare')?.repoSlug).toBeUndefined();
+  });
+});

--- a/packages/db/src/queries/session-worktree.ts
+++ b/packages/db/src/queries/session-worktree.ts
@@ -9,6 +9,7 @@ type SessionWorktreeRow = {
   parallel_index: number;
   mount_workspace_id: string | null;
   mount_name: string | null;
+  repo_slug: string | null;
   created_at: number;
 };
 
@@ -20,6 +21,7 @@ export type SessionWorktree = {
   readonly parallelIndex: number;
   readonly mountWorkspaceId?: WorkspaceId;
   readonly mountName?: string;
+  readonly repoSlug?: string;
   readonly createdAt: number;
 };
 
@@ -34,6 +36,7 @@ function toDomain(row: SessionWorktreeRow): SessionWorktree {
       ? { mountWorkspaceId: row.mount_workspace_id as WorkspaceId }
       : {}),
     ...(row.mount_name != null ? { mountName: row.mount_name } : {}),
+    ...(row.repo_slug != null ? { repoSlug: row.repo_slug } : {}),
     createdAt: row.created_at,
   };
 }
@@ -44,8 +47,8 @@ export const insertSessionWorktree = async (
 ): Promise<void> => {
   await db.execute(
     `INSERT INTO session_worktrees
-      (id, session_id, worktree_path, branch, parallel_index, mount_workspace_id, mount_name, created_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      (id, session_id, worktree_path, branch, parallel_index, mount_workspace_id, mount_name, repo_slug, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     [
       worktree.id,
       worktree.sessionId,
@@ -54,6 +57,7 @@ export const insertSessionWorktree = async (
       worktree.parallelIndex,
       worktree.mountWorkspaceId ?? null,
       worktree.mountName ?? null,
+      worktree.repoSlug ?? null,
       worktree.createdAt,
     ],
   );
@@ -127,6 +131,25 @@ export const updateSessionWorktreePath = async ({
   await db.execute(
     'UPDATE session_worktrees SET worktree_path = ? WHERE session_id = ? AND parallel_index = ?',
     [worktreePath, sessionId, parallelIndex],
+  );
+};
+
+type UpdateSessionWorktreeRepoSlugParams = {
+  readonly db: Database;
+  readonly sessionId: SessionId;
+  readonly worktreePath: string;
+  readonly repoSlug: string;
+};
+
+export const updateSessionWorktreeRepoSlug = async ({
+  db,
+  sessionId,
+  worktreePath,
+  repoSlug,
+}: UpdateSessionWorktreeRepoSlugParams): Promise<void> => {
+  await db.execute(
+    'UPDATE session_worktrees SET repo_slug = ? WHERE session_id = ? AND worktree_path = ?',
+    [repoSlug, sessionId, worktreePath],
   );
 };
 

--- a/packages/types/src/github.ts
+++ b/packages/types/src/github.ts
@@ -92,10 +92,15 @@ export type PullRequestDiff = {
   files: ReadonlyArray<FileDiff>;
 };
 
+export type CachedPullRequest = Pick<
+  PullRequestState,
+  'number' | 'title' | 'url' | 'state' | 'updatedAt'
+>;
+
 export type GithubPrCacheEntry = {
   branch: string;
   repoSlug: string;
-  pr: PullRequestState | null;
+  pr: CachedPullRequest | null;
   fetchedAt: string;
 };
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -239,6 +239,7 @@ export type {
   SessionViewPrefs,
 } from './session-view';
 export type {
+  CachedPullRequest,
   DiffHunk,
   DiffHunkLine,
   FileDiff,


### PR DESCRIPTION
## What

`github_pr_cache` has had no production writer since migration m018, so the
shipped pull requests panel in Impact Studio has been empty for everyone. This
gives it a writer, gives the join the repository slug it needs, and bounds what
the read will accept.

Five parts, one PR:

1. **The write.** `apps/desktop/src/store/slices/github/refreshSessionPr.ts`
   upserts `github_pr_cache` on a successful refresh, calling
   `upsertGithubPrCache` from `@goodboy/db` directly. The dead
   `getPrForBranch` / `createTauriPrCacheStore` adapter pair was not revived.
2. **The migration, m111.** `ALTER TABLE session_worktrees ADD COLUMN repo_slug TEXT`
   plus an additive index on `(repo_slug, branch)` for the join. Nullable, no
   default, no backfill, nothing dropped or renamed.
3. **The corrected join** at both TypeScript sites in
   `packages/db/src/queries/impact.ts`: the main join and the nested spend
   subquery.
4. **The key decision**, written below.
5. **An age bound at the read** on `g.fetched_at`.

Population is app side: at mount in
`apps/desktop/src/store/slices/sessions/createSession.ts` and at refresh. The
mount call site did not exist before and is new here. It is fire and forget and
failure tolerant, because `detectRepoSlug` shells out to `gh` and returns null
offline or unauthenticated; session creation must not regress on that, and a
test covers the null case.

## Key decision: cache row scope

`github_pr_cache` stays keyed `(repo_slug, branch)` with **no `workspace_id`**.
Two workspaces pointed at the same repository and branch intentionally share
one row. The row is a re-fetchable mirror of GitHub and carries no per workspace
fact, so sharing it leaks nothing between workspaces; the per workspace scoping
that matters happens on the read, which joins through `session_worktrees` and
`sessions` and filters on `s.workspace_id`.

The cached payload is now a real type rather than a convention.
`CachedPullRequest` is `Pick<PullRequestState, 'number' | 'title' | 'url' | 'state' | 'updatedAt'>`
and `GithubPrCacheEntry.pr` narrows to it, so `body`, `mergeable`, `checks`,
`baseBranch`, `headBranch`, `isDraft` and `reviewDecision` no longer reach disk
and a future writer cannot re-fatten the row without changing the type. A test
asserts the stored row has exactly those five keys, and another asserts the
token accepted by `getPrForBranch` never appears in what gets stored.

## Eviction: an age bound at the read, not a delete

`packages/db/src/queries/impact.ts` gains
`PR_CACHE_MAX_READ_AGE_MS` (180 days) and an extra `WHERE` clause on
`g.fetched_at`, independent of the existing `sinceMs` window parameter, which
can be null and is about pull request *update* recency rather than cache *entry*
age. `selectPullRequests` is the only SQL behind `getPullRequestOutcomes`, so
the single clause covers both read paths.

The bound deliberately does **not** reuse `DEFAULT_PR_CACHE_TTL_MS`
(`packages/core/src/github/cache.ts`, 60 seconds). That constant is a fetch
freshness value; used as a read filter it would hide everything older than a
minute and re-empty the exact panel this change exists to fill. The new constant
is named distinctly so the two do not get conflated.

Nothing is deleted. There is no retention sweep and no cache eviction on session
delete; wiring a delete is a separate, irreversible change that is not in scope
here.

## The strict join and what users see at upgrade

The join is strict: `sw.repo_slug = g.repo_slug`, not null tolerant. A NULL
`repo_slug` matches every slug, so tolerating NULL would preserve exactly the
cross attribution the column exists to prevent.

The consequence is intended and worth stating plainly in the release notes:
**at upgrade the panel shows exactly what it shows today, empty, for every
session that existed before the upgrade**, because every pre-existing
`session_worktrees` row has `repo_slug = NULL`. Each row heals when it next gets
a slug from a new mount or a successful refresh. The panel fills prospectively,
not retroactively.

## Companion residual: a third site that stays wrong

`apps/desktop/src-tauri/src/bridge/snapshot.rs` ships `session_worktrees` as
`(session_id, branch, parallel_index)` with no `repo_slug`, alongside the cache
keyed `(branch, repo_slug)`, and the paired phone pairs the two arrays on branch
alone. It therefore still cannot disambiguate by repository, whatever the
desktop does. No Rust in this release: "corrected join at both sites" means both
TypeScript sites, not all sites.

## Mobile consequence of the trim

`snapshot.rs` parses `pr_json` into an untyped `serde_json::Value` and passes it
through verbatim, so nothing breaks in Rust. A mobile client that destructures
`mergeable`, `checks` or `body` from the embedded pull request object will now
get `undefined` for those fields.

## Compile break the plan did not name

Narrowing `GithubPrCacheEntry.pr` breaks `getPrForBranch` in
`packages/core/src/github/cache.ts`, whose declared return type was
`Promise<PullRequestState | null>`. It is widened to `CachedPullRequest | null`,
and the trim helper `toCachedPullRequest` is applied on its write path too, so
the bound holds on every path rather than only the new one.

## Data class

Class A: the migration only adds. Nullable column, additive index, no backfill,
no `NOT NULL`, no `UNIQUE`, nothing dropped or renamed. A crash between the
`ALTER TABLE` and any population leaves every row as it is today plus one NULL
column; the strict join excludes those rows and the next mount or refresh heals
the row it touches. No repair path is needed.

**Migration number: 111.** Verified free against
`packages/db/src/migrations/index.ts`, which registered 1..110 contiguously
before this change, and against the filenames on disk.

## Verification

`pnpm exec turbo run test --force` across the workspace, read at `0 cached`:
646 desktop files / 5528 tests, 32 db files, 103 core files, 37 ui files, all
passing. `turbo run lint typecheck --force` clean, and
`pnpm knip --include files,duplicates,unlisted` (the form CI runs) reports no
findings.


## Gate repair

The gate blocked this PR because `updateSessionWorktreeRepoSlug` was pinned by
nothing: removing its `WHERE session_id = ? AND worktree_path = ?` left the
whole `packages/db` suite green. There was no test file for the query, the m111
test exercises raw SQL rather than the query layer, and every desktop test mocks
`@goodboy/db`.

`packages/db/src/queries/session-worktree.test.ts` is new and is the only file
this repair adds. No production code changed: the query source, the SQL bind
order, `PR_CACHE_MAX_READ_AGE_MS` and every section above are untouched, and
migration 111 was re-verified free against `origin/main` (highest on disk is
m110) and against every open PR.

Three cases:

1. Stamping one mount of a two mount composite session that shares a branch
   name leaves the sibling unset. Pins the `worktree_path` predicate and the
   bind order.
2. Addressing a path owned by a different session while passing our own session
   id stamps nothing anywhere. Pins the `session_id` predicate.
3. A slug round trips through `insertSessionWorktree`. Pins the new bind and the
   `toDomain` mapping.

Case 2 is deliberately not the shape first proposed. Because `worktree_path` is
unique from m031, dropping the `session_id` predicate still touches exactly one
row, so a case built on two distinct paths cannot tell the difference, and the
earlier `rowsAffected = 1` measurement would have been unchanged. What changes is
*which* row: a caller passing session A with a path owned by session B goes from
a correct no-op to stamping B. Addressing a foreign path is what makes the
predicate load bearing.

Verified by sabotage rather than by assertion, restoring the source between runs:

| Sabotage | Result |
| --- | --- |
| none, baseline | 3 passed |
| `WHERE` dropped entirely | 2 failed |
| `worktree_path` predicate dropped | 2 failed |
| `session_id` predicate dropped | 1 failed |
| bind order swapped | 1 failed |
| insert binds `null` for the slug | 1 failed |
| `toDomain` drops the slug mapping | 2 failed |

### Verification

`pnpm exec turbo run test --force`, read at `Cached: 0 cached, 4 total`:
646 desktop files / 5531 tests, 33 db files / 223 tests and 1 skipped, 103 core
files / 1129 tests, 37 ui files / 185 tests. `tsc --noEmit` on `packages/db`
clean.

One caveat worth recording. Across three forced runs, one came back red on
`src/migrations/registry.test.ts > reaches the fresh-install schema from every
intermediate version`, which timed out at its 30s budget while the 646 file
desktop suite ran alongside it. Run alone that test takes 6.4s, so it has
roughly 4.8x headroom, and m111 adds about 1.8% to its `O(n^2)` work. The
timeout is load sensitivity in a test whose cost grows with every migration,
not a regression from this change, but the margin will keep shrinking as
migrations accumulate.
