### PR TITLE
refactor(ui): one place for actions, and nothing trims without a way out

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -176,6 +176,16 @@ in Status & signals.
 
 ## Components & interaction
 
+### Action zones
+
+Actions follow the object they affect and remain visible while its content scrolls.
+
+- The context row is the fixed breadcrumb or object-title row. Generic object actions such as open folder, archive, restore and delete sit at its far end. Lifecycle actions such as mark done and reopen join them because they change the object, not the current section. Destructive actions use the same zone and open `InlineConfirm` beside their trigger.
+- The primary action for the focused object sits in the fixed detail header. It answers what takes the object forward. A creation or edit flow instead commits through its single fixed footer primary action, with cancel and errors in that same footer.
+- Section actions affect only one section and use `SectionHeader`'s action slot. Row and card actions follow the card action grammar.
+
+An action row must not scroll away with content. Generic object actions do not belong at the bottom of a transcript, detail body or long form. A footer is not a second home for object actions.
+
 - **Tabs when you return, accordion when you'd forget.** Studio detail panels
   are tabs.
 - **Read inline, edit on a focused surface.** The transcript is for reading.

--- a/apps/desktop/src/features/session/components/AgentInspector/AgentHeaderActions.tsx
+++ b/apps/desktop/src/features/session/components/AgentInspector/AgentHeaderActions.tsx
@@ -1,10 +1,9 @@
 import { useState } from 'react';
 import { CircleCheck, CircleDot, OctagonX, Trash2 } from 'lucide-react';
-import { InlineConfirm, cn } from '@goodboy/ui';
+import { InlineConfirm } from '@goodboy/ui';
 import type { Agent, SessionId } from '@goodboy/types';
 import { useAppStore } from '../../../../store';
 import { GhostActionButton } from '@goodboy/ui';
-import { PANE_RHYTHM } from '@goodboy/ui';
 
 type Props = {
   readonly agent: Agent;
@@ -15,7 +14,7 @@ type Props = {
   readonly onDeleted?: () => void;
 };
 
-export const AgentActionsFooter = ({
+export const AgentHeaderActions = ({
   agent,
   sessionId,
   allowInterrupt = false,
@@ -37,7 +36,7 @@ export const AgentActionsFooter = ({
   };
 
   return (
-    <div className={cn('flex shrink-0 flex-col gap-2', PANE_RHYTHM.rail.dock)}>
+    <div className="flex shrink-0 flex-col items-end gap-2">
       <div className="flex flex-wrap items-center gap-1.5">
         {agent.doneAt == null ? (
           <GhostActionButton

--- a/apps/desktop/src/features/session/components/AgentInspector/ResolverThreadLead.tsx
+++ b/apps/desktop/src/features/session/components/AgentInspector/ResolverThreadLead.tsx
@@ -1,3 +1,4 @@
+import { ClampedProse } from '@goodboy/ui';
 import type { ResolverThreadBrief } from '../../resolverThreadBrief';
 
 type Props = {
@@ -18,7 +19,9 @@ export const ResolverThreadLead = ({ brief }: Props) => (
     )}
     <div className="flex min-w-0 gap-2">
       <dt className={ROW_LABEL_CLASS}>Verdict</dt>
-      <dd className={ROW_VALUE_CLASS}>{brief.verdict}</dd>
+      <dd className={ROW_VALUE_CLASS}>
+        <ClampedProse text={brief.verdict} lines={3} className="text-xs leading-relaxed" />
+      </dd>
     </div>
     <div className="flex min-w-0 gap-2">
       <dt className={ROW_LABEL_CLASS}>Next</dt>

--- a/apps/desktop/src/features/session/components/AgentInspector/index.test.tsx
+++ b/apps/desktop/src/features/session/components/AgentInspector/index.test.tsx
@@ -125,6 +125,11 @@ describe('AgentInspector', () => {
 
     expect(h.setAgentDone).toHaveBeenCalledWith(SESSION_ID, AGENT_ID);
     expect(h.cancelCurrentTurn).toHaveBeenCalledWith(SESSION_ID, AGENT_ID);
+    expect(
+      screen
+        .getByRole('button', { name: 'Mark done' })
+        .compareDocumentPosition(screen.getByText('Identity')),
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
   });
 
   it('reopens a done agent and hides interrupt when idle', () => {

--- a/apps/desktop/src/features/session/components/AgentInspector/index.tsx
+++ b/apps/desktop/src/features/session/components/AgentInspector/index.tsx
@@ -5,7 +5,7 @@ import { EMPTY_ARRAY, useAppStore } from '../../../../store';
 import { classifyAgent } from '../../agent-kind';
 import { useAgentMetrics } from '../../hooks/useAgentMetrics';
 import { InspectorHeader } from '../SessionWorkspace/parts/InspectorSplit/InspectorHeader';
-import { AgentActionsFooter } from './AgentActionsFooter';
+import { AgentHeaderActions } from './AgentHeaderActions';
 import { CostsSection } from './CostsSection';
 import { IdentitySection } from './IdentitySection';
 
@@ -43,7 +43,19 @@ export const AgentInspector = ({ sessionId, agentId, onClose }: Props) => {
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      <InspectorHeader title={agent.name} closeLabel="close agent inspector" onClose={onClose} />
+      <InspectorHeader
+        title={agent.name}
+        closeLabel="close agent inspector"
+        actions={
+          <AgentHeaderActions
+            agent={agent}
+            sessionId={sessionId}
+            allowInterrupt
+            onDeleted={onClose}
+          />
+        }
+        onClose={onClose}
+      />
       <ScrollFade className="min-h-0 flex-1" viewportClassName={PANE_RHYTHM.rail.body}>
         <div className="flex flex-col gap-4">
           <IdentitySection
@@ -61,8 +73,6 @@ export const AgentInspector = ({ sessionId, agentId, onClose }: Props) => {
           />
         </div>
       </ScrollFade>
-      <Divider />
-      <AgentActionsFooter agent={agent} sessionId={sessionId} allowInterrupt onDeleted={onClose} />
     </div>
   );
 };

--- a/apps/desktop/src/features/session/components/AgentInspector/resolver.test.tsx
+++ b/apps/desktop/src/features/session/components/AgentInspector/resolver.test.tsx
@@ -422,6 +422,24 @@ describe('ResolverDetailPane (resolver)', () => {
     expect(screen.queryByLabelText('Reply for thread 1')).toBeNull();
   });
 
+  it('reveals a long verdict in place', () => {
+    const reason = 'This verdict explains the unchanged path in enough detail to wrap. '.repeat(8);
+    reset({
+      resolverState: { [SETTLED_ID]: 'wontfix' },
+      outcomes: {
+        [SETTLED_ID]: {
+          PRRT_3: { kind: 'wontfix', reason, reply: 'Already guarded' },
+        },
+      },
+    });
+    renderPane(SETTLED_ID);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show more' }));
+
+    expect(screen.getByRole('button', { name: 'Show less' })).toBeDefined();
+    expect(screen.getByText(`No change needed: ${reason.trim()}`)).toBeDefined();
+  });
+
   it('gives every owned thread its own outcome, its own reply and its own action', () => {
     reset({
       settledThreadIds: ['PRRT_3', 'PRRT_4'],
@@ -735,15 +753,16 @@ describe('ResolverDetailPane (resolver)', () => {
     expect(screen.queryByRole('menuitem', { name: 'Mark done' })).toBeNull();
   });
 
-  it('puts mark done, reopen and delete in the footer at the bottom of the panel, not the header', () => {
+  it('puts mark done, reopen and delete in the fixed header', () => {
     renderPane(RUNNING_ID);
 
     expect(screen.getByRole('button', { name: 'Mark done' })).toBeDefined();
     expect(screen.getByRole('button', { name: 'Delete' })).toBeDefined();
     expect(screen.queryByRole('button', { name: 'Reopen' })).toBeNull();
+    expect(screen.queryByTestId('detail-dock')).toBeNull();
   });
 
-  it('marks a resolver done from the footer and deletes it after confirming', async () => {
+  it('marks a resolver done from the header and deletes it after confirming', async () => {
     renderPane(RUNNING_ID);
 
     fireEvent.click(screen.getByRole('button', { name: 'Mark done' }));

--- a/apps/desktop/src/features/session/components/ResolverDetailPane/index.tsx
+++ b/apps/desktop/src/features/session/components/ResolverDetailPane/index.tsx
@@ -17,7 +17,7 @@ import { resolverCommitSha } from '../../resolverCommitSha';
 import { resolverThreadCommitShas } from '../../resolverThreadCommitShas';
 import { resolverTallySentence } from '../../resolverTallySentence';
 import { agentThreadIds } from '../../agentThreadIds';
-import { AgentActionsFooter } from '../AgentInspector/AgentActionsFooter';
+import { AgentHeaderActions } from '../AgentInspector/AgentHeaderActions';
 import { ChangesSection } from '../AgentInspector/ChangesSection';
 import {
   ResolverCommentSection,
@@ -217,23 +217,33 @@ export const ResolverDetailPane = ({ session, agent, isChatActive, onBack }: Pro
             )
           }
           actions={
-            <ResolverOverflowMenu
-              agent={agent}
-              actions={actions}
-              commits={localCommits}
-              headSha={changes.headSha}
-              onAmend={async (sha, message) => {
-                await amendSessionCommit(sessionId, { sha, message });
-                changes.reload();
-              }}
-              onSquash={async (sha, message) => {
-                await squashSessionCommits(sessionId, { sha, message });
-                changes.reload();
-              }}
-            />
+            <div className="flex items-start gap-2">
+              <AgentHeaderActions
+                agent={agent}
+                sessionId={sessionId}
+                deleteTitle="Delete this resolver?"
+                deleteDescription="Removes the agent and its transcript from the session."
+                onDeleted={onBack}
+              />
+              <ResolverOverflowMenu
+                agent={agent}
+                actions={actions}
+                commits={localCommits}
+                headSha={changes.headSha}
+                onAmend={async (sha, message) => {
+                  await amendSessionCommit(sessionId, { sha, message });
+                  changes.reload();
+                }}
+                onSquash={async (sha, message) => {
+                  await squashSessionCommits(sessionId, { sha, message });
+                  changes.reload();
+                }}
+              />
+            </div>
           }
         />
       }
+      rail={<ResolverRunRecap tally={actions.tally} blockedBy={blockedBy} actions={actions} />}
       tabs={
         <StudioDetailTabs
           ariaLabel="Resolver sections"
@@ -242,21 +252,11 @@ export const ResolverDetailPane = ({ session, agent, isChatActive, onBack }: Pro
           onChange={setTab}
         />
       }
-      dock={
-        <AgentActionsFooter
-          agent={agent}
-          sessionId={sessionId}
-          deleteTitle="Delete this resolver?"
-          deleteDescription="Removes the agent and its transcript from the session."
-          onDeleted={onBack}
-        />
-      }
     >
       {tab === 'transcript' ? (
         <ChatView session={session} isActive={isChatActive} header={null} />
       ) : (
         <>
-          <ResolverRunRecap tally={actions.tally} blockedBy={blockedBy} actions={actions} />
           <ResolverMetaLine
             agent={agent}
             model={

--- a/apps/desktop/src/features/session/resolverThreadBrief.test.ts
+++ b/apps/desktop/src/features/session/resolverThreadBrief.test.ts
@@ -23,7 +23,7 @@ describe('resolverThreadBrief', () => {
     });
 
     expect(brief.ask).toBe('Add a guard clause here.');
-    expect(brief.verdict).toBe('No change needed: The branch is unreachable.');
+    expect(brief.verdict).toBe('No change needed: The branch is unreachable. Details.');
     expect(brief.next).toContain('not worth a change');
   });
 

--- a/apps/desktop/src/features/session/resolverThreadBrief.ts
+++ b/apps/desktop/src/features/session/resolverThreadBrief.ts
@@ -1,5 +1,6 @@
 import { resolverReplySummary } from './resolverReplySummary';
 import { resolverThreadDecisions } from './resolverThreadDecisions';
+import { markdownPreview } from '../../shared/utils/markdownPreview';
 import type {
   ResolverThreadSettlement,
   ResolverThreadSettlementKind,
@@ -31,7 +32,7 @@ export const resolverThreadBrief = ({
   prNumber,
   isBusy,
 }: Params): ResolverThreadBrief => {
-  const detail = resolverReplySummary({ text: settlement.reason ?? settlement.reply ?? '' });
+  const detail = markdownPreview({ text: settlement.reason ?? settlement.reply ?? '' });
   const lead = VERDICT_LEAD[settlement.kind];
 
   return {

--- a/packages/ui/DESIGN-SYSTEM.md
+++ b/packages/ui/DESIGN-SYSTEM.md
@@ -121,6 +121,26 @@ where an uncapped paragraph runs past a comfortable measure.
 applied conditionally: the workbench goes full width, its empty state stays in
 the reading column, so an empty pane never presents a 2000px-wide dashed box.
 
+## Action zones
+
+The fixed chrome row uses one flexible context region followed by one shrink-safe action region. `StudioShell` exposes that region as `headerAccessory`, `HeaderBand` exposes it as `actions`, and inspector headers use the same `actions` slot. Generic object, lifecycle and destructive controls go there. The action region is pushed to the far end and never enters the content scroller.
+
+The focused object's primary action uses the same fixed header action region. The one exception is a creation or edit flow: its commit action uses one fixed footer, with supporting error copy at the start and cancel plus exactly one primary action at the end. A section-scoped action uses `SectionHeader.action`; a field control uses `FieldRow`; neither promotes itself into global chrome.
+
+`InlineConfirm` stays attached to a destructive trigger in its action region. A detached confirmation in the body or a destructive footer dock is not another zone.
+
+## Section rhythm
+
+`PANE_RHYTHM.stack` separates peer sections and `Divider` separates regions whose boundary matters. Section children do not add margins. `SectionHeader` is the canonical section heading and optional description: its default eyebrow size is for compact and scan surfaces, while `size="page"` is for a reading-surface section that needs an `h2`. Description copy comes only through `hint`, so its size and muted tone remain paired with the heading grade.
+
+`Eyebrow` is a label primitive for metadata, statistics and small internal groups. It does not replace `SectionHeader` when a section also needs an action or description. `FieldRow` owns a form field's label, help copy and control alignment; it does not title a section. When these roles overlap, `SectionHeader` wins for the section, then `FieldRow` labels the controls inside it. `Divider` is a sibling between regions, never decoration after every heading or field.
+
+## Prose disclosure
+
+`ClampedProse` is the only multi-line prose clamp. It accepts one to six lines, renders the text as preview markdown and reveals the complete text in place through Show more and Show less. Do not apply `line-clamp-*` directly to prose or slice a display string. Single-line identity labels may use `truncate` when their full value is available from the focused object or an accessible disclosure.
+
+Artifacts exempted by `DESIGN.md`, including the text of an open question, never use `ClampedProse`.
+
 ## Card action grammar and creation grammar
 
 **One card action grammar.** Two stable slots: navigation top right, always


### PR DESCRIPTION
## Why

The owner, on the resolve page, but he meant the whole app:

> le azioni mark done e delete sono in basso, se entro nella transcription sono sotto la chat, ma che senso ha? Il testo di Verdict e' trimmato, ma perche' le robe trimmate non hanno una CTA mostra di piu'? Le informazioni sono suddivise in maniera errata sullo schermo, occupando tantissimo spazio verticale e facendo sembrare l'app cheap, dato che hanno dimensioni copy colori etc molto casuali. Tutte le sezioni, titoli CTA descrizioni ordine pulizia divider, devono essere allineate. Questo non vuol dire avere le stesse azioni, ma averle strutturate in un punto comune.

This is the foundation branch. It writes the rule and provides the primitives; sibling branches move the remaining surfaces onto it.

## What changed

**Action zones are named in `DESIGN-SYSTEM.md`**, with the owner's own call encoded: generic object actions live on the breadcrumb row, pushed to the far end, not stranded at the bottom of a scroll. The rule also fixes where the primary action for the thing on screen lives, where destructive actions go, and what is forbidden, notably an action row that scrolls away with its content.

**One disclosure primitive for clamped prose.** Nothing is trimmed without a way to see the rest. The open question keeps its documented exemption: its text is never clamped, because a truncated question cannot be answered.

**Rhythm.** The canonical section header, its description, the divider treatment and the spacing between sections are settled, using what `SectionHeader`, `Eyebrow`, `FieldRow` and `Divider` already provide, with a ruling where two of them competed.

Migrated as proof: the **agent inspector** and the **resolver detail**, which is the surface the complaint came from. `AgentActionsFooter` is gone, replaced by header actions in the zone the rule names.

## The handoff

A written rule the code contradicts is worse than no rule, so the surfaces not yet migrated are listed rather than left silently non-compliant. Still owed, grouped by what they need:

- **Rhythm**: `PlanStudio` focused detail header, resolver Comment/Thread/Changes via `ResolverPanelSection`, agent inspector spacing between Identity and Cost, GitHub PR action bar and `SectionBody`, GitHub Resolve board cards, integration issue detail surfaces.
- **Truncation**: `WorkflowStepCard`, `WorkflowRailCard`, workflow preset and library cards, `resolverReplySummary`, `TurnErrorCallout`, `PermissionRequestCard/formatRequestInput`.
- **Already compliant, do not re-migrate**: `GitHubStudio/ThreadBody`, `ResolverThreadComment`, the session overview goal, `ToolCallCard/CollapsibleString`, `ReportIssueStudio`, `StudioShell`.

Title and identity clamps in `RailCard`, workflow step rows, the activity bar, the plan-ready suggestion and the stage-board card were found but deliberately not auto-migrated: they need an accessibility judgement, not a prose disclosure.

Display-time slices that build goals, slugs, prompts, bounded logs, diffs, crash reports or stored titles were inventoried and left alone. Those are data budgets, not hidden UI prose.

## Verification

- `pnpm --filter @goodboy/ui typecheck`, `pnpm --filter @goodboy/desktop typecheck`
- full desktop suite, 671 files, 5825 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
