### PR TITLE
docs(repo): the readme credits contributors instead of stars

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,11 +210,25 @@ triaged every release cycle, so you get an answer even when it is "not yet". A
 request for something the project refuses on principle, tracking above all,
 gets a written no rather than silence.
 
-## Star history
+## Contributors
 
-<a href="https://www.star-history.com/?repos=akhayam99%2Fgoodboy&type=date&legend=top-left">
-  <img src="https://api.star-history.com/svg?repos=akhayam99/goodboy&type=Date" alt="Star history chart" width="640" />
-</a>
+<table>
+  <tr>
+    <td align="center">
+      <a href="https://github.com/akhayam99">
+        <img src="https://avatars.githubusercontent.com/u/87425758?s=120" width="80" alt="" /><br />
+        <sub><b>Amin Khayam</b></sub>
+      </a>
+    </td>
+    <td align="center">
+      <a href="https://github.com/teckperry">
+        <img src="https://avatars.githubusercontent.com/u/85160151?s=120" width="80" alt="" /><br />
+        <sub><b>Luca Laudiero</b></sub>
+      </a><br />
+      <sub><a href="https://teckperry.xyz">teckperry.xyz</a></sub>
+    </td>
+  </tr>
+</table>
 
 ## More
 

--- a/README.md
+++ b/README.md
@@ -212,23 +212,8 @@ gets a written no rather than silence.
 
 ## Contributors
 
-<table>
-  <tr>
-    <td align="center">
-      <a href="https://github.com/akhayam99">
-        <img src="https://avatars.githubusercontent.com/u/87425758?s=120" width="80" alt="" /><br />
-        <sub><b>Amin Khayam</b></sub>
-      </a>
-    </td>
-    <td align="center">
-      <a href="https://github.com/teckperry">
-        <img src="https://avatars.githubusercontent.com/u/85160151?s=120" width="80" alt="" /><br />
-        <sub><b>Luca Laudiero</b></sub>
-      </a><br />
-      <sub><a href="https://teckperry.xyz">teckperry.xyz</a></sub>
-    </td>
-  </tr>
-</table>
+<a href="https://github.com/akhayam99"><img src="https://avatars.githubusercontent.com/u/87425758?s=120" width="56" height="56" alt="Amin Khayam" style="border-radius:50%" /></a>
+<a href="https://github.com/teckperry"><img src="https://avatars.githubusercontent.com/u/85160151?s=120" width="56" height="56" alt="Luca Laudiero" style="border-radius:50%" /></a>
 
 ## More
 


### PR DESCRIPTION
The star history chart at the foot of the readme becomes a Contributors section, in the shape Mantine uses: avatars linking to profiles rather than a growth graph.

Two entries: Amin Khayam, and Luca Laudiero, who opened issues #1472 and #1473, with his site alongside his profile.