### PR TITLE
feat(desktop): surface the resolve work in the overview

### DIFF
--- a/apps/desktop/src/features/session/components/SessionOverviewPane/OverviewResolve.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/OverviewResolve.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { IsoDateTime, Session, SessionId, WorkspaceId } from '@goodboy/types';
+import type { ResolverStatus } from '../../resolver-linkage';
+
+const state = vi.hoisted(() => ({
+  sessionGithub: {} as Record<string, unknown>,
+  sessionPendingResolutions: {} as Record<string, ReadonlyArray<unknown>>,
+}));
+
+const resolvers = vi.hoisted(() => ({ links: [] as ReadonlyArray<unknown> }));
+
+vi.mock('../../../../store', () => ({
+  EMPTY_ARRAY: Object.freeze([]),
+  useAppStore: <T,>(selector: (value: typeof state) => T) => selector(state),
+}));
+
+vi.mock('../../hooks/useResolverIndex', () => ({
+  useResolverIndex: () => resolvers,
+}));
+
+import { OverviewResolve } from './OverviewResolve';
+
+const sessionId = 'session-1' as SessionId;
+
+const session = {
+  id: sessionId,
+  workspaceId: 'ws-1' as WorkspaceId,
+  goal: 'ship it',
+  stateKind: 'idle',
+  createdAt: '2026-08-20T00:00:00.000Z' as IsoDateTime,
+  updatedAt: '2026-08-20T00:00:00.000Z' as IsoDateTime,
+  agents: [],
+  workflowRuns: [],
+} as unknown as Session;
+
+const link = (status: ResolverStatus) => ({ agent: { id: `agent-${status}` }, status });
+
+const reviewComment = (resolved: boolean) => ({ source: 'review', resolved });
+
+const setUp = (next: {
+  readonly links?: ReadonlyArray<unknown>;
+  readonly comments?: ReadonlyArray<unknown>;
+  readonly pending?: ReadonlyArray<unknown>;
+}) => {
+  resolvers.links = next.links ?? [];
+  state.sessionGithub = { [sessionId]: { detail: { comments: next.comments ?? [] } } };
+  state.sessionPendingResolutions = { [sessionId]: next.pending ?? [] };
+};
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('OverviewResolve', () => {
+  it('stays out of the way when nothing is waiting', () => {
+    setUp({});
+    const { container } = render(<OverviewResolve session={session} onSelectLens={vi.fn()} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('counts the unresolved review comments and opens the resolve lens', () => {
+    setUp({ comments: [reviewComment(false), reviewComment(false), reviewComment(true)] });
+    const onSelectLens = vi.fn();
+    render(<OverviewResolve session={session} onSelectLens={onSelectLens} />);
+
+    fireEvent.click(screen.getByText('2 comments to resolve'));
+
+    expect(onSelectLens).toHaveBeenCalledWith('resolve');
+  });
+
+  it('counts only the resolvers that have not settled', () => {
+    setUp({ links: [link('running'), link('awaiting'), link('resolved'), link('wontfix')] });
+    render(<OverviewResolve session={session} onSelectLens={vi.fn()} />);
+
+    expect(screen.getByText('2 resolvers still open')).toBeTruthy();
+    expect(screen.getByText('1 running')).toBeTruthy();
+  });
+
+  it('falls back to the resolutions waiting to be pushed', () => {
+    setUp({ pending: [{ threadId: 'thread-1' }] });
+    render(<OverviewResolve session={session} onSelectLens={vi.fn()} />);
+
+    expect(screen.getByText('1 resolution ready to push')).toBeTruthy();
+  });
+});

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/OverviewResolve.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/OverviewResolve.tsx
@@ -62,7 +62,7 @@ export const OverviewResolve = ({ session, onSelectLens }: Props) => {
       >
         <CONCEPT_ICONS.resolve size={13} aria-hidden className="shrink-0 text-muted-foreground" />
         <span className="min-w-0 flex-1 truncate text-sm text-foreground">{label}</span>
-        {meta ? <Chip tone="accent" size="3xs" bordered={false} label={meta} /> : null}
+        {meta !== null ? <Chip tone="accent" size="3xs" bordered={false} label={meta} /> : null}
       </button>
     </section>
   );

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/OverviewResolve.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/OverviewResolve.tsx
@@ -1,0 +1,69 @@
+import { Chip, Eyebrow } from '@goodboy/ui';
+import type { Session } from '@goodboy/types';
+import type { LensKind } from '../../../../store';
+import { EMPTY_ARRAY, useAppStore } from '../../../../store';
+import { CONCEPT_ICONS } from '../../../../shared/components/conceptIcons';
+import { useResolverIndex } from '../../hooks/useResolverIndex';
+import type { ResolverStatus } from '../../resolver-linkage';
+
+type Props = {
+  readonly session: Session;
+  readonly onSelectLens: (lens: LensKind) => void;
+};
+
+const SETTLED: ReadonlySet<ResolverStatus> = new Set<ResolverStatus>([
+  'resolved',
+  'wontfix',
+  'stopped',
+  'done',
+]);
+
+const plural = (count: number, word: string): string => `${count} ${word}${count === 1 ? '' : 's'}`;
+
+export const OverviewResolve = ({ session, onSelectLens }: Props) => {
+  const sessionId = session.id;
+  const resolverIndex = useResolverIndex(sessionId);
+  const prDetail = useAppStore((s) => s.sessionGithub[sessionId]?.detail ?? null);
+  const pendingResolutions = useAppStore(
+    (s) => s.sessionPendingResolutions[sessionId] ?? EMPTY_ARRAY,
+  );
+
+  const openResolvers = resolverIndex.links.filter((link) => !SETTLED.has(link.status));
+  const runningResolvers = openResolvers.filter((link) => link.status === 'running').length;
+  const openComments = (prDetail?.comments ?? []).filter(
+    (comment) => comment.source === 'review' && comment.resolved === false,
+  ).length;
+  const pendingCount = pendingResolutions.length;
+
+  if (openComments === 0 && openResolvers.length === 0 && pendingCount === 0) {
+    return null;
+  }
+
+  const label =
+    openComments > 0
+      ? `${plural(openComments, 'comment')} to resolve`
+      : openResolvers.length > 0
+        ? `${plural(openResolvers.length, 'resolver')} still open`
+        : `${plural(pendingCount, 'resolution')} ready to push`;
+  const meta =
+    runningResolvers > 0
+      ? `${runningResolvers} running`
+      : pendingCount > 0
+        ? `${pendingCount} ready to push`
+        : null;
+
+  return (
+    <section aria-label="Resolve" className="flex flex-col gap-2">
+      <Eyebrow label="Resolve" className="px-0.5" />
+      <button
+        type="button"
+        onClick={() => onSelectLens('resolve')}
+        className="flex w-full items-center gap-2 rounded-lg border-l-2 border-border-soft px-3 py-1.5 text-left hover:bg-muted/40"
+      >
+        <CONCEPT_ICONS.resolve size={13} aria-hidden className="shrink-0 text-muted-foreground" />
+        <span className="min-w-0 flex-1 truncate text-sm text-foreground">{label}</span>
+        {meta ? <Chip tone="accent" size="3xs" bordered={false} label={meta} /> : null}
+      </button>
+    </section>
+  );
+};

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/index.tsx
@@ -22,6 +22,7 @@ import { GoalOverviewRegion } from './GoalOverviewRegion';
 import { OverviewNextSteps } from './OverviewNextSteps';
 import { OverviewPlans } from './OverviewPlans';
 import { OverviewPrs } from './OverviewPrs';
+import { OverviewResolve } from './OverviewResolve';
 
 type Props = {
   readonly session: Session;
@@ -90,6 +91,7 @@ export const SessionOverviewPane = ({ session, onSelectLens }: Props) => {
         animationClassName="animate-fade-in"
       >
         <OverviewNextSteps session={session} agents={sessionAgents} />
+        <OverviewResolve session={session} onSelectLens={onSelectLens} />
         <OverviewPlans session={session} onSelectLens={onSelectLens} />
         <OverviewPrs session={session} onSelectLens={onSelectLens} />
         <TimelinePane


### PR DESCRIPTION
## Why

Resolve had no standing entry point. You got there from a keyboard shortcut, a timeline row or the PR panel, so a session with review comments waiting looked idle from the overview.

## What

A `Resolve` section in the session overview, sibling of `Plans` and `Pull requests`, above the timeline. It renders nothing when there is nothing waiting, so quiet sessions stay quiet.

The row reads, in priority order:

1. `N comments to resolve` when the PR detail has unresolved review comments
2. `N resolvers still open` when resolvers are running, pending, awaiting, analyzed, committed or failed
3. `N resolutions ready to push` when only pushes are outstanding

A chip carries the secondary count (`N running`, `N ready to push`). Clicking the row opens the resolve lens.

## Placement note

Considered putting it next to `Add workflow` and `New agent`, but that row is for starting new work and this is attention on existing work, which is what the `Plans` and `Pull requests` sections already model. Same visual language as those rows.

4 new tests, session suite green (1777 tests), typecheck green.