### PR TITLE
fix(core): open the codex sandbox to git metadata and the query bridge

### DIFF
--- a/apps/desktop/src-tauri/src/query_bridge/mod.rs
+++ b/apps/desktop/src-tauri/src/query_bridge/mod.rs
@@ -46,6 +46,10 @@ fn socket_path() -> Option<&'static Path> {
         .as_deref()
 }
 
+pub(crate) fn socket_directory() -> Option<&'static Path> {
+    socket_path()?.parent()
+}
+
 fn abandoned_sockets<'a>(
     file_names: impl Iterator<Item = &'a str>,
     is_alive: &dyn Fn(u32) -> bool,

--- a/apps/desktop/src-tauri/src/turn.rs
+++ b/apps/desktop/src-tauri/src/turn.rs
@@ -401,8 +401,11 @@ pub fn turn_spawn(
             model: &args.model,
             working_dir: &args.working_dir,
             writable_roots: &args.writable_roots,
-            query_socket_directory: crate::query_bridge::socket_directory()
-                .and_then(|path| path.to_str()),
+            query_socket_directory: if crate::query_bridge::is_serving() {
+                crate::query_bridge::socket_directory().and_then(|path| path.to_str())
+            } else {
+                None
+            },
             prompt: &args.prompt,
             permission_mode: &permission_mode,
             allowed_tools: &args.allowed_tools,

--- a/apps/desktop/src-tauri/src/turn.rs
+++ b/apps/desktop/src-tauri/src/turn.rs
@@ -48,6 +48,8 @@ pub struct SpawnArgs {
     pub run_id: String,
     pub model: String,
     pub working_dir: String,
+    #[serde(default)]
+    pub writable_roots: Vec<String>,
     pub prompt: String,
     #[serde(default)]
     pub binary: Option<String>,
@@ -178,6 +180,14 @@ fn build_provider_cli_args(binary: &str, args: &SpawnOneArgs<'_>) -> Vec<String>
             } else {
                 v.push("-s".to_string());
                 v.push("workspace-write".to_string());
+                for root in args.writable_roots {
+                    v.push("--add-dir".to_string());
+                    v.push(root.to_string());
+                }
+                if let Some(socket_directory) = args.query_socket_directory {
+                    v.push("--add-dir".to_string());
+                    v.push(socket_directory.to_string());
+                }
             }
             if let Some(eff) = args.effort {
                 v.push("-c".to_string());
@@ -263,6 +273,8 @@ struct SpawnOneArgs<'a> {
     pub binary: &'a str,
     pub model: &'a str,
     pub working_dir: &'a str,
+    pub writable_roots: &'a [String],
+    pub query_socket_directory: Option<&'a str>,
     pub prompt: &'a str,
     pub permission_mode: &'a str,
     pub allowed_tools: &'a [String],
@@ -388,6 +400,9 @@ pub fn turn_spawn(
             binary,
             model: &args.model,
             working_dir: &args.working_dir,
+            writable_roots: &args.writable_roots,
+            query_socket_directory: crate::query_bridge::socket_directory()
+                .and_then(|path| path.to_str()),
             prompt: &args.prompt,
             permission_mode: &permission_mode,
             allowed_tools: &args.allowed_tools,
@@ -509,6 +524,8 @@ mod tests {
             binary: "echo",
             model: "claude-3",
             working_dir: "/tmp",
+            writable_roots: &[],
+            query_socket_directory: Some("/tmp/goodboy-query"),
             prompt: "hello",
             permission_mode: "default",
             allowed_tools: &allowed,
@@ -537,6 +554,8 @@ mod tests {
             binary: "claude",
             model: "claude-3",
             working_dir: "/tmp",
+            writable_roots: empty,
+            query_socket_directory: Some("/tmp/goodboy-query"),
             prompt: "hi",
             permission_mode: "default",
             allowed_tools: empty,
@@ -623,6 +642,16 @@ mod tests {
     }
 
     #[test]
+    fn claude_args_ignore_writable_directories() {
+        let empty: Vec<String> = vec![];
+        let roots = vec!["/repo/one/.git".to_string()];
+        let mut args = make_args(None, None, &empty);
+        args.writable_roots = &roots;
+        let cli = build_provider_cli_args("claude", &args);
+        assert!(!cli.iter().any(|arg| arg == "--add-dir"));
+    }
+
+    #[test]
     fn codex_args_use_cd_not_cwd() {
         let empty: Vec<String> = vec![];
         let args = make_args(None, None, &empty);
@@ -644,10 +673,21 @@ mod tests {
     #[test]
     fn codex_args_default_to_workspace_write_sandbox() {
         let empty: Vec<String> = vec![];
-        let args = make_args(None, None, &empty);
+        let roots = vec!["/repo/one/.git".to_string(), "/repo/two/.git".to_string()];
+        let mut args = make_args(None, None, &empty);
+        args.writable_roots = &roots;
         let cli = build_provider_cli_args("codex", &args);
         let idx = cli.iter().position(|a| a == "-s").expect("-s");
         assert_eq!(cli[idx + 1], "workspace-write");
+        let added_directories: Vec<&str> = cli
+            .windows(2)
+            .filter(|pair| pair[0] == "--add-dir")
+            .map(|pair| pair[1].as_str())
+            .collect();
+        assert_eq!(
+            added_directories,
+            vec!["/repo/one/.git", "/repo/two/.git", "/tmp/goodboy-query"]
+        );
         assert!(!cli
             .iter()
             .any(|a| a == "--dangerously-bypass-approvals-and-sandbox"));
@@ -733,6 +773,7 @@ mod tests {
             .iter()
             .any(|a| a == "--dangerously-bypass-approvals-and-sandbox"));
         assert!(!cli.iter().any(|a| a == "-s"));
+        assert!(!cli.iter().any(|a| a == "--add-dir"));
         assert!(cli.iter().any(|a| a == "--skip-git-repo-check"));
     }
 
@@ -782,6 +823,8 @@ mod tests {
             binary: "codex",
             model: "gpt-5.5",
             working_dir: "/tmp",
+            writable_roots: &[],
+            query_socket_directory: Some("/tmp/goodboy-query"),
             prompt: "say hello",
             permission_mode: "default",
             allowed_tools: &allowed,

--- a/apps/desktop/src/features/chat/turn.test.ts
+++ b/apps/desktop/src/features/chat/turn.test.ts
@@ -54,6 +54,7 @@ describe('runTurn', () => {
       provider: 'anthropic',
       model: 'claude-sonnet-4-6',
       workingDir: '/tmp/worktree',
+      writableRoots: [],
       prompt: 'hello',
     })[Symbol.asyncIterator]();
 
@@ -79,6 +80,7 @@ describe('runTurn', () => {
       provider: 'cursor',
       model: 'gpt-5.5-high',
       workingDir: '/tmp/worktree',
+      writableRoots: [],
       prompt: 'hello',
     })[Symbol.asyncIterator]();
 
@@ -116,6 +118,7 @@ describe('runTurn', () => {
       provider: 'cursor',
       model: 'gpt-5.6-sol-high',
       workingDir: '/tmp/worktree',
+      writableRoots: [],
       prompt: 'hello',
     })[Symbol.asyncIterator]();
 
@@ -165,6 +168,7 @@ describe('runTurn', () => {
       provider: 'cursor',
       model: 'gpt-5.6-sol-high',
       workingDir: '/tmp/worktree',
+      writableRoots: [],
       prompt: 'hello',
     })[Symbol.asyncIterator]();
 
@@ -194,6 +198,7 @@ describe('runTurn', () => {
       provider: 'cursor',
       model: 'gpt-5.5-high',
       workingDir: '/tmp/worktree',
+      writableRoots: [],
       prompt: 'hello',
     })[Symbol.asyncIterator]();
 

--- a/apps/desktop/src/features/chat/turn.ts
+++ b/apps/desktop/src/features/chat/turn.ts
@@ -83,6 +83,7 @@ type SpawnArgs = {
   readonly provider: ProviderId;
   readonly model: string;
   readonly workingDir: string;
+  readonly writableRoots: ReadonlyArray<string>;
   readonly prompt: string;
   readonly binary?: string;
   readonly allowedTools?: ReadonlyArray<string>;

--- a/apps/desktop/src/store/scopeGuard.test.ts
+++ b/apps/desktop/src/store/scopeGuard.test.ts
@@ -74,6 +74,9 @@ describe('buildScopeGuard', () => {
     expect(guard).toContain('- web (repo) root: /tmp/web | NOT materialized');
     expect(guard).toContain('You may READ the project root paths listed above.');
     expect(guard).toContain('<<materialize: <project name> | <why you need it>>>');
+    expect(guard).toContain(
+      'After emitting the marker, end your turn. The mount is ready on the next one.',
+    );
     expect(guard).not.toContain('GOODBOY_BIN');
   });
 
@@ -90,6 +93,7 @@ describe('buildScopeGuard', () => {
       .filter((line) => line.includes('<<materialize:') || line.includes('GOODBOY_BIN'));
     expect(materializeLines).toHaveLength(1);
     expect(materializeLines[0]).toContain('query project materialize');
+    expect(guard).not.toContain('After emitting the marker, end your turn.');
   });
 
   it('suppresses the materialize instruction for kinds that cannot write', () => {

--- a/apps/desktop/src/store/scopeGuard.ts
+++ b/apps/desktop/src/store/scopeGuard.ts
@@ -32,7 +32,7 @@ const materializeLine = ({ isBridgeServing }: MaterializeLineParams): string => 
   const marker =
     'Based on the goal, identify and materialize every relevant project before writing. To materialize a project marked NOT materialized, emit on its own line: <<materialize: <project name> | <why you need it>>> and the mount is ready from your next turn.';
   if (!isBridgeServing) {
-    return marker;
+    return `${marker} After emitting the marker, end your turn. The mount is ready on the next one.`;
   }
   return `${marker} For an immediate mount, run \`"$GOODBOY_BIN" query project materialize <name> --reason "<why you need it>"\`; it prints the mount path and branch.`;
 };

--- a/apps/desktop/src/store/slices/turn/sendTurn.ts
+++ b/apps/desktop/src/store/slices/turn/sendTurn.ts
@@ -767,6 +767,11 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
       .filter((block) => block.length > 0)
       .join('\n\n');
     const fullSystemPrompt = kindSystemPrompt ? `${guards}\n\n${kindSystemPrompt}` : guards;
+    const writableRoots = Array.from(
+      new Set(
+        scopeMounts.filter((mount) => mount.branch !== '').map((mount) => `${mount.repoRoot}/.git`),
+      ),
+    );
 
     if (provider !== 'anthropic') {
       resolvedPrompt = `${guards}\n\n${
@@ -784,6 +789,7 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
         provider,
         model: spawnModel,
         workingDir,
+        writableRoots,
         prompt: resolvedPrompt,
         binary: providerInfo?.binary,
         workspaceId: session.workspaceId,
@@ -1189,6 +1195,16 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
       await insertMessage(tauriDatabase, assistantMessage);
     }
 
+    if (!turnWasCancelled && assistantText.length > 0) {
+      await captureMaterializeRequestsFromTurn({
+        get,
+        sessionId,
+        agentId: activeAgentId,
+        runId,
+        assistantText,
+      });
+    }
+
     if (!lastError && !turnWasCancelled && assistantText.length > 0) {
       enqueueSummarizer(set, get, sessionId, resolvedPrompt, assistantText);
       const capturedPlan = await capturePlanFromTurn(
@@ -1203,13 +1219,6 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
         sessionId,
         agentId: activeAgentId,
         agentKind: earlyAgentKind,
-        assistantText,
-      });
-      await captureMaterializeRequestsFromTurn({
-        get,
-        sessionId,
-        agentId: activeAgentId,
-        runId,
         assistantText,
       });
       void emitTurnNudges(set, get, sessionId, activeAgentId, assistantText, capturedPlan);

--- a/apps/desktop/src/store/store.story-materialize-on-demand.test.ts
+++ b/apps/desktop/src/store/store.story-materialize-on-demand.test.ts
@@ -131,6 +131,7 @@ describe('story: an agent works from its own project and reads the others', () =
     expect(storySpies.createWorktree).not.toHaveBeenCalled();
     expect(storySpies.scratchDirPrepare).not.toHaveBeenCalled();
     expect(spawnedArgs()['workingDir']).toBe(APP_MOUNT_PATH);
+    expect(spawnedArgs()['writableRoots']).toEqual(['/tmp/app/.git']);
     const systemPrompt = String(spawnedArgs()['systemPrompt']);
     expect(systemPrompt).toContain('[worktree-scope]');
     expect(systemPrompt).toContain(
@@ -140,6 +141,19 @@ describe('story: an agent works from its own project and reads the others', () =
     expect(systemPrompt).not.toContain('NOT materialized');
     expect(useAppStore.getState().sessionBranches[SESSION_ID]).toBe(APP_BRANCH);
     expect(recordedEventKinds()).not.toContain('project_materialized');
+  });
+
+  it('passes deduplicated repository git directories and excludes folder mounts', async () => {
+    seedSession([appProject, webProject]);
+    useAppStore.setState({
+      sessionProjectMounts: {
+        [SESSION_ID]: [appMount, appMount, { ...webMount, branch: '' }],
+      },
+    } as never);
+
+    await useAppStore.getState().sendTurn({ sessionId: SESSION_ID, content: 'go' });
+
+    expect(spawnedArgs()['writableRoots']).toEqual(['/tmp/app/.git']);
   });
 
   it('teaches the materialize marker for the projects that are not mounted yet', async () => {
@@ -269,6 +283,28 @@ describe('story: an agent asks for write access with the materialize marker', ()
     });
     expect(useAppStore.getState().sessionBranches[SESSION_ID]).toBe(APP_BRANCH);
     expect(stripControlMarkers(assistantText)).not.toContain('<<materialize');
+  });
+
+  it('mounts the requested project when the provider fails after emitting the marker', async () => {
+    seedSession([appProject, webProject]);
+    storySpies.createWorktree.mockResolvedValueOnce({
+      worktreePath: WEB_MOUNT_PATH,
+      branchName: WEB_BRANCH,
+      slug: 'goal-12345678',
+      reused: false,
+    } as never);
+    storySpies.runTurn.mockImplementation(async function* failedTurn() {
+      yield* assistantTurnStream('<<materialize: web | need to patch the router>>')();
+      throw new Error('provider failed after responding');
+    });
+
+    await expect(
+      useAppStore.getState().sendTurn({ sessionId: SESSION_ID, content: 'go' }),
+    ).rejects.toThrow('provider failed after responding');
+
+    expect(storySpies.createWorktree).toHaveBeenCalledWith(
+      expect.objectContaining({ repoPath: '/tmp/web' }),
+    );
   });
 
   it('refuses an unknown project name and notes it inline for the user', async () => {


### PR DESCRIPTION
Codex agents in session worktrees died on every commit: `.git/worktrees/<n>/index.lock: Operation not permitted`. Two clusters reproduced it today, each burning ~190k tokens of retries before a manual switch to Claude. Same root cause kept the in-turn query bridge unreachable, so mounts requested via the `<<materialize>>` marker never appeared mid-run.

- the turn spawn threads every repo mount's `<repoRoot>/.git` plus the query-bridge socket directory into codex `--add-dir` writable roots (workspace-write only; bypass unchanged; claude untouched)
- the materialize capture no longer skips failed turns: the failing turn is typically exactly the sandbox-denied one, and materialization is idempotent and workspace-scoped
- the "end your turn after emitting" marker guidance renders only for providers without the live bridge

Benchmark: git worktrees keep metadata and objects in the shared git dir by design; the sandbox has to follow the tool's actual write set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)