### PR TITLE
feat(ui): project chips in the sidebar and a shared project filter

### DIFF
--- a/apps/desktop/src/features/workspace/components/ProjectChip/index.test.tsx
+++ b/apps/desktop/src/features/workspace/components/ProjectChip/index.test.tsx
@@ -1,0 +1,40 @@
+import type { ReactElement } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+
+vi.mock('@goodboy/ui', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@goodboy/ui')>();
+  return {
+    ...actual,
+    Tooltip: ({
+      content,
+      children,
+    }: {
+      readonly content: string;
+      readonly children: ReactElement;
+    }) => <span data-tooltip={content}>{children}</span>,
+  };
+});
+
+import { ProjectChip } from './index';
+
+afterEach(cleanup);
+
+describe('ProjectChip', () => {
+  it('renders nothing without a mounted project', () => {
+    const { container } = render(<ProjectChip projectNames={[]} />);
+    expect(container.childElementCount).toBe(0);
+  });
+
+  it('renders one compact named chip', () => {
+    render(<ProjectChip projectNames={['goodboy-desktop']} />);
+    expect(screen.getByLabelText('Project: goodboy-desktop')).toBeDefined();
+    expect(screen.getByText('goodboy-desktop').className).toContain('max-w-[12ch]');
+  });
+
+  it('renders one aggregate chip with all names in its tooltip', () => {
+    render(<ProjectChip projectNames={['desktop', 'ui', 'types']} />);
+    const chip = screen.getByText('3 projects');
+    expect(chip.closest('[data-tooltip]')?.getAttribute('data-tooltip')).toBe('desktop, ui, types');
+  });
+});

--- a/apps/desktop/src/features/workspace/components/ProjectChip/index.tsx
+++ b/apps/desktop/src/features/workspace/components/ProjectChip/index.tsx
@@ -1,0 +1,36 @@
+import { Chip, Tooltip } from '@goodboy/ui';
+
+type Props = {
+  readonly projectNames: ReadonlyArray<string>;
+};
+
+export const ProjectChip = ({ projectNames }: Props) => {
+  if (projectNames.length === 0) {
+    return null;
+  }
+  if (projectNames.length === 1) {
+    return (
+      <Chip
+        tone="neutral"
+        size="3xs"
+        bordered={false}
+        label={<span className="max-w-[12ch] truncate">{projectNames[0]}</span>}
+        ariaLabel={`Project: ${projectNames[0]}`}
+        className="max-w-[14ch] shrink-0"
+      />
+    );
+  }
+  const label = `${projectNames.length} projects`;
+  return (
+    <Tooltip content={projectNames.join(', ')} side="top">
+      <Chip
+        tone="neutral"
+        size="3xs"
+        bordered={false}
+        label={label}
+        ariaLabel={`${label}: ${projectNames.join(', ')}`}
+        className="shrink-0"
+      />
+    </Tooltip>
+  );
+};

--- a/apps/desktop/src/features/workspace/components/ProjectFilter/ProjectFilterOption.tsx
+++ b/apps/desktop/src/features/workspace/components/ProjectFilter/ProjectFilterOption.tsx
@@ -1,0 +1,23 @@
+import { Checkbox } from '@goodboy/ui';
+
+type Props = {
+  readonly label: string;
+  readonly count: number;
+  readonly checked: boolean;
+  readonly onChange: (checked: boolean) => void;
+};
+
+export const ProjectFilterOption = ({ label, count, checked, onChange }: Props) => (
+  <Checkbox
+    checked={checked}
+    onChange={onChange}
+    ariaLabel={`Filter by ${label}`}
+    className="w-full rounded px-2 py-1.5 hover:bg-foreground/5"
+    label={
+      <span className="flex min-w-0 flex-1 items-center justify-between gap-3">
+        <span className="truncate font-medium">{label}</span>
+        <span className="shrink-0 tabular-nums text-muted-foreground/60">{count}</span>
+      </span>
+    }
+  />
+);

--- a/apps/desktop/src/features/workspace/components/ProjectFilter/index.tsx
+++ b/apps/desktop/src/features/workspace/components/ProjectFilter/index.tsx
@@ -1,0 +1,163 @@
+import { useEffect, useMemo, useRef } from 'react';
+import { Filter, X } from 'lucide-react';
+import { AnchoredPopover, cn, Divider, Eyebrow, Tooltip, useDropdown } from '@goodboy/ui';
+import type { Session, WorkspaceId } from '@goodboy/types';
+import {
+  EMPTY_ARRAY,
+  NO_PROJECT_FILTER_ID,
+  useAppStore,
+  useSelectedProjectIds,
+} from '../../../../store';
+import { ProjectFilterOption } from './ProjectFilterOption';
+
+type Props = {
+  readonly workspaceId: WorkspaceId;
+  readonly sessions: ReadonlyArray<Session>;
+};
+
+type FilterOption = {
+  readonly id: string;
+  readonly label: string;
+  readonly count: number;
+};
+
+type UpdateOptionParams = {
+  readonly id: string;
+  readonly checked: boolean;
+};
+
+const MENU_WIDTH = 240;
+
+export const ProjectFilter = ({ workspaceId, sessions }: Props) => {
+  const selectedProjectIds = useSelectedProjectIds({ workspaceId });
+  const setSelectedProjectIds = useAppStore((state) => state.setSelectedProjectIds);
+  const projects = useAppStore((state) => state.projects);
+  const sessionProjectMounts = useAppStore((state) => state.sessionProjectMounts);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const dropdown = useDropdown({
+    align: 'end',
+    width: 'w-[240px]',
+    expectedWidth: MENU_WIDTH,
+    expectedHeight: 300,
+    isEscapeEnabled: false,
+  });
+  const { close, open, toggle } = dropdown;
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') {
+        return;
+      }
+      event.preventDefault();
+      close();
+      triggerRef.current?.focus();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [close, open]);
+
+  const options = useMemo(() => {
+    const counts = new Map<string, number>();
+    let noProjectCount = 0;
+    for (const session of sessions) {
+      const mounts = sessionProjectMounts[session.id] ?? EMPTY_ARRAY;
+      if (mounts.length === 0) {
+        noProjectCount += 1;
+        continue;
+      }
+      for (const projectId of new Set(mounts.map((mount) => mount.projectId))) {
+        counts.set(projectId, (counts.get(projectId) ?? 0) + 1);
+      }
+    }
+    const projectOptions: ReadonlyArray<FilterOption> = projects
+      .filter((project) => project.workspaceId === workspaceId && counts.has(project.id))
+      .map((project) => ({
+        id: project.id,
+        label: project.name,
+        count: counts.get(project.id) ?? 0,
+      }))
+      .sort((left, right) => left.label.localeCompare(right.label));
+    if (noProjectCount === 0) {
+      return projectOptions;
+    }
+    return [
+      ...projectOptions,
+      { id: NO_PROJECT_FILTER_ID, label: 'No project', count: noProjectCount },
+    ];
+  }, [projects, sessionProjectMounts, sessions, workspaceId]);
+
+  const updateOption = ({ id, checked }: UpdateOptionParams) => {
+    const next = checked
+      ? [...selectedProjectIds, id]
+      : selectedProjectIds.filter((selectedId) => selectedId !== id);
+    setSelectedProjectIds({ workspaceId, selectedProjectIds: next });
+  };
+
+  const activeCount = selectedProjectIds.length;
+
+  return (
+    <AnchoredPopover
+      dropdown={dropdown}
+      role="dialog"
+      ariaLabel="Filter sessions by project"
+      className="py-1"
+      hasBackdrop
+      trigger={
+        <Tooltip content="Filter by project" side="bottom">
+          <button
+            ref={triggerRef}
+            type="button"
+            onClick={toggle}
+            aria-haspopup="dialog"
+            aria-expanded={open}
+            aria-label={
+              activeCount > 0 ? `Project filter, ${activeCount} active` : 'Project filter'
+            }
+            className={cn(
+              'inline-flex shrink-0 items-center gap-1 rounded px-1 py-0.5 text-2xs font-medium motion-safe:transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/40',
+              activeCount > 0 || open
+                ? 'bg-primary/10 text-primary'
+                : 'text-muted-foreground/70 hover:bg-foreground/10 hover:text-foreground',
+            )}
+          >
+            <Filter size={11} aria-hidden />
+            {activeCount > 0 ? <span className="tabular-nums">{activeCount}</span> : null}
+          </button>
+        </Tooltip>
+      }
+    >
+      <div className="flex items-center justify-between gap-2 px-3 py-2">
+        <Eyebrow label="Projects" muted />
+        {activeCount > 0 ? (
+          <button
+            type="button"
+            onClick={() => setSelectedProjectIds({ workspaceId, selectedProjectIds: [] })}
+            className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-2xs font-medium text-muted-foreground hover:bg-foreground/5 hover:text-foreground"
+          >
+            <X size={10} aria-hidden />
+            Clear
+          </button>
+        ) : null}
+      </div>
+      <Divider />
+      <div className="flex max-h-64 flex-col overflow-y-auto p-1">
+        {options.length === 0 ? (
+          <span className="px-2 py-3 text-xs text-muted-foreground">No mounted projects</span>
+        ) : (
+          options.map((option) => (
+            <ProjectFilterOption
+              key={option.id}
+              label={option.label}
+              count={option.count}
+              checked={selectedProjectIds.includes(option.id)}
+              onChange={(checked) => updateOption({ id: option.id, checked })}
+            />
+          ))
+        )}
+      </div>
+    </AnchoredPopover>
+  );
+};

--- a/apps/desktop/src/features/workspace/components/ProjectFilter/index.tsx
+++ b/apps/desktop/src/features/workspace/components/ProjectFilter/index.tsx
@@ -26,7 +26,10 @@ type UpdateOptionParams = {
   readonly checked: boolean;
 };
 
-const MENU_WIDTH = 240;
+const MENU_WIDTH = {
+  className: 'w-[240px]',
+  expected: 240,
+};
 
 export const ProjectFilter = ({ workspaceId, sessions }: Props) => {
   const selectedProjectIds = useSelectedProjectIds({ workspaceId });
@@ -36,8 +39,8 @@ export const ProjectFilter = ({ workspaceId, sessions }: Props) => {
   const triggerRef = useRef<HTMLButtonElement>(null);
   const dropdown = useDropdown({
     align: 'end',
-    width: 'w-[240px]',
-    expectedWidth: MENU_WIDTH,
+    width: MENU_WIDTH.className,
+    expectedWidth: MENU_WIDTH.expected,
     expectedHeight: 300,
     isEscapeEnabled: false,
   });

--- a/apps/desktop/src/features/workspace/components/SessionActivityBar/index.test.tsx
+++ b/apps/desktop/src/features/workspace/components/SessionActivityBar/index.test.tsx
@@ -9,6 +9,8 @@ const { state } = vi.hoisted(() => ({
     sessionGithub: {} as Record<string, unknown>,
     sessionTelemetry: {} as Record<string, ReadonlyArray<unknown>>,
     sessionExternalTasks: {} as Record<string, unknown>,
+    sessionProjectMounts: {} as Record<string, ReadonlyArray<unknown>>,
+    projects: [] as ReadonlyArray<unknown>,
     bulkUnarchiveTask: vi.fn(async () => undefined),
     bulkArchiveTask: vi.fn(async () => undefined),
     bulkDeleteTask: vi.fn(async () => undefined),
@@ -29,6 +31,10 @@ vi.mock('../../../../store', () => ({
 
 vi.mock('./SessionViewMenu', () => ({
   SessionViewMenu: () => null,
+}));
+
+vi.mock('../ProjectFilter', () => ({
+  ProjectFilter: () => <span data-testid="project-filter" />,
 }));
 
 vi.mock('../../../../features/providers/components/CostBadge', () => ({
@@ -96,6 +102,8 @@ beforeEach(() => {
   state.bulkArchiveTask.mockClear();
   state.bulkDeleteTask.mockClear();
   state.sessionExternalTasks = {};
+  state.sessionProjectMounts = {};
+  state.projects = [];
 });
 
 afterEach(cleanup);
@@ -105,6 +113,7 @@ describe('SessionActivityBar, baseline', () => {
     renderBar([]);
     expect(screen.getByText(/^Sessions$/)).toBeDefined();
     expect(screen.getByRole('button', { name: /create new session/i })).toBeDefined();
+    expect(screen.getByTestId('project-filter')).toBeDefined();
   });
 
   it('renders empty-state copy when no sessions in active tab', () => {

--- a/apps/desktop/src/features/workspace/components/SessionActivityBar/index.test.tsx
+++ b/apps/desktop/src/features/workspace/components/SessionActivityBar/index.test.tsx
@@ -143,6 +143,19 @@ describe('SessionActivityBar, baseline', () => {
     fireEvent(window, new CustomEvent('goodboy:new-session'));
     expect(screen.getByRole('button', { name: /create new session/i })).toBeDefined();
   });
+
+  it('shows one project name when a session mounts the same project more than once', () => {
+    state.projects = [{ id: 'project-1', name: 'Goodboy' }];
+    state.sessionProjectMounts = {
+      'a-1': [
+        { projectId: 'project-1', mountName: 'desktop' },
+        { projectId: 'project-1', mountName: 'desktop-copy' },
+      ],
+    };
+    renderBar([], [makeSession('a-1', 'duplicate mounts')]);
+    expect(screen.getByLabelText('Project: Goodboy')).toBeDefined();
+    expect(screen.queryByLabelText(/2 projects/)).toBeNull();
+  });
 });
 
 describe('SessionActivityBar, bulk selection', () => {

--- a/apps/desktop/src/features/workspace/components/SessionActivityBar/index.tsx
+++ b/apps/desktop/src/features/workspace/components/SessionActivityBar/index.tsx
@@ -42,6 +42,8 @@ import { BulkActionBar } from '../BulkActionBar';
 import { useSidebarPeekHold } from '../SidebarPeekOverlay/hold';
 import { SessionViewMenu } from './SessionViewMenu';
 import { shortcutGlyphs } from '../../../../shared/keyboard/registry';
+import { ProjectChip } from '../ProjectChip';
+import { ProjectFilter } from '../ProjectFilter';
 
 type ActivityTab = 'active' | 'archived';
 
@@ -97,6 +99,23 @@ export const SessionActivityBar = ({
   );
 
   const prefs = useSessionViewPrefs(workspaceId);
+  const projects = useAppStore((state) => state.projects);
+  const sessionProjectMounts = useAppStore((state) => state.sessionProjectMounts);
+  const projectNamesBySession = useMemo(() => {
+    const projectNames = new Map(projects.map((project) => [project.id, project.name]));
+    const namesBySession = new Map<string, ReadonlyArray<string>>();
+    for (const session of [...sessions, ...archivedSessions]) {
+      const names = (sessionProjectMounts[session.id] ?? EMPTY_ARRAY).map(
+        (mount) => projectNames.get(mount.projectId) ?? mount.mountName,
+      );
+      namesBySession.set(session.id, names);
+    }
+    return namesBySession;
+  }, [archivedSessions, projects, sessionProjectMounts, sessions]);
+  const filterSessions = useMemo(
+    () => [...sessions, ...archivedSessions],
+    [archivedSessions, sessions],
+  );
 
   const groupedActive = useSortedGroupedSessions(workspaceId, sessions);
   const groupedArchived = useSortedGroupedSessions(workspaceId, archivedSessions);
@@ -171,6 +190,7 @@ export const SessionActivityBar = ({
           <div className="mb-1 flex items-center justify-between gap-1 px-0.5">
             <Eyebrow label="Sessions" />
             <div className="flex items-center gap-0.5">
+              <ProjectFilter workspaceId={workspaceId} sessions={filterSessions} />
               <button
                 type="button"
                 onClick={() => {
@@ -257,6 +277,7 @@ export const SessionActivityBar = ({
                     <SessionActivityItem
                       key={session.id}
                       session={session}
+                      projectNames={projectNamesBySession.get(session.id) ?? EMPTY_ARRAY}
                       isActive={session.id === currentSessionId}
                       dimmed={isArchivedView}
                       selected={isSelected(session.id as SessionId)}
@@ -316,6 +337,7 @@ type SelectionClickEvent = {
 
 type SessionActivityItemProps = {
   session: Session;
+  projectNames: ReadonlyArray<string>;
   isActive: boolean;
   dimmed?: boolean;
   selected?: boolean;
@@ -325,6 +347,7 @@ type SessionActivityItemProps = {
 
 const SessionActivityItem = memo(function SessionActivityItem({
   session,
+  projectNames,
   isActive,
   dimmed,
   selected,
@@ -381,6 +404,7 @@ const SessionActivityItem = memo(function SessionActivityItem({
           <span className="line-clamp-2 min-w-0 flex-1 text-sm font-medium leading-snug">
             {session.goal}
           </span>
+          <ProjectChip projectNames={projectNames} />
           {externalTasks.map((task) => (
             <ExternalTaskChip
               key={`${task.provider}:${task.externalId}`}

--- a/apps/desktop/src/features/workspace/components/SessionActivityBar/index.tsx
+++ b/apps/desktop/src/features/workspace/components/SessionActivityBar/index.tsx
@@ -105,8 +105,13 @@ export const SessionActivityBar = ({
     const projectNames = new Map(projects.map((project) => [project.id, project.name]));
     const namesBySession = new Map<string, ReadonlyArray<string>>();
     for (const session of [...sessions, ...archivedSessions]) {
-      const names = (sessionProjectMounts[session.id] ?? EMPTY_ARRAY).map(
-        (mount) => projectNames.get(mount.projectId) ?? mount.mountName,
+      const names = Array.from(
+        new Map(
+          (sessionProjectMounts[session.id] ?? EMPTY_ARRAY).map((mount) => [
+            mount.projectId,
+            projectNames.get(mount.projectId) ?? mount.mountName,
+          ]),
+        ).values(),
       );
       namesBySession.set(session.id, names);
     }

--- a/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.test.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.test.tsx
@@ -27,6 +27,8 @@ const { state, hooks, useDynamicActionsMock } = vi.hoisted(() => ({
     sessionGitlabMr: {} as Record<string, { mr: GitlabMergeRequest | null }>,
     sessionExternalTasks: {} as Record<string, ReadonlyArray<SessionExternalTask>>,
     sessionWorktrees: {} as Record<string, ReadonlyArray<string>>,
+    sessionProjectMounts: {} as Record<string, ReadonlyArray<unknown>>,
+    projects: [] as ReadonlyArray<unknown>,
     sessionPhaseRuns: {} as Record<string, ReadonlyArray<unknown>>,
     reviewDrafts: {} as Record<string, ReadonlyArray<unknown>>,
     loadReviewDrafts: vi.fn(async () => undefined),
@@ -119,6 +121,8 @@ beforeEach(() => {
   state.sessionGitlabMr = {};
   state.sessionExternalTasks = {};
   state.sessionWorktrees = {};
+  state.sessionProjectMounts = {};
+  state.projects = [];
   state.sessionPhaseRuns = {};
   state.reviewDrafts = {};
   state.loadReviewDrafts.mockClear();

--- a/apps/desktop/src/features/workspace/components/StageBoard/index.test.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/index.test.tsx
@@ -26,6 +26,7 @@ vi.mock('../../../../store', () => ({
   EMPTY_ARRAY: [],
   useAppStore: (selector: (s: typeof state) => unknown) => selector(state),
   useStageGroupedSessions: () => groups.current,
+  useProjectFilteredSessions: ({ sessions }: { sessions: ReadonlyArray<Session> }) => sessions,
 }));
 
 vi.mock('../../hooks/useWorkspaceGitStatus', () => ({
@@ -42,6 +43,10 @@ vi.mock('../WorkspaceGitPanel', () => ({
   WorkspaceGitPanel: ({ status }: { status: WorkspaceGitStatus }) => (
     <div data-testid="git-panel">{status.state}</div>
   ),
+}));
+
+vi.mock('../ProjectFilter', () => ({
+  ProjectFilter: () => <span data-testid="project-filter" />,
 }));
 
 vi.mock('./useBoardNavigation', () => ({
@@ -150,6 +155,7 @@ describe('StageBoard loading gate', () => {
     expect(screen.queryByLabelText('Loading board')).toBeNull();
     expect(screen.getAllByTestId('stage-column').length).toBeGreaterThan(0);
     expect(screen.getByText('Stage board')).toBeDefined();
+    expect(screen.getByTestId('project-filter')).toBeDefined();
     expect(screen.getAllByRole('button', { name: 'New session' })).toHaveLength(1);
   });
 

--- a/apps/desktop/src/features/workspace/components/StageBoard/index.test.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/index.test.tsx
@@ -281,12 +281,20 @@ describe('StageBoard selection', () => {
   const shelved = { id: 's-9' } as Session;
 
   it('offers the alt-click hint only once the board holds more than one session', () => {
+    groups.current = [{ key: 'building', sessions: [session] }];
     render(<StageBoard workspaceId={wsId} sessions={[session]} />);
     expect(screen.queryByText(/lasso/)).toBeNull();
 
     cleanup();
+    groups.current = [{ key: 'building', sessions: [session, other] }];
     render(<StageBoard workspaceId={wsId} sessions={[session, other]} />);
     expect(screen.getByText('⌥click to select · drag to lasso')).toBeDefined();
+  });
+
+  it('hides the alt-click hint when the project filter leaves one visible session', () => {
+    groups.current = [{ key: 'building', sessions: [session] }];
+    render(<StageBoard workspaceId={wsId} sessions={[session, other]} />);
+    expect(screen.queryByText(/lasso/)).toBeNull();
   });
 
   it('raises a single bulk bar for the whole board, not one per column', () => {

--- a/apps/desktop/src/features/workspace/components/StageBoard/index.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/index.tsx
@@ -2,7 +2,12 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Plus } from 'lucide-react';
 import { Button, cn, Divider, EmptyState, Eyebrow, Skeleton } from '@goodboy/ui';
 import type { Session, SessionId, SessionStage, WorkspaceId } from '@goodboy/types';
-import { EMPTY_ARRAY, useAppStore, useStageGroupedSessions } from '../../../../store';
+import {
+  EMPTY_ARRAY,
+  useAppStore,
+  useProjectFilteredSessions,
+  useStageGroupedSessions,
+} from '../../../../store';
 import { STAGE_ORDER } from '../../../../store/slices/session-view/types';
 import { DogMascot } from '../../../../shared/components/DogMascot';
 import { PANE_RHYTHM } from '@goodboy/ui';
@@ -17,6 +22,7 @@ import { ProjectsStep } from '../../../onboarding/OnboardingWizard/steps/Project
 import { StageColumn } from './StageColumn';
 import { useBoardNavigation } from './useBoardNavigation';
 import { useBoardSelection } from './useBoardSelection';
+import { ProjectFilter } from '../ProjectFilter';
 
 type Confirm = { readonly kind: 'archive' | 'delete'; readonly session: Session };
 
@@ -67,6 +73,8 @@ export const StageBoard = ({ workspaceId, sessions }: Props) => {
   const nav = useBoardNavigation();
   const archivedList = useAppStore((s) => s.archivedSessions[workspaceId]);
   const archived = archivedList ?? EMPTY_ARRAY;
+  const filteredArchived = useProjectFilteredSessions({ workspaceId, sessions: archived });
+  const filterSessions = useMemo(() => [...sessions, ...archived], [archived, sessions]);
   const boardReady = useAppStore((s) => s.boardReady);
   const loadArchivedSessions = useAppStore((s) => s.loadArchivedSessions);
   const rootPath = useAppStore((s) => primaryProjectRoot({ projects: s.projects, workspaceId }));
@@ -98,11 +106,11 @@ export const StageBoard = ({ workspaceId, sessions }: Props) => {
     () => STAGES.flatMap((stage) => [...(byStage.get(stage) ?? EMPTY_ARRAY)]),
     [byStage],
   );
-  const selection = useBoardSelection({ activeSessions, archivedSessions: archived });
+  const selection = useBoardSelection({ activeSessions, archivedSessions: filteredArchived });
   const columnsRef = useRef<HTMLDivElement | null>(null);
   const onLassoSelect = useCallback(
     (ids: ReadonlyArray<SessionId>, mode: 'replace' | 'add') => {
-      const archivedIds = new Set(archived.map((session) => session.id as SessionId));
+      const archivedIds = new Set(filteredArchived.map((session) => session.id as SessionId));
       const inArchived = ids.filter((id) => archivedIds.has(id));
       const inActive = ids.filter((id) => !archivedIds.has(id));
       if (inArchived.length > inActive.length) {
@@ -111,7 +119,7 @@ export const StageBoard = ({ workspaceId, sessions }: Props) => {
       }
       selection.active.selectIds(inActive, mode);
     },
-    [archived, selection],
+    [filteredArchived, selection],
   );
   const lasso = useDragLasso<SessionId>({ containerRef: columnsRef, onSelect: onLassoSelect });
 
@@ -142,7 +150,7 @@ export const StageBoard = ({ workspaceId, sessions }: Props) => {
             <span className="flex items-baseline gap-2">
               <Eyebrow label="Stage board" />
               <span className="text-2xs tabular-nums text-muted-foreground/60">
-                {sessions.length}
+                {activeSessions.length}
               </span>
               {sessions.length > 1 && (
                 <span className="hidden text-3xs text-muted-foreground/50 sm:inline">
@@ -151,6 +159,7 @@ export const StageBoard = ({ workspaceId, sessions }: Props) => {
               )}
             </span>
             <span className="flex items-center gap-1.5">
+              <ProjectFilter workspaceId={workspaceId} sessions={filterSessions} />
               <button
                 type="button"
                 onClick={() =>
@@ -239,7 +248,7 @@ export const StageBoard = ({ workspaceId, sessions }: Props) => {
             <StageColumn
               key="archived"
               spec={{ kind: 'archived' }}
-              sessions={archived}
+              sessions={filteredArchived}
               nav={nav}
               selection={selection.archived}
               onArchive={onArchive}

--- a/apps/desktop/src/features/workspace/components/StageBoard/index.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/index.tsx
@@ -152,7 +152,7 @@ export const StageBoard = ({ workspaceId, sessions }: Props) => {
               <span className="text-2xs tabular-nums text-muted-foreground/60">
                 {activeSessions.length}
               </span>
-              {sessions.length > 1 && (
+              {activeSessions.length > 1 && (
                 <span className="hidden text-3xs text-muted-foreground/50 sm:inline">
                   ⌥click to select · drag to lasso
                 </span>

--- a/apps/desktop/src/shared/lib/storage-keys.ts
+++ b/apps/desktop/src/shared/lib/storage-keys.ts
@@ -17,6 +17,7 @@ export const STORAGE_PREFIXES = {
   workSurfaceView: `${PREFIX}work-surface-view:`,
   diffReviewed: `${PREFIX}diff-reviewed:`,
   sessionView: `${PREFIX}session-view:`,
+  sessionFilters: `${PREFIX}session-filters:`,
   cursorMaxMode: `${PREFIX}cursor-max-mode:`,
 } as const;
 

--- a/apps/desktop/src/store/index.ts
+++ b/apps/desktop/src/store/index.ts
@@ -24,6 +24,8 @@ export {
   useSessionSlotsLoad,
   useSessionStageInfo,
   useSessionViewPrefs,
+  useSelectedProjectIds,
+  useProjectFilteredSessions,
   useSlotHistory,
   useSlotHistoryCount,
   useSessions,
@@ -41,5 +43,6 @@ export {
 export { useTranscript } from './transcript';
 export { readPersistedLens } from './slices/session-view';
 export type { SessionStudio, LensKind, DiffFocus } from './slices/session-view';
+export { NO_PROJECT_FILTER_ID, sessionMatchesProjectFilter } from './slices/sessionFilters';
 
 export const EMPTY_ARRAY: readonly never[] = [];

--- a/apps/desktop/src/store/selectors.test.ts
+++ b/apps/desktop/src/store/selectors.test.ts
@@ -138,6 +138,8 @@ beforeEach(() => {
     sessionOpenQuestions: {},
     sessionViewPrefs: {},
     getSessionViewPrefs: vi.fn(),
+    selectedProjectIds: {},
+    getSelectedProjectIds: vi.fn(),
     sessions: [],
     workspaces: [],
     projects: [],
@@ -576,5 +578,38 @@ describe('useMountDiffStats', () => {
 
     expect(result.current.size).toBe(0);
     expect(changedFiles).not.toHaveBeenCalled();
+  });
+});
+
+describe('shared project filtering', () => {
+  it('feeds the same project selection into sidebar and board grouping', () => {
+    const mounted = createSession(SESSION_ID);
+    const unmounted = createSession('session-2' as SessionId);
+    setProjectScope();
+    store.state.selectedProjectIds = { [WORKSPACE_ID]: [PROJECT_ID] };
+    store.state.sessionProjectMounts = {
+      [SESSION_ID]: [
+        {
+          projectId: PROJECT_ID,
+          mountName: 'project',
+          repoRoot: '/tmp/ws',
+          worktreePath: '/tmp/ws-worktree',
+          branch: 'ak/feat-thing',
+        },
+      ],
+      [unmounted.id]: [],
+    };
+    const { result } = renderHook(() => ({
+      sidebar: useSortedGroupedSessions(WORKSPACE_ID, [mounted, unmounted]),
+      board: useStageGroupedSessions(WORKSPACE_ID, [mounted, unmounted]),
+    }));
+    const sidebarIds = result.current.sidebar.flatMap((group) =>
+      group.sessions.map((session) => session.id),
+    );
+    const boardIds = result.current.board.flatMap((group) =>
+      group.sessions.map((session) => session.id),
+    );
+    expect(sidebarIds).toEqual([SESSION_ID]);
+    expect(boardIds).toEqual([SESSION_ID]);
   });
 });

--- a/apps/desktop/src/store/selectors.ts
+++ b/apps/desktop/src/store/selectors.ts
@@ -13,6 +13,7 @@ import type {
   Session,
   SessionId,
   SessionPrFetchState,
+  SessionProjectMount,
   SessionStage,
   SessionStageInfo,
   SessionViewPrefs,
@@ -23,6 +24,7 @@ import type {
 import type { Workspace } from '@goodboy/types';
 import { isBranchlessSession } from '../shared/utils/isBranchlessSession';
 import { useAppStore } from './store';
+import { sessionMatchesProjectFilter } from './slices/sessionFilters';
 import type {
   AppState,
   SessionLoadingFlags,
@@ -50,6 +52,8 @@ export { agentHasUnread } from './slices/agents/agentHasUnread';
 const DEFAULT_SESSION_VIEW_PREFS: SessionViewPrefs = { sort: 'updatedAt', group: 'stage' };
 const EMPTY_TELEMETRY: ReadonlyArray<TelemetryRecord> = [];
 const EMPTY_AGENTS: ReadonlyArray<Agent> = [];
+const EMPTY_PROJECT_FILTER_IDS: ReadonlyArray<string> = [];
+const EMPTY_PROJECT_MOUNTS: ReadonlyArray<SessionProjectMount> = [];
 
 export const sumSessionCost = (records: readonly TelemetryRecord[]): number => {
   let sum = 0;
@@ -110,6 +114,50 @@ export const useSessionViewPrefs = (workspaceId: WorkspaceId | null): SessionVie
   }, [workspaceId, prefs, getSessionViewPrefs]);
 
   return prefs ?? DEFAULT_SESSION_VIEW_PREFS;
+};
+
+type UseSelectedProjectIdsParams = {
+  readonly workspaceId: WorkspaceId | null;
+};
+
+export const useSelectedProjectIds = ({
+  workspaceId,
+}: UseSelectedProjectIdsParams): ReadonlyArray<string> => {
+  const selectedProjectIds = useAppStore((state) =>
+    workspaceId !== null ? (state.selectedProjectIds[workspaceId] ?? null) : null,
+  );
+  const getSelectedProjectIds = useAppStore((state) => state.getSelectedProjectIds);
+
+  useEffect(() => {
+    if (workspaceId === null || selectedProjectIds !== null) {
+      return;
+    }
+    getSelectedProjectIds({ workspaceId });
+  }, [getSelectedProjectIds, selectedProjectIds, workspaceId]);
+
+  return selectedProjectIds ?? EMPTY_PROJECT_FILTER_IDS;
+};
+
+type UseProjectFilteredSessionsParams = UseSelectedProjectIdsParams & {
+  readonly sessions: ReadonlyArray<Session>;
+};
+
+export const useProjectFilteredSessions = ({
+  workspaceId,
+  sessions,
+}: UseProjectFilteredSessionsParams): ReadonlyArray<Session> => {
+  const selectedProjectIds = useSelectedProjectIds({ workspaceId });
+  const sessionProjectMounts = useAppStore((state) => state.sessionProjectMounts);
+  return useMemo(
+    () =>
+      sessions.filter((session) =>
+        sessionMatchesProjectFilter({
+          mounts: sessionProjectMounts[session.id] ?? EMPTY_PROJECT_MOUNTS,
+          selectedProjectIds,
+        }),
+      ),
+    [selectedProjectIds, sessionProjectMounts, sessions],
+  );
 };
 
 const EMPTY_GITHUB_STATE: Readonly<Record<string, never>> = Object.freeze({});
@@ -203,6 +251,7 @@ export const useSortedGroupedSessions = (
   workspaceId: WorkspaceId | null,
   sessions: ReadonlyArray<Session>,
 ): ReadonlyArray<GroupedSessions> => {
+  const filteredSessions = useProjectFilteredSessions({ workspaceId, sessions });
   const prefs = useSessionViewPrefs(workspaceId);
   const needsGithub = prefs.group === 'pr' || prefs.group === 'stage';
   const needsStage = prefs.group === 'stage';
@@ -239,7 +288,7 @@ export const useSortedGroupedSessions = (
   );
   return useMemo(() => {
     const partial: StageInfoState = {
-      sessions,
+      sessions: filteredSessions,
       workspaces,
       projects,
       sessionBranches,
@@ -256,13 +305,13 @@ export const useSortedGroupedSessions = (
     };
     const stages: Record<SessionId, SessionStage> = {};
     if (needsStage) {
-      for (const session of sessions) {
+      for (const session of filteredSessions) {
         stages[session.id as SessionId] = stageInfoOf(partial, session).stage;
       }
     }
-    return sortAndGroupSessions(sessions, prefs, sessionGithub, stages);
+    return sortAndGroupSessions(filteredSessions, prefs, sessionGithub, stages);
   }, [
-    sessions,
+    filteredSessions,
     prefs,
     needsStage,
     workspaces,
@@ -313,6 +362,7 @@ export const useStageGroupedSessions = (
   workspaceId: WorkspaceId | null,
   sessions: ReadonlyArray<Session>,
 ): ReadonlyArray<GroupedSessions> => {
+  const filteredSessions = useProjectFilteredSessions({ workspaceId, sessions });
   const prefs = useSessionViewPrefs(workspaceId);
   const sessionGithub = useAppStore((s) => s.sessionGithub);
   const sessionGitlabMr = useAppStore((s) => s.sessionGitlabMr);
@@ -330,7 +380,7 @@ export const useStageGroupedSessions = (
   const previousRef = useRef<ReadonlyArray<GroupedSessions> | null>(null);
   const grouped = useMemo(() => {
     const partial: StageInfoState = {
-      sessions,
+      sessions: filteredSessions,
       workspaces,
       projects,
       sessionBranches,
@@ -346,17 +396,17 @@ export const useStageGroupedSessions = (
       githubStatus,
     };
     const stages: Record<SessionId, SessionStage> = {};
-    for (const session of sessions) {
+    for (const session of filteredSessions) {
       stages[session.id as SessionId] = stageInfoOf(partial, session).stage;
     }
     return sortAndGroupSessions(
-      sessions,
+      filteredSessions,
       { sort: prefs.sort, group: 'stage' },
       sessionGithub,
       stages,
     );
   }, [
-    sessions,
+    filteredSessions,
     prefs.sort,
     workspaces,
     projects,

--- a/apps/desktop/src/store/slices/sessionFilters/getSelectedProjectIds.ts
+++ b/apps/desktop/src/store/slices/sessionFilters/getSelectedProjectIds.ts
@@ -1,0 +1,22 @@
+import type { GetSelectedProjectIdsParams } from './types';
+import type { GetFn, SetFn } from '../../slice-types';
+import { readFromStorage } from './storage';
+
+type Params = {
+  readonly set: SetFn;
+  readonly get: GetFn;
+};
+
+export const getSelectedProjectIds =
+  ({ set, get }: Params) =>
+  ({ workspaceId }: GetSelectedProjectIdsParams): ReadonlyArray<string> => {
+    const cached = get().selectedProjectIds[workspaceId];
+    if (cached !== undefined) {
+      return cached;
+    }
+    const selectedProjectIds = readFromStorage({ workspaceId });
+    set((state) => ({
+      selectedProjectIds: { ...state.selectedProjectIds, [workspaceId]: selectedProjectIds },
+    }));
+    return selectedProjectIds;
+  };

--- a/apps/desktop/src/store/slices/sessionFilters/index.test.ts
+++ b/apps/desktop/src/store/slices/sessionFilters/index.test.ts
@@ -1,0 +1,54 @@
+// @vitest-environment happy-dom
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { SessionProjectMount, WorkspaceId } from '@goodboy/types';
+import { STORAGE_PREFIXES } from '../../../shared/lib/storage-keys';
+import { useAppStore } from '../../store';
+import { NO_PROJECT_FILTER_ID, sessionMatchesProjectFilter } from './index';
+
+const WORKSPACE_ID = 'workspace-filter-test' as WorkspaceId;
+
+const mount = {
+  projectId: 'project-a',
+  mountName: 'project-a',
+  worktreePath: '/tmp/project-a',
+  repoRoot: '/tmp/project-a',
+  branch: 'main',
+} as SessionProjectMount;
+
+beforeEach(() => {
+  localStorage.clear();
+  useAppStore.setState({ selectedProjectIds: {} });
+});
+
+describe('sessionFilters slice', () => {
+  it('persists selection per workspace and restores it into the slice', () => {
+    useAppStore.getState().setSelectedProjectIds({
+      workspaceId: WORKSPACE_ID,
+      selectedProjectIds: ['project-a', NO_PROJECT_FILTER_ID],
+    });
+    useAppStore.setState({ selectedProjectIds: {} });
+    const restored = useAppStore.getState().getSelectedProjectIds({ workspaceId: WORKSPACE_ID });
+    expect(restored).toEqual(['project-a', NO_PROJECT_FILTER_ID]);
+    expect(useAppStore.getState().selectedProjectIds[WORKSPACE_ID]).toEqual(restored);
+    expect(
+      localStorage.getItem(`${STORAGE_PREFIXES.sessionFilters}${WORKSPACE_ID}`),
+    ).not.toBeNull();
+  });
+
+  it('shows all sessions for an empty selection', () => {
+    expect(sessionMatchesProjectFilter({ mounts: [mount], selectedProjectIds: [] })).toBe(true);
+  });
+
+  it('matches any mounted selection and the explicit no-project selection', () => {
+    expect(
+      sessionMatchesProjectFilter({ mounts: [mount], selectedProjectIds: ['project-a'] }),
+    ).toBe(true);
+    expect(
+      sessionMatchesProjectFilter({ mounts: [mount], selectedProjectIds: ['project-b'] }),
+    ).toBe(false);
+    expect(
+      sessionMatchesProjectFilter({ mounts: [], selectedProjectIds: [NO_PROJECT_FILTER_ID] }),
+    ).toBe(true);
+  });
+});

--- a/apps/desktop/src/store/slices/sessionFilters/index.ts
+++ b/apps/desktop/src/store/slices/sessionFilters/index.ts
@@ -1,0 +1,18 @@
+import { getSelectedProjectIds } from './getSelectedProjectIds';
+import { setSelectedProjectIds } from './setSelectedProjectIds';
+import type { GetFn, SetFn, SessionFiltersSlice } from './types';
+
+export { NO_PROJECT_FILTER_ID } from './types';
+export { sessionMatchesProjectFilter } from './sessionMatchesProjectFilter';
+export type { SessionFiltersSlice } from './types';
+
+type Params = {
+  readonly set: SetFn;
+  readonly get: GetFn;
+};
+
+export const createSessionFiltersSlice = ({ set, get }: Params): SessionFiltersSlice => ({
+  selectedProjectIds: {},
+  getSelectedProjectIds: getSelectedProjectIds({ set, get }),
+  setSelectedProjectIds: setSelectedProjectIds({ set }),
+});

--- a/apps/desktop/src/store/slices/sessionFilters/sessionMatchesProjectFilter.ts
+++ b/apps/desktop/src/store/slices/sessionFilters/sessionMatchesProjectFilter.ts
@@ -1,0 +1,17 @@
+import type { SessionProjectMount } from '@goodboy/types';
+import { NO_PROJECT_FILTER_ID } from './types';
+
+type Params = {
+  readonly mounts: ReadonlyArray<SessionProjectMount>;
+  readonly selectedProjectIds: ReadonlyArray<string>;
+};
+
+export const sessionMatchesProjectFilter = ({ mounts, selectedProjectIds }: Params): boolean => {
+  if (selectedProjectIds.length === 0) {
+    return true;
+  }
+  if (mounts.length === 0) {
+    return selectedProjectIds.includes(NO_PROJECT_FILTER_ID);
+  }
+  return mounts.some((mount) => selectedProjectIds.includes(mount.projectId));
+};

--- a/apps/desktop/src/store/slices/sessionFilters/setSelectedProjectIds.ts
+++ b/apps/desktop/src/store/slices/sessionFilters/setSelectedProjectIds.ts
@@ -1,0 +1,17 @@
+import type { SetSelectedProjectIdsParams } from './types';
+import type { SetFn } from '../../slice-types';
+import { writeToStorage } from './storage';
+
+type Params = {
+  readonly set: SetFn;
+};
+
+export const setSelectedProjectIds =
+  ({ set }: Params) =>
+  ({ workspaceId, selectedProjectIds }: SetSelectedProjectIdsParams): void => {
+    const uniqueIds = [...new Set(selectedProjectIds)];
+    writeToStorage({ workspaceId, selectedProjectIds: uniqueIds });
+    set((state) => ({
+      selectedProjectIds: { ...state.selectedProjectIds, [workspaceId]: uniqueIds },
+    }));
+  };

--- a/apps/desktop/src/store/slices/sessionFilters/storage.ts
+++ b/apps/desktop/src/store/slices/sessionFilters/storage.ts
@@ -1,0 +1,49 @@
+import type { WorkspaceId } from '@goodboy/types';
+import { STORAGE_PREFIXES } from '../../../shared/lib/storage-keys';
+
+type PersistedFilters = {
+  readonly v: 1;
+  readonly selectedProjectIds: ReadonlyArray<string>;
+};
+
+type Params = {
+  readonly workspaceId: WorkspaceId;
+};
+
+type WriteParams = Params & {
+  readonly selectedProjectIds: ReadonlyArray<string>;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+const storageKey = ({ workspaceId }: Params): string =>
+  `${STORAGE_PREFIXES.sessionFilters}${workspaceId}`;
+
+export const readFromStorage = ({ workspaceId }: Params): ReadonlyArray<string> => {
+  try {
+    const raw = localStorage.getItem(storageKey({ workspaceId }));
+    if (raw === null) {
+      return [];
+    }
+    const parsed: unknown = JSON.parse(raw);
+    if (!isRecord(parsed)) {
+      return [];
+    }
+    if (parsed['v'] !== 1 || !Array.isArray(parsed['selectedProjectIds'])) {
+      return [];
+    }
+    return parsed['selectedProjectIds'].filter((id): id is string => typeof id === 'string');
+  } catch {
+    return [];
+  }
+};
+
+export const writeToStorage = ({ workspaceId, selectedProjectIds }: WriteParams): void => {
+  try {
+    const persisted: PersistedFilters = { v: 1, selectedProjectIds };
+    localStorage.setItem(storageKey({ workspaceId }), JSON.stringify(persisted));
+  } catch {
+    return;
+  }
+};

--- a/apps/desktop/src/store/slices/sessionFilters/types.ts
+++ b/apps/desktop/src/store/slices/sessionFilters/types.ts
@@ -1,0 +1,20 @@
+import type { WorkspaceId } from '@goodboy/types';
+
+export type { GetFn, SetFn } from '../../slice-types';
+
+export const NO_PROJECT_FILTER_ID = '__goodboy_no_project__';
+
+export type GetSelectedProjectIdsParams = {
+  readonly workspaceId: WorkspaceId;
+};
+
+export type SetSelectedProjectIdsParams = {
+  readonly workspaceId: WorkspaceId;
+  readonly selectedProjectIds: ReadonlyArray<string>;
+};
+
+export type SessionFiltersSlice = {
+  readonly selectedProjectIds: Readonly<Record<WorkspaceId, ReadonlyArray<string>>>;
+  getSelectedProjectIds(params: GetSelectedProjectIdsParams): ReadonlyArray<string>;
+  setSelectedProjectIds(params: SetSelectedProjectIdsParams): void;
+};

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -125,6 +125,11 @@ import { createIntegrationsSlice } from './slices/integrations';
 import { createSidebarSlice } from './slices/sidebar';
 import type { PanelSection } from './slices/sidebar/types';
 import { createSessionViewSlice } from './slices/session-view';
+import { createSessionFiltersSlice } from './slices/sessionFilters';
+import type {
+  GetSelectedProjectIdsParams,
+  SetSelectedProjectIdsParams,
+} from './slices/sessionFilters/types';
 import { createInitialSessionViewState } from './slices/session-view/createInitialSessionViewState';
 import type {
   DiffFocus,
@@ -221,6 +226,8 @@ type RunScriptParams = {
 };
 
 export type AppActions = {
+  getSelectedProjectIds(params: GetSelectedProjectIdsParams): ReadonlyArray<string>;
+  setSelectedProjectIds(params: SetSelectedProjectIdsParams): void;
   hydrate(): Promise<void>;
   retryHydrate(): Promise<void>;
   checkForUpdates(): Promise<void>;
@@ -864,6 +871,7 @@ export const initialState: AppState = {
   ...initialChangelogState,
   ...initialBugReportDraftState,
   ...createInitialSessionViewState({}),
+  selectedProjectIds: {},
   workspaces: [],
   projects: [],
   workspaceIntegrations: {},
@@ -1017,6 +1025,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
   ...createIntegrationsSlice(set, get),
   ...createSidebarSlice(set, get),
   ...createSessionViewSlice(set, get),
+  ...createSessionFiltersSlice({ set, get }),
   ...createTerminalSlice(set, get),
   ...createScriptsSlice(set, get),
   ...createPermissionsSlice(set, get),

--- a/apps/desktop/src/store/types.ts
+++ b/apps/desktop/src/store/types.ts
@@ -178,6 +178,7 @@ export type SummarizerSessionStatus = {
 type AppSliceState = UpdaterState & ChangelogState & SlackThreadsSliceState & BugReportDraftState;
 
 export type AppState = AppSliceState & {
+  readonly selectedProjectIds: Readonly<Record<WorkspaceId, ReadonlyArray<string>>>;
   readonly workspaces: ReadonlyArray<Workspace>;
   readonly projects: ReadonlyArray<Project>;
   readonly workspaceIntegrations: Readonly<Record<WorkspaceId, ReadonlyArray<IntegrationBinding>>>;


### PR DESCRIPTION
## What
**Chips (sidebar rows)**
- 1 mounted project → chip with the project name (truncated), matching the existing chip language of the row.
- 2+ → single `N projects` chip with a tooltip listing the names.
- 0 → no chip. Board card already showed project identity in its footer, left as is.

**Filter (board + sidebar, shared)**
- New `sessionFilters` slice: `selectedProjectIds: Record<WorkspaceId, ReadonlyArray<string>>`, persisted per workspace in local storage.
- One popover filter control in the sidebar header (next to the view menu) and in the board toolbar, both driving the same slice: multi-select, only projects with ≥1 session mount, per-project session counts, a `No project` bucket for unmounted sessions, active-count badge on the trigger, clear affordance.
- Composes with existing sorting/grouping/collapsing instead of replacing them.

## Tests
182 files / 1742 passed + focused 167, typecheck green.

## Note
Touches `SessionActivityBar/index.tsx` like #1548 (one-line import there): if both are green, merge #1548 first, this one rebases trivially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)