### PR TITLE
feat(ui): pausing autorun lets the step in flight finish

### DIFF
--- a/apps/desktop/src/features/workflows/components/OrchestratorPanel/index.test.tsx
+++ b/apps/desktop/src/features/workflows/components/OrchestratorPanel/index.test.tsx
@@ -158,7 +158,7 @@ describe('OrchestratorPanel state ladder', () => {
   it('says where the run got to before offering the next decision', () => {
     renderPanel({ agents: [agent(0, 'completed'), agent(1, 'completed')] });
 
-    expect(sentence()).toContain('Step 2 done · ready to continue');
+    expect(sentence()).toContain('Paused · autorun is off');
     fireEvent.click(screen.getByTestId('workflow-orchestrate-next-cta'));
 
     expect(storeState['orchestrateNextStep']).toHaveBeenCalledWith(SESSION_ID, RUN_ID);
@@ -209,6 +209,7 @@ describe('OrchestratorPanel state ladder', () => {
   it('names the step it waits on and how long it has been running', () => {
     const startedAt = new Date(Date.now() - 90_000).toISOString() as IsoDateTime;
     renderPanel({
+      runOverride: run({ autoRun: true }),
       agents: [
         agent(0, 'completed'),
         agent(1, 'running', { name: 'implement language-id remap', startedAt }),
@@ -219,6 +220,30 @@ describe('OrchestratorPanel state ladder', () => {
     expect(screen.getByTestId('orchestrator-elapsed').textContent).toContain('1m 30s');
     expect(screen.getByTestId('orchestrator-panel').className).not.toContain('spin-border');
     expect(screen.queryByTestId('workflow-orchestrate-next-cta')).toBeNull();
+  });
+
+  it('confirms Stop now and dispatches the hard stop while autorun is on', () => {
+    renderPanel({
+      runOverride: run({ autoRun: true }),
+      agents: [agent(0, 'running')],
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Stop now' }));
+
+    const confirm = screen.getByRole('group', { name: 'Stop now?' });
+    expect(confirm.textContent).toContain(
+      'The step in flight is cancelled and marked skipped. Everything it already wrote is kept.',
+    );
+    fireEvent.click(within(confirm).getByRole('button', { name: 'Stop now' }));
+
+    expect(storeState['stopWorkflowRunNow']).toHaveBeenCalledWith(SESSION_ID, RUN_ID);
+  });
+
+  it('keeps Stop now available during a graceful pause', () => {
+    renderPanel({ agents: [agent(0, 'running')] });
+
+    expect(sentence()).toContain('Finishing the step in flight · autorun is off');
+    expect(screen.getByRole('button', { name: 'Stop now' })).toBeDefined();
   });
 
   it('sends the user to the questions lens when one gates the run', () => {
@@ -292,7 +317,7 @@ describe('OrchestratorPanel state ladder', () => {
       agents: [agent(0, 'completed')],
     });
 
-    expect(sentence()).toContain('ready to continue');
+    expect(sentence()).toContain('Paused · autorun is off');
     fireEvent.click(screen.getByTestId('workflow-orchestrate-next-cta'));
 
     expect(storeState['orchestrateNextStep']).toHaveBeenCalledWith(SESSION_ID, RUN_ID);

--- a/apps/desktop/src/features/workflows/components/OrchestratorPanel/index.tsx
+++ b/apps/desktop/src/features/workflows/components/OrchestratorPanel/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   CircleHelp,
   CircleStop,
@@ -101,6 +101,12 @@ export const OrchestratorPanel = ({
   const pulseTone = state.tone === 'neutral' ? 'info' : state.tone;
   const isRunOver = state.phase === 'done';
   const isStepInFlight = isOrchestrating || agents.some((agent) => agent.status === 'running');
+  const showStopNow = isStepInFlight && run.orchestrationStop?.kind !== 'operator';
+  useEffect(() => {
+    if (!showStopNow) {
+      setIsStopArmed(false);
+    }
+  }, [showStopNow]);
 
   const guard = async (action: () => Promise<void>) => {
     if (busy) {
@@ -276,7 +282,7 @@ export const OrchestratorPanel = ({
               <Markdown text={state.detail} className="text-2xs leading-relaxed" />
             </div>
           ) : null}
-          {isStepInFlight && run.orchestrationStop?.kind !== 'operator' ? (
+          {showStopNow ? (
             <div className="relative flex">
               <button
                 type="button"

--- a/apps/desktop/src/features/workflows/components/OrchestratorPanel/index.tsx
+++ b/apps/desktop/src/features/workflows/components/OrchestratorPanel/index.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import {
   CircleHelp,
+  CircleStop,
   Eraser,
   PenLine,
   Play,
@@ -9,7 +10,7 @@ import {
   Users,
   Wallet,
 } from 'lucide-react';
-import { Eyebrow, Markdown, StatusDot, cn, tintClasses } from '@goodboy/ui';
+import { Eyebrow, InlineConfirm, Markdown, StatusDot, cn, tintClasses } from '@goodboy/ui';
 import { CONCEPT_ICONS } from '../../../../shared/components/conceptIcons';
 import type {
   Agent,
@@ -71,6 +72,7 @@ export const OrchestratorPanel = ({
   const [hintsDraft, setHintsDraft] = useState(run.orchestratorHints ?? '');
   const [continueNote, setContinueNote] = useState('');
   const [busy, setBusy] = useState(false);
+  const [isStopArmed, setIsStopArmed] = useState(false);
   const savedHints = run.orchestratorHints ?? '';
   const continueOpen = openDrawer === 'continue';
   const hintsOpen = openDrawer === 'hints';
@@ -91,7 +93,11 @@ export const OrchestratorPanel = ({
   const elapsed = useElapsedLabel({ since: state.waitingSince });
   const tint = tintClasses(state.tone);
   const isDeciding = state.phase === 'deciding';
-  const isPulsing = isDeciding || state.phase === 'automatic' || state.phase === 'stopping';
+  const isPulsing =
+    isDeciding ||
+    state.phase === 'automatic' ||
+    state.phase === 'stopping' ||
+    state.phase === 'stopping-graceful';
   const pulseTone = state.tone === 'neutral' ? 'info' : state.tone;
   const isRunOver = state.phase === 'done';
   const isStepInFlight = isOrchestrating || agents.some((agent) => agent.status === 'running');
@@ -270,6 +276,34 @@ export const OrchestratorPanel = ({
               <Markdown text={state.detail} className="text-2xs leading-relaxed" />
             </div>
           ) : null}
+          {isStepInFlight && run.orchestrationStop?.kind !== 'operator' ? (
+            <div className="relative flex">
+              <button
+                type="button"
+                aria-expanded={isStopArmed}
+                onClick={() => setIsStopArmed(true)}
+                className="rounded px-1.5 text-2xs text-danger hover:bg-danger/10"
+              >
+                Stop now
+              </button>
+              {isStopArmed ? (
+                <div className="absolute left-0 top-full z-popover w-72 rounded-lg bg-background shadow-lg">
+                  <InlineConfirm
+                    role="alert"
+                    icon={<CircleStop size={12} aria-hidden />}
+                    title="Stop now?"
+                    description="The step in flight is cancelled and marked skipped. Everything it already wrote is kept."
+                    confirmLabel="Stop now"
+                    onConfirm={() => {
+                      setIsStopArmed(false);
+                      void stopWorkflowRunNow(sessionId, run.id);
+                    }}
+                    onCancel={() => setIsStopArmed(false)}
+                  />
+                </div>
+              ) : null}
+            </div>
+          ) : null}
         </div>
 
         <div className="flex shrink-0 flex-wrap items-center justify-end gap-1.5">
@@ -277,9 +311,7 @@ export const OrchestratorPanel = ({
             <WorkflowAutorunToggle
               variant="detail"
               isOn={run.autoRun === true}
-              isStepInFlight={isStepInFlight}
               onToggle={() => void setWorkflowRunAutoRun(sessionId, run.id, run.autoRun !== true)}
-              onStopNow={() => void stopWorkflowRunNow(sessionId, run.id)}
             />
           )}
           {primaryAction}

--- a/apps/desktop/src/features/workflows/components/OrchestratorPanel/orchestratorState.test.ts
+++ b/apps/desktop/src/features/workflows/components/OrchestratorPanel/orchestratorState.test.ts
@@ -80,6 +80,22 @@ describe('resolveOrchestratorState', () => {
     expect(state.sentence).toBe('Stopping · waiting for the decision already in flight');
   });
 
+  it('reports a graceful pause while a step finishes with autorun off', () => {
+    const state = resolve({ agents: [makeAgent(0, 'running')] });
+
+    expect(state.phase).toBe('stopping-graceful');
+    expect(state.tone).toBe('neutral');
+    expect(state.sentence).toBe('Finishing the step in flight · autorun is off');
+  });
+
+  it('reports a normal pause after the graceful step finishes', () => {
+    const state = resolve({ agents: [makeAgent(0, 'completed')] });
+
+    expect(state.phase).toBe('ready-mid');
+    expect(state.tone).toBe('neutral');
+    expect(state.sentence).toBe('Paused · autorun is off');
+  });
+
   it('never claims the run is stopped before the decision returns', () => {
     const stopped = resolve({
       run: makeRun({ orchestrationStop: { kind: 'operator', message: 'you stopped this run' } }),
@@ -155,12 +171,13 @@ describe('resolveOrchestratorState', () => {
     });
 
     expect(state.phase).toBe('ready-mid');
-    expect(state.sentence).toBe('Step 1 done · ready to continue');
+    expect(state.sentence).toBe('Paused · autorun is off');
   });
 
   it('waits on the running step and carries its start time', () => {
     const startedAt = '2025-01-01T00:00:00.000Z' as IsoDateTime;
     const state = resolve({
+      run: makeRun({ autoRun: true }),
       agents: [makeAgent(0, 'completed'), makeAgent(1, 'running', { startedAt })],
     });
 

--- a/apps/desktop/src/features/workflows/components/OrchestratorPanel/orchestratorState.ts
+++ b/apps/desktop/src/features/workflows/components/OrchestratorPanel/orchestratorState.ts
@@ -9,6 +9,7 @@ import type {
 
 type OrchestratorPhase =
   | 'deciding'
+  | 'stopping-graceful'
   | 'stopping'
   | 'waiting'
   | 'automatic'
@@ -99,6 +100,7 @@ export const resolveOrchestratorState = ({
   const ordered = [...agents].sort((left, right) => left.ordinal - right.ordinal);
   const doneCount = ordered.filter(isDone).length;
   const base = { detail: null, waitingSince: null };
+  const hasRunningStep = agents.some((agent) => agent.status === 'running');
 
   if (isOrchestrating && run.orchestrationStop?.kind === 'operator') {
     return {
@@ -106,6 +108,14 @@ export const resolveOrchestratorState = ({
       phase: OPERATOR_STOP_IN_FLIGHT.phase,
       tone: OPERATOR_STOP_IN_FLIGHT.tone,
       sentence: OPERATOR_STOP_IN_FLIGHT.sentence,
+    };
+  }
+  if (hasRunningStep && run.autoRun === false) {
+    return {
+      ...base,
+      phase: 'stopping-graceful',
+      tone: 'neutral',
+      sentence: 'Finishing the step in flight · autorun is off',
     };
   }
   if (isOrchestrating) {
@@ -196,6 +206,14 @@ export const resolveOrchestratorState = ({
       phase: 'ready-first',
       tone: 'neutral',
       sentence: 'Ready to plan the first step',
+    };
+  }
+  if (run.autoRun === false) {
+    return {
+      ...base,
+      phase: 'ready-mid',
+      tone: 'neutral',
+      sentence: 'Paused · autorun is off',
     };
   }
   return {

--- a/apps/desktop/src/features/workflows/components/OrchestratorPanel/orchestratorState.ts
+++ b/apps/desktop/src/features/workflows/components/OrchestratorPanel/orchestratorState.ts
@@ -110,7 +110,7 @@ export const resolveOrchestratorState = ({
       sentence: OPERATOR_STOP_IN_FLIGHT.sentence,
     };
   }
-  if (hasRunningStep && run.autoRun === false) {
+  if (hasRunningStep && run.autoRun === false && run.orchestrationStop?.kind !== 'operator') {
     return {
       ...base,
       phase: 'stopping-graceful',

--- a/apps/desktop/src/features/workflows/components/WorkflowAutorunToggle/index.test.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowAutorunToggle/index.test.tsx
@@ -8,54 +8,28 @@ afterEach(cleanup);
 
 describe('WorkflowAutorunToggle', () => {
   it('shows the computed on/off label in the detail variant instead of a static word', () => {
-    render(
-      <WorkflowAutorunToggle
-        isOn={false}
-        isStepInFlight={false}
-        onToggle={vi.fn()}
-        onStopNow={vi.fn()}
-      />,
-    );
+    render(<WorkflowAutorunToggle isOn={false} onToggle={vi.fn()} />);
     expect(screen.getByRole('button', { name: 'Autorun off' })).toBeDefined();
     expect(screen.queryByRole('button', { name: 'Autorun' })).toBeNull();
   });
 
   it('toggles immediately when no step is in flight', () => {
     const onToggle = vi.fn();
-    render(
-      <WorkflowAutorunToggle
-        isOn={false}
-        isStepInFlight={false}
-        onToggle={onToggle}
-        onStopNow={vi.fn()}
-      />,
-    );
+    render(<WorkflowAutorunToggle isOn={false} onToggle={onToggle} />);
     fireEvent.click(screen.getByRole('button', { name: 'Autorun off' }));
     expect(onToggle).toHaveBeenCalledOnce();
   });
 
-  it('arms a stop confirm instead of toggling while a step is in flight', () => {
+  it('turns autorun off immediately without presenting a stop confirmation', () => {
     const onToggle = vi.fn();
-    const onStopNow = vi.fn();
-    render(<WorkflowAutorunToggle isOn isStepInFlight onToggle={onToggle} onStopNow={onStopNow} />);
+    render(<WorkflowAutorunToggle isOn onToggle={onToggle} />);
     fireEvent.click(screen.getByRole('button', { name: 'Autorun on' }));
-    expect(screen.getByText('Stop this run?')).toBeDefined();
-    expect(onToggle).not.toHaveBeenCalled();
-
-    fireEvent.click(screen.getByRole('button', { name: 'Stop the run' }));
-    expect(onStopNow).toHaveBeenCalledOnce();
+    expect(onToggle).toHaveBeenCalledOnce();
+    expect(screen.queryByRole('group')).toBeNull();
   });
 
   it('keeps the sidebar variant as an icon with the same computed label as its tooltip', () => {
-    render(
-      <WorkflowAutorunToggle
-        variant="sidebar"
-        isOn
-        isStepInFlight={false}
-        onToggle={vi.fn()}
-        onStopNow={vi.fn()}
-      />,
-    );
+    render(<WorkflowAutorunToggle variant="sidebar" isOn onToggle={vi.fn()} />);
     expect(screen.getByRole('button', { name: 'Autorun on' })).toBeDefined();
   });
 });

--- a/apps/desktop/src/features/workflows/components/WorkflowAutorunToggle/index.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowAutorunToggle/index.tsx
@@ -1,36 +1,18 @@
-import { useState } from 'react';
-import { CircleStop, Zap, ZapOff } from 'lucide-react';
-import { InlineConfirm, cn } from '@goodboy/ui';
+import { Zap, ZapOff } from 'lucide-react';
+import { cn } from '@goodboy/ui';
 import { CardAction } from '@goodboy/ui';
 
 type Props = {
   readonly isOn: boolean;
-  readonly isStepInFlight: boolean;
   readonly variant?: 'sidebar' | 'detail';
   readonly onToggle: () => void;
-  readonly onStopNow?: () => void;
 };
 
-export const WorkflowAutorunToggle = ({
-  isOn,
-  isStepInFlight,
-  variant = 'detail',
-  onToggle,
-  onStopNow,
-}: Props) => {
-  const [isArmed, setIsArmed] = useState(false);
+export const WorkflowAutorunToggle = ({ isOn, variant = 'detail', onToggle }: Props) => {
   const label = isOn ? 'Autorun on' : 'Autorun off';
 
-  const press = () => {
-    if (isOn && isStepInFlight) {
-      setIsArmed(true);
-      return;
-    }
-    onToggle();
-  };
-
   return (
-    <div className="relative flex shrink-0 items-center">
+    <div className="flex shrink-0 items-center">
       {variant === 'sidebar' ? (
         <CardAction
           icon={isOn ? Zap : ZapOff}
@@ -38,17 +20,15 @@ export const WorkflowAutorunToggle = ({
           tone="primary"
           pressed={isOn}
           highlighted={isOn}
-          expanded={isArmed}
-          onClick={press}
+          onClick={onToggle}
         />
       ) : (
         <button
           type="button"
           aria-pressed={isOn}
-          aria-expanded={isArmed}
           aria-label={label}
           data-testid="workflow-autorun-toggle"
-          onClick={press}
+          onClick={onToggle}
           className={cn(
             'inline-flex min-h-7 min-w-[6.5rem] shrink-0 items-center justify-center gap-1 rounded-full border px-2.5 text-2xs font-semibold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] motion-safe:transition-colors',
             isOn
@@ -60,22 +40,6 @@ export const WorkflowAutorunToggle = ({
           {label}
         </button>
       )}
-      {isArmed ? (
-        <div className="absolute right-0 top-full z-popover mt-1 w-72 rounded-lg bg-background shadow-lg">
-          <InlineConfirm
-            role="alert"
-            icon={<CircleStop size={12} aria-hidden />}
-            title="Stop this run?"
-            description="The run stops, the step in flight is skipped, and everything it already wrote is kept."
-            confirmLabel="Stop the run"
-            onConfirm={() => {
-              setIsArmed(false);
-              onStopNow?.();
-            }}
-            onCancel={() => setIsArmed(false)}
-          />
-        </div>
-      ) : null}
     </div>
   );
 };

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.test.tsx
@@ -20,7 +20,6 @@ import type { WorkflowBlockReason } from '../../../../workflows/advanceGate';
 
 const storeMocks = vi.hoisted(() => ({
   renameWorkflow: vi.fn(async () => undefined),
-  stopWorkflowRunNow: vi.fn(async () => undefined),
   orchestratingWorkflowRuns: {} as Record<string, boolean>,
   runSpendUsd: 0,
 }));
@@ -32,7 +31,6 @@ vi.mock('../../../../../store', () => ({
   useAppStore: <T,>(selector: (state: unknown) => T) =>
     selector({
       renameWorkflow: storeMocks.renameWorkflow,
-      stopWorkflowRunNow: storeMocks.stopWorkflowRunNow,
       orchestratingWorkflowRuns: storeMocks.orchestratingWorkflowRuns,
       agentEffortOverride: {},
     }),
@@ -210,7 +208,6 @@ const renderDetail = ({
 
 beforeEach(() => {
   storeMocks.renameWorkflow.mockClear();
-  storeMocks.stopWorkflowRunNow.mockClear();
 });
 
 afterEach(() => {
@@ -279,10 +276,10 @@ describe('WorkflowRow detail dashboard', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Autorun on' }));
 
     expect(setAutoRun).toHaveBeenCalledWith(SESSION_ID, RUN_ID, false);
-    expect(screen.queryByRole('group', { name: 'Stop this run?' })).toBeNull();
+    expect(screen.queryByRole('group', { name: 'Stop now?' })).toBeNull();
   });
 
-  it('names the consequence before stopping a step in flight', () => {
+  it('turns autorun off immediately while a step is in flight', () => {
     const setAutoRun = vi.fn(async () => undefined);
     const running = agents.map((agent, index) =>
       index === 1 ? { ...agent, status: 'running' as const } : agent,
@@ -295,13 +292,8 @@ describe('WorkflowRow detail dashboard', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Autorun on' }));
 
-    const confirm = screen.getByRole('group', { name: 'Stop this run?' });
-    expect(confirm.textContent).toContain('the step in flight is skipped');
-    expect(setAutoRun).not.toHaveBeenCalled();
-
-    fireEvent.click(within(confirm).getByRole('button', { name: 'Stop the run' }));
-
-    expect(storeMocks.stopWorkflowRunNow).toHaveBeenCalledWith(SESSION_ID, RUN_ID);
+    expect(setAutoRun).toHaveBeenCalledWith(SESSION_ID, RUN_ID, false);
+    expect(screen.queryByRole('group', { name: 'Stop now?' })).toBeNull();
   });
 
   it('keeps completed detail navigation non-empty without lifecycle actions in it', () => {
@@ -441,8 +433,9 @@ describe('WorkflowRow substep disclosure', () => {
   });
 });
 
-describe('WorkflowRow sidebar autorun stop', () => {
-  it('wires the sidebar stop confirmation to stopWorkflowRunNow independently of the detail mount', () => {
+describe('WorkflowRow sidebar autorun pause', () => {
+  it('turns autorun off immediately without a hard-stop confirmation', () => {
+    const setAutoRun = vi.fn(async () => undefined);
     const running = agents.map((agent, index) =>
       index === 1 ? { ...agent, status: 'running' as const } : agent,
     );
@@ -450,26 +443,30 @@ describe('WorkflowRow sidebar autorun stop', () => {
       runOverride: { ...run, autoRun: true },
       agentsOverride: running,
       variant: 'sidebar',
+      setWorkflowRunAutoRun: setAutoRun,
     });
 
     expect(screen.queryByRole('heading', { name: 'Refactor' })).toBeNull();
 
     fireEvent.click(screen.getByRole('button', { name: 'Autorun on' }));
-    const confirm = screen.getByRole('group', { name: 'Stop this run?' });
-    fireEvent.click(within(confirm).getByRole('button', { name: 'Stop the run' }));
 
-    expect(storeMocks.stopWorkflowRunNow).toHaveBeenCalledWith(SESSION_ID, RUN_ID);
+    expect(setAutoRun).toHaveBeenCalledWith(SESSION_ID, RUN_ID, false);
+    expect(screen.queryByRole('group', { name: 'Stop now?' })).toBeNull();
   });
 });
 
 describe('WorkflowRow step-in-flight predicate', () => {
-  it('arms the stop confirm while the orchestrator is deciding, even with no agent running', () => {
+  it('turns autorun off while the orchestrator is deciding, even with no agent running', () => {
+    const setAutoRun = vi.fn(async () => undefined);
     storeMocks.orchestratingWorkflowRuns[RUN_ID] = true;
-    renderDetail({ runOverride: { ...run, autoRun: true } });
+    renderDetail({
+      runOverride: { ...run, autoRun: true },
+      setWorkflowRunAutoRun: setAutoRun,
+    });
 
     fireEvent.click(screen.getByRole('button', { name: 'Autorun on' }));
 
-    expect(screen.getByRole('group', { name: 'Stop this run?' })).toBeDefined();
+    expect(setAutoRun).toHaveBeenCalledWith(SESSION_ID, RUN_ID, false);
   });
 
   it('reads the collapsed row as stopping while the decision is still in flight', () => {
@@ -566,7 +563,9 @@ describe('WorkflowRow dynamic runs', () => {
     renderDetail({ runOverride: dynamicRun, agentsOverride: doneAgents, actionableStepId: null });
 
     expect(screen.queryByText('Completed')).toBeNull();
-    expect(screen.getByTestId('orchestrator-state').textContent).toContain('ready to continue');
+    expect(screen.getByTestId('orchestrator-state').textContent).toContain(
+      'Paused · autorun is off',
+    );
   });
 
   it('leaves the orchestrator phase to the strip instead of a second pill', () => {

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.tsx
@@ -148,7 +148,6 @@ export const WorkflowRow = ({
   const sessionEffort = task.effort ?? null;
   const isOrchestrating = useAppStore((s) => s.orchestratingWorkflowRuns?.[run.id] ?? false);
   const restoreWorkflow = useAppStore((s) => s.restoreWorkflow);
-  const stopWorkflowRunNow = useAppStore((s) => s.stopWorkflowRunNow);
   const workflowRun = run;
   const isDiscarded = run.discardedAt != null;
   const wfAgents = agentsByRunId.get(run.id) ?? EMPTY_ARRAY;
@@ -175,7 +174,6 @@ export const WorkflowRow = ({
       ? run.id === focusedWorkflowRunId
       : (workflowExpand?.[run.id] ?? defaultExpanded);
   const hasStarted = wfAgents.length > 0;
-  const isStepInFlight = isOrchestrating || wfAgents.some((agent) => agent.status === 'running');
   const isQueuedManual = !isDiscarded && run.triggerMode === 'manual' && !hasStarted;
   const predecessorName = run.chainAfterId
     ? (workflowNameByRunId.get(run.chainAfterId) ?? 'previous')
@@ -339,9 +337,7 @@ export const WorkflowRow = ({
                 <WorkflowAutorunToggle
                   variant="detail"
                   isOn={run.autoRun}
-                  isStepInFlight={isStepInFlight}
                   onToggle={() => void setWorkflowRunAutoRun(task.id, run.id, !run.autoRun)}
-                  onStopNow={() => void stopWorkflowRunNow(task.id, run.id)}
                 />
               ) : null}
               <Divider orientation="vertical" className="h-5 self-center" />
@@ -372,9 +368,7 @@ export const WorkflowRow = ({
                   <WorkflowAutorunToggle
                     variant="sidebar"
                     isOn={run.autoRun}
-                    isStepInFlight={isStepInFlight}
                     onToggle={() => void setWorkflowRunAutoRun(task.id, run.id, !run.autoRun)}
-                    onStopNow={() => void stopWorkflowRunNow(task.id, run.id)}
                   />
                 ) : null}
                 <WorkflowKillButton onConfirm={() => void onDiscardWorkflow(run.id)} />

--- a/apps/desktop/src/store/slices/workflows/orchestrateNextStep.test.ts
+++ b/apps/desktop/src/store/slices/workflows/orchestrateNextStep.test.ts
@@ -278,6 +278,25 @@ beforeEach(() => {
 });
 
 describe('orchestrateNextStep', () => {
+  it('returns before doing work when the run already has an operator stop', async () => {
+    const state = baseState();
+    const sessions = state['sessions'] as ReadonlyArray<Session>;
+    state['sessions'] = [
+      {
+        ...sessions[0]!,
+        workflowRuns: [{ ...sessions[0]!.workflowRuns[0]!, orchestrationStop: OPERATOR_STOP }],
+      },
+    ];
+    const { set, get } = harness(state);
+
+    await orchestrateNextStep(set, get)(SESSION_ID, WORKFLOW_RUN_ID);
+
+    expect(decideSpy).not.toHaveBeenCalled();
+    expect(listOpenQuestionsSpy).not.toHaveBeenCalled();
+    expect(updateStopSpy).not.toHaveBeenCalled();
+    expect(invokeWorkflowUpsertSpy).not.toHaveBeenCalled();
+  });
+
   it('appends a real step and agent, emits the decision, and activates it', async () => {
     decideSpy.mockResolvedValue({
       usage: NO_USAGE,

--- a/apps/desktop/src/store/slices/workflows/orchestrateNextStep.ts
+++ b/apps/desktop/src/store/slices/workflows/orchestrateNextStep.ts
@@ -460,7 +460,8 @@ export const orchestrateNextStep = (set: SetFn, get: GetFn) => {
         run == null ||
         run.executionMode !== 'dynamic' ||
         run.discardedAt != null ||
-        run.orchestrationOutcome != null
+        run.orchestrationOutcome != null ||
+        run.orchestrationStop?.kind === 'operator'
       ) {
         return;
       }


### PR DESCRIPTION
Stopping an orchestrated run in autorun killed the in-flight step: the only stop was the destructive one.

- toggling autorun off is now instant, writes no stop record and cancels nothing; the running step finishes and the autoRun gate prevents the next spawn (macOS Quit vs Force Quit split; Buildkite graceful cancel)
- while the step finishes the state reads "Finishing the step in flight · autorun is off" in a neutral tone; once done it falls into the normal paused presentation, resumable
- the immediate kill is an explicit "Stop now" danger action with the confirm ("The step in flight is cancelled and marked skipped. Everything it already wrote is kept."), semantics of stopWorkflowRunNow untouched
- orchestrateNextStep refuses operator-stopped runs at entry, closing the race where a step could launch after the stop persisted

🤖 Generated with [Claude Code](https://claude.com/claude-code)