### PR TITLE
feat(desktop): write the session trace at every emit point

### DIFF
--- a/apps/desktop/src/store/slices/github/closePr.ts
+++ b/apps/desktop/src/store/slices/github/closePr.ts
@@ -1,6 +1,7 @@
 import type { SessionId } from '@goodboy/types';
 import { tauriGhRunner } from '../../../features/github/github';
 import { getSessionRepo } from '../worktrees/getSessionRepo';
+import { prEventPayload } from './prEventPayload';
 import type { GetFn, SetFn } from './types';
 
 export const closePr = (_set: SetFn, get: GetFn) => {
@@ -32,5 +33,10 @@ export const closePr = (_set: SetFn, get: GetFn) => {
       throw new Error(errMsg);
     }
     await get().refreshSessionPr(sessionId, { force: true });
+    await get().recordSessionEventOnce({
+      sessionId,
+      kind: 'pr_closed',
+      payload: prEventPayload({ number: num, pr: get().sessionGithub[sessionId]?.pr ?? null }),
+    });
   };
 };

--- a/apps/desktop/src/store/slices/github/createPrForSession.test.ts
+++ b/apps/desktop/src/store/slices/github/createPrForSession.test.ts
@@ -52,6 +52,7 @@ type FakeState = {
   refreshSessionPr: ReturnType<typeof vi.fn>;
   editPr: ReturnType<typeof vi.fn>;
   emitNotification: ReturnType<typeof vi.fn>;
+  recordSessionEventOnce: ReturnType<typeof vi.fn>;
 };
 
 const buildState = (overrides: Partial<FakeState> = {}): FakeState => ({
@@ -66,6 +67,7 @@ const buildState = (overrides: Partial<FakeState> = {}): FakeState => ({
   refreshSessionPr: vi.fn(async () => undefined),
   editPr: vi.fn(async () => undefined),
   emitNotification: vi.fn(async () => undefined),
+  recordSessionEventOnce: vi.fn(async () => undefined),
   ...overrides,
 });
 

--- a/apps/desktop/src/store/slices/github/createPrForSession.ts
+++ b/apps/desktop/src/store/slices/github/createPrForSession.ts
@@ -84,6 +84,14 @@ export const createPrForSession = (_set: SetFn, get: GetFn) => {
           .catch(() => undefined);
       }
     }
+    const created = get().sessionGithub[sessionId]?.pr ?? null;
+    if (created != null) {
+      await get().recordSessionEventOnce({
+        sessionId,
+        kind: 'pr_created',
+        payload: { number: created.number, title: created.title, url: created.url },
+      });
+    }
     void get().emitNotification(
       'pr-created',
       'success',

--- a/apps/desktop/src/store/slices/github/markPrReady.ts
+++ b/apps/desktop/src/store/slices/github/markPrReady.ts
@@ -1,6 +1,7 @@
 import type { SessionId } from '@goodboy/types';
 import { tauriGhRunner } from '../../../features/github/github';
 import { getSessionRepo } from '../worktrees/getSessionRepo';
+import { prEventPayload } from './prEventPayload';
 import type { GetFn, SetFn } from './types';
 
 export const markPrReady = (_set: SetFn, get: GetFn) => {
@@ -32,5 +33,10 @@ export const markPrReady = (_set: SetFn, get: GetFn) => {
       throw new Error(errMsg);
     }
     await get().refreshSessionPr(sessionId, { force: true });
+    await get().recordSessionEventOnce({
+      sessionId,
+      kind: 'pr_ready',
+      payload: prEventPayload({ number: num, pr: get().sessionGithub[sessionId]?.pr ?? null }),
+    });
   };
 };

--- a/apps/desktop/src/store/slices/github/mergePr.ts
+++ b/apps/desktop/src/store/slices/github/mergePr.ts
@@ -1,6 +1,7 @@
 import type { PrMergeMethod, SessionId } from '@goodboy/types';
 import { tauriGhRunner } from '../../../features/github/github';
 import { getSessionRepo } from '../worktrees/getSessionRepo';
+import { prEventPayload } from './prEventPayload';
 import type { GetFn, SetFn } from './types';
 
 // `gh pr merge` takes exactly one strategy flag. Squash is the desktop default
@@ -40,5 +41,10 @@ export const mergePr = (_set: SetFn, get: GetFn) => {
       throw new Error(errMsg);
     }
     await get().refreshSessionPr(sessionId, { force: true });
+    await get().recordSessionEventOnce({
+      sessionId,
+      kind: 'pr_merged',
+      payload: prEventPayload({ number: num, pr: get().sessionGithub[sessionId]?.pr ?? null }),
+    });
   };
 };

--- a/apps/desktop/src/store/slices/github/observePrTransition.test.ts
+++ b/apps/desktop/src/store/slices/github/observePrTransition.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { PullRequestState, PullRequestStateKind, SessionId } from '@goodboy/types';
+import { observePrTransition } from './observePrTransition';
+import type { GetFn } from './types';
+
+const sessionId = 'session-1' as SessionId;
+
+type PrParams = {
+  readonly state: PullRequestStateKind;
+  readonly number?: number;
+};
+
+const makePr = ({ state, number = 42 }: PrParams): PullRequestState => ({
+  number,
+  title: 'Persist the session trace',
+  url: `https://github.com/acme/web/pull/${number}`,
+  state,
+  mergeable: true,
+  checks: 'success',
+  baseBranch: 'main',
+  headBranch: 'ak/feat-session-events',
+  isDraft: false,
+  reviewDecision: null,
+  body: '',
+  updatedAt: '2026-08-21T10:00:00.000Z',
+});
+
+type RecordParams = {
+  readonly kind: string;
+};
+
+const record = vi.fn(async (_params: RecordParams) => undefined);
+const get = (() => ({ recordSessionEventOnce: record })) as unknown as GetFn;
+
+describe('observePrTransition', () => {
+  beforeEach(() => {
+    record.mockClear();
+  });
+
+  it('records an approval observed between two polls', async () => {
+    await observePrTransition({
+      get,
+      sessionId,
+      previous: makePr({ state: 'open' }),
+      next: makePr({ state: 'approved' }),
+    });
+
+    expect(record).toHaveBeenCalledWith({
+      sessionId,
+      kind: 'pr_approved',
+      payload: {
+        number: 42,
+        title: 'Persist the session trace',
+        url: 'https://github.com/acme/web/pull/42',
+      },
+    });
+  });
+
+  it('records a merge observed between two polls', async () => {
+    await observePrTransition({
+      get,
+      sessionId,
+      previous: makePr({ state: 'approved' }),
+      next: makePr({ state: 'merged' }),
+    });
+
+    expect(record.mock.calls[0]?.[0]).toMatchObject({ kind: 'pr_merged' });
+  });
+
+  it('stays quiet when the state did not move', async () => {
+    await observePrTransition({
+      get,
+      sessionId,
+      previous: makePr({ state: 'open' }),
+      next: makePr({ state: 'open' }),
+    });
+
+    expect(record).not.toHaveBeenCalled();
+  });
+
+  it('stays quiet on a transition with no event of its own', async () => {
+    await observePrTransition({
+      get,
+      sessionId,
+      previous: makePr({ state: 'draft' }),
+      next: makePr({ state: 'open' }),
+    });
+
+    expect(record).not.toHaveBeenCalled();
+  });
+
+  it('stays quiet when the poll returns a different pull request', async () => {
+    await observePrTransition({
+      get,
+      sessionId,
+      previous: makePr({ state: 'open', number: 41 }),
+      next: makePr({ state: 'merged', number: 42 }),
+    });
+
+    expect(record).not.toHaveBeenCalled();
+  });
+
+  it('stays quiet the first time a pull request is seen', async () => {
+    await observePrTransition({
+      get,
+      sessionId,
+      previous: null,
+      next: makePr({ state: 'merged' }),
+    });
+
+    expect(record).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/store/slices/github/observePrTransition.ts
+++ b/apps/desktop/src/store/slices/github/observePrTransition.ts
@@ -1,0 +1,44 @@
+import type {
+  PullRequestState,
+  PullRequestStateKind,
+  SessionEventKind,
+  SessionId,
+} from '@goodboy/types';
+import { prEventPayload } from './prEventPayload';
+import type { GetFn } from './types';
+
+const OBSERVED_KIND: Partial<Record<PullRequestStateKind, SessionEventKind>> = {
+  approved: 'pr_approved',
+  merged: 'pr_merged',
+  closed: 'pr_closed',
+};
+
+type Params = {
+  readonly get: GetFn;
+  readonly sessionId: SessionId;
+  readonly previous: PullRequestState | null;
+  readonly next: PullRequestState | null;
+};
+
+export const observePrTransition = async ({
+  get,
+  sessionId,
+  previous,
+  next,
+}: Params): Promise<void> => {
+  if (previous == null || next == null || previous.number !== next.number) {
+    return;
+  }
+  if (previous.state === next.state) {
+    return;
+  }
+  const kind = OBSERVED_KIND[next.state];
+  if (kind === undefined) {
+    return;
+  }
+  await get().recordSessionEventOnce({
+    sessionId,
+    kind,
+    payload: prEventPayload({ number: next.number, pr: next }),
+  });
+};

--- a/apps/desktop/src/store/slices/github/prEventPayload.ts
+++ b/apps/desktop/src/store/slices/github/prEventPayload.ts
@@ -1,0 +1,13 @@
+import type { PullRequestState, SessionEventPayload } from '@goodboy/types';
+
+type Params = {
+  readonly number: number;
+  readonly pr: PullRequestState | null;
+};
+
+export const prEventPayload = ({ number, pr }: Params): SessionEventPayload => {
+  if (pr == null || pr.number !== number) {
+    return { number };
+  }
+  return { number, title: pr.title, url: pr.url };
+};

--- a/apps/desktop/src/store/slices/github/refreshSessionPr.ts
+++ b/apps/desktop/src/store/slices/github/refreshSessionPr.ts
@@ -9,6 +9,7 @@ import { formatError } from '@goodboy/ui';
 import type { IsoDateTime, PullRequestState, SessionId } from '@goodboy/types';
 import { tauriGhRunner } from '../../../features/github/github';
 import { tauriDatabase } from '../../../shared/lib/db';
+import { observePrTransition } from './observePrTransition';
 import { resolveSessionPrFetch } from './resolveSessionPrFetch';
 import type { GetFn, SetFn } from './types';
 
@@ -124,6 +125,7 @@ export const refreshSessionPr = (set: SetFn, get: GetFn) => {
           ...(memberWorkspaceId != null ? { memberWorkspaceId } : {}),
         });
         const canonicalPr = prs[0] ?? null;
+        const observedFrom = get().sessionGithub[sessionId]?.pr ?? null;
         const selectedNumber = get().sessionSelectedPrNumber[sessionId] ?? null;
         const selectedPr =
           selectedNumber != null
@@ -175,6 +177,12 @@ export const refreshSessionPr = (set: SetFn, get: GetFn) => {
               },
             },
           };
+        });
+        await observePrTransition({
+          get,
+          sessionId,
+          previous: observedFrom,
+          next: canonicalPr,
         });
         await persistSessionPrCache({
           sessionId,

--- a/apps/desktop/src/store/slices/session-events/decisionsDelta.ts
+++ b/apps/desktop/src/store/slices/session-events/decisionsDelta.ts
@@ -1,0 +1,26 @@
+type Params = {
+  readonly previous: string;
+  readonly next: string;
+};
+
+export type DecisionsDelta = {
+  readonly added: number;
+  readonly removed: number;
+};
+
+const linesOf = ({ value }: { readonly value: string }): ReadonlyArray<string> =>
+  value
+    .split('\n')
+    .map((line) => line.replace(/^\s*[-*]\s+/, '').trim())
+    .filter((line) => line.length > 0);
+
+export const decisionsDelta = ({ previous, next }: Params): DecisionsDelta => {
+  const before = linesOf({ value: previous });
+  const after = linesOf({ value: next });
+  const beforeSet = new Set(before);
+  const afterSet = new Set(after);
+  return {
+    added: after.filter((line) => !beforeSet.has(line)).length,
+    removed: before.filter((line) => !afterSet.has(line)).length,
+  };
+};

--- a/apps/desktop/src/store/slices/session-events/index.test.ts
+++ b/apps/desktop/src/store/slices/session-events/index.test.ts
@@ -10,8 +10,10 @@ vi.mock('@goodboy/db', () => ({ insertSessionEvent, listSessionEvents }));
 vi.mock('../../../shared/lib/db', () => ({ tauriDatabase: {} }));
 
 import type { AppStore } from '../../store';
+import { decisionsDelta } from './decisionsDelta';
 import { loadSessionEvents } from './loadSessionEvents';
 import { recordSessionEvent } from './recordSessionEvent';
+import { recordSessionEventOnce } from './recordSessionEventOnce';
 
 const sessionId = 'session-1' as SessionId;
 
@@ -119,5 +121,103 @@ describe('session events slice', () => {
     await record({ sessionId, kind: 'pr_closed' });
 
     expect(store.read().sessionEvents[sessionId]).toEqual([]);
+  });
+});
+
+describe('recordSessionEventOnce', () => {
+  beforeEach(() => {
+    listSessionEvents.mockClear();
+    listSessionEvents.mockResolvedValue([]);
+  });
+
+  const makeOnceStore = (recorded: ReadonlyArray<SessionEvent>) => {
+    const record = vi.fn(async () => undefined);
+    listSessionEvents.mockResolvedValue(recorded);
+    const get = (() => ({ recordSessionEvent: record })) as unknown as () => AppStore;
+    return { get, record };
+  };
+
+  it('records a transition the log has never seen', async () => {
+    const { get, record } = makeOnceStore([]);
+
+    await recordSessionEventOnce(get)({
+      sessionId,
+      kind: 'pr_merged',
+      payload: { number: 12 },
+    });
+
+    expect(record).toHaveBeenCalledWith({
+      sessionId,
+      kind: 'pr_merged',
+      payload: { number: 12 },
+    });
+  });
+
+  it('skips a transition already recorded for the same pull request', async () => {
+    const { get, record } = makeOnceStore([
+      {
+        id: 'ev-1' as SessionEvent['id'],
+        sessionId,
+        kind: 'pr_merged',
+        payload: { number: 12 },
+        createdAt: '2026-08-21T10:00:00.000Z' as SessionEvent['createdAt'],
+      },
+    ]);
+
+    await recordSessionEventOnce(get)({
+      sessionId,
+      kind: 'pr_merged',
+      payload: { number: 12 },
+    });
+
+    expect(record).not.toHaveBeenCalled();
+  });
+
+  it('records the same kind again for a different pull request', async () => {
+    const { get, record } = makeOnceStore([
+      {
+        id: 'ev-1' as SessionEvent['id'],
+        sessionId,
+        kind: 'pr_merged',
+        payload: { number: 12 },
+        createdAt: '2026-08-21T10:00:00.000Z' as SessionEvent['createdAt'],
+      },
+    ]);
+
+    await recordSessionEventOnce(get)({
+      sessionId,
+      kind: 'pr_merged',
+      payload: { number: 13 },
+    });
+
+    expect(record).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('decisionsDelta', () => {
+  it('counts a decision appended to the slot', () => {
+    expect(
+      decisionsDelta({ previous: '- keep sqlite', next: '- keep sqlite\n- ship the trace' }),
+    ).toEqual({ added: 1, removed: 0 });
+  });
+
+  it('counts a decision dropped from the slot', () => {
+    expect(
+      decisionsDelta({ previous: '- keep sqlite\n- ship the trace', next: '- keep sqlite' }),
+    ).toEqual({ added: 0, removed: 1 });
+  });
+
+  it('ignores bullet punctuation and blank lines', () => {
+    expect(decisionsDelta({ previous: '- keep sqlite', next: '\n*  keep sqlite\n\n' })).toEqual({
+      added: 0,
+      removed: 0,
+    });
+  });
+
+  it('reports both sides of a replacement', () => {
+    expect(decisionsDelta({ previous: '- old call', next: '- new call' })).toEqual({
+      added: 1,
+      removed: 1,
+    });
   });
 });

--- a/apps/desktop/src/store/slices/session-events/index.ts
+++ b/apps/desktop/src/store/slices/session-events/index.ts
@@ -1,10 +1,14 @@
 import { loadSessionEvents } from './loadSessionEvents';
 import { recordSessionEvent } from './recordSessionEvent';
+import { recordSessionEventOnce } from './recordSessionEventOnce';
 import type { GetFn, SetFn } from './types';
+
+export { decisionsDelta } from './decisionsDelta';
 
 export const createSessionEventsSlice = (set: SetFn, get: GetFn) => {
   return {
     loadSessionEvents: loadSessionEvents(set, get),
     recordSessionEvent: recordSessionEvent(set),
+    recordSessionEventOnce: recordSessionEventOnce(get),
   };
 };

--- a/apps/desktop/src/store/slices/session-events/loadSessionEvents.ts
+++ b/apps/desktop/src/store/slices/session-events/loadSessionEvents.ts
@@ -10,7 +10,7 @@ type Params = Readonly<{
 
 export const loadSessionEvents = (set: SetFn, get: GetFn) => {
   return async ({ sessionId, force = false }: Params): Promise<void> => {
-    if (!force && get().sessionEvents[sessionId] !== undefined) {
+    if (!force && get().sessionEvents?.[sessionId] !== undefined) {
       return;
     }
     if (sessionEventsLoadInFlight.has(sessionId)) {

--- a/apps/desktop/src/store/slices/session-events/recordSessionEvent.ts
+++ b/apps/desktop/src/store/slices/session-events/recordSessionEvent.ts
@@ -32,7 +32,7 @@ export const recordSessionEvent = (set: SetFn) => {
       return;
     }
     set((state) => {
-      const existing = state.sessionEvents[sessionId];
+      const existing = state.sessionEvents?.[sessionId];
       if (existing === undefined) {
         return {};
       }

--- a/apps/desktop/src/store/slices/session-events/recordSessionEventOnce.ts
+++ b/apps/desktop/src/store/slices/session-events/recordSessionEventOnce.ts
@@ -1,0 +1,39 @@
+import { listSessionEvents } from '@goodboy/db';
+import type { SessionEventKind, SessionEventPayload, SessionId } from '@goodboy/types';
+import { tauriDatabase } from '../../../shared/lib/db';
+import { sessionEventsOnceInFlight, type GetFn } from './types';
+
+type Params = Readonly<{
+  sessionId: SessionId;
+  kind: SessionEventKind;
+  payload?: SessionEventPayload;
+}>;
+
+export const recordSessionEventOnce = (get: GetFn) => {
+  return async ({ sessionId, kind, payload }: Params): Promise<void> => {
+    const subject = payload?.number ?? null;
+    const guardKey = `${sessionId}:${kind}:${subject ?? ''}`;
+    if (sessionEventsOnceInFlight.has(guardKey)) {
+      return;
+    }
+    sessionEventsOnceInFlight.add(guardKey);
+    try {
+      const recorded = await listSessionEvents({ db: tauriDatabase, sessionId });
+      const isAlreadyRecorded = recorded.some(
+        (event) => event.kind === kind && (event.payload?.number ?? null) === subject,
+      );
+      if (isAlreadyRecorded) {
+        return;
+      }
+      await get().recordSessionEvent({
+        sessionId,
+        kind,
+        ...(payload === undefined ? {} : { payload }),
+      });
+    } catch (error) {
+      console.warn(`[session-events] dedupe check for ${kind} failed`, error);
+    } finally {
+      sessionEventsOnceInFlight.delete(guardKey);
+    }
+  };
+};

--- a/apps/desktop/src/store/slices/session-events/types.ts
+++ b/apps/desktop/src/store/slices/session-events/types.ts
@@ -4,6 +4,8 @@ export type { SetFn, GetFn } from '../../slice-types';
 
 export const sessionEventsLoadInFlight = new Set<SessionId>();
 
+export const sessionEventsOnceInFlight = new Set<string>();
+
 type MergeParams = {
   readonly existing: ReadonlyArray<SessionEvent>;
   readonly next: SessionEvent;

--- a/apps/desktop/src/store/slices/sessions/createSession.ts
+++ b/apps/desktop/src/store/slices/sessions/createSession.ts
@@ -303,6 +303,18 @@ export const createSession = (set: SetFn, get: GetFn) => {
         createdAt: Date.now(),
       });
     }
+    await get().recordSessionEvent({
+      sessionId: session.id,
+      kind: 'worktree_created',
+      payload: { worktreePath: worktree.worktreePath },
+    });
+    if (worktree.branchName.length > 0) {
+      await get().recordSessionEvent({
+        sessionId: session.id,
+        kind: 'branch_created',
+        payload: { branch: worktree.branchName },
+      });
+    }
     const repoSlugTargets: ReadonlyArray<RepoSlugTarget> = isComposite
       ? memberWorktrees.map(({ member, worktree: wt }) => ({
           repoRoot: member.rootPath,

--- a/apps/desktop/src/store/slices/sessions/deleteTask.ts
+++ b/apps/desktop/src/store/slices/sessions/deleteTask.ts
@@ -126,6 +126,8 @@ export const deleteTask = (set: SetFn, get: GetFn) => {
       delete nextFileVersionsLoading[sessionId];
       const nextFileVersionsPath = { ...state.sessionFileVersionSelectedPath };
       delete nextFileVersionsPath[sessionId];
+      const nextSessionEvents = { ...state.sessionEvents };
+      delete nextSessionEvents[sessionId];
       const cachedArchived = state.archivedSessions[sessionWorkspaceId];
       const nextArchived = cachedArchived
         ? {
@@ -156,6 +158,7 @@ export const deleteTask = (set: SetFn, get: GetFn) => {
         sessionFileVersions: nextFileVersions,
         sessionFileVersionsLoading: nextFileVersionsLoading,
         sessionFileVersionSelectedPath: nextFileVersionsPath,
+        sessionEvents: nextSessionEvents,
       };
     });
     void get().emitNotification(

--- a/apps/desktop/src/store/slices/sessions/index.ts
+++ b/apps/desktop/src/store/slices/sessions/index.ts
@@ -32,7 +32,7 @@ export const createSessionsSlice = (set: SetFn, get: GetFn) => {
     bulkUnarchiveTask: bulkUnarchiveTask(set, get),
     createSession: createSession(set, get),
     linkSessionExternalTask: linkSessionExternalTask({ set, get }),
-    unlinkSessionExternalTask: unlinkSessionExternalTask({ set }),
+    unlinkSessionExternalTask: unlinkSessionExternalTask({ set, get }),
     setCurrentSession: setCurrentSession(set, get),
   };
 };

--- a/apps/desktop/src/store/slices/sessions/linkSessionExternalTask.ts
+++ b/apps/desktop/src/store/slices/sessions/linkSessionExternalTask.ts
@@ -43,5 +43,15 @@ export const linkSessionExternalTask = ({ set, get }: Params) => {
         sessionExternalTasks: { ...state.sessionExternalTasks, [sessionId]: next },
       };
     });
+    await get().recordSessionEvent({
+      sessionId,
+      kind: 'issue_linked',
+      payload: {
+        provider: linkedTask.provider,
+        identifier: linkedTask.identifier,
+        title: linkedTask.title,
+        url: linkedTask.url,
+      },
+    });
   };
 };

--- a/apps/desktop/src/store/slices/sessions/unlinkSessionExternalTask.ts
+++ b/apps/desktop/src/store/slices/sessions/unlinkSessionExternalTask.ts
@@ -1,19 +1,27 @@
 import { deleteSessionExternalTask } from '@goodboy/db';
 import type { SessionExternalTaskProvider, SessionId, WorkspaceId } from '@goodboy/types';
 import { tauriDatabase } from '../../../shared/lib/db';
-import type { SetFn } from './types';
+import type { GetFn, SetFn } from './types';
 
 type Params = {
   readonly set: SetFn;
+  readonly get: GetFn;
 };
 
-export const unlinkSessionExternalTask = ({ set }: Params) => {
+export const unlinkSessionExternalTask = ({ set, get }: Params) => {
   return async (
     sessionId: SessionId,
     provider: SessionExternalTaskProvider,
     externalId: string,
     mountWorkspaceId?: WorkspaceId,
   ): Promise<void> => {
+    const unlinked =
+      (get().sessionExternalTasks[sessionId] ?? []).find(
+        (task) =>
+          task.provider === provider &&
+          task.externalId === externalId &&
+          task.mountWorkspaceId === mountWorkspaceId,
+      ) ?? null;
     await deleteSessionExternalTask({
       db: tauriDatabase,
       sessionId,
@@ -32,5 +40,18 @@ export const unlinkSessionExternalTask = ({ set }: Params) => {
         ),
       },
     }));
+    if (unlinked == null) {
+      return;
+    }
+    await get().recordSessionEvent({
+      sessionId,
+      kind: 'issue_unlinked',
+      payload: {
+        provider: unlinked.provider,
+        identifier: unlinked.identifier,
+        title: unlinked.title,
+        url: unlinked.url,
+      },
+    });
   };
 };

--- a/apps/desktop/src/store/slices/slots/upsertSessionSlot.ts
+++ b/apps/desktop/src/store/slices/slots/upsertSessionSlot.ts
@@ -6,6 +6,7 @@ import {
   upsertContextSlot,
 } from '@goodboy/db';
 import { tauriDatabase } from '../../../shared/lib/db';
+import { decisionsDelta } from '../session-events';
 import { mergeSlots, type GetFn, type SetFn } from './types';
 
 export const upsertSessionSlot = (set: SetFn, get: GetFn) => {
@@ -38,5 +39,17 @@ export const upsertSessionSlot = (set: SetFn, get: GetFn) => {
             },
       slotHistoryCounts: { ...state.slotHistoryCounts, [sessionId]: counts },
     }));
+    if (key !== 'decisions') {
+      return;
+    }
+    const delta = decisionsDelta({ previous: prev?.value ?? '', next: value });
+    if (delta.added === 0 && delta.removed === 0) {
+      return;
+    }
+    await get().recordSessionEvent({
+      sessionId,
+      kind: 'decisions_changed',
+      payload: { added: delta.added, removed: delta.removed },
+    });
   };
 };

--- a/apps/desktop/src/store/slices/turn/sendTurn.ts
+++ b/apps/desktop/src/store/slices/turn/sendTurn.ts
@@ -73,6 +73,7 @@ import { buildContextPreamble, buildPriorTurnsBlock, getModelContextWindow } fro
 import { applyAgentTurnState, cancelledRunIds } from '../../session-mutators';
 import { buildSessionLanguageGuard, resolveSessionLanguageGoal } from '../../sessionLanguage';
 import { stepSummaryDegraded } from '../../summarizeAgentOutput';
+import { decisionsDelta } from '../session-events';
 import { relinkSimpleSessionDirectories } from '../workspaces/relinkSimpleSessionDirectories';
 import { flushTurnEvents } from '../transcripts/buffer';
 import {
@@ -1064,6 +1065,9 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
         } catch {
           turnOrdinal = transcriptTurnOrdinal;
         }
+        const decisionsBefore =
+          (get().sessionSlots[sessionId] ?? []).find((slot) => slot.key === 'decisions')?.value ??
+          '';
         const result = await autoPopulateContext({
           db: tauriDatabase,
           sessionId,
@@ -1084,6 +1088,17 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
           set((state) => ({
             sessionSlots: { ...state.sessionSlots, [sessionId]: refreshedSlots },
           }));
+          const delta = decisionsDelta({
+            previous: decisionsBefore,
+            next: refreshedSlots.find((slot) => slot.key === 'decisions')?.value ?? '',
+          });
+          if (delta.added > 0 || delta.removed > 0) {
+            await get().recordSessionEvent({
+              sessionId,
+              kind: 'decisions_changed',
+              payload: { added: delta.added, removed: delta.removed },
+            });
+          }
         }
         if (result.openQuestionsChanged) {
           await get().loadSessionOpenQuestions(sessionId);

--- a/apps/desktop/src/store/slices/workflows/chainTriggers.test.ts
+++ b/apps/desktop/src/store/slices/workflows/chainTriggers.test.ts
@@ -171,6 +171,7 @@ describe('maybeAutoAdvanceWorkflow chain detection', () => {
       startWorkflowRun: vi.fn(async () => undefined),
       activateWorkflowAgent: vi.fn(async () => undefined),
       emitNotification: vi.fn(async () => undefined),
+      recordSessionEvent: vi.fn(async () => undefined),
     };
   }
 
@@ -445,6 +446,7 @@ describe('discardWorkflow chain flip', () => {
       sessions: [makeSession([target, chained])],
       sessionPhaseRuns: { [SESSION_ID]: [] as ReadonlyArray<Agent> },
       agentTurnState: {},
+      recordSessionEvent: vi.fn(async () => undefined),
     };
     const { set, get, setCalls } = harness(state);
     await discardWorkflow(set, get)(SESSION_ID, 'target' as WorkflowRunId);
@@ -469,6 +471,7 @@ describe('discardWorkflow chain flip', () => {
       sessions: [makeSession([target, a, b])],
       sessionPhaseRuns: { [SESSION_ID]: [] as ReadonlyArray<Agent> },
       agentTurnState: {},
+      recordSessionEvent: vi.fn(async () => undefined),
     };
     const { set, get } = harness(state);
     await discardWorkflow(set, get)(SESSION_ID, 'target' as WorkflowRunId);
@@ -495,6 +498,7 @@ describe('discardWorkflow chain flip', () => {
       sessions: [makeSession([target, other])],
       sessionPhaseRuns: { [SESSION_ID]: [] as ReadonlyArray<Agent> },
       agentTurnState: {},
+      recordSessionEvent: vi.fn(async () => undefined),
     };
     const { set, get } = harness(state);
     await discardWorkflow(set, get)(SESSION_ID, 'target' as WorkflowRunId);
@@ -511,6 +515,7 @@ describe('discardWorkflow chain flip', () => {
       sessions: [makeSession([target, chained])],
       sessionPhaseRuns: { [SESSION_ID]: [] as ReadonlyArray<Agent> },
       agentTurnState: {},
+      recordSessionEvent: vi.fn(async () => undefined),
     };
     const { set, get } = harness(state);
     await discardWorkflow(set, get)(SESSION_ID, 'target' as WorkflowRunId);
@@ -526,6 +531,7 @@ describe('discardWorkflow chain flip', () => {
       sessions: [makeSession([target, chained])],
       sessionPhaseRuns: { [SESSION_ID]: [] as ReadonlyArray<Agent> },
       agentTurnState: {},
+      recordSessionEvent: vi.fn(async () => undefined),
     };
     const { set, get } = harness(state);
     await discardWorkflow(set, get)(SESSION_ID, 'target' as WorkflowRunId);
@@ -543,6 +549,7 @@ describe('attachWorkflowToSession trigger modes', () => {
       providers: [],
       transcripts: {},
       agentTurnState: {},
+      recordSessionEvent: vi.fn(async () => undefined),
       agentModelOverride: {} as Record<string, string>,
       agentKindOverride: {} as Record<string, string>,
       agentProviderOverride: {} as Record<string, ProviderId>,

--- a/apps/desktop/src/store/slices/workflows/deleteWorkflow.ts
+++ b/apps/desktop/src/store/slices/workflows/deleteWorkflow.ts
@@ -1,9 +1,21 @@
-import type { IsoDateTime, Workflow, WorkflowId, WorkspaceId } from '@goodboy/types';
+import type { IsoDateTime, SessionId, Workflow, WorkflowId, WorkspaceId } from '@goodboy/types';
 import { invokeWorkflowDelete } from '../../../features/workflows/workflows';
-import type { SetFn } from './types';
+import type { GetFn, SetFn } from './types';
 
-export const deleteWorkflow = (set: SetFn) => {
+export const deleteWorkflow = (set: SetFn, get: GetFn) => {
   return async (id: WorkflowId, workspaceId: WorkspaceId) => {
+    const deletedName =
+      Object.values(get().sessionWorkflows)
+        .flat()
+        .find((workflow) => workflow.id === id)?.name ??
+      (get().phaseTemplates[workspaceId] ?? []).find((workflow) => workflow.id === id)?.name ??
+      null;
+    const affectedSessionIds = Object.entries(get().sessionWorkflows).flatMap(
+      ([sessionId, workflows]) =>
+        workflows.some((workflow) => workflow.id === id && workflow.deletedAt == null)
+          ? [sessionId as SessionId]
+          : [],
+    );
     await invokeWorkflowDelete(id);
     const now = new Date().toISOString() as IsoDateTime;
     const markDeleted = (w: Workflow): Workflow => (w.id === id ? { ...w, deletedAt: now } : w);
@@ -18,5 +30,12 @@ export const deleteWorkflow = (set: SetFn) => {
         sessionWorkflows: nextSessionWorkflows,
       };
     });
+    for (const sessionId of affectedSessionIds) {
+      await get().recordSessionEvent({
+        sessionId,
+        kind: 'workflow_deleted',
+        payload: deletedName == null ? {} : { workflowName: deletedName },
+      });
+    }
   };
 };

--- a/apps/desktop/src/store/slices/workflows/discardWorkflow.ts
+++ b/apps/desktop/src/store/slices/workflows/discardWorkflow.ts
@@ -84,5 +84,16 @@ export const discardWorkflow = (set: SetFn, get: GetFn) => {
     if (derived !== null) {
       await updateSessionState(tauriDatabase, sessionId, derived, now).catch(() => undefined);
     }
+    const discarded = (state.sessionWorkflows?.[sessionId] ?? []).find(
+      (workflow) => workflow.id === run.workflowId,
+    );
+    await get().recordSessionEvent({
+      sessionId,
+      kind: 'workflow_discarded',
+      payload: {
+        runId: workflowRunId,
+        ...(discarded == null ? {} : { workflowName: discarded.name }),
+      },
+    });
   };
 };

--- a/apps/desktop/src/store/slices/workflows/index.ts
+++ b/apps/desktop/src/store/slices/workflows/index.ts
@@ -39,7 +39,7 @@ export const createWorkflowsSlice = (set: SetFn, get: GetFn) => {
   return {
     loadPhaseTemplates: loadPhaseTemplates(set),
     savePhaseTemplate: savePhaseTemplate(set),
-    deleteWorkflow: deleteWorkflow(set),
+    deleteWorkflow: deleteWorkflow(set, get),
     renameWorkflow: renameWorkflow(set, get),
     makeWorkflowPreset: makeWorkflowPreset(set, get),
     generateWorkflowTitle: generateWorkflowTitle(set, get),

--- a/apps/desktop/src/store/slices/worktrees/changeSessionBranch.test.ts
+++ b/apps/desktop/src/store/slices/worktrees/changeSessionBranch.test.ts
@@ -44,6 +44,7 @@ const makeState = (): State => ({
     [SESSION_ID]: [{ provider: 'linear', externalId: 'GB-1', branch: 'ak/outgoing' }],
   },
   emitNotification: h.emitNotification,
+  recordSessionEvent: vi.fn(async () => undefined),
 });
 
 beforeEach(() => {
@@ -69,6 +70,24 @@ describe('changeSessionBranch', () => {
       '1 linked issue stays on ak/outgoing and moved to the work history. Pull requests now read from ak/incoming.',
       { sessionId: SESSION_ID, workspaceId: 'workspace-1' },
     );
+  });
+
+  it('writes the switch to the session trace with both branch names', async () => {
+    const state = makeState();
+    const set = vi.fn((updater: (current: State) => State) => {
+      Object.assign(state, updater(state));
+    });
+
+    await changeSessionBranch(set as never, (() => state) as never)(SESSION_ID, {
+      branch: 'ak/incoming',
+      createNew: false,
+    });
+
+    expect(state['recordSessionEvent']).toHaveBeenCalledWith({
+      sessionId: SESSION_ID,
+      kind: 'branch_switched',
+      payload: { from: 'ak/outgoing', to: 'ak/incoming' },
+    });
   });
 
   it('resets the pull requests of the outgoing branch and the selected one', async () => {

--- a/apps/desktop/src/store/slices/worktrees/changeSessionBranch.ts
+++ b/apps/desktop/src/store/slices/worktrees/changeSessionBranch.ts
@@ -97,6 +97,11 @@ export const changeSessionBranch = (set: SetFn, get: GetFn) => {
         sessionSelectedPrNumber: nextSelectedPrNumber,
       };
     });
+    await get().recordSessionEvent({
+      sessionId,
+      kind: 'branch_switched',
+      payload: { from: previousBranch, to: target },
+    });
     await announceSessionBranchChange({
       get,
       sessionId,

--- a/apps/desktop/src/store/store.branchless-session.test.ts
+++ b/apps/desktop/src/store/store.branchless-session.test.ts
@@ -79,6 +79,7 @@ type Store = {
   sessionPhaseRuns: Record<string, ReadonlyArray<unknown>>;
   closeSessionTerminals: () => Promise<void>;
   emitNotification: () => void;
+  recordSessionEvent: () => Promise<void>;
 };
 
 const makeStore = (branch: string): Store => ({
@@ -94,6 +95,7 @@ const makeStore = (branch: string): Store => ({
   sessionPhaseRuns: {},
   closeSessionTerminals: vi.fn(async () => undefined),
   emitNotification: vi.fn(),
+  recordSessionEvent: vi.fn(async () => undefined),
 });
 
 beforeEach(() => {

--- a/apps/desktop/src/store/store.composite-session.test.ts
+++ b/apps/desktop/src/store/store.composite-session.test.ts
@@ -127,6 +127,7 @@ type Store = {
   sessionPhaseRuns: Record<string, ReadonlyArray<unknown>>;
   closeSessionTerminals: () => Promise<void>;
   emitNotification: () => void;
+  recordSessionEvent: () => Promise<void>;
 };
 
 type MakeStoreParams = {
@@ -184,6 +185,7 @@ const makeStore = ({ activeMount }: MakeStoreParams): Store => ({
   sessionPhaseRuns: {},
   closeSessionTerminals: vi.fn(async () => undefined),
   emitNotification: vi.fn(),
+  recordSessionEvent: vi.fn(async () => undefined),
 });
 
 beforeEach(() => {

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -723,6 +723,11 @@ export type AppActions = {
     kind: SessionEventKind;
     payload?: SessionEventPayload;
   }): Promise<void>;
+  recordSessionEventOnce(params: {
+    sessionId: SessionId;
+    kind: SessionEventKind;
+    payload?: SessionEventPayload;
+  }): Promise<void>;
   loadSessionFileVersions(params: { sessionId: SessionId; force?: boolean }): Promise<void>;
   selectSessionFileVersionPath(params: { sessionId: SessionId; relativePath: string | null }): void;
   restoreSessionFileVersion(params: {


### PR DESCRIPTION
Stacked on #1505.

## What

Fills `session_events` from the actions that change a session outside an agent run.

| Action | Event |
| --- | --- |
| `createSession` | `worktree_created`, `branch_created` (skipped for a branchless session) |
| `changeSessionBranch` | `branch_switched` with `{from, to}`, read before the row is overwritten |
| `linkSessionExternalTask` / `unlinkSessionExternalTask` | `issue_linked` / `issue_unlinked` with provider, identifier, title, url |
| `createPrForSession`, `markPrReady`, `mergePr`, `closePr` | `pr_created`, `pr_ready`, `pr_merged`, `pr_closed` |
| `refreshSessionPr` | `pr_approved` / `pr_merged` / `pr_closed` when a poll observes the transition |
| `discardWorkflow`, `deleteWorkflow` | `workflow_discarded`, `workflow_deleted` |
| `upsertSessionSlot('decisions')`, `sendTurn` post-autopopulate | `decisions_changed` with `{added, removed}` |

Two mechanisms carry the weight:

- `observePrTransition` compares the previous canonical PR to the new one inside `refreshSessionPr`. It only fires on a state change for the same PR number, so a first sighting of an already-merged PR writes nothing.
- `recordSessionEventOnce` reads the log before writing and drops a duplicate of the same kind for the same PR number, plus an in-flight guard against two concurrent polls. This is what keeps `mergePr` (which refreshes first, then records) from writing the merge twice.

`decisionsDelta` compares the decision lines before and after, ignoring bullet punctuation, so one turn that adds three decisions writes one aggregated event.

## Why

Without emit points the table from #1505 is empty. Timestamps are observation time, which is the only honest reading for anything GitHub decided while the app was not looking.

## Notes

- `workflow_started` stays reserved and unwritten. Workflow runs already render in the timeline as derived entries; emitting a start event would put the same run in the feed twice.
- Session deletion needs no new call. `session_events` cascades from `sessions`, the runtime opens SQLite with `PRAGMA foreign_keys = ON`, and #1505 tests the cascade. This PR only clears the in-memory map in `deleteTask`.
- Test store fakes in five files gained the new store actions. That is the usual cost of a new action landing in a hot path.

## Test plan

- `pnpm turbo run typecheck` green across all 5 packages.
- `apps/desktop` `src/store`: 134 files / 1269 tests pass, including the new `observePrTransition` suite, the `recordSessionEventOnce` dedupe cases, the `decisionsDelta` cases, and a branch-switch trace assertion.
- `apps/desktop` `src/features` + `src/__tests__`: 504 files / 4399 tests pass.
- `packages/db`: 39 files / 267 tests pass.
- `pnpm knip --include files,duplicates,unlisted` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
