### PR TITLE
fix(desktop): take a socket out of the way before discarding it

### DIFF
--- a/apps/desktop/src-tauri/src/query_bridge/mod.rs
+++ b/apps/desktop/src-tauri/src/query_bridge/mod.rs
@@ -14,6 +14,7 @@ use protocol::{
 pub(crate) use cli::dispatch as run_cli;
 
 const APP_DIR: &str = ".goodboy";
+const SWEEP_SUFFIX: &str = "sweep-";
 
 static SOCKET_PATH: OnceLock<Option<PathBuf>> = OnceLock::new();
 static EXE_PATH: OnceLock<Option<PathBuf>> = OnceLock::new();
@@ -45,10 +46,10 @@ fn socket_path() -> Option<&'static Path> {
 fn abandoned_sockets<'a>(
     file_names: impl Iterator<Item = &'a str>,
     is_alive: &dyn Fn(u32) -> bool,
-) -> Vec<String> {
+) -> Vec<(String, u32)> {
     file_names
-        .filter(|name| socket_pid(name).is_some_and(|pid| !is_alive(pid)))
-        .map(str::to_string)
+        .filter_map(|name| socket_pid(name).map(|pid| (name.to_string(), pid)))
+        .filter(|(_, pid)| !is_alive(*pid))
         .collect()
 }
 
@@ -105,14 +106,21 @@ fn has_listener(path: &Path) -> bool {
 }
 
 #[cfg(unix)]
-fn sweep_legacy_socket(path: &Path) {
-    if !path.exists() {
+fn staged_name(path: &Path) -> PathBuf {
+    path.with_extension(format!("{}{}", SWEEP_SUFFIX, std::process::id()))
+}
+
+#[cfg(unix)]
+fn discard_unless_owned(path: &Path, is_owned: &dyn Fn(&Path) -> bool) {
+    let staged = staged_name(path);
+    if std::fs::rename(path, &staged).is_err() {
         return;
     }
-    if has_listener(path) {
+    if is_owned(&staged) {
+        let _ = std::fs::rename(&staged, path);
         return;
     }
-    let _ = std::fs::remove_file(path);
+    let _ = std::fs::remove_file(&staged);
 }
 
 #[cfg(unix)]
@@ -124,10 +132,10 @@ fn sweep_abandoned_sockets(dir: &Path) {
         .filter_map(|entry| entry.ok())
         .filter_map(|entry| entry.file_name().into_string().ok())
         .collect();
-    for name in abandoned_sockets(file_names.iter().map(String::as_str), &is_pid_alive) {
-        let _ = std::fs::remove_file(dir.join(name));
+    for (name, pid) in abandoned_sockets(file_names.iter().map(String::as_str), &is_pid_alive) {
+        discard_unless_owned(&dir.join(name), &|_| is_pid_alive(pid));
     }
-    sweep_legacy_socket(&dir.join(protocol::LEGACY_SOCKET_FILE));
+    discard_unless_owned(&dir.join(protocol::LEGACY_SOCKET_FILE), &has_listener);
 }
 
 #[cfg(unix)]
@@ -269,7 +277,13 @@ mod tests {
 
         let taken = abandoned_sockets(names.into_iter(), &alive);
 
-        assert_eq!(taken, vec!["query-11.sock", "query-33.sock"]);
+        assert_eq!(
+            taken,
+            vec![
+                ("query-11.sock".to_string(), 11),
+                ("query-33.sock".to_string(), 33)
+            ]
+        );
     }
 
     #[cfg(unix)]
@@ -294,14 +308,51 @@ mod tests {
         let path = dir.join(protocol::LEGACY_SOCKET_FILE);
         let listener = std::os::unix::net::UnixListener::bind(&path).expect("a legacy listener");
 
-        sweep_legacy_socket(&path);
+        sweep_abandoned_sockets(&dir);
+
         assert!(path.exists());
+        assert!(has_listener(&path));
+        assert_eq!(staged_leftovers(&dir), Vec::<String>::new());
 
         drop(listener);
-        sweep_legacy_socket(&path);
-        assert!(!path.exists());
+        sweep_abandoned_sockets(&dir);
 
-        sweep_legacy_socket(&path);
+        assert!(!path.exists());
+        assert_eq!(staged_leftovers(&dir), Vec::<String>::new());
+
+        sweep_abandoned_sockets(&dir);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[cfg(unix)]
+    fn staged_leftovers(dir: &Path) -> Vec<String> {
+        let mut names: Vec<String> = std::fs::read_dir(dir)
+            .expect("a readable directory")
+            .filter_map(|entry| entry.ok())
+            .filter_map(|entry| entry.file_name().into_string().ok())
+            .filter(|name| name.contains(SWEEP_SUFFIX))
+            .collect();
+        names.sort();
+        names
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_socket_taken_out_of_the_way_goes_back_when_its_owner_still_answers() {
+        let dir = scratch_dir("restore");
+        let path = dir.join(socket_file_name(std::process::id()));
+        std::fs::write(&path, b"").expect("a probe file");
+
+        discard_unless_owned(&path, &|_| true);
+
+        assert!(path.exists());
+        assert_eq!(staged_leftovers(&dir), Vec::<String>::new());
+
+        discard_unless_owned(&path, &|_| false);
+
+        assert!(!path.exists());
+        assert_eq!(staged_leftovers(&dir), Vec::<String>::new());
 
         let _ = std::fs::remove_dir_all(&dir);
     }
@@ -324,6 +375,7 @@ mod tests {
         assert!(!leftover.exists());
         assert!(!legacy.exists());
         assert!(unrelated.exists());
+        assert_eq!(staged_leftovers(&dir), Vec::<String>::new());
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/apps/desktop/src-tauri/src/query_bridge/mod.rs
+++ b/apps/desktop/src-tauri/src/query_bridge/mod.rs
@@ -127,13 +127,21 @@ fn staged_name(path: &Path) -> PathBuf {
 }
 
 #[cfg(unix)]
+fn restore_staged(staged: &Path, path: &Path) {
+    if std::fs::hard_link(staged, path).is_err() {
+        return;
+    }
+    let _ = std::fs::remove_file(staged);
+}
+
+#[cfg(unix)]
 fn discard_unless_owned(path: &Path, is_owned: &dyn Fn(&Path) -> bool) {
     let staged = staged_name(path);
     if std::fs::rename(path, &staged).is_err() {
         return;
     }
     if is_owned(&staged) {
-        let _ = std::fs::rename(&staged, path);
+        restore_staged(&staged, path);
         return;
     }
     let _ = std::fs::remove_file(&staged);
@@ -398,6 +406,44 @@ mod tests {
 
         assert!(!path.exists());
         assert_eq!(staged_leftovers(&dir), Vec::<String>::new());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_restore_puts_the_very_same_file_back_under_its_own_name() {
+        let dir = scratch_dir("restore-back");
+        let path = dir.join(socket_file_name(std::process::id()));
+        std::fs::write(&path, b"owner").expect("a probe file");
+        let staged = staged_name(&path);
+        std::fs::rename(&path, &staged).expect("a staged file");
+
+        restore_staged(&staged, &path);
+
+        assert_eq!(std::fs::read_to_string(&path).expect("the file"), "owner");
+        assert!(!staged.exists());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_restore_never_lands_on_a_name_another_process_took_meanwhile() {
+        let dir = scratch_dir("restore-taken");
+        let path = dir.join(socket_file_name(std::process::id()));
+        std::fs::write(&path, b"owner").expect("a probe file");
+        let staged = staged_name(&path);
+        std::fs::rename(&path, &staged).expect("a staged file");
+        std::fs::write(&path, b"newcomer").expect("a newcomer file");
+
+        restore_staged(&staged, &path);
+
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("the file"),
+            "newcomer"
+        );
+        assert!(staged.exists());
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/apps/desktop/src-tauri/src/query_bridge/mod.rs
+++ b/apps/desktop/src-tauri/src/query_bridge/mod.rs
@@ -14,7 +14,7 @@ use protocol::{
 pub(crate) use cli::dispatch as run_cli;
 
 const APP_DIR: &str = ".goodboy";
-const SWEEP_SUFFIX: &str = "sweep-";
+const SWEEP_SUFFIX: &str = ".sweep-";
 
 static SOCKET_PATH: OnceLock<Option<PathBuf>> = OnceLock::new();
 static EXE_PATH: OnceLock<Option<PathBuf>> = OnceLock::new();
@@ -50,6 +50,20 @@ fn abandoned_sockets<'a>(
     file_names
         .filter_map(|name| socket_pid(name).map(|pid| (name.to_string(), pid)))
         .filter(|(_, pid)| !is_alive(*pid))
+        .collect()
+}
+
+fn sweeper_pid(file_name: &str) -> Option<u32> {
+    file_name.rsplit_once(SWEEP_SUFFIX)?.1.parse::<u32>().ok()
+}
+
+fn abandoned_staged_files<'a>(
+    file_names: impl Iterator<Item = &'a str>,
+    is_alive: &dyn Fn(u32) -> bool,
+) -> Vec<String> {
+    file_names
+        .filter(|name| sweeper_pid(name).is_some_and(|pid| !is_alive(pid)))
+        .map(str::to_string)
         .collect()
 }
 
@@ -107,7 +121,9 @@ fn has_listener(path: &Path) -> bool {
 
 #[cfg(unix)]
 fn staged_name(path: &Path) -> PathBuf {
-    path.with_extension(format!("{}{}", SWEEP_SUFFIX, std::process::id()))
+    let mut name = path.as_os_str().to_os_string();
+    name.push(format!("{}{}", SWEEP_SUFFIX, std::process::id()));
+    PathBuf::from(name)
 }
 
 #[cfg(unix)]
@@ -134,6 +150,9 @@ fn sweep_abandoned_sockets(dir: &Path) {
         .collect();
     for (name, pid) in abandoned_sockets(file_names.iter().map(String::as_str), &is_pid_alive) {
         discard_unless_owned(&dir.join(name), &|_| is_pid_alive(pid));
+    }
+    for name in abandoned_staged_files(file_names.iter().map(String::as_str), &is_pid_alive) {
+        let _ = std::fs::remove_file(dir.join(name));
     }
     discard_unless_owned(&dir.join(protocol::LEGACY_SOCKET_FILE), &has_listener);
 }
@@ -286,6 +305,32 @@ mod tests {
         );
     }
 
+    #[test]
+    fn a_staged_file_belongs_to_the_sweeper_named_in_it() {
+        assert_eq!(sweeper_pid("query-9.sock.sweep-4321"), Some(4321));
+        assert_eq!(sweeper_pid("query.sock.sweep-7"), Some(7));
+        assert_eq!(sweeper_pid("query-9.sock"), None);
+        assert_eq!(sweeper_pid("query-9.sock.sweep-"), None);
+        assert_eq!(sweeper_pid("query-9.sock.sweep-abc"), None);
+        assert_eq!(sweeper_pid("data.db"), None);
+    }
+
+    #[test]
+    fn a_sweeper_that_died_mid_operation_leaves_nothing_behind() {
+        let names = [
+            "query-9.sock.sweep-11",
+            "query-9.sock.sweep-22",
+            "query.sock.sweep-33",
+            "query-9.sock",
+            "data.db",
+        ];
+        let alive = |pid: u32| pid == 22;
+
+        let taken = abandoned_staged_files(names.into_iter(), &alive);
+
+        assert_eq!(taken, vec!["query-9.sock.sweep-11", "query.sock.sweep-33"]);
+    }
+
     #[cfg(unix)]
     fn scratch_dir(name: &str) -> PathBuf {
         let dir = std::env::temp_dir().join(format!("goodboy-query-bridge-{}", name));
@@ -353,6 +398,34 @@ mod tests {
 
         assert!(!path.exists());
         assert_eq!(staged_leftovers(&dir), Vec::<String>::new());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_staged_file_outlives_its_sweeper_only_while_that_sweeper_runs() {
+        let dir = scratch_dir("staged");
+        let mine = dir.join(format!(
+            "{}{}{}",
+            socket_file_name(7),
+            SWEEP_SUFFIX,
+            std::process::id()
+        ));
+        let orphan = dir.join(format!(
+            "{}{}{}",
+            socket_file_name(7),
+            SWEEP_SUFFIX,
+            0x7fff_fffe_u32
+        ));
+        for path in [&mine, &orphan] {
+            std::fs::write(path, b"").expect("a probe file");
+        }
+
+        sweep_abandoned_sockets(&dir);
+
+        assert!(mine.exists());
+        assert!(!orphan.exists());
 
         let _ = std::fs::remove_dir_all(&dir);
     }


### PR DESCRIPTION
## Why this exists separately

Follow-up to #1515, which landed the per-instance socket. Copilot flagged a TOCTOU in the sweep there; #1515 was merged while this answer to it was still in flight, so it arrives on its own branch. It carries no behavior from #1515, only the sweep's ownership check.

## What

The sweep probed a candidate socket and then unlinked it. Two steps on the same name: a process that binds that name in between loses a live listener path to the sweep. The window is microseconds and the loser degrades rather than misroutes, but it is avoidable.

The candidate is now renamed to a staged name first, which is one atomic step, and only then asked whether anyone still owns it:

- a process that binds the name after the rename gets a fresh file the sweep never looks at;
- an owner that answers on the staged path is renamed back where it was;
- the pid-named branch goes through the same helper and re-checks liveness after staging, so a recycled pid is covered by the same argument.

What remains is an old build that binds the legacy name before the rename: it gets its path handed back a moment later, so the cost is an unadvertised bridge for the length of a rename instead of a deleted listener path. Closing that completely would need the shipped legacy binary to take part in the protocol, and it cannot, since its own startup unlinks and binds the fixed name with no probe at all.

## Test plan

- `cargo test --locked` in `apps/desktop/src-tauri`: 507 passed, 0 failed.
- New coverage: a staged socket goes back when its owner answers, and every sweep path asserts no staged leftovers remain in the directory.
- The legacy test now drives the real `sweep_abandoned_sockets` against a bound listener and checks the listener still answers on its original path afterwards, which is what proves the rename kept the inode.
- Live smoke rerun on a scratch `HOME` and a scratch `GOODBOY_DB_FILE`: a planted dead-pid socket and a legacy `query.sock` were swept, a planted live-pid socket survived, the instance bound `srw------- query-<pid>.sock`, a second copy of the binary reached it through `GOODBOY_QUERY_SOCKET`, and no staged file was left behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Update: staged files a dead sweeper left behind

Review caught that staging introduces its own leftover class. A sweeper that dies between the rename and the verdict leaves a `query-<n>.sock.sweep-<sweeper-pid>` that no later pass matched, since it fails the socket pattern. The staged name carries the sweeper's pid, so the same liveness check answers for it: a staged file whose sweeper is gone is removed, and one whose sweeper still runs is left alone because that sweeper is mid-operation.

It is removed rather than restored to its unstaged name. Restoring would have to ask whether that name is free and then rename, which is the two-step pattern this branch exists to remove. The original owner is unreachable either way and its agents fail loudly.

Covered by a classifier test, a directory-level test that keeps the live sweeper's staged file and takes the dead one, and a smoke rerun with a planted orphan staged file that the next instance collected. `cargo test --locked`: 510 passed, 0 failed.

## Update: the restore is no-overwrite

Review caught that renaming the staged file back onto its name replaces whatever sits there, so a process that bound that name after the staging lost its live listener to the restore. The same race, one step later.

The restore now links the staged file to its name and drops the staged one. `link` refuses an existing destination, so a name taken meanwhile is left untouched and the staged file stays put for a later sweep to collect under the dead-sweeper rule. Two tests cover it, and the legacy test drives a real bound listener through stage and restore and then connects to it at its original path, which proves the link keeps the inode.

`cargo test --locked`: 512 passed, 0 failed.
