### PR TITLE
feat(ui): open review lens from draft comments and review locally

### DIFF
--- a/apps/desktop/src/features/review/components/ReviewPrDetailPanel/index.test.tsx
+++ b/apps/desktop/src/features/review/components/ReviewPrDetailPanel/index.test.tsx
@@ -83,7 +83,11 @@ describe('ReviewPrDetailPanel', () => {
 
     await waitFor(() => {
       expect(h.startPrReviewSession).toHaveBeenCalledWith(WORKSPACE_ID, PR);
-      expect(h.openSession).toHaveBeenCalledWith('session-9', onClose);
+      expect(h.openSession).toHaveBeenCalledWith({
+        sessionId: 'session-9',
+        lens: 'review',
+        onOpened: onClose,
+      });
     });
   });
 

--- a/apps/desktop/src/features/review/components/ReviewPrDetailPanel/index.tsx
+++ b/apps/desktop/src/features/review/components/ReviewPrDetailPanel/index.tsx
@@ -78,7 +78,7 @@ export const ReviewPrDetailPanel = ({ pr, workspaceId, onClose }: Props) => {
     setError(null);
     try {
       const sessionId = await startPrReviewSession(workspaceId, pr);
-      openSession(sessionId, onClose);
+      openSession({ sessionId, lens: 'review', onOpened: onClose });
     } catch (launchError) {
       setError(formatError(launchError));
       setBusy(false);

--- a/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.test.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.test.tsx
@@ -32,6 +32,8 @@ const { state, hooks, useDynamicActionsMock } = vi.hoisted(() => ({
     sessionPhaseRuns: {} as Record<string, ReadonlyArray<unknown>>,
     reviewDrafts: {} as Record<string, ReadonlyArray<unknown>>,
     loadReviewDrafts: vi.fn(async () => undefined),
+    setCurrentSession: vi.fn(async () => undefined),
+    setActiveLens: vi.fn(),
   },
   hooks: {
     stage: 'building' as SessionStage,
@@ -126,6 +128,8 @@ beforeEach(() => {
   state.sessionPhaseRuns = {};
   state.reviewDrafts = {};
   state.loadReviewDrafts.mockClear();
+  state.setCurrentSession.mockClear();
+  state.setActiveLens.mockClear();
   useDynamicActionsMock.mockReset();
   useDynamicActionsMock.mockReturnValue([]);
   nav.selectCard.mockClear();
@@ -358,7 +362,13 @@ describe('StageBoardCard review drafts', () => {
     };
     render(<StageBoardCard session={session} nav={nav} />);
 
-    expect(screen.getByText('draft comments').previousElementSibling?.textContent).toBe('2');
+    const chip = screen.getByRole('button', { name: 'Review 2 draft comments' });
+    expect(chip.tagName).toBe('BUTTON');
+
+    fireEvent.click(chip);
+
+    expect(state.setCurrentSession).toHaveBeenCalledWith(SESSION_ID);
+    expect(nav.selectCard).not.toHaveBeenCalled();
   });
 
   it('loads drafts once for review sessions and hides the chip elsewhere', () => {

--- a/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.tsx
@@ -27,6 +27,7 @@ import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../../shared/components/co
 import { STAGE_TONE } from '../../../../session/session-stage';
 import { sessionCardShell } from '../../../../session/components/sessionCardShell';
 import { formatRelativeAge } from '../../../../../shared/utils/relativeDate';
+import { useOpenSession } from '../../../../../shared/hooks/useOpenSession';
 import type { BoardNavigation } from '../useBoardNavigation';
 import { getLinkedRequest } from './getLinkedRequest';
 import { PrRequestSlot } from './PrRequestSlot';
@@ -85,6 +86,7 @@ export const StageBoardCard = memo(function StageBoardCard({
   const isPrReview = useMemo(() => isPrReviewSession({ agents: phaseRuns }), [phaseRuns]);
   const reviewDrafts = useAppStore((s) => s.reviewDrafts[id]);
   const loadReviewDrafts = useAppStore((s) => s.loadReviewDrafts);
+  const openSession = useOpenSession();
 
   useEffect(() => {
     if (!isPrReview || reviewDrafts != null) {
@@ -180,6 +182,11 @@ export const StageBoardCard = memo(function StageBoardCard({
               tone="draft"
               size="3xs"
               bordered={false}
+              ariaLabel={`Review ${reviewDraftCount} draft ${reviewDraftCount === 1 ? 'comment' : 'comments'}`}
+              onClick={(event) => {
+                event.stopPropagation();
+                openSession({ sessionId: id, lens: 'review' });
+              }}
               icon={<MessageSquareDiff size={10} aria-hidden />}
               label={<span className="tabular-nums">{reviewDraftCount}</span>}
               trailing={<span>draft {reviewDraftCount === 1 ? 'comment' : 'comments'}</span>}

--- a/apps/desktop/src/shared/components/OpenSessionButton/index.test.tsx
+++ b/apps/desktop/src/shared/components/OpenSessionButton/index.test.tsx
@@ -21,6 +21,6 @@ describe('OpenSessionButton', () => {
     const onOpened = vi.fn();
     render(<OpenSessionButton sessionId={'s1' as SessionId} onOpened={onOpened} />);
     fireEvent.click(screen.getByRole('button', { name: /open session/i }));
-    expect(openSession).toHaveBeenCalledWith('s1', onOpened);
+    expect(openSession).toHaveBeenCalledWith({ sessionId: 's1', onOpened });
   });
 });

--- a/apps/desktop/src/shared/components/OpenSessionButton/index.tsx
+++ b/apps/desktop/src/shared/components/OpenSessionButton/index.tsx
@@ -20,7 +20,7 @@ export const OpenSessionButton = ({
 }: Props) => {
   const openSession = useOpenSession();
   return (
-    <Button size={size} variant={variant} onClick={() => openSession(sessionId, onOpened)}>
+    <Button size={size} variant={variant} onClick={() => openSession({ sessionId, onOpened })}>
       <MessagesSquare size={14} aria-hidden />
       {label}
     </Button>

--- a/apps/desktop/src/shared/hooks/useOpenSession/index.test.ts
+++ b/apps/desktop/src/shared/hooks/useOpenSession/index.test.ts
@@ -1,30 +1,93 @@
-import { renderHook } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { SessionId } from '@goodboy/types';
 import { useOpenSession } from './index';
 
-const setCurrentSession = vi.fn();
+const setCurrentSession = vi.fn<() => Promise<void>>(async () => undefined);
+const setActiveLens = vi.fn();
 
 vi.mock('../../../store', () => ({
-  useAppStore: (selector: (s: { setCurrentSession: typeof setCurrentSession }) => unknown) =>
-    selector({ setCurrentSession }),
+  useAppStore: (
+    selector: (s: {
+      setCurrentSession: typeof setCurrentSession;
+      setActiveLens: typeof setActiveLens;
+    }) => unknown,
+  ) => selector({ setCurrentSession, setActiveLens }),
 }));
 
 describe('useOpenSession', () => {
   beforeEach(() => {
-    setCurrentSession.mockClear();
+    setCurrentSession.mockReset();
+    setCurrentSession.mockResolvedValue(undefined);
+    setActiveLens.mockReset();
   });
 
-  it('sets the current session', () => {
+  it('sets the active lens after the current session resolves', async () => {
+    let resolveCurrentSession: (() => void) | undefined;
+    setCurrentSession.mockImplementation(
+      async () =>
+        new Promise<void>((resolve) => {
+          resolveCurrentSession = resolve;
+        }),
+    );
     const { result } = renderHook(() => useOpenSession());
-    result.current('s1' as SessionId);
+    let opening: Promise<void> | undefined;
+
+    act(() => {
+      opening = result.current({ sessionId: 's1' as SessionId, lens: 'review' });
+    });
+
     expect(setCurrentSession).toHaveBeenCalledWith('s1');
+    expect(setActiveLens).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolveCurrentSession?.();
+      await opening;
+    });
+
+    expect(setActiveLens).toHaveBeenCalledWith('s1', 'review');
   });
 
-  it('runs onOpened after navigating', () => {
+  it('does not set an active lens when one is omitted', async () => {
+    const { result } = renderHook(() => useOpenSession());
+
+    await act(async () => {
+      await result.current({ sessionId: 's2' as SessionId });
+    });
+
+    expect(setActiveLens).not.toHaveBeenCalled();
+  });
+
+  it('runs onOpened last', async () => {
+    const calls: string[] = [];
+    setCurrentSession.mockImplementation(async () => {
+      calls.push('session');
+    });
+    setActiveLens.mockImplementation(() => {
+      calls.push('lens');
+    });
+    const onOpened = vi.fn(() => {
+      calls.push('opened');
+    });
+    const { result } = renderHook(() => useOpenSession());
+
+    await act(async () => {
+      await result.current({ sessionId: 's3' as SessionId, lens: 'review', onOpened });
+    });
+
+    expect(calls).toEqual(['session', 'lens', 'opened']);
+  });
+
+  it('does nothing after setting the current session fails', async () => {
+    setCurrentSession.mockRejectedValue(new Error('navigation failed'));
     const onOpened = vi.fn();
     const { result } = renderHook(() => useOpenSession());
-    result.current('s2' as SessionId, onOpened);
-    expect(onOpened).toHaveBeenCalledOnce();
+
+    await act(async () => {
+      await result.current({ sessionId: 's4' as SessionId, lens: 'review', onOpened });
+    });
+
+    expect(setActiveLens).not.toHaveBeenCalled();
+    expect(onOpened).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/shared/hooks/useOpenSession/index.ts
+++ b/apps/desktop/src/shared/hooks/useOpenSession/index.ts
@@ -1,14 +1,28 @@
 import { useCallback } from 'react';
 import type { SessionId } from '@goodboy/types';
-import { useAppStore } from '../../../store';
+import { useAppStore, type LensKind } from '../../../store';
 
-export const useOpenSession = (): ((sessionId: SessionId, onOpened?: () => void) => void) => {
+type Params = {
+  readonly sessionId: SessionId;
+  readonly lens?: LensKind;
+  readonly onOpened?: () => void;
+};
+
+export const useOpenSession = (): ((params: Params) => Promise<void>) => {
   const setCurrentSession = useAppStore((s) => s.setCurrentSession);
+  const setActiveLens = useAppStore((s) => s.setActiveLens);
   return useCallback(
-    (sessionId: SessionId, onOpened?: () => void) => {
-      void setCurrentSession(sessionId);
+    async ({ sessionId, lens, onOpened }: Params) => {
+      try {
+        await setCurrentSession(sessionId);
+      } catch {
+        return;
+      }
+      if (lens !== undefined) {
+        setActiveLens(sessionId, lens);
+      }
       onOpened?.();
     },
-    [setCurrentSession],
+    [setActiveLens, setCurrentSession],
   );
 };

--- a/packages/ui/src/components/Chip.tsx
+++ b/packages/ui/src/components/Chip.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import type { MouseEvent, ReactNode } from 'react';
 import { cn } from '../cn';
 import { tintClasses, type Tone } from '../tint';
 
@@ -20,7 +20,7 @@ export type ChipProps = {
   readonly title?: string;
   readonly ariaLabel?: string;
   readonly testId?: string;
-  readonly onClick?: () => void;
+  readonly onClick?: (event: MouseEvent<HTMLButtonElement>) => void;
   readonly disabled?: boolean;
   readonly expanded?: boolean;
   readonly hasPopup?: 'dialog' | 'menu' | 'listbox' | 'true';


### PR DESCRIPTION
## Summary
- the board card advertised `N draft comments` as a non-interactive chip and `Review locally` created the pr-reviewer session but dropped the user on the overview: the review board those drafts live in was reachable only via its keyboard shortcut
- `useOpenSession` gains a single object param `{ sessionId, lens?, onOpened? }` and sets the lens strictly after `setCurrentSession` resolves (which is the fix: session selection resets the active lens to null, so any lens set before it was overwritten)
- the draft-comments chip becomes a real button (aria label `Review N draft comments`, stopPropagation so the card click does not also fire) landing on the review lens; `Review locally` lands inside the fresh session on the review lens and then closes the panel
- `Chip.onClick` now receives the mouse event; existing zero-arg callers unaffected

## Tests
- hook: lens set after selection resolves, skipped when omitted, onOpened last, nothing after a rejection
- StageBoardCard: chip is a button with the aria label, clicking selects the session without triggering card navigation
- ReviewPrDetailPanel: review locally passes `lens: 'review'` with onClose as onOpened
- 92 desktop tests green across 12 files, full @goodboy/ui suite green (235), desktop typecheck green

🤖 Generated with [Claude Code](https://claude.com/claude-code)