### PR TITLE
fix(core): deny account mcp tools on every claude spawn

### DIFF
--- a/apps/desktop/src-tauri/src/aux_spawn.rs
+++ b/apps/desktop/src-tauri/src/aux_spawn.rs
@@ -2,6 +2,11 @@ use std::process::Command;
 
 pub const CLAUDE_SETTING_SOURCES: &str = "project,local";
 
+pub fn push_claude_mcp_deny(args: &mut Vec<String>) {
+    args.push("--disallowedTools".to_string());
+    args.push("mcp__*".to_string());
+}
+
 /// Strip env vars that signal "running inside another Claude Code / Agent SDK
 /// session". When Goodboy is launched from such a context the vars propagate to
 /// children; the claude CLI then either refuses with a nested-session error or
@@ -46,6 +51,16 @@ mod tests {
     fn setting_sources_keeps_project_and_local_only() {
         assert_eq!(CLAUDE_SETTING_SOURCES, "project,local");
         assert!(!CLAUDE_SETTING_SOURCES.contains("user"));
+    }
+
+    #[test]
+    fn push_claude_mcp_deny_adds_flag_and_pattern() {
+        let mut args = Vec::new();
+        push_claude_mcp_deny(&mut args);
+        assert_eq!(
+            args,
+            vec!["--disallowedTools".to_string(), "mcp__*".to_string()]
+        );
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/planner.rs
+++ b/apps/desktop/src-tauri/src/planner.rs
@@ -100,6 +100,7 @@ fn build_cli_args(args: &PlannerArgs) -> Result<Vec<String>, PlannerError> {
                 cli_args.push("--tools".to_string());
                 cli_args.push(String::new());
             }
+            crate::aux_spawn::push_claude_mcp_deny(&mut cli_args);
             crate::aux_spawn::push_effort_args("anthropic", args.effort.as_deref(), &mut cli_args);
             Ok(cli_args)
         }
@@ -205,12 +206,28 @@ mod tests {
         let cli = build_cli_args(&args).expect("anthropic args");
         let idx = cli.iter().position(|a| a == "--tools").expect("--tools");
         assert_eq!(cli[idx + 1], "");
+        assert!(cli
+            .windows(2)
+            .any(|pair| pair[0] == "--disallowedTools" && pair[1] == "mcp__*"));
     }
 
     #[test]
     fn anthropic_args_keep_tools_by_default() {
         let cli = build_cli_args(&make_args("anthropic")).expect("anthropic args");
         assert!(!cli.iter().any(|a| a == "--tools"));
+        assert!(cli
+            .windows(2)
+            .any(|pair| pair[0] == "--disallowedTools" && pair[1] == "mcp__*"));
+    }
+
+    #[test]
+    fn cursor_and_codex_args_do_not_deny_mcp_tools() {
+        for provider_id in ["cursor", "codex"] {
+            let cli = build_cli_args(&make_args(provider_id)).expect("provider args");
+            assert!(!cli
+                .windows(2)
+                .any(|pair| pair[0] == "--disallowedTools" && pair[1] == "mcp__*"));
+        }
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/summarize.rs
+++ b/apps/desktop/src-tauri/src/summarize.rs
@@ -190,6 +190,7 @@ fn build_cli_args(args: &SummarizeArgs) -> Result<Vec<String>, SummarizeError> {
                 "json".to_string(),
                 "--no-session-persistence".to_string(),
             ];
+            crate::aux_spawn::push_claude_mcp_deny(&mut cli_args);
             crate::aux_spawn::push_effort_args("anthropic", args.effort.as_deref(), &mut cli_args);
             Ok(cli_args)
         }
@@ -285,6 +286,24 @@ mod tests {
             .expect("--setting-sources");
         assert_eq!(cli[idx + 1], "project,local");
         assert!(!cli.iter().any(|a| a == "--bare"));
+    }
+
+    #[test]
+    fn anthropic_args_deny_mcp_tools() {
+        let cli = build_cli_args(&make_args("anthropic")).expect("anthropic args");
+        assert!(cli
+            .windows(2)
+            .any(|pair| pair[0] == "--disallowedTools" && pair[1] == "mcp__*"));
+    }
+
+    #[test]
+    fn cursor_and_codex_args_do_not_deny_mcp_tools() {
+        for provider_id in ["cursor", "codex"] {
+            let cli = build_cli_args(&make_args(provider_id)).expect("provider args");
+            assert!(!cli
+                .windows(2)
+                .any(|pair| pair[0] == "--disallowedTools" && pair[1] == "mcp__*"));
+        }
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/turn.rs
+++ b/apps/desktop/src-tauri/src/turn.rs
@@ -261,10 +261,15 @@ fn build_provider_cli_args(binary: &str, args: &SpawnOneArgs<'_>) -> Vec<String>
                 v.push("--allowedTools".to_string());
                 v.push(args.allowed_tools.join(","));
             }
-            if !args.disallowed_tools.is_empty() {
-                v.push("--disallowedTools".to_string());
-                v.push(args.disallowed_tools.join(","));
-            }
+            let mut disallowed_tools: Vec<String> = args
+                .disallowed_tools
+                .iter()
+                .filter(|tool| tool.as_str() != "mcp__*")
+                .cloned()
+                .collect();
+            disallowed_tools.push("mcp__*".to_string());
+            v.push("--disallowedTools".to_string());
+            v.push(disallowed_tools.join(","));
             v
         }
     }
@@ -644,6 +649,58 @@ mod tests {
         let args = make_args(None, Some("sp"), &empty);
         let cli = build_provider_cli_args("claude", &args);
         assert!(!cli.iter().any(|a| a == "--bare"));
+    }
+
+    #[test]
+    fn claude_args_always_deny_mcp_tools() {
+        let empty: Vec<String> = vec![];
+        let args = make_args(None, None, &empty);
+        let cli = build_provider_cli_args("claude", &args);
+        let idx = cli
+            .iter()
+            .position(|arg| arg == "--disallowedTools")
+            .expect("--disallowedTools");
+        assert_eq!(cli[idx + 1], "mcp__*");
+    }
+
+    #[test]
+    fn claude_args_append_mcp_tools_to_existing_denies() {
+        let empty: Vec<String> = vec![];
+        let disallowed = vec!["Bash".to_string(), "WebFetch".to_string()];
+        let mut args = make_args(None, None, &empty);
+        args.disallowed_tools = &disallowed;
+        let cli = build_provider_cli_args("claude", &args);
+        let idx = cli
+            .iter()
+            .position(|arg| arg == "--disallowedTools")
+            .expect("--disallowedTools");
+        assert_eq!(cli[idx + 1], "Bash,WebFetch,mcp__*");
+    }
+
+    #[test]
+    fn claude_args_do_not_duplicate_mcp_tools_deny() {
+        let empty: Vec<String> = vec![];
+        let disallowed = vec!["mcp__*".to_string(), "Bash".to_string()];
+        let mut args = make_args(None, None, &empty);
+        args.disallowed_tools = &disallowed;
+        let cli = build_provider_cli_args("claude", &args);
+        let idx = cli
+            .iter()
+            .position(|arg| arg == "--disallowedTools")
+            .expect("--disallowedTools");
+        assert_eq!(cli[idx + 1], "Bash,mcp__*");
+    }
+
+    #[test]
+    fn cursor_and_codex_args_do_not_deny_mcp_tools() {
+        let empty: Vec<String> = vec![];
+        let args = make_args(None, None, &empty);
+        for binary in ["cursor-agent", "codex"] {
+            let cli = build_provider_cli_args(binary, &args);
+            assert!(!cli
+                .windows(2)
+                .any(|pair| pair[0] == "--disallowedTools" && pair[1].contains("mcp__*")));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- claude turns spawned by goodboy could see the user's personal claude.ai account connectors (`mcp__claude_ai_Linear__*` and friends): account-level MCP tools ride with the login, so `--setting-sources project,local` never filtered them, and the model preferred those typed tools over the goodboy bridge prose, writing to integrations outside the app's credentials, timeline and linked-work tracking, with per-provider asymmetry as a bonus
- goodboy provisions no MCP servers, so `mcp__*` has no legitimate use in a goodboy turn: the claude arm now always emits `--disallowedTools` with `mcp__*` appended (caller denies preserved, deduplicated), and a shared aux helper applies the same deny to the claude summarizer and planner spawns
- codex and cursor arms untouched (they carry no MCP exposure); integrations keep flowing through the query bridge verbs, identical for every provider

## Tests
- main claude argv carries the deny with and without caller-provided entries (order preserved, dedup); summarizer and planner argvs carry it (planner also with tools disabled); codex and cursor argvs carry none
- 49 rust tests green across turn, summarize, planner, aux_spawn suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)