### PR TITLE
refactor(desktop): the remaining surfaces move onto the canon

### DIFF
--- a/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
+++ b/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
@@ -1744,11 +1744,15 @@ exports[`snapshot, error states > TranscriptCard: turn error item 1`] = `
   <div
     class="flex min-w-0 flex-1 flex-col gap-1"
   >
-    <p
-      class="min-w-0 break-words leading-relaxed text-danger"
+    <div
+      class="flex flex-col gap-1 min-w-0 break-words text-xs leading-relaxed text-danger"
     >
-      provider failed to respond
-    </p>
+      <p
+        class="leading-relaxed wrap-anywhere"
+      >
+        provider failed to respond
+      </p>
+    </div>
   </div>
 </div>
 `;

--- a/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
+++ b/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
@@ -1571,7 +1571,7 @@ exports[`snapshot, error states > SessionOverviewLoading: silent skeleton before
   >
     <div
       aria-label="Loading session overview"
-      class="flex flex-col mx-auto w-full gap-5 max-w-5xl"
+      class="mx-auto w-full flex flex-col gap-5 max-w-5xl"
       role="status"
     >
       <div

--- a/apps/desktop/src/features/chat/components/TranscriptCards/index.test.tsx
+++ b/apps/desktop/src/features/chat/components/TranscriptCards/index.test.tsx
@@ -57,7 +57,7 @@ describe('TranscriptCard', () => {
     expect(screen.queryByRole('button', { name: 'retry' })).toBeNull();
   });
 
-  it('truncates long transcript errors and reveals full text on demand', async () => {
+  it('discloses long transcript errors in place', async () => {
     const user = userEvent.setup();
     const longMessage =
       'provider stderr: ' +
@@ -74,8 +74,10 @@ describe('TranscriptCard', () => {
         }}
       />,
     );
-    expect(screen.queryByText(longMessage)).toBeNull();
-    await user.click(screen.getByRole('button', { name: 'show full error' }));
+    const disclosure = screen.getByRole('button', { name: 'Show more' });
+    expect(disclosure.getAttribute('aria-expanded')).toBe('false');
+    await user.click(disclosure);
+    expect(disclosure.getAttribute('aria-expanded')).toBe('true');
     expect(screen.getByText(longMessage)).toBeTruthy();
   });
 });

--- a/apps/desktop/src/features/chat/components/TurnErrorCallout/index.tsx
+++ b/apps/desktop/src/features/chat/components/TurnErrorCallout/index.tsx
@@ -1,8 +1,5 @@
-import { useMemo, useState } from 'react';
 import { CircleAlert } from 'lucide-react';
-import { cn, tintClasses } from '@goodboy/ui';
-
-const MAX_INLINE_ERROR_LENGTH = 220;
+import { ClampedProse, cn, tintClasses } from '@goodboy/ui';
 const dangerTint = tintClasses('danger');
 
 type RetryAction = {
@@ -19,27 +16,7 @@ type Props = {
   readonly retryAction?: RetryAction;
 };
 
-type TruncateParams = {
-  readonly message: string;
-  readonly maxLength: number;
-};
-
-const truncateMessage = ({ message, maxLength }: TruncateParams): string => {
-  if (message.length <= maxLength) {
-    return message;
-  }
-  return `${message.slice(0, maxLength).trimEnd()}...`;
-};
-
 export const TurnErrorCallout = ({ message, role, className, iconTestId, retryAction }: Props) => {
-  const [expanded, setExpanded] = useState(false);
-  const longMessage = message.length > MAX_INLINE_ERROR_LENGTH;
-  const truncatedMessage = useMemo(
-    () => truncateMessage({ message, maxLength: MAX_INLINE_ERROR_LENGTH }),
-    [message],
-  );
-  const displayMessage = longMessage && !expanded ? truncatedMessage : message;
-
   return (
     <div
       role={role}
@@ -57,23 +34,11 @@ export const TurnErrorCallout = ({ message, role, className, iconTestId, retryAc
         className={cn('mt-0.5 shrink-0', dangerTint.icon)}
       />
       <div className="flex min-w-0 flex-1 flex-col gap-1">
-        <p className={cn('min-w-0 break-words leading-relaxed', dangerTint.text)}>
-          {displayMessage}
-        </p>
-        {longMessage ? (
-          <button
-            type="button"
-            onClick={() => setExpanded((value) => !value)}
-            aria-expanded={expanded}
-            className={cn(
-              'w-fit rounded-md px-1 py-0.5 text-2xs font-medium',
-              dangerTint.text,
-              dangerTint.hoverBgSoft,
-            )}
-          >
-            {expanded ? 'show less' : 'show full error'}
-          </button>
-        ) : null}
+        <ClampedProse
+          text={message}
+          lines={3}
+          className={cn('min-w-0 break-words text-xs leading-relaxed', dangerTint.text)}
+        />
       </div>
       {retryAction != null ? (
         <button

--- a/apps/desktop/src/features/github/components/GitHubStudio/ResolveBoard/ResolveCard.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/ResolveBoard/ResolveCard.tsx
@@ -1,5 +1,5 @@
 import type { AgentId, ProviderId } from '@goodboy/types';
-import { Button, Checkbox, Chip, cn } from '@goodboy/ui';
+import { Button, Checkbox, Chip, ClampedProse, cn } from '@goodboy/ui';
 import { ArrowUpRight, ChevronDown, ExternalLink, RotateCcw } from 'lucide-react';
 import { modelEffortLevels } from '../../../../chat/utils/chat-constants';
 import { RoutingBadge } from '../../../../../shared/components/RoutingBadge';
@@ -58,7 +58,7 @@ export const ResolveCard = ({
           ariaLabel={`Include comment by ${head.author}`}
           className="mt-0.5"
         />
-        <div className="min-w-0 flex-1">
+        <div className="flex min-w-0 flex-1 flex-col gap-2">
           <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
             <span className="font-medium text-foreground">{head.author}</span>
             <span className="opacity-50">·</span>
@@ -71,7 +71,7 @@ export const ResolveCard = ({
                 title="This comment is anchored to code that later commits changed"
               />
             ) : null}
-            <div className="ml-auto flex shrink-0 items-center gap-1.5">
+            <div className="flex shrink-0 items-center gap-1.5">
               {link ? <ResolverStateBadge state={resolverBadgeState(link.status)} /> : null}
               {onOpenThread ? (
                 <button
@@ -86,24 +86,28 @@ export const ResolveCard = ({
               ) : null}
             </div>
           </div>
-          <p className="mt-1 line-clamp-3 whitespace-pre-wrap text-sm leading-snug text-foreground [overflow-wrap:anywhere]">
-            {head.body.trim() || '(empty)'}
-          </p>
+          <ClampedProse
+            text={head.body.trim() || '(empty)'}
+            lines={3}
+            className="text-sm leading-snug text-foreground [overflow-wrap:anywhere]"
+          />
 
           {replies.length > 0 && (
-            <div className="mt-2 flex flex-col gap-1.5 border-l border-border-soft pl-2.5">
+            <div className="flex flex-col gap-2 rounded-md bg-subtle px-2.5 py-2">
               {replies.map((r) => (
-                <div key={r.id} className="flex flex-col gap-0.5">
+                <div key={r.id} className="flex flex-col gap-1">
                   <span className="text-2xs font-medium text-muted-foreground">{r.author}</span>
-                  <p className="line-clamp-2 whitespace-pre-wrap text-xs leading-snug text-muted-foreground/80 [overflow-wrap:anywhere]">
-                    {r.body.trim() || '(empty)'}
-                  </p>
+                  <ClampedProse
+                    text={r.body.trim() || '(empty)'}
+                    lines={2}
+                    className="text-xs leading-snug text-muted-foreground/80 [overflow-wrap:anywhere]"
+                  />
                 </div>
               ))}
             </div>
           )}
 
-          <div className="mt-2 flex flex-wrap items-center gap-1.5">
+          <div className="flex flex-wrap items-center justify-end gap-2">
             {claimed && link ? (
               <Button
                 variant="info"

--- a/apps/desktop/src/features/github/components/GitHubStudio/ResolveBoard/index.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/ResolveBoard/index.tsx
@@ -100,7 +100,7 @@ export const ResolveBoard = ({
 
   return (
     <div className="flex flex-col gap-3">
-      <div className="sticky top-0 z-10 flex flex-wrap items-center gap-2 rounded-md border border-border-soft bg-background/95 px-2.5 py-2 backdrop-blur">
+      <div className="sticky top-0 z-10 flex flex-wrap items-center justify-end gap-2 rounded-md bg-background/95 px-2.5 py-2 backdrop-blur">
         <Checkbox
           checked={allSelected}
           indeterminate={!allSelected && selected.length > 0}
@@ -108,7 +108,7 @@ export const ResolveBoard = ({
           label={<span className="font-medium">{selected.length} selected</span>}
         />
 
-        <div className="ml-auto">
+        <div>
           <ResolveConfigPopover
             ariaLabel="Configure batch resolvers"
             config={defaults}

--- a/apps/desktop/src/features/github/components/GitHubStudio/SectionBody.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/SectionBody.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 import type { PrDetail } from '@goodboy/types';
-import { Skeleton } from '@goodboy/ui';
+import { ClampedProse, PANE_RHYTHM, Skeleton } from '@goodboy/ui';
 import { AlertCircle, RefreshCw } from 'lucide-react';
 
 type Props = {
@@ -13,13 +13,13 @@ type Props = {
 
 export const SectionBody = ({ detail, detailLoading, detailError, onRetry, children }: Props) => {
   return (
-    <div className="flex w-full flex-col gap-3">
+    <div className={PANE_RHYTHM.stack}>
       {detailError != null ? (
         <div className="flex items-center gap-1.5 text-xs text-danger">
           <AlertCircle size={13} aria-hidden />
-          <span className="min-w-0 flex-1 truncate" title={detailError}>
-            {detailError}
-          </span>
+          <div className="min-w-0 flex-1">
+            <ClampedProse text={detailError} lines={2} className="text-xs text-danger" />
+          </div>
           <button
             type="button"
             onClick={onRetry}

--- a/apps/desktop/src/features/permissions/components/PermissionRequestCard/formatRequestInput.ts
+++ b/apps/desktop/src/features/permissions/components/PermissionRequestCard/formatRequestInput.ts
@@ -1,5 +1,3 @@
-const MAX_CHARS = 400;
-
 type Params = {
   readonly input: unknown;
 };
@@ -8,9 +6,9 @@ export const formatRequestInput = ({ input }: Params): string | null => {
   if (input == null) {
     return null;
   }
-  const json = JSON.stringify(input, null, 2);
+  const json = JSON.stringify(input);
   if (json === undefined || json === '{}') {
     return null;
   }
-  return json.length > MAX_CHARS ? `${json.slice(0, MAX_CHARS)}...` : json;
+  return json;
 };

--- a/apps/desktop/src/features/permissions/components/PermissionRequestCard/formatRequestInput.ts
+++ b/apps/desktop/src/features/permissions/components/PermissionRequestCard/formatRequestInput.ts
@@ -6,7 +6,7 @@ export const formatRequestInput = ({ input }: Params): string | null => {
   if (input == null) {
     return null;
   }
-  const json = JSON.stringify(input);
+  const json = JSON.stringify(input, null, 2);
   if (json === undefined || json === '{}') {
     return null;
   }

--- a/apps/desktop/src/features/permissions/components/PermissionRequestCard/index.tsx
+++ b/apps/desktop/src/features/permissions/components/PermissionRequestCard/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { ShieldAlert } from 'lucide-react';
-import { tintClasses } from '@goodboy/ui';
+import { ClampedProse, tintClasses } from '@goodboy/ui';
 import type { AgentId, SessionId } from '@goodboy/types';
 import type { TranscriptItem } from '../../../chat/utils/transcript-items';
 import { PermissionScopePicker } from '../PermissionScopePicker';
@@ -49,9 +49,11 @@ export const PermissionRequestCard = ({ item, sessionId, agentId }: Props) => {
         or deny.
       </span>
       {inputPreview !== null && (
-        <pre className="min-w-0 whitespace-pre-wrap break-words rounded-md bg-background/60 px-2 py-1 font-mono text-2xs text-muted-foreground">
-          {inputPreview}
-        </pre>
+        <ClampedProse
+          text={inputPreview}
+          lines={4}
+          className="min-w-0 break-words rounded-md bg-background/60 px-2 py-1 font-mono text-2xs text-muted-foreground"
+        />
       )}
       {showPicker ? (
         <PermissionScopePicker

--- a/apps/desktop/src/features/plans/components/PlanStudio/index.tsx
+++ b/apps/desktop/src/features/plans/components/PlanStudio/index.tsx
@@ -151,76 +151,109 @@ export const PlanStudio = ({ sessionId }: Props) => {
                 />
               </div>
               <div className="flex shrink-0 flex-col items-end gap-1.5">
-                <div className="flex items-center gap-1.5">
-                  {selected.status !== 'discarded' ? (
-                    selected.status === 'consumed' ? (
-                      <Button
-                        variant="warning"
-                        emphasis="outline"
-                        size="sm"
-                        onClick={() => setReplayArmed(true)}
-                        disabled={spawning}
-                        title="Plan already ran, click to replay and confirm"
-                        className={cn(spawning && 'cursor-not-allowed animate-border-pulse')}
-                      >
-                        <RotateCw size={12} aria-hidden />
-                        Replay
-                      </Button>
-                    ) : (
-                      <Button
-                        variant="primary"
-                        size="sm"
-                        onClick={() => void handleTrigger()}
-                        disabled={spawning}
-                        className={cn(spawning && 'cursor-not-allowed animate-border-pulse')}
-                        title={
-                          selected.status === 'active'
-                            ? 'Spawn new agent to execute this plan'
-                            : 'Replay this plan'
-                        }
-                      >
-                        {selected.status === 'active' ? (
-                          <Play size={12} aria-hidden className="fill-current" />
-                        ) : (
+                {deleteArmed ? (
+                  <InlineConfirm
+                    role="danger"
+                    icon={<Trash2 size={12} aria-hidden />}
+                    title={`Delete "${selected.title}"?`}
+                    description="Moves this plan to discarded plans, where it can still be restored."
+                    confirmLabel={`Delete ${selected.title}`}
+                    autoDisarmMs={4000}
+                    onConfirm={() => {
+                      handleDiscard(selected);
+                      setDeleteArmed(false);
+                    }}
+                    onCancel={() => setDeleteArmed(false)}
+                    className="shrink-0"
+                  />
+                ) : replayArmed ? (
+                  <InlineConfirm
+                    role="alert"
+                    icon={<RotateCw size={12} aria-hidden />}
+                    title="Replay this plan?"
+                    description="It already ran once. Replaying spawns a new agent to execute it again."
+                    confirmLabel="Replay"
+                    autoDisarmMs={4000}
+                    isBusy={spawning}
+                    onConfirm={async () => {
+                      await handleTrigger();
+                      setReplayArmed(false);
+                    }}
+                    onCancel={() => setReplayArmed(false)}
+                    className="shrink-0"
+                  />
+                ) : (
+                  <div className="flex items-center gap-2">
+                    {selected.status !== 'discarded' ? (
+                      selected.status === 'consumed' ? (
+                        <Button
+                          variant="warning"
+                          emphasis="outline"
+                          size="sm"
+                          onClick={() => setReplayArmed(true)}
+                          disabled={spawning}
+                          title="Plan already ran, click to replay and confirm"
+                          className={cn(spawning && 'cursor-not-allowed animate-border-pulse')}
+                        >
                           <RotateCw size={12} aria-hidden />
-                        )}
-                        {selected.status === 'active' ? 'Start' : 'Replay'}
-                      </Button>
-                    )
-                  ) : null}
-                  {selected.status === 'consumed' ? (
-                    <Tooltip content="Consumed plans cannot be deleted">
-                      <span
-                        className="inline-flex cursor-not-allowed items-center justify-center rounded-md border border-border-soft p-1.5 text-danger/30"
-                        aria-label="Consumed plans cannot be deleted"
-                      >
-                        <Trash2 size={13} aria-hidden />
-                      </span>
-                    </Tooltip>
-                  ) : selected.status === 'discarded' ? (
-                    <Tooltip content="Restore plan">
-                      <button
-                        type="button"
-                        onClick={() => handleRestore(selected)}
-                        aria-label="Restore plan"
-                        className="inline-flex items-center justify-center rounded-md border border-info/20 p-1.5 text-info transition hover:border-info/40 hover:bg-info/10"
-                      >
-                        <ArchiveRestore size={13} aria-hidden />
-                      </button>
-                    </Tooltip>
-                  ) : (
-                    <Tooltip content="Delete plan (soft delete, click restore to recover)">
-                      <button
-                        type="button"
-                        onClick={() => setDeleteArmed(true)}
-                        aria-label="Delete plan"
-                        className="inline-flex items-center justify-center rounded-md border border-danger/20 p-1.5 text-danger transition hover:border-danger/40 hover:bg-danger/10"
-                      >
-                        <Trash2 size={13} aria-hidden />
-                      </button>
-                    </Tooltip>
-                  )}
-                </div>
+                          Replay
+                        </Button>
+                      ) : (
+                        <Button
+                          variant="primary"
+                          size="sm"
+                          onClick={() => void handleTrigger()}
+                          disabled={spawning}
+                          className={cn(spawning && 'cursor-not-allowed animate-border-pulse')}
+                          title={
+                            selected.status === 'active'
+                              ? 'Spawn new agent to execute this plan'
+                              : 'Replay this plan'
+                          }
+                        >
+                          {selected.status === 'active' ? (
+                            <Play size={12} aria-hidden className="fill-current" />
+                          ) : (
+                            <RotateCw size={12} aria-hidden />
+                          )}
+                          {selected.status === 'active' ? 'Start' : 'Replay'}
+                        </Button>
+                      )
+                    ) : null}
+                    {selected.status === 'consumed' ? (
+                      <Tooltip content="Consumed plans cannot be deleted">
+                        <span
+                          className="inline-flex cursor-not-allowed items-center justify-center rounded-md border border-border-soft p-1.5 text-danger/30"
+                          aria-label="Consumed plans cannot be deleted"
+                        >
+                          <Trash2 size={13} aria-hidden />
+                        </span>
+                      </Tooltip>
+                    ) : selected.status === 'discarded' ? (
+                      <Tooltip content="Restore plan">
+                        <button
+                          type="button"
+                          onClick={() => handleRestore(selected)}
+                          aria-label="Restore plan"
+                          className="inline-flex items-center justify-center rounded-md border border-info/20 p-1.5 text-info transition hover:border-info/40 hover:bg-info/10"
+                        >
+                          <ArchiveRestore size={13} aria-hidden />
+                        </button>
+                      </Tooltip>
+                    ) : (
+                      <Tooltip content="Delete plan (soft delete, click restore to recover)">
+                        <button
+                          type="button"
+                          onClick={() => setDeleteArmed(true)}
+                          aria-label="Delete plan"
+                          className="inline-flex items-center justify-center rounded-md border border-danger/20 p-1.5 text-danger transition hover:border-danger/40 hover:bg-danger/10"
+                        >
+                          <Trash2 size={13} aria-hidden />
+                        </button>
+                      </Tooltip>
+                    )}
+                  </div>
+                )}
                 <SegmentedTabs
                   ariaLabel="Content mode"
                   options={[
@@ -246,39 +279,6 @@ export const PlanStudio = ({ sessionId }: Props) => {
                 />
               </div>
             </div>
-            {deleteArmed ? (
-              <InlineConfirm
-                role="danger"
-                icon={<Trash2 size={12} aria-hidden />}
-                title={`Delete "${selected.title}"?`}
-                description="Moves this plan to discarded plans, where it can still be restored."
-                confirmLabel={`Delete ${selected.title}`}
-                autoDisarmMs={4000}
-                onConfirm={() => {
-                  handleDiscard(selected);
-                  setDeleteArmed(false);
-                }}
-                onCancel={() => setDeleteArmed(false)}
-                className="shrink-0"
-              />
-            ) : null}
-            {replayArmed && (
-              <InlineConfirm
-                role="alert"
-                icon={<RotateCw size={12} aria-hidden />}
-                title="Replay this plan?"
-                description="It already ran once. Replaying spawns a new agent to execute it again."
-                confirmLabel="Replay"
-                autoDisarmMs={4000}
-                isBusy={spawning}
-                onConfirm={async () => {
-                  await handleTrigger();
-                  setReplayArmed(false);
-                }}
-                onCancel={() => setReplayArmed(false)}
-                className="shrink-0"
-              />
-            )}
           </div>
           <Divider />
           <ScrollFade className="min-h-0 flex-1" viewportClassName={PANE_RHYTHM.body} fadeSize={24}>

--- a/apps/desktop/src/features/session/components/AgentInspector/ResolverPanelSection.tsx
+++ b/apps/desktop/src/features/session/components/AgentInspector/ResolverPanelSection.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { Eyebrow } from '@goodboy/ui';
+import { SectionHeader } from '@goodboy/ui';
 
 type Props = {
   readonly label: string;
@@ -8,7 +8,7 @@ type Props = {
 
 export const ResolverPanelSection = ({ label, children }: Props) => (
   <section className="flex flex-col gap-2">
-    <Eyebrow label={label} muted />
+    <SectionHeader label={label} />
     {children}
   </section>
 );

--- a/apps/desktop/src/features/session/components/AgentInspector/ResolverThreadLead.tsx
+++ b/apps/desktop/src/features/session/components/AgentInspector/ResolverThreadLead.tsx
@@ -14,7 +14,9 @@ export const ResolverThreadLead = ({ brief }: Props) => (
     {brief.ask !== '' && (
       <div className="flex min-w-0 gap-2">
         <dt className={ROW_LABEL_CLASS}>Ask</dt>
-        <dd className={ROW_VALUE_CLASS}>{brief.ask}</dd>
+        <dd className={ROW_VALUE_CLASS}>
+          <ClampedProse text={brief.ask} lines={3} className="text-xs leading-relaxed" />
+        </dd>
       </div>
     )}
     <div className="flex min-w-0 gap-2">

--- a/apps/desktop/src/features/session/components/AgentInspector/index.tsx
+++ b/apps/desktop/src/features/session/components/AgentInspector/index.tsx
@@ -57,7 +57,7 @@ export const AgentInspector = ({ sessionId, agentId, onClose }: Props) => {
         onClose={onClose}
       />
       <ScrollFade className="min-h-0 flex-1" viewportClassName={PANE_RHYTHM.rail.body}>
-        <div className="flex flex-col gap-4">
+        <div className={PANE_RHYTHM.stack}>
           <IdentitySection
             agent={agent}
             kind={kind}

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/SessionOverviewSkeleton.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/SessionOverviewSkeleton.tsx
@@ -12,12 +12,7 @@ export const SessionOverviewSkeleton = ({ isFreshLayout }: Props) => {
   return (
     <ScrollFade className="h-full" viewportClassName={PANE_RHYTHM.body} fadeSize={24}>
       <div
-        className={cn(
-          'flex flex-col',
-          PANE_RHYTHM.column,
-          PANE_RHYTHM.stack,
-          PANE_RHYTHM.measure.pane,
-        )}
+        className={cn(PANE_RHYTHM.column, PANE_RHYTHM.stack, PANE_RHYTHM.measure.pane)}
         role="status"
         aria-label="Loading session overview"
       >

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowRailCard.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowRailCard.tsx
@@ -1,5 +1,5 @@
 import type { Agent, Workflow, WorkflowOrigin, WorkflowRun } from '@goodboy/types';
-import { MetaRow, formatUsdPrecise } from '@goodboy/ui';
+import { ClampedProse, MetaRow, formatUsdPrecise } from '@goodboy/ui';
 import { classifyWorkflowChain } from '@goodboy/core';
 import { workflowKindName } from '../../../../workspace/components/WorkspacesSidebar/lib';
 import { WorkflowRunStatus } from '../../../../workspace/components/WorkspacesSidebar/parts/WorkflowRunStatus';
@@ -84,9 +84,6 @@ export const WorkflowRailCard = ({
               predecessorName={predecessorName}
               isOrchestrating={isOrchestrating}
             />
-            {stepLine != null ? (
-              <span className="line-clamp-1 text-2xs text-muted-foreground">{stepLine}</span>
-            ) : null}
           </>
         }
         meta={
@@ -124,6 +121,11 @@ export const WorkflowRailCard = ({
         className={isDiscarded ? 'pr-16' : undefined}
         onSelect={onSelect}
       />
+      {stepLine != null ? (
+        <div className="px-3 py-1">
+          <ClampedProse text={stepLine} lines={2} className="text-2xs text-muted-foreground" />
+        </div>
+      ) : null}
       {isDiscarded ? (
         <button
           type="button"

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowRunDetail.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowRunDetail.tsx
@@ -12,7 +12,7 @@ export const WorkflowRunDetail = ({ session, workflowRunId }: Props) => (
   <ScrollFade className="h-full min-w-0 flex-1" viewportClassName={PANE_RHYTHM.body} fadeSize={24}>
     <div
       className={cn(
-        'flex flex-col motion-safe:animate-studio-in',
+        'motion-safe:animate-studio-in',
         PANE_RHYTHM.column,
         PANE_RHYTHM.stack,
         PANE_RHYTHM.measure.pane,

--- a/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
@@ -779,12 +779,7 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
         <div className="flex min-h-0 w-full flex-1 flex-col">
           <ScrollFade className="min-h-0 flex-1">
             <div
-              className={cn(
-                'flex max-w-2xl flex-col',
-                PANE_RHYTHM.column,
-                PANE_RHYTHM.stack,
-                PANE_RHYTHM.body,
-              )}
+              className={cn('max-w-2xl', PANE_RHYTHM.column, PANE_RHYTHM.stack, PANE_RHYTHM.body)}
             >
               <section className="flex flex-col gap-2">
                 <SectionHeader

--- a/apps/desktop/src/features/session/components/WorkflowStepCard/index.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowStepCard/index.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode, useRef } from 'react';
 import { GripVertical, Trash2 } from 'lucide-react';
-import { Input, Textarea, cn } from '@goodboy/ui';
+import { ClampedProse, Input, Textarea, cn } from '@goodboy/ui';
 import type { AgentRole, ProviderId } from '@goodboy/types';
 import { agentKindPalette, ROLE_LABEL, ROLE_TO_KIND, type AgentKind } from '../../agent-kind';
 import { AgentAvatar } from '../../../../shared/components/AgentAvatar';
@@ -189,31 +189,32 @@ export const WorkflowStepCard = ({
       {!expanded ? (
         <div className="flex items-stretch">
           {grip}
-          <button
-            type="button"
-            onClick={onExpand}
-            aria-label={`Step ${ordinal + 1}: ${displayName}`}
-            title="Open this step to edit it"
-            className="flex min-w-0 flex-1 flex-col gap-1 py-2 pl-1 pr-8 text-left"
-          >
-            {headerRow(
-              <RoutingBadge
-                className="shrink-0"
-                glyphPlacement="trailing"
-                provider={provider}
-                model={resolvedModel}
-                effort={effort}
-              />,
-            )}
-            <span
-              className={cn(
-                'line-clamp-1 pl-[1.625rem] text-2xs leading-relaxed',
-                promptPrefix.trim() ? 'text-muted-foreground' : 'italic text-muted-foreground',
-              )}
+          <div className="flex min-w-0 flex-1 flex-col gap-1 py-2 pl-1 pr-8">
+            <button
+              type="button"
+              onClick={onExpand}
+              aria-label={`Step ${ordinal + 1}: ${displayName}`}
+              title="Open this step to edit it"
+              className="min-w-0 text-left"
             >
-              {promptPrefix.trim() || 'Click to add instructions'}
-            </span>
-          </button>
+              {headerRow(
+                <RoutingBadge
+                  className="shrink-0"
+                  glyphPlacement="trailing"
+                  provider={provider}
+                  model={resolvedModel}
+                  effort={effort}
+                />,
+              )}
+            </button>
+            <div className={cn('pl-[1.625rem]', promptPrefix.trim().length === 0 && 'italic')}>
+              <ClampedProse
+                text={promptPrefix.trim() || 'Click to add instructions'}
+                lines={2}
+                className="text-2xs leading-relaxed text-muted-foreground"
+              />
+            </div>
+          </div>
         </div>
       ) : null}
 

--- a/apps/desktop/src/features/session/resolverReplySummary.test.ts
+++ b/apps/desktop/src/features/session/resolverReplySummary.test.ts
@@ -18,11 +18,10 @@ describe('resolverReplySummary', () => {
     expect(resolverReplySummary({ text })).toBe('Use the translated label instead.');
   });
 
-  it('truncates a long first sentence at the character cap with an ellipsis', () => {
+  it('preserves a long first sentence for rendering through a disclosure', () => {
     const longSentence = `${'word '.repeat(30).trim()}.`;
     const result = resolverReplySummary({ text: longSentence });
-    expect(result.endsWith('...')).toBe(true);
-    expect(result.length).toBeLessThanOrEqual(123);
+    expect(result).toBe(longSentence);
   });
 
   it('returns an empty string for blank text', () => {

--- a/apps/desktop/src/features/session/resolverReplySummary.ts
+++ b/apps/desktop/src/features/session/resolverReplySummary.ts
@@ -4,8 +4,6 @@ type Params = {
   readonly text: string;
 };
 
-const MAX_LENGTH = 120;
-
 const SENTENCE_END = /(?<=[.!?])\s/;
 
 export const resolverReplySummary = ({ text }: Params): string => {
@@ -13,9 +11,5 @@ export const resolverReplySummary = ({ text }: Params): string => {
   if (flat === '') {
     return '';
   }
-  const first = flat.split(SENTENCE_END)[0] ?? flat;
-  if (first.length <= MAX_LENGTH) {
-    return first;
-  }
-  return `${first.slice(0, MAX_LENGTH).trimEnd()}...`;
+  return flat.split(SENTENCE_END)[0] ?? flat;
 };

--- a/apps/desktop/src/features/workflows/components/LibraryCard/index.tsx
+++ b/apps/desktop/src/features/workflows/components/LibraryCard/index.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Tooltip, cn } from '@goodboy/ui';
+import { ClampedProse, Tooltip, cn } from '@goodboy/ui';
 import { Check, GripVertical, Pencil, Trash2, X } from 'lucide-react';
 import type { StepDef } from '@goodboy/types';
 import { agentKindPalette, ROLE_LABEL, ROLE_TO_KIND } from '../../../session/agent-kind';
@@ -44,9 +44,11 @@ export const LibraryCard = ({ def, dragDisabled, onStartDrag, onEdit, onDelete }
           </span>
         </div>
         {def.promptPrefix ? (
-          <span className="line-clamp-1 text-2xs leading-relaxed text-muted-foreground/60">
-            {def.promptPrefix}
-          </span>
+          <ClampedProse
+            text={def.promptPrefix}
+            lines={2}
+            className="text-2xs leading-relaxed text-muted-foreground/60"
+          />
         ) : null}
       </div>
 

--- a/apps/desktop/src/features/workflows/components/PresetCard/index.tsx
+++ b/apps/desktop/src/features/workflows/components/PresetCard/index.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { SelectableRow } from '@goodboy/ui';
+import { ClampedProse, SelectableRow } from '@goodboy/ui';
 import { Check, Copy, Trash2, X } from 'lucide-react';
 import type { Workflow } from '@goodboy/types';
 import { inferAgentKindFromName, ROLE_TO_KIND } from '../../../session/agent-kind';
@@ -35,9 +35,6 @@ export const PresetCard = ({ template, active, onSelect, onDuplicate, onDelete }
             </span>
           </span>
         </div>
-        {description ? (
-          <span className="line-clamp-1 text-2xs text-muted-foreground/70">{description}</span>
-        ) : null}
         {steps.length > 0 ? (
           <span className="flex flex-wrap items-center gap-2 pr-8">
             {steps.map((step) => {
@@ -47,6 +44,15 @@ export const PresetCard = ({ template, active, onSelect, onDuplicate, onDelete }
           </span>
         ) : null}
       </SelectableRow>
+      {description ? (
+        <div className="px-2.5 py-1">
+          <ClampedProse
+            text={description}
+            lines={2}
+            className="text-2xs text-muted-foreground/70"
+          />
+        </div>
+      ) : null}
       {confirming ? (
         <div className="absolute right-1.5 top-1.5 flex items-center gap-0.5 rounded-md border border-border bg-background/95 px-1 py-0.5 shadow-sm backdrop-blur-sm">
           <span className="px-1 text-2xs text-muted-foreground">Delete?</span>

--- a/apps/desktop/src/shared/components/PaneShell/index.tsx
+++ b/apps/desktop/src/shared/components/PaneShell/index.tsx
@@ -37,7 +37,6 @@ export const PaneShell = (props: Props) => {
     <ScrollFade className="h-full" viewportClassName={PANE_RHYTHM.body} fadeSize={24}>
       <div
         className={cn(
-          'flex flex-col',
           animationClassName,
           PANE_RHYTHM.column,
           PANE_RHYTHM.stack,

--- a/apps/desktop/src/shared/components/StudioDetail/StudioDetailLayout.tsx
+++ b/apps/desktop/src/shared/components/StudioDetail/StudioDetailLayout.tsx
@@ -51,13 +51,11 @@ export const StudioDetailLayout = ({
         <Divider />
       </div>
       <div className={cn('flex min-w-0 flex-col', isFlow ? 'gap-4' : 'min-h-0 flex-1')}>
-        {isFlow ? <div className={cn('flex flex-col', PANE_RHYTHM.stack)}>{children}</div> : null}
+        {isFlow ? <div className={PANE_RHYTHM.stack}>{children}</div> : null}
         {fit === 'bleed' ? <div className="flex min-h-0 flex-1 flex-col">{children}</div> : null}
         {fit === 'fill' ? (
           <ScrollFade className="min-h-0 flex-1" viewportClassName={PANE_RHYTHM.body} fadeSize={24}>
-            <div className={cn('flex flex-col', PANE_RHYTHM.column, PANE_RHYTHM.stack, measure)}>
-              {children}
-            </div>
+            <div className={cn(PANE_RHYTHM.column, PANE_RHYTHM.stack, measure)}>{children}</div>
           </ScrollFade>
         ) : null}
         {dock != null ? <Divider /> : null}

--- a/apps/desktop/src/shared/components/StudioPanel/index.tsx
+++ b/apps/desktop/src/shared/components/StudioPanel/index.tsx
@@ -36,11 +36,7 @@ export const StudioPanel = ({
       <Divider />
       <div className="min-h-0 flex-1">
         <ScrollFade className="h-full" viewportClassName={PANE_RHYTHM.body} fadeSize={24}>
-          <div
-            className={cn('flex flex-col', PANE_RHYTHM.column, PANE_RHYTHM.stack, maxWidthClass)}
-          >
-            {children}
-          </div>
+          <div className={cn(PANE_RHYTHM.column, PANE_RHYTHM.stack, maxWidthClass)}>{children}</div>
         </ScrollFade>
       </div>
     </div>

--- a/packages/ui/src/paneRhythm.ts
+++ b/packages/ui/src/paneRhythm.ts
@@ -3,7 +3,7 @@ export const PANE_RHYTHM = {
   header: 'px-6 py-4',
   body: 'px-6 py-5',
   dock: 'px-6 py-4',
-  stack: 'gap-5',
+  stack: 'flex flex-col gap-5',
   column: 'mx-auto w-full',
   measure: {
     reading: 'max-w-3xl',


### PR DESCRIPTION
## Why

The action-zone, truncation and rhythm rules landed in #1449 with two surfaces migrated as worked examples and the rest listed. A written rule the code contradicts is worse than no rule, so this is the rest.

The owner's complaint that produced it: information split badly across the screen, eating vertical space and making the app read as cheap, because copy sizes, colours, headings and dividers differ between surfaces doing the same job.

## Rhythm

Migrated onto the canonical section header, divider and spacing: the `PlanStudio` focused detail header and confirmation layout, the resolver Comment, Thread and Changes sections, the agent inspector spacing between Identity and Cost, the GitHub pull request action bar and `SectionBody`, the GitHub Resolve board cards and controls, and the integration issue detail surfaces.

## Truncation

Six clamped strings gained the shared disclosure rather than ending in an ellipsis with nothing to click: `WorkflowStepCard`, `WorkflowRailCard`, the workflow preset and library cards, `resolverReplySummary`, `TurnErrorCallout`, and `PermissionRequestCard/formatRequestInput`.

## What was deliberately not given an expander

The identity clamps in `RailCard`, the workspace workflow-step rows, the activity bar, the plan-ready suggestion and the stage-board card are single-line names, not prose. They were audited for an accessible full name instead, because a truncated name needs to be readable, not expandable.

Display-time slices that build goals, slugs, prompts, bounded logs, diffs or stored titles were left alone. Those are data budgets, not hidden UI prose.

Surfaces being rebuilt on other open branches were skipped by agreement rather than collided with.

## Verification

- desktop and ui typechecks
- desktop suite 672 files, 5829 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

