### PR TITLE
fix(desktop): stop the boot from failing silently

### DIFF
--- a/apps/desktop/index.html
+++ b/apps/desktop/index.html
@@ -13,6 +13,43 @@
         background: oklch(0.915 0.006 250);
         color-scheme: light;
       }
+      #boot-shell {
+        align-items: center;
+        color: #e6e8ec;
+        display: flex;
+        flex-direction: column;
+        font-family: system-ui, sans-serif;
+        gap: 0.5rem;
+        inset: 0;
+        justify-content: center;
+        position: fixed;
+      }
+      #boot-shell strong {
+        font-size: 1.125rem;
+      }
+      #boot-shell span {
+        font-size: 0.75rem;
+      }
+      #boot-shell small {
+        color: #92969e;
+        font-size: 0.625rem;
+      }
+      html[data-theme='light'] #boot-shell {
+        color: #303238;
+      }
+      html[data-theme='light'] #boot-shell small {
+        color: #666a72;
+      }
+      @media (prefers-reduced-motion: no-preference) {
+        #boot-shell small {
+          animation: boot-shell-pulse 2s ease-in-out infinite;
+        }
+      }
+      @keyframes boot-shell-pulse {
+        50% {
+          opacity: 0.45;
+        }
+      }
     </style>
     <script>
       (function () {
@@ -25,6 +62,11 @@
     </script>
   </head>
   <body class="bg-background text-foreground antialiased">
+    <div id="boot-shell">
+      <strong>Goodboy</strong>
+      <span>workspace orchestrator for coding agents</span>
+      <small>starting up</small>
+    </div>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/apps/desktop/index.html
+++ b/apps/desktop/index.html
@@ -22,6 +22,7 @@
         gap: 0.5rem;
         inset: 0;
         justify-content: center;
+        pointer-events: none;
         position: fixed;
       }
       #boot-shell strong {

--- a/apps/desktop/src-tauri/src/boot_breadcrumb.rs
+++ b/apps/desktop/src-tauri/src/boot_breadcrumb.rs
@@ -160,6 +160,23 @@ mod tests {
         ))
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn the_sink_file_is_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = temp_path("permissions");
+        fs::create_dir_all(&directory).expect("create temp directory");
+        let path = directory.join(BREADCRUMB_FILE);
+        write_line_to(&path, "0 launch process-start start\n").expect("append breadcrumb");
+        let mode = fs::metadata(&path)
+            .expect("read breadcrumb metadata")
+            .permissions()
+            .mode();
+        assert_eq!(mode & 0o777, 0o600);
+        fs::remove_dir_all(directory).expect("remove temp directory");
+    }
+
     #[test]
     fn allowlisted_phase_passes() {
         assert!(validate_phase("process-start").is_ok());

--- a/apps/desktop/src-tauri/src/boot_breadcrumb.rs
+++ b/apps/desktop/src-tauri/src/boot_breadcrumb.rs
@@ -1,0 +1,203 @@
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use thiserror::Error;
+
+const APP_DIR: &str = ".goodboy";
+const BREADCRUMB_FILE: &str = "boot-breadcrumbs.log";
+const MAX_FILE_SIZE: u64 = 64 * 1024;
+const PHASES: [&str; 13] = [
+    "process-start",
+    "window-created",
+    "webview-attached",
+    "pending",
+    "migrating",
+    "loading-settings",
+    "detecting-cli",
+    "loading-workspaces",
+    "restoring-session",
+    "ready",
+    "error",
+    "retry",
+    "slow",
+];
+const OUTCOMES: [&str; 5] = ["start", "ok", "error", "slow", "timeout"];
+
+static LAUNCH_ID: OnceLock<String> = OnceLock::new();
+static WRITE_LOCK: Mutex<()> = Mutex::new(());
+
+#[derive(Debug, Error)]
+pub enum BreadcrumbError {
+    #[error("invalid breadcrumb phase")]
+    Phase,
+    #[error("home directory not available")]
+    NoHomeDir,
+    #[error("breadcrumb io error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+crate::util::impl_error_serialize!(BreadcrumbError);
+
+impl BreadcrumbError {
+    fn kind(&self) -> &'static str {
+        match self {
+            BreadcrumbError::Phase => "phase",
+            BreadcrumbError::NoHomeDir => "no_home_dir",
+            BreadcrumbError::Io(_) => "io",
+        }
+    }
+}
+
+pub fn record(phase: &str, detail: Option<&str>) {
+    let _ = record_result(phase, detail);
+}
+
+#[tauri::command(async)]
+pub fn boot_breadcrumb(phase: String, detail: Option<String>) -> Result<(), BreadcrumbError> {
+    record_result(&phase, detail.as_deref())
+}
+
+fn record_result(phase: &str, detail: Option<&str>) -> Result<(), BreadcrumbError> {
+    validate_phase(phase)?;
+    let path = resolve_path()?;
+    let line = format_line(phase, sanitize_detail(detail));
+    write_line_to(&path, &line)?;
+    Ok(())
+}
+
+fn validate_phase(phase: &str) -> Result<(), BreadcrumbError> {
+    if PHASES.contains(&phase) {
+        return Ok(());
+    }
+    Err(BreadcrumbError::Phase)
+}
+
+fn sanitize_detail(detail: Option<&str>) -> Option<&str> {
+    let value = detail?;
+    if value.is_empty() {
+        return None;
+    }
+    let is_valid = value.split(',').all(|token| {
+        if OUTCOMES.contains(&token) {
+            return true;
+        }
+        let Some(digits) = token.strip_prefix("ms=") else {
+            return false;
+        };
+        !digits.is_empty() && digits.len() <= 9 && digits.bytes().all(|byte| byte.is_ascii_digit())
+    });
+    if is_valid {
+        return Some(value);
+    }
+    None
+}
+
+fn resolve_path() -> Result<PathBuf, BreadcrumbError> {
+    let home = dirs::home_dir().ok_or(BreadcrumbError::NoHomeDir)?;
+    let directory = home.join(APP_DIR);
+    fs::create_dir_all(&directory)?;
+    Ok(directory.join(BREADCRUMB_FILE))
+}
+
+fn unix_millis() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+}
+
+fn launch_id() -> &'static str {
+    LAUNCH_ID
+        .get_or_init(|| format!("{}-{}", unix_millis(), std::process::id()))
+        .as_str()
+}
+
+fn format_line(phase: &str, detail: Option<&str>) -> String {
+    match detail {
+        Some(value) => format!("{} {} {} {}\n", unix_millis(), launch_id(), phase, value),
+        None => format!("{} {} {}\n", unix_millis(), launch_id(), phase),
+    }
+}
+
+fn write_line_to(path: &Path, line: &str) -> Result<(), std::io::Error> {
+    let _guard = WRITE_LOCK.lock().unwrap_or_else(|error| error.into_inner());
+    if path.metadata().map(|metadata| metadata.len()).unwrap_or(0) > MAX_FILE_SIZE {
+        let rotated = PathBuf::from(format!("{}.1", path.display()));
+        if rotated.exists() {
+            fs::remove_file(&rotated)?;
+        }
+        fs::rename(path, rotated)?;
+    }
+    let mut options = OpenOptions::new();
+    options.create(true).append(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options.open(path)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        file.set_permissions(fs::Permissions::from_mode(0o600))?;
+    }
+    file.write_all(line.as_bytes())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_path(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "goodboy-breadcrumb-{}-{}-{}",
+            name,
+            std::process::id(),
+            unix_millis()
+        ))
+    }
+
+    #[test]
+    fn allowlisted_phase_passes() {
+        assert!(validate_phase("process-start").is_ok());
+    }
+
+    #[test]
+    fn non_allowlisted_phase_is_rejected() {
+        assert!(matches!(
+            validate_phase("secret"),
+            Err(BreadcrumbError::Phase)
+        ));
+    }
+
+    #[test]
+    fn valid_detail_survives() {
+        assert_eq!(sanitize_detail(Some("ms=1234,ok")), Some("ms=1234,ok"));
+    }
+
+    #[test]
+    fn unsafe_detail_is_dropped() {
+        assert_eq!(
+            sanitize_detail(Some("--dangerously-skip x=/Users/me/tok")),
+            None
+        );
+    }
+
+    #[test]
+    fn rotates_past_size_cap() {
+        let directory = temp_path("rotation");
+        fs::create_dir_all(&directory).expect("create temp directory");
+        let path = directory.join(BREADCRUMB_FILE);
+        fs::write(&path, vec![b'x'; MAX_FILE_SIZE as usize + 1]).expect("write oversized file");
+        write_line_to(&path, "new line\n").expect("append breadcrumb");
+        assert_eq!(
+            fs::read_to_string(&path).expect("read breadcrumb"),
+            "new line\n"
+        );
+        assert!(PathBuf::from(format!("{}.1", path.display())).exists());
+        fs::remove_dir_all(directory).expect("remove temp directory");
+    }
+}

--- a/apps/desktop/src-tauri/src/boot_breadcrumb.rs
+++ b/apps/desktop/src-tauri/src/boot_breadcrumb.rs
@@ -60,12 +60,14 @@ pub fn boot_breadcrumb(phase: String, detail: Option<String>) -> Result<(), Brea
     record_result(&phase, detail.as_deref())
 }
 
-fn record_result(phase: &str, detail: Option<&str>) -> Result<(), BreadcrumbError> {
+fn record_to(path: &Path, phase: &str, detail: Option<&str>) -> Result<(), BreadcrumbError> {
     validate_phase(phase)?;
-    let path = resolve_path()?;
-    let line = format_line(phase, sanitize_detail(detail));
-    write_line_to(&path, &line)?;
+    write_line_to(path, &format_line(phase, sanitize_detail(detail)))?;
     Ok(())
+}
+
+fn record_result(phase: &str, detail: Option<&str>) -> Result<(), BreadcrumbError> {
+    record_to(&resolve_path()?, phase, detail)
 }
 
 fn validate_phase(phase: &str) -> Result<(), BreadcrumbError> {
@@ -174,6 +176,40 @@ mod tests {
             .permissions()
             .mode();
         assert_eq!(mode & 0o777, 0o600);
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o644))
+            .expect("relax breadcrumb permissions");
+        write_line_to(&path, "0 launch ready ok\n").expect("append second breadcrumb");
+        let mode = fs::metadata(&path)
+            .expect("read updated breadcrumb metadata")
+            .permissions()
+            .mode();
+        assert_eq!(mode & 0o777, 0o600);
+        fs::remove_dir_all(directory).expect("remove temp directory");
+    }
+
+    #[test]
+    fn record_to_writes_one_composed_line() {
+        let directory = temp_path("record");
+        fs::create_dir_all(&directory).expect("create temp directory");
+        let path = directory.join(BREADCRUMB_FILE);
+        record_to(&path, "migrating", Some("ms=12,ok")).expect("record breadcrumb");
+        let contents = fs::read_to_string(&path).expect("read breadcrumb");
+        let lines: Vec<&str> = contents.lines().collect();
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0].split_whitespace().nth(3), Some("ms=12,ok"));
+        fs::remove_dir_all(directory).expect("remove temp directory");
+    }
+
+    #[test]
+    fn record_to_rejects_a_phase_outside_the_allowlist() {
+        let directory = temp_path("record-rejected");
+        fs::create_dir_all(&directory).expect("create temp directory");
+        let path = directory.join(BREADCRUMB_FILE);
+        assert!(matches!(
+            record_to(&path, "secret", None),
+            Err(BreadcrumbError::Phase)
+        ));
+        assert!(!path.exists());
         fs::remove_dir_all(directory).expect("remove temp directory");
     }
 
@@ -209,12 +245,17 @@ mod tests {
         fs::create_dir_all(&directory).expect("create temp directory");
         let path = directory.join(BREADCRUMB_FILE);
         fs::write(&path, vec![b'x'; MAX_FILE_SIZE as usize + 1]).expect("write oversized file");
+        let rotated = PathBuf::from(format!("{}.1", path.display()));
+        fs::write(&rotated, "stale\n").expect("write stale rotated file");
         write_line_to(&path, "new line\n").expect("append breadcrumb");
         assert_eq!(
             fs::read_to_string(&path).expect("read breadcrumb"),
             "new line\n"
         );
-        assert!(PathBuf::from(format!("{}.1", path.display())).exists());
+        assert!(rotated.exists());
+        let rotated_contents = fs::read(&rotated).expect("read rotated breadcrumb");
+        assert_ne!(rotated_contents, b"stale\n");
+        assert_eq!(rotated_contents.len(), MAX_FILE_SIZE as usize + 1);
         fs::remove_dir_all(directory).expect("remove temp directory");
     }
 }

--- a/apps/desktop/src-tauri/src/db.rs
+++ b/apps/desktop/src-tauri/src/db.rs
@@ -102,14 +102,14 @@ pub struct ExecResult {
     pub rows_affected: i64,
 }
 
-#[tauri::command]
+#[tauri::command(async)]
 pub fn db_exec(state: State<'_, Db>, sql: String) -> Result<(), DbError> {
     let conn = state.0.lock().map_err(|_| DbError::Poisoned)?;
     conn.execute_batch(&sql)?;
     Ok(())
 }
 
-#[tauri::command]
+#[tauri::command(async)]
 pub fn db_execute(
     state: State<'_, Db>,
     sql: String,
@@ -123,7 +123,7 @@ pub fn db_execute(
     Ok(ExecResult { rows_affected })
 }
 
-#[tauri::command]
+#[tauri::command(async)]
 pub fn db_wipe(state: State<'_, Db>) -> Result<(), DbError> {
     // Drop every user table + schema_version so the next runDbMigrations call
     // replays the chain from m001. Done in-place via SQL so the TS side
@@ -146,7 +146,7 @@ pub fn db_wipe(state: State<'_, Db>) -> Result<(), DbError> {
     Ok(())
 }
 
-#[tauri::command]
+#[tauri::command(async)]
 pub fn db_select(
     state: State<'_, Db>,
     sql: String,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 mod attachment;
 mod aux_spawn;
 mod bitbucket;
+mod boot_breadcrumb;
 mod bridge;
 mod budget;
 mod config_export;
@@ -69,6 +70,7 @@ fn drain_child_processes(app: &tauri::AppHandle) {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    boot_breadcrumb::record("process-start", Some("start"));
     #[cfg(target_os = "macos")]
     suppress_webkit_media_remote();
     let database = db::open().expect("failed to open Goodboy database");
@@ -137,6 +139,7 @@ pub fn run() {
         .manage(bitbucket_token_cache)
         .manage(slack_token_cache)
         .setup(move |app| {
+            use tauri::Manager;
             providers::spawn_startup_detection(app.handle().clone(), detection_opener);
             #[cfg(desktop)]
             app.handle()
@@ -147,6 +150,14 @@ pub fn run() {
                         .level(log::LevelFilter::Info)
                         .build(),
                 )?;
+            }
+            let windows = app.webview_windows();
+            if !windows.is_empty() {
+                boot_breadcrumb::record("window-created", Some("ok"));
+                for window in windows.values() {
+                    let _ = window.show();
+                }
+                boot_breadcrumb::record("webview-attached", Some("ok"));
             }
             Ok(())
         })
@@ -162,6 +173,7 @@ pub fn run() {
             explore::explore_list,
             explore::explore_read,
             explore::explore_open,
+            boot_breadcrumb::boot_breadcrumb,
             db::db_exec,
             db::db_execute,
             db::db_select,

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -17,9 +17,11 @@
         "height": 900,
         "minWidth": 1024,
         "minHeight": 700,
+        "backgroundColor": "#202225",
         "center": true,
         "resizable": true,
-        "fullscreen": false
+        "fullscreen": false,
+        "visible": false
       }
     ],
     "security": {

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -78,6 +78,7 @@ import { useGithubConnection } from './features/integrations/github/useGithubCon
 import { resolveSessionRepo } from './store/slices/worktrees/resolveSessionRepo';
 import { resolveOpenDiffViewerEvent } from './store/slices/session-view/openDiffViewerEvent';
 import { useSessionSidebarVisibility } from './features/workspace/hooks/useSessionSidebarVisibility';
+import { resetHydrateMemo } from './store/slices/boot/hydrate';
 
 const KEEP_ALIVE_CAP = 5;
 
@@ -748,7 +749,10 @@ export const App = () => {
       <BootSplash
         phase={bootPhase}
         error={error}
-        onRetry={() => void hydrate()}
+        onRetry={() => {
+          resetHydrateMemo();
+          void hydrate();
+        }}
         onFinished={() => setSplashFinished(true)}
       />
     );

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -78,12 +78,12 @@ import { useGithubConnection } from './features/integrations/github/useGithubCon
 import { resolveSessionRepo } from './store/slices/worktrees/resolveSessionRepo';
 import { resolveOpenDiffViewerEvent } from './store/slices/session-view/openDiffViewerEvent';
 import { useSessionSidebarVisibility } from './features/workspace/hooks/useSessionSidebarVisibility';
-import { resetHydrateMemo } from './store/slices/boot/hydrate';
 
 const KEEP_ALIVE_CAP = 5;
 
 export const App = () => {
   const hydrate = useAppStore((s) => s.hydrate);
+  const retryHydrate = useAppStore((s) => s.retryHydrate);
   const checkForUpdates = useAppStore((s) => s.checkForUpdates);
   const hydrated = useAppStore((s) => s.hydrated);
   const bootPhase = useAppStore((s) => s.bootPhase);
@@ -749,10 +749,7 @@ export const App = () => {
       <BootSplash
         phase={bootPhase}
         error={error}
-        onRetry={() => {
-          resetHydrateMemo();
-          void hydrate();
-        }}
+        onRetry={retryHydrate}
         onFinished={() => setSplashFinished(true)}
       />
     );

--- a/apps/desktop/src/app/components/BootSplash/BootSlowNotice.tsx
+++ b/apps/desktop/src/app/components/BootSplash/BootSlowNotice.tsx
@@ -1,22 +1,32 @@
+import { useCallback, useState } from 'react';
+
 type Props = {
   elapsedMs: number;
   onRetry?: () => void;
 };
 
 export const BootSlowNotice = ({ elapsedMs, onRetry }: Props) => {
+  const [hasRequestedRestart, setHasRequestedRestart] = useState(false);
+
+  const requestRestart = useCallback(() => {
+    onRetry?.();
+    setHasRequestedRestart(true);
+  }, [onRetry]);
+
   return (
     <div className="flex flex-col items-center gap-1.5 text-2xs text-muted-foreground">
       <span>this is taking longer than usual</span>
-      <span>{Math.floor(elapsedMs / 1_000)}s</span>
-      {onRetry !== undefined ? (
+      <span>{`${Math.floor(elapsedMs / 1_000)}s in this step`}</span>
+      {onRetry !== undefined && !hasRequestedRestart ? (
         <button
           type="button"
-          onClick={onRetry}
+          onClick={requestRestart}
           className="rounded border border-border-soft bg-background px-3 py-1.5 text-foreground motion-safe:transition-colors hover:bg-subtle"
         >
-          retry
+          restart
         </button>
       ) : null}
+      {hasRequestedRestart ? <span>still working, give it a moment</span> : null}
     </div>
   );
 };

--- a/apps/desktop/src/app/components/BootSplash/BootSlowNotice.tsx
+++ b/apps/desktop/src/app/components/BootSplash/BootSlowNotice.tsx
@@ -1,0 +1,22 @@
+type Props = {
+  elapsedMs: number;
+  onRetry?: () => void;
+};
+
+export const BootSlowNotice = ({ elapsedMs, onRetry }: Props) => {
+  return (
+    <div className="flex flex-col items-center gap-1.5 text-2xs text-muted-foreground">
+      <span>this is taking longer than usual</span>
+      <span>{Math.floor(elapsedMs / 1_000)}s</span>
+      {onRetry !== undefined ? (
+        <button
+          type="button"
+          onClick={onRetry}
+          className="rounded border border-border-soft bg-background px-3 py-1.5 text-foreground motion-safe:transition-colors hover:bg-subtle"
+        >
+          retry
+        </button>
+      ) : null}
+    </div>
+  );
+};

--- a/apps/desktop/src/app/components/BootSplash/index.test.tsx
+++ b/apps/desktop/src/app/components/BootSplash/index.test.tsx
@@ -59,3 +59,22 @@ describe('BootSplash slow boot recovery', () => {
     expect(screen.queryByRole('button', { name: /retry/i })).toBeNull();
   });
 });
+
+describe('BootSplash boot handoff', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('removes the static boot shell once react takes over', () => {
+    document.body.insertAdjacentHTML('afterbegin', '<div id="boot-shell"></div>');
+    render(<BootSplash phase="migrating" error={null} />);
+    expect(document.getElementById('boot-shell')).toBeNull();
+  });
+
+  it('offers retry on the error screen', () => {
+    const onRetry = vi.fn();
+    render(<BootSplash phase="migrating" error="boom" onRetry={onRetry} />);
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }));
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/desktop/src/app/components/BootSplash/index.test.tsx
+++ b/apps/desktop/src/app/components/BootSplash/index.test.tsx
@@ -28,10 +28,10 @@ describe('BootSplash slow boot recovery', () => {
     });
 
     expect(screen.queryByText('this is taking longer than usual')).toBeNull();
-    expect(screen.queryByRole('button', { name: /retry/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /restart/i })).toBeNull();
   });
 
-  it('offers retry after the phase takes longer than usual', () => {
+  it('offers restart after the phase takes longer than usual', () => {
     const onRetry = vi.fn();
     render(<BootSplash phase="detecting-cli" error={null} onRetry={onRetry} />);
 
@@ -40,9 +40,21 @@ describe('BootSplash slow boot recovery', () => {
     });
 
     expect(screen.getByText('this is taking longer than usual')).toBeDefined();
-    expect(screen.getByText('10s')).toBeDefined();
-    fireEvent.click(screen.getByRole('button', { name: /retry/i }));
+    expect(screen.getByText('10s in this step')).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: /restart/i }));
     expect(onRetry).toHaveBeenCalledOnce();
+  });
+
+  it('acknowledges the restart press instead of leaving the button dead', () => {
+    render(<BootSplash phase="detecting-cli" error={null} onRetry={vi.fn()} />);
+
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+    fireEvent.click(screen.getByRole('button', { name: /restart/i }));
+
+    expect(screen.getByText('still working, give it a moment')).toBeDefined();
+    expect(screen.queryByRole('button', { name: /restart/i })).toBeNull();
   });
 
   it('resets the escalation when the phase changes', () => {
@@ -56,7 +68,7 @@ describe('BootSplash slow boot recovery', () => {
     rerender(<BootSplash phase="detecting-cli" error={null} onRetry={vi.fn()} />);
 
     expect(screen.queryByText('this is taking longer than usual')).toBeNull();
-    expect(screen.queryByRole('button', { name: /retry/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /restart/i })).toBeNull();
   });
 });
 

--- a/apps/desktop/src/app/components/BootSplash/index.test.tsx
+++ b/apps/desktop/src/app/components/BootSplash/index.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment happy-dom
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
+vi.mock('../../../shared/lib/editor', () => ({
+  openInEditor: vi.fn(),
+  openUrl: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { BootSplash } from './index';
+
+describe('BootSplash slow boot recovery', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it('keeps the normal splash unchanged below the slow threshold', () => {
+    render(<BootSplash phase="loading-settings" error={null} />);
+
+    act(() => {
+      vi.advanceTimersByTime(9_000);
+    });
+
+    expect(screen.queryByText('this is taking longer than usual')).toBeNull();
+    expect(screen.queryByRole('button', { name: /retry/i })).toBeNull();
+  });
+
+  it('offers retry after the phase takes longer than usual', () => {
+    const onRetry = vi.fn();
+    render(<BootSplash phase="detecting-cli" error={null} onRetry={onRetry} />);
+
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+
+    expect(screen.getByText('this is taking longer than usual')).toBeDefined();
+    expect(screen.getByText('10s')).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }));
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+
+  it('resets the escalation when the phase changes', () => {
+    const { rerender } = render(
+      <BootSplash phase="loading-settings" error={null} onRetry={vi.fn()} />,
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+    rerender(<BootSplash phase="detecting-cli" error={null} onRetry={vi.fn()} />);
+
+    expect(screen.queryByText('this is taking longer than usual')).toBeNull();
+    expect(screen.queryByRole('button', { name: /retry/i })).toBeNull();
+  });
+});

--- a/apps/desktop/src/app/components/BootSplash/index.tsx
+++ b/apps/desktop/src/app/components/BootSplash/index.tsx
@@ -101,7 +101,7 @@ function BootErrorRecovery({
   onRetry?: () => void;
 }) {
   const openIssue = useCallback(() => {
-    const url = `${GITHUB_NEW_ISSUE_URL}&body=${encodeURIComponent(`**phase:** ${phase}\n\n**error:**\n\`\`\`\n${error}\n\`\`\``)}`;
+    const url = `${GITHUB_NEW_ISSUE_URL}&body=${encodeURIComponent(`**phase:** ${phase}\n\n**error:**\n\`\`\`\n${error}\n\`\`\`\n\nBoot timings for this launch are in \`~/.goodboy/boot-breadcrumbs.log\` (phase and timing only, no paths or credentials). Paste the last few lines if you can.`)}`;
     void openUrl(url);
   }, [error, phase]);
 

--- a/apps/desktop/src/app/components/BootSplash/index.tsx
+++ b/apps/desktop/src/app/components/BootSplash/index.tsx
@@ -2,9 +2,12 @@ import { useCallback, useEffect, useRef } from 'react';
 import type { BootPhase } from '../../../store/types';
 import { openUrl } from '../../../shared/lib/editor';
 import { DogMascot } from '../../../shared/components/DogMascot';
+import { BootSlowNotice } from './BootSlowNotice';
+import { useElapsedSincePhase } from './useElapsedSincePhase';
 
 const GITHUB_NEW_ISSUE_URL =
   'https://github.com/akhayam99/goodboy/issues/new?template=bug_report.md&labels=bug%2Cboot&title=Boot+failure';
+const BOOT_SLOW_AFTER_MS = 10_000;
 
 const BOOT_PHASE_LABEL: Record<BootPhase, string> = {
   pending: 'starting up',
@@ -27,6 +30,12 @@ type BootSplashProps = {
 export const BootSplash = ({ phase, error, onRetry, onFinished }: BootSplashProps) => {
   const hasError = error != null;
   const finishedRef = useRef(false);
+  const elapsedMs = useElapsedSincePhase({ phase });
+  const isSlow = phase !== 'error' && phase !== 'ready' && elapsedMs >= BOOT_SLOW_AFTER_MS;
+
+  useEffect(() => {
+    document.getElementById('boot-shell')?.remove();
+  }, []);
 
   useEffect(() => {
     if (finishedRef.current || hasError) {
@@ -54,9 +63,12 @@ export const BootSplash = ({ phase, error, onRetry, onFinished }: BootSplashProp
       aria-label="Loading Goodboy"
     >
       <BootBrand />
-      <span className="text-2xs tracking-tight text-muted-foreground/50 motion-safe:animate-pulse">
-        {BOOT_PHASE_LABEL[phase]}
-      </span>
+      <div className="flex flex-col items-center gap-3">
+        <span className="text-2xs tracking-tight text-muted-foreground/50 motion-safe:animate-pulse">
+          {BOOT_PHASE_LABEL[phase]}
+        </span>
+        {isSlow ? <BootSlowNotice elapsedMs={elapsedMs} onRetry={onRetry} /> : null}
+      </div>
     </div>
   );
 };

--- a/apps/desktop/src/app/components/BootSplash/useElapsedSincePhase.ts
+++ b/apps/desktop/src/app/components/BootSplash/useElapsedSincePhase.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react';
+import type { BootPhase } from '../../../store/types';
+
+type Params = {
+  phase: BootPhase;
+};
+
+export const useElapsedSincePhase = ({ phase }: Params): number => {
+  const [elapsedMs, setElapsedMs] = useState(0);
+
+  useEffect(() => {
+    const startedAt = Date.now();
+    setElapsedMs(0);
+    const intervalId = window.setInterval(() => {
+      setElapsedMs(Date.now() - startedAt);
+    }, 1_000);
+
+    return () => window.clearInterval(intervalId);
+  }, [phase]);
+
+  return elapsedMs;
+};

--- a/apps/desktop/src/store/slices/boot/hydrate.ts
+++ b/apps/desktop/src/store/slices/boot/hydrate.ts
@@ -47,10 +47,6 @@ const recordBootBreadcrumb = ({ phase, detail }: RecordBootBreadcrumbParams): vo
 
 let hydratePromise: Promise<void> | null = null;
 
-const resetHydrateMemo = (): void => {
-  hydratePromise = null;
-};
-
 export const hydrate = (set: SetFn, get: GetFn) => {
   return async (): Promise<void> => {
     if (hydratePromise) {
@@ -314,7 +310,11 @@ export const hydrate = (set: SetFn, get: GetFn) => {
 
 export const retryHydrate = (get: GetFn) => {
   return async (): Promise<void> => {
-    resetHydrateMemo();
+    const inFlight = hydratePromise;
+    if (inFlight !== null) {
+      await inFlight;
+      return;
+    }
     await get().hydrate();
   };
 };

--- a/apps/desktop/src/store/slices/boot/hydrate.ts
+++ b/apps/desktop/src/store/slices/boot/hydrate.ts
@@ -47,7 +47,7 @@ const recordBootBreadcrumb = ({ phase, detail }: RecordBootBreadcrumbParams): vo
 
 let hydratePromise: Promise<void> | null = null;
 
-export const resetHydrateMemo = (): void => {
+const resetHydrateMemo = (): void => {
   hydratePromise = null;
 };
 
@@ -309,5 +309,12 @@ export const hydrate = (set: SetFn, get: GetFn) => {
         hydratePromise = null;
       }
     }
+  };
+};
+
+export const retryHydrate = (get: GetFn) => {
+  return async (): Promise<void> => {
+    resetHydrateMemo();
+    await get().hydrate();
   };
 };

--- a/apps/desktop/src/store/slices/boot/hydrate.ts
+++ b/apps/desktop/src/store/slices/boot/hydrate.ts
@@ -1,6 +1,7 @@
 import type { SessionId, WorkspaceId } from '@goodboy/types';
 import { formatError } from '@goodboy/ui';
 import { getSetting, listWorkspaces } from '@goodboy/db';
+import { invoke } from '@tauri-apps/api/core';
 import { runDbMigrations, tauriDatabase } from '../../../shared/lib/db';
 import { migrateLsToDb } from '../../../shared/lib/ls-to-db-migration';
 import { hydrateOnboardingFromDb } from '../../../features/onboarding/onboarding-store';
@@ -29,8 +30,26 @@ import { recoverStagedFileVersions } from '../file-versions/recoverStagedFileVer
 import { applyQaDecidingPreview } from '../workflows/applyQaDecidingPreview';
 import { drainAuditRetryQueue } from './auditRetryQueue';
 import type { GetFn, SetFn } from './types';
+import type { BootPhase } from '../../types';
+
+type RecordBootBreadcrumbParams = {
+  phase: BootPhase;
+  detail?: string;
+};
+
+const recordBootBreadcrumb = ({ phase, detail }: RecordBootBreadcrumbParams): void => {
+  try {
+    void Promise.resolve(invoke('boot_breadcrumb', { phase, detail })).catch(() => undefined);
+  } catch {
+    return;
+  }
+};
 
 let hydratePromise: Promise<void> | null = null;
+
+export const resetHydrateMemo = (): void => {
+  hydratePromise = null;
+};
 
 export const hydrate = (set: SetFn, get: GetFn) => {
   return async (): Promise<void> => {
@@ -38,8 +57,17 @@ export const hydrate = (set: SetFn, get: GetFn) => {
       return hydratePromise;
     }
     hydratePromise = (async () => {
+      const bootStartedAt = Date.now();
+      let previousTransitionAt = bootStartedAt;
       try {
+        recordBootBreadcrumb({ phase: 'pending', detail: 'start' });
+        const migratingAt = Date.now();
         set({ bootPhase: 'migrating', error: null });
+        recordBootBreadcrumb({
+          phase: 'migrating',
+          detail: `ms=${migratingAt - previousTransitionAt}`,
+        });
+        previousTransitionAt = migratingAt;
         await runDbMigrations();
         await migrateLsToDb();
         await hydrateOnboardingFromDb();
@@ -48,7 +76,13 @@ export const hydrate = (set: SetFn, get: GetFn) => {
           .loadNotifications()
           .catch(() => {});
 
+        const loadingSettingsAt = Date.now();
         set({ bootPhase: 'loading-settings' });
+        recordBootBreadcrumb({
+          phase: 'loading-settings',
+          detail: `ms=${loadingSettingsAt - previousTransitionAt}`,
+        });
+        previousTransitionAt = loadingSettingsAt;
         const [editorBinary, lastWorkspaceRaw, lastSessionRaw, reopenLastRaw] = await Promise.all([
           getSetting(tauriDatabase, SETTING_EDITOR_BINARY),
           getSetting(tauriDatabase, SETTING_LAST_WORKSPACE_ID),
@@ -72,7 +106,13 @@ export const hydrate = (set: SetFn, get: GetFn) => {
           return { settings: next };
         });
 
+        const detectingCliAt = Date.now();
         set({ bootPhase: 'detecting-cli' });
+        recordBootBreadcrumb({
+          phase: 'detecting-cli',
+          detail: `ms=${detectingCliAt - previousTransitionAt}`,
+        });
+        previousTransitionAt = detectingCliAt;
         const [
           providerStatus,
           cursorStatus,
@@ -135,7 +175,13 @@ export const hydrate = (set: SetFn, get: GetFn) => {
         };
         set({ authResults, providers: buildProviderList(statuses, authResults) });
 
+        const loadingWorkspacesAt = Date.now();
         set({ bootPhase: 'loading-workspaces' });
+        recordBootBreadcrumb({
+          phase: 'loading-workspaces',
+          detail: `ms=${loadingWorkspacesAt - previousTransitionAt}`,
+        });
+        previousTransitionAt = loadingWorkspacesAt;
         await get()
           .loadCredentials()
           .catch(() => {});
@@ -177,7 +223,13 @@ export const hydrate = (set: SetFn, get: GetFn) => {
 
         await applyQaDecidingPreview({ set }).catch(() => {});
 
+        const restoringSessionAt = Date.now();
         set({ bootPhase: 'restoring-session' });
+        recordBootBreadcrumb({
+          phase: 'restoring-session',
+          detail: `ms=${restoringSessionAt - previousTransitionAt}`,
+        });
+        previousTransitionAt = restoringSessionAt;
         const reloadIntent = consumeReloadIntent();
         if (reloadIntent?.mode === 'restore') {
           const snapWorkspace = workspaces.find((w) => w.id === reloadIntent.workspaceId) ?? null;
@@ -228,6 +280,10 @@ export const hydrate = (set: SetFn, get: GetFn) => {
         }
 
         set({ bootPhase: 'ready', hydrated: true });
+        recordBootBreadcrumb({
+          phase: 'ready',
+          detail: `ms=${Date.now() - bootStartedAt},ok`,
+        });
 
         void drainAuditRetryQueue(set);
 
@@ -237,6 +293,7 @@ export const hydrate = (set: SetFn, get: GetFn) => {
 
         void get().refreshGithubStatus();
       } catch (err) {
+        recordBootBreadcrumb({ phase: 'error', detail: 'error' });
         set({
           bootPhase: 'error',
           error: formatError(err),
@@ -244,10 +301,13 @@ export const hydrate = (set: SetFn, get: GetFn) => {
         });
       }
     })();
+    const ownPromise = hydratePromise;
     try {
-      await hydratePromise;
+      await ownPromise;
     } finally {
-      hydratePromise = null;
+      if (hydratePromise === ownPromise) {
+        hydratePromise = null;
+      }
     }
   };
 };

--- a/apps/desktop/src/store/slices/boot/index.test.ts
+++ b/apps/desktop/src/store/slices/boot/index.test.ts
@@ -556,21 +556,99 @@ describe('store contract', () => {
       expect(s.bootPhase).toBe('ready');
     });
 
-    it('starts a fresh hydration after the memo is reset', async () => {
+    it('restarts hydration when retry runs while the first attempt is in flight', async () => {
       const store = await getStore();
-      const { resetHydrateMemo } = await import('./hydrate');
-      listWorkspacesSpy.mockImplementationOnce(() => new Promise(() => {}));
+      let releaseFirst: () => void = () => undefined;
+      listWorkspacesSpy.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            releaseFirst = () => resolve([]);
+          }),
+      );
 
       void store.getState().hydrate();
       await vi.waitFor(() => {
         expect(listWorkspacesSpy).toHaveBeenCalledOnce();
       });
 
-      resetHydrateMemo();
-      await store.getState().hydrate();
+      const retry = store.getState().retryHydrate();
+      await vi.waitFor(() => {
+        expect(listWorkspacesSpy).toHaveBeenCalledTimes(2);
+      });
+
+      releaseFirst();
+      await retry;
+
+      expect(store.getState().bootPhase).toBe('ready');
+    });
+
+    it('keeps the retry hydration memoized when the first attempt settles late', async () => {
+      const store = await getStore();
+      let releaseFirst: () => void = () => undefined;
+      let releaseSecond: () => void = () => undefined;
+      listWorkspacesSpy.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            releaseFirst = () => resolve([]);
+          }),
+      );
+      listWorkspacesSpy.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            releaseSecond = () => resolve([]);
+          }),
+      );
+
+      void store.getState().hydrate();
+      await vi.waitFor(() => {
+        expect(listWorkspacesSpy).toHaveBeenCalledOnce();
+      });
+
+      const retry = store.getState().retryHydrate();
+      await vi.waitFor(() => {
+        expect(listWorkspacesSpy).toHaveBeenCalledTimes(2);
+      });
+
+      releaseFirst();
+      await vi.waitFor(() => {
+        expect(store.getState().bootPhase).toBe('ready');
+      });
+
+      const joined = store.getState().hydrate();
+      releaseSecond();
+      await Promise.all([retry, joined]);
 
       expect(listWorkspacesSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('survives a boot breadcrumb command that throws synchronously', async () => {
+      const store = await getStore();
+      invokeSpy.mockImplementation(((command: unknown) => {
+        if (command === 'boot_breadcrumb') {
+          throw new Error('breadcrumb sink exploded');
+        }
+        return Promise.resolve(null);
+      }) as never);
+
+      await store.getState().hydrate();
+
       expect(store.getState().bootPhase).toBe('ready');
+      expect(store.getState().error).toBeNull();
+    });
+
+    it('survives a boot breadcrumb command that rejects', async () => {
+      const store = await getStore();
+      invokeSpy.mockImplementation(((command: unknown) => {
+        if (command === 'boot_breadcrumb') {
+          return Promise.reject(new Error('breadcrumb sink exploded'));
+        }
+        return Promise.resolve(null);
+      }) as never);
+
+      await store.getState().hydrate();
+
+      expect(store.getState().bootPhase).toBe('ready');
+      expect(store.getState().error).toBeNull();
     });
 
     it('loads notifications at boot without waiting for the bell to mount', async () => {

--- a/apps/desktop/src/store/slices/boot/index.test.ts
+++ b/apps/desktop/src/store/slices/boot/index.test.ts
@@ -46,6 +46,7 @@ vi.mock('@tauri-apps/api/event', () => ({
 }));
 
 const listWorkspacesSpy = vi.fn(async () => [] as ReadonlyArray<Workspace>);
+const runDbMigrationsSpy = vi.fn(async () => undefined);
 const dbSetSettingSpy = vi.fn(async () => undefined);
 const dbGetSettingSpy: ReturnType<typeof vi.fn> = vi.fn<() => Promise<string | null>>(
   async () => null,
@@ -157,7 +158,7 @@ vi.mock('@goodboy/db', () => ({
 }));
 
 vi.mock('../../../shared/lib/db', () => ({
-  runDbMigrations: vi.fn(async () => undefined),
+  runDbMigrations: runDbMigrationsSpy,
   wipeDb: vi.fn(async () => undefined),
   tauriDatabase: { execute: vi.fn(), select: vi.fn() },
 }));
@@ -556,7 +557,7 @@ describe('store contract', () => {
       expect(s.bootPhase).toBe('ready');
     });
 
-    it('restarts hydration when retry runs while the first attempt is in flight', async () => {
+    it('joins the in-flight hydration instead of starting a second run on retry', async () => {
       const store = await getStore();
       let releaseFirst: () => void = () => undefined;
       listWorkspacesSpy.mockImplementationOnce(
@@ -572,53 +573,25 @@ describe('store contract', () => {
       });
 
       const retry = store.getState().retryHydrate();
-      await vi.waitFor(() => {
-        expect(listWorkspacesSpy).toHaveBeenCalledTimes(2);
-      });
-
       releaseFirst();
       await retry;
 
+      expect(listWorkspacesSpy).toHaveBeenCalledOnce();
+      expect(runDbMigrationsSpy).toHaveBeenCalledOnce();
       expect(store.getState().bootPhase).toBe('ready');
     });
 
-    it('keeps the retry hydration memoized when the first attempt settles late', async () => {
+    it('still restarts hydration when retry runs after a failed attempt', async () => {
       const store = await getStore();
-      let releaseFirst: () => void = () => undefined;
-      let releaseSecond: () => void = () => undefined;
-      listWorkspacesSpy.mockImplementationOnce(
-        () =>
-          new Promise((resolve) => {
-            releaseFirst = () => resolve([]);
-          }),
-      );
-      listWorkspacesSpy.mockImplementationOnce(
-        () =>
-          new Promise((resolve) => {
-            releaseSecond = () => resolve([]);
-          }),
-      );
+      listWorkspacesSpy.mockRejectedValueOnce(new Error('boom'));
 
-      void store.getState().hydrate();
-      await vi.waitFor(() => {
-        expect(listWorkspacesSpy).toHaveBeenCalledOnce();
-      });
+      await store.getState().hydrate();
+      expect(store.getState().bootPhase).toBe('error');
 
-      const retry = store.getState().retryHydrate();
-      await vi.waitFor(() => {
-        expect(listWorkspacesSpy).toHaveBeenCalledTimes(2);
-      });
+      await store.getState().retryHydrate();
 
-      releaseFirst();
-      await vi.waitFor(() => {
-        expect(store.getState().bootPhase).toBe('ready');
-      });
-
-      const joined = store.getState().hydrate();
-      releaseSecond();
-      await Promise.all([retry, joined]);
-
-      expect(listWorkspacesSpy).toHaveBeenCalledTimes(2);
+      expect(store.getState().bootPhase).toBe('ready');
+      expect(runDbMigrationsSpy).toHaveBeenCalledTimes(2);
     });
 
     it('survives a boot breadcrumb command that throws synchronously', async () => {

--- a/apps/desktop/src/store/slices/boot/index.test.ts
+++ b/apps/desktop/src/store/slices/boot/index.test.ts
@@ -636,19 +636,27 @@ describe('store contract', () => {
       expect(store.getState().error).toBeNull();
     });
 
-    it('survives a boot breadcrumb command that rejects', async () => {
+    it('never leaves the breadcrumb rejection unhandled', async () => {
       const store = await getStore();
+      const unhandled = vi.fn();
+      process.on('unhandledRejection', unhandled);
       invokeSpy.mockImplementation(((command: unknown) => {
         if (command === 'boot_breadcrumb') {
-          return Promise.reject(new Error('breadcrumb sink exploded'));
+          return {
+            then: (_onFulfilled: unknown, onRejected: (reason: unknown) => void) => {
+              onRejected(new Error('breadcrumb sink exploded'));
+            },
+          };
         }
         return Promise.resolve(null);
       }) as never);
 
       await store.getState().hydrate();
+      await new Promise((resolve) => setImmediate(resolve));
+      process.off('unhandledRejection', unhandled);
 
+      expect(unhandled).not.toHaveBeenCalled();
       expect(store.getState().bootPhase).toBe('ready');
-      expect(store.getState().error).toBeNull();
     });
 
     it('loads notifications at boot without waiting for the bell to mount', async () => {

--- a/apps/desktop/src/store/slices/boot/index.test.ts
+++ b/apps/desktop/src/store/slices/boot/index.test.ts
@@ -556,6 +556,23 @@ describe('store contract', () => {
       expect(s.bootPhase).toBe('ready');
     });
 
+    it('starts a fresh hydration after the memo is reset', async () => {
+      const store = await getStore();
+      const { resetHydrateMemo } = await import('./hydrate');
+      listWorkspacesSpy.mockImplementationOnce(() => new Promise(() => {}));
+
+      void store.getState().hydrate();
+      await vi.waitFor(() => {
+        expect(listWorkspacesSpy).toHaveBeenCalledOnce();
+      });
+
+      resetHydrateMemo();
+      await store.getState().hydrate();
+
+      expect(listWorkspacesSpy).toHaveBeenCalledTimes(2);
+      expect(store.getState().bootPhase).toBe('ready');
+    });
+
     it('loads notifications at boot without waiting for the bell to mount', async () => {
       const store = await getStore();
       await store.getState().hydrate();

--- a/apps/desktop/src/store/slices/boot/index.ts
+++ b/apps/desktop/src/store/slices/boot/index.ts
@@ -1,10 +1,11 @@
-import { hydrate } from './hydrate';
+import { hydrate, retryHydrate } from './hydrate';
 import { loadDetectedEditors } from './loadDetectedEditors';
 import type { GetFn, SetFn } from './types';
 
 export const createBootSlice = (set: SetFn, get: GetFn) => {
   return {
     hydrate: hydrate(set, get),
+    retryHydrate: retryHydrate(get),
     loadDetectedEditors: loadDetectedEditors(set, get),
   };
 };

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -190,6 +190,7 @@ export type {
 
 export type AppActions = {
   hydrate(): Promise<void>;
+  retryHydrate(): Promise<void>;
   checkForUpdates(): Promise<void>;
   installUpdate(): Promise<void>;
   loadChangelog(): Promise<void>;

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -19,6 +19,25 @@ Owns what to test and how. Test file placement: [file-system.md](file-system.md)
 
 If a test fails because the component / store / hook does the wrong thing, **fix the code, not the test**. Never weaken a test to make it pass.
 
+## Manual release gate: the window must appear
+
+`tauri.conf.json` ships the main window with `"visible": false`, and the only
+thing that ever reveals it is the loop over `app.webview_windows()` inside
+`.setup()` in `apps/desktop/src-tauri/src/lib.rs`. That loop has no in-process
+seam: it needs a real Tauri runtime, so no unit test stands in for it, and a
+test that greps the source for the call asserts a shape rather than the
+behavior. Every release runs this step by hand and records the result.
+
+1. Build the bundle from the commit under judgment: `pnpm tauri:build`.
+2. Launch the binary directly, never through `open`, so the database override
+   applies:
+   `GOODBOY_DB_FILE=<path that does not exist yet> apps/desktop/src-tauri/target/release/bundle/macos/Goodboy.app/Contents/MacOS/goodboy-desktop`
+3. A window must appear and paint the boot splash. No window on screen is a
+   release blocker regardless of how green the suites are.
+4. Confirm the run left a `webview-attached` line in the breadcrumb sink at
+   `.goodboy/boot-breadcrumbs.log` under the home directory. A missing line
+   with a visible window means the breadcrumb path broke, not the reveal.
+
 ## Reaching a state that only exists in memory
 
 The orchestrator "stopping" state lives only in the store while a decision is


### PR DESCRIPTION
## What

Boot could fail silently: five of seven launches showed a window with a title bar and nothing painted, with the splash never appearing even though `BootSplash` was already wired to every boot phase.

## The falsifier, answered first

Before building anything, the question was whether the failing body is the charcoal `index.html` paints or an unpainted OS surface, because a shell splash only helps in the first case.

- `apps/desktop/index.html` paints `html { background: oklch(0.25 0.006 255) }` from an inline `<style>`, so charcoal appears as soon as the document is parsed, before the bundle evaluates.
- `apps/desktop/src-tauri/tauri.conf.json` declared **no** `backgroundColor` and **no** `visible: false`, so anything before the document exists is the platform default surface, not charcoal.

A window painting neither the splash nor charcoal is therefore a window that never got to run the document, not a window waiting on a slow bundle. That matches the diagnosis, and it means a shell splash alone would not have helped the photographed launches.

## What shipped

**The fix that actually paints.** `db_exec`, `db_execute`, `db_select` and `db_wipe` were synchronous `#[tauri::command]` functions. A non-async Tauri command runs on the main thread, which on macOS is the UI thread, and every boot database call routes through them. They are now `#[tauri::command(async)]`. The conversion is mechanical: they hold a `Mutex` guard with no `await` inside.

**A branded pre-paint surface.** The window declares `backgroundColor: "#202225"` (the sRGB value of the charcoal the document paints) and `visible: false`, and Rust shows it from `setup`, so the appearing window is branded rather than a black rectangle and the show never depends on webview JavaScript.

**A Rust breadcrumb sink.** New `boot_breadcrumb.rs`: an append-only file at `~/.goodboy/boot-breadcrumbs.log` resolved with the `dirs` pattern already used by `db.rs`, no new dependency. Process-side milestones (`process-start`, `window-created`, `webview-attached`) are emitted from Rust, so the sink is not silent on exactly the launch where the webview never runs. Every line carries a per-process launch id, so a reader can answer "did launch 14 write process-start".

Its security conditions were treated as build requirements, since the real egress path is a user attaching it to an issue:

- `phase` is validated against a fixed allowlist and rejected otherwise.
- `detail` is not free text: every comma-separated token must be an outcome keyword or `ms=<digits>`. Anything else is dropped rather than written, so argv, environment values, integration response bodies and credential key names have no path to the file.
- File mode `0600`, capped at 64 KiB, rotated whole-line to `.log.1`.
- The global logger is untouched: `tauri-plugin-log` stays registered only under `cfg!(debug_assertions)`. Persisting every `log::` call in release is not a decision a boot item gets to make implicitly.

**A shell splash, scoped honestly.** `index.html` gains a static pre-React shell (inline CSS, no bundle dependency, both themes) torn down when the splash mounts. It helps when the block is inside the bundle. That is a real case and it is not the case the walkers photographed.

**The retry that was a no-op.** `hydrate.ts` memoises `hydratePromise` and clears it in the awaiting caller's `finally`, which never runs while a phase is stuck, so a retry re-awaited the same stuck promise. `resetHydrateMemo` now clears it and the splash retry calls it first. The `finally` also only clears the memo it owns, so a late resolution cannot clear a newer run's promise.

**A slow-boot escalation.** A per-phase elapsed timer and, past ten seconds, a "this is taking longer than usual" notice with the elapsed seconds and a working retry. The existing phase labels and error-path retry already shipped and were not reimplemented.

## What did NOT ship

**The Rust watchdog with a native dialog.** The timer, the notice and the retry are all webview JavaScript: on a parked main thread no `setTimeout` fires, so they help the slow-bundle case and nothing else. The version that survives a parked main thread is a Rust-side watchdog raising a native dialog. It was deliberately left out of scope and remains the honest unbuilt half of "never fails silently".

Also not covered: secondary workspace windows are built at runtime from JavaScript and do not inherit the config's `backgroundColor`, so their pre-paint surface is unchanged. That file is outside this item's footprint.

## Test plan

- `pnpm exec turbo run typecheck test build --force`: 10 tasks successful, `0 cached`.
- `cargo test --locked`: 428 passed, including 5 new `boot_breadcrumb` tests (phase allowlist, detail grammar accept and drop, rotation past the cap).
- New `BootSplash/index.test.tsx`: no escalation below the threshold, notice plus a working retry past it, escalation resets on a phase change.
- New boot-slice test: a hydrate stuck mid-phase, then `resetHydrateMemo`, then a second `hydrate()` that actually runs again.
- `pnpm knip --include files,duplicates,unlisted` clean, `cargo fmt --check` clean on the touched files.
