### PR TITLE
fix(ui): order the activity trace strictly by timestamp

### DIFF
--- a/apps/desktop/src/features/session/timeline/buildTimelineGroups.test.ts
+++ b/apps/desktop/src/features/session/timeline/buildTimelineGroups.test.ts
@@ -231,7 +231,7 @@ describe('buildTimelineGroups', () => {
     );
   });
 
-  it('keeps a run and its steps as one contiguous block with workflow ordinals', () => {
+  it('keeps workflow membership and ordinals as run metadata', () => {
     const model = build({
       workflows: [attachedWorkflow()],
       agents: [

--- a/apps/desktop/src/features/session/timeline/buildTimelineStream.test.ts
+++ b/apps/desktop/src/features/session/timeline/buildTimelineStream.test.ts
@@ -520,7 +520,7 @@ describe('buildTimelineStream', () => {
     ]);
   });
 
-  it('lifts a pending block above every dated entry, standalone agents included', () => {
+  it('places a pending block above its run newest dated row', () => {
     const { items } = stream({
       workflows: [attachedWorkflow({ createdAt: localIso({ day: 18, hour: 8 }) })],
       agents: RUN_WITH_PENDING_AGENTS,
@@ -528,8 +528,8 @@ describe('buildTimelineStream', () => {
 
     expect(items.map(labelOf)).toEqual([
       'now',
-      'cluster:3',
       'entry:agent:built-by-hand',
+      'cluster:3',
       'step:agent:implement',
       'step:agent:plan',
       'entry:run:run-1',
@@ -571,7 +571,7 @@ describe('buildTimelineStream', () => {
 
     expect(clusterRail?.joins.map((join) => `${join.kind}:${join.dash}`)).toEqual(['merge:dashed']);
     expect(clusterRail?.segments.filter((segment) => segment.column > 0)).toEqual([]);
-    expect(clusterRail?.joins[0]?.path).toBe('M 24 48 C 24 39.16, 16.84 24, 8 24');
+    expect(clusterRail?.joins[0]?.path).toBe('M 24 60 C 24 51.16, 16.84 36, 8 36');
     expect(clusterRail?.markerColumn).toBe(0);
     expect(nowRail?.segments.filter((segment) => segment.column > 0)).toEqual([]);
   });
@@ -615,9 +615,9 @@ describe('buildTimelineStream', () => {
     expect(items.map(labelOf)).toEqual([
       'now',
       'cluster:2',
-      'cluster:2',
       'step:agent:b-running',
       'entry:run:run-2',
+      'cluster:2',
       'step:agent:a-done',
       'entry:run:run-1',
     ]);
@@ -656,8 +656,8 @@ describe('buildTimelineStream', () => {
 
     expect(items.map(labelOf)).toEqual([
       'now',
-      'step:agent:todo',
       'entry:agent:built-by-hand',
+      'step:agent:todo',
       'day:Aug 10',
       'step:agent:done',
       'entry:run:run-1',
@@ -727,7 +727,7 @@ describe('buildTimelineStream', () => {
     expect(layout.columnByGroupId.get('lane:agent:implement')).toBe(2);
   });
 
-  it('keeps a run whole when a standalone agent ran between two of its steps', () => {
+  it('draws a run lane behind a standalone agent between two steps', () => {
     const { items, groups } = stream({
       workflows: [attachedWorkflow({ createdAt: localIso({ day: 18, hour: 8 }) })],
       agents: [
@@ -752,12 +752,43 @@ describe('buildTimelineStream', () => {
     expect(items.map(labelOf)).toEqual([
       'now',
       'step:agent:step-two',
+      'entry:agent:loose',
       'step:agent:step-one',
       'entry:run:run-1',
-      'entry:agent:loose',
     ]);
     expect(layout.rows[looseIndex]?.markerColumn).toBe(0);
-    expect(layout.rows[looseIndex]?.segments.filter((segment) => segment.column > 0)).toEqual([]);
+    expect(layout.rows[looseIndex]?.segments.filter((segment) => segment.column > 0)).toHaveLength(
+      1,
+    );
+  });
+
+  it('orders workflow steps and standalone agents by each row timestamp', () => {
+    const { items } = stream({
+      workflows: [attachedWorkflow({ createdAt: localIso({ day: 18, hour: 8 }) })],
+      agents: [
+        agent({
+          id: 'step-one',
+          ordinal: 1,
+          startedAt: localIso({ day: 18, hour: 9 }),
+          workflowRunId: RUN_ID,
+        }),
+        agent({ id: 'loose', ordinal: 2, startedAt: localIso({ day: 18, hour: 9, minute: 30 }) }),
+        agent({
+          id: 'step-two',
+          ordinal: 3,
+          startedAt: localIso({ day: 18, hour: 10 }),
+          workflowRunId: RUN_ID,
+        }),
+      ],
+    });
+
+    expect(items.map(labelOf)).toEqual([
+      'now',
+      'step:agent:step-two',
+      'entry:agent:loose',
+      'step:agent:step-one',
+      'entry:run:run-1',
+    ]);
   });
 
   it('keeps a chain with its parent when the children landed a day later', () => {
@@ -796,12 +827,12 @@ describe('buildTimelineStream', () => {
       'now',
       'step:agent:cluster-child',
       'day:Yesterday',
-      'entry:agent:cluster-parent',
       'entry:event:ev-decision',
       'entry:agent:elenca',
+      'entry:agent:cluster-parent',
     ]);
-    expect(laneSegmentsOf({ id: 'event:ev-decision' })).toEqual([]);
-    expect(laneSegmentsOf({ id: 'agent:elenca' })).toEqual([]);
+    expect(laneSegmentsOf({ id: 'event:ev-decision' })).toHaveLength(1);
+    expect(laneSegmentsOf({ id: 'agent:elenca' })).toHaveLength(1);
     const dayIndex = items.findIndex((item) => item.kind === 'day');
 
     expect(layout.rows[dayIndex]?.segments.filter((segment) => segment.column > 0)).toHaveLength(1);
@@ -1366,7 +1397,7 @@ describe('buildTimelineStream, plan visibility and family anchoring', () => {
     agent({ id: 'review', ordinal: 5, status: 'pending', workflowRunId: RUN_ID }),
   ];
 
-  it('anchors a waiting parent under its children instead of lifting it to the head', () => {
+  it('places every waiting family row above the newest dated family row', () => {
     const { items } = stream({
       workflows: PLAN_RUN_WORKFLOWS,
       agents: CLUSTER_RUN_AGENTS,
@@ -1376,9 +1407,9 @@ describe('buildTimelineStream, plan visibility and family anchoring', () => {
       'now',
       'step:agent:review',
       'step:agent:sub-3',
+      'step:agent:implement',
       'step:agent:sub-2',
       'step:agent:sub-1',
-      'step:agent:implement',
       'entry:run:run-1',
     ]);
   });

--- a/apps/desktop/src/features/session/timeline/buildTimelineStream.ts
+++ b/apps/desktop/src/features/session/timeline/buildTimelineStream.ts
@@ -104,7 +104,6 @@ type DraftRow = {
   readonly markerState: TimelineMarkerState;
   readonly hasUnread: boolean;
   readonly isPending: boolean;
-  readonly isSubagent: boolean;
 };
 
 type DraftCluster = {
@@ -180,11 +179,6 @@ const isRunFinished = ({ entry }: { readonly entry: TimelineRunEntry }): boolean
   });
 };
 
-type DraftBlock = {
-  readonly key: Sortable;
-  readonly rows: ReadonlyArray<DraftRow>;
-};
-
 type EmitContext = {
   readonly unreadAgentIds: ReadonlySet<string>;
   readonly blockedRunIds: ReadonlySet<string>;
@@ -207,29 +201,6 @@ const hasUnreadDescendant = ({
       unreadAgentIds.has(child.agent.id) || hasUnreadDescendant({ entry: child, unreadAgentIds }),
   );
 
-const sortableOf = ({ row }: { readonly row: DraftRow }): Sortable => ({
-  at: row.at,
-  sortOrdinal: row.sortOrdinal,
-  id: row.id,
-});
-
-const blockOf = ({
-  rows,
-  origin,
-}: {
-  readonly rows: ReadonlyArray<DraftRow>;
-  readonly origin: DraftRow;
-}): DraftBlock => ({ key: sortableOf({ row: rows[0] ?? origin }), rows });
-
-const nestedFirst = ({
-  blocks,
-}: {
-  readonly blocks: ReadonlyArray<DraftBlock>;
-}): ReadonlyArray<DraftRow> =>
-  [...blocks]
-    .sort((first, second) => compareNewestFirst({ first: first.key, second: second.key }))
-    .flatMap((block) => block.rows);
-
 type EmitAgentParams = {
   readonly entry: TimelineAgentEntry;
   readonly grade: TimelineRowGrade;
@@ -238,11 +209,10 @@ type EmitAgentParams = {
   readonly familyId: string | null;
   readonly groupId: string | null;
   readonly showSubagents: boolean;
-  readonly isSubagent: boolean;
   readonly context: EmitContext;
 };
 
-const agentBlock = ({
+const agentRows = ({
   entry,
   grade,
   identity,
@@ -250,11 +220,10 @@ const agentBlock = ({
   familyId,
   groupId,
   showSubagents,
-  isSubagent,
   context,
-}: EmitAgentParams): DraftBlock => {
+}: EmitAgentParams): ReadonlyArray<DraftRow> => {
   const childLaneId = laneIdOf({ entryId: entry.id });
-  const nested: DraftBlock[] = [];
+  const nested: DraftRow[] = [];
   if (showSubagents && entry.children.length > 0) {
     context.groups.push({
       id: childLaneId,
@@ -269,19 +238,17 @@ const agentBlock = ({
           : 'open',
     });
     for (const child of entry.children) {
-      const block = agentBlock({
-        entry: child,
-        grade: 'step',
-        identity,
-        isMuted,
-        familyId,
-        groupId: childLaneId,
-        showSubagents,
-        isSubagent: true,
-        context,
-      });
       nested.push(
-        child.agent.status === 'pending' ? { ...block, key: { ...block.key, at: null } } : block,
+        ...agentRows({
+          entry: child,
+          grade: 'step',
+          identity,
+          isMuted,
+          familyId,
+          groupId: childLaneId,
+          showSubagents,
+          context,
+        }),
       );
     }
   }
@@ -301,9 +268,8 @@ const agentBlock = ({
         markerState: 'done',
         hasUnread: false,
         isPending: false,
-        isSubagent,
       };
-      nested.push({ key: sortableOf({ row }), rows: [row] });
+      nested.push(row);
     }
   }
   const origin: DraftRow = {
@@ -326,9 +292,8 @@ const agentBlock = ({
       context.unreadAgentIds.has(entry.agent.id) ||
       (!showSubagents && hasUnreadDescendant({ entry, unreadAgentIds: context.unreadAgentIds })),
     isPending: entry.agent.status === 'pending',
-    isSubagent,
   };
-  return blockOf({ rows: [...nestedFirst({ blocks: nested }), origin], origin });
+  return [...nested, origin];
 };
 
 type EmitRunParams = {
@@ -336,7 +301,7 @@ type EmitRunParams = {
   readonly context: EmitContext;
 };
 
-const runBlock = ({ entry, context }: EmitRunParams): DraftBlock => {
+const runRows = ({ entry, context }: EmitRunParams): ReadonlyArray<DraftRow> => {
   const laneId = laneIdOf({ entryId: entry.id });
   const isFinished = isRunFinished({ entry });
   const needsUser = context.blockedRunIds.has(entry.run.id);
@@ -350,11 +315,11 @@ const runBlock = ({ entry, context }: EmitRunParams): DraftBlock => {
     originRowId: entry.id,
     shape,
   });
-  const nested: DraftBlock[] = [];
+  const nested: DraftRow[] = [];
   for (const child of entry.children) {
     if (child.kind === 'agent') {
       nested.push(
-        agentBlock({
+        ...agentRows({
           entry: child,
           grade: 'step',
           identity: entry.identity,
@@ -362,7 +327,6 @@ const runBlock = ({ entry, context }: EmitRunParams): DraftBlock => {
           familyId: entry.id,
           groupId: laneId,
           showSubagents: context.showWorkflowSubagents,
-          isSubagent: false,
           context,
         }),
       );
@@ -385,9 +349,8 @@ const runBlock = ({ entry, context }: EmitRunParams): DraftBlock => {
       markerState: 'done',
       hasUnread: false,
       isPending: false,
-      isSubagent: false,
     };
-    nested.push({ key: sortableOf({ row }), rows: [row] });
+    nested.push(row);
   }
   const steps = stepAgentsOf({ entry });
   const origin: DraftRow = {
@@ -414,51 +377,52 @@ const runBlock = ({ entry, context }: EmitRunParams): DraftBlock => {
     }),
     hasUnread: steps.some((agent) => context.unreadAgentIds.has(agent.id)),
     isPending: false,
-    isSubagent: false,
   };
-  return blockOf({ rows: [...nestedFirst({ blocks: nested }), origin], origin });
+  return [...nested, origin];
 };
 
 const isPendingStep = ({ draft }: { readonly draft: DraftRow }): boolean =>
   draft.grade === 'step' && draft.markerState === 'pending';
 
-const isFamilyAnchored = ({ draft }: { readonly draft: DraftRow }): boolean =>
-  draft.isSubagent || (draft.entry.kind === 'agent' && draft.entry.children.length > 0);
-
-const blockKeyOf = ({ block }: { readonly block: DraftBlock }): Sortable => {
-  const dated = block.rows.find((row) => !isPendingStep({ draft: row }));
-  return dated === undefined ? block.key : sortableOf({ row: dated });
-};
-
 type HeadParams = {
   readonly drafts: ReadonlyArray<DraftRow>;
 };
 
-const withPendingAtHead = ({ drafts }: HeadParams): ReadonlyArray<DraftRow> => {
-  const laneRankById = new Map<string, number>();
-  for (const [index, draft] of drafts.entries()) {
-    if (draft.familyId === draft.id) {
-      laneRankById.set(draft.id, index);
+const withPendingAtFamilyHead = ({ drafts }: HeadParams): ReadonlyArray<DraftRow> => {
+  const pendingByFamilyId = new Map<string, DraftRow[]>();
+  const unanchored: DraftRow[] = [];
+  for (const draft of drafts) {
+    if (!isPendingStep({ draft }) || draft.familyId == null || draft.familyId === draft.id) {
+      unanchored.push(draft);
+      continue;
     }
+    const pending = pendingByFamilyId.get(draft.familyId) ?? [];
+    pending.push({ ...draft, at: null });
+    pendingByFamilyId.set(draft.familyId, pending);
   }
-  const laneRankOf = ({ draft }: { readonly draft: DraftRow }): number =>
-    draft.familyId == null ? drafts.length : (laneRankById.get(draft.familyId) ?? drafts.length);
-  const future = drafts
-    .filter((draft) => isPendingStep({ draft }) && !isFamilyAnchored({ draft }))
-    .map((draft) => ({ ...draft, at: null }))
-    .sort(
+  for (const pending of pendingByFamilyId.values()) {
+    pending.sort(
       (first, second) =>
-        laneRankOf({ draft: first }) - laneRankOf({ draft: second }) ||
-        (first.groupId ?? '').localeCompare(second.groupId ?? '') ||
-        second.sortOrdinal - first.sortOrdinal ||
-        first.id.localeCompare(second.id),
+        second.sortOrdinal - first.sortOrdinal || first.id.localeCompare(second.id),
     );
-  return [
-    ...future,
-    ...drafts
-      .filter((draft) => !isPendingStep({ draft }) || isFamilyAnchored({ draft }))
-      .map((draft) => (isPendingStep({ draft }) ? { ...draft, at: null } : draft)),
-  ];
+  }
+  const result: DraftRow[] = [];
+  for (const draft of unanchored) {
+    const familyId = draft.familyId;
+    if (familyId != null) {
+      const pending = pendingByFamilyId.get(familyId);
+      if (pending !== undefined) {
+        result.push(...pending);
+        pendingByFamilyId.delete(familyId);
+      }
+    }
+    result.push(draft);
+  }
+  const remaining = [...pendingByFamilyId.values()]
+    .flat()
+    .map((draft) => ({ ...draft, at: null }))
+    .sort((first, second) => compareNewestFirst({ first, second }));
+  return [...remaining, ...result];
 };
 
 type ClusterParams = {
@@ -551,16 +515,16 @@ export const buildTimelineStream = ({
     showPlans,
     showQuestions,
   };
-  const blocks: DraftBlock[] = [];
+  const rows: DraftRow[] = [];
 
   for (const entry of entries) {
     if (entry.kind === 'run') {
-      blocks.push(runBlock({ entry, context }));
+      rows.push(...runRows({ entry, context }));
       continue;
     }
     if (entry.kind === 'agent') {
-      blocks.push(
-        agentBlock({
+      rows.push(
+        ...agentRows({
           entry,
           grade: 'entry',
           identity: entry.chain?.identity ?? null,
@@ -568,7 +532,6 @@ export const buildTimelineStream = ({
           familyId: entry.id,
           groupId: null,
           showSubagents: context.showAgentSubagents,
-          isSubagent: false,
           context,
         }),
       );
@@ -588,21 +551,13 @@ export const buildTimelineStream = ({
       markerState: 'done',
       hasUnread: false,
       isPending: false,
-      isSubagent: false,
     };
-    blocks.push({ key: sortableOf({ row }), rows: [row] });
+    rows.push(row);
   }
 
-  const sorted = [...blocks]
-    .sort((first, second) =>
-      compareNewestFirst({
-        first: blockKeyOf({ block: first }),
-        second: blockKeyOf({ block: second }),
-      }),
-    )
-    .flatMap((block) => block.rows);
+  const sorted = [...rows].sort((first, second) => compareNewestFirst({ first, second }));
   const withDays = withDayBreaks({
-    drafts: withPendingClusters({ drafts: withPendingAtHead({ drafts: sorted }) }),
+    drafts: withPendingClusters({ drafts: withPendingAtFamilyHead({ drafts: sorted }) }),
     dayLabelFor,
   });
 


### PR DESCRIPTION
## Problem
An agent created between workflow step 1 and step 2 was visually displaced below the whole workflow once step 2 appeared, despite its correct timestamp. Root cause: the stream sorted contiguous run blocks keyed by their newest non-pending row, dragging older steps above interleaved standalone agents.

## Fix
- Flatten workflow families into globally sortable rows; strict newest-first ordering by each row's own timestamp.
- Chain membership conveyed only by the link icon and the rail lane (geometry already supports lanes crossing interleaved rows).
- Pending steps (no timestamp) stay anchored above their family's newest dated row.
- Removed the now-dead block helpers (`DraftBlock`, `blockKeyOf`, `sortableOf`, unused `isSubagent`).

## Tests
- Regression test for the exact reported scenario (step1 09:00, standalone 09:30, step2 10:00).
- Timeline suites: 158 passed. TimelinePane suites: 78 passed. Typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)