### PR TITLE
chore(repo): bump version to 0.1.82

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,41 +9,46 @@ if it can't find a matching `## Goodboy vX.Y.Z` heading.
 
 ## Goodboy v0.1.82
 
-A repository Goodboy could not read no longer reads as in sync, the first-run
-checklist agrees with the app around it, and archive and delete move out of the
-session rail.
+Goodboy fast-forwards your checkout without a terminal, tells you when it cannot
+read your repository instead of calling it in sync, and the first-run checklist
+finally agrees with the app around it.
 
-### [#1419] Repository status shows unknown instead of in sync, and offers a fast-forward
+### [#1419] Repository status says when it cannot read your checkout, and offers a fast-forward
 
 Goodboy used to report "In sync and clean" whenever it could not work out the
 state of your repository, so a failed read looked exactly like a healthy one. It
-now shows that state as unknown and names what it could not resolve: no upstream
-branch, a checkout that is not on a branch, a status it could not read.
+now says it cannot read the checkout and names what went wrong: git could not
+compare this branch with its upstream, git could not resolve a main branch to
+compare against, or git status could not be read.
 
 A file in conflict used to count twice, once as staged and once as unstaged. It
 counts once now, as conflicted, and a merge, rebase, cherry-pick or bisect left
-in progress shows in the panel instead of hiding inside the change count.
+in progress shows in the panel now, where nothing read it before.
 
 When your branch is behind its upstream and the tree is clean, the checkout
 panel offers a fast-forward that names the branch and the upstream it will move.
 It never rebases and never stashes. When it cannot run, the control stays
 visible and disabled with the reason on it: uncommitted changes, no upstream, an
 operation in progress, a status Goodboy could not read, or a branch already up
-to date. An unknown state disables it exactly like a dirty one.
+to date. A checkout Goodboy cannot read disables it exactly like a dirty one.
+
+Follow-up: the fast-forward is pinned by tests that run it against real clones,
+though no pull has been run from a packaged build yet. If git refuses, its own
+message comes back in the checkout panel.
 
 ### [#1416] The first-run checklist matches the app it opens beside
 
 The setup checklist used to open at "0 of 7 steps done" with "Connect a
 workspace" unticked, next to a header naming the workspace you had just created.
 It now counts what the app already has the moment it opens, so a workspace, a
-code host, a connected tool, a session, a run and a plan tick as soon as they
+code host, a connected tool, a session, an agent and a plan tick as soon as they
 exist, and a step that has ticked stays ticked even if you later delete the
 thing that earned it.
 
 The wizard's progress dots mark where you are, distinct from what is done and
 what is still ahead, one dot per screen you will actually see and no fraction
-anywhere. Two of those screens, Tracker and Sentry, count toward the same
-checklist entry, so connecting a tracker ticks both.
+anywhere. Two of those screens, the tools step and the Sentry step, count toward
+the same checklist entry, so connecting any one tool ticks both.
 
 ### [#1418] Archive and delete move to the session header
 
@@ -54,19 +59,18 @@ and they route through the same confirm the keyboard shortcuts use, whose
 warning differs for a session with a branch and one without. Two clicks to
 confirm and Escape to dismiss, both unchanged.
 
-The confirm acts on the session whose menu you opened, even if you switch
-sessions with the keyboard before you confirm. A failed archive or delete
-reports inside the confirm now instead of as a toast.
+A failed archive or delete reports inside the confirm now instead of as a toast.
 
 ### [#1422] Connect Slack while setting up
 
 The first-run tools step offers Slack beside Linear and Jira, and connecting it
-completes the setup step the same way a tracker does. That step is called
-Connect your tools now, since it no longer covers trackers alone.
+completes the setup step the same way a tracker does. That step is now called
+Connect your tools, since it no longer covers trackers alone.
 
 A connect that failed partway used to leave a Slack token in your keychain that
 no screen in the app could remove. A failed connect now leaves nothing behind in
-the keychain and puts back the integration you already had.
+the keychain and puts the previous connection's record back, so you can
+reconnect or disconnect it.
 
 ### Smaller fixes
 
@@ -77,8 +81,7 @@ the keychain and puts back the integration you already had.
 - Push and rebase are offered only when Goodboy knows how far ahead or behind
   the branch is [#1419]
 - A remote address carrying a token no longer appears in git error text [#1419]
-- A checkout that is not on a branch is explained in plain words instead of
-  git's own vocabulary [#1419]
+- `docs/concepts.md` and `docs/traps.md` now match the app that shipped [#1421]
 
 ## Goodboy v0.1.81
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,10 +35,10 @@ to date. An unknown state disables it exactly like a dirty one.
 
 The setup checklist used to open at "0 of 7 steps done" with "Connect a
 workspace" unticked, next to a header naming the workspace you had just created.
-It now reads the app's own state on the first paint, so a workspace, a code
-host, a connected tool, a session, a run and a plan tick as soon as they exist,
-and a step that has ticked stays ticked even if you later delete the thing that
-earned it.
+It now counts what the app already has the moment it opens, so a workspace, a
+code host, a connected tool, a session, a run and a plan tick as soon as they
+exist, and a step that has ticked stays ticked even if you later delete the
+thing that earned it.
 
 The wizard's progress dots mark where you are, distinct from what is done and
 what is still ahead, one dot per screen you will actually see and no fraction
@@ -65,8 +65,8 @@ completes the setup step the same way a tracker does. That step is called
 Connect your tools now, since it no longer covers trackers alone.
 
 A connect that failed partway used to leave a Slack token in your keychain that
-no screen in the app could remove. The credential is written last now, and a
-failure restores the integration you already had.
+no screen in the app could remove. A failed connect now leaves nothing behind in
+the keychain and puts back the integration you already had.
 
 ### Smaller fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,79 @@ version in the same PR that bumps the version numbers (see
 `docs/release-command.md`), before the tag is pushed: the release build fails
 if it can't find a matching `## Goodboy vX.Y.Z` heading.
 
+## Goodboy v0.1.82
+
+A repository Goodboy could not read no longer reads as in sync, the first-run
+checklist agrees with the app around it, and archive and delete move out of the
+session rail.
+
+### [#1419] Repository status shows unknown instead of in sync, and offers a fast-forward
+
+Goodboy used to report "In sync and clean" whenever it could not work out the
+state of your repository, so a failed read looked exactly like a healthy one. It
+now shows that state as unknown and names what it could not resolve: no upstream
+branch, a checkout that is not on a branch, a status it could not read.
+
+A file in conflict used to count twice, once as staged and once as unstaged. It
+counts once now, as conflicted, and a merge, rebase, cherry-pick or bisect left
+in progress shows in the panel instead of hiding inside the change count.
+
+When your branch is behind its upstream and the tree is clean, the checkout
+panel offers a fast-forward that names the branch and the upstream it will move.
+It never rebases and never stashes. When it cannot run, the control stays
+visible and disabled with the reason on it: uncommitted changes, no upstream, an
+operation in progress, a status Goodboy could not read, or a branch already up
+to date. An unknown state disables it exactly like a dirty one.
+
+### [#1416] The first-run checklist matches the app it opens beside
+
+The setup checklist used to open at "0 of 7 steps done" with "Connect a
+workspace" unticked, next to a header naming the workspace you had just created.
+It now reads the app's own state on the first paint, so a workspace, a code
+host, a connected tool, a session, a run and a plan tick as soon as they exist,
+and a step that has ticked stays ticked even if you later delete the thing that
+earned it.
+
+The wizard's progress dots mark where you are, distinct from what is done and
+what is still ahead, one dot per screen you will actually see and no fraction
+anywhere. Two of those screens, Tracker and Sentry, count toward the same
+checklist entry, so connecting a tracker ticks both.
+
+### [#1418] Archive and delete move to the session header
+
+Archive, unarchive and delete used to sit at the bottom of the session rail
+behind their own inline confirm and a single flat warning. They now live in a
+Session actions menu in the session header, beside the editor and git actions,
+and they route through the same confirm the keyboard shortcuts use, whose
+warning differs for a session with a branch and one without. Two clicks to
+confirm and Escape to dismiss, both unchanged.
+
+The confirm acts on the session whose menu you opened, even if you switch
+sessions with the keyboard before you confirm. A failed archive or delete
+reports inside the confirm now instead of as a toast.
+
+### [#1422] Connect Slack while setting up
+
+The first-run tools step offers Slack beside Linear and Jira, and connecting it
+completes the setup step the same way a tracker does. That step is called
+Connect your tools now, since it no longer covers trackers alone.
+
+A connect that failed partway used to leave a Slack token in your keychain that
+no screen in the app could remove. The credential is written last now, and a
+failure restores the integration you already had.
+
+### Smaller fixes
+
+- A run paused by the session budget offered two controls that opened the same
+  budget screen, and now offers one [#1417]
+- The first-run screens with no workspace to show use the same empty state as
+  the rest of the app [#1420]
+- Push and rebase are offered only when Goodboy knows how far ahead or behind
+  the branch is [#1419]
+- A remote address carrying a token no longer appears in git error text [#1419]
+- A checkout that is not on a branch is explained in plain words instead of
+  git's own vocabulary [#1419]
+
 ## Goodboy v0.1.81
 
 Goodboy reaches the board without waiting on provider detection, and the

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goodboy/desktop",
-  "version": "0.1.81",
+  "version": "0.1.82",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -1626,7 +1626,7 @@ dependencies = [
 
 [[package]]
 name = "goodboy-desktop"
-version = "0.1.81"
+version = "0.1.82"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goodboy-desktop"
-version = "0.1.81"
+version = "0.1.82"
 description = "Goodboy desktop app"
 authors = ["Amin Khayam"]
 license = "MIT"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Goodboy",
-  "version": "0.1.81",
+  "version": "0.1.82",
   "identifier": "com.goodboy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goodboy",
-  "version": "0.1.81",
+  "version": "0.1.82",
   "private": true,
   "description": "AI workspace orchestrator. Local-first, provider-agnostic.",
   "license": "MIT",

--- a/website/src/site.ts
+++ b/website/src/site.ts
@@ -1,5 +1,5 @@
 export const SITE = {
-  version: 'v0.1.81',
+  version: 'v0.1.82',
   repo: 'https://github.com/akhayam99/goodboy',
   releases: 'https://github.com/akhayam99/goodboy/releases',
   latest: 'https://github.com/akhayam99/goodboy/releases/latest',


### PR DESCRIPTION
## What shipped

The v0.1.82 version bump plus its release notes, as the runbook requires: `release.yml` reads the release body out of the `## Goodboy v0.1.82` section of `CHANGELOG.md` and fails if it is missing.

Six version carriers, all at `0.1.82` except the website which keeps the leading `v`:

- `package.json`
- `apps/desktop/package.json`
- `apps/desktop/src-tauri/tauri.conf.json`
- `apps/desktop/src-tauri/Cargo.toml`
- `apps/desktop/src-tauri/Cargo.lock` (the `goodboy-desktop` entry, so `cargo test --locked` stays green)
- `website/src/site.ts` (`v0.1.82`)

## The notes

Written from the merged PR bodies since v0.1.81 and checked against the shipped code on `main`. The batch is #1416, #1417, #1418, #1419, #1420, #1421, #1422.

Ordering: #1419 leads. It is the largest change of the batch and the only one that adds a capability rather than correcting a wrong. Then #1416 and #1422, the first-run pair; then #1418, which moves the destructive verbs out of the rail. #1417, #1420, #1421 and two further #1419 lines are one line each under Smaller fixes.

Limits are stated inside the sentence that promises the thing, per `docs/tone-of-voice.md`: the checklist tick that cannot be undone, the two wizard screens sharing one checklist entry, the five conditions that disable the fast-forward, the archive/delete failure that now reports inline instead of as a toast.

## Review repair (second commit)

Two review passes landed on the first draft of the notes. Every point is applied:

Copy, against shipped strings:

- The fifth checklist item is named **an agent**, matching its shipped title "Create your first agent". It read "a run".
- The two screens sharing one checklist entry are named **the tools step and the Sentry step**. The draft said "Tracker", a source filename, and the screen no longer covers trackers alone.
- The renamed step reads **now called Connect your tools**. As punctuated before, "now" read as part of the title.

Facts, against shipped code:

- **Lead line rewritten.** It now names the fast-forward and the first-run theme, and the fail-closed correction lives inside its own section. The old lead opened on a double negative and never mentioned the release's one new capability.
- **#1419 heading** names the capability in on-screen words instead of `unknown`, which is a type tag no screen renders. The panel shows "Goodboy cannot read this checkout".
- **The three named reasons are now the three the app classifies as read failures** (`rev-list-failed`, `main-ref-unresolved`, `status-read-failed`). The draft named `no-upstream` and `detached-head`, which `isReadFailureReason` explicitly excludes.
- **"instead of hiding inside the change count" cut**, since nothing read merge, rebase, cherry-pick or bisect state before and a bisect leaves no changed files to hide inside.
- **The Slack rollback line claims the restored record**, not a working integration: the rollback restores the database row, which may hold no working credential.
- **The confirm-targeting line cut.** The portaled overflow menu that made a keyboard session switch mis-target arrived in #1418 itself, so no released build ever had that hazard and it does not belong in user-facing notes.
- **The plain-words fix line cut.** `MainStatus.tsx` still renders `status.branch ?? 'detached HEAD'` in the branch chip and builds "Fast-forward detached HEAD" from it, so git's vocabulary is still on screen in the very panel that line claimed it left. Fixing those two labels is a code change outside this PR's footprint and goes to the backlog.
- **Follow-up line added to #1419**, which `docs/tone-of-voice.md` mandates for this shape: no walk clicked the fast-forward, and it is the first git-mutating command aimed at the user's own checkout. It stands on five Rust integration tests against real clones, and a refusal surfaces in the panel under an alert role.

### Declared departure from the runbook

The runbook filters app notes to `desktop`/`ui`/`core` PRs, which excludes #1421 (`docs(repo)`). This PR includes one Smaller fixes line for it anyway, as a deliberate exception: `docs/concepts.md` and `docs/traps.md` are shipped user documentation, this release is themed the first minute and those two files are what a new user reads next, and the PR closed three issues that had each waited three releases. Recording it here so the next reader sees a decision rather than a slip.

## Verification

- `prettier --check` clean on every touched file, and the format hook plus commitlint ran on both commits.
- `cargo metadata --locked --offline` resolves, so the lockfile matches the bumped manifest.
- No em dash anywhere in the new section, verified by grep.
- Every rewritten claim re-derived from source on this branch: `apps/desktop/src/shared/lib/gitStatus.ts`, `apps/desktop/src/features/workspace/components/WorkspaceGitPanel/MainStatus.tsx`, `apps/desktop/src/features/onboarding/onboarding-store.ts`, `apps/desktop/src-tauri/src/worktree.rs`.

## Unverified

- No CI-independent build of the app was run from this branch: the change is version strings and a markdown section only.
- The release body rendering is not exercised until a tag exists, which is the captain's step.
