### PR TITLE
feat(desktop): connect slack with a user token

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -61,7 +61,7 @@ Goodboy runs entirely on your machine, no backend:
 - No telemetry, of any kind, ever. Adding it is refused whoever asks.
 
 Caveat: a personal API key you paste for an integration (GitHub, GitLab, Jira,
-Bitbucket, Linear, Sentry), or a Slack bot token, is stored locally but sent to
+Bitbucket, Linear, Sentry), or a Slack user token, is stored locally but sent to
 that provider on every request. Local-only storage does not mean the credential
 never travels.
 

--- a/apps/desktop/src-tauri/src/slack.rs
+++ b/apps/desktop/src-tauri/src/slack.rs
@@ -29,7 +29,7 @@ const API_BASE: &str = "https://slack.com/api";
 const MAX_PAGES: u32 = 20;
 const PAGE_LEN: u32 = 200;
 
-const AUTH_HINT: &str = "slack rejected the token. goodboy signs every call with the bot token you pasted as a bearer token, so it has to start with xoxb- and belong to an app installed in this workspace. check that the app grants channels:read, channels:history, users:read, chat:write and reactions:write";
+const AUTH_HINT: &str = "slack rejected the token. goodboy signs every call with the user token you pasted as a bearer token, so it has to start with xoxp- and belong to an app installed in this workspace. check that the app grants channels:read, channels:history, users:read, chat:write and reactions:write under user token scopes";
 
 #[derive(Debug, Error)]
 pub enum SlackError {
@@ -45,7 +45,7 @@ pub enum SlackError {
     Api(String),
     #[error("invalid response shape: {0}")]
     InvalidShape(String),
-    #[error("no bot token stored for workspace {0}")]
+    #[error("no slack token stored for workspace {0}")]
     NoToken(String),
     #[error("credential store error: {0}")]
     Credential(#[from] IntegrationCredentialError),
@@ -1312,6 +1312,23 @@ mod tests {
     }
 
     #[test]
+    fn the_auth_hint_asks_for_a_user_token_and_names_every_scope() {
+        assert!(AUTH_HINT.contains("user token"));
+        assert!(AUTH_HINT.contains("xoxp-"));
+        assert!(!AUTH_HINT.contains("xoxb-"));
+        assert!(!AUTH_HINT.contains("bot"));
+        for scope in [
+            "channels:read",
+            "channels:history",
+            "users:read",
+            "chat:write",
+            "reactions:write",
+        ] {
+            assert!(AUTH_HINT.contains(scope), "the hint drops {scope}");
+        }
+    }
+
+    #[test]
     fn the_envelope_decoder_classifies_the_ok_false_error_tokens() {
         let auth =
             decode_slack_envelope(&serde_json::json!({"ok": false, "error": "invalid_auth"}))
@@ -1352,14 +1369,14 @@ mod tests {
         )])
         .await;
 
-        let connection = validate_connection(&server.base, "xoxb-secret")
+        let connection = validate_connection(&server.base, "xoxp-secret")
             .await
             .unwrap();
 
         let request = server.only();
         assert_eq!(request.method, "POST");
         assert_eq!(request.path(), "/auth.test");
-        assert_eq!(request.authorization.as_deref(), Some("Bearer xoxb-secret"));
+        assert_eq!(request.authorization.as_deref(), Some("Bearer xoxp-secret"));
         assert_eq!(connection.team_id, "T01");
         assert_eq!(connection.team_name, "Acme");
         assert_eq!(connection.bot_user_id, "U09");
@@ -1374,7 +1391,7 @@ mod tests {
         }])
         .await;
 
-        let error = validate_connection(&server.base, "xoxb-secret")
+        let error = validate_connection(&server.base, "xoxp-secret")
             .await
             .unwrap_err();
 
@@ -1393,7 +1410,7 @@ mod tests {
         }])
         .await;
 
-        let error = validate_connection(&server.base, "xoxb-secret")
+        let error = validate_connection(&server.base, "xoxp-secret")
             .await
             .unwrap_err();
 
@@ -1407,7 +1424,7 @@ mod tests {
         )])
         .await;
 
-        let error = list_channels(&server.base, "xoxb-secret")
+        let error = list_channels(&server.base, "xoxp-secret")
             .await
             .unwrap_err();
 
@@ -1425,7 +1442,7 @@ mod tests {
         )])
         .await;
 
-        let channels = list_channels(&server.base, "xoxb-secret").await.unwrap();
+        let channels = list_channels(&server.base, "xoxp-secret").await.unwrap();
 
         let request = server.only();
         assert_eq!(request.method, "GET");
@@ -1447,7 +1464,7 @@ mod tests {
         )])
         .await;
 
-        let heads = list_thread_heads(&server.base, "xoxb-secret", "C0EN")
+        let heads = list_thread_heads(&server.base, "xoxp-secret", "C0EN")
             .await
             .unwrap();
 
@@ -1470,7 +1487,7 @@ mod tests {
         )])
         .await;
 
-        let thread = get_thread(&server.base, "xoxb-secret", "C0EN", "1723456789.123456")
+        let thread = get_thread(&server.base, "xoxp-secret", "C0EN", "1723456789.123456")
             .await
             .unwrap();
 
@@ -1490,7 +1507,7 @@ mod tests {
         )])
         .await;
 
-        let permalink = get_permalink(&server.base, "xoxb-secret", "C0EN", "1723456789.123456")
+        let permalink = get_permalink(&server.base, "xoxp-secret", "C0EN", "1723456789.123456")
             .await
             .unwrap();
 
@@ -1514,7 +1531,7 @@ mod tests {
         )])
         .await;
 
-        let users = list_users(&server.base, "xoxb-secret").await.unwrap();
+        let users = list_users(&server.base, "xoxp-secret").await.unwrap();
 
         let request = server.only();
         assert_eq!(request.method, "GET");
@@ -1537,7 +1554,7 @@ mod tests {
 
         let message = post_reply(
             &server.base,
-            "xoxb-secret",
+            "xoxp-secret",
             "C0EN",
             "1723456789.123456",
             "on it",
@@ -1548,7 +1565,7 @@ mod tests {
         let request = server.only();
         assert_eq!(request.method, "POST");
         assert_eq!(request.path(), "/chat.postMessage");
-        assert_eq!(request.authorization.as_deref(), Some("Bearer xoxb-secret"));
+        assert_eq!(request.authorization.as_deref(), Some("Bearer xoxp-secret"));
         assert_eq!(request.json()["thread_ts"], "1723456789.123456");
         assert_eq!(request.json()["text"], "on it");
         assert_eq!(message.ts, "1723460000.000200");
@@ -1561,7 +1578,7 @@ mod tests {
 
         add_reaction(
             &server.base,
-            "xoxb-secret",
+            "xoxp-secret",
             "C0EN",
             "1723456789.123456",
             "eyes",
@@ -1583,7 +1600,7 @@ mod tests {
 
         let error = add_reaction(
             &server.base,
-            "xoxb-secret",
+            "xoxp-secret",
             "C0EN",
             "1723456789.123456",
             "eyes",
@@ -1606,7 +1623,7 @@ mod tests {
         ])
         .await;
 
-        let channels = list_channels(&server.base, "xoxb-secret").await.unwrap();
+        let channels = list_channels(&server.base, "xoxp-secret").await.unwrap();
 
         let taken = server.taken();
         assert_eq!(taken.len(), 2);

--- a/apps/desktop/src/features/integrations/ConnectIntegrationEmptyState.test.tsx
+++ b/apps/desktop/src/features/integrations/ConnectIntegrationEmptyState.test.tsx
@@ -42,7 +42,7 @@ const PROVIDERS = [
   ['gitlab', 'GitLab', 'Personal API key'],
   ['jira', 'Jira', 'Personal API key'],
   ['bitbucket', 'Bitbucket', 'Personal API key'],
-  ['slack', 'Slack', 'Bot token'],
+  ['slack', 'Slack', 'User token'],
 ] as const;
 
 afterEach(cleanup);
@@ -76,10 +76,11 @@ describe('ConnectIntegrationEmptyState', () => {
     },
   );
 
-  it('keeps the Slack credential a bot token, because it belongs to an app and not a person', () => {
+  it('asks Slack for a user token, so replies carry the person and not an app', () => {
     render(<ConnectIntegrationEmptyState provider="slack" workspaceId={WORKSPACE_ID} />);
 
-    expect(screen.getByLabelText('Bot token')).toBeDefined();
+    expect(screen.getByLabelText('User token')).toBeDefined();
+    expect(screen.queryByLabelText('Bot token')).toBeNull();
     expect(screen.queryByLabelText('Personal API key')).toBeNull();
   });
 });

--- a/apps/desktop/src/features/integrations/describeIntegrationConfig.test.ts
+++ b/apps/desktop/src/features/integrations/describeIntegrationConfig.test.ts
@@ -119,7 +119,7 @@ describe('describeIntegrationConfig', () => {
     expect(description).toBe('bitbucket.org/serenis as Grace Hopper');
   });
 
-  it('names the Slack team and the bot the token belongs to', () => {
+  it('names the Slack team and the person the token belongs to', () => {
     const description = describeIntegrationConfig({
       integration: integration({
         provider: 'slack',

--- a/apps/desktop/src/features/integrations/slack/SlackFormBody.test.tsx
+++ b/apps/desktop/src/features/integrations/slack/SlackFormBody.test.tsx
@@ -57,7 +57,7 @@ describe('SlackFormBody', () => {
     render(<SlackFormBody workspaceId={WS_ID} />);
 
     const link = screen.getByRole('link', { name: /create a Slack app/i });
-    const field = screen.getByLabelText(/bot token/i);
+    const field = screen.getByLabelText(/user token/i);
 
     expect(link.compareDocumentPosition(field)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
   });
@@ -66,34 +66,43 @@ describe('SlackFormBody', () => {
     render(<SlackFormBody workspaceId={WS_ID} />);
     const connect = screen.getByRole('button', { name: /^connect$/i }) as HTMLButtonElement;
     expect(connect.disabled).toBe(true);
-    fireEvent.change(screen.getByLabelText(/bot token/i), { target: { value: ' xoxb-secret ' } });
+    fireEvent.change(screen.getByLabelText(/user token/i), { target: { value: ' xoxp-secret ' } });
     expect(connect.disabled).toBe(false);
   });
 
   it('trims the pasted token before connecting', async () => {
     const onConnected = vi.fn();
     render(<SlackFormBody workspaceId={WS_ID} onConnected={onConnected} />);
-    fireEvent.change(screen.getByLabelText(/bot token/i), { target: { value: ' xoxb-secret ' } });
+    fireEvent.change(screen.getByLabelText(/user token/i), { target: { value: ' xoxp-secret ' } });
     fireEvent.click(screen.getByRole('button', { name: /^connect$/i }));
     await waitFor(() =>
       expect(state.connectSlack).toHaveBeenCalledWith({
         workspaceId: WS_ID,
-        botToken: 'xoxb-secret',
+        botToken: 'xoxp-secret',
         credentialId: null,
       }),
     );
     await waitFor(() => expect(onConnected).toHaveBeenCalledOnce());
   });
 
-  it('names every scope the bot token needs and where the token travels', () => {
+  it('names every scope the user token needs and where the token travels', () => {
     render(<SlackFormBody workspaceId={WS_ID} />);
     expect(screen.getByText('channels:read')).toBeDefined();
     expect(screen.getByText('channels:history')).toBeDefined();
     expect(screen.getByText('users:read')).toBeDefined();
     expect(screen.getByText('chat:write')).toBeDefined();
     expect(screen.getByText('reactions:write')).toBeDefined();
+    expect(screen.getByText(/User Token Scopes and not Bot Token Scopes/i)).toBeDefined();
     expect(screen.getByText(/never touches Goodboy's own servers/i)).toBeDefined();
     expect(screen.queryByText(/never leaving this machine/i)).toBeNull();
+  });
+
+  it('promises the channels you are in and says replies go out under your name', () => {
+    render(<SlackFormBody workspaceId={WS_ID} />);
+    expect(screen.getByText(/public channels you have joined/i)).toBeDefined();
+    expect(screen.getByText(/under your own name/i)).toBeDefined();
+    expect(screen.queryByText(/the bot has joined/i)).toBeNull();
+    expect(screen.queryByText(/Public channels only/i)).toBeNull();
   });
 
   it('shows the failure and skips onConnected when the probe is rejected', async () => {
@@ -102,7 +111,7 @@ describe('SlackFormBody', () => {
       throw new Error('slack rejected the token');
     });
     render(<SlackFormBody workspaceId={WS_ID} onConnected={onConnected} />);
-    fireEvent.change(screen.getByLabelText(/bot token/i), { target: { value: 'xoxb-bad' } });
+    fireEvent.change(screen.getByLabelText(/user token/i), { target: { value: 'xoxp-bad' } });
     fireEvent.click(screen.getByRole('button', { name: /^connect$/i }));
     expect(await screen.findByText(/slack rejected the token/i)).toBeDefined();
     expect(onConnected).not.toHaveBeenCalled();
@@ -113,11 +122,13 @@ describe('SlackFormBody', () => {
       state.workspaceIntegrations = { [WS_ID]: [slackIntegration] };
     });
 
-    it('shows the team and the bot user instead of the form', () => {
+    it('names the person the token belongs to, never a bot', () => {
       render(<SlackFormBody workspaceId={WS_ID} />);
       expect(screen.getByText(/Connected to Acme/i)).toBeDefined();
       expect(screen.getByText('T01')).toBeDefined();
+      expect(screen.getByText('connected as')).toBeDefined();
       expect(screen.getByText('goodboy')).toBeDefined();
+      expect(screen.queryByText(/bot user/i)).toBeNull();
       expect(screen.queryByRole('button', { name: /^connect$/i })).toBeNull();
     });
 

--- a/apps/desktop/src/features/integrations/slack/SlackFormBody.tsx
+++ b/apps/desktop/src/features/integrations/slack/SlackFormBody.tsx
@@ -77,7 +77,7 @@ export const SlackFormBody = ({ workspaceId, onConnected, shouldAutoFocus = fals
           <dl className="grid grid-cols-[8rem_1fr] gap-y-1 text-xs">
             <dt className="text-muted-foreground">team</dt>
             <dd className="font-mono text-foreground">{slack.config.teamId}</dd>
-            <dt className="text-muted-foreground">bot user</dt>
+            <dt className="text-muted-foreground">connected as</dt>
             <dd className="font-mono text-foreground">
               {slack.config.botUserName ?? slack.config.botUserId}
             </dd>
@@ -87,7 +87,7 @@ export const SlackFormBody = ({ workspaceId, onConnected, shouldAutoFocus = fals
               role="danger"
               icon={<Unplug size={12} aria-hidden />}
               title="Disconnect Slack?"
-              description="Unlinks this project from the Slack bot token. The token stays saved for your other projects."
+              description="Unlinks this project from the Slack token. The token stays saved for your other projects."
               confirmLabel="Disconnect Slack"
               autoDisarmMs={4000}
               onConfirm={onDisconnect}
@@ -117,7 +117,7 @@ export const SlackFormBody = ({ workspaceId, onConnected, shouldAutoFocus = fals
             <>
               <div className="flex flex-col gap-2">
                 <label htmlFor="slack-token" className="text-xs font-semibold text-foreground">
-                  Bot token
+                  User token
                 </label>
                 <a
                   href={APP_URL}
@@ -125,13 +125,14 @@ export const SlackFormBody = ({ workspaceId, onConnected, shouldAutoFocus = fals
                   rel="noreferrer"
                   className="inline-flex items-center gap-1 text-2xs text-muted-foreground hover:text-foreground"
                 >
-                  Create a Slack app and copy its bot token <ExternalLink size={10} aria-hidden />
+                  Create a Slack app and copy its user OAuth token{' '}
+                  <ExternalLink size={10} aria-hidden />
                 </a>
                 <Input
                   id="slack-token"
                   type="password"
                   autoFocus={shouldAutoFocus}
-                  placeholder="xoxb-…"
+                  placeholder="xoxp-…"
                   value={botToken}
                   onChange={(event) => setBotToken(event.target.value)}
                   disabled={isBusy}
@@ -142,8 +143,8 @@ export const SlackFormBody = ({ workspaceId, onConnected, shouldAutoFocus = fals
               </div>
               <div className="flex flex-col gap-2">
                 <p className="text-2xs leading-relaxed text-muted-foreground">
-                  The bot token starts with <span className="font-mono">xoxb-</span> and needs these
-                  scopes:
+                  The user token starts with <span className="font-mono">xoxp-</span> and needs
+                  these scopes, granted under User Token Scopes and not Bot Token Scopes:
                 </p>
                 <ul className="flex flex-wrap gap-2">
                   {SCOPES.map((scope) => (
@@ -159,11 +160,13 @@ export const SlackFormBody = ({ workspaceId, onConnected, shouldAutoFocus = fals
             </>
           ) : null}
           <p className="text-2xs leading-relaxed text-muted-foreground">
-            Public channels only, and Goodboy sees only the ones the bot has joined. Invite it to a
-            channel in Slack to read that conversation here. Goodboy also pulls your
-            workspace&apos;s full member list, names and avatars, to show who posted in a thread.
-            Your token is checked against Slack over HTTPS before anything is stored, then kept in
-            your OS keychain, encrypted at rest. It never touches Goodboy&apos;s own servers.
+            Goodboy reads the public channels you have joined and asks Slack for nothing beyond the
+            five scopes it needs, so private channels and direct messages stay out. Replies and
+            reactions go out under your own name, the way they would if you typed them in Slack.
+            Goodboy also pulls your workspace&apos;s full member list, names and avatars, to show
+            who posted in a thread. Your token is checked against Slack over HTTPS before anything
+            is stored, then kept in your OS keychain, encrypted at rest. It never touches
+            Goodboy&apos;s own servers.
           </p>
         </>
       )}

--- a/apps/desktop/src/features/integrations/slack/SlackStudio/ThreadInbox.tsx
+++ b/apps/desktop/src/features/integrations/slack/SlackStudio/ThreadInbox.tsx
@@ -98,7 +98,7 @@ export const ThreadInbox = ({
             description={
               hasQuery
                 ? 'Try a different search term.'
-                : 'Invite the bot to a public channel in Slack and it shows up here. Goodboy only sees channels the bot has joined.'
+                : 'Join a public channel in Slack and it shows up here. Goodboy only reads the public channels you are in.'
             }
             size="inline"
             action={
@@ -171,7 +171,7 @@ export const ThreadInbox = ({
             ))}
             {hiddenChannelCount > 0 && (
               <p className="px-1 text-2xs text-muted-foreground/60">
-                {`${hiddenChannelCount} more channels the bot joined are not read here, and each channel only reads its latest 200 messages.`}
+                {`${hiddenChannelCount} more of your channels are not read here, and each channel only reads its latest 200 messages.`}
               </p>
             )}
           </div>

--- a/apps/desktop/src/features/integrations/slack/SlackStudio/index.test.tsx
+++ b/apps/desktop/src/features/integrations/slack/SlackStudio/index.test.tsx
@@ -67,7 +67,7 @@ vi.mock('./ThreadDetailPanel', () => ({
 vi.mock('../SlackFormBody', () => ({
   SlackFormBody: () => (
     <label htmlFor="slack-token-test">
-      Bot token
+      User token
       <input id="slack-token-test" />
     </label>
   ),
@@ -119,7 +119,7 @@ describe('SlackStudio', () => {
     renderStudio();
 
     expect(screen.getByText('Connect Slack to read the threads a task came out of')).toBeDefined();
-    expect(screen.getByLabelText('Bot token')).toBeDefined();
+    expect(screen.getByLabelText('User token')).toBeDefined();
     expect(h.isEnabled).toBe(false);
     expect(screen.queryByRole('button', { name: 'Disconnect Slack' })).toBeNull();
   });
@@ -175,7 +175,7 @@ describe('SlackStudio', () => {
     );
   });
 
-  it('says nothing is there when the bot joined no channels', () => {
+  it('says nothing is there when you are in no channels', () => {
     h.integrations = { 'workspace-1': [{ provider: 'slack' }] };
 
     renderStudio();
@@ -183,7 +183,7 @@ describe('SlackStudio', () => {
     expect(screen.getByText('No channels yet')).toBeDefined();
     expect(
       screen.getByText(
-        'Invite the bot to a public channel in Slack and it shows up here. Goodboy only sees channels the bot has joined.',
+        'Join a public channel in Slack and it shows up here. Goodboy only reads the public channels you are in.',
       ),
     ).toBeDefined();
   });

--- a/apps/desktop/src/features/integrations/slack/SlackStudio/index.tsx
+++ b/apps/desktop/src/features/integrations/slack/SlackStudio/index.tsx
@@ -89,7 +89,7 @@ export const SlackStudio = ({ workspaceId, workspaceName, initialThreadTs, onClo
             <Divider orientation="vertical" className="mx-0.5 h-5" />
             <IntegrationDisconnect
               label="Slack"
-              description="Unlinks this project from the Slack bot token. The token stays saved for your other projects."
+              description="Unlinks this project from the Slack token. The token stays saved for your other projects."
               onDisconnect={() => disconnectIntegration({ workspaceId, provider: 'slack' })}
             />
           </div>

--- a/apps/desktop/src/features/integrations/slack/client.test.ts
+++ b/apps/desktop/src/features/integrations/slack/client.test.ts
@@ -30,11 +30,11 @@ describe('slack client', () => {
   it('probes a token under a credential id, never under a goodboy workspace', async () => {
     mockInvoke.mockResolvedValue({ teamId: 'T01' });
 
-    await slackValidateConnection({ credentialId, botToken: 'xoxb-secret' });
+    await slackValidateConnection({ credentialId, botToken: 'xoxp-secret' });
 
     expect(mockInvoke).toHaveBeenCalledWith('slack_validate_connection', {
       credentialId,
-      botToken: 'xoxb-secret',
+      botToken: 'xoxp-secret',
     });
     expect(mockInvoke).not.toHaveBeenCalledWith(
       'slack_validate_connection',

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/index.tsx
@@ -91,8 +91,7 @@ const PROVIDER_META: Record<SessionExternalTaskProvider, ProviderMeta> = {
     noun: 'thread',
     nounPhrase: 'a thread',
     nounPlural: 'threads',
-    linkHint:
-      'Pick a thread from a channel the bot has joined, or paste a Slack permalink to link one.',
+    linkHint: 'Pick a thread from a channel you are in, or paste a Slack permalink to link one.',
   },
 };
 

--- a/apps/desktop/src/store/slices/integrations/index.test.ts
+++ b/apps/desktop/src/store/slices/integrations/index.test.ts
@@ -966,12 +966,12 @@ describe('store contract', () => {
 
       const out = await store
         .getState()
-        .connectSlack({ workspaceId: WS_ID, botToken: ' xoxb-secret ', credentialId: null });
+        .connectSlack({ workspaceId: WS_ID, botToken: ' xoxp-secret ', credentialId: null });
 
       expect(out.teamId).toBe('T01');
       expect(slackValidateConnectionSpy).toHaveBeenCalledWith({
         credentialId: expect.any(String),
-        botToken: ' xoxb-secret ',
+        botToken: ' xoxp-secret ',
       });
       const cached = store
         .getState()
@@ -996,7 +996,7 @@ describe('store contract', () => {
 
       await store
         .getState()
-        .connectSlack({ workspaceId: WS_ID, botToken: 'xoxb-secret', credentialId: null });
+        .connectSlack({ workspaceId: WS_ID, botToken: 'xoxp-secret', credentialId: null });
 
       const dbCallOrder = upsertWorkspaceIntegrationSpy.mock.invocationCallOrder[0];
       const keychainCallOrder = slackConnectSpy.mock.invocationCallOrder[0];
@@ -1018,7 +1018,7 @@ describe('store contract', () => {
       await expect(
         store
           .getState()
-          .connectSlack({ workspaceId: WS_ID, botToken: 'xoxb-secret', credentialId: null }),
+          .connectSlack({ workspaceId: WS_ID, botToken: 'xoxp-secret', credentialId: null }),
       ).rejects.toThrow(/keychain unavailable/);
 
       expect(upsertWorkspaceIntegrationSpy).toHaveBeenCalledTimes(1);
@@ -1050,7 +1050,7 @@ describe('store contract', () => {
       await expect(
         store
           .getState()
-          .connectSlack({ workspaceId: WS_ID, botToken: 'xoxb-new', credentialId: CRED_ID }),
+          .connectSlack({ workspaceId: WS_ID, botToken: 'xoxp-new', credentialId: CRED_ID }),
       ).rejects.toThrow(/keychain unavailable/);
 
       expect(deleteWorkspaceIntegrationSpy).not.toHaveBeenCalled();
@@ -1072,7 +1072,7 @@ describe('store contract', () => {
       await expect(
         store
           .getState()
-          .connectSlack({ workspaceId: WS_ID, botToken: 'xoxb-secret', credentialId: null }),
+          .connectSlack({ workspaceId: WS_ID, botToken: 'xoxp-secret', credentialId: null }),
       ).rejects.toThrow(/keychain unavailable/);
     });
 
@@ -1083,7 +1083,7 @@ describe('store contract', () => {
       await expect(
         store
           .getState()
-          .connectSlack({ workspaceId: WS_ID, botToken: 'xoxb-bad', credentialId: null }),
+          .connectSlack({ workspaceId: WS_ID, botToken: 'xoxp-bad', credentialId: null }),
       ).rejects.toThrow(/invalid_auth/);
 
       expect(slackConnectSpy).not.toHaveBeenCalled();
@@ -1113,7 +1113,7 @@ describe('store contract', () => {
 
       await store
         .getState()
-        .connectSlack({ workspaceId: WS_ID, botToken: 'xoxb-secret', credentialId: CRED_ID });
+        .connectSlack({ workspaceId: WS_ID, botToken: 'xoxp-secret', credentialId: CRED_ID });
 
       const rows = (store.getState().workspaceIntegrations[WS_ID] ?? []).filter(
         (i) => i.provider === 'slack',

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -87,7 +87,7 @@ Where each connected source stands, honestly:
   and team we read carry no id to send back. Linear is where the PM persona
   lives.
 - **Sentry.** Issues and events read; no write path yet.
-- **Slack.** Threads read and replied to (replies post as the connected bot),
+- **Slack.** Threads read and replied to (replies post as the connected user),
   routed into sessions with the goal pre-filled. The connection is per
   workspace; public bot-joined channels only, and no call has run against a
   live workspace yet, only contract tests.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -89,8 +89,8 @@ Where each connected source stands, honestly:
 - **Sentry.** Issues and events read; no write path yet.
 - **Slack.** Threads read and replied to (replies post as the connected user),
   routed into sessions with the goal pre-filled. The connection is per
-  workspace; public bot-joined channels only, and no call has run against a
-  live workspace yet, only contract tests.
+  workspace; only the public channels the connected person has joined, and no
+  call has run against a live workspace yet, only contract tests.
 
 The rule for every integration: share the layout, never the logic. A Sentry
 issue and a GitHub pull request look coherent side by side because the page

--- a/docs/tone-of-voice.md
+++ b/docs/tone-of-voice.md
@@ -112,8 +112,9 @@ being short. The lead line is the pitch; everything under it is plain fact.
   message, and nobody outside the team reads a changelog to learn them. The
   announcement post lives by this rule too.
 - **State a limit inside the sentence that promises the thing**, not in a
-  paragraph of its own. "Public channels the bot has joined" beats four
-  sentences of scope caveats.
+  paragraph of its own. "Goodboy reads the public channels you have joined and
+  asks Slack for nothing beyond the five scopes it needs" beats four sentences
+  of scope caveats.
 - **Work not yet exercised against a live service is a follow-up, never a
   confession.** Never write "not verified", "this has not run against a live
   X", or "proves nothing". Write what the work stands on and what the app does


### PR DESCRIPTION
## What changed

The Slack connect form asked for a bot token. It now asks for a user token, so Goodboy acts as the person who pasted it.

- Field label `Bot token` becomes `User token`, placeholder `xoxb-…` becomes `xoxp-…`, and the link now reads "Create a Slack app and copy its user OAuth token".
- The scope list keeps the same five scopes and now says where to grant them: under **User Token Scopes**, not Bot Token Scopes.
- The disclosure paragraph stopped promising something the token no longer decides. It used to say "Public channels only, and Goodboy sees only the ones the bot has joined". It now states the limit inside the promise: the public channels you have joined, nothing beyond the five scopes, and replies and reactions going out under your own name.
- `AUTH_HINT` in `slack.rs` names a user token and `xoxp-`, and points at user token scopes. The `NoToken` error stopped saying "bot token".
- The connected identity is no longer called a bot in the UI: the connected panel row reads `connected as`, the studio empty state and the hidden-channel note talk about the channels you are in, and the session integration pane matches.
- `SECURITY.md` and `docs/concepts.md` follow.

No change to the HTTP layer, no new dependency, no new Slack method, no new scope. The client already sent the token as a plain `bearer_auth` with no prefix check, so nothing in the request path had to move.

**Wire and storage names are deliberately unchanged.** `botToken`, `bot_token`, `botUserId` and the `config` JSON keys read by `m114-integration-credentials` stay as they are. Renaming them means a data migration for zero user-visible gain.

## If you already connected Slack with a bot token

Nothing breaks and nothing changes on its own. No code path inspects the token prefix, so a stored `xoxb-` token keeps going out as a bearer token and keeps working exactly as it did, still posting as the app and still limited to the channels that app was invited to. Getting the "as me" behavior is a deliberate act: disconnect, then reconnect and paste an `xoxp-` token.

One rough edge worth naming, and it predates this PR. Disconnecting drops the project's link to Slack through `deleteWorkspaceIntegration` and leaves the saved credential and its keychain entry alone. Pasting a token always mints a fresh credential id, so the `xoxp-` token lands in its own keychain slot and the old `xoxb-` one stays saved rather than being overwritten. It stops being used the moment the project repoints, and the Forget button beside it in the saved credentials list clears the row and the keychain entry together. This PR does not change that flow.

## Why a user token is the right shape

Two concrete wins:

1. **Replies and reactions carry the human.** `chat.postMessage` and `reactions.add` under a user token post as the person, so a thread reply from Goodboy reads like the reply they would have typed, not like an app talking.
2. **Reach follows the person, not an invite list.** `conversations.list` under a user token returns the channels that human is in, so no one has to remember to invite an app to a channel before Goodboy can read it. The `is_member && !is_archived` filter now means "channels I am in", which is the intent, and it is left in place.

## Why not OAuth

Full OAuth would make Goodboy a distributed non-Marketplace app, and Slack applies the [post-May-2025 rate limits](https://docs.slack.dev/apis/web-api/rate-limits) to exactly that category on `conversations.history` and `conversations.replies`. That doc states internal customer-built apps do not see the change, so a per-user internal app keeps the existing limits.

## The scopes did not change, and that is verified

All five scopes carry byte-identical names for user tokens and bot tokens on every method the app calls. Checked against Slack's published reference:

| Method | Scope, both token types |
| --- | --- |
| [`conversations.list`](https://docs.slack.dev/reference/methods/conversations.list) | `channels:read` |
| [`conversations.history`](https://docs.slack.dev/reference/methods/conversations.history) | `channels:history` |
| [`conversations.replies`](https://docs.slack.dev/reference/methods/conversations.replies) | `channels:history` |
| [`users.list`](https://docs.slack.dev/reference/methods/users.list) | `users:read` |
| [`chat.postMessage`](https://docs.slack.dev/reference/methods/chat.postMessage) | `chat:write` |
| [`reactions.add`](https://docs.slack.dev/reference/methods/reactions.add) | `reactions:write` |
| [`chat.getPermalink`](https://docs.slack.dev/reference/methods/chat.getPermalink) | no scope required |

## Test plan

- `cargo test --locked` from `apps/desktop/src-tauri`: 508 passed. A new test pins the hint copy to a user token, the `xoxp-` prefix and all five scope names.
- `pnpm exec vitest run src/features/integrations src/store/slices/integrations src/features/session` from `apps/desktop`: 2214 passed. New assertions cover the `User token` label, the User Token Scopes line, the rewritten disclosure, and the absence of the old "the bot has joined" promise.
- `pnpm turbo run typecheck`: green.
- `pnpm knip --include files,duplicates,unlisted`: green.

Follow-up: everything above rests on Slack's published reference, linked inline, and no call has gone out to a live Slack workspace from here. The first connect with a real `xoxp-` token is the remaining check, and if Slack disagrees its own error comes back in the form through `AUTH_HINT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
