### PR TITLE
fix(desktop): show only reachable integrations in the lens rail

### DIFF
--- a/apps/desktop/src/features/session/components/SessionNavSidebar/parts/LensNav/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionNavSidebar/parts/LensNav/index.test.tsx
@@ -22,6 +22,7 @@ const { hooks, remote, store } = vi.hoisted(() => {
     remote: {
       kind: 'github' as 'github' | 'gitlab' | 'other' | null,
       isGithubAuthenticated: true,
+      isGithubResolved: true,
     },
     store: {
       sessionMounts: {},
@@ -124,7 +125,7 @@ vi.mock('../../../../../worktree/useRemoteHostKind', () => ({
 vi.mock('../../../../../integrations/github/useGithubConnection', () => ({
   useGithubConnection: () => ({
     isAuthenticated: remote.isGithubAuthenticated,
-    isResolved: true,
+    isResolved: remote.isGithubResolved,
     refresh: vi.fn(async () => undefined),
   }),
 }));
@@ -141,6 +142,7 @@ const SESSION = {
 beforeEach(() => {
   remote.kind = 'github';
   remote.isGithubAuthenticated = true;
+  remote.isGithubResolved = true;
   hooks.agentCount = 0;
   hooks.doneAgentCount = 0;
   hooks.planCount = 0;
@@ -154,6 +156,7 @@ beforeEach(() => {
   store.sessionWorkflows = { 'session-1': [] };
   store.reviewDrafts = { 'session-1': [] };
   store.sessionGithub = {};
+  store.sessionGitlabMr = {};
   store.sessionExternalTasks = { 'session-1': [] };
   store.workspaceIntegrations = {
     'workspace-1': [{ provider: 'linear' }, { provider: 'sentry' }],
@@ -221,11 +224,61 @@ describe('LensNav', () => {
     expect(inactiveIcon?.className).toContain('opacity-55');
   });
 
-  it('marks a disconnected integration and leaves connected ones unmarked', () => {
+  it('drops the integrations the workspace never connected', () => {
     const { container } = render(<LensNav session={SESSION} filesCount={0} />);
 
-    expect(container.querySelector('[title="GitLab disconnected"]')).not.toBeNull();
+    expect(screen.getByRole('button', { name: 'Linear' })).toBeDefined();
+    expect(screen.queryByRole('button', { name: 'GitLab' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Jira' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Slack' })).toBeNull();
     expect(container.querySelector('[title="Linear disconnected"]')).toBeNull();
+  });
+
+  it('keeps a disconnected provider that still holds linked work, degraded', () => {
+    store.workspaceIntegrations = { 'workspace-1': [] };
+    store.sessionExternalTasks = { 'session-1': [{ provider: 'linear' }] };
+
+    const { container } = render(<LensNav session={SESSION} filesCount={0} />);
+
+    const linear = screen.getByRole('button', { name: 'Linear 1' });
+    expect(linear.className).toContain('opacity-40');
+    expect(container.querySelector('[title="Linear disconnected"]')).not.toBeNull();
+    expect(screen.queryByRole('button', { name: 'Sentry' })).toBeNull();
+  });
+
+  it('keeps a disconnected GitLab row while a merge request stays linked', () => {
+    store.workspaceIntegrations = { 'workspace-1': [] };
+    store.sessionGitlabMr = { 'session-1': { mr: { iid: 7 } } };
+
+    const { container } = render(<LensNav session={SESSION} filesCount={0} />);
+
+    expect(screen.getByRole('button', { name: 'GitLab' })).toBeDefined();
+    expect(container.querySelector('[title="GitLab disconnected"]')).not.toBeNull();
+  });
+
+  it('hides the integrations group entirely when nothing survives the filter', () => {
+    store.workspaceIntegrations = { 'workspace-1': [] };
+    remote.isGithubAuthenticated = false;
+
+    render(<LensNav session={SESSION} filesCount={0} />);
+
+    expect(screen.queryByText('Integrations')).toBeNull();
+    expect(screen.queryByRole('button', { name: 'GitHub' })).toBeNull();
+    expect(screen.getByRole('button', { name: 'Terminal' })).toBeDefined();
+  });
+
+  it('waits for the github connection to resolve before listing its row', () => {
+    remote.isGithubResolved = false;
+    const { container, rerender } = render(<LensNav session={SESSION} filesCount={0} />);
+
+    expect(screen.queryByRole('button', { name: 'GitHub' })).toBeNull();
+    expect(container.querySelector('[title="GitHub disconnected"]')).toBeNull();
+
+    remote.isGithubResolved = true;
+    rerender(<LensNav session={SESSION} filesCount={1} />);
+
+    expect(screen.getByRole('button', { name: 'GitHub' })).toBeDefined();
+    expect(container.querySelector('[title="GitHub disconnected"]')).toBeNull();
   });
 
   it('orders the regrouped lens sections and rows', () => {
@@ -260,9 +313,6 @@ describe('LensNav', () => {
       'GitHub',
       'Linear',
       'Sentry',
-      'GitLab',
-      'Jira',
-      'Slack',
     ]);
     expect(screen.queryByRole('button', { name: 'Explore' })).toBeNull();
   });
@@ -489,21 +539,22 @@ describe('LensNav', () => {
   });
 
   it.each([
-    ['GitHub', 'pr', 'goodboy:open-github-studio'],
-    ['GitLab', 'gitlab_issues', 'goodboy:open-gitlab-studio'],
-    ['Linear', 'linear', 'goodboy:open-linear-studio'],
-    ['Sentry', 'sentry', 'goodboy:open-sentry-studio'],
+    ['GitHub', 'github', 'pr', 'goodboy:open-github-studio'],
+    ['GitLab', 'gitlab', 'gitlab_issues', 'goodboy:open-gitlab-studio'],
+    ['Linear', 'linear', 'linear', 'goodboy:open-linear-studio'],
+    ['Sentry', 'sentry', 'sentry', 'goodboy:open-sentry-studio'],
   ] as const)(
     'selects the inline %s pane when disconnected instead of opening the studio',
-    (label, lens, studioEvent) => {
+    (label, provider, lens, studioEvent) => {
       store.workspaceIntegrations = {};
+      store.sessionExternalTasks = { 'session-1': [{ provider }] };
       remote.kind = null;
       remote.isGithubAuthenticated = false;
       const listener = vi.fn();
       window.addEventListener(studioEvent, listener);
 
       render(<LensNav session={SESSION} filesCount={0} />);
-      const row = screen.getByRole('button', { name: label });
+      const row = screen.getByRole('button', { name: `${label} 1` });
       fireEvent.click(row);
 
       expect(row.className).toContain('opacity-40');

--- a/apps/desktop/src/features/session/components/SessionNavSidebar/parts/LensNav/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionNavSidebar/parts/LensNav/index.tsx
@@ -206,65 +206,92 @@ export const LensNav = ({ session, filesCount, diffstat, isBranchless = false }:
     externalTasks,
     isGithubAuthenticated: false,
   });
+  const isGithubListed =
+    githubAuthentication.isResolved && (githubConnection.isAvailable || hasGithubPr);
+  const isGitlabListed = gitlabConnection.isAvailable || hasGitlabMr;
   const integrationRows: ReadonlyArray<LensRow> = [
-    {
-      kind: 'pr',
-      label: 'GitHub',
-      glyph: 'github',
-      tone: CONCEPT_TONE.pr,
-      count: githubCount,
-      isCountLoading: isCountUnknown(areExternalTasksLoaded),
-      secondaryDot: hasGithubPr,
-      secondaryDotLabel: 'Pull request linked',
-      isConnected: githubConnection.isConnected,
-    },
-    {
-      kind: 'gitlab_issues',
-      label: 'GitLab',
-      glyph: 'gitlab',
-      tone: CONCEPT_TONE.gitlab,
-      count: gitlabCount,
-      isCountLoading: isCountUnknown(areExternalTasksLoaded),
-      secondaryDot: hasGitlabMr,
-      secondaryDotLabel: 'Merge request linked',
-      isConnected: gitlabConnection.isConnected,
-    },
-    {
-      kind: 'jira_issues',
-      label: 'Jira',
-      glyph: 'jira',
-      tone: CONCEPT_TONE.jira,
-      count: jiraCount,
-      isCountLoading: isCountUnknown(areExternalTasksLoaded),
-      isConnected: jiraConnection.isConnected,
-    },
-    {
-      kind: 'linear',
-      label: 'Linear',
-      glyph: 'linear',
-      tone: CONCEPT_TONE.linear,
-      count: linearCount,
-      isCountLoading: isCountUnknown(areExternalTasksLoaded),
-      isConnected: linearConnection.isConnected,
-    },
-    {
-      kind: 'sentry',
-      label: 'Sentry',
-      glyph: 'sentry',
-      tone: CONCEPT_TONE.sentry,
-      count: sentryCount,
-      isCountLoading: isCountUnknown(areExternalTasksLoaded),
-      isConnected: sentryConnection.isConnected,
-    },
-    {
-      kind: 'slack_threads',
-      label: 'Slack',
-      glyph: 'slack',
-      tone: CONCEPT_TONE.slack,
-      count: slackCount,
-      isCountLoading: isCountUnknown(areExternalTasksLoaded),
-      isConnected: slackConnection.isConnected,
-    },
+    ...(isGithubListed
+      ? [
+          {
+            kind: 'pr',
+            label: 'GitHub',
+            glyph: 'github',
+            tone: CONCEPT_TONE.pr,
+            count: githubCount,
+            isCountLoading: isCountUnknown(areExternalTasksLoaded),
+            secondaryDot: hasGithubPr,
+            secondaryDotLabel: 'Pull request linked',
+            isConnected: githubConnection.isConnected,
+          } satisfies LensRow,
+        ]
+      : []),
+    ...(isGitlabListed
+      ? [
+          {
+            kind: 'gitlab_issues',
+            label: 'GitLab',
+            glyph: 'gitlab',
+            tone: CONCEPT_TONE.gitlab,
+            count: gitlabCount,
+            isCountLoading: isCountUnknown(areExternalTasksLoaded),
+            secondaryDot: hasGitlabMr,
+            secondaryDotLabel: 'Merge request linked',
+            isConnected: gitlabConnection.isConnected,
+          } satisfies LensRow,
+        ]
+      : []),
+    ...(jiraConnection.isAvailable
+      ? [
+          {
+            kind: 'jira_issues',
+            label: 'Jira',
+            glyph: 'jira',
+            tone: CONCEPT_TONE.jira,
+            count: jiraCount,
+            isCountLoading: isCountUnknown(areExternalTasksLoaded),
+            isConnected: jiraConnection.isConnected,
+          } satisfies LensRow,
+        ]
+      : []),
+    ...(linearConnection.isAvailable
+      ? [
+          {
+            kind: 'linear',
+            label: 'Linear',
+            glyph: 'linear',
+            tone: CONCEPT_TONE.linear,
+            count: linearCount,
+            isCountLoading: isCountUnknown(areExternalTasksLoaded),
+            isConnected: linearConnection.isConnected,
+          } satisfies LensRow,
+        ]
+      : []),
+    ...(sentryConnection.isAvailable
+      ? [
+          {
+            kind: 'sentry',
+            label: 'Sentry',
+            glyph: 'sentry',
+            tone: CONCEPT_TONE.sentry,
+            count: sentryCount,
+            isCountLoading: isCountUnknown(areExternalTasksLoaded),
+            isConnected: sentryConnection.isConnected,
+          } satisfies LensRow,
+        ]
+      : []),
+    ...(slackConnection.isAvailable
+      ? [
+          {
+            kind: 'slack_threads',
+            label: 'Slack',
+            glyph: 'slack',
+            tone: CONCEPT_TONE.slack,
+            count: slackCount,
+            isCountLoading: isCountUnknown(areExternalTasksLoaded),
+            isConnected: slackConnection.isConnected,
+          } satisfies LensRow,
+        ]
+      : []),
   ];
   const sortedIntegrationRows: ReadonlyArray<LensRow> = [...integrationRows].sort((a, b) => {
     if (a.isConnected === false && b.isConnected !== false) {
@@ -356,29 +383,31 @@ export const LensNav = ({ session, filesCount, diffstat, isBranchless = false }:
               />
             ))}
           </div>
-          {groups.map((group) => (
-            <div key={group.label} className="flex flex-col gap-0.5">
-              <span
-                className={cn(
-                  'pb-1 text-3xs font-medium uppercase tracking-[0.12em] transition-colors',
-                  PANE_RHYTHM.navRail.inset,
-                  rowsWantAttention({ rows: group.rows })
-                    ? 'text-foreground/80'
-                    : 'text-muted-foreground/60',
-                )}
-              >
-                {group.label}
-              </span>
-              {group.rows.map((row) => (
-                <LensNavRow
-                  key={row.kind}
-                  row={row}
-                  isActive={activeSurface === row.kind}
-                  onSelect={() => setActiveLens(sessionId, row.kind)}
-                />
-              ))}
-            </div>
-          ))}
+          {groups
+            .filter((group) => group.rows.length > 0)
+            .map((group) => (
+              <div key={group.label} className="flex flex-col gap-0.5">
+                <span
+                  className={cn(
+                    'pb-1 text-3xs font-medium uppercase tracking-[0.12em] transition-colors',
+                    PANE_RHYTHM.navRail.inset,
+                    rowsWantAttention({ rows: group.rows })
+                      ? 'text-foreground/80'
+                      : 'text-muted-foreground/60',
+                  )}
+                >
+                  {group.label}
+                </span>
+                {group.rows.map((row) => (
+                  <LensNavRow
+                    key={row.kind}
+                    row={row}
+                    isActive={activeSurface === row.kind}
+                    onSelect={() => setActiveLens(sessionId, row.kind)}
+                  />
+                ))}
+              </div>
+            ))}
         </nav>
       </ScrollFade>
     </div>


### PR DESCRIPTION
## What the sidebar shows now

The `Integrations` group in the session sidebar lists only the providers this
session can actually reach. A provider the workspace never connected, with
nothing linked here, is gone from the rail instead of sitting there dimmed with
an `Unplug` badge. Connecting one is still one click away in the footer
`IntegrationAddPopover`, which keeps offering all six on purpose.

## Why `isAvailable` and not `isConnected`

`resolveIntegrationConnection` already returns `isAvailable = isConnected ||
hasLinkedTask`, and nothing read it until now. Filtering on `isConnected` would
delete work the user can still see: a Linear issue linked before Linear was
disconnected, a Sentry issue attached last week. `isAvailable` keeps that row
reachable, which is the only reason the degraded treatment exists.

The GitHub and GitLab rows carry one more piece of linked work that is not an
external task: the session PR and MR. Those extend the predicate at the call
site (`isAvailable || hasGithubPr`, `isAvailable || hasGitlabMr`) so an open PR
on a workspace that later loses its GitHub token does not take its row with it.

## A disconnected provider that still has linked work

It stays, and it stays degraded. `LensNavRow` is untouched: `opacity-40`, the
greyscale brand glyph and the `Unplug` badge all still key off
`isConnected === false`. The row keeps its count, keeps opening the inline pane
rather than the studio, and now it is the only kind of disconnected row the rail
can produce.

## The GitHub boot case

`useGithubConnection` starts every workspace at `isResolved: false` and answers
from `ghStatus` a moment later. The existing hack treats unresolved as connected
so the `Unplug` badge never flashes, and that is preserved verbatim for the
`isConnected` flag.

For the filter that hack is the wrong way round: optimistic-visible means the
row renders, then vanishes once the status comes back absent, which is a yank.
So the GitHub row is listed only once `isResolved` is true. The row can appear,
never disappear, as the connection settles. Every other provider reads from the
store, which is already resolved when the sidebar mounts.

## Empty group

The eyebrow is guarded at the render site (`group.rows.length > 0`), not inside
`buildLensNavigation`: `groups.test.ts` pins that the group survives with zero
rows and `CollapsedRail` builds its navigation with `integrationRows:
EMPTY_ARRAY`.

## Test plan

Rewritten in `LensNav/index.test.tsx`:

- a provider the workspace never connected is absent from the rail
- a disconnected provider with a linked task is present, `opacity-40`, badged
- a disconnected GitLab with a linked MR survives the same way
- the `Integrations` eyebrow does not render when nothing survives
- the GitHub row waits for `isResolved` and shows no disconnected badge either
  side of the transition
- the row-order assertion now expects GitHub, Linear, Sentry only
- the disconnected-row `it.each` gives each provider a linked task so the row it
  clicks still exists

Green: `npx tsc --noEmit`, `npx vitest run src/features/session
src/features/integrations` (238 files, 2193 tests), `pnpm knip --include
files,duplicates,unlisted`.

Untouched on purpose: `IntegrationAddPopover`, the onboarding steps, the footer
strip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
