### PR TITLE
refactor(desktop): adopt pane header slot, dedupe icons, move pill

### DIFF
--- a/apps/desktop/src/features/session/components/SessionNavSidebar/parts/SessionNavFooter.tsx
+++ b/apps/desktop/src/features/session/components/SessionNavSidebar/parts/SessionNavFooter.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from 'react';
 import { Archive, ArchiveRestore, Trash2 } from 'lucide-react';
 import type { Session, SessionId } from '@goodboy/types';
-import { ConfirmPill, formatError } from '@goodboy/ui';
+import { formatError } from '@goodboy/ui';
 import { useAppStore } from '../../../../../store';
 import { useToast } from '../../../../../app/components/Toast';
+import { ConfirmPill } from '../../../../../shared/components/ConfirmPill';
 import { EditorMenu } from '../../SessionOverviewPane/EditorMenu';
 import { SessionGitActions } from '../../SessionWorkspace/parts/SessionGitActions';
 import type { Density } from '../../../density';

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ActivitySection.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ActivitySection.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { tintClasses } from '@goodboy/ui';
+import type { Session } from '@goodboy/types';
+
+vi.mock('./InFlightActionsStrip', () => ({
+  InFlightActionsStrip: () => null,
+}));
+
+vi.mock('./PipelineSection', () => ({
+  PipelineSection: () => null,
+}));
+
+vi.mock('../CreateAgentPopover', () => ({
+  CreateAgentPopover: () => null,
+}));
+
+vi.mock('../../../context/components/ContextPanel/strips/PendingResolutionsStrip', () => ({
+  PendingResolutionsStrip: () => null,
+}));
+
+import { ActivitySection } from './ActivitySection';
+
+afterEach(cleanup);
+
+const session = { id: 'sess-1', workflowRuns: [] } as unknown as Session;
+
+const baseProps = {
+  session,
+  workspaceId: null,
+  runs: {
+    lanes: [],
+    freeAgents: [],
+    resolveQueue: [],
+    aggregate: { runCount: 0, agentCount: 0, runningCount: 0, stalledCount: 0, spendUsd: 0 },
+    blockedLanes: [],
+    completedLanes: [],
+    completedFreeAgents: [],
+  },
+  isFresh: false,
+  resolveCount: 0,
+  onOpenWorkflowBuilder: vi.fn(),
+  onFocusCompletedRun: vi.fn(),
+  onSelectLens: vi.fn(),
+};
+
+describe('ActivitySection', () => {
+  it('keeps a blocked workflow on the danger tone, not the workflows concept tone', () => {
+    render(
+      <ActivitySection
+        {...baseProps}
+        runs={{ ...baseProps.runs, blockedLanes: [{ runId: 'run-1' }] as never }}
+      />,
+    );
+
+    const row = screen.getByRole('button', { name: '1 blocked workflow' });
+    const icon = row.querySelectorAll('svg')[0] as SVGElement;
+    expect(icon.getAttribute('class')).toContain(tintClasses('danger').icon);
+  });
+
+  it('keeps active resolvers on the neutral tone, not the resolve concept tone', () => {
+    render(<ActivitySection {...baseProps} resolveCount={2} />);
+
+    const row = screen.getByRole('button', { name: '2 active resolvers' });
+    const icon = row.querySelectorAll('svg')[0] as SVGElement;
+    expect(icon.getAttribute('class')).toContain(tintClasses('neutral').icon);
+    expect(icon.getAttribute('class')).not.toContain(tintClasses('success').icon);
+  });
+
+  it('routes a blocked-workflow click through onFocusCompletedRun and onSelectLens', () => {
+    render(
+      <ActivitySection
+        {...baseProps}
+        runs={{ ...baseProps.runs, blockedLanes: [{ runId: 'run-1' }] as never }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '1 blocked workflow' }));
+    expect(baseProps.onFocusCompletedRun).toHaveBeenCalledWith('run-1');
+    expect(baseProps.onSelectLens).toHaveBeenCalledWith('workflows');
+  });
+});

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ActivitySection.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ActivitySection.tsx
@@ -1,4 +1,5 @@
 import { Button, Eyebrow } from '@goodboy/ui';
+import type { Tone } from '@goodboy/ui';
 import type { Session, SessionId, WorkspaceId } from '@goodboy/types';
 import type { LensKind } from '../../../../store';
 import { CONCEPT_ICONS } from '../../../../shared/components/conceptIcons';
@@ -20,6 +21,13 @@ type Props = {
   readonly onFocusCompletedRun: (runId: string) => void;
   readonly onSelectLens: (lens: LensKind) => void;
 };
+
+const ACTIVITY_STATE_TONE_OVERRIDE = {
+  blockedWorkflows: 'danger',
+  activeResolvers: 'neutral',
+  completedWorkflows: 'neutral',
+  completedAgents: 'neutral',
+} satisfies Record<string, Tone>;
 
 export const ActivitySection = ({
   session,
@@ -84,7 +92,7 @@ export const ActivitySection = ({
           {blockedLanes.length > 0 ? (
             <SummaryRow
               icon={CONCEPT_ICONS.workflows}
-              tone="danger"
+              tone={ACTIVITY_STATE_TONE_OVERRIDE.blockedWorkflows}
               label={
                 blockedLanes.length === 1
                   ? '1 blocked workflow'
@@ -96,7 +104,7 @@ export const ActivitySection = ({
           {resolveCount > 0 ? (
             <SummaryRow
               icon={CONCEPT_ICONS.resolve}
-              tone="neutral"
+              tone={ACTIVITY_STATE_TONE_OVERRIDE.activeResolvers}
               label={resolveCount === 1 ? '1 active resolver' : `${resolveCount} active resolvers`}
               onClick={() => onSelectLens('resolve')}
             />
@@ -104,7 +112,7 @@ export const ActivitySection = ({
           {completedLanes.length > 0 ? (
             <SummaryRow
               icon={CONCEPT_ICONS.decisions}
-              tone="neutral"
+              tone={ACTIVITY_STATE_TONE_OVERRIDE.completedWorkflows}
               label={
                 completedLanes.length === 1
                   ? '1 completed workflow'
@@ -116,7 +124,7 @@ export const ActivitySection = ({
           {completedAgents.length > 0 ? (
             <SummaryRow
               icon={CONCEPT_ICONS.agents}
-              tone="neutral"
+              tone={ACTIVITY_STATE_TONE_OVERRIDE.completedAgents}
               label={
                 completedAgents.length === 1
                   ? '1 completed agent'

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/NextUpCard.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/NextUpCard.test.tsx
@@ -1,0 +1,66 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { NextUpCard } from './NextUpCard';
+import type { NextUpItem } from './selectNextUp';
+
+afterEach(cleanup);
+
+const ALL_ITEM_IDS: ReadonlyArray<NextUpItem['id']> = [
+  'question',
+  'review',
+  'checks',
+  'resume',
+  'resolve',
+  'pending-push',
+  'stalled',
+  'errored',
+  'close-out',
+  'start',
+  'next-step',
+  'follow',
+];
+
+const itemFor = ({ id }: { readonly id: NextUpItem['id'] }): NextUpItem => ({
+  id,
+  title: `title for ${id}`,
+  detail: '',
+  action: 'Go',
+  tone: 'neutral',
+  lens: null,
+  itemId: null,
+  signals: [],
+});
+
+describe('NextUpCard', () => {
+  it.each(ALL_ITEM_IDS)('renders an icon and the title for id %s without crashing', (id) => {
+    render(<NextUpCard item={itemFor({ id })} onAct={vi.fn()} />);
+    expect(screen.getByText(`title for ${id}`)).toBeDefined();
+  });
+
+  it('renders a chip per signal and dispatches onAct from the primary button', () => {
+    const onAct = vi.fn();
+    render(
+      <NextUpCard
+        item={{
+          id: 'question',
+          title: '1 open question',
+          detail: 'What should happen next?',
+          action: 'Answer',
+          tone: 'warning',
+          lens: 'questions',
+          itemId: null,
+          signals: ['resolve'],
+        }}
+        onAct={onAct}
+      />,
+    );
+
+    expect(screen.getByText('1 open question')).toBeDefined();
+    expect(screen.getByText('What should happen next?')).toBeDefined();
+    expect(screen.getByText('resolve')).toBeDefined();
+    screen.getByRole('button', { name: 'Answer' }).click();
+    expect(onAct).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/NextUpCard.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/NextUpCard.test.tsx
@@ -3,7 +3,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, render, screen } from '@testing-library/react';
 import { NextUpCard } from './NextUpCard';
-import type { NextUpItem } from './selectNextUp';
+import type { NextUpItem, NextUpSignal } from './selectNextUp';
 
 afterEach(cleanup);
 
@@ -22,6 +22,41 @@ const ALL_ITEM_IDS: ReadonlyArray<NextUpItem['id']> = [
   'follow',
 ];
 
+const ITEM_ICON_GLYPH: Record<NextUpItem['id'], string> = {
+  question: 'circle-question-mark',
+  review: 'git-pull-request',
+  checks: 'circle-x',
+  resume: 'bot',
+  resolve: 'message-square-reply',
+  'pending-push': 'upload',
+  stalled: 'waypoints',
+  errored: 'circle-alert',
+  'close-out': 'git-pull-request',
+  start: 'waypoints',
+  'next-step': 'waypoints',
+  follow: 'bot',
+};
+
+const ALL_SIGNAL_IDS: ReadonlyArray<NextUpSignal> = [
+  'question',
+  'review',
+  'checks',
+  'resume',
+  'stalled',
+  'errored',
+  'resolve',
+];
+
+const SIGNAL_ICON_GLYPH: Record<NextUpSignal, string> = {
+  question: 'circle-question-mark',
+  review: 'git-pull-request',
+  checks: 'circle-x',
+  resume: 'bot',
+  stalled: 'triangle-alert',
+  errored: 'circle-alert',
+  resolve: 'message-square-reply',
+};
+
 const itemFor = ({ id }: { readonly id: NextUpItem['id'] }): NextUpItem => ({
   id,
   title: `title for ${id}`,
@@ -33,10 +68,35 @@ const itemFor = ({ id }: { readonly id: NextUpItem['id'] }): NextUpItem => ({
   signals: [],
 });
 
+const itemWithSignal = ({ signal }: { readonly signal: NextUpSignal }): NextUpItem => ({
+  id: 'question',
+  title: 'title',
+  detail: '',
+  action: 'Go',
+  tone: 'neutral',
+  lens: null,
+  itemId: null,
+  signals: [signal],
+});
+
 describe('NextUpCard', () => {
-  it.each(ALL_ITEM_IDS)('renders an icon and the title for id %s without crashing', (id) => {
-    render(<NextUpCard item={itemFor({ id })} onAct={vi.fn()} />);
+  it.each(ALL_ITEM_IDS)('renders the pinned glyph and title for id %s', (id) => {
+    const { container } = render(<NextUpCard item={itemFor({ id })} onAct={vi.fn()} />);
     expect(screen.getByText(`title for ${id}`)).toBeDefined();
+
+    const leadingIcon = container.querySelector('svg');
+    expect(leadingIcon).not.toBeNull();
+    expect(leadingIcon?.classList.contains(`lucide-${ITEM_ICON_GLYPH[id]}`)).toBe(true);
+  });
+
+  it.each(ALL_SIGNAL_IDS)('renders the pinned signal glyph for %s', (signal) => {
+    const { container } = render(<NextUpCard item={itemWithSignal({ signal })} onAct={vi.fn()} />);
+
+    const icons = container.querySelectorAll('svg');
+    expect(icons).toHaveLength(2);
+    const signalIcon = icons.item(1);
+    expect(signalIcon).not.toBeNull();
+    expect(signalIcon?.classList.contains(`lucide-${SIGNAL_ICON_GLYPH[signal]}`)).toBe(true);
   });
 
   it('renders a chip per signal and dispatches onAct from the primary button', () => {

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/NextUpCard.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/NextUpCard.tsx
@@ -1,13 +1,4 @@
-import {
-  AlertCircle,
-  AlertTriangle,
-  Bot,
-  CircleHelp,
-  GitPullRequest,
-  MessageSquareReply,
-  Upload,
-  XCircle,
-} from 'lucide-react';
+import { AlertCircle, AlertTriangle, Bot, GitPullRequest, Upload, XCircle } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import { Button, Chip, cn, tintClasses } from '@goodboy/ui';
 import { CONCEPT_ICONS } from '../../../../shared/components/conceptIcons';
@@ -19,13 +10,13 @@ type Props = {
 };
 
 const SIGNAL_ICON: Record<NextUpSignal, LucideIcon> = {
-  question: CircleHelp,
+  question: CONCEPT_ICONS.questions,
   review: GitPullRequest,
   checks: XCircle,
   resume: Bot,
   stalled: AlertTriangle,
   errored: AlertCircle,
-  resolve: MessageSquareReply,
+  resolve: CONCEPT_ICONS.resolve,
 };
 
 const SIGNAL_LABEL: Record<NextUpSignal, string> = {
@@ -39,11 +30,11 @@ const SIGNAL_LABEL: Record<NextUpSignal, string> = {
 };
 
 const ITEM_ICON: Record<NextUpItem['id'], LucideIcon> = {
-  question: CircleHelp,
+  question: CONCEPT_ICONS.questions,
   review: GitPullRequest,
   checks: XCircle,
   resume: Bot,
-  resolve: MessageSquareReply,
+  resolve: CONCEPT_ICONS.resolve,
   'pending-push': Upload,
   stalled: CONCEPT_ICONS.workflows,
   errored: AlertCircle,

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/index.test.tsx
@@ -734,6 +734,16 @@ describe('SessionOverviewPane block order', () => {
   });
 });
 
+describe('SessionOverviewPane mount animation', () => {
+  it('keeps the pre-PaneShell fade-in rise instead of the PaneShell studio-in zoom', () => {
+    const { container } = renderPane();
+    const root = container.querySelector('.mx-auto.w-full');
+    expect(root).not.toBeNull();
+    expect(root!.className).toContain('animate-fade-in');
+    expect(root!.className).not.toContain('animate-studio-in');
+  });
+});
+
 describe('SessionOverviewPane pipeline lane next-step badge', () => {
   const STEP_ID = 'step-1';
   const RUN_ID = 'run-1';

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo } from 'react';
-import { Divider, Eyebrow, ScrollFade, cn } from '@goodboy/ui';
+import { Divider, Eyebrow } from '@goodboy/ui';
 import { classifyWorkflowChain, runsForWorkflowRun, upcomingSteps } from '@goodboy/core';
 import type { Agent, AgentId, Session, SessionId, Workflow } from '@goodboy/types';
 import {
@@ -21,6 +21,7 @@ import {
   type AgentHomeLens,
 } from '../../agent-kind';
 import { useActiveResolverCount } from '../../hooks/useActiveResolverCount';
+import { PaneShell } from '../../../../shared/components/PaneShell';
 import { selectOpenQuestions } from './lib';
 import {
   selectNextUp,
@@ -36,7 +37,6 @@ import { LinkedWorkSection } from './LinkedWorkSection';
 import { NextUpCard } from './NextUpCard';
 import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../shared/components/conceptIcons';
 import { LensEmptyState } from '@goodboy/ui';
-import { PANE_RHYTHM } from '@goodboy/ui';
 
 type Props = {
   readonly session: Session;
@@ -253,44 +253,34 @@ export const SessionOverviewPane = ({ session, onSelectLens }: Props) => {
   };
 
   return (
-    <ScrollFade className="h-full" viewportClassName={PANE_RHYTHM.body} fadeSize={24}>
-      <div
-        className={cn(
-          'animate-fade-in flex flex-col',
-          PANE_RHYTHM.column,
-          PANE_RHYTHM.stack,
-          PANE_RHYTHM.measure.pane,
+    <PaneShell header={<HeaderBand session={session} stage={stage} />}>
+      <Divider />
+      <section aria-label="Next up" className="flex flex-col gap-2">
+        <Eyebrow label="Next up" muted className="px-0.5 font-medium" />
+        {nextUp !== null ? (
+          <NextUpCard item={nextUp} onAct={() => actOnNextUp({ item: nextUp })} />
+        ) : (
+          <LensEmptyState
+            icon={CONCEPT_ICONS.nextUp}
+            tone={CONCEPT_TONE.nextUp}
+            title="Nothing needs you right now"
+            description="Every agent, question, and review on this session is settled. Start work from the activity below."
+          />
         )}
-      >
-        <HeaderBand session={session} stage={stage} />
-        <Divider />
-        <section aria-label="Next up" className="flex flex-col gap-2">
-          <Eyebrow label="Next up" muted className="px-0.5 font-medium" />
-          {nextUp !== null ? (
-            <NextUpCard item={nextUp} onAct={() => actOnNextUp({ item: nextUp })} />
-          ) : (
-            <LensEmptyState
-              icon={CONCEPT_ICONS.nextUp}
-              tone={CONCEPT_TONE.nextUp}
-              title="Nothing needs you right now"
-              description="Every agent, question, and review on this session is settled. Start work from the activity below."
-            />
-          )}
-        </section>
-        <Divider />
-        <LinkedWorkSection sessionId={sessionId} onSelectLens={onSelectLens} />
-        <Divider />
-        <ActivitySection
-          session={session}
-          workspaceId={workspace?.id ?? null}
-          runs={runs}
-          isFresh={isFresh}
-          resolveCount={resolveCount}
-          onOpenWorkflowBuilder={openWorkflowBuilder}
-          onFocusCompletedRun={(runId) => setFocusedWorkflowRun(sessionId, runId)}
-          onSelectLens={onSelectLens}
-        />
-      </div>
-    </ScrollFade>
+      </section>
+      <Divider />
+      <LinkedWorkSection sessionId={sessionId} onSelectLens={onSelectLens} />
+      <Divider />
+      <ActivitySection
+        session={session}
+        workspaceId={workspace?.id ?? null}
+        runs={runs}
+        isFresh={isFresh}
+        resolveCount={resolveCount}
+        onOpenWorkflowBuilder={openWorkflowBuilder}
+        onFocusCompletedRun={(runId) => setFocusedWorkflowRun(sessionId, runId)}
+        onSelectLens={onSelectLens}
+      />
+    </PaneShell>
   );
 };

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/index.tsx
@@ -253,7 +253,10 @@ export const SessionOverviewPane = ({ session, onSelectLens }: Props) => {
   };
 
   return (
-    <PaneShell header={<HeaderBand session={session} stage={stage} />}>
+    <PaneShell
+      header={<HeaderBand session={session} stage={stage} />}
+      animationClassName="animate-fade-in"
+    >
       <Divider />
       <section aria-label="Next up" className="flex flex-col gap-2">
         <Eyebrow label="Next up" muted className="px-0.5 font-medium" />

--- a/apps/desktop/src/shared/components/ConfirmPill/index.test.tsx
+++ b/apps/desktop/src/shared/components/ConfirmPill/index.test.tsx
@@ -2,7 +2,7 @@
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
-import { ConfirmPill } from '../components/ConfirmPill';
+import { ConfirmPill } from '.';
 
 afterEach(cleanup);
 

--- a/apps/desktop/src/shared/components/ConfirmPill/index.tsx
+++ b/apps/desktop/src/shared/components/ConfirmPill/index.tsx
@@ -1,5 +1,5 @@
 import { Check, X } from 'lucide-react';
-import { cn } from '../cn';
+import { cn } from '@goodboy/ui';
 
 type Props = {
   readonly label: string;

--- a/apps/desktop/src/shared/components/PaneShell/index.test.tsx
+++ b/apps/desktop/src/shared/components/PaneShell/index.test.tsx
@@ -76,6 +76,18 @@ describe('PaneShell', () => {
     }) as HTMLElement;
     expect(column.className).toContain(PANE_RHYTHM.measure.full);
   });
+
+  it('renders a custom header in place of the title block when given one', () => {
+    render(
+      <PaneShell header={<h1>Custom header</h1>}>
+        <p>Body copy</p>
+      </PaneShell>,
+    );
+
+    expect(screen.getByRole('heading', { name: 'Custom header' })).toBeDefined();
+    expect(screen.getAllByRole('heading')).toHaveLength(1);
+    expect(screen.getByText('Body copy')).toBeDefined();
+  });
 });
 
 describe('FocusedPane', () => {

--- a/apps/desktop/src/shared/components/PaneShell/index.test.tsx
+++ b/apps/desktop/src/shared/components/PaneShell/index.test.tsx
@@ -88,6 +88,36 @@ describe('PaneShell', () => {
     expect(screen.getAllByRole('heading')).toHaveLength(1);
     expect(screen.getByText('Body copy')).toBeDefined();
   });
+
+  it('mounts with the studio-in animation by default', () => {
+    render(
+      <PaneShell title="Linear">
+        <p>Body copy</p>
+      </PaneShell>,
+    );
+
+    const column = closestWith({
+      node: screen.getByText('Body copy'),
+      pattern: /^max-w-/,
+    }) as HTMLElement;
+    expect(column.className).toContain('motion-safe:animate-studio-in');
+    expect(column.className).not.toContain('animate-fade-in');
+  });
+
+  it('lets a consumer override the mount animation without touching the default', () => {
+    render(
+      <PaneShell header={<h1>Custom header</h1>} animationClassName="animate-fade-in">
+        <p>Body copy</p>
+      </PaneShell>,
+    );
+
+    const column = closestWith({
+      node: screen.getByText('Body copy'),
+      pattern: /^max-w-/,
+    }) as HTMLElement;
+    expect(column.className).toContain('animate-fade-in');
+    expect(column.className).not.toContain('motion-safe:animate-studio-in');
+  });
 });
 
 describe('FocusedPane', () => {

--- a/apps/desktop/src/shared/components/PaneShell/index.tsx
+++ b/apps/desktop/src/shared/components/PaneShell/index.tsx
@@ -1,50 +1,69 @@
-import type { ReactNode } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 import { ScrollFade, cn } from '@goodboy/ui';
 import { PANE_RHYTHM } from '@goodboy/ui';
 
-type Props = {
-  readonly title: string;
-  readonly description?: string;
-  readonly meta?: ReactNode;
-  readonly actions?: ReactNode;
+type BaseProps = {
   readonly measure?: keyof typeof PANE_RHYTHM.measure;
   readonly children: ReactNode;
 };
 
-export const PaneShell = ({
-  title,
-  description,
-  meta,
-  actions,
-  measure = 'pane',
-  children,
-}: Props) => (
-  <ScrollFade className="h-full" viewportClassName={PANE_RHYTHM.body} fadeSize={24}>
-    <div
-      className={cn(
-        'flex flex-col motion-safe:animate-studio-in',
-        PANE_RHYTHM.column,
-        PANE_RHYTHM.stack,
-        PANE_RHYTHM.measure[measure],
-      )}
-    >
-      <div className="flex flex-wrap items-start justify-between gap-3">
-        <div className="flex min-w-0 flex-col gap-1">
-          <div className="flex items-baseline gap-2">
-            <h1 className="text-xl font-semibold leading-snug text-foreground">{title}</h1>
-            {meta ? (
-              <span className="text-xs tabular-nums text-muted-foreground">{meta}</span>
+type TitleHeaderProps = {
+  readonly title: string;
+  readonly description?: string;
+  readonly meta?: ReactNode;
+  readonly actions?: ReactNode;
+  readonly header?: undefined;
+};
+
+type CustomHeaderProps = {
+  readonly header: ReactElement;
+  readonly title?: undefined;
+  readonly description?: undefined;
+  readonly meta?: undefined;
+  readonly actions?: undefined;
+};
+
+type Props = BaseProps & (TitleHeaderProps | CustomHeaderProps);
+
+export const PaneShell = (props: Props) => {
+  const { measure = 'pane', children } = props;
+
+  return (
+    <ScrollFade className="h-full" viewportClassName={PANE_RHYTHM.body} fadeSize={24}>
+      <div
+        className={cn(
+          'flex flex-col motion-safe:animate-studio-in',
+          PANE_RHYTHM.column,
+          PANE_RHYTHM.stack,
+          PANE_RHYTHM.measure[measure],
+        )}
+      >
+        {props.header !== undefined ? (
+          props.header
+        ) : (
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="flex min-w-0 flex-col gap-1">
+              <div className="flex items-baseline gap-2">
+                <h1 className="text-xl font-semibold leading-snug text-foreground">
+                  {props.title}
+                </h1>
+                {props.meta ? (
+                  <span className="text-xs tabular-nums text-muted-foreground">{props.meta}</span>
+                ) : null}
+              </div>
+              {props.description ? (
+                <p className="text-sm text-muted-foreground">{props.description}</p>
+              ) : null}
+            </div>
+            {props.actions ? (
+              <div className="flex min-w-0 flex-wrap items-center justify-end gap-1.5 pt-0.5">
+                {props.actions}
+              </div>
             ) : null}
           </div>
-          {description ? <p className="text-sm text-muted-foreground">{description}</p> : null}
-        </div>
-        {actions ? (
-          <div className="flex min-w-0 flex-wrap items-center justify-end gap-1.5 pt-0.5">
-            {actions}
-          </div>
-        ) : null}
+        )}
+        {children}
       </div>
-      {children}
-    </div>
-  </ScrollFade>
-);
+    </ScrollFade>
+  );
+};

--- a/apps/desktop/src/shared/components/PaneShell/index.tsx
+++ b/apps/desktop/src/shared/components/PaneShell/index.tsx
@@ -4,6 +4,7 @@ import { PANE_RHYTHM } from '@goodboy/ui';
 
 type BaseProps = {
   readonly measure?: keyof typeof PANE_RHYTHM.measure;
+  readonly animationClassName?: string;
   readonly children: ReactNode;
 };
 
@@ -26,13 +27,18 @@ type CustomHeaderProps = {
 type Props = BaseProps & (TitleHeaderProps | CustomHeaderProps);
 
 export const PaneShell = (props: Props) => {
-  const { measure = 'pane', children } = props;
+  const {
+    measure = 'pane',
+    animationClassName = 'motion-safe:animate-studio-in',
+    children,
+  } = props;
 
   return (
     <ScrollFade className="h-full" viewportClassName={PANE_RHYTHM.body} fadeSize={24}>
       <div
         className={cn(
-          'flex flex-col motion-safe:animate-studio-in',
+          'flex flex-col',
+          animationClassName,
           PANE_RHYTHM.column,
           PANE_RHYTHM.stack,
           PANE_RHYTHM.measure[measure],

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -91,7 +91,6 @@ export type { FieldRowProps } from './components/FieldRow';
 export type { GhostActionButtonProps } from './components/GhostActionButton';
 export { IconButton } from './components/IconButton';
 export type { IconButtonProps } from './components/IconButton';
-export { ConfirmPill } from './components/ConfirmPill';
 export { InlineConfirm } from './components/InlineConfirm';
 export type { ConfirmAltAction, ConfirmRole } from './components/InlineConfirm';
 export { Input } from './components/Input';


### PR DESCRIPTION
## Summary

Grouped S slot, MU5: three refactor-class items, one branch, per-item provenance below. Zero user-visible change is the declared bar for all three; each section says what stayed out to hold that bar.

### S10 (Closes #1370) — session overview adopts `PaneShell`

`PaneShell` (`apps/desktop/src/shared/components/PaneShell/`) gains an optional `header` slot, additive: 17 existing render sites across 12 files (`ExplorePane`, `PlanStudio`, `SessionWorkspace` x2, `AgentsPane`, `FileVersionsPane`, `FilesPane` x2, `IntegrationPane`, `QuestionsPane` x4, `ResolvePane`, `SlotPane`, `WorkflowsPane`, `TerminalDock`) all pass `title`/`description`/`meta`/`actions`, none pass the new slot, none change.

`SessionOverviewPane` adopts `PaneShell` with its own `HeaderBand` as that header slot, replacing the hand-rolled `ScrollFade` + `PANE_RHYTHM` wrapper it had instead of adding to `PaneShell`'s own title block. That distinction matters: `PaneShell`'s `title` renders an unconditional `<h1>`, and `HeaderBand` already renders the surface's one `<h1>` at its own line 100 (the editable session goal). Passing both `title` and `header` would give the pane two headings; the header slot replaces the title block instead.

**Mount animation correction**: an earlier revision of this diff let the wrapper swap carry `PaneShell`'s own mount animation (`motion-safe:animate-studio-in`, 280ms, `scale(0.985)`) into `SessionOverviewPane`, replacing what the surface had on `main` (`animate-fade-in`, 120ms, `translateY(2px)`, ungated because the underlying keyframes only exist under `prefers-reduced-motion: no-preference`). That is a user-visible change on the surface a user opens most often and is out of bounds for a refactor-class item. `PaneShell` now takes an additive, defaulted `animationClassName` prop (default stays `motion-safe:animate-studio-in`, so all 17 other render sites are byte-for-byte unaffected); `SessionOverviewPane` passes `animationClassName="animate-fade-in"` to keep exactly the animation it had before this PR. Pinned by a new test in `PaneShell/index.test.tsx` (default vs. override) and a new `describe('SessionOverviewPane mount animation')` block in `SessionOverviewPane/index.test.tsx` asserting the rendered root carries `animate-fade-in` and not `animate-studio-in`.

Out of scope, named explicitly: folding the 162-line `HeaderBand` into a `PaneShell` title slot is M-sized work on the same file, not this item.

**Known duplicate, not fixed here**: `packages/ui/src/components/HeaderBand.tsx` (an unrelated 23-line primitive) and `SessionOverviewPane/HeaderBand.tsx` (the 162-line session-local composite this item touches) share a name. Recording it, not renaming either.

### S11 (Closes #1372) — concept icon and tone maps

The honest footprint here is smaller than the issue text: most of the candidate swaps are visible changes, not dedupes, and are named as such rather than made.

- `NextUpCard.tsx`'s `question` and `resolve` entries in `SIGNAL_ICON`/`ITEM_ICON` now come from `CONCEPT_ICONS.questions`/`CONCEPT_ICONS.resolve` instead of importing the same lucide symbols (`CircleHelp`, `MessageSquareReply`) a second time. Every other entry stays as-is: `review` (`GitPullRequest`) differs from `CONCEPT_ICONS.review` (`MessageSquareDiff`), `checks` (`XCircle`, deliberately "failed") differs from `CONCEPT_ICONS.checks` (`ListChecks`), `errored` (`AlertCircle`) differs from `CONCEPT_ICONS.errors` (`CircleAlert`) — swapping any of those would change the rendered glyph.
- `ActivitySection.tsx`'s four summary-row tones are **not** wired to `CONCEPT_TONE`: `CONCEPT_TONE.workflows` is `accent` (would mask a blocked workflow behind a neutral-reading color) and `CONCEPT_TONE.resolve` is `success` (would paint an outstanding action item green). The literals stay, now behind a named `ACTIVITY_STATE_TONE_OVERRIDE` map instead of four inline tone strings, so the override reads as deliberate rather than as four unexplained magic strings a future pass could "fix" into the concept map by mistake.
- `LinkedWorkSection.tsx`'s Linear/Sentry/GitLab menu icons (`ListTodo`, `Bug`, `GitFork`) are untouched. `CONCEPT_ICONS.linear`/`.sentry`/`.gitlab` are brand-logo components, not equivalent generic glyphs; swapping them would visibly change the "Link work" menu.

Added `NextUpCard.test.tsx` and `ActivitySection.test.tsx`, both previously untested: `NextUpCard`'s `ITEM_ICON` map is exhaustive over `NextUpItem['id']` (a missing key crashes the card, per Wave A's `pending-push` addition), now pinned per id; `ActivitySection`'s tone overrides are pinned by asserting the rendered icon's tint class per row, so a future swap toward `CONCEPT_TONE` would fail the test that documents why it must not happen.

### S12 (Closes #1373) — `ConfirmPill` relocates

Pure relocation, not a swap for `InlineConfirm` (untouched, stays in `packages/ui`). Four files touched, matching the confirmed reference count: moved `packages/ui/src/components/ConfirmPill.tsx` and its test to `apps/desktop/src/shared/components/ConfirmPill/` (the folder convention already used by `PaneShell`, `BetaPill`), deleted the barrel export at `packages/ui/src/index.ts`, updated the one production call site (`SessionNavFooter.tsx`, armed-archive and armed-delete). No className, prop, or markup changes. `SessionNavFooter.test.tsx` already exercises both armed states against the real component and passes unchanged.

### Gate repair: `NextUpCard.test.tsx` pins glyph identity per id/signal

The wave's test architect blocked the gate: the `it.each` over all 12 `ITEM_ICON` ids added by this PR asserted only a fixture title invariant across every id, so it pinned nothing about which glyph renders for which id, and its totality claim over `Record<NextUpItem['id'], LucideIcon>` was already guaranteed by the compiler. Three mutations to the real icon maps (`resolve` glyph swapped, `pending-push` glyph swapped, `stalled` glyph swapped) all passed 13/13 under the old test.

Fixed by freezing a literal expected-glyph table (`lucide-<kebab>` class names, hand-written against the installed `lucide-react@1.27.0` icon sources, never derived from `ITEM_ICON`/`SIGNAL_ICON` themselves) and asserting the rendered svg's class against it. Covers both `ITEM_ICON` (leading icon) and `SIGNAL_ICON` (chip icon), since the architect's own first draft of this fix read only the leading svg and missed a `SIGNAL_ICON.resolve` regression.

Verified by mutation, each red under exactly its own case and green on the unmodified source:

| mutation | case that catches it |
|---|---|
| `ITEM_ICON.resolve`: `CONCEPT_ICONS.resolve` → `GitPullRequest` | `renders the pinned glyph and title for id resolve` |
| `ITEM_ICON['pending-push']`: `Upload` → `GitPullRequest` | `renders the pinned glyph and title for id pending-push` |
| `ITEM_ICON.stalled`: `CONCEPT_ICONS.workflows` → `CONCEPT_ICONS.agents` | `renders the pinned glyph and title for id stalled` |
| `SIGNAL_ICON.resolve`: `CONCEPT_ICONS.resolve` → `CONCEPT_ICONS.review` | `renders the pinned signal glyph for resolve` |

Each mutation trips exactly one of the 20 cases and leaves the other 19 green.

## Test plan

- [x] `pnpm --filter @goodboy/desktop exec tsc --noEmit` green
- [x] `npx turbo run test --filter=@goodboy/desktop --continue --force` — `0 cached`, 650 test files / 5575 tests, all green
- [x] Mutation-tested the gate repair: 4/4 mutations red under exactly the intended case, source restored and diffed clean against HEAD before commit
