### PR TITLE
fix(ui): bound an absolute popover to the space on screen

### DIFF
--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/ActivityFilterButton.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/ActivityFilterButton.tsx
@@ -51,15 +51,17 @@ export const ActivityFilterButton = ({ filter, hiddenCount, onCategory }: Props)
           className={cn(popupClassName, 'bg-subtle')}
           style={popupStyle}
         >
-          <PopoverBody className="flex flex-col gap-2 px-3 py-2.5">
-            {ACTIVITY_CATEGORIES.map((category) => (
-              <Checkbox
-                key={category}
-                checked={filter[category]}
-                label={ACTIVITY_CATEGORY_LABEL[category]}
-                onChange={(enabled) => onCategory({ category, enabled })}
-              />
-            ))}
+          <PopoverBody>
+            <div className="flex flex-col gap-2 px-3 py-2.5">
+              {ACTIVITY_CATEGORIES.map((category) => (
+                <Checkbox
+                  key={category}
+                  checked={filter[category]}
+                  label={ACTIVITY_CATEGORY_LABEL[category]}
+                  onChange={(enabled) => onCategory({ category, enabled })}
+                />
+              ))}
+            </div>
           </PopoverBody>
         </Popover>
       ) : null}

--- a/packages/ui/src/__tests__/Popover.test.tsx
+++ b/packages/ui/src/__tests__/Popover.test.tsx
@@ -1,8 +1,10 @@
 // @vitest-environment happy-dom
 
-import { describe, expect, it } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
 import { Popover, PopoverBody, PopoverFooter } from '../components/Popover';
+
+afterEach(cleanup);
 
 describe('Popover', () => {
   it('keeps the footer action available when the body overflows', () => {
@@ -18,5 +20,37 @@ describe('Popover', () => {
     );
 
     expect(screen.getByRole('button', { name: 'Start' })).toBeDefined();
+  });
+  it('defers its own height bound to the dropdown variable', () => {
+    render(
+      <Popover role="menu" ariaLabel="Bounded">
+        <PopoverBody>Row</PopoverBody>
+      </Popover>,
+    );
+
+    const popover = screen.getByRole('menu');
+    expect(popover.style.maxHeight).toBe('var(--dropdown-max-height, 100%)');
+    expect(popover.className).not.toContain('max-h-full');
+  });
+
+  it('lets a positioned caller override the bound', () => {
+    render(
+      <Popover role="menu" ariaLabel="Fixed" style={{ maxHeight: 320 }}>
+        <PopoverBody>Row</PopoverBody>
+      </Popover>,
+    );
+
+    expect(screen.getByRole('menu').style.maxHeight).toBe('320px');
+  });
+  it('lets the body viewport fill the bounded popover instead of the content', () => {
+    render(
+      <Popover role="menu" ariaLabel="Scrolling">
+        <PopoverBody>Row</PopoverBody>
+      </Popover>,
+    );
+
+    const viewport = screen.getByRole('menu').querySelector('[class*="overflow-y-auto"]');
+    expect(viewport?.className).toContain('flex-1');
+    expect(viewport?.className).not.toContain('h-full');
   });
 });

--- a/packages/ui/src/__tests__/useDropdown.test.ts
+++ b/packages/ui/src/__tests__/useDropdown.test.ts
@@ -132,4 +132,125 @@ describe('useDropdown', () => {
     expect(result.current.popupStyle).toMatchObject({ left: 96, top: 234 });
     scrollAncestor.remove();
   });
+  it('bounds an absolute popup to the space left under the trigger', () => {
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1024 });
+    Object.defineProperty(window, 'innerHeight', { configurable: true, value: 768 });
+    const trigger = document.createElement('div');
+    document.body.append(trigger);
+    trigger.getBoundingClientRect = () =>
+      DOMRect.fromRect({ x: 40, y: 100, width: 60, height: 28 });
+    const { result } = renderHook(() => useDropdown({ expectedHeight: 220 }));
+
+    act(() => {
+      result.current.containerRef.current = trigger;
+      result.current.toggle();
+    });
+
+    expect(result.current.popupClassName).toContain('top-[calc(100%+0.25rem)]');
+    expect(result.current.popupStyle).toBeUndefined();
+    expect(trigger.style.getPropertyValue('--dropdown-max-height')).toBe('628px');
+    trigger.remove();
+  });
+
+  it('bounds an absolute popup to its clipping ancestor', () => {
+    Object.defineProperty(window, 'innerHeight', { configurable: true, value: 768 });
+    const clipper = document.createElement('div');
+    clipper.style.overflowY = 'auto';
+    const trigger = document.createElement('div');
+    clipper.append(trigger);
+    document.body.append(clipper);
+    clipper.getBoundingClientRect = () =>
+      DOMRect.fromRect({ x: 0, y: 60, width: 400, height: 340 });
+    trigger.getBoundingClientRect = () =>
+      DOMRect.fromRect({ x: 40, y: 100, width: 60, height: 28 });
+    const { result } = renderHook(() => useDropdown({ expectedHeight: 220 }));
+
+    act(() => {
+      result.current.containerRef.current = trigger;
+      result.current.toggle();
+    });
+
+    expect(trigger.style.getPropertyValue('--dropdown-max-height')).toBe('260px');
+    clipper.remove();
+  });
+
+  it('bounds an absolute popup opening upwards to the space above the trigger', () => {
+    Object.defineProperty(window, 'innerHeight', { configurable: true, value: 768 });
+    const trigger = document.createElement('div');
+    document.body.append(trigger);
+    trigger.getBoundingClientRect = () =>
+      DOMRect.fromRect({ x: 40, y: 620, width: 60, height: 28 });
+    const { result } = renderHook(() => useDropdown({ expectedHeight: 220 }));
+
+    act(() => {
+      result.current.containerRef.current = trigger;
+      result.current.toggle();
+    });
+
+    expect(result.current.popupClassName).toContain('bottom-[calc(100%+0.25rem)]');
+    expect(trigger.style.getPropertyValue('--dropdown-max-height')).toBe('608px');
+    trigger.remove();
+  });
+
+  it('drops the absolute bound once the popup closes', () => {
+    Object.defineProperty(window, 'innerHeight', { configurable: true, value: 768 });
+    const trigger = document.createElement('div');
+    document.body.append(trigger);
+    trigger.getBoundingClientRect = () =>
+      DOMRect.fromRect({ x: 40, y: 100, width: 60, height: 28 });
+    const { result } = renderHook(() => useDropdown({}));
+
+    act(() => {
+      result.current.containerRef.current = trigger;
+      result.current.toggle();
+    });
+    expect(trigger.style.getPropertyValue('--dropdown-max-height')).not.toBe('');
+
+    act(() => result.current.close());
+
+    expect(trigger.style.getPropertyValue('--dropdown-max-height')).toBe('');
+    trigger.remove();
+  });
+
+  it('leaves a fixed popup on its own inline bound', () => {
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1024 });
+    Object.defineProperty(window, 'innerHeight', { configurable: true, value: 768 });
+    const trigger = document.createElement('div');
+    document.body.append(trigger);
+    trigger.getBoundingClientRect = () =>
+      DOMRect.fromRect({ x: 40, y: 100, width: 60, height: 28 });
+    const { result } = renderHook(() =>
+      useDropdown({ expectedHeight: 220, expectedWidth: 240, strategy: 'fixed' }),
+    );
+
+    act(() => {
+      result.current.containerRef.current = trigger;
+      result.current.toggle();
+    });
+
+    expect(result.current.popupStyle).toMatchObject({ top: 132, maxHeight: 628 });
+    expect(trigger.style.getPropertyValue('--dropdown-max-height')).toBe('');
+    trigger.remove();
+  });
+  it('keeps a usable bound when the clipping ancestor hugs the trigger', () => {
+    Object.defineProperty(window, 'innerHeight', { configurable: true, value: 768 });
+    const clipper = document.createElement('div');
+    clipper.style.overflowY = 'hidden';
+    const trigger = document.createElement('div');
+    clipper.append(trigger);
+    document.body.append(clipper);
+    clipper.getBoundingClientRect = () =>
+      DOMRect.fromRect({ x: 0, y: 100, width: 400, height: 28 });
+    trigger.getBoundingClientRect = () =>
+      DOMRect.fromRect({ x: 40, y: 100, width: 60, height: 28 });
+    const { result } = renderHook(() => useDropdown({ expectedHeight: 220 }));
+
+    act(() => {
+      result.current.containerRef.current = trigger;
+      result.current.toggle();
+    });
+
+    expect(trigger.style.getPropertyValue('--dropdown-max-height')).toBe('160px');
+    clipper.remove();
+  });
 });

--- a/packages/ui/src/components/Popover.tsx
+++ b/packages/ui/src/components/Popover.tsx
@@ -1,5 +1,6 @@
 import type { CSSProperties, ReactNode, Ref } from 'react';
 import { cn } from '../cn';
+import { DROPDOWN_MAX_HEIGHT_VARIABLE } from '../dropdownMaxHeight';
 import { ScrollFade } from './ScrollFade';
 
 export type PopoverProps = {
@@ -37,9 +38,9 @@ export const Popover = ({
       role={role}
       aria-label={ariaLabel}
       tabIndex={tabIndex}
-      style={style}
+      style={{ maxHeight: `var(${DROPDOWN_MAX_HEIGHT_VARIABLE}, 100%)`, ...style }}
       className={cn(
-        'flex max-h-full min-h-0 min-w-0 flex-col overflow-hidden rounded-md border border-border bg-elevated text-xs shadow-lg',
+        'flex min-h-0 min-w-0 flex-col overflow-hidden rounded-md border border-border bg-elevated text-xs shadow-lg',
         className,
       )}
     >
@@ -49,7 +50,12 @@ export const Popover = ({
 };
 
 export const PopoverBody = ({ children, className }: PopoverBodyProps) => (
-  <ScrollFade className={cn('min-h-0 flex-1', className)} fadeSize={12} fadeFrom="elevated">
+  <ScrollFade
+    className={cn('flex min-h-0 flex-1 flex-col', className)}
+    viewportClassName="h-auto min-h-0 flex-1"
+    fadeSize={12}
+    fadeFrom="elevated"
+  >
     {children}
   </ScrollFade>
 );

--- a/packages/ui/src/dropdownMaxHeight.ts
+++ b/packages/ui/src/dropdownMaxHeight.ts
@@ -1,0 +1,1 @@
+export const DROPDOWN_MAX_HEIGHT_VARIABLE = '--dropdown-max-height';

--- a/packages/ui/src/useDropdownDirection.ts
+++ b/packages/ui/src/useDropdownDirection.ts
@@ -1,5 +1,6 @@
 import { useLayoutEffect, useState } from 'react';
 import type { CSSProperties, RefObject } from 'react';
+import { DROPDOWN_MAX_HEIGHT_VARIABLE } from './dropdownMaxHeight';
 
 type Direction = 'up' | 'down';
 
@@ -32,6 +33,13 @@ type ResolveDesiredLeftParams = {
   readonly align: Align;
 };
 
+type ResolveBoundedMaxHeightParams = {
+  readonly rect: DOMRect;
+  readonly direction: Direction;
+  readonly bottomBound: number;
+  readonly topBound: number;
+};
+
 const VIEWPORT_MARGIN = 8;
 const DROPDOWN_GAP = 4;
 const MIN_DROPDOWN_HEIGHT = 160;
@@ -44,6 +52,22 @@ const resolveDesiredLeft = ({ rect, popupWidth, align }: ResolveDesiredLeftParam
     return rect.left + rect.width / 2 - popupWidth / 2;
   }
   return rect.left;
+};
+
+const resolveBoundedMaxHeight = ({
+  rect,
+  direction,
+  bottomBound,
+  topBound,
+}: ResolveBoundedMaxHeightParams): number => {
+  const inset = DROPDOWN_GAP + VIEWPORT_MARGIN;
+  const clipped =
+    direction === 'down'
+      ? Math.min(bottomBound, window.innerHeight) - rect.bottom
+      : rect.top - Math.max(topBound, 0);
+  const onScreen = direction === 'down' ? window.innerHeight - rect.bottom : rect.top;
+  const wanted = Math.max(clipped - inset, MIN_DROPDOWN_HEIGHT);
+  return Math.max(Math.min(wanted, onScreen - inset), 0);
 };
 
 const findClippingAncestor = ({ element }: FindClippingAncestorParams): HTMLElement | null => {
@@ -88,9 +112,12 @@ export const useDropdownDirection = ({
         const topBound = clipperRect?.top ?? 0;
         const spaceBelow = bottomBound - rect.bottom;
         const spaceAbove = rect.top - topBound;
-        setPosition({
-          direction: spaceBelow < expectedHeight && spaceAbove > spaceBelow ? 'up' : 'down',
-        });
+        const direction = spaceBelow < expectedHeight && spaceAbove > spaceBelow ? 'up' : 'down';
+        trigger.style.setProperty(
+          DROPDOWN_MAX_HEIGHT_VARIABLE,
+          `${resolveBoundedMaxHeight({ rect, direction, bottomBound, topBound })}px`,
+        );
+        setPosition({ direction });
         return;
       }
 
@@ -130,7 +157,11 @@ export const useDropdownDirection = ({
 
     updatePosition();
     if (strategy === 'absolute') {
-      return;
+      window.addEventListener('resize', updatePosition);
+      return () => {
+        window.removeEventListener('resize', updatePosition);
+        triggerRef.current?.style.removeProperty(DROPDOWN_MAX_HEIGHT_VARIABLE);
+      };
     }
     window.addEventListener('resize', updatePosition);
     window.addEventListener('scroll', updatePosition, true);


### PR DESCRIPTION
## Mechanism

`Popover` carried `max-h-full` on its root. For a popover positioned with the `absolute` strategy the containing block is the `relative` wrapper around the trigger, which is only as tall as the trigger itself (often `h-7`), so `max-height: 100%` resolved to 28px and the root's `overflow-hidden` cut the content down to a sliver. The popover looked like it failed to open. The `fixed` strategy was never affected because `useDropdownDirection` already hands it a pixel `maxHeight` in the inline style, which beats the class.

## What changed

- `useDropdownDirection`: the `absolute` branch now measures the room between the trigger and the bound it already resolves (the clipping ancestor from `findClippingAncestor`, clamped to the viewport), subtracts the same `DROPDOWN_GAP` + `VIEWPORT_MARGIN` the `fixed` branch uses, and publishes the result as a `--dropdown-max-height` custom property on the trigger container. It keeps a `MIN_DROPDOWN_HEIGHT` floor so an ancestor that hugs the trigger cannot collapse the popover to nothing, and never exceeds the room left on screen. The property is dropped when the popover closes, and recomputed on window resize.
- `Popover`: the root takes `max-height: var(--dropdown-max-height, 100%)` inline instead of `max-h-full`. An inline `maxHeight` from a caller (the `fixed` strategy) still wins, and a `Popover` rendered outside a dropdown keeps the old `100%` behavior.
- `PopoverBody`: the `ScrollFade` viewport fills the bounded body through flex instead of `h-full`. A percentage height cannot resolve inside a max-height driven column, so the viewport used to grow to its content: with a bound in place the tail of a long list was clipped, unscrollable, and hidden behind `PopoverFooter`.

The change lives entirely in `packages/ui`; no call site was touched.

## Call sites this unblocks

`ActivityFilterButton`, `RunSpendLimitPopover`, jira `TransitionMenu` and `AssigneePicker`, GitHub `ReviewerPicker`, `PrVerdictAction` and `PrSwitcher`, `VerbositySelect`, `ChainAfterSelect`, `BranchChip`, `ResolverOverflowMenu`, `RoleSelect`.

## Test plan

- `pnpm --filter @goodboy/ui test`: 226 passing, including new coverage for the absolute branch (viewport-bounded, clipper-bounded, upward, floored, cleared on close) and for the fixed branch keeping its inline `top`/`maxHeight` with no custom property written.
- `pnpm turbo run typecheck` and `pnpm knip --include files,duplicates,unlisted` clean. `apps/desktop` suite green (6242 tests).
- Real layout engine, real components, dev build of this branch: with the fix reverted the Activity filter popover measures 28px tall with `max-height: 100%` and 1 of its 7 rows inside the box. With the fix it measures 96px with `max-height: 756.5px`, all 7 checkbox rows inside, and a hit test on a row lands on the checkbox input. An absolute popover with 24 rows near the bottom of the window opens upward, stops at the 8px viewport margin, and scrolls to its last row with the footer still visible. A fixed-strategy popover keeps `position: fixed` with its inline bound and behaves as before.



## Follow-up: the filter checkboxes wrapped two per row

Same complaint, second cause. `ActivityFilterButton` passed `flex flex-col gap-2 px-3 py-2.5` to `PopoverBody`, which forwards its `className` to the `ScrollFade` root. That root holds a single in-flow child, the scroll viewport, so the column and the gap applied to the viewport rather than to the checkboxes inside it and the rows ran two per line. The classes move onto the list itself, matching how `RunSpendLimitPopover`, `ResolveConfigPopover` and `CreateAgentPopover` already lay their contents out (plain `PopoverBody`, an inner div carrying padding and flow). No new prop was needed.

Measured in Chrome on this branch, 1280x800: before, the 7 labels shared 4 distinct top offsets, two to a line. After, 7 labels at 7 distinct tops 24px apart, all left-aligned at the same x, popover 182px tall inside its 756.5px bound, and `elementFromPoint` on every row lands on that row's checkbox input.

`ActivityFilterButton` was the only `PopoverBody` caller passing a `className` at all, so no other caller carries this defect.

Closes #1518
