### PR TITLE
feat(desktop): attach report screenshots to the issue it files

### DIFF
--- a/apps/desktop/src-tauri/src/attachment.rs
+++ b/apps/desktop/src-tauri/src/attachment.rs
@@ -1,5 +1,7 @@
+use std::collections::HashSet;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
 
 use base64::engine::general_purpose::STANDARD;
 use base64::Engine as _;
@@ -254,26 +256,59 @@ fn write_bug_report_images(
     Ok(())
 }
 
+/// Canonical paths of the staging folders this process created, so a
+/// caller-supplied path can be proven to be one of ours before it is opened,
+/// written to, or deleted.
+fn staged_bug_report_dirs() -> &'static Mutex<HashSet<PathBuf>> {
+    static DIRS: OnceLock<Mutex<HashSet<PathBuf>>> = OnceLock::new();
+    DIRS.get_or_init(|| Mutex::new(HashSet::new()))
+}
+
+fn remember_bug_report_dir(dir: &Path) {
+    if let Ok(mut dirs) = staged_bug_report_dirs().lock() {
+        dirs.insert(dir.to_path_buf());
+    }
+}
+
+fn forget_bug_report_dir(dir: &Path) {
+    if let Ok(mut dirs) = staged_bug_report_dirs().lock() {
+        dirs.remove(dir);
+    }
+}
+
+fn is_staged_bug_report_dir(dir: &Path) -> bool {
+    staged_bug_report_dirs()
+        .lock()
+        .map(|dirs| dirs.contains(dir))
+        .unwrap_or(false)
+}
+
 #[tauri::command]
 pub fn bug_report_stage_images(
     images: Vec<BugReportImageInput>,
 ) -> Result<String, AttachmentError> {
     let dir = std::env::temp_dir().join(bug_report_dir_name());
     write_bug_report_images(&dir, &images)?;
-    Ok(dir.to_string_lossy().to_string())
+    let canonical_dir = dir.canonicalize()?;
+    remember_bug_report_dir(&canonical_dir);
+    Ok(canonical_dir.to_string_lossy().to_string())
 }
 
 /// Resolves a caller-supplied path back to a staging folder this process
-/// created. Anything outside the temp directory, or not named like a report
-/// folder, is refused before it can be opened, written to, or deleted.
-fn resolve_bug_report_dir(dir: &str) -> Result<std::path::PathBuf, AttachmentError> {
+/// created. Anything this process did not stage, anything outside the temp
+/// directory, and anything not named like a report folder is refused before it
+/// can be opened, written to, or deleted.
+fn resolve_bug_report_dir(dir: &str) -> Result<PathBuf, AttachmentError> {
     let canonical_dir = Path::new(dir).canonicalize()?;
     let canonical_temp_dir = std::env::temp_dir().canonicalize()?;
     let is_report_dir = canonical_dir
         .file_name()
         .and_then(|name| name.to_str())
-        .is_some_and(|name| name.starts_with("goodboy-report-"));
-    if !canonical_dir.starts_with(canonical_temp_dir) || !is_report_dir {
+        .is_some_and(|name| name.starts_with(&format!("goodboy-report-{}-", std::process::id())));
+    if !canonical_dir.starts_with(canonical_temp_dir)
+        || !is_report_dir
+        || !is_staged_bug_report_dir(&canonical_dir)
+    {
         return Err(AttachmentError::InvalidPath);
     }
     Ok(canonical_dir)
@@ -339,6 +374,7 @@ pub fn bug_report_stage_upload_payloads(
 pub fn bug_report_discard_images(dir: String) -> Result<(), AttachmentError> {
     let canonical_dir = resolve_bug_report_dir(&dir)?;
     fs::remove_dir_all(&canonical_dir)?;
+    forget_bug_report_dir(&canonical_dir);
     Ok(())
 }
 
@@ -535,23 +571,66 @@ mod tests {
 
     #[test]
     fn bug_report_discard_removes_a_staged_folder_with_its_payloads() {
-        let stamp = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_nanos())
-            .unwrap_or(0);
-        let dir = std::env::temp_dir().join(format!(
-            "goodboy-report-discard-{}-{}",
-            std::process::id(),
-            stamp
-        ));
-        fs::create_dir_all(dir.join(UPLOAD_SUBDIR)).unwrap();
-        fs::write(dir.join("01-shot.png"), b"bytes").unwrap();
-        let path = dir.to_string_lossy().to_string();
+        let png_b64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=";
+        let path = bug_report_stage_images(vec![BugReportImageInput {
+            file_name: "shot.png".to_string(),
+            data_base64: png_b64.to_string(),
+        }])
+        .unwrap();
+        let dir = PathBuf::from(&path);
+        bug_report_stage_upload_payloads(
+            path.clone(),
+            vec![BugReportImageInput {
+                file_name: "shot.png".to_string(),
+                data_base64: png_b64.to_string(),
+            }],
+        )
+        .unwrap();
+        assert!(dir.join(UPLOAD_SUBDIR).is_dir());
 
         bug_report_discard_images(path.clone()).unwrap();
 
         assert!(!dir.exists());
         assert!(bug_report_discard_images(path).is_err());
+    }
+
+    #[test]
+    fn bug_report_discard_rejects_a_report_folder_this_process_did_not_stage() {
+        let stamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let dir =
+            std::env::temp_dir().join(format!("goodboy-report-{}-{}", std::process::id(), stamp));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+
+        let result = bug_report_discard_images(dir.to_string_lossy().to_string());
+
+        assert!(matches!(result, Err(AttachmentError::InvalidPath)));
+        assert!(dir.exists());
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn bug_report_stage_upload_payloads_rejects_a_folder_this_process_did_not_stage() {
+        let stamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let dir = std::env::temp_dir().join(format!(
+            "goodboy-report-{}-up-{}",
+            std::process::id(),
+            stamp
+        ));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+
+        let result = bug_report_stage_upload_payloads(dir.to_string_lossy().to_string(), vec![]);
+
+        assert!(matches!(result, Err(AttachmentError::InvalidPath)));
+        assert!(!dir.join(UPLOAD_SUBDIR).exists());
+        let _ = fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/attachment.rs
+++ b/apps/desktop/src-tauri/src/attachment.rs
@@ -263,9 +263,11 @@ pub fn bug_report_stage_images(
     Ok(dir.to_string_lossy().to_string())
 }
 
-#[tauri::command]
-pub fn bug_report_reveal_images(dir: String) -> Result<(), AttachmentError> {
-    let canonical_dir = Path::new(&dir).canonicalize()?;
+/// Resolves a caller-supplied path back to a staging folder this process
+/// created. Anything outside the temp directory, or not named like a report
+/// folder, is refused before it can be opened, written to, or deleted.
+fn resolve_bug_report_dir(dir: &str) -> Result<std::path::PathBuf, AttachmentError> {
+    let canonical_dir = Path::new(dir).canonicalize()?;
     let canonical_temp_dir = std::env::temp_dir().canonicalize()?;
     let is_report_dir = canonical_dir
         .file_name()
@@ -274,7 +276,69 @@ pub fn bug_report_reveal_images(dir: String) -> Result<(), AttachmentError> {
     if !canonical_dir.starts_with(canonical_temp_dir) || !is_report_dir {
         return Err(AttachmentError::InvalidPath);
     }
+    Ok(canonical_dir)
+}
+
+#[tauri::command]
+pub fn bug_report_reveal_images(dir: String) -> Result<(), AttachmentError> {
+    let canonical_dir = resolve_bug_report_dir(&dir)?;
     crate::explore::spawn_open(&canonical_dir, false)?;
+    Ok(())
+}
+
+/// The base64 payload of one staged image, written next to the image itself.
+/// `gh api -F content=@<path>` reads the value from this file: the same bytes
+/// passed as an argument would blow the platform argv ceiling well before the
+/// 5MB per-image cap the composer allows.
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StagedUploadPayload {
+    file_name: String,
+    payload_path: String,
+}
+
+const UPLOAD_SUBDIR: &str = ".upload";
+
+fn write_bug_report_upload_payloads(
+    dir: &Path,
+    images: &[BugReportImageInput],
+) -> Result<Vec<StagedUploadPayload>, AttachmentError> {
+    let upload_dir = dir.join(UPLOAD_SUBDIR);
+    fs::create_dir_all(&upload_dir)?;
+    let mut payloads = Vec::with_capacity(images.len());
+    for (index, image) in images.iter().enumerate() {
+        let bytes = STANDARD.decode(image.data_base64.as_bytes())?;
+        if bytes.len() > MAX_BYTES {
+            return Err(AttachmentError::TooLarge(MAX_BYTES));
+        }
+        let stored = format!(
+            "{:02}-{}.b64",
+            index + 1,
+            sanitize_segment(&image.file_name)
+        );
+        let payload_path = upload_dir.join(stored);
+        fs::write(&payload_path, image.data_base64.as_bytes())?;
+        payloads.push(StagedUploadPayload {
+            file_name: image.file_name.clone(),
+            payload_path: payload_path.to_string_lossy().to_string(),
+        });
+    }
+    Ok(payloads)
+}
+
+#[tauri::command]
+pub fn bug_report_stage_upload_payloads(
+    dir: String,
+    images: Vec<BugReportImageInput>,
+) -> Result<Vec<StagedUploadPayload>, AttachmentError> {
+    let canonical_dir = resolve_bug_report_dir(&dir)?;
+    write_bug_report_upload_payloads(&canonical_dir, &images)
+}
+
+#[tauri::command]
+pub fn bug_report_discard_images(dir: String) -> Result<(), AttachmentError> {
+    let canonical_dir = resolve_bug_report_dir(&dir)?;
+    fs::remove_dir_all(&canonical_dir)?;
     Ok(())
 }
 
@@ -427,6 +491,79 @@ mod tests {
         );
         assert!(matches!(err, Err(AttachmentError::Decode(_))));
 
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn bug_report_upload_payloads_carry_the_base64_verbatim() {
+        let dir = std::env::temp_dir().join(format!("goodboy-report-up-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+
+        let png_b64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=";
+        let payloads = write_bug_report_upload_payloads(
+            &dir,
+            &[BugReportImageInput {
+                file_name: "board freeze.png".to_string(),
+                data_base64: png_b64.to_string(),
+            }],
+        )
+        .unwrap();
+
+        assert_eq!(payloads[0].file_name, "board freeze.png");
+        assert!(payloads[0].payload_path.ends_with("01-board_freeze.png.b64"));
+        assert_eq!(fs::read_to_string(&payloads[0].payload_path).unwrap(), png_b64);
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn bug_report_upload_payloads_reject_a_bad_payload() {
+        let dir = std::env::temp_dir().join(format!("goodboy-report-upbad-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+
+        let err = write_bug_report_upload_payloads(
+            &dir,
+            &[BugReportImageInput {
+                file_name: "shot.png".to_string(),
+                data_base64: "not base64!!".to_string(),
+            }],
+        );
+
+        assert!(matches!(err, Err(AttachmentError::Decode(_))));
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn bug_report_discard_removes_a_staged_folder_with_its_payloads() {
+        let stamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let dir = std::env::temp_dir().join(format!(
+            "goodboy-report-discard-{}-{}",
+            std::process::id(),
+            stamp
+        ));
+        fs::create_dir_all(dir.join(UPLOAD_SUBDIR)).unwrap();
+        fs::write(dir.join("01-shot.png"), b"bytes").unwrap();
+        let path = dir.to_string_lossy().to_string();
+
+        bug_report_discard_images(path.clone()).unwrap();
+
+        assert!(!dir.exists());
+        assert!(bug_report_discard_images(path).is_err());
+    }
+
+    #[test]
+    fn bug_report_discard_rejects_an_unrelated_temp_folder() {
+        let dir = std::env::temp_dir().join(format!("goodboy-other-rm-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+
+        let result = bug_report_discard_images(dir.to_string_lossy().to_string());
+
+        assert!(matches!(result, Err(AttachmentError::InvalidPath)));
+        assert!(dir.exists());
         let _ = fs::remove_dir_all(&dir);
     }
 

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -253,6 +253,8 @@ pub fn run() {
             attachment::attachment_read_dropped,
             attachment::bug_report_stage_images,
             attachment::bug_report_reveal_images,
+            attachment::bug_report_stage_upload_payloads,
+            attachment::bug_report_discard_images,
             file_versions::file_versions_begin_snapshot,
             file_versions::file_versions_finalize_snapshot,
             file_versions::file_versions_list_staged_snapshots,

--- a/apps/desktop/src/features/settings/components/ReportIssueStudio/index.test.tsx
+++ b/apps/desktop/src/features/settings/components/ReportIssueStudio/index.test.tsx
@@ -17,6 +17,15 @@ const mocks = vi.hoisted(() => ({
   ),
   showToast: vi.fn(),
   dragHandlers: Array<DragHandler>(),
+  settings: new Map<string, string>(),
+}));
+
+vi.mock('@goodboy/db', () => ({
+  migrate: vi.fn(),
+  getSetting: async (_db: unknown, key: string) => mocks.settings.get(key) ?? null,
+  setSetting: async (_db: unknown, key: string, value: string) => {
+    mocks.settings.set(key, value);
+  },
 }));
 
 vi.mock('@tauri-apps/api/core', () => ({
@@ -67,6 +76,55 @@ vi.mock('../../../../app/components/Toast', () => ({
 import { ReportIssueStudio } from './index';
 import { useAppStore } from '../../../../store';
 import { initialBugReportDraftState } from '../../../../store/slices/bugReportDraft/state';
+import { SETTING_ISSUE_ASSETS_REPO } from '../../settings';
+
+const ASSETS_REPO = 'octocat/goodboy-issue-assets';
+const STAGED_DIR = '/tmp/goodboy-report-1';
+const RAW_URL = `https://raw.githubusercontent.com/${ASSETS_REPO}/main/reports/board.png`;
+
+const stagingInvoke = async (command: string, args: Record<string, unknown>): Promise<unknown> => {
+  if (command !== 'bug_report_stage_upload_payloads') {
+    return STAGED_DIR;
+  }
+  const staged = args.images as ReadonlyArray<{ readonly fileName: string }>;
+  return staged.map(({ fileName }, index) => ({
+    fileName,
+    payloadPath: `${STAGED_DIR}/.upload/0${index + 1}-${fileName}.b64`,
+  }));
+};
+
+type GhRouterParams = {
+  readonly hasAssetsRepo: boolean;
+  readonly isUploadOk?: boolean;
+};
+
+const ghRouter =
+  ({ hasAssetsRepo, isUploadOk = true }: GhRouterParams) =>
+  async (args: ReadonlyArray<string>): Promise<GhRunResult> => {
+    if (args.includes('PUT')) {
+      return isUploadOk
+        ? { stdout: `${RAW_URL}\n`, stderr: '', exitCode: 0 }
+        : { stdout: '', stderr: 'HTTP 403', exitCode: 1 };
+    }
+    if (args.includes('user/repos')) {
+      return { stdout: '{}', stderr: '', exitCode: 0 };
+    }
+    if (args.includes(`repos/${ASSETS_REPO}`)) {
+      return hasAssetsRepo
+        ? { stdout: `${ASSETS_REPO}\n`, stderr: '', exitCode: 0 }
+        : { stdout: '', stderr: 'gh: Not Found', exitCode: 1 };
+    }
+    return {
+      stdout: 'https://github.com/akhayam99/goodboy/issues/99\n',
+      stderr: '',
+      exitCode: 0,
+    };
+  };
+
+const issueBody = (): string => {
+  const call = mocks.run.mock.calls.find(([args]) => args[0] === 'issue');
+  return (call?.[0][7] as string | undefined) ?? '';
+};
 
 const setGithubStatus = (githubStatus: GhTokenStatus | null) => {
   useAppStore.setState({ githubStatus });
@@ -96,9 +154,10 @@ beforeEach(() => {
   mocks.openUrl.mockReset();
   mocks.openUrl.mockImplementation(async () => undefined);
   mocks.invoke.mockReset();
-  mocks.invoke.mockImplementation(async () => '/tmp/goodboy-report-1');
+  mocks.invoke.mockImplementation(stagingInvoke);
   mocks.showToast.mockReset();
   mocks.dragHandlers = [];
+  mocks.settings.clear();
 });
 afterEach(cleanup);
 
@@ -571,6 +630,97 @@ describe('ReportIssueStudio', () => {
 
     expect(screen.getByText(/Connect GitHub to send the full text\./)).toBeDefined();
     expect(screen.queryByText(/GitHub CLI/)).toBeNull();
+  });
+
+  const renderWithImageAndLogin = ({ hasAssetsRepo, isUploadOk }: GhRouterParams) => {
+    setGithubStatus({ available: true, mode: 'gh-cli', user: 'octocat' });
+    attachOneImage();
+    mocks.run.mockImplementation(ghRouter({ hasAssetsRepo, isUploadOk }));
+    render(<ReportIssueStudio onClose={vi.fn()} />);
+    fillReport({ area: 'board-sessions', title: 'Board freeze', notes: 'Freezes on archive.' });
+  };
+
+  const clickSend = async () => {
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Send' }));
+    });
+  };
+
+  it('asks before it creates the assets repository, and files nothing yet', async () => {
+    renderWithImageAndLogin({ hasAssetsRepo: false });
+
+    await clickSend();
+
+    expect(
+      screen.getByRole('group', { name: `Create ${ASSETS_REPO} to carry your images` }),
+    ).toBeDefined();
+    expect(screen.getByText(/small public repository on your account/)).toBeDefined();
+    expect(mocks.run.mock.calls.some(([args]) => args[0] === 'issue')).toBe(false);
+  });
+
+  it('creates the repository and embeds the uploaded images once the reporter accepts', async () => {
+    renderWithImageAndLogin({ hasAssetsRepo: false });
+
+    await clickSend();
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Create and attach' }));
+    });
+
+    expect(mocks.run.mock.calls.some(([args]) => args.includes('user/repos'))).toBe(true);
+    expect(issueBody()).toContain(`![board.png](${RAW_URL})`);
+    expect(mocks.settings.get(SETTING_ISSUE_ASSETS_REPO)).toBe(ASSETS_REPO);
+  });
+
+  it('clears the staged folder and drops the drag reminder after a full upload', async () => {
+    renderWithImageAndLogin({ hasAssetsRepo: true });
+
+    await clickSend();
+
+    expect(mocks.invoke).toHaveBeenCalledWith('bug_report_discard_images', { dir: STAGED_DIR });
+    expect(mocks.showToast).toHaveBeenCalledWith(
+      'success',
+      'Filed on GitHub with your images, under your account.',
+      expect.objectContaining({ title: 'Issue sent' }),
+    );
+  });
+
+  it('never asks again once the assets repository is remembered', async () => {
+    mocks.settings.set(SETTING_ISSUE_ASSETS_REPO, ASSETS_REPO);
+    renderWithImageAndLogin({ hasAssetsRepo: true });
+
+    await clickSend();
+
+    expect(mocks.run.mock.calls.some(([args]) => args.includes(`repos/${ASSETS_REPO}`))).toBe(
+      false,
+    );
+    expect(issueBody()).toContain(`![board.png](${RAW_URL})`);
+  });
+
+  it('files the report with the drag reminder when the reporter declines', async () => {
+    renderWithImageAndLogin({ hasAssetsRepo: false });
+
+    await clickSend();
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Send without them' }));
+    });
+
+    expect(mocks.run.mock.calls.some(([args]) => args.includes('user/repos'))).toBe(false);
+    expect(issueBody()).toContain('Screenshots to drag into this issue: board.png');
+    expect(mocks.invoke).not.toHaveBeenCalledWith('bug_report_discard_images', { dir: STAGED_DIR });
+  });
+
+  it('falls back to the staged folder when an upload fails, and still files the report', async () => {
+    mocks.settings.set(SETTING_ISSUE_ASSETS_REPO, ASSETS_REPO);
+    renderWithImageAndLogin({ hasAssetsRepo: true, isUploadOk: false });
+
+    await clickSend();
+
+    expect(issueBody()).toContain('Screenshots to drag into this issue: board.png');
+    expect(mocks.showToast).toHaveBeenCalledWith(
+      'success',
+      "Your images aren't on it yet. GitHub only takes them by drag and drop.",
+      expect.objectContaining({ persist: true }),
+    );
   });
 
   it('discloses that the report is posted publicly under the reporter account', () => {

--- a/apps/desktop/src/features/settings/components/ReportIssueStudio/index.tsx
+++ b/apps/desktop/src/features/settings/components/ReportIssueStudio/index.tsx
@@ -6,6 +6,8 @@ import {
   Divider,
   FieldRow,
   formatError,
+  GithubIcon,
+  InlineConfirm,
   Input,
   PANE_RHYTHM,
   ScrollFade,
@@ -28,11 +30,14 @@ import { ISSUE_TYPE_OPTIONS, issueTypeLabel, type IssueTypeValue } from '../../r
 import { BugReportImages } from '../BugReportImages';
 import { AREA_OPTIONS, type AreaValue } from './areas';
 import { guessArea } from './guessArea';
+import { knownIssueAssetsRepo, rememberIssueAssetsRepo } from './issueAssetsConsent';
+import { createIssueAssetsRepo, hasIssueAssetsRepo, issueAssetsRepoSlug } from './issueAssetsRepo';
 import { buildFallbackIssue, buildIssueBody, isOpenableUrl } from './issuePayload';
 import { parseIssueCreateResult } from './parseIssueCreateResult';
 import { previewHint } from './previewHint';
-import { revealBugReportImages, stageBugReportImages } from './stageImages';
+import { discardBugReportImages, revealBugReportImages, stageBugReportImages } from './stageImages';
 import { truncationNotice } from './truncationNotice';
+import { uploadIssueImages } from './uploadIssueImages';
 
 type Props = {
   readonly onClose: () => void;
@@ -42,7 +47,11 @@ type Params = {
   readonly requestClose: () => void;
 };
 
-type SendState = 'idle' | 'sending' | 'error';
+type SendState = 'idle' | 'sending' | 'consent' | 'error';
+
+type RunParams = Params & {
+  readonly isUploadAllowed: boolean;
+};
 
 const TITLE_PLACEHOLDERS = {
   bug: "What's wrong, in one line",
@@ -131,25 +140,36 @@ export const ReportIssueStudio = ({ onClose }: Props) => {
     area !== '' &&
     trimmedTitle !== '' &&
     mode != null &&
-    sendState !== 'sending';
+    sendState !== 'sending' &&
+    sendState !== 'consent';
+  const login = status?.user ?? '';
+  const assetsRepoSlug = login === '' ? '' : issueAssetsRepoSlug({ login });
+  const canAttachImages = sendsDirectly && imageControl.images.length > 0 && assetsRepoSlug !== '';
 
-  const onSend = async ({ requestClose }: Params) => {
-    if (!canSend) {
-      return;
-    }
+  const runSend = async ({ requestClose, isUploadAllowed }: RunParams) => {
     setSendState('sending');
     setErrorMessage(null);
 
-    let stagedImagesDir: string | null;
+    let dir: string | null;
     try {
-      stagedImagesDir = await stageBugReportImages({ images: imageControl.images });
+      dir = await stageBugReportImages({ images: imageControl.images });
     } catch (err) {
       setSendState('error');
       setErrorMessage(`Could not prepare the images to attach. ${formatError(err)}`);
       return;
     }
+    const stagedImagesDir = dir;
 
     if (sendsDirectly) {
+      const uploaded =
+        isUploadAllowed && stagedImagesDir != null
+          ? await uploadIssueImages({
+              runner: tauriGhRunner,
+              slug: assetsRepoSlug,
+              dir: stagedImagesDir,
+              images: imageControl.images,
+            })
+          : null;
       try {
         const result = await tauriGhRunner.run(
           [
@@ -160,7 +180,14 @@ export const ReportIssueStudio = ({ onClose }: Props) => {
             '--title',
             trimmedTitle,
             '--body',
-            directBody,
+            buildIssueBody({
+              typeLabel,
+              version: version ?? '',
+              areaLabel,
+              notes: trimmedNotes,
+              imageNames,
+              uploadedImages: uploaded ?? [],
+            }),
           ],
           {},
         );
@@ -173,14 +200,23 @@ export const ReportIssueStudio = ({ onClose }: Props) => {
         const issueUrl = parsed.url;
         clearBugReportDraft();
         requestClose();
-        if (stagedImagesDir == null) {
-          showToast('success', 'Filed on GitHub, under your account.', {
-            title: 'Issue sent',
-            action:
-              issueUrl == null
-                ? undefined
-                : { label: 'View issue', onClick: () => void openUrl(issueUrl) },
-          });
+        if (stagedImagesDir != null && uploaded != null) {
+          void discardBugReportImages({ dir: stagedImagesDir });
+        }
+        if (stagedImagesDir == null || uploaded != null) {
+          showToast(
+            'success',
+            uploaded == null
+              ? 'Filed on GitHub, under your account.'
+              : 'Filed on GitHub with your images, under your account.',
+            {
+              title: 'Issue sent',
+              action:
+                issueUrl == null
+                  ? undefined
+                  : { label: 'View issue', onClick: () => void openUrl(issueUrl) },
+            },
+          );
           return;
         }
         const action =
@@ -228,6 +264,37 @@ export const ReportIssueStudio = ({ onClose }: Props) => {
     }
   };
 
+  const onSend = async ({ requestClose }: Params) => {
+    if (!canSend) {
+      return;
+    }
+    if (!canAttachImages) {
+      await runSend({ requestClose, isUploadAllowed: false });
+      return;
+    }
+    setSendState('sending');
+    setErrorMessage(null);
+    if ((await knownIssueAssetsRepo()) === assetsRepoSlug) {
+      await runSend({ requestClose, isUploadAllowed: true });
+      return;
+    }
+    if (await hasIssueAssetsRepo({ runner: tauriGhRunner, slug: assetsRepoSlug })) {
+      await rememberIssueAssetsRepo({ slug: assetsRepoSlug });
+      await runSend({ requestClose, isUploadAllowed: true });
+      return;
+    }
+    setSendState('consent');
+  };
+
+  const onConsentAccept = async ({ requestClose }: Params) => {
+    setSendState('sending');
+    const isCreated = await createIssueAssetsRepo({ runner: tauriGhRunner });
+    if (isCreated) {
+      await rememberIssueAssetsRepo({ slug: assetsRepoSlug });
+    }
+    await runSend({ requestClose, isUploadAllowed: isCreated });
+  };
+
   return (
     <StudioShell
       icon={CONCEPT_ICONS.reportIssue}
@@ -269,7 +336,11 @@ export const ReportIssueStudio = ({ onClose }: Props) => {
                 />
                 <FieldRow
                   label="Images"
-                  help="GitHub only takes images by hand. After you send, one click opens the issue and the folder, so you can drag them in."
+                  help={
+                    sendsDirectly
+                      ? 'Uploaded to a repository on your account and shown inline in the issue. If that fails, one click opens the issue and the folder, so you can drag them in.'
+                      : 'A GitHub link cannot carry images. After you send, one click opens the issue and the folder, so you can drag them in.'
+                  }
                   layout="stacked"
                 >
                   <BugReportImages control={imageControl} />
@@ -325,6 +396,19 @@ export const ReportIssueStudio = ({ onClose }: Props) => {
                   ) : null}
                 </div>
               </SectionSurface>
+
+              {sendState === 'consent' ? (
+                <InlineConfirm
+                  role="primary"
+                  icon={<GithubIcon size={14} />}
+                  title={`Create ${assetsRepoSlug} to carry your images`}
+                  description="GitHub has no way to attach an image from an app. Goodboy can create this small public repository on your account, upload the screenshots there, and show them inside the issue. You are asked once."
+                  confirmLabel="Create and attach"
+                  cancelLabel="Send without them"
+                  onConfirm={() => void onConsentAccept({ requestClose })}
+                  onCancel={() => void runSend({ requestClose, isUploadAllowed: false })}
+                />
+              ) : null}
 
               <footer className="flex items-center gap-3">
                 <div className="flex min-w-0 flex-1 items-center gap-3">

--- a/apps/desktop/src/features/settings/components/ReportIssueStudio/issueAssetPath.test.ts
+++ b/apps/desktop/src/features/settings/components/ReportIssueStudio/issueAssetPath.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { issueAssetPath } from './issueAssetPath';
+
+const NOW = new Date(Date.UTC(2026, 2, 9, 12, 0, 0));
+
+describe('issueAssetPath', () => {
+  it('files the asset under the year and month of the report', () => {
+    const path = issueAssetPath({ fileName: 'board.png', index: 0, now: NOW });
+    expect(path).toBe(`reports/2026-03/${NOW.getTime()}-01-board.png`);
+  });
+
+  it('drops a posix directory prefix from the stored name', () => {
+    const path = issueAssetPath({ fileName: '/Users/dev/shots/board.png', index: 1, now: NOW });
+    expect(path).toBe(`reports/2026-03/${NOW.getTime()}-02-board.png`);
+  });
+
+  it('drops a windows directory prefix from the stored name', () => {
+    const path = issueAssetPath({
+      fileName: 'C:\\Users\\dev\\shots\\board.png',
+      index: 0,
+      now: NOW,
+    });
+    expect(path).toBe(`reports/2026-03/${NOW.getTime()}-01-board.png`);
+  });
+
+  it('falls back to a default name when nothing usable survives', () => {
+    const path = issueAssetPath({ fileName: 'C:\\shots\\...', index: 0, now: NOW });
+    expect(path).toBe(`reports/2026-03/${NOW.getTime()}-01-image.png`);
+  });
+});

--- a/apps/desktop/src/features/settings/components/ReportIssueStudio/issueAssetPath.ts
+++ b/apps/desktop/src/features/settings/components/ReportIssueStudio/issueAssetPath.ts
@@ -1,0 +1,22 @@
+const MAX_NAME_CHARS = 60;
+
+const padded = ({ value }: { readonly value: number }): string => String(value).padStart(2, '0');
+
+const assetFileName = ({ fileName }: { readonly fileName: string }): string => {
+  const base = fileName.split('/').pop() ?? '';
+  const cleaned = base.replace(/[^A-Za-z0-9._-]/g, '-').replace(/^[-.]+/, '');
+  const capped = cleaned.slice(0, MAX_NAME_CHARS);
+  return capped === '' ? 'image.png' : capped;
+};
+
+type Params = {
+  readonly fileName: string;
+  readonly index: number;
+  readonly now: Date;
+};
+
+export const issueAssetPath = ({ fileName, index, now }: Params): string => {
+  const month = padded({ value: now.getUTCMonth() + 1 });
+  const ordinal = padded({ value: index + 1 });
+  return `reports/${now.getUTCFullYear()}-${month}/${now.getTime()}-${ordinal}-${assetFileName({ fileName })}`;
+};

--- a/apps/desktop/src/features/settings/components/ReportIssueStudio/issueAssetPath.ts
+++ b/apps/desktop/src/features/settings/components/ReportIssueStudio/issueAssetPath.ts
@@ -3,7 +3,7 @@ const MAX_NAME_CHARS = 60;
 const padded = ({ value }: { readonly value: number }): string => String(value).padStart(2, '0');
 
 const assetFileName = ({ fileName }: { readonly fileName: string }): string => {
-  const base = fileName.split('/').pop() ?? '';
+  const base = fileName.split(/[/\\]/).pop() ?? '';
   const cleaned = base.replace(/[^A-Za-z0-9._-]/g, '-').replace(/^[-.]+/, '');
   const capped = cleaned.slice(0, MAX_NAME_CHARS);
   return capped === '' ? 'image.png' : capped;

--- a/apps/desktop/src/features/settings/components/ReportIssueStudio/issueAssetsConsent.ts
+++ b/apps/desktop/src/features/settings/components/ReportIssueStudio/issueAssetsConsent.ts
@@ -1,0 +1,23 @@
+import { getSetting, setSetting } from '@goodboy/db';
+import { tauriDatabase } from '../../../../shared/lib/db';
+import { SETTING_ISSUE_ASSETS_REPO } from '../../settings';
+
+export const knownIssueAssetsRepo = async (): Promise<string | null> => {
+  try {
+    return await getSetting(tauriDatabase, SETTING_ISSUE_ASSETS_REPO);
+  } catch {
+    return null;
+  }
+};
+
+type RememberParams = {
+  readonly slug: string;
+};
+
+export const rememberIssueAssetsRepo = async ({ slug }: RememberParams): Promise<void> => {
+  try {
+    await setSetting(tauriDatabase, SETTING_ISSUE_ASSETS_REPO, slug);
+  } catch {
+    return;
+  }
+};

--- a/apps/desktop/src/features/settings/components/ReportIssueStudio/issueAssetsRepo.ts
+++ b/apps/desktop/src/features/settings/components/ReportIssueStudio/issueAssetsRepo.ts
@@ -1,0 +1,55 @@
+import type { GhRunner } from '@goodboy/core';
+
+const ISSUE_ASSETS_REPO_NAME = 'goodboy-issue-assets';
+
+const ISSUE_ASSETS_REPO_DESCRIPTION = 'Screenshots attached to Goodboy issue reports';
+
+type SlugParams = {
+  readonly login: string;
+};
+
+export const issueAssetsRepoSlug = ({ login }: SlugParams): string =>
+  `${login}/${ISSUE_ASSETS_REPO_NAME}`;
+
+type ExistsParams = {
+  readonly runner: GhRunner;
+  readonly slug: string;
+};
+
+export const hasIssueAssetsRepo = async ({ runner, slug }: ExistsParams): Promise<boolean> => {
+  try {
+    const result = await runner.run(['api', `repos/${slug}`, '--jq', '.full_name'], {});
+    return result.exitCode === 0;
+  } catch {
+    return false;
+  }
+};
+
+type CreateParams = {
+  readonly runner: GhRunner;
+};
+
+export const createIssueAssetsRepo = async ({ runner }: CreateParams): Promise<boolean> => {
+  try {
+    const result = await runner.run(
+      [
+        'api',
+        '--method',
+        'POST',
+        'user/repos',
+        '-f',
+        `name=${ISSUE_ASSETS_REPO_NAME}`,
+        '-f',
+        `description=${ISSUE_ASSETS_REPO_DESCRIPTION}`,
+        '-F',
+        'private=false',
+        '-F',
+        'auto_init=true',
+      ],
+      {},
+    );
+    return result.exitCode === 0;
+  } catch {
+    return false;
+  }
+};

--- a/apps/desktop/src/features/settings/components/ReportIssueStudio/issuePayload.test.ts
+++ b/apps/desktop/src/features/settings/components/ReportIssueStudio/issuePayload.test.ts
@@ -21,6 +21,35 @@ describe('buildIssueBody', () => {
       'Type: Bug\nArea: Board and sessions\nVersion: 0.1.69\n\nThe board freezes after archiving a session.',
     );
   });
+
+  it('asks for a drag and drop when the images have nowhere to live', () => {
+    const body = buildIssueBody({
+      typeLabel: 'Bug',
+      version: '0.1.69',
+      areaLabel: 'Board and sessions',
+      notes: 'Freezes on archive.',
+      imageNames: ['board.png', 'lane.png'],
+    });
+    expect(body).toContain('Screenshots to drag into this issue: board.png, lane.png');
+  });
+
+  it('embeds the uploaded images instead of naming them', () => {
+    const body = buildIssueBody({
+      typeLabel: 'Bug',
+      version: '0.1.69',
+      areaLabel: 'Board and sessions',
+      notes: 'Freezes on archive.',
+      imageNames: ['board.png', 'lane.png'],
+      uploadedImages: [
+        { fileName: 'board.png', url: 'https://raw.githubusercontent.com/o/r/main/board.png' },
+        { fileName: 'lane.png', url: 'https://raw.githubusercontent.com/o/r/main/lane.png' },
+      ],
+    });
+    expect(body).toBe(
+      'Type: Bug\nArea: Board and sessions\nVersion: 0.1.69\n\nFreezes on archive.\n\n![board.png](https://raw.githubusercontent.com/o/r/main/board.png)\n![lane.png](https://raw.githubusercontent.com/o/r/main/lane.png)',
+    );
+    expect(body).not.toContain('drag');
+  });
 });
 
 describe('buildFallbackIssue', () => {

--- a/apps/desktop/src/features/settings/components/ReportIssueStudio/issuePayload.test.ts
+++ b/apps/desktop/src/features/settings/components/ReportIssueStudio/issuePayload.test.ts
@@ -50,6 +50,24 @@ describe('buildIssueBody', () => {
     );
     expect(body).not.toContain('drag');
   });
+
+  it('escapes brackets and backslashes in the embedded alt text', () => {
+    const body = buildIssueBody({
+      typeLabel: 'Bug',
+      version: '0.1.69',
+      areaLabel: 'Board and sessions',
+      notes: 'Freezes on archive.',
+      uploadedImages: [
+        {
+          fileName: 'scr[een]sh\\ot.png',
+          url: 'https://raw.githubusercontent.com/o/r/main/board.png',
+        },
+      ],
+    });
+    expect(body).toContain(
+      '![scr\\[een\\]sh\\\\ot.png](https://raw.githubusercontent.com/o/r/main/board.png)',
+    );
+  });
 });
 
 describe('buildFallbackIssue', () => {

--- a/apps/desktop/src/features/settings/components/ReportIssueStudio/issuePayload.ts
+++ b/apps/desktop/src/features/settings/components/ReportIssueStudio/issuePayload.ts
@@ -6,6 +6,7 @@ import {
   MAX_ISSUE_URL_BYTES,
   withoutLoneSurrogates,
 } from '../../issueUrl';
+import type { UploadedIssueImage } from './uploadIssueImages';
 
 const TRUNCATION_NOTICE =
   '\n\n[Notes truncated to fit the GitHub link. Finish writing after the issue opens.]';
@@ -16,6 +17,7 @@ type BuildIssueBodyParams = {
   readonly areaLabel: string;
   readonly notes: string;
   readonly imageNames?: ReadonlyArray<string>;
+  readonly uploadedImages?: ReadonlyArray<UploadedIssueImage>;
 };
 
 export const buildIssueBody = ({
@@ -24,8 +26,13 @@ export const buildIssueBody = ({
   areaLabel,
   notes,
   imageNames = [],
+  uploadedImages = [],
 }: BuildIssueBodyParams): string => {
   const head = `Type: ${typeLabel}\nArea: ${areaLabel}\nVersion: ${version}\n\n${notes}`;
+  if (uploadedImages.length > 0) {
+    const embeds = uploadedImages.map(({ fileName, url }) => `![${fileName}](${url})`).join('\n');
+    return `${head}\n\n${embeds}`;
+  }
   if (imageNames.length === 0) {
     return head;
   }

--- a/apps/desktop/src/features/settings/components/ReportIssueStudio/issuePayload.ts
+++ b/apps/desktop/src/features/settings/components/ReportIssueStudio/issuePayload.ts
@@ -11,6 +11,9 @@ import type { UploadedIssueImage } from './uploadIssueImages';
 const TRUNCATION_NOTICE =
   '\n\n[Notes truncated to fit the GitHub link. Finish writing after the issue opens.]';
 
+const escapedAltText = ({ text }: { readonly text: string }): string =>
+  text.replace(/[\\[\]]/g, (char) => `\\${char}`);
+
 type BuildIssueBodyParams = {
   readonly typeLabel: string;
   readonly version: string;
@@ -30,7 +33,9 @@ export const buildIssueBody = ({
 }: BuildIssueBodyParams): string => {
   const head = `Type: ${typeLabel}\nArea: ${areaLabel}\nVersion: ${version}\n\n${notes}`;
   if (uploadedImages.length > 0) {
-    const embeds = uploadedImages.map(({ fileName, url }) => `![${fileName}](${url})`).join('\n');
+    const embeds = uploadedImages
+      .map(({ fileName, url }) => `![${escapedAltText({ text: fileName })}](${url})`)
+      .join('\n');
     return `${head}\n\n${embeds}`;
   }
   if (imageNames.length === 0) {

--- a/apps/desktop/src/features/settings/components/ReportIssueStudio/stageImages.ts
+++ b/apps/desktop/src/features/settings/components/ReportIssueStudio/stageImages.ts
@@ -22,10 +22,37 @@ export const stageBugReportImages = async ({ images }: Params): Promise<string |
   });
 };
 
-type RevealParams = {
+type DirParams = {
   readonly dir: string;
 };
 
-export const revealBugReportImages = async ({ dir }: RevealParams): Promise<void> => {
+export const revealBugReportImages = async ({ dir }: DirParams): Promise<void> => {
   await invoke('bug_report_reveal_images', { dir });
+};
+
+export type StagedUploadPayload = {
+  readonly fileName: string;
+  readonly payloadPath: string;
+};
+
+type StageUploadParams = DirParams & Params;
+
+export const stageBugReportUploadPayloads = async ({
+  dir,
+  images,
+}: StageUploadParams): Promise<ReadonlyArray<StagedUploadPayload>> =>
+  invoke<ReadonlyArray<StagedUploadPayload>>('bug_report_stage_upload_payloads', {
+    dir,
+    images: images.map((image) => ({
+      fileName: image.fileName,
+      dataBase64: base64FromDataUrl(image.dataUrl),
+    })),
+  });
+
+export const discardBugReportImages = async ({ dir }: DirParams): Promise<void> => {
+  try {
+    await invoke('bug_report_discard_images', { dir });
+  } catch {
+    return;
+  }
 };

--- a/apps/desktop/src/features/settings/components/ReportIssueStudio/uploadIssueImages.test.ts
+++ b/apps/desktop/src/features/settings/components/ReportIssueStudio/uploadIssueImages.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { GhRunner } from '@goodboy/core';
+import type { BugReportImage } from '../../../../store/slices/bugReportDraft/state';
+
+type GhRunResult = { stdout: string; stderr: string; exitCode: number };
+
+const mocks = vi.hoisted(() => ({
+  invoke: vi.fn<(cmd: string, args: Record<string, unknown>) => Promise<unknown>>(),
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: mocks.invoke,
+}));
+
+import { uploadIssueImages } from './uploadIssueImages';
+
+const image = ({ fileName }: { readonly fileName: string }): BugReportImage => ({
+  id: fileName,
+  fileName,
+  mimeType: 'image/png',
+  sizeBytes: 4,
+  dataUrl: 'data:image/png;base64,AAAA',
+});
+
+const runnerOf = (
+  run: (args: ReadonlyArray<string>) => Promise<GhRunResult>,
+): GhRunner & { readonly calls: Array<ReadonlyArray<string>> } => {
+  const calls: Array<ReadonlyArray<string>> = [];
+  return {
+    calls,
+    run: async (args) => {
+      calls.push(args);
+      return run(args);
+    },
+  };
+};
+
+const ok = (url: string): GhRunResult => ({ stdout: `${url}\n`, stderr: '', exitCode: 0 });
+
+const NOW = new Date('2026-08-21T10:00:00.000Z');
+
+beforeEach(() => {
+  mocks.invoke.mockReset();
+  mocks.invoke.mockImplementation(async (_command, args) => {
+    const staged = (args as { readonly images: ReadonlyArray<{ readonly fileName: string }> })
+      .images;
+    return staged.map(({ fileName }, index) => ({
+      fileName,
+      payloadPath: `/tmp/goodboy-report-1/.upload/0${index + 1}-${fileName}.b64`,
+    }));
+  });
+});
+
+describe('uploadIssueImages', () => {
+  it('puts every image into the assets repo and returns the raw urls in order', async () => {
+    const runner = runnerOf(async (args) =>
+      ok(`https://raw.githubusercontent.com/octocat/goodboy-issue-assets/main/${args[3]}`),
+    );
+
+    const uploaded = await uploadIssueImages({
+      runner,
+      slug: 'octocat/goodboy-issue-assets',
+      dir: '/tmp/goodboy-report-1',
+      images: [image({ fileName: 'board.png' }), image({ fileName: 'lane.png' })],
+      now: NOW,
+    });
+
+    expect(uploaded?.map((entry) => entry.fileName)).toEqual(['board.png', 'lane.png']);
+    expect(uploaded?.[0]?.url).toContain(
+      `repos/octocat/goodboy-issue-assets/contents/reports/2026-08/${NOW.getTime()}-01-board.png`,
+    );
+  });
+
+  it('reads the payload from the staged file rather than the command line', async () => {
+    const runner = runnerOf(async () => ok('https://raw.githubusercontent.com/o/r/main/a.png'));
+
+    await uploadIssueImages({
+      runner,
+      slug: 'octocat/goodboy-issue-assets',
+      dir: '/tmp/goodboy-report-1',
+      images: [image({ fileName: 'board.png' })],
+      now: NOW,
+    });
+
+    expect(runner.calls[0]).toContain('content=@/tmp/goodboy-report-1/.upload/01-board.png.b64');
+    expect(runner.calls[0]?.[1]).toBe('--method');
+    expect(runner.calls[0]?.[2]).toBe('PUT');
+  });
+
+  it('gives up on the whole batch when one upload fails', async () => {
+    const runner = runnerOf(async (args) =>
+      args.some((arg) => arg.includes('02-lane'))
+        ? { stdout: '', stderr: 'HTTP 403', exitCode: 1 }
+        : ok('https://raw.githubusercontent.com/o/r/main/a.png'),
+    );
+
+    const uploaded = await uploadIssueImages({
+      runner,
+      slug: 'octocat/goodboy-issue-assets',
+      dir: '/tmp/goodboy-report-1',
+      images: [image({ fileName: 'board.png' }), image({ fileName: 'lane.png' })],
+      now: NOW,
+    });
+
+    expect(uploaded).toBeNull();
+    expect(runner.calls).toHaveLength(2);
+  });
+
+  it('gives up when the response carries no usable url', async () => {
+    const runner = runnerOf(async () => ok(''));
+
+    const uploaded = await uploadIssueImages({
+      runner,
+      slug: 'octocat/goodboy-issue-assets',
+      dir: '/tmp/goodboy-report-1',
+      images: [image({ fileName: 'board.png' })],
+      now: NOW,
+    });
+
+    expect(uploaded).toBeNull();
+  });
+
+  it('gives up when the payloads cannot be staged, without calling gh', async () => {
+    mocks.invoke.mockImplementation(async () => {
+      throw new Error('disk is full');
+    });
+    const runner = runnerOf(async () => ok('https://raw.githubusercontent.com/o/r/main/a.png'));
+
+    const uploaded = await uploadIssueImages({
+      runner,
+      slug: 'octocat/goodboy-issue-assets',
+      dir: '/tmp/goodboy-report-1',
+      images: [image({ fileName: 'board.png' })],
+      now: NOW,
+    });
+
+    expect(uploaded).toBeNull();
+    expect(runner.calls).toHaveLength(0);
+  });
+});

--- a/apps/desktop/src/features/settings/components/ReportIssueStudio/uploadIssueImages.ts
+++ b/apps/desktop/src/features/settings/components/ReportIssueStudio/uploadIssueImages.ts
@@ -1,0 +1,79 @@
+import type { GhRunner } from '@goodboy/core';
+import type { BugReportImage } from '../../../../store/slices/bugReportDraft/state';
+import { issueAssetPath } from './issueAssetPath';
+import { stageBugReportUploadPayloads, type StagedUploadPayload } from './stageImages';
+
+export type UploadedIssueImage = {
+  readonly fileName: string;
+  readonly url: string;
+};
+
+type Params = {
+  readonly runner: GhRunner;
+  readonly slug: string;
+  readonly dir: string;
+  readonly images: ReadonlyArray<BugReportImage>;
+  readonly now?: Date;
+};
+
+type PutParams = {
+  readonly runner: GhRunner;
+  readonly slug: string;
+  readonly payload: StagedUploadPayload;
+  readonly path: string;
+};
+
+const putIssueAsset = async ({
+  runner,
+  slug,
+  payload,
+  path,
+}: PutParams): Promise<string | null> => {
+  const result = await runner.run(
+    [
+      'api',
+      '--method',
+      'PUT',
+      `repos/${slug}/contents/${path}`,
+      '-f',
+      `message=Add ${path}`,
+      '-F',
+      `content=@${payload.payloadPath}`,
+      '--jq',
+      '.content.download_url',
+    ],
+    {},
+  );
+  if (result.exitCode !== 0) {
+    return null;
+  }
+  const url = result.stdout.trim();
+  return url.startsWith('https://') ? url : null;
+};
+
+export const uploadIssueImages = async ({
+  runner,
+  slug,
+  dir,
+  images,
+  now = new Date(),
+}: Params): Promise<ReadonlyArray<UploadedIssueImage> | null> => {
+  if (images.length === 0) {
+    return null;
+  }
+  try {
+    const payloads = await stageBugReportUploadPayloads({ dir, images });
+    const uploaded: Array<UploadedIssueImage> = [];
+    for (const [index, payload] of payloads.entries()) {
+      const path = issueAssetPath({ fileName: payload.fileName, index, now });
+      const url = await putIssueAsset({ runner, slug, payload, path });
+      if (url == null) {
+        return null;
+      }
+      uploaded.push({ fileName: payload.fileName, url });
+    }
+    return uploaded.length === images.length ? uploaded : null;
+  } catch {
+    return null;
+  }
+};

--- a/apps/desktop/src/features/settings/settings.ts
+++ b/apps/desktop/src/features/settings/settings.ts
@@ -5,6 +5,7 @@ export const SETTING_DEFAULT_EDITOR = 'editor.default';
 export const SETTING_LAST_WORKSPACE_ID = 'last.workspace_id';
 export const SETTING_LAST_SESSION_ID = 'last.session_id';
 export const SETTING_REOPEN_LAST = 'launch.reopen_last';
+export const SETTING_ISSUE_ASSETS_REPO = 'report.issue_assets_repo';
 export const DEFAULT_EDITOR_BINARY = 'code';
 export const DEFAULT_BRANCH_PREFIX = 'goodboy';
 


### PR DESCRIPTION
## What

Report an issue, direct mode: the screenshots the reporter attaches now land inside the GitHub issue instead of being named in a line that asks for a manual drag and drop.

- **Consent first.** Sending with images, when `<login>/goodboy-issue-assets` is not already known, shows an inline confirmation naming the small public repository the app would create on the reporter's own account. Only an accept creates it (`POST user/repos`, public, `auto_init`, description "Screenshots attached to Goodboy issue reports"). The answer is remembered under the `report.issue_assets_repo` setting, so later reports go straight through.
- **Upload.** Each image is PUT to `reports/<yyyy-mm>/<timestamp>-<nn>-<sanitized-name>` through the contents API, and the returned raw URL is embedded as `![name](url)`. The issue is created once, with the final body.
- **Degradation.** A decline, no known login, a repository that cannot be created, or any upload failure falls back to exactly today's behavior: staged folder, drag reminder in the body, persistent toast with the reveal action. The issue is filed either way.
- **Cleanup.** The temp staging folder is deleted once every image is on the issue. It was never cleaned before. The manual-drag path keeps it, since that is what the reporter is about to open.
- The no-auth fallback (prefilled `issues/new` URL) is untouched.

## Why the payload goes through a file

There is no issue-attachment endpoint, and the browser upload flow needs session cookies, so the contents API against a repository the reporter's own token can write to is the only route an app can drive. Its `content` field takes the base64 the app already holds, but handing megabytes of base64 to `gh` as an argument hits the platform argv ceiling well below the 5MB per-image cap the composer allows. Two new Tauri commands write the payload next to the staged image (`bug_report_stage_upload_payloads`) and remove the folder afterwards (`bug_report_discard_images`); the runner reads the value with `-F content=@<path>`. Both commands refuse any path that is not a staging folder this process created, the same guard `bug_report_reveal_images` already used.

## Test plan

- `apps/desktop`: `pnpm typecheck`, `vitest run src/features/settings` (12 files, 119 tests).
- New: upload orchestration (order and raw URLs, payload read from file, whole batch abandoned on one failure, no gh call when staging fails), issue body with and without uploaded URLs, and the studio flow end to end (prompt shown and nothing filed yet, accept creates and embeds, staged folder cleared, remembered repository never asks again, decline keeps the drag reminder, failed upload still files the report).
- `cargo test --locked`: 455 passed, including staging payload contents, the decode guard, and the discard path guard.
- No GitHub operation was performed while building this: every test drives a mocked gh runner. The real calls run in the shipped app, under the reporter's own credentials, after the in-app consent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)