### PR TITLE
fix(ui): wake chained runs on every completion path

### DIFF
--- a/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
@@ -40,7 +40,6 @@ import {
   PlannerClient,
   type PlannerOutput,
   defaultsForRole,
-  isWorkflowComplete,
   polishStepInstruction,
   polishWorkflowGoal,
   recommendedModelForRole,
@@ -76,6 +75,7 @@ import { AgentAvatar } from '../../../../shared/components/AgentAvatar';
 import { WorkflowStepCard } from '../WorkflowStepCard';
 import { RoutingPicker } from '../../../../shared/components/RoutingPicker';
 import { type EffortLevel, clampEffort } from '../../../chat/utils/chat-constants';
+import { isRunSettled } from '../../../workflows/isRunSettled';
 import { useWorkflowDrag } from '../../../workflows/hooks/useWorkflowDrag';
 import { StepFlowConnector } from '../../../workflows/components/WorkflowStudio/StepFlowConnector';
 import { parseSpendLimit } from '../../../workflows/components/RunSpendLimitPopover/SpendLimitFields';
@@ -368,12 +368,7 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
       .map((r) => {
         const template = phaseTemplates.find((t) => t.id === r.workflowId) ?? null;
         const agents = runsForWorkflowRun(sessionPhaseRuns, r.id);
-        const complete =
-          r.executionMode === 'dynamic'
-            ? r.orchestrationOutcome === 'done'
-            : template
-              ? isWorkflowComplete(template, agents)
-              : false;
+        const complete = isRunSettled({ run: r, workflow: template, agents });
         const failed = agents.some((a) => a.status === 'failed');
         return { run: r, template, complete, failed };
       })

--- a/apps/desktop/src/features/workflows/isRunSettled.test.ts
+++ b/apps/desktop/src/features/workflows/isRunSettled.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  Agent,
+  AgentId,
+  AgentStatus,
+  IsoDateTime,
+  SessionId,
+  StepId,
+  Workflow,
+  WorkflowId,
+  WorkflowRun,
+  WorkflowRunId,
+  WorkspaceId,
+} from '@goodboy/types';
+import { isRunSettled } from './isRunSettled';
+
+const NOW = '2026-08-31T00:00:00.000Z' as IsoDateTime;
+const SESSION_ID = 'session-1' as SessionId;
+const WORKFLOW_ID = 'workflow-1' as WorkflowId;
+const RUN_ID = 'run-1' as WorkflowRunId;
+const STEP_ID = 'step-1' as StepId;
+const AGENT_ID = 'agent-1' as AgentId;
+
+const workflow: Workflow = {
+  id: WORKFLOW_ID,
+  workspaceId: 'workspace-1' as WorkspaceId,
+  name: 'Ship it',
+  description: '',
+  steps: [
+    {
+      id: STEP_ID,
+      workflowId: WORKFLOW_ID,
+      ordinal: 0,
+      name: 'Implement',
+      promptPrefix: '',
+    },
+  ],
+  createdAt: NOW,
+  updatedAt: NOW,
+};
+
+const run = (over: Partial<WorkflowRun> = {}): WorkflowRun =>
+  ({
+    id: RUN_ID,
+    workflowId: WORKFLOW_ID,
+    ordinal: 0,
+    currentStep: 0,
+    autoRun: true,
+    triggerMode: 'immediate',
+    executionMode: 'static',
+    ...over,
+  }) as WorkflowRun;
+
+const stepAgent = (status: AgentStatus): Agent => ({
+  id: AGENT_ID,
+  sessionId: SESSION_ID,
+  stepId: STEP_ID,
+  workflowRunId: RUN_ID,
+  ordinal: 0,
+  name: 'Implement',
+  status,
+});
+
+describe('isRunSettled', () => {
+  it('settles a dynamic run once the orchestration outcome is done', () => {
+    expect(
+      isRunSettled({
+        run: run({ executionMode: 'dynamic', orchestrationOutcome: 'done' }),
+        workflow,
+        agents: [],
+      }),
+    ).toBe(true);
+  });
+
+  it('leaves a dynamic run unsettled while no outcome is persisted', () => {
+    expect(
+      isRunSettled({
+        run: run({ executionMode: 'dynamic' }),
+        workflow,
+        agents: [stepAgent('completed')],
+      }),
+    ).toBe(false);
+  });
+
+  it('leaves a dynamic run unsettled when the orchestration ended blocked', () => {
+    expect(
+      isRunSettled({
+        run: run({ executionMode: 'dynamic', orchestrationOutcome: 'blocked' }),
+        workflow,
+        agents: [],
+      }),
+    ).toBe(false);
+  });
+
+  it('settles a static run when every step agent settled', () => {
+    expect(isRunSettled({ run: run(), workflow, agents: [stepAgent('completed')] })).toBe(true);
+  });
+
+  it('leaves a static run unsettled while a step agent is pending', () => {
+    expect(isRunSettled({ run: run(), workflow, agents: [stepAgent('pending')] })).toBe(false);
+  });
+
+  it('leaves a static run unsettled when its workflow cannot be resolved', () => {
+    expect(isRunSettled({ run: run(), workflow: null, agents: [stepAgent('completed')] })).toBe(
+      false,
+    );
+  });
+});

--- a/apps/desktop/src/features/workflows/isRunSettled.ts
+++ b/apps/desktop/src/features/workflows/isRunSettled.ts
@@ -1,0 +1,18 @@
+import type { Agent, Workflow, WorkflowRun } from '@goodboy/types';
+import { isWorkflowComplete } from '@goodboy/core';
+
+type Params = {
+  readonly run: WorkflowRun;
+  readonly workflow: Workflow | null;
+  readonly agents: ReadonlyArray<Agent>;
+};
+
+export const isRunSettled = ({ run, workflow, agents }: Params): boolean => {
+  if (run.executionMode === 'dynamic') {
+    return run.orchestrationOutcome === 'done';
+  }
+  if (workflow == null) {
+    return false;
+  }
+  return isWorkflowComplete(workflow, agents);
+};

--- a/apps/desktop/src/store/slices/workflows/attachWorkflowToSession.ts
+++ b/apps/desktop/src/store/slices/workflows/attachWorkflowToSession.ts
@@ -13,8 +13,9 @@ import type {
   WorkflowTriggerMode,
 } from '@goodboy/types';
 import { attachWorkflowToSession as attachWorkflowToSessionInDb } from '@goodboy/db';
-import { isWorkflowComplete, runsForWorkflowRun } from '@goodboy/core';
+import { runsForWorkflowRun } from '@goodboy/core';
 import { tauriDatabase } from '../../../shared/lib/db';
+import { isRunSettled } from '../../../features/workflows/isRunSettled';
 import { roleModelsForSession } from '../overrides/roleModelsForSession';
 import { preSpawnWorkflowAgents } from './preSpawnWorkflowAgents';
 import { activateWorkflowAgentOrNotify } from './activateWorkflowAgentOrNotify';
@@ -68,11 +69,7 @@ export const attachWorkflowToSession = (set: SetFn, get: GetFn) => {
           get().sessionPhaseRuns[sessionId] ?? [],
           chainAfterId,
         );
-        const predecessorComplete =
-          predecessor.executionMode === 'dynamic'
-            ? predecessor.orchestrationOutcome === 'done'
-            : isWorkflowComplete(predTemplate, predAgents);
-        if (predecessorComplete) {
+        if (isRunSettled({ run: predecessor, workflow: predTemplate, agents: predAgents })) {
           triggerMode = 'immediate';
         }
       }
@@ -178,6 +175,11 @@ export const attachWorkflowToSession = (set: SetFn, get: GetFn) => {
     }
 
     void get().reprocessGoalForWorkflow(sessionId);
+
+    if (triggerMode === 'after_run') {
+      void get().maybeAutoAdvanceWorkflow(sessionId);
+      return;
+    }
 
     if (triggerMode === 'immediate') {
       if (executionMode === 'dynamic' && autoRun) {

--- a/apps/desktop/src/store/slices/workflows/chainTriggers.test.ts
+++ b/apps/desktop/src/store/slices/workflows/chainTriggers.test.ts
@@ -599,7 +599,7 @@ describe('attachWorkflowToSession trigger modes', () => {
     expect(state['maybeAutoAdvanceWorkflow']).not.toHaveBeenCalled();
   });
 
-  it('after_run with an incomplete predecessor stays queued', async () => {
+  it('after_run with an incomplete predecessor stays queued and still wakes the advance', async () => {
     const pred = makeRun('pred', 'immediate');
     const state = baseState([pred], [makeAgent('pred' as WorkflowRunId, 's0', 'pending', 0)]);
     const { set, get } = harness(state);
@@ -610,7 +610,9 @@ describe('attachWorkflowToSession trigger modes', () => {
     });
     expect(attachArgs()?.['triggerMode']).toBe('after_run');
     expect(attachArgs()?.['chainAfterRunId']).toBe('pred');
-    expect(state['maybeAutoAdvanceWorkflow']).not.toHaveBeenCalled();
+    expect(state['maybeAutoAdvanceWorkflow']).toHaveBeenCalledTimes(1);
+    expect(state['maybeAutoAdvanceWorkflow']).toHaveBeenCalledWith(SESSION_ID);
+    expect(state['activateWorkflowAgent']).not.toHaveBeenCalled();
   });
 
   it('after_run degrades to immediate when the predecessor is already complete', async () => {
@@ -623,6 +625,7 @@ describe('attachWorkflowToSession trigger modes', () => {
       chainAfterId: 'pred' as WorkflowRunId,
     });
     expect(attachArgs()?.['triggerMode']).toBe('immediate');
+    expect(state['maybeAutoAdvanceWorkflow']).toHaveBeenCalledTimes(1);
     expect(state['maybeAutoAdvanceWorkflow']).toHaveBeenCalledWith(SESSION_ID);
   });
 
@@ -636,10 +639,10 @@ describe('attachWorkflowToSession trigger modes', () => {
       chainAfterId: 'pred' as WorkflowRunId,
     });
     expect(attachArgs()?.['triggerMode']).toBe('after_run');
-    expect(state['maybeAutoAdvanceWorkflow']).not.toHaveBeenCalled();
+    expect(state['maybeAutoAdvanceWorkflow']).toHaveBeenCalledTimes(1);
   });
 
-  it('after_run stays queued when the predecessor cannot be found', async () => {
+  it('after_run wakes the advance once when the predecessor cannot be found', async () => {
     const state = baseState([], []);
     const { set, get } = harness(state);
     await attachWorkflowToSession(set, get)(SESSION_ID, WF_ID, {
@@ -648,7 +651,8 @@ describe('attachWorkflowToSession trigger modes', () => {
       chainAfterId: 'ghost' as WorkflowRunId,
     });
     expect(attachArgs()?.['triggerMode']).toBe('after_run');
-    expect(state['maybeAutoAdvanceWorkflow']).not.toHaveBeenCalled();
+    expect(state['maybeAutoAdvanceWorkflow']).toHaveBeenCalledTimes(1);
+    expect(state['maybeAutoAdvanceWorkflow']).toHaveBeenCalledWith(SESSION_ID);
   });
 
   it('persists chainAfterId onto the new run in store state', async () => {
@@ -739,5 +743,20 @@ describe('attachWorkflowToSession trigger modes', () => {
       chainAfterId: 'pred' as WorkflowRunId,
     });
     expect(attachArgs()?.['triggerMode']).toBe('after_run');
+    expect(state['maybeAutoAdvanceWorkflow']).toHaveBeenCalledTimes(1);
+  });
+
+  it('after_run wakes the advance when the predecessor template is missing', async () => {
+    const pred = makeRun('pred', 'immediate', { workflowId: 'wf-gone' as WorkflowId });
+    const state = baseState([pred], [makeAgent('pred' as WorkflowRunId, 's0', 'completed', 0)]);
+    const { set, get } = harness(state);
+    await attachWorkflowToSession(set, get)(SESSION_ID, WF_ID, {
+      autoRun: true,
+      triggerMode: 'after_run',
+      chainAfterId: 'pred' as WorkflowRunId,
+    });
+    expect(attachArgs()?.['triggerMode']).toBe('after_run');
+    expect(state['maybeAutoAdvanceWorkflow']).toHaveBeenCalledTimes(1);
+    expect(state['maybeAutoAdvanceWorkflow']).toHaveBeenCalledWith(SESSION_ID);
   });
 });

--- a/apps/desktop/src/store/slices/workflows/maybeAutoAdvanceWorkflow.ts
+++ b/apps/desktop/src/store/slices/workflows/maybeAutoAdvanceWorkflow.ts
@@ -1,12 +1,8 @@
 import type { Agent, SessionId, WorkflowRunId } from '@goodboy/types';
 import { listOpenQuestionsForSession } from '@goodboy/db';
-import {
-  classifyWorkflowChain,
-  findReusableAgent,
-  isWorkflowComplete,
-  runsForWorkflowRun,
-} from '@goodboy/core';
+import { classifyWorkflowChain, findReusableAgent, runsForWorkflowRun } from '@goodboy/core';
 import { tauriDatabase } from '../../../shared/lib/db';
+import { isRunSettled } from '../../../features/workflows/isRunSettled';
 import { workflowRunHasOpenQuestions } from '../../../features/context/openQuestionsGate';
 import {
   BUDGET_BLOCK_MESSAGE,
@@ -54,11 +50,13 @@ const startChainedRuns = async ({ get, sessionId }: Params): Promise<void> => {
     if (predTemplate == null) {
       continue;
     }
-    const predecessorComplete =
-      predecessor.executionMode === 'dynamic'
-        ? predecessor.orchestrationOutcome === 'done'
-        : isWorkflowComplete(predTemplate, runsForWorkflowRun(runs, predecessor.id));
-    if (predecessorComplete) {
+    if (
+      isRunSettled({
+        run: predecessor,
+        workflow: predTemplate,
+        agents: runsForWorkflowRun(runs, predecessor.id),
+      })
+    ) {
       await get().startWorkflowRun(sessionId, candidate.id);
     }
   }

--- a/apps/desktop/src/store/slices/workflows/orchestrateNextStep.test.ts
+++ b/apps/desktop/src/store/slices/workflows/orchestrateNextStep.test.ts
@@ -12,6 +12,7 @@ import type {
   TelemetryRecord,
   Workflow,
   WorkflowId,
+  WorkflowRun,
   WorkflowRunId,
   WorkflowSpendLimitMode,
   WorkspaceId,
@@ -80,6 +81,7 @@ vi.mock('../../../features/workflows/workflows', () => ({
 import { OrchestratorClient, ROLE_DEFAULTS } from '@goodboy/core';
 import { orchestrateNextStep, persistOrchestrationStop } from './orchestrateNextStep';
 import { continueWorkflowRun } from './continueWorkflowRun';
+import { maybeAutoAdvanceWorkflow } from './maybeAutoAdvanceWorkflow';
 
 const WORKSPACE_ID = 'workspace-1' as WorkspaceId;
 const SESSION_ID = 'session-1' as SessionId;
@@ -204,6 +206,7 @@ const baseState = (): State => {
     appendTurnEvent: vi.fn(),
     activateWorkflowAgent: vi.fn(async () => undefined),
     emitNotification: vi.fn(async () => undefined),
+    maybeAutoAdvanceWorkflow: vi.fn(async () => undefined),
   };
 };
 
@@ -1677,5 +1680,69 @@ describe('orchestrateNextStep and the session context summarizer', () => {
     await pending;
 
     expect(runOutcomeOf(state)).toBe('done');
+  });
+});
+
+describe('orchestrateNextStep and the runs chained behind it', () => {
+  const CHAINED_RUN_ID = 'workflow-run-2' as WorkflowRunId;
+
+  const chainedState = (): State => {
+    const state = baseState();
+    const base = session();
+    const chained: WorkflowRun = {
+      id: CHAINED_RUN_ID,
+      workflowId: WORKFLOW_ID,
+      ordinal: 1,
+      currentStep: 0,
+      autoRun: true,
+      triggerMode: 'after_run',
+      chainAfterId: WORKFLOW_RUN_ID,
+      executionMode: 'static',
+    };
+    state['sessions'] = [{ ...base, workflowRuns: [...base.workflowRuns, chained] }];
+    state['budgetAlerts'] = [];
+    state['startWorkflowRun'] = vi.fn(async () => undefined);
+    return state;
+  };
+
+  it('starts the chained run once the dynamic predecessor lands done', async () => {
+    decideSpy.mockResolvedValue({
+      usage: NO_USAGE,
+      decision: { action: 'done', reason: 'Every step landed.' },
+    });
+    const state = chainedState();
+    const { set, get } = harness(state);
+    state['maybeAutoAdvanceWorkflow'] = maybeAutoAdvanceWorkflow(set, get);
+
+    await orchestrateNextStep(set, get)(SESSION_ID, WORKFLOW_RUN_ID);
+
+    await vi.waitFor(() =>
+      expect(state['startWorkflowRun']).toHaveBeenCalledWith(SESSION_ID, CHAINED_RUN_ID),
+    );
+  });
+
+  it('leaves the chain asleep when the orchestration ends blocked', async () => {
+    decideSpy.mockResolvedValue({
+      usage: NO_USAGE,
+      decision: { action: 'blocked', reason: 'The repository has no tests.' },
+    });
+    const state = chainedState();
+    const { set, get } = harness(state);
+
+    await orchestrateNextStep(set, get)(SESSION_ID, WORKFLOW_RUN_ID);
+
+    expect(state['maybeAutoAdvanceWorkflow']).not.toHaveBeenCalled();
+    expect(state['startWorkflowRun']).not.toHaveBeenCalled();
+  });
+
+  it('leaves the chain asleep when the orchestrator call fails', async () => {
+    decideSpy.mockRejectedValue(new Error('provider exploded'));
+    const state = chainedState();
+    const { set, get } = harness(state);
+
+    await orchestrateNextStep(set, get)(SESSION_ID, WORKFLOW_RUN_ID);
+
+    expect(state['maybeAutoAdvanceWorkflow']).not.toHaveBeenCalled();
+    expect(state['startWorkflowRun']).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/store/slices/workflows/orchestrateNextStep.ts
+++ b/apps/desktop/src/store/slices/workflows/orchestrateNextStep.ts
@@ -814,6 +814,12 @@ export const orchestrateNextStep = (set: SetFn, get: GetFn) => {
           });
         });
       }
+      const finished = get()
+        .sessions.find((candidate) => candidate.id === sessionId)
+        ?.workflowRuns.find((candidate) => candidate.id === workflowRunId);
+      if (finished?.orchestrationOutcome === 'done') {
+        void get().maybeAutoAdvanceWorkflow(sessionId);
+      }
     }
   };
 };

--- a/apps/desktop/src/store/slices/workspaces/setCurrentWorkspace.ts
+++ b/apps/desktop/src/store/slices/workspaces/setCurrentWorkspace.ts
@@ -252,6 +252,18 @@ export const setCurrentWorkspace = (set: SetFn, get: GetFn) => {
           phaseTemplates: { ...state.phaseTemplates, [id]: mergedTemplates },
           stepLibrary: { ...state.stepLibrary, [id]: stepLibrary },
         }));
+        for (const session of get().sessions) {
+          const hasQueuedChain = session.workflowRuns.some(
+            (run) =>
+              run.discardedAt == null &&
+              run.triggerMode === 'after_run' &&
+              run.chainAfterId != null,
+          );
+          if (!hasQueuedChain) {
+            continue;
+          }
+          void get().maybeAutoAdvanceWorkflow(session.id);
+        }
         if (import.meta.env.DEV) {
           console.log(`[perf] workspace:deferred ${(performance.now() - tWsDefer).toFixed(0)}ms`);
         }

--- a/apps/desktop/src/store/store.workspace-switch.test.ts
+++ b/apps/desktop/src/store/store.workspace-switch.test.ts
@@ -1,10 +1,12 @@
-import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import type {
   BudgetAlert,
   IsoDateTime,
   ProviderRunId,
   Session,
   SessionId,
+  WorkflowId,
+  WorkflowRunId,
   WorkspaceId,
 } from '@goodboy/types';
 import { buildStorySession, resetStorySpies, storySpies } from './storyHarness';
@@ -182,5 +184,104 @@ describe('setCurrentWorkspace, session-scoped state cleanup', () => {
       expect(useAppStore.getState().budgetAlerts).toEqual([alert]);
     });
     expect(storySpies.invokeBudgetAlertsList).toHaveBeenCalledOnce();
+  });
+});
+
+describe('setCurrentWorkspace, queued chain self-heal', () => {
+  const SESSION_CHAINED = 'session-chained' as SessionId;
+  const SESSION_PLAIN = 'session-plain' as SessionId;
+  const PRED_RUN = 'run-pred' as WorkflowRunId;
+  const CHAINED_RUN = 'run-chained' as WorkflowRunId;
+  const WF_ID = 'workflow-1' as WorkflowId;
+
+  const chainedSession = (): Session =>
+    buildStorySession({
+      id: SESSION_CHAINED,
+      workspaceId: WS_B,
+      goal: 'chain the runs',
+      state: { kind: 'idle', lastActivityAt: NOW },
+      workflowRuns: [
+        {
+          id: PRED_RUN,
+          workflowId: WF_ID,
+          ordinal: 0,
+          currentStep: 0,
+          autoRun: true,
+          triggerMode: 'immediate',
+          executionMode: 'static',
+        },
+        {
+          id: CHAINED_RUN,
+          workflowId: WF_ID,
+          ordinal: 1,
+          currentStep: 0,
+          autoRun: true,
+          triggerMode: 'after_run',
+          chainAfterId: PRED_RUN,
+          executionMode: 'static',
+        },
+      ],
+    });
+
+  const advance = vi.fn(async () => undefined);
+  const originalAdvance = { current: null as null | ((sessionId: SessionId) => Promise<void>) };
+
+  beforeEach(async () => {
+    resetStorySpies();
+    advance.mockClear();
+    originalAdvance.current = useAppStore.getState().maybeAutoAdvanceWorkflow;
+    useAppStore.setState({ maybeAutoAdvanceWorkflow: advance });
+    const { listSessionsForWorkspace } = await import('@goodboy/db');
+    vi.mocked(listSessionsForWorkspace).mockResolvedValue([
+      chainedSession(),
+      buildStorySession({
+        id: SESSION_PLAIN,
+        workspaceId: WS_B,
+        goal: 'no chain here',
+        state: { kind: 'idle', lastActivityAt: NOW },
+      }),
+    ]);
+  });
+
+  afterEach(async () => {
+    if (originalAdvance.current != null) {
+      useAppStore.setState({ maybeAutoAdvanceWorkflow: originalAdvance.current });
+    }
+    const { listSessionsForWorkspace } = await import('@goodboy/db');
+    vi.mocked(listSessionsForWorkspace).mockResolvedValue([]);
+  });
+
+  it('wakes the advance for a session holding a queued after_run chain', async () => {
+    await useAppStore.getState().setCurrentWorkspace(WS_B);
+
+    await vi.waitFor(() => {
+      expect(advance).toHaveBeenCalledWith(SESSION_CHAINED);
+    });
+    expect(advance).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves sessions without a queued chain alone', async () => {
+    const { listSessionsForWorkspace } = await import('@goodboy/db');
+    vi.mocked(listSessionsForWorkspace).mockResolvedValue([
+      buildStorySession({
+        id: SESSION_PLAIN,
+        workspaceId: WS_B,
+        goal: 'no chain here',
+        state: { kind: 'idle', lastActivityAt: NOW },
+      }),
+      buildStorySession({
+        id: SESSION_IDLE,
+        workspaceId: WS_B,
+        goal: 'still no chain',
+        state: { kind: 'idle', lastActivityAt: NOW },
+      }),
+    ]);
+
+    await useAppStore.getState().setCurrentWorkspace(WS_B);
+
+    await vi.waitFor(() => {
+      expect(storySpies.invokeBudgetAlertsList).toHaveBeenCalled();
+    });
+    expect(advance).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- an `after_run` chained workflow could miss its predecessor's completion and stall forever at 0 steps: the attach path woke the advance only when its own inline check promoted the chain to immediate (one shot, silent bail on a stale snapshot or missing template), and a dynamic predecessor completing via the orchestrator's `done` outcome never woke chain evaluation at all: the wake surface was purely activity events, and an idle session emits none
- fixes all the wake paths: attach always pokes `maybeAutoAdvanceWorkflow` when the run stays `after_run` (the independent `startChainedRuns` evaluator gets its shot, idempotent otherwise); the orchestrator's `finally` wakes the advance when the run landed `done` (deliberately only `done`: an unconditional wake would loop a failing decide forever, pinned by tests); workspace load self-heals by waking each session holding a pending chained run, which also un-stalls chains created by older builds
- the predecessor-complete formula, duplicated inline in 3 execution-path sites, is now one `isRunSettled` helper; `isWorkflowRunComplete` stays as the deliberately stricter UI-grouping check

## Tests
- attach with complete predecessor still flips to immediate; incomplete or unresolvable predecessor still wakes the advance; orchestrated `done` starts the chain end to end; blocked and failed orchestrations stay asleep; workspace load wakes chained sessions exactly once
- 129 tests green across the 5 touched suites, full desktop suite green on the builder pass (6479), typecheck green

🤖 Generated with [Claude Code](https://claude.com/claude-code)