### PR TITLE
chore(repo): bump version to 0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ version in the same PR that bumps the version numbers (see
 `docs/release-command.md`), before the tag is pushed: the release build fails
 if it can't find a matching `## Goodboy vX.Y.Z` heading.
 
+## Goodboy v0.2.6
+
+Codex agents stop fighting their sandbox, stopping a run stops being
+destructive, and the notification panel learns to count.
+
+### [#1565] Codex agents can commit and mount again
+
+Codex agents in session worktrees died on every commit because the sandbox
+blocked git's own metadata, and mounts requested mid-run never appeared.
+The sandbox now covers each mounted repository's git directory and the
+in-app query bridge, so commits land and a requested project is ready
+inside the same run. A failed turn no longer loses the mounts it asked
+for.
+
+### [#1567] Pausing autorun lets the step finish
+
+Turning autorun off used to kill the step in flight. It is now an instant,
+safe pause: the running step completes and no new one starts. The
+immediate kill is a separate Stop now action with its own confirmation.
+
+### [#1568] One notification per story
+
+Cluster handoffs now produce a real summary instead of raw output behind a
+permanent warning, and the notification panel folds repeats into a single
+group with a count, inline expansion and per-group retry and dismiss. The
+bell badge counts stories, not repeats.
+
+### Fixes
+
+- A project row with changes and no pull request offers Create PR again,
+  or Create MR on GitLab remotes, opening the studio on the create panel.
+  [#1572]
+- The chain glyph on trace chips sits beside the label again instead of
+  overlapping it. [#1566]
+
 ## Goodboy v0.2.5
 
 Branches get real names, scripts get their bearings and every workflow gets

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goodboy/desktop",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -1626,7 +1626,7 @@ dependencies = [
 
 [[package]]
 name = "goodboy-desktop"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goodboy-desktop"
-version = "0.2.5"
+version = "0.2.6"
 description = "Goodboy desktop app"
 authors = ["Amin Khayam"]
 license = "MIT"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Goodboy",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "identifier": "com.goodboy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goodboy",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "private": true,
   "description": "AI workspace orchestrator. Local-first, provider-agnostic.",
   "license": "MIT",

--- a/website/src/site.ts
+++ b/website/src/site.ts
@@ -1,5 +1,5 @@
 export const SITE = {
-  version: 'v0.2.5',
+  version: 'v0.2.6',
   repo: 'https://github.com/akhayam99/goodboy',
   releases: 'https://github.com/akhayam99/goodboy/releases',
   latest: 'https://github.com/akhayam99/goodboy/releases/latest',


### PR DESCRIPTION
Version bump plus the v0.2.6 changelog: codex sandbox fix (#1565), graceful autorun pause (#1567), cluster summaries + notification grouping (#1568), create PR row action (#1572), chip glyph revert (#1566).

🤖 Generated with [Claude Code](https://claude.com/claude-code)