### PR TITLE
refactor(desktop): context gets its rhythm and its icons straight

### DIFF
--- a/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
+++ b/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
@@ -143,49 +143,49 @@ exports[`snapshot, empty states > NewSessionView: no workflows 1`] = `
             class="flex flex-col gap-3"
           >
             <div
-              class="flex items-start gap-3"
+              class="flex flex-col gap-1"
             >
-              <span
-                class="flex w-5 shrink-0 justify-center"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="lucide lucide-target text-primary"
-                  fill="none"
-                  height="16"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  viewBox="0 0 24 24"
-                  width="16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <circle
-                    cx="12"
-                    cy="12"
-                    r="10"
-                  />
-                  <circle
-                    cx="12"
-                    cy="12"
-                    r="6"
-                  />
-                  <circle
-                    cx="12"
-                    cy="12"
-                    r="2"
-                  />
-                </svg>
-              </span>
               <div
-                class="flex min-w-0 flex-1 flex-col gap-1"
+                class="flex items-center justify-between gap-2"
               >
                 <div
-                  class="flex items-center justify-between gap-2"
+                  class="flex min-w-0 items-center gap-2"
                 >
+                  <span
+                    class="flex shrink-0 items-center"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="lucide lucide-target text-primary"
+                      fill="none"
+                      height="14"
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      viewBox="0 0 24 24"
+                      width="14"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <circle
+                        cx="12"
+                        cy="12"
+                        r="10"
+                      />
+                      <circle
+                        cx="12"
+                        cy="12"
+                        r="6"
+                      />
+                      <circle
+                        cx="12"
+                        cy="12"
+                        r="2"
+                      />
+                    </svg>
+                  </span>
                   <h2
-                    class="text-base font-semibold text-foreground"
+                    class="min-w-0 text-base font-semibold leading-6 text-foreground"
                   >
                     Goal
                   </h2>
@@ -295,47 +295,47 @@ exports[`snapshot, empty states > NewSessionView: no workflows 1`] = `
             class="flex flex-col gap-3"
           >
             <div
-              class="flex items-start gap-3"
+              class="flex flex-col gap-1"
             >
-              <span
-                class="flex w-5 shrink-0 justify-center"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="lucide lucide-git-branch text-info"
-                  fill="none"
-                  height="16"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  viewBox="0 0 24 24"
-                  width="16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M15 6a9 9 0 0 0-9 9V3"
-                  />
-                  <circle
-                    cx="18"
-                    cy="6"
-                    r="3"
-                  />
-                  <circle
-                    cx="6"
-                    cy="18"
-                    r="3"
-                  />
-                </svg>
-              </span>
               <div
-                class="flex min-w-0 flex-1 flex-col gap-1"
+                class="flex items-center justify-between gap-2"
               >
                 <div
-                  class="flex items-center justify-between gap-2"
+                  class="flex min-w-0 items-center gap-2"
                 >
+                  <span
+                    class="flex shrink-0 items-center"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="lucide lucide-git-branch text-info"
+                      fill="none"
+                      height="14"
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      viewBox="0 0 24 24"
+                      width="14"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M15 6a9 9 0 0 0-9 9V3"
+                      />
+                      <circle
+                        cx="18"
+                        cy="6"
+                        r="3"
+                      />
+                      <circle
+                        cx="6"
+                        cy="18"
+                        r="3"
+                      />
+                    </svg>
+                  </span>
                   <h2
-                    class="text-base font-semibold text-foreground"
+                    class="min-w-0 text-base font-semibold leading-6 text-foreground"
                   >
                     Branch
                   </h2>
@@ -1024,49 +1024,49 @@ exports[`snapshot, error states > NewSessionView: form error 1`] = `
             class="flex flex-col gap-3"
           >
             <div
-              class="flex items-start gap-3"
+              class="flex flex-col gap-1"
             >
-              <span
-                class="flex w-5 shrink-0 justify-center"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="lucide lucide-target text-primary"
-                  fill="none"
-                  height="16"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  viewBox="0 0 24 24"
-                  width="16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <circle
-                    cx="12"
-                    cy="12"
-                    r="10"
-                  />
-                  <circle
-                    cx="12"
-                    cy="12"
-                    r="6"
-                  />
-                  <circle
-                    cx="12"
-                    cy="12"
-                    r="2"
-                  />
-                </svg>
-              </span>
               <div
-                class="flex min-w-0 flex-1 flex-col gap-1"
+                class="flex items-center justify-between gap-2"
               >
                 <div
-                  class="flex items-center justify-between gap-2"
+                  class="flex min-w-0 items-center gap-2"
                 >
+                  <span
+                    class="flex shrink-0 items-center"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="lucide lucide-target text-primary"
+                      fill="none"
+                      height="14"
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      viewBox="0 0 24 24"
+                      width="14"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <circle
+                        cx="12"
+                        cy="12"
+                        r="10"
+                      />
+                      <circle
+                        cx="12"
+                        cy="12"
+                        r="6"
+                      />
+                      <circle
+                        cx="12"
+                        cy="12"
+                        r="2"
+                      />
+                    </svg>
+                  </span>
                   <h2
-                    class="text-base font-semibold text-foreground"
+                    class="min-w-0 text-base font-semibold leading-6 text-foreground"
                   >
                     Goal
                   </h2>
@@ -1176,47 +1176,47 @@ exports[`snapshot, error states > NewSessionView: form error 1`] = `
             class="flex flex-col gap-3"
           >
             <div
-              class="flex items-start gap-3"
+              class="flex flex-col gap-1"
             >
-              <span
-                class="flex w-5 shrink-0 justify-center"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="lucide lucide-git-branch text-info"
-                  fill="none"
-                  height="16"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  viewBox="0 0 24 24"
-                  width="16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M15 6a9 9 0 0 0-9 9V3"
-                  />
-                  <circle
-                    cx="18"
-                    cy="6"
-                    r="3"
-                  />
-                  <circle
-                    cx="6"
-                    cy="18"
-                    r="3"
-                  />
-                </svg>
-              </span>
               <div
-                class="flex min-w-0 flex-1 flex-col gap-1"
+                class="flex items-center justify-between gap-2"
               >
                 <div
-                  class="flex items-center justify-between gap-2"
+                  class="flex min-w-0 items-center gap-2"
                 >
+                  <span
+                    class="flex shrink-0 items-center"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="lucide lucide-git-branch text-info"
+                      fill="none"
+                      height="14"
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      viewBox="0 0 24 24"
+                      width="14"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M15 6a9 9 0 0 0-9 9V3"
+                      />
+                      <circle
+                        cx="18"
+                        cy="6"
+                        r="3"
+                      />
+                      <circle
+                        cx="6"
+                        cy="18"
+                        r="3"
+                      />
+                    </svg>
+                  </span>
                   <h2
-                    class="text-base font-semibold text-foreground"
+                    class="min-w-0 text-base font-semibold leading-6 text-foreground"
                   >
                     Branch
                   </h2>

--- a/apps/desktop/src/features/session/components/NewSessionView/NewSessionForm.tsx
+++ b/apps/desktop/src/features/session/components/NewSessionView/NewSessionForm.tsx
@@ -37,7 +37,7 @@ const sectionGlyph = ({
 }: {
   readonly Icon: (typeof CONCEPT_ICONS)[keyof typeof CONCEPT_ICONS];
   readonly tone: Tone;
-}): ReactNode => <Icon size={16} aria-hidden className={tintClasses(tone).icon} />;
+}): ReactNode => <Icon size={14} aria-hidden className={tintClasses(tone).icon} />;
 
 type BranchMode = 'new' | 'existing';
 

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/ContextPane/AddDecisionRow.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/ContextPane/AddDecisionRow.tsx
@@ -37,9 +37,9 @@ export const AddDecisionRow = ({ isLocked, onAdd }: Props) => {
       type="button"
       disabled={isLocked}
       onClick={() => setIsWriting(true)}
-      className="flex w-full items-center gap-2 rounded-lg border border-dashed border-border-soft px-3 py-2.5 text-left text-sm text-muted-foreground motion-safe:transition-colors hover:bg-muted/30 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] disabled:pointer-events-none disabled:opacity-40"
+      className="flex w-full items-center gap-2 rounded-lg border border-dashed border-border-soft px-3 py-2 text-left text-xs leading-5 text-muted-foreground motion-safe:transition-colors hover:bg-muted/30 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] disabled:pointer-events-none disabled:opacity-40"
     >
-      <Plus size={14} aria-hidden className="shrink-0" />
+      <Plus size={13} aria-hidden className="shrink-0" />
       Add decision
     </button>
   );

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/ContextPane/ContextSection.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/ContextPane/ContextSection.tsx
@@ -25,7 +25,7 @@ export const ContextSection = ({
   const tint = tintClasses(CONCEPT_TONE[concept]);
 
   return (
-    <section id={sectionId} aria-label={title} className="flex flex-col gap-2">
+    <section id={sectionId} aria-label={title} className="flex flex-col gap-4">
       <SectionHeader
         size="page"
         label={title}

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/ContextPane/ContextSection.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/ContextPane/ContextSection.tsx
@@ -25,12 +25,12 @@ export const ContextSection = ({
   const tint = tintClasses(CONCEPT_TONE[concept]);
 
   return (
-    <section id={sectionId} aria-label={title} className="flex flex-col gap-4">
+    <section id={sectionId} aria-label={title} className="flex flex-col gap-2">
       <SectionHeader
         size="page"
         label={title}
         hint={description}
-        icon={<Icon size={16} aria-hidden className={tint.icon} />}
+        icon={<Icon size={14} aria-hidden className={tint.icon} />}
         action={actions}
       />
       {children}

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/ContextPane/DecisionRowItem.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/ContextPane/DecisionRowItem.tsx
@@ -1,33 +1,25 @@
 import { useState } from 'react';
 import { Trash2 } from 'lucide-react';
-import {
-  CardAction,
-  CardActionSlot,
-  InlineConfirm,
-  Markdown,
-  cn,
-  tintClasses,
-  type Tone,
-} from '@goodboy/ui';
+import { CardAction, CardActionSlot, InlineConfirm, Markdown, cn } from '@goodboy/ui';
 import { BlockEditor } from './BlockEditor';
 
 const REVEAL_GROUP =
   'group-hover/decision-row:opacity-100 group-focus-within/decision-row:opacity-100';
 
+const ROW_PROSE = 'text-xs [&_li]:leading-5 [&_p]:leading-5';
+
 type Props = {
   readonly text: string;
   readonly position: number;
-  readonly tone: Tone;
   readonly isLocked: boolean;
   readonly onCommit: (text: string) => void;
   readonly onDelete: () => void;
 };
 
-export const DecisionRowItem = ({ text, position, tone, isLocked, onCommit, onDelete }: Props) => {
+export const DecisionRowItem = ({ text, position, isLocked, onCommit, onDelete }: Props) => {
   const [isEditing, setIsEditing] = useState(false);
   const [isDeleteArmed, setIsDeleteArmed] = useState(false);
   const [draft, setDraft] = useState(text);
-  const tint = tintClasses(tone);
   const label = `Decision ${position}`;
 
   const commit = () => {
@@ -55,11 +47,10 @@ export const DecisionRowItem = ({ text, position, tone, isLocked, onCommit, onDe
   }
 
   return (
-    <div className="flex flex-col gap-1">
+    <div className="flex flex-col gap-2">
       <div
         className={cn(
-          'group/decision-row flex items-start gap-2 rounded-lg border bg-muted/30 p-3 motion-safe:transition-colors',
-          tint.borderSoft,
+          'group/decision-row flex items-center gap-2 rounded-lg bg-muted/30 px-3 py-2 motion-safe:transition-colors',
           isLocked ? '' : 'hover:bg-muted/50',
         )}
       >
@@ -72,11 +63,11 @@ export const DecisionRowItem = ({ text, position, tone, isLocked, onCommit, onDe
             setIsEditing(true);
           }}
           className={cn(
-            'min-w-0 flex-1 rounded-md text-left text-sm leading-relaxed text-foreground [overflow-wrap:anywhere] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] [&_pre]:whitespace-pre-wrap',
+            'min-w-0 flex-1 rounded-md text-left [overflow-wrap:anywhere] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] [&_pre]:whitespace-pre-wrap',
             isLocked ? 'cursor-default' : 'cursor-text',
           )}
         >
-          <Markdown text={text} />
+          <Markdown text={text} className={ROW_PROSE} />
         </button>
         <CardActionSlot label={`${label} actions`}>
           <CardAction

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/ContextPane/DecisionsSection.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/ContextPane/DecisionsSection.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
+import { SkeletonText } from '@goodboy/ui';
 import { appendDecision, parseDecisions, removeDecision, replaceDecision } from '@goodboy/core';
-import { CONCEPT_TONE } from '../../../../../../shared/components/conceptIcons';
 import { AddDecisionRow } from './AddDecisionRow';
 import { DecisionRowItem } from './DecisionRowItem';
 import { RawDocumentEditor } from './RawDocumentEditor';
@@ -36,25 +36,16 @@ export const DecisionsSection = ({
   }
 
   if (isLoading) {
-    return (
-      <div className="flex flex-col gap-2" aria-label="Loading decisions">
-        <div className="h-4 w-full rounded bg-muted/50" />
-        <div className="h-4 w-3/4 rounded bg-muted/50" />
-      </div>
-    );
+    return <SkeletonText lines={2} />;
   }
 
   return (
     <div className="flex flex-col gap-2">
-      {document.rows.length === 0 ? (
-        <p className="text-sm text-muted-foreground">No decisions yet</p>
-      ) : null}
       {document.rows.map((row, position) => (
         <DecisionRowItem
           key={row.index}
           text={row.text}
           position={position + 1}
-          tone={CONCEPT_TONE.decisions}
           isLocked={isLocked}
           onCommit={(decision) =>
             onWrite(replaceDecision({ text: value, index: row.index, decision }))
@@ -67,7 +58,7 @@ export const DecisionsSection = ({
         onAdd={(decision) => onWrite(appendDecision({ text: value, decision }))}
       />
       {document.hasContentOutsideRows ? (
-        <p className="text-2xs leading-relaxed text-muted-foreground">
+        <p className="text-2xs text-muted-foreground">
           This document also holds text that no row covers. Edit the source to reach it.
         </p>
       ) : null}

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/ContextPane/SummaryBlock.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/ContextPane/SummaryBlock.tsx
@@ -1,19 +1,21 @@
 import { useState } from 'react';
-import { Button, Eyebrow, Markdown, cn, tintClasses, type Tone } from '@goodboy/ui';
+import { Pencil, Plus } from 'lucide-react';
+import { CardAction, CardActionSlot, Eyebrow, Markdown } from '@goodboy/ui';
 import { BlockEditor } from './BlockEditor';
+
+const REVEAL_GROUP =
+  'group-hover/summary-block:opacity-100 group-focus-within/summary-block:opacity-100';
 
 type Props = {
   readonly title: string;
   readonly body: string;
-  readonly tone: Tone;
   readonly isLocked: boolean;
   readonly onCommit: (body: string) => void;
 };
 
-export const SummaryBlockCard = ({ title, body, tone, isLocked, onCommit }: Props) => {
+export const SummaryBlock = ({ title, body, isLocked, onCommit }: Props) => {
   const [isEditing, setIsEditing] = useState(false);
   const [draft, setDraft] = useState(body);
-  const tint = tintClasses(tone);
   const hasBody = body.trim() !== '';
 
   const startEditing = () => {
@@ -30,25 +32,22 @@ export const SummaryBlockCard = ({ title, body, tone, isLocked, onCommit }: Prop
   };
 
   return (
-    <section
-      aria-label={title}
-      className={cn('flex flex-col gap-2 rounded-lg border bg-muted/30 p-3', tint.borderSoft)}
-    >
+    <section aria-label={title} className="group/summary-block flex flex-col gap-2">
       <div className="flex items-center justify-between gap-2">
         <h3>
           <Eyebrow label={title} />
         </h3>
         {isEditing ? null : (
-          <Button
-            size="sm"
-            variant="ghost"
-            onClick={startEditing}
-            disabled={isLocked}
-            aria-label={`${hasBody ? 'Edit' : 'Add'} ${title.toLowerCase()}`}
-            className="h-6 px-2 text-2xs"
-          >
-            {hasBody ? 'Edit' : 'Add'}
-          </Button>
+          <CardActionSlot label={`${title} actions`}>
+            <CardAction
+              icon={hasBody ? Pencil : Plus}
+              label={`${hasBody ? 'Edit' : 'Add'} ${title.toLowerCase()}`}
+              reveal={hasBody}
+              revealGroup={REVEAL_GROUP}
+              disabled={isLocked}
+              onClick={startEditing}
+            />
+          </CardActionSlot>
         )}
       </div>
       {isEditing ? (
@@ -66,9 +65,7 @@ export const SummaryBlockCard = ({ title, body, tone, isLocked, onCommit }: Prop
         <div className="text-sm leading-relaxed [overflow-wrap:anywhere] [&_pre]:whitespace-pre-wrap">
           <Markdown text={body} />
         </div>
-      ) : (
-        <p className="text-sm text-muted-foreground">Nothing here yet</p>
-      )}
+      ) : null}
     </section>
   );
 };

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/ContextPane/SummarySection.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/ContextPane/SummarySection.tsx
@@ -1,13 +1,12 @@
 import { useMemo } from 'react';
-import { Button } from '@goodboy/ui';
+import { SkeletonText } from '@goodboy/ui';
 import {
   insertSummarySection,
   parseSummaryDocument,
   replaceSummarySectionBody,
 } from '@goodboy/core';
-import { CONCEPT_TONE } from '../../../../../../shared/components/conceptIcons';
 import { RawDocumentEditor } from './RawDocumentEditor';
-import { SummaryBlockCard } from './SummaryBlockCard';
+import { SummaryBlock } from './SummaryBlock';
 import { summaryDisplayBlocks } from './summaryDisplayBlocks';
 
 type Props = {
@@ -44,38 +43,16 @@ export const SummarySection = ({
   }
 
   if (isLoading) {
-    return (
-      <div className="flex flex-col gap-2" aria-label="Loading session summary">
-        <div className="h-4 w-full rounded bg-muted/50" />
-        <div className="h-4 w-3/4 rounded bg-muted/50" />
-      </div>
-    );
-  }
-
-  if (blocks.length === 0) {
-    return (
-      <div className="flex items-center gap-4 rounded-lg bg-subtle p-3">
-        <p className="min-w-0 flex-1 text-sm text-muted-foreground">No session summary yet</p>
-        <Button
-          size="sm"
-          variant="ghost"
-          disabled={isLocked}
-          onClick={() => onWrite('#### Problem\n')}
-        >
-          Add
-        </Button>
-      </div>
-    );
+    return <SkeletonText lines={3} />;
   }
 
   return (
-    <div className="flex flex-col gap-2">
+    <div className="flex flex-col gap-4">
       {blocks.map((block) => (
-        <SummaryBlockCard
+        <SummaryBlock
           key={block.id}
           title={block.title}
           body={block.body}
-          tone={CONCEPT_TONE.sessionSummary}
           isLocked={isLocked}
           onCommit={(body) => {
             if (block.index != null) {

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/ContextPane/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/ContextPane/index.test.tsx
@@ -84,7 +84,11 @@ vi.mock('@goodboy/ui', async (importOriginal) => {
   return {
     ...actual,
     ScrollFade: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-    Markdown: ({ text }: { text: string }) => <span data-testid="markdown">{text}</span>,
+    Markdown: ({ text, className }: { text: string; className?: string }) => (
+      <span data-testid="markdown" className={className}>
+        {text}
+      </span>
+    ),
   };
 });
 
@@ -264,6 +268,39 @@ describe('Decisions rows', () => {
     ]);
     expect(decisions.querySelector('li')).toBeNull();
     expect(decisions.querySelector('[class*="list-disc"]')).toBeNull();
+  });
+
+  it('sets a row one step down the type scale, on a whole-pixel line box', () => {
+    render(<ContextPane session={SESSION} />);
+    const decisions = sectionFor('Decisions');
+
+    const prose = within(decisions).getAllByTestId('markdown')[0] as HTMLElement;
+
+    expect(prose.className).toContain('text-xs');
+    expect(prose.className).toContain('[&_p]:leading-5');
+    expect(prose.className).not.toContain('text-sm');
+  });
+
+  it('tightens the row and keeps the delete control on the text it belongs to', () => {
+    render(<ContextPane session={SESSION} />);
+    const decisions = sectionFor('Decisions');
+
+    const row = within(decisions).getByRole('button', { name: 'Edit decision 1' })
+      .parentElement as HTMLElement;
+
+    expect(row.className).toContain('py-2');
+    expect(row.className).not.toContain('p-3');
+    expect(row.className).toContain('items-center');
+    expect(row.className).not.toContain('border');
+  });
+
+  it('leaves the empty section to its add row rather than a placeholder', () => {
+    store.sessionSlots['session-1'] = slots({ decisions: '' });
+    render(<ContextPane session={SESSION} />);
+    const decisions = sectionFor('Decisions');
+
+    expect(decisions.textContent).not.toContain('No decisions yet');
+    expect(within(decisions).getByRole('button', { name: 'Add decision' })).toBeDefined();
   });
 
   it('edits the clicked row in place and leaves the rest byte identical', () => {

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/ContextPane/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/ContextPane/index.test.tsx
@@ -146,6 +146,25 @@ describe('Context regions', () => {
     );
   });
 
+  it('puts the variable-width controls before the constant-width copy glyph', () => {
+    store.sessionSlots['session-1'] = slots();
+    render(<ContextPane session={SESSION} />);
+    const decisions = sectionFor('Decisions');
+    const actions = within(decisions).getAllByRole('button');
+    const editSource = within(decisions).getByRole('button', { name: 'Edit source' });
+    const copy = within(decisions).getByRole('button', { name: 'copy decisions' });
+
+    expect(actions.indexOf(copy)).toBeGreaterThan(actions.indexOf(editSource));
+  });
+
+  it('states each region once, in its own heading, and not again above them', () => {
+    render(<ContextPane session={SESSION} />);
+
+    expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('Context');
+    expect(screen.getByText('One row per choice already settled along the way.')).toBeDefined();
+    expect(screen.queryByText(/summary and the decisions settled/)).toBeNull();
+  });
+
   it('keeps both regions on one page rather than behind a segmented control', () => {
     render(<ContextPane session={SESSION} />);
 
@@ -165,6 +184,29 @@ describe('Session summary blocks', () => {
       expect(within(summary).getByRole('region', { name: title })).toBeDefined();
     }
     expect(summary.textContent).not.toContain('####');
+  });
+
+  it('labels each block without drawing a box around it', () => {
+    render(<ContextPane session={SESSION} />);
+    const problem = within(sectionFor('Session summary')).getByRole('region', { name: 'Problem' });
+
+    expect(problem.className).not.toContain('border');
+    expect(problem.className).not.toContain('bg-');
+    expect(within(problem).getByText('Problem').className).toContain('uppercase');
+  });
+
+  it('offers the four blocks on an empty document instead of a bespoke placeholder', () => {
+    store.sessionSlots['session-1'] = slots({ last_output_summary: '' });
+    render(<ContextPane session={SESSION} />);
+    const summary = sectionFor('Session summary');
+
+    for (const title of ['Problem', 'Learned', 'State', 'Next']) {
+      expect(within(summary).getByRole('region', { name: title })).toBeDefined();
+      expect(
+        within(summary).getByRole('button', { name: `Add ${title.toLowerCase()}` }),
+      ).toBeDefined();
+    }
+    expect(summary.textContent).not.toContain('No session summary yet');
   });
 
   it('edits one section without touching the other three', () => {
@@ -241,7 +283,7 @@ describe('Session summary blocks', () => {
     render(<ContextPane session={SESSION} />);
     const next = within(sectionFor('Session summary')).getByRole('region', { name: 'Next' });
 
-    expect(next.textContent).toContain('Nothing here yet');
+    expect(next.textContent).toBe('Next');
     expect(store.upsertSessionSlot).not.toHaveBeenCalled();
 
     fireEvent.click(within(next).getByRole('button', { name: 'Add next' }));

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/ContextPane/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/ContextPane/index.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useMemo, useState } from 'react';
-import { Button, CopyButton, Divider } from '@goodboy/ui';
-import { History } from 'lucide-react';
+import { Fragment, useEffect, useMemo, useState } from 'react';
+import { CopyButton, Divider, GhostActionButton } from '@goodboy/ui';
+import { Code, History } from 'lucide-react';
 import type { Session, SessionId } from '@goodboy/types';
 import {
   useAppStore,
@@ -28,7 +28,7 @@ const REGION_TITLE: Record<ContextLens, string> = {
 
 const REGION_DESCRIPTION: Record<ContextLens, string> = {
   decisions: 'One row per choice already settled along the way.',
-  last_output_summary: 'What the session has amounted to so far, in four blocks.',
+  last_output_summary: 'What the session has amounted to so far, block by block.',
 };
 
 const REGION_CONCEPT = {
@@ -123,10 +123,7 @@ export const ContextPane = ({ session, initialRegion }: Props) => {
         )
       }
     >
-      <PaneShell
-        title="Context"
-        description="The current session summary and the decisions settled along the way."
-      >
+      <PaneShell title="Context">
         {REGION_ORDER.map((slotKey, index) => {
           const value = valueFor({ slots, slotKey });
           const title = REGION_TITLE[slotKey];
@@ -138,7 +135,7 @@ export const ContextPane = ({ session, initialRegion }: Props) => {
           };
 
           return (
-            <div key={slotKey} className="contents">
+            <Fragment key={slotKey}>
               {index > 0 ? <Divider /> : null}
               <ContextSection
                 concept={REGION_CONCEPT[slotKey]}
@@ -147,16 +144,25 @@ export const ContextPane = ({ session, initialRegion }: Props) => {
                 description={REGION_DESCRIPTION[slotKey]}
                 actions={
                   <div className="flex shrink-0 items-center gap-1">
-                    <Button
-                      size="sm"
-                      variant="ghost"
-                      onClick={() => setRawKey(isRawEditing ? null : slotKey)}
-                      aria-pressed={isRawEditing}
+                    <GhostActionButton
+                      icon={Code}
+                      label={isRawEditing ? 'Done' : 'Edit source'}
+                      pressed={isRawEditing}
+                      highlighted={isRawEditing}
                       disabled={isLocked}
-                      className="h-7 px-2 text-xs text-muted-foreground"
-                    >
-                      {isRawEditing ? 'Done' : 'Edit source'}
-                    </Button>
+                      onClick={() => setRawKey(isRawEditing ? null : slotKey)}
+                    />
+                    {historyCount > 0 ? (
+                      <GhostActionButton
+                        icon={History}
+                        label={`${historyCount} ${historyCount === 1 ? 'version' : 'versions'}`}
+                        ariaLabel={`View ${historyCount} previous ${historyCount === 1 ? 'version' : 'versions'} of ${title}`}
+                        onClick={() => {
+                          void loadSlotHistory(sessionId, slotKey);
+                          setHistoryKey(slotKey);
+                        }}
+                      />
+                    ) : null}
                     {value.length > 0 ? (
                       <CopyButton
                         presentation="icon"
@@ -166,25 +172,8 @@ export const ContextPane = ({ session, initialRegion }: Props) => {
                             ? 'copy shareable summary'
                             : `copy ${title.toLowerCase()}`
                         }
-                        size={15}
-                        className="rounded-md p-1.5 text-muted-foreground/60 transition-colors hover:bg-foreground/5 hover:text-foreground"
+                        size={13}
                       />
-                    ) : null}
-                    {historyCount > 0 ? (
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => {
-                          void loadSlotHistory(sessionId, slotKey);
-                          setHistoryKey(slotKey);
-                        }}
-                        aria-label={`View ${historyCount} previous ${historyCount === 1 ? 'version' : 'versions'} of ${title}`}
-                        className="h-7 gap-1.5 px-2 text-xs text-muted-foreground"
-                      >
-                        <History size={13} aria-hidden />
-                        {historyCount} {historyCount === 1 ? 'version' : 'versions'}
-                      </Button>
                     ) : null}
                   </div>
                 }
@@ -209,7 +198,7 @@ export const ContextPane = ({ session, initialRegion }: Props) => {
                   />
                 )}
               </ContextSection>
-            </div>
+            </Fragment>
           );
         })}
       </PaneShell>

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/ContextPane/summaryDisplayBlocks.test.ts
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/ContextPane/summaryDisplayBlocks.test.ts
@@ -35,9 +35,16 @@ describe('summaryDisplayBlocks', () => {
     expect(blocks.map((block) => block.index)).toEqual([0, null, null, null]);
   });
 
-  it('implies no structure for a document that carries none', () => {
+  it('implies no structure over prose that carries none', () => {
     expect(titlesOf('**bold label:** legacy prose')).toEqual(['Notes']);
-    expect(titlesOf('')).toEqual([]);
+  });
+
+  it('offers the four sections on a blank document, so nothing needs a placeholder', () => {
+    const blocks = summaryDisplayBlocks({ document: parseSummaryDocument({ text: '' }) });
+
+    expect(blocks.map((block) => block.title)).toEqual(['Problem', 'Learned', 'State', 'Next']);
+    expect(blocks.map((block) => block.index)).toEqual([null, null, null, null]);
+    expect(blocks.map((block) => block.body)).toEqual(['', '', '', '']);
   });
 
   it('keeps the heading the document actually wrote as the block title', () => {

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/ContextPane/summaryDisplayBlocks.ts
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/ContextPane/summaryDisplayBlocks.ts
@@ -30,7 +30,9 @@ export const summaryDisplayBlocks = ({ document }: Params): ReadonlyArray<Summar
       sectionKey: null,
     }));
 
-  const hasAnyKnownSection = document.blocks.some((block) => block.sectionKey != null);
+  const hasKnownSection = document.blocks.some((block) => block.sectionKey != null);
+  const isBlankDocument = document.blocks.length === 0;
+  const offersEverySection = hasKnownSection || isBlankDocument;
 
   const sections = SUMMARY_SECTION_KEYS.flatMap<SummaryDisplayBlock>((sectionKey) => {
     const block = document.blocks.find((candidate) => candidate.sectionKey === sectionKey);
@@ -45,7 +47,7 @@ export const summaryDisplayBlocks = ({ document }: Params): ReadonlyArray<Summar
         },
       ];
     }
-    if (hasAnyKnownSection === false) {
+    if (offersEverySection === false) {
       return [];
     }
     return [

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/SlotPane.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/SlotPane.test.tsx
@@ -209,12 +209,14 @@ describe('ContextPane', () => {
     ).toEqual(['Session summary', 'Decisions']);
   });
 
-  it('shows a normal empty state for each empty region', () => {
+  it('offers the way into each empty region rather than a placeholder', () => {
     store.sessionSlots['session-1'] = [];
     render(<ContextPane session={SESSION} />);
 
-    expect(screen.getByText('No decisions yet')).toBeDefined();
-    expect(screen.getByText('No session summary yet')).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Add decision' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Add problem' })).toBeDefined();
+    expect(screen.queryByText('No decisions yet')).toBeNull();
+    expect(screen.queryByText('No session summary yet')).toBeNull();
   });
 
   it('does not pull slot history on mount, only the counts already in the store', () => {

--- a/packages/ui/src/__tests__/SectionHeader.test.tsx
+++ b/packages/ui/src/__tests__/SectionHeader.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { SectionHeader } from '../components/SectionHeader';
+
+afterEach(cleanup);
+
+const glyph = <svg data-testid="glyph" />;
+
+describe('SectionHeader, page size', () => {
+  it('anchors the glyph on the heading line box instead of the top of the column', () => {
+    render(<SectionHeader size="page" label="Decisions" icon={glyph} />);
+
+    const heading = screen.getByRole('heading', { level: 2, name: 'Decisions' });
+    const cluster = screen.getByTestId('glyph').parentElement?.parentElement;
+
+    expect(cluster).toBe(heading.parentElement);
+    expect(cluster?.className).toContain('items-center');
+  });
+
+  it('declares the heading line height so the pair lands on whole pixels', () => {
+    render(<SectionHeader size="page" label="Session summary" icon={glyph} />);
+
+    expect(screen.getByRole('heading', { level: 2 }).className).toContain('leading-6');
+  });
+
+  it('keeps a taller action out of the pair, so it cannot lift the glyph off the text', () => {
+    render(
+      <SectionHeader
+        size="page"
+        label="Decisions"
+        icon={glyph}
+        action={<button type="button" className="h-7" />}
+      />,
+    );
+
+    const cluster = screen.getByTestId('glyph').parentElement?.parentElement;
+
+    expect(cluster?.contains(screen.getByRole('button'))).toBe(false);
+  });
+
+  it('leaves the description on the same left edge as the glyph and the section body', () => {
+    render(
+      <SectionHeader
+        size="page"
+        label="Decisions"
+        icon={glyph}
+        hint="One row per choice already settled."
+      />,
+    );
+
+    const hint = screen.getByText('One row per choice already settled.');
+    const heading = screen.getByRole('heading', { level: 2 });
+
+    expect(hint.parentElement).toBe(heading.parentElement?.parentElement?.parentElement);
+    expect(heading.parentElement?.contains(hint)).toBe(false);
+  });
+});
+
+describe('SectionHeader, eyebrow size', () => {
+  it('labels the section without adding a heading to the outline', () => {
+    render(<SectionHeader label="Versions" icon={glyph} hint="restore any of them" />);
+
+    expect(screen.queryByRole('heading')).toBeNull();
+    expect(screen.getByText('Versions')).toBeDefined();
+    expect(screen.getByText('restore any of them')).toBeDefined();
+  });
+});

--- a/packages/ui/src/components/SectionHeader.tsx
+++ b/packages/ui/src/components/SectionHeader.tsx
@@ -25,17 +25,17 @@ export const SectionHeader = ({
 
   if (size === 'page') {
     return (
-      <div className={cn('flex items-start gap-3', className)}>
-        {icon != null ? <span className="flex w-5 shrink-0 justify-center">{icon}</span> : null}
-        <div className="flex min-w-0 flex-1 flex-col gap-1">
-          <div className="flex items-center justify-between gap-2">
-            <h2 className="text-base font-semibold text-foreground">{title}</h2>
-            {action ?? null}
+      <div className={cn('flex flex-col gap-1', className)}>
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex min-w-0 items-center gap-2">
+            {icon != null ? <span className="flex shrink-0 items-center">{icon}</span> : null}
+            <h2 className="min-w-0 text-base font-semibold leading-6 text-foreground">{title}</h2>
           </div>
-          {hint != null ? (
-            <p className="text-sm leading-relaxed text-muted-foreground">{hint}</p>
-          ) : null}
+          {action ?? null}
         </div>
+        {hint != null ? (
+          <p className="text-sm leading-relaxed text-muted-foreground">{hint}</p>
+        ) : null}
       </div>
     );
   }


### PR DESCRIPTION
Second pass on Context. The structure #1475 landed stays: two regions on one
page, editable blocks over one markdown document, decisions as rows, byte
preserving round trips. This is the visual and rhythmic pass on top of it.

## What I judged wrong, and what I did

**The concept glyph never met its heading, and the bug was shared.** The
page-size `SectionHeader` put the glyph in its own top-aligned 20px column
beside the content column, so it sat against the top of the column rather
than on the heading's line box: about 4px high on its own, and about 6px
high in Context, because the `h-7` ghost buttons in the action slot grow the
row the heading is centred in and the glyph column never learns about it.
Fixed at the pair, in the shared place: the glyph joins the heading in one
`gap-2` cluster that centres on the text and excludes the action, so no
action height can move it again. The heading also declares `leading-6`,
since `text-base` has no line-height of its own and inherited the body's
1.55 for a 23.25px line box, which is the fractional-pixel trap
`DESIGN-SYSTEM.md` describes and #1478 just paid for elsewhere. The same
misalignment was live on the nine Guide studio headings and the three create
session headings; they are all fixed by that one change. Their glyph grade
disagreed too, 14px in Guide and 16px in Context and create session, so
Context and create session drop to the 14px the majority already used, which
is also the grade that matches the cap height of a 15px heading.

**Decisions were built like cards, not like reference material.** A one-line
decision cost 47px: `p-3` around a `text-sm` body whose `leading-relaxed`
resolves to 22.75px, so every row in a column that transitions on hover sat
on a fractional pixel. The row is now one step down the type scale with a
declared 20px line box and an 8px vertical inset: 36px, a 23% cut, and about
a viewport of scrolling saved on the 93-row document in the snapshot. The
delete control now sits centred on the text it deletes instead of 2px above
it, and it is still the same 24px `CardAction` revealed on hover and focus.
The multi-line case stays readable: the row keeps the document markdown
render, not the preview one, because preview collapses a fenced block to its
first line and `DESIGN.md` exempts a document pane from truncation.

**The page was boxes all the way down.** Four bordered, filled cards for the
summary blocks, plus a bordered filled row per decision, plus a tone tint on
every one of them, inside a page whose two regions a `Divider` already
separates. The tint was decoration rather than meaning: it repeated the
concept tone the section heading already carries, identically on every row,
so it distinguished nothing. Tone stays where it identifies the concept, on
the heading glyph. The summary blocks stop being cards and become what they
are, which `docs/styling.md` already names: a `2xs` uppercase muted label
plus its content, never a nested card. Their edit control follows the card
action grammar the decision rows use, an icon action revealed on hover and
focus, and it stays visible while a block is empty because then there is
nothing else to see.

**The rhythm now reads as one ladder** rather than four gaps that disagreed:
8px inside a block and between rows, 16px from a section header to its body,
20px and a hairline between the two regions.

**The empty states were three shapes for one idea.** A "No decisions yet"
paragraph, a bespoke "No session summary yet" panel on a second surface
shade, and "Nothing here yet" inside every empty block. All three are gone.
An empty section inside a composite page shows its header at most, and each
region already carries its own way in: the add row for decisions, and, for a
blank summary, the same four blocks it shows once one heading exists. So a
new session is taught the shape of a summary instead of being told it has
none.

**The action cluster leaked its own placement.** Three hand-sized ghost
buttons (`h-7 px-2 text-xs`, restating what `Button size="sm"` already sets)
and a `CopyButton` carrying five hand-written classes. They go through
`GhostActionButton` and the primitive's own presentation. Order changed too:
the cluster is right-aligned, so the constant-width copy glyph goes last and
the variable "N versions" control before it, or the right edge wanders
between the two section headers as the count changes.

**The pane description restated the two headings under it** and each region
already has a hint that says something the heading does not. It is cut. The
summary hint stopped claiming "in four blocks", which the parser can exceed
whenever a document carries a heading we do not know.

## What to look at

Open a session with a long decisions document: the column, the row height,
and the glyph beside each of the two headings. Then a session with no
summary yet, which now shows Problem, Learned, State and Next with an add
control each. Then Guide studio and the create-session form, which get the
alignment fix for free.

## What I decided that the task did not specify

- Dropping the tone tint from the rows and blocks. The task said tone is
  meaning; repeated identically per row it is not.
- Un-indenting the section description. It shared the heading's indent while
  the section body below it started at the container edge, which is one of
  the left edges that made the page feel arbitrary. Now the glyph, the
  description and the body share one edge.
- Keeping the decision row's surface. The fill is its hit target and its
  hover state; only the border and the tint went.
- Renaming `SummaryBlockCard` to `SummaryBlock`, since it is no longer one.

## What I left alone, deliberately

- The two-region structure, the editable-block model, and every parser. No
  file under `packages/core/src/context/` is touched.
- `SectionSurface` for the two regions. It would raise a surface around
  sections that hold their own rows, which is the third level the elevation
  ramp forbids, and the `Divider` already carries the boundary.
- `Markdown`'s internal `leading-relaxed` on paragraphs and list items,
  which is off the pixel grid at every size in our scale. Correcting it is a
  design-system change affecting every markdown surface in the app, not a
  Context pass; the decision row pins its own line box instead.
- The same hand-written `CopyButton` classes and the same nested-`bg-subtle`
  empty state in `GoalOverviewRegion`, which is the Overview pane and not
  this surface.
- The `size="eyebrow"` heading variant. Its glyph sits on a `text-2xs` line
  box that does declare its height, so it is already aligned.

## Verification

From the worktree root, after rebasing onto `origin/main` at 480b5b9bb:

- `pnpm typecheck`: 5 tasks, all pass.
- `pnpm lint`: 0 tasks executed, as `CONVENTIONS.md` documents.
- `pnpm test`: 7617 pass, 5 skipped, 0 fail. Desktop 5911 in 688 files, core
  1265, ui 202 in 40 files, db 239.
- `pnpm build`: pass.
- `pnpm knip --include files,duplicates,unlisted`, the CI gate: clean.

Round trip re-checked against the production snapshot rather than the
fixtures, with a throwaway probe over every real document in it, 375
decisions and 433 summaries: all 808 rebuild byte for byte, and rewriting
any single row or any single section with its own current body returns the
document unchanged. The probe is not committed since it reads a local
database.

One flake seen once and not reproduced: `NewSessionView issue sources >
hides issue and branch controls...` failed in one full run and passed in
that file alone and in two later full runs. It touches nothing in this
change.

Made with [Cursor](https://cursor.com)