### PR TITLE
feat(desktop): the running marker pulses a dot inside its ring

### DIFF
--- a/apps/desktop/src/__tests__/regressions/timeline-feed-animates-only-running.test.ts
+++ b/apps/desktop/src/__tests__/regressions/timeline-feed-animates-only-running.test.ts
@@ -1,0 +1,62 @@
+import { readdirSync, readFileSync, statSync } from 'fs';
+import { join, relative } from 'path';
+import { describe, expect, it } from 'vitest';
+
+const FEED = join(
+  __dirname,
+  '..',
+  '..',
+  'features',
+  'session',
+  'components',
+  'SessionWorkspace',
+  'parts',
+  'TimelinePane',
+);
+const MARKER = join(FEED, 'TimelineMarker.tsx');
+
+const ANIMATION = /animate-|spin-border|attention-ring/;
+
+const listSourceFiles = (dir: string, acc: string[] = []): string[] => {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      listSourceFiles(full, acc);
+      continue;
+    }
+    if (entry.endsWith('.tsx') || entry.endsWith('.ts')) {
+      acc.push(full);
+    }
+  }
+  return acc;
+};
+
+describe('activity feed motion', () => {
+  it('animates the running marker and nothing else on the rail', () => {
+    const offenders: string[] = [];
+    for (const file of listSourceFiles(FEED)) {
+      if (file === MARKER || file.endsWith('.test.tsx') || file.endsWith('.test.ts')) {
+        continue;
+      }
+      readFileSync(file, 'utf8')
+        .split('\n')
+        .forEach((line, idx) => {
+          if (ANIMATION.test(line)) {
+            offenders.push(`${relative(FEED, file)}:${idx + 1} ${line.trim()}`);
+          }
+        });
+    }
+    expect(
+      offenders,
+      `Running is the only animated state in the feed, and it lives in TimelineMarker.tsx:\n${offenders.join('\n')}`,
+    ).toEqual([]);
+  });
+
+  it('gates the running dot on motion-safe so reduced motion keeps the dot and drops the pulse', () => {
+    const source = readFileSync(MARKER, 'utf8');
+    const pulses = source.split('\n').filter((line) => line.includes('animate-soft-pulse'));
+
+    expect(pulses).toHaveLength(1);
+    expect(pulses.every((line) => line.includes('motion-safe:animate-soft-pulse'))).toBe(true);
+  });
+});

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineMarker.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineMarker.test.tsx
@@ -3,7 +3,7 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { cleanup, render, screen } from '@testing-library/react';
 import type { TimelineMarkerState } from '../../../../timeline/markerState';
-import { TIMELINE_RHYTHM } from '../../../../timeline/timelineRhythm';
+import { TIMELINE_RHYTHM, type TimelineRowGrade } from '../../../../timeline/timelineRhythm';
 import { TimelineMarker } from './TimelineMarker';
 
 afterEach(cleanup);
@@ -35,6 +35,19 @@ const rootOf = ({ state }: { readonly state: TimelineMarkerState }) => {
     throw new Error('marker did not render');
   }
   return root;
+};
+
+const classOf = ({ node }: { readonly node: Element }) => node.getAttribute('class') ?? '';
+
+const animatedInside = ({ root }: { readonly root: Element }) =>
+  Array.from(root.querySelectorAll('*')).filter((node) => classOf({ node }).includes('animate-'));
+
+const dotOf = ({ root }: { readonly root: Element }) => {
+  const dot = root.querySelector('[class*="bg-info"]');
+  if (dot === null) {
+    throw new Error('running marker rendered no centre dot');
+  }
+  return dot;
 };
 
 describe('TimelineMarker', () => {
@@ -85,6 +98,54 @@ describe('TimelineMarker', () => {
     ] satisfies ReadonlyArray<TimelineMarkerState>) {
       expect(rootOf({ state }).className).not.toContain('spin-border');
       cleanup();
+    }
+  });
+
+  it('draws running as the ring plus a pulsing dot at its centre', () => {
+    const root = rootOf({ state: 'running' });
+
+    expect(root.className).toContain('spin-border');
+    expect(classOf({ node: dotOf({ root }) })).toContain('motion-safe:animate-soft-pulse');
+  });
+
+  it('pulses the running dot and leaves every other marker still', () => {
+    expect(animatedInside({ root: rootOf({ state: 'running' }) })).toHaveLength(1);
+    cleanup();
+    for (const state of [
+      'done',
+      'failed',
+      'pending',
+      'skipped',
+      'needsUser',
+      'question',
+    ] satisfies ReadonlyArray<TimelineMarkerState>) {
+      const root = rootOf({ state });
+      expect(root.className).not.toContain('animate-');
+      expect(animatedInside({ root })).toHaveLength(0);
+      cleanup();
+    }
+  });
+
+  it('keeps the dot under reduced motion and stops only its animation', () => {
+    const dot = dotOf({ root: rootOf({ state: 'running' }) });
+    const animations = classOf({ node: dot })
+      .split(' ')
+      .filter((token) => token.includes('animate-'));
+
+    expect(animations).toHaveLength(1);
+    expect(animations.every((token) => token.startsWith('motion-safe:'))).toBe(true);
+    expect(dot.getAttribute('style')).toContain(`${TIMELINE_RHYTHM.grade.step.dotSize}px`);
+  });
+
+  it('keeps the dot inside the ring so running never reads as the filled done marker', () => {
+    const root = rootOf({ state: 'running' });
+
+    expect(root.className).toContain('bg-background');
+    expect(root.getAttribute('style')).toContain(`${TIMELINE_RHYTHM.grade.step.markerSize}px`);
+    for (const grade of ['entry', 'step', 'pending'] satisfies ReadonlyArray<TimelineRowGrade>) {
+      const { markerSize, dotSize } = TIMELINE_RHYTHM.grade[grade];
+      expect(dotSize).toBeLessThanOrEqual(markerSize / 2);
+      expect(dotSize % 2).toBe(0);
     }
   });
 

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineMarker.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineMarker.tsx
@@ -60,7 +60,7 @@ const glyphClasses = ({ fill, tone }: { readonly fill: Fill; readonly tone: Tone
 };
 
 export const TimelineMarker = ({ state, grade, hasUnread = false }: Props) => {
-  const { markerSize, glyphSize } = TIMELINE_RHYTHM.grade[grade];
+  const { markerSize, glyphSize, dotSize } = TIMELINE_RHYTHM.grade[grade];
   const unread = hasUnread ? (
     <span
       className={cn(
@@ -113,6 +113,12 @@ export const TimelineMarker = ({ state, grade, hasUnread = false }: Props) => {
           aria-label={spec.label}
         />
       )}
+      {state === 'running' ? (
+        <span
+          className={cn('rounded-full motion-safe:animate-soft-pulse', tintClasses(spec.tone).dot)}
+          style={{ width: dotSize, height: dotSize }}
+        />
+      ) : null}
       {unread}
     </span>
   );

--- a/apps/desktop/src/features/session/timeline/timelineRhythm.ts
+++ b/apps/desktop/src/features/session/timeline/timelineRhythm.ts
@@ -7,12 +7,13 @@ type GradeRhythm = {
   readonly height: number;
   readonly markerSize: number;
   readonly glyphSize: number;
+  readonly dotSize: number;
 };
 
 const GRADE: Record<TimelineRowGrade, GradeRhythm> = {
-  entry: { lineHeight: 20, height: 36, markerSize: 16, glyphSize: 10 },
-  step: { lineHeight: 16, height: 28, markerSize: 12, glyphSize: 8 },
-  pending: { lineHeight: 16, height: 16, markerSize: 12, glyphSize: 8 },
+  entry: { lineHeight: 20, height: 36, markerSize: 16, glyphSize: 10, dotSize: 6 },
+  step: { lineHeight: 16, height: 28, markerSize: 12, glyphSize: 8, dotSize: 4 },
+  pending: { lineHeight: 16, height: 16, markerSize: 12, glyphSize: 8, dotSize: 4 },
 };
 
 const GAP: Record<TimelineGap, number> = {

--- a/packages/ui/DESIGN-SYSTEM.md
+++ b/packages/ui/DESIGN-SYSTEM.md
@@ -290,8 +290,11 @@ Four animations, one meaning each.
 - `attention-ring`: something new arrived, a finite outward breath (three
   cycles, then rest) on an element that now requires the user, never one that
   is working.
-- `soft-pulse`: the only standing-state animation in the app, breathing the
-  Providers launcher while no provider is connected. The bar for a second one
+- `soft-pulse`: the only standing-state animation in the app, breathing a state
+  that holds and is alive. It breathes the Providers launcher while no provider
+  is connected, and the centre dot of the running marker on the activity rail,
+  where it sits inside the `spin-border` ring so the pair reads as one running
+  state rather than two claims. The bar for a second standing-state animation
   is high.
 
 Motion-safe gating, "motion confirms, never decorates", "motion names who is


### PR DESCRIPTION
## What changed

The Activity feed's running marker kept its `spin-border` ring and gained a filled dot at its centre that breathes. The owner's report was that the ring alone reads as too quiet on the rail.

- `TimelineMarker` renders the dot only for `running`, tinted through `tintClasses('info').dot`, sized from the row grade.
- `timelineRhythm` grows a `dotSize` per grade: entry 6px, step 4px, pending 4px.
- `DESIGN-SYSTEM.md` motion registry: the `soft-pulse` entry now names both of its consumers.

## Reused, not added

No fifth animation. `soft-pulse` is already the standing-state animation and its meaning, a state that holds and is alive, is exactly what a running dot claims. `DESIGN.md` already names this signal in so many words: "Generating right now (seconds): moving border plus pulsing dot." `spin-border` means working but it spins a border, so it cannot be the dot; the two now compose into one running state rather than two claims. The registry stays at four, and the bar for a second standing-state animation stays high.

## The two hard constraints

**Motion-safe gating.** The dot carries `motion-safe:animate-soft-pulse`. Verified in the built CSS that `.motion-safe\:animate-soft-pulse` compiles inside `@media (prefers-reduced-motion: no-preference)`, so under reduced motion the element keeps its `bg-info` fill and its size and only the pulse stops. Running stays distinguishable without any movement.

**Legible without colour.** Running is the ring plus a small centre dot; done is a filled circle with a check; pending is the outline with a clock. The dot is at most half the marker diameter (6 in 16, 4 in 12), so a marker whose centre carries a small dot never reads as a filled circle.

**Geometry untouched.** `markerSize`, `lineHeight` and `markerCenterY` are unchanged, so the marker still sizes off the row's first text line and centres on that line. The dot is a flex child of a fixed width/height box, so the footprint the lane stroke and the rail column were sized against does not move. Dot diameters are even so the dot centres on whole pixels inside an even-sized marker, which matters because it is the one element here that animates.

## What you should look at

A session with a running agent: the marker on the rail should show the info ring with a breathing dot at its centre, and nothing else in the feed should move. Then the same view under System Settings > Accessibility > Display > Reduce motion: the dot stays, still, and running still reads as running.

## Verification

From the worktree root, all green:

- `pnpm typecheck`: 5 tasks successful.
- `pnpm lint`: no task implements it in this repo, 0 tasks executed.
- `pnpm test`: 694 files, 5993 tests passed.
- `pnpm build`: 4 tasks successful.
- `pnpm knip --include files,duplicates,unlisted`, which is what CI runs: clean. Plain `pnpm knip` fails on 42 pre-existing unused exports on `main`, none of them mine.

## Tests

`TimelineMarker.test.tsx` pins that running renders the ring and the dot together, that the dot is the only pulsing element and every other state renders nothing animated, that the dot's only animation class is `motion-safe:` prefixed so reduced motion keeps the dot, and that the dot stays at most half the marker while the marker keeps its grade size. A new regression, `timeline-feed-animates-only-running.test.ts`, scans the whole `TimelinePane` folder and fails if any animation class appears outside `TimelineMarker.tsx`, which is the feed-wide half of "running is the only animated thing on the screen".

## Decided, not specified

- Dot diameter per grade rather than one value: the rail carries 16px and 12px markers, and one dot size would be either lost in the entry marker or fat in the step marker. Even numbers were chosen over a ratio so the dot centres on whole pixels.
- The dot takes the running state's own `info` tone through the tint helper, so it cannot drift from the ring's hue.
- The `soft-pulse` registry entry was rewritten rather than left as is, since it claimed a single consumer that is no longer true.

## Deliberately left out

- No animation on `needsUser` or `question`. They stay still by the owner's ruling that motion names machine agency.
- No new keyframe and no new token.
- No `aria` change: the marker already exposes `role="img"` with a "Running" label, and the dot is decoration inside it.

## Not seen rendered

A dev instance is running from another worktree, so I did not start a second Tauri server. The visual claims above rest on the tests, on reading, and on the compiled CSS, not on my eyes.

Made with [Cursor](https://cursor.com)