### PR TITLE
fix(ui): deliver session attention through one stage selector

### DIFF
--- a/apps/desktop/src/app/components/AppTopBar/index.test.tsx
+++ b/apps/desktop/src/app/components/AppTopBar/index.test.tsx
@@ -33,7 +33,7 @@ const { currentWorkspace, hooks, store } = vi.hoisted(() => {
       }>,
       rollup: { attentionCount: 0, runningCount: 0, todaySpend: 0 },
       reasons: {} as Record<string, string>,
-      attention: {} as Record<string, string | undefined>,
+      attention: {} as Record<string, string | null>,
     },
     store: {
       setCurrentSession: vi.fn(async () => undefined),
@@ -59,7 +59,7 @@ vi.mock('../../../store', () => ({
   useSessionStageInfo: (session: Session) => ({
     stage: 'attention',
     reason: hooks.reasons[session.id] ?? 'Needs attention',
-    attention: hooks.attention[session.id],
+    attention: hooks.attention[session.id] ?? null,
   }),
   useAppStore: <T,>(selector: (state: typeof store) => T) => selector(store),
 }));
@@ -230,20 +230,21 @@ describe('AppTopBar', () => {
     expect(screen.queryByText('PR #42: CI failed')).toBeNull();
   });
 
-  it('marks each row with the icon of its own reason, not a repeated dot', () => {
+  it('renders the open-question icon and tone instead of the sessions fallback', () => {
     hooks.sessions = [ATTENTION_SESSION];
     hooks.groups = [{ key: 'attention', sessions: [ATTENTION_SESSION] }];
     hooks.rollup = { attentionCount: 1, runningCount: 0, todaySpend: 0 };
     hooks.reasons = { [ATTENTION_SESSION_ID]: 'PR #42: CI failed' };
-    hooks.attention = { [ATTENTION_SESSION_ID]: 'ci-failed' };
+    hooks.attention = { [ATTENTION_SESSION_ID]: 'open-question' };
     renderBar();
 
     fireEvent.click(screen.getByRole('button', { name: '1 session needs you' }));
 
     const row = screen.getByTitle('Review the failing checks · PR #42: CI failed');
     const icon = row.querySelector('svg');
-    expect(icon?.getAttribute('class')).toContain('text-danger');
-    expect(row.querySelector('[class*="bg-warning"]')).toBeNull();
+    expect(icon?.getAttribute('class')).toContain('text-warning');
+    expect(icon?.getAttribute('class')).toContain('lucide-circle-question-mark');
+    expect(icon?.getAttribute('class')).not.toContain('lucide-circle-play');
   });
 
   it('closes the needs-you dialog on Escape', () => {

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/lib.test.ts
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/lib.test.ts
@@ -3,7 +3,7 @@ import type { OpenQuestion, SessionStageInfo } from '@goodboy/types';
 import { resolveAttentionLens, selectOpenQuestions } from './lib';
 
 const stage = (over: Partial<SessionStageInfo>): SessionStageInfo =>
-  ({ stage: 'building', reason: '', ...over }) as SessionStageInfo;
+  ({ stage: 'building', reason: '', attention: null, ...over }) satisfies SessionStageInfo;
 
 const question = (over: Partial<OpenQuestion>): OpenQuestion =>
   ({ status: 'open', text: 'q', ...over }) as unknown as OpenQuestion;

--- a/apps/desktop/src/store/selectors.ts
+++ b/apps/desktop/src/store/selectors.ts
@@ -231,11 +231,8 @@ function stageInfoOf(state: StageInfoState, session: Session): SessionStageInfo 
   });
 }
 
-export const useSessionStageInfo = (session: Session): SessionStageInfo => {
-  const stage = useAppStore((s) => stageInfoOf(s, session).stage);
-  const reason = useAppStore((s) => stageInfoOf(s, session).reason);
-  return useMemo(() => ({ stage, reason }), [stage, reason]);
-};
+export const useSessionStageInfo = (session: Session): SessionStageInfo =>
+  useAppStore(useShallow((s) => stageInfoOf(s, session)));
 
 export const useSessionPrFetchState = (sessionId: SessionId): SessionPrFetchState =>
   useAppStore((s) =>

--- a/apps/desktop/src/store/slices/session-view/deriveSessionStage.test.ts
+++ b/apps/desktop/src/store/slices/session-view/deriveSessionStage.test.ts
@@ -46,8 +46,21 @@ describe('deriveSessionStage pull request freshness', () => {
 
   it('claims no PR only once the fetch has landed', () => {
     const info = deriveSessionStage({ session, pr: null, ...signals, prFetchState: 'known' });
-    expect(info.stage).toBe('building');
-    expect(info.reason).toBe('no PR yet');
+    expect(info).toEqual({ stage: 'building', reason: 'no PR yet', attention: null });
+  });
+
+  it('keeps the open-question attention reason', () => {
+    const info = deriveSessionStage({
+      session,
+      pr: null,
+      hasUnread: false,
+      openQuestionCount: 1,
+    });
+    expect(info).toEqual({
+      stage: 'attention',
+      reason: '1 open question',
+      attention: 'open-question',
+    });
   });
 
   it('says GitHub is unreachable rather than claiming no PR when the fetch failed', () => {

--- a/apps/desktop/src/store/slices/session-view/deriveSessionStage.ts
+++ b/apps/desktop/src/store/slices/session-view/deriveSessionStage.ts
@@ -37,7 +37,7 @@ export const deriveSessionStage = ({
   const label = requestLabel ?? (pr === null ? '' : `PR #${pr.number}`);
   if (isBranchless) {
     if (session.state.kind === 'running' || session.state.kind === 'starting' || hasRunningAgent) {
-      return { stage: 'running', reason: 'agent running' };
+      return { stage: 'running', reason: 'agent running', attention: null };
     }
     if (session.state.kind === 'error') {
       return { stage: 'attention', reason: 'agent errored', attention: 'agent-error' };
@@ -55,16 +55,16 @@ export const deriveSessionStage = ({
     if (hasUnread) {
       return { stage: 'attention', reason: 'unread agent reply', attention: 'unread-reply' };
     }
-    return { stage: 'building', reason: 'ready for work' };
+    return { stage: 'building', reason: 'ready for work', attention: null };
   }
   if (session.state.kind === 'error') {
     return { stage: 'attention', reason: 'agent errored', attention: 'agent-error' };
   }
   if (session.state.kind === 'running' || session.state.kind === 'starting') {
-    return { stage: 'running', reason: 'agent running' };
+    return { stage: 'running', reason: 'agent running', attention: null };
   }
   if (hasRunningAgent) {
-    return { stage: 'running', reason: 'agent running' };
+    return { stage: 'running', reason: 'agent running', attention: null };
   }
   if (isPrLive(pr) && pr.checks === 'failure') {
     return { stage: 'attention', reason: `${label}: CI failed`, attention: 'ci-failed' };
@@ -97,28 +97,28 @@ export const deriveSessionStage = ({
     return { stage: 'attention', reason: 'unread agent reply', attention: 'unread-reply' };
   }
   if (isPrReview && pr === null) {
-    return { stage: 'review', reason: 'reviewing an external PR' };
+    return { stage: 'review', reason: 'reviewing an external PR', attention: null };
   }
   if (pr === null && prFetchState === 'unknown') {
-    return { stage: 'building', reason: 'checking GitHub' };
+    return { stage: 'building', reason: 'checking GitHub', attention: null };
   }
   if (pr === null && prFetchState === 'unreachable') {
-    return { stage: 'building', reason: 'GitHub unreachable' };
+    return { stage: 'building', reason: 'GitHub unreachable', attention: null };
   }
   if (pr === null) {
-    return { stage: 'building', reason: 'no PR yet' };
+    return { stage: 'building', reason: 'no PR yet', attention: null };
   }
   if (pr.state === 'merged') {
-    return { stage: 'done', reason: `${label} merged` };
+    return { stage: 'done', reason: `${label} merged`, attention: null };
   }
   if (pr.state === 'closed') {
-    return { stage: 'done', reason: `${label} closed` };
+    return { stage: 'done', reason: `${label} closed`, attention: null };
   }
   if (pr.isDraft) {
-    return { stage: 'review', reason: `draft ${label}` };
+    return { stage: 'review', reason: `draft ${label}`, attention: null };
   }
   if (pr.checks === 'pending') {
-    return { stage: 'review', reason: `${label}: CI running` };
+    return { stage: 'review', reason: `${label}: CI running`, attention: null };
   }
-  return { stage: 'review', reason: `${label} awaiting review` };
+  return { stage: 'review', reason: `${label} awaiting review`, attention: null };
 };

--- a/apps/desktop/src/store/slices/session-view/resolveSessionRequest.test.ts
+++ b/apps/desktop/src/store/slices/session-view/resolveSessionRequest.test.ts
@@ -72,7 +72,7 @@ describe('resolveSessionRequest', () => {
       hasUnread: false,
       openQuestionCount: 0,
     });
-    expect(info).toEqual({ stage: 'done', reason: 'MR !7 merged' });
+    expect(info).toEqual({ stage: 'done', reason: 'MR !7 merged', attention: null });
   });
 
   it('lets the GitHub pull request win when both hosts answer', () => {
@@ -84,7 +84,7 @@ describe('resolveSessionRequest', () => {
       hasUnread: false,
       openQuestionCount: 0,
     });
-    expect(info).toEqual({ stage: 'review', reason: 'PR #42 awaiting review' });
+    expect(info).toEqual({ stage: 'review', reason: 'PR #42 awaiting review', attention: null });
   });
 
   it('never reads CI from a merge request', () => {

--- a/apps/desktop/src/store/store.session-view.test.ts
+++ b/apps/desktop/src/store/store.session-view.test.ts
@@ -318,18 +318,18 @@ describe('deriveSessionStage', () => {
 
   it('no PR and quiet → building', () => {
     const info = deriveSessionStage({ session: base(1), pr: null, ...signals });
-    expect(info).toEqual({ stage: 'building', reason: 'no PR yet' });
+    expect(info).toEqual({ stage: 'building', reason: 'no PR yet', attention: null });
   });
 
   it('open PR and quiet → review', () => {
     const info = deriveSessionStage({ session: base(1), pr: makePr(), ...signals });
-    expect(info).toEqual({ stage: 'review', reason: 'PR #1 awaiting review' });
+    expect(info).toEqual({ stage: 'review', reason: 'PR #1 awaiting review', attention: null });
   });
 
   it('draft PR → review with draft reason', () => {
     const pr = makePr({ isDraft: true });
     const info = deriveSessionStage({ session: base(1), pr, ...signals });
-    expect(info).toEqual({ stage: 'review', reason: 'draft PR #1' });
+    expect(info).toEqual({ stage: 'review', reason: 'draft PR #1', attention: null });
   });
 
   it('unread beats merged', () => {
@@ -341,7 +341,7 @@ describe('deriveSessionStage', () => {
   it('merged PR and quiet → done', () => {
     const pr = makePr({ state: 'merged' });
     const info = deriveSessionStage({ session: base(1), pr, ...signals });
-    expect(info).toEqual({ stage: 'done', reason: 'PR #1 merged' });
+    expect(info).toEqual({ stage: 'done', reason: 'PR #1 merged', attention: null });
   });
 
   it('idle state + running standalone agent → running', () => {
@@ -376,7 +376,7 @@ describe('deriveSessionStage', () => {
       state: { kind: 'starting', startedAt: '2024-01-01T00:00:00.000Z' as never },
     };
     const info = deriveSessionStage({ session, pr: null, ...signals });
-    expect(info).toEqual({ stage: 'running', reason: 'agent running' });
+    expect(info).toEqual({ stage: 'running', reason: 'agent running', attention: null });
   });
 
   it('running agent outranks open questions', () => {
@@ -409,7 +409,7 @@ describe('deriveSessionStage', () => {
       hasRunningAgent: true,
       isBranchless: true,
     });
-    expect(info).toEqual({ stage: 'running', reason: 'agent running' });
+    expect(info).toEqual({ stage: 'running', reason: 'agent running', attention: null });
   });
 
   it('branchless sessions derive attention from questions or unread replies', () => {
@@ -446,7 +446,7 @@ describe('deriveSessionStage', () => {
       ...signals,
       isBranchless: true,
     });
-    expect(info).toEqual({ stage: 'building', reason: 'ready for work' });
+    expect(info).toEqual({ stage: 'building', reason: 'ready for work', attention: null });
   });
 });
 

--- a/packages/types/src/session-view.ts
+++ b/packages/types/src/session-view.ts
@@ -28,7 +28,7 @@ export type SessionPrFetchState = 'unknown' | 'unreachable' | 'known';
 export type SessionStageInfo = Readonly<{
   stage: SessionStage;
   reason: string;
-  attention?: SessionAttentionReason;
+  attention: SessionAttentionReason | null;
 }>;
 
 export type SessionPrGroup =


### PR DESCRIPTION
## Summary
- makes `SessionStageInfo.attention` non-optional (`SessionAttentionReason | null`) so a consumer can never silently drop it again
- replaces the two split subscriptions plus `useMemo` in `useSessionStageInfo` with a single `useShallow` object selector: the needs-you popover now receives `attention` (per-reason icon and tone were permanently on the fallback), and the 20-branch stage derivation runs once per render instead of twice
- every non-attention branch of `deriveSessionStage` now returns `attention: null` explicitly

## Tests
- deriveSessionStage: non-attention branches return `attention: null`, open-question branch returns its literal
- NeedsYouSessionRow: renders the `ATTENTION_REASON_META` icon and warning tone for `open-question` instead of the sessions fallback
- 103 tests green across 7 touched files, desktop typecheck green

🤖 Generated with [Claude Code](https://claude.com/claude-code)