### PR TITLE
refactor: two debt slices for v0.1.79

### DIFF
--- a/apps/desktop/src/app/components/KeepAliveWorkSurface/index.test.tsx
+++ b/apps/desktop/src/app/components/KeepAliveWorkSurface/index.test.tsx
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render } from '@testing-library/react';
+import type { Session, SessionId } from '@goodboy/types';
+
+const useSessionByIdSpy = vi.hoisted(() => vi.fn<() => Session | null>(() => null));
+const sessionWorkspaceSpy = vi.hoisted(() =>
+  vi.fn<(props: { readonly isActive: boolean }) => null>(() => null),
+);
+
+vi.mock('../../../store', () => ({
+  useSessionById: useSessionByIdSpy,
+}));
+
+vi.mock('../../../features/session/components/SessionWorkspace', () => ({
+  SessionWorkspace: sessionWorkspaceSpy,
+}));
+
+import { KeepAliveWorkSurface } from './index';
+
+const SESSION_ID = 'session-1' as SessionId;
+const SESSION = { id: SESSION_ID } as Session;
+
+beforeEach(() => {
+  useSessionByIdSpy.mockReset();
+  sessionWorkspaceSpy.mockClear();
+});
+
+afterEach(cleanup);
+
+describe('KeepAliveWorkSurface', () => {
+  it('renders nothing when the session is missing', () => {
+    useSessionByIdSpy.mockReturnValue(null);
+    const { container } = render(<KeepAliveWorkSurface sessionId={SESSION_ID} isActive />);
+    expect(container.firstChild).toBeNull();
+    expect(sessionWorkspaceSpy).not.toHaveBeenCalled();
+  });
+
+  it('mounts the workspace visible when active', () => {
+    useSessionByIdSpy.mockReturnValue(SESSION);
+    const { container } = render(<KeepAliveWorkSurface sessionId={SESSION_ID} isActive />);
+    const wrapper = container.firstElementChild;
+    expect(wrapper?.hasAttribute('hidden')).toBe(false);
+    expect(sessionWorkspaceSpy.mock.calls[0]?.[0]?.isActive).toBe(true);
+  });
+
+  it('keeps the workspace mounted but hidden when inactive', () => {
+    useSessionByIdSpy.mockReturnValue(SESSION);
+    const { container } = render(<KeepAliveWorkSurface sessionId={SESSION_ID} isActive={false} />);
+    const wrapper = container.firstElementChild;
+    expect(wrapper?.hasAttribute('hidden')).toBe(true);
+    expect(sessionWorkspaceSpy.mock.calls[0]?.[0]?.isActive).toBe(false);
+  });
+});

--- a/apps/desktop/src/app/components/KeepAliveWorkSurface/index.tsx
+++ b/apps/desktop/src/app/components/KeepAliveWorkSurface/index.tsx
@@ -7,7 +7,7 @@ type KeepAliveWorkSurfaceProps = {
   readonly isActive: boolean;
 };
 
-export function KeepAliveWorkSurface({ sessionId, isActive }: KeepAliveWorkSurfaceProps) {
+export const KeepAliveWorkSurface = ({ sessionId, isActive }: KeepAliveWorkSurfaceProps) => {
   const session = useSessionById(sessionId);
   if (!session) {
     return null;
@@ -17,4 +17,4 @@ export function KeepAliveWorkSurface({ sessionId, isActive }: KeepAliveWorkSurfa
       <SessionWorkspace session={session} isActive={isActive} />
     </div>
   );
-}
+};

--- a/apps/desktop/src/features/chat/components/ChatInput/hooks/useAgentSwitchSync.test.ts
+++ b/apps/desktop/src/features/chat/components/ChatInput/hooks/useAgentSwitchSync.test.ts
@@ -1,0 +1,122 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AgentId, ProviderId, Session, WorkspaceId } from '@goodboy/types';
+import { useAppStore } from '../../../../../store';
+import type { EffortLevel } from '../../../utils/chat-constants';
+import { useAgentSwitchSync } from './useAgentSwitchSync';
+
+const WORKSPACE_ID = 'workspace-1' as WorkspaceId;
+const SESSION = { id: 'session-1', workspaceId: WORKSPACE_ID } as unknown as Session;
+const AGENT_A = 'agent-a' as AgentId;
+const AGENT_B = 'agent-b' as AgentId;
+
+const setAgentConfig = vi.fn(async () => undefined);
+
+const spies = {
+  setIsPicked: vi.fn(),
+  setSelectedProviderState: vi.fn(),
+  setSelectedModelState: vi.fn(),
+  setEffortState: vi.fn(),
+  setVerbosityState: vi.fn(),
+  setRightSizePending: vi.fn(),
+  setRightSizeDismissed: vi.fn(),
+  setScopePending: vi.fn(),
+  setScopeNudgeEventId: vi.fn(),
+};
+
+type MountParams = {
+  readonly provider: ProviderId | null;
+  readonly model: string | null;
+  readonly effort: EffortLevel;
+};
+
+const mount = ({ provider, model, effort }: MountParams) =>
+  renderHook(
+    ({ selectedAgentId }: { readonly selectedAgentId: AgentId | null }) =>
+      useAgentSwitchSync({
+        session: SESSION,
+        selectedAgentId,
+        currentProviderRef: { current: provider },
+        currentModelRef: { current: model },
+        currentEffortRef: { current: effort },
+        ...spies,
+      }),
+    { initialProps: { selectedAgentId: AGENT_A as AgentId | null } },
+  );
+
+beforeEach(() => {
+  setAgentConfig.mockClear();
+  for (const spy of Object.values(spies)) {
+    spy.mockClear();
+  }
+  useAppStore.setState({
+    setAgentConfig,
+    workspaceOverrides: {},
+    sessionPhaseRuns: {},
+  });
+});
+
+describe('useAgentSwitchSync', () => {
+  it('does nothing on the first render', () => {
+    mount({ provider: 'claude' as ProviderId, model: 'opus', effort: 'high' as EffortLevel });
+    expect(setAgentConfig).not.toHaveBeenCalled();
+    expect(spies.setIsPicked).not.toHaveBeenCalled();
+  });
+
+  it('persists the outgoing agent routing on a switch', () => {
+    const { rerender } = mount({
+      provider: 'claude' as ProviderId,
+      model: 'opus',
+      effort: 'high' as EffortLevel,
+    });
+    rerender({ selectedAgentId: AGENT_B });
+    expect(setAgentConfig).toHaveBeenCalledWith(SESSION.id, AGENT_A, {
+      providerOverride: 'claude',
+      modelOverride: 'opus',
+      effort: 'high',
+    });
+  });
+
+  it('does not persist an outgoing agent with no routing of its own', () => {
+    const { rerender } = mount({ provider: null, model: null, effort: 'high' as EffortLevel });
+    rerender({ selectedAgentId: AGENT_B });
+    expect(setAgentConfig).not.toHaveBeenCalled();
+  });
+
+  it('restores the incoming agent routing and resets the nudges', () => {
+    useAppStore.setState({
+      sessionPhaseRuns: {
+        [SESSION.id]: [
+          { id: AGENT_B, providerOverride: 'codex', modelOverride: 'gpt', effort: 'low' },
+        ],
+      },
+    } as never);
+    const { rerender } = mount({ provider: null, model: null, effort: 'high' as EffortLevel });
+    rerender({ selectedAgentId: AGENT_B });
+    expect(spies.setIsPicked).toHaveBeenCalledWith(false);
+    expect(spies.setSelectedProviderState).toHaveBeenCalledWith('codex');
+    expect(spies.setSelectedModelState).toHaveBeenCalledWith('gpt');
+    expect(spies.setEffortState).toHaveBeenCalledWith('low');
+    expect(spies.setRightSizePending).toHaveBeenCalledWith(null);
+    expect(spies.setRightSizeDismissed).toHaveBeenCalledWith(false);
+    expect(spies.setScopePending).toHaveBeenCalledWith(null);
+    expect(spies.setScopeNudgeEventId).toHaveBeenCalledWith(null);
+  });
+
+  it('clears the routing when the incoming agent has none', () => {
+    const { rerender } = mount({ provider: null, model: null, effort: 'high' as EffortLevel });
+    rerender({ selectedAgentId: AGENT_B });
+    expect(spies.setSelectedProviderState).toHaveBeenCalledWith(null);
+    expect(spies.setSelectedModelState).toHaveBeenCalledWith(null);
+    expect(spies.setEffortState).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the workspace default verbosity', () => {
+    useAppStore.setState({
+      workspaceOverrides: { [WORKSPACE_ID]: { defaultVerbosity: 'concise' } },
+    } as never);
+    const { rerender } = mount({ provider: null, model: null, effort: 'high' as EffortLevel });
+    rerender({ selectedAgentId: AGENT_B });
+    expect(spies.setVerbosityState).toHaveBeenCalledWith('concise');
+  });
+});

--- a/apps/desktop/src/features/chat/components/ChatInput/hooks/useAgentSwitchSync.ts
+++ b/apps/desktop/src/features/chat/components/ChatInput/hooks/useAgentSwitchSync.ts
@@ -22,7 +22,7 @@ type UseAgentSwitchSyncArgs = {
   readonly setScopeNudgeEventId: (v: null) => void;
 };
 
-export function useAgentSwitchSync({
+export const useAgentSwitchSync = ({
   session,
   selectedAgentId,
   currentProviderRef,
@@ -37,7 +37,7 @@ export function useAgentSwitchSync({
   setRightSizeDismissed,
   setScopePending,
   setScopeNudgeEventId,
-}: UseAgentSwitchSyncArgs) {
+}: UseAgentSwitchSyncArgs) => {
   const storeSetAgentConfig = useAppStore((s) => s.setAgentConfig);
   const workspaceDefaultVerbosity = useAppStore(
     (s) => s.workspaceOverrides[session.workspaceId]?.defaultVerbosity ?? null,
@@ -88,4 +88,4 @@ export function useAgentSwitchSync({
     setScopePending(null);
     setScopeNudgeEventId(null);
   }, [selectedAgentId]);
-}
+};

--- a/apps/desktop/src/features/chat/components/ChatInput/hooks/useAttachments.test.ts
+++ b/apps/desktop/src/features/chat/components/ChatInput/hooks/useAttachments.test.ts
@@ -1,0 +1,184 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useRef, useState } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AgentId, SessionId } from '@goodboy/types';
+import { useAppStore } from '../../../../../store';
+import type { PendingAttachment } from '../lib';
+
+const writeAttachmentSpy = vi.hoisted(() => vi.fn(async () => 'attachments/a.png'));
+const readAttachmentSpy = vi.hoisted(() => vi.fn(async () => 'data:image/png;base64,QUJD'));
+const deleteAttachmentSpy = vi.hoisted(() => vi.fn(async () => undefined));
+
+type PendingAttachmentsArgs = {
+  readonly enabled: boolean;
+  readonly persistToDisk: (att: {
+    readonly id: string;
+    readonly fileName: string;
+    readonly dataUrl: string;
+  }) => Promise<string | null>;
+};
+
+const lastPendingArgs = vi.hoisted(() => ({ current: null as PendingAttachmentsArgs | null }));
+
+vi.mock('../../../turn', () => ({
+  writeAttachment: writeAttachmentSpy,
+  readAttachment: readAttachmentSpy,
+  deleteAttachment: deleteAttachmentSpy,
+}));
+
+vi.mock('./usePendingAttachments', () => ({
+  usePendingAttachments: (args: PendingAttachmentsArgs) => {
+    lastPendingArgs.current = args;
+    const [attachments, setAttachments] = useState<ReadonlyArray<PendingAttachment>>([]);
+    const composerRef = useRef(null);
+    const fileInputRef = useRef(null);
+    return {
+      attachments,
+      setAttachments,
+      isDragging: false,
+      composerRef,
+      fileInputRef,
+      onPaste: () => undefined,
+      onFileInputChange: () => undefined,
+      removeAttachment: () => undefined,
+    };
+  },
+}));
+
+const { useAttachments } = await import('./useAttachments');
+
+const SESSION_ID = 'session-1' as SessionId;
+const AGENT_A = 'agent-a' as AgentId;
+const showToast = vi.fn();
+
+const draft = {
+  id: 'att-1',
+  fileName: 'a.png',
+  mimeType: 'image/png',
+  relPath: 'attachments/a.png',
+};
+
+type MountParams = {
+  readonly worktree: string | null;
+  readonly providerDisconnected?: boolean;
+};
+
+const mount = ({ worktree, providerDisconnected = false }: MountParams) =>
+  renderHook(
+    ({ selectedAgentId }: { readonly selectedAgentId: AgentId | null }) =>
+      useAttachments({
+        sessionId: SESSION_ID,
+        selectedAgentId,
+        sessionWorktree: worktree,
+        providerDisconnected,
+        showToast,
+      }),
+    { initialProps: { selectedAgentId: null as AgentId | null } },
+  );
+
+beforeEach(() => {
+  writeAttachmentSpy.mockClear();
+  readAttachmentSpy.mockClear();
+  deleteAttachmentSpy.mockClear();
+  lastPendingArgs.current = null;
+  useAppStore.setState({
+    agentAttachments: {},
+    selectedAgentId: {},
+    setAgentAttachments: vi.fn(),
+    clearAgentAttachments: vi.fn(),
+  } as never);
+});
+
+describe('useAttachments', () => {
+  it('disables the composer picker when the provider is disconnected', () => {
+    mount({ worktree: '/tmp/wt', providerDisconnected: true });
+    expect(lastPendingArgs.current?.enabled).toBe(false);
+  });
+
+  it('refuses to persist to disk without a worktree', async () => {
+    mount({ worktree: null });
+    const persisted = await lastPendingArgs.current?.persistToDisk({
+      id: 'att-1',
+      fileName: 'a.png',
+      dataUrl: 'data:image/png;base64,QUJD',
+    });
+    expect(persisted).toBeNull();
+    expect(writeAttachmentSpy).not.toHaveBeenCalled();
+  });
+
+  it('writes the decoded attachment into the worktree', async () => {
+    mount({ worktree: '/tmp/wt' });
+    const persisted = await lastPendingArgs.current?.persistToDisk({
+      id: 'att-1',
+      fileName: 'a.png',
+      dataUrl: 'data:image/png;base64,QUJD',
+    });
+    expect(persisted).toBe('attachments/a.png');
+    expect(writeAttachmentSpy).toHaveBeenCalledWith({
+      worktreeDir: '/tmp/wt',
+      attachmentId: 'att-1',
+      fileName: 'a.png',
+      dataBase64: 'QUJD',
+    });
+  });
+
+  it('returns null when the write fails', async () => {
+    writeAttachmentSpy.mockRejectedValueOnce(new Error('disk full'));
+    mount({ worktree: '/tmp/wt' });
+    const persisted = await lastPendingArgs.current?.persistToDisk({
+      id: 'att-1',
+      fileName: 'a.png',
+      dataUrl: 'data:image/png;base64,QUJD',
+    });
+    expect(persisted).toBeNull();
+  });
+
+  it('restores the stored draft when an agent is selected', async () => {
+    useAppStore.setState({ agentAttachments: { [AGENT_A]: [draft] } } as never);
+    const { result, rerender } = mount({ worktree: '/tmp/wt' });
+    rerender({ selectedAgentId: AGENT_A });
+    await waitFor(() => {
+      expect(result.current.attachments.map((a) => a.id)).toEqual(['att-1']);
+    });
+    expect(readAttachmentSpy).toHaveBeenCalledWith('/tmp/wt', 'attachments/a.png');
+  });
+
+  it('drops the restored draft when the attachment cannot be read', async () => {
+    readAttachmentSpy.mockRejectedValueOnce(new Error('missing'));
+    useAppStore.setState({ agentAttachments: { [AGENT_A]: [draft] } } as never);
+    const { result, rerender } = mount({ worktree: '/tmp/wt' });
+    rerender({ selectedAgentId: AGENT_A });
+    await waitFor(() => {
+      expect(readAttachmentSpy).toHaveBeenCalled();
+    });
+    expect(result.current.attachments).toEqual([]);
+  });
+
+  it('clears the composer when no agent is selected', async () => {
+    const { result, rerender } = mount({ worktree: '/tmp/wt' });
+    rerender({ selectedAgentId: AGENT_A });
+    await waitFor(() => {
+      expect(readAttachmentSpy).not.toHaveBeenCalled();
+    });
+    rerender({ selectedAgentId: null });
+    expect(result.current.attachments).toEqual([]);
+  });
+
+  it('deletes the sent files and clears the draft for the sending agent', async () => {
+    const clearAgentAttachments = vi.fn();
+    useAppStore.setState({
+      selectedAgentId: { [SESSION_ID]: AGENT_A },
+      clearAgentAttachments,
+    } as never);
+    const { result } = mount({ worktree: '/tmp/wt' });
+    act(() => {
+      result.current.cleanupSentAttachments([
+        { ...draft, dataUrl: 'data:image/png;base64,QUJD' },
+        { ...draft, id: 'att-2', relPath: null, dataUrl: 'data:image/png;base64,QUJD' },
+      ]);
+    });
+    expect(deleteAttachmentSpy).toHaveBeenCalledTimes(1);
+    expect(deleteAttachmentSpy).toHaveBeenCalledWith('/tmp/wt', 'attachments/a.png');
+    expect(clearAgentAttachments).toHaveBeenCalledWith(AGENT_A);
+  });
+});

--- a/apps/desktop/src/features/chat/components/ChatInput/hooks/useAttachments.ts
+++ b/apps/desktop/src/features/chat/components/ChatInput/hooks/useAttachments.ts
@@ -15,13 +15,13 @@ type Params = {
   readonly showToast: (kind: ToastKind, message: string) => void;
 };
 
-export function useAttachments({
+export const useAttachments = ({
   sessionId,
   selectedAgentId,
   sessionWorktree,
   providerDisconnected,
   showToast,
-}: Params) {
+}: Params) => {
   const setAgentAttachments = useAppStore((s) => s.setAgentAttachments);
 
   const sessionWorktreeRef = useRef(sessionWorktree);
@@ -156,4 +156,4 @@ export function useAttachments({
     removeAttachment,
     cleanupSentAttachments,
   };
-}
+};

--- a/apps/desktop/src/features/chat/components/ChatInput/hooks/useChatPrefix/index.ts
+++ b/apps/desktop/src/features/chat/components/ChatInput/hooks/useChatPrefix/index.ts
@@ -27,14 +27,14 @@ type Params = {
   readonly wrapperRef: RefObject<HTMLDivElement | null>;
 };
 
-export function useChatPrefix({
+export const useChatPrefix = ({
   session,
   value,
   setValue,
   sessionWorktree,
   showToast,
   wrapperRef,
-}: Params) {
+}: Params) => {
   const workspaceSkills = useAppStore(
     useShallow((s) => s.skills[session.workspaceId] ?? EMPTY_ARRAY),
   );
@@ -188,4 +188,4 @@ export function useChatPrefix({
     onQuickActionSelect,
     dismissPopover,
   };
-}
+};

--- a/apps/desktop/src/features/chat/components/ChatInput/hooks/useMessageQueue.ts
+++ b/apps/desktop/src/features/chat/components/ChatInput/hooks/useMessageQueue.ts
@@ -14,7 +14,12 @@ type UseMessageQueueArgs = {
 
 const EMPTY: ReadonlyArray<QueuedTurn> = [];
 
-export function useMessageQueue({ agentId, isRunning, dispatchTurn, onEdit }: UseMessageQueueArgs) {
+export const useMessageQueue = ({
+  agentId,
+  isRunning,
+  dispatchTurn,
+  onEdit,
+}: UseMessageQueueArgs) => {
   const queue = useAppStore((s) =>
     agentId ? ((s.agentQueue[agentId] as ReadonlyArray<QueuedTurn> | undefined) ?? EMPTY) : EMPTY,
   );
@@ -89,4 +94,4 @@ export function useMessageQueue({ agentId, isRunning, dispatchTurn, onEdit }: Us
   }, [agentId, setAgentQueue]);
 
   return { queue, enqueue, removeQueued, editQueued, clearQueue };
-}
+};

--- a/apps/desktop/src/features/chat/components/ChatInput/hooks/useScopeNudge.test.ts
+++ b/apps/desktop/src/features/chat/components/ChatInput/hooks/useScopeNudge.test.ts
@@ -1,0 +1,160 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Session } from '@goodboy/types';
+import type { AgentKind } from '../../../../session/agent-kind';
+import type { ScopeMismatch } from '../../../utils/scope-mismatch';
+
+const insertNudgeEventSpy = vi.hoisted(() => vi.fn(async () => undefined));
+const updateNudgeEventOutcomeSpy = vi.hoisted(() => vi.fn(async () => undefined));
+const detectScopeMismatchSpy = vi.hoisted(() => vi.fn<() => ScopeMismatch | null>(() => null));
+
+vi.mock('@goodboy/db', () => ({
+  insertNudgeEvent: insertNudgeEventSpy,
+  updateNudgeEventOutcome: updateNudgeEventOutcomeSpy,
+}));
+
+vi.mock('../../../../../shared/lib/db', () => ({ tauriDatabase: {} }));
+
+vi.mock('../../../utils/scope-mismatch', () => ({
+  detectScopeMismatch: detectScopeMismatchSpy,
+}));
+
+const { useScopeNudge } = await import('./useScopeNudge');
+
+const MISMATCH = {
+  kind: 'implement-on-planner',
+  suggestedAgentKind: 'implementer',
+} as unknown as ScopeMismatch;
+
+const session = (workflowRuns: ReadonlyArray<unknown> = []): Session =>
+  ({ id: 'session-1', workflowRuns }) as unknown as Session;
+
+type Args = {
+  readonly workflowRuns?: ReadonlyArray<unknown>;
+  readonly activeAgentKind?: AgentKind | null;
+  readonly isRunning?: boolean;
+};
+
+const mount = (args: Args = {}) =>
+  renderHook(() =>
+    useScopeNudge({
+      session: session(args.workflowRuns ?? []),
+      activeAgentKind:
+        args.activeAgentKind === undefined ? ('planner' as AgentKind) : args.activeAgentKind,
+      isRunning: args.isRunning ?? false,
+    }),
+  );
+
+beforeEach(() => {
+  insertNudgeEventSpy.mockClear();
+  updateNudgeEventOutcomeSpy.mockClear();
+  detectScopeMismatchSpy.mockReset();
+  detectScopeMismatchSpy.mockReturnValue(null);
+});
+
+describe('useScopeNudge', () => {
+  it('starts with nothing pending', () => {
+    const { result } = mount();
+    expect(result.current.scopePending).toBeNull();
+    expect(result.current.scopeNudgeEventId).toBeNull();
+  });
+
+  it('does not intercept while a turn is running', async () => {
+    detectScopeMismatchSpy.mockReturnValue(MISMATCH);
+    const { result } = mount({ isRunning: true });
+    let intercepted = true;
+    await act(async () => {
+      intercepted = await result.current.checkAndInterceptScope('do it', []);
+    });
+    expect(intercepted).toBe(false);
+    expect(detectScopeMismatchSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not intercept without an active agent kind', async () => {
+    detectScopeMismatchSpy.mockReturnValue(MISMATCH);
+    const { result } = mount({ activeAgentKind: null });
+    let intercepted = true;
+    await act(async () => {
+      intercepted = await result.current.checkAndInterceptScope('do it', []);
+    });
+    expect(intercepted).toBe(false);
+  });
+
+  it('does not intercept when a workflow is attached', async () => {
+    detectScopeMismatchSpy.mockReturnValue(MISMATCH);
+    const { result } = mount({ workflowRuns: [{}] });
+    let intercepted = true;
+    await act(async () => {
+      intercepted = await result.current.checkAndInterceptScope('do it', []);
+    });
+    expect(intercepted).toBe(false);
+  });
+
+  it('does not intercept when there is no mismatch', async () => {
+    const { result } = mount();
+    let intercepted = true;
+    await act(async () => {
+      intercepted = await result.current.checkAndInterceptScope('do it', []);
+    });
+    expect(intercepted).toBe(false);
+    expect(result.current.scopePending).toBeNull();
+  });
+
+  it('intercepts a mismatch, records the nudge, and holds the draft', async () => {
+    detectScopeMismatchSpy.mockReturnValue(MISMATCH);
+    const { result } = mount();
+    let intercepted = false;
+    await act(async () => {
+      intercepted = await result.current.checkAndInterceptScope('do it', []);
+    });
+    expect(intercepted).toBe(true);
+    expect(result.current.scopePending?.content).toBe('do it');
+    expect(result.current.scopePending?.mismatch).toBe(MISMATCH);
+    expect(result.current.scopeNudgeEventId).not.toBeNull();
+    expect(insertNudgeEventSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not intercept twice while a draft is held', async () => {
+    detectScopeMismatchSpy.mockReturnValue(MISMATCH);
+    const { result } = mount();
+    await act(async () => {
+      await result.current.checkAndInterceptScope('do it', []);
+    });
+    let intercepted = true;
+    await act(async () => {
+      intercepted = await result.current.checkAndInterceptScope('again', []);
+    });
+    expect(intercepted).toBe(false);
+    expect(insertNudgeEventSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('still intercepts when recording the nudge fails', async () => {
+    detectScopeMismatchSpy.mockReturnValue(MISMATCH);
+    insertNudgeEventSpy.mockRejectedValueOnce(new Error('db down'));
+    const { result } = mount();
+    let intercepted = false;
+    await act(async () => {
+      intercepted = await result.current.checkAndInterceptScope('do it', []);
+    });
+    expect(intercepted).toBe(true);
+    expect(result.current.scopePending).not.toBeNull();
+  });
+
+  it('records an outcome once and clears the event id', async () => {
+    detectScopeMismatchSpy.mockReturnValue(MISMATCH);
+    const { result } = mount();
+    await act(async () => {
+      await result.current.checkAndInterceptScope('do it', []);
+    });
+    await act(async () => {
+      await result.current.recordScopeOutcome('accepted');
+    });
+    expect(updateNudgeEventOutcomeSpy).toHaveBeenCalledTimes(1);
+    expect(result.current.scopeNudgeEventId).toBeNull();
+
+    await act(async () => {
+      await result.current.recordScopeOutcome('accepted');
+    });
+    expect(updateNudgeEventOutcomeSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/features/chat/components/ChatInput/hooks/useScopeNudge.ts
+++ b/apps/desktop/src/features/chat/components/ChatInput/hooks/useScopeNudge.ts
@@ -18,7 +18,7 @@ type UseScopeNudgeArgs = {
   readonly isRunning: boolean;
 };
 
-export function useScopeNudge({ session, activeAgentKind, isRunning }: UseScopeNudgeArgs) {
+export const useScopeNudge = ({ session, activeAgentKind, isRunning }: UseScopeNudgeArgs) => {
   const [scopePending, setScopePending] = useState<ScopePending | null>(null);
   const [scopeNudgeEventId, setScopeNudgeEventId] = useState<string | null>(null);
 
@@ -31,9 +31,7 @@ export function useScopeNudge({ session, activeAgentKind, isRunning }: UseScopeN
         outcome,
         new Date().toISOString() as IsoDateTime,
       );
-    } catch {
-      // best-effort
-    }
+    } catch {}
     setScopeNudgeEventId(null);
   };
 
@@ -67,9 +65,7 @@ export function useScopeNudge({ session, activeAgentKind, isRunning }: UseScopeN
         outcome: null,
         outcomeTs: null,
       });
-    } catch {
-      // telemetry is best-effort
-    }
+    } catch {}
     setScopeNudgeEventId(id);
     setScopePending({ content, attachments: atts, mismatch });
     return true;
@@ -83,4 +79,4 @@ export function useScopeNudge({ session, activeAgentKind, isRunning }: UseScopeN
     recordScopeOutcome,
     checkAndInterceptScope,
   };
-}
+};

--- a/apps/desktop/src/features/chat/components/ChatInput/hooks/useSuggestionCards.test.tsx
+++ b/apps/desktop/src/features/chat/components/ChatInput/hooks/useSuggestionCards.test.tsx
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Session, SessionId } from '@goodboy/types';
+import type { SessionNudge } from '../../../../../store/types';
+import type { AgentKind } from '../../../../session/agent-kind';
+import type { ScopePending } from './useScopeNudge';
+import type { RightSizePending, RightSizeSuggestion } from './useRightSizeNudge';
+
+vi.mock('../../NudgeCard', () => ({ NudgeCard: () => null }));
+vi.mock('../../RightSizeCard', () => ({ RightSizeCard: () => null }));
+
+const { useSuggestionCards } = await import('./useSuggestionCards');
+
+const SESSION_ID = 'session-1' as SessionId;
+
+const session = (workflowRuns: ReadonlyArray<unknown>): Session =>
+  ({ id: SESSION_ID, workflowRuns }) as unknown as Session;
+
+const scopePending = {
+  content: 'ship it',
+  attachments: [],
+  mismatch: { kind: 'implement', suggestedAgentKind: 'implementer' },
+} as unknown as ScopePending;
+
+const rightSizePending = {} as RightSizePending;
+const rightSizeSuggestion = {
+  direction: 'up',
+  kind: 'cost',
+  costMultiplier: 2,
+  model: 'opus',
+} as unknown as RightSizeSuggestion;
+
+type Overrides = {
+  readonly workflowRuns?: ReadonlyArray<unknown>;
+  readonly sessionNudge?: SessionNudge | null;
+  readonly activeAgentKind?: AgentKind | null;
+  readonly scopePending?: ScopePending | null;
+  readonly rightSizePending?: RightSizePending | null;
+  readonly rightSizeSuggestion?: RightSizeSuggestion | null;
+};
+
+const noop = () => {};
+const asyncNoop = async () => undefined;
+
+const keysFor = (overrides: Overrides): ReadonlyArray<string> =>
+  useSuggestionCards({
+    session: session(overrides.workflowRuns ?? []),
+    sessionNudge: overrides.sessionNudge ?? null,
+    activeAgentKind: overrides.activeAgentKind ?? null,
+    scopePending: overrides.scopePending ?? null,
+    rightSizePending: overrides.rightSizePending ?? null,
+    rightSizeSuggestion: overrides.rightSizeSuggestion ?? null,
+    effectiveModel: 'sonnet',
+    onScopeSpawn: noop,
+    onScopeSendAnyway: noop,
+    onScopeDismiss: noop,
+    onUseSuggested: noop,
+    onKeepCurrent: noop,
+    onChangeModel: noop,
+    dismissSessionNudge: asyncNoop,
+    acceptSessionNudgeHandoff: asyncNoop,
+  }).map((suggestion) => suggestion.key);
+
+const planReady = { kind: 'plan-ready', planTitle: 'the plan' } as unknown as SessionNudge;
+
+describe('useSuggestionCards', () => {
+  it('returns nothing when no suggestion applies', () => {
+    expect(keysFor({})).toEqual([]);
+  });
+
+  it('offers the plan-ready card only when no workflow is attached', () => {
+    expect(keysFor({ sessionNudge: planReady })).toEqual(['plan-ready']);
+    expect(keysFor({ sessionNudge: planReady, workflowRuns: [{}] })).toEqual([]);
+  });
+
+  it('offers the scope card only with an active agent kind', () => {
+    expect(keysFor({ scopePending, activeAgentKind: 'planner' as AgentKind })).toEqual(['scope']);
+    expect(keysFor({ scopePending })).toEqual([]);
+  });
+
+  it('offers the right-size card only when both the pending and the suggestion exist', () => {
+    expect(keysFor({ rightSizePending, rightSizeSuggestion })).toEqual(['right-size']);
+    expect(keysFor({ rightSizePending })).toEqual([]);
+    expect(keysFor({ rightSizeSuggestion })).toEqual([]);
+  });
+
+  it('keeps plan-ready, scope, then right-size order', () => {
+    expect(
+      keysFor({
+        sessionNudge: planReady,
+        scopePending,
+        activeAgentKind: 'planner' as AgentKind,
+        rightSizePending,
+        rightSizeSuggestion,
+      }),
+    ).toEqual(['plan-ready', 'scope', 'right-size']);
+  });
+});

--- a/apps/desktop/src/features/chat/components/ChatInput/hooks/useSuggestionCards.tsx
+++ b/apps/desktop/src/features/chat/components/ChatInput/hooks/useSuggestionCards.tsx
@@ -29,7 +29,7 @@ type UseSuggestionCardsArgs = {
   readonly acceptSessionNudgeHandoff: (sessionId: SessionId) => Promise<void>;
 };
 
-export function useSuggestionCards({
+export const useSuggestionCards = ({
   session,
   sessionNudge,
   activeAgentKind,
@@ -45,7 +45,7 @@ export function useSuggestionCards({
   onChangeModel,
   dismissSessionNudge,
   acceptSessionNudgeHandoff,
-}: UseSuggestionCardsArgs): { readonly key: string; readonly node: ReactNode }[] {
+}: UseSuggestionCardsArgs): { readonly key: string; readonly node: ReactNode }[] => {
   const suggestions: { readonly key: string; readonly node: ReactNode }[] = [];
 
   if (sessionNudge?.kind === 'plan-ready' && session.workflowRuns.length === 0) {
@@ -139,4 +139,4 @@ export function useSuggestionCards({
   }
 
   return suggestions;
-}
+};

--- a/apps/desktop/src/features/chat/components/ChatInput/lib.ts
+++ b/apps/desktop/src/features/chat/components/ChatInput/lib.ts
@@ -41,18 +41,18 @@ export type QueuedTurn = {
   readonly override: TurnProviderOverride | undefined;
 };
 
-export function extFromMime(mimeType: string): string {
+export const extFromMime = (mimeType: string): string => {
   const slash = mimeType.indexOf('/');
   const ext = slash >= 0 ? mimeType.slice(slash + 1) : '';
   return ext.length > 0 && ext.length <= 5 ? ext : 'png';
-}
+};
 
-export function dataUrlToBase64(dataUrl: string): string {
+export const dataUrlToBase64 = (dataUrl: string): string => {
   const comma = dataUrl.indexOf(',');
   return comma >= 0 ? dataUrl.slice(comma + 1) : dataUrl;
-}
+};
 
-export function readFileAsDataUrl(file: File): Promise<string> {
+export const readFileAsDataUrl = (file: File): Promise<string> => {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
     reader.onload = () => {
@@ -65,21 +65,21 @@ export function readFileAsDataUrl(file: File): Promise<string> {
     reader.onerror = () => reject(reader.error ?? new Error('file read failed'));
     reader.readAsDataURL(file);
   });
-}
+};
 
-export function toAttachmentInput(a: PendingAttachment): AttachmentInput {
+export const toAttachmentInput = (a: PendingAttachment): AttachmentInput => {
   return {
     id: a.id,
     fileName: a.fileName,
     mimeType: a.mimeType,
     dataBase64: dataUrlToBase64(a.dataUrl),
   };
-}
+};
 
-export function asEffortLevel(v: string | undefined | null): EffortLevel | null {
+export const asEffortLevel = (v: string | undefined | null): EffortLevel | null => {
   return v && EFFORT_LEVELS.includes(v as EffortLevel) ? (v as EffortLevel) : null;
-}
+};
 
-export function asProvider(v: string | undefined | null): ProviderId | null {
+export const asProvider = (v: string | undefined | null): ProviderId | null => {
   return v && VALID_PROVIDERS.includes(v as ProviderId) ? (v as ProviderId) : null;
-}
+};

--- a/apps/desktop/src/features/chat/components/ChatInput/parts/QueuedMessages.tsx
+++ b/apps/desktop/src/features/chat/components/ChatInput/parts/QueuedMessages.tsx
@@ -4,7 +4,7 @@ import type { QueuedTurn } from '../lib';
 
 type QueuedItem = Pick<QueuedTurn, 'id' | 'content' | 'attachments' | 'override'>;
 
-export function QueuedMessages({
+export const QueuedMessages = ({
   items,
   canEdit,
   onEdit,
@@ -14,7 +14,7 @@ export function QueuedMessages({
   readonly canEdit: boolean;
   readonly onEdit: (id: string) => void;
   readonly onRemove: (id: string) => void;
-}) {
+}) => {
   if (items.length === 0) {
     return null;
   }
@@ -81,4 +81,4 @@ export function QueuedMessages({
       })}
     </div>
   );
-}
+};

--- a/apps/desktop/src/features/chat/components/ChatInput/parts/SuggestionStack.test.tsx
+++ b/apps/desktop/src/features/chat/components/ChatInput/parts/SuggestionStack.test.tsx
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { SuggestionStack } from './SuggestionStack';
+
+afterEach(cleanup);
+
+const item = (key: string) => ({ key, node: <span>{key}</span> });
+
+describe('SuggestionStack', () => {
+  it('renders nothing when there are no items', () => {
+    const { container } = render(<SuggestionStack items={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders only the first item and no toggle for a single item', () => {
+    render(<SuggestionStack items={[item('a')]} />);
+    expect(screen.getByText('a')).toBeTruthy();
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+
+  it('hides the rest behind a toggle that counts them', () => {
+    render(<SuggestionStack items={[item('a'), item('b'), item('c')]} />);
+    expect(screen.queryByText('b')).toBeNull();
+    expect(screen.getByRole('button').textContent).toBe('+2 more suggestions');
+  });
+
+  it('uses the singular label for exactly one hidden item', () => {
+    render(<SuggestionStack items={[item('a'), item('b')]} />);
+    expect(screen.getByRole('button').textContent).toBe('+1 more suggestion');
+  });
+
+  it('expands and collapses the rest', () => {
+    render(<SuggestionStack items={[item('a'), item('b')]} />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(screen.getByText('b')).toBeTruthy();
+    expect(screen.getByRole('button').textContent).toBe('show fewer suggestions');
+    fireEvent.click(screen.getByRole('button'));
+    expect(screen.queryByText('b')).toBeNull();
+  });
+});

--- a/apps/desktop/src/features/chat/components/ChatInput/parts/SuggestionStack.tsx
+++ b/apps/desktop/src/features/chat/components/ChatInput/parts/SuggestionStack.tsx
@@ -1,10 +1,10 @@
 import { useState, type ReactNode } from 'react';
 
-export function SuggestionStack({
+export const SuggestionStack = ({
   items,
 }: {
   items: ReadonlyArray<{ readonly key: string; readonly node: ReactNode }>;
-}) {
+}) => {
   const [expanded, setExpanded] = useState(false);
 
   if (items.length === 0) {
@@ -32,4 +32,4 @@ export function SuggestionStack({
       )}
     </div>
   );
-}
+};

--- a/apps/desktop/src/features/context/components/ContextPanel/lib.ts
+++ b/apps/desktop/src/features/context/components/ContextPanel/lib.ts
@@ -7,7 +7,7 @@ export type FilesTouchedShape = {
   readonly deletions: number;
 };
 
-export function normalizeFilesSlot(slot: ContextSlot, workingDir: string | null): ContextSlot {
+export const normalizeFilesSlot = (slot: ContextSlot, workingDir: string | null): ContextSlot => {
   if (!workingDir || slot.value.length === 0) return slot;
   const root = workingDir.endsWith('/') ? workingDir : `${workingDir}/`;
   const normalized = slot.value
@@ -15,4 +15,4 @@ export function normalizeFilesSlot(slot: ContextSlot, workingDir: string | null)
     .map((p) => (p.startsWith(root) ? p.slice(root.length) : p))
     .join('\n');
   return normalized === slot.value ? slot : { ...slot, value: normalized };
-}
+};

--- a/apps/desktop/src/features/context/components/ContextPanel/strips/GoalAttachmentsStrip.tsx
+++ b/apps/desktop/src/features/context/components/ContextPanel/strips/GoalAttachmentsStrip.tsx
@@ -7,7 +7,7 @@ import { AttachmentChip } from '../../../../attachments/components/AttachmentChi
 import { useAttachmentThumbnail } from '../../../../attachments/hooks/useAttachmentThumbnail';
 import { ATTACHMENT_KIND_ROUTING } from '../../../../providers/attachment-routing';
 
-export function GoalAttachmentsStrip({ owner }: { readonly owner: GoalAttachmentOwner }) {
+export const GoalAttachmentsStrip = ({ owner }: { readonly owner: GoalAttachmentOwner }) => {
   const loadGoalAttachments = useAppStore((s) => s.loadGoalAttachments);
   const removeGoalAttachment = useAppStore((s) => s.removeGoalAttachment);
   const attachments = useAppStore((s) =>
@@ -48,7 +48,7 @@ export function GoalAttachmentsStrip({ owner }: { readonly owner: GoalAttachment
       </div>
     </div>
   );
-}
+};
 
 const GoalAttachmentChip = ({
   attachment,

--- a/apps/desktop/src/features/context/components/ContextPanel/strips/PendingResolutionsStrip.test.tsx
+++ b/apps/desktop/src/features/context/components/ContextPanel/strips/PendingResolutionsStrip.test.tsx
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { PendingResolution, SessionId } from '@goodboy/types';
+import { useAppStore } from '../../../../../store';
+import { PendingResolutionsStrip } from './PendingResolutionsStrip';
+
+const SESSION_ID = 'session-1' as SessionId;
+
+const loadPendingResolutions = vi.fn(async () => undefined);
+const pushAllResolutions = vi.fn(async () => undefined);
+
+const seed = (count: number) => {
+  const pending = Array.from(
+    { length: count },
+    (_, index) => ({ id: `pr-${index}` }) as unknown as PendingResolution,
+  );
+  useAppStore.setState({
+    sessionPendingResolutions: { [SESSION_ID]: pending },
+    loadPendingResolutions,
+    pushAllResolutions,
+  });
+};
+
+beforeEach(() => {
+  loadPendingResolutions.mockClear();
+  pushAllResolutions.mockClear();
+});
+
+afterEach(cleanup);
+
+describe('PendingResolutionsStrip', () => {
+  it('renders nothing when nothing is queued', () => {
+    seed(0);
+    const { container } = render(<PendingResolutionsStrip sessionId={SESSION_ID} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('loads the queue for the session on mount', () => {
+    seed(0);
+    render(<PendingResolutionsStrip sessionId={SESSION_ID} />);
+    expect(loadPendingResolutions).toHaveBeenCalledWith(SESSION_ID);
+  });
+
+  it('pluralizes the queued comment count', () => {
+    seed(1);
+    render(<PendingResolutionsStrip sessionId={SESSION_ID} />);
+    expect(screen.getByText('Push & resolve 1 comment')).toBeTruthy();
+    cleanup();
+    seed(3);
+    render(<PendingResolutionsStrip sessionId={SESSION_ID} />);
+    expect(screen.getByText('Push & resolve 3 comments')).toBeTruthy();
+  });
+
+  it('pushes every queued resolution once per click', async () => {
+    seed(2);
+    render(<PendingResolutionsStrip sessionId={SESSION_ID} />);
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button'));
+    });
+    expect(pushAllResolutions).toHaveBeenCalledWith(SESSION_ID);
+    expect(pushAllResolutions).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/features/context/components/ContextPanel/strips/PendingResolutionsStrip.test.tsx
+++ b/apps/desktop/src/features/context/components/ContextPanel/strips/PendingResolutionsStrip.test.tsx
@@ -7,7 +7,7 @@ import { PendingResolutionsStrip } from './PendingResolutionsStrip';
 const SESSION_ID = 'session-1' as SessionId;
 
 const loadPendingResolutions = vi.fn(async () => undefined);
-const pushAllResolutions = vi.fn(async () => undefined);
+const pushAllResolutions = vi.fn(async () => ({ pushed: true, resolved: 0, failed: 0 }));
 
 const seed = (count: number) => {
   const pending = Array.from(

--- a/apps/desktop/src/features/context/components/ContextPanel/strips/PendingResolutionsStrip.tsx
+++ b/apps/desktop/src/features/context/components/ContextPanel/strips/PendingResolutionsStrip.tsx
@@ -4,7 +4,7 @@ import { cn } from '@goodboy/ui';
 import type { SessionId } from '@goodboy/types';
 import { EMPTY_ARRAY, useAppStore } from '../../../../../store';
 
-export function PendingResolutionsStrip({ sessionId }: { sessionId: SessionId }) {
+export const PendingResolutionsStrip = ({ sessionId }: { sessionId: SessionId }) => {
   const pending = useAppStore((s) => s.sessionPendingResolutions[sessionId] ?? EMPTY_ARRAY);
   const loadPendingResolutions = useAppStore((s) => s.loadPendingResolutions);
   const pushAllResolutions = useAppStore((s) => s.pushAllResolutions);
@@ -47,4 +47,4 @@ export function PendingResolutionsStrip({ sessionId }: { sessionId: SessionId })
       <ArrowUpRight size={12} aria-hidden className="shrink-0 opacity-70" />
     </button>
   );
-}
+};

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/lib.ts
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/lib.ts
@@ -2,14 +2,14 @@ import type { Agent, Workflow } from '@goodboy/types';
 import { WORKFLOW_LIBRARY } from '@goodboy/core';
 import { agentThreadIds } from '../../../session/agentThreadIds';
 
-export function workflowKindName(workflow: Workflow): string {
+export const workflowKindName = (workflow: Workflow): string => {
   const raw = workflow.name.trim();
   if (!raw) {
     return 'custom';
   }
   const match = WORKFLOW_LIBRARY.find((entry) => entry.name.toLowerCase() === raw.toLowerCase());
   return match ? match.name.toLowerCase() : raw;
-}
+};
 
 export const pluralize = (count: number, singular: string) =>
   `${count} ${singular}${count === 1 ? '' : 's'}`;

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/CollapsedSummary.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/CollapsedSummary.test.tsx
@@ -1,0 +1,18 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { CollapsedSummary } from './CollapsedSummary';
+
+afterEach(cleanup);
+
+describe('CollapsedSummary', () => {
+  it('renders the text in a paragraph', () => {
+    render(<CollapsedSummary text="3 agents" />);
+    const node = screen.getByText('3 agents');
+    expect(node.tagName).toBe('P');
+  });
+
+  it('renders an empty paragraph for empty text', () => {
+    const { container } = render(<CollapsedSummary text="" />);
+    expect(container.querySelector('p')?.textContent).toBe('');
+  });
+});

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/CollapsedSummary.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/CollapsedSummary.tsx
@@ -1,3 +1,3 @@
-export function CollapsedSummary({ text }: { readonly text: string }) {
+export const CollapsedSummary = ({ text }: { readonly text: string }) => {
   return <p className="pb-1 pl-2 text-2xs text-muted-foreground/60">{text}</p>;
-}
+};

--- a/packages/db/src/migrations/registry.test.ts
+++ b/packages/db/src/migrations/registry.test.ts
@@ -17,6 +17,29 @@ const fileVersions = (): ReadonlyArray<number> =>
     .map((match) => Number(match[1]))
     .sort((a, b) => a - b);
 
+const SAMPLED_INTERMEDIATE_VERSIONS = 12;
+
+type SampleIntermediateCountsParams = {
+  readonly total: number;
+  readonly sampleSize: number;
+};
+
+const sampleIntermediateCounts = ({
+  total,
+  sampleSize,
+}: SampleIntermediateCountsParams): ReadonlyArray<number> => {
+  const highest = total - 1;
+  if (highest < 1) {
+    return [];
+  }
+  const step = Math.max(1, Math.ceil(highest / sampleSize));
+  const sampled = new Set<number>([1, highest]);
+  for (let count = 1; count <= highest; count += step) {
+    sampled.add(count);
+  }
+  return [...sampled].sort((a, b) => a - b);
+};
+
 const schemaOf = async (db: Database): Promise<ReadonlyArray<string>> => {
   const rows = await db.select<{ readonly sql: string | null }>(
     "SELECT sql FROM sqlite_master WHERE sql IS NOT NULL AND name NOT LIKE 'sqlite_%'",
@@ -66,12 +89,26 @@ describe('migration convergence', () => {
     expect(result.applied).toEqual([]);
   });
 
-  it('reaches the fresh-install schema from every intermediate version', async () => {
+  it('samples the oldest and the newest intermediate version', () => {
+    const counts = sampleIntermediateCounts({
+      total: migrations.length,
+      sampleSize: SAMPLED_INTERMEDIATE_VERSIONS,
+    });
+    expect(counts.at(0)).toBe(1);
+    expect(counts.at(-1)).toBe(migrations.length - 1);
+    expect(counts.length).toBeLessThanOrEqual(SAMPLED_INTERMEDIATE_VERSIONS + 1);
+  });
+
+  it('reaches the fresh-install schema from sampled intermediate versions', async () => {
     const fresh = makeTestDatabase();
     await migrate(fresh);
     const target = await schemaOf(fresh);
 
-    for (let count = 1; count < migrations.length; count += 1) {
+    const counts = sampleIntermediateCounts({
+      total: migrations.length,
+      sampleSize: SAMPLED_INTERMEDIATE_VERSIONS,
+    });
+    for (const count of counts) {
       const upgraded = makeTestDatabase();
       await migrate(upgraded, migrations.slice(0, count));
       const result = await migrate(upgraded);

--- a/packages/db/src/queries/session-workflow.ts
+++ b/packages/db/src/queries/session-workflow.ts
@@ -90,7 +90,7 @@ const toStop = ({ message, kind }: StopColumns): WorkflowOrchestrationStop | nul
   return { kind: kind as WorkflowOrchestrationStopKind, message };
 };
 
-export function toWorkflowRun(row: SessionWorkflowRow): WorkflowRun {
+export const toWorkflowRun = (row: SessionWorkflowRow): WorkflowRun => {
   const orchestrationStop = toStop({
     message: row.orchestration_error,
     kind: row.orchestration_stop_kind,
@@ -129,7 +129,7 @@ export function toWorkflowRun(row: SessionWorkflowRow): WorkflowRun {
     ...(row.discarded_at != null && { discardedAt: row.discarded_at as IsoDateTime }),
     ...(createdAt != null && { createdAt }),
   };
-}
+};
 
 export const listWorkflowsForSession = async (
   db: Database,


### PR DESCRIPTION
Two refactor slices. No behavior added, no assertion weakened.

## S1 (DEBT-A): the migration convergence check stops being quadratic

`packages/db/src/migrations/registry.test.ts`

The convergence check built one database per intermediate version and applied every migration to each. At 111 migrations that is 110 databases and 12,210 applications, and the cost grows with the square of the migration count, so every future release pays more. Measured at 5.97s of test time against a 30,000ms budget, and it went red once this release under concurrent load. m111 did not cause it.

It now samples a deterministic spread of intermediate versions, always including the oldest (1) and the newest (n-1): 13 databases and 1,443 applications at 111 migrations, linear from here on.

**Per-sample assertions are unchanged.** Each sampled database still asserts the exact applied-version list and a full `sqlite_master` schema comparison against a fresh install. What is lost is the untested intermediate versions between samples; that is the declared trade, and it is the trade the release audit proposed.

The registry contract itself was not touched. Proven still red under mutation:

| mutation | failing tests |
| --- | --- |
| duplicate version (111 registered as 110) | 4 |
| version gap (111 skipped, 112 registered) | 2 |
| filename disagrees with the registered version | 1 |

The 30,000ms budget is kept as-is: at 0.77s it now has 40x headroom, which is the point.

Result: 5.97s to 0.77s.

## S2 (DEBT-B): the last function-declaration exports are retired

`AGENTS.md` forbids default exports and `export function`; the convention is named `export const` arrows. Twenty-one declaration sites across sixteen files had never been converted. They are now, and the pattern is extinct in source. The only remaining default exports are `vite.config.ts` and `vitest.config.ts`, where the tooling requires them:

```
grep -rn "export function \|export default " --include='*.ts' --include='*.tsx' apps packages
apps/desktop/vitest.config.ts:4:export default defineConfig({
apps/desktop/vite.config.ts:8:export default defineConfig({
```

**Declaration form only.** Signatures, parameter shapes, bodies, and export names are byte-identical, so every call site and every existing test is untouched. Two forbidden comments inside `catch` blocks in `useScopeNudge` went with them. Parameter-shape convergence (the positional and inline-object parameters several of these still declare) is deliberately not in this slice; see below.

Eight of the sixteen files had no test at all. They are pinned first, in their own commit, so the conversion diff has something to prove itself against: `KeepAliveWorkSurface`, `CollapsedSummary`, `PendingResolutionsStrip`, `SuggestionStack`, `useSuggestionCards`, `useScopeNudge`, `useAgentSwitchSync`, `useAttachments`. 48 assertions, no production code in that commit.

## Swapped out, with the reason

The release audit sent one more item here by name: roughly twenty store test mocks declare `delete` where `PrCacheStore` and the Tauri store both implement `invalidate`, which would not catch a missing invalidate call.

It is 22 sites, all real. It was swapped out because correcting them polishes a mock of an abstraction that has no production caller at all:

- `getPrForBranch` and `invalidatePrCache` (`packages/core/src/github/cache.ts`) are exported through the `@goodboy/core` barrel and called from nothing but tests.
- `createTauriPrCacheStore` (`apps/desktop/src/features/github/github.ts:379`) is the only implementation of `PrCacheStore` and is imported by nothing.
- The `github_pr_cache` table is live, but `store/slices/github/refreshSessionPr.ts` writes it directly through `@goodboy/db`, bypassing the abstraction entirely.

So a missing invalidate call cannot exist to be caught, and fixing the mock would make a dead layer look maintained. Backlogged instead as its own item, which subsumes it.

## Backlogged, not fixed here

- Remove the orphaned PR-cache abstraction (`PrCacheStore`, `PrCacheDeps`, `DEFAULT_PR_CACHE_TTL_MS`, `toCachedPullRequest`, `getPrForBranch`, `invalidatePrCache`, `createTauriPrCacheStore`, their barrel entries, their tests, and the 22 mock lines). Cascades into `packages/db`, so it wants its own slice and its own review.
- Parameter-shape convergence on the files S2 touched: `normalizeFilesSlot`, `extFromMime`, `dataUrlToBase64`, `readFileAsDataUrl`, `toAttachmentInput`, `asEffortLevel`, `asProvider`, `workflowKindName`, and `toWorkflowRun` still take positional parameters, and `PendingResolutionsStrip` and `SuggestionStack` still take inline-object props. Changing them changes call sites, which is a wider diff than a declaration-form sweep should carry.
- `apps/desktop/src/features/permissions/components/DiffViewerDialog/highlight/index.ts` holds 19 `if/else` branches, the densest remaining pocket of that forbidden pattern.
- The suite-runner cap the backlog wants raised is declared nowhere: not `turbo.json`, not `apps/desktop/vitest.config.ts`, not `ci.yml`, not `docs/testing.md`. Vitest's own default is what runs. That backlog line is a documentation defect, not a code one.

No `design-system` marker on either slice: the steward's one named duplicate this release is the two components both called `HeaderBand`, and that file belongs to a live sibling.

## Checks

- `pnpm exec turbo run test --force`: 655 files, 5588 tests, all passing, `0 cached` on all 4 tasks.
- `pnpm exec turbo run typecheck --force`: 5 of 5, `0 cached`.
- `pnpm knip --include files,duplicates,unlisted`: exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
