### PR TITLE
fix(desktop): the trail keeps its ancestors and the parent stays mounted

### DIFF
--- a/apps/desktop/src/features/session/components/SessionWorkspace/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/index.test.tsx
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, cleanup, fireEvent, render, renderHook, screen } from '@testing-library/react';
+import { useEffect } from 'react';
 import type { Agent, Session } from '@goodboy/types';
 import type { LensKind } from '../../../../store';
 
@@ -88,6 +89,8 @@ const { store, hooks } = vi.hoisted(() => ({
   hooks: {
     agentHome: 'workflows' as LensKind,
     openQuestions: [] as ReadonlyArray<{ readonly createdByAgentId?: string }>,
+    agentsLaneMounts: 0,
+    agentsLaneUnmounts: 0,
   },
 }));
 
@@ -165,18 +168,26 @@ vi.mock('../StandaloneAgentsLane', () => ({
   }: {
     session: Session;
     onInspectAgent?: (agentId: string) => void;
-  }) => (
-    <div data-testid="agents-lane">
-      {(store.sessionPhaseRuns[session.id] ?? []).map((agent) => (
-        <button
-          key={agent.id}
-          type="button"
-          onClick={() => onInspectAgent?.(agent.id)}
-          aria-label={`inspect ${agent.id}`}
-        />
-      ))}
-    </div>
-  ),
+  }) => {
+    useEffect(() => {
+      hooks.agentsLaneMounts += 1;
+      return () => {
+        hooks.agentsLaneUnmounts += 1;
+      };
+    }, []);
+    return (
+      <div data-testid="agents-lane">
+        {(store.sessionPhaseRuns[session.id] ?? []).map((agent) => (
+          <button
+            key={agent.id}
+            type="button"
+            onClick={() => onInspectAgent?.(agent.id)}
+            aria-label={`inspect ${agent.id}`}
+          />
+        ))}
+      </div>
+    );
+  },
 }));
 vi.mock('../CreateAgentPopover', () => ({
   CreateAgentPopover: () => (
@@ -291,6 +302,8 @@ beforeEach(() => {
   store.loadSessionPlans.mockClear();
   hooks.agentHome = 'workflows';
   hooks.openQuestions = [];
+  hooks.agentsLaneMounts = 0;
+  hooks.agentsLaneUnmounts = 0;
 });
 
 afterEach(cleanup);
@@ -304,7 +317,7 @@ describe('SessionWorkspace agent overlay', () => {
     expect(
       screen.getByTestId('chat-view').contains(screen.getByTestId('workflow-breadcrumb')),
     ).toBe(true);
-    expect(screen.queryByTestId('agents-lane')).toBeNull();
+    expect(screen.getByTestId('agents-lane')).toBeDefined();
     expect(screen.queryByTestId('agents-section')).toBeNull();
     expect(screen.queryByRole('separator', { name: 'Resize agent inspector' })).toBeNull();
   });
@@ -419,9 +432,9 @@ describe('SessionWorkspace agent overlay', () => {
     render(<SessionWorkspace session={session} isActive />);
     expect(screen.queryByTestId('workflow-breadcrumb')).toBeNull();
     expect(screen.queryByRole('separator', { name: 'resize agent list' })).toBeNull();
-    expect(screen.queryByTestId('agents-lane')).toBeNull();
+    expect(screen.getByTestId('agents-lane')).toBeDefined();
     expect(screen.getAllByRole('button', { name: 'Agents' })).toHaveLength(1);
-    expect(screen.getByTestId('agent-inspector').textContent).toBe(standaloneAgent.id);
+    expect(screen.getAllByTestId('agent-inspector')).toHaveLength(2);
     expect(screen.getByRole('separator', { name: 'Resize agent inspector' })).toBeDefined();
   });
 
@@ -702,14 +715,28 @@ describe('SessionWorkspace breadcrumb visibility', () => {
     expect(screen.getByTestId('session-crumb-bar')).toBeDefined();
   });
 
-  it('drops the crumb bar once an agent overlay owns the surface', () => {
+  it('keeps the crumb bar mounted once an agent overlay owns the surface', () => {
     store.activeLens = { [SESSION_ID]: 'agents' };
     store.selectedAgentId = { [SESSION_ID]: selectedAgent.id };
     store.sessionPhaseRuns = { [SESSION_ID]: [selectedAgent] };
 
     render(<SessionWorkspace session={session} isActive />);
 
-    expect(screen.queryByTestId('session-crumb-bar')).toBeNull();
+    expect(screen.getByTestId('session-crumb-bar')).toBeDefined();
+  });
+
+  it('does not unmount the ancestor lens when a child is selected', () => {
+    store.selectedAgentId = {};
+    const view = render(<SessionWorkspace session={session} isActive />);
+
+    expect(hooks.agentsLaneMounts).toBe(1);
+
+    store.selectedAgentId = { [SESSION_ID]: selectedAgent.id };
+    view.rerender(<SessionWorkspace session={session} isActive />);
+
+    expect(hooks.agentsLaneMounts).toBe(1);
+    expect(hooks.agentsLaneUnmounts).toBe(0);
+    expect(screen.getByTestId('chat-view')).toBeDefined();
   });
 
   it('moves the workflow run name into the chat header while an agent is open', () => {

--- a/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
@@ -264,151 +264,154 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
 
   return (
     <div className="relative flex h-full w-full min-w-0 flex-col">
-      {showLens ? <SessionCrumbBar /> : null}
-      {showLens ? <RepoScopeBar sessionId={sessionId} /> : null}
+      <div
+        className={cn(!showLens && 'pointer-events-none invisible absolute inset-x-0 top-0')}
+        inert={!showLens}
+      >
+        <SessionCrumbBar />
+        <RepoScopeBar sessionId={sessionId} />
+      </div>
       <div className="relative min-h-0 flex-1">
-        {showLens ? (
-          <div className="absolute inset-0 z-0">
-            {lens === null ? (
-              isOverviewLoaded ? (
-                <SessionOverviewPane session={session} onSelectLens={onSelectLens} />
-              ) : (
-                <SessionOverviewLoading
-                  isFreshLayout={isFreshOverviewLayout}
-                  onRetry={onRetryOverview}
-                />
-              )
-            ) : null}
-            {lens === 'questions' ? <QuestionsPane session={session} /> : null}
-            {lens === 'timeline' ? <TimelinePane session={session} /> : null}
-            {lens === 'plans' ? <PlanStudio sessionId={sessionId} /> : null}
-            {lens === 'workflows' ? <WorkflowsPane session={session} /> : null}
-            {lens === 'resolve' ? (
-              <ResolvePane
-                session={session}
-                meta={resolveMeta}
-                inspectedResolverId={inspectedResolverId}
-                onInspectResolver={setInspectedResolverId}
-                showCompleted={showCompletedResolvers}
-                onShowCompletedChange={setShowCompletedResolvers}
+        <div
+          className={cn('absolute inset-0 z-0', !showLens && 'invisible pointer-events-none')}
+          inert={!showLens}
+        >
+          {lens === null ? (
+            isOverviewLoaded ? (
+              <SessionOverviewPane session={session} onSelectLens={onSelectLens} />
+            ) : (
+              <SessionOverviewLoading
+                isFreshLayout={isFreshOverviewLayout}
+                onRetry={onRetryOverview}
               />
-            ) : null}
-            {lens === 'scripts' ? (
+            )
+          ) : null}
+          {lens === 'questions' ? <QuestionsPane session={session} /> : null}
+          {lens === 'timeline' ? <TimelinePane session={session} /> : null}
+          {lens === 'plans' ? <PlanStudio sessionId={sessionId} /> : null}
+          {lens === 'workflows' ? <WorkflowsPane session={session} /> : null}
+          {lens === 'resolve' ? (
+            <ResolvePane
+              session={session}
+              meta={resolveMeta}
+              inspectedResolverId={inspectedResolverId}
+              onInspectResolver={setInspectedResolverId}
+              showCompleted={showCompletedResolvers}
+              onShowCompletedChange={setShowCompletedResolvers}
+            />
+          ) : null}
+          {lens === 'scripts' ? (
+            <PaneShell
+              title="Scripts"
+              description="Shell commands you run by hand from this session, no agent involved."
+            >
+              <ScriptsPanel
+                workspaceId={session.workspaceId}
+                sessionId={sessionId}
+                worktreePath={workingDir}
+                hasHostHeading
+              />
+            </PaneShell>
+          ) : null}
+          {lens === 'context' ||
+          lens === 'goal' ||
+          lens === 'decisions' ||
+          lens === 'last_output_summary' ? (
+            <ContextPane session={session} initialRegion={lens === 'context' ? undefined : lens} />
+          ) : null}
+          {lens === 'pr' ? <PrPane session={session} onSelectLens={onSelectLens} /> : null}
+          {lens === 'review' ? <ReviewBoardPane session={session} /> : null}
+          {lens === 'linear' ? (
+            <IntegrationPane
+              sessionId={sessionId}
+              workspaceId={session.workspaceId}
+              provider="linear"
+            />
+          ) : null}
+          {lens === 'sentry' ? (
+            <IntegrationPane
+              sessionId={sessionId}
+              workspaceId={session.workspaceId}
+              provider="sentry"
+            />
+          ) : null}
+          {lens === 'gitlab_issues' ? (
+            <IntegrationPane
+              sessionId={sessionId}
+              workspaceId={session.workspaceId}
+              provider="gitlab"
+            />
+          ) : null}
+          {lens === 'jira_issues' ? (
+            <IntegrationPane
+              sessionId={sessionId}
+              workspaceId={session.workspaceId}
+              provider="jira"
+            />
+          ) : null}
+          {lens === 'slack_threads' ? (
+            <IntegrationPane
+              sessionId={sessionId}
+              workspaceId={session.workspaceId}
+              provider="slack"
+            />
+          ) : null}
+          {lens === 'github_issue' ? (
+            githubIssueNumber != null ? (
+              <GithubTaskDetail
+                workspaceId={session.workspaceId}
+                rootPath={projectWorktreePath}
+                {...(githubTask != null && { task: githubTask })}
+                issueNumber={githubIssueNumber}
+              />
+            ) : (
               <PaneShell
-                title="Scripts"
-                description="Shell commands you run by hand from this session, no agent involved."
+                title="GitHub issue"
+                description="The GitHub issue linked to this session."
               >
-                <ScriptsPanel
-                  workspaceId={session.workspaceId}
-                  sessionId={sessionId}
-                  worktreePath={workingDir}
-                  hasHostHeading
+                <LensEmptyState
+                  icon={CONCEPT_ICONS.github}
+                  tone={CONCEPT_TONE.github}
+                  title="No GitHub issue linked"
+                  description="Link a GitHub issue to this session to see it here."
+                  action={
+                    <LinkTicketPopover
+                      sessionId={sessionId}
+                      workspaceId={session.workspaceId}
+                      provider="github"
+                      providerLabel="GitHub"
+                      noun="issue"
+                      nounPhrase="an issue"
+                      nounPlural="issues"
+                    />
+                  }
                 />
               </PaneShell>
-            ) : null}
-            {lens === 'context' ||
-            lens === 'goal' ||
-            lens === 'decisions' ||
-            lens === 'last_output_summary' ? (
-              <ContextPane
-                session={session}
-                initialRegion={lens === 'context' ? undefined : lens}
-              />
-            ) : null}
-            {lens === 'pr' ? <PrPane session={session} onSelectLens={onSelectLens} /> : null}
-            {lens === 'review' ? <ReviewBoardPane session={session} /> : null}
-            {lens === 'linear' ? (
-              <IntegrationPane
-                sessionId={sessionId}
-                workspaceId={session.workspaceId}
-                provider="linear"
-              />
-            ) : null}
-            {lens === 'sentry' ? (
-              <IntegrationPane
-                sessionId={sessionId}
-                workspaceId={session.workspaceId}
-                provider="sentry"
-              />
-            ) : null}
-            {lens === 'gitlab_issues' ? (
-              <IntegrationPane
-                sessionId={sessionId}
-                workspaceId={session.workspaceId}
-                provider="gitlab"
-              />
-            ) : null}
-            {lens === 'jira_issues' ? (
-              <IntegrationPane
-                sessionId={sessionId}
-                workspaceId={session.workspaceId}
-                provider="jira"
-              />
-            ) : null}
-            {lens === 'slack_threads' ? (
-              <IntegrationPane
-                sessionId={sessionId}
-                workspaceId={session.workspaceId}
-                provider="slack"
-              />
-            ) : null}
-            {lens === 'github_issue' ? (
-              githubIssueNumber != null ? (
-                <GithubTaskDetail
-                  workspaceId={session.workspaceId}
-                  rootPath={projectWorktreePath}
-                  {...(githubTask != null && { task: githubTask })}
-                  issueNumber={githubIssueNumber}
-                />
-              ) : (
-                <PaneShell
-                  title="GitHub issue"
-                  description="The GitHub issue linked to this session."
-                >
-                  <LensEmptyState
-                    icon={CONCEPT_ICONS.github}
-                    tone={CONCEPT_TONE.github}
-                    title="No GitHub issue linked"
-                    description="Link a GitHub issue to this session to see it here."
-                    action={
-                      <LinkTicketPopover
-                        sessionId={sessionId}
-                        workspaceId={session.workspaceId}
-                        provider="github"
-                        providerLabel="GitHub"
-                        noun="issue"
-                        nounPhrase="an issue"
-                        nounPlural="issues"
-                      />
-                    }
-                  />
-                </PaneShell>
-              )
-            ) : null}
-            {lens === 'files' ? (
-              <FilesPane
-                sessionId={sessionId}
-                sessionDir={workingDir}
-                worktreePath={projectWorktreePath}
-                isBranchless={isBranchless}
-                onClose={onSelectOverview}
-              />
-            ) : null}
-            {lens === 'explore' ? (
-              <ExplorePane sessionId={sessionId} sessionDir={workingDir} />
-            ) : null}
-            <Pane visible={lens === 'agents'}>
-              <AgentsPane
-                session={session}
-                meta={agentsMeta}
-                inspectedAgentId={inspectedAgentId}
-                onInspectAgent={setInspectedAgentId}
-                showCompleted={showCompletedAgents}
-                onShowCompletedChange={setShowCompletedAgents}
-              />
-            </Pane>
-          </div>
-        ) : null}
+            )
+          ) : null}
+          {lens === 'files' ? (
+            <FilesPane
+              sessionId={sessionId}
+              sessionDir={workingDir}
+              worktreePath={projectWorktreePath}
+              isBranchless={isBranchless}
+              onClose={onSelectOverview}
+            />
+          ) : null}
+          {lens === 'explore' ? (
+            <ExplorePane sessionId={sessionId} sessionDir={workingDir} />
+          ) : null}
+          <Pane visible={lens === 'agents'}>
+            <AgentsPane
+              session={session}
+              meta={agentsMeta}
+              inspectedAgentId={inspectedAgentId}
+              onInspectAgent={setInspectedAgentId}
+              showCompleted={showCompletedAgents}
+              onShowCompletedChange={setShowCompletedAgents}
+            />
+          </Pane>
+        </div>
 
         {showAgentOverlay ? (
           <AgentOverlay
@@ -419,6 +422,7 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
             overlayHome={overlayHome}
             overlayHomeLabel={LENS_LABEL[overlayHome]}
             showWorkflowStrip={showWorkflowStrip}
+            onOverview={onSelectOverview}
             onBack={() => setActiveLens(sessionId, overlayHome)}
             onOpenWorkflow={() => {
               if (selectedWorkflowRunId == null) {

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/AgentBreadcrumb.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/AgentBreadcrumb.test.tsx
@@ -54,6 +54,7 @@ const renderCrumb = (
       selectedAgentId={selectedAgentId}
       overlayHome={overlayHome}
       homeLabel="Agents"
+      onOverview={vi.fn()}
       onHome={onHome}
     />,
   );

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/AgentBreadcrumb.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/AgentBreadcrumb.tsx
@@ -21,6 +21,7 @@ type Props = {
   readonly selectedAgentId: AgentId | null;
   readonly overlayHome: AgentHomeLens;
   readonly homeLabel: string;
+  readonly onOverview: () => void;
   readonly onHome: () => void;
 };
 
@@ -29,6 +30,7 @@ export const AgentBreadcrumb = ({
   selectedAgentId,
   overlayHome,
   homeLabel,
+  onOverview,
   onHome,
 }: Props) => {
   const { open, close, toggle, containerRef, popupClassName } = useDropdown({
@@ -76,10 +78,12 @@ export const AgentBreadcrumb = ({
   const crumbs = agentOverlayCrumbs({
     homeLabel,
     agentName: selectedAgent?.name ?? null,
+    onOverview,
     onHome,
   });
-  const homeCrumb = crumbs[0]!;
-  const agentCrumb = crumbs[1] ?? null;
+  const overviewCrumb = crumbs[0]!;
+  const homeCrumb = crumbs[1]!;
+  const agentCrumb = crumbs[2] ?? null;
   const canSwitch = siblings.length > 1;
 
   const renderSiblingRow = (agent: Agent) => (
@@ -108,6 +112,15 @@ export const AgentBreadcrumb = ({
 
   return (
     <nav aria-label="Agent breadcrumb" className="flex min-w-0 items-center gap-1">
+      <button
+        type="button"
+        onClick={overviewCrumb.onClick}
+        title={overviewCrumb.label}
+        className={cn(CRUMB_CLASS, 'max-w-40 shrink-0')}
+      >
+        {overviewCrumb.label}
+      </button>
+      <ChevronRight size={11} aria-hidden className="shrink-0 text-muted-foreground/40" />
       <button
         type="button"
         onClick={homeCrumb.onClick}

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/AgentOverlay.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/AgentOverlay.tsx
@@ -19,6 +19,7 @@ type Props = {
   readonly overlayHome: AgentHomeLens;
   readonly overlayHomeLabel: string;
   readonly showWorkflowStrip: boolean;
+  readonly onOverview: () => void;
   readonly onBack: () => void;
   readonly onOpenWorkflow: () => void;
 };
@@ -31,6 +32,7 @@ export const AgentOverlay = ({
   overlayHome,
   overlayHomeLabel,
   showWorkflowStrip,
+  onOverview,
   onBack,
   onOpenWorkflow,
 }: Props) => {
@@ -57,6 +59,7 @@ export const AgentOverlay = ({
     overlayHome,
     overlayHomeLabel,
     showWorkflowStrip,
+    onOverview,
     onBack,
     onOpenWorkflow,
   });

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/ChatWorkflowHeader.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/ChatWorkflowHeader.tsx
@@ -13,6 +13,7 @@ type Props = {
   readonly sessionId: SessionId;
   readonly session: Session;
   readonly selectedAgentId: AgentId;
+  readonly onOverview: () => void;
   readonly onOpenWorkflow: () => void;
 };
 
@@ -20,6 +21,7 @@ export const ChatWorkflowHeader = ({
   sessionId,
   session,
   selectedAgentId,
+  onOverview,
   onOpenWorkflow,
 }: Props) => {
   const phaseRuns = useAppStore(
@@ -44,6 +46,7 @@ export const ChatWorkflowHeader = ({
           sessionId={sessionId}
           session={session}
           selectedAgentId={selectedAgentId}
+          onOverview={onOverview}
           homeLabel={attached == null ? 'Workflows' : workflowKindName(attached.workflow)}
           onHome={onOpenWorkflow}
         />

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowBreadcrumb.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowBreadcrumb.test.tsx
@@ -66,6 +66,7 @@ const renderCrumb = (selectedAgentId: AgentId) =>
       sessionId={SESSION_ID}
       session={session}
       selectedAgentId={selectedAgentId}
+      onOverview={vi.fn()}
       homeLabel="Workflows"
       onHome={vi.fn()}
     />,

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowBreadcrumb.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowBreadcrumb.tsx
@@ -14,6 +14,7 @@ type Props = {
   readonly sessionId: SessionId;
   readonly session: Session;
   readonly selectedAgentId: AgentId;
+  readonly onOverview: () => void;
   readonly homeLabel: string;
   readonly onHome: () => void;
 };
@@ -22,6 +23,7 @@ export const WorkflowBreadcrumb = ({
   sessionId,
   session,
   selectedAgentId,
+  onOverview,
   homeLabel,
   onHome,
 }: Props) => {
@@ -101,6 +103,15 @@ export const WorkflowBreadcrumb = ({
 
   return (
     <nav aria-label="Workflow breadcrumb" className="flex min-w-0 items-center gap-1">
+      <button
+        type="button"
+        onClick={onOverview}
+        title="Overview"
+        className={cn(CRUMB_CLASS, 'max-w-40 shrink-0 text-muted-foreground hover:text-foreground')}
+      >
+        <span className="truncate">Overview</span>
+      </button>
+      <ChevronRight size={11} aria-hidden className="shrink-0 text-muted-foreground/40" />
       <button
         type="button"
         onClick={onHome}

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/agentOverlayCrumbs.ts
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/agentOverlayCrumbs.ts
@@ -3,17 +3,24 @@ import type { BreadcrumbCrumb } from '../../../../../app/components/AppBreadcrum
 type Params = {
   readonly homeLabel: string;
   readonly agentName: string | null;
+  readonly onOverview: () => void;
   readonly onHome: () => void;
 };
 
 export const agentOverlayCrumbs = ({
   homeLabel,
   agentName,
+  onOverview,
   onHome,
 }: Params): ReadonlyArray<BreadcrumbCrumb> => {
+  const overview: BreadcrumbCrumb = {
+    id: 'overview',
+    label: 'Overview',
+    onClick: onOverview,
+  };
   const home: BreadcrumbCrumb = { id: 'overlay-home', label: homeLabel, onClick: onHome };
   if (agentName == null) {
-    return [home];
+    return [overview, home];
   }
-  return [home, { id: 'overlay-agent', label: agentName }];
+  return [overview, home, { id: 'overlay-agent', label: agentName }];
 };

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/agentOverlayHeader.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/agentOverlayHeader.tsx
@@ -13,6 +13,7 @@ type Params = {
   readonly overlayHome: AgentHomeLens;
   readonly overlayHomeLabel: string;
   readonly showWorkflowStrip: boolean;
+  readonly onOverview: () => void;
   readonly onBack: () => void;
   readonly onOpenWorkflow: () => void;
 };
@@ -24,6 +25,7 @@ export const agentOverlayHeader = ({
   overlayHome,
   overlayHomeLabel,
   showWorkflowStrip,
+  onOverview,
   onBack,
   onOpenWorkflow,
 }: Params): ReactNode | undefined => {
@@ -33,6 +35,7 @@ export const agentOverlayHeader = ({
         sessionId={sessionId}
         session={session}
         selectedAgentId={selectedAgentId}
+        onOverview={onOverview}
         onOpenWorkflow={onOpenWorkflow}
       />
     );
@@ -50,6 +53,7 @@ export const agentOverlayHeader = ({
           selectedAgentId={selectedAgentId}
           overlayHome={overlayHome}
           homeLabel={overlayHomeLabel}
+          onOverview={onOverview}
           onHome={onBack}
         />
       </div>

--- a/apps/desktop/src/features/session/components/SessionWorkspace/sessionBreadcrumb.test.ts
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/sessionBreadcrumb.test.ts
@@ -20,6 +20,7 @@ const base = (
   studio: null,
   focusedWorkflowName: null,
   focusedPlanTitle: null,
+  selectedChildLabel: null,
   lensLabel,
   handlers,
   ...overrides,
@@ -43,6 +44,18 @@ describe('buildSessionBreadcrumb', () => {
     expect(labels(crumbs)).toEqual(['Overview', 'questions']);
     crumbs[0]!.onClick!();
     expect(h.toOverview).toHaveBeenCalledOnce();
+    expect(last(crumbs)?.onClick).toBeUndefined();
+  });
+
+  it('extends the lens trail without dropping an ancestor when a child opens', () => {
+    const h = makeHandlers();
+    const crumbs = buildSessionBreadcrumb(
+      base({ lens: 'agents', selectedChildLabel: 'Selected agent' }, h),
+    );
+
+    expect(labels(crumbs)).toEqual(['Overview', 'agents', 'Selected agent']);
+    crumbs[1]!.onClick!();
+    expect(h.toLens).toHaveBeenCalledWith('agents');
     expect(last(crumbs)?.onClick).toBeUndefined();
   });
 

--- a/apps/desktop/src/features/session/components/SessionWorkspace/sessionBreadcrumb.ts
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/sessionBreadcrumb.ts
@@ -13,6 +13,7 @@ export type SessionBreadcrumbInput = {
   studio: SessionStudio | null;
   focusedWorkflowName: string | null;
   focusedPlanTitle: string | null;
+  selectedChildLabel: string | null;
   lensLabel: (lens: LensKind) => string;
   handlers: SessionBreadcrumbHandlers;
 };
@@ -25,7 +26,15 @@ const sealLast = (crumbs: BreadcrumbCrumb[]): BreadcrumbCrumb[] => {
 };
 
 export const buildSessionBreadcrumb = (input: SessionBreadcrumbInput): BreadcrumbCrumb[] => {
-  const { lens, studio, focusedWorkflowName, focusedPlanTitle, lensLabel, handlers } = input;
+  const {
+    lens,
+    studio,
+    focusedWorkflowName,
+    focusedPlanTitle,
+    selectedChildLabel,
+    lensLabel,
+    handlers,
+  } = input;
 
   const overview: BreadcrumbCrumb = {
     id: 'overview',
@@ -81,6 +90,14 @@ export const buildSessionBreadcrumb = (input: SessionBreadcrumbInput): Breadcrum
 
   if (lens === 'plans' && focusedPlanTitle != null) {
     return sealLast([overview, plansList, { id: 'plan', label: focusedPlanTitle }]);
+  }
+
+  if (lens != null && selectedChildLabel != null) {
+    return sealLast([
+      overview,
+      { id: `lens-${lens}`, label: lensLabel(lens), onClick: () => handlers.toLens(lens) },
+      { id: 'selected-child', label: selectedChildLabel },
+    ]);
   }
 
   if (lens != null) {

--- a/apps/desktop/src/features/session/hooks/useSessionCrumbs/index.ts
+++ b/apps/desktop/src/features/session/hooks/useSessionCrumbs/index.ts
@@ -23,6 +23,11 @@ export const useSessionCrumbs = ({ session }: Params): ReadonlyArray<BreadcrumbC
   const studio = useAppStore((s) => s.sessionStudio[sessionId] ?? null);
   const focusedWorkflowRunId = useAppStore((s) => s.focusedWorkflowRunId[sessionId] ?? null);
   const focusedPlanId = useAppStore((s) => s.focusedPlanId[sessionId] ?? null);
+  const selectedAgentId = useAppStore((s) => s.selectedAgentId[sessionId] ?? null);
+  const selectedChildLabel = useAppStore(
+    (s) =>
+      s.sessionPhaseRuns[sessionId]?.find((agent) => agent.id === selectedAgentId)?.name ?? null,
+  );
   const attachedWorkflowRuns = useAttachedWorkflowRuns({ session });
   const plans = useSessionPlans(sessionId);
   const setActiveLens = useAppStore((s) => s.setActiveLens);
@@ -46,6 +51,7 @@ export const useSessionCrumbs = ({ session }: Params): ReadonlyArray<BreadcrumbC
         studio,
         focusedWorkflowName,
         focusedPlanTitle,
+        selectedChildLabel,
         lensLabel: (kind: LensKind) => lensLabelFor({ lens: kind, isBranchless }),
         handlers: {
           toOverview: () => setActiveLens(sessionId, null),
@@ -65,6 +71,7 @@ export const useSessionCrumbs = ({ session }: Params): ReadonlyArray<BreadcrumbC
       studio,
       focusedWorkflowName,
       focusedPlanTitle,
+      selectedChildLabel,
       isBranchless,
       sessionId,
       setActiveLens,

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -111,14 +111,14 @@ parked beside it.
 - **The trail starts at `Overview`, and the session name is not a crumb.** The
   sidebar already carries the session identity, so repeating it in the trail
   spends a crumb on something the user is already looking at.
-- At most three crumbs. The last is the current location and is never
-  clickable. A list view never pre-populates a crumb for an item the user has
-  not opened yet.
+- The last crumb is the current location and is never clickable. A list view
+  never pre-populates a crumb for an item the user has not opened yet.
 - **An integration trail hangs off its own tool**, named as the sidebar names
   it (GitHub, GitLab, Jira, Linear, Sentry, Slack), at the same depth as any
   other lens: a studio belongs under its tool, never under another tool's lens.
-- **With an agent open the trail is replaced, never nested**:
-  `{HomeLens} > {Agent}`, at most two crumbs, never rooted at `Overview`.
+- **Opening a child extends the trail and preserves every ancestor**:
+  `Overview > {HomeLens} > {Agent}`. Selecting a sibling changes only the last
+  crumb and the child region. The lens shell remains mounted beneath it.
 - **The home lens is resolved, not inherited.** If the active lens hosts an
   agent list (`agents`, `resolve`, `workflows`) it wins; otherwise the agent's
   own home lens, falling back to `agents`. Standing in Agents with a
@@ -126,10 +126,10 @@ parked beside it.
   step cannot rename it out from under the user.
 - **A crumb with siblings is a switcher**: plain text when the agent is alone
   in its home lens, otherwise a popover that switches the open agent in place.
-- **The workflow case swaps the whole control**: `{WorkflowKind} > {Step}`,
-  plus a third crumb for implementer clusters (the child's name, or
-  `{done}/{total} clusters` when the root is selected). No separate step strip,
-  no "Part of {Workflow}" line.
+- **The workflow case extends the same control**:
+  `Overview > {WorkflowKind} > {Step}`, plus a fourth crumb for implementer
+  clusters (the child's name, or `{done}/{total} clusters` when the root is
+  selected). No separate step strip, no "Part of {Workflow}" line.
 
 ## Top bar
 


### PR DESCRIPTION
## Why

The owner, verbatim:

> Quando sono dentro ad Agents vedo `Overview > Agents`. Ma quando seleziono un agente vedo `Agents > SelectedAgent`. Mi sembra che cambiamo totalmente rotta, che il componente precedente venga smontato e ci venga montato sopra quello nuovo, perche' per un attimo la parte con overview sparisce e viene ridisegnata.

Two defects, and the second is the one that matters.

## What they were

**The trail truncated** because each lens built its own breadcrumb from its own root instead of extending one ladder. Selecting a child dropped the ancestor.

**The parent really was remounting.** The flash was not a repaint, the ancestor lens subtree was being torn down and rebuilt underneath the child. That is why Overview visibly disappeared and came back.

## What changed

The trail is one ladder that only ever grows deeper, rooted at Overview, and never drops an ancestor. `buildSessionBreadcrumb` now carries the selected child rather than each surface rebuilding its own trail.

The active lens subtree stays mounted while a child is open, held inert and non interactive beneath it, so selecting a child changes only the child's own space. Nothing else unmounts and no spinner appears over content that was already correct.

`docs/navigation.md` had a trail-replacement rule that described the old behaviour. It is replaced.

## Every lens, checked

| lens | before | after | remounts |
|---|---|---|---|
| Resolve | `Overview > Resolve` | `Overview > Resolve > SelectedAgent` | no |
| Questions | `Overview > Questions` | `Overview > Questions > child` | no |
| Diff | `Overview > Diff` | `Overview > Diff > child` | no |
| Plans | `Overview > Plans` | `Overview > Plans > plan` | no |
| Scripts, Terminal | `Overview > X` | no child detail | no |

Resolve got particular attention since a selection there can cross into GitHub and Diff.

## Verification

- `pnpm --filter @goodboy/desktop typecheck`
- full desktop suite, 671 files, 5826 tests, including a regression on the ladder and one proving a child selection does not unmount the ancestor

🤖 Generated with [Claude Code](https://claude.com/claude-code)
