### PR TITLE
fix(desktop): a crumb parent comes from the object, not from the lens

### DIFF
--- a/apps/desktop/src/features/session/components/SessionWorkspace/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/index.test.tsx
@@ -240,7 +240,7 @@ vi.mock('../../../../shared/components/PaneShell', () => ({
     </div>
   ),
 }));
-vi.mock('./hooks/useSelectedAgentHome', () => ({
+vi.mock('../../hooks/useSelectedAgentHome', () => ({
   useSelectedAgentHome: () => hooks.agentHome,
 }));
 import { SessionWorkspace } from './index';
@@ -725,7 +725,7 @@ describe('SessionWorkspace breadcrumb visibility', () => {
     ]);
   });
 
-  it('keeps resolve as the chat-header back target when a workflow step agent auto-advances', () => {
+  it('keeps resolve as the back target while the trail still names the run', () => {
     const workflowAgent = {
       ...selectedAgent,
       stepId: 'step-1',
@@ -753,13 +753,15 @@ describe('SessionWorkspace breadcrumb visibility', () => {
 
     render(<SessionWorkspace session={workflowSession} isActive />);
 
-    expect(screen.getByTestId('session-crumb-bar')).toBeDefined();
     expect(screen.queryByText('Part of')).toBeNull();
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(store.setActiveLens).toHaveBeenCalledWith(SESSION_ID, 'resolve');
 
     const { result } = renderHook(() => useSessionCrumbs({ session: workflowSession }));
     expect(result.current.map((crumb) => crumb.label)).toEqual([
       'Overview',
-      'Resolve',
+      'Workflows',
+      'Release flow',
       'Selected agent',
     ]);
   });

--- a/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
@@ -25,7 +25,7 @@ import { ResolvePane } from './parts/ResolvePane';
 import { PrPane } from './parts/PrPane';
 import { FilesPane } from './parts/FilesPane';
 import { PaneShell } from '../../../../shared/components/PaneShell';
-import { useSelectedAgentHome } from './hooks/useSelectedAgentHome';
+import { useSelectedAgentHome } from '../../hooks/useSelectedAgentHome';
 import { resolveOverlayHome } from './resolveOverlayHome';
 import { WorkflowsPane } from './parts/WorkflowsPane';
 import { IntegrationPane } from './parts/IntegrationPane';

--- a/apps/desktop/src/features/session/components/SessionWorkspace/sessionBreadcrumb.test.ts
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/sessionBreadcrumb.test.ts
@@ -23,6 +23,7 @@ const base = (
   selectedChildWorkflowName: null,
   focusedPlanTitle: null,
   selectedChildLabel: null,
+  selectedChildHome: null,
   lensLabel,
   handlers,
   ...overrides,
@@ -49,16 +50,61 @@ describe('buildSessionBreadcrumb', () => {
     expect(last(crumbs)?.onClick).toBeUndefined();
   });
 
-  it('extends the lens trail without dropping an ancestor when a child opens', () => {
+  it('extends the trail without dropping an ancestor when a child opens', () => {
     const h = makeHandlers();
     const crumbs = buildSessionBreadcrumb(
-      base({ lens: 'agents', selectedChildLabel: 'Selected agent' }, h),
+      base(
+        { lens: 'agents', selectedChildHome: 'agents', selectedChildLabel: 'Selected agent' },
+        h,
+      ),
     );
 
     expect(labels(crumbs)).toEqual(['Overview', 'agents', 'Selected agent']);
     crumbs[1]!.onClick!();
     expect(h.toLens).toHaveBeenCalledWith('agents');
     expect(last(crumbs)?.onClick).toBeUndefined();
+  });
+
+  it('parents a child on its own home when a shortcut left the lens on overview', () => {
+    const h = makeHandlers();
+    const adHoc = buildSessionBreadcrumb(
+      base({ lens: null, selectedChildHome: 'agents', selectedChildLabel: 'scout one' }, h),
+    );
+    const resolver = buildSessionBreadcrumb(
+      base({ lens: null, selectedChildHome: 'resolve', selectedChildLabel: 'resolve one' }, h),
+    );
+
+    expect(labels(adHoc)).toEqual(['Overview', 'agents', 'scout one']);
+    expect(labels(resolver)).toEqual(['Overview', 'resolve', 'resolve one']);
+  });
+
+  it('parents a step on its run no matter which lens the jump came from', () => {
+    const h = makeHandlers();
+    const fromFeed = buildSessionBreadcrumb(
+      base(
+        {
+          lens: null,
+          selectedChildHome: 'workflows',
+          selectedChildWorkflowName: 'refactor',
+          selectedChildLabel: 'Implement',
+        },
+        h,
+      ),
+    );
+    const fromAnotherLens = buildSessionBreadcrumb(
+      base(
+        {
+          lens: 'resolve',
+          selectedChildHome: 'workflows',
+          selectedChildWorkflowName: 'refactor',
+          selectedChildLabel: 'Implement',
+        },
+        h,
+      ),
+    );
+
+    expect(labels(fromFeed)).toEqual(['Overview', 'Workflows', 'refactor', 'Implement']);
+    expect(labels(fromAnotherLens)).toEqual(labels(fromFeed));
   });
 
   it('renders Overview > Workflows > {name} for a focused workflow run', () => {
@@ -78,6 +124,7 @@ describe('buildSessionBreadcrumb', () => {
       base(
         {
           lens: 'workflows',
+          selectedChildHome: 'workflows',
           selectedChildWorkflowName: 'refactor',
           selectedChildLabel: 'Implement',
         },
@@ -96,6 +143,7 @@ describe('buildSessionBreadcrumb', () => {
       base(
         {
           lens: 'workflows',
+          selectedChildHome: 'workflows',
           selectedChildWorkflowName: 'refactor',
           selectedChildLabel: 'Implement',
         },
@@ -115,6 +163,7 @@ describe('buildSessionBreadcrumb', () => {
       base(
         {
           lens: 'workflows',
+          selectedChildHome: 'workflows',
           focusedWorkflowName: 'release',
           selectedChildWorkflowName: 'refactor',
           selectedChildLabel: 'Implement',
@@ -126,13 +175,35 @@ describe('buildSessionBreadcrumb', () => {
     expect(labels(crumbs)).toEqual(['Overview', 'Workflows', 'refactor', 'Implement']);
   });
 
-  it('keeps a workflow agent with no resolvable run on the three-crumb lens trail', () => {
+  it('keeps a workflow agent with no resolvable run under the workflows list', () => {
     const h = makeHandlers();
     const crumbs = buildSessionBreadcrumb(
-      base({ lens: 'workflows', selectedChildLabel: 'Implement' }, h),
+      base(
+        { lens: 'workflows', selectedChildHome: 'workflows', selectedChildLabel: 'Implement' },
+        h,
+      ),
     );
 
-    expect(labels(crumbs)).toEqual(['Overview', 'workflows', 'Implement']);
+    expect(labels(crumbs)).toEqual(['Overview', 'Workflows', 'Implement']);
+    crumbs[1]!.onClick!();
+    expect(h.toWorkflowsList).toHaveBeenCalledOnce();
+  });
+
+  it('shows the open child rather than the plan the lens still has focused', () => {
+    const h = makeHandlers();
+    const crumbs = buildSessionBreadcrumb(
+      base(
+        {
+          lens: 'plans',
+          focusedPlanTitle: 'migration plan',
+          selectedChildHome: 'agents',
+          selectedChildLabel: 'scout one',
+        },
+        h,
+      ),
+    );
+
+    expect(labels(crumbs)).toEqual(['Overview', 'agents', 'scout one']);
   });
 
   it('renders Overview > Workflows > Create for the workflow builder studio', () => {

--- a/apps/desktop/src/features/session/components/SessionWorkspace/sessionBreadcrumb.ts
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/sessionBreadcrumb.ts
@@ -1,5 +1,6 @@
 import type { BreadcrumbCrumb } from '../../../../app/components/AppBreadcrumb/buildBreadcrumb';
 import type { LensKind, SessionStudio } from '../../../../store';
+import type { AgentHomeLens } from '../../agent-kind';
 
 export type SessionBreadcrumbHandlers = {
   toOverview: () => void;
@@ -16,6 +17,7 @@ export type SessionBreadcrumbInput = {
   selectedChildWorkflowName: string | null;
   focusedPlanTitle: string | null;
   selectedChildLabel: string | null;
+  selectedChildHome: AgentHomeLens | null;
   lensLabel: (lens: LensKind) => string;
   handlers: SessionBreadcrumbHandlers;
 };
@@ -35,6 +37,7 @@ export const buildSessionBreadcrumb = (input: SessionBreadcrumbInput): Breadcrum
     selectedChildWorkflowName,
     focusedPlanTitle,
     selectedChildLabel,
+    selectedChildHome,
     lensLabel,
     handlers,
   } = input;
@@ -87,7 +90,25 @@ export const buildSessionBreadcrumb = (input: SessionBreadcrumbInput): Breadcrum
     ]);
   }
 
-  if (lens === 'workflows' && selectedChildWorkflowName != null && selectedChildLabel != null) {
+  if (selectedChildLabel != null && selectedChildHome != null) {
+    const selectedChild: BreadcrumbCrumb = { id: 'selected-child', label: selectedChildLabel };
+
+    if (selectedChildHome !== 'workflows') {
+      return sealLast([
+        overview,
+        {
+          id: `lens-${selectedChildHome}`,
+          label: lensLabel(selectedChildHome),
+          onClick: () => handlers.toLens(selectedChildHome),
+        },
+        selectedChild,
+      ]);
+    }
+
+    if (selectedChildWorkflowName == null) {
+      return sealLast([overview, workflowsList, selectedChild]);
+    }
+
     return sealLast([
       overview,
       workflowsList,
@@ -96,7 +117,7 @@ export const buildSessionBreadcrumb = (input: SessionBreadcrumbInput): Breadcrum
         label: selectedChildWorkflowName,
         onClick: handlers.toWorkflowRun,
       },
-      { id: 'selected-child', label: selectedChildLabel },
+      selectedChild,
     ]);
   }
 
@@ -106,14 +127,6 @@ export const buildSessionBreadcrumb = (input: SessionBreadcrumbInput): Breadcrum
 
   if (lens === 'plans' && focusedPlanTitle != null) {
     return sealLast([overview, plansList, { id: 'plan', label: focusedPlanTitle }]);
-  }
-
-  if (lens != null && selectedChildLabel != null) {
-    return sealLast([
-      overview,
-      { id: `lens-${lens}`, label: lensLabel(lens), onClick: () => handlers.toLens(lens) },
-      { id: 'selected-child', label: selectedChildLabel },
-    ]);
   }
 
   if (lens != null) {

--- a/apps/desktop/src/features/session/hooks/useSelectedAgentHome/index.test.ts
+++ b/apps/desktop/src/features/session/hooks/useSelectedAgentHome/index.test.ts
@@ -19,7 +19,7 @@ const { store } = vi.hoisted(() => {
   return { store };
 });
 
-vi.mock('../../../../../../store', () => ({
+vi.mock('../../../../store', () => ({
   EMPTY_ARRAY: [],
   useAppStore: (selector: (state: StoreState) => unknown) => selector(store.state),
 }));

--- a/apps/desktop/src/features/session/hooks/useSelectedAgentHome/index.ts
+++ b/apps/desktop/src/features/session/hooks/useSelectedAgentHome/index.ts
@@ -1,12 +1,12 @@
 import { useMemo } from 'react';
 import type { SessionId } from '@goodboy/types';
-import { EMPTY_ARRAY, useAppStore } from '../../../../../../store';
+import { EMPTY_ARRAY, useAppStore } from '../../../../store';
 import {
   agentHomeLens,
   classifyAgent,
   resolveRootAgent,
   type AgentHomeLens,
-} from '../../../../agent-kind';
+} from '../../agent-kind';
 
 export const useSelectedAgentHome = (sessionId: SessionId): AgentHomeLens | null => {
   const selectedAgentId = useAppStore((s) => s.selectedAgentId[sessionId] ?? null);

--- a/apps/desktop/src/features/session/hooks/useSessionCrumbs/index.test.ts
+++ b/apps/desktop/src/features/session/hooks/useSessionCrumbs/index.test.ts
@@ -1,0 +1,156 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  Agent,
+  AgentId,
+  Session,
+  SessionId,
+  StepId,
+  Workflow,
+  WorkflowRunId,
+} from '@goodboy/types';
+import type { LensKind } from '../../../../store';
+
+type StoreState = Record<string, unknown>;
+
+const { store, actions } = vi.hoisted(() => {
+  const store: { state: StoreState } = { state: {} };
+  const actions = {
+    setActiveLens: vi.fn(),
+    setFocusedWorkflowRun: vi.fn(),
+    setFocusedPlanId: vi.fn(),
+  };
+  return { store, actions };
+});
+
+vi.mock('../../../../store', () => ({
+  EMPTY_ARRAY: [],
+  useAppStore: (selector: (state: StoreState) => unknown) => selector(store.state),
+  useSessionPlans: () => [],
+}));
+
+import { useSessionCrumbs } from './index';
+
+const SESSION_ID = 'session-1' as SessionId;
+const RUN_ID = 'run-1' as WorkflowRunId;
+const STEP_AGENT_ID = 'agent-step' as AgentId;
+const ADHOC_AGENT_ID = 'agent-scout' as AgentId;
+const RESOLVER_AGENT_ID = 'agent-resolver' as AgentId;
+
+const workflow = { id: 'workflow-1', name: 'refactor', steps: [] } as unknown as Workflow;
+
+const session = {
+  id: SESSION_ID,
+  workspaceId: 'workspace-1',
+  workflowRuns: [{ id: RUN_ID, workflowId: 'workflow-1', ordinal: 0 }],
+} as unknown as Session;
+
+const agentOf = (overrides: Partial<Agent> & Pick<Agent, 'id' | 'name'>): Agent =>
+  ({
+    sessionId: SESSION_ID,
+    ordinal: 0,
+    status: 'running',
+    ...overrides,
+  }) as Agent;
+
+const stepAgent = agentOf({
+  id: STEP_AGENT_ID,
+  name: 'Implement',
+  kind: 'implementer',
+  stepId: 'step-1' as StepId,
+  workflowRunId: RUN_ID,
+});
+
+const adHocAgent = agentOf({ id: ADHOC_AGENT_ID, name: 'scout one', kind: 'scout' });
+
+const resolverAgent = agentOf({
+  id: RESOLVER_AGENT_ID,
+  name: 'resolve one',
+  kind: 'resolver',
+});
+
+type SurfaceParams = {
+  readonly lens: LensKind | null;
+  readonly selectedAgentId: AgentId;
+};
+
+const openOn = ({ lens, selectedAgentId }: SurfaceParams) => {
+  store.state = {
+    ...store.state,
+    activeLens: { [SESSION_ID]: lens },
+    selectedAgentId: { [SESSION_ID]: selectedAgentId },
+  };
+};
+
+const labelsOf = (lens: LensKind | null, selectedAgentId: AgentId): ReadonlyArray<string> => {
+  openOn({ lens, selectedAgentId });
+  const { result } = renderHook(() => useSessionCrumbs({ session }));
+  return result.current.map((crumb) => crumb.label);
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  store.state = {
+    activeLens: {},
+    sessionStudio: {},
+    focusedWorkflowRunId: {},
+    focusedPlanId: {},
+    selectedAgentId: {},
+    sessionPhaseRuns: { [SESSION_ID]: [stepAgent, adHocAgent, resolverAgent] },
+    agentKindOverride: {},
+    phaseTemplates: { 'workspace-1': [workflow] },
+    sessionWorkflows: {},
+    sessionBranches: { [SESSION_ID]: 'feature/one' },
+    workspaces: [{ id: 'workspace-1', kind: 'repo' }],
+    ...actions,
+  };
+});
+
+describe('useSessionCrumbs', () => {
+  it('parents a step opened from the activity feed on its run, not on overview', () => {
+    expect(labelsOf(null, STEP_AGENT_ID)).toEqual([
+      'Overview',
+      'Workflows',
+      'refactor',
+      'Implement',
+    ]);
+  });
+
+  it('reads the same trail when the step is opened from the workflows lens', () => {
+    expect(labelsOf('workflows', STEP_AGENT_ID)).toEqual([
+      'Overview',
+      'Workflows',
+      'refactor',
+      'Implement',
+    ]);
+  });
+
+  it('keeps a step parented on its run while the app sits in another lens', () => {
+    expect(labelsOf('agents', STEP_AGENT_ID)).toEqual([
+      'Overview',
+      'Workflows',
+      'refactor',
+      'Implement',
+    ]);
+  });
+
+  it('gives an ad-hoc agent opened from the feed the agents home as parent', () => {
+    expect(labelsOf(null, ADHOC_AGENT_ID)).toEqual(['Overview', 'Agents', 'scout one']);
+  });
+
+  it('gives a resolver opened from the feed the resolve home as parent', () => {
+    expect(labelsOf(null, RESOLVER_AGENT_ID)).toEqual(['Overview', 'Resolve', 'resolve one']);
+  });
+
+  it('navigates from the run crumb to that run, and from Workflows to the list', () => {
+    openOn({ lens: null, selectedAgentId: STEP_AGENT_ID });
+    const { result } = renderHook(() => useSessionCrumbs({ session }));
+
+    result.current[2]?.onClick?.();
+    expect(actions.setFocusedWorkflowRun).toHaveBeenCalledWith(SESSION_ID, RUN_ID);
+
+    result.current[1]?.onClick?.();
+    expect(actions.setFocusedWorkflowRun).toHaveBeenCalledWith(SESSION_ID, null);
+    expect(actions.setActiveLens).toHaveBeenCalledWith(SESSION_ID, 'workflows');
+  });
+});

--- a/apps/desktop/src/features/session/hooks/useSessionCrumbs/index.ts
+++ b/apps/desktop/src/features/session/hooks/useSessionCrumbs/index.ts
@@ -8,6 +8,7 @@ import { useAttachedWorkflowRuns } from '../../../workflows/useAttachedWorkflowR
 import { buildSessionBreadcrumb } from '../../components/SessionWorkspace/sessionBreadcrumb';
 import { SIMPLE_LENSES, lensLabelFor } from '../../lens-labels';
 import { useSelectedWorkflowRun } from '../useSelectedWorkflowRun';
+import { useSelectedAgentHome } from '../useSelectedAgentHome';
 
 type Params = {
   readonly session: Session;
@@ -29,6 +30,7 @@ export const useSessionCrumbs = ({ session }: Params): ReadonlyArray<BreadcrumbC
     (s) =>
       s.sessionPhaseRuns[sessionId]?.find((agent) => agent.id === selectedAgentId)?.name ?? null,
   );
+  const selectedChildHome = useSelectedAgentHome(sessionId);
   const attachedWorkflowRuns = useAttachedWorkflowRuns({ session });
   const selectedWorkflowRun = useSelectedWorkflowRun({ session });
   const plans = useSessionPlans(sessionId);
@@ -59,6 +61,7 @@ export const useSessionCrumbs = ({ session }: Params): ReadonlyArray<BreadcrumbC
         selectedChildWorkflowName,
         focusedPlanTitle,
         selectedChildLabel,
+        selectedChildHome,
         lensLabel: (kind: LensKind) => lensLabelFor({ lens: kind, isBranchless }),
         handlers: {
           toOverview: () => setActiveLens(sessionId, null),
@@ -88,6 +91,7 @@ export const useSessionCrumbs = ({ session }: Params): ReadonlyArray<BreadcrumbC
       selectedWorkflowRunId,
       focusedPlanTitle,
       selectedChildLabel,
+      selectedChildHome,
       isBranchless,
       sessionId,
       setActiveLens,

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -119,11 +119,17 @@ parked beside it.
 - **Opening a child extends the trail and preserves every ancestor**:
   `Overview > {HomeLens} > {Agent}`. Selecting a sibling changes only the last
   crumb and the child region. The lens shell remains mounted beneath it.
-- **The home lens is resolved, not inherited.** If the active lens hosts an
-  agent list (`agents`, `resolve`, `workflows`) it wins; otherwise the agent's
-  own home lens, falling back to `agents`. Standing in Agents with a
-  workflow-step agent selected keeps the crumb on Agents, so an auto-advancing
-  step cannot rename it out from under the user.
+- **The trail describes the structure of the app, not the history of the
+  session.** A parent is derived from the object that is open, never from the
+  surface the jump came from: selecting an agent leaves the active lens where it
+  was, so that lens is only ever where the user came from. The activity feed,
+  the palette, a notification, a linked-work chip and a restored session are
+  shortcuts into a place that already has a parent, and none of them may rewrite
+  it. History is what Back is for.
+- **A child hangs off its own home lens**: a step under its run under
+  Workflows, an ad-hoc agent under Agents, a resolver under Resolve. The
+  overlay's back target still prefers the agent-list lens the user was standing
+  in, so Back returns where you were while the trail states where you are.
 - **A crumb with siblings is a switcher**: plain text when the agent is alone
   in its home lens, otherwise a popover that switches the open agent in place.
 - **The workflow case extends the same control**:


### PR DESCRIPTION
Opening a workflow step from the Activity feed landed on the right page and put **Overview** directly above it. A step is a child of its run, which is a child of Workflows, and that is true no matter which surface launched the jump.

## The real cause

`workSurfaceFocus` treats `{ kind: 'agent' }` as a focus change that deliberately leaves `activeLens` untouched, so while an agent overlay owns the surface the active lens is only ever *where the user came from*. `buildSessionBreadcrumb` was deriving the parent from exactly that lens, so a shortcut that never sets a lens got the lens of the surface it was launched from:

- the feed and a notification leave the lens on Overview (`null`), and no branch in the builder matched, so the trail collapsed to the single crumb `Overview` while a step chat was on screen;
- the palette, the sidebar agent rows, the `needs you` question rows, the board card and a restored session inherited whatever lens happened to be open, so the same step read `Overview > Agents > step` or `Overview > Resolve > step`.

Confirmed before changing anything with a `useSessionCrumbs` test driven by a real store: `activeLens = null` plus a selected step agent produced `['Overview']`. Only the case where the lens already said `workflows` was right, which is why #1481 looked correct.

## What changed

- `buildSessionBreadcrumb` takes `selectedChildHome` and parents an open child on that home: a step under its run under Workflows, an ad-hoc agent under Agents, a resolver under Resolve. The lens no longer participates in a child trail; it still parents a lens-level trail, which is what is on screen when no child is open. The old `lens + selectedChildLabel` branch is gone rather than left as an unreachable fallback, so there is one rule for a child.
- A workflow child whose run cannot be resolved now sits under the real **Workflows** list crumb (which also clears a stale focused run) instead of a lens crumb.
- `useSessionCrumbs` feeds that home from the selected agent's root through `useSelectedAgentHome`, the same object-derived resolution `switcherPeers` already used for the switcher, so the trail and the switcher can no longer disagree.
- `useSelectedAgentHome` moved from `components/SessionWorkspace/hooks/` to `features/session/hooks/`, since it now has a second consumer.
- `docs/navigation.md` reverses the bullet that said the active agent-list lens wins. The rule is now that the trail describes the structure of the app, not the history of the session.

## Every entry point checked

Fixed by this change, all of them reaching the builder through one path:

| Entry point | Before |
| --- | --- |
| Activity feed, `useTimelineOpen` | lens left on Overview, trail `Overview` only |
| Notification center | resets the lens to `null`, same collapse |
| Command palette | inherited the open lens |
| Sidebar agent rows and `needs you` rows | inherited the open lens |
| Stage board `openAgent` | inherited the persisted lens |
| Session restore on boot | inherited the persisted lens |
| Agent started toast, chat child and parent hops, resolver lanes, questions pane, review board, plan studio, diff viewer, PR and MR panels, explore spawn | inherited the open lens |
| Direct selection from the workflows lane | already correct, unchanged |

Checked and deliberately left alone: the run and plan trails still key off the lens, because a focused run or plan is invisible state until its lens mounts the pane, so there the lens *is* what is on screen. `startWorkflowRun`, `WorkflowsPane` and `PlanRailCard` need nothing.

## What I decided that the task did not specify

- **Back stays history.** `resolveOverlayHome` still prefers the agent-list lens the user was standing in, so Escape and the overlay back button return where you were while the trail states where you are. The test that asserted this through crumb labels now asserts it through the Escape handler and expects the workflow trail.
- **The doc bullet is reversed, not softened.** Its old rationale (an auto-advancing step must not rename the crumb out from under the user standing in Agents) is now served by Back rather than by the trail.

## Deliberately left out

The crumb bar is untouched: no restyle, no second breadcrumb component, and the agent switcher on the last crumb keeps its `fixed` popover strategy. `ChatBreadcrumb` is a chat header, not a page trail, so it is out of scope.

## Verification

Run from the worktree root:

- `pnpm typecheck`: 5 successful, 5 total
- `pnpm lint`: 0 tasks executed (no package implements it, per CONVENTIONS.md)
- `pnpm test`: 694 test files, 5998 tests, all passed
- `pnpm build`: 1 successful, 1 total
- `pnpm knip --include files,duplicates,unlisted` (the CI shape): clean, configuration hints only

New tests: 6 in `useSessionCrumbs/index.test.ts` covering a step from the feed, the same step from the workflows lens, the same step from another lens, an ad-hoc agent, a resolver, and both navigating crumbs; 3 more in `sessionBreadcrumb.test.ts` covering the shortcut homes, lens independence and a child winning over a focused plan.

Not verified visually: a dev server from another worktree owns the port, so I did not see this rendered.

Made with [Cursor](https://cursor.com)