### PR TITLE
refactor(desktop): serve the query client from the app binary

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -254,6 +254,7 @@ pub fn run() {
             turn::turn_spawn,
             turn::turn_cancel,
             turn::turn_list_live,
+            query_bridge::query_bridge_serving,
             attachment::attachment_write,
             attachment::attachment_read,
             attachment::attachment_delete,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -71,6 +71,10 @@ fn drain_child_processes(app: &tauri::AppHandle) {
     query_bridge::shutdown();
 }
 
+pub fn run_query_cli() -> Option<i32> {
+    query_bridge::run_cli()
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     boot_breadcrumb::record("process-start", Some("start"));

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -2,5 +2,8 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
+    if let Some(code) = goodboy_desktop_lib::run_query_cli() {
+        std::process::exit(code);
+    }
     goodboy_desktop_lib::run();
 }

--- a/apps/desktop/src-tauri/src/query_bridge/cli.rs
+++ b/apps/desktop/src-tauri/src/query_bridge/cli.rs
@@ -1,24 +1,26 @@
-#[path = "../query_bridge/protocol.rs"]
-mod protocol;
-
-use std::process::ExitCode;
-
-use protocol::{
-    help_text, parse_argv, ArgvOutcome, QueryRequest, QueryResponse, SOCKET_ENV, WORKSPACE_ENV,
+use super::protocol::{
+    self, help_text, parse_argv, ArgvOutcome, QueryRequest, QueryResponse, SOCKET_ENV, SUBCOMMAND,
+    WORKSPACE_ENV,
 };
 
-fn main() -> ExitCode {
-    let argv: Vec<String> = std::env::args().skip(1).collect();
+pub(crate) fn dispatch() -> Option<i32> {
+    let tokens: Vec<String> = std::env::args().skip(1).collect();
+    let argv = query_argv(&tokens)?;
     match run(&argv) {
         Ok(out) => {
             println!("{}", out);
-            ExitCode::SUCCESS
+            Some(0)
         }
         Err(error) => {
             eprintln!("{}", error);
-            ExitCode::FAILURE
+            Some(1)
         }
     }
+}
+
+fn query_argv(tokens: &[String]) -> Option<Vec<String>> {
+    let (first, rest) = tokens.split_first()?;
+    (first == SUBCOMMAND).then(|| rest.to_vec())
 }
 
 fn run(argv: &[String]) -> Result<String, String> {
@@ -156,6 +158,35 @@ fn render_entry(value: &serde_json::Value) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn owned(tokens: &[&str]) -> Vec<String> {
+        tokens.iter().map(|token| token.to_string()).collect()
+    }
+
+    #[test]
+    fn the_query_subcommand_hands_the_rest_of_argv_to_the_client() {
+        let tokens = owned(&["query", "linear", "issue", "ENG-1"]);
+
+        assert_eq!(
+            query_argv(&tokens),
+            Some(owned(&["linear", "issue", "ENG-1"]))
+        );
+    }
+
+    #[test]
+    fn a_bare_launch_or_another_first_token_leaves_the_app_alone() {
+        assert_eq!(query_argv(&[]), None);
+        assert_eq!(query_argv(&owned(&["--version"])), None);
+        assert_eq!(query_argv(&owned(&["linear", "issue"])), None);
+    }
+
+    #[test]
+    fn the_subcommand_with_nothing_after_it_asks_for_help() {
+        let argv = query_argv(&owned(&["query"])).expect("the query subcommand");
+
+        assert!(argv.is_empty());
+        assert!(run(&argv).expect("help").contains("usage:"));
+    }
 
     #[test]
     fn the_workspace_override_is_read_from_argv_in_both_spellings() {

--- a/apps/desktop/src-tauri/src/query_bridge/mod.rs
+++ b/apps/desktop/src-tauri/src/query_bridge/mod.rs
@@ -4,6 +4,7 @@ pub mod protocol;
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::OnceLock;
 
 use protocol::{QueryRequest, QueryResponse, BIN_ENV, SOCKET_ENV, SOCKET_FILE, WORKSPACE_ENV};
@@ -14,6 +15,7 @@ const APP_DIR: &str = ".goodboy";
 
 static SOCKET_PATH: OnceLock<Option<PathBuf>> = OnceLock::new();
 static EXE_PATH: OnceLock<Option<PathBuf>> = OnceLock::new();
+static LISTENING: AtomicBool = AtomicBool::new(false);
 
 fn socket_path() -> Option<&'static Path> {
     SOCKET_PATH
@@ -27,13 +29,26 @@ fn exe_path() -> Option<&'static Path> {
         .as_deref()
 }
 
+fn serving(is_listening: bool, socket: Option<&Path>) -> bool {
+    is_listening && socket.map(Path::exists).unwrap_or(false)
+}
+
+pub(crate) fn is_serving() -> bool {
+    serving(LISTENING.load(Ordering::SeqCst), socket_path())
+}
+
+#[tauri::command]
+pub fn query_bridge_serving() -> bool {
+    is_serving()
+}
+
 pub(crate) fn apply_env(command: &mut Command, workspace_id: Option<&str>) {
+    if !is_serving() {
+        return;
+    }
     let Some(socket) = socket_path() else {
         return;
     };
-    if !socket.exists() {
-        return;
-    }
     command.env(SOCKET_ENV, socket);
     if let Some(workspace_id) = workspace_id {
         command.env(WORKSPACE_ENV, workspace_id);
@@ -74,6 +89,7 @@ pub(crate) fn start(app: tauri::AppHandle) {
             let _ = std::fs::remove_file(path);
             return;
         }
+        LISTENING.store(true, Ordering::SeqCst);
         loop {
             let Ok((stream, _)) = listener.accept().await else {
                 break;
@@ -83,6 +99,7 @@ pub(crate) fn start(app: tauri::AppHandle) {
                 serve_connection(stream, app).await;
             });
         }
+        LISTENING.store(false, Ordering::SeqCst);
     });
 }
 
@@ -90,6 +107,7 @@ pub(crate) fn start(app: tauri::AppHandle) {
 pub(crate) fn start(_app: tauri::AppHandle) {}
 
 pub(crate) fn shutdown() {
+    LISTENING.store(false, Ordering::SeqCst);
     if let Some(path) = socket_path() {
         let _ = std::fs::remove_file(path);
     }
@@ -139,19 +157,54 @@ mod tests {
         assert!(path.ends_with(format!("{}/{}", APP_DIR, SOCKET_FILE)));
     }
 
-    #[test]
-    fn a_child_is_told_about_the_bridge_only_while_the_socket_is_live() {
+    fn injected_names(workspace_id: Option<&str>) -> Vec<String> {
         let mut command = Command::new("true");
-
-        apply_env(&mut command, Some("ws-1"));
-
-        let names: Vec<String> = command
+        apply_env(&mut command, workspace_id);
+        command
             .get_envs()
             .filter_map(|(key, _)| key.to_str().map(str::to_string))
-            .collect();
-        let live = socket_path().map(Path::exists).unwrap_or(false);
-        assert_eq!(names.contains(&SOCKET_ENV.to_string()), live);
-        assert_eq!(names.contains(&BIN_ENV.to_string()), live);
+            .collect()
+    }
+
+    #[test]
+    fn a_child_is_told_about_the_bridge_only_while_it_is_serving() {
+        let names = injected_names(Some("ws-1"));
+
+        assert_eq!(names.contains(&SOCKET_ENV.to_string()), is_serving());
+        assert_eq!(names.contains(&BIN_ENV.to_string()), is_serving());
+        assert_eq!(names.contains(&WORKSPACE_ENV.to_string()), is_serving());
+    }
+
+    #[test]
+    fn the_advertisement_and_the_injection_answer_to_one_predicate() {
+        let advertised = query_bridge_serving();
+
+        assert_eq!(advertised, is_serving());
+        assert_eq!(injected_names(Some("ws-1")).is_empty(), !advertised);
+    }
+
+    #[test]
+    fn a_socket_file_no_listener_owns_serves_nobody() {
+        assert!(!LISTENING.load(Ordering::SeqCst));
+
+        assert!(!is_serving());
+        assert!(!query_bridge_serving());
+        assert!(injected_names(Some("ws-1")).is_empty());
+    }
+
+    #[test]
+    fn serving_needs_a_live_listener_and_the_socket_file_it_bound() {
+        let file = std::env::temp_dir().join("goodboy-query-bridge-serving.probe");
+        std::fs::write(&file, b"").expect("a probe file");
+        let missing = std::env::temp_dir().join("goodboy-query-bridge-serving.absent");
+        let _ = std::fs::remove_file(&missing);
+
+        assert!(serving(true, Some(&file)));
+        assert!(!serving(false, Some(&file)));
+        assert!(!serving(true, Some(&missing)));
+        assert!(!serving(true, None));
+
+        let _ = std::fs::remove_file(&file);
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/query_bridge/mod.rs
+++ b/apps/desktop/src-tauri/src/query_bridge/mod.rs
@@ -1,3 +1,4 @@
+mod cli;
 mod dispatch;
 pub mod protocol;
 
@@ -5,12 +6,14 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::OnceLock;
 
-use protocol::{QueryRequest, QueryResponse, SOCKET_ENV, SOCKET_FILE, WORKSPACE_ENV};
+use protocol::{QueryRequest, QueryResponse, BIN_ENV, SOCKET_ENV, SOCKET_FILE, WORKSPACE_ENV};
+
+pub(crate) use cli::dispatch as run_cli;
 
 const APP_DIR: &str = ".goodboy";
 
 static SOCKET_PATH: OnceLock<Option<PathBuf>> = OnceLock::new();
-static CLI_DIR: OnceLock<Option<PathBuf>> = OnceLock::new();
+static EXE_PATH: OnceLock<Option<PathBuf>> = OnceLock::new();
 
 fn socket_path() -> Option<&'static Path> {
     SOCKET_PATH
@@ -18,14 +21,9 @@ fn socket_path() -> Option<&'static Path> {
         .as_deref()
 }
 
-fn cli_dir() -> Option<&'static Path> {
-    CLI_DIR
-        .get_or_init(|| {
-            let exe = std::env::current_exe().ok()?;
-            let dir = exe.parent()?;
-            let candidate = dir.join(protocol::BINARY_NAME);
-            candidate.is_file().then(|| dir.to_path_buf())
-        })
+fn exe_path() -> Option<&'static Path> {
+    EXE_PATH
+        .get_or_init(|| std::env::current_exe().ok())
         .as_deref()
 }
 
@@ -40,11 +38,8 @@ pub(crate) fn apply_env(command: &mut Command, workspace_id: Option<&str>) {
     if let Some(workspace_id) = workspace_id {
         command.env(WORKSPACE_ENV, workspace_id);
     }
-    if let Some(dir) = cli_dir() {
-        command.env(
-            "PATH",
-            format!("{}:{}", dir.display(), crate::path_env::resolved_path()),
-        );
+    if let Some(exe) = exe_path() {
+        command.env(BIN_ENV, exe);
     }
 }
 
@@ -156,6 +151,15 @@ mod tests {
             .collect();
         let live = socket_path().map(Path::exists).unwrap_or(false);
         assert_eq!(names.contains(&SOCKET_ENV.to_string()), live);
+        assert_eq!(names.contains(&BIN_ENV.to_string()), live);
+    }
+
+    #[test]
+    fn the_advertised_binary_is_the_running_executable_by_absolute_path() {
+        let exe = exe_path().expect("a current executable");
+
+        assert!(exe.is_absolute(), "{}", exe.display());
+        assert_eq!(exe, std::env::current_exe().expect("a current executable"));
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/query_bridge/protocol.rs
+++ b/apps/desktop/src-tauri/src/query_bridge/protocol.rs
@@ -7,7 +7,9 @@ use serde::{Deserialize, Serialize};
 pub const SOCKET_ENV: &str = "GOODBOY_QUERY_SOCKET";
 pub const WORKSPACE_ENV: &str = "GOODBOY_WORKSPACE_ID";
 pub const SOCKET_FILE: &str = "query.sock";
-pub const BINARY_NAME: &str = "goodboy-query";
+pub const BIN_ENV: &str = "GOODBOY_BIN";
+pub const SUBCOMMAND: &str = "query";
+pub const INVOCATION: &str = "\"$GOODBOY_BIN\" query";
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct QueryRequest {
@@ -509,7 +511,7 @@ pub fn providers() -> Vec<&'static str> {
 }
 
 pub fn usage(spec: &VerbSpec) -> String {
-    let mut line = format!("{} {} {}", BINARY_NAME, spec.provider, spec.verb);
+    let mut line = format!("{} {} {}", INVOCATION, spec.provider, spec.verb);
     for param in spec.params {
         let body = match param.kind {
             ParamKind::Flag => format!("--{}", param.name),
@@ -587,13 +589,13 @@ pub fn parse_argv(argv: &[String]) -> Result<ArgvOutcome, String> {
     let Some(verb) = positional.get(1) else {
         return Err(format!(
             "missing verb. try: {} {} --help",
-            BINARY_NAME, provider
+            INVOCATION, provider
         ));
     };
     let Some(spec) = spec_for(provider, verb) else {
         return Err(format!(
             "unknown command: {} {}. try: {} --help",
-            provider, verb, BINARY_NAME
+            provider, verb, INVOCATION
         ));
     };
 
@@ -667,17 +669,14 @@ pub fn help_text(provider: Option<&str>) -> String {
     let mut lines: Vec<String> = Vec::new();
     match provider {
         Some(provider) => {
-            lines.push(format!("{} {} commands", BINARY_NAME, provider));
+            lines.push(format!("{} {} commands", INVOCATION, provider));
             for spec in specs_for_provider(provider) {
                 lines.push(format!("  {}", usage(spec)));
                 lines.push(format!("      {}", spec.summary));
             }
         }
         None => {
-            lines.push(format!(
-                "usage: {} <provider> <verb> [options]",
-                BINARY_NAME
-            ));
+            lines.push(format!("usage: {} <provider> <verb> [options]", INVOCATION));
             lines.push(String::new());
             lines.push("providers:".to_string());
             for provider in providers() {
@@ -687,7 +686,7 @@ pub fn help_text(provider: Option<&str>) -> String {
             lines.push(String::new());
             lines.push(format!(
                 "run `{} <provider> --help` for that provider's commands",
-                BINARY_NAME
+                INVOCATION
             ));
             lines.push(format!(
                 "the workspace comes from {}; override it with --workspace <id>",
@@ -864,7 +863,7 @@ mod tests {
         let error = parse_argv(&argv).expect_err("missing id");
 
         assert!(error.contains("--id"));
-        assert!(error.contains("goodboy-query linear issue"));
+        assert!(error.contains(&format!("{} linear issue", INVOCATION)));
     }
 
     #[test]
@@ -947,6 +946,12 @@ mod tests {
             providers(),
             vec!["linear", "sentry", "gitlab", "jira", "bitbucket", "slack"]
         );
+    }
+
+    #[test]
+    fn the_advertised_invocation_quotes_a_binary_path_that_may_hold_spaces() {
+        assert_eq!(INVOCATION, format!("\"${}\" {}", BIN_ENV, SUBCOMMAND));
+        assert!(help_text(Some("linear")).contains("\"$GOODBOY_BIN\" query linear issue"));
     }
 
     #[test]

--- a/apps/desktop/src/features/integrations/queryBridge.test.ts
+++ b/apps/desktop/src/features/integrations/queryBridge.test.ts
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { invoke } = vi.hoisted(() => ({ invoke: vi.fn() }));
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke }));
+
+import { isQueryBridgeServing } from './queryBridge';
+
+describe('isQueryBridgeServing', () => {
+  beforeEach(() => {
+    invoke.mockReset();
+  });
+
+  it('reports what the backend answers', async () => {
+    invoke.mockResolvedValueOnce(true);
+
+    await expect(isQueryBridgeServing()).resolves.toBe(true);
+    expect(invoke).toHaveBeenCalledWith('query_bridge_serving');
+  });
+
+  it('reports a bridge that is not serving', async () => {
+    invoke.mockResolvedValueOnce(false);
+
+    await expect(isQueryBridgeServing()).resolves.toBe(false);
+  });
+
+  it('fails closed when the command cannot be reached', async () => {
+    invoke.mockRejectedValueOnce(new Error('command not found'));
+
+    await expect(isQueryBridgeServing()).resolves.toBe(false);
+  });
+});

--- a/apps/desktop/src/features/integrations/queryBridge.ts
+++ b/apps/desktop/src/features/integrations/queryBridge.ts
@@ -1,0 +1,9 @@
+import { invoke } from '@tauri-apps/api/core';
+
+export const isQueryBridgeServing = async (): Promise<boolean> => {
+  try {
+    return await invoke<boolean>('query_bridge_serving');
+  } catch {
+    return false;
+  }
+};

--- a/apps/desktop/src/store/integrationsGuard.test.ts
+++ b/apps/desktop/src/store/integrationsGuard.test.ts
@@ -37,8 +37,15 @@ describe('buildIntegrationsGuard', () => {
   it('names the command an agent has to type', () => {
     const guard = buildIntegrationsGuard({ providers: ['linear'] });
 
-    expect(guard).toContain('goodboy-query linear issue ENG-123');
-    expect(guard).toContain('goodboy-query <provider> --help');
+    expect(guard).toContain('"$GOODBOY_BIN" query linear issue ENG-123');
+    expect(guard).toContain('"$GOODBOY_BIN" query <provider> --help');
+  });
+
+  it('quotes the binary so a path with a space still runs', () => {
+    const guard = buildIntegrationsGuard({ providers: ['linear'] });
+
+    expect(guard).not.toMatch(/[^"]\$GOODBOY_BIN" query/);
+    expect(guard).toContain('Keep the quotes');
   });
 
   it('never leaks a credential, a token or an MCP endpoint into the prompt', () => {

--- a/apps/desktop/src/store/integrationsGuard.test.ts
+++ b/apps/desktop/src/store/integrationsGuard.test.ts
@@ -22,11 +22,21 @@ const catalogVerbs = (): Record<string, ReadonlyArray<string>> => {
 
 describe('buildIntegrationsGuard', () => {
   it('says nothing when the workspace has no connection', () => {
-    expect(buildIntegrationsGuard({ providers: [] })).toBe('');
+    expect(buildIntegrationsGuard({ providers: [], isBridgeServing: true })).toBe('');
+  });
+
+  it('says nothing while the bridge is not serving, connections or not', () => {
+    const guard = buildIntegrationsGuard({
+      providers: ['linear', 'jira'],
+      isBridgeServing: false,
+    });
+
+    expect(guard).toBe('');
+    expect(guard).not.toContain('GOODBOY_BIN');
   });
 
   it('lists only the providers the workspace actually connected', () => {
-    const guard = buildIntegrationsGuard({ providers: ['linear'] });
+    const guard = buildIntegrationsGuard({ providers: ['linear'], isBridgeServing: true });
 
     expect(guard).toContain('[integrations]');
     expect(guard).toContain('linear: issue,');
@@ -35,14 +45,14 @@ describe('buildIntegrationsGuard', () => {
   });
 
   it('names the command an agent has to type', () => {
-    const guard = buildIntegrationsGuard({ providers: ['linear'] });
+    const guard = buildIntegrationsGuard({ providers: ['linear'], isBridgeServing: true });
 
     expect(guard).toContain('"$GOODBOY_BIN" query linear issue ENG-123');
     expect(guard).toContain('"$GOODBOY_BIN" query <provider> --help');
   });
 
   it('quotes the binary so a path with a space still runs', () => {
-    const guard = buildIntegrationsGuard({ providers: ['linear'] });
+    const guard = buildIntegrationsGuard({ providers: ['linear'], isBridgeServing: true });
 
     expect(guard).not.toMatch(/[^"]\$GOODBOY_BIN" query/);
     expect(guard).toContain('Keep the quotes');
@@ -51,13 +61,17 @@ describe('buildIntegrationsGuard', () => {
   it('never leaks a credential, a token or an MCP endpoint into the prompt', () => {
     const guard = buildIntegrationsGuard({
       providers: ['linear', 'sentry', 'gitlab', 'jira', 'bitbucket', 'slack'],
+      isBridgeServing: true,
     });
 
     expect(guard).not.toMatch(/token|api[_ -]?key|secret|credential_id/i);
   });
 
   it('collapses a duplicated provider into a single line', () => {
-    const guard = buildIntegrationsGuard({ providers: ['linear', 'linear'] });
+    const guard = buildIntegrationsGuard({
+      providers: ['linear', 'linear'],
+      isBridgeServing: true,
+    });
 
     expect(guard.split('\n').filter((line) => line.startsWith('linear:'))).toHaveLength(1);
   });
@@ -65,6 +79,7 @@ describe('buildIntegrationsGuard', () => {
   it('stays short enough to ride along on every prompt', () => {
     const guard = buildIntegrationsGuard({
       providers: ['linear', 'sentry', 'gitlab', 'jira', 'bitbucket', 'slack'],
+      isBridgeServing: true,
     });
 
     expect(guard.split('\n')).toHaveLength(12);
@@ -73,6 +88,7 @@ describe('buildIntegrationsGuard', () => {
   it('ignores a provider the bridge cannot serve', () => {
     const guard = buildIntegrationsGuard({
       providers: ['github' as WorkspaceIntegrationProvider, 'linear'],
+      isBridgeServing: true,
     });
 
     expect(guard).not.toContain('github');
@@ -86,6 +102,7 @@ describe('buildIntegrationsGuard', () => {
         'constructor' as WorkspaceIntegrationProvider,
         'linear',
       ],
+      isBridgeServing: true,
     });
 
     expect(guard).not.toContain('toString');

--- a/apps/desktop/src/store/integrationsGuard.ts
+++ b/apps/desktop/src/store/integrationsGuard.ts
@@ -68,10 +68,10 @@ export const buildIntegrationsGuard = ({ providers }: GuardParams): string => {
   const listed = order.filter((provider) => known.includes(provider));
   return [
     '[integrations]',
-    'This workspace has live connections you can query with the `goodboy-query` command, already on your PATH. Goodboy runs the call for you, so there is nothing to authenticate and no MCP server to reach.',
+    'This workspace has live connections you can query by running the Goodboy binary at $GOODBOY_BIN with its `query` subcommand. Goodboy runs the call for you, so there is nothing to authenticate and no MCP server to reach.',
     ...listed.map((provider) => `${provider}: ${QUERY_BRIDGE_VERBS[provider].join(', ')}`),
-    'Call it as `goodboy-query <provider> <verb> [arguments]`, for example `goodboy-query linear issue ENG-123`.',
-    'Run `goodboy-query <provider> --help` for the exact arguments of a verb. Output is plain text; add --json for the raw payload.',
+    'Call it as `"$GOODBOY_BIN" query <provider> <verb> [arguments]`, for example `"$GOODBOY_BIN" query linear issue ENG-123`. Keep the quotes around it: the path can contain spaces.',
+    'Run `"$GOODBOY_BIN" query <provider> --help` for the exact arguments of a verb. Output is plain text; add --json for the raw payload.',
     'Prefer it over scraping a web UI, and never invent a verb that is not listed here.',
     '[/integrations]',
   ].join('\n');

--- a/apps/desktop/src/store/integrationsGuard.ts
+++ b/apps/desktop/src/store/integrationsGuard.ts
@@ -54,9 +54,13 @@ export const QUERY_BRIDGE_VERBS: Readonly<
 
 type GuardParams = {
   readonly providers: ReadonlyArray<WorkspaceIntegrationProvider>;
+  readonly isBridgeServing: boolean;
 };
 
-export const buildIntegrationsGuard = ({ providers }: GuardParams): string => {
+export const buildIntegrationsGuard = ({ providers, isBridgeServing }: GuardParams): string => {
+  if (!isBridgeServing) {
+    return '';
+  }
   const known = Array.from(new Set(providers)).filter(
     (provider): provider is WorkspaceIntegrationProvider =>
       Object.prototype.hasOwnProperty.call(QUERY_BRIDGE_VERBS, provider),

--- a/apps/desktop/src/store/slices/turn/sendTurn.ts
+++ b/apps/desktop/src/store/slices/turn/sendTurn.ts
@@ -71,6 +71,7 @@ import { isBranchlessSession } from '../../../shared/utils/isBranchlessSession';
 import { detectParallelGroup } from '../../parallel-turn';
 import { buildContextPreamble, buildPriorTurnsBlock, getModelContextWindow } from '../../preamble';
 import { applyAgentTurnState, cancelledRunIds } from '../../session-mutators';
+import { isQueryBridgeServing } from '../../../features/integrations/queryBridge';
 import { buildIntegrationsGuard } from '../../integrationsGuard';
 import { buildSessionLanguageGuard, resolveSessionLanguageGoal } from '../../sessionLanguage';
 import { stepSummaryDegraded } from '../../summarizeAgentOutput';
@@ -861,6 +862,7 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
       providers: (get().workspaceIntegrations[session.workspaceId] ?? []).map(
         (integration) => integration.provider,
       ),
+      isBridgeServing: await isQueryBridgeServing(),
     });
     const guards = [scopeGuard, languageGuard, integrationsGuard]
       .filter((block) => block.length > 0)

--- a/docs/query-bridge.md
+++ b/docs/query-bridge.md
@@ -72,8 +72,22 @@ any window or plugin exists. One binary is what a macOS bundle actually ships,
 so nothing has to be packaged beside it or resolved on PATH.
 
 A spawned agent is told where that executable lives through `GOODBOY_BIN`, an
-absolute path injected only while the socket is live, next to the socket and
-workspace variables. The prompt advertises the call as
-`"$GOODBOY_BIN" query <provider> <verb>`, quoted because the path may contain a
-space. When the socket is down nothing is injected and no prompt advertises a
-command that cannot run.
+absolute path injected next to the socket and workspace variables. The prompt
+advertises the call as `"$GOODBOY_BIN" query <provider> <verb>`, quoted because
+the path may contain a space.
+
+## Advertised and injected are the same condition
+
+Having a connected integration is not the same thing as having a reachable
+bridge, and a prompt that names a command the child cannot run is worse than
+silence: the agent runs an empty path and reads a shell error instead of an
+answer. So the advertisement is not gated on credentials. Both the injection
+and the prompt read one predicate, true only when this process owns a bound
+listener and its socket file is still there, and the frontend reaches it
+through `query_bridge_serving` rather than inferring it. A frontend that cannot
+reach that command reads it as false.
+
+That is what suppresses the block on Windows, where nothing ever binds, and
+before the listener is up or after it is gone. The two can still disagree only
+inside the instant between composing a prompt and spawning the child, and the
+cost of losing that race is a command the agent is told about for one turn.

--- a/docs/query-bridge.md
+++ b/docs/query-bridge.md
@@ -63,8 +63,17 @@ Gemini or opencode. Nothing about it is provider-specific.
 ## Where it is reachable
 
 The socket is created when the app starts and removed when it stops, so an
-agent outliving the app fails loudly instead of hanging. The CLI is found next
-to the running executable, which covers both a development build and a bundled
-app once the binary is shipped alongside the main one; when it is not there,
-the environment is simply not injected and no prompt advertises a command that
-cannot run. Windows has no Unix socket and is not served.
+agent outliving the app fails loudly instead of hanging. Windows has no Unix
+socket and is not served.
+
+The CLI is not a second program. It is the same executable the user launched,
+entered through the `query` first argument, which is answered and exited before
+any window or plugin exists. One binary is what a macOS bundle actually ships,
+so nothing has to be packaged beside it or resolved on PATH.
+
+A spawned agent is told where that executable lives through `GOODBOY_BIN`, an
+absolute path injected only while the socket is live, next to the socket and
+workspace variables. The prompt advertises the call as
+`"$GOODBOY_BIN" query <provider> <verb>`, quoted because the path may contain a
+space. When the socket is down nothing is injected and no prompt advertises a
+command that cannot run.


### PR DESCRIPTION
## Why

The query bridge shipped its client as a second bin target, `goodboy-query`.
A packaged `.app` bundles only the main executable, so shipping it meant tauri
`bundle.externalBin` sidecars with one binary per triple for the universal
macOS build. Everything has to live in the one executable we already ship.

## What changed

- `src/bin/goodboy-query.rs` is gone. The client moved to
  `query_bridge::cli`, tests included, and now uses `super::protocol` instead
  of the `#[path]` include.
- `main.rs` answers a leading `query` argument and exits with the client's
  code before any tauri builder, plugin or window exists. Anything else
  starts the app exactly as before.
- The bridge no longer probes for a sibling binary or prepends a directory to
  `PATH`. It injects `GOODBOY_BIN`, the absolute path of the running
  executable, next to the socket and workspace variables, and only while the
  socket is live.
- The advertisement in `integrationsGuard.ts` and the CLI's own help now read
  `"$GOODBOY_BIN" query linear issue ENG-123`. The quotes are load-bearing:
  the path can hold a space. A test pins the quoting.
- `docs/query-bridge.md` describes the one-binary shape.
- `default-run = "goodboy-desktop"` stays in `Cargo.toml`. It is inert with a
  single bin and keeps a future second target honest; the manifest guard test
  passes unchanged.

## Advertised and injected now answer to one predicate

Review caught a mismatch this refactor inherited: the guard block was
composed from which providers hold credentials, while the env var was
injected from whether the socket was live. On Windows nothing ever binds, and
before the listener is up or after it is gone there is no socket, so an agent
could be handed a command that expands to an empty path.

`query_bridge::is_serving()` is now the single condition, true only when this
process owns a bound listener and its socket file is still present.
`apply_env` early-returns on it; the frontend reads the same value through the
new `query_bridge_serving` command and fails closed when it cannot reach it.
`buildIntegrationsGuard` takes `isBridgeServing` as a required parameter, so a
caller cannot forget to ask.

## The CLI contract is unchanged

Same verbs, same flags, same `--flag=value` rejection, same stderr and exit 1
on failure. Only the first argument and the way the binary is named moved.

## Verification

- `cargo test --locked`: 498 lib tests, 10 manifest tests, all green. The
  query bridge suite went from 34 to 42 tests, none deleted.
- CLI personality of the built debug binary: `query --help`, a narrowed
  `query linear --help`, the unset-socket error at exit 1, and
  `--json=true` refused. No window opens.
- End to end through a stub socket, invoked exactly as advertised from a path
  containing a space: the request arrives with its parsed arguments and the
  answer renders as text.
- App personality: launched with no arguments and `GOODBOY_DB_FILE` on a
  scratch file, stayed alive, created the database and bound the bridge
  socket, then answered a `query` call made by a second copy of the same
  binary before being killed.
- `pnpm typecheck`, `vitest run src/store` (1282 passed, guard and bridge
  wrapper included), and `pnpm knip --include files,duplicates,unlisted`
  clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
