### PR TITLE
fix(desktop): gate ghost budget button on session block

### DIFF
--- a/apps/desktop/src/features/workflows/components/OrchestratorPanel/index.test.tsx
+++ b/apps/desktop/src/features/workflows/components/OrchestratorPanel/index.test.tsx
@@ -536,6 +536,16 @@ describe('OrchestratorPanel strip', () => {
     expect(screen.getByTestId('orchestrator-budget')).toBeDefined();
   });
 
+  it('renders one budget control when the session budget pauses the run', () => {
+    storeState['budgetAlerts'] = [{ kind: 'session-exceeded', sessionId: SESSION_ID }];
+    renderPanel({
+      runOverride: run({ orchestrationStop: { kind: 'budget', message: 'cap reached' } }),
+    });
+
+    expect(screen.getByTestId('orchestrator-review-budget')).toBeDefined();
+    expect(screen.queryByTestId('orchestrator-budget')).toBeNull();
+  });
+
   it('says what the run is allowed to spend and what happens at the limit', () => {
     renderPanel({ runOverride: run({ spendLimitUsd: 12, spendLimitMode: 'notify' }) });
 
@@ -556,6 +566,7 @@ describe('OrchestratorPanel strip', () => {
 
     expect(opened).toHaveBeenCalledTimes(1);
     expect(screen.queryByTestId('run-spend-limit-trigger')).toBeNull();
+    expect(screen.queryByTestId('orchestrator-budget')).toBeNull();
   });
 
   it('saves a spend limit for the run from the strip', () => {

--- a/apps/desktop/src/features/workflows/components/OrchestratorPanel/index.tsx
+++ b/apps/desktop/src/features/workflows/components/OrchestratorPanel/index.tsx
@@ -283,14 +283,16 @@ export const OrchestratorPanel = ({
           {state.phase === 'paused-budget' ? null : (
             <RunSpendLimitPopover sessionId={sessionId} run={run} variant="ghost" />
           )}
-          <OrchestratorAction
-            icon={Wallet}
-            label="Budget"
-            variant="ghost"
-            testId="orchestrator-budget"
-            title="Open the budget for this session"
-            onClick={() => openBudgetStudio({ scope: { kind: 'session', sessionId } })}
-          />
+          {state.phase === 'paused-budget' && sessionBudgetBlocked ? null : (
+            <OrchestratorAction
+              icon={Wallet}
+              label="Budget"
+              variant="ghost"
+              testId="orchestrator-budget"
+              title="Open the budget for this session"
+              onClick={() => openBudgetStudio({ scope: { kind: 'session', sessionId } })}
+            />
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
## What shipped

References #1333, addresses only the duplicate-CTA sub-question: two budget controls fired the identical `openBudgetStudio` action and both rendered at once in `OrchestratorPanel` whenever `state.phase === 'paused-budget'` and `sessionBudgetBlocked` was true.

The ghost RunSpendLimitPopover already gated on `state.phase === 'paused-budget'` (existing pattern). The ghost "Budget" button did not follow it. It now hides with the same style of conditional, gated on `state.phase === 'paused-budget' && sessionBudgetBlocked`, so it keeps rendering in the case where the run is paused by its own spend limit rather than the session budget (primary there is the `RunSpendLimitPopover`, not "Review budget", so no duplicate exists in that state).

- `apps/desktop/src/features/workflows/components/OrchestratorPanel/index.tsx`: one-condition gate on the ghost Budget button.
- `apps/desktop/src/features/workflows/components/OrchestratorPanel/index.test.tsx`: new test pinning exactly one budget control in the session-blocked paused state, plus an added assertion on the existing session-budget test.

This does not touch the issue's separate "rethink the screen" line; that stays open for the release thread, not built here.

## Verification

- `pnpm --filter @goodboy/desktop exec vitest run -- src/features/workflows/components/OrchestratorPanel/index.test.tsx` green standalone (662 files / 5717 tests).

## Unverified

- Full monorepo `turbo run test --force` was not re-run in isolation for this PR (single-file footprint, no other files touched).