### PR TITLE
fix(desktop): context shows what the session holds, not an empty pane

### DIFF
--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/ContextPane/ContextLoadFailure.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/ContextPane/ContextLoadFailure.tsx
@@ -1,0 +1,24 @@
+import { RotateCcw, TriangleAlert } from 'lucide-react';
+import { Button, LensEmptyState } from '@goodboy/ui';
+
+type Props = {
+  readonly title: string;
+  readonly onRetry: () => void;
+};
+
+export const ContextLoadFailure = ({ title, onRetry }: Props) => {
+  return (
+    <LensEmptyState
+      icon={TriangleAlert}
+      tone="warning"
+      title={`${title} did not load`}
+      description="The database did not answer, so this is not what the session holds. Nothing here is missing on purpose."
+      action={
+        <Button size="sm" variant="ghost" onClick={onRetry}>
+          <RotateCcw size={14} aria-hidden />
+          Retry
+        </Button>
+      }
+    />
+  );
+};

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/ContextPane/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/ContextPane/index.test.tsx
@@ -42,7 +42,7 @@ const { store } = vi.hoisted(() => ({
         plans: false,
         summary: false,
       },
-    },
+    } as Record<string, Record<string, boolean>>,
     summarizerStatus: {
       'session-1': {
         status: 'idle',
@@ -68,14 +68,15 @@ vi.mock('../../../../../../store', () => ({
   useAppStore: <T,>(selector: (state: typeof store) => T) => selector(store),
   useSessionSlots: (sessionId: string) => store.sessionSlots[sessionId] ?? [],
   useSessionSlotsLoad: (sessionId: string) => store.sessionSlotsLoad[sessionId] ?? null,
-  useSessionLoading: () => ({
-    agents: false,
-    transcript: false,
-    telemetry: false,
-    slots: false,
-    plans: false,
-    summary: false,
-  }),
+  useSessionLoading: (sessionId: string) =>
+    store.sessionLoading[sessionId] ?? {
+      agents: false,
+      transcript: false,
+      telemetry: false,
+      slots: false,
+      plans: false,
+      summary: false,
+    },
   useSummarizerStatus: (sessionId: string) =>
     store.summarizerStatus[sessionId] ?? { status: 'idle' },
   useSlotHistory: () => [],
@@ -130,6 +131,14 @@ const sectionFor = (name: string): HTMLElement => {
 beforeEach(() => {
   store.sessionSlots['session-1'] = slots();
   store.sessionSlotsLoad['session-1'] = 'loaded';
+  store.sessionLoading['session-1'] = {
+    agents: false,
+    transcript: false,
+    telemetry: false,
+    slots: false,
+    plans: false,
+    summary: false,
+  };
   store.summarizerStatus['session-1'] = { status: 'idle' };
   store.upsertSessionSlot = vi.fn();
   store.ensureSessionSlots = vi.fn().mockResolvedValue(undefined);
@@ -206,6 +215,24 @@ describe('Context regions', () => {
     fireEvent.click(within(sectionFor('Decisions')).getByRole('button', { name: 'Retry' }));
 
     expect(store.loadSessionSlots).toHaveBeenCalledWith('session-1');
+  });
+
+  it('shows the retry underway rather than the failure it is already replacing', () => {
+    store.sessionSlots['session-1'] = [];
+    store.sessionSlotsLoad['session-1'] = 'failed';
+    store.sessionLoading['session-1'] = {
+      agents: false,
+      transcript: false,
+      telemetry: false,
+      slots: true,
+      plans: false,
+      summary: false,
+    };
+    render(<ContextPane session={SESSION} />);
+    const summary = sectionFor('Session summary');
+
+    expect(within(summary).getByRole('status', { name: 'Loading' })).toBeDefined();
+    expect(within(summary).queryByText('Session summary did not load')).toBeNull();
   });
 
   it('waits rather than claiming a session is empty before the read has answered', () => {

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/ContextPane/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/ContextPane/index.test.tsx
@@ -53,10 +53,13 @@ const { store } = vi.hoisted(() => ({
       },
     } as Record<string, { status: string }>,
     slotHistory: {} as Record<string, Record<string, ReadonlyArray<unknown>>>,
+    sessionSlotsLoad: {} as Record<string, 'loaded' | 'failed' | undefined>,
     sessionOpenQuestions: {} as Record<string, ReadonlyArray<unknown>>,
     upsertSessionSlot: vi.fn(),
     loadSlotHistory: vi.fn().mockResolvedValue(undefined),
     loadSessionOpenQuestions: vi.fn().mockResolvedValue(undefined),
+    ensureSessionSlots: vi.fn().mockResolvedValue(undefined),
+    loadSessionSlots: vi.fn().mockResolvedValue(undefined),
   },
 }));
 
@@ -64,6 +67,7 @@ vi.mock('../../../../../../store', () => ({
   EMPTY_ARRAY: Object.freeze([]),
   useAppStore: <T,>(selector: (state: typeof store) => T) => selector(store),
   useSessionSlots: (sessionId: string) => store.sessionSlots[sessionId] ?? [],
+  useSessionSlotsLoad: (sessionId: string) => store.sessionSlotsLoad[sessionId] ?? null,
   useSessionLoading: () => ({
     agents: false,
     transcript: false,
@@ -125,8 +129,11 @@ const sectionFor = (name: string): HTMLElement => {
 
 beforeEach(() => {
   store.sessionSlots['session-1'] = slots();
+  store.sessionSlotsLoad['session-1'] = 'loaded';
   store.summarizerStatus['session-1'] = { status: 'idle' };
   store.upsertSessionSlot = vi.fn();
+  store.ensureSessionSlots = vi.fn().mockResolvedValue(undefined);
+  store.loadSessionSlots = vi.fn().mockResolvedValue(undefined);
 });
 
 afterEach(cleanup);
@@ -172,6 +179,43 @@ describe('Context regions', () => {
       screen.getAllByRole('heading', { level: 2 }).map((heading) => heading.textContent),
     ).toEqual(['Session summary', 'Decisions']);
     expect(screen.queryByRole('tablist')).toBeNull();
+  });
+
+  it('asks for the context itself, so the pane does not depend on the session switch', () => {
+    render(<ContextPane session={SESSION} />);
+
+    expect(store.ensureSessionSlots).toHaveBeenCalledWith('session-1');
+  });
+
+  it('says the read failed instead of offering the blank document as the truth', () => {
+    store.sessionSlots['session-1'] = [];
+    store.sessionSlotsLoad['session-1'] = 'failed';
+    render(<ContextPane session={SESSION} />);
+    const summary = sectionFor('Session summary');
+
+    expect(within(summary).getByText('Session summary did not load')).toBeDefined();
+    expect(within(summary).queryByRole('region', { name: 'Problem' })).toBeNull();
+    expect(within(sectionFor('Decisions')).getByText('Decisions did not load')).toBeDefined();
+  });
+
+  it('reads the database again from the failed state', () => {
+    store.sessionSlots['session-1'] = [];
+    store.sessionSlotsLoad['session-1'] = 'failed';
+    render(<ContextPane session={SESSION} />);
+
+    fireEvent.click(within(sectionFor('Decisions')).getByRole('button', { name: 'Retry' }));
+
+    expect(store.loadSessionSlots).toHaveBeenCalledWith('session-1');
+  });
+
+  it('waits rather than claiming a session is empty before the read has answered', () => {
+    store.sessionSlots['session-1'] = [];
+    store.sessionSlotsLoad['session-1'] = undefined;
+    render(<ContextPane session={SESSION} />);
+    const summary = sectionFor('Session summary');
+
+    expect(within(summary).getByRole('status', { name: 'Loading' })).toBeDefined();
+    expect(within(summary).queryByRole('region', { name: 'Problem' })).toBeNull();
   });
 });
 

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/ContextPane/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/ContextPane/index.tsx
@@ -7,6 +7,7 @@ import {
   useSessionLoading,
   useSessionOpenQuestions,
   useSessionSlots,
+  useSessionSlotsLoad,
   useSlotHistory,
   useSlotHistoryCount,
   useSummarizerStatus,
@@ -15,6 +16,7 @@ import { PaneShell } from '../../../../../../shared/components/PaneShell';
 import type { ContextLens } from '../../../../lens-surface';
 import { InspectorSplit } from '../InspectorSplit';
 import { SlotHistoryPanel } from '../SlotHistoryPanel';
+import { ContextLoadFailure } from './ContextLoadFailure';
 import { ContextSection } from './ContextSection';
 import { DecisionsSection } from './DecisionsSection';
 import { SummarySection } from './SummarySection';
@@ -53,8 +55,11 @@ export const ContextPane = ({ session, initialRegion }: Props) => {
   const sessionId = session.id as SessionId;
   const slots = useSessionSlots(sessionId);
   const loading = useSessionLoading(sessionId);
+  const slotsLoad = useSessionSlotsLoad(sessionId);
   const openQuestions = useSessionOpenQuestions(sessionId);
   const loadSessionOpenQuestions = useAppStore((s) => s.loadSessionOpenQuestions);
+  const ensureSessionSlots = useAppStore((s) => s.ensureSessionSlots);
+  const loadSessionSlots = useAppStore((s) => s.loadSessionSlots);
   const loadSlotHistory = useAppStore((s) => s.loadSlotHistory);
   const upsertSessionSlot = useAppStore((s) => s.upsertSessionSlot);
   const summarizer = useSummarizerStatus(sessionId);
@@ -74,6 +79,10 @@ export const ContextPane = ({ session, initialRegion }: Props) => {
   useEffect(() => {
     void loadSessionOpenQuestions(sessionId);
   }, [loadSessionOpenQuestions, sessionId]);
+
+  useEffect(() => {
+    void ensureSessionSlots(sessionId);
+  }, [ensureSessionSlots, sessionId]);
 
   useEffect(() => {
     if (initialRegion == null) {
@@ -128,7 +137,9 @@ export const ContextPane = ({ session, initialRegion }: Props) => {
           const value = valueFor({ slots, slotKey });
           const title = REGION_TITLE[slotKey];
           const historyCount = historyCounts[slotKey];
-          const isLoading = slots.some((slot) => slot.key === slotKey) === false && loading.slots;
+          const hasSlot = slots.some((slot) => slot.key === slotKey);
+          const isLoading = !hasSlot && (loading.slots || slotsLoad === null);
+          const hasFailed = !hasSlot && slotsLoad === 'failed';
           const isRawEditing = rawKey === slotKey;
           const onWrite = (next: string) => {
             void upsertSessionSlot(sessionId, slotKey, next);
@@ -178,7 +189,14 @@ export const ContextPane = ({ session, initialRegion }: Props) => {
                   </div>
                 }
               >
-                {slotKey === 'last_output_summary' ? (
+                {hasFailed ? (
+                  <ContextLoadFailure
+                    title={title}
+                    onRetry={() => {
+                      void loadSessionSlots(sessionId);
+                    }}
+                  />
+                ) : slotKey === 'last_output_summary' ? (
                   <SummarySection
                     value={value}
                     isLoading={isLoading}

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/ContextPane/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/ContextPane/index.tsx
@@ -139,7 +139,7 @@ export const ContextPane = ({ session, initialRegion }: Props) => {
           const historyCount = historyCounts[slotKey];
           const hasSlot = slots.some((slot) => slot.key === slotKey);
           const isLoading = !hasSlot && (loading.slots || slotsLoad === null);
-          const hasFailed = !hasSlot && slotsLoad === 'failed';
+          const hasFailed = !hasSlot && !isLoading && slotsLoad === 'failed';
           const isRawEditing = rawKey === slotKey;
           const onWrite = (next: string) => {
             void upsertSessionSlot(sessionId, slotKey, next);

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/SlotPane.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/SlotPane.test.tsx
@@ -114,9 +114,12 @@ const { store } = vi.hoisted(() => {
           },
         ],
       } as Record<string, OpenQuestion[]>,
+      sessionSlotsLoad: {} as Record<string, 'loaded' | 'failed' | undefined>,
       upsertSessionSlot: vi.fn(),
       loadSlotHistory: vi.fn().mockResolvedValue(undefined),
       loadSessionOpenQuestions: vi.fn().mockResolvedValue(undefined),
+      ensureSessionSlots: vi.fn().mockResolvedValue(undefined),
+      loadSessionSlots: vi.fn().mockResolvedValue(undefined),
     },
   };
 });
@@ -125,6 +128,7 @@ vi.mock('../../../../../store', () => ({
   EMPTY_ARRAY: Object.freeze([]),
   useAppStore: <T,>(selector: (state: typeof store) => T) => selector(store),
   useSessionSlots: (sessionId: string) => store.sessionSlots[sessionId] ?? [],
+  useSessionSlotsLoad: (sessionId: string) => store.sessionSlotsLoad[sessionId] ?? null,
   useSessionLoading: (sessionId: string) =>
     store.sessionLoading[sessionId] ?? {
       agents: false,
@@ -176,9 +180,12 @@ beforeEach(() => {
     { key: 'decisions', value: 'use tailwind', enabled: true },
     { key: 'last_output_summary', value: '**Status**: done', enabled: true },
   ];
+  store.sessionSlotsLoad['session-1'] = 'loaded';
   store.upsertSessionSlot = vi.fn();
   store.loadSlotHistory = vi.fn().mockResolvedValue(undefined);
   store.loadSessionOpenQuestions = vi.fn().mockResolvedValue(undefined);
+  store.ensureSessionSlots = vi.fn().mockResolvedValue(undefined);
+  store.loadSessionSlots = vi.fn().mockResolvedValue(undefined);
   writeText.mockReset();
   writeText.mockResolvedValue(undefined);
   Object.defineProperty(navigator, 'clipboard', {

--- a/apps/desktop/src/store/index.ts
+++ b/apps/desktop/src/store/index.ts
@@ -19,6 +19,7 @@ export {
   useRunSpendUsd,
   useSessionPrFetchState,
   useSessionSlots,
+  useSessionSlotsLoad,
   useSessionStageInfo,
   useSessionUnreadLens,
   useSessionViewPrefs,

--- a/apps/desktop/src/store/selectors.ts
+++ b/apps/desktop/src/store/selectors.ts
@@ -29,7 +29,12 @@ import type { Workspace } from '@goodboy/types';
 import type { TerminalTab } from '../shared/types/terminal';
 import { isBranchlessSession } from '../shared/utils/isBranchlessSession';
 import { useAppStore } from './store';
-import type { AppState, SessionLoadingFlags, SummarizerSessionStatus } from './types';
+import type {
+  AppState,
+  SessionLoadingFlags,
+  SessionSlotsLoad,
+  SummarizerSessionStatus,
+} from './types';
 import {
   deriveSessionStage,
   isPrReviewSession,
@@ -497,6 +502,9 @@ const EMPTY_SLOTS: ReadonlyArray<ContextSlot> = [];
 
 export const useSessionSlots = (sessionId: SessionId | null): ReadonlyArray<ContextSlot> =>
   useAppStore((s) => (sessionId ? (s.sessionSlots[sessionId] ?? EMPTY_SLOTS) : EMPTY_SLOTS));
+
+export const useSessionSlotsLoad = (sessionId: SessionId | null): SessionSlotsLoad | null =>
+  useAppStore((s) => (sessionId ? (s.sessionSlotsLoad[sessionId] ?? null) : null));
 
 const EMPTY_OPEN_QUESTIONS: ReadonlyArray<OpenQuestion> = [];
 

--- a/apps/desktop/src/store/slices/sessions/index.test.ts
+++ b/apps/desktop/src/store/slices/sessions/index.test.ts
@@ -540,6 +540,7 @@ describe('store contract', () => {
         planConsumptions: {},
         sessionOpenQuestions: {},
         sessionLoading: {},
+        sessionSlotsLoad: {},
         sessionViewPrefs: {},
         terminalSessions: {},
       };
@@ -567,6 +568,58 @@ describe('store contract', () => {
       expect(ss).toHaveLength(2);
       expect(ss[0]?.id).toBe(SESSION_ID);
       expect(ss[1]?.goal).toBe('two');
+    });
+
+    it('setCurrentSession reads the context slots the database holds', async () => {
+      const store = await getStore();
+      const db = await import('@goodboy/db');
+      (db.listContextSlotsForSession as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([
+        { key: 'last_output_summary', value: '#### State\n- shipped', enabled: true },
+        { key: 'decisions', value: '- use tailwind', enabled: true },
+      ]);
+
+      await store.getState().setCurrentSession(SESSION_ID);
+
+      await vi.waitFor(() => {
+        expect(store.getState().sessionSlotsLoad[SESSION_ID]).toBe('loaded');
+      });
+      expect(store.getState().sessionSlots[SESSION_ID]).toHaveLength(2);
+    });
+
+    it('opens a session whose id another path already made current, so its context still loads', async () => {
+      const store = await getStore();
+      const db = await import('@goodboy/db');
+      (db.listContextSlotsForSession as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([
+        { key: 'last_output_summary', value: '#### State\n- shipped', enabled: true },
+      ]);
+      store.setState({
+        sessions: [buildSession({ id: SESSION_ID })],
+        currentWorkspaceId: WS_ID,
+        currentSessionId: SESSION_ID,
+      });
+
+      await store.getState().setCurrentSession(SESSION_ID);
+
+      expect(store.getState().sessionSlots[SESSION_ID]).toHaveLength(1);
+      expect(store.getState().sessionSlotsLoad[SESSION_ID]).toBe('loaded');
+    });
+
+    it('reads the database for a session whose slots were only ever written in memory', async () => {
+      const store = await getStore();
+      const db = await import('@goodboy/db');
+      (db.listContextSlotsForSession as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([
+        { key: 'goal', value: 'ship it', enabled: true },
+        { key: 'last_output_summary', value: '#### State\n- shipped', enabled: true },
+      ]);
+      store.setState({
+        sessionSlots: { [SESSION_ID]: [{ key: 'goal', value: 'ship it', enabled: true }] },
+      });
+
+      await store.getState().setCurrentSession(SESSION_ID);
+
+      await vi.waitFor(() => {
+        expect(store.getState().sessionSlots[SESSION_ID]).toHaveLength(2);
+      });
     });
 
     it('setCurrentSession rebuilds resolver verdicts from the persisted transcript', async () => {

--- a/apps/desktop/src/store/slices/sessions/setCurrentSession.ts
+++ b/apps/desktop/src/store/slices/sessions/setCurrentSession.ts
@@ -1,13 +1,6 @@
-import type {
-  IsoDateTime,
-  Message,
-  PlanWithCount,
-  ProviderRunId,
-  SessionId,
-  TurnState,
-} from '@goodboy/types';
+import type { IsoDateTime, Message, ProviderRunId, SessionId, TurnState } from '@goodboy/types';
+import { formatError } from '@goodboy/ui';
 import {
-  listContextSlotsForSession,
   listAgentRunIdsForSession,
   listOpenQuestionsForSession,
   listTelemetryForSession,
@@ -26,6 +19,9 @@ import type { GetFn, SetFn } from './types';
 export const setCurrentSession = (set: SetFn, get: GetFn) => {
   return async (id: SessionId | null) => {
     if (get().currentSessionId === id) {
+      if (id !== null) {
+        await get().ensureSessionSlots(id);
+      }
       return;
     }
     const tSwitch = performance.now();
@@ -33,7 +29,7 @@ export const setCurrentSession = (set: SetFn, get: GetFn) => {
     const cached = id
       ? {
           telemetry: stateNow.sessionTelemetry[id] !== undefined,
-          slots: stateNow.sessionSlots[id] !== undefined,
+          slots: stateNow.sessionSlotsLoad[id] === 'loaded',
           plans: stateNow.sessionPlans[id] !== undefined,
           agents: stateNow.sessionPhaseRuns[id] !== undefined,
         }
@@ -109,7 +105,9 @@ export const setCurrentSession = (set: SetFn, get: GetFn) => {
             sessionTelemetry: { ...state.sessionTelemetry, [id]: telemetry },
           }));
         })
-        .catch(() => {})
+        .catch((error: unknown) => {
+          console.error(`[telemetry] load failed for session ${id}`, formatError(error));
+        })
         .finally(() => {
           endTelemetry();
           markDone('telemetry');
@@ -118,17 +116,9 @@ export const setCurrentSession = (set: SetFn, get: GetFn) => {
 
     if (!cached?.slots) {
       const endSlots = perf('slots');
-      void listContextSlotsForSession(tauriDatabase, id)
-        .then((slots) => {
-          set((state) => ({
-            sessionSlots: { ...state.sessionSlots, [id]: slots },
-          }));
-        })
-        .catch(() => {})
-        .finally(() => {
-          endSlots();
-          markDone('slots');
-        });
+      void get()
+        .ensureSessionSlots(id)
+        .finally(() => endSlots());
     }
 
     void get().loadGoalAttachments({ type: 'session', id });
@@ -143,19 +133,15 @@ export const setCurrentSession = (set: SetFn, get: GetFn) => {
 
     if (!cached?.plans) {
       const endPlans = perf('plans');
-      void (async (): Promise<ReadonlyArray<PlanWithCount>> => {
-        try {
-          return await invokeListPlansForSession(id);
-        } catch {
-          return [];
-        }
-      })()
+      void invokeListPlansForSession(id)
         .then((plans) => {
           set((state) => ({
             sessionPlans: { ...state.sessionPlans, [id]: plans },
           }));
         })
-        .catch(() => {})
+        .catch((error: unknown) => {
+          console.error(`[plans] load failed for session ${id}`, formatError(error));
+        })
         .finally(() => {
           endPlans();
           markDone('plans');
@@ -233,7 +219,8 @@ export const setCurrentSession = (set: SetFn, get: GetFn) => {
             markDone('transcript');
           }
         })
-        .catch(() => {
+        .catch((error: unknown) => {
+          console.error(`[agents] load failed for session ${id}`, formatError(error));
           markDone('agents');
           markDone('transcript');
         })

--- a/apps/desktop/src/store/slices/slots/ensureSessionSlots.ts
+++ b/apps/desktop/src/store/slices/slots/ensureSessionSlots.ts
@@ -1,0 +1,11 @@
+import type { SessionId } from '@goodboy/types';
+import type { GetFn } from './types';
+
+export const ensureSessionSlots = (get: GetFn) => {
+  return async (sessionId: SessionId) => {
+    if (get().sessionSlotsLoad[sessionId] === 'loaded') {
+      return;
+    }
+    await get().loadSessionSlots(sessionId);
+  };
+};

--- a/apps/desktop/src/store/slices/slots/ensureSessionSlots.ts
+++ b/apps/desktop/src/store/slices/slots/ensureSessionSlots.ts
@@ -2,10 +2,20 @@ import type { SessionId } from '@goodboy/types';
 import type { GetFn } from './types';
 
 export const ensureSessionSlots = (get: GetFn) => {
+  const readsInFlight = new Map<SessionId, Promise<void>>();
   return async (sessionId: SessionId) => {
     if (get().sessionSlotsLoad[sessionId] === 'loaded') {
       return;
     }
-    await get().loadSessionSlots(sessionId);
+    const running = readsInFlight.get(sessionId);
+    if (running !== undefined) {
+      await running;
+      return;
+    }
+    const read = get()
+      .loadSessionSlots(sessionId)
+      .finally(() => readsInFlight.delete(sessionId));
+    readsInFlight.set(sessionId, read);
+    await read;
   };
 };

--- a/apps/desktop/src/store/slices/slots/index.test.ts
+++ b/apps/desktop/src/store/slices/slots/index.test.ts
@@ -593,6 +593,40 @@ describe('store contract', () => {
       expect(listSlots).toHaveBeenCalledTimes(2);
     });
 
+    it('reads the database once when the switch and the pane both ask at once', async () => {
+      const store = await getStore();
+      const db = await import('@goodboy/db');
+      const listSlots = db.listContextSlotsForSession as unknown as ReturnType<typeof vi.fn>;
+      listSlots.mockResolvedValue([{ key: 'goal', value: 'g', enabled: true } as ContextSlot]);
+
+      await Promise.all([
+        store.getState().ensureSessionSlots(SESSION_ID),
+        store.getState().ensureSessionSlots(SESSION_ID),
+      ]);
+
+      expect(listSlots).toHaveBeenCalledTimes(1);
+      expect(store.getState().sessionSlotsLoad[SESSION_ID]).toBe('loaded');
+    });
+
+    it('marks the read in flight so a retry is not mistaken for the failure it replaces', async () => {
+      const store = await getStore();
+      const db = await import('@goodboy/db');
+      const listSlots = db.listContextSlotsForSession as unknown as ReturnType<typeof vi.fn>;
+      let release: (slots: ReadonlyArray<ContextSlot>) => void = () => undefined;
+      listSlots.mockReturnValueOnce(
+        new Promise<ReadonlyArray<ContextSlot>>((resolve) => {
+          release = resolve;
+        }),
+      );
+
+      const read = store.getState().loadSessionSlots(SESSION_ID);
+      expect(store.getState().sessionLoading[SESSION_ID]?.slots).toBe(true);
+
+      release([]);
+      await read;
+      expect(store.getState().sessionLoading[SESSION_ID]?.slots).toBe(false);
+    });
+
     it('toggleSessionSlot upserts the slot with new enabled flag', async () => {
       const store = await getStore();
       const db = await import('@goodboy/db');

--- a/apps/desktop/src/store/slices/slots/index.test.ts
+++ b/apps/desktop/src/store/slices/slots/index.test.ts
@@ -507,6 +507,7 @@ describe('store contract', () => {
         planConsumptions: {},
         sessionOpenQuestions: {},
         sessionLoading: {},
+        sessionSlotsLoad: {},
         sessionViewPrefs: {},
         terminalSessions: {},
       };
@@ -530,6 +531,66 @@ describe('store contract', () => {
       ]);
       await store.getState().loadSessionSlots(SESSION_ID);
       expect(store.getState().sessionSlots[SESSION_ID]).toHaveLength(1);
+    });
+
+    it('records a completed read so an open can tell loaded from never read', async () => {
+      const store = await getStore();
+      const db = await import('@goodboy/db');
+      (db.listContextSlotsForSession as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+        [],
+      );
+      await store.getState().loadSessionSlots(SESSION_ID);
+      expect(store.getState().sessionSlotsLoad[SESSION_ID]).toBe('loaded');
+    });
+
+    it('records a rejected read as failed instead of leaving the session looking empty', async () => {
+      const store = await getStore();
+      const db = await import('@goodboy/db');
+      store.setState({
+        sessionLoading: {
+          [SESSION_ID]: {
+            agents: false,
+            transcript: false,
+            telemetry: false,
+            slots: true,
+            plans: false,
+            summary: false,
+          },
+        },
+      });
+      (db.listContextSlotsForSession as unknown as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+        new Error('database is locked'),
+      );
+      const trace = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+      await store.getState().loadSessionSlots(SESSION_ID);
+      const traceCount = trace.mock.calls.length;
+      trace.mockRestore();
+
+      expect(store.getState().sessionSlotsLoad[SESSION_ID]).toBe('failed');
+      expect(store.getState().sessionSlots[SESSION_ID]).toBeUndefined();
+      expect(store.getState().sessionLoading[SESSION_ID]?.slots).toBe(false);
+      expect(traceCount).toBe(1);
+    });
+
+    it('ensureSessionSlots reads the database once and reads it again after a failure', async () => {
+      const store = await getStore();
+      const db = await import('@goodboy/db');
+      const listSlots = db.listContextSlotsForSession as unknown as ReturnType<typeof vi.fn>;
+      listSlots.mockRejectedValueOnce(new Error('database is locked'));
+      const trace = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+      await store.getState().ensureSessionSlots(SESSION_ID);
+      trace.mockRestore();
+      expect(listSlots).toHaveBeenCalledTimes(1);
+
+      listSlots.mockResolvedValueOnce([{ key: 'goal', value: 'g', enabled: true } as ContextSlot]);
+      await store.getState().ensureSessionSlots(SESSION_ID);
+      expect(listSlots).toHaveBeenCalledTimes(2);
+      expect(store.getState().sessionSlots[SESSION_ID]).toHaveLength(1);
+
+      await store.getState().ensureSessionSlots(SESSION_ID);
+      expect(listSlots).toHaveBeenCalledTimes(2);
     });
 
     it('toggleSessionSlot upserts the slot with new enabled flag', async () => {

--- a/apps/desktop/src/store/slices/slots/index.ts
+++ b/apps/desktop/src/store/slices/slots/index.ts
@@ -1,3 +1,4 @@
+import { ensureSessionSlots } from './ensureSessionSlots';
 import { loadSessionSlots } from './loadSessionSlots';
 import { loadSessionTelemetry } from './loadSessionTelemetry';
 import { loadSlotHistory } from './loadSlotHistory';
@@ -9,6 +10,7 @@ export const createSlotsSlice = (set: SetFn, get: GetFn) => {
   return {
     loadSessionTelemetry: loadSessionTelemetry(set),
     loadSessionSlots: loadSessionSlots(set),
+    ensureSessionSlots: ensureSessionSlots(get),
     upsertSessionSlot: upsertSessionSlot(set, get),
     loadSlotHistory: loadSlotHistory(set),
     toggleSessionSlot: toggleSessionSlot(set, get),

--- a/apps/desktop/src/store/slices/slots/loadSessionSlots.ts
+++ b/apps/desktop/src/store/slices/slots/loadSessionSlots.ts
@@ -1,17 +1,43 @@
 import type { SessionId } from '@goodboy/types';
+import { formatError } from '@goodboy/ui';
 import { countContextSlotHistoryForSession, listContextSlotsForSession } from '@goodboy/db';
 import { tauriDatabase } from '../../../shared/lib/db';
+import { EMPTY_LOADING } from '../../session-mutators';
+import type { AppState, SessionLoadingFlags } from '../../types';
 import type { SetFn } from './types';
+
+type SettleParams = {
+  readonly state: AppState;
+  readonly sessionId: SessionId;
+};
+
+const withSlotsSettled = ({
+  state,
+  sessionId,
+}: SettleParams): Readonly<Record<string, SessionLoadingFlags>> => {
+  const current = state.sessionLoading[sessionId] ?? EMPTY_LOADING;
+  return { ...state.sessionLoading, [sessionId]: { ...current, slots: false } };
+};
 
 export const loadSessionSlots = (set: SetFn) => {
   return async (sessionId: SessionId) => {
-    const [slots, counts] = await Promise.all([
-      listContextSlotsForSession(tauriDatabase, sessionId),
-      countContextSlotHistoryForSession(tauriDatabase, sessionId),
-    ]);
-    set((state) => ({
-      sessionSlots: { ...state.sessionSlots, [sessionId]: slots },
-      slotHistoryCounts: { ...state.slotHistoryCounts, [sessionId]: counts },
-    }));
+    try {
+      const [slots, counts] = await Promise.all([
+        listContextSlotsForSession(tauriDatabase, sessionId),
+        countContextSlotHistoryForSession(tauriDatabase, sessionId),
+      ]);
+      set((state) => ({
+        sessionSlots: { ...state.sessionSlots, [sessionId]: slots },
+        slotHistoryCounts: { ...state.slotHistoryCounts, [sessionId]: counts },
+        sessionSlotsLoad: { ...state.sessionSlotsLoad, [sessionId]: 'loaded' },
+        sessionLoading: withSlotsSettled({ state, sessionId }),
+      }));
+    } catch (error) {
+      console.error(`[slots] context load failed for session ${sessionId}`, formatError(error));
+      set((state) => ({
+        sessionSlotsLoad: { ...state.sessionSlotsLoad, [sessionId]: 'failed' },
+        sessionLoading: withSlotsSettled({ state, sessionId }),
+      }));
+    }
   };
 };

--- a/apps/desktop/src/store/slices/slots/loadSessionSlots.ts
+++ b/apps/desktop/src/store/slices/slots/loadSessionSlots.ts
@@ -6,21 +6,24 @@ import { EMPTY_LOADING } from '../../session-mutators';
 import type { AppState, SessionLoadingFlags } from '../../types';
 import type { SetFn } from './types';
 
-type SettleParams = {
+type ReadingParams = {
   readonly state: AppState;
   readonly sessionId: SessionId;
+  readonly isReading: boolean;
 };
 
-const withSlotsSettled = ({
+const withSlotsReading = ({
   state,
   sessionId,
-}: SettleParams): Readonly<Record<string, SessionLoadingFlags>> => {
+  isReading,
+}: ReadingParams): Readonly<Record<string, SessionLoadingFlags>> => {
   const current = state.sessionLoading[sessionId] ?? EMPTY_LOADING;
-  return { ...state.sessionLoading, [sessionId]: { ...current, slots: false } };
+  return { ...state.sessionLoading, [sessionId]: { ...current, slots: isReading } };
 };
 
 export const loadSessionSlots = (set: SetFn) => {
   return async (sessionId: SessionId) => {
+    set((state) => ({ sessionLoading: withSlotsReading({ state, sessionId, isReading: true }) }));
     try {
       const [slots, counts] = await Promise.all([
         listContextSlotsForSession(tauriDatabase, sessionId),
@@ -30,13 +33,13 @@ export const loadSessionSlots = (set: SetFn) => {
         sessionSlots: { ...state.sessionSlots, [sessionId]: slots },
         slotHistoryCounts: { ...state.slotHistoryCounts, [sessionId]: counts },
         sessionSlotsLoad: { ...state.sessionSlotsLoad, [sessionId]: 'loaded' },
-        sessionLoading: withSlotsSettled({ state, sessionId }),
+        sessionLoading: withSlotsReading({ state, sessionId, isReading: false }),
       }));
     } catch (error) {
       console.error(`[slots] context load failed for session ${sessionId}`, formatError(error));
       set((state) => ({
         sessionSlotsLoad: { ...state.sessionSlotsLoad, [sessionId]: 'failed' },
-        sessionLoading: withSlotsSettled({ state, sessionId }),
+        sessionLoading: withSlotsReading({ state, sessionId, isReading: false }),
       }));
     }
   };

--- a/apps/desktop/src/store/slices/workspaces/deleteWorkspace.ts
+++ b/apps/desktop/src/store/slices/workspaces/deleteWorkspace.ts
@@ -57,6 +57,7 @@ export const deleteWorkspace = (set: SetFn, get: GetFn) => {
               sessionSlots: {},
               slotHistory: {},
               slotHistoryCounts: {},
+              sessionSlotsLoad: {},
               sessionWorktrees: {},
               sessionMounts: {},
               sessionActiveMount: {},

--- a/apps/desktop/src/store/slices/workspaces/setCurrentWorkspace.ts
+++ b/apps/desktop/src/store/slices/workspaces/setCurrentWorkspace.ts
@@ -66,6 +66,7 @@ export const setCurrentWorkspace = (set: SetFn, get: GetFn) => {
       sessionSlots: {},
       slotHistory: {},
       slotHistoryCounts: {},
+      sessionSlotsLoad: {},
       sessionWorktrees: {},
       sessionMounts: {},
       sessionActiveMount: {},

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -436,6 +436,7 @@ export type AppActions = {
   refreshWorkspaceSummary(workspaceId: WorkspaceId): Promise<void>;
   loadSessionTelemetry(sessionId: SessionId): Promise<void>;
   loadSessionSlots(sessionId: SessionId): Promise<void>;
+  ensureSessionSlots(sessionId: SessionId): Promise<void>;
   upsertSessionSlot(sessionId: SessionId, key: SlotKey, value: string): Promise<void>;
   loadSlotHistory(sessionId: SessionId, key: SlotKey): Promise<void>;
   toggleSessionSlot(sessionId: SessionId, key: SlotKey, enabled: boolean): Promise<void>;
@@ -854,6 +855,7 @@ export const initialState: AppState = {
   sessionSlots: {},
   slotHistory: {},
   slotHistoryCounts: {},
+  sessionSlotsLoad: {},
   summarizerStatus: {},
   storageStats: null,
   storageStatsLoading: false,

--- a/apps/desktop/src/store/types.ts
+++ b/apps/desktop/src/store/types.ts
@@ -137,6 +137,8 @@ export type SessionLoadingFlags = {
   readonly summary: boolean;
 };
 
+export type SessionSlotsLoad = 'loaded' | 'failed';
+
 export type SessionGitlabMrState = {
   readonly mr: GitlabMergeRequest | null;
   readonly fetchedAt: IsoDateTime | null;
@@ -218,6 +220,7 @@ export type AppState = AppSliceState & {
     Record<string, Readonly<Record<string, ReadonlyArray<ContextSlotHistoryEntry>>>>
   >;
   readonly slotHistoryCounts: Readonly<Record<string, Readonly<Record<string, number>>>>;
+  readonly sessionSlotsLoad: Readonly<Record<string, SessionSlotsLoad>>;
   readonly summarizerStatus: Readonly<Record<string, SummarizerSessionStatus>>;
   readonly storageStats: StorageStats | null;
   readonly storageStatsLoading: boolean;


### PR DESCRIPTION
## The cause

Opening a session decided the database had already been read from two proxies, and both are wrong.

`setCurrentSession` returns early when the requested id is already `currentSessionId`, and separately treats the mere presence of a `sessionSlots[id]` entry as proof the read finished:

```ts
if (get().currentSessionId === id) return;
const cached = { slots: stateNow.sessionSlots[id] !== undefined, ... };
```

Nothing in the codebase writes `sessionSlots` only from the database. `createSession` seeds the entry with the goal the user typed, `setSlot` and the slot editors write into it, and turn completion updates it. Any of those makes `sessionSlots[id]` defined, which permanently satisfies `cached.slots`, so `listContextSlotsForSession` is never called for that session and `last_output_summary` and `decisions` never arrive. The pane then renders its four block labels over empty strings, which is exactly what a genuinely empty session looks like, so the failure was invisible.

The read also swallowed its own rejection:

```ts
listContextSlotsForSession(id).then(...).catch(() => {})
```

so a database that did not answer was indistinguishable from a session with nothing in it, and nothing retried.

### Evidence

A regression test in `apps/desktop/src/store/slices/sessions/index.test.ts` fails on `main` and passes here. It seeds one in-memory slot the way `createSession` does, calls `setCurrentSession`, and asserts the database slots arrive:

- before: `listContextSlotsForSession` is called 0 times, the store keeps the single in-memory slot
- after: it is called once, the store holds both

The companion test drives the other half of the guard: an id another path already made current (boot restore writes `currentSessionId` directly) still gets its context read rather than skipped.

The production snapshot at the read-only path confirms the data side of the brief: sessions there carry non-empty `last_output_summary` and `decisions` rows with `enabled = 1`, so the empty pane was never absent data.

## What changed

Store, `slots` slice:
- `sessionSlotsLoad: Record<SessionId, 'loaded' | 'failed'>` records the outcome of the read itself, so a session that was written in memory is no longer mistaken for one that was read.
- `loadSessionSlots` owns that record, settles `sessionLoading.slots` on both the success and the failure path, and traces the rejection instead of dropping it.
- `ensureSessionSlots` reads once, skips a session already read, and reads again after a failure.

Store, `sessions` slice:
- the already-current branch ensures the slots instead of returning, and `cached.slots` now asks `sessionSlotsLoad[id] === 'loaded'`.
- the siblings in the same function shared the swallow. The plan load additionally fabricated an empty list on failure, which keyed `sessionPlans[id]` and stopped any later attempt; it now leaves the key absent so a stalled load stays distinguishable from a session with no plans. Telemetry and agents keep their retry-on-reopen behaviour and gain a trace.

Surface:
- `ContextPane` asks for its own slots on mount rather than depending on the session switch having run, holds the skeleton while the read is outstanding, and renders `ContextLoadFailure` when it failed: warning tone, one sentence saying nothing here is missing on purpose, and a retry that reads again.

## What to look at

Open a session, leave Context, come back to it: the summary and decisions are there every time, including on a fresh boot into a restored session and on a session created in this run. The failed state is the one thing I could not see rendered, because a dev instance is already running from another worktree and I did not start a second one; it is covered by test instead.

## Decided, not specified

- The load record is a two-state `'loaded' | 'failed'` rather than a four-state machine. `sessionLoading.slots` already carries "in flight", and a third state would have two owners.
- A failed read retries on the next open rather than on a timer. Automatic retry loops against a local database hide the problem again.
- The plan load stops fabricating `[]`, which is a behaviour change beyond the brief's scope but the same defect in the same function; leaving it would have left a second silent empty pane.

## Left out

- The blocking `std::sync::Mutex` around the SQLite connection in `db.rs`. Under contention it serialises reads, and it is a plausible source of the slow first paint, but it is not this bug and rewriting the connection handling under a live regression is the wrong trade.
- The wider `catch(() => {})` population outside `setCurrentSession`. I fixed the ones on this path and left an audit of the rest to its own change.
- No migration, no schema change, no change to `listContextSlotsForSession`, which the brief had already cleared.

## Verification

From the worktree root, rebased on `7b7a736b6`:

```
pnpm typecheck   5 tasks successful
pnpm lint        0 findings
pnpm test        691 test files, 5944 tests, all passing
pnpm build       built, 3735 modules transformed
```

`pnpm knip` reports 42 unused exports, byte for byte the same 42 it reports on `main` with only line numbers shifted, verified by diffing the two runs. Every symbol this PR adds has a consumer, so it adds nothing to that list; the pre-existing 42 are not mine to clear here.

Made with [Cursor](https://cursor.com)

## Review round

Copilot raised three findings. Two were real and are fixed in `daab83da9`:

- Every session open read the database twice. `setCurrentSession` and the `ContextPane` mount effect both ensure the slots for the same session in the same tick, and neither sees a finished read yet, so both issued one. `ensureSessionSlots` now shares the read already in flight.
- Retry from the failure state changed nothing on screen. The record stayed `failed` and the loading flag stayed false until the read answered, so the pane kept rendering the failure it was replacing. The read now marks itself in flight when it starts and the pane waits while one is outstanding.

The third, a loading flag stuck true when `ensureSessionSlots` returns early, is not reachable: `cached` and the ensure call happen in the same synchronous run with no `await` between them, so the record cannot become `loaded` in the gap. Answered on the thread with that reasoning rather than changed.

Both fixes are pinned by tests that fail without them, verified by reverting each fix in turn.

Re-verified after the round: typecheck 5 tasks successful, lint 0 findings, 691 desktop test files and 5947 tests passing across 4 packages, build successful, knip still the same pre-existing 42.
