### PR TITLE
refactor(desktop): take money controls off the orchestrator card

### DIFF
--- a/apps/desktop/src/features/workflows/components/OrchestratorPanel/index.test.tsx
+++ b/apps/desktop/src/features/workflows/components/OrchestratorPanel/index.test.tsx
@@ -514,27 +514,23 @@ describe('OrchestratorPanel strip', () => {
     expect(screen.queryByRole('menuitem')).toBeNull();
     expect(screen.getByRole('button', { name: /decide next step/i })).toBeDefined();
     expect(screen.getByRole('button', { name: /^hints$/i })).toBeDefined();
-    expect(screen.getByRole('button', { name: /^budget$/i })).toBeDefined();
     expect(screen.getByTestId('workflow-autorun-toggle')).toBeDefined();
   });
 
-  it('opens the budget from the row instead of a second review button', () => {
-    renderPanel();
-    const opened = vi.fn();
-    window.addEventListener('goodboy:open-budget-studio', opened);
-    fireEvent.click(screen.getByTestId('orchestrator-budget'));
-    window.removeEventListener('goodboy:open-budget-studio', opened);
+  it('keeps money controls off the card while the run is not paused on budget', () => {
+    renderPanel({ agents: [agent(0, 'completed')] });
 
-    expect(opened).toHaveBeenCalledTimes(1);
+    expect(screen.queryByTestId('orchestrator-budget')).toBeNull();
+    expect(screen.queryByTestId('run-spend-limit-trigger')).toBeNull();
   });
 
-  it('leaves one spend limit control on a budget pause, with the session budget still reachable', () => {
+  it('leaves one spend limit control on a budget pause and no budget button', () => {
     renderPanel({
       runOverride: run({ orchestrationStop: { kind: 'budget', message: 'cap reached' } }),
     });
 
     expect(screen.getAllByTestId('run-spend-limit-trigger')).toHaveLength(1);
-    expect(screen.getByTestId('orchestrator-budget')).toBeDefined();
+    expect(screen.queryByTestId('orchestrator-budget')).toBeNull();
   });
 
   it('renders one budget control when the session budget pauses the run', () => {
@@ -547,12 +543,11 @@ describe('OrchestratorPanel strip', () => {
     expect(screen.queryByTestId('orchestrator-budget')).toBeNull();
   });
 
-  it('says what the run is allowed to spend and what happens at the limit', () => {
+  it('keeps the spend limit out of the state sentence', () => {
     renderPanel({ runOverride: run({ spendLimitUsd: 12, spendLimitMode: 'notify' }) });
 
-    expect(screen.getByTestId('orchestrator-spend-limit').textContent).toContain(
-      'Spend limit $12.00 · notifies at the limit',
-    );
+    expect(screen.queryByTestId('orchestrator-spend-limit')).toBeNull();
+    expect(screen.getByTestId('orchestrator-panel').textContent).not.toContain('Spend limit');
   });
 
   it('sends a session budget pause to the session budget, not to the run limit', () => {
@@ -570,8 +565,10 @@ describe('OrchestratorPanel strip', () => {
     expect(screen.queryByTestId('orchestrator-budget')).toBeNull();
   });
 
-  it('saves a spend limit for the run from the strip', () => {
-    renderPanel();
+  it('saves a spend limit for the run from the budget pause', () => {
+    renderPanel({
+      runOverride: run({ orchestrationStop: { kind: 'budget', message: 'cap reached' } }),
+    });
 
     fireEvent.click(screen.getByTestId('run-spend-limit-trigger'));
     fireEvent.change(screen.getByTestId('spend-limit-amount'), { target: { value: '8' } });

--- a/apps/desktop/src/features/workflows/components/OrchestratorPanel/index.tsx
+++ b/apps/desktop/src/features/workflows/components/OrchestratorPanel/index.tsx
@@ -9,7 +9,7 @@ import {
   Users,
   Wallet,
 } from 'lucide-react';
-import { Eyebrow, Markdown, StatusDot, cn, formatUsd, tintClasses } from '@goodboy/ui';
+import { Eyebrow, Markdown, StatusDot, cn, tintClasses } from '@goodboy/ui';
 import { CONCEPT_ICONS } from '../../../../shared/components/conceptIcons';
 import type {
   Agent,
@@ -263,15 +263,6 @@ export const OrchestratorPanel = ({
                 model
               </span>
             )}
-            {run.spendLimitUsd == null ? null : (
-              <span
-                data-testid="orchestrator-spend-limit"
-                className="font-normal text-muted-foreground"
-              >
-                · Spend limit {formatUsd(run.spendLimitUsd)} ·{' '}
-                {run.spendLimitMode === 'notify' ? 'notifies at the limit' : 'pauses at the limit'}
-              </span>
-            )}
           </p>
 
           {state.detail != null && state.detail !== '' ? (
@@ -310,19 +301,6 @@ export const OrchestratorPanel = ({
             expanded={rolesOpen}
             onClick={() => toggleDrawer('roles')}
           />
-          {state.phase === 'paused-budget' ? null : (
-            <RunSpendLimitPopover sessionId={sessionId} run={run} variant="ghost" />
-          )}
-          {state.phase === 'paused-budget' && sessionBudgetBlocked ? null : (
-            <OrchestratorAction
-              icon={Wallet}
-              label="Budget"
-              variant="ghost"
-              testId="orchestrator-budget"
-              title="Open the budget for this session"
-              onClick={() => openBudgetStudio({ scope: { kind: 'session', sessionId } })}
-            />
-          )}
         </div>
       </div>
 

--- a/apps/desktop/src/features/workflows/components/RunSpendLimitPopover/index.tsx
+++ b/apps/desktop/src/features/workflows/components/RunSpendLimitPopover/index.tsx
@@ -19,13 +19,8 @@ import { SpendLimitFields, parseSpendLimit } from './SpendLimitFields';
 type Props = {
   readonly sessionId: SessionId;
   readonly run: WorkflowRun;
-  readonly variant: 'primary' | 'ghost' | 'meta';
+  readonly variant: 'primary' | 'meta';
 };
-
-const TRIGGER_LABEL = {
-  primary: 'Raise the spend limit',
-  ghost: 'Spend limit',
-} as const;
 
 export const RunSpendLimitPopover = ({ sessionId, run, variant }: Props) => {
   const setWorkflowRunSpendLimit = useAppStore((state) => state.setWorkflowRunSpendLimit);
@@ -85,8 +80,8 @@ export const RunSpendLimitPopover = ({ sessionId, run, variant }: Props) => {
       ) : (
         <OrchestratorAction
           icon={CircleDollarSign}
-          label={TRIGGER_LABEL[variant]}
-          variant={variant}
+          label="Raise the spend limit"
+          variant="primary"
           tone="warning"
           testId="run-spend-limit-trigger"
           title="Cap what this run is allowed to spend"


### PR DESCRIPTION
## What

The orchestrator card on the workflow page carried three money controls that
did not earn their place there:

- the `Spend limit ... pauses at the limit` meta line in the state sentence
- the `Spend limit` ghost action
- the `Budget` ghost action opening Budget Studio

All three are gone. The workflow row header already mounts the spend limit
popover (`variant="meta"`), so the run cap stays one click away from the same
screen, and the session budget has its own home.

## Why

The card is the place you look to know what the orchestrator is doing and to
unblock it. Spend numbers and a Budget CTA are neither. The owner wants no
Budget CTA on the workflow page at all.

The paused-budget primary path stays untouched: `Review budget` when a session
cap blocked the run, `Raise the spend limit` when the run cap did. That is a
blocking state the user has to act on, not decoration.

## Follow-on cleanup

With the ghost action gone, `RunSpendLimitPopover`'s `ghost` variant had no
caller left, so the variant and its `TRIGGER_LABEL` map are removed (knip would
flag them). The now-unused `formatUsd` import is dropped from the card.

## Test plan

- `apps/desktop` typecheck green.
- `vitest run OrchestratorPanel/index.test.tsx RunSpendLimitPopover/index.test.tsx`: 44 passed.
- `pnpm knip --include files,duplicates,unlisted` clean.
- Tests referencing the removed testids are rewritten to assert the controls
  are gone; the spend-limit save path is exercised from the budget pause, where
  the popover still lives, and by the popover's own suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
