### PR TITLE
feat(desktop): link several tasks to a new session and draft its goal

### DIFF
--- a/apps/desktop/src/features/companion/commandExecutor.commands.test.ts
+++ b/apps/desktop/src/features/companion/commandExecutor.commands.test.ts
@@ -913,17 +913,19 @@ describe('createSessionFromIssue (security-gated write)', () => {
     );
     expect(res.ok).toBe(true);
     expect(res.data).toEqual({ sessionId: 'new-session-1' });
-    // Goal + externalTask are derived from the resolved issue, not the phone.
+    // Goal + externalTasks are derived from the resolved issue, not the phone.
     expect(h.createSession).toHaveBeenCalledWith({
       workspaceId: 'w1',
       goal: '[ENG-1] Fix the thing',
-      externalTask: {
-        provider: 'linear',
-        externalId: 'lin-uuid-1',
-        identifier: 'ENG-1',
-        url: 'https://linear.app/x/issue/ENG-1',
-        title: 'Fix the thing',
-      },
+      externalTasks: [
+        {
+          provider: 'linear',
+          externalId: 'lin-uuid-1',
+          identifier: 'ENG-1',
+          url: 'https://linear.app/x/issue/ENG-1',
+          title: 'Fix the thing',
+        },
+      ],
       // Origin marker: confines the new session before any kickoff turn.
       mobileShared: true,
     });
@@ -959,13 +961,15 @@ describe('createSessionFromIssue (security-gated write)', () => {
     expect(h.createSession).toHaveBeenCalledWith({
       workspaceId: 'w1',
       goal: '[PROJ-1] Fix the thing',
-      externalTask: {
-        provider: 'jira',
-        externalId: 'jira-10001',
-        identifier: 'PROJ-1',
-        url: 'https://example.atlassian.net/browse/PROJ-1',
-        title: 'Fix the thing',
-      },
+      externalTasks: [
+        {
+          provider: 'jira',
+          externalId: 'jira-10001',
+          identifier: 'PROJ-1',
+          url: 'https://example.atlassian.net/browse/PROJ-1',
+          title: 'Fix the thing',
+        },
+      ],
       mobileShared: true,
     });
     expect(integ.jiraGetFetch).toHaveBeenCalledWith({

--- a/apps/desktop/src/features/companion/commandExecutor.ts
+++ b/apps/desktop/src/features/companion/commandExecutor.ts
@@ -560,7 +560,7 @@ async function dispatchMobile(cmd: BridgeCommand): Promise<unknown> {
         ({ session } = await store.createSession({
           workspaceId: gate.workspaceId,
           goal: resolved.goal,
-          externalTask: resolved.externalTask,
+          externalTasks: [resolved.externalTask],
           mobileShared: true,
         }));
       } catch (e) {

--- a/apps/desktop/src/features/github/components/GitHubStudio/GithubIssueDetailPanel/index.test.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/GithubIssueDetailPanel/index.test.tsx
@@ -77,13 +77,15 @@ describe('GithubIssueDetailPanel', () => {
       expect.objectContaining({
         workspaceId: 'workspace-1',
         branchSlug: '42-add-issue-dashboard',
-        externalTask: {
-          provider: 'github',
-          externalId: '42',
-          identifier: '#42',
-          url: ISSUE.url,
-          title: ISSUE.title,
-        },
+        externalTasks: [
+          {
+            provider: 'github',
+            externalId: '42',
+            identifier: '#42',
+            url: ISSUE.url,
+            title: ISSUE.title,
+          },
+        ],
       }),
     );
   });

--- a/apps/desktop/src/features/integrations/components/LaunchSessionPanel/index.test.tsx
+++ b/apps/desktop/src/features/integrations/components/LaunchSessionPanel/index.test.tsx
@@ -86,7 +86,7 @@ describe('LaunchSessionPanel', () => {
     await waitFor(() => expect(h.createSession).toHaveBeenCalledOnce());
     const payload = h.createSession.mock.calls[0]?.[0] ?? {};
     expect(payload['openWorkflowBuilder']).toBeUndefined();
-    expect(payload).toMatchObject({ externalTask: EXTERNAL_TASK });
+    expect(payload).toMatchObject({ externalTasks: [EXTERNAL_TASK] });
   });
 
   it('launches on the keyboard submit shortcut', async () => {

--- a/apps/desktop/src/features/integrations/components/LaunchSessionPanel/index.tsx
+++ b/apps/desktop/src/features/integrations/components/LaunchSessionPanel/index.tsx
@@ -174,7 +174,7 @@ export const LaunchSessionPanel = ({
           ? { folderName }
           : { branchPrefix: prefix, branchSlug: branchSlug.trim() || undefined }),
         ...(adoptedBranch != null ? { existingBranch: adoptedBranch } : {}),
-        externalTask,
+        externalTasks: [externalTask],
       });
       showToast('success', `Session created: ${session.goal}`);
       onClose();

--- a/apps/desktop/src/features/session/components/NewSessionView/IssueSourceField.test.tsx
+++ b/apps/desktop/src/features/session/components/NewSessionView/IssueSourceField.test.tsx
@@ -1,0 +1,137 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import type { SessionExternalTaskProvider, WorkspaceId } from '@goodboy/types';
+import type { IssueCandidate } from '../../../integrations/fetchIssueCandidates';
+import type { IssueSource } from '../../../integrations/issueSources';
+
+const { candidates, load } = vi.hoisted(() => ({
+  candidates: { byProvider: {} as Record<string, ReadonlyArray<unknown>>, asked: [] as string[] },
+  load: vi.fn(),
+}));
+
+vi.mock('../../../integrations/hooks/useIssueCandidates', () => ({
+  useIssueCandidates: ({ provider }: { provider: SessionExternalTaskProvider }) => {
+    candidates.asked.push(provider);
+    return {
+      rows: candidates.byProvider[provider] ?? [],
+      isLoading: false,
+      isLoaded: true,
+      error: null,
+      load,
+    };
+  },
+}));
+
+vi.mock('../../../../shared/lib/editor', () => ({ openUrl: vi.fn() }));
+
+import { IssueSourceField } from './IssueSourceField';
+
+const WORKSPACE_ID = 'workspace-1' as WorkspaceId;
+
+const SOURCES: ReadonlyArray<IssueSource> = [
+  { provider: 'linear', label: 'Linear' },
+  { provider: 'github', label: 'GitHub' },
+];
+
+const LINEAR_ISSUE: IssueCandidate = {
+  provider: 'linear',
+  externalId: 'lin-1',
+  identifier: 'ENG-1',
+  title: 'Extract token validation',
+  url: 'https://linear.app/acme/issue/ENG-1',
+  goal: 'Extract token validation into a shared module.',
+  branchSlug: 'extract-token-validation',
+};
+
+const GITHUB_ISSUE: IssueCandidate = {
+  provider: 'github',
+  externalId: '42',
+  identifier: '#42',
+  title: 'Retry the payment webhook',
+  url: 'https://github.com/acme/web/issues/42',
+  goal: 'Retry the payment webhook.',
+  branchSlug: 'retry-payment-webhook',
+};
+
+type RenderParams = {
+  readonly values?: ReadonlyArray<IssueCandidate>;
+  readonly onPick?: (candidate: IssueCandidate) => void;
+  readonly onRemove?: (candidate: IssueCandidate) => void;
+};
+
+const renderField = ({ values = [], onPick = vi.fn(), onRemove = vi.fn() }: RenderParams = {}) =>
+  render(
+    <IssueSourceField
+      workspaceId={WORKSPACE_ID}
+      sources={SOURCES}
+      values={values}
+      disabled={false}
+      onPick={onPick}
+      onRemove={onRemove}
+    />,
+  );
+
+beforeEach(() => {
+  candidates.byProvider = { linear: [LINEAR_ISSUE], github: [GITHUB_ISSUE] };
+  candidates.asked = [];
+  load.mockClear();
+});
+
+afterEach(cleanup);
+
+describe('IssueSourceField', () => {
+  it('keeps the picker open for another task once one is linked', () => {
+    renderField({ values: [LINEAR_ISSUE] });
+
+    const group = screen.getByTestId('new-session-linked-tasks');
+    expect(within(group).getByText('Extract token validation')).toBeDefined();
+    expect(screen.getByRole('combobox').getAttribute('placeholder')).toContain('to add another');
+  });
+
+  it('lists every linked task with its own remove control', () => {
+    const onRemove = vi.fn();
+    renderField({ values: [LINEAR_ISSUE, GITHUB_ISSUE], onRemove });
+
+    const group = screen.getByTestId('new-session-linked-tasks');
+    expect(within(group).getByText('Extract token validation')).toBeDefined();
+    expect(within(group).getByText('Retry the payment webhook')).toBeDefined();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove #42' }));
+
+    expect(onRemove).toHaveBeenCalledWith(GITHUB_ISSUE);
+  });
+
+  it('adds a pick instead of replacing what is already linked', () => {
+    const onPick = vi.fn();
+    renderField({ values: [GITHUB_ISSUE], onPick });
+
+    fireEvent.focus(screen.getByRole('combobox'));
+    fireEvent.mouseDown(screen.getByRole('option', { name: /Extract token validation/ }));
+
+    expect(onPick).toHaveBeenCalledWith(LINEAR_ISSUE);
+  });
+
+  it('clears the search text after a pick so the next one starts fresh', () => {
+    renderField();
+
+    fireEvent.focus(screen.getByRole('combobox'));
+    fireEvent.mouseDown(screen.getByRole('option', { name: /Extract token validation/ }));
+
+    expect((screen.getByRole('combobox') as HTMLInputElement).value).toBe('');
+  });
+
+  it('switches what the picker browses without dropping the tasks already picked', () => {
+    const onRemove = vi.fn();
+    renderField({ values: [LINEAR_ISSUE], onRemove });
+
+    fireEvent.click(screen.getByRole('tab', { name: /GitHub/ }));
+
+    expect(onRemove).not.toHaveBeenCalled();
+    expect(candidates.asked.at(-1)).toBe('github');
+    expect(
+      within(screen.getByTestId('new-session-linked-tasks')).getByText('Extract token validation'),
+    ).toBeDefined();
+  });
+});

--- a/apps/desktop/src/features/session/components/NewSessionView/IssueSourceField.tsx
+++ b/apps/desktop/src/features/session/components/NewSessionView/IssueSourceField.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
-import { SegmentedTabs } from '@goodboy/ui';
+import { X } from 'lucide-react';
+import { IconButton, SegmentedTabs } from '@goodboy/ui';
 import type { SessionExternalTaskProvider, WorkspaceId } from '@goodboy/types';
 import { ExternalTaskChip } from '../../../integrations/components/ExternalTaskChip';
 import { IntegrationGlyph } from '../../../integrations/components/IntegrationGlyph';
@@ -11,28 +12,29 @@ import type { IssueSource } from '../../../integrations/issueSources';
 type Props = {
   readonly workspaceId: WorkspaceId;
   readonly sources: ReadonlyArray<IssueSource>;
-  readonly value: IssueCandidate | null;
+  readonly values: ReadonlyArray<IssueCandidate>;
   readonly disabled: boolean;
   readonly onPick: (candidate: IssueCandidate) => void;
-  readonly onClear: () => void;
+  readonly onRemove: (candidate: IssueCandidate) => void;
 };
 
 export const IssueSourceField = ({
   workspaceId,
   sources,
-  value,
+  values,
   disabled,
   onPick,
-  onClear,
+  onRemove,
 }: Props) => {
   const [choice, setChoice] = useState<SessionExternalTaskProvider | null>(null);
+  const [pickCount, setPickCount] = useState(0);
   const active = sources.find((source) => source.provider === choice) ?? sources[0] ?? null;
   const provider = active?.provider ?? 'linear';
   const { rows, isLoading, isLoaded, error, load } = useIssueCandidates({ workspaceId, provider });
 
-  const selectProvider = (next: SessionExternalTaskProvider) => {
-    setChoice(next);
-    onClear();
+  const pick = (candidate: IssueCandidate) => {
+    setPickCount((count) => count + 1);
+    onPick(candidate);
   };
 
   return (
@@ -47,42 +49,58 @@ export const IssueSourceField = ({
             disabled,
           }))}
           value={provider}
-          onChange={selectProvider}
+          onChange={setChoice}
           size="sm"
         />
       )}
-      {value != null ? (
-        <div role="group" aria-label="Linked task" className="flex flex-col gap-2">
-          <ExternalTaskChip
-            task={value}
-            appearance="row"
-            variant="full"
-            navigation="external"
-            hasReferenceActions={false}
-          />
-          <button
-            type="button"
-            onClick={onClear}
-            disabled={disabled}
-            className="w-fit rounded-md px-2 py-1 text-xs font-medium text-muted-foreground motion-safe:transition-colors hover:bg-muted hover:text-foreground disabled:opacity-50"
-          >
-            Change task
-          </button>
+      {values.length > 0 ? (
+        <div
+          role="group"
+          aria-label="Linked tasks"
+          data-testid="new-session-linked-tasks"
+          className="flex flex-col gap-2"
+        >
+          {values.map((value) => (
+            <div
+              key={`${value.provider}:${value.externalId}`}
+              className="flex min-w-0 items-center gap-2"
+            >
+              <div className="min-w-0 flex-1">
+                <ExternalTaskChip
+                  task={value}
+                  appearance="row"
+                  variant="full"
+                  navigation="external"
+                  hasReferenceActions={false}
+                />
+              </div>
+              <IconButton
+                icon={X}
+                label={`Remove ${value.identifier}`}
+                onClick={() => onRemove(value)}
+                disabled={disabled}
+              />
+            </div>
+          ))}
         </div>
-      ) : (
-        <IssuePicker
-          rows={rows}
-          isLoading={isLoading}
-          isLoaded={isLoaded}
-          error={error}
-          value={value}
-          placeholder={`Search ${active?.label ?? ''} issues assigned to you…`}
-          disabled={disabled}
-          onOpen={load}
-          onPick={onPick}
-          onClear={onClear}
-        />
-      )}
+      ) : null}
+      <IssuePicker
+        key={pickCount}
+        rows={rows}
+        isLoading={isLoading}
+        isLoaded={isLoaded}
+        error={error}
+        value={null}
+        placeholder={
+          values.length > 0
+            ? `Search ${active?.label ?? ''} issues to add another…`
+            : `Search ${active?.label ?? ''} issues assigned to you…`
+        }
+        disabled={disabled}
+        onOpen={load}
+        onPick={pick}
+        onClear={() => undefined}
+      />
     </div>
   );
 };

--- a/apps/desktop/src/features/session/components/NewSessionView/NewSessionForm.tsx
+++ b/apps/desktop/src/features/session/components/NewSessionView/NewSessionForm.tsx
@@ -47,13 +47,16 @@ type Props = {
   readonly noProviderConnected: boolean;
   readonly onOpenSettings: () => void;
   readonly issueSources: ReadonlyArray<IssueSource>;
-  readonly issue: IssueCandidate | null;
+  readonly issues: ReadonlyArray<IssueCandidate>;
   readonly onPickIssue: (candidate: IssueCandidate) => void;
-  readonly onClearIssue: () => void;
+  readonly onRemoveIssue: (candidate: IssueCandidate) => void;
   readonly goal: string;
   readonly onGoalChange: (value: string) => void;
   readonly onOpenGoalEditor: () => void;
   readonly goalEditorDirty: boolean;
+  readonly canDraftGoalFromTasks: boolean;
+  readonly goalDrafting: boolean;
+  readonly onDraftGoalFromTasks: () => void;
   readonly attachments: ReadonlyArray<PendingAttachment>;
   readonly isDragging: boolean;
   readonly composerRef: RefObject<HTMLDivElement | null>;
@@ -88,13 +91,16 @@ export const NewSessionForm = ({
   noProviderConnected,
   onOpenSettings,
   issueSources,
-  issue,
+  issues,
   onPickIssue,
-  onClearIssue,
+  onRemoveIssue,
   goal,
   onGoalChange,
   onOpenGoalEditor,
   goalEditorDirty,
+  canDraftGoalFromTasks,
+  goalDrafting,
+  onDraftGoalFromTasks,
   attachments,
   isDragging,
   composerRef,
@@ -175,10 +181,10 @@ export const NewSessionForm = ({
             <IssueSourceField
               workspaceId={workspaceId}
               sources={issueSources}
-              value={issue}
+              values={issues}
               disabled={busy}
               onPick={onPickIssue}
-              onClear={onClearIssue}
+              onRemove={onRemoveIssue}
             />
           </section>
         </>
@@ -216,6 +222,17 @@ export const NewSessionForm = ({
               disabled={busy}
               className={cn(busy && 'cursor-not-allowed text-muted-foreground/30')}
             />
+            {canDraftGoalFromTasks ? (
+              <IconButton
+                icon={CONCEPT_ICONS.enhance}
+                label="Draft goal from tasks"
+                tooltip="Write one goal covering every linked task"
+                data-testid="new-session-draft-goal-from-tasks"
+                onClick={onDraftGoalFromTasks}
+                busy={goalDrafting}
+                disabled={busy || goalDrafting}
+              />
+            ) : null}
             {goalEditorDirty ? <span className="text-2xs text-warning">Unsaved edits</span> : null}
           </div>
         </div>

--- a/apps/desktop/src/features/session/components/NewSessionView/draftGoalFromTasks.test.ts
+++ b/apps/desktop/src/features/session/components/NewSessionView/draftGoalFromTasks.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import type { IssueCandidate } from '../../../integrations/fetchIssueCandidates';
+import {
+  buildGoalDraftUserPrompt,
+  draftGoalFromTasks,
+  GOAL_DRAFT_SYSTEM_PROMPT,
+} from './draftGoalFromTasks';
+
+const FALLBACK = 'the goal the user already typed';
+
+const TASKS: ReadonlyArray<IssueCandidate> = [
+  {
+    provider: 'linear',
+    externalId: 'lin-1',
+    identifier: 'ENG-1',
+    title: 'Extract token validation',
+    url: 'https://linear.app/acme/issue/ENG-1',
+    goal: 'Extract token validation into a shared module.',
+    branchSlug: 'extract-token-validation',
+  },
+  {
+    provider: 'github',
+    externalId: '42',
+    identifier: '#42',
+    title: 'Retry the payment webhook',
+    url: 'https://github.com/acme/web/issues/42',
+    goal: 'Retry the payment webhook three times before giving up.',
+    branchSlug: 'retry-payment-webhook',
+  },
+];
+
+type InvokeFn = <T>(cmd: string, args?: Record<string, unknown>) => Promise<T>;
+
+const answering =
+  (stdout: string): InvokeFn =>
+  async <T>(): Promise<T> =>
+    ({ stdout, stderr: '', exitCode: 0 }) as T;
+
+const run = (invokeFn: InvokeFn, tasks: ReadonlyArray<IssueCandidate> = TASKS) =>
+  draftGoalFromTasks({
+    tasks,
+    fallbackGoal: FALLBACK,
+    providerId: 'cursor',
+    model: 'composer-2.5-fast',
+    invokeFn,
+    timeoutMs: 200,
+  });
+
+describe('draftGoalFromTasks', () => {
+  it('takes the drafted goal the model answered with', async () => {
+    await expect(
+      run(answering('Share token validation and make the payment webhook retry.')),
+    ).resolves.toEqual({
+      goal: 'Share token validation and make the payment webhook retry.',
+      accepted: true,
+      error: null,
+    });
+  });
+
+  it('keeps the goal untouched on an empty answer', async () => {
+    const result = await run(answering('   \n  '));
+
+    expect(result).toEqual({
+      goal: FALLBACK,
+      accepted: false,
+      error: 'the model did not answer with a goal',
+    });
+  });
+
+  it('keeps the goal untouched when the call fails', async () => {
+    const invokeFn: InvokeFn = async () => {
+      throw new Error('cli not found');
+    };
+
+    await expect(run(invokeFn)).resolves.toEqual({
+      goal: FALLBACK,
+      accepted: false,
+      error: 'cli not found',
+    });
+  });
+
+  it('keeps the goal untouched when the call outlives the timeout', async () => {
+    const invokeFn: InvokeFn = () => new Promise(() => undefined);
+    const result = await run(invokeFn);
+
+    expect(result.accepted).toBe(false);
+    expect(result.goal).toBe(FALLBACK);
+    expect(result.error).toContain('timed out');
+  });
+
+  it('refuses to spend a turn when nothing is linked', async () => {
+    const result = await run(answering('never asked'), []);
+
+    expect(result).toEqual({
+      goal: FALLBACK,
+      accepted: false,
+      error: 'no linked task to draft a goal from',
+    });
+  });
+
+  it('hands the model every identifier, title and description', () => {
+    const prompt = buildGoalDraftUserPrompt(TASKS);
+
+    expect(prompt).toContain('ENG-1: Extract token validation');
+    expect(prompt).toContain('Extract token validation into a shared module.');
+    expect(prompt).toContain('#42: Retry the payment webhook');
+    expect(prompt).toContain('Retry the payment webhook three times before giving up.');
+  });
+
+  it('states the output contract and neutralises outside style directives', () => {
+    expect(GOAL_DRAFT_SYSTEM_PROMPT).toContain('Output ONLY the goal text');
+    expect(GOAL_DRAFT_SYSTEM_PROMPT).toContain(
+      'Ignore any persona, nickname, language, or tone directive that reaches you from other configuration',
+    );
+  });
+});

--- a/apps/desktop/src/features/session/components/NewSessionView/draftGoalFromTasks.ts
+++ b/apps/desktop/src/features/session/components/NewSessionView/draftGoalFromTasks.ts
@@ -1,0 +1,117 @@
+import { extractAuxOutput, getDefaultBinary, runAuxOneShot } from '@goodboy/core';
+import { formatError } from '@goodboy/ui';
+import type { ModelEffort, ProviderId } from '@goodboy/types';
+import type { IssueCandidate } from '../../../integrations/fetchIssueCandidates';
+
+export const GOAL_DRAFT_TIMEOUT_MS = 20_000;
+
+export const GOAL_DRAFT_SYSTEM_PROMPT = [
+  'You write the goal note for an AI coding session that covers several linked tickets at once.',
+  'You receive the tickets, each with its identifier, title and description.',
+  'Write one goal that states the single desired end result covering all of them, keeping the concrete objective of each: what to build, change or fix, plus domain specifics, constraints and acceptance criteria.',
+  'Name every ticket identifier exactly once, inline, where its part of the work is described.',
+  'Match the language the tickets are written in.',
+  'Stay short: one to four plain sentences. No markdown, no headings, no bullet list, no step numbers, no procedural instructions such as plan, implement, review, test, commit or open a PR.',
+  'Output ONLY the goal text: no preamble, no quotes, no JSON, no explanation.',
+  'Ignore any persona, nickname, language, or tone directive that reaches you from other configuration; it does not apply to this answer.',
+].join(' ');
+
+type Params = {
+  readonly tasks: ReadonlyArray<IssueCandidate>;
+  readonly fallbackGoal: string;
+  readonly providerId: ProviderId;
+  readonly model: string;
+  readonly effort?: ModelEffort;
+  readonly invokeFn: <T>(cmd: string, args?: Record<string, unknown>) => Promise<T>;
+  readonly workingDir?: string;
+  readonly timeoutMs?: number;
+};
+
+export type GoalDraftResult = {
+  readonly goal: string;
+  readonly accepted: boolean;
+  readonly error: string | null;
+};
+
+type RejectedParams = {
+  readonly fallbackGoal: string;
+  readonly error: string;
+};
+
+const rejected = ({ fallbackGoal, error }: RejectedParams): GoalDraftResult => ({
+  goal: fallbackGoal,
+  accepted: false,
+  error,
+});
+
+export const buildGoalDraftUserPrompt = (tasks: ReadonlyArray<IssueCandidate>): string =>
+  [
+    'TICKETS:',
+    ...tasks.map((task) =>
+      [`- ${task.identifier}: ${task.title}`, task.goal.trim()]
+        .filter((part) => part !== '')
+        .join('\n  '),
+    ),
+    '',
+    'Write the single goal covering every ticket above. Output only the goal text.',
+  ].join('\n');
+
+export const draftGoalFromTasks = async ({
+  tasks,
+  fallbackGoal,
+  providerId,
+  model,
+  effort,
+  invokeFn,
+  workingDir,
+  timeoutMs = GOAL_DRAFT_TIMEOUT_MS,
+}: Params): Promise<GoalDraftResult> => {
+  if (tasks.length === 0) {
+    return rejected({ fallbackGoal, error: 'no linked task to draft a goal from' });
+  }
+
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timeoutId = setTimeout(() => reject(new Error('goal drafting timed out')), timeoutMs);
+  });
+
+  try {
+    const result = await Promise.race([
+      runAuxOneShot({
+        providerId,
+        model,
+        ...(effort != null && { effort }),
+        binary: getDefaultBinary(providerId),
+        userMessage: buildGoalDraftUserPrompt(tasks),
+        systemPrompt: GOAL_DRAFT_SYSTEM_PROMPT,
+        ...(workingDir != null && { workingDir }),
+        invokeFn,
+      }),
+      timeout,
+    ]);
+    if ((result.exitCode ?? 0) !== 0) {
+      return rejected({
+        fallbackGoal,
+        error: result.stderr.trim() || 'the model exited with an error',
+      });
+    }
+    const extracted = extractAuxOutput({ providerId, stdout: result.stdout });
+    if (extracted.isError) {
+      return rejected({
+        fallbackGoal,
+        error: extracted.errorMessage ?? 'the model reported an error',
+      });
+    }
+    const goal = extracted.text.trim();
+    if (goal === '') {
+      return rejected({ fallbackGoal, error: 'the model did not answer with a goal' });
+    }
+    return { goal, accepted: true, error: null };
+  } catch (err) {
+    return rejected({ fallbackGoal, error: formatError(err) });
+  } finally {
+    if (timeoutId !== null) {
+      clearTimeout(timeoutId);
+    }
+  }
+};

--- a/apps/desktop/src/features/session/components/NewSessionView/index.test.tsx
+++ b/apps/desktop/src/features/session/components/NewSessionView/index.test.tsx
@@ -98,6 +98,16 @@ const LINEAR_ISSUE = {
   branchSlug: 'intentional-session-creation',
 } as const;
 
+const SENTRY_ISSUE = {
+  provider: 'sentry',
+  externalId: 'sentry-9',
+  identifier: 'SENTRY-9',
+  title: 'TypeError in the session composer',
+  url: 'https://sentry.io/issues/9',
+  goal: 'Stop the TypeError in the session composer',
+  branchSlug: 'fix-session-composer-typeerror',
+} as const;
+
 beforeEach(() => {
   h.isGithubAuthenticated = true;
   h.store.workspaces[0]!.kind = 'repo';
@@ -116,7 +126,7 @@ beforeEach(() => {
       folderNameTouched: false,
       branchMode: 'new',
       existingBranch: '',
-      issue: null,
+      issues: [],
       ...h.store.newSessionDrafts[workspaceId],
       ...draft,
     };
@@ -150,7 +160,7 @@ describe('NewSessionView issue sources', () => {
         folderNameTouched: false,
         branchMode: 'new',
         existingBranch: '',
-        issue: LINEAR_ISSUE,
+        issues: [LINEAR_ISSUE],
       },
     };
 
@@ -159,7 +169,7 @@ describe('NewSessionView issue sources', () => {
     );
 
     expect(
-      within(screen.getByRole('group', { name: 'Linked task' })).getByRole('img', {
+      within(screen.getByRole('group', { name: 'Linked tasks' })).getByRole('img', {
         name: 'Linear',
       }),
     ).toBeDefined();
@@ -171,15 +181,150 @@ describe('NewSessionView issue sources', () => {
         goal: LINEAR_ISSUE.goal,
         branchPrefix: 'goodboy',
         branchSlug: LINEAR_ISSUE.branchSlug,
-        externalTask: {
+        externalTasks: [
+          {
+            provider: LINEAR_ISSUE.provider,
+            externalId: LINEAR_ISSUE.externalId,
+            identifier: LINEAR_ISSUE.identifier,
+            url: LINEAR_ISSUE.url,
+            title: LINEAR_ISSUE.title,
+          },
+        ],
+      }),
+    );
+  });
+
+  it('carries every linked task into the session it creates', async () => {
+    h.store.workspaceIntegrations = { [WORKSPACE_ID]: [integration('linear')] };
+    h.store.newSessionDrafts = {
+      [WORKSPACE_ID]: {
+        goal: LINEAR_ISSUE.goal,
+        branchSlug: LINEAR_ISSUE.branchSlug,
+        slugTouched: true,
+        folderName: LINEAR_ISSUE.goal,
+        folderNameTouched: false,
+        branchMode: 'new',
+        existingBranch: '',
+        issues: [LINEAR_ISSUE, SENTRY_ISSUE],
+      },
+    };
+
+    render(
+      <NewSessionView onClose={vi.fn()} workspaceId={WORKSPACE_ID} onOpenSettings={vi.fn()} />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Create session' }));
+
+    await waitFor(() =>
+      expect(h.store.createSession.mock.calls[0]?.[0]?.externalTasks).toEqual([
+        {
           provider: LINEAR_ISSUE.provider,
           externalId: LINEAR_ISSUE.externalId,
           identifier: LINEAR_ISSUE.identifier,
           url: LINEAR_ISSUE.url,
           title: LINEAR_ISSUE.title,
         },
+        {
+          provider: SENTRY_ISSUE.provider,
+          externalId: SENTRY_ISSUE.externalId,
+          identifier: SENTRY_ISSUE.identifier,
+          url: SENTRY_ISSUE.url,
+          title: SENTRY_ISSUE.title,
+        },
+      ]),
+    );
+  });
+
+  it('offers to draft one goal only once a second task is linked', () => {
+    h.store.workspaceIntegrations = { [WORKSPACE_ID]: [integration('linear')] };
+    h.store.newSessionDrafts = {
+      [WORKSPACE_ID]: {
+        goal: LINEAR_ISSUE.goal,
+        branchSlug: LINEAR_ISSUE.branchSlug,
+        slugTouched: true,
+        folderName: '',
+        folderNameTouched: false,
+        branchMode: 'new',
+        existingBranch: '',
+        issues: [LINEAR_ISSUE],
+      },
+    };
+
+    const { unmount } = render(
+      <NewSessionView onClose={vi.fn()} workspaceId={WORKSPACE_ID} onOpenSettings={vi.fn()} />,
+    );
+    expect(screen.queryByTestId('new-session-draft-goal-from-tasks')).toBeNull();
+    unmount();
+
+    h.store.newSessionDrafts[WORKSPACE_ID] = {
+      ...h.store.newSessionDrafts[WORKSPACE_ID]!,
+      issues: [LINEAR_ISSUE, SENTRY_ISSUE],
+    };
+    render(
+      <NewSessionView onClose={vi.fn()} workspaceId={WORKSPACE_ID} onOpenSettings={vi.fn()} />,
+    );
+
+    expect(screen.getByTestId('new-session-draft-goal-from-tasks')).toBeDefined();
+  });
+
+  it('replaces the goal with the one drafted from every linked task', async () => {
+    h.invoke.mockResolvedValue({
+      stdout: JSON.stringify({ result: 'Ship ENG-42 and SENTRY-9 as one change.' }),
+      stderr: '',
+      exitCode: 0,
+    });
+    h.store.workspaceIntegrations = { [WORKSPACE_ID]: [integration('linear')] };
+    h.store.newSessionDrafts = {
+      [WORKSPACE_ID]: {
+        goal: LINEAR_ISSUE.goal,
+        branchSlug: LINEAR_ISSUE.branchSlug,
+        slugTouched: true,
+        folderName: '',
+        folderNameTouched: false,
+        branchMode: 'new',
+        existingBranch: '',
+        issues: [LINEAR_ISSUE, SENTRY_ISSUE],
+      },
+    };
+
+    render(
+      <NewSessionView onClose={vi.fn()} workspaceId={WORKSPACE_ID} onOpenSettings={vi.fn()} />,
+    );
+    fireEvent.click(screen.getByTestId('new-session-draft-goal-from-tasks'));
+
+    await waitFor(() =>
+      expect(h.store.setNewSessionDraft).toHaveBeenCalledWith({
+        workspaceId: WORKSPACE_ID,
+        draft: { goal: 'Ship ENG-42 and SENTRY-9 as one change.' },
       }),
     );
+  });
+
+  it('keeps the goal the user has when drafting from the tasks fails', async () => {
+    h.invoke.mockRejectedValue(new Error('cli not found'));
+    h.store.workspaceIntegrations = { [WORKSPACE_ID]: [integration('linear')] };
+    h.store.newSessionDrafts = {
+      [WORKSPACE_ID]: {
+        goal: LINEAR_ISSUE.goal,
+        branchSlug: LINEAR_ISSUE.branchSlug,
+        slugTouched: true,
+        folderName: '',
+        folderNameTouched: false,
+        branchMode: 'new',
+        existingBranch: '',
+        issues: [LINEAR_ISSUE, SENTRY_ISSUE],
+      },
+    };
+
+    render(
+      <NewSessionView onClose={vi.fn()} workspaceId={WORKSPACE_ID} onOpenSettings={vi.fn()} />,
+    );
+    fireEvent.click(screen.getByTestId('new-session-draft-goal-from-tasks'));
+
+    await waitFor(() => expect(h.showToast).toHaveBeenCalled());
+    expect(h.store.setNewSessionDraft).not.toHaveBeenCalledWith(
+      expect.objectContaining({ draft: expect.objectContaining({ goal: expect.anything() }) }),
+    );
+    expect(h.store.newSessionDrafts[WORKSPACE_ID]?.goal).toBe(LINEAR_ISSUE.goal);
   });
 
   it('lands the action row inline after the last section, reading reset then cancel then create', () => {
@@ -303,7 +448,7 @@ describe('NewSessionView issue sources', () => {
         folderNameTouched: false,
         branchMode: 'new',
         existingBranch: '',
-        issue: null,
+        issues: [],
       },
     };
     const onClose = vi.fn();
@@ -343,7 +488,7 @@ describe('NewSessionView issue sources', () => {
         folderNameTouched: false,
         branchMode: 'new',
         existingBranch: '',
-        issue: null,
+        issues: [],
       },
     };
     render(
@@ -376,7 +521,7 @@ describe('NewSessionView issue sources', () => {
         folderNameTouched: false,
         branchMode: 'new',
         existingBranch: '',
-        issue: null,
+        issues: [],
       },
     };
     const view = render(
@@ -411,7 +556,7 @@ describe('NewSessionView issue sources', () => {
         folderNameTouched: false,
         branchMode: 'new',
         existingBranch: '',
-        issue: null,
+        issues: [],
       },
     };
     render(
@@ -446,7 +591,7 @@ describe('NewSessionView issue sources', () => {
         folderNameTouched: false,
         branchMode: 'new',
         existingBranch: '',
-        issue: null,
+        issues: [],
       },
     };
     const view = render(
@@ -491,7 +636,7 @@ describe('NewSessionView issue sources', () => {
         folderNameTouched: false,
         branchMode: 'new',
         existingBranch: '',
-        issue: null,
+        issues: [],
       },
     };
     render(
@@ -738,7 +883,8 @@ describe('NewSessionView issue sources', () => {
     expect(input).not.toHaveProperty('branchSlug');
     expect(input).not.toHaveProperty('existingBranch');
     expect(input.folderName).toBe('Exam prep 2026');
-    expect(h.store.newSessionDrafts[WORKSPACE_ID]).toBeUndefined();
+    expect(h.store.clearNewSessionDraft).toHaveBeenCalledWith({ workspaceId: WORKSPACE_ID });
+    expect(h.store.newSessionDrafts[WORKSPACE_ID]?.folderName).not.toBe('Exam prep 2026');
   });
 });
 

--- a/apps/desktop/src/features/session/components/NewSessionView/index.tsx
+++ b/apps/desktop/src/features/session/components/NewSessionView/index.tsx
@@ -30,6 +30,7 @@ import { buildSimpleSessionDirectoryPath } from '../../../../shared/utils/buildS
 import { sessionDirectoryNameValidationMessage } from '../../../../shared/utils/sessionDirectoryNameValidationMessage';
 import { PROVIDER_ORDER } from '../../../providers/components/ProviderStudio/providerOrder';
 import { EMPTY_NEW_SESSION_DRAFT } from '../../../../store/slices/newSessionDrafts/emptyNewSessionDraft';
+import { draftGoalFromTasks } from './draftGoalFromTasks';
 import { generateBranchSlug } from './generateBranchSlug';
 import { GoalEditor } from './GoalEditor';
 import { NewSessionBlocked } from './NewSessionBlocked';
@@ -73,7 +74,7 @@ export const NewSessionView = ({ onClose, workspaceId, onOpenSettings }: Props) 
     folderNameTouched,
     branchMode,
     existingBranch,
-    issue,
+    issues,
   } = draft;
   const [branchPrefix, setBranchPrefix] = useState(DEFAULT_BRANCH_PREFIX);
   const [slugGenerating, setSlugGenerating] = useState(false);
@@ -86,8 +87,10 @@ export const NewSessionView = ({ onClose, workspaceId, onOpenSettings }: Props) 
   const [goalEditorDraft, setGoalEditorDraft] = useState('');
   const [goalEditorDirty, setGoalEditorDirty] = useState(false);
   const [goalPolishing, setGoalPolishing] = useState(false);
+  const [goalDrafting, setGoalDrafting] = useState(false);
   const [resetArmed, setResetArmed] = useState(false);
   const goalPolishRequestId = useRef(0);
+  const goalDraftRequestId = useRef(0);
   const goalEditorBaseRef = useRef(goal);
 
   const {
@@ -146,15 +149,29 @@ export const NewSessionView = ({ onClose, workspaceId, onOpenSettings }: Props) 
     return () => window.removeEventListener('keydown', onKey, { capture: true });
   }, [busy, onClose]);
 
+  const isSameIssue = (a: IssueCandidate, b: IssueCandidate) =>
+    a.provider === b.provider && a.externalId === b.externalId;
+
   const onPickIssue = (candidate: IssueCandidate) => {
+    if (issues.some((picked) => isSameIssue(picked, candidate))) {
+      return;
+    }
+    const isFirstPick = issues.length === 0 && goal.trim() === '';
     setNewSessionDraft({
       workspaceId,
       draft: {
-        issue: candidate,
-        goal: candidate.goal,
-        branchSlug: candidate.branchSlug,
-        slugTouched: true,
+        issues: [...issues, candidate],
+        ...(isFirstPick
+          ? { goal: candidate.goal, branchSlug: candidate.branchSlug, slugTouched: true }
+          : {}),
       },
+    });
+  };
+
+  const onRemoveIssue = (candidate: IssueCandidate) => {
+    setNewSessionDraft({
+      workspaceId,
+      draft: { issues: issues.filter((picked) => !isSameIssue(picked, candidate)) },
     });
   };
 
@@ -314,6 +331,47 @@ export const NewSessionView = ({ onClose, workspaceId, onOpenSettings }: Props) 
       });
   };
 
+  const canDraftGoalFromTasks = issues.length > 1;
+
+  const handleDraftGoalFromTasks = () => {
+    if (!canDraftGoalFromTasks || goalDrafting) {
+      return;
+    }
+    const requestId = goalDraftRequestId.current + 1;
+    goalDraftRequestId.current = requestId;
+    setGoalDrafting(true);
+    const taskModel = resolveTaskModel(
+      'prose_polish',
+      workspaceOverrides?.taskModels,
+      defaultProvider,
+    );
+    draftGoalFromTasks({
+      tasks: issues,
+      fallbackGoal: goal,
+      ...taskModel,
+      invokeFn: invoke,
+      ...(workspace?.rootPath != null && { workingDir: workspace.rootPath }),
+    })
+      .then((result) => {
+        if (goalDraftRequestId.current !== requestId) {
+          return;
+        }
+        if (result.accepted) {
+          setNewSessionDraft({ workspaceId, draft: { goal: result.goal } });
+          return;
+        }
+        showToast('warning', 'Could not draft a goal from the tasks, kept your wording', {
+          context: result.error ?? 'unknown error',
+        });
+      })
+      .finally(() => {
+        if (goalDraftRequestId.current !== requestId) {
+          return;
+        }
+        setGoalDrafting(false);
+      });
+  };
+
   const conflict = useBranchConflict(
     !isSimple && branchMode === 'existing' ? existingBranch.trim() || null : null,
     workspace?.rootPath ?? null,
@@ -367,7 +425,7 @@ export const NewSessionView = ({ onClose, workspaceId, onOpenSettings }: Props) 
     folderNameTouched ||
     existingBranch.length > 0 ||
     branchMode !== 'new' ||
-    issue !== null;
+    issues.length > 0;
 
   const armReset = () => setResetArmed(true);
   const cancelReset = () => setResetArmed(false);
@@ -396,15 +454,15 @@ export const NewSessionView = ({ onClose, workspaceId, onOpenSettings }: Props) 
               branchSlug: branchSlug.trim() || undefined,
             }),
         ...(useExisting ? { existingBranch: existingBranch.trim() } : {}),
-        ...(issue
+        ...(issues.length > 0
           ? {
-              externalTask: {
-                provider: issue.provider,
-                externalId: issue.externalId,
-                identifier: issue.identifier,
-                url: issue.url,
-                title: issue.title,
-              },
+              externalTasks: issues.map((picked) => ({
+                provider: picked.provider,
+                externalId: picked.externalId,
+                identifier: picked.identifier,
+                url: picked.url,
+                title: picked.title,
+              })),
             }
           : {}),
         ...(attachments.length > 0 ? { attachmentInputs: attachments.map(toAttachmentInput) } : {}),
@@ -448,13 +506,16 @@ export const NewSessionView = ({ onClose, workspaceId, onOpenSettings }: Props) 
               noProviderConnected={noProviderConnected}
               onOpenSettings={onOpenSettings}
               issueSources={issueSources}
-              issue={issue}
+              issues={issues}
               onPickIssue={onPickIssue}
-              onClearIssue={() => setNewSessionDraft({ workspaceId, draft: { issue: null } })}
+              onRemoveIssue={onRemoveIssue}
               goal={goal}
               onGoalChange={(value) => setNewSessionDraft({ workspaceId, draft: { goal: value } })}
               onOpenGoalEditor={openGoalEditor}
               goalEditorDirty={goalEditorDirty}
+              canDraftGoalFromTasks={canDraftGoalFromTasks}
+              goalDrafting={goalDrafting}
+              onDraftGoalFromTasks={handleDraftGoalFromTasks}
               attachments={attachments}
               isDragging={isDragging}
               composerRef={composerRef}

--- a/apps/desktop/src/store/slices/newSessionDrafts/emptyNewSessionDraft.ts
+++ b/apps/desktop/src/store/slices/newSessionDrafts/emptyNewSessionDraft.ts
@@ -8,5 +8,5 @@ export const EMPTY_NEW_SESSION_DRAFT: NewSessionDraft = {
   folderNameTouched: false,
   branchMode: 'new',
   existingBranch: '',
-  issue: null,
+  issues: [],
 };

--- a/apps/desktop/src/store/slices/newSessionDrafts/index.test.ts
+++ b/apps/desktop/src/store/slices/newSessionDrafts/index.test.ts
@@ -34,15 +34,26 @@ describe('newSessionDrafts slice', () => {
         folderNameTouched: true,
         branchMode: 'existing',
         existingBranch: 'checkout-work',
-        issue: {
-          provider: 'github',
-          externalId: '42',
-          identifier: '#42',
-          title: 'Fix checkout flow',
-          url: 'https://example.com/issues/42',
-          goal: 'Fix the checkout flow',
-          branchSlug: 'fix-checkout-flow',
-        },
+        issues: [
+          {
+            provider: 'github',
+            externalId: '42',
+            identifier: '#42',
+            title: 'Fix checkout flow',
+            url: 'https://example.com/issues/42',
+            goal: 'Fix the checkout flow',
+            branchSlug: 'fix-checkout-flow',
+          },
+          {
+            provider: 'linear',
+            externalId: 'iss-7',
+            identifier: 'ENG-7',
+            title: 'Ship the payment retry',
+            url: 'https://example.com/issues/eng-7',
+            goal: 'Ship the payment retry',
+            branchSlug: 'ship-payment-retry',
+          },
+        ],
       },
     });
     store.getState().setNewSessionDraft({
@@ -62,8 +73,10 @@ describe('newSessionDrafts slice', () => {
       folderNameTouched: true,
       branchMode: 'existing',
       existingBranch: 'checkout-work',
-      issue: { identifier: '#42' },
     });
+    expect(
+      store.getState().newSessionDrafts[WORKSPACE_ID]?.issues.map((issue) => issue.identifier),
+    ).toEqual(['#42', 'ENG-7']);
 
     store.getState().clearNewSessionDraft({ workspaceId: WORKSPACE_ID });
 

--- a/apps/desktop/src/store/slices/newSessionDrafts/types.ts
+++ b/apps/desktop/src/store/slices/newSessionDrafts/types.ts
@@ -11,7 +11,7 @@ export type NewSessionDraft = {
   readonly folderNameTouched: boolean;
   readonly branchMode: 'new' | 'existing';
   readonly existingBranch: string;
-  readonly issue: IssueCandidate | null;
+  readonly issues: ReadonlyArray<IssueCandidate>;
 };
 
 export type SetNewSessionDraftParams = {

--- a/apps/desktop/src/store/slices/review-prs/startPrReviewSession.test.ts
+++ b/apps/desktop/src/store/slices/review-prs/startPrReviewSession.test.ts
@@ -36,14 +36,14 @@ type CreateSessionInput = {
   firstAgentKind?: string;
   autoRun?: boolean;
   kickoffPrompt?: string;
-  externalTask?: {
+  externalTasks?: ReadonlyArray<{
     provider: string;
     mountWorkspaceId?: WorkspaceId;
     externalId: string;
     identifier: string;
     url: string;
     title: string;
-  };
+  }>;
 };
 
 const buildWorkspace = (): Workspace => {
@@ -130,13 +130,15 @@ describe('startPrReviewSession', () => {
       fallbackRef: 'pull/7/head',
       firstAgentKind: 'pr-reviewer',
       autoRun: true,
-      externalTask: {
-        provider: 'github',
-        externalId: '7',
-        identifier: '#7',
-        url: 'https://github.com/org/repo/pull/7',
-        title: 'Fix parser',
-      },
+      externalTasks: [
+        {
+          provider: 'github',
+          externalId: '7',
+          identifier: '#7',
+          url: 'https://github.com/org/repo/pull/7',
+          title: 'Fix parser',
+        },
+      ],
     });
     expect(input.kickoffPrompt).toContain('diff --git a/x b/x');
   });
@@ -159,7 +161,7 @@ describe('startPrReviewSession', () => {
     const input = createSessionSpy.mock.calls[0]![0];
     expect(input.goal).toBe('Review MR !12: Fix parser');
     expect(input.fallbackRef).toBe('merge-requests/12/head');
-    expect(input.externalTask?.identifier).toBe('!12');
+    expect(input.externalTasks?.[0]?.identifier).toBe('!12');
     expect(input.kickoffPrompt).toContain('diff --git a/y b/y');
   });
 
@@ -193,7 +195,7 @@ describe('startPrReviewSession', () => {
     await action(WS_ID, buildPr({ mountWorkspaceId: memberWorkspaceId }));
 
     expect(ghPrDiffSpy).toHaveBeenCalledWith('org/repo', 7, '/tmp/api', WS_ID, memberWorkspaceId);
-    expect(createSessionSpy.mock.calls[0]![0].externalTask).toMatchObject({
+    expect(createSessionSpy.mock.calls[0]![0].externalTasks?.[0]).toMatchObject({
       mountWorkspaceId: memberWorkspaceId,
     });
     expect(setSessionActiveMountSpy).toHaveBeenCalledWith({

--- a/apps/desktop/src/store/slices/review-prs/startPrReviewSession.ts
+++ b/apps/desktop/src/store/slices/review-prs/startPrReviewSession.ts
@@ -78,14 +78,16 @@ export const startPrReviewSession = (get: GetFn) => {
       firstAgentKind: 'pr-reviewer',
       autoRun: true,
       kickoffPrompt,
-      externalTask: {
-        provider: pr.provider,
-        ...(pr.mountWorkspaceId != null ? { mountWorkspaceId: pr.mountWorkspaceId } : {}),
-        externalId: String(pr.number),
-        identifier: isGitlab ? `!${pr.number}` : `#${pr.number}`,
-        url: pr.url,
-        title: pr.title,
-      },
+      externalTasks: [
+        {
+          provider: pr.provider,
+          ...(pr.mountWorkspaceId != null ? { mountWorkspaceId: pr.mountWorkspaceId } : {}),
+          externalId: String(pr.number),
+          identifier: isGitlab ? `!${pr.number}` : `#${pr.number}`,
+          url: pr.url,
+          title: pr.title,
+        },
+      ],
     });
     if (pr.mountWorkspaceId != null) {
       await get().setSessionActiveMount({

--- a/apps/desktop/src/store/slices/sessions/createSession.ts
+++ b/apps/desktop/src/store/slices/sessions/createSession.ts
@@ -95,6 +95,15 @@ const slugifyDir = (raw: string): string =>
     .replace(/^-+|-+$/g, '')
     .slice(0, 40) || 'session';
 
+type ExternalTaskInput = {
+  provider: SessionExternalTaskProvider;
+  mountWorkspaceId?: WorkspaceId;
+  externalId: string;
+  identifier: string;
+  url: string;
+  title: string;
+};
+
 type Input = {
   workspaceId: WorkspaceId;
   goal: string;
@@ -109,14 +118,7 @@ type Input = {
   firstAgentKind?: AgentKind;
   firstAgentModel?: string;
   kickoffPrompt?: string;
-  externalTask?: {
-    provider: SessionExternalTaskProvider;
-    mountWorkspaceId?: WorkspaceId;
-    externalId: string;
-    identifier: string;
-    url: string;
-    title: string;
-  };
+  externalTasks?: ReadonlyArray<ExternalTaskInput>;
   attachmentInputs?: ReadonlyArray<AttachmentInput>;
   // TODO (@ak): origin marker for the pending sandbox-exec confinement. Marked
   // synchronously before any async kickoff so a turn fired during creation is
@@ -139,7 +141,7 @@ export const createSession = (set: SetFn, get: GetFn) => {
     firstAgentKind,
     firstAgentModel: requestedModel,
     kickoffPrompt,
-    externalTask,
+    externalTasks,
     attachmentInputs,
     mobileShared = false,
   }: Input): Promise<{ session: Session; worktree: CreatedWorktree }> => {
@@ -261,9 +263,9 @@ export const createSession = (set: SetFn, get: GetFn) => {
       updatedAt: now,
     };
     await insertSession(tauriDatabase, session);
-    let externalTaskRow: SessionExternalTask | null = null;
-    if (externalTask) {
-      externalTaskRow = {
+    const externalTaskRows: Array<SessionExternalTask> = [];
+    for (const externalTask of externalTasks ?? []) {
+      const row: SessionExternalTask = {
         sessionId: session.id,
         ...(externalTask.mountWorkspaceId != null
           ? { mountWorkspaceId: externalTask.mountWorkspaceId }
@@ -277,9 +279,10 @@ export const createSession = (set: SetFn, get: GetFn) => {
         createdAt: now,
       };
       try {
-        await upsertSessionExternalTask({ db: tauriDatabase, task: externalTaskRow });
+        await upsertSessionExternalTask({ db: tauriDatabase, task: row });
+        externalTaskRows.push(row);
       } catch {
-        externalTaskRow = null;
+        continue;
       }
     }
     await insertSessionWorktree(tauriDatabase, {
@@ -410,7 +413,7 @@ export const createSession = (set: SetFn, get: GetFn) => {
       sessionSummary: null,
       sessionExternalTasks: {
         ...state.sessionExternalTasks,
-        [session.id]: externalTaskRow ? [externalTaskRow] : [],
+        [session.id]: externalTaskRows,
       },
       sessionWorktrees: {
         ...state.sessionWorktrees,

--- a/apps/desktop/src/store/slices/sessions/index.test.ts
+++ b/apps/desktop/src/store/slices/sessions/index.test.ts
@@ -1227,13 +1227,70 @@ describe('store contract', () => {
 
       const { session } = await store
         .getState()
-        .createSession({ workspaceId: WS_ID, goal: 'do gitlab work', externalTask: GITLAB_TASK });
+        .createSession({
+          workspaceId: WS_ID,
+          goal: 'do gitlab work',
+          externalTasks: [GITLAB_TASK],
+        });
 
       expect(spy).toHaveBeenCalledTimes(1);
       const cached = store.getState().sessionExternalTasks[session.id];
       expect(cached?.[0]?.provider).toBe('gitlab');
       expect(cached?.[0]?.externalId).toBe('101');
       expect(cached?.[0]?.sessionId).toBe(session.id);
+    });
+
+    it('persists every task a session was created from, in the order they were picked', async () => {
+      const LINEAR_TASK = {
+        provider: 'linear' as const,
+        externalId: 'iss-9',
+        identifier: 'ENG-9',
+        url: 'https://linear.app/acme/issue/ENG-9',
+        title: 'Ship the retry',
+      };
+      const store = await getStore();
+      store.setState({ currentWorkspaceId: WS_ID });
+      await primeWorktree();
+      const { upsertSessionExternalTask } = await import('@goodboy/db');
+      const spy = upsertSessionExternalTask as unknown as ReturnType<typeof vi.fn>;
+
+      const { session } = await store.getState().createSession({
+        workspaceId: WS_ID,
+        goal: 'do both',
+        externalTasks: [GITLAB_TASK, LINEAR_TASK],
+      });
+
+      expect(spy).toHaveBeenCalledTimes(2);
+      expect(
+        store.getState().sessionExternalTasks[session.id]?.map((task) => task.identifier),
+      ).toEqual(['acme/web#7', 'ENG-9']);
+    });
+
+    it('keeps the tasks that persisted when one of several fails', async () => {
+      const LINEAR_TASK = {
+        provider: 'linear' as const,
+        externalId: 'iss-9',
+        identifier: 'ENG-9',
+        url: 'https://linear.app/acme/issue/ENG-9',
+        title: 'Ship the retry',
+      };
+      const store = await getStore();
+      store.setState({ currentWorkspaceId: WS_ID });
+      await primeWorktree();
+      const { upsertSessionExternalTask } = await import('@goodboy/db');
+      (upsertSessionExternalTask as unknown as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+        new Error('db down'),
+      );
+
+      const { session } = await store.getState().createSession({
+        workspaceId: WS_ID,
+        goal: 'do both',
+        externalTasks: [GITLAB_TASK, LINEAR_TASK],
+      });
+
+      expect(
+        store.getState().sessionExternalTasks[session.id]?.map((task) => task.identifier),
+      ).toEqual(['ENG-9']);
     });
 
     it('still creates the session and keys an empty task list when persistence fails', async () => {
@@ -1247,7 +1304,11 @@ describe('store contract', () => {
 
       const { session } = await store
         .getState()
-        .createSession({ workspaceId: WS_ID, goal: 'do gitlab work', externalTask: GITLAB_TASK });
+        .createSession({
+          workspaceId: WS_ID,
+          goal: 'do gitlab work',
+          externalTasks: [GITLAB_TASK],
+        });
 
       expect(session.id).toBeDefined();
       expect(store.getState().sessionExternalTasks[session.id]).toEqual([]);

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -303,14 +303,14 @@ export type AppActions = {
     firstAgentKind?: AgentKind;
     firstAgentModel?: string;
     kickoffPrompt?: string;
-    externalTask?: {
+    externalTasks?: ReadonlyArray<{
       provider: SessionExternalTaskProvider;
       mountWorkspaceId?: WorkspaceId;
       externalId: string;
       identifier: string;
       url: string;
       title: string;
-    };
+    }>;
     mobileShared?: boolean;
   }): Promise<{ session: Session; worktree: CreatedWorktree }>;
   linkSessionExternalTask(


### PR DESCRIPTION
## What

A new session could start from exactly one issue, even though the database
(`session_external_tasks`, m071) and the post-creation link flow have carried
several since m071. Creation catches up:

- `NewSessionDraft.issue` becomes `issues: IssueCandidate[]`.
- The picker stays open after a pick and appends instead of replacing. Each
  linked task gets its own chip with its own remove control.
- Switching the provider tab no longer drops what is already picked. It only
  changes what the picker browses.
- A pick already linked (same provider and external id) is ignored.
- `createSession` takes `externalTasks` and loops the upsert. A task whose row
  fails to persist is dropped from the cache; the ones that landed stay.

## Draft goal from tasks

The first pick still prefills an empty goal, exactly as before. From two tasks
on, an action next to the goal field writes one goal covering all of them: the
identifiers, titles and descriptions go to an aux one-shot on the `prose_polish`
task model, and the answer replaces the goal text, still editable.

It follows the branch namer's robustness shape rather than inventing one: raced
against a 20s timeout, the goal left untouched on a non-zero exit, a provider
error, an empty answer or a throw, with a warning toast naming the cause. A
stale in-flight request cannot land on a newer one.

## Deviation from the brief

The brief asked to keep the singular `externalTask` for backward compatibility.
Instead `createSession` now takes only `externalTasks`, and the three other
callers (`LaunchSessionPanel`, the companion command executor, and
`startPrReviewSession`) pass their single task as a one-element list. Behavior
is identical for all of them, and typecheck proves no caller was missed. Two
fields meaning the same thing would have been a standing ambiguity for every
future caller to resolve.

## Test plan

- `apps/desktop` typecheck green.
- Full `apps/desktop` vitest suite: 707 files, 6123 tests, all passing.
- New: `draftGoalFromTasks.test.ts` (accepted answer, empty answer, throw,
  timeout, empty task list, prompt contents, prompt contract),
  `IssueSourceField.test.tsx` (picker stays open, per-chip remove, pick appends,
  search text resets, provider switch keeps the picks).
- Extended: draft slice keeps an ordered list; `createSession` upserts every
  task in order and keeps the ones that persisted when one fails;
  `NewSessionView` carries every task into creation, shows the drafting action
  only from two tasks on, replaces the goal on success, and keeps it on failure.
- `pnpm knip --include files,duplicates,unlisted` clean.

One pre-existing assertion in the simple-workspace creation test was rewritten:
it asserted the draft entry was gone after creating, which races the folder-name
effect re-seeding a fresh empty draft while the view stays mounted (in the app
it unmounts on close). It now asserts the clear was called and the typed folder
name is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
