### PR TITLE
fix(desktop): land the sidebar rail on whole device pixels

### DIFF
--- a/apps/desktop/src/__tests__/regressions/nav-rail-whole-pixel-geometry.test.ts
+++ b/apps/desktop/src/__tests__/regressions/nav-rail-whole-pixel-geometry.test.ts
@@ -1,0 +1,132 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { describe, expect, it } from 'vitest';
+import { PANE_RHYTHM } from '@goodboy/ui';
+
+const STYLES = join(__dirname, '..', '..', 'styles.css');
+
+const RAIL_GLYPH_PX = 14;
+const COUNT_CHIP_PADDING_STEP = 0.5;
+const KBD_PILL_HEIGHT_STEP = 5;
+const GROUP_LABEL_PADDING_STEP = 1;
+const ROW_GAP_STEP = 0.5;
+const GROUP_GAP_STEP = 4;
+const SCALE_STEP = /^[a-z]+(?:-[a-z]+)*-(\d+(?:\.5)?)$/;
+
+const readTokenPx = ({ token }: { token: string }): number => {
+  const css = readFileSync(STYLES, 'utf8');
+  const match = new RegExp(`${token}:\\s*(\\d+(?:\\.\\d+)?)px\\s*;`).exec(css);
+  if (match === null) {
+    throw new Error(`styles.css must declare ${token} as a px value`);
+  }
+  return Number(match[1]);
+};
+
+const SPACING_PX = readTokenPx({ token: '--spacing' });
+const LEADING_3XS_PX = readTokenPx({ token: '--text-3xs--line-height' });
+const LEADING_2XS_PX = readTokenPx({ token: '--text-2xs--line-height' });
+const LEADING_SM_PX = readTokenPx({ token: '--text-sm--line-height' });
+
+const step = ({ multiplier }: { multiplier: number }): number => multiplier * SPACING_PX;
+
+const utilitiesOf = ({ classes }: { classes: string }): ReadonlyArray<string> =>
+  classes.split(/\s+/).filter((utility) => utility.length > 0);
+
+const blockPaddingPx = ({ classes }: { classes: string }): number => {
+  let total = 0;
+  for (const utility of utilitiesOf({ classes })) {
+    const match = /^(p|py|pt|pb)-(\d+(?:\.\d+)?)$/.exec(utility);
+    if (match === null) {
+      continue;
+    }
+    const edge = step({ multiplier: Number(match[2]) });
+    total += match[1] === 'pt' || match[1] === 'pb' ? edge : edge * 2;
+  }
+  return total;
+};
+
+const COUNT_CHIP_PX = LEADING_2XS_PX + step({ multiplier: COUNT_CHIP_PADDING_STEP }) * 2;
+const KBD_PILL_PX = step({ multiplier: KBD_PILL_HEIGHT_STEP });
+const ROW_CONTENT_PX = Math.max(RAIL_GLYPH_PX, LEADING_SM_PX, COUNT_CHIP_PX, KBD_PILL_PX);
+const ROW_PX = blockPaddingPx({ classes: PANE_RHYTHM.navRail.row }) + ROW_CONTENT_PX;
+const GROUP_LABEL_PX = LEADING_3XS_PX + step({ multiplier: GROUP_LABEL_PADDING_STEP });
+
+const isWhole = (value: number): boolean => Number.isInteger(value);
+
+const railColumnOffsets = ({
+  groups,
+}: {
+  groups: ReadonlyArray<{ readonly hasLabel: boolean; readonly rows: number }>;
+}): ReadonlyArray<number> => {
+  const offsets: number[] = [];
+  let cursor = blockPaddingPx({ classes: PANE_RHYTHM.navRail.body }) / 2;
+  for (const [index, group] of groups.entries()) {
+    if (index > 0) {
+      cursor += step({ multiplier: GROUP_GAP_STEP });
+    }
+    if (group.hasLabel) {
+      offsets.push(cursor);
+      cursor += GROUP_LABEL_PX + step({ multiplier: ROW_GAP_STEP });
+    }
+    for (let row = 0; row < group.rows; row += 1) {
+      offsets.push(cursor);
+      cursor += ROW_PX;
+      if (row < group.rows - 1) {
+        cursor += step({ multiplier: ROW_GAP_STEP });
+      }
+    }
+  }
+  return offsets;
+};
+
+describe('lens rail whole-pixel geometry', () => {
+  it('keeps the spacing base an even whole pixel, so every half step is whole', () => {
+    expect(isWhole(SPACING_PX)).toBe(true);
+    expect(SPACING_PX % 2).toBe(0);
+    expect(isWhole(step({ multiplier: 0.5 }))).toBe(true);
+  });
+
+  it('pins a whole line box on every text size the rail composes', () => {
+    expect([LEADING_3XS_PX, LEADING_2XS_PX, LEADING_SM_PX].filter((px) => !isWhole(px))).toEqual(
+      [],
+    );
+    expect(LEADING_3XS_PX).toBeGreaterThan(readTokenPx({ token: '--text-3xs' }));
+    expect(LEADING_2XS_PX).toBeGreaterThan(readTokenPx({ token: '--text-2xs' }));
+    expect(LEADING_SM_PX).toBeGreaterThan(readTokenPx({ token: '--text-sm' }));
+  });
+
+  it('builds the rail rhythm from spacing-scale steps, never an arbitrary value', () => {
+    const offScale = [
+      PANE_RHYTHM.navRail.inset,
+      PANE_RHYTHM.navRail.body,
+      PANE_RHYTHM.navRail.row,
+    ].flatMap((classes) => utilitiesOf({ classes }).filter((utility) => !SCALE_STEP.test(utility)));
+    expect(offScale).toEqual([]);
+  });
+
+  it('keeps a badged row exactly as tall as a bare row', () => {
+    expect(COUNT_CHIP_PX).toBeLessThanOrEqual(LEADING_SM_PX);
+    expect(KBD_PILL_PX).toBeLessThanOrEqual(LEADING_SM_PX);
+    expect(ROW_CONTENT_PX).toBe(LEADING_SM_PX);
+  });
+
+  it('lands the row box and the group label on whole pixels', () => {
+    expect(isWhole(ROW_PX)).toBe(true);
+    expect(isWhole(GROUP_LABEL_PX)).toBe(true);
+    expect(isWhole(step({ multiplier: ROW_GAP_STEP }))).toBe(true);
+    expect(isWhole(step({ multiplier: GROUP_GAP_STEP }))).toBe(true);
+  });
+
+  it('lands every row of a grouped rail column on a whole pixel', () => {
+    const offsets = railColumnOffsets({
+      groups: [
+        { hasLabel: false, rows: 2 },
+        { hasLabel: true, rows: 7 },
+        { hasLabel: true, rows: 3 },
+        { hasLabel: true, rows: 6 },
+      ],
+    });
+    expect(offsets).toHaveLength(21);
+    expect(offsets.filter((offset) => !isWhole(offset))).toEqual([]);
+  });
+});

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -91,10 +91,15 @@
   --color-syntax-tag: oklch(0.74 0.13 25);
   --color-syntax-regex: oklch(0.77 0.11 120);
 
+  --spacing: 4px;
+
   --text-3xs: 10px;
+  --text-3xs--line-height: 14px;
   --text-2xs: 11px;
+  --text-2xs--line-height: 16px;
   --text-xs: 12px;
   --text-sm: 14px;
+  --text-sm--line-height: 20px;
   --text-base: 15px;
   --text-lg: 17px;
   --text-xl: 20px;

--- a/packages/ui/DESIGN-SYSTEM.md
+++ b/packages/ui/DESIGN-SYSTEM.md
@@ -16,11 +16,11 @@ lives here.
 `lg` 17px, `xl` 20px. Any `text-[Npx]` is rejected; standing exceptions live in
 `docs/styling.md`, which owns the authoring rule.
 
-**A size a repeated row composes carries its own line-height.** Without the
-pair, the box height follows whatever `line-height` it inherits: `3xs` and `2xs`
-inherited the body's 1.55 and resolved to 15.5px and 17.05px, which put the lens
-rail's group labels and count chips on a fractional pixel and made a row with a
-count taller than its neighbour without one.
+**Every size a repeated row uses declares its own line-height.** Without that
+pair, the box height follows whatever `line-height` the size inherits: `3xs` and
+`2xs` inherited the body's 1.55 and resolved to 15.5px and 17.05px, which put the
+lens rail's group labels and count chips on a fractional pixel and made a row
+carrying a count taller than a row without one.
 
 ## Radius scale
 

--- a/packages/ui/DESIGN-SYSTEM.md
+++ b/packages/ui/DESIGN-SYSTEM.md
@@ -12,9 +12,15 @@ lives here.
 
 ## Type scale
 
-`text-3xs` 10px, `2xs` 11px, `xs` 12px, `sm` 14px, `base` 15px, `lg` 17px,
-`xl` 20px. Any `text-[Npx]` is rejected; standing exceptions live in
+`text-3xs` 10px/14px, `2xs` 11px/16px, `xs` 12px, `sm` 14px/20px, `base` 15px,
+`lg` 17px, `xl` 20px. Any `text-[Npx]` is rejected; standing exceptions live in
 `docs/styling.md`, which owns the authoring rule.
+
+**A size a repeated row composes carries its own line-height.** Without the
+pair, the box height follows whatever `line-height` it inherits: `3xs` and `2xs`
+inherited the body's 1.55 and resolved to 15.5px and 17.05px, which put the lens
+rail's group labels and count chips on a fractional pixel and made a row with a
+count taller than its neighbour without one.
 
 ## Radius scale
 
@@ -26,6 +32,19 @@ at this scale.
 | `rounded-lg`   | 8px   | framed surfaces: cards, banners, inputs, buttons   |
 | `rounded-md`   | 6px   | small inset controls: icon buttons, segmented tabs |
 | `rounded-full` | n/a   | pills, avatars, circular icon buttons              |
+
+## Spacing scale
+
+The base is `4px`, declared in px and never in rem. Every utility resolves to
+`calc(4px * n)`, so the smallest step the scale offers (`0.5`, a 2px gap) is
+still a whole pixel and so is everything above it.
+
+A rem base breaks that: the root font size is 15px, which turns the same scale
+into a 3.75px grid and leaves most boxes on a fractional pixel. That is invisible
+until something animates. An element with a running transition is promoted to its
+own compositing layer and rasterised on the device pixel grid, so a fractional
+box snaps to whole pixels when the transition starts and back when it ends, which
+reads as a one pixel bounce on every icon in the column.
 
 ## Gap scale
 


### PR DESCRIPTION
## What the owner saw

> ogni volta che vado in hover su un item in sidebar, tutte le icone dei vari panel si spostano di un px verso l'alto, per poi tornare dove erano prima

## What changed

Three tokens in `apps/desktop/src/styles.css`:

- `--spacing: 4px`, replacing Tailwind's rem based default.
- `--text-3xs--line-height: 14px` and `--text-2xs--line-height: 16px`, which the two custom sizes never had.
- `--text-sm--line-height: 20px`, the value it already computed, now pinned rather than inherited from a framework default.

Plus a regression test and the token law in `packages/ui/DESIGN-SYSTEM.md`.

## The diagnosis, and how it was proved

The app cannot boot outside Tauri (`Cannot read properties of undefined (reading 'invoke')` at init), so the real app in a browser was not an option. Instead the real `LensNav` markup was rendered through the existing test harness, mounted in the real sidebar chain against the real compiled stylesheet, and measured in headless Chrome at `devicePixelRatio: 2` over CDP.

**Hover does not touch layout.** With the mouse really over a row (`:hover` matching, row background at `oklch(0.265 0.01 255)`, badge opacity `0`, shortcut pill opacity `0.6`), `getBoundingClientRect()` on every row and every icon is byte identical to the un-hovered snapshot, both 60ms into the transition and 600ms after it. Zero diffs. So it is not a reflow and not a re-render, exactly as the task said.

**The pixels were never on the grid.** 95 boxes in the rail sat at a fractional device pixel position or height. The icons were the visible ones: device-pixel tops of `239.75`, `440.75`, `507.797`, `574.844`, `641.891`, `709.734`, `777.578`. A composited layer is rasterised on whole device pixels, so promoting on transition start and demoting on transition end moves those glyphs by one device pixel and back. That is the bounce.

**Why they were fractional.** The root font size is 15px, so the rem based spacing scale is a 3.75px grid, not a 4px one: `py-3` was `11.25px`, `py-1.5` was `5.625px`, `gap-0.5` was `1.875px`, `w-5` was `18.75px`. Independently, `text-3xs` and `text-2xs` emitted `font-size` with no `line-height`, so they inherited the body's unitless `1.55` and resolved to `15.5px` and `17.05px`, which is also why a row with a count badge was `32.047px` tall next to a bare row at `31.25px`.

Both causes are load bearing, tested in isolation: spacing alone leaves 81 offenders, line-heights alone leave 79, together zero.

## Before and after, measured

| | before | after |
| --- | --- | --- |
| boxes off the device pixel grid | 95 | 0 |
| distinct row heights | 31.25px, 32.047px | 32px |
| nav inset | 11.25px / 7.5px | 12px / 8px |
| row gap | 1.875px | 2px |
| group gap | 15px | 16px |
| group label box | 19.25px | 18px |

Hover affordances still work after the fix: the row tints, the badge fades to `0`, the shortcut pill fades to `0.6`, and layout still does not move.

## What to look at

The spacing scale grows by 1/15 across the whole app, because 3.75px steps become 4px steps. That is the point: it restores the values the design system documents. Worth a look at anything with a fixed height holding spacing sized content. I checked the tight ones statically: the collapsed rail's `w-11` now measures exactly the 44px grid column it lives in instead of 41.25px, the stage board card keeps 30px of slack inside `h-[8.25rem]`, and nothing inside `h-[var(--chat-header-h)]` uses an `h-8` or `size-8` child.

**I did not see this rendered.** A dev instance was already running from another worktree, so no second Tauri dev server was started; the browser measurement above is the evidence, and Blink was the engine, not the WKWebView the bug was reported in. The fractional geometry it measures is spec defined box math and identical in both, but the compositing snap itself was reasoned about, not observed.

## Decisions the task did not specify

- **Fixed the token, not the rail.** Rounding only the nav column would have taken about six arbitrary px values in a codebase that rejects them, and would have left the same latent bug in every other transitioned surface. The spacing base is one line and no arbitrary values.
- **Rounded up, to the documented grid.** No zero-delta option exists, since the current values are fractional either way. 4px is what `DESIGN-SYSTEM.md` already describes.
- **Pinned `text-sm` too.** It is a no-op today, but the row's height derives from it, and an unpinned line box is the class of bug being fixed.

## Deliberately left out

- `--text-base` (15px) and `--text-lg` (17px) still inherit fractional line boxes from Tailwind's defaults, at 22.5px and 26.44px. Neither is in the rail, and pinning them changes prose rhythm across the app, which is not this PR's concern.
- `--container-*` is still rem based, so `max-w-5xl` measures 960px while `DESIGN-SYSTEM.md` claims 1024px. Same root cause, different surface, no bearing on the jitter.
- No `will-change` or `translateZ(0)` anywhere: that trades the jump for permanent extra layers and blurry text.

## Verification

Run from the worktree root:

- `pnpm typecheck`: 5 successful, 5 total.
- `pnpm lint`: 0 tasks executed, no package implements it.
- `pnpm test`: 680 test files, 5835 tests, all passed.
- `pnpm build`: built in 997ms, `index-TmXSedyr.css` 134.79 kB. The shipped CSS carries `--spacing:4px` and a `line-height` on both custom sizes.
- `pnpm knip`: fails, with byte identical output before and after this branch (128 lines both ways). Every finding pre-exists on `main` and none is in a file this PR touches.
- `pnpm format:check`: fails on `packages/core/src/roles.ts` and three files in `packages/types`, all pre-existing on `main` and none touched here.

The new test was confirmed to fail without the fix three ways: reverting the spacing base to `0.25rem`, dropping either line-height token, and setting an odd px base.

Made with [Cursor](https://cursor.com)