### PR TITLE
fix(db): restore the purge review fixes lost by a stale-head merge

### DIFF
--- a/apps/desktop/src/store/slices/sessions/deleteTask.teardown.test.ts
+++ b/apps/desktop/src/store/slices/sessions/deleteTask.teardown.test.ts
@@ -70,10 +70,7 @@ describe('deleting a session', () => {
     await deleteTask(vi.fn(), (() => store) as never)(SESSION_ID);
 
     expect(order).toEqual(['terminals closed', 'worktree removed']);
-    expect(deleteGithubPrCacheForWorktreePath).toHaveBeenCalledWith({
-      db: {},
-      worktreePath: '/repo/.goodboy/worktrees/gb-ghost',
-    });
+    expect(deleteGithubPrCacheForWorktreePath).not.toHaveBeenCalled();
     expect(purgeSessionForDelete).toHaveBeenCalledWith({ db: {}, id: SESSION_ID });
   });
 

--- a/apps/desktop/src/store/slices/sessions/deleteTask.ts
+++ b/apps/desktop/src/store/slices/sessions/deleteTask.ts
@@ -1,10 +1,6 @@
 import type { ProviderRunId, SessionId } from '@goodboy/types';
 import { formatError } from '@goodboy/ui';
-import {
-  deleteGithubPrCacheForWorktreePath,
-  listWorktreesForSession,
-  purgeSessionForDelete,
-} from '@goodboy/db';
+import { listWorktreesForSession, purgeSessionForDelete } from '@goodboy/db';
 import { tauriDatabase } from '../../../shared/lib/db';
 import { cancelTurn } from '../../../features/chat/turn';
 import {
@@ -66,14 +62,6 @@ export const deleteTask = (set: SetFn, get: GetFn) => {
         } catch (error) {
           cleanupFailures.push(error);
           continue;
-        }
-        try {
-          await deleteGithubPrCacheForWorktreePath({
-            db: tauriDatabase,
-            worktreePath: row.worktreePath,
-          });
-        } catch (error) {
-          cleanupFailures.push(error);
         }
         continue;
       }

--- a/apps/desktop/src/store/slices/sessions/index.test.ts
+++ b/apps/desktop/src/store/slices/sessions/index.test.ts
@@ -120,6 +120,7 @@ vi.mock('@goodboy/db', () => ({
   listAllSessionWorktrees: vi.fn(async () => []),
   renameSession: vi.fn(async () => undefined),
   deleteSession: vi.fn(async () => undefined),
+  purgeSessionForDelete: vi.fn(async () => undefined),
   deleteFileVersionsForSession: deleteFileVersionsForSessionSpy,
   archiveSession: vi.fn(async () => undefined),
   unarchiveSession: vi.fn(async () => undefined),
@@ -1024,8 +1025,8 @@ describe('store contract', () => {
 
       it('bulkDeleteTask deletes sequentially in the given id order', async () => {
         const store = await getStore();
-        const { deleteSession } = await import('@goodboy/db');
-        const spy = deleteSession as unknown as ReturnType<typeof vi.fn>;
+        const { purgeSessionForDelete } = await import('@goodboy/db');
+        const spy = purgeSessionForDelete as unknown as ReturnType<typeof vi.fn>;
         store.setState({
           workspaces: [buildWorkspace()],
           currentWorkspaceId: WS_ID,
@@ -1034,14 +1035,17 @@ describe('store contract', () => {
           },
         });
         await store.getState().bulkDeleteTask([SESSION_ID_2, SESSION_ID]);
-        expect(spy.mock.calls.map((c) => c[1])).toEqual([SESSION_ID_2, SESSION_ID]);
+        expect(spy.mock.calls.map((c) => (c[0] as { id: string }).id)).toEqual([
+          SESSION_ID_2,
+          SESSION_ID,
+        ]);
       });
 
       it('bulkDeleteTask is a no-op and emits no notification for an empty selection', async () => {
         const store = await getStore();
-        const { deleteSession } = await import('@goodboy/db');
+        const { purgeSessionForDelete } = await import('@goodboy/db');
         await store.getState().bulkDeleteTask([]);
-        expect(deleteSession as unknown as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+        expect(purgeSessionForDelete as unknown as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
         expect(insertNotificationSpy).not.toHaveBeenCalled();
       });
 

--- a/apps/desktop/src/store/store.story-session-teardown.test.ts
+++ b/apps/desktop/src/store/store.story-session-teardown.test.ts
@@ -10,6 +10,7 @@ const {
   listWorktreesForSession,
   updateSessionWorktreeBranch,
   deleteSession,
+  purgeSessionForDelete,
   deleteFileVersionsForSession,
   fileVersionsPurgeSession,
   detectRepoSlug,
@@ -25,6 +26,7 @@ const {
   listWorktreesForSession: vi.fn(async () => [] as ReadonlyArray<unknown>),
   updateSessionWorktreeBranch: vi.fn(async () => undefined),
   deleteSession: vi.fn(async () => undefined),
+  purgeSessionForDelete: vi.fn(async () => undefined),
   deleteFileVersionsForSession: vi.fn(async () => undefined),
   fileVersionsPurgeSession: vi.fn(async () => undefined),
   detectRepoSlug: vi.fn(async () => 'acme/widgets'),
@@ -37,6 +39,7 @@ vi.mock('@goodboy/db', () => ({
   listWorktreesForSession,
   updateSessionWorktreeBranch,
   deleteSession,
+  purgeSessionForDelete,
   deleteFileVersionsForSession,
 }));
 
@@ -298,7 +301,7 @@ describe('story: deleting a session that never did any work', () => {
       (call) => call[0],
     );
     expect(notificationKinds).not.toContain('error');
-    expect(deleteSession).toHaveBeenCalledOnce();
+    expect(purgeSessionForDelete).toHaveBeenCalledOnce();
   });
 });
 
@@ -333,7 +336,7 @@ describe('story: a branchless folder session lives and dies without git', () => 
       path: CONTAINER_PATH,
     });
     expect(fileVersionsPurgeSession).toHaveBeenCalledWith({ sessionId: SESSION_ID });
-    expect(deleteSession).toHaveBeenCalledOnce();
+    expect(purgeSessionForDelete).toHaveBeenCalledOnce();
   });
 
   it('never refreshes a pull request', async () => {
@@ -474,7 +477,7 @@ describe('story: a two-project session routes git work through the active mount'
       basePath: '/tmp/sessions',
       path: CONTAINER_PATH,
     });
-    expect(deleteSession).toHaveBeenCalledOnce();
+    expect(purgeSessionForDelete).toHaveBeenCalledOnce();
   });
 
   it('keeps every worktree and the container on disk when the session is archived', async () => {
@@ -519,7 +522,7 @@ describe('story: deleting a session created before project mounts existed', () =
       basePath: '/tmp/sessions',
       path: CONTAINER_PATH,
     });
-    expect(deleteSession).toHaveBeenCalledOnce();
+    expect(purgeSessionForDelete).toHaveBeenCalledOnce();
   });
 
   it('falls back to a plain directory removal when no project matches the row', async () => {
@@ -540,6 +543,6 @@ describe('story: deleting a session created before project mounts existed', () =
       basePath: '/tmp/sessions',
       path: CONTAINER_PATH,
     });
-    expect(deleteSession).toHaveBeenCalledOnce();
+    expect(purgeSessionForDelete).toHaveBeenCalledOnce();
   });
 });

--- a/packages/db/src/queries/session.test.ts
+++ b/packages/db/src/queries/session.test.ts
@@ -165,7 +165,7 @@ describe('purgeSessionForDelete', () => {
       ['session_workflows', 'session_id', sessionId],
       ['session_worktrees', 'session_id', sessionId],
       ['diff_comments', 'session_id', sessionId],
-    ]) {
+    ] as const) {
       await expect(countRows({ db, table, column, value })).resolves.toBe(1);
     }
     await expect(

--- a/packages/db/src/queries/session.ts
+++ b/packages/db/src/queries/session.ts
@@ -419,10 +419,7 @@ export const purgeSessionForDelete = async ({
   await db.exec('BEGIN');
   try {
     await db.execute('DELETE FROM messages WHERE session_id = ?', [id]);
-    await db.execute(
-      'DELETE FROM turn_events WHERE agent_id IN (SELECT id FROM agents WHERE session_id = ?)',
-      [id],
-    );
+    await db.execute('DELETE FROM turn_events WHERE session_id = ?', [id]);
     await db.execute('DELETE FROM file_versions WHERE session_id = ?', [id]);
     await db.execute('DELETE FROM context_slots WHERE session_id = ?', [id]);
     await db.execute('DELETE FROM context_slot_history WHERE session_id = ?', [id]);


### PR DESCRIPTION
## Summary
- #1582 was merged at a stale head: its review-fix commit (keep the PR cache on delete, purge turn events by session_id, the `as const` test fix, the db-mock updates) never reached main, so main's CI is red on the db typecheck and 13 session-teardown tests
- cherry-picks the lost commit and aligns `store.story-session-teardown.test.ts` (db mock + assertions) with the delete purge

## Tests
- the two failing suites are green (83), db and desktop typechecks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)