### PR TITLE
feat(ui): scoped scripts entry, header shortcut and tidier script lists

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -682,6 +682,9 @@ export const App = () => {
     if (!id) {
       return;
     }
+    if (kind === 'scripts') {
+      s.setScriptsLensScope({ scope: null });
+    }
     s.setActiveLens(id, kind != null && s.activeLens[id] === kind ? null : kind);
   }, []);
 

--- a/apps/desktop/src/features/scripts/components/ScriptsPanel/ScriptRow.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsPanel/ScriptRow.tsx
@@ -150,7 +150,7 @@ export const ScriptRow = ({
           expanded ? 'grid-rows-[auto_auto] gap-y-2' : 'grid-rows-[auto]',
           presentation.borderClass,
           presentation.pulseClass,
-          expanded && 'bg-muted/20',
+          expanded ? 'bg-muted/20' : 'bg-card/40',
         )}
       >
         <div className="col-start-1 row-start-1 flex min-w-0 flex-col gap-0.5">

--- a/apps/desktop/src/features/scripts/components/ScriptsPanel/index.test.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsPanel/index.test.tsx
@@ -31,6 +31,8 @@ const { state } = vi.hoisted(() => ({
     deleteScript: vi.fn(async () => undefined),
     runScript: vi.fn(async () => undefined),
     cancelScript: vi.fn(async () => undefined),
+    scriptsLensScope: null as { readonly projectId: string } | null,
+    setScriptsLensScope: vi.fn(),
   },
 }));
 
@@ -47,6 +49,8 @@ vi.mock('../../../../store', () => {
     deleteScript: state.deleteScript,
     runScript: state.runScript,
     cancelScript: state.cancelScript,
+    scriptsLensScope: state.scriptsLensScope,
+    setScriptsLensScope: state.setScriptsLensScope,
   });
   const useAppStore = <T,>(selector: (storeState: ReturnType<typeof getStoreState>) => T) =>
     selector(getStoreState());
@@ -70,11 +74,70 @@ beforeEach(() => {
   state.deleteScript = vi.fn(async () => undefined);
   state.runScript = vi.fn(async () => undefined);
   state.cancelScript = vi.fn(async () => undefined);
+  state.scriptsLensScope = null;
+  state.setScriptsLensScope = vi.fn();
 });
 
 afterEach(cleanup);
 
 describe('ScriptsPanel', () => {
+  it('consumes a scoped open and preselects its project tab', () => {
+    state.projects = [
+      { id: 'project-1', workspaceId: 'ws-1', name: 'API' },
+      { id: 'project-2', workspaceId: 'ws-1', name: 'Web' },
+    ];
+    state.scriptsLensScope = { projectId: 'project-2' };
+    state.scripts = [
+      { id: 's1', projectId: 'project-1', name: 'setup api', body: 'echo api' },
+      { id: 's2', projectId: 'project-2', name: 'deploy web', body: 'echo web' },
+    ];
+
+    render(<ScriptsPanel workspaceId={'ws-1' as never} sessionId={'session-1' as never} />);
+
+    expect(screen.getByRole('tab', { name: 'Web' }).getAttribute('aria-selected')).toBe('true');
+    expect(screen.getByText('deploy web')).toBeDefined();
+    expect(screen.queryByText('setup api')).toBeNull();
+    expect(state.setScriptsLensScope).toHaveBeenCalledWith({ scope: null });
+  });
+
+  it('uses All for a generic open', () => {
+    state.projects = [
+      { id: 'project-1', workspaceId: 'ws-1', name: 'API' },
+      { id: 'project-2', workspaceId: 'ws-1', name: 'Web' },
+    ];
+    state.scripts = [
+      { id: 's1', projectId: 'project-1', name: 'setup api', body: 'echo api' },
+      { id: 's2', projectId: 'project-2', name: 'deploy web', body: 'echo web' },
+    ];
+
+    render(<ScriptsPanel workspaceId={'ws-1' as never} />);
+
+    expect(screen.getByRole('tab', { name: 'All' }).getAttribute('aria-selected')).toBe('true');
+    expect(screen.getByText('setup api')).toBeDefined();
+    expect(screen.getByText('deploy web')).toBeDefined();
+  });
+
+  it('orders project tabs, groups, and scripts alphabetically', () => {
+    state.projects = [
+      { id: 'project-2', workspaceId: 'ws-1', name: 'Web' },
+      { id: 'project-1', workspaceId: 'ws-1', name: 'API' },
+    ];
+    state.scripts = [
+      { id: 's2', projectId: 'project-1', name: 'zebra', body: 'echo z' },
+      { id: 's3', projectId: 'project-2', name: 'deploy', body: 'echo deploy' },
+      { id: 's1', projectId: 'project-1', name: 'Alpha', body: 'echo a' },
+    ];
+
+    render(<ScriptsPanel workspaceId={'ws-1' as never} />);
+
+    expect(screen.getAllByRole('tab').map((tab) => tab.textContent)).toEqual(['All', 'API', 'Web']);
+    expect(screen.getAllByRole('listitem').map((item) => item.textContent)).toEqual([
+      expect.stringContaining('Alpha'),
+      expect.stringContaining('zebra'),
+      expect.stringContaining('deploy'),
+    ]);
+  });
+
   it('loads scripts and renders the empty hint when none exist', () => {
     render(<ScriptsPanel workspaceId={'ws-1' as never} />);
 
@@ -129,6 +192,8 @@ describe('ScriptsPanel', () => {
     expect(screen.getByText('+1 line')).toBeDefined();
     fireEvent.click(screen.getByRole('button', { name: 'Expand setup' }));
 
+    expect(screen.getByTestId('script-card-s1').className).toContain('bg-muted/20');
+    expect(screen.getByTestId('script-card-s1').className).not.toContain('bg-card/40');
     expect(
       screen.getByText(
         (_, element) =>
@@ -246,6 +311,8 @@ describe('ScriptsPanel', () => {
 
     const row = screen.getByTestId('script-card-s1');
     expect(row.className).toContain('border-transparent');
+    expect(row.className).toContain('bg-card/40');
+    expect(row.className).not.toContain('bg-muted/20');
     expect(row.className).not.toContain('border-info/50');
     expect(row.className).not.toContain('border-success/40');
     expect(row.className).not.toContain('border-danger/40');

--- a/apps/desktop/src/features/scripts/components/ScriptsPanel/index.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsPanel/index.tsx
@@ -116,9 +116,16 @@ export const ScriptsPanel = ({ workspaceId, sessionId, hasHostHeading = false }:
   const [error, setError] = useState<string | null>(null);
   const [copiedId, setCopiedId] = useState<ProjectScriptId | null>(null);
   const [completedAt, setCompletedAt] = useState<Record<string, number>>({});
-  const [projectFilter, setProjectFilter] = useState<ProjectFilter>(
-    () => scriptsLensScope?.projectId ?? 'all',
-  );
+  const [projectFilter, setProjectFilter] = useState<ProjectFilter>(() => {
+    const scoped = scriptsLensScope?.projectId;
+    if (scoped == null) {
+      return 'all';
+    }
+    const belongs = allProjects.some(
+      (project) => project.id === scoped && project.workspaceId === workspaceId,
+    );
+    return belongs ? scoped : 'all';
+  });
 
   const runnable = sessionId != null;
   const list = scripts ?? [];

--- a/apps/desktop/src/features/scripts/components/ScriptsPanel/index.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsPanel/index.tsx
@@ -104,6 +104,8 @@ export const ScriptsPanel = ({ workspaceId, sessionId, hasHostHeading = false }:
   const deleteScript = useAppStore((state) => state.deleteScript);
   const runScript = useAppStore((state) => state.runScript);
   const cancelScript = useAppStore((state) => state.cancelScript);
+  const scriptsLensScope = useAppStore((state) => state.scriptsLensScope);
+  const setScriptsLensScope = useAppStore((state) => state.setScriptsLensScope);
   const runs = useAppStore((state) =>
     sessionId != null ? state.scriptRuns[sessionId] : undefined,
   );
@@ -114,7 +116,9 @@ export const ScriptsPanel = ({ workspaceId, sessionId, hasHostHeading = false }:
   const [error, setError] = useState<string | null>(null);
   const [copiedId, setCopiedId] = useState<ProjectScriptId | null>(null);
   const [completedAt, setCompletedAt] = useState<Record<string, number>>({});
-  const [projectFilter, setProjectFilter] = useState<ProjectFilter>('all');
+  const [projectFilter, setProjectFilter] = useState<ProjectFilter>(
+    () => scriptsLensScope?.projectId ?? 'all',
+  );
 
   const runnable = sessionId != null;
   const list = scripts ?? [];
@@ -135,29 +139,39 @@ export const ScriptsPanel = ({ workspaceId, sessionId, hasHostHeading = false }:
   const projectFilterOptions = useMemo<ReadonlyArray<SegmentedTabOption<ProjectFilter>>>(
     () => [
       { value: 'all', label: 'All' },
-      ...projects.map((project) => ({ value: project.id, label: project.name })),
+      ...[...projects]
+        .sort((left, right) => left.name.localeCompare(right.name))
+        .map((project) => ({ value: project.id, label: project.name })),
     ],
     [projects],
   );
   const groups = useMemo<ReadonlyArray<ScriptGroup>>(() => {
+    const sortScripts = (groupScripts: ReadonlyArray<ProjectScript>) =>
+      [...groupScripts].sort((left, right) =>
+        left.name.localeCompare(right.name, undefined, { sensitivity: 'base' }),
+      );
     if (!isMultiProject) {
-      return [{ key: 'all', label: null, scripts: list }];
+      return [{ key: 'all', label: null, scripts: sortScripts(list) }];
     }
     if (projectFilter !== 'all') {
       return [
         {
           key: projectFilter,
           label: null,
-          scripts: list.filter((script) => script.projectId === projectFilter),
+          scripts: sortScripts(list.filter((script) => script.projectId === projectFilter)),
         },
       ];
     }
-    return projects.flatMap((project) => {
-      const projectScripts = list.filter((script) => script.projectId === project.id);
-      return projectScripts.length === 0
-        ? []
-        : [{ key: project.id, label: project.name, scripts: projectScripts }];
-    });
+    return [...projects]
+      .sort((left, right) => left.name.localeCompare(right.name))
+      .flatMap((project) => {
+        const projectScripts = sortScripts(
+          list.filter((script) => script.projectId === project.id),
+        );
+        return projectScripts.length === 0
+          ? []
+          : [{ key: project.id, label: project.name, scripts: projectScripts }];
+      });
   }, [isMultiProject, list, projectFilter, projects]);
   const newDraftDirty =
     newDraft != null && (newDraft.name.trim() !== '' || newDraft.body.trim() !== '');
@@ -165,6 +179,10 @@ export const ScriptsPanel = ({ workspaceId, sessionId, hasHostHeading = false }:
   useEffect(() => {
     void loadScripts(workspaceId);
   }, [workspaceId, loadScripts]);
+
+  useEffect(() => {
+    setScriptsLensScope({ scope: null });
+  }, [setScriptsLensScope]);
 
   useEffect(() => {
     if (runs === undefined) {
@@ -425,13 +443,19 @@ export const ScriptsPanel = ({ workspaceId, sessionId, hasHostHeading = false }:
             action={newScriptAction}
           />
         ) : (
-          <div className="flex flex-col gap-3">
+          <div className="flex flex-col gap-4">
             {groups.map((group) => (
               <div key={group.key} className="flex flex-col gap-1.5">
                 {group.label != null ? (
-                  <span className="px-0.5 text-xs font-medium text-muted-foreground">
-                    {group.label}
-                  </span>
+                  <div className="flex items-center gap-2 px-0.5">
+                    <span className="text-2xs font-semibold uppercase tracking-wider text-muted-foreground/80">
+                      {group.label}
+                    </span>
+                    <span className="text-2xs tabular-nums text-muted-foreground/50">
+                      {group.scripts.length}
+                    </span>
+                    <span className="h-px flex-1 bg-border/40" aria-hidden />
+                  </div>
                 ) : null}
                 <ul className="flex flex-col gap-2">
                   {group.scripts.map((script) => {

--- a/apps/desktop/src/features/scripts/components/ScriptsSection/index.test.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsSection/index.test.tsx
@@ -17,6 +17,7 @@ type MockState = {
   runScript: ReturnType<typeof vi.fn>;
   cancelScript: ReturnType<typeof vi.fn>;
   setActiveLens: ReturnType<typeof vi.fn>;
+  setScriptsLensScope: ReturnType<typeof vi.fn>;
 };
 
 const { state } = vi.hoisted<{ state: MockState }>(() => ({
@@ -31,6 +32,7 @@ const { state } = vi.hoisted<{ state: MockState }>(() => ({
     runScript: vi.fn(async () => undefined),
     cancelScript: vi.fn(async () => undefined),
     setActiveLens: vi.fn(),
+    setScriptsLensScope: vi.fn(),
   },
 }));
 

--- a/apps/desktop/src/features/scripts/components/ScriptsSection/index.test.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsSection/index.test.tsx
@@ -73,6 +73,7 @@ describe('ScriptsSection', () => {
     render(<ScriptsSection sessionId={'sess-1' as never} workspaceId={'ws-1' as never} />);
     fireEvent.click(screen.getByText('Create script'));
     expect(state.setActiveLens).toHaveBeenCalledWith('sess-1', 'scripts');
+    expect(state.setScriptsLensScope).toHaveBeenCalledWith({ scope: null });
   });
 
   it('lists the workspace scripts', () => {

--- a/apps/desktop/src/features/scripts/components/ScriptsSection/index.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsSection/index.tsx
@@ -45,6 +45,7 @@ export const ScriptsSection = ({
   const runScript = useAppStore((s) => s.runScript);
   const cancelScript = useAppStore((s) => s.cancelScript);
   const setActiveLens = useAppStore((s) => s.setActiveLens);
+  const setScriptsLensScope = useAppStore((s) => s.setScriptsLensScope);
 
   useEffect(() => {
     void loadScripts(workspaceId);
@@ -72,7 +73,10 @@ export const ScriptsSection = ({
   const projects = allProjects.filter((project) => project.workspaceId === workspaceId);
   const isMultiProject = projects.length > 1;
 
-  const openScripts = () => setActiveLens(sessionId, 'scripts');
+  const openScripts = () => {
+    setScriptsLensScope({ scope: null });
+    setActiveLens(sessionId, 'scripts');
+  };
 
   const logScript = log ? list.find((s) => s.id === log.scriptId) : null;
   const logResult = log ? (runs?.[log.scriptId]?.result ?? null) : null;

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/HeaderBand.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/HeaderBand.test.tsx
@@ -2,7 +2,7 @@
 
 import type { ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import type { Session } from '@goodboy/types';
 
 const { store } = vi.hoisted(() => ({
@@ -11,6 +11,7 @@ const { store } = vi.hoisted(() => ({
     clearPendingTitleFocus: vi.fn(),
     sessionGithub: {},
     sessionExternalTasks: {},
+    setScriptsLensScope: vi.fn(),
   },
 }));
 
@@ -67,14 +68,22 @@ describe('HeaderBand', () => {
   beforeEach(() => {
     store.pendingTitleFocusSessionId = null;
     store.clearPendingTitleFocus.mockClear();
+    store.setScriptsLensScope.mockClear();
   });
 
-  it('puts mount with the title actions and removes terminal and scripts shortcuts', () => {
-    render(<HeaderBand session={session} onSelectLens={vi.fn()} goal={<div>Goal</div>} />);
+  it('puts Scripts first in the title actions and opens it without scope', () => {
+    const onSelectLens = vi.fn();
+    render(<HeaderBand session={session} onSelectLens={onSelectLens} goal={<div>Goal</div>} />);
 
     expect(screen.getByRole('button', { name: 'Mount a project' })).toBeDefined();
     expect(screen.queryByRole('button', { name: /terminal/i })).toBeNull();
-    expect(screen.queryByRole('button', { name: /scripts/i })).toBeNull();
+    const scripts = screen.getByRole('button', { name: 'Scripts' });
+    expect(scripts.parentElement?.firstElementChild).toBe(scripts);
+
+    fireEvent.click(scripts);
+
+    expect(store.setScriptsLensScope).toHaveBeenCalledWith({ scope: null });
+    expect(onSelectLens).toHaveBeenCalledWith('scripts');
   });
 
   it('renders mounted projects before the goal', () => {

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/HeaderBand.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/HeaderBand.tsx
@@ -11,6 +11,7 @@ import { LinkIssueAction } from './LinkIssueAction';
 import { ContextChip } from './ContextChip';
 import { LinkedWorkChips } from './LinkedWorkChips';
 import { MountProjectAction } from './ProjectMountRows/MountProjectAction';
+import { CONCEPT_ICONS } from '../../../../shared/components/conceptIcons';
 import { ProjectMountRows } from './ProjectMountRows';
 import { SessionCostChip } from './SessionCostChip';
 
@@ -20,11 +21,15 @@ type Props = {
   readonly goal: ReactNode;
 };
 
+const ICON_BUTTON =
+  'inline-flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground motion-safe:transition-colors hover:bg-muted/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]';
+
 export const HeaderBand = ({ session, onSelectLens, goal }: Props) => {
   const sessionId = session.id as SessionId;
   const rename = useSessionTitleRename({ sessionId, currentTitle: session.goal });
   const pendingTitleFocus = useAppStore((s) => s.pendingTitleFocusSessionId);
   const clearPendingTitleFocus = useAppStore((s) => s.clearPendingTitleFocus);
+  const setScriptsLensScope = useAppStore((s) => s.setScriptsLensScope);
   const hasLinkedWork = useAppStore((s) => {
     const linkedIssues = s.sessionGithub[sessionId]?.linkedIssues ?? EMPTY_ARRAY;
     const externalTasks = s.sessionExternalTasks[sessionId] ?? EMPTY_ARRAY;
@@ -53,6 +58,11 @@ export const HeaderBand = ({ session, onSelectLens, goal }: Props) => {
   }, [rename.editing]);
 
   const goalText = session.goal === '' ? 'Untitled session' : session.goal;
+
+  const openScripts = () => {
+    setScriptsLensScope({ scope: null });
+    onSelectLens('scripts');
+  };
 
   return (
     <div className="flex flex-col gap-3">
@@ -93,6 +103,16 @@ export const HeaderBand = ({ session, onSelectLens, goal }: Props) => {
           </Tooltip>
         )}
         <div className="flex shrink-0 items-center gap-1">
+          <Tooltip content="Scripts (⌘⌥S)">
+            <button
+              type="button"
+              aria-label="Scripts"
+              onClick={openScripts}
+              className={ICON_BUTTON}
+            >
+              <CONCEPT_ICONS.scripts size={13} aria-hidden />
+            </button>
+          </Tooltip>
           <EditorMenu sessionId={sessionId} density="compact" />
           <MountProjectAction sessionId={sessionId} workspaceId={session.workspaceId} />
           <SessionDestructiveActions session={session} />

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectMountRow.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectMountRow.tsx
@@ -39,6 +39,7 @@ export const ProjectMountRow = ({
   onSelectLens,
 }: Props) => {
   const setSessionActiveProject = useAppStore((state) => state.setSessionActiveProject);
+  const setScriptsLensScope = useAppStore((state) => state.setScriptsLensScope);
   const openMountDiff = useAppStore((state) => state.openMountDiff);
   const GlyphIcon = project?.kind === 'repo' ? FolderGit2 : Folder;
   const projectName = project?.name ?? mount.mountName;
@@ -46,6 +47,9 @@ export const ProjectMountRow = ({
 
   const openLens = async ({ lens }: { readonly lens: LensKind }) => {
     await setSessionActiveProject({ sessionId, projectId: mount.projectId });
+    if (lens === 'scripts') {
+      setScriptsLensScope({ scope: { projectId: mount.projectId } });
+    }
     onSelectLens(lens);
   };
   return (

--- a/apps/desktop/src/store/slices/session-view/createInitialSessionViewState.ts
+++ b/apps/desktop/src/store/slices/session-view/createInitialSessionViewState.ts
@@ -1,6 +1,7 @@
 type Params = Record<string, never>;
 
 export const createInitialSessionViewState = ({}: Params) => ({
+  scriptsLensScope: null,
   sessionViewPrefs: {},
   activeLens: {},
   lensHistory: {},

--- a/apps/desktop/src/store/slices/session-view/index.ts
+++ b/apps/desktop/src/store/slices/session-view/index.ts
@@ -38,6 +38,7 @@ export type {
 export const createSessionViewSlice = (set: SetFn, get: GetFn): SessionViewSlice => {
   return {
     ...createInitialSessionViewState({}),
+    setScriptsLensScope: ({ scope }) => set({ scriptsLensScope: scope }),
     getSessionViewPrefs: getSessionViewPrefs(set, get),
     setSessionSort: setSessionSort(set, get),
     setSessionGroup: setSessionGroup(set, get),

--- a/apps/desktop/src/store/slices/session-view/types.ts
+++ b/apps/desktop/src/store/slices/session-view/types.ts
@@ -126,6 +126,7 @@ export type SessionCreation = {
 };
 
 type SessionViewSliceState = {
+  readonly scriptsLensScope: { readonly projectId: ProjectId } | null;
   readonly sessionViewPrefs: Readonly<Record<WorkspaceId, SessionViewPrefs>>;
   readonly activeLens: Readonly<Record<SessionId, LensKind | null>>;
   readonly lensHistory: Readonly<Record<SessionId, LensHistory>>;
@@ -141,6 +142,7 @@ type SessionViewSliceState = {
 };
 
 type SessionViewSliceActions = {
+  setScriptsLensScope(params: { readonly scope: { readonly projectId: ProjectId } | null }): void;
   getSessionViewPrefs(workspaceId: WorkspaceId): SessionViewPrefs;
   setSessionSort(workspaceId: WorkspaceId, sort: SessionSortKey): void;
   setSessionGroup(workspaceId: WorkspaceId, group: SessionGroupKey): void;

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -835,6 +835,7 @@ export type AppActions = {
   runPlan(sessionId: SessionId, planId: PlanId): Promise<AgentId | null>;
   dismissSessionNudge(sessionId: SessionId, outcome?: 'accepted' | 'dismissed'): Promise<void>;
   acceptSessionNudgeHandoff(sessionId: SessionId): Promise<AgentId | null>;
+  setScriptsLensScope(params: { readonly scope: { readonly projectId: ProjectId } | null }): void;
   getSessionViewPrefs(workspaceId: WorkspaceId): SessionViewPrefs;
   setSessionSort(workspaceId: WorkspaceId, sort: SessionSortKey): void;
   setSessionGroup(workspaceId: WorkspaceId, group: SessionGroupKey): void;

--- a/apps/desktop/src/store/types.ts
+++ b/apps/desktop/src/store/types.ts
@@ -311,6 +311,7 @@ export type AppState = AppSliceState & {
   readonly sessionNudges: Readonly<Record<SessionId, SessionNudge | null>>;
   readonly sessionLoading: Readonly<Record<SessionId, SessionLoadingFlags>>;
   readonly boardReady: boolean;
+  readonly scriptsLensScope: { readonly projectId: ProjectId } | null;
   readonly sessionViewPrefs: Readonly<Record<WorkspaceId, SessionViewPrefs>>;
   readonly activeLens: Readonly<Record<SessionId, LensKind | null>>;
   readonly lensHistory: Readonly<Record<SessionId, LensHistory>>;


### PR DESCRIPTION
- the scripts button on an overview project row now opens the scripts lens filtered to that project (one-shot `scriptsLensScope` handoff, cleared on consume; preselected tab, All one click away). Sidebar Create script and ⌘⌥S keep opening on All
- the overview header action cluster regains a Scripts shortcut (leftmost ghost icon, opens All): the per-project row buttons open scoped views, nothing else could reach the workspace-wide list. Terminal deliberately not re-added, it is per-project by nature
- project tabs, project groups and scripts inside each group sort alphabetically (same localeCompare convention as the project filter)
- hierarchy pass instead of identity colors: group headers get label + count + hairline, collapsed rows sit on a tonal card surface, wider group gaps. Run-state borders remain the only color accent

Benchmark: linear project-scoped filters and group headers; vscode npm-scripts explorer alphabetical ordering; github repo-level Actions tab argument for the header entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)