### PR TITLE
fix(core): let sandboxed codex reach the bridge and the network

### DIFF
--- a/apps/desktop/src-tauri/src/turn.rs
+++ b/apps/desktop/src-tauri/src/turn.rs
@@ -180,6 +180,8 @@ fn build_provider_cli_args(binary: &str, args: &SpawnOneArgs<'_>) -> Vec<String>
             } else {
                 v.push("-s".to_string());
                 v.push("workspace-write".to_string());
+                v.push("-c".to_string());
+                v.push("sandbox_workspace_write.network_access=true".to_string());
                 for root in args.writable_roots {
                     v.push("--add-dir".to_string());
                     v.push(root.to_string());
@@ -682,6 +684,9 @@ mod tests {
         let cli = build_provider_cli_args("codex", &args);
         let idx = cli.iter().position(|a| a == "-s").expect("-s");
         assert_eq!(cli[idx + 1], "workspace-write");
+        assert!(cli.windows(2).any(|pair| {
+            pair[0] == "-c" && pair[1] == "sandbox_workspace_write.network_access=true"
+        }));
         let added_directories: Vec<&str> = cli
             .windows(2)
             .filter(|pair| pair[0] == "--add-dir")
@@ -702,8 +707,9 @@ mod tests {
         let mut args = make_args(None, None, &empty);
         args.effort = Some("high");
         let cli = build_provider_cli_args("codex", &args);
-        let idx = cli.iter().position(|a| a == "-c").expect("-c");
-        assert_eq!(cli[idx + 1], "model_reasoning_effort=\"high\"");
+        assert!(cli
+            .windows(2)
+            .any(|pair| pair[0] == "-c" && pair[1] == "model_reasoning_effort=\"high\""));
     }
 
     #[test]
@@ -777,6 +783,9 @@ mod tests {
             .any(|a| a == "--dangerously-bypass-approvals-and-sandbox"));
         assert!(!cli.iter().any(|a| a == "-s"));
         assert!(!cli.iter().any(|a| a == "--add-dir"));
+        assert!(!cli.windows(2).any(|pair| {
+            pair[0] == "-c" && pair[1] == "sandbox_workspace_write.network_access=true"
+        }));
         assert!(cli.iter().any(|a| a == "--skip-git-repo-check"));
     }
 

--- a/apps/desktop/src/features/session/hooks/useRebaseAgent/index.test.ts
+++ b/apps/desktop/src/features/session/hooks/useRebaseAgent/index.test.ts
@@ -125,10 +125,18 @@ describe('useRebaseAgent', () => {
       sessionId,
       expect.objectContaining({
         name: 'Rebase on main',
-        initialPrompt: expect.stringContaining('Rebase this session branch onto origin/main.'),
+        initialPrompt: expect.stringContaining(
+          '- Push the rebased branch with "$GOODBOY_BIN" query github push --force-with-lease; fall back to git push --force-with-lease only if the bridge is unavailable.',
+        ),
         provider: 'codex',
         model: 'gpt-5.4',
         effort: 'low',
+      }),
+    );
+    expect(state.spawnAgent).toHaveBeenCalledWith(
+      sessionId,
+      expect.objectContaining({
+        initialPrompt: expect.stringContaining('- Fetch origin main before rebasing.'),
       }),
     );
     expect(state.selectAgent).not.toHaveBeenCalled();

--- a/apps/desktop/src/features/session/hooks/useRebaseAgent/index.ts
+++ b/apps/desktop/src/features/session/hooks/useRebaseAgent/index.ts
@@ -54,7 +54,7 @@ export const useRebaseAgent = ({ sessionId, status, onError }: Params): Result =
     `- Fetch origin ${baseBranch} before rebasing.`,
     `- Rebase the session branch onto origin/${baseBranch} and resolve conflicts by favoring the branch's intent.`,
     "- Run the repository's typecheck to confirm nothing broke.",
-    '- Push the rebased branch with --force-with-lease.',
+    '- Push the rebased branch with "$GOODBOY_BIN" query github push --force-with-lease; fall back to git push --force-with-lease only if the bridge is unavailable.',
     '- Never merge and never touch other branches.',
     '- If a conflict cannot be resolved confidently, stop and report the conflicting files.',
   ].join('\n');


### PR DESCRIPTION
## Summary
- codex `workspace-write` blocks ALL network including unix domain socket connects, verified empirically: a socket connect from inside the sandbox fails with `Operation not permitted` even with `--add-dir` on the socket directory, and `curl` cannot even resolve DNS. So the query bridge was never reachable from codex (mounts only worked through the marker path) and every `git push`/`fetch` died, forcing the switch-to-claude workaround
- the codex spawner now passes `-c sandbox_workspace_write.network_access=true` in the sandboxed path (verified: unblocks both the socket and https while filesystem confinement stays). Codex remains strictly more confined than claude's default bypass: writes stay limited to the worktree plus the v0.2.6 `.git` add-dirs
- the rebase agent kickoff now pushes through the bridge verb (`"$GOODBOY_BIN" query github push --force-with-lease`, host-executed with the user's credentials) with raw git as fallback; fetch stays raw git

## Tests
- rust: sandboxed args include the network pair, bypass path does not (37 turn tests green)
- useRebaseAgent prompt pins updated (9 green); desktop typecheck green

🤖 Generated with [Claude Code](https://claude.com/claude-code)