### PR TITLE
fix(desktop): resolve integration credentials by project

### DIFF
--- a/apps/desktop/src-tauri/src/bitbucket.rs
+++ b/apps/desktop/src-tauri/src/bitbucket.rs
@@ -296,8 +296,12 @@ async fn send_no_content(
     Ok(())
 }
 
-fn read_token(workspace_id: &str, cache: &BitbucketTokenCache) -> Result<String, BitbucketError> {
-    integration_credentials::read_for_binding(PROVIDER, workspace_id, None, &cache.0)?
+fn read_token(
+    workspace_id: &str,
+    project_id: Option<&str>,
+    cache: &BitbucketTokenCache,
+) -> Result<String, BitbucketError> {
+    integration_credentials::read_for_binding(PROVIDER, workspace_id, project_id, &cache.0)?
         .ok_or_else(|| BitbucketError::NoToken(workspace_id.to_string()))
 }
 
@@ -908,13 +912,14 @@ pub async fn bitbucket_connect(
 #[tauri::command]
 pub async fn bitbucket_list_pull_requests(
     workspace_id: String,
+    project_id: Option<String>,
     workspace_slug: String,
     repo_slug: String,
     email: String,
     state: Option<String>,
     cache: State<'_, BitbucketTokenCache>,
 ) -> Result<Vec<BitbucketPullRequest>, BitbucketError> {
-    let token = read_token(&workspace_id, &cache)?;
+    let token = read_token(&workspace_id, project_id.as_deref(), &cache)?;
     let credentials = Credentials {
         email: &email,
         token: &token,
@@ -927,13 +932,14 @@ pub async fn bitbucket_list_pull_requests(
 #[tauri::command]
 pub async fn bitbucket_get_pull_request(
     workspace_id: String,
+    project_id: Option<String>,
     workspace_slug: String,
     repo_slug: String,
     email: String,
     pull_request_id: u64,
     cache: State<'_, BitbucketTokenCache>,
 ) -> Result<BitbucketPullRequest, BitbucketError> {
-    let token = read_token(&workspace_id, &cache)?;
+    let token = read_token(&workspace_id, project_id.as_deref(), &cache)?;
     let credentials = Credentials {
         email: &email,
         token: &token,
@@ -946,13 +952,14 @@ pub async fn bitbucket_get_pull_request(
 #[tauri::command]
 pub async fn bitbucket_pull_request_diff(
     workspace_id: String,
+    project_id: Option<String>,
     workspace_slug: String,
     repo_slug: String,
     email: String,
     pull_request_id: u64,
     cache: State<'_, BitbucketTokenCache>,
 ) -> Result<String, BitbucketError> {
-    let token = read_token(&workspace_id, &cache)?;
+    let token = read_token(&workspace_id, project_id.as_deref(), &cache)?;
     let credentials = Credentials {
         email: &email,
         token: &token,
@@ -964,13 +971,14 @@ pub async fn bitbucket_pull_request_diff(
 #[tauri::command]
 pub async fn bitbucket_list_pull_request_comments(
     workspace_id: String,
+    project_id: Option<String>,
     workspace_slug: String,
     repo_slug: String,
     email: String,
     pull_request_id: u64,
     cache: State<'_, BitbucketTokenCache>,
 ) -> Result<Vec<BitbucketComment>, BitbucketError> {
-    let token = read_token(&workspace_id, &cache)?;
+    let token = read_token(&workspace_id, project_id.as_deref(), &cache)?;
     let credentials = Credentials {
         email: &email,
         token: &token,
@@ -983,13 +991,14 @@ pub async fn bitbucket_list_pull_request_comments(
 #[tauri::command]
 pub async fn bitbucket_list_pull_request_statuses(
     workspace_id: String,
+    project_id: Option<String>,
     workspace_slug: String,
     repo_slug: String,
     email: String,
     pull_request_id: u64,
     cache: State<'_, BitbucketTokenCache>,
 ) -> Result<Vec<BitbucketStatus>, BitbucketError> {
-    let token = read_token(&workspace_id, &cache)?;
+    let token = read_token(&workspace_id, project_id.as_deref(), &cache)?;
     let credentials = Credentials {
         email: &email,
         token: &token,
@@ -1002,13 +1011,14 @@ pub async fn bitbucket_list_pull_request_statuses(
 #[tauri::command]
 pub async fn bitbucket_pull_request_for_branch(
     workspace_id: String,
+    project_id: Option<String>,
     workspace_slug: String,
     repo_slug: String,
     email: String,
     source_branch: String,
     cache: State<'_, BitbucketTokenCache>,
 ) -> Result<Option<BitbucketPullRequest>, BitbucketError> {
-    let token = read_token(&workspace_id, &cache)?;
+    let token = read_token(&workspace_id, project_id.as_deref(), &cache)?;
     let credentials = Credentials {
         email: &email,
         token: &token,
@@ -1021,13 +1031,14 @@ pub async fn bitbucket_pull_request_for_branch(
 #[tauri::command]
 pub async fn bitbucket_approve_pull_request(
     workspace_id: String,
+    project_id: Option<String>,
     workspace_slug: String,
     repo_slug: String,
     email: String,
     pull_request_id: u64,
     cache: State<'_, BitbucketTokenCache>,
 ) -> Result<BitbucketParticipant, BitbucketError> {
-    let token = read_token(&workspace_id, &cache)?;
+    let token = read_token(&workspace_id, project_id.as_deref(), &cache)?;
     let credentials = Credentials {
         email: &email,
         token: &token,
@@ -1041,13 +1052,14 @@ pub async fn bitbucket_approve_pull_request(
 #[tauri::command]
 pub async fn bitbucket_unapprove_pull_request(
     workspace_id: String,
+    project_id: Option<String>,
     workspace_slug: String,
     repo_slug: String,
     email: String,
     pull_request_id: u64,
     cache: State<'_, BitbucketTokenCache>,
 ) -> Result<(), BitbucketError> {
-    let token = read_token(&workspace_id, &cache)?;
+    let token = read_token(&workspace_id, project_id.as_deref(), &cache)?;
     let credentials = Credentials {
         email: &email,
         token: &token,
@@ -1059,13 +1071,14 @@ pub async fn bitbucket_unapprove_pull_request(
 #[tauri::command]
 pub async fn bitbucket_request_changes(
     workspace_id: String,
+    project_id: Option<String>,
     workspace_slug: String,
     repo_slug: String,
     email: String,
     pull_request_id: u64,
     cache: State<'_, BitbucketTokenCache>,
 ) -> Result<BitbucketParticipant, BitbucketError> {
-    let token = read_token(&workspace_id, &cache)?;
+    let token = read_token(&workspace_id, project_id.as_deref(), &cache)?;
     let credentials = Credentials {
         email: &email,
         token: &token,
@@ -1079,13 +1092,14 @@ pub async fn bitbucket_request_changes(
 #[tauri::command]
 pub async fn bitbucket_unrequest_changes(
     workspace_id: String,
+    project_id: Option<String>,
     workspace_slug: String,
     repo_slug: String,
     email: String,
     pull_request_id: u64,
     cache: State<'_, BitbucketTokenCache>,
 ) -> Result<(), BitbucketError> {
-    let token = read_token(&workspace_id, &cache)?;
+    let token = read_token(&workspace_id, project_id.as_deref(), &cache)?;
     let credentials = Credentials {
         email: &email,
         token: &token,
@@ -1097,6 +1111,7 @@ pub async fn bitbucket_unrequest_changes(
 #[tauri::command]
 pub async fn bitbucket_merge_pull_request(
     workspace_id: String,
+    project_id: Option<String>,
     workspace_slug: String,
     repo_slug: String,
     email: String,
@@ -1105,7 +1120,7 @@ pub async fn bitbucket_merge_pull_request(
     message: Option<String>,
     cache: State<'_, BitbucketTokenCache>,
 ) -> Result<BitbucketPullRequest, BitbucketError> {
-    let token = read_token(&workspace_id, &cache)?;
+    let token = read_token(&workspace_id, project_id.as_deref(), &cache)?;
     let credentials = Credentials {
         email: &email,
         token: &token,
@@ -1126,13 +1141,14 @@ pub async fn bitbucket_merge_pull_request(
 #[tauri::command]
 pub async fn bitbucket_decline_pull_request(
     workspace_id: String,
+    project_id: Option<String>,
     workspace_slug: String,
     repo_slug: String,
     email: String,
     pull_request_id: u64,
     cache: State<'_, BitbucketTokenCache>,
 ) -> Result<BitbucketPullRequest, BitbucketError> {
-    let token = read_token(&workspace_id, &cache)?;
+    let token = read_token(&workspace_id, project_id.as_deref(), &cache)?;
     let credentials = Credentials {
         email: &email,
         token: &token,
@@ -1146,6 +1162,7 @@ pub async fn bitbucket_decline_pull_request(
 #[tauri::command]
 pub async fn bitbucket_create_pull_request_comment(
     workspace_id: String,
+    project_id: Option<String>,
     workspace_slug: String,
     repo_slug: String,
     email: String,
@@ -1153,7 +1170,7 @@ pub async fn bitbucket_create_pull_request_comment(
     body: String,
     cache: State<'_, BitbucketTokenCache>,
 ) -> Result<BitbucketComment, BitbucketError> {
-    let token = read_token(&workspace_id, &cache)?;
+    let token = read_token(&workspace_id, project_id.as_deref(), &cache)?;
     let credentials = Credentials {
         email: &email,
         token: &token,
@@ -1173,6 +1190,7 @@ pub async fn bitbucket_create_pull_request_comment(
 #[tauri::command]
 pub async fn bitbucket_reply_to_pull_request_comment(
     workspace_id: String,
+    project_id: Option<String>,
     workspace_slug: String,
     repo_slug: String,
     email: String,
@@ -1181,7 +1199,7 @@ pub async fn bitbucket_reply_to_pull_request_comment(
     body: String,
     cache: State<'_, BitbucketTokenCache>,
 ) -> Result<BitbucketComment, BitbucketError> {
-    let token = read_token(&workspace_id, &cache)?;
+    let token = read_token(&workspace_id, project_id.as_deref(), &cache)?;
     let credentials = Credentials {
         email: &email,
         token: &token,

--- a/apps/desktop/src-tauri/src/github.rs
+++ b/apps/desktop/src-tauri/src/github.rs
@@ -293,42 +293,43 @@ fn parse_version(stdout: &str) -> Option<String> {
         .and_then(|rest| rest.split_whitespace().next().map(|s| s.to_string()))
 }
 
-fn read_token_from<F>(
+fn read_token_with<F, G>(
     workspace_id: Option<&str>,
     project_id: Option<&str>,
-    mut resolve: F,
+    mut read_binding: F,
+    mut read_global: G,
 ) -> Option<String>
 where
-    F: FnMut(Option<&str>) -> Option<String>,
+    F: FnMut(&str, Option<&str>) -> Option<String>,
+    G: FnMut() -> Option<String>,
 {
-    let mut scopes: Vec<&str> = Vec::new();
-    for id in [workspace_id, project_id]
-        .into_iter()
-        .flatten()
-        .filter(|id| !id.is_empty())
-    {
-        if !scopes.contains(&id) {
-            scopes.push(id);
-        }
+    if let Some(workspace_id) = workspace_id.filter(|id| !id.is_empty()) {
+        return read_binding(workspace_id, project_id.filter(|id| !id.is_empty()));
     }
-    for scope in scopes {
-        if let Some(token) = resolve(Some(scope)) {
-            return Some(token);
-        }
-    }
-    resolve(None)
+    read_global()
 }
 
 pub(crate) fn read_token(workspace_id: Option<&str>, project_id: Option<&str>) -> Option<String> {
     let cache = integration_credentials::SecretCache::default();
-    read_token_from(workspace_id, project_id, |scope| match scope {
-        Some(id) => integration_credentials::read_for_binding(GITHUB_PROVIDER, id, None, &cache)
+    read_token_with(
+        workspace_id,
+        project_id,
+        |workspace_id, project_id| {
+            integration_credentials::read_for_binding(
+                GITHUB_PROVIDER,
+                workspace_id,
+                project_id,
+                &cache,
+            )
             .ok()
-            .flatten(),
-        None => integration_credentials::read_global(GITHUB_PROVIDER, &cache)
-            .ok()
-            .flatten(),
-    })
+            .flatten()
+        },
+        || {
+            integration_credentials::read_global(GITHUB_PROVIDER, &cache)
+                .ok()
+                .flatten()
+        },
+    )
 }
 
 pub(crate) fn token_for_workspace(workspace_id: Option<&str>) -> Option<String> {
@@ -495,7 +496,7 @@ pub async fn gh_pr_diff(
 #[cfg(test)]
 mod tests {
     use super::{
-        command_succeeds, read_token_from, run_binary, run_with_timeout, token_failure_message,
+        command_succeeds, read_token_with, run_binary, run_with_timeout, token_failure_message,
         validate_token_with, GhRunResult, GithubError, BAD_CREDENTIALS_MESSAGE,
         CERTIFICATE_MESSAGE, EMPTY_TOKEN_MESSAGE, EXPIRED_MESSAGE, GH_PROBE_TIMEOUT, GH_TIMEOUT,
         MISSING_SCOPE_MESSAGE, NETWORK_MESSAGE, RATE_LIMIT_MESSAGE, UNVERIFIED_MESSAGE,
@@ -826,76 +827,30 @@ mod tests {
     }
 
     #[test]
-    fn token_fallback_prefers_workspace_then_member_then_global() {
-        let mut reads: Vec<Option<String>> = Vec::new();
-        let token = read_token_from(Some("composite"), Some("member"), |scope| {
-            reads.push(scope.map(str::to_string));
-            (scope == Some("member")).then(|| "member-token".to_string())
-        });
-
-        assert_eq!(token.as_deref(), Some("member-token"));
-        assert_eq!(
-            reads,
-            vec![Some("composite".to_string()), Some("member".to_string())]
+    fn a_project_override_beats_the_workspace_binding() {
+        let token = read_token_with(
+            Some("workspace-1"),
+            Some("project-1"),
+            |workspace_id, project_id| {
+                assert_eq!(workspace_id, "workspace-1");
+                assert_eq!(project_id, Some("project-1"));
+                Some("project-token".to_string())
+            },
+            || panic!("a scoped read must not use the global credential"),
         );
 
-        let mut global_reads: Vec<Option<String>> = Vec::new();
-        let global = read_token_from(Some("composite"), Some("member"), |scope| {
-            global_reads.push(scope.map(str::to_string));
-            scope.is_none().then(|| "global-token".to_string())
-        });
-
-        assert_eq!(global.as_deref(), Some("global-token"));
-        assert_eq!(
-            global_reads,
-            vec![
-                Some("composite".to_string()),
-                Some("member".to_string()),
-                None,
-            ]
-        );
+        assert_eq!(token.as_deref(), Some("project-token"));
     }
 
     #[test]
-    fn clearing_one_workspace_binding_leaves_the_global_credential_serving_it() {
-        let mut reads: Vec<Option<String>> = Vec::new();
-        let token = read_token_from(Some("composite"), None, |scope| {
-            reads.push(scope.map(str::to_string));
-            scope.is_none().then(|| "global-token".to_string())
-        });
+    fn no_workspace_id_degrades_to_the_global_credential() {
+        let token = read_token_with(
+            None,
+            Some("project-1"),
+            |_, _| panic!("a project cannot resolve without a workspace"),
+            || Some("global-token".to_string()),
+        );
 
         assert_eq!(token.as_deref(), Some("global-token"));
-        assert_eq!(reads, vec![Some("composite".to_string()), None]);
-    }
-
-    #[test]
-    fn explicit_workspace_token_wins_before_member() {
-        let mut reads: Vec<Option<String>> = Vec::new();
-        let token = read_token_from(Some("composite"), Some("member"), |scope| {
-            reads.push(scope.map(str::to_string));
-            (scope == Some("composite")).then(|| "workspace-token".to_string())
-        });
-
-        assert_eq!(token.as_deref(), Some("workspace-token"));
-        assert_eq!(reads, vec![Some("composite".to_string())]);
-    }
-
-    #[test]
-    fn a_blank_or_repeated_scope_never_reaches_the_resolver() {
-        let mut reads: Vec<Option<String>> = Vec::new();
-        let token = read_token_from(Some(""), Some("member"), |scope| {
-            reads.push(scope.map(str::to_string));
-            None
-        });
-
-        assert_eq!(token, None);
-        assert_eq!(reads, vec![Some("member".to_string()), None]);
-
-        let mut dedup_reads: Vec<Option<String>> = Vec::new();
-        read_token_from(Some("same"), Some("same"), |scope| {
-            dedup_reads.push(scope.map(str::to_string));
-            None
-        });
-        assert_eq!(dedup_reads, vec![Some("same".to_string()), None]);
     }
 }

--- a/apps/desktop/src-tauri/src/gitlab.rs
+++ b/apps/desktop/src-tauri/src/gitlab.rs
@@ -226,8 +226,12 @@ fn encode_project_path(project_path: &str) -> String {
     percent_encode(project_path.trim().trim_matches('/'))
 }
 
-fn read_token(workspace_id: &str, cache: &GitlabTokenCache) -> Result<String, GitlabError> {
-    integration_credentials::read_for_binding(PROVIDER, workspace_id, None, &cache.0)?
+fn read_token(
+    workspace_id: &str,
+    project_id: Option<&str>,
+    cache: &GitlabTokenCache,
+) -> Result<String, GitlabError> {
+    integration_credentials::read_for_binding(PROVIDER, workspace_id, project_id, &cache.0)?
         .ok_or_else(|| GitlabError::NoToken(workspace_id.to_string()))
 }
 
@@ -293,10 +297,11 @@ pub async fn gitlab_connect(
 #[tauri::command]
 pub async fn gitlab_fetch_assigned_issues(
     workspace_id: String,
+    project_id: Option<String>,
     host: String,
     cache: State<'_, GitlabTokenCache>,
 ) -> Result<Vec<GitlabIssue>, GitlabError> {
-    let token = read_token(&workspace_id, &cache)?;
+    let token = read_token(&workspace_id, project_id.as_deref(), &cache)?;
     get_json(
         &host,
         &token,
@@ -308,12 +313,13 @@ pub async fn gitlab_fetch_assigned_issues(
 #[tauri::command]
 pub async fn gitlab_fetch_issue(
     workspace_id: String,
+    project_id: Option<String>,
     host: String,
     project_path: String,
     issue_iid: i64,
     cache: State<'_, GitlabTokenCache>,
 ) -> Result<GitlabIssue, GitlabError> {
-    let token = read_token(&workspace_id, &cache)?;
+    let token = read_token(&workspace_id, project_id.as_deref(), &cache)?;
     get_json(
         &host,
         &token,
@@ -329,13 +335,14 @@ pub async fn gitlab_fetch_issue(
 #[tauri::command]
 pub async fn gitlab_update_issue(
     workspace_id: String,
+    project_id: Option<String>,
     host: String,
     project_path: String,
     issue_iid: i64,
     description: String,
     cache: State<'_, GitlabTokenCache>,
 ) -> Result<String, GitlabError> {
-    let token = read_token(&workspace_id, &cache)?;
+    let token = read_token(&workspace_id, project_id.as_deref(), &cache)?;
     let encoded = encode_project_path(&project_path);
     let body = serde_json::json!({ "description": description });
     let issue: GitlabIssue = send_json(
@@ -389,10 +396,11 @@ pub struct GitlabMergeRequest {
 #[tauri::command]
 pub async fn gitlab_fetch_assigned_mrs(
     workspace_id: String,
+    project_id: Option<String>,
     host: String,
     cache: State<'_, GitlabTokenCache>,
 ) -> Result<Vec<GitlabMergeRequest>, GitlabError> {
-    let token = read_token(&workspace_id, &cache)?;
+    let token = read_token(&workspace_id, project_id.as_deref(), &cache)?;
     get_json(
         &host,
         &token,
@@ -404,11 +412,12 @@ pub async fn gitlab_fetch_assigned_mrs(
 #[tauri::command]
 pub async fn gitlab_fetch_project_mrs(
     workspace_id: String,
+    project_id: Option<String>,
     host: String,
     project_path: String,
     cache: State<'_, GitlabTokenCache>,
 ) -> Result<Vec<GitlabMergeRequest>, GitlabError> {
-    let token = read_token(&workspace_id, &cache)?;
+    let token = read_token(&workspace_id, project_id.as_deref(), &cache)?;
     let encoded = encode_project_path(&project_path);
     get_json(
         &host,
@@ -421,12 +430,13 @@ pub async fn gitlab_fetch_project_mrs(
 #[tauri::command]
 pub async fn gitlab_mr_for_branch(
     workspace_id: String,
+    project_id: Option<String>,
     host: String,
     project_path: String,
     source_branch: String,
     cache: State<'_, GitlabTokenCache>,
 ) -> Result<Option<GitlabMergeRequest>, GitlabError> {
-    let token = read_token(&workspace_id, &cache)?;
+    let token = read_token(&workspace_id, project_id.as_deref(), &cache)?;
     let encoded = encode_project_path(&project_path);
     let branch = percent_encode(&source_branch);
     let path = format!(
@@ -439,6 +449,7 @@ pub async fn gitlab_mr_for_branch(
 #[tauri::command]
 pub async fn gitlab_create_mr(
     workspace_id: String,
+    project_id: Option<String>,
     host: String,
     project_path: String,
     source_branch: String,
@@ -448,7 +459,7 @@ pub async fn gitlab_create_mr(
     draft: bool,
     cache: State<'_, GitlabTokenCache>,
 ) -> Result<GitlabMergeRequest, GitlabError> {
-    let token = read_token(&workspace_id, &cache)?;
+    let token = read_token(&workspace_id, project_id.as_deref(), &cache)?;
     let encoded = encode_project_path(&project_path);
     let mr_title = if draft {
         format!("Draft: {title}")
@@ -518,12 +529,13 @@ fn assemble_mr_diff(changes: &[GitlabMrChange]) -> String {
 #[tauri::command]
 pub async fn gitlab_mr_diff(
     workspace_id: String,
+    project_id: Option<String>,
     host: String,
     project_path: String,
     mr_iid: i64,
     cache: State<'_, GitlabTokenCache>,
 ) -> Result<String, GitlabError> {
-    let token = read_token(&workspace_id, &cache)?;
+    let token = read_token(&workspace_id, project_id.as_deref(), &cache)?;
     let encoded = encode_project_path(&project_path);
     let payload: GitlabMrChanges = get_json(
         &host,
@@ -553,12 +565,13 @@ pub struct GitlabMrRefsPayload {
 #[tauri::command]
 pub async fn gitlab_mr_diff_refs(
     workspace_id: String,
+    project_id: Option<String>,
     host: String,
     project_path: String,
     mr_iid: i64,
     cache: State<'_, GitlabTokenCache>,
 ) -> Result<GitlabDiffRefs, GitlabError> {
-    let token = read_token(&workspace_id, &cache)?;
+    let token = read_token(&workspace_id, project_id.as_deref(), &cache)?;
     let encoded = encode_project_path(&project_path);
     let payload: GitlabMrRefsPayload = get_json(
         &host,
@@ -614,6 +627,7 @@ pub struct GitlabDiscussion {
 #[tauri::command]
 pub async fn gitlab_create_mr_discussion(
     workspace_id: String,
+    project_id: Option<String>,
     host: String,
     project_path: String,
     mr_iid: i64,
@@ -621,7 +635,7 @@ pub async fn gitlab_create_mr_discussion(
     position: GitlabDiscussionPosition,
     cache: State<'_, GitlabTokenCache>,
 ) -> Result<String, GitlabError> {
-    let token = read_token(&workspace_id, &cache)?;
+    let token = read_token(&workspace_id, project_id.as_deref(), &cache)?;
     let encoded = encode_project_path(&project_path);
     let payload = discussion_payload(&body, &position);
     let discussion: GitlabDiscussion = send_json(
@@ -643,13 +657,14 @@ pub struct GitlabNote {
 #[tauri::command]
 pub async fn gitlab_create_mr_note(
     workspace_id: String,
+    project_id: Option<String>,
     host: String,
     project_path: String,
     mr_iid: i64,
     body: String,
     cache: State<'_, GitlabTokenCache>,
 ) -> Result<i64, GitlabError> {
-    let token = read_token(&workspace_id, &cache)?;
+    let token = read_token(&workspace_id, project_id.as_deref(), &cache)?;
     let encoded = encode_project_path(&project_path);
     let note: GitlabNote = send_json(
         reqwest::Method::POST,
@@ -705,12 +720,13 @@ pub struct GitlabMrDiscussion {
 #[tauri::command]
 pub async fn gitlab_list_mr_discussions(
     workspace_id: String,
+    project_id: Option<String>,
     host: String,
     project_path: String,
     mr_iid: i64,
     cache: State<'_, GitlabTokenCache>,
 ) -> Result<Vec<GitlabMrDiscussion>, GitlabError> {
-    let token = read_token(&workspace_id, &cache)?;
+    let token = read_token(&workspace_id, project_id.as_deref(), &cache)?;
     let encoded = encode_project_path(&project_path);
     get_json_paged(
         &host,
@@ -723,6 +739,7 @@ pub async fn gitlab_list_mr_discussions(
 #[tauri::command]
 pub async fn gitlab_reply_to_mr_discussion(
     workspace_id: String,
+    project_id: Option<String>,
     host: String,
     project_path: String,
     mr_iid: i64,
@@ -730,7 +747,7 @@ pub async fn gitlab_reply_to_mr_discussion(
     body: String,
     cache: State<'_, GitlabTokenCache>,
 ) -> Result<i64, GitlabError> {
-    let token = read_token(&workspace_id, &cache)?;
+    let token = read_token(&workspace_id, project_id.as_deref(), &cache)?;
     let encoded = encode_project_path(&project_path);
     let discussion = percent_encode(&discussion_id);
     let note: GitlabNote = send_json(
@@ -760,6 +777,7 @@ fn mr_discussion_resolve_path(
 #[tauri::command]
 pub async fn gitlab_resolve_mr_discussion(
     workspace_id: String,
+    project_id: Option<String>,
     host: String,
     project_path: String,
     mr_iid: i64,
@@ -767,7 +785,7 @@ pub async fn gitlab_resolve_mr_discussion(
     resolved: bool,
     cache: State<'_, GitlabTokenCache>,
 ) -> Result<GitlabMrDiscussion, GitlabError> {
-    let token = read_token(&workspace_id, &cache)?;
+    let token = read_token(&workspace_id, project_id.as_deref(), &cache)?;
     send_json(
         reqwest::Method::PUT,
         &host,
@@ -794,12 +812,13 @@ pub struct GitlabIssueNote {
 #[tauri::command]
 pub async fn gitlab_list_issue_notes(
     workspace_id: String,
+    project_id: Option<String>,
     host: String,
     project_path: String,
     issue_iid: i64,
     cache: State<'_, GitlabTokenCache>,
 ) -> Result<Vec<GitlabIssueNote>, GitlabError> {
-    let token = read_token(&workspace_id, &cache)?;
+    let token = read_token(&workspace_id, project_id.as_deref(), &cache)?;
     let encoded = encode_project_path(&project_path);
     get_json_paged(
         &host,
@@ -812,13 +831,14 @@ pub async fn gitlab_list_issue_notes(
 #[tauri::command]
 pub async fn gitlab_create_issue_note(
     workspace_id: String,
+    project_id: Option<String>,
     host: String,
     project_path: String,
     issue_iid: i64,
     body: String,
     cache: State<'_, GitlabTokenCache>,
 ) -> Result<i64, GitlabError> {
-    let token = read_token(&workspace_id, &cache)?;
+    let token = read_token(&workspace_id, project_id.as_deref(), &cache)?;
     let encoded = encode_project_path(&project_path);
     let note: GitlabNote = send_json(
         reqwest::Method::POST,
@@ -867,12 +887,13 @@ async fn read_approval_state(
 #[tauri::command]
 pub async fn gitlab_mr_approval_state(
     workspace_id: String,
+    project_id: Option<String>,
     host: String,
     project_path: String,
     mr_iid: i64,
     cache: State<'_, GitlabTokenCache>,
 ) -> Result<Option<GitlabMrApprovalState>, GitlabError> {
-    let token = read_token(&workspace_id, &cache)?;
+    let token = read_token(&workspace_id, project_id.as_deref(), &cache)?;
     let encoded = encode_project_path(&project_path);
     read_approval_state(&host, &token, &encoded, mr_iid).await
 }
@@ -880,12 +901,13 @@ pub async fn gitlab_mr_approval_state(
 #[tauri::command]
 pub async fn gitlab_approve_mr(
     workspace_id: String,
+    project_id: Option<String>,
     host: String,
     project_path: String,
     mr_iid: i64,
     cache: State<'_, GitlabTokenCache>,
 ) -> Result<Option<GitlabMrApprovalState>, GitlabError> {
-    let token = read_token(&workspace_id, &cache)?;
+    let token = read_token(&workspace_id, project_id.as_deref(), &cache)?;
     let encoded = encode_project_path(&project_path);
     send_no_content(
         reqwest::Method::POST,
@@ -901,12 +923,13 @@ pub async fn gitlab_approve_mr(
 #[tauri::command]
 pub async fn gitlab_unapprove_mr(
     workspace_id: String,
+    project_id: Option<String>,
     host: String,
     project_path: String,
     mr_iid: i64,
     cache: State<'_, GitlabTokenCache>,
 ) -> Result<Option<GitlabMrApprovalState>, GitlabError> {
-    let token = read_token(&workspace_id, &cache)?;
+    let token = read_token(&workspace_id, project_id.as_deref(), &cache)?;
     let encoded = encode_project_path(&project_path);
     send_no_content(
         reqwest::Method::POST,
@@ -933,6 +956,7 @@ fn mr_update_payload(state_event: Option<&str>, title: Option<&str>) -> serde_js
 #[tauri::command]
 pub async fn gitlab_update_mr_state(
     workspace_id: String,
+    project_id: Option<String>,
     host: String,
     project_path: String,
     mr_iid: i64,
@@ -940,7 +964,7 @@ pub async fn gitlab_update_mr_state(
     title: Option<String>,
     cache: State<'_, GitlabTokenCache>,
 ) -> Result<GitlabMergeRequest, GitlabError> {
-    let token = read_token(&workspace_id, &cache)?;
+    let token = read_token(&workspace_id, project_id.as_deref(), &cache)?;
     let encoded = encode_project_path(&project_path);
     let payload = mr_update_payload(state_event.as_deref(), title.as_deref());
     if payload.as_object().map(|map| map.is_empty()) == Some(true) {
@@ -961,12 +985,13 @@ pub async fn gitlab_update_mr_state(
 #[tauri::command]
 pub async fn gitlab_merge_mr(
     workspace_id: String,
+    project_id: Option<String>,
     host: String,
     project_path: String,
     mr_iid: i64,
     cache: State<'_, GitlabTokenCache>,
 ) -> Result<GitlabMergeRequest, GitlabError> {
-    let token = read_token(&workspace_id, &cache)?;
+    let token = read_token(&workspace_id, project_id.as_deref(), &cache)?;
     let encoded = encode_project_path(&project_path);
     send_json(
         reqwest::Method::PUT,

--- a/apps/desktop/src-tauri/src/integration_credentials.rs
+++ b/apps/desktop/src-tauri/src/integration_credentials.rs
@@ -18,8 +18,11 @@ pub enum IntegrationCredentialError {
     MissingWorkspace,
     #[error("a credential id is required")]
     MissingCredential,
-    #[error("no {0} credential is stored under that id")]
-    NoCredential(String),
+    #[error("the {provider} key for this connection is missing from the keychain, paste it again to reconnect")]
+    MissingSecret {
+        provider: String,
+        credential_id: String,
+    },
     #[error("credential store error: {0}")]
     Store(String),
     #[error("secret store error: {0}")]
@@ -34,7 +37,7 @@ impl IntegrationCredentialError {
             IntegrationCredentialError::UnknownProvider(_) => "unknown_provider",
             IntegrationCredentialError::MissingWorkspace => "missing_workspace",
             IntegrationCredentialError::MissingCredential => "missing_credential",
-            IntegrationCredentialError::NoCredential(_) => "no_credential",
+            IntegrationCredentialError::MissingSecret { .. } => "missing_secret",
             IntegrationCredentialError::Store(_) => "store",
             IntegrationCredentialError::Secret(_) => "secret",
         }
@@ -127,17 +130,26 @@ fn global_credential_id(
     conn: &Connection,
     provider: &str,
 ) -> Result<Option<String>, IntegrationCredentialError> {
-    conn.query_row(
-        "SELECT c.id FROM integration_credentials c
-         WHERE c.provider = ?1
-           AND NOT EXISTS (SELECT 1 FROM integration_bindings b WHERE b.credential_id = c.id)
-         ORDER BY c.updated_at DESC, c.id ASC
-         LIMIT 1",
-        rusqlite::params![provider],
-        |row| row.get(0),
-    )
-    .optional()
-    .map_err(store_err)
+    Ok(global_credential_ids(conn, provider)?.into_iter().next())
+}
+
+/// Every credential no binding references, newest first.
+fn global_credential_ids(
+    conn: &Connection,
+    provider: &str,
+) -> Result<Vec<String>, IntegrationCredentialError> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT c.id FROM integration_credentials c
+             WHERE c.provider = ?1
+               AND NOT EXISTS (SELECT 1 FROM integration_bindings b WHERE b.credential_id = c.id)
+             ORDER BY c.updated_at DESC, c.id ASC",
+        )
+        .map_err(store_err)?;
+    let rows = stmt
+        .query_map(rusqlite::params![provider], |row| row.get(0))
+        .map_err(store_err)?;
+    rows.collect::<Result<Vec<_>, _>>().map_err(store_err)
 }
 
 fn config_for_binding_in(
@@ -212,8 +224,12 @@ fn read_for_credential(
     if let Some(hit) = cached(cache, credential_id) {
         return Ok(hit);
     }
-    let secret = secrets::read(&secret_key(credential_id))?
-        .ok_or_else(|| IntegrationCredentialError::NoCredential(provider.to_string()))?;
+    let secret = secrets::read(&secret_key(credential_id))?.ok_or_else(|| {
+        IntegrationCredentialError::MissingSecret {
+            provider: provider.to_string(),
+            credential_id: credential_id.to_string(),
+        }
+    })?;
     remember(cache, credential_id, &secret);
     Ok(secret)
 }
@@ -237,15 +253,54 @@ pub(crate) fn read_for_binding(
         return Err(IntegrationCredentialError::MissingWorkspace);
     }
     let conn = open_db()?;
-    let bound = credential_id_for_binding(&conn, provider, workspace_id, project_id)?;
-    let credential_id = match bound {
-        Some(id) => Some(id),
-        None => global_credential_id(&conn, provider)?,
-    };
-    let Some(credential_id) = credential_id else {
-        return Ok(None);
-    };
-    read_for_credential(provider, &credential_id, cache).map(Some)
+    resolve_and_read(
+        &conn,
+        provider,
+        workspace_id,
+        project_id,
+        |credential_id| match cached(cache, credential_id) {
+            Some(hit) => Ok(Some(hit)),
+            None => {
+                let found = secrets::read(&secret_key(credential_id))?;
+                if let Some(secret) = found.as_deref() {
+                    remember(cache, credential_id, secret);
+                }
+                Ok(found)
+            }
+        },
+    )
+}
+
+/// A bound credential is the scope's declared account, so a missing secret is
+/// an error rather than a reason to reach for another one. Only the unbound
+/// tier, where no scope declared anything, may skip a credential it cannot read.
+fn resolve_and_read<F>(
+    conn: &Connection,
+    provider: &str,
+    workspace_id: &str,
+    project_id: Option<&str>,
+    mut read_secret: F,
+) -> Result<Option<String>, IntegrationCredentialError>
+where
+    F: FnMut(&str) -> Result<Option<String>, secrets::SecretError>,
+{
+    if let Some(credential_id) =
+        credential_id_for_binding(conn, provider, workspace_id, project_id)?
+    {
+        return match read_secret(&credential_id)? {
+            Some(secret) => Ok(Some(secret)),
+            None => Err(IntegrationCredentialError::MissingSecret {
+                provider: provider.to_string(),
+                credential_id,
+            }),
+        };
+    }
+    for credential_id in global_credential_ids(conn, provider)? {
+        if let Some(secret) = read_secret(&credential_id)? {
+            return Ok(Some(secret));
+        }
+    }
+    Ok(None)
 }
 
 /// The provider-wide fallback alone, for callers that hold no workspace.
@@ -546,7 +601,55 @@ pub fn integration_credentials_adopt() -> Result<usize, IntegrationCredentialErr
     let legacy = adopt_with(&bindings, secrets::read, secrets::set, secrets::clear)?;
     let conn = open_db()?;
     let github = adopt_github_with(&conn, secrets::read, secrets::set, secrets::clear)?;
+    sweep_orphan_credentials(&conn, secrets::read)?;
     Ok(legacy + github)
+}
+
+/// A credential no binding claims and no keychain entry backs can never resolve
+/// to anything, and it would shadow a healthy one in the unbound tier. Only the
+/// row goes: a credential a scope still names stays, broken and visible.
+fn sweep_orphan_credentials<R>(
+    conn: &Connection,
+    mut read_secret: R,
+) -> Result<usize, IntegrationCredentialError>
+where
+    R: FnMut(&str) -> Result<Option<String>, secrets::SecretError>,
+{
+    let mut stmt = conn
+        .prepare(
+            "SELECT c.id FROM integration_credentials c
+             WHERE NOT EXISTS (SELECT 1 FROM integration_bindings b WHERE b.credential_id = c.id)",
+        )
+        .map_err(store_err)?;
+    let rows = stmt
+        .query_map([], |row| row.get::<_, String>(0))
+        .map_err(store_err)?;
+    let unbound = rows.collect::<Result<Vec<_>, _>>().map_err(store_err)?;
+    let mut swept = 0;
+    for credential_id in unbound {
+        if read_secret(&secret_key(&credential_id))?.is_some() {
+            continue;
+        }
+        conn.execute(
+            "DELETE FROM integration_credentials WHERE id = ?1",
+            rusqlite::params![credential_id],
+        )
+        .map_err(store_err)?;
+        swept += 1;
+    }
+    Ok(swept)
+}
+
+/// Whether the keychain still holds the secret a credential claims to own.
+/// A binding whose credential answers false is connected on paper only.
+#[tauri::command]
+pub fn integration_credential_has_secret(
+    credential_id: String,
+) -> Result<bool, IntegrationCredentialError> {
+    if credential_id.is_empty() {
+        return Err(IntegrationCredentialError::MissingCredential);
+    }
+    Ok(secrets::read(&secret_key(&credential_id))?.is_some())
 }
 
 /// Removes the secret itself. The row is deleted first on the database side,
@@ -671,6 +774,121 @@ mod tests {
         assert_eq!(with_override.as_deref(), Some("cred-proj"));
         assert_eq!(without.as_deref(), Some("cred-ws"));
         assert_eq!(other_project.as_deref(), Some("cred-ws"));
+    }
+
+    #[test]
+    fn a_project_override_is_read_even_when_the_workspace_key_is_gone() {
+        let conn = test_conn();
+        seed_credential(&conn, "cred-dead", "linear");
+        seed_credential(&conn, "cred-live", "linear");
+        seed_binding(&conn, "b-ws", "container-1", None, "linear", "cred-dead");
+        seed_binding(
+            &conn,
+            "b-proj",
+            "container-1",
+            Some("app-web"),
+            "linear",
+            "cred-live",
+        );
+        let read = |id: &str| match id {
+            "cred-live" => Ok(Some("live-token".to_string())),
+            _ => Ok(None),
+        };
+
+        let scoped = resolve_and_read(&conn, "linear", "container-1", Some("app-web"), read)
+            .expect("resolves");
+        let unscoped = resolve_and_read(&conn, "linear", "container-1", None, read);
+
+        assert_eq!(scoped.as_deref(), Some("live-token"));
+        assert!(matches!(
+            unscoped,
+            Err(IntegrationCredentialError::MissingSecret { ref credential_id, .. })
+                if credential_id == "cred-dead"
+        ));
+    }
+
+    #[test]
+    fn a_bound_credential_without_a_key_never_borrows_another_account() {
+        let conn = test_conn();
+        seed_credential(&conn, "cred-bound", "linear");
+        seed_credential(&conn, "cred-free", "linear");
+        seed_binding(&conn, "b-ws", "container-1", None, "linear", "cred-bound");
+        let read = |id: &str| match id {
+            "cred-free" => Ok(Some("someone-elses-token".to_string())),
+            _ => Ok(None),
+        };
+
+        let resolved = resolve_and_read(&conn, "linear", "container-1", None, read);
+
+        assert!(matches!(
+            resolved,
+            Err(IntegrationCredentialError::MissingSecret { .. })
+        ));
+    }
+
+    #[test]
+    fn the_unbound_tier_skips_a_credential_it_cannot_read() {
+        let conn = test_conn();
+        seed_credential(&conn, "cred-newer", "linear");
+        seed_credential(&conn, "cred-older", "linear");
+        conn.execute(
+            "UPDATE integration_credentials SET updated_at = 2 WHERE id = 'cred-newer'",
+            [],
+        )
+        .expect("touch");
+        let read = |id: &str| match id {
+            "cred-older" => Ok(Some("older-token".to_string())),
+            _ => Ok(None),
+        };
+
+        let resolved =
+            resolve_and_read(&conn, "linear", "container-1", None, read).expect("resolves");
+
+        assert_eq!(resolved.as_deref(), Some("older-token"));
+    }
+
+    #[test]
+    fn a_scope_with_no_binding_and_no_credential_resolves_to_nothing() {
+        let conn = test_conn();
+
+        let resolved =
+            resolve_and_read(&conn, "linear", "container-1", None, |_| Ok(None)).expect("resolves");
+
+        assert_eq!(resolved, None);
+    }
+
+    #[test]
+    fn the_sweep_drops_only_credentials_nothing_claims_and_nothing_backs() {
+        let conn = test_conn();
+        seed_credential(&conn, "cred-bound-dead", "linear");
+        seed_credential(&conn, "cred-free-dead", "linear");
+        seed_credential(&conn, "cred-free-live", "linear");
+        seed_binding(
+            &conn,
+            "b-ws",
+            "container-1",
+            None,
+            "linear",
+            "cred-bound-dead",
+        );
+        let read = |key: &str| match key {
+            "goodboy.credential.cred-free-live" => Ok(Some("live".to_string())),
+            _ => Ok(None),
+        };
+
+        let swept = sweep_orphan_credentials(&conn, read).expect("sweeps");
+        let again = sweep_orphan_credentials(&conn, read).expect("sweeps");
+        let left = conn
+            .prepare("SELECT id FROM integration_credentials ORDER BY id")
+            .expect("prepare")
+            .query_map([], |row| row.get::<_, String>(0))
+            .expect("query")
+            .collect::<Result<Vec<_>, _>>()
+            .expect("rows");
+
+        assert_eq!(swept, 1);
+        assert_eq!(again, 0);
+        assert_eq!(left, vec!["cred-bound-dead", "cred-free-live"]);
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/jira.rs
+++ b/apps/desktop/src-tauri/src/jira.rs
@@ -261,8 +261,12 @@ async fn send_no_content(
     Ok(())
 }
 
-fn read_token(workspace_id: &str, cache: &JiraTokenCache) -> Result<String, JiraError> {
-    integration_credentials::read_for_binding(PROVIDER, workspace_id, None, &cache.0)?
+fn read_token(
+    workspace_id: &str,
+    project_id: Option<&str>,
+    cache: &JiraTokenCache,
+) -> Result<String, JiraError> {
+    integration_credentials::read_for_binding(PROVIDER, workspace_id, project_id, &cache.0)?
         .ok_or_else(|| JiraError::NoToken(workspace_id.to_string()))
 }
 
@@ -820,13 +824,14 @@ pub async fn jira_connect(
 #[tauri::command]
 pub async fn jira_list_issues(
     workspace_id: String,
+    project_id: Option<String>,
     site_url: String,
     email: String,
     project_key: String,
     assigned_only: bool,
     cache: State<'_, JiraTokenCache>,
 ) -> Result<Vec<JiraIssue>, JiraError> {
-    let token = read_token(&workspace_id, &cache)?;
+    let token = read_token(&workspace_id, project_id.as_deref(), &cache)?;
     let root = site_root(&site_url)?;
     let base = api_base(&site_url)?;
     let credentials = Credentials {
@@ -845,12 +850,13 @@ pub async fn jira_list_issues(
 #[tauri::command]
 pub async fn jira_get_issue(
     workspace_id: String,
+    project_id: Option<String>,
     site_url: String,
     email: String,
     issue_key: String,
     cache: State<'_, JiraTokenCache>,
 ) -> Result<JiraIssue, JiraError> {
-    let token = read_token(&workspace_id, &cache)?;
+    let token = read_token(&workspace_id, project_id.as_deref(), &cache)?;
     let root = site_root(&site_url)?;
     let base = api_base(&site_url)?;
     let credentials = Credentials {
@@ -870,12 +876,13 @@ pub async fn jira_get_issue(
 #[tauri::command]
 pub async fn jira_list_comments(
     workspace_id: String,
+    project_id: Option<String>,
     site_url: String,
     email: String,
     issue_key: String,
     cache: State<'_, JiraTokenCache>,
 ) -> Result<Vec<JiraComment>, JiraError> {
-    let token = read_token(&workspace_id, &cache)?;
+    let token = read_token(&workspace_id, project_id.as_deref(), &cache)?;
     let root = site_root(&site_url)?;
     let base = api_base(&site_url)?;
     let credentials = Credentials {
@@ -903,13 +910,14 @@ pub async fn jira_list_comments(
 #[tauri::command]
 pub async fn jira_create_comment(
     workspace_id: String,
+    project_id: Option<String>,
     site_url: String,
     email: String,
     issue_key: String,
     body: String,
     cache: State<'_, JiraTokenCache>,
 ) -> Result<JiraComment, JiraError> {
-    let token = read_token(&workspace_id, &cache)?;
+    let token = read_token(&workspace_id, project_id.as_deref(), &cache)?;
     let root = site_root(&site_url)?;
     let base = api_base(&site_url)?;
     let credentials = Credentials {
@@ -926,13 +934,14 @@ pub async fn jira_create_comment(
 #[tauri::command]
 pub async fn jira_update_issue(
     workspace_id: String,
+    project_id: Option<String>,
     site_url: String,
     email: String,
     issue_key: String,
     description: String,
     cache: State<'_, JiraTokenCache>,
 ) -> Result<(), JiraError> {
-    let token = read_token(&workspace_id, &cache)?;
+    let token = read_token(&workspace_id, project_id.as_deref(), &cache)?;
     let root = site_root(&site_url)?;
     let base = api_base(&site_url)?;
     let credentials = Credentials {
@@ -947,13 +956,14 @@ pub async fn jira_update_issue(
 #[tauri::command]
 pub async fn jira_set_assignee(
     workspace_id: String,
+    project_id: Option<String>,
     site_url: String,
     email: String,
     issue_key: String,
     account_id: Option<String>,
     cache: State<'_, JiraTokenCache>,
 ) -> Result<(), JiraError> {
-    let token = read_token(&workspace_id, &cache)?;
+    let token = read_token(&workspace_id, project_id.as_deref(), &cache)?;
     let root = site_root(&site_url)?;
     let base = api_base(&site_url)?;
     let credentials = Credentials {
@@ -968,13 +978,14 @@ pub async fn jira_set_assignee(
 #[tauri::command]
 pub async fn jira_list_assignable_users(
     workspace_id: String,
+    project_id: Option<String>,
     site_url: String,
     email: String,
     issue_key: String,
     query: Option<String>,
     cache: State<'_, JiraTokenCache>,
 ) -> Result<Vec<JiraUser>, JiraError> {
-    let token = read_token(&workspace_id, &cache)?;
+    let token = read_token(&workspace_id, project_id.as_deref(), &cache)?;
     let root = site_root(&site_url)?;
     let base = api_base(&site_url)?;
     let credentials = Credentials {
@@ -992,12 +1003,13 @@ pub async fn jira_list_assignable_users(
 #[tauri::command]
 pub async fn jira_list_transitions(
     workspace_id: String,
+    project_id: Option<String>,
     site_url: String,
     email: String,
     issue_key: String,
     cache: State<'_, JiraTokenCache>,
 ) -> Result<Vec<JiraTransition>, JiraError> {
-    let token = read_token(&workspace_id, &cache)?;
+    let token = read_token(&workspace_id, project_id.as_deref(), &cache)?;
     let root = site_root(&site_url)?;
     let base = api_base(&site_url)?;
     let credentials = Credentials {
@@ -1016,13 +1028,14 @@ pub async fn jira_list_transitions(
 #[tauri::command]
 pub async fn jira_transition_issue(
     workspace_id: String,
+    project_id: Option<String>,
     site_url: String,
     email: String,
     issue_key: String,
     transition_id: String,
     cache: State<'_, JiraTokenCache>,
 ) -> Result<(), JiraError> {
-    let token = read_token(&workspace_id, &cache)?;
+    let token = read_token(&workspace_id, project_id.as_deref(), &cache)?;
     let root = site_root(&site_url)?;
     let base = api_base(&site_url)?;
     let credentials = Credentials {

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -349,6 +349,7 @@ pub fn run() {
             github::gh_pr_diff,
             integration_credentials::integration_credentials_adopt,
             integration_credentials::integration_credential_forget,
+            integration_credentials::integration_credential_has_secret,
             linear::linear_validate_connection,
             linear::linear_connect,
             linear::linear_fetch_assigned_issues,

--- a/apps/desktop/src-tauri/src/linear.rs
+++ b/apps/desktop/src-tauri/src/linear.rs
@@ -102,8 +102,12 @@ async fn graphql<T: serde::de::DeserializeOwned>(
     serde_json::from_value(data).map_err(|e| LinearError::InvalidShape(e.to_string()))
 }
 
-fn read_token(workspace_id: &str, cache: &LinearTokenCache) -> Result<String, LinearError> {
-    integration_credentials::read_for_binding(PROVIDER, workspace_id, None, &cache.0)?
+fn read_token(
+    workspace_id: &str,
+    project_id: Option<&str>,
+    cache: &LinearTokenCache,
+) -> Result<String, LinearError> {
+    integration_credentials::read_for_binding(PROVIDER, workspace_id, project_id, &cache.0)?
         .ok_or_else(|| LinearError::NoToken(workspace_id.to_string()))
 }
 
@@ -344,10 +348,11 @@ pub async fn linear_connect(
 #[tauri::command]
 pub async fn linear_fetch_assigned_issues(
     workspace_id: String,
+    project_id: Option<String>,
     team_id: Option<String>,
     cache: State<'_, LinearTokenCache>,
 ) -> Result<Vec<LinearIssue>, LinearError> {
-    let token = read_token(&workspace_id, &cache)?;
+    let token = read_token(&workspace_id, project_id.as_deref(), &cache)?;
     let mut filter = serde_json::json!({
         "assignee": { "isMe": { "eq": true } },
         "state": { "type": { "nin": ["completed", "canceled"] } }
@@ -367,10 +372,11 @@ pub async fn linear_fetch_assigned_issues(
 #[tauri::command]
 pub async fn linear_fetch_issue(
     workspace_id: String,
+    project_id: Option<String>,
     issue_id: String,
     cache: State<'_, LinearTokenCache>,
 ) -> Result<LinearIssue, LinearError> {
-    let token = read_token(&workspace_id, &cache)?;
+    let token = read_token(&workspace_id, project_id.as_deref(), &cache)?;
     let resp: IssueResponse = graphql(
         &token,
         ISSUE_QUERY,
@@ -384,10 +390,11 @@ pub async fn linear_fetch_issue(
 #[tauri::command]
 pub async fn linear_fetch_issue_comments(
     workspace_id: String,
+    project_id: Option<String>,
     issue_id: String,
     cache: State<'_, LinearTokenCache>,
 ) -> Result<Vec<LinearIssueComment>, LinearError> {
-    let token = read_token(&workspace_id, &cache)?;
+    let token = read_token(&workspace_id, project_id.as_deref(), &cache)?;
     let resp: IssueCommentsResponse = graphql(
         &token,
         ISSUE_COMMENTS_QUERY,
@@ -406,11 +413,12 @@ pub async fn linear_fetch_issue_comments(
 #[tauri::command]
 pub async fn linear_create_comment(
     workspace_id: String,
+    project_id: Option<String>,
     issue_id: String,
     body: String,
     cache: State<'_, LinearTokenCache>,
 ) -> Result<LinearIssueComment, LinearError> {
-    let token = read_token(&workspace_id, &cache)?;
+    let token = read_token(&workspace_id, project_id.as_deref(), &cache)?;
     let resp: CommentCreateResponse = graphql(
         &token,
         COMMENT_CREATE_MUTATION,
@@ -431,11 +439,12 @@ pub async fn linear_create_comment(
 #[tauri::command]
 pub async fn linear_update_issue(
     workspace_id: String,
+    project_id: Option<String>,
     issue_id: String,
     description: String,
     cache: State<'_, LinearTokenCache>,
 ) -> Result<String, LinearError> {
-    let token = read_token(&workspace_id, &cache)?;
+    let token = read_token(&workspace_id, project_id.as_deref(), &cache)?;
     let resp: IssueUpdateResponse = graphql(
         &token,
         ISSUE_UPDATE_MUTATION,

--- a/apps/desktop/src-tauri/src/query_bridge/dispatch.rs
+++ b/apps/desktop/src-tauri/src/query_bridge/dispatch.rs
@@ -149,6 +149,7 @@ async fn run_read(
         ("linear", "issue") => encode(
             crate::linear::linear_fetch_issue(
                 scope.workspace.to_string(),
+                scope.project.clone(),
                 text(args, "id")?,
                 app.state(),
             )
@@ -158,6 +159,7 @@ async fn run_read(
         ("linear", "issues-assigned") => encode(
             crate::linear::linear_fetch_assigned_issues(
                 scope.workspace.to_string(),
+                scope.project.clone(),
                 optional_text(args, "team"),
                 app.state(),
             )
@@ -167,6 +169,7 @@ async fn run_read(
         ("linear", "comments") => encode(
             crate::linear::linear_fetch_issue_comments(
                 scope.workspace.to_string(),
+                scope.project.clone(),
                 text(args, "id")?,
                 app.state(),
             )
@@ -176,6 +179,7 @@ async fn run_read(
         ("sentry", "issues") => encode(
             crate::sentry::sentry_fetch_issues(
                 scope.workspace.to_string(),
+                scope.project.clone(),
                 optional_text(args, "query"),
                 optional_text(args, "cursor"),
                 app.state(),
@@ -186,6 +190,7 @@ async fn run_read(
         ("sentry", "issue") => encode(
             crate::sentry::sentry_fetch_issue(
                 scope.workspace.to_string(),
+                scope.project.clone(),
                 text(args, "id")?,
                 app.state(),
             )
@@ -195,6 +200,7 @@ async fn run_read(
         ("sentry", "issue-detail") => encode(
             crate::sentry::sentry_fetch_issue_detail(
                 scope.workspace.to_string(),
+                scope.project.clone(),
                 text(args, "id")?,
                 app.state(),
             )
@@ -223,6 +229,7 @@ async fn run_read(
         ("gitlab", "issues-assigned") => encode(
             crate::gitlab::gitlab_fetch_assigned_issues(
                 scope.workspace.to_string(),
+                scope.project.clone(),
                 config_field("gitlab", scope, "host")?,
                 app.state(),
             )
@@ -232,6 +239,7 @@ async fn run_read(
         ("gitlab", "issue") => encode(
             crate::gitlab::gitlab_fetch_issue(
                 scope.workspace.to_string(),
+                scope.project.clone(),
                 config_field("gitlab", scope, "host")?,
                 text(args, "project")?,
                 number(args, "iid")?,
@@ -243,6 +251,7 @@ async fn run_read(
         ("gitlab", "issue-notes") => encode(
             crate::gitlab::gitlab_list_issue_notes(
                 scope.workspace.to_string(),
+                scope.project.clone(),
                 config_field("gitlab", scope, "host")?,
                 text(args, "project")?,
                 number(args, "iid")?,
@@ -254,6 +263,7 @@ async fn run_read(
         ("gitlab", "mrs-assigned") => encode(
             crate::gitlab::gitlab_fetch_assigned_mrs(
                 scope.workspace.to_string(),
+                scope.project.clone(),
                 config_field("gitlab", scope, "host")?,
                 app.state(),
             )
@@ -263,6 +273,7 @@ async fn run_read(
         ("gitlab", "mrs") => encode(
             crate::gitlab::gitlab_fetch_project_mrs(
                 scope.workspace.to_string(),
+                scope.project.clone(),
                 config_field("gitlab", scope, "host")?,
                 text(args, "project")?,
                 app.state(),
@@ -273,6 +284,7 @@ async fn run_read(
         ("gitlab", "mr-for-branch") => encode(
             crate::gitlab::gitlab_mr_for_branch(
                 scope.workspace.to_string(),
+                scope.project.clone(),
                 config_field("gitlab", scope, "host")?,
                 text(args, "project")?,
                 text(args, "branch")?,
@@ -284,6 +296,7 @@ async fn run_read(
         ("gitlab", "mr-diff") => encode(
             crate::gitlab::gitlab_mr_diff(
                 scope.workspace.to_string(),
+                scope.project.clone(),
                 config_field("gitlab", scope, "host")?,
                 text(args, "project")?,
                 number(args, "iid")?,
@@ -295,6 +308,7 @@ async fn run_read(
         ("gitlab", "mr-discussions") => encode(
             crate::gitlab::gitlab_list_mr_discussions(
                 scope.workspace.to_string(),
+                scope.project.clone(),
                 config_field("gitlab", scope, "host")?,
                 text(args, "project")?,
                 number(args, "iid")?,
@@ -306,6 +320,7 @@ async fn run_read(
         ("gitlab", "mr-approval-state") => encode(
             crate::gitlab::gitlab_mr_approval_state(
                 scope.workspace.to_string(),
+                scope.project.clone(),
                 config_field("gitlab", scope, "host")?,
                 text(args, "project")?,
                 number(args, "iid")?,
@@ -317,6 +332,7 @@ async fn run_read(
         ("jira", "issues") => encode(
             crate::jira::jira_list_issues(
                 scope.workspace.to_string(),
+                scope.project.clone(),
                 config_field("jira", scope, "siteUrl")?,
                 config_field("jira", scope, "email")?,
                 match optional_text(args, "project") {
@@ -332,6 +348,7 @@ async fn run_read(
         ("jira", "issue") => encode(
             crate::jira::jira_get_issue(
                 scope.workspace.to_string(),
+                scope.project.clone(),
                 config_field("jira", scope, "siteUrl")?,
                 config_field("jira", scope, "email")?,
                 text(args, "key")?,
@@ -343,6 +360,7 @@ async fn run_read(
         ("jira", "comments") => encode(
             crate::jira::jira_list_comments(
                 scope.workspace.to_string(),
+                scope.project.clone(),
                 config_field("jira", scope, "siteUrl")?,
                 config_field("jira", scope, "email")?,
                 text(args, "key")?,
@@ -354,6 +372,7 @@ async fn run_read(
         ("jira", "transitions") => encode(
             crate::jira::jira_list_transitions(
                 scope.workspace.to_string(),
+                scope.project.clone(),
                 config_field("jira", scope, "siteUrl")?,
                 config_field("jira", scope, "email")?,
                 text(args, "key")?,
@@ -365,6 +384,7 @@ async fn run_read(
         ("bitbucket", "prs") => encode(
             crate::bitbucket::bitbucket_list_pull_requests(
                 scope.workspace.to_string(),
+                scope.project.clone(),
                 config_field("bitbucket", scope, "workspaceSlug")?,
                 text(args, "repo")?,
                 config_field("bitbucket", scope, "email")?,
@@ -377,6 +397,7 @@ async fn run_read(
         ("bitbucket", "pr") => encode(
             crate::bitbucket::bitbucket_get_pull_request(
                 scope.workspace.to_string(),
+                scope.project.clone(),
                 config_field("bitbucket", scope, "workspaceSlug")?,
                 text(args, "repo")?,
                 config_field("bitbucket", scope, "email")?,
@@ -389,6 +410,7 @@ async fn run_read(
         ("bitbucket", "pr-diff") => encode(
             crate::bitbucket::bitbucket_pull_request_diff(
                 scope.workspace.to_string(),
+                scope.project.clone(),
                 config_field("bitbucket", scope, "workspaceSlug")?,
                 text(args, "repo")?,
                 config_field("bitbucket", scope, "email")?,
@@ -401,6 +423,7 @@ async fn run_read(
         ("bitbucket", "pr-comments") => encode(
             crate::bitbucket::bitbucket_list_pull_request_comments(
                 scope.workspace.to_string(),
+                scope.project.clone(),
                 config_field("bitbucket", scope, "workspaceSlug")?,
                 text(args, "repo")?,
                 config_field("bitbucket", scope, "email")?,
@@ -413,6 +436,7 @@ async fn run_read(
         ("bitbucket", "pr-statuses") => encode(
             crate::bitbucket::bitbucket_list_pull_request_statuses(
                 scope.workspace.to_string(),
+                scope.project.clone(),
                 config_field("bitbucket", scope, "workspaceSlug")?,
                 text(args, "repo")?,
                 config_field("bitbucket", scope, "email")?,
@@ -425,6 +449,7 @@ async fn run_read(
         ("bitbucket", "pr-for-branch") => encode(
             crate::bitbucket::bitbucket_pull_request_for_branch(
                 scope.workspace.to_string(),
+                scope.project.clone(),
                 config_field("bitbucket", scope, "workspaceSlug")?,
                 text(args, "repo")?,
                 config_field("bitbucket", scope, "email")?,
@@ -435,13 +460,18 @@ async fn run_read(
             .map_err(|error| error.to_string())?,
         ),
         ("slack", "channels") => encode(
-            crate::slack::slack_list_channels(scope.workspace.to_string(), app.state())
-                .await
-                .map_err(|error| error.to_string())?,
+            crate::slack::slack_list_channels(
+                scope.workspace.to_string(),
+                scope.project.clone(),
+                app.state(),
+            )
+            .await
+            .map_err(|error| error.to_string())?,
         ),
         ("slack", "thread-heads") => encode(
             crate::slack::slack_list_thread_heads(
                 scope.workspace.to_string(),
+                scope.project.clone(),
                 text(args, "channel")?,
                 app.state(),
             )
@@ -451,6 +481,7 @@ async fn run_read(
         ("slack", "thread") => encode(
             crate::slack::slack_get_thread(
                 scope.workspace.to_string(),
+                scope.project.clone(),
                 text(args, "channel")?,
                 text(args, "ts")?,
                 app.state(),
@@ -461,6 +492,7 @@ async fn run_read(
         ("slack", "permalink") => encode(
             crate::slack::slack_get_permalink(
                 scope.workspace.to_string(),
+                scope.project.clone(),
                 text(args, "channel")?,
                 text(args, "ts")?,
                 app.state(),
@@ -469,9 +501,13 @@ async fn run_read(
             .map_err(|error| error.to_string())?,
         ),
         ("slack", "users") => encode(
-            crate::slack::slack_list_users(scope.workspace.to_string(), app.state())
-                .await
-                .map_err(|error| error.to_string())?,
+            crate::slack::slack_list_users(
+                scope.workspace.to_string(),
+                scope.project.clone(),
+                app.state(),
+            )
+            .await
+            .map_err(|error| error.to_string())?,
         ),
         _ => Err(format!("unhandled read command: {} {}", provider, verb)),
     }
@@ -488,6 +524,7 @@ async fn run_write(
         ("linear", "comment-create") => encode(
             crate::linear::linear_create_comment(
                 scope.workspace.to_string(),
+                scope.project.clone(),
                 text(args, "id")?,
                 text(args, "body")?,
                 app.state(),
@@ -498,6 +535,7 @@ async fn run_write(
         ("linear", "issue-update") => encode(
             crate::linear::linear_update_issue(
                 scope.workspace.to_string(),
+                scope.project.clone(),
                 text(args, "id")?,
                 text(args, "description")?,
                 app.state(),
@@ -554,6 +592,7 @@ async fn run_write(
         ("gitlab", "issue-update") => encode(
             crate::gitlab::gitlab_update_issue(
                 scope.workspace.to_string(),
+                scope.project.clone(),
                 config_field("gitlab", scope, "host")?,
                 text(args, "project")?,
                 number(args, "iid")?,
@@ -566,6 +605,7 @@ async fn run_write(
         ("gitlab", "issue-note-create") => encode(
             crate::gitlab::gitlab_create_issue_note(
                 scope.workspace.to_string(),
+                scope.project.clone(),
                 config_field("gitlab", scope, "host")?,
                 text(args, "project")?,
                 number(args, "iid")?,
@@ -578,6 +618,7 @@ async fn run_write(
         ("gitlab", "mr-note-create") => encode(
             crate::gitlab::gitlab_create_mr_note(
                 scope.workspace.to_string(),
+                scope.project.clone(),
                 config_field("gitlab", scope, "host")?,
                 text(args, "project")?,
                 number(args, "iid")?,
@@ -590,6 +631,7 @@ async fn run_write(
         ("gitlab", "mr-discussion-reply") => encode(
             crate::gitlab::gitlab_reply_to_mr_discussion(
                 scope.workspace.to_string(),
+                scope.project.clone(),
                 config_field("gitlab", scope, "host")?,
                 text(args, "project")?,
                 number(args, "iid")?,
@@ -603,6 +645,7 @@ async fn run_write(
         ("gitlab", "mr-discussion-resolve") => encode(
             crate::gitlab::gitlab_resolve_mr_discussion(
                 scope.workspace.to_string(),
+                scope.project.clone(),
                 config_field("gitlab", scope, "host")?,
                 text(args, "project")?,
                 number(args, "iid")?,
@@ -616,6 +659,7 @@ async fn run_write(
         ("gitlab", "mr-approve") => encode(
             crate::gitlab::gitlab_approve_mr(
                 scope.workspace.to_string(),
+                scope.project.clone(),
                 config_field("gitlab", scope, "host")?,
                 text(args, "project")?,
                 number(args, "iid")?,
@@ -627,6 +671,7 @@ async fn run_write(
         ("gitlab", "mr-unapprove") => encode(
             crate::gitlab::gitlab_unapprove_mr(
                 scope.workspace.to_string(),
+                scope.project.clone(),
                 config_field("gitlab", scope, "host")?,
                 text(args, "project")?,
                 number(args, "iid")?,
@@ -638,6 +683,7 @@ async fn run_write(
         ("gitlab", "mr-merge") => encode(
             crate::gitlab::gitlab_merge_mr(
                 scope.workspace.to_string(),
+                scope.project.clone(),
                 config_field("gitlab", scope, "host")?,
                 text(args, "project")?,
                 number(args, "iid")?,
@@ -649,6 +695,7 @@ async fn run_write(
         ("jira", "comment-create") => encode(
             crate::jira::jira_create_comment(
                 scope.workspace.to_string(),
+                scope.project.clone(),
                 config_field("jira", scope, "siteUrl")?,
                 config_field("jira", scope, "email")?,
                 text(args, "key")?,
@@ -661,6 +708,7 @@ async fn run_write(
         ("jira", "issue-update") => encode(
             crate::jira::jira_update_issue(
                 scope.workspace.to_string(),
+                scope.project.clone(),
                 config_field("jira", scope, "siteUrl")?,
                 config_field("jira", scope, "email")?,
                 text(args, "key")?,
@@ -673,6 +721,7 @@ async fn run_write(
         ("jira", "transition") => encode(
             crate::jira::jira_transition_issue(
                 scope.workspace.to_string(),
+                scope.project.clone(),
                 config_field("jira", scope, "siteUrl")?,
                 config_field("jira", scope, "email")?,
                 text(args, "key")?,
@@ -685,6 +734,7 @@ async fn run_write(
         ("bitbucket", "pr-comment-create") => encode(
             crate::bitbucket::bitbucket_create_pull_request_comment(
                 scope.workspace.to_string(),
+                scope.project.clone(),
                 config_field("bitbucket", scope, "workspaceSlug")?,
                 text(args, "repo")?,
                 config_field("bitbucket", scope, "email")?,
@@ -698,6 +748,7 @@ async fn run_write(
         ("bitbucket", "pr-comment-reply") => encode(
             crate::bitbucket::bitbucket_reply_to_pull_request_comment(
                 scope.workspace.to_string(),
+                scope.project.clone(),
                 config_field("bitbucket", scope, "workspaceSlug")?,
                 text(args, "repo")?,
                 config_field("bitbucket", scope, "email")?,
@@ -712,6 +763,7 @@ async fn run_write(
         ("bitbucket", "pr-approve") => encode(
             crate::bitbucket::bitbucket_approve_pull_request(
                 scope.workspace.to_string(),
+                scope.project.clone(),
                 config_field("bitbucket", scope, "workspaceSlug")?,
                 text(args, "repo")?,
                 config_field("bitbucket", scope, "email")?,
@@ -724,6 +776,7 @@ async fn run_write(
         ("bitbucket", "pr-unapprove") => encode(
             crate::bitbucket::bitbucket_unapprove_pull_request(
                 scope.workspace.to_string(),
+                scope.project.clone(),
                 config_field("bitbucket", scope, "workspaceSlug")?,
                 text(args, "repo")?,
                 config_field("bitbucket", scope, "email")?,
@@ -736,6 +789,7 @@ async fn run_write(
         ("bitbucket", "pr-request-changes") => encode(
             crate::bitbucket::bitbucket_request_changes(
                 scope.workspace.to_string(),
+                scope.project.clone(),
                 config_field("bitbucket", scope, "workspaceSlug")?,
                 text(args, "repo")?,
                 config_field("bitbucket", scope, "email")?,
@@ -748,6 +802,7 @@ async fn run_write(
         ("bitbucket", "pr-unrequest-changes") => encode(
             crate::bitbucket::bitbucket_unrequest_changes(
                 scope.workspace.to_string(),
+                scope.project.clone(),
                 config_field("bitbucket", scope, "workspaceSlug")?,
                 text(args, "repo")?,
                 config_field("bitbucket", scope, "email")?,
@@ -760,6 +815,7 @@ async fn run_write(
         ("bitbucket", "pr-merge") => encode(
             crate::bitbucket::bitbucket_merge_pull_request(
                 scope.workspace.to_string(),
+                scope.project.clone(),
                 config_field("bitbucket", scope, "workspaceSlug")?,
                 text(args, "repo")?,
                 config_field("bitbucket", scope, "email")?,
@@ -774,6 +830,7 @@ async fn run_write(
         ("bitbucket", "pr-decline") => encode(
             crate::bitbucket::bitbucket_decline_pull_request(
                 scope.workspace.to_string(),
+                scope.project.clone(),
                 config_field("bitbucket", scope, "workspaceSlug")?,
                 text(args, "repo")?,
                 config_field("bitbucket", scope, "email")?,
@@ -786,6 +843,7 @@ async fn run_write(
         ("slack", "reply") => encode(
             crate::slack::slack_post_reply(
                 scope.workspace.to_string(),
+                scope.project.clone(),
                 text(args, "channel")?,
                 text(args, "ts")?,
                 text(args, "text")?,
@@ -797,6 +855,7 @@ async fn run_write(
         ("slack", "reaction-add") => encode(
             crate::slack::slack_add_reaction(
                 scope.workspace.to_string(),
+                scope.project.clone(),
                 text(args, "channel")?,
                 text(args, "ts")?,
                 text(args, "name")?,

--- a/apps/desktop/src-tauri/src/sentry.rs
+++ b/apps/desktop/src-tauri/src/sentry.rs
@@ -173,10 +173,15 @@ fn token_from_secret(raw: &str) -> String {
         .unwrap_or_else(|_| raw.to_string())
 }
 
-fn read_config(workspace_id: &str, cache: &SentryTokenCache) -> Result<SentryConfig, SentryError> {
-    let raw = integration_credentials::read_for_binding(PROVIDER, workspace_id, None, &cache.0)?
-        .ok_or_else(|| SentryError::NoToken(workspace_id.to_string()))?;
-    let scope = integration_credentials::config_for_binding(PROVIDER, workspace_id, None)?
+fn read_config(
+    workspace_id: &str,
+    project_id: Option<&str>,
+    cache: &SentryTokenCache,
+) -> Result<SentryConfig, SentryError> {
+    let raw =
+        integration_credentials::read_for_binding(PROVIDER, workspace_id, project_id, &cache.0)?
+            .ok_or_else(|| SentryError::NoToken(workspace_id.to_string()))?;
+    let scope = integration_credentials::config_for_binding(PROVIDER, workspace_id, project_id)?
         .ok_or_else(|| SentryError::NoToken(workspace_id.to_string()))?;
     let scope: SentryScope = serde_json::from_str(&scope)?;
     Ok(SentryConfig {
@@ -336,11 +341,12 @@ pub async fn sentry_connect(
 #[tauri::command]
 pub async fn sentry_fetch_issues(
     workspace_id: String,
+    project_id: Option<String>,
     query: Option<String>,
     cursor: Option<String>,
     cache: State<'_, SentryTokenCache>,
 ) -> Result<SentryIssuesPage, SentryError> {
-    let cfg = read_config(&workspace_id, &cache)?;
+    let cfg = read_config(&workspace_id, project_id.as_deref(), &cache)?;
     let url = format!("{}/projects/{}/{}/issues/", BASE_URL, cfg.org, cfg.project);
     let mut params: Vec<(&str, String)> = vec![
         ("limit", PAGE_LIMIT.to_string()),
@@ -375,10 +381,11 @@ pub async fn sentry_fetch_issues(
 #[tauri::command]
 pub async fn sentry_fetch_issue(
     workspace_id: String,
+    project_id: Option<String>,
     issue_id: String,
     cache: State<'_, SentryTokenCache>,
 ) -> Result<SentryIssue, SentryError> {
-    let cfg = read_config(&workspace_id, &cache)?;
+    let cfg = read_config(&workspace_id, project_id.as_deref(), &cache)?;
     let url = format!("{}/issues/{}/", BASE_URL, issue_id);
     let res = http_client()
         .get(&url)
@@ -398,10 +405,11 @@ pub async fn sentry_fetch_issue(
 #[tauri::command]
 pub async fn sentry_fetch_issue_detail(
     workspace_id: String,
+    project_id: Option<String>,
     issue_id: String,
     cache: State<'_, SentryTokenCache>,
 ) -> Result<SentryIssueDetail, SentryError> {
-    let cfg = read_config(&workspace_id, &cache)?;
+    let cfg = read_config(&workspace_id, project_id.as_deref(), &cache)?;
     let url = format!("{}/issues/{}/events/latest/", BASE_URL, issue_id);
     let res = http_client()
         .get(&url)

--- a/apps/desktop/src-tauri/src/slack.rs
+++ b/apps/desktop/src-tauri/src/slack.rs
@@ -441,8 +441,12 @@ async fn fetch_paged<T: serde::de::DeserializeOwned>(
     Ok(collected)
 }
 
-fn read_token(workspace_id: &str, cache: &SlackTokenCache) -> Result<String, SlackError> {
-    integration_credentials::read_for_binding(PROVIDER, workspace_id, None, &cache.0)?
+fn read_token(
+    workspace_id: &str,
+    project_id: Option<&str>,
+    cache: &SlackTokenCache,
+) -> Result<String, SlackError> {
+    integration_credentials::read_for_binding(PROVIDER, workspace_id, project_id, &cache.0)?
         .ok_or_else(|| SlackError::NoToken(workspace_id.to_string()))
 }
 
@@ -869,74 +873,81 @@ pub async fn slack_connect(
 #[tauri::command]
 pub async fn slack_list_channels(
     workspace_id: String,
+    project_id: Option<String>,
     cache: State<'_, SlackTokenCache>,
 ) -> Result<Vec<SlackChannel>, SlackError> {
-    let token = read_token(&workspace_id, &cache)?;
+    let token = read_token(&workspace_id, project_id.as_deref(), &cache)?;
     list_channels(API_BASE, &token).await
 }
 
 #[tauri::command]
 pub async fn slack_list_thread_heads(
     workspace_id: String,
+    project_id: Option<String>,
     channel_id: String,
     cache: State<'_, SlackTokenCache>,
 ) -> Result<Vec<SlackMessage>, SlackError> {
-    let token = read_token(&workspace_id, &cache)?;
+    let token = read_token(&workspace_id, project_id.as_deref(), &cache)?;
     list_thread_heads(API_BASE, &token, &channel_id).await
 }
 
 #[tauri::command]
 pub async fn slack_get_thread(
     workspace_id: String,
+    project_id: Option<String>,
     channel_id: String,
     thread_ts: String,
     cache: State<'_, SlackTokenCache>,
 ) -> Result<Vec<SlackMessage>, SlackError> {
-    let token = read_token(&workspace_id, &cache)?;
+    let token = read_token(&workspace_id, project_id.as_deref(), &cache)?;
     get_thread(API_BASE, &token, &channel_id, &thread_ts).await
 }
 
 #[tauri::command]
 pub async fn slack_get_permalink(
     workspace_id: String,
+    project_id: Option<String>,
     channel_id: String,
     message_ts: String,
     cache: State<'_, SlackTokenCache>,
 ) -> Result<String, SlackError> {
-    let token = read_token(&workspace_id, &cache)?;
+    let token = read_token(&workspace_id, project_id.as_deref(), &cache)?;
     get_permalink(API_BASE, &token, &channel_id, &message_ts).await
 }
 
 #[tauri::command]
 pub async fn slack_list_users(
     workspace_id: String,
+    project_id: Option<String>,
     cache: State<'_, SlackTokenCache>,
 ) -> Result<Vec<SlackUser>, SlackError> {
-    let token = read_token(&workspace_id, &cache)?;
+    let token = read_token(&workspace_id, project_id.as_deref(), &cache)?;
     list_users(API_BASE, &token).await
 }
 
 #[tauri::command]
 pub async fn slack_post_reply(
     workspace_id: String,
+    project_id: Option<String>,
     channel_id: String,
     thread_ts: String,
     text: String,
     cache: State<'_, SlackTokenCache>,
 ) -> Result<SlackMessage, SlackError> {
-    let token = read_token(&workspace_id, &cache)?;
+    let token = read_token(&workspace_id, project_id.as_deref(), &cache)?;
     post_reply(API_BASE, &token, &channel_id, &thread_ts, &text).await
 }
 
 #[tauri::command]
 pub async fn slack_add_reaction(
     workspace_id: String,
+    project_id: Option<String>,
     channel_id: String,
     message_ts: String,
     name: String,
     cache: State<'_, SlackTokenCache>,
 ) -> Result<(), SlackError> {
-    let token = read_token(&workspace_id, &cache)?;
+    let token = read_token(&workspace_id, project_id.as_deref(), &cache)?;
     add_reaction(API_BASE, &token, &channel_id, &message_ts, &name).await
 }
 

--- a/apps/desktop/src/features/integrations/bitbucket/BitbucketFormBody.tsx
+++ b/apps/desktop/src/features/integrations/bitbucket/BitbucketFormBody.tsx
@@ -36,6 +36,7 @@ export const BitbucketFormBody = ({ workspaceId, onConnected, shouldAutoFocus = 
     return (
       <IntegrationConnectedRow
         provider="bitbucket"
+        credentialId={bitbucket?.credentialId ?? null}
         primary={`Connected as ${bitbucket.config.displayName ?? bitbucket.config.email}`}
         secondary={`bitbucket.org/${bitbucket.config.workspaceSlug}`}
         disconnectDescription="Unlinks this project from the Bitbucket personal API key. The key stays saved for your other projects."

--- a/apps/desktop/src/features/integrations/bitbucket/client.ts
+++ b/apps/desktop/src/features/integrations/bitbucket/client.ts
@@ -1,5 +1,5 @@
 import { invoke } from '@tauri-apps/api/core';
-import type { IntegrationCredentialId, WorkspaceId } from '@goodboy/types';
+import type { IntegrationCredentialId, ProjectId, WorkspaceId } from '@goodboy/types';
 
 export type BitbucketUser = {
   readonly uuid: string;
@@ -116,6 +116,7 @@ export const bitbucketConnect = async ({
 
 export type BitbucketRepo = {
   readonly workspaceId: WorkspaceId;
+  readonly projectId?: ProjectId;
   readonly workspaceSlug: string;
   readonly repoSlug: string;
   readonly email: string;
@@ -131,6 +132,7 @@ type ListPullRequestsParams = BitbucketRepo & {
 
 export const bitbucketListPullRequests = async ({
   workspaceId,
+  projectId,
   workspaceSlug,
   repoSlug,
   email,
@@ -138,6 +140,7 @@ export const bitbucketListPullRequests = async ({
 }: ListPullRequestsParams): Promise<ReadonlyArray<BitbucketPullRequest>> =>
   invoke<ReadonlyArray<BitbucketPullRequest>>('bitbucket_list_pull_requests', {
     workspaceId,
+    ...(projectId != null ? { projectId } : {}),
     workspaceSlug,
     repoSlug,
     email,
@@ -146,6 +149,7 @@ export const bitbucketListPullRequests = async ({
 
 export const bitbucketGetPullRequest = async ({
   workspaceId,
+  projectId,
   workspaceSlug,
   repoSlug,
   email,
@@ -153,6 +157,7 @@ export const bitbucketGetPullRequest = async ({
 }: BitbucketPullRequestTarget): Promise<BitbucketPullRequest> =>
   invoke<BitbucketPullRequest>('bitbucket_get_pull_request', {
     workspaceId,
+    ...(projectId != null ? { projectId } : {}),
     workspaceSlug,
     repoSlug,
     email,
@@ -161,6 +166,7 @@ export const bitbucketGetPullRequest = async ({
 
 export const bitbucketPullRequestDiff = async ({
   workspaceId,
+  projectId,
   workspaceSlug,
   repoSlug,
   email,
@@ -168,6 +174,7 @@ export const bitbucketPullRequestDiff = async ({
 }: BitbucketPullRequestTarget): Promise<string> =>
   invoke<string>('bitbucket_pull_request_diff', {
     workspaceId,
+    ...(projectId != null ? { projectId } : {}),
     workspaceSlug,
     repoSlug,
     email,
@@ -176,6 +183,7 @@ export const bitbucketPullRequestDiff = async ({
 
 export const bitbucketListPullRequestComments = async ({
   workspaceId,
+  projectId,
   workspaceSlug,
   repoSlug,
   email,
@@ -183,6 +191,7 @@ export const bitbucketListPullRequestComments = async ({
 }: BitbucketPullRequestTarget): Promise<ReadonlyArray<BitbucketComment>> =>
   invoke<ReadonlyArray<BitbucketComment>>('bitbucket_list_pull_request_comments', {
     workspaceId,
+    ...(projectId != null ? { projectId } : {}),
     workspaceSlug,
     repoSlug,
     email,
@@ -191,6 +200,7 @@ export const bitbucketListPullRequestComments = async ({
 
 export const bitbucketListPullRequestStatuses = async ({
   workspaceId,
+  projectId,
   workspaceSlug,
   repoSlug,
   email,
@@ -198,6 +208,7 @@ export const bitbucketListPullRequestStatuses = async ({
 }: BitbucketPullRequestTarget): Promise<ReadonlyArray<BitbucketStatus>> =>
   invoke<ReadonlyArray<BitbucketStatus>>('bitbucket_list_pull_request_statuses', {
     workspaceId,
+    ...(projectId != null ? { projectId } : {}),
     workspaceSlug,
     repoSlug,
     email,
@@ -210,6 +221,7 @@ type BranchParams = BitbucketRepo & {
 
 export const bitbucketPullRequestForBranch = async ({
   workspaceId,
+  projectId,
   workspaceSlug,
   repoSlug,
   email,
@@ -217,6 +229,7 @@ export const bitbucketPullRequestForBranch = async ({
 }: BranchParams): Promise<BitbucketPullRequest | null> =>
   invoke<BitbucketPullRequest | null>('bitbucket_pull_request_for_branch', {
     workspaceId,
+    ...(projectId != null ? { projectId } : {}),
     workspaceSlug,
     repoSlug,
     email,
@@ -225,6 +238,7 @@ export const bitbucketPullRequestForBranch = async ({
 
 export const bitbucketApprovePullRequest = async ({
   workspaceId,
+  projectId,
   workspaceSlug,
   repoSlug,
   email,
@@ -232,6 +246,7 @@ export const bitbucketApprovePullRequest = async ({
 }: BitbucketPullRequestTarget): Promise<BitbucketParticipant> =>
   invoke<BitbucketParticipant>('bitbucket_approve_pull_request', {
     workspaceId,
+    ...(projectId != null ? { projectId } : {}),
     workspaceSlug,
     repoSlug,
     email,
@@ -240,6 +255,7 @@ export const bitbucketApprovePullRequest = async ({
 
 export const bitbucketUnapprovePullRequest = async ({
   workspaceId,
+  projectId,
   workspaceSlug,
   repoSlug,
   email,
@@ -247,6 +263,7 @@ export const bitbucketUnapprovePullRequest = async ({
 }: BitbucketPullRequestTarget): Promise<void> => {
   await invoke('bitbucket_unapprove_pull_request', {
     workspaceId,
+    ...(projectId != null ? { projectId } : {}),
     workspaceSlug,
     repoSlug,
     email,
@@ -256,6 +273,7 @@ export const bitbucketUnapprovePullRequest = async ({
 
 export const bitbucketRequestChanges = async ({
   workspaceId,
+  projectId,
   workspaceSlug,
   repoSlug,
   email,
@@ -263,6 +281,7 @@ export const bitbucketRequestChanges = async ({
 }: BitbucketPullRequestTarget): Promise<BitbucketParticipant> =>
   invoke<BitbucketParticipant>('bitbucket_request_changes', {
     workspaceId,
+    ...(projectId != null ? { projectId } : {}),
     workspaceSlug,
     repoSlug,
     email,
@@ -271,6 +290,7 @@ export const bitbucketRequestChanges = async ({
 
 export const bitbucketUnrequestChanges = async ({
   workspaceId,
+  projectId,
   workspaceSlug,
   repoSlug,
   email,
@@ -278,6 +298,7 @@ export const bitbucketUnrequestChanges = async ({
 }: BitbucketPullRequestTarget): Promise<void> => {
   await invoke('bitbucket_unrequest_changes', {
     workspaceId,
+    ...(projectId != null ? { projectId } : {}),
     workspaceSlug,
     repoSlug,
     email,
@@ -292,6 +313,7 @@ type MergeParams = BitbucketPullRequestTarget & {
 
 export const bitbucketMergePullRequest = async ({
   workspaceId,
+  projectId,
   workspaceSlug,
   repoSlug,
   email,
@@ -301,6 +323,7 @@ export const bitbucketMergePullRequest = async ({
 }: MergeParams): Promise<BitbucketPullRequest> =>
   invoke<BitbucketPullRequest>('bitbucket_merge_pull_request', {
     workspaceId,
+    ...(projectId != null ? { projectId } : {}),
     workspaceSlug,
     repoSlug,
     email,
@@ -311,6 +334,7 @@ export const bitbucketMergePullRequest = async ({
 
 export const bitbucketDeclinePullRequest = async ({
   workspaceId,
+  projectId,
   workspaceSlug,
   repoSlug,
   email,
@@ -318,6 +342,7 @@ export const bitbucketDeclinePullRequest = async ({
 }: BitbucketPullRequestTarget): Promise<BitbucketPullRequest> =>
   invoke<BitbucketPullRequest>('bitbucket_decline_pull_request', {
     workspaceId,
+    ...(projectId != null ? { projectId } : {}),
     workspaceSlug,
     repoSlug,
     email,
@@ -330,6 +355,7 @@ type CreateCommentParams = BitbucketPullRequestTarget & {
 
 export const bitbucketCreatePullRequestComment = async ({
   workspaceId,
+  projectId,
   workspaceSlug,
   repoSlug,
   email,
@@ -338,6 +364,7 @@ export const bitbucketCreatePullRequestComment = async ({
 }: CreateCommentParams): Promise<BitbucketComment> =>
   invoke<BitbucketComment>('bitbucket_create_pull_request_comment', {
     workspaceId,
+    ...(projectId != null ? { projectId } : {}),
     workspaceSlug,
     repoSlug,
     email,
@@ -351,6 +378,7 @@ type ReplyParams = CreateCommentParams & {
 
 export const bitbucketReplyToPullRequestComment = async ({
   workspaceId,
+  projectId,
   workspaceSlug,
   repoSlug,
   email,
@@ -360,6 +388,7 @@ export const bitbucketReplyToPullRequestComment = async ({
 }: ReplyParams): Promise<BitbucketComment> =>
   invoke<BitbucketComment>('bitbucket_reply_to_pull_request_comment', {
     workspaceId,
+    ...(projectId != null ? { projectId } : {}),
     workspaceSlug,
     repoSlug,
     email,

--- a/apps/desktop/src/features/integrations/components/IntegrationConnectedRow/index.test.tsx
+++ b/apps/desktop/src/features/integrations/components/IntegrationConnectedRow/index.test.tsx
@@ -2,16 +2,28 @@
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { IntegrationCredentialId } from '@goodboy/types';
 import { IntegrationConnectedRow } from '.';
 
-afterEach(cleanup);
+const secret = vi.hoisted(() => ({ has: true }));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(async () => secret.has),
+}));
+
+afterEach(() => {
+  cleanup();
+  secret.has = true;
+});
 
 const renderRow = ({
   onDisconnect = vi.fn(async () => undefined),
   badge,
+  credentialId,
 }: {
   readonly onDisconnect?: () => Promise<void>;
   readonly badge?: string;
+  readonly credentialId?: IntegrationCredentialId;
 } = {}) =>
   render(
     <IntegrationConnectedRow
@@ -19,6 +31,7 @@ const renderRow = ({
       primary="Connected as Ada Lovelace"
       secondary="linear.app/acme"
       {...(badge != null ? { badge } : {})}
+      {...(credentialId != null ? { credentialId } : {})}
       disconnectDescription="Unlinks this project."
       onDisconnect={onDisconnect}
     />,
@@ -65,5 +78,22 @@ describe('IntegrationConnectedRow', () => {
     fireEvent.click(screen.getByRole('button', { name: /disconnect linear/i }));
     fireEvent.click(screen.getByRole('button', { name: /^disconnect linear$/i }));
     expect(await screen.findByText(/keychain said no/i)).toBeDefined();
+  });
+});
+
+describe('a connection whose key left the keychain', () => {
+  it('says the key is gone instead of claiming a healthy connection', async () => {
+    secret.has = false;
+    renderRow({ credentialId: 'cred-1' as IntegrationCredentialId });
+
+    await waitFor(() => expect(screen.getByText(/missing from this Mac/i)).toBeDefined());
+    expect(screen.getByText('Connected as Ada Lovelace')).toBeDefined();
+  });
+
+  it('stays quiet while the key is where it should be', async () => {
+    renderRow({ credentialId: 'cred-1' as IntegrationCredentialId });
+
+    await waitFor(() => expect(screen.getByText('Connected as Ada Lovelace')).toBeDefined());
+    expect(screen.queryByText(/missing from this Mac/i)).toBeNull();
   });
 });

--- a/apps/desktop/src/features/integrations/components/IntegrationConnectedRow/index.tsx
+++ b/apps/desktop/src/features/integrations/components/IntegrationConnectedRow/index.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react';
 import { Chip, formatError, IconButton, InlineConfirm } from '@goodboy/ui';
-import { Unplug } from 'lucide-react';
+import { TriangleAlert, Unplug } from 'lucide-react';
+import type { IntegrationCredentialId } from '@goodboy/types';
+import { useCredentialSecret } from '../../useCredentialSecret';
 import {
   IntegrationGlyph,
   integrationLabel,
@@ -12,6 +14,7 @@ type Props = {
   readonly primary: string;
   readonly secondary?: string;
   readonly badge?: string;
+  readonly credentialId?: IntegrationCredentialId | null;
   readonly disconnectDescription: string;
   readonly onDisconnect: () => Promise<void>;
 };
@@ -21,10 +24,12 @@ export const IntegrationConnectedRow = ({
   primary,
   secondary,
   badge,
+  credentialId = null,
   disconnectDescription,
   onDisconnect,
 }: Props) => {
   const label = integrationLabel({ provider });
+  const secret = useCredentialSecret({ credentialId });
   const [isArmed, setIsArmed] = useState(false);
   const [isBusy, setIsBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -74,6 +79,15 @@ export const IntegrationConnectedRow = ({
           onConfirm={disconnect}
           onCancel={() => setIsArmed(false)}
         />
+      ) : null}
+      {secret === 'missing' ? (
+        <p className="flex items-start gap-1.5 text-2xs leading-relaxed text-warning">
+          <TriangleAlert size={12} aria-hidden className="mt-0.5 shrink-0" />
+          <span>
+            The key is missing from this Mac's keychain, so every request with it fails. Disconnect
+            and connect again to paste a new one.
+          </span>
+        </p>
       ) : null}
       {error != null ? <p className="text-2xs leading-relaxed text-danger">{error}</p> : null}
     </div>

--- a/apps/desktop/src/features/integrations/gitlab/GitlabFormBody.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabFormBody.tsx
@@ -44,6 +44,7 @@ export const GitlabFormBody = ({ workspaceId, onConnected, shouldAutoFocus = fal
     return (
       <IntegrationConnectedRow
         provider="gitlab"
+        credentialId={gitlab?.credentialId ?? null}
         primary={`Connected as ${config.userName}`}
         secondary={config.host}
         disconnectDescription="Unlinks this project from the GitLab personal API key. The key stays saved for your other projects."

--- a/apps/desktop/src/features/integrations/gitlab/GitlabIssueDetail/index.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabIssueDetail/index.tsx
@@ -1,7 +1,7 @@
 import { StudioDetailLayout } from '../../../../shared/components/StudioDetail';
 import { useState, type ReactNode } from 'react';
 import { FileText, MessageSquare } from 'lucide-react';
-import type { WorkspaceId } from '@goodboy/types';
+import type { ProjectId, WorkspaceId } from '@goodboy/types';
 import type { SegmentedTabOption } from '@goodboy/ui';
 import { HeaderBand, StudioDetailTabs } from '@goodboy/ui';
 import { DescriptionSection } from '../../../../shared/components/DescriptionSection';
@@ -19,6 +19,7 @@ type IssueSection = 'overview' | 'conversation';
 type Props = {
   readonly issue: GitlabIssue;
   readonly workspaceId: WorkspaceId;
+  readonly projectId?: ProjectId;
   readonly headerActions?: ReactNode;
   readonly fit?: Fit;
 };
@@ -28,10 +29,16 @@ const SECTION_OPTIONS: ReadonlyArray<SegmentedTabOption<IssueSection>> = [
   { value: 'conversation', label: 'Conversation', icon: MessageSquare },
 ];
 
-export const GitlabIssueDetail = ({ issue, workspaceId, headerActions, fit = 'fill' }: Props) => {
+export const GitlabIssueDetail = ({
+  issue,
+  workspaceId,
+  projectId,
+  headerActions,
+  fit = 'fill',
+}: Props) => {
   const [section, setSection] = useState<IssueSection>('overview');
-  const { description, save } = useGitlabIssueDescription({ issue, workspaceId });
-  const notes = useGitlabIssueNotes({ issue, workspaceId });
+  const { description, save } = useGitlabIssueDescription({ issue, workspaceId, projectId });
+  const notes = useGitlabIssueNotes({ issue, workspaceId, projectId });
 
   return (
     <StudioDetailLayout

--- a/apps/desktop/src/features/integrations/gitlab/client.ts
+++ b/apps/desktop/src/features/integrations/gitlab/client.ts
@@ -1,5 +1,5 @@
 import { invoke } from '@tauri-apps/api/core';
-import type { IntegrationCredentialId, WorkspaceId } from '@goodboy/types';
+import type { IntegrationCredentialId, ProjectId, WorkspaceId } from '@goodboy/types';
 
 export type GitlabUser = {
   id: number;
@@ -39,8 +39,13 @@ export const gitlabConnect = async (
 export const gitlabFetchAssignedIssues = async (
   workspaceId: WorkspaceId,
   host: string,
+  projectId?: ProjectId,
 ): Promise<GitlabIssue[]> => {
-  return invoke<GitlabIssue[]>('gitlab_fetch_assigned_issues', { workspaceId, host });
+  return invoke<GitlabIssue[]>('gitlab_fetch_assigned_issues', {
+    workspaceId,
+    host,
+    ...(projectId != null ? { projectId } : {}),
+  });
 };
 
 export const gitlabFetchIssue = async (
@@ -48,9 +53,11 @@ export const gitlabFetchIssue = async (
   host: string,
   projectPath: string,
   issueIid: number,
+  projectId?: ProjectId,
 ): Promise<GitlabIssue> => {
   return invoke<GitlabIssue>('gitlab_fetch_issue', {
     workspaceId,
+    ...(projectId != null ? { projectId } : {}),
     host,
     projectPath,
     issueIid,
@@ -59,6 +66,7 @@ export const gitlabFetchIssue = async (
 
 type UpdateDescriptionParams = {
   readonly workspaceId: WorkspaceId;
+  readonly projectId?: ProjectId;
   readonly host: string;
   readonly projectPath: string;
   readonly issueIid: number;
@@ -67,6 +75,7 @@ type UpdateDescriptionParams = {
 
 export const gitlabUpdateIssueDescription = async ({
   workspaceId,
+  projectId,
   host,
   projectPath,
   issueIid,
@@ -74,6 +83,7 @@ export const gitlabUpdateIssueDescription = async ({
 }: UpdateDescriptionParams): Promise<string> => {
   return invoke<string>('gitlab_update_issue', {
     workspaceId,
+    ...(projectId != null ? { projectId } : {}),
     host,
     projectPath,
     issueIid,
@@ -119,17 +129,24 @@ export type GitlabMergeRequest = {
 export const gitlabFetchAssignedMrs = async (
   workspaceId: WorkspaceId,
   host: string,
+  projectId?: ProjectId,
 ): Promise<GitlabMergeRequest[]> => {
-  return invoke<GitlabMergeRequest[]>('gitlab_fetch_assigned_mrs', { workspaceId, host });
+  return invoke<GitlabMergeRequest[]>('gitlab_fetch_assigned_mrs', {
+    workspaceId,
+    host,
+    ...(projectId != null ? { projectId } : {}),
+  });
 };
 
 export const gitlabFetchProjectMrs = async (
   workspaceId: WorkspaceId,
   host: string,
   projectPath: string,
+  projectId?: ProjectId,
 ): Promise<GitlabMergeRequest[]> => {
   return invoke<GitlabMergeRequest[]>('gitlab_fetch_project_mrs', {
     workspaceId,
+    ...(projectId != null ? { projectId } : {}),
     host,
     projectPath,
   });
@@ -159,9 +176,11 @@ export const gitlabMrForBranch = async (
   host: string,
   projectPath: string,
   sourceBranch: string,
+  projectId?: ProjectId,
 ): Promise<GitlabMergeRequest | null> => {
   return invoke<GitlabMergeRequest | null>('gitlab_mr_for_branch', {
     workspaceId,
+    ...(projectId != null ? { projectId } : {}),
     host,
     projectPath,
     sourceBranch,
@@ -170,6 +189,7 @@ export const gitlabMrForBranch = async (
 
 export const gitlabCreateMr = async (args: {
   workspaceId: WorkspaceId;
+  projectId?: ProjectId;
   host: string;
   projectPath: string;
   sourceBranch: string;
@@ -178,7 +198,11 @@ export const gitlabCreateMr = async (args: {
   description: string;
   draft: boolean;
 }): Promise<GitlabMergeRequest> => {
-  return invoke<GitlabMergeRequest>('gitlab_create_mr', args);
+  const { projectId, ...payload } = args;
+  return invoke<GitlabMergeRequest>('gitlab_create_mr', {
+    ...payload,
+    ...(projectId != null ? { projectId } : {}),
+  });
 };
 
 export const gitlabMrDiff = async (
@@ -186,9 +210,11 @@ export const gitlabMrDiff = async (
   host: string,
   projectPath: string,
   mrIid: number,
+  projectId?: ProjectId,
 ): Promise<string> => {
   return invoke<string>('gitlab_mr_diff', {
     workspaceId,
+    ...(projectId != null ? { projectId } : {}),
     host,
     projectPath,
     mrIid,
@@ -206,9 +232,11 @@ export const gitlabMrDiffRefs = async (
   host: string,
   projectPath: string,
   mrIid: number,
+  projectId?: ProjectId,
 ): Promise<GitlabDiffRefs> => {
   return invoke<GitlabDiffRefs>('gitlab_mr_diff_refs', {
     workspaceId,
+    ...(projectId != null ? { projectId } : {}),
     host,
     projectPath,
     mrIid,
@@ -232,9 +260,11 @@ export const gitlabCreateMrDiscussion = async (
   mrIid: number,
   body: string,
   position: GitlabDiscussionPosition,
+  projectId?: ProjectId,
 ): Promise<string> => {
   return invoke<string>('gitlab_create_mr_discussion', {
     workspaceId,
+    ...(projectId != null ? { projectId } : {}),
     host,
     projectPath,
     mrIid,
@@ -249,9 +279,11 @@ export const gitlabCreateMrNote = async (
   projectPath: string,
   mrIid: number,
   body: string,
+  projectId?: ProjectId,
 ): Promise<number> => {
   return invoke<number>('gitlab_create_mr_note', {
     workspaceId,
+    ...(projectId != null ? { projectId } : {}),
     host,
     projectPath,
     mrIid,
@@ -297,6 +329,7 @@ export type GitlabMrApprovalState = {
 
 type MrTarget = {
   readonly workspaceId: WorkspaceId;
+  readonly projectId?: ProjectId;
   readonly host: string;
   readonly projectPath: string;
   readonly mrIid: number;
@@ -304,12 +337,14 @@ type MrTarget = {
 
 export const gitlabListMrDiscussions = async ({
   workspaceId,
+  projectId,
   host,
   projectPath,
   mrIid,
 }: MrTarget): Promise<ReadonlyArray<GitlabMrDiscussion>> => {
   return invoke<ReadonlyArray<GitlabMrDiscussion>>('gitlab_list_mr_discussions', {
     workspaceId,
+    ...(projectId != null ? { projectId } : {}),
     host,
     projectPath,
     mrIid,
@@ -323,6 +358,7 @@ type ReplyParams = MrTarget & {
 
 export const gitlabReplyToMrDiscussion = async ({
   workspaceId,
+  projectId,
   host,
   projectPath,
   mrIid,
@@ -331,6 +367,7 @@ export const gitlabReplyToMrDiscussion = async ({
 }: ReplyParams): Promise<number> => {
   return invoke<number>('gitlab_reply_to_mr_discussion', {
     workspaceId,
+    ...(projectId != null ? { projectId } : {}),
     host,
     projectPath,
     mrIid,
@@ -346,6 +383,7 @@ type ResolveDiscussionParams = MrTarget & {
 
 export const gitlabResolveMrDiscussion = async ({
   workspaceId,
+  projectId,
   host,
   projectPath,
   mrIid,
@@ -354,6 +392,7 @@ export const gitlabResolveMrDiscussion = async ({
 }: ResolveDiscussionParams): Promise<GitlabMrDiscussion> => {
   return invoke<GitlabMrDiscussion>('gitlab_resolve_mr_discussion', {
     workspaceId,
+    ...(projectId != null ? { projectId } : {}),
     host,
     projectPath,
     mrIid,
@@ -372,6 +411,7 @@ export type GitlabIssueNote = {
 
 type IssueTarget = {
   readonly workspaceId: WorkspaceId;
+  readonly projectId?: ProjectId;
   readonly host: string;
   readonly projectPath: string;
   readonly issueIid: number;
@@ -379,12 +419,14 @@ type IssueTarget = {
 
 export const gitlabListIssueNotes = async ({
   workspaceId,
+  projectId,
   host,
   projectPath,
   issueIid,
 }: IssueTarget): Promise<ReadonlyArray<GitlabIssueNote>> => {
   return invoke<ReadonlyArray<GitlabIssueNote>>('gitlab_list_issue_notes', {
     workspaceId,
+    ...(projectId != null ? { projectId } : {}),
     host,
     projectPath,
     issueIid,
@@ -397,6 +439,7 @@ type CreateIssueNoteParams = IssueTarget & {
 
 export const gitlabCreateIssueNote = async ({
   workspaceId,
+  projectId,
   host,
   projectPath,
   issueIid,
@@ -404,6 +447,7 @@ export const gitlabCreateIssueNote = async ({
 }: CreateIssueNoteParams): Promise<number> => {
   return invoke<number>('gitlab_create_issue_note', {
     workspaceId,
+    ...(projectId != null ? { projectId } : {}),
     host,
     projectPath,
     issueIid,
@@ -413,12 +457,14 @@ export const gitlabCreateIssueNote = async ({
 
 export const gitlabMrApprovalState = async ({
   workspaceId,
+  projectId,
   host,
   projectPath,
   mrIid,
 }: MrTarget): Promise<GitlabMrApprovalState | null> => {
   return invoke<GitlabMrApprovalState | null>('gitlab_mr_approval_state', {
     workspaceId,
+    ...(projectId != null ? { projectId } : {}),
     host,
     projectPath,
     mrIid,
@@ -427,12 +473,14 @@ export const gitlabMrApprovalState = async ({
 
 export const gitlabApproveMr = async ({
   workspaceId,
+  projectId,
   host,
   projectPath,
   mrIid,
 }: MrTarget): Promise<GitlabMrApprovalState | null> => {
   return invoke<GitlabMrApprovalState | null>('gitlab_approve_mr', {
     workspaceId,
+    ...(projectId != null ? { projectId } : {}),
     host,
     projectPath,
     mrIid,
@@ -441,12 +489,14 @@ export const gitlabApproveMr = async ({
 
 export const gitlabUnapproveMr = async ({
   workspaceId,
+  projectId,
   host,
   projectPath,
   mrIid,
 }: MrTarget): Promise<GitlabMrApprovalState | null> => {
   return invoke<GitlabMrApprovalState | null>('gitlab_unapprove_mr', {
     workspaceId,
+    ...(projectId != null ? { projectId } : {}),
     host,
     projectPath,
     mrIid,
@@ -462,6 +512,7 @@ type UpdateMrStateParams = MrTarget & {
 
 export const gitlabUpdateMrState = async ({
   workspaceId,
+  projectId,
   host,
   projectPath,
   mrIid,
@@ -470,6 +521,7 @@ export const gitlabUpdateMrState = async ({
 }: UpdateMrStateParams): Promise<GitlabMergeRequest> => {
   return invoke<GitlabMergeRequest>('gitlab_update_mr_state', {
     workspaceId,
+    ...(projectId != null ? { projectId } : {}),
     host,
     projectPath,
     mrIid,
@@ -483,9 +535,11 @@ export const gitlabMergeMr = async (
   host: string,
   projectPath: string,
   mrIid: number,
+  projectId?: ProjectId,
 ): Promise<GitlabMergeRequest> => {
   return invoke<GitlabMergeRequest>('gitlab_merge_mr', {
     workspaceId,
+    ...(projectId != null ? { projectId } : {}),
     host,
     projectPath,
     mrIid,

--- a/apps/desktop/src/features/integrations/gitlab/useGitlabIssue.test.ts
+++ b/apps/desktop/src/features/integrations/gitlab/useGitlabIssue.test.ts
@@ -55,7 +55,13 @@ describe('useGitlabIssue', () => {
     );
 
     await waitFor(() => expect(result.current.issue).toEqual(ISSUE));
-    expect(fetchIssue).toHaveBeenCalledWith(WORKSPACE_ID, 'https://gitlab.com', 'acme/web', 7);
+    expect(fetchIssue).toHaveBeenCalledWith(
+      WORKSPACE_ID,
+      'https://gitlab.com',
+      'acme/web',
+      7,
+      undefined,
+    );
   });
 
   it('surfaces the fetch error and recovers on retry', async () => {

--- a/apps/desktop/src/features/integrations/gitlab/useGitlabIssue.ts
+++ b/apps/desktop/src/features/integrations/gitlab/useGitlabIssue.ts
@@ -1,13 +1,14 @@
 import { useEffect, useState } from 'react';
 import { formatError } from '@goodboy/ui';
 import { useShallow } from 'zustand/react/shallow';
-import type { GitlabIntegrationBinding, WorkspaceId } from '@goodboy/types';
+import type { GitlabIntegrationBinding, ProjectId, WorkspaceId } from '@goodboy/types';
 import { useAppStore } from '../../../store';
 import { gitlabFetchIssue, type GitlabIssue } from './client';
 
 type Params = {
   readonly workspaceId: WorkspaceId;
   readonly identifier: string;
+  readonly projectId?: ProjectId;
 };
 
 type Result = {
@@ -35,7 +36,7 @@ const parseIdentifier = (identifier: string): ParsedIdentifier | null => {
   return { projectPath, issueIid };
 };
 
-export const useGitlabIssue = ({ workspaceId, identifier }: Params): Result => {
+export const useGitlabIssue = ({ workspaceId, identifier, projectId }: Params): Result => {
   const host = useAppStore(
     useShallow((state) => {
       const integration = (state.workspaceIntegrations[workspaceId] ?? []).find(
@@ -62,7 +63,7 @@ export const useGitlabIssue = ({ workspaceId, identifier }: Params): Result => {
     setIssue(null);
     setError(null);
     setIsLoading(true);
-    gitlabFetchIssue(workspaceId, host, parsed.projectPath, parsed.issueIid)
+    gitlabFetchIssue(workspaceId, host, parsed.projectPath, parsed.issueIid, projectId)
       .then((nextIssue) => {
         if (isCancelled) {
           return;
@@ -85,7 +86,7 @@ export const useGitlabIssue = ({ workspaceId, identifier }: Params): Result => {
     return () => {
       isCancelled = true;
     };
-  }, [workspaceId, host, identifier, attempt]);
+  }, [workspaceId, host, identifier, projectId, attempt]);
 
   return { issue, isLoading, error, refetch: () => setAttempt((n) => n + 1) };
 };

--- a/apps/desktop/src/features/integrations/gitlab/useGitlabIssueDescription.ts
+++ b/apps/desktop/src/features/integrations/gitlab/useGitlabIssueDescription.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import type { GitlabIntegrationBinding, WorkspaceId } from '@goodboy/types';
+import type { GitlabIntegrationBinding, ProjectId, WorkspaceId } from '@goodboy/types';
 import { useAppStore } from '../../../store';
 import { gitlabUpdateIssueDescription, type GitlabIssue } from './client';
 import { projectPathFromIssue } from './issueProjectPath';
@@ -7,6 +7,7 @@ import { projectPathFromIssue } from './issueProjectPath';
 type Params = {
   readonly issue: GitlabIssue | null;
   readonly workspaceId: WorkspaceId;
+  readonly projectId?: ProjectId;
 };
 
 type Result = {
@@ -14,7 +15,7 @@ type Result = {
   readonly save: ((next: string) => Promise<void>) | null;
 };
 
-export const useGitlabIssueDescription = ({ issue, workspaceId }: Params): Result => {
+export const useGitlabIssueDescription = ({ issue, workspaceId, projectId }: Params): Result => {
   const host = useAppStore((state) => {
     const integration = (state.workspaceIntegrations[workspaceId] ?? []).find(
       (candidate): candidate is GitlabIntegrationBinding => candidate.provider === 'gitlab',
@@ -40,10 +41,11 @@ export const useGitlabIssueDescription = ({ issue, workspaceId }: Params): Resul
         projectPath,
         issueIid,
         description: next,
+        projectId,
       });
       setSaved(description);
     },
-    [workspaceId, host, projectPath, issueIid],
+    [workspaceId, host, projectPath, issueIid, projectId],
   );
 
   return {

--- a/apps/desktop/src/features/integrations/gitlab/useGitlabIssueNotes/index.ts
+++ b/apps/desktop/src/features/integrations/gitlab/useGitlabIssueNotes/index.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { formatError } from '@goodboy/ui';
-import type { GitlabIntegrationBinding, WorkspaceId } from '@goodboy/types';
+import type { GitlabIntegrationBinding, ProjectId, WorkspaceId } from '@goodboy/types';
 import { useAppStore } from '../../../../store';
 import {
   gitlabCreateIssueNote,
@@ -13,6 +13,7 @@ import { projectPathFromIssue } from '../issueProjectPath';
 type Params = {
   readonly issue: GitlabIssue | null;
   readonly workspaceId: WorkspaceId;
+  readonly projectId?: ProjectId;
 };
 
 type Result = {
@@ -23,7 +24,7 @@ type Result = {
   readonly post: ((body: string) => Promise<void>) | null;
 };
 
-export const useGitlabIssueNotes = ({ issue, workspaceId }: Params): Result => {
+export const useGitlabIssueNotes = ({ issue, workspaceId, projectId }: Params): Result => {
   const host = useAppStore((state) => {
     const integration = (state.workspaceIntegrations[workspaceId] ?? []).find(
       (candidate): candidate is GitlabIntegrationBinding => candidate.provider === 'gitlab',
@@ -48,7 +49,7 @@ export const useGitlabIssueNotes = ({ issue, workspaceId }: Params): Result => {
 
     let isCancelled = false;
     setIsLoading(true);
-    gitlabListIssueNotes({ workspaceId, host, projectPath, issueIid })
+    gitlabListIssueNotes({ workspaceId, host, projectPath, issueIid, projectId })
       .then((next) => {
         if (isCancelled) {
           return;
@@ -71,7 +72,7 @@ export const useGitlabIssueNotes = ({ issue, workspaceId }: Params): Result => {
     return () => {
       isCancelled = true;
     };
-  }, [workspaceId, host, projectPath, issueIid, reloadToken]);
+  }, [workspaceId, host, projectPath, issueIid, projectId, reloadToken]);
 
   const reload = useCallback(() => {
     setReloadToken((token) => token + 1);
@@ -82,10 +83,10 @@ export const useGitlabIssueNotes = ({ issue, workspaceId }: Params): Result => {
       if (host == null || projectPath == null || issueIid == null) {
         return;
       }
-      await gitlabCreateIssueNote({ workspaceId, host, projectPath, issueIid, body });
+      await gitlabCreateIssueNote({ workspaceId, host, projectPath, issueIid, body, projectId });
       setReloadToken((token) => token + 1);
     },
-    [workspaceId, host, projectPath, issueIid],
+    [workspaceId, host, projectPath, issueIid, projectId],
   );
 
   return {

--- a/apps/desktop/src/features/integrations/jira/JiraFormBody.tsx
+++ b/apps/desktop/src/features/integrations/jira/JiraFormBody.tsx
@@ -37,6 +37,7 @@ export const JiraFormBody = ({ workspaceId, onConnected, shouldAutoFocus = false
     return (
       <IntegrationConnectedRow
         provider="jira"
+        credentialId={jira?.credentialId ?? null}
         primary={`Connected as ${jira.config.displayName ?? jira.config.email}`}
         secondary={`${jira.config.siteUrl} (${jira.config.projectKey})`}
         disconnectDescription="Unlinks this project from the Jira personal API key. The key stays saved for your other projects."

--- a/apps/desktop/src/features/integrations/jira/JiraIssueDetail/index.tsx
+++ b/apps/desktop/src/features/integrations/jira/JiraIssueDetail/index.tsx
@@ -1,7 +1,7 @@
 import { StudioDetailLayout } from '../../../../shared/components/StudioDetail';
 import { useState, type ReactNode } from 'react';
 import { FileText, MessageSquare } from 'lucide-react';
-import type { WorkspaceId } from '@goodboy/types';
+import type { ProjectId, WorkspaceId } from '@goodboy/types';
 import type { SegmentedTabOption } from '@goodboy/ui';
 import { HeaderBand, StudioDetailTabs } from '@goodboy/ui';
 import { DescriptionSection } from '../../../../shared/components/DescriptionSection';
@@ -22,6 +22,7 @@ type IssueSection = 'overview' | 'conversation';
 type Props = {
   readonly issue: JiraIssue;
   readonly workspaceId: WorkspaceId;
+  readonly projectId?: ProjectId;
   readonly headerActions?: ReactNode;
   readonly dock?: ReactNode;
   readonly fit?: Fit;
@@ -36,15 +37,16 @@ const SECTION_OPTIONS: ReadonlyArray<SegmentedTabOption<IssueSection>> = [
 export const JiraIssueDetail = ({
   issue,
   workspaceId,
+  projectId,
   headerActions,
   dock,
   fit = 'fill',
   onIssueWritten,
 }: Props) => {
   const [section, setSection] = useState<IssueSection>('overview');
-  const actions = useJiraIssueActions({ issue, workspaceId, onWritten: onIssueWritten });
+  const actions = useJiraIssueActions({ issue, workspaceId, projectId, onWritten: onIssueWritten });
   const live = actions.issue;
-  const conversation = useJiraIssueComments({ issue: live, workspaceId });
+  const conversation = useJiraIssueComments({ issue: live, workspaceId, projectId });
 
   return (
     <StudioDetailLayout

--- a/apps/desktop/src/features/integrations/jira/client.ts
+++ b/apps/desktop/src/features/integrations/jira/client.ts
@@ -1,5 +1,5 @@
 import { invoke } from '@tauri-apps/api/core';
-import type { IntegrationCredentialId, WorkspaceId } from '@goodboy/types';
+import type { IntegrationCredentialId, ProjectId, WorkspaceId } from '@goodboy/types';
 
 export type JiraAvatarUrls = {
   readonly '48x48': string | null;
@@ -55,6 +55,7 @@ export type JiraTransition = {
 
 export type JiraSite = {
   readonly workspaceId: WorkspaceId;
+  readonly projectId?: ProjectId;
   readonly siteUrl: string;
   readonly email: string;
 };
@@ -94,6 +95,7 @@ type ListIssuesParams = JiraSite & {
 
 export const jiraListIssues = async ({
   workspaceId,
+  projectId,
   siteUrl,
   email,
   projectKey,
@@ -101,6 +103,7 @@ export const jiraListIssues = async ({
 }: ListIssuesParams): Promise<ReadonlyArray<JiraIssue>> =>
   invoke<ReadonlyArray<JiraIssue>>('jira_list_issues', {
     workspaceId,
+    ...(projectId != null ? { projectId } : {}),
     siteUrl,
     email,
     projectKey,
@@ -109,20 +112,29 @@ export const jiraListIssues = async ({
 
 export const jiraGetIssue = async ({
   workspaceId,
+  projectId,
   siteUrl,
   email,
   issueKey,
 }: JiraIssueTarget): Promise<JiraIssue> =>
-  invoke<JiraIssue>('jira_get_issue', { workspaceId, siteUrl, email, issueKey });
+  invoke<JiraIssue>('jira_get_issue', {
+    workspaceId,
+    ...(projectId != null ? { projectId } : {}),
+    siteUrl,
+    email,
+    issueKey,
+  });
 
 export const jiraListComments = async ({
   workspaceId,
+  projectId,
   siteUrl,
   email,
   issueKey,
 }: JiraIssueTarget): Promise<ReadonlyArray<JiraComment>> =>
   invoke<ReadonlyArray<JiraComment>>('jira_list_comments', {
     workspaceId,
+    ...(projectId != null ? { projectId } : {}),
     siteUrl,
     email,
     issueKey,
@@ -134,12 +146,20 @@ type CreateCommentParams = JiraIssueTarget & {
 
 export const jiraCreateComment = async ({
   workspaceId,
+  projectId,
   siteUrl,
   email,
   issueKey,
   body,
 }: CreateCommentParams): Promise<JiraComment> =>
-  invoke<JiraComment>('jira_create_comment', { workspaceId, siteUrl, email, issueKey, body });
+  invoke<JiraComment>('jira_create_comment', {
+    workspaceId,
+    ...(projectId != null ? { projectId } : {}),
+    siteUrl,
+    email,
+    issueKey,
+    body,
+  });
 
 type UpdateDescriptionParams = JiraIssueTarget & {
   readonly description: string;
@@ -147,12 +167,20 @@ type UpdateDescriptionParams = JiraIssueTarget & {
 
 export const jiraUpdateIssueDescription = async ({
   workspaceId,
+  projectId,
   siteUrl,
   email,
   issueKey,
   description,
 }: UpdateDescriptionParams): Promise<void> => {
-  await invoke('jira_update_issue', { workspaceId, siteUrl, email, issueKey, description });
+  await invoke('jira_update_issue', {
+    workspaceId,
+    ...(projectId != null ? { projectId } : {}),
+    siteUrl,
+    email,
+    issueKey,
+    description,
+  });
 };
 
 type SetAssigneeParams = JiraIssueTarget & {
@@ -161,12 +189,20 @@ type SetAssigneeParams = JiraIssueTarget & {
 
 export const jiraSetAssignee = async ({
   workspaceId,
+  projectId,
   siteUrl,
   email,
   issueKey,
   accountId,
 }: SetAssigneeParams): Promise<void> => {
-  await invoke('jira_set_assignee', { workspaceId, siteUrl, email, issueKey, accountId });
+  await invoke('jira_set_assignee', {
+    workspaceId,
+    ...(projectId != null ? { projectId } : {}),
+    siteUrl,
+    email,
+    issueKey,
+    accountId,
+  });
 };
 
 type AssignableParams = JiraIssueTarget & {
@@ -175,6 +211,7 @@ type AssignableParams = JiraIssueTarget & {
 
 export const jiraListAssignableUsers = async ({
   workspaceId,
+  projectId,
   siteUrl,
   email,
   issueKey,
@@ -182,6 +219,7 @@ export const jiraListAssignableUsers = async ({
 }: AssignableParams): Promise<ReadonlyArray<JiraUser>> =>
   invoke<ReadonlyArray<JiraUser>>('jira_list_assignable_users', {
     workspaceId,
+    ...(projectId != null ? { projectId } : {}),
     siteUrl,
     email,
     issueKey,
@@ -190,12 +228,14 @@ export const jiraListAssignableUsers = async ({
 
 export const jiraListTransitions = async ({
   workspaceId,
+  projectId,
   siteUrl,
   email,
   issueKey,
 }: JiraIssueTarget): Promise<ReadonlyArray<JiraTransition>> =>
   invoke<ReadonlyArray<JiraTransition>>('jira_list_transitions', {
     workspaceId,
+    ...(projectId != null ? { projectId } : {}),
     siteUrl,
     email,
     issueKey,
@@ -207,6 +247,7 @@ type TransitionParams = JiraIssueTarget & {
 
 export const jiraTransitionIssue = async ({
   workspaceId,
+  projectId,
   siteUrl,
   email,
   issueKey,
@@ -214,6 +255,7 @@ export const jiraTransitionIssue = async ({
 }: TransitionParams): Promise<void> => {
   await invoke('jira_transition_issue', {
     workspaceId,
+    ...(projectId != null ? { projectId } : {}),
     siteUrl,
     email,
     issueKey,

--- a/apps/desktop/src/features/integrations/jira/useJiraIssue/index.ts
+++ b/apps/desktop/src/features/integrations/jira/useJiraIssue/index.ts
@@ -1,11 +1,12 @@
 import { useEffect, useState } from 'react';
 import { formatError } from '@goodboy/ui';
-import type { WorkspaceId } from '@goodboy/types';
+import type { ProjectId, WorkspaceId } from '@goodboy/types';
 import { jiraGetIssue, type JiraIssue } from '../client';
 import { useJiraConfig } from '../useJiraConfig';
 
 type Params = {
   readonly workspaceId: WorkspaceId;
+  readonly projectId?: ProjectId;
   readonly issueKey: string;
 };
 
@@ -16,7 +17,7 @@ type Result = {
   readonly refetch: () => void;
 };
 
-export const useJiraIssue = ({ workspaceId, issueKey }: Params): Result => {
+export const useJiraIssue = ({ workspaceId, projectId, issueKey }: Params): Result => {
   const config = useJiraConfig({ workspaceId });
   const siteUrl = config?.siteUrl ?? null;
   const email = config?.email ?? null;
@@ -37,7 +38,7 @@ export const useJiraIssue = ({ workspaceId, issueKey }: Params): Result => {
     setIssue(null);
     setError(null);
     setIsLoading(true);
-    jiraGetIssue({ workspaceId, siteUrl, email, issueKey })
+    jiraGetIssue({ workspaceId, projectId, siteUrl, email, issueKey })
       .then((next) => {
         if (isCancelled) {
           return;
@@ -60,7 +61,7 @@ export const useJiraIssue = ({ workspaceId, issueKey }: Params): Result => {
     return () => {
       isCancelled = true;
     };
-  }, [workspaceId, siteUrl, email, issueKey, attempt]);
+  }, [workspaceId, projectId, siteUrl, email, issueKey, attempt]);
 
   return { issue, isLoading, error, refetch: () => setAttempt((count) => count + 1) };
 };

--- a/apps/desktop/src/features/integrations/jira/useJiraIssueActions/index.ts
+++ b/apps/desktop/src/features/integrations/jira/useJiraIssueActions/index.ts
@@ -1,5 +1,5 @@
 import { useCallback, useState } from 'react';
-import type { WorkspaceId } from '@goodboy/types';
+import type { ProjectId, WorkspaceId } from '@goodboy/types';
 import {
   jiraGetIssue,
   jiraSetAssignee,
@@ -12,6 +12,7 @@ import { useJiraConfig } from '../useJiraConfig';
 type Params = {
   readonly issue: JiraIssue;
   readonly workspaceId: WorkspaceId;
+  readonly projectId?: ProjectId;
   readonly onWritten?: (() => void) | null;
 };
 
@@ -33,7 +34,12 @@ type SignatureParams = {
 
 const issueSignature = ({ issue }: SignatureParams): string => `${issue.id}:${issue.updated}`;
 
-export const useJiraIssueActions = ({ issue, workspaceId, onWritten }: Params): Result => {
+export const useJiraIssueActions = ({
+  issue,
+  workspaceId,
+  projectId,
+  onWritten,
+}: Params): Result => {
   const config = useJiraConfig({ workspaceId });
   const siteUrl = config?.siteUrl ?? null;
   const email = config?.email ?? null;
@@ -45,20 +51,20 @@ export const useJiraIssueActions = ({ issue, workspaceId, onWritten }: Params): 
     if (siteUrl == null || email == null) {
       return;
     }
-    const next = await jiraGetIssue({ workspaceId, siteUrl, email, issueKey });
+    const next = await jiraGetIssue({ workspaceId, projectId, siteUrl, email, issueKey });
     setHeld({ signature, issue: next });
     onWritten?.();
-  }, [workspaceId, siteUrl, email, issueKey, signature, onWritten]);
+  }, [workspaceId, projectId, siteUrl, email, issueKey, signature, onWritten]);
 
   const assign = useCallback(
     async (accountId: string | null) => {
       if (siteUrl == null || email == null) {
         return;
       }
-      await jiraSetAssignee({ workspaceId, siteUrl, email, issueKey, accountId });
+      await jiraSetAssignee({ workspaceId, projectId, siteUrl, email, issueKey, accountId });
       await refresh();
     },
-    [workspaceId, siteUrl, email, issueKey, refresh],
+    [workspaceId, projectId, siteUrl, email, issueKey, refresh],
   );
 
   const transition = useCallback(
@@ -66,10 +72,10 @@ export const useJiraIssueActions = ({ issue, workspaceId, onWritten }: Params): 
       if (siteUrl == null || email == null) {
         return;
       }
-      await jiraTransitionIssue({ workspaceId, siteUrl, email, issueKey, transitionId });
+      await jiraTransitionIssue({ workspaceId, projectId, siteUrl, email, issueKey, transitionId });
       await refresh();
     },
-    [workspaceId, siteUrl, email, issueKey, refresh],
+    [workspaceId, projectId, siteUrl, email, issueKey, refresh],
   );
 
   const saveDescription = useCallback(
@@ -79,6 +85,7 @@ export const useJiraIssueActions = ({ issue, workspaceId, onWritten }: Params): 
       }
       await jiraUpdateIssueDescription({
         workspaceId,
+        projectId,
         siteUrl,
         email,
         issueKey,
@@ -86,7 +93,7 @@ export const useJiraIssueActions = ({ issue, workspaceId, onWritten }: Params): 
       });
       await refresh();
     },
-    [workspaceId, siteUrl, email, issueKey, refresh],
+    [workspaceId, projectId, siteUrl, email, issueKey, refresh],
   );
 
   const isReady = siteUrl != null && email != null;

--- a/apps/desktop/src/features/integrations/jira/useJiraIssueComments/index.ts
+++ b/apps/desktop/src/features/integrations/jira/useJiraIssueComments/index.ts
@@ -82,7 +82,7 @@ export const useJiraIssueComments = ({ issue, workspaceId, projectId }: Params):
       });
       setComments((current) => [...current, created]);
     },
-    [workspaceId, siteUrl, email, issueKey],
+    [workspaceId, projectId, siteUrl, email, issueKey],
   );
 
   const isReady = siteUrl != null && email != null && issueKey != null;

--- a/apps/desktop/src/features/integrations/jira/useJiraIssueComments/index.ts
+++ b/apps/desktop/src/features/integrations/jira/useJiraIssueComments/index.ts
@@ -1,12 +1,13 @@
 import { useCallback, useEffect, useState } from 'react';
 import { formatError } from '@goodboy/ui';
-import type { WorkspaceId } from '@goodboy/types';
+import type { ProjectId, WorkspaceId } from '@goodboy/types';
 import { jiraCreateComment, jiraListComments, type JiraComment, type JiraIssue } from '../client';
 import { useJiraConfig } from '../useJiraConfig';
 
 type Params = {
   readonly issue: JiraIssue | null;
   readonly workspaceId: WorkspaceId;
+  readonly projectId?: ProjectId;
 };
 
 type Result = {
@@ -17,7 +18,7 @@ type Result = {
   readonly post: ((body: string) => Promise<void>) | null;
 };
 
-export const useJiraIssueComments = ({ issue, workspaceId }: Params): Result => {
+export const useJiraIssueComments = ({ issue, workspaceId, projectId }: Params): Result => {
   const config = useJiraConfig({ workspaceId });
   const siteUrl = config?.siteUrl ?? null;
   const email = config?.email ?? null;
@@ -37,7 +38,7 @@ export const useJiraIssueComments = ({ issue, workspaceId }: Params): Result => 
 
     let isCancelled = false;
     setIsLoading(true);
-    jiraListComments({ workspaceId, siteUrl, email, issueKey })
+    jiraListComments({ workspaceId, projectId, siteUrl, email, issueKey })
       .then((next) => {
         if (isCancelled) {
           return;
@@ -60,7 +61,7 @@ export const useJiraIssueComments = ({ issue, workspaceId }: Params): Result => 
     return () => {
       isCancelled = true;
     };
-  }, [workspaceId, siteUrl, email, issueKey, reloadToken]);
+  }, [workspaceId, projectId, siteUrl, email, issueKey, reloadToken]);
 
   const reload = useCallback(() => {
     setReloadToken((token) => token + 1);
@@ -71,7 +72,14 @@ export const useJiraIssueComments = ({ issue, workspaceId }: Params): Result => 
       if (siteUrl == null || email == null || issueKey == null) {
         return;
       }
-      const created = await jiraCreateComment({ workspaceId, siteUrl, email, issueKey, body });
+      const created = await jiraCreateComment({
+        workspaceId,
+        projectId,
+        siteUrl,
+        email,
+        issueKey,
+        body,
+      });
       setComments((current) => [...current, created]);
     },
     [workspaceId, siteUrl, email, issueKey],

--- a/apps/desktop/src/features/integrations/linear/LinearFormBody.tsx
+++ b/apps/desktop/src/features/integrations/linear/LinearFormBody.tsx
@@ -21,6 +21,7 @@ export const LinearFormBody = ({ workspaceId, onConnected, shouldAutoFocus = fal
     return (
       <IntegrationConnectedRow
         provider="linear"
+        credentialId={linear?.credentialId ?? null}
         primary={`Connected as ${linearConfig?.viewerName}`}
         secondary={`linear.app/${linearConfig?.workspaceUrlKey}`}
         disconnectDescription="Unlinks this project from the Linear personal API key. The key stays saved for your other projects."

--- a/apps/desktop/src/features/integrations/linear/LinearIssueDetail/index.tsx
+++ b/apps/desktop/src/features/integrations/linear/LinearIssueDetail/index.tsx
@@ -1,7 +1,7 @@
 import { StudioDetailLayout } from '../../../../shared/components/StudioDetail';
 import { useState, type ReactNode } from 'react';
 import { FileText, MessageSquare } from 'lucide-react';
-import type { WorkspaceId } from '@goodboy/types';
+import type { ProjectId, WorkspaceId } from '@goodboy/types';
 import { HeaderBand, StudioDetailTabs } from '@goodboy/ui';
 import { DescriptionSection } from '../../../../shared/components/DescriptionSection';
 import { linearIssueFields, resolveDetailFields } from '../../../../shared/detail-fields';
@@ -18,6 +18,7 @@ type Fit = 'fill' | 'bleed' | 'flow';
 type Props = {
   readonly issue: LinearIssue;
   readonly workspaceId: WorkspaceId;
+  readonly projectId?: ProjectId;
   readonly dock?: ReactNode;
   readonly headerActions?: ReactNode;
   readonly fit?: Fit;
@@ -26,6 +27,7 @@ type Props = {
 export const LinearIssueDetail = ({
   issue,
   workspaceId,
+  projectId,
   dock,
   headerActions,
   fit = 'fill',
@@ -34,8 +36,9 @@ export const LinearIssueDetail = ({
   const { comments, isLoading, error, post } = useLinearIssueComments({
     workspaceId,
     issueId: issue.id,
+    projectId,
   });
-  const { description, save } = useLinearIssueDescription({ issue, workspaceId });
+  const { description, save } = useLinearIssueDescription({ issue, workspaceId, projectId });
 
   return (
     <StudioDetailLayout

--- a/apps/desktop/src/features/integrations/linear/client.test.ts
+++ b/apps/desktop/src/features/integrations/linear/client.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { invoke } from '@tauri-apps/api/core';
-import type { WorkspaceId } from '@goodboy/types';
+import type { ProjectId, WorkspaceId } from '@goodboy/types';
 import {
   issuePullRequests,
   linearCreateComment,
@@ -114,6 +114,25 @@ describe('Linear issue requests', () => {
     expect(mockInvoke.mock.calls).toEqual([
       ['linear_fetch_issue', { workspaceId: WORKSPACE_ID, issueId: 'issue-42' }],
       ['linear_fetch_issue_comments', { workspaceId: WORKSPACE_ID, issueId: 'issue-42' }],
+    ]);
+  });
+
+  it('carries the project scope only when the caller knows one', async () => {
+    mockInvoke.mockResolvedValueOnce(makeIssue([])).mockResolvedValueOnce(makeIssue([]));
+
+    await linearFetchIssue({
+      workspaceId: WORKSPACE_ID,
+      issueId: 'issue-42',
+      projectId: 'project-9' as ProjectId,
+    });
+    await linearFetchIssue({ workspaceId: WORKSPACE_ID, issueId: 'issue-42' });
+
+    expect(mockInvoke.mock.calls).toEqual([
+      [
+        'linear_fetch_issue',
+        { workspaceId: WORKSPACE_ID, issueId: 'issue-42', projectId: 'project-9' },
+      ],
+      ['linear_fetch_issue', { workspaceId: WORKSPACE_ID, issueId: 'issue-42' }],
     ]);
   });
 

--- a/apps/desktop/src/features/integrations/linear/client.ts
+++ b/apps/desktop/src/features/integrations/linear/client.ts
@@ -1,5 +1,5 @@
 import { invoke } from '@tauri-apps/api/core';
-import type { IntegrationCredentialId, WorkspaceId } from '@goodboy/types';
+import type { IntegrationCredentialId, ProjectId, WorkspaceId } from '@goodboy/types';
 
 export type LinearViewer = {
   id: string;
@@ -57,6 +57,7 @@ export type LinearIssueComment = {
 type Params = {
   readonly workspaceId: WorkspaceId;
   readonly issueId: string;
+  readonly projectId?: ProjectId;
 };
 
 export type LinearLinkedPr = {
@@ -114,22 +115,37 @@ export const linearConnect = async (
 export const linearFetchAssignedIssues = async (
   workspaceId: WorkspaceId,
   teamId?: string,
+  projectId?: ProjectId,
 ): Promise<LinearIssue[]> => {
   return invoke<LinearIssue[]>('linear_fetch_assigned_issues', {
     workspaceId,
     teamId: teamId ?? null,
+    ...(projectId != null ? { projectId } : {}),
   });
 };
 
-export const linearFetchIssue = async ({ workspaceId, issueId }: Params): Promise<LinearIssue> => {
-  return invoke<LinearIssue>('linear_fetch_issue', { workspaceId, issueId });
+export const linearFetchIssue = async ({
+  workspaceId,
+  issueId,
+  projectId,
+}: Params): Promise<LinearIssue> => {
+  return invoke<LinearIssue>('linear_fetch_issue', {
+    workspaceId,
+    issueId,
+    ...(projectId != null ? { projectId } : {}),
+  });
 };
 
 export const linearFetchIssueComments = async ({
   workspaceId,
   issueId,
+  projectId,
 }: Params): Promise<LinearIssueComment[]> => {
-  return invoke<LinearIssueComment[]>('linear_fetch_issue_comments', { workspaceId, issueId });
+  return invoke<LinearIssueComment[]>('linear_fetch_issue_comments', {
+    workspaceId,
+    issueId,
+    ...(projectId != null ? { projectId } : {}),
+  });
 };
 
 type CreateCommentParams = Params & {
@@ -140,8 +156,14 @@ export const linearCreateComment = async ({
   workspaceId,
   issueId,
   body,
+  projectId,
 }: CreateCommentParams): Promise<LinearIssueComment> => {
-  return invoke<LinearIssueComment>('linear_create_comment', { workspaceId, issueId, body });
+  return invoke<LinearIssueComment>('linear_create_comment', {
+    workspaceId,
+    issueId,
+    body,
+    ...(projectId != null ? { projectId } : {}),
+  });
 };
 
 type UpdateDescriptionParams = Params & {
@@ -152,6 +174,12 @@ export const linearUpdateIssueDescription = async ({
   workspaceId,
   issueId,
   description,
+  projectId,
 }: UpdateDescriptionParams): Promise<string> => {
-  return invoke<string>('linear_update_issue', { workspaceId, issueId, description });
+  return invoke<string>('linear_update_issue', {
+    workspaceId,
+    issueId,
+    description,
+    ...(projectId != null ? { projectId } : {}),
+  });
 };

--- a/apps/desktop/src/features/integrations/linear/useLinearIssue.ts
+++ b/apps/desktop/src/features/integrations/linear/useLinearIssue.ts
@@ -1,11 +1,12 @@
 import { useEffect, useState } from 'react';
 import { formatError } from '@goodboy/ui';
-import type { WorkspaceId } from '@goodboy/types';
+import type { ProjectId, WorkspaceId } from '@goodboy/types';
 import { linearFetchIssue, type LinearIssue } from './client';
 
 type Params = {
   readonly workspaceId: WorkspaceId;
   readonly issueId: string;
+  readonly projectId?: ProjectId;
 };
 
 type Result = {
@@ -15,7 +16,7 @@ type Result = {
   readonly refetch: () => void;
 };
 
-export const useLinearIssue = ({ workspaceId, issueId }: Params): Result => {
+export const useLinearIssue = ({ workspaceId, issueId, projectId }: Params): Result => {
   const [issue, setIssue] = useState<LinearIssue | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -26,7 +27,7 @@ export const useLinearIssue = ({ workspaceId, issueId }: Params): Result => {
     setIssue(null);
     setError(null);
     setIsLoading(true);
-    linearFetchIssue({ workspaceId, issueId })
+    linearFetchIssue({ workspaceId, issueId, projectId })
       .then((nextIssue) => {
         if (isCancelled) {
           return;
@@ -49,7 +50,7 @@ export const useLinearIssue = ({ workspaceId, issueId }: Params): Result => {
     return () => {
       isCancelled = true;
     };
-  }, [issueId, workspaceId, attempt]);
+  }, [issueId, workspaceId, projectId, attempt]);
 
   return { issue, isLoading, error, refetch: () => setAttempt((count) => count + 1) };
 };

--- a/apps/desktop/src/features/integrations/linear/useLinearIssueComments.ts
+++ b/apps/desktop/src/features/integrations/linear/useLinearIssueComments.ts
@@ -1,11 +1,12 @@
 import { useCallback, useEffect, useState } from 'react';
 import { formatError } from '@goodboy/ui';
-import type { WorkspaceId } from '@goodboy/types';
+import type { ProjectId, WorkspaceId } from '@goodboy/types';
 import { linearCreateComment, linearFetchIssueComments, type LinearIssueComment } from './client';
 
 type Params = {
   readonly workspaceId: WorkspaceId;
   readonly issueId: string | null;
+  readonly projectId?: ProjectId;
 };
 
 type Result = {
@@ -15,7 +16,7 @@ type Result = {
   readonly post: ((body: string) => Promise<void>) | null;
 };
 
-export const useLinearIssueComments = ({ workspaceId, issueId }: Params): Result => {
+export const useLinearIssueComments = ({ workspaceId, issueId, projectId }: Params): Result => {
   const [comments, setComments] = useState<ReadonlyArray<LinearIssueComment>>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -30,7 +31,7 @@ export const useLinearIssueComments = ({ workspaceId, issueId }: Params): Result
 
     let isCancelled = false;
     setIsLoading(true);
-    linearFetchIssueComments({ workspaceId, issueId })
+    linearFetchIssueComments({ workspaceId, issueId, projectId })
       .then((nextComments) => {
         if (isCancelled) {
           return;
@@ -53,17 +54,17 @@ export const useLinearIssueComments = ({ workspaceId, issueId }: Params): Result
     return () => {
       isCancelled = true;
     };
-  }, [issueId, workspaceId]);
+  }, [issueId, workspaceId, projectId]);
 
   const post = useCallback(
     async (body: string) => {
       if (issueId == null) {
         return;
       }
-      const created = await linearCreateComment({ workspaceId, issueId, body });
+      const created = await linearCreateComment({ workspaceId, issueId, body, projectId });
       setComments((current) => [...current, created]);
     },
-    [issueId, workspaceId],
+    [issueId, workspaceId, projectId],
   );
 
   return { comments, isLoading, error, post: issueId != null ? post : null };

--- a/apps/desktop/src/features/integrations/linear/useLinearIssueDescription.ts
+++ b/apps/desktop/src/features/integrations/linear/useLinearIssueDescription.ts
@@ -1,10 +1,11 @@
 import { useCallback, useEffect, useState } from 'react';
-import type { WorkspaceId } from '@goodboy/types';
+import type { ProjectId, WorkspaceId } from '@goodboy/types';
 import { linearUpdateIssueDescription, type LinearIssue } from './client';
 
 type Params = {
   readonly issue: LinearIssue;
   readonly workspaceId: WorkspaceId | null;
+  readonly projectId?: ProjectId;
 };
 
 type Result = {
@@ -12,7 +13,7 @@ type Result = {
   readonly save: ((next: string) => Promise<void>) | null;
 };
 
-export const useLinearIssueDescription = ({ issue, workspaceId }: Params): Result => {
+export const useLinearIssueDescription = ({ issue, workspaceId, projectId }: Params): Result => {
   const [saved, setSaved] = useState<string | null>(null);
   const issueId = issue.id;
 
@@ -29,10 +30,11 @@ export const useLinearIssueDescription = ({ issue, workspaceId }: Params): Resul
         workspaceId,
         issueId,
         description: next,
+        projectId,
       });
       setSaved(description);
     },
-    [workspaceId, issueId],
+    [workspaceId, issueId, projectId],
   );
 
   return {

--- a/apps/desktop/src/features/integrations/sentry/SentryFormBody.tsx
+++ b/apps/desktop/src/features/integrations/sentry/SentryFormBody.tsx
@@ -25,6 +25,7 @@ export const SentryFormBody = ({ workspaceId, onConnected, shouldAutoFocus = fal
     return (
       <IntegrationConnectedRow
         provider="sentry"
+        credentialId={sentry?.credentialId ?? null}
         primary={`Connected to ${sentryConfig.projectName ?? sentryConfig.project}`}
         secondary={`${sentryConfig.org}/${sentryConfig.project}`}
         disconnectDescription="Unlinks this project from the Sentry personal API key. The key stays saved for your other projects."

--- a/apps/desktop/src/features/integrations/sentry/client.ts
+++ b/apps/desktop/src/features/integrations/sentry/client.ts
@@ -1,5 +1,5 @@
 import { invoke } from '@tauri-apps/api/core';
-import type { IntegrationCredentialId, WorkspaceId } from '@goodboy/types';
+import type { IntegrationCredentialId, ProjectId, WorkspaceId } from '@goodboy/types';
 
 export type SentryOrganization = {
   slug: string;
@@ -89,29 +89,42 @@ export const sentryFetchIssues = async (
   workspaceId: WorkspaceId,
   query?: string,
   cursor?: string,
+  projectId?: ProjectId,
 ): Promise<SentryIssuesPage> => {
   return invoke<SentryIssuesPage>('sentry_fetch_issues', {
     workspaceId,
     query: query ?? null,
     cursor: cursor ?? null,
+    ...(projectId != null ? { projectId } : {}),
   });
 };
 
 type FetchIssueParams = {
   readonly workspaceId: WorkspaceId;
   readonly issueId: string;
+  readonly projectId?: ProjectId;
 };
 
 export const sentryFetchIssue = async ({
   workspaceId,
   issueId,
+  projectId,
 }: FetchIssueParams): Promise<SentryIssue> => {
-  return invoke<SentryIssue>('sentry_fetch_issue', { workspaceId, issueId });
+  return invoke<SentryIssue>('sentry_fetch_issue', {
+    workspaceId,
+    issueId,
+    ...(projectId != null ? { projectId } : {}),
+  });
 };
 
 export const sentryFetchIssueDetail = async (
   workspaceId: WorkspaceId,
   issueId: string,
+  projectId?: ProjectId,
 ): Promise<SentryIssueDetail> => {
-  return invoke<SentryIssueDetail>('sentry_fetch_issue_detail', { workspaceId, issueId });
+  return invoke<SentryIssueDetail>('sentry_fetch_issue_detail', {
+    workspaceId,
+    issueId,
+    ...(projectId != null ? { projectId } : {}),
+  });
 };

--- a/apps/desktop/src/features/integrations/sentry/useSentryIssue/index.ts
+++ b/apps/desktop/src/features/integrations/sentry/useSentryIssue/index.ts
@@ -1,11 +1,12 @@
 import { useEffect, useState } from 'react';
 import { formatError } from '@goodboy/ui';
-import type { WorkspaceId } from '@goodboy/types';
+import type { ProjectId, WorkspaceId } from '@goodboy/types';
 import { sentryFetchIssue, type SentryIssue } from '../client';
 
 type Params = {
   readonly workspaceId: WorkspaceId;
   readonly issueId: string | null;
+  readonly projectId?: ProjectId;
 };
 
 type Result = {
@@ -15,7 +16,7 @@ type Result = {
   readonly refetch: () => void;
 };
 
-export const useSentryIssue = ({ workspaceId, issueId }: Params): Result => {
+export const useSentryIssue = ({ workspaceId, issueId, projectId }: Params): Result => {
   const [issue, setIssue] = useState<SentryIssue | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -31,7 +32,7 @@ export const useSentryIssue = ({ workspaceId, issueId }: Params): Result => {
 
     let isCancelled = false;
     setIsLoading(true);
-    sentryFetchIssue({ workspaceId, issueId })
+    sentryFetchIssue({ workspaceId, issueId, projectId })
       .then((nextIssue) => {
         if (isCancelled) {
           return;
@@ -54,7 +55,7 @@ export const useSentryIssue = ({ workspaceId, issueId }: Params): Result => {
     return () => {
       isCancelled = true;
     };
-  }, [workspaceId, issueId, attempt]);
+  }, [workspaceId, issueId, projectId, attempt]);
 
   return { issue, isLoading, error, refetch: () => setAttempt((n) => n + 1) };
 };

--- a/apps/desktop/src/features/integrations/sentry/useSentryIssueDetail.ts
+++ b/apps/desktop/src/features/integrations/sentry/useSentryIssueDetail.ts
@@ -1,11 +1,12 @@
 import { useEffect, useState } from 'react';
 import { formatError } from '@goodboy/ui';
-import type { WorkspaceId } from '@goodboy/types';
+import type { ProjectId, WorkspaceId } from '@goodboy/types';
 import { sentryFetchIssueDetail, type SentryIssueDetail } from './client';
 
 type Params = {
   readonly workspaceId: WorkspaceId;
   readonly issueId: string | null;
+  readonly projectId?: ProjectId;
 };
 
 type Detail = SentryIssueDetail & {
@@ -18,7 +19,7 @@ type Result = {
   readonly error: string | null;
 };
 
-export const useSentryIssueDetail = ({ workspaceId, issueId }: Params): Result => {
+export const useSentryIssueDetail = ({ workspaceId, issueId, projectId }: Params): Result => {
   const [detail, setDetail] = useState<Detail | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -33,7 +34,7 @@ export const useSentryIssueDetail = ({ workspaceId, issueId }: Params): Result =
 
     let isCancelled = false;
     setIsLoading(true);
-    sentryFetchIssueDetail(workspaceId, issueId)
+    sentryFetchIssueDetail(workspaceId, issueId, projectId)
       .then((nextDetail) => {
         if (isCancelled) {
           return;
@@ -56,7 +57,7 @@ export const useSentryIssueDetail = ({ workspaceId, issueId }: Params): Result =
     return () => {
       isCancelled = true;
     };
-  }, [issueId, workspaceId]);
+  }, [issueId, workspaceId, projectId]);
 
   return { detail, isLoading, error };
 };

--- a/apps/desktop/src/features/integrations/slack/SlackFormBody.tsx
+++ b/apps/desktop/src/features/integrations/slack/SlackFormBody.tsx
@@ -29,6 +29,7 @@ export const SlackFormBody = ({ workspaceId, onConnected, shouldAutoFocus = fals
     return (
       <IntegrationConnectedRow
         provider="slack"
+        credentialId={slack?.credentialId ?? null}
         primary={`Connected to ${slack.config.teamName}`}
         secondary={`as ${slack.config.botUserName ?? slack.config.botUserId}`}
         disconnectDescription="Unlinks this project from the Slack token. The token stays saved for your other projects."

--- a/apps/desktop/src/features/integrations/useCredentialSecret/index.ts
+++ b/apps/desktop/src/features/integrations/useCredentialSecret/index.ts
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react';
+import type { IntegrationCredentialId } from '@goodboy/types';
+import { invoke } from '@tauri-apps/api/core';
+
+export type CredentialSecretState = 'unknown' | 'present' | 'missing';
+
+type Params = {
+  readonly credentialId: IntegrationCredentialId | null;
+};
+
+export const useCredentialSecret = ({ credentialId }: Params): CredentialSecretState => {
+  const [state, setState] = useState<CredentialSecretState>('unknown');
+
+  useEffect(() => {
+    if (credentialId == null) {
+      setState('unknown');
+      return;
+    }
+    let isCancelled = false;
+    setState('unknown');
+    invoke<boolean>('integration_credential_has_secret', { credentialId })
+      .then((hasSecret) => {
+        if (isCancelled) {
+          return;
+        }
+        setState(hasSecret ? 'present' : 'missing');
+      })
+      .catch(() => {
+        if (isCancelled) {
+          return;
+        }
+        setState('unknown');
+      });
+    return () => {
+      isCancelled = true;
+    };
+  }, [credentialId]);
+
+  return state;
+};

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/FocusedTaskBody.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/FocusedTaskBody.tsx
@@ -2,6 +2,7 @@ import type {
   SessionExternalTask,
   SessionExternalTaskProvider,
   SessionId,
+  ProjectId,
   WorkspaceId,
 } from '@goodboy/types';
 import { StudioDetailLayout } from '../../../../../../shared/components/StudioDetail';
@@ -21,18 +22,26 @@ type Props = {
   readonly sessionId: SessionId;
   readonly workspaceId: WorkspaceId;
   readonly task: SessionExternalTask;
+  readonly projectId?: ProjectId;
   readonly isConnected: boolean;
 };
 
-export const FocusedTaskBody = ({ provider, sessionId, workspaceId, task, isConnected }: Props) => {
+export const FocusedTaskBody = ({
+  provider,
+  sessionId,
+  workspaceId,
+  task,
+  projectId,
+  isConnected,
+}: Props) => {
   const repo = useSessionRepo({ sessionId });
 
   if (isConnected && provider === 'linear') {
-    return <LinearTaskDetail workspaceId={workspaceId} task={task} />;
+    return <LinearTaskDetail workspaceId={workspaceId} projectId={projectId} task={task} />;
   }
 
   if (isConnected && provider === 'sentry') {
-    return <SentryTaskDetail workspaceId={workspaceId} task={task} />;
+    return <SentryTaskDetail workspaceId={workspaceId} projectId={projectId} task={task} />;
   }
 
   if (isConnected && provider === 'github') {
@@ -42,11 +51,11 @@ export const FocusedTaskBody = ({ provider, sessionId, workspaceId, task, isConn
   }
 
   if (isConnected && provider === 'gitlab') {
-    return <GitlabTaskDetail workspaceId={workspaceId} task={task} />;
+    return <GitlabTaskDetail workspaceId={workspaceId} projectId={projectId} task={task} />;
   }
 
   if (isConnected && provider === 'jira') {
-    return <JiraTaskDetail workspaceId={workspaceId} task={task} />;
+    return <JiraTaskDetail workspaceId={workspaceId} projectId={projectId} task={task} />;
   }
 
   if (isConnected && provider === 'slack') {

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/GitlabTaskDetail.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/GitlabTaskDetail.tsx
@@ -1,6 +1,6 @@
 import { StudioDetailLayout } from '../../../../../../shared/components/StudioDetail';
 import { Skeleton } from '@goodboy/ui';
-import type { SessionExternalTask, WorkspaceId } from '@goodboy/types';
+import type { ProjectId, SessionExternalTask, WorkspaceId } from '@goodboy/types';
 import { ErrorStrip } from '@goodboy/ui';
 import { HeaderBand } from '@goodboy/ui';
 import { GitlabIssueDetail } from '../../../../../integrations/gitlab/GitlabIssueDetail';
@@ -8,17 +8,21 @@ import { useGitlabIssue } from '../../../../../integrations/gitlab/useGitlabIssu
 
 type Props = {
   readonly workspaceId: WorkspaceId;
+  readonly projectId?: ProjectId;
   readonly task: SessionExternalTask;
 };
 
-export const GitlabTaskDetail = ({ workspaceId, task }: Props) => {
+export const GitlabTaskDetail = ({ workspaceId, projectId, task }: Props) => {
   const { issue, isLoading, error, refetch } = useGitlabIssue({
     workspaceId,
     identifier: task.identifier,
+    projectId,
   });
 
   if (issue != null) {
-    return <GitlabIssueDetail issue={issue} workspaceId={workspaceId} fit="fill" />;
+    return (
+      <GitlabIssueDetail issue={issue} workspaceId={workspaceId} projectId={projectId} fit="fill" />
+    );
   }
 
   return (

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/JiraTaskDetail.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/JiraTaskDetail.tsx
@@ -1,6 +1,6 @@
 import { StudioDetailLayout } from '../../../../../../shared/components/StudioDetail';
 import { Skeleton } from '@goodboy/ui';
-import type { SessionExternalTask, WorkspaceId } from '@goodboy/types';
+import type { ProjectId, SessionExternalTask, WorkspaceId } from '@goodboy/types';
 import { ErrorStrip } from '@goodboy/ui';
 import { HeaderBand } from '@goodboy/ui';
 import { JiraIssueDetail } from '../../../../../integrations/jira/JiraIssueDetail';
@@ -8,17 +8,21 @@ import { useJiraIssue } from '../../../../../integrations/jira/useJiraIssue';
 
 type Props = {
   readonly workspaceId: WorkspaceId;
+  readonly projectId?: ProjectId;
   readonly task: SessionExternalTask;
 };
 
-export const JiraTaskDetail = ({ workspaceId, task }: Props) => {
+export const JiraTaskDetail = ({ workspaceId, projectId, task }: Props) => {
   const { issue, isLoading, error, refetch } = useJiraIssue({
     workspaceId,
     issueKey: task.identifier,
+    projectId,
   });
 
   if (issue != null) {
-    return <JiraIssueDetail issue={issue} workspaceId={workspaceId} fit="fill" />;
+    return (
+      <JiraIssueDetail issue={issue} workspaceId={workspaceId} projectId={projectId} fit="fill" />
+    );
   }
 
   return (

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/LinearTaskDetail.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/LinearTaskDetail.tsx
@@ -1,6 +1,6 @@
 import { StudioDetailLayout } from '../../../../../../shared/components/StudioDetail';
 import { Skeleton } from '@goodboy/ui';
-import type { SessionExternalTask, WorkspaceId } from '@goodboy/types';
+import type { ProjectId, SessionExternalTask, WorkspaceId } from '@goodboy/types';
 import { ErrorStrip } from '@goodboy/ui';
 import { HeaderBand } from '@goodboy/ui';
 import { LinearIssueDetail } from '../../../../../integrations/linear/LinearIssueDetail';
@@ -8,17 +8,21 @@ import { useLinearIssue } from '../../../../../integrations/linear/useLinearIssu
 
 type Props = {
   readonly workspaceId: WorkspaceId;
+  readonly projectId?: ProjectId;
   readonly task: SessionExternalTask;
 };
 
-export const LinearTaskDetail = ({ workspaceId, task }: Props) => {
+export const LinearTaskDetail = ({ workspaceId, projectId, task }: Props) => {
   const { issue, isLoading, error, refetch } = useLinearIssue({
     workspaceId,
     issueId: task.externalId,
+    projectId,
   });
 
   if (issue != null) {
-    return <LinearIssueDetail issue={issue} workspaceId={workspaceId} fit="fill" />;
+    return (
+      <LinearIssueDetail issue={issue} workspaceId={workspaceId} projectId={projectId} fit="fill" />
+    );
   }
 
   return (

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/SentryTaskDetail.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/SentryTaskDetail.tsx
@@ -1,14 +1,15 @@
-import type { SessionExternalTask, WorkspaceId } from '@goodboy/types';
+import type { ProjectId, SessionExternalTask, WorkspaceId } from '@goodboy/types';
 import { SentryIssueDetail } from '../../../../../integrations/sentry/SentryIssueDetail';
 import { useSentryIssue } from '../../../../../integrations/sentry/useSentryIssue';
 import { useSentryIssueDetail } from '../../../../../integrations/sentry/useSentryIssueDetail';
 
 type Props = {
   readonly workspaceId: WorkspaceId;
+  readonly projectId?: ProjectId;
   readonly task: SessionExternalTask;
 };
 
-export const SentryTaskDetail = ({ workspaceId, task }: Props) => {
+export const SentryTaskDetail = ({ workspaceId, projectId, task }: Props) => {
   const {
     issue,
     isLoading: isIssueLoading,
@@ -17,10 +18,12 @@ export const SentryTaskDetail = ({ workspaceId, task }: Props) => {
   } = useSentryIssue({
     workspaceId,
     issueId: task.externalId,
+    projectId,
   });
   const { detail, isLoading, error } = useSentryIssueDetail({
     workspaceId,
     issueId: task.externalId,
+    projectId,
   });
 
   return (

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/index.tsx
@@ -25,6 +25,7 @@ import { FocusedTaskBody } from './FocusedTaskBody';
 import { integrationTaskKey } from './integrationTaskKey';
 import { LinkTicketPopover } from './LinkTicketPopover';
 import { WorkItemList } from './WorkItemList';
+import { useSessionProjectScope } from '../../../../hooks/useSessionProjectScope';
 
 type Props = {
   readonly sessionId: SessionId;
@@ -120,6 +121,7 @@ export const IntegrationPane = ({ sessionId, workspaceId, provider }: Props) => 
   );
   const githubConnection = useGithubConnection({ workspaceId });
   const sessionBranch = useSessionRepo({ sessionId })?.branch ?? null;
+  const projectScope = useSessionProjectScope({ sessionId });
   const branchPrs = useAppStore((state) => selectActiveProjectPrs({ state, sessionId }));
   const mergeRequest = useAppStore((state) => state.sessionGitlabMr[sessionId]?.mr ?? null);
   const tasks = useMemo(
@@ -222,6 +224,7 @@ export const IntegrationPane = ({ sessionId, workspaceId, provider }: Props) => 
             sessionId={sessionId}
             workspaceId={workspaceId}
             task={focusedTask}
+            projectId={focusedTask.projectId ?? projectScope}
             isConnected={connection.isConnected}
           />
         </div>

--- a/apps/desktop/src/features/session/hooks/useSessionProjectScope/index.test.ts
+++ b/apps/desktop/src/features/session/hooks/useSessionProjectScope/index.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import type { ProjectId, Session, SessionId } from '@goodboy/types';
+import { useAppStore } from '../../../../store';
+import { useSessionProjectScope } from './index';
+
+const SESSION_ID = 'session-1' as SessionId;
+const STORED = 'project-stored' as ProjectId;
+const ON_ROW = 'project-row' as ProjectId;
+
+const session = { id: SESSION_ID, activeProjectId: ON_ROW } as unknown as Session;
+
+const seed = ({
+  sessions,
+  active,
+}: {
+  readonly sessions: ReadonlyArray<Session>;
+  readonly active: Record<string, ProjectId>;
+}) => {
+  useAppStore.setState({ sessions, sessionActiveProject: active } as never);
+};
+
+describe('useSessionProjectScope', () => {
+  it('prefers the project the store says is active', () => {
+    seed({ sessions: [session], active: { [SESSION_ID]: STORED } });
+
+    const { result } = renderHook(() => useSessionProjectScope({ sessionId: SESSION_ID }));
+
+    expect(result.current).toBe(STORED);
+  });
+
+  it('falls back to the project on the session row', () => {
+    seed({ sessions: [session], active: {} });
+
+    const { result } = renderHook(() => useSessionProjectScope({ sessionId: SESSION_ID }));
+
+    expect(result.current).toBe(ON_ROW);
+  });
+
+  it('has no scope for a session that touches no project', () => {
+    seed({ sessions: [{ ...session, activeProjectId: undefined }], active: {} });
+
+    const { result } = renderHook(() => useSessionProjectScope({ sessionId: SESSION_ID }));
+
+    expect(result.current).toBeUndefined();
+  });
+});

--- a/apps/desktop/src/features/session/hooks/useSessionProjectScope/index.ts
+++ b/apps/desktop/src/features/session/hooks/useSessionProjectScope/index.ts
@@ -1,0 +1,15 @@
+import type { ProjectId, SessionId } from '@goodboy/types';
+import { useAppStore } from '../../../../store';
+
+type Params = {
+  readonly sessionId: SessionId;
+};
+
+export const useSessionProjectScope = ({ sessionId }: Params): ProjectId | undefined =>
+  useAppStore((state) => {
+    const storedProjectId = state.sessionActiveProject[sessionId];
+    if (storedProjectId != null) {
+      return storedProjectId;
+    }
+    return state.sessions.find((session) => session.id === sessionId)?.activeProjectId ?? undefined;
+  });


### PR DESCRIPTION
## The bug, from a real machine

Opening a Linear task in a session failed with `credential store error: no linear credential is stored under that id`, while Sentry in the same workspace worked and GitHub had to be re-pasted by hand after upgrading to v0.2.0.

Checked against the live keychain (service `com.goodboy.desktop`, one entry per credential id):

| credential | binding | keychain |
|---|---|---|
| linear A | project `app-web` | present |
| linear B | workspace | **absent** |
| sentry | workspace | present |

The session's active project is `app-web`, so the healthy credential was right there. It was unreachable: `read_for_binding` takes a `project_id` and prefers a project override, but every caller passed `None`, so resolution always landed on the workspace binding, which pointed at a credential whose key was never in the keychain.

`github.rs` was worse. Its `read_token` fed each scope id into `read_for_binding` as the *workspace* id with `project_id` hardcoded to `None`. Since m131 put a foreign key from `integration_bindings.workspace_id` to `workspaces(id)`, a project id can never match that column, so the whole scope chain was dead code and every read fell through to the global credential.

This is v0.2 fallout: m131 elected a lead project and moved the meaningful binding down to project scope, where nobody was looking.

## What changed

**Resolution** (`integration_credentials.rs`). `resolve_and_read` takes the secret read as a closure, so resolution is testable without a keychain. A bound credential is the scope's declared account: if its key is gone the caller gets `MissingSecret` naming the provider, never a silent hop onto another account, because a wrong-account fallback can comment or push as someone else. Only the unbound tier, where nothing was declared, skips a candidate it cannot read.

**Threading**. The commands of linear, sentry, gitlab, jira, bitbucket and slack take an optional project id (59 signatures, every one optional, so callers that omit it behave exactly as before). Sentry also scopes its config lookup. The companion bridge forwards the project its scope already carries. github's dead scope chain is replaced by a real project, workspace, global resolution.

**Front end**. The session task detail sends `task.projectId ?? sessionActiveProject`. Workspace surfaces (Studios, kickoff, connect forms, settings) deliberately keep sending nothing.

**Honesty in settings**. The connected row asked "does this credential still have a key" and says plainly when it does not, instead of rendering `Connected as X` over a connection that fails every request.

**Boot sweep**. Credential rows that no binding claims and no key backs are deleted at boot. Rows only, never the keychain, and never a credential a scope still names.

## Deliberately not here

- No SQL migration: the breakage is keychain state, invisible to SQLite, so a migration could only guess and guessing here deletes real bindings.
- Slack stays workspace-scoped: its thread cache is keyed without a project, so scoping it is its own change.
- The user's dead workspace binding still needs one manual reconnect; after this it is visible instead of silent.

## Verification

Rust 566 tests, desktop 6497 tests, typecheck clean. New tests pin the exact case above: with the project the live credential answers, without it the resolution fails naming the dead credential, a bound credential never borrows another account, the unbound tier skips what it cannot read, and the sweep drops only what nothing claims.