### PR TITLE
feat(ui): give every script the project it belongs to

### DIFF
--- a/apps/desktop/src/features/chat/components/ChatInput/hooks/useChatPrefix/index.test.tsx
+++ b/apps/desktop/src/features/chat/components/ChatInput/hooks/useChatPrefix/index.test.tsx
@@ -46,7 +46,6 @@ function renderChatPrefix() {
       session,
       value: '~',
       setValue: vi.fn(),
-      sessionWorktree: null,
       showToast: vi.fn(),
       wrapperRef: { current: null },
     }),

--- a/apps/desktop/src/features/chat/components/ChatInput/hooks/useChatPrefix/index.ts
+++ b/apps/desktop/src/features/chat/components/ChatInput/hooks/useChatPrefix/index.ts
@@ -22,19 +22,11 @@ type Params = {
   readonly session: Session;
   readonly value: string;
   readonly setValue: (next: string) => void;
-  readonly sessionWorktree: string | null;
   readonly showToast: (kind: ToastKind, message: string) => void;
   readonly wrapperRef: RefObject<HTMLDivElement | null>;
 };
 
-export const useChatPrefix = ({
-  session,
-  value,
-  setValue,
-  sessionWorktree,
-  showToast,
-  wrapperRef,
-}: Params) => {
+export const useChatPrefix = ({ session, value, setValue, showToast, wrapperRef }: Params) => {
   const workspaceSkills = useAppStore(
     useShallow((s) => s.skills[session.workspaceId] ?? EMPTY_ARRAY),
   );
@@ -65,15 +57,11 @@ export const useChatPrefix = ({
 
   const onPickScript = useCallback(
     (script: ProjectScript) => {
-      if (!sessionWorktree) {
-        showToast('warning', `${script.name}, open a session worktree to run scripts`);
-        return;
-      }
       setValue('');
       setShowPopover(false);
-      void runScript(session.id, script.id, sessionWorktree);
+      void runScript({ sessionId: session.id, scriptId: script.id });
     },
-    [runScript, setValue, session.id, sessionWorktree, showToast],
+    [runScript, setValue, session.id],
   );
 
   const onPickSkill = useCallback(

--- a/apps/desktop/src/features/chat/components/ChatInput/index.tsx
+++ b/apps/desktop/src/features/chat/components/ChatInput/index.tsx
@@ -115,7 +115,7 @@ export const ChatInput = ({ session, providerDisconnected = false }: Props) => {
     quickEmptyHint,
     onQuickActionSelect,
     dismissPopover,
-  } = useChatPrefix({ session, value, setValue, sessionWorktree, showToast, wrapperRef });
+  } = useChatPrefix({ session, value, setValue, showToast, wrapperRef });
 
   const routing = useTurnRouting({ session });
   const dispatch = useTurnDispatch({ sessionId: session.id, cleanupSentAttachments });
@@ -547,8 +547,8 @@ export const ChatInput = ({ session, providerDisconnected = false }: Props) => {
                   wrapperRef.current?.querySelector('textarea')?.focus();
                 }}
                 disabled={providerDisconnected}
-                title="Run a workspace script"
-                aria-label="Run a workspace script"
+                title="Run a project script"
+                aria-label="Run a project script"
                 className="inline-flex h-7 w-7 items-center justify-center rounded-md font-mono text-sm text-muted-foreground transition-colors hover:bg-foreground/5 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40"
               >
                 $

--- a/apps/desktop/src/features/scripts/components/ScriptsPanel/NewScriptCard.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsPanel/NewScriptCard.tsx
@@ -1,12 +1,17 @@
 import { AlertTriangle } from 'lucide-react';
 import { Button, Divider, FieldRow, Input, Textarea } from '@goodboy/ui';
+import type { Project, ProjectId } from '@goodboy/types';
+import { ProjectSelect } from './ProjectSelect';
 
 type Props = {
   readonly name: string;
   readonly body: string;
+  readonly projects: ReadonlyArray<Project>;
+  readonly projectId: ProjectId;
   readonly error: string | null;
   readonly onNameChange: (value: string) => void;
   readonly onBodyChange: (value: string) => void;
+  readonly onProjectChange: (projectId: ProjectId) => void;
   readonly onSave: () => void;
   readonly onCancel: () => void;
 };
@@ -14,9 +19,12 @@ type Props = {
 export const NewScriptCard = ({
   name,
   body,
+  projects,
+  projectId,
   error,
   onNameChange,
   onBodyChange,
+  onProjectChange,
   onSave,
   onCancel,
 }: Props) => (
@@ -32,7 +40,20 @@ export const NewScriptCard = ({
         />
       </FieldRow>
       <Divider />
-      <FieldRow label="Command" help="Runs from the session worktree.">
+      {projects.length > 1 ? (
+        <>
+          <FieldRow label="Project">
+            <ProjectSelect
+              projects={projects}
+              projectId={projectId}
+              ariaLabel="New script project"
+              onChange={onProjectChange}
+            />
+          </FieldRow>
+          <Divider />
+        </>
+      ) : null}
+      <FieldRow label="Command" help="Runs from this project's worktree for the session.">
         <Textarea
           value={body}
           onChange={(event) => onBodyChange(event.target.value)}

--- a/apps/desktop/src/features/scripts/components/ScriptsPanel/ProjectSelect.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsPanel/ProjectSelect.tsx
@@ -1,0 +1,24 @@
+import type { Project, ProjectId } from '@goodboy/types';
+import { Select } from '@goodboy/ui';
+
+type Props = {
+  readonly projects: ReadonlyArray<Project>;
+  readonly projectId: ProjectId;
+  readonly ariaLabel: string;
+  readonly onChange: (projectId: ProjectId) => void;
+};
+
+export const ProjectSelect = ({ projects, projectId, ariaLabel, onChange }: Props) => (
+  <Select
+    size="sm"
+    value={projectId}
+    aria-label={ariaLabel}
+    onChange={(event) => onChange(event.target.value as ProjectId)}
+  >
+    {projects.map((project) => (
+      <option key={project.id} value={project.id}>
+        {project.name}
+      </option>
+    ))}
+  </Select>
+);

--- a/apps/desktop/src/features/scripts/components/ScriptsPanel/ScriptRow.test.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsPanel/ScriptRow.test.tsx
@@ -2,7 +2,7 @@
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
-import type { ProjectScript } from '@goodboy/types';
+import type { Project, ProjectScript } from '@goodboy/types';
 import { ScriptRow } from './ScriptRow';
 
 const script = {
@@ -12,6 +12,8 @@ const script = {
   body: 'echo hi',
 } as ProjectScript;
 
+const projects = [{ id: 'project-1', name: 'API' }] as unknown as ReadonlyArray<Project>;
+
 afterEach(cleanup);
 
 describe('ScriptRow', () => {
@@ -20,11 +22,15 @@ describe('ScriptRow', () => {
     render(
       <ScriptRow
         script={script}
+        projects={projects}
+        projectName="API"
+        mountPath="/tmp/api"
         run={null}
         completedAt={undefined}
         expanded
         runnable
         canRun
+        runDisabledReason={null}
         copied={false}
         onToggle={vi.fn()}
         onSave={onSave}
@@ -50,11 +56,15 @@ describe('ScriptRow', () => {
     render(
       <ScriptRow
         script={script}
+        projects={projects}
+        projectName="API"
+        mountPath="/tmp/api"
         run={null}
         completedAt={undefined}
         expanded
         runnable
         canRun
+        runDisabledReason={null}
         copied={false}
         onToggle={vi.fn()}
         onSave={onSave}
@@ -75,18 +85,22 @@ describe('ScriptRow', () => {
     fireEvent.blur(textarea);
 
     expect(onSave).toHaveBeenCalledOnce();
-    expect(onSave).toHaveBeenCalledWith('setup', 'echo next');
+    expect(onSave).toHaveBeenCalledWith('setup', 'echo next', 'project-1');
   });
 
   it('places expand in navigation and run, copy, edit, and delete in lifecycle', () => {
     render(
       <ScriptRow
         script={script}
+        projects={projects}
+        projectName="API"
+        mountPath="/tmp/api"
         run={null}
         completedAt={undefined}
         expanded={false}
         runnable
         canRun
+        runDisabledReason={null}
         copied={false}
         onToggle={vi.fn()}
         onSave={vi.fn()}
@@ -116,11 +130,15 @@ describe('ScriptRow', () => {
     render(
       <ScriptRow
         script={script}
+        projects={projects}
+        projectName="API"
+        mountPath="/tmp/api"
         run={null}
         completedAt={undefined}
         expanded={false}
         runnable
         canRun
+        runDisabledReason={null}
         copied={false}
         onToggle={vi.fn()}
         onSave={vi.fn()}

--- a/apps/desktop/src/features/scripts/components/ScriptsPanel/ScriptRow.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsPanel/ScriptRow.tsx
@@ -1,23 +1,28 @@
 import { useEffect, useState } from 'react';
 import { Check, ChevronDown, ChevronRight, Copy, Pencil, Play, Square, Trash2 } from 'lucide-react';
 import { InlineConfirm, Textarea, cn } from '@goodboy/ui';
-import type { ProjectScript } from '@goodboy/types';
+import type { Project, ProjectId, ProjectScript } from '@goodboy/types';
 import { CardAction } from '@goodboy/ui';
 import { CardActionSlot } from '@goodboy/ui';
 import type { ScriptRunRecord } from '../../scripts';
 import { ScriptRunOutput } from './ScriptRunOutput';
 import { SCRIPT_RUN_PRESENTATION } from './scriptRunPresentation';
+import { ProjectSelect } from './ProjectSelect';
 
 type Props = {
   readonly script: ProjectScript;
+  readonly projects: ReadonlyArray<Project>;
+  readonly projectName: string;
+  readonly mountPath: string | null;
   readonly run: ScriptRunRecord | null;
   readonly completedAt: number | undefined;
   readonly expanded: boolean;
   readonly runnable: boolean;
   readonly canRun: boolean;
+  readonly runDisabledReason: string | null;
   readonly copied: boolean;
   readonly onToggle: () => void;
-  readonly onSave: (name: string, body: string) => void | Promise<void>;
+  readonly onSave: (name: string, body: string, projectId: ProjectId) => void | Promise<void>;
   readonly onRun: () => void;
   readonly onCancel: () => void;
   readonly onCopy: () => void;
@@ -34,6 +39,10 @@ type EditParams = {
   readonly field: EditField;
 };
 
+type ProjectChangeParams = {
+  readonly projectId: ProjectId;
+};
+
 const extractPreviewLine = ({ body }: PreviewParams): string => {
   const lines = body.split('\n');
   for (const line of lines) {
@@ -48,11 +57,15 @@ const extractPreviewLine = ({ body }: PreviewParams): string => {
 
 export const ScriptRow = ({
   script,
+  projects,
+  projectName,
+  mountPath,
   run,
   completedAt,
   expanded,
   runnable,
   canRun,
+  runDisabledReason,
   copied,
   onToggle,
   onSave,
@@ -64,6 +77,7 @@ export const ScriptRow = ({
   const [editingField, setEditingField] = useState<EditField | null>(null);
   const [nameDraft, setNameDraft] = useState(script.name);
   const [bodyDraft, setBodyDraft] = useState(script.body);
+  const [projectIdDraft, setProjectIdDraft] = useState(script.projectId);
   const [isDeleteArmed, setIsDeleteArmed] = useState(false);
   const status = run?.status ?? 'idle';
   const presentation = SCRIPT_RUN_PRESENTATION[status];
@@ -73,7 +87,8 @@ export const ScriptRow = ({
   useEffect(() => {
     setNameDraft(script.name);
     setBodyDraft(script.body);
-  }, [script.body, script.name]);
+    setProjectIdDraft(script.projectId);
+  }, [script.body, script.name, script.projectId]);
 
   useEffect(() => {
     if (!expanded) {
@@ -102,7 +117,17 @@ export const ScriptRow = ({
       setBodyDraft(script.body);
       return;
     }
-    void onSave(name, body);
+    void onSave(name, body, projectIdDraft);
+  };
+
+  const changeProject = ({ projectId }: ProjectChangeParams) => {
+    const name = nameDraft.trim();
+    const body = bodyDraft.trim();
+    setProjectIdDraft(projectId);
+    if (name === '' || body === '' || projectId === script.projectId) {
+      return;
+    }
+    void onSave(name, body, projectId);
   };
 
   const cancelEditing = ({ field }: EditParams) => {
@@ -161,6 +186,12 @@ export const ScriptRow = ({
               className="min-w-0 truncate text-left text-sm font-medium text-foreground"
             >
               {script.name}
+              {projects.length > 1 ? (
+                <span className="text-xs font-normal text-muted-foreground">
+                  {' · '}
+                  {projectName}
+                </span>
+              ) : null}
             </button>
           )}
           {!expanded && preview !== '' ? (
@@ -196,6 +227,7 @@ export const ScriptRow = ({
               <CardAction
                 icon={Play}
                 label="Run script"
+                tooltip={runDisabledReason ?? undefined}
                 disabled={!canRun}
                 size="default"
                 onClick={onRun}
@@ -238,6 +270,25 @@ export const ScriptRow = ({
 
         {expanded ? (
           <div className="col-span-2 flex flex-col gap-2">
+            {runnable ? (
+              <p
+                className="truncate font-mono text-2xs text-muted-foreground"
+                title={mountPath ?? undefined}
+              >
+                {mountPath ?? `${projectName} is not mounted in this session`}
+              </p>
+            ) : null}
+            {editingField !== null && projects.length > 1 ? (
+              <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                <span>Project</span>
+                <ProjectSelect
+                  projects={projects}
+                  projectId={projectIdDraft}
+                  ariaLabel="Edit script project"
+                  onChange={(projectId) => changeProject({ projectId })}
+                />
+              </div>
+            ) : null}
             {editingField === 'body' ? (
               <Textarea
                 autoFocus

--- a/apps/desktop/src/features/scripts/components/ScriptsPanel/index.test.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsPanel/index.test.tsx
@@ -5,6 +5,7 @@ import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 
 type Script = {
   readonly id: string;
+  readonly projectId: string;
   readonly name: string;
   readonly body: string;
 };
@@ -18,6 +19,12 @@ type RunRecord = {
 const { state } = vi.hoisted(() => ({
   state: {
     scripts: [] as ReadonlyArray<Script>,
+    projects: [{ id: 'project-1', workspaceId: 'ws-1', name: 'API' }],
+    sessions: [{ id: 'session-1', activeProjectId: 'project-1' }],
+    sessionActiveProject: { 'session-1': 'project-1' } as Record<string, string>,
+    sessionProjectMounts: {
+      'session-1': [{ projectId: 'project-1', worktreePath: '/tmp/api' }],
+    } as Record<string, ReadonlyArray<{ projectId: string; worktreePath: string }>>,
     scriptRuns: {} as Record<string, Record<string, RunRecord>>,
     loadScripts: vi.fn(async () => undefined),
     saveScript: vi.fn(async () => undefined),
@@ -30,6 +37,10 @@ const { state } = vi.hoisted(() => ({
 vi.mock('../../../../store', () => {
   const getStoreState = () => ({
     projectScripts: { 'ws-1': state.scripts },
+    projects: state.projects,
+    sessions: state.sessions,
+    sessionActiveProject: state.sessionActiveProject,
+    sessionProjectMounts: state.sessionProjectMounts,
     scriptRuns: { 'session-1': state.scriptRuns['session-1'] ?? {} },
     loadScripts: state.loadScripts,
     saveScript: state.saveScript,
@@ -47,6 +58,12 @@ import { ScriptsPanel } from './index';
 
 beforeEach(() => {
   state.scripts = [];
+  state.projects = [{ id: 'project-1', workspaceId: 'ws-1', name: 'API' }];
+  state.sessions = [{ id: 'session-1', activeProjectId: 'project-1' }];
+  state.sessionActiveProject = { 'session-1': 'project-1' };
+  state.sessionProjectMounts = {
+    'session-1': [{ projectId: 'project-1', worktreePath: '/tmp/api' }],
+  };
   state.scriptRuns = {};
   state.loadScripts = vi.fn(async () => undefined);
   state.saveScript = vi.fn(async () => undefined);
@@ -64,13 +81,15 @@ describe('ScriptsPanel', () => {
     expect(state.loadScripts).toHaveBeenCalledWith('ws-1');
     expect(screen.getByText(/no scripts yet/i)).toBeDefined();
     expect(
-      screen.getByText(/scripts are shared across every session of this workspace/i),
-    ).toBeDefined();
+      screen.getAllByText(/scripts are shared across every session of the workspace/i).length,
+    ).toBeGreaterThan(0);
   });
 
   it('creates a new script in an inline card', async () => {
     state.saveScript = vi.fn(async () => {
-      state.scripts = [{ id: 's1', name: 'copy env', body: 'cp ../main/.env .env' }];
+      state.scripts = [
+        { id: 's1', projectId: 'project-1', name: 'copy env', body: 'cp ../main/.env .env' },
+      ];
     });
     render(<ScriptsPanel workspaceId={'ws-1' as never} />);
 
@@ -87,6 +106,7 @@ describe('ScriptsPanel', () => {
 
     expect(state.saveScript).toHaveBeenCalledWith({
       workspaceId: 'ws-1',
+      projectId: 'project-1',
       id: undefined,
       name: 'copy env',
       body: 'cp ../main/.env .env',
@@ -95,10 +115,15 @@ describe('ScriptsPanel', () => {
     expect(screen.getByTestId('script-card-s1')).toBeDefined();
     expect(screen.getByText('cp ../main/.env .env')).toBeDefined();
     expect(screen.queryByRole('button', { name: /close script panel/i })).toBeNull();
+    expect(screen.queryByRole('tablist')).toBeNull();
+    expect(screen.queryByRole('combobox', { name: /project/i })).toBeNull();
+    expect(screen.queryByText('API')).toBeNull();
   });
 
   it('expands an existing script in place with its full command', () => {
-    state.scripts = [{ id: 's1', name: 'setup', body: '#!/bin/bash\necho hi' }];
+    state.scripts = [
+      { id: 's1', projectId: 'project-1', name: 'setup', body: '#!/bin/bash\necho hi' },
+    ];
     render(<ScriptsPanel workspaceId={'ws-1' as never} />);
 
     expect(screen.getByText('+1 line')).toBeDefined();
@@ -114,7 +139,7 @@ describe('ScriptsPanel', () => {
   });
 
   it('edits an existing command inline and commits on blur', async () => {
-    state.scripts = [{ id: 's1', name: 'setup', body: 'echo hi' }];
+    state.scripts = [{ id: 's1', projectId: 'project-1', name: 'setup', body: 'echo hi' }];
     render(<ScriptsPanel workspaceId={'ws-1' as never} />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Edit script' }));
@@ -126,6 +151,7 @@ describe('ScriptsPanel', () => {
 
     expect(state.saveScript).toHaveBeenCalledWith({
       workspaceId: 'ws-1',
+      projectId: 'project-1',
       id: 's1',
       name: 'setup',
       body: 'echo hi again',
@@ -133,7 +159,7 @@ describe('ScriptsPanel', () => {
   });
 
   it('edits an existing script name inline and commits with Cmd+Enter', async () => {
-    state.scripts = [{ id: 's1', name: 'setup', body: 'echo hi' }];
+    state.scripts = [{ id: 's1', projectId: 'project-1', name: 'setup', body: 'echo hi' }];
     render(<ScriptsPanel workspaceId={'ws-1' as never} />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Expand setup' }));
@@ -146,6 +172,7 @@ describe('ScriptsPanel', () => {
 
     expect(state.saveScript).toHaveBeenCalledWith({
       workspaceId: 'ws-1',
+      projectId: 'project-1',
       id: 's1',
       name: 'bootstrap',
       body: 'echo hi',
@@ -153,7 +180,7 @@ describe('ScriptsPanel', () => {
   });
 
   it('keeps the discard guard for an unfinished new script', () => {
-    state.scripts = [{ id: 's1', name: 'setup', body: 'echo hi' }];
+    state.scripts = [{ id: 's1', projectId: 'project-1', name: 'setup', body: 'echo hi' }];
     render(<ScriptsPanel workspaceId={'ws-1' as never} />);
 
     fireEvent.click(screen.getByRole('button', { name: /new script/i }));
@@ -169,7 +196,7 @@ describe('ScriptsPanel', () => {
   });
 
   it('deletes a script through its lifecycle action after confirmation', async () => {
-    state.scripts = [{ id: 's1', name: 'setup', body: 'echo hi' }];
+    state.scripts = [{ id: 's1', projectId: 'project-1', name: 'setup', body: 'echo hi' }];
     render(<ScriptsPanel workspaceId={'ws-1' as never} />);
 
     const lifecycleSlot = screen.getByRole('group', { name: 'Script lifecycle actions' });
@@ -186,22 +213,16 @@ describe('ScriptsPanel', () => {
   });
 
   it('runs a script without expanding it', () => {
-    state.scripts = [{ id: 's1', name: 'setup', body: 'echo hi' }];
-    render(
-      <ScriptsPanel
-        workspaceId={'ws-1' as never}
-        sessionId={'session-1' as never}
-        worktreePath="/tmp/work"
-      />,
-    );
+    state.scripts = [{ id: 's1', projectId: 'project-1', name: 'setup', body: 'echo hi' }];
+    render(<ScriptsPanel workspaceId={'ws-1' as never} sessionId={'session-1' as never} />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Run script' }));
-    expect(state.runScript).toHaveBeenCalledWith('session-1', 's1', '/tmp/work');
+    expect(state.runScript).toHaveBeenCalledWith({ sessionId: 'session-1', scriptId: 's1' });
     expect(screen.getByRole('button', { name: 'Expand setup' })).toBeDefined();
   });
 
   it('shows the last run output inside an expanded card', () => {
-    state.scripts = [{ id: 's1', name: 'setup', body: 'echo hi' }];
+    state.scripts = [{ id: 's1', projectId: 'project-1', name: 'setup', body: 'echo hi' }];
     state.scriptRuns = {
       'session-1': {
         s1: {
@@ -211,13 +232,7 @@ describe('ScriptsPanel', () => {
         },
       },
     };
-    render(
-      <ScriptsPanel
-        workspaceId={'ws-1' as never}
-        sessionId={'session-1' as never}
-        worktreePath="/tmp/work"
-      />,
-    );
+    render(<ScriptsPanel workspaceId={'ws-1' as never} sessionId={'session-1' as never} />);
 
     expect(screen.queryByText('completed output')).toBeNull();
     fireEvent.click(screen.getByRole('button', { name: 'Expand setup' }));
@@ -226,14 +241,8 @@ describe('ScriptsPanel', () => {
   });
 
   it('renders an idle script row with no status border accent', () => {
-    state.scripts = [{ id: 's1', name: 'setup', body: 'echo hi' }];
-    render(
-      <ScriptsPanel
-        workspaceId={'ws-1' as never}
-        sessionId={'session-1' as never}
-        worktreePath="/tmp/work"
-      />,
-    );
+    state.scripts = [{ id: 's1', projectId: 'project-1', name: 'setup', body: 'echo hi' }];
+    render(<ScriptsPanel workspaceId={'ws-1' as never} sessionId={'session-1' as never} />);
 
     const row = screen.getByTestId('script-card-s1');
     expect(row.className).toContain('border-transparent');
@@ -249,7 +258,7 @@ describe('ScriptsPanel', () => {
     ['error', 'border-danger/40', null],
     ['cancelled', 'border-border', null],
   ] as const)('uses the %s run state for the row border', (status, borderClass, pulseClass) => {
-    state.scripts = [{ id: 's1', name: 'setup', body: 'echo hi' }];
+    state.scripts = [{ id: 's1', projectId: 'project-1', name: 'setup', body: 'echo hi' }];
     state.scriptRuns = {
       'session-1': {
         s1: {
@@ -259,13 +268,7 @@ describe('ScriptsPanel', () => {
         },
       },
     };
-    render(
-      <ScriptsPanel
-        workspaceId={'ws-1' as never}
-        sessionId={'session-1' as never}
-        worktreePath="/tmp/work"
-      />,
-    );
+    render(<ScriptsPanel workspaceId={'ws-1' as never} sessionId={'session-1' as never} />);
 
     const row = screen.getByTestId('script-card-s1');
     expect(row.className).toContain(borderClass);
@@ -273,5 +276,62 @@ describe('ScriptsPanel', () => {
       expect(row.className).toContain(pulseClass);
     }
     expect(row.querySelector('[role="img"]')).toBeNull();
+  });
+
+  it('groups the All view, filters by project, and explains an unmounted project', () => {
+    state.projects = [
+      { id: 'project-1', workspaceId: 'ws-1', name: 'API' },
+      { id: 'project-2', workspaceId: 'ws-1', name: 'Web' },
+    ];
+    state.scripts = [
+      { id: 's1', projectId: 'project-1', name: 'setup api', body: 'echo api' },
+      { id: 's2', projectId: 'project-2', name: 'deploy web', body: 'echo web' },
+    ];
+    render(<ScriptsPanel workspaceId={'ws-1' as never} sessionId={'session-1' as never} />);
+
+    expect(screen.getByRole('tab', { name: 'All' })).toBeDefined();
+    expect(screen.getAllByText('API').length).toBeGreaterThan(1);
+    expect(screen.getAllByText('Web').length).toBeGreaterThan(1);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Expand deploy web' }));
+    expect(screen.getByText('Web is not mounted in this session')).toBeDefined();
+    expect(
+      (screen.getAllByRole('button', { name: 'Run script' })[1] as HTMLButtonElement).disabled,
+    ).toBe(true);
+
+    fireEvent.click(screen.getByRole('tab', { name: 'API' }));
+    expect(screen.getByText('setup api')).toBeDefined();
+    expect(screen.queryByText('deploy web')).toBeNull();
+  });
+
+  it('defaults a new script to the active project and allows reassignment while editing', async () => {
+    state.projects = [
+      { id: 'project-1', workspaceId: 'ws-1', name: 'API' },
+      { id: 'project-2', workspaceId: 'ws-1', name: 'Web' },
+    ];
+    state.sessionActiveProject = { 'session-1': 'project-2' };
+    state.scripts = [{ id: 's1', projectId: 'project-1', name: 'setup', body: 'echo hi' }];
+    render(<ScriptsPanel workspaceId={'ws-1' as never} sessionId={'session-1' as never} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /new script/i }));
+    expect(
+      (screen.getByRole('combobox', { name: 'New script project' }) as HTMLSelectElement).value,
+    ).toBe('project-2');
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit script' }));
+    await act(async () => {
+      fireEvent.change(screen.getByRole('combobox', { name: 'Edit script project' }), {
+        target: { value: 'project-2' },
+      });
+    });
+
+    expect(state.saveScript).toHaveBeenCalledWith({
+      workspaceId: 'ws-1',
+      projectId: 'project-2',
+      id: 's1',
+      name: 'setup',
+      body: 'echo hi',
+    });
   });
 });

--- a/apps/desktop/src/features/scripts/components/ScriptsPanel/index.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsPanel/index.tsx
@@ -1,6 +1,20 @@
-import { useCallback, useEffect, useState } from 'react';
-import { Button, formatError, SectionHeader } from '@goodboy/ui';
-import type { SessionId, WorkspaceId, ProjectScript, ProjectScriptId } from '@goodboy/types';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Button,
+  formatError,
+  SectionHeader,
+  SegmentedTabs,
+  type SegmentedTabOption,
+} from '@goodboy/ui';
+import type {
+  Project,
+  ProjectId,
+  SessionId,
+  WorkspaceId,
+  ProjectScript,
+  ProjectScriptId,
+  SessionProjectMount,
+} from '@goodboy/types';
 import { Plus } from 'lucide-react';
 import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../shared/components/conceptIcons';
 import { LensEmptyState } from '@goodboy/ui';
@@ -12,16 +26,16 @@ import { ScriptRow } from './ScriptRow';
 type Props = {
   readonly workspaceId: WorkspaceId;
   readonly sessionId?: SessionId;
-  readonly worktreePath?: string | null;
   readonly hasHostHeading?: boolean;
 };
 
 const SCRIPTS_HINT =
-  'Shell scripts you run by hand from inside a session. cwd is the session worktree. Scripts are shared across every session of this workspace.';
+  "Shell scripts you run by hand from inside a session. Each script belongs to a project and runs in that project's worktree for this session. Scripts are shared across every session of the workspace.";
 
 type NewDraft = {
   readonly name: string;
   readonly body: string;
+  readonly projectId: ProjectId | null;
 };
 
 type PendingNewAction = {
@@ -59,15 +73,32 @@ type SaveExistingParams = {
   readonly script: ProjectScript;
   readonly name: string;
   readonly body: string;
+  readonly projectId: ProjectId;
 };
 
-export const ScriptsPanel = ({
-  workspaceId,
-  sessionId,
-  worktreePath,
-  hasHostHeading = false,
-}: Props) => {
+type ProjectFilter = 'all' | ProjectId;
+
+type ScriptGroup = {
+  readonly key: string;
+  readonly label: string | null;
+  readonly scripts: ReadonlyArray<ProjectScript>;
+};
+
+const EMPTY_MOUNTS: ReadonlyArray<SessionProjectMount> = [];
+
+export const ScriptsPanel = ({ workspaceId, sessionId, hasHostHeading = false }: Props) => {
   const scripts = useAppStore((state) => state.projectScripts[workspaceId]);
+  const allProjects = useAppStore((state) => state.projects);
+  const sessionMounts = useAppStore((state) =>
+    sessionId == null ? EMPTY_MOUNTS : (state.sessionProjectMounts[sessionId] ?? EMPTY_MOUNTS),
+  );
+  const activeProjectId = useAppStore((state) => {
+    if (sessionId == null) {
+      return null;
+    }
+    const session = state.sessions.find((candidate) => candidate.id === sessionId);
+    return state.sessionActiveProject[sessionId] ?? session?.activeProjectId ?? null;
+  });
   const loadScripts = useAppStore((state) => state.loadScripts);
   const saveScript = useAppStore((state) => state.saveScript);
   const deleteScript = useAppStore((state) => state.deleteScript);
@@ -83,9 +114,51 @@ export const ScriptsPanel = ({
   const [error, setError] = useState<string | null>(null);
   const [copiedId, setCopiedId] = useState<ProjectScriptId | null>(null);
   const [completedAt, setCompletedAt] = useState<Record<string, number>>({});
+  const [projectFilter, setProjectFilter] = useState<ProjectFilter>('all');
 
   const runnable = sessionId != null;
   const list = scripts ?? [];
+  const projects = useMemo(
+    () => allProjects.filter((project) => project.workspaceId === workspaceId),
+    [allProjects, workspaceId],
+  );
+  const projectById = useMemo(
+    () => new Map(projects.map((project) => [project.id, project])),
+    [projects],
+  );
+  const mountPathByProjectId = useMemo(
+    () => new Map(sessionMounts.map((mount) => [mount.projectId, mount.worktreePath])),
+    [sessionMounts],
+  );
+  const isMultiProject = projects.length > 1;
+  const defaultProjectId = activeProjectId ?? projects[0]?.id ?? null;
+  const projectFilterOptions = useMemo<ReadonlyArray<SegmentedTabOption<ProjectFilter>>>(
+    () => [
+      { value: 'all', label: 'All' },
+      ...projects.map((project) => ({ value: project.id, label: project.name })),
+    ],
+    [projects],
+  );
+  const groups = useMemo<ReadonlyArray<ScriptGroup>>(() => {
+    if (!isMultiProject) {
+      return [{ key: 'all', label: null, scripts: list }];
+    }
+    if (projectFilter !== 'all') {
+      return [
+        {
+          key: projectFilter,
+          label: null,
+          scripts: list.filter((script) => script.projectId === projectFilter),
+        },
+      ];
+    }
+    return projects.flatMap((project) => {
+      const projectScripts = list.filter((script) => script.projectId === project.id);
+      return projectScripts.length === 0
+        ? []
+        : [{ key: project.id, label: project.name, scripts: projectScripts }];
+    });
+  }, [isMultiProject, list, projectFilter, projects]);
   const newDraftDirty =
     newDraft != null && (newDraft.name.trim() !== '' || newDraft.body.trim() !== '');
 
@@ -124,7 +197,17 @@ export const ScriptsPanel = ({
       const previousIds = new Set(list.map((script) => script.id));
       setError(null);
       try {
-        await saveScript({ workspaceId, id: undefined, name, body });
+        if (newDraft.projectId == null) {
+          setError('project is required');
+          return { kind: 'failed' };
+        }
+        await saveScript({
+          workspaceId,
+          projectId: newDraft.projectId,
+          id: undefined,
+          name,
+          body,
+        });
         const savedScript =
           useAppStore
             .getState()
@@ -169,8 +252,8 @@ export const ScriptsPanel = ({
     }
     setExpandedId(null);
     setError(null);
-    setNewDraft({ name: '', body: '' });
-  }, [newDraft]);
+    setNewDraft({ name: '', body: '', projectId: defaultProjectId });
+  }, [defaultProjectId, newDraft]);
 
   const onCancelNew = useCallback(() => {
     if (newDraftDirty) {
@@ -207,20 +290,21 @@ export const ScriptsPanel = ({
   }, [pendingNewAction, saveNew]);
 
   const onSaveExisting = useCallback(
-    async ({ script, name, body }: SaveExistingParams) => {
+    async ({ script, name, body, projectId }: SaveExistingParams) => {
       const nextName = name.trim();
       const nextBody = body.trim();
       if (nextName === '' || nextBody === '') {
         setError('name and script body are required');
         return;
       }
-      if (nextName === script.name && nextBody === script.body) {
+      if (nextName === script.name && nextBody === script.body && projectId === script.projectId) {
         return;
       }
       setError(null);
       try {
         await saveScript({
           workspaceId,
+          projectId,
           id: script.id,
           name: nextName,
           body: nextBody,
@@ -256,12 +340,12 @@ export const ScriptsPanel = ({
 
   const onRun = useCallback(
     ({ script }: RunParams) => {
-      if (sessionId == null || worktreePath == null) {
+      if (sessionId == null) {
         return;
       }
-      void runScript(sessionId, script.id, worktreePath);
+      void runScript({ sessionId, scriptId: script.id });
     },
-    [runScript, sessionId, worktreePath],
+    [runScript, sessionId],
   );
 
   const onCancel = useCallback(
@@ -300,54 +384,95 @@ export const ScriptsPanel = ({
       {error !== null && newDraft === null ? <p className="text-xs text-danger">{error}</p> : null}
 
       <div className="flex min-h-0 flex-1 flex-col gap-2">
-        {newDraft != null ? (
-          <NewScriptCard
-            name={newDraft.name}
-            body={newDraft.body}
-            error={error}
-            onNameChange={(name) =>
-              setNewDraft((current) => (current == null ? null : { ...current, name }))
-            }
-            onBodyChange={(body) =>
-              setNewDraft((current) => (current == null ? null : { ...current, body }))
-            }
-            onSave={onSaveNew}
-            onCancel={onCancelNew}
+        {isMultiProject ? (
+          <SegmentedTabs
+            ariaLabel="Filter scripts by project"
+            options={projectFilterOptions}
+            value={projectFilter}
+            onChange={setProjectFilter}
+            size="sm"
+            className="max-w-full flex-wrap self-start"
           />
+        ) : null}
+        {newDraft != null ? (
+          newDraft.projectId != null ? (
+            <NewScriptCard
+              name={newDraft.name}
+              body={newDraft.body}
+              projects={projects}
+              projectId={newDraft.projectId}
+              error={error}
+              onNameChange={(name) =>
+                setNewDraft((current) => (current == null ? null : { ...current, name }))
+              }
+              onBodyChange={(body) =>
+                setNewDraft((current) => (current == null ? null : { ...current, body }))
+              }
+              onProjectChange={(projectId) =>
+                setNewDraft((current) => (current == null ? null : { ...current, projectId }))
+              }
+              onSave={onSaveNew}
+              onCancel={onCancelNew}
+            />
+          ) : null
         ) : null}
         {list.length === 0 && newDraft == null ? (
           <LensEmptyState
             tone={CONCEPT_TONE.scripts}
             icon={CONCEPT_ICONS.scripts}
             title="No scripts yet"
-            description="A script is a shell command you run by hand from a session, no agent, no tokens spent. Create one to run setup or checks from the session worktree."
+            description="Each script belongs to a project and runs in that project's worktree for this session. Scripts are shared across every session of the workspace."
             action={newScriptAction}
           />
         ) : (
-          <ul className="flex flex-col gap-2">
-            {list.map((script) => {
-              const run = runs?.[script.id] ?? null;
-              return (
-                <li key={script.id}>
-                  <ScriptRow
-                    script={script}
-                    run={run}
-                    completedAt={run == null ? undefined : completedAt[run.runId]}
-                    expanded={expandedId === script.id}
-                    runnable={runnable}
-                    canRun={worktreePath != null}
-                    copied={copiedId === script.id}
-                    onToggle={() => onToggle({ id: script.id })}
-                    onSave={(name, body) => onSaveExisting({ script, name, body })}
-                    onRun={() => onRun({ script })}
-                    onCancel={() => onCancel({ id: script.id })}
-                    onCopy={() => onCopy({ id: script.id, body: script.body })}
-                    onDelete={() => onDelete({ id: script.id })}
-                  />
-                </li>
-              );
-            })}
-          </ul>
+          <div className="flex flex-col gap-3">
+            {groups.map((group) => (
+              <div key={group.key} className="flex flex-col gap-1.5">
+                {group.label != null ? (
+                  <span className="px-0.5 text-xs font-medium text-muted-foreground">
+                    {group.label}
+                  </span>
+                ) : null}
+                <ul className="flex flex-col gap-2">
+                  {group.scripts.map((script) => {
+                    const run = runs?.[script.id] ?? null;
+                    const project = projectById.get(script.projectId) ?? null;
+                    const projectName = project?.name ?? 'Project';
+                    const mountPath = mountPathByProjectId.get(script.projectId) ?? null;
+                    const runDisabledReason =
+                      runnable && mountPath == null
+                        ? `${projectName} is not mounted in this session`
+                        : null;
+                    return (
+                      <li key={script.id}>
+                        <ScriptRow
+                          script={script}
+                          projects={projects}
+                          projectName={projectName}
+                          mountPath={mountPath}
+                          run={run}
+                          completedAt={run == null ? undefined : completedAt[run.runId]}
+                          expanded={expandedId === script.id}
+                          runnable={runnable}
+                          canRun={mountPath != null}
+                          runDisabledReason={runDisabledReason}
+                          copied={copiedId === script.id}
+                          onToggle={() => onToggle({ id: script.id })}
+                          onSave={(name, body, projectId) =>
+                            onSaveExisting({ script, name, body, projectId })
+                          }
+                          onRun={() => onRun({ script })}
+                          onCancel={() => onCancel({ id: script.id })}
+                          onCopy={() => onCopy({ id: script.id, body: script.body })}
+                          onDelete={() => onDelete({ id: script.id })}
+                        />
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
+            ))}
+          </div>
         )}
       </div>
 

--- a/apps/desktop/src/features/scripts/components/ScriptsSection/index.test.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsSection/index.test.tsx
@@ -4,7 +4,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 
 type MockState = {
-  projectScripts: Record<string, ReadonlyArray<{ id: string; name: string; body: string }>>;
+  projectScripts: Record<
+    string,
+    ReadonlyArray<{ id: string; projectId: string; name: string; body: string }>
+  >;
+  projects: ReadonlyArray<{ id: string; workspaceId: string; name: string }>;
+  sessionProjectMounts: Record<string, ReadonlyArray<{ projectId: string; worktreePath: string }>>;
   scriptRuns: Record<string, Record<string, { status: string; result: unknown }>>;
   sessionPanelExpanded: Record<string, Partial<Record<string, boolean>>>;
   setPanelSectionExpanded: ReturnType<typeof vi.fn>;
@@ -17,6 +22,8 @@ type MockState = {
 const { state } = vi.hoisted<{ state: MockState }>(() => ({
   state: {
     projectScripts: {},
+    projects: [],
+    sessionProjectMounts: {},
     scriptRuns: {},
     sessionPanelExpanded: {},
     setPanelSectionExpanded: vi.fn(),
@@ -29,13 +36,18 @@ const { state } = vi.hoisted<{ state: MockState }>(() => ({
 
 vi.mock('../../../../store', () => ({
   useAppStore: <T,>(selector: (s: MockState) => T) => selector(state),
+  EMPTY_ARRAY: [],
 }));
 
 import { ScriptsSection } from './index';
 
 beforeEach(() => {
   state.projectScripts = {
-    'ws-1': [{ id: 'sc-1', name: 'sync env', body: 'cp .env .env.local' }],
+    'ws-1': [{ id: 'sc-1', projectId: 'project-1', name: 'sync env', body: 'cp .env .env.local' }],
+  };
+  state.projects = [{ id: 'project-1', workspaceId: 'ws-1', name: 'API' }];
+  state.sessionProjectMounts = {
+    'sess-1': [{ projectId: 'project-1', worktreePath: '/wt/api' }],
   };
   state.scriptRuns = {};
   state.sessionPanelExpanded = { 'sess-1': { scripts: true } };
@@ -50,102 +62,75 @@ afterEach(cleanup);
 describe('ScriptsSection', () => {
   it('shows a create-script entry when the workspace has no scripts', () => {
     state.projectScripts = {};
-    render(
-      <ScriptsSection
-        sessionId={'sess-1' as never}
-        workspaceId={'ws-1' as never}
-        worktreePath="/wt"
-      />,
-    );
+    render(<ScriptsSection sessionId={'sess-1' as never} workspaceId={'ws-1' as never} />);
     expect(screen.getByText('Create script')).toBeDefined();
   });
 
   it('opens the session scripts lens from the create-script entry', () => {
     state.projectScripts = {};
-    render(
-      <ScriptsSection
-        sessionId={'sess-1' as never}
-        workspaceId={'ws-1' as never}
-        worktreePath="/wt"
-      />,
-    );
+    render(<ScriptsSection sessionId={'sess-1' as never} workspaceId={'ws-1' as never} />);
     fireEvent.click(screen.getByText('Create script'));
     expect(state.setActiveLens).toHaveBeenCalledWith('sess-1', 'scripts');
   });
 
   it('lists the workspace scripts', () => {
-    render(
-      <ScriptsSection
-        sessionId={'sess-1' as never}
-        workspaceId={'ws-1' as never}
-        worktreePath="/wt"
-      />,
-    );
+    render(<ScriptsSection sessionId={'sess-1' as never} workspaceId={'ws-1' as never} />);
     expect(screen.getByText('sync env')).toBeDefined();
     expect(screen.queryByText('cp .env .env.local')).toBeNull();
   });
 
-  it('disables the run control when the session has no worktree', () => {
-    render(
-      <ScriptsSection
-        sessionId={'sess-1' as never}
-        workspaceId={'ws-1' as never}
-        worktreePath={null}
-      />,
-    );
+  it('disables the run control when the script project is not mounted', () => {
+    state.sessionProjectMounts = {};
+    render(<ScriptsSection sessionId={'sess-1' as never} workspaceId={'ws-1' as never} />);
     expect(
       (screen.getByRole('button', { name: /run script/i }) as HTMLButtonElement).disabled,
     ).toBe(true);
   });
 
   it('runs the script when its run control is clicked', () => {
-    render(
-      <ScriptsSection
-        sessionId={'sess-1' as never}
-        workspaceId={'ws-1' as never}
-        worktreePath="/wt"
-      />,
-    );
+    render(<ScriptsSection sessionId={'sess-1' as never} workspaceId={'ws-1' as never} />);
     fireEvent.click(screen.getByRole('button', { name: /run script/i }));
-    expect(state.runScript).toHaveBeenCalledWith('sess-1', 'sc-1', '/wt');
+    expect(state.runScript).toHaveBeenCalledWith({ sessionId: 'sess-1', scriptId: 'sc-1' });
   });
 
   it('stops a pending script', () => {
     state.scriptRuns = { 'sess-1': { 'sc-1': { status: 'pending', result: null } } };
-    render(
-      <ScriptsSection
-        sessionId={'sess-1' as never}
-        workspaceId={'ws-1' as never}
-        worktreePath="/wt"
-      />,
-    );
+    render(<ScriptsSection sessionId={'sess-1' as never} workspaceId={'ws-1' as never} />);
     fireEvent.click(screen.getByRole('button', { name: /stop script/i }));
     expect(state.cancelScript).toHaveBeenCalledWith('sess-1', 'sc-1');
   });
 
   it('defaults to collapsed, hiding rows behind a count summary', () => {
     state.sessionPanelExpanded = {};
-    render(
-      <ScriptsSection
-        sessionId={'sess-1' as never}
-        workspaceId={'ws-1' as never}
-        worktreePath="/wt"
-      />,
-    );
+    render(<ScriptsSection sessionId={'sess-1' as never} workspaceId={'ws-1' as never} />);
     expect(screen.queryByText('sync env')).toBeNull();
     expect(screen.getByText('1 script')).toBeDefined();
   });
 
   it('persists the expanded state through the store when toggled', () => {
     state.sessionPanelExpanded = {};
-    render(
-      <ScriptsSection
-        sessionId={'sess-1' as never}
-        workspaceId={'ws-1' as never}
-        worktreePath="/wt"
-      />,
-    );
+    render(<ScriptsSection sessionId={'sess-1' as never} workspaceId={'ws-1' as never} />);
     fireEvent.click(screen.getByRole('button', { name: /expand scripts/i }));
     expect(state.setPanelSectionExpanded).toHaveBeenCalledWith('sess-1', 'scripts', true);
+  });
+
+  it('shows project suffixes and disables only the unmounted project script', () => {
+    state.projects = [
+      { id: 'project-1', workspaceId: 'ws-1', name: 'API' },
+      { id: 'project-2', workspaceId: 'ws-1', name: 'Web' },
+    ];
+    state.projectScripts = {
+      'ws-1': [
+        { id: 'sc-1', projectId: 'project-1', name: 'sync api', body: 'echo api' },
+        { id: 'sc-2', projectId: 'project-2', name: 'sync web', body: 'echo web' },
+      ],
+    };
+    render(<ScriptsSection sessionId={'sess-1' as never} workspaceId={'ws-1' as never} />);
+
+    const runButtons = screen.getAllByRole('button', { name: 'Run script' });
+    expect((runButtons[0] as HTMLButtonElement).disabled).toBe(false);
+    expect((runButtons[1] as HTMLButtonElement).disabled).toBe(true);
+    expect(screen.getByText('· API')).toBeDefined();
+    expect(screen.getByText('· Web')).toBeDefined();
   });
 });

--- a/apps/desktop/src/features/scripts/components/ScriptsSection/index.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsSection/index.tsx
@@ -12,13 +12,12 @@ import {
   Terminal,
   X,
 } from 'lucide-react';
-import { useAppStore } from '../../../../store';
+import { EMPTY_ARRAY, useAppStore } from '../../../../store';
 import type { ScriptRunRecord, ScriptRunResult, ScriptRunStatus } from '../../scripts';
 
 type ScriptsSectionProps = {
   readonly sessionId: SessionId;
   readonly workspaceId: WorkspaceId;
-  readonly worktreePath: string | null;
   readonly forceExpanded?: boolean;
   readonly hideHeader?: boolean;
 };
@@ -31,7 +30,6 @@ type LogTarget = {
 export const ScriptsSection = ({
   sessionId,
   workspaceId,
-  worktreePath,
   forceExpanded = false,
   hideHeader = false,
 }: ScriptsSectionProps) => {
@@ -40,6 +38,8 @@ export const ScriptsSection = ({
   const setPanelSectionExpanded = useAppStore((s) => s.setPanelSectionExpanded);
   const [log, setLog] = useState<LogTarget | null>(null);
   const scripts = useAppStore((s) => s.projectScripts[workspaceId]);
+  const allProjects = useAppStore((s) => s.projects);
+  const mounts = useAppStore((s) => s.sessionProjectMounts[sessionId] ?? EMPTY_ARRAY);
   const runs = useAppStore((s) => s.scriptRuns[sessionId]);
   const loadScripts = useAppStore((s) => s.loadScripts);
   const runScript = useAppStore((s) => s.runScript);
@@ -52,12 +52,9 @@ export const ScriptsSection = ({
 
   const onRun = useCallback(
     (script: ProjectScript) => {
-      if (!worktreePath) {
-        return;
-      }
-      void runScript(sessionId, script.id, worktreePath);
+      void runScript({ sessionId, scriptId: script.id });
     },
-    [runScript, sessionId, worktreePath],
+    [runScript, sessionId],
   );
 
   const onCancel = useCallback(
@@ -72,6 +69,8 @@ export const ScriptsSection = ({
   }, []);
 
   const list = scripts ?? [];
+  const projects = allProjects.filter((project) => project.workspaceId === workspaceId);
+  const isMultiProject = projects.length > 1;
 
   const openScripts = () => setActiveLens(sessionId, 'scripts');
 
@@ -108,19 +107,28 @@ export const ScriptsSection = ({
         <>
           {list.length > 0 ? (
             <ul className="flex flex-col gap-1 pl-2">
-              {list.map((script) => (
-                <li key={script.id}>
-                  <ScriptRow
-                    script={script}
-                    run={runs?.[script.id] ?? null}
-                    disabled={!worktreePath}
-                    logOpen={log?.scriptId === script.id}
-                    onRun={() => onRun(script)}
-                    onCancel={() => onCancel(script.id)}
-                    onToggleLog={(anchor) => onToggleLog(script.id, anchor)}
-                  />
-                </li>
-              ))}
+              {list.map((script) => {
+                const project = projects.find((candidate) => candidate.id === script.projectId);
+                const projectName = project?.name ?? 'Project';
+                const mount = mounts.find((candidate) => candidate.projectId === script.projectId);
+                const disabledReason =
+                  mount === undefined ? `${projectName} is not mounted in this session` : null;
+                return (
+                  <li key={script.id}>
+                    <ScriptRow
+                      script={script}
+                      projectName={projectName}
+                      showProjectName={isMultiProject}
+                      run={runs?.[script.id] ?? null}
+                      disabledReason={disabledReason}
+                      logOpen={log?.scriptId === script.id}
+                      onRun={() => onRun(script)}
+                      onCancel={() => onCancel(script.id)}
+                      onToggleLog={(anchor) => onToggleLog(script.id, anchor)}
+                    />
+                  </li>
+                );
+              })}
             </ul>
           ) : null}
           <button
@@ -153,8 +161,10 @@ export const ScriptsSection = ({
 
 type ScriptRowProps = {
   readonly script: ProjectScript;
+  readonly projectName: string;
+  readonly showProjectName: boolean;
   readonly run: ScriptRunRecord | null;
-  readonly disabled: boolean;
+  readonly disabledReason: string | null;
   readonly logOpen: boolean;
   readonly onRun: () => void;
   readonly onCancel: () => void;
@@ -163,8 +173,10 @@ type ScriptRowProps = {
 
 function ScriptRow({
   script,
+  projectName,
+  showProjectName,
   run,
-  disabled,
+  disabledReason,
   logOpen,
   onRun,
   onCancel,
@@ -185,8 +197,11 @@ function ScriptRow({
       )}
     >
       <StatusDot status={status} />
-      <span className="min-w-0 flex-1 truncate text-xs font-medium text-foreground">
-        {script.name}
+      <span className="flex min-w-0 flex-1 items-baseline gap-1 text-xs">
+        <span className="min-w-0 truncate font-medium text-foreground">{script.name}</span>
+        {showProjectName ? (
+          <span className="shrink-0 text-2xs text-muted-foreground">· {projectName}</span>
+        ) : null}
       </span>
       {hasOutput ? (
         <button
@@ -222,11 +237,11 @@ function ScriptRow({
           </button>
         </Tooltip>
       ) : (
-        <Tooltip content="Run script" anchorClassName="shrink-0">
+        <Tooltip content={disabledReason ?? 'Run script'} anchorClassName="shrink-0">
           <button
             type="button"
             onClick={onRun}
-            disabled={disabled}
+            disabled={disabledReason != null}
             aria-label="Run script"
             className="flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground/50 transition-colors hover:bg-foreground/10 hover:text-primary group-hover:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-40"
           >

--- a/apps/desktop/src/features/session/components/CommandPalette/index.tsx
+++ b/apps/desktop/src/features/session/components/CommandPalette/index.tsx
@@ -114,9 +114,6 @@ export const CommandPalette = ({
   ) as ReadonlyArray<Agent>;
   const agentKindOverride = useAppStore((s) => s.agentKindOverride);
   const runScript = useAppStore((s) => s.runScript);
-  const sessionWorktree = useAppStore((s) =>
-    currentSession ? (s.sessionWorktrees[currentSession.id]?.[0] ?? null) : null,
-  );
   const { showToast } = useToast();
   const theme = useThemeStore((s) => s.theme);
   const toggleTheme = useThemeStore((s) => s.toggleTheme);
@@ -198,14 +195,14 @@ export const CommandPalette = ({
       out.push({
         id: `script:${sc.id}`,
         label: sc.name,
-        sublabel: 'workspace script',
+        sublabel: 'project script',
         group: 'script',
         onSelect: () => {
-          if (!currentSession || !sessionWorktree) {
-            showToast('warning', `${sc.name}, open a session worktree to run scripts`);
+          if (currentSession == null) {
+            showToast('warning', `${sc.name}, open a session to run scripts`);
             return;
           }
-          void runScript(currentSession.id, sc.id, sessionWorktree).then((result) => {
+          void runScript({ sessionId: currentSession.id, scriptId: sc.id }).then((result) => {
             showToast(
               result.exitCode === 0 ? 'success' : 'error',
               result.exitCode === 0 ? `${sc.name}, done` : `${sc.name}, exited ${result.exitCode}`,
@@ -285,7 +282,6 @@ export const CommandPalette = ({
     agents,
     scripts,
     currentSession,
-    sessionWorktree,
     runScript,
     showToast,
     agentKindOverride,

--- a/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
@@ -258,7 +258,6 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
               <ScriptsPanel
                 workspaceId={session.workspaceId}
                 sessionId={sessionId}
-                worktreePath={workingDir}
                 hasHostHeading
               />
             </PaneShell>

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.tsx
@@ -154,11 +154,7 @@ export const AgentsSection = ({
             <p className="px-2 text-2xs text-danger">{section.spawnError}</p>
           )}
           <PlanReadySuggestion task={task} />
-          <ScriptsSection
-            sessionId={task.id}
-            workspaceId={task.workspaceId}
-            worktreePath={section.worktreePath}
-          />
+          <ScriptsSection sessionId={task.id} workspaceId={task.workspaceId} />
         </>
       )}
     </section>

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/useAgentsSection.ts
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/useAgentsSection.ts
@@ -27,7 +27,6 @@ import { workflowRunHasOpenQuestions } from '../../../../../features/context/ope
 import { classifyAgent, type AgentKind } from '../../../../../features/session/agent-kind';
 import { useAgentMetrics } from '../../../../../features/session/hooks/useAgentMetrics';
 import { useAttachedWorkflowRuns } from '../../../../workflows/useAttachedWorkflowRuns';
-import { resolveActiveMountPath } from '../../../../../store/slices/worktrees/resolveActiveMountPath';
 import { useSessionAgentTree } from './useSessionAgentTree';
 import { workflowKindName } from '../lib';
 
@@ -96,7 +95,6 @@ export const useAgentsSection = ({ task, workflowRunId }: Params) => {
     }),
   );
   const selectedAgentId = useAppStore((s) => s.selectedAgentId[task.id] ?? null);
-  const worktreePath = useAppStore((s) => resolveActiveMountPath({ state: s, sessionId: task.id }));
   const selectAgent = useAppStore((s) => s.selectAgent);
   const requestOpenQuestionScroll = useAppStore((s) => s.requestOpenQuestionScroll);
   const spawnAgent = useAppStore((s) => s.spawnAgent);
@@ -333,6 +331,5 @@ export const useAgentsSection = ({ task, workflowRunId }: Params) => {
     workflowExpand,
     workflowExpanded,
     workflowNameByRunId,
-    worktreePath,
   };
 };

--- a/apps/desktop/src/store/slices/scripts/index.test.ts
+++ b/apps/desktop/src/store/slices/scripts/index.test.ts
@@ -617,7 +617,10 @@ describe('store contract', () => {
     it('saveScript refuses a project that belongs to another workspace', async () => {
       const store = await getStore();
       store.setState({
-        projects: [buildProject(), buildProject({ id: PROJECT_ID_2, workspaceId: 'ws-other' })],
+        projects: [
+          buildProject(),
+          buildProject({ id: PROJECT_ID_2, workspaceId: 'ws-other' as WorkspaceId }),
+        ],
       } as never);
 
       await expect(

--- a/apps/desktop/src/store/slices/scripts/index.test.ts
+++ b/apps/desktop/src/store/slices/scripts/index.test.ts
@@ -399,7 +399,7 @@ function buildWorkspace(overrides: Partial<Workspace> = {}): Workspace {
   };
 }
 
-const buildProject = (): Project => ({
+const buildProject = (overrides: Partial<Project> = {}): Project => ({
   id: PROJECT_ID,
   workspaceId: WS_ID,
   name: 'repo',
@@ -408,6 +408,7 @@ const buildProject = (): Project => ({
   overrides: buildWorkspace().overrides,
   createdAt: NOW,
   updatedAt: NOW,
+  ...overrides,
 });
 
 function buildSession(overrides: Partial<Session> = {}): Session {
@@ -485,7 +486,7 @@ describe('store contract', () => {
       const snap = store.getState();
       resetState = {
         workspaces: [],
-        projects: [buildProject()],
+        projects: [buildProject(), buildProject({ id: PROJECT_ID_2, name: 'web' })],
         workspaceIntegrations: {},
         sessionExternalTasks: {},
         currentWorkspaceId: null,
@@ -611,6 +612,20 @@ describe('store contract', () => {
           script: expect.objectContaining({ projectId: PROJECT_ID_2 }),
         }),
       );
+    });
+
+    it('saveScript refuses a project that belongs to another workspace', async () => {
+      const store = await getStore();
+      store.setState({
+        projects: [buildProject(), buildProject({ id: PROJECT_ID_2, workspaceId: 'ws-other' })],
+      } as never);
+
+      await expect(
+        store
+          .getState()
+          .saveScript({ workspaceId: WS_ID, projectId: PROJECT_ID_2, name: 'x', body: 'echo' }),
+      ).rejects.toThrow(/does not belong/);
+      expect(upsertProjectScriptSpy).not.toHaveBeenCalled();
     });
 
     it('saveScript reassigns an existing script to the given project', async () => {

--- a/apps/desktop/src/store/slices/scripts/index.test.ts
+++ b/apps/desktop/src/store/slices/scripts/index.test.ts
@@ -19,6 +19,7 @@ import type {
   ProviderRunId,
   Session,
   SessionId,
+  SessionProjectMount,
   Skill,
   SkillId,
   TelemetryRecord,
@@ -63,6 +64,14 @@ const deleteIntegrationBindingSpy = vi.fn(async () => undefined);
 const listProjectScriptsSpy = vi.fn(async () => [] as ReadonlyArray<ProjectScript>);
 const upsertProjectScriptSpy = vi.fn(async () => undefined);
 const deleteProjectScriptSpy = vi.fn(async () => undefined);
+const invokeScriptRunSpy: ReturnType<typeof vi.fn> = vi.fn(async () => undefined);
+let scriptExitHandler: ((payload: { runId: string; exitCode: number }) => void) | null = null;
+const listenScriptExitSpy = vi.fn(
+  async (handler: (payload: { runId: string; exitCode: number }) => void) => {
+    scriptExitHandler = handler;
+    return () => undefined;
+  },
+);
 
 vi.mock('@goodboy/db', () => ({
   getSetting: dbGetSettingSpy,
@@ -331,10 +340,10 @@ vi.mock('@goodboy/core', async (importOriginal) => {
 });
 
 vi.mock('../../../features/scripts/scripts', () => ({
-  invokeScriptRun: vi.fn(async () => undefined),
+  invokeScriptRun: invokeScriptRunSpy,
   invokeScriptCancel: vi.fn(async () => undefined),
   listenScriptOutput: vi.fn(async () => () => undefined),
-  listenScriptExit: vi.fn(async () => () => undefined),
+  listenScriptExit: listenScriptExitSpy,
 }));
 
 vi.mock('../../../features/terminal/terminal', () => ({
@@ -356,6 +365,7 @@ vi.mock('../../../features/settings/config-export', () => ({
 const WS_ID = 'workspace-1' as WorkspaceId;
 const WS_ID_2 = 'workspace-2' as WorkspaceId;
 const PROJECT_ID = 'project-1' as ProjectId;
+const PROJECT_ID_2 = 'project-2' as ProjectId;
 const SESSION_ID = 'session-1' as SessionId;
 const SESSION_ID_2 = 'session-2' as SessionId;
 const AGENT_ID = 'agent-1' as AgentId;
@@ -464,6 +474,7 @@ describe('store contract', () => {
     invokeListConsumptionsForPlanSpy.mockResolvedValue([]);
     invokeWorkspacesWithUnreadSpy.mockResolvedValue([]);
     listProjectScriptsSpy.mockResolvedValue([]);
+    scriptExitHandler = null;
     listIntegrationBindingsForWorkspaceSpy.mockResolvedValue([]);
     listDiffCommentsSpy.mockResolvedValue([]);
     dbGetSettingSpy.mockResolvedValue(null);
@@ -494,6 +505,8 @@ describe('store contract', () => {
         transcripts: {},
         messages: {},
         sessionWorktrees: {},
+        sessionProjectMounts: {},
+        sessionActiveProject: {},
         sessionBranches: {},
         sessionTelemetry: {},
         workspaceSummary: null,
@@ -581,6 +594,124 @@ describe('store contract', () => {
       store.setState({ projectScripts: { [WS_ID]: [script] } });
       await store.getState().deleteScript(script.id, WS_ID);
       expect(store.getState().projectScripts[WS_ID]).toEqual([]);
+    });
+
+    it('saveScript persists the required project id for a new script', async () => {
+      const store = await getStore();
+
+      await store.getState().saveScript({
+        workspaceId: WS_ID,
+        projectId: PROJECT_ID_2,
+        name: 'web setup',
+        body: 'echo web',
+      });
+
+      expect(upsertProjectScriptSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          script: expect.objectContaining({ projectId: PROJECT_ID_2 }),
+        }),
+      );
+    });
+
+    it('saveScript reassigns an existing script to the given project', async () => {
+      const store = await getStore();
+      const script: ProjectScript = {
+        id: 'sc-1' as ProjectScriptId,
+        projectId: PROJECT_ID,
+        name: 'setup',
+        body: 'echo api',
+        sortOrder: 0,
+        createdAt: NOW,
+        updatedAt: NOW,
+      };
+      store.setState({ projectScripts: { [WS_ID]: [script] } });
+
+      await store.getState().saveScript({
+        workspaceId: WS_ID,
+        projectId: PROJECT_ID_2,
+        id: script.id,
+        name: script.name,
+        body: script.body,
+      });
+
+      expect(upsertProjectScriptSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          script: expect.objectContaining({ id: script.id, projectId: PROJECT_ID_2 }),
+        }),
+      );
+    });
+
+    it("runScript invokes the script in its project's session mount", async () => {
+      const store = await getStore();
+      const script: ProjectScript = {
+        id: 'sc-1' as ProjectScriptId,
+        projectId: PROJECT_ID_2,
+        name: 'web setup',
+        body: 'echo web',
+        sortOrder: 0,
+        createdAt: NOW,
+        updatedAt: NOW,
+      };
+      const mounts: ReadonlyArray<SessionProjectMount> = [
+        {
+          projectId: PROJECT_ID,
+          mountName: 'api',
+          worktreePath: '/sessions/one/api',
+          repoRoot: '/repos/api',
+          branch: 'ak/one',
+        },
+        {
+          projectId: PROJECT_ID_2,
+          mountName: 'web',
+          worktreePath: '/sessions/one/web',
+          repoRoot: '/repos/web',
+          branch: 'ak/one',
+        },
+      ];
+      store.setState({
+        sessions: [buildSession({ activeProjectId: PROJECT_ID })],
+        sessionProjectMounts: { [SESSION_ID]: mounts },
+        projectScripts: { [WS_ID]: [script] },
+      });
+
+      const resultPromise = store
+        .getState()
+        .runScript({ sessionId: SESSION_ID, scriptId: script.id });
+      await vi.waitFor(() => expect(invokeScriptRunSpy).toHaveBeenCalledOnce());
+      const runId = invokeScriptRunSpy.mock.calls[0]?.[1];
+      if (runId === undefined || scriptExitHandler === null) {
+        throw new Error('script listeners were not ready');
+      }
+      scriptExitHandler({ runId, exitCode: 0 });
+      await resultPromise;
+
+      expect(invokeScriptRunSpy.mock.calls[0]?.[2]).toBe('/sessions/one/web');
+    });
+
+    it('runScript records an error and refuses to invoke when the project is unmounted', async () => {
+      const store = await getStore();
+      const script: ProjectScript = {
+        id: 'sc-1' as ProjectScriptId,
+        projectId: PROJECT_ID,
+        name: 'setup',
+        body: 'echo api',
+        sortOrder: 0,
+        createdAt: NOW,
+        updatedAt: NOW,
+      };
+      store.setState({
+        sessions: [buildSession()],
+        sessionProjectMounts: { [SESSION_ID]: [] },
+        projectScripts: { [WS_ID]: [script] },
+      });
+
+      const result = await store
+        .getState()
+        .runScript({ sessionId: SESSION_ID, scriptId: script.id });
+
+      expect(invokeScriptRunSpy).not.toHaveBeenCalled();
+      expect(store.getState().scriptRuns[SESSION_ID]?.[script.id]?.status).toBe('error');
+      expect(result.stderr).toBe('repo is not mounted in this session');
     });
   });
 });

--- a/apps/desktop/src/store/slices/scripts/runScript.ts
+++ b/apps/desktop/src/store/slices/scripts/runScript.ts
@@ -1,4 +1,4 @@
-import type { SessionId, ProjectScriptId } from '@goodboy/types';
+import type { ProjectScriptId, SessionId } from '@goodboy/types';
 import { formatError } from '@goodboy/ui';
 import {
   invokeScriptRun,
@@ -7,20 +7,26 @@ import {
   type ScriptRunRecord,
   type ScriptRunResult,
 } from '../../../features/scripts/scripts';
+import { resolveProjectMountPath } from '../worktrees/resolveProjectMountPath';
 import type { GetFn, SetFn } from './types';
 
+type Params = {
+  readonly sessionId: SessionId;
+  readonly scriptId: ProjectScriptId;
+  readonly cols?: number;
+  readonly rows?: number;
+};
+
+type WriteRunParams = {
+  readonly record: ScriptRunRecord;
+};
+
 export const runScript = (set: SetFn, get: GetFn) => {
-  return async (
-    sessionId: SessionId,
-    scriptId: ProjectScriptId,
-    cwd: string,
-    cols: number = 220,
-    rows: number = 50,
-  ) => {
+  return async ({ sessionId, scriptId, cols = 220, rows = 50 }: Params) => {
     const runId = crypto.randomUUID();
     const startedAt = Date.now();
 
-    const writeRun = (record: ScriptRunRecord) =>
+    const writeRun = ({ record }: WriteRunParams) =>
       set((state) => ({
         scriptRuns: {
           ...state.scriptRuns,
@@ -28,36 +34,57 @@ export const runScript = (set: SetFn, get: GetFn) => {
         },
       }));
 
-    writeRun({ status: 'pending', result: null, runId, startedAt });
+    writeRun({ record: { status: 'pending', result: null, runId, startedAt } });
+
+    const state = get();
+    const session = state.sessions.find((candidate) => candidate.id === sessionId);
+    const script =
+      session === undefined
+        ? undefined
+        : (state.projectScripts[session.workspaceId] ?? []).find(
+            (candidate) => candidate.id === scriptId,
+          );
+    const cwd =
+      script === undefined
+        ? null
+        : resolveProjectMountPath({ state, sessionId, projectId: script.projectId });
+    if (script === undefined || cwd === null) {
+      const project =
+        script === undefined
+          ? undefined
+          : state.projects.find((candidate) => candidate.id === script.projectId);
+      const message =
+        script === undefined
+          ? 'Script is not available in this session'
+          : `${project?.name ?? 'Script project'} is not mounted in this session`;
+      const result: ScriptRunResult = { stdout: '', stderr: message, exitCode: -1 };
+      writeRun({ record: { status: 'error', result, runId, startedAt } });
+      return result;
+    }
 
     let unlistenExit: () => void = () => undefined;
     let unlistenOutput: () => void = () => undefined;
-    let resolveResult!: (r: ScriptRunResult) => void;
-    let rejectResult!: (e: unknown) => void;
-    const resultPromise = new Promise<ScriptRunResult>((res, rej) => {
-      resolveResult = res;
-      rejectResult = rej;
+    let resolveResult: ((result: ScriptRunResult) => void) | null = null;
+    const resultPromise = new Promise<ScriptRunResult>((resolve) => {
+      resolveResult = resolve;
     });
 
-    const STDOUT_CAP = 64 * 1024;
-    const ANSI_RE = /\x1B\[[0-?]*[ -/]*[@-~]/g;
-    let stdoutBuf = '';
-    let truncated = false;
+    const stdoutCap = 64 * 1024;
+    const ansiPattern = /\x1B\[[0-?]*[ -/]*[@-~]/g;
+    let stdoutBuffer = '';
+    let isTruncated = false;
 
     unlistenOutput = await listenScriptOutput((payload) => {
-      if (payload.runId !== runId) {
-        return;
-      }
-      if (truncated) {
+      if (payload.runId !== runId || isTruncated) {
         return;
       }
       const chunk = atob(payload.data);
-      if (stdoutBuf.length + chunk.length > STDOUT_CAP) {
-        stdoutBuf = '…(truncated)\n' + (stdoutBuf + chunk).slice(-(STDOUT_CAP - 14));
-        truncated = true;
-      } else {
-        stdoutBuf += chunk;
+      if (stdoutBuffer.length + chunk.length > stdoutCap) {
+        stdoutBuffer = '…(truncated)\n' + (stdoutBuffer + chunk).slice(-(stdoutCap - 14));
+        isTruncated = true;
+        return;
       }
+      stdoutBuffer += chunk;
     });
 
     unlistenExit = await listenScriptExit((payload) => {
@@ -66,29 +93,35 @@ export const runScript = (set: SetFn, get: GetFn) => {
       }
       unlistenExit();
       unlistenOutput();
-      const curr = get().scriptRuns[sessionId]?.[scriptId];
-      if (!curr || curr.runId !== runId) {
+      const current = get().scriptRuns[sessionId]?.[scriptId];
+      if (current == null || current.runId !== runId) {
         return;
       }
-      const stdout = stdoutBuf.replace(ANSI_RE, '');
+      const stdout = stdoutBuffer.replace(ansiPattern, '');
       const result: ScriptRunResult = { stdout, stderr: '', exitCode: payload.exitCode };
       writeRun({
-        status: curr.status === 'cancelled' ? 'cancelled' : payload.exitCode === 0 ? 'ok' : 'error',
-        result,
-        runId,
-        startedAt,
+        record: {
+          status:
+            current.status === 'cancelled' ? 'cancelled' : payload.exitCode === 0 ? 'ok' : 'error',
+          result,
+          runId,
+          startedAt,
+        },
       });
-      resolveResult(result);
+      resolveResult?.(result);
     });
 
     try {
       await invokeScriptRun(scriptId, runId, cwd, cols, rows);
-    } catch (err) {
+    } catch (caughtError) {
       unlistenExit();
       unlistenOutput();
-      const result: ScriptRunResult = { stdout: '', stderr: formatError(err), exitCode: -1 };
-      writeRun({ status: 'error', result, runId, startedAt });
-      rejectResult(err);
+      const result: ScriptRunResult = {
+        stdout: '',
+        stderr: formatError(caughtError),
+        exitCode: -1,
+      };
+      writeRun({ record: { status: 'error', result, runId, startedAt } });
       return result;
     }
 

--- a/apps/desktop/src/store/slices/scripts/saveScript.ts
+++ b/apps/desktop/src/store/slices/scripts/saveScript.ts
@@ -1,28 +1,32 @@
-import type { IsoDateTime, WorkspaceId, ProjectScript, ProjectScriptId } from '@goodboy/types';
+import type {
+  IsoDateTime,
+  ProjectId,
+  WorkspaceId,
+  ProjectScript,
+  ProjectScriptId,
+} from '@goodboy/types';
 import { upsertProjectScript } from '@goodboy/db';
 import { tauriDatabase } from '../../../shared/lib/db';
 import type { GetFn } from './types';
 
 type Params = {
   workspaceId: WorkspaceId;
+  projectId: ProjectId;
   id?: ProjectScriptId;
   name: string;
   body: string;
 };
 
 export const saveScript = (get: GetFn) => {
-  return async ({ workspaceId, id, name, body }: Params) => {
-    const project = get().projects.find((candidate) => candidate.workspaceId === workspaceId);
-    if (project === undefined) {
-      throw new Error(`workspace has no projects: ${workspaceId}`);
-    }
+  return async ({ workspaceId, projectId, id, name, body }: Params) => {
     const now = new Date().toISOString() as IsoDateTime;
-    const existing = id
-      ? (get().projectScripts[workspaceId] ?? []).find((s) => s.id === id)
-      : undefined;
+    const existing =
+      id !== undefined
+        ? (get().projectScripts[workspaceId] ?? []).find((s) => s.id === id)
+        : undefined;
     const script: ProjectScript = {
       id: id ?? (crypto.randomUUID() as ProjectScriptId),
-      projectId: existing?.projectId ?? project.id,
+      projectId,
       name,
       body,
       sortOrder: existing?.sortOrder ?? get().projectScripts[workspaceId]?.length ?? 0,

--- a/apps/desktop/src/store/slices/scripts/saveScript.ts
+++ b/apps/desktop/src/store/slices/scripts/saveScript.ts
@@ -19,6 +19,10 @@ type Params = {
 
 export const saveScript = (get: GetFn) => {
   return async ({ workspaceId, projectId, id, name, body }: Params) => {
+    const project = get().projects.find((candidate) => candidate.id === projectId);
+    if (project === undefined || project.workspaceId !== workspaceId) {
+      throw new Error(`project ${projectId} does not belong to workspace ${workspaceId}`);
+    }
     const now = new Date().toISOString() as IsoDateTime;
     const existing =
       id !== undefined

--- a/apps/desktop/src/store/slices/worktrees/resolveProjectMountPath.test.ts
+++ b/apps/desktop/src/store/slices/worktrees/resolveProjectMountPath.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  IsoDateTime,
+  ProjectId,
+  Session,
+  SessionId,
+  SessionProjectMount,
+  WorkspaceId,
+} from '@goodboy/types';
+import { resolveProjectMountPath } from './resolveProjectMountPath';
+
+const NOW = '2026-01-01T00:00:00.000Z' as IsoDateTime;
+const WORKSPACE_ID = 'workspace-1' as WorkspaceId;
+const API_ID = 'project-api' as ProjectId;
+const WEB_ID = 'project-web' as ProjectId;
+const SESSION_ID = 'session-1' as SessionId;
+
+const SESSION: Session = {
+  id: SESSION_ID,
+  workspaceId: WORKSPACE_ID,
+  activeProjectId: API_ID,
+  goal: 'test',
+  state: { kind: 'draft' },
+  contextSlots: [],
+  providerPreference: {
+    defaultProvider: 'anthropic',
+    enabledProviders: ['anthropic'],
+    allowTurnOverride: true,
+  },
+  permissionMode: 'bypassPermissions',
+  workflowRuns: [],
+  autoRun: false,
+  titleUserEdited: false,
+  createdAt: NOW,
+  updatedAt: NOW,
+};
+
+const MOUNTS: ReadonlyArray<SessionProjectMount> = [
+  {
+    projectId: WEB_ID,
+    mountName: 'web',
+    worktreePath: '/sessions/one/web',
+    repoRoot: '/repo/web',
+    branch: 'ak/one',
+  },
+  {
+    projectId: API_ID,
+    mountName: 'api',
+    worktreePath: '/sessions/one/api',
+    repoRoot: '/repo/api',
+    branch: 'ak/one',
+  },
+];
+
+describe('resolveProjectMountPath', () => {
+  it('returns the requested project mount instead of the active mount', () => {
+    const path = resolveProjectMountPath({
+      state: { sessions: [SESSION], sessionProjectMounts: { [SESSION_ID]: MOUNTS } },
+      sessionId: SESSION_ID,
+      projectId: WEB_ID,
+    });
+
+    expect(path).toBe('/sessions/one/web');
+  });
+
+  it('returns null when the requested project is not mounted', () => {
+    const path = resolveProjectMountPath({
+      state: { sessions: [SESSION], sessionProjectMounts: { [SESSION_ID]: [MOUNTS[0]!] } },
+      sessionId: SESSION_ID,
+      projectId: API_ID,
+    });
+
+    expect(path).toBeNull();
+  });
+
+  it('returns null when the session does not exist', () => {
+    const path = resolveProjectMountPath({
+      state: { sessions: [], sessionProjectMounts: { [SESSION_ID]: MOUNTS } },
+      sessionId: SESSION_ID,
+      projectId: WEB_ID,
+    });
+
+    expect(path).toBeNull();
+  });
+});

--- a/apps/desktop/src/store/slices/worktrees/resolveProjectMountPath.ts
+++ b/apps/desktop/src/store/slices/worktrees/resolveProjectMountPath.ts
@@ -1,0 +1,20 @@
+import type { ProjectId, SessionId } from '@goodboy/types';
+import type { AppState } from '../../types';
+
+type State = Pick<AppState, 'sessions' | 'sessionProjectMounts'>;
+
+type Params = {
+  readonly state: State;
+  readonly sessionId: SessionId;
+  readonly projectId: ProjectId;
+};
+
+export const resolveProjectMountPath = ({ state, sessionId, projectId }: Params): string | null => {
+  const session = state.sessions.find((candidate) => candidate.id === sessionId);
+  if (session === undefined) {
+    return null;
+  }
+  const mounts = state.sessionProjectMounts[sessionId] ?? [];
+  const mount = mounts.find((candidate) => candidate.projectId === projectId);
+  return mount?.worktreePath ?? null;
+};

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -205,6 +205,21 @@ export type {
   SystemAlertKind,
 } from './types';
 
+type SaveScriptParams = {
+  readonly workspaceId: WorkspaceId;
+  readonly projectId: ProjectId;
+  readonly id?: ProjectScriptId;
+  readonly name: string;
+  readonly body: string;
+};
+
+type RunScriptParams = {
+  readonly sessionId: SessionId;
+  readonly scriptId: ProjectScriptId;
+  readonly cols?: number;
+  readonly rows?: number;
+};
+
 export type AppActions = {
   hydrate(): Promise<void>;
   retryHydrate(): Promise<void>;
@@ -503,20 +518,9 @@ export type AppActions = {
   deleteSkill(skillId: SkillId, workspaceId: WorkspaceId): Promise<void>;
   rescanSkills(workspaceId: WorkspaceId): Promise<void>;
   loadScripts(workspaceId: WorkspaceId): Promise<void>;
-  saveScript(input: {
-    workspaceId: WorkspaceId;
-    id?: ProjectScriptId;
-    name: string;
-    body: string;
-  }): Promise<void>;
+  saveScript(input: SaveScriptParams): Promise<void>;
   deleteScript(scriptId: ProjectScriptId, workspaceId: WorkspaceId): Promise<void>;
-  runScript(
-    sessionId: SessionId,
-    scriptId: ProjectScriptId,
-    cwd: string,
-    cols?: number,
-    rows?: number,
-  ): Promise<ScriptRunResult>;
+  runScript(input: RunScriptParams): Promise<ScriptRunResult>;
   cancelScript(sessionId: SessionId, scriptId: ProjectScriptId): Promise<void>;
   loadPhaseTemplates(workspaceId: WorkspaceId): Promise<void>;
   savePhaseTemplate(template: WorkflowUpsertArgs): Promise<Workflow>;

--- a/packages/ui/src/components/CardAction.tsx
+++ b/packages/ui/src/components/CardAction.tsx
@@ -6,6 +6,7 @@ import { Tooltip } from './Tooltip';
 export type CardActionProps = {
   readonly icon: LucideIcon;
   readonly label: string;
+  readonly tooltip?: string;
   readonly tone?: Tone;
   readonly size?: 'compact' | 'default';
   readonly reveal?: boolean;
@@ -20,6 +21,7 @@ export type CardActionProps = {
 export const CardAction = ({
   icon: Icon,
   label,
+  tooltip,
   tone = 'neutral',
   size = 'compact',
   reveal = false,
@@ -31,7 +33,7 @@ export const CardAction = ({
   onClick,
 }: CardActionProps) => (
   <Tooltip
-    content={label}
+    content={tooltip ?? label}
     side="top"
     anchorClassName={cn('shrink-0', size === 'compact' ? 'size-6' : 'size-7')}
   >


### PR DESCRIPTION
## Why

`project_scripts` has carried a `project_id` since m118, but the UI never showed it and `saveScript` assigned every new script to whichever project came first in the workspace. So the grouping existed in the data and was wrong on screen: on a real workspace two scripts named `copy env` sat next to each other with nothing to tell them apart, and one of them was labelled with a project it has nothing to do with.

The run path was the other half. #1537 made scripts run in the session's **active** project, which was right at the time and is still the wrong answer once a script knows its own project.

## What

- A script names its project, and the editor lets you choose it. The first-project fallback is gone, and `saveScript` refuses a project that does not belong to the workspace.
- It runs in **its own** project's mount for this session. `resolveProjectMountPath` is the single enforcement point inside `runScript`, so no caller can pass a cwd any more; the `worktreePath` props on `ScriptsPanel` and `ScriptsSection` and their plumbing are deleted.
- Project not mounted in this session: the run is refused with the reason on the button. The script stays visible and editable.
- The expanded row shows the path the script will actually run in, for every workspace, because that is the question the old copy answered with a lie about "the session worktree".
- Multi-project workspaces additionally get a chip row (`All` plus one per project), project labels grouping the list, the project name on the collapsed row and the picker in the editor. **With a single project none of that appears**, so the collapsed list looks exactly as it does today.
- The panel copy stopped claiming "cwd is the session worktree".

## Not done, deliberately

- **No workspace-level bucket, no nullable `project_id`.** A workspace has no path of its own, so such a script would have no cwd to run in.
- **No migration and no schema change.** m118 already did the modeling. Pre-m118 rows are correctly attributed because the old workspace is exactly today's project; post-m118 misassignments carry no recoverable intent, so a migration could only shuffle guesses. The visible label plus the picker fixes them in one click.
- **No offer-to-mount from the scripts surface.** Mounting is a heavyweight side effect that lives in the projects lens, and the sidebar row has no room for it.
- **No fallback to the active mount when the project is unmounted**, which would silently reintroduce the wrong-repo bug #1537 just fixed.
- No Rust change: `workspace_script_run` already takes the cwd from the front end.
- `sortOrder` keeps its append semantics, sorted within groups.

Desktop suite green (6510 tests), `@goodboy/ui` green (235), typecheck clean.