### PR TITLE
fix(desktop): a step panel stops losing the newest turn

### DIFF
--- a/apps/desktop/src/features/workflows/workflows.test.ts
+++ b/apps/desktop/src/features/workflows/workflows.test.ts
@@ -7,47 +7,73 @@ vi.mock('@tauri-apps/api/core', () => ({
   invoke: vi.fn(),
 }));
 
+type RawAgentParams = {
+  readonly id: string;
+  readonly status?: string;
+};
+
+const rawAgent = ({ id, status = 'pending' }: RawAgentParams) => ({
+  id,
+  sessionId: 'session-1',
+  stepId: null,
+  workflowRunId: null,
+  parentAgentId: null,
+  ordinal: 0,
+  name: 'agent',
+  status,
+  providerRunId: null,
+  outputSummary: null,
+  startedAt: null,
+  completedAt: null,
+  providerSessionId: 'codex-session',
+  providerSessionProviderId: 'codex',
+  lastFinishedAt: null,
+  lastViewedAt: null,
+  doneAt: null,
+  kind: null,
+  verbosity: null,
+  effort: null,
+  modelOverride: null,
+  providerOverride: null,
+  sourceThreadId: null,
+  sourceThreadIds: null,
+  sourceCommentUrl: null,
+  sourceKind: null,
+  domainsJson: null,
+});
+
 describe('workflow agent rows', () => {
   beforeEach(() => {
     vi.mocked(invoke).mockReset();
   });
 
   it('maps the provider session owner returned by the Rust agent select', async () => {
-    vi.mocked(invoke).mockResolvedValue([
-      {
-        id: 'agent-1',
-        sessionId: 'session-1',
-        stepId: null,
-        workflowRunId: null,
-        parentAgentId: null,
-        ordinal: 0,
-        name: 'agent',
-        status: 'pending',
-        providerRunId: null,
-        outputSummary: null,
-        startedAt: null,
-        completedAt: null,
-        providerSessionId: 'codex-session',
-        providerSessionProviderId: 'codex',
-        lastFinishedAt: null,
-        lastViewedAt: null,
-        doneAt: null,
-        kind: null,
-        verbosity: null,
-        effort: null,
-        modelOverride: null,
-        providerOverride: null,
-        sourceThreadId: null,
-        sourceThreadIds: null,
-        sourceCommentUrl: null,
-        sourceKind: null,
-        domainsJson: null,
-      },
-    ]);
+    vi.mocked(invoke).mockResolvedValue([rawAgent({ id: 'agent-1' })]);
 
     const agents = await invokeAgentList('session-1' as SessionId);
 
     expect(agents[0]?.providerSessionId).toBe('codex-session');
     expect(agents[0]?.providerSessionProviderId).toBe('codex');
+  });
+
+  it('sequences refreshes for one session so an older snapshot settles first', async () => {
+    let resolveFirst: (rows: ReadonlyArray<ReturnType<typeof rawAgent>>) => void = () => undefined;
+    vi.mocked(invoke)
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFirst = resolve;
+          }),
+      )
+      .mockResolvedValueOnce([rawAgent({ id: 'agent-1', status: 'completed' })]);
+
+    const first = invokeAgentList('session-1' as SessionId);
+    const second = invokeAgentList('session-1' as SessionId);
+    await vi.waitFor(() => expect(invoke).toHaveBeenCalledTimes(1));
+    resolveFirst([rawAgent({ id: 'agent-1', status: 'running' })]);
+
+    await expect(first).resolves.toMatchObject([{ status: 'running' }]);
+    await expect(second).resolves.toMatchObject([{ status: 'completed' }]);
+    expect(invoke).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/desktop/src/features/workflows/workflows.ts
+++ b/apps/desktop/src/features/workflows/workflows.ts
@@ -333,9 +333,26 @@ export const invokeStepDefDelete = async (id: StepDefId): Promise<void> => {
   return invoke<void>('step_def_delete', { id });
 };
 
+const agentListRequestTails = new Map<SessionId, Promise<void>>();
+
 export const invokeAgentList = async (sessionId: SessionId): Promise<Agent[]> => {
-  const rows = await invoke<RawAgentRow[]>('agent_list_for_session', { sessionId });
-  return rows.map(rowToAgent);
+  const previous = agentListRequestTails.get(sessionId) ?? Promise.resolve();
+  const request = previous.then(async () => {
+    const rows = await invoke<RawAgentRow[]>('agent_list_for_session', { sessionId });
+    return rows.map(rowToAgent);
+  });
+  const tail = request.then(
+    () => undefined,
+    () => undefined,
+  );
+  agentListRequestTails.set(sessionId, tail);
+  try {
+    return await request;
+  } finally {
+    if (agentListRequestTails.get(sessionId) === tail) {
+      agentListRequestTails.delete(sessionId);
+    }
+  }
 };
 
 export type AgentInsertArgs = {

--- a/apps/desktop/src/store/store.summarizer-queue.test.ts
+++ b/apps/desktop/src/store/store.summarizer-queue.test.ts
@@ -7,6 +7,7 @@ import type {
   SessionId,
   TelemetryRecord,
   TelemetryRecordId,
+  ProviderRunId,
   WorkspaceId,
 } from '@goodboy/types';
 
@@ -366,7 +367,7 @@ describe('summarizer queue, coalescing and no-stack', () => {
   it('keeps telemetry recorded while the summarizer refresh is in flight', async () => {
     const staleRecord = {
       id: 'telemetry-old' as TelemetryRecordId,
-      runId: 'run-old',
+      runId: 'run-old' as ProviderRunId,
       sessionId: SESSION_ID,
       kind: 'turn',
       provider: 'anthropic',
@@ -381,7 +382,7 @@ describe('summarizer queue, coalescing and no-stack', () => {
     const currentRecord = {
       ...staleRecord,
       id: 'telemetry-current' as TelemetryRecordId,
-      runId: 'run-current',
+      runId: 'run-current' as ProviderRunId,
       inputTokens: 200,
     } satisfies TelemetryRecord;
     listTelemetryForSessionSpy.mockImplementationOnce(

--- a/apps/desktop/src/store/store.summarizer-queue.test.ts
+++ b/apps/desktop/src/store/store.summarizer-queue.test.ts
@@ -1,6 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { SlotKey } from '@goodboy/core';
-import type { ContextSlot, IsoDateTime, Session, SessionId, WorkspaceId } from '@goodboy/types';
+import type {
+  ContextSlot,
+  IsoDateTime,
+  Session,
+  SessionId,
+  TelemetryRecord,
+  TelemetryRecordId,
+  WorkspaceId,
+} from '@goodboy/types';
 
 vi.mock('../features/chat/turn', () => ({
   runTurn: vi.fn(),
@@ -119,6 +127,8 @@ vi.mock('@goodboy/core', async (importOriginal) => {
 });
 
 let dbSlots: ReadonlyArray<ContextSlot> = [];
+let resolveTelemetryList: ((records: ReadonlyArray<TelemetryRecord>) => void) | null = null;
+const listTelemetryForSessionSpy = vi.fn(async () => [] as ReadonlyArray<TelemetryRecord>);
 const upsertContextSlotSpy = vi.fn(
   async (_database: unknown, _sessionId: SessionId, slot: ContextSlot, _author: string) => {
     dbSlots = [...dbSlots.filter((existing) => existing.key !== slot.key), slot];
@@ -138,7 +148,7 @@ vi.mock('@goodboy/db', () => ({
   listContextSlotsForSession: vi.fn(async () => dbSlots),
   listMessagesForSession: vi.fn(async () => []),
   listSessionsForWorkspace: vi.fn(async () => []),
-  listTelemetryForSession: vi.fn(async () => []),
+  listTelemetryForSession: listTelemetryForSessionSpy,
   listWorkspaces: vi.fn(async () => []),
   listWorktreesForTask: vi.fn(async () => []),
   deleteWorktreesForSession: vi.fn(),
@@ -213,6 +223,9 @@ describe('summarizer queue, coalescing and no-stack', () => {
     summarizerUpsertSequence = [];
     summarizerConstructorCalls = [];
     dbSlots = [];
+    resolveTelemetryList = null;
+    listTelemetryForSessionSpy.mockReset();
+    listTelemetryForSessionSpy.mockResolvedValue([]);
     upsertContextSlotSpy.mockClear();
     summarizeSpy.mockResolvedValue(undefined);
   });
@@ -348,6 +361,65 @@ describe('summarizer queue, coalescing and no-stack', () => {
     expect(queue.inFlight).toBe(false);
 
     sq.delete(SESSION_ID);
+  });
+
+  it('keeps telemetry recorded while the summarizer refresh is in flight', async () => {
+    const staleRecord = {
+      id: 'telemetry-old' as TelemetryRecordId,
+      runId: 'run-old',
+      sessionId: SESSION_ID,
+      kind: 'turn',
+      provider: 'anthropic',
+      model: 'claude-sonnet-4-5',
+      inputTokens: 100,
+      outputTokens: 10,
+      cachedInputTokens: 0,
+      cacheCreationInputTokens: 0,
+      estimatedCostUsd: 0.01,
+      recordedAt: NOW,
+    } satisfies TelemetryRecord;
+    const currentRecord = {
+      ...staleRecord,
+      id: 'telemetry-current' as TelemetryRecordId,
+      runId: 'run-current',
+      inputTokens: 200,
+    } satisfies TelemetryRecord;
+    listTelemetryForSessionSpy.mockImplementationOnce(
+      () =>
+        new Promise<ReadonlyArray<TelemetryRecord>>((resolve) => {
+          resolveTelemetryList = resolve;
+        }),
+    );
+
+    const { useAppStore } = await import('./store');
+    const { enqueueSummarizer, summarizerQueues: queues } = await import('./turn-helpers');
+    queues.clear();
+    useAppStore.setState({
+      sessions: [buildSession()],
+      sessionSlots: { [SESSION_ID]: [] },
+      sessionTelemetry: { [SESSION_ID]: [staleRecord] },
+      summarizerStatus: {},
+      workspaces: [
+        { id: WORKSPACE_ID, name: 'ws', rootPath: '/tmp', createdAt: NOW, updatedAt: NOW },
+      ],
+    });
+
+    enqueueSummarizer(
+      useAppStore.setState,
+      useAppStore.getState,
+      SESSION_ID,
+      'turn input',
+      'turn output',
+    );
+    await vi.waitFor(() => expect(listTelemetryForSessionSpy).toHaveBeenCalledTimes(1));
+    useAppStore.setState({ sessionTelemetry: { [SESSION_ID]: [staleRecord, currentRecord] } });
+    resolveTelemetryList?.([staleRecord]);
+
+    await vi.waitFor(() => expect(queues.get(SESSION_ID)?.inFlight).toBe(false));
+    expect(useAppStore.getState().sessionTelemetry[SESSION_ID]).toEqual([
+      staleRecord,
+      currentRecord,
+    ]);
   });
 
   it('in-flight + multiple queued coalesces to one pending entry', async () => {

--- a/apps/desktop/src/store/turn-helpers.ts
+++ b/apps/desktop/src/store/turn-helpers.ts
@@ -121,6 +121,25 @@ type Params = {
   readonly entry: SummarizerQueueEntry;
 };
 
+type MergeTelemetryParams = {
+  readonly refreshed: ReadonlyArray<TelemetryRecord>;
+  readonly current: ReadonlyArray<TelemetryRecord>;
+};
+
+const mergeTelemetry = ({
+  refreshed,
+  current,
+}: MergeTelemetryParams): ReadonlyArray<TelemetryRecord> => {
+  const recordsById = new Map(refreshed.map((record) => [record.id, record]));
+  for (const record of current) {
+    if (recordsById.has(record.id)) {
+      continue;
+    }
+    recordsById.set(record.id, record);
+  }
+  return [...recordsById.values()];
+};
+
 function scheduleIdle(fn: () => void): void {
   if (typeof requestIdleCallback === 'function') {
     requestIdleCallback(() => fn());
@@ -373,7 +392,13 @@ const runSummarizer = async ({ set, get, sessionId, entry }: Params): Promise<vo
       },
       sessionSummary,
       workspaceSummary,
-      sessionTelemetry: { ...state.sessionTelemetry, [sessionId]: telemetry },
+      sessionTelemetry: {
+        ...state.sessionTelemetry,
+        [sessionId]: mergeTelemetry({
+          refreshed: telemetry,
+          current: state.sessionTelemetry[sessionId] ?? [],
+        }),
+      },
       summarizerStatus: {
         ...state.summarizerStatus,
         [sessionId]: {

--- a/docs/traps.md
+++ b/docs/traps.md
@@ -11,6 +11,12 @@ below has been "fixed" at least once and had to be put back.
 
 ## Deliberate dead ends
 
+- Claude and Cursor report a turn's cumulative billing usage on the final
+  `result`, but the live context size comes from the last `assistant` message.
+  A tool-heavy turn emits several assistant messages, so using the first one or
+  the final billing totals makes the context bar increasingly wrong as the turn
+  continues. `parseAnthropicEnvelopeLine` deliberately retains the last
+  assistant usage and attaches that value to the result event.
 - `fetchIssueCandidates` returns `[]` for Bitbucket, and `issueSources.ts`
   has no Bitbucket entry. Goodboy deliberately does not expose Bitbucket
   issues, because Atlassian points issues at Jira. Adding the source entry


### PR DESCRIPTION
## Why

The owner: after many back and forth turns, the right-hand panel of a step seemed not to update with the latest information, and the question was whether anything retriggers an agent's context when a turn completes.

## What it actually was

Not a subscription bug. The selectors return store-owned references and resubscribe correctly, and the memoized rows are keyed on stable references. Two read-modify-write races were the cause.

**Telemetry.** The background summarizer read a telemetry snapshot, and by the time it wrote the refreshed list back, a turn recorded during that query was gone. The record was still in SQLite, which is exactly why clicking away and back repaired the panel. It gets worse with rapid turns because more completions overlap an in-flight summarizer, not because of any count limit or bounded list.

**Agent reads.** The same shape: two concurrent `invokeAgentList` refreshes could settle out of order and leave an older snapshot on top, taking status, timestamps, output summaries, routing and spawned-child state with it.

Telemetry now merges by id instead of replacing, and agent reads are sequenced per session so a newer snapshot cannot be overwritten by an older one.

## Field audit

Every field on the pane was traced to its source and its refresh path. The ones fed by telemetry and by agent snapshots were vulnerable and are fixed. The static ones, step instructions, expected output, title, ordinal and previous step, come from the attached workflow definition and cannot go stale from a turn.

## Also

`docs/traps.md` gained the Claude and Cursor entry about context being derived from the last assistant message. The implementation and its test existed, the trap was undocumented, and it is exactly the kind of thing that makes a display lag look like a routing bug.

## Verification

- `pnpm --filter @goodboy/desktop typecheck`
- full desktop suite, 668 files, 5776 tests, including a regression proving two concurrent refreshes settle in order and one proving a newer turn survives a stale summarizer refresh

No polling, no forced remount, no component effect added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)