### PR TITLE
refactor(desktop): one type scale across the panes, and every icon control says what it does

### DIFF
--- a/apps/desktop/src/__tests__/helpers/tooltip.ts
+++ b/apps/desktop/src/__tests__/helpers/tooltip.ts
@@ -3,12 +3,26 @@ import { vi } from 'vitest';
 
 const HOVER_INTENT_MS = 400;
 
+const anchorOf = ({ element }: { element: HTMLElement }): HTMLElement => {
+  const anchor = element.parentElement;
+  if (anchor === null) {
+    throw new Error('a disabled control needs a tooltip anchor to take its hover');
+  }
+  return anchor;
+};
+
+const isDisabled = ({ element }: { element: HTMLElement }): boolean =>
+  element instanceof HTMLButtonElement && element.disabled;
+
 export const tooltipTextOf = ({ element }: { element: HTMLElement }): string => {
+  const hovered = isDisabled({ element }) ? anchorOf({ element }) : element;
   vi.useFakeTimers();
-  fireEvent.mouseEnter(element);
+  fireEvent.mouseEnter(hovered);
   act(() => {
     vi.advanceTimersByTime(HOVER_INTENT_MS);
   });
   vi.useRealTimers();
-  return screen.getByRole('tooltip').textContent ?? '';
+  const text = screen.getByRole('tooltip').textContent ?? '';
+  fireEvent.mouseLeave(hovered);
+  return text;
 };

--- a/apps/desktop/src/__tests__/helpers/tooltip.ts
+++ b/apps/desktop/src/__tests__/helpers/tooltip.ts
@@ -1,0 +1,14 @@
+import { act, fireEvent, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+
+const HOVER_INTENT_MS = 400;
+
+export const tooltipTextOf = ({ element }: { element: HTMLElement }): string => {
+  vi.useFakeTimers();
+  fireEvent.mouseEnter(element);
+  act(() => {
+    vi.advanceTimersByTime(HOVER_INTENT_MS);
+  });
+  vi.useRealTimers();
+  return screen.getByRole('tooltip').textContent ?? '';
+};

--- a/apps/desktop/src/__tests__/regressions/icon-only-controls-carry-a-tooltip.test.ts
+++ b/apps/desktop/src/__tests__/regressions/icon-only-controls-carry-a-tooltip.test.ts
@@ -123,22 +123,24 @@ const rendersOwnText = ({ body }: { body: string }): boolean => {
 const rendersAnIcon = ({ body }: { body: string }): boolean =>
   /<[A-Z]\w*\s[^>]*(size=|aria-hidden)/.test(body);
 
-const hasTooltipAncestor = ({ source, from }: { source: string; from: number }): boolean => {
+const NOT_FOUND = -1;
+
+const tooltipDistance = ({ source, from }: { source: string; from: number }): number => {
   let cursor = from - 1;
   for (let hop = 0; hop < 3; hop++) {
     while (cursor >= 0 && /\s/.test(source.charAt(cursor))) {
       cursor--;
     }
     if (source.charAt(cursor) !== '>') {
-      return false;
+      return NOT_FOUND;
     }
     const start = source.lastIndexOf('<', cursor);
     if (/^<Tooltip\b/.test(source.slice(start, cursor + 1))) {
-      return true;
+      return hop;
     }
     cursor = start - 1;
   }
-  return false;
+  return NOT_FOUND;
 };
 
 type Offender = { location: string; reason: string };
@@ -175,12 +177,25 @@ const auditFile = ({ file, root }: { file: string; root: string }): Audit => {
     const line = source.slice(0, start).split('\n').length;
     const location = `${relative(root, file)}:${line}`;
     const canBeDisabled = /\sdisabled(?:=|\s|$)/.test(openTag);
-    if (/\stitle=/.test(openTag) && !canBeDisabled) {
-      offenders.push({ location, reason: 'carries a native title' });
+    const hasTitle = /\stitle=/.test(openTag);
+    const distance = tooltipDistance({ source, from: start });
+
+    if (distance === NOT_FOUND) {
+      offenders.push({ location, reason: 'has no Tooltip' });
       continue;
     }
-    if (!hasTooltipAncestor({ source, from: start })) {
-      offenders.push({ location, reason: 'has no Tooltip' });
+    if (hasTitle && !canBeDisabled) {
+      offenders.push({ location, reason: 'carries a native title it does not need' });
+      continue;
+    }
+    // the tooltip opens on whatever the Tooltip wraps, so a wrapper between the two
+    // still receives the hover the disabled control itself would swallow
+    const tooltipReachesTheDisabledState = distance > 0;
+    if (canBeDisabled && !hasTitle && !tooltipReachesTheDisabledState) {
+      offenders.push({
+        location,
+        reason: 'can go disabled with nothing left to explain it',
+      });
     }
   }
   return { offenders, inspected };
@@ -213,7 +228,10 @@ describe('an icon-only control', () => {
         'A control whose only content is an icon needs a tooltip: the aria-label',
         'names it for assistive tech, and nothing at all names it for the pointer.',
         'The native title waits a second and renders in the OS chrome, so wrap the',
-        'control in the shared Tooltip instead. Offenders:',
+        'control in the shared Tooltip instead. A control that can go disabled is',
+        'the exception, since a disabled element dispatches no pointer events: give',
+        'it a title for that state, or let the Tooltip wrap something around it that',
+        'can still take the hover. Offenders:',
         offenders.join('\n'),
       ].join('\n'),
     ).toEqual([]);

--- a/apps/desktop/src/__tests__/regressions/icon-only-controls-carry-a-tooltip.test.ts
+++ b/apps/desktop/src/__tests__/regressions/icon-only-controls-carry-a-tooltip.test.ts
@@ -116,23 +116,25 @@ const rendersOwnText = ({ body }: { body: string }): boolean => {
   if (literalText) {
     return true;
   }
-  // an interpolated child with no element inside it resolves to text, not an icon
-  return childExpressions({ body }).some((expression) => !expression.includes('<'));
+  const interpolationsResolvingToText = childExpressions({ body }).filter(
+    (expression) => !expression.includes('<'),
+  );
+  return interpolationsResolvingToText.length > 0;
 };
 
 const rendersAnIcon = ({ body }: { body: string }): boolean =>
   /<[A-Z]\w*\s[^>]*(size=|aria-hidden)/.test(body);
 
-const NOT_FOUND = -1;
+const NO_TOOLTIP = -1;
 
-const tooltipDistance = ({ source, from }: { source: string; from: number }): number => {
+const elementsUpToTooltip = ({ source, from }: { source: string; from: number }): number => {
   let cursor = from - 1;
   for (let hop = 0; hop < 3; hop++) {
     while (cursor >= 0 && /\s/.test(source.charAt(cursor))) {
       cursor--;
     }
     if (source.charAt(cursor) !== '>') {
-      return NOT_FOUND;
+      return NO_TOOLTIP;
     }
     const start = source.lastIndexOf('<', cursor);
     if (/^<Tooltip\b/.test(source.slice(start, cursor + 1))) {
@@ -140,7 +142,7 @@ const tooltipDistance = ({ source, from }: { source: string; from: number }): nu
     }
     cursor = start - 1;
   }
-  return NOT_FOUND;
+  return NO_TOOLTIP;
 };
 
 type Offender = { location: string; reason: string };
@@ -177,24 +179,19 @@ const auditFile = ({ file, root }: { file: string; root: string }): Audit => {
     const line = source.slice(0, start).split('\n').length;
     const location = `${relative(root, file)}:${line}`;
     const canBeDisabled = /\sdisabled(?:=|\s|$)/.test(openTag);
-    const hasTitle = /\stitle=/.test(openTag);
-    const distance = tooltipDistance({ source, from: start });
-
-    if (distance === NOT_FOUND) {
+    if (/\stitle=/.test(openTag)) {
+      offenders.push({ location, reason: 'carries a native title' });
+      continue;
+    }
+    const hops = elementsUpToTooltip({ source, from: start });
+    if (hops === NO_TOOLTIP) {
       offenders.push({ location, reason: 'has no Tooltip' });
       continue;
     }
-    if (hasTitle && !canBeDisabled) {
-      offenders.push({ location, reason: 'carries a native title it does not need' });
-      continue;
-    }
-    // the tooltip opens on whatever the Tooltip wraps, so a wrapper between the two
-    // still receives the hover the disabled control itself would swallow
-    const tooltipReachesTheDisabledState = distance > 0;
-    if (canBeDisabled && !hasTitle && !tooltipReachesTheDisabledState) {
+    if (canBeDisabled && hops > 0) {
       offenders.push({
         location,
-        reason: 'can go disabled with nothing left to explain it',
+        reason: 'can go disabled behind a wrapper, where Tooltip cannot anchor it',
       });
     }
   }
@@ -229,9 +226,10 @@ describe('an icon-only control', () => {
         'names it for assistive tech, and nothing at all names it for the pointer.',
         'The native title waits a second and renders in the OS chrome, so wrap the',
         'control in the shared Tooltip instead. A control that can go disabled is',
-        'the exception, since a disabled element dispatches no pointer events: give',
-        'it a title for that state, or let the Tooltip wrap something around it that',
-        'can still take the hover. Offenders:',
+        'the direct child of its Tooltip, never wrapped in a hand-rolled span: the',
+        'primitive reads disabled off its child to anchor the listeners somewhere',
+        'the pointer can still reach. Shape that anchor with anchorClassName.',
+        'Offenders:',
         offenders.join('\n'),
       ].join('\n'),
     ).toEqual([]);

--- a/apps/desktop/src/__tests__/regressions/icon-only-controls-carry-a-tooltip.test.ts
+++ b/apps/desktop/src/__tests__/regressions/icon-only-controls-carry-a-tooltip.test.ts
@@ -1,0 +1,225 @@
+import { readdirSync, readFileSync, statSync } from 'fs';
+import { join, relative } from 'path';
+import { describe, expect, it } from 'vitest';
+
+const ROOTS = [
+  join(__dirname, '..', '..'),
+  join(__dirname, '..', '..', '..', '..', '..', 'packages', 'ui', 'src'),
+];
+
+const SKIP_SEGMENTS = new Set(['__tests__', 'node_modules', 'dist']);
+
+const listComponentFiles = (dir: string, acc: string[] = []): string[] => {
+  for (const entry of readdirSync(dir)) {
+    if (SKIP_SEGMENTS.has(entry)) {
+      continue;
+    }
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      listComponentFiles(full, acc);
+      continue;
+    }
+    if (entry.endsWith('.tsx') && !entry.includes('.test.')) {
+      acc.push(full);
+    }
+  }
+  return acc;
+};
+
+const openTagEnd = ({ source, from }: { source: string; from: number }): number => {
+  let depth = 0;
+  for (let i = from; i < source.length; i++) {
+    const char = source[i];
+    if (char === '{') {
+      depth++;
+      continue;
+    }
+    if (char === '}') {
+      depth--;
+      continue;
+    }
+    if (char === '>' && depth === 0) {
+      return i;
+    }
+  }
+  return -1;
+};
+
+const closeTagEnd = ({ source, from }: { source: string; from: number }): number => {
+  let cursor = from + 1;
+  let nested = 0;
+  while (cursor < source.length) {
+    const nextOpen = source.indexOf('<button', cursor);
+    const nextClose = source.indexOf('</button>', cursor);
+    if (nextClose === -1) {
+      return -1;
+    }
+    if (nextOpen !== -1 && nextOpen < nextClose) {
+      nested++;
+      cursor = nextOpen + '<button'.length;
+      continue;
+    }
+    if (nested === 0) {
+      return nextClose + '</button>'.length;
+    }
+    nested--;
+    cursor = nextClose + '</button>'.length;
+  }
+  return -1;
+};
+
+const PLACEHOLDER = '\u0000';
+
+const childExpressions = ({ body }: { body: string }): string[] => {
+  const found: string[] = [];
+  let cursor = 0;
+  let tagDepth = 0;
+  while (cursor < body.length) {
+    const char = body[cursor];
+    if (char === '<') {
+      tagDepth++;
+      cursor++;
+      continue;
+    }
+    if (char === '>' && tagDepth > 0) {
+      tagDepth--;
+      cursor++;
+      continue;
+    }
+    if (char !== '{' || tagDepth > 0) {
+      cursor++;
+      continue;
+    }
+    let braces = 0;
+    let end = cursor;
+    while (end < body.length) {
+      const inner = body[end];
+      braces += inner === '{' ? 1 : inner === '}' ? -1 : 0;
+      if (braces === 0) {
+        break;
+      }
+      end++;
+    }
+    found.push(body.slice(cursor, end + 1));
+    cursor = end + 1;
+  }
+  return found;
+};
+
+const rendersOwnText = ({ body }: { body: string }): boolean => {
+  const literalText = body
+    .replace(/<[^>]*>/g, PLACEHOLDER)
+    .replace(/\{[^]*?\}/g, PLACEHOLDER)
+    .split(PLACEHOLDER)
+    .map((chunk) => chunk.trim())
+    .some((chunk) => chunk.length > 0 && !/^[{}()/]+$/.test(chunk));
+  if (literalText) {
+    return true;
+  }
+  // an interpolated child with no element inside it resolves to text, not an icon
+  return childExpressions({ body }).some((expression) => !expression.includes('<'));
+};
+
+const rendersAnIcon = ({ body }: { body: string }): boolean =>
+  /<[A-Z]\w*\s[^>]*(size=|aria-hidden)/.test(body);
+
+const hasTooltipAncestor = ({ source, from }: { source: string; from: number }): boolean => {
+  let cursor = from - 1;
+  for (let hop = 0; hop < 3; hop++) {
+    while (cursor >= 0 && /\s/.test(source.charAt(cursor))) {
+      cursor--;
+    }
+    if (source.charAt(cursor) !== '>') {
+      return false;
+    }
+    const start = source.lastIndexOf('<', cursor);
+    if (/^<Tooltip\b/.test(source.slice(start, cursor + 1))) {
+      return true;
+    }
+    cursor = start - 1;
+  }
+  return false;
+};
+
+type Offender = { location: string; reason: string };
+
+type Audit = { offenders: Offender[]; inspected: number };
+
+const auditFile = ({ file, root }: { file: string; root: string }): Audit => {
+  const source = readFileSync(file, 'utf8');
+  const offenders: Offender[] = [];
+  let inspected = 0;
+  const buttons = /<button\b/g;
+  let match = buttons.exec(source);
+  while (match !== null) {
+    const start = match.index;
+    const tagEnd = openTagEnd({ source, from: start });
+    match = buttons.exec(source);
+    if (tagEnd === -1) {
+      continue;
+    }
+    const openTag = source.slice(start, tagEnd + 1);
+    if (!/aria-label/.test(openTag)) {
+      continue;
+    }
+    const selfClosing = openTag.trimEnd().endsWith('/>');
+    const end = selfClosing ? tagEnd + 1 : closeTagEnd({ source, from: tagEnd });
+    if (end === -1) {
+      continue;
+    }
+    const body = selfClosing ? '' : source.slice(tagEnd + 1, end - '</button>'.length);
+    if (rendersOwnText({ body }) || !rendersAnIcon({ body })) {
+      continue;
+    }
+    inspected++;
+    const line = source.slice(0, start).split('\n').length;
+    const location = `${relative(root, file)}:${line}`;
+    const canBeDisabled = /\sdisabled(?:=|\s|$)/.test(openTag);
+    if (/\stitle=/.test(openTag) && !canBeDisabled) {
+      offenders.push({ location, reason: 'carries a native title' });
+      continue;
+    }
+    if (!hasTooltipAncestor({ source, from: start })) {
+      offenders.push({ location, reason: 'has no Tooltip' });
+    }
+  }
+  return { offenders, inspected };
+};
+
+const auditEverything = (): Audit => {
+  const offenders: Offender[] = [];
+  let inspected = 0;
+  for (const root of ROOTS) {
+    for (const file of listComponentFiles(root)) {
+      const audit = auditFile({ file, root });
+      offenders.push(...audit.offenders);
+      inspected += audit.inspected;
+    }
+  }
+  return { offenders, inspected };
+};
+
+const FLOOR = 80;
+
+describe('an icon-only control', () => {
+  it('says what it does through the shared Tooltip, never a native title', () => {
+    const offenders = auditEverything().offenders.map(
+      (offender) => `${offender.location} ${offender.reason}`,
+    );
+
+    expect(
+      offenders,
+      [
+        'A control whose only content is an icon needs a tooltip: the aria-label',
+        'names it for assistive tech, and nothing at all names it for the pointer.',
+        'The native title waits a second and renders in the OS chrome, so wrap the',
+        'control in the shared Tooltip instead. Offenders:',
+        offenders.join('\n'),
+      ].join('\n'),
+    ).toEqual([]);
+  });
+
+  it('is still being found, so the sweep above cannot pass by seeing nothing', () => {
+    expect(auditEverything().inspected).toBeGreaterThanOrEqual(FLOOR);
+  });
+});

--- a/apps/desktop/src/__tests__/regressions/type-scale-whole-pixel-line-boxes.test.ts
+++ b/apps/desktop/src/__tests__/regressions/type-scale-whole-pixel-line-boxes.test.ts
@@ -1,0 +1,86 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { describe, expect, it } from 'vitest';
+
+const STYLES = join(__dirname, '..', '..', 'styles.css');
+
+const css = readFileSync(STYLES, 'utf8');
+
+const readTokenPx = ({ token }: { token: string }): number => {
+  const match = new RegExp(`${token}:\\s*(\\d+(?:\\.\\d+)?)px\\s*;`).exec(css);
+  if (match === null) {
+    throw new Error(`styles.css must declare ${token} as a px value`);
+  }
+  return Number(match[1]);
+};
+
+const hasToken = ({ token }: { token: string }): boolean => new RegExp(`${token}:`).test(css);
+
+const rootFontSizePx = (): number => {
+  const match = /#root\s*\{[^}]*font-size:\s*(\d+(?:\.\d+)?)px/.exec(css);
+  if (match === null) {
+    throw new Error('styles.css must declare the root font size in px');
+  }
+  return Number(match[1]);
+};
+
+const ROOT_PX = rootFontSizePx();
+const SPACING_PX = readTokenPx({ token: '--spacing' });
+
+const isWhole = (value: number): boolean => Number.isInteger(value);
+
+const leadingPx = ({ step }: { step: number }): number => step * SPACING_PX;
+
+const PINNED_GRADES = ['3xs', '2xs', 'sm'] as const;
+
+const UNPINNED_GRADES = ['xs', 'base', 'lg', 'xl'] as const;
+
+const CORRECTED_ROW_LEADING_STEPS = [4, 5] as const;
+
+describe('type scale line boxes on the corrected surfaces', () => {
+  it('reads a 15px root, the size the pinned line boxes were chosen against', () => {
+    expect(ROOT_PX).toBe(15);
+  });
+
+  it('keeps every pinned line box a whole pixel and taller than its glyph', () => {
+    for (const grade of PINNED_GRADES) {
+      const size = readTokenPx({ token: `--text-${grade}` });
+      const lineHeight = readTokenPx({ token: `--text-${grade}--line-height` });
+
+      expect(isWhole(lineHeight)).toBe(true);
+      expect(lineHeight).toBeGreaterThan(size);
+    }
+  });
+
+  it('leaves text-xs unpinned, which is why a repeated row pairs its own leading', () => {
+    expect(hasToken({ token: '--text-xs--line-height' })).toBe(false);
+    expect(readTokenPx({ token: '--text-xs' }) * 1.55).not.toBe(
+      Math.round(readTokenPx({ token: '--text-xs' }) * 1.55),
+    );
+  });
+
+  it('names every unpinned grade, so a row reaching for one knows to pair a leading', () => {
+    for (const grade of UNPINNED_GRADES) {
+      expect(hasToken({ token: `--text-${grade}--line-height` })).toBe(false);
+    }
+  });
+
+  it('resolves the leading a corrected row pairs to a whole pixel', () => {
+    for (const step of CORRECTED_ROW_LEADING_STEPS) {
+      const box = leadingPx({ step });
+
+      expect(isWhole(box)).toBe(true);
+      expect(box).toBeGreaterThan(readTokenPx({ token: '--text-xs' }));
+    }
+  });
+
+  it('matches the paired leading to the pinned box of the grade above it', () => {
+    expect(leadingPx({ step: 4 })).toBe(readTokenPx({ token: '--text-2xs--line-height' }));
+    expect(leadingPx({ step: 5 })).toBe(readTokenPx({ token: '--text-sm--line-height' }));
+  });
+
+  it('declares the spacing base in px, so a leading utility never follows the root', () => {
+    expect(css).toContain(`--spacing: ${SPACING_PX}px;`);
+    expect(isWhole(SPACING_PX)).toBe(true);
+  });
+});

--- a/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
+++ b/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
@@ -204,50 +204,54 @@ exports[`snapshot, empty states > NewSessionView: no workflows 1`] = `
               <div
                 class="flex shrink-0 flex-col items-end gap-1"
               >
-                <button
-                  aria-label="Open goal editor"
-                  class="inline-flex items-center justify-center rounded-md border border-border-soft p-1.5 text-muted-foreground motion-safe:transition-colors hover:border-border hover:bg-muted/50 hover:text-foreground disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
-                  type="button"
+                <span
+                  class="inline-flex"
                 >
-                  <svg
-                    aria-hidden="true"
-                    class="lucide lucide-expand"
-                    fill="none"
-                    height="13"
-                    stroke="currentColor"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    viewBox="0 0 24 24"
-                    width="13"
-                    xmlns="http://www.w3.org/2000/svg"
+                  <button
+                    aria-label="Open goal editor"
+                    class="inline-flex items-center justify-center rounded-md border border-border-soft p-1.5 text-muted-foreground motion-safe:transition-colors hover:border-border hover:bg-muted/50 hover:text-foreground disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
+                    type="button"
                   >
-                    <path
-                      d="m15 15 6 6"
-                    />
-                    <path
-                      d="m15 9 6-6"
-                    />
-                    <path
-                      d="M21 16v5h-5"
-                    />
-                    <path
-                      d="M21 8V3h-5"
-                    />
-                    <path
-                      d="M3 16v5h5"
-                    />
-                    <path
-                      d="m3 21 6-6"
-                    />
-                    <path
-                      d="M3 8V3h5"
-                    />
-                    <path
-                      d="M9 9 3 3"
-                    />
-                  </svg>
-                </button>
+                    <svg
+                      aria-hidden="true"
+                      class="lucide lucide-expand"
+                      fill="none"
+                      height="13"
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      viewBox="0 0 24 24"
+                      width="13"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="m15 15 6 6"
+                      />
+                      <path
+                        d="m15 9 6-6"
+                      />
+                      <path
+                        d="M21 16v5h-5"
+                      />
+                      <path
+                        d="M21 8V3h-5"
+                      />
+                      <path
+                        d="M3 16v5h5"
+                      />
+                      <path
+                        d="m3 21 6-6"
+                      />
+                      <path
+                        d="M3 8V3h5"
+                      />
+                      <path
+                        d="M9 9 3 3"
+                      />
+                    </svg>
+                  </button>
+                </span>
               </div>
             </div>
             <div
@@ -1084,50 +1088,54 @@ exports[`snapshot, error states > NewSessionView: form error 1`] = `
               <div
                 class="flex shrink-0 flex-col items-end gap-1"
               >
-                <button
-                  aria-label="Open goal editor"
-                  class="inline-flex items-center justify-center rounded-md border border-border-soft p-1.5 text-muted-foreground motion-safe:transition-colors hover:border-border hover:bg-muted/50 hover:text-foreground disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
-                  type="button"
+                <span
+                  class="inline-flex"
                 >
-                  <svg
-                    aria-hidden="true"
-                    class="lucide lucide-expand"
-                    fill="none"
-                    height="13"
-                    stroke="currentColor"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    viewBox="0 0 24 24"
-                    width="13"
-                    xmlns="http://www.w3.org/2000/svg"
+                  <button
+                    aria-label="Open goal editor"
+                    class="inline-flex items-center justify-center rounded-md border border-border-soft p-1.5 text-muted-foreground motion-safe:transition-colors hover:border-border hover:bg-muted/50 hover:text-foreground disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
+                    type="button"
                   >
-                    <path
-                      d="m15 15 6 6"
-                    />
-                    <path
-                      d="m15 9 6-6"
-                    />
-                    <path
-                      d="M21 16v5h-5"
-                    />
-                    <path
-                      d="M21 8V3h-5"
-                    />
-                    <path
-                      d="M3 16v5h5"
-                    />
-                    <path
-                      d="m3 21 6-6"
-                    />
-                    <path
-                      d="M3 8V3h5"
-                    />
-                    <path
-                      d="M9 9 3 3"
-                    />
-                  </svg>
-                </button>
+                    <svg
+                      aria-hidden="true"
+                      class="lucide lucide-expand"
+                      fill="none"
+                      height="13"
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      viewBox="0 0 24 24"
+                      width="13"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="m15 15 6 6"
+                      />
+                      <path
+                        d="m15 9 6-6"
+                      />
+                      <path
+                        d="M21 16v5h-5"
+                      />
+                      <path
+                        d="M21 8V3h-5"
+                      />
+                      <path
+                        d="M3 16v5h5"
+                      />
+                      <path
+                        d="m3 21 6-6"
+                      />
+                      <path
+                        d="M3 8V3h5"
+                      />
+                      <path
+                        d="M9 9 3 3"
+                      />
+                    </svg>
+                  </button>
+                </span>
               </div>
             </div>
             <div

--- a/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
+++ b/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
@@ -207,7 +207,6 @@ exports[`snapshot, empty states > NewSessionView: no workflows 1`] = `
                 <button
                   aria-label="Open goal editor"
                   class="inline-flex items-center justify-center rounded-md border border-border-soft p-1.5 text-muted-foreground motion-safe:transition-colors hover:border-border hover:bg-muted/50 hover:text-foreground disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
-                  title="Open goal editor"
                   type="button"
                 >
                   <svg
@@ -1088,7 +1087,6 @@ exports[`snapshot, error states > NewSessionView: form error 1`] = `
                 <button
                   aria-label="Open goal editor"
                   class="inline-flex items-center justify-center rounded-md border border-border-soft p-1.5 text-muted-foreground motion-safe:transition-colors hover:border-border hover:bg-muted/50 hover:text-foreground disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
-                  title="Open goal editor"
                   type="button"
                 >
                   <svg

--- a/apps/desktop/src/app/components/Toast/index.tsx
+++ b/apps/desktop/src/app/components/Toast/index.tsx
@@ -1,6 +1,6 @@
 import { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
 import { AlertCircle, AlertTriangle, Bell, CheckCircle2, Info, X } from 'lucide-react';
-import { cn } from '@goodboy/ui';
+import { cn, Tooltip } from '@goodboy/ui';
 
 export type ToastKind = 'info' | 'warning' | 'error' | 'success';
 
@@ -232,14 +232,16 @@ function ToastCard({ toast, onDismiss }: ToastCardProps) {
             </button>
           ) : null}
         </div>
-        <button
-          type="button"
-          className="ml-1 flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-muted-foreground/60 hover:bg-muted hover:text-foreground"
-          onClick={() => onDismiss(toast.id)}
-          aria-label="Dismiss notification"
-        >
-          <X size={13} aria-hidden />
-        </button>
+        <Tooltip content="Dismiss notification">
+          <button
+            type="button"
+            className="ml-1 flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-muted-foreground/60 hover:bg-muted hover:text-foreground"
+            onClick={() => onDismiss(toast.id)}
+            aria-label="Dismiss notification"
+          >
+            <X size={13} aria-hidden />
+          </button>
+        </Tooltip>
       </div>
     </div>
   );

--- a/apps/desktop/src/features/budget/components/BudgetStudio/AlertBanner.tsx
+++ b/apps/desktop/src/features/budget/components/BudgetStudio/AlertBanner.tsx
@@ -1,4 +1,4 @@
-import { formatUsd } from '@goodboy/ui';
+import { formatUsd, Tooltip } from '@goodboy/ui';
 import { TriangleAlert, X } from 'lucide-react';
 import type { BudgetAlert } from '@goodboy/types';
 import { providerLabel } from './lib';
@@ -46,14 +46,16 @@ export const AlertBanner = ({ alerts, onDismiss }: Props) => {
               className={exceeded ? 'shrink-0 text-danger' : 'shrink-0 text-warning'}
             />
             <span className="flex-1 text-xs text-foreground">{alertMessage(alert)}</span>
-            <button
-              type="button"
-              onClick={() => onDismiss(alert.id)}
-              aria-label="Dismiss alert"
-              className="shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
-            >
-              <X size={13} aria-hidden />
-            </button>
+            <Tooltip content="Dismiss alert">
+              <button
+                type="button"
+                onClick={() => onDismiss(alert.id)}
+                aria-label="Dismiss alert"
+                className="shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
+              >
+                <X size={13} aria-hidden />
+              </button>
+            </Tooltip>
           </li>
         );
       })}

--- a/apps/desktop/src/features/budget/components/BudgetStudio/TurnsTable.tsx
+++ b/apps/desktop/src/features/budget/components/BudgetStudio/TurnsTable.tsx
@@ -1,5 +1,13 @@
 import { useMemo, useState } from 'react';
-import { Button, Chip, EmptyState, formatTokens, formatUsd, formatUsdPrecise } from '@goodboy/ui';
+import {
+  Button,
+  Chip,
+  EmptyState,
+  formatTokens,
+  formatUsd,
+  formatUsdPrecise,
+  Tooltip,
+} from '@goodboy/ui';
 import type { SessionId } from '@goodboy/types';
 import { ArrowUpRight } from 'lucide-react';
 import { STORAGE_KEYS } from '../../../../shared/lib/storage-keys';
@@ -126,14 +134,16 @@ export const TurnsTable = ({
                       {formatSpent(record.estimatedCostUsd)}
                     </td>
                     <td className="px-2 py-2">
-                      <button
-                        type="button"
-                        aria-label={`Open session ${sessionGoal}`}
-                        onClick={() => onOpenSession(sessionId)}
-                        className="inline-flex size-5 items-center justify-center rounded-md text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] group-hover:opacity-100"
-                      >
-                        <ArrowUpRight size={12} aria-hidden />
-                      </button>
+                      <Tooltip content={`Open session ${sessionGoal}`}>
+                        <button
+                          type="button"
+                          aria-label={`Open session ${sessionGoal}`}
+                          onClick={() => onOpenSession(sessionId)}
+                          className="inline-flex size-5 items-center justify-center rounded-md text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] group-hover:opacity-100"
+                        >
+                          <ArrowUpRight size={12} aria-hidden />
+                        </button>
+                      </Tooltip>
                     </td>
                   </tr>
                 ))}

--- a/apps/desktop/src/features/changelog/components/ReleaseToast/index.tsx
+++ b/apps/desktop/src/features/changelog/components/ReleaseToast/index.tsx
@@ -4,6 +4,7 @@ import { CONCEPT_ICONS } from '../../../../shared/components/conceptIcons';
 import { useAppStore } from '../../../../store';
 import { useInstalledVersion } from '../../hooks/useInstalledVersion';
 import { useUnseenRelease } from '../../hooks/useUnseenRelease';
+import { Tooltip } from '@goodboy/ui';
 
 type Props = {
   readonly onOpenChangelog: () => void;
@@ -44,14 +45,16 @@ export const ReleaseToast = ({ onOpenChangelog }: Props) => {
           Read the changelog
         </button>
       </div>
-      <button
-        type="button"
-        aria-label="Dismiss release notice"
-        onClick={() => setDismissed(true)}
-        className="ml-1 flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-muted-foreground/60 hover:bg-muted hover:text-foreground"
-      >
-        <X size={13} aria-hidden />
-      </button>
+      <Tooltip content="Dismiss release notice">
+        <button
+          type="button"
+          aria-label="Dismiss release notice"
+          onClick={() => setDismissed(true)}
+          className="ml-1 flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-muted-foreground/60 hover:bg-muted hover:text-foreground"
+        >
+          <X size={13} aria-hidden />
+        </button>
+      </Tooltip>
     </div>
   );
 };

--- a/apps/desktop/src/features/chat/components/ChatInput/index.tsx
+++ b/apps/desktop/src/features/chat/components/ChatInput/index.tsx
@@ -1,6 +1,6 @@
 import { useRef, useCallback, useEffect, type KeyboardEvent as ReactKeyboardEvent } from 'react';
 import { Paperclip, Send, Square } from 'lucide-react';
-import { Divider, Textarea, cn, formatUsd } from '@goodboy/ui';
+import { cn, Divider, formatUsd, Textarea, Tooltip } from '@goodboy/ui';
 import type { Session, SessionId, TurnProviderOverride } from '@goodboy/types';
 import { resolveStoredModelSelection } from '@goodboy/core';
 import { useAppStore, useSessionCost } from '../../../../store';
@@ -488,42 +488,53 @@ export const ChatInput = ({ session, providerDisconnected = false }: Props) => {
               className="resize-none border-0 bg-transparent px-3 py-2 pr-12 text-sm text-foreground shadow-none placeholder:text-muted-foreground/60 focus-visible:border-0 focus-visible:shadow-none focus-visible:ring-0"
             />
             {isRunning && value.trim().length === 0 && attachments.length === 0 ? (
-              <button
-                type="button"
-                onClick={() => void cancelCurrentTurn(session.id)}
-                title="Cancel turn"
-                aria-label="Cancel turn"
-                className="absolute right-2 top-1/2 inline-flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-lg bg-danger/10 text-danger transition-colors hover:bg-danger/20"
-              >
-                <Square size={14} aria-hidden fill="currentColor" />
-              </button>
+              <Tooltip content="Cancel turn">
+                <button
+                  type="button"
+                  onClick={() => void cancelCurrentTurn(session.id)}
+                  aria-label="Cancel turn"
+                  className="absolute right-2 top-1/2 inline-flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-lg bg-danger/10 text-danger transition-colors hover:bg-danger/20"
+                >
+                  <Square size={14} aria-hidden fill="currentColor" />
+                </button>
+              </Tooltip>
             ) : (
-              <button
-                type="button"
-                onClick={() => void onSend()}
-                disabled={!canSend}
-                title={sendDisabledTitle ?? (isRunning ? 'Queue message (enter)' : 'Send (enter)')}
-                aria-label={isRunning ? 'Queue message' : 'Send message'}
-                className="absolute right-2 top-1/2 inline-flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-lg bg-primary text-primary-foreground shadow-sm transition-all hover:brightness-110 disabled:cursor-not-allowed disabled:bg-muted disabled:text-muted-foreground disabled:shadow-none"
+              <Tooltip
+                content={
+                  sendDisabledTitle ?? (isRunning ? 'Queue message (enter)' : 'Send (enter)')
+                }
               >
-                <Send size={14} aria-hidden className="-translate-x-px" />
-              </button>
+                <button
+                  type="button"
+                  onClick={() => void onSend()}
+                  disabled={!canSend}
+                  title={
+                    sendDisabledTitle ?? (isRunning ? 'Queue message (enter)' : 'Send (enter)')
+                  }
+                  aria-label={isRunning ? 'Queue message' : 'Send message'}
+                  className="absolute right-2 top-1/2 inline-flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-lg bg-primary text-primary-foreground shadow-sm transition-all hover:brightness-110 disabled:cursor-not-allowed disabled:bg-muted disabled:text-muted-foreground disabled:shadow-none"
+                >
+                  <Send size={14} aria-hidden className="-translate-x-px" />
+                </button>
+              </Tooltip>
             )}
           </div>
           <Divider />
           <div className="flex h-9 items-center justify-between gap-2 px-2.5">
             <div className="flex items-center gap-2">
               <PermissionModePicker session={session} activeProvider={routing.effectiveProvider} />
-              <button
-                type="button"
-                onClick={() => fileInputRef.current?.click()}
-                disabled={providerDisconnected}
-                title="Attach files"
-                aria-label="Attach files"
-                className="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-foreground/5 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40"
-              >
-                <Paperclip size={15} aria-hidden />
-              </button>
+              <Tooltip content="Attach files">
+                <button
+                  type="button"
+                  onClick={() => fileInputRef.current?.click()}
+                  disabled={providerDisconnected}
+                  title="Attach files"
+                  aria-label="Attach files"
+                  className="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-foreground/5 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  <Paperclip size={15} aria-hidden />
+                </button>
+              </Tooltip>
               <input
                 ref={fileInputRef}
                 type="file"

--- a/apps/desktop/src/features/chat/components/ChatInput/index.tsx
+++ b/apps/desktop/src/features/chat/components/ChatInput/index.tsx
@@ -503,16 +503,14 @@ export const ChatInput = ({ session, providerDisconnected = false }: Props) => {
                 content={
                   sendDisabledTitle ?? (isRunning ? 'Queue message (enter)' : 'Send (enter)')
                 }
+                anchorClassName="absolute right-2 top-1/2 -translate-y-1/2"
               >
                 <button
                   type="button"
                   onClick={() => void onSend()}
                   disabled={!canSend}
-                  title={
-                    sendDisabledTitle ?? (isRunning ? 'Queue message (enter)' : 'Send (enter)')
-                  }
                   aria-label={isRunning ? 'Queue message' : 'Send message'}
-                  className="absolute right-2 top-1/2 inline-flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-lg bg-primary text-primary-foreground shadow-sm transition-all hover:brightness-110 disabled:cursor-not-allowed disabled:bg-muted disabled:text-muted-foreground disabled:shadow-none"
+                  className="inline-flex h-7 w-7 items-center justify-center rounded-lg bg-primary text-primary-foreground shadow-sm transition-all hover:brightness-110 disabled:cursor-not-allowed disabled:bg-muted disabled:text-muted-foreground disabled:shadow-none"
                 >
                   <Send size={14} aria-hidden className="-translate-x-px" />
                 </button>
@@ -528,7 +526,6 @@ export const ChatInput = ({ session, providerDisconnected = false }: Props) => {
                   type="button"
                   onClick={() => fileInputRef.current?.click()}
                   disabled={providerDisconnected}
-                  title="Attach files"
                   aria-label="Attach files"
                   className="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-foreground/5 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40"
                 >

--- a/apps/desktop/src/features/chat/components/ChatInput/parts/QueuedMessages.tsx
+++ b/apps/desktop/src/features/chat/components/ChatInput/parts/QueuedMessages.tsx
@@ -1,6 +1,7 @@
 import { Clock, Paperclip, X } from 'lucide-react';
 import { RoutingBadge } from '../../../../../shared/components/RoutingBadge';
 import type { QueuedTurn } from '../lib';
+import { Tooltip } from '@goodboy/ui';
 
 type QueuedItem = Pick<QueuedTurn, 'id' | 'content' | 'attachments' | 'override'>;
 
@@ -67,15 +68,16 @@ export const QueuedMessages = ({
                 {attachmentCount}
               </span>
             )}
-            <button
-              type="button"
-              onClick={() => onRemove(item.id)}
-              title="Remove from queue"
-              aria-label="Remove from queue"
-              className="flex size-5 shrink-0 items-center justify-center rounded-md text-muted-foreground/60 transition-colors hover:bg-foreground/10 hover:text-foreground"
-            >
-              <X size={11} aria-hidden />
-            </button>
+            <Tooltip content="Remove from queue">
+              <button
+                type="button"
+                onClick={() => onRemove(item.id)}
+                aria-label="Remove from queue"
+                className="flex size-5 shrink-0 items-center justify-center rounded-md text-muted-foreground/60 transition-colors hover:bg-foreground/10 hover:text-foreground"
+              >
+                <X size={11} aria-hidden />
+              </button>
+            </Tooltip>
           </div>
         );
       })}

--- a/apps/desktop/src/features/chat/components/ChatView/ParallelColumn.tsx
+++ b/apps/desktop/src/features/chat/components/ChatView/ParallelColumn.tsx
@@ -1,7 +1,7 @@
 import { useLayoutEffect, useMemo, useRef } from 'react';
 import { ArrowDown } from 'lucide-react';
 import type { Agent, ProviderRunId } from '@goodboy/types';
-import { Divider, EmptyState, ScrollFade, StatusDot } from '@goodboy/ui';
+import { Divider, EmptyState, ScrollFade, StatusDot, Tooltip } from '@goodboy/ui';
 import { useAppStore, useTranscript } from '../../../../store';
 import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../shared/components/conceptIcons';
 import { filterEventsByRunId, reduceTranscript } from '../../utils/transcript-items';
@@ -118,18 +118,19 @@ export const ParallelColumn = ({
           )}
         </ScrollFade>
         {!pinned && (
-          <button
-            type="button"
-            aria-label="Jump to latest"
-            title="Jump to latest"
-            className="pointer-events-auto absolute bottom-3 left-1/2 z-10 -translate-x-1/2 flex h-8 w-8 items-center justify-center rounded-full border border-border-soft bg-background/90 ring-1 ring-border-soft transition-colors hover:bg-muted"
-            onClick={() => {
-              const el = scrollerRef.current;
-              el?.scrollTo({ top: el.scrollHeight, behavior: 'smooth' });
-            }}
-          >
-            <ArrowDown size={14} aria-hidden />
-          </button>
+          <Tooltip content="Jump to latest">
+            <button
+              type="button"
+              aria-label="Jump to latest"
+              className="pointer-events-auto absolute bottom-3 left-1/2 z-10 -translate-x-1/2 flex h-8 w-8 items-center justify-center rounded-full border border-border-soft bg-background/90 ring-1 ring-border-soft transition-colors hover:bg-muted"
+              onClick={() => {
+                const el = scrollerRef.current;
+                el?.scrollTo({ top: el.scrollHeight, behavior: 'smooth' });
+              }}
+            >
+              <ArrowDown size={14} aria-hidden />
+            </button>
+          </Tooltip>
         )}
       </div>
     </div>

--- a/apps/desktop/src/features/chat/components/ChatView/index.tsx
+++ b/apps/desktop/src/features/chat/components/ChatView/index.tsx
@@ -21,7 +21,7 @@ import type {
   TurnEvent,
   TurnProviderOverride,
 } from '@goodboy/types';
-import { Button, Divider, ScrollFade, cn } from '@goodboy/ui';
+import { Button, cn, Divider, ScrollFade, Tooltip } from '@goodboy/ui';
 import { PANE_RHYTHM } from '@goodboy/ui';
 import {
   EMPTY_ARRAY,
@@ -592,18 +592,19 @@ export const ChatView = ({ session, isActive = true, header }: Props) => {
           )}
         </ScrollFade>
         {!pinned && (
-          <button
-            type="button"
-            aria-label="Jump to latest"
-            title="Jump to latest"
-            className="pointer-events-auto absolute bottom-3 left-1/2 z-10 -translate-x-1/2 flex h-8 w-8 items-center justify-center rounded-full border border-border-soft bg-background/90 ring-1 ring-border-soft transition-colors hover:bg-muted"
-            onClick={() => {
-              const el = scrollerRef.current;
-              el?.scrollTo({ top: el.scrollHeight, behavior: 'smooth' });
-            }}
-          >
-            <ArrowDown size={14} aria-hidden />
-          </button>
+          <Tooltip content="Jump to latest">
+            <button
+              type="button"
+              aria-label="Jump to latest"
+              className="pointer-events-auto absolute bottom-3 left-1/2 z-10 -translate-x-1/2 flex h-8 w-8 items-center justify-center rounded-full border border-border-soft bg-background/90 ring-1 ring-border-soft transition-colors hover:bg-muted"
+              onClick={() => {
+                const el = scrollerRef.current;
+                el?.scrollTo({ top: el.scrollHeight, behavior: 'smooth' });
+              }}
+            >
+              <ArrowDown size={14} aria-hidden />
+            </button>
+          </Tooltip>
         )}
       </div>
       {selectedAgentId != null &&

--- a/apps/desktop/src/features/chat/components/ImageLightbox/index.tsx
+++ b/apps/desktop/src/features/chat/components/ImageLightbox/index.tsx
@@ -71,7 +71,7 @@ export const ImageLightbox = ({ src, alt, onClose, media = 'image' }: Props) => 
       <IconButton
         icon={X}
         label="Close image preview"
-        title="Close image preview (esc)"
+        tooltip="Close image preview (esc)"
         iconSize={18}
         onClick={requestClose}
         className={`absolute right-4 top-4 h-9 w-9 rounded-full border-0 bg-background/95 p-0 text-foreground shadow-lg ring-1 ring-border-soft transition-all duration-[180ms] ease-out hover:bg-background hover:text-foreground ${

--- a/apps/desktop/src/features/chat/components/NudgeCard/index.tsx
+++ b/apps/desktop/src/features/chat/components/NudgeCard/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, type ReactNode } from 'react';
 import { X } from 'lucide-react';
-import { cn, tintClasses } from '@goodboy/ui';
+import { cn, tintClasses, Tooltip } from '@goodboy/ui';
 import { TranscriptShell } from '../TranscriptShell';
 
 type NudgeSeverity = 'info' | 'warning' | 'success';
@@ -61,15 +61,17 @@ export const NudgeCard = ({
     <TranscriptShell tone={severity} variant="boxed" emphasis className="relative text-xs">
       <section data-testid={testId} aria-label={ariaLabel} className="flex flex-col gap-2">
         {onDismiss ? (
-          <button
-            type="button"
-            onClick={onDismiss}
-            aria-label="Dismiss"
-            className="absolute right-1.5 top-1.5 inline-flex h-5 w-5 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
-            data-testid={testId ? `${testId}-dismiss` : undefined}
-          >
-            <X size={12} aria-hidden />
-          </button>
+          <Tooltip content="Dismiss">
+            <button
+              type="button"
+              onClick={onDismiss}
+              aria-label="Dismiss"
+              className="absolute right-1.5 top-1.5 inline-flex h-5 w-5 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
+              data-testid={testId ? `${testId}-dismiss` : undefined}
+            >
+              <X size={12} aria-hidden />
+            </button>
+          </Tooltip>
         ) : null}
         <div className="flex items-start gap-2 pr-5">
           {icon ? (

--- a/apps/desktop/src/features/chat/components/TranscriptCards/AssistantText.test.tsx
+++ b/apps/desktop/src/features/chat/components/TranscriptCards/AssistantText.test.tsx
@@ -34,6 +34,14 @@ describe('AssistantText', () => {
     expect(root.className).toBe('group relative flex flex-col gap-2 text-sm leading-relaxed');
   });
 
+  it('keeps prose on the comfortable reading grade while chrome around it compresses', () => {
+    const { container } = render(<AssistantText text="assistant response" sessionId={null} />);
+    const root = container.firstElementChild!;
+
+    expect(root.className).toContain('text-sm');
+    expect(root.className).not.toContain('text-xs');
+  });
+
   it('hides copy when a non-first resolved marker belongs to a review thread', () => {
     extractAllCommentResolvedMock.mockReturnValueOnce([
       { threadId: 'local-1' },

--- a/apps/desktop/src/features/chat/components/TranscriptRowHeader/index.test.tsx
+++ b/apps/desktop/src/features/chat/components/TranscriptRowHeader/index.test.tsx
@@ -30,4 +30,18 @@ describe('TranscriptRowHeader', () => {
     expect(screen.queryByTestId('transcript-chevron')).toBeNull();
     expect(screen.getByTestId('skill-row').tagName).toBe('DIV');
   });
+
+  it('reads the row as a nested row: eyebrow, step-grade preview, metadata time', () => {
+    render(<TranscriptRowHeader tone="primary" eyebrow="tool" preview="read a file" meta="1.2s" />);
+
+    expect(screen.getByText('tool').className).toContain('text-2xs');
+    expect(screen.getByText('read a file').className).toContain('text-xs');
+    expect(screen.getByText('1.2s').className).toContain('text-3xs');
+  });
+
+  it('keeps the time off the grade its own label uses, so the row reads as one column', () => {
+    render(<TranscriptRowHeader tone="primary" eyebrow="tool" preview="read a file" meta="1.2s" />);
+
+    expect(screen.getByText('1.2s').className).not.toContain('text-2xs');
+  });
 });

--- a/apps/desktop/src/features/chat/components/TranscriptRowHeader/index.tsx
+++ b/apps/desktop/src/features/chat/components/TranscriptRowHeader/index.tsx
@@ -49,7 +49,7 @@ export const TranscriptRowHeader = ({
       {badge}
       <span className="min-w-0 flex-1 truncate text-xs text-foreground/60">{preview}</span>
       {meta != null && (
-        <span className="shrink-0 font-mono text-2xs tabular-nums text-muted-foreground">
+        <span className="shrink-0 font-mono text-3xs tabular-nums text-muted-foreground">
           {meta}
         </span>
       )}

--- a/apps/desktop/src/features/context/components/QuestionsTab/QuestionCard/index.test.tsx
+++ b/apps/desktop/src/features/context/components/QuestionsTab/QuestionCard/index.test.tsx
@@ -48,7 +48,9 @@ describe('QuestionCard', () => {
     const { container } = render(<QuestionCard {...baseProps} justAnswered />);
     const root = container.firstElementChild as HTMLElement;
     const questionTint = tintClasses(CONCEPT_TONE.questions);
-    const feedbackIcon = screen.getByTitle(/dismiss question/i).querySelector('svg');
+    const feedbackIcon = screen
+      .getByRole('button', { name: /dismiss question/i })
+      .querySelector('svg');
 
     expect(root.className).toContain(questionTint.border);
     expect(root.className).not.toContain('success');
@@ -65,7 +67,7 @@ describe('QuestionCard', () => {
   it('fires onDismiss when the close button is clicked', () => {
     const onDismiss = vi.fn();
     render(<QuestionCard {...baseProps} onDismiss={onDismiss} />);
-    fireEvent.click(screen.getByTitle(/dismiss question/i));
+    fireEvent.click(screen.getByRole('button', { name: /dismiss question/i }));
     expect(onDismiss).toHaveBeenCalledWith('q1');
   });
 

--- a/apps/desktop/src/features/context/components/QuestionsTab/QuestionCard/index.tsx
+++ b/apps/desktop/src/features/context/components/QuestionsTab/QuestionCard/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Check, MessageCircleQuestion, X } from 'lucide-react';
-import { cn, Markdown, tintClasses } from '@goodboy/ui';
+import { cn, Markdown, tintClasses, Tooltip } from '@goodboy/ui';
 import type { OpenQuestion, OpenQuestionId, OpenQuestionSelectMode } from '@goodboy/types';
 import { formatRelativeAge } from '../../../../../shared/utils/relativeDate';
 import { CONCEPT_TONE } from '../../../../../shared/components/conceptIcons';
@@ -88,20 +88,21 @@ export const QuestionCard = ({
             className="min-w-0 gap-1.5 break-words text-sm font-medium leading-relaxed text-foreground"
           />
         </div>
-        <button
-          type="button"
-          onClick={() => onDismiss(question.id)}
-          className={cn(
-            'shrink-0 rounded-md p-1 text-muted-foreground/60 opacity-0 transition-[opacity,color,background-color] duration-150',
-            'hover:bg-muted hover:text-foreground focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/40',
-            'group-hover:opacity-100 motion-reduce:opacity-60',
-            animate && 'opacity-100',
-          )}
-          title="Dismiss question"
-          aria-label="Dismiss question"
-        >
-          {animate ? <Check size={12} className={warningTint.icon} /> : <X size={12} />}
-        </button>
+        <Tooltip content="Dismiss question">
+          <button
+            type="button"
+            onClick={() => onDismiss(question.id)}
+            className={cn(
+              'shrink-0 rounded-md p-1 text-muted-foreground/60 opacity-0 transition-[opacity,color,background-color] duration-150',
+              'hover:bg-muted hover:text-foreground focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/40',
+              'group-hover:opacity-100 motion-reduce:opacity-60',
+              animate && 'opacity-100',
+            )}
+            aria-label="Dismiss question"
+          >
+            {animate ? <Check size={12} className={warningTint.icon} /> : <X size={12} />}
+          </button>
+        </Tooltip>
         <div className="flex items-center gap-2 text-2xs text-muted-foreground">
           <span>{formatRelativeAge({ fromIso: question.createdAt })}</span>
           {question.ownedByStepOrdinal != null && (

--- a/apps/desktop/src/features/explore/components/ExplorePane/index.tsx
+++ b/apps/desktop/src/features/explore/components/ExplorePane/index.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
 import { ChevronDown, ChevronRight, ExternalLink, File, Folder, FolderSearch } from 'lucide-react';
-import { Button, EmptyState, Skeleton, cn } from '@goodboy/ui';
+import { Button, cn, EmptyState, Skeleton, Tooltip } from '@goodboy/ui';
 import type { SessionId } from '@goodboy/types';
 import {
   exploreList,
@@ -308,22 +308,26 @@ export const ExplorePane = ({ sessionId, sessionDir }: Props) => {
               )}
               <div className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover/explore-row:opacity-100 group-focus-within/explore-row:opacity-100">
                 {entry.isDir ? null : <ExploreSpawnPopover sessionId={sessionId} entry={entry} />}
-                <button
-                  type="button"
-                  onClick={() => void runOpenAction({ entry, reveal: false })}
-                  aria-label={`Open ${entry.name} outside the app`}
-                  className="rounded-md p-1.5 text-muted-foreground/70 transition-colors hover:bg-foreground/5 hover:text-foreground"
-                >
-                  <ExternalLink size={14} aria-hidden />
-                </button>
-                <button
-                  type="button"
-                  onClick={() => void runOpenAction({ entry, reveal: true })}
-                  aria-label={`Reveal ${entry.name} in file manager`}
-                  className="rounded-md p-1.5 text-muted-foreground/70 transition-colors hover:bg-foreground/5 hover:text-foreground"
-                >
-                  <FolderSearch size={14} aria-hidden />
-                </button>
+                <Tooltip content={`Open ${entry.name} outside the app`}>
+                  <button
+                    type="button"
+                    onClick={() => void runOpenAction({ entry, reveal: false })}
+                    aria-label={`Open ${entry.name} outside the app`}
+                    className="rounded-md p-1.5 text-muted-foreground/70 transition-colors hover:bg-foreground/5 hover:text-foreground"
+                  >
+                    <ExternalLink size={14} aria-hidden />
+                  </button>
+                </Tooltip>
+                <Tooltip content={`Reveal ${entry.name} in file manager`}>
+                  <button
+                    type="button"
+                    onClick={() => void runOpenAction({ entry, reveal: true })}
+                    aria-label={`Reveal ${entry.name} in file manager`}
+                    className="rounded-md p-1.5 text-muted-foreground/70 transition-colors hover:bg-foreground/5 hover:text-foreground"
+                  >
+                    <FolderSearch size={14} aria-hidden />
+                  </button>
+                </Tooltip>
               </div>
             </div>
             {actionError != null ? <p className="pl-8 text-xs text-danger">{actionError}</p> : null}

--- a/apps/desktop/src/features/github/components/GitHubStudio/OpenThread.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/OpenThread.tsx
@@ -1,5 +1,5 @@
 import { ExternalLink } from 'lucide-react';
-import { Chip } from '@goodboy/ui';
+import { Chip, Tooltip } from '@goodboy/ui';
 import type { CommentThread } from '../../comment-threads';
 import { isBot } from '../../comment-threads';
 import {
@@ -52,15 +52,16 @@ export const OpenThread = ({ thread, link, onOpenUrl }: Props) => {
             title="This comment is anchored to code that later commits changed"
           />
         ) : null}
-        <button
-          type="button"
-          onClick={() => onOpenUrl(head.url)}
-          title="Open in browser"
-          aria-label="Open in browser"
-          className="ml-auto rounded p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
-        >
-          <ExternalLink size={12} aria-hidden />
-        </button>
+        <Tooltip content="Open in browser">
+          <button
+            type="button"
+            onClick={() => onOpenUrl(head.url)}
+            aria-label="Open in browser"
+            className="ml-auto rounded p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+          >
+            <ExternalLink size={12} aria-hidden />
+          </button>
+        </Tooltip>
       </div>
 
       {head.path != null && head.path !== '' ? (

--- a/apps/desktop/src/features/github/components/GitHubStudio/ResolveBoard/ResolveCard.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/ResolveBoard/ResolveCard.tsx
@@ -1,5 +1,5 @@
 import type { AgentId, ProviderId } from '@goodboy/types';
-import { Button, Checkbox, Chip, ClampedProse, cn } from '@goodboy/ui';
+import { Button, Checkbox, Chip, ClampedProse, cn, Tooltip } from '@goodboy/ui';
 import { ArrowUpRight, ChevronDown, ExternalLink, RotateCcw } from 'lucide-react';
 import { modelEffortLevels } from '../../../../chat/utils/chat-constants';
 import { RoutingBadge } from '../../../../../shared/components/RoutingBadge';
@@ -74,15 +74,16 @@ export const ResolveCard = ({
             <div className="flex shrink-0 items-center gap-1.5">
               {link ? <ResolverStateBadge state={resolverBadgeState(link.status)} /> : null}
               {onOpenThread ? (
-                <button
-                  type="button"
-                  onClick={onOpenThread}
-                  title="Open the full thread"
-                  aria-label="Open the full thread"
-                  className="shrink-0 rounded p-0.5 text-muted-foreground/60 transition-colors hover:bg-muted hover:text-foreground"
-                >
-                  <ExternalLink size={12} aria-hidden />
-                </button>
+                <Tooltip content="Open the full thread">
+                  <button
+                    type="button"
+                    onClick={onOpenThread}
+                    aria-label="Open the full thread"
+                    className="shrink-0 rounded p-0.5 text-muted-foreground/60 transition-colors hover:bg-muted hover:text-foreground"
+                  >
+                    <ExternalLink size={12} aria-hidden />
+                  </button>
+                </Tooltip>
               ) : null}
             </div>
           </div>

--- a/apps/desktop/src/features/github/components/GitHubStudio/SectionBody.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/SectionBody.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 import type { PrDetail } from '@goodboy/types';
-import { ClampedProse, PANE_RHYTHM, Skeleton } from '@goodboy/ui';
+import { ClampedProse, PANE_RHYTHM, Skeleton, Tooltip } from '@goodboy/ui';
 import { AlertCircle, RefreshCw } from 'lucide-react';
 
 type Props = {
@@ -20,14 +20,16 @@ export const SectionBody = ({ detail, detailLoading, detailError, onRetry, child
           <div className="min-w-0 flex-1">
             <ClampedProse text={detailError} lines={2} className="text-xs text-danger" />
           </div>
-          <button
-            type="button"
-            onClick={onRetry}
-            aria-label="Retry"
-            className="rounded-md p-0.5 hover:bg-muted"
-          >
-            <RefreshCw size={12} aria-hidden />
-          </button>
+          <Tooltip content="Retry">
+            <button
+              type="button"
+              onClick={onRetry}
+              aria-label="Retry"
+              className="rounded-md p-0.5 hover:bg-muted"
+            >
+              <RefreshCw size={12} aria-hidden />
+            </button>
+          </Tooltip>
         </div>
       ) : detailLoading && detail == null ? (
         <div className="flex flex-col gap-2" role="status" aria-label="Loading pr data">

--- a/apps/desktop/src/features/github/components/Panel/index.tsx
+++ b/apps/desktop/src/features/github/components/Panel/index.tsx
@@ -72,12 +72,11 @@ export const GithubPanel = ({ hideSectionHeader }: { hideSectionHeader?: boolean
           </>
         )}
         <div className="flex-1" />
-        <Tooltip content="Refresh GitHub status">
+        <Tooltip content="Refresh GitHub status" anchorClassName="shrink-0">
           <button
             type="button"
             onClick={() => void onReload()}
             disabled={checking}
-            title="Refresh GitHub status"
             aria-label="Refresh GitHub status"
             className="flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground ring-1 ring-border-soft/40 transition-colors hover:bg-foreground/5 hover:text-foreground disabled:opacity-50"
           >

--- a/apps/desktop/src/features/github/components/Panel/index.tsx
+++ b/apps/desktop/src/features/github/components/Panel/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Check, AlertCircle, RefreshCw } from 'lucide-react';
-import { Button, cn, formatError, Input } from '@goodboy/ui';
+import { Button, cn, formatError, Input, Tooltip } from '@goodboy/ui';
 import { GithubIcon } from '@goodboy/ui';
 import type { SaveState } from '../../../../shared/types/saveState';
 import { useAppStore } from '../../../../store';
@@ -72,16 +72,18 @@ export const GithubPanel = ({ hideSectionHeader }: { hideSectionHeader?: boolean
           </>
         )}
         <div className="flex-1" />
-        <button
-          type="button"
-          onClick={() => void onReload()}
-          disabled={checking}
-          title="Refresh GitHub status"
-          aria-label="Refresh GitHub status"
-          className="flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground ring-1 ring-border-soft/40 transition-colors hover:bg-foreground/5 hover:text-foreground disabled:opacity-50"
-        >
-          <RefreshCw size={13} aria-hidden />
-        </button>
+        <Tooltip content="Refresh GitHub status">
+          <button
+            type="button"
+            onClick={() => void onReload()}
+            disabled={checking}
+            title="Refresh GitHub status"
+            aria-label="Refresh GitHub status"
+            className="flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground ring-1 ring-border-soft/40 transition-colors hover:bg-foreground/5 hover:text-foreground disabled:opacity-50"
+          >
+            <RefreshCw size={13} aria-hidden />
+          </button>
+        </Tooltip>
       </div>
 
       {status === null ? (

--- a/apps/desktop/src/features/integrations/components/IntegrationCredentialPicker/CredentialRow.tsx
+++ b/apps/desktop/src/features/integrations/components/IntegrationCredentialPicker/CredentialRow.tsx
@@ -53,7 +53,7 @@ export const CredentialRow = ({
         icon={Trash2}
         label={`Forget ${credential.label}`}
         disabled={isDisabled}
-        title={
+        tooltip={
           usedBy > 0
             ? `${usageLabel({ usedBy })}. Disconnect it there before removing the key.`
             : 'Remove this key from the keychain'

--- a/apps/desktop/src/features/integrations/components/IssuePicker/index.tsx
+++ b/apps/desktop/src/features/integrations/components/IssuePicker/index.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { cn, EmptyState, ScrollFade, Skeleton, useDropdown } from '@goodboy/ui';
+import { cn, EmptyState, ScrollFade, Skeleton, Tooltip, useDropdown } from '@goodboy/ui';
 import { ChevronDown, ExternalLink } from 'lucide-react';
 import type { IssueCandidate } from '../../fetchIssueCandidates';
 import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../shared/components/conceptIcons';
@@ -178,32 +178,36 @@ export const IssuePicker = ({
           onKeyDown={onKeyDown}
         />
         {value != null && value.url !== '' && (
+          <Tooltip content="Open issue in browser">
+            <button
+              type="button"
+              tabIndex={-1}
+              onClick={(event) => {
+                event.stopPropagation();
+                void openUrl(value.url);
+              }}
+              aria-label="Open issue in browser"
+              className="flex h-7 w-7 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            >
+              <ExternalLink size={12} aria-hidden />
+            </button>
+          </Tooltip>
+        )}
+        <Tooltip content={isOpen ? 'Close issue list' : 'Open issue list'}>
           <button
             type="button"
             tabIndex={-1}
-            onClick={(event) => {
-              event.stopPropagation();
-              void openUrl(value.url);
-            }}
-            aria-label="Open issue in browser"
+            onClick={togglePanel}
+            aria-label={isOpen ? 'Close issue list' : 'Open issue list'}
             className="flex h-7 w-7 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
           >
-            <ExternalLink size={12} aria-hidden />
+            <ChevronDown
+              size={13}
+              aria-hidden
+              className={cn('motion-safe:transition-transform', isOpen && 'rotate-180')}
+            />
           </button>
-        )}
-        <button
-          type="button"
-          tabIndex={-1}
-          onClick={togglePanel}
-          aria-label={isOpen ? 'Close issue list' : 'Open issue list'}
-          className="flex h-7 w-7 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-        >
-          <ChevronDown
-            size={13}
-            aria-hidden
-            className={cn('motion-safe:transition-transform', isOpen && 'rotate-180')}
-          />
-        </button>
+        </Tooltip>
       </div>
 
       {isOpen && pasted == null && isLoading && rows.length === 0 && (

--- a/apps/desktop/src/features/onboarding/OnboardingCard/ChecklistBody.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingCard/ChecklistBody.tsx
@@ -2,6 +2,7 @@ import { X } from 'lucide-react';
 import { collapse, visibleOnboardingSteps, type OnboardingGroup } from '../onboarding-store';
 import type { OnboardingProgress } from '../hooks/useOnboardingProgress';
 import { StepRow } from './StepRow';
+import { Tooltip } from '@goodboy/ui';
 
 const GROUP_LABEL: Record<OnboardingGroup, string> = {
   setup: 'Setup',
@@ -20,15 +21,16 @@ export const ChecklistBody = ({ progress }: Props) => {
     <>
       <div className="flex items-center justify-between">
         <span className="text-xs font-semibold tracking-tight text-foreground">Goodboy setup</span>
-        <button
-          type="button"
-          onClick={() => collapse()}
-          title="Hide onboarding checklist (reopen it from the top bar)"
-          aria-label="Hide onboarding checklist"
-          className="rounded-md p-0.5 text-muted-foreground/70 motion-safe:transition-colors hover:bg-foreground/5 hover:text-foreground"
-        >
-          <X size={11} aria-hidden />
-        </button>
+        <Tooltip content="Hide onboarding checklist (reopen it from the top bar)">
+          <button
+            type="button"
+            onClick={() => collapse()}
+            aria-label="Hide onboarding checklist"
+            className="rounded-md p-0.5 text-muted-foreground/70 motion-safe:transition-colors hover:bg-foreground/5 hover:text-foreground"
+          >
+            <X size={11} aria-hidden />
+          </button>
+        </Tooltip>
       </div>
       <div className="flex flex-col gap-2.5">
         {GROUP_ORDER.map((group) => {

--- a/apps/desktop/src/features/onboarding/OnboardingCard/CompletedBody.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingCard/CompletedBody.tsx
@@ -1,6 +1,7 @@
 import { X } from 'lucide-react';
 import { finish } from '../onboarding-store';
 import { CONCEPT_ICONS } from '../../../shared/components/conceptIcons';
+import { Tooltip } from '@goodboy/ui';
 
 export const CompletedBody = () => (
   <>
@@ -9,15 +10,16 @@ export const CompletedBody = () => (
         <CONCEPT_ICONS.decisions size={11} aria-hidden />
         Setup complete
       </span>
-      <button
-        type="button"
-        onClick={() => finish()}
-        title="Dismiss onboarding"
-        aria-label="Dismiss onboarding"
-        className="rounded-md p-0.5 text-muted-foreground/70 motion-safe:transition-colors hover:bg-foreground/5 hover:text-foreground"
-      >
-        <X size={11} aria-hidden />
-      </button>
+      <Tooltip content="Dismiss onboarding">
+        <button
+          type="button"
+          onClick={() => finish()}
+          aria-label="Dismiss onboarding"
+          className="rounded-md p-0.5 text-muted-foreground/70 motion-safe:transition-colors hover:bg-foreground/5 hover:text-foreground"
+        >
+          <X size={11} aria-hidden />
+        </button>
+      </Tooltip>
     </div>
     <p className="text-2xs leading-snug text-muted-foreground/80">
       That was the last step. Setup is complete.

--- a/apps/desktop/src/features/onboarding/OnboardingCard/index.test.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingCard/index.test.tsx
@@ -41,6 +41,7 @@ afterEach(() => {
   finishMock.mockReset();
 });
 
+import { tooltipTextOf } from '../../../__tests__/helpers/tooltip';
 import { OnboardingCard, OnboardingChip } from './index';
 
 describe('OnboardingCard', () => {
@@ -48,7 +49,7 @@ describe('OnboardingCard', () => {
     progress.collapsed = false;
     render(<OnboardingCard />);
     const hide = screen.getByRole('button', { name: 'Hide onboarding checklist' });
-    expect(hide.getAttribute('title')).toBe(
+    expect(tooltipTextOf({ element: hide })).toBe(
       'Hide onboarding checklist (reopen it from the top bar)',
     );
   });
@@ -57,7 +58,7 @@ describe('OnboardingCard', () => {
     progress.collapsed = false;
     render(<OnboardingCard />);
     const hide = screen.getByRole('button', { name: 'Hide onboarding checklist' });
-    expect(hide.getAttribute('title')).not.toMatch(/sidebar/i);
+    expect(tooltipTextOf({ element: hide })).not.toMatch(/sidebar/i);
   });
 });
 

--- a/apps/desktop/src/features/onboarding/OnboardingCard/index.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingCard/index.tsx
@@ -1,5 +1,5 @@
 import { X } from 'lucide-react';
-import { cn } from '@goodboy/ui';
+import { cn, Tooltip } from '@goodboy/ui';
 import { finish, reopen, visibleOnboardingSteps } from '../onboarding-store';
 import { useOnboardingProgress } from '../hooks/useOnboardingProgress';
 import { ChecklistBody } from './ChecklistBody';
@@ -52,17 +52,19 @@ export const OnboardingChip = () => {
           />
         ))}
       </button>
-      <button
-        type="button"
-        aria-label="Skip tutorial"
-        onClick={(event) => {
-          event.stopPropagation();
-          finish();
-        }}
-        className="flex items-center justify-center rounded-sm text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100"
-      >
-        <X size={10} aria-hidden />
-      </button>
+      <Tooltip content="Skip tutorial">
+        <button
+          type="button"
+          aria-label="Skip tutorial"
+          onClick={(event) => {
+            event.stopPropagation();
+            finish();
+          }}
+          className="flex items-center justify-center rounded-sm text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100"
+        >
+          <X size={10} aria-hidden />
+        </button>
+      </Tooltip>
     </div>
   );
 };

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/steps/PreferencesStep.test.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/steps/PreferencesStep.test.tsx
@@ -3,6 +3,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { ProviderId, WorkspaceId } from '@goodboy/types';
+import { tooltipTextOf } from '../../../../__tests__/helpers/tooltip';
 import { DEFAULT_BRANCH_PREFIX, settingBranchPrefix } from '../../../settings/settings';
 
 const { state } = vi.hoisted(() => ({
@@ -82,8 +83,8 @@ describe('PreferencesStep', () => {
       const gemini = screen.getByRole('button', { name: /gemini/i }) as HTMLButtonElement;
       expect(codex.disabled).toBe(true);
       expect(gemini.disabled).toBe(true);
-      expect(codex.getAttribute('title')).toContain('not connected');
-      expect(gemini.getAttribute('title')).toContain('not connected');
+      expect(tooltipTextOf({ element: codex })).toContain('not connected');
+      expect(tooltipTextOf({ element: gemini })).toContain('not connected');
     });
 
     it('leaves connected providers enabled', () => {

--- a/apps/desktop/src/features/permissions/components/DiffViewerDialog/DiffToolbar.tsx
+++ b/apps/desktop/src/features/permissions/components/DiffViewerDialog/DiffToolbar.tsx
@@ -100,7 +100,6 @@ export const DiffToolbar = ({
                 type="button"
                 onClick={onRefresh}
                 disabled={refreshing}
-                title="Refresh git state"
                 aria-label="Refresh git state"
                 className={cn(TOOLBAR_ICON_BTN, 'disabled:opacity-50')}
               >

--- a/apps/desktop/src/features/permissions/components/DiffViewerDialog/DiffToolbar.tsx
+++ b/apps/desktop/src/features/permissions/components/DiffViewerDialog/DiffToolbar.tsx
@@ -1,5 +1,5 @@
 import { Check, GitBranch, RefreshCw, X } from 'lucide-react';
-import { Chip, cn, Divider } from '@goodboy/ui';
+import { Chip, cn, Divider, Tooltip } from '@goodboy/ui';
 import type { WorktreeStatus } from '@goodboy/types';
 import { distanceAhead, distanceBehind } from '../../../../shared/lib/gitStatus';
 import { TOOLBAR_ICON_BTN } from './lib';
@@ -95,27 +95,30 @@ export const DiffToolbar = ({
 
         <div className="flex shrink-0 items-center gap-0.5">
           {onRefresh ? (
-            <button
-              type="button"
-              onClick={onRefresh}
-              disabled={refreshing}
-              title="Refresh git state"
-              aria-label="Refresh git state"
-              className={cn(TOOLBAR_ICON_BTN, 'disabled:opacity-50')}
-            >
-              <RefreshCw size={12} aria-hidden />
-            </button>
+            <Tooltip content="Refresh git state">
+              <button
+                type="button"
+                onClick={onRefresh}
+                disabled={refreshing}
+                title="Refresh git state"
+                aria-label="Refresh git state"
+                className={cn(TOOLBAR_ICON_BTN, 'disabled:opacity-50')}
+              >
+                <RefreshCw size={12} aria-hidden />
+              </button>
+            </Tooltip>
           ) : null}
           {showClose ? (
-            <button
-              type="button"
-              onClick={onClose}
-              title="Close"
-              aria-label="Close"
-              className={TOOLBAR_ICON_BTN}
-            >
-              <X size={13} />
-            </button>
+            <Tooltip content="Close">
+              <button
+                type="button"
+                onClick={onClose}
+                aria-label="Close"
+                className={TOOLBAR_ICON_BTN}
+              >
+                <X size={13} />
+              </button>
+            </Tooltip>
           ) : null}
         </div>
       </div>

--- a/apps/desktop/src/features/permissions/components/DiffViewerDialog/DiffViewerContent.tsx
+++ b/apps/desktop/src/features/permissions/components/DiffViewerDialog/DiffViewerContent.tsx
@@ -1,7 +1,15 @@
 import { useEffect, useMemo, useState, useCallback, useRef, useLayoutEffect } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { AlertTriangle, GitBranch, RefreshCw, X } from 'lucide-react';
-import { cn, DiffLayoutToggle, Divider, formatError, ScrollFade, Skeleton } from '@goodboy/ui';
+import {
+  cn,
+  DiffLayoutToggle,
+  Divider,
+  formatError,
+  ScrollFade,
+  Skeleton,
+  Tooltip,
+} from '@goodboy/ui';
 import { getDefaultTurnModel, parseUnifiedDiff } from '@goodboy/core';
 import type {
   BranchCommit,
@@ -863,15 +871,16 @@ export const DiffViewerContent = ({
             <div className="flex min-w-0 flex-wrap items-center justify-end gap-1.5 pt-0.5">
               {isGitAware &&
                 (isDefaultView ? (
-                  <button
-                    type="button"
-                    onClick={() => setRefreshTick((tick) => tick + 1)}
-                    title="Refresh git state"
-                    aria-label="Refresh git state"
-                    className={cn(TOOLBAR_ICON_BTN, 'disabled:opacity-50')}
-                  >
-                    <RefreshCw size={12} aria-hidden />
-                  </button>
+                  <Tooltip content="Refresh git state">
+                    <button
+                      type="button"
+                      onClick={() => setRefreshTick((tick) => tick + 1)}
+                      aria-label="Refresh git state"
+                      className={cn(TOOLBAR_ICON_BTN, 'disabled:opacity-50')}
+                    >
+                      <RefreshCw size={12} aria-hidden />
+                    </button>
+                  </Tooltip>
                 ) : (
                   <DiffViewSelector
                     view={view}
@@ -902,15 +911,16 @@ export const DiffViewerContent = ({
                     />
                   </div>
                   {showToolbarClose ? (
-                    <button
-                      type="button"
-                      onClick={onClose}
-                      title="Close"
-                      aria-label="Close"
-                      className={TOOLBAR_ICON_BTN}
-                    >
-                      <X size={13} />
-                    </button>
+                    <Tooltip content="Close">
+                      <button
+                        type="button"
+                        onClick={onClose}
+                        aria-label="Close"
+                        className={TOOLBAR_ICON_BTN}
+                      >
+                        <X size={13} />
+                      </button>
+                    </Tooltip>
                   ) : null}
                 </div>
                 <Divider className="shrink-0" />
@@ -918,15 +928,16 @@ export const DiffViewerContent = ({
             ) : showToolbarClose ? (
               <>
                 <div className="flex shrink-0 items-center justify-end px-2.5 py-1.5">
-                  <button
-                    type="button"
-                    onClick={onClose}
-                    title="Close"
-                    aria-label="Close"
-                    className={TOOLBAR_ICON_BTN}
-                  >
-                    <X size={13} />
-                  </button>
+                  <Tooltip content="Close">
+                    <button
+                      type="button"
+                      onClick={onClose}
+                      aria-label="Close"
+                      className={TOOLBAR_ICON_BTN}
+                    >
+                      <X size={13} />
+                    </button>
+                  </Tooltip>
                 </div>
                 <Divider className="shrink-0" />
               </>

--- a/apps/desktop/src/features/permissions/components/DiffViewerDialog/FileDiffCard.tsx
+++ b/apps/desktop/src/features/permissions/components/DiffViewerDialog/FileDiffCard.tsx
@@ -260,22 +260,23 @@ export const FileDiffCard = ({
     <section ref={registerRef} data-file-path={file.path} className="min-w-0 max-w-full">
       <div className="sticky top-0 z-10 bg-background">
         <div className="flex items-center gap-2 px-3 py-1.5">
-          <button
-            type="button"
-            onClick={() => setCollapsed((c) => !c)}
-            title={collapsed ? 'Expand file' : 'Collapse file'}
-            aria-label={collapsed ? 'Expand file' : 'Collapse file'}
-            className={TOOLBAR_ICON_BTN}
-          >
-            <ChevronRight
-              size={13}
-              aria-hidden
-              className={cn(
-                'motion-safe:transition-transform duration-150',
-                !collapsed && 'rotate-90',
-              )}
-            />
-          </button>
+          <Tooltip content={collapsed ? 'Expand file' : 'Collapse file'}>
+            <button
+              type="button"
+              onClick={() => setCollapsed((c) => !c)}
+              aria-label={collapsed ? 'Expand file' : 'Collapse file'}
+              className={TOOLBAR_ICON_BTN}
+            >
+              <ChevronRight
+                size={13}
+                aria-hidden
+                className={cn(
+                  'motion-safe:transition-transform duration-150',
+                  !collapsed && 'rotate-90',
+                )}
+              />
+            </button>
+          </Tooltip>
           <span
             className={cn(
               'w-3 shrink-0 text-center font-mono text-2xs font-bold',

--- a/apps/desktop/src/features/permissions/components/DiffViewerDialog/FileTree/FileRail.tsx
+++ b/apps/desktop/src/features/permissions/components/DiffViewerDialog/FileTree/FileRail.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef } from 'react';
 import { PanelLeftClose, PanelLeftOpen } from 'lucide-react';
-import { Divider, ScrollArea, cn } from '@goodboy/ui';
+import { cn, Divider, ScrollArea, Tooltip } from '@goodboy/ui';
 import type { FileDiff } from '@goodboy/types';
 import { TOOLBAR_ICON_BTN, type ReviewState } from '../lib';
 import { buildTree } from './tree';
@@ -38,16 +38,17 @@ export const FileRail = ({
     <div className={cn('flex min-h-0 shrink-0', collapsed ? 'w-9' : 'w-[26%]')}>
       <div className="flex min-w-0 flex-1 flex-col">
         <div className="flex shrink-0 items-center justify-end px-1.5 pt-1.5">
-          <button
-            type="button"
-            onClick={onToggle}
-            className={TOOLBAR_ICON_BTN}
-            title={collapsed ? 'Show file list' : 'Hide file list'}
-            aria-label={collapsed ? 'Show file list' : 'Hide file list'}
-            aria-expanded={!collapsed}
-          >
-            {collapsed ? <PanelLeftOpen size={13} /> : <PanelLeftClose size={13} />}
-          </button>
+          <Tooltip content={collapsed ? 'Show file list' : 'Hide file list'}>
+            <button
+              type="button"
+              onClick={onToggle}
+              className={TOOLBAR_ICON_BTN}
+              aria-label={collapsed ? 'Show file list' : 'Hide file list'}
+              aria-expanded={!collapsed}
+            >
+              {collapsed ? <PanelLeftOpen size={13} /> : <PanelLeftClose size={13} />}
+            </button>
+          </Tooltip>
         </div>
         {collapsed ? null : (
           <ScrollArea className="min-w-0 flex-1">

--- a/apps/desktop/src/features/permissions/components/DiffViewerDialog/comments/CommentItem.tsx
+++ b/apps/desktop/src/features/permissions/components/DiffViewerDialog/comments/CommentItem.tsx
@@ -1,5 +1,5 @@
 import { ArrowUpRight, Check, RotateCcw, Trash2 } from 'lucide-react';
-import { Chip, cn, type Tone } from '@goodboy/ui';
+import { Chip, cn, Tooltip, type Tone } from '@goodboy/ui';
 import type { AgentId, DiffComment } from '@goodboy/types';
 import { formatRelativeAge } from '../../../../../shared/utils/relativeDate';
 
@@ -53,36 +53,39 @@ export const CommentItem = ({
         ) : null}
         <div className="ml-auto flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
           {comment.status === 'open' && (
-            <button
-              type="button"
-              onClick={() => onResolve(comment.id)}
-              title="Mark resolved"
-              aria-label="Mark resolved"
-              className="rounded-sm p-0.5 text-muted-foreground hover:bg-muted hover:text-success"
-            >
-              <Check size={11} />
-            </button>
+            <Tooltip content="Mark resolved">
+              <button
+                type="button"
+                onClick={() => onResolve(comment.id)}
+                aria-label="Mark resolved"
+                className="rounded-sm p-0.5 text-muted-foreground hover:bg-muted hover:text-success"
+              >
+                <Check size={11} />
+              </button>
+            </Tooltip>
           )}
           {comment.status === 'consumed' && (
+            <Tooltip content="Reopen note">
+              <button
+                type="button"
+                onClick={() => onReopen(comment.id)}
+                aria-label="Reopen note"
+                className="rounded-sm p-0.5 text-muted-foreground hover:bg-muted hover:text-warning"
+              >
+                <RotateCcw size={11} />
+              </button>
+            </Tooltip>
+          )}
+          <Tooltip content="Delete">
             <button
               type="button"
-              onClick={() => onReopen(comment.id)}
-              title="Reopen note"
-              aria-label="Reopen note"
-              className="rounded-sm p-0.5 text-muted-foreground hover:bg-muted hover:text-warning"
+              onClick={() => onDelete(comment.id)}
+              aria-label="Delete"
+              className="rounded-sm p-0.5 text-muted-foreground hover:bg-muted hover:text-danger"
             >
-              <RotateCcw size={11} />
+              <Trash2 size={11} />
             </button>
-          )}
-          <button
-            type="button"
-            onClick={() => onDelete(comment.id)}
-            title="Delete"
-            aria-label="Delete"
-            className="rounded-sm p-0.5 text-muted-foreground hover:bg-muted hover:text-danger"
-          >
-            <Trash2 size={11} />
-          </button>
+          </Tooltip>
         </div>
       </div>
       <p className="whitespace-pre-wrap break-words text-xs leading-relaxed text-foreground">

--- a/apps/desktop/src/features/providers/components/ProviderStudio/ApiProviderDetail.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/ApiProviderDetail.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useState } from 'react';
-import { SectionHeader } from '@goodboy/ui';
+import { SectionHeader, Tooltip } from '@goodboy/ui';
 import { CircleCheck, RotateCw, Terminal, TriangleAlert } from 'lucide-react';
 import type { ProviderInfo } from '../../../../features/providers/providers';
 import { useAppStore } from '../../../../store';
@@ -31,15 +31,17 @@ export const ApiProviderDetail = ({ info }: Props) => {
 
   const action = (
     <div className="flex items-center gap-2">
-      <button
-        type="button"
-        aria-label="Re-detect OpenCode"
-        disabled={isRefreshing}
-        onClick={() => void onRefresh()}
-        className="inline-flex size-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-50"
-      >
-        <RotateCw size={14} aria-hidden />
-      </button>
+      <Tooltip content="Re-detect OpenCode">
+        <button
+          type="button"
+          aria-label="Re-detect OpenCode"
+          disabled={isRefreshing}
+          onClick={() => void onRefresh()}
+          className="inline-flex size-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-50"
+        >
+          <RotateCw size={14} aria-hidden />
+        </button>
+      </Tooltip>
     </div>
   );
 

--- a/apps/desktop/src/features/providers/components/ProviderStudio/ApiProviderDetail.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/ApiProviderDetail.tsx
@@ -36,7 +36,6 @@ export const ApiProviderDetail = ({ info }: Props) => {
           type="button"
           aria-label="Re-detect OpenCode"
           disabled={isRefreshing}
-          title={isRefreshing ? 'Looking for OpenCode' : undefined}
           onClick={() => void onRefresh()}
           className="inline-flex size-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-50"
         >

--- a/apps/desktop/src/features/providers/components/ProviderStudio/ApiProviderDetail.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/ApiProviderDetail.tsx
@@ -36,6 +36,7 @@ export const ApiProviderDetail = ({ info }: Props) => {
           type="button"
           aria-label="Re-detect OpenCode"
           disabled={isRefreshing}
+          title={isRefreshing ? 'Looking for OpenCode' : undefined}
           onClick={() => void onRefresh()}
           className="inline-flex size-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-50"
         >

--- a/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/RoutingStatusControl.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/RoutingStatusControl.tsx
@@ -1,5 +1,5 @@
 import { RotateCcw } from 'lucide-react';
-import { Chip } from '@goodboy/ui';
+import { Chip, Tooltip } from '@goodboy/ui';
 
 type Props = {
   readonly label: string;
@@ -21,15 +21,17 @@ export const RoutingStatusControl = ({ label, isCustom, disabled, onReset }: Pro
         bordered={false}
         trailing={
           isCustom ? (
-            <button
-              type="button"
-              onClick={onReset}
-              disabled={disabled}
-              aria-label="Reset to default"
-              className="inline-flex items-center justify-center rounded-full text-current opacity-70 transition-opacity hover:opacity-100 disabled:cursor-not-allowed disabled:opacity-40"
-            >
-              <RotateCcw size={11} aria-hidden />
-            </button>
+            <Tooltip content="Reset to default">
+              <button
+                type="button"
+                onClick={onReset}
+                disabled={disabled}
+                aria-label="Reset to default"
+                className="inline-flex items-center justify-center rounded-full text-current opacity-70 transition-opacity hover:opacity-100 disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                <RotateCcw size={11} aria-hidden />
+              </button>
+            </Tooltip>
           ) : null
         }
       />

--- a/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/RoutingStatusControl.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/RoutingStatusControl.tsx
@@ -26,6 +26,7 @@ export const RoutingStatusControl = ({ label, isCustom, disabled, onReset }: Pro
                 type="button"
                 onClick={onReset}
                 disabled={disabled}
+                title={disabled === true ? 'Reset to default' : undefined}
                 aria-label="Reset to default"
                 className="inline-flex items-center justify-center rounded-full text-current opacity-70 transition-opacity hover:opacity-100 disabled:cursor-not-allowed disabled:opacity-40"
               >

--- a/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/RoutingStatusControl.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/RoutingStatusControl.tsx
@@ -26,7 +26,6 @@ export const RoutingStatusControl = ({ label, isCustom, disabled, onReset }: Pro
                 type="button"
                 onClick={onReset}
                 disabled={disabled}
-                title={disabled === true ? 'Reset to default' : undefined}
                 aria-label="Reset to default"
                 className="inline-flex items-center justify-center rounded-full text-current opacity-70 transition-opacity hover:opacity-100 disabled:cursor-not-allowed disabled:opacity-40"
               >

--- a/apps/desktop/src/features/providers/components/ProviderStudio/ProviderCredentialsSection.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/ProviderCredentialsSection.tsx
@@ -1,5 +1,13 @@
 import { useCallback, useMemo, useState } from 'react';
-import { Button, EmptyState, formatError, InlineConfirm, Input, SectionHeader } from '@goodboy/ui';
+import {
+  Button,
+  EmptyState,
+  formatError,
+  InlineConfirm,
+  Input,
+  SectionHeader,
+  Tooltip,
+} from '@goodboy/ui';
 import { KeyRound, Plus, Trash2 } from 'lucide-react';
 import { PROVIDER_API_KEY_ENV, type CredentialId, type ProviderId } from '@goodboy/types';
 import { useAppStore } from '../../../../store';
@@ -130,14 +138,16 @@ export const ProviderCredentialsSection = ({ providerId }: Props) => {
                   <span className="font-mono text-2xs text-muted-foreground/70">{c.hint}</span>
                 </div>
                 <div className="flex-1" />
-                <button
-                  type="button"
-                  aria-label={`Remove ${c.label}`}
-                  onClick={() => setArmedId(c.id)}
-                  className="inline-flex size-7 items-center justify-center rounded-md text-muted-foreground opacity-0 transition-opacity hover:bg-danger/10 hover:text-danger focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] group-hover:opacity-100"
-                >
-                  <Trash2 size={13} aria-hidden />
-                </button>
+                <Tooltip content={`Remove ${c.label}`}>
+                  <button
+                    type="button"
+                    aria-label={`Remove ${c.label}`}
+                    onClick={() => setArmedId(c.id)}
+                    className="inline-flex size-7 items-center justify-center rounded-md text-muted-foreground opacity-0 transition-opacity hover:bg-danger/10 hover:text-danger focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] group-hover:opacity-100"
+                  >
+                    <Trash2 size={13} aria-hidden />
+                  </button>
+                </Tooltip>
               </li>
             ),
           )}

--- a/apps/desktop/src/features/providers/components/ProviderStudio/ProviderDetailPanel.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/ProviderDetailPanel.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { Button, EmptyState, SectionHeader, StatusDot } from '@goodboy/ui';
+import { Button, EmptyState, SectionHeader, StatusDot, Tooltip } from '@goodboy/ui';
 import { RotateCw, type LucideIcon } from 'lucide-react';
 import { PROVIDER_CONNECT_CAPABILITIES, isApiProvider, type ProviderId } from '@goodboy/types';
 import type { ProviderInfo } from '../../../../features/providers/providers';
@@ -81,15 +81,17 @@ function Detail({
   const subtitle = info.version ? `${info.binary} ${info.version}` : info.binary;
   const action = (
     <div className="flex items-center gap-2">
-      <button
-        type="button"
-        aria-label="Re-detect CLIs"
-        disabled={refreshing}
-        onClick={() => void onRefresh()}
-        className="inline-flex size-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-50"
-      >
-        <RotateCw size={14} aria-hidden />
-      </button>
+      <Tooltip content="Re-detect CLIs">
+        <button
+          type="button"
+          aria-label="Re-detect CLIs"
+          disabled={refreshing}
+          onClick={() => void onRefresh()}
+          className="inline-flex size-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-50"
+        >
+          <RotateCw size={14} aria-hidden />
+        </button>
+      </Tooltip>
     </div>
   );
 

--- a/apps/desktop/src/features/providers/components/ProviderStudio/ProviderDetailPanel.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/ProviderDetailPanel.tsx
@@ -86,7 +86,6 @@ function Detail({
           type="button"
           aria-label="Re-detect CLIs"
           disabled={refreshing}
-          title={refreshing ? 'Looking for CLIs' : undefined}
           onClick={() => void onRefresh()}
           className="inline-flex size-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-50"
         >

--- a/apps/desktop/src/features/providers/components/ProviderStudio/ProviderDetailPanel.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/ProviderDetailPanel.tsx
@@ -86,6 +86,7 @@ function Detail({
           type="button"
           aria-label="Re-detect CLIs"
           disabled={refreshing}
+          title={refreshing ? 'Looking for CLIs' : undefined}
           onClick={() => void onRefresh()}
           className="inline-flex size-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-50"
         >

--- a/apps/desktop/src/features/review/components/ReviewBoardPane/DraftCard.tsx
+++ b/apps/desktop/src/features/review/components/ReviewBoardPane/DraftCard.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Trash2 } from 'lucide-react';
-import { Chip, Textarea, cn } from '@goodboy/ui';
+import { Chip, cn, Textarea, Tooltip } from '@goodboy/ui';
 import type { PrReviewDraft } from '@goodboy/types';
 import { ComposerActionRow } from './ComposerActionRow';
 
@@ -57,15 +57,16 @@ export const DraftCard = ({ draft, onEdit, onDiscard }: Props) => {
           />
         ) : null}
         <span className="flex-1" />
-        <button
-          type="button"
-          onClick={onDiscard}
-          title="Discard draft"
-          aria-label={`Discard draft on ${draft.path}:${draft.line}`}
-          className="flex size-5 shrink-0 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-muted hover:text-danger"
-        >
-          <Trash2 size={11} aria-hidden />
-        </button>
+        <Tooltip content="Discard draft">
+          <button
+            type="button"
+            onClick={onDiscard}
+            aria-label={`Discard draft on ${draft.path}:${draft.line}`}
+            className="flex size-5 shrink-0 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-muted hover:text-danger"
+          >
+            <Trash2 size={11} aria-hidden />
+          </button>
+        </Tooltip>
       </div>
       {editing ? (
         <div className="flex flex-col gap-1">

--- a/apps/desktop/src/features/review/components/ReviewBoardPane/ReviewFileDiff.tsx
+++ b/apps/desktop/src/features/review/components/ReviewBoardPane/ReviewFileDiff.tsx
@@ -1,6 +1,6 @@
 import { Fragment, useMemo, useState } from 'react';
 import { Bot, ChevronRight, MessageSquarePlus } from 'lucide-react';
-import { Chip, cn, type DiffLayoutMode, Divider, EmptyState } from '@goodboy/ui';
+import { Chip, cn, Divider, EmptyState, Tooltip, type DiffLayoutMode } from '@goodboy/ui';
 import type { DiffHunkLine, FileDiff, PrReviewDraft, ReviewDraftSide } from '@goodboy/types';
 import {
   INITIAL_VISIBLE_LINES,
@@ -120,22 +120,23 @@ export const ReviewFileDiff = ({ file, layoutMode, drafts, onAddDraft, onAskAgen
     <section data-file-path={file.path}>
       <div className="sticky top-0 z-10 bg-background">
         <div className="flex items-center gap-2 px-3 py-1.5">
-          <button
-            type="button"
-            onClick={() => setCollapsed((value) => !value)}
-            title={collapsed ? 'Expand file' : 'Collapse file'}
-            aria-label={collapsed ? 'Expand file' : 'Collapse file'}
-            className="flex size-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-          >
-            <ChevronRight
-              size={13}
-              aria-hidden
-              className={cn(
-                'duration-150 motion-safe:transition-transform',
-                !collapsed && 'rotate-90',
-              )}
-            />
-          </button>
+          <Tooltip content={collapsed ? 'Expand file' : 'Collapse file'}>
+            <button
+              type="button"
+              onClick={() => setCollapsed((value) => !value)}
+              aria-label={collapsed ? 'Expand file' : 'Collapse file'}
+              className="flex size-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            >
+              <ChevronRight
+                size={13}
+                aria-hidden
+                className={cn(
+                  'duration-150 motion-safe:transition-transform',
+                  !collapsed && 'rotate-90',
+                )}
+              />
+            </button>
+          </Tooltip>
           <span
             className={cn(
               'w-3 shrink-0 text-center font-mono text-2xs font-bold',
@@ -295,31 +296,33 @@ export const ReviewFileDiff = ({ file, layoutMode, drafts, onAddDraft, onAskAgen
                             >
                               {target != null && canComment ? (
                                 <span className="flex items-center gap-0.5">
-                                  <button
-                                    type="button"
-                                    onClick={() =>
-                                      setActiveAnchor(isActive ? null : (anchor ?? null))
-                                    }
-                                    title="Draft a comment on this line"
-                                    aria-label={`Draft a comment on line ${target.line}`}
-                                    className={cn(
-                                      'flex h-4 w-4 items-center justify-center rounded-sm text-muted-foreground transition-opacity hover:bg-muted hover:text-foreground focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]',
-                                      isActive
-                                        ? 'opacity-100'
-                                        : 'opacity-0 group-hover:opacity-100',
-                                    )}
-                                  >
-                                    <MessageSquarePlus size={9} aria-hidden />
-                                  </button>
-                                  <button
-                                    type="button"
-                                    onClick={() => onAskAgent?.(target)}
-                                    title="Ask the agent about this line"
-                                    aria-label={`Ask the agent about line ${target.line}`}
-                                    className="flex h-4 w-4 items-center justify-center rounded-sm text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
-                                  >
-                                    <Bot size={9} aria-hidden />
-                                  </button>
+                                  <Tooltip content="Draft a comment on this line">
+                                    <button
+                                      type="button"
+                                      onClick={() =>
+                                        setActiveAnchor(isActive ? null : (anchor ?? null))
+                                      }
+                                      aria-label={`Draft a comment on line ${target.line}`}
+                                      className={cn(
+                                        'flex h-4 w-4 items-center justify-center rounded-sm text-muted-foreground transition-opacity hover:bg-muted hover:text-foreground focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]',
+                                        isActive
+                                          ? 'opacity-100'
+                                          : 'opacity-0 group-hover:opacity-100',
+                                      )}
+                                    >
+                                      <MessageSquarePlus size={9} aria-hidden />
+                                    </button>
+                                  </Tooltip>
+                                  <Tooltip content="Ask the agent about this line">
+                                    <button
+                                      type="button"
+                                      onClick={() => onAskAgent?.(target)}
+                                      aria-label={`Ask the agent about line ${target.line}`}
+                                      className="flex h-4 w-4 items-center justify-center rounded-sm text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
+                                    >
+                                      <Bot size={9} aria-hidden />
+                                    </button>
+                                  </Tooltip>
                                 </span>
                               ) : null}
                             </td>

--- a/apps/desktop/src/features/review/components/ReviewBoardPane/ReviewLineActions.tsx
+++ b/apps/desktop/src/features/review/components/ReviewBoardPane/ReviewLineActions.tsx
@@ -1,5 +1,5 @@
 import { Bot, MessageSquarePlus } from 'lucide-react';
-import { cn } from '@goodboy/ui';
+import { cn, Tooltip } from '@goodboy/ui';
 import type { ReviewLineTarget } from './ReviewFileDiff';
 
 type Props = {
@@ -18,24 +18,26 @@ export const ReviewLineActions = ({ target, isActive, onToggleComposer, onAskAge
   }
   return (
     <span className="flex items-center gap-0.5">
-      <button
-        type="button"
-        onClick={() => onToggleComposer(target)}
-        title="Draft a comment on this line"
-        aria-label={`Draft a comment on ${target.side} line ${target.line}`}
-        className={cn(ACTION_BTN, isActive ? 'opacity-100' : 'opacity-0 group-hover:opacity-100')}
-      >
-        <MessageSquarePlus size={9} aria-hidden />
-      </button>
-      <button
-        type="button"
-        onClick={() => onAskAgent(target)}
-        title="Ask the agent about this line"
-        aria-label={`Ask the agent about ${target.side} line ${target.line}`}
-        className={cn(ACTION_BTN, 'opacity-0 group-hover:opacity-100')}
-      >
-        <Bot size={9} aria-hidden />
-      </button>
+      <Tooltip content="Draft a comment on this line">
+        <button
+          type="button"
+          onClick={() => onToggleComposer(target)}
+          aria-label={`Draft a comment on ${target.side} line ${target.line}`}
+          className={cn(ACTION_BTN, isActive ? 'opacity-100' : 'opacity-0 group-hover:opacity-100')}
+        >
+          <MessageSquarePlus size={9} aria-hidden />
+        </button>
+      </Tooltip>
+      <Tooltip content="Ask the agent about this line">
+        <button
+          type="button"
+          onClick={() => onAskAgent(target)}
+          aria-label={`Ask the agent about ${target.side} line ${target.line}`}
+          className={cn(ACTION_BTN, 'opacity-0 group-hover:opacity-100')}
+        >
+          <Bot size={9} aria-hidden />
+        </button>
+      </Tooltip>
     </span>
   );
 };

--- a/apps/desktop/src/features/scripts/components/RunningScriptsIndicator/RunningScriptRow.tsx
+++ b/apps/desktop/src/features/scripts/components/RunningScriptsIndicator/RunningScriptRow.tsx
@@ -1,5 +1,5 @@
 import { Square } from 'lucide-react';
-import { StatusDot } from '@goodboy/ui';
+import { StatusDot, Tooltip } from '@goodboy/ui';
 import type { RunningScript } from './useRunningScripts';
 
 type Props = {
@@ -36,13 +36,15 @@ export const RunningScriptRow = ({ run, now, onOpen, onStop }: Props) => (
     <span className="shrink-0 text-2xs tabular-nums text-muted-foreground">
       {elapsed(now - run.startedAt)}
     </span>
-    <button
-      type="button"
-      onClick={() => onStop(run)}
-      aria-label={`Stop ${run.scriptName}`}
-      className="shrink-0 rounded p-1 text-muted-foreground transition-colors hover:bg-danger/10 hover:text-danger"
-    >
-      <Square size={11} aria-hidden />
-    </button>
+    <Tooltip content={`Stop ${run.scriptName}`}>
+      <button
+        type="button"
+        onClick={() => onStop(run)}
+        aria-label={`Stop ${run.scriptName}`}
+        className="shrink-0 rounded p-1 text-muted-foreground transition-colors hover:bg-danger/10 hover:text-danger"
+      >
+        <Square size={11} aria-hidden />
+      </button>
+    </Tooltip>
   </li>
 );

--- a/apps/desktop/src/features/scripts/components/ScriptsSection/index.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsSection/index.tsx
@@ -222,12 +222,11 @@ function ScriptRow({
           </button>
         </Tooltip>
       ) : (
-        <Tooltip content="Run script">
+        <Tooltip content="Run script" anchorClassName="shrink-0">
           <button
             type="button"
             onClick={onRun}
             disabled={disabled}
-            title="Run script"
             aria-label="Run script"
             className="flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground/50 transition-colors hover:bg-foreground/10 hover:text-primary group-hover:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-40"
           >

--- a/apps/desktop/src/features/scripts/components/ScriptsSection/index.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsSection/index.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { cn, Divider, Popover, ScrollFade, SectionHeader } from '@goodboy/ui';
+import { cn, Divider, Popover, ScrollFade, SectionHeader, Tooltip } from '@goodboy/ui';
 import type { SessionId, WorkspaceId, WorkspaceScript, WorkspaceScriptId } from '@goodboy/types';
 import {
   ChevronDown,
@@ -86,19 +86,21 @@ export const ScriptsSection = ({
           icon={<Terminal size={11} aria-hidden className="text-info" />}
           label="Scripts"
           action={
-            <button
-              type="button"
-              onClick={() => setPanelSectionExpanded(sessionId, 'scripts', !storedExpanded)}
-              aria-expanded={expanded}
-              aria-label={`${expanded ? 'collapse' : 'expand'} scripts`}
-              className="flex size-5 shrink-0 items-center justify-center rounded text-muted-foreground/50 transition-colors hover:bg-foreground/10 hover:text-foreground"
-            >
-              {expanded ? (
-                <ChevronDown size={12} aria-hidden />
-              ) : (
-                <ChevronRight size={12} aria-hidden />
-              )}
-            </button>
+            <Tooltip content={`${expanded ? 'Collapse' : 'Expand'} scripts`}>
+              <button
+                type="button"
+                onClick={() => setPanelSectionExpanded(sessionId, 'scripts', !storedExpanded)}
+                aria-expanded={expanded}
+                aria-label={`${expanded ? 'collapse' : 'expand'} scripts`}
+                className="flex size-5 shrink-0 items-center justify-center rounded text-muted-foreground/50 transition-colors hover:bg-foreground/10 hover:text-foreground"
+              >
+                {expanded ? (
+                  <ChevronDown size={12} aria-hidden />
+                ) : (
+                  <ChevronRight size={12} aria-hidden />
+                )}
+              </button>
+            </Tooltip>
           }
         />
       )}
@@ -209,26 +211,29 @@ function ScriptRow({
         </button>
       ) : null}
       {isPending ? (
-        <button
-          type="button"
-          onClick={onCancel}
-          title="Stop script"
-          aria-label="Stop script"
-          className="flex size-6 shrink-0 items-center justify-center rounded text-danger transition-colors hover:bg-danger/10"
-        >
-          <Square size={11} fill="currentColor" aria-hidden />
-        </button>
+        <Tooltip content="Stop script">
+          <button
+            type="button"
+            onClick={onCancel}
+            aria-label="Stop script"
+            className="flex size-6 shrink-0 items-center justify-center rounded text-danger transition-colors hover:bg-danger/10"
+          >
+            <Square size={11} fill="currentColor" aria-hidden />
+          </button>
+        </Tooltip>
       ) : (
-        <button
-          type="button"
-          onClick={onRun}
-          disabled={disabled}
-          title="Run script"
-          aria-label="Run script"
-          className="flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground/50 transition-colors hover:bg-foreground/10 hover:text-primary group-hover:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-40"
-        >
-          <Play size={12} aria-hidden />
-        </button>
+        <Tooltip content="Run script">
+          <button
+            type="button"
+            onClick={onRun}
+            disabled={disabled}
+            title="Run script"
+            aria-label="Run script"
+            className="flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground/50 transition-colors hover:bg-foreground/10 hover:text-primary group-hover:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            <Play size={12} aria-hidden />
+          </button>
+        </Tooltip>
       )}
     </div>
   );
@@ -304,15 +309,16 @@ function LogFlyout({ script, result, anchor: initialAnchor, onClose }: LogFlyout
           {script.name}
         </span>
         <span className="shrink-0 text-2xs text-muted-foreground">exit {result.exitCode}</span>
-        <button
-          type="button"
-          onClick={onClose}
-          title="Close log"
-          aria-label="Close log"
-          className="flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground/60 transition-colors hover:bg-foreground/10 hover:text-foreground"
-        >
-          <X size={12} aria-hidden />
-        </button>
+        <Tooltip content="Close log">
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close log"
+            className="flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground/60 transition-colors hover:bg-foreground/10 hover:text-foreground"
+          >
+            <X size={12} aria-hidden />
+          </button>
+        </Tooltip>
       </div>
       <Divider className="shrink-0" />
       <ScrollFade className="min-h-0 flex-1" viewportClassName="px-3 py-2">

--- a/apps/desktop/src/features/session/components/AgentDetailPane/AgentBrief.test.tsx
+++ b/apps/desktop/src/features/session/components/AgentDetailPane/AgentBrief.test.tsx
@@ -187,6 +187,38 @@ describe('AgentBrief open questions', () => {
   });
 });
 
+describe('AgentBrief type scale', () => {
+  it('labels the outcome on the eyebrow grade while keeping it in the outline', () => {
+    render(
+      <AgentBrief session={session} agent={makeAgent({ outputSummary: 'shipped the refactor' })} />,
+    );
+
+    const heading = screen.getByRole('heading', { level: 2, name: 'Outcome' });
+
+    expect(heading.className).not.toContain('text-base');
+    expect(screen.getByText('Outcome').className).toContain('text-2xs');
+  });
+
+  it('leaves the outcome body on the reading grade, since it is prose', () => {
+    render(
+      <AgentBrief session={session} agent={makeAgent({ outputSummary: 'shipped the refactor' })} />,
+    );
+
+    const prose = screen.getByText('shipped the refactor').closest('.text-sm');
+
+    expect(prose).not.toBeNull();
+  });
+
+  it('reads the live state on the status grade the overview header uses', () => {
+    render(<AgentBrief session={session} agent={makeAgent({ status: 'pending' })} />);
+
+    const line = screen.getByText('queued').parentElement;
+
+    expect(line?.className).toContain('text-xs');
+    expect(line?.className).not.toContain('text-sm');
+  });
+});
+
 describe('AgentBrief sections', () => {
   it('carries every section on the one shared surface', () => {
     state.sessionPlans = {

--- a/apps/desktop/src/features/session/components/AgentDetailPane/AgentBrief.tsx
+++ b/apps/desktop/src/features/session/components/AgentDetailPane/AgentBrief.tsx
@@ -82,7 +82,7 @@ export const AgentBrief = ({ session, agent }: Props) => {
     <div className="flex flex-col gap-4">
       <AgentBriefQuestions session={session} agent={agent} />
       {summary !== '' ? (
-        <SectionSurface label={hasOutputSummary ? 'Outcome' : 'Latest'} headingSize="page">
+        <SectionSurface label={hasOutputSummary ? 'Outcome' : 'Latest'} headingLevel={2}>
           <div className="text-sm text-foreground">
             <Markdown text={stripControlMarkers(summary)} />
           </div>
@@ -93,7 +93,7 @@ export const AgentBrief = ({ session, agent }: Props) => {
       ) : null}
       {!isTerminal ? (
         <SectionSurface label="Now">
-          <div className="flex items-center gap-2 text-sm text-foreground">
+          <div className="flex items-center gap-2 text-xs text-foreground">
             <StatusDot tone={now.tone} size="sm" pulsing={now.isPulsing} />
             <span>{now.label}</span>
           </div>

--- a/apps/desktop/src/features/session/components/AgentDetailPane/AgentBriefChildren.test.tsx
+++ b/apps/desktop/src/features/session/components/AgentDetailPane/AgentBriefChildren.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import type { Agent, AgentId, Session, SessionId } from '@goodboy/types';
+import type { SpawnedChild } from '../../../../shared/utils/spawnedChildren';
+
+vi.mock('../../../../store', () => ({
+  useAppStore: <T,>(selector: (value: { selectAgent: () => void }) => T) =>
+    selector({ selectAgent: () => undefined }),
+}));
+
+vi.mock('../../hooks/useAgentMetrics', () => ({
+  useAgentMetrics: () => ({
+    aggregatesByAgentId: new Map([['child-1', { estimatedCostUsd: 0.42 }]]),
+  }),
+}));
+
+import { AgentBriefChildren } from './AgentBriefChildren';
+
+const sessionId = 'session-1' as SessionId;
+const session = { id: sessionId } as unknown as Session;
+
+const child = (over: Partial<SpawnedChild> = {}): SpawnedChild => ({
+  agent: {
+    id: 'child-1' as AgentId,
+    sessionId,
+    ordinal: 0,
+    name: 'Split the store',
+    status: 'completed',
+    kind: 'implementer',
+  } as Agent,
+  index: 0,
+  total: 1,
+  status: 'completed',
+  assignment: null,
+  ...over,
+});
+
+afterEach(cleanup);
+
+describe('AgentBriefChildren type scale', () => {
+  it('sits a child row label on the nested row grade the feed gives the same agent', () => {
+    render(<AgentBriefChildren session={session} kind="implementer" children={[child()]} />);
+
+    const label = screen.getByText('Split the store');
+
+    expect(label.className).toContain('text-xs');
+    expect(label.className).toContain('leading-4');
+    expect(label.className).not.toContain('text-sm');
+  });
+
+  it('declares a line height on the row label, since text-xs has no pinned line box', () => {
+    render(<AgentBriefChildren session={session} kind="implementer" children={[child()]} />);
+
+    expect(screen.getByText('Split the store').className).toMatch(/\bleading-\d/);
+  });
+
+  it('drops the ordinal and the cost to the metadata grade a feed row uses', () => {
+    render(<AgentBriefChildren session={session} kind="implementer" children={[child()]} />);
+
+    expect(screen.getByText('1').className).toContain('text-3xs');
+    expect(screen.getByText(/^\$0\.42/).className).toContain('text-3xs');
+  });
+
+  it('keeps the status word one grade above metadata, as a secondary label', () => {
+    render(<AgentBriefChildren session={session} kind="implementer" children={[child()]} />);
+
+    expect(screen.getByText('completed').className).toContain('text-2xs');
+  });
+
+  it('labels the section on the eyebrow grade rather than a page heading', () => {
+    render(<AgentBriefChildren session={session} kind="implementer" children={[child()]} />);
+
+    expect(screen.getByText('Clusters').className).toContain('text-2xs');
+  });
+});

--- a/apps/desktop/src/features/session/components/AgentDetailPane/AgentBriefChildren.tsx
+++ b/apps/desktop/src/features/session/components/AgentDetailPane/AgentBriefChildren.tsx
@@ -54,14 +54,14 @@ export const AgentBriefChildren = ({ session, kind, children }: Props) => {
                 size="sm"
                 pulsing={child.status === 'running'}
               />
-              <span className="w-5 shrink-0 text-2xs tabular-nums text-muted-foreground">
+              <span className="w-5 shrink-0 text-3xs tabular-nums text-muted-foreground">
                 {child.index + 1}
               </span>
-              <span className="min-w-0 flex-1 truncate text-sm text-foreground">
+              <span className="min-w-0 flex-1 truncate text-xs leading-4 text-foreground">
                 {child.agent.name}
               </span>
               {cost > 0 ? (
-                <span className="shrink-0 text-2xs tabular-nums text-muted-foreground">
+                <span className="shrink-0 text-3xs tabular-nums text-muted-foreground">
                   {formatUsd(cost)}
                 </span>
               ) : null}

--- a/apps/desktop/src/features/session/components/AgentDetailPane/AgentBriefPlans.tsx
+++ b/apps/desktop/src/features/session/components/AgentDetailPane/AgentBriefPlans.tsx
@@ -22,7 +22,7 @@ export const AgentBriefPlans = ({ plans, sessionId }: Props) => {
             key={plan.id}
             type="button"
             className={cn(
-              'flex items-center justify-between gap-4 rounded-md border px-3 py-2 text-left text-sm transition-colors',
+              'flex items-center justify-between gap-4 rounded-md border px-3 py-2 text-left text-xs leading-4 transition-colors',
               planTint.bgSoft,
               planTint.borderSoft,
               planTint.hoverBgSoft,
@@ -39,7 +39,7 @@ export const AgentBriefPlans = ({ plans, sessionId }: Props) => {
               <CONCEPT_ICONS.plans size={13} aria-hidden className={planTint.icon} />
               <span className="min-w-0 truncate text-foreground">{plan.title}</span>
             </span>
-            <span className="shrink-0 text-2xs tabular-nums text-muted-foreground">
+            <span className="shrink-0 text-3xs tabular-nums text-muted-foreground">
               {plan.status} · {pluralize(plan.consumptionCount, 'use')}
             </span>
           </button>

--- a/apps/desktop/src/features/session/components/InlineField/index.tsx
+++ b/apps/desktop/src/features/session/components/InlineField/index.tsx
@@ -1,5 +1,5 @@
 import { Pencil } from 'lucide-react';
-import { cn } from '@goodboy/ui';
+import { cn, Tooltip } from '@goodboy/ui';
 
 type Props = {
   label: string;
@@ -16,19 +16,21 @@ export const InlineField = ({ label, children, onEdit, editLabel }: Props) => {
           {label}
         </span>
         {onEdit ? (
-          <button
-            type="button"
-            onClick={onEdit}
-            aria-label={editLabel ?? `edit ${label}`}
-            className={cn(
-              'inline-flex size-4 items-center justify-center rounded text-muted-foreground/50',
-              'opacity-0 transition-[opacity,color,background-color] hover:bg-muted hover:text-foreground',
-              'focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]',
-              'group-hover/inline:opacity-100 motion-reduce:opacity-60',
-            )}
-          >
-            <Pencil size={10} aria-hidden />
-          </button>
+          <Tooltip content={editLabel ?? `Edit ${label}`}>
+            <button
+              type="button"
+              onClick={onEdit}
+              aria-label={editLabel ?? `edit ${label}`}
+              className={cn(
+                'inline-flex size-4 items-center justify-center rounded text-muted-foreground/50',
+                'opacity-0 transition-[opacity,color,background-color] hover:bg-muted hover:text-foreground',
+                'focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]',
+                'group-hover/inline:opacity-100 motion-reduce:opacity-60',
+              )}
+            >
+              <Pencil size={10} aria-hidden />
+            </button>
+          </Tooltip>
         ) : null}
       </div>
       {children}

--- a/apps/desktop/src/features/session/components/ResolverDetailPane/parts/ResolverOverflowMenu.tsx
+++ b/apps/desktop/src/features/session/components/ResolverDetailPane/parts/ResolverOverflowMenu.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { MoreHorizontal } from 'lucide-react';
-import { cn, Divider, Popover, useDropdown } from '@goodboy/ui';
+import { cn, Divider, Popover, Tooltip, useDropdown } from '@goodboy/ui';
 import type { Agent, BranchCommit } from '@goodboy/types';
 import { RESOLVER_ACTION_ICON } from '../../../resolverActionIcon';
 import type { ResolverAction, ResolverActionKind } from '../../../resolverActions';
@@ -59,19 +59,21 @@ export const ResolverOverflowMenu = ({
 
   return (
     <div className="relative" ref={containerRef}>
-      <button
-        type="button"
-        onClick={toggle}
-        aria-label="More resolver actions"
-        aria-haspopup="menu"
-        aria-expanded={isOpen}
-        className={cn(
-          'rounded-md p-1 text-muted-foreground/60 transition-colors hover:bg-foreground/5 hover:text-foreground',
-          isOpen && 'bg-foreground/10 text-foreground',
-        )}
-      >
-        <MoreHorizontal size={14} aria-hidden />
-      </button>
+      <Tooltip content="More resolver actions">
+        <button
+          type="button"
+          onClick={toggle}
+          aria-label="More resolver actions"
+          aria-haspopup="menu"
+          aria-expanded={isOpen}
+          className={cn(
+            'rounded-md p-1 text-muted-foreground/60 transition-colors hover:bg-foreground/5 hover:text-foreground',
+            isOpen && 'bg-foreground/10 text-foreground',
+          )}
+        >
+          <MoreHorizontal size={14} aria-hidden />
+        </button>
+      </Tooltip>
       {isOpen && (
         <Popover
           role="menu"

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/BranchChip.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/BranchChip.tsx
@@ -43,25 +43,26 @@ export const BranchChip = ({ branch, mountName = null, sessionId, canEdit }: Pro
           : 'border-border-soft bg-muted/30 text-foreground/80 hover:border-border hover:bg-muted/50 hover:text-foreground',
       )}
     >
-      <button
-        type="button"
-        onClick={() => void copy(branch)}
-        title="Click to copy branch name"
-        aria-label={`Copy branch ${branch}`}
-        className="inline-flex min-w-0 items-center gap-1.5 px-2 py-1"
-      >
-        {copied ? (
-          <Check size={10} aria-hidden className="shrink-0" />
-        ) : (
-          <GitBranch
-            size={10}
-            aria-hidden
-            className="shrink-0 text-muted-foreground group-hover/branch:text-foreground"
-          />
-        )}
-        {mountName != null ? <span className="text-muted-foreground">{mountName}:</span> : null}
-        <span className="truncate">{branch}</span>
-      </button>
+      <Tooltip content={copied ? 'Copied' : 'Click to copy the branch name'}>
+        <button
+          type="button"
+          onClick={() => void copy(branch)}
+          aria-label={`Copy branch ${branch}`}
+          className="inline-flex min-w-0 items-center gap-1.5 px-2 py-1"
+        >
+          {copied ? (
+            <Check size={10} aria-hidden className="shrink-0" />
+          ) : (
+            <GitBranch
+              size={10}
+              aria-hidden
+              className="shrink-0 text-muted-foreground group-hover/branch:text-foreground"
+            />
+          )}
+          {mountName != null ? <span className="text-muted-foreground">{mountName}:</span> : null}
+          <span className="truncate">{branch}</span>
+        </button>
+      </Tooltip>
 
       {canEdit ? (
         <Tooltip content="Edit branch" side="top">

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/EditorMenu.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/EditorMenu.tsx
@@ -101,6 +101,7 @@ export const EditorMenu = ({ sessionId, density = 'full' }: Props) => {
     <OverflowMenu
       items={items}
       label="Open worktree"
+      tooltip="Open the worktree in an editor, or copy its path"
       align="left"
       triggerClassName={triggerClassName}
       trigger={

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/ContextPane/ContextSection.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/ContextPane/ContextSection.tsx
@@ -27,10 +27,10 @@ export const ContextSection = ({
   return (
     <section id={sectionId} aria-label={title} className="flex flex-col gap-4">
       <SectionHeader
-        size="page"
+        headingLevel={2}
         label={title}
         hint={description}
-        icon={<Icon size={14} aria-hidden className={tint.icon} />}
+        icon={<Icon size={13} aria-hidden className={tint.icon} />}
         action={actions}
       />
       {children}

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/ContextPane/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/ContextPane/index.test.tsx
@@ -190,6 +190,31 @@ describe('Context regions', () => {
     expect(screen.queryByRole('tablist')).toBeNull();
   });
 
+  it('labels a region on the eyebrow grade, not the page grade, while keeping the h2', () => {
+    render(<ContextPane session={SESSION} />);
+
+    const heading = screen.getByRole('heading', { level: 2, name: 'Decisions' });
+
+    expect(heading.className).not.toContain('text-base');
+    expect(screen.getByText('Decisions').className).toContain('text-2xs');
+  });
+
+  it('pairs the region description with its heading grade instead of the reading grade', () => {
+    render(<ContextPane session={SESSION} />);
+
+    const hint = screen.getByText('One row per choice already settled along the way.');
+
+    expect(hint.className).toContain('text-2xs');
+    expect(hint.className).not.toContain('text-sm');
+  });
+
+  it('leaves the summary body on the reading grade, because the document is the artifact', () => {
+    render(<ContextPane session={SESSION} />);
+    const problem = within(sectionFor('Session summary')).getByRole('region', { name: 'Problem' });
+
+    expect(problem.querySelector('.text-sm')).not.toBeNull();
+  });
+
   it('asks for the context itself, so the pane does not depend on the session switch', () => {
     render(<ContextPane session={SESSION} />);
 

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/FileVersionsPane/versionHistoryList.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/FileVersionsPane/versionHistoryList.tsx
@@ -69,9 +69,6 @@ export const VersionHistoryList = ({
                   type="button"
                   onClick={() => onDeleteVersion(version.id)}
                   disabled={isDeleting || restoringVersionId != null}
-                  title={
-                    isDeleting || restoringVersionId != null ? 'Delete this version' : undefined
-                  }
                   aria-label="Delete this version"
                   className="inline-flex size-7 items-center justify-center rounded-md border border-border text-muted-foreground transition-colors hover:bg-danger/10 hover:text-danger disabled:cursor-not-allowed disabled:opacity-60"
                 >

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/FileVersionsPane/versionHistoryList.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/FileVersionsPane/versionHistoryList.tsx
@@ -1,5 +1,5 @@
 import { RotateCcw, Trash2 } from 'lucide-react';
-import { Button, EmptyState } from '@goodboy/ui';
+import { Button, EmptyState, Tooltip } from '@goodboy/ui';
 import type { FileVersion, FileVersionId } from '@goodboy/types';
 import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../../../shared/components/conceptIcons';
 import { AuthorshipChip } from '../AuthorshipChip';
@@ -64,15 +64,17 @@ export const VersionHistoryList = ({
                 <RotateCcw size={12} aria-hidden />
                 {isRestoring ? 'Restoring' : 'Restore'}
               </Button>
-              <button
-                type="button"
-                onClick={() => onDeleteVersion(version.id)}
-                disabled={isDeleting || restoringVersionId != null}
-                aria-label="Delete this version"
-                className="inline-flex size-7 items-center justify-center rounded-md border border-border text-muted-foreground transition-colors hover:bg-danger/10 hover:text-danger disabled:cursor-not-allowed disabled:opacity-60"
-              >
-                <Trash2 size={12} aria-hidden />
-              </button>
+              <Tooltip content="Delete this version">
+                <button
+                  type="button"
+                  onClick={() => onDeleteVersion(version.id)}
+                  disabled={isDeleting || restoringVersionId != null}
+                  aria-label="Delete this version"
+                  className="inline-flex size-7 items-center justify-center rounded-md border border-border text-muted-foreground transition-colors hover:bg-danger/10 hover:text-danger disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  <Trash2 size={12} aria-hidden />
+                </button>
+              </Tooltip>
             </div>
           </li>
         );

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/FileVersionsPane/versionHistoryList.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/FileVersionsPane/versionHistoryList.tsx
@@ -69,6 +69,9 @@ export const VersionHistoryList = ({
                   type="button"
                   onClick={() => onDeleteVersion(version.id)}
                   disabled={isDeleting || restoringVersionId != null}
+                  title={
+                    isDeleting || restoringVersionId != null ? 'Delete this version' : undefined
+                  }
                   aria-label="Delete this version"
                   className="inline-flex size-7 items-center justify-center rounded-md border border-border text-muted-foreground transition-colors hover:bg-danger/10 hover:text-danger disabled:cursor-not-allowed disabled:opacity-60"
                 >

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/InspectorSplit/InspectorHeader.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/InspectorSplit/InspectorHeader.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { Divider, cn } from '@goodboy/ui';
+import { cn, Divider, Tooltip } from '@goodboy/ui';
 import { X } from 'lucide-react';
 import { PANE_RHYTHM } from '@goodboy/ui';
 
@@ -10,7 +10,7 @@ type Props = {
   readonly onClose?: () => void;
 };
 
-export const InspectorHeader = ({ title, closeLabel, actions, onClose }: Props) => (
+export const InspectorHeader = ({ title, closeLabel = 'close panel', actions, onClose }: Props) => (
   <>
     <div
       className={cn('flex shrink-0 items-center justify-between gap-2', PANE_RHYTHM.rail.header)}
@@ -21,14 +21,16 @@ export const InspectorHeader = ({ title, closeLabel, actions, onClose }: Props) 
       <div className="flex shrink-0 items-center gap-0.5">
         {actions}
         {onClose !== undefined && (
-          <button
-            type="button"
-            onClick={onClose}
-            aria-label={closeLabel}
-            className="rounded-md p-1 text-muted-foreground/60 transition-colors hover:bg-foreground/5 hover:text-foreground"
-          >
-            <X size={14} aria-hidden />
-          </button>
+          <Tooltip content={closeLabel}>
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label={closeLabel}
+              className="rounded-md p-1 text-muted-foreground/60 transition-colors hover:bg-foreground/5 hover:text-foreground"
+            >
+              <X size={14} aria-hidden />
+            </button>
+          </Tooltip>
         )}
       </div>
     </div>

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/SessionGitActions.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/SessionGitActions.tsx
@@ -110,6 +110,7 @@ export const SessionGitActions = ({ session, density = 'full' }: Props) => {
     <OverflowMenu
       items={items}
       label="Branch actions"
+      tooltip="Rebase this branch on main, or push it"
       align="left"
       triggerClassName={triggerClassName}
       trigger={

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/SlotPane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/SlotPane.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { History, type LucideIcon } from 'lucide-react';
-import { Button, Markdown, Textarea, cn, type Tone } from '@goodboy/ui';
+import { Button, cn, Markdown, Textarea, Tooltip, type Tone } from '@goodboy/ui';
 import { LensEmptyState } from '@goodboy/ui';
 import type { Session, SessionId } from '@goodboy/types';
 import {
@@ -178,18 +178,19 @@ export const SlotPane = ({ session, slotKey }: Props) => {
               />
             ) : null}
             {historyCount > 0 ? (
-              <button
-                type="button"
-                onClick={toggleHistory}
-                title={`View history for ${SLOT_TITLE[slotKey]}`}
-                aria-label={`View history for ${SLOT_TITLE[slotKey]}`}
-                className={cn(
-                  'rounded-md p-1.5 text-muted-foreground/60 transition-colors hover:bg-foreground/5 hover:text-foreground',
-                  historyOpen && 'bg-foreground/5 text-foreground',
-                )}
-              >
-                <History size={15} aria-hidden />
-              </button>
+              <Tooltip content={`View history for ${SLOT_TITLE[slotKey]}`}>
+                <button
+                  type="button"
+                  onClick={toggleHistory}
+                  aria-label={`View history for ${SLOT_TITLE[slotKey]}`}
+                  className={cn(
+                    'rounded-md p-1.5 text-muted-foreground/60 transition-colors hover:bg-foreground/5 hover:text-foreground',
+                    historyOpen && 'bg-foreground/5 text-foreground',
+                  )}
+                >
+                  <History size={15} aria-hidden />
+                </button>
+              </Tooltip>
             ) : null}
           </>
         }

--- a/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
@@ -28,9 +28,10 @@ import {
   ScrollFade,
   SectionHeader,
   SegmentedTabs,
-  type SegmentedTabOption,
   Skeleton,
   Textarea,
+  Tooltip,
+  type SegmentedTabOption,
 } from '@goodboy/ui';
 import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../shared/components/conceptIcons';
 import { PANE_RHYTHM } from '@goodboy/ui';
@@ -1130,22 +1131,26 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
                                   <span className="px-1 text-2xs text-muted-foreground">
                                     Delete?
                                   </span>
-                                  <button
-                                    type="button"
-                                    onClick={() => void onDeletePreset(t)}
-                                    aria-label={`Confirm delete ${t.name}`}
-                                    className="rounded-md p-1 text-danger transition-colors hover:bg-danger/10"
-                                  >
-                                    <Check size={12} aria-hidden />
-                                  </button>
-                                  <button
-                                    type="button"
-                                    onClick={() => setConfirmDeleteId(null)}
-                                    aria-label="Cancel delete"
-                                    className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
-                                  >
-                                    <X size={12} aria-hidden />
-                                  </button>
+                                  <Tooltip content={`Confirm delete ${t.name}`}>
+                                    <button
+                                      type="button"
+                                      onClick={() => void onDeletePreset(t)}
+                                      aria-label={`Confirm delete ${t.name}`}
+                                      className="rounded-md p-1 text-danger transition-colors hover:bg-danger/10"
+                                    >
+                                      <Check size={12} aria-hidden />
+                                    </button>
+                                  </Tooltip>
+                                  <Tooltip content="Cancel delete">
+                                    <button
+                                      type="button"
+                                      onClick={() => setConfirmDeleteId(null)}
+                                      aria-label="Cancel delete"
+                                      className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
+                                    >
+                                      <X size={12} aria-hidden />
+                                    </button>
+                                  </Tooltip>
                                 </span>
                               ) : (
                                 <OverflowMenu

--- a/apps/desktop/src/features/session/components/WorkflowStepCard/index.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowStepCard/index.tsx
@@ -117,7 +117,7 @@ export const WorkflowStepCard = ({
   };
 
   const grip = (
-    <Tooltip content="Reorder step (drag or arrow keys)">
+    <Tooltip content="Reorder step (drag or arrow keys)" anchorClassName="shrink-0 self-stretch">
       <button
         type="button"
         onPointerDown={onStartDrag}
@@ -135,7 +135,6 @@ export const WorkflowStepCard = ({
         }}
         disabled={disabled}
         aria-label="Reorder step (drag or arrow keys)"
-        title="Reorder step (drag or arrow keys)"
         className="flex shrink-0 cursor-grab touch-none items-center self-stretch rounded-l-lg px-1 text-muted-foreground/30 transition-colors hover:bg-muted/40 hover:text-muted-foreground active:cursor-grabbing disabled:cursor-not-allowed"
       >
         <GripVertical size={14} aria-hidden />
@@ -162,14 +161,13 @@ export const WorkflowStepCard = ({
   );
 
   const removeButton = (
-    <Tooltip content="Remove step">
+    <Tooltip content="Remove step" anchorClassName="absolute right-1.5 top-1.5 z-10">
       <button
         type="button"
         onClick={onRemove}
         disabled={disabled}
         aria-label="Remove step"
-        title="Remove step"
-        className="absolute right-1.5 top-1.5 z-10 inline-flex items-center justify-center rounded p-1 text-muted-foreground opacity-0 transition-opacity hover:bg-muted/60 hover:text-danger focus-visible:opacity-100 disabled:cursor-not-allowed disabled:opacity-30 group-hover:opacity-100"
+        className="inline-flex items-center justify-center rounded p-1 text-muted-foreground opacity-0 transition-opacity hover:bg-muted/60 hover:text-danger focus-visible:opacity-100 disabled:cursor-not-allowed disabled:opacity-30 group-hover:opacity-100"
       >
         <Trash2 size={13} aria-hidden />
       </button>

--- a/apps/desktop/src/features/session/components/WorkflowStepCard/index.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowStepCard/index.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode, useRef } from 'react';
 import { GripVertical, Trash2 } from 'lucide-react';
-import { ClampedProse, Input, Textarea, cn } from '@goodboy/ui';
+import { ClampedProse, cn, Input, Textarea, Tooltip } from '@goodboy/ui';
 import type { AgentRole, ProviderId } from '@goodboy/types';
 import { agentKindPalette, ROLE_LABEL, ROLE_TO_KIND, type AgentKind } from '../../agent-kind';
 import { AgentAvatar } from '../../../../shared/components/AgentAvatar';
@@ -117,28 +117,30 @@ export const WorkflowStepCard = ({
   };
 
   const grip = (
-    <button
-      type="button"
-      onPointerDown={onStartDrag}
-      onKeyDown={(e) => {
-        if (e.key === 'ArrowUp') {
-          e.preventDefault();
-          onMoveUp();
-          return;
-        }
-        if (e.key === 'ArrowDown') {
-          e.preventDefault();
-          onMoveDown();
-          return;
-        }
-      }}
-      disabled={disabled}
-      aria-label="Reorder step (drag or arrow keys)"
-      title="Reorder step (drag or arrow keys)"
-      className="flex shrink-0 cursor-grab touch-none items-center self-stretch rounded-l-lg px-1 text-muted-foreground/30 transition-colors hover:bg-muted/40 hover:text-muted-foreground active:cursor-grabbing disabled:cursor-not-allowed"
-    >
-      <GripVertical size={14} aria-hidden />
-    </button>
+    <Tooltip content="Reorder step (drag or arrow keys)">
+      <button
+        type="button"
+        onPointerDown={onStartDrag}
+        onKeyDown={(e) => {
+          if (e.key === 'ArrowUp') {
+            e.preventDefault();
+            onMoveUp();
+            return;
+          }
+          if (e.key === 'ArrowDown') {
+            e.preventDefault();
+            onMoveDown();
+            return;
+          }
+        }}
+        disabled={disabled}
+        aria-label="Reorder step (drag or arrow keys)"
+        title="Reorder step (drag or arrow keys)"
+        className="flex shrink-0 cursor-grab touch-none items-center self-stretch rounded-l-lg px-1 text-muted-foreground/30 transition-colors hover:bg-muted/40 hover:text-muted-foreground active:cursor-grabbing disabled:cursor-not-allowed"
+      >
+        <GripVertical size={14} aria-hidden />
+      </button>
+    </Tooltip>
   );
 
   const headerRow = (trailing?: ReactNode) => (
@@ -160,16 +162,18 @@ export const WorkflowStepCard = ({
   );
 
   const removeButton = (
-    <button
-      type="button"
-      onClick={onRemove}
-      disabled={disabled}
-      aria-label="Remove step"
-      title="Remove step"
-      className="absolute right-1.5 top-1.5 z-10 inline-flex items-center justify-center rounded p-1 text-muted-foreground opacity-0 transition-opacity hover:bg-muted/60 hover:text-danger focus-visible:opacity-100 disabled:cursor-not-allowed disabled:opacity-30 group-hover:opacity-100"
-    >
-      <Trash2 size={13} aria-hidden />
-    </button>
+    <Tooltip content="Remove step">
+      <button
+        type="button"
+        onClick={onRemove}
+        disabled={disabled}
+        aria-label="Remove step"
+        title="Remove step"
+        className="absolute right-1.5 top-1.5 z-10 inline-flex items-center justify-center rounded p-1 text-muted-foreground opacity-0 transition-opacity hover:bg-muted/60 hover:text-danger focus-visible:opacity-100 disabled:cursor-not-allowed disabled:opacity-30 group-hover:opacity-100"
+      >
+        <Trash2 size={13} aria-hidden />
+      </button>
+    </Tooltip>
   );
 
   return (

--- a/apps/desktop/src/features/terminal/components/TerminalTabStrip/index.tsx
+++ b/apps/desktop/src/features/terminal/components/TerminalTabStrip/index.tsx
@@ -1,5 +1,5 @@
 import { Plus, X } from 'lucide-react';
-import { cn, StatusDot, type Tone } from '@goodboy/ui';
+import { cn, StatusDot, Tooltip, type Tone } from '@goodboy/ui';
 import type {
   TerminalTab,
   TerminalTabId,
@@ -47,28 +47,32 @@ export const TerminalTabStrip = ({ tabs, activeId, onSelect, onClose, onSpawn }:
           >
             <StatusDot tone={STATUS_TONE[t.status]} size="md" />
             <span className="max-w-[10rem] truncate">{t.title}</span>
-            <button
-              type="button"
-              aria-label={`Close ${t.title}`}
-              onClick={(e) => {
-                e.stopPropagation();
-                onClose(t.id);
-              }}
-              className="flex size-4 shrink-0 items-center justify-center rounded-sm text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/40"
-            >
-              <X size={11} aria-hidden />
-            </button>
+            <Tooltip content={`Close ${t.title}`}>
+              <button
+                type="button"
+                aria-label={`Close ${t.title}`}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onClose(t.id);
+                }}
+                className="flex size-4 shrink-0 items-center justify-center rounded-sm text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/40"
+              >
+                <X size={11} aria-hidden />
+              </button>
+            </Tooltip>
           </div>
         );
       })}
-      <button
-        type="button"
-        aria-label="New terminal"
-        onClick={onSpawn}
-        className="flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-muted/50 hover:text-foreground motion-safe:transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/40"
-      >
-        <Plus size={13} aria-hidden />
-      </button>
+      <Tooltip content="New terminal">
+        <button
+          type="button"
+          aria-label="New terminal"
+          onClick={onSpawn}
+          className="flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-muted/50 hover:text-foreground motion-safe:transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/40"
+        >
+          <Plus size={13} aria-hidden />
+        </button>
+      </Tooltip>
     </div>
   );
 };

--- a/apps/desktop/src/features/workflows/components/WorkflowOrchestratorTldr/index.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowOrchestratorTldr/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { ChevronDown, ChevronRight } from 'lucide-react';
-import { Chip, Divider, Markdown, type Tone } from '@goodboy/ui';
+import { Chip, Divider, Markdown, Tooltip, type Tone } from '@goodboy/ui';
 import type { Step, WorkflowRun } from '@goodboy/types';
 
 const COLLAPSED_COUNT = 3;
@@ -123,26 +123,28 @@ export const WorkflowOrchestratorTldr = ({ steps, run }: Props) => {
                 data-testid="workflow-orchestrator-closing"
                 className="flex min-w-0 flex-col gap-1"
               >
-                <button
-                  type="button"
-                  aria-expanded={closingOpen}
-                  aria-label={`Why the run ended: ${OUTCOME_LABEL[outcome]}`}
-                  onClick={() => setClosingOpen((open) => !open)}
-                  className={ROW_BUTTON}
-                >
-                  <Chip
-                    tone={OUTCOME_TONE[outcome]}
-                    size="xs"
-                    bordered={false}
-                    label={OUTCOME_LABEL[outcome]}
-                    className="shrink-0 font-semibold"
-                  />
-                  {!closingOpen && (
-                    <span className="min-w-0 flex-1 truncate text-muted-foreground">
-                      {closingReason}
-                    </span>
-                  )}
-                </button>
+                <Tooltip content={`Why the run ended: ${OUTCOME_LABEL[outcome]}`}>
+                  <button
+                    type="button"
+                    aria-expanded={closingOpen}
+                    aria-label={`Why the run ended: ${OUTCOME_LABEL[outcome]}`}
+                    onClick={() => setClosingOpen((open) => !open)}
+                    className={ROW_BUTTON}
+                  >
+                    <Chip
+                      tone={OUTCOME_TONE[outcome]}
+                      size="xs"
+                      bordered={false}
+                      label={OUTCOME_LABEL[outcome]}
+                      className="shrink-0 font-semibold"
+                    />
+                    {!closingOpen && (
+                      <span className="min-w-0 flex-1 truncate text-muted-foreground">
+                        {closingReason}
+                      </span>
+                    )}
+                  </button>
+                </Tooltip>
                 {closingOpen ? (
                   <div className="min-w-0 pl-5">
                     <Markdown text={closingReason} className="text-2xs leading-relaxed" />

--- a/apps/desktop/src/features/workflows/components/WorkflowStudio/WorkflowsRail/index.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowStudio/WorkflowsRail/index.tsx
@@ -75,30 +75,26 @@ export const WorkflowsRail = ({
               made are kept.
             </span>
             <Tooltip content="confirm restore">
-              <span className="inline-flex">
-                <button
-                  type="button"
-                  onClick={onReset}
-                  disabled={resetting}
-                  aria-label="Confirm restore defaults"
-                  className="rounded-md p-0.5 text-warning transition-colors hover:bg-warning/10 disabled:opacity-50"
-                >
-                  <Check size={13} aria-hidden />
-                </button>
-              </span>
+              <button
+                type="button"
+                onClick={onReset}
+                disabled={resetting}
+                aria-label="Confirm restore defaults"
+                className="rounded-md p-0.5 text-warning transition-colors hover:bg-warning/10 disabled:opacity-50"
+              >
+                <Check size={13} aria-hidden />
+              </button>
             </Tooltip>
             <Tooltip content="cancel">
-              <span className="inline-flex">
-                <button
-                  type="button"
-                  onClick={() => setConfirmReset(false)}
-                  disabled={resetting}
-                  aria-label="Cancel restore defaults"
-                  className="rounded-md p-0.5 text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground disabled:opacity-50"
-                >
-                  <X size={13} aria-hidden />
-                </button>
-              </span>
+              <button
+                type="button"
+                onClick={() => setConfirmReset(false)}
+                disabled={resetting}
+                aria-label="Cancel restore defaults"
+                className="rounded-md p-0.5 text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground disabled:opacity-50"
+              >
+                <X size={13} aria-hidden />
+              </button>
             </Tooltip>
           </div>
         ) : (

--- a/apps/desktop/src/features/workspace/components/WorkspaceLauncher/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspaceLauncher/index.tsx
@@ -1,6 +1,14 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Plus, Search, Unplug } from 'lucide-react';
-import { Button, Checkbox, EmptyState, Eyebrow, InlineConfirm, ScrollFade } from '@goodboy/ui';
+import {
+  Button,
+  Checkbox,
+  EmptyState,
+  Eyebrow,
+  InlineConfirm,
+  ScrollFade,
+  Tooltip,
+} from '@goodboy/ui';
 import type { Workspace } from '@goodboy/types';
 import { useAppStore, useWorkspaces } from '../../../../store';
 import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../shared/components/conceptIcons';
@@ -129,16 +137,17 @@ export const WorkspaceLauncher = () => {
                       highlighted={i === activeIndex}
                       onOpen={() => select(w)}
                     />
-                    <button
-                      type="button"
-                      data-tauri-drag-region="false"
-                      aria-label={`Disconnect ${w.name}`}
-                      title={`Disconnect ${w.name}`}
-                      onClick={() => setDisconnectTarget(w)}
-                      className="absolute right-2 top-1/2 -translate-y-1/2 rounded-md border border-border-soft bg-background p-1.5 text-muted-foreground opacity-0 transition-opacity hover:text-danger focus-visible:opacity-100 group-hover/launcher:opacity-100"
-                    >
-                      <Unplug size={13} aria-hidden />
-                    </button>
+                    <Tooltip content={`Disconnect ${w.name}`}>
+                      <button
+                        type="button"
+                        data-tauri-drag-region="false"
+                        aria-label={`Disconnect ${w.name}`}
+                        onClick={() => setDisconnectTarget(w)}
+                        className="absolute right-2 top-1/2 -translate-y-1/2 rounded-md border border-border-soft bg-background p-1.5 text-muted-foreground opacity-0 transition-opacity hover:text-danger focus-visible:opacity-100 group-hover/launcher:opacity-100"
+                      >
+                        <Unplug size={13} aria-hidden />
+                      </button>
+                    </Tooltip>
                   </li>
                 ),
               )

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/SectionToggle.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/SectionToggle.tsx
@@ -1,4 +1,5 @@
 import { ChevronDown, ChevronRight } from 'lucide-react';
+import { Tooltip } from '@goodboy/ui';
 
 type Props = {
   readonly expanded: boolean;
@@ -8,14 +9,16 @@ type Props = {
 
 export const SectionToggle = ({ expanded, label, onToggle }: Props) => {
   return (
-    <button
-      type="button"
-      onClick={onToggle}
-      aria-expanded={expanded}
-      aria-label={`${expanded ? 'collapse' : 'expand'} ${label}`}
-      className="flex size-5 shrink-0 items-center justify-center rounded text-muted-foreground/50 transition-colors hover:bg-foreground/10 hover:text-foreground"
-    >
-      {expanded ? <ChevronDown size={12} aria-hidden /> : <ChevronRight size={12} aria-hidden />}
-    </button>
+    <Tooltip content={`${expanded ? 'Collapse' : 'Expand'} ${label}`}>
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={expanded}
+        aria-label={`${expanded ? 'collapse' : 'expand'} ${label}`}
+        className="flex size-5 shrink-0 items-center justify-center rounded text-muted-foreground/50 transition-colors hover:bg-foreground/10 hover:text-foreground"
+      >
+        {expanded ? <ChevronDown size={12} aria-hidden /> : <ChevronRight size={12} aria-hidden />}
+      </button>
+    </Tooltip>
   );
 };

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.tsx
@@ -1,5 +1,14 @@
 import { Fragment, type Dispatch, type SetStateAction } from 'react';
-import { cn, Collapsible, Divider, formatUsdPrecise, Input, MetaRow, StatusDot } from '@goodboy/ui';
+import {
+  cn,
+  Collapsible,
+  Divider,
+  formatUsdPrecise,
+  Input,
+  MetaRow,
+  StatusDot,
+  Tooltip,
+} from '@goodboy/ui';
 import { ChevronDown, ChevronRight, ChevronUp, Pencil, Undo2 } from 'lucide-react';
 import type {
   Agent,
@@ -223,20 +232,21 @@ export const WorkflowRow = ({
                     <h2 className="truncate text-xl font-semibold leading-snug text-foreground">
                       {name}
                     </h2>
-                    <button
-                      type="button"
-                      onClick={rename.start}
-                      aria-label="Edit workflow name"
-                      title="Edit workflow name"
-                      className={cn(
-                        'mt-1 inline-flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground/50',
-                        'opacity-0 transition-[opacity,color,background-color] hover:bg-muted hover:text-foreground',
-                        'focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]',
-                        'group-hover/name:opacity-100 motion-reduce:opacity-60',
-                      )}
-                    >
-                      <Pencil size={13} aria-hidden />
-                    </button>
+                    <Tooltip content="Edit workflow name">
+                      <button
+                        type="button"
+                        onClick={rename.start}
+                        aria-label="Edit workflow name"
+                        className={cn(
+                          'mt-1 inline-flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground/50',
+                          'opacity-0 transition-[opacity,color,background-color] hover:bg-muted hover:text-foreground',
+                          'focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]',
+                          'group-hover/name:opacity-100 motion-reduce:opacity-60',
+                        )}
+                      >
+                        <Pencil size={13} aria-hidden />
+                      </button>
+                    </Tooltip>
                   </div>
                 )}
                 <WorkflowRunStatus

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowStepRow.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowStepRow.test.tsx
@@ -168,7 +168,9 @@ describe('WorkflowStepRow', () => {
     expect(planButton.className).toContain(planTint.borderSoft);
     fireEvent.click(planButton);
 
-    expect(screen.getByTitle(plan.title).textContent).toContain('Plan');
+    expect(screen.getByRole('button', { name: `Open plan: ${plan.title}` }).textContent).toContain(
+      'Plan',
+    );
     const event = onOpen.mock.calls[0]?.[0];
     if (!(event instanceof CustomEvent)) {
       throw new Error('expected a plan studio event');
@@ -213,7 +215,7 @@ describe('WorkflowStepRow', () => {
     expect(screen.getByRole('button', { name: /open from plan:/i }).textContent).toContain(
       'From plan',
     );
-    expect(screen.getByTitle(plan.title)).toBeTruthy();
+    expect(screen.getByRole('button', { name: `Open from plan: ${plan.title}` })).toBeTruthy();
   });
 
   it('falls back to the latest run plan for a completed consumer without consumptions', () => {
@@ -235,7 +237,6 @@ describe('WorkflowStepRow', () => {
 
     renderRow({ kind: 'generic', runOverride: consumer });
 
-    expect(screen.getByRole('button', { name: /open from plan:/i })).toBeTruthy();
-    expect(screen.getByTitle(plan.title)).toBeTruthy();
+    expect(screen.getByRole('button', { name: `Open from plan: ${plan.title}` })).toBeTruthy();
   });
 });

--- a/apps/desktop/src/features/worktree/BranchCombobox.tsx
+++ b/apps/desktop/src/features/worktree/BranchCombobox.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { cn, DropdownPortal, ScrollFade, useDropdown } from '@goodboy/ui';
+import { cn, DropdownPortal, ScrollFade, Tooltip, useDropdown } from '@goodboy/ui';
 import { ChevronDown } from 'lucide-react';
 import type { LocalBranchInfo } from './worktree';
 
@@ -176,27 +176,29 @@ export const BranchCombobox = ({
           }}
           onKeyDown={onKeyDown}
         />
-        <button
-          type="button"
-          tabIndex={-1}
-          onClick={() => {
-            if (disabled || branches.length === 0) {
-              return;
-            }
-            toggle();
-            if (open) {
-              inputRef.current?.focus();
-            }
-          }}
-          aria-label={open ? 'Close branch list' : 'Open branch list'}
-          className="flex h-7 w-7 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-        >
-          <ChevronDown
-            size={13}
-            aria-hidden
-            className={cn('motion-safe:transition-transform', open && 'rotate-180')}
-          />
-        </button>
+        <Tooltip content={open ? 'Close branch list' : 'Open branch list'}>
+          <button
+            type="button"
+            tabIndex={-1}
+            onClick={() => {
+              if (disabled || branches.length === 0) {
+                return;
+              }
+              toggle();
+              if (open) {
+                inputRef.current?.focus();
+              }
+            }}
+            aria-label={open ? 'Close branch list' : 'Open branch list'}
+            className="flex h-7 w-7 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          >
+            <ChevronDown
+              size={13}
+              aria-hidden
+              className={cn('motion-safe:transition-transform', open && 'rotate-180')}
+            />
+          </button>
+        </Tooltip>
       </div>
       <DropdownPortal portal={portal} portalTarget={portalTarget}>
         {isPopupVisible ? (

--- a/apps/desktop/src/shared/components/GenericTerminalPanel/index.tsx
+++ b/apps/desktop/src/shared/components/GenericTerminalPanel/index.tsx
@@ -10,6 +10,7 @@ import { RotateCcw } from 'lucide-react';
 import { useThemeStore } from '../../lib/theme';
 import { openUrl } from '../../lib/editor';
 import { resolveTerminalTheme } from './terminal-theme';
+import { Tooltip } from '@goodboy/ui';
 
 export type TerminalDriver = {
   write(data: string): void;
@@ -207,15 +208,16 @@ export const GenericTerminalPanel = ({
         className="size-full overflow-hidden"
       />
       {onRestart ? (
-        <button
-          type="button"
-          onClick={onRestart}
-          title="Restart shell"
-          aria-label="Restart shell"
-          className="absolute right-2 top-2 z-10 rounded-sm bg-background/80 p-1 text-muted-foreground backdrop-blur hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
-        >
-          <RotateCcw size={12} aria-hidden />
-        </button>
+        <Tooltip content="Restart shell">
+          <button
+            type="button"
+            onClick={onRestart}
+            aria-label="Restart shell"
+            className="absolute right-2 top-2 z-10 rounded-sm bg-background/80 p-1 text-muted-foreground backdrop-blur hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
+          >
+            <RotateCcw size={12} aria-hidden />
+          </button>
+        </Tooltip>
       ) : null}
     </div>
   );

--- a/apps/desktop/src/shared/components/RoutingPicker/ProviderGrid.tsx
+++ b/apps/desktop/src/shared/components/RoutingPicker/ProviderGrid.tsx
@@ -1,6 +1,6 @@
 import { Plus } from 'lucide-react';
 import type { ProviderId } from '@goodboy/types';
-import { cn } from '@goodboy/ui';
+import { cn, Tooltip } from '@goodboy/ui';
 import { PROVIDER_LABEL } from '../../../features/chat/utils/chat-constants';
 import { ProviderGlyph } from './ProviderGlyph';
 import { ROUTING_PICKER_CONSTANTS } from './constants';
@@ -39,31 +39,35 @@ export const ProviderGrid = ({
         const isSecondary = secondaryProvider === id;
         const isDisabled = disableDisconnected && !isConnected;
         return (
-          <button
+          <Tooltip
             key={id}
-            type="button"
-            title={isConnected ? PROVIDER_LABEL[id] : `${PROVIDER_LABEL[id]} is not connected`}
-            aria-label={PROVIDER_LABEL[id]}
-            aria-pressed={isActive}
-            disabled={isDisabled}
-            onClick={() => onSelect(id)}
-            className={cn(
-              'relative inline-flex min-w-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-background/60 hover:text-foreground',
-              isActive && 'bg-background text-foreground shadow-sm',
-              isSecondary && 'text-foreground ring-1 ring-inset ring-border-soft',
-              isDisabled && 'cursor-not-allowed',
-            )}
+            content={isConnected ? PROVIDER_LABEL[id] : `${PROVIDER_LABEL[id]} is not connected`}
           >
-            <span className={cn(!isConnected && 'opacity-35')}>
-              <ProviderGlyph id={id} size={15} />
-            </span>
-            {!isConnected ? (
-              <span
-                className="absolute right-1 top-1 size-1.5 rounded-full bg-warning ring-1 ring-subtle"
-                aria-hidden
-              />
-            ) : null}
-          </button>
+            <button
+              type="button"
+              title={isConnected ? PROVIDER_LABEL[id] : `${PROVIDER_LABEL[id]} is not connected`}
+              aria-label={PROVIDER_LABEL[id]}
+              aria-pressed={isActive}
+              disabled={isDisabled}
+              onClick={() => onSelect(id)}
+              className={cn(
+                'relative inline-flex min-w-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-background/60 hover:text-foreground',
+                isActive && 'bg-background text-foreground shadow-sm',
+                isSecondary && 'text-foreground ring-1 ring-inset ring-border-soft',
+                isDisabled && 'cursor-not-allowed',
+              )}
+            >
+              <span className={cn(!isConnected && 'opacity-35')}>
+                <ProviderGlyph id={id} size={15} />
+              </span>
+              {!isConnected ? (
+                <span
+                  className="absolute right-1 top-1 size-1.5 rounded-full bg-warning ring-1 ring-subtle"
+                  aria-hidden
+                />
+              ) : null}
+            </button>
+          </Tooltip>
         );
       })}
     {onNavigateProviders != null && (

--- a/apps/desktop/src/shared/components/RoutingPicker/ProviderGrid.tsx
+++ b/apps/desktop/src/shared/components/RoutingPicker/ProviderGrid.tsx
@@ -45,13 +45,12 @@ export const ProviderGrid = ({
           >
             <button
               type="button"
-              title={isConnected ? PROVIDER_LABEL[id] : `${PROVIDER_LABEL[id]} is not connected`}
               aria-label={PROVIDER_LABEL[id]}
               aria-pressed={isActive}
               disabled={isDisabled}
               onClick={() => onSelect(id)}
               className={cn(
-                'relative inline-flex min-w-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-background/60 hover:text-foreground',
+                'relative inline-flex size-full min-w-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-background/60 hover:text-foreground',
                 isActive && 'bg-background text-foreground shadow-sm',
                 isSecondary && 'text-foreground ring-1 ring-inset ring-border-soft',
                 isDisabled && 'cursor-not-allowed',

--- a/apps/desktop/src/shared/components/RoutingPicker/ProviderPicker.test.tsx
+++ b/apps/desktop/src/shared/components/RoutingPicker/ProviderPicker.test.tsx
@@ -3,6 +3,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import type { ProviderId } from '@goodboy/types';
+import { tooltipTextOf } from '../../../__tests__/helpers/tooltip';
 import { ProviderPicker } from './ProviderPicker';
 
 const connectedProviders = ['anthropic', 'cursor'] as ReadonlyArray<ProviderId>;
@@ -63,6 +64,6 @@ describe('ProviderPicker', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Default provider: Claude' }));
     const codex = screen.getByRole('button', { name: 'Codex' });
     expect(codex.hasAttribute('disabled')).toBe(true);
-    expect(codex.getAttribute('title')).toBe('Codex is not connected');
+    expect(tooltipTextOf({ element: codex })).toBe('Codex is not connected');
   });
 });

--- a/apps/desktop/src/shared/components/RoutingPicker/constants.ts
+++ b/apps/desktop/src/shared/components/RoutingPicker/constants.ts
@@ -12,5 +12,5 @@ export const ROUTING_PICKER_CONSTANTS = {
     (id): id is ProviderId => id in PROVIDER_CAPABILITIES,
   ),
   emptyModelKeys: new Set<string>(),
-  providerChipGroupClassName: 'flex gap-1.5 bg-subtle px-2.5 [&>button]:h-7 [&>button]:flex-1',
+  providerChipGroupClassName: 'flex gap-1.5 bg-subtle px-2.5 [&>*]:h-7 [&>*]:flex-1',
 } satisfies RoutingPickerConstants;

--- a/apps/desktop/src/shared/components/RoutingPicker/index.test.tsx
+++ b/apps/desktop/src/shared/components/RoutingPicker/index.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { act, cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import { MODEL_CATALOGS, PROVIDER_CAPABILITIES } from '@goodboy/core';
 import type { ProviderId } from '@goodboy/types';
+import { tooltipTextOf } from '../../../__tests__/helpers/tooltip';
 import { PROVIDER_LABEL } from '../../../features/chat/utils/chat-constants';
 import { cursorMaxModeAdvisory } from '../../lib/cursorMaxModeAdvisory';
 import { RoutingPicker } from './index';
@@ -48,21 +49,21 @@ describe('RoutingPicker', () => {
     render(<RoutingPicker {...baseProps} verbosity="brief" onVerbosity={vi.fn()} />);
     const trigger = screen.getByRole('button', { name: /routing/i });
     expect(trigger.getAttribute('aria-label')).toBe('routing: Claude · Opus 5 · High · Brief');
-    expect(trigger.getAttribute('title')).toContain('Claude · Opus 5 · High · Brief');
+    expect(tooltipTextOf({ element: trigger })).toContain('Claude · Opus 5 · High · Brief');
   });
 
   it('still explains a disabled trigger when the caller gives no reason', () => {
     render(
       <RoutingPicker {...baseProps} disabled={true} verbosity="brief" onVerbosity={vi.fn()} />,
     );
-    expect(screen.getByRole('button', { name: /routing/i }).getAttribute('title')).toBe(
+    expect(tooltipTextOf({ element: screen.getByRole('button', { name: /routing/i }) })).toBe(
       'Claude · Opus 5 · High · Brief',
     );
   });
 
   it('prefers the caller reason over the summary on a disabled trigger', () => {
     render(<RoutingPicker {...baseProps} disabled={true} disabledTitle="the turn is running" />);
-    expect(screen.getByRole('button', { name: /routing/i }).getAttribute('title')).toBe(
+    expect(tooltipTextOf({ element: screen.getByRole('button', { name: /routing/i }) })).toBe(
       'the turn is running',
     );
   });
@@ -226,7 +227,7 @@ describe('RoutingPicker', () => {
       />,
     );
     fireEvent.click(screen.getByRole('button', { name: /routing/i }));
-    const providerRow = screen.getByRole('button', { name: 'Cursor' }).parentElement;
+    const providerRow = screen.getByRole('button', { name: 'Cursor' }).closest('div');
     expect(providerRow?.querySelectorAll('svg')).toHaveLength(
       baseProps.connectedProviders.length + 1,
     );
@@ -547,7 +548,7 @@ describe('RoutingPicker', () => {
       />,
     );
     fireEvent.click(screen.getByRole('button', { name: /routing/i }));
-    expect(screen.getByRole('button', { name: 'Codex' }).getAttribute('title')).toBe(
+    expect(tooltipTextOf({ element: screen.getByRole('button', { name: 'Codex' }) })).toBe(
       'Codex is not connected',
     );
     expect(screen.getByText('Codex is not connected')).toBeDefined();
@@ -611,9 +612,9 @@ describe('RoutingPicker', () => {
     render(<RoutingPicker {...baseProps} />);
     fireEvent.click(screen.getByRole('button', { name: /routing/i }));
     const providerButton = screen.getByRole('button', { name: 'Cursor' });
-    const providerRow = providerButton.parentElement;
+    const providerRow = providerButton.closest('div');
     expect(providerRow?.className).toContain('gap-1.5');
-    expect(providerRow?.className).toContain('[&>button]:flex-1');
+    expect(providerRow?.className).toContain('[&>*]:flex-1');
     expect(providerButton.className).toContain('min-w-0');
   });
 });

--- a/apps/desktop/src/shared/components/RoutingPicker/index.tsx
+++ b/apps/desktop/src/shared/components/RoutingPicker/index.tsx
@@ -302,12 +302,14 @@ export const RoutingPicker = ({
           </button>
         </Tooltip>
       )}
-      <Tooltip content={disabled ? (disabledTitle ?? summary) : `${summary}. Click to change.`}>
+      <Tooltip
+        content={disabled ? (disabledTitle ?? summary) : `${summary}. Click to change.`}
+        anchorClassName={variant === 'field' ? 'w-full' : undefined}
+      >
         <button
           type="button"
           onClick={toggle}
           disabled={disabled}
-          title={disabled ? (disabledTitle ?? summary) : `${summary}. Click to change.`}
           aria-haspopup="dialog"
           aria-expanded={open}
           aria-label={ariaLabel != null ? `${ariaLabel}: ${summary}` : summary}

--- a/apps/desktop/src/shared/components/RoutingPicker/index.tsx
+++ b/apps/desktop/src/shared/components/RoutingPicker/index.tsx
@@ -8,7 +8,16 @@ import {
   resolveModelArgs,
   resolveStoredModelSelection,
 } from '@goodboy/core';
-import { Button, cn, Divider, DropdownPortal, Popover, ScrollFade, useDropdown } from '@goodboy/ui';
+import {
+  Button,
+  cn,
+  Divider,
+  DropdownPortal,
+  Popover,
+  ScrollFade,
+  Tooltip,
+  useDropdown,
+} from '@goodboy/ui';
 import type { CatalogModel, ModelSelection, ProviderId } from '@goodboy/types';
 import {
   EFFORT_LABEL,
@@ -278,61 +287,66 @@ export const RoutingPicker = ({
       className={cn('relative flex items-center gap-1', variant === 'field' && 'w-full')}
     >
       {onReset != null && isOverridden && !disabled && (
-        <button
-          type="button"
-          onClick={onReset}
-          title={
+        <Tooltip
+          content={
             defaultSummary != null ? `reset to default (${defaultSummary})` : 'reset to default'
           }
-          aria-label="Reset routing override"
-          className="shrink-0 rounded-full p-1 text-muted-foreground/70 transition-colors hover:bg-muted hover:text-foreground"
         >
-          <RotateCcw size={10} aria-hidden />
-        </button>
+          <button
+            type="button"
+            onClick={onReset}
+            aria-label="Reset routing override"
+            className="shrink-0 rounded-full p-1 text-muted-foreground/70 transition-colors hover:bg-muted hover:text-foreground"
+          >
+            <RotateCcw size={10} aria-hidden />
+          </button>
+        </Tooltip>
       )}
-      <button
-        type="button"
-        onClick={toggle}
-        disabled={disabled}
-        title={disabled ? (disabledTitle ?? summary) : `${summary}. Click to change.`}
-        aria-haspopup="dialog"
-        aria-expanded={open}
-        aria-label={ariaLabel != null ? `${ariaLabel}: ${summary}` : summary}
-        className={cn(
-          'items-center gap-1.5 text-xs transition-colors',
-          variant === 'pill'
-            ? 'inline-flex rounded-full px-2.5 py-0.5'
-            : 'flex w-full rounded-md border px-2 py-1.5 text-left',
-          variant === 'field' &&
-            (open
-              ? 'border-primary bg-primary/5'
-              : 'border-border-soft bg-subtle hover:border-border hover:bg-muted/50'),
-          variant === 'pill' &&
-            (isOverridden
-              ? 'bg-warning/10 ring-1 ring-warning/30 hover:bg-warning/15'
-              : 'bg-subtle hover:bg-muted'),
-          disabled && 'cursor-not-allowed opacity-60',
-        )}
-      >
-        <span className="flex min-w-0 flex-1 items-center gap-1.5">
-          <TriggerLabel
-            provider={routing.provider}
-            model={routing.model}
-            modelDetail={routingVariant?.label}
-            effort={routing.effort}
-            showEffort={showEffort}
-            verbosity={verbosity}
-          />
-        </span>
-        <ChevronDown
-          size={11}
-          aria-hidden
+      <Tooltip content={disabled ? (disabledTitle ?? summary) : `${summary}. Click to change.`}>
+        <button
+          type="button"
+          onClick={toggle}
+          disabled={disabled}
+          title={disabled ? (disabledTitle ?? summary) : `${summary}. Click to change.`}
+          aria-haspopup="dialog"
+          aria-expanded={open}
+          aria-label={ariaLabel != null ? `${ariaLabel}: ${summary}` : summary}
           className={cn(
-            'shrink-0 text-muted-foreground transition-transform',
-            open && 'rotate-180',
+            'items-center gap-1.5 text-xs transition-colors',
+            variant === 'pill'
+              ? 'inline-flex rounded-full px-2.5 py-0.5'
+              : 'flex w-full rounded-md border px-2 py-1.5 text-left',
+            variant === 'field' &&
+              (open
+                ? 'border-primary bg-primary/5'
+                : 'border-border-soft bg-subtle hover:border-border hover:bg-muted/50'),
+            variant === 'pill' &&
+              (isOverridden
+                ? 'bg-warning/10 ring-1 ring-warning/30 hover:bg-warning/15'
+                : 'bg-subtle hover:bg-muted'),
+            disabled && 'cursor-not-allowed opacity-60',
           )}
-        />
-      </button>
+        >
+          <span className="flex min-w-0 flex-1 items-center gap-1.5">
+            <TriggerLabel
+              provider={routing.provider}
+              model={routing.model}
+              modelDetail={routingVariant?.label}
+              effort={routing.effort}
+              showEffort={showEffort}
+              verbosity={verbosity}
+            />
+          </span>
+          <ChevronDown
+            size={11}
+            aria-hidden
+            className={cn(
+              'shrink-0 text-muted-foreground transition-transform',
+              open && 'rotate-180',
+            )}
+          />
+        </button>
+      </Tooltip>
       <DropdownPortal portal={portal} portalTarget={portalTarget}>
         {open && (
           <Popover

--- a/packages/ui/DESIGN-SYSTEM.md
+++ b/packages/ui/DESIGN-SYSTEM.md
@@ -272,6 +272,20 @@ visible; lifecycle and destructive bottom right. Hover may reveal lifecycle
 actions without moving either slot, and keyboard focus reveals the same. Icon
 actions use the shared `Tooltip`, never the native `title`.
 
+**A control whose only content is an icon carries a tooltip, everywhere.** The
+`aria-label` names it for assistive tech and leaves the pointer with nothing, so
+`IconButton`, `OverflowMenu`, `CopyButton` and `RefreshIconButton` wrap
+themselves, and a hand-rolled icon button wraps itself in `Tooltip`. The native
+`title` waits a second, renders in the OS chrome rather than ours, and cannot be
+positioned or styled. Passing `tooltip` says more than the accessible name when
+the control needs it, and `IconButton` refuses a `title` at the type level.
+
+The one place a native `title` stays is a control that can go `disabled`: a
+disabled element dispatches no pointer events, so its hover tooltip would never
+open, and the title is the only thing left that explains why the control is
+unavailable. Those controls carry both. `icon-only-controls-carry-a-tooltip`
+holds the rule and that exception.
+
 **One creation grammar.** Bare sections stacked in one column, never a bordered
 box around the whole thing; secondary affordances in `SectionHeader`'s
 `action` slot; related options in one container, not one card each; one

--- a/packages/ui/DESIGN-SYSTEM.md
+++ b/packages/ui/DESIGN-SYSTEM.md
@@ -20,7 +20,36 @@ lives here.
 pair, the box height follows whatever `line-height` the size inherits: `3xs` and
 `2xs` inherited the body's 1.55 and resolved to 15.5px and 17.05px, which put the
 lens rail's group labels and count chips on a fractional pixel and made a row
-carrying a count taller than a row without one.
+carrying a count taller than a row without one. `3xs`, `2xs` and `sm` carry a
+pinned line height in the tokens; `xs` does not, so a repeated row using it
+writes `leading-4` at the call site.
+
+### One grade per role
+
+The grade follows what a thing **is**, not which file draws it. A row label is a
+row label in the activity feed and in a brief, so it is the same size in both.
+The session Overview is the reference surface: its density was calibrated
+deliberately, and a surface that runs a grade larger for the same role forces the
+user to pick between a comfortable Overview and a comfortable everything else,
+since window zoom scales all of them at once.
+
+| role                                             | grade               | resolves to |
+| ------------------------------------------------ | ------------------- | ----------- |
+| pane title                                       | `text-xl`           | 20px        |
+| section label, and its `hint`                    | `text-2xs`          | 11px / 16px |
+| top-level row label                              | `text-sm leading-5` | 14px / 20px |
+| nested row label, a child of the row above it    | `text-xs leading-4` | 12px / 16px |
+| secondary label beside a row label               | `text-2xs`          | 11px / 16px |
+| chip                                             | `text-2xs`          | 11px / 16px |
+| metadata inside a row: time, ordinal, cost, hint | `text-3xs`          | 10px / 14px |
+| status label                                     | `text-xs`           | 12px        |
+
+**Prose is the one exception, and it is a reading grade, not a drift.** Human and
+assistant transcript messages, a markdown body and any artifact the reader came
+for stay on the comfortable grade (`text-sm`). Shrinking those makes the app
+worse. Chrome around prose still takes the grade its role asks for: a document
+pane's section label is an eyebrow even when the body under it is `text-sm`,
+because `DESIGN.md` compresses chrome without limit and never the artifact.
 
 ## Radius scale
 
@@ -218,7 +247,9 @@ That row also shares the measure of the content it commits, never stretched acro
 
 ## Section rhythm
 
-`PANE_RHYTHM.stack` separates peer sections and `Divider` separates regions whose boundary matters. Section children do not add margins. `SectionHeader` is the canonical section heading and optional description: its default eyebrow size is for compact and scan surfaces, while `size="page"` is for a reading-surface section that needs an `h2`. Description copy comes only through `hint`, so its size and muted tone remain paired with the heading grade.
+`PANE_RHYTHM.stack` separates peer sections and `Divider` separates regions whose boundary matters. Section children do not add margins. `SectionHeader` is the canonical section heading and optional description: the eyebrow size is the default for every surface, and `size="page"` is reserved for a document whose body is prose the reader came for, such as the guide or a creation flow's form sections. Description copy comes only through `hint`, so its size and muted tone remain paired with the heading grade.
+
+**The outline is independent of the grade.** `headingLevel` promotes an eyebrow-grade label to an `h2` or `h3`, so a pane section keeps its place in the document outline without taking the page grade. A section that needs a heading is not thereby a section that needs bigger type.
 
 `SectionSurface` is `SectionHeader` on the one raised section surface, for a
 reading surface whose sections would otherwise be separated by vertical space

--- a/packages/ui/DESIGN-SYSTEM.md
+++ b/packages/ui/DESIGN-SYSTEM.md
@@ -280,15 +280,18 @@ themselves, and a hand-rolled icon button wraps itself in `Tooltip`. The native
 positioned or styled. Passing `tooltip` says more than the accessible name when
 the control needs it, and `IconButton` refuses a `title` at the type level.
 
-A control that can go `disabled` is the exception, because a disabled element
-dispatches no pointer events and its hover tooltip would never open. Such a
-control needs one of two things: a `title` set only for the disabled state, which
-is what the primitives do, or a `Tooltip` that wraps something around the control
-rather than the control itself, so the wrapper takes the hover the disabled
-button swallows. Never a `title` that is always present, since then the OS
-tooltip and ours both open while the control is live.
-`icon-only-controls-carry-a-tooltip` holds the rule and both halves of the
-exception.
+There is no exception for a control that can go `disabled`, and no native
+`title` for that state either. A disabled element dispatches no mouse event and
+truncates the event path above itself, so listeners on the control are dead in
+exactly the state where the user most needs to know why nothing happens.
+`Tooltip` answers that itself: a trigger that declares `disabled` gets an anchor
+span that carries the listeners and takes `pointer-events` away from the
+disabled control, so the hover lands on the anchor and the tooltip still opens.
+A trigger that needs its anchor shaped, because it is out of flow or stretches,
+passes `anchorClassName` rather than hand-rolling a wrapper, since a wrapper
+between `Tooltip` and the control hides the `disabled` the primitive acts on.
+Keyboard focus is still out of reach while `disabled`, which is the attribute's
+own doing. `icon-only-controls-carry-a-tooltip` holds the rule.
 
 **One creation grammar.** Bare sections stacked in one column, never a bordered
 box around the whole thing; secondary affordances in `SectionHeader`'s

--- a/packages/ui/DESIGN-SYSTEM.md
+++ b/packages/ui/DESIGN-SYSTEM.md
@@ -280,11 +280,15 @@ themselves, and a hand-rolled icon button wraps itself in `Tooltip`. The native
 positioned or styled. Passing `tooltip` says more than the accessible name when
 the control needs it, and `IconButton` refuses a `title` at the type level.
 
-The one place a native `title` stays is a control that can go `disabled`: a
-disabled element dispatches no pointer events, so its hover tooltip would never
-open, and the title is the only thing left that explains why the control is
-unavailable. Those controls carry both. `icon-only-controls-carry-a-tooltip`
-holds the rule and that exception.
+A control that can go `disabled` is the exception, because a disabled element
+dispatches no pointer events and its hover tooltip would never open. Such a
+control needs one of two things: a `title` set only for the disabled state, which
+is what the primitives do, or a `Tooltip` that wraps something around the control
+rather than the control itself, so the wrapper takes the hover the disabled
+button swallows. Never a `title` that is always present, since then the OS
+tooltip and ours both open while the control is live.
+`icon-only-controls-carry-a-tooltip` holds the rule and both halves of the
+exception.
 
 **One creation grammar.** Bare sections stacked in one column, never a bordered
 box around the whole thing; secondary affordances in `SectionHeader`'s

--- a/packages/ui/src/__tests__/IconButton.test.tsx
+++ b/packages/ui/src/__tests__/IconButton.test.tsx
@@ -5,6 +5,14 @@ import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { RefreshCw } from 'lucide-react';
 import { IconButton } from '../components/IconButton';
 
+const anchorOf = (trigger: HTMLElement): HTMLElement => {
+  const anchor = trigger.parentElement;
+  if (anchor === null) {
+    throw new Error('the trigger has no anchor to hover');
+  }
+  return anchor;
+};
+
 const hover = (button: HTMLElement): void => {
   vi.useFakeTimers();
   fireEvent.mouseEnter(button);
@@ -38,11 +46,12 @@ describe('IconButton', () => {
     expect(screen.getByRole('tooltip').textContent).toBe('Refresh issues from GitHub');
   });
 
-  it('falls back to a native title while disabled, the one state hover cannot reach', () => {
+  it('keeps explaining itself while disabled, and still without a native title', () => {
     render(<IconButton icon={RefreshCw} label="Refresh issues" disabled />);
-    expect(screen.getByRole('button', { name: 'Refresh issues' }).getAttribute('title')).toBe(
-      'Refresh issues',
-    );
+    const button = screen.getByRole('button', { name: 'Refresh issues' });
+    expect(button.getAttribute('title')).toBeNull();
+    hover(anchorOf(button));
+    expect(screen.getByRole('tooltip').textContent).toBe('Refresh issues');
   });
 
   it('reports the action back to the caller', () => {

--- a/packages/ui/src/__tests__/IconButton.test.tsx
+++ b/packages/ui/src/__tests__/IconButton.test.tsx
@@ -1,17 +1,41 @@
 // @vitest-environment happy-dom
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, render, screen } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { RefreshCw } from 'lucide-react';
 import { IconButton } from '../components/IconButton';
+
+const hover = (button: HTMLElement): void => {
+  vi.useFakeTimers();
+  fireEvent.mouseEnter(button);
+  act(() => {
+    vi.advanceTimersByTime(400);
+  });
+  vi.useRealTimers();
+};
 
 describe('IconButton', () => {
   afterEach(cleanup);
 
-  it('names itself for assistive tech and for the pointer', () => {
+  it('names itself for assistive tech and leaves the native tooltip alone', () => {
     render(<IconButton icon={RefreshCw} label="Refresh issues" />);
     const button = screen.getByRole('button', { name: 'Refresh issues' });
-    expect(button.getAttribute('title')).toBe('Refresh issues');
+    expect(button.getAttribute('title')).toBeNull();
+  });
+
+  it('explains itself to the pointer through the shared tooltip', () => {
+    render(<IconButton icon={RefreshCw} label="Refresh issues" />);
+    hover(screen.getByRole('button', { name: 'Refresh issues' }));
+    expect(screen.getByRole('tooltip').textContent).toBe('Refresh issues');
+  });
+
+  it('lets the caller say more in the tooltip than the accessible name', () => {
+    render(
+      <IconButton icon={RefreshCw} label="Refresh issues" tooltip="Refresh issues from GitHub" />,
+    );
+    const button = screen.getByRole('button', { name: 'Refresh issues' });
+    hover(button);
+    expect(screen.getByRole('tooltip').textContent).toBe('Refresh issues from GitHub');
   });
 
   it('reports the action back to the caller', () => {

--- a/packages/ui/src/__tests__/IconButton.test.tsx
+++ b/packages/ui/src/__tests__/IconButton.test.tsx
@@ -38,6 +38,13 @@ describe('IconButton', () => {
     expect(screen.getByRole('tooltip').textContent).toBe('Refresh issues from GitHub');
   });
 
+  it('falls back to a native title while disabled, the one state hover cannot reach', () => {
+    render(<IconButton icon={RefreshCw} label="Refresh issues" disabled />);
+    expect(screen.getByRole('button', { name: 'Refresh issues' }).getAttribute('title')).toBe(
+      'Refresh issues',
+    );
+  });
+
   it('reports the action back to the caller', () => {
     const onClick = vi.fn();
     render(<IconButton icon={RefreshCw} label="Refresh issues" onClick={onClick} />);

--- a/packages/ui/src/__tests__/OverflowMenu.test.tsx
+++ b/packages/ui/src/__tests__/OverflowMenu.test.tsx
@@ -1,15 +1,40 @@
 // @vitest-environment happy-dom
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { OverflowMenu, type OverflowMenuItem } from '../components/OverflowMenu';
 
 afterEach(cleanup);
+
+const hover = (button: HTMLElement): void => {
+  vi.useFakeTimers();
+  fireEvent.mouseEnter(button);
+  act(() => {
+    vi.advanceTimersByTime(400);
+  });
+  vi.useRealTimers();
+};
 
 describe('OverflowMenu', () => {
   it('renders a trigger button with the default label', () => {
     render(<OverflowMenu items={[]} />);
     expect(screen.getByRole('button', { name: /more actions/i })).toBeDefined();
+  });
+
+  it('explains the trigger through the shared tooltip, not a native title', () => {
+    render(<OverflowMenu items={[]} />);
+    const trigger = screen.getByRole('button', { name: /more actions/i });
+    expect(trigger.getAttribute('title')).toBeNull();
+    hover(trigger);
+    expect(screen.getByRole('tooltip').textContent).toBe('More actions');
+  });
+
+  it('lets the caller name the action in the tooltip', () => {
+    render(
+      <OverflowMenu items={[]} label="Branch actions" tooltip="Rebase this branch, or push" />,
+    );
+    hover(screen.getByRole('button', { name: /branch actions/i }));
+    expect(screen.getByRole('tooltip').textContent).toBe('Rebase this branch, or push');
   });
 
   it('opens the menu on trigger click and shows item labels', () => {

--- a/packages/ui/src/__tests__/SectionHeader.test.tsx
+++ b/packages/ui/src/__tests__/SectionHeader.test.tsx
@@ -66,4 +66,34 @@ describe('SectionHeader, eyebrow size', () => {
     expect(screen.getByText('Versions')).toBeDefined();
     expect(screen.getByText('restore any of them')).toBeDefined();
   });
+
+  it('sits the label on the eyebrow grade and the description one grade under nothing', () => {
+    render(<SectionHeader label="Decisions" hint="One row per choice already settled." />);
+
+    expect(screen.getByText('Decisions').className).toContain('text-2xs');
+    expect(screen.getByText('One row per choice already settled.').className).toContain('text-2xs');
+  });
+
+  it('keeps the heading in the outline when a reading surface asks for one', () => {
+    render(<SectionHeader label="Session summary" headingLevel={2} />);
+
+    const heading = screen.getByRole('heading', { level: 2, name: 'Session summary' });
+
+    expect(heading.textContent).toBe('Session summary');
+  });
+
+  it('leaves a promoted heading on the eyebrow grade rather than the page grade', () => {
+    render(<SectionHeader label="Session summary" headingLevel={2} />);
+
+    const heading = screen.getByRole('heading', { level: 2 });
+
+    expect(heading.className).not.toContain('text-base');
+    expect(screen.getByText('Session summary').className).toContain('text-2xs');
+  });
+
+  it('takes a third-level heading for a block nested inside a section', () => {
+    render(<SectionHeader label="Decisions" headingLevel={3} />);
+
+    expect(screen.getByRole('heading', { level: 3, name: 'Decisions' })).toBeDefined();
+  });
 });

--- a/packages/ui/src/__tests__/SectionSurface.test.tsx
+++ b/packages/ui/src/__tests__/SectionSurface.test.tsx
@@ -36,6 +36,19 @@ describe('SectionSurface', () => {
     expect(screen.getByText('what the agent produced')).toBeDefined();
   });
 
+  it('keeps the label in the outline while it stays on the eyebrow grade', () => {
+    render(
+      <SectionSurface label="Outcome" headingLevel={2}>
+        shipped it
+      </SectionSurface>,
+    );
+
+    const heading = screen.getByRole('heading', { level: 2, name: 'Outcome' });
+
+    expect(heading.className).not.toContain('text-base');
+    expect(screen.getByText('Outcome').className).toContain('text-2xs');
+  });
+
   it('names the surface as a region only when it is given a name', () => {
     const { rerender } = render(<SectionSurface label="Preview">body</SectionSurface>);
     expect(screen.queryByRole('region')).toBeNull();

--- a/packages/ui/src/__tests__/Tooltip.test.tsx
+++ b/packages/ui/src/__tests__/Tooltip.test.tsx
@@ -5,6 +5,14 @@ import { Tooltip } from '../components/Tooltip';
 
 afterEach(cleanup);
 
+const anchorOf = (trigger: HTMLElement): HTMLElement => {
+  const anchor = trigger.parentElement;
+  if (anchor === null) {
+    throw new Error('the trigger has no anchor to hover');
+  }
+  return anchor;
+};
+
 describe('Tooltip', () => {
   it('does not show tooltip initially', () => {
     render(
@@ -79,6 +87,67 @@ describe('Tooltip', () => {
     fireEvent.blur(screen.getByRole('button'));
     expect(screen.queryByRole('tooltip')).toBeNull();
     vi.useRealTimers();
+  });
+
+  it('still opens while the trigger is disabled, from the anchor around it', async () => {
+    vi.useFakeTimers();
+    render(
+      <Tooltip content="nothing to send yet">
+        <button type="button" disabled>
+          btn
+        </button>
+      </Tooltip>,
+    );
+    fireEvent.mouseEnter(anchorOf(screen.getByRole('button')));
+    await act(async () => {
+      vi.advanceTimersByTime(400);
+    });
+    expect(screen.getByRole('tooltip').textContent).toBe('nothing to send yet');
+    vi.useRealTimers();
+  });
+
+  it('takes pointer events off the disabled trigger so the anchor receives them', () => {
+    render(
+      <Tooltip content="nothing to send yet">
+        <button type="button" disabled>
+          btn
+        </button>
+      </Tooltip>,
+    );
+    expect(anchorOf(screen.getByRole('button')).className).toContain(
+      '[&_:disabled]:pointer-events-none',
+    );
+  });
+
+  it('leaves the live trigger hoverable, anchor or not', () => {
+    render(
+      <Tooltip content="send">
+        <button type="button" disabled={false}>
+          btn
+        </button>
+      </Tooltip>,
+    );
+    expect(anchorOf(screen.getByRole('button')).className).not.toContain('pointer-events-none');
+  });
+
+  it('adds nothing around a trigger that can never go disabled', () => {
+    const { container } = render(
+      <Tooltip content="send">
+        <button type="button">btn</button>
+      </Tooltip>,
+    );
+    expect(anchorOf(screen.getByRole('button'))).toBe(container);
+  });
+
+  it('lets a trigger that is out of flow shape its own anchor', () => {
+    render(
+      <Tooltip content="remove step" anchorClassName="absolute right-1.5 top-1.5">
+        <button type="button" disabled={false}>
+          btn
+        </button>
+      </Tooltip>,
+    );
+    expect(anchorOf(screen.getByRole('button')).className).toContain('absolute right-1.5 top-1.5');
   });
 
   it('portals the tooltip into its nearest open dialog', async () => {

--- a/packages/ui/src/components/CardAction.tsx
+++ b/packages/ui/src/components/CardAction.tsx
@@ -30,30 +30,32 @@ export const CardAction = ({
   disabled = false,
   onClick,
 }: CardActionProps) => (
-  <Tooltip content={label} side="top">
-    <span className={cn('inline-flex shrink-0', size === 'compact' ? 'size-6' : 'size-7')}>
-      <button
-        type="button"
-        aria-label={label}
-        aria-pressed={pressed}
-        aria-expanded={expanded}
-        disabled={disabled}
-        onClick={(event) => {
-          event.stopPropagation();
-          onClick();
-        }}
-        className={cn(
-          'inline-flex size-full shrink-0 items-center justify-center rounded-md font-medium text-muted-foreground transition-[background-color,color,opacity] focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] disabled:pointer-events-none disabled:opacity-40',
-          size === 'compact' ? 'text-3xs' : 'text-xs',
-          tintClasses(tone).hoverBgSoft,
-          tintClasses(tone).hoverText,
-          reveal && 'opacity-0',
-          reveal && revealGroup,
-          highlighted && cn(tintClasses(tone).bgSoft, tintClasses(tone).text),
-        )}
-      >
-        <Icon size={size === 'compact' ? 12 : 14} aria-hidden />
-      </button>
-    </span>
+  <Tooltip
+    content={label}
+    side="top"
+    anchorClassName={cn('shrink-0', size === 'compact' ? 'size-6' : 'size-7')}
+  >
+    <button
+      type="button"
+      aria-label={label}
+      aria-pressed={pressed}
+      aria-expanded={expanded}
+      disabled={disabled}
+      onClick={(event) => {
+        event.stopPropagation();
+        onClick();
+      }}
+      className={cn(
+        'inline-flex size-full shrink-0 items-center justify-center rounded-md font-medium text-muted-foreground transition-[background-color,color,opacity] focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] disabled:opacity-40',
+        size === 'compact' ? 'text-3xs' : 'text-xs',
+        tintClasses(tone).hoverBgSoft,
+        tintClasses(tone).hoverText,
+        reveal && 'opacity-0',
+        reveal && revealGroup,
+        highlighted && cn(tintClasses(tone).bgSoft, tintClasses(tone).text),
+      )}
+    >
+      <Icon size={size === 'compact' ? 12 : 14} aria-hidden />
+    </button>
   </Tooltip>
 );

--- a/packages/ui/src/components/CopyButton.tsx
+++ b/packages/ui/src/components/CopyButton.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react';
 import { Check, Copy, X } from 'lucide-react';
 import { cn } from '../cn';
 import { useCopyLink } from '../useCopyLink';
+import { Tooltip } from './Tooltip';
 
 export type CopyButtonProps = {
   value: string;
@@ -27,31 +28,32 @@ export const CopyButton = ({
   const Glyph = GLYPH[state];
 
   return (
-    <button
-      type="button"
-      onClick={(event) => {
-        event.stopPropagation();
-        void copy(value);
-      }}
-      title={state === 'idle' ? label : state === 'copied' ? 'copied' : 'copy failed'}
-      aria-label={presentation === 'text' ? `copy ${label === 'Copy' ? 'text' : label}` : label}
-      className={cn(
-        'inline-flex shrink-0 items-center rounded-md p-1 transition-colors',
-        state === 'idle' && 'text-muted-foreground hover:bg-muted/50 hover:text-foreground',
-        state === 'copied' && 'text-success',
-        state === 'failed' && 'text-danger',
-        className,
-      )}
-    >
-      {presentation === 'icon' ? <Glyph size={size} aria-hidden /> : null}
-      {presentation === 'text'
-        ? state === 'copied'
-          ? `copied: ${label === 'Copy' ? 'text' : label}`
-          : state === 'failed'
-            ? 'copy failed'
-            : 'copy'
-        : null}
-      {presentation === 'icon' && children != null && (state === 'copied' ? 'Copied' : children)}
-    </button>
+    <Tooltip content={state === 'idle' ? label : state === 'copied' ? 'copied' : 'copy failed'}>
+      <button
+        type="button"
+        onClick={(event) => {
+          event.stopPropagation();
+          void copy(value);
+        }}
+        aria-label={presentation === 'text' ? `copy ${label === 'Copy' ? 'text' : label}` : label}
+        className={cn(
+          'inline-flex shrink-0 items-center rounded-md p-1 transition-colors',
+          state === 'idle' && 'text-muted-foreground hover:bg-muted/50 hover:text-foreground',
+          state === 'copied' && 'text-success',
+          state === 'failed' && 'text-danger',
+          className,
+        )}
+      >
+        {presentation === 'icon' ? <Glyph size={size} aria-hidden /> : null}
+        {presentation === 'text'
+          ? state === 'copied'
+            ? `copied: ${label === 'Copy' ? 'text' : label}`
+            : state === 'failed'
+              ? 'copy failed'
+              : 'copy'
+          : null}
+        {presentation === 'icon' && children != null && (state === 'copied' ? 'Copied' : children)}
+      </button>
+    </Tooltip>
   );
 };

--- a/packages/ui/src/components/IconButton.tsx
+++ b/packages/ui/src/components/IconButton.tsx
@@ -2,10 +2,12 @@ import type { ComponentProps } from 'react';
 import type { LucideIcon } from 'lucide-react';
 import { cn } from '../cn';
 import { tintClasses, type Tone } from '../tint';
+import { Tooltip } from './Tooltip';
 
-export type IconButtonProps = Omit<ComponentProps<'button'>, 'type' | 'children'> & {
+export type IconButtonProps = Omit<ComponentProps<'button'>, 'type' | 'children' | 'title'> & {
   icon: LucideIcon;
   label: string;
+  tooltip?: string;
   iconSize?: number;
   busy?: boolean;
   tone?: Tone;
@@ -20,6 +22,7 @@ const toneClasses = (tone: Tone): string => {
 export const IconButton = ({
   icon: Icon,
   label,
+  tooltip,
   iconSize = 13,
   busy = false,
   tone = 'neutral',
@@ -28,22 +31,23 @@ export const IconButton = ({
   ...rest
 }: IconButtonProps) => {
   return (
-    <button
-      type={type}
-      title={label}
-      aria-label={label}
-      className={cn(
-        'inline-flex items-center justify-center rounded-md border border-border-soft p-1.5',
-        'text-muted-foreground motion-safe:transition-colors',
-        'hover:border-border hover:bg-muted/50 hover:text-foreground disabled:opacity-50',
-        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]',
-        tone !== 'neutral' && toneClasses(tone),
-        busy && 'animate-border-pulse',
-        className,
-      )}
-      {...rest}
-    >
-      <Icon size={iconSize} aria-hidden />
-    </button>
+    <Tooltip content={tooltip ?? label}>
+      <button
+        type={type}
+        aria-label={label}
+        className={cn(
+          'inline-flex items-center justify-center rounded-md border border-border-soft p-1.5',
+          'text-muted-foreground motion-safe:transition-colors',
+          'hover:border-border hover:bg-muted/50 hover:text-foreground disabled:opacity-50',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]',
+          tone !== 'neutral' && toneClasses(tone),
+          busy && 'animate-border-pulse',
+          className,
+        )}
+        {...rest}
+      >
+        <Icon size={iconSize} aria-hidden />
+      </button>
+    </Tooltip>
   );
 };

--- a/packages/ui/src/components/IconButton.tsx
+++ b/packages/ui/src/components/IconButton.tsx
@@ -27,13 +27,18 @@ export const IconButton = ({
   busy = false,
   tone = 'neutral',
   type = 'button',
+  disabled,
   className,
   ...rest
 }: IconButtonProps) => {
+  const explanation = tooltip ?? label;
+
   return (
-    <Tooltip content={tooltip ?? label}>
+    <Tooltip content={explanation}>
       <button
         type={type}
+        disabled={disabled}
+        title={disabled === true ? explanation : undefined}
         aria-label={label}
         className={cn(
           'inline-flex items-center justify-center rounded-md border border-border-soft p-1.5',

--- a/packages/ui/src/components/IconButton.tsx
+++ b/packages/ui/src/components/IconButton.tsx
@@ -27,18 +27,13 @@ export const IconButton = ({
   busy = false,
   tone = 'neutral',
   type = 'button',
-  disabled,
   className,
   ...rest
 }: IconButtonProps) => {
-  const explanation = tooltip ?? label;
-
   return (
-    <Tooltip content={explanation}>
+    <Tooltip content={tooltip ?? label}>
       <button
         type={type}
-        disabled={disabled}
-        title={disabled === true ? explanation : undefined}
         aria-label={label}
         className={cn(
           'inline-flex items-center justify-center rounded-md border border-border-soft p-1.5',

--- a/packages/ui/src/components/OverflowMenu.tsx
+++ b/packages/ui/src/components/OverflowMenu.tsx
@@ -56,12 +56,11 @@ export const OverflowMenu = ({
 
   return (
     <div className="relative" ref={dropdown.containerRef}>
-      <Tooltip content={tooltip ?? label}>
+      <Tooltip content={tooltip ?? label} anchorClassName="shrink-0">
         <button
           type="button"
           onClick={dropdown.toggle}
           disabled={disabled}
-          title={disabled === true ? (tooltip ?? label) : undefined}
           aria-label={label}
           aria-haspopup="menu"
           aria-expanded={dropdown.open}

--- a/packages/ui/src/components/OverflowMenu.tsx
+++ b/packages/ui/src/components/OverflowMenu.tsx
@@ -2,6 +2,7 @@ import type { ComponentType, ReactNode } from 'react';
 import { MoreVertical } from 'lucide-react';
 import { cn } from '../cn';
 import { Popover } from './Popover';
+import { Tooltip } from './Tooltip';
 import { useDropdown } from '../useDropdown';
 import { DropdownPortal } from '../useDropdown/DropdownPortal';
 
@@ -29,6 +30,7 @@ export type OverflowMenuItem =
 type OverflowMenuProps = {
   readonly items: ReadonlyArray<OverflowMenuItem>;
   readonly label?: string;
+  readonly tooltip?: string;
   readonly triggerClassName?: string;
   readonly trigger?: ReactNode;
   readonly disabled?: boolean;
@@ -38,6 +40,7 @@ type OverflowMenuProps = {
 export const OverflowMenu = ({
   items,
   label = 'More actions',
+  tooltip,
   triggerClassName,
   trigger,
   disabled,
@@ -53,25 +56,26 @@ export const OverflowMenu = ({
 
   return (
     <div className="relative" ref={dropdown.containerRef}>
-      <button
-        type="button"
-        onClick={dropdown.toggle}
-        disabled={disabled}
-        title={label}
-        aria-label={label}
-        aria-haspopup="menu"
-        aria-expanded={dropdown.open}
-        className={cn(
-          'shrink-0 rounded p-1 motion-safe:transition-colors',
-          disabled
-            ? 'cursor-not-allowed text-muted-foreground/30'
-            : 'text-muted-foreground/60 hover:bg-foreground/10 hover:text-foreground',
-          dropdown.open && 'bg-foreground/10 text-foreground',
-          triggerClassName,
-        )}
-      >
-        {trigger ?? <MoreVertical size={13} aria-hidden />}
-      </button>
+      <Tooltip content={tooltip ?? label}>
+        <button
+          type="button"
+          onClick={dropdown.toggle}
+          disabled={disabled}
+          aria-label={label}
+          aria-haspopup="menu"
+          aria-expanded={dropdown.open}
+          className={cn(
+            'shrink-0 rounded p-1 motion-safe:transition-colors',
+            disabled
+              ? 'cursor-not-allowed text-muted-foreground/30'
+              : 'text-muted-foreground/60 hover:bg-foreground/10 hover:text-foreground',
+            dropdown.open && 'bg-foreground/10 text-foreground',
+            triggerClassName,
+          )}
+        >
+          {trigger ?? <MoreVertical size={13} aria-hidden />}
+        </button>
+      </Tooltip>
       {dropdown.open ? (
         <DropdownPortal portal={dropdown.portal} portalTarget={dropdown.portalTarget}>
           <Popover

--- a/packages/ui/src/components/OverflowMenu.tsx
+++ b/packages/ui/src/components/OverflowMenu.tsx
@@ -61,6 +61,7 @@ export const OverflowMenu = ({
           type="button"
           onClick={dropdown.toggle}
           disabled={disabled}
+          title={disabled === true ? (tooltip ?? label) : undefined}
           aria-label={label}
           aria-haspopup="menu"
           aria-expanded={dropdown.open}

--- a/packages/ui/src/components/OverlayHeader.tsx
+++ b/packages/ui/src/components/OverlayHeader.tsx
@@ -77,12 +77,11 @@ export const OverlayHeader = ({
       ) : null}
       <div className="flex-1" />
       {children}
-      <Tooltip content={closeLabel}>
+      <Tooltip content={closeLabel} anchorClassName="shrink-0">
         <button
           type="button"
           onClick={onClose}
           disabled={closeDisabled}
-          title={closeDisabled === true ? closeLabel : undefined}
           aria-label={closeLabel}
           className={cn(
             'flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors',

--- a/packages/ui/src/components/OverlayHeader.tsx
+++ b/packages/ui/src/components/OverlayHeader.tsx
@@ -82,6 +82,7 @@ export const OverlayHeader = ({
           type="button"
           onClick={onClose}
           disabled={closeDisabled}
+          title={closeDisabled === true ? closeLabel : undefined}
           aria-label={closeLabel}
           className={cn(
             'flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors',

--- a/packages/ui/src/components/OverlayHeader.tsx
+++ b/packages/ui/src/components/OverlayHeader.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react';
 import { cn } from '../cn';
 import { tintClasses, type Tone } from '../tint';
 import { X, type LucideIcon } from 'lucide-react';
+import { Tooltip } from './Tooltip';
 
 type Props = {
   readonly icon?: LucideIcon;
@@ -76,20 +77,22 @@ export const OverlayHeader = ({
       ) : null}
       <div className="flex-1" />
       {children}
-      <button
-        type="button"
-        onClick={onClose}
-        disabled={closeDisabled}
-        aria-label={closeLabel}
-        className={cn(
-          'flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors',
-          'hover:bg-muted/50 hover:text-foreground',
-          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]',
-          closeDisabled && 'cursor-not-allowed opacity-50',
-        )}
-      >
-        <X size={14} aria-hidden />
-      </button>
+      <Tooltip content={closeLabel}>
+        <button
+          type="button"
+          onClick={onClose}
+          disabled={closeDisabled}
+          aria-label={closeLabel}
+          className={cn(
+            'flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors',
+            'hover:bg-muted/50 hover:text-foreground',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]',
+            closeDisabled && 'cursor-not-allowed opacity-50',
+          )}
+        >
+          <X size={14} aria-hidden />
+        </button>
+      </Tooltip>
     </header>
   );
 };

--- a/packages/ui/src/components/RefreshIconButton.tsx
+++ b/packages/ui/src/components/RefreshIconButton.tsx
@@ -26,7 +26,7 @@ export const RefreshIconButton = ({
       onClick={onClick}
       disabled={isLoading}
       busy={isLoading}
-      title={error != null && error !== '' ? `refresh failed: ${error}` : label}
+      tooltip={error != null && error !== '' ? `refresh failed: ${error}` : label}
       className={className}
     />
   );

--- a/packages/ui/src/components/SectionHeader.tsx
+++ b/packages/ui/src/components/SectionHeader.tsx
@@ -2,12 +2,15 @@ import type { ReactNode } from 'react';
 import { cn } from '../cn';
 import { Eyebrow } from './Eyebrow';
 
+const HEADING_TAG = { 2: 'h2', 3: 'h3' } as const;
+
 export type SectionHeaderProps = {
   readonly label: string;
   readonly icon?: ReactNode;
   readonly hint?: string;
   readonly action?: ReactNode;
   readonly size?: 'eyebrow' | 'page';
+  readonly headingLevel?: 2 | 3;
   readonly className?: string;
   readonly htmlFor?: string;
 };
@@ -18,6 +21,7 @@ export const SectionHeader = ({
   hint,
   action,
   size = 'eyebrow',
+  headingLevel,
   className,
   htmlFor,
 }: SectionHeaderProps) => {
@@ -40,10 +44,13 @@ export const SectionHeader = ({
     );
   }
 
+  const eyebrow = <Eyebrow icon={icon} label={title} className="flex items-center gap-1.5" />;
+  const Heading = headingLevel == null ? null : HEADING_TAG[headingLevel];
+
   return (
     <div className={cn('flex flex-col gap-1', className)}>
       <div className="flex items-center justify-between gap-2">
-        <Eyebrow icon={icon} label={title} className="flex items-center gap-1.5" />
+        {Heading == null ? eyebrow : <Heading className="min-w-0">{eyebrow}</Heading>}
         {action ?? null}
       </div>
       {hint != null ? <p className="text-2xs text-muted-foreground/70">{hint}</p> : null}

--- a/packages/ui/src/components/SectionSurface.tsx
+++ b/packages/ui/src/components/SectionSurface.tsx
@@ -9,6 +9,7 @@ export type SectionSurfaceProps = {
   readonly hint?: string;
   readonly action?: ReactNode;
   readonly headingSize?: 'eyebrow' | 'page';
+  readonly headingLevel?: 2 | 3;
   readonly ariaLabel?: string;
   readonly className?: string;
   readonly children: ReactNode;
@@ -19,12 +20,19 @@ export const SectionSurface = ({
   hint,
   action,
   headingSize = 'eyebrow',
+  headingLevel,
   ariaLabel,
   className,
   children,
 }: SectionSurfaceProps) => (
   <section aria-label={ariaLabel} className={cn(SECTION_SURFACE_CLASS, className)}>
-    <SectionHeader label={label} size={headingSize} hint={hint} action={action} />
+    <SectionHeader
+      label={label}
+      size={headingSize}
+      headingLevel={headingLevel}
+      hint={hint}
+      action={action}
+    />
     {children}
   </section>
 );

--- a/packages/ui/src/components/Tooltip.tsx
+++ b/packages/ui/src/components/Tooltip.tsx
@@ -7,8 +7,10 @@ export type TooltipSide = 'top' | 'bottom' | 'left' | 'right';
 export type TooltipProps = {
   content: string;
   side?: TooltipSide;
+  anchorClassName?: string;
   children: React.ReactElement<{
     ref?: React.Ref<HTMLElement>;
+    disabled?: boolean;
     onMouseEnter?: React.MouseEventHandler;
     onMouseLeave?: React.MouseEventHandler;
     onFocus?: React.FocusEventHandler;
@@ -99,7 +101,7 @@ const positionFor = (anchor: DOMRect, tip: DOMRect, side: TooltipSide): Coords =
   return { top, left, side: chosen };
 };
 
-export const Tooltip = ({ content, side = 'top', children }: TooltipProps) => {
+export const Tooltip = ({ content, side = 'top', anchorClassName, children }: TooltipProps) => {
   const [visible, setVisible] = useState(false);
   const [coords, setCoords] = useState<Coords | null>(null);
   const delayRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -156,25 +158,45 @@ export const Tooltip = ({ content, side = 'top', children }: TooltipProps) => {
     [childRef],
   );
 
-  const enhanced = cloneElement(children, {
-    ref: mergedRef,
-    onMouseEnter: (e: React.MouseEvent) => {
-      show();
-      children.props.onMouseEnter?.(e);
-    },
-    onMouseLeave: (e: React.MouseEvent) => {
-      hide();
-      children.props.onMouseLeave?.(e);
-    },
-    onFocus: (e: React.FocusEvent) => {
-      show();
-      children.props.onFocus?.(e);
-    },
-    onBlur: (e: React.FocusEvent) => {
-      hide();
-      children.props.onBlur?.(e);
-    },
-  });
+  const isTriggerDisabled = children.props.disabled;
+  const canTriggerBeDisabled = isTriggerDisabled !== undefined;
+  const hasAnchor = canTriggerBeDisabled || anchorClassName !== undefined;
+
+  const enhanced = hasAnchor ? (
+    <span
+      className={cn(
+        'inline-flex',
+        isTriggerDisabled === true && 'cursor-not-allowed [&_:disabled]:pointer-events-none',
+        anchorClassName,
+      )}
+      onMouseEnter={show}
+      onMouseLeave={hide}
+      onFocus={show}
+      onBlur={hide}
+    >
+      {cloneElement(children, { ref: mergedRef })}
+    </span>
+  ) : (
+    cloneElement(children, {
+      ref: mergedRef,
+      onMouseEnter: (e: React.MouseEvent) => {
+        show();
+        children.props.onMouseEnter?.(e);
+      },
+      onMouseLeave: (e: React.MouseEvent) => {
+        hide();
+        children.props.onMouseLeave?.(e);
+      },
+      onFocus: (e: React.FocusEvent) => {
+        show();
+        children.props.onFocus?.(e);
+      },
+      onBlur: (e: React.FocusEvent) => {
+        hide();
+        children.props.onBlur?.(e);
+      },
+    })
+  );
   const portalTarget =
     typeof document === 'undefined'
       ? null


### PR DESCRIPTION
Two corrections that both come down to the same thing: a role should look the same wherever it appears, and a control should tell you what it does.

## What I measured first

The session Overview is the reference: its density was calibrated deliberately, and window zoom scales every surface at once, so a surface that runs a grade larger for the same role forces the user to choose between a comfortable Overview and a comfortable everything else.

Grades resolve against a 15px root, `--spacing: 4px`:

| role | Overview (reference) | Brief before | Chat before | Context before |
| --- | --- | --- | --- | --- |
| pane title | `text-xl`, 20px | same | n/a | n/a |
| section label | `text-2xs`, 11/16 | `text-base`, 16/24 | `text-2xs` | `text-base`, 16/24 |
| section hint | `text-2xs`, 11/16 | n/a | n/a | `text-sm` + `leading-relaxed` |
| top-level row label | `text-sm`, 14/20 | same | n/a | n/a |
| nested row label | `text-xs`, 12 | `text-sm`, 14/20 | `text-xs` | n/a |
| secondary label | `text-2xs`, 11/16 | same | `text-2xs` | n/a |
| row metadata: time, ordinal, cost | `text-3xs`, 10/14 | `text-2xs`, 11/16 | `text-2xs`, 11/16 | n/a |
| status label | `text-xs`, 12 | `text-sm`, 14/20 | n/a | n/a |
| prose | `text-sm` | `text-sm` | `text-sm` | `text-sm` |

Brief and Context both ran their section label two grades hot, and all three surfaces drew row metadata one grade above Overview.

## What changed

Brief, Chat and Context now take the grade the role asks for. Nothing in the spacing scale moved.

- **Brief**: section labels drop from `text-base` to the eyebrow grade, child rows and plan rows go from `text-sm` to `text-xs leading-4`, and ordinals, costs and plan metadata drop to `text-3xs`. The live "Now" line joins the status grade.
- **Context**: section labels drop to the eyebrow grade and their descriptions to `text-2xs`. The section icon goes 14 to 13 to sit on the smaller label.
- **Chat**: a transcript row's time joins the metadata grade at `text-3xs`.

A section label losing two grades would have cost the document outline, so `SectionHeader` and `SectionSurface` take a `headingLevel`: the label renders as `h2` or `h3` while staying visually an eyebrow. Size and outline are now separate decisions.

`text-xs` is the one grade with no pinned line height, so every row moved onto it pairs an explicit `leading-4`. A regression test resolves each grade against the root and fails on a fractional line box.

## Tooltips

`IconButton`, `OverflowMenu`, `CopyButton` and `RefreshIconButton` carry the shared `Tooltip` instead of a native `title`, which covers every call site at once, and `IconButton` refuses a `title` at the type level so one cannot come back. The Overview header went first: the worktree and branch menus were two near-identical glyphs whose only name was for assistive tech, and the branch chip now says it copies rather than making you click to find out.

Then the sweep: 67 hand-rolled icon-only controls across 48 files. `Tooltip` renders no wrapper around a control that cannot go `disabled`, which is all but twelve of them, so none of that moved a pixel.

## What to look at

- `packages/ui/src/components/SectionHeader.tsx`, for the size and outline split.
- `apps/desktop/src/__tests__/regressions/icon-only-controls-carry-a-tooltip.test.ts`, which walks every component in the app and the ui package and fails on a new icon-only control with no tooltip. Its second assertion floors how many controls it inspects, so a detector that stops recognizing them fails instead of quietly passing on an empty set.
- The three commits by surface, which are the readable way through the type scale half.

## Decisions worth naming

**Prose is exempt.** Transcript messages, markdown bodies and any artifact the reader came for stay at `text-sm`. Chrome around prose still takes its role's grade: a document pane's section label is an eyebrow even when the body under it is `text-sm`.

**A control that can go `disabled` explains itself through an anchor, not a native `title`.** Review caught the real hole: a disabled element dispatches no mouse event, and Chrome, Edge and Safari also truncate the event path above it, so the tooltip's listeners were dead in the one state where the user most needs to know why nothing responds. The first answer on this branch was a `title` for that state, which fixed the hover by breaking the rule the rest of this PR enforces, so it was reversed. `Tooltip` now solves it once: a trigger that declares `disabled` is wrapped in an `inline-flex` anchor span that carries the listeners, and the disabled control loses `pointer-events` so the hover lands on the anchor. Twelve controls are in this position and they inherit it from the primitive rather than being patched one by one. Three that are out of flow or stretch pass `anchorClassName` instead of hand-rolling a wrapper, which would hide the `disabled` the primitive reads. The guard test now refuses a native `title` outright, and refuses a disabled-capable control parked behind a wrapper its `Tooltip` cannot see.

## What I left out

- **`GhostActionButton`.** It renders its label as text, so it is not an icon-only control and the pointer already has something to read. Its `title` explains a blocked action while disabled, which a tooltip cannot do.
- **Switching those disabled controls to `aria-disabled`.** The anchor restores the pointer, but `disabled` still removes a control from the tab order, so a keyboard user cannot reach the explanation. Keeping the control focusable and marking it `aria-disabled` is the better answer to that half. It changes click semantics across the pickers, the resolver decisions and the chat composer, so it belongs in its own change.
- **`text-xs` line heights outside the rows I moved.** The token stays unpinned on purpose and pinning it now would shift type nobody asked me to touch.
- **Labeled controls that carry a `title`.** Out of scope here, and their visible label already does the naming.

## Verification

`pnpm typecheck`, `pnpm test` (6074 desktop, 217 ui, 1261 core, 253 db), `pnpm build` and `pnpm knip` all pass. Knip reports the same 42 unused exports and 71 unused types as `origin/main`, so this branch adds none. `pnpm format:check` flags four files in `packages/core` and `packages/types` that this branch never touches.

Rebased onto the four sibling branches that landed on the Activity feed, the open questions and the markers. The one conflict was in `AgentBrief.test.tsx`, where the open-questions suite and the type-scale suite both appended a describe block; both are kept.

Made with [Cursor](https://cursor.com)
