### PR TITLE
feat(ui): fold system alerts into notifications

### DIFF
--- a/apps/desktop/src/store/slices/agents/index.test.ts
+++ b/apps/desktop/src/store/slices/agents/index.test.ts
@@ -491,7 +491,6 @@ describe('store contract', () => {
         sessionBudgets: {},
         providerSpendBreakdown: [],
         budgetAlerts: [],
-        systemAlerts: [],
         skills: {},
         projectScripts: {},
         scriptRuns: {},

--- a/apps/desktop/src/store/slices/boot/auditRetryQueue.ts
+++ b/apps/desktop/src/store/slices/boot/auditRetryQueue.ts
@@ -7,7 +7,7 @@ import {
   type PermissionAuditInsertPayload,
 } from '../../../features/permissions/permissions';
 import { formatError } from '@goodboy/ui';
-import type { SetFn } from './types';
+import type { GetFn } from './types';
 
 const AUDIT_RETRY_MAX_ATTEMPTS = 5;
 const AUDIT_RETRY_DRAIN_BATCH = 50;
@@ -17,15 +17,13 @@ function auditRetryBackoffMs(attempt: number): number {
   return AUDIT_RETRY_BACKOFF_MS[Math.min(attempt, AUDIT_RETRY_BACKOFF_MS.length - 1)] ?? 16000;
 }
 
-export const drainAuditRetryQueue = async (set: SetFn): Promise<void> => {
+export const drainAuditRetryQueue = async (get: GetFn): Promise<void> => {
   let entries: ReadonlyArray<AuditRetryEntry>;
   try {
     entries = await invokeAuditRetryDrain(AUDIT_RETRY_DRAIN_BATCH);
   } catch {
     return;
   }
-
-  const now = () => new Date().toISOString();
 
   for (const entry of entries) {
     const backoffMs = auditRetryBackoffMs(entry.attempts);
@@ -39,17 +37,15 @@ export const drainAuditRetryQueue = async (set: SetFn): Promise<void> => {
       payload = JSON.parse(entry.payloadJson) as PermissionAuditInsertPayload;
     } catch {
       await invokeAuditRetryDelete(entry.id).catch(() => undefined);
-      set((state) => ({
-        systemAlerts: [
-          ...state.systemAlerts,
-          {
-            id: crypto.randomUUID(),
-            kind: 'audit-retry-corrupt' as const,
-            message: `permission audit retry entry ${entry.id} had corrupt payload and was dropped`,
-            createdAt: now(),
-          },
-        ],
-      }));
+      await get()
+        .emitNotification(
+          'error',
+          'warning',
+          'Audit entry dropped',
+          `A queued permission audit record was corrupt and was removed. Entry ${entry.id}.`,
+          { coalesceKey: 'audit-retry:corrupt' },
+        )
+        .catch(() => undefined);
       continue;
     }
 
@@ -67,17 +63,15 @@ export const drainAuditRetryQueue = async (set: SetFn): Promise<void> => {
 
       if (nextAttempts >= AUDIT_RETRY_MAX_ATTEMPTS) {
         await invokeAuditRetryDelete(entry.id).catch(() => undefined);
-        set((state) => ({
-          systemAlerts: [
-            ...state.systemAlerts,
-            {
-              id: crypto.randomUUID(),
-              kind: 'audit-retry-exhausted' as const,
-              message: `permission audit retry for entry ${entry.id} exhausted after ${AUDIT_RETRY_MAX_ATTEMPTS} attempts: ${errMsg}`,
-              createdAt: now(),
-            },
-          ],
-        }));
+        await get()
+          .emitNotification(
+            'error',
+            'error',
+            'Audit write failed',
+            `A permission audit record could not be saved after ${AUDIT_RETRY_MAX_ATTEMPTS} attempts. Entry ${entry.id}: ${errMsg}`,
+            { coalesceKey: 'audit-retry:exhausted' },
+          )
+          .catch(() => undefined);
       } else {
         await invokeAuditRetryUpdate(entry.id, nextAttempts, errMsg).catch(() => undefined);
       }

--- a/apps/desktop/src/store/slices/boot/hydrate.ts
+++ b/apps/desktop/src/store/slices/boot/hydrate.ts
@@ -200,7 +200,7 @@ export const hydrate = (set: SetFn, get: GetFn) => {
           detail: `ms=${Date.now() - bootStartedAt},ok`,
         });
 
-        void drainAuditRetryQueue(set);
+        void drainAuditRetryQueue(get);
 
         void get()
           .reconcileOrphanWorktrees()

--- a/apps/desktop/src/store/slices/boot/index.test.ts
+++ b/apps/desktop/src/store/slices/boot/index.test.ts
@@ -517,7 +517,6 @@ describe('store contract', () => {
         sessionBudgets: {},
         providerSpendBreakdown: [],
         budgetAlerts: [],
-        systemAlerts: [],
         skills: {},
         projectScripts: {},
         scriptRuns: {},

--- a/apps/desktop/src/store/slices/budget/index.test.ts
+++ b/apps/desktop/src/store/slices/budget/index.test.ts
@@ -489,7 +489,6 @@ describe('store contract', () => {
         sessionBudgets: {},
         providerSpendBreakdown: [],
         budgetAlerts: [],
-        systemAlerts: [],
         skills: {},
         projectScripts: {},
         scriptRuns: {},

--- a/apps/desktop/src/store/slices/diff-comments/index.test.ts
+++ b/apps/desktop/src/store/slices/diff-comments/index.test.ts
@@ -489,7 +489,6 @@ describe('store contract', () => {
         sessionBudgets: {},
         providerSpendBreakdown: [],
         budgetAlerts: [],
-        systemAlerts: [],
         skills: {},
         projectScripts: {},
         scriptRuns: {},

--- a/apps/desktop/src/store/slices/github/index.test.ts
+++ b/apps/desktop/src/store/slices/github/index.test.ts
@@ -552,7 +552,6 @@ describe('store contract', () => {
         sessionBudgets: {},
         providerSpendBreakdown: [],
         budgetAlerts: [],
-        systemAlerts: [],
         skills: {},
         projectScripts: {},
         scriptRuns: {},

--- a/apps/desktop/src/store/slices/integrations/index.test.ts
+++ b/apps/desktop/src/store/slices/integrations/index.test.ts
@@ -556,7 +556,6 @@ describe('store contract', () => {
         sessionBudgets: {},
         providerSpendBreakdown: [],
         budgetAlerts: [],
-        systemAlerts: [],
         skills: {},
         projectScripts: {},
         scriptRuns: {},

--- a/apps/desktop/src/store/slices/notifications/index.test.ts
+++ b/apps/desktop/src/store/slices/notifications/index.test.ts
@@ -501,7 +501,6 @@ describe('store contract', () => {
         sessionBudgets: {},
         providerSpendBreakdown: [],
         budgetAlerts: [],
-        systemAlerts: [],
         skills: {},
         projectScripts: {},
         scriptRuns: {},

--- a/apps/desktop/src/store/slices/nudges/index.test.ts
+++ b/apps/desktop/src/store/slices/nudges/index.test.ts
@@ -489,7 +489,6 @@ describe('store contract', () => {
         sessionBudgets: {},
         providerSpendBreakdown: [],
         budgetAlerts: [],
-        systemAlerts: [],
         skills: {},
         projectScripts: {},
         scriptRuns: {},

--- a/apps/desktop/src/store/slices/overrides/index.test.ts
+++ b/apps/desktop/src/store/slices/overrides/index.test.ts
@@ -489,7 +489,6 @@ describe('store contract', () => {
         sessionBudgets: {},
         providerSpendBreakdown: [],
         budgetAlerts: [],
-        systemAlerts: [],
         skills: {},
         projectScripts: {},
         scriptRuns: {},

--- a/apps/desktop/src/store/slices/permissions/index.test.ts
+++ b/apps/desktop/src/store/slices/permissions/index.test.ts
@@ -489,7 +489,6 @@ describe('store contract', () => {
         sessionBudgets: {},
         providerSpendBreakdown: [],
         budgetAlerts: [],
-        systemAlerts: [],
         skills: {},
         projectScripts: {},
         scriptRuns: {},

--- a/apps/desktop/src/store/slices/plans/contract.test.ts
+++ b/apps/desktop/src/store/slices/plans/contract.test.ts
@@ -489,7 +489,6 @@ describe('store contract', () => {
         sessionBudgets: {},
         providerSpendBreakdown: [],
         budgetAlerts: [],
-        systemAlerts: [],
         skills: {},
         projectScripts: {},
         scriptRuns: {},

--- a/apps/desktop/src/store/slices/scripts/index.test.ts
+++ b/apps/desktop/src/store/slices/scripts/index.test.ts
@@ -518,7 +518,6 @@ describe('store contract', () => {
         sessionBudgets: {},
         providerSpendBreakdown: [],
         budgetAlerts: [],
-        systemAlerts: [],
         skills: {},
         projectScripts: {},
         scriptRuns: {},

--- a/apps/desktop/src/store/slices/session-view/index.test.ts
+++ b/apps/desktop/src/store/slices/session-view/index.test.ts
@@ -508,7 +508,6 @@ describe('store contract', () => {
         sessionBudgets: {},
         providerSpendBreakdown: [],
         budgetAlerts: [],
-        systemAlerts: [],
         skills: {},
         projectScripts: {},
         scriptRuns: {},

--- a/apps/desktop/src/store/slices/sessions/index.test.ts
+++ b/apps/desktop/src/store/slices/sessions/index.test.ts
@@ -557,7 +557,6 @@ describe('store contract', () => {
         sessionBudgets: {},
         providerSpendBreakdown: [],
         budgetAlerts: [],
-        systemAlerts: [],
         skills: {},
         projectScripts: {},
         scriptRuns: {},

--- a/apps/desktop/src/store/slices/settings/dismissSystemAlert.ts
+++ b/apps/desktop/src/store/slices/settings/dismissSystemAlert.ts
@@ -1,9 +1,0 @@
-import type { SetFn } from './types';
-
-export const dismissSystemAlert = (set: SetFn) => {
-  return (id: string) => {
-    set((state) => ({
-      systemAlerts: state.systemAlerts.filter((a) => a.id !== id),
-    }));
-  };
-};

--- a/apps/desktop/src/store/slices/settings/index.test.ts
+++ b/apps/desktop/src/store/slices/settings/index.test.ts
@@ -489,7 +489,6 @@ describe('store contract', () => {
         sessionBudgets: {},
         providerSpendBreakdown: [],
         budgetAlerts: [],
-        systemAlerts: [],
         skills: {},
         projectScripts: {},
         scriptRuns: {},
@@ -533,20 +532,6 @@ describe('store contract', () => {
 
   afterEach(() => {
     vi.clearAllMocks();
-  });
-
-  describe('system alerts', () => {
-    it('dismissSystemAlert removes the matching alert', async () => {
-      const store = await getStore();
-      store.setState({
-        systemAlerts: [
-          { id: 'a1', kind: 'context-soft-cap', message: 'x', createdAt: NOW } as never,
-          { id: 'a2', kind: 'context-soft-cap', message: 'y', createdAt: NOW } as never,
-        ],
-      });
-      store.getState().dismissSystemAlert('a1');
-      expect(store.getState().systemAlerts.map((a) => a.id)).toEqual(['a2']);
-    });
   });
 
   describe('settings', () => {

--- a/apps/desktop/src/store/slices/settings/index.ts
+++ b/apps/desktop/src/store/slices/settings/index.ts
@@ -1,4 +1,3 @@
-import { dismissSystemAlert } from './dismissSystemAlert';
 import { exportConfig } from './exportConfig';
 import { importConfig } from './importConfig';
 import { loadSetting } from './loadSetting';
@@ -11,6 +10,5 @@ export const createSettingsSlice = (set: SetFn, _get: GetFn) => {
     saveSetting: saveSetting(set),
     exportConfig: exportConfig(),
     importConfig: importConfig(),
-    dismissSystemAlert: dismissSystemAlert(set),
   };
 };

--- a/apps/desktop/src/store/slices/sidebar/index.test.ts
+++ b/apps/desktop/src/store/slices/sidebar/index.test.ts
@@ -489,7 +489,6 @@ describe('store contract', () => {
         sessionBudgets: {},
         providerSpendBreakdown: [],
         budgetAlerts: [],
-        systemAlerts: [],
         skills: {},
         projectScripts: {},
         scriptRuns: {},

--- a/apps/desktop/src/store/slices/skills/index.test.ts
+++ b/apps/desktop/src/store/slices/skills/index.test.ts
@@ -489,7 +489,6 @@ describe('store contract', () => {
         sessionBudgets: {},
         providerSpendBreakdown: [],
         budgetAlerts: [],
-        systemAlerts: [],
         skills: {},
         projectScripts: {},
         scriptRuns: {},

--- a/apps/desktop/src/store/slices/slots/index.test.ts
+++ b/apps/desktop/src/store/slices/slots/index.test.ts
@@ -489,7 +489,6 @@ describe('store contract', () => {
         sessionBudgets: {},
         providerSpendBreakdown: [],
         budgetAlerts: [],
-        systemAlerts: [],
         skills: {},
         projectScripts: {},
         scriptRuns: {},

--- a/apps/desktop/src/store/slices/terminal/index.test.ts
+++ b/apps/desktop/src/store/slices/terminal/index.test.ts
@@ -497,7 +497,6 @@ describe('store contract', () => {
         sessionBudgets: {},
         providerSpendBreakdown: [],
         budgetAlerts: [],
-        systemAlerts: [],
         skills: {},
         projectScripts: {},
         scriptRuns: {},

--- a/apps/desktop/src/store/slices/transcripts/index.test.ts
+++ b/apps/desktop/src/store/slices/transcripts/index.test.ts
@@ -489,7 +489,6 @@ describe('store contract', () => {
         sessionBudgets: {},
         providerSpendBreakdown: [],
         budgetAlerts: [],
-        systemAlerts: [],
         skills: {},
         projectScripts: {},
         scriptRuns: {},

--- a/apps/desktop/src/store/slices/turn/sendTurn.ts
+++ b/apps/desktop/src/store/slices/turn/sendTurn.ts
@@ -67,7 +67,6 @@ import {
   kindWritesFiles,
 } from '../../../features/session/agent-kind';
 import { slotsForKind } from '../../../features/providers/slot-routing';
-import { formatInteger } from '../../../shared/utils/formatInteger';
 import { cursorMaxModeAdvisory } from '../../../shared/lib/cursorMaxModeAdvisory';
 import { estimateTokens } from '../../../shared/utils/estimate-tokens';
 import { isBranchlessSession } from '../../../shared/utils/isBranchlessSession';
@@ -670,21 +669,17 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
       const ratio = estimated / ctxWindow;
       if (ratio >= 0.85) {
         const pct = Math.round(ratio * 100);
-        const msg = `ctx estimate: ${formatInteger(estimated)} / ${formatInteger(ctxWindow)} (${pct}%). consider /compact`;
-        if (import.meta.env.DEV) {
-          console.warn(msg);
-        }
-        set((state) => ({
-          systemAlerts: [
-            ...state.systemAlerts,
-            {
-              id: crypto.randomUUID(),
-              kind: 'context-soft-cap' as const,
-              message: msg,
-              createdAt: now(),
-            },
-          ],
-        }));
+        void get().emitNotification(
+          'error',
+          'warning',
+          'Context near the limit',
+          `This turn is estimated at ${estimated.toLocaleString()} of ${ctxWindow.toLocaleString()} tokens (${pct}%). Consider /compact.`,
+          {
+            sessionId,
+            workspaceId: session.workspaceId,
+            coalesceKey: `context-soft-cap:${sessionId}`,
+          },
+        );
       }
     }
 

--- a/apps/desktop/src/store/slices/turn/sendTurn.ts
+++ b/apps/desktop/src/store/slices/turn/sendTurn.ts
@@ -669,17 +669,19 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
       const ratio = estimated / ctxWindow;
       if (ratio >= 0.85) {
         const pct = Math.round(ratio * 100);
-        void get().emitNotification(
-          'error',
-          'warning',
-          'Context near the limit',
-          `This turn is estimated at ${estimated.toLocaleString()} of ${ctxWindow.toLocaleString()} tokens (${pct}%). Consider /compact.`,
-          {
-            sessionId,
-            workspaceId: session.workspaceId,
-            coalesceKey: `context-soft-cap:${sessionId}`,
-          },
-        );
+        void get()
+          .emitNotification(
+            'error',
+            'warning',
+            'Context near the limit',
+            `This turn is estimated at ${estimated.toLocaleString()} of ${ctxWindow.toLocaleString()} tokens (${pct}%). Consider /compact.`,
+            {
+              sessionId,
+              workspaceId: session.workspaceId,
+              coalesceKey: `context-soft-cap:${sessionId}`,
+            },
+          )
+          .catch(() => undefined);
       }
     }
 

--- a/apps/desktop/src/store/store.audit-retry.test.ts
+++ b/apps/desktop/src/store/store.audit-retry.test.ts
@@ -434,7 +434,7 @@ describe('audit retry queue, drain worker (happy path)', () => {
     expect(auditRetryUpdateSpy).not.toHaveBeenCalled();
   });
 
-  it('max-attempts exhausted: emits system alert', async () => {
+  it('max-attempts exhausted: emits an error notification', async () => {
     const entry = { ...makeRetryEntry({ id: 'retry-exhausted', attempts: 4 }), updatedAt: 0 };
     auditRetryDrainSpy.mockResolvedValue([entry]);
     permissionAuditInsertSpy.mockRejectedValue(new Error('permanent failure'));
@@ -442,11 +442,16 @@ describe('audit retry queue, drain worker (happy path)', () => {
     const mod = await import('./store');
     await runHydrate();
 
-    const { systemAlerts } = mod.useAppStore.getState();
-    const alert = systemAlerts.find((a) => a.kind === 'audit-retry-exhausted');
-    expect(alert).toBeDefined();
-    expect(alert?.kind).toBe('audit-retry-exhausted');
-    expect(alert?.message).toContain('5 attempts');
+    await vi.waitFor(() => {
+      expect(mod.useAppStore.getState().notifications).toEqual([
+        expect.objectContaining({
+          kind: 'error',
+          severity: 'error',
+          coalesceKey: 'audit-retry:exhausted',
+        }),
+      ]);
+    });
+    expect(auditRetryDeleteSpy).toHaveBeenCalledWith('retry-exhausted');
   });
 
   it('drain skips rows with invalid JSON payload (deletes them)', async () => {
@@ -489,7 +494,7 @@ describe('audit retry queue, drain worker (happy path)', () => {
     expect(permissionAuditInsertSpy).not.toHaveBeenCalled();
   });
 
-  it('corrupt payload: emits system alert', async () => {
+  it('corrupt payload: emits a warning notification and deletes the entry', async () => {
     const entry = {
       ...makeRetryEntry({ id: 'retry-bad-json', payloadJson: 'not-json' }),
       updatedAt: 0,
@@ -499,11 +504,16 @@ describe('audit retry queue, drain worker (happy path)', () => {
     const mod = await import('./store');
     await runHydrate();
 
-    const { systemAlerts } = mod.useAppStore.getState();
-    const alert = systemAlerts.find((a) => a.kind === 'audit-retry-corrupt');
-    expect(alert).toBeDefined();
-    expect(alert?.kind).toBe('audit-retry-corrupt');
-    expect(alert?.message).toContain('corrupt payload');
+    await vi.waitFor(() => {
+      expect(mod.useAppStore.getState().notifications).toEqual([
+        expect.objectContaining({
+          kind: 'error',
+          severity: 'warning',
+          coalesceKey: 'audit-retry:corrupt',
+        }),
+      ]);
+    });
+    expect(auditRetryDeleteSpy).toHaveBeenCalledWith('retry-bad-json');
   });
 
   it('backoff: skips entry whose updatedAt is too recent for attempt count', async () => {

--- a/apps/desktop/src/store/store.idle-on-empty-stream.test.ts
+++ b/apps/desktop/src/store/store.idle-on-empty-stream.test.ts
@@ -335,6 +335,37 @@ describe('sendTurn, terminal state guarantees', () => {
     expect(session?.state.kind).toBe('idle');
   });
 
+  it('emits a scoped warning near the context limit and still runs the turn', async () => {
+    runTurnSpy.mockImplementation(() => emptyStream());
+    const routingMod = await import('../features/providers/routing');
+    (routingMod.resolveProviderForTurn as ReturnType<typeof vi.fn>).mockResolvedValue({
+      selectedProvider: 'anthropic',
+      selectedModel: 'claude-haiku-4-5',
+      reason: 'preference',
+    });
+
+    const useAppStore = await importStore();
+    setupSession(useAppStore);
+
+    await useAppStore.getState().sendTurn({
+      sessionId: SESSION_ID,
+      content: 'x'.repeat(680_000),
+    });
+
+    expect(runTurnSpy).toHaveBeenCalledOnce();
+    await vi.waitFor(() => {
+      expect(useAppStore.getState().notifications).toEqual([
+        expect.objectContaining({
+          kind: 'error',
+          severity: 'warning',
+          sessionId: SESSION_ID,
+          workspaceId: WORKSPACE_ID,
+          coalesceKey: `context-soft-cap:${SESSION_ID}`,
+        }),
+      ]);
+    });
+  });
+
   it('appends an error event when the stream ends with no assistant text', async () => {
     runTurnSpy.mockImplementation(() => emptyStream());
 

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -206,8 +206,6 @@ export type {
   SessionLoadingFlags,
   SessionNudge,
   SummarizerSessionStatus,
-  SystemAlert,
-  SystemAlertKind,
 } from './types';
 
 type SaveScriptParams = {
@@ -603,7 +601,6 @@ export type AppActions = {
   clearAgentQueue(agentId: AgentId): void;
   deleteAgent(sessionId: SessionId, agentId: AgentId): Promise<void>;
   wipeLocalDatabase(): Promise<void>;
-  dismissSystemAlert(id: string): void;
   loadWorkspaceOverrides(workspaceId: WorkspaceId): Promise<void>;
   setWorkspaceOverrides(workspaceId: WorkspaceId, overrides: OverrideSettings): Promise<void>;
   setWorkspaceProviderBinding(
@@ -957,7 +954,6 @@ export const initialState: AppState = {
   clusterStartAttempts: {},
   unknownPayloadCounts: {},
   detectedEditors: [],
-  systemAlerts: [],
   workspaceOverrides: {},
   sessionOverrides: {},
   sidebarWorkspaceSearch: '',

--- a/apps/desktop/src/store/types.ts
+++ b/apps/desktop/src/store/types.ts
@@ -103,15 +103,6 @@ export type BootPhase =
   | 'ready'
   | 'error';
 
-export type SystemAlertKind = 'audit-retry-corrupt' | 'audit-retry-exhausted' | 'context-soft-cap';
-
-export type SystemAlert = {
-  readonly id: string;
-  readonly kind: SystemAlertKind;
-  readonly message: string;
-  readonly createdAt: string;
-};
-
 export type SessionNudge =
   | {
       readonly kind: 'plan-ready';
@@ -231,7 +222,6 @@ export type AppState = AppSliceState & {
   readonly sessionBudgets: Readonly<Record<SessionId, SessionBudget>>;
   readonly providerSpendBreakdown: ReadonlyArray<ProviderSpendEntry>;
   readonly budgetAlerts: ReadonlyArray<BudgetAlert>;
-  readonly systemAlerts: ReadonlyArray<SystemAlert>;
   readonly skills: Readonly<Record<WorkspaceId, ReadonlyArray<Skill>>>;
   readonly projectScripts: Readonly<Record<WorkspaceId, ReadonlyArray<ProjectScript>>>;
   readonly scriptRuns: Readonly<


### PR DESCRIPTION
## Summary
- deletes the `systemAlerts` channel: it was populated on real failures (corrupt or exhausted audit retries, context soft cap) but no component ever rendered it, so those errors were invisible
- the three writers now emit persisted notifications through `emitNotification` with explicit coalesce keys (`audit-retry:corrupt`, `audit-retry:exhausted`, `context-soft-cap:<sessionId>`), so they land in the bell with m137 grouping; no actions, since the retry entries are already deleted by the time the alert fires and the soft cap is advisory
- `drainAuditRetryQueue` now receives `get` and awaits its emits defensively; the context soft cap emit is fire-and-forget and the turn keeps running
- removes `SystemAlertKind`, `SystemAlert`, `dismissSystemAlert`, the initial state and all fixtures; repo-wide grep is zero hits

## Tests
- audit corrupt path emits one warning notification and deletes the entry; exhausted path emits severity error
- sendTurn at ratio >= 0.85 emits one `context-soft-cap` notification and still runs the turn
- 126 tests green across boot, settings, notifications, turn, audit-retry suites; desktop typecheck green

🤖 Generated with [Claude Code](https://claude.com/claude-code)