### PR TITLE
refactor(desktop): the ladder drops rows a model does not have

### DIFF
--- a/apps/desktop/src/features/github/components/GitHubStudio/ResolveBoard/ResolveConfigPopover/index.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/ResolveBoard/ResolveConfigPopover/index.tsx
@@ -120,6 +120,7 @@ export const ResolveConfigPopover = ({
                 }}
                 viewProvider={viewProvider}
                 onViewProvider={setViewProvider}
+                onNavigateProviders={close}
                 onPickProvider={(provider) => onChange(configFor({ provider, base: config }))}
                 onPickModel={(model, effort) =>
                   onChange({ ...config, provider: viewProvider, model, effort })

--- a/apps/desktop/src/features/session/components/CreateAgentPopover/AgentRoutingSections.tsx
+++ b/apps/desktop/src/features/session/components/CreateAgentPopover/AgentRoutingSections.tsx
@@ -3,6 +3,7 @@ import { MODEL_CATALOGS, modelAxes, modelIdForSelection } from '@goodboy/core';
 import { Divider } from '@goodboy/ui';
 import type { ModelSelection, ProviderId } from '@goodboy/types';
 import { AxesSection } from '../../../../shared/components/RoutingPicker/AxesSection';
+import { NoConnectedProviders } from '../../../../shared/components/RoutingPicker/NoConnectedProviders';
 import { PickerSection } from '../../../../shared/components/RoutingPicker/PickerSection';
 import { ProviderGrid } from '../../../../shared/components/RoutingPicker/ProviderGrid';
 import { ROUTING_PICKER_CONSTANTS } from '../../../../shared/components/RoutingPicker/constants';
@@ -19,6 +20,7 @@ type Props = {
   readonly onViewProvider: (provider: ProviderId) => void;
   readonly onPickProvider: (provider: ProviderId) => void;
   readonly onPickModel: (model: string, effort: AgentKindRouting['effort']) => void;
+  readonly onNavigateProviders: () => void;
 };
 
 type PickSelectionParams = {
@@ -32,6 +34,7 @@ export const AgentRoutingSections = ({
   onViewProvider,
   onPickProvider,
   onPickModel,
+  onNavigateProviders,
 }: Props) => {
   const viewedRouting = resolveRouting({
     providers: ROUTING_PICKER_CONSTANTS.providers,
@@ -67,11 +70,12 @@ export const AgentRoutingSections = ({
     <>
       <PickerSection label="Provider">
         {connectedProviders.length === 0 ? (
-          <p className="px-2.5 py-2 text-xs text-muted-foreground">No providers connected</p>
+          <NoConnectedProviders onNavigate={onNavigateProviders} />
         ) : (
           <ProviderGrid
             connectedProviders={connectedProviders}
             activeProvider={viewProvider}
+            onNavigateProviders={onNavigateProviders}
             onSelect={(provider) => {
               onViewProvider(provider);
               setClampNotice(undefined);
@@ -82,7 +86,7 @@ export const AgentRoutingSections = ({
       </PickerSection>
       <Divider />
       <div>
-        {!isProviderConnected && (
+        {connectedProviders.length > 0 && !isProviderConnected && (
           <p className="px-2.5 py-1 text-xs text-muted-foreground">
             Selected provider is not connected
           </p>

--- a/apps/desktop/src/features/session/components/CreateAgentPopover/index.test.tsx
+++ b/apps/desktop/src/features/session/components/CreateAgentPopover/index.test.tsx
@@ -276,6 +276,19 @@ describe('CreateAgentPopover', () => {
     expect(screen.queryByRole('button', { name: 'Codex' })).toBeNull();
   });
 
+  it('links an empty provider state to the in-app Providers surface', () => {
+    h.providers = [];
+    renderControl();
+    openPopover();
+    const openProviders = screen.getByRole('button', { name: 'Open providers' });
+    const onOpenProviderStudio = vi.fn();
+    window.addEventListener('goodboy:open-provider-studio', onOpenProviderStudio);
+    fireEvent.click(openProviders);
+    window.removeEventListener('goodboy:open-provider-studio', onOpenProviderStudio);
+    expect(onOpenProviderStudio).toHaveBeenCalledOnce();
+    expect(screen.queryByRole('dialog', { name: 'Create agent' })).toBeNull();
+  });
+
   it('drops the type section entirely in a simple workspace', () => {
     h.workspaceKind = 'simple';
     renderControl();

--- a/apps/desktop/src/features/session/components/CreateAgentPopover/index.tsx
+++ b/apps/desktop/src/features/session/components/CreateAgentPopover/index.tsx
@@ -132,6 +132,7 @@ export const CreateAgentPopover = ({
                 effective={effective}
                 viewProvider={viewProvider}
                 onViewProvider={setViewProvider}
+                onNavigateProviders={close}
                 onPickProvider={(provider) => {
                   const model = getDefaultTurnModel({ id: provider });
                   setRouting({

--- a/apps/desktop/src/shared/components/RoutingPicker/AxesSection.tsx
+++ b/apps/desktop/src/shared/components/RoutingPicker/AxesSection.tsx
@@ -32,14 +32,16 @@ export const AxesSection = ({
   onToggle,
 }: Props) => {
   const toggleRowLabel = 'Modes';
+  const selectionAxes = axes.version == null ? [axes.model] : [axes.model, axes.version];
+  const variantAxis = axes.variant;
   return (
     <section aria-label="Model options" className="flex flex-col gap-2.5 p-3">
-      {[axes.model, axes.version].map((axis) => (
+      {selectionAxes.map((axis) => (
         <AxisRow key={axis.label} label={axis.label}>
           <div
             role="group"
             aria-label={axis.label}
-            className="flex flex-wrap justify-center gap-1 rounded-lg bg-background/40 p-1"
+            className="flex flex-wrap justify-end gap-1 rounded-lg bg-background/40 p-1"
           >
             {axis.options.map((option) => (
               <PickerChip
@@ -52,52 +54,40 @@ export const AxesSection = ({
           </div>
         </AxisRow>
       ))}
-      <AxisRow label={axes.variant.label}>
-        <div
-          role="group"
-          aria-label={axes.variant.label}
-          className="flex flex-wrap justify-center gap-1 rounded-lg bg-background/40 p-1"
-        >
-          {axes.variant.options.length === 0 ? (
-            <PickerChip label="Not available" active={false} disabled onSelect={() => undefined} />
-          ) : (
-            axes.variant.options.map((option) => {
-              return (
-                <PickerChip
-                  key={option.id}
-                  label={option.label}
-                  active={option.id === axes.variant.activeId}
-                  onSelect={() => onVariant(option.id)}
-                />
-              );
-            })
-          )}
-        </div>
-      </AxisRow>
-      <AxisRow label={axes.effort.label}>
-        {axes.effort.levels.length === 0 ? (
+      {variantAxis != null && (
+        <AxisRow label={variantAxis.label}>
           <div
             role="group"
-            aria-label={axes.effort.label}
-            className="flex rounded-lg bg-background/40 p-1"
+            aria-label={variantAxis.label}
+            className="flex flex-wrap justify-end gap-1 rounded-lg bg-background/40 p-1"
           >
-            <PickerChip label="Not available" active={false} disabled onSelect={() => undefined} />
+            {variantAxis.options.map((option) => (
+              <PickerChip
+                key={option.id}
+                label={option.label}
+                active={option.id === variantAxis.activeId}
+                onSelect={() => onVariant(option.id)}
+              />
+            ))}
           </div>
-        ) : (
+        </AxisRow>
+      )}
+      {axes.effort != null && (
+        <AxisRow label={axes.effort.label}>
           <EffortChips
             axis={axes.effort}
             value={effortValue}
             canEdit={canEditEffort}
             onPick={onEffort}
           />
-        )}
-      </AxisRow>
+        </AxisRow>
+      )}
       {axes.toggles.length > 0 && (
         <AxisRow label={toggleRowLabel}>
           <div
             role="group"
             aria-label={toggleRowLabel}
-            className="flex flex-wrap justify-center gap-1 rounded-lg bg-background/40 p-1"
+            className="flex flex-wrap justify-end gap-1 rounded-lg bg-background/40 p-1"
           >
             {axes.toggles.map((toggle) => (
               <PickerChip

--- a/apps/desktop/src/shared/components/RoutingPicker/AxisRow.tsx
+++ b/apps/desktop/src/shared/components/RoutingPicker/AxisRow.tsx
@@ -8,6 +8,6 @@ type Props = {
 export const AxisRow = ({ label, children }: Props) => (
   <div className="flex items-center gap-2">
     <span className="w-14 shrink-0 text-2xs font-medium text-muted-foreground">{label}</span>
-    <div className="flex flex-1 justify-center">{children}</div>
+    <div className="flex flex-1 justify-end">{children}</div>
   </div>
 );

--- a/apps/desktop/src/shared/components/RoutingPicker/EffortChips.tsx
+++ b/apps/desktop/src/shared/components/RoutingPicker/EffortChips.tsx
@@ -14,7 +14,7 @@ export const EffortChips = ({ axis, value, canEdit, onPick }: Props) => (
   <div
     role="group"
     aria-label={axis.label}
-    className="flex flex-wrap justify-center gap-1 rounded-lg bg-background/40 p-1"
+    className="flex flex-wrap justify-end gap-1 rounded-lg bg-background/40 p-1"
   >
     {axis.levels.map(({ level, available }) => (
       <PickerChip

--- a/apps/desktop/src/shared/components/RoutingPicker/ProviderGrid.tsx
+++ b/apps/desktop/src/shared/components/RoutingPicker/ProviderGrid.tsx
@@ -1,3 +1,4 @@
+import { Plus } from 'lucide-react';
 import type { ProviderId } from '@goodboy/types';
 import { cn } from '@goodboy/ui';
 import { PROVIDER_LABEL } from '../../../features/chat/utils/chat-constants';
@@ -11,6 +12,7 @@ type Props = {
   readonly disableDisconnected?: boolean;
   readonly showDisconnected?: boolean;
   readonly onSelect: (provider: ProviderId) => void;
+  readonly onNavigateProviders?: () => void;
 };
 
 export const ProviderGrid = ({
@@ -20,6 +22,7 @@ export const ProviderGrid = ({
   disableDisconnected = false,
   showDisconnected = false,
   onSelect,
+  onNavigateProviders,
 }: Props) => (
   <div className={ROUTING_PICKER_CONSTANTS.providerChipGroupClassName}>
     {ROUTING_PICKER_CONSTANTS.providers
@@ -63,5 +66,20 @@ export const ProviderGrid = ({
           </button>
         );
       })}
+    {onNavigateProviders != null && (
+      <button
+        type="button"
+        title="Add provider"
+        aria-label="Add provider"
+        onClick={() => {
+          onNavigateProviders();
+          window.dispatchEvent(new CustomEvent('goodboy:open-provider-studio'));
+        }}
+        className="inline-flex min-w-0 items-center justify-center gap-1 rounded-md text-3xs font-medium text-muted-foreground transition-colors hover:bg-background/60 hover:text-foreground"
+      >
+        <Plus size={13} aria-hidden className="shrink-0" />
+        <span className="truncate">Add</span>
+      </button>
+    )}
   </div>
 );

--- a/apps/desktop/src/shared/components/RoutingPicker/ProviderPicker.test.tsx
+++ b/apps/desktop/src/shared/components/RoutingPicker/ProviderPicker.test.tsx
@@ -28,6 +28,7 @@ describe('ProviderPicker', () => {
     expect(screen.getByText('Provider')).toBeDefined();
     expect(screen.queryByText('Models')).toBeNull();
     expect(screen.queryByText('Tuning')).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Add provider' })).toBeNull();
   });
 
   it('selects a connected provider and closes the picker', () => {

--- a/apps/desktop/src/shared/components/RoutingPicker/index.test.tsx
+++ b/apps/desktop/src/shared/components/RoutingPicker/index.test.tsx
@@ -227,7 +227,9 @@ describe('RoutingPicker', () => {
     );
     fireEvent.click(screen.getByRole('button', { name: /routing/i }));
     const providerRow = screen.getByRole('button', { name: 'Cursor' }).parentElement;
-    expect(providerRow?.querySelectorAll('svg')).toHaveLength(baseProps.connectedProviders.length);
+    expect(providerRow?.querySelectorAll('svg')).toHaveLength(
+      baseProps.connectedProviders.length + 1,
+    );
   });
 
   it('reports the picked model and keeps the popover open', () => {
@@ -291,7 +293,7 @@ describe('RoutingPicker', () => {
     expect(within(modes).getByRole('button', { name: 'Fast' }).getAttribute('aria-pressed')).toBe(
       'true',
     );
-    expect(modes.className).toContain('justify-center');
+    expect(modes.className).toContain('justify-end');
   });
 
   it('reports the picked effort and keeps the popover open', () => {
@@ -386,18 +388,27 @@ describe('RoutingPicker', () => {
     ).toEqual(['Low', 'High']);
   });
 
-  it('keeps unavailable variant and effort levels visible and disabled for Haiku', () => {
+  it('omits variant and effort rows that Haiku does not have', () => {
     render(<RoutingPicker {...baseProps} model="haiku-4.5" />);
     fireEvent.click(screen.getByRole('button', { name: /routing/i }));
     const modelOptions = screen.getByRole('region', { name: 'Model options' });
-    const effort = within(modelOptions).getByRole('group', { name: 'Effort' });
-    const variant = within(modelOptions).getByRole('group', { name: 'Variant' });
-    expect(
-      within(effort).getByRole('button', { name: 'Not available' }).hasAttribute('disabled'),
-    ).toBe(true);
-    expect(
-      within(variant).getByRole('button', { name: 'Not available' }).hasAttribute('disabled'),
-    ).toBe(true);
+    expect(within(modelOptions).queryByRole('group', { name: 'Effort' })).toBeNull();
+    expect(within(modelOptions).queryByRole('group', { name: 'Variant' })).toBeNull();
+  });
+
+  it('omits the Variant row for Opus 5 while keeping its Effort row', () => {
+    render(<RoutingPicker {...baseProps} />);
+    fireEvent.click(screen.getByRole('button', { name: /routing/i }));
+    const modelOptions = screen.getByRole('region', { name: 'Model options' });
+    expect(within(modelOptions).queryByRole('group', { name: 'Variant' })).toBeNull();
+    expect(within(modelOptions).getByRole('group', { name: 'Effort' })).toBeDefined();
+  });
+
+  it('omits the version row for a model without a version axis', () => {
+    render(<RoutingPicker {...baseProps} provider="cursor" model="auto" />);
+    fireEvent.click(screen.getByRole('button', { name: /routing/i }));
+    const modelOptions = screen.getByRole('region', { name: 'Model options' });
+    expect(within(modelOptions).queryByRole('group', { name: 'Model Version' })).toBeNull();
   });
 
   it('shows a Max Mode advisory after failure and clears it after success', () => {
@@ -481,15 +492,21 @@ describe('RoutingPicker', () => {
     expect(within(models).getByRole('button', { name: 'Auto' })).toBeDefined();
   });
 
-  it('centers variant and effort controls inside the tuning control area', () => {
+  it('aligns every model axis to the end of its row', () => {
     render(<RoutingPicker {...baseProps} provider="codex" model="gpt-5.6-terra" />);
     fireEvent.click(screen.getByRole('button', { name: /routing/i }));
+    const model = screen.getByRole('group', { name: 'Model' });
+    const version = screen.getByRole('group', { name: 'Model Version' });
     const variant = screen.getByRole('button', { name: 'Terra' }).parentElement;
     const effort = screen.getByRole('group', { name: 'Effort' });
-    expect(variant?.className).toContain('justify-center');
-    expect(variant?.parentElement?.className).toContain('justify-center');
-    expect(effort.className).toContain('justify-center');
-    expect(effort.parentElement?.className).toContain('justify-center');
+    expect(
+      [model, version, variant, effort].every((group) => group?.className.includes('justify-end')),
+    ).toBe(true);
+    expect(
+      [model, version, variant, effort].every((group) =>
+        group?.parentElement?.className.includes('justify-end'),
+      ),
+    ).toBe(true);
   });
 
   it('offers verbosity only when the caller wires it', () => {
@@ -506,6 +523,18 @@ describe('RoutingPicker', () => {
     expect(screen.getByRole('button', { name: 'Claude' })).toBeDefined();
     expect(screen.queryByRole('button', { name: 'Codex' })).toBeNull();
     expect(screen.queryByRole('button', { name: 'Cursor' })).toBeNull();
+  });
+
+  it('links the connected provider row to the in-app Providers surface', () => {
+    render(<RoutingPicker {...baseProps} connectedProviders={['anthropic']} />);
+    fireEvent.click(screen.getByRole('button', { name: /routing/i }));
+    const addProvider = screen.getByRole('button', { name: 'Add provider' });
+    const onOpenProviderStudio = vi.fn();
+    window.addEventListener('goodboy:open-provider-studio', onOpenProviderStudio);
+    fireEvent.click(addProvider);
+    window.removeEventListener('goodboy:open-provider-studio', onOpenProviderStudio);
+    expect(onOpenProviderStudio).toHaveBeenCalledOnce();
+    expect(screen.queryByRole('dialog', { name: 'routing' })).toBeNull();
   });
 
   it('keeps a disconnected selection visible and marked', () => {

--- a/apps/desktop/src/shared/components/RoutingPicker/index.tsx
+++ b/apps/desktop/src/shared/components/RoutingPicker/index.tsx
@@ -386,6 +386,7 @@ export const RoutingPicker = ({
                   activeProvider={isViewingAuto ? null : viewProvider}
                   secondaryProvider={isViewingAuto ? (recommendedProvider ?? null) : null}
                   showDisconnected={availability === 'setup'}
+                  onNavigateProviders={close}
                   onSelect={(id) => {
                     const isConnected = connectedProviders.includes(id);
                     setViewProvider(id);

--- a/apps/desktop/src/store/store.permissions.test.ts
+++ b/apps/desktop/src/store/store.permissions.test.ts
@@ -310,6 +310,19 @@ describe('sendTurn, permission proxy integration', () => {
     expect(JSON.stringify(args)).not.toContain('dangerously-skip-permissions');
   });
 
+  it('keeps scout restrictions in copy instead of enforcing read-only tools', async () => {
+    const useAppStore = await importStore();
+    setupSession(useAppStore);
+    useAppStore.setState({ agentKindOverride: { [AGENT_ID]: 'scout' } });
+    await useAppStore.getState().sendTurn({ sessionId: SESSION_ID, content: 'inspect' });
+
+    const args = runTurnSpy.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(args.systemPrompt).toContain('FORBIDDEN: editing files');
+    expect(args.allowedTools).toEqual([]);
+    expect(args.disallowedTools).toEqual([]);
+    expect(args.permissionMode).toBe('bypassPermissions');
+  });
+
   it('does NOT forward permission flags when provider is cursor', async () => {
     const routingMod = await import('../features/providers/routing');
     (routingMod.resolveProviderForTurn as ReturnType<typeof vi.fn>).mockResolvedValueOnce({

--- a/docs/model-picker.md
+++ b/docs/model-picker.md
@@ -37,25 +37,30 @@ independent toggle, an account-level gate. The picker refuses to learn those
 differences. One provider-aware layer, `modelAxes`, normalizes them into a
 single shape, and every surface renders that shape.
 
-- **A level the current selection cannot reach renders disabled, never
-  hidden.** The ladder must not jump around as the user toggles things.
+- **An axis the model does not have is omitted. An axis the current selection
+  cannot reach stays mounted and disabled.** The ladder must not jump around as
+  the user toggles things.
 - **Every control here is a chip**, never a `select`.
 - **One effort control exists in the app.** A second one anywhere is a bug.
 - A tuning concept that is not a ladder, a variant list or a toggle is added to
   the axes shape and renders for everyone, never special-cased in a mount.
 
-The picker renders one stable ladder in this order: Provider, Model, Model
-Version, Variant and Effort. Model names and versions come directly from the
-catalog entry's authored `presentation.group` and `presentation.version`.
-`modelAxes` turns those entries into separate model and version axes alongside
-variant and effort, so mounts never regroup catalog entries themselves.
+The picker renders one ladder in this order: Provider, Model, Model Version,
+Variant and Effort. Model names and versions come directly from the catalog
+entry's authored `presentation.group` and `presentation.version`. `modelAxes`
+turns those entries into separate model and version axes alongside variant and
+effort, so mounts never regroup catalog entries themselves.
 
-Every level remains mounted. When Variant does not apply, its row contains one
-disabled `Not available` chip. Effort follows the same rule when the selected
-model has no effort choices. A partially reachable effort ladder keeps every
-authored level visible and disables only the unavailable chips. This keeps the
-ladder's height, reading order and keyboard order stable as higher levels
-change.
+An absent axis is `null` in `modelAxes` and renders no row. A model whose
+`presentation.group` is `null` has no version axis. A model with no variants
+has no variant axis, and a model or provider with no effort control has no
+effort axis. Opus 5 therefore renders no Variant row.
+
+A present axis remains mounted when the current selection makes some or all of
+its authored choices unreachable. Those choices render disabled. A partially
+reachable effort ladder keeps every authored level visible and disables only
+the unavailable chips. This preserves the ladder's height, reading order and
+keyboard order while the user changes a higher selection.
 
 ## Selection to spawn
 

--- a/packages/core/src/providers/modelAxes.test.ts
+++ b/packages/core/src/providers/modelAxes.test.ts
@@ -84,13 +84,22 @@ describe('modelAxes', () => {
     ]);
   });
 
-  it('keeps an unreachable effort axis empty instead of hiding it', () => {
+  it('omits effort and variant axes the model does not support', () => {
     const model = ANTHROPIC_CATALOG.find((candidate) => candidate.key === 'haiku-4.5');
     if (model == null) {
       throw new Error('missing anthropic haiku-4.5');
     }
     const axes = modelAxes({ model, selection: { key: model.key } });
-    expect(axes.effort).toEqual({ label: 'Effort', levels: [] });
+    expect(axes.effort).toBeNull();
+    expect(axes.variant).toBeNull();
+  });
+
+  it('omits the version axis when the catalog declares no model group', () => {
+    const model = CURSOR_CATALOG.find((candidate) => candidate.key === 'auto');
+    if (model == null) {
+      throw new Error('missing cursor auto');
+    }
+    expect(modelAxes({ model, selection: { key: model.key } }).version).toBeNull();
   });
 
   it('uses Effort as the effort axis label across providers', () => {

--- a/packages/core/src/providers/modelAxes.ts
+++ b/packages/core/src/providers/modelAxes.ts
@@ -52,14 +52,15 @@ type CursorToggleParams = CursorParams & {
   readonly fast: boolean;
 };
 
-const effortAxis = ({ label, efforts }: EffortParams): EffortAxis => {
+const effortAxis = ({ label, efforts }: EffortParams): EffortAxis | null => {
+  if (efforts.length === 0) {
+    return null;
+  }
   return {
     label,
     levels: efforts.map((level) => ({ level, available: true })),
   };
 };
-
-const unavailableEffortAxis = (): EffortAxis => ({ label: 'Effort', levels: [] });
 
 const selectionAxes = ({ model }: SelectionAxesParams) => {
   const catalog = [...MODEL_CATALOGS[model.provider]].sort(
@@ -83,20 +84,23 @@ const selectionAxes = ({ model }: SelectionAxesParams) => {
       })),
       activeId: activeGroup,
     },
-    version: {
-      label: 'Model Version',
-      options: catalog
-        .filter(
-          (candidate) =>
-            (candidate.presentation.group ?? candidate.presentation.version) === activeGroup,
-        )
-        .map((candidate) => ({
-          id: candidate.key,
-          label: candidate.presentation.version,
-          modelKey: candidate.key,
-        })),
-      activeId: model.key,
-    },
+    version:
+      model.presentation.group == null
+        ? null
+        : {
+            label: 'Model Version',
+            options: catalog
+              .filter(
+                (candidate) =>
+                  (candidate.presentation.group ?? candidate.presentation.version) === activeGroup,
+              )
+              .map((candidate) => ({
+                id: candidate.key,
+                label: candidate.presentation.version,
+                modelKey: candidate.key,
+              })),
+            activeId: model.key,
+          },
   };
 };
 
@@ -144,8 +148,8 @@ const cursorAxes = ({ model, selection }: CursorParams): ModelAxes => {
     : null;
   return {
     ...selectionAxes({ model }),
-    effort: effort ?? unavailableEffortAxis(),
-    variant: { label: 'Variant', options: [], activeId: null },
+    effort,
+    variant: null,
     toggles: cursorToggles({ model, selection, thinking, fast }),
     requiresMaxMode: resolveCursorCombo({ model, selection }).maxMode,
   };
@@ -156,14 +160,14 @@ type VariantParams = {
   readonly selection: ModelSelection;
 };
 
-const variantAxis = ({ model, selection }: VariantParams): VariantAxis => {
+const variantAxis = ({ model, selection }: VariantParams): VariantAxis | null => {
   if (model.variants.length <= 1) {
-    return { label: 'Variant', options: [], activeId: null };
+    return null;
   }
   const active =
     model.variants.find((variant) => variant.id === selection.variant) ?? model.variants[0];
   if (active == null) {
-    return { label: 'Variant', options: [], activeId: null };
+    return null;
   }
   return {
     label: 'Variant',
@@ -179,16 +183,16 @@ export const modelAxes = ({ model, selection }: Params): ModelAxes => {
       return {
         ...selections,
         effort:
-          model.efforts.length > 0
-            ? {
+          model.efforts.length === 0
+            ? null
+            : {
                 label: 'Effort',
                 levels: ANTHROPIC_EFFORT_ORDER.map((level) => ({
                   level,
                   available: model.efforts.includes(level),
                 })),
-              }
-            : unavailableEffortAxis(),
-        variant: { label: 'Variant', options: [], activeId: null },
+              },
+        variant: null,
         toggles: [],
         requiresMaxMode: false,
       };
@@ -209,7 +213,7 @@ export const modelAxes = ({ model, selection }: Params): ModelAxes => {
       return {
         ...selections,
         effort: effortAxis({ label: 'Effort', efforts: model.efforts }),
-        variant: { label: 'Variant', options: [], activeId: null },
+        variant: null,
         toggles: [],
         requiresMaxMode: false,
       };

--- a/packages/types/src/model-catalog.ts
+++ b/packages/types/src/model-catalog.ts
@@ -142,9 +142,9 @@ export type ToggleAxis = {
 
 export type ModelAxes = {
   readonly model: ModelAxis;
-  readonly version: ModelAxis;
-  readonly effort: EffortAxis;
-  readonly variant: VariantAxis;
+  readonly version: ModelAxis | null;
+  readonly effort: EffortAxis | null;
+  readonly variant: VariantAxis | null;
   readonly toggles: ReadonlyArray<ToggleAxis>;
   readonly requiresMaxMode: boolean;
 };


### PR DESCRIPTION
## Why

The owner's verdict on the ladder that shipped: "decisamente meglio rispetto a prima", with four things left and two questions.

## A way to connect another provider

The provider row shows only connected providers, which was a deliberate fix and left a user with no way out when the one they wanted was missing. A trailing `+ Add` entry closes the picker and opens Providers **inside the app**, per the in-app link rule.

## The chips align to the end

Model, version, variant, effort and mode all right-align, so the ladder reads as one straight edge instead of five ragged centred groups.

Precedent: VS Code's right-aligned settings controls, Linear's trailing integration action.

## An axis that does not exist gets no row

> A differenza di quello che abbiamo scritto nel design, se un modello non ha versione, non ha variante, non ha effort etc, non mostrerei la riga

Implemented, and `docs/model-picker.md` is updated so the doc and the code agree rather than contradicting each other.

**The distinction the old rule existed to protect is kept**, because collapsing it would bring back the bug that rule was written for:

- an axis the model **does not have at all** now returns `null` from `modelAxes` and renders no row. Opus 5 no longer shows a `Variant: Not available` row.
- an axis that **exists but the current selection cannot reach** stays mounted and disabled, so the ladder still does not jump under the user's hands as he changes a selection above it.

That distinction now lives in the catalog, which is what `docs/model-picker.md` requires: the catalog describes, the picker renders.

## The two questions

**PR reviewer versus Review**: untouched here on purpose. A sibling branch owns that decision and will change the roles themselves; changing them in two places at once would collide.

**Read-only versus writing roles**: the honest answer is no, not as things stand. A scout's "never edits files" is a prompt instruction, not a runtime restriction; permissions are session-wide and not enforced per role. Rendering that split in the picker would claim a guarantee the runtime does not make. If the restriction ever becomes real, the picker is the right place to show it.

## Verification

- desktop, core and types typechecks clean
- desktop 5826 passed across 673 files, core 1147 passed / 4 skipped across 105 files
- knip clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
