### PR TITLE
feat(desktop): let any agent query the connected integrations

### DIFF
--- a/apps/desktop/src-tauri/src/bin/goodboy-query.rs
+++ b/apps/desktop/src-tauri/src/bin/goodboy-query.rs
@@ -1,0 +1,211 @@
+#[path = "../query_bridge/protocol.rs"]
+mod protocol;
+
+use std::process::ExitCode;
+
+use protocol::{
+    help_text, parse_argv, ArgvOutcome, QueryRequest, QueryResponse, SOCKET_ENV, WORKSPACE_ENV,
+};
+
+fn main() -> ExitCode {
+    let argv: Vec<String> = std::env::args().skip(1).collect();
+    match run(&argv) {
+        Ok(out) => {
+            println!("{}", out);
+            ExitCode::SUCCESS
+        }
+        Err(error) => {
+            eprintln!("{}", error);
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn run(argv: &[String]) -> Result<String, String> {
+    let parsed = match parse_argv(argv)? {
+        ArgvOutcome::Help => return Ok(help_text(help_provider(argv))),
+        ArgvOutcome::Parsed(parsed) => parsed,
+    };
+    let workspace_id = named_value(argv, "workspace")
+        .or_else(|| std::env::var(WORKSPACE_ENV).ok())
+        .unwrap_or_default();
+    if workspace_id.trim().is_empty() {
+        return Err(format!(
+            "no workspace: {} is unset, pass --workspace <id>",
+            WORKSPACE_ENV
+        ));
+    }
+    let request = QueryRequest {
+        workspace_id: workspace_id.trim().to_string(),
+        provider: parsed.provider,
+        verb: parsed.verb,
+        args: parsed.args,
+    };
+    let response = ask(&request)?;
+    if !response.ok {
+        return Err(response
+            .error
+            .unwrap_or_else(|| "the bridge refused the request".to_string()));
+    }
+    let data = response.data.unwrap_or(serde_json::Value::Null);
+    if named_flag(argv, "json") {
+        return serde_json::to_string_pretty(&data).map_err(|error| error.to_string());
+    }
+    Ok(render(&data))
+}
+
+fn help_provider(argv: &[String]) -> Option<&str> {
+    argv.iter()
+        .map(String::as_str)
+        .find(|token| !token.starts_with('-'))
+        .filter(|token| protocol::providers().contains(token))
+}
+
+fn named_value(argv: &[String], name: &str) -> Option<String> {
+    let flag = format!("--{}", name);
+    let inline = format!("--{}=", name);
+    let mut index = 0;
+    while index < argv.len() {
+        let token = argv[index].as_str();
+        if let Some(value) = token.strip_prefix(inline.as_str()) {
+            return Some(value.to_string());
+        }
+        if token == flag {
+            return argv.get(index + 1).cloned();
+        }
+        index += 1;
+    }
+    None
+}
+
+fn named_flag(argv: &[String], name: &str) -> bool {
+    let flag = format!("--{}", name);
+    argv.iter().any(|token| token == &flag)
+}
+
+#[cfg(unix)]
+fn ask(request: &QueryRequest) -> Result<QueryResponse, String> {
+    use std::io::{BufRead, BufReader, Write};
+    use std::os::unix::net::UnixStream;
+
+    let socket = std::env::var(SOCKET_ENV).map_err(|_| {
+        format!(
+            "{} is unset: run this inside a Goodboy agent, or start the Goodboy app",
+            SOCKET_ENV
+        )
+    })?;
+    let mut stream = UnixStream::connect(&socket)
+        .map_err(|error| format!("cannot reach Goodboy at {}: {}", socket, error))?;
+    let mut payload = serde_json::to_string(request).map_err(|error| error.to_string())?;
+    payload.push('\n');
+    stream
+        .write_all(payload.as_bytes())
+        .map_err(|error| error.to_string())?;
+    stream.flush().map_err(|error| error.to_string())?;
+    let mut line = String::new();
+    BufReader::new(&stream)
+        .read_line(&mut line)
+        .map_err(|error| error.to_string())?;
+    if line.trim().is_empty() {
+        return Err("Goodboy closed the connection without answering".to_string());
+    }
+    serde_json::from_str(&line).map_err(|error| format!("unreadable answer: {}", error))
+}
+
+#[cfg(not(unix))]
+fn ask(_request: &QueryRequest) -> Result<QueryResponse, String> {
+    Err("the Goodboy query bridge runs on macOS and Linux only".to_string())
+}
+
+fn render(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::Null => String::new(),
+        serde_json::Value::String(text) => text.clone(),
+        serde_json::Value::Bool(flag) => flag.to_string(),
+        serde_json::Value::Number(number) => number.to_string(),
+        serde_json::Value::Array(items) => items
+            .iter()
+            .map(render_entry)
+            .collect::<Vec<String>>()
+            .join("\n\n"),
+        serde_json::Value::Object(_) => render_entry(value),
+    }
+}
+
+fn render_entry(value: &serde_json::Value) -> String {
+    let serde_json::Value::Object(fields) = value else {
+        return render(value);
+    };
+    let mut lines: Vec<String> = Vec::new();
+    for (key, field) in fields {
+        let rendered = match field {
+            serde_json::Value::String(text) => text.clone(),
+            serde_json::Value::Null => continue,
+            serde_json::Value::Array(items) if items.is_empty() => continue,
+            other => serde_json::to_string(other).unwrap_or_default(),
+        };
+        if rendered.contains('\n') {
+            lines.push(format!("{}:\n{}", key, rendered));
+            continue;
+        }
+        lines.push(format!("{}: {}", key, rendered));
+    }
+    lines.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_workspace_override_is_read_from_argv_in_both_spellings() {
+        let spaced = vec!["--workspace".to_string(), "ws-1".to_string()];
+        let inline = vec!["--workspace=ws-2".to_string()];
+
+        assert_eq!(named_value(&spaced, "workspace").as_deref(), Some("ws-1"));
+        assert_eq!(named_value(&inline, "workspace").as_deref(), Some("ws-2"));
+        assert_eq!(named_value(&[], "workspace"), None);
+    }
+
+    #[test]
+    fn a_provider_named_before_help_narrows_the_help_text() {
+        let argv = vec!["linear".to_string(), "--help".to_string()];
+
+        assert_eq!(help_provider(&argv), Some("linear"));
+        assert_eq!(help_provider(&["--help".to_string()]), None);
+    }
+
+    #[test]
+    fn a_string_answer_prints_as_itself_and_not_as_quoted_json() {
+        let rendered = render(&serde_json::json!("a unified diff"));
+
+        assert_eq!(rendered, "a unified diff");
+    }
+
+    #[test]
+    fn an_object_prints_one_readable_field_per_line() {
+        let rendered = render(&serde_json::json!({
+            "identifier": "ENG-1",
+            "title": "ship the bridge",
+            "assignee": null
+        }));
+
+        assert!(rendered.contains("identifier: ENG-1"));
+        assert!(rendered.contains("title: ship the bridge"));
+        assert!(!rendered.contains("assignee"));
+    }
+
+    #[test]
+    fn a_list_separates_its_entries_with_a_blank_line() {
+        let rendered = render(&serde_json::json!([{ "id": "a" }, { "id": "b" }]));
+
+        assert_eq!(rendered, "id: a\n\nid: b");
+    }
+
+    #[test]
+    fn a_multiline_field_keeps_its_own_lines_under_its_key() {
+        let rendered = render(&serde_json::json!({ "description": "one\ntwo" }));
+
+        assert_eq!(rendered, "description:\none\ntwo");
+    }
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -24,6 +24,7 @@ mod provider_credentials;
 mod provider_lifecycle;
 mod providers;
 mod qa_preview;
+mod query_bridge;
 mod releases;
 mod remote_image;
 mod repo;
@@ -67,6 +68,7 @@ fn drain_child_processes(app: &tauri::AppHandle) {
     scripts::shutdown(&app.state::<scripts::ScriptRegistry>());
     terminal::shutdown(&app.state::<terminal::TerminalRegistry>());
     provider_lifecycle::shutdown(&app.state::<provider_lifecycle::ProviderLifecycleRegistry>());
+    query_bridge::shutdown();
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -155,6 +157,7 @@ pub fn run() {
         .setup(move |app| {
             use tauri::Manager;
             providers::spawn_startup_detection(app.handle().clone(), detection_opener);
+            query_bridge::start(app.handle().clone());
             #[cfg(desktop)]
             app.handle()
                 .plugin(tauri_plugin_updater::Builder::new().build())?;

--- a/apps/desktop/src-tauri/src/query_bridge/dispatch.rs
+++ b/apps/desktop/src-tauri/src/query_bridge/dispatch.rs
@@ -1,0 +1,808 @@
+use std::collections::BTreeMap;
+
+use serde::Serialize;
+use serde_json::Value;
+use tauri::{AppHandle, Manager};
+
+use super::protocol::{spec_for, Access, QueryRequest};
+
+type Args = BTreeMap<String, Value>;
+
+fn encode<T: Serialize>(value: T) -> Result<Value, String> {
+    serde_json::to_value(value).map_err(|error| error.to_string())
+}
+
+fn text(args: &Args, key: &str) -> Result<String, String> {
+    args.get(key)
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| format!("missing argument: {}", key))
+}
+
+fn optional_text(args: &Args, key: &str) -> Option<String> {
+    args.get(key).and_then(Value::as_str).map(str::to_string)
+}
+
+fn number(args: &Args, key: &str) -> Result<i64, String> {
+    args.get(key)
+        .and_then(Value::as_i64)
+        .ok_or_else(|| format!("missing numeric argument: {}", key))
+}
+
+fn unsigned(args: &Args, key: &str) -> Result<u64, String> {
+    let value = number(args, key)?;
+    u64::try_from(value).map_err(|_| format!("{} must not be negative", key))
+}
+
+fn flag(args: &Args, key: &str) -> bool {
+    args.get(key).and_then(Value::as_bool).unwrap_or(false)
+}
+
+fn config_field(provider: &str, workspace_id: &str, key: &str) -> Result<String, String> {
+    let raw = crate::integration_credentials::config_for_workspace(provider, workspace_id)
+        .map_err(|error| error.to_string())?
+        .ok_or_else(|| format!("{} is not connected in this workspace", provider))?;
+    let parsed: Value = serde_json::from_str(&raw).map_err(|error| error.to_string())?;
+    parsed
+        .get(key)
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .ok_or_else(|| format!("the {} connection stores no {}", provider, key))
+}
+
+pub async fn dispatch(app: &AppHandle, request: &QueryRequest) -> Result<Value, String> {
+    if request.workspace_id.is_empty() {
+        return Err("no workspace: pass --workspace <id>".to_string());
+    }
+    let spec = spec_for(&request.provider, &request.verb)
+        .ok_or_else(|| format!("unknown command: {} {}", request.provider, request.verb))?;
+    let workspace = request.workspace_id.as_str();
+    let args = &request.args;
+    match spec.access {
+        Access::Read => run_read(app, &request.provider, &request.verb, workspace, args).await,
+        Access::Write => run_write(app, &request.provider, &request.verb, workspace, args).await,
+    }
+}
+
+async fn run_read(
+    app: &AppHandle,
+    provider: &str,
+    verb: &str,
+    workspace: &str,
+    args: &Args,
+) -> Result<Value, String> {
+    match (provider, verb) {
+        ("linear", "issue") => encode(
+            crate::linear::linear_fetch_issue(
+                workspace.to_string(),
+                text(args, "id")?,
+                app.state(),
+            )
+            .await
+            .map_err(|error| error.to_string())?,
+        ),
+        ("linear", "issues-assigned") => encode(
+            crate::linear::linear_fetch_assigned_issues(
+                workspace.to_string(),
+                optional_text(args, "team"),
+                app.state(),
+            )
+            .await
+            .map_err(|error| error.to_string())?,
+        ),
+        ("linear", "comments") => encode(
+            crate::linear::linear_fetch_issue_comments(
+                workspace.to_string(),
+                text(args, "id")?,
+                app.state(),
+            )
+            .await
+            .map_err(|error| error.to_string())?,
+        ),
+        ("sentry", "issues") => encode(
+            crate::sentry::sentry_fetch_issues(
+                workspace.to_string(),
+                optional_text(args, "query"),
+                optional_text(args, "cursor"),
+                app.state(),
+            )
+            .await
+            .map_err(|error| error.to_string())?,
+        ),
+        ("sentry", "issue") => encode(
+            crate::sentry::sentry_fetch_issue(
+                workspace.to_string(),
+                text(args, "id")?,
+                app.state(),
+            )
+            .await
+            .map_err(|error| error.to_string())?,
+        ),
+        ("sentry", "issue-detail") => encode(
+            crate::sentry::sentry_fetch_issue_detail(
+                workspace.to_string(),
+                text(args, "id")?,
+                app.state(),
+            )
+            .await
+            .map_err(|error| error.to_string())?,
+        ),
+        ("gitlab", "issues-assigned") => encode(
+            crate::gitlab::gitlab_fetch_assigned_issues(
+                workspace.to_string(),
+                config_field("gitlab", workspace, "host")?,
+                app.state(),
+            )
+            .await
+            .map_err(|error| error.to_string())?,
+        ),
+        ("gitlab", "issue") => encode(
+            crate::gitlab::gitlab_fetch_issue(
+                workspace.to_string(),
+                config_field("gitlab", workspace, "host")?,
+                text(args, "project")?,
+                number(args, "iid")?,
+                app.state(),
+            )
+            .await
+            .map_err(|error| error.to_string())?,
+        ),
+        ("gitlab", "issue-notes") => encode(
+            crate::gitlab::gitlab_list_issue_notes(
+                workspace.to_string(),
+                config_field("gitlab", workspace, "host")?,
+                text(args, "project")?,
+                number(args, "iid")?,
+                app.state(),
+            )
+            .await
+            .map_err(|error| error.to_string())?,
+        ),
+        ("gitlab", "mrs-assigned") => encode(
+            crate::gitlab::gitlab_fetch_assigned_mrs(
+                workspace.to_string(),
+                config_field("gitlab", workspace, "host")?,
+                app.state(),
+            )
+            .await
+            .map_err(|error| error.to_string())?,
+        ),
+        ("gitlab", "mrs") => encode(
+            crate::gitlab::gitlab_fetch_project_mrs(
+                workspace.to_string(),
+                config_field("gitlab", workspace, "host")?,
+                text(args, "project")?,
+                app.state(),
+            )
+            .await
+            .map_err(|error| error.to_string())?,
+        ),
+        ("gitlab", "mr-for-branch") => encode(
+            crate::gitlab::gitlab_mr_for_branch(
+                workspace.to_string(),
+                config_field("gitlab", workspace, "host")?,
+                text(args, "project")?,
+                text(args, "branch")?,
+                app.state(),
+            )
+            .await
+            .map_err(|error| error.to_string())?,
+        ),
+        ("gitlab", "mr-diff") => encode(
+            crate::gitlab::gitlab_mr_diff(
+                workspace.to_string(),
+                config_field("gitlab", workspace, "host")?,
+                text(args, "project")?,
+                number(args, "iid")?,
+                app.state(),
+            )
+            .await
+            .map_err(|error| error.to_string())?,
+        ),
+        ("gitlab", "mr-discussions") => encode(
+            crate::gitlab::gitlab_list_mr_discussions(
+                workspace.to_string(),
+                config_field("gitlab", workspace, "host")?,
+                text(args, "project")?,
+                number(args, "iid")?,
+                app.state(),
+            )
+            .await
+            .map_err(|error| error.to_string())?,
+        ),
+        ("gitlab", "mr-approval-state") => encode(
+            crate::gitlab::gitlab_mr_approval_state(
+                workspace.to_string(),
+                config_field("gitlab", workspace, "host")?,
+                text(args, "project")?,
+                number(args, "iid")?,
+                app.state(),
+            )
+            .await
+            .map_err(|error| error.to_string())?,
+        ),
+        ("jira", "issues") => encode(
+            crate::jira::jira_list_issues(
+                workspace.to_string(),
+                config_field("jira", workspace, "siteUrl")?,
+                config_field("jira", workspace, "email")?,
+                match optional_text(args, "project") {
+                    Some(project) => project,
+                    None => config_field("jira", workspace, "projectKey")?,
+                },
+                !flag(args, "all"),
+                app.state(),
+            )
+            .await
+            .map_err(|error| error.to_string())?,
+        ),
+        ("jira", "issue") => encode(
+            crate::jira::jira_get_issue(
+                workspace.to_string(),
+                config_field("jira", workspace, "siteUrl")?,
+                config_field("jira", workspace, "email")?,
+                text(args, "key")?,
+                app.state(),
+            )
+            .await
+            .map_err(|error| error.to_string())?,
+        ),
+        ("jira", "comments") => encode(
+            crate::jira::jira_list_comments(
+                workspace.to_string(),
+                config_field("jira", workspace, "siteUrl")?,
+                config_field("jira", workspace, "email")?,
+                text(args, "key")?,
+                app.state(),
+            )
+            .await
+            .map_err(|error| error.to_string())?,
+        ),
+        ("jira", "transitions") => encode(
+            crate::jira::jira_list_transitions(
+                workspace.to_string(),
+                config_field("jira", workspace, "siteUrl")?,
+                config_field("jira", workspace, "email")?,
+                text(args, "key")?,
+                app.state(),
+            )
+            .await
+            .map_err(|error| error.to_string())?,
+        ),
+        ("bitbucket", "prs") => encode(
+            crate::bitbucket::bitbucket_list_pull_requests(
+                workspace.to_string(),
+                config_field("bitbucket", workspace, "workspaceSlug")?,
+                text(args, "repo")?,
+                config_field("bitbucket", workspace, "email")?,
+                optional_text(args, "state"),
+                app.state(),
+            )
+            .await
+            .map_err(|error| error.to_string())?,
+        ),
+        ("bitbucket", "pr") => encode(
+            crate::bitbucket::bitbucket_get_pull_request(
+                workspace.to_string(),
+                config_field("bitbucket", workspace, "workspaceSlug")?,
+                text(args, "repo")?,
+                config_field("bitbucket", workspace, "email")?,
+                unsigned(args, "id")?,
+                app.state(),
+            )
+            .await
+            .map_err(|error| error.to_string())?,
+        ),
+        ("bitbucket", "pr-diff") => encode(
+            crate::bitbucket::bitbucket_pull_request_diff(
+                workspace.to_string(),
+                config_field("bitbucket", workspace, "workspaceSlug")?,
+                text(args, "repo")?,
+                config_field("bitbucket", workspace, "email")?,
+                unsigned(args, "id")?,
+                app.state(),
+            )
+            .await
+            .map_err(|error| error.to_string())?,
+        ),
+        ("bitbucket", "pr-comments") => encode(
+            crate::bitbucket::bitbucket_list_pull_request_comments(
+                workspace.to_string(),
+                config_field("bitbucket", workspace, "workspaceSlug")?,
+                text(args, "repo")?,
+                config_field("bitbucket", workspace, "email")?,
+                unsigned(args, "id")?,
+                app.state(),
+            )
+            .await
+            .map_err(|error| error.to_string())?,
+        ),
+        ("bitbucket", "pr-statuses") => encode(
+            crate::bitbucket::bitbucket_list_pull_request_statuses(
+                workspace.to_string(),
+                config_field("bitbucket", workspace, "workspaceSlug")?,
+                text(args, "repo")?,
+                config_field("bitbucket", workspace, "email")?,
+                unsigned(args, "id")?,
+                app.state(),
+            )
+            .await
+            .map_err(|error| error.to_string())?,
+        ),
+        ("bitbucket", "pr-for-branch") => encode(
+            crate::bitbucket::bitbucket_pull_request_for_branch(
+                workspace.to_string(),
+                config_field("bitbucket", workspace, "workspaceSlug")?,
+                text(args, "repo")?,
+                config_field("bitbucket", workspace, "email")?,
+                text(args, "branch")?,
+                app.state(),
+            )
+            .await
+            .map_err(|error| error.to_string())?,
+        ),
+        ("slack", "channels") => encode(
+            crate::slack::slack_list_channels(workspace.to_string(), app.state())
+                .await
+                .map_err(|error| error.to_string())?,
+        ),
+        ("slack", "thread-heads") => encode(
+            crate::slack::slack_list_thread_heads(
+                workspace.to_string(),
+                text(args, "channel")?,
+                app.state(),
+            )
+            .await
+            .map_err(|error| error.to_string())?,
+        ),
+        ("slack", "thread") => encode(
+            crate::slack::slack_get_thread(
+                workspace.to_string(),
+                text(args, "channel")?,
+                text(args, "ts")?,
+                app.state(),
+            )
+            .await
+            .map_err(|error| error.to_string())?,
+        ),
+        ("slack", "permalink") => encode(
+            crate::slack::slack_get_permalink(
+                workspace.to_string(),
+                text(args, "channel")?,
+                text(args, "ts")?,
+                app.state(),
+            )
+            .await
+            .map_err(|error| error.to_string())?,
+        ),
+        ("slack", "users") => encode(
+            crate::slack::slack_list_users(workspace.to_string(), app.state())
+                .await
+                .map_err(|error| error.to_string())?,
+        ),
+        _ => Err(format!("unhandled read command: {} {}", provider, verb)),
+    }
+}
+
+async fn run_write(
+    app: &AppHandle,
+    provider: &str,
+    verb: &str,
+    workspace: &str,
+    args: &Args,
+) -> Result<Value, String> {
+    match (provider, verb) {
+        ("linear", "comment-create") => encode(
+            crate::linear::linear_create_comment(
+                workspace.to_string(),
+                text(args, "id")?,
+                text(args, "body")?,
+                app.state(),
+            )
+            .await
+            .map_err(|error| error.to_string())?,
+        ),
+        ("linear", "issue-update") => encode(
+            crate::linear::linear_update_issue(
+                workspace.to_string(),
+                text(args, "id")?,
+                text(args, "description")?,
+                app.state(),
+            )
+            .await
+            .map_err(|error| error.to_string())?,
+        ),
+        ("gitlab", "issue-update") => encode(
+            crate::gitlab::gitlab_update_issue(
+                workspace.to_string(),
+                config_field("gitlab", workspace, "host")?,
+                text(args, "project")?,
+                number(args, "iid")?,
+                text(args, "description")?,
+                app.state(),
+            )
+            .await
+            .map_err(|error| error.to_string())?,
+        ),
+        ("gitlab", "issue-note-create") => encode(
+            crate::gitlab::gitlab_create_issue_note(
+                workspace.to_string(),
+                config_field("gitlab", workspace, "host")?,
+                text(args, "project")?,
+                number(args, "iid")?,
+                text(args, "body")?,
+                app.state(),
+            )
+            .await
+            .map_err(|error| error.to_string())?,
+        ),
+        ("gitlab", "mr-note-create") => encode(
+            crate::gitlab::gitlab_create_mr_note(
+                workspace.to_string(),
+                config_field("gitlab", workspace, "host")?,
+                text(args, "project")?,
+                number(args, "iid")?,
+                text(args, "body")?,
+                app.state(),
+            )
+            .await
+            .map_err(|error| error.to_string())?,
+        ),
+        ("gitlab", "mr-discussion-reply") => encode(
+            crate::gitlab::gitlab_reply_to_mr_discussion(
+                workspace.to_string(),
+                config_field("gitlab", workspace, "host")?,
+                text(args, "project")?,
+                number(args, "iid")?,
+                text(args, "discussion")?,
+                text(args, "body")?,
+                app.state(),
+            )
+            .await
+            .map_err(|error| error.to_string())?,
+        ),
+        ("gitlab", "mr-discussion-resolve") => encode(
+            crate::gitlab::gitlab_resolve_mr_discussion(
+                workspace.to_string(),
+                config_field("gitlab", workspace, "host")?,
+                text(args, "project")?,
+                number(args, "iid")?,
+                text(args, "discussion")?,
+                !flag(args, "unresolve"),
+                app.state(),
+            )
+            .await
+            .map_err(|error| error.to_string())?,
+        ),
+        ("gitlab", "mr-approve") => encode(
+            crate::gitlab::gitlab_approve_mr(
+                workspace.to_string(),
+                config_field("gitlab", workspace, "host")?,
+                text(args, "project")?,
+                number(args, "iid")?,
+                app.state(),
+            )
+            .await
+            .map_err(|error| error.to_string())?,
+        ),
+        ("gitlab", "mr-unapprove") => encode(
+            crate::gitlab::gitlab_unapprove_mr(
+                workspace.to_string(),
+                config_field("gitlab", workspace, "host")?,
+                text(args, "project")?,
+                number(args, "iid")?,
+                app.state(),
+            )
+            .await
+            .map_err(|error| error.to_string())?,
+        ),
+        ("gitlab", "mr-merge") => encode(
+            crate::gitlab::gitlab_merge_mr(
+                workspace.to_string(),
+                config_field("gitlab", workspace, "host")?,
+                text(args, "project")?,
+                number(args, "iid")?,
+                app.state(),
+            )
+            .await
+            .map_err(|error| error.to_string())?,
+        ),
+        ("jira", "comment-create") => encode(
+            crate::jira::jira_create_comment(
+                workspace.to_string(),
+                config_field("jira", workspace, "siteUrl")?,
+                config_field("jira", workspace, "email")?,
+                text(args, "key")?,
+                text(args, "body")?,
+                app.state(),
+            )
+            .await
+            .map_err(|error| error.to_string())?,
+        ),
+        ("jira", "issue-update") => encode(
+            crate::jira::jira_update_issue(
+                workspace.to_string(),
+                config_field("jira", workspace, "siteUrl")?,
+                config_field("jira", workspace, "email")?,
+                text(args, "key")?,
+                text(args, "description")?,
+                app.state(),
+            )
+            .await
+            .map_err(|error| error.to_string())?,
+        ),
+        ("jira", "transition") => encode(
+            crate::jira::jira_transition_issue(
+                workspace.to_string(),
+                config_field("jira", workspace, "siteUrl")?,
+                config_field("jira", workspace, "email")?,
+                text(args, "key")?,
+                text(args, "transition")?,
+                app.state(),
+            )
+            .await
+            .map_err(|error| error.to_string())?,
+        ),
+        ("bitbucket", "pr-comment-create") => encode(
+            crate::bitbucket::bitbucket_create_pull_request_comment(
+                workspace.to_string(),
+                config_field("bitbucket", workspace, "workspaceSlug")?,
+                text(args, "repo")?,
+                config_field("bitbucket", workspace, "email")?,
+                unsigned(args, "id")?,
+                text(args, "body")?,
+                app.state(),
+            )
+            .await
+            .map_err(|error| error.to_string())?,
+        ),
+        ("bitbucket", "pr-comment-reply") => encode(
+            crate::bitbucket::bitbucket_reply_to_pull_request_comment(
+                workspace.to_string(),
+                config_field("bitbucket", workspace, "workspaceSlug")?,
+                text(args, "repo")?,
+                config_field("bitbucket", workspace, "email")?,
+                unsigned(args, "id")?,
+                unsigned(args, "parent")?,
+                text(args, "body")?,
+                app.state(),
+            )
+            .await
+            .map_err(|error| error.to_string())?,
+        ),
+        ("bitbucket", "pr-approve") => encode(
+            crate::bitbucket::bitbucket_approve_pull_request(
+                workspace.to_string(),
+                config_field("bitbucket", workspace, "workspaceSlug")?,
+                text(args, "repo")?,
+                config_field("bitbucket", workspace, "email")?,
+                unsigned(args, "id")?,
+                app.state(),
+            )
+            .await
+            .map_err(|error| error.to_string())?,
+        ),
+        ("bitbucket", "pr-unapprove") => encode(
+            crate::bitbucket::bitbucket_unapprove_pull_request(
+                workspace.to_string(),
+                config_field("bitbucket", workspace, "workspaceSlug")?,
+                text(args, "repo")?,
+                config_field("bitbucket", workspace, "email")?,
+                unsigned(args, "id")?,
+                app.state(),
+            )
+            .await
+            .map_err(|error| error.to_string())?,
+        ),
+        ("bitbucket", "pr-request-changes") => encode(
+            crate::bitbucket::bitbucket_request_changes(
+                workspace.to_string(),
+                config_field("bitbucket", workspace, "workspaceSlug")?,
+                text(args, "repo")?,
+                config_field("bitbucket", workspace, "email")?,
+                unsigned(args, "id")?,
+                app.state(),
+            )
+            .await
+            .map_err(|error| error.to_string())?,
+        ),
+        ("bitbucket", "pr-unrequest-changes") => encode(
+            crate::bitbucket::bitbucket_unrequest_changes(
+                workspace.to_string(),
+                config_field("bitbucket", workspace, "workspaceSlug")?,
+                text(args, "repo")?,
+                config_field("bitbucket", workspace, "email")?,
+                unsigned(args, "id")?,
+                app.state(),
+            )
+            .await
+            .map_err(|error| error.to_string())?,
+        ),
+        ("bitbucket", "pr-merge") => encode(
+            crate::bitbucket::bitbucket_merge_pull_request(
+                workspace.to_string(),
+                config_field("bitbucket", workspace, "workspaceSlug")?,
+                text(args, "repo")?,
+                config_field("bitbucket", workspace, "email")?,
+                unsigned(args, "id")?,
+                None,
+                optional_text(args, "message"),
+                app.state(),
+            )
+            .await
+            .map_err(|error| error.to_string())?,
+        ),
+        ("bitbucket", "pr-decline") => encode(
+            crate::bitbucket::bitbucket_decline_pull_request(
+                workspace.to_string(),
+                config_field("bitbucket", workspace, "workspaceSlug")?,
+                text(args, "repo")?,
+                config_field("bitbucket", workspace, "email")?,
+                unsigned(args, "id")?,
+                app.state(),
+            )
+            .await
+            .map_err(|error| error.to_string())?,
+        ),
+        ("slack", "reply") => encode(
+            crate::slack::slack_post_reply(
+                workspace.to_string(),
+                text(args, "channel")?,
+                text(args, "ts")?,
+                text(args, "text")?,
+                app.state(),
+            )
+            .await
+            .map_err(|error| error.to_string())?,
+        ),
+        ("slack", "reaction-add") => encode(
+            crate::slack::slack_add_reaction(
+                workspace.to_string(),
+                text(args, "channel")?,
+                text(args, "ts")?,
+                text(args, "name")?,
+                app.state(),
+            )
+            .await
+            .map_err(|error| error.to_string())?,
+        ),
+        _ => Err(format!("unhandled write command: {} {}", provider, verb)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::query_bridge::protocol::CATALOG;
+
+    fn args(pairs: &[(&str, Value)]) -> Args {
+        pairs
+            .iter()
+            .map(|(key, value)| ((*key).to_string(), value.clone()))
+            .collect()
+    }
+
+    #[test]
+    fn a_required_text_argument_reports_its_own_name_when_absent() {
+        let error = text(&args(&[]), "id").expect_err("missing id");
+
+        assert!(error.contains("id"));
+    }
+
+    #[test]
+    fn a_numeric_argument_refuses_a_string_that_looks_like_a_number() {
+        assert!(number(&args(&[("iid", Value::from("42"))]), "iid").is_err());
+        assert_eq!(number(&args(&[("iid", Value::from(42))]), "iid"), Ok(42));
+    }
+
+    #[test]
+    fn an_unsigned_argument_refuses_a_negative_id() {
+        assert!(unsigned(&args(&[("id", Value::from(-1))]), "id").is_err());
+        assert_eq!(unsigned(&args(&[("id", Value::from(7))]), "id"), Ok(7));
+    }
+
+    #[test]
+    fn an_absent_flag_reads_as_false() {
+        assert!(!flag(&args(&[]), "all"));
+        assert!(flag(&args(&[("all", Value::from(true))]), "all"));
+    }
+
+    #[test]
+    fn every_catalogued_verb_is_routed_by_the_arm_matching_its_access() {
+        for spec in CATALOG {
+            let routed = match spec.access {
+                Access::Read => READ_VERBS.contains(&(spec.provider, spec.verb)),
+                Access::Write => WRITE_VERBS.contains(&(spec.provider, spec.verb)),
+            };
+            assert!(
+                routed,
+                "{} {} is catalogued but never dispatched",
+                spec.provider, spec.verb
+            );
+        }
+    }
+
+    #[test]
+    fn no_dispatched_verb_is_missing_from_the_catalog() {
+        for (provider, verb) in READ_VERBS.iter().chain(WRITE_VERBS.iter()) {
+            assert!(
+                spec_for(provider, verb).is_some(),
+                "{} {} is dispatched but not catalogued",
+                provider,
+                verb
+            );
+        }
+    }
+
+    #[test]
+    fn a_write_verb_never_hides_inside_the_read_arm() {
+        for (provider, verb) in WRITE_VERBS {
+            assert!(
+                !READ_VERBS.contains(&(provider, verb)),
+                "{} {} is reachable from the read arm",
+                provider,
+                verb
+            );
+        }
+    }
+
+    const READ_VERBS: &[(&str, &str)] = &[
+        ("linear", "issue"),
+        ("linear", "issues-assigned"),
+        ("linear", "comments"),
+        ("sentry", "issues"),
+        ("sentry", "issue"),
+        ("sentry", "issue-detail"),
+        ("gitlab", "issues-assigned"),
+        ("gitlab", "issue"),
+        ("gitlab", "issue-notes"),
+        ("gitlab", "mrs-assigned"),
+        ("gitlab", "mrs"),
+        ("gitlab", "mr-for-branch"),
+        ("gitlab", "mr-diff"),
+        ("gitlab", "mr-discussions"),
+        ("gitlab", "mr-approval-state"),
+        ("jira", "issues"),
+        ("jira", "issue"),
+        ("jira", "comments"),
+        ("jira", "transitions"),
+        ("bitbucket", "prs"),
+        ("bitbucket", "pr"),
+        ("bitbucket", "pr-diff"),
+        ("bitbucket", "pr-comments"),
+        ("bitbucket", "pr-statuses"),
+        ("bitbucket", "pr-for-branch"),
+        ("slack", "channels"),
+        ("slack", "thread-heads"),
+        ("slack", "thread"),
+        ("slack", "permalink"),
+        ("slack", "users"),
+    ];
+
+    const WRITE_VERBS: &[(&str, &str)] = &[
+        ("linear", "comment-create"),
+        ("linear", "issue-update"),
+        ("gitlab", "issue-update"),
+        ("gitlab", "issue-note-create"),
+        ("gitlab", "mr-note-create"),
+        ("gitlab", "mr-discussion-reply"),
+        ("gitlab", "mr-discussion-resolve"),
+        ("gitlab", "mr-approve"),
+        ("gitlab", "mr-unapprove"),
+        ("gitlab", "mr-merge"),
+        ("jira", "comment-create"),
+        ("jira", "issue-update"),
+        ("jira", "transition"),
+        ("bitbucket", "pr-comment-create"),
+        ("bitbucket", "pr-comment-reply"),
+        ("bitbucket", "pr-approve"),
+        ("bitbucket", "pr-unapprove"),
+        ("bitbucket", "pr-request-changes"),
+        ("bitbucket", "pr-unrequest-changes"),
+        ("bitbucket", "pr-merge"),
+        ("bitbucket", "pr-decline"),
+        ("slack", "reply"),
+        ("slack", "reaction-add"),
+    ];
+}

--- a/apps/desktop/src-tauri/src/query_bridge/mod.rs
+++ b/apps/desktop/src-tauri/src/query_bridge/mod.rs
@@ -1,0 +1,172 @@
+mod dispatch;
+pub mod protocol;
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::OnceLock;
+
+use protocol::{QueryRequest, QueryResponse, SOCKET_ENV, SOCKET_FILE, WORKSPACE_ENV};
+
+const APP_DIR: &str = ".goodboy";
+
+static SOCKET_PATH: OnceLock<Option<PathBuf>> = OnceLock::new();
+static CLI_DIR: OnceLock<Option<PathBuf>> = OnceLock::new();
+
+fn socket_path() -> Option<&'static Path> {
+    SOCKET_PATH
+        .get_or_init(|| dirs::home_dir().map(|home| home.join(APP_DIR).join(SOCKET_FILE)))
+        .as_deref()
+}
+
+fn cli_dir() -> Option<&'static Path> {
+    CLI_DIR
+        .get_or_init(|| {
+            let exe = std::env::current_exe().ok()?;
+            let dir = exe.parent()?;
+            let candidate = dir.join(protocol::BINARY_NAME);
+            candidate.is_file().then(|| dir.to_path_buf())
+        })
+        .as_deref()
+}
+
+pub(crate) fn apply_env(command: &mut Command, workspace_id: Option<&str>) {
+    let Some(socket) = socket_path() else {
+        return;
+    };
+    if !socket.exists() {
+        return;
+    }
+    command.env(SOCKET_ENV, socket);
+    if let Some(workspace_id) = workspace_id {
+        command.env(WORKSPACE_ENV, workspace_id);
+    }
+    if let Some(dir) = cli_dir() {
+        command.env(
+            "PATH",
+            format!("{}:{}", dir.display(), crate::path_env::resolved_path()),
+        );
+    }
+}
+
+#[cfg(unix)]
+pub(crate) fn start(app: tauri::AppHandle) {
+    use std::os::unix::fs::PermissionsExt;
+    use tokio::net::UnixListener;
+
+    let Some(path) = socket_path() else {
+        return;
+    };
+    if let Some(parent) = path.parent() {
+        if let Err(error) = std::fs::create_dir_all(parent) {
+            log::warn!("query bridge: state directory unavailable: {error}");
+            return;
+        }
+    }
+    let _ = std::fs::remove_file(path);
+    tauri::async_runtime::spawn(async move {
+        let Some(path) = socket_path() else {
+            return;
+        };
+        let listener = match UnixListener::bind(path) {
+            Ok(listener) => listener,
+            Err(error) => {
+                log::warn!("query bridge: socket unavailable: {error}");
+                return;
+            }
+        };
+        if let Err(error) = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)) {
+            log::warn!("query bridge: socket permissions not narrowed: {error}");
+            let _ = std::fs::remove_file(path);
+            return;
+        }
+        loop {
+            let Ok((stream, _)) = listener.accept().await else {
+                break;
+            };
+            let app = app.clone();
+            tauri::async_runtime::spawn(async move {
+                serve_connection(stream, app).await;
+            });
+        }
+    });
+}
+
+#[cfg(not(unix))]
+pub(crate) fn start(_app: tauri::AppHandle) {}
+
+pub(crate) fn shutdown() {
+    if let Some(path) = socket_path() {
+        let _ = std::fs::remove_file(path);
+    }
+}
+
+#[cfg(unix)]
+async fn serve_connection(stream: tokio::net::UnixStream, app: tauri::AppHandle) {
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+    let (reader, mut writer) = stream.into_split();
+    let mut lines = BufReader::new(reader).lines();
+    while let Ok(Some(line)) = lines.next_line().await {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let response = answer(&app, &line).await;
+        let mut payload = match serde_json::to_string(&response) {
+            Ok(payload) => payload,
+            Err(error) => format!("{{\"ok\":false,\"error\":\"{}\"}}", error),
+        };
+        payload.push('\n');
+        if writer.write_all(payload.as_bytes()).await.is_err() {
+            break;
+        }
+    }
+}
+
+async fn answer(app: &tauri::AppHandle, line: &str) -> QueryResponse {
+    let request = match serde_json::from_str::<QueryRequest>(line) {
+        Ok(request) => request,
+        Err(error) => return QueryResponse::failed(format!("malformed request: {}", error)),
+    };
+    match dispatch::dispatch(app, &request).await {
+        Ok(data) => QueryResponse::ok(data),
+        Err(error) => QueryResponse::failed(error),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_socket_lives_beside_the_database_in_the_state_directory() {
+        let path = socket_path().expect("a home directory");
+
+        assert!(path.ends_with(format!("{}/{}", APP_DIR, SOCKET_FILE)));
+    }
+
+    #[test]
+    fn a_child_is_told_about_the_bridge_only_while_the_socket_is_live() {
+        let mut command = Command::new("true");
+
+        apply_env(&mut command, Some("ws-1"));
+
+        let names: Vec<String> = command
+            .get_envs()
+            .filter_map(|(key, _)| key.to_str().map(str::to_string))
+            .collect();
+        let live = socket_path().map(Path::exists).unwrap_or(false);
+        assert_eq!(names.contains(&SOCKET_ENV.to_string()), live);
+    }
+
+    #[test]
+    fn a_malformed_request_is_answered_rather_than_dropped() {
+        let response = QueryResponse::failed("malformed request: expected value");
+
+        assert!(!response.ok);
+        assert!(response.data.is_none());
+        assert!(response
+            .error
+            .expect("an error")
+            .contains("malformed request"));
+    }
+}

--- a/apps/desktop/src-tauri/src/query_bridge/protocol.rs
+++ b/apps/desktop/src-tauri/src/query_bridge/protocol.rs
@@ -1,0 +1,887 @@
+#![allow(dead_code)]
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+pub const SOCKET_ENV: &str = "GOODBOY_QUERY_SOCKET";
+pub const WORKSPACE_ENV: &str = "GOODBOY_WORKSPACE_ID";
+pub const SOCKET_FILE: &str = "query.sock";
+pub const BINARY_NAME: &str = "goodboy-query";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct QueryRequest {
+    pub workspace_id: String,
+    pub provider: String,
+    pub verb: String,
+    #[serde(default)]
+    pub args: BTreeMap<String, serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QueryResponse {
+    pub ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+impl QueryResponse {
+    pub fn ok(data: serde_json::Value) -> Self {
+        Self {
+            ok: true,
+            data: Some(data),
+            error: None,
+        }
+    }
+
+    pub fn failed(error: impl Into<String>) -> Self {
+        Self {
+            ok: false,
+            data: None,
+            error: Some(error.into()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Access {
+    Read,
+    Write,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct VerbSpec {
+    pub provider: &'static str,
+    pub verb: &'static str,
+    pub params: &'static [Param],
+    pub access: Access,
+    pub summary: &'static str,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Param {
+    pub name: &'static str,
+    pub required: bool,
+    pub kind: ParamKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ParamKind {
+    Text,
+    Number,
+    Flag,
+}
+
+const fn req(name: &'static str) -> Param {
+    Param {
+        name,
+        required: true,
+        kind: ParamKind::Text,
+    }
+}
+
+const fn opt(name: &'static str) -> Param {
+    Param {
+        name,
+        required: false,
+        kind: ParamKind::Text,
+    }
+}
+
+const fn num(name: &'static str) -> Param {
+    Param {
+        name,
+        required: true,
+        kind: ParamKind::Number,
+    }
+}
+
+const fn flag(name: &'static str) -> Param {
+    Param {
+        name,
+        required: false,
+        kind: ParamKind::Flag,
+    }
+}
+
+pub const CATALOG: &[VerbSpec] = &[
+    VerbSpec {
+        provider: "linear",
+        verb: "issue",
+        params: &[req("id")],
+        access: Access::Read,
+        summary: "one issue by identifier, for example ENG-123",
+    },
+    VerbSpec {
+        provider: "linear",
+        verb: "issues-assigned",
+        params: &[opt("team")],
+        access: Access::Read,
+        summary: "open issues assigned to the connected user",
+    },
+    VerbSpec {
+        provider: "linear",
+        verb: "comments",
+        params: &[req("id")],
+        access: Access::Read,
+        summary: "every comment on an issue, oldest first",
+    },
+    VerbSpec {
+        provider: "linear",
+        verb: "comment-create",
+        params: &[req("id"), req("body")],
+        access: Access::Write,
+        summary: "post a comment on an issue",
+    },
+    VerbSpec {
+        provider: "linear",
+        verb: "issue-update",
+        params: &[req("id"), req("description")],
+        access: Access::Write,
+        summary: "replace an issue description",
+    },
+    VerbSpec {
+        provider: "sentry",
+        verb: "issues",
+        params: &[opt("query"), opt("cursor")],
+        access: Access::Read,
+        summary: "issues in the connected project",
+    },
+    VerbSpec {
+        provider: "sentry",
+        verb: "issue",
+        params: &[req("id")],
+        access: Access::Read,
+        summary: "one issue by id",
+    },
+    VerbSpec {
+        provider: "sentry",
+        verb: "issue-detail",
+        params: &[req("id")],
+        access: Access::Read,
+        summary: "one issue with stack frames, tags and breadcrumbs",
+    },
+    VerbSpec {
+        provider: "gitlab",
+        verb: "issues-assigned",
+        params: &[],
+        access: Access::Read,
+        summary: "open issues assigned to the connected user",
+    },
+    VerbSpec {
+        provider: "gitlab",
+        verb: "issue",
+        params: &[req("project"), num("iid")],
+        access: Access::Read,
+        summary: "one issue by project path and iid",
+    },
+    VerbSpec {
+        provider: "gitlab",
+        verb: "issue-notes",
+        params: &[req("project"), num("iid")],
+        access: Access::Read,
+        summary: "notes on an issue",
+    },
+    VerbSpec {
+        provider: "gitlab",
+        verb: "issue-update",
+        params: &[req("project"), num("iid"), req("description")],
+        access: Access::Write,
+        summary: "replace an issue description",
+    },
+    VerbSpec {
+        provider: "gitlab",
+        verb: "issue-note-create",
+        params: &[req("project"), num("iid"), req("body")],
+        access: Access::Write,
+        summary: "post a note on an issue",
+    },
+    VerbSpec {
+        provider: "gitlab",
+        verb: "mrs-assigned",
+        params: &[],
+        access: Access::Read,
+        summary: "merge requests assigned to the connected user",
+    },
+    VerbSpec {
+        provider: "gitlab",
+        verb: "mrs",
+        params: &[req("project")],
+        access: Access::Read,
+        summary: "merge requests of one project",
+    },
+    VerbSpec {
+        provider: "gitlab",
+        verb: "mr-for-branch",
+        params: &[req("project"), req("branch")],
+        access: Access::Read,
+        summary: "the merge request opened from a source branch",
+    },
+    VerbSpec {
+        provider: "gitlab",
+        verb: "mr-diff",
+        params: &[req("project"), num("iid")],
+        access: Access::Read,
+        summary: "unified diff of a merge request",
+    },
+    VerbSpec {
+        provider: "gitlab",
+        verb: "mr-discussions",
+        params: &[req("project"), num("iid")],
+        access: Access::Read,
+        summary: "review threads on a merge request",
+    },
+    VerbSpec {
+        provider: "gitlab",
+        verb: "mr-approval-state",
+        params: &[req("project"), num("iid")],
+        access: Access::Read,
+        summary: "who approved a merge request and what is still required",
+    },
+    VerbSpec {
+        provider: "gitlab",
+        verb: "mr-note-create",
+        params: &[req("project"), num("iid"), req("body")],
+        access: Access::Write,
+        summary: "post a plain note on a merge request",
+    },
+    VerbSpec {
+        provider: "gitlab",
+        verb: "mr-discussion-reply",
+        params: &[req("project"), num("iid"), req("discussion"), req("body")],
+        access: Access::Write,
+        summary: "reply inside an existing review thread",
+    },
+    VerbSpec {
+        provider: "gitlab",
+        verb: "mr-discussion-resolve",
+        params: &[
+            req("project"),
+            num("iid"),
+            req("discussion"),
+            flag("unresolve"),
+        ],
+        access: Access::Write,
+        summary: "resolve a review thread, or reopen it with --unresolve",
+    },
+    VerbSpec {
+        provider: "gitlab",
+        verb: "mr-approve",
+        params: &[req("project"), num("iid")],
+        access: Access::Write,
+        summary: "approve a merge request",
+    },
+    VerbSpec {
+        provider: "gitlab",
+        verb: "mr-unapprove",
+        params: &[req("project"), num("iid")],
+        access: Access::Write,
+        summary: "withdraw an approval",
+    },
+    VerbSpec {
+        provider: "gitlab",
+        verb: "mr-merge",
+        params: &[req("project"), num("iid")],
+        access: Access::Write,
+        summary: "merge a merge request",
+    },
+    VerbSpec {
+        provider: "jira",
+        verb: "issues",
+        params: &[opt("project"), flag("all")],
+        access: Access::Read,
+        summary: "issues of a project, assigned to the connected user unless --all",
+    },
+    VerbSpec {
+        provider: "jira",
+        verb: "issue",
+        params: &[req("key")],
+        access: Access::Read,
+        summary: "one issue by key, for example ENG-123",
+    },
+    VerbSpec {
+        provider: "jira",
+        verb: "comments",
+        params: &[req("key")],
+        access: Access::Read,
+        summary: "every comment on an issue",
+    },
+    VerbSpec {
+        provider: "jira",
+        verb: "transitions",
+        params: &[req("key")],
+        access: Access::Read,
+        summary: "transitions available on an issue",
+    },
+    VerbSpec {
+        provider: "jira",
+        verb: "comment-create",
+        params: &[req("key"), req("body")],
+        access: Access::Write,
+        summary: "post a comment on an issue",
+    },
+    VerbSpec {
+        provider: "jira",
+        verb: "issue-update",
+        params: &[req("key"), req("description")],
+        access: Access::Write,
+        summary: "replace an issue description",
+    },
+    VerbSpec {
+        provider: "jira",
+        verb: "transition",
+        params: &[req("key"), req("transition")],
+        access: Access::Write,
+        summary: "move an issue through a transition id",
+    },
+    VerbSpec {
+        provider: "bitbucket",
+        verb: "prs",
+        params: &[req("repo"), opt("state")],
+        access: Access::Read,
+        summary: "pull requests of a repository",
+    },
+    VerbSpec {
+        provider: "bitbucket",
+        verb: "pr",
+        params: &[req("repo"), num("id")],
+        access: Access::Read,
+        summary: "one pull request by id",
+    },
+    VerbSpec {
+        provider: "bitbucket",
+        verb: "pr-diff",
+        params: &[req("repo"), num("id")],
+        access: Access::Read,
+        summary: "unified diff of a pull request",
+    },
+    VerbSpec {
+        provider: "bitbucket",
+        verb: "pr-comments",
+        params: &[req("repo"), num("id")],
+        access: Access::Read,
+        summary: "comments on a pull request",
+    },
+    VerbSpec {
+        provider: "bitbucket",
+        verb: "pr-statuses",
+        params: &[req("repo"), num("id")],
+        access: Access::Read,
+        summary: "build statuses reported on a pull request",
+    },
+    VerbSpec {
+        provider: "bitbucket",
+        verb: "pr-for-branch",
+        params: &[req("repo"), req("branch")],
+        access: Access::Read,
+        summary: "the pull request opened from a source branch",
+    },
+    VerbSpec {
+        provider: "bitbucket",
+        verb: "pr-comment-create",
+        params: &[req("repo"), num("id"), req("body")],
+        access: Access::Write,
+        summary: "post a comment on a pull request",
+    },
+    VerbSpec {
+        provider: "bitbucket",
+        verb: "pr-comment-reply",
+        params: &[req("repo"), num("id"), num("parent"), req("body")],
+        access: Access::Write,
+        summary: "reply to an existing pull request comment",
+    },
+    VerbSpec {
+        provider: "bitbucket",
+        verb: "pr-approve",
+        params: &[req("repo"), num("id")],
+        access: Access::Write,
+        summary: "approve a pull request",
+    },
+    VerbSpec {
+        provider: "bitbucket",
+        verb: "pr-unapprove",
+        params: &[req("repo"), num("id")],
+        access: Access::Write,
+        summary: "withdraw an approval",
+    },
+    VerbSpec {
+        provider: "bitbucket",
+        verb: "pr-request-changes",
+        params: &[req("repo"), num("id")],
+        access: Access::Write,
+        summary: "mark a pull request as needing changes",
+    },
+    VerbSpec {
+        provider: "bitbucket",
+        verb: "pr-unrequest-changes",
+        params: &[req("repo"), num("id")],
+        access: Access::Write,
+        summary: "withdraw a changes-requested mark",
+    },
+    VerbSpec {
+        provider: "bitbucket",
+        verb: "pr-merge",
+        params: &[req("repo"), num("id"), opt("message")],
+        access: Access::Write,
+        summary: "merge a pull request",
+    },
+    VerbSpec {
+        provider: "bitbucket",
+        verb: "pr-decline",
+        params: &[req("repo"), num("id")],
+        access: Access::Write,
+        summary: "decline a pull request",
+    },
+    VerbSpec {
+        provider: "slack",
+        verb: "channels",
+        params: &[],
+        access: Access::Read,
+        summary: "channels the connected bot can read",
+    },
+    VerbSpec {
+        provider: "slack",
+        verb: "thread-heads",
+        params: &[req("channel")],
+        access: Access::Read,
+        summary: "root messages of a channel",
+    },
+    VerbSpec {
+        provider: "slack",
+        verb: "thread",
+        params: &[req("channel"), req("ts")],
+        access: Access::Read,
+        summary: "every message in one thread",
+    },
+    VerbSpec {
+        provider: "slack",
+        verb: "permalink",
+        params: &[req("channel"), req("ts")],
+        access: Access::Read,
+        summary: "the permalink of one message",
+    },
+    VerbSpec {
+        provider: "slack",
+        verb: "users",
+        params: &[],
+        access: Access::Read,
+        summary: "members of the connected workspace",
+    },
+    VerbSpec {
+        provider: "slack",
+        verb: "reply",
+        params: &[req("channel"), req("ts"), req("text")],
+        access: Access::Write,
+        summary: "post a reply in a thread",
+    },
+    VerbSpec {
+        provider: "slack",
+        verb: "reaction-add",
+        params: &[req("channel"), req("ts"), req("name")],
+        access: Access::Write,
+        summary: "add an emoji reaction to a message",
+    },
+];
+
+pub fn spec_for(provider: &str, verb: &str) -> Option<&'static VerbSpec> {
+    CATALOG
+        .iter()
+        .find(|spec| spec.provider == provider && spec.verb == verb)
+}
+
+pub fn specs_for_provider(provider: &str) -> Vec<&'static VerbSpec> {
+    CATALOG
+        .iter()
+        .filter(|spec| spec.provider == provider)
+        .collect()
+}
+
+pub fn providers() -> Vec<&'static str> {
+    let mut seen: Vec<&'static str> = Vec::new();
+    for spec in CATALOG {
+        if !seen.contains(&spec.provider) {
+            seen.push(spec.provider);
+        }
+    }
+    seen
+}
+
+pub fn usage(spec: &VerbSpec) -> String {
+    let mut line = format!("{} {} {}", BINARY_NAME, spec.provider, spec.verb);
+    for param in spec.params {
+        let body = match param.kind {
+            ParamKind::Flag => format!("--{}", param.name),
+            _ => format!("--{} <{}>", param.name, param.name),
+        };
+        if param.required {
+            line.push_str(&format!(" {}", body));
+            continue;
+        }
+        line.push_str(&format!(" [{}]", body));
+    }
+    line
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct ParsedArgv {
+    pub provider: String,
+    pub verb: String,
+    pub args: BTreeMap<String, serde_json::Value>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum ArgvOutcome {
+    Help,
+    Parsed(ParsedArgv),
+}
+
+pub fn parse_argv(argv: &[String]) -> Result<ArgvOutcome, String> {
+    let mut positional: Vec<&str> = Vec::new();
+    let mut flags: Vec<(&str, Option<&str>)> = Vec::new();
+    let mut index = 0;
+    while index < argv.len() {
+        let token = argv[index].as_str();
+        if token == "--help" || token == "-h" {
+            return Ok(ArgvOutcome::Help);
+        }
+        let Some(name) = token.strip_prefix("--") else {
+            positional.push(token);
+            index += 1;
+            continue;
+        };
+        if let Some((name, value)) = name.split_once('=') {
+            flags.push((name, Some(value)));
+            index += 1;
+            continue;
+        }
+        if is_valueless(name) {
+            flags.push((name, None));
+            index += 1;
+            continue;
+        }
+        let next = argv.get(index + 1).map(String::as_str);
+        match next {
+            Some(value) if !value.starts_with("--") => {
+                flags.push((name, Some(value)));
+                index += 2;
+            }
+            _ => {
+                flags.push((name, None));
+                index += 1;
+            }
+        }
+    }
+
+    if positional.is_empty() {
+        return Ok(ArgvOutcome::Help);
+    }
+    let provider = positional[0];
+    let Some(verb) = positional.get(1) else {
+        return Err(format!(
+            "missing verb. try: {} {} --help",
+            BINARY_NAME, provider
+        ));
+    };
+    let Some(spec) = spec_for(provider, verb) else {
+        return Err(format!(
+            "unknown command: {} {}. try: {} --help",
+            provider, verb, BINARY_NAME
+        ));
+    };
+
+    let mut args: BTreeMap<String, serde_json::Value> = BTreeMap::new();
+    let mut free = positional[2..].iter();
+    for param in spec.params {
+        let supplied = flags
+            .iter()
+            .find(|(name, _)| *name == param.name)
+            .map(|(_, value)| *value);
+        let value = match (supplied, param.kind) {
+            (Some(_), ParamKind::Flag) => Some(serde_json::Value::Bool(true)),
+            (Some(Some(raw)), _) => Some(text_or_number(raw, param.kind)?),
+            (Some(None), _) => {
+                return Err(format!("--{} needs a value", param.name));
+            }
+            (None, ParamKind::Flag) => None,
+            (None, _) => match free.next() {
+                Some(raw) => Some(text_or_number(raw, param.kind)?),
+                None => None,
+            },
+        };
+        match value {
+            Some(value) => {
+                args.insert(param.name.to_string(), value);
+            }
+            None if param.required => {
+                return Err(format!("missing --{}\nusage: {}", param.name, usage(spec)));
+            }
+            None => {}
+        }
+    }
+
+    for (name, _) in &flags {
+        let known = spec.params.iter().any(|param| param.name == *name)
+            || *name == "workspace"
+            || *name == "json";
+        if !known {
+            return Err(format!("unknown option --{}\nusage: {}", name, usage(spec)));
+        }
+    }
+
+    Ok(ArgvOutcome::Parsed(ParsedArgv {
+        provider: provider.to_string(),
+        verb: (*verb).to_string(),
+        args,
+    }))
+}
+
+fn is_valueless(name: &str) -> bool {
+    if name == "json" {
+        return true;
+    }
+    CATALOG.iter().any(|spec| {
+        spec.params
+            .iter()
+            .any(|param| param.name == name && param.kind == ParamKind::Flag)
+    })
+}
+
+fn text_or_number(raw: &str, kind: ParamKind) -> Result<serde_json::Value, String> {
+    if kind != ParamKind::Number {
+        return Ok(serde_json::Value::String(raw.to_string()));
+    }
+    raw.parse::<i64>()
+        .map(|value| serde_json::Value::Number(value.into()))
+        .map_err(|_| format!("expected a number, got {}", raw))
+}
+
+pub fn help_text(provider: Option<&str>) -> String {
+    let mut lines: Vec<String> = Vec::new();
+    match provider {
+        Some(provider) => {
+            lines.push(format!("{} {} commands", BINARY_NAME, provider));
+            for spec in specs_for_provider(provider) {
+                lines.push(format!("  {}", usage(spec)));
+                lines.push(format!("      {}", spec.summary));
+            }
+        }
+        None => {
+            lines.push(format!(
+                "usage: {} <provider> <verb> [options]",
+                BINARY_NAME
+            ));
+            lines.push(String::new());
+            lines.push("providers:".to_string());
+            for provider in providers() {
+                let count = specs_for_provider(provider).len();
+                lines.push(format!("  {} ({} commands)", provider, count));
+            }
+            lines.push(String::new());
+            lines.push(format!(
+                "run `{} <provider> --help` for that provider's commands",
+                BINARY_NAME
+            ));
+            lines.push(format!(
+                "the workspace comes from {}; override it with --workspace <id>",
+                WORKSPACE_ENV
+            ));
+        }
+    }
+    lines.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_verb_takes_its_arguments_positionally_in_declaration_order() {
+        let argv = vec![
+            "linear".to_string(),
+            "issue".to_string(),
+            "ENG-1".to_string(),
+        ];
+
+        let outcome = parse_argv(&argv).expect("parsed");
+
+        assert_eq!(
+            outcome,
+            ArgvOutcome::Parsed(ParsedArgv {
+                provider: "linear".to_string(),
+                verb: "issue".to_string(),
+                args: BTreeMap::from([("id".to_string(), serde_json::json!("ENG-1"))]),
+            })
+        );
+    }
+
+    #[test]
+    fn a_named_option_wins_over_the_positional_slot_it_covers() {
+        let argv = vec![
+            "linear".to_string(),
+            "comment-create".to_string(),
+            "--id".to_string(),
+            "ENG-2".to_string(),
+            "--body".to_string(),
+            "ship it".to_string(),
+        ];
+
+        let ArgvOutcome::Parsed(parsed) = parse_argv(&argv).expect("parsed") else {
+            panic!("expected a parsed command");
+        };
+
+        assert_eq!(parsed.args["id"], serde_json::json!("ENG-2"));
+        assert_eq!(parsed.args["body"], serde_json::json!("ship it"));
+    }
+
+    #[test]
+    fn a_numeric_parameter_reaches_the_bridge_as_a_number() {
+        let argv = vec![
+            "gitlab".to_string(),
+            "issue".to_string(),
+            "group/app".to_string(),
+            "42".to_string(),
+        ];
+
+        let ArgvOutcome::Parsed(parsed) = parse_argv(&argv).expect("parsed") else {
+            panic!("expected a parsed command");
+        };
+
+        assert_eq!(parsed.args["project"], serde_json::json!("group/app"));
+        assert_eq!(parsed.args["iid"], serde_json::json!(42));
+    }
+
+    #[test]
+    fn a_numeric_parameter_refuses_a_word() {
+        let argv = vec![
+            "gitlab".to_string(),
+            "issue".to_string(),
+            "group/app".to_string(),
+            "iid-42".to_string(),
+        ];
+
+        assert!(parse_argv(&argv).is_err());
+    }
+
+    #[test]
+    fn a_flag_parameter_needs_no_value_and_stays_absent_when_unused() {
+        let with = vec![
+            "jira".to_string(),
+            "issues".to_string(),
+            "--all".to_string(),
+        ];
+        let without = vec!["jira".to_string(), "issues".to_string()];
+
+        let ArgvOutcome::Parsed(with) = parse_argv(&with).expect("parsed") else {
+            panic!("expected a parsed command");
+        };
+        let ArgvOutcome::Parsed(without) = parse_argv(&without).expect("parsed") else {
+            panic!("expected a parsed command");
+        };
+
+        assert_eq!(with.args["all"], serde_json::json!(true));
+        assert!(without.args.get("all").is_none());
+    }
+
+    #[test]
+    fn a_missing_required_argument_reports_the_usage_line() {
+        let argv = vec!["linear".to_string(), "issue".to_string()];
+
+        let error = parse_argv(&argv).expect_err("missing id");
+
+        assert!(error.contains("--id"));
+        assert!(error.contains("goodboy-query linear issue"));
+    }
+
+    #[test]
+    fn an_unknown_verb_is_refused_before_the_socket_is_touched() {
+        let argv = vec!["linear".to_string(), "delete-everything".to_string()];
+
+        let error = parse_argv(&argv).expect_err("unknown verb");
+
+        assert!(error.contains("unknown command"));
+    }
+
+    #[test]
+    fn the_workspace_override_is_accepted_on_every_verb() {
+        let argv = vec![
+            "linear".to_string(),
+            "issue".to_string(),
+            "ENG-1".to_string(),
+            "--workspace".to_string(),
+            "ws-9".to_string(),
+        ];
+
+        let ArgvOutcome::Parsed(parsed) = parse_argv(&argv).expect("parsed") else {
+            panic!("expected a parsed command");
+        };
+
+        assert!(parsed.args.get("workspace").is_none());
+    }
+
+    #[test]
+    fn an_unknown_option_is_refused() {
+        let argv = vec![
+            "linear".to_string(),
+            "issue".to_string(),
+            "ENG-1".to_string(),
+            "--force".to_string(),
+        ];
+
+        assert!(parse_argv(&argv)
+            .expect_err("unknown option")
+            .contains("--force"));
+    }
+
+    #[test]
+    fn no_argument_at_all_asks_for_help() {
+        assert_eq!(parse_argv(&[]).expect("help"), ArgvOutcome::Help);
+    }
+
+    #[test]
+    fn every_catalog_entry_has_a_unique_provider_and_verb_pair() {
+        let mut seen: Vec<(&str, &str)> = Vec::new();
+        for spec in CATALOG {
+            let key = (spec.provider, spec.verb);
+            assert!(!seen.contains(&key), "duplicate verb: {:?}", key);
+            seen.push(key);
+        }
+    }
+
+    #[test]
+    fn every_catalog_entry_declares_required_parameters_before_optional_ones() {
+        for spec in CATALOG {
+            let first_optional = spec
+                .params
+                .iter()
+                .position(|param| !param.required)
+                .unwrap_or(spec.params.len());
+            assert!(
+                spec.params[first_optional..]
+                    .iter()
+                    .all(|param| !param.required),
+                "{} {} mixes a required parameter after an optional one",
+                spec.provider,
+                spec.verb
+            );
+        }
+    }
+
+    #[test]
+    fn the_catalog_covers_every_credential_backed_provider() {
+        assert_eq!(
+            providers(),
+            vec!["linear", "sentry", "gitlab", "jira", "bitbucket", "slack"]
+        );
+    }
+
+    #[test]
+    fn help_without_a_provider_lists_all_of_them() {
+        let text = help_text(None);
+
+        for provider in providers() {
+            assert!(text.contains(provider), "{} missing from help", provider);
+        }
+    }
+}

--- a/apps/desktop/src-tauri/src/query_bridge/protocol.rs
+++ b/apps/desktop/src-tauri/src/query_bridge/protocol.rs
@@ -552,6 +552,12 @@ pub fn parse_argv(argv: &[String]) -> Result<ArgvOutcome, String> {
             continue;
         };
         if let Some((name, value)) = name.split_once('=') {
+            if is_valueless(name) {
+                return Err(format!(
+                    "--{} is a flag and takes no value: pass --{} to turn it on, or leave it out",
+                    name, name
+                ));
+            }
             flags.push((name, Some(value)));
             index += 1;
             continue;
@@ -782,6 +788,73 @@ mod tests {
 
         assert_eq!(with.args["all"], serde_json::json!(true));
         assert!(without.args.get("all").is_none());
+    }
+
+    #[test]
+    fn a_flag_written_as_an_assignment_is_refused_in_both_polarities() {
+        let off = vec![
+            "jira".to_string(),
+            "issues".to_string(),
+            "--all=false".to_string(),
+        ];
+        let on = vec![
+            "jira".to_string(),
+            "issues".to_string(),
+            "--all=true".to_string(),
+        ];
+
+        let off_error = parse_argv(&off).expect_err("--all=false is not a value");
+        let on_error = parse_argv(&on).expect_err("--all=true is not a value");
+
+        assert!(off_error.contains("--all is a flag and takes no value"));
+        assert!(off_error.contains("pass --all"));
+        assert_eq!(off_error, on_error);
+    }
+
+    #[test]
+    fn only_the_bare_spelling_of_a_flag_turns_it_on() {
+        let bare = vec![
+            "jira".to_string(),
+            "issues".to_string(),
+            "--all".to_string(),
+        ];
+
+        let ArgvOutcome::Parsed(parsed) = parse_argv(&bare).expect("parsed") else {
+            panic!("expected a parsed command");
+        };
+
+        assert_eq!(parsed.args["all"], serde_json::json!(true));
+    }
+
+    #[test]
+    fn the_output_switch_is_refused_when_it_carries_a_value() {
+        let argv = vec![
+            "linear".to_string(),
+            "issue".to_string(),
+            "ENG-1".to_string(),
+            "--json=false".to_string(),
+        ];
+
+        let error = parse_argv(&argv).expect_err("--json takes no value");
+
+        assert!(error.contains("--json is a flag and takes no value"));
+    }
+
+    #[test]
+    fn an_option_that_wants_a_value_still_accepts_the_inline_spelling() {
+        let argv = vec![
+            "linear".to_string(),
+            "comment-create".to_string(),
+            "--id=ENG-3".to_string(),
+            "--body=ship it".to_string(),
+        ];
+
+        let ArgvOutcome::Parsed(parsed) = parse_argv(&argv).expect("parsed") else {
+            panic!("expected a parsed command");
+        };
+
+        assert_eq!(parsed.args["id"], serde_json::json!("ENG-3"));
+        assert_eq!(parsed.args["body"], serde_json::json!("ship it"));
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/turn.rs
+++ b/apps/desktop/src-tauri/src/turn.rs
@@ -314,6 +314,8 @@ pub(crate) fn spawn_one(
         command.env("GITHUB_TOKEN", &token);
     }
 
+    crate::query_bridge::apply_env(&mut command, args.workspace_id);
+
     let cli_args = build_provider_cli_args(args.binary, &args);
     for a in &cli_args {
         command.arg(a);

--- a/apps/desktop/src/store/integrationsGuard.test.ts
+++ b/apps/desktop/src/store/integrationsGuard.test.ts
@@ -71,6 +71,20 @@ describe('buildIntegrationsGuard', () => {
     expect(guard).not.toContain('github');
     expect(guard).toContain('linear:');
   });
+
+  it('ignores a name that only exists on the object prototype', () => {
+    const guard = buildIntegrationsGuard({
+      providers: [
+        'toString' as WorkspaceIntegrationProvider,
+        'constructor' as WorkspaceIntegrationProvider,
+        'linear',
+      ],
+    });
+
+    expect(guard).not.toContain('toString');
+    expect(guard).not.toContain('constructor');
+    expect(guard.split('\n')).toHaveLength(7);
+  });
 });
 
 describe('the advertised verbs', () => {

--- a/apps/desktop/src/store/integrationsGuard.test.ts
+++ b/apps/desktop/src/store/integrationsGuard.test.ts
@@ -1,0 +1,85 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import type { WorkspaceIntegrationProvider } from '@goodboy/types';
+import { QUERY_BRIDGE_VERBS, buildIntegrationsGuard } from './integrationsGuard';
+
+const catalogSource = (): string =>
+  readFileSync(resolve(process.cwd(), 'src-tauri/src/query_bridge/protocol.rs'), 'utf8');
+
+const catalogVerbs = (): Record<string, ReadonlyArray<string>> => {
+  const entries = catalogSource().matchAll(
+    /provider:\s*"([a-z]+)",\s*\n\s*verb:\s*"([a-z0-9-]+)"/g,
+  );
+  const out: Record<string, Array<string>> = {};
+  for (const match of entries) {
+    const provider = match[1] ?? '';
+    const verb = match[2] ?? '';
+    out[provider] = [...(out[provider] ?? []), verb];
+  }
+  return out;
+};
+
+describe('buildIntegrationsGuard', () => {
+  it('says nothing when the workspace has no connection', () => {
+    expect(buildIntegrationsGuard({ providers: [] })).toBe('');
+  });
+
+  it('lists only the providers the workspace actually connected', () => {
+    const guard = buildIntegrationsGuard({ providers: ['linear'] });
+
+    expect(guard).toContain('[integrations]');
+    expect(guard).toContain('linear: issue,');
+    expect(guard).not.toContain('jira:');
+    expect(guard).not.toContain('slack:');
+  });
+
+  it('names the command an agent has to type', () => {
+    const guard = buildIntegrationsGuard({ providers: ['linear'] });
+
+    expect(guard).toContain('goodboy-query linear issue ENG-123');
+    expect(guard).toContain('goodboy-query <provider> --help');
+  });
+
+  it('never leaks a credential, a token or an MCP endpoint into the prompt', () => {
+    const guard = buildIntegrationsGuard({
+      providers: ['linear', 'sentry', 'gitlab', 'jira', 'bitbucket', 'slack'],
+    });
+
+    expect(guard).not.toMatch(/token|api[_ -]?key|secret|credential_id/i);
+  });
+
+  it('collapses a duplicated provider into a single line', () => {
+    const guard = buildIntegrationsGuard({ providers: ['linear', 'linear'] });
+
+    expect(guard.split('\n').filter((line) => line.startsWith('linear:'))).toHaveLength(1);
+  });
+
+  it('stays short enough to ride along on every prompt', () => {
+    const guard = buildIntegrationsGuard({
+      providers: ['linear', 'sentry', 'gitlab', 'jira', 'bitbucket', 'slack'],
+    });
+
+    expect(guard.split('\n')).toHaveLength(12);
+  });
+
+  it('ignores a provider the bridge cannot serve', () => {
+    const guard = buildIntegrationsGuard({
+      providers: ['github' as WorkspaceIntegrationProvider, 'linear'],
+    });
+
+    expect(guard).not.toContain('github');
+    expect(guard).toContain('linear:');
+  });
+});
+
+describe('the advertised verbs', () => {
+  it('match the catalog the Rust bridge dispatches', () => {
+    const rust = catalogVerbs();
+
+    expect(Object.keys(rust).sort()).toEqual(Object.keys(QUERY_BRIDGE_VERBS).sort());
+    for (const [provider, verbs] of Object.entries(QUERY_BRIDGE_VERBS)) {
+      expect([...verbs].sort()).toEqual([...(rust[provider] ?? [])].sort());
+    }
+  });
+});

--- a/apps/desktop/src/store/integrationsGuard.ts
+++ b/apps/desktop/src/store/integrationsGuard.ts
@@ -58,7 +58,8 @@ type GuardParams = {
 
 export const buildIntegrationsGuard = ({ providers }: GuardParams): string => {
   const known = Array.from(new Set(providers)).filter(
-    (provider): provider is WorkspaceIntegrationProvider => provider in QUERY_BRIDGE_VERBS,
+    (provider): provider is WorkspaceIntegrationProvider =>
+      Object.prototype.hasOwnProperty.call(QUERY_BRIDGE_VERBS, provider),
   );
   if (known.length === 0) {
     return '';

--- a/apps/desktop/src/store/integrationsGuard.ts
+++ b/apps/desktop/src/store/integrationsGuard.ts
@@ -1,0 +1,77 @@
+import type { WorkspaceIntegrationProvider } from '@goodboy/types';
+
+export const QUERY_BRIDGE_VERBS: Readonly<
+  Record<WorkspaceIntegrationProvider, ReadonlyArray<string>>
+> = {
+  linear: ['issue', 'issues-assigned', 'comments', 'comment-create', 'issue-update'],
+  sentry: ['issues', 'issue', 'issue-detail'],
+  gitlab: [
+    'issues-assigned',
+    'issue',
+    'issue-notes',
+    'issue-update',
+    'issue-note-create',
+    'mrs-assigned',
+    'mrs',
+    'mr-for-branch',
+    'mr-diff',
+    'mr-discussions',
+    'mr-approval-state',
+    'mr-note-create',
+    'mr-discussion-reply',
+    'mr-discussion-resolve',
+    'mr-approve',
+    'mr-unapprove',
+    'mr-merge',
+  ],
+  jira: [
+    'issues',
+    'issue',
+    'comments',
+    'transitions',
+    'comment-create',
+    'issue-update',
+    'transition',
+  ],
+  bitbucket: [
+    'prs',
+    'pr',
+    'pr-diff',
+    'pr-comments',
+    'pr-statuses',
+    'pr-for-branch',
+    'pr-comment-create',
+    'pr-comment-reply',
+    'pr-approve',
+    'pr-unapprove',
+    'pr-request-changes',
+    'pr-unrequest-changes',
+    'pr-merge',
+    'pr-decline',
+  ],
+  slack: ['channels', 'thread-heads', 'thread', 'permalink', 'users', 'reply', 'reaction-add'],
+};
+
+type GuardParams = {
+  readonly providers: ReadonlyArray<WorkspaceIntegrationProvider>;
+};
+
+export const buildIntegrationsGuard = ({ providers }: GuardParams): string => {
+  const known = Array.from(new Set(providers)).filter(
+    (provider): provider is WorkspaceIntegrationProvider => provider in QUERY_BRIDGE_VERBS,
+  );
+  if (known.length === 0) {
+    return '';
+  }
+  const order = Object.keys(QUERY_BRIDGE_VERBS) as ReadonlyArray<WorkspaceIntegrationProvider>;
+  const listed = order.filter((provider) => known.includes(provider));
+  return [
+    '[integrations]',
+    'This workspace has live connections you can query with the `goodboy-query` command, already on your PATH. Goodboy runs the call for you, so there is nothing to authenticate and no MCP server to reach.',
+    ...listed.map((provider) => `${provider}: ${QUERY_BRIDGE_VERBS[provider].join(', ')}`),
+    'Call it as `goodboy-query <provider> <verb> [arguments]`, for example `goodboy-query linear issue ENG-123`.',
+    'Run `goodboy-query <provider> --help` for the exact arguments of a verb. Output is plain text; add --json for the raw payload.',
+    'Prefer it over scraping a web UI, and never invent a verb that is not listed here.',
+    '[/integrations]',
+  ].join('\n');
+};

--- a/apps/desktop/src/store/slices/turn/sendTurn.ts
+++ b/apps/desktop/src/store/slices/turn/sendTurn.ts
@@ -71,6 +71,7 @@ import { isBranchlessSession } from '../../../shared/utils/isBranchlessSession';
 import { detectParallelGroup } from '../../parallel-turn';
 import { buildContextPreamble, buildPriorTurnsBlock, getModelContextWindow } from '../../preamble';
 import { applyAgentTurnState, cancelledRunIds } from '../../session-mutators';
+import { buildIntegrationsGuard } from '../../integrationsGuard';
 import { buildSessionLanguageGuard, resolveSessionLanguageGoal } from '../../sessionLanguage';
 import { stepSummaryDegraded } from '../../summarizeAgentOutput';
 import { relinkSimpleSessionDirectories } from '../workspaces/relinkSimpleSessionDirectories';
@@ -855,7 +856,14 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
         }),
       }),
     });
-    const guards = languageGuard.length > 0 ? `${scopeGuard}\n\n${languageGuard}` : scopeGuard;
+    const integrationsGuard = buildIntegrationsGuard({
+      providers: (get().workspaceIntegrations[session.workspaceId] ?? []).map(
+        (integration) => integration.provider,
+      ),
+    });
+    const guards = [scopeGuard, languageGuard, integrationsGuard]
+      .filter((block) => block.length > 0)
+      .join('\n\n');
     const fullSystemPrompt = kindSystemPrompt ? `${guards}\n\n${kindSystemPrompt}` : guards;
 
     if (provider !== 'anthropic') {

--- a/docs/README.md
+++ b/docs/README.md
@@ -78,6 +78,8 @@ one only when the current task reaches its trigger.
   the app: subprocess environment, provider routing, or DB migrations.
 - [model-picker.md](model-picker.md): when changing how a user picks a model or
   effort.
+- [query-bridge.md](query-bridge.md): when changing what a spawned agent can
+  ask a connected integration, or how it asks.
 - [workflows.md](workflows.md): when touching workflow tables, run advance
   logic, or the post-step summarizer.
 - [release.md](release.md): when you need the technical detail of a release:

--- a/docs/query-bridge.md
+++ b/docs/query-bridge.md
@@ -1,0 +1,70 @@
+# Query bridge
+
+> **Read this when** you are changing what a spawned agent can ask a connected
+> integration, or how it asks. **Not for** connecting an integration in the UI
+> (`concepts.md`) or the subprocess environment in general
+> (`architecture.md`).
+
+An agent running under Goodboy is a child process on the user's machine. It can
+read the repository and it can run `gh`, but the Linear, Jira, GitLab,
+Bitbucket, Sentry and Slack connections the workspace owns are unreachable to
+it: the secrets behind them live in the OS keychain, and only the Goodboy
+process may open them. The bridge closes that gap without ever moving a secret.
+
+## The invariant
+
+**A secret never leaves the Goodboy process.** The agent does not receive a
+token, a key, a header, or a URL that carries one. It names a workspace, a
+provider and a verb; Goodboy resolves the credential, performs the call, and
+returns the result. Anything that would hand an agent a usable credential, even
+indirectly, is out of bounds and no convenience justifies it.
+
+That is the whole reason the bridge exists rather than an MCP server or an
+injected environment variable. It is also why the transport is a Unix socket
+owned by the user with no other reader: the trust boundary is the OS account,
+not a token the agent could copy, log, or forward.
+
+## One catalog, three readers
+
+A verb is declared once. The dispatcher routes it, the CLI parses and prints
+it, and the prompt advertises it. None of the three owns the list; all three
+read the same declaration, and a test fails when the advertisement drifts from
+what the dispatcher can actually serve.
+
+The dispatcher never reimplements a provider call. Every verb lands on the
+function the app itself already uses for that integration, so a fix to a query
+reaches the UI and the agent at the same time and there is no second GraphQL
+document to keep honest.
+
+## Read and write are not the same act
+
+Reading an issue is inert. Posting a comment, merging, approving, or moving a
+ticket is visible to other humans and cannot be taken back by re-running the
+command. The two are dispatched through separate paths for that reason, and a
+verb declares which one it is. Today both are allowed; the split exists so that
+gating writes later is a policy change, not a refactor, and so that no write
+can ever arrive by way of the read path.
+
+Connecting, disconnecting and validating a connection are deliberately absent.
+Those manage the credential itself and belong to the person at the keyboard.
+
+## The advertisement is a cost
+
+The list of available commands ships inside every prompt of every turn, for
+every provider, forever. It names only the integrations this workspace actually
+connected, and it stays at one line per provider: detail belongs in the CLI's
+own help, which costs nothing until an agent asks for it. A workspace with no
+connection produces no block at all.
+
+The same text reaches every provider through the guard-block channel, so the
+bridge is advertised identically whether the agent is Claude, Codex, Cursor,
+Gemini or opencode. Nothing about it is provider-specific.
+
+## Where it is reachable
+
+The socket is created when the app starts and removed when it stops, so an
+agent outliving the app fails loudly instead of hanging. The CLI is found next
+to the running executable, which covers both a development build and a bundled
+app once the binary is shipped alongside the main one; when it is not there,
+the environment is simply not injected and no prompt advertises a command that
+cannot run. Windows has no Unix socket and is not served.


### PR DESCRIPTION
## What

`goodboy-query`, a local bridge that lets **any** agent (claude, codex, cursor, gemini, opencode) read and act on the workspace's connected integrations without MCP and without ever seeing a credential.

- **Server**: the Tauri process listens on `~/.goodboy/query.sock` (mode 0600, recreated on start, removed on shutdown). Newline-delimited JSON in, newline-delimited JSON out.
- **Client**: `goodboy-query <provider> <verb> [args]`, a second dependency-light Rust bin target in the same crate. Readable text on stdout, `--json` for the raw payload, errors on stderr, exit 1.
- **Spawn**: `spawn_one` injects `GOODBOY_QUERY_SOCKET` and `GOODBOY_WORKSPACE_ID` and prepends the CLI's directory to the child's PATH, next to the existing `GH_TOKEN` precedent.
- **Advertisement**: an `[integrations]` guard block, one line per connected provider, composed alongside the scope and language guards so it reaches every provider through the same channel.

53 verbs across linear, sentry, gitlab, jira, bitbucket and slack. Every one of them calls the provider function the app already uses; no GraphQL document or REST path is duplicated. `host`, `siteUrl`, `email`, `workspaceSlug` and `projectKey` are resolved from the stored integration config, so the agent never has to know them.

## Why

Only Claude could reach Linear, through the target repo's own `.mcp.json`. Codex and the rest could not reach it at all, and MCP pays for that reach in tokens on every turn. The credentials are already in the OS keychain; the secure shape is for the agent to ask Goodboy to run the query rather than to hold a key.

**The invariant**: a secret never leaves the Goodboy process. The agent names a workspace, a provider and a verb. Nothing it receives can be replayed against a provider API.

## Design notes

- **Read and write are separate dispatch paths.** Both are allowed today; the split means gating writes later is a policy change rather than a refactor, and a write can never arrive by way of the read path.
- **`connect` / `validate` are deliberately absent.** Those manage the credential itself and belong to the person at the keyboard.
- **One catalog, three readers.** The verb list is declared once; the dispatcher, the CLI and the prompt read it. `integrationsGuard.test.ts` parses the Rust catalog and fails when the advertisement drifts from what is actually dispatched.

## Deviations from the brief

1. **GitHub is not served.** `gh` already works for every agent: `spawn_one` has injected `GH_TOKEN`/`GITHUB_TOKEN` since well before this change, so github is not part of the gap this closes. Adding a second, weaker path to it would only cost prompt budget.
2. **`tauri.conf.json` is untouched, so the bundled app does not ship the binary yet.** The correct target is `bundle.externalBin` (a sidecar lands in `Contents/MacOS/`, exactly where the runtime resolver looks, and unlike a resource it stays executable and code-signed). But the macOS release builds `--target universal-apple-darwin`, and tauri requires a per-triple sidecar for each half plus a prebuild step to stamp the names; a missing file there turns every `tauri build` into a hard failure. That wiring wants its own PR where a full bundle can actually be produced. Until then the resolver finds nothing, injects nothing, and the prompt advertises nothing, so a packaged build behaves exactly as it does today.
3. **Unix only.** The socket has no Windows equivalent; `start` is a no-op there and the CLI says so.
4. **`gitlab mr-create` and `mr-discussion-create` are out.** Both need a structured diff position or a full MR body; neither is a query and both have poor CLI ergonomics.

## Test plan

- `cargo test --locked`: 475 lib + 20 CLI tests, 0 failed.
- `pnpm turbo run typecheck`: clean.
- `pnpm exec vitest run src/store`: 133 files, 1257 tests, 0 failed.
- End-to-end against a stub socket server: argv parsing, numeric coercion, text and `--json` rendering, error passthrough, and the exit codes for a missing argument, a missing workspace and a missing socket.
- `pnpm knip`: identical to the baseline on `main`.

Not verified here: a real query against a live provider, which needs a running app with a connected workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
