### PR TITLE
feat(db): purge heavy data and soft delete sessions

### DIFF
--- a/apps/desktop/src/store/slices/sessions/deleteTask.teardown.test.ts
+++ b/apps/desktop/src/store/slices/sessions/deleteTask.teardown.test.ts
@@ -5,7 +5,7 @@ const order: Array<string> = [];
 const {
   removeWorktree,
   listWorktreesForSession,
-  deleteSession,
+  purgeSessionForDelete,
   deleteGithubPrCacheForWorktreePath,
 } = vi.hoisted(() => ({
   removeWorktree: vi.fn(async () => undefined),
@@ -17,13 +17,13 @@ const {
       parallelIndex: 0,
     },
   ]),
-  deleteSession: vi.fn(async () => undefined),
+  purgeSessionForDelete: vi.fn(async () => undefined),
   deleteGithubPrCacheForWorktreePath: vi.fn(async () => 1),
 }));
 
 vi.mock('@goodboy/db', () => ({
   listWorktreesForSession,
-  deleteSession,
+  purgeSessionForDelete,
   deleteGithubPrCacheForWorktreePath,
 }));
 vi.mock('../../../shared/lib/db', () => ({ tauriDatabase: {} }));
@@ -74,6 +74,7 @@ describe('deleting a session', () => {
       db: {},
       worktreePath: '/repo/.goodboy/worktrees/gb-ghost',
     });
+    expect(purgeSessionForDelete).toHaveBeenCalledWith({ db: {}, id: SESSION_ID });
   });
 
   it('reports the paths it could not remove', async () => {

--- a/apps/desktop/src/store/slices/sessions/deleteTask.ts
+++ b/apps/desktop/src/store/slices/sessions/deleteTask.ts
@@ -2,8 +2,8 @@ import type { ProviderRunId, SessionId } from '@goodboy/types';
 import { formatError } from '@goodboy/ui';
 import {
   deleteGithubPrCacheForWorktreePath,
-  deleteSession as deleteSessionFromDb,
   listWorktreesForSession,
+  purgeSessionForDelete,
 } from '@goodboy/db';
 import { tauriDatabase } from '../../../shared/lib/db';
 import { cancelTurn } from '../../../features/chat/turn';
@@ -103,7 +103,7 @@ export const deleteTask = (set: SetFn, get: GetFn) => {
     }
     const sessionGoal = session.goal;
     const sessionWorkspaceId = session.workspaceId;
-    await deleteSessionFromDb(tauriDatabase, sessionId);
+    await purgeSessionForDelete({ db: tauriDatabase, id: sessionId });
     dropPendingTurnEvents({
       agentIds: (get().sessionPhaseRuns[sessionId] ?? []).map((agent) => agent.id),
     });

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -75,6 +75,7 @@ export {
   listArchivedSessionRefs,
   renameSession,
   deleteSession,
+  purgeSessionForDelete,
   softDeleteSession,
   restoreSession,
   archiveSession,

--- a/packages/db/src/queries/impact.test.ts
+++ b/packages/db/src/queries/impact.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { WorkspaceId } from '@goodboy/types';
+import type { SessionId, WorkspaceId } from '@goodboy/types';
 import type { Database } from '../client';
 import { migrate } from '../migrations/runner';
 import { makeTestDatabase } from '../test-helpers/test-db';
@@ -15,6 +15,7 @@ import {
   getRightSizeNudgeOutcomes,
   getTurnDistribution,
 } from './impact';
+import { purgeSessionForDelete } from './session';
 
 const workspaceId = 'w1' as WorkspaceId;
 const otherWorkspaceId = 'w2' as WorkspaceId;
@@ -275,11 +276,17 @@ describe('pull request outcomes', () => {
         RECENT,
       ],
     );
+    await addTelemetry({
+      db,
+      seed: { id: 't-s1', runId: 'r-s1', sessionId: 's1', at: RECENT, cost: 2.5 },
+    });
+
+    await purgeSessionForDelete({ db, id: 's1' as SessionId });
 
     const result = await getPullRequestOutcomes(params({ db, sinceMs: SINCE }));
 
     expect(result).toMatchObject({ open: 0, merged: 1, closed: 0 });
-    expect(result.entries[0]).toMatchObject({ number: 8, sessionId: 's1' });
+    expect(result.entries[0]).toMatchObject({ number: 8, sessionId: 's1', spendUsd: 2.5 });
   });
 
   it('does not double-count spend when a multi-project session has two worktree rows on one branch', async () => {

--- a/packages/db/src/queries/impact.ts
+++ b/packages/db/src/queries/impact.ts
@@ -449,7 +449,6 @@ const selectPullRequests = async ({
               WHERE sw2.branch = g.branch
                 AND sw2.repo_slug = g.repo_slug
                 AND s2.workspace_id = s.workspace_id
-                AND s2.deleted_at IS NULL
            )),
          0
        ) AS spend_usd
@@ -457,7 +456,6 @@ const selectPullRequests = async ({
      JOIN session_worktrees sw ON sw.branch = g.branch AND sw.repo_slug = g.repo_slug
      JOIN sessions s ON s.id = sw.session_id
     WHERE s.workspace_id = ?
-      AND s.deleted_at IS NULL
       AND g.pr_json IS NOT NULL
       AND g.fetched_at >= ?
       AND (? IS NULL OR julianday(json_extract(g.pr_json, '$.updatedAt')) >= julianday(?))

--- a/packages/db/src/queries/session.test.ts
+++ b/packages/db/src/queries/session.test.ts
@@ -1,0 +1,179 @@
+import type { SessionId, WorkspaceId } from '@goodboy/types';
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { Database } from '../client';
+import { migrate } from '../migrations/runner';
+import { makeTestDatabase } from '../test-helpers/test-db';
+import {
+  listArchivedSessionsForWorkspace,
+  listSessionsForWorkspace,
+  purgeSessionForDelete,
+} from './session';
+
+const workspaceId = 'workspace-1' as WorkspaceId;
+const sessionId = 'session-1' as SessionId;
+const otherSessionId = 'session-2' as SessionId;
+
+const countRows = async ({
+  db,
+  table,
+  column,
+  value,
+}: {
+  readonly db: Database;
+  readonly table: string;
+  readonly column: string;
+  readonly value: string;
+}): Promise<number> => {
+  const rows = await db.select<{ count: number }>(
+    `SELECT COUNT(*) AS count FROM ${table} WHERE ${column} = ?`,
+    [value],
+  );
+  return rows[0]?.count ?? 0;
+};
+
+describe('purgeSessionForDelete', () => {
+  let db: Database;
+
+  beforeEach(async () => {
+    db = makeTestDatabase();
+    await migrate(db);
+    await db.execute(
+      'INSERT INTO workspaces (id, name, slug, created_at, updated_at) VALUES (?, ?, ?, 1, 1)',
+      [workspaceId, 'Workspace', '/tmp/workspace'],
+    );
+    await db.execute(
+      `INSERT INTO sessions (id, workspace_id, goal, state_kind, created_at, updated_at)
+       VALUES (?, ?, 'Delete me', 'idle', 1, 1), (?, ?, 'Keep me', 'idle', 2, 2)`,
+      [sessionId, workspaceId, otherSessionId, workspaceId],
+    );
+    await db.execute(
+      `INSERT INTO agents (id, session_id, ordinal, name, status)
+       VALUES ('agent-1', ?, 0, 'Agent', 'completed'),
+              ('agent-2', ?, 0, 'Other agent', 'completed')`,
+      [sessionId, otherSessionId],
+    );
+    await db.execute(
+      `INSERT INTO messages (id, session_id, agent_id, role, content, created_at)
+       VALUES ('message-1', ?, 'agent-1', 'user', 'hello', 1),
+              ('message-2', ?, 'agent-2', 'user', 'hello', 2)`,
+      [sessionId, otherSessionId],
+    );
+    await db.execute(
+      `INSERT INTO turn_events (id, session_id, agent_id, payload, created_at)
+       VALUES ('event-1', ?, 'agent-1', '{}', 1),
+              ('event-2', ?, 'agent-2', '{}', 2)`,
+      [sessionId, otherSessionId],
+    );
+    await db.execute(
+      `INSERT INTO file_versions
+         (id, session_id, relative_path, stored_name, size_bytes, content_hash, change_kind, snapshot_source, captured_at)
+       VALUES ('file-1', ?, 'a', 'a', 1, 'a', 'modified', 'agent_turn', 1),
+              ('file-2', ?, 'b', 'b', 1, 'b', 'modified', 'agent_turn', 2)`,
+      [sessionId, otherSessionId],
+    );
+    await db.execute(
+      `INSERT INTO context_slots (session_id, key, value)
+       VALUES (?, 'key', 'value'), (?, 'key', 'value')`,
+      [sessionId, otherSessionId],
+    );
+    await db.execute(
+      `INSERT INTO context_slot_history (id, session_id, key, value, author, created_at)
+       VALUES ('history-1', ?, 'key', 'value', 'user', 1),
+              ('history-2', ?, 'key', 'value', 'user', 2)`,
+      [sessionId, otherSessionId],
+    );
+    await db.execute(
+      `INSERT INTO workflows (id, workspace_id, name, created_at, updated_at)
+       VALUES ('workflow-1', ?, 'Workflow', 1, 1)`,
+      [workspaceId],
+    );
+    await db.execute(
+      `INSERT INTO session_workflows
+         (workflow_run_id, session_id, workflow_id, ordinal, created_at)
+       VALUES ('run-1', ?, 'workflow-1', 0, 1),
+              ('run-2', ?, 'workflow-1', 0, 2)`,
+      [sessionId, otherSessionId],
+    );
+    await db.execute(
+      `INSERT INTO goal_attachments
+         (id, session_id, workflow_run_id, rel_path, kind, file_name, mime_type, created_at)
+       VALUES ('attachment-session', ?, NULL, 'a', 'file', 'a', 'text/plain', 1),
+              ('attachment-run', NULL, 'run-1', 'b', 'file', 'b', 'text/plain', 1),
+              ('attachment-other', ?, NULL, 'c', 'file', 'c', 'text/plain', 2)`,
+      [sessionId, otherSessionId],
+    );
+    await db.execute(
+      `INSERT INTO provider_runs (id, session_id, provider, model, status_kind, created_at)
+       VALUES ('provider-run-1', ?, 'anthropic', 'model', 'succeeded', 1)`,
+      [sessionId],
+    );
+    await db.execute(
+      `INSERT INTO telemetry_records
+         (id, run_id, session_id, kind, provider, model, input_tokens, output_tokens, estimated_cost_usd, recorded_at)
+       VALUES ('telemetry-1', 'provider-run-1', ?, 'turn', 'anthropic', 'model', 1, 1, 1, 1)`,
+      [sessionId],
+    );
+    await db.execute(
+      `INSERT INTO session_worktrees (id, session_id, worktree_path, branch, created_at)
+       VALUES ('worktree-1', ?, '/tmp/worktree-1', 'branch', 1)`,
+      [sessionId],
+    );
+    await db.execute(
+      `INSERT INTO diff_comments (id, session_id, file_path, body, status, created_at)
+       VALUES ('comment-1', ?, 'file', 'body', 'open', 1)`,
+      [sessionId],
+    );
+  });
+
+  it('purges heavy rows, preserves metrics and links, and hides the session', async () => {
+    await purgeSessionForDelete({ db, id: sessionId });
+
+    const sessions = await db.select<{ deleted_at: number | null; updated_at: number }>(
+      'SELECT deleted_at, updated_at FROM sessions WHERE id = ?',
+      [sessionId],
+    );
+    expect(sessions[0]?.deleted_at).toEqual(expect.any(Number));
+    expect(sessions[0]?.updated_at).toBe(sessions[0]?.deleted_at);
+
+    for (const table of ['messages', 'file_versions', 'context_slots', 'context_slot_history']) {
+      await expect(countRows({ db, table, column: 'session_id', value: sessionId })).resolves.toBe(
+        0,
+      );
+      await expect(
+        countRows({ db, table, column: 'session_id', value: otherSessionId }),
+      ).resolves.toBe(1);
+    }
+    await expect(
+      countRows({ db, table: 'turn_events', column: 'agent_id', value: 'agent-1' }),
+    ).resolves.toBe(0);
+    await expect(
+      countRows({ db, table: 'turn_events', column: 'agent_id', value: 'agent-2' }),
+    ).resolves.toBe(1);
+    await expect(
+      countRows({ db, table: 'goal_attachments', column: 'session_id', value: sessionId }),
+    ).resolves.toBe(0);
+    await expect(
+      countRows({ db, table: 'goal_attachments', column: 'workflow_run_id', value: 'run-1' }),
+    ).resolves.toBe(0);
+    await expect(
+      countRows({ db, table: 'goal_attachments', column: 'session_id', value: otherSessionId }),
+    ).resolves.toBe(1);
+
+    for (const [table, column, value] of [
+      ['agents', 'session_id', sessionId],
+      ['telemetry_records', 'session_id', sessionId],
+      ['session_workflows', 'session_id', sessionId],
+      ['session_worktrees', 'session_id', sessionId],
+      ['diff_comments', 'session_id', sessionId],
+    ]) {
+      await expect(countRows({ db, table, column, value })).resolves.toBe(1);
+    }
+    await expect(
+      countRows({ db, table: 'sessions', column: 'id', value: otherSessionId }),
+    ).resolves.toBe(1);
+    await expect(listSessionsForWorkspace(db, workspaceId)).resolves.toHaveLength(1);
+
+    await db.execute('UPDATE sessions SET archived_at = 1 WHERE id = ?', [sessionId]);
+    await expect(listArchivedSessionsForWorkspace(db, workspaceId)).resolves.toEqual([]);
+  });
+});

--- a/packages/db/src/queries/session.ts
+++ b/packages/db/src/queries/session.ts
@@ -409,6 +409,44 @@ export const deleteSession = async (db: Database, id: SessionId): Promise<void> 
   await db.execute('DELETE FROM sessions WHERE id = ?', [id]);
 };
 
+export const purgeSessionForDelete = async ({
+  db,
+  id,
+}: {
+  readonly db: Database;
+  readonly id: SessionId;
+}): Promise<void> => {
+  await db.exec('BEGIN');
+  try {
+    await db.execute('DELETE FROM messages WHERE session_id = ?', [id]);
+    await db.execute(
+      'DELETE FROM turn_events WHERE agent_id IN (SELECT id FROM agents WHERE session_id = ?)',
+      [id],
+    );
+    await db.execute('DELETE FROM file_versions WHERE session_id = ?', [id]);
+    await db.execute('DELETE FROM context_slots WHERE session_id = ?', [id]);
+    await db.execute('DELETE FROM context_slot_history WHERE session_id = ?', [id]);
+    await db.execute(
+      `DELETE FROM goal_attachments
+       WHERE session_id = ?
+          OR workflow_run_id IN (
+            SELECT workflow_run_id FROM session_workflows WHERE session_id = ?
+          )`,
+      [id, id],
+    );
+    const now = Date.now();
+    await db.execute('UPDATE sessions SET deleted_at = ?, updated_at = ? WHERE id = ?', [
+      now,
+      now,
+      id,
+    ]);
+    await db.exec('COMMIT');
+  } catch (error) {
+    await db.exec('ROLLBACK');
+    throw error;
+  }
+};
+
 export const softDeleteSession = async (db: Database, id: SessionId): Promise<void> => {
   await db.execute('UPDATE sessions SET deleted_at = ? WHERE id = ?', [Date.now(), id]);
 };


### PR DESCRIPTION
## Summary
- deleting a session was `DELETE FROM sessions` + full cascade: transcripts AND metrics died together. New semantics per the retention decision: soft delete plus explicit heavy purge in one transaction, so analytics keep counting the session and external links survive while the heavy payload goes (benchmark: Linear's trash keeps the record, drops nothing analytics needs)
- `purgeSessionForDelete` deletes messages, turn events, file versions, context slots + history, and session/run-owned goal attachments, then stamps `deleted_at`/`updated_at`; kept untouched: agents, telemetry, budget alerts, nudges, diff comments, workflows, plans, questions, external tasks, worktrees, PR cache, resolutions, review drafts, session events, provider runs
- the two `deleted_at IS NULL` filters inside the shipped-PR impact query are removed on purpose: before this change deleted rows never existed, now they must keep counting
- no new migration: `deleted_at` and every listing filter already exist, and all purge paths are already indexed; no vacuum at delete time (compaction belongs to the storage surface)
- `deleteTask` routes through the purge; store-side eviction stays with the #1580 registry

## Tests
- purge leaves the soft-deleted row, wipes the heavy tables, preserves the keep list, leaves other sessions untouched, listings exclude the session, impact still counts it
- full @goodboy/db suite green (333), desktop typecheck green

🤖 Generated with [Claude Code](https://claude.com/claude-code)