### PR TITLE
fix(ui): put the chain glyph back beside the chip label

### DIFF
--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRowLabel.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRowLabel.test.tsx
@@ -150,8 +150,8 @@ describe('TimelineRowLabel', () => {
       isChained: true,
     });
 
-    expect(container.querySelector('svg')?.classList.contains('absolute')).toBe(true);
-    expect(screen.getByText(AGENT_KIND_META.planner.label).className).toContain('justify-center');
+    expect(container.querySelector('svg')).not.toBeNull();
+    expect(container.querySelector('svg')?.classList.contains('absolute')).toBe(false);
   });
 
   it('marks a chained descendant too, on the step row it lives on', () => {

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRowLabel.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRowLabel.tsx
@@ -81,16 +81,12 @@ const chipOf = ({ entry, grade }: ChipParams) => {
     <Chip
       tone="neutral"
       label={palette.label}
-      icon={
-        isChained ? (
-          <CONCEPT_ICONS.chain className="absolute left-1.5" size={10} aria-hidden />
-        ) : null
-      }
+      icon={isChained ? <CONCEPT_ICONS.chain size={10} aria-hidden /> : null}
       shape="badge"
       size="3xs"
       width="md"
       uppercase
-      className={cn('relative shrink-0', palette.fg)}
+      className={cn('shrink-0', palette.fg)}
     />
   );
 };


### PR DESCRIPTION
Reverts the absolute-positioned chain icon from #1548: the icon overlapped the label on IMPLEMENT/DEBUG chips. Back to the inline icon-beside-text layout the Chip primitive gives by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)