### PR TITLE
fix(desktop): pending steps head the feed and the lane reaches them

### DIFF
--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineStreamRow.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineStreamRow.test.tsx
@@ -63,6 +63,7 @@ const itemOf = (): TimelineRowItem => ({
   height: TIMELINE_RHYTHM.grade.step.height + TIMELINE_RHYTHM.gap.sibling,
   topY: 0,
   markerY: 18,
+  topAnchorY: null,
   groupId: 'lane:run:one',
   isPending: false,
   gap: 'sibling',

--- a/apps/desktop/src/features/session/timeline/buildTimelineStream.test.ts
+++ b/apps/desktop/src/features/session/timeline/buildTimelineStream.test.ts
@@ -116,6 +116,27 @@ const attachedWorkflow = ({
   };
 };
 
+const RUN_WITH_PENDING_AGENTS: ReadonlyArray<Agent> = [
+  agent({
+    id: 'plan',
+    ordinal: 1,
+    startedAt: localIso({ day: 18, hour: 9 }),
+    completedAt: localIso({ day: 18, hour: 9, minute: 30 }),
+    workflowRunId: RUN_ID,
+  }),
+  agent({
+    id: 'implement',
+    ordinal: 2,
+    status: 'running',
+    startedAt: localIso({ day: 18, hour: 10 }),
+    workflowRunId: RUN_ID,
+  }),
+  agent({ id: 'test', ordinal: 3, status: 'pending', workflowRunId: RUN_ID }),
+  agent({ id: 'review', ordinal: 4, status: 'pending', workflowRunId: RUN_ID }),
+  agent({ id: 'ship', ordinal: 5, status: 'pending', workflowRunId: RUN_ID }),
+  agent({ id: 'built-by-hand', ordinal: 6, startedAt: localIso({ day: 18, hour: 11 }) }),
+];
+
 type StreamParams = {
   readonly agents: ReadonlyArray<Agent>;
   readonly workflows?: ReadonlyArray<ReturnType<typeof attachedWorkflow>>;
@@ -410,6 +431,50 @@ describe('buildTimelineStream', () => {
       'step:agent:running',
       'entry:run:run-1',
     ]);
+  });
+
+  it('lifts a pending block above every dated entry, standalone agents included', () => {
+    const { items } = stream({
+      workflows: [attachedWorkflow({ createdAt: localIso({ day: 18, hour: 8 }) })],
+      agents: RUN_WITH_PENDING_AGENTS,
+    });
+
+    expect(items.map(labelOf)).toEqual([
+      'now',
+      'cluster:3',
+      'entry:agent:built-by-hand',
+      'step:agent:implement',
+      'step:agent:plan',
+      'entry:run:run-1',
+    ]);
+  });
+
+  it('gives a lone pending step no borrowed clock and no day rule of its own', () => {
+    const { items } = stream({
+      workflows: [attachedWorkflow({ createdAt: localIso({ day: 10, hour: 8 }) })],
+      agents: [
+        agent({
+          id: 'done',
+          ordinal: 1,
+          startedAt: localIso({ day: 10, hour: 9 }),
+          completedAt: localIso({ day: 10, hour: 10 }),
+          workflowRunId: RUN_ID,
+        }),
+        agent({ id: 'todo', ordinal: 2, status: 'pending', workflowRunId: RUN_ID }),
+        agent({ id: 'built-by-hand', ordinal: 3, startedAt: localIso({ day: 18, hour: 11 }) }),
+      ],
+    });
+    const pending = items.find((item) => item.id === 'agent:todo');
+
+    expect(items.map(labelOf)).toEqual([
+      'now',
+      'step:agent:todo',
+      'entry:agent:built-by-hand',
+      'day:Aug 10',
+      'step:agent:done',
+      'entry:run:run-1',
+    ]);
+    expect(pending?.kind === 'row' ? pending.at : 'borrowed').toBeNull();
   });
 
   it('breaks the day inside a run that crossed midnight and keeps its lane whole', () => {

--- a/apps/desktop/src/features/session/timeline/buildTimelineStream.test.ts
+++ b/apps/desktop/src/features/session/timeline/buildTimelineStream.test.ts
@@ -15,6 +15,7 @@ import { buildTimelineGroups } from './buildTimelineGroups';
 import { buildTimelineStream, type TimelineStreamItem } from './buildTimelineStream';
 import { dayLabel } from './dayLabel';
 import { layoutTimelineRail } from './railGeometry';
+import { runIdentity } from './runIdentity';
 import { markerCenterY, TIMELINE_RHYTHM } from './timelineRhythm';
 
 type TypedStringParams = {
@@ -158,6 +159,38 @@ const stream = ({ agents, workflows = [], unreadAgentIds = new Set() }: StreamPa
     blockedRunIds: new Set(),
     dayLabelFor: ({ at }) => dayLabel({ at, now: NOW }),
   });
+
+type LaneSpan = {
+  readonly from: number;
+  readonly to: number;
+};
+
+type LaneSpanParams = {
+  readonly items: ReadonlyArray<TimelineStreamItem>;
+  readonly layout: ReturnType<typeof layoutTimelineRail>;
+};
+
+const laneSpansOf = ({ items, layout }: LaneSpanParams): ReadonlyArray<LaneSpan> => {
+  const spans: LaneSpan[] = [];
+  let offset = 0;
+  for (const [index, item] of items.entries()) {
+    for (const segment of layout.rows[index]?.segments ?? []) {
+      if (segment.column > 0) {
+        spans.push({ from: offset + segment.fromY, to: offset + segment.toY });
+      }
+    }
+    offset += item.height;
+  }
+  return [...spans].sort((first, second) => first.from - second.from);
+};
+
+const topOfItem = ({
+  items,
+  index,
+}: {
+  readonly items: ReadonlyArray<TimelineStreamItem>;
+  readonly index: number;
+}): number => items.slice(0, index).reduce((total, item) => total + item.height, 0);
 
 const labelOf = (item: TimelineStreamItem): string => {
   if (item.kind === 'row') {
@@ -446,6 +479,107 @@ describe('buildTimelineStream', () => {
       'step:agent:implement',
       'step:agent:plan',
       'entry:run:run-1',
+    ]);
+  });
+
+  it('runs one unbroken lane from the run origin to the topmost pending step', () => {
+    const { items, groups } = stream({
+      workflows: [attachedWorkflow({ createdAt: localIso({ day: 18, hour: 8 }) })],
+      agents: RUN_WITH_PENDING_AGENTS,
+    });
+    const layout = layoutTimelineRail({ rows: items, groups });
+    const spans = laneSpansOf({ items, layout });
+    const clusterIndex = items.findIndex((item) => item.kind === 'cluster');
+    const originIndex = items.findIndex((item) => item.id === 'run:run-1');
+    const breaks = spans.filter((span, index) => {
+      const previous = spans[index - 1];
+      return previous !== undefined && span.from > previous.to;
+    });
+
+    expect(spans[0]?.from).toBe(
+      topOfItem({ items, index: clusterIndex }) + TIMELINE_RHYTHM.grade.pending.height / 2,
+    );
+    expect(spans.at(-1)?.to).toBe(topOfItem({ items, index: originIndex }));
+    expect(breaks).toEqual([]);
+  });
+
+  it('merges the dashed stretch into the spine at the topmost pending step', () => {
+    const { items, groups } = stream({
+      workflows: [attachedWorkflow({ createdAt: localIso({ day: 18, hour: 8 }) })],
+      agents: RUN_WITH_PENDING_AGENTS,
+    });
+    const layout = layoutTimelineRail({ rows: items, groups });
+    const clusterIndex = items.findIndex((item) => item.kind === 'cluster');
+    const clusterRail = layout.rows[clusterIndex];
+    const nowRail = layout.rows[0];
+
+    expect(clusterRail?.joins.map((join) => `${join.kind}:${join.dash}`)).toEqual(['merge:dashed']);
+    expect(clusterRail?.segments.filter((segment) => segment.column > 0)).toEqual([
+      {
+        column: 1,
+        identityIndex: runIdentity({ runId: RUN_ID }).index,
+        dash: 'dashed',
+        fromY: TIMELINE_RHYTHM.grade.pending.height / 2,
+        toY: 3 * TIMELINE_RHYTHM.grade.pending.height,
+      },
+    ]);
+    expect(nowRail?.segments.filter((segment) => segment.column > 0)).toEqual([]);
+  });
+
+  it('keeps two concurrent runs on their own pending block and their own lane', () => {
+    const { items, groups } = stream({
+      workflows: [
+        attachedWorkflow({ createdAt: localIso({ day: 18, hour: 8 }) }),
+        attachedWorkflow({
+          runId: OTHER_RUN_ID,
+          name: 'Refactor workflow',
+          createdAt: localIso({ day: 18, hour: 10 }),
+        }),
+      ],
+      agents: [
+        agent({
+          id: 'a-done',
+          ordinal: 1,
+          startedAt: localIso({ day: 18, hour: 9 }),
+          completedAt: localIso({ day: 18, hour: 9, minute: 30 }),
+          workflowRunId: RUN_ID,
+        }),
+        agent({ id: 'a-next', ordinal: 2, status: 'pending', workflowRunId: RUN_ID }),
+        agent({ id: 'a-last', ordinal: 3, status: 'pending', workflowRunId: RUN_ID }),
+        agent({
+          id: 'b-running',
+          ordinal: 4,
+          status: 'running',
+          startedAt: localIso({ day: 18, hour: 10, minute: 30 }),
+          workflowRunId: OTHER_RUN_ID,
+        }),
+        agent({ id: 'b-next', ordinal: 5, status: 'pending', workflowRunId: OTHER_RUN_ID }),
+        agent({ id: 'b-last', ordinal: 6, status: 'pending', workflowRunId: OTHER_RUN_ID }),
+      ],
+    });
+    const layout = layoutTimelineRail({ rows: items, groups });
+    const clusters = items.flatMap((item, index) =>
+      item.kind === 'cluster' ? [{ item, rail: layout.rows[index] }] : [],
+    );
+
+    expect(items.map(labelOf)).toEqual([
+      'now',
+      'cluster:2',
+      'cluster:2',
+      'step:agent:b-running',
+      'entry:run:run-2',
+      'step:agent:a-done',
+      'entry:run:run-1',
+    ]);
+    expect(clusters.map(({ item }) => item.groupId)).toEqual(['lane:run:run-2', 'lane:run:run-1']);
+    expect(clusters.map(({ item }) => item.identity.index)).toEqual([
+      runIdentity({ runId: OTHER_RUN_ID }).index,
+      runIdentity({ runId: RUN_ID }).index,
+    ]);
+    expect(new Set(clusters.map(({ rail }) => rail?.markerColumn)).size).toBe(2);
+    expect(clusters.map(({ rail }) => rail?.joins.map((join) => join.kind))).toEqual([
+      ['merge'],
+      ['merge'],
     ]);
   });
 

--- a/apps/desktop/src/features/session/timeline/buildTimelineStream.ts
+++ b/apps/desktop/src/features/session/timeline/buildTimelineStream.ts
@@ -315,6 +315,35 @@ const emitRun = ({ entry, context }: EmitRunParams): void => {
   });
 };
 
+const isPendingStep = ({ draft }: { readonly draft: DraftRow }): boolean =>
+  draft.grade === 'step' && draft.markerState === 'pending';
+
+type HeadParams = {
+  readonly drafts: ReadonlyArray<DraftRow>;
+};
+
+const withPendingAtHead = ({ drafts }: HeadParams): ReadonlyArray<DraftRow> => {
+  const laneRankById = new Map<string, number>();
+  for (const [index, draft] of drafts.entries()) {
+    if (draft.familyId === draft.id) {
+      laneRankById.set(draft.id, index);
+    }
+  }
+  const laneRankOf = ({ draft }: { readonly draft: DraftRow }): number =>
+    draft.familyId == null ? drafts.length : (laneRankById.get(draft.familyId) ?? drafts.length);
+  const future = drafts
+    .filter((draft) => isPendingStep({ draft }))
+    .map((draft) => ({ ...draft, at: null }))
+    .sort(
+      (first, second) =>
+        laneRankOf({ draft: first }) - laneRankOf({ draft: second }) ||
+        (first.groupId ?? '').localeCompare(second.groupId ?? '') ||
+        second.sortOrdinal - first.sortOrdinal ||
+        first.id.localeCompare(second.id),
+    );
+  return [...future, ...drafts.filter((draft) => !isPendingStep({ draft }))];
+};
+
 type ClusterParams = {
   readonly drafts: ReadonlyArray<DraftRow>;
 };
@@ -344,8 +373,7 @@ const withPendingClusters = ({ drafts }: ClusterParams): ReadonlyArray<DraftRow 
   };
 
   for (const draft of drafts) {
-    const isPendingStep = draft.grade === 'step' && draft.markerState === 'pending';
-    if (!isPendingStep) {
+    if (!isPendingStep({ draft })) {
       flush();
       clustered.push(draft);
       continue;
@@ -435,7 +463,7 @@ export const buildTimelineStream = ({
 
   const sorted = [...context.drafts].sort((first, second) => compareNewestFirst({ first, second }));
   const withDays = withDayBreaks({
-    drafts: withPendingClusters({ drafts: sorted }),
+    drafts: withPendingClusters({ drafts: withPendingAtHead({ drafts: sorted }) }),
     dayLabelFor,
   });
 

--- a/apps/desktop/src/features/session/timeline/buildTimelineStream.ts
+++ b/apps/desktop/src/features/session/timeline/buildTimelineStream.ts
@@ -32,6 +32,7 @@ type StreamRail = {
   readonly height: number;
   readonly topY: number;
   readonly markerY: number | null;
+  readonly topAnchorY: number | null;
   readonly groupId: string | null;
   readonly isPending: boolean;
   readonly gap: TimelineGap;
@@ -475,6 +476,7 @@ export const buildTimelineStream = ({
       topY: TIMELINE_RHYTHM.now.ruleY,
       ruleY: TIMELINE_RHYTHM.now.ruleY,
       markerY: null,
+      topAnchorY: null,
       groupId: null,
       isPending: false,
       gap: 'none',
@@ -492,6 +494,7 @@ export const buildTimelineStream = ({
         topY: 0,
         ruleY: TIMELINE_RHYTHM.day.ruleY,
         markerY: TIMELINE_RHYTHM.day.ruleY,
+        topAnchorY: null,
         groupId: null,
         isPending: false,
         gap: 'none',
@@ -518,6 +521,7 @@ export const buildTimelineStream = ({
         height,
         topY: 0,
         markerY: (TIMELINE_RHYTHM.gap[gap] + height) / 2,
+        topAnchorY: TIMELINE_RHYTHM.gap[gap] + TIMELINE_RHYTHM.grade.pending.height / 2,
         groupId: draft.groupId,
         isPending: true,
         gap,
@@ -539,6 +543,7 @@ export const buildTimelineStream = ({
       height: rowBoxHeight({ grade: draft.grade, gap }),
       topY: 0,
       markerY: markerCenterY({ grade: draft.grade, gap }),
+      topAnchorY: null,
       groupId: draft.groupId,
       isPending: draft.isPending,
       gap,

--- a/apps/desktop/src/features/session/timeline/railGeometry.test.ts
+++ b/apps/desktop/src/features/session/timeline/railGeometry.test.ts
@@ -15,6 +15,7 @@ type RowParams = {
   readonly groupId?: string | null;
   readonly isPending?: boolean;
   readonly markerY?: number | null;
+  readonly topAnchorY?: number | null;
   readonly height?: number;
   readonly topY?: number;
 };
@@ -24,9 +25,10 @@ const row = ({
   groupId = null,
   isPending = false,
   markerY = 18,
+  topAnchorY = null,
   height = 36,
   topY = 0,
-}: RowParams): RailRowInput => ({ id, groupId, isPending, markerY, height, topY });
+}: RowParams): RailRowInput => ({ id, groupId, isPending, markerY, topAnchorY, height, topY });
 
 type GroupParams = {
   readonly id: string;
@@ -111,6 +113,56 @@ describe('layoutTimelineRail', () => {
     expect(lanesOf(layout, 'now')).toEqual([
       { column: 1, identityIndex: 0, dash: 'dashed', fromY: 12, toY: 48 },
     ]);
+  });
+
+  it('ends an open lane at its topmost pending row instead of dangling past it', () => {
+    const layout = layoutTimelineRail({
+      rows: [
+        row({ id: 'now', markerY: null, height: 48, topY: 12 }),
+        row({ id: 'pending', groupId: 'lane', isPending: true }),
+        row({ id: 'done', groupId: 'lane' }),
+        row({ id: 'origin' }),
+      ],
+      groups: [group({ id: 'lane', originRowId: 'origin', shape: 'open' })],
+    });
+
+    expect(railRow(layout, 'pending').joins).toEqual([
+      {
+        kind: 'merge',
+        spineColumn: 0,
+        laneColumn: 1,
+        identityIndex: 0,
+        dash: 'dashed',
+        anchorY: 18,
+      },
+    ]);
+    expect(lanesOf(layout, 'pending')).toEqual([
+      { column: 1, identityIndex: 0, dash: 'dashed', fromY: 18, toY: 36 },
+    ]);
+    expect(lanesOf(layout, 'now')).toEqual([]);
+  });
+
+  it('anchors the merge on the first line of a compressed pending stretch', () => {
+    const layout = layoutTimelineRail({
+      rows: [
+        row({
+          id: 'cluster',
+          groupId: 'lane',
+          isPending: true,
+          markerY: 24,
+          topAnchorY: 8,
+          height: 48,
+        }),
+        row({ id: 'origin' }),
+      ],
+      groups: [group({ id: 'lane', originRowId: 'origin', shape: 'open' })],
+    });
+
+    expect(railRow(layout, 'cluster').joins.map((join) => join.anchorY)).toEqual([8]);
+    expect(lanesOf(layout, 'cluster')).toEqual([
+      { column: 1, identityIndex: 0, dash: 'dashed', fromY: 8, toY: 48 },
+    ]);
+    expect(railRow(layout, 'cluster').markerY).toBe(24);
   });
 
   it('draws the lane through a standalone row that interleaves with the run', () => {

--- a/apps/desktop/src/features/session/timeline/railGeometry.ts
+++ b/apps/desktop/src/features/session/timeline/railGeometry.ts
@@ -20,6 +20,7 @@ export type RailRowInput = {
   readonly height: number;
   readonly topY: number;
   readonly markerY: number | null;
+  readonly topAnchorY: number | null;
   readonly groupId: string | null;
   readonly isPending: boolean;
 };
@@ -80,6 +81,9 @@ export const railColumnX = ({ column }: { readonly column: number }): number =>
 
 const anchorOf = ({ row }: { readonly row: RailRowInput }): number =>
   row.markerY ?? (row.topY + row.height) / 2;
+
+const topAnchorOf = ({ row }: { readonly row: RailRowInput }): number =>
+  row.topAnchorY ?? anchorOf({ row });
 
 const overlaps = ({ first, second }: { readonly first: Interval; readonly second: Interval }) =>
   first.from <= second.to && second.from <= first.to;
@@ -228,24 +232,23 @@ export const layoutTimelineRail = ({ rows, groups }: Params): RailLayout => {
     if (topRow === undefined) {
       continue;
     }
-    const topAnchor = anchorOf({ row: topRow });
+    const topAnchor = topAnchorOf({ row: topRow });
     const shared = { column: plan.column, identityIndex: plan.group.identityIndex };
     const isTopPending = topIndex < plan.boundaryIndex;
 
-    if (plan.group.shape === 'open') {
-      segmentsByIndex[topIndex]?.push(
-        isTopPending
-          ? { ...shared, dash: 'dashed', fromY: topRow.topY, toY: topRow.height }
-          : { ...shared, dash: 'solid', fromY: topAnchor, toY: topRow.height },
-      );
-      if (!isTopPending) {
-        segmentsByIndex[topIndex]?.push({
-          ...shared,
-          dash: 'dashed',
-          fromY: topRow.topY,
-          toY: topAnchor,
-        });
-      }
+    if (plan.group.shape === 'open' && !isTopPending) {
+      segmentsByIndex[topIndex]?.push({
+        ...shared,
+        dash: 'solid',
+        fromY: topAnchor,
+        toY: topRow.height,
+      });
+      segmentsByIndex[topIndex]?.push({
+        ...shared,
+        dash: 'dashed',
+        fromY: topRow.topY,
+        toY: topAnchor,
+      });
       for (let index = 0; index < topIndex; index += 1) {
         const row = rows[index];
         if (row === undefined) {
@@ -272,7 +275,7 @@ export const layoutTimelineRail = ({ rows, groups }: Params): RailLayout => {
       spineColumn: parentColumn,
       laneColumn: plan.column,
       identityIndex: plan.group.identityIndex,
-      dash: 'solid',
+      dash: isTopPending ? 'dashed' : 'solid',
       anchorY: topAnchor,
     });
   }


### PR DESCRIPTION
## What was wrong

The pending stretch of a run was drawn inside the run's body, between its own steps, instead of at the head of the feed.

The cause is a borrowed timestamp. `resolveAgentCreation` clamps an agent with no recorded start to the creation ceiling of the next agent by ordinal, which is right for a step that ran without recording its start. A pending step has no start because it has not happened, so it inherited the instant of whatever was created after it. A standalone agent built later in the session lent its instant to every pending step below it, and the block sorted to that agent instead of to the top. In the snapshot at `data.uxcheck.db`, 10 pending steps sit below a later started agent and were placed this way.

The consequence was the second half: an open lane ran dashed past its newest row all the way to NOW, so the dashed tail hung above the block it belongs to instead of ending on it.

## What changed

Two files, both in `features/session/timeline`.

`buildTimelineStream` moves a pending step to the head and drops its borrowed instant. Placement now follows the model the feed already runs on: newer above older, and pending work is the future, so it stacks directly under NOW. Dropping the instant also stops a lone pending row from dragging a day rule to the top of the feed.

`railGeometry` closes a lane on its topmost pending row: solid from the origin through the completed stretch, dashed from the boundary up through the pending stretch, and a dashed merge back into the spine level with the topmost pending step. A compressed stretch reports that first step line as its top anchor, so the lane ends level with the top step while the single clock stays centred on the block.

## What to look at

A session with a run mid-flight and a standalone agent built after it. The pending block should sit directly under NOW, above the standalone agent and above every dated step, with its dashed lane ending on its top row and curving back to the spine there. Nothing dashed should continue above it.

## What I decided that the task did not specify

**Order inside the head.** A run's pending steps stay one contiguous block, ordered by descending step so the highest step sits on top. Two blocks are ordered newest run first, the run's own creation instant being the only clock available for work that has none.

**Concurrent runs are readable at the head, so I kept them there.** Each run keeps its own block, its own lane column, its own identity colour and its own merge, so two blocks never share a lane. This is not hypothetical: one session in the snapshot holds two runs with pending work at once, 5 steps and 3 steps, and those two runs take identity 0 and 3, so colour separates them there as well as column does.

**A lane with no pending step still dangles toward NOW.** An unenumerated future has nothing to reach, so that stays as it was; only a lane whose future is spelled out now closes on it.

## What I left out

The compressed rows with one clock, no grouping, no disclosure, the run origin at the bottom of its group, day rules only where two days meet, and the identity colours are all untouched: this is placement and geometry only.

I did not change the creation ceiling in `resolveAgentCreation`. It is correct for its own job, and the fix belongs where the assumption was wrong, which is that pending work should be placed by a clock at all.

Column reservation still treats an open lane as spanning to the top of the feed even though the lane now stops at its block. Tightening it would reshuffle columns in every session and is not needed here.

## Verification

From the worktree root, on this branch:

- `pnpm typecheck`: 5 successful, 5 total.
- `pnpm lint`: 0 tasks executed. No package implements a `lint` script, the documented repo anomaly.
- `pnpm test`: 693 test files passed, 5996 tests passed. The timeline suite alone is 7 files, 69 tests, up from 64, the 5 new tests covering placement above every dated entry, the unbroken lane from origin to top step, the merge at that point, two concurrent runs each keeping their own block and lane, and a lone pending step carrying neither a borrowed clock nor a day rule.
- `pnpm build`: 1 successful, 1 total.
- `pnpm knip --include files,duplicates,unlisted`, the scope CI runs: clean, configuration hints only. Default-scope `pnpm knip` reports 42 unused exports and 71 unused exported types, byte-identical on `origin/main` and on this branch, so it is pre-existing and names no file this PR touches.

Each test was watched failing first: placement put the block one row too low, exactly as in the screenshot, and the lane carried no merge and started at the top of the NOW row.

One thing I did not see: the feed rendered. A dev instance is already running from another worktree and I did not start a second one. The geometry is asserted in the tests rather than eyeballed, and one detail is worth a look on screen: the merge curve at the head has only the block's own top inset of vertical room, so the hook into the spine is steeper there than on an ordinary merged row.

Made with [Cursor](https://cursor.com)
