### PR TITLE
feat(desktop): attach report screenshots to the issue body

### DIFF
--- a/apps/desktop/src-tauri/src/attachment.rs
+++ b/apps/desktop/src-tauri/src/attachment.rs
@@ -289,9 +289,11 @@ pub fn bug_report_stage_images(
     })
 }
 
-#[tauri::command]
-pub fn bug_report_reveal_images(dir: String) -> Result<(), AttachmentError> {
-    let canonical_dir = Path::new(&dir).canonicalize()?;
+/// Resolves a caller-supplied path back to a report staging folder. Anything
+/// outside the temp directory and anything not named like a report folder is
+/// refused before it can be opened or deleted.
+fn resolve_bug_report_dir(dir: &str) -> Result<std::path::PathBuf, AttachmentError> {
+    let canonical_dir = Path::new(dir).canonicalize()?;
     let canonical_temp_dir = std::env::temp_dir().canonicalize()?;
     let is_report_dir = canonical_dir
         .file_name()
@@ -300,8 +302,24 @@ pub fn bug_report_reveal_images(dir: String) -> Result<(), AttachmentError> {
     if !canonical_dir.starts_with(canonical_temp_dir) || !is_report_dir {
         return Err(AttachmentError::InvalidPath);
     }
+    Ok(canonical_dir)
+}
+
+#[tauri::command]
+pub fn bug_report_reveal_images(dir: String) -> Result<(), AttachmentError> {
+    let canonical_dir = resolve_bug_report_dir(&dir)?;
     crate::explore::spawn_open(&canonical_dir, false)?;
     Ok(())
+}
+
+#[tauri::command]
+pub fn bug_report_discard_images(dir: String) -> Result<(), AttachmentError> {
+    let canonical_dir = resolve_bug_report_dir(&dir)?;
+    match fs::remove_dir_all(&canonical_dir) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(AttachmentError::Io(e)),
+    }
 }
 
 #[cfg(test)]
@@ -464,6 +482,26 @@ mod tests {
         assert!(matches!(err, Err(AttachmentError::Decode(_))));
 
         let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn bug_report_discard_removes_a_staged_folder_and_refuses_anything_else() {
+        let dir = std::env::temp_dir().join(format!("goodboy-report-drop-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("01-shot.png"), b"bytes").unwrap();
+
+        bug_report_discard_images(dir.to_string_lossy().to_string()).unwrap();
+        assert!(!dir.exists());
+
+        let other = std::env::temp_dir().join(format!("goodboy-keep-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&other);
+        fs::create_dir_all(&other).unwrap();
+        let err = bug_report_discard_images(other.to_string_lossy().to_string());
+        assert!(matches!(err, Err(AttachmentError::InvalidPath)));
+        assert!(other.exists());
+
+        let _ = fs::remove_dir_all(&other);
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/attachment.rs
+++ b/apps/desktop/src-tauri/src/attachment.rs
@@ -224,6 +224,7 @@ pub fn attachment_delete(worktree_dir: String, rel_path: String) -> Result<(), A
 #[serde(rename_all = "camelCase")]
 pub struct BugReportImageInput {
     file_name: String,
+    mime_type: String,
     data_base64: String,
 }
 
@@ -235,32 +236,57 @@ fn bug_report_dir_name() -> String {
     format!("goodboy-report-{}-{}", std::process::id(), stamp)
 }
 
-/// GitHub has no public endpoint for issue-body image uploads, so the images
-/// are written to a throwaway folder and the file manager is opened on it: the
-/// reporter drags them straight into the issue the app just opened.
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StagedBugReportImage {
+    file_name: String,
+    mime_type: String,
+    path: String,
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StagedBugReport {
+    dir: String,
+    images: Vec<StagedBugReportImage>,
+}
+
+/// Writes the images to a throwaway folder and reports where each one landed.
+/// The upload reads them back from there, and the folder is what the file
+/// manager opens when the reporter has to drag them in by hand instead.
 fn write_bug_report_images(
     dir: &Path,
     images: &[BugReportImageInput],
-) -> Result<(), AttachmentError> {
+) -> Result<Vec<StagedBugReportImage>, AttachmentError> {
     fs::create_dir_all(dir)?;
+    let mut staged = Vec::with_capacity(images.len());
     for (index, image) in images.iter().enumerate() {
         let bytes = STANDARD.decode(image.data_base64.as_bytes())?;
         if bytes.len() > MAX_BYTES {
             return Err(AttachmentError::TooLarge(MAX_BYTES));
         }
         let stored = format!("{:02}-{}", index + 1, sanitize_segment(&image.file_name));
-        fs::write(dir.join(stored), &bytes)?;
+        let path = dir.join(stored);
+        fs::write(&path, &bytes)?;
+        staged.push(StagedBugReportImage {
+            file_name: image.file_name.clone(),
+            mime_type: image.mime_type.clone(),
+            path: path.to_string_lossy().to_string(),
+        });
     }
-    Ok(())
+    Ok(staged)
 }
 
 #[tauri::command]
 pub fn bug_report_stage_images(
     images: Vec<BugReportImageInput>,
-) -> Result<String, AttachmentError> {
+) -> Result<StagedBugReport, AttachmentError> {
     let dir = std::env::temp_dir().join(bug_report_dir_name());
-    write_bug_report_images(&dir, &images)?;
-    Ok(dir.to_string_lossy().to_string())
+    let staged = write_bug_report_images(&dir, &images)?;
+    Ok(StagedBugReport {
+        dir: dir.to_string_lossy().to_string(),
+        images: staged,
+    })
 }
 
 #[tauri::command]
@@ -388,15 +414,17 @@ mod tests {
         let _ = fs::remove_dir_all(&dir);
 
         let png_b64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=";
-        write_bug_report_images(
+        let staged = write_bug_report_images(
             &dir,
             &[
                 BugReportImageInput {
                     file_name: "../../board freeze.png".to_string(),
+                    mime_type: "image/png".to_string(),
                     data_base64: png_b64.to_string(),
                 },
                 BugReportImageInput {
                     file_name: "second.png".to_string(),
+                    mime_type: "image/png".to_string(),
                     data_base64: png_b64.to_string(),
                 },
             ],
@@ -405,6 +433,13 @@ mod tests {
 
         assert!(dir.join("01-board_freeze.png").is_file());
         assert!(dir.join("02-second.png").is_file());
+        assert_eq!(staged.len(), 2);
+        assert_eq!(staged[0].file_name, "../../board freeze.png");
+        assert_eq!(staged[0].mime_type, "image/png");
+        assert_eq!(
+            staged[0].path,
+            dir.join("01-board_freeze.png").to_string_lossy()
+        );
         assert_eq!(
             fs::read(dir.join("02-second.png")).unwrap(),
             STANDARD.decode(png_b64).unwrap()
@@ -422,6 +457,7 @@ mod tests {
             &dir,
             &[BugReportImageInput {
                 file_name: "shot.png".to_string(),
+                mime_type: "image/png".to_string(),
                 data_base64: "not base64!!".to_string(),
             }],
         );

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -260,6 +260,7 @@ pub fn run() {
             attachment::attachment_delete,
             attachment::attachment_read_dropped,
             attachment::bug_report_stage_images,
+            attachment::bug_report_discard_images,
             attachment::bug_report_reveal_images,
             file_versions::file_versions_begin_snapshot,
             file_versions::file_versions_finalize_snapshot,

--- a/apps/desktop/src/features/settings/components/ReportIssueStudio/index.test.tsx
+++ b/apps/desktop/src/features/settings/components/ReportIssueStudio/index.test.tsx
@@ -302,6 +302,9 @@ describe('ReportIssueStudio', () => {
       'Filed on GitHub with your images, under your account.',
       expect.objectContaining({ title: 'Issue sent' }),
     );
+    expect(mocks.invoke).toHaveBeenCalledWith('bug_report_discard_images', {
+      dir: '/tmp/goodboy-report-1',
+    });
   });
 
   it('falls back to the drag reminder when the upload does not go through', async () => {
@@ -336,6 +339,14 @@ describe('ReportIssueStudio', () => {
       "Your images aren't on it yet. GitHub only takes them by drag and drop.",
       expect.objectContaining({ persist: true }),
     );
+    expect(mocks.invoke).not.toHaveBeenCalledWith('bug_report_discard_images', expect.anything());
+  });
+
+  it('does not promise an upload the browser path cannot make', () => {
+    setGithubStatus({ available: false, mode: 'absent' });
+    render(<ReportIssueStudio onClose={vi.fn()} />);
+
+    expect(screen.getByText(/The GitHub form cannot carry them/)).toBeDefined();
   });
 
   it('writes the attached image bytes out to a folder before the issue is filed', async () => {

--- a/apps/desktop/src/features/settings/components/ReportIssueStudio/index.test.tsx
+++ b/apps/desktop/src/features/settings/components/ReportIssueStudio/index.test.tsx
@@ -7,14 +7,22 @@ import type { GhTokenStatus } from '@goodboy/types';
 type GhRunResult = { stdout: string; stderr: string; exitCode: number };
 type DragHandler = (event: { payload: unknown }) => void;
 
+const STAGED_REPORT = {
+  dir: '/tmp/goodboy-report-1',
+  images: [
+    { fileName: 'board.png', mimeType: 'image/png', path: '/tmp/goodboy-report-1/01-board.png' },
+  ],
+};
+
 const mocks = vi.hoisted(() => ({
   run: vi.fn<
     (args: ReadonlyArray<string>, opts: Readonly<Record<string, unknown>>) => Promise<GhRunResult>
   >(async () => ({ stdout: '', stderr: '', exitCode: 0 })),
   openUrl: vi.fn<(url: string) => Promise<void>>(async () => undefined),
-  invoke: vi.fn<(cmd: string, args: Record<string, unknown>) => Promise<unknown>>(
-    async () => '/tmp/goodboy-report-1',
-  ),
+  invoke: vi.fn<(cmd: string, args: Record<string, unknown>) => Promise<unknown>>(async () => ({
+    dir: '/tmp/goodboy-report-1',
+    images: [],
+  })),
   showToast: vi.fn(),
   dragHandlers: Array<DragHandler>(),
 }));
@@ -96,7 +104,7 @@ beforeEach(() => {
   mocks.openUrl.mockReset();
   mocks.openUrl.mockImplementation(async () => undefined);
   mocks.invoke.mockReset();
-  mocks.invoke.mockImplementation(async () => '/tmp/goodboy-report-1');
+  mocks.invoke.mockImplementation(async () => STAGED_REPORT);
   mocks.showToast.mockReset();
   mocks.dragHandlers = [];
 });
@@ -187,7 +195,7 @@ describe('ReportIssueStudio', () => {
             mimeType: 'image/png',
             dataBase64: 'aGk=',
           }
-        : '/tmp/goodboy-report-1',
+        : STAGED_REPORT,
     );
     render(<ReportIssueStudio onClose={vi.fn()} />);
 
@@ -218,6 +226,9 @@ describe('ReportIssueStudio', () => {
     expect(measure?.contains(footer as Node)).toBe(true);
     expect(preview.nextElementSibling).toBe(footer);
   });
+
+  const issueCreateArgs = (): ReadonlyArray<string> =>
+    mocks.run.mock.calls.map((call) => call[0]).find((args) => args[0] === 'issue') ?? [];
 
   const attachOneImage = () => {
     useAppStore.getState().addBugReportImages({
@@ -250,8 +261,80 @@ describe('ReportIssueStudio', () => {
       fireEvent.click(screen.getByRole('button', { name: 'Send' }));
     });
 
-    expect(mocks.run.mock.calls[0]?.[0]).toContain(
+    expect(issueCreateArgs()).toContain(
       'Type: Bug\nArea: Board and sessions\nVersion: 0.1.69\n\nFreezes on archive.\n\nScreenshots to drag into this issue: board.png',
+    );
+  });
+
+  it('embeds the uploaded screenshots in the issue and drops the drag reminder', async () => {
+    setGithubStatus({ available: true, mode: 'gh-cli' });
+    attachOneImage();
+    mocks.invoke.mockImplementation(async () => STAGED_REPORT);
+    mocks.run.mockImplementation(async (args) => {
+      if (args[0] === 'api' && args[1] === 'repos/akhayam99/goodboy') {
+        return { stdout: '1231334462\n', stderr: '', exitCode: 0 };
+      }
+      if (args[0] === 'api') {
+        return {
+          stdout: '{"url":"https://github.com/user-attachments/assets/aaa"}',
+          stderr: '',
+          exitCode: 0,
+        };
+      }
+      return {
+        stdout: 'https://github.com/akhayam99/goodboy/issues/99\n',
+        stderr: '',
+        exitCode: 0,
+      };
+    });
+    render(<ReportIssueStudio onClose={vi.fn()} />);
+
+    fillReport({ area: 'board-sessions', title: 'Board freeze', notes: 'Freezes on archive.' });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Send' }));
+    });
+
+    const body = issueCreateArgs().at(-1) ?? '';
+    expect(body).toContain('![board.png](https://github.com/user-attachments/assets/aaa)');
+    expect(body).not.toContain('Screenshots to drag into this issue');
+    expect(mocks.showToast).toHaveBeenCalledWith(
+      'success',
+      'Filed on GitHub with your images, under your account.',
+      expect.objectContaining({ title: 'Issue sent' }),
+    );
+  });
+
+  it('falls back to the drag reminder when the upload does not go through', async () => {
+    setGithubStatus({ available: true, mode: 'gh-cli' });
+    attachOneImage();
+    mocks.invoke.mockImplementation(async () => STAGED_REPORT);
+    mocks.run.mockImplementation(async (args) => {
+      if (args[0] === 'api' && args[1] === 'repos/akhayam99/goodboy') {
+        return { stdout: '1231334462\n', stderr: '', exitCode: 0 };
+      }
+      if (args[0] === 'api') {
+        return { stdout: '', stderr: 'gone', exitCode: 1 };
+      }
+      return {
+        stdout: 'https://github.com/akhayam99/goodboy/issues/99\n',
+        stderr: '',
+        exitCode: 0,
+      };
+    });
+    render(<ReportIssueStudio onClose={vi.fn()} />);
+
+    fillReport({ area: 'board-sessions', title: 'Board freeze', notes: 'Freezes on archive.' });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Send' }));
+    });
+
+    expect(issueCreateArgs().at(-1) ?? '').toContain(
+      'Screenshots to drag into this issue: board.png',
+    );
+    expect(mocks.showToast).toHaveBeenCalledWith(
+      'success',
+      "Your images aren't on it yet. GitHub only takes them by drag and drop.",
+      expect.objectContaining({ persist: true }),
     );
   });
 
@@ -271,7 +354,7 @@ describe('ReportIssueStudio', () => {
     });
 
     expect(mocks.invoke).toHaveBeenCalledWith('bug_report_stage_images', {
-      images: [{ fileName: 'board.png', dataBase64: 'AAAA' }],
+      images: [{ fileName: 'board.png', mimeType: 'image/png', dataBase64: 'AAAA' }],
     });
   });
 
@@ -312,7 +395,7 @@ describe('ReportIssueStudio', () => {
     });
 
     expect(mocks.invoke).toHaveBeenCalledWith('bug_report_stage_images', {
-      images: [{ fileName: 'board.png', dataBase64: 'AAAA' }],
+      images: [{ fileName: 'board.png', mimeType: 'image/png', dataBase64: 'AAAA' }],
     });
     expect(mocks.openUrl).toHaveBeenCalledTimes(1);
   });

--- a/apps/desktop/src/features/settings/components/ReportIssueStudio/index.tsx
+++ b/apps/desktop/src/features/settings/components/ReportIssueStudio/index.tsx
@@ -31,7 +31,12 @@ import { guessArea } from './guessArea';
 import { buildFallbackIssue, buildIssueBody, isOpenableUrl } from './issuePayload';
 import { parseIssueCreateResult } from './parseIssueCreateResult';
 import { previewHint } from './previewHint';
-import { revealBugReportImages, stageBugReportImages, type StagedBugReport } from './stageImages';
+import {
+  discardBugReportImages,
+  revealBugReportImages,
+  stageBugReportImages,
+  type StagedBugReport,
+} from './stageImages';
 import { truncationNotice } from './truncationNotice';
 import { uploadIssueAttachments } from './uploadIssueAttachments';
 
@@ -191,6 +196,9 @@ export const ReportIssueStudio = ({ onClose }: Props) => {
         const issueUrl = parsed.url;
         clearBugReportDraft();
         requestClose();
+        if (stagedImagesDir != null && uploaded != null) {
+          void discardBugReportImages({ dir: stagedImagesDir });
+        }
         if (stagedImagesDir == null || uploaded != null) {
           showToast(
             'success',
@@ -293,7 +301,11 @@ export const ReportIssueStudio = ({ onClose }: Props) => {
                 />
                 <FieldRow
                   label="Images"
-                  help="Attached to the issue when you send. If GitHub turns them away, one click opens the issue and the folder, so you can drag them in."
+                  help={
+                    sendsDirectly
+                      ? 'Attached to the issue when you send. If GitHub turns them away, one click opens the issue and the folder, so you can drag them in.'
+                      : 'The GitHub form cannot carry them. It opens with the folder beside it, so you can drag them in.'
+                  }
                   layout="stacked"
                 >
                   <BugReportImages control={imageControl} />

--- a/apps/desktop/src/features/settings/components/ReportIssueStudio/index.tsx
+++ b/apps/desktop/src/features/settings/components/ReportIssueStudio/index.tsx
@@ -31,8 +31,9 @@ import { guessArea } from './guessArea';
 import { buildFallbackIssue, buildIssueBody, isOpenableUrl } from './issuePayload';
 import { parseIssueCreateResult } from './parseIssueCreateResult';
 import { previewHint } from './previewHint';
-import { revealBugReportImages, stageBugReportImages } from './stageImages';
+import { revealBugReportImages, stageBugReportImages, type StagedBugReport } from './stageImages';
 import { truncationNotice } from './truncationNotice';
+import { uploadIssueAttachments } from './uploadIssueAttachments';
 
 type Props = {
   readonly onClose: () => void;
@@ -140,16 +141,25 @@ export const ReportIssueStudio = ({ onClose }: Props) => {
     setSendState('sending');
     setErrorMessage(null);
 
-    let stagedImagesDir: string | null;
+    let staged: StagedBugReport | null;
     try {
-      stagedImagesDir = await stageBugReportImages({ images: imageControl.images });
+      staged = await stageBugReportImages({ images: imageControl.images });
     } catch (err) {
       setSendState('error');
       setErrorMessage(`Could not prepare the images to attach. ${formatError(err)}`);
       return;
     }
+    const stagedImagesDir = staged?.dir ?? null;
 
     if (sendsDirectly) {
+      const uploaded =
+        staged == null
+          ? null
+          : await uploadIssueAttachments({
+              runner: tauriGhRunner,
+              repo: REPORT_ISSUE_REPO,
+              images: staged.images,
+            });
       try {
         const result = await tauriGhRunner.run(
           [
@@ -160,7 +170,15 @@ export const ReportIssueStudio = ({ onClose }: Props) => {
             '--title',
             trimmedTitle,
             '--body',
-            directBody,
+            uploaded == null
+              ? directBody
+              : buildIssueBody({
+                  typeLabel,
+                  version: version ?? '',
+                  areaLabel,
+                  notes: trimmedNotes,
+                  uploadedImages: uploaded,
+                }),
           ],
           {},
         );
@@ -173,14 +191,20 @@ export const ReportIssueStudio = ({ onClose }: Props) => {
         const issueUrl = parsed.url;
         clearBugReportDraft();
         requestClose();
-        if (stagedImagesDir == null) {
-          showToast('success', 'Filed on GitHub, under your account.', {
-            title: 'Issue sent',
-            action:
-              issueUrl == null
-                ? undefined
-                : { label: 'View issue', onClick: () => void openUrl(issueUrl) },
-          });
+        if (stagedImagesDir == null || uploaded != null) {
+          showToast(
+            'success',
+            uploaded == null
+              ? 'Filed on GitHub, under your account.'
+              : 'Filed on GitHub with your images, under your account.',
+            {
+              title: 'Issue sent',
+              action:
+                issueUrl == null
+                  ? undefined
+                  : { label: 'View issue', onClick: () => void openUrl(issueUrl) },
+            },
+          );
           return;
         }
         const action =
@@ -269,7 +293,7 @@ export const ReportIssueStudio = ({ onClose }: Props) => {
                 />
                 <FieldRow
                   label="Images"
-                  help="GitHub only takes images by hand. After you send, one click opens the issue and the folder, so you can drag them in."
+                  help="Attached to the issue when you send. If GitHub turns them away, one click opens the issue and the folder, so you can drag them in."
                   layout="stacked"
                 >
                   <BugReportImages control={imageControl} />

--- a/apps/desktop/src/features/settings/components/ReportIssueStudio/issuePayload.test.ts
+++ b/apps/desktop/src/features/settings/components/ReportIssueStudio/issuePayload.test.ts
@@ -22,6 +22,25 @@ describe('buildIssueBody', () => {
     );
   });
 
+  it('embeds the uploaded screenshots and escapes what would break the markdown', () => {
+    const body = buildIssueBody({
+      typeLabel: 'Bug',
+      version: '0.1.69',
+      areaLabel: 'Board and sessions',
+      notes: 'Freezes on archive.',
+      imageNames: ['a]b\\c.png'],
+      uploadedImages: [
+        { name: 'a]b\\c.png', url: 'https://github.com/user-attachments/assets/aaa' },
+        { name: 'plain.png', url: 'https://github.com/user-attachments/assets/bbb' },
+      ],
+    });
+
+    expect(body).toContain(
+      '![a\\]b\\\\c.png](https://github.com/user-attachments/assets/aaa)\n![plain.png](https://github.com/user-attachments/assets/bbb)',
+    );
+    expect(body).not.toContain('Screenshots to drag into this issue');
+  });
+
   it('names the staged screenshots so the reporter can drag them in', () => {
     const body = buildIssueBody({
       typeLabel: 'Bug',

--- a/apps/desktop/src/features/settings/components/ReportIssueStudio/issuePayload.ts
+++ b/apps/desktop/src/features/settings/components/ReportIssueStudio/issuePayload.ts
@@ -6,6 +6,7 @@ import {
   MAX_ISSUE_URL_BYTES,
   withoutLoneSurrogates,
 } from '../../issueUrl';
+import type { UploadedIssueImage } from './uploadIssueAttachments';
 
 const TRUNCATION_NOTICE =
   '\n\n[Notes truncated to fit the GitHub link. Finish writing after the issue opens.]';
@@ -16,7 +17,10 @@ type BuildIssueBodyParams = {
   readonly areaLabel: string;
   readonly notes: string;
   readonly imageNames?: ReadonlyArray<string>;
+  readonly uploadedImages?: ReadonlyArray<UploadedIssueImage>;
 };
+
+const escapeAltText = (name: string): string => name.replace(/[[\]\\]/g, (match) => `\\${match}`);
 
 export const buildIssueBody = ({
   typeLabel,
@@ -24,8 +28,15 @@ export const buildIssueBody = ({
   areaLabel,
   notes,
   imageNames = [],
+  uploadedImages = [],
 }: BuildIssueBodyParams): string => {
   const head = `Type: ${typeLabel}\nArea: ${areaLabel}\nVersion: ${version}\n\n${notes}`;
+  if (uploadedImages.length > 0) {
+    const embeds = uploadedImages
+      .map((image) => `![${escapeAltText(image.name)}](${image.url})`)
+      .join('\n');
+    return `${head}\n\n${embeds}`;
+  }
   if (imageNames.length === 0) {
     return head;
   }

--- a/apps/desktop/src/features/settings/components/ReportIssueStudio/stageImages.ts
+++ b/apps/desktop/src/features/settings/components/ReportIssueStudio/stageImages.ts
@@ -10,13 +10,25 @@ const base64FromDataUrl = (dataUrl: string): string => {
   return comma === -1 ? dataUrl : dataUrl.slice(comma + 1);
 };
 
-export const stageBugReportImages = async ({ images }: Params): Promise<string | null> => {
+export type StagedBugReportImage = {
+  readonly fileName: string;
+  readonly mimeType: string;
+  readonly path: string;
+};
+
+export type StagedBugReport = {
+  readonly dir: string;
+  readonly images: ReadonlyArray<StagedBugReportImage>;
+};
+
+export const stageBugReportImages = async ({ images }: Params): Promise<StagedBugReport | null> => {
   if (images.length === 0) {
     return null;
   }
-  return invoke<string>('bug_report_stage_images', {
+  return invoke<StagedBugReport>('bug_report_stage_images', {
     images: images.map((image) => ({
       fileName: image.fileName,
+      mimeType: image.mimeType,
       dataBase64: base64FromDataUrl(image.dataUrl),
     })),
   });

--- a/apps/desktop/src/features/settings/components/ReportIssueStudio/stageImages.ts
+++ b/apps/desktop/src/features/settings/components/ReportIssueStudio/stageImages.ts
@@ -41,3 +41,11 @@ type RevealParams = {
 export const revealBugReportImages = async ({ dir }: RevealParams): Promise<void> => {
   await invoke('bug_report_reveal_images', { dir });
 };
+
+export const discardBugReportImages = async ({ dir }: RevealParams): Promise<void> => {
+  try {
+    await invoke('bug_report_discard_images', { dir });
+  } catch {
+    return;
+  }
+};

--- a/apps/desktop/src/features/settings/components/ReportIssueStudio/uploadIssueAttachments.test.ts
+++ b/apps/desktop/src/features/settings/components/ReportIssueStudio/uploadIssueAttachments.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it, vi } from 'vitest';
+import { uploadIssueAttachments } from './uploadIssueAttachments';
+
+type Call = ReadonlyArray<string>;
+
+const stagedImage = (overrides: Partial<{ fileName: string; mimeType: string; path: string }>) => ({
+  fileName: 'board.png',
+  mimeType: 'image/png',
+  path: '/tmp/goodboy-report-1/01-board.png',
+  ...overrides,
+});
+
+const runnerFor = (results: ReadonlyArray<{ stdout: string; exitCode: number }>) => {
+  const calls: Call[] = [];
+  let index = 0;
+  return {
+    calls,
+    runner: {
+      run: vi.fn(async (args: ReadonlyArray<string>) => {
+        calls.push(args);
+        const result = results[index] ?? { stdout: '', exitCode: 1 };
+        index += 1;
+        return { stdout: result.stdout, stderr: '', exitCode: result.exitCode };
+      }),
+    },
+  };
+};
+
+describe('uploadIssueAttachments', () => {
+  it('posts every image to the attachment host and returns the urls in order', async () => {
+    const { runner, calls } = runnerFor([
+      { stdout: '1231334462\n', exitCode: 0 },
+      { stdout: '{"url":"https://github.com/user-attachments/assets/aaa"}', exitCode: 0 },
+      { stdout: '{"url":"https://github.com/user-attachments/assets/bbb"}', exitCode: 0 },
+    ]);
+
+    const uploaded = await uploadIssueAttachments({
+      runner,
+      repo: 'akhayam99/goodboy',
+      images: [
+        stagedImage({}),
+        stagedImage({ fileName: 'console.jpg', mimeType: '', path: '/tmp/r/02-console.jpg' }),
+      ],
+    });
+
+    expect(uploaded).toEqual([
+      { name: 'board.png', url: 'https://github.com/user-attachments/assets/aaa' },
+      { name: 'console.jpg', url: 'https://github.com/user-attachments/assets/bbb' },
+    ]);
+    expect(calls[0]).toEqual(['api', 'repos/akhayam99/goodboy', '--jq', '.id']);
+    expect(calls[1]?.[3]).toBe(
+      'https://uploads.github.com/user-attachments/assets?name=board.png&content_type=image%2Fpng&repository_id=1231334462',
+    );
+    expect(calls[1]).toContain('--input');
+    expect(calls[1]?.at(-1)).toBe('/tmp/goodboy-report-1/01-board.png');
+    expect(calls[2]?.[3]).toContain('content_type=image%2Fjpeg');
+  });
+
+  it('escapes a name that would break the query string', async () => {
+    const { runner, calls } = runnerFor([
+      { stdout: '7\n', exitCode: 0 },
+      { stdout: '{"url":"https://github.com/user-attachments/assets/aaa"}', exitCode: 0 },
+    ]);
+
+    await uploadIssueAttachments({
+      runner,
+      repo: 'akhayam99/goodboy',
+      images: [stagedImage({ fileName: 'board freeze&crash.png' })],
+    });
+
+    expect(calls[1]?.[3]).toContain('name=board+freeze%26crash.png');
+  });
+
+  it('abandons the batch when one upload fails', async () => {
+    const { runner } = runnerFor([
+      { stdout: '7\n', exitCode: 0 },
+      { stdout: '{"url":"https://github.com/user-attachments/assets/aaa"}', exitCode: 0 },
+      { stdout: 'gone', exitCode: 1 },
+    ]);
+
+    const uploaded = await uploadIssueAttachments({
+      runner,
+      repo: 'akhayam99/goodboy',
+      images: [stagedImage({}), stagedImage({ fileName: 'second.png' })],
+    });
+
+    expect(uploaded).toBeNull();
+  });
+
+  it('refuses an answer that is not an attachment url', async () => {
+    const { runner } = runnerFor([
+      { stdout: '7\n', exitCode: 0 },
+      { stdout: '{"url":"https://evil.example/asset"}', exitCode: 0 },
+    ]);
+
+    const uploaded = await uploadIssueAttachments({
+      runner,
+      repo: 'akhayam99/goodboy',
+      images: [stagedImage({})],
+    });
+
+    expect(uploaded).toBeNull();
+  });
+
+  it('survives an answer that is not json', async () => {
+    const { runner } = runnerFor([
+      { stdout: '7\n', exitCode: 0 },
+      { stdout: '<html>gateway timeout</html>', exitCode: 0 },
+    ]);
+
+    const uploaded = await uploadIssueAttachments({
+      runner,
+      repo: 'akhayam99/goodboy',
+      images: [stagedImage({})],
+    });
+
+    expect(uploaded).toBeNull();
+  });
+
+  it('gives up when the repository id cannot be read', async () => {
+    const { runner, calls } = runnerFor([{ stdout: 'not-a-number', exitCode: 0 }]);
+
+    const uploaded = await uploadIssueAttachments({
+      runner,
+      repo: 'akhayam99/goodboy',
+      images: [stagedImage({})],
+    });
+
+    expect(uploaded).toBeNull();
+    expect(calls).toHaveLength(1);
+  });
+
+  it('does nothing without images', async () => {
+    const { runner, calls } = runnerFor([]);
+
+    expect(
+      await uploadIssueAttachments({ runner, repo: 'akhayam99/goodboy', images: [] }),
+    ).toBeNull();
+    expect(calls).toHaveLength(0);
+  });
+});

--- a/apps/desktop/src/features/settings/components/ReportIssueStudio/uploadIssueAttachments.ts
+++ b/apps/desktop/src/features/settings/components/ReportIssueStudio/uploadIssueAttachments.ts
@@ -1,0 +1,113 @@
+import type { GhRunner } from '@goodboy/core';
+import type { StagedBugReportImage } from './stageImages';
+
+const UPLOAD_ENDPOINT = 'https://uploads.github.com/user-attachments/assets';
+
+const ATTACHMENT_URL_PREFIX = 'https://github.com/user-attachments/assets/';
+
+const UPLOAD_TIMEOUT_MS = 60_000;
+
+const MIME_BY_EXTENSION: Record<string, string> = {
+  gif: 'image/gif',
+  jpeg: 'image/jpeg',
+  jpg: 'image/jpeg',
+  png: 'image/png',
+  webp: 'image/webp',
+};
+
+export type UploadedIssueImage = {
+  readonly name: string;
+  readonly url: string;
+};
+
+const imageMimeType = ({ image }: { readonly image: StagedBugReportImage }): string => {
+  if (image.mimeType.startsWith('image/')) {
+    return image.mimeType;
+  }
+  const extension = image.fileName.split('.').pop()?.toLowerCase() ?? '';
+  return MIME_BY_EXTENSION[extension] ?? 'image/png';
+};
+
+const parseAttachmentUrl = ({ stdout }: { readonly stdout: string }): string | null => {
+  try {
+    const payload: unknown = JSON.parse(stdout);
+    if (typeof payload !== 'object' || payload === null || !('url' in payload)) {
+      return null;
+    }
+    const { url } = payload as { readonly url: unknown };
+    return typeof url === 'string' && url.startsWith(ATTACHMENT_URL_PREFIX) ? url : null;
+  } catch {
+    return null;
+  }
+};
+
+type RepositoryIdParams = {
+  readonly runner: GhRunner;
+  readonly repo: string;
+};
+
+const repositoryId = async ({ runner, repo }: RepositoryIdParams): Promise<string | null> => {
+  const result = await runner.run(['api', `repos/${repo}`, '--jq', '.id'], {});
+  if (result.exitCode !== 0) {
+    return null;
+  }
+  const id = result.stdout.trim();
+  return /^[0-9]+$/.test(id) ? id : null;
+};
+
+type Params = {
+  readonly runner: GhRunner;
+  readonly repo: string;
+  readonly images: ReadonlyArray<StagedBugReportImage>;
+};
+
+export const uploadIssueAttachments = async ({
+  runner,
+  repo,
+  images,
+}: Params): Promise<ReadonlyArray<UploadedIssueImage> | null> => {
+  if (images.length === 0) {
+    return null;
+  }
+  try {
+    const id = await repositoryId({ runner, repo });
+    if (id == null) {
+      return null;
+    }
+    const uploaded: UploadedIssueImage[] = [];
+    for (const image of images) {
+      const mimeType = imageMimeType({ image });
+      const query = new URLSearchParams({
+        name: image.fileName,
+        content_type: mimeType,
+        repository_id: id,
+      });
+      const result = await runner.run(
+        [
+          'api',
+          '--method',
+          'POST',
+          `${UPLOAD_ENDPOINT}?${query.toString()}`,
+          '-H',
+          `Content-Type: ${mimeType}`,
+          '-H',
+          'Accept: application/json',
+          '--input',
+          image.path,
+        ],
+        { timeoutMs: UPLOAD_TIMEOUT_MS },
+      );
+      if (result.exitCode !== 0) {
+        return null;
+      }
+      const url = parseAttachmentUrl({ stdout: result.stdout });
+      if (url == null) {
+        return null;
+      }
+      uploaded.push({ name: image.fileName, url });
+    }
+    return uploaded;
+  } catch {
+    return null;
+  }
+};


### PR DESCRIPTION
Follow-up to #1519, which removed the repository-on-your-account version of this. The screenshots go back into the issue, this time through the host the browser itself posts to.

## What

`POST https://uploads.github.com/user-attachments/assets?name=&content_type=&repository_id=` with a Bearer token, which is what the browser does when you drop an image into a comment box. It answers `{"url":"https://github.com/user-attachments/assets/<uuid>"}`, and that url goes into the body as `![name](url)`.

The upload is scoped to the repository the report is filed against. **Nothing is created on the reporter's account**: no repository, no gist, no setting to remember, no consent step to click through.

- `bug_report_stage_images` now answers with the folder **and** each staged file (name, mime type, absolute path). The upload reads the bytes from there, so no second staging command and no base64 in argv.
- `uploadIssueAttachments` resolves the numeric repository id once, then posts each image through `gh api --input`, the runner the studio already uses. Any non-zero exit, any answer that is not JSON, and any url outside the attachment host abandons the whole batch.
- `buildIssueBody` embeds the returned urls when there are any, and keeps the drag reminder for when there are not. Alt text escapes brackets and backslashes.
- The help line under the images now says what actually happens.

## Verified against the live endpoint

- Upload through `curl` and through `gh api --input`: both answered with an attachment url, and the asset came back `200 image/png`, 70 bytes, byte-for-byte the file that went up.
- Before being referenced, the asset is `404` to an anonymous reader. Filed a throwaway issue on this repository embedding it: the same url turned `200` publicly. Issue deleted afterwards.

## The caveat, stated plainly

The endpoint is undocumented. GitHub has no public API for comment attachments, and this one only started accepting a token instead of a session cookie recently. It can change without notice, which is why every failure lands on the path #1519 restored: the folder stays on disk, the body names the files, and the toast opens the issue and the folder for a manual drag.

Also unproven from here: a reporter without push access on this repository. The browser flow lets any user attach images to an issue they file on a public repository, so the same should hold for the token, but the test above ran with an account that owns the repository. If it does not hold, that reporter gets the drag path.

## Test plan

- `apps/desktop`: `npx tsc --noEmit` clean.
- `apps/desktop`: `npx vitest run src/features/settings`: 12 files, 116 tests pass. New: 7 cases on the uploader (argv shape, query escaping, order of returned urls, batch abandoned on a failed upload, url outside the host refused, non-JSON answer, unreadable repository id) and 2 on the studio (uploaded images embedded with no drag reminder and the images toast, failed upload falling back to the reminder).
- `apps/desktop/src-tauri`: `cargo test --locked`: 506 passed, 0 failed, including the staged paths coming back from staging.
- `pnpm knip --include files,duplicates,unlisted`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)