### PR TITLE
refactor(desktop): open questions read as one dense row of answers

### DIFF
--- a/apps/desktop/src/features/chat/components/ChatView/OpenQuestionCluster.tsx
+++ b/apps/desktop/src/features/chat/components/ChatView/OpenQuestionCluster.tsx
@@ -59,7 +59,7 @@ export const OpenQuestionCluster = ({ questions, sessionId, viewerAgentId = null
   }, [pendingPairs, flashAnswered, answerOpenQuestions, sessionId, targetAgentId]);
 
   return (
-    <div className="flex flex-col gap-2">
+    <div className="flex min-w-0 flex-col gap-1.5">
       {settled.map((q) => (
         <OpenQuestionInlineCard key={q.id} question={q} sessionId={sessionId} />
       ))}
@@ -68,7 +68,7 @@ export const OpenQuestionCluster = ({ questions, sessionId, viewerAgentId = null
           cluster.ownerAgentId != null ? (agentById.get(cluster.ownerAgentId) ?? null) : null;
         const showsOwner = cluster.ownerAgentId != null && cluster.ownerAgentId !== viewerAgentId;
         return (
-          <div key={cluster.ownerAgentId ?? '__orphan__'} className="flex flex-col gap-2">
+          <div key={cluster.ownerAgentId ?? '__orphan__'} className="flex min-w-0 flex-col gap-1.5">
             {showsOwner && (
               <QuestionClusterHeader
                 sessionId={sessionId}

--- a/apps/desktop/src/features/chat/components/ChatView/OpenQuestionInlineCard.tsx
+++ b/apps/desktop/src/features/chat/components/ChatView/OpenQuestionInlineCard.tsx
@@ -9,7 +9,7 @@ type Props = {
 
 export const OpenQuestionInlineCard = ({ question, sessionId }: Props) => {
   return (
-    <div data-oq-anchor={question.id}>
+    <div data-oq-anchor={question.id} className="min-w-0">
       {question.status === 'answered' ? (
         <AnsweredCard question={question} />
       ) : (

--- a/apps/desktop/src/features/context/components/QuestionsTab/CustomAnswerField/index.tsx
+++ b/apps/desktop/src/features/context/components/QuestionsTab/CustomAnswerField/index.tsx
@@ -23,7 +23,7 @@ export const CustomAnswerField = ({
         onClick={onToggle}
         title="Add custom answer"
         className={cn(
-          'inline-flex items-center gap-1 rounded-full border border-dashed border-border/60 px-2.5 py-1',
+          'inline-flex items-center gap-1 rounded-md border border-dashed border-border/60 px-2.5 py-1',
           'text-xs text-muted-foreground transition-[color,background-color,border-color,transform] duration-150',
           'hover:border-border hover:bg-muted hover:text-foreground active:scale-[0.97]',
           'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
@@ -36,17 +36,17 @@ export const CustomAnswerField = ({
   }
 
   return (
-    <div className="flex w-full flex-col gap-2 motion-safe:animate-fade-in">
-      <span className="px-0.5 text-2xs font-medium text-muted-foreground">your answer</span>
+    <div className="flex min-w-0 max-w-full flex-[1_1_14rem] items-center gap-2 motion-safe:animate-fade-in">
+      <span className="shrink-0 text-2xs font-medium text-muted-foreground">your answer</span>
       <Textarea
         autoFocus
         value={value}
         onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
         autoGrow
-        minRows={2}
-        maxRows={6}
-        className="rounded-md border-border-soft bg-subtle text-xs shadow-none"
+        minRows={1}
+        maxRows={3}
+        className="min-h-7 flex-1 rounded-md border-border-soft bg-subtle text-xs shadow-none"
       />
     </div>
   );

--- a/apps/desktop/src/features/context/components/QuestionsTab/QuestionCard/index.test.tsx
+++ b/apps/desktop/src/features/context/components/QuestionsTab/QuestionCard/index.test.tsx
@@ -30,12 +30,12 @@ const baseProps = {
 };
 
 describe('QuestionCard', () => {
-  it('reads as a filled demands-you surface', () => {
+  it('reads as a quiet workflow surface', () => {
     const { container } = render(<QuestionCard {...baseProps} />);
     const root = container.firstElementChild!;
-    expect(root.className).toContain('rounded-lg');
+    expect(root.className).toContain('border-l-2');
     expect(root.className).toContain('border-warning/40');
-    expect(root.className).toContain('bg-warning/10');
+    expect(root.className).not.toContain('rounded-lg');
   });
 
   it('renders the question text with one button per suggestion', () => {

--- a/apps/desktop/src/features/context/components/QuestionsTab/QuestionCard/index.tsx
+++ b/apps/desktop/src/features/context/components/QuestionsTab/QuestionCard/index.tsx
@@ -63,16 +63,15 @@ export const QuestionCard = ({
   return (
     <TranscriptShell
       tone="warning"
-      variant="boxed"
-      emphasis
+      variant="leftBorder"
       className={cn(
-        'group flex flex-col gap-2 transition-[background-color,transform] duration-200',
+        'group flex flex-col gap-1.5 transition-[background-color,transform] duration-200',
         animate
           ? 'motion-safe:animate-answer-lock motion-reduce:bg-success/5'
           : 'motion-safe:animate-fade-in',
       )}
     >
-      <div className="flex items-start justify-between gap-2">
+      <div className="flex flex-wrap items-start justify-between gap-x-2 gap-y-1">
         <div className="flex min-w-0 items-start gap-2">
           <MessageCircleQuestion
             size={14}
@@ -98,6 +97,19 @@ export const QuestionCard = ({
         >
           {animate ? <Check size={12} className="text-success" /> : <X size={12} />}
         </button>
+        <div className="flex items-center gap-2 text-2xs text-muted-foreground">
+          <span>{formatRelativeAge({ fromIso: question.createdAt })}</span>
+          {question.ownedByStepOrdinal != null && (
+            <span className="rounded-md bg-muted px-1 py-0.5 font-mono text-2xs text-muted-foreground">
+              step {question.ownedByStepOrdinal}
+            </span>
+          )}
+          {question.workflowId && question.ownedByStepOrdinal != null && (
+            <span className="rounded-md bg-muted px-1 py-0.5 text-2xs text-muted-foreground">
+              workflow
+            </span>
+          )}
+        </div>
       </div>
 
       <div className="flex flex-wrap items-center gap-1.5 pl-6">
@@ -116,20 +128,6 @@ export const QuestionCard = ({
           onToggle={() => onToggleCustomField(question.id)}
           onChange={(text) => onSetCustomAnswer(question.id, text)}
         />
-      </div>
-
-      <div className="flex items-center gap-2 pl-6 text-2xs text-muted-foreground">
-        <span>{formatRelativeAge({ fromIso: question.createdAt })}</span>
-        {question.ownedByStepOrdinal != null && (
-          <span className="rounded-md bg-muted px-1 py-0.5 font-mono text-2xs text-muted-foreground">
-            step {question.ownedByStepOrdinal}
-          </span>
-        )}
-        {question.workflowId && question.ownedByStepOrdinal != null && (
-          <span className="rounded-md bg-muted px-1 py-0.5 text-2xs text-muted-foreground">
-            workflow
-          </span>
-        )}
       </div>
     </TranscriptShell>
   );

--- a/apps/desktop/src/features/context/components/QuestionsTab/SuggestionChip/index.tsx
+++ b/apps/desktop/src/features/context/components/QuestionsTab/SuggestionChip/index.tsx
@@ -19,7 +19,7 @@ export const SuggestionChip = ({ label, selected, recommended = false, onToggle 
       aria-pressed={selected}
       title={recommended ? `${label} (suggested)` : label}
       className={cn(
-        'group inline-flex max-w-full items-center gap-1 rounded-full border text-xs font-medium transition-[color,background-color,border-color,box-shadow,transform] duration-150',
+        'group inline-flex min-w-0 max-w-40 items-center gap-1 rounded-md border text-xs font-medium transition-[color,background-color,border-color,box-shadow,transform] duration-150',
         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
         isCodeLike(label) && 'font-mono text-2xs',
         selected
@@ -41,7 +41,7 @@ export const SuggestionChip = ({ label, selected, recommended = false, onToggle 
       {recommended && !selected && (
         <CONCEPT_ICONS.suggestion size={11} aria-hidden className="shrink-0 text-info" />
       )}
-      <span className="min-w-0 break-words text-left">{label}</span>
+      <span className="min-w-0 truncate text-left">{label}</span>
     </button>
   );
 };


### PR DESCRIPTION
## Why

The owner on the open questions surface: put the answers on one row, cut the rounding, the whole thing can be polished a lot harder.

The interesting part is why they stacked. `QuestionCard` already used a wrapping flex row, so the container was never the problem. A suggested answer is free text from a model and is often a full sentence, so one chip ate the width and the next wrapped under it.

## What changed

- A suggestion chip caps its width and truncates. The full text stays reachable through the title it already set, and the accessible name is unchanged.
- The custom answer field shrinks inside the option row instead of breaking it into a column.
- The card no longer spends a dedicated row on the relative age plus the step and workflow chips. That metadata folds into the header.
- Radii and vertical rhythm aligned to the transcript conventions, and the card moved to the quiet left border treatment rather than a nested boxed card.

Both representations, the chat transcript and the questions tab, render the same component, so they stay in sync by construction.

No store, gate, submit, dismissal or keyboard behaviour changed.

## Verification

- `pnpm --filter @goodboy/desktop typecheck`
- vitest over QuestionsTab and the ChatView open questions, 39 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)