### PR TITLE
refactor(desktop): finished work is visible without asking for it

### DIFF
--- a/apps/desktop/src/features/plans/components/PlanStudio/index.test.tsx
+++ b/apps/desktop/src/features/plans/components/PlanStudio/index.test.tsx
@@ -156,7 +156,7 @@ describe('PlanStudio', () => {
     expect(state.setActiveLens).toHaveBeenCalledWith('sess-1', 'agents');
   });
 
-  it('renders the consumed toggle as a row beneath Nothing active, not inside the empty state card', () => {
+  it('renders a consumed plan beneath the active empty state without interaction', () => {
     state.plans = [
       {
         id: 'plan-1',
@@ -172,16 +172,14 @@ describe('PlanStudio', () => {
     render(<PlanStudio sessionId={'sess-1' as never} />);
 
     expect(screen.getByText('Nothing active')).toBeDefined();
-    const toggle = screen.getByRole('button', { name: /consumed/i });
     const emptyCard = screen.getByText('Nothing active').closest('.border-dashed');
     expect(emptyCard).not.toBeNull();
-    expect(emptyCard?.contains(toggle)).toBe(false);
-
-    fireEvent.click(toggle);
     expect(screen.getByText('Implement auth module')).toBeDefined();
+    expect(screen.getByText('consumed')).toBeDefined();
+    expect(screen.getByRole('region', { name: 'Finished history' })).toBeDefined();
   });
 
-  it('shows the consumed toggle alongside active plans too', () => {
+  it('shows consumed plans alongside active plans too', () => {
     state.plans = [
       {
         id: 'plan-1',
@@ -207,7 +205,7 @@ describe('PlanStudio', () => {
     render(<PlanStudio sessionId={'sess-1' as never} />);
 
     expect(screen.queryByText('Nothing active')).toBeNull();
-    expect(screen.getByRole('button', { name: /consumed/i })).toBeDefined();
+    expect(screen.getByText('Old plan')).toBeDefined();
   });
 
   it('selects a plan from the list, focusing it', () => {

--- a/apps/desktop/src/features/plans/components/PlanStudio/index.tsx
+++ b/apps/desktop/src/features/plans/components/PlanStudio/index.tsx
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useState } from 'react';
 import { ArchiveRestore, CircleCheck, Eye, Pencil, Play, RotateCw, Trash2 } from 'lucide-react';
 import {
   Button,
-  CountToggle,
   Divider,
   InlineConfirm,
   Markdown,
@@ -24,6 +23,7 @@ import { PlanRailCard } from './PlanRailCard';
 import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../shared/components/conceptIcons';
 import { LensEmptyState } from '@goodboy/ui';
 import { useAgentStartedToast } from '../../../../shared/hooks/useAgentStartedToast';
+import { FinishedRegister } from '../../../../shared/components/FinishedRegister';
 
 type Props = {
   readonly sessionId: SessionId;
@@ -46,7 +46,6 @@ export const PlanStudio = ({ sessionId }: Props) => {
   const { showToast } = useToast();
   const announceAgentStarted = useAgentStartedToast();
 
-  const [showConsumed, setShowConsumed] = useState(false);
   const [mode, setMode] = useState<'preview' | 'edit'>('preview');
   const [draft, setDraft] = useState('');
   const [spawning, setSpawning] = useState(false);
@@ -305,6 +304,8 @@ export const PlanStudio = ({ sessionId }: Props) => {
 
   const active = plans.filter((plan) => plan.status === 'active');
   const consumed = plans.filter((plan) => plan.status !== 'active');
+  const visibleConsumed = consumed.slice(0, 30);
+  const earlierConsumed = consumed.slice(30);
 
   return (
     <PaneShell
@@ -325,7 +326,7 @@ export const PlanStudio = ({ sessionId }: Props) => {
           tone={CONCEPT_TONE.plans}
           icon={CONCEPT_ICONS.plans}
           title="Nothing active"
-          description="Every plan here already ran or was discarded. Show the consumed ones to reread them."
+          description="Every plan here already ran or was discarded. Finished plans remain below for reference."
         />
       ) : null}
       {active.length > 0 ? (
@@ -337,25 +338,29 @@ export const PlanStudio = ({ sessionId }: Props) => {
           ))}
         </ul>
       ) : null}
-      <div className="flex justify-center">
-        <CountToggle
-          label="Consumed"
-          itemsLabel="plans"
-          count={consumed.length}
-          isShown={showConsumed}
-          icon={CircleCheck}
-          onChange={setShowConsumed}
-        />
-      </div>
-      {showConsumed && consumed.length > 0 ? (
-        <ul className="flex flex-col gap-2">
-          {consumed.map((plan) => (
-            <li key={plan.id}>
-              <PlanRailCard plan={plan} onSelect={() => setFocusedPlanId(sessionId, plan.id)} />
-            </li>
-          ))}
-        </ul>
-      ) : null}
+      <FinishedRegister
+        label="Finished"
+        count={consumed.length}
+        visible={
+          <ul className="flex flex-col gap-2">
+            {visibleConsumed.map((plan) => (
+              <li key={plan.id}>
+                <PlanRailCard plan={plan} onSelect={() => setFocusedPlanId(sessionId, plan.id)} />
+              </li>
+            ))}
+          </ul>
+        }
+        earlierCount={earlierConsumed.length}
+        earlier={
+          <ul className="flex flex-col gap-2">
+            {earlierConsumed.map((plan) => (
+              <li key={plan.id}>
+                <PlanRailCard plan={plan} onSelect={() => setFocusedPlanId(sessionId, plan.id)} />
+              </li>
+            ))}
+          </ul>
+        }
+      />
     </PaneShell>
   );
 };

--- a/apps/desktop/src/features/plans/components/PlanStudio/index.tsx
+++ b/apps/desktop/src/features/plans/components/PlanStudio/index.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import { ArchiveRestore, CircleCheck, Eye, Pencil, Play, RotateCw, Trash2 } from 'lucide-react';
+import { ArchiveRestore, Eye, Pencil, Play, RotateCw, Trash2 } from 'lucide-react';
 import {
   Button,
   Divider,

--- a/apps/desktop/src/features/session/components/ResolverAgentsLane/ResolverCard.tsx
+++ b/apps/desktop/src/features/session/components/ResolverAgentsLane/ResolverCard.tsx
@@ -149,6 +149,7 @@ export const ResolverCard = ({
       status={
         <>
           <Chip tone="neutral" size="sm" label={origin.label} />
+          {isMuted ? <Chip tone="success" size="xs" bordered={false} label="completed" /> : null}
           <ResolverCardTally agent={agent} sessionId={agent.sessionId} />
         </>
       }

--- a/apps/desktop/src/features/session/components/ResolverAgentsLane/index.test.tsx
+++ b/apps/desktop/src/features/session/components/ResolverAgentsLane/index.test.tsx
@@ -241,6 +241,7 @@ describe('ResolverAgentsLane', () => {
     expect(
       screen.getAllByTestId('resolver-row').map((row) => row.getAttribute('data-muted')),
     ).toEqual(['false', 'false', 'true', 'true']);
+    expect(screen.getByRole('region', { name: 'Completed history' })).toBeDefined();
   });
 
   it('keeps a resolver active while its thread is still open', () => {

--- a/apps/desktop/src/features/session/components/ResolverAgentsLane/index.tsx
+++ b/apps/desktop/src/features/session/components/ResolverAgentsLane/index.tsx
@@ -1,6 +1,5 @@
 import { useEffect, type ReactNode } from 'react';
 import type { AgentId, Session } from '@goodboy/types';
-import { EmptyState } from '@goodboy/ui';
 import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../shared/components/conceptIcons';
 import { LensEmptyState } from '@goodboy/ui';
 import { AgentLane } from '../AgentLane';
@@ -15,7 +14,7 @@ const VISIBLE_FINISHED_COUNT = 30;
 const NOTHING_TO_RESOLVE_DESCRIPTION =
   'Spawn a resolver from a pull request comment or a diff selection and it will show up here.';
 const ALL_RESOLVED_DESCRIPTION =
-  'Every resolver here has finished. Show completed resolvers to review what they did.';
+  'Every resolver here has finished. Completed resolvers remain below for reference.';
 
 type Props = {
   readonly session: Session;

--- a/apps/desktop/src/features/session/components/ResolverAgentsLane/index.tsx
+++ b/apps/desktop/src/features/session/components/ResolverAgentsLane/index.tsx
@@ -8,6 +8,9 @@ import { ResolveCommentsAction } from './ResolveCommentsAction';
 import { ResolverLaneToolbar } from './ResolverLaneToolbar';
 import { ResolverRows } from './ResolverRows';
 import { useResolverAgentsLane } from './useResolverAgentsLane';
+import { FinishedRegister } from '../../../../shared/components/FinishedRegister';
+
+const VISIBLE_FINISHED_COUNT = 30;
 
 const NOTHING_TO_RESOLVE_DESCRIPTION =
   'Spawn a resolver from a pull request comment or a diff selection and it will show up here.';
@@ -94,26 +97,55 @@ export const ResolverAgentsLane = ({
             />
           ) : null}
           {filedToggle}
-          {showCompleted && lane.completedEntries.length > 0 ? (
-            <ResolverRows
-              entries={lane.completedEntries}
-              activeIds={lane.activeIds}
-              canOpenDiff={lane.canOpenDiff}
-              isQueueStalled={lane.isStalled}
-              isTaskActive={lane.isTaskActive}
-              isTranscriptLoading={lane.isTranscriptLoading}
-              isMuted
-              selectedAgentId={lane.selectedAgentId}
-              inspectedAgentId={inspectedResolverId}
-              commentByThreadId={lane.commentByThreadId}
-              diffCommentByAgentId={lane.diffCommentByAgentId}
-              metrics={lane.metrics}
-              reportedCommitShaByAgentId={lane.reportedCommitShaByAgentId}
-              diffTargetByAgentId={lane.diffTargetByAgentId}
-              onOpenChat={lane.onOpenChat}
-              onInspect={onInspectResolver}
-              onJump={lane.onJump}
-              onOpenDiff={lane.onOpenDiff}
+          {showCompleted ? (
+            <FinishedRegister
+              label="Completed"
+              count={lane.completedEntries.length}
+              visible={
+                <ResolverRows
+                  entries={lane.completedEntries.slice(0, VISIBLE_FINISHED_COUNT)}
+                  activeIds={lane.activeIds}
+                  canOpenDiff={lane.canOpenDiff}
+                  isQueueStalled={lane.isStalled}
+                  isTaskActive={lane.isTaskActive}
+                  isTranscriptLoading={lane.isTranscriptLoading}
+                  isMuted
+                  selectedAgentId={lane.selectedAgentId}
+                  inspectedAgentId={inspectedResolverId}
+                  commentByThreadId={lane.commentByThreadId}
+                  diffCommentByAgentId={lane.diffCommentByAgentId}
+                  metrics={lane.metrics}
+                  reportedCommitShaByAgentId={lane.reportedCommitShaByAgentId}
+                  diffTargetByAgentId={lane.diffTargetByAgentId}
+                  onOpenChat={lane.onOpenChat}
+                  onInspect={onInspectResolver}
+                  onJump={lane.onJump}
+                  onOpenDiff={lane.onOpenDiff}
+                />
+              }
+              earlierCount={Math.max(0, lane.completedEntries.length - VISIBLE_FINISHED_COUNT)}
+              earlier={
+                <ResolverRows
+                  entries={lane.completedEntries.slice(VISIBLE_FINISHED_COUNT)}
+                  activeIds={lane.activeIds}
+                  canOpenDiff={lane.canOpenDiff}
+                  isQueueStalled={lane.isStalled}
+                  isTaskActive={lane.isTaskActive}
+                  isTranscriptLoading={lane.isTranscriptLoading}
+                  isMuted
+                  selectedAgentId={lane.selectedAgentId}
+                  inspectedAgentId={inspectedResolverId}
+                  commentByThreadId={lane.commentByThreadId}
+                  diffCommentByAgentId={lane.diffCommentByAgentId}
+                  metrics={lane.metrics}
+                  reportedCommitShaByAgentId={lane.reportedCommitShaByAgentId}
+                  diffTargetByAgentId={lane.diffTargetByAgentId}
+                  onOpenChat={lane.onOpenChat}
+                  onInspect={onInspectResolver}
+                  onJump={lane.onJump}
+                  onOpenDiff={lane.onOpenDiff}
+                />
+              }
             />
           ) : null}
         </div>

--- a/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
@@ -56,8 +56,6 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
   const sessionId = session.id as SessionId;
   const [inspectedResolverId, setInspectedResolverId] = useState<AgentId | null>(null);
   const [inspectedAgentId, setInspectedAgentId] = useState<AgentId | null>(null);
-  const [showCompletedAgents, setShowCompletedAgents] = useState(false);
-  const [showCompletedResolvers, setShowCompletedResolvers] = useState(false);
   const hasInitializedResolverInspector = useRef(false);
   const hasInitializedAgentInspector = useRef(false);
   const storedActiveLens = useAppStore((s) => s.activeLens[sessionId]);
@@ -289,8 +287,6 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
                 meta={resolveMeta}
                 inspectedResolverId={inspectedResolverId}
                 onInspectResolver={setInspectedResolverId}
-                showCompleted={showCompletedResolvers}
-                onShowCompletedChange={setShowCompletedResolvers}
               />
             ) : null}
             {lens === 'scripts' ? (
@@ -403,8 +399,6 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
                 meta={agentsMeta}
                 inspectedAgentId={inspectedAgentId}
                 onInspectAgent={setInspectedAgentId}
-                showCompleted={showCompletedAgents}
-                onShowCompletedChange={setShowCompletedAgents}
               />
             </Pane>
           </div>

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/AgentsPane.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/AgentsPane.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, render, screen } from '@testing-library/react';
 import type { Session } from '@goodboy/types';
 
 vi.mock('@goodboy/ui', async (importOriginal) => ({
@@ -83,8 +83,6 @@ describe('AgentsPane', () => {
         meta={undefined}
         inspectedAgentId={null}
         onInspectAgent={vi.fn()}
-        showCompleted={false}
-        onShowCompletedChange={vi.fn()}
       />,
     );
 
@@ -103,8 +101,6 @@ describe('AgentsPane', () => {
         meta={undefined}
         inspectedAgentId={'agent-7' as never}
         onInspectAgent={vi.fn()}
-        showCompleted={false}
-        onShowCompletedChange={vi.fn()}
       />,
     );
 
@@ -113,27 +109,18 @@ describe('AgentsPane', () => {
     expect(lane.getAttribute('data-inspected')).toBe('agent-7');
   });
 
-  it('places the completed toggle after the list, not in the header, and forwards its state', () => {
-    const onShowCompletedChange = vi.fn();
+  it('shows completed agents in the lane without interaction', () => {
     render(
       <AgentsPane
         session={SESSION}
         meta={undefined}
         inspectedAgentId={null}
         onInspectAgent={vi.fn()}
-        showCompleted={false}
-        onShowCompletedChange={onShowCompletedChange}
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Report completed agents' }));
-    const toggle = screen.getByRole('button', { name: 'Completed (2)' });
-    const create = screen.getByTestId('header-spawn');
     const lane = screen.getByTestId('agents-lane');
-    expect(create.compareDocumentPosition(toggle) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-    expect(lane.contains(toggle)).toBe(true);
-    fireEvent.click(toggle);
-    expect(onShowCompletedChange).toHaveBeenCalledWith(true);
-    expect(screen.getByTestId('agents-lane').getAttribute('data-show-completed')).toBe('false');
+    expect(lane.getAttribute('data-show-completed')).toBe('true');
+    expect(screen.queryByRole('button', { name: /Completed/ })).toBeNull();
   });
 });

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/AgentsPane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/AgentsPane.tsx
@@ -1,6 +1,3 @@
-import { useState } from 'react';
-import { CircleCheck } from 'lucide-react';
-import { CountToggle } from '@goodboy/ui';
 import type { AgentId, Session, SessionId } from '@goodboy/types';
 import { AgentInspector } from '../../AgentInspector';
 import { CreateAgentPopover } from '../../CreateAgentPopover';
@@ -13,20 +10,10 @@ type Props = {
   readonly meta: string | undefined;
   readonly inspectedAgentId: AgentId | null;
   readonly onInspectAgent: (agentId: AgentId | null) => void;
-  readonly showCompleted: boolean;
-  readonly onShowCompletedChange: (showCompleted: boolean) => void;
 };
 
-export const AgentsPane = ({
-  session,
-  meta,
-  inspectedAgentId,
-  onInspectAgent,
-  showCompleted,
-  onShowCompletedChange,
-}: Props) => {
+export const AgentsPane = ({ session, meta, inspectedAgentId, onInspectAgent }: Props) => {
   const sessionId = session.id as SessionId;
-  const [completedCount, setCompletedCount] = useState(0);
 
   return (
     <InspectorSplit
@@ -52,20 +39,7 @@ export const AgentsPane = ({
           variant="lens"
           inspectedAgentId={inspectedAgentId}
           onInspectAgent={(agentId) => onInspectAgent(agentId)}
-          showCompleted={showCompleted}
-          onCompletedCountChange={setCompletedCount}
-          filedToggle={
-            <div className="flex justify-center">
-              <CountToggle
-                label="Completed"
-                itemsLabel="agents"
-                count={completedCount}
-                isShown={showCompleted}
-                icon={CircleCheck}
-                onChange={onShowCompletedChange}
-              />
-            </div>
-          }
+          showCompleted
         />
       </PaneShell>
     </InspectorSplit>

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/QuestionsPane.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/QuestionsPane.test.tsx
@@ -599,7 +599,7 @@ describe('QuestionsPane', () => {
       expect(screen.queryByTestId(/^answered-card-/)).toBeNull();
     });
 
-    it('hides answered cards behind the Answered toggle by default', () => {
+    it('shows answered cards without interaction', () => {
       const scout = mkAgent('agent_scout', undefined, 'scout');
       setupStore({
         openQuestions: [],
@@ -615,11 +615,11 @@ describe('QuestionsPane', () => {
       });
 
       render(<QuestionsPane session={BASE_SESSION} />);
-      expect(screen.queryByTestId('answered-card-aq1')).toBeNull();
-      expect(screen.getByRole('button', { name: /answered/i })).toBeDefined();
+      expect(screen.getByTestId('answered-card-aq1')).toBeDefined();
+      expect(screen.getByRole('region', { name: 'Answered history' })).toBeDefined();
     });
 
-    it('renders answered cards grouped by creator agent once the toggle is opened', () => {
+    it('renders answered cards grouped by creator agent', () => {
       const scout = mkAgent('agent_scout', undefined, 'scout');
       setupStore({
         openQuestions: [],
@@ -641,7 +641,6 @@ describe('QuestionsPane', () => {
       });
 
       render(<QuestionsPane session={BASE_SESSION} />);
-      fireEvent.click(screen.getByRole('button', { name: /answered/i }));
       expect(screen.getByTestId('answered-card-aq1')).toBeDefined();
       expect(screen.getByTestId('answered-card-aq2')).toBeDefined();
       expect(screen.getByText('scout')).toBeDefined();
@@ -682,7 +681,6 @@ describe('QuestionsPane', () => {
       });
 
       render(<QuestionsPane session={BASE_SESSION} />);
-      fireEvent.click(screen.getByRole('button', { name: /answered/i }));
       expect(screen.getByText('scout')).toBeDefined();
       expect(screen.getByText('fixer')).toBeDefined();
       expect(screen.getByTestId('answered-card-aq1')).toBeDefined();
@@ -712,7 +710,6 @@ describe('QuestionsPane', () => {
       });
 
       render(<QuestionsPane session={BASE_SESSION} />);
-      fireEvent.click(screen.getByRole('button', { name: /answered/i }));
       const agentLabels = screen.getAllByText(/.*-agent$/);
       expect(agentLabels[0]!.textContent).toBe('newer-agent');
       expect(agentLabels[1]!.textContent).toBe('older-agent');
@@ -734,12 +731,11 @@ describe('QuestionsPane', () => {
       });
 
       render(<QuestionsPane session={BASE_SESSION} />);
-      fireEvent.click(screen.getByRole('button', { name: /answered/i }));
       fireEvent.click(screen.getByText('scout'));
       expect(mockSelectAgent).toHaveBeenCalledWith(SESSION_ID, scout.id);
     });
 
-    it('renders answered section below open questions when the toggle is opened', () => {
+    it('renders answered section below open questions', () => {
       const scout = mkAgent('agent_scout', undefined, 'scout');
       setupStore({
         openQuestions: [mkQuestion('open1', { createdByAgentId: scout.id })],
@@ -756,9 +752,6 @@ describe('QuestionsPane', () => {
 
       render(<QuestionsPane session={BASE_SESSION} />);
       expect(screen.getByTestId('question-card-open1')).toBeDefined();
-      expect(screen.queryByTestId('answered-card-aq1')).toBeNull();
-
-      fireEvent.click(screen.getByRole('button', { name: /answered/i }));
       expect(screen.getByTestId('answered-card-aq1')).toBeDefined();
     });
   });

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/QuestionsPane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/QuestionsPane.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Bot, Check } from 'lucide-react';
-import { CountToggle, Skeleton } from '@goodboy/ui';
+import { useCallback, useEffect, useMemo } from 'react';
+import { Bot } from 'lucide-react';
+import { Skeleton } from '@goodboy/ui';
 import { LensEmptyState } from '@goodboy/ui';
 import type {
   Agent,
@@ -33,6 +33,7 @@ import {
 import { selectOpenQuestions } from '../../SessionOverviewPane/lib';
 import { PaneShell } from '../../../../../shared/components/PaneShell';
 import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../../shared/components/conceptIcons';
+import { FinishedRegister } from '../../../../../shared/components/FinishedRegister';
 
 type AnswerPair = { id: OpenQuestionId; text: string; answer: string };
 
@@ -253,7 +254,6 @@ export const QuestionsPane = ({ session }: QuestionsPaneProps) => {
   const answerOpenQuestions = useAppStore((s) => s.answerOpenQuestions);
   const dismissOpenQuestion = useAppStore((s) => s.dismissOpenQuestion);
   const restoreDismissedOpenQuestion = useAppStore((s) => s.restoreDismissedOpenQuestion);
-  const [showAnswered, setShowAnswered] = useState(false);
 
   useEffect(() => {
     void loadSessionOpenQuestions(sessionId);
@@ -349,27 +349,17 @@ export const QuestionsPane = ({ session }: QuestionsPaneProps) => {
   if (open.length === 0 && pendingUndoQuestion === null) {
     return (
       <PaneShell title="Questions" description="Decisions agents need from you to keep going.">
-        {showAnswered ? null : (
-          <LensEmptyState
-            tone={CONCEPT_TONE.questions}
-            icon={CONCEPT_ICONS.questions}
-            title="Nothing needs you right now"
-            description={`Every question on this session is answered. Reveal the ${answered.length} answered ${answered.length === 1 ? 'one' : 'ones'} to reread them.`}
-          />
-        )}
-        <div className="flex justify-center">
-          <CountToggle
-            label="Answered"
-            itemsLabel="questions"
-            count={answered.length}
-            isShown={showAnswered}
-            icon={Check}
-            onChange={setShowAnswered}
-          />
-        </div>
-        {showAnswered ? (
-          <AnsweredHistory clusters={answeredClusters} sessionId={sessionId} />
-        ) : null}
+        <LensEmptyState
+          tone={CONCEPT_TONE.questions}
+          icon={CONCEPT_ICONS.questions}
+          title="Nothing needs you right now"
+          description="Every question on this session is answered. Answered questions remain below for reference."
+        />
+        <FinishedRegister
+          label="Answered"
+          count={answered.length}
+          visible={<AnsweredHistory clusters={answeredClusters} sessionId={sessionId} />}
+        />
       </PaneShell>
     );
   }
@@ -402,19 +392,11 @@ export const QuestionsPane = ({ session }: QuestionsPaneProps) => {
             onSubmit={(pairs, ownerAgentId) => void handleSubmit(pairs, ownerAgentId)}
           />
         ))}
-        <div className="flex justify-center">
-          <CountToggle
-            label="Answered"
-            itemsLabel="questions"
-            count={answered.length}
-            isShown={showAnswered}
-            icon={Check}
-            onChange={setShowAnswered}
-          />
-        </div>
-        {showAnswered ? (
-          <AnsweredHistory clusters={answeredClusters} sessionId={sessionId} />
-        ) : null}
+        <FinishedRegister
+          label="Answered"
+          count={answered.length}
+          visible={<AnsweredHistory clusters={answeredClusters} sessionId={sessionId} />}
+        />
       </div>
     </PaneShell>
   );

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/ResolvePane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/ResolvePane.tsx
@@ -1,6 +1,3 @@
-import { useState } from 'react';
-import { CircleCheck } from 'lucide-react';
-import { CountToggle } from '@goodboy/ui';
 import type { AgentId, Session, SessionId } from '@goodboy/types';
 import { useAppStore } from '../../../../../store';
 import { ResolverAgentsLane } from '../../ResolverAgentsLane';
@@ -11,21 +8,11 @@ type Props = {
   readonly meta: string | undefined;
   readonly inspectedResolverId: AgentId | null;
   readonly onInspectResolver: (agentId: AgentId | null) => void;
-  readonly showCompleted: boolean;
-  readonly onShowCompletedChange: (showCompleted: boolean) => void;
 };
 
-export const ResolvePane = ({
-  session,
-  meta,
-  inspectedResolverId,
-  onInspectResolver,
-  showCompleted,
-  onShowCompletedChange,
-}: Props) => {
+export const ResolvePane = ({ session, meta, inspectedResolverId, onInspectResolver }: Props) => {
   const sessionId = session.id as SessionId;
   const selectAgent = useAppStore((s) => s.selectAgent);
-  const [completedCount, setCompletedCount] = useState(0);
 
   return (
     <PaneShell
@@ -40,20 +27,7 @@ export const ResolvePane = ({
           onInspectResolver(agentId);
           void selectAgent(sessionId, agentId);
         }}
-        showCompleted={showCompleted}
-        onCompletedCountChange={setCompletedCount}
-        filedToggle={
-          <div className="flex justify-center">
-            <CountToggle
-              label="Completed"
-              itemsLabel="resolvers"
-              count={completedCount}
-              isShown={showCompleted}
-              icon={CircleCheck}
-              onChange={onShowCompletedChange}
-            />
-          </div>
-        }
+        showCompleted
       />
     </PaneShell>
   );

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowsPane.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowsPane.test.tsx
@@ -279,8 +279,6 @@ describe('WorkflowsPane', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Completed (1)' }));
-
     expect(screen.getByText('2 of 2 steps run')).toBeDefined();
     expect(screen.getByText('3m')).toBeDefined();
     expect(screen.getByText('Last: Second')).toBeDefined();
@@ -313,8 +311,6 @@ describe('WorkflowsPane', () => {
         })}
       />,
     );
-
-    fireEvent.click(screen.getByRole('button', { name: 'Completed (1)' }));
 
     expect(screen.getByText('1 step run')).toBeDefined();
     expect(screen.queryByText('1 of 2 steps run')).toBeNull();
@@ -371,7 +367,7 @@ describe('WorkflowsPane', () => {
     expect(screen.getByText('Second workflow')).toBeDefined();
   });
 
-  it('shows the empty state when every run is completed and none is revealed', () => {
+  it('keeps the active empty state above always-visible completed runs', () => {
     render(
       <WorkflowsPane
         session={buildSession({
@@ -385,17 +381,15 @@ describe('WorkflowsPane', () => {
     );
 
     expect(screen.getByTestId('workflow-empty').textContent).toContain('Nothing running');
-    expect(screen.queryByText('First workflow')).toBeNull();
+    expect(screen.getByText('First workflow')).toBeDefined();
     expect(screen.getAllByRole('button', { name: 'Attach another workflow' })).toHaveLength(1);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Completed (2)' }));
-
     expect(screen.getByTestId('workflow-empty').textContent).toContain('Nothing running');
-    expect(screen.getByText('First workflow')).toBeDefined();
+    expect(screen.getByRole('region', { name: 'Finished history' })).toBeDefined();
     expect(screen.getAllByRole('button', { name: 'Attach another workflow' })).toHaveLength(1);
   });
 
-  it('files a discarded run under its own toggle instead of the active list', () => {
+  it('shows a discarded run below the active list with its true state', () => {
     render(
       <WorkflowsPane
         session={buildSession({
@@ -405,12 +399,9 @@ describe('WorkflowsPane', () => {
       />,
     );
 
-    expect(screen.queryByText('First workflow')).toBeNull();
-    expect(screen.getByText('Second workflow')).toBeDefined();
-
-    fireEvent.click(screen.getByRole('button', { name: 'Discarded (1)' }));
-
     expect(screen.getByText('First workflow')).toBeDefined();
+    expect(screen.getByText('Second workflow')).toBeDefined();
+    expect(screen.getByText('Discarded')).toBeDefined();
   });
 
   it('keeps the attach action when a revealed bucket is empty', () => {
@@ -425,7 +416,6 @@ describe('WorkflowsPane', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Completed (1)' }));
     rerender(
       <WorkflowsPane
         session={buildSession({
@@ -449,7 +439,6 @@ describe('WorkflowsPane', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Discarded (1)' }));
     fireEvent.click(screen.getByRole('button', { name: 'Restore' }));
 
     expect(store.restoreWorkflow).toHaveBeenCalledWith(SESSION_ID, 'run-1');
@@ -494,7 +483,7 @@ describe('WorkflowsPane', () => {
     expect(screen.queryByText('Stopping')).toBeNull();
   });
 
-  it('files a completed dynamic run under the completed toggle', () => {
+  it('shows a completed dynamic run below active work without interaction', () => {
     render(
       <WorkflowsPane
         session={buildSession({
@@ -506,10 +495,7 @@ describe('WorkflowsPane', () => {
       />,
     );
 
-    expect(screen.queryByText('First workflow')).toBeNull();
-
-    fireEvent.click(screen.getByRole('button', { name: 'Completed (1)' }));
-
     expect(screen.getByText('First workflow')).toBeDefined();
+    expect(screen.getByText('Completed')).toBeDefined();
   });
 });

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowsPane.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowsPane.test.tsx
@@ -404,6 +404,25 @@ describe('WorkflowsPane', () => {
     expect(screen.getByText('Discarded')).toBeDefined();
   });
 
+  it('keeps the finished list in ordinal order across completed and discarded runs', () => {
+    render(
+      <WorkflowsPane
+        session={buildSession({
+          runIds: ['run-1', 'run-2'],
+          runOverrides: {
+            'run-1': { executionMode: 'dynamic', orchestrationOutcome: 'done' },
+            'run-2': { discardedAt: '2026-07-21T10:00:00.000Z' },
+          },
+        })}
+      />,
+    );
+
+    const finishedList = screen.getByRole('region', { name: 'Finished history' });
+    const text = finishedList.textContent ?? '';
+
+    expect(text.indexOf('Second workflow')).toBeLessThan(text.indexOf('First workflow'));
+  });
+
   it('keeps the attach action when a revealed bucket is empty', () => {
     const { rerender } = render(
       <WorkflowsPane

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowsPane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowsPane.tsx
@@ -1,6 +1,4 @@
-import { useState } from 'react';
-import { Archive, BookmarkPlus, Check } from 'lucide-react';
-import { CountToggle } from '@goodboy/ui';
+import { BookmarkPlus } from 'lucide-react';
 import type { Agent, Session, SessionId, Workflow, WorkflowRun } from '@goodboy/types';
 import { EMPTY_ARRAY, useAppStore } from '../../../../../store';
 import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../../shared/components/conceptIcons';
@@ -16,6 +14,9 @@ import { useAgentMetrics } from '../../../hooks/useAgentMetrics';
 import { PaneShell } from '../../../../../shared/components/PaneShell';
 import { FocusedPane } from '../../../../../shared/components/PaneShell/FocusedPane';
 import { GhostActionButton } from '@goodboy/ui';
+import { FinishedRegister } from '../../../../../shared/components/FinishedRegister';
+
+const VISIBLE_FINISHED_COUNT = 30;
 
 type Props = {
   readonly session: Session;
@@ -35,7 +36,6 @@ export const WorkflowsPane = ({ session }: Props) => {
   const orchestratingWorkflowRuns = useAppStore((state) => state.orchestratingWorkflowRuns);
   const setFocusedWorkflowRun = useAppStore((state) => state.setFocusedWorkflowRun);
   const restoreWorkflow = useAppStore((state) => state.restoreWorkflow);
-  const [showFiled, setShowFiled] = useState(false);
   const { agentsByRunId, discarded, completed, active } = splitWorkflowRuns({
     attachedRuns,
     agents: phaseRuns,
@@ -129,32 +129,21 @@ export const WorkflowsPane = ({ session }: Props) => {
         />
       ) : null}
       {active.length > 0 ? <ul className="flex flex-col gap-2">{active.map(renderCard)}</ul> : null}
-      <div className="flex justify-center">
-        <div className="flex flex-wrap items-center justify-center gap-2">
-          <CountToggle
-            label="Completed"
-            itemsLabel="workflows"
-            count={completed.length}
-            isShown={showFiled}
-            icon={Check}
-            onChange={setShowFiled}
-          />
-          <CountToggle
-            label="Discarded"
-            itemsLabel="workflows"
-            count={discarded.length}
-            isShown={showFiled}
-            icon={Archive}
-            onChange={setShowFiled}
-          />
-        </div>
-      </div>
-      {showFiled && completed.length > 0 ? (
-        <ul className="flex flex-col gap-2">{completed.map(renderCard)}</ul>
-      ) : null}
-      {showFiled && discarded.length > 0 ? (
-        <ul className="flex flex-col gap-2">{discarded.map(renderCard)}</ul>
-      ) : null}
+      <FinishedRegister
+        label="Finished"
+        count={completed.length + discarded.length}
+        visible={
+          <ul className="flex flex-col gap-2">
+            {[...completed, ...discarded].slice(0, VISIBLE_FINISHED_COUNT).map(renderCard)}
+          </ul>
+        }
+        earlierCount={Math.max(0, completed.length + discarded.length - VISIBLE_FINISHED_COUNT)}
+        earlier={
+          <ul className="flex flex-col gap-2">
+            {[...completed, ...discarded].slice(VISIBLE_FINISHED_COUNT).map(renderCard)}
+          </ul>
+        }
+      />
     </PaneShell>
   );
 };

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowsPane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowsPane.tsx
@@ -48,6 +48,8 @@ export const WorkflowsPane = ({ session }: Props) => {
   const hasActiveRuns = active.length > 0;
   const shouldShowHeaderAttach = hasRuns && (focusedRun != null || hasActiveRuns);
   const shouldShowEmptyCard = hasRuns && focusedRun == null && !hasActiveRuns;
+  const finishedRunIds = new Set([...completed, ...discarded].map(({ run }) => run.id));
+  const finished = attachedRuns.filter(({ run }) => finishedRunIds.has(run.id));
 
   const renderCard = ({ run, workflow }: { run: WorkflowRun; workflow: Workflow }) => {
     const agents = agentsByRunId.get(run.id) ?? EMPTY_ARRAY;
@@ -120,27 +122,23 @@ export const WorkflowsPane = ({ session }: Props) => {
           tone={CONCEPT_TONE.workflows}
           icon={CONCEPT_ICONS.workflows}
           title="Nothing running"
-          description={
-            completed.length > 0
-              ? 'Every attached workflow is done. Reveal the completed ones to reread them, or attach another.'
-              : 'No live workflow on this session. Attach one to start.'
-          }
+          description="Every attached workflow is done. Finished workflows remain below for reference."
           action={<WorkflowAttachButton sessionId={sessionId} placement="header" />}
         />
       ) : null}
       {active.length > 0 ? <ul className="flex flex-col gap-2">{active.map(renderCard)}</ul> : null}
       <FinishedRegister
         label="Finished"
-        count={completed.length + discarded.length}
+        count={finished.length}
         visible={
           <ul className="flex flex-col gap-2">
-            {[...completed, ...discarded].slice(0, VISIBLE_FINISHED_COUNT).map(renderCard)}
+            {finished.slice(0, VISIBLE_FINISHED_COUNT).map(renderCard)}
           </ul>
         }
-        earlierCount={Math.max(0, completed.length + discarded.length - VISIBLE_FINISHED_COUNT)}
+        earlierCount={Math.max(0, finished.length - VISIBLE_FINISHED_COUNT)}
         earlier={
           <ul className="flex flex-col gap-2">
-            {[...completed, ...discarded].slice(VISIBLE_FINISHED_COUNT).map(renderCard)}
+            {finished.slice(VISIBLE_FINISHED_COUNT).map(renderCard)}
           </ul>
         }
       />

--- a/apps/desktop/src/features/session/components/StandaloneAgentsLane/index.test.tsx
+++ b/apps/desktop/src/features/session/components/StandaloneAgentsLane/index.test.tsx
@@ -119,6 +119,7 @@ describe('StandaloneAgentsLane', () => {
     expect(screen.getAllByTestId('agent-row').map((row) => row.getAttribute('data-muted'))).toEqual(
       ['false', 'false', 'true', 'true'],
     );
+    expect(screen.getByRole('region', { name: 'Completed history' })).toBeDefined();
   });
 
   it('shows the active empty state when its last agent is marked done', () => {

--- a/apps/desktop/src/features/session/components/StandaloneAgentsLane/index.tsx
+++ b/apps/desktop/src/features/session/components/StandaloneAgentsLane/index.tsx
@@ -2,7 +2,6 @@ import { useEffect, type ReactNode } from 'react';
 import type { Agent, AgentId, Session, SessionId } from '@goodboy/types';
 import { AdHocRow } from '../../../workspace/components/WorkspacesSidebar/parts/AdHocRow';
 import { AgentLane } from '../AgentLane';
-import { EmptyState } from '@goodboy/ui';
 import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../shared/components/conceptIcons';
 import { LensEmptyState } from '@goodboy/ui';
 import { AgentLaneNote } from '../AgentLane/AgentLaneNote';

--- a/apps/desktop/src/features/session/components/StandaloneAgentsLane/index.tsx
+++ b/apps/desktop/src/features/session/components/StandaloneAgentsLane/index.tsx
@@ -10,6 +10,9 @@ import { CreateAgentPopover } from '../CreateAgentPopover';
 import { AgentListSkeleton } from './AgentListSkeleton';
 import { useStandaloneAgentsLane } from './useStandaloneAgentsLane';
 import { visibleLaneAgents } from './visibleLaneAgents';
+import { FinishedRegister } from '../../../../shared/components/FinishedRegister';
+
+const VISIBLE_FINISHED_COUNT = 30;
 
 const NO_AGENTS_DESCRIPTION =
   'Spawn an agent to start working on this session, or kick off a workflow to run a sequence of agents toward the goal.';
@@ -127,9 +130,15 @@ export const StandaloneAgentsLane = ({
         <div className="flex flex-col gap-5">
           {lane.activeAgents.length > 0 ? renderList(lane.activeAgents, false) : null}
           {filedToggle}
-          {showCompleted && lane.completedAgents.length > 0
-            ? renderList(lane.completedAgents, true)
-            : null}
+          {showCompleted ? (
+            <FinishedRegister
+              label="Completed"
+              count={lane.completedAgents.length}
+              visible={renderList(lane.completedAgents.slice(0, VISIBLE_FINISHED_COUNT), true)}
+              earlierCount={Math.max(0, lane.completedAgents.length - VISIBLE_FINISHED_COUNT)}
+              earlier={renderList(lane.completedAgents.slice(VISIBLE_FINISHED_COUNT), true)}
+            />
+          ) : null}
         </div>
       ) : null}
     </AgentLane>

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentRow.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentRow.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { CircleCheck, PanelRight, RotateCcw, Trash2 } from 'lucide-react';
-import { InlineConfirm } from '@goodboy/ui';
+import { Chip, InlineConfirm } from '@goodboy/ui';
 import { contextTokensForUsage } from '@goodboy/core';
 import type { Agent, TelemetryRecord } from '@goodboy/types';
 import { modelLabel } from '../../../../../features/chat/utils/chat-constants';
@@ -183,10 +183,13 @@ export const AgentRow = ({
         </>
       }
       status={
-        <AgentKindChip
-          kind={kind}
-          title={`Agent ${run.ordinal + 1}: ${agentKindPalette({ kind }).label}`}
-        />
+        <>
+          <AgentKindChip
+            kind={kind}
+            title={`Agent ${run.ordinal + 1}: ${agentKindPalette({ kind }).label}`}
+          />
+          {isMuted ? <Chip tone="success" size="xs" bordered={false} label="completed" /> : null}
+        </>
       }
       meta={
         <AgentMetrics

--- a/apps/desktop/src/shared/components/FinishedRegister/index.tsx
+++ b/apps/desktop/src/shared/components/FinishedRegister/index.tsx
@@ -1,0 +1,53 @@
+import { useState, type ReactNode } from 'react';
+import { ChevronDown } from 'lucide-react';
+import { CountToggle, Divider } from '@goodboy/ui';
+
+type Props = {
+  readonly label: string;
+  readonly count: number;
+  readonly visible: ReactNode;
+  readonly earlier?: ReactNode;
+  readonly earlierCount?: number;
+};
+
+export const FinishedRegister = ({
+  label,
+  count,
+  visible,
+  earlier = null,
+  earlierCount = 0,
+}: Props) => {
+  const [isEarlierShown, setIsEarlierShown] = useState(false);
+
+  if (count === 0) {
+    return null;
+  }
+
+  return (
+    <section className="flex flex-col gap-4" aria-label={`${label} history`}>
+      <Divider />
+      <div className="flex items-center justify-between gap-2">
+        <h2 className="text-2xs font-medium uppercase tracking-wide text-muted-foreground">
+          {label}
+        </h2>
+        <span className="text-2xs tabular-nums text-muted-foreground">{count}</span>
+      </div>
+      {visible}
+      {earlierCount > 0 ? (
+        <div className="flex flex-col gap-4">
+          <div className="flex justify-center">
+            <CountToggle
+              label="Earlier"
+              itemsLabel="items"
+              count={earlierCount}
+              isShown={isEarlierShown}
+              icon={ChevronDown}
+              onChange={setIsEarlierShown}
+            />
+          </div>
+          {isEarlierShown ? earlier : null}
+        </div>
+      ) : null}
+    </section>
+  );
+};


### PR DESCRIPTION
## Why

The owner:

> Gli elementi come workflows/agents/resolve/questions/plans che sono stati completati o consumati non si vedono subito, ma bisogna cliccare la voce completed al centro dello schermo. Secondo me e' un'idea stupida, gli mostrerei sempre, divisi fra in alto quelli ancora attivi, in basso quelli finiti, con lo stato corretto.

A toggle you have to click to discover that finished work exists only works for someone who already knows it does.

## What changed

Every lens shows both registers in one list: active on top, finished below a boundary. No interaction needed to see that work was done. A shared `FinishedRegister` keeps the five lenses telling the same story, and the completion-toggle state is gone from the session workspace.

Each finished item carries the state that is actually true of it, in the vocabulary the owner named, rather than one flattened word: a workflow run is completed or discarded, which were separated for exactly this reason; a plan is consumed; an agent and a resolver are completed; a question is answered.

## Density

A real session in the owner's database has 646 agents, so showing everything cannot make a lens unusable. The boundary between active and finished is where it folds, since someone scanning finished work is browsing rather than acting. What is no longer allowed is hiding that finished work exists, and the active register can never be pushed off screen by the finished one.

The status vocabulary matches the Timeline spec on a sibling branch, so the lenses and the Overview will not disagree about how a finished item reads.

## Verification

- `pnpm --filter @goodboy/desktop typecheck`
- full desktop suite, 671 files, 5824 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

