### PR TITLE
fix(ui): drop the removed system alerts key from the registry

### DIFF
--- a/apps/desktop/src/store/sessionEviction.ts
+++ b/apps/desktop/src/store/sessionEviction.ts
@@ -124,7 +124,6 @@ export const NON_SESSION_STATE_KEYS = [
   'budgetRules',
   'providerSpendBreakdown',
   'budgetAlerts',
-  'systemAlerts',
   'skills',
   'projectScripts',
   'phaseTemplates',


### PR DESCRIPTION
## Summary
- #1580 merged at a head that predated this one-line fix: the eviction registry still classified `systemAlerts`, a key #1575 had removed from `AppState`, so the registry's own exhaustiveness gate broke typecheck on main
- removes the dead entry; the gate is doing exactly its job, this realigns the declaration

## Tests
- desktop typecheck green with this applied on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)