### PR TITLE
feat(desktop): read the session trace in the activity feed

### DIFF
--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/ActivityFilterButton.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/ActivityFilterButton.tsx
@@ -1,0 +1,68 @@
+import { ListFilter } from 'lucide-react';
+import { Checkbox, cn, Popover, PopoverBody, useDropdown } from '@goodboy/ui';
+import {
+  ACTIVITY_CATEGORIES,
+  ACTIVITY_CATEGORY_LABEL,
+  type ActivityCategory,
+  type ActivityFilter,
+} from '../../../../timeline/activityFilter';
+
+type Props = {
+  readonly filter: ActivityFilter;
+  readonly hiddenCount: number;
+  readonly onCategory: (params: {
+    readonly category: ActivityCategory;
+    readonly enabled: boolean;
+  }) => void;
+};
+
+export const ActivityFilterButton = ({ filter, hiddenCount, onCategory }: Props) => {
+  const { open, toggle, containerRef, popupRef, popupClassName, popupStyle } = useDropdown({
+    align: 'end',
+    expectedHeight: 240,
+    expectedWidth: 208,
+    width: 'w-52',
+  });
+
+  return (
+    <div ref={containerRef} className="relative inline-flex">
+      <button
+        type="button"
+        onClick={toggle}
+        aria-label="Filter the activity feed"
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        className={cn(
+          'inline-flex h-7 items-center gap-1 rounded-md px-1.5 text-2xs motion-safe:transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]',
+          hiddenCount > 0
+            ? 'text-foreground hover:bg-foreground/10'
+            : 'text-muted-foreground/70 hover:bg-foreground/10 hover:text-foreground',
+        )}
+      >
+        <ListFilter size={13} aria-hidden className="shrink-0" />
+        {hiddenCount > 0 ? hiddenCount : null}
+      </button>
+
+      {open ? (
+        <Popover
+          innerRef={popupRef}
+          role="dialog"
+          ariaLabel="Activity filter"
+          className={cn(popupClassName, 'bg-subtle')}
+          style={popupStyle}
+        >
+          <PopoverBody className="flex flex-col gap-2 px-3 py-2.5">
+            {ACTIVITY_CATEGORIES.map((category) => (
+              <Checkbox
+                key={category}
+                checked={filter[category]}
+                label={ACTIVITY_CATEGORY_LABEL[category]}
+                onChange={(enabled) => onCategory({ category, enabled })}
+              />
+            ))}
+          </PopoverBody>
+        </Popover>
+      ) : null}
+    </div>
+  );
+};

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRowLabel.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRowLabel.tsx
@@ -1,6 +1,10 @@
 import { Chip, cn } from '@goodboy/ui';
 import { agentKindPalette } from '../../../../agent-kind';
 import type { TimelineRunEntry } from '../../../../timeline/buildTimelineGroups';
+import {
+  sessionEventEmphasis,
+  sessionEventTitle,
+} from '../../../../timeline/sessionEventPresentation';
 import type {
   TimelineRowItem,
   TimelineStreamEntry,
@@ -20,7 +24,7 @@ type EntryParams = {
 
 const titleOf = ({ entry }: EntryParams): string => {
   if (entry.kind === 'agent') {
-    return entry.agent.name;
+    return entry.chain?.label ?? entry.agent.name;
   }
   if (entry.kind === 'plan') {
     return entry.plan.title;
@@ -30,6 +34,9 @@ const titleOf = ({ entry }: EntryParams): string => {
   }
   if (entry.kind === 'branch') {
     return 'Branch created';
+  }
+  if (entry.kind === 'event') {
+    return sessionEventTitle({ event: entry.event });
   }
   return entry.question.text;
 };
@@ -41,6 +48,19 @@ type ChipParams = EntryParams & {
 const chipOf = ({ entry, grade }: ChipParams) => {
   if (entry.kind !== 'agent' || grade !== 'entry') {
     return null;
+  }
+  if (entry.chain != null) {
+    return (
+      <Chip
+        tone="neutral"
+        label="Chain"
+        shape="badge"
+        size="3xs"
+        width="md"
+        uppercase
+        className={cn('shrink-0', entry.chain.identity.chip)}
+      />
+    );
   }
   const palette = agentKindPalette({ kind: entry.agentKind });
   return (
@@ -62,6 +82,9 @@ export const TimelineRowLabel = ({ item }: Props) => {
     return <TimelineRunLabel entry={entry} />;
   }
   const isStep = grade === 'step';
+  const emphasis =
+    entry.kind === 'event' ? sessionEventEmphasis({ kind: entry.event.kind }) : 'plain';
+  const isPath = entry.kind === 'event' && entry.event.kind === 'worktree_created';
   return (
     <>
       {chipOf({ entry, grade })}
@@ -77,11 +100,16 @@ export const TimelineRowLabel = ({ item }: Props) => {
         className={cn(
           'min-w-0 truncate',
           isStep ? 'text-xs leading-4' : 'text-sm leading-5',
-          item.markerState === 'running' || item.hasUnread
-            ? 'font-medium text-foreground'
-            : isStep
-              ? 'text-foreground/85'
-              : 'text-foreground',
+          isPath && 'font-mono text-xs',
+          emphasis === 'success'
+            ? 'text-success'
+            : emphasis === 'muted'
+              ? 'text-muted-foreground'
+              : item.markerState === 'running' || item.hasUnread
+                ? 'font-medium text-foreground'
+                : isStep
+                  ? 'text-foreground/85'
+                  : 'text-foreground',
         )}
       >
         {titleOf({ entry })}

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRowMarker.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRowMarker.tsx
@@ -5,6 +5,7 @@ import type { Tone } from '@goodboy/ui';
 import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../../../shared/components/conceptIcons';
 import { IntegrationGlyph } from '../../../../../integrations/components/IntegrationGlyph';
 import type { TimelineRowItem } from '../../../../timeline/buildTimelineStream';
+import { sessionEventGlyph } from '../../../../timeline/sessionEventPresentation';
 import { TIMELINE_RHYTHM } from '../../../../timeline/timelineRhythm';
 import { TimelineEmphasisMarker } from './TimelineEmphasisMarker';
 import { TimelineGlyphMarker } from './TimelineGlyphMarker';
@@ -36,6 +37,19 @@ export const TimelineRowMarker = ({ item }: Props) => {
     return (
       <TimelineGlyphMarker tone="neutral" grade={grade}>
         <IntegrationGlyph provider={entry.task.provider} size="xs" />
+      </TimelineGlyphMarker>
+    );
+  }
+  if (entry.kind === 'event') {
+    const eventGlyph = sessionEventGlyph({ kind: entry.event.kind });
+    const EventIcon = eventGlyph.icon;
+    return (
+      <TimelineGlyphMarker tone={eventGlyph.tone} grade={grade}>
+        <EventIcon
+          size={glyphSize}
+          aria-label={eventGlyph.label}
+          className={tintClasses(eventGlyph.tone).icon}
+        />
       </TimelineGlyphMarker>
     );
   }

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/index.tsx
@@ -1,7 +1,7 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import type { ReactNode } from 'react';
 import { CheckCheck } from 'lucide-react';
-import { Button, Eyebrow } from '@goodboy/ui';
+import { Button, Eyebrow, useCopyLink } from '@goodboy/ui';
 import type { Session, SessionId } from '@goodboy/types';
 import {
   EMPTY_ARRAY,
@@ -16,6 +16,8 @@ import {
   resolveWorkflowAdvance,
   type WorkflowAdvanceState,
 } from '../../../../../workflows/advanceGate';
+import { useToast } from '../../../../../../app/components/Toast';
+import { filterTimelineEntries } from '../../../../timeline/activityFilter';
 import { buildTimelineGroups } from '../../../../timeline/buildTimelineGroups';
 import {
   buildTimelineStream,
@@ -23,7 +25,9 @@ import {
 } from '../../../../timeline/buildTimelineStream';
 import { dayLabel } from '../../../../timeline/dayLabel';
 import { layoutTimelineRail } from '../../../../timeline/railGeometry';
+import { useActivityFilter } from '../../../../hooks/useActivityFilter';
 import { useTimelineOpen } from '../../../../hooks/useTimelineOpen';
+import { ActivityFilterButton } from './ActivityFilterButton';
 import { TimelineDayRule } from './TimelineDayRule';
 import { TimelineNowRule } from './TimelineNowRule';
 import { TimelinePendingCluster } from './TimelinePendingCluster';
@@ -42,6 +46,8 @@ export const TimelinePane = ({ session, runs, actions }: Props) => {
   const plans = useAppStore((s) => s.sessionPlans?.[sessionId] ?? EMPTY_ARRAY);
   const externalTasks = useAppStore((s) => s.sessionExternalTasks?.[sessionId] ?? EMPTY_ARRAY);
   const worktrees = useAppStore((s) => s.sessionWorktreeRecords?.[sessionId] ?? EMPTY_ARRAY);
+  const events = useAppStore((s) => s.sessionEvents?.[sessionId] ?? EMPTY_ARRAY);
+  const loadSessionEvents = useAppStore((s) => s.loadSessionEvents);
   const agentKindOverride = useAppStore((s) => s.agentKindOverride);
   const activateWorkflowAgent = useAppStore((s) => s.activateWorkflowAgent);
   const emitNotification = useAppStore((s) => s.emitNotification);
@@ -59,6 +65,25 @@ export const TimelinePane = ({ session, runs, actions }: Props) => {
   const questions = useSessionOpenQuestions(sessionId);
   const workflows = useAttachedWorkflowRuns({ session });
   const openTargetFor = useTimelineOpen({ sessionId });
+  const activity = useActivityFilter();
+  const { showToast } = useToast();
+  const { copied, failed, copy } = useCopyLink();
+
+  useEffect(() => {
+    void loadSessionEvents({ sessionId });
+  }, [loadSessionEvents, sessionId]);
+
+  useEffect(() => {
+    if (copied) {
+      showToast('success', 'path copied');
+    }
+  }, [copied, showToast]);
+
+  useEffect(() => {
+    if (failed) {
+      showToast('error', 'copy failed');
+    }
+  }, [failed, showToast]);
 
   const model = useMemo(
     () =>
@@ -69,9 +94,15 @@ export const TimelinePane = ({ session, runs, actions }: Props) => {
         externalTasks,
         questions,
         worktrees,
+        events,
         agentKindOverride,
       }),
-    [agentKindOverride, agents, externalTasks, plans, questions, workflows, worktrees],
+    [agentKindOverride, agents, events, externalTasks, plans, questions, workflows, worktrees],
+  );
+
+  const visibleEntries = useMemo(
+    () => filterTimelineEntries({ entries: model.entries, filter: activity.filter }),
+    [activity.filter, model.entries],
   );
 
   const advanceByRunId = useMemo(() => {
@@ -135,12 +166,12 @@ export const TimelinePane = ({ session, runs, actions }: Props) => {
   const stream = useMemo(
     () =>
       buildTimelineStream({
-        entries: model.entries,
+        entries: visibleEntries,
         unreadAgentIds,
         blockedRunIds,
         dayLabelFor: dayLabel,
       }),
-    [blockedRunIds, model.entries, unreadAgentIds],
+    [blockedRunIds, unreadAgentIds, visibleEntries],
   );
 
   const rail = useMemo(
@@ -162,6 +193,16 @@ export const TimelinePane = ({ session, runs, actions }: Props) => {
 
   const actionFor = ({ item }: { readonly item: TimelineRowItem }): TimelineRowAction | null => {
     const { entry } = item;
+    if (entry.kind === 'event' && entry.event.kind === 'worktree_created') {
+      const worktreePath = entry.event.payload?.worktreePath ?? null;
+      if (worktreePath == null) {
+        return null;
+      }
+      return {
+        label: copied ? 'Copied' : 'Copy path',
+        onAct: () => void copy(worktreePath),
+      };
+    }
     if (entry.kind === 'agent' && entry.openQuestions.length > 0) {
       return { label: 'Answer', onAct: () => setActiveLens(sessionId, 'questions') };
     }
@@ -215,6 +256,11 @@ export const TimelinePane = ({ session, runs, actions }: Props) => {
               Mark all seen
             </Button>
           ) : null}
+          <ActivityFilterButton
+            filter={activity.filter}
+            hiddenCount={activity.hiddenCount}
+            onCategory={activity.setCategory}
+          />
           {actions}
         </div>
       </div>

--- a/apps/desktop/src/features/session/hooks/useActivityFilter/index.ts
+++ b/apps/desktop/src/features/session/hooks/useActivityFilter/index.ts
@@ -1,0 +1,37 @@
+import { useCallback, useState } from 'react';
+import {
+  readActivityFilter,
+  writeActivityFilter,
+  type ActivityCategory,
+  type ActivityFilter,
+} from '../../timeline/activityFilter';
+
+export type ActivityFilterControl = {
+  readonly filter: ActivityFilter;
+  readonly hiddenCount: number;
+  readonly setCategory: (params: {
+    readonly category: ActivityCategory;
+    readonly enabled: boolean;
+  }) => void;
+};
+
+export const useActivityFilter = (): ActivityFilterControl => {
+  const [filter, setFilter] = useState<ActivityFilter>(() => readActivityFilter());
+
+  const setCategory = useCallback(
+    ({ category, enabled }: { readonly category: ActivityCategory; readonly enabled: boolean }) => {
+      setFilter((current) => {
+        const next: ActivityFilter = { ...current, [category]: enabled };
+        writeActivityFilter({ filter: next });
+        return next;
+      });
+    },
+    [],
+  );
+
+  return {
+    filter,
+    hiddenCount: Object.values(filter).filter((enabled) => !enabled).length,
+    setCategory,
+  };
+};

--- a/apps/desktop/src/features/session/hooks/useTimelineOpen/index.ts
+++ b/apps/desktop/src/features/session/hooks/useTimelineOpen/index.ts
@@ -1,7 +1,34 @@
 import { useCallback } from 'react';
 import type { SessionId } from '@goodboy/types';
+import type { SessionEventKind } from '@goodboy/types';
 import { useAppStore } from '../../../../store';
+import type { LensKind } from '../../../../store/slices/session-view/types';
 import type { TimelineStreamEntry } from '../../timeline/buildTimelineStream';
+
+type EventTarget = {
+  readonly lens: LensKind | null;
+  readonly label: string;
+};
+
+const EVENT_TARGET: Record<SessionEventKind, EventTarget> = {
+  worktree_created: { lens: 'files', label: 'Open files' },
+  branch_created: { lens: 'files', label: 'Open files' },
+  branch_switched: { lens: 'files', label: 'Open files' },
+  issue_linked: { lens: null, label: 'Open overview' },
+  issue_unlinked: { lens: null, label: 'Open overview' },
+  pr_created: { lens: 'pr', label: 'Open PR' },
+  pr_ready: { lens: 'pr', label: 'Open PR' },
+  pr_approved: { lens: 'pr', label: 'Open PR' },
+  pr_merged: { lens: 'pr', label: 'Open PR' },
+  pr_closed: { lens: 'pr', label: 'Open PR' },
+  workflow_started: { lens: 'workflows', label: 'Open workflows' },
+  workflow_discarded: { lens: 'workflows', label: 'Open workflows' },
+  workflow_deleted: { lens: 'workflows', label: 'Open workflows' },
+  decisions_changed: { lens: 'decisions', label: 'Open decisions' },
+};
+
+const eventOpenTarget = ({ kind }: { readonly kind: SessionEventKind }): EventTarget =>
+  EVENT_TARGET[kind];
 
 type Params = {
   readonly sessionId: SessionId;
@@ -60,6 +87,13 @@ export const useTimelineOpen = ({
       }
       if (entry.kind === 'branch') {
         return { label: 'Open files', open: () => store.setActiveLens(sessionId, 'files') };
+      }
+      if (entry.kind === 'event') {
+        const target = eventOpenTarget({ kind: entry.event.kind });
+        return {
+          label: target.label,
+          open: () => store.setActiveLens(sessionId, target.lens),
+        };
       }
       return {
         label: 'Open questions',

--- a/apps/desktop/src/features/session/timeline/activityFilter.test.ts
+++ b/apps/desktop/src/features/session/timeline/activityFilter.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest';
+import type { SessionEvent, SessionEventKind } from '@goodboy/types';
+import {
+  DEFAULT_ACTIVITY_FILTER,
+  activityCategoryOf,
+  filterTimelineEntries,
+  parseActivityFilter,
+  type ActivityFilter,
+} from './activityFilter';
+import type { TimelineTopLevelEntry } from './buildTimelineGroups';
+
+type EventEntryParams = {
+  readonly id: string;
+  readonly kind: SessionEventKind;
+};
+
+const eventEntry = ({ id, kind }: EventEntryParams): TimelineTopLevelEntry => ({
+  kind: 'event',
+  id: `event:${id}`,
+  at: '2026-08-21T10:00:00.000Z',
+  event: {
+    id,
+    sessionId: 'session-1',
+    kind,
+    payload: null,
+    createdAt: '2026-08-21T10:00:00.000Z',
+  } as unknown as SessionEvent,
+});
+
+const agentEntry = ({
+  id,
+  agentKind,
+}: {
+  readonly id: string;
+  readonly agentKind: string;
+}): TimelineTopLevelEntry =>
+  ({
+    kind: 'agent',
+    id: `agent:${id}`,
+    at: '2026-08-21T10:00:00.000Z',
+    ordinal: 0,
+    agent: { id, name: id },
+    agentKind,
+    stepLabel: null,
+    openQuestions: [],
+    terminalQuestions: [],
+    children: [],
+    answers: [],
+    hasDuration: false,
+    chain: null,
+  }) as unknown as TimelineTopLevelEntry;
+
+describe('activityCategoryOf', () => {
+  it('files every event kind under a category', () => {
+    expect(activityCategoryOf({ entry: eventEntry({ id: 'a', kind: 'branch_switched' }) })).toBe(
+      'worktree',
+    );
+    expect(activityCategoryOf({ entry: eventEntry({ id: 'b', kind: 'issue_unlinked' }) })).toBe(
+      'issues',
+    );
+    expect(activityCategoryOf({ entry: eventEntry({ id: 'c', kind: 'pr_merged' }) })).toBe(
+      'pullRequests',
+    );
+    expect(activityCategoryOf({ entry: eventEntry({ id: 'd', kind: 'workflow_deleted' }) })).toBe(
+      'workflows',
+    );
+    expect(activityCategoryOf({ entry: eventEntry({ id: 'e', kind: 'decisions_changed' }) })).toBe(
+      'decisions',
+    );
+  });
+
+  it('separates a resolver agent from an ordinary one', () => {
+    expect(activityCategoryOf({ entry: agentEntry({ id: 'a', agentKind: 'resolver' }) })).toBe(
+      'resolver',
+    );
+    expect(activityCategoryOf({ entry: agentEntry({ id: 'b', agentKind: 'implementer' }) })).toBe(
+      'agents',
+    );
+  });
+});
+
+describe('filterTimelineEntries', () => {
+  it('hides decisions by default and keeps everything else', () => {
+    const entries = [
+      eventEntry({ id: 'a', kind: 'decisions_changed' }),
+      eventEntry({ id: 'b', kind: 'pr_merged' }),
+    ];
+
+    expect(
+      filterTimelineEntries({ entries, filter: DEFAULT_ACTIVITY_FILTER }).map((entry) => entry.id),
+    ).toEqual(['event:b']);
+  });
+
+  it('drops every row of a disabled category', () => {
+    const filter: ActivityFilter = { ...DEFAULT_ACTIVITY_FILTER, pullRequests: false };
+    const entries = [
+      eventEntry({ id: 'a', kind: 'pr_merged' }),
+      eventEntry({ id: 'b', kind: 'branch_created' }),
+    ];
+
+    expect(filterTimelineEntries({ entries, filter }).map((entry) => entry.id)).toEqual([
+      'event:b',
+    ]);
+  });
+
+  it('keeps an entry that belongs to no category', () => {
+    const plan = {
+      kind: 'plan',
+      id: 'plan:1',
+      at: '2026-08-21T10:00:00.000Z',
+    } as unknown as TimelineTopLevelEntry;
+
+    expect(
+      filterTimelineEntries({ entries: [plan], filter: DEFAULT_ACTIVITY_FILTER }),
+    ).toHaveLength(1);
+  });
+});
+
+describe('parseActivityFilter', () => {
+  it('falls back to the defaults on missing storage', () => {
+    expect(parseActivityFilter({ raw: null })).toEqual(DEFAULT_ACTIVITY_FILTER);
+  });
+
+  it('falls back to the defaults on malformed storage', () => {
+    expect(parseActivityFilter({ raw: 'not json' })).toEqual(DEFAULT_ACTIVITY_FILTER);
+    expect(parseActivityFilter({ raw: '[]' })).toEqual(DEFAULT_ACTIVITY_FILTER);
+  });
+
+  it('keeps a stored choice and defaults the rest', () => {
+    const parsed = parseActivityFilter({ raw: '{"decisions":true,"agents":"yes"}' });
+
+    expect(parsed.decisions).toBe(true);
+    expect(parsed.agents).toBe(DEFAULT_ACTIVITY_FILTER.agents);
+  });
+});

--- a/apps/desktop/src/features/session/timeline/activityFilter.ts
+++ b/apps/desktop/src/features/session/timeline/activityFilter.ts
@@ -1,0 +1,142 @@
+import type { SessionEventKind } from '@goodboy/types';
+import type { TimelineTopLevelEntry } from './buildTimelineGroups';
+
+export const ACTIVITY_CATEGORIES = [
+  'worktree',
+  'issues',
+  'pullRequests',
+  'workflows',
+  'agents',
+  'resolver',
+  'decisions',
+] as const;
+
+export type ActivityCategory = (typeof ACTIVITY_CATEGORIES)[number];
+
+export type ActivityFilter = Readonly<Record<ActivityCategory, boolean>>;
+
+export const ACTIVITY_CATEGORY_LABEL: Record<ActivityCategory, string> = {
+  worktree: 'Worktree and branch',
+  issues: 'Issues',
+  pullRequests: 'Pull requests',
+  workflows: 'Workflows',
+  agents: 'Agents',
+  resolver: 'Resolver',
+  decisions: 'Decisions',
+};
+
+export const DEFAULT_ACTIVITY_FILTER: ActivityFilter = {
+  worktree: true,
+  issues: true,
+  pullRequests: true,
+  workflows: true,
+  agents: true,
+  resolver: true,
+  decisions: false,
+};
+
+export const ACTIVITY_FILTER_STORAGE_KEY = 'goodboy:activity-filter';
+
+const CATEGORY_BY_EVENT_KIND: Record<SessionEventKind, ActivityCategory> = {
+  worktree_created: 'worktree',
+  branch_created: 'worktree',
+  branch_switched: 'worktree',
+  issue_linked: 'issues',
+  issue_unlinked: 'issues',
+  pr_created: 'pullRequests',
+  pr_ready: 'pullRequests',
+  pr_approved: 'pullRequests',
+  pr_merged: 'pullRequests',
+  pr_closed: 'pullRequests',
+  workflow_started: 'workflows',
+  workflow_discarded: 'workflows',
+  workflow_deleted: 'workflows',
+  decisions_changed: 'decisions',
+};
+
+type EntryParams = {
+  readonly entry: TimelineTopLevelEntry;
+};
+
+export const activityCategoryOf = ({ entry }: EntryParams): ActivityCategory | null => {
+  if (entry.kind === 'event') {
+    return CATEGORY_BY_EVENT_KIND[entry.event.kind];
+  }
+  if (entry.kind === 'run') {
+    return 'workflows';
+  }
+  if (entry.kind === 'agent') {
+    return entry.agentKind === 'resolver' ? 'resolver' : 'agents';
+  }
+  if (entry.kind === 'issue') {
+    return 'issues';
+  }
+  if (entry.kind === 'branch') {
+    return 'worktree';
+  }
+  return null;
+};
+
+type FilterParams = {
+  readonly entries: ReadonlyArray<TimelineTopLevelEntry>;
+  readonly filter: ActivityFilter;
+};
+
+export const filterTimelineEntries = ({
+  entries,
+  filter,
+}: FilterParams): ReadonlyArray<TimelineTopLevelEntry> =>
+  entries.filter((entry) => {
+    const category = activityCategoryOf({ entry });
+    return category == null || filter[category];
+  });
+
+type ParseParams = {
+  readonly raw: string | null;
+};
+
+export const parseActivityFilter = ({ raw }: ParseParams): ActivityFilter => {
+  if (raw == null || raw.length === 0) {
+    return DEFAULT_ACTIVITY_FILTER;
+  }
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      return DEFAULT_ACTIVITY_FILTER;
+    }
+    const source = parsed as Readonly<Record<string, unknown>>;
+    const entries = ACTIVITY_CATEGORIES.map((category) => {
+      const value = source[category];
+      return [category, typeof value === 'boolean' ? value : DEFAULT_ACTIVITY_FILTER[category]];
+    });
+    return Object.fromEntries(entries) as ActivityFilter;
+  } catch {
+    return DEFAULT_ACTIVITY_FILTER;
+  }
+};
+
+export const readActivityFilter = (): ActivityFilter => {
+  if (typeof localStorage === 'undefined') {
+    return DEFAULT_ACTIVITY_FILTER;
+  }
+  try {
+    return parseActivityFilter({ raw: localStorage.getItem(ACTIVITY_FILTER_STORAGE_KEY) });
+  } catch {
+    return DEFAULT_ACTIVITY_FILTER;
+  }
+};
+
+type WriteParams = {
+  readonly filter: ActivityFilter;
+};
+
+export const writeActivityFilter = ({ filter }: WriteParams): void => {
+  if (typeof localStorage === 'undefined') {
+    return;
+  }
+  try {
+    localStorage.setItem(ACTIVITY_FILTER_STORAGE_KEY, JSON.stringify(filter));
+  } catch {
+    return;
+  }
+};

--- a/apps/desktop/src/features/session/timeline/buildTimelineGroups.test.ts
+++ b/apps/desktop/src/features/session/timeline/buildTimelineGroups.test.ts
@@ -5,6 +5,11 @@ import type {
   IsoDateTime,
   OpenQuestion,
   OpenQuestionId,
+  SessionEvent,
+  SessionEventId,
+  SessionEventKind,
+  SessionEventPayload,
+  SessionExternalTask,
   SessionId,
   StepId,
   Workflow,
@@ -13,6 +18,7 @@ import type {
   WorkflowRunId,
   WorkspaceId,
 } from '@goodboy/types';
+import type { SessionWorktree } from '@goodboy/db';
 import { buildTimelineGroups } from './buildTimelineGroups';
 
 type TypedStringParams = {
@@ -128,16 +134,27 @@ type BuildParams = {
   readonly agents: ReadonlyArray<Agent>;
   readonly workflows?: ReadonlyArray<ReturnType<typeof attachedWorkflow>>;
   readonly questions?: ReadonlyArray<OpenQuestion>;
+  readonly externalTasks?: ReadonlyArray<SessionExternalTask>;
+  readonly worktrees?: ReadonlyArray<SessionWorktree>;
+  readonly events?: ReadonlyArray<SessionEvent>;
 };
 
-const build = ({ agents, workflows = [], questions = [] }: BuildParams) =>
+const build = ({
+  agents,
+  workflows = [],
+  questions = [],
+  externalTasks = [],
+  worktrees = [],
+  events = [],
+}: BuildParams) =>
   buildTimelineGroups({
     agents,
     workflows,
     plans: [],
-    externalTasks: [],
+    externalTasks,
     questions,
-    worktrees: [],
+    worktrees,
+    events,
     agentKindOverride: {},
   });
 
@@ -373,5 +390,182 @@ describe('buildTimelineGroups', () => {
     expect(agentEntry?.kind === 'agent' ? agentEntry.answers.map((item) => item.id) : []).toEqual([
       'answer:agent:first:direct',
     ]);
+  });
+});
+
+type EventParams = {
+  readonly id: string;
+  readonly kind: SessionEventKind;
+  readonly at: string;
+  readonly payload?: SessionEventPayload;
+};
+
+const sessionEvent = ({ id, kind, at, payload }: EventParams): SessionEvent => ({
+  id: typedString<SessionEventId>({ value: id }),
+  sessionId: SESSION_ID,
+  kind,
+  payload: payload ?? null,
+  createdAt: typedString<IsoDateTime>({ value: at }),
+});
+
+const worktree = ({ branch }: { readonly branch: string }): SessionWorktree => ({
+  id: 'wt-1',
+  sessionId: SESSION_ID,
+  worktreePath: '/repo/.goodboy/worktrees/gb-trace',
+  branch,
+  parallelIndex: 0,
+  createdAt: Date.parse('2026-08-17T07:00:00Z'),
+});
+
+const externalTask = ({ url }: { readonly url: string }): SessionExternalTask => ({
+  sessionId: SESSION_ID,
+  provider: 'linear',
+  externalId: 'lin-1',
+  identifier: 'GB-1',
+  url,
+  title: 'Persist the trace',
+  createdAt: typedString<IsoDateTime>({ value: '2026-08-17T07:30:00Z' }),
+});
+
+describe('buildTimelineGroups, session events', () => {
+  it('turns every event into its own top level entry', () => {
+    const model = build({
+      agents: [],
+      events: [
+        sessionEvent({ id: 'ev-1', kind: 'pr_merged', at: '2026-08-17T12:00:00Z' }),
+        sessionEvent({ id: 'ev-2', kind: 'branch_switched', at: '2026-08-17T11:00:00Z' }),
+      ],
+    });
+
+    expect(model.entries.map((entry) => entry.id)).toEqual(['event:ev-1', 'event:ev-2']);
+  });
+
+  it('drops the derived branch row once a branch event exists', () => {
+    const model = build({
+      agents: [],
+      worktrees: [worktree({ branch: 'ak/feat' })],
+      events: [
+        sessionEvent({
+          id: 'ev-1',
+          kind: 'branch_created',
+          at: '2026-08-17T07:00:00Z',
+          payload: { branch: 'ak/feat' },
+        }),
+      ],
+    });
+
+    expect(model.entries.map((entry) => entry.kind)).toEqual(['event']);
+  });
+
+  it('keeps the derived branch row for a session recorded before the event log', () => {
+    const model = build({
+      agents: [],
+      worktrees: [worktree({ branch: 'ak/feat' })],
+      events: [sessionEvent({ id: 'ev-1', kind: 'pr_merged', at: '2026-08-17T12:00:00Z' })],
+    });
+
+    expect(model.entries.some((entry) => entry.kind === 'branch')).toBe(true);
+  });
+
+  it('drops the derived issue row once the link event carries the same url', () => {
+    const url = 'https://linear.app/goodboy/issue/GB-1';
+    const model = build({
+      agents: [],
+      externalTasks: [externalTask({ url })],
+      events: [
+        sessionEvent({
+          id: 'ev-1',
+          kind: 'issue_linked',
+          at: '2026-08-17T07:30:00Z',
+          payload: { url, identifier: 'GB-1', title: 'Persist the trace' },
+        }),
+      ],
+    });
+
+    expect(model.entries.map((entry) => entry.kind)).toEqual(['event']);
+  });
+
+  it('keeps the derived issue row when the event points at another issue', () => {
+    const model = build({
+      agents: [],
+      externalTasks: [externalTask({ url: 'https://linear.app/goodboy/issue/GB-1' })],
+      events: [
+        sessionEvent({
+          id: 'ev-1',
+          kind: 'issue_linked',
+          at: '2026-08-17T07:30:00Z',
+          payload: { url: 'https://linear.app/goodboy/issue/GB-2' },
+        }),
+      ],
+    });
+
+    expect(model.entries.filter((entry) => entry.kind === 'issue')).toHaveLength(1);
+  });
+});
+
+describe('buildTimelineGroups, agent chains', () => {
+  it('marks a standalone agent with descendants as a chain and names the path', () => {
+    const model = build({
+      agents: [
+        agent({ id: 'planner', ordinal: 0, startedAt: '2026-08-17T09:00:00Z' }),
+        agent({
+          id: 'implementer',
+          ordinal: 1,
+          parentAgentId: 'planner',
+          startedAt: '2026-08-17T09:30:00Z',
+        }),
+      ],
+    });
+    const root = model.entries.find((entry) => entry.kind === 'agent');
+
+    expect(root?.kind === 'agent' ? root.chain?.label : null).toBe('planner → implementer');
+    expect(root?.kind === 'agent' ? root.chain?.identity.index : null).toEqual(expect.any(Number));
+  });
+
+  it('leaves a childless agent without a chain', () => {
+    const model = build({
+      agents: [agent({ id: 'solo', startedAt: '2026-08-17T09:00:00Z' })],
+    });
+    const root = model.entries.find((entry) => entry.kind === 'agent');
+
+    expect(root?.kind === 'agent' ? root.chain : 'missing').toBeNull();
+  });
+
+  it('leaves a workflow step without a chain so the run keeps its own grammar', () => {
+    const model = build({
+      workflows: [attachedWorkflow()],
+      agents: [
+        agent({ id: 'step', startedAt: '2026-08-17T09:00:00Z', workflowRunId: WORKFLOW_RUN_ID }),
+        agent({
+          id: 'child',
+          ordinal: 1,
+          parentAgentId: 'step',
+          startedAt: '2026-08-17T09:10:00Z',
+        }),
+      ],
+    });
+    const run = model.entries.find((entry) => entry.kind === 'run');
+    const step = run?.kind === 'run' ? run.children[0] : null;
+
+    expect(step?.kind === 'agent' ? step.chain : 'missing').toBeNull();
+  });
+
+  it('truncates a chain longer than three agents', () => {
+    const model = build({
+      agents: [
+        agent({ id: 'one', ordinal: 0, startedAt: '2026-08-17T09:00:00Z' }),
+        agent({ id: 'two', ordinal: 1, parentAgentId: 'one', startedAt: '2026-08-17T09:10:00Z' }),
+        agent({ id: 'three', ordinal: 2, parentAgentId: 'two', startedAt: '2026-08-17T09:20:00Z' }),
+        agent({
+          id: 'four',
+          ordinal: 3,
+          parentAgentId: 'three',
+          startedAt: '2026-08-17T09:30:00Z',
+        }),
+      ],
+    });
+    const root = model.entries.find((entry) => entry.kind === 'agent');
+
+    expect(root?.kind === 'agent' ? root.chain?.label : null).toBe('one → two → three → …');
   });
 });

--- a/apps/desktop/src/features/session/timeline/buildTimelineGroups.ts
+++ b/apps/desktop/src/features/session/timeline/buildTimelineGroups.ts
@@ -3,6 +3,7 @@ import type {
   Agent,
   OpenQuestion,
   PlanWithCount,
+  SessionEvent,
   SessionExternalTask,
   Workflow,
   WorkflowRun,
@@ -11,6 +12,11 @@ import { classifyAgent, type AgentKind } from '../agent-kind';
 import { attachedQuestionsFor } from './attachedQuestions';
 import { resolveAgentCreation, type AgentCreation } from './agentCreation';
 import { runIdentity, type RunIdentity } from './runIdentity';
+
+export type TimelineChain = {
+  readonly identity: RunIdentity;
+  readonly label: string;
+};
 
 export type TimelineAgentEntry = {
   readonly kind: 'agent';
@@ -25,6 +31,7 @@ export type TimelineAgentEntry = {
   readonly children: ReadonlyArray<TimelineAgentEntry>;
   readonly answers: ReadonlyArray<TimelineAnswerEntry>;
   readonly hasDuration: boolean;
+  readonly chain: TimelineChain | null;
 };
 
 export type TimelinePlanEntry = {
@@ -46,6 +53,13 @@ export type TimelineBranchEntry = {
   readonly id: string;
   readonly at: string;
   readonly worktree: SessionWorktree;
+};
+
+export type TimelineEventEntry = {
+  readonly kind: 'event';
+  readonly id: string;
+  readonly at: string;
+  readonly event: SessionEvent;
 };
 
 export type TimelineAnswerEntry = {
@@ -73,6 +87,7 @@ export type TimelineTopLevelEntry =
   | TimelinePlanEntry
   | TimelineIssueEntry
   | TimelineBranchEntry
+  | TimelineEventEntry
   | TimelineRunEntry;
 
 export type TimelineModel = {
@@ -91,6 +106,7 @@ type Params = {
   readonly externalTasks: ReadonlyArray<SessionExternalTask>;
   readonly questions: ReadonlyArray<OpenQuestion>;
   readonly worktrees: ReadonlyArray<SessionWorktree>;
+  readonly events: ReadonlyArray<SessionEvent>;
   readonly agentKindOverride: Readonly<Record<string, AgentKind>>;
 };
 
@@ -130,6 +146,23 @@ const buildAnswers = ({
     ];
   });
 
+const CHAIN_LABEL_LIMIT = 3;
+
+type ChainLabelParams = {
+  readonly entry: TimelineAgentEntry;
+};
+
+const chainLabelOf = ({ entry }: ChainLabelParams): string => {
+  const names: string[] = [];
+  let node: TimelineAgentEntry | undefined = entry;
+  while (node !== undefined && names.length < CHAIN_LABEL_LIMIT) {
+    names.push(node.agent.name);
+    node = node.children[node.children.length - 1];
+  }
+  const suffix = node === undefined ? '' : ' → …';
+  return `${names.join(' → ')}${suffix}`;
+};
+
 const compareNewestFirst = (first: SortableEntry, second: SortableEntry): number => {
   if (first.at != null && second.at != null && first.at !== second.at) {
     return second.at.localeCompare(first.at);
@@ -150,6 +183,7 @@ export const buildTimelineGroups = ({
   externalTasks,
   questions,
   worktrees,
+  events,
   agentKindOverride,
 }: Params): TimelineModel => {
   const liveAgents = agents.filter((agent) => agent.deletedAt == null);
@@ -209,6 +243,7 @@ export const buildTimelineGroups = ({
       children,
       answers: buildAnswers({ questions: attachedQuestions, parentId: entryId }),
       hasDuration: agent.startedAt != null && agent.completedAt != null,
+      chain: null,
     };
   };
 
@@ -260,7 +295,18 @@ export const buildTimelineGroups = ({
         agent.parentAgentId == null &&
         !(agent.workflowRunId != null && agent.stepId != null && runIds.has(agent.workflowRunId)),
     )
-    .map((agent) => buildAgentEntry({ agent, stepLabel: null }));
+    .map((agent) => buildAgentEntry({ agent, stepLabel: null }))
+    .map((entry) =>
+      entry.children.length === 0
+        ? entry
+        : {
+            ...entry,
+            chain: {
+              identity: runIdentity({ runId: entry.agent.id }),
+              label: chainLabelOf({ entry }),
+            },
+          },
+    );
   const standalonePlans: ReadonlyArray<TimelinePlanEntry> = plans
     .filter((plan) => !groupedPlanIds.has(plan.id))
     .map((plan) => ({ kind: 'plan', id: `plan:${plan.id}`, at: plan.createdAt, plan }));
@@ -270,19 +316,35 @@ export const buildTimelineGroups = ({
     at: task.createdAt,
     task,
   }));
-  const branches: ReadonlyArray<TimelineBranchEntry> = worktrees.map((worktree) => ({
-    kind: 'branch',
-    id: `branch:${worktree.id}`,
-    at: timestampForWorktree({ worktree }),
-    worktree,
+  const linkedIssueUrls = new Set(
+    events.flatMap((event) =>
+      event.kind === 'issue_linked' && event.payload?.url != null ? [event.payload.url] : [],
+    ),
+  );
+  const visibleIssues = issues.filter((entry) => !linkedIssueUrls.has(entry.task.url));
+  const hasBranchEvent = events.some((event) => event.kind === 'branch_created');
+  const branches: ReadonlyArray<TimelineBranchEntry> = hasBranchEvent
+    ? []
+    : worktrees.map((worktree) => ({
+        kind: 'branch',
+        id: `branch:${worktree.id}`,
+        at: timestampForWorktree({ worktree }),
+        worktree,
+      }));
+  const eventEntries: ReadonlyArray<TimelineEventEntry> = events.map((event) => ({
+    kind: 'event',
+    id: `event:${event.id}`,
+    at: event.createdAt,
+    event,
   }));
 
   const entries = [
     ...runEntries,
     ...standaloneAgents,
     ...standalonePlans,
-    ...issues,
+    ...visibleIssues,
     ...branches,
+    ...eventEntries,
   ].sort((first, second) =>
     compareNewestFirst(
       { at: first.at, ordinal: first.kind === 'agent' ? first.ordinal : 0, id: first.id },

--- a/apps/desktop/src/features/session/timeline/buildTimelineStream.test.ts
+++ b/apps/desktop/src/features/session/timeline/buildTimelineStream.test.ts
@@ -3,6 +3,9 @@ import type {
   Agent,
   AgentId,
   IsoDateTime,
+  SessionEvent,
+  SessionEventId,
+  SessionEventKind,
   SessionId,
   StepId,
   Workflow,
@@ -142,9 +145,15 @@ type StreamParams = {
   readonly agents: ReadonlyArray<Agent>;
   readonly workflows?: ReadonlyArray<ReturnType<typeof attachedWorkflow>>;
   readonly unreadAgentIds?: ReadonlySet<string>;
+  readonly events?: ReadonlyArray<SessionEvent>;
 };
 
-const stream = ({ agents, workflows = [], unreadAgentIds = new Set() }: StreamParams) =>
+const stream = ({
+  agents,
+  workflows = [],
+  unreadAgentIds = new Set(),
+  events = [],
+}: StreamParams) =>
   buildTimelineStream({
     entries: buildTimelineGroups({
       agents,
@@ -153,6 +162,7 @@ const stream = ({ agents, workflows = [], unreadAgentIds = new Set() }: StreamPa
       externalTasks: [],
       questions: [],
       worktrees: [],
+      events,
       agentKindOverride: {},
     }).entries,
     unreadAgentIds,
@@ -750,5 +760,68 @@ describe('buildTimelineStream', () => {
       'agent:step-one:sibling',
       'run:run-1:sibling',
     ]);
+  });
+});
+
+type SessionEventParams = {
+  readonly id: string;
+  readonly kind: SessionEventKind;
+  readonly at: string;
+};
+
+const sessionEvent = ({ id, kind, at }: SessionEventParams): SessionEvent => ({
+  id: typedString<SessionEventId>({ value: id }),
+  sessionId: SESSION_ID,
+  kind,
+  payload: null,
+  createdAt: typedString<IsoDateTime>({ value: at }),
+});
+
+describe('buildTimelineStream, session events', () => {
+  it('keeps the worktree row at the bottom when creation events share an instant', () => {
+    const at = localIso({ day: 18, hour: 8 });
+    const result = stream({
+      agents: [],
+      events: [
+        sessionEvent({ id: 'ev-branch', kind: 'branch_created', at }),
+        sessionEvent({ id: 'ev-worktree', kind: 'worktree_created', at }),
+      ],
+    });
+    const rows = result.items.flatMap((item) => (item.kind === 'row' ? [item.id] : []));
+
+    expect(rows).toEqual(['event:ev-branch', 'event:ev-worktree']);
+  });
+
+  it('orders the rest of the trace newest first', () => {
+    const result = stream({
+      agents: [],
+      events: [
+        sessionEvent({
+          id: 'ev-worktree',
+          kind: 'worktree_created',
+          at: localIso({ day: 18, hour: 8 }),
+        }),
+        sessionEvent({ id: 'ev-merge', kind: 'pr_merged', at: localIso({ day: 18, hour: 12 }) }),
+      ],
+    });
+    const rows = result.items.flatMap((item) => (item.kind === 'row' ? [item.id] : []));
+
+    expect(rows).toEqual(['event:ev-merge', 'event:ev-worktree']);
+  });
+
+  it('gives a chained agent group a colored lane', () => {
+    const result = stream({
+      agents: [
+        agent({ id: 'planner', ordinal: 0, startedAt: localIso({ day: 18, hour: 9 }) }),
+        agent({
+          id: 'implementer',
+          ordinal: 1,
+          parentAgentId: 'planner',
+          startedAt: localIso({ day: 18, hour: 10 }),
+        }),
+      ],
+    });
+
+    expect(result.groups.map((group) => group.identityIndex)).toEqual([expect.any(Number)]);
   });
 });

--- a/apps/desktop/src/features/session/timeline/buildTimelineStream.ts
+++ b/apps/desktop/src/features/session/timeline/buildTimelineStream.ts
@@ -1,8 +1,9 @@
-import type { Agent } from '@goodboy/types';
+import type { Agent, SessionEventKind } from '@goodboy/types';
 import type {
   TimelineAgentEntry,
   TimelineAnswerEntry,
   TimelineBranchEntry,
+  TimelineEventEntry,
   TimelineIssueEntry,
   TimelinePlanEntry,
   TimelineRunEntry,
@@ -25,6 +26,7 @@ export type TimelineStreamEntry =
   | TimelinePlanEntry
   | TimelineIssueEntry
   | TimelineBranchEntry
+  | TimelineEventEntry
   | TimelineAnswerEntry;
 
 type StreamRail = {
@@ -115,6 +117,16 @@ type DraftDay = {
 };
 
 type Draft = DraftRow | DraftCluster | DraftDay;
+
+const eventRank = ({ kind }: { readonly kind: SessionEventKind }): number => {
+  if (kind === 'worktree_created') {
+    return -2;
+  }
+  if (kind === 'branch_created') {
+    return -1;
+  }
+  return 0;
+};
 
 const laneIdOf = ({ entryId }: { readonly entryId: string }): string => `lane:${entryId}`;
 
@@ -438,7 +450,7 @@ export const buildTimelineStream = ({
       emitAgent({
         entry,
         grade: 'entry',
-        identity: null,
+        identity: entry.chain?.identity ?? null,
         familyId: entry.id,
         groupId: null,
         context,
@@ -455,7 +467,7 @@ export const buildTimelineStream = ({
       familyId: null,
       groupId: null,
       ordinal: null,
-      sortOrdinal: 0,
+      sortOrdinal: entry.kind === 'event' ? eventRank({ kind: entry.event.kind }) : 0,
       markerState: 'done',
       hasUnread: false,
       isPending: false,

--- a/apps/desktop/src/features/session/timeline/sessionEventPresentation.test.ts
+++ b/apps/desktop/src/features/session/timeline/sessionEventPresentation.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import type { SessionEvent, SessionEventKind, SessionEventPayload } from '@goodboy/types';
+import { SESSION_EVENT_KINDS } from '@goodboy/types';
+import {
+  sessionEventEmphasis,
+  sessionEventGlyph,
+  sessionEventTitle,
+} from './sessionEventPresentation';
+
+type MakeParams = {
+  readonly kind: SessionEventKind;
+  readonly payload?: SessionEventPayload;
+};
+
+const event = ({ kind, payload }: MakeParams): SessionEvent =>
+  ({
+    id: 'ev-1',
+    sessionId: 'session-1',
+    kind,
+    payload: payload ?? null,
+    createdAt: '2026-08-21T10:00:00.000Z',
+  }) as unknown as SessionEvent;
+
+describe('sessionEventTitle', () => {
+  it('shows the worktree path so it can be copied', () => {
+    expect(
+      sessionEventTitle({
+        event: event({ kind: 'worktree_created', payload: { worktreePath: '/repo/wt/gb-trace' } }),
+      }),
+    ).toBe('/repo/wt/gb-trace');
+  });
+
+  it('names both branches of a switch', () => {
+    expect(
+      sessionEventTitle({
+        event: event({ kind: 'branch_switched', payload: { from: 'main', to: 'ak/feat' } }),
+      }),
+    ).toBe('Branch switched: main → ak/feat');
+  });
+
+  it('reads an issue by identifier and title', () => {
+    expect(
+      sessionEventTitle({
+        event: event({
+          kind: 'issue_unlinked',
+          payload: { identifier: 'GB-1', title: 'Persist the trace' },
+        }),
+      }),
+    ).toBe('Unlinked GB-1: Persist the trace');
+  });
+
+  it('reads a pull request by number', () => {
+    expect(
+      sessionEventTitle({ event: event({ kind: 'pr_merged', payload: { number: 42 } }) }),
+    ).toBe('#42 merged');
+  });
+
+  it('counts decisions on both sides', () => {
+    expect(
+      sessionEventTitle({
+        event: event({ kind: 'decisions_changed', payload: { added: 3, removed: 1 } }),
+      }),
+    ).toBe('3 decisions added, 1 removed');
+  });
+
+  it('keeps a single decision singular', () => {
+    expect(
+      sessionEventTitle({
+        event: event({ kind: 'decisions_changed', payload: { added: 1, removed: 0 } }),
+      }),
+    ).toBe('1 decision added, 0 removed');
+  });
+
+  it('stays readable when the payload is missing', () => {
+    for (const kind of SESSION_EVENT_KINDS) {
+      expect(sessionEventTitle({ event: event({ kind }) }).length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('sessionEventEmphasis', () => {
+  it('celebrates an approval and a merge', () => {
+    expect(sessionEventEmphasis({ kind: 'pr_approved' })).toBe('success');
+    expect(sessionEventEmphasis({ kind: 'pr_merged' })).toBe('success');
+  });
+
+  it('dims what was taken away', () => {
+    expect(sessionEventEmphasis({ kind: 'issue_unlinked' })).toBe('muted');
+    expect(sessionEventEmphasis({ kind: 'workflow_discarded' })).toBe('muted');
+    expect(sessionEventEmphasis({ kind: 'workflow_deleted' })).toBe('muted');
+    expect(sessionEventEmphasis({ kind: 'decisions_changed' })).toBe('muted');
+  });
+});
+
+describe('sessionEventGlyph', () => {
+  it('gives every kind a glyph', () => {
+    for (const kind of SESSION_EVENT_KINDS) {
+      expect(sessionEventGlyph({ kind }).label.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/apps/desktop/src/features/session/timeline/sessionEventPresentation.ts
+++ b/apps/desktop/src/features/session/timeline/sessionEventPresentation.ts
@@ -1,0 +1,131 @@
+import {
+  FolderPlus,
+  GitBranch,
+  GitMerge,
+  GitPullRequest,
+  GitPullRequestClosed,
+  Link2,
+  Link2Off,
+  Trash2,
+} from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+import type { SessionEvent, SessionEventKind, SessionEventPayload } from '@goodboy/types';
+import type { Tone } from '@goodboy/ui';
+import { CONCEPT_ICONS } from '../../../shared/components/conceptIcons';
+
+export type SessionEventEmphasis = 'plain' | 'muted' | 'success';
+
+const EMPHASIS: Record<SessionEventKind, SessionEventEmphasis> = {
+  worktree_created: 'plain',
+  branch_created: 'plain',
+  branch_switched: 'plain',
+  issue_linked: 'plain',
+  issue_unlinked: 'muted',
+  pr_created: 'plain',
+  pr_ready: 'plain',
+  pr_approved: 'success',
+  pr_merged: 'success',
+  pr_closed: 'muted',
+  workflow_started: 'plain',
+  workflow_discarded: 'muted',
+  workflow_deleted: 'muted',
+  decisions_changed: 'muted',
+};
+
+export type SessionEventGlyph = {
+  readonly icon: LucideIcon;
+  readonly tone: Tone;
+  readonly label: string;
+};
+
+const GLYPH: Record<SessionEventKind, SessionEventGlyph> = {
+  worktree_created: { icon: FolderPlus, tone: 'neutral', label: 'Worktree' },
+  branch_created: { icon: GitBranch, tone: 'info', label: 'Branch' },
+  branch_switched: { icon: GitBranch, tone: 'info', label: 'Branch' },
+  issue_linked: { icon: Link2, tone: 'neutral', label: 'Issue' },
+  issue_unlinked: { icon: Link2Off, tone: 'neutral', label: 'Issue' },
+  pr_created: { icon: GitPullRequest, tone: 'primary', label: 'Pull request' },
+  pr_ready: { icon: GitPullRequest, tone: 'primary', label: 'Pull request' },
+  pr_approved: { icon: CONCEPT_ICONS.checks, tone: 'success', label: 'Pull request' },
+  pr_merged: { icon: GitMerge, tone: 'success', label: 'Pull request' },
+  pr_closed: { icon: GitPullRequestClosed, tone: 'neutral', label: 'Pull request' },
+  workflow_started: { icon: CONCEPT_ICONS.workflows, tone: 'accent', label: 'Workflow' },
+  workflow_discarded: { icon: CONCEPT_ICONS.workflows, tone: 'neutral', label: 'Workflow' },
+  workflow_deleted: { icon: Trash2, tone: 'neutral', label: 'Workflow' },
+  decisions_changed: { icon: CONCEPT_ICONS.decisions, tone: 'neutral', label: 'Decisions' },
+};
+
+type PayloadParams = {
+  readonly payload: SessionEventPayload | null;
+};
+
+const issueLabel = ({ payload }: PayloadParams): string => {
+  const identifier = payload?.identifier ?? null;
+  const title = payload?.title ?? null;
+  if (identifier != null && title != null) {
+    return `${identifier}: ${title}`;
+  }
+  return identifier ?? title ?? 'an issue';
+};
+
+const prLabel = ({ payload }: PayloadParams): string =>
+  payload?.number == null ? 'Pull request' : `#${payload.number}`;
+
+const workflowLabel = ({ payload }: PayloadParams): string => payload?.workflowName ?? 'Workflow';
+
+const decisionCount = ({ count }: { readonly count: number }): string =>
+  count === 1 ? '1 decision' : `${count} decisions`;
+
+type TitleParams = {
+  readonly event: SessionEvent;
+};
+
+export const sessionEventTitle = ({ event }: TitleParams): string => {
+  const { payload } = event;
+  switch (event.kind) {
+    case 'worktree_created':
+      return payload?.worktreePath ?? 'Worktree created';
+    case 'branch_created':
+      return payload?.branch == null ? 'Branch created' : `Branch created: ${payload.branch}`;
+    case 'branch_switched':
+      return payload?.from == null || payload.to == null
+        ? 'Branch switched'
+        : `Branch switched: ${payload.from} → ${payload.to}`;
+    case 'issue_linked':
+      return `Linked ${issueLabel({ payload })}`;
+    case 'issue_unlinked':
+      return `Unlinked ${issueLabel({ payload })}`;
+    case 'pr_created':
+      return payload?.title == null
+        ? `Opened ${prLabel({ payload })}`
+        : `Opened ${prLabel({ payload })}: ${payload.title}`;
+    case 'pr_ready':
+      return `${prLabel({ payload })} ready for review`;
+    case 'pr_approved':
+      return `${prLabel({ payload })} approved`;
+    case 'pr_merged':
+      return `${prLabel({ payload })} merged`;
+    case 'pr_closed':
+      return `${prLabel({ payload })} closed`;
+    case 'workflow_started':
+      return `${workflowLabel({ payload })} started`;
+    case 'workflow_discarded':
+      return `${workflowLabel({ payload })} discarded`;
+    case 'workflow_deleted':
+      return `${workflowLabel({ payload })} deleted`;
+    case 'decisions_changed':
+      return `${decisionCount({ count: payload?.added ?? 0 })} added, ${payload?.removed ?? 0} removed`;
+    default: {
+      const exhaustive: never = event.kind;
+      return exhaustive;
+    }
+  }
+};
+
+type KindParams = {
+  readonly kind: SessionEventKind;
+};
+
+export const sessionEventEmphasis = ({ kind }: KindParams): SessionEventEmphasis => EMPHASIS[kind];
+
+export const sessionEventGlyph = ({ kind }: KindParams): SessionEventGlyph => GLYPH[kind];


### PR DESCRIPTION
Stacked on #1510.

## What

The activity feed reads the event log and becomes a full trace instead of a partial derivation.

**Event rows.** `buildTimelineGroups` takes the session's events and merges them into the stream as top level entries. Agents, runs and plans stay derived exactly as before.

- `worktree_created` opens the trace at the bottom, showing the worktree path in mono with a `Copy path` action on the row.
- `branch_created` replaces the derived branch row when an event exists. A session created before this feature keeps the derived row, so nothing disappears from an existing feed.
- `issue_linked` replaces the derived issue row for the same url; every other linked issue keeps its derived row.
- `pr_approved` and `pr_merged` read in the success tone. `issue_unlinked`, `pr_closed`, `workflow_discarded`, `workflow_deleted` and `decisions_changed` read dimmed.
- `decisions_changed` collapses into one row: "3 decisions added, 1 removed".

**Agent chains.** A standalone agent with descendants renders as a group with a colored lane, reusing the rail and lane geometry the workflow runs already use, but with its own grammar: a `Chain` eyebrow rather than a workflow name, no stepper or step count, and the path of names as the label (`planner → implementer`, truncated past three). The chain is derived purely from `parentAgentId`; a workflow step never becomes one.

**Filter.** A filter icon on the Activity header opens a checkbox popover over seven categories: worktree and branch, issues, pull requests, workflows, agents, resolver, decisions. Enabled categories persist under `goodboy:activity-filter`, defaulting to everything on except decisions. The count of hidden categories sits next to the icon so a filtered feed never looks empty by accident. Benchmark: Linear's activity feed filter, which also filters by category from the feed header rather than a settings screen.

Filtering runs on top level entries before the stream is built, so the rail geometry stays consistent and hiding a workflow hides its steps with it.

## Notes and deviations

- The copy affordance is the row's action slot, not a chip inside the label. The label already sits inside the row's own `<button>`, and a button inside a button is invalid markup. It keeps `useCopyLink` and the same success and failure toasts as `BranchChip`.
- Event rows navigate to the lens that owns the fact: worktree and branch to files, pull requests to the PR lens, workflows to workflows, decisions to decisions, issues back to the overview where linked work lives.
- Plan and answer rows belong to no filter category and are always shown.

## Test plan

- `pnpm turbo run typecheck` green across all 5 packages.
- `apps/desktop` `src/features` + `src/__tests__`: 506 files / 4433 tests pass, including new suites for `activityFilter` and `sessionEventPresentation` and new cases in `buildTimelineGroups` and `buildTimelineStream` covering event entries, both suppression rules, the pre-event fallback, chain detection and label truncation, and the worktree row staying at the bottom when two creation events share an instant.
- `apps/desktop` `src/store`: 134 files / 1269 tests pass.
- `pnpm knip --include files,duplicates,unlisted` clean.
- Not verified in a running app: the desktop shell needs a real Tauri database, so the rendering was covered by unit tests rather than by launching it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
