### PR TITLE
fix(desktop): markers occlude their lane, and a role says its name

### DIFF
--- a/apps/desktop/src/features/session/agent-kind.test.ts
+++ b/apps/desktop/src/features/session/agent-kind.test.ts
@@ -258,12 +258,14 @@ describe('AGENT_KIND_PALETTE', () => {
     }
   });
 
-  it('renders the generalist role as the GEN badge', () => {
-    expect(AGENT_KIND_PALETTE.generic.label).toBe('gen');
+  it('renders the generalist role under its full name, never an abbreviation', () => {
+    expect(AGENT_KIND_PALETTE.generic.label).toBe('Generalist');
   });
 
-  it('spells every badge as a word, never a truncated fragment', () => {
-    expect(AGENT_KIND_PALETTE.implementer.label).toBe('implement');
+  it('takes every badge from the one role name the rest of the app uses', () => {
+    for (const kind of ALL_KINDS) {
+      expect(AGENT_KIND_PALETTE[kind].label).toBe(AGENT_KIND_META[kind].label);
+    }
   });
 });
 

--- a/apps/desktop/src/features/session/agent-kind.ts
+++ b/apps/desktop/src/features/session/agent-kind.ts
@@ -153,52 +153,52 @@ export const AGENT_KIND_PALETTE: Record<AgentKind, AgentKindPaletteEntry> = {
   scout: {
     bg: 'bg-sky-400',
     fg: 'text-sky-400',
-    label: 'scout',
+    label: AGENT_KIND_META.scout.label,
   },
   planner: {
     bg: 'bg-violet-400',
     fg: 'text-violet-400',
-    label: 'plan',
+    label: AGENT_KIND_META.planner.label,
   },
   implementer: {
     bg: 'bg-emerald-400',
     fg: 'text-emerald-400',
-    label: 'implement',
+    label: AGENT_KIND_META.implementer.label,
   },
   debugger: {
     bg: 'bg-amber-400',
     fg: 'text-amber-400',
-    label: 'debug',
+    label: AGENT_KIND_META.debugger.label,
   },
   tester: {
     bg: 'bg-teal-400',
     fg: 'text-teal-400',
-    label: 'test',
+    label: AGENT_KIND_META.tester.label,
   },
   reviewer: {
     bg: 'bg-cyan-400',
     fg: 'text-cyan-400',
-    label: 'review',
+    label: AGENT_KIND_META.reviewer.label,
   },
   'pr-reviewer': {
     bg: 'bg-indigo-400',
     fg: 'text-indigo-400',
-    label: 'pr review',
+    label: AGENT_KIND_META['pr-reviewer'].label,
   },
   docs: {
     bg: 'bg-orange-400',
     fg: 'text-orange-400',
-    label: 'docs',
+    label: AGENT_KIND_META.docs.label,
   },
   resolver: {
     bg: 'bg-lime-400',
     fg: 'text-lime-400',
-    label: 'resolve',
+    label: AGENT_KIND_META.resolver.label,
   },
   generic: {
     bg: 'bg-rose-400',
     fg: 'text-rose-400',
-    label: 'gen',
+    label: AGENT_KIND_META.generic.label,
   },
 };
 

--- a/apps/desktop/src/features/session/components/AgentKindChip/index.test.tsx
+++ b/apps/desktop/src/features/session/components/AgentKindChip/index.test.tsx
@@ -3,21 +3,30 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { cleanup, render, screen } from '@testing-library/react';
 import { AgentKindChip } from '.';
-import type { AgentKind } from '../../agent-kind';
+import { AGENT_KIND_ORDER, type AgentKind } from '../../agent-kind';
 
 afterEach(cleanup);
 
 const persistedKind = (value: string): AgentKind => JSON.parse(JSON.stringify(value));
 
+const widthOf = ({ kind }: { readonly kind: AgentKind }): string => {
+  const { container } = render(<AgentKindChip kind={kind} />);
+  const chip = container.firstElementChild;
+  return (chip?.className ?? '')
+    .split(' ')
+    .filter((token) => token.startsWith('w-'))
+    .join(' ');
+};
+
 describe('AgentKindChip', () => {
   it('renders the palette label for the given kind', () => {
     render(<AgentKindChip kind="planner" />);
-    expect(screen.getByText('plan')).toBeDefined();
+    expect(screen.getByText('Plan')).toBeDefined();
   });
 
   it('renders a different label for a different kind', () => {
     render(<AgentKindChip kind="implementer" />);
-    expect(screen.getByText('implement')).toBeDefined();
+    expect(screen.getByText('Implement')).toBeDefined();
   });
 
   it('degrades to the stored value instead of crashing on a kind the app does not know', () => {
@@ -30,10 +39,28 @@ describe('AgentKindChip', () => {
     expect(container.querySelector('[class*="bg-"]')).not.toBeNull();
   });
 
-  it('renders GEN for the generalist role, uppercased by the chip styling', () => {
+  it('writes the generalist role out in full, uppercased by the chip styling', () => {
     render(<AgentKindChip kind="generic" />);
-    const chip = screen.getByText('gen');
+    const chip = screen.getByText('Generalist');
     expect(chip.className).toContain('uppercase');
+  });
+
+  it('holds one width for every role so a column of chips stays aligned', () => {
+    const widths = new Set<string>();
+    for (const kind of AGENT_KIND_ORDER) {
+      widths.add(widthOf({ kind }));
+      cleanup();
+    }
+    widths.add(widthOf({ kind: persistedKind('gremlin') }));
+
+    expect(widths.size).toBe(1);
+    expect([...widths][0]).toBe('w-24');
+  });
+
+  it('insets the label so the longest role never touches the chip edge', () => {
+    const { container } = render(<AgentKindChip kind="pr-reviewer" />);
+
+    expect(container.firstElementChild?.className).toContain('px-1.5');
   });
 
   it('applies the title attribute when provided', () => {

--- a/apps/desktop/src/features/session/components/AgentKindChip/index.tsx
+++ b/apps/desktop/src/features/session/components/AgentKindChip/index.tsx
@@ -13,7 +13,7 @@ export const AgentKindChip = ({ kind, muted, title, className }: Props) => {
   return (
     <span
       className={cn(
-        'inline-flex w-[3.25rem] shrink-0 items-center justify-center rounded py-0.5 text-3xs font-semibold uppercase leading-none tracking-wide',
+        'inline-flex w-24 shrink-0 items-center justify-center rounded px-1.5 py-0.5 text-3xs font-semibold uppercase leading-none tracking-wide',
         muted ? 'bg-muted-foreground/20 text-muted-foreground/60' : [palette.bg, 'text-background'],
         className,
       )}

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineEmphasisMarker.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineEmphasisMarker.tsx
@@ -1,0 +1,39 @@
+import type { ReactNode } from 'react';
+import type { LucideIcon } from 'lucide-react';
+import { cn, tintClasses } from '@goodboy/ui';
+import type { Tone } from '@goodboy/ui';
+import { TIMELINE_RHYTHM, type TimelineRowGrade } from '../../../../timeline/timelineRhythm';
+import { TIMELINE_SURFACE_FILL } from './timelineLayout';
+
+type Props = {
+  readonly icon: LucideIcon;
+  readonly tone: Tone;
+  readonly label: string;
+  readonly grade: TimelineRowGrade;
+  readonly children?: ReactNode;
+};
+
+const EMPHASIS_GROWTH = 4;
+const HALO_OPACITY = 0.18;
+
+export const TimelineEmphasisMarker = ({ icon: Icon, tone, label, grade, children }: Props) => {
+  const emphasisSize = TIMELINE_RHYTHM.grade[grade].markerSize + EMPHASIS_GROWTH;
+  return (
+    <span className="relative inline-flex items-center justify-center">
+      <span
+        aria-hidden
+        className={cn('absolute rounded-full', TIMELINE_SURFACE_FILL)}
+        style={{ width: emphasisSize, height: emphasisSize }}
+      />
+      <Icon
+        size={emphasisSize}
+        strokeWidth={2}
+        fill="currentColor"
+        fillOpacity={HALO_OPACITY}
+        className={cn('relative', tintClasses(tone).icon)}
+        aria-label={label}
+      />
+      {children}
+    </span>
+  );
+};

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineGlyphMarker.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineGlyphMarker.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react';
 import { cn, tintClasses } from '@goodboy/ui';
 import type { Tone } from '@goodboy/ui';
 import { TIMELINE_RHYTHM, type TimelineRowGrade } from '../../../../timeline/timelineRhythm';
+import { TIMELINE_SURFACE_FILL } from './timelineLayout';
 
 type Props = {
   readonly tone: Tone;
@@ -14,7 +15,8 @@ export const TimelineGlyphMarker = ({ tone, grade, children }: Props) => {
   return (
     <span
       className={cn(
-        'inline-flex items-center justify-center rounded-full bg-background ring-1',
+        'inline-flex items-center justify-center rounded-full ring-1',
+        TIMELINE_SURFACE_FILL,
         tintClasses(tone).ring,
       )}
       style={{ width: markerSize, height: markerSize }}

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineMarker.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineMarker.test.tsx
@@ -27,6 +27,8 @@ const CIRCLE_STATES = [
   'skipped',
 ] satisfies ReadonlyArray<TimelineMarkerState>;
 
+const ELEVATION_RAMP = ['bg-background', 'bg-subtle', 'bg-muted', 'bg-elevated'];
+
 const LABELS: Record<TimelineMarkerState, string> = {
   done: 'Done',
   failed: 'Failed',
@@ -107,8 +109,8 @@ describe('TimelineMarker', () => {
     }
   });
 
-  it('takes the occluding fill from the surface the feed is drawn on', () => {
-    expect(TIMELINE_SURFACE_FILL).toBe('bg-background');
+  it('takes the occluding fill from the elevation ramp, never a picked colour', () => {
+    expect(ELEVATION_RAMP).toContain(TIMELINE_SURFACE_FILL);
   });
 
   it('leaves pending an outline while a settled state carries its tone', () => {

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineMarker.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineMarker.test.tsx
@@ -5,6 +5,7 @@ import { cleanup, render, screen } from '@testing-library/react';
 import type { TimelineMarkerState } from '../../../../timeline/markerState';
 import { TIMELINE_RHYTHM, type TimelineRowGrade } from '../../../../timeline/timelineRhythm';
 import { TimelineMarker } from './TimelineMarker';
+import { TIMELINE_SURFACE_FILL } from './timelineLayout';
 
 afterEach(cleanup);
 
@@ -16,6 +17,14 @@ const STATES = [
   'skipped',
   'needsUser',
   'question',
+] satisfies ReadonlyArray<TimelineMarkerState>;
+
+const CIRCLE_STATES = [
+  'done',
+  'failed',
+  'running',
+  'pending',
+  'skipped',
 ] satisfies ReadonlyArray<TimelineMarkerState>;
 
 const LABELS: Record<TimelineMarkerState, string> = {
@@ -50,6 +59,24 @@ const dotOf = ({ root }: { readonly root: Element }) => {
   return dot;
 };
 
+const layersOf = ({ state }: { readonly state: TimelineMarkerState }) => {
+  const root = rootOf({ state });
+  return [root, ...Array.from(root.querySelectorAll('span'))].map((node) => node.className);
+};
+
+const fillsOf = ({ className }: { readonly className: string }): ReadonlyArray<string> =>
+  className.split(' ').filter((token) => token.startsWith('bg-'));
+
+const bottomFillOf = ({ state }: { readonly state: TimelineMarkerState }): string | null => {
+  for (const className of layersOf({ state })) {
+    const fill = fillsOf({ className })[0];
+    if (fill !== undefined) {
+      return fill;
+    }
+  }
+  return null;
+};
+
 describe('TimelineMarker', () => {
   it('names every state for a screen reader', () => {
     for (const state of STATES) {
@@ -60,14 +87,7 @@ describe('TimelineMarker', () => {
   });
 
   it('gives the two blocking states a shape that is not the circle', () => {
-    const circles = [
-      'done',
-      'failed',
-      'running',
-      'pending',
-      'skipped',
-    ] satisfies ReadonlyArray<TimelineMarkerState>;
-    for (const state of circles) {
+    for (const state of CIRCLE_STATES) {
       expect(rootOf({ state }).className).toContain('rounded-full');
       cleanup();
     }
@@ -77,12 +97,33 @@ describe('TimelineMarker', () => {
     }
   });
 
-  it('leaves pending and running hollow so fill reads as has happened', () => {
-    expect(rootOf({ state: 'pending' }).className).toContain('bg-background');
+  it('cuts the lane it sits on, so a translucent tone never paints onto the rail', () => {
+    for (const state of STATES) {
+      const fill = bottomFillOf({ state });
+
+      expect(fill).not.toBeNull();
+      expect(fill).not.toContain('/');
+      cleanup();
+    }
+  });
+
+  it('takes the occluding fill from the surface the feed is drawn on', () => {
+    expect(TIMELINE_SURFACE_FILL).toBe('bg-background');
+  });
+
+  it('leaves pending an outline while a settled state carries its tone', () => {
+    expect(rootOf({ state: 'pending' }).className).toContain(TIMELINE_SURFACE_FILL);
+    expect(rootOf({ state: 'pending' }).querySelector('span.absolute')).toBeNull();
     cleanup();
-    expect(rootOf({ state: 'running' }).className).toContain('bg-background');
+    expect(rootOf({ state: 'running' }).className).toContain(TIMELINE_SURFACE_FILL);
     cleanup();
-    expect(rootOf({ state: 'done' }).className).toContain('bg-success');
+    expect(rootOf({ state: 'done' }).querySelector('span.absolute')?.className).toContain(
+      'bg-success',
+    );
+    cleanup();
+    expect(rootOf({ state: 'skipped' }).querySelector('span.absolute')?.className).toContain(
+      'bg-muted',
+    );
     cleanup();
     expect(rootOf({ state: 'failed' }).className).toContain('bg-danger');
   });
@@ -152,6 +193,12 @@ describe('TimelineMarker', () => {
   it('carries unread as a dot beside the state instead of replacing it', () => {
     render(<TimelineMarker state="failed" grade="step" hasUnread />);
     expect(screen.getByLabelText('Failed')).toBeDefined();
+    expect(screen.getByLabelText('Unseen')).toBeDefined();
+  });
+
+  it('keeps unread on a blocking state, which does not render a circle', () => {
+    render(<TimelineMarker state="question" grade="entry" hasUnread />);
+    expect(screen.getByLabelText('Waiting on your answer')).toBeDefined();
     expect(screen.getByLabelText('Unseen')).toBeDefined();
   });
 

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineMarker.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineMarker.tsx
@@ -4,6 +4,8 @@ import { cn, tintClasses } from '@goodboy/ui';
 import type { Tone } from '@goodboy/ui';
 import type { TimelineMarkerState } from '../../../../timeline/markerState';
 import { TIMELINE_RHYTHM, type TimelineRowGrade } from '../../../../timeline/timelineRhythm';
+import { TimelineEmphasisMarker } from './TimelineEmphasisMarker';
+import { TIMELINE_SURFACE_FILL } from './timelineLayout';
 
 type Props = {
   readonly state: TimelineMarkerState;
@@ -38,18 +40,27 @@ const SHAPE: Record<
   question: { icon: MessageCircleQuestionMark, label: 'Waiting on your answer' },
 };
 
-const fillClasses = ({ fill, tone }: { readonly fill: Fill; readonly tone: Tone }): string => {
+type FillParams = {
+  readonly fill: Fill;
+  readonly tone: Tone;
+};
+
+const surfaceClasses = ({ fill, tone }: FillParams): string => {
   const tint = tintClasses(tone);
   if (fill === 'solid') {
     return cn(tint.solid, 'ring-1', tint.ringStrong);
   }
-  if (fill === 'soft') {
-    return cn(tint.bg, 'ring-1', tint.ring);
-  }
-  return cn('bg-background ring-1', tint.ring);
+  return cn(TIMELINE_SURFACE_FILL, 'ring-1', tint.ring);
 };
 
-const glyphClasses = ({ fill, tone }: { readonly fill: Fill; readonly tone: Tone }): string => {
+const toneWashClasses = ({ fill, tone }: FillParams): string | null => {
+  if (fill === 'soft') {
+    return tintClasses(tone).bg;
+  }
+  return null;
+};
+
+const glyphClasses = ({ fill, tone }: FillParams): string => {
   if (fill === 'solid') {
     return 'text-current';
   }
@@ -72,50 +83,45 @@ export const TimelineMarker = ({ state, grade, hasUnread = false }: Props) => {
   ) : null;
 
   if (state === 'needsUser' || state === 'question') {
-    const { icon: Icon, label } = SHAPE[state];
+    const { icon, label } = SHAPE[state];
     return (
-      <span className="relative inline-flex items-center justify-center">
-        <span
-          className="absolute rounded-full bg-background"
-          style={{ width: markerSize, height: markerSize }}
-        />
-        <Icon
-          size={markerSize + 4}
-          strokeWidth={2}
-          fill="currentColor"
-          fillOpacity={0.18}
-          className="relative text-warning"
-          aria-label={label}
-        />
+      <TimelineEmphasisMarker icon={icon} tone="warning" label={label} grade={grade}>
         {unread}
-      </span>
+      </TimelineEmphasisMarker>
     );
   }
 
   const spec = CIRCLE[state];
   const Glyph = spec.icon;
+  const wash = toneWashClasses({ fill: spec.fill, tone: spec.tone });
   return (
     <span
       className={cn(
         'relative inline-flex items-center justify-center rounded-full',
-        fillClasses({ fill: spec.fill, tone: spec.tone }),
+        surfaceClasses({ fill: spec.fill, tone: spec.tone }),
         state === 'running' && 'spin-border spin-border-info',
       )}
       style={{ width: markerSize, height: markerSize }}
       aria-label={Glyph === null ? spec.label : undefined}
       role={Glyph === null ? 'img' : undefined}
     >
+      {wash === null ? null : (
+        <span aria-hidden className={cn('absolute inset-0 rounded-full', wash)} />
+      )}
       {Glyph === null ? null : (
         <Glyph
           size={glyphSize}
           strokeWidth={2.5}
-          className={glyphClasses({ fill: spec.fill, tone: spec.tone })}
+          className={cn('relative', glyphClasses({ fill: spec.fill, tone: spec.tone }))}
           aria-label={spec.label}
         />
       )}
       {state === 'running' ? (
         <span
-          className={cn('rounded-full motion-safe:animate-soft-pulse', tintClasses(spec.tone).dot)}
+          className={cn(
+            'relative rounded-full motion-safe:animate-soft-pulse',
+            tintClasses(spec.tone).dot,
+          )}
           style={{ width: dotSize, height: dotSize }}
         />
       ) : null}

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRowLabel.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRowLabel.test.tsx
@@ -1,0 +1,113 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { AGENT_KIND_META, type AgentKind } from '../../../../agent-kind';
+import type {
+  TimelineRowItem,
+  TimelineStreamEntry,
+} from '../../../../timeline/buildTimelineStream';
+import { TIMELINE_RHYTHM, type TimelineRowGrade } from '../../../../timeline/timelineRhythm';
+import { TimelineRowLabel } from './TimelineRowLabel';
+
+afterEach(cleanup);
+
+type AgentParams = {
+  readonly agentKind: AgentKind;
+  readonly name: string;
+};
+
+const agentEntry = ({ agentKind, name }: AgentParams): TimelineStreamEntry =>
+  ({
+    kind: 'agent',
+    id: `agent:${agentKind}`,
+    at: '2026-08-17T09:04:00Z',
+    ordinal: 1,
+    agent: { id: agentKind, name, status: 'completed' },
+    agentKind,
+    stepLabel: null,
+    openQuestions: [],
+    terminalQuestions: [],
+    children: [],
+    answers: [],
+    hasDuration: true,
+  }) as unknown as TimelineStreamEntry;
+
+type ItemParams = {
+  readonly entry: TimelineStreamEntry;
+  readonly grade?: TimelineRowGrade;
+};
+
+const itemOf = ({ entry, grade = 'entry' }: ItemParams): TimelineRowItem => ({
+  kind: 'row',
+  id: entry.id,
+  at: '2026-08-17T09:04:00Z',
+  grade,
+  entry,
+  identity: null,
+  familyId: null,
+  ordinal: null,
+  markerState: 'done',
+  hasUnread: false,
+  height: TIMELINE_RHYTHM.grade[grade].height,
+  topY: 0,
+  markerY: 18,
+  groupId: null,
+  isPending: false,
+  gap: 'entry',
+});
+
+const renderKind = ({ agentKind, name }: AgentParams) =>
+  render(<TimelineRowLabel item={itemOf({ entry: agentEntry({ agentKind, name }) })} />);
+
+describe('TimelineRowLabel', () => {
+  it('leads a resolver row with its role chip, like every other kind of agent', () => {
+    renderKind({ agentKind: 'resolver', name: 'resolve: 2 review threads' });
+
+    expect(screen.getByText(AGENT_KIND_META.resolver.label)).toBeDefined();
+    expect(screen.getByText('resolve: 2 review threads')).toBeDefined();
+  });
+
+  it('spells the role out in full rather than abbreviating it', () => {
+    renderKind({ agentKind: 'generic', name: 'Look into the failing build' });
+
+    expect(screen.getByText('Generalist')).toBeDefined();
+    expect(screen.queryByText('gen')).toBeNull();
+  });
+
+  it('holds one fixed chip width down the column, whatever the role is', () => {
+    const widths = new Set<string>();
+    for (const agentKind of [
+      'resolver',
+      'generic',
+      'planner',
+      'pr-reviewer',
+    ] satisfies ReadonlyArray<AgentKind>) {
+      const { container } = renderKind({ agentKind, name: 'A step' });
+      const chip = container.firstElementChild;
+      const width = (chip?.className ?? '')
+        .split(' ')
+        .filter((token) => token.includes('w-'))
+        .join(' ');
+
+      expect(width).not.toBe('');
+      widths.add(width);
+      cleanup();
+    }
+
+    expect(widths.size).toBe(1);
+  });
+
+  it('keeps the chip off a step row, where the run already names the role', () => {
+    render(
+      <TimelineRowLabel
+        item={itemOf({
+          entry: agentEntry({ agentKind: 'resolver', name: 'resolve: one thread' }),
+          grade: 'step',
+        })}
+      />,
+    );
+
+    expect(screen.queryByText(AGENT_KIND_META.resolver.label)).toBeNull();
+  });
+});

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRowLabel.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRowLabel.test.tsx
@@ -52,6 +52,7 @@ const itemOf = ({ entry, grade = 'entry' }: ItemParams): TimelineRowItem => ({
   height: TIMELINE_RHYTHM.grade[grade].height,
   topY: 0,
   markerY: 18,
+  topAnchorY: null,
   groupId: null,
   isPending: false,
   gap: 'entry',

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRowLabel.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRowLabel.tsx
@@ -39,7 +39,7 @@ type ChipParams = EntryParams & {
 };
 
 const chipOf = ({ entry, grade }: ChipParams) => {
-  if (entry.kind !== 'agent' || grade !== 'entry' || entry.agentKind === 'resolver') {
+  if (entry.kind !== 'agent' || grade !== 'entry') {
     return null;
   }
   const palette = agentKindPalette({ kind: entry.agentKind });

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRowMarker.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRowMarker.test.tsx
@@ -1,0 +1,96 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { tintClasses } from '@goodboy/ui';
+import { CONCEPT_TONE } from '../../../../../../shared/components/conceptIcons';
+import type {
+  TimelineRowItem,
+  TimelineStreamEntry,
+} from '../../../../timeline/buildTimelineStream';
+import { TIMELINE_RHYTHM } from '../../../../timeline/timelineRhythm';
+import { TimelineMarker } from './TimelineMarker';
+import { TimelineRowMarker } from './TimelineRowMarker';
+
+afterEach(cleanup);
+
+const planEntry = (): TimelineStreamEntry =>
+  ({
+    kind: 'plan',
+    id: 'plan:one',
+    at: '2026-08-17T09:04:00Z',
+    plan: { id: 'one', title: 'Move the rail geometry', clusterCount: 3 },
+  }) as unknown as TimelineStreamEntry;
+
+const branchEntry = (): TimelineStreamEntry =>
+  ({
+    kind: 'branch',
+    id: 'branch:one',
+    at: '2026-08-17T09:00:00Z',
+    worktree: { branch: 'ak/refactor-markers' },
+  }) as unknown as TimelineStreamEntry;
+
+const itemOf = ({ entry }: { readonly entry: TimelineStreamEntry }): TimelineRowItem => ({
+  kind: 'row',
+  id: entry.id,
+  at: '2026-08-17T09:04:00Z',
+  grade: 'entry',
+  entry,
+  identity: null,
+  familyId: null,
+  ordinal: null,
+  markerState: 'done',
+  hasUnread: false,
+  height: TIMELINE_RHYTHM.grade.entry.height,
+  topY: 0,
+  markerY: 18,
+  groupId: null,
+  isPending: false,
+  gap: 'entry',
+});
+
+const glyphOf = ({ label }: { readonly label: string }): Element => screen.getByLabelText(label);
+
+describe('TimelineRowMarker', () => {
+  it('gives the plan the emphasis the open question has, not a dim circle', () => {
+    render(<TimelineRowMarker item={itemOf({ entry: planEntry() })} />);
+    const plan = glyphOf({ label: 'Plan' });
+    cleanup();
+    render(<TimelineMarker state="question" grade="entry" />);
+    const question = glyphOf({ label: 'Waiting on your answer' });
+
+    expect(plan.getAttribute('width')).toBe(question.getAttribute('width'));
+    expect(plan.getAttribute('fill-opacity')).toBe(question.getAttribute('fill-opacity'));
+    expect(plan.getAttribute('fill')).toBe(question.getAttribute('fill'));
+  });
+
+  it('outgrows the circle markers so a plan reads as a distinct artifact', () => {
+    render(<TimelineRowMarker item={itemOf({ entry: planEntry() })} />);
+    const plan = Number(glyphOf({ label: 'Plan' }).getAttribute('width'));
+
+    expect(plan).toBeGreaterThan(TIMELINE_RHYTHM.grade.entry.markerSize);
+  });
+
+  it('takes the plan hue from the concept map, so it never reads as a question', () => {
+    render(<TimelineRowMarker item={itemOf({ entry: planEntry() })} />);
+
+    expect(glyphOf({ label: 'Plan' }).getAttribute('class')).toContain(
+      tintClasses(CONCEPT_TONE.plans).icon,
+    );
+    expect(glyphOf({ label: 'Plan' }).getAttribute('class')).not.toContain('text-warning');
+  });
+
+  it('occludes the lane behind the plan marker as well', () => {
+    const { container } = render(<TimelineRowMarker item={itemOf({ entry: planEntry() })} />);
+    const root = container.firstElementChild;
+
+    expect(root?.querySelector('span')?.className).toContain('bg-background');
+  });
+
+  it('leaves the other artifact markers on their own container', () => {
+    const { container } = render(<TimelineRowMarker item={itemOf({ entry: branchEntry() })} />);
+
+    expect(screen.getByLabelText('Branch')).toBeDefined();
+    expect(container.firstElementChild?.className).toContain('rounded-full');
+  });
+});

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRowMarker.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRowMarker.test.tsx
@@ -11,6 +11,7 @@ import type {
 import { TIMELINE_RHYTHM } from '../../../../timeline/timelineRhythm';
 import { TimelineMarker } from './TimelineMarker';
 import { TimelineRowMarker } from './TimelineRowMarker';
+import { TIMELINE_SURFACE_FILL } from './timelineLayout';
 
 afterEach(cleanup);
 
@@ -84,7 +85,7 @@ describe('TimelineRowMarker', () => {
     const { container } = render(<TimelineRowMarker item={itemOf({ entry: planEntry() })} />);
     const root = container.firstElementChild;
 
-    expect(root?.querySelector('span')?.className).toContain('bg-background');
+    expect(root?.querySelector('span')?.className).toContain(TIMELINE_SURFACE_FILL);
   });
 
   it('leaves the other artifact markers on their own container', () => {

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRowMarker.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRowMarker.test.tsx
@@ -45,6 +45,7 @@ const itemOf = ({ entry }: { readonly entry: TimelineStreamEntry }): TimelineRow
   height: TIMELINE_RHYTHM.grade.entry.height,
   topY: 0,
   markerY: 18,
+  topAnchorY: null,
   groupId: null,
   isPending: false,
   gap: 'entry',

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRowMarker.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRowMarker.tsx
@@ -6,6 +6,7 @@ import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../../../shared/components
 import { IntegrationGlyph } from '../../../../../integrations/components/IntegrationGlyph';
 import type { TimelineRowItem } from '../../../../timeline/buildTimelineStream';
 import { TIMELINE_RHYTHM } from '../../../../timeline/timelineRhythm';
+import { TimelineEmphasisMarker } from './TimelineEmphasisMarker';
 import { TimelineGlyphMarker } from './TimelineGlyphMarker';
 import { TimelineMarker } from './TimelineMarker';
 
@@ -19,8 +20,7 @@ type Glyph = {
   readonly label: string;
 };
 
-const ARTIFACT: Record<'plan' | 'branch' | 'answer', Glyph> = {
-  plan: { icon: CONCEPT_ICONS.plans, tone: CONCEPT_TONE.plans, label: 'Plan' },
+const ARTIFACT: Record<'branch' | 'answer', Glyph> = {
   branch: { icon: GitBranch, tone: 'neutral', label: 'Branch' },
   answer: { icon: MessageSquare, tone: 'warning', label: 'You answered' },
 };
@@ -37,6 +37,16 @@ export const TimelineRowMarker = ({ item }: Props) => {
       <TimelineGlyphMarker tone="neutral" grade={grade}>
         <IntegrationGlyph provider={entry.task.provider} size="xs" />
       </TimelineGlyphMarker>
+    );
+  }
+  if (entry.kind === 'plan') {
+    return (
+      <TimelineEmphasisMarker
+        icon={CONCEPT_ICONS.plans}
+        tone={CONCEPT_TONE.plans}
+        label="Plan"
+        grade={grade}
+      />
     );
   }
   const glyph = ARTIFACT[entry.kind];

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/timelineLayout.ts
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/timelineLayout.ts
@@ -1,1 +1,3 @@
 export const TIMELINE_GUTTER = 'w-16';
+
+export const TIMELINE_SURFACE_FILL = 'bg-background';


### PR DESCRIPTION
Three visual fixes on the Activity feed, one per commit.

## What changed

**A marker occludes the lane it sits on.** A marker was drawn over its lane but its
fill was translucent, so the run stroke read through the glyph. Every marker now
paints the feed's own surface step underneath, and a translucent tone sits on that
layer rather than on the rail. The fill resolves through one named constant
(`TIMELINE_SURFACE_FILL`, the `background` step of the elevation ramp the feed is
drawn on), so it follows the theme instead of a picked colour. `failed` needed no
layer: its solid tone is already opaque. `pending` keeps the surface fill with no
tone above it, so it stays the outline state, and the marker's diameter and its
centring on the row's first text line are untouched.

**The plan marker reads as an artifact.** The plan now takes the open question's
treatment through a shared `TimelineEmphasisMarker`: its own container, the same
growth over the circle markers, the same halo. Its hue is `CONCEPT_TONE.plans`
(`draft`, the violet), so it carries the question's weight without being mistaken
for one. The two blocking states now render through the same component, which is
also where their occluding disc lives.

**A resolver gets its chip, and every role its full name.** The feed skipped the
role chip for `resolver` only; that exclusion is gone. The chip label now derives
from `AGENT_KIND_META`, the role name the rest of the app already shows, which
retires `GEN` beside `IMPLEMENT` without inventing a second vocabulary. That makes
the longest label `PR REVIEWER`; measured at the chip's type (10px, semibold,
`tracking-wide`) it is 72px, and `AgentKindChip` was a 48.75px box with no inset,
so `IMPLEMENT` already overflowed it. The chip is now `w-24` with `px-1.5`, whole
pixels off the spacing scale and the same 96px as the feed's chip column, so every
surface that repeats it holds one aligned column.

## What to look at

- A finished run whose lane crosses its check markers: the lane stops at the
  marker's edge in both themes.
- The five circle states side by side: pending must still read as the only outline.
- A plan row next to an open question row: same weight, violet against amber.
- A resolver row (`resolve: 2 review threads`): it now leads with a RESOLVE chip.
- The role chips in the workflow step rows, the agents section, the step graph and
  the agent detail header: full names, one width.
- A running marker: its centre dot sits above this branch's fill layers, not under
  them.

## Concept map

Shared-map changes, since it moves everywhere at once: none. `CONCEPT_TONE.plans`
and `CONCEPT_ICONS.plans` are read, not changed.

## Decided, since the task did not specify it

- The resolve chip renders through the same role palette as every other role. The
  concept map's `resolve` tone and icon already govern the resolve lens and its
  cards; giving that one chip a second colour source would split the chip
  vocabulary the fix exists to unify.
- `AGENT_KIND_META` is the single label source rather than the palette's own
  strings, so `PR reviewer` also stops being `pr review`.
- The unknown-kind label stays capped at 9 characters. It is a raw persisted value,
  and the cap is still inside the column.

## Deliberately left out

- **The plan glyph.** I checked it, as asked, and kept `ClipboardList`. The
  complaint was weight, not identity, and the emphasis treatment answers that. The
  glyph is shared, so moving it would change the plan studio, the plan chip and the
  lens rail for no stated gain.
- **`AGENT_KIND_PALETTE`'s raw Tailwind colours** (`bg-lime-400` and friends) are a
  third colour vocabulary for agent kinds beside the tones and the
  `--color-agent-*` tokens. Out of scope here; it needs its own change.
- No visual claim is verified on screen: a dev server is already running from
  another worktree, so I did not start a second one. Everything below is read and
  tested, and the text measurement is `NSFont.systemFont(ofSize: 10, weight:
  .semibold)` with 0.25 kern.

## Rebased onto main

Rebased onto `main` at #1490. Three resolutions:

- **`TimelineMarker.tsx`**, against #1487's pulsing centre dot. Both intents kept.
  The dot renders after the glyph in the circle branch, and it gained `relative`,
  the same one word this branch already gives the glyph, so it is a positioned box
  that paints above the `absolute inset-0` tone layer instead of under it. Running
  is a hollow fill and so carries no tone layer today, but the ordering is now
  structural rather than a coincidence of the spec table. The fill still occludes:
  the dot is opaque, sits inside the ring, and `dotSize` stays at or under half the
  marker, so nothing translucent reaches the rail.
- **`TimelineMarker.test.tsx`**, a helper block both sides appended to. Kept both
  sets whole (`classOf`, `animatedInside`, `dotOf` from #1487; `layersOf`,
  `fillsOf`, `bottomFillOf` from here). Every assertion from both sides survives
  unchanged, and #1487's feed-wide animation scan stays green because
  `TimelineEmphasisMarker` carries no animation class.
- **The two new marker fixtures**, a type conflict git could not see. #1490 made
  `topAnchorY` required on a stream row. Both fixtures describe settled, non
  pending rows, which take the marker anchor, so both pass `null`, matching what
  `buildTimelineStream` writes for an ordinary row.

## Test plan

New coverage: the marker fill that occludes a lane crossing it (the bottom-most
fill of every state is opaque), pending as the only outline state, the plan marker
matching the question's growth and halo with the plan tone, a resolver row
rendering its chip, and every role label in full with the chip column fixed.

Re-run after the rebase, uncached (`turbo run --force`, `0 cached`):

```
pnpm typecheck  5 successful, 5 total
pnpm lint       0 tasks (no package implements lint)
pnpm test       ui 202, core 1261 (4 skipped), db 253 (1 skipped), desktop 6045, all passed
pnpm build      1 successful
pnpm knip --include files,duplicates,unlisted  clean
```

Made with [Cursor](https://cursor.com)
