### PR TITLE
fix(ui): read a discarded run as discarded everywhere

### DIFF
--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRail.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRail.test.tsx
@@ -2,17 +2,35 @@
 
 import { afterEach, describe, expect, it } from 'vitest';
 import { cleanup, render } from '@testing-library/react';
-import type { RailRow, RailSegment } from '../../../../timeline/railGeometry';
+import { TERMINAL_DIM } from '@goodboy/ui';
+import type { RailJoin, RailRow, RailSegment } from '../../../../timeline/railGeometry';
 import { TimelineRail } from './TimelineRail';
 
-const railOf = ({ segment }: { readonly segment: RailSegment }): RailRow => ({
+const railOf = ({
+  segment,
+  joins = [],
+}: {
+  readonly segment: RailSegment;
+  readonly joins?: ReadonlyArray<RailJoin>;
+}): RailRow => ({
   id: 'row',
   height: 32,
   segments: [segment],
-  joins: [],
+  joins,
   markerColumn: 0,
   markerY: 16,
 });
+
+const MUTED_JOIN: RailJoin = {
+  kind: 'depart',
+  spineColumn: 0,
+  laneColumn: 1,
+  identityIndex: 0,
+  isMuted: true,
+  dash: 'solid',
+  anchorY: 16,
+  path: 'M 8 16 L 24 0',
+};
 
 afterEach(cleanup);
 
@@ -25,6 +43,7 @@ describe('TimelineRail', () => {
           segment: {
             column: 1,
             identityIndex: 0,
+            isMuted: false,
             dash: 'solid',
             fromY: 0,
             toY: 32,
@@ -46,6 +65,7 @@ describe('TimelineRail', () => {
           segment: {
             column: 0,
             identityIndex: null,
+            isMuted: false,
             dash: 'solid',
             fromY: 16,
             toY: 32,
@@ -59,5 +79,31 @@ describe('TimelineRail', () => {
     expect(container.querySelector('linearGradient')).toBeNull();
     expect(line?.getAttribute('stroke')).toBe('var(--color-border)');
     expect(line?.getAttribute('class') ?? '').not.toContain('opacity');
+  });
+
+  it('recedes a muted lane without changing the hue that names its run', () => {
+    const { container } = render(
+      <TimelineRail
+        width={32}
+        rail={railOf({
+          segment: {
+            column: 1,
+            identityIndex: 0,
+            isMuted: true,
+            dash: 'solid',
+            fromY: 0,
+            toY: 32,
+          },
+          joins: [MUTED_JOIN],
+        })}
+      />,
+    );
+    const line = container.querySelector('line');
+    const join = container.querySelector('path');
+
+    expect(line?.getAttribute('stroke')).toBe('var(--color-run-1)');
+    expect(line?.getAttribute('class')).toContain(TERMINAL_DIM);
+    expect(join?.getAttribute('stroke')).toBe('var(--color-run-1)');
+    expect(join?.getAttribute('class')).toContain(TERMINAL_DIM);
   });
 });

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRail.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRail.tsx
@@ -1,3 +1,4 @@
+import { TERMINAL_DIM } from '@goodboy/ui';
 import { runIdentityStroke } from '../../../../timeline/runIdentity';
 import { railColumnX, type RailRow, type RailSegment } from '../../../../timeline/railGeometry';
 
@@ -13,6 +14,9 @@ const DASH_PATTERN = '3 3';
 const strokeOf = ({ identityIndex }: { readonly identityIndex: number | null }): string =>
   identityIndex == null ? 'var(--color-border)' : runIdentityStroke({ index: identityIndex });
 
+const dimOf = ({ isMuted }: { readonly isMuted: boolean }): string | undefined =>
+  isMuted ? TERMINAL_DIM : undefined;
+
 const segmentKey = ({ segment }: { readonly segment: RailSegment }): string =>
   `${segment.column}:${segment.fromY}:${segment.toY}:${segment.dash}`;
 
@@ -27,6 +31,7 @@ export const TimelineRail = ({ rail, width }: Props) => (
     {rail.segments.map((segment) => (
       <line
         key={segmentKey({ segment })}
+        className={dimOf({ isMuted: segment.isMuted })}
         x1={railColumnX({ column: segment.column })}
         y1={segment.fromY}
         x2={railColumnX({ column: segment.column })}
@@ -41,6 +46,7 @@ export const TimelineRail = ({ rail, width }: Props) => (
     {rail.joins.map((join) => (
       <path
         key={`${join.kind}:${join.laneColumn}:${join.anchorY}`}
+        className={dimOf({ isMuted: join.isMuted })}
         d={join.path}
         fill="none"
         stroke={strokeOf({ identityIndex: join.identityIndex })}

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRunChip.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRunChip.tsx
@@ -7,6 +7,7 @@ import type { RunWorkflowKind } from '../../../../timeline/runWorkflowKind';
 type Props = {
   readonly kind: RunWorkflowKind;
   readonly identity: RunIdentity;
+  readonly muted?: boolean;
 };
 
 type KindGlyph = {
@@ -22,13 +23,13 @@ const KIND: Record<RunWorkflowKind, KindGlyph> = {
 
 const GLYPH_SIZE = 10;
 
-export const TimelineRunChip = ({ kind, identity }: Props) => {
+export const TimelineRunChip = ({ kind, identity, muted = false }: Props) => {
   const { icon: Icon, label } = KIND[kind];
   return (
     <span
       className={cn(
         'inline-flex min-w-24 shrink-0 items-center justify-center gap-1 rounded-md px-1.5 py-0.5 text-3xs font-medium uppercase tracking-wide ring-1',
-        identity.chip,
+        muted ? identity.mutedChip : identity.chip,
       )}
       title={label}
     >

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRunLabel.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRunLabel.test.tsx
@@ -26,6 +26,7 @@ type EntryParams = {
   readonly name?: string;
   readonly goal?: string;
   readonly runId?: string;
+  readonly discardedAt?: string | null;
 };
 
 const entryOf = ({
@@ -33,12 +34,13 @@ const entryOf = ({
   name = 'Refactor (example)',
   goal = 'Restructure the legacy module',
   runId = 'run-7',
+  discardedAt = null,
 }: EntryParams = {}) =>
   ({
     kind: 'run',
     id: `run:${runId}`,
     at: '2026-08-18T09:00:00Z',
-    run: { id: runId, goal },
+    run: { id: runId, goal, discardedAt },
     workflow: { name, origin: ORIGIN_OF[kind] },
     identity: runIdentity({ runId }),
     children: [],
@@ -97,6 +99,34 @@ describe('TimelineRunLabel', () => {
     render(<TimelineRunLabel entry={entryOf({ name: 'Ship it', goal: 'Ship it' })} />);
 
     expect(screen.getAllByText('Ship it')).toHaveLength(1);
+  });
+
+  it('keeps a live run at full-strength label ink', () => {
+    render(<TimelineRunLabel entry={entryOf()} />);
+
+    expect(screen.getByText('Refactor (example)').className).toContain('text-foreground');
+    expect(screen.queryByText('Discarded')).toBeNull();
+  });
+
+  it('reads a discarded run in the muted register the discard event next to it uses', () => {
+    render(<TimelineRunLabel entry={entryOf({ discardedAt: '2026-08-18T10:00:00Z' })} />);
+
+    const name = screen.getByText('Refactor (example)');
+
+    expect(name.className).toContain('text-muted-foreground');
+    expect(name.className).not.toContain('text-foreground');
+  });
+
+  it('says the state in words instead of leaving it to the ink alone', () => {
+    render(<TimelineRunLabel entry={entryOf({ discardedAt: '2026-08-18T10:00:00Z' })} />);
+
+    expect(screen.getByText('Discarded')).toBeDefined();
+  });
+
+  it('leaves the run identity tint alone when the run is discarded', () => {
+    render(<TimelineRunLabel entry={entryOf({ discardedAt: '2026-08-18T10:00:00Z' })} />);
+
+    expect(chipOf().className).toContain(runIdentity({ runId: 'run-7' }).chip);
   });
 
   it('drops the title when the run carries no goal at all', () => {

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRunLabel.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRunLabel.test.tsx
@@ -101,11 +101,11 @@ describe('TimelineRunLabel', () => {
     expect(screen.getAllByText('Ship it')).toHaveLength(1);
   });
 
-  it('keeps a live run at full-strength label ink', () => {
+  it('keeps a live run at full-strength label ink and a filled chip', () => {
     render(<TimelineRunLabel entry={entryOf()} />);
 
     expect(screen.getByText('Refactor (example)').className).toContain('text-foreground');
-    expect(screen.queryByText('Discarded')).toBeNull();
+    expect(chipOf().className).toContain(runIdentity({ runId: 'run-7' }).chip);
   });
 
   it('reads a discarded run in the muted register the discard event next to it uses', () => {
@@ -117,16 +117,21 @@ describe('TimelineRunLabel', () => {
     expect(name.className).not.toContain('text-foreground');
   });
 
-  it('says the state in words instead of leaving it to the ink alone', () => {
+  it('hollows the chip of a discarded run without spending a word on it', () => {
     render(<TimelineRunLabel entry={entryOf({ discardedAt: '2026-08-18T10:00:00Z' })} />);
 
-    expect(screen.getByText('Discarded')).toBeDefined();
+    expect(chipOf().className).toContain(runIdentity({ runId: 'run-7' }).mutedChip);
+    expect(chipOf().className).not.toContain(runIdentity({ runId: 'run-7' }).chip);
+    expect(screen.queryByText('Discarded')).toBeNull();
   });
 
-  it('leaves the run identity tint alone when the run is discarded', () => {
+  it('keeps the run identity hue on a discarded run so it stays that run', () => {
+    const { mutedChip } = runIdentity({ runId: 'run-7' });
+
     render(<TimelineRunLabel entry={entryOf({ discardedAt: '2026-08-18T10:00:00Z' })} />);
 
-    expect(chipOf().className).toContain(runIdentity({ runId: 'run-7' }).chip);
+    expect(mutedChip).toContain('text-run-');
+    expect(chipOf().className).toContain(mutedChip);
   });
 
   it('drops the title when the run carries no goal at all', () => {

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRunLabel.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRunLabel.tsx
@@ -1,3 +1,4 @@
+import { cn } from '@goodboy/ui';
 import type { TimelineRunEntry } from '../../../../timeline/buildTimelineGroups';
 import { runWorkflowKind } from '../../../../timeline/runWorkflowKind';
 import { TimelineRunChip } from './TimelineRunChip';
@@ -16,15 +17,24 @@ const titleOf = ({ entry }: Props): string | null => {
 
 export const TimelineRunLabel = ({ entry }: Props) => {
   const title = titleOf({ entry });
+  const isDiscarded = entry.run.discardedAt != null;
   return (
     <>
       <TimelineRunChip
         kind={runWorkflowKind({ workflow: entry.workflow })}
         identity={entry.identity}
       />
-      <span className="min-w-0 truncate text-sm leading-5 text-foreground">
+      <span
+        className={cn(
+          'min-w-0 truncate text-sm leading-5',
+          isDiscarded ? 'text-muted-foreground' : 'text-foreground',
+        )}
+      >
         {entry.workflow.name}
       </span>
+      {isDiscarded ? (
+        <span className="shrink-0 text-2xs text-muted-foreground">Discarded</span>
+      ) : null}
       {title == null ? null : (
         <span className="min-w-0 truncate text-sm leading-5 text-muted-foreground">{title}</span>
       )}

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRunLabel.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRunLabel.tsx
@@ -23,6 +23,7 @@ export const TimelineRunLabel = ({ entry }: Props) => {
       <TimelineRunChip
         kind={runWorkflowKind({ workflow: entry.workflow })}
         identity={entry.identity}
+        muted={isDiscarded}
       />
       <span
         className={cn(
@@ -32,9 +33,6 @@ export const TimelineRunLabel = ({ entry }: Props) => {
       >
         {entry.workflow.name}
       </span>
-      {isDiscarded ? (
-        <span className="shrink-0 text-2xs text-muted-foreground">Discarded</span>
-      ) : null}
       {title == null ? null : (
         <span className="min-w-0 truncate text-sm leading-5 text-muted-foreground">{title}</span>
       )}

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowsPane.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowsPane.test.tsx
@@ -125,6 +125,7 @@ vi.mock('./WorkflowRunDetail', () => ({
   ),
 }));
 
+import { TERMINAL_DIM } from '@goodboy/ui';
 import { WorkflowsPane } from './WorkflowsPane';
 
 const SESSION_ID = 'session-1';
@@ -402,6 +403,26 @@ describe('WorkflowsPane', () => {
     expect(screen.getByText('First workflow')).toBeDefined();
     expect(screen.getByText('Second workflow')).toBeDefined();
     expect(screen.getByText('Discarded')).toBeDefined();
+  });
+
+  it('sets the discarded card apart from the completed one it sits beside', () => {
+    render(
+      <WorkflowsPane
+        session={buildSession({
+          runIds: ['run-1', 'run-2'],
+          runOverrides: {
+            'run-1': { discardedAt: '2026-07-21T10:00:00.000Z' },
+            'run-2': { executionMode: 'dynamic', orchestrationOutcome: 'done' },
+          },
+        })}
+      />,
+    );
+
+    const discarded = screen.getByText('First workflow').closest('button');
+    const completed = screen.getByText('Second workflow').closest('button');
+
+    expect(discarded?.className).toContain(TERMINAL_DIM);
+    expect(completed?.className).not.toContain(TERMINAL_DIM);
   });
 
   it('keeps the finished list in ordinal order across completed and discarded runs', () => {

--- a/apps/desktop/src/features/session/timeline/buildTimelineStream.test.ts
+++ b/apps/desktop/src/features/session/timeline/buildTimelineStream.test.ts
@@ -809,6 +809,61 @@ describe('buildTimelineStream, session events', () => {
     expect(rows).toEqual(['event:ev-merge', 'event:ev-worktree']);
   });
 
+  it('recedes the lane of a discarded run together with the lanes of its children', () => {
+    const attached = attachedWorkflow({ createdAt: localIso({ day: 18, hour: 8 }) });
+    const { groups } = stream({
+      workflows: [
+        {
+          ...attached,
+          run: {
+            ...attached.run,
+            discardedAt: typedString<IsoDateTime>({ value: localIso({ day: 18, hour: 11 }) }),
+          },
+        },
+      ],
+      agents: [
+        agent({
+          id: 'implement',
+          ordinal: 1,
+          startedAt: localIso({ day: 18, hour: 9 }),
+          workflowRunId: RUN_ID,
+        }),
+        agent({
+          id: 'sub-a',
+          ordinal: 2,
+          parentAgentId: 'implement',
+          startedAt: localIso({ day: 18, hour: 9, minute: 10 }),
+        }),
+      ],
+    });
+
+    expect(groups.map((group) => group.id)).toEqual(['lane:run:run-1', 'lane:agent:implement']);
+    expect(groups.every((group) => group.isMuted)).toBe(true);
+    expect(new Set(groups.map((group) => group.identityIndex)).size).toBe(1);
+  });
+
+  it('leaves the lanes of a live run at full presence', () => {
+    const { groups } = stream({
+      workflows: [attachedWorkflow({ createdAt: localIso({ day: 18, hour: 8 }) })],
+      agents: [
+        agent({
+          id: 'implement',
+          ordinal: 1,
+          startedAt: localIso({ day: 18, hour: 9 }),
+          workflowRunId: RUN_ID,
+        }),
+        agent({
+          id: 'sub-a',
+          ordinal: 2,
+          parentAgentId: 'implement',
+          startedAt: localIso({ day: 18, hour: 9, minute: 10 }),
+        }),
+      ],
+    });
+
+    expect(groups.some((group) => group.isMuted)).toBe(false);
+  });
+
   it('gives a chained agent group a colored lane', () => {
     const result = stream({
       agents: [

--- a/apps/desktop/src/features/session/timeline/buildTimelineStream.ts
+++ b/apps/desktop/src/features/session/timeline/buildTimelineStream.ts
@@ -182,6 +182,7 @@ type EmitAgentParams = {
   readonly entry: TimelineAgentEntry;
   readonly grade: TimelineRowGrade;
   readonly identity: RunIdentity | null;
+  readonly isMuted: boolean;
   readonly familyId: string | null;
   readonly groupId: string | null;
   readonly context: EmitContext;
@@ -191,6 +192,7 @@ const emitAgent = ({
   entry,
   grade,
   identity,
+  isMuted,
   familyId,
   groupId,
   context,
@@ -202,6 +204,7 @@ const emitAgent = ({
       id: childLaneId,
       parentGroupId: groupId,
       identityIndex: identity?.index ?? null,
+      isMuted,
       originRowId: entry.id,
       shape: entry.children.every((child) => isSettled({ agent: child.agent })) ? 'merged' : 'open',
     });
@@ -210,6 +213,7 @@ const emitAgent = ({
         entry: child,
         grade: 'step',
         identity,
+        isMuted,
         familyId,
         groupId: childLaneId,
         context,
@@ -264,11 +268,13 @@ const emitRun = ({ entry, context }: EmitRunParams): void => {
   const laneId = laneIdOf({ entryId: entry.id });
   const isFinished = isRunFinished({ entry });
   const needsUser = context.blockedRunIds.has(entry.run.id);
+  const isMuted = entry.run.discardedAt != null;
   const shape: RailGroupShape = isFinished ? 'merged' : 'open';
   context.groups.push({
     id: laneId,
     parentGroupId: null,
     identityIndex: entry.identity.index,
+    isMuted,
     originRowId: entry.id,
     shape,
   });
@@ -278,6 +284,7 @@ const emitRun = ({ entry, context }: EmitRunParams): void => {
         entry: child,
         grade: 'step',
         identity: entry.identity,
+        isMuted,
         familyId: entry.id,
         groupId: laneId,
         context,
@@ -451,6 +458,7 @@ export const buildTimelineStream = ({
         entry,
         grade: 'entry',
         identity: entry.chain?.identity ?? null,
+        isMuted: false,
         familyId: entry.id,
         groupId: null,
         context,

--- a/apps/desktop/src/features/session/timeline/railGeometry.test.ts
+++ b/apps/desktop/src/features/session/timeline/railGeometry.test.ts
@@ -37,6 +37,7 @@ type GroupParams = {
   readonly shape?: RailGroupShape;
   readonly parentGroupId?: string | null;
   readonly identityIndex?: number | null;
+  readonly isMuted?: boolean;
 };
 
 const group = ({
@@ -45,7 +46,15 @@ const group = ({
   shape = 'merged',
   parentGroupId = null,
   identityIndex = 0,
-}: GroupParams): RailGroupInput => ({ id, originRowId, shape, parentGroupId, identityIndex });
+  isMuted = false,
+}: GroupParams): RailGroupInput => ({
+  id,
+  originRowId,
+  shape,
+  parentGroupId,
+  identityIndex,
+  isMuted,
+});
 
 const railRow = (layout: ReturnType<typeof layoutTimelineRail>, id: string) => {
   const found = layout.rows.find((candidate) => candidate.id === id);
@@ -107,6 +116,7 @@ describe('layoutTimelineRail', () => {
         spineColumn: 0,
         laneColumn: 1,
         identityIndex: 0,
+        isMuted: false,
         dash: 'solid',
         anchorY: 18,
         path: 'M 8 18 C 16.84 18, 24 9.9414, 24 0',
@@ -115,6 +125,27 @@ describe('layoutTimelineRail', () => {
     expect(railRow(layout, 'origin').markerColumn).toBe(0);
     expect(railRow(layout, 'step-1').markerColumn).toBe(1);
     expect(railRow(layout, 'step-2').markerColumn).toBe(0);
+  });
+
+  it('carries a muted lane onto every stroke it draws, spine excluded', () => {
+    const layout = layoutTimelineRail({
+      rows: [
+        row({ id: 'step-2', groupId: 'lane' }),
+        row({ id: 'step-1', groupId: 'lane' }),
+        row({ id: 'origin' }),
+      ],
+      groups: [group({ id: 'lane', originRowId: 'origin', isMuted: true })],
+    });
+    const lanes = lanesOf(layout, 'step-1');
+
+    expect(lanes.length).toBeGreaterThan(0);
+    expect(lanes.every((segment) => segment.isMuted)).toBe(true);
+    expect(railRow(layout, 'origin').joins.every((join) => join.isMuted)).toBe(true);
+    expect(
+      railRow(layout, 'origin')
+        .segments.filter((segment) => segment.column === 0)
+        .every((segment) => segment.isMuted),
+    ).toBe(false);
   });
 
   it('builds a departure from the marker to a vertical lane edge with the reviewed quarter arc', () => {
@@ -218,10 +249,10 @@ describe('layoutTimelineRail', () => {
 
     expect(railRow(layout, 'step-1').joins).toEqual([]);
     expect(lanesOf(layout, 'newer-entry')).toEqual([
-      { column: 1, identityIndex: 0, dash: 'dashed', fromY: 0, toY: 36 },
+      { column: 1, identityIndex: 0, isMuted: false, dash: 'dashed', fromY: 0, toY: 36 },
     ]);
     expect(lanesOf(layout, 'now')).toEqual([
-      { column: 1, identityIndex: 0, dash: 'dashed', fromY: 12, toY: 48 },
+      { column: 1, identityIndex: 0, isMuted: false, dash: 'dashed', fromY: 12, toY: 48 },
     ]);
   });
 
@@ -242,6 +273,7 @@ describe('layoutTimelineRail', () => {
         spineColumn: 0,
         laneColumn: 1,
         identityIndex: 0,
+        isMuted: false,
         dash: 'dashed',
         anchorY: 18,
         path: 'M 24 36 C 24 27.16, 16.84 18, 8 18',
@@ -285,7 +317,7 @@ describe('layoutTimelineRail', () => {
 
     expect(railRow(layout, 'standalone').markerColumn).toBe(0);
     expect(lanesOf(layout, 'standalone')).toEqual([
-      { column: 1, identityIndex: 0, dash: 'solid', fromY: 0, toY: 36 },
+      { column: 1, identityIndex: 0, isMuted: false, dash: 'solid', fromY: 0, toY: 36 },
     ]);
   });
 
@@ -302,8 +334,8 @@ describe('layoutTimelineRail', () => {
     const dayRail = railRow(layout, 'day');
 
     expect(dayRail.segments).toEqual([
-      { column: 0, identityIndex: null, dash: 'solid', fromY: 0, toY: 48 },
-      { column: 1, identityIndex: 0, dash: 'solid', fromY: 0, toY: 48 },
+      { column: 0, identityIndex: null, isMuted: false, dash: 'solid', fromY: 0, toY: 48 },
+      { column: 1, identityIndex: 0, isMuted: false, dash: 'solid', fromY: 0, toY: 48 },
     ]);
   });
 
@@ -380,8 +412,8 @@ describe('layoutTimelineRail', () => {
     expect(railRow(layout, 'pending-2').joins.map((join) => join.dash)).toEqual(['dashed']);
     expect(lanesOf(layout, 'pending-2')).toEqual([]);
     expect(lanesOf(layout, 'running')).toEqual([
-      { column: 1, identityIndex: 0, dash: 'solid', fromY: 18, toY: 36 },
-      { column: 1, identityIndex: 0, dash: 'dashed', fromY: 0, toY: 18 },
+      { column: 1, identityIndex: 0, isMuted: false, dash: 'solid', fromY: 18, toY: 36 },
+      { column: 1, identityIndex: 0, isMuted: false, dash: 'dashed', fromY: 0, toY: 18 },
     ]);
     expect(lanesOf(layout, 'done-1').map((segment) => segment.dash)).toEqual(['solid']);
   });
@@ -461,7 +493,7 @@ describe('layoutTimelineRail', () => {
     });
 
     expect(lanesOf(layout, 'child-1')).toEqual([
-      { column: 1, identityIndex: 0, dash: 'dashed', fromY: 0, toY: 36 },
+      { column: 1, identityIndex: 0, isMuted: false, dash: 'dashed', fromY: 0, toY: 36 },
     ]);
   });
 

--- a/apps/desktop/src/features/session/timeline/railGeometry.ts
+++ b/apps/desktop/src/features/session/timeline/railGeometry.ts
@@ -12,6 +12,7 @@ export type RailGroupInput = {
   readonly id: string;
   readonly parentGroupId: string | null;
   readonly identityIndex: number | null;
+  readonly isMuted: boolean;
   readonly originRowId: string;
   readonly shape: RailGroupShape;
 };
@@ -29,6 +30,7 @@ export type RailRowInput = {
 export type RailSegment = {
   readonly column: number;
   readonly identityIndex: number | null;
+  readonly isMuted: boolean;
   readonly dash: RailDash;
   readonly fromY: number;
   readonly toY: number;
@@ -39,6 +41,7 @@ export type RailJoin = {
   readonly spineColumn: number;
   readonly laneColumn: number;
   readonly identityIndex: number | null;
+  readonly isMuted: boolean;
   readonly dash: RailDash;
   readonly anchorY: number;
   readonly path: string;
@@ -192,7 +195,11 @@ export const layoutTimelineRail = ({ rows, groups }: Params): RailLayout => {
     if (row === undefined) {
       return;
     }
-    const shared = { column: plan.column, identityIndex: plan.group.identityIndex };
+    const shared = {
+      column: plan.column,
+      identityIndex: plan.group.identityIndex,
+      isMuted: plan.group.isMuted,
+    };
     if (index > plan.boundaryIndex) {
       laneSegmentsByIndex[index]?.push({
         ...shared,
@@ -242,6 +249,7 @@ export const layoutTimelineRail = ({ rows, groups }: Params): RailLayout => {
         spineColumn: parentColumn,
         laneColumn: plan.column,
         identityIndex: plan.group.identityIndex,
+        isMuted: plan.group.isMuted,
         dash: plan.boundaryIndex === plan.originIndex ? 'dashed' : 'solid',
         anchorY: anchorOf({ row: originRow }),
       });
@@ -252,7 +260,11 @@ export const layoutTimelineRail = ({ rows, groups }: Params): RailLayout => {
       continue;
     }
     const topAnchor = topAnchorOf({ row: topRow });
-    const shared = { column: plan.column, identityIndex: plan.group.identityIndex };
+    const shared = {
+      column: plan.column,
+      identityIndex: plan.group.identityIndex,
+      isMuted: plan.group.isMuted,
+    };
     const isTopPending = topIndex < plan.boundaryIndex;
 
     if (plan.group.shape === 'open' && !isTopPending) {
@@ -288,6 +300,7 @@ export const layoutTimelineRail = ({ rows, groups }: Params): RailLayout => {
       spineColumn: parentColumn,
       laneColumn: plan.column,
       identityIndex: plan.group.identityIndex,
+      isMuted: plan.group.isMuted,
       dash: isTopPending ? 'dashed' : 'solid',
       anchorY: anchorOf({ row: topRow }),
     });
@@ -321,6 +334,7 @@ export const layoutTimelineRail = ({ rows, groups }: Params): RailLayout => {
         {
           column: 0,
           identityIndex: null,
+          isMuted: false,
           dash: 'solid',
           fromY: row.topY,
           toY: row.height,

--- a/apps/desktop/src/features/session/timeline/runIdentity.ts
+++ b/apps/desktop/src/features/session/timeline/runIdentity.ts
@@ -1,16 +1,47 @@
 export type RunIdentity = {
   readonly stroke: string;
   readonly chip: string;
+  readonly mutedChip: string;
   readonly index: number;
 };
 
 const IDENTITIES: ReadonlyArray<RunIdentity> = [
-  { stroke: 'var(--color-run-1)', chip: 'bg-run-1/12 text-run-1 ring-run-1/35', index: 0 },
-  { stroke: 'var(--color-run-2)', chip: 'bg-run-2/12 text-run-2 ring-run-2/35', index: 1 },
-  { stroke: 'var(--color-run-3)', chip: 'bg-run-3/12 text-run-3 ring-run-3/35', index: 2 },
-  { stroke: 'var(--color-run-4)', chip: 'bg-run-4/12 text-run-4 ring-run-4/35', index: 3 },
-  { stroke: 'var(--color-run-5)', chip: 'bg-run-5/12 text-run-5 ring-run-5/35', index: 4 },
-  { stroke: 'var(--color-run-6)', chip: 'bg-run-6/12 text-run-6 ring-run-6/35', index: 5 },
+  {
+    stroke: 'var(--color-run-1)',
+    chip: 'bg-run-1/12 text-run-1 ring-run-1/35',
+    mutedChip: 'bg-transparent text-run-1 ring-run-1/20',
+    index: 0,
+  },
+  {
+    stroke: 'var(--color-run-2)',
+    chip: 'bg-run-2/12 text-run-2 ring-run-2/35',
+    mutedChip: 'bg-transparent text-run-2 ring-run-2/20',
+    index: 1,
+  },
+  {
+    stroke: 'var(--color-run-3)',
+    chip: 'bg-run-3/12 text-run-3 ring-run-3/35',
+    mutedChip: 'bg-transparent text-run-3 ring-run-3/20',
+    index: 2,
+  },
+  {
+    stroke: 'var(--color-run-4)',
+    chip: 'bg-run-4/12 text-run-4 ring-run-4/35',
+    mutedChip: 'bg-transparent text-run-4 ring-run-4/20',
+    index: 3,
+  },
+  {
+    stroke: 'var(--color-run-5)',
+    chip: 'bg-run-5/12 text-run-5 ring-run-5/35',
+    mutedChip: 'bg-transparent text-run-5 ring-run-5/20',
+    index: 4,
+  },
+  {
+    stroke: 'var(--color-run-6)',
+    chip: 'bg-run-6/12 text-run-6 ring-run-6/35',
+    mutedChip: 'bg-transparent text-run-6 ring-run-6/20',
+    index: 5,
+  },
 ];
 
 type Params = {

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.test.tsx
@@ -15,6 +15,7 @@ import type {
   WorkflowRunId,
   WorkspaceId,
 } from '@goodboy/types';
+import { TERMINAL_DIM } from '@goodboy/ui';
 import type { WorkflowBlockReason } from '../../../../workflows/advanceGate';
 
 const storeMocks = vi.hoisted(() => ({
@@ -614,5 +615,17 @@ describe('WorkflowRow dynamic runs', () => {
 
     expect(screen.getByText('Completed')).toBeDefined();
     expect(screen.queryByTestId('workflow-orchestrate-next-cta')).toBeNull();
+  });
+
+  it('dims a discarded run with the same token the workflows lens card quotes', () => {
+    const { container } = renderDetail({ runOverride: { ...run, discardedAt: NOW } });
+
+    expect((container.firstChild as HTMLElement).className).toContain(TERMINAL_DIM);
+  });
+
+  it('leaves a live run undimmed', () => {
+    const { container } = renderDetail();
+
+    expect((container.firstChild as HTMLElement).className).not.toContain(TERMINAL_DIM);
   });
 });

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.tsx
@@ -7,6 +7,7 @@ import {
   Input,
   MetaRow,
   StatusDot,
+  TERMINAL_DIM,
   Tooltip,
 } from '@goodboy/ui';
 import { ChevronDown, ChevronRight, ChevronUp, Pencil, Undo2 } from 'lucide-react';
@@ -205,7 +206,7 @@ export const WorkflowRow = ({
         isDetail && !expanded && 'grid-rows-[auto]',
         !isDetail && expanded && 'grid-rows-[auto_auto] gap-y-1.5',
         !isDetail && !expanded && 'grid-rows-[auto]',
-        isDiscarded && 'opacity-70',
+        isDiscarded && TERMINAL_DIM,
       )}
     >
       <div className="col-span-2 row-start-1 grid grid-cols-[minmax(0,1fr)_auto] grid-rows-[auto] items-start gap-2">

--- a/packages/ui/src/__tests__/RailCard.test.tsx
+++ b/packages/ui/src/__tests__/RailCard.test.tsx
@@ -1,0 +1,26 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { RailCard } from '../components/RailCard';
+import { TERMINAL_DIM } from '../terminalDim';
+
+afterEach(cleanup);
+
+const cardOf = () => screen.getByRole('button', { name: 'Open the run' });
+
+describe('RailCard', () => {
+  it('keeps a live card at full strength on the elevated surface', () => {
+    render(<RailCard title="Refactor" ariaLabel="Open the run" onSelect={vi.fn()} />);
+
+    expect(cardOf().className).toContain('bg-elevated/40');
+    expect(cardOf().className).not.toContain(TERMINAL_DIM);
+  });
+
+  it('dims a terminal card and drops its fill so it recedes from the live ones', () => {
+    render(<RailCard title="Refactor" ariaLabel="Open the run" muted onSelect={vi.fn()} />);
+
+    expect(cardOf().className).toContain(TERMINAL_DIM);
+    expect(cardOf().className).toContain('bg-transparent');
+    expect(cardOf().className).not.toContain('bg-elevated/40');
+  });
+});

--- a/packages/ui/src/components/RailCard.tsx
+++ b/packages/ui/src/components/RailCard.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 import { ChevronRight } from 'lucide-react';
 import { cn } from '../cn';
+import { TERMINAL_DIM } from '../terminalDim';
 
 type Props = {
   readonly title: ReactNode;
@@ -29,7 +30,7 @@ export const RailCard = ({
     onClick={onSelect}
     className={cn(
       'flex w-full items-center gap-3 rounded-lg border border-border-soft bg-elevated/40 px-3 py-2.5 text-left transition-colors hover:border-border hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]',
-      muted && 'opacity-70',
+      muted && ['border-border-soft/60 bg-transparent', TERMINAL_DIM],
       className,
     )}
   >

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -6,6 +6,7 @@ export { useDropdown } from './useDropdown';
 export { DropdownBackdrop } from './useDropdown/DropdownBackdrop';
 export { DropdownPortal } from './useDropdown/DropdownPortal';
 export { PANE_RHYTHM } from './paneRhythm';
+export { TERMINAL_DIM } from './terminalDim';
 export { formatError } from './formatError';
 export { formatTokens, formatUsd, formatUsdPrecise } from './format-cost';
 export {

--- a/packages/ui/src/terminalDim.ts
+++ b/packages/ui/src/terminalDim.ts
@@ -1,0 +1,1 @@
+export const TERMINAL_DIM = 'opacity-65';


### PR DESCRIPTION
## What

A discarded workflow run looked the same as a live one. The worst case was the activity timeline, where a discarded run row had no treatment at all. The card dim was also a literal repeated per surface, so the sidebar row and the lens card could drift apart.

## Surfaces and the token each one now uses

| Surface | File | Token |
| --- | --- | --- |
| Shared terminal dim | `packages/ui/src/terminalDim.ts` (new) | `TERMINAL_DIM = 'opacity-65'` |
| Rail card (workflows lens, plans, integration tasks) | `packages/ui/src/components/RailCard.tsx` | `muted` applies `TERMINAL_DIM` plus `bg-transparent border-border-soft/60` |
| Workspaces sidebar row and workflow run detail | `WorkspacesSidebar/parts/WorkflowRow.tsx` | `TERMINAL_DIM` replaces the hand-rolled `opacity-70` |
| Activity timeline: run name | `TimelinePane/TimelineRunLabel.tsx` | `text-muted-foreground` |
| Activity timeline: run chip | `runIdentity.ts`, `TimelinePane/TimelineRunChip.tsx` | `mutedChip`, the identity's own hue with the fill dropped: `bg-transparent text-run-N ring-run-N/20` |
| Activity timeline: lane stroke, run lane and every child lane under it | `buildTimelineStream.ts`, `railGeometry.ts`, `TimelinePane/TimelineRail.tsx` | `TERMINAL_DIM` on the `line` and `path` of a muted lane |

No per-surface opacity literal survives: the sidebar row and the lens card quote the same exported constant, and the tests assert that agreement by importing it.

## The timeline: the lane carries it, not a word

The state is not written out in the row. A `Discarded` qualifier would have to be paid for out of the run name, which truncates first, so the row would lose the one thing that identifies it in order to say something the lane can say on its own.

Instead the run's identity channel recedes as a whole, and it recedes in one piece:

- `RailGroupInput` gains `isMuted`, set from `run.discardedAt` in `emitRun`, and passed down through `emitAgent` to every child lane of that run. `railGeometry` carries the flag onto each `RailSegment` and `RailJoin`, so the run's lane, the stubs its fan-outs hang on, and the depart and merge curves all dim in one step. The shared spine stays at full strength, and a live or completed run is untouched.
- The children therefore read as belonging to the discarded run rather than as a separate live lane: they sit on the same hue at the same reduced presence, one continuous receded lane instead of a bright lane under a faded header.
- The hue never changes, so a receded lane is still recognisably *that* run, which is what the identity palette is for. This is the same objection I raised earlier about greying the chip alone; dimming chip and stroke together removes it.

Two different mechanisms on purpose:

- The lane stroke has nothing but hue to lose, so it fades with `TERMINAL_DIM`.
- The chip carries a word, so it recedes by shedding its tinted fill rather than by fading its label. Same rule the `RailCard` follows in this PR: a terminal surface gives up its fill, its text stays readable.

## Contrast, measured

Computed from the oklch tokens in `apps/desktop/src/styles.css` through oklab to sRGB to WCAG relative luminance, against the pane canvas (`--color-background`), worst case across all six run hues.

| | dark | light |
| --- | --- | --- |
| run name, live (`text-foreground`) | 14.58:1 | 16.48:1 |
| run name, discarded (`text-muted-foreground`) | **8.65:1** | **7.54:1** |
| chip label, live (on its `bg-run-N/12` fill) | 4.80:1 | 3.94:1 |
| chip label, discarded (fill dropped) | **5.64:1** | **4.61:1** |
| lane stroke, live | 5.64:1 | 4.61:1 |
| lane stroke, discarded (`opacity-65`) | 3.09:1 | 2.59:1 |

The discarded run name clears AA by a wide margin in both themes, and the chip label ends up *more* legible than it is today, because the tinted fill it sheds was working against it. The lane stroke is the only thing that drops below a text threshold, and it carries no text.

For reference, this is why the card dim in this PR is `opacity-65` and not `opacity-60`: opacity composites a card's text toward the canvas, and in the light theme the `text-sm` card title measures ~6.4:1 at 70%, ~5.3:1 at 65%, and ~4.1:1 at 60%, which is under AA. 65 is the last step that holds in both themes, and the rest of the card's recession is carried by dropping the `bg-elevated/40` fill, which costs nothing in contrast.

`border-dashed` was considered and rejected: in this codebase it consistently means empty, add, or drop target (`AddDecisionRow`, `WorkflowAttachButton`, `FileDropZone`, `EmptyState`), so it would have collided with an existing meaning.

## Test plan

- `packages/ui/src/__tests__/RailCard.test.tsx` (new): a live card keeps the elevated fill and no dim; a muted card carries `TERMINAL_DIM`, drops `bg-elevated/40`, and goes transparent.
- `TimelineRunLabel.test.tsx`: a live run keeps `text-foreground` and a filled chip; a discarded run takes `text-muted-foreground`, takes the hollow `mutedChip`, keeps its `text-run-N` hue, and spends no word on the state.
- `TimelineRail.test.tsx`: a muted segment and a muted join keep `var(--color-run-1)` and gain `TERMINAL_DIM`; the existing full-strength cases still assert no opacity class.
- `buildTimelineStream.test.ts`: a discarded run mutes its own lane and its child lane, both on one identity; a live run mutes nothing.
- `railGeometry.test.ts`: a muted group carries the flag onto every lane segment and join it draws, and leaves the shared spine alone.
- `WorkflowRow.test.tsx`: a discarded run quotes `TERMINAL_DIM`, a live one does not.
- `WorkflowsPane.test.tsx`: in the Finished register, the discarded card carries `TERMINAL_DIM` and the completed card beside it does not. This is the adjacency that prompted the report.

Green: `npx tsc --noEmit` (desktop and ui), `npx vitest run src/features/workflows src/features/session src/features/workspace src/__tests__` (229 files, 2484 tests), the `packages/ui` suite (219 tests), `pnpm knip --include files,duplicates,unlisted` (only the pre-existing config hints).
