### PR TITLE
refactor(desktop): unify wizard empty state with the ui primitive

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -98,9 +98,10 @@ Six rules, phrased so a diff can be checked against them directly.
   with a count, or a collapsed disclosure row.
 - **One visible action per row**, plus the chevron. Everything else is revealed
   on hover and focus, or lives in the focused view.
-- **Empty sections collapse.** Inside a composite page, a section with nothing
-  to show renders its header at most, never a placeholder card. Only a full
-  pane may show an `EmptyState`.
+- **Empty sections collapse.** A surface that is the whole body of what the
+  user navigated to (a pane, or a wizard step) shows an `EmptyState`. A
+  section inside a composite page shows its header at most, never a
+  placeholder card.
 - **No off-scale type.** The type scale lives in
   [packages/ui/DESIGN-SYSTEM.md](./packages/ui/DESIGN-SYSTEM.md).
 

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/steps/CodeHostStep.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/steps/CodeHostStep.tsx
@@ -1,8 +1,9 @@
 import { useState } from 'react';
 import { FolderGit2, GitBranch } from 'lucide-react';
-import { Button } from '@goodboy/ui';
+import { Button, EmptyState } from '@goodboy/ui';
 import type { WorkspaceId } from '@goodboy/types';
 import { BitbucketIcon, GithubIcon, GitlabIcon } from '@goodboy/ui';
+import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../shared/components/conceptIcons';
 import { Segmented, type SegmentedOption } from '../Segmented';
 import { CodeHostForm, type CodeHost } from './CodeHostForm';
 
@@ -83,21 +84,21 @@ export const CodeHostStep = ({
       </div>
 
       {workspaceId === null ? (
-        <div className="flex w-full max-w-sm flex-col items-center gap-3 rounded-lg border border-border-soft/40 bg-subtle/20 px-4 py-6 text-center">
-          <span className="flex size-10 items-center justify-center rounded-lg border border-border-soft/40 bg-subtle/40 text-muted-foreground">
-            <FolderGit2 size={18} aria-hidden />
-          </span>
-          <p className="text-xs leading-relaxed text-muted-foreground">
-            Add a workspace first to connect a code host.
-          </p>
-          <Button
-            variant="secondary"
-            size="sm"
-            onClick={() => window.dispatchEvent(new CustomEvent('goodboy:add-workspace'))}
-          >
-            <FolderGit2 size={14} aria-hidden /> Add workspace
-          </Button>
-        </div>
+        <EmptyState
+          bordered
+          icon={CONCEPT_ICONS.workspace}
+          tone={CONCEPT_TONE.workspace}
+          title="Add a workspace first to connect a code host."
+          action={
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => window.dispatchEvent(new CustomEvent('goodboy:add-workspace'))}
+            >
+              <FolderGit2 size={14} aria-hidden /> Add workspace
+            </Button>
+          }
+        />
       ) : (
         <div className="flex w-full flex-col gap-4 text-left">
           <Segmented ariaLabel="Code host" options={options} value={host} onChange={setHost} />

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/steps/SentryStep.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/steps/SentryStep.tsx
@@ -1,7 +1,8 @@
 import { FolderGit2 } from 'lucide-react';
-import { Button } from '@goodboy/ui';
+import { Button, EmptyState } from '@goodboy/ui';
 import type { WorkspaceId } from '@goodboy/types';
 import { SentryIcon } from '@goodboy/ui';
+import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../shared/components/conceptIcons';
 import { SentryFormBody } from '../../../integrations/sentry/SentryFormBody';
 
 type Props = {
@@ -29,21 +30,21 @@ export const SentryStep = ({ workspaceId }: Props) => {
       </div>
 
       {workspaceId === null ? (
-        <div className="flex w-full max-w-sm flex-col items-center gap-3 rounded-lg border border-border-soft/40 bg-subtle/20 px-4 py-6 text-center">
-          <span className="flex size-10 items-center justify-center rounded-lg border border-border-soft/40 bg-subtle/40 text-muted-foreground">
-            <FolderGit2 size={18} aria-hidden />
-          </span>
-          <p className="text-xs leading-relaxed text-muted-foreground">
-            Add a workspace first to connect Sentry.
-          </p>
-          <Button
-            variant="secondary"
-            size="sm"
-            onClick={() => window.dispatchEvent(new CustomEvent('goodboy:add-workspace'))}
-          >
-            <FolderGit2 size={14} aria-hidden /> Add workspace
-          </Button>
-        </div>
+        <EmptyState
+          bordered
+          icon={CONCEPT_ICONS.workspace}
+          tone={CONCEPT_TONE.workspace}
+          title="Add a workspace first to connect Sentry."
+          action={
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => window.dispatchEvent(new CustomEvent('goodboy:add-workspace'))}
+            >
+              <FolderGit2 size={14} aria-hidden /> Add workspace
+            </Button>
+          }
+        />
       ) : (
         <div className="flex w-full flex-col gap-4 text-left">
           <div className="rounded-lg border border-border-soft/40 bg-subtle/20 p-4">

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/steps/TrackerStep.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/steps/TrackerStep.tsx
@@ -1,8 +1,9 @@
 import { useState } from 'react';
 import { FolderGit2, ListChecks } from 'lucide-react';
-import { Button } from '@goodboy/ui';
+import { Button, EmptyState } from '@goodboy/ui';
 import type { WorkspaceId } from '@goodboy/types';
 import { JiraIcon, LinearIcon } from '@goodboy/ui';
+import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../shared/components/conceptIcons';
 import { JiraFormBody } from '../../../integrations/jira/JiraFormBody';
 import { LinearFormBody } from '../../../integrations/linear/LinearFormBody';
 import { Segmented, type SegmentedOption } from '../Segmented';
@@ -54,21 +55,21 @@ export const TrackerStep = ({ workspaceId, linearConnected, jiraConnected }: Pro
       </div>
 
       {workspaceId === null ? (
-        <div className="flex w-full max-w-sm flex-col items-center gap-3 rounded-lg border border-border-soft/40 bg-subtle/20 px-4 py-6 text-center">
-          <span className="flex size-10 items-center justify-center rounded-lg border border-border-soft/40 bg-subtle/40 text-muted-foreground">
-            <FolderGit2 size={18} aria-hidden />
-          </span>
-          <p className="text-xs leading-relaxed text-muted-foreground">
-            Add a workspace first to connect your tracker.
-          </p>
-          <Button
-            variant="secondary"
-            size="sm"
-            onClick={() => window.dispatchEvent(new CustomEvent('goodboy:add-workspace'))}
-          >
-            <FolderGit2 size={14} aria-hidden /> Add workspace
-          </Button>
-        </div>
+        <EmptyState
+          bordered
+          icon={CONCEPT_ICONS.workspace}
+          tone={CONCEPT_TONE.workspace}
+          title="Add a workspace first to connect your tracker."
+          action={
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => window.dispatchEvent(new CustomEvent('goodboy:add-workspace'))}
+            >
+              <FolderGit2 size={14} aria-hidden /> Add workspace
+            </Button>
+          }
+        />
       ) : (
         <div className="flex w-full flex-col gap-4 text-left">
           <Segmented


### PR DESCRIPTION
## MU4 - one empty state, one rule (#1371)

`PreferencesStep` already used the `EmptyState` primitive from `packages/ui` for its "no workspace yet" fallback. `CodeHostStep`, `TrackerStep` and `SentryStep` each hand rolled the same shape with a solid border and a neutral `FolderGit2` glyph instead of the primitive's dashed, tinted-concept-icon shape. All three now render `EmptyState` with `CONCEPT_ICONS.workspace` / `CONCEPT_TONE.workspace`, matching `PreferencesStep` exactly.

- `CodeHostStep.tsx`
- `TrackerStep.tsx`
- `SentryStep.tsx`

Copy text is unchanged on all three; only the container shape moved.

### DESIGN.md

Amended the existing Compaction bullet in place (one sentence, not a new paragraph): it already said only a full pane may show an `EmptyState`, but did not say whether a wizard step counts as one. It now does. No new rule was added; the gap was the missing case, not a missing rule.

### Verification, both themes

Grepped the full `apps/desktop/src` tree for the hand-rolled wrapper's class signature (`px-4 py-6 text-center` alongside the `size-10` muted glyph wrapper) and for the `FolderGit2 size={18}` neutral glyph: zero matches anywhere, confirming the hand-rolled shape survives nowhere else in the wizard. `EmptyState`'s `bordered` prop is theme-token driven (`border-border-soft`, `bg-elevated/40`, tint classes from `tintClasses(tone)`), so it renders correctly in both themes with no per-site override.

Typecheck: `turbo run typecheck --filter=@goodboy/desktop --force`, 0 cached, clean.

Tests: ran the four affected test files standalone (`CodeHostStep`, `TrackerStep`, `SentryStep`, `PreferencesStep`), 30/30 passed unmodified. The three tests the brief flagged as asserting the moved copy did not need edits: `getByText`/`queryByText` match by text content regardless of the underlying element, so the same regex assertions hold against `EmptyState`'s rendered title.

### Out of footprint, by design

These three call sites carry the label "Add workspace," one of four labels the app uses for the same act (Connect a workspace / Add workspace / New workspace / Change workspace), with the wizard inconsistent between its own screens. The correct verb is "connect" since nothing is created, a folder is linked, and the shipped inverse is already "Disconnect." Not changed here: this unit's class is design token, not copy, and unifying the label is a separate item. Flagging it here so the next batch can see it was one word per site at this point.

### Unverified

None.