### PR TITLE
fix(desktop): point the rust queries at the v0.2 schema

### DIFF
--- a/apps/desktop/src-tauri/src/bridge/snapshot.rs
+++ b/apps/desktop/src-tauri/src/bridge/snapshot.rs
@@ -163,8 +163,15 @@ pub fn build() -> Result<Snapshot, BridgeError> {
 
     let workspaces = rows(
         &conn,
-        "SELECT id, name, root_path, kind, disconnected_at, last_accessed_at, created_at, updated_at \
-         FROM workspaces WHERE deleted_at IS NULL",
+        "SELECT w.id AS id, w.name AS name, p.root_path AS root_path, p.kind AS kind, \
+                w.disconnected_at AS disconnected_at, w.last_accessed_at AS last_accessed_at, \
+                w.created_at AS created_at, w.updated_at AS updated_at \
+         FROM workspaces w \
+         LEFT JOIN projects p ON p.id = ( \
+           SELECT id FROM projects WHERE workspace_id = w.id \
+           ORDER BY created_at ASC, id ASC LIMIT 1 \
+         ) \
+         WHERE w.deleted_at IS NULL",
     )?;
     let sessions = rows(
         &conn,

--- a/apps/desktop/src-tauri/src/bridge/snapshot.rs
+++ b/apps/desktop/src-tauri/src/bridge/snapshot.rs
@@ -169,7 +169,7 @@ pub fn build() -> Result<Snapshot, BridgeError> {
          FROM workspaces w \
          LEFT JOIN projects p ON p.id = ( \
            SELECT id FROM projects WHERE workspace_id = w.id \
-           ORDER BY created_at ASC, id ASC LIMIT 1 \
+           ORDER BY disconnected_at IS NULL DESC, created_at ASC, id ASC LIMIT 1 \
          ) \
          WHERE w.deleted_at IS NULL",
     )?;

--- a/apps/desktop/src-tauri/src/config_export.rs
+++ b/apps/desktop/src-tauri/src/config_export.rs
@@ -4,7 +4,7 @@ use tauri::State;
 use crate::db::{Db, DbError};
 
 // ---------------------------------------------------------------------------
-// Schema version — bump on breaking change
+// Schema version - bump on breaking change
 // ---------------------------------------------------------------------------
 
 const SCHEMA_VERSION: u32 = 2;
@@ -340,7 +340,7 @@ pub fn export_config(state: State<'_, Db>) -> Result<ConfigBundle, ConfigExportE
         templates
     };
 
-    // permission rules — global + workspace scope only (no session-scoped rules; sessions are ephemeral)
+    // permission rules - global + workspace scope only (no session-scoped rules; sessions are ephemeral)
     let permission_rules = {
         let mut stmt = conn.prepare(
             "SELECT id, scope, workspace_id, session_id, pattern_tool, pattern_args_matcher,
@@ -386,7 +386,7 @@ pub fn export_config(state: State<'_, Db>) -> Result<ConfigBundle, ConfigExportE
         rows.collect::<Result<Vec<_>, _>>()?
     };
 
-    // settings — only well-known keys (no api keys, no credentials)
+    // settings - only well-known keys (no api keys, no credentials)
     let settings = {
         fn get_setting(conn: &rusqlite::Connection, key: &str) -> Option<String> {
             conn.query_row(
@@ -526,7 +526,7 @@ pub fn import_config(
     let result = (|| -> Result<ImportStats, rusqlite::Error> {
         let now_ms = crate::util::now_ms();
 
-        // Workspaces — upsert (preserve existing data, add missing).
+        // Workspaces - upsert (preserve existing data, add missing).
         for w in &bundle.workspaces {
             let parallel_val: Option<i64> =
                 w.overrides.parallel_enabled.map(|v| if v { 1 } else { 0 });
@@ -576,7 +576,7 @@ pub fn import_config(
             }
         }
 
-        // Skills — upsert.
+        // Skills - upsert.
         for s in &bundle.skills {
             conn.execute(
                 "INSERT INTO skills
@@ -598,7 +598,7 @@ pub fn import_config(
             )?;
         }
 
-        // Phase templates + definitions — upsert.
+        // Phase templates + definitions - upsert.
         for t in &bundle.phase_templates {
             conn.execute(
                 "INSERT INTO workflows (id, workspace_id, name, description, created_at, updated_at)
@@ -632,7 +632,7 @@ pub fn import_config(
             }
         }
 
-        // Permission rules — upsert (global + workspace only).
+        // Permission rules - upsert (global + workspace only).
         for r in &bundle.permission_rules {
             conn.execute(
                 "INSERT INTO permission_rules
@@ -662,7 +662,7 @@ pub fn import_config(
             )?;
         }
 
-        // Budget rules — upsert.
+        // Budget rules - upsert.
         for b in &bundle.budget_rules {
             conn.execute(
                 "INSERT INTO budget_rules (id, provider, period, cap_usd, alert_threshold_pct, created_at)
@@ -683,7 +683,7 @@ pub fn import_config(
             )?;
         }
 
-        // Settings — upsert only non-null values.
+        // Settings - upsert only non-null values.
         let setting_pairs: &[(&str, Option<&str>)] = &[
             ("editor.binary", bundle.settings.editor_binary.as_deref()),
             (
@@ -802,10 +802,9 @@ fn workspace_projects(workspace: &WorkspaceBundle) -> Vec<ProjectBundle> {
 }
 
 fn normalized_kind(kind: &str) -> String {
-    if kind == "folder" {
-        "folder".to_string()
-    } else {
-        "repo".to_string()
+    match kind {
+        "folder" => "folder".to_string(),
+        _ => "repo".to_string(),
     }
 }
 

--- a/apps/desktop/src-tauri/src/config_export.rs
+++ b/apps/desktop/src-tauri/src/config_export.rs
@@ -7,7 +7,8 @@ use crate::db::{Db, DbError};
 // Schema version — bump on breaking change
 // ---------------------------------------------------------------------------
 
-const SCHEMA_VERSION: u32 = 1;
+const SCHEMA_VERSION: u32 = 2;
+const LEGACY_SCHEMA_VERSION: u32 = 1;
 
 // ---------------------------------------------------------------------------
 // Bundle types (mirrors packages/types/src/config-bundle.ts)
@@ -17,13 +18,28 @@ const SCHEMA_VERSION: u32 = 1;
 pub struct WorkspaceBundle {
     pub id: String,
     pub name: String,
-    #[serde(rename = "rootPath")]
-    pub root_path: String,
+    #[serde(rename = "rootPath", default, skip_serializing_if = "Option::is_none")]
+    pub root_path: Option<String>,
+    #[serde(default)]
+    pub projects: Vec<ProjectBundle>,
     #[serde(rename = "createdAt")]
     pub created_at: String,
     #[serde(rename = "updatedAt")]
     pub updated_at: String,
     pub overrides: WorkspaceOverridesBundle,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ProjectBundle {
+    pub id: String,
+    pub name: String,
+    #[serde(rename = "rootPath")]
+    pub root_path: String,
+    pub kind: String,
+    #[serde(rename = "createdAt")]
+    pub created_at: String,
+    #[serde(rename = "updatedAt")]
+    pub updated_at: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -197,31 +213,55 @@ impl From<DbError> for ConfigExportError {
 pub fn export_config(state: State<'_, Db>) -> Result<ConfigBundle, ConfigExportError> {
     let conn = state.0.lock().map_err(|_| ConfigExportError::Poisoned)?;
 
-    // workspaces + overrides
+    // workspaces + overrides + projects
     let workspaces = {
         let mut stmt = conn.prepare(
-            "SELECT id, name, root_path, created_at, updated_at,
+            "SELECT id, name, created_at, updated_at,
                     default_provider_id, default_workflow_id, default_branch_prefix, parallel_enabled
              FROM workspaces
+             WHERE deleted_at IS NULL
              ORDER BY created_at ASC",
         )?;
         let rows = stmt.query_map([], |row| {
-            let parallel_raw: Option<i64> = row.get(8)?;
+            let parallel_raw: Option<i64> = row.get(7)?;
             Ok(WorkspaceBundle {
                 id: row.get(0)?,
                 name: row.get(1)?,
-                root_path: row.get(2)?,
-                created_at: ms_col_to_iso(row.get::<_, i64>(3).unwrap_or(0)),
-                updated_at: ms_col_to_iso(row.get::<_, i64>(4).unwrap_or(0)),
+                root_path: None,
+                projects: Vec::new(),
+                created_at: ms_col_to_iso(row.get::<_, i64>(2).unwrap_or(0)),
+                updated_at: ms_col_to_iso(row.get::<_, i64>(3).unwrap_or(0)),
                 overrides: WorkspaceOverridesBundle {
-                    default_provider_id: row.get(5)?,
-                    default_workflow_id: row.get(6)?,
-                    default_branch_prefix: row.get(7)?,
+                    default_provider_id: row.get(4)?,
+                    default_workflow_id: row.get(5)?,
+                    default_branch_prefix: row.get(6)?,
                     parallel_enabled: parallel_raw.map(|v| v != 0),
                 },
             })
         })?;
-        rows.collect::<Result<Vec<_>, _>>()?
+        let mut workspaces = rows.collect::<Result<Vec<_>, _>>()?;
+        let mut project_stmt = conn.prepare(
+            "SELECT id, name, root_path, kind, created_at, updated_at
+             FROM projects
+             WHERE workspace_id = ?1
+             ORDER BY created_at ASC, id ASC",
+        )?;
+        for workspace in &mut workspaces {
+            let project_rows = project_stmt.query_map(rusqlite::params![workspace.id], |row| {
+                Ok(ProjectBundle {
+                    id: row.get(0)?,
+                    name: row.get(1)?,
+                    root_path: row.get(2)?,
+                    kind: row
+                        .get::<_, Option<String>>(3)?
+                        .unwrap_or_else(|| "repo".to_string()),
+                    created_at: ms_col_to_iso(row.get::<_, i64>(4).unwrap_or(0)),
+                    updated_at: ms_col_to_iso(row.get::<_, i64>(5).unwrap_or(0)),
+                })
+            })?;
+            workspace.projects = project_rows.collect::<Result<Vec<_>, _>>()?;
+        }
+        workspaces
     };
 
     // skills
@@ -411,7 +451,7 @@ pub fn import_config(
     bundle: ConfigBundle,
 ) -> Result<ImportResult, ConfigExportError> {
     // Validate schema version.
-    if bundle.schema_version != SCHEMA_VERSION {
+    if bundle.schema_version != SCHEMA_VERSION && bundle.schema_version != LEGACY_SCHEMA_VERSION {
         return Err(ConfigExportError::SchemaMismatch {
             got: bundle.schema_version,
             expected: SCHEMA_VERSION,
@@ -494,7 +534,7 @@ pub fn import_config(
             let updated_ms = iso_to_ms(&w.updated_at).unwrap_or(now_ms);
             conn.execute(
                 "INSERT INTO workspaces
-                   (id, name, root_path, created_at, updated_at,
+                   (id, name, slug, created_at, updated_at,
                     default_provider_id, default_workflow_id, default_branch_prefix, parallel_enabled)
                  VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
                  ON CONFLICT(id) DO UPDATE SET
@@ -505,7 +545,7 @@ pub fn import_config(
                    parallel_enabled          = excluded.parallel_enabled,
                    updated_at                = excluded.updated_at",
                 rusqlite::params![
-                    w.id, w.name, w.root_path,
+                    w.id, w.name, workspace_slug(&w.name, &w.id),
                     created_ms, updated_ms,
                     w.overrides.default_provider_id,
                     w.overrides.default_workflow_id,
@@ -513,6 +553,27 @@ pub fn import_config(
                     parallel_val,
                 ],
             )?;
+            for p in workspace_projects(w) {
+                conn.execute(
+                    "INSERT INTO projects
+                       (id, workspace_id, name, root_path, kind, created_at, updated_at)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+                     ON CONFLICT(id) DO UPDATE SET
+                       name       = excluded.name,
+                       root_path  = excluded.root_path,
+                       kind       = excluded.kind,
+                       updated_at = excluded.updated_at",
+                    rusqlite::params![
+                        p.id,
+                        w.id,
+                        p.name,
+                        p.root_path,
+                        p.kind,
+                        iso_to_ms(&p.created_at).unwrap_or(created_ms),
+                        iso_to_ms(&p.updated_at).unwrap_or(updated_ms),
+                    ],
+                )?;
+            }
         }
 
         // Skills — upsert.
@@ -686,6 +747,68 @@ fn iso_to_ms(s: &str) -> Option<i64> {
     crate::util::iso_to_ms(s)
 }
 
+fn workspace_slug(name: &str, id: &str) -> String {
+    let mut prefix = String::new();
+    let mut pending_dash = false;
+    for ch in name.to_lowercase().chars() {
+        if ch.is_ascii_alphanumeric() {
+            if pending_dash && !prefix.is_empty() {
+                prefix.push('-');
+            }
+            pending_dash = false;
+            prefix.push(ch);
+        } else {
+            pending_dash = true;
+        }
+        if prefix.len() >= 32 {
+            break;
+        }
+    }
+    let stem = if prefix.is_empty() {
+        "workspace"
+    } else {
+        prefix.as_str()
+    };
+    let suffix: String = id.chars().take(8).collect();
+    format!("{stem}-{suffix}")
+}
+
+fn workspace_projects(workspace: &WorkspaceBundle) -> Vec<ProjectBundle> {
+    if !workspace.projects.is_empty() {
+        return workspace
+            .projects
+            .iter()
+            .map(|project| ProjectBundle {
+                id: project.id.clone(),
+                name: project.name.clone(),
+                root_path: project.root_path.clone(),
+                kind: normalized_kind(&project.kind),
+                created_at: project.created_at.clone(),
+                updated_at: project.updated_at.clone(),
+            })
+            .collect();
+    }
+    match &workspace.root_path {
+        Some(root_path) if !root_path.trim().is_empty() => vec![ProjectBundle {
+            id: format!("{}-project", workspace.id),
+            name: workspace.name.clone(),
+            root_path: root_path.clone(),
+            kind: "repo".to_string(),
+            created_at: workspace.created_at.clone(),
+            updated_at: workspace.updated_at.clone(),
+        }],
+        _ => Vec::new(),
+    }
+}
+
+fn normalized_kind(kind: &str) -> String {
+    if kind == "folder" {
+        "folder".to_string()
+    } else {
+        "repo".to_string()
+    }
+}
+
 // ---------------------------------------------------------------------------
 // File-based commands (avoid requiring tauri-plugin-fs on the JS side)
 // ---------------------------------------------------------------------------
@@ -726,8 +849,70 @@ mod tests {
     }
 
     #[test]
-    fn schema_version_is_one() {
-        assert_eq!(SCHEMA_VERSION, 1);
+    fn schema_version_is_two() {
+        assert_eq!(SCHEMA_VERSION, 2);
+        assert_eq!(LEGACY_SCHEMA_VERSION, 1);
+    }
+
+    #[test]
+    fn workspace_slug_matches_the_desktop_shape() {
+        assert_eq!(
+            workspace_slug("Kay AM", "0efb8311-8d9c-4c85"),
+            "kay-am-0efb8311"
+        );
+        assert_eq!(workspace_slug("  ", "1234abcd-0000"), "workspace-1234abcd");
+    }
+
+    #[test]
+    fn legacy_root_path_becomes_the_single_project() {
+        let workspace = WorkspaceBundle {
+            id: "workspace-1".to_string(),
+            name: "Goodboy".to_string(),
+            root_path: Some("/Users/dev/goodboy".to_string()),
+            projects: vec![],
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            updated_at: "2026-01-02T00:00:00Z".to_string(),
+            overrides: WorkspaceOverridesBundle {
+                default_provider_id: None,
+                default_workflow_id: None,
+                default_branch_prefix: None,
+                parallel_enabled: None,
+            },
+        };
+        let projects = workspace_projects(&workspace);
+        assert_eq!(projects.len(), 1);
+        assert_eq!(projects[0].id, "workspace-1-project");
+        assert_eq!(projects[0].root_path, "/Users/dev/goodboy");
+        assert_eq!(projects[0].kind, "repo");
+    }
+
+    #[test]
+    fn bundled_projects_win_over_a_legacy_root_path() {
+        let workspace = WorkspaceBundle {
+            id: "workspace-1".to_string(),
+            name: "Goodboy".to_string(),
+            root_path: Some("/Users/dev/legacy".to_string()),
+            projects: vec![ProjectBundle {
+                id: "project-1".to_string(),
+                name: "desktop".to_string(),
+                root_path: "/Users/dev/goodboy".to_string(),
+                kind: "unknown".to_string(),
+                created_at: "2026-01-01T00:00:00Z".to_string(),
+                updated_at: "2026-01-02T00:00:00Z".to_string(),
+            }],
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            updated_at: "2026-01-02T00:00:00Z".to_string(),
+            overrides: WorkspaceOverridesBundle {
+                default_provider_id: None,
+                default_workflow_id: None,
+                default_branch_prefix: None,
+                parallel_enabled: None,
+            },
+        };
+        let projects = workspace_projects(&workspace);
+        assert_eq!(projects.len(), 1);
+        assert_eq!(projects[0].id, "project-1");
+        assert_eq!(projects[0].kind, "repo");
     }
 
     #[test]
@@ -757,7 +942,7 @@ mod tests {
         assert_eq!(
             serde_json::from_str::<serde_json::Value>(&json).expect("parse failed")
                 ["schemaVersion"],
-            serde_json::Value::Number(serde_json::Number::from(1u32))
+            serde_json::Value::Number(serde_json::Number::from(SCHEMA_VERSION))
         );
     }
 

--- a/apps/desktop/src-tauri/src/integration_credentials.rs
+++ b/apps/desktop/src-tauri/src/integration_credentials.rs
@@ -662,8 +662,8 @@ mod tests {
         let with_override =
             credential_id_for_binding(&conn, "linear", "container-1", Some("project-1"))
                 .expect("resolves");
-        let without = credential_id_for_binding(&conn, "linear", "container-1", None)
-            .expect("resolves");
+        let without =
+            credential_id_for_binding(&conn, "linear", "container-1", None).expect("resolves");
         let other_project =
             credential_id_for_binding(&conn, "linear", "container-1", Some("project-2"))
                 .expect("resolves");
@@ -681,8 +681,8 @@ mod tests {
         seed_binding(&conn, "b-1", "container-1", None, "github", "cred-bound");
 
         let global = global_credential_id(&conn, "github").expect("resolves");
-        let missing = credential_id_for_binding(&conn, "github", "container-2", None)
-            .expect("resolves");
+        let missing =
+            credential_id_for_binding(&conn, "github", "container-2", None).expect("resolves");
 
         assert_eq!(global.as_deref(), Some("cred-free"));
         assert_eq!(missing, None);
@@ -707,8 +707,7 @@ mod tests {
 
         let own = config_for_binding_in(&conn, "gitlab", "container-1", Some("project-1"))
             .expect("resolves");
-        let shared =
-            config_for_binding_in(&conn, "gitlab", "container-1", None).expect("resolves");
+        let shared = config_for_binding_in(&conn, "gitlab", "container-1", None).expect("resolves");
 
         assert_eq!(own.as_deref(), Some("{\"host\":\"own\"}"));
         assert_eq!(shared.as_deref(), Some("{\"host\":\"shared\"}"));
@@ -919,10 +918,7 @@ mod tests {
         assert_eq!(adopted, 0);
     }
 
-    fn run_github_adoption(
-        conn: &Connection,
-        store: &RefCell<HashMap<String, String>>,
-    ) -> usize {
+    fn run_github_adoption(conn: &Connection, store: &RefCell<HashMap<String, String>>) -> usize {
         adopt_github_with(
             conn,
             |key| Ok(store.borrow().get(key).cloned()),
@@ -980,7 +976,10 @@ mod tests {
             .expect("resolves")
             .expect("bound");
         assert_eq!(
-            store.borrow().get(&secret_key(&credential)).map(String::as_str),
+            store
+                .borrow()
+                .get(&secret_key(&credential))
+                .map(String::as_str),
             Some("ghp_scoped")
         );
         assert!(!store.borrow().contains_key("github.pat.ex-ws-1"));

--- a/apps/desktop/src-tauri/src/query_bridge/cli.rs
+++ b/apps/desktop/src-tauri/src/query_bridge/cli.rs
@@ -225,7 +225,10 @@ mod tests {
         let argv = owned(&["linear", "issue", "ENG-1", "--project", "app"]);
 
         assert_eq!(project_scope(&args, &argv), "app");
-        assert_eq!(project_scope(&args, &owned(&["linear", "issue", "ENG-1"])), "");
+        assert_eq!(
+            project_scope(&args, &owned(&["linear", "issue", "ENG-1"])),
+            ""
+        );
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/query_bridge/project.rs
+++ b/apps/desktop/src-tauri/src/query_bridge/project.rs
@@ -199,10 +199,7 @@ mod tests {
 
     #[test]
     fn a_blank_reason_is_refused_before_anything_runs() {
-        let refused = request(&[
-            ("name", Value::from("app")),
-            ("reason", Value::from("   ")),
-        ]);
+        let refused = request(&[("name", Value::from("app")), ("reason", Value::from("   "))]);
 
         assert!(text_arg(&refused, "reason")
             .expect_err("blank reason")

--- a/apps/desktop/src-tauri/src/scripts.rs
+++ b/apps/desktop/src-tauri/src/scripts.rs
@@ -145,7 +145,7 @@ pub async fn workspace_script_run(
     let body = {
         let conn = state.0.lock().map_err(|_| ScriptError::Poisoned)?;
         conn.query_row(
-            "SELECT body FROM workspace_scripts WHERE id = ?1 LIMIT 1",
+            "SELECT body FROM project_scripts WHERE id = ?1 LIMIT 1",
             rusqlite::params![script_id],
             |row| row.get::<_, String>(0),
         )

--- a/apps/desktop/src-tauri/src/session_dir.rs
+++ b/apps/desktop/src-tauri/src/session_dir.rs
@@ -286,7 +286,12 @@ mod tests {
         assert_eq!(created.slug, "study-plan");
         assert!(!created.reused);
         assert!(Path::new(&created.worktree_path).is_dir());
-        let marker = std::fs::read(Path::new(&created.worktree_path).join(".goodboy").join("session.json")).unwrap();
+        let marker = std::fs::read(
+            Path::new(&created.worktree_path)
+                .join(".goodboy")
+                .join("session.json"),
+        )
+        .unwrap();
         let marker = serde_json::from_slice::<SessionMarker>(&marker).unwrap();
         assert_eq!(marker.session_id, "session-1");
         assert_eq!(marker.workspace_id, "workspace-1");
@@ -294,8 +299,12 @@ mod tests {
         let first_created_at = marker.created_at.clone();
         let reused = session_dir_create(args()).unwrap();
         assert!(reused.reused);
-        let marker_after_reuse =
-            std::fs::read(Path::new(&created.worktree_path).join(".goodboy").join("session.json")).unwrap();
+        let marker_after_reuse = std::fs::read(
+            Path::new(&created.worktree_path)
+                .join(".goodboy")
+                .join("session.json"),
+        )
+        .unwrap();
         let marker_after_reuse =
             serde_json::from_slice::<SessionMarker>(&marker_after_reuse).unwrap();
         assert_eq!(marker_after_reuse.created_at, first_created_at);
@@ -354,7 +363,10 @@ mod tests {
             base_path: root.to_string_lossy().into_owned(),
             path: root.to_string_lossy().into_owned(),
         });
-        assert!(matches!(base_itself, Err(SessionDirError::OutsideWorkspace)));
+        assert!(matches!(
+            base_itself,
+            Err(SessionDirError::OutsideWorkspace)
+        ));
         std::fs::remove_dir_all(root).unwrap();
     }
 
@@ -464,5 +476,4 @@ mod tests {
             Err(SessionDirError::InvalidDirectoryName)
         ));
     }
-
 }

--- a/apps/desktop/src-tauri/src/worktree.rs
+++ b/apps/desktop/src-tauri/src/worktree.rs
@@ -2279,7 +2279,10 @@ mod rewrite_tests {
         );
         let exclude =
             std::fs::read_to_string(root.join(".git").join("info").join("exclude")).unwrap();
-        assert_eq!(exclude.lines().filter(|line| *line == ".goodboy/").count(), 1);
+        assert_eq!(
+            exclude.lines().filter(|line| *line == ".goodboy/").count(),
+            1
+        );
         let status = git_ok(&root, &["status", "--porcelain"]);
         assert!(!status.contains(".goodboy"), "{status}");
         assert!(!root.join(".gitignore").exists());
@@ -2297,7 +2300,10 @@ mod rewrite_tests {
         assert!(reused.reused);
         let exclude_path = root.join(".git").join("info").join("exclude");
         let exclude = std::fs::read_to_string(&exclude_path).unwrap();
-        assert_eq!(exclude.lines().filter(|line| *line == ".goodboy/").count(), 1);
+        assert_eq!(
+            exclude.lines().filter(|line| *line == ".goodboy/").count(),
+            1
+        );
 
         worktree_remove(
             root.to_string_lossy().into_owned(),
@@ -2328,7 +2334,10 @@ mod rewrite_tests {
         assert!(!root.join(".goodboy").exists());
         let exclude_path = root.join(".git").join("info").join("exclude");
         let exclude = std::fs::read_to_string(&exclude_path).unwrap();
-        assert_eq!(exclude.lines().filter(|line| *line == ".goodboy/").count(), 0);
+        assert_eq!(
+            exclude.lines().filter(|line| *line == ".goodboy/").count(),
+            0
+        );
         std::fs::remove_dir_all(root).unwrap();
     }
 
@@ -2350,7 +2359,10 @@ mod rewrite_tests {
         assert!(Path::new(&survivor.worktree_path).is_dir());
         let exclude_path = root.join(".git").join("info").join("exclude");
         let exclude = std::fs::read_to_string(&exclude_path).unwrap();
-        assert_eq!(exclude.lines().filter(|line| *line == ".goodboy/").count(), 1);
+        assert_eq!(
+            exclude.lines().filter(|line| *line == ".goodboy/").count(),
+            1
+        );
         std::fs::remove_dir_all(root).unwrap();
     }
 }

--- a/packages/db/src/migrations/rust-sql-schema.test.ts
+++ b/packages/db/src/migrations/rust-sql-schema.test.ts
@@ -1,0 +1,109 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { makeTestDatabase } from '../test-helpers/test-db';
+import { migrate } from './runner';
+
+const RUST_SRC = fileURLToPath(new URL('../../../../apps/desktop/src-tauri/src', import.meta.url));
+
+const VIRTUAL_TABLES: ReadonlySet<string> = new Set(['sqlite_master', 'sqlite_sequence']);
+
+type Reference = {
+  readonly file: string;
+  readonly table: string;
+  readonly columns: ReadonlyArray<string>;
+};
+
+const rustFiles = (dir: string): ReadonlyArray<string> =>
+  readdirSync(dir).flatMap((entry) => {
+    const path = join(dir, entry);
+    if (statSync(path).isDirectory()) {
+      return rustFiles(path);
+    }
+    return path.endsWith('.rs') ? [path] : [];
+  });
+
+const tableReferences = (source: string, file: string): ReadonlyArray<Reference> => {
+  const matches = source.matchAll(/(?:FROM|JOIN|INTO|UPDATE)\s+([a-z_][a-z0-9_]*)/g);
+  return [...matches].flatMap(([, table]) =>
+    table === undefined || VIRTUAL_TABLES.has(table) ? [] : [{ file, table, columns: [] }],
+  );
+};
+
+const selectReferences = (source: string, file: string): ReadonlyArray<Reference> => {
+  const matches = source.matchAll(/SELECT\s+([^;]*?)\s+FROM\s+([a-z_][a-z0-9_]*)([^;]*)/g);
+  return [...matches].flatMap(([, list, table, tail]) => {
+    if (list === undefined || table === undefined || VIRTUAL_TABLES.has(table)) {
+      return [];
+    }
+    const isSingleTable = !/^\s*(?:,|[a-z_]+\s+(?:AS\s+)?[a-z_]*\s*(?:JOIN|,))/i.test(tail ?? '');
+    const isPlainList = !/[(*.]|\sAS\s/i.test(list);
+    if (!isSingleTable || !isPlainList) {
+      return [];
+    }
+    const columns = list
+      .split(',')
+      .map((column) => column.trim())
+      .filter((column) => /^[a-z_][a-z0-9_]*$/.test(column));
+    return columns.length === 0 ? [] : [{ file, table, columns }];
+  });
+};
+
+const insertReferences = (source: string, file: string): ReadonlyArray<Reference> => {
+  const matches = source.matchAll(/INSERT\s+INTO\s+([a-z_][a-z0-9_]*)\s*\(([^)]*)\)/g);
+  return [...matches].flatMap(([, table, list]) => {
+    if (table === undefined || list === undefined) {
+      return [];
+    }
+    const columns = list
+      .split(',')
+      .map((column) => column.trim())
+      .filter((column) => /^[a-z_][a-z0-9_]*$/.test(column));
+    return columns.length === 0 ? [] : [{ file, table, columns }];
+  });
+};
+
+const describeReference = (reference: Reference, column?: string): string =>
+  `${reference.file.slice(RUST_SRC.length + 1)}: ${reference.table}${column ? `.${column}` : ''}`;
+
+describe('rust sql', () => {
+  it('only touches tables and columns the migrations create', async () => {
+    const db = makeTestDatabase();
+    await migrate(db);
+    const tables = await db.select<{ name: string }>(
+      "SELECT name FROM sqlite_master WHERE type = 'table'",
+    );
+    const columnsByTable = new Map<string, ReadonlySet<string>>();
+    for (const { name } of tables) {
+      const info = await db.select<{ name: string }>(`PRAGMA table_info(${name})`);
+      columnsByTable.set(name, new Set(info.map((column) => column.name)));
+    }
+
+    const references = rustFiles(RUST_SRC).flatMap((file) => {
+      const source = readFileSync(file, 'utf8');
+      return [
+        ...tableReferences(source, file),
+        ...selectReferences(source, file),
+        ...insertReferences(source, file),
+      ];
+    });
+    expect(references.length).toBeGreaterThan(50);
+
+    const unknownTables = references
+      .filter((reference) => !columnsByTable.has(reference.table))
+      .map((reference) => describeReference(reference));
+    const unknownColumns = references.flatMap((reference) => {
+      const known = columnsByTable.get(reference.table);
+      if (known === undefined) {
+        return [];
+      }
+      return reference.columns
+        .filter((column) => !known.has(column))
+        .map((column) => describeReference(reference, column));
+    });
+
+    expect([...new Set(unknownTables)]).toEqual([]);
+    expect([...new Set(unknownColumns)]).toEqual([]);
+  });
+});

--- a/packages/types/src/config-bundle.ts
+++ b/packages/types/src/config-bundle.ts
@@ -1,11 +1,21 @@
 import type { WorkspaceId } from './ids';
 
-export const CONFIG_BUNDLE_SCHEMA_VERSION = 1 as const;
+export const CONFIG_BUNDLE_SCHEMA_VERSION = 2 as const;
+
+export type ConfigBundleProject = Readonly<{
+  id: string;
+  name: string;
+  rootPath: string;
+  kind: 'repo' | 'folder';
+  createdAt: string;
+  updatedAt: string;
+}>;
 
 export type ConfigBundleWorkspace = Readonly<{
   id: WorkspaceId;
   name: string;
-  rootPath: string;
+  rootPath?: string;
+  projects: ReadonlyArray<ConfigBundleProject>;
   createdAt: string;
   updatedAt: string;
   overrides: {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -211,6 +211,7 @@ export type {
   ConfigBundleBudgetRule,
   ConfigBundleImportResult,
   ConfigBundlePermissionRule,
+  ConfigBundleProject,
   ConfigBundleSettings,
   ConfigBundleSkill,
   ConfigBundleStep,


### PR DESCRIPTION
## What broke

m118 (shipped in v0.2.0) renamed `workspace_scripts` to `project_scripts` and moved `root_path` and `kind` from `workspaces` to `projects`. Three Rust call sites kept the old names:

- `scripts.rs` reads `SELECT body FROM workspace_scripts` → **every script run fails**, which is how this was found.
- `bridge/snapshot.rs` selects `root_path, kind FROM workspaces` → the companion snapshot never builds.
- `config_export.rs` selects and inserts `workspaces.root_path`, and its workspace insert omits the now-required `slug` → config export and import both fail.

Verified against the live schema: `no such table: workspace_scripts`, `no such column: root_path`.

## What this does

- Scripts read `project_scripts`.
- The snapshot derives `root_path` and `kind` from the workspace's first project, so the phone keeps the shape it decodes today.
- The config bundle carries `projects` and moves to schema version 2. A version 1 bundle still imports: its `rootPath` becomes the workspace's single project. The workspace insert writes the slug the schema requires.

## The guard that was missing

`packages/db/src/migrations/rust-sql-schema.test.ts` walks every Rust source, collects the tables and columns its SQL touches, and checks them against a freshly migrated schema. Confirmed it fails on both original bugs when they are put back.

Rust suite green (563 tests), `packages/db` green (330 tests).