### PR TITLE
fix(desktop): a degraded handoff explains itself, a stuck step recovers

### DIFF
--- a/apps/desktop/src/features/chat/components/PhaseTransitionCard/index.test.tsx
+++ b/apps/desktop/src/features/chat/components/PhaseTransitionCard/index.test.tsx
@@ -1,8 +1,17 @@
 // @vitest-environment happy-dom
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { AgentId, SessionId } from '@goodboy/types';
 import type { TranscriptItem } from '../../utils/transcript-items';
+
+const retryStepSummary = vi.hoisted(() => vi.fn(async () => undefined));
+
+vi.mock('../../../../store', () => ({
+  useAppStore: <T,>(selector: (state: { retryStepSummary: typeof retryStepSummary }) => T) =>
+    selector({ retryStepSummary }),
+}));
+
 import { PhaseTransitionCard } from './index';
 
 afterEach(cleanup);
@@ -64,6 +73,25 @@ describe('PhaseTransitionCard', () => {
     } satisfies Extract<TranscriptItem, { kind: 'step_transition' }>;
     rerender(<PhaseTransitionCard item={degradedItem} />);
     expect(screen.getByText('degraded handoff')).toBeDefined();
+    fireEvent.click(screen.getByRole('button'));
+    expect(screen.getByText(/received a deterministic copy/i)).toBeDefined();
+  });
+
+  it('retries a degraded summary from the transition card', () => {
+    const degradedItem = {
+      ...item,
+      degraded: true,
+      sessionId: 'session-1' as SessionId,
+      fromAgentId: 'agent-1' as AgentId,
+    } satisfies Extract<TranscriptItem, { kind: 'step_transition' }>;
+    render(<PhaseTransitionCard item={degradedItem} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry summary' }));
+
+    expect(retryStepSummary).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      agentId: 'agent-1',
+    });
   });
 
   it('renders the step duration when present', () => {

--- a/apps/desktop/src/features/chat/components/PhaseTransitionCard/index.tsx
+++ b/apps/desktop/src/features/chat/components/PhaseTransitionCard/index.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { ArrowRight, Milestone } from 'lucide-react';
-import { Markdown, tintClasses } from '@goodboy/ui';
+import { Button, Markdown, tintClasses } from '@goodboy/ui';
+import { useAppStore } from '../../../../store';
 import type { TranscriptItem } from '../../utils/transcript-items';
 import { formatCardTime } from '../../utils/format-card-time';
 import { formatDuration } from '../../utils/format-duration';
@@ -15,10 +16,26 @@ type Props = {
 };
 
 export const PhaseTransitionCard = ({ item }: Props) => {
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useState(item.degraded === true);
+  const [isRetrying, setIsRetrying] = useState(false);
+  const retryStepSummary = useAppStore((state) => state.retryStepSummary);
   const timestamp = formatCardTime(item.at);
   const context = stripWorkflowHandoffHeading({ context: item.carryForwardContext });
   const hasContext = context.trim().length > 0;
+  const canRetry = item.sessionId != null && item.fromAgentId != null;
+  const retry = async () => {
+    const sessionId = item.sessionId;
+    const agentId = item.fromAgentId;
+    if (sessionId == null || agentId == null || isRetrying) {
+      return;
+    }
+    setIsRetrying(true);
+    try {
+      await retryStepSummary({ sessionId, agentId });
+    } finally {
+      setIsRetrying(false);
+    }
+  };
 
   return (
     <TranscriptDisclosure
@@ -64,6 +81,25 @@ export const PhaseTransitionCard = ({ item }: Props) => {
         />
       }
     >
+      {item.degraded === true ? (
+        <div className={`flex flex-col gap-2 rounded-md p-3 text-xs ${warningTint.bg}`}>
+          <span className={warningTint.text}>
+            The summary failed, so this step received a deterministic copy of the previous output.
+            Long output omits its middle. A retry repairs the summary for later steps, but cannot
+            replace context already sent to this step.
+          </span>
+          <Button
+            variant="warning"
+            emphasis="outline"
+            size="sm"
+            disabled={!canRetry || isRetrying}
+            onClick={() => void retry()}
+            className="self-start"
+          >
+            {isRetrying ? 'Retrying summary' : 'Retry summary'}
+          </Button>
+        </div>
+      ) : null}
       <span className="text-2xs font-medium uppercase tracking-wide text-muted-foreground">
         carried forward
       </span>

--- a/apps/desktop/src/features/chat/utils/transcript-items.ts
+++ b/apps/desktop/src/features/chat/utils/transcript-items.ts
@@ -1,11 +1,13 @@
 import type {
   IsoDateTime,
+  AgentId,
   MessageAttachment,
   PermissionRuleId,
   PermissionScope,
   ProviderId,
   ProviderRunId,
   ProviderUsage,
+  SessionId,
   TurnEvent,
 } from '@goodboy/types';
 import { isOpenQuestionAnswerText } from '@goodboy/core';
@@ -51,6 +53,8 @@ export type TranscriptItem =
       fromStep: { ordinal: number; name: string };
       toStep: { ordinal: number; name: string };
       carryForwardContext: string;
+      sessionId?: SessionId;
+      fromAgentId?: AgentId;
       degraded?: true;
       durationMs?: number;
       at: string;
@@ -275,6 +279,8 @@ export const reduceTranscript = (
           fromStep: event.fromStep,
           toStep: event.toStep,
           carryForwardContext: event.carryForwardContext,
+          sessionId: event.sessionId,
+          fromAgentId: event.fromAgentId,
           degraded: event.degraded,
           durationMs: event.durationMs,
           at: event.at,

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/ChatWorkflowAdvance.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/ChatWorkflowAdvance.test.tsx
@@ -26,6 +26,7 @@ type Store = {
   agentEffortOverride: Record<string, string>;
   activateWorkflowAgent: ReturnType<typeof vi.fn>;
   skipStuckStepAndAdvance: ReturnType<typeof vi.fn>;
+  recoverStuckStep: ReturnType<typeof vi.fn>;
   emitNotification: ReturnType<typeof vi.fn>;
 };
 
@@ -39,6 +40,7 @@ const { store, gate } = vi.hoisted(() => ({
     agentEffortOverride: {},
     activateWorkflowAgent: vi.fn(async () => undefined),
     skipStuckStepAndAdvance: vi.fn(async () => undefined),
+    recoverStuckStep: vi.fn(async () => undefined),
     emitNotification: vi.fn(async () => undefined),
   } as Store,
   gate: { hasOpenQuestions: false },
@@ -116,6 +118,8 @@ beforeEach(() => {
   store.activateWorkflowAgent.mockReset();
   store.activateWorkflowAgent.mockResolvedValue(undefined);
   store.skipStuckStepAndAdvance.mockReset();
+  store.recoverStuckStep.mockReset();
+  store.recoverStuckStep.mockResolvedValue(undefined);
   store.emitNotification.mockReset();
   store.emitNotification.mockResolvedValue(undefined);
   gate.hasOpenQuestions = false;
@@ -178,6 +182,19 @@ describe('ChatWorkflowAdvance', () => {
     expect(store.skipStuckStepAndAdvance).toHaveBeenCalledWith(SESSION_ID, RUN_ID, {
       onlyWhenBlocked: true,
     });
+  });
+
+  it('asks the failed agent to check completion without skipping its output', () => {
+    store.sessionPhaseRuns = { [SESSION_ID]: [agent(0, 'failed'), agent(1, 'pending')] };
+    renderStrip();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Check completion' }));
+
+    expect(store.recoverStuckStep).toHaveBeenCalledWith({
+      sessionId: SESSION_ID,
+      workflowRunId: RUN_ID,
+    });
+    expect(store.skipStuckStepAndAdvance).not.toHaveBeenCalled();
   });
 
   it('renders nothing at all while autorun drives the run, controls live on the run card', () => {

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/ChatWorkflowAdvance.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/ChatWorkflowAdvance.tsx
@@ -34,6 +34,7 @@ export const ChatWorkflowAdvance = ({ sessionId, run, workflow }: Props) => {
   const roleModels = useSessionRoleModels({ sessionId });
   const activateWorkflowAgent = useAppStore((state) => state.activateWorkflowAgent);
   const skipStuckStepAndAdvance = useAppStore((state) => state.skipStuckStepAndAdvance);
+  const recoverStuckStep = useAppStore((state) => state.recoverStuckStep);
   const emitNotification = useAppStore((state) => state.emitNotification);
 
   const stepAgents = useMemo(
@@ -114,6 +115,7 @@ export const ChatWorkflowAdvance = ({ sessionId, run, workflow }: Props) => {
       onForceAdvance={() =>
         void skipStuckStepAndAdvance(sessionId, workflowRunId, { onlyWhenBlocked: true })
       }
+      onRecover={() => recoverStuckStep({ sessionId, workflowRunId })}
       className="ml-auto shrink-0"
     />
   );

--- a/apps/desktop/src/features/workflows/components/WorkflowNextStepCta/index.test.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowNextStepCta/index.test.tsx
@@ -157,7 +157,36 @@ describe('WorkflowNextStepCta', () => {
       />,
     );
     expect(screen.getByTestId('workflow-force-next-step-cta')).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Check completion' })).toBeDefined();
     expect(screen.queryByTestId('workflow-next-step-cta')).toBeNull();
+  });
+
+  it('shows progress while the agent checks the blocked step', async () => {
+    const blockedRuns: Agent[] = [
+      run('s1' as StepId, 'failed', 0),
+      run('s2' as StepId, 'pending', 1),
+    ];
+    let finish: (() => void) | undefined;
+    const onRecover = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finish = resolve;
+        }),
+    );
+    render(
+      <WorkflowNextStepCta
+        workflow={wf()}
+        runs={blockedRuns}
+        onAdvance={vi.fn()}
+        onRecover={onRecover}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Check completion' }));
+
+    expect(screen.getByRole('button', { name: 'Checking step' })).toBeDefined();
+    expect(screen.getByTestId('workflow-force-next-step-cta').hasAttribute('disabled')).toBe(true);
+    finish?.();
   });
 
   it('shows confirmation before executing force advance', async () => {

--- a/apps/desktop/src/features/workflows/components/WorkflowNextStepCta/index.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowNextStepCta/index.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { AlertTriangle, Play } from 'lucide-react';
+import { AlertTriangle, Play, RotateCcw } from 'lucide-react';
 import { Button, InlineConfirm, cn } from '@goodboy/ui';
 import { classifyWorkflowChain, getModelDescriptor } from '@goodboy/core';
 import type {
@@ -31,6 +31,7 @@ export type Props = {
   readonly runs: ReadonlyArray<Agent>;
   readonly onAdvance: (params: AdvanceParams) => void | Promise<void>;
   readonly onForceAdvance?: () => void | Promise<void>;
+  readonly onRecover?: () => void | Promise<void>;
   readonly blockReason?: WorkflowBlockReason | null;
   readonly consumesActivePlan?: boolean;
   readonly className?: string;
@@ -45,6 +46,7 @@ export const WorkflowNextStepCta = ({
   runs,
   onAdvance,
   onForceAdvance,
+  onRecover,
   blockReason = null,
   consumesActivePlan = false,
   className,
@@ -55,6 +57,7 @@ export const WorkflowNextStepCta = ({
 }: Props) => {
   const [busy, setBusy] = useState(false);
   const [pendingForce, setPendingForce] = useState(false);
+  const [isRecovering, setIsRecovering] = useState(false);
   const chain = useMemo(() => classifyWorkflowChain(workflow, runs), [workflow, runs]);
   const next = chain.kind === 'step' ? chain.step : null;
   const kind = useMemo(() => (next ? inferAgentKindFromName(next.name) : 'generic'), [next]);
@@ -92,12 +95,38 @@ export const WorkflowNextStepCta = ({
       setBusy(false);
     }
   };
+  const recover = async () => {
+    if (busy) {
+      return;
+    }
+    setBusy(true);
+    setIsRecovering(true);
+    try {
+      await onRecover?.();
+    } finally {
+      setBusy(false);
+      setIsRecovering(false);
+    }
+  };
   if (chain.kind === 'complete') {
     return null;
   }
   if (chain.kind === 'blocked') {
     return (
-      <div className={cn('relative', className)}>
+      <div className={cn('relative flex items-center gap-2', className)}>
+        <Button
+          variant="warning"
+          emphasis="outline"
+          size="sm"
+          onClick={() => void recover()}
+          disabled={busy || onRecover == null}
+          data-testid="workflow-recover-step-cta"
+          title="Ask the agent to verify the work, finish anything missing, and emit the completion marker"
+          className="h-auto border-warning/50 bg-warning/10 px-2 py-1 text-2xs font-semibold"
+        >
+          <RotateCcw size={12} aria-hidden className="shrink-0" />
+          {isRecovering ? 'Checking step' : 'Check completion'}
+        </Button>
         <Button
           variant="warning"
           emphasis="outline"
@@ -105,7 +134,7 @@ export const WorkflowNextStepCta = ({
           onClick={() => setPendingForce(true)}
           disabled={busy}
           data-testid="workflow-force-next-step-cta"
-          title={`Step blocked: ${chain.failedStep.name}`}
+          title="Discard this step output and continue without it"
           className="h-auto border-warning/50 bg-warning/10 px-2 py-1 text-2xs font-semibold"
         >
           <AlertTriangle size={12} aria-hidden className="shrink-0" />
@@ -117,7 +146,7 @@ export const WorkflowNextStepCta = ({
               role="alert"
               icon={<AlertTriangle size={12} />}
               title="Skip the blocked step and start the next agent?"
-              description={`${chain.failedStep.name} did not finish. Its output will not be carried forward.`}
+              description={`${chain.failedStep.name} will be marked skipped. Its output will not be carried forward.`}
               confirmLabel="Skip and continue"
               cancelLabel="Cancel"
               isBusy={busy}

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.tsx
@@ -113,6 +113,7 @@ export const AgentsSection = ({
                 onResolveFirstForRun={section.onResolveFirstForRun}
                 toggleClusterExpand={section.toggleClusterExpand}
                 skipStuckStepAndAdvance={section.skipStuckStepAndAdvance}
+                recoverStuckStep={section.recoverStuckStep}
               />
             ))}
           </div>

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.test.tsx
@@ -202,6 +202,7 @@ const renderDetail = ({
       onResolveFirstForRun={vi.fn()}
       toggleClusterExpand={vi.fn()}
       skipStuckStepAndAdvance={vi.fn(async () => undefined)}
+      recoverStuckStep={vi.fn(async () => undefined)}
     />,
   );
 

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.tsx
@@ -85,6 +85,7 @@ type Props = {
   readonly onResolveFirstForRun: (run: WorkflowRun) => void;
   readonly toggleClusterExpand: (id: string) => void;
   readonly skipStuckStepAndAdvance: AppStore['skipStuckStepAndAdvance'];
+  readonly recoverStuckStep: AppStore['recoverStuckStep'];
 };
 
 const isRunning = (agent: Agent): boolean => agent.status === 'running';
@@ -130,6 +131,7 @@ export const WorkflowRow = ({
   onResolveFirstForRun,
   toggleClusterExpand,
   skipStuckStepAndAdvance,
+  recoverStuckStep,
 }: Props) => {
   const roleModels = useSessionRoleModels({ sessionId: task.id });
   const isOrchestrating = useAppStore((s) => s.orchestratingWorkflowRuns?.[run.id] ?? false);
@@ -428,6 +430,7 @@ export const WorkflowRow = ({
                 onForceAdvance={() =>
                   void skipStuckStepAndAdvance(task.id, run.id, { onlyWhenBlocked: true })
                 }
+                onRecover={() => recoverStuckStep({ sessionId: task.id, workflowRunId: run.id })}
               />
             </div>
           ) : null}

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/useAgentsSection.ts
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/useAgentsSection.ts
@@ -101,6 +101,7 @@ export const useAgentsSection = ({ task, workflowRunId }: Params) => {
   const spawnAgent = useAppStore((s) => s.spawnAgent);
   const activateWorkflowAgent = useAppStore((s) => s.activateWorkflowAgent);
   const skipStuckStepAndAdvance = useAppStore((s) => s.skipStuckStepAndAdvance);
+  const recoverStuckStep = useAppStore((s) => s.recoverStuckStep);
   const detachWorkflowFromSession = useAppStore((s) => s.detachWorkflowFromSession);
   const renameAgent = useAppStore((s) => s.renameAgent);
   const attachedRuns = useAttachedWorkflowRuns({ session: task });
@@ -306,6 +307,7 @@ export const useAgentsSection = ({ task, workflowRunId }: Params) => {
     editingId,
     focusedWorkflowRunId,
     skipStuckStepAndAdvance,
+    recoverStuckStep,
     hasAnyWorkflow: attachedRuns.length > 0,
     isTaskActive,
     isTranscriptLoading: loading.transcript,

--- a/apps/desktop/src/store/slices/turn/sendTurn.ts
+++ b/apps/desktop/src/store/slices/turn/sendTurn.ts
@@ -355,6 +355,8 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
               },
               toStep: { ordinal: nextDef.ordinal, name: nextDef.name },
               carryForwardContext,
+              sessionId,
+              fromAgentId: immediatePredecessor.id,
               ...(isDegraded && { degraded: true }),
               ...(durationMs != null && { durationMs }),
               at: now(),

--- a/apps/desktop/src/store/slices/workflows/index.ts
+++ b/apps/desktop/src/store/slices/workflows/index.ts
@@ -1,6 +1,7 @@
 import { activateWorkflowAgent } from './activateWorkflowAgent';
 import { advanceClusterImplementation } from './clusterImplementation';
 import { retryStepSummary } from './retryStepSummary';
+import { recoverStuckStep } from './recoverStuckStep';
 import { attachWorkflowToSession } from './attachWorkflowToSession';
 import { deleteStepDef } from './deleteStepDef';
 import { deleteWorkflow } from './deleteWorkflow';
@@ -68,5 +69,6 @@ export const createWorkflowsSlice = (set: SetFn, get: GetFn) => {
     setWorkflowOrchestratorHints: setWorkflowOrchestratorHints(set, get),
     setWorkflowOrchestratorRouting: setWorkflowOrchestratorRouting(set, get),
     retryStepSummary: retryStepSummary(set, get),
+    recoverStuckStep: recoverStuckStep(get),
   };
 };

--- a/apps/desktop/src/store/slices/workflows/recoverStuckStep.test.ts
+++ b/apps/desktop/src/store/slices/workflows/recoverStuckStep.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it, vi } from 'vitest';
+import type {
+  Agent,
+  AgentId,
+  IsoDateTime,
+  Session,
+  SessionId,
+  StepId,
+  Workflow,
+  WorkflowId,
+  WorkflowRunId,
+  WorkspaceId,
+} from '@goodboy/types';
+import { recoverStuckStep } from './recoverStuckStep';
+
+const SESSION_ID = 'session-1' as SessionId;
+const RUN_ID = 'run-1' as WorkflowRunId;
+const WORKFLOW_ID = 'workflow-1' as WorkflowId;
+const WORKSPACE_ID = 'workspace-1' as WorkspaceId;
+const AGENT_ID = 'agent-1' as AgentId;
+const NOW = '2026-08-17T00:00:00.000Z' as IsoDateTime;
+
+const workflow: Workflow = {
+  id: WORKFLOW_ID,
+  workspaceId: WORKSPACE_ID,
+  name: 'Delivery',
+  description: '',
+  steps: [
+    {
+      id: 'step-1' as StepId,
+      workflowId: WORKFLOW_ID,
+      ordinal: 0,
+      name: 'Analyze',
+      promptPrefix: '',
+    },
+  ],
+  createdAt: NOW,
+  updatedAt: NOW,
+};
+
+const session: Session = {
+  id: SESSION_ID,
+  workspaceId: WORKSPACE_ID,
+  goal: 'ship safely',
+  state: { kind: 'idle', lastActivityAt: NOW },
+  contextSlots: [],
+  providerPreference: { defaultProvider: 'anthropic', allowTurnOverride: true },
+  permissionMode: 'default',
+  workflowRuns: [
+    {
+      id: RUN_ID,
+      workflowId: WORKFLOW_ID,
+      ordinal: 0,
+      currentStep: 0,
+      autoRun: false,
+      triggerMode: 'immediate',
+      executionMode: 'static',
+    },
+  ],
+  autoRun: false,
+  titleUserEdited: false,
+  createdAt: NOW,
+  updatedAt: NOW,
+};
+
+const failedAgent: Agent = {
+  id: AGENT_ID,
+  sessionId: SESSION_ID,
+  workflowRunId: RUN_ID,
+  stepId: workflow.steps[0]!.id,
+  ordinal: 0,
+  name: 'Analyze',
+  status: 'failed',
+};
+
+describe('recoverStuckStep', () => {
+  it('uses the normal turn path to verify completion and request the marker', async () => {
+    const sendTurn = vi.fn(async () => ({ blockedOverBudget: false }));
+    const emitNotification = vi.fn(async () => undefined);
+    const state = {
+      sessions: [session],
+      phaseTemplates: { [WORKSPACE_ID]: [workflow] },
+      sessionWorkflows: {},
+      sessionPhaseRuns: { [SESSION_ID]: [failedAgent] },
+      agentTurnState: {},
+      sendTurn,
+      emitNotification,
+    };
+    const run = recoverStuckStep(
+      (() => state) as unknown as Parameters<typeof recoverStuckStep>[0],
+    );
+
+    await run({ sessionId: SESSION_ID, workflowRunId: RUN_ID });
+
+    expect(sendTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: SESSION_ID,
+        agentId: AGENT_ID,
+        content: expect.stringContaining('Check whether this workflow step is complete'),
+      }),
+    );
+    expect(sendTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining(`<<step-done id="${AGENT_ID}">>`),
+      }),
+    );
+    expect(emitNotification).not.toHaveBeenCalled();
+  });
+
+  it('reports a failed recovery and leaves skip available', async () => {
+    const sendTurn = vi.fn(async () => {
+      throw new Error('provider unavailable');
+    });
+    const emitNotification = vi.fn(async () => undefined);
+    const state = {
+      sessions: [session],
+      phaseTemplates: { [WORKSPACE_ID]: [workflow] },
+      sessionWorkflows: {},
+      sessionPhaseRuns: { [SESSION_ID]: [failedAgent] },
+      agentTurnState: {},
+      sendTurn,
+      emitNotification,
+    };
+    const run = recoverStuckStep(
+      (() => state) as unknown as Parameters<typeof recoverStuckStep>[0],
+    );
+
+    await run({ sessionId: SESSION_ID, workflowRunId: RUN_ID });
+
+    expect(emitNotification).toHaveBeenCalledWith(
+      'error',
+      'warning',
+      'the blocked step could not be checked',
+      'provider unavailable. You can still skip this step.',
+      { sessionId: SESSION_ID },
+    );
+  });
+});

--- a/apps/desktop/src/store/slices/workflows/recoverStuckStep.ts
+++ b/apps/desktop/src/store/slices/workflows/recoverStuckStep.ts
@@ -1,0 +1,70 @@
+import { classifyWorkflowChain, findReusableAgent, runsForWorkflowRun } from '@goodboy/core';
+import { formatError } from '@goodboy/ui';
+import type { SessionId, WorkflowRunId } from '@goodboy/types';
+import { composeStepBoundary } from '../../kickoff';
+import type { GetFn } from './types';
+
+type Params = {
+  readonly sessionId: SessionId;
+  readonly workflowRunId: WorkflowRunId;
+};
+
+const recoveryPrompt = ({
+  agentId,
+}: {
+  readonly agentId: Parameters<typeof composeStepBoundary>[0];
+}): string =>
+  [
+    'Check whether this workflow step is complete.',
+    'If work remains, finish it. If the work is complete, briefly confirm the result.',
+    composeStepBoundary(agentId),
+  ].join('\n');
+
+export const recoverStuckStep = (get: GetFn) => {
+  return async ({ sessionId, workflowRunId }: Params): Promise<void> => {
+    try {
+      const session = get().sessions.find((candidate) => candidate.id === sessionId);
+      if (session == null) {
+        return;
+      }
+      const run = session.workflowRuns.find((candidate) => candidate.id === workflowRunId);
+      if (run == null || run.discardedAt != null) {
+        return;
+      }
+      const workflows = [
+        ...(get().phaseTemplates[session.workspaceId] ?? []),
+        ...(get().sessionWorkflows?.[sessionId] ?? []),
+      ];
+      const workflow = workflows.find((candidate) => candidate.id === run.workflowId);
+      if (workflow == null) {
+        return;
+      }
+      const agents = runsForWorkflowRun(get().sessionPhaseRuns[sessionId] ?? [], workflowRunId);
+      const chain = classifyWorkflowChain(workflow, agents);
+      if (chain.kind !== 'blocked') {
+        return;
+      }
+      const agent = findReusableAgent(agents, chain.failedStep.id);
+      if (agent == null || agent.status !== 'failed') {
+        return;
+      }
+      const turn = get().agentTurnState[agent.id];
+      if (turn?.kind === 'running' || turn?.kind === 'starting') {
+        return;
+      }
+      await get().sendTurn({
+        sessionId,
+        agentId: agent.id,
+        content: recoveryPrompt({ agentId: agent.id }),
+      });
+    } catch (error) {
+      void get().emitNotification(
+        'error',
+        'warning',
+        'the blocked step could not be checked',
+        `${formatError(error)}. You can still skip this step.`,
+        { sessionId },
+      );
+    }
+  };
+};

--- a/apps/desktop/src/store/slices/workflows/retryStepSummary.test.ts
+++ b/apps/desktop/src/store/slices/workflows/retryStepSummary.test.ts
@@ -66,6 +66,7 @@ type State = {
   sessionPhaseRuns: Record<string, ReadonlyArray<Agent>>;
   transcripts: Record<string, ReadonlyArray<{ kind: string; delta?: string }>>;
   workspaceOverrides: Record<string, unknown>;
+  emitNotification: ReturnType<typeof vi.fn>;
 };
 
 const buildHarness = (stateOverrides: Partial<State> = {}) => {
@@ -84,6 +85,7 @@ const buildHarness = (stateOverrides: Partial<State> = {}) => {
       ],
     },
     workspaceOverrides: {},
+    emitNotification: vi.fn(async () => undefined),
     ...stateOverrides,
   };
   const set = vi.fn();
@@ -133,6 +135,7 @@ describe('retryStepSummary', () => {
       sessionPhaseRuns: { [SESSION_ID]: [agent] },
       transcripts: { [AGENT_ID]: [{ kind: 'assistant_text', delta: 'output' }] },
       workspaceOverrides: {},
+      emitNotification: vi.fn(async () => undefined),
     };
     const get = (() => state) as unknown as Parameters<typeof retryStepSummary>[1];
     const retry = retryStepSummary(set as unknown as Parameters<typeof retryStepSummary>[0], get);

--- a/apps/desktop/src/store/slices/workflows/retryStepSummary.ts
+++ b/apps/desktop/src/store/slices/workflows/retryStepSummary.ts
@@ -58,6 +58,16 @@ export const retryStepSummary = (set: SetFn, get: GetFn) => {
       ...(worktreePath != null && { workingDir: worktreePath }),
       ...(expectedOutput !== '' && { expectedOutput }),
     });
+    if (result.degraded) {
+      void get().emitNotification(
+        'summarizer-degraded',
+        'warning',
+        'step summary retry failed',
+        result.error ?? 'summarization failed',
+        { sessionId, action: { kind: 'retry-step-summary', sessionId, agentId } },
+      );
+      return;
+    }
     await invokeAgentUpdateStatus(agentId, { status: 'completed', outputSummary: result.summary });
 
     set((state) => ({
@@ -68,5 +78,12 @@ export const retryStepSummary = (set: SetFn, get: GetFn) => {
         ),
       },
     }));
+    void get().emitNotification(
+      'summarizer-success',
+      'success',
+      'step summary repaired',
+      'later workflow steps will use the repaired handoff.',
+      { sessionId },
+    );
   };
 };

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -365,6 +365,10 @@ export type AppActions = {
     workflowRunId: WorkflowRunId,
     options?: { readonly onlyWhenBlocked?: boolean },
   ): Promise<void>;
+  recoverStuckStep(params: {
+    readonly sessionId: SessionId;
+    readonly workflowRunId: WorkflowRunId;
+  }): Promise<void>;
   maybeAutoAdvanceWorkflow(sessionId: SessionId): Promise<void>;
   orchestrateNextStep(
     sessionId: SessionId,

--- a/apps/desktop/src/store/summarizeAgentOutput.ts
+++ b/apps/desktop/src/store/summarizeAgentOutput.ts
@@ -3,7 +3,7 @@ import { formatError } from '@goodboy/ui';
 import { fallbackStepOutputSummary, summarizeStepOutput } from '@goodboy/core';
 import type { AgentId, TaskModelPreference } from '@goodboy/types';
 
-export const SUMMARY_TIMEOUT_MS = 60_000;
+export const SUMMARY_TIMEOUT_MS = 90_000;
 
 type Params = {
   readonly agentId: AgentId;

--- a/packages/core/src/summarizer/step-output.test.ts
+++ b/packages/core/src/summarizer/step-output.test.ts
@@ -89,6 +89,35 @@ describe('summarizeStepOutput', () => {
     expect(systemPrompt).toContain('File paths touched');
   });
 
+  it('bounds long output before invoking the summarizer and preserves its end', async () => {
+    let request: Record<string, unknown> | undefined;
+    const invokeFn: SummarizerDeps['invokeFn'] = async <T>(
+      _cmd: string,
+      args?: Record<string, unknown>,
+    ): Promise<T> => {
+      request = args;
+      return { stdout: 'Bounded the handoff input.', stderr: '', exitCode: 0 } as T;
+    };
+    const output = `${'h'.repeat(130_000)}TAIL_BLOCKER`;
+
+    await summarizeStepOutput({
+      providerId: 'cursor',
+      model: 'composer-2-fast',
+      invokeFn,
+      output,
+    });
+    const args = request?.['args'];
+    const userMessage =
+      typeof args === 'object' && args !== null && 'userMessage' in args
+        ? String(args.userMessage)
+        : '';
+
+    expect(userMessage.length).toBe(120_000);
+    expect(userMessage.startsWith('h'.repeat(100_000))).toBe(true);
+    expect(userMessage).toContain('middle output omitted to fit the summarizer input budget');
+    expect(userMessage.endsWith('TAIL_BLOCKER')).toBe(true);
+  });
+
   it('parses the anthropic result envelope', async () => {
     const invokeFn: SummarizerDeps['invokeFn'] = async <T>(): Promise<T> => {
       return {

--- a/packages/core/src/summarizer/step-output.ts
+++ b/packages/core/src/summarizer/step-output.ts
@@ -9,6 +9,10 @@ const MAX_FIRST_LINE_LENGTH = 120;
 const FALLBACK_HEAD_LENGTH = 1500;
 const FALLBACK_TAIL_LENGTH = 400;
 const FALLBACK_JOINER = '\n...\n';
+const MAX_SUMMARIZER_INPUT_LENGTH = 120_000;
+const SUMMARIZER_INPUT_HEAD_LENGTH = 100_000;
+const SUMMARIZER_INPUT_JOINER =
+  '\n\n[middle output omitted to fit the summarizer input budget]\n\n';
 const CLAMP_NOTICE =
   '\n\n(clamped to the handoff budget, the full step output is in the step transcript)';
 
@@ -76,6 +80,15 @@ const clampToSummaryBudget = ({ summary }: ClampParams): string => {
   return `${kept.join('\n').trimEnd()}${CLAMP_NOTICE}`;
 };
 
+const boundSummarizerInput = ({ output }: Params): string => {
+  if (output.length <= MAX_SUMMARIZER_INPUT_LENGTH) {
+    return output;
+  }
+  const tailLength =
+    MAX_SUMMARIZER_INPUT_LENGTH - SUMMARIZER_INPUT_HEAD_LENGTH - SUMMARIZER_INPUT_JOINER.length;
+  return `${output.slice(0, SUMMARIZER_INPUT_HEAD_LENGTH)}${SUMMARIZER_INPUT_JOINER}${output.slice(-tailLength)}`;
+};
+
 export const summarizeStepOutput = async ({
   providerId,
   binary,
@@ -91,7 +104,7 @@ export const summarizeStepOutput = async ({
     providerId,
     model,
     binary: binary ?? getDefaultBinary(providerId),
-    userMessage: output,
+    userMessage: boundSummarizerInput({ output }),
     systemPrompt: stepOutputSystemPrompt({ expectedOutput: expectedOutput ?? '' }),
     ...(effort != null && { effort }),
     ...(workingDir != null && { workingDir }),

--- a/packages/types/src/adapter.ts
+++ b/packages/types/src/adapter.ts
@@ -1,4 +1,4 @@
-import type { IsoDateTime, PermissionRuleId, ProviderRunId, SessionId } from './ids';
+import type { AgentId, IsoDateTime, PermissionRuleId, ProviderRunId, SessionId } from './ids';
 import type { MessageAttachment } from './message';
 import type { ClaudePermissionMode, PermissionScope } from './permission';
 import type { ProviderName } from './provider';
@@ -109,6 +109,8 @@ export type TurnEvent =
       fromStep: { ordinal: number; name: string };
       toStep: { ordinal: number; name: string };
       carryForwardContext: string;
+      sessionId?: SessionId;
+      fromAgentId?: AgentId;
       degraded?: true;
       durationMs?: number;
       at: IsoDateTime;


### PR DESCRIPTION
## Why

Two things from a real session the owner watched a colleague run.

A serious analysis step finished, and the transition into planning read `degraded handoff`. The owner asked whether context was lost between step one and step two.

Then the colleague's first step ended in error and the workflow would not move. The only way forward turned out to be typing "perfect, re-emit the completion marker" into the chat, which nobody could be expected to discover.

## What degraded actually meant

Context was thinned, not fabricated. When `summarizeStepOutput` throws or exceeds its budget, the code falls back to `fallbackStepOutputSummary` and marks the handoff degraded. That fallback is a deterministic head and tail of the output, so decisions and findings in the middle can simply disappear, and the next step runs on that.

Failure modes that can really occur: the 60 second budget, unbounded input exceeding or slowing the provider context, a provider or auth failure, provider output that is not valid JSON, empty output. A missing marker is not one of them, the summarizer prompt asks for no marker. The exact cause here cannot be proven without the original error, but the most likely one is the budget, blown by a long analysis sent whole.

## What changed

**The input is bounded before it is sent**, capped at 120k characters, keeping 100k from the start and the remainder from the end, and the budget is 90 seconds against that bound. Raising the timeout alone would have been papering over unbounded input.

**A degraded card explains itself.** It opens with what happened and offers a retry, and it says plainly that retrying repairs later handoffs but cannot retroactively replace context the current step already received. Both outcomes of a retry produce a durable notification instead of a one-shot toast.

**A blocked step now offers two distinct actions.** `Check completion` asks the existing agent to verify its work, finish anything missing, and emit the normal completion marker, through the standard `sendTurn` path rather than a parallel mechanism. `Skip blocked step` still marks it skipped and discards its output. One recovers, one discards, and the copy makes clear which is which. While it runs the user sees `Checking step`, and a failure says so and leaves skip available.

## Note for the attribution question

While in here: `AgentContext` already carries `agentId`, `workflowId`, `workflowRunId` and `stepOrdinal`, and the step-summary writer already holds the agent id, workflow run id, step id and ordinal at write time. So the provenance precedent exists and the identity is in hand. Nothing was built here, but that answers whether attributing a summary to an agent is feasible.

## Verification

- `pnpm --filter @goodboy/core typecheck`, `pnpm --filter @goodboy/desktop typecheck`
- core suite, 103 files, 1146 tests
- desktop suite, 669 files, 5779 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
