### PR TITLE
fix(db): repair audit clear and add boot retention sweeps

### DIFF
--- a/apps/desktop/src-tauri/src/permissions.rs
+++ b/apps/desktop/src-tauri/src/permissions.rs
@@ -502,7 +502,7 @@ fn build_audit_list_sql(input: &PermissionAuditQueryInput) -> String {
     }
     if input.workspace_id.is_some() {
         conditions.push(format!(
-            "pal.session_id IN (SELECT id FROM agents WHERE session_id IN (SELECT id FROM sessions WHERE workspace_id = ?{idx}))"
+            "pal.session_id IN (SELECT id FROM sessions WHERE workspace_id = ?{idx})"
         ));
         idx += 1;
     }
@@ -537,23 +537,29 @@ pub fn permission_audit_clear(
     state: State<'_, Db>,
     input: PermissionAuditClearInput,
 ) -> Result<(), PermissionError> {
-    if input.session_id.is_none() && input.workspace_id.is_none() {
-        return Err(PermissionError::ClearScopeRequired);
-    }
-
     let conn = state.0.lock().map_err(|_| PermissionError::Poisoned)?;
+    clear_permission_audit(&conn, input)
+}
 
-    if let Some(sid) = input.session_id {
-        conn.execute(
-            "DELETE FROM permission_audit_log WHERE session_id = ?1",
-            rusqlite::params![sid],
-        )?;
-    } else if let Some(wid) = input.workspace_id {
-        conn.execute(
-            "DELETE FROM permission_audit_log
-             WHERE session_id IN (SELECT id FROM agents WHERE session_id IN (SELECT id FROM sessions WHERE workspace_id = ?1))",
-            rusqlite::params![wid],
-        )?;
+fn clear_permission_audit(
+    conn: &rusqlite::Connection,
+    input: PermissionAuditClearInput,
+) -> Result<(), PermissionError> {
+    match (input.session_id, input.workspace_id) {
+        (Some(session_id), _) => {
+            conn.execute(
+                "DELETE FROM permission_audit_log WHERE session_id = ?1",
+                rusqlite::params![session_id],
+            )?;
+        }
+        (None, Some(workspace_id)) => {
+            conn.execute(
+                "DELETE FROM permission_audit_log
+             WHERE session_id IN (SELECT id FROM sessions WHERE workspace_id = ?1)",
+                rusqlite::params![workspace_id],
+            )?;
+        }
+        (None, None) => return Err(PermissionError::ClearScopeRequired),
     }
 
     Ok(())
@@ -661,4 +667,46 @@ pub fn permission_audit_retry_delete(
         rusqlite::params![id],
     )?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::Connection;
+
+    use super::{clear_permission_audit, PermissionAuditClearInput};
+
+    #[test]
+    fn workspace_clear_matches_audit_session_ids_to_sessions() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE sessions (id TEXT PRIMARY KEY, workspace_id TEXT NOT NULL);
+             CREATE TABLE agents (id TEXT PRIMARY KEY, session_id TEXT NOT NULL);
+             CREATE TABLE permission_audit_log (id TEXT PRIMARY KEY, session_id TEXT NOT NULL);
+             INSERT INTO sessions VALUES ('session-a', 'workspace-a');
+             INSERT INTO sessions VALUES ('session-b', 'workspace-b');
+             INSERT INTO agents VALUES ('agent-a', 'session-a');
+             INSERT INTO agents VALUES ('agent-b', 'session-b');
+             INSERT INTO permission_audit_log VALUES ('audit-a', 'session-a');
+             INSERT INTO permission_audit_log VALUES ('audit-b', 'session-b');",
+        )
+        .unwrap();
+
+        clear_permission_audit(
+            &conn,
+            PermissionAuditClearInput {
+                session_id: None,
+                workspace_id: Some("workspace-a".to_string()),
+            },
+        )
+        .unwrap();
+
+        let remaining: Vec<String> = conn
+            .prepare("SELECT id FROM permission_audit_log ORDER BY id")
+            .unwrap()
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(remaining, vec!["audit-b"]);
+    }
 }

--- a/apps/desktop/src/shared/lib/db.ts
+++ b/apps/desktop/src/shared/lib/db.ts
@@ -1,5 +1,10 @@
 import { invoke } from '@tauri-apps/api/core';
-import { migrate as runMigrations, type Database, type MigrateResult } from '@goodboy/db';
+import {
+  migrate as runMigrations,
+  runDatabaseHygiene,
+  type Database,
+  type MigrateResult,
+} from '@goodboy/db';
 
 const UNMANAGED_STATE_MARKER = 'state not managed';
 
@@ -56,7 +61,9 @@ export const tauriDatabase: Database = {
 };
 
 export const runDbMigrations = async (): Promise<MigrateResult> => {
-  return runMigrations(tauriDatabase);
+  const result = await runMigrations(tauriDatabase);
+  await runDatabaseHygiene({ db: tauriDatabase, now: Date.now() });
+  return result;
 };
 
 export const wipeDb = async (): Promise<MigrateResult> => {

--- a/apps/desktop/src/store/slices/boot/auditRetryQueue.ts
+++ b/apps/desktop/src/store/slices/boot/auditRetryQueue.ts
@@ -53,6 +53,11 @@ export const drainAuditRetryQueue = async (set: SetFn): Promise<void> => {
       continue;
     }
 
+    if (payload.decidedBy === 'default') {
+      await invokeAuditRetryDelete(entry.id).catch(() => undefined);
+      continue;
+    }
+
     try {
       await invokePermissionAuditInsert(payload);
       await invokeAuditRetryDelete(entry.id);

--- a/apps/desktop/src/store/slices/sessions/deleteTask.teardown.test.ts
+++ b/apps/desktop/src/store/slices/sessions/deleteTask.teardown.test.ts
@@ -2,15 +2,25 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const order: Array<string> = [];
 
-const { removeWorktree, listWorktreesForSession, deleteSession } = vi.hoisted(() => ({
+const {
+  removeWorktree,
+  listWorktreesForSession,
+  deleteSession,
+  deleteGithubPrCacheForWorktreePath,
+} = vi.hoisted(() => ({
   removeWorktree: vi.fn(async () => undefined),
   listWorktreesForSession: vi.fn(async () => [
     { worktreePath: '/repo/.goodboy/worktrees/gb-ghost', branch: 'gb/ghost', parallelIndex: 0 },
   ]),
   deleteSession: vi.fn(async () => undefined),
+  deleteGithubPrCacheForWorktreePath: vi.fn(async () => 1),
 }));
 
-vi.mock('@goodboy/db', () => ({ listWorktreesForSession, deleteSession }));
+vi.mock('@goodboy/db', () => ({
+  listWorktreesForSession,
+  deleteSession,
+  deleteGithubPrCacheForWorktreePath,
+}));
 vi.mock('../../../shared/lib/db', () => ({ tauriDatabase: {} }));
 vi.mock('../../../features/worktree/worktree', () => ({
   removeWorktree,
@@ -50,6 +60,10 @@ describe('deleting a session', () => {
     await deleteTask(vi.fn(), (() => store) as never)(SESSION_ID);
 
     expect(order).toEqual(['terminals closed', 'worktree removed']);
+    expect(deleteGithubPrCacheForWorktreePath).toHaveBeenCalledWith({
+      db: {},
+      worktreePath: '/repo/.goodboy/worktrees/gb-ghost',
+    });
   });
 
   it('reports the paths it could not remove', async () => {

--- a/apps/desktop/src/store/slices/sessions/deleteTask.ts
+++ b/apps/desktop/src/store/slices/sessions/deleteTask.ts
@@ -1,6 +1,10 @@
 import type { ProviderRunId, SessionId } from '@goodboy/types';
 import { formatError } from '@goodboy/ui';
-import { deleteSession as deleteSessionFromDb, listWorktreesForSession } from '@goodboy/db';
+import {
+  deleteGithubPrCacheForWorktreePath,
+  deleteSession as deleteSessionFromDb,
+  listWorktreesForSession,
+} from '@goodboy/db';
 import { tauriDatabase } from '../../../shared/lib/db';
 import { cancelTurn } from '../../../features/chat/turn';
 import { removeSessionDirectory, removeWorktree } from '../../../features/worktree/worktree';
@@ -45,6 +49,15 @@ export const deleteTask = (set: SetFn, get: GetFn) => {
         } catch (error) {
           memberCleanupFailures.push(error);
           cleanupFailures.push(error);
+          continue;
+        }
+        try {
+          await deleteGithubPrCacheForWorktreePath({
+            db: tauriDatabase,
+            worktreePath: mount.worktreePath,
+          });
+        } catch (error) {
+          cleanupFailures.push(error);
         }
       }
       const containerPath = rows.find((row) => row.mountWorkspaceId == null)?.worktreePath;
@@ -59,10 +72,19 @@ export const deleteTask = (set: SetFn, get: GetFn) => {
     if (workspace?.kind !== 'composite' && workspace != null && !isBranchless) {
       const worktreePath = paths[0];
       if (worktreePath != null) {
+        let isWorktreeRemoved = false;
         try {
           await removeWorktree(workspace.rootPath, worktreePath);
+          isWorktreeRemoved = true;
         } catch (error) {
           cleanupFailures.push(error);
+        }
+        if (isWorktreeRemoved) {
+          try {
+            await deleteGithubPrCacheForWorktreePath({ db: tauriDatabase, worktreePath });
+          } catch (error) {
+            cleanupFailures.push(error);
+          }
         }
       }
     }

--- a/apps/desktop/src/store/slices/storage/index.test.ts
+++ b/apps/desktop/src/store/slices/storage/index.test.ts
@@ -9,6 +9,7 @@ const {
   getTurnEventStatsForSessions,
   getDatabaseSizeBytes,
   vacuumDatabase,
+  deleteGithubPrCacheForWorktreePath,
   removeWorktree,
   worktreeList,
 } = vi.hoisted(() => ({
@@ -18,6 +19,7 @@ const {
   getTurnEventStatsForSessions: vi.fn(),
   getDatabaseSizeBytes: vi.fn(),
   vacuumDatabase: vi.fn(),
+  deleteGithubPrCacheForWorktreePath: vi.fn(),
   removeWorktree: vi.fn(),
   worktreeList: vi.fn(),
 }));
@@ -29,6 +31,7 @@ vi.mock('@goodboy/db', () => ({
   getTurnEventStatsForSessions,
   getDatabaseSizeBytes,
   vacuumDatabase,
+  deleteGithubPrCacheForWorktreePath,
 }));
 
 vi.mock('../../../shared/lib/db', () => ({
@@ -86,6 +89,7 @@ beforeEach(() => {
   getTurnEventStatsForSessions.mockReset();
   getDatabaseSizeBytes.mockReset();
   vacuumDatabase.mockReset();
+  deleteGithubPrCacheForWorktreePath.mockReset();
   removeWorktree.mockReset();
   worktreeList.mockReset();
 
@@ -111,6 +115,7 @@ beforeEach(() => {
   getTurnEventStatsForSessions.mockResolvedValue({ rowCount: 12, payloadBytes: 4096 });
   getDatabaseSizeBytes.mockResolvedValue(233_000_000);
   deleteTurnEventsForSessions.mockResolvedValue(12);
+  deleteGithubPrCacheForWorktreePath.mockResolvedValue(1);
 });
 
 describe('collectArchivedWorktrees', () => {
@@ -139,6 +144,10 @@ describe('removeArchivedWorktrees', () => {
     const result = await removeArchivedWorktrees(vi.fn(), makeGet(loadStats))();
 
     expect(removeWorktree.mock.calls).toEqual([['/repo', archivedWorktree.worktreePath]]);
+    expect(deleteGithubPrCacheForWorktreePath).toHaveBeenCalledWith({
+      db: {},
+      worktreePath: archivedWorktree.worktreePath,
+    });
     expect(result).toEqual({ removed: 1, failed: 0 });
     expect(loadStats).toHaveBeenCalled();
   });

--- a/apps/desktop/src/store/slices/storage/removeArchivedWorktrees.ts
+++ b/apps/desktop/src/store/slices/storage/removeArchivedWorktrees.ts
@@ -1,4 +1,6 @@
+import { deleteGithubPrCacheForWorktreePath } from '@goodboy/db';
 import { removeWorktree } from '../../../features/worktree/worktree';
+import { tauriDatabase } from '../../../shared/lib/db';
 import { collectArchivedWorktrees } from './collectArchivedWorktrees';
 import type { GetFn, SetFn, WorktreeRemovalResult } from './types';
 
@@ -10,6 +12,10 @@ export const removeArchivedWorktrees = (_set: SetFn, get: GetFn) => {
     for (const target of targets) {
       try {
         await removeWorktree(target.repoPath, target.worktreePath);
+        await deleteGithubPrCacheForWorktreePath({
+          db: tauriDatabase,
+          worktreePath: target.worktreePath,
+        });
         removed += 1;
       } catch {
         failed += 1;

--- a/apps/desktop/src/store/slices/turn/auditToolCall.ts
+++ b/apps/desktop/src/store/slices/turn/auditToolCall.ts
@@ -9,11 +9,8 @@ import type {
   TurnEvent,
   WorkspaceId,
 } from '@goodboy/types';
-import {
-  invokePermissionAuditInsert,
-  invokeAuditRetryEnqueue,
-  type PermissionAuditInsertPayload,
-} from '../../../features/permissions/permissions';
+import type { PermissionAuditInsertPayload } from '../../../features/permissions/permissions';
+import { persistPermissionAudit } from './persistPermissionAudit';
 import type { GetFn, SetFn } from './types';
 
 type Params = {
@@ -73,13 +70,5 @@ export const auditToolCall = async (
     requestedAt: event.at,
     decidedAt: decision.at,
   };
-  try {
-    await invokePermissionAuditInsert(auditPayload);
-  } catch {
-    try {
-      await invokeAuditRetryEnqueue(auditRequestId, JSON.stringify(auditPayload));
-    } catch (enqueueErr) {
-      console.error('permission audit retry enqueue failed', enqueueErr);
-    }
-  }
+  await persistPermissionAudit({ payload: auditPayload });
 };

--- a/apps/desktop/src/store/slices/turn/persistPermissionAudit.test.ts
+++ b/apps/desktop/src/store/slices/turn/persistPermissionAudit.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IsoDateTime, ProviderRunId, SessionId } from '@goodboy/types';
+
+const { invokeAuditRetryEnqueue, invokePermissionAuditInsert } = vi.hoisted(() => ({
+  invokeAuditRetryEnqueue: vi.fn(async () => undefined),
+  invokePermissionAuditInsert: vi.fn(async () => undefined),
+}));
+
+vi.mock('../../../features/permissions/permissions', () => ({
+  invokeAuditRetryEnqueue,
+  invokePermissionAuditInsert,
+}));
+
+import { persistPermissionAudit } from './persistPermissionAudit';
+
+const makePayload = (decidedBy: 'default' | 'rule' | 'user') => ({
+  id: 'audit-1',
+  runId: 'run-1' as ProviderRunId,
+  sessionId: 'session-1' as SessionId,
+  toolUseId: 'tool-1',
+  toolName: 'Read',
+  inputJson: '{}',
+  decision: 'deny' as const,
+  decidedBy,
+  requestedAt: '2026-08-22T10:00:00.000Z' as IsoDateTime,
+  decidedAt: '2026-08-22T10:00:00.000Z' as IsoDateTime,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('persistPermissionAudit', () => {
+  it('does not persist or enqueue default decisions', async () => {
+    await persistPermissionAudit({ payload: makePayload('default') });
+
+    expect(invokePermissionAuditInsert).not.toHaveBeenCalled();
+    expect(invokeAuditRetryEnqueue).not.toHaveBeenCalled();
+  });
+
+  it('keeps explicit rule decisions', async () => {
+    const payload = makePayload('rule');
+
+    await persistPermissionAudit({ payload });
+
+    expect(invokePermissionAuditInsert).toHaveBeenCalledWith(payload);
+  });
+});

--- a/apps/desktop/src/store/slices/turn/persistPermissionAudit.ts
+++ b/apps/desktop/src/store/slices/turn/persistPermissionAudit.ts
@@ -1,0 +1,24 @@
+import {
+  invokeAuditRetryEnqueue,
+  invokePermissionAuditInsert,
+  type PermissionAuditInsertPayload,
+} from '../../../features/permissions/permissions';
+
+type Params = {
+  readonly payload: PermissionAuditInsertPayload;
+};
+
+export const persistPermissionAudit = async ({ payload }: Params): Promise<void> => {
+  if (payload.decidedBy === 'default') {
+    return;
+  }
+  try {
+    await invokePermissionAuditInsert(payload);
+  } catch {
+    try {
+      await invokeAuditRetryEnqueue(payload.id ?? crypto.randomUUID(), JSON.stringify(payload));
+    } catch (enqueueError) {
+      console.error('permission audit retry enqueue failed', enqueueError);
+    }
+  }
+};

--- a/apps/desktop/src/store/store.audit-retry.test.ts
+++ b/apps/desktop/src/store/store.audit-retry.test.ts
@@ -189,7 +189,7 @@ function makeRetryEntry(overrides: { id?: string; payloadJson?: string; attempts
         toolName: 'Edit',
         inputJson: '{}',
         decision: 'allow',
-        decidedBy: 'engine',
+        decidedBy: 'rule',
         requestedAt: NOW,
         decidedAt: NOW,
       }),
@@ -266,7 +266,7 @@ describe('audit retry queue, sendTurn enqueue on failure', () => {
     });
   }
 
-  it('enqueues to retry queue when audit insert fails', async () => {
+  it('enqueues an explicit user decision when audit insert fails', async () => {
     permissionAuditInsertSpy.mockRejectedValue(new Error('db locked'));
 
     async function* toolStream(): AsyncIterable<TurnEvent> {
@@ -282,6 +282,7 @@ describe('audit retry queue, sendTurn enqueue on failure', () => {
 
     const useAppStore = await importStore();
     setupSession(useAppStore);
+    useAppStore.setState({ volatilePermissionAllows: new Set(['tu-1']) });
     await useAppStore.getState().sendTurn({ sessionId: SESSION_ID, content: 'go' });
 
     expect(permissionAuditInsertSpy).toHaveBeenCalledTimes(1);
@@ -293,7 +294,7 @@ describe('audit retry queue, sendTurn enqueue on failure', () => {
     expect(typeof parsed.decision).toBe('string');
   });
 
-  it('does NOT enqueue when audit insert succeeds', async () => {
+  it('does not write or enqueue a default decision', async () => {
     permissionAuditInsertSpy.mockResolvedValue({});
 
     async function* toolStream(): AsyncIterable<TurnEvent> {
@@ -311,6 +312,7 @@ describe('audit retry queue, sendTurn enqueue on failure', () => {
     setupSession(useAppStore);
     await useAppStore.getState().sendTurn({ sessionId: SESSION_ID, content: 'go' });
 
+    expect(permissionAuditInsertSpy).not.toHaveBeenCalled();
     expect(auditRetryEnqueueSpy).not.toHaveBeenCalled();
   });
 });
@@ -432,6 +434,33 @@ describe('audit retry queue, drain worker (happy path)', () => {
     await runHydrate();
 
     expect(auditRetryDeleteSpy).toHaveBeenCalledWith('retry-bad-json');
+    expect(permissionAuditInsertSpy).not.toHaveBeenCalled();
+  });
+
+  it('drain deletes legacy default decisions without inserting them', async () => {
+    const entry = {
+      ...makeRetryEntry({
+        id: 'retry-default',
+        payloadJson: JSON.stringify({
+          id: 'req-default',
+          runId: 'run-1',
+          sessionId: SESSION_ID,
+          toolUseId: 'tu-default',
+          toolName: 'Read',
+          inputJson: '{}',
+          decision: 'deny',
+          decidedBy: 'default',
+          requestedAt: NOW,
+          decidedAt: NOW,
+        }),
+      }),
+      updatedAt: 0,
+    };
+    auditRetryDrainSpy.mockResolvedValue([entry]);
+
+    await runHydrate();
+
+    expect(auditRetryDeleteSpy).toHaveBeenCalledWith('retry-default');
     expect(permissionAuditInsertSpy).not.toHaveBeenCalled();
   });
 

--- a/apps/desktop/src/store/store.branchless-session.test.ts
+++ b/apps/desktop/src/store/store.branchless-session.test.ts
@@ -6,6 +6,7 @@ const {
   listWorktreesForSession,
   updateSessionWorktreeBranch,
   deleteSession,
+  deleteGithubPrCacheForWorktreePath,
   deleteFileVersionsForSession,
   fileVersionsPurgeSession,
   detectRepoSlug,
@@ -17,6 +18,7 @@ const {
   ]),
   updateSessionWorktreeBranch: vi.fn(async () => undefined),
   deleteSession: vi.fn(async () => undefined),
+  deleteGithubPrCacheForWorktreePath: vi.fn(async () => 1),
   deleteFileVersionsForSession: vi.fn(async () => undefined),
   fileVersionsPurgeSession: vi.fn(async () => undefined),
   detectRepoSlug: vi.fn(async () => 'acme/widgets'),
@@ -26,6 +28,7 @@ vi.mock('@goodboy/db', () => ({
   listWorktreesForSession,
   updateSessionWorktreeBranch,
   deleteSession,
+  deleteGithubPrCacheForWorktreePath,
   deleteFileVersionsForSession,
 }));
 

--- a/apps/desktop/src/store/store.composite-session.test.ts
+++ b/apps/desktop/src/store/store.composite-session.test.ts
@@ -7,6 +7,7 @@ const {
   listWorktreesForSession,
   updateSessionWorktreeBranch,
   deleteSession,
+  deleteGithubPrCacheForWorktreePath,
   detectRepoSlug,
   gitPush,
   tauriGhRunner,
@@ -37,6 +38,7 @@ const {
   ]),
   updateSessionWorktreeBranch: vi.fn(async () => undefined),
   deleteSession: vi.fn(async () => undefined),
+  deleteGithubPrCacheForWorktreePath: vi.fn(async () => 1),
   detectRepoSlug: vi.fn(async () => 'acme/web'),
   gitPush: vi.fn(async () => ({ stdout: '', stderr: '', exitCode: 0 })),
   tauriGhRunner: {},
@@ -46,6 +48,7 @@ vi.mock('@goodboy/db', () => ({
   listWorktreesForSession,
   updateSessionWorktreeBranch,
   deleteSession,
+  deleteGithubPrCacheForWorktreePath,
 }));
 
 vi.mock('@goodboy/core', () => ({

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -2,6 +2,7 @@ export type { Database } from './client';
 
 export { migrate, type MigrateResult } from './migrations/runner';
 export { migrations, type Migration } from './migrations';
+export { runDatabaseHygiene, type DatabaseHygieneResult } from './maintenance/runDatabaseHygiene';
 
 export { NotFoundError, UniqueViolationError } from './shared/errors';
 
@@ -204,6 +205,7 @@ export {
   getGithubPrCache,
   upsertGithubPrCache,
   deleteGithubPrCache,
+  deleteGithubPrCacheForWorktreePath,
 } from './queries/github-pr-cache';
 export {
   insertDiffComment,

--- a/packages/db/src/maintenance/runDatabaseHygiene.test.ts
+++ b/packages/db/src/maintenance/runDatabaseHygiene.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from 'vitest';
+import type { Database } from '../client';
+import { migrate } from '../migrations/runner';
+import { makeTestDatabase } from '../test-helpers/test-db';
+import { runDatabaseHygiene } from './runDatabaseHygiene';
+
+const NOW = Date.UTC(2026, 7, 22, 12, 0, 0);
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const seedSession = async ({ db }: { readonly db: Database }): Promise<void> => {
+  await db.execute(
+    `INSERT INTO workspaces (id, name, root_path, created_at, updated_at)
+     VALUES ('workspace-1', 'workspace', '/tmp/workspace', ?, ?)`,
+    [NOW, NOW],
+  );
+  await db.execute(
+    `INSERT INTO sessions (id, workspace_id, goal, state_kind, created_at, updated_at)
+     VALUES ('session-1', 'workspace-1', 'goal', 'idle', ?, ?)`,
+    [NOW, NOW],
+  );
+  await db.execute(
+    `INSERT INTO agents (id, session_id, ordinal, name, status)
+     VALUES ('agent-1', 'session-1', 0, 'agent', 'pending')`,
+  );
+};
+
+describe('runDatabaseHygiene', () => {
+  it('cancels only stale in-flight provider runs through the status updater', async () => {
+    const db = makeTestDatabase();
+    await migrate(db);
+    await seedSession({ db });
+    await db.execute(
+      `INSERT INTO provider_runs
+         (id, session_id, provider, model, status_kind, status_payload, created_at)
+       VALUES
+         ('old-stream', 'session-1', 'anthropic', 'model', 'streaming', '{"routingDecision":{"provider":"anthropic","model":"model","reason":"session-default"}}', ?),
+         ('recent-pending', 'session-1', 'anthropic', 'model', 'pending', '{}', ?),
+         ('old-success', 'session-1', 'anthropic', 'model', 'succeeded', '{}', ?)`,
+      [NOW - 2 * DAY_MS, NOW - 60 * 60 * 1000, NOW - 2 * DAY_MS],
+    );
+
+    const result = await runDatabaseHygiene({ db, now: NOW });
+    const rows = await db.select<{
+      id: string;
+      status_kind: string;
+      status_payload: string;
+    }>('SELECT id, status_kind, status_payload FROM provider_runs ORDER BY id');
+
+    expect(result.providerRunsCancelled).toBe(1);
+    expect(rows.map((row) => [row.id, row.status_kind])).toEqual([
+      ['old-stream', 'cancelled'],
+      ['old-success', 'succeeded'],
+      ['recent-pending', 'pending'],
+    ]);
+    expect(JSON.parse(rows[0]?.status_payload ?? '{}')).toMatchObject({
+      finishedAt: new Date(NOW).toISOString(),
+      routingDecision: { provider: 'anthropic' },
+    });
+  });
+
+  it('removes expired audit events, old turn events, and orphaned PR cache rows', async () => {
+    const db = makeTestDatabase();
+    await migrate(db);
+    await seedSession({ db });
+    await db.execute(
+      `INSERT INTO session_worktrees
+         (id, session_id, worktree_path, branch, parallel_index, created_at)
+       VALUES ('worktree-1', 'session-1', '/tmp/worktree', 'ak/live', 0, ?)`,
+      [NOW],
+    );
+    await db.execute(
+      `INSERT INTO permission_audit_log
+         (id, run_id, session_id, tool_use_id, tool_name, input_json, decision, decided_by, requested_at, decided_at)
+       VALUES
+         ('old-audit', 'run', 'session-1', 'tool-old', 'Read', '{}', 'allow', 'user', ?, ?),
+         ('new-audit', 'run', 'session-1', 'tool-new', 'Read', '{}', 'allow', 'user', ?, ?)`,
+      [
+        new Date(NOW - 31 * DAY_MS).toISOString(),
+        new Date(NOW - 31 * DAY_MS).toISOString(),
+        new Date(NOW).toISOString(),
+        new Date(NOW).toISOString(),
+      ],
+    );
+    await db.execute(
+      `INSERT INTO turn_events (id, session_id, agent_id, payload, created_at)
+       VALUES
+         ('old-event', 'session-1', 'agent-1', '{}', ?),
+         ('new-event', 'session-1', 'agent-1', '{}', ?)`,
+      [NOW - 91 * DAY_MS, NOW],
+    );
+    await db.execute(
+      `INSERT INTO github_pr_cache (branch, repo_slug, pr_json, fetched_at)
+       VALUES
+         ('ak/live', 'acme/repo', NULL, ?),
+         ('ak/orphan', 'acme/repo', NULL, ?)`,
+      [new Date(NOW).toISOString(), new Date(NOW).toISOString()],
+    );
+
+    const result = await runDatabaseHygiene({ db, now: NOW });
+    const auditRows = await db.select<{ id: string }>('SELECT id FROM permission_audit_log');
+    const eventRows = await db.select<{ id: string }>('SELECT id FROM turn_events');
+    const cacheRows = await db.select<{ branch: string }>('SELECT branch FROM github_pr_cache');
+
+    expect(result).toMatchObject({
+      permissionAuditRowsDeleted: 1,
+      turnEventRowsDeleted: 1,
+      githubPrCacheRowsDeleted: 1,
+    });
+    expect(auditRows).toEqual([{ id: 'new-audit' }]);
+    expect(eventRows).toEqual([{ id: 'new-event' }]);
+    expect(cacheRows).toEqual([{ branch: 'ak/live' }]);
+  });
+
+  it('caps audit and turn event tables to their newest rows', async () => {
+    const db = makeTestDatabase();
+    await migrate(db);
+    await seedSession({ db });
+    await db.execute(
+      `WITH RECURSIVE sequence(value) AS (
+         SELECT 1
+         UNION ALL
+         SELECT value + 1 FROM sequence WHERE value < 5001
+       )
+       INSERT INTO permission_audit_log
+         (id, run_id, session_id, tool_use_id, tool_name, input_json, decision, decided_by, requested_at, decided_at)
+       SELECT
+         'audit-' || value,
+         'run',
+         'session-1',
+         'tool-' || value,
+         'Read',
+         '{}',
+         'allow',
+         'user',
+         ?,
+         ?
+       FROM sequence`,
+      [new Date(NOW).toISOString(), new Date(NOW).toISOString()],
+    );
+    await db.execute(
+      `WITH RECURSIVE sequence(value) AS (
+         SELECT 1
+         UNION ALL
+         SELECT value + 1 FROM sequence WHERE value < 200001
+       )
+       INSERT INTO turn_events (id, session_id, agent_id, payload, created_at)
+       SELECT 'event-' || value, 'session-1', 'agent-1', '{}', ?
+       FROM sequence`,
+      [NOW],
+    );
+
+    const result = await runDatabaseHygiene({ db, now: NOW });
+    const auditCount = await db.select<{ count: number }>(
+      'SELECT COUNT(*) AS count FROM permission_audit_log',
+    );
+    const eventCount = await db.select<{ count: number }>(
+      'SELECT COUNT(*) AS count FROM turn_events',
+    );
+
+    expect(result.permissionAuditRowsDeleted).toBe(1);
+    expect(result.turnEventRowsDeleted).toBe(1);
+    expect(auditCount[0]?.count).toBe(5000);
+    expect(eventCount[0]?.count).toBe(200_000);
+  });
+});

--- a/packages/db/src/maintenance/runDatabaseHygiene.test.ts
+++ b/packages/db/src/maintenance/runDatabaseHygiene.test.ts
@@ -58,14 +58,62 @@ describe('runDatabaseHygiene', () => {
     });
   });
 
+  it('does not cancel a stale run that finishes after zombie selection', async () => {
+    const sourceDb = makeTestDatabase();
+    await migrate(sourceDb);
+    await seedSession({ db: sourceDb });
+    await sourceDb.execute(
+      `INSERT INTO provider_runs
+         (id, session_id, provider, model, status_kind, status_payload, created_at)
+       VALUES
+         ('racing-run', 'session-1', 'anthropic', 'model', 'streaming', '{}', ?)`,
+      [NOW - 2 * DAY_MS],
+    );
+    let hasFinishedRun = false;
+    const db: Database = {
+      exec: (sql) => sourceDb.exec(sql),
+      execute: (sql, params) => sourceDb.execute(sql, params),
+      select: async <Row>(sql: string, params?: ReadonlyArray<unknown>) => {
+        const rows = await sourceDb.select<Row>(sql, params);
+        if (sql.includes('SELECT id FROM provider_runs') && hasFinishedRun === false) {
+          hasFinishedRun = true;
+          await sourceDb.execute(
+            `UPDATE provider_runs
+             SET status_kind = 'succeeded', status_payload = '{"finishedAt":"provider-finished"}'
+             WHERE id = 'racing-run'`,
+          );
+        }
+        return rows;
+      },
+    };
+
+    const result = await runDatabaseHygiene({ db, now: NOW });
+    const rows = await sourceDb.select<{ status_kind: string; status_payload: string }>(
+      "SELECT status_kind, status_payload FROM provider_runs WHERE id = 'racing-run'",
+    );
+
+    expect(result.providerRunsCancelled).toBe(0);
+    expect(rows).toEqual([
+      { status_kind: 'succeeded', status_payload: '{"finishedAt":"provider-finished"}' },
+    ]);
+  });
+
   it('removes expired audit events, old turn events, and orphaned PR cache rows', async () => {
     const db = makeTestDatabase();
     await migrate(db);
     await seedSession({ db });
     await db.execute(
       `INSERT INTO session_worktrees
-         (id, session_id, worktree_path, branch, parallel_index, created_at)
-       VALUES ('worktree-1', 'session-1', '/tmp/worktree', 'ak/live', 0, ?)`,
+         (id, session_id, worktree_path, branch, parallel_index, repo_slug, created_at)
+       VALUES
+         ('worktree-1', 'session-1', '/tmp/worktree', 'ak/live', 0, 'acme/repo', ?),
+         ('worktree-2', 'session-1', '/tmp/unknown-repo', 'ak/unknown-repo', 1, NULL, ?)`,
+      [NOW, NOW],
+    );
+    await db.execute(
+      `INSERT INTO session_worktrees
+         (id, session_id, worktree_path, branch, parallel_index, repo_slug, created_at)
+       VALUES ('worktree-3', 'session-1', '/tmp/other-repo', 'ak/other-live', 2, 'other/repo', ?)`,
       [NOW],
     );
     await db.execute(
@@ -92,23 +140,34 @@ describe('runDatabaseHygiene', () => {
       `INSERT INTO github_pr_cache (branch, repo_slug, pr_json, fetched_at)
        VALUES
          ('ak/live', 'acme/repo', NULL, ?),
+         ('ak/live', 'other/repo', NULL, ?),
+         ('ak/unknown-repo', 'acme/repo', NULL, ?),
+         ('ak/other-live', 'acme/repo', NULL, ?),
          ('ak/orphan', 'acme/repo', NULL, ?)`,
-      [new Date(NOW).toISOString(), new Date(NOW).toISOString()],
+      [
+        new Date(NOW).toISOString(),
+        new Date(NOW).toISOString(),
+        new Date(NOW).toISOString(),
+        new Date(NOW).toISOString(),
+        new Date(NOW).toISOString(),
+      ],
     );
 
     const result = await runDatabaseHygiene({ db, now: NOW });
     const auditRows = await db.select<{ id: string }>('SELECT id FROM permission_audit_log');
     const eventRows = await db.select<{ id: string }>('SELECT id FROM turn_events');
-    const cacheRows = await db.select<{ branch: string }>('SELECT branch FROM github_pr_cache');
+    const cacheRows = await db.select<{ branch: string; repo_slug: string }>(
+      'SELECT branch, repo_slug FROM github_pr_cache',
+    );
 
     expect(result).toMatchObject({
       permissionAuditRowsDeleted: 1,
       turnEventRowsDeleted: 1,
-      githubPrCacheRowsDeleted: 1,
+      githubPrCacheRowsDeleted: 4,
     });
     expect(auditRows).toEqual([{ id: 'new-audit' }]);
     expect(eventRows).toEqual([{ id: 'new-event' }]);
-    expect(cacheRows).toEqual([{ branch: 'ak/live' }]);
+    expect(cacheRows).toEqual([{ branch: 'ak/live', repo_slug: 'acme/repo' }]);
   });
 
   it('caps audit and turn event tables to their newest rows', async () => {

--- a/packages/db/src/maintenance/runDatabaseHygiene.ts
+++ b/packages/db/src/maintenance/runDatabaseHygiene.ts
@@ -1,6 +1,6 @@
 import type { IsoDateTime, ProviderRunId } from '@goodboy/types';
 import type { Database } from '../client';
-import { updateProviderRunStatus } from '../queries/provider-run';
+import { updateProviderRunStatusIfInFlight } from '../queries/provider-run';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const PERMISSION_AUDIT_MAX_ROWS = 5000;
@@ -57,6 +57,7 @@ export const runDatabaseHygiene = async ({ db, now }: Params): Promise<DatabaseH
        FROM session_worktrees sw
        JOIN sessions s ON s.id = sw.session_id
        WHERE sw.branch = github_pr_cache.branch
+         AND sw.repo_slug IS github_pr_cache.repo_slug
          AND s.deleted_at IS NULL
          AND s.archived_at IS NULL
      )`,
@@ -69,14 +70,19 @@ export const runDatabaseHygiene = async ({ db, now }: Params): Promise<DatabaseH
     [providerRunCutoff],
   );
   const finishedAt = new Date(now).toISOString() as IsoDateTime;
+  let providerRunsCancelled = 0;
   for (const run of zombieProviderRuns) {
-    await updateProviderRunStatus(db, run.id, { kind: 'cancelled', finishedAt });
+    providerRunsCancelled += await updateProviderRunStatusIfInFlight({
+      db,
+      id: run.id,
+      status: { kind: 'cancelled', finishedAt },
+    });
   }
 
   return {
     permissionAuditRowsDeleted: oldPermissionRows.rowsAffected + excessPermissionRows.rowsAffected,
     turnEventRowsDeleted: oldTurnEvents.rowsAffected + excessTurnEvents.rowsAffected,
     githubPrCacheRowsDeleted: githubPrCacheRows.rowsAffected,
-    providerRunsCancelled: zombieProviderRuns.length,
+    providerRunsCancelled,
   };
 };

--- a/packages/db/src/maintenance/runDatabaseHygiene.ts
+++ b/packages/db/src/maintenance/runDatabaseHygiene.ts
@@ -1,0 +1,82 @@
+import type { IsoDateTime, ProviderRunId } from '@goodboy/types';
+import type { Database } from '../client';
+import { updateProviderRunStatus } from '../queries/provider-run';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const PERMISSION_AUDIT_MAX_ROWS = 5000;
+const TURN_EVENT_MAX_ROWS = 200_000;
+
+type Params = {
+  readonly db: Database;
+  readonly now: number;
+};
+
+export type DatabaseHygieneResult = {
+  readonly permissionAuditRowsDeleted: number;
+  readonly turnEventRowsDeleted: number;
+  readonly githubPrCacheRowsDeleted: number;
+  readonly providerRunsCancelled: number;
+};
+
+type ProviderRunRow = {
+  readonly id: ProviderRunId;
+};
+
+export const runDatabaseHygiene = async ({ db, now }: Params): Promise<DatabaseHygieneResult> => {
+  const permissionCutoff = new Date(now - 30 * DAY_MS).toISOString();
+  const oldPermissionRows = await db.execute(
+    'DELETE FROM permission_audit_log WHERE julianday(requested_at) < julianday(?)',
+    [permissionCutoff],
+  );
+  const excessPermissionRows = await db.execute(
+    `DELETE FROM permission_audit_log
+     WHERE rowid IN (
+       SELECT rowid FROM permission_audit_log
+       ORDER BY julianday(requested_at) DESC, rowid DESC
+       LIMIT -1 OFFSET ${PERMISSION_AUDIT_MAX_ROWS}
+     )`,
+  );
+
+  const turnEventCutoff = now - 90 * DAY_MS;
+  const oldTurnEvents = await db.execute('DELETE FROM turn_events WHERE created_at < ?', [
+    turnEventCutoff,
+  ]);
+  const excessTurnEvents = await db.execute(
+    `DELETE FROM turn_events
+     WHERE rowid IN (
+       SELECT rowid FROM turn_events
+       ORDER BY created_at DESC, rowid DESC
+       LIMIT -1 OFFSET ${TURN_EVENT_MAX_ROWS}
+     )`,
+  );
+
+  const githubPrCacheRows = await db.execute(
+    `DELETE FROM github_pr_cache
+     WHERE NOT EXISTS (
+       SELECT 1
+       FROM session_worktrees sw
+       JOIN sessions s ON s.id = sw.session_id
+       WHERE sw.branch = github_pr_cache.branch
+         AND s.deleted_at IS NULL
+         AND s.archived_at IS NULL
+     )`,
+  );
+
+  const providerRunCutoff = now - DAY_MS;
+  const zombieProviderRuns = await db.select<ProviderRunRow>(
+    `SELECT id FROM provider_runs
+     WHERE status_kind IN ('pending', 'streaming') AND created_at < ?`,
+    [providerRunCutoff],
+  );
+  const finishedAt = new Date(now).toISOString() as IsoDateTime;
+  for (const run of zombieProviderRuns) {
+    await updateProviderRunStatus(db, run.id, { kind: 'cancelled', finishedAt });
+  }
+
+  return {
+    permissionAuditRowsDeleted: oldPermissionRows.rowsAffected + excessPermissionRows.rowsAffected,
+    turnEventRowsDeleted: oldTurnEvents.rowsAffected + excessTurnEvents.rowsAffected,
+    githubPrCacheRowsDeleted: githubPrCacheRows.rowsAffected,
+    providerRunsCancelled: zombieProviderRuns.length,
+  };
+};

--- a/packages/db/src/queries/github-pr-cache.test.ts
+++ b/packages/db/src/queries/github-pr-cache.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { SessionId, WorkspaceId } from '@goodboy/types';
+import type { Database } from '../client';
+import { migrate } from '../migrations/runner';
+import { makeTestDatabase } from '../test-helpers/test-db';
+import { insertSessionWorktree } from './session-worktree';
+import {
+  deleteGithubPrCacheForWorktreePath,
+  getGithubPrCache,
+  upsertGithubPrCache,
+} from './github-pr-cache';
+
+const NOW = Date.UTC(2026, 7, 22, 12, 0, 0);
+const workspaceId = 'workspace-1' as WorkspaceId;
+const sessionId = 'session-1' as SessionId;
+
+const seed = async (): Promise<Database> => {
+  const db = makeTestDatabase();
+  await migrate(db);
+  await db.execute(
+    'INSERT INTO workspaces (id, name, root_path, created_at, updated_at) VALUES (?, ?, ?, ?, ?)',
+    [workspaceId, 'workspace', '/tmp/workspace', NOW, NOW],
+  );
+  await db.execute(
+    'INSERT INTO sessions (id, workspace_id, goal, state_kind, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)',
+    [sessionId, workspaceId, 'goal', 'idle', NOW, NOW],
+  );
+  return db;
+};
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('GitHub PR cache', () => {
+  it('treats entries older than ten minutes and invalid timestamps as stale', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const db = await seed();
+    await upsertGithubPrCache(db, {
+      branch: 'ak/stale',
+      repoSlug: 'acme/repo',
+      pr: null,
+      fetchedAt: new Date(NOW - 10 * 60 * 1000 - 1).toISOString(),
+    });
+    await upsertGithubPrCache(db, {
+      branch: 'ak/invalid',
+      repoSlug: 'acme/repo',
+      pr: null,
+      fetchedAt: 'not-a-date',
+    });
+    await upsertGithubPrCache(db, {
+      branch: 'ak/fresh',
+      repoSlug: 'acme/repo',
+      pr: null,
+      fetchedAt: new Date(NOW - 9 * 60 * 1000).toISOString(),
+    });
+
+    await expect(getGithubPrCache(db, 'acme/repo', 'ak/stale')).resolves.toBeNull();
+    await expect(getGithubPrCache(db, 'acme/repo', 'ak/invalid')).resolves.toBeNull();
+    await expect(getGithubPrCache(db, 'acme/repo', 'ak/fresh')).resolves.toMatchObject({
+      branch: 'ak/fresh',
+    });
+  });
+
+  it('deletes only cache rows owned by the removed worktree', async () => {
+    const db = await seed();
+    await insertSessionWorktree(db, {
+      id: 'worktree-1',
+      sessionId,
+      worktreePath: '/tmp/worktree',
+      branch: 'ak/branch',
+      parallelIndex: 0,
+      repoSlug: 'acme/repo',
+      createdAt: NOW,
+    });
+    await db.execute(
+      `INSERT INTO github_pr_cache (branch, repo_slug, pr_json, fetched_at)
+       VALUES
+         ('ak/branch', 'acme/repo', NULL, ?),
+         ('ak/branch', 'other/repo', NULL, ?),
+         ('ak/other', 'acme/repo', NULL, ?)`,
+      [new Date(NOW).toISOString(), new Date(NOW).toISOString(), new Date(NOW).toISOString()],
+    );
+
+    await expect(
+      deleteGithubPrCacheForWorktreePath({ db, worktreePath: '/tmp/worktree' }),
+    ).resolves.toBe(1);
+    const rows = await db.select<{ branch: string; repo_slug: string }>(
+      'SELECT branch, repo_slug FROM github_pr_cache ORDER BY repo_slug, branch',
+    );
+    expect(rows).toEqual([
+      { branch: 'ak/other', repo_slug: 'acme/repo' },
+      { branch: 'ak/branch', repo_slug: 'other/repo' },
+    ]);
+  });
+});

--- a/packages/db/src/queries/github-pr-cache.test.ts
+++ b/packages/db/src/queries/github-pr-cache.test.ts
@@ -94,4 +94,31 @@ describe('GitHub PR cache', () => {
       { branch: 'ak/branch', repo_slug: 'other/repo' },
     ]);
   });
+
+  it('does not use a worktree with an unknown repo as a branch wildcard', async () => {
+    const db = await seed();
+    await insertSessionWorktree(db, {
+      id: 'worktree-1',
+      sessionId,
+      worktreePath: '/tmp/worktree',
+      branch: 'ak/branch',
+      parallelIndex: 0,
+      createdAt: NOW,
+    });
+    await db.execute(
+      `INSERT INTO github_pr_cache (branch, repo_slug, pr_json, fetched_at)
+       VALUES
+         ('ak/branch', 'acme/repo', NULL, ?),
+         ('ak/branch', 'other/repo', NULL, ?)`,
+      [new Date(NOW).toISOString(), new Date(NOW).toISOString()],
+    );
+
+    await expect(
+      deleteGithubPrCacheForWorktreePath({ db, worktreePath: '/tmp/worktree' }),
+    ).resolves.toBe(0);
+    const rows = await db.select<{ repo_slug: string }>(
+      'SELECT repo_slug FROM github_pr_cache ORDER BY repo_slug',
+    );
+    expect(rows).toEqual([{ repo_slug: 'acme/repo' }, { repo_slug: 'other/repo' }]);
+  });
 });

--- a/packages/db/src/queries/github-pr-cache.ts
+++ b/packages/db/src/queries/github-pr-cache.ts
@@ -83,7 +83,7 @@ export const deleteGithubPrCacheForWorktreePath = async ({
        FROM session_worktrees sw
        WHERE sw.worktree_path = ?
          AND sw.branch = github_pr_cache.branch
-         AND (sw.repo_slug IS NULL OR sw.repo_slug = github_pr_cache.repo_slug)
+         AND sw.repo_slug IS github_pr_cache.repo_slug
      )`,
     [worktreePath],
   );

--- a/packages/db/src/queries/github-pr-cache.ts
+++ b/packages/db/src/queries/github-pr-cache.ts
@@ -8,6 +8,8 @@ type Row = {
   fetched_at: string;
 };
 
+const CACHE_TTL_MS = 10 * 60 * 1000;
+
 function toDomain(row: Row): GithubPrCacheEntry {
   return {
     branch: row.branch,
@@ -30,7 +32,14 @@ export const getGithubPrCache = async (
     [repoSlug, branch],
   );
   const first = rows[0];
-  return first ? toDomain(first) : null;
+  if (first === undefined) {
+    return null;
+  }
+  const fetchedAt = Date.parse(first.fetched_at);
+  if (Number.isNaN(fetchedAt) || Date.now() - fetchedAt > CACHE_TTL_MS) {
+    return null;
+  }
+  return toDomain(first);
 };
 
 export const upsertGithubPrCache = async (
@@ -56,4 +65,27 @@ export const deleteGithubPrCache = async (
     repoSlug,
     branch,
   ]);
+};
+
+type DeleteForWorktreePathParams = {
+  readonly db: Database;
+  readonly worktreePath: string;
+};
+
+export const deleteGithubPrCacheForWorktreePath = async ({
+  db,
+  worktreePath,
+}: DeleteForWorktreePathParams): Promise<number> => {
+  const result = await db.execute(
+    `DELETE FROM github_pr_cache
+     WHERE EXISTS (
+       SELECT 1
+       FROM session_worktrees sw
+       WHERE sw.worktree_path = ?
+         AND sw.branch = github_pr_cache.branch
+         AND (sw.repo_slug IS NULL OR sw.repo_slug = github_pr_cache.repo_slug)
+     )`,
+    [worktreePath],
+  );
+  return result.rowsAffected;
 };

--- a/packages/db/src/queries/provider-run.ts
+++ b/packages/db/src/queries/provider-run.ts
@@ -88,6 +88,32 @@ export const updateProviderRunStatus = async (
   ]);
 };
 
+type UpdateProviderRunStatusIfInFlightParams = {
+  readonly db: Database;
+  readonly id: ProviderRunId;
+  readonly status: ProviderRunStatus;
+};
+
+export const updateProviderRunStatusIfInFlight = async ({
+  db,
+  id,
+  status,
+}: UpdateProviderRunStatusIfInFlightParams): Promise<number> => {
+  const rows = await db.select<Pick<ProviderRunRow, 'status_payload'>>(
+    'SELECT status_payload FROM provider_runs WHERE id = ?',
+    [id],
+  );
+  const existingRouting = rows[0] ? extractRoutingDecision(rows[0].status_payload) : undefined;
+  const { kind, payload } = splitStatus(status, existingRouting);
+  const result = await db.execute(
+    `UPDATE provider_runs
+     SET status_kind = ?, status_payload = ?
+     WHERE id = ? AND status_kind IN ('pending', 'streaming')`,
+    [kind, payload, id],
+  );
+  return result.rowsAffected;
+};
+
 export const getProviderRunById = async (
   db: Database,
   id: ProviderRunId,

--- a/packages/db/src/queries/turn-event.test.ts
+++ b/packages/db/src/queries/turn-event.test.ts
@@ -110,4 +110,46 @@ describe('turn event queries', () => {
     }
     expect(decision.operatorNote).toBe('the gate is in place but its tests are missing');
   });
+
+  it('does not persist unknown provider payloads', async () => {
+    await insertTurnEvent(db, {
+      id: 'event-unknown',
+      sessionId,
+      agentId,
+      event: {
+        kind: 'unknown_payload',
+        runId,
+        adapter: 'provider',
+        payloadType: 'rate_limit',
+        raw: { message: 'noise' },
+        at,
+      },
+    });
+
+    await expect(listTurnEventsForAgent(db, agentId)).resolves.toEqual([]);
+  });
+
+  it('stores oversized payloads as valid bounded events with a marker', async () => {
+    await insertTurnEvent(db, {
+      id: 'event-large',
+      sessionId,
+      agentId,
+      event: {
+        kind: 'tool_call_end',
+        runId,
+        toolUseId: 'tool-large',
+        output: { body: 'x'.repeat(100_000) },
+        isError: false,
+        at,
+      },
+    });
+
+    const rows = await db.select<{ payload: string }>(
+      'SELECT payload FROM turn_events WHERE id = ?',
+      ['event-large'],
+    );
+    const events = await listTurnEventsForAgent(db, agentId);
+    expect(new TextEncoder().encode(rows[0]?.payload).byteLength).toBeLessThanOrEqual(64 * 1024);
+    expect(events[0]).toMatchObject({ kind: 'tool_call_end', output: '…[truncated]' });
+  });
 });

--- a/packages/db/src/queries/turn-event.ts
+++ b/packages/db/src/queries/turn-event.ts
@@ -18,6 +18,129 @@ type CountRow = {
   count: number;
 };
 
+const MAX_PAYLOAD_BYTES = 64 * 1024;
+const MAX_TRUNCATED_STRING_LENGTH = 4096;
+const TRUNCATION_MARKER = '…[truncated]';
+
+type SerializeTurnEventParams = {
+  readonly event: TurnEvent;
+};
+
+const payloadBytes = (payload: string): number => new TextEncoder().encode(payload).byteLength;
+
+const markTruncated = (value: string): string =>
+  `${value.slice(0, MAX_TRUNCATED_STRING_LENGTH)}${TRUNCATION_MARKER}`;
+
+const toTruncatedEvent = ({ event }: SerializeTurnEventParams): TurnEvent => {
+  switch (event.kind) {
+    case 'user_text':
+      return {
+        kind: event.kind,
+        runId: event.runId,
+        text: markTruncated(event.text),
+        ...(event.attachments !== undefined ? { attachments: [] } : {}),
+        ...(event.provider !== undefined ? { provider: event.provider } : {}),
+        ...(event.model !== undefined ? { model: markTruncated(event.model) } : {}),
+        at: event.at,
+      };
+    case 'assistant_text':
+      return { ...event, delta: markTruncated(event.delta) };
+    case 'tool_call_start':
+      return {
+        kind: event.kind,
+        runId: event.runId,
+        toolUseId: markTruncated(event.toolUseId),
+        toolName: markTruncated(event.toolName),
+        input: TRUNCATION_MARKER,
+        at: event.at,
+      };
+    case 'tool_call_end':
+      return {
+        kind: event.kind,
+        runId: event.runId,
+        toolUseId: markTruncated(event.toolUseId),
+        output: TRUNCATION_MARKER,
+        isError: event.isError,
+        at: event.at,
+      };
+    case 'file_edit':
+      return { ...event, path: markTruncated(event.path) };
+    case 'usage':
+      return {
+        kind: event.kind,
+        runId: event.runId,
+        usage: event.usage,
+        at: event.at,
+      };
+    case 'error':
+      return { ...event, message: markTruncated(event.message) };
+    case 'done':
+      return event;
+    case 'provider_session_init':
+      return { ...event, providerSessionId: markTruncated(event.providerSessionId) };
+    case 'skill_invocation':
+      return {
+        ...event,
+        skillName: markTruncated(event.skillName),
+        args: event.args.slice(0, 8).map(markTruncated),
+      };
+    case 'step_transition':
+      return {
+        ...event,
+        fromStep: { ...event.fromStep, name: markTruncated(event.fromStep.name) },
+        toStep: { ...event.toStep, name: markTruncated(event.toStep.name) },
+        carryForwardContext: markTruncated(event.carryForwardContext),
+      };
+    case 'orchestrator_decision':
+      return {
+        ...event,
+        reason: markTruncated(event.reason),
+        ...(event.stepName !== undefined ? { stepName: markTruncated(event.stepName) } : {}),
+        ...(event.operatorNote !== undefined
+          ? { operatorNote: markTruncated(event.operatorNote) }
+          : {}),
+      };
+    case 'permission_request':
+      return {
+        kind: event.kind,
+        runId: event.runId,
+        toolUseId: markTruncated(event.toolUseId),
+        toolName: markTruncated(event.toolName),
+        input: TRUNCATION_MARKER,
+        at: event.at,
+      };
+    case 'permission_decision':
+      return event;
+    case 'unknown_payload':
+      return { ...event, raw: TRUNCATION_MARKER };
+    default: {
+      const exhaustive: never = event;
+      return exhaustive;
+    }
+  }
+};
+
+const serializeTurnEvent = ({ event }: SerializeTurnEventParams): string | null => {
+  if (event.kind === 'unknown_payload') {
+    return null;
+  }
+  const payload = JSON.stringify(event);
+  if (payloadBytes(payload) <= MAX_PAYLOAD_BYTES) {
+    return payload;
+  }
+  const truncatedPayload = JSON.stringify(toTruncatedEvent({ event }));
+  if (payloadBytes(truncatedPayload) <= MAX_PAYLOAD_BYTES) {
+    return truncatedPayload;
+  }
+  return JSON.stringify({
+    kind: 'error',
+    runId: event.runId,
+    message: `${event.kind}${TRUNCATION_MARKER}`,
+    retryable: false,
+    at: event.at,
+  } satisfies TurnEvent);
+};
+
 function rowToEvent(row: TurnEventRow): TurnEvent | null {
   try {
     return JSON.parse(row.payload) as TurnEvent;
@@ -45,10 +168,14 @@ export const insertTurnEvent = async (
     readonly event: TurnEvent;
   },
 ): Promise<void> => {
+  const payload = serializeTurnEvent({ event: args.event });
+  if (payload === null) {
+    return;
+  }
   await db.execute(
     `INSERT INTO turn_events (id, session_id, agent_id, payload, created_at)
      VALUES (?, ?, ?, ?, ?)`,
-    [args.id, args.sessionId, args.agentId, JSON.stringify(args.event), eventTimestamp(args.event)],
+    [args.id, args.sessionId, args.agentId, payload, eventTimestamp(args.event)],
   );
 };
 
@@ -71,16 +198,17 @@ export const insertTurnEventsBatch = async (
     await insertTurnEvent(db, ins);
     return;
   }
-  const placeholders = inserts.map(() => '(?, ?, ?, ?, ?)').join(', ');
+  const persisted = inserts.flatMap((insert) => {
+    const payload = serializeTurnEvent({ event: insert.event });
+    return payload === null ? [] : [{ insert, payload }];
+  });
+  if (persisted.length === 0) {
+    return;
+  }
+  const placeholders = persisted.map(() => '(?, ?, ?, ?, ?)').join(', ');
   const values: unknown[] = [];
-  for (const ins of inserts) {
-    values.push(
-      ins.id,
-      ins.sessionId,
-      ins.agentId,
-      JSON.stringify(ins.event),
-      eventTimestamp(ins.event),
-    );
+  for (const { insert, payload } of persisted) {
+    values.push(insert.id, insert.sessionId, insert.agentId, payload, eventTimestamp(insert.event));
   }
   await db.execute(
     `INSERT INTO turn_events (id, session_id, agent_id, payload, created_at) VALUES ${placeholders}`,


### PR DESCRIPTION
## Cosa

Quattro fix di igiene DB (audit 2026-08-22), solo runtime, zero migrazioni:

1. **permission_audit_log**: la clear per-workspace confrontava `session_id` con id di AGENT (no-op silenzioso) → query corretta; le decisioni `default` non vengono più loggate (in bypass producevano righe "deny" per chiamate eseguite); retention a boot (30 giorni / cap 5000 righe).
2. **turn_events** (127.6 MB, 56% del DB prod): `unknown_payload` non viene più persistito, payload > 64 KB troncati in JSON valido, retention a boot (90 giorni / cap 200k righe).
3. **github_pr_cache**: TTL 10 minuti in lettura, GC al teardown del worktree, sweep a boot delle righe senza worktree vivo (92% in prod).
4. **provider_runs**: sweep a boot dei run zombie `pending/streaming` più vecchi di 24h → `cancelled` (35 in prod).

Tutto in un modulo coeso `packages/db/src/maintenance/runDatabaseHygiene.ts` invocato a boot.

## Test

- db: 282 passed, 1 skipped
- desktop: 6284 passed
- rust: regression test sulla clear per-workspace; `cargo test --locked` verde eccetto i 17 sandbox-sensitive noti (socket binding / descendant process)

🤖 Generated with [Claude Code](https://claude.com/claude-code)