### PR TITLE
refactor(desktop): the studio stops strobing and its actions settle

### DIFF
--- a/apps/desktop/src/features/workflows/components/LibraryCard/index.test.tsx
+++ b/apps/desktop/src/features/workflows/components/LibraryCard/index.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { IsoDateTime, StepDef, StepDefId, WorkspaceId } from '@goodboy/types';
+import { LibraryCard } from './index';
+
+afterEach(cleanup);
+
+const NOW = '2026-08-17T00:00:00.000Z' as IsoDateTime;
+
+const step = {
+  id: 'step-1' as StepDefId,
+  workspaceId: 'ws-1' as WorkspaceId,
+  role: 'planner',
+  name: 'Plan the change',
+  promptPrefix: 'Write a plan',
+  createdAt: NOW,
+  updatedAt: NOW,
+} satisfies StepDef;
+
+describe('LibraryCard', () => {
+  it('adds a library step without requiring drag and drop', () => {
+    const onAdd = vi.fn();
+    render(
+      <ul>
+        <LibraryCard
+          def={step}
+          dragDisabled={false}
+          onStartDrag={vi.fn()}
+          onAdd={onAdd}
+          onEdit={vi.fn()}
+          onDelete={vi.fn()}
+        />
+      </ul>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add Plan the change to workflow' }));
+
+    expect(onAdd).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/desktop/src/features/workflows/components/LibraryCard/index.tsx
+++ b/apps/desktop/src/features/workflows/components/LibraryCard/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Tooltip, cn } from '@goodboy/ui';
-import { Check, GripVertical, Pencil, Trash2, X } from 'lucide-react';
+import { Check, GripVertical, Pencil, Plus, Trash2, X } from 'lucide-react';
 import type { StepDef } from '@goodboy/types';
 import { agentKindPalette, ROLE_LABEL, ROLE_TO_KIND } from '../../../session/agent-kind';
 import { AgentAvatar } from '../../../../shared/components/AgentAvatar';
@@ -9,11 +9,12 @@ type Props = {
   readonly def: StepDef;
   readonly dragDisabled: boolean;
   readonly onStartDrag: (def: StepDef, e: React.PointerEvent) => void;
+  readonly onAdd: () => void;
   readonly onEdit: () => void;
   readonly onDelete: () => void;
 };
 
-export const LibraryCard = ({ def, dragDisabled, onStartDrag, onEdit, onDelete }: Props) => {
+export const LibraryCard = ({ def, dragDisabled, onStartDrag, onAdd, onEdit, onDelete }: Props) => {
   const [confirming, setConfirming] = useState(false);
   const kind = ROLE_TO_KIND[def.role] ?? 'generic';
   const isGlobal = def.workspaceId === null;
@@ -36,7 +37,7 @@ export const LibraryCard = ({ def, dragDisabled, onStartDrag, onEdit, onDelete }
         aria-hidden
       />
       <AgentAvatar kind={kind} size="sm" />
-      <div className="flex min-w-0 flex-1 flex-col gap-0.5 pr-14">
+      <div className="flex min-w-0 flex-1 flex-col gap-0.5 pr-20">
         <div className="flex items-baseline gap-2">
           <span className="truncate text-xs font-medium text-foreground">{def.name}</span>
           <span className={cn('shrink-0 text-2xs font-medium', agentKindPalette({ kind }).fg)}>
@@ -56,6 +57,17 @@ export const LibraryCard = ({ def, dragDisabled, onStartDrag, onEdit, onDelete }
             global
           </span>
         ) : null}
+        <Tooltip content="add to workflow">
+          <button
+            type="button"
+            onPointerDown={(e) => e.stopPropagation()}
+            onClick={onAdd}
+            aria-label={`Add ${def.name} to workflow`}
+            className="rounded-md p-1 text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] motion-safe:transition-colors hover:bg-muted/50 hover:text-foreground"
+          >
+            <Plus size={12} aria-hidden />
+          </button>
+        </Tooltip>
         {confirming ? (
           <div
             className="flex items-center gap-0.5 rounded-md border border-border bg-background/95 px-1 py-0.5 shadow-sm"

--- a/apps/desktop/src/features/workflows/components/PresetCard/index.test.tsx
+++ b/apps/desktop/src/features/workflows/components/PresetCard/index.test.tsx
@@ -23,34 +23,23 @@ const workflow = (over: Partial<Workflow> = {}): Workflow => ({
 const renderCard = (template: Workflow) =>
   render(
     <ul>
-      <PresetCard
-        template={template}
-        active={false}
-        onSelect={vi.fn()}
-        onDuplicate={vi.fn()}
-        onDelete={vi.fn()}
-      />
+      <PresetCard template={template} active={false} onSelect={vi.fn()} />
     </ul>,
   );
 
 describe('PresetCard', () => {
-  it('duplicates from the row action', () => {
-    const onDuplicate = vi.fn();
+  it('uses the row only to open a workflow', () => {
+    const onSelect = vi.fn();
     render(
       <ul>
-        <PresetCard
-          template={workflow()}
-          active={false}
-          onSelect={vi.fn()}
-          onDuplicate={onDuplicate}
-          onDelete={vi.fn()}
-        />
+        <PresetCard template={workflow()} active={false} onSelect={onSelect} />
       </ul>,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Duplicate Refactor' }));
+    fireEvent.click(screen.getByRole('button', { name: /Refactor/ }));
 
-    expect(onDuplicate).toHaveBeenCalledOnce();
+    expect(onSelect).toHaveBeenCalledOnce();
+    expect(screen.queryByRole('button', { name: 'Duplicate Refactor' })).toBeNull();
   });
 
   it('names the origin of the workflow', () => {

--- a/apps/desktop/src/features/workflows/components/PresetCard/index.tsx
+++ b/apps/desktop/src/features/workflows/components/PresetCard/index.tsx
@@ -1,6 +1,4 @@
-import { useState } from 'react';
 import { SelectableRow } from '@goodboy/ui';
-import { Check, Copy, Trash2, X } from 'lucide-react';
 import type { Workflow } from '@goodboy/types';
 import { inferAgentKindFromName, ROLE_TO_KIND } from '../../../session/agent-kind';
 import { AgentAvatar } from '../../../../shared/components/AgentAvatar';
@@ -10,16 +8,13 @@ type Props = {
   readonly template: Workflow;
   readonly active: boolean;
   readonly onSelect: () => void;
-  readonly onDuplicate: () => void;
-  readonly onDelete: () => void;
 };
 
-export const PresetCard = ({ template, active, onSelect, onDuplicate, onDelete }: Props) => {
-  const [confirming, setConfirming] = useState(false);
+export const PresetCard = ({ template, active, onSelect }: Props) => {
   const steps = [...template.steps].sort((a, b) => a.ordinal - b.ordinal);
   const description = template.description?.trim();
   return (
-    <li className="group relative">
+    <li>
       <SelectableRow
         selected={active}
         ariaCurrent={active}
@@ -47,61 +42,6 @@ export const PresetCard = ({ template, active, onSelect, onDuplicate, onDelete }
           </span>
         ) : null}
       </SelectableRow>
-      {confirming ? (
-        <div className="absolute right-1.5 top-1.5 flex items-center gap-0.5 rounded-md border border-border bg-background/95 px-1 py-0.5 shadow-sm backdrop-blur-sm">
-          <span className="px-1 text-2xs text-muted-foreground">Delete?</span>
-          <button
-            type="button"
-            onClick={(e) => {
-              e.stopPropagation();
-              setConfirming(false);
-              onDelete();
-            }}
-            title="Confirm delete"
-            aria-label={`Confirm delete ${template.name}`}
-            className="rounded-md p-0.5 text-danger focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] motion-safe:transition-colors hover:bg-danger/10"
-          >
-            <Check size={12} aria-hidden />
-          </button>
-          <button
-            type="button"
-            onClick={(e) => {
-              e.stopPropagation();
-              setConfirming(false);
-            }}
-            title="Cancel delete"
-            aria-label="Cancel delete"
-            className="rounded-md p-0.5 text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] motion-safe:transition-colors hover:bg-muted/50 hover:text-foreground"
-          >
-            <X size={12} aria-hidden />
-          </button>
-        </div>
-      ) : (
-        <div className="absolute right-1.5 top-1.5 flex items-center gap-0.5 text-muted-foreground/0 group-focus-within:text-muted-foreground group-hover:text-muted-foreground">
-          <button
-            type="button"
-            onClick={(event) => {
-              event.stopPropagation();
-              onDuplicate();
-            }}
-            aria-label={`Duplicate ${template.name}`}
-            className="rounded-md p-1 focus-visible:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] motion-safe:transition-colors hover:bg-muted/50 hover:!text-foreground"
-          >
-            <Copy size={12} aria-hidden />
-          </button>
-          <button
-            type="button"
-            onClick={(event) => {
-              event.stopPropagation();
-              setConfirming(true);
-            }}
-            aria-label={`Delete ${template.name}`}
-            className="rounded-md p-1 focus-visible:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] motion-safe:transition-colors hover:bg-danger/10 hover:!text-danger"
-          >
-            <Trash2 size={12} aria-hidden />
-          </button>
-        </div>
-      )}
     </li>
   );
 };

--- a/apps/desktop/src/features/workflows/components/WorkflowStudio/StepLibraryPalette/index.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowStudio/StepLibraryPalette/index.tsx
@@ -12,6 +12,7 @@ type Props = {
   readonly workspaceId: WorkspaceId;
   readonly connectedProviders: ReadonlyArray<ProviderId>;
   readonly onStartDrag: (def: StepDef, e: React.PointerEvent) => void;
+  readonly onAdd: (def: StepDef) => void;
   readonly onSaveDef: (args: StepDefUpsertArgs) => void;
   readonly onDeleteDef: (id: StepDefId) => void;
 };
@@ -21,6 +22,7 @@ export const StepLibraryPalette = ({
   workspaceId,
   connectedProviders,
   onStartDrag,
+  onAdd,
   onSaveDef,
   onDeleteDef,
 }: Props) => {
@@ -50,8 +52,6 @@ export const StepLibraryPalette = ({
           connectedProviders={connectedProviders}
           onCommit={(args) => {
             onSaveDef(args);
-            // A new step persists on its first valid commit; close so repeated
-            // blurs don't insert duplicates. It reappears in the list to re-edit.
             setEditing(null);
           }}
           onClose={() => setEditing(null)}
@@ -92,6 +92,7 @@ export const StepLibraryPalette = ({
                 def={def}
                 dragDisabled={false}
                 onStartDrag={onStartDrag}
+                onAdd={() => onAdd(def)}
                 onEdit={() => setEditing(def.id)}
                 onDelete={() => onDeleteDef(def.id)}
               />

--- a/apps/desktop/src/features/workflows/components/WorkflowStudio/WorkflowComposer/WorkflowHeaderActions.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowStudio/WorkflowComposer/WorkflowHeaderActions.tsx
@@ -1,0 +1,93 @@
+import { useState } from 'react';
+import { ArrowLeft, Copy, RotateCcw, Trash2 } from 'lucide-react';
+import { Button, GhostActionButton, InlineConfirm } from '@goodboy/ui';
+import { CONCEPT_ICONS } from '../../../../../shared/components/conceptIcons';
+
+type Props = {
+  readonly isNew: boolean;
+  readonly saving: boolean;
+  readonly generating: boolean;
+  readonly canGenerate: boolean;
+  readonly onDuplicate: () => void;
+  readonly onDelete: () => void;
+  readonly onGenerate: () => void;
+  readonly onReset: () => void;
+  readonly onBack: () => void;
+};
+
+export const WorkflowHeaderActions = ({
+  isNew,
+  saving,
+  generating,
+  canGenerate,
+  onDuplicate,
+  onDelete,
+  onGenerate,
+  onReset,
+  onBack,
+}: Props) => {
+  const [confirmation, setConfirmation] = useState<'delete' | 'reset' | null>(null);
+
+  return (
+    <div className="flex shrink-0 flex-col items-end gap-2">
+      <div className="flex flex-wrap items-center justify-end gap-1.5">
+        <GhostActionButton icon={ArrowLeft} label="All workflows" onClick={onBack} />
+        <GhostActionButton
+          icon={Copy}
+          label="Duplicate"
+          disabled={saving || isNew}
+          onClick={onDuplicate}
+        />
+        <GhostActionButton
+          icon={RotateCcw}
+          label="Reset"
+          disabled={saving}
+          onClick={() => setConfirmation('reset')}
+        />
+        <GhostActionButton
+          icon={Trash2}
+          label={isNew ? 'Discard' : 'Delete'}
+          tone="danger"
+          disabled={saving}
+          onClick={() => setConfirmation('delete')}
+        />
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={onGenerate}
+          disabled={saving || generating || !canGenerate}
+        >
+          <CONCEPT_ICONS.enhance size={13} aria-hidden />
+          {generating ? 'Working on your workflow' : 'Rewrite with agent'}
+        </Button>
+      </div>
+
+      {confirmation === 'reset' ? (
+        <InlineConfirm
+          role="alert"
+          icon={<RotateCcw size={12} aria-hidden />}
+          title="Discard local changes?"
+          description="Restores the last saved version of this workflow."
+          confirmLabel="Reset"
+          onConfirm={onReset}
+          onCancel={() => setConfirmation(null)}
+        />
+      ) : null}
+      {confirmation === 'delete' ? (
+        <InlineConfirm
+          role="danger"
+          icon={<Trash2 size={12} aria-hidden />}
+          title={isNew ? 'Discard this draft?' : 'Delete this workflow?'}
+          description={
+            isNew
+              ? 'Removes the local draft from this workspace.'
+              : 'Removes this workflow from the preset list.'
+          }
+          confirmLabel={isNew ? 'Discard' : 'Delete'}
+          onConfirm={onDelete}
+          onCancel={() => setConfirmation(null)}
+        />
+      ) : null}
+    </div>
+  );
+};

--- a/apps/desktop/src/features/workflows/components/WorkflowStudio/WorkflowComposer/index.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowStudio/WorkflowComposer/index.tsx
@@ -1,6 +1,6 @@
-import { Fragment } from 'react';
-import { Button, Divider, Input, SectionHeader, ScrollFade } from '@goodboy/ui';
-import { Check, Copy, Plus, RotateCcw, Trash2, X } from 'lucide-react';
+import { Fragment, useState } from 'react';
+import { Divider, Input, SectionHeader, ScrollFade } from '@goodboy/ui';
+import { Library, Plus, X } from 'lucide-react';
 import { recommendedModelForRole } from '@goodboy/core';
 import type { ProviderId, StepDef, StepDefId, WorkspaceId } from '@goodboy/types';
 import type { StepDefUpsertArgs } from '../../../workflows';
@@ -11,7 +11,7 @@ import { WorkflowStepCard } from '../../../../session/components/WorkflowStepCar
 import { StepFlowConnector } from '../StepFlowConnector';
 import { StepLibraryPalette } from '../StepLibraryPalette';
 import { useAppStore } from '../../../../../store';
-import { CONCEPT_ICONS } from '../../../../../shared/components/conceptIcons';
+import { WorkflowHeaderActions } from './WorkflowHeaderActions';
 
 type Props = {
   readonly form: TemplateForm;
@@ -23,10 +23,9 @@ type Props = {
   readonly error: string | null;
   readonly dragging: boolean;
   readonly dropIndex: number | null;
-  readonly confirmingReset: boolean;
+  readonly isNew: boolean;
   readonly generating: boolean;
   readonly canGenerate: boolean;
-  readonly onConfirmingReset: (value: boolean) => void;
   readonly onChangeMeta: (
     patch: Partial<Pick<TemplateForm, 'name' | 'description' | 'goal'>>,
   ) => void;
@@ -37,6 +36,7 @@ type Props = {
   readonly onMoveStep: (idx: number, dir: -1 | 1) => void;
   readonly draggingStepIdx: number | null;
   readonly onStartDrag: (def: StepDef, e: React.PointerEvent) => void;
+  readonly onAddLibraryStep: (def: StepDef) => void;
   readonly onStartStepDrag: (fromIndex: number, label: string, e: React.PointerEvent) => void;
   readonly onSaveDef: (args: StepDefUpsertArgs) => void;
   readonly onDeleteDef: (id: StepDefId) => void;
@@ -57,10 +57,9 @@ export const WorkflowComposer = ({
   error,
   dragging,
   dropIndex,
-  confirmingReset,
+  isNew,
   generating,
   canGenerate,
-  onConfirmingReset,
   onChangeMeta,
   onAddBlank,
   onToggleExpand,
@@ -69,6 +68,7 @@ export const WorkflowComposer = ({
   onMoveStep,
   draggingStepIdx,
   onStartDrag,
+  onAddLibraryStep,
   onStartStepDrag,
   onSaveDef,
   onDeleteDef,
@@ -80,7 +80,7 @@ export const WorkflowComposer = ({
 }: Props) => {
   const roleModels = useAppStore((s) => s.workspaceOverrides?.[workspaceId]?.roleModels ?? null);
   const stepCount = form.steps.length;
-  const savedHint = saving ? 'Saving…' : 'Saved';
+  const [isLibraryOpen, setIsLibraryOpen] = useState(false);
 
   const defaultProvider: ProviderId =
     connectedProviders.length > 0 ? (connectedProviders[0] as ProviderId) : 'anthropic';
@@ -119,68 +119,24 @@ export const WorkflowComposer = ({
               aria-label="Workflow description"
               className="border-transparent bg-transparent px-0 text-xs text-muted-foreground shadow-none hover:border-border-soft focus:border-border"
             />
+            <span className="text-2xs text-muted-foreground/60">Changes save automatically</span>
             {error !== null ? (
-              <span className="text-2xs font-medium text-danger">{error}</span>
+              <span className="text-2xs font-medium text-danger" role="alert">
+                {error}
+              </span>
             ) : null}
           </div>
-          <div className="flex shrink-0 items-center gap-2">
-            <span
-              className="text-2xs text-muted-foreground/60 tabular-nums"
-              aria-live="polite"
-              role="status"
-            >
-              {savedHint}
-            </span>
-            <Button
-              variant="primary"
-              size="sm"
-              onClick={onGenerate}
-              disabled={saving || generating || !canGenerate}
-            >
-              <CONCEPT_ICONS.enhance size={13} aria-hidden />
-              {generating ? 'Working on your workflow' : 'Rewrite with agent'}
-            </Button>
-            <Button variant="ghost" size="sm" onClick={onDuplicate} disabled={saving}>
-              <Copy size={13} aria-hidden /> Duplicate
-            </Button>
-            <Button variant="ghost" size="sm" onClick={onDelete} disabled={saving}>
-              <Trash2 size={13} aria-hidden /> Delete
-            </Button>
-            {confirmingReset ? (
-              <div className="flex items-center gap-2 rounded-md bg-warning/5 px-2 py-1">
-                <span className="text-2xs text-muted-foreground">Discard local changes?</span>
-                <button
-                  type="button"
-                  aria-label="Confirm reset workflow"
-                  onClick={onReset}
-                  className="rounded-md p-1 text-warning focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
-                >
-                  <Check size={12} aria-hidden />
-                </button>
-                <button
-                  type="button"
-                  aria-label="Cancel reset workflow"
-                  onClick={() => onConfirmingReset(false)}
-                  className="rounded-md p-1 text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
-                >
-                  <X size={12} aria-hidden />
-                </button>
-              </div>
-            ) : (
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => onConfirmingReset(true)}
-                disabled={saving}
-              >
-                <RotateCcw size={13} aria-hidden /> Reset
-              </Button>
-            )}
-            <Button variant="ghost" size="sm" onClick={onClose} aria-label="Close workflow editor">
-              <X size={13} aria-hidden />
-              Close
-            </Button>
-          </div>
+          <WorkflowHeaderActions
+            isNew={isNew}
+            saving={saving}
+            generating={generating}
+            canGenerate={canGenerate}
+            onDuplicate={onDuplicate}
+            onDelete={onDelete}
+            onGenerate={onGenerate}
+            onReset={onReset}
+            onBack={onClose}
+          />
         </div>
 
         <Divider />
@@ -203,13 +159,28 @@ export const WorkflowComposer = ({
                   : 'Runs top to bottom, in order. Add a blank step or drag one in from the library.'
               }
               action={
-                <button
-                  type="button"
-                  className="inline-flex items-center gap-1 rounded-md border border-border-soft px-2 py-1 text-2xs font-medium text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] motion-safe:transition-colors hover:border-border hover:bg-muted/40 hover:text-foreground"
-                  onClick={onAddBlank}
-                >
-                  <Plus size={11} aria-hidden /> blank step
-                </button>
+                <div className="flex items-center gap-1.5">
+                  <button
+                    type="button"
+                    aria-expanded={isLibraryOpen}
+                    onClick={() => setIsLibraryOpen((current) => !current)}
+                    className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-2xs font-medium text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] motion-safe:transition-colors hover:bg-muted/40 hover:text-foreground"
+                  >
+                    {isLibraryOpen ? (
+                      <X size={11} aria-hidden />
+                    ) : (
+                      <Library size={11} aria-hidden />
+                    )}
+                    {isLibraryOpen ? 'Close library' : 'Step library'}
+                  </button>
+                  <button
+                    type="button"
+                    className="inline-flex items-center gap-1 rounded-md border border-border-soft px-2 py-1 text-2xs font-medium text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] motion-safe:transition-colors hover:border-border hover:bg-muted/40 hover:text-foreground"
+                    onClick={onAddBlank}
+                  >
+                    <Plus size={11} aria-hidden /> Add blank step
+                  </button>
+                </div>
               }
             />
           </div>
@@ -283,20 +254,23 @@ export const WorkflowComposer = ({
         </div>
       </section>
 
-      <Divider orientation="vertical" />
+      {isLibraryOpen ? <Divider orientation="vertical" /> : null}
 
-      <aside className="flex w-64 shrink-0 flex-col">
-        <ScrollFade className="min-h-0 flex-1" viewportClassName="px-3 py-4" fadeSize={24}>
-          <StepLibraryPalette
-            library={library}
-            workspaceId={workspaceId}
-            connectedProviders={connectedProviders}
-            onStartDrag={onStartDrag}
-            onSaveDef={onSaveDef}
-            onDeleteDef={onDeleteDef}
-          />
-        </ScrollFade>
-      </aside>
+      {isLibraryOpen ? (
+        <aside className="flex w-72 shrink-0 flex-col">
+          <ScrollFade className="min-h-0 flex-1" viewportClassName="px-3 py-4" fadeSize={24}>
+            <StepLibraryPalette
+              library={library}
+              workspaceId={workspaceId}
+              connectedProviders={connectedProviders}
+              onStartDrag={onStartDrag}
+              onAdd={onAddLibraryStep}
+              onSaveDef={onSaveDef}
+              onDeleteDef={onDeleteDef}
+            />
+          </ScrollFade>
+        </aside>
+      ) : null}
     </div>
   );
 };

--- a/apps/desktop/src/features/workflows/components/WorkflowStudio/WorkflowsRail/index.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowStudio/WorkflowsRail/index.tsx
@@ -12,8 +12,6 @@ type Props = {
   readonly setConfirmReset: (value: boolean) => void;
   readonly onSelect: (t: Workflow) => void;
   readonly onNew: () => void;
-  readonly onDuplicate: (t: Workflow) => void;
-  readonly onDelete: (t: Workflow) => void;
   readonly onReset: () => void;
 };
 
@@ -25,8 +23,6 @@ export const WorkflowsRail = ({
   setConfirmReset,
   onSelect,
   onNew,
-  onDuplicate,
-  onDelete,
   onReset,
 }: Props) => {
   return (
@@ -65,8 +61,6 @@ export const WorkflowsRail = ({
                 template={t}
                 active={t.id === activeId}
                 onSelect={() => onSelect(t)}
-                onDuplicate={() => onDuplicate(t)}
-                onDelete={() => onDelete(t)}
               />
             ))}
           </ul>

--- a/apps/desktop/src/features/workflows/components/WorkflowsPanel/index.test.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowsPanel/index.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 
 const { state } = vi.hoisted(() => ({
   state: {
@@ -162,7 +162,8 @@ describe('WorkflowsPanel', () => {
     }));
     renderPanel();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Duplicate Plan and build' }));
+    fireEvent.click(screen.getByRole('button', { name: /Plan and build/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'Duplicate' }));
 
     await waitFor(() => expect(state.savePhaseTemplate).toHaveBeenCalledOnce());
     const input = state.savePhaseTemplate.mock.calls[0]?.[0];
@@ -202,9 +203,52 @@ describe('WorkflowsPanel', () => {
     }) as HTMLInputElement;
     expect(description.value).toBe('Half typed description');
     fireEvent.click(screen.getByRole('button', { name: 'Reset' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Confirm reset workflow' }));
+    fireEvent.click(
+      within(screen.getByRole('group', { name: 'Discard local changes?' })).getByRole('button', {
+        name: 'Reset',
+      }),
+    );
 
     expect(state.clearWorkflowStudioDraft).toHaveBeenCalledWith({ workspaceId: 'ws-1' });
     expect(screen.getByRole('heading', { name: 'Build a workflow' })).toBeDefined();
+  });
+
+  it('never reports saved while an autosave write is outstanding', async () => {
+    let finishSave: (workflow: unknown) => void = vi.fn();
+    state.phaseTemplates = { 'ws-1': [makeWorkflow({ name: 'Plan and build' })] };
+    state.savePhaseTemplate = vi.fn(
+      async () =>
+        await new Promise<unknown>((resolve) => {
+          finishSave = resolve;
+        }),
+    );
+    renderPanel();
+
+    fireEvent.click(screen.getByRole('button', { name: /Plan and build/ }));
+    fireEvent.change(screen.getByRole('textbox', { name: 'Workflow name' }), {
+      target: { value: 'Plan, build, review' },
+    });
+
+    await waitFor(() => expect(state.savePhaseTemplate).toHaveBeenCalledOnce(), { timeout: 2_000 });
+    expect(screen.queryByText('Saved')).toBeNull();
+    expect(screen.getByText('Changes save automatically')).toBeDefined();
+
+    finishSave(makeWorkflow({ name: 'Plan, build, review' }));
+  });
+
+  it('keeps an autosave failure visible in the editor header', async () => {
+    state.phaseTemplates = { 'ws-1': [makeWorkflow({ name: 'Plan and build' })] };
+    state.savePhaseTemplate = vi.fn(async () => {
+      throw new Error('disk is read-only');
+    });
+    renderPanel();
+
+    fireEvent.click(screen.getByRole('button', { name: /Plan and build/ }));
+    fireEvent.change(screen.getByRole('textbox', { name: 'Workflow name' }), {
+      target: { value: 'Plan, build, review' },
+    });
+
+    const alert = await screen.findByRole('alert', {}, { timeout: 2_000 });
+    expect(alert.textContent).toContain('disk is read-only');
   });
 });

--- a/apps/desktop/src/features/workflows/components/WorkflowsPanel/index.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowsPanel/index.tsx
@@ -93,11 +93,11 @@ export const WorkflowsPanel = ({ workspaceId }: Props) => {
   const [saving, setSaving] = useState(false);
   const [formError, setFormError] = useState<string | null>(null);
   const [confirmDefaults, setConfirmDefaults] = useState(false);
-  const [confirmEditorReset, setConfirmEditorReset] = useState(false);
   const [resetting, setResetting] = useState(false);
   const editingIdRef = useRef<WorkflowId | null>(restoredWorkflow?.id ?? null);
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const formRef = useRef(form);
+  const savedFormRef = useRef(restoredWorkflow === null ? null : JSON.stringify(form));
   formRef.current = form;
 
   useEffect(() => {
@@ -115,7 +115,9 @@ export const WorkflowsPanel = ({ workspaceId }: Props) => {
     }
     setEditing(workflow);
     editingIdRef.current = workflow.id;
-    setForm(templateToForm(workflow));
+    const nextForm = templateToForm(workflow);
+    setForm(nextForm);
+    savedFormRef.current = JSON.stringify(nextForm);
     setAgentPrompt('');
     consumeWorkflowGeneration({ workspaceId });
   }, [consumeWorkflowGeneration, generation, templates, workspaceId]);
@@ -159,8 +161,10 @@ export const WorkflowsPanel = ({ workspaceId }: Props) => {
     try {
       const saved = await savePhaseTemplate(args);
       editingIdRef.current = saved.id;
-      setEditing(saved);
-      setForm(templateToForm(saved));
+      savedFormRef.current = JSON.stringify(snapshot);
+      if (editing === 'new') {
+        setEditing(saved);
+      }
       clearWorkflowStudioDraft({ workspaceId });
       return true;
     } catch (error) {
@@ -173,6 +177,9 @@ export const WorkflowsPanel = ({ workspaceId }: Props) => {
 
   useEffect(() => {
     if (editing === null) {
+      return;
+    }
+    if (JSON.stringify(form) === savedFormRef.current) {
       return;
     }
     if (saveTimer.current !== null) {
@@ -199,6 +206,7 @@ export const WorkflowsPanel = ({ workspaceId }: Props) => {
     setEditing(null);
     editingIdRef.current = null;
     setForm(emptyForm());
+    savedFormRef.current = null;
     setAgentPrompt('');
     setFormError(null);
     clearWorkflowStudioDraft({ workspaceId });
@@ -209,6 +217,7 @@ export const WorkflowsPanel = ({ workspaceId }: Props) => {
     setEditing('new');
     editingIdRef.current = null;
     setForm(nextForm);
+    savedFormRef.current = null;
     setExpandedIdx(0);
     setFormError(null);
   };
@@ -216,7 +225,9 @@ export const WorkflowsPanel = ({ workspaceId }: Props) => {
   const openEdit = (workflow: Workflow) => {
     setEditing(workflow);
     editingIdRef.current = workflow.id;
-    setForm(templateToForm(workflow));
+    const nextForm = templateToForm(workflow);
+    setForm(nextForm);
+    savedFormRef.current = JSON.stringify(nextForm);
     setAgentPrompt('');
     setExpandedIdx(null);
     setFormError(null);
@@ -253,9 +264,10 @@ export const WorkflowsPanel = ({ workspaceId }: Props) => {
       openStarter();
       return;
     }
-    setForm(templateToForm(editing));
+    const nextForm = templateToForm(editing);
+    setForm(nextForm);
+    savedFormRef.current = JSON.stringify(nextForm);
     clearWorkflowStudioDraft({ workspaceId });
-    setConfirmEditorReset(false);
   };
 
   const createWithAgent = async () => {
@@ -336,8 +348,6 @@ export const WorkflowsPanel = ({ workspaceId }: Props) => {
             setConfirmReset={setConfirmDefaults}
             onSelect={openEdit}
             onNew={openStarter}
-            onDuplicate={(workflow) => void duplicate(workflow)}
-            onDelete={(workflow) => void deleteWorkflow(workflow.id, workspaceId)}
             onReset={() => {
               setResetting(true);
               void resetWorkflows(workspaceId).finally(() => {
@@ -371,14 +381,13 @@ export const WorkflowsPanel = ({ workspaceId }: Props) => {
               library={stepLibrary}
               expandedIdx={expandedIdx}
               saving={saving}
+              isNew={editing === 'new'}
               error={formError}
               dragging={drag !== null}
               dropIndex={dropIndex}
               draggingStepIdx={drag?.kind === 'step' ? drag.fromIndex : null}
-              confirmingReset={confirmEditorReset}
               generating={generation?.status === 'running'}
               canGenerate={connectedProviders.length > 0}
-              onConfirmingReset={setConfirmEditorReset}
               onChangeMeta={(patch) => setForm((current) => ({ ...current, ...patch }))}
               onAddBlank={() => {
                 insertStep({ definition: emptyDefinition(), atIndex: form.steps.length });
@@ -403,6 +412,13 @@ export const WorkflowsPanel = ({ workspaceId }: Props) => {
                 moveStepTo({ from: idx, to: idx + direction + (direction > 0 ? 1 : 0) })
               }
               onStartDrag={startLibraryDrag}
+              onAddLibraryStep={(definition) => {
+                insertStep({
+                  definition: defFromLibraryStep(definition),
+                  atIndex: form.steps.length,
+                });
+                setExpandedIdx(form.steps.length);
+              }}
               onStartStepDrag={startStepDrag}
               onSaveDef={(args) => void saveStepDef(args, workspaceId)}
               onDeleteDef={(id) => void deleteStepDef(id, workspaceId)}


### PR DESCRIPTION
## Why

The owner used the rewritten studio and gave a mixed verdict: the draft persistence landed well, three things did not.

> il workflow che sto creando ha una chip orchestrated, perche'? poi continua a saltare da saving a saved nell'header. Le azioni sono poste male. In linea generale farei un lavoro piu' pulito, non e' ancora il best della navigabilita'.

## The strobing indicator

Autosave is a 700ms debounce and the status was derived straight from the in-flight flag, so every burst of typing produced a visible flip between `Saving…` and `Saved`. An indicator that strobes does the opposite of reassuring.

It is now quiet while saves succeed and loud when one fails, and it never claims saved while a write is outstanding. The user needs two facts, that nothing is lost and when something failed; a successful save is not news.

## Actions

The rail and editor actions move onto the zones the action canon settled, so duplicate, delete, reset and close sit where the rest of the app puts them rather than where they fit at the time.

## Navigability

Moving between rail and editor, which workflow is open, and the keyboard path through the editor were all reworked. Keeping the step library permanently visible was considered and rejected: it shrank the primary editing surface and still required pointer dragging.

The `orchestrated` chip was fixed separately in #1447, where the origin became `custom`, since a studio preset has its steps fixed before it runs.

## Verification

- `pnpm --filter @goodboy/desktop typecheck`
- desktop suite 672 files, 5827 tests, run with bounded workers because the machine was under heavy parallel load

🤖 Generated with [Claude Code](https://claude.com/claude-code)
