### PR TITLE
fix(desktop): give every instance its own query bridge socket

### DIFF
--- a/apps/desktop/src-tauri/src/query_bridge/mod.rs
+++ b/apps/desktop/src-tauri/src/query_bridge/mod.rs
@@ -7,7 +7,9 @@ use std::process::Command;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::OnceLock;
 
-use protocol::{QueryRequest, QueryResponse, BIN_ENV, SOCKET_ENV, SOCKET_FILE, WORKSPACE_ENV};
+use protocol::{
+    QueryRequest, QueryResponse, BIN_ENV, SOCKET_ENV, SOCKET_PREFIX, SOCKET_SUFFIX, WORKSPACE_ENV,
+};
 
 pub(crate) use cli::dispatch as run_cli;
 
@@ -17,10 +19,37 @@ static SOCKET_PATH: OnceLock<Option<PathBuf>> = OnceLock::new();
 static EXE_PATH: OnceLock<Option<PathBuf>> = OnceLock::new();
 static LISTENING: AtomicBool = AtomicBool::new(false);
 
+fn socket_file_name(pid: u32) -> String {
+    format!("{}{}{}", SOCKET_PREFIX, pid, SOCKET_SUFFIX)
+}
+
+fn socket_pid(file_name: &str) -> Option<u32> {
+    file_name
+        .strip_prefix(SOCKET_PREFIX)?
+        .strip_suffix(SOCKET_SUFFIX)?
+        .parse::<u32>()
+        .ok()
+}
+
 fn socket_path() -> Option<&'static Path> {
     SOCKET_PATH
-        .get_or_init(|| dirs::home_dir().map(|home| home.join(APP_DIR).join(SOCKET_FILE)))
+        .get_or_init(|| {
+            dirs::home_dir().map(|home| {
+                home.join(APP_DIR)
+                    .join(socket_file_name(std::process::id()))
+            })
+        })
         .as_deref()
+}
+
+fn abandoned_sockets<'a>(
+    file_names: impl Iterator<Item = &'a str>,
+    is_alive: &dyn Fn(u32) -> bool,
+) -> Vec<String> {
+    file_names
+        .filter(|name| socket_pid(name).is_some_and(|pid| !is_alive(pid)))
+        .map(str::to_string)
+        .collect()
 }
 
 fn exe_path() -> Option<&'static Path> {
@@ -59,6 +88,49 @@ pub(crate) fn apply_env(command: &mut Command, workspace_id: Option<&str>) {
 }
 
 #[cfg(unix)]
+fn is_pid_alive(pid: u32) -> bool {
+    if pid == 0 {
+        return true;
+    }
+    let outcome = unsafe { libc::kill(pid as libc::pid_t, 0) };
+    if outcome == 0 {
+        return true;
+    }
+    std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+}
+
+#[cfg(unix)]
+fn has_listener(path: &Path) -> bool {
+    std::os::unix::net::UnixStream::connect(path).is_ok()
+}
+
+#[cfg(unix)]
+fn sweep_legacy_socket(path: &Path) {
+    if !path.exists() {
+        return;
+    }
+    if has_listener(path) {
+        return;
+    }
+    let _ = std::fs::remove_file(path);
+}
+
+#[cfg(unix)]
+fn sweep_abandoned_sockets(dir: &Path) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    let file_names: Vec<String> = entries
+        .filter_map(|entry| entry.ok())
+        .filter_map(|entry| entry.file_name().into_string().ok())
+        .collect();
+    for name in abandoned_sockets(file_names.iter().map(String::as_str), &is_pid_alive) {
+        let _ = std::fs::remove_file(dir.join(name));
+    }
+    sweep_legacy_socket(&dir.join(protocol::LEGACY_SOCKET_FILE));
+}
+
+#[cfg(unix)]
 pub(crate) fn start(app: tauri::AppHandle) {
     use std::os::unix::fs::PermissionsExt;
     use tokio::net::UnixListener;
@@ -71,6 +143,7 @@ pub(crate) fn start(app: tauri::AppHandle) {
             log::warn!("query bridge: state directory unavailable: {error}");
             return;
         }
+        sweep_abandoned_sockets(parent);
     }
     let _ = std::fs::remove_file(path);
     tauri::async_runtime::spawn(async move {
@@ -154,7 +227,105 @@ mod tests {
     fn the_socket_lives_beside_the_database_in_the_state_directory() {
         let path = socket_path().expect("a home directory");
 
-        assert!(path.ends_with(format!("{}/{}", APP_DIR, SOCKET_FILE)));
+        assert!(path.ends_with(format!(
+            "{}/{}",
+            APP_DIR,
+            socket_file_name(std::process::id())
+        )));
+    }
+
+    #[test]
+    fn every_running_instance_binds_a_socket_named_after_its_own_pid() {
+        let path = socket_path().expect("a home directory");
+        let name = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .expect("a file name");
+
+        assert_eq!(socket_pid(name), Some(std::process::id()));
+        assert_ne!(socket_file_name(1), socket_file_name(2));
+    }
+
+    #[test]
+    fn only_a_pid_suffixed_socket_answers_for_an_owner() {
+        assert_eq!(socket_pid("query-4321.sock"), Some(4321));
+        assert_eq!(socket_pid(protocol::LEGACY_SOCKET_FILE), None);
+        assert_eq!(socket_pid("query-.sock"), None);
+        assert_eq!(socket_pid("query-abc.sock"), None);
+        assert_eq!(socket_pid("query-12.sock.bak"), None);
+        assert_eq!(socket_pid("data.db"), None);
+    }
+
+    #[test]
+    fn the_sweep_takes_the_dead_and_spares_every_live_instance() {
+        let names = [
+            "query-11.sock",
+            "query-22.sock",
+            "query-33.sock",
+            "query.sock",
+            "data.db",
+        ];
+        let alive = |pid: u32| pid == 22;
+
+        let taken = abandoned_sockets(names.into_iter(), &alive);
+
+        assert_eq!(taken, vec!["query-11.sock", "query-33.sock"]);
+    }
+
+    #[cfg(unix)]
+    fn scratch_dir(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("goodboy-query-bridge-{}", name));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("a scratch directory");
+        dir
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn the_process_running_the_sweep_is_alive_and_a_free_pid_is_not() {
+        assert!(is_pid_alive(std::process::id()));
+        assert!(!is_pid_alive(0x7fff_fffe));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_legacy_socket_survives_only_while_a_listener_answers_on_it() {
+        let dir = scratch_dir("legacy");
+        let path = dir.join(protocol::LEGACY_SOCKET_FILE);
+        let listener = std::os::unix::net::UnixListener::bind(&path).expect("a legacy listener");
+
+        sweep_legacy_socket(&path);
+        assert!(path.exists());
+
+        drop(listener);
+        sweep_legacy_socket(&path);
+        assert!(!path.exists());
+
+        sweep_legacy_socket(&path);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_crash_leftover_goes_and_this_instance_keeps_its_own_socket() {
+        let dir = scratch_dir("sweep");
+        let mine = dir.join(socket_file_name(std::process::id()));
+        let leftover = dir.join(socket_file_name(0x7fff_fffe));
+        let legacy = dir.join(protocol::LEGACY_SOCKET_FILE);
+        let unrelated = dir.join("data.db");
+        for path in [&mine, &leftover, &legacy, &unrelated] {
+            std::fs::write(path, b"").expect("a probe file");
+        }
+
+        sweep_abandoned_sockets(&dir);
+
+        assert!(mine.exists());
+        assert!(!leftover.exists());
+        assert!(!legacy.exists());
+        assert!(unrelated.exists());
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     fn injected_names(workspace_id: Option<&str>) -> Vec<String> {
@@ -173,6 +344,21 @@ mod tests {
         assert_eq!(names.contains(&SOCKET_ENV.to_string()), is_serving());
         assert_eq!(names.contains(&BIN_ENV.to_string()), is_serving());
         assert_eq!(names.contains(&WORKSPACE_ENV.to_string()), is_serving());
+    }
+
+    #[test]
+    fn the_socket_a_child_is_handed_is_the_one_this_instance_binds() {
+        let mut command = Command::new("true");
+        apply_env(&mut command, Some("ws-1"));
+        let injected = command
+            .get_envs()
+            .find(|(key, _)| *key == std::ffi::OsStr::new(SOCKET_ENV))
+            .and_then(|(_, value)| value);
+
+        assert_eq!(
+            injected,
+            is_serving().then(|| socket_path().expect("a home directory").as_os_str())
+        );
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/query_bridge/protocol.rs
+++ b/apps/desktop/src-tauri/src/query_bridge/protocol.rs
@@ -6,7 +6,9 @@ use serde::{Deserialize, Serialize};
 
 pub const SOCKET_ENV: &str = "GOODBOY_QUERY_SOCKET";
 pub const WORKSPACE_ENV: &str = "GOODBOY_WORKSPACE_ID";
-pub const SOCKET_FILE: &str = "query.sock";
+pub const LEGACY_SOCKET_FILE: &str = "query.sock";
+pub const SOCKET_PREFIX: &str = "query-";
+pub const SOCKET_SUFFIX: &str = ".sock";
 pub const BIN_ENV: &str = "GOODBOY_BIN";
 pub const SUBCOMMAND: &str = "query";
 pub const INVOCATION: &str = "\"$GOODBOY_BIN\" query";

--- a/docs/query-bridge.md
+++ b/docs/query-bridge.md
@@ -66,6 +66,23 @@ The socket is created when the app starts and removed when it stops, so an
 agent outliving the app fails loudly instead of hanging. Windows has no Unix
 socket and is not served.
 
+## One socket per running instance
+
+The socket file is named after the process that binds it, `query-<pid>.sock` in
+the state directory. A fixed name can only ever belong to the newest process
+that started, and the loss is silent: an installed build and a development
+build both bind it, the second one wins, and the agents of the first keep
+talking to a bridge that answers from another database with another set of
+credentials. Naming the file after the owner removes the collision instead of
+detecting it, and it is what lets a second window hold its own bridge later.
+
+Nothing has to be cleaned up by hand. Before binding, a starting instance
+removes the sockets in that directory whose owning pid no longer exists, which
+is what a crash leaves behind, and never touches one whose owner is still
+alive, including another live instance. The fixed-name socket earlier versions
+bound is removed only when no listener answers on it, so upgrading does not
+disturb an older build that is still running.
+
 The CLI is not a second program. It is the same executable the user launched,
 entered through the `query` first argument, which is answered and exited before
 any window or plugin exists. One binary is what a macOS bundle actually ships,
@@ -85,7 +102,8 @@ answer. So the advertisement is not gated on credentials. Both the injection
 and the prompt read one predicate, true only when this process owns a bound
 listener and its socket file is still there, and the frontend reaches it
 through `query_bridge_serving` rather than inferring it. A frontend that cannot
-reach that command reads it as false.
+reach that command reads it as false. The path handed to the child is the one
+this process bound, so a child never inherits an address another instance owns.
 
 That is what suppresses the block on Windows, where nothing ever binds, and
 before the listener is up or after it is gone. The two can still disagree only


### PR DESCRIPTION
## What

The query bridge bound a fixed `~/.goodboy/query.sock`. Two Goodboy processes on one machine (the installed app and a dev build today, a second window tomorrow) both bind that name, the newest one wins, and the agents of the older instance keep talking to a bridge that answers from another database with another set of credentials. Nothing reported it. This was found live when a smoke test took the socket away from a running dev app.

The socket is now named after the process that binds it, `query-<pid>.sock` in the same directory, still `0600`, still created on start and removed on the drain hook.

## Sweep

A fixed name never accumulated leftovers. A pid-suffixed one does, so a starting instance sweeps the state directory before binding:

- a `query-<pid>.sock` whose pid no longer exists is removed, which is what a crash leaves behind;
- a `query-<pid>.sock` whose pid is alive is never touched, including the socket of another live instance. Liveness is `kill(pid, 0)`, with `EPERM` read as alive;
- the legacy fixed-name `query.sock` is removed only when a connect finds no listener on it, so upgrading does not disturb an older build that is still running.

`is_serving()` and `apply_env` keep their semantics: the path a child is handed is the one this process bound.

## Test plan

- `cargo test --locked` in `apps/desktop/src-tauri`: 506 passed, 0 failed. New coverage for the pid-suffixed name, the name parser, the sweep classification, legacy handling against a real listener, and a scratch-directory sweep.
- `pnpm typecheck`: green. No TypeScript changed.
- Live smoke on a scratch `HOME` and a scratch `GOODBOY_DB_FILE`, with a planted live-pid socket, a dead-pid socket and a legacy `query.sock`:
  - instance A bound `srw------- query-67249.sock`;
  - the planted dead-pid socket and the legacy file were swept, the live-pid one survived;
  - a second copy of the binary reached the listener through `GOODBOY_QUERY_SOCKET` and got an answer from the dispatcher;
  - with the variable unset the CLI refuses, confirming there is no fallback to the fixed path;
  - `SIGTERM` skips the Tauri exit hook and leaves the socket behind, which is exactly the case the sweep covers: instance B removed it and bound its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
