### PR TITLE
feat(ui): show activity dots on the project mount row

### DIFF
--- a/apps/desktop/src-tauri/src/terminal.rs
+++ b/apps/desktop/src-tauri/src/terminal.rs
@@ -32,8 +32,13 @@ struct TerminalExitPayload {
 
 type SessionSlot = Arc<Mutex<Option<TerminalSession>>>;
 
+struct TerminalEntry {
+    slot: SessionSlot,
+    cwd: String,
+}
+
 #[derive(Default)]
-pub struct TerminalRegistry(Arc<Mutex<HashMap<String, SessionSlot>>>);
+pub struct TerminalRegistry(Arc<Mutex<HashMap<String, TerminalEntry>>>);
 
 impl TerminalRegistry {
     pub fn new() -> Self {
@@ -42,20 +47,27 @@ impl TerminalRegistry {
 
     fn list_live(&self) -> Result<Vec<LiveTerminal>, TerminalError> {
         let map = self.0.lock().map_err(|_| TerminalError::Poisoned)?;
-        Ok(map.keys().cloned().map(|id| LiveTerminal { id }).collect())
+        Ok(map
+            .iter()
+            .map(|(id, entry)| LiveTerminal {
+                id: id.clone(),
+                cwd: entry.cwd.clone(),
+            })
+            .collect())
     }
 }
 
 #[derive(Serialize, Clone, Debug, PartialEq, Eq)]
 pub struct LiveTerminal {
     id: String,
+    cwd: String,
 }
 
 /// Drains every live terminal, killing the whole pty session behind each
 /// leader. Killing the leader alone leaves grandchildren holding ports.
 pub fn shutdown(registry: &TerminalRegistry) {
     let slots: Vec<SessionSlot> = match registry.0.lock() {
-        Ok(mut map) => map.drain().map(|(_, slot)| slot).collect(),
+        Ok(mut map) => map.drain().map(|(_, entry)| entry.slot).collect(),
         Err(_) => return,
     };
     for slot in slots {
@@ -157,8 +169,8 @@ pub async fn terminal_open(
 ) -> Result<(), TerminalError> {
     {
         let map = registry.0.lock().map_err(|_| TerminalError::Poisoned)?;
-        if let Some(slot) = map.get(&session_id) {
-            let guard = slot.lock().map_err(|_| TerminalError::Poisoned)?;
+        if let Some(entry) = map.get(&session_id) {
+            let guard = entry.slot.lock().map_err(|_| TerminalError::Poisoned)?;
             if guard.is_some() {
                 return Ok(());
             }
@@ -220,7 +232,13 @@ pub async fn terminal_open(
         registry_arc
             .lock()
             .map_err(|_| TerminalError::Poisoned)?
-            .insert(session_id_clone.clone(), Arc::clone(&slot));
+            .insert(
+                session_id_clone.clone(),
+                TerminalEntry {
+                    slot: Arc::clone(&slot),
+                    cwd: effective_cwd,
+                },
+            );
 
         let sid = session_id_clone.clone();
         let app_r = app.clone();
@@ -248,7 +266,10 @@ pub async fn terminal_open(
             let exit_code = {
                 let slot = {
                     let guard = registry_r.lock().ok();
-                    guard.as_ref().and_then(|m| m.get(&sid).cloned())
+                    guard
+                        .as_ref()
+                        .and_then(|m| m.get(&sid))
+                        .map(|entry| Arc::clone(&entry.slot))
                 };
                 if let Some(slot) = slot {
                     let mut g = slot.lock().unwrap_or_else(|e| e.into_inner());
@@ -299,7 +320,7 @@ pub fn terminal_write(
 
     let slot = {
         let map = registry.0.lock().map_err(|_| TerminalError::Poisoned)?;
-        map.get(&session_id).cloned()
+        map.get(&session_id).map(|entry| Arc::clone(&entry.slot))
     };
 
     if let Some(slot) = slot {
@@ -321,7 +342,7 @@ pub fn terminal_resize(
 ) -> Result<(), TerminalError> {
     let slot = {
         let map = registry.0.lock().map_err(|_| TerminalError::Poisoned)?;
-        map.get(&session_id).cloned()
+        map.get(&session_id).map(|entry| Arc::clone(&entry.slot))
     };
 
     if let Some(slot) = slot {
@@ -346,7 +367,7 @@ pub fn terminal_close(
 ) -> Result<(), TerminalError> {
     let slot = {
         let mut map = registry.0.lock().map_err(|_| TerminalError::Poisoned)?;
-        map.remove(&session_id)
+        map.remove(&session_id).map(|entry| entry.slot)
     };
     if let Some(slot) = slot {
         if let Ok(mut guard) = slot.lock() {
@@ -366,19 +387,22 @@ mod tests {
     use super::*;
 
     #[test]
-    fn registry_lists_open_terminal_keys() {
+    fn registry_lists_open_terminal_keys_with_their_cwd() {
         let registry = TerminalRegistry::new();
         let slot = Arc::new(Mutex::new(None));
-        registry
-            .0
-            .lock()
-            .unwrap()
-            .insert("session-1::t1".to_string(), slot);
+        registry.0.lock().unwrap().insert(
+            "session-1::t1".to_string(),
+            TerminalEntry {
+                slot,
+                cwd: "/worktrees/api".to_string(),
+            },
+        );
 
         assert_eq!(
             registry.list_live().unwrap(),
             vec![LiveTerminal {
-                id: "session-1::t1".to_string()
+                id: "session-1::t1".to_string(),
+                cwd: "/worktrees/api".to_string(),
             }]
         );
     }
@@ -477,11 +501,14 @@ mod tests {
         let registry = TerminalRegistry::new();
         registry.0.lock().unwrap().insert(
             "session-1".to_string(),
-            Arc::new(Mutex::new(Some(TerminalSession {
-                writer,
-                master: pair.master,
-                child,
-            }))),
+            TerminalEntry {
+                slot: Arc::new(Mutex::new(Some(TerminalSession {
+                    writer,
+                    master: pair.master,
+                    child,
+                }))),
+                cwd: "/".to_string(),
+            },
         );
 
         shutdown(&registry);

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectMountRow.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectMountRow.test.tsx
@@ -12,6 +12,12 @@ const { store, remoteKind } = vi.hoisted(() => ({
     openMountDiff: vi.fn(async () => undefined),
     projects: [] as ReadonlyArray<{ id: string; baseBranch?: string | null }>,
     emitNotification: vi.fn(),
+    terminalTabs: {} as Record<
+      string,
+      ReadonlyArray<{ id: string; projectId?: string; status: string }>
+    >,
+    scriptRuns: {} as Record<string, Record<string, { status: string }>>,
+    projectScripts: {} as Record<string, ReadonlyArray<{ id: string; projectId: string }>>,
   },
 }));
 
@@ -31,6 +37,7 @@ vi.mock('../../../../worktree/useRemoteHostKind', () => ({
   useRemoteHostKind: () => remoteKind.current,
 }));
 
+import { tooltipTextOf } from '../../../../../__tests__/helpers/tooltip';
 import { ProjectMountRow } from './ProjectMountRow';
 
 const sessionId = 'session-1' as SessionId;
@@ -39,6 +46,7 @@ const project = {
   id: 'api',
   name: 'API',
   kind: 'repo',
+  workspaceId: 'ws-1',
 } as Project;
 
 const mount = {
@@ -72,6 +80,14 @@ beforeEach(() => {
   store.setSessionActiveProject.mockClear();
   store.setSessionActiveProject.mockResolvedValue(undefined);
   remoteKind.current = 'github';
+  store.terminalTabs = {};
+  store.scriptRuns = {};
+  store.projectScripts = {
+    'ws-1': [
+      { id: 'script-api', projectId: 'api' },
+      { id: 'script-web', projectId: 'web' },
+    ],
+  };
 });
 
 afterEach(cleanup);
@@ -118,5 +134,81 @@ describe('ProjectMountRow create pr action', () => {
     remoteKind.current = null;
     renderRow({ diffStat: { additions: 1, deletions: 0 } });
     expect(screen.queryByRole('button', { name: 'Create a PR for API' })).toBeNull();
+  });
+});
+
+describe('ProjectMountRow activity dots', () => {
+  it('marks the terminal icon when a live tab belongs to the project', () => {
+    store.terminalTabs = {
+      [sessionId]: [{ id: `${sessionId}::t1`, projectId: 'api', status: 'running' }],
+    };
+    renderRow({});
+    expect(screen.getByTestId('terminal-activity-dot')).toBeDefined();
+    expect(screen.queryByTestId('scripts-activity-dot')).toBeNull();
+  });
+
+  it('leaves the terminal icon bare when the live tab belongs to another project', () => {
+    store.terminalTabs = {
+      [sessionId]: [{ id: `${sessionId}::t1`, projectId: 'web', status: 'running' }],
+    };
+    renderRow({});
+    expect(screen.queryByTestId('terminal-activity-dot')).toBeNull();
+  });
+
+  it('leaves the terminal icon bare when the only tab of the project has exited', () => {
+    store.terminalTabs = {
+      [sessionId]: [{ id: `${sessionId}::t1`, projectId: 'api', status: 'exited' }],
+    };
+    renderRow({});
+    expect(screen.queryByTestId('terminal-activity-dot')).toBeNull();
+  });
+
+  it('marks the scripts icon when a pending run belongs to the project', () => {
+    store.scriptRuns = { [sessionId]: { 'script-api': { status: 'pending' } } };
+    renderRow({});
+    expect(screen.getByTestId('scripts-activity-dot')).toBeDefined();
+    expect(screen.queryByTestId('terminal-activity-dot')).toBeNull();
+  });
+
+  it('leaves the scripts icon bare when the pending run belongs to another project', () => {
+    store.scriptRuns = { [sessionId]: { 'script-web': { status: 'pending' } } };
+    renderRow({});
+    expect(screen.queryByTestId('scripts-activity-dot')).toBeNull();
+  });
+
+  it('leaves the scripts icon bare when the run of the project has finished', () => {
+    store.scriptRuns = { [sessionId]: { 'script-api': { status: 'ok' } } };
+    renderRow({});
+    expect(screen.queryByTestId('scripts-activity-dot')).toBeNull();
+  });
+
+  it('carries the counts in the tooltips', () => {
+    store.terminalTabs = {
+      [sessionId]: [
+        { id: `${sessionId}::t1`, projectId: 'api', status: 'running' },
+        { id: `${sessionId}::t2`, projectId: 'api', status: 'running' },
+        { id: `${sessionId}::t3`, projectId: 'web', status: 'running' },
+      ],
+    };
+    store.scriptRuns = { [sessionId]: { 'script-api': { status: 'pending' } } };
+    renderRow({});
+
+    expect(
+      tooltipTextOf({ element: screen.getByRole('button', { name: 'Open terminal for API' }) }),
+    ).toBe('Open terminal in API, 2 running');
+    expect(
+      tooltipTextOf({ element: screen.getByRole('button', { name: 'Open scripts for API' }) }),
+    ).toBe('Open scripts for API, 1 running');
+  });
+
+  it('keeps the plain tooltips when nothing runs for the project', () => {
+    renderRow({});
+
+    expect(
+      tooltipTextOf({ element: screen.getByRole('button', { name: 'Open terminal for API' }) }),
+    ).toBe('Open terminal in API');
+    expect(
+      tooltipTextOf({ element: screen.getByRole('button', { name: 'Open scripts for API' }) }),
+    ).toBe('Open scripts for API');
   });
 });

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectMountRow.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectMountRow.tsx
@@ -16,6 +16,7 @@ import { DiffStat } from '../../DiffStat';
 import { ProjectBranchChip } from './ProjectBranchChip';
 import { ProjectSyncControl } from './ProjectSyncControl';
 import { ProjectDetachMenu } from './ProjectDetachMenu';
+import { useProjectActivity } from './useProjectActivity';
 
 type Props = {
   readonly sessionId: SessionId;
@@ -28,7 +29,15 @@ type Props = {
 };
 
 const ICON_BUTTON =
-  'inline-flex size-7 items-center justify-center rounded-md text-muted-foreground hover:bg-muted/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]';
+  'relative inline-flex size-7 items-center justify-center rounded-md text-muted-foreground hover:bg-muted/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]';
+
+const ACTIVITY_DOT = 'absolute -right-0.5 -top-0.5 size-1.5 rounded-full bg-success';
+
+type SuffixParams = {
+  readonly count: number;
+};
+
+const runningSuffix = ({ count }: SuffixParams) => (count > 0 ? `, ${count} running` : '');
 
 export const ProjectMountRow = ({
   sessionId,
@@ -46,6 +55,11 @@ export const ProjectMountRow = ({
   const projectName = project?.name ?? mount.mountName;
   const changes = diffStat != null && (diffStat.additions > 0 || diffStat.deletions > 0);
   const remoteKind = useRemoteHostKind({ sessionId });
+  const activity = useProjectActivity({
+    sessionId,
+    projectId: mount.projectId,
+    workspaceId: project?.workspaceId ?? null,
+  });
 
   const openLens = async ({ lens }: { readonly lens: LensKind }) => {
     await setSessionActiveProject({ sessionId, projectId: mount.projectId });
@@ -136,7 +150,9 @@ export const ProjectMountRow = ({
           <span className="font-mono">#{pullRequest.number}</span>
         </button>
       ) : null}
-      <Tooltip content={`Open terminal in ${projectName}`}>
+      <Tooltip
+        content={`Open terminal in ${projectName}${runningSuffix({ count: activity.liveTerminals })}`}
+      >
         <button
           type="button"
           aria-label={`Open terminal for ${projectName}`}
@@ -144,9 +160,14 @@ export const ProjectMountRow = ({
           className={ICON_BUTTON}
         >
           <CONCEPT_ICONS.terminal size={13} aria-hidden />
+          {activity.liveTerminals > 0 ? (
+            <span data-testid="terminal-activity-dot" aria-hidden className={ACTIVITY_DOT} />
+          ) : null}
         </button>
       </Tooltip>
-      <Tooltip content={`Open scripts for ${projectName}`}>
+      <Tooltip
+        content={`Open scripts for ${projectName}${runningSuffix({ count: activity.runningScripts })}`}
+      >
         <button
           type="button"
           aria-label={`Open scripts for ${projectName}`}
@@ -154,6 +175,9 @@ export const ProjectMountRow = ({
           className={ICON_BUTTON}
         >
           <CONCEPT_ICONS.scripts size={13} aria-hidden />
+          {activity.runningScripts > 0 ? (
+            <span data-testid="scripts-activity-dot" aria-hidden className={ACTIVITY_DOT} />
+          ) : null}
         </button>
       </Tooltip>
       <ProjectDetachMenu

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/useProjectActivity.ts
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/useProjectActivity.ts
@@ -1,0 +1,48 @@
+import { useMemo } from 'react';
+import type { ProjectId, ProjectScriptId, SessionId, WorkspaceId } from '@goodboy/types';
+import { useAppStore } from '../../../../../store';
+
+type Params = {
+  readonly sessionId: SessionId;
+  readonly projectId: ProjectId;
+  readonly workspaceId: WorkspaceId | null;
+};
+
+type ProjectActivity = {
+  readonly liveTerminals: number;
+  readonly runningScripts: number;
+};
+
+export const useProjectActivity = ({
+  sessionId,
+  projectId,
+  workspaceId,
+}: Params): ProjectActivity => {
+  const liveTerminals = useAppStore((state) => {
+    const tabs = state.terminalTabs[sessionId];
+    if (tabs === undefined) {
+      return 0;
+    }
+    return tabs.filter((tab) => tab.projectId === projectId && tab.status !== 'exited').length;
+  });
+
+  const runningScripts = useAppStore((state) => {
+    if (workspaceId === null) {
+      return 0;
+    }
+    const runs = state.scriptRuns[sessionId];
+    if (runs === undefined) {
+      return 0;
+    }
+    const owned = new Set<ProjectScriptId>(
+      (state.projectScripts[workspaceId] ?? [])
+        .filter((script) => script.projectId === projectId)
+        .map((script) => script.id),
+    );
+    return Object.entries(runs).filter(
+      ([scriptId, record]) => record.status === 'pending' && owned.has(scriptId as ProjectScriptId),
+    ).length;
+  });
+
+  return useMemo(() => ({ liveTerminals, runningScripts }), [liveTerminals, runningScripts]);
+};

--- a/apps/desktop/src/features/terminal/terminal.ts
+++ b/apps/desktop/src/features/terminal/terminal.ts
@@ -13,6 +13,7 @@ export type TerminalExitPayload = {
 
 export type LiveTerminal = {
   readonly id: string;
+  readonly cwd: string;
 };
 
 export const invokeTerminalListLive = (): Promise<ReadonlyArray<LiveTerminal>> => {

--- a/apps/desktop/src/shared/types/terminal.ts
+++ b/apps/desktop/src/shared/types/terminal.ts
@@ -1,4 +1,4 @@
-import type { SessionId } from '@goodboy/types';
+import type { ProjectId, SessionId } from '@goodboy/types';
 
 export type TerminalTabId = string & { readonly __brand: 'TerminalTabId' };
 
@@ -9,6 +9,7 @@ export type TerminalTab = {
   readonly sessionId: SessionId;
   readonly title: string;
   readonly cwd: string | null;
+  readonly projectId?: ProjectId;
   readonly status: TerminalTabStatus;
   readonly createdAt: number;
 };

--- a/apps/desktop/src/store/slices/terminal/addTerminalTab.ts
+++ b/apps/desktop/src/store/slices/terminal/addTerminalTab.ts
@@ -1,6 +1,17 @@
-import type { SessionId } from '@goodboy/types';
+import type { ProjectId, SessionId } from '@goodboy/types';
 import type { TerminalTab, TerminalTabId } from '../../../shared/types/terminal';
 import type { GetFn, SetFn } from './types';
+
+type ActiveProjectParams = {
+  readonly get: GetFn;
+  readonly sessionId: SessionId;
+};
+
+const activeProjectId = ({ get, sessionId }: ActiveProjectParams): ProjectId | undefined => {
+  const state = get();
+  const session = state.sessions.find((candidate) => candidate.id === sessionId);
+  return state.sessionActiveProject[sessionId] ?? session?.activeProjectId ?? undefined;
+};
 
 function nextOrdinal(tabs: readonly TerminalTab[]): number {
   let max = 0;
@@ -24,6 +35,7 @@ export const addTerminalTab = (set: SetFn, get: GetFn) => {
       sessionId,
       title: `Terminal ${n}`,
       cwd,
+      projectId: activeProjectId({ get, sessionId }),
       status: 'running',
       createdAt: Date.now(),
     };

--- a/apps/desktop/src/store/slices/terminal/index.test.ts
+++ b/apps/desktop/src/store/slices/terminal/index.test.ts
@@ -14,6 +14,7 @@ import type {
   PlanConsumptionId,
   PlanId,
   PlanWithCount,
+  ProjectId,
   ProviderRunId,
   Session,
   SessionId,
@@ -336,7 +337,7 @@ vi.mock('../../../features/scripts/scripts', () => ({
 }));
 
 const invokeTerminalCloseSpy = vi.fn(async () => undefined);
-const invokeTerminalListLiveSpy = vi.fn<() => Promise<ReadonlyArray<{ id: string }>>>(
+const invokeTerminalListLiveSpy = vi.fn<() => Promise<ReadonlyArray<{ id: string; cwd: string }>>>(
   async () => [],
 );
 
@@ -537,6 +538,8 @@ describe('store contract', () => {
         terminalSessions: {},
         terminalTabs: {},
         activeTerminalTab: {},
+        sessionActiveProject: {},
+        sessionProjectMounts: {},
       };
     }
     store.setState(resetState as never);
@@ -587,8 +590,8 @@ describe('store contract', () => {
     it('reattaches live terminal tabs and makes the first tab active', async () => {
       const store = await getStore();
       invokeTerminalListLiveSpy.mockResolvedValueOnce([
-        { id: `${SESSION_ID}::t2` },
-        { id: `${SESSION_ID}::t1` },
+        { id: `${SESSION_ID}::t2`, cwd: '/worktrees/api' },
+        { id: `${SESSION_ID}::t1`, cwd: '/worktrees/api' },
       ]);
 
       await store.getState().reattachTerminalTabs();
@@ -596,6 +599,54 @@ describe('store contract', () => {
       const tabs = store.getState().terminalTabs[SESSION_ID] ?? [];
       expect(tabs.map((tab) => tab.id)).toEqual([`${SESSION_ID}::t1`, `${SESSION_ID}::t2`]);
       expect(store.getState().activeTerminalTab[SESSION_ID]).toBe(`${SESSION_ID}::t1`);
+    });
+
+    it('addTerminalTab tags the tab with the active project of the session', async () => {
+      const store = await getStore();
+      store.setState({ sessionActiveProject: { [SESSION_ID]: 'api' as ProjectId } });
+
+      const id = store.getState().addTerminalTab(SESSION_ID, '/worktrees/api');
+
+      const tab = (store.getState().terminalTabs[SESSION_ID] ?? []).find(
+        (candidate) => candidate.id === id,
+      );
+      expect(tab?.projectId).toBe('api');
+    });
+
+    it('addTerminalTab leaves the project undefined when the session has no active project', async () => {
+      const store = await getStore();
+      const id = store.getState().addTerminalTab(SESSION_ID, null);
+      const tab = (store.getState().terminalTabs[SESSION_ID] ?? []).find(
+        (candidate) => candidate.id === id,
+      );
+      expect(tab?.projectId).toBeUndefined();
+    });
+
+    it('a reattached tab regains its project from the cwd of the live terminal', async () => {
+      const store = await getStore();
+      store.setState({
+        sessionProjectMounts: {
+          [SESSION_ID]: [
+            {
+              projectId: 'api' as ProjectId,
+              mountName: 'API',
+              worktreePath: '/worktrees/api',
+              repoRoot: '/repo/api',
+              branch: 'feat/api',
+            },
+          ],
+        },
+      });
+      invokeTerminalListLiveSpy.mockResolvedValueOnce([
+        { id: `${SESSION_ID}::t1`, cwd: '/worktrees/api' },
+        { id: `${SESSION_ID}::t2`, cwd: '/somewhere/else' },
+      ]);
+
+      await store.getState().reattachTerminalTabs();
+
+      const tabs = store.getState().terminalTabs[SESSION_ID] ?? [];
+      expect(tabs.map((tab) => tab.projectId)).toEqual(['api', undefined]);
+      expect(tabs.map((tab) => tab.cwd)).toEqual(['/worktrees/api', '/somewhere/else']);
     });
 
     it('setActiveTerminalTab switches the active tab', async () => {

--- a/apps/desktop/src/store/slices/terminal/reattachTerminalTabs.ts
+++ b/apps/desktop/src/store/slices/terminal/reattachTerminalTabs.ts
@@ -1,4 +1,4 @@
-import type { SessionId } from '@goodboy/types';
+import type { ProjectId, SessionId, SessionProjectMount } from '@goodboy/types';
 import { invokeTerminalListLive } from '../../../features/terminal/terminal';
 import type { TerminalTab, TerminalTabId } from '../../../shared/types/terminal';
 import type { SetFn } from './types';
@@ -24,6 +24,18 @@ const parseTerminalId = ({ id }: ParseParams): ParsedTerminalId | null => {
   return { sessionId: id.slice(0, separatorIndex) as SessionId, ordinal };
 };
 
+type MountedProjectParams = {
+  readonly mounts: ReadonlyArray<SessionProjectMount>;
+  readonly cwd: string | null;
+};
+
+const mountedProjectId = ({ mounts, cwd }: MountedProjectParams): ProjectId | undefined => {
+  if (cwd == null || cwd === '') {
+    return undefined;
+  }
+  return mounts.find((mount) => mount.worktreePath === cwd)?.projectId;
+};
+
 export const reattachTerminalTabs = (set: SetFn) => {
   return async (): Promise<void> => {
     const liveTerminals = await invokeTerminalListLive();
@@ -36,11 +48,14 @@ export const reattachTerminalTabs = (set: SetFn) => {
         if (parsed === null) {
           continue;
         }
+        const mounts = state.sessionProjectMounts[parsed.sessionId] ?? [];
+        const cwd = live.cwd;
         const tab: TerminalTab = {
           id: live.id as TerminalTabId,
           sessionId: parsed.sessionId,
           title: `Terminal ${parsed.ordinal}`,
-          cwd: null,
+          cwd,
+          projectId: mountedProjectId({ mounts, cwd }),
           status: 'running',
           createdAt: Date.now(),
         };


### PR DESCRIPTION
## Summary
- the project mount row now shows a small `bg-success` dot (no counter) on the terminal icon when the project has live terminals and on the scripts icon when it has running scripts; the count lives in the tooltip only (`Open terminal in API, 2 running`), reusing the repo's existing button-dot pattern
- terminals gain project attribution: tabs record the active project at creation, the host registry keeps the effective cwd and `terminal_list_live` returns it, so tabs recovered after a reload regain their project by matching cwd to the mount worktree; scripts resolve through `scriptId -> projectScripts`

## Tests
- dot presence and absence per project for both icons, tooltip counts, projectId at creation and after reattach, cwd in list-live
- rust terminal suite green (4), 107 desktop tests green across 15 files, typecheck green

🤖 Generated with [Claude Code](https://claude.com/claude-code)