### PR TITLE
fix(ui): collapse consecutive decision events in the session trace

### DIFF
--- a/apps/desktop/src/features/session/timeline/buildTimelineStream.test.ts
+++ b/apps/desktop/src/features/session/timeline/buildTimelineStream.test.ts
@@ -929,6 +929,37 @@ describe('buildTimelineStream, session events', () => {
     });
   });
 
+  it('keeps decision runs separate across a day boundary', () => {
+    const result = stream({
+      agents: [],
+      events: [
+        sessionEvent({
+          id: 'ev-yesterday',
+          kind: 'decisions_changed',
+          at: localIso({ day: 17, hour: 23 }),
+          payload: { added: 1, removed: 0 },
+        }),
+        sessionEvent({
+          id: 'ev-today',
+          kind: 'decisions_changed',
+          at: localIso({ day: 18, hour: 1 }),
+          payload: { added: 2, removed: 1 },
+        }),
+      ],
+    });
+    const rows = result.items.flatMap((item) => (item.kind === 'row' ? [item] : []));
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0]?.entry.kind === 'event' ? rows[0].entry.event.payload : null).toEqual({
+      added: 2,
+      removed: 1,
+    });
+    expect(rows[1]?.entry.kind === 'event' ? rows[1].entry.event.payload : null).toEqual({
+      added: 1,
+      removed: 0,
+    });
+  });
+
   it('keeps decision runs separate across an agent row', () => {
     const result = stream({
       agents: [

--- a/apps/desktop/src/features/session/timeline/buildTimelineStream.test.ts
+++ b/apps/desktop/src/features/session/timeline/buildTimelineStream.test.ts
@@ -10,6 +10,7 @@ import type {
   SessionEvent,
   SessionEventId,
   SessionEventKind,
+  SessionEventPayload,
   SessionId,
   Step,
   StepId,
@@ -880,17 +881,143 @@ type SessionEventParams = {
   readonly id: string;
   readonly kind: SessionEventKind;
   readonly at: string;
+  readonly payload?: SessionEventPayload;
 };
 
-const sessionEvent = ({ id, kind, at }: SessionEventParams): SessionEvent => ({
+const sessionEvent = ({ id, kind, at, payload }: SessionEventParams): SessionEvent => ({
   id: typedString<SessionEventId>({ value: id }),
   sessionId: SESSION_ID,
   kind,
-  payload: null,
+  payload: payload ?? null,
   createdAt: typedString<IsoDateTime>({ value: at }),
 });
 
 describe('buildTimelineStream, session events', () => {
+  it('merges three consecutive decision changes into the newest row', () => {
+    const newestAt = localIso({ day: 18, hour: 12 });
+    const result = stream({
+      agents: [],
+      events: [
+        sessionEvent({
+          id: 'ev-oldest',
+          kind: 'decisions_changed',
+          at: localIso({ day: 18, hour: 10 }),
+          payload: { added: 1, removed: 2 },
+        }),
+        sessionEvent({
+          id: 'ev-middle',
+          kind: 'decisions_changed',
+          at: localIso({ day: 18, hour: 11 }),
+          payload: { added: 3, removed: 1 },
+        }),
+        sessionEvent({
+          id: 'ev-newest',
+          kind: 'decisions_changed',
+          at: newestAt,
+          payload: { added: 2, removed: 4 },
+        }),
+      ],
+    });
+    const rows = result.items.flatMap((item) => (item.kind === 'row' ? [item] : []));
+    const row = rows[0];
+
+    expect(rows).toHaveLength(1);
+    expect(row?.at).toBe(newestAt);
+    expect(row?.entry.kind === 'event' ? row.entry.event.payload : null).toEqual({
+      added: 6,
+      removed: 7,
+    });
+  });
+
+  it('keeps decision runs separate across an agent row', () => {
+    const result = stream({
+      agents: [
+        agent({ id: 'interleaved', ordinal: 1, startedAt: localIso({ day: 18, hour: 11 }) }),
+      ],
+      events: [
+        sessionEvent({
+          id: 'ev-oldest',
+          kind: 'decisions_changed',
+          at: localIso({ day: 18, hour: 9 }),
+          payload: { added: 1, removed: 0 },
+        }),
+        sessionEvent({
+          id: 'ev-older',
+          kind: 'decisions_changed',
+          at: localIso({ day: 18, hour: 10 }),
+          payload: { added: 2, removed: 1 },
+        }),
+        sessionEvent({
+          id: 'ev-newer',
+          kind: 'decisions_changed',
+          at: localIso({ day: 18, hour: 12 }),
+          payload: { added: 3, removed: 2 },
+        }),
+        sessionEvent({
+          id: 'ev-newest',
+          kind: 'decisions_changed',
+          at: localIso({ day: 18, hour: 13 }),
+          payload: { added: 4, removed: 3 },
+        }),
+      ],
+    });
+    const rows = result.items.flatMap((item) => (item.kind === 'row' ? [item] : []));
+    const payloads = rows.flatMap((row) =>
+      row.entry.kind === 'event' ? [row.entry.event.payload] : [],
+    );
+
+    expect(rows.map((row) => row.id)).toEqual([
+      'event:ev-newest',
+      'agent:interleaved',
+      'event:ev-older',
+    ]);
+    expect(payloads).toEqual([
+      { added: 7, removed: 5 },
+      { added: 3, removed: 1 },
+    ]);
+  });
+
+  it('leaves a single decision change unchanged', () => {
+    const payload = { added: 1, removed: 2 };
+    const result = stream({
+      agents: [],
+      events: [
+        sessionEvent({
+          id: 'ev-only',
+          kind: 'decisions_changed',
+          at: localIso({ day: 18, hour: 12 }),
+          payload,
+        }),
+      ],
+    });
+    const row = result.items.find((item) => item.kind === 'row');
+
+    expect(row?.entry.kind === 'event' ? row.entry.event.payload : null).toBe(payload);
+  });
+
+  it('keeps the newest decision row id after merging', () => {
+    const result = stream({
+      agents: [],
+      events: [
+        sessionEvent({
+          id: 'ev-older',
+          kind: 'decisions_changed',
+          at: localIso({ day: 18, hour: 11 }),
+          payload: { added: 1, removed: 0 },
+        }),
+        sessionEvent({
+          id: 'ev-newest',
+          kind: 'decisions_changed',
+          at: localIso({ day: 18, hour: 12 }),
+          payload: { added: 1, removed: 0 },
+        }),
+      ],
+    });
+    const rows = result.items.flatMap((item) => (item.kind === 'row' ? [item] : []));
+
+    expect(rows.map((row) => row.id)).toEqual(['event:ev-newest']);
+  });
+
   it('keeps the worktree row at the bottom when creation events share an instant', () => {
     const at = localIso({ day: 18, hour: 8 });
     const result = stream({

--- a/apps/desktop/src/features/session/timeline/buildTimelineStream.ts
+++ b/apps/desktop/src/features/session/timeline/buildTimelineStream.ts
@@ -191,9 +191,14 @@ const mergeConsecutiveDecisionRows = ({
     let added = 0;
     let removed = 0;
     let runIndex = index;
+    const newestDayKey = newest.at === null ? null : dayKeyOf({ at: newest.at });
     while (runIndex < drafts.length) {
       const draft = drafts[runIndex];
       if (draft === undefined || !isDecisionChangeRow({ draft }) || draft.entry.kind !== 'event') {
+        break;
+      }
+      const draftDayKey = draft.at === null ? null : dayKeyOf({ at: draft.at });
+      if (runIndex > index && draftDayKey !== newestDayKey) {
         break;
       }
       added += draft.entry.event.payload?.added ?? 0;

--- a/apps/desktop/src/features/session/timeline/buildTimelineStream.ts
+++ b/apps/desktop/src/features/session/timeline/buildTimelineStream.ts
@@ -162,6 +162,71 @@ const compareNewestFirst = ({
   return second.sortOrdinal - first.sortOrdinal || first.id.localeCompare(second.id);
 };
 
+const isDecisionChangeRow = ({ draft }: { readonly draft: DraftRow }): boolean =>
+  draft.groupId == null &&
+  draft.entry.kind === 'event' &&
+  draft.entry.event.kind === 'decisions_changed';
+
+type MergeDecisionRowsParams = {
+  readonly drafts: ReadonlyArray<DraftRow>;
+};
+
+const mergeConsecutiveDecisionRows = ({
+  drafts,
+}: MergeDecisionRowsParams): ReadonlyArray<DraftRow> => {
+  const merged: DraftRow[] = [];
+  let index = 0;
+
+  while (index < drafts.length) {
+    const newest = drafts[index];
+    if (newest === undefined) {
+      break;
+    }
+    if (!isDecisionChangeRow({ draft: newest }) || newest.entry.kind !== 'event') {
+      merged.push(newest);
+      index += 1;
+      continue;
+    }
+
+    let added = 0;
+    let removed = 0;
+    let runIndex = index;
+    while (runIndex < drafts.length) {
+      const draft = drafts[runIndex];
+      if (draft === undefined || !isDecisionChangeRow({ draft }) || draft.entry.kind !== 'event') {
+        break;
+      }
+      added += draft.entry.event.payload?.added ?? 0;
+      removed += draft.entry.event.payload?.removed ?? 0;
+      runIndex += 1;
+    }
+
+    if (runIndex === index + 1) {
+      merged.push(newest);
+      index = runIndex;
+      continue;
+    }
+
+    merged.push({
+      ...newest,
+      entry: {
+        ...newest.entry,
+        event: {
+          ...newest.entry.event,
+          payload: {
+            ...newest.entry.event.payload,
+            added,
+            removed,
+          },
+        },
+      },
+    });
+    index = runIndex;
+  }
+
+  return merged;
+};
+
 const stepAgentsOf = ({ entry }: { readonly entry: TimelineRunEntry }): ReadonlyArray<Agent> =>
   entry.children.flatMap((child) => (child.kind === 'agent' ? [child.agent] : []));
 
@@ -556,8 +621,9 @@ export const buildTimelineStream = ({
   }
 
   const sorted = [...rows].sort((first, second) => compareNewestFirst({ first, second }));
+  const merged = mergeConsecutiveDecisionRows({ drafts: sorted });
   const withDays = withDayBreaks({
-    drafts: withPendingClusters({ drafts: withPendingAtFamilyHead({ drafts: sorted }) }),
+    drafts: withPendingClusters({ drafts: withPendingAtFamilyHead({ drafts: merged }) }),
     dayLabelFor,
   });
 


### PR DESCRIPTION
A burst of decision changes rendered one row each (`1 decision added, 2 removed` five times in a screenful). Consecutive `decisions_changed` rows now merge into a single row: summed added and removed counts, newest row's timestamp and id. Rows separated by any other timeline row stay distinct. Merge happens as a pre-pass on the flat sorted rows in buildTimelineStream, so rail lanes and day breaks are untouched.

Benchmark: GitHub's PR timeline collapsing pushed commits into one "added N commits" row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)