### PR TITLE
chore(repo): bump version to 0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ version in the same PR that bumps the version numbers (see
 `docs/release-command.md`), before the tag is pushed: the release build fails
 if it can't find a matching `## Goodboy vX.Y.Z` heading.
 
+## Goodboy v0.2.3
+
+The board sheds its git banner and every project picks its own base branch.
+
+### [#1553] The board header carries a git pill per project
+
+The full-width main checkout band above the board is gone. Each repository
+project now shows a compact branch pill next to the board controls, with a
+count badge when there is something to act on: commits to pull, uncommitted
+changes, conflicts. The detail, the fast-forward action, open in editor and
+the first-time git setup guide all live in the pill. Workspaces with several
+projects finally see the state of each checkout, not just the first one.
+
+### [#1554] Choose the base branch per project
+
+Everything assumed main: new session branches, diffs, rebases, sync state and
+new pull requests. Each project now carries its own base branch, editable
+from the git pill on the board and from the workspace settings. Leave it
+empty and Goodboy follows the repository's default branch on its own.
+
+### Fixes
+
+- A burst of decision changes filled the activity trace with one row each;
+  consecutive rows now collapse into one with the summed counts. [#1555]
+- The session cost sits next to the context gauge instead of floating in the
+  breadcrumb, and stray dividers under the breadcrumb, the Board button and
+  the sidebar stage labels are gone. Filter buttons share one icon. [#1556]
+
 ## Goodboy v0.2.2
 
 The session decides where it works. Projects mount as you go, and the app now

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goodboy/desktop",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -1626,7 +1626,7 @@ dependencies = [
 
 [[package]]
 name = "goodboy-desktop"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goodboy-desktop"
-version = "0.2.2"
+version = "0.2.3"
 description = "Goodboy desktop app"
 authors = ["Amin Khayam"]
 license = "MIT"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Goodboy",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "identifier": "com.goodboy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goodboy",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "description": "AI workspace orchestrator. Local-first, provider-agnostic.",
   "license": "MIT",

--- a/website/src/site.ts
+++ b/website/src/site.ts
@@ -1,5 +1,5 @@
 export const SITE = {
-  version: 'v0.2.2',
+  version: 'v0.2.3',
   repo: 'https://github.com/akhayam99/goodboy',
   releases: 'https://github.com/akhayam99/goodboy/releases',
   latest: 'https://github.com/akhayam99/goodboy/releases/latest',


### PR DESCRIPTION
Version bump across the six canonical spots plus the v0.2.3 changelog section: git pill board header (#1553), per-project base branch (#1554), decision trace collapse (#1555), session chrome declutter (#1556).

🤖 Generated with [Claude Code](https://claude.com/claude-code)