### PR TITLE
fix(ui): show the deciding spinner across overview and board

### DIFF
--- a/apps/desktop/src/features/orchestration/hooks/useWorkspaceRuns/index.ts
+++ b/apps/desktop/src/features/orchestration/hooks/useWorkspaceRuns/index.ts
@@ -243,6 +243,9 @@ export const useWorkspaceRuns = (
           ? runs.some((r) => agentHasUnread(r, isCurrent && r.id === selected))
           : false;
         const hasRunningAgent = runs ? runs.some((r) => r.status === 'running') : false;
+        const isDecidingWorkflow = session.workflowRuns.some(
+          (run) => s.orchestratingWorkflowRuns?.[run.id] === true && run.discardedAt == null,
+        );
         const openQuestionCount = (s.sessionOpenQuestions[id] ?? []).filter(
           (q) => q.status === 'open',
         ).length;
@@ -252,6 +255,7 @@ export const useWorkspaceRuns = (
           hasUnread,
           openQuestionCount,
           hasRunningAgent,
+          isDecidingWorkflow,
           isPrReview: isPrReviewSession({ agents: runs ?? [] }),
           isBranchless: isBranchlessSession({ branch: s.sessionBranches[id] }),
         }).stage;

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineMarker.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineMarker.test.tsx
@@ -4,7 +4,9 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { cleanup, render, screen } from '@testing-library/react';
 import { tintClasses } from '@goodboy/ui';
 import type { TimelineMarkerState } from '../../../../timeline/markerState';
+import { runIdentity } from '../../../../timeline/runIdentity';
 import { TIMELINE_RHYTHM, type TimelineRowGrade } from '../../../../timeline/timelineRhythm';
+import { ORCHESTRATOR_DECIDING_SENTENCE } from '../../../../../workflows/orchestratorCopy';
 import { TimelineMarker } from './TimelineMarker';
 import { TIMELINE_SURFACE_FILL } from './timelineLayout';
 
@@ -14,6 +16,7 @@ const STATES = [
   'done',
   'failed',
   'running',
+  'deciding',
   'pending',
   'skipped',
   'needsUser',
@@ -26,6 +29,7 @@ const LABELS: Record<TimelineMarkerState, string> = {
   done: 'Done',
   failed: 'Failed',
   running: 'Running',
+  deciding: ORCHESTRATOR_DECIDING_SENTENCE,
   pending: 'Not started',
   skipped: 'Skipped',
   needsUser: 'Needs you',
@@ -125,9 +129,11 @@ describe('TimelineMarker', () => {
     expect(rootOf({ state: 'failed' }).className).toContain('bg-danger');
   });
 
-  it('animates running and nothing else', () => {
-    expect(rootOf({ state: 'running' }).className).toContain('spin-border');
-    cleanup();
+  it('animates the two live states and nothing else', () => {
+    for (const state of ['running', 'deciding'] satisfies ReadonlyArray<TimelineMarkerState>) {
+      expect(rootOf({ state }).className).toContain('spin-border');
+      cleanup();
+    }
     for (const state of [
       'done',
       'failed',
@@ -137,6 +143,28 @@ describe('TimelineMarker', () => {
       expect(rootOf({ state }).className).not.toContain('spin-border');
       cleanup();
     }
+  });
+
+  it('spins the deciding marker in the lane identity hue instead of the info tone', () => {
+    const identity = runIdentity({ laneIndex: 0, seed: 0 });
+    const { container } = render(
+      <TimelineMarker state="deciding" grade="entry" identity={identity} />,
+    );
+
+    expect(container.firstElementChild?.className).toContain(identity.spin);
+    expect(container.firstElementChild?.className).not.toContain('spin-border-info');
+  });
+
+  it('falls back to the info tone when a deciding marker has no lane', () => {
+    expect(rootOf({ state: 'deciding' }).className).toContain('spin-border-info');
+  });
+
+  it('leaves the deciding marker without the dot that says a step is working', () => {
+    const root = rootOf({ state: 'deciding' });
+
+    expect(screen.getByLabelText(ORCHESTRATOR_DECIDING_SENTENCE)).toBeDefined();
+    expect(root.querySelector('[class*="bg-info"]')).toBeNull();
+    expect(root.querySelector('svg')).toBeNull();
   });
 
   it('draws running as the ring plus a pulsing dot at its centre', () => {
@@ -152,6 +180,7 @@ describe('TimelineMarker', () => {
     for (const state of [
       'done',
       'failed',
+      'deciding',
       'pending',
       'skipped',
       'needsUser',

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineMarker.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineMarker.tsx
@@ -3,7 +3,9 @@ import type { LucideIcon } from 'lucide-react';
 import { cn, tintClasses } from '@goodboy/ui';
 import type { Tone } from '@goodboy/ui';
 import type { TimelineMarkerState } from '../../../../timeline/markerState';
+import type { RunIdentity } from '../../../../timeline/runIdentity';
 import { TIMELINE_RHYTHM, type TimelineRowGrade } from '../../../../timeline/timelineRhythm';
+import { ORCHESTRATOR_DECIDING_SENTENCE } from '../../../../../workflows/orchestratorCopy';
 import { TimelineEmphasisMarker } from './TimelineEmphasisMarker';
 import { TIMELINE_SURFACE_FILL } from './timelineLayout';
 
@@ -11,6 +13,7 @@ type Props = {
   readonly state: TimelineMarkerState;
   readonly grade: TimelineRowGrade;
   readonly hasUnread?: boolean;
+  readonly identity?: RunIdentity | null;
 };
 
 type CircleState = Exclude<TimelineMarkerState, 'needsUser' | 'question'>;
@@ -30,6 +33,12 @@ const CIRCLE: Record<CircleState, CircleSpec> = {
   skipped: { tone: 'neutral', icon: Minus, fill: 'soft', label: 'Skipped' },
   pending: { tone: 'neutral', icon: Clock, fill: 'hollow', label: 'Not started' },
   running: { tone: 'info', icon: null, fill: 'hollow', label: 'Running' },
+  deciding: {
+    tone: 'info',
+    icon: null,
+    fill: 'hollow',
+    label: ORCHESTRATOR_DECIDING_SENTENCE,
+  },
 };
 
 const SHAPE: Record<
@@ -70,7 +79,7 @@ const glyphClasses = ({ fill, tone }: FillParams): string => {
   return tintClasses(tone).icon;
 };
 
-export const TimelineMarker = ({ state, grade, hasUnread = false }: Props) => {
+export const TimelineMarker = ({ state, grade, hasUnread = false, identity = null }: Props) => {
   const { markerSize, glyphSize, dotSize } = TIMELINE_RHYTHM.grade[grade];
   const unread = hasUnread ? (
     <span
@@ -100,6 +109,7 @@ export const TimelineMarker = ({ state, grade, hasUnread = false }: Props) => {
         'relative inline-flex items-center justify-center rounded-full',
         surfaceClasses({ fill: spec.fill, tone: spec.tone }),
         state === 'running' && 'spin-border spin-border-info',
+        state === 'deciding' && cn('spin-border', identity?.spin ?? 'spin-border-info'),
       )}
       style={{ width: markerSize, height: markerSize }}
       aria-label={Glyph === null ? spec.label : undefined}

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRowLabel.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRowLabel.tsx
@@ -94,7 +94,7 @@ const chipOf = ({ entry, grade }: ChipParams) => {
 export const TimelineRowLabel = ({ item, diffStat = null }: Props) => {
   const { entry, grade } = item;
   if (entry.kind === 'run') {
-    return <TimelineRunLabel entry={entry} />;
+    return <TimelineRunLabel entry={entry} isDeciding={item.markerState === 'deciding'} />;
   }
   const isStep = grade === 'step';
   const emphasis =

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRowMarker.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRowMarker.tsx
@@ -31,7 +31,14 @@ export const TimelineRowMarker = ({ item }: Props) => {
   const { glyphSize } = TIMELINE_RHYTHM.grade[grade];
 
   if (entry.kind === 'run' || entry.kind === 'agent') {
-    return <TimelineMarker state={item.markerState} grade={grade} hasUnread={item.hasUnread} />;
+    return (
+      <TimelineMarker
+        state={item.markerState}
+        grade={grade}
+        hasUnread={item.hasUnread}
+        identity={item.identity}
+      />
+    );
   }
   if (entry.kind === 'issue') {
     return (

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRunLabel.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRunLabel.test.tsx
@@ -2,9 +2,12 @@
 
 import { afterEach, describe, expect, it } from 'vitest';
 import { cleanup, render, screen } from '@testing-library/react';
+import type { WorkflowRun } from '@goodboy/types';
+import { resolveOrchestratorState } from '../../../../../workflows/components/OrchestratorPanel/orchestratorState';
 import type { TimelineRunEntry } from '../../../../timeline/buildTimelineGroups';
 import { runIdentity } from '../../../../timeline/runIdentity';
 import type { RunWorkflowKind } from '../../../../timeline/runWorkflowKind';
+import { ORCHESTRATOR_DECIDING_SENTENCE } from '../../../../../workflows/orchestratorCopy';
 import { TimelineRunLabel } from './TimelineRunLabel';
 
 afterEach(cleanup);
@@ -132,6 +135,34 @@ describe('TimelineRunLabel', () => {
 
     expect(mutedChip).toContain('text-run-');
     expect(chipOf().className).toContain(mutedChip);
+  });
+
+  it('says what the orchestrator is doing while it chooses the next step', () => {
+    render(<TimelineRunLabel entry={entryOf({ kind: 'orchestrator' })} isDeciding />);
+    const sentence = screen.getByText(ORCHESTRATOR_DECIDING_SENTENCE);
+
+    expect(sentence.className).toContain('text-muted-foreground');
+    expect(screen.getByText('Refactor (example)')).toBeDefined();
+  });
+
+  it('words the deciding row exactly as the orchestrator panel words it', () => {
+    render(<TimelineRunLabel entry={entryOf({ kind: 'orchestrator' })} isDeciding />);
+
+    expect(
+      resolveOrchestratorState({
+        run: { autoRun: true } as unknown as WorkflowRun,
+        agents: [],
+        isOrchestrating: true,
+        hasOpenQuestions: false,
+        costUsd: 0,
+      }).sentence,
+    ).toBe(screen.getByText(ORCHESTRATOR_DECIDING_SENTENCE).textContent);
+  });
+
+  it('stays silent about the orchestrator when no decision is in flight', () => {
+    render(<TimelineRunLabel entry={entryOf({ kind: 'orchestrator' })} />);
+
+    expect(screen.queryByText(ORCHESTRATOR_DECIDING_SENTENCE)).toBeNull();
   });
 
   it('drops the title when the run carries no goal at all', () => {

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRunLabel.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRunLabel.tsx
@@ -1,13 +1,15 @@
 import { cn } from '@goodboy/ui';
 import type { TimelineRunEntry } from '../../../../timeline/buildTimelineGroups';
 import { runWorkflowKind } from '../../../../timeline/runWorkflowKind';
+import { ORCHESTRATOR_DECIDING_SENTENCE } from '../../../../../workflows/orchestratorCopy';
 import { TimelineRunChip } from './TimelineRunChip';
 
 type Props = {
   readonly entry: TimelineRunEntry;
+  readonly isDeciding?: boolean;
 };
 
-const titleOf = ({ entry }: Props): string | null => {
+const titleOf = ({ entry }: { readonly entry: TimelineRunEntry }): string | null => {
   const goal = entry.run.goal?.trim() ?? '';
   if (goal.length === 0 || goal === entry.workflow.name.trim()) {
     return null;
@@ -15,7 +17,7 @@ const titleOf = ({ entry }: Props): string | null => {
   return goal;
 };
 
-export const TimelineRunLabel = ({ entry }: Props) => {
+export const TimelineRunLabel = ({ entry, isDeciding = false }: Props) => {
   const title = titleOf({ entry });
   const isDiscarded = entry.run.discardedAt != null;
   return (
@@ -36,6 +38,11 @@ export const TimelineRunLabel = ({ entry }: Props) => {
       {title == null ? null : (
         <span className="min-w-0 truncate text-sm leading-5 text-muted-foreground">{title}</span>
       )}
+      {isDeciding ? (
+        <span className="min-w-0 truncate text-2xs text-muted-foreground">
+          {ORCHESTRATOR_DECIDING_SENTENCE}
+        </span>
+      ) : null}
     </>
   );
 };

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineStreamRow.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineStreamRow.test.tsx
@@ -3,10 +3,16 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import type { Agent, AgentId, IsoDateTime, SessionId } from '@goodboy/types';
-import type { TimelineAgentEntry } from '../../../../timeline/buildTimelineGroups';
+import type {
+  TimelineAgentEntry,
+  TimelineRunEntry,
+} from '../../../../timeline/buildTimelineGroups';
 import type { TimelineRowItem } from '../../../../timeline/buildTimelineStream';
+import type { TimelineMarkerState } from '../../../../timeline/markerState';
 import type { RailRow } from '../../../../timeline/railGeometry';
+import { runIdentity } from '../../../../timeline/runIdentity';
 import { TIMELINE_RHYTHM } from '../../../../timeline/timelineRhythm';
+import { ORCHESTRATOR_DECIDING_SENTENCE } from '../../../../../workflows/orchestratorCopy';
 
 vi.mock('../../../../../../store', () => ({
   EMPTY_ARRAY: Object.freeze([]),
@@ -67,6 +73,33 @@ const itemOf = (): TimelineRowItem => ({
   groupId: 'lane:run:one',
   isPending: false,
   gap: 'sibling',
+});
+
+const runEntryOf = (): TimelineRunEntry =>
+  ({
+    kind: 'run',
+    id: 'run:one',
+    at: '2026-08-17T09:04:00Z',
+    run: { id: 'one', goal: 'Ship the parser', discardedAt: null },
+    workflow: { name: 'Orchestrated workflow 3', origin: 'orchestrated' },
+    identity: runIdentity({ laneIndex: 0, seed: 0 }),
+    children: [],
+    producedPlan: null,
+  }) as unknown as TimelineRunEntry;
+
+const runItemOf = ({
+  markerState,
+}: {
+  readonly markerState: TimelineMarkerState;
+}): TimelineRowItem => ({
+  ...itemOf(),
+  id: 'run:one',
+  grade: 'entry',
+  entry: runEntryOf(),
+  identity: runIdentity({ laneIndex: 0, seed: 0 }),
+  ordinal: null,
+  markerState,
+  groupId: null,
 });
 
 const railOf = (): RailRow => ({
@@ -175,6 +208,41 @@ describe('TimelineStreamRow', () => {
 
     expect(wrapper.getAttribute('style')).toBe(content.getAttribute('style'));
     expect(wrapper.className).toContain('items-center');
+  });
+
+  it('spins the run marker in its lane hue while the orchestrator is choosing', () => {
+    const { container } = render(
+      <TimelineStreamRow
+        item={runItemOf({ markerState: 'deciding' })}
+        rail={railOf()}
+        railWidth={32}
+        sessionId={SESSION_ID}
+        openTarget={null}
+        action={null}
+      />,
+    );
+    const marker = container.querySelector('[class*="spin-border"]');
+
+    expect(marker?.className).toContain(runIdentity({ laneIndex: 0, seed: 0 }).spin);
+    expect(screen.getByText(ORCHESTRATOR_DECIDING_SENTENCE)).toBeDefined();
+    expect(screen.queryByLabelText('Not started')).toBeNull();
+  });
+
+  it('leaves a run with no decision in flight on the idle clock and no sentence', () => {
+    const { container } = render(
+      <TimelineStreamRow
+        item={runItemOf({ markerState: 'pending' })}
+        rail={railOf()}
+        railWidth={32}
+        sessionId={SESSION_ID}
+        openTarget={null}
+        action={null}
+      />,
+    );
+
+    expect(screen.getByLabelText('Not started')).toBeDefined();
+    expect(container.querySelector('[class*="spin-border"]')).toBeNull();
+    expect(screen.queryByText(ORCHESTRATOR_DECIDING_SENTENCE)).toBeNull();
   });
 
   it('reserves the same box for a step whatever trailing metadata it carries', () => {

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/index.tsx
@@ -49,6 +49,7 @@ export const TimelinePane = ({ session, runs, actions, kickoff }: Props) => {
   const areEventsLoaded = useAppStore((s) => s.sessionEvents?.[sessionId] !== undefined);
   const loadSessionEvents = useAppStore((s) => s.loadSessionEvents);
   const agentKindOverride = useAppStore((s) => s.agentKindOverride);
+  const orchestratingWorkflowRuns = useAppStore((s) => s.orchestratingWorkflowRuns);
   const markAllAgentsSeen = useAppStore((s) => s.markAllAgentsSeen);
   const setActiveLens = useAppStore((s) => s.setActiveLens);
   const openMountDiff = useAppStore((s) => s.openMountDiff);
@@ -134,6 +135,16 @@ export const TimelinePane = ({ session, runs, actions, kickoff }: Props) => {
     return unread;
   }, [agents]);
 
+  const decidingRunIds = useMemo(() => {
+    const deciding = new Set<string>();
+    for (const { run } of workflows) {
+      if (orchestratingWorkflowRuns?.[run.id] === true) {
+        deciding.add(run.id);
+      }
+    }
+    return deciding;
+  }, [orchestratingWorkflowRuns, workflows]);
+
   const blockedRunIds = useMemo(() => {
     const blocked = new Set<string>(stalledRunIds);
     for (const [runId, state] of advanceByRunId) {
@@ -150,6 +161,7 @@ export const TimelinePane = ({ session, runs, actions, kickoff }: Props) => {
         entries: visibleEntries,
         unreadAgentIds,
         blockedRunIds,
+        decidingRunIds,
         dayLabelFor: dayLabel,
         showWorkflowSubagents: activity.filter.workflowSubagents,
         showAgentSubagents: activity.filter.agentSubagents,
@@ -162,6 +174,7 @@ export const TimelinePane = ({ session, runs, actions, kickoff }: Props) => {
       activity.filter.questions,
       activity.filter.workflowSubagents,
       blockedRunIds,
+      decidingRunIds,
       unreadAgentIds,
       visibleEntries,
     ],

--- a/apps/desktop/src/features/session/timeline/buildTimelineStream.test.ts
+++ b/apps/desktop/src/features/session/timeline/buildTimelineStream.test.ts
@@ -167,6 +167,7 @@ type StreamParams = {
   readonly agents: ReadonlyArray<Agent>;
   readonly workflows?: ReadonlyArray<ReturnType<typeof attachedWorkflow>>;
   readonly unreadAgentIds?: ReadonlySet<string>;
+  readonly decidingRunIds?: ReadonlySet<string>;
   readonly events?: ReadonlyArray<SessionEvent>;
   readonly plans?: ReadonlyArray<PlanWithCount>;
   readonly questions?: ReadonlyArray<OpenQuestion>;
@@ -180,6 +181,7 @@ const stream = ({
   agents,
   workflows = [],
   unreadAgentIds = new Set(),
+  decidingRunIds = new Set(),
   events = [],
   plans = [],
   questions = [],
@@ -202,6 +204,7 @@ const stream = ({
     }).entries,
     unreadAgentIds,
     blockedRunIds: new Set(),
+    decidingRunIds,
     dayLabelFor: ({ at }) => dayLabel({ at, now: NOW }),
     ...(showWorkflowSubagents != null ? { showWorkflowSubagents } : {}),
     ...(showAgentSubagents != null ? { showAgentSubagents } : {}),
@@ -1168,6 +1171,59 @@ describe('buildTimelineStream, session events', () => {
 
     expect(lane?.shape).toBe('open');
     expect(runRow?.kind === 'row' ? runRow.markerState : null).toBe('pending');
+  });
+
+  it('marks a run whose orchestrator is choosing the next step as deciding, not pending', () => {
+    const settledSteps = {
+      workflows: [
+        attachedWorkflow({
+          createdAt: localIso({ day: 18, hour: 8 }),
+          stepIds: ['one'],
+          executionMode: 'dynamic',
+        }),
+      ],
+      agents: [
+        agent({
+          id: 'one',
+          ordinal: 1,
+          startedAt: localIso({ day: 18, hour: 9 }),
+          completedAt: localIso({ day: 18, hour: 9, minute: 30 }),
+          workflowRunId: RUN_ID,
+        }),
+      ],
+    };
+    const idle = stream(settledSteps);
+    const deciding = stream({ ...settledSteps, decidingRunIds: new Set([RUN_ID]) });
+    const idleRow = idle.items.find((item) => item.id === 'run:run-1');
+    const decidingRow = deciding.items.find((item) => item.id === 'run:run-1');
+
+    expect(idleRow?.kind === 'row' ? idleRow.markerState : null).toBe('pending');
+    expect(decidingRow?.kind === 'row' ? decidingRow.markerState : null).toBe('deciding');
+  });
+
+  it('keeps a run with a step in flight on running even while a decision is in flight', () => {
+    const { items } = stream({
+      workflows: [
+        attachedWorkflow({
+          createdAt: localIso({ day: 18, hour: 8 }),
+          stepIds: ['one'],
+          executionMode: 'dynamic',
+        }),
+      ],
+      agents: [
+        agent({
+          id: 'one',
+          ordinal: 1,
+          status: 'running',
+          startedAt: localIso({ day: 18, hour: 9 }),
+          workflowRunId: RUN_ID,
+        }),
+      ],
+      decidingRunIds: new Set([RUN_ID]),
+    });
+    const runRow = items.find((item) => item.id === 'run:run-1');
+
+    expect(runRow?.kind === 'row' ? runRow.markerState : null).toBe('running');
   });
 
   it('closes the lane of a dynamic run once the orchestrator declares it done', () => {

--- a/apps/desktop/src/features/session/timeline/buildTimelineStream.ts
+++ b/apps/desktop/src/features/session/timeline/buildTimelineStream.ts
@@ -83,6 +83,7 @@ type Params = {
   readonly entries: ReadonlyArray<TimelineTopLevelEntry>;
   readonly unreadAgentIds: ReadonlySet<string>;
   readonly blockedRunIds: ReadonlySet<string>;
+  readonly decidingRunIds: ReadonlySet<string>;
   readonly dayLabelFor: (params: { readonly at: string }) => string | null;
   readonly showWorkflowSubagents?: boolean;
   readonly showAgentSubagents?: boolean;
@@ -252,6 +253,7 @@ const isRunFinished = ({ entry }: { readonly entry: TimelineRunEntry }): boolean
 type EmitContext = {
   readonly unreadAgentIds: ReadonlySet<string>;
   readonly blockedRunIds: ReadonlySet<string>;
+  readonly decidingRunIds: ReadonlySet<string>;
   readonly groups: RailGroupInput[];
   readonly showWorkflowSubagents: boolean;
   readonly showAgentSubagents: boolean;
@@ -423,6 +425,19 @@ const runRows = ({ entry, context }: EmitRunParams): ReadonlyArray<DraftRow> => 
     nested.push(row);
   }
   const steps = stepAgentsOf({ entry });
+  const hasRunningStep = steps.some((agent) => agent.status === 'running');
+  const isDeciding = !isFinished && !hasRunningStep && context.decidingRunIds.has(entry.run.id);
+  const settledState: TimelineMarkerState = resolveMarkerState({
+    status: hasRunningStep
+      ? 'running'
+      : steps.some((agent) => agent.status === 'failed')
+        ? 'failed'
+        : isFinished
+          ? 'completed'
+          : 'pending',
+    hasOpenQuestion: false,
+    needsUser,
+  });
   const origin: DraftRow = {
     kind: 'row',
     id: entry.id,
@@ -434,17 +449,7 @@ const runRows = ({ entry, context }: EmitRunParams): ReadonlyArray<DraftRow> => 
     groupId: null,
     ordinal: null,
     sortOrdinal: 0,
-    markerState: resolveMarkerState({
-      status: steps.some((agent) => agent.status === 'running')
-        ? 'running'
-        : steps.some((agent) => agent.status === 'failed')
-          ? 'failed'
-          : isFinished
-            ? 'completed'
-            : 'pending',
-      hasOpenQuestion: false,
-      needsUser,
-    }),
+    markerState: isDeciding ? 'deciding' : settledState,
     hasUnread: steps.some((agent) => context.unreadAgentIds.has(agent.id)),
     isPending: false,
   };
@@ -570,6 +575,7 @@ export const buildTimelineStream = ({
   entries,
   unreadAgentIds,
   blockedRunIds,
+  decidingRunIds,
   dayLabelFor,
   showWorkflowSubagents = true,
   showAgentSubagents = true,
@@ -579,6 +585,7 @@ export const buildTimelineStream = ({
   const context: EmitContext = {
     unreadAgentIds,
     blockedRunIds,
+    decidingRunIds,
     groups: [],
     showWorkflowSubagents,
     showAgentSubagents,

--- a/apps/desktop/src/features/session/timeline/markerState.ts
+++ b/apps/desktop/src/features/session/timeline/markerState.ts
@@ -1,7 +1,7 @@
 import type { Agent } from '@goodboy/types';
 
 export type TimelineMarkerState =
-  'done' | 'failed' | 'running' | 'pending' | 'skipped' | 'needsUser' | 'question';
+  'done' | 'failed' | 'running' | 'deciding' | 'pending' | 'skipped' | 'needsUser' | 'question';
 
 type Params = {
   readonly status: Agent['status'];

--- a/apps/desktop/src/features/session/timeline/runIdentity.ts
+++ b/apps/desktop/src/features/session/timeline/runIdentity.ts
@@ -2,6 +2,7 @@ export type RunIdentity = {
   readonly stroke: string;
   readonly chip: string;
   readonly mutedChip: string;
+  readonly spin: string;
   readonly index: number;
 };
 
@@ -10,30 +11,35 @@ const IDENTITIES: ReadonlyArray<RunIdentity> = [
     stroke: 'var(--color-run-1)',
     chip: 'bg-run-1/12 text-run-1 ring-run-1/35',
     mutedChip: 'bg-transparent text-run-1 ring-run-1/20',
+    spin: 'spin-border-run-1',
     index: 0,
   },
   {
     stroke: 'var(--color-run-2)',
     chip: 'bg-run-2/12 text-run-2 ring-run-2/35',
     mutedChip: 'bg-transparent text-run-2 ring-run-2/20',
+    spin: 'spin-border-run-2',
     index: 1,
   },
   {
     stroke: 'var(--color-run-3)',
     chip: 'bg-run-3/12 text-run-3 ring-run-3/35',
     mutedChip: 'bg-transparent text-run-3 ring-run-3/20',
+    spin: 'spin-border-run-3',
     index: 2,
   },
   {
     stroke: 'var(--color-run-4)',
     chip: 'bg-run-4/12 text-run-4 ring-run-4/35',
     mutedChip: 'bg-transparent text-run-4 ring-run-4/20',
+    spin: 'spin-border-run-4',
     index: 3,
   },
   {
     stroke: 'var(--color-run-5)',
     chip: 'bg-run-5/12 text-run-5 ring-run-5/35',
     mutedChip: 'bg-transparent text-run-5 ring-run-5/20',
+    spin: 'spin-border-run-5',
     index: 4,
   },
 ];

--- a/apps/desktop/src/features/workflows/components/OrchestratorPanel/orchestratorState.ts
+++ b/apps/desktop/src/features/workflows/components/OrchestratorPanel/orchestratorState.ts
@@ -6,6 +6,7 @@ import type {
   WorkflowOrchestrationStopKind,
   WorkflowRun,
 } from '@goodboy/types';
+import { ORCHESTRATOR_DECIDING_SENTENCE } from '../../orchestratorCopy';
 
 type OrchestratorPhase =
   | 'deciding'
@@ -119,7 +120,12 @@ export const resolveOrchestratorState = ({
     };
   }
   if (isOrchestrating) {
-    return { ...base, phase: 'deciding', tone: 'info', sentence: 'Choosing the next step' };
+    return {
+      ...base,
+      phase: 'deciding',
+      tone: 'info',
+      sentence: ORCHESTRATOR_DECIDING_SENTENCE,
+    };
   }
   if (run.orchestrationOutcome === 'done') {
     const steps = `${ordered.length} ${ordered.length === 1 ? 'step' : 'steps'}`;

--- a/apps/desktop/src/features/workflows/orchestratorCopy.ts
+++ b/apps/desktop/src/features/workflows/orchestratorCopy.ts
@@ -1,0 +1,1 @@
+export const ORCHESTRATOR_DECIDING_SENTENCE = 'Choosing the next step';

--- a/apps/desktop/src/store/selectors.ts
+++ b/apps/desktop/src/store/selectors.ts
@@ -176,6 +176,7 @@ type StageInfoState = Pick<
   | 'sessionGitlabMr'
   | 'sessionOpenQuestions'
   | 'sessionPhaseRuns'
+  | 'orchestratingWorkflowRuns'
   | 'selectedAgentId'
   | 'currentSessionId'
   | 'githubStatus'
@@ -204,6 +205,12 @@ function sessionHasRunningAgentIn(state: StageInfoState, sessionId: SessionId): 
   return runs ? runs.some((r) => r.status === 'running') : false;
 }
 
+function sessionIsDecidingIn(state: StageInfoState, session: Session): boolean {
+  return session.workflowRuns.some(
+    (run) => state.orchestratingWorkflowRuns?.[run.id] === true && run.discardedAt == null,
+  );
+}
+
 function stageInfoOf(state: StageInfoState, session: Session): SessionStageInfo {
   const sessionId = session.id as SessionId;
   const isBranchless = isBranchlessSession({
@@ -226,6 +233,7 @@ function stageInfoOf(state: StageInfoState, session: Session): SessionStageInfo 
     hasUnread: sessionHasUnreadIn(state, sessionId),
     openQuestionCount: countOpenQuestions(state, sessionId),
     hasRunningAgent: sessionHasRunningAgentIn(state, sessionId),
+    isDecidingWorkflow: sessionIsDecidingIn(state, session),
     isPrReview: isPrReviewSession({ agents: state.sessionPhaseRuns[sessionId] ?? [] }),
     isBranchless,
   });
@@ -264,6 +272,11 @@ export const useSortedGroupedSessions = (
   const sessionPhaseRuns = useAppStore((s) =>
     needsStage ? s.sessionPhaseRuns : (EMPTY_GITHUB_STATE as typeof s.sessionPhaseRuns),
   );
+  const orchestratingWorkflowRuns = useAppStore((s) =>
+    needsStage
+      ? s.orchestratingWorkflowRuns
+      : (EMPTY_GITHUB_STATE as typeof s.orchestratingWorkflowRuns),
+  );
   const selectedAgentId = useAppStore((s) =>
     needsStage ? s.selectedAgentId : (EMPTY_GITHUB_STATE as typeof s.selectedAgentId),
   );
@@ -296,6 +309,7 @@ export const useSortedGroupedSessions = (
       sessionGitlabMr,
       sessionOpenQuestions,
       sessionPhaseRuns,
+      orchestratingWorkflowRuns,
       selectedAgentId,
       currentSessionId,
       githubStatus,
@@ -321,6 +335,7 @@ export const useSortedGroupedSessions = (
     sessionGitlabMr,
     sessionOpenQuestions,
     sessionPhaseRuns,
+    orchestratingWorkflowRuns,
     selectedAgentId,
     currentSessionId,
     githubStatus,
@@ -365,6 +380,7 @@ export const useStageGroupedSessions = (
   const sessionGitlabMr = useAppStore((s) => s.sessionGitlabMr);
   const sessionOpenQuestions = useAppStore((s) => s.sessionOpenQuestions);
   const sessionPhaseRuns = useAppStore((s) => s.sessionPhaseRuns);
+  const orchestratingWorkflowRuns = useAppStore((s) => s.orchestratingWorkflowRuns);
   const selectedAgentId = useAppStore((s) => s.selectedAgentId);
   const currentSessionId = useAppStore((s) => s.currentSessionId);
   const githubStatus = useAppStore((s) => s.githubStatus);
@@ -388,6 +404,7 @@ export const useStageGroupedSessions = (
       sessionGitlabMr,
       sessionOpenQuestions,
       sessionPhaseRuns,
+      orchestratingWorkflowRuns,
       selectedAgentId,
       currentSessionId,
       githubStatus,
@@ -415,6 +432,7 @@ export const useStageGroupedSessions = (
     sessionGitlabMr,
     sessionOpenQuestions,
     sessionPhaseRuns,
+    orchestratingWorkflowRuns,
     selectedAgentId,
     currentSessionId,
     githubStatus,

--- a/apps/desktop/src/store/slices/session-view/deriveSessionStage.test.ts
+++ b/apps/desktop/src/store/slices/session-view/deriveSessionStage.test.ts
@@ -117,6 +117,38 @@ describe('deriveSessionStage pull request freshness', () => {
   });
 });
 
+describe('deriveSessionStage orchestrator decision', () => {
+  it('keeps a session awake while its orchestrator chooses the next step', () => {
+    const info = deriveSessionStage({
+      session,
+      pr: null,
+      ...signals,
+      hasRunningAgent: false,
+      isDecidingWorkflow: true,
+    });
+
+    expect(info).toEqual({ stage: 'running', reason: 'deciding the next step', attention: null });
+  });
+
+  it('keeps a branchless session awake for the same decision', () => {
+    const info = deriveSessionStage({
+      session,
+      pr: null,
+      ...signals,
+      isBranchless: true,
+      isDecidingWorkflow: true,
+    });
+
+    expect(info).toEqual({ stage: 'running', reason: 'deciding the next step', attention: null });
+  });
+
+  it('reads the same session as idle work once the decision has landed', () => {
+    const info = deriveSessionStage({ session, pr: null, ...signals, isDecidingWorkflow: false });
+
+    expect(info.stage).toBe('building');
+  });
+});
+
 describe('deriveSessionStage lazy session', () => {
   it('places a freshly created branchless draft session as building and ready for work', () => {
     const draftSession: Session = { ...session, state: { kind: 'draft' } };

--- a/apps/desktop/src/store/slices/session-view/deriveSessionStage.ts
+++ b/apps/desktop/src/store/slices/session-view/deriveSessionStage.ts
@@ -11,6 +11,7 @@ type Params = {
   hasUnread: boolean;
   openQuestionCount: number;
   hasRunningAgent?: boolean;
+  isDecidingWorkflow?: boolean;
   isPrReview?: boolean;
   isBranchless?: boolean;
   requestLabel?: string;
@@ -29,6 +30,7 @@ export const deriveSessionStage = ({
   hasUnread,
   openQuestionCount,
   hasRunningAgent = false,
+  isDecidingWorkflow = false,
   isPrReview = false,
   isBranchless = false,
   requestLabel,
@@ -38,6 +40,9 @@ export const deriveSessionStage = ({
   if (isBranchless) {
     if (session.state.kind === 'running' || session.state.kind === 'starting' || hasRunningAgent) {
       return { stage: 'running', reason: 'agent running', attention: null };
+    }
+    if (isDecidingWorkflow) {
+      return { stage: 'running', reason: 'deciding the next step', attention: null };
     }
     if (session.state.kind === 'error') {
       return { stage: 'attention', reason: 'agent errored', attention: 'agent-error' };
@@ -65,6 +70,9 @@ export const deriveSessionStage = ({
   }
   if (hasRunningAgent) {
     return { stage: 'running', reason: 'agent running', attention: null };
+  }
+  if (isDecidingWorkflow) {
+    return { stage: 'running', reason: 'deciding the next step', attention: null };
   }
   if (isPrLive(pr) && pr.checks === 'failure') {
     return { stage: 'attention', reason: `${label}: CI failed`, attention: 'ci-failed' };

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -499,6 +499,21 @@ dialog[open]::backdrop {
 .spin-border-primary {
   --spin-border-color: var(--color-primary);
 }
+.spin-border-run-1 {
+  --spin-border-color: var(--color-run-1);
+}
+.spin-border-run-2 {
+  --spin-border-color: var(--color-run-2);
+}
+.spin-border-run-3 {
+  --spin-border-color: var(--color-run-3);
+}
+.spin-border-run-4 {
+  --spin-border-color: var(--color-run-4);
+}
+.spin-border-run-5 {
+  --spin-border-color: var(--color-run-5);
+}
 
 @media (prefers-reduced-motion: no-preference) {
   .animate-border-pulse {


### PR DESCRIPTION
## Summary
- while the orchestrator chooses the next step the workflow detail said `Choosing the next step` but the overview timeline showed the idle clock and the board derived an idle-looking stage: between two steps no agent is running, so every existing signal read as asleep
- the timeline run row now resolves a `deciding` state from `orchestratingWorkflowRuns` (a running step still outranks it): hollow marker with the repo's `spin-border` ring in the lane's identity hue, secondary label shared byte-for-byte with the orchestrator panel via a single copy source so the two can never drift
- `deriveSessionStage` gains the deciding branch (`running · deciding the next step`) in both derivation paths, wired through both board stage consumers

## Tests
- deciding vs pending on the same settled run, running step outranks the decision, lane-hued spinner with info fallback, label pinned to the panel sentence, stage derivation for a deciding-only session
- 349 tests green across 23 timeline and session-view files, typecheck green

🤖 Generated with [Claude Code](https://claude.com/claude-code)