### PR TITLE
fix(ui): unify pull request status colors and center trace chips

### DIFF
--- a/apps/desktop/src/features/github/components/PullRequestChip/index.test.tsx
+++ b/apps/desktop/src/features/github/components/PullRequestChip/index.test.tsx
@@ -40,9 +40,9 @@ describe('PullRequestChip', () => {
 
 describe('pullRequestMeta', () => {
   it('exposes a label for every state', () => {
-    expect(pullRequestMeta('open').label).toBe('In review');
-    expect(pullRequestMeta('queued').label).toBe('Queued');
-    expect(pullRequestMeta('closed').label).toBe('Closed');
-    expect(pullRequestMeta('none').label).toBe('No pull request');
+    expect(pullRequestMeta({ state: 'open' }).label).toBe('In review');
+    expect(pullRequestMeta({ state: 'queued' }).label).toBe('Queued');
+    expect(pullRequestMeta({ state: 'closed' }).label).toBe('Closed');
+    expect(pullRequestMeta({ state: 'none' }).label).toBe('No pull request');
   });
 });

--- a/apps/desktop/src/features/github/components/PullRequestChip/index.tsx
+++ b/apps/desktop/src/features/github/components/PullRequestChip/index.tsx
@@ -1,77 +1,19 @@
+import { Chip, cn } from '@goodboy/ui';
 import {
-  Check,
-  CircleDashed,
-  GitMerge,
-  GitPullRequest,
-  GitPullRequestClosed,
-  GitPullRequestDraft,
-  ListChecks,
-} from 'lucide-react';
-import { Chip, cn, type Tone } from '@goodboy/ui';
-import type { PullRequestStateKind } from '@goodboy/types';
+  PULL_REQUEST_PRESENTATION,
+  type PullRequestPresentationState,
+} from '../../../../shared/pullRequestPresentation';
 
-type PrStateMeta = {
-  readonly icon: React.ElementType;
-  readonly label: string;
-  readonly textClass: string;
-  readonly tone: Tone;
+type MetaParams = {
+  readonly state: PullRequestPresentationState;
 };
 
-type PullRequestChipState = PullRequestStateKind | 'none';
-
-const PR_META: Record<PullRequestChipState, PrStateMeta> = {
-  none: {
-    icon: CircleDashed,
-    label: 'No pull request',
-    textClass: 'text-muted-foreground/50',
-    tone: 'neutral',
-  },
-  draft: {
-    icon: GitPullRequestDraft,
-    label: 'Draft',
-    textClass: 'text-muted-foreground',
-    tone: 'neutral',
-  },
-  open: {
-    icon: GitPullRequest,
-    label: 'In review',
-    textClass: 'text-success',
-    tone: 'success',
-  },
-  approved: {
-    icon: Check,
-    label: 'Approved',
-    textClass: 'text-success',
-    tone: 'success',
-  },
-  queued: {
-    icon: ListChecks,
-    label: 'Queued',
-    textClass: 'text-primary',
-    tone: 'primary',
-  },
-  merged: {
-    icon: GitMerge,
-    label: 'Merged',
-    textClass: 'text-merged',
-    tone: 'merged',
-  },
-  closed: {
-    icon: GitPullRequestClosed,
-    label: 'Closed',
-    textClass: 'text-danger',
-    tone: 'danger',
-  },
-};
-
-export const pullRequestMeta = (state: PullRequestChipState): PrStateMeta => {
-  return PR_META[state];
-};
+export const pullRequestMeta = ({ state }: MetaParams) => PULL_REQUEST_PRESENTATION[state];
 
 type Variant = 'icon' | 'compact' | 'badge';
 
 type Props = {
-  readonly state: PullRequestChipState;
+  readonly state: PullRequestPresentationState;
   readonly variant?: Variant;
   readonly number?: number;
   readonly iconSize?: number;
@@ -87,7 +29,7 @@ export const PullRequestChip = ({
   className,
   title,
 }: Props) => {
-  const meta = PR_META[state];
+  const meta = PULL_REQUEST_PRESENTATION[state];
   const Icon = meta.icon;
   const description = title ?? meta.label + (number !== undefined ? ` · #${number}` : '');
 

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.tsx
@@ -245,7 +245,7 @@ export const PrPane = ({ session, onSelectLens }: Props) => {
                   <span className="font-mono text-2xs tabular-nums text-muted-foreground">
                     !{mergeRequest.iid}
                   </span>
-                  <StateBadge>{pullRequestMeta(mergeRequestState).label}</StateBadge>
+                  <StateBadge>{pullRequestMeta({ state: mergeRequestState }).label}</StateBadge>
                   <span className="min-w-0 truncate text-sm text-muted-foreground">
                     {mergeRequest.title}
                   </span>
@@ -604,7 +604,9 @@ const LinkedPullRequestsSection = ({
                   : `Show pull request #${candidate.number}`
               }
               tooltip={isSelected ? 'Open this pull request' : 'Show this pull request instead'}
-              attribution={<StateBadge>{pullRequestMeta(candidate.state).label}</StateBadge>}
+              attribution={
+                <StateBadge>{pullRequestMeta({ state: candidate.state }).label}</StateBadge>
+              }
               onClick={() => (isSelected ? onOpenSelected() : onSelect(candidate.number))}
               actions={
                 <ExternalRefActions

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRowLabel.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRowLabel.test.tsx
@@ -150,7 +150,8 @@ describe('TimelineRowLabel', () => {
       isChained: true,
     });
 
-    expect(container.querySelector('svg')).not.toBeNull();
+    expect(container.querySelector('svg')?.classList.contains('absolute')).toBe(true);
+    expect(screen.getByText(AGENT_KIND_META.planner.label).className).toContain('justify-center');
   });
 
   it('marks a chained descendant too, on the step row it lives on', () => {

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRowLabel.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRowLabel.tsx
@@ -81,12 +81,16 @@ const chipOf = ({ entry, grade }: ChipParams) => {
     <Chip
       tone="neutral"
       label={palette.label}
-      icon={isChained ? <CONCEPT_ICONS.chain size={10} aria-hidden /> : null}
+      icon={
+        isChained ? (
+          <CONCEPT_ICONS.chain className="absolute left-1.5" size={10} aria-hidden />
+        ) : null
+      }
       shape="badge"
       size="3xs"
       width="md"
       uppercase
-      className={cn('shrink-0', palette.fg)}
+      className={cn('relative shrink-0', palette.fg)}
     />
   );
 };
@@ -119,13 +123,17 @@ export const TimelineRowLabel = ({ item, diffStat = null }: Props) => {
           isStep ? 'text-xs leading-4' : 'text-sm leading-5',
           emphasis === 'success'
             ? 'text-success'
-            : emphasis === 'muted'
-              ? 'text-muted-foreground'
-              : item.markerState === 'running' || item.hasUnread
-                ? 'font-medium text-foreground'
-                : isStep
-                  ? 'text-foreground/85'
-                  : 'text-foreground',
+            : emphasis === 'merged'
+              ? 'text-merged'
+              : emphasis === 'danger'
+                ? 'text-danger'
+                : emphasis === 'muted'
+                  ? 'text-muted-foreground'
+                  : item.markerState === 'running' || item.hasUnread
+                    ? 'font-medium text-foreground'
+                    : isStep
+                      ? 'text-foreground/85'
+                      : 'text-foreground',
         )}
       >
         {segments.map((segment, index) =>

--- a/apps/desktop/src/features/session/timeline/sessionEventPresentation.test.ts
+++ b/apps/desktop/src/features/session/timeline/sessionEventPresentation.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { SessionEvent, SessionEventKind, SessionEventPayload } from '@goodboy/types';
 import { SESSION_EVENT_KINDS } from '@goodboy/types';
 import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../shared/components/conceptIcons';
+import { PULL_REQUEST_PRESENTATION } from '../../../shared/pullRequestPresentation';
 import {
   sessionEventEmphasis,
   sessionEventGlyph,
@@ -237,9 +238,12 @@ describe('sessionEventLabel', () => {
 });
 
 describe('sessionEventEmphasis', () => {
-  it('celebrates an approval and a merge', () => {
+  it('uses the shared pull request colors', () => {
+    expect(sessionEventEmphasis({ kind: 'pr_created' })).toBe('success');
+    expect(sessionEventEmphasis({ kind: 'pr_ready' })).toBe('success');
     expect(sessionEventEmphasis({ kind: 'pr_approved' })).toBe('success');
-    expect(sessionEventEmphasis({ kind: 'pr_merged' })).toBe('success');
+    expect(sessionEventEmphasis({ kind: 'pr_merged' })).toBe('merged');
+    expect(sessionEventEmphasis({ kind: 'pr_closed' })).toBe('danger');
   });
 
   it('dims what was taken away', () => {
@@ -269,5 +273,22 @@ describe('sessionEventGlyph', () => {
     expect(glyph.icon).toBe(CONCEPT_ICONS.context);
     expect(glyph.tone).toBe(CONCEPT_TONE.context);
     expect(glyph.label).toBe('Context');
+  });
+
+  it('uses the shared pull request glyphs and tones', () => {
+    for (const [kind, state] of [
+      ['pr_created', 'open'],
+      ['pr_ready', 'open'],
+      ['pr_approved', 'approved'],
+      ['pr_merged', 'merged'],
+      ['pr_closed', 'closed'],
+    ] satisfies ReadonlyArray<
+      readonly [SessionEventKind, keyof typeof PULL_REQUEST_PRESENTATION]
+    >) {
+      const glyph = sessionEventGlyph({ kind });
+      const presentation = PULL_REQUEST_PRESENTATION[state];
+      expect(glyph.icon).toBe(presentation.icon);
+      expect(glyph.tone).toBe(presentation.tone);
+    }
   });
 });

--- a/apps/desktop/src/features/session/timeline/sessionEventPresentation.ts
+++ b/apps/desktop/src/features/session/timeline/sessionEventPresentation.ts
@@ -3,9 +3,6 @@ import {
   FolderMinus,
   FolderPlus,
   GitBranch,
-  GitMerge,
-  GitPullRequest,
-  GitPullRequestClosed,
   Link2,
   Link2Off,
   Trash2,
@@ -14,8 +11,22 @@ import type { LucideIcon } from 'lucide-react';
 import type { SessionEvent, SessionEventKind, SessionEventPayload } from '@goodboy/types';
 import type { Tone } from '@goodboy/ui';
 import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../shared/components/conceptIcons';
+import {
+  PULL_REQUEST_PRESENTATION,
+  type PullRequestPresentationState,
+} from '../../../shared/pullRequestPresentation';
 
-export type SessionEventEmphasis = 'plain' | 'muted' | 'success';
+export type SessionEventEmphasis = 'plain' | 'muted' | 'success' | 'merged' | 'danger';
+
+type PullRequestEventKind = Extract<SessionEventKind, `pr_${string}`>;
+
+const PR_EVENT_STATE = {
+  pr_created: 'open',
+  pr_ready: 'open',
+  pr_approved: 'approved',
+  pr_merged: 'merged',
+  pr_closed: 'closed',
+} satisfies Record<PullRequestEventKind, PullRequestPresentationState>;
 
 const EMPHASIS: Record<SessionEventKind, SessionEventEmphasis> = {
   worktree_created: 'plain',
@@ -23,11 +34,11 @@ const EMPHASIS: Record<SessionEventKind, SessionEventEmphasis> = {
   branch_switched: 'plain',
   issue_linked: 'plain',
   issue_unlinked: 'muted',
-  pr_created: 'plain',
-  pr_ready: 'plain',
-  pr_approved: 'success',
-  pr_merged: 'success',
-  pr_closed: 'muted',
+  pr_created: PULL_REQUEST_PRESENTATION[PR_EVENT_STATE.pr_created].tone,
+  pr_ready: PULL_REQUEST_PRESENTATION[PR_EVENT_STATE.pr_ready].tone,
+  pr_approved: PULL_REQUEST_PRESENTATION[PR_EVENT_STATE.pr_approved].tone,
+  pr_merged: PULL_REQUEST_PRESENTATION[PR_EVENT_STATE.pr_merged].tone,
+  pr_closed: PULL_REQUEST_PRESENTATION[PR_EVENT_STATE.pr_closed].tone,
   workflow_started: 'plain',
   workflow_discarded: 'muted',
   workflow_restored: 'plain',
@@ -51,11 +62,11 @@ const GLYPH: Record<SessionEventKind, SessionEventGlyph> = {
   branch_switched: { icon: GitBranch, tone: 'info', label: 'Branch' },
   issue_linked: { icon: Link2, tone: 'neutral', label: 'Issue' },
   issue_unlinked: { icon: Link2Off, tone: 'neutral', label: 'Issue' },
-  pr_created: { icon: GitPullRequest, tone: 'primary', label: 'Pull request' },
-  pr_ready: { icon: GitPullRequest, tone: 'primary', label: 'Pull request' },
-  pr_approved: { icon: CONCEPT_ICONS.checks, tone: 'success', label: 'Pull request' },
-  pr_merged: { icon: GitMerge, tone: 'success', label: 'Pull request' },
-  pr_closed: { icon: GitPullRequestClosed, tone: 'neutral', label: 'Pull request' },
+  pr_created: { ...PULL_REQUEST_PRESENTATION[PR_EVENT_STATE.pr_created], label: 'Pull request' },
+  pr_ready: { ...PULL_REQUEST_PRESENTATION[PR_EVENT_STATE.pr_ready], label: 'Pull request' },
+  pr_approved: { ...PULL_REQUEST_PRESENTATION[PR_EVENT_STATE.pr_approved], label: 'Pull request' },
+  pr_merged: { ...PULL_REQUEST_PRESENTATION[PR_EVENT_STATE.pr_merged], label: 'Pull request' },
+  pr_closed: { ...PULL_REQUEST_PRESENTATION[PR_EVENT_STATE.pr_closed], label: 'Pull request' },
   workflow_started: { icon: CONCEPT_ICONS.workflows, tone: 'accent', label: 'Workflow' },
   workflow_discarded: { icon: CONCEPT_ICONS.workflows, tone: 'neutral', label: 'Workflow' },
   workflow_restored: { icon: CONCEPT_ICONS.workflows, tone: 'accent', label: 'Workflow' },

--- a/apps/desktop/src/features/workspace/components/SessionActivityBar/index.tsx
+++ b/apps/desktop/src/features/workspace/components/SessionActivityBar/index.tsx
@@ -335,7 +335,7 @@ const SessionActivityItem = memo(function SessionActivityItem({
   const isAutoMode =
     stage === 'running' && session.workflowRuns.some((r) => r.autoRun && !r.discardedAt);
   const prState = useAppStore((s) => s.sessionGithub[session.id as SessionId]?.pr?.state ?? null);
-  const prMeta = prState ? pullRequestMeta(prState) : null;
+  const prMeta = prState != null ? pullRequestMeta({ state: prState }) : null;
   const externalTasks = useAppStore(
     (s) => s.sessionExternalTasks[session.id as SessionId] ?? EMPTY_ARRAY,
   );

--- a/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/PrRequestSlot.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/PrRequestSlot.tsx
@@ -18,7 +18,7 @@ type Props = {
 
 export const PrRequestSlot = ({ linkedRequest, isGitlab, prFetchState, onOpen }: Props) => {
   if (linkedRequest.state !== 'none') {
-    const meta = pullRequestMeta(linkedRequest.state);
+    const meta = pullRequestMeta({ state: linkedRequest.state });
     const numberSuffix =
       linkedRequest.number === undefined
         ? ''

--- a/apps/desktop/src/shared/pullRequestPresentation.ts
+++ b/apps/desktop/src/shared/pullRequestPresentation.ts
@@ -1,0 +1,66 @@
+import {
+  CircleCheck,
+  CircleDashed,
+  GitMerge,
+  GitPullRequest,
+  GitPullRequestClosed,
+  GitPullRequestDraft,
+  ListChecks,
+  type LucideIcon,
+} from 'lucide-react';
+import type { PullRequestStateKind } from '@goodboy/types';
+import type { Tone } from '@goodboy/ui';
+
+export type PullRequestPresentationState = PullRequestStateKind | 'none';
+
+export type PullRequestPresentation = {
+  readonly icon: LucideIcon;
+  readonly label: string;
+  readonly textClass: string;
+  readonly tone: Tone;
+};
+
+export const PULL_REQUEST_PRESENTATION = {
+  none: {
+    icon: CircleDashed,
+    label: 'No pull request',
+    textClass: 'text-muted-foreground/50',
+    tone: 'neutral',
+  },
+  draft: {
+    icon: GitPullRequestDraft,
+    label: 'Draft',
+    textClass: 'text-muted-foreground',
+    tone: 'neutral',
+  },
+  open: {
+    icon: GitPullRequest,
+    label: 'In review',
+    textClass: 'text-success',
+    tone: 'success',
+  },
+  approved: {
+    icon: CircleCheck,
+    label: 'Approved',
+    textClass: 'text-success',
+    tone: 'success',
+  },
+  queued: {
+    icon: ListChecks,
+    label: 'Queued',
+    textClass: 'text-primary',
+    tone: 'primary',
+  },
+  merged: {
+    icon: GitMerge,
+    label: 'Merged',
+    textClass: 'text-merged',
+    tone: 'merged',
+  },
+  closed: {
+    icon: GitPullRequestClosed,
+    label: 'Closed',
+    textClass: 'text-danger',
+    tone: 'danger',
+  },
+} satisfies Record<PullRequestPresentationState, PullRequestPresentation>;


### PR DESCRIPTION
## What
- New `shared/pullRequestPresentation.ts`: single status → {color, icon, label} map following the GitHub convention (open green GitPullRequest, approved green CircleCheck, merged purple GitMerge, closed red GitPullRequestClosed, draft muted).
- Timeline events, PullRequestChip, sidebar, and board card all consume it. The trace no longer shows MERGED in green: it is purple with the merge icon everywhere.
- Trace agent chips (IMPLEMENT/REVIEW): label always centered in the chip, chain link icon absolutely positioned left so chained and unchained chips align as a column.
- Deleted the duplicated `PR_META` map and superseded icon imports.

## Tests
44 files, 389 passed. Typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)