### PR TITLE
fix(desktop): every run keeps its own lane instead of the spine

### DIFF
--- a/apps/desktop/src/features/session/timeline/railGeometry.test.ts
+++ b/apps/desktop/src/features/session/timeline/railGeometry.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
   RAIL_LANE_OFFSET,
-  RAIL_MAX_COLUMN,
   RAIL_SPINE_X,
   layoutTimelineRail,
   railColumnX,
@@ -466,7 +465,7 @@ describe('layoutTimelineRail', () => {
     ]);
   });
 
-  it('never puts a lane past the column cap however deep the nesting goes', () => {
+  it('gives every nesting level its own lane so no marker falls back to the spine', () => {
     const layout = layoutTimelineRail({
       rows: [
         row({ id: 'great-grandchild', groupId: 'stub-3' }),
@@ -483,10 +482,8 @@ describe('layoutTimelineRail', () => {
       ],
     });
 
-    for (const column of layout.columnByGroupId.values()) {
-      expect(column).toBeLessThanOrEqual(RAIL_MAX_COLUMN);
-    }
-    expect(layout.width).toBe(RAIL_SPINE_X + RAIL_MAX_COLUMN * RAIL_LANE_OFFSET + 8);
+    expect([...layout.columnByGroupId.values()]).toEqual([1, 2, 3, 4]);
+    expect(layout.width).toBe(RAIL_SPINE_X + 4 * RAIL_LANE_OFFSET + 8);
   });
 
   it('draws a standalone agent fan-out in the neutral spine ink, not a run colour', () => {
@@ -571,16 +568,15 @@ describe('junction integrity', () => {
 
   const fixtures: ReadonlyArray<Fixture> = [saturated, nested, dangling];
 
-  it('parks a group on the spine when every free column under the cap is taken', () => {
+  it('widens the rail rather than sharing a lane when many runs are live at once', () => {
     const layout = layoutTimelineRail(saturated);
 
     expect(layout.columnByGroupId.get('lane-a')).toBe(1);
     expect(layout.columnByGroupId.get('lane-b')).toBe(2);
     expect(layout.columnByGroupId.get('lane-c')).toBe(3);
-    expect(layout.columnByGroupId.get('stub-a')).toBe(0);
-    expect(railRow(layout, 'a-child').joins).toEqual([]);
-    expect(railRow(layout, 'a-child').markerColumn).toBe(0);
-    expect(railRow(layout, 'a-step').joins).toEqual([]);
+    expect(layout.columnByGroupId.get('stub-a')).toBe(4);
+    expect(railRow(layout, 'a-child').markerColumn).toBe(1);
+    expect(railRow(layout, 'a-child').joins.map((join) => join.laneColumn)).toEqual([4]);
   });
 
   it('never overlaps two strokes in the same lane column of a row', () => {
@@ -625,7 +621,8 @@ describe('junction integrity', () => {
         if (upper === undefined || lower === undefined) {
           continue;
         }
-        for (let column = 1; column <= RAIL_MAX_COLUMN; column += 1) {
+        const widest = Math.max(...layout.columnByGroupId.values());
+        for (let column = 1; column <= widest; column += 1) {
           const bottomTouch =
             upper.segments.some(
               (segment) => segment.column === column && segment.toY === upper.height,

--- a/apps/desktop/src/features/session/timeline/railGeometry.ts
+++ b/apps/desktop/src/features/session/timeline/railGeometry.ts
@@ -123,7 +123,7 @@ export const layoutTimelineRail = ({ rows, groups }: Params): RailLayout => {
   const depthOf = ({ group }: { readonly group: RailGroupInput }): number => {
     let depth = 0;
     let parentId = group.parentGroupId;
-    while (parentId != null && depth <= groups.length) {
+    while (parentId != null && depth < groups.length) {
       depth += 1;
       parentId = groupById.get(parentId)?.parentGroupId ?? null;
     }
@@ -155,15 +155,17 @@ export const layoutTimelineRail = ({ rows, groups }: Params): RailLayout => {
     const parentColumn =
       group.parentGroupId == null ? 0 : (columnByGroupId.get(group.parentGroupId) ?? 0);
     let column = parentColumn + 1;
-    while (
-      (takenByColumn.get(column) ?? []).some((taken) =>
-        overlaps({ first: taken, second: interval }),
-      )
-    ) {
+    let taken = takenByColumn.get(column);
+    while (taken?.some((other) => overlaps({ first: other, second: interval })) === true) {
       column += 1;
+      taken = takenByColumn.get(column);
     }
     columnByGroupId.set(group.id, column);
-    takenByColumn.set(column, [...(takenByColumn.get(column) ?? []), interval]);
+    if (taken === undefined) {
+      takenByColumn.set(column, [interval]);
+    } else {
+      taken.push(interval);
+    }
   }
 
   const plans: ReadonlyArray<GroupPlan> = ordered.map((group) => {

--- a/apps/desktop/src/features/session/timeline/railGeometry.ts
+++ b/apps/desktop/src/features/session/timeline/railGeometry.ts
@@ -1,6 +1,5 @@
 export const RAIL_SPINE_X = 8;
 export const RAIL_LANE_OFFSET = 16;
-export const RAIL_MAX_COLUMN = 3;
 const RAIL_EDGE_PAD = 8;
 const RAIL_CURVE_K = 0.5523;
 const RAIL_CURVE_HANDLE = 8.84;
@@ -124,7 +123,7 @@ export const layoutTimelineRail = ({ rows, groups }: Params): RailLayout => {
   const depthOf = ({ group }: { readonly group: RailGroupInput }): number => {
     let depth = 0;
     let parentId = group.parentGroupId;
-    while (parentId != null && depth <= RAIL_MAX_COLUMN) {
+    while (parentId != null && depth <= groups.length) {
       depth += 1;
       parentId = groupById.get(parentId)?.parentGroupId ?? null;
     }
@@ -150,7 +149,6 @@ export const layoutTimelineRail = ({ rows, groups }: Params): RailLayout => {
   );
 
   const columnByGroupId = new Map<string, number>();
-  const lanelessGroupIds = new Set<string>();
   const takenByColumn = new Map<number, Interval[]>();
   for (const group of ordered) {
     const interval = intervalOf({ group });
@@ -158,39 +156,31 @@ export const layoutTimelineRail = ({ rows, groups }: Params): RailLayout => {
       group.parentGroupId == null ? 0 : (columnByGroupId.get(group.parentGroupId) ?? 0);
     let column = parentColumn + 1;
     while (
-      column <= RAIL_MAX_COLUMN &&
       (takenByColumn.get(column) ?? []).some((taken) =>
         overlaps({ first: taken, second: interval }),
       )
     ) {
       column += 1;
     }
-    if (column > RAIL_MAX_COLUMN) {
-      columnByGroupId.set(group.id, 0);
-      lanelessGroupIds.add(group.id);
-      continue;
-    }
     columnByGroupId.set(group.id, column);
     takenByColumn.set(column, [...(takenByColumn.get(column) ?? []), interval]);
   }
 
-  const plans: ReadonlyArray<GroupPlan> = ordered
-    .filter((group) => !lanelessGroupIds.has(group.id))
-    .map((group) => {
-      const memberIndexes = membersByGroupId.get(group.id) ?? [];
-      const settled = memberIndexes.filter((index) => rows[index]?.isPending !== true);
-      const originIndex = indexById.get(group.originRowId) ?? lastIndex;
-      const boundaryIndex = settled[0] ?? originIndex;
-      return {
-        group,
-        column: columnByGroupId.get(group.id) ?? 1,
-        memberIndexes,
-        originIndex,
-        boundaryIndex,
-        hasFuture:
-          group.shape === 'open' || memberIndexes.some((index) => rows[index]?.isPending === true),
-      };
-    });
+  const plans: ReadonlyArray<GroupPlan> = ordered.map((group) => {
+    const memberIndexes = membersByGroupId.get(group.id) ?? [];
+    const settled = memberIndexes.filter((index) => rows[index]?.isPending !== true);
+    const originIndex = indexById.get(group.originRowId) ?? lastIndex;
+    const boundaryIndex = settled[0] ?? originIndex;
+    return {
+      group,
+      column: columnByGroupId.get(group.id) ?? 1,
+      memberIndexes,
+      originIndex,
+      boundaryIndex,
+      hasFuture:
+        group.shape === 'open' || memberIndexes.some((index) => rows[index]?.isPending === true),
+    };
+  });
 
   const laneSegmentsByIndex: RailSegment[][] = rows.map(() => []);
   const joinsByIndex: PlannedJoin[][] = rows.map(() => []);


### PR DESCRIPTION
A group that found no free column under the cap was parked on the spine, so its markers rendered on the main line instead of on their own coloured lane. With three or more runs live at once the cap saturated immediately and whole workflows lost their lane.

The allocator no longer caps: a group always takes the first column free over its interval, and the rail widens by one offset instead of dropping a lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)