### PR TITLE
feat(ui): overview detach confirm, base branch edit and calmer rhythm

### DIFF
--- a/apps/desktop/src/features/session/components/SessionOverviewPane/HeaderBand.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/HeaderBand.tsx
@@ -55,7 +55,7 @@ export const HeaderBand = ({ session, onSelectLens, goal }: Props) => {
   const goalText = session.goal === '' ? 'Untitled session' : session.goal;
 
   return (
-    <div className="flex flex-col gap-2.5">
+    <div className="flex flex-col gap-3">
       <div className="flex items-center gap-2">
         {rename.editing ? (
           <div ref={titleFieldRef} className="flex min-w-0 flex-1 flex-col gap-1">
@@ -98,7 +98,7 @@ export const HeaderBand = ({ session, onSelectLens, goal }: Props) => {
           <SessionDestructiveActions session={session} />
         </div>
       </div>
-      <div className="flex flex-wrap items-center gap-2">
+      <div className="flex flex-wrap items-center gap-1.5">
         <ContextChip sessionId={sessionId} onSelectLens={onSelectLens} />
         <div className="ml-auto flex flex-wrap items-center justify-end gap-2">
           <LinkedWorkChips sessionId={sessionId} onSelectLens={onSelectLens} />

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/OverviewResolve.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/OverviewResolve.tsx
@@ -103,7 +103,7 @@ export const OverviewResolve = ({ session }: Props) => {
   };
 
   return (
-    <section aria-label="Suggestions" className="flex flex-col gap-2">
+    <section aria-label="Suggestions" className="flex flex-col gap-2.5">
       <Eyebrow label="Suggestions" className="px-0.5" />
       {hasReviewSuggestion ? (
         <div className="flex w-full items-center gap-3 rounded-lg border-l-2 border-border-soft px-3 py-1.5">

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectDetachMenu.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectDetachMenu.test.tsx
@@ -1,0 +1,113 @@
+// @vitest-environment happy-dom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ProjectId, SessionId, WorktreeStatus } from '@goodboy/types';
+
+const { state, showToast } = vi.hoisted(() => ({
+  state: {
+    detachProject: vi.fn(async () => undefined),
+    emitNotification: vi.fn(),
+  },
+  showToast: vi.fn(),
+}));
+
+vi.mock('../../../../../store', () => ({
+  useAppStore: <T,>(selector: (store: typeof state) => T) => selector(state),
+}));
+
+vi.mock('../../../../../app/components/Toast', () => ({
+  useToast: () => ({ showToast }),
+}));
+
+import { ProjectDetachMenu } from './ProjectDetachMenu';
+
+const typedString = <Value extends string>({ value }: { readonly value: string }): Value =>
+  JSON.parse(JSON.stringify(value));
+
+const workingTreeStatus = ({ changed }: { readonly changed: number }): WorktreeStatus => ({
+  branch: 'feature',
+  head: 'abc123',
+  headSubject: 'Feature',
+  mainDistance: { kind: 'known', ahead: 0, behind: 0 },
+  upstreamDistance: { kind: 'known', ahead: 0, behind: 0 },
+  workingTree: {
+    kind: 'known',
+    staged: 0,
+    unstaged: changed,
+    untracked: 0,
+    unmerged: 0,
+    changed,
+  },
+  upstream: 'origin/feature',
+  inProgress: null,
+});
+
+const renderMenu = ({ status }: { readonly status: WorktreeStatus | null }) =>
+  render(
+    <ProjectDetachMenu
+      sessionId={typedString<SessionId>({ value: 'session-1' })}
+      projectId={typedString<ProjectId>({ value: 'project-1' })}
+      workspaceId={undefined}
+      projectName="api"
+      worktreePath="/worktrees/api"
+      worktreeStatus={status}
+      triggerClassName="trigger"
+    />,
+  );
+
+const openConfirm = () => {
+  fireEvent.click(screen.getByRole('button', { name: 'api actions' }));
+  fireEvent.click(screen.getByRole('menuitem', { name: 'Detach project' }));
+};
+
+afterEach(cleanup);
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('ProjectDetachMenu', () => {
+  it('renders clean worktree confirmation copy', () => {
+    renderMenu({ status: workingTreeStatus({ changed: 0 }) });
+    openConfirm();
+
+    expect(screen.getByText('Detach api?')).toBeDefined();
+    expect(screen.getByText('Its worktree is clean and will be removed.')).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Detach' })).toBeDefined();
+  });
+
+  it('renders dirty worktree confirmation copy and keeps changes', () => {
+    renderMenu({ status: workingTreeStatus({ changed: 2 }) });
+    openConfirm();
+
+    expect(screen.getByText('Uncommitted changes stay on disk at')).toBeDefined();
+    expect(screen.getByText('/worktrees/api')).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Detach, keep changes' })).toBeDefined();
+  });
+
+  it('treats unknown status as dirty', () => {
+    renderMenu({ status: null });
+    openConfirm();
+
+    expect(screen.getByText('Uncommitted changes stay on disk at')).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Detach, keep changes' })).toBeDefined();
+  });
+
+  it('returns to the item list on cancel', () => {
+    renderMenu({ status: null });
+    openConfirm();
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(screen.getByRole('menuitem', { name: 'Detach project' })).toBeDefined();
+  });
+
+  it('reports the kept worktree path after a dirty detach', async () => {
+    renderMenu({ status: workingTreeStatus({ changed: 2 }) });
+    openConfirm();
+    fireEvent.click(screen.getByRole('button', { name: 'Detach, keep changes' }));
+
+    await waitFor(() =>
+      expect(showToast).toHaveBeenCalledWith('info', 'Worktree kept at /worktrees/api'),
+    );
+  });
+});

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectDetachMenu.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectDetachMenu.tsx
@@ -39,6 +39,7 @@ export const ProjectDetachMenu = ({
     try {
       await detachProject({ sessionId, projectId });
       dropdown.close();
+      setIsConfirming(false);
       if (!isClean) {
         showToast('info', `Worktree kept at ${worktreePath}`);
       }

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectDetachMenu.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectDetachMenu.tsx
@@ -1,0 +1,130 @@
+import { useState } from 'react';
+import { MoreHorizontal } from 'lucide-react';
+import { AnchoredPopover, Button, Tooltip, formatError, useDropdown } from '@goodboy/ui';
+import type { ProjectId, SessionId, WorktreeStatus, WorkspaceId } from '@goodboy/types';
+import { useToast } from '../../../../../app/components/Toast';
+import { useAppStore } from '../../../../../store';
+import { isWorkingTreeClean } from '../../../../../shared/lib/gitStatus';
+
+type Props = {
+  readonly sessionId: SessionId;
+  readonly projectId: ProjectId;
+  readonly workspaceId: WorkspaceId | undefined;
+  readonly projectName: string;
+  readonly worktreePath: string;
+  readonly worktreeStatus: WorktreeStatus | null;
+  readonly triggerClassName: string;
+};
+
+export const ProjectDetachMenu = ({
+  sessionId,
+  projectId,
+  workspaceId,
+  projectName,
+  worktreePath,
+  worktreeStatus,
+  triggerClassName,
+}: Props) => {
+  const dropdown = useDropdown({ align: 'end', width: 'w-72', expectedHeight: 150 });
+  const detachProject = useAppStore((state) => state.detachProject);
+  const emitNotification = useAppStore((state) => state.emitNotification);
+  const { showToast } = useToast();
+  const [isConfirming, setIsConfirming] = useState(false);
+  const [isDetaching, setIsDetaching] = useState(false);
+  const isClean =
+    worktreeStatus != null && isWorkingTreeClean({ workingTree: worktreeStatus.workingTree });
+
+  const detach = async () => {
+    setIsDetaching(true);
+    try {
+      await detachProject({ sessionId, projectId });
+      dropdown.close();
+      if (!isClean) {
+        showToast('info', `Worktree kept at ${worktreePath}`);
+      }
+    } catch (error) {
+      void emitNotification(
+        'error',
+        'warning',
+        'could not detach the project',
+        formatError(error),
+        { sessionId, workspaceId },
+      );
+    } finally {
+      setIsDetaching(false);
+    }
+  };
+
+  return (
+    <AnchoredPopover
+      dropdown={dropdown}
+      role="menu"
+      ariaLabel={`${projectName} actions`}
+      trigger={
+        <Tooltip content={`${projectName} actions`} anchorClassName="shrink-0">
+          <button
+            type="button"
+            onClick={() => {
+              if (dropdown.open) {
+                dropdown.close();
+                setIsConfirming(false);
+                return;
+              }
+              dropdown.toggle();
+            }}
+            aria-label={`${projectName} actions`}
+            aria-haspopup="menu"
+            aria-expanded={dropdown.open}
+            className={triggerClassName}
+          >
+            <MoreHorizontal size={14} aria-hidden />
+          </button>
+        </Tooltip>
+      }
+    >
+      {isConfirming ? (
+        <div className="flex w-72 flex-col gap-2 p-3">
+          <span className="text-xs font-medium">{`Detach ${projectName}?`}</span>
+          {isClean ? (
+            <span className="text-2xs text-muted-foreground">
+              Its worktree is clean and will be removed.
+            </span>
+          ) : (
+            <div className="flex min-w-0 flex-col gap-1 text-muted-foreground">
+              <span className="text-2xs">Uncommitted changes stay on disk at</span>
+              <span className="truncate font-mono text-2xs">{worktreePath}</span>
+            </div>
+          )}
+          <div className="flex items-center gap-1">
+            <Button
+              size="sm"
+              variant="ghost"
+              className="text-danger hover:text-danger"
+              disabled={isDetaching}
+              onClick={() => void detach()}
+            >
+              {isClean ? 'Detach' : 'Detach, keep changes'}
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              disabled={isDetaching}
+              onClick={() => setIsConfirming(false)}
+            >
+              Cancel
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <button
+          type="button"
+          role="menuitem"
+          onClick={() => setIsConfirming(true)}
+          className="flex w-full items-center px-2.5 py-1.5 text-left text-danger/90 transition-colors hover:bg-danger/10 hover:text-danger"
+        >
+          Detach project
+        </button>
+      )}
+    </AnchoredPopover>
+  );
+};

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectMountRow.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectMountRow.tsx
@@ -1,7 +1,5 @@
-import { useState } from 'react';
-import { Folder, FolderGit2, MoreHorizontal } from 'lucide-react';
-import { OverflowMenu, Tooltip, cn, formatError } from '@goodboy/ui';
-import type { OverflowMenuItem } from '@goodboy/ui';
+import { Folder, FolderGit2 } from 'lucide-react';
+import { Tooltip } from '@goodboy/ui';
 import type {
   Project,
   PullRequestState,
@@ -16,6 +14,7 @@ import { PullRequestChip } from '../../../../github/components/PullRequestChip';
 import { DiffStat } from '../../DiffStat';
 import { ProjectBranchChip } from './ProjectBranchChip';
 import { ProjectSyncControl } from './ProjectSyncControl';
+import { ProjectDetachMenu } from './ProjectDetachMenu';
 
 type Props = {
   readonly sessionId: SessionId;
@@ -40,10 +39,7 @@ export const ProjectMountRow = ({
   onSelectLens,
 }: Props) => {
   const setSessionActiveProject = useAppStore((state) => state.setSessionActiveProject);
-  const detachProject = useAppStore((state) => state.detachProject);
   const openMountDiff = useAppStore((state) => state.openMountDiff);
-  const emitNotification = useAppStore((state) => state.emitNotification);
-  const [isDetaching, setIsDetaching] = useState(false);
   const GlyphIcon = project?.kind === 'repo' ? FolderGit2 : Folder;
   const projectName = project?.name ?? mount.mountName;
   const changes = diffStat != null && (diffStat.additions > 0 || diffStat.deletions > 0);
@@ -52,36 +48,10 @@ export const ProjectMountRow = ({
     await setSessionActiveProject({ sessionId, projectId: mount.projectId });
     onSelectLens(lens);
   };
-  const detach = async () => {
-    setIsDetaching(true);
-    try {
-      await detachProject({ sessionId, projectId: mount.projectId });
-    } catch (error) {
-      void emitNotification(
-        'error',
-        'warning',
-        'could not detach the project',
-        formatError(error),
-        { sessionId, workspaceId: project?.workspaceId },
-      );
-    } finally {
-      setIsDetaching(false);
-    }
-  };
-  const menuItems: ReadonlyArray<OverflowMenuItem> = [
-    {
-      kind: 'item',
-      key: 'detach',
-      label: isDetaching ? `Detaching ${projectName}` : 'Detach project',
-      onClick: () => void detach(),
-      disabled: isDetaching,
-    },
-  ];
-
   return (
     <div
       data-testid="project-mount-row"
-      className="flex min-h-12 w-full items-center gap-3 border-b border-border-soft px-3 py-2 last:border-b-0"
+      className="flex min-h-10 w-full items-center gap-3 border-b border-border-soft px-3 py-1.5 last:border-b-0"
     >
       <div className="flex min-w-36 flex-1 items-center gap-2">
         <GlyphIcon size={14} aria-hidden className="shrink-0 text-muted-foreground" />
@@ -159,11 +129,14 @@ export const ProjectMountRow = ({
           <CONCEPT_ICONS.scripts size={13} aria-hidden />
         </button>
       </Tooltip>
-      <OverflowMenu
-        items={menuItems}
-        label={`${projectName} actions`}
-        triggerClassName={cn(ICON_BUTTON)}
-        trigger={<MoreHorizontal size={14} aria-hidden />}
+      <ProjectDetachMenu
+        sessionId={sessionId}
+        projectId={mount.projectId}
+        workspaceId={project?.workspaceId}
+        projectName={projectName}
+        worktreePath={mount.worktreePath}
+        worktreeStatus={worktreeStatus}
+        triggerClassName={ICON_BUTTON}
       />
     </div>
   );

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectSyncControl.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectSyncControl.test.tsx
@@ -1,13 +1,14 @@
 // @vitest-environment happy-dom
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { WorktreeStatus } from '@goodboy/types';
 
 const { store } = vi.hoisted(() => ({
   store: {
     setSessionActiveProject: vi.fn(async () => undefined),
     emitNotification: vi.fn(),
+    updateProjectBaseBranch: vi.fn(async () => undefined),
     projects: [] as ReadonlyArray<{ id: string; baseBranch?: string | null }>,
   },
 }));
@@ -52,7 +53,10 @@ const renderControl = ({ status }: { readonly status: WorktreeStatus | null }) =
   );
 
 describe('ProjectSyncControl', () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    store.projects = [{ id: 'project-1', baseBranch: 'develop' }];
+  });
   afterEach(cleanup);
 
   it('shows the behind badge only when behind is greater than zero', async () => {
@@ -71,5 +75,49 @@ describe('ProjectSyncControl', () => {
     expect(screen.queryByTestId('project-behind-badge')).toBeNull();
     fireEvent.click(screen.getByRole('button', { name: 'Branch sync actions' }));
     expect(screen.getAllByText('--')).toHaveLength(2);
+  });
+
+  it('commits a trimmed base branch on Enter', async () => {
+    renderControl({ status: null });
+    fireEvent.click(screen.getByRole('button', { name: 'Branch sync actions' }));
+    fireEvent.click(screen.getByRole('button', { name: /Compared with develop/ }));
+    const input = screen.getByRole('textbox', { name: 'Base branch' });
+    fireEvent.change(input, { target: { value: '  release  ' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    await waitFor(() =>
+      expect(store.updateProjectBaseBranch).toHaveBeenCalledWith({
+        projectId: 'project-1',
+        baseBranch: 'release',
+      }),
+    );
+  });
+
+  it('clears an empty base branch to null', async () => {
+    renderControl({ status: null });
+    fireEvent.click(screen.getByRole('button', { name: 'Branch sync actions' }));
+    fireEvent.click(screen.getByRole('button', { name: /Compared with develop/ }));
+    const input = screen.getByRole('textbox', { name: 'Base branch' });
+    fireEvent.change(input, { target: { value: '   ' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    await waitFor(() =>
+      expect(store.updateProjectBaseBranch).toHaveBeenCalledWith({
+        projectId: 'project-1',
+        baseBranch: null,
+      }),
+    );
+  });
+
+  it('reverts the base branch edit on Escape', () => {
+    renderControl({ status: null });
+    fireEvent.click(screen.getByRole('button', { name: 'Branch sync actions' }));
+    fireEvent.click(screen.getByRole('button', { name: /Compared with develop/ }));
+    const input = screen.getByRole('textbox', { name: 'Base branch' });
+    fireEvent.change(input, { target: { value: 'release' } });
+    fireEvent.keyDown(input, { key: 'Escape' });
+
+    expect(store.updateProjectBaseBranch).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: /Compared with develop/ })).toBeDefined();
   });
 });

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectSyncControl.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectSyncControl.tsx
@@ -1,5 +1,6 @@
-import { ArrowDown, ArrowUp, GitBranch, RefreshCw, Upload } from 'lucide-react';
-import { AnchoredPopover, cn, useDropdown } from '@goodboy/ui';
+import { useState } from 'react';
+import { ArrowDown, ArrowUp, GitBranch, Pencil, RefreshCw, Upload } from 'lucide-react';
+import { AnchoredPopover, Input, cn, formatError, useDropdown } from '@goodboy/ui';
 import type { ProjectId, SessionId, WorktreeStatus } from '@goodboy/types';
 import { useAppStore } from '../../../../../store';
 import { distanceAhead } from '../../../../../shared/lib/gitStatus';
@@ -16,9 +17,14 @@ export const ProjectSyncControl = ({ sessionId, projectId, status }: Props) => {
   const dropdown = useDropdown({ width: 'w-64', expectedHeight: 160 });
   const setSessionActiveProject = useAppStore((state) => state.setSessionActiveProject);
   const emitNotification = useAppStore((state) => state.emitNotification);
-  const baseBranch = useAppStore(
-    (state) => state.projects.find((project) => project.id === projectId)?.baseBranch ?? 'main',
+  const configuredBaseBranch = useAppStore(
+    (state) => state.projects.find((project) => project.id === projectId)?.baseBranch ?? null,
   );
+  const updateProjectBaseBranch = useAppStore((state) => state.updateProjectBaseBranch);
+  const [isEditingBase, setIsEditingBase] = useState(false);
+  const [baseDraft, setBaseDraft] = useState('');
+  const [baseError, setBaseError] = useState<string | null>(null);
+  const baseBranch = configuredBaseBranch ?? 'main';
   const notify = ({ title, message }: { readonly title: string; readonly message: string }) => {
     void emitNotification('error', 'error', title, message, { sessionId });
   };
@@ -39,6 +45,26 @@ export const ProjectSyncControl = ({ sessionId, projectId, status }: Props) => {
   const targetProject = async ({ action }: { readonly action: () => Promise<void> }) => {
     await setSessionActiveProject({ sessionId, projectId });
     await action();
+  };
+  const startBaseEdit = () => {
+    setBaseDraft(configuredBaseBranch ?? '');
+    setBaseError(null);
+    setIsEditingBase(true);
+  };
+  const cancelBaseEdit = () => {
+    setBaseDraft(configuredBaseBranch ?? '');
+    setBaseError(null);
+    setIsEditingBase(false);
+  };
+  const commitBaseEdit = async () => {
+    const value = baseDraft.trim();
+    try {
+      await updateProjectBaseBranch({ projectId, baseBranch: value === '' ? null : value });
+      setBaseError(null);
+      setIsEditingBase(false);
+    } catch (error) {
+      setBaseError(formatError(error));
+    }
   };
 
   return (
@@ -68,16 +94,56 @@ export const ProjectSyncControl = ({ sessionId, projectId, status }: Props) => {
       }
     >
       <div className="flex flex-col py-1">
-        <div className="flex items-center gap-3 border-b border-border-soft px-3 py-2 text-xs tabular-nums text-muted-foreground">
-          <span className="font-medium text-foreground">Compared with {baseBranch}</span>
-          <span className="ml-auto flex items-center gap-1">
-            <ArrowDown size={11} aria-hidden />
-            {distance?.behind ?? '--'}
-          </span>
-          <span className="flex items-center gap-1">
-            <ArrowUp size={11} aria-hidden />
-            {distance?.ahead ?? '--'}
-          </span>
+        <div className="flex flex-col gap-1 border-b border-border-soft px-3 py-2 text-xs tabular-nums text-muted-foreground">
+          <div className="group flex items-center gap-3">
+            {isEditingBase ? (
+              <Input
+                autoFocus
+                aria-label="Base branch"
+                placeholder="main"
+                value={baseDraft}
+                onChange={(event) => setBaseDraft(event.target.value)}
+                onBlur={() => void commitBaseEdit()}
+                onKeyDown={(event) => {
+                  if (event.key === 'Escape') {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    cancelBaseEdit();
+                    return;
+                  }
+                  if (event.key !== 'Enter') {
+                    return;
+                  }
+                  event.preventDefault();
+                  void commitBaseEdit();
+                }}
+                className="h-7 font-mono text-xs"
+              />
+            ) : (
+              <button
+                type="button"
+                onClick={startBaseEdit}
+                className="flex items-center gap-1 font-medium text-foreground"
+              >
+                <span>Compared with</span>
+                <span className="rounded px-1 font-mono hover:bg-muted/60">{baseBranch}</span>
+                <Pencil
+                  size={10}
+                  aria-hidden
+                  className="opacity-0 transition-opacity group-hover:opacity-100"
+                />
+              </button>
+            )}
+            <span className="ml-auto flex items-center gap-1">
+              <ArrowDown size={11} aria-hidden />
+              {distance?.behind ?? '--'}
+            </span>
+            <span className="flex items-center gap-1">
+              <ArrowUp size={11} aria-hidden />
+              {distance?.ahead ?? '--'}
+            </span>
+          </div>
+          {baseError == null ? null : <span className="text-2xs text-danger">{baseError}</span>}
         </div>
         <button
           type="button"

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectSyncControl.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectSyncControl.tsx
@@ -58,8 +58,14 @@ export const ProjectSyncControl = ({ sessionId, projectId, status }: Props) => {
   };
   const commitBaseEdit = async () => {
     const value = baseDraft.trim();
+    const next = value === '' ? null : value;
+    if (next === (configuredBaseBranch ?? null)) {
+      setBaseError(null);
+      setIsEditingBase(false);
+      return;
+    }
     try {
-      await updateProjectBaseBranch({ projectId, baseBranch: value === '' ? null : value });
+      await updateProjectBaseBranch({ projectId, baseBranch: next });
       setBaseError(null);
       setIsEditingBase(false);
     } catch (error) {
@@ -115,7 +121,7 @@ export const ProjectSyncControl = ({ sessionId, projectId, status }: Props) => {
                     return;
                   }
                   event.preventDefault();
-                  void commitBaseEdit();
+                  event.currentTarget.blur();
                 }}
                 className="h-7 font-mono text-xs"
               />

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/index.tsx
@@ -88,16 +88,20 @@ export const SessionOverviewPane = ({ session, onSelectLens }: Props) => {
         }
         animationClassName="animate-fade-in"
       >
-        <OverviewNextSteps session={session} agents={sessionAgents} />
-        <OverviewResolve session={session} />
-        <TimelinePane
-          session={session}
-          runs={runs}
-          actions={
-            <OverviewActions sessionId={sessionId} onOpenWorkflowBuilder={openWorkflowBuilder} />
-          }
-          kickoff={<SessionKickoff session={session} onOpenWorkflowBuilder={openWorkflowBuilder} />}
-        />
+        <div className="flex flex-col gap-6">
+          <OverviewNextSteps session={session} agents={sessionAgents} />
+          <OverviewResolve session={session} />
+          <TimelinePane
+            session={session}
+            runs={runs}
+            actions={
+              <OverviewActions sessionId={sessionId} onOpenWorkflowBuilder={openWorkflowBuilder} />
+            }
+            kickoff={
+              <SessionKickoff session={session} onOpenWorkflowBuilder={openWorkflowBuilder} />
+            }
+          />
+        </div>
       </PaneShell>
     </InspectorSplit>
   );

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineStreamRow.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineStreamRow.test.tsx
@@ -90,9 +90,8 @@ const renderRow = ({ onOpen = vi.fn(), action = null }: RenderParams = {}) =>
       rail={railOf()}
       railWidth={32}
       sessionId={SESSION_ID}
-      openLabel="Open chat"
+      openTarget={{ label: 'Open chat', open: onOpen }}
       action={action}
-      onOpen={onOpen}
     />,
   );
 
@@ -148,6 +147,25 @@ describe('TimelineStreamRow', () => {
 
     expect(screen.getByText('Open chat ↵').className).toContain('opacity-0');
     expect(screen.getByText('Open chat ↵').className).toContain('group-hover:opacity-100');
+  });
+
+  it('renders a plain row when it has no open target', () => {
+    render(
+      <TimelineStreamRow
+        item={itemOf()}
+        rail={railOf()}
+        railWidth={32}
+        sessionId={SESSION_ID}
+        openTarget={null}
+        action={null}
+      />,
+    );
+
+    expect(screen.queryByRole('button', { name: /Implement the parser/ })).toBeNull();
+    expect(screen.queryByText(/Open chat/)).toBeNull();
+    expect(screen.getByText('Implement the parser').parentElement?.className).not.toContain(
+      'hover:bg-muted/40',
+    );
   });
 
   it('boxes the trailing action to the same height as the row content line', () => {

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineStreamRow.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineStreamRow.tsx
@@ -4,6 +4,7 @@ import type { MountDiffStat } from '../../../../../../store';
 import { formatCardTime } from '../../../../../chat/utils/format-card-time';
 import { useHoverMarkViewed } from '../../../../hooks/useHoverMarkViewed';
 import type { TimelineRowItem } from '../../../../timeline/buildTimelineStream';
+import type { TimelineOpenTarget } from '../../../../hooks/useTimelineOpen';
 import { railColumnX, type RailRow } from '../../../../timeline/railGeometry';
 import { TIMELINE_RHYTHM } from '../../../../timeline/timelineRhythm';
 import { TIMELINE_GUTTER } from './timelineLayout';
@@ -21,10 +22,9 @@ type Props = {
   readonly rail: RailRow;
   readonly railWidth: number;
   readonly sessionId: SessionId;
-  readonly openLabel: string;
+  readonly openTarget: TimelineOpenTarget | null;
   readonly action: TimelineRowAction | null;
   readonly diffStat?: MountDiffStat | null;
-  readonly onOpen: () => void;
 };
 
 const agentIdOf = ({ item }: { readonly item: TimelineRowItem }): AgentId | null =>
@@ -35,10 +35,9 @@ export const TimelineStreamRow = ({
   rail,
   railWidth,
   sessionId,
-  openLabel,
+  openTarget,
   action,
   diffStat = null,
-  onOpen,
 }: Props) => {
   const hover = useHoverMarkViewed({
     sessionId,
@@ -47,6 +46,24 @@ export const TimelineStreamRow = ({
   });
   const boxHeight = TIMELINE_RHYTHM.grade[item.grade].height;
   const needsUser = item.markerState === 'needsUser' || item.markerState === 'question';
+  const contentClassName = cn(
+    'flex min-w-0 flex-1 items-center gap-2 rounded-md pl-2 pr-1.5 text-left',
+    openTarget == null
+      ? null
+      : 'motion-safe:transition-colors hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--color-focus-ring)]',
+    needsUser && tintClasses('warning').bgSoft,
+    !needsUser && item.hasUnread && tintClasses('primary').bgSoft,
+  );
+  const content = (
+    <>
+      <TimelineRowLabel item={item} diffStat={diffStat} />
+      {openTarget == null ? null : (
+        <span className="shrink-0 text-3xs text-muted-foreground opacity-0 motion-safe:transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
+          {`${openTarget.label} ↵`}
+        </span>
+      )}
+    </>
+  );
 
   return (
     <div
@@ -78,21 +95,20 @@ export const TimelineStreamRow = ({
         )}
       </span>
       <div className={cn('flex min-w-0 flex-1 items-end gap-1', item.grade === 'step' && 'pr-1')}>
-        <button
-          type="button"
-          onClick={onOpen}
-          className={cn(
-            'flex min-w-0 flex-1 items-center gap-2 rounded-md pl-2 pr-1.5 text-left motion-safe:transition-colors hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--color-focus-ring)]',
-            needsUser && tintClasses('warning').bgSoft,
-            !needsUser && item.hasUnread && tintClasses('primary').bgSoft,
-          )}
-          style={{ height: boxHeight }}
-        >
-          <TimelineRowLabel item={item} diffStat={diffStat} />
-          <span className="shrink-0 text-3xs text-muted-foreground opacity-0 motion-safe:transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
-            {`${openLabel} ↵`}
-          </span>
-        </button>
+        {openTarget == null ? (
+          <div className={contentClassName} style={{ height: boxHeight }}>
+            {content}
+          </div>
+        ) : (
+          <button
+            type="button"
+            onClick={openTarget.open}
+            className={contentClassName}
+            style={{ height: boxHeight }}
+          >
+            {content}
+          </button>
+        )}
         {action == null ? null : (
           <span
             data-testid="timeline-row-action"

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/index.tsx
@@ -217,9 +217,13 @@ export const TimelinePane = ({ session, runs, actions, kickoff }: Props) => {
       return null;
     }
     if (stalledRunIds.has(entry.run.id)) {
+      const target = openTargetFor({ entry });
+      if (target == null) {
+        return null;
+      }
       return {
         label: 'Restart the step',
-        onAct: () => openTargetFor({ entry }).open(),
+        onAct: target.open,
       };
     }
     const advance = advanceByRunId.get(entry.run.id) ?? { kind: 'complete' as const };
@@ -252,7 +256,7 @@ export const TimelinePane = ({ session, runs, actions, kickoff }: Props) => {
   }
 
   return (
-    <section aria-label="Activity" className="flex flex-col gap-2">
+    <section aria-label="Activity" className="flex flex-col gap-2.5">
       <SectionHeader
         label="Activity"
         className="px-0.5"
@@ -328,10 +332,9 @@ export const TimelinePane = ({ session, runs, actions, kickoff }: Props) => {
                 rail={railRow}
                 railWidth={rail.width}
                 sessionId={sessionId}
-                openLabel={target.label}
+                openTarget={target}
                 action={actionFor({ item })}
                 diffStat={diffStatFor({ item })}
-                onOpen={target.open}
               />
             );
           })}

--- a/apps/desktop/src/features/session/hooks/useRebaseAgent/index.test.ts
+++ b/apps/desktop/src/features/session/hooks/useRebaseAgent/index.test.ts
@@ -150,6 +150,21 @@ describe('useRebaseAgent', () => {
     expect(showToast.mock.calls[0]?.[2]?.title).toBe('Rebase started');
   });
 
+  it('offers a spawn toast action that selects the spawned agent', async () => {
+    state.spawnAgent.mockResolvedValueOnce('agent-new');
+    const { result } = renderHook(() => useRebaseAgent({ sessionId, status: status(2) }));
+
+    await act(() => result.current.run());
+    const action = showToast.mock.calls[0]?.[2]?.action;
+    expect(action?.label).toBe('Open the rebase agent');
+
+    action?.onClick();
+
+    expect(state.selectAgent).toHaveBeenCalledWith(sessionId, 'agent-new');
+    expect(state.setActiveLens).toHaveBeenCalledWith(sessionId, 'agents');
+    expect(state.spawnAgent).toHaveBeenCalledTimes(1);
+  });
+
   it('offers an action that opens the agent once the rebase settles', async () => {
     const { result, rerender } = renderHook(() => useRebaseAgent({ sessionId, status: status(2) }));
 

--- a/apps/desktop/src/features/session/hooks/useRebaseAgent/index.ts
+++ b/apps/desktop/src/features/session/hooks/useRebaseAgent/index.ts
@@ -170,6 +170,13 @@ export const useRebaseAgent = ({ sessionId, status, onError }: Params): Result =
         `An agent is rebasing this branch on ${baseBranch}. You can keep working.`,
         {
           title: 'Rebase started',
+          action: {
+            label: 'Open the rebase agent',
+            onClick: () => {
+              setActiveLens(sessionId, 'agents');
+              void selectAgent(sessionId, agentId);
+            },
+          },
         },
       );
     } catch (failure) {

--- a/apps/desktop/src/features/session/hooks/useTimelineOpen/index.test.ts
+++ b/apps/desktop/src/features/session/hooks/useTimelineOpen/index.test.ts
@@ -1,0 +1,42 @@
+// @vitest-environment happy-dom
+
+import { cleanup, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { IsoDateTime, SessionEventId, SessionId } from '@goodboy/types';
+import type { TimelineEventEntry } from '../../timeline/buildTimelineGroups';
+
+const state = vi.hoisted(() => ({
+  setActiveLens: vi.fn(),
+}));
+
+vi.mock('../../../../store', () => ({
+  useAppStore: { getState: () => state },
+}));
+
+import { useTimelineOpen } from '.';
+
+const typedString = <Value extends string>({ value }: { readonly value: string }): Value =>
+  JSON.parse(JSON.stringify(value));
+
+afterEach(cleanup);
+
+describe('useTimelineOpen', () => {
+  it('has no open target for a detached project event', () => {
+    const sessionId = typedString<SessionId>({ value: 'session-1' });
+    const entry: TimelineEventEntry = {
+      kind: 'event',
+      id: 'event-1',
+      at: '2026-08-30T10:00:00Z',
+      event: {
+        id: typedString<SessionEventId>({ value: 'event-1' }),
+        sessionId,
+        kind: 'project_detached',
+        payload: { projectName: 'api' },
+        createdAt: typedString<IsoDateTime>({ value: '2026-08-30T10:00:00Z' }),
+      },
+    };
+    const { result } = renderHook(() => useTimelineOpen({ sessionId }));
+
+    expect(result.current({ entry })).toBeNull();
+  });
+});

--- a/apps/desktop/src/features/session/hooks/useTimelineOpen/index.ts
+++ b/apps/desktop/src/features/session/hooks/useTimelineOpen/index.ts
@@ -10,7 +10,7 @@ type EventTarget = {
   readonly label: string;
 };
 
-const EVENT_TARGET: Record<SessionEventKind, EventTarget> = {
+const EVENT_TARGET: Record<SessionEventKind, EventTarget | null> = {
   worktree_created: { lens: 'files', label: 'Open files' },
   branch_created: { lens: 'files', label: 'Open files' },
   branch_switched: { lens: 'files', label: 'Open files' },
@@ -28,11 +28,11 @@ const EVENT_TARGET: Record<SessionEventKind, EventTarget> = {
   decisions_changed: { lens: 'decisions', label: 'Open decisions' },
   project_materialized: { lens: 'files', label: 'Open files' },
   project_materialization_refused: { lens: null, label: 'Open overview' },
-  project_detached: { lens: null, label: 'Open overview' },
+  project_detached: null,
   external_task_created: { lens: null, label: 'Open overview' },
 };
 
-const eventOpenTarget = ({ kind }: { readonly kind: SessionEventKind }): EventTarget =>
+const eventOpenTarget = ({ kind }: { readonly kind: SessionEventKind }): EventTarget | null =>
   EVENT_TARGET[kind];
 
 type Params = {
@@ -50,9 +50,9 @@ type TargetParams = {
 
 export const useTimelineOpen = ({
   sessionId,
-}: Params): ((params: TargetParams) => TimelineOpenTarget) =>
+}: Params): ((params: TargetParams) => TimelineOpenTarget | null) =>
   useCallback(
-    ({ entry }: TargetParams): TimelineOpenTarget => {
+    ({ entry }: TargetParams): TimelineOpenTarget | null => {
       const store = useAppStore.getState();
       if (entry.kind === 'run') {
         return {
@@ -95,6 +95,9 @@ export const useTimelineOpen = ({
       }
       if (entry.kind === 'event') {
         const target = eventOpenTarget({ kind: entry.event.kind });
+        if (target == null) {
+          return null;
+        }
         return {
           label: target.label,
           open: () => store.setActiveLens(sessionId, target.lens),


### PR DESCRIPTION
- the sync popover's "Compared with main" row is now the base branch editor: pencil on hover, in-place input, Enter/blur commits, empty clears back to auto-detect, Escape reverts (github's "base: main" edit, linear's inline property editing)
- "Detach project" confirms inline in the overflow menu, no dialog: clean worktree reads "will be removed", dirty reads "Uncommitted changes stay on disk at <path>" with a "Detach, keep changes" primary and a toast carrying the kept path; no discard option by design
- detached-project rows in the activity trace lose click, hover and the "Open overview" CTA; they are records, not links
- the rebase spawn toast gains "Open the rebase agent", focusing the agent it just spawned
- overview rhythm: gap-6 between sections, header band gap-3 with tighter metadata chips, mount rows at linear-list density (40px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)