### PR TITLE
fix(desktop): unify concept tones and detail measures

### DIFF
--- a/apps/desktop/src/features/chat/components/ChatView/AnsweredCard.tsx
+++ b/apps/desktop/src/features/chat/components/ChatView/AnsweredCard.tsx
@@ -3,6 +3,7 @@ import { Bot, CheckCircle2 } from 'lucide-react';
 import { Markdown } from '@goodboy/ui';
 import type { OpenQuestion } from '@goodboy/types';
 import { formatRelativeAge } from '../../../../shared/utils/relativeDate';
+import { CONCEPT_TONE } from '../../../../shared/components/conceptIcons';
 import { TranscriptDisclosure } from '../TranscriptDisclosure';
 import { TranscriptRowHeader } from '../TranscriptRowHeader';
 
@@ -16,7 +17,7 @@ export const AnsweredCard = ({ question }: Props) => {
   const [open, setOpen] = useState(false);
   const resolvedByAgent = question.userAnswer === RESOLVED_BY_AGENT;
   const answeredAt = question.answeredAt ?? question.createdAt;
-  const tone = resolvedByAgent ? 'neutral' : 'success';
+  const tone = CONCEPT_TONE.questions;
 
   return (
     <TranscriptDisclosure

--- a/apps/desktop/src/features/chat/components/ChatView/OpenQuestionInlineCard.test.tsx
+++ b/apps/desktop/src/features/chat/components/ChatView/OpenQuestionInlineCard.test.tsx
@@ -2,7 +2,9 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { tintClasses } from '@goodboy/ui';
 import type { OpenQuestion } from '@goodboy/types';
+import { CONCEPT_TONE } from '../../../../shared/components/conceptIcons';
 
 const { state } = vi.hoisted(() => ({
   state: {
@@ -62,6 +64,21 @@ describe('OpenQuestionInlineCard', () => {
     fireEvent.click(screen.getByRole('button'));
     expect(screen.getByText('You answered:')).toBeTruthy();
     expect(screen.getByText('Postgres')).toBeTruthy();
+  });
+
+  it('keeps an answered question on the shared question tone', () => {
+    const answered: OpenQuestion = {
+      ...baseQuestion,
+      status: 'answered',
+      userAnswer: 'Postgres',
+      answeredAt: '2026-06-13T00:05:00.000Z',
+    } as unknown as OpenQuestion;
+
+    render(<OpenQuestionInlineCard question={answered} sessionId={'sess-1' as never} />);
+
+    const disclosure = screen.getByRole('button').closest('.border-l-2') as HTMLElement;
+    expect(disclosure.className).toContain(tintClasses(CONCEPT_TONE.questions).border);
+    expect(disclosure.className).not.toContain(tintClasses('success').border);
   });
 
   it('collapses a settled question to a single row until it is expanded', () => {

--- a/apps/desktop/src/features/chat/components/PlanChip/index.test.tsx
+++ b/apps/desktop/src/features/chat/components/PlanChip/index.test.tsx
@@ -2,6 +2,8 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { tintClasses } from '@goodboy/ui';
+import { CONCEPT_TONE } from '../../../../shared/components/conceptIcons';
 
 const { extractPlanMock, state } = vi.hoisted(() => ({
   extractPlanMock: vi.fn<(text: string) => unknown>(() => null),
@@ -30,12 +32,18 @@ describe('PlanChip', () => {
     expect(container.firstChild).toBeNull();
   });
 
-  it('renders a clickable chip with the plan title', () => {
+  it('renders a clickable chip with the shared plan tone', () => {
     extractPlanMock.mockReturnValue({ title: 'My Plan', bodyMd: 'body' });
     state.sessionPlans = { s1: [{ id: 'p1', title: 'My Plan' }] };
     render(<PlanChip assistantText="x" sessionId={'s1' as never} />);
+
+    const chip = screen.getByTestId('plan-chip');
+    const planTint = tintClasses(CONCEPT_TONE.plans);
+
     expect(screen.getByText('My Plan')).toBeTruthy();
-    expect(screen.getByTestId('plan-chip')).toBeTruthy();
+    expect(chip.className).toContain(planTint.bg);
+    expect(chip.className).toContain(planTint.border);
+    expect(chip.className).toContain(planTint.text);
   });
 
   it('dispatches goodboy:open-plan-studio with planId when clicked', () => {

--- a/apps/desktop/src/features/chat/components/PlanChip/index.tsx
+++ b/apps/desktop/src/features/chat/components/PlanChip/index.tsx
@@ -37,7 +37,7 @@ export const PlanChip = ({ assistantText, sessionId }: Props) => {
       type="button"
       onClick={onClick}
       data-testid="plan-chip"
-      tone="neutral"
+      tone={CONCEPT_TONE.plans}
       variant="pill"
       className={`inline-flex w-fit items-center gap-1.5 text-xs font-medium transition-opacity hover:opacity-80 ${accent.text}`}
     >

--- a/apps/desktop/src/features/context/components/QuestionsTab/QuestionCard/index.test.tsx
+++ b/apps/desktop/src/features/context/components/QuestionsTab/QuestionCard/index.test.tsx
@@ -2,7 +2,9 @@
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { tintClasses } from '@goodboy/ui';
 import type { OpenQuestion } from '@goodboy/types';
+import { CONCEPT_TONE } from '../../../../../shared/components/conceptIcons';
 import { QuestionCard } from '.';
 
 afterEach(cleanup);
@@ -36,6 +38,17 @@ describe('QuestionCard', () => {
     expect(root.className).toContain('border-l-2');
     expect(root.className).toContain('border-warning/40');
     expect(root.className).not.toContain('rounded-lg');
+  });
+
+  it('keeps just-answered feedback on the shared question tone', () => {
+    const { container } = render(<QuestionCard {...baseProps} justAnswered />);
+    const root = container.firstElementChild as HTMLElement;
+    const questionTint = tintClasses(CONCEPT_TONE.questions);
+    const feedbackIcon = screen.getByTitle(/dismiss question/i).querySelector('svg');
+
+    expect(root.className).toContain(questionTint.border);
+    expect(root.className).not.toContain('success');
+    expect(feedbackIcon?.getAttribute('class')).toContain(questionTint.icon);
   });
 
   it('renders the question text with one button per suggestion', () => {

--- a/apps/desktop/src/features/context/components/QuestionsTab/QuestionCard/index.tsx
+++ b/apps/desktop/src/features/context/components/QuestionsTab/QuestionCard/index.tsx
@@ -3,12 +3,13 @@ import { Check, MessageCircleQuestion, X } from 'lucide-react';
 import { cn, Markdown, tintClasses } from '@goodboy/ui';
 import type { OpenQuestion, OpenQuestionId, OpenQuestionSelectMode } from '@goodboy/types';
 import { formatRelativeAge } from '../../../../../shared/utils/relativeDate';
+import { CONCEPT_TONE } from '../../../../../shared/components/conceptIcons';
 import { TranscriptShell } from '../../../../chat/components/TranscriptShell';
 import { SuggestionChip } from '../SuggestionChip';
 import { CustomAnswerField } from '../CustomAnswerField';
 import { deriveSuggestions } from '../deriveSuggestions';
 
-const warningTint = tintClasses('warning');
+const warningTint = tintClasses(CONCEPT_TONE.questions);
 
 type Props = {
   question: OpenQuestion;
@@ -70,14 +71,9 @@ export const QuestionCard = ({
 
   return (
     <TranscriptShell
-      tone="warning"
+      tone={CONCEPT_TONE.questions}
       variant="leftBorder"
-      className={cn(
-        'group flex flex-col gap-1.5 transition-[background-color,transform] duration-200',
-        animate
-          ? 'motion-safe:animate-answer-lock motion-reduce:bg-success/5'
-          : 'motion-safe:animate-fade-in',
-      )}
+      className="group flex flex-col gap-1.5 transition-[background-color,transform] duration-200 motion-safe:animate-fade-in"
     >
       <div className="flex flex-wrap items-start justify-between gap-x-2 gap-y-1">
         <div className="flex min-w-0 items-start gap-2">
@@ -103,7 +99,7 @@ export const QuestionCard = ({
           title="Dismiss question"
           aria-label="Dismiss question"
         >
-          {animate ? <Check size={12} className="text-success" /> : <X size={12} />}
+          {animate ? <Check size={12} className={warningTint.icon} /> : <X size={12} />}
         </button>
         <div className="flex items-center gap-2 text-2xs text-muted-foreground">
           <span>{formatRelativeAge({ fromIso: question.createdAt })}</span>

--- a/apps/desktop/src/features/session/components/AgentDetailPane/AgentBriefPlans.test.tsx
+++ b/apps/desktop/src/features/session/components/AgentDetailPane/AgentBriefPlans.test.tsx
@@ -2,7 +2,9 @@
 
 import { afterEach, describe, expect, it } from 'vitest';
 import { cleanup, render, screen } from '@testing-library/react';
+import { tintClasses } from '@goodboy/ui';
 import type { PlanId, PlanWithCount, SessionId } from '@goodboy/types';
+import { CONCEPT_TONE } from '../../../../shared/components/conceptIcons';
 
 import { AgentBriefPlans } from './AgentBriefPlans';
 
@@ -35,6 +37,15 @@ describe('AgentBriefPlans', () => {
     render(<AgentBriefPlans plans={[makePlan({ consumptionCount: 1 })]} sessionId={sessionId} />);
 
     expect(screen.getByText('active · 1 use')).toBeDefined();
+  });
+
+  it('renders each plan with the shared plan tone', () => {
+    render(<AgentBriefPlans plans={[makePlan({})]} sessionId={sessionId} />);
+
+    const card = screen.getByRole('button', { name: /Implement chat surface/ });
+    const planTint = tintClasses(CONCEPT_TONE.plans);
+    expect(card.className).toContain(planTint.bgSoft);
+    expect(card.className).toContain(planTint.borderSoft);
   });
 
   it('pluralizes uses for a consumption count above one', () => {

--- a/apps/desktop/src/features/session/components/AgentDetailPane/AgentBriefPlans.tsx
+++ b/apps/desktop/src/features/session/components/AgentDetailPane/AgentBriefPlans.tsx
@@ -1,6 +1,9 @@
-import { SectionHeader } from '@goodboy/ui';
+import { SectionHeader, cn, tintClasses } from '@goodboy/ui';
 import type { PlanWithCount, SessionId } from '@goodboy/types';
 import { pluralize } from '../../../../shared/utils/pluralize';
+import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../shared/components/conceptIcons';
+
+const planTint = tintClasses(CONCEPT_TONE.plans);
 
 type Props = {
   readonly plans: ReadonlyArray<PlanWithCount>;
@@ -19,7 +22,12 @@ export const AgentBriefPlans = ({ plans, sessionId }: Props) => {
           <button
             key={plan.id}
             type="button"
-            className="flex items-center justify-between gap-4 rounded-md bg-elevated px-3 py-2 text-left text-sm ring-1 ring-border-soft"
+            className={cn(
+              'flex items-center justify-between gap-4 rounded-md border px-3 py-2 text-left text-sm transition-colors',
+              planTint.bgSoft,
+              planTint.borderSoft,
+              planTint.hoverBgSoft,
+            )}
             onClick={() =>
               window.dispatchEvent(
                 new CustomEvent('goodboy:open-plan-studio', {
@@ -28,7 +36,10 @@ export const AgentBriefPlans = ({ plans, sessionId }: Props) => {
               )
             }
           >
-            <span className="min-w-0 truncate text-foreground">{plan.title}</span>
+            <span className="flex min-w-0 items-center gap-2">
+              <CONCEPT_ICONS.plans size={13} aria-hidden className={planTint.icon} />
+              <span className="min-w-0 truncate text-foreground">{plan.title}</span>
+            </span>
             <span className="shrink-0 text-2xs tabular-nums text-muted-foreground">
               {plan.status} · {pluralize(plan.consumptionCount, 'use')}
             </span>

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/index.tsx
@@ -295,7 +295,6 @@ export const SessionOverviewPane = ({ session, onSelectLens }: Props) => {
       <PaneShell
         header={<HeaderBand session={session} stage={stage} onSelectLens={onSelectLens} />}
         animationClassName="animate-fade-in"
-        measure="chat"
       >
         <GoalOverviewRegion
           sessionId={sessionId}

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/ContextPane/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/ContextPane/index.tsx
@@ -124,7 +124,6 @@ export const ContextPane = ({ session, initialRegion }: Props) => {
       <PaneShell
         title="Context"
         description="The current session summary and the decisions settled along the way."
-        measure="reading"
       >
         {REGION_ORDER.map((slotKey, index) => (
           <div key={slotKey} className="contents">

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/index.tsx
@@ -234,7 +234,6 @@ export const IntegrationPane = ({ sessionId, workspaceId, provider }: Props) => 
       title={meta.label}
       description={`External ${meta.label} ${meta.nounPlural} linked to this session.`}
       meta={hasTasks ? tasks.length : undefined}
-      measure="reading"
       actions={connection.isConnected && hasTasks ? linkAction : undefined}
     >
       {!connection.isConnected ? (

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/SlotPane.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/SlotPane.test.tsx
@@ -2,6 +2,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { PANE_RHYTHM } from '@goodboy/ui';
 import type { Session } from '@goodboy/types';
 
 const writeText = vi.fn(async () => undefined);
@@ -189,6 +190,16 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe('ContextPane', () => {
+  it('matches the shared pane measure', () => {
+    render(<ContextPane session={SESSION} />);
+
+    expect(
+      screen
+        .getByRole('heading', { level: 1, name: 'Context' })
+        .closest(`.${PANE_RHYTHM.measure.pane}`),
+    ).not.toBeNull();
+  });
+
   it('renders session summary and decisions as two ordered regions', () => {
     render(<ContextPane session={SESSION} />);
 

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/SlotPane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/SlotPane.tsx
@@ -166,7 +166,6 @@ export const SlotPane = ({ session, slotKey }: Props) => {
       <PaneShell
         title={SLOT_TITLE[slotKey]}
         description={SLOT_DESCRIPTION[slotKey]}
-        measure="reading"
         actions={
           <>
             {hasValue ? (

--- a/apps/desktop/src/features/workflows/components/WorkflowNextStepCta/index.test.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowNextStepCta/index.test.tsx
@@ -2,6 +2,7 @@
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { tintClasses } from '@goodboy/ui';
 import type {
   Agent,
   AgentId,
@@ -14,6 +15,7 @@ import type {
   WorkflowRunId,
   WorkspaceId,
 } from '@goodboy/types';
+import { CONCEPT_TONE } from '../../../../shared/components/conceptIcons';
 import { WorkflowNextStepCta } from './index';
 
 afterEach(cleanup);
@@ -138,6 +140,17 @@ describe('WorkflowNextStepCta', () => {
     render(<WorkflowNextStepCta workflow={wf()} runs={ctaRuns} onAdvance={vi.fn()} />);
     expect(screen.getByTestId('workflow-next-step-cta').textContent).toMatch(
       /run next step: scout/i,
+    );
+  });
+
+  it('uses the shared plan tone for an active plan marker', () => {
+    render(
+      <WorkflowNextStepCta workflow={wf()} runs={ctaRuns} onAdvance={vi.fn()} consumesActivePlan />,
+    );
+
+    const marker = screen.getByTitle('Advancing will consume the active plan');
+    expect(marker.querySelector('svg')?.getAttribute('class')).toContain(
+      tintClasses(CONCEPT_TONE.plans).icon,
     );
   });
 

--- a/apps/desktop/src/features/workflows/components/WorkflowNextStepCta/index.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowNextStepCta/index.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react';
 import { AlertTriangle, Play, RotateCcw } from 'lucide-react';
-import { Button, InlineConfirm, cn } from '@goodboy/ui';
+import { Button, InlineConfirm, cn, tintClasses } from '@goodboy/ui';
 import { classifyWorkflowChain, getModelDescriptor } from '@goodboy/core';
 import type {
   Agent,
@@ -17,7 +17,9 @@ import { RoutingBadge } from '../../../../shared/components/RoutingBadge';
 import type { WorkflowBlockReason } from '../../advanceGate';
 import { WORKFLOW_BLOCK_COPY } from '../../blockCopy';
 import { useStartAnywayConfirm } from '../../useStartAnywayConfirm';
-import { CONCEPT_ICONS } from '../../../../shared/components/conceptIcons';
+import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../shared/components/conceptIcons';
+
+const planTint = tintClasses(CONCEPT_TONE.plans);
 
 export type AdvanceParams = {
   readonly step: Step;
@@ -204,7 +206,7 @@ export const WorkflowNextStepCta = ({
         />
         {consumesActivePlan ? (
           <span className="shrink-0" title="Advancing will consume the active plan">
-            <CONCEPT_ICONS.plans size={11} aria-hidden />
+            <CONCEPT_ICONS.plans size={11} aria-hidden className={planTint.icon} />
           </span>
         ) : null}
       </button>

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/PlanReadySuggestion.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/PlanReadySuggestion.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { tintClasses } from '@goodboy/ui';
+import type { PlanWithCount, Session } from '@goodboy/types';
+import { CONCEPT_TONE } from '../../../../../shared/components/conceptIcons';
+
+const { state } = vi.hoisted(() => ({
+  state: {
+    plans: [
+      {
+        id: 'plan-1',
+        sessionId: 'session-1',
+        agentId: 'planner-1',
+        title: 'Unify the detail surfaces',
+        bodyMd: '',
+        status: 'active',
+        createdAt: '2026-08-18T08:00:00.000Z',
+        updatedAt: '2026-08-18T08:00:00.000Z',
+        consumptionCount: 0,
+      },
+    ] as unknown as ReadonlyArray<PlanWithCount>,
+    sessionPhaseRuns: {},
+    phaseTemplates: {},
+    runPlan: vi.fn(async () => 'implementer-1'),
+  },
+}));
+
+vi.mock('../../../../../store', () => ({
+  EMPTY_ARRAY: Object.freeze([]),
+  useAppStore: <T,>(selector: (value: typeof state) => T) => selector(state),
+  useSessionOpenQuestions: () => [],
+  useSessionPlans: () => state.plans,
+}));
+
+vi.mock('../../../../../shared/hooks/useAgentStartedToast', () => ({
+  useAgentStartedToast: () => vi.fn(),
+}));
+
+import { PlanReadySuggestion } from './PlanReadySuggestion';
+
+const SESSION = {
+  id: 'session-1',
+  workspaceId: 'workspace-1',
+  workflowRuns: [],
+} as unknown as Session;
+
+afterEach(cleanup);
+
+describe('PlanReadySuggestion', () => {
+  it('renders the ready plan with the shared plan concept', () => {
+    render(<PlanReadySuggestion task={SESSION} />);
+
+    const suggestion = screen.getByTestId('plan-ready-suggestion');
+    const planTint = tintClasses(CONCEPT_TONE.plans);
+    expect(suggestion.className).toContain(planTint.bg);
+    expect(suggestion.className).toContain(planTint.border);
+    expect(suggestion.querySelector('.lucide-clipboard-list')).not.toBeNull();
+  });
+});

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/PlanReadySuggestion.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/PlanReadySuggestion.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { ArrowRight } from 'lucide-react';
-import { cn } from '@goodboy/ui';
+import { cn, tintClasses } from '@goodboy/ui';
 import type { Agent, Session, StepId, Workflow } from '@goodboy/types';
 import {
   EMPTY_ARRAY,
@@ -15,7 +15,9 @@ import {
   kindConsumesPlan,
 } from '../../../../session/agent-kind';
 import { useAgentStartedToast } from '../../../../../shared/hooks/useAgentStartedToast';
-import { CONCEPT_ICONS } from '../../../../../shared/components/conceptIcons';
+import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../../shared/components/conceptIcons';
+
+const planTint = tintClasses(CONCEPT_TONE.plans);
 
 type Props = {
   task: Session;
@@ -98,18 +100,31 @@ export const PlanReadySuggestion = ({ task }: Props) => {
       title={latest.title}
       aria-label={`Spawn an implementer agent to execute the plan: ${latest.title}`}
       className={cn(
-        'group mt-1 flex w-full items-start gap-2 rounded-md border border-primary/40 bg-primary/10 px-2.5 py-2 text-left transition-colors hover:border-primary/60 hover:bg-primary/15 disabled:cursor-not-allowed disabled:opacity-60',
+        'group mt-1 flex w-full items-start gap-2 rounded-md border px-2.5 py-2 text-left transition-colors disabled:cursor-not-allowed disabled:opacity-60',
+        planTint.border,
+        planTint.bg,
+        planTint.hoverBorder,
+        planTint.hoverBg,
         spawning && 'animate-border-pulse',
       )}
     >
       <span
-        className="mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-primary/20 text-primary"
+        className={cn(
+          'mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full',
+          planTint.bg,
+          planTint.icon,
+        )}
         aria-hidden
       >
-        <CONCEPT_ICONS.suggestion size={11} />
+        <CONCEPT_ICONS.plans size={11} />
       </span>
       <span className="flex min-w-0 flex-1 flex-col gap-0.5">
-        <span className="flex items-center gap-1.5 text-3xs font-semibold uppercase tracking-wide text-primary">
+        <span
+          className={cn(
+            'flex items-center gap-1.5 text-3xs font-semibold uppercase tracking-wide',
+            planTint.text,
+          )}
+        >
           <span>plan ready</span>
           <span aria-hidden className="opacity-40">
             ·
@@ -123,7 +138,11 @@ export const PlanReadySuggestion = ({ task }: Props) => {
       <ArrowRight
         size={12}
         aria-hidden
-        className="mt-0.5 shrink-0 text-primary/70 motion-safe:transition-transform group-hover:translate-x-0.5 group-hover:text-primary"
+        className={cn(
+          'mt-0.5 shrink-0 opacity-70 motion-safe:transition-transform group-hover:translate-x-0.5',
+          planTint.icon,
+          planTint.hoverText,
+        )}
       />
     </button>
   );

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowStepPlanBadge.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowStepPlanBadge.tsx
@@ -1,7 +1,10 @@
 import type { Agent } from '@goodboy/types';
+import { cn, tintClasses } from '@goodboy/ui';
 import { useAppStore, useSessionPlans } from '../../../../../store';
 import { kindConsumesPlan, type AgentKind } from '../../../../session/agent-kind';
-import { CONCEPT_ICONS } from '../../../../../shared/components/conceptIcons';
+import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../../shared/components/conceptIcons';
+
+const planTint = tintClasses(CONCEPT_TONE.plans);
 
 type Props = {
   readonly run: Agent;
@@ -59,9 +62,15 @@ export const WorkflowStepPlanBadge = ({ run, kind }: Props) => {
       onKeyDown={(event) => event.stopPropagation()}
       title={plan.title}
       aria-label={`Open ${label.toLowerCase()}: ${plan.title}`}
-      className="flex max-w-full shrink-0 items-center gap-1 rounded-md bg-muted/60 px-1.5 py-0.5 text-2xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+      className={cn(
+        'flex max-w-full shrink-0 items-center gap-1 rounded-md border px-1.5 py-0.5 text-2xs text-muted-foreground transition-colors',
+        planTint.bgSoft,
+        planTint.borderSoft,
+        planTint.hoverBgSoft,
+        planTint.hoverText,
+      )}
     >
-      <CONCEPT_ICONS.plans size={12} aria-hidden className="shrink-0" />
+      <CONCEPT_ICONS.plans size={12} aria-hidden className={cn('shrink-0', planTint.icon)} />
       <span className="shrink-0 font-medium">{label}</span>
       <span className="max-w-[24ch] truncate">{plan.title}</span>
     </button>

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowStepRow.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowStepRow.test.tsx
@@ -2,6 +2,7 @@
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { tintClasses } from '@goodboy/ui';
 import type {
   Agent,
   AgentId,
@@ -15,6 +16,7 @@ import type {
   WorkflowRunId,
 } from '@goodboy/types';
 import type { AgentKind } from '../../../../../features/session/agent-kind';
+import { CONCEPT_TONE } from '../../../../../shared/components/conceptIcons';
 
 const storeState = vi.hoisted(() => ({
   plans: [] as ReadonlyArray<PlanWithCount>,
@@ -160,7 +162,11 @@ describe('WorkflowStepRow', () => {
     window.addEventListener('goodboy:open-plan-studio', onOpen);
 
     renderRow({ kind: 'planner' });
-    fireEvent.click(screen.getByRole('button', { name: /open plan:/i }));
+    const planButton = screen.getByRole('button', { name: /open plan:/i });
+    const planTint = tintClasses(CONCEPT_TONE.plans);
+    expect(planButton.className).toContain(planTint.bgSoft);
+    expect(planButton.className).toContain(planTint.borderSoft);
+    fireEvent.click(planButton);
 
     expect(screen.getByTitle(plan.title).textContent).toContain('Plan');
     const event = onOpen.mock.calls[0]?.[0];

--- a/apps/desktop/src/shared/components/StudioDetail/StudioDetailLayout.tsx
+++ b/apps/desktop/src/shared/components/StudioDetail/StudioDetailLayout.tsx
@@ -28,8 +28,8 @@ export const StudioDetailLayout = ({
   const isFlow = fit === 'flow';
   const hasProperties = properties != null && properties.length > 0;
   const hasMeta = fit !== 'bleed' && (rail != null || hasProperties);
-  const headerMeasure = PANE_RHYTHM.measure.reading;
-  const bodyMeasure = fit === 'fill' ? PANE_RHYTHM.measure.reading : PANE_RHYTHM.measure.full;
+  const headerMeasure = PANE_RHYTHM.measure.pane;
+  const bodyMeasure = fit === 'fill' ? PANE_RHYTHM.measure.pane : PANE_RHYTHM.measure.full;
 
   return (
     <div className={cn('flex flex-col', isFlow ? 'gap-4' : 'h-full min-h-0')}>

--- a/apps/desktop/src/shared/components/StudioDetail/index.test.tsx
+++ b/apps/desktop/src/shared/components/StudioDetail/index.test.tsx
@@ -76,7 +76,7 @@ describe('StudioDetailLayout', () => {
     expect(screen.getByText('Tabs slot')).toBeDefined();
   });
 
-  it('keeps the header measure constant across fit modes', () => {
+  it('uses the shared pane measure for every header and a fill body', () => {
     const { unmount } = render(
       <StudioDetailLayout header={<span>Header slot</span>} fit="fill">
         <span>Main slot</span>
@@ -84,8 +84,9 @@ describe('StudioDetailLayout', () => {
     );
     const fillHeaderMeasure = screen
       .getByTestId('detail-header-band')
-      .querySelector(`.${PANE_RHYTHM.measure.reading}`);
+      .querySelector(`.${PANE_RHYTHM.measure.pane}`);
     expect(fillHeaderMeasure).not.toBeNull();
+    expect(screen.getByText('Main slot').closest(`.${PANE_RHYTHM.measure.pane}`)).not.toBeNull();
     unmount();
 
     render(
@@ -95,11 +96,9 @@ describe('StudioDetailLayout', () => {
     );
     const bleedHeaderMeasure = screen
       .getByTestId('detail-header-band')
-      .querySelector(`.${PANE_RHYTHM.measure.reading}`);
+      .querySelector(`.${PANE_RHYTHM.measure.pane}`);
     expect(bleedHeaderMeasure).not.toBeNull();
-    expect(
-      screen.getByTestId('detail-header-band').querySelector(`.${PANE_RHYTHM.measure.full}`),
-    ).toBeNull();
+    expect(screen.getByText('Main slot').closest('[class*="max-w-"]')).toBeNull();
   });
 
   it('drops the rail and the scroll region for a full-bleed body', () => {

--- a/apps/desktop/src/shared/components/conceptIcons.test.ts
+++ b/apps/desktop/src/shared/components/conceptIcons.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest';
+import { CONCEPT_TONE } from './conceptIcons';
+
+describe('CONCEPT_TONE', () => {
+  it('uses the draft tone for plans', () => {
+    expect(CONCEPT_TONE.plans).toBe('draft');
+  });
+});

--- a/apps/desktop/src/shared/components/conceptIcons.ts
+++ b/apps/desktop/src/shared/components/conceptIcons.ts
@@ -122,7 +122,7 @@ export const CONCEPT_TONE = {
   linear: 'primary',
   notifications: 'warning',
   orchestrator: 'accent',
-  plans: 'success',
+  plans: 'draft',
   nextUp: 'warning',
   pr: 'primary',
   providers: 'info',

--- a/apps/desktop/src/shared/components/paneRhythm.test.tsx
+++ b/apps/desktop/src/shared/components/paneRhythm.test.tsx
@@ -32,7 +32,7 @@ const MEASURE = /^max-w-/;
 
 const paneShellBody = () => {
   const { unmount } = render(
-    <PaneShell title="Pane" measure="reading">
+    <PaneShell title="Pane">
       <p>Pane body</p>
     </PaneShell>,
   );
@@ -111,7 +111,7 @@ describe('pane rhythm', () => {
 
     expect(detail.header.measure).toBe(detail.body.measure);
     expect(detail.tabsMeasure).toBe(detail.body.measure);
-    expect(detail.header.measure).toBe(PANE_RHYTHM.measure.reading);
+    expect(detail.header.measure).toBe(PANE_RHYTHM.measure.pane);
   });
 
   it('fills its parent so the studio column centers instead of hugging the left edge', () => {

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -171,32 +171,6 @@
 
   --animate-nav-step-out: nav-step-out 180ms cubic-bezier(0.2, 0, 0, 1);
 
-  --animate-answer-lock: answer-lock 700ms cubic-bezier(0.2, 0, 0, 1);
-
-  @keyframes answer-lock {
-    0% {
-      transform: scale(1);
-      background-color: var(--color-elevated);
-      box-shadow:
-        var(--shadow-sm),
-        0 0 0 0 oklch(from var(--color-success) l c h / 0);
-    }
-    35% {
-      transform: scale(1.005);
-      background-color: oklch(from var(--color-success) l c h / 0.08);
-      box-shadow:
-        var(--shadow-sm),
-        inset 0 0 0 1px oklch(from var(--color-success) l c h / 0.45);
-    }
-    100% {
-      transform: scale(1);
-      background-color: var(--color-elevated);
-      box-shadow:
-        var(--shadow-sm),
-        0 0 0 0 oklch(from var(--color-success) l c h / 0);
-    }
-  }
-
   --animate-studio-in: studio-in 280ms cubic-bezier(0.2, 0, 0, 1);
 
   @keyframes studio-in {

--- a/packages/ui/DESIGN-SYSTEM.md
+++ b/packages/ui/DESIGN-SYSTEM.md
@@ -68,14 +68,15 @@ a tone or vice versa.
 - **One tone per concept, passed alongside the icon** as a pair at the call
   site.
 - **Tone is meaning, not decoration.** `questions` is `warning` because a
-  question blocks someone, `decisions` and `plans` are `success` because they
-  are settled, `sentry` is `danger` because it is errors, `terminal` and
-  `settings` are `neutral` because they are plumbing. Recolouring a concept
-  changes what it claims.
+  question blocks someone, `decisions` is `success` because it is settled, and
+  `plans` is `draft` because a plan is a proposal, not a settled fact. `sentry`
+  is `danger` because it is errors, while `terminal` and `settings` are
+  `neutral` because they are plumbing. Recolouring a concept changes what it
+  claims.
 
-Nine tones (`success`, `info`, `warning`, `danger`, `primary`, `accent`,
-`merged`, `operations`, `neutral`), each resolving through the single accessor
-`tintClasses(tone)`. Components take a `Tone` and call it; they never
+Ten tones (`success`, `info`, `warning`, `danger`, `primary`, `accent`,
+`merged`, `draft`, `operations`, `neutral`), each resolving through the single
+accessor `tintClasses(tone)`. Components take a `Tone` and call it; they never
 hand-write `bg-warning/10`.
 
 ## z-index tokens


### PR DESCRIPTION
Plans stop reading as resolvers and answered questions stop reading as settled, and every detail surface finally shares one column width.

- `plans` moves from `success` to the violet `draft` tone in `CONCEPT_TONE`, so a plan is no longer the same green as a resolver and an answered question. The owner ruled that the violet is free within the WORK section even though draft pull requests also use it.
- An answered question keeps the `warning` tone instead of flipping to green. The `answer-lock` keyframes, which flashed success-tinted on answering, are gone.
- `StudioDetailLayout` moves both `headerMeasure` and the `fill` `bodyMeasure` from `measure.reading` (`max-w-3xl`) to `measure.pane` (`max-w-5xl`), which is what the Linear and other integration panes already get through `PaneShell`. Header and body now share one column and detail headers stop being narrower than their content.

This blocks the other three UX15 branches, which all rebase onto it.