### PR TITLE
fix(desktop): pick goodboy-desktop as the default run target

### DIFF
--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 repository = "https://github.com/akhayam99/goodboy"
 edition = "2021"
 rust-version = "1.77.2"
+default-run = "goodboy-desktop"
 
 [lib]
 name = "goodboy_desktop_lib"

--- a/apps/desktop/src-tauri/tests/cargo_manifest.rs
+++ b/apps/desktop/src-tauri/tests/cargo_manifest.rs
@@ -1,0 +1,76 @@
+use std::fs;
+use std::path::Path;
+
+fn package_field(manifest: &str, key: &str) -> Option<String> {
+    let mut in_package = false;
+    for line in manifest.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with('[') {
+            in_package = trimmed == "[package]";
+            continue;
+        }
+        if !in_package {
+            continue;
+        }
+        let Some((raw_key, raw_value)) = trimmed.split_once('=') else {
+            continue;
+        };
+        if raw_key.trim() != key {
+            continue;
+        }
+        return Some(raw_value.trim().trim_matches('"').to_string());
+    }
+    None
+}
+
+fn bin_target_names(root: &Path, package_name: &str) -> Vec<String> {
+    let mut names = Vec::new();
+    if root.join("src").join("main.rs").is_file() {
+        names.push(package_name.to_string());
+    }
+    let Ok(entries) = fs::read_dir(root.join("src").join("bin")) else {
+        return names;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|ext| ext.to_str()) != Some("rs") {
+            continue;
+        }
+        let Some(stem) = path.file_stem().and_then(|stem| stem.to_str()) else {
+            continue;
+        };
+        names.push(stem.to_string());
+    }
+    names.sort();
+    names
+}
+
+#[test]
+fn multiple_bin_targets_require_a_default_run() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let manifest = fs::read_to_string(root.join("Cargo.toml")).expect("Cargo.toml is readable");
+    let package_name = package_field(&manifest, "name").expect("[package] declares a name");
+    let bins = bin_target_names(root, &package_name);
+    assert!(
+        !bins.is_empty(),
+        "no bin target found, expected at least src/main.rs"
+    );
+
+    let default_run = package_field(&manifest, "default-run");
+    if bins.len() < 2 {
+        return;
+    }
+
+    let declared = default_run.unwrap_or_else(|| {
+        panic!(
+            "{} bin targets exist ({}) but [package] has no default-run, so `cargo run` and `tauri dev` cannot pick one",
+            bins.len(),
+            bins.join(", ")
+        )
+    });
+    assert!(
+        bins.contains(&declared),
+        "default-run points at {declared}, which is not one of the bin targets ({})",
+        bins.join(", ")
+    );
+}

--- a/apps/desktop/src-tauri/tests/cargo_manifest.rs
+++ b/apps/desktop/src-tauri/tests/cargo_manifest.rs
@@ -1,10 +1,50 @@
 use std::fs;
 use std::path::Path;
 
+fn strip_inline_comment(line: &str) -> &str {
+    let mut in_basic = false;
+    let mut in_literal = false;
+    let mut escaped = false;
+    for (index, character) in line.char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        if in_basic && character == '\\' {
+            escaped = true;
+            continue;
+        }
+        if character == '"' && !in_literal {
+            in_basic = !in_basic;
+            continue;
+        }
+        if character == '\'' && !in_basic {
+            in_literal = !in_literal;
+            continue;
+        }
+        if character == '#' && !in_basic && !in_literal {
+            return &line[..index];
+        }
+    }
+    line
+}
+
+fn unquote(value: &str) -> String {
+    let trimmed = value.trim();
+    for quote in ['"', '\''] {
+        let is_quoted =
+            trimmed.len() >= 2 && trimmed.starts_with(quote) && trimmed.ends_with(quote);
+        if is_quoted {
+            return trimmed[1..trimmed.len() - 1].to_string();
+        }
+    }
+    trimmed.to_string()
+}
+
 fn package_field(manifest: &str, key: &str) -> Option<String> {
     let mut in_package = false;
     for line in manifest.lines() {
-        let trimmed = line.trim();
+        let trimmed = strip_inline_comment(line).trim();
         if trimmed.starts_with('[') {
             in_package = trimmed == "[package]";
             continue;
@@ -18,7 +58,7 @@ fn package_field(manifest: &str, key: &str) -> Option<String> {
         if raw_key.trim() != key {
             continue;
         }
-        return Some(raw_value.trim().trim_matches('"').to_string());
+        return Some(unquote(raw_value));
     }
     None
 }
@@ -45,8 +85,32 @@ fn bin_target_names(root: &Path, package_name: &str) -> Vec<String> {
     names
 }
 
+fn check_default_run(bins: &[String], default_run: Option<&str>) -> Result<(), String> {
+    let Some(declared) = default_run else {
+        if bins.len() > 1 {
+            return Err(format!(
+                "{} bin targets exist ({}) but [package] has no default-run, so `cargo run` and `tauri dev` cannot pick one",
+                bins.len(),
+                bins.join(", ")
+            ));
+        }
+        return Ok(());
+    };
+    if bins.iter().any(|bin| bin == declared) {
+        return Ok(());
+    }
+    Err(format!(
+        "default-run points at {declared}, which is not one of the bin targets ({})",
+        bins.join(", ")
+    ))
+}
+
+fn owned(names: &[&str]) -> Vec<String> {
+    names.iter().map(|name| name.to_string()).collect()
+}
+
 #[test]
-fn multiple_bin_targets_require_a_default_run() {
+fn the_manifest_can_pick_a_bin_for_a_bare_cargo_run() {
     let root = Path::new(env!("CARGO_MANIFEST_DIR"));
     let manifest = fs::read_to_string(root.join("Cargo.toml")).expect("Cargo.toml is readable");
     let package_name = package_field(&manifest, "name").expect("[package] declares a name");
@@ -57,20 +121,73 @@ fn multiple_bin_targets_require_a_default_run() {
     );
 
     let default_run = package_field(&manifest, "default-run");
-    if bins.len() < 2 {
-        return;
+    if let Err(reason) = check_default_run(&bins, default_run.as_deref()) {
+        panic!("{reason}");
     }
+}
 
-    let declared = default_run.unwrap_or_else(|| {
-        panic!(
-            "{} bin targets exist ({}) but [package] has no default-run, so `cargo run` and `tauri dev` cannot pick one",
-            bins.len(),
-            bins.join(", ")
-        )
-    });
-    assert!(
-        bins.contains(&declared),
-        "default-run points at {declared}, which is not one of the bin targets ({})",
-        bins.join(", ")
+#[test]
+fn a_field_keeps_its_value_when_an_inline_comment_follows() {
+    let manifest = "[package]\ndefault-run = \"goodboy-desktop\" # pick the UI app\n";
+    assert_eq!(
+        package_field(manifest, "default-run").as_deref(),
+        Some("goodboy-desktop")
     );
+}
+
+#[test]
+fn a_single_quoted_field_reads_the_same_as_a_double_quoted_one() {
+    let manifest = "[package]\ndefault-run = 'goodboy-desktop'\n";
+    assert_eq!(
+        package_field(manifest, "default-run").as_deref(),
+        Some("goodboy-desktop")
+    );
+}
+
+#[test]
+fn a_hash_inside_a_quoted_value_is_not_a_comment() {
+    let manifest = "[package]\nname = \"good#boy\" # trailing\n";
+    assert_eq!(package_field(manifest, "name").as_deref(), Some("good#boy"));
+}
+
+#[test]
+fn a_commented_section_header_still_opens_the_package_table() {
+    let manifest = "[package] # the crate\ndefault-run = \"goodboy-desktop\"\n";
+    assert_eq!(
+        package_field(manifest, "default-run").as_deref(),
+        Some("goodboy-desktop")
+    );
+}
+
+#[test]
+fn a_field_outside_the_package_table_is_ignored() {
+    let manifest = "[dependencies]\ndefault-run = \"nope\"\n";
+    assert_eq!(package_field(manifest, "default-run"), None);
+}
+
+#[test]
+fn several_bins_without_a_default_run_are_rejected() {
+    let bins = owned(&["goodboy-desktop", "goodboy-query"]);
+    let reason = check_default_run(&bins, None).expect_err("two bins need a default-run");
+    assert!(reason.contains("no default-run"), "{reason}");
+}
+
+#[test]
+fn a_single_bin_without_a_default_run_is_accepted() {
+    let bins = owned(&["goodboy-desktop"]);
+    assert!(check_default_run(&bins, None).is_ok());
+}
+
+#[test]
+fn a_single_bin_with_an_unknown_default_run_is_rejected() {
+    let bins = owned(&["goodboy-desktop"]);
+    let reason = check_default_run(&bins, Some("goodboy-query"))
+        .expect_err("default-run must name a real bin target");
+    assert!(reason.contains("goodboy-query"), "{reason}");
+}
+
+#[test]
+fn several_bins_with_a_known_default_run_are_accepted() {
+    let bins = owned(&["goodboy-desktop", "goodboy-query"]);
+    assert!(check_default_run(&bins, Some("goodboy-desktop")).is_ok());
 }


### PR DESCRIPTION
## What

Add `default-run = "goodboy-desktop"` to the `[package]` section of the
Tauri crate, plus an integration test that keeps the key honest.

## Why

#1508 added a second bin target, `goodboy-query`, next to the existing
`goodboy-desktop`. `tauri dev` runs a bare `cargo run` with no `--bin`,
and with two candidates Cargo refuses to guess:

```
error: `cargo run` could not determine which binary to run. Use the `--bin` option to specify a binary, or the `default-run` manifest key.
available binaries: goodboy-desktop, goodboy-query
ELIFECYCLE Command failed with exit code 101.
```

So the dev loop has been dead since that merge. CI stayed green because
it only runs `cargo test --locked` and `tauri build`, and neither goes
near the bare `cargo run` path.

`Cargo.lock` needs no regeneration: `default-run` selects a target, it
does not touch the dependency graph. `tauri.conf.json` and the dev
script need nothing either.

## Guard

`apps/desktop/src-tauri/tests/cargo_manifest.rs` enumerates the bin
targets from the crate layout (`src/main.rs` plus `src/bin/*.rs`) and
fails when more than one exists without a `default-run`, or when
`default-run` names a target that is not there. No new dependency: it
reads the two manifest keys it needs with a small scanner.

It lives in `tests/` on purpose. `cargo test --locked` is the only
blocking step in `rust.yml` (fmt and clippy are `continue-on-error`), so
this is the cheapest place to catch a regression that a build-only
pipeline structurally cannot see. A dedicated CI step would have cost an
extra job for the same signal.

## Test plan

- `cargo test --locked --test cargo_manifest` passes.
- Same test with `default-run` removed fails with the message naming
  both bin targets, so the guard is not vacuous.
- `pnpm tauri dev` on this branch: Vite comes up on 1421, the
  `DevCommand` runs the same bare `cargo run` as before, compiles
  `goodboy-desktop`, and reports
  `Running .../target/debug/goodboy-desktop`. The process stays alive
  and the log has zero occurrences of `could not determine which
  binary`. Run against a scratch database via `GOODBOY_DB_FILE`.

Refs #1508

🤖 Generated with [Claude Code](https://claude.com/claude-code)
