### PR TITLE
feat(desktop): guide the slack connect to install and paste

### DIFF
--- a/apps/desktop/src/features/integrations/slack/SlackConnectGuide.test.tsx
+++ b/apps/desktop/src/features/integrations/slack/SlackConnectGuide.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+const { openUrl } = vi.hoisted(() => ({ openUrl: vi.fn(async () => undefined) }));
+
+vi.mock('../../../shared/lib/editor', () => ({ openUrl }));
+
+import { SlackConnectGuide } from './SlackConnectGuide';
+import { buildSlackManifestUrl, SLACK_USER_SCOPES } from './slackAppManifest';
+
+const MANIFEST_URL = buildSlackManifestUrl({ userScopes: SLACK_USER_SCOPES });
+
+const writeText = vi.fn(async () => undefined);
+
+beforeEach(() => {
+  openUrl.mockClear();
+  writeText.mockClear();
+  Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText } });
+});
+afterEach(cleanup);
+
+describe('SlackConnectGuide', () => {
+  it('leads with one action that carries the scopes into Slack', () => {
+    render(<SlackConnectGuide manifestUrl={MANIFEST_URL} />);
+    fireEvent.click(screen.getByRole('button', { name: /open Slack with the scopes filled in/i }));
+    expect(openUrl).toHaveBeenCalledWith(MANIFEST_URL);
+    expect(screen.getByText(/Copy the User OAuth Token/i)).toBeDefined();
+  });
+
+  it('names every scope and hands the exact list to the clipboard', async () => {
+    render(<SlackConnectGuide manifestUrl={MANIFEST_URL} />);
+    SLACK_USER_SCOPES.forEach((scope) => expect(screen.getByText(scope)).toBeDefined());
+    fireEvent.click(screen.getByRole('button', { name: 'Slack scopes' }));
+    await waitFor(() =>
+      expect(writeText).toHaveBeenCalledWith(
+        'channels:read\nchannels:history\nusers:read\nchat:write\nreactions:write',
+      ),
+    );
+  });
+
+  it('sends the owner of an existing app to that app instead of a second one', () => {
+    render(<SlackConnectGuide manifestUrl={MANIFEST_URL} />);
+    fireEvent.click(screen.getByRole('tab', { name: /existing app/i }));
+    expect(screen.getByText(/Add the scopes below under User Token Scopes/i)).toBeDefined();
+    expect(screen.getByText(/Reinstall the app/i)).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: /open your Slack apps/i }));
+    expect(openUrl).toHaveBeenCalledWith('https://api.slack.com/apps');
+  });
+
+  it('falls back to the manual steps when the manifest url is unavailable', () => {
+    render(<SlackConnectGuide manifestUrl={null} />);
+    expect(screen.queryByRole('button', { name: /scopes filled in/i })).toBeNull();
+    expect(screen.getByText(/Add the scopes below under User Token Scopes/i)).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: /open Slack app creation/i }));
+    expect(openUrl).toHaveBeenCalledWith('https://api.slack.com/apps/new');
+  });
+});

--- a/apps/desktop/src/features/integrations/slack/SlackConnectGuide.tsx
+++ b/apps/desktop/src/features/integrations/slack/SlackConnectGuide.tsx
@@ -1,0 +1,179 @@
+import { useState } from 'react';
+import {
+  Button,
+  CopyButton,
+  Divider,
+  Eyebrow,
+  SegmentedTabs,
+  type SegmentedTabOption,
+} from '@goodboy/ui';
+import { ExternalLink } from 'lucide-react';
+import { openUrl } from '../../../shared/lib/editor';
+import { SLACK_APPS_URL, SLACK_NEW_APP_URL, SLACK_USER_SCOPES } from './slackAppManifest';
+
+type Props = {
+  readonly manifestUrl: string | null;
+};
+
+type SetupPath = 'new' | 'existing';
+
+type GuideStep = {
+  readonly title: string;
+  readonly body: string;
+  readonly action: {
+    readonly label: string;
+    readonly url: string;
+  } | null;
+};
+
+const PATH_OPTIONS: ReadonlyArray<SegmentedTabOption<SetupPath>> = [
+  { value: 'new', label: 'New app' },
+  { value: 'existing', label: 'Existing app' },
+];
+
+const INSTALL_STEP: GuideStep = {
+  title: 'Install it in your workspace',
+  body: 'Slack shows what Goodboy will be able to do, then asks you to allow it.',
+  action: null,
+};
+
+const TOKEN_STEP: GuideStep = {
+  title: 'Copy the User OAuth Token',
+  body: 'It sits under OAuth and Permissions, in the User column, and starts with xoxp-.',
+  action: null,
+};
+
+const SCOPE_STEP: GuideStep = {
+  title: 'Add the scopes below under User Token Scopes',
+  body: 'Open OAuth and Permissions and leave Bot Token Scopes as they are.',
+  action: null,
+};
+
+type StepParams = {
+  readonly path: SetupPath;
+  readonly manifestUrl: string | null;
+};
+
+const buildSteps = ({ path, manifestUrl }: StepParams): ReadonlyArray<GuideStep> => {
+  if (path === 'existing') {
+    return [
+      {
+        title: 'Open the app you already have',
+        body: 'Pick it from your Slack apps, then open OAuth and Permissions.',
+        action: { label: 'Open your Slack apps', url: SLACK_APPS_URL },
+      },
+      SCOPE_STEP,
+      {
+        title: 'Reinstall the app',
+        body: 'Slack asks for it after a scope change, so the new scopes take effect.',
+        action: null,
+      },
+      TOKEN_STEP,
+    ];
+  }
+
+  if (manifestUrl == null) {
+    return [
+      {
+        title: 'Create an app from scratch',
+        body: 'Name it Goodboy and pick the workspace whose threads you read.',
+        action: { label: 'Open Slack app creation', url: SLACK_NEW_APP_URL },
+      },
+      SCOPE_STEP,
+      INSTALL_STEP,
+      TOKEN_STEP,
+    ];
+  }
+
+  return [
+    {
+      title: 'Create the app in Slack',
+      body: 'Slack opens with the name and the five user scopes already filled in.',
+      action: { label: 'Open Slack with the scopes filled in', url: manifestUrl },
+    },
+    INSTALL_STEP,
+    TOKEN_STEP,
+  ];
+};
+
+export const SlackConnectGuide = ({ manifestUrl }: Props) => {
+  const [path, setPath] = useState<SetupPath>('new');
+  const steps = buildSteps({ path, manifestUrl });
+
+  return (
+    <div className="flex flex-col gap-3 rounded-lg border border-border-soft bg-subtle/40 p-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <Eyebrow label="Set up" />
+        <SegmentedTabs
+          size="sm"
+          options={PATH_OPTIONS}
+          value={path}
+          onChange={setPath}
+          ariaLabel="Slack setup path"
+        />
+      </div>
+
+      <ol className="flex flex-col gap-2.5">
+        {steps.map((step, index) => {
+          const { action } = step;
+          return (
+            <li
+              key={step.title}
+              className="grid grid-cols-[1.125rem_minmax(0,1fr)] gap-x-2 gap-y-1"
+            >
+              <span className="pt-px text-2xs font-semibold tabular-nums text-muted-foreground">
+                {index + 1}
+              </span>
+              <div className="flex min-w-0 flex-col gap-1.5">
+                <span className="text-xs font-semibold leading-snug text-foreground">
+                  {step.title}
+                </span>
+                <p className="text-2xs leading-relaxed text-muted-foreground">{step.body}</p>
+                {action != null ? (
+                  <div className="flex">
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      onClick={() => void openUrl(action.url)}
+                      className="max-w-full"
+                    >
+                      <span className="truncate">{action.label}</span>
+                      <ExternalLink size={11} aria-hidden />
+                    </Button>
+                  </div>
+                ) : null}
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+
+      <Divider />
+
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center justify-between gap-2">
+          <p className="min-w-0 text-2xs leading-relaxed text-muted-foreground">
+            The user token starts with <span className="font-mono">xoxp-</span> and needs these
+            scopes, granted under User Token Scopes and not Bot Token Scopes:
+          </p>
+          <CopyButton
+            value={SLACK_USER_SCOPES.join('\n')}
+            label="Slack scopes"
+            presentation="icon"
+            size={12}
+          />
+        </div>
+        <ul className="flex flex-wrap gap-2">
+          {SLACK_USER_SCOPES.map((scope) => (
+            <li
+              key={scope}
+              className="rounded-full border border-border-soft px-2 py-0.5 font-mono text-2xs text-foreground"
+            >
+              {scope}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+};

--- a/apps/desktop/src/features/integrations/slack/SlackFormBody.test.tsx
+++ b/apps/desktop/src/features/integrations/slack/SlackFormBody.test.tsx
@@ -23,6 +23,10 @@ vi.mock('../../../store', () => ({
   useAppStore: <T,>(selector: (s: typeof state) => T) => selector(state),
 }));
 
+const { openUrl } = vi.hoisted(() => ({ openUrl: vi.fn(async () => undefined) }));
+
+vi.mock('../../../shared/lib/editor', () => ({ openUrl }));
+
 const WS_ID = 'ws-1' as WorkspaceId;
 
 const slackIntegration: SlackWorkspaceIntegration = {
@@ -47,19 +51,28 @@ beforeEach(() => {
   state.forgetIntegrationCredential = vi.fn(async () => undefined);
   state.integrationCredentials = [];
   state.integrationCredentialUsage = {};
+  openUrl.mockClear();
 });
 afterEach(cleanup);
 
 import { SlackFormBody } from './SlackFormBody';
+import { buildSlackManifestUrl, SLACK_USER_SCOPES } from './slackAppManifest';
 
 describe('SlackFormBody', () => {
-  it('offers the app link before the token field', () => {
+  it('walks the setup through before the token field', () => {
     render(<SlackFormBody workspaceId={WS_ID} />);
 
-    const link = screen.getByRole('link', { name: /create a Slack app/i });
+    const firstStep = screen.getByRole('button', { name: /open Slack with the scopes filled in/i });
     const field = screen.getByLabelText(/user token/i);
 
-    expect(link.compareDocumentPosition(field)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    expect(firstStep.compareDocumentPosition(field)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    expect(screen.queryByRole('link', { name: /create a Slack app/i })).toBeNull();
+  });
+
+  it('opens Slack through the app rather than a raw anchor', () => {
+    render(<SlackFormBody workspaceId={WS_ID} />);
+    fireEvent.click(screen.getByRole('button', { name: /open Slack with the scopes filled in/i }));
+    expect(openUrl).toHaveBeenCalledWith(buildSlackManifestUrl({ userScopes: SLACK_USER_SCOPES }));
   });
 
   it('keeps Connect disabled until a token is pasted', () => {

--- a/apps/desktop/src/features/integrations/slack/SlackFormBody.tsx
+++ b/apps/desktop/src/features/integrations/slack/SlackFormBody.tsx
@@ -6,9 +6,11 @@ import type {
   WorkspaceId,
 } from '@goodboy/types';
 import { Button, formatError, InlineConfirm, Input } from '@goodboy/ui';
-import { CheckCircle2, ExternalLink, Unplug } from 'lucide-react';
+import { CheckCircle2, Unplug } from 'lucide-react';
 import { useAppStore } from '../../../store';
 import { IntegrationCredentialPicker } from '../components/IntegrationCredentialPicker';
+import { SlackConnectGuide } from './SlackConnectGuide';
+import { buildSlackManifestUrl, SLACK_USER_SCOPES } from './slackAppManifest';
 
 type Props = {
   readonly workspaceId: WorkspaceId;
@@ -16,9 +18,7 @@ type Props = {
   readonly shouldAutoFocus?: boolean;
 };
 
-const APP_URL = 'https://api.slack.com/apps';
-
-const SCOPES = ['channels:read', 'channels:history', 'users:read', 'chat:write', 'reactions:write'];
+const MANIFEST_URL = buildSlackManifestUrl({ userScopes: SLACK_USER_SCOPES });
 
 export const SlackFormBody = ({ workspaceId, onConnected, shouldAutoFocus = false }: Props) => {
   const integrations = useAppStore(
@@ -115,19 +115,11 @@ export const SlackFormBody = ({ workspaceId, onConnected, shouldAutoFocus = fals
           />
           {credentialId === null ? (
             <>
+              <SlackConnectGuide manifestUrl={MANIFEST_URL} />
               <div className="flex flex-col gap-2">
                 <label htmlFor="slack-token" className="text-xs font-semibold text-foreground">
                   User token
                 </label>
-                <a
-                  href={APP_URL}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="inline-flex items-center gap-1 text-2xs text-muted-foreground hover:text-foreground"
-                >
-                  Create a Slack app and copy its user OAuth token{' '}
-                  <ExternalLink size={10} aria-hidden />
-                </a>
                 <Input
                   id="slack-token"
                   type="password"
@@ -140,22 +132,6 @@ export const SlackFormBody = ({ workspaceId, onConnected, shouldAutoFocus = fals
                   autoCorrect="off"
                   spellCheck={false}
                 />
-              </div>
-              <div className="flex flex-col gap-2">
-                <p className="text-2xs leading-relaxed text-muted-foreground">
-                  The user token starts with <span className="font-mono">xoxp-</span> and needs
-                  these scopes, granted under User Token Scopes and not Bot Token Scopes:
-                </p>
-                <ul className="flex flex-wrap gap-2">
-                  {SCOPES.map((scope) => (
-                    <li
-                      key={scope}
-                      className="rounded-full border border-border-soft px-2 py-0.5 font-mono text-2xs text-foreground"
-                    >
-                      {scope}
-                    </li>
-                  ))}
-                </ul>
               </div>
             </>
           ) : null}

--- a/apps/desktop/src/features/integrations/slack/slackAppManifest.test.ts
+++ b/apps/desktop/src/features/integrations/slack/slackAppManifest.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildSlackManifestUrl,
+  SLACK_MANIFEST_URL_LIMIT,
+  SLACK_USER_SCOPES,
+} from './slackAppManifest';
+
+type DecodedManifest = {
+  readonly _metadata: { readonly major_version: number; readonly minor_version: number };
+  readonly display_information: { readonly name: string };
+  readonly oauth_config: { readonly scopes: Record<string, ReadonlyArray<string>> };
+  readonly settings: { readonly token_rotation_enabled: boolean };
+};
+
+const decode = (url: string): DecodedManifest => {
+  const encoded = new URL(url).searchParams.get('manifest_json');
+  return JSON.parse(encoded ?? '{}') as DecodedManifest;
+};
+
+describe('buildSlackManifestUrl', () => {
+  it('drops the manifest into the app creation flow', () => {
+    const url = buildSlackManifestUrl({ userScopes: SLACK_USER_SCOPES }) ?? '';
+    expect(url.startsWith('https://api.slack.com/apps?new_app=1&manifest_json=')).toBe(true);
+    expect(url.length).toBeLessThan(SLACK_MANIFEST_URL_LIMIT);
+  });
+
+  it('asks for the five scopes as user scopes and for no bot scope at all', () => {
+    const url = buildSlackManifestUrl({ userScopes: SLACK_USER_SCOPES });
+    const manifest = decode(url ?? '');
+    expect(manifest.oauth_config.scopes.user).toEqual([
+      'channels:read',
+      'channels:history',
+      'users:read',
+      'chat:write',
+      'reactions:write',
+    ]);
+    expect(Object.keys(manifest.oauth_config.scopes)).toEqual(['user']);
+  });
+
+  it('targets the current manifest schema and keeps the pasted token valid', () => {
+    const manifest = decode(buildSlackManifestUrl({ userScopes: SLACK_USER_SCOPES }) ?? '');
+    expect(manifest._metadata).toEqual({ major_version: 2, minor_version: 1 });
+    expect(manifest.display_information.name).toBe('Goodboy');
+    expect(manifest.settings.token_rotation_enabled).toBe(false);
+  });
+
+  it('gives up on the url when the manifest outgrows what a url can carry', () => {
+    const oversized = Array.from({ length: 400 }, (_, index) => `scope:${index}`.padEnd(40, 'x'));
+    expect(buildSlackManifestUrl({ userScopes: oversized })).toBeNull();
+  });
+});

--- a/apps/desktop/src/features/integrations/slack/slackAppManifest.test.ts
+++ b/apps/desktop/src/features/integrations/slack/slackAppManifest.test.ts
@@ -21,7 +21,7 @@ describe('buildSlackManifestUrl', () => {
   it('drops the manifest into the app creation flow', () => {
     const url = buildSlackManifestUrl({ userScopes: SLACK_USER_SCOPES }) ?? '';
     expect(url.startsWith('https://api.slack.com/apps?new_app=1&manifest_json=')).toBe(true);
-    expect(url.length).toBeLessThan(SLACK_MANIFEST_URL_LIMIT);
+    expect(url.length).toBeLessThanOrEqual(SLACK_MANIFEST_URL_LIMIT);
   });
 
   it('asks for the five scopes as user scopes and for no bot scope at all', () => {

--- a/apps/desktop/src/features/integrations/slack/slackAppManifest.ts
+++ b/apps/desktop/src/features/integrations/slack/slackAppManifest.ts
@@ -1,0 +1,69 @@
+export const SLACK_USER_SCOPES: ReadonlyArray<string> = [
+  'channels:read',
+  'channels:history',
+  'users:read',
+  'chat:write',
+  'reactions:write',
+];
+
+export const SLACK_APPS_URL = 'https://api.slack.com/apps';
+
+export const SLACK_NEW_APP_URL = 'https://api.slack.com/apps/new';
+
+export const SLACK_MANIFEST_URL_LIMIT = 8000;
+
+const MANIFEST_MAJOR_VERSION = 2;
+
+const MANIFEST_MINOR_VERSION = 1;
+
+type SlackAppManifest = {
+  readonly _metadata: {
+    readonly major_version: number;
+    readonly minor_version: number;
+  };
+  readonly display_information: {
+    readonly name: string;
+    readonly description: string;
+  };
+  readonly oauth_config: {
+    readonly scopes: {
+      readonly user: ReadonlyArray<string>;
+    };
+  };
+  readonly settings: {
+    readonly org_deploy_enabled: boolean;
+    readonly socket_mode_enabled: boolean;
+    readonly token_rotation_enabled: boolean;
+  };
+};
+
+type ManifestParams = {
+  readonly userScopes: ReadonlyArray<string>;
+};
+
+const buildSlackAppManifest = ({ userScopes }: ManifestParams): SlackAppManifest => ({
+  _metadata: {
+    major_version: MANIFEST_MAJOR_VERSION,
+    minor_version: MANIFEST_MINOR_VERSION,
+  },
+  display_information: {
+    name: 'Goodboy',
+    description: 'Reads the Slack threads your tasks come out of.',
+  },
+  oauth_config: {
+    scopes: {
+      user: [...userScopes],
+    },
+  },
+  settings: {
+    org_deploy_enabled: false,
+    socket_mode_enabled: false,
+    token_rotation_enabled: false,
+  },
+});
+
+export const buildSlackManifestUrl = ({ userScopes }: ManifestParams): string | null => {
+  const manifest = buildSlackAppManifest({ userScopes });
+  const url = `${SLACK_APPS_URL}?new_app=1&manifest_json=${encodeURIComponent(JSON.stringify(manifest))}`;
+  return url.length > SLACK_MANIFEST_URL_LIMIT ? null : url;
+};


### PR DESCRIPTION
## What changed

Connecting Slack today means four steps on Slack's own site before the token even exists: create an app, find OAuth and Permissions, add exactly five scopes under **User Token Scopes** and not Bot Token Scopes, install, then copy the token that starts with `xoxp-`.

The connect form now carries a manifest into Slack's app creation flow. The user clicks one button, reviews the app Slack has already filled in, installs it, and pastes the token. The scopes are no longer something they have to get right by hand.

The token field stays the point of the screen: the guide sits above it in the same panel, steps are one line of title plus one line of body, and it disappears entirely once a saved credential is picked or Slack is connected.

## The manifest mechanism

Slack accepts a manifest in the query string of its app creation URL. Shape emitted:

```
https://api.slack.com/apps?new_app=1&manifest_json=<encodeURIComponent(JSON.stringify(manifest))>
```

Manifest:

```json
{
  "_metadata": { "major_version": 2, "minor_version": 1 },
  "display_information": {
    "name": "Goodboy",
    "description": "Reads the Slack threads your tasks come out of."
  },
  "oauth_config": {
    "scopes": {
      "user": ["channels:read", "channels:history", "users:read", "chat:write", "reactions:write"]
    }
  },
  "settings": {
    "org_deploy_enabled": false,
    "socket_mode_enabled": false,
    "token_rotation_enabled": false
  }
}
```

Only `oauth_config.scopes.user` is present. There is no `bot` key and no `features.bot_user`, so no bot user is created and no bot scope is requested. `token_rotation_enabled` stays false because a rotating token would invalidate the pasted `xoxp-` value.

Verified against:

- https://docs.slack.dev/app-manifests/configuring-apps-with-app-manifests/ for the URL shape, both the `manifest_json` and `manifest_yaml` parameter names, and the requirement that the manifest be URL encoded before sharing the link.
- https://docs.slack.dev/reference/app-manifest/ for the field set: `display_information` is the only required top-level section, `display_information.name` caps at 35 characters, `_metadata.major_version` 2 and `minor_version` 1 is the current schema, and `oauth_config.scopes.user` is the user-token side of the scope split.

Neither page states a URL length limit. The built URL is 604 characters, well inside any browser or server ceiling, but the builder still returns `null` above 8000 characters rather than hand Slack a URL that could be truncated into a broken app.

No OAuth, no sign-in button, no redirect flow, no Slack app owned by Goodboy. Each user keeps their own workspace app.

## The user who already has an app

A bot-token user coming from #1522 is not pushed into creating a second app. A segmented control switches the guide to the existing-app path: open your Slack apps, add the five scopes to the User column while Bot Token Scopes stay as they are, reinstall so the scopes take effect, then copy the User OAuth Token.

## The fallback

Nothing depends on the manifest URL working. The numbered steps, the five scopes and the copy affordance render on every path. When the manifest URL is unavailable the new-app path swaps its first step for `https://api.slack.com/apps/new` and adds the manual scope step, in the order the user meets them.

All external URLs go through `openUrl` from `shared/lib/editor`. The raw anchor that was in the form is gone.

## Test plan

- `npx tsc --noEmit` from `apps/desktop`: clean.
- `npx vitest run src/features/integrations` from `apps/desktop`: 105 files, 551 tests, green.
- `pnpm knip --include files,duplicates,unlisted` from the repo root: clean, hints only and pre-existing.

New coverage: the manifest URL carries all five scopes under `user` with no bot key and targets schema 2.1, the copy affordance yields the exact newline-separated scope list, the existing-app path is reachable through the segmented control and opens the apps list, the fallback renders and opens the app creation page when the manifest URL is unavailable, and the form opens Slack through `openUrl` rather than an anchor.

No live Slack workspace is reachable from this environment. The manifest URL is verified against Slack's documentation as cited above; creating a real app from it in a live workspace is the remaining check.
