### PR TITLE
fix(ui): reconcile stale runs on every session load

### DIFF
--- a/apps/desktop/src/store/slices/sessions/index.test.ts
+++ b/apps/desktop/src/store/slices/sessions/index.test.ts
@@ -75,6 +75,8 @@ const listPendingResolutionsForSessionSpy = vi.fn(
 const getWorkspaceByIdSpy = vi.fn();
 const listProjectsForWorkspaceSpy = vi.fn();
 const upsertSessionExternalTaskSpy = vi.fn(async () => undefined);
+const updateSessionStateSpy = vi.fn(async () => undefined);
+const listLiveRunIdsSpy = vi.fn(async () => new Set<string>());
 
 vi.mock('@goodboy/db', () => ({
   getSetting: dbGetSettingSpy,
@@ -131,7 +133,7 @@ vi.mock('@goodboy/db', () => ({
   updateSessionAutoRun: vi.fn(async () => undefined),
   updateSessionTitleUserEdited: vi.fn(async () => undefined),
   updateSessionActiveProject: vi.fn(async () => undefined),
-  updateSessionState: vi.fn(async () => undefined),
+  updateSessionState: updateSessionStateSpy,
   attachWorkflowToSession: vi.fn(async () => undefined),
   detachWorkflowFromSession: vi.fn(async () => undefined),
   updateWorkflowOrder: vi.fn(async () => undefined),
@@ -191,6 +193,7 @@ vi.mock('../../../features/onboarding/onboarding-store', () => ({
 vi.mock('../../../features/chat/turn', () => ({
   runTurn: vi.fn(),
   cancelTurn: vi.fn(async () => undefined),
+  listLiveRunIds: listLiveRunIdsSpy,
   writeAttachment: vi.fn(async () => 'rel/path'),
   encodeAuthRequiredMessage: () => '',
   isAuthErrorMessage: () => false,
@@ -622,6 +625,27 @@ describe('store contract', () => {
       expect(ss).toHaveLength(2);
       expect(ss[0]?.id).toBe(SESSION_ID);
       expect(ss[1]?.goal).toBe('two');
+    });
+
+    it('refreshSessions reconciles a database-running session before storing it', async () => {
+      const store = await getStore();
+      const { listSessionsForWorkspace } = await import('@goodboy/db');
+      (listSessionsForWorkspace as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+        buildSession({ state: { kind: 'running', runId: RUN_ID, startedAt: NOW } }),
+      ]);
+      listLiveRunIdsSpy.mockResolvedValueOnce(new Set());
+
+      await store.getState().refreshSessions(WS_ID);
+
+      expect(
+        store.getState().sessions.filter((session) => session.state.kind === 'running'),
+      ).toHaveLength(0);
+      expect(updateSessionStateSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        SESSION_ID,
+        expect.objectContaining({ kind: 'idle' }),
+        expect.any(String),
+      );
     });
 
     it('setCurrentSession reads the context slots the database holds', async () => {

--- a/apps/desktop/src/store/slices/sessions/reconcileSessionRuns.test.ts
+++ b/apps/desktop/src/store/slices/sessions/reconcileSessionRuns.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Agent, IsoDateTime, ProviderRunId, Session } from '@goodboy/types';
+
+const { cancelTurn, updateAgentStatus, updateSessionState } = vi.hoisted(() => ({
+  cancelTurn: vi.fn(async () => undefined),
+  updateAgentStatus: vi.fn(async () => undefined),
+  updateSessionState: vi.fn(async () => undefined),
+}));
+
+vi.mock('@goodboy/db', () => ({ updateAgentStatus, updateSessionState }));
+vi.mock('../../../features/chat/turn', () => ({ cancelTurn }));
+vi.mock('../../../shared/lib/db', () => ({ tauriDatabase: {} }));
+
+import { reconcileLoadedAgent, reconcileLoadedSessions } from './reconcileSessionRuns';
+
+const NOW = '2026-08-31T10:00:00.000Z' as IsoDateTime;
+const RUN_ID = 'run-1' as ProviderRunId;
+
+const buildSession = ({ state }: Pick<Session, 'state'>): Session => ({
+  id: 'session-1' as never,
+  workspaceId: 'workspace-1' as never,
+  goal: 'recover',
+  state,
+  contextSlots: [],
+  providerPreference: { defaultProvider: 'anthropic', allowTurnOverride: false },
+  permissionMode: 'bypassPermissions',
+  workflowRuns: [],
+  autoRun: false,
+  titleUserEdited: false,
+  createdAt: NOW,
+  updatedAt: NOW,
+});
+
+const buildAgent = ({ status }: Pick<Agent, 'status'>): Agent => ({
+  id: 'agent-1' as never,
+  sessionId: 'session-1' as never,
+  ordinal: 0,
+  name: 'agent',
+  status,
+  runId: RUN_ID,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('loaded run reconciliation', () => {
+  it('persists an absent running session as idle without cancellation', async () => {
+    const session = buildSession({ state: { kind: 'running', runId: RUN_ID, startedAt: NOW } });
+
+    const [reconciled] = await reconcileLoadedSessions({
+      sessions: [session],
+      liveRunIds: new Set(),
+      now: NOW,
+    });
+
+    expect(cancelTurn).not.toHaveBeenCalled();
+    expect(updateSessionState).toHaveBeenCalledWith(
+      {},
+      session.id,
+      { kind: 'idle', lastActivityAt: NOW },
+      NOW,
+    );
+    expect(reconciled?.state).toEqual({ kind: 'idle', lastActivityAt: NOW });
+  });
+
+  it('cancels a live running session before persisting it as idle', async () => {
+    const session = buildSession({ state: { kind: 'running', runId: RUN_ID, startedAt: NOW } });
+
+    await reconcileLoadedSessions({
+      sessions: [session],
+      liveRunIds: new Set([RUN_ID]),
+      now: NOW,
+    });
+
+    expect(cancelTurn).toHaveBeenCalledWith(RUN_ID);
+    expect(cancelTurn.mock.invocationCallOrder[0]).toBeLessThan(
+      updateSessionState.mock.invocationCallOrder[0] ?? 0,
+    );
+    expect(updateSessionState).toHaveBeenCalledOnce();
+  });
+
+  it('persists a running agent as pending', async () => {
+    const agent = buildAgent({ status: 'running' });
+
+    const reconciled = await reconcileLoadedAgent({ agent, liveRunIds: new Set([RUN_ID]) });
+
+    expect(cancelTurn).toHaveBeenCalledWith(RUN_ID);
+    expect(updateAgentStatus).toHaveBeenCalledWith({}, agent.id, { status: 'pending' });
+    expect(reconciled.status).toBe('pending');
+  });
+
+  it('returns settled records with the same references', async () => {
+    const session = buildSession({ state: { kind: 'idle', lastActivityAt: NOW } });
+    const agent = buildAgent({ status: 'completed' });
+
+    const [reconciledSession] = await reconcileLoadedSessions({
+      sessions: [session],
+      liveRunIds: new Set(),
+      now: NOW,
+    });
+    const reconciledAgent = await reconcileLoadedAgent({ agent, liveRunIds: new Set() });
+
+    expect(reconciledSession).toBe(session);
+    expect(reconciledAgent).toBe(agent);
+    expect(updateSessionState).not.toHaveBeenCalled();
+    expect(updateAgentStatus).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/store/slices/sessions/reconcileSessionRuns.ts
+++ b/apps/desktop/src/store/slices/sessions/reconcileSessionRuns.ts
@@ -1,0 +1,49 @@
+import type { Agent, IsoDateTime, Session, TurnState } from '@goodboy/types';
+import { updateAgentStatus, updateSessionState } from '@goodboy/db';
+import { cancelTurn } from '../../../features/chat/turn';
+import { tauriDatabase } from '../../../shared/lib/db';
+
+type ReconcileLoadedSessionsParams = Readonly<{
+  sessions: ReadonlyArray<Session>;
+  liveRunIds: ReadonlySet<string>;
+  now: IsoDateTime;
+}>;
+
+type ReconcileLoadedAgentParams = Readonly<{
+  agent: Agent;
+  liveRunIds: ReadonlySet<string>;
+}>;
+
+export const reconcileLoadedSessions = async ({
+  sessions,
+  liveRunIds,
+  now,
+}: ReconcileLoadedSessionsParams): Promise<ReadonlyArray<Session>> => {
+  return Promise.all(
+    sessions.map(async (session) => {
+      if (session.state.kind !== 'running') {
+        return session;
+      }
+      if (liveRunIds.has(session.state.runId)) {
+        await cancelTurn(session.state.runId).catch(() => undefined);
+      }
+      const idleState: TurnState = { kind: 'idle', lastActivityAt: now };
+      await updateSessionState(tauriDatabase, session.id, idleState, now).catch(() => undefined);
+      return { ...session, state: idleState, updatedAt: now };
+    }),
+  );
+};
+
+export const reconcileLoadedAgent = async ({
+  agent,
+  liveRunIds,
+}: ReconcileLoadedAgentParams): Promise<Agent> => {
+  if (agent.status !== 'running') {
+    return agent;
+  }
+  if (agent.runId != null && liveRunIds.has(agent.runId)) {
+    await cancelTurn(agent.runId).catch(() => undefined);
+  }
+  await updateAgentStatus(tauriDatabase, agent.id, { status: 'pending' }).catch(() => undefined);
+  return { ...agent, status: 'pending' };
+};

--- a/apps/desktop/src/store/slices/summaries/refreshSessions.ts
+++ b/apps/desktop/src/store/slices/summaries/refreshSessions.ts
@@ -1,11 +1,16 @@
-import type { WorkspaceId } from '@goodboy/types';
+import type { IsoDateTime, WorkspaceId } from '@goodboy/types';
 import { listSessionsForWorkspace } from '@goodboy/db';
+import { listLiveRunIds } from '../../../features/chat/turn';
 import { tauriDatabase } from '../../../shared/lib/db';
+import { reconcileLoadedSessions } from '../sessions/reconcileSessionRuns';
 import type { SetFn } from './types';
 
 export const refreshSessions = (set: SetFn) => {
   return async (workspaceId: WorkspaceId) => {
-    const sessions = await listSessionsForWorkspace(tauriDatabase, workspaceId);
+    const loadedSessions = await listSessionsForWorkspace(tauriDatabase, workspaceId);
+    const liveRunIds = await listLiveRunIds();
+    const now = new Date().toISOString() as IsoDateTime;
+    const sessions = await reconcileLoadedSessions({ sessions: loadedSessions, liveRunIds, now });
     set({ sessions });
   };
 };

--- a/apps/desktop/src/store/slices/workspaces/setCurrentWorkspace.ts
+++ b/apps/desktop/src/store/slices/workspaces/setCurrentWorkspace.ts
@@ -4,7 +4,6 @@ import type {
   ProjectId,
   ProviderRunId,
   SessionExternalTask,
-  TurnState,
   Workflow,
   WorkspaceId,
 } from '@goodboy/types';
@@ -18,9 +17,7 @@ import {
   summarizeWorkspaceProviderTelemetry,
   summarizeWorkspaceTelemetry,
   touchWorkspaceLastAccessed,
-  updateAgentStatus,
   updateSessionActiveProject,
-  updateSessionState,
 } from '@goodboy/db';
 import type { SessionWorktree } from '@goodboy/db';
 import { tauriDatabase } from '../../../shared/lib/db';
@@ -39,6 +36,7 @@ import {
   SETTING_LAST_WORKSPACE_ID,
 } from '../../../features/settings/settings';
 import { buildProviderSpendBreakdown } from '../budget';
+import { reconcileLoadedAgent, reconcileLoadedSessions } from '../sessions/reconcileSessionRuns';
 import { buildSessionProjectMounts } from '../worktrees/buildSessionProjectMounts';
 import { clearPendingTurnEvents } from '../transcripts/buffer';
 import type { GetFn, SetFn } from './types';
@@ -107,33 +105,11 @@ export const setCurrentWorkspace = (set: SetFn, get: GetFn) => {
       const loadedSessions = await listSessionsForWorkspace(tauriDatabase, id);
       const liveRunIds = await listLiveRunIds();
       const recoveryNow = new Date().toISOString() as IsoDateTime;
-      const sessions = await Promise.all(
-        loadedSessions.map(async (s) => {
-          if (s.state.kind !== 'running') {
-            return s;
-          }
-          if (liveRunIds.has(s.state.runId)) {
-            await cancelTurn(s.state.runId).catch(() => undefined);
-          }
-          const idleState: TurnState = { kind: 'idle', lastActivityAt: recoveryNow };
-          await updateSessionState(tauriDatabase, s.id, idleState, recoveryNow).catch(
-            () => undefined,
-          );
-          return { ...s, state: idleState, updatedAt: recoveryNow };
-        }),
-      );
-      const recoverOrphanAgent = async (run: Agent): Promise<Agent> => {
-        if (run.status !== 'running') {
-          return run;
-        }
-        if (run.runId && liveRunIds.has(run.runId)) {
-          await cancelTurn(run.runId).catch(() => undefined);
-        }
-        await updateAgentStatus(tauriDatabase, run.id, { status: 'pending' }).catch(
-          () => undefined,
-        );
-        return { ...run, status: 'pending' };
-      };
+      const sessions = await reconcileLoadedSessions({
+        sessions: loadedSessions,
+        liveRunIds,
+        now: recoveryNow,
+      });
       const sessionIds = sessions.map((s) => s.id);
       const [loadedWorktreesBySession, agentsBySession, externalTasks] = await Promise.all([
         listWorktreesForSessions(tauriDatabase, sessionIds),
@@ -178,7 +154,11 @@ export const setCurrentWorkspace = (set: SetFn, get: GetFn) => {
             sessionBranches[s.id] = primaryRow.branch;
           }
         }
-        const runs = await Promise.all((agentsBySession.get(s.id) ?? []).map(recoverOrphanAgent));
+        const runs = await Promise.all(
+          (agentsBySession.get(s.id) ?? []).map((agent) =>
+            reconcileLoadedAgent({ agent, liveRunIds }),
+          ),
+        );
         sessionPhaseRuns[s.id] = runs;
         for (const run of runs) {
           if (run.kind) {


### PR DESCRIPTION
## Summary
- a crash or force quit could leave a session permanently `running` in SQLite: recovery lived only inside `setCurrentWorkspace`, so it ran on workspace switch but a later `refreshSessions` could resurrect the ghost, poisoning stage derivation, autorun gating and the needs-you rollup
- extracts the recovery into `reconcileLoadedSessions` / `reconcileLoadedAgent` (`store/slices/sessions/reconcileSessionRuns.ts`) and runs them on both session-load paths: `setCurrentWorkspace` (behavior identical) and `refreshSessions` (the actual hole)
- semantics unchanged: a DB-running session whose run is still live gets a best-effort `cancelTurn`, then lands idle; running agents land pending, which already carries the resume affordances. Recovery is silent, matching how vscode restores a crashed workspace

## Tests
- helper: running session absent from the live set is persisted idle without cancelTurn; present gets cancelTurn then idle; running agent becomes pending; settled entries pass through by reference
- refreshSessions: a DB-running session with an empty live set ends idle in the store
- 106 tests green across sessions, summaries, workspaces suites; desktop typecheck green

🤖 Generated with [Claude Code](https://claude.com/claude-code)