### PR TITLE
feat(ui): create a pr straight from the project row

### DIFF
--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectMountRow.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectMountRow.test.tsx
@@ -4,7 +4,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { Project, SessionId, SessionProjectMount } from '@goodboy/types';
 
-const { store } = vi.hoisted(() => ({
+const { store, remoteKind } = vi.hoisted(() => ({
+  remoteKind: { current: 'github' as string | null },
   store: {
     setSessionActiveProject: vi.fn(async () => undefined),
     setScriptsLensScope: vi.fn(),
@@ -25,6 +26,9 @@ vi.mock('./ProjectSyncControl', () => ({
 }));
 vi.mock('./ProjectDetachMenu', () => ({
   ProjectDetachMenu: () => <span data-testid="detach-menu" />,
+}));
+vi.mock('../../../../worktree/useRemoteHostKind', () => ({
+  useRemoteHostKind: () => remoteKind.current,
 }));
 
 import { ProjectMountRow } from './ProjectMountRow';
@@ -67,6 +71,7 @@ const renderRow = ({
 beforeEach(() => {
   store.setSessionActiveProject.mockClear();
   store.setSessionActiveProject.mockResolvedValue(undefined);
+  remoteKind.current = 'github';
 });
 
 afterEach(cleanup);
@@ -97,5 +102,19 @@ describe('ProjectMountRow create pr action', () => {
     });
     expect(screen.queryByRole('button', { name: 'Create a PR for API' })).toBeNull();
     expect(screen.getByRole('button', { name: 'Open PR #12' })).toBeDefined();
+  });
+
+  it('offers create mr on a gitlab remote', () => {
+    remoteKind.current = 'gitlab';
+    renderRow({ diffStat: { additions: 1, deletions: 0 } });
+    expect(screen.getByRole('button', { name: 'Create a PR for API' }).textContent).toBe(
+      'Create MR',
+    );
+  });
+
+  it('hides the action when the remote kind is unknown', () => {
+    remoteKind.current = null;
+    renderRow({ diffStat: { additions: 1, deletions: 0 } });
+    expect(screen.queryByRole('button', { name: 'Create a PR for API' })).toBeNull();
   });
 });

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectMountRow.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectMountRow.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { Project, SessionId, SessionProjectMount } from '@goodboy/types';
+
+const { store } = vi.hoisted(() => ({
+  store: {
+    setSessionActiveProject: vi.fn(async () => undefined),
+    setScriptsLensScope: vi.fn(),
+    openMountDiff: vi.fn(async () => undefined),
+    projects: [] as ReadonlyArray<{ id: string; baseBranch?: string | null }>,
+    emitNotification: vi.fn(),
+  },
+}));
+
+vi.mock('../../../../../store', () => ({
+  useAppStore: <T,>(selector: (state: typeof store) => T) => selector(store),
+}));
+vi.mock('./ProjectBranchChip', () => ({
+  ProjectBranchChip: () => <span data-testid="branch-chip" />,
+}));
+vi.mock('./ProjectSyncControl', () => ({
+  ProjectSyncControl: () => <span data-testid="sync-control" />,
+}));
+vi.mock('./ProjectDetachMenu', () => ({
+  ProjectDetachMenu: () => <span data-testid="detach-menu" />,
+}));
+
+import { ProjectMountRow } from './ProjectMountRow';
+
+const sessionId = 'session-1' as SessionId;
+
+const project = {
+  id: 'api',
+  name: 'API',
+  kind: 'repo',
+} as Project;
+
+const mount = {
+  projectId: 'api',
+  mountName: 'API',
+  branch: 'feat/api',
+  worktreePath: '/api',
+  repoRoot: '/repo/api',
+} as SessionProjectMount;
+
+const renderRow = ({
+  diffStat = null,
+  pullRequest = null,
+}: {
+  readonly diffStat?: { additions: number; deletions: number } | null;
+  readonly pullRequest?: { number: number; state: 'open'; isDraft: boolean } | null;
+}) =>
+  render(
+    <ProjectMountRow
+      sessionId={sessionId}
+      project={project}
+      mount={mount}
+      diffStat={diffStat}
+      pullRequest={pullRequest as never}
+      worktreeStatus={null}
+      onSelectLens={vi.fn()}
+    />,
+  );
+
+beforeEach(() => {
+  store.setSessionActiveProject.mockClear();
+  store.setSessionActiveProject.mockResolvedValue(undefined);
+});
+
+afterEach(cleanup);
+
+describe('ProjectMountRow create pr action', () => {
+  it('offers create pr when there are changes and no pr, targeting the mount project', async () => {
+    const listener = vi.fn();
+    window.addEventListener('goodboy:open-github-session', listener);
+    renderRow({ diffStat: { additions: 3, deletions: 1 } });
+
+    const action = screen.getByRole('button', { name: 'Create a PR for API' });
+    fireEvent.click(action);
+
+    await waitFor(() => expect(listener).toHaveBeenCalledTimes(1));
+    expect(store.setSessionActiveProject).toHaveBeenCalledWith({ sessionId, projectId: 'api' });
+    window.removeEventListener('goodboy:open-github-session', listener);
+  });
+
+  it('hides create pr without changes', () => {
+    renderRow({ diffStat: null });
+    expect(screen.queryByRole('button', { name: 'Create a PR for API' })).toBeNull();
+  });
+
+  it('hides create pr when a pr already exists', () => {
+    renderRow({
+      diffStat: { additions: 3, deletions: 1 },
+      pullRequest: { number: 12, state: 'open', isDraft: false },
+    });
+    expect(screen.queryByRole('button', { name: 'Create a PR for API' })).toBeNull();
+    expect(screen.getByRole('button', { name: 'Open PR #12' })).toBeDefined();
+  });
+});

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectMountRow.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectMountRow.test.tsx
@@ -2,7 +2,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import type { Project, SessionId, SessionProjectMount } from '@goodboy/types';
+import type { Project, PullRequestState, SessionId, SessionProjectMount } from '@goodboy/types';
 
 const { store, remoteKind } = vi.hoisted(() => ({
   remoteKind: { current: 'github' as string | null },
@@ -54,7 +54,7 @@ const renderRow = ({
   pullRequest = null,
 }: {
   readonly diffStat?: { additions: number; deletions: number } | null;
-  readonly pullRequest?: { number: number; state: 'open'; isDraft: boolean } | null;
+  readonly pullRequest?: PullRequestState | null;
 }) =>
   render(
     <ProjectMountRow
@@ -62,7 +62,7 @@ const renderRow = ({
       project={project}
       mount={mount}
       diffStat={diffStat}
-      pullRequest={pullRequest as never}
+      pullRequest={pullRequest ?? null}
       worktreeStatus={null}
       onSelectLens={vi.fn()}
     />,
@@ -86,6 +86,8 @@ describe('ProjectMountRow create pr action', () => {
     fireEvent.click(action);
 
     await waitFor(() => expect(listener).toHaveBeenCalledTimes(1));
+    const event = listener.mock.calls[0]?.[0] as CustomEvent<{ sessionId: SessionId }>;
+    expect(event.detail).toEqual({ sessionId });
     expect(store.setSessionActiveProject).toHaveBeenCalledWith({ sessionId, projectId: 'api' });
     window.removeEventListener('goodboy:open-github-session', listener);
   });
@@ -98,7 +100,7 @@ describe('ProjectMountRow create pr action', () => {
   it('hides create pr when a pr already exists', () => {
     renderRow({
       diffStat: { additions: 3, deletions: 1 },
-      pullRequest: { number: 12, state: 'open', isDraft: false },
+      pullRequest: { number: 12, state: 'open', isDraft: false } as PullRequestState,
     });
     expect(screen.queryByRole('button', { name: 'Create a PR for API' })).toBeNull();
     expect(screen.getByRole('button', { name: 'Open PR #12' })).toBeDefined();

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectMountRow.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectMountRow.tsx
@@ -11,6 +11,7 @@ import type { LensKind, MountDiffStat } from '../../../../../store';
 import { useAppStore } from '../../../../../store';
 import { CONCEPT_ICONS } from '../../../../../shared/components/conceptIcons';
 import { PullRequestChip } from '../../../../github/components/PullRequestChip';
+import { useRemoteHostKind } from '../../../../worktree/useRemoteHostKind';
 import { DiffStat } from '../../DiffStat';
 import { ProjectBranchChip } from './ProjectBranchChip';
 import { ProjectSyncControl } from './ProjectSyncControl';
@@ -44,6 +45,7 @@ export const ProjectMountRow = ({
   const GlyphIcon = project?.kind === 'repo' ? FolderGit2 : Folder;
   const projectName = project?.name ?? mount.mountName;
   const changes = diffStat != null && (diffStat.additions > 0 || diffStat.deletions > 0);
+  const remoteKind = useRemoteHostKind({ sessionId });
 
   const openLens = async ({ lens }: { readonly lens: LensKind }) => {
     await setSessionActiveProject({ sessionId, projectId: mount.projectId });
@@ -92,20 +94,25 @@ export const ProjectMountRow = ({
       ) : (
         <span className="text-xs text-muted-foreground/50">No changes</span>
       )}
-      {pullRequest == null && changes ? (
+      {pullRequest == null && changes && remoteKind != null ? (
         <button
           type="button"
           aria-label={`Create a PR for ${projectName}`}
           onClick={() => {
             void setSessionActiveProject({ sessionId, projectId: mount.projectId }).then(() => {
               window.dispatchEvent(
-                new CustomEvent('goodboy:open-github-session', { detail: { sessionId } }),
+                new CustomEvent(
+                  remoteKind === 'gitlab'
+                    ? 'goodboy:open-gitlab-mr'
+                    : 'goodboy:open-github-session',
+                  { detail: { sessionId } },
+                ),
               );
             });
           }}
           className="rounded-md px-1.5 py-1 text-xs text-muted-foreground/70 hover:bg-muted/40 hover:text-foreground"
         >
-          Create PR
+          {remoteKind === 'gitlab' ? 'Create MR' : 'Create PR'}
         </button>
       ) : null}
       {pullRequest != null ? (

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectMountRow.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectMountRow.tsx
@@ -92,6 +92,22 @@ export const ProjectMountRow = ({
       ) : (
         <span className="text-xs text-muted-foreground/50">No changes</span>
       )}
+      {pullRequest == null && changes ? (
+        <button
+          type="button"
+          aria-label={`Create a PR for ${projectName}`}
+          onClick={() => {
+            void setSessionActiveProject({ sessionId, projectId: mount.projectId }).then(() => {
+              window.dispatchEvent(
+                new CustomEvent('goodboy:open-github-session', { detail: { sessionId } }),
+              );
+            });
+          }}
+          className="rounded-md px-1.5 py-1 text-xs text-muted-foreground/70 hover:bg-muted/40 hover:text-foreground"
+        >
+          Create PR
+        </button>
+      ) : null}
       {pullRequest != null ? (
         <button
           type="button"


### PR DESCRIPTION
The redesign in #1549 dropped the old overview PR block and with it the only create-PR affordance: the project row shows the PR chip only once a PR exists, so a branch with +232 -68 and no PR had nothing to click.

- when a mount has changes and no PR, a quiet `Create PR` action renders in the chip's slot; it activates the mount's project and dispatches the existing github-studio event, which already lands on CreatePrPanel for sessions without an active PR
- with a PR, the chip renders as before; with no changes, nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)