### PR TITLE
feat(ui): seed run lane colors per session

### DIFF
--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRunLabel.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRunLabel.test.tsx
@@ -42,7 +42,7 @@ const entryOf = ({
     at: '2026-08-18T09:00:00Z',
     run: { id: runId, goal, discardedAt },
     workflow: { name, origin: ORIGIN_OF[kind] },
-    identity: runIdentity({ runId, laneIndex: 0 }),
+    identity: runIdentity({ laneIndex: 0, seed: 0 }),
     children: [],
     producedPlan: null,
   }) as unknown as TimelineRunEntry;
@@ -64,7 +64,7 @@ describe('TimelineRunLabel', () => {
     render(<TimelineRunLabel entry={entryOf()} />);
     const { className } = chipOf();
 
-    expect(className).toContain(runIdentity({ runId: 'run-7', laneIndex: 0 }).chip);
+    expect(className).toContain(runIdentity({ laneIndex: 0, seed: 0 }).chip);
     for (const tone of ['primary', 'accent', 'success', 'danger', 'warning', 'info']) {
       expect(className).not.toContain(`bg-${tone}`);
       expect(className).not.toContain(`text-${tone}`);
@@ -105,7 +105,7 @@ describe('TimelineRunLabel', () => {
     render(<TimelineRunLabel entry={entryOf()} />);
 
     expect(screen.getByText('Refactor (example)').className).toContain('text-foreground');
-    expect(chipOf().className).toContain(runIdentity({ runId: 'run-7', laneIndex: 0 }).chip);
+    expect(chipOf().className).toContain(runIdentity({ laneIndex: 0, seed: 0 }).chip);
   });
 
   it('reads a discarded run in the muted register the discard event next to it uses', () => {
@@ -120,13 +120,13 @@ describe('TimelineRunLabel', () => {
   it('hollows the chip of a discarded run without spending a word on it', () => {
     render(<TimelineRunLabel entry={entryOf({ discardedAt: '2026-08-18T10:00:00Z' })} />);
 
-    expect(chipOf().className).toContain(runIdentity({ runId: 'run-7', laneIndex: 0 }).mutedChip);
-    expect(chipOf().className).not.toContain(runIdentity({ runId: 'run-7', laneIndex: 0 }).chip);
+    expect(chipOf().className).toContain(runIdentity({ laneIndex: 0, seed: 0 }).mutedChip);
+    expect(chipOf().className).not.toContain(runIdentity({ laneIndex: 0, seed: 0 }).chip);
     expect(screen.queryByText('Discarded')).toBeNull();
   });
 
   it('keeps the run identity hue on a discarded run so it stays that run', () => {
-    const { mutedChip } = runIdentity({ runId: 'run-7', laneIndex: 0 });
+    const { mutedChip } = runIdentity({ laneIndex: 0, seed: 0 });
 
     render(<TimelineRunLabel entry={entryOf({ discardedAt: '2026-08-18T10:00:00Z' })} />);
 

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/index.tsx
@@ -80,6 +80,7 @@ export const TimelinePane = ({ session, runs, actions, kickoff }: Props) => {
   const model = useMemo(
     () =>
       buildTimelineGroups({
+        sessionId,
         agents,
         workflows,
         plans,
@@ -89,7 +90,17 @@ export const TimelinePane = ({ session, runs, actions, kickoff }: Props) => {
         events,
         agentKindOverride,
       }),
-    [agentKindOverride, agents, events, externalTasks, plans, questions, workflows, worktrees],
+    [
+      agentKindOverride,
+      agents,
+      events,
+      externalTasks,
+      plans,
+      questions,
+      sessionId,
+      workflows,
+      worktrees,
+    ],
   );
 
   const visibleEntries = useMemo(

--- a/apps/desktop/src/features/session/timeline/buildTimelineGroups.test.ts
+++ b/apps/desktop/src/features/session/timeline/buildTimelineGroups.test.ts
@@ -21,6 +21,7 @@ import type {
 } from '@goodboy/types';
 import type { SessionWorktree } from '@goodboy/db';
 import { buildTimelineGroups, type TimelineAgentEntry } from './buildTimelineGroups';
+import { runIdentity, runIdentitySeed } from './runIdentity';
 
 type TypedStringParams = {
   readonly value: string;
@@ -132,6 +133,7 @@ const question = ({
 });
 
 type BuildParams = {
+  readonly sessionId?: SessionId;
   readonly agents: ReadonlyArray<Agent>;
   readonly workflows?: ReadonlyArray<ReturnType<typeof attachedWorkflow>>;
   readonly questions?: ReadonlyArray<OpenQuestion>;
@@ -141,6 +143,7 @@ type BuildParams = {
 };
 
 const build = ({
+  sessionId = SESSION_ID,
   agents,
   workflows = [],
   questions = [],
@@ -149,6 +152,7 @@ const build = ({
   events = [],
 }: BuildParams) =>
   buildTimelineGroups({
+    sessionId,
     agents,
     workflows,
     plans: [],
@@ -276,9 +280,11 @@ describe('buildTimelineGroups', () => {
       entry.kind === 'run' ? [[entry.run.id, entry.identity.index] satisfies [string, number]] : [],
     );
 
+    const seed = runIdentitySeed({ sessionId: SESSION_ID });
+
     expect(identities).toEqual([
-      ['run-2', 1],
-      ['run-1', 0],
+      ['run-2', runIdentity({ laneIndex: 1, seed }).index],
+      ['run-1', runIdentity({ laneIndex: 0, seed }).index],
     ]);
   });
 
@@ -308,9 +314,58 @@ describe('buildTimelineGroups', () => {
       );
     const beforeIndexes = indexesOf({ model: before });
     const afterIndexes = indexesOf({ model: after });
+    const seed = runIdentitySeed({ sessionId: SESSION_ID });
 
-    expect(afterIndexes.get(WORKFLOW_RUN_ID)).toBe(beforeIndexes.get(WORKFLOW_RUN_ID));
-    expect(afterIndexes.get(OTHER_RUN_ID)).toBe(beforeIndexes.get(OTHER_RUN_ID));
+    expect(beforeIndexes.get(WORKFLOW_RUN_ID)).toBe(runIdentity({ laneIndex: 0, seed }).index);
+    expect(beforeIndexes.get(OTHER_RUN_ID)).toBe(runIdentity({ laneIndex: 1, seed }).index);
+    expect(afterIndexes.get(WORKFLOW_RUN_ID)).toBe(runIdentity({ laneIndex: 0, seed }).index);
+    expect(afterIndexes.get(OTHER_RUN_ID)).toBe(runIdentity({ laneIndex: 1, seed }).index);
+  });
+
+  it('assigns adjacent lanes different palette indices for every seed', () => {
+    for (let seed = 0; seed < 5; seed += 1) {
+      for (let laneIndex = 0; laneIndex < 5; laneIndex += 1) {
+        const current = runIdentity({ laneIndex, seed });
+        const adjacent = runIdentity({ laneIndex: laneIndex + 1, seed });
+
+        expect(current.index).not.toBe(adjacent.index);
+      }
+    }
+  });
+
+  it('starts different sessions at different lane-zero indices', () => {
+    const firstSessionId = typedString<SessionId>({ value: 'session-alpha' });
+    const secondSessionId = typedString<SessionId>({ value: 'session-beta' });
+    const firstSeed = runIdentitySeed({ sessionId: firstSessionId });
+    const secondSeed = runIdentitySeed({ sessionId: secondSessionId });
+
+    expect(firstSeed).not.toBe(secondSeed);
+
+    const first = build({ sessionId: firstSessionId, workflows: [attachedWorkflow()], agents: [] });
+    const second = build({
+      sessionId: secondSessionId,
+      workflows: [attachedWorkflow()],
+      agents: [],
+    });
+    const firstRun = first.entries.find((entry) => entry.kind === 'run');
+    const secondRun = second.entries.find((entry) => entry.kind === 'run');
+
+    expect(firstRun?.kind === 'run' ? firstRun.identity.index : null).not.toBe(
+      secondRun?.kind === 'run' ? secondRun.identity.index : null,
+    );
+  });
+
+  it('returns identical identity indices for identical builds', () => {
+    const workflows = [
+      attachedWorkflow({ createdAt: '2026-08-17T08:00:00Z' }),
+      attachedWorkflow({ runId: OTHER_RUN_ID, createdAt: '2026-08-17T09:00:00Z' }),
+    ];
+    const identityIndexesOf = ({ model }: { readonly model: ReturnType<typeof build> }) =>
+      model.entries.flatMap((entry) => (entry.kind === 'run' ? [entry.identity.index] : []));
+
+    expect(identityIndexesOf({ model: build({ workflows, agents: [] }) })).toEqual(
+      identityIndexesOf({ model: build({ workflows, agents: [] }) }),
+    );
   });
 
   it('nests a sub-agent under its parent with the parent ordinal as its prefix', () => {
@@ -618,10 +673,17 @@ describe('buildTimelineGroups, agent chains', () => {
     const firstRun = model.entries.find((entry) => entry.id === 'run:run-1');
     const chain = model.entries.find((entry) => entry.id === 'agent:planner');
     const secondRun = model.entries.find((entry) => entry.id === 'run:run-2');
+    const seed = runIdentitySeed({ sessionId: SESSION_ID });
 
-    expect(firstRun?.kind === 'run' ? firstRun.identity.index : null).toBe(0);
-    expect(chain?.kind === 'agent' ? chain.chain?.identity.index : null).toBe(1);
-    expect(secondRun?.kind === 'run' ? secondRun.identity.index : null).toBe(2);
+    expect(firstRun?.kind === 'run' ? firstRun.identity.index : null).toBe(
+      runIdentity({ laneIndex: 0, seed }).index,
+    );
+    expect(chain?.kind === 'agent' ? chain.chain?.identity.index : null).toBe(
+      runIdentity({ laneIndex: 1, seed }).index,
+    );
+    expect(secondRun?.kind === 'run' ? secondRun.identity.index : null).toBe(
+      runIdentity({ laneIndex: 2, seed }).index,
+    );
   });
 
   it('marks a standalone agent with descendants as a chain without renaming it', () => {

--- a/apps/desktop/src/features/session/timeline/buildTimelineGroups.ts
+++ b/apps/desktop/src/features/session/timeline/buildTimelineGroups.ts
@@ -5,13 +5,14 @@ import type {
   PlanWithCount,
   SessionEvent,
   SessionExternalTask,
+  SessionId,
   Workflow,
   WorkflowRun,
 } from '@goodboy/types';
 import { classifyAgent, type AgentKind } from '../agent-kind';
 import { attachedQuestionsFor } from './attachedQuestions';
 import { earliestEvidence, resolveAgentCreation, type AgentCreation } from './agentCreation';
-import { runIdentity, type RunIdentity } from './runIdentity';
+import { runIdentity, runIdentitySeed, type RunIdentity } from './runIdentity';
 
 export type TimelineChain = {
   readonly identity: RunIdentity;
@@ -99,6 +100,7 @@ type AttachedWorkflow = {
 };
 
 type Params = {
+  readonly sessionId: SessionId;
   readonly agents: ReadonlyArray<Agent>;
   readonly workflows: ReadonlyArray<AttachedWorkflow>;
   readonly plans: ReadonlyArray<PlanWithCount>;
@@ -164,6 +166,7 @@ const compareNewestFirst = (first: SortableEntry, second: SortableEntry): number
 };
 
 export const buildTimelineGroups = ({
+  sessionId,
   agents,
   workflows,
   plans,
@@ -173,6 +176,7 @@ export const buildTimelineGroups = ({
   events,
   agentKindOverride,
 }: Params): TimelineModel => {
+  const seed = runIdentitySeed({ sessionId });
   const liveAgents = agents.filter((agent) => agent.deletedAt == null);
   const creations = resolveAgentCreation({ agents: liveAgents });
   const byOrdinal = [...liveAgents].sort((first, second) => first.ordinal - second.ordinal);
@@ -209,7 +213,7 @@ export const buildTimelineGroups = ({
     if (laneIndex === undefined) {
       throw new Error(`lane identity is missing for ${runId}`);
     }
-    return runIdentity({ runId, laneIndex });
+    return runIdentity({ laneIndex, seed });
   };
 
   const stepsByRunId = new Map<string, ReadonlyArray<Agent>>();

--- a/apps/desktop/src/features/session/timeline/buildTimelineStream.test.ts
+++ b/apps/desktop/src/features/session/timeline/buildTimelineStream.test.ts
@@ -26,6 +26,7 @@ import { buildTimelineGroups } from './buildTimelineGroups';
 import { buildTimelineStream, type TimelineStreamItem } from './buildTimelineStream';
 import { dayLabel } from './dayLabel';
 import { layoutTimelineRail } from './railGeometry';
+import { runIdentity, runIdentitySeed } from './runIdentity';
 import { markerCenterY, TIMELINE_RHYTHM } from './timelineRhythm';
 
 type TypedStringParams = {
@@ -189,6 +190,7 @@ const stream = ({
 }: StreamParams) =>
   buildTimelineStream({
     entries: buildTimelineGroups({
+      sessionId: SESSION_ID,
       agents,
       workflows,
       plans,
@@ -611,6 +613,7 @@ describe('buildTimelineStream', () => {
     const clusters = items.flatMap((item, index) =>
       item.kind === 'cluster' ? [{ item, rail: layout.rows[index] }] : [],
     );
+    const seed = runIdentitySeed({ sessionId: SESSION_ID });
 
     expect(items.map(labelOf)).toEqual([
       'now',
@@ -622,7 +625,10 @@ describe('buildTimelineStream', () => {
       'entry:run:run-1',
     ]);
     expect(clusters.map(({ item }) => item.groupId)).toEqual(['lane:run:run-2', 'lane:run:run-1']);
-    expect(clusters.map(({ item }) => item.identity.index)).toEqual([1, 0]);
+    expect(clusters.map(({ item }) => item.identity.index)).toEqual([
+      runIdentity({ laneIndex: 1, seed }).index,
+      runIdentity({ laneIndex: 0, seed }).index,
+    ]);
     expect(clusters.every(({ rail }) => rail?.markerColumn === 0)).toBe(true);
     expect(
       new Set(clusters.flatMap(({ rail }) => rail?.joins.map((join) => join.laneColumn) ?? []))

--- a/apps/desktop/src/features/session/timeline/runIdentity.test.ts
+++ b/apps/desktop/src/features/session/timeline/runIdentity.test.ts
@@ -1,22 +1,28 @@
 import { describe, expect, it } from 'vitest';
-import { runIdentity, runIdentityStroke } from './runIdentity';
+import { runIdentity, runIdentitySeed, runIdentityStroke } from './runIdentity';
 
 describe('runIdentity', () => {
-  it('maps a lane index to its palette slot', () => {
-    expect(runIdentity({ runId: 'run-1', laneIndex: 0 }).index).toBe(0);
-    expect(runIdentity({ runId: 'run-2', laneIndex: 1 }).index).toBe(1);
+  it('walks the palette with stride two from the seed', () => {
+    expect(
+      Array.from({ length: 5 }, (_, laneIndex) => runIdentity({ laneIndex, seed: 3 }).index),
+    ).toEqual([3, 0, 2, 4, 1]);
+    expect(runIdentity({ laneIndex: 5, seed: 3 }).index).toBe(3);
   });
 
   it('cycles the five-slot palette', () => {
-    expect(runIdentity({ runId: 'run-wrap', laneIndex: 5 })).toEqual(
-      runIdentity({ runId: 'run-1', laneIndex: 0 }),
+    expect(runIdentity({ laneIndex: 5, seed: 0 })).toEqual(runIdentity({ laneIndex: 0, seed: 0 }));
+  });
+
+  it('returns a deterministic seed for a session', () => {
+    expect(runIdentitySeed({ sessionId: 'session-1' })).toBe(
+      runIdentitySeed({ sessionId: 'session-1' }),
     );
   });
 
   it('never borrows a semantic tone', () => {
     const tones = ['success', 'danger', 'warning', 'info', 'accent', 'plan', 'neutral'];
     for (let index = 0; index < 40; index += 1) {
-      const identity = runIdentity({ runId: `run-${index}`, laneIndex: index });
+      const identity = runIdentity({ laneIndex: index, seed: 0 });
       expect(tones.some((tone) => identity.stroke.includes(tone))).toBe(false);
       expect(tones.some((tone) => identity.chip.includes(tone))).toBe(false);
       expect(identity.stroke.startsWith('var(--color-run-')).toBe(true);
@@ -24,7 +30,7 @@ describe('runIdentity', () => {
   });
 
   it('offers the same identity to a chip as to its lane', () => {
-    const identity = runIdentity({ runId: 'run-7', laneIndex: 4 });
+    const identity = runIdentity({ laneIndex: 4, seed: 0 });
     const slot = identity.index + 1;
 
     expect(identity.stroke).toBe(`var(--color-run-${slot})`);
@@ -32,7 +38,7 @@ describe('runIdentity', () => {
   });
 
   it('reads a lane stroke back from the index the geometry carries', () => {
-    const identity = runIdentity({ runId: 'run-7', laneIndex: 4 });
+    const identity = runIdentity({ laneIndex: 4, seed: 0 });
 
     expect(runIdentityStroke({ index: identity.index })).toBe(identity.stroke);
   });

--- a/apps/desktop/src/features/session/timeline/runIdentity.ts
+++ b/apps/desktop/src/features/session/timeline/runIdentity.ts
@@ -38,13 +38,25 @@ const IDENTITIES: ReadonlyArray<RunIdentity> = [
   },
 ];
 
-type Params = {
-  readonly runId: string;
-  readonly laneIndex: number;
+const IDENTITY_STRIDE = 2;
+
+export const runIdentitySeed = ({ sessionId }: { readonly sessionId: string }): number => {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < sessionId.length; index += 1) {
+    hash ^= sessionId.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash % IDENTITIES.length;
 };
 
-export const runIdentity = ({ runId: _runId, laneIndex }: Params): RunIdentity => {
-  const identity = IDENTITIES[laneIndex % IDENTITIES.length];
+export const runIdentity = ({
+  laneIndex,
+  seed,
+}: {
+  readonly laneIndex: number;
+  readonly seed: number;
+}): RunIdentity => {
+  const identity = IDENTITIES[(seed + laneIndex * IDENTITY_STRIDE) % IDENTITIES.length];
   if (identity === undefined) {
     throw new Error('run identity palette is empty');
   }


### PR DESCRIPTION
## Summary
- the first workflow lane of every session was always violet: `runIdentity` ignored the run id and mapped `laneIndex % 5` straight onto the palette
- adds `runIdentitySeed` (FNV-1a over the session id, dependency free) and walks the unchanged 5-slot palette with stride 2 from that seed: colors are stable within a session across rebuilds (no flicker), vary across sessions (violet-first only one fifth of the time), and adjacent lanes always land on non-adjacent palette slots for stronger tonal separation
- `buildTimelineGroups` receives the session id and computes the seed once; benchmark: slack derives member colors from a deterministic id hash, stable per user, never random per render

## Tests
- seed 3 walk yields 3, 0, 2, 4, 1 with wrap; adjacent lanes differ for every seed; distinct-seed sessions get distinct lane-0 colors; appended runs keep earlier identities under the same session id; two identical builds are index-identical
- 249 tests green across 18 timeline files; desktop typecheck green

🤖 Generated with [Claude Code](https://claude.com/claude-code)