### PR TITLE
feat(core): smart session branch names from the prefix setting and task

### DIFF
--- a/apps/desktop/src-tauri/src/worktree.rs
+++ b/apps/desktop/src-tauri/src/worktree.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use thiserror::Error;
 
-const MAX_SLUG_LEN: usize = 40;
+const MAX_SLUG_LEN: usize = 48;
 
 #[derive(Debug, Error)]
 pub enum WorktreeError {
@@ -175,7 +175,7 @@ pub fn worktree_create(args: CreateArgs) -> Result<CreatedWorktree, WorktreeErro
         .map(str::trim)
         .filter(|s| !s.is_empty());
     let worktree_path = match explicit_dir {
-        Some(name) => parent.join(name),
+        Some(name) => parent.join(sanitize_slug(name)),
         None => parent.join(format!("{}-{dir_slug}", args.branch_prefix)),
     };
 

--- a/apps/desktop/src/store/slices/sessions/createSession.ts
+++ b/apps/desktop/src/store/slices/sessions/createSession.ts
@@ -28,10 +28,7 @@ import {
 import { tauriDatabase } from '../../../shared/lib/db';
 import { invokeAgentInsert } from '../../../features/workflows/workflows';
 import { kindRouting, AGENT_KIND_META, type AgentKind } from '../../../features/session/agent-kind';
-import {
-  SETTING_LAST_SESSION_ID,
-  DEFAULT_BRANCH_PREFIX,
-} from '../../../features/settings/settings';
+import { SETTING_LAST_SESSION_ID } from '../../../features/settings/settings';
 import { markSessionMobileShared } from '../../../features/companion/mobileConfinement';
 import { workSurfaceFocus } from '../session-view/workSurfaceFocus';
 import { clampTitle } from './titleLimit';
@@ -39,7 +36,6 @@ import { preSpawnWorkflowAgents } from '../workflows/preSpawnWorkflowAgents';
 import { discardUncreatedSession } from './discardUncreatedSession';
 import { rememberMaterializationSeed } from './materializationSeeds';
 import { resolveSessionProject } from './resolveSessionProject';
-import { slugifyDir } from './slugifyDir';
 import type { GetFn, SetFn } from './types';
 
 type ExternalTaskInput = {
@@ -100,9 +96,8 @@ export const createSession = (set: SetFn, get: GetFn) => {
     const projects = await listProjectsForWorkspace({ db: tauriDatabase, workspaceId });
     const project = projectId !== undefined ? resolveSessionProject({ projects, projectId }) : null;
 
-    const prefix = branchPrefix?.trim() || DEFAULT_BRANCH_PREFIX;
-    const slugSeed =
-      branchSlug?.trim() || (goal.trim().length > 0 ? goal : `session-${Date.now()}`);
+    const trimmedPrefix = branchPrefix?.trim();
+    const trimmedBranchSlug = branchSlug?.trim();
     const trimmedExisting = existingBranch?.trim();
     const trimmedFallbackRef = fallbackRef?.trim();
     const trimmedFolderName = folderName?.trim();
@@ -110,12 +105,22 @@ export const createSession = (set: SetFn, get: GetFn) => {
     if (mobileShared) {
       markSessionMobileShared(sessionId);
     }
-    const dirSlug = `${slugifyDir(slugSeed)}-${sessionId.slice(0, 8)}`;
+    const existingSeparator = trimmedExisting?.lastIndexOf('/') ?? -1;
+    const existingPrefix =
+      existingSeparator > 0 ? trimmedExisting?.slice(0, existingSeparator) : undefined;
     rememberMaterializationSeed({
       sessionId,
       seed: {
-        branchPrefix: prefix,
-        sessionSlug: branchSlug?.trim() ? slugifyDir(branchSlug) : dirSlug,
+        ...(trimmedPrefix !== undefined && trimmedPrefix !== ''
+          ? { branchPrefix: trimmedPrefix }
+          : existingPrefix !== undefined
+            ? { branchPrefix: existingPrefix }
+            : {}),
+        ...(trimmedBranchSlug !== undefined && trimmedBranchSlug !== ''
+          ? { sessionSlug: trimmedBranchSlug }
+          : trimmedExisting !== undefined && trimmedExisting !== ''
+            ? { sessionSlug: trimmedExisting }
+            : {}),
         ...(trimmedExisting !== undefined && trimmedExisting !== ''
           ? { existingBranch: trimmedExisting }
           : {}),
@@ -155,7 +160,7 @@ export const createSession = (set: SetFn, get: GetFn) => {
     const session: Session = {
       id: sessionId,
       workspaceId,
-      goal: clampTitle(goal.trim() || dirSlug),
+      goal: clampTitle(goal.trim()),
       state: initialState,
       contextSlots: [],
       providerPreference: providerPreference ?? inheritedPreference,
@@ -201,6 +206,7 @@ export const createSession = (set: SetFn, get: GetFn) => {
             trimmedExisting !== undefined && trimmedExisting !== ''
               ? `adopted existing branch ${trimmedExisting}`
               : 'the session works in this project',
+          taskIdentifiers: (externalTasks ?? []).map((task) => task.identifier),
         });
       } catch (error) {
         await discardUncreatedSession({ set, sessionId: session.id });
@@ -242,7 +248,7 @@ export const createSession = (set: SetFn, get: GetFn) => {
       });
     }
 
-    const goalText = omitGoalSlot ? '' : goal.trim() || dirSlug;
+    const goalText = omitGoalSlot ? '' : goal.trim();
     if (goalText.length > 0) {
       await upsertContextSlot(tauriDatabase, session.id, {
         key: 'goal',

--- a/apps/desktop/src/store/slices/sessions/deriveBranchName.test.ts
+++ b/apps/desktop/src/store/slices/sessions/deriveBranchName.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { deriveBranchName } from './deriveBranchName';
+
+const ID = '12345678-rest';
+
+describe('deriveBranchName', () => {
+  it('keeps an explicit seed slug untouched', () => {
+    expect(
+      deriveBranchName({
+        prefix: 'ak',
+        sessionId: ID,
+        goal: 'Ignored goal',
+        explicitSlug: 'Foreign_Feature/Exact',
+        taskIdentifiers: ['GRW-1'],
+      }),
+    ).toBe('Foreign_Feature/Exact');
+  });
+
+  it('builds a task slug without an id suffix and strips bracketed tokens', () => {
+    expect(
+      deriveBranchName({
+        prefix: 'ak',
+        sessionId: ID,
+        goal: '[GRW-1220] [FE] Applicare nuove icone alla navbar',
+        taskIdentifiers: ['GRW-1220'],
+      }),
+    ).toBe('grw-1220-applicare-nuove-icone-alla-navbar');
+  });
+
+  it('strips an unbracketed identifier from the goal case insensitively', () => {
+    expect(
+      deriveBranchName({
+        prefix: 'ak',
+        sessionId: ID,
+        goal: 'Fix grw-1220 navigation for GRW-1220',
+        taskIdentifiers: ['GRW-1220'],
+      }),
+    ).toBe('grw-1220-fix-navigation-for');
+  });
+
+  it('adds the id suffix when another live session owns the task branch', () => {
+    expect(
+      deriveBranchName({
+        prefix: 'ak',
+        sessionId: ID,
+        goal: 'Fix navigation',
+        taskIdentifiers: ['GRW-1220'],
+        existingBranches: ['ak/grw-1220-fix-navigation'],
+      }),
+    ).toBe('grw-1220-fix-navigation-12345678');
+  });
+
+  it('builds a goal slug with the id suffix', () => {
+    expect(deriveBranchName({ prefix: 'ak', sessionId: ID, goal: 'Build navigation' })).toBe(
+      'build-navigation-12345678',
+    );
+  });
+
+  it('uses a session slug for placeholder goals', () => {
+    expect(deriveBranchName({ prefix: 'ak', sessionId: ID, goal: 'Untitled session' })).toBe(
+      'session-12345678',
+    );
+    expect(deriveBranchName({ prefix: 'ak', sessionId: ID, goal: '' })).toBe('session-12345678');
+  });
+
+  it('caps the slug at a complete word before 48 characters', () => {
+    const slug = deriveBranchName({
+      prefix: 'ak',
+      sessionId: ID,
+      goal: 'Implement extraordinarily detailed navigation behavior across every workspace',
+    });
+    expect(slug).toBe('implement-extraordinarily-detailed-12345678');
+    expect(slug.length).toBeLessThanOrEqual(48);
+  });
+});

--- a/apps/desktop/src/store/slices/sessions/deriveBranchName.ts
+++ b/apps/desktop/src/store/slices/sessions/deriveBranchName.ts
@@ -1,0 +1,86 @@
+import { slugifyDir } from './slugifyDir';
+import { UNTITLED_BASE } from './untitledTitle';
+
+const MAX_SLUG_LENGTH = 48;
+const IDENTIFIER_MAX_LENGTH = 16;
+
+type Params = {
+  readonly prefix: string;
+  readonly sessionId: string;
+  readonly goal: string;
+  readonly explicitSlug?: string;
+  readonly taskIdentifiers?: ReadonlyArray<string>;
+  readonly existingBranches?: ReadonlyArray<string>;
+};
+
+const trimAtWord = ({
+  value,
+  maxLength,
+}: {
+  readonly value: string;
+  readonly maxLength: number;
+}) => {
+  if (value.length <= maxLength) {
+    return value;
+  }
+  const sliced = value.slice(0, maxLength + 1);
+  const boundary = sliced.lastIndexOf('-');
+  if (boundary > 0) {
+    return sliced.slice(0, boundary);
+  }
+  return value.slice(0, maxLength).replace(/-+$/g, '');
+};
+
+const withSuffix = ({
+  base,
+  suffix,
+}: {
+  readonly base: string;
+  readonly suffix: string;
+}): string => {
+  const maxBaseLength = MAX_SLUG_LENGTH - suffix.length - 1;
+  return `${trimAtWord({ value: base, maxLength: maxBaseLength })}-${suffix}`;
+};
+
+const taskSlug = ({ identifier, goal }: { readonly identifier: string; readonly goal: string }) => {
+  const normalizedIdentifier = trimAtWord({
+    value: slugifyDir(identifier).slice(0, IDENTIFIER_MAX_LENGTH).replace(/-+$/g, ''),
+    maxLength: IDENTIFIER_MAX_LENGTH,
+  });
+  const bracketlessGoal = goal.replace(/\[[^\]]*\]/g, ' ');
+  const escapedIdentifier = identifier.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const identifierlessGoal = bracketlessGoal.replace(new RegExp(escapedIdentifier, 'gi'), ' ');
+  const remainder = slugifyDir(identifierlessGoal);
+  return trimAtWord({
+    value: `${normalizedIdentifier}-${remainder}`,
+    maxLength: MAX_SLUG_LENGTH,
+  });
+};
+
+export const deriveBranchName = ({
+  prefix,
+  sessionId,
+  goal,
+  explicitSlug,
+  taskIdentifiers = [],
+  existingBranches = [],
+}: Params): string => {
+  if (explicitSlug !== undefined) {
+    return explicitSlug;
+  }
+  const id8 = sessionId.slice(0, 8);
+  const identifier = taskIdentifiers.find((candidate) => candidate.trim() !== '')?.trim();
+  if (identifier !== undefined) {
+    const candidate = taskSlug({ identifier, goal });
+    const branch = `${prefix}/${candidate}`;
+    if (!existingBranches.includes(branch)) {
+      return candidate;
+    }
+    return withSuffix({ base: candidate, suffix: id8 });
+  }
+  const trimmedGoal = goal.trim();
+  if (trimmedGoal === '' || trimmedGoal === UNTITLED_BASE) {
+    return `session-${id8}`;
+  }
+  return withSuffix({ base: slugifyDir(trimmedGoal), suffix: id8 });
+};

--- a/apps/desktop/src/store/slices/sessions/index.test.ts
+++ b/apps/desktop/src/store/slices/sessions/index.test.ts
@@ -37,6 +37,7 @@ import type {
   ProjectScript,
   ProjectScriptId,
 } from '@goodboy/types';
+import { materializationSeedFor } from './materializationSeeds';
 
 vi.mock('@tauri-apps/api/core', () => ({
   invoke: vi.fn(async () => null),
@@ -1276,6 +1277,140 @@ describe('store contract', () => {
 
       const kinds = vi.mocked(db.insertSessionEvent).mock.calls.map(([{ event }]) => event.kind);
       expect(kinds).toEqual(['project_materialized', 'external_task_created']);
+    });
+
+    it('passes task identifiers into the initial materialization', async () => {
+      const store = await getStore();
+      store.setState({ currentWorkspaceId: WS_ID });
+
+      await store.getState().createSession({
+        workspaceId: WS_ID,
+        projectId: PROJECT_ID,
+        goal: '[GRW-1220] [FE] Applicare nuove icone alla navbar',
+        externalTasks: [
+          {
+            provider: 'linear',
+            externalId: 'issue-1220',
+            identifier: 'GRW-1220',
+            url: 'https://linear.app/acme/issue/GRW-1220',
+            title: 'Applicare nuove icone alla navbar',
+          },
+        ],
+      });
+
+      expect(createWorktreeSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          slug: 'grw-1220-applicare-nuove-icone-alla-navbar',
+        }),
+      );
+    });
+
+    it('does not freeze the default prefix or ordinary slug in the seed', async () => {
+      const store = await getStore();
+      listProjectsForWorkspaceSpy.mockResolvedValueOnce([]);
+      store.setState({ currentWorkspaceId: WS_ID, projects: [] });
+
+      const { session } = await store
+        .getState()
+        .createSession({ workspaceId: WS_ID, goal: 'Study plan' });
+
+      expect(materializationSeedFor({ sessionId: session.id })).toEqual({});
+    });
+
+    it('uses the project branch prefix before the workspace prefix', async () => {
+      const store = await getStore();
+      const project = buildProject({
+        overrides: { ...buildWorkspace().overrides, defaultBranchPrefix: 'project-prefix' },
+      });
+      listProjectsForWorkspaceSpy.mockResolvedValueOnce([project]);
+      store.setState({
+        currentWorkspaceId: WS_ID,
+        projects: [project],
+        workspaceOverrides: {
+          [WS_ID]: { ...buildWorkspace().overrides, defaultBranchPrefix: 'workspace-prefix' },
+        },
+      });
+
+      await store.getState().createSession({
+        workspaceId: WS_ID,
+        projectId: PROJECT_ID,
+        goal: 'Study plan',
+      });
+
+      expect(createWorktreeSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ branchPrefix: 'project-prefix' }),
+      );
+    });
+
+    it('uses the workspace branch prefix when the project has none', async () => {
+      const store = await getStore();
+      store.setState({
+        currentWorkspaceId: WS_ID,
+        workspaceOverrides: {
+          [WS_ID]: { ...buildWorkspace().overrides, defaultBranchPrefix: 'workspace-prefix' },
+        },
+      });
+
+      await store.getState().createSession({
+        workspaceId: WS_ID,
+        projectId: PROJECT_ID,
+        goal: 'Study plan',
+      });
+
+      expect(createWorktreeSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ branchPrefix: 'workspace-prefix' }),
+      );
+    });
+
+    it('uses the session slug for an untitled mount', async () => {
+      const store = await getStore();
+      store.setState({ currentWorkspaceId: WS_ID });
+
+      const { session } = await store.getState().createSession({
+        workspaceId: WS_ID,
+        projectId: PROJECT_ID,
+        goal: 'Untitled session',
+      });
+
+      expect(createWorktreeSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ slug: `session-${session.id.slice(0, 8)}` }),
+      );
+    });
+
+    it('keeps an explicit branch slug untouched', async () => {
+      const store = await getStore();
+      store.setState({ currentWorkspaceId: WS_ID });
+
+      await store.getState().createSession({
+        workspaceId: WS_ID,
+        projectId: PROJECT_ID,
+        goal: 'Study plan',
+        branchSlug: 'Foreign_Feature/Exact',
+      });
+
+      expect(createWorktreeSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ slug: 'Foreign_Feature/Exact' }),
+      );
+    });
+
+    it('pins a foreign prefix and verbatim slug for existing branch adoption', async () => {
+      const store = await getStore();
+      store.setState({ currentWorkspaceId: WS_ID });
+
+      await store.getState().createSession({
+        workspaceId: WS_ID,
+        projectId: PROJECT_ID,
+        goal: 'Review parser fix',
+        existingBranch: 'alice/fix-parser',
+      });
+
+      expect(createWorktreeSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          branchPrefix: 'alice',
+          slug: 'alice/fix-parser',
+          existingBranch: 'alice/fix-parser',
+        }),
+      );
     });
   });
 

--- a/apps/desktop/src/store/slices/sessions/materializationSeeds.ts
+++ b/apps/desktop/src/store/slices/sessions/materializationSeeds.ts
@@ -1,8 +1,8 @@
 import type { SessionId } from '@goodboy/types';
 
 export type SessionMaterializationSeed = {
-  readonly branchPrefix: string;
-  readonly sessionSlug: string;
+  readonly branchPrefix?: string;
+  readonly sessionSlug?: string;
   readonly existingBranch?: string;
   readonly fallbackRef?: string;
   readonly folderName?: string;

--- a/apps/desktop/src/store/slices/sessions/materializeProject.ts
+++ b/apps/desktop/src/store/slices/sessions/materializeProject.ts
@@ -7,19 +7,20 @@ import {
   type SessionWorktree,
 } from '@goodboy/db';
 import { formatError } from '@goodboy/ui';
-import { detectRepoSlug } from '@goodboy/core';
+import { detectRepoSlug, resolveSettings } from '@goodboy/core';
 import { tauriDatabase } from '../../../shared/lib/db';
 import { tauriGhRunner } from '../../../features/github/github';
 import { createSessionDir, createWorktree } from '../../../features/worktree/worktree';
 import { DEFAULT_BRANCH_PREFIX } from '../../../features/settings/settings';
 import { consumeAdoptionSeed, materializationSeedFor } from './materializationSeeds';
-import { slugifyDir } from './slugifyDir';
+import { deriveBranchName } from './deriveBranchName';
 import type { GetFn, SetFn } from './types';
 
 export type MaterializeProjectInput = {
   readonly sessionId: SessionId;
   readonly projectId: ProjectId;
   readonly reason: string;
+  readonly taskIdentifiers?: ReadonlyArray<string>;
 };
 
 type StampRepoSlugParams = {
@@ -78,6 +79,7 @@ export const materializeProject = (set: SetFn, get: GetFn) => {
     sessionId,
     projectId,
     reason,
+    taskIdentifiers,
   }: MaterializeProjectInput): Promise<SessionProjectMount> => {
     const trimmedReason = reason.trim();
     if (trimmedReason === '') {
@@ -129,8 +131,45 @@ export const materializeProject = (set: SetFn, get: GetFn) => {
       return persistedMount;
     }
     const seed = materializationSeedFor({ sessionId });
-    const sessionSlug = seed?.sessionSlug ?? `${slugifyDir(session.goal)}-${sessionId.slice(0, 8)}`;
-    const prefix = seed?.branchPrefix ?? DEFAULT_BRANCH_PREFIX;
+    const resolved = resolveSettings({
+      global: {
+        defaultProviderId: session.providerPreference.defaultProvider,
+        defaultWorkflowId: null,
+        defaultBranchPrefix: DEFAULT_BRANCH_PREFIX,
+        parallelEnabled: false,
+        defaultVerbosity: 'normal',
+      },
+      workspaceOverride: get().workspaceOverrides[session.workspaceId] ?? null,
+      projectOverride: project.overrides,
+    });
+    const prefix = seed?.branchPrefix ?? resolved.defaultBranchPrefix;
+    const liveSessionIds: ReadonlySet<string> = new Set(
+      get()
+        .sessions.filter(
+          (candidate) =>
+            candidate.workspaceId === session.workspaceId && candidate.id !== sessionId,
+        )
+        .map((candidate) => candidate.id),
+    );
+    const recordBranches = Object.entries(get().sessionWorktreeRecords ?? {}).flatMap(
+      ([candidateId, records]) =>
+        liveSessionIds.has(candidateId) ? records.map((record) => record.branch) : [],
+    );
+    const mountBranches = Object.entries(get().sessionProjectMounts).flatMap(
+      ([candidateId, mounts]) =>
+        liveSessionIds.has(candidateId) ? mounts.map((mount) => mount.branch) : [],
+    );
+    const storedIdentifiers = (get().sessionExternalTasks[sessionId] ?? []).map(
+      (task) => task.identifier,
+    );
+    const sessionSlug = deriveBranchName({
+      prefix,
+      sessionId,
+      goal: session.goal,
+      ...(seed?.sessionSlug !== undefined ? { explicitSlug: seed.sessionSlug } : {}),
+      taskIdentifiers: storedIdentifiers.length > 0 ? storedIdentifiers : taskIdentifiers,
+      existingBranches: [...recordBranches, ...mountBranches],
+    });
     const hasRepoMount = rows.some((row) => row.projectId !== undefined && row.branch !== '');
     const adoptedBranch = hasRepoMount ? undefined : seed?.existingBranch;
     const adoptedFallbackRef = adoptedBranch === undefined ? undefined : seed?.fallbackRef;
@@ -143,7 +182,7 @@ export const materializeProject = (set: SetFn, get: GetFn) => {
               branchPrefix: prefix,
               slug: sessionSlug,
               parentDir: `${project.rootPath}/.goodboy/worktrees`,
-              dirName: sessionSlug,
+              ...(adoptedBranch === undefined ? { dirName: sessionSlug } : {}),
               baseBranch: project.baseBranch ?? undefined,
               ...(adoptedBranch !== undefined ? { existingBranch: adoptedBranch } : {}),
               ...(adoptedFallbackRef !== undefined ? { fallbackRef: adoptedFallbackRef } : {}),

--- a/apps/desktop/src/store/slices/sessions/untitledTitle.ts
+++ b/apps/desktop/src/store/slices/sessions/untitledTitle.ts
@@ -1,4 +1,4 @@
-const UNTITLED_BASE = 'Untitled session';
+export const UNTITLED_BASE = 'Untitled session';
 
 const UNTITLED_PATTERN = /^untitled session(?: (\d+))?$/i;
 

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -379,6 +379,7 @@ export type AppActions = {
     sessionId: SessionId;
     projectId: ProjectId;
     reason: string;
+    taskIdentifiers?: ReadonlyArray<string>;
   }): Promise<SessionProjectMount>;
   detachProject(input: { sessionId: SessionId; projectId: ProjectId }): Promise<void>;
   linkSessionExternalTask(

--- a/packages/core/src/settings/__tests__/resolver.test.ts
+++ b/packages/core/src/settings/__tests__/resolver.test.ts
@@ -113,6 +113,23 @@ describe('resolveSettings', () => {
     expect(result.defaultVerbosity).toBe('verbose');
   });
 
+  it('resolves session then project then workspace then global', () => {
+    const result = resolveSettings({
+      global: GLOBAL,
+      workspaceOverride: { ...NULL_OVERRIDE, defaultBranchPrefix: 'workspace' },
+      projectOverride: { ...NULL_OVERRIDE, defaultBranchPrefix: 'project' },
+    });
+    expect(result.defaultBranchPrefix).toBe('project');
+
+    const sessionResult = resolveSettings({
+      global: GLOBAL,
+      workspaceOverride: { ...NULL_OVERRIDE, defaultBranchPrefix: 'workspace' },
+      projectOverride: { ...NULL_OVERRIDE, defaultBranchPrefix: 'project' },
+      sessionOverride: { ...NULL_OVERRIDE, defaultBranchPrefix: 'session' },
+    });
+    expect(sessionResult.defaultBranchPrefix).toBe('session');
+  });
+
   it('null-fields session falls back to workspace', () => {
     const wsOverride: OverrideSettings = {
       defaultProviderId: 'cursor' as ProviderId,

--- a/packages/core/src/settings/resolver.ts
+++ b/packages/core/src/settings/resolver.ts
@@ -3,15 +3,24 @@ import type { GlobalSettings, OverrideSettings, ResolvedSettings } from '@goodbo
 export type ResolveSettingsInput = {
   readonly global: GlobalSettings;
   readonly workspaceOverride?: OverrideSettings | null;
+  readonly projectOverride?: OverrideSettings | null;
   readonly sessionOverride?: OverrideSettings | null;
 };
 
 export const resolveSettings = (input: ResolveSettingsInput): ResolvedSettings => {
-  const { global: g, workspaceOverride: ws, sessionOverride: sess } = input;
+  const {
+    global: g,
+    workspaceOverride: ws,
+    projectOverride: project,
+    sessionOverride: sess,
+  } = input;
 
   const resolvedWorkflowId = (() => {
     if (sess?.defaultWorkflowId !== undefined) {
       return sess.defaultWorkflowId;
+    }
+    if (project?.defaultWorkflowId !== undefined) {
+      return project.defaultWorkflowId;
     }
     if (ws?.defaultWorkflowId !== undefined) {
       return ws.defaultWorkflowId;
@@ -20,11 +29,23 @@ export const resolveSettings = (input: ResolveSettingsInput): ResolvedSettings =
   })();
 
   return {
-    defaultProviderId: sess?.defaultProviderId ?? ws?.defaultProviderId ?? g.defaultProviderId,
+    defaultProviderId:
+      sess?.defaultProviderId ??
+      project?.defaultProviderId ??
+      ws?.defaultProviderId ??
+      g.defaultProviderId,
     defaultWorkflowId: resolvedWorkflowId,
     defaultBranchPrefix:
-      sess?.defaultBranchPrefix ?? ws?.defaultBranchPrefix ?? g.defaultBranchPrefix,
-    parallelEnabled: sess?.parallelEnabled ?? ws?.parallelEnabled ?? g.parallelEnabled,
-    defaultVerbosity: sess?.defaultVerbosity ?? ws?.defaultVerbosity ?? g.defaultVerbosity,
+      sess?.defaultBranchPrefix ??
+      project?.defaultBranchPrefix ??
+      ws?.defaultBranchPrefix ??
+      g.defaultBranchPrefix,
+    parallelEnabled:
+      sess?.parallelEnabled ?? project?.parallelEnabled ?? ws?.parallelEnabled ?? g.parallelEnabled,
+    defaultVerbosity:
+      sess?.defaultVerbosity ??
+      project?.defaultVerbosity ??
+      ws?.defaultVerbosity ??
+      g.defaultVerbosity,
   };
 };

--- a/packages/core/src/worktree/slug.test.ts
+++ b/packages/core/src/worktree/slug.test.ts
@@ -14,9 +14,9 @@ describe('sanitizeSlug', () => {
     expect(sanitizeSlug('---hi---')).toBe('hi');
   });
 
-  it('truncates to max 40 chars without trailing hyphen', () => {
+  it('truncates to max 48 chars without trailing hyphen', () => {
     const long = 'a'.repeat(60);
-    expect(sanitizeSlug(long)).toHaveLength(40);
+    expect(sanitizeSlug(long)).toHaveLength(48);
   });
 
   it('falls back to a stable hash for empty input', () => {

--- a/packages/core/src/worktree/slug.ts
+++ b/packages/core/src/worktree/slug.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto';
 
-const MAX_SLUG_LENGTH = 40;
+const MAX_SLUG_LENGTH = 48;
 
 export const sanitizeSlug = (input: string): string => {
   const cleaned = input


### PR DESCRIPTION
A session linked to GRW-1220 mounted `goodboy/untitled-session-48c535d9`: the workspace branch-prefix setting was written by the UI but never read by any branch-creation path, and the slug froze at creation time before the auto-title or the linked task existed.

- prefix resolves at mount time through the core settings resolver, now project-aware: project override, then workspace, then global, then `goodboy`
- slug derives at mount: `grw-1220-applicare-nuove-icone-alla-navbar` (task identifier + goal with bracketed tokens and duplicate identifier stripped, 48-char word-boundary cap, collision-guarded), goal+id8 without a task, `session-<id8>` for untitled ones
- create-with-project passes its task identifiers into the first materialization instead of persisting them too late
- adoption and PR-review flows with explicit slugs and pinned prefixes stay byte-identical

Benchmark: Linear's copy-branch-name format (`user/grw-1220-title`), resolved at creation like vscode branch settings, no LLM involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)