### PR TITLE
chore(repo): bump version to 0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ version in the same PR that bumps the version numbers (see
 `docs/release-command.md`), before the tag is pushed: the release build fails
 if it can't find a matching `## Goodboy vX.Y.Z` heading.
 
+## Goodboy v0.2.4
+
+The board scales past a handful of projects and the overview earns its keep.
+
+### [#1558] One git pill however many projects you mount
+
+Three or more repository projects now share a single pill in the board
+header: a summed badge for everything that needs action, a warning when any
+checkout does, and a popover that lists every project sorted by urgency.
+One click drills into the full detail for a project: counts, base branch,
+fast-forward, open in editor. Two projects or fewer keep their own pills.
+When fast-forward is blocked, the reason now reads right under the button
+instead of hiding in a tooltip.
+
+### [#1559] Detach with confidence, edit the base where you see it
+
+Detaching a project now confirms inline: a clean worktree says it will be
+removed, uncommitted changes stay on disk with the path spelled out and a
+toast to find them later. The base branch is editable right on the
+"Compared with" row of the sync popover, where the comparison already
+lives. The rebase toast can open its agent the moment it starts, and
+detached-project rows in the trace stopped pretending to be links.
+
+Both surfaces also breathe better: a shared gutter, clearer section
+separation and denser project rows.
+
 ## Goodboy v0.2.3
 
 The board sheds its git banner and every project picks its own base branch.

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goodboy/desktop",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -1626,7 +1626,7 @@ dependencies = [
 
 [[package]]
 name = "goodboy-desktop"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goodboy-desktop"
-version = "0.2.3"
+version = "0.2.4"
 description = "Goodboy desktop app"
 authors = ["Amin Khayam"]
 license = "MIT"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Goodboy",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "identifier": "com.goodboy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goodboy",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": true,
   "description": "AI workspace orchestrator. Local-first, provider-agnostic.",
   "license": "MIT",

--- a/website/src/site.ts
+++ b/website/src/site.ts
@@ -1,5 +1,5 @@
 export const SITE = {
-  version: 'v0.2.3',
+  version: 'v0.2.4',
   repo: 'https://github.com/akhayam99/goodboy',
   releases: 'https://github.com/akhayam99/goodboy/releases',
   latest: 'https://github.com/akhayam99/goodboy/releases/latest',


### PR DESCRIPTION
Version bump plus the v0.2.4 changelog: aggregated board git pill (#1558), overview detach confirm + inline base branch edit + rhythm pass (#1559).

🤖 Generated with [Claude Code](https://claude.com/claude-code)