### PR TITLE
feat(ui): pull chain plans into their lane on the timeline

### DIFF
--- a/apps/desktop/src/features/session/timeline/buildTimelineGroups.ts
+++ b/apps/desktop/src/features/session/timeline/buildTimelineGroups.ts
@@ -39,6 +39,10 @@ export type TimelinePlanEntry = {
   readonly id: string;
   readonly at: string;
   readonly plan: PlanWithCount;
+  readonly lane?: {
+    readonly identity: RunIdentity;
+    readonly rootEntryId: string;
+  };
 };
 
 export type TimelineIssueEntry = {
@@ -190,9 +194,25 @@ export const buildTimelineGroups = ({
     childrenByParentId.set(agent.parentAgentId, [...siblings, agent]);
   }
 
+  const liveAgentById = new Map(byOrdinal.map((agent) => [agent.id, agent]));
+  const chainRootIdByAgentId = new Map<string, Agent['id']>();
+  for (const agent of byOrdinal) {
+    const visitedAgentIds = new Set<string>();
+    let currentAgent: Agent | undefined = agent;
+    while (currentAgent != null && !visitedAgentIds.has(currentAgent.id)) {
+      visitedAgentIds.add(currentAgent.id);
+      if (currentAgent.parentAgentId == null) {
+        chainRootIdByAgentId.set(agent.id, currentAgent.id);
+        break;
+      }
+      currentAgent = liveAgentById.get(currentAgent.parentAgentId);
+    }
+  }
+
   const chainRoots = byOrdinal.filter(
     (agent) => agent.parentAgentId == null && (childrenByParentId.get(agent.id) ?? []).length > 0,
   );
+  const chainRootIds = new Set(chainRoots.map((agent) => agent.id));
   const laneOwners: ReadonlyArray<LaneOwner> = [
     ...workflows.flatMap(({ run }) =>
       run.createdAt == null ? [] : [{ id: run.id, createdAt: run.createdAt }],
@@ -325,7 +345,23 @@ export const buildTimelineGroups = ({
     });
   const standalonePlans: ReadonlyArray<TimelinePlanEntry> = plans
     .filter((plan) => !groupedPlanIds.has(plan.id))
-    .map((plan) => ({ kind: 'plan', id: `plan:${plan.id}`, at: plan.createdAt, plan }));
+    .map((plan) => {
+      const rootId = chainRootIdByAgentId.get(plan.agentId);
+      return {
+        kind: 'plan',
+        id: `plan:${plan.id}`,
+        at: plan.createdAt,
+        plan,
+        ...(rootId != null && chainRootIds.has(rootId)
+          ? {
+              lane: {
+                identity: identityFor({ runId: rootId }),
+                rootEntryId: `agent:${rootId}`,
+              },
+            }
+          : {}),
+      };
+    });
   const issues: ReadonlyArray<TimelineIssueEntry> = externalTasks.map((task) => ({
     kind: 'issue',
     id: `issue:${task.provider}:${task.externalId}`,

--- a/apps/desktop/src/features/session/timeline/buildTimelineStream.test.ts
+++ b/apps/desktop/src/features/session/timeline/buildTimelineStream.test.ts
@@ -1473,6 +1473,66 @@ describe('buildTimelineStream, plan visibility and family anchoring', () => {
 
   const PLAN_RUN_WORKFLOWS = [attachedWorkflow({ createdAt: localIso({ day: 18, hour: 8 }) })];
 
+  type StandalonePlanParams = {
+    readonly id: string;
+    readonly agentId: string;
+  };
+
+  const standalonePlan = ({ id, agentId }: StandalonePlanParams): PlanWithCount => ({
+    id: typedString<PlanId>({ value: id }),
+    sessionId: SESSION_ID,
+    agentId: typedString<AgentId>({ value: agentId }),
+    title: id,
+    bodyMd: '',
+    status: 'active',
+    createdAt: typedString<IsoDateTime>({ value: localIso({ day: 18, hour: 9, minute: 15 }) }),
+    updatedAt: typedString<IsoDateTime>({ value: localIso({ day: 18, hour: 9, minute: 15 }) }),
+    consumptionCount: 0,
+  });
+
+  it('joins plans authored by a chain root and child to the root lane', () => {
+    const { items } = stream({
+      agents: [
+        agent({ id: 'planner', ordinal: 0, startedAt: localIso({ day: 18, hour: 9 }) }),
+        agent({
+          id: 'implementer',
+          ordinal: 1,
+          parentAgentId: 'planner',
+          startedAt: localIso({ day: 18, hour: 10 }),
+        }),
+      ],
+      plans: [
+        standalonePlan({ id: 'root-plan', agentId: 'planner' }),
+        standalonePlan({ id: 'child-plan', agentId: 'implementer' }),
+      ],
+    });
+    const root = items.find((item) => item.kind === 'row' && item.id === 'agent:planner');
+    const planRows = items.filter(
+      (item) =>
+        item.kind === 'row' && (item.id === 'plan:root-plan' || item.id === 'plan:child-plan'),
+    );
+
+    expect(planRows.map((item) => item.groupId)).toEqual([
+      'lane:agent:planner',
+      'lane:agent:planner',
+    ]);
+    expect(planRows.map((item) => (item.kind === 'row' ? item.identity : null))).toEqual([
+      root?.kind === 'row' ? root.identity : null,
+      root?.kind === 'row' ? root.identity : null,
+    ]);
+  });
+
+  it('keeps a plan authored outside a chain on the spine', () => {
+    const { items } = stream({
+      agents: [agent({ id: 'solo', ordinal: 0, startedAt: localIso({ day: 18, hour: 9 }) })],
+      plans: [standalonePlan({ id: 'solo-plan', agentId: 'solo' })],
+    });
+    const planRow = items.find((item) => item.kind === 'row' && item.id === 'plan:solo-plan');
+
+    expect(planRow?.groupId).toBeNull();
+    expect(planRow?.kind === 'row' ? planRow.identity : 'missing').toBeNull();
+  });
+
   it('keeps a run plan in the stream by default', () => {
     const { items } = stream({
       workflows: PLAN_RUN_WORKFLOWS,

--- a/apps/desktop/src/features/session/timeline/buildTimelineStream.ts
+++ b/apps/desktop/src/features/session/timeline/buildTimelineStream.ts
@@ -607,6 +607,24 @@ export const buildTimelineStream = ({
       );
       continue;
     }
+    if (entry.kind === 'plan' && entry.lane != null) {
+      rows.push({
+        kind: 'row',
+        id: entry.id,
+        at: entry.at,
+        grade: 'step',
+        entry,
+        identity: entry.lane.identity,
+        familyId: entry.lane.rootEntryId,
+        groupId: laneIdOf({ entryId: entry.lane.rootEntryId }),
+        ordinal: null,
+        sortOrdinal: 0,
+        markerState: 'done',
+        hasUnread: false,
+        isPending: false,
+      });
+      continue;
+    }
     const row: DraftRow = {
       kind: 'row',
       id: entry.id,


### PR DESCRIPTION
## Summary
- a plan produced inside a standalone agent chain (plan step then implement) rendered on the timeline spine while the chain had its own colored lane, so the artifact looked orphaned from the work that produced and consumes it; plans attached to a workflow run already joined the run lane and that path is untouched
- `buildTimelineGroups` gains an author-to-chain-root resolver over the existing parent graph: a standalone plan whose `agentId` resolves to a lane-owning chain root carries that root's identity and entry id; `buildTimelineStream` then emits it as a step row in `lane:agent:<rootId>` with the lane's identity color
- plans whose author belongs to no chain stay on the spine exactly as before; no schema change, the provenance was already persisted

## Tests
- root-authored and child-authored plans land in the root lane with the lane identity; a non-chain plan keeps a null group; run-scoped plan tests untouched as regression
- 172 timeline tests green across 9 files; desktop typecheck green

🤖 Generated with [Claude Code](https://claude.com/claude-code)