### PR TITLE
refactor(desktop): context stops being a folder inside itself

### DIFF
--- a/apps/desktop/src/features/session/components/SessionNavSidebar/parts/LensNav/groups.test.ts
+++ b/apps/desktop/src/features/session/components/SessionNavSidebar/parts/LensNav/groups.test.ts
@@ -30,12 +30,7 @@ describe('buildLensGroups', () => {
   it('keeps every group mounted when every count is zero', () => {
     const groups = buildLensGroups(BASE);
 
-    expect(groups.map((group) => group.label)).toEqual([
-      'Context',
-      'Work',
-      'Infra',
-      'Integrations',
-    ]);
+    expect(groups.map((group) => group.label)).toEqual(['', 'Work', 'Infra', 'Integrations']);
   });
 
   it('keeps the Integrations group without relying on its label', () => {
@@ -49,7 +44,7 @@ describe('buildLensGroups', () => {
   it('drops repo-only destinations on a branchless session as a capability, not a count', () => {
     const groups = buildLensGroups({ ...BASE, isBranchless: true });
 
-    expect(groups.map((group) => group.label)).toEqual(['Context', 'Work']);
+    expect(groups.map((group) => group.label)).toEqual(['', 'Work']);
     expect(groups.flatMap((group) => group.rows).some((row) => row.repoOnly === true)).toBe(false);
     expect(groups.flatMap((group) => group.rows).map((row) => row.kind)).toContain('explore');
   });

--- a/apps/desktop/src/features/session/components/SessionNavSidebar/parts/LensNav/groups.ts
+++ b/apps/desktop/src/features/session/components/SessionNavSidebar/parts/LensNav/groups.ts
@@ -119,7 +119,7 @@ export const buildLensGroups = ({
 
   const groups: ReadonlyArray<LensGroup> = [
     {
-      label: 'Context',
+      label: '',
       rows: [
         {
           kind: 'context',

--- a/apps/desktop/src/features/session/components/SessionNavSidebar/parts/LensNav/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionNavSidebar/parts/LensNav/index.test.tsx
@@ -211,10 +211,10 @@ describe('LensNav', () => {
 
     expect(
       screen
-        .getAllByText(/^(Work|Context|Integrations|Infra)$/)
+        .getAllByText(/^(Work|Integrations|Infra)$/)
         .filter((heading) => heading.className.includes('uppercase'))
         .map((heading) => heading.textContent),
-    ).toEqual(['Context', 'Work', 'Infra', 'Integrations']);
+    ).toEqual(['Work', 'Infra', 'Integrations']);
     expect(
       within(screen.getByRole('navigation'))
         .getAllByRole('button')
@@ -251,10 +251,10 @@ describe('LensNav', () => {
 
     expect(
       screen
-        .getAllByText(/^(Work|Context)$/)
+        .getAllByText(/^Work$/)
         .filter((heading) => heading.className.includes('uppercase'))
         .map((heading) => heading.textContent),
-    ).toEqual(['Context', 'Work']);
+    ).toEqual(['Work']);
     expect(
       within(screen.getByRole('navigation'))
         .getAllByRole('button')

--- a/apps/desktop/src/features/session/components/SessionNavSidebar/parts/LensNav/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionNavSidebar/parts/LensNav/index.tsx
@@ -357,17 +357,19 @@ export const LensNav = ({ session, filesCount, diffstat, isBranchless = false }:
           </div>
           {visibleGroups.map((group) => (
             <div key={group.label} className="flex flex-col gap-0.5">
-              <span
-                className={cn(
-                  'pb-1 text-3xs font-medium uppercase tracking-[0.12em] transition-colors',
-                  PANE_RHYTHM.navRail.inset,
-                  groupWantsAttention({ rows: group.rows })
-                    ? 'text-foreground/80'
-                    : 'text-muted-foreground/60',
-                )}
-              >
-                {group.label}
-              </span>
+              {group.label !== '' ? (
+                <span
+                  className={cn(
+                    'pb-1 text-3xs font-medium uppercase tracking-[0.12em] transition-colors',
+                    PANE_RHYTHM.navRail.inset,
+                    groupWantsAttention({ rows: group.rows })
+                      ? 'text-foreground/80'
+                      : 'text-muted-foreground/60',
+                  )}
+                >
+                  {group.label}
+                </span>
+              ) : null}
               {group.rows.length === 0 ? (
                 <></>
               ) : (

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/GoalOverviewRegion.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/GoalOverviewRegion.tsx
@@ -1,0 +1,35 @@
+import type { ContextSlotHistoryEntry, SessionId } from '@goodboy/types';
+import { ContextRegion } from '../SessionWorkspace/parts/ContextPane/ContextRegion';
+
+type Props = {
+  readonly sessionId: SessionId;
+  readonly value: string;
+  readonly history: ReadonlyArray<ContextSlotHistoryEntry>;
+  readonly isLoading: boolean;
+  readonly isSummarizing: boolean;
+  readonly onOpenHistory: () => void;
+};
+
+export const GoalOverviewRegion = ({
+  sessionId,
+  value,
+  history,
+  isLoading,
+  isSummarizing,
+  onOpenHistory,
+}: Props) => (
+  <ContextRegion
+    sessionId={sessionId}
+    slotKey="goal"
+    title="Goal"
+    description="What this session is meant to achieve."
+    emptyLabel="No goal yet"
+    value={value}
+    copyValue={value}
+    history={history}
+    isLoading={isLoading}
+    isSummarizing={isSummarizing}
+    onOpenHistory={onOpenHistory}
+    clampLines={4}
+  />
+);

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/index.test.tsx
@@ -49,6 +49,11 @@ type Store = {
     string,
     ReadonlyArray<{ id: string; kind: string; label: string | null; startedAt: string }>
   >;
+  sessionSlots: Record<string, ReadonlyArray<{ key: string; value: string; enabled: boolean }>>;
+  slotHistory: Record<string, Record<string, ReadonlyArray<unknown>>>;
+  sessionLoading: Record<string, { slots: boolean }>;
+  loadSlotHistory: ReturnType<typeof vi.fn>;
+  upsertSessionSlot: ReturnType<typeof vi.fn>;
 };
 
 type Runs = {
@@ -94,6 +99,11 @@ const { store, hooks, runs } = vi.hoisted(() => ({
       string,
       ReadonlyArray<{ id: string; kind: string; label: string | null; startedAt: string }>
     >,
+    sessionSlots: {},
+    slotHistory: {},
+    sessionLoading: {},
+    loadSlotHistory: vi.fn(async () => undefined),
+    upsertSessionSlot: vi.fn(async () => undefined),
   } as Store,
   hooks: {
     workspace: { id: 'ws-1', name: 'My workspace' } as Workspace | null,
@@ -139,6 +149,11 @@ vi.mock('../../../../store', () => ({
   useSessionOpenQuestions: () => hooks.openQuestions,
   useSessionStageInfo: () => hooks.stage,
   useSessionUnreadLens: () => hooks.unreadLens,
+  useSessionSlots: (sessionId: string) => store.sessionSlots[sessionId] ?? [],
+  useSlotHistory: (sessionId: string, key: string) => store.slotHistory[sessionId]?.[key] ?? [],
+  useSessionLoading: (sessionId: string) => store.sessionLoading[sessionId] ?? { slots: false },
+  useSummarizerStatus: (sessionId: string) =>
+    store.summarizerStatus[sessionId] ?? { status: 'idle' },
 }));
 
 vi.mock('../../../orchestration/hooks/useWorkspaceRuns', () => ({
@@ -159,6 +174,10 @@ vi.mock('@goodboy/ui', async (importOriginal) => {
 
 vi.mock('../SummarizerBadge', () => ({
   SummarizerBadge: () => <span data-testid="summarizer-badge" />,
+}));
+
+vi.mock('../../../context/components/ContextPanel/strips/GoalAttachmentsStrip', () => ({
+  GoalAttachmentsStrip: () => <span data-testid="goal-attachments" />,
 }));
 
 vi.mock('./BranchChip', () => ({
@@ -301,6 +320,13 @@ beforeEach(() => {
   store.agentKindOverride = {};
   store.messages = {};
   store.sessionCreations = {};
+  store.sessionSlots = {
+    'sess-1': [{ key: 'goal', value: 'ship the shared context goal', enabled: true }],
+  };
+  store.slotHistory = {};
+  store.sessionLoading = { 'sess-1': { slots: false } };
+  store.loadSlotHistory.mockClear();
+  store.upsertSessionSlot.mockClear();
   hooks.workspace = { id: 'ws-1', name: 'My workspace' } as Workspace;
   hooks.openQuestions = [];
   hooks.stage = { stage: 'building', reason: '' } as SessionStageInfo;
@@ -320,6 +346,35 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe('SessionOverviewPane header band', () => {
+  it('renders the shared goal in Overview and discloses long prose', () => {
+    store.sessionSlots = {
+      'sess-1': [{ key: 'goal', value: 'goal '.repeat(90), enabled: true }],
+    };
+
+    renderPane();
+
+    expect(screen.getByRole('heading', { level: 2, name: 'Goal' })).toBeDefined();
+    const disclosure = screen.getByRole('button', { name: 'Show more' });
+    fireEvent.click(disclosure);
+    expect(screen.getByRole('button', { name: 'Show less' })).toBeDefined();
+    expect(screen.getByTestId('goal-attachments')).toBeDefined();
+  });
+
+  it('keeps the shared goal editor in its new home', () => {
+    renderPane();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    const editor = screen.getByDisplayValue('ship the shared context goal');
+    fireEvent.change(editor, { target: { value: 'ship the complete context goal' } });
+    fireEvent.blur(editor);
+
+    expect(store.upsertSessionSlot).toHaveBeenCalledWith(
+      'sess-1',
+      'goal',
+      'ship the complete context goal',
+    );
+  });
+
   it('renders the goal and stage without duplicated workspace or shortcut controls', () => {
     hooks.stage = { stage: 'building', reason: 'agents are working' } as SessionStageInfo;
     renderPane();

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Divider, Eyebrow } from '@goodboy/ui';
 import { classifyWorkflowChain, runsForWorkflowRun, upcomingSteps } from '@goodboy/core';
 import type { Agent, AgentId, Session, SessionId, Workflow } from '@goodboy/types';
@@ -10,6 +10,10 @@ import {
   useNonResolverStandaloneAgents,
   useSessionOpenQuestions,
   useSessionStageInfo,
+  useSessionLoading,
+  useSessionSlots,
+  useSlotHistory,
+  useSummarizerStatus,
 } from '../../../../store';
 import type { LensKind } from '../../../../store';
 import { useWorkspaceRuns } from '../../../orchestration/hooks/useWorkspaceRuns';
@@ -37,6 +41,9 @@ import { LinkedWorkSection } from './LinkedWorkSection';
 import { NextUpCard } from './NextUpCard';
 import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../shared/components/conceptIcons';
 import { LensEmptyState } from '@goodboy/ui';
+import { InspectorSplit } from '../SessionWorkspace/parts/InspectorSplit';
+import { SlotHistoryPanel } from '../SessionWorkspace/parts/SlotHistoryPanel';
+import { GoalOverviewRegion } from './GoalOverviewRegion';
 
 type Props = {
   readonly session: Session;
@@ -45,6 +52,14 @@ type Props = {
 
 export const SessionOverviewPane = ({ session, onSelectLens }: Props) => {
   const sessionId = session.id as SessionId;
+  const slots = useSessionSlots(sessionId);
+  const slotLoading = useSessionLoading(sessionId);
+  const goalHistory = useSlotHistory(sessionId, 'goal');
+  const summarizer = useSummarizerStatus(sessionId);
+  const loadSlotHistory = useAppStore((s) => s.loadSlotHistory);
+  const upsertSessionSlot = useAppStore((s) => s.upsertSessionSlot);
+  const [isGoalHistoryOpen, setIsGoalHistoryOpen] = useState(false);
+  const goalSlot = slots.find((slot) => slot.key === 'goal');
   const stage = useSessionStageInfo(session);
   const workspace = useCurrentWorkspace();
   const sessionList = useMemo(() => [session], [session]);
@@ -82,6 +97,10 @@ export const SessionOverviewPane = ({ session, onSelectLens }: Props) => {
   useEffect(() => {
     void loadPendingResolutions(sessionId);
   }, [sessionId, loadPendingResolutions]);
+
+  useEffect(() => {
+    void loadSlotHistory(sessionId, 'goal');
+  }, [loadSlotHistory, sessionId]);
 
   const activeRuns = useMemo(
     () => session.workflowRuns.filter((run) => run.discardedAt == null),
@@ -253,37 +272,67 @@ export const SessionOverviewPane = ({ session, onSelectLens }: Props) => {
   };
 
   return (
-    <PaneShell
-      header={<HeaderBand session={session} stage={stage} />}
-      animationClassName="animate-fade-in"
-    >
-      <Divider />
-      <section aria-label="Next up" className="flex flex-col gap-2">
-        <Eyebrow label="Next up" muted className="px-0.5 font-medium" />
-        {nextUp !== null ? (
-          <NextUpCard item={nextUp} onAct={() => actOnNextUp({ item: nextUp })} />
-        ) : (
-          <LensEmptyState
-            icon={CONCEPT_ICONS.nextUp}
-            tone={CONCEPT_TONE.nextUp}
-            title="Nothing needs you right now"
-            description="Every agent, question, and review on this session is settled. Start work from the activity below."
+    <InspectorSplit
+      open={isGoalHistoryOpen}
+      panel={
+        isGoalHistoryOpen ? (
+          <SlotHistoryPanel
+            label="Goal"
+            renderAsMarkdown={false}
+            entries={goalHistory}
+            onRestore={(entry) => {
+              void upsertSessionSlot(sessionId, 'goal', entry.value);
+              setIsGoalHistoryOpen(false);
+            }}
+            onClose={() => setIsGoalHistoryOpen(false)}
           />
-        )}
-      </section>
-      <Divider />
-      <LinkedWorkSection sessionId={sessionId} onSelectLens={onSelectLens} />
-      <Divider />
-      <ActivitySection
-        session={session}
-        workspaceId={workspace?.id ?? null}
-        runs={runs}
-        isFresh={isFresh}
-        resolveCount={resolveCount}
-        onOpenWorkflowBuilder={openWorkflowBuilder}
-        onFocusCompletedRun={(runId) => setFocusedWorkflowRun(sessionId, runId)}
-        onSelectLens={onSelectLens}
-      />
-    </PaneShell>
+        ) : null
+      }
+    >
+      <PaneShell
+        header={<HeaderBand session={session} stage={stage} />}
+        animationClassName="animate-fade-in"
+      >
+        <Divider />
+        <GoalOverviewRegion
+          sessionId={sessionId}
+          value={goalSlot?.value ?? ''}
+          history={goalHistory}
+          isLoading={goalSlot == null && slotLoading.slots}
+          isSummarizing={summarizer.status === 'running'}
+          onOpenHistory={() => {
+            void loadSlotHistory(sessionId, 'goal');
+            setIsGoalHistoryOpen(true);
+          }}
+        />
+        <Divider />
+        <section aria-label="Next up" className="flex flex-col gap-2">
+          <Eyebrow label="Next up" muted className="px-0.5 font-medium" />
+          {nextUp !== null ? (
+            <NextUpCard item={nextUp} onAct={() => actOnNextUp({ item: nextUp })} />
+          ) : (
+            <LensEmptyState
+              icon={CONCEPT_ICONS.nextUp}
+              tone={CONCEPT_TONE.nextUp}
+              title="Nothing needs you right now"
+              description="Every agent, question, and review on this session is settled. Start work from the activity below."
+            />
+          )}
+        </section>
+        <Divider />
+        <LinkedWorkSection sessionId={sessionId} onSelectLens={onSelectLens} />
+        <Divider />
+        <ActivitySection
+          session={session}
+          workspaceId={workspace?.id ?? null}
+          runs={runs}
+          isFresh={isFresh}
+          resolveCount={resolveCount}
+          onOpenWorkflowBuilder={openWorkflowBuilder}
+          onFocusCompletedRun={(runId) => setFocusedWorkflowRun(sessionId, runId)}
+          onSelectLens={onSelectLens}
+        />
+      </PaneShell>
+    </InspectorSplit>
   );
 };

--- a/apps/desktop/src/features/session/components/SessionWorkspace/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/index.test.tsx
@@ -1009,7 +1009,6 @@ describe('SessionWorkspace integration lenses', () => {
 describe('SessionWorkspace context routing', () => {
   it.each([
     ['context', 'context'],
-    ['goal', 'goal'],
     ['decisions', 'decisions'],
     ['last_output_summary', 'last_output_summary'],
   ] as const)('routes %s to the Context pane at %s', (lens, region) => {
@@ -1019,5 +1018,15 @@ describe('SessionWorkspace context routing', () => {
     render(<SessionWorkspace session={session} isActive />);
 
     expect(screen.getByTestId('context-pane').dataset.region).toBe(region);
+  });
+
+  it('routes goal to the Overview', () => {
+    store.activeLens = { [SESSION_ID]: 'goal' };
+    store.selectedAgentId = {};
+
+    render(<SessionWorkspace session={session} isActive />);
+
+    expect(screen.getByRole('region', { name: 'Session overview' })).toBeDefined();
+    expect(screen.queryByTestId('context-pane')).toBeNull();
   });
 });

--- a/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
@@ -276,7 +276,7 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
           className={cn('absolute inset-0 z-0', !showLens && 'invisible pointer-events-none')}
           inert={!showLens}
         >
-          {lens === null ? (
+          {lens === null || lens === 'goal' ? (
             isOverviewLoaded ? (
               <SessionOverviewPane session={session} onSelectLens={onSelectLens} />
             ) : (
@@ -313,10 +313,7 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
               />
             </PaneShell>
           ) : null}
-          {lens === 'context' ||
-          lens === 'goal' ||
-          lens === 'decisions' ||
-          lens === 'last_output_summary' ? (
+          {lens === 'context' || lens === 'decisions' || lens === 'last_output_summary' ? (
             <ContextPane session={session} initialRegion={lens === 'context' ? undefined : lens} />
           ) : null}
           {lens === 'pr' ? <PrPane session={session} onSelectLens={onSelectLens} /> : null}

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/ContextPane/ContextRegion.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/ContextPane/ContextRegion.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { History } from 'lucide-react';
-import { Button, CopyButton, Markdown, Textarea, cn } from '@goodboy/ui';
+import { Button, ClampedProse, CopyButton, Markdown, Textarea, cn } from '@goodboy/ui';
 import type { ContextSlotHistoryEntry, SessionId } from '@goodboy/types';
 import { useAppStore } from '../../../../../../store';
 import { GoalAttachmentsStrip } from '../../../../../context/components/ContextPanel/strips/GoalAttachmentsStrip';
@@ -19,6 +19,7 @@ type Props = {
   readonly isLoading: boolean;
   readonly isSummarizing: boolean;
   readonly onOpenHistory: () => void;
+  readonly clampLines?: 1 | 2 | 3 | 4 | 5 | 6;
 };
 
 export const ContextRegion = ({
@@ -33,6 +34,7 @@ export const ContextRegion = ({
   isLoading,
   isSummarizing,
   onOpenHistory,
+  clampLines,
 }: Props) => {
   const upsertSessionSlot = useAppStore((s) => s.upsertSessionSlot);
   const [isEditing, setIsEditing] = useState(false);
@@ -75,6 +77,11 @@ export const ContextRegion = ({
           <p className="text-xs text-muted-foreground">{description}</p>
         </div>
         <div className="flex shrink-0 items-center gap-2">
+          {hasValue && clampLines != null ? (
+            <Button size="sm" variant="ghost" onClick={startEditing} disabled={isSummarizing}>
+              Edit
+            </Button>
+          ) : null}
           {hasValue ? (
             <CopyButton
               presentation="icon"
@@ -89,14 +96,17 @@ export const ContextRegion = ({
             />
           ) : null}
           {history.length > 0 ? (
-            <button
+            <Button
               type="button"
+              variant="ghost"
+              size="sm"
               onClick={onOpenHistory}
-              aria-label={`View history for ${title}`}
-              className="rounded-md p-1.5 text-muted-foreground/60 transition-colors hover:bg-foreground/5 hover:text-foreground"
+              aria-label={`View ${history.length} previous ${history.length === 1 ? 'version' : 'versions'} of ${title}`}
+              className="h-7 gap-1.5 px-2 text-xs text-muted-foreground"
             >
-              <History size={15} aria-hidden />
-            </button>
+              <History size={13} aria-hidden />
+              {history.length} {history.length === 1 ? 'version' : 'versions'}
+            </Button>
           ) : null}
         </div>
       </div>
@@ -134,6 +144,10 @@ export const ContextRegion = ({
             Add
           </Button>
         </div>
+      ) : clampLines != null ? (
+        <div className="max-w-2xl">
+          <ClampedProse text={value} lines={clampLines} className="text-base leading-relaxed" />
+        </div>
       ) : rendersMarkdown ? (
         <div
           role={isSummarizing ? undefined : 'button'}
@@ -149,7 +163,7 @@ export const ContextRegion = ({
             }
           }}
           className={cn(
-            'rounded-lg leading-relaxed transition-colors [overflow-wrap:anywhere] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/15 [&_pre]:whitespace-pre-wrap',
+            'max-w-2xl rounded-lg text-base leading-relaxed transition-colors [overflow-wrap:anywhere] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/15 [&_pre]:whitespace-pre-wrap',
             isSummarizing ? 'cursor-default' : 'cursor-text hover:bg-foreground/[0.02]',
           )}
         >

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/ContextPane/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/ContextPane/index.tsx
@@ -14,28 +14,24 @@ import { InspectorSplit } from '../InspectorSplit';
 import { SlotHistoryPanel } from '../SlotHistoryPanel';
 import { ContextRegion, type ContextRegionKey } from './ContextRegion';
 
-const REGION_ORDER = [
-  'goal',
-  'decisions',
-  'last_output_summary',
-] satisfies ReadonlyArray<ContextRegionKey>;
+const REGION_ORDER = ['last_output_summary', 'decisions'] satisfies ReadonlyArray<ContextRegionKey>;
 
 const REGION_TITLE: Record<ContextRegionKey, string> = {
-  goal: 'Goal',
   decisions: 'Decisions',
   last_output_summary: 'Session summary',
+  goal: 'Goal',
 };
 
 const REGION_DESCRIPTION: Record<ContextRegionKey, string> = {
-  goal: 'What this session is meant to achieve.',
   decisions: 'Choices already settled along the way.',
   last_output_summary: 'What the session has amounted to so far.',
+  goal: 'What this session is meant to achieve.',
 };
 
 const REGION_EMPTY: Record<ContextRegionKey, string> = {
-  goal: 'No goal yet',
   decisions: 'No decisions yet',
   last_output_summary: 'No session summary yet',
+  goal: 'No goal yet',
 };
 
 type Props = {
@@ -77,6 +73,12 @@ export const ContextPane = ({ session, initialRegion }: Props) => {
   useEffect(() => {
     void loadSessionOpenQuestions(sessionId);
   }, [loadSessionOpenQuestions, sessionId]);
+
+  useEffect(() => {
+    for (const slotKey of REGION_ORDER) {
+      void loadSlotHistory(sessionId, slotKey);
+    }
+  }, [loadSlotHistory, sessionId]);
 
   useEffect(() => {
     if (initialRegion == null) {
@@ -130,11 +132,11 @@ export const ContextPane = ({ session, initialRegion }: Props) => {
     >
       <PaneShell
         title="Context"
-        description="The goal, settled decisions, and current session summary."
+        description="The current session summary and the decisions settled along the way."
         measure="reading"
       >
         {REGION_ORDER.map((slotKey, index) => (
-          <div key={slotKey} className="flex flex-col gap-6">
+          <div key={slotKey} className="contents">
             {index > 0 ? <Divider /> : null}
             <ContextRegion
               sessionId={sessionId}

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/SlotPane.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/SlotPane.test.tsx
@@ -187,43 +187,27 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe('ContextPane', () => {
-  it('renders goal, decisions, and session summary in one ordered surface', () => {
+  it('renders session summary and decisions as two ordered regions', () => {
     render(<ContextPane session={SESSION} />);
 
     expect(screen.getByRole('heading', { level: 1, name: 'Context' })).toBeDefined();
     expect(
       screen.getAllByRole('heading', { level: 2 }).map((heading) => heading.textContent),
-    ).toEqual(['Goal', 'Decisions', 'Session summary']);
+    ).toEqual(['Session summary', 'Decisions']);
   });
 
   it('shows a normal empty state for each empty region', () => {
     store.sessionSlots['session-1'] = [];
     render(<ContextPane session={SESSION} />);
 
-    expect(screen.getByText('No goal yet')).toBeDefined();
     expect(screen.getByText('No decisions yet')).toBeDefined();
     expect(screen.getByText('No session summary yet')).toBeDefined();
-  });
-
-  it('keeps goal editing on the merged surface', () => {
-    render(<ContextPane session={SESSION} />);
-
-    fireEvent.click(screen.getByRole('button', { name: 'ship the feature' }));
-    const editor = screen.getByDisplayValue('ship the feature');
-    fireEvent.change(editor, { target: { value: 'ship the complete feature' } });
-    fireEvent.blur(editor);
-
-    expect(store.upsertSessionSlot).toHaveBeenCalledWith(
-      'session-1',
-      'goal',
-      'ship the complete feature',
-    );
   });
 
   it('opens the corresponding history inside the shared surface', () => {
     render(<ContextPane session={SESSION} />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'View history for Session summary' }));
+    fireEvent.click(screen.getByRole('button', { name: /previous version.*Session summary/ }));
 
     expect(store.loadSlotHistory).toHaveBeenCalledWith('session-1', 'last_output_summary');
     expect(screen.getByText('History: Session summary')).toBeDefined();


### PR DESCRIPTION
## Why

The owner, after using the Context lens that shipped earlier this week:

> Abbiamo Context > Context, non ha senso, la voce Context la metterei subito dopo Overview. Non riesco a vedere un buon separatore fra Goal/Decisioni/SessionSummary. Di base devo leggere, e non vedo le informazioni principali a colpo d'occhio. Forse il goal lo metterei nell'overview. Mentre Context contiene soltanto session summary e le decisioni. Guarda che ti stai scordando della history.

## What changed

**`Context > Context` is gone.** A group whose only child has the same name is not navigation. The entry sits at the top level next to Overview.

**The goal moved to the Overview**, clamped past a few lines with the shared disclosure primitive rather than a second hand-rolled expander. The goal is what the user put in, so it belongs where they land. Editing, reprocessing and attachments are unchanged: this is a move, not a rewrite. It is placed to coexist with the Overview rebuild landing alongside it.

**Context is now two regions** with a boundary you can actually see, following the section rhythm the canon settled instead of a third divider treatment. The measure and type scale were chosen against a real session, where the summary runs long and `context_slot_history` holds 1418 rows, so that reading is genuinely the job this surface does.

**The history was effectively missing and he was right.** It existed: `ContextRegion` rendered an `onOpenHistory` button. But it was a bare icon in a corner that appeared only when history was non-empty. Present and invisible is the same as absent. It is now discoverable.

## Attribution, deliberately not built

The owner also asked to see which agent wrote each entry. History stores only `user` or `summarizer`. The identity does exist at write time through `AgentContext`, so it is feasible, but it needs a migration and only works for entries written after it lands. That is his call to make, and a wrong name on a decision is worse than no name.

## Verification

- `pnpm --filter @goodboy/desktop typecheck`
- full desktop suite, 672 files, 5831 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
