### PR TITLE
fix(ui): queue coalesced reruns for orchestration and advance

### DIFF
--- a/apps/desktop/src/store/slices/workflows/maybeAutoAdvanceWorkflow.test.ts
+++ b/apps/desktop/src/store/slices/workflows/maybeAutoAdvanceWorkflow.test.ts
@@ -128,7 +128,11 @@ const harness = (state: StoreState) => {
     }
     Object.assign(state, updater as StoreState);
   });
-  return { set: set as never, get: (() => state) as never };
+  const get = () => state;
+  if (typeof state['maybeAutoAdvanceWorkflow'] !== 'function') {
+    state['maybeAutoAdvanceWorkflow'] = maybeAutoAdvanceWorkflow(set as never, get as never);
+  }
+  return { set: set as never, get: get as never };
 };
 
 beforeEach(() => {
@@ -138,6 +142,37 @@ beforeEach(() => {
 });
 
 describe('maybeAutoAdvanceWorkflow', () => {
+  it('reruns once when another advance arrives in flight', async () => {
+    const openQuestionsGate: { release: (() => void) | null } = { release: null };
+    listOpenQuestionsSpy.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          openQuestionsGate.release = () => resolve([]);
+        }),
+    );
+    const state = baseState(['s0'], [makeAgent('s0', 'pending', 0)]);
+    state['pendingAdvanceSessions'] = new Set<SessionId>();
+    const { set, get } = harness(state);
+    const advance = vi.fn(maybeAutoAdvanceWorkflow(set, get));
+    state['maybeAutoAdvanceWorkflow'] = advance;
+
+    const first = advance(SESSION_ID);
+    await vi.waitFor(() => expect(listOpenQuestionsSpy).toHaveBeenCalledTimes(1));
+    await advance(SESSION_ID);
+
+    expect(state['pendingAdvanceSessions']).toEqual(new Set([SESSION_ID]));
+
+    if (openQuestionsGate.release == null) {
+      throw new Error('open questions query was not reached');
+    }
+    openQuestionsGate.release();
+    await first;
+    await vi.waitFor(() => expect(advance).toHaveBeenCalledTimes(3));
+    await vi.waitFor(() => expect(state['activateWorkflowAgent']).toHaveBeenCalledTimes(2));
+
+    expect(state['pendingAdvanceSessions']).toEqual(new Set());
+  });
+
   it('activates the next pending step once its predecessors are done', async () => {
     const state = baseState(
       ['s0', 's1', 's2'],
@@ -264,7 +299,7 @@ describe('maybeAutoAdvanceWorkflow', () => {
     expect(state['emitNotification']).not.toHaveBeenCalled();
   });
 
-  it('spawns a single agent when two advances race', async () => {
+  it('reruns after two advances race', async () => {
     let release = () => {};
     const gate = new Promise<void>((resolve) => {
       release = resolve;
@@ -279,7 +314,7 @@ describe('maybeAutoAdvanceWorkflow', () => {
     const second = advance(SESSION_ID);
     release();
     await Promise.all([first, second]);
-    expect(state['activateWorkflowAgent']).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(state['activateWorkflowAgent']).toHaveBeenCalledTimes(2));
   });
 
   it('starts a chained run and activates its first step in the same pass', async () => {

--- a/apps/desktop/src/store/slices/workflows/maybeAutoAdvanceWorkflow.ts
+++ b/apps/desktop/src/store/slices/workflows/maybeAutoAdvanceWorkflow.ts
@@ -231,6 +231,9 @@ const runAdvance = async ({ set, get, sessionId }: Params): Promise<void> => {
 export const maybeAutoAdvanceWorkflow = (set: SetFn, get: GetFn) => {
   return async (sessionId: SessionId) => {
     if (advanceInFlight.has(sessionId)) {
+      set((state) => ({
+        pendingAdvanceSessions: new Set([...(state.pendingAdvanceSessions ?? []), sessionId]),
+      }));
       return;
     }
     advanceInFlight.add(sessionId);
@@ -238,6 +241,15 @@ export const maybeAutoAdvanceWorkflow = (set: SetFn, get: GetFn) => {
       await runAdvance({ set, get, sessionId });
     } finally {
       advanceInFlight.delete(sessionId);
+      const pendingAdvanceSessions = get().pendingAdvanceSessions ?? new Set<SessionId>();
+      if (pendingAdvanceSessions.has(sessionId)) {
+        const nextPendingAdvanceSessions = new Set(pendingAdvanceSessions);
+        nextPendingAdvanceSessions.delete(sessionId);
+        set({ pendingAdvanceSessions: nextPendingAdvanceSessions });
+        queueMicrotask(() => {
+          void get().maybeAutoAdvanceWorkflow(sessionId);
+        });
+      }
     }
   };
 };

--- a/apps/desktop/src/store/slices/workflows/orchestrateNextStep.test.ts
+++ b/apps/desktop/src/store/slices/workflows/orchestrateNextStep.test.ts
@@ -254,7 +254,11 @@ const harness = (state: State) => {
     }
     Object.assign(state, updater as State);
   });
-  return { set: set as never, get: (() => state) as never };
+  const get = () => state;
+  if (typeof state['orchestrateNextStep'] !== 'function') {
+    state['orchestrateNextStep'] = orchestrateNextStep(set as never, get as never);
+  }
+  return { set: set as never, get: get as never };
 };
 
 beforeEach(() => {
@@ -278,6 +282,105 @@ beforeEach(() => {
 });
 
 describe('orchestrateNextStep', () => {
+  it('queues one merged rerun while orchestration is in flight', async () => {
+    const openQuestionsGate: { release: (() => void) | null } = { release: null };
+    listOpenQuestionsSpy.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          openQuestionsGate.release = () => resolve([]);
+        }),
+    );
+    decideSpy.mockResolvedValue({
+      usage: NO_USAGE,
+      model: 'claude-haiku-4-5',
+      decision: { action: 'done', reason: 'all set' },
+    });
+    const state = baseState();
+    state['pendingOrchestrations'] = {};
+    const { set, get } = harness(state);
+    const orchestrate = vi.fn(orchestrateNextStep(set, get));
+    state['orchestrateNextStep'] = orchestrate;
+
+    const first = orchestrate(SESSION_ID, WORKFLOW_RUN_ID);
+    await vi.waitFor(() => expect(listOpenQuestionsSpy).toHaveBeenCalledTimes(1));
+    await orchestrate(SESSION_ID, WORKFLOW_RUN_ID, {
+      bypassGate: true,
+      extraHints: ' first pending hint ',
+      routing: { providerId: 'anthropic', model: 'claude-sonnet-4-5' },
+    });
+
+    expect(decideSpy).not.toHaveBeenCalled();
+    expect(state['pendingOrchestrations']).toEqual({
+      [WORKFLOW_RUN_ID]: {
+        sessionId: SESSION_ID,
+        bypassGate: true,
+        extraHints: ['first pending hint'],
+        routing: { providerId: 'anthropic', model: 'claude-sonnet-4-5' },
+      },
+    });
+
+    if (openQuestionsGate.release == null) {
+      throw new Error('open questions gate was not reached');
+    }
+    openQuestionsGate.release();
+    await first;
+    await vi.waitFor(() => expect(orchestrate).toHaveBeenCalledTimes(3));
+
+    expect(orchestrate).toHaveBeenLastCalledWith(SESSION_ID, WORKFLOW_RUN_ID, {
+      bypassGate: true,
+      extraHints: 'first pending hint',
+      routing: { providerId: 'anthropic', model: 'claude-sonnet-4-5' },
+    });
+    expect(state['pendingOrchestrations']).toEqual({});
+  });
+
+  it('coalesces three concurrent calls into one rerun with deduped hints and last routing', async () => {
+    const openQuestionsGate: { release: (() => void) | null } = { release: null };
+    listOpenQuestionsSpy.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          openQuestionsGate.release = () => resolve([]);
+        }),
+    );
+    decideSpy.mockResolvedValue({
+      usage: NO_USAGE,
+      model: 'claude-haiku-4-5',
+      decision: { action: 'done', reason: 'all set' },
+    });
+    const state = baseState();
+    state['pendingOrchestrations'] = {};
+    const { set, get } = harness(state);
+    const orchestrate = vi.fn(orchestrateNextStep(set, get));
+    state['orchestrateNextStep'] = orchestrate;
+
+    const first = orchestrate(SESSION_ID, WORKFLOW_RUN_ID);
+    await vi.waitFor(() => expect(listOpenQuestionsSpy).toHaveBeenCalledTimes(1));
+    await orchestrate(SESSION_ID, WORKFLOW_RUN_ID, {
+      extraHints: 'first hint',
+      routing: { providerId: 'anthropic', model: 'claude-haiku-4-5' },
+    });
+    await orchestrate(SESSION_ID, WORKFLOW_RUN_ID, {
+      bypassGate: true,
+      extraHints: 'second hint',
+      routing: { providerId: 'anthropic', model: 'claude-sonnet-4-5' },
+    });
+    await orchestrate(SESSION_ID, WORKFLOW_RUN_ID, { extraHints: 'first hint' });
+
+    if (openQuestionsGate.release == null) {
+      throw new Error('open questions gate was not reached');
+    }
+    openQuestionsGate.release();
+    await first;
+    await vi.waitFor(() => expect(orchestrate).toHaveBeenCalledTimes(5));
+
+    expect(orchestrate).toHaveBeenLastCalledWith(SESSION_ID, WORKFLOW_RUN_ID, {
+      bypassGate: true,
+      extraHints: 'first hint\n\nsecond hint',
+      routing: { providerId: 'anthropic', model: 'claude-sonnet-4-5' },
+    });
+    expect(state['pendingOrchestrations']).toEqual({});
+  });
+
   it('returns before doing work when the run already has an operator stop', async () => {
     const state = baseState();
     const sessions = state['sessions'] as ReadonlyArray<Session>;

--- a/apps/desktop/src/store/slices/workflows/orchestrateNextStep.ts
+++ b/apps/desktop/src/store/slices/workflows/orchestrateNextStep.ts
@@ -448,6 +448,26 @@ export const orchestrateNextStep = (set: SetFn, get: GetFn) => {
     options?: OrchestrateOptions,
   ): Promise<void> => {
     if (orchestrationInFlight.has(workflowRunId)) {
+      set((state) => {
+        const previous = state.pendingOrchestrations?.[workflowRunId];
+        const extraHint = options?.extraHints?.trim() ?? '';
+        const extraHints = [...(previous?.extraHints ?? [])];
+        if (extraHint !== '' && !extraHints.includes(extraHint)) {
+          extraHints.push(extraHint);
+        }
+        const routing = options?.routing ?? previous?.routing;
+        return {
+          pendingOrchestrations: {
+            ...(state.pendingOrchestrations ?? {}),
+            [workflowRunId]: {
+              sessionId,
+              bypassGate: (previous?.bypassGate ?? false) || (options?.bypassGate ?? false),
+              extraHints,
+              ...(routing != null && { routing }),
+            },
+          },
+        };
+      });
       return;
     }
     orchestrationInFlight.add(workflowRunId);
@@ -777,6 +797,23 @@ export const orchestrateNextStep = (set: SetFn, get: GetFn) => {
     } finally {
       orchestrationInFlight.delete(workflowRunId);
       setDeciding({ set, workflowRunId, isDeciding: false });
+      const pending = get().pendingOrchestrations?.[workflowRunId];
+      if (pending != null) {
+        set((state) => ({
+          pendingOrchestrations: Object.fromEntries(
+            Object.entries(state.pendingOrchestrations ?? {}).filter(
+              ([pendingWorkflowRunId]) => pendingWorkflowRunId !== workflowRunId,
+            ),
+          ),
+        }));
+        queueMicrotask(() => {
+          void get().orchestrateNextStep(pending.sessionId, workflowRunId, {
+            ...(pending.bypassGate && { bypassGate: true }),
+            ...(pending.extraHints.length > 0 && { extraHints: pending.extraHints.join('\n\n') }),
+            ...(pending.routing != null && { routing: pending.routing }),
+          });
+        });
+      }
     }
   };
 };

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -208,6 +208,7 @@ export type {
   SummarizerSessionStatus,
   SystemAlert,
   SystemAlertKind,
+  PendingOrchestration,
 } from './types';
 
 type SaveScriptParams = {
@@ -949,6 +950,8 @@ export const initialState: AppState = {
   sessionWorkflows: {},
   sessionPhaseRuns: {},
   orchestratingWorkflowRuns: {},
+  pendingOrchestrations: {},
+  pendingAdvanceSessions: new Set<SessionId>(),
   announcedWorkflowBlocks: {},
   announcedRunBudget: {},
   selectedAgentId: {},

--- a/apps/desktop/src/store/types.ts
+++ b/apps/desktop/src/store/types.ts
@@ -19,6 +19,7 @@ import type {
   Message,
   OpenQuestion,
   OpenQuestionId,
+  OrchestratorRouting,
   OverrideSettings,
   PendingResolution,
   PlanConsumption,
@@ -175,6 +176,13 @@ export type SummarizerSessionStatus = {
   } | null;
 };
 
+export type PendingOrchestration = {
+  readonly sessionId: SessionId;
+  readonly bypassGate: boolean;
+  readonly extraHints: ReadonlyArray<string>;
+  readonly routing?: OrchestratorRouting;
+};
+
 type AppSliceState = UpdaterState & ChangelogState & SlackThreadsSliceState & BugReportDraftState;
 
 export type AppState = AppSliceState & {
@@ -242,6 +250,8 @@ export type AppState = AppSliceState & {
   readonly sessionWorkflows: Readonly<Record<SessionId, ReadonlyArray<Workflow>>>;
   readonly sessionPhaseRuns: Readonly<Record<SessionId, ReadonlyArray<Agent>>>;
   readonly orchestratingWorkflowRuns: Readonly<Record<WorkflowRunId, boolean>>;
+  readonly pendingOrchestrations: Readonly<Record<WorkflowRunId, PendingOrchestration>>;
+  readonly pendingAdvanceSessions: ReadonlySet<SessionId>;
   readonly announcedWorkflowBlocks: Readonly<Record<WorkflowRunId, string>>;
   readonly announcedRunBudget: Readonly<Record<WorkflowRunId, number>>;
   readonly selectedAgentId: Readonly<Record<SessionId, AgentId | null>>;


### PR DESCRIPTION
## Summary
- `orchestrateNextStep` and `maybeAutoAdvanceWorkflow` silently dropped concurrent calls at their in-flight guards: a turn finishing during an in-flight orchestration was simply lost, stalling the run until an unrelated trigger (this is the class of stall `recoverStuckStep` papers over), and a dropped call also lost caller intent (`bypassGate` from skip recovery, `extraHints` from continue)
- adds coalesced pending-rerun queues in inspectable store state (`pendingOrchestrations` per run, `pendingAdvanceSessions` per session), drained via `queueMicrotask` in each `finally` after the guard release, mirroring the summarizer queue pattern already in `turn-helpers.ts`
- merge policy: `bypassGate` ORs, hints concatenate deduped, routing last-wins; benchmark: GitHub Actions concurrency groups with one queued latest run, nothing dropped

## Tests
- two concurrent orchestrations: the second records the merged pending entry, release triggers exactly one follow-up carrying `bypassGate: true` and both hints, queue empty after
- three concurrent calls coalesce to one pending; auto-advance during in-flight advance re-runs once
- 88 tests green across the two suites plus skip/continue callers; desktop typecheck green

🤖 Generated with [Claude Code](https://claude.com/claude-code)