### PR TITLE
fix(desktop): first-run progress agrees with the app on first paint

### DIFF
--- a/apps/desktop/src/features/onboarding/OnboardingCard/index.test.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingCard/index.test.tsx
@@ -1,12 +1,13 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { OnboardingStepId } from '../onboarding-store';
 
 const { finishMock, progress } = vi.hoisted(() => ({
   finishMock: vi.fn(),
   progress: {
     completedCount: 0,
     totalCount: 2,
-    completed: new Set(),
+    completed: new Set<OnboardingStepId>(),
     collapsed: true,
     finished: false,
     isDone: false,
@@ -58,6 +59,15 @@ describe('OnboardingCard', () => {
 });
 
 describe('OnboardingChip', () => {
+  it('fills the completed checklist ids instead of leading positions', () => {
+    progress.completedCount = 1;
+    progress.completed = new Set(['session']);
+    const { container } = render(<OnboardingChip />);
+    const dots = container.querySelectorAll('[aria-hidden="true"]');
+    expect(dots[0]?.className).toContain('bg-border');
+    expect(dots[1]?.className).toContain('bg-primary');
+  });
+
   it('finishes onboarding from the skip button', () => {
     render(<OnboardingChip />);
     fireEvent.click(screen.getByRole('button', { name: 'Skip tutorial' }));

--- a/apps/desktop/src/features/onboarding/OnboardingCard/index.test.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingCard/index.test.tsx
@@ -31,6 +31,8 @@ vi.mock('../hooks/useOnboardingProgress', () => ({
 
 beforeEach(() => {
   progress.collapsed = true;
+  progress.completedCount = 0;
+  progress.completed = new Set<OnboardingStepId>();
 });
 
 afterEach(() => {

--- a/apps/desktop/src/features/onboarding/OnboardingCard/index.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingCard/index.tsx
@@ -158,13 +158,13 @@ export const OnboardingChip = () => {
         aria-label="Open onboarding checklist"
         className="inline-flex items-center gap-1"
       >
-        {visibleSteps.map((step, i) => (
+        {visibleSteps.map((step) => (
           <span
             key={step.id}
             aria-hidden
             className={cn(
               'size-1.5 rounded-full motion-safe:transition-colors',
-              i < progress.completedCount ? 'bg-primary' : 'bg-border',
+              progress.completed.has(step.id) ? 'bg-primary' : 'bg-border',
             )}
           />
         ))}

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/Stepper.test.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/Stepper.test.tsx
@@ -1,0 +1,26 @@
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { Stepper } from './Stepper';
+
+afterEach(cleanup);
+
+describe('Stepper', () => {
+  it('marks the current step distinctly and uses checklist completion ahead of it', () => {
+    const { container } = render(
+      <Stepper current={3} steps={[0, 1, 2, 3, 4, 5, 6, 7]} completed={new Set(['codeHost'])} />,
+    );
+    const dots = container.querySelectorAll('[data-state]');
+    expect(dots).toHaveLength(8);
+    expect(dots[2]?.getAttribute('data-state')).toBe('done');
+    expect(dots[3]?.getAttribute('data-state')).toBe('current');
+    expect(dots[4]?.getAttribute('data-state')).toBe('done');
+    expect(dots[5]?.getAttribute('data-state')).toBe('pending');
+  });
+
+  it('uses the supplied step list for standalone workspaces', () => {
+    const { container } = render(
+      <Stepper current={5} steps={[0, 1, 2, 3, 5, 7]} completed={new Set()} />,
+    );
+    expect(container.querySelectorAll('[data-state]')).toHaveLength(6);
+  });
+});

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/Stepper.test.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/Stepper.test.tsx
@@ -17,6 +17,22 @@ describe('Stepper', () => {
     expect(dots[5]?.getAttribute('data-state')).toBe('pending');
   });
 
+  it('ticks both tracker and sentry from the single tools id', () => {
+    const { container } = render(
+      <Stepper current={2} steps={[0, 1, 2, 3, 4, 5, 6, 7]} completed={new Set(['tools'])} />,
+    );
+    const dots = container.querySelectorAll('[data-state]');
+    expect(dots[5]?.getAttribute('data-state')).toBe('done');
+    expect(dots[6]?.getAttribute('data-state')).toBe('done');
+  });
+
+  it('renders position only, never a fraction over the checklist set', () => {
+    const { container } = render(
+      <Stepper current={3} steps={[0, 1, 2, 3, 4, 5, 6, 7]} completed={new Set(['workspace'])} />,
+    );
+    expect(container.textContent).toBe('');
+  });
+
   it('uses the supplied step list for standalone workspaces', () => {
     const { container } = render(
       <Stepper current={5} steps={[0, 1, 2, 3, 5, 7]} completed={new Set()} />,

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/Stepper.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/Stepper.tsx
@@ -1,22 +1,71 @@
 import { cn } from '@goodboy/ui';
+import type { OnboardingStepId } from '../onboarding-store';
+
+const CHECKLIST_ID_BY_WIZARD_STEP: Readonly<Record<number, OnboardingStepId | null>> = {
+  0: null,
+  1: null,
+  2: 'workspace',
+  3: null,
+  4: 'codeHost',
+  5: 'tools',
+  6: null,
+  7: null,
+};
+
+type DotState = 'done' | 'current' | 'pending';
+
+type DotStateParams = {
+  readonly wizardStep: number;
+  readonly position: number;
+  readonly currentPosition: number;
+  readonly completed: ReadonlySet<OnboardingStepId>;
+};
+
+const dotState = ({
+  wizardStep,
+  position,
+  currentPosition,
+  completed,
+}: DotStateParams): DotState => {
+  if (position === currentPosition) {
+    return 'current';
+  }
+  if (position < currentPosition) {
+    return 'done';
+  }
+  const checklistId = CHECKLIST_ID_BY_WIZARD_STEP[wizardStep] ?? null;
+  if (checklistId !== null && completed.has(checklistId)) {
+    return 'done';
+  }
+  return 'pending';
+};
+
+const DOT_CLASS: Readonly<Record<DotState, string>> = {
+  done: 'w-6 bg-primary',
+  current: 'w-3 bg-primary/50 ring-1 ring-primary',
+  pending: 'w-1.5 bg-border',
+};
 
 type Props = {
   readonly current: number;
-  readonly total: number;
+  readonly steps: ReadonlyArray<number>;
+  readonly completed: ReadonlySet<OnboardingStepId>;
 };
 
-export const Stepper = ({ current, total }: Props) => {
+export const Stepper = ({ current, steps, completed }: Props) => {
+  const currentPosition = steps.indexOf(current);
   return (
     <div className="flex items-center justify-center gap-2" aria-hidden>
-      {Array.from({ length: total }, (_, i) => (
-        <span
-          key={i}
-          className={cn(
-            'h-1.5 rounded-full motion-safe:transition-all',
-            i < current ? 'w-6 bg-primary' : 'w-1.5 bg-border',
-          )}
-        />
-      ))}
+      {steps.map((wizardStep, position) => {
+        const state = dotState({ wizardStep, position, currentPosition, completed });
+        return (
+          <span
+            key={wizardStep}
+            data-state={state}
+            className={cn('h-1.5 rounded-full motion-safe:transition-all', DOT_CLASS[state])}
+          />
+        );
+      })}
     </div>
   );
 };

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/Stepper.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/Stepper.tsx
@@ -8,7 +8,7 @@ const CHECKLIST_ID_BY_WIZARD_STEP: Readonly<Record<number, OnboardingStepId | nu
   3: null,
   4: 'codeHost',
   5: 'tools',
-  6: null,
+  6: 'tools',
   7: null,
 };
 

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/index.test.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/index.test.tsx
@@ -5,13 +5,14 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import type { IsoDateTime, Workspace, WorkspaceId } from '@goodboy/types';
 import type { OnboardingWizardState } from './useOnboardingWizard';
 
-const { hookState, finishWizard } = vi.hoisted(() => ({
+const { hookState, progressState, finishWizard } = vi.hoisted(() => ({
   hookState: {} as OnboardingWizardState,
+  progressState: { completed: new Set<string>() },
   finishWizard: vi.fn(),
 }));
 
 vi.mock('../hooks/useOnboardingProgress', () => ({
-  useOnboardingProgress: () => ({ completed: new Set() }),
+  useOnboardingProgress: () => progressState,
 }));
 
 vi.mock('./useOnboardingWizard', () => ({
@@ -23,8 +24,16 @@ vi.mock('../onboarding-store', () => ({
 }));
 
 vi.mock('./Stepper', () => ({
-  Stepper: ({ current, steps }: { current: number; steps: ReadonlyArray<number> }) => (
-    <div data-testid="stepper">{`${current}/${steps.join(',')}`}</div>
+  Stepper: ({
+    current,
+    steps,
+    completed,
+  }: {
+    current: number;
+    steps: ReadonlyArray<number>;
+    completed: ReadonlySet<string>;
+  }) => (
+    <div data-testid="stepper">{`${current}/${steps.join(',')}/${[...completed].join(',')}`}</div>
   ),
 }));
 
@@ -76,6 +85,7 @@ const setHook = (partial: Partial<OnboardingWizardState>) =>
 
 beforeEach(() => {
   finishWizard.mockClear();
+  progressState.completed = new Set();
   Object.assign(hookState, baseState);
 });
 afterEach(cleanup);
@@ -214,6 +224,14 @@ describe('OnboardingWizard', () => {
       expect(screen.getByTestId('ReadyStep')).toBeDefined();
       expect(screen.queryByTestId('CodeHostStep')).toBeNull();
       expect(screen.queryByTestId('SentryStep')).toBeNull();
+    });
+
+    it('passes the current step, filtered steps, and completed progress to the stepper', () => {
+      progressState.completed = new Set(['workspace']);
+      setHook({ mode: 'setup', hasWorkspace: true, workspaceKind: 'simple' });
+      render(<OnboardingWizard />);
+      fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+      expect(screen.getByTestId('stepper').textContent).toBe('5/3,5,7/workspace');
     });
   });
 

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/index.test.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/index.test.tsx
@@ -10,6 +10,10 @@ const { hookState, finishWizard } = vi.hoisted(() => ({
   finishWizard: vi.fn(),
 }));
 
+vi.mock('../hooks/useOnboardingProgress', () => ({
+  useOnboardingProgress: () => ({ completed: new Set() }),
+}));
+
 vi.mock('./useOnboardingWizard', () => ({
   useOnboardingWizard: () => hookState,
 }));
@@ -19,8 +23,8 @@ vi.mock('../onboarding-store', () => ({
 }));
 
 vi.mock('./Stepper', () => ({
-  Stepper: ({ current, total }: { current: number; total: number }) => (
-    <div data-testid="stepper">{`${current}/${total}`}</div>
+  Stepper: ({ current, steps }: { current: number; steps: ReadonlyArray<number> }) => (
+    <div data-testid="stepper">{`${current}/${steps.join(',')}`}</div>
   ),
 }));
 

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/index.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/index.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { Button, ScrollFade, cn, type ButtonVariant } from '@goodboy/ui';
 import { finishWizard } from '../onboarding-store';
+import { useOnboardingProgress } from '../hooks/useOnboardingProgress';
 import { useOnboardingWizard } from './useOnboardingWizard';
 import { Stepper } from './Stepper';
 import { WelcomeStep } from './steps/WelcomeStep';
@@ -77,6 +78,7 @@ type Cta = {
 };
 
 export const OnboardingWizard = () => {
+  const progress = useOnboardingProgress();
   const {
     open,
     mode,
@@ -259,7 +261,7 @@ export const OnboardingWizard = () => {
         <span aria-hidden />
         <div className="flex justify-center">
           {step > minStep && (
-            <Stepper current={steps.indexOf(step)} total={Math.max(steps.length - 1, 0)} />
+            <Stepper current={step} steps={steps} completed={progress.completed} />
           )}
         </div>
         <div className="flex justify-end">

--- a/apps/desktop/src/features/onboarding/hooks/useOnboardingProgress/index.test.ts
+++ b/apps/desktop/src/features/onboarding/hooks/useOnboardingProgress/index.test.ts
@@ -7,6 +7,8 @@ const workspaces: Array<{ id: string; kind?: 'repo' | 'simple' }> = [];
 let currentWorkspaceId: string | null = null;
 let workspaceIntegrations: Record<string, Array<{ provider: string }>> = {};
 let sessions: Array<unknown> = [];
+let sessionPhaseRuns: Record<string, unknown[]> = {};
+let sessionPlans: Record<string, unknown[]> = {};
 
 const { markStepCompleteMock, ghStatusMock } = vi.hoisted(() => ({
   markStepCompleteMock: vi.fn(),
@@ -51,8 +53,8 @@ vi.mock('../../../../store', () => ({
   ) =>
     selector({
       sessions,
-      sessionPhaseRuns: {},
-      sessionPlans: {},
+      sessionPhaseRuns,
+      sessionPlans,
       currentWorkspaceId,
       workspaceIntegrations,
     }),
@@ -66,6 +68,8 @@ function reset() {
   currentWorkspaceId = null;
   workspaceIntegrations = {};
   sessions = [];
+  sessionPhaseRuns = {};
+  sessionPlans = {};
   markStepCompleteMock.mockReset();
   ghStatusMock.mockReset();
   ghStatusMock.mockResolvedValue({ scoped: false });
@@ -134,6 +138,32 @@ describe('useOnboardingProgress auto-mark', () => {
     expect(result.current.completedCount).toBe(2);
     expect(result.current.totalCount).toBe(7);
     expect(result.current.isDone).toBe(false);
+  });
+
+  it('unions live completion over persisted completion on the first render', () => {
+    completed = ['palette'];
+    workspaces.push({ id: 'w1' });
+    workspaceIntegrations = { w1: [{ provider: 'gitlab' }, { provider: 'linear' }] };
+    sessions = [{}];
+    sessionPhaseRuns = { s1: [{}] };
+    sessionPlans = { s1: [{}] };
+    const { result } = renderHook(() => useOnboardingProgress());
+    expect([...result.current.completed]).toEqual([
+      'palette',
+      'workspace',
+      'codeHost',
+      'tools',
+      'session',
+      'agent',
+      'plan',
+    ]);
+    expect(result.current.completedCount).toBe(7);
+    expect(result.current.isDone).toBe(true);
+  });
+
+  it('keeps palette purely persisted', () => {
+    const { result } = renderHook(() => useOnboardingProgress());
+    expect(result.current.completed.has('palette')).toBe(false);
   });
 
   it('removes the code host step but keeps the tracker step for a simple workspace', () => {

--- a/apps/desktop/src/features/onboarding/hooks/useOnboardingProgress/index.ts
+++ b/apps/desktop/src/features/onboarding/hooks/useOnboardingProgress/index.ts
@@ -134,14 +134,47 @@ export const useOnboardingProgress = (): OnboardingProgress => {
     currentSession,
   ]);
 
+  const completed = useMemo(() => {
+    const liveCompleted = new Set(persistedCompleted);
+    if (workspaces.length > 0) {
+      liveCompleted.add('workspace');
+    }
+    if (!isSimple && (gitlabConnected || bitbucketConnected || githubScoped)) {
+      liveCompleted.add('codeHost');
+    }
+    if (hasTools) {
+      liveCompleted.add('tools');
+    }
+    if (sessionCount > 0) {
+      liveCompleted.add('session');
+    }
+    if (anyAgent) {
+      liveCompleted.add('agent');
+    }
+    if (anyPlan) {
+      liveCompleted.add('plan');
+    }
+    return liveCompleted;
+  }, [
+    persistedCompleted,
+    workspaces.length,
+    isSimple,
+    gitlabConnected,
+    bitbucketConnected,
+    githubScoped,
+    hasTools,
+    sessionCount,
+    anyAgent,
+    anyPlan,
+  ]);
   const visibleSteps = visibleOnboardingSteps({ isSimple });
   const totalCount = visibleSteps.length;
-  const completedCount = visibleSteps.filter((step) => persistedCompleted.has(step.id)).length;
+  const completedCount = visibleSteps.filter((step) => completed.has(step.id)).length;
 
   return {
     completedCount,
     totalCount,
-    completed: persistedCompleted,
+    completed,
     collapsed,
     finished,
     isDone: completedCount >= totalCount,


### PR DESCRIPTION
MU1 of v0.1.82: the first-run setup progress stops lying. Two slots, one branch, per-item provenance below.

## Slot 1 (M, code) - the checklist agrees with the app on the first paint

Provenance: internal, from the product critic's first-run walk and coherence findings D1/D2. Data class none: no schema, no migration, no table, no column, and **the write side is untouched**.

`useOnboardingProgress` rendered `completedCount` and the returned `completed` set from `persistedCompleted` alone, while the effect that calls `markStepComplete` wrote completion asynchronously. The event loop between the two is what made the first paint after the wizard closed read "0 of 7 steps done" with "Connect a workspace" unticked, beside a header naming the workspace that had just been created and a database already holding the workspace step.

The fix is entirely at render: the six live-predicate steps are derived from live app state and **unioned** over the persisted set.

| checklist id | live predicate |
| --- | --- |
| `workspace` | a workspace exists |
| `codeHost` | GitLab, Bitbucket or a scoped GitHub token, non-standalone workspaces only |
| `tools` | a tracker or error integration is connected for the workspace |
| `session` | a session exists |
| `agent` | any session has a phase run |
| `plan` | any session has a plan |
| `palette` | none, stays purely persisted |

The persisted array stays append-only exactly as it was: the store's append and its fire-and-forget flush are unchanged, no stored row is narrowed, pruned or rewritten, and the effect writes exactly what it wrote before. The union is also what tolerates legacy profiles that already hold derived ids, so an upgraded profile cannot regress to a smaller count.

**Named limitation, stated rather than silently skipped.** A union cannot un-tick, and this holds for all six live-predicate ids, not only `workspace`. If a user deletes every workspace after creating one, the checklist still shows "Connect a workspace" struck through beside the no-workspace screen; the same holds for the other five: delete every session and `session` stays ticked, disconnect the code host and `codeHost` stays ticked, and so on. Un-ticking would mean letting the live predicate override the persisted row, which is exactly the regression the union exists to avoid on upgraded profiles. That trade is deliberate; the first-paint defect this unit was cut for is fixed.

`hasTools` is untouched. Its provider list is still `linear | jira | sentry`, so the wave-B unit that adds Slack inherits the same single predicate and the union in this slot picks the change up for free.

## Slot 2 (M, code) - one named set for the checklist surfaces, position for the stepper

Provenance: internal, coherence findings D12 and D14.

**The named set is the checklist's seven**: `workspace, codeHost, tools, session, agent, plan, palette` (six for a standalone workspace, which drops `codeHost`). The card and the chip count that set. **The stepper counts wizard position, not the checklist set.** What all three share is per-step tick state, never a denominator.

That split is deliberate. Drawn literally, a seven-dot checklist stepper inside the wizard could honestly light at most three, because `session`, `agent`, `plan` and `palette` are all earned after the wizard exits, so a successful wizard would end reading "3 of 7". That is the same lie this unit exists to remove, relocated into the other set's denominator. Linear keeps its in-flow stepper as position and its persistent "Get started" checklist as the account-level set, and never puts one denominator across both; Stripe's account onboarding does the same.

- **Chip** (`OnboardingCard`): filled positionally as `i < completedCount`, so it could light dot 1 while the card had step 4 checked. It now fills per step from the same set the card reads.
- **Stepper** (`OnboardingWizard`): was positional-by-index over `steps.length - 1`, with no you-are-here marker (the current dot was identical to a pending one). It now takes the visible wizard step list and renders one dot per visible wizard step, with three distinct states: done, current, pending. It renders **no fraction and no number of any kind**, and a test pins that its rendered text is empty.

**Cardinality, resolved against `origin/main`.** The wizard has **eight** steps at indices 0-7 (`STEP_COUNT = 8` in `OnboardingWizard/index.tsx`), of which a standalone workspace shows six (`SIMPLE_STEPS = [0, 1, 2, 3, 5, 7]`, dropping Code host and Sentry). The reconciled plan's slot 2 lists seven wizard steps and omits Providers at index 1; the eight above is what is on `main` and is what this mapping is written against.

**The wizard-step to checklist-id mapping**, which did not exist in the code before and is now explicit in `Stepper.tsx`:

| wizard step | screen | checklist claim |
| --- | --- | --- |
| 0 | Welcome | none |
| 1 | Providers | none |
| 2 | Workspace | `workspace` |
| 3 | Preferences | none |
| 4 | Code host | `codeHost` |
| 5 | Tracker | `tools` |
| 6 | Sentry | `tools` |
| 7 | Ready | none |

Two cases in that table are the point of writing it down:

- **The `null` cases are an answer, not an omission.** Welcome, Providers, Preferences and Ready advance no checklist id. They are stepper positions with no checklist claim, and they are never silently counted as one.
- **Two wizard steps advance one id.** Tracker and Sentry both advance `tools`, so both dots tick when `tools` completes. In plain terms: connect Linear on the Tracker step and the Sentry dot lights as done too, even though Sentry was never touched, because both steps read the same `tools` id. This is deliberate and unchanged by this unit, but on a slot named "progress stops lying" it is worth naming as a small new inaccuracy in its own right, not just as a row in the mapping table. After the wave-B unit adds Slack to the tracker step, that single id will span two wizard steps and four providers. Naming it here is the deliverable; discovering it later is the class of defect this unit is fixing.

**The stepper's dot count changed from seven to eight, undocumented until now.** Before this unit the stepper rendered one dot per `steps.length` with no distinct current marker; the reconciled plan and earlier drafts of this PR referenced seven wizard steps. The wizard on `main` has eight (`STEP_COUNT = 8`), so the stepper now renders eight dots on the full path (six for a standalone workspace), one more than a reader following the earlier plan would expect.

The four post-wizard ids (`session`, `agent`, `plan`, `palette`) are claimed by no wizard step at all.

**The uncounted sub-step is excluded, once, on purpose.** The workspace creation sub-step inside `WorkspaceStep` (the one that takes the wizard footer over through `stepOwnsActions`) gets no stepper position. It is a sub-state of the Workspace step, and the stepper keeps that position marked as current for its whole duration, which is now visibly different from a pending position.

## Verification

- `pnpm exec turbo run test typecheck --force`: 9 tasks successful, `0 cached`, 5723 desktop tests passing.
- `pnpm exec vitest run src/features/onboarding`: 12 files, 114 tests.
- Prettier check clean on the touched files; commitlint and the format hook ran on commit.
- New coverage: the union on first render, `palette` staying purely persisted, the chip filling per step, the stepper's current marker, its step list, the two-steps-one-id tick for Tracker and Sentry, and the stepper rendering no fraction.

## Repair (this push)

The verifier blocked the PR above: the wizard-to-`Stepper` wiring was unpinned. `OnboardingWizard/index.test.tsx` stubbed `Stepper` as `{current}/{steps.join(',')}` and never asserted the value, and stubbed `useOnboardingProgress` to an empty set, so nothing observed what the wizard actually handed the stepper. Three separate defects survived a full green suite: passing `completed={new Set()}`, passing `steps={ALL_STEPS}` instead of the visible list, and passing `current={steps.indexOf(step)}` instead of `current={step}`. The third is not cosmetic: on `SIMPLE_STEPS` or in `setup` mode, `steps.indexOf(step)` can be `-1`, which the `Stepper` renders as no dot current and no dot done, silently deleting the you-are-here marker on standalone workspaces and in setup mode, both ordinary paths reached from every connect flow.

The fix: the `Stepper` mock now renders `completed` alongside `current` and `steps`, and a new test in `setup mode` (`workspaceKind: 'simple'`, steps filtered to `[3, 5, 7]`, asserted at wizard step 5, where `steps.indexOf(5) === 1 !== 5`) pins all three values in one assertion: `'5/3,5,7/workspace'`. `OnboardingWizard/index.tsx` itself needed no change; it already wired `current={step} steps={steps} completed={progress.completed}` correctly. Each of the three sabotages above was applied by hand, run against this new test to confirm it goes red, and reverted; the production file is unchanged from before this repair.

Also fixed as a smaller, related item: `OnboardingCard/index.test.tsx` mutated the hoisted `progress` object's `completed` and `completedCount` in one test without resetting them in `beforeEach`, so a later test could inherit stale progress state depending on run order. `beforeEach` now resets both alongside `collapsed`.

Three disclosure corrections above, all requested by the verifier and none changing behavior: the un-tick-gap paragraph in Slot 1 now names all six live-predicate ids instead of illustrating with `workspace` alone; the Tracker/Sentry-share-`tools` note in Slot 2 now states in plain words that connecting Linear alone lights the Sentry dot as done; and a new paragraph states the stepper's dot count changed from seven to eight relative to the reconciled plan.

## Not verified

- No manual run of the packaged app; the first-paint claim is verified at the hook and component level, not on a launched binary.
- The light-theme-on-second-launch report from the release walk is out of this unit's footprint and was not chased.

