### PR TITLE
chore(repo): bump version to 0.1.80

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,58 @@ version in the same PR that bumps the version numbers (see
 `docs/release-command.md`), before the tag is pushed: the release build fails
 if it can't find a matching `## Goodboy vX.Y.Z` heading.
 
+## Goodboy v0.1.80
+
+Goodboy opens. Every launch reaches a painted window, a folder without a git
+repository is now a folder you can work in, and a lens that has not loaded shows
+a skeleton instead of a zero.
+
+### [#1397] The window paints on every launch
+
+Five of seven launches used to show a window with a title bar and nothing in it,
+and the splash never appeared even though it was wired to every boot phase. The
+cause was not a slow bundle. Every database call the boot makes ran on the macOS
+UI thread, so a slow query parked the thread that paints.
+
+Those calls now run off it. The window declares its own background colour and
+stays hidden until Rust shows it, so the first thing you see is Goodboy's
+charcoal rather than a black rectangle, and the window appears whether or not the
+web view ever runs.
+
+When a phase takes longer than usual the splash says so and offers to restart.
+If the boot fails outright, the error screen offers a retry that genuinely re-runs
+it. Every launch also appends its phases and their timings to
+`~/.goodboy/boot-breadcrumbs.log`, owner-only, phase and timing only, no paths and
+no credentials, so a boot you cannot reproduce is still a boot you can report.
+
+### [#1401] Create or link a repository when a folder has no git
+
+Opening a folder without a git repository used to leave you with instructions and
+no sessions. That folder is now a workspace you can use as it is, with a way to
+link a code host whenever you want one. Create a new GitHub repository from inside
+the app, pick public or private yourself with nothing preselected, and the app
+tells you exactly what it is about to make before it makes it. Declining costs
+nothing and the offer stays.
+
+Follow-up: repository creation goes through the `gh` CLI and its flags come from
+gh's published surface, though no create has gone out to a live GitHub account
+yet. If a call is refused, gh's own message comes back in the dialog and the
+folder stays usable.
+
+### [#1402] A lens shows a skeleton until it has loaded
+
+A lens with no rows and a lens that had not loaded looked identical, so an empty
+state could be a claim the app had no evidence for. Collections that have not
+loaded now show a skeleton, and an empty state means the app looked and found
+nothing.
+
+### Fixes
+
+- Status dots in the session rail carry labels for screen readers [#1402]
+- The README no longer describes screens that are not there, and says what the
+  website measures and what the app does not [#1399]
+- Shipped database migrations are guarded against edits after release [#1395]
+
 ## Goodboy v0.1.79
 
 The resolver becomes a dashboard, a run gets a spending limit you set yourself, and two counts that disagreed about your session become one.

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goodboy/desktop",
-  "version": "0.1.79",
+  "version": "0.1.80",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -1626,7 +1626,7 @@ dependencies = [
 
 [[package]]
 name = "goodboy-desktop"
-version = "0.1.79"
+version = "0.1.80"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goodboy-desktop"
-version = "0.1.79"
+version = "0.1.80"
 description = "Goodboy desktop app"
 authors = ["Amin Khayam"]
 license = "MIT"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Goodboy",
-  "version": "0.1.79",
+  "version": "0.1.80",
   "identifier": "com.goodboy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goodboy",
-  "version": "0.1.79",
+  "version": "0.1.80",
   "private": true,
   "description": "AI workspace orchestrator. Local-first, provider-agnostic.",
   "license": "MIT",

--- a/website/src/site.ts
+++ b/website/src/site.ts
@@ -1,5 +1,5 @@
 export const SITE = {
-  version: 'v0.1.79',
+  version: 'v0.1.80',
   repo: 'https://github.com/akhayam99/goodboy',
   releases: 'https://github.com/akhayam99/goodboy/releases',
   latest: 'https://github.com/akhayam99/goodboy/releases/latest',


### PR DESCRIPTION
Version bump across the six places plus the `## Goodboy v0.1.80` section in `CHANGELOG.md`, in the same commit, per `docs/release-command.md`.

Notes written from the merged PR bodies and reviewed by the challenger (impact: pass) and the voice steward. Ten merge units shipped of a planned fifteen; the cut is declared in the release record.