### PR TITLE
fix(desktop): the timeline clock drops seconds and now keeps a dot

### DIFF
--- a/apps/desktop/src/features/chat/components/WorkflowKickoffCard/index.test.tsx
+++ b/apps/desktop/src/features/chat/components/WorkflowKickoffCard/index.test.tsx
@@ -101,6 +101,6 @@ describe('WorkflowKickoffCard', () => {
   it('renders the timestamp', () => {
     render(<WorkflowKickoffCard item={parsedItem} />);
 
-    expect(screen.getByText(/\d{2}:\d{2}:\d{2}/)).toBeDefined();
+    expect(screen.getByText(/\d{2}:\d{2}\s?(AM|PM)/)).toBeDefined();
   });
 });

--- a/apps/desktop/src/features/chat/utils/format-card-time.test.ts
+++ b/apps/desktop/src/features/chat/utils/format-card-time.test.ts
@@ -2,14 +2,14 @@ import { describe, expect, it, vi } from 'vitest';
 import { formatCardTime } from './format-card-time';
 
 describe('formatCardTime', () => {
-  it('renders ISO timestamps as HH:MM:SS', () => {
+  it('renders ISO timestamps as HH:MM with a meridiem', () => {
     const output = formatCardTime('2026-05-14T09:30:45');
-    expect(output).toMatch(/\d{1,2}:\d{2}:\d{2}/);
+    expect(output).toMatch(/^\d{2}:\d{2}\s?(AM|PM)$/);
   });
 
-  it('includes hour, minute, and second fields', () => {
+  it('carries hour and minute only, never seconds', () => {
     const output = formatCardTime('2026-05-14T23:59:59');
-    expect(output).toMatch(/\d{1,2}:\d{2}:\d{2}/);
+    expect(output).not.toMatch(/:\d{2}:\d{2}/);
   });
 
   it('pins the Intl locale to en-US', () => {

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineNowRule.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineNowRule.test.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render } from '@testing-library/react';
+import type { TimelineNowItem } from '../../../../timeline/buildTimelineStream';
+import type { RailRow } from '../../../../timeline/railGeometry';
+import { TIMELINE_RHYTHM } from '../../../../timeline/timelineRhythm';
+import { TimelineNowRule } from './TimelineNowRule';
+
+const item: TimelineNowItem = {
+  kind: 'now',
+  id: 'now',
+  height: TIMELINE_RHYTHM.now.height,
+  topY: TIMELINE_RHYTHM.now.ruleY,
+  ruleY: TIMELINE_RHYTHM.now.ruleY,
+  markerY: null,
+  topAnchorY: null,
+  groupId: null,
+  isPending: false,
+  gap: 'none',
+};
+
+const rail: RailRow = {
+  id: 'now',
+  height: TIMELINE_RHYTHM.now.height,
+  segments: [],
+  joins: [],
+  markerColumn: 0,
+  markerY: null,
+};
+
+describe('TimelineNowRule', () => {
+  afterEach(cleanup);
+
+  it('marks NOW with a dot on the spine', () => {
+    const { getByTestId } = render(<TimelineNowRule item={item} rail={rail} railWidth={24} />);
+
+    expect(getByTestId('timeline-now-dot')).toBeDefined();
+  });
+
+  it('draws no dashed rule across the row', () => {
+    const { container } = render(<TimelineNowRule item={item} rail={rail} railWidth={24} />);
+
+    expect(container.querySelector('.border-dashed')).toBeNull();
+  });
+});

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineNowRule.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineNowRule.tsx
@@ -1,6 +1,6 @@
 import { cn } from '@goodboy/ui';
 import type { TimelineNowItem } from '../../../../timeline/buildTimelineStream';
-import type { RailRow } from '../../../../timeline/railGeometry';
+import { RAIL_SPINE_X, type RailRow } from '../../../../timeline/railGeometry';
 import { TIMELINE_GUTTER } from './timelineLayout';
 import { TimelineRail } from './TimelineRail';
 
@@ -22,13 +22,13 @@ export const TimelineNowRule = ({ item, rail, railWidth }: Props) => (
     </span>
     <span className="relative shrink-0" style={{ width: railWidth }}>
       <TimelineRail rail={rail} width={railWidth} />
-    </span>
-    <span className="relative min-w-0 flex-1">
       <span
-        className="absolute left-2 right-0 border-t border-dashed border-border-soft"
-        style={{ top: item.ruleY }}
+        data-testid="timeline-now-dot"
         aria-hidden
+        className="absolute size-2 -translate-x-1/2 -translate-y-1/2 rounded-full bg-border"
+        style={{ left: RAIL_SPINE_X, top: item.ruleY }}
       />
     </span>
+    <span className="relative min-w-0 flex-1" />
   </div>
 );

--- a/apps/desktop/src/shared/utils/formatClockTime.test.ts
+++ b/apps/desktop/src/shared/utils/formatClockTime.test.ts
@@ -4,8 +4,8 @@ import { formatClockTime } from './formatClockTime';
 const ISO = '2026-07-29T11:49:00';
 
 describe('formatClockTime', () => {
-  it('renders 2-digit hour, minute, and second with an AM/PM marker', () => {
-    expect(formatClockTime({ iso: ISO })).toBe('11:49:00 AM');
+  it('renders 2-digit hour and minute with an AM/PM marker, and no seconds', () => {
+    expect(formatClockTime({ iso: ISO })).toBe('11:49 AM');
   });
 
   it('pins the Intl locale to en-US', () => {
@@ -21,6 +21,6 @@ describe('formatClockTime', () => {
   });
 
   it('accepts an epoch millisecond number', () => {
-    expect(formatClockTime({ iso: new Date(ISO).getTime() })).toBe('11:49:00 AM');
+    expect(formatClockTime({ iso: new Date(ISO).getTime() })).toBe('11:49 AM');
   });
 });

--- a/apps/desktop/src/shared/utils/formatClockTime.ts
+++ b/apps/desktop/src/shared/utils/formatClockTime.ts
@@ -13,6 +13,5 @@ export const formatClockTime = ({ iso }: Params): string => {
   return new Intl.DateTimeFormat(APP_LOCALE, {
     hour: '2-digit',
     minute: '2-digit',
-    second: '2-digit',
   }).format(date);
 };


### PR DESCRIPTION
Timestamps in the feed show hour and minute only, since seconds carry no meaning there.

NOW gets its dot back on the spine, and the horizontal dashed rule on that row is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)