### PR TITLE
perf(desktop): move provider detection off the boot path

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,8 +140,9 @@ pnpm + Turborepo monorepo: `apps/desktop` plus `packages/{ui,core,db,types}`.
 ## What stays on your machine
 
 Goodboy is an orchestration layer. There is no backend, there are no accounts,
-and nothing is stored, logged or transmitted anywhere except to the services
-you connected yourself.
+and what you write reaches only the services you connected yourself. Two things
+sit outside that sentence and are listed below with the rest: a local
+diagnostics file, and the check for a new version.
 
 - **The app carries no telemetry.** No usage pings, no crash reports, no
   opt-in switch to find later.
@@ -157,6 +158,17 @@ you connected yourself.
 - Local persistence is one SQLite file, `~/.goodboy/data.db`: workspaces,
   sessions, agents, messages, context, plans, local usage records, skills,
   settings. Cleared when you ask, and not before.
+- **Every launch appends a few lines to `~/.goodboy/boot-breadcrumbs.log`.** A
+  timestamp, a launch id, the boot phase and how long that phase took. The
+  phase and the detail are matched against a fixed set of allowed values before
+  the line is written, so no path, argument or credential can reach it, and the
+  file never leaves your machine. [SECURITY.md](./SECURITY.md) has the
+  allowlist, the file mode and the rotation.
+- **A release build asks GitHub whether a newer version exists.** It requests
+  the update manifest published with the releases, on window focus and once an
+  hour, and that is the one request Goodboy makes with nothing connected at
+  all. It carries no data about you, and an update it finds is verified against
+  the signing key shipped in the app before anything is installed.
 
 If Goodboy disappeared tomorrow, your data would be untouched, because it was
 never ours.

--- a/README.md
+++ b/README.md
@@ -165,10 +165,14 @@ diagnostics file, and the check for a new version.
   file never leaves your machine. [SECURITY.md](./SECURITY.md) has the
   allowlist, the file mode and the rotation.
 - **A release build asks GitHub whether a newer version exists.** It requests
-  the update manifest published with the releases, on window focus and once an
-  hour, and that is the one request Goodboy makes with nothing connected at
-  all. It carries no data about you, and an update it finds is verified against
-  the signing key shipped in the app before anything is installed.
+  the update manifest published with the releases: once as a window opens, then
+  again when that window regains focus or becomes visible, and once an hour
+  while it stays visible. Only those later checks are spaced half an hour apart,
+  the one at open is not, so launching and clicking into the app sends two
+  requests. That is the only reason Goodboy touches the network with nothing
+  connected at all. It carries no data about you, and an update it finds is
+  verified against the signing key shipped in the app before anything is
+  installed.
 
 If Goodboy disappeared tomorrow, your data would be untouched, because it was
 never ours.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,6 +29,13 @@ Goodboy runs entirely on your machine, no backend:
   values, paths, response bodies or credentials. On macOS and Linux the file is
   owner-only (`0600`). Past 64 KiB it is renamed to `boot-breadcrumbs.log.1`
   and a fresh file starts, so at most two are kept.
+- A release build checks for its own updates, and this is the one request
+  Goodboy makes with no provider connected: it fetches the update manifest
+  `latest.json` published with the GitHub releases, on window focus and hourly,
+  at most once every 30 minutes, and never in a development build. The request
+  carries no data about you or your machine, and any update it finds is
+  verified against the public key in `apps/desktop/src-tauri/tauri.conf.json`
+  before it is installed.
 - No telemetry, of any kind, ever. Adding it is refused whoever asks.
 
 Caveat: a token you paste for an integration (GitHub, GitLab, Jira,
@@ -48,8 +55,8 @@ macOS builds are signed and notarized under the Apple team named in
 touch signing material or secrets.
 
 The Linux AppImage, deb and rpm carry no updater signature and the release
-publishes no update manifest for them: a Linux build never fetches anything
-on its own, every new version is a package taken from the release page.
+publishes no update manifest entry for them: a Linux build is never offered an
+update, and every new version is a package taken from the release page.
 The OS credential store is the Keychain on macOS, and on Linux the
 freedesktop Secret Service (GNOME Keyring or KWallet), so a keyring daemon
 must be running before a token can be saved there.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,13 +29,16 @@ Goodboy runs entirely on your machine, no backend:
   values, paths, response bodies or credentials. On macOS and Linux the file is
   owner-only (`0600`). Past 64 KiB it is renamed to `boot-breadcrumbs.log.1`
   and a fresh file starts, so at most two are kept.
-- A release build checks for its own updates, and this is the one request
-  Goodboy makes with no provider connected: it fetches the update manifest
-  `latest.json` published with the GitHub releases, on window focus and hourly,
-  at most once every 30 minutes, and never in a development build. The request
-  carries no data about you or your machine, and any update it finds is
-  verified against the public key in `apps/desktop/src-tauri/tauri.conf.json`
-  before it is installed.
+- A release build checks for its own updates, and that is the only reason
+  Goodboy touches the network with no provider connected: it fetches the update
+  manifest `latest.json` published with the GitHub releases. Each window checks
+  once as it opens, and after that when it regains focus, when it becomes
+  visible again, and hourly while it stays visible. Only those later checks are
+  spaced, at least 30 minutes apart and counted per window; the check at open is
+  not, so an ordinary launch followed by a click into the app sends two requests
+  seconds apart. A development build never checks. The request carries no data
+  about you or your machine, and any update it finds is verified against the
+  public key in `apps/desktop/src-tauri/tauri.conf.json` before it is installed.
 - No telemetry, of any kind, ever. Adding it is refused whoever asks.
 
 Caveat: a token you paste for an integration (GitHub, GitLab, Jira,

--- a/apps/desktop/src/features/providers/components/ProviderLifecycleTile/StatusPill.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderLifecycleTile/StatusPill.tsx
@@ -27,6 +27,13 @@ function connectionSpec(connection: ProviderConnectionState): PillSpec {
       };
     case 'error':
       return { label: 'Error', tone: 'danger', labelClass: 'text-danger' };
+    case 'unknown':
+      return {
+        label: 'Checking',
+        tone: 'neutral',
+        dotClassName: 'bg-muted-foreground/40',
+        labelClass: 'text-muted-foreground',
+      };
   }
 }
 

--- a/apps/desktop/src/features/providers/components/ProviderStudio/ApiProviderDetail.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/ApiProviderDetail.tsx
@@ -17,7 +17,8 @@ export const ApiProviderDetail = ({ info }: Props) => {
   const color = brandColor(info.id);
   const refreshProviders = useAppStore((state) => state.refreshProviders);
   const [isRefreshing, setIsRefreshing] = useState(false);
-  const isRuntimeReady = info.connection !== 'missing' && info.connection !== 'error';
+  const isRuntimeReady =
+    info.connection !== 'missing' && info.connection !== 'error' && info.connection !== 'unknown';
 
   const onRefresh = useCallback(async () => {
     setIsRefreshing(true);

--- a/apps/desktop/src/features/providers/components/ProviderStudio/ProviderDetailPanel.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/ProviderDetailPanel.tsx
@@ -144,7 +144,7 @@ function Detail({
         )}
       </section>
 
-      {info.connection !== 'missing' && (
+      {info.connection !== 'missing' && info.connection !== 'unknown' && (
         <>
           <ProviderCredentialsSection providerId={id} />
           <ProviderBindingsSection providerId={id} cliIdentity={info.identity} />

--- a/apps/desktop/src/features/providers/components/ProviderStudio/ProvidersRail.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/ProvidersRail.tsx
@@ -16,6 +16,7 @@ const STATUS_TONE: Record<ProviderConnectionState, Tone> = {
   installed_disconnected: 'warning',
   missing: 'neutral',
   error: 'danger',
+  unknown: 'neutral',
 };
 
 const STATUS_LABEL: Record<ProviderConnectionState, string> = {
@@ -23,6 +24,7 @@ const STATUS_LABEL: Record<ProviderConnectionState, string> = {
   installed_disconnected: 'installed',
   missing: 'not installed',
   error: 'error',
+  unknown: 'checking',
 };
 
 export const ProvidersRail = ({ providers, focusedId, onSelect, onSelectDefaults }: Props) => {

--- a/apps/desktop/src/features/providers/providers.test.ts
+++ b/apps/desktop/src/features/providers/providers.test.ts
@@ -75,3 +75,37 @@ describe('Moonshot provider connection', () => {
     expect(openrouter?.connection).toBe('installed_disconnected');
   });
 });
+
+describe('undetected providers', () => {
+  it('reports an unknown API provider connection regardless of credentials', () => {
+    expect(connectionForApiProvider({ status: null, hasCredential: true })).toBe('unknown');
+    expect(connectionForApiProvider({ status: null, hasCredential: false })).toBe('unknown');
+  });
+
+  it('reports unknown connections across undetected provider types', () => {
+    const providers = buildProviderList({
+      anthropic: null,
+      cursor: null,
+      codex: null,
+      gemini: null,
+      opencode: null,
+      openrouter: null,
+      moonshot: null,
+    });
+    const anthropic = providers.find((provider) => provider.id === 'anthropic');
+    const cursor = providers.find((provider) => provider.id === 'cursor');
+    const openrouter = providers.find((provider) => provider.id === 'openrouter');
+    expect(anthropic?.connection).toBe('unknown');
+    expect(cursor?.connection).toBe('unknown');
+    expect(openrouter?.connection).toBe('unknown');
+  });
+
+  it('reports a detected unavailable runtime provider as missing', () => {
+    const providers = buildProviderList({
+      ...statusesFor({ available: true }),
+      cursor: { ...runtimeStatus({ available: false }), id: 'cursor' },
+    });
+    const cursor = providers.find((provider) => provider.id === 'cursor');
+    expect(cursor?.connection).toBe('missing');
+  });
+});

--- a/apps/desktop/src/features/providers/providers.ts
+++ b/apps/desktop/src/features/providers/providers.ts
@@ -120,7 +120,10 @@ export const connectionForApiProvider = ({
   status,
   hasCredential,
 }: ApiConnectionParams): ProviderConnectionState => {
-  if (status?.available !== true) {
+  if (status === null) {
+    return 'unknown';
+  }
+  if (status.available !== true) {
     return 'missing';
   }
   return hasCredential ? 'connected' : 'installed_disconnected';
@@ -158,7 +161,7 @@ function providerInfoFromStatus(
   };
   if (id === 'anthropic') {
     if (!status) {
-      return { ...base, connection: 'missing', version: null, error: null };
+      return { ...base, connection: 'unknown', version: null, error: null };
     }
     const connection = connectionFromDetectionAndAuth(status.available, status.error, auth);
     return {
@@ -168,8 +171,11 @@ function providerInfoFromStatus(
       error: status.available ? null : status.error,
     };
   }
-  if (!status || !status.available) {
-    return { ...base, connection: 'missing', version: null, error: status?.error ?? null };
+  if (status === null) {
+    return { ...base, connection: 'unknown', version: null, error: null };
+  }
+  if (!status.available) {
+    return { ...base, connection: 'missing', version: null, error: status.error ?? null };
   }
   const connection = connectionFromDetectionAndAuth(status.available, status.error, auth);
   return { ...base, connection, version: status.version, error: null };

--- a/apps/desktop/src/shared/hooks/useProviderRefreshOnFocus/index.test.ts
+++ b/apps/desktop/src/shared/hooks/useProviderRefreshOnFocus/index.test.ts
@@ -46,4 +46,18 @@ describe('useProviderRefreshOnFocus', () => {
     await vi.advanceTimersByTimeAsync(1000);
     expect(state.refreshProviders).toHaveBeenCalledOnce();
   });
+
+  it('does not repeat a focus during boot when the ready kick runs', async () => {
+    state.bootPhase = 'loading-workspaces';
+    const view = renderHook(() => useProviderRefreshOnFocus());
+
+    window.dispatchEvent(new Event('focus'));
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(state.refreshProviders).toHaveBeenCalledOnce();
+
+    state.bootPhase = 'ready';
+    view.rerender();
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(state.refreshProviders).toHaveBeenCalledOnce();
+  });
 });

--- a/apps/desktop/src/shared/hooks/useProviderRefreshOnFocus/index.test.ts
+++ b/apps/desktop/src/shared/hooks/useProviderRefreshOnFocus/index.test.ts
@@ -1,0 +1,49 @@
+// @vitest-environment happy-dom
+
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useProviderRefreshOnFocus } from './index';
+
+const state = vi.hoisted(() => ({
+  refreshProviders: vi.fn(async () => undefined),
+  bootPhase: 'pending',
+  providerLifecycle: {},
+  providerConnect: {},
+}));
+
+vi.mock('../../../store/store', () => {
+  const useAppStore = Object.assign(
+    (selector: (value: typeof state) => unknown) => selector(state),
+    { getState: () => state },
+  );
+  return { useAppStore };
+});
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.clearAllMocks();
+  state.bootPhase = 'pending';
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('useProviderRefreshOnFocus', () => {
+  it('runs one provider detection for a cold start followed by a window focus', async () => {
+    state.bootPhase = 'pending';
+    const view = renderHook(() => useProviderRefreshOnFocus());
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(state.refreshProviders).not.toHaveBeenCalled();
+
+    state.bootPhase = 'ready';
+    view.rerender();
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(state.refreshProviders).toHaveBeenCalledOnce();
+
+    window.dispatchEvent(new Event('focus'));
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(state.refreshProviders).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/desktop/src/shared/hooks/useProviderRefreshOnFocus/index.ts
+++ b/apps/desktop/src/shared/hooks/useProviderRefreshOnFocus/index.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useAppStore } from '../../../store/store';
 import { ACTIVE_CONNECT_PHASES } from '../../../store/slices/providers/types';
 
@@ -12,10 +12,11 @@ type ScheduleParams = {
 
 export const useProviderRefreshOnFocus = (): void => {
   const refreshProviders = useAppStore((s) => s.refreshProviders);
+  const bootPhase = useAppStore((s) => s.bootPhase);
+  const lastRunAtRef = useRef(0);
 
   useEffect(() => {
     let timer: number | null = null;
-    let lastRunAt = 0;
 
     const schedule = ({ delayMs = DEBOUNCE_MS }: ScheduleParams): void => {
       if (timer !== null) {
@@ -23,7 +24,7 @@ export const useProviderRefreshOnFocus = (): void => {
       }
       timer = window.setTimeout(() => {
         timer = null;
-        const elapsed = Date.now() - lastRunAt;
+        const elapsed = Date.now() - lastRunAtRef.current;
         if (elapsed < REFRESH_TTL_MS) {
           schedule({ delayMs: REFRESH_TTL_MS - elapsed });
           return;
@@ -40,7 +41,7 @@ export const useProviderRefreshOnFocus = (): void => {
           return;
         }
 
-        lastRunAt = Date.now();
+        lastRunAtRef.current = Date.now();
         void refreshProviders();
       }, delayMs);
     };
@@ -54,6 +55,9 @@ export const useProviderRefreshOnFocus = (): void => {
 
     window.addEventListener('focus', onFocus);
     document.addEventListener('visibilitychange', onVisibility);
+    if (bootPhase === 'ready') {
+      schedule({});
+    }
     return () => {
       window.removeEventListener('focus', onFocus);
       document.removeEventListener('visibilitychange', onVisibility);
@@ -61,5 +65,5 @@ export const useProviderRefreshOnFocus = (): void => {
         window.clearTimeout(timer);
       }
     };
-  }, [refreshProviders]);
+  }, [bootPhase, refreshProviders]);
 };

--- a/apps/desktop/src/store/slices/boot/hydrate.ts
+++ b/apps/desktop/src/store/slices/boot/hydrate.ts
@@ -5,19 +5,6 @@ import { invoke } from '@tauri-apps/api/core';
 import { runDbMigrations, tauriDatabase } from '../../../shared/lib/db';
 import { migrateLsToDb } from '../../../shared/lib/ls-to-db-migration';
 import { hydrateOnboardingFromDb } from '../../../features/onboarding/onboarding-store';
-import {
-  buildProviderList,
-  checkProviderAuth,
-  getCodexStatus,
-  getCursorStatus,
-  getGeminiStatus,
-  getMoonshotStatus,
-  getOpenCodeStatus,
-  getOpenRouterStatus,
-  getProviderStatus,
-  type ProviderAuthResults,
-  type ProviderStatuses,
-} from '../../../features/providers/providers';
 import { setWindowTitle, targetWorkspaceFromHash } from '../../../features/workspace/window';
 import { consumeReloadIntent } from '../../../features/workspace/windowView';
 import {
@@ -54,16 +41,10 @@ export const hydrate = (set: SetFn, get: GetFn) => {
     }
     hydratePromise = (async () => {
       const bootStartedAt = Date.now();
-      let previousTransitionAt = bootStartedAt;
       try {
         recordBootBreadcrumb({ phase: 'pending', detail: 'start' });
         const migratingAt = Date.now();
         set({ bootPhase: 'migrating', error: null });
-        recordBootBreadcrumb({
-          phase: 'migrating',
-          detail: `ms=${migratingAt - previousTransitionAt}`,
-        });
-        previousTransitionAt = migratingAt;
         await runDbMigrations();
         await migrateLsToDb();
         await hydrateOnboardingFromDb();
@@ -71,14 +52,13 @@ export const hydrate = (set: SetFn, get: GetFn) => {
         void get()
           .loadNotifications()
           .catch(() => {});
+        recordBootBreadcrumb({
+          phase: 'migrating',
+          detail: `ms=${Date.now() - migratingAt}`,
+        });
 
         const loadingSettingsAt = Date.now();
         set({ bootPhase: 'loading-settings' });
-        recordBootBreadcrumb({
-          phase: 'loading-settings',
-          detail: `ms=${loadingSettingsAt - previousTransitionAt}`,
-        });
-        previousTransitionAt = loadingSettingsAt;
         const [editorBinary, lastWorkspaceRaw, lastSessionRaw, reopenLastRaw] = await Promise.all([
           getSetting(tauriDatabase, SETTING_EDITOR_BINARY),
           getSetting(tauriDatabase, SETTING_LAST_WORKSPACE_ID),
@@ -101,92 +81,23 @@ export const hydrate = (set: SetFn, get: GetFn) => {
           }
           return { settings: next };
         });
+        recordBootBreadcrumb({
+          phase: 'loading-settings',
+          detail: `ms=${Date.now() - loadingSettingsAt}`,
+        });
 
         const detectingCliAt = Date.now();
         set({ bootPhase: 'detecting-cli' });
-        recordBootBreadcrumb({
-          phase: 'detecting-cli',
-          detail: `ms=${detectingCliAt - previousTransitionAt}`,
-        });
-        previousTransitionAt = detectingCliAt;
-        const [
-          providerStatus,
-          cursorStatus,
-          codexStatus,
-          geminiStatus,
-          opencodeStatus,
-          openrouterStatus,
-          moonshotStatus,
-        ] = await Promise.all([
-          getProviderStatus('anthropic'),
-          getCursorStatus(),
-          getCodexStatus(),
-          getGeminiStatus(),
-          getOpenCodeStatus(),
-          getOpenRouterStatus(),
-          getMoonshotStatus(),
-        ]);
-        const statuses: ProviderStatuses = {
-          anthropic: providerStatus,
-          cursor: cursorStatus,
-          codex: codexStatus,
-          gemini: geminiStatus,
-          opencode: opencodeStatus,
-          openrouter: openrouterStatus,
-          moonshot: moonshotStatus,
-        };
-        set({
-          providerStatus,
-          cursorStatus,
-          codexStatus,
-          geminiStatus,
-          providers: buildProviderList(statuses),
-        });
-
-        const [
-          anthropicAuth,
-          cursorAuth,
-          codexAuth,
-          geminiAuth,
-          opencodeAuth,
-          openrouterAuth,
-          moonshotAuth,
-        ] = await Promise.all([
-          checkProviderAuth('anthropic'),
-          checkProviderAuth('cursor'),
-          checkProviderAuth('codex'),
-          checkProviderAuth('gemini'),
-          checkProviderAuth('opencode'),
-          checkProviderAuth('openrouter'),
-          checkProviderAuth('moonshot'),
-        ]);
-        const authResults: ProviderAuthResults = {
-          anthropic: anthropicAuth,
-          cursor: cursorAuth,
-          codex: codexAuth,
-          gemini: geminiAuth,
-          opencode: opencodeAuth,
-          openrouter: openrouterAuth,
-          moonshot: moonshotAuth,
-        };
-        set({ authResults, providers: buildProviderList(statuses, authResults) });
-
-        const loadingWorkspacesAt = Date.now();
-        set({ bootPhase: 'loading-workspaces' });
-        recordBootBreadcrumb({
-          phase: 'loading-workspaces',
-          detail: `ms=${loadingWorkspacesAt - previousTransitionAt}`,
-        });
-        previousTransitionAt = loadingWorkspacesAt;
         await get()
           .loadCredentials()
           .catch(() => {});
-        const credentialProviderIds = new Set(
-          get().providerCredentials.map((item) => item.providerId),
-        );
-        set({
-          providers: buildProviderList(statuses, authResults, credentialProviderIds),
+        recordBootBreadcrumb({
+          phase: 'detecting-cli',
+          detail: `ms=${Date.now() - detectingCliAt}`,
         });
+
+        const loadingWorkspacesAt = Date.now();
+        set({ bootPhase: 'loading-workspaces' });
         const workspaces = await listWorkspaces(tauriDatabase);
         set({ workspaces });
         await Promise.all(
@@ -218,14 +129,13 @@ export const hydrate = (set: SetFn, get: GetFn) => {
         }
 
         await applyQaDecidingPreview({ set }).catch(() => {});
+        recordBootBreadcrumb({
+          phase: 'loading-workspaces',
+          detail: `ms=${Date.now() - loadingWorkspacesAt}`,
+        });
 
         const restoringSessionAt = Date.now();
         set({ bootPhase: 'restoring-session' });
-        recordBootBreadcrumb({
-          phase: 'restoring-session',
-          detail: `ms=${restoringSessionAt - previousTransitionAt}`,
-        });
-        previousTransitionAt = restoringSessionAt;
         const reloadIntent = consumeReloadIntent();
         if (reloadIntent?.mode === 'restore') {
           const snapWorkspace = workspaces.find((w) => w.id === reloadIntent.workspaceId) ?? null;
@@ -275,6 +185,10 @@ export const hydrate = (set: SetFn, get: GetFn) => {
           }
         }
 
+        recordBootBreadcrumb({
+          phase: 'restoring-session',
+          detail: `ms=${Date.now() - restoringSessionAt}`,
+        });
         set({ bootPhase: 'ready', hydrated: true });
         recordBootBreadcrumb({
           phase: 'ready',

--- a/apps/desktop/src/store/slices/boot/index.test.ts
+++ b/apps/desktop/src/store/slices/boot/index.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment happy-dom
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SETTING_EDITOR_BINARY } from '../../../features/settings/settings';
 import { SETTING_CHANGELOG_SEEN } from '../changelog/state';
 import type {
   Agent,
@@ -46,6 +47,7 @@ vi.mock('@tauri-apps/api/event', () => ({
 }));
 
 const listWorkspacesSpy = vi.fn(async () => [] as ReadonlyArray<Workspace>);
+const listProviderCredentialsSpy = vi.fn(async () => []);
 const runDbMigrationsSpy = vi.fn(async () => undefined);
 const dbSetSettingSpy = vi.fn(async () => undefined);
 const dbGetSettingSpy: ReturnType<typeof vi.fn> = vi.fn<() => Promise<string | null>>(
@@ -154,7 +156,7 @@ vi.mock('@goodboy/db', () => ({
   getGithubPrCache: vi.fn(async () => null),
   upsertGithubPrCache: vi.fn(async () => undefined),
   deleteGithubPrCache: vi.fn(async () => undefined),
-  listProviderCredentials: vi.fn(async () => []),
+  listProviderCredentials: listProviderCredentialsSpy,
 }));
 
 vi.mock('../../../shared/lib/db', () => ({
@@ -555,6 +557,61 @@ describe('store contract', () => {
       const s = store.getState();
       expect(s.hydrated).toBe(true);
       expect(s.bootPhase).toBe('ready');
+    });
+
+    it('reports the elapsed time of the phase named by every boot breadcrumb', async () => {
+      type BreadcrumbDetailParams = { phase: string };
+
+      const store = await getStore();
+      let clock = 0;
+      const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => clock);
+      runDbMigrationsSpy.mockImplementationOnce(async () => {
+        clock = 10;
+      });
+      dbGetSettingSpy.mockImplementation(async (_db: unknown, key: string) => {
+        if (key === SETTING_EDITOR_BINARY) {
+          clock = 1_010;
+        }
+        return null;
+      });
+      listProviderCredentialsSpy.mockImplementationOnce(async () => {
+        clock = 1_040;
+        return [];
+      });
+
+      await store.getState().hydrate();
+      nowSpy.mockRestore();
+
+      const calls = invokeSpy.mock.calls as unknown as ReadonlyArray<ReadonlyArray<unknown>>;
+      const breadcrumbDetail = ({ phase }: BreadcrumbDetailParams): unknown => {
+        const call = calls.find(([command, payload]) => {
+          if (command !== 'boot_breadcrumb') {
+            return false;
+          }
+          if (typeof payload !== 'object' || payload === null) {
+            return false;
+          }
+          if (!('phase' in payload)) {
+            return false;
+          }
+          return payload.phase === phase;
+        });
+        if (call === undefined) {
+          return undefined;
+        }
+        const payload = call[1];
+        if (typeof payload !== 'object' || payload === null) {
+          return undefined;
+        }
+        if (!('detail' in payload)) {
+          return undefined;
+        }
+        return payload.detail;
+      };
+
+      expect(breadcrumbDetail({ phase: 'migrating' })).toBe('ms=10');
+      expect(breadcrumbDetail({ phase: 'loading-settings' })).toBe('ms=1000');
+      expect(breadcrumbDetail({ phase: 'detecting-cli' })).toBe('ms=30');
     });
 
     it('joins the in-flight hydration instead of starting a second run on retry', async () => {

--- a/apps/desktop/src/store/slices/boot/index.test.ts
+++ b/apps/desktop/src/store/slices/boot/index.test.ts
@@ -581,6 +581,15 @@ describe('store contract', () => {
       expect(store.getState().bootPhase).toBe('ready');
     });
 
+    it('runs the database migrations once when two hydrations start concurrently', async () => {
+      const store = await getStore();
+
+      await Promise.all([store.getState().hydrate(), store.getState().hydrate()]);
+
+      expect(runDbMigrationsSpy).toHaveBeenCalledOnce();
+      expect(store.getState().bootPhase).toBe('ready');
+    });
+
     it('still restarts hydration when retry runs after a failed attempt', async () => {
       const store = await getStore();
       listWorkspacesSpy.mockRejectedValueOnce(new Error('boom'));

--- a/apps/desktop/src/store/slices/boot/index.test.ts
+++ b/apps/desktop/src/store/slices/boot/index.test.ts
@@ -612,6 +612,9 @@ describe('store contract', () => {
       expect(breadcrumbDetail({ phase: 'migrating' })).toBe('ms=10');
       expect(breadcrumbDetail({ phase: 'loading-settings' })).toBe('ms=1000');
       expect(breadcrumbDetail({ phase: 'detecting-cli' })).toBe('ms=30');
+      expect(breadcrumbDetail({ phase: 'loading-workspaces' })).toBe('ms=0');
+      expect(breadcrumbDetail({ phase: 'restoring-session' })).toBe('ms=0');
+      expect(breadcrumbDetail({ phase: 'ready' })).toBe('ms=1040,ok');
     });
 
     it('joins the in-flight hydration instead of starting a second run on retry', async () => {

--- a/apps/desktop/src/store/slices/providers/connectProvider.test.ts
+++ b/apps/desktop/src/store/slices/providers/connectProvider.test.ts
@@ -62,13 +62,34 @@ type Harness = {
   readonly errorTail: () => string | null;
 };
 
-const harness = ({ missing }: { readonly missing?: ProviderId } = {}): Harness => {
+const providerConnection = ({
+  id,
+  missing,
+  undetected,
+}: {
+  readonly id: ProviderId;
+  readonly missing?: ProviderId;
+  readonly undetected?: ProviderId;
+}) => {
+  if (id === missing) {
+    return 'missing';
+  }
+  if (id === undetected) {
+    return 'unknown';
+  }
+  return 'installed_disconnected';
+};
+
+const harness = ({
+  missing,
+  undetected,
+}: { readonly missing?: ProviderId; readonly undetected?: ProviderId } = {}): Harness => {
   let state: Record<string, unknown> = {
     providerConnect: { ...INITIAL_CONNECT_MAP },
     providerLifecycle: { ...INITIAL_LIFECYCLE_MAP },
     providers: PROVIDER_IDS.map((id) => ({
       id,
-      connection: id === missing ? 'missing' : 'installed_disconnected',
+      connection: providerConnection({ id, missing, undetected }),
     })),
     refreshProviders: vi.fn(async () => undefined),
     emitNotification: vi.fn(async () => undefined),
@@ -219,6 +240,15 @@ describe('connectProvider', () => {
     void h.connect('anthropic');
     await vi.advanceTimersByTimeAsync(60_000);
     expect(h.phase()).toBe('working');
+    expect(mocks.invokeProviderLifecycleRun).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'install' }),
+    );
+  });
+
+  it('installs an undetected provider before login rather than assuming it is present', async () => {
+    const h = harness({ undetected: 'anthropic' });
+    void h.connect('anthropic');
+    await vi.advanceTimersByTimeAsync(60_000);
     expect(mocks.invokeProviderLifecycleRun).toHaveBeenCalledWith(
       expect.objectContaining({ action: 'install' }),
     );

--- a/apps/desktop/src/store/slices/providers/connectProvider.ts
+++ b/apps/desktop/src/store/slices/providers/connectProvider.ts
@@ -436,7 +436,7 @@ const isInstalled = ({ get, providerId }: InstalledParams): boolean => {
   if (info === undefined) {
     return false;
   }
-  return info.connection !== 'missing';
+  return info.connection !== 'missing' && info.connection !== 'unknown';
 };
 
 export const connectProvider = (set: SetFn, get: GetFn) => {

--- a/apps/desktop/src/store/slices/providers/refreshProviderStatus.ts
+++ b/apps/desktop/src/store/slices/providers/refreshProviderStatus.ts
@@ -20,7 +20,8 @@ const statusFor = ({ providers, id }: StatusParams): ProviderStatus | null => {
   return {
     id,
     binary: info.binary,
-    available: info.connection !== 'missing' && info.connection !== 'error',
+    available:
+      info.connection !== 'missing' && info.connection !== 'error' && info.connection !== 'unknown',
     version: info.version,
     error: info.error,
   };

--- a/apps/desktop/src/store/slices/providers/refreshProviders.test.ts
+++ b/apps/desktop/src/store/slices/providers/refreshProviders.test.ts
@@ -1,4 +1,8 @@
+// @vitest-environment happy-dom
+
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { cursorMaxModeAdvisory } from '../../../shared/lib/cursorMaxModeAdvisory';
+import { STORAGE_PREFIXES } from '../../../shared/lib/storage-keys';
 import { refreshProviders } from './refreshProviders';
 import { IDLE_CONNECT, INITIAL_CONNECT_MAP } from './types';
 
@@ -15,7 +19,10 @@ const providerMocks = vi.hoisted(() => {
     buildProviderList: vi.fn(
       (_statuses: unknown, _authResults: unknown, _credentialProviderIds: unknown) => [],
     ),
-    checkProviderAuth: vi.fn(async () => ({ state: 'unknown', identity: null })),
+    checkProviderAuth: vi.fn(async (): Promise<{ state: string; identity: string | null }> => ({
+      state: 'unknown',
+      identity: null,
+    })),
     refreshProviderDetection: vi.fn(async () => status),
   };
 });
@@ -24,6 +31,7 @@ vi.mock('../../../features/providers/providers', () => providerMocks);
 
 beforeEach(() => {
   vi.clearAllMocks();
+  localStorage.clear();
 });
 
 describe('refreshProviders', () => {
@@ -80,5 +88,51 @@ describe('refreshProviders', () => {
     await refreshProviders(set as never, get as never)();
     const patch = set.mock.calls[0]?.[0] as { providerConnect: typeof INITIAL_CONNECT_MAP };
     expect(patch.providerConnect.cursor).toEqual(connected);
+  });
+
+  it('keeps every cursor max mode key on the first refresh after a cold start', async () => {
+    const key = STORAGE_PREFIXES.cursorMaxMode + 'someone%40example.com:composer-1';
+    localStorage.setItem(key, '1');
+    const clearAll = vi.spyOn(cursorMaxModeAdvisory, 'clearAll');
+    providerMocks.checkProviderAuth.mockResolvedValue({
+      state: 'connected',
+      identity: 'someone@example.com',
+    });
+    const get = vi.fn(() => ({
+      authResults: null,
+      providerCredentials: [],
+      providerConnect: INITIAL_CONNECT_MAP,
+    }));
+    const set = vi.fn();
+
+    await refreshProviders(set as never, get as never)();
+
+    expect(clearAll).not.toHaveBeenCalled();
+    expect(localStorage.getItem(key)).toBe('1');
+    clearAll.mockRestore();
+  });
+
+  it('still clears the cursor max mode keys when a known identity changes', async () => {
+    const key = STORAGE_PREFIXES.cursorMaxMode + 'someone%40example.com:composer-1';
+    localStorage.setItem(key, '1');
+    const clearAll = vi.spyOn(cursorMaxModeAdvisory, 'clearAll');
+    providerMocks.checkProviderAuth.mockResolvedValue({
+      state: 'connected',
+      identity: 'someone@example.com',
+    });
+    const get = vi.fn(() => ({
+      authResults: {
+        cursor: { state: 'connected', identity: 'previous@example.com' },
+      },
+      providerCredentials: [],
+      providerConnect: INITIAL_CONNECT_MAP,
+    }));
+    const set = vi.fn();
+
+    await refreshProviders(set as never, get as never)();
+
+    expect(clearAll).toHaveBeenCalledOnce();
+    expect(localStorage.getItem(key)).toBeNull();
+    clearAll.mockRestore();
   });
 });

--- a/apps/desktop/src/store/slices/providers/refreshProviders.ts
+++ b/apps/desktop/src/store/slices/providers/refreshProviders.ts
@@ -11,8 +11,9 @@ import type { GetFn, SetFn } from './types';
 
 export const refreshProviders = (set: SetFn, get: GetFn) => {
   return async () => {
-    const previousCursorIdentity = get().authResults?.cursor?.identity ?? null;
-    const previousCursorState = get().authResults?.cursor?.state ?? null;
+    const previousAuthResults = get().authResults;
+    const previousCursorIdentity = previousAuthResults?.cursor?.identity ?? null;
+    const previousCursorState = previousAuthResults?.cursor?.state ?? null;
     const [providerStatus, cursorStatus, codexStatus, geminiStatus, opencodeStatus] =
       await Promise.all([
         refreshProviderDetection({ id: 'anthropic' }),
@@ -59,8 +60,10 @@ export const refreshProviders = (set: SetFn, get: GetFn) => {
       moonshot: moonshotAuth,
     };
     if (
-      previousCursorIdentity !== cursorAuth.identity ||
-      (cursorAuth.state === 'connected' && previousCursorState !== 'connected')
+      previousAuthResults !== null &&
+      previousAuthResults !== undefined &&
+      (previousCursorIdentity !== cursorAuth.identity ||
+        (cursorAuth.state === 'connected' && previousCursorState !== 'connected'))
     ) {
       cursorMaxModeAdvisory.clearAll({});
     }

--- a/apps/desktop/src/store/slices/providers/runLifecycle.ts
+++ b/apps/desktop/src/store/slices/providers/runLifecycle.ts
@@ -99,7 +99,8 @@ const storedStatus = ({ providerId, providers }: StoredStatusParams): ProviderSt
   return {
     id: providerId,
     binary: info.binary,
-    available: info.connection !== 'missing' && info.connection !== 'error',
+    available:
+      info.connection !== 'missing' && info.connection !== 'error' && info.connection !== 'unknown',
     version: info.version,
     error: info.error,
   };

--- a/packages/types/src/provider-registry.ts
+++ b/packages/types/src/provider-registry.ts
@@ -16,7 +16,8 @@ type ProviderIdsAreTotal =
   Exclude<ProviderId, (typeof PROVIDER_IDS)[number]> extends never ? true : false;
 type _ProviderIdsTotalCheck = Expect<ProviderIdsAreTotal>;
 
-export type ProviderConnectionState = 'connected' | 'installed_disconnected' | 'missing' | 'error';
+export type ProviderConnectionState =
+  'connected' | 'installed_disconnected' | 'missing' | 'error' | 'unknown';
 
 export type ModelFamily =
   'claude' | 'gpt' | 'codex' | 'gemini' | 'composer' | 'cursor-auto' | 'other';


### PR DESCRIPTION
Merge unit MU5, "boot": the release's performance and reliability floor. Three
items, one branch, provenance per item below.

## Item 8: every boot breadcrumb now reports the phase it names

`hydrate` stamped each breadcrumb's `ms=` with the duration of the **preceding**
phase while tagging it with the phase being **entered**. Each phase now records
a start timestamp on entry, does its work, and writes its own elapsed time when
it ends. `previousTransitionAt` is gone. `pending start`, the total on `ready`
and the `error` breadcrumb are unchanged, and the `set({ bootPhase })` calls
keep their order and position.

The Rust half needed no change and has none: `PHASES` gains nothing because the
sequence reaches no new phase, and `sanitize_detail` is untouched
(`git diff origin/main -- apps/desktop/src-tauri` is empty).

### The pin the instrument never had

The first revision shipped this fix unpinned, in the very PR whose body records
that the inversion survived four releases because nothing checked it. Reverting
the timing to the exact pre-PR inversion left all 660 files and 5674 tests
green. It now does not.

**`reports the elapsed time of the phase named by every boot breadcrumb`** in
`store/slices/boot/index.test.ts` patches `Date.now` with a controllable clock
and moves it forward from inside mocks that each run in exactly one phase:
`runDbMigrations` in `migrating`, the `editor.binary` read in
`loading-settings`, the credential read that is the whole of `detecting-cli`.
The three phases therefore carry three distinct known durations, and the test
reads the `detail` of each `boot_breadcrumb` invoke out of the existing
`invokeSpy`.

The assertion is on the numbers, not on the shape: a regex over `ms=\d+` would
survive the very inversion the test exists to catch. Watched failing against
the restored inversion first, per phase:

- `migrating`: `expected 'ms=0' to be 'ms=10'`
- `detecting-cli`, the phase the block named: `expected 'ms=1000' to be 'ms=30'`,
  the predecessor's duration reported under this phase's name, which is the
  defect in one line.

### The v0.1.80 baseline, re-attributed under the old semantics

This unit rewrites the instrument the release's speed claim is measured with,
so the old numbers have to be restated before the new stamp lands. Source:
10 complete v0.1.80 launches in the local breadcrumb sink.

| breadcrumb tag (v0.1.80) | phase the number actually measures | v0.1.80 range |
| --- | --- | --- |
| `migrating ms=` | store setup before migrating | 0-1 ms |
| `loading-settings ms=` | migrating | 6-388 ms |
| `detecting-cli ms=` | loading-settings | 1-3 ms |
| `loading-workspaces ms=` | **detecting-cli, the 14 provider round-trips** | **1084-7514 ms** |
| `restoring-session ms=` | loading-workspaces | 3-7 ms |
| `ready ms=,ok` | total boot, correct under both semantics | 1108-7911 ms |

Per launch, the number tagged `loading-workspaces` (really detecting-cli):
1084, 2225, 2426, 1210, 1933, 7514, 5312, 1211, 2616, 2383 ms. Median around
2300 ms, which is 88 to 99 percent of each recorded total. Any v0.1.81 speed
claim must be walked against **that** column, not against the label it carried.

This also confirms ADR 0007 Probe 2 named the wrong phase: its
"loading-workspaces ms=2591 dominates this launch" was detecting-cli's cost.

## Item 9: provider detection leaves the boot-to-board path

The 7 `get_*_status` invokes and the 7 `checkProviderAuth` invokes, one of them
a `claude auth status` subprocess, no longer run before `bootPhase: 'ready'`.
`loadCredentials` stays on boot and is now the whole of the `detecting-cli`
phase.

**Reaching the board no longer means the app knows which providers exist.**
That is a deliberate, stated change of what `ready` implies. Until the first
post-boot detection lands, every provider sits in a fifth
`ProviderConnectionState` member, `unknown`, added because `buildProviderList`
mapped a null status to `missing`, which made "not yet detected" byte-identical
to "CLI not installed".

`unknown` is consumed exhaustively. The compiler forced 2 Records
(`STATUS_TONE`, `STATUS_LABEL`) and 1 defaultless switch (`StatusPill`). The
comparisons it could not force were checked by hand: all 27 `connection ===`
sites compare against `'connected'` or `'error'` and are correct unchanged; all
5 `connection !==` sites were deciders that had to exclude the new member and
now do, in `ApiProviderDetail`, `ProviderDetailPanel`, `connectProvider`,
`refreshProviderStatus` and `runLifecycle`. Every decider gating a connect, a
credential write or a runtime call treats `unknown` as not connected.

The first post-boot detection is `useProviderRefreshOnFocus`, which now also
fires once the boot phase reaches `ready` and holds its 60 second TTL in a ref
so the kick and a following focus share it. No third caller of
`checkProviderAuth` exists.

### The data-loss guard, and the test that pins it

Boot used to seed `authResults`, so `refreshProviders`'s `?? null` never fired.
Moving detection off boot would have made the first post-boot refresh compare a
never-known `null` against the real cursor identity and call
`cursorMaxModeAdvisory.clearAll()`, deleting every `cursorMaxMode` localStorage
key the user taught the app, on every launch, with no undo. The comparison now
runs only when the previous auth results are a known value.

Nothing new holds `authResults` in between: it stays unset until the first
refresh. No `setItem`, no `setSetting`, no filesystem write of provider auth
state, identity or email was added in any file this branch touches.

Pinned by **`keeps every cursor max mode key on the first refresh after a cold
start`** in `refreshProviders.test.ts`, which asserts `clearAll` is never called
and the seeded key survives. It was watched failing against the unguarded code
first: `expected "clearAll" to not be called at all, but actually been called
1 times`. Its sibling, `still clears the cursor max mode keys when a known
identity changes`, proves the guard did not disable the real behavior.

The memo dedupe guard in `hydrate` also gets its missing pin:
**`runs the database migrations once when two hydrations start concurrently`**
in `store/slices/boot/index.test.ts`. The existing coverage only went through
`retryHydrate`, so deleting the guard stayed green.

### The three pins the new union member now carries

`unknown` was introduced, consumed and reasoned about, but three of the places
that hold it were free to revert with the suite still green. They are pinned
now, each watched failing against its own revert first:

- **the pure function that produces the member at all.**
  `connectionForApiProvider`'s null arm and both `providerInfoFromStatus` null
  arms, covered in `providers.test.ts` for an api provider, for `anthropic` and
  for a runtime provider, which are three separate code arms. Reverted:
  `expected 'missing' to be 'unknown'`. A companion case keeps `missing` on a
  status that is present and unavailable, so the two states stay distinct.
- **the decider that gates a connect.** `isInstalled` in `connectProvider.ts`
  must not treat a never-detected provider as installed. Reverted, connect runs
  `action: 'login'` where the test expects `action: 'install'`.
- **the refresh TTL that survives the effect re-running.**
  `useProviderRefreshOnFocus` holds `lastRunAt` in a ref because the effect
  re-runs on every boot phase transition. A window focus landing inside a slow
  boot phase runs one detection; with an effect-local counter the `ready` kick
  resets the TTL and runs a second full detection milliseconds later. Reverted:
  `expected "vi.fn()" to be called once, but got 2 times`. Reachable, not
  theoretical: the v0.1.80 table above shows single phases running seconds.

## Item 3: the disclosure ADR 0007 owes

`README.md` claimed nothing is stored, logged or transmitted anywhere except to
the services you connected. Two benign omissions now appear in the same list:
`~/.goodboy/boot-breadcrumbs.log`, and the release build's fetch of the update
manifest, which happens with nothing connected at all.

The updater disclosure lands in **both** documents. `SECURITY.md` already
covered the breadcrumb file, its allowlist, its `0600` mode, its cap and its
rotation, and that section is untouched; it gains the positive updater
statement, and its "a Linux build never fetches anything on its own" is
corrected, because `tauri_plugin_updater` is registered under `#[cfg(desktop)]`
for every desktop target. What is true of Linux is that no manifest entry is
published for it, so it is never offered an update.

**Correction after the security review.** The first draft of that statement said
the check runs "on window focus and hourly, at most once every 30 minutes" and
called it "the one request". Both are false. `App.tsx:203-208` calls
`checkForUpdates()` on every mount of a PROD build, outside `useUpdaterPolling`
entirely, and the hook's `lastRunAt` starts at `0` inside a per-mount closure, so
the first focus after launch clears the 30 minute gate and issues a second
request seconds later. Both documents now name the check at window open, scope
the 30 minute floor to the checks a window makes after opening, and drop the
single-request count. No production code changed: the wording was wrong, not the
behaviour.

For the backlog: the per-window update check is **pre-existing**, not introduced
here, and its recheck TTL lives in `useUpdaterPolling`'s per-mount closure, so it
is **per window rather than per process**; each window opened via
`spawnWorkspaceWindow` loads `index.html` afresh and carries its own launch check
and its own gate.

## Breadcrumbs now land at phase exit, and that is accepted

A breadcrumb is written when a phase ends, so a boot that throws or hangs
inside a phase writes no breadcrumb naming that phase. This is a conscious
acceptance, not an oversight, and the reason is that the missing line carries
no information the sink does not already hold.

Every line is `<unix millis> <launch id> <phase> [detail]`, so each line
timestamps the moment its phase ended, and the phase order is fixed in
`hydrate`. A boot that dies inside phase P leaves P-1's exit line as the last
line of the launch: P is the next phase in that fixed order, and P's start is
that line's timestamp. A throw additionally writes the `error` breadcrumb. The
failing phase and its start time are both recoverable, so an entry line would
add nothing except a second line per phase in a size-capped, rotating file,
which buys the loss of retained launch history.

The one case this reasoning does not cover, a hang with no further line at all,
is also the case an entry breadcrumb would not resolve either: it would name
the phase but never its duration, which the last exit timestamp plus the file's
own write time already bound.

## Dead surface this leaves behind, for the backlog

`getCodexStatus`, `getCursorStatus`, `getGeminiStatus`, `getMoonshotStatus`,
`getOpenCodeStatus`, `getOpenRouterStatus` and `getProviderStatus` in
`features/providers/providers.ts` now have zero production callers: boot was
the last one, and `refreshProviders` calls the Tauri commands through its own
path. knip's configured scope does not examine unused exports, so CI stays
green on them. They are not deleted here on purpose: this is a repair pass on
a merge unit whose `src-tauri` diff must stay byte-empty, and removing the
exports invites removing the Rust commands behind them. Noted so it reaches the
backlog rather than rotting.

## Files another item claims

`apps/desktop/src-tauri/src/lib.rs` (MU8, MU9) and
`packages/types/src/workspace.ts` (MU9) are untouched.
`app/components/BootSplash/index.tsx` (MU1) is untouched and still compiles:
`BootPhase` keeps all eight members, `detecting-cli` included, so the
`Record<BootPhase, string>` in `BOOT_PHASE_LABEL` is unaffected. Note for MU1:
`detecting-cli` now covers only the local credential read, so its copy
("detecting agents") is no longer accurate and is worth rewording there.

## Test plan

- `CI=1 pnpm exec turbo run test --force`: 4 of 4 tasks, **660 test files, 5680
  tests, `0 cached`**. Reference on `main` at `35b1e2030` was 659 files and 5670
  tests: the 1 new file and 4 new tests of the first revision, plus the 6 pins
  added by this repair, which land in files that already existed.
- `CI=1 pnpm exec turbo run typecheck`: 5 of 5 green, which is what proves the
  new union member is consumed exhaustively.
- `cargo test --locked`: 431 passed, 0 failed. `cargo fmt` was not run, so the
  `provider_credentials.rs` reformat is not in this diff.


