### PR TITLE
fix(desktop): reach rename and the next step where the work is

### DIFF
--- a/apps/desktop/src/features/session/components/AgentDetailPane/AgentTitle.test.tsx
+++ b/apps/desktop/src/features/session/components/AgentDetailPane/AgentTitle.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { Agent, AgentId, SessionId } from '@goodboy/types';
+
+const state = vi.hoisted(() => ({
+  renameAgent: vi.fn(async () => undefined),
+}));
+
+vi.mock('../../../../store', () => ({
+  useAppStore: <T,>(selector: (value: typeof state) => T) => selector(state),
+}));
+
+import { AgentTitle } from './AgentTitle';
+
+const sessionId = 'session-1' as SessionId;
+const agent = {
+  id: 'agent-1' as AgentId,
+  sessionId,
+  ordinal: 0,
+  name: 'Implement chat',
+  status: 'completed',
+  kind: 'implementer',
+} as Agent;
+
+afterEach(cleanup);
+
+beforeEach(() => {
+  state.renameAgent.mockClear();
+});
+
+describe('AgentTitle', () => {
+  it('reads the agent name until someone asks to change it', () => {
+    render(<AgentTitle agent={agent} sessionId={sessionId} />);
+
+    expect(screen.getByText('Implement chat')).toBeDefined();
+    expect(screen.queryByRole('textbox')).toBeNull();
+  });
+
+  it('opens the field from the rename affordance', () => {
+    render(<AgentTitle agent={agent} sessionId={sessionId} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Rename agent' }));
+
+    expect(screen.getByRole('textbox')).toBeDefined();
+  });
+
+  it('opens the field on a double click, as the agent card does', () => {
+    render(<AgentTitle agent={agent} sessionId={sessionId} />);
+
+    fireEvent.doubleClick(screen.getByText('Implement chat'));
+
+    expect(screen.getByRole('textbox')).toBeDefined();
+  });
+
+  it('saves the new name on Enter', async () => {
+    render(<AgentTitle agent={agent} sessionId={sessionId} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Rename agent' }));
+
+    const field = screen.getByRole('textbox');
+    fireEvent.change(field, { target: { value: 'Ship the chat dock' } });
+    fireEvent.keyDown(field, { key: 'Enter' });
+    await vi.waitFor(() => expect(state.renameAgent).toHaveBeenCalledTimes(1));
+
+    expect(state.renameAgent).toHaveBeenCalledWith(sessionId, 'agent-1', 'Ship the chat dock');
+  });
+
+  it('refuses an empty name and leaves the agent alone', () => {
+    render(<AgentTitle agent={agent} sessionId={sessionId} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Rename agent' }));
+
+    const field = screen.getByRole('textbox');
+    fireEvent.change(field, { target: { value: '   ' } });
+    fireEvent.keyDown(field, { key: 'Enter' });
+
+    expect(state.renameAgent).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/features/session/components/AgentDetailPane/AgentTitle.tsx
+++ b/apps/desktop/src/features/session/components/AgentDetailPane/AgentTitle.tsx
@@ -1,0 +1,60 @@
+import { Pencil } from 'lucide-react';
+import { Tooltip, cn } from '@goodboy/ui';
+import type { Agent, SessionId } from '@goodboy/types';
+import { useAppStore } from '../../../../store';
+import { useInlineRename } from '../../../../shared/hooks/useInlineRename';
+
+type Props = {
+  readonly agent: Agent;
+  readonly sessionId: SessionId;
+};
+
+export const AgentTitle = ({ agent, sessionId }: Props) => {
+  const renameAgent = useAppStore((state) => state.renameAgent);
+  const rename = useInlineRename({
+    value: agent.name,
+    onCommit: (next) => renameAgent(sessionId, agent.id, next),
+  });
+
+  if (rename.editing) {
+    return (
+      <input
+        autoFocus
+        value={rename.draft}
+        aria-label="Rename agent"
+        onChange={(event) => rename.setDraft(event.target.value)}
+        onKeyDown={rename.onKeyDown}
+        onBlur={rename.onBlur}
+        title={rename.error ?? undefined}
+        aria-invalid={rename.error !== null}
+        className={cn(
+          'w-full min-w-0 rounded-md bg-background px-1.5 py-0.5 text-lg font-semibold leading-snug text-foreground outline-none ring-1',
+          rename.error !== null ? 'ring-danger' : 'ring-primary',
+        )}
+      />
+    );
+  }
+
+  return (
+    <span className="group/title flex min-w-0 items-center gap-1.5">
+      <span className="truncate" onDoubleClick={rename.start} title={agent.name}>
+        {agent.name}
+      </span>
+      <Tooltip content="Rename agent" side="top">
+        <button
+          type="button"
+          onClick={rename.start}
+          aria-label="Rename agent"
+          className={cn(
+            'inline-flex size-5 shrink-0 items-center justify-center rounded text-muted-foreground/50',
+            'opacity-0 transition-[opacity,color,background-color] hover:bg-muted hover:text-foreground',
+            'focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]',
+            'group-hover/title:opacity-100 motion-reduce:opacity-60',
+          )}
+        >
+          <Pencil size={12} aria-hidden />
+        </button>
+      </Tooltip>
+    </span>
+  );
+};

--- a/apps/desktop/src/features/session/components/AgentDetailPane/index.tsx
+++ b/apps/desktop/src/features/session/components/AgentDetailPane/index.tsx
@@ -12,6 +12,7 @@ import { AgentStatusBadge } from '../../../workspace/components/WorkspacesSideba
 import { AgentHeaderActions } from '../AgentHeaderActions';
 import { ResolverDetailPane } from '../ResolverDetailPane';
 import { AgentBrief } from './AgentBrief';
+import { AgentTitle } from './AgentTitle';
 
 type Props = {
   readonly session: Session;
@@ -76,7 +77,7 @@ export const AgentDetailPane = ({ session, agent, isChatActive, onBack }: Props)
       fit={tab === 'transcript' ? 'bleed' : 'fill'}
       header={
         <HeaderBand
-          title={agent.name}
+          title={<AgentTitle agent={agent} sessionId={session.id} />}
           meta={
             <>
               <AgentStatusBadge status={status} />

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/OverviewNextStep.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/OverviewNextStep.tsx
@@ -1,0 +1,57 @@
+import type { Agent, SessionId, StepId, Workflow } from '@goodboy/types';
+import { useAppStore } from '../../../../store';
+import { useSessionRoleModels } from '../../../../shared/hooks/useSessionRoleModels';
+import { agentRoutingOverrides } from '../../../workflows/agentRoutingOverrides';
+import { useAdvanceWorkflowAgent } from '../../../workflows/useAdvanceWorkflowAgent';
+import { WorkflowNextStepCta } from '../../../workflows/components/WorkflowNextStepCta';
+
+type Props = {
+  readonly sessionId: SessionId;
+  readonly workflow: Workflow;
+  readonly runAgents: ReadonlyArray<Agent>;
+  readonly stepId: StepId;
+};
+
+const pendingForStep = ({
+  runAgents,
+  stepId,
+}: {
+  readonly runAgents: ReadonlyArray<Agent>;
+  readonly stepId: StepId;
+}): Agent | null =>
+  runAgents.find((agent) => agent.stepId === stepId && agent.status === 'pending') ?? null;
+
+export const OverviewNextStep = ({ sessionId, workflow, runAgents, stepId }: Props) => {
+  const roleModels = useSessionRoleModels({ sessionId });
+  const advanceAgent = useAdvanceWorkflowAgent({ sessionId });
+  const nextAgent = pendingForStep({ runAgents, stepId });
+  const modelOverride = useAppStore((state) =>
+    nextAgent != null ? (state.agentModelOverride[nextAgent.id] ?? null) : null,
+  );
+  const providerOverride = useAppStore((state) =>
+    nextAgent != null ? (state.agentProviderOverride[nextAgent.id] ?? null) : null,
+  );
+  const effortOverride = useAppStore((state) =>
+    nextAgent != null ? (state.agentEffortOverride[nextAgent.id] ?? null) : null,
+  );
+  const routing = agentRoutingOverrides({
+    agent: nextAgent,
+    modelOverride,
+    providerOverride,
+    effortOverride,
+  });
+
+  return (
+    <WorkflowNextStepCta
+      workflow={workflow}
+      runs={runAgents}
+      roleModels={roleModels}
+      agentModel={routing.agentModel}
+      agentProvider={routing.agentProvider}
+      agentEffort={routing.agentEffort}
+      onAdvance={({ step, isConfirmed }) => {
+        void advanceAgent({ agent: pendingForStep({ runAgents, stepId: step.id }), isConfirmed });
+      }}
+    />
+  );
+};

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/OverviewNextSteps.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/OverviewNextSteps.test.tsx
@@ -1,0 +1,147 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type {
+  Agent,
+  AgentId,
+  IsoDateTime,
+  Session,
+  SessionId,
+  StepId,
+  Workflow,
+  WorkflowId,
+  WorkflowRun,
+  WorkflowRunId,
+  WorkspaceId,
+} from '@goodboy/types';
+
+const state = vi.hoisted(() => ({
+  summarizerStatus: {} as Record<string, unknown>,
+  agentTurnState: {} as Record<string, unknown>,
+  agentModelOverride: {} as Record<string, string>,
+  agentProviderOverride: {} as Record<string, string>,
+  agentEffortOverride: {} as Record<string, string>,
+  activateWorkflowAgent: vi.fn(async () => undefined),
+  emitNotification: vi.fn(),
+}));
+
+const attached = vi.hoisted(() => ({ runs: [] as ReadonlyArray<unknown> }));
+
+vi.mock('../../../../store', () => ({
+  EMPTY_ARRAY: Object.freeze([]),
+  useAppStore: <T,>(selector: (value: typeof state) => T) => selector(state),
+  useSessionOpenQuestions: () => [],
+}));
+
+vi.mock('../../../workflows/useAttachedWorkflowRuns', () => ({
+  useAttachedWorkflowRuns: () => attached.runs,
+}));
+
+vi.mock('../../../../shared/hooks/useSessionRoleModels', () => ({
+  useSessionRoleModels: () => null,
+}));
+
+import { OverviewNextSteps } from './OverviewNextSteps';
+
+const workspaceId = 'ws-1' as WorkspaceId;
+const sessionId = 'session-1' as SessionId;
+const workflowId = 'wf-1' as WorkflowId;
+const runId = 'run-1' as WorkflowRunId;
+const now = '2026-08-20T00:00:00.000Z' as IsoDateTime;
+
+const workflow: Workflow = {
+  id: workflowId,
+  workspaceId,
+  name: 'Refactor',
+  description: '',
+  steps: [
+    { id: 's1' as StepId, workflowId, ordinal: 0, name: 'Scout', promptPrefix: '' },
+    { id: 's2' as StepId, workflowId, ordinal: 1, name: 'Plan', promptPrefix: '' },
+  ],
+  createdAt: now,
+  updatedAt: now,
+};
+
+const run: WorkflowRun = {
+  id: runId,
+  workflowId,
+  ordinal: 0,
+  currentStep: 0,
+  autoRun: false,
+  triggerMode: 'manual',
+  executionMode: 'static',
+};
+
+const session = { id: sessionId, workspaceId, workflowRuns: [run] } as unknown as Session;
+
+const stepAgent = (stepId: StepId, status: Agent['status'], index: number): Agent =>
+  ({
+    id: `agent-${index}` as AgentId,
+    sessionId,
+    workflowRunId: runId,
+    stepId,
+    ordinal: index,
+    name: stepId,
+    status,
+  }) as Agent;
+
+const betweenSteps: ReadonlyArray<Agent> = [
+  stepAgent('s1' as StepId, 'completed', 0),
+  stepAgent('s2' as StepId, 'pending', 1),
+];
+
+afterEach(cleanup);
+
+beforeEach(() => {
+  attached.runs = [{ run, workflow }];
+  state.summarizerStatus = {};
+  state.agentTurnState = {};
+  state.activateWorkflowAgent.mockClear();
+});
+
+describe('OverviewNextSteps', () => {
+  it('offers the next step from the overview while the run waits between steps', () => {
+    render(<OverviewNextSteps session={session} agents={betweenSteps} />);
+
+    expect(screen.getByTestId('workflow-next-step-cta')).toBeDefined();
+    expect(screen.getByText('Run next step: Plan')).toBeDefined();
+  });
+
+  it('starts the agent waiting on that step', async () => {
+    render(<OverviewNextSteps session={session} agents={betweenSteps} />);
+
+    fireEvent.click(screen.getByTestId('workflow-next-step-cta'));
+    await vi.waitFor(() => expect(state.activateWorkflowAgent).toHaveBeenCalledTimes(1));
+
+    expect(state.activateWorkflowAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId, agentId: 'agent-1' }),
+    );
+  });
+
+  it('says nothing while a step is still running', () => {
+    render(
+      <OverviewNextSteps
+        session={session}
+        agents={[stepAgent('s1' as StepId, 'running', 0), stepAgent('s2' as StepId, 'pending', 1)]}
+      />,
+    );
+
+    expect(screen.queryByTestId('workflow-next-step-cta')).toBeNull();
+    expect(screen.queryByLabelText('Up next')).toBeNull();
+  });
+
+  it('says nothing once every step is done', () => {
+    render(
+      <OverviewNextSteps
+        session={session}
+        agents={[
+          stepAgent('s1' as StepId, 'completed', 0),
+          stepAgent('s2' as StepId, 'completed', 1),
+        ]}
+      />,
+    );
+
+    expect(screen.queryByTestId('workflow-next-step-cta')).toBeNull();
+  });
+});

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/OverviewNextSteps.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/OverviewNextSteps.tsx
@@ -1,0 +1,53 @@
+import { useMemo } from 'react';
+import { Eyebrow } from '@goodboy/ui';
+import type { Agent, Session } from '@goodboy/types';
+import { splitWorkflowRuns } from '../../../workflows/activeWorkflowRuns';
+import { useAttachedWorkflowRuns } from '../../../workflows/useAttachedWorkflowRuns';
+import { useWorkflowAdvanceStates } from '../../../workflows/useWorkflowAdvanceStates';
+import { OverviewNextStep } from './OverviewNextStep';
+
+type Props = {
+  readonly session: Session;
+  readonly agents: ReadonlyArray<Agent>;
+};
+
+export const OverviewNextSteps = ({ session, agents }: Props) => {
+  const attachedRuns = useAttachedWorkflowRuns({ session });
+  const { agentsByRunId, active } = useMemo(
+    () => splitWorkflowRuns({ attachedRuns, agents }),
+    [agents, attachedRuns],
+  );
+  const advanceByRunId = useWorkflowAdvanceStates({
+    sessionId: session.id,
+    workflows: active,
+    agents,
+  });
+  const waiting = active.filter(({ run }) => advanceByRunId.get(run.id)?.kind === 'ready');
+
+  if (waiting.length === 0) {
+    return null;
+  }
+
+  return (
+    <section aria-label="Up next" className="flex flex-col gap-2">
+      <Eyebrow label="Up next" muted className="px-0.5 font-medium" />
+      <div className="flex flex-col items-start gap-1.5">
+        {waiting.map(({ run, workflow }) => {
+          const state = advanceByRunId.get(run.id);
+          if (state?.kind !== 'ready') {
+            return null;
+          }
+          return (
+            <OverviewNextStep
+              key={run.id}
+              sessionId={session.id}
+              workflow={workflow}
+              runAgents={agentsByRunId.get(run.id) ?? []}
+              stepId={state.step.id}
+            />
+          );
+        })}
+      </div>
+    </section>
+  );
+};

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/index.tsx
@@ -23,6 +23,7 @@ import { OverviewActions } from './OverviewActions';
 import { InspectorSplit } from '../SessionWorkspace/parts/InspectorSplit';
 import { SlotHistoryPanel } from '../SessionWorkspace/parts/SlotHistoryPanel';
 import { GoalOverviewRegion } from './GoalOverviewRegion';
+import { OverviewNextSteps } from './OverviewNextSteps';
 
 type Props = {
   readonly session: Session;
@@ -91,6 +92,7 @@ export const SessionOverviewPane = ({ session, onSelectLens }: Props) => {
             setIsGoalHistoryOpen(true);
           }}
         />
+        {isFresh ? null : <OverviewNextSteps session={session} agents={sessionAgents} />}
         {isFresh ? (
           <section aria-label="Start work" className="flex flex-col gap-2">
             <p className="text-sm text-muted-foreground">

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/index.tsx
@@ -9,13 +9,9 @@ import {
   useAppStore,
   useSessionOpenQuestions,
 } from '../../../../../../store';
-import { notifyWorkflowGateBlock } from '../../../../../../store/slices/workflows/notifyWorkflowGateBlock';
 import { useAttachedWorkflowRuns } from '../../../../../workflows/useAttachedWorkflowRuns';
-import { workflowRunHasOpenQuestions } from '../../../../../context/openQuestionsGate';
-import {
-  resolveWorkflowAdvance,
-  type WorkflowAdvanceState,
-} from '../../../../../workflows/advanceGate';
+import { useAdvanceWorkflowAgent } from '../../../../../workflows/useAdvanceWorkflowAgent';
+import { useWorkflowAdvanceStates } from '../../../../../workflows/useWorkflowAdvanceStates';
 import { buildTimelineGroups } from '../../../../timeline/buildTimelineGroups';
 import {
   buildTimelineStream,
@@ -43,22 +39,12 @@ export const TimelinePane = ({ session, runs, actions }: Props) => {
   const externalTasks = useAppStore((s) => s.sessionExternalTasks?.[sessionId] ?? EMPTY_ARRAY);
   const worktrees = useAppStore((s) => s.sessionWorktreeRecords?.[sessionId] ?? EMPTY_ARRAY);
   const agentKindOverride = useAppStore((s) => s.agentKindOverride);
-  const activateWorkflowAgent = useAppStore((s) => s.activateWorkflowAgent);
-  const emitNotification = useAppStore((s) => s.emitNotification);
   const markAllAgentsSeen = useAppStore((s) => s.markAllAgentsSeen);
   const setActiveLens = useAppStore((s) => s.setActiveLens);
-  const isSummarizerRunning = useAppStore(
-    (s) => s.summarizerStatus?.[sessionId]?.status === 'running',
-  );
-  const hasRunningTurn = useAppStore((s) =>
-    agents.some((agent) => {
-      const turn = s.agentTurnState?.[agent.id];
-      return turn?.kind === 'running' || turn?.kind === 'starting';
-    }),
-  );
   const questions = useSessionOpenQuestions(sessionId);
   const workflows = useAttachedWorkflowRuns({ session });
   const openTargetFor = useTimelineOpen({ sessionId });
+  const advanceAgent = useAdvanceWorkflowAgent({ sessionId });
 
   const model = useMemo(
     () =>
@@ -74,29 +60,7 @@ export const TimelinePane = ({ session, runs, actions }: Props) => {
     [agentKindOverride, agents, externalTasks, plans, questions, workflows, worktrees],
   );
 
-  const advanceByRunId = useMemo(() => {
-    const states = new Map<string, WorkflowAdvanceState>();
-    for (const attached of workflows) {
-      const runAgents = agents.filter(
-        (agent) =>
-          agent.workflowRunId === attached.run.id &&
-          agent.parentAgentId == null &&
-          agent.stepId != null,
-      );
-      states.set(
-        attached.run.id,
-        resolveWorkflowAdvance({
-          workflow: attached.workflow,
-          agents: runAgents,
-          hasOpenQuestions: workflowRunHasOpenQuestions(questions, attached.run.id),
-          isSummarizerRunning,
-          isTurnRunning: hasRunningTurn,
-          isAutoRun: attached.run.autoRun === true,
-        }),
-      );
-    }
-    return states;
-  }, [agents, hasRunningTurn, isSummarizerRunning, questions, workflows]);
+  const advanceByRunId = useWorkflowAdvanceStates({ sessionId, workflows, agents });
 
   const stalledRunIds = useMemo(() => {
     const stalled = new Set<string>();
@@ -148,18 +112,6 @@ export const TimelinePane = ({ session, runs, actions }: Props) => {
     [stream.groups, stream.items],
   );
 
-  const advanceAgent = async ({ agentId }: { readonly agentId: string }) => {
-    const agent = agents.find((candidate) => candidate.id === agentId) ?? null;
-    if (agent == null || agent.status !== 'pending') {
-      return;
-    }
-    try {
-      await activateWorkflowAgent({ sessionId, agentId: agent.id, focus: 'none' });
-    } catch (error) {
-      notifyWorkflowGateBlock({ error, sessionId, emitNotification });
-    }
-  };
-
   const actionFor = ({ item }: { readonly item: TimelineRowItem }): TimelineRowAction | null => {
     const { entry } = item;
     if (entry.kind === 'agent' && entry.openQuestions.length > 0) {
@@ -193,7 +145,7 @@ export const TimelinePane = ({ session, runs, actions }: Props) => {
     const { agent } = pending;
     return {
       label: `Start ${advance.step.name}`,
-      onAct: () => void advanceAgent({ agentId: agent.id }),
+      onAct: () => void advanceAgent({ agent }),
     };
   };
 

--- a/apps/desktop/src/features/workflows/useAdvanceWorkflowAgent.ts
+++ b/apps/desktop/src/features/workflows/useAdvanceWorkflowAgent.ts
@@ -1,0 +1,39 @@
+import { useCallback } from 'react';
+import type { Agent, SessionId } from '@goodboy/types';
+import { useAppStore } from '../../store';
+import { notifyWorkflowGateBlock } from '../../store/slices/workflows/notifyWorkflowGateBlock';
+
+type Params = {
+  readonly sessionId: SessionId;
+};
+
+type AdvanceParams = {
+  readonly agent: Agent | null;
+  readonly isConfirmed?: boolean;
+};
+
+export const useAdvanceWorkflowAgent = ({
+  sessionId,
+}: Params): ((params: AdvanceParams) => Promise<void>) => {
+  const activateWorkflowAgent = useAppStore((state) => state.activateWorkflowAgent);
+  const emitNotification = useAppStore((state) => state.emitNotification);
+
+  return useCallback(
+    async ({ agent, isConfirmed = false }: AdvanceParams): Promise<void> => {
+      if (agent == null || agent.status !== 'pending') {
+        return;
+      }
+      try {
+        await activateWorkflowAgent({
+          sessionId,
+          agentId: agent.id,
+          focus: 'none',
+          bypassGate: isConfirmed,
+        });
+      } catch (error) {
+        notifyWorkflowGateBlock({ error, sessionId, emitNotification });
+      }
+    },
+    [activateWorkflowAgent, emitNotification, sessionId],
+  );
+};

--- a/apps/desktop/src/features/workflows/useWorkflowAdvanceStates.ts
+++ b/apps/desktop/src/features/workflows/useWorkflowAdvanceStates.ts
@@ -1,0 +1,53 @@
+import { useMemo } from 'react';
+import type { Agent, SessionId } from '@goodboy/types';
+import { useAppStore, useSessionOpenQuestions } from '../../store';
+import { workflowRunHasOpenQuestions } from '../context/openQuestionsGate';
+import type { AttachedRun } from './activeWorkflowRuns';
+import { resolveWorkflowAdvance, type WorkflowAdvanceState } from './advanceGate';
+
+type Params = {
+  readonly sessionId: SessionId;
+  readonly workflows: ReadonlyArray<AttachedRun>;
+  readonly agents: ReadonlyArray<Agent>;
+};
+
+export const useWorkflowAdvanceStates = ({
+  sessionId,
+  workflows,
+  agents,
+}: Params): ReadonlyMap<string, WorkflowAdvanceState> => {
+  const questions = useSessionOpenQuestions(sessionId);
+  const isSummarizerRunning = useAppStore(
+    (state) => state.summarizerStatus?.[sessionId]?.status === 'running',
+  );
+  const hasRunningTurn = useAppStore((state) =>
+    agents.some((agent) => {
+      const turn = state.agentTurnState?.[agent.id];
+      return turn?.kind === 'running' || turn?.kind === 'starting';
+    }),
+  );
+
+  return useMemo(() => {
+    const states = new Map<string, WorkflowAdvanceState>();
+    for (const attached of workflows) {
+      const runAgents = agents.filter(
+        (agent) =>
+          agent.workflowRunId === attached.run.id &&
+          agent.parentAgentId == null &&
+          agent.stepId != null,
+      );
+      states.set(
+        attached.run.id,
+        resolveWorkflowAdvance({
+          workflow: attached.workflow,
+          agents: runAgents,
+          hasOpenQuestions: workflowRunHasOpenQuestions(questions, attached.run.id),
+          isSummarizerRunning,
+          isTurnRunning: hasRunningTurn,
+          isAutoRun: attached.run.autoRun === true,
+        }),
+      );
+    }
+    return states;
+  }, [agents, hasRunningTurn, isSummarizerRunning, questions, workflows]);
+};


### PR DESCRIPTION
## What

Two affordances that existed but could not be reached from the surface the
user was actually on.

**Rename an agent from its own page.** `renameAgent` shipped long ago, but the
only way in was a double click on the agent card in the sidebar. Open an agent
and its title was read-only. The detail header now renders the name through
the same `useInlineRename` pattern the card uses: double click to edit, plus a
pencil button that appears on hover and takes focus, following the
`BranchChip` affordance already in the overview.

**Run the next step from the overview.** A run sitting between steps offered
**Run next step: XYZ** in the workflow detail only. The session overview, which
is where you land, said nothing. It now mounts the same
`WorkflowNextStepCta` in an "Up next" band above the activity timeline,
whenever the attached run resolves to `ready`.

No logic was forked to do it. `TimelinePane` already computed the per-run
advance state and already knew how to activate a pending step agent; both
moved out into `useWorkflowAdvanceStates` and `useAdvanceWorkflowAgent`, and
`TimelinePane` now consumes them alongside the new overview band. The CTA
component itself is untouched.

## Why

Both are the same failure: the app knows how to do the thing, but the answer
lives one surface away from the question. Renaming an agent while reading its
transcript meant navigating back to a card; advancing a run meant leaving the
overview to find a button.

## Test plan

- `apps/desktop`: `npx vitest run src/features/session src/features/workspace` (164 files, 1918 tests)
- `apps/desktop`: `npx vitest run src/features/workflows` green
- `apps/desktop`: `npx tsc --noEmit` clean
- Full `npx vitest run` shows 5 unrelated store files timing out on a
  saturated runner (permissions, integrations, github, workspaces,
  session-view, sendturn, review diff). All pass in isolation and none is
  touched here.
- New: `AgentTitle.test.tsx` covers read-only default, both ways into the
  field, the Enter commit and the empty-name refusal.
  `OverviewNextSteps.test.tsx` covers the CTA appearing between steps,
  starting the agent that waits on that step, and staying silent while a step
  runs or once the run is done.

Closes #1499
Closes #1500

🤖 Generated with [Claude Code](https://claude.com/claude-code)
