### PR TITLE
chore(ui): declutter session chrome and unify filter icons

### DIFF
--- a/apps/desktop/src/features/session/components/SessionCrumbBar/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionCrumbBar/index.test.tsx
@@ -38,10 +38,6 @@ vi.mock('./WorkflowAdvance', () => ({
   ),
 }));
 
-vi.mock('../SessionOverviewPane/SessionCostChip', () => ({
-  SessionCostChip: () => <span data-testid="session-cost-chip" />,
-}));
-
 vi.mock('@goodboy/ui', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@goodboy/ui')>();
   return {
@@ -182,12 +178,12 @@ afterEach(() => {
 });
 
 describe('SessionCrumbBar', () => {
-  it('renders the ladder inside a divider-flanked strip, not a bordered bar', () => {
+  it('renders the ladder without a divider or bordered bar', () => {
     render(<SessionCrumbBar />);
     const nav = screen.getByRole('navigation', { name: 'Breadcrumb' });
     expect(nav.className).not.toContain('border-b');
     expect(nav.className).not.toContain('border-border-soft');
-    expect(screen.getByRole('separator', { hidden: true })).toBeDefined();
+    expect(screen.queryByRole('separator', { hidden: true })).toBeNull();
   });
 
   it('carries the stage label and reason as a tooltip on the crumb dot', () => {
@@ -206,16 +202,6 @@ describe('SessionCrumbBar', () => {
 
     const nav = screen.getByRole('navigation', { name: 'Breadcrumb' });
     expect(nav.querySelector('[data-tooltip="running"]')).not.toBeNull();
-  });
-
-  it('renders the session cost right-aligned at the end of the strip', () => {
-    render(<SessionCrumbBar />);
-
-    const chip = screen.getByTestId('session-cost-chip');
-    const nav = screen.getByRole('navigation', { name: 'Breadcrumb' });
-    expect(nav.contains(chip)).toBe(true);
-    expect(chip.parentElement?.className).toContain('ml-auto');
-    expect(nav.lastElementChild).toBe(chip.parentElement);
   });
 
   it('lists the crumbs from useSessionCrumbs in order', () => {

--- a/apps/desktop/src/features/session/components/SessionCrumbBar/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionCrumbBar/index.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { ChevronRight } from 'lucide-react';
-import { Divider, StatusDot, Tooltip } from '@goodboy/ui';
+import { StatusDot, Tooltip } from '@goodboy/ui';
 import type { Agent, AgentId, Session, SessionId } from '@goodboy/types';
 import {
   EMPTY_ARRAY,
@@ -9,7 +9,6 @@ import {
   useSessionStageInfo,
 } from '../../../../store';
 import { SESSION_STAGE_META, STAGE_TONE } from '../../session-stage';
-import { SessionCostChip } from '../SessionOverviewPane/SessionCostChip';
 import { useSessionCrumbs } from '../../hooks/useSessionCrumbs';
 import { useSelectedWorkflowRun } from '../../hooks/useSelectedWorkflowRun';
 import { agentHomeLens, classifyAgent, resolveRootAgent } from '../../agent-kind';
@@ -124,66 +123,58 @@ const SessionCrumbs = ({ session }: SessionCrumbsProps) => {
     selectedWorkflowRun.run.discardedAt == null;
 
   return (
-    <>
-      <nav
-        aria-label="Breadcrumb"
-        className="flex h-8 min-w-0 shrink-0 items-center gap-1.5 bg-background px-4"
+    <nav
+      aria-label="Breadcrumb"
+      className="flex h-8 min-w-0 shrink-0 items-center gap-1.5 bg-background px-4"
+    >
+      <Tooltip
+        content={
+          stage.reason === ''
+            ? SESSION_STAGE_META[stage.stage].label
+            : `${SESSION_STAGE_META[stage.stage].label} · ${stage.reason}`
+        }
       >
-        <Tooltip
-          content={
-            stage.reason === ''
-              ? SESSION_STAGE_META[stage.stage].label
-              : `${SESSION_STAGE_META[stage.stage].label} · ${stage.reason}`
-          }
-        >
-          <span className="inline-flex shrink-0 items-center">
-            <StatusDot tone={STAGE_TONE[stage.stage]} size="sm" />
-          </span>
-        </Tooltip>
-        {crumbs.map((crumb, index) => (
-          <span key={crumb.id} className="flex min-w-0 items-center gap-1.5">
-            {index > 0 ? (
-              <ChevronRight size={12} aria-hidden className="shrink-0 text-muted-foreground/40" />
-            ) : null}
-            {index === crumbs.length - 1 && canSwitchAgent && selectedAgent != null ? (
-              <AgentSwitcherCrumb
-                label={crumb.label}
-                siblings={siblings}
-                selectedAgentId={selectedAgent.id}
-                onSelect={(id) => {
-                  void selectAgent(sessionId, id);
-                }}
-              />
-            ) : crumb.id === 'selected-parent' &&
-              parentAgent != null &&
-              parentSiblings.length > 1 ? (
-              <AgentSwitcherCrumb
-                label={crumb.label}
-                siblings={parentSiblings}
-                selectedAgentId={parentAgent.id}
-                onNavigate={crumb.onClick}
-                onSelect={(id) => {
-                  void selectAgent(sessionId, id);
-                }}
-              />
-            ) : (
-              <PlainCrumb crumb={crumb} isLast={index === crumbs.length - 1} />
-            )}
-          </span>
-        ))}
-        {canAdvanceRun ? (
-          <WorkflowAdvance
-            sessionId={sessionId}
-            run={selectedWorkflowRun.run}
-            workflow={selectedWorkflowRun.workflow}
-          />
-        ) : null}
-        <div className="ml-auto flex shrink-0 items-center">
-          <SessionCostChip sessionId={sessionId} />
-        </div>
-      </nav>
-      <Divider className="shrink-0" />
-    </>
+        <span className="inline-flex shrink-0 items-center">
+          <StatusDot tone={STAGE_TONE[stage.stage]} size="sm" />
+        </span>
+      </Tooltip>
+      {crumbs.map((crumb, index) => (
+        <span key={crumb.id} className="flex min-w-0 items-center gap-1.5">
+          {index > 0 ? (
+            <ChevronRight size={12} aria-hidden className="shrink-0 text-muted-foreground/40" />
+          ) : null}
+          {index === crumbs.length - 1 && canSwitchAgent && selectedAgent != null ? (
+            <AgentSwitcherCrumb
+              label={crumb.label}
+              siblings={siblings}
+              selectedAgentId={selectedAgent.id}
+              onSelect={(id) => {
+                void selectAgent(sessionId, id);
+              }}
+            />
+          ) : crumb.id === 'selected-parent' && parentAgent != null && parentSiblings.length > 1 ? (
+            <AgentSwitcherCrumb
+              label={crumb.label}
+              siblings={parentSiblings}
+              selectedAgentId={parentAgent.id}
+              onNavigate={crumb.onClick}
+              onSelect={(id) => {
+                void selectAgent(sessionId, id);
+              }}
+            />
+          ) : (
+            <PlainCrumb crumb={crumb} isLast={index === crumbs.length - 1} />
+          )}
+        </span>
+      ))}
+      {canAdvanceRun ? (
+        <WorkflowAdvance
+          sessionId={sessionId}
+          run={selectedWorkflowRun.run}
+          workflow={selectedWorkflowRun.workflow}
+        />
+      ) : null}
+    </nav>
   );
 };
 

--- a/apps/desktop/src/features/session/components/SessionNavSidebar/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionNavSidebar/index.tsx
@@ -1,5 +1,4 @@
 import { useCallback } from 'react';
-import { Divider } from '@goodboy/ui';
 import type { Session, SessionId } from '@goodboy/types';
 import { EMPTY_ARRAY, useAppStore, useCurrentWorkspace, useSessions } from '../../../../store';
 import { SessionActivityBar } from '../../../workspace/components/SessionActivityBar';
@@ -53,7 +52,6 @@ export const SessionNavSidebar = ({
         {onCollapse ? <SidebarHeader onCollapse={onCollapse} action={collapseAction} /> : null}
         <BoardCta onNavigate={onBoard} />
       </div>
-      <Divider />
       <div className="flex min-h-0 flex-1 flex-col overflow-x-clip">
         <div className="flex min-h-0 flex-1">
           {currentWorkspace ? (

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/HeaderBand.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/HeaderBand.test.tsx
@@ -37,6 +37,9 @@ vi.mock('./SessionDestructiveActions', () => ({
   SessionDestructiveActions: () => <button aria-label="Session actions" />,
 }));
 vi.mock('./ContextChip', () => ({ ContextChip: () => <span>Context</span> }));
+vi.mock('./SessionCostChip', () => ({
+  SessionCostChip: () => <span data-testid="session-cost-chip" />,
+}));
 vi.mock('./LinkedWorkChips', () => ({ LinkedWorkChips: () => <span>Linked work</span> }));
 vi.mock('./LinkIssueAction', () => ({ LinkIssueAction: () => <button>Link issue</button> }));
 vi.mock('./ProjectMountRows', () => ({
@@ -80,5 +83,15 @@ describe('HeaderBand', () => {
     const projects = screen.getByRole('region', { name: 'Mounted projects' });
     const goal = screen.getByText('Goal');
     expect(projects.compareDocumentPosition(goal) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('renders the session cost at the right edge of the context row', () => {
+    render(<HeaderBand session={session} onSelectLens={vi.fn()} goal={<div>Goal</div>} />);
+
+    const context = screen.getByText('Context');
+    const chip = screen.getByTestId('session-cost-chip');
+    expect(context.parentElement).toBe(chip.parentElement?.parentElement);
+    expect(chip.parentElement?.className).toContain('ml-auto');
+    expect(chip.parentElement?.lastElementChild).toBe(chip);
   });
 });

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/HeaderBand.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/HeaderBand.tsx
@@ -12,6 +12,7 @@ import { ContextChip } from './ContextChip';
 import { LinkedWorkChips } from './LinkedWorkChips';
 import { MountProjectAction } from './ProjectMountRows/MountProjectAction';
 import { ProjectMountRows } from './ProjectMountRows';
+import { SessionCostChip } from './SessionCostChip';
 
 type Props = {
   readonly session: Session;
@@ -102,6 +103,7 @@ export const HeaderBand = ({ session, onSelectLens, goal }: Props) => {
         <div className="ml-auto flex flex-wrap items-center justify-end gap-2">
           <LinkedWorkChips sessionId={sessionId} onSelectLens={onSelectLens} />
           <LinkIssueAction session={session} presentation="chip" isCollapsed={hasLinkedWork} />
+          <SessionCostChip sessionId={sessionId} />
         </div>
       </div>
       <ProjectMountRows session={session} onSelectLens={onSelectLens} />

--- a/apps/desktop/src/features/workspace/components/ProjectFilter/index.tsx
+++ b/apps/desktop/src/features/workspace/components/ProjectFilter/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef } from 'react';
-import { Filter, X } from 'lucide-react';
+import { ListFilter, X } from 'lucide-react';
 import { AnchoredPopover, cn, Divider, Eyebrow, Tooltip, useDropdown } from '@goodboy/ui';
 import type { Session, WorkspaceId } from '@goodboy/types';
 import {
@@ -126,7 +126,7 @@ export const ProjectFilter = ({ workspaceId, sessions }: Props) => {
                 : 'text-muted-foreground/70 hover:bg-foreground/10 hover:text-foreground',
             )}
           >
-            <Filter size={11} aria-hidden />
+            <ListFilter size={11} aria-hidden />
             {activeCount > 0 ? <span className="tabular-nums">{activeCount}</span> : null}
           </button>
         </Tooltip>

--- a/apps/desktop/src/features/workspace/components/SessionActivityBar/index.tsx
+++ b/apps/desktop/src/features/workspace/components/SessionActivityBar/index.tsx
@@ -274,7 +274,6 @@ export const SessionActivityBar = ({
                     <span aria-hidden className="text-2xs text-muted-foreground tabular-nums">
                       {group.sessions.length}
                     </span>
-                    <span aria-hidden className="ml-1 h-px flex-1 bg-border-soft" />
                   </button>
                 )}
                 {!collapsed &&


### PR DESCRIPTION
- session cost chip leaves the breadcrumb and joins the overview context row, right aligned
- divider under the breadcrumb removed
- divider under the sidebar Board CTA removed
- stage group headers in the sidebar drop their trailing divider line, the label alone separates groups
- ProjectFilter trigger swaps lucide `Filter` for `ListFilter`, matching the activity timeline filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)