### PR TITLE
fix(ui): lanes get sequential identity colors clear of primary

### DIFF
--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRunLabel.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRunLabel.test.tsx
@@ -42,7 +42,7 @@ const entryOf = ({
     at: '2026-08-18T09:00:00Z',
     run: { id: runId, goal, discardedAt },
     workflow: { name, origin: ORIGIN_OF[kind] },
-    identity: runIdentity({ runId }),
+    identity: runIdentity({ runId, laneIndex: 0 }),
     children: [],
     producedPlan: null,
   }) as unknown as TimelineRunEntry;
@@ -64,7 +64,7 @@ describe('TimelineRunLabel', () => {
     render(<TimelineRunLabel entry={entryOf()} />);
     const { className } = chipOf();
 
-    expect(className).toContain(runIdentity({ runId: 'run-7' }).chip);
+    expect(className).toContain(runIdentity({ runId: 'run-7', laneIndex: 0 }).chip);
     for (const tone of ['primary', 'accent', 'success', 'danger', 'warning', 'info']) {
       expect(className).not.toContain(`bg-${tone}`);
       expect(className).not.toContain(`text-${tone}`);
@@ -105,7 +105,7 @@ describe('TimelineRunLabel', () => {
     render(<TimelineRunLabel entry={entryOf()} />);
 
     expect(screen.getByText('Refactor (example)').className).toContain('text-foreground');
-    expect(chipOf().className).toContain(runIdentity({ runId: 'run-7' }).chip);
+    expect(chipOf().className).toContain(runIdentity({ runId: 'run-7', laneIndex: 0 }).chip);
   });
 
   it('reads a discarded run in the muted register the discard event next to it uses', () => {
@@ -120,13 +120,13 @@ describe('TimelineRunLabel', () => {
   it('hollows the chip of a discarded run without spending a word on it', () => {
     render(<TimelineRunLabel entry={entryOf({ discardedAt: '2026-08-18T10:00:00Z' })} />);
 
-    expect(chipOf().className).toContain(runIdentity({ runId: 'run-7' }).mutedChip);
-    expect(chipOf().className).not.toContain(runIdentity({ runId: 'run-7' }).chip);
+    expect(chipOf().className).toContain(runIdentity({ runId: 'run-7', laneIndex: 0 }).mutedChip);
+    expect(chipOf().className).not.toContain(runIdentity({ runId: 'run-7', laneIndex: 0 }).chip);
     expect(screen.queryByText('Discarded')).toBeNull();
   });
 
   it('keeps the run identity hue on a discarded run so it stays that run', () => {
-    const { mutedChip } = runIdentity({ runId: 'run-7' });
+    const { mutedChip } = runIdentity({ runId: 'run-7', laneIndex: 0 });
 
     render(<TimelineRunLabel entry={entryOf({ discardedAt: '2026-08-18T10:00:00Z' })} />);
 

--- a/apps/desktop/src/features/session/timeline/agentCreation.ts
+++ b/apps/desktop/src/features/session/timeline/agentCreation.ts
@@ -14,7 +14,7 @@ type EvidenceParams = {
   readonly agent: Agent;
 };
 
-const earliestEvidence = ({ agent }: EvidenceParams): string | null => {
+export const earliestEvidence = ({ agent }: EvidenceParams): string | null => {
   const known: ReadonlyArray<string> = [agent.startedAt, agent.completedAt].filter(
     (value): value is NonNullable<typeof value> => value != null,
   );

--- a/apps/desktop/src/features/session/timeline/buildTimelineGroups.test.ts
+++ b/apps/desktop/src/features/session/timeline/buildTimelineGroups.test.ts
@@ -264,15 +264,53 @@ describe('buildTimelineGroups', () => {
     ).toEqual(['2', '1']);
   });
 
-  it('gives a run a stable identity colour derived from its id', () => {
-    const first = build({ workflows: [attachedWorkflow()], agents: [] });
-    const second = build({ workflows: [attachedWorkflow()], agents: [] });
-    const firstRun = first.entries[0];
-    const secondRun = second.entries[0];
-
-    expect(firstRun?.kind === 'run' ? firstRun.identity.stroke : null).toBe(
-      secondRun?.kind === 'run' ? secondRun.identity.stroke : undefined,
+  it('assigns runs distinct slots in creation order', () => {
+    const model = build({
+      workflows: [
+        attachedWorkflow({ createdAt: '2026-08-17T08:00:00Z' }),
+        attachedWorkflow({ runId: OTHER_RUN_ID, createdAt: '2026-08-17T09:00:00Z' }),
+      ],
+      agents: [],
+    });
+    const identities = model.entries.flatMap((entry) =>
+      entry.kind === 'run' ? [[entry.run.id, entry.identity.index] satisfies [string, number]] : [],
     );
+
+    expect(identities).toEqual([
+      ['run-2', 1],
+      ['run-1', 0],
+    ]);
+  });
+
+  it('keeps existing run identities when a later run is appended', () => {
+    const firstTwo = [
+      attachedWorkflow({ createdAt: '2026-08-17T08:00:00Z' }),
+      attachedWorkflow({ runId: OTHER_RUN_ID, createdAt: '2026-08-17T09:00:00Z' }),
+    ];
+    const before = build({ workflows: firstTwo, agents: [] });
+    const after = build({
+      workflows: [
+        ...firstTwo,
+        attachedWorkflow({
+          runId: typedString<WorkflowRunId>({ value: 'run-3' }),
+          createdAt: '2026-08-17T10:00:00Z',
+        }),
+      ],
+      agents: [],
+    });
+    const indexesOf = ({ model }: { readonly model: ReturnType<typeof build> }) =>
+      new Map(
+        model.entries.flatMap((entry) =>
+          entry.kind === 'run'
+            ? [[entry.run.id, entry.identity.index] satisfies [string, number]]
+            : [],
+        ),
+      );
+    const beforeIndexes = indexesOf({ model: before });
+    const afterIndexes = indexesOf({ model: after });
+
+    expect(afterIndexes.get(WORKFLOW_RUN_ID)).toBe(beforeIndexes.get(WORKFLOW_RUN_ID));
+    expect(afterIndexes.get(OTHER_RUN_ID)).toBe(beforeIndexes.get(OTHER_RUN_ID));
   });
 
   it('nests a sub-agent under its parent with the parent ordinal as its prefix', () => {
@@ -561,6 +599,31 @@ describe('buildTimelineGroups, session events', () => {
 });
 
 describe('buildTimelineGroups, agent chains', () => {
+  it('shares one creation-ordered identity sequence across runs and chains', () => {
+    const model = build({
+      workflows: [
+        attachedWorkflow({ createdAt: '2026-08-17T08:00:00Z' }),
+        attachedWorkflow({ runId: OTHER_RUN_ID, createdAt: '2026-08-17T10:00:00Z' }),
+      ],
+      agents: [
+        agent({ id: 'planner', ordinal: 0, startedAt: '2026-08-17T09:00:00Z' }),
+        agent({
+          id: 'implementer',
+          ordinal: 1,
+          parentAgentId: 'planner',
+          startedAt: '2026-08-17T09:30:00Z',
+        }),
+      ],
+    });
+    const firstRun = model.entries.find((entry) => entry.id === 'run:run-1');
+    const chain = model.entries.find((entry) => entry.id === 'agent:planner');
+    const secondRun = model.entries.find((entry) => entry.id === 'run:run-2');
+
+    expect(firstRun?.kind === 'run' ? firstRun.identity.index : null).toBe(0);
+    expect(chain?.kind === 'agent' ? chain.chain?.identity.index : null).toBe(1);
+    expect(secondRun?.kind === 'run' ? secondRun.identity.index : null).toBe(2);
+  });
+
   it('marks a standalone agent with descendants as a chain without renaming it', () => {
     const model = build({
       agents: [

--- a/apps/desktop/src/features/session/timeline/buildTimelineGroups.ts
+++ b/apps/desktop/src/features/session/timeline/buildTimelineGroups.ts
@@ -119,6 +119,11 @@ type SortableEntry = {
   readonly id: string;
 };
 
+type LaneOwner = {
+  readonly id: string;
+  readonly createdAt: string | null;
+};
+
 const timestampForWorktree = ({ worktree }: WorktreeParams): string =>
   new Date(worktree.createdAt).toISOString();
 
@@ -180,6 +185,32 @@ export const buildTimelineGroups = ({
     const siblings = childrenByParentId.get(agent.parentAgentId) ?? [];
     childrenByParentId.set(agent.parentAgentId, [...siblings, agent]);
   }
+
+  const chainRoots = byOrdinal.filter(
+    (agent) => agent.parentAgentId == null && (childrenByParentId.get(agent.id) ?? []).length > 0,
+  );
+  const laneOwners: ReadonlyArray<LaneOwner> = [
+    ...workflows.flatMap(({ run }) =>
+      run.createdAt == null ? [] : [{ id: run.id, createdAt: run.createdAt }],
+    ),
+    ...chainRoots.map((agent) => ({
+      id: agent.id,
+      createdAt: creations.get(agent.id)?.at ?? null,
+    })),
+  ].sort(
+    (first, second) =>
+      (first.createdAt ?? '').localeCompare(second.createdAt ?? '') ||
+      first.id.localeCompare(second.id),
+  );
+  const laneIndexById = new Map(laneOwners.map((owner, laneIndex) => [owner.id, laneIndex]));
+
+  const identityFor = ({ runId }: { readonly runId: string }): RunIdentity => {
+    const laneIndex = laneIndexById.get(runId);
+    if (laneIndex === undefined) {
+      throw new Error(`lane identity is missing for ${runId}`);
+    }
+    return runIdentity({ runId, laneIndex });
+  };
 
   const stepsByRunId = new Map<string, ReadonlyArray<Agent>>();
   for (const agent of byOrdinal) {
@@ -261,7 +292,7 @@ export const buildTimelineGroups = ({
         at: run.createdAt,
         run,
         workflow,
-        identity: runIdentity({ runId: run.id }),
+        identity: identityFor({ runId: run.id }),
         children,
         producedPlan,
       },
@@ -285,7 +316,7 @@ export const buildTimelineGroups = ({
       return buildAgentEntry({
         agent,
         stepLabel: null,
-        chain: hasDescendants ? { identity: runIdentity({ runId: agent.id }) } : null,
+        chain: hasDescendants ? { identity: identityFor({ runId: agent.id }) } : null,
       });
     });
   const standalonePlans: ReadonlyArray<TimelinePlanEntry> = plans

--- a/apps/desktop/src/features/session/timeline/buildTimelineGroups.ts
+++ b/apps/desktop/src/features/session/timeline/buildTimelineGroups.ts
@@ -10,7 +10,7 @@ import type {
 } from '@goodboy/types';
 import { classifyAgent, type AgentKind } from '../agent-kind';
 import { attachedQuestionsFor } from './attachedQuestions';
-import { resolveAgentCreation, type AgentCreation } from './agentCreation';
+import { earliestEvidence, resolveAgentCreation, type AgentCreation } from './agentCreation';
 import { runIdentity, type RunIdentity } from './runIdentity';
 
 export type TimelineChain = {
@@ -195,11 +195,11 @@ export const buildTimelineGroups = ({
     ),
     ...chainRoots.map((agent) => ({
       id: agent.id,
-      createdAt: creations.get(agent.id)?.at ?? null,
+      createdAt: earliestEvidence({ agent }),
     })),
   ].sort(
     (first, second) =>
-      (first.createdAt ?? '').localeCompare(second.createdAt ?? '') ||
+      (first.createdAt ?? '￿').localeCompare(second.createdAt ?? '￿') ||
       first.id.localeCompare(second.id),
   );
   const laneIndexById = new Map(laneOwners.map((owner, laneIndex) => [owner.id, laneIndex]));

--- a/apps/desktop/src/features/session/timeline/buildTimelineStream.test.ts
+++ b/apps/desktop/src/features/session/timeline/buildTimelineStream.test.ts
@@ -26,7 +26,6 @@ import { buildTimelineGroups } from './buildTimelineGroups';
 import { buildTimelineStream, type TimelineStreamItem } from './buildTimelineStream';
 import { dayLabel } from './dayLabel';
 import { layoutTimelineRail } from './railGeometry';
-import { runIdentity } from './runIdentity';
 import { markerCenterY, TIMELINE_RHYTHM } from './timelineRhythm';
 
 type TypedStringParams = {
@@ -623,10 +622,7 @@ describe('buildTimelineStream', () => {
       'entry:run:run-1',
     ]);
     expect(clusters.map(({ item }) => item.groupId)).toEqual(['lane:run:run-2', 'lane:run:run-1']);
-    expect(clusters.map(({ item }) => item.identity.index)).toEqual([
-      runIdentity({ runId: OTHER_RUN_ID }).index,
-      runIdentity({ runId: RUN_ID }).index,
-    ]);
+    expect(clusters.map(({ item }) => item.identity.index)).toEqual([1, 0]);
     expect(clusters.every(({ rail }) => rail?.markerColumn === 0)).toBe(true);
     expect(
       new Set(clusters.flatMap(({ rail }) => rail?.joins.map((join) => join.laneColumn) ?? []))

--- a/apps/desktop/src/features/session/timeline/runIdentity.test.ts
+++ b/apps/desktop/src/features/session/timeline/runIdentity.test.ts
@@ -2,18 +2,21 @@ import { describe, expect, it } from 'vitest';
 import { runIdentity, runIdentityStroke } from './runIdentity';
 
 describe('runIdentity', () => {
-  it('is stable for the same run id', () => {
-    expect(runIdentity({ runId: 'run-1' })).toEqual(runIdentity({ runId: 'run-1' }));
+  it('maps a lane index to its palette slot', () => {
+    expect(runIdentity({ runId: 'run-1', laneIndex: 0 }).index).toBe(0);
+    expect(runIdentity({ runId: 'run-2', laneIndex: 1 }).index).toBe(1);
   });
 
-  it('separates two runs that a stage colour would have merged', () => {
-    expect(runIdentity({ runId: 'run-1' }).stroke).not.toBe(runIdentity({ runId: 'run-2' }).stroke);
+  it('cycles the five-slot palette', () => {
+    expect(runIdentity({ runId: 'run-wrap', laneIndex: 5 })).toEqual(
+      runIdentity({ runId: 'run-1', laneIndex: 0 }),
+    );
   });
 
   it('never borrows a semantic tone', () => {
     const tones = ['success', 'danger', 'warning', 'info', 'accent', 'plan', 'neutral'];
     for (let index = 0; index < 40; index += 1) {
-      const identity = runIdentity({ runId: `run-${index}` });
+      const identity = runIdentity({ runId: `run-${index}`, laneIndex: index });
       expect(tones.some((tone) => identity.stroke.includes(tone))).toBe(false);
       expect(tones.some((tone) => identity.chip.includes(tone))).toBe(false);
       expect(identity.stroke.startsWith('var(--color-run-')).toBe(true);
@@ -21,7 +24,7 @@ describe('runIdentity', () => {
   });
 
   it('offers the same identity to a chip as to its lane', () => {
-    const identity = runIdentity({ runId: 'run-7' });
+    const identity = runIdentity({ runId: 'run-7', laneIndex: 4 });
     const slot = identity.index + 1;
 
     expect(identity.stroke).toBe(`var(--color-run-${slot})`);
@@ -29,7 +32,7 @@ describe('runIdentity', () => {
   });
 
   it('reads a lane stroke back from the index the geometry carries', () => {
-    const identity = runIdentity({ runId: 'run-7' });
+    const identity = runIdentity({ runId: 'run-7', laneIndex: 4 });
 
     expect(runIdentityStroke({ index: identity.index })).toBe(identity.stroke);
   });

--- a/apps/desktop/src/features/session/timeline/runIdentity.ts
+++ b/apps/desktop/src/features/session/timeline/runIdentity.ts
@@ -36,24 +36,15 @@ const IDENTITIES: ReadonlyArray<RunIdentity> = [
     mutedChip: 'bg-transparent text-run-5 ring-run-5/20',
     index: 4,
   },
-  {
-    stroke: 'var(--color-run-6)',
-    chip: 'bg-run-6/12 text-run-6 ring-run-6/35',
-    mutedChip: 'bg-transparent text-run-6 ring-run-6/20',
-    index: 5,
-  },
 ];
 
 type Params = {
   readonly runId: string;
+  readonly laneIndex: number;
 };
 
-export const runIdentity = ({ runId }: Params): RunIdentity => {
-  let hash = 0;
-  for (let position = 0; position < runId.length; position += 1) {
-    hash = (hash * 31 + runId.charCodeAt(position)) % 1_000_003;
-  }
-  const identity = IDENTITIES[hash % IDENTITIES.length];
+export const runIdentity = ({ runId: _runId, laneIndex }: Params): RunIdentity => {
+  const identity = IDENTITIES[laneIndex % IDENTITIES.length];
   if (identity === undefined) {
     throw new Error('run identity palette is empty');
   }

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -71,12 +71,11 @@
      describing its state.      Only the timeline spine reads from it, and it is
      deliberately outside the ten tones so a violet spine is never a plan.
      See packages/ui/DESIGN-SYSTEM.md, "The one identity exception". */
-  --color-run-1: oklch(0.68 0.17 12);
+  --color-run-1: oklch(0.68 0.17 320);
   --color-run-2: oklch(0.72 0.15 65);
-  --color-run-3: oklch(0.7 0.15 130);
-  --color-run-4: oklch(0.7 0.12 190);
-  --color-run-5: oklch(0.66 0.16 265);
-  --color-run-6: oklch(0.68 0.17 330);
+  --color-run-3: oklch(0.7 0.15 120);
+  --color-run-4: oklch(0.66 0.16 265);
+  --color-run-5: oklch(0.68 0.17 12);
 
   --color-agent-generic: oklch(0.71 0.16 17);
   --color-agent-scout: oklch(0.74 0.13 233);
@@ -334,12 +333,11 @@ html[data-theme='light'] {
   --color-workspace-6: oklch(0.52 0.13 140);
   --color-workspace-7: oklch(0.5 0.17 25);
   --color-workspace-8: oklch(0.5 0.12 220);
-  --color-run-1: oklch(0.53 0.18 12);
-  --color-run-2: oklch(0.55 0.15 65);
-  --color-run-3: oklch(0.5 0.15 130);
-  --color-run-4: oklch(0.52 0.12 190);
-  --color-run-5: oklch(0.5 0.17 265);
-  --color-run-6: oklch(0.52 0.18 330);
+  --color-run-1: oklch(0.52 0.18 320);
+  --color-run-2: oklch(0.55 0.14 75);
+  --color-run-3: oklch(0.5 0.15 120);
+  --color-run-4: oklch(0.5 0.17 265);
+  --color-run-5: oklch(0.53 0.18 12);
   --color-agent-generic: oklch(0.52 0.16 17);
   --color-agent-scout: oklch(0.52 0.13 233);
   --color-agent-planner: oklch(0.5 0.16 295);

--- a/packages/ui/DESIGN-SYSTEM.md
+++ b/packages/ui/DESIGN-SYSTEM.md
@@ -135,10 +135,10 @@ readable as part of that run at a glance, and stage cannot carry that: two
 workflows running at once are both `info`, which is exactly the pair a reader
 needs to tell apart.
 
-So the lane of a run takes an **identity** colour from a six-entry palette,
-`--color-run-1` to `--color-run-6` in `apps/desktop/src/styles.css`, picked
-deterministically from the run id so it is stable across reloads and across
-sessions. `runIdentity` in
+So the lane of a run takes an **identity** colour from a five-entry palette,
+`--color-run-1` to `--color-run-5` in `apps/desktop/src/styles.css`, assigned
+sequentially across workflow runs and agent chains by creation time and id.
+`runIdentity` in
 `apps/desktop/src/features/session/timeline/runIdentity.ts` is the only accessor.
 It hands out exactly two readings of one slot: `stroke` for an SVG lane and
 `chip` for the run's own chip, and `runIdentityStroke` beside it resolves a


### PR DESCRIPTION
Two workflows in one session drew the same lane color (1-in-6 hash collision) and both read as primary in a page already full of primary.

- assignment: hash replaced by sequential creation order over the session's full set of workflow runs and agent chains, sorted `(createdAt, id)`; new runs append, existing lanes never recolor, no collisions until six concurrent lanes
- palette: six slots become five, the teal slot (hue 190, vs primary 210) is deleted; violet leads (nudged to 320), amber's light variant moves off the light-theme warning hue, green moves off success; blue and red keep their values
- order violet, amber, green, blue, red: the everyday single-workflow trace reads identity, not status, and the common two-lane case gets near-complementary contrast

Benchmark: vscode bracket-pair colorization (sequential, cycling); linear and slack parking identity on violet because it carries no semantic load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)