### PR TITLE
feat(desktop): report an issue is compact, guessed, and confirms in app

### DIFF
--- a/apps/desktop/src-tauri/src/attachment.rs
+++ b/apps/desktop/src-tauri/src/attachment.rs
@@ -260,8 +260,22 @@ pub fn bug_report_stage_images(
 ) -> Result<String, AttachmentError> {
     let dir = std::env::temp_dir().join(bug_report_dir_name());
     write_bug_report_images(&dir, &images)?;
-    crate::explore::spawn_open(&dir, false)?;
     Ok(dir.to_string_lossy().to_string())
+}
+
+#[tauri::command]
+pub fn bug_report_reveal_images(dir: String) -> Result<(), AttachmentError> {
+    let canonical_dir = Path::new(&dir).canonicalize()?;
+    let canonical_temp_dir = std::env::temp_dir().canonicalize()?;
+    let is_report_dir = canonical_dir
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.starts_with("goodboy-report-"));
+    if !canonical_dir.starts_with(canonical_temp_dir) || !is_report_dir {
+        return Err(AttachmentError::InvalidPath);
+    }
+    crate::explore::spawn_open(&canonical_dir, false)?;
+    Ok(())
 }
 
 #[cfg(test)]
@@ -413,6 +427,18 @@ mod tests {
         );
         assert!(matches!(err, Err(AttachmentError::Decode(_))));
 
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn bug_report_reveal_rejects_an_unrelated_temp_folder() {
+        let dir = std::env::temp_dir().join(format!("goodboy-other-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+
+        let result = bug_report_reveal_images(dir.to_string_lossy().to_string());
+
+        assert!(matches!(result, Err(AttachmentError::InvalidPath)));
         let _ = fs::remove_dir_all(&dir);
     }
 

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -251,6 +251,7 @@ pub fn run() {
             attachment::attachment_delete,
             attachment::attachment_read_dropped,
             attachment::bug_report_stage_images,
+            attachment::bug_report_reveal_images,
             file_versions::file_versions_begin_snapshot,
             file_versions::file_versions_finalize_snapshot,
             file_versions::file_versions_list_staged_snapshots,

--- a/apps/desktop/src/features/notifications/components/NotificationCenter/index.tsx
+++ b/apps/desktop/src/features/notifications/components/NotificationCenter/index.tsx
@@ -26,6 +26,7 @@ import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../shared/components/conce
 import { formatRelativeAge } from '../../../../shared/utils/relativeDate';
 import { NOTIFICATION_SEVERITY } from '../../severity';
 import { NOTIFICATIONS_STUDIO_EVENT } from '../../studioEvent';
+import { sendNotificationToDevelopers } from '../../../settings/sendNotificationToDevelopers';
 
 const DROPDOWN_WIDTH = 384;
 const LIST_MAX_HEIGHT = 400;
@@ -241,6 +242,7 @@ const NotificationItem = ({ notification: n, onNavigated }: NotificationItemProp
   const [pickerOpen, setPickerOpen] = useState(false);
   const sessionId = n.sessionId;
   const agentId = n.action?.kind === 'retry-step-summary' ? n.action.agentId : null;
+  const canSendToDevelopers = n.severity === 'warning' || n.severity === 'error';
 
   const severity = NOTIFICATION_SEVERITY[n.severity];
   const SeverityIcon = severity.icon;
@@ -306,15 +308,17 @@ const NotificationItem = ({ notification: n, onNavigated }: NotificationItemProp
           {body}
         </button>
       )}
-      {action != null ? (
+      {action != null || canSendToDevelopers ? (
         <div className="flex items-center gap-1.5 pl-5">
-          <button
-            type="button"
-            className="rounded px-1.5 py-0.5 text-2xs font-medium text-foreground/80 ring-1 ring-inset ring-foreground/20 hover:bg-muted hover:text-foreground"
-            onClick={action.onClick}
-          >
-            {action.label}
-          </button>
+          {action != null ? (
+            <button
+              type="button"
+              className="rounded px-1.5 py-0.5 text-2xs font-medium text-foreground/80 ring-1 ring-inset ring-foreground/20 hover:bg-muted hover:text-foreground"
+              onClick={action.onClick}
+            >
+              {action.label}
+            </button>
+          ) : null}
           {retryAction != null && (
             <button
               type="button"
@@ -324,6 +328,19 @@ const NotificationItem = ({ notification: n, onNavigated }: NotificationItemProp
               Retry with…
             </button>
           )}
+          {canSendToDevelopers ? (
+            <button
+              type="button"
+              className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-2xs text-muted-foreground hover:bg-muted hover:text-foreground"
+              onClick={() => {
+                sendNotificationToDevelopers({ notification: n });
+                onNavigated();
+              }}
+            >
+              <CONCEPT_ICONS.reportIssue size={11} aria-hidden />
+              Send to developers
+            </button>
+          ) : null}
         </div>
       ) : null}
       {action != null && pickerOpen && retryAction != null ? (

--- a/apps/desktop/src/features/notifications/components/NotificationsStudio/NotificationCard.tsx
+++ b/apps/desktop/src/features/notifications/components/NotificationsStudio/NotificationCard.tsx
@@ -3,6 +3,8 @@ import { Eyebrow, MetaRow, StatusDot, cn, tintClasses } from '@goodboy/ui';
 import type { Notification } from '@goodboy/db';
 import { formatAbsoluteDateTime, formatRelativeAge } from '../../../../shared/utils/relativeDate';
 import { NOTIFICATION_SEVERITY } from '../../severity';
+import { CONCEPT_ICONS } from '../../../../shared/components/conceptIcons';
+import { sendNotificationToDevelopers } from '../../../settings/sendNotificationToDevelopers';
 
 type Props = {
   readonly notification: Notification;
@@ -23,6 +25,8 @@ export const NotificationCard = ({
   const SeverityIcon = severity.icon;
   const tint = tintClasses(severity.tone);
   const hasBody = notification.body != null && notification.body !== '';
+  const canSendToDevelopers =
+    notification.severity === 'warning' || notification.severity === 'error';
 
   return (
     <li
@@ -76,6 +80,16 @@ export const NotificationCard = ({
             {actionLabel}
           </button>
         )}
+        {canSendToDevelopers ? (
+          <button
+            type="button"
+            onClick={() => sendNotificationToDevelopers({ notification })}
+            className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-2xs text-muted-foreground motion-safe:transition-colors hover:bg-muted hover:text-foreground"
+          >
+            <CONCEPT_ICONS.reportIssue size={11} aria-hidden />
+            Send to developers
+          </button>
+        ) : null}
         <div className="ml-auto flex items-center gap-1.5">
           {!notification.read && (
             <button

--- a/apps/desktop/src/features/notifications/components/NotificationsStudio/index.test.tsx
+++ b/apps/desktop/src/features/notifications/components/NotificationsStudio/index.test.tsx
@@ -17,6 +17,13 @@ const { state } = vi.hoisted(() => ({
     retrySummarizer: vi.fn(),
     retryStepSummary: vi.fn(async () => undefined),
     summarizerStatus: {} as Record<string, unknown>,
+    bugReportDraft: {
+      issueType: 'idea',
+      title: 'Existing draft',
+      description: 'Earlier notes',
+      images: [],
+    },
+    setBugReportDraft: vi.fn(),
   },
 }));
 
@@ -67,6 +74,13 @@ beforeEach(() => {
   state.clearNotifications = vi.fn(async () => undefined);
   state.retrySummarizer = vi.fn();
   state.summarizerStatus = {};
+  state.bugReportDraft = {
+    issueType: 'idea',
+    title: 'Existing draft',
+    description: 'Earlier notes',
+    images: [],
+  };
+  state.setBugReportDraft = vi.fn();
 });
 
 afterEach(cleanup);
@@ -83,6 +97,32 @@ describe('NotificationsStudio', () => {
     expect(body.textContent).toBe(LONG_BODY);
     expect(body.className).not.toContain('line-clamp');
     expect(body.className).toContain('whitespace-pre-wrap');
+    expect(screen.getByRole('button', { name: 'Send to developers' })).toBeDefined();
+  });
+
+  it('does not offer an informational notification to developers', () => {
+    seedNotifications([buildNotification({ severity: 'info' })]);
+    renderStudio();
+
+    expect(screen.queryByRole('button', { name: 'Send to developers' })).toBeNull();
+  });
+
+  it('merges a warning into the existing draft before opening the report studio', () => {
+    const onOpenStudio = vi.fn();
+    window.addEventListener('goodboy:open-report-issue', onOpenStudio);
+    seedNotifications([buildNotification({ severity: 'warning' })]);
+    renderStudio();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Send to developers' }));
+
+    expect(state.setBugReportDraft).toHaveBeenCalledWith({
+      issueType: 'bug',
+      title: 'Existing draft',
+      description: `Earlier notes\n\nsummarizer failed\n\n${LONG_BODY}`,
+    });
+    expect(state.markNotificationRead).not.toHaveBeenCalled();
+    expect(onOpenStudio).toHaveBeenCalledOnce();
+    window.removeEventListener('goodboy:open-report-issue', onOpenStudio);
   });
 
   it('fires the mapped handler behind a notification CTA', async () => {

--- a/apps/desktop/src/features/settings/components/ReportIssuePopover/index.test.tsx
+++ b/apps/desktop/src/features/settings/components/ReportIssuePopover/index.test.tsx
@@ -162,4 +162,12 @@ describe('ReportIssuePopover', () => {
 
     expect(screen.queryByTestId('report-issue-draft-dot')).toBeNull();
   });
+
+  it('shows the draft dot when only the studio title is waiting', () => {
+    useAppStore.getState().setBugReportDraft({ title: 'Terminal loses focus' });
+
+    render(<ReportIssuePopover />);
+
+    expect(screen.getByTestId('report-issue-draft-dot')).toBeDefined();
+  });
 });

--- a/apps/desktop/src/features/settings/components/ReportIssuePopover/index.tsx
+++ b/apps/desktop/src/features/settings/components/ReportIssuePopover/index.tsx
@@ -44,6 +44,7 @@ export const ReportIssuePopover = () => {
   const imageControl = useBugReportImages();
 
   const hasDraft =
+    draft.title !== '' ||
     draft.description !== '' ||
     draft.issueType !== emptyBugReportDraft.issueType ||
     draft.images.length > 0;
@@ -114,7 +115,7 @@ export const ReportIssuePopover = () => {
               />
               <BugReportImages control={imageControl} />
               <p className="text-2xs leading-relaxed text-muted-foreground">
-                Kept as a draft until you send it from the report form.
+                Kept as a draft until you send it.
               </p>
             </div>
             <Divider />

--- a/apps/desktop/src/features/settings/components/ReportIssueStudio/guessArea.test.ts
+++ b/apps/desktop/src/features/settings/components/ReportIssueStudio/guessArea.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { guessArea } from './guessArea';
+
+describe('guessArea', () => {
+  it('returns null when no keyword matches', () => {
+    expect(guessArea({ text: 'The screen feels odd' })).toBeNull();
+  });
+
+  it('counts each keyword once and supports Italian reports', () => {
+    expect(guessArea({ text: 'Il costo supera il budget. Budget budget budget.' })).toBe(
+      'budget-spend',
+    );
+  });
+
+  it('uses word boundaries for single words', () => {
+    expect(guessArea({ text: 'The cardinal direction changed' })).toBeNull();
+  });
+
+  it('matches phrases and resolves score ties by earliest match', () => {
+    expect(guessArea({ text: 'Pull request fails after a provider update' })).toBe('reviews');
+  });
+
+  it('never guesses the catch-all area', () => {
+    expect(guessArea({ text: 'Something else happened on GitHub' })).toBeNull();
+  });
+});

--- a/apps/desktop/src/features/settings/components/ReportIssueStudio/guessArea.ts
+++ b/apps/desktop/src/features/settings/components/ReportIssueStudio/guessArea.ts
@@ -1,0 +1,186 @@
+import type { AreaValue } from './areas';
+
+type GuessAreaParams = {
+  readonly text: string;
+};
+
+type AreaKeywords = {
+  readonly area: Exclude<AreaValue, 'something-else'>;
+  readonly keywords: ReadonlyArray<string>;
+};
+
+type AreaScore = {
+  readonly area: Exclude<AreaValue, 'something-else'>;
+  readonly count: number;
+  readonly firstIndex: number;
+};
+
+const AREA_KEYWORDS = [
+  {
+    area: 'board-sessions',
+    keywords: [
+      'board',
+      'session',
+      'sessione',
+      'sessioni',
+      'stage',
+      'lane',
+      'kanban',
+      'goal',
+      'card',
+    ],
+  },
+  {
+    area: 'chat-agents',
+    keywords: [
+      'chat',
+      'agent',
+      'agente',
+      'agenti',
+      'transcript',
+      'composer',
+      'message',
+      'messaggio',
+      'turn',
+    ],
+  },
+  {
+    area: 'workflows-plans',
+    keywords: [
+      'workflow',
+      'plan',
+      'piano',
+      'step',
+      'preset',
+      'orchestrator',
+      'orchestratore',
+      'autorun',
+    ],
+  },
+  {
+    area: 'diff-files-terminal',
+    keywords: ['diff', 'file', 'terminal', 'terminale', 'worktree', 'editor', 'esplora'],
+  },
+  {
+    area: 'reviews',
+    keywords: ['pull request', 'pr', 'review', 'merge request', 'mr', 'merge'],
+  },
+  {
+    area: 'integrations',
+    keywords: [
+      'integration',
+      'integrazione',
+      'integrazioni',
+      'linear',
+      'gitlab',
+      'bitbucket',
+      'slack',
+      'jira',
+      'sentry',
+      'webhook',
+      'issue',
+    ],
+  },
+  {
+    area: 'providers-models',
+    keywords: [
+      'provider',
+      'model',
+      'modello',
+      'claude',
+      'codex',
+      'cursor',
+      'opus',
+      'sonnet',
+      'gpt',
+      'gemini',
+      'antigravity',
+      'opencode',
+      'effort',
+    ],
+  },
+  {
+    area: 'budget-spend',
+    keywords: ['budget', 'spend', 'cost', 'costo', 'spesa', 'price', 'prezzo', 'cap', 'usd'],
+  },
+  {
+    area: 'permissions-scripts',
+    keywords: ['permission', 'permesso', 'permessi', 'script', 'allowlist', 'sandbox'],
+  },
+  {
+    area: 'notifications',
+    keywords: ['notification', 'notifica', 'notifiche', 'toast', 'inbox'],
+  },
+  {
+    area: 'phone-companion',
+    keywords: ['phone', 'companion', 'mobile', 'telefono', 'qr'],
+  },
+  {
+    area: 'settings-onboarding',
+    keywords: [
+      'settings',
+      'impostazioni',
+      'onboarding',
+      'wizard',
+      'setup',
+      'guide',
+      'guida',
+      'theme',
+      'tema',
+    ],
+  },
+  {
+    area: 'startup-updates-data',
+    keywords: [
+      'startup',
+      'avvio',
+      'launch',
+      'update',
+      'aggiornamento',
+      'crash',
+      'boot',
+      'database',
+      'migration',
+    ],
+  },
+] satisfies ReadonlyArray<AreaKeywords>;
+
+type KeywordIndexParams = {
+  readonly text: string;
+  readonly keyword: string;
+};
+
+const keywordIndex = ({ text, keyword }: KeywordIndexParams): number => {
+  if (keyword.includes(' ')) {
+    return text.indexOf(keyword);
+  }
+  return text.search(new RegExp(`\\b${keyword}\\b`));
+};
+
+type ScoreParams = {
+  readonly text: string;
+  readonly entry: AreaKeywords;
+};
+
+const scoreArea = ({ text, entry }: ScoreParams): AreaScore | null => {
+  const indexes = entry.keywords
+    .map((keyword) => keywordIndex({ text, keyword }))
+    .filter((index) => index >= 0);
+  if (indexes.length === 0) {
+    return null;
+  }
+  return {
+    area: entry.area,
+    count: indexes.length,
+    firstIndex: Math.min(...indexes),
+  };
+};
+
+export const guessArea = ({ text }: GuessAreaParams): AreaValue | null => {
+  const normalized = text.toLowerCase();
+  const scores = AREA_KEYWORDS.map((entry) => scoreArea({ text: normalized, entry })).filter(
+    (score): score is AreaScore => score != null,
+  );
+  scores.sort((left, right) => right.count - left.count || left.firstIndex - right.firstIndex);
+  return scores[0]?.area ?? null;
+};

--- a/apps/desktop/src/features/settings/components/ReportIssueStudio/index.test.tsx
+++ b/apps/desktop/src/features/settings/components/ReportIssueStudio/index.test.tsx
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   invoke: vi.fn<(cmd: string, args: Record<string, unknown>) => Promise<unknown>>(
     async () => '/tmp/goodboy-report-1',
   ),
+  showToast: vi.fn(),
 }));
 
 vi.mock('@tauri-apps/api/core', () => ({
@@ -44,6 +45,10 @@ vi.mock('../../../github/github', () => ({
 
 vi.mock('../../../../shared/lib/editor', () => ({
   openUrl: mocks.openUrl,
+}));
+
+vi.mock('../../../../app/components/Toast', () => ({
+  useToast: () => ({ showToast: mocks.showToast }),
 }));
 
 import { ReportIssueStudio } from './index';
@@ -79,6 +84,7 @@ beforeEach(() => {
   mocks.openUrl.mockImplementation(async () => undefined);
   mocks.invoke.mockReset();
   mocks.invoke.mockImplementation(async () => '/tmp/goodboy-report-1');
+  mocks.showToast.mockReset();
 });
 afterEach(cleanup);
 
@@ -90,11 +96,29 @@ describe('ReportIssueStudio', () => {
     const send = () => screen.getByRole('button', { name: 'Send' }) as HTMLButtonElement;
     expect(send().disabled).toBe(true);
 
-    fillReport({ title: 'Board freezes' });
+    fillReport({ title: 'Unexpected behavior' });
     expect(send().disabled).toBe(true);
 
     fillReport({ area: 'board-sessions' });
     expect(send().disabled).toBe(false);
+  });
+
+  it('guesses the area from drafted words until the reporter changes it', () => {
+    setGithubStatus({ available: true, mode: 'gh-cli' });
+    useAppStore.getState().setBugReportDraft({
+      title: 'Budget warning is stale',
+      description: 'The cost cap changed yesterday.',
+    });
+    render(<ReportIssueStudio onClose={vi.fn()} />);
+
+    expect(screen.getByLabelText<HTMLSelectElement>('Area').value).toBe('budget-spend');
+    expect(screen.getByText("Guessed from your words. Change it if it's off.")).toBeDefined();
+
+    fireEvent.change(screen.getByLabelText('Area'), { target: { value: 'notifications' } });
+    fireEvent.change(screen.getByLabelText('Notes'), { target: { value: 'provider model issue' } });
+
+    expect(screen.getByLabelText<HTMLSelectElement>('Area').value).toBe('notifications');
+    expect(screen.queryByText("Guessed from your words. Change it if it's off.")).toBeNull();
   });
 
   it('shows exactly the version, area label, title and notes in the preview, nothing else', () => {
@@ -106,6 +130,8 @@ describe('ReportIssueStudio', () => {
       title: 'Agent reply is cut off',
       notes: 'The reply stops mid-sentence after a tool call.',
     });
+
+    fireEvent.click(screen.getByRole('button', { name: /Preview/ }));
 
     expect(screen.getByText('Agent reply is cut off')).toBeDefined();
     expect(
@@ -172,6 +198,32 @@ describe('ReportIssueStudio', () => {
     });
   });
 
+  it('keeps an image reminder until its action reveals the staged folder', async () => {
+    setGithubStatus({ available: true, mode: 'gh-cli' });
+    attachOneImage();
+    mocks.run.mockImplementation(async () => ({
+      stdout: 'https://github.com/akhayam99/goodboy/issues/99\n',
+      stderr: '',
+      exitCode: 0,
+    }));
+    render(<ReportIssueStudio onClose={vi.fn()} />);
+
+    fillReport({ area: 'board-sessions', title: 'Board freeze', notes: 'Freezes on archive.' });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Send' }));
+    });
+
+    expect(mocks.showToast).toHaveBeenCalledWith(
+      'success',
+      "Your images aren't on it yet. GitHub only takes them by drag and drop.",
+      expect.objectContaining({
+        title: 'Issue sent',
+        persist: true,
+        action: expect.objectContaining({ label: 'Open issue and images' }),
+      }),
+    );
+  });
+
   it('stages the images on the fallback path too, where the link cannot carry them', async () => {
     setGithubStatus({ available: false, mode: 'absent' });
     attachOneImage();
@@ -223,7 +275,7 @@ describe('ReportIssueStudio', () => {
     expect(mocks.invoke).not.toHaveBeenCalled();
   });
 
-  it('sends directly through gh when connected, and opens the created issue', async () => {
+  it('sends directly through gh and offers the created issue without opening it', async () => {
     setGithubStatus({ available: true, mode: 'gh-cli' });
     mocks.run.mockImplementation(async () => ({
       stdout: 'https://github.com/akhayam99/goodboy/issues/99\n',
@@ -250,7 +302,12 @@ describe('ReportIssueStudio', () => {
       ],
       {},
     );
-    expect(mocks.openUrl).toHaveBeenCalledWith('https://github.com/akhayam99/goodboy/issues/99');
+    expect(mocks.openUrl).not.toHaveBeenCalled();
+    expect(mocks.showToast).toHaveBeenCalledWith(
+      'success',
+      'Filed on GitHub, under your account.',
+      expect.objectContaining({ title: 'Issue sent' }),
+    );
   });
 
   it('empties the draft and leaves the form once the issue is filed', async () => {
@@ -444,7 +501,7 @@ describe('ReportIssueStudio', () => {
     render(<ReportIssueStudio onClose={vi.fn()} />);
 
     expect(
-      screen.getByText('This posts publicly on GitHub, under your own account.'),
+      screen.getByText('v0.1.69 · Posts publicly on GitHub, under your account'),
     ).toBeDefined();
   });
 });

--- a/apps/desktop/src/features/settings/components/ReportIssueStudio/index.tsx
+++ b/apps/desktop/src/features/settings/components/ReportIssueStudio/index.tsx
@@ -3,34 +3,36 @@ import { AlertTriangle } from 'lucide-react';
 import {
   Button,
   cn,
+  Collapsible,
   Divider,
   FieldRow,
   formatError,
   Input,
+  PANE_RHYTHM,
   ScrollFade,
-  SectionHeader,
   SegmentedTabs,
   Select,
   Skeleton,
   Textarea,
 } from '@goodboy/ui';
+import { useToast } from '../../../../app/components/Toast';
 import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../shared/components/conceptIcons';
 import { StudioShell } from '../../../../shared/components/StudioShell';
 import { openUrl } from '../../../../shared/lib/editor';
 import { useAppStore } from '../../../../store';
-import { tauriGhRunner } from '../../../github/github';
 import { useInstalledVersion } from '../../../changelog/hooks/useInstalledVersion';
-import { ISSUE_TYPE_OPTIONS, issueTypeLabel, type IssueTypeValue } from '../../reportIssueTypes';
+import { tauriGhRunner } from '../../../github/github';
 import { useBugReportImages } from '../../hooks/useBugReportImages';
 import { REPORT_ISSUE_REPO } from '../../issueUrl';
+import { ISSUE_TYPE_OPTIONS, issueTypeLabel, type IssueTypeValue } from '../../reportIssueTypes';
 import { BugReportImages } from '../BugReportImages';
 import { AREA_OPTIONS, type AreaValue } from './areas';
+import { guessArea } from './guessArea';
 import { buildFallbackIssue, buildIssueBody, isOpenableUrl } from './issuePayload';
 import { parseIssueCreateResult } from './parseIssueCreateResult';
 import { previewHint } from './previewHint';
-import { stageBugReportImages } from './stageImages';
+import { revealBugReportImages, stageBugReportImages } from './stageImages';
 import { truncationNotice } from './truncationNotice';
-import { PANE_RHYTHM } from '@goodboy/ui';
 
 type Props = {
   readonly onClose: () => void;
@@ -42,6 +44,18 @@ type Params = {
 
 type SendState = 'idle' | 'sending' | 'error';
 
+const TITLE_PLACEHOLDERS = {
+  bug: "What's wrong, in one line",
+  idea: "What you'd change, in one line",
+  question: "What you're stuck on, in one line",
+} satisfies Record<IssueTypeValue, string>;
+
+const NOTES_PLACEHOLDERS = {
+  bug: 'Steps to reproduce, what you expected, what happened instead',
+  idea: "What it does today, what you'd want instead",
+  question: 'What you tried, and where it stopped making sense',
+} satisfies Record<IssueTypeValue, string>;
+
 export const ReportIssueStudio = ({ onClose }: Props) => {
   const version = useInstalledVersion();
   const status = useAppStore((s) => s.githubStatus);
@@ -49,11 +63,11 @@ export const ReportIssueStudio = ({ onClose }: Props) => {
   const draft = useAppStore((s) => s.bugReportDraft);
   const setBugReportDraft = useAppStore((s) => s.setBugReportDraft);
   const clearBugReportDraft = useAppStore((s) => s.clearBugReportDraft);
-
+  const { showToast } = useToast();
   const imageControl = useBugReportImages();
-
-  const [area, setArea] = useState<AreaValue | ''>('');
-  const [title, setTitle] = useState('');
+  const [selectedArea, setSelectedArea] = useState<AreaValue | ''>('');
+  const [isAreaTouched, setIsAreaTouched] = useState(false);
+  const [isPreviewOpen, setIsPreviewOpen] = useState(false);
   const [sendState, setSendState] = useState<SendState>('idle');
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
@@ -65,20 +79,23 @@ export const ReportIssueStudio = ({ onClose }: Props) => {
 
   const mode = status?.mode ?? null;
   const sendsDirectly = mode === 'gh-cli' || mode === 'pat';
-
-  const trimmedTitle = title.trim();
+  const guessedArea = useMemo(
+    () => guessArea({ text: `${draft.title}\n${draft.description}` }),
+    [draft.title, draft.description],
+  );
+  const area = isAreaTouched ? selectedArea : (guessedArea ?? '');
+  const isAreaGuessed = !isAreaTouched && guessedArea != null;
+  const trimmedTitle = draft.title.trim();
   const trimmedNotes = draft.description.trim();
   const areaLabel = useMemo(
     () => AREA_OPTIONS.find((option) => option.value === area)?.label ?? '',
     [area],
   );
   const typeLabel = issueTypeLabel({ issueType: draft.issueType });
-
   const imageNames = useMemo(
     () => imageControl.images.map((image) => image.fileName),
     [imageControl.images],
   );
-
   const directBody = useMemo(
     () =>
       buildIssueBody({
@@ -102,7 +119,6 @@ export const ReportIssueStudio = ({ onClose }: Props) => {
       }),
     [trimmedTitle, typeLabel, version, areaLabel, trimmedNotes, imageNames],
   );
-
   const previewBody = sendsDirectly ? directBody : fallback.body;
   const previewTitle = sendsDirectly ? trimmedTitle : fallback.title;
   const previewTruncation = sendsDirectly
@@ -111,7 +127,6 @@ export const ReportIssueStudio = ({ onClose }: Props) => {
         titleTruncated: fallback.titleTruncated,
         notesTruncated: fallback.notesTruncated,
       });
-
   const canSend =
     version != null &&
     area !== '' &&
@@ -126,8 +141,9 @@ export const ReportIssueStudio = ({ onClose }: Props) => {
     setSendState('sending');
     setErrorMessage(null);
 
+    let stagedImagesDir: string | null;
     try {
-      await stageBugReportImages({ images: imageControl.images });
+      stagedImagesDir = await stageBugReportImages({ images: imageControl.images });
     } catch (err) {
       setSendState('error');
       setErrorMessage(`Could not prepare the images to attach. ${formatError(err)}`);
@@ -136,7 +152,7 @@ export const ReportIssueStudio = ({ onClose }: Props) => {
 
     if (sendsDirectly) {
       try {
-        const res = await tauriGhRunner.run(
+        const result = await tauriGhRunner.run(
           [
             'issue',
             'create',
@@ -149,17 +165,43 @@ export const ReportIssueStudio = ({ onClose }: Props) => {
           ],
           {},
         );
-        const parsed = parseIssueCreateResult(res);
+        const parsed = parseIssueCreateResult(result);
         if (!parsed.ok) {
           setSendState('error');
           setErrorMessage(parsed.message);
           return;
         }
-        if (parsed.url != null) {
-          await openUrl(parsed.url);
-        }
+        const issueUrl = parsed.url;
         clearBugReportDraft();
         requestClose();
+        if (stagedImagesDir == null) {
+          showToast('success', 'Filed on GitHub, under your account.', {
+            title: 'Issue sent',
+            action:
+              issueUrl == null
+                ? undefined
+                : { label: 'View issue', onClick: () => void openUrl(issueUrl) },
+          });
+          return;
+        }
+        const action =
+          issueUrl == null
+            ? {
+                label: 'Open images folder',
+                onClick: () => void revealBugReportImages({ dir: stagedImagesDir }),
+              }
+            : {
+                label: 'Open issue and images',
+                onClick: () => {
+                  void openUrl(issueUrl);
+                  void revealBugReportImages({ dir: stagedImagesDir });
+                },
+              };
+        showToast(
+          'success',
+          "Your images aren't on it yet. GitHub only takes them by drag and drop.",
+          { title: 'Issue sent', persist: true, action },
+        );
       } catch (err) {
         setSendState('error');
         setErrorMessage(formatError(err));
@@ -176,6 +218,9 @@ export const ReportIssueStudio = ({ onClose }: Props) => {
     }
     try {
       await openUrl(fallback.url);
+      if (stagedImagesDir != null) {
+        await revealBugReportImages({ dir: stagedImagesDir });
+      }
       clearBugReportDraft();
       requestClose();
     } catch (err) {
@@ -197,92 +242,96 @@ export const ReportIssueStudio = ({ onClose }: Props) => {
         <div className="flex min-h-0 flex-1 flex-col">
           <ScrollFade className="min-h-0 flex-1" viewportClassName={PANE_RHYTHM.body} fadeSize={24}>
             <div className="mx-auto flex w-full max-w-2xl flex-col gap-6">
-              <section className="flex flex-col">
-                <SectionHeader
-                  icon={<CONCEPT_ICONS.reportIssue size={12} aria-hidden />}
-                  label="Report details"
-                  hint="What you type here is the whole report. Nothing else is read from the app."
+              <div className="flex flex-col gap-4">
+                <SegmentedTabs
+                  size="md"
+                  fill
+                  ariaLabel="Issue type"
+                  options={ISSUE_TYPE_OPTIONS}
+                  value={draft.issueType}
+                  onChange={(issueType: IssueTypeValue) => setBugReportDraft({ issueType })}
                 />
-                <FieldRow label="Version" help="The version running right now.">
-                  {version != null ? (
-                    <span className="text-sm text-foreground">{version}</span>
-                  ) : (
-                    <Skeleton className="h-4 w-14" />
-                  )}
-                </FieldRow>
-                <FieldRow label="Type" help="What kind of report this is.">
-                  <SegmentedTabs
-                    size="sm"
-                    ariaLabel="Issue type"
-                    options={ISSUE_TYPE_OPTIONS}
-                    value={draft.issueType}
-                    onChange={(issueType: IssueTypeValue) => setBugReportDraft({ issueType })}
-                  />
-                </FieldRow>
-                <FieldRow label="Area" help="Which part of the app this is about.">
-                  <Select
-                    size="sm"
-                    value={area}
-                    onChange={(e) => setArea(e.target.value as AreaValue | '')}
-                    required
-                  >
-                    <option value="" disabled hidden>
-                      Choose an area
-                    </option>
-                    {AREA_OPTIONS.map((option) => (
-                      <option key={option.value} value={option.value}>
-                        {option.label}
-                      </option>
-                    ))}
-                  </Select>
-                </FieldRow>
-                <FieldRow label="Title" help="A short summary.">
-                  <Input
-                    value={title}
-                    onChange={(e) => setTitle(e.target.value)}
-                    placeholder="What's wrong, in one line"
-                    className="w-full sm:w-80"
-                  />
-                </FieldRow>
-                <FieldRow
-                  label="Notes"
-                  help="What happened, what you expected, steps to reproduce."
-                  layout="stacked"
-                >
-                  <Textarea
-                    autoGrow
-                    minRows={4}
-                    maxRows={12}
-                    value={draft.description}
-                    onChange={(e) => setBugReportDraft({ description: e.target.value })}
-                    onPaste={imageControl.onPaste}
-                    placeholder="Steps to reproduce, what you expected, what happened instead"
-                  />
-                </FieldRow>
+                <Input
+                  aria-label="Title"
+                  value={draft.title}
+                  onChange={(e) => setBugReportDraft({ title: e.target.value })}
+                  placeholder={TITLE_PLACEHOLDERS[draft.issueType]}
+                  className="w-full"
+                />
+                <Textarea
+                  autoGrow
+                  minRows={4}
+                  maxRows={12}
+                  aria-label="Notes"
+                  value={draft.description}
+                  onChange={(e) => setBugReportDraft({ description: e.target.value })}
+                  onPaste={imageControl.onPaste}
+                  placeholder={NOTES_PLACEHOLDERS[draft.issueType]}
+                />
                 <FieldRow
                   label="Images"
-                  help="Screenshots that show the problem. Their folder opens on send, so you can drag them into the issue."
+                  help="GitHub only takes images by hand. After you send, one click opens the issue and the folder, so you can drag them in."
                   layout="stacked"
                 >
                   <BugReportImages control={imageControl} />
                 </FieldRow>
-              </section>
+                <FieldRow label="Area">
+                  <div className="flex flex-col gap-2">
+                    <Select
+                      aria-label="Area"
+                      size="sm"
+                      value={area}
+                      onChange={(e) => {
+                        const nextArea = AREA_OPTIONS.find(
+                          (option) => option.value === e.target.value,
+                        )?.value;
+                        setSelectedArea(nextArea ?? '');
+                        setIsAreaTouched(true);
+                      }}
+                      required
+                    >
+                      <option value="" disabled hidden>
+                        Choose an area
+                      </option>
+                      {AREA_OPTIONS.map((option) => (
+                        <option key={option.value} value={option.value}>
+                          {option.label}
+                        </option>
+                      ))}
+                    </Select>
+                    {isAreaGuessed ? (
+                      <p className="text-2xs leading-relaxed text-info">
+                        Guessed from your words. Change it if it's off.
+                      </p>
+                    ) : null}
+                  </div>
+                </FieldRow>
+              </div>
 
               <Divider />
 
-              <section className="flex flex-col gap-3">
-                <SectionHeader label="Preview" hint={previewHint({ mode })} />
-                <div className="flex max-w-prose flex-col gap-2 text-sm leading-relaxed text-foreground">
-                  <p className="font-medium">{previewTitle === '' ? 'Untitled' : previewTitle}</p>
-                  <p className="whitespace-pre-wrap text-foreground/85">{previewBody}</p>
+              <Collapsible
+                open={isPreviewOpen || previewTruncation != null}
+                onOpenChange={setIsPreviewOpen}
+                trigger={
+                  <span className="flex flex-col gap-1">
+                    <span>Preview</span>
+                    <span className="text-2xs font-normal leading-relaxed text-muted-foreground">
+                      {previewHint({ mode })}
+                    </span>
+                  </span>
+                }
+              >
+                <div className="flex flex-col gap-3">
+                  <div className="flex max-w-prose flex-col gap-2 text-sm leading-relaxed text-foreground">
+                    <p className="font-medium">{previewTitle === '' ? 'Untitled' : previewTitle}</p>
+                    <p className="whitespace-pre-wrap text-foreground/85">{previewBody}</p>
+                  </div>
+                  {previewTruncation != null ? (
+                    <p className="text-2xs leading-relaxed text-warning">{previewTruncation}</p>
+                  ) : null}
                 </div>
-                {previewTruncation != null && (
-                  <p className="text-2xs leading-relaxed text-warning">{previewTruncation}</p>
-                )}
-                <p className="text-2xs leading-relaxed text-muted-foreground">
-                  This posts publicly on GitHub, under your own account.
-                </p>
-              </section>
+              </Collapsible>
             </div>
           </ScrollFade>
           <Divider />
@@ -293,7 +342,13 @@ export const ReportIssueStudio = ({ onClose }: Props) => {
                   <AlertTriangle size={12} aria-hidden />
                   {errorMessage}
                 </span>
-              ) : null}
+              ) : version != null ? (
+                <span className="text-2xs text-muted-foreground">
+                  v{version} · Posts publicly on GitHub, under your account
+                </span>
+              ) : (
+                <Skeleton className="h-4 w-14" />
+              )}
             </div>
             <Button variant="ghost" onClick={requestClose}>
               Cancel

--- a/apps/desktop/src/features/settings/components/ReportIssueStudio/stageImages.ts
+++ b/apps/desktop/src/features/settings/components/ReportIssueStudio/stageImages.ts
@@ -21,3 +21,11 @@ export const stageBugReportImages = async ({ images }: Params): Promise<string |
     })),
   });
 };
+
+type RevealParams = {
+  readonly dir: string;
+};
+
+export const revealBugReportImages = async ({ dir }: RevealParams): Promise<void> => {
+  await invoke('bug_report_reveal_images', { dir });
+};

--- a/apps/desktop/src/features/settings/reportIssueTypes.ts
+++ b/apps/desktop/src/features/settings/reportIssueTypes.ts
@@ -2,13 +2,27 @@ import { Bug, CircleQuestionMark, Lightbulb } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 
 export const ISSUE_TYPE_OPTIONS = [
-  { value: 'bug', label: 'Bug', icon: Bug },
-  { value: 'idea', label: 'Idea', icon: Lightbulb },
-  { value: 'question', label: 'Question', icon: CircleQuestionMark },
+  { value: 'bug', label: 'Bug', icon: Bug, hint: 'Something broke', tone: 'danger' },
+  {
+    value: 'idea',
+    label: 'Idea',
+    icon: Lightbulb,
+    hint: 'Something could be better',
+    tone: 'success',
+  },
+  {
+    value: 'question',
+    label: 'Question',
+    icon: CircleQuestionMark,
+    hint: 'Something is unclear',
+    tone: 'warning',
+  },
 ] as const satisfies ReadonlyArray<{
   readonly value: string;
   readonly label: string;
   readonly icon: LucideIcon;
+  readonly hint: string;
+  readonly tone: 'danger' | 'success' | 'warning';
 }>;
 
 export type IssueTypeValue = (typeof ISSUE_TYPE_OPTIONS)[number]['value'];

--- a/apps/desktop/src/features/settings/sendNotificationToDevelopers.ts
+++ b/apps/desktop/src/features/settings/sendNotificationToDevelopers.ts
@@ -1,0 +1,21 @@
+import type { Notification } from '@goodboy/db';
+import { useAppStore } from '../../store';
+import { REPORT_ISSUE_STUDIO_EVENT } from './reportIssueStudioEvent';
+
+type Params = {
+  readonly notification: Notification;
+};
+
+export const sendNotificationToDevelopers = ({ notification }: Params): void => {
+  const report = [notification.title, notification.body]
+    .filter((part) => part != null && part !== '')
+    .join('\n\n');
+  const draft = useAppStore.getState().bugReportDraft;
+  const description = draft.description === '' ? report : `${draft.description}\n\n${report}`;
+  useAppStore.getState().setBugReportDraft({
+    issueType: 'bug',
+    title: draft.title === '' ? notification.title : draft.title,
+    description,
+  });
+  window.dispatchEvent(new CustomEvent(REPORT_ISSUE_STUDIO_EVENT));
+};

--- a/apps/desktop/src/store/slices/bugReportDraft/index.test.ts
+++ b/apps/desktop/src/store/slices/bugReportDraft/index.test.ts
@@ -32,6 +32,7 @@ describe('bug report draft slice', () => {
   it('starts on the bug type with nothing written', () => {
     expect(harnessed.getState().bugReportDraft).toEqual({
       issueType: 'bug',
+      title: '',
       description: '',
       images: [],
     });
@@ -43,6 +44,7 @@ describe('bug report draft slice', () => {
 
     expect(harnessed.getState().bugReportDraft).toEqual({
       issueType: 'idea',
+      title: '',
       description: 'The board keeps the old goal',
       images: [],
     });

--- a/apps/desktop/src/store/slices/bugReportDraft/setBugReportDraft.ts
+++ b/apps/desktop/src/store/slices/bugReportDraft/setBugReportDraft.ts
@@ -3,16 +3,18 @@ import type { GetFn, SetFn } from './types';
 
 export type Params = {
   readonly issueType?: IssueTypeValue;
+  readonly title?: string;
   readonly description?: string;
 };
 
 export const setBugReportDraft = (set: SetFn, get: GetFn) => {
-  return ({ issueType, description }: Params): void => {
+  return ({ issueType, title, description }: Params): void => {
     const current = get().bugReportDraft;
     set({
       bugReportDraft: {
         ...current,
         issueType: issueType ?? current.issueType,
+        title: title ?? current.title,
         description: description ?? current.description,
       },
     });

--- a/apps/desktop/src/store/slices/bugReportDraft/state.ts
+++ b/apps/desktop/src/store/slices/bugReportDraft/state.ts
@@ -13,12 +13,14 @@ export type BugReportImage = {
 
 export type BugReportDraft = {
   readonly issueType: IssueTypeValue;
+  readonly title: string;
   readonly description: string;
   readonly images: ReadonlyArray<BugReportImage>;
 };
 
 export const emptyBugReportDraft: BugReportDraft = {
   issueType: DEFAULT_ISSUE_TYPE,
+  title: '',
   description: '',
   images: [],
 };

--- a/packages/ui/src/components/SegmentedTabs.tsx
+++ b/packages/ui/src/components/SegmentedTabs.tsx
@@ -2,6 +2,7 @@ import { useRef } from 'react';
 import type { CSSProperties, KeyboardEvent, ReactNode } from 'react';
 import type { LucideIcon } from 'lucide-react';
 import { cn } from '../cn';
+import { tintClasses, type Tone } from '../tint';
 
 export type SegmentedTabOption<T extends string = string> = {
   readonly value: T;
@@ -11,6 +12,7 @@ export type SegmentedTabOption<T extends string = string> = {
   readonly badge?: ReactNode;
   readonly disabled?: boolean;
   readonly accent?: string;
+  readonly tone?: Tone;
 };
 
 export type Props<T extends string = string> = {
@@ -93,6 +95,7 @@ export const SegmentedTabs = <T extends string>({
       {options.map((option, index) => {
         const isActive = option.value === value;
         const Icon = option.icon;
+        const tone = option.tone != null ? tintClasses(option.tone) : null;
         const activeStyle: CSSProperties | undefined =
           isActive && option.accent != null
             ? { color: option.accent, borderColor: option.accent }
@@ -105,7 +108,7 @@ export const SegmentedTabs = <T extends string>({
             aria-selected={isActive}
             tabIndex={isActive ? 0 : -1}
             disabled={option.disabled}
-            title={option.hint}
+            title={isMedium ? option.hint : undefined}
             onClick={() => onChange(option.value)}
             onKeyDown={(event) => onKeyDown({ event, index })}
             style={activeStyle}
@@ -113,7 +116,10 @@ export const SegmentedTabs = <T extends string>({
               'relative flex items-center justify-center gap-1.5 rounded-md border border-transparent font-medium motion-safe:transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]',
               isMedium ? 'px-3 py-2 text-sm font-semibold' : 'px-2.5 py-1 text-xs',
               isActive
-                ? 'bg-elevated font-semibold text-foreground ring-1 ring-inset ring-border'
+                ? cn(
+                    'bg-elevated font-semibold text-foreground ring-1 ring-inset',
+                    option.accent != null || tone == null ? 'ring-border' : tone.ring,
+                  )
                 : 'text-muted-foreground hover:bg-foreground/5 hover:text-foreground',
               option.disabled === true &&
                 'cursor-not-allowed opacity-50 hover:bg-transparent hover:text-muted-foreground',
@@ -121,20 +127,31 @@ export const SegmentedTabs = <T extends string>({
           >
             {Icon != null ? (
               isMedium ? (
-                <Icon size={15} aria-hidden className="shrink-0" />
+                <Icon
+                  size={15}
+                  aria-hidden
+                  className={cn(
+                    'shrink-0',
+                    isActive && option.accent == null && tone != null && tone.icon,
+                  )}
+                />
               ) : (
-                <Icon size={13} aria-hidden className="shrink-0" />
+                <Icon
+                  size={13}
+                  aria-hidden
+                  className={cn(
+                    'shrink-0',
+                    isActive && option.accent == null && tone != null && tone.icon,
+                  )}
+                />
               )
             ) : null}
-            <span className={cn('min-w-0', option.hint != null && 'flex flex-col gap-0.5')}>
+            <span
+              className={cn('min-w-0', isMedium && option.hint != null && 'flex flex-col gap-0.5')}
+            >
               <span className="block truncate">{option.label}</span>
-              {option.hint != null ? (
-                <span
-                  className={cn(
-                    'block truncate font-normal text-muted-foreground',
-                    isMedium ? 'text-2xs' : 'text-3xs',
-                  )}
-                >
+              {isMedium && option.hint != null ? (
+                <span className="block truncate text-2xs font-normal text-muted-foreground">
                   {option.hint}
                 </span>
               ) : null}


### PR DESCRIPTION
## Why

The owner, on the shipped form: it is boilerplate text, it is flat, the title is not at the top, the selector is plain, and opening an issue throws you straight into a browser. Plus #1301, #1425 and #1426.

## The image question, answered first

**#1425**: a user attached an image and it did not appear on the GitHub issue.

Ground truth, established before any code was written. `bug_report_stage_images` writes the files to a temp directory and opens Finder; the issue body only ever carried the filenames. `gh issue create` has no attachment flag. The endpoint the web UI uses, `github.com/upload/policies/assets`, needs a browser session cookie and returns 422 with a token. Confirmed against `cli/cli#12960` and the GitHub community threads. The same reporter's #1424 has its image because they dragged it in by hand; #1425 does not because they did not.

So there is no upload to build, and none was faked. What changed is that the app stops implying otherwise: the success toast persists when images are attached, its action opens the issue and the image folder together, and the folder now reveals on that click instead of at send time, when the user had nothing to drag into yet.

## What changed in the form

- Order is Type, Title, Notes, Images, Area, with the preview collapsed. The title is first because it is the first thing anyone writes.
- Most help lines are gone, replaced by per-type placeholders. The `Version` row left the body and became a meta line in the footer next to the notice that this posts publicly under the user's own account.
- The type selector uses the existing `SegmentedTabs`, extended in `packages/ui` with an optional tone per option so the active tab tints. Bug reads danger, idea success, question warning, following the tone canon. Only the active tab is tinted, so the form gains a point of colour rather than a rainbow.
- The title now lives in the draft. It was local component state before, which quietly broke the draft promise: the popover said your work was kept and then dropped the title.

## The area guess

`guessArea.ts` is a pure function over the words already typed, with English and Italian keywords, because the real reports come in Italian. It counts distinct keyword matches, breaks ties on the earliest match in the text, and never guesses `something-else`. It keeps re-deriving until the user touches the field, and it says `Guessed from your words. Change it if it's off.` It is a suggestion the user can see and override, never a silent decision.

## Sending

No more browser tab on send. A success toast says the issue was filed, with a `View issue` action that opens it only when clicked.

## #1426, send to developers

A WARNING or ERROR notification can hand itself to the report form. The button is derived from severity rather than a new notification action kind. It prefills only the title and body the card already showed the user, merges into the existing draft, and opens the studio. Nothing is sent without the user reading it and pressing send, and nothing is collected that they had not already seen.

## Verification

- `pnpm --filter @goodboy/desktop typecheck`, `pnpm --filter @goodboy/ui typecheck`
- full desktop suite, 669 files, 5779 tests
- full ui suite, 36 files, 189 tests
- `cargo test attachment::tests`, 10 tests

Closes #1301
Closes #1425
Closes #1426

🤖 Generated with [Claude Code](https://claude.com/claude-code)