### PR TITLE
feat(desktop): follow-up section tracks the agents it spawned

### DIFF
--- a/apps/desktop/src/features/session/components/AgentDetailPane/AgentBrief.tsx
+++ b/apps/desktop/src/features/session/components/AgentDetailPane/AgentBrief.tsx
@@ -1,8 +1,8 @@
 import { useMemo } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { fallbackStepOutputSummary, stripControlMarkers } from '@goodboy/core';
-import { Markdown, SectionSurface, StatusDot, type Tone } from '@goodboy/ui';
-import type { Agent, Session, TurnEvent, TurnState } from '@goodboy/types';
+import { Markdown, SectionSurface, StatusDot } from '@goodboy/ui';
+import type { Agent, Session, TurnState } from '@goodboy/types';
 import { EMPTY_ARRAY, useAppStore } from '../../../../store';
 import { useTranscript } from '../../../../store/transcript';
 import { selectSpawnedChildren } from '../../../../shared/utils/spawnedChildren';
@@ -14,6 +14,9 @@ import { AgentBriefChildren } from './AgentBriefChildren';
 import { AgentBriefPlans } from './AgentBriefPlans';
 import { AgentBriefQuestions } from './AgentBriefQuestions';
 import { AgentFollowUps } from './AgentFollowUps';
+import { agentFollowUpMoves } from './followUpMoves';
+import { selectFollowUpChildren } from './followUpChildren';
+import { agentNowState } from './agentNowState';
 import { useAttachedWorkflowRuns } from '../../../workflows/useAttachedWorkflowRuns';
 
 type Props = {
@@ -49,6 +52,18 @@ export const AgentBrief = ({ session, agent }: Props) => {
     [agent.id, runs, turnStates],
   );
   const kind = classifyAgent(agent, kindOverride);
+  const followUps = useMemo(
+    () =>
+      selectFollowUpChildren({
+        spawned: children,
+        kinds: agentFollowUpMoves({ sourceKind: kind }).map((move) => move.kind),
+      }),
+    [children, kind],
+  );
+  const laneChildren = useMemo(() => {
+    const followUpIds = new Set(followUps.map((entry) => entry.child.agent.id));
+    return children.filter((child) => !followUpIds.has(child.agent.id));
+  }, [children, followUps]);
   const step = useMemo(() => {
     if (agent.workflowRunId == null || agent.stepId == null) {
       return null;
@@ -76,7 +91,7 @@ export const AgentBrief = ({ session, agent }: Props) => {
   const expectedOutput = step?.expectedOutput?.trim() ?? AGENT_KIND_META[kind].expectedOutput;
   const isTerminal =
     agent.status === 'completed' || agent.status === 'failed' || agent.status === 'skipped';
-  const now = nowState({ agent, turnState, transcript });
+  const now = agentNowState({ agent, turnState, transcript });
 
   return (
     <div className="flex flex-col gap-4">
@@ -113,8 +128,9 @@ export const AgentBrief = ({ session, agent }: Props) => {
         sourceKind={kind}
         summary={summary}
         sessionId={session.id}
+        followUps={followUps}
       />
-      <AgentBriefChildren session={session} kind={kind} children={children} />
+      <AgentBriefChildren session={session} kind={kind} children={laneChildren} />
       <AgentMetaLine
         aggregate={metrics.aggregatesByAgentId.get(agent.id) ?? null}
         contextUsage={metrics.providerUsageByAgentId.get(agent.id) ?? EMPTY_ARRAY}
@@ -122,52 +138,4 @@ export const AgentBrief = ({ session, agent }: Props) => {
       />
     </div>
   );
-};
-
-type NowStateParams = {
-  readonly agent: Agent;
-  readonly turnState: TurnState | null;
-  readonly transcript: ReadonlyArray<TurnEvent>;
-};
-
-type NowState = {
-  readonly tone: Tone;
-  readonly label: string;
-  readonly isPulsing: boolean;
-};
-
-const nowState = ({ agent, turnState, transcript }: NowStateParams): NowState => {
-  if (turnState?.kind === 'running') {
-    return { tone: 'info', label: runningLabel({ transcript }), isPulsing: true };
-  }
-  if (turnState?.kind === 'blocked') {
-    return { tone: 'warning', label: 'waiting on a permission decision', isPulsing: false };
-  }
-  if (turnState?.kind === 'error') {
-    return { tone: 'danger', label: turnState.message, isPulsing: false };
-  }
-  if (agent.status === 'pending') {
-    return { tone: 'neutral', label: 'queued', isPulsing: false };
-  }
-  return { tone: 'neutral', label: 'ready', isPulsing: false };
-};
-
-type RunningLabelParams = {
-  readonly transcript: ReadonlyArray<TurnEvent>;
-};
-
-const runningLabel = ({ transcript }: RunningLabelParams): string => {
-  const endedToolIds = new Set(
-    transcript.filter((event) => event.kind === 'tool_call_end').map((event) => event.toolUseId),
-  );
-  for (let index = transcript.length - 1; index >= 0; index -= 1) {
-    const event = transcript[index];
-    if (event?.kind === 'tool_call_start' && !endedToolIds.has(event.toolUseId)) {
-      return event.toolName;
-    }
-    if (event?.kind === 'assistant_text') {
-      return 'writing';
-    }
-  }
-  return 'thinking';
 };

--- a/apps/desktop/src/features/session/components/AgentDetailPane/AgentFollowUpChild.tsx
+++ b/apps/desktop/src/features/session/components/AgentDetailPane/AgentFollowUpChild.tsx
@@ -1,0 +1,72 @@
+import { useMemo } from 'react';
+import { StatusDot, cn } from '@goodboy/ui';
+import type { AgentStatus, SessionId } from '@goodboy/types';
+import { useAppStore, useSessionOpenQuestions } from '../../../../store';
+import { useTranscript } from '../../../../store/transcript';
+import { attachedQuestionsFor } from '../../timeline/attachedQuestions';
+import { AgentKindChip } from '../AgentKindChip';
+import { AgentStatusIcon } from '../AgentCard/AgentStatusIcon';
+import { agentNowState } from './agentNowState';
+import type { FollowUpChild } from './followUpChildren';
+
+type Props = {
+  readonly entry: FollowUpChild;
+  readonly sessionId: SessionId;
+};
+
+const TERMINAL_LABELS: Partial<Record<AgentStatus, string>> = {
+  completed: 'done',
+  failed: 'failed',
+  skipped: 'skipped',
+};
+
+export const AgentFollowUpChild = ({ entry, sessionId }: Props) => {
+  const { child, kind } = entry;
+  const agent = child.agent;
+  const selectAgent = useAppStore((state) => state.selectAgent);
+  const setCurrentSession = useAppStore((state) => state.setCurrentSession);
+  const setActiveLens = useAppStore((state) => state.setActiveLens);
+  const turnState = useAppStore((state) => state.agentTurnState[agent.id] ?? null);
+  const transcript = useTranscript(agent.id);
+  const questions = useSessionOpenQuestions(sessionId);
+  const hasQuestion = useMemo(
+    () => attachedQuestionsFor({ questions, agent }).some((question) => question.status === 'open'),
+    [agent, questions],
+  );
+
+  const terminalLabel = TERMINAL_LABELS[child.status] ?? null;
+  const live = agentNowState({ agent, turnState, transcript });
+  const label = hasQuestion ? 'question' : (terminalLabel ?? live.label);
+
+  const onOpen = () => {
+    void (async () => {
+      await setCurrentSession(sessionId);
+      setActiveLens(sessionId, 'agents');
+      await selectAgent(sessionId, agent.id);
+      window.dispatchEvent(new CustomEvent('goodboy:reveal-chat'));
+    })();
+  };
+
+  return (
+    <div className="flex items-center gap-2 rounded-md border border-border-soft bg-elevated px-3 py-2 text-xs">
+      <AgentKindChip kind={kind} muted />
+      <span className="min-w-0 flex-1 truncate text-foreground">{agent.name}</span>
+      {hasQuestion ? (
+        <StatusDot tone="warning" size="sm" />
+      ) : (
+        <AgentStatusIcon status={child.status} />
+      )}
+      <span className="max-w-28 shrink-0 truncate text-2xs text-muted-foreground">{label}</span>
+      <button
+        type="button"
+        onClick={onOpen}
+        className={cn(
+          'shrink-0 rounded px-1.5 py-0.5 text-2xs font-medium text-muted-foreground',
+          'hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--color-focus-ring)]',
+        )}
+      >
+        Go to chat
+      </button>
+    </div>
+  );
+};

--- a/apps/desktop/src/features/session/components/AgentDetailPane/AgentFollowUps.test.tsx
+++ b/apps/desktop/src/features/session/components/AgentDetailPane/AgentFollowUps.test.tsx
@@ -1,0 +1,184 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import type { Agent, AgentId, OpenQuestion, SessionId } from '@goodboy/types';
+import type { SpawnedChild } from '../../../../shared/utils/spawnedChildren';
+
+const state = vi.hoisted(() => ({
+  agentTurnState: {} as Record<string, unknown>,
+  openQuestions: [] as ReadonlyArray<OpenQuestion>,
+  spawnAgent: vi.fn(async () => 'agent-2' as AgentId),
+  selectAgent: vi.fn(async () => undefined),
+  setCurrentSession: vi.fn(async () => undefined),
+  setActiveLens: vi.fn(() => undefined),
+}));
+
+const announce = vi.hoisted(() => vi.fn());
+
+vi.mock('../../../../store', () => ({
+  EMPTY_ARRAY: [],
+  useAppStore: <T,>(selector: (value: typeof state) => T) => selector(state),
+  useSessionOpenQuestions: () => state.openQuestions,
+}));
+
+vi.mock('../../../../store/transcript', () => ({
+  useTranscript: () => [],
+}));
+
+vi.mock('../../../../shared/hooks/useAgentStartedToast', () => ({
+  useAgentStartedToast: () => announce,
+}));
+
+import { AgentFollowUps } from './AgentFollowUps';
+import type { FollowUpChild } from './followUpChildren';
+
+const sessionId = 'session-1' as SessionId;
+const sourceId = 'agent-1' as AgentId;
+
+const source: Agent = {
+  id: sourceId,
+  sessionId,
+  ordinal: 0,
+  name: 'Review the store split',
+  status: 'completed',
+  kind: 'reviewer',
+} as Agent;
+
+const makeChild = (over: Partial<Agent>): FollowUpChild => {
+  const agent = {
+    id: 'agent-2' as AgentId,
+    sessionId,
+    ordinal: 1,
+    name: 'Plan the store split',
+    status: 'running',
+    kind: 'planner',
+    parentAgentId: sourceId,
+    ...over,
+  } as Agent;
+  return {
+    kind: 'planner',
+    child: { agent, index: 0, total: 1, status: agent.status, assignment: null } as SpawnedChild,
+  };
+};
+
+afterEach(cleanup);
+
+beforeEach(() => {
+  state.agentTurnState = {};
+  state.openQuestions = [];
+  state.spawnAgent.mockClear();
+  state.selectAgent.mockClear();
+  announce.mockClear();
+});
+
+describe('AgentFollowUps suggestions', () => {
+  it('names the kind about to be spawned on every suggestion', () => {
+    render(
+      <AgentFollowUps
+        sourceAgent={source}
+        sourceKind="reviewer"
+        summary="two findings"
+        sessionId={sessionId}
+        followUps={[]}
+      />,
+    );
+
+    expect(screen.getByText('Plan')).toBeDefined();
+    expect(screen.getByText('Implement')).toBeDefined();
+    expect(screen.getByText('Turn the review findings into a plan')).toBeDefined();
+  });
+
+  it('links the spawned agent to the agent it continues', async () => {
+    render(
+      <AgentFollowUps
+        sourceAgent={source}
+        sourceKind="reviewer"
+        summary="two findings"
+        sessionId={sessionId}
+        followUps={[]}
+      />,
+    );
+
+    screen.getByText('Turn the review findings into a plan').click();
+    await vi.waitFor(() => expect(state.spawnAgent).toHaveBeenCalledTimes(1));
+
+    expect(state.spawnAgent).toHaveBeenCalledWith(
+      sessionId,
+      expect.objectContaining({ kindOverride: 'planner', parentAgentId: sourceId }),
+    );
+  });
+});
+
+describe('AgentFollowUps after a spawn', () => {
+  it('replaces the suggestion of a spawned kind with its live status', () => {
+    render(
+      <AgentFollowUps
+        sourceAgent={source}
+        sourceKind="reviewer"
+        summary="two findings"
+        sessionId={sessionId}
+        followUps={[makeChild({})]}
+      />,
+    );
+
+    expect(screen.getByText('Plan the store split')).toBeDefined();
+    expect(screen.queryByText('Turn the review findings into a plan')).toBeNull();
+    expect(screen.getByText('Fix these review findings')).toBeDefined();
+  });
+
+  it('reads a spawned child that finished as done', () => {
+    render(
+      <AgentFollowUps
+        sourceAgent={source}
+        sourceKind="reviewer"
+        summary="two findings"
+        sessionId={sessionId}
+        followUps={[makeChild({ status: 'completed' })]}
+      />,
+    );
+
+    expect(screen.getByText('done')).toBeDefined();
+  });
+
+  it('flags a spawned child that is waiting on an answer', () => {
+    state.openQuestions = [
+      {
+        id: 'oq-1',
+        sessionId,
+        text: 'which module first?',
+        status: 'open',
+        createdByAgentId: 'agent-2' as AgentId,
+      } as OpenQuestion,
+    ];
+
+    render(
+      <AgentFollowUps
+        sourceAgent={source}
+        sourceKind="reviewer"
+        summary="two findings"
+        sessionId={sessionId}
+        followUps={[makeChild({})]}
+      />,
+    );
+
+    expect(screen.getByText('question')).toBeDefined();
+  });
+
+  it('opens the spawned child from its row', async () => {
+    render(
+      <AgentFollowUps
+        sourceAgent={source}
+        sourceKind="reviewer"
+        summary="two findings"
+        sessionId={sessionId}
+        followUps={[makeChild({})]}
+      />,
+    );
+
+    screen.getByRole('button', { name: 'Go to chat' }).click();
+    await vi.waitFor(() => expect(state.selectAgent).toHaveBeenCalledTimes(1));
+
+    expect(state.selectAgent).toHaveBeenCalledWith(sessionId, 'agent-2');
+  });
+});

--- a/apps/desktop/src/features/session/components/AgentDetailPane/AgentFollowUps.tsx
+++ b/apps/desktop/src/features/session/components/AgentDetailPane/AgentFollowUps.tsx
@@ -5,16 +5,26 @@ import { useAppStore } from '../../../../store';
 import { useAgentStartedToast } from '../../../../shared/hooks/useAgentStartedToast';
 import type { AgentKind } from '../../agent-kind';
 import { AGENT_KIND_META } from '../../agent-kind';
+import { AgentKindChip } from '../AgentKindChip';
 import { agentFollowUpMoves, composeFollowUpSeed } from './followUpMoves';
+import type { FollowUpChild } from './followUpChildren';
+import { AgentFollowUpChild } from './AgentFollowUpChild';
 
 type Props = {
   readonly sourceAgent: Agent;
   readonly sourceKind: AgentKind;
   readonly summary: string;
   readonly sessionId: SessionId;
+  readonly followUps: ReadonlyArray<FollowUpChild>;
 };
 
-export const AgentFollowUps = ({ sourceAgent, sourceKind, summary, sessionId }: Props) => {
+export const AgentFollowUps = ({
+  sourceAgent,
+  sourceKind,
+  summary,
+  sessionId,
+  followUps,
+}: Props) => {
   const spawnAgent = useAppStore((state) => state.spawnAgent);
   const announceAgentStarted = useAgentStartedToast();
 
@@ -29,12 +39,16 @@ export const AgentFollowUps = ({ sourceAgent, sourceKind, summary, sessionId }: 
     return null;
   }
 
+  const spawnedKinds = new Set(followUps.map((entry) => entry.kind));
+  const pending = moves.filter((move) => !spawnedKinds.has(move.kind));
+
   const onSpawn = (nextKind: AgentKind) => {
     const seed = composeFollowUpSeed({ sourceAgent, summary });
     void (async () => {
       const agentId = await spawnAgent(sessionId, {
         kindOverride: nextKind,
         initialPrompt: seed,
+        parentAgentId: sourceAgent.id,
         focus: 'agent',
       });
       announceAgentStarted({
@@ -47,27 +61,35 @@ export const AgentFollowUps = ({ sourceAgent, sourceKind, summary, sessionId }: 
   };
 
   return (
-    <SectionSurface label="Continue" hint="Spawn a follow-up seeded with this agent's output.">
+    <SectionSurface
+      label="Continue"
+      hint={
+        pending.length > 0
+          ? "Spawn a follow-up seeded with this agent's output."
+          : "Follow-ups already picked up this agent's output."
+      }
+    >
       <div className="flex flex-col gap-1.5">
-        {moves.map((move) => (
+        {followUps.map((entry) => (
+          <AgentFollowUpChild key={entry.child.agent.id} entry={entry} sessionId={sessionId} />
+        ))}
+        {pending.map((move) => (
           <button
             key={move.kind}
             type="button"
             onClick={() => onSpawn(move.kind)}
             className={cn(
-              'group flex items-start gap-2 rounded-md border border-border-soft bg-elevated px-3 py-2 text-left text-xs transition-colors hover:border-border',
+              'group flex items-center gap-2 rounded-md border border-border-soft bg-elevated px-3 py-2 text-left text-xs transition-colors hover:border-border',
               'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]',
             )}
           >
+            <AgentKindChip kind={move.kind} title={move.label} />
+            <span className="min-w-0 flex-1 text-foreground">{move.hint}</span>
             <ArrowRight
               size={12}
               aria-hidden
-              className="mt-0.5 shrink-0 text-muted-foreground/60 transition-transform group-hover:translate-x-0.5"
+              className="shrink-0 text-muted-foreground/60 transition-transform group-hover:translate-x-0.5"
             />
-            <span className="flex min-w-0 flex-1 flex-col gap-0.5">
-              <span className="font-medium text-foreground">{move.label}</span>
-              <span className="text-2xs text-muted-foreground">{move.hint}</span>
-            </span>
           </button>
         ))}
       </div>

--- a/apps/desktop/src/features/session/components/AgentDetailPane/agentNowState.ts
+++ b/apps/desktop/src/features/session/components/AgentDetailPane/agentNowState.ts
@@ -1,0 +1,50 @@
+import type { Tone } from '@goodboy/ui';
+import type { Agent, TurnEvent, TurnState } from '@goodboy/types';
+
+type AgentNowState = {
+  readonly tone: Tone;
+  readonly label: string;
+  readonly isPulsing: boolean;
+};
+
+type RunningLabelParams = {
+  readonly transcript: ReadonlyArray<TurnEvent>;
+};
+
+const runningLabel = ({ transcript }: RunningLabelParams): string => {
+  const endedToolIds = new Set(
+    transcript.filter((event) => event.kind === 'tool_call_end').map((event) => event.toolUseId),
+  );
+  for (let index = transcript.length - 1; index >= 0; index -= 1) {
+    const event = transcript[index];
+    if (event?.kind === 'tool_call_start' && !endedToolIds.has(event.toolUseId)) {
+      return event.toolName;
+    }
+    if (event?.kind === 'assistant_text') {
+      return 'writing';
+    }
+  }
+  return 'thinking';
+};
+
+type NowStateParams = {
+  readonly agent: Agent;
+  readonly turnState: TurnState | null;
+  readonly transcript: ReadonlyArray<TurnEvent>;
+};
+
+export const agentNowState = ({ agent, turnState, transcript }: NowStateParams): AgentNowState => {
+  if (turnState?.kind === 'running') {
+    return { tone: 'info', label: runningLabel({ transcript }), isPulsing: true };
+  }
+  if (turnState?.kind === 'blocked') {
+    return { tone: 'warning', label: 'waiting on a permission decision', isPulsing: false };
+  }
+  if (turnState?.kind === 'error') {
+    return { tone: 'danger', label: turnState.message, isPulsing: false };
+  }
+  if (agent.status === 'pending') {
+    return { tone: 'neutral', label: 'queued', isPulsing: false };
+  }
+  return { tone: 'neutral', label: 'ready', isPulsing: false };
+};

--- a/apps/desktop/src/features/session/components/AgentDetailPane/followUpChildren.test.ts
+++ b/apps/desktop/src/features/session/components/AgentDetailPane/followUpChildren.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import type { Agent, AgentId, SessionId } from '@goodboy/types';
+import type { SpawnedChild } from '../../../../shared/utils/spawnedChildren';
+import { selectFollowUpChildren } from './followUpChildren';
+
+const sessionId = 'session-1' as SessionId;
+
+const makeSpawned = (over: Partial<Agent>): SpawnedChild => {
+  const agent = {
+    id: 'agent-2' as AgentId,
+    sessionId,
+    ordinal: 1,
+    name: 'child',
+    status: 'running',
+    kind: 'planner',
+    ...over,
+  } as Agent;
+  return { agent, index: 0, total: 1, status: agent.status, assignment: null } as SpawnedChild;
+};
+
+describe('selectFollowUpChildren', () => {
+  it('keeps a child whose kind is one of the offered moves', () => {
+    const matched = selectFollowUpChildren({
+      spawned: [makeSpawned({})],
+      kinds: ['planner', 'implementer'],
+    });
+
+    expect(matched).toHaveLength(1);
+    expect(matched[0]?.kind).toBe('planner');
+  });
+
+  it('drops a child spawned by something other than a follow-up move', () => {
+    const matched = selectFollowUpChildren({
+      spawned: [makeSpawned({ kind: 'scout', name: 'scout 1' })],
+      kinds: ['planner', 'implementer'],
+    });
+
+    expect(matched).toHaveLength(0);
+  });
+
+  it('reads the kind off the name when the row carries none', () => {
+    const matched = selectFollowUpChildren({
+      spawned: [makeSpawned({ kind: undefined, name: 'implement the split' })],
+      kinds: ['implementer'],
+    });
+
+    expect(matched[0]?.kind).toBe('implementer');
+  });
+});

--- a/apps/desktop/src/features/session/components/AgentDetailPane/followUpChildren.ts
+++ b/apps/desktop/src/features/session/components/AgentDetailPane/followUpChildren.ts
@@ -1,0 +1,29 @@
+import type { SpawnedChild } from '../../../../shared/utils/spawnedChildren';
+import { classifyAgent } from '../../agent-kind';
+import type { FollowUpKind } from './followUpMoves';
+
+export type FollowUpChild = Readonly<{
+  child: SpawnedChild;
+  kind: FollowUpKind;
+}>;
+
+type Params = {
+  readonly spawned: ReadonlyArray<SpawnedChild>;
+  readonly kinds: ReadonlyArray<FollowUpKind>;
+};
+
+export const selectFollowUpChildren = ({
+  spawned,
+  kinds,
+}: Params): ReadonlyArray<FollowUpChild> => {
+  const matched: Array<FollowUpChild> = [];
+  for (const child of spawned) {
+    const classified = classifyAgent(child.agent, null);
+    const kind = kinds.find((candidate) => candidate === classified);
+    if (kind === undefined) {
+      continue;
+    }
+    matched.push({ child, kind });
+  }
+  return matched;
+};

--- a/apps/desktop/src/store/slices/agents/spawnAgent.ts
+++ b/apps/desktop/src/store/slices/agents/spawnAgent.ts
@@ -48,6 +48,7 @@ type SpawnArgs = {
   sourceKind?: AgentSourceKind;
   deferKickoff?: boolean;
   focus?: SpawnFocus;
+  parentAgentId?: AgentId;
 };
 
 type Params = {
@@ -115,6 +116,7 @@ const runSpawn = async ({ set, get, sessionId, session, args }: Params): Promise
     ...(args.sourceThreadIds !== undefined && { sourceThreadIds: args.sourceThreadIds }),
     ...(args.sourceCommentUrl !== undefined && { sourceCommentUrl: args.sourceCommentUrl }),
     ...(args.sourceKind !== undefined && { sourceKind: args.sourceKind }),
+    ...(args.parentAgentId !== undefined && { parentAgentId: args.parentAgentId }),
   });
   const resolvedProvider = args.provider ?? routing.provider;
   const resolvedModel = args.model ?? routing.model;

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -519,6 +519,7 @@ export type AppActions = {
       sourceKind?: AgentSourceKind;
       deferKickoff?: boolean;
       focus?: SpawnFocus;
+      parentAgentId?: AgentId;
     },
   ): Promise<AgentId>;
   activateNextResolver(sessionId: SessionId): Promise<void>;


### PR DESCRIPTION
## What

The **Continue** section on an agent brief spawned a follow-up and then went
on offering the same suggestion forever, with no sign the agent it created
existed. Two things were missing: the spawned agent was never linked back to
its source, and the suggestions did not say which role they were about to
start.

- `spawnAgent` accepts `parentAgentId` and passes it to the insert. The
  column, the Rust binding and the TS client already supported it; the store
  action was the only gap, so direct-insert callers keep working unchanged.
- `AgentFollowUps` spawns with `parentAgentId: sourceAgent.id`, and swaps the
  suggestion of any already-spawned kind for a live status row: kind chip,
  name, status icon, live label, and a **Go to chat** button that selects the
  agent and reveals its transcript.
- The live label reuses the brief's own `nowState`, now extracted to
  `agentNowState.ts` and shared. An open question attached to the child
  overrides it with `question`.
- Suggestions that remain carry the colored `AgentKindChip` of the agent they
  will start, so the role reads at a glance.
- Follow-up children are excluded from the `AgentBriefChildren` lane, so the
  same agent does not show up twice on one brief. That lane also skipped
  planners entirely, which is why a plan spawned from a review used to
  disappear.

## Why

Spawning was a dead end in the UI: the section stayed stateless, so the only
way to find the agent you had just started was the toast, and once it faded
there was nothing. The parent link makes the chain real in the database and
readable on the page.

## Test plan

- `apps/desktop`: `npx vitest run src/features/session/components/AgentDetailPane` (8 files, 51 tests)
- `apps/desktop`: `npx vitest run src/store/slices/agents src/features/session/agent-kind.test.ts` (148 tests)
- `apps/desktop`: `npx tsc --noEmit` clean
- New: `AgentFollowUps.test.tsx` covers the kind chip, the parent link on
  spawn, suggestion replacement, the done and question labels, and the
  Go to chat navigation. `followUpChildren.test.ts` covers the selector.

Closes #1502
Closes #1501

🤖 Generated with [Claude Code](https://claude.com/claude-code)
