### PR TITLE
fix(ui): read the branch again when a turn ends

### DIFF
--- a/apps/desktop/src/features/session/components/SessionWorkspace/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/index.test.tsx
@@ -121,6 +121,7 @@ vi.mock('../../../../store', () => ({
     return records[collection]?.[sessionId] !== undefined;
   },
   useFilesTouched: () => ({ paths: [], count: 0, additions: 0, deletions: 0 }),
+  useSessionLastTurnFinishedAt: () => null,
   useSessionPlans: () => [],
   useSessionOpenQuestions: () => hooks.openQuestions,
   useDiffComments: () => [],

--- a/apps/desktop/src/features/session/hooks/useSessionBranchSync/index.test.ts
+++ b/apps/desktop/src/features/session/hooks/useSessionBranchSync/index.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, renderHook, waitFor } from '@testing-library/react';
+import type { Session, SessionId, WorkspaceId } from '@goodboy/types';
+
+const h = vi.hoisted(() => ({
+  reconcileSessionBranch: vi.fn(async () => undefined),
+  lastTurnFinishedAt: null as string | null,
+  worktreePath: '/sessions/one/api' as string | null,
+  status: vi.fn(async () => ({ branch: 'ak/renamed-by-an-agent' })),
+}));
+
+vi.mock('../../../../store', () => ({
+  useAppStore: (selector: (state: unknown) => unknown) =>
+    selector({ reconcileSessionBranch: h.reconcileSessionBranch }),
+  useSessionLastTurnFinishedAt: () => h.lastTurnFinishedAt,
+}));
+
+vi.mock('../../../../store/slices/worktrees/resolveSessionRepo', () => ({
+  resolveSessionRepo: () => (h.worktreePath == null ? null : { worktreePath: h.worktreePath }),
+}));
+
+vi.mock('../../../worktree/worktree', () => ({
+  worktreeStatus: () => h.status(),
+}));
+
+vi.mock('../useIsBranchlessSession', () => ({
+  useIsBranchlessSession: () => false,
+}));
+
+import { useSessionBranchSync } from './index';
+
+const session = {
+  id: 'session-1' as SessionId,
+  workspaceId: 'workspace-1' as WorkspaceId,
+} as unknown as Session;
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  h.lastTurnFinishedAt = null;
+  h.worktreePath = '/sessions/one/api';
+});
+
+describe('useSessionBranchSync', () => {
+  it('reads the branch off disk once the session is on screen', async () => {
+    renderHook(() => useSessionBranchSync({ session, isActive: true }));
+
+    await waitFor(() =>
+      expect(h.reconcileSessionBranch).toHaveBeenCalledWith(session.id, 'ak/renamed-by-an-agent'),
+    );
+  });
+
+  it('reads it again when a turn ends, even though no file changed', async () => {
+    const { rerender } = renderHook(() => useSessionBranchSync({ session, isActive: true }));
+    await waitFor(() => expect(h.status).toHaveBeenCalledTimes(1));
+
+    h.lastTurnFinishedAt = '2026-08-27T10:00:00.000Z';
+    rerender();
+
+    await waitFor(() => expect(h.status).toHaveBeenCalledTimes(2));
+  });
+
+  it('leaves a session alone while it is off screen', () => {
+    renderHook(() => useSessionBranchSync({ session, isActive: false }));
+
+    expect(h.status).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/features/session/hooks/useSessionBranchSync/index.ts
+++ b/apps/desktop/src/features/session/hooks/useSessionBranchSync/index.ts
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import type { Session, SessionId } from '@goodboy/types';
-import { useAppStore, useFilesTouched } from '../../../../store';
+import { useAppStore, useSessionLastTurnFinishedAt } from '../../../../store';
 import { resolveSessionRepo } from '../../../../store/slices/worktrees/resolveSessionRepo';
 import { worktreeStatus } from '../../../worktree/worktree';
 import { useIsBranchlessSession } from '../useIsBranchlessSession';
@@ -17,7 +17,7 @@ export const useSessionBranchSync = ({ session, isActive }: Params): void => {
   const sessionRepo = useAppStore(useShallow((state) => resolveSessionRepo({ state, sessionId })));
   const projectWorktreePath = sessionRepo?.worktreePath ?? null;
   const reconcileSessionBranch = useAppStore((s) => s.reconcileSessionBranch);
-  const filesTouched = useFilesTouched(sessionId, isActive && !isBranchless);
+  const lastTurnFinishedAt = useSessionLastTurnFinishedAt(sessionId);
 
   useEffect(() => {
     if (!isActive || projectWorktreePath == null || isBranchless) return;
@@ -33,9 +33,9 @@ export const useSessionBranchSync = ({ session, isActive }: Params): void => {
       cancelled = true;
     };
   }, [
-    filesTouched.count,
     isActive,
     isBranchless,
+    lastTurnFinishedAt,
     projectWorktreePath,
     reconcileSessionBranch,
     sessionId,

--- a/apps/desktop/src/store/index.ts
+++ b/apps/desktop/src/store/index.ts
@@ -7,6 +7,7 @@ export {
   useCurrentWorkspace,
   useDiffComments,
   useFilesTouched,
+  useSessionLastTurnFinishedAt,
   useMountDiffStats,
   useSessionAnsweredQuestions,
   useSessionById,

--- a/apps/desktop/src/store/selectors.ts
+++ b/apps/desktop/src/store/selectors.ts
@@ -588,7 +588,7 @@ export type FilesTouched = {
 
 const EMPTY_FILES_TOUCHED: FilesTouched = { paths: [], count: 0, additions: 0, deletions: 0 };
 
-const useSessionLastTurnFinishedAt = (sessionId: SessionId | null): string | null =>
+export const useSessionLastTurnFinishedAt = (sessionId: SessionId | null): string | null =>
   useAppStore((s) => {
     if (sessionId == null) {
       return null;


### PR DESCRIPTION
Closes #1539.

## Why

Reported on v0.2.0: an agent renamed the project branch and the overview kept showing the old name until a manual reload.

`useSessionBranchSync` reads the branch off disk and reconciles it, but its effect was keyed on `filesTouched.count`. That number comes from `worktreeChangedFiles`, so the branch is only re-read when the count of changed files changes. Renaming a branch changes no files, so the effect never fired again and the stale name stayed until the app reloaded and the mount-time run happened.

## What

The effect keys off the last turn that finished, which is the moment an agent can have moved the branch, so the check runs after every turn regardless of what happened to the working tree. `useSessionLastTurnFinishedAt` moves from private to exported for it; the hook no longer asks for a file list it only used as a change counter, which also drops one `git status` per refresh.

The window between an agent renaming the branch mid-turn and the turn ending still shows the old name. Closing that needs a watcher, not a trigger, and is not worth it here.

3 new tests: reads on mount, reads again when a turn ends with no file change (the reported bug), stays quiet while the session is off screen.

Session and store suites green (3165 tests), typecheck clean.