### PR TITLE
fix(desktop): setup items act, and a linear goal keeps its text

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -58,6 +58,7 @@ import { OnboardingWizard } from './features/onboarding/OnboardingWizard';
 import { CompanionStudio } from './features/companion/CompanionStudio';
 import { listenBridgeCommands } from './features/companion/commandExecutor';
 import { markStepComplete } from './features/onboarding/onboarding-store';
+import { OPEN_COMMAND_PALETTE_EVENT } from './features/onboarding/openCommandPaletteEvent';
 import { useShortcut } from './shared/keyboard/useShortcut';
 import { useProviderRefreshOnFocus } from './shared/hooks/useProviderRefreshOnFocus';
 import { useZoomShortcuts } from './shared/hooks/useZoomShortcuts';
@@ -610,6 +611,12 @@ export const App = () => {
     setPaletteOpen(true);
     markStepComplete('palette');
   }, []);
+
+  useEffect(() => {
+    const handler = () => openPalette();
+    window.addEventListener(OPEN_COMMAND_PALETTE_EVENT, handler);
+    return () => window.removeEventListener(OPEN_COMMAND_PALETTE_EVENT, handler);
+  }, [openPalette]);
   const openWorkspace = useAppStore((s) => s.openWorkspace);
   const setCurrentSession = useAppStore((s) => s.setCurrentSession);
   const lensGo = useAppStore((s) => s.lensGo);

--- a/apps/desktop/src/features/integrations/linear/goal-from-issue.test.ts
+++ b/apps/desktop/src/features/integrations/linear/goal-from-issue.test.ts
@@ -29,11 +29,10 @@ describe('goalFromIssue', () => {
     expect(goalFromIssue(makeIssue({ description: '   ' }))).toBe('[SER-123] Add user signup');
   });
 
-  it('trims trailing whitespace and overlong descriptions', () => {
+  it('keeps overlong descriptions intact after trimming whitespace', () => {
     const long = 'x'.repeat(2000);
     const goal = goalFromIssue(makeIssue({ description: long }));
-    expect(goal.endsWith('…')).toBe(true);
-    expect(goal.length).toBeLessThanOrEqual(1300);
+    expect(goal).toBe(`[SER-123] Add user signup\n\n${long}`);
   });
 
   it('strips title whitespace', () => {

--- a/apps/desktop/src/features/integrations/linear/goal-from-issue.ts
+++ b/apps/desktop/src/features/integrations/linear/goal-from-issue.ts
@@ -1,16 +1,10 @@
 import type { LinearIssue } from './client';
 
-const DESCRIPTION_CHAR_CAP = 1200;
-
 export const goalFromIssue = (issue: LinearIssue): string => {
   const heading = `[${issue.identifier}] ${issue.title.trim()}`;
   const description = (issue.description ?? '').trim();
   if (!description) {
     return heading;
   }
-  const trimmed =
-    description.length > DESCRIPTION_CHAR_CAP
-      ? `${description.slice(0, DESCRIPTION_CHAR_CAP).trimEnd()}…`
-      : description;
-  return `${heading}\n\n${trimmed}`;
+  return `${heading}\n\n${description}`;
 };

--- a/apps/desktop/src/features/onboarding/OnboardingCard/ChecklistBody.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingCard/ChecklistBody.tsx
@@ -1,0 +1,64 @@
+import { X } from 'lucide-react';
+import { collapse, visibleOnboardingSteps, type OnboardingGroup } from '../onboarding-store';
+import type { OnboardingProgress } from '../hooks/useOnboardingProgress';
+import { StepRow } from './StepRow';
+
+const GROUP_LABEL: Record<OnboardingGroup, string> = {
+  setup: 'Setup',
+  build: 'First steps',
+};
+
+const GROUP_ORDER: ReadonlyArray<OnboardingGroup> = ['setup', 'build'];
+
+type Props = {
+  readonly progress: OnboardingProgress;
+};
+
+export const ChecklistBody = ({ progress }: Props) => {
+  const visibleSteps = visibleOnboardingSteps({ isSimple: progress.isSimple });
+  return (
+    <>
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-semibold tracking-tight text-foreground">Goodboy setup</span>
+        <button
+          type="button"
+          onClick={() => collapse()}
+          title="Hide onboarding checklist (reopen it from the top bar)"
+          aria-label="Hide onboarding checklist"
+          className="rounded-md p-0.5 text-muted-foreground/70 motion-safe:transition-colors hover:bg-foreground/5 hover:text-foreground"
+        >
+          <X size={11} aria-hidden />
+        </button>
+      </div>
+      <div className="flex flex-col gap-2.5">
+        {GROUP_ORDER.map((group) => {
+          const steps = visibleSteps.filter((step) => step.group === group);
+          if (steps.length === 0) {
+            return null;
+          }
+          return (
+            <div key={group} className="flex flex-col gap-1">
+              <span className="px-1.5 text-3xs font-medium uppercase tracking-[0.08em] text-muted-foreground/50">
+                {GROUP_LABEL[group]}
+              </span>
+              <ul className="flex flex-col gap-1">
+                {steps.map((step) => (
+                  <StepRow
+                    key={step.id}
+                    id={step.id}
+                    title={step.title}
+                    why={step.why}
+                    done={progress.completed.has(step.id)}
+                  />
+                ))}
+              </ul>
+            </div>
+          );
+        })}
+      </div>
+      <p className="text-3xs leading-snug text-muted-foreground/60">
+        {progress.completedCount} of {progress.totalCount} steps done
+      </p>
+    </>
+  );
+};

--- a/apps/desktop/src/features/onboarding/OnboardingCard/CompletedBody.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingCard/CompletedBody.tsx
@@ -1,0 +1,26 @@
+import { X } from 'lucide-react';
+import { finish } from '../onboarding-store';
+import { CONCEPT_ICONS } from '../../../shared/components/conceptIcons';
+
+export const CompletedBody = () => (
+  <>
+    <div className="flex items-center justify-between">
+      <span className="inline-flex items-center gap-1 text-2xs font-semibold uppercase tracking-[0.08em] text-success">
+        <CONCEPT_ICONS.decisions size={11} aria-hidden />
+        Setup complete
+      </span>
+      <button
+        type="button"
+        onClick={() => finish()}
+        title="Dismiss onboarding"
+        aria-label="Dismiss onboarding"
+        className="rounded-md p-0.5 text-muted-foreground/70 motion-safe:transition-colors hover:bg-foreground/5 hover:text-foreground"
+      >
+        <X size={11} aria-hidden />
+      </button>
+    </div>
+    <p className="text-2xs leading-snug text-muted-foreground/80">
+      That was the last step. Setup is complete.
+    </p>
+  </>
+);

--- a/apps/desktop/src/features/onboarding/OnboardingCard/StepRow.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingCard/StepRow.tsx
@@ -1,0 +1,68 @@
+import { Check } from 'lucide-react';
+import { cn } from '@goodboy/ui';
+import { OPEN_WIZARD_EVENT, type OnboardingStepId } from '../onboarding-store';
+import { OPEN_COMMAND_PALETTE_EVENT } from '../openCommandPaletteEvent';
+
+type Props = {
+  readonly id: OnboardingStepId;
+  readonly title: string;
+  readonly why: string;
+  readonly done: boolean;
+};
+
+export const StepRow = ({ id, title, why, done }: Props) => {
+  const actionByStep: Readonly<Partial<Record<OnboardingStepId, string>>> = {
+    workspace: 'goodboy:add-workspace',
+    codeHost: 'goodboy:open-github-studio',
+    tools: OPEN_WIZARD_EVENT,
+    session: 'goodboy:new-session',
+    palette: OPEN_COMMAND_PALETTE_EVENT,
+  };
+  const action = actionByStep[id];
+  const activate = () => {
+    if (action === undefined) {
+      return;
+    }
+    window.dispatchEvent(new CustomEvent(action));
+  };
+
+  return (
+    <li title={why} className="rounded-md">
+      {done || action === undefined ? (
+        <span
+          className={cn(
+            'flex items-center gap-2 px-1.5 py-1 text-2xs',
+            done ? 'text-muted-foreground/60' : 'text-foreground',
+          )}
+        >
+          <span
+            aria-hidden
+            className={cn(
+              'inline-flex size-3.5 shrink-0 items-center justify-center rounded-full border',
+              done
+                ? 'border-success bg-success/15 text-success'
+                : 'border-border-soft bg-transparent',
+            )}
+          >
+            {done ? <Check size={9} aria-hidden /> : null}
+          </span>
+          <span className={cn('truncate', done && 'line-through decoration-1')}>{title}</span>
+        </span>
+      ) : (
+        <button
+          type="button"
+          onClick={activate}
+          title={why}
+          aria-label={`Set up ${title}`}
+          className="flex w-full items-center gap-2 rounded-md px-1.5 py-1 text-left text-2xs text-foreground motion-safe:transition-colors hover:bg-foreground/5 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary"
+        >
+          <span
+            aria-hidden
+            className="inline-flex size-3.5 shrink-0 items-center justify-center rounded-full border border-border-soft bg-transparent"
+          />
+          <span className="truncate">{title}</span>
+        </button>
+      )}
+    </li>
+  );
+};

--- a/apps/desktop/src/features/onboarding/OnboardingCard/index.test.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingCard/index.test.tsx
@@ -16,6 +16,7 @@ const { finishMock, progress } = vi.hoisted(() => ({
 }));
 
 vi.mock('../onboarding-store', () => ({
+  OPEN_WIZARD_EVENT: 'goodboy:open-onboarding-wizard',
   visibleOnboardingSteps: () => [
     { id: 'workspace', title: 'Workspace', why: 'Workspace', group: 'setup' },
     { id: 'session', title: 'Session', why: 'Session', group: 'build' },

--- a/apps/desktop/src/features/onboarding/OnboardingCard/index.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingCard/index.tsx
@@ -1,22 +1,9 @@
-import { Check, X } from 'lucide-react';
+import { X } from 'lucide-react';
 import { cn } from '@goodboy/ui';
-import {
-  visibleOnboardingSteps,
-  collapse,
-  finish,
-  reopen,
-  type OnboardingGroup,
-  type OnboardingStepId,
-} from '../onboarding-store';
-import { useOnboardingProgress, type OnboardingProgress } from '../hooks/useOnboardingProgress';
-import { CONCEPT_ICONS } from '../../../shared/components/conceptIcons';
-
-const GROUP_LABEL: Record<OnboardingGroup, string> = {
-  setup: 'Setup',
-  build: 'First steps',
-};
-
-const GROUP_ORDER: ReadonlyArray<OnboardingGroup> = ['setup', 'build'];
+import { finish, reopen, visibleOnboardingSteps } from '../onboarding-store';
+import { useOnboardingProgress } from '../hooks/useOnboardingProgress';
+import { ChecklistBody } from './ChecklistBody';
+import { CompletedBody } from './CompletedBody';
 
 export const OnboardingCard = () => {
   const progress = useOnboardingProgress();
@@ -36,110 +23,6 @@ export const OnboardingCard = () => {
     </div>
   );
 };
-
-function ChecklistBody({ progress }: { progress: OnboardingProgress }) {
-  const visibleSteps = visibleOnboardingSteps({ isSimple: progress.isSimple });
-  return (
-    <>
-      <div className="flex items-center justify-between">
-        <span className="text-xs font-semibold tracking-tight text-foreground">Goodboy setup</span>
-        <button
-          type="button"
-          onClick={() => collapse()}
-          title="Hide onboarding checklist (reopen it from the top bar)"
-          aria-label="Hide onboarding checklist"
-          className="rounded-md p-0.5 text-muted-foreground/70 motion-safe:transition-colors hover:bg-foreground/5 hover:text-foreground"
-        >
-          <X size={11} aria-hidden />
-        </button>
-      </div>
-      <div className="flex flex-col gap-2.5">
-        {GROUP_ORDER.map((group) => {
-          const steps = visibleSteps.filter((s) => s.group === group);
-          if (steps.length === 0) {
-            return null;
-          }
-          return (
-            <div key={group} className="flex flex-col gap-1">
-              <span className="px-1.5 text-3xs font-medium uppercase tracking-[0.08em] text-muted-foreground/50">
-                {GROUP_LABEL[group]}
-              </span>
-              <ul className="flex flex-col gap-1">
-                {steps.map((step) => (
-                  <StepRow
-                    key={step.id}
-                    id={step.id}
-                    title={step.title}
-                    why={step.why}
-                    done={progress.completed.has(step.id)}
-                  />
-                ))}
-              </ul>
-            </div>
-          );
-        })}
-      </div>
-      <p className="text-3xs leading-snug text-muted-foreground/60">
-        {progress.completedCount} of {progress.totalCount} steps done
-      </p>
-    </>
-  );
-}
-
-function CompletedBody() {
-  return (
-    <>
-      <div className="flex items-center justify-between">
-        <span className="inline-flex items-center gap-1 text-2xs font-semibold uppercase tracking-[0.08em] text-success">
-          <CONCEPT_ICONS.decisions size={11} aria-hidden />
-          Setup complete
-        </span>
-        <button
-          type="button"
-          onClick={() => finish()}
-          title="Dismiss onboarding"
-          aria-label="Dismiss onboarding"
-          className="rounded-md p-0.5 text-muted-foreground/70 motion-safe:transition-colors hover:bg-foreground/5 hover:text-foreground"
-        >
-          <X size={11} aria-hidden />
-        </button>
-      </div>
-      <p className="text-2xs leading-snug text-muted-foreground/80">
-        That was the last step. Setup is complete.
-      </p>
-    </>
-  );
-}
-
-type StepRowProps = {
-  readonly id: OnboardingStepId;
-  readonly title: string;
-  readonly why: string;
-  readonly done: boolean;
-};
-
-function StepRow({ title, why, done }: StepRowProps) {
-  return (
-    <li
-      title={why}
-      className={cn(
-        'flex items-center gap-2 rounded-md px-1.5 py-1 text-2xs motion-safe:transition-colors',
-        done ? 'text-muted-foreground/60' : 'text-foreground',
-      )}
-    >
-      <span
-        aria-hidden
-        className={cn(
-          'inline-flex size-3.5 shrink-0 items-center justify-center rounded-full border',
-          done ? 'border-success bg-success/15 text-success' : 'border-border-soft bg-transparent',
-        )}
-      >
-        {done ? <Check size={9} aria-hidden /> : null}
-      </span>
-      <span className={cn('truncate', done && 'line-through decoration-1')}>{title}</span>
-    </li>
-  );
-}
 
 export const OnboardingChip = () => {
   const progress = useOnboardingProgress();

--- a/apps/desktop/src/features/onboarding/openCommandPaletteEvent.ts
+++ b/apps/desktop/src/features/onboarding/openCommandPaletteEvent.ts
@@ -1,0 +1,1 @@
+export const OPEN_COMMAND_PALETTE_EVENT = 'goodboy:open-command-palette';


### PR DESCRIPTION
## Why

Two reports from the field, plus a verification pass on two older issues.

**#1424**: the Goodboy setup modal lists what is still missing but nothing in it is clickable, so the user reads a to-do list and then has to go find each destination themselves.

**#1429**: creating a session from a Linear task put the task title and description into the goal, and the text stopped part way through.

## What changed

**#1429** was a 1200 character cap on the Linear description. The tail was dropped silently, with nothing telling the user their goal had been shortened. The cap is gone and the goal keeps the full text.

**#1424**: an unmet checklist item is now a control that opens the surface which actually resolves it. Where it lands, one line each:

- workspace, opens workspace creation
- code host, opens the GitHub studio
- tools, opens the onboarding wizard, which is where Linear, Jira, Slack and Sentry are configured
- session, opens a new session
- palette, opens the command palette
- agent and plan stay inert, because neither has a destination that can satisfy them without a session already existing. They explain what would satisfy them rather than sending the user somewhere that cannot help.

A satisfied item stays inert and does not look clickable.

Cleanup taken while in the file, since the repo rules were already being broken there: the onboarding card moved off `function` declarations onto named arrows, `ChecklistBody`, `CompletedBody` and `StepRow` moved to sibling files, and the palette event name became one exported constant instead of a string literal repeated at the dispatch and the listener.

## Two issues verified, not reworked

- **#1252**, pull of the main checkout as an action: already shipped in `dce89a86f`, which exposes pulling main as an explicit action and makes git status fail closed. Safe to close.
- **#1371**, the empty-state drift: partially addressed in `4841b0ce6`. The rule and the wrapper land on the popover branch, and the remaining sweep is listed there.

## Verification

- `pnpm --filter @goodboy/desktop typecheck`
- vitest over onboarding and the linear goal

Closes #1424
Closes #1429

🤖 Generated with [Claude Code](https://claude.com/claude-code)