### PR TITLE
feat(ui): give the resolver its own role model row

### DIFF
--- a/apps/desktop/src/features/chat/spawn-from-comment.test.ts
+++ b/apps/desktop/src/features/chat/spawn-from-comment.test.ts
@@ -84,32 +84,23 @@ describe('spawn-from-comment', () => {
     ).toBe('resolve: alice comment');
   });
 
-  it('builds args as a resolver agent with sonnet defaults', () => {
+  it('builds args as a resolver agent carrying the comment context', () => {
     const args = buildCommentAgentArgs(makeComment(), PR);
     expect(args.name).toBe('resolve: alice on foo.ts:42');
     expect(args.kind).toBe('resolver');
-    expect(args.effort).toBe('medium');
-    expect(args.provider).toBeUndefined();
     expect(args.initialPrompt).toContain('src/foo.ts:42');
     expect(args.initialPrompt).toContain('this should use a helper');
     expect(args.initialPrompt).toContain('#9108');
   });
 
-  it('honors a provider/model/effort choice and links the source comment', () => {
+  it('links the source comment of a review thread', () => {
     const args = buildCommentAgentArgs(makeComment({ threadId: 'PRRT_7' }), PR, {
       provider: 'codex',
       model: 'gpt-5-codex',
       effort: 'high',
     });
-    expect(args.provider).toBe('codex');
-    expect(args.model).toBe('gpt-5-codex');
-    expect(args.effort).toBe('high');
     expect(args.sourceThreadId).toBe('PRRT_7');
     expect(args.sourceCommentUrl).toBe('https://github.com/o/r/pull/9108#discussion_r1');
-  });
-
-  it('falls back to the resolver default effort when unspecified', () => {
-    expect(buildCommentAgentArgs(makeComment(), PR).effort).toBe('medium');
   });
 
   it('omits sourceThreadId for issue comments but keeps the url', () => {

--- a/apps/desktop/src/features/chat/spawn-from-comment.ts
+++ b/apps/desktop/src/features/chat/spawn-from-comment.ts
@@ -1,7 +1,6 @@
 import type { AgentSourceKind, PrComment, ProviderId, PullRequestState } from '@goodboy/types';
 import type { AgentKind } from '../session/agent-kind';
 import type { CommentThread } from '../github/comment-threads';
-import { kindRouting } from '../session/agent-kind';
 import { prCommentLocation } from '../session/pr-comment-location';
 import { RESOLVER_KICKOFF_LABELS } from './utils/resolverKickoffLabels';
 import type { EffortLevel } from './utils/chat-constants';
@@ -177,9 +176,6 @@ const buildResolverKickoff = ({ threads, pr, hint }: KickoffParams): string => {
 export type CommentAgentArgs = {
   readonly name: string;
   readonly kind: AgentKind;
-  readonly model: string;
-  readonly provider?: ProviderId;
-  readonly effort: EffortLevel;
   readonly initialPrompt: string;
   readonly sourceThreadId?: string;
   readonly sourceThreadIds?: ReadonlyArray<string>;
@@ -192,7 +188,6 @@ export const buildCombinedCommentAgentArgs = (
   pr: PullRequestState,
   choice: ResolveModelChoice = {},
 ): CommentAgentArgs => {
-  const defaults = kindRouting({ kind: 'resolver' });
   const first = threads[0];
   if (first === undefined) {
     throw new Error('combined resolver requires at least one thread');
@@ -203,9 +198,6 @@ export const buildCombinedCommentAgentArgs = (
   return {
     name: `resolve: ${threads.length} review threads`,
     kind: 'resolver',
-    model: choice.model ?? defaults.model,
-    ...(choice.provider !== undefined && { provider: choice.provider }),
-    effort: choice.effort ?? defaults.effort,
     initialPrompt: buildResolverKickoff({ threads, pr, hint: choice.hint ?? '' }),
     sourceThreadIds,
     sourceCommentUrl: first.head.url,
@@ -226,13 +218,9 @@ export const buildCommentAgentArgs = (
   choice: ResolveModelChoice = {},
   replies: ReadonlyArray<PrComment> = [],
 ): CommentAgentArgs => {
-  const defaults = kindRouting({ kind: 'resolver' });
   return {
     name: buildCommentAgentTitle(c),
     kind: 'resolver',
-    model: choice.model ?? defaults.model,
-    ...(choice.provider !== undefined && { provider: choice.provider }),
-    effort: choice.effort ?? defaults.effort,
     initialPrompt: buildResolverKickoff({
       threads: [{ head: c, replies }],
       pr,

--- a/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/index.test.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/index.test.tsx
@@ -302,7 +302,34 @@ describe('DefaultsPanel', () => {
     expect(screen.getByText('Debugger')).toBeDefined();
     expect(screen.getByText('Planner')).toBeDefined();
     expect(screen.getByText('Reviewer')).toBeDefined();
+    expect(screen.getByText('Resolver')).toBeDefined();
     expect(screen.getByText('Custom')).toBeDefined();
+  });
+
+  it('reads the resolver role with no override as its compiled default', () => {
+    render(<DefaultsPanel workspaceId={'ws-1' as never} />);
+    openRolesTab();
+
+    expect(screen.getByRole('button', { name: 'Resolver routing model' }).textContent).toBe(
+      'sonnet-5',
+    );
+    expect(screen.getByLabelText('Resolver routing status: default').textContent).toBe('default');
+  });
+
+  it('persists a resolver role model of its own', () => {
+    render(<DefaultsPanel workspaceId={'ws-1' as never} />);
+    openRolesTab();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Resolver routing model' }));
+
+    expect(state.setWorkspaceOverrides).toHaveBeenCalledWith(
+      'ws-1',
+      expect.objectContaining({
+        roleModels: {
+          resolver: { providerId: 'anthropic', model: 'sonnet-4.6', effort: 'medium' },
+        },
+      }),
+    );
   });
 
   it('reads a role with no override as its compiled default', () => {

--- a/apps/desktop/src/features/session/agent-kind.ts
+++ b/apps/desktop/src/features/session/agent-kind.ts
@@ -274,6 +274,7 @@ export const ROLE_TO_KIND: Record<AgentRole, AgentKind> = {
   reviewer: 'reviewer',
   tester: 'tester',
   investigator: 'debugger',
+  resolver: 'resolver',
   custom: 'generic',
 };
 
@@ -286,7 +287,7 @@ export const KIND_TO_ROLE: Record<AgentKind, AgentRole> = {
   reviewer: 'reviewer',
   'pr-reviewer': 'reviewer',
   docs: 'custom',
-  resolver: 'custom',
+  resolver: 'resolver',
   generic: 'custom',
 };
 
@@ -297,6 +298,7 @@ export const ROLE_LABEL: Record<AgentRole, string> = {
   reviewer: 'Reviewer',
   tester: 'Tester',
   investigator: 'Debugger',
+  resolver: 'Resolver',
   custom: 'Custom',
 };
 

--- a/apps/desktop/src/features/session/hooks/useResolverSpawner/index.test.ts
+++ b/apps/desktop/src/features/session/hooks/useResolverSpawner/index.test.ts
@@ -1,0 +1,140 @@
+// @vitest-environment happy-dom
+
+import { act, cleanup, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SessionId } from '@goodboy/types';
+import { ROLE_DEFAULTS } from '@goodboy/core';
+import type { CommentAgentArgs } from '../../../chat/spawn-from-comment';
+
+type Overrides = { readonly roleModels: Record<string, unknown> | null };
+
+const { state } = vi.hoisted(() => ({
+  state: {
+    sessions: [{ id: 'session-1', workspaceId: 'workspace-1' }],
+    workspaceOverrides: {} as Record<string, { roleModels: Record<string, unknown> | null }>,
+    spawnAgent: vi.fn(async () => 'agent-1'),
+    setAgentConfig: vi.fn(async () => undefined),
+  },
+}));
+
+vi.mock('../../../../store', () => ({
+  useAppStore: <T>(selector: (store: typeof state) => T) => selector(state),
+}));
+
+import { useResolverSpawner } from './index';
+
+const SESSION_ID = 'session-1' as SessionId;
+
+const ARGS: CommentAgentArgs = {
+  name: 'resolve: alice on foo.ts:42',
+  kind: 'resolver',
+  initialPrompt: 'resolve the thread',
+  sourceCommentUrl: 'https://github.com/o/r/pull/1#discussion_r1',
+  sourceKind: 'review_comment',
+};
+
+const withOverrides = (overrides: Overrides | null) => {
+  state.workspaceOverrides = overrides == null ? {} : { 'workspace-1': overrides };
+};
+
+beforeEach(() => {
+  withOverrides(null);
+  state.spawnAgent.mockReset();
+  state.spawnAgent.mockResolvedValue('agent-1');
+  state.setAgentConfig.mockReset();
+  state.setAgentConfig.mockResolvedValue(undefined);
+});
+
+afterEach(cleanup);
+
+describe('useResolverSpawner', () => {
+  it('routes an empty choice through the resolver role default', async () => {
+    withOverrides({
+      roleModels: {
+        resolver: { providerId: 'codex', model: 'gpt-5.6', effort: 'high' },
+      },
+    });
+    const { result } = renderHook(() => useResolverSpawner({ sessionId: SESSION_ID }));
+
+    await act(async () => {
+      await result.current.spawnResolver({ args: ARGS, choice: {}, deferKickoff: false });
+    });
+
+    expect(state.spawnAgent).toHaveBeenCalledWith(
+      SESSION_ID,
+      expect.objectContaining({ provider: 'codex', model: 'gpt-5.6', effort: 'high' }),
+    );
+    expect(state.setAgentConfig).toHaveBeenCalledWith(SESSION_ID, 'agent-1', {
+      providerOverride: 'codex',
+      modelOverride: 'gpt-5.6',
+      effort: 'high',
+    });
+  });
+
+  it('lets an explicit popover choice win over the role default', async () => {
+    withOverrides({
+      roleModels: {
+        resolver: { providerId: 'codex', model: 'gpt-5.6', effort: 'high' },
+      },
+    });
+    const { result } = renderHook(() => useResolverSpawner({ sessionId: SESSION_ID }));
+
+    await act(async () => {
+      await result.current.spawnResolver({
+        args: ARGS,
+        choice: { provider: 'anthropic', model: 'claude-opus-5', effort: 'medium' },
+        deferKickoff: false,
+      });
+    });
+
+    expect(state.spawnAgent).toHaveBeenCalledWith(
+      SESSION_ID,
+      expect.objectContaining({
+        provider: 'anthropic',
+        model: 'claude-opus-5',
+        effort: 'medium',
+      }),
+    );
+    expect(state.setAgentConfig).toHaveBeenCalledWith(SESSION_ID, 'agent-1', {
+      providerOverride: 'anthropic',
+      modelOverride: 'claude-opus-5',
+      effort: 'medium',
+    });
+  });
+
+  it('ignores a preference stored for another role', async () => {
+    withOverrides({
+      roleModels: {
+        custom: { providerId: 'codex', model: 'gpt-5.6', effort: 'high' },
+      },
+    });
+    const { result } = renderHook(() => useResolverSpawner({ sessionId: SESSION_ID }));
+
+    await act(async () => {
+      await result.current.spawnResolver({ args: ARGS, choice: {}, deferKickoff: false });
+    });
+
+    expect(state.spawnAgent).toHaveBeenCalledWith(
+      SESSION_ID,
+      expect.objectContaining({
+        provider: ROLE_DEFAULTS.resolver.provider,
+        model: ROLE_DEFAULTS.resolver.model,
+        effort: ROLE_DEFAULTS.resolver.effort,
+      }),
+    );
+  });
+
+  it('tracks every resolver it spawned', async () => {
+    const { result } = renderHook(() => useResolverSpawner({ sessionId: SESSION_ID }));
+
+    await act(async () => {
+      await result.current.spawnResolver({ args: ARGS, choice: {}, deferKickoff: true });
+    });
+
+    expect(state.spawnAgent).toHaveBeenCalledWith(
+      SESSION_ID,
+      expect.objectContaining({ deferKickoff: true, kindOverride: 'resolver' }),
+    );
+    expect(result.current.spawnedResolverIds).toEqual(['agent-1']);
+  });
+});

--- a/apps/desktop/src/features/session/hooks/useResolverSpawner/index.ts
+++ b/apps/desktop/src/features/session/hooks/useResolverSpawner/index.ts
@@ -1,7 +1,9 @@
 import { useState } from 'react';
 import type { AgentId, SessionId } from '@goodboy/types';
 import type { CommentAgentArgs, ResolveModelChoice } from '../../../chat/spawn-from-comment';
+import { useSessionRoleModels } from '../../../../shared/hooks/useSessionRoleModels';
 import { useAppStore } from '../../../../store';
+import { kindRouting } from '../../agent-kind';
 
 type SpawnParams = {
   readonly args: CommentAgentArgs;
@@ -22,14 +24,19 @@ type Result = {
 export const useResolverSpawner = ({ sessionId }: Params): Result => {
   const spawnAgent = useAppStore((state) => state.spawnAgent);
   const setAgentConfig = useAppStore((state) => state.setAgentConfig);
+  const roleModels = useSessionRoleModels({ sessionId });
   const [spawnedResolverIds, setSpawnedResolverIds] = useState<ReadonlyArray<AgentId>>([]);
 
   const spawnResolver = async ({ args, choice, deferKickoff }: SpawnParams): Promise<AgentId> => {
+    const roleDefault = kindRouting({ kind: 'resolver', roleModels });
+    const provider = choice.provider ?? roleDefault.provider;
+    const model = choice.model ?? roleDefault.model;
+    const effort = choice.effort ?? roleDefault.effort;
     const agentId = await spawnAgent(sessionId, {
       name: args.name,
-      model: args.model,
-      ...(args.provider !== undefined && { provider: args.provider }),
-      effort: args.effort,
+      model,
+      provider,
+      effort,
       initialPrompt: args.initialPrompt,
       kindOverride: args.kind,
       ...(args.sourceThreadId !== undefined && { sourceThreadId: args.sourceThreadId }),
@@ -40,9 +47,9 @@ export const useResolverSpawner = ({ sessionId }: Params): Result => {
       focus: 'none',
     });
     await setAgentConfig(sessionId, agentId, {
-      ...(choice.provider !== undefined && { providerOverride: choice.provider }),
-      ...(choice.model !== undefined && { modelOverride: choice.model }),
-      effort: args.effort,
+      providerOverride: provider,
+      modelOverride: model,
+      effort,
     });
     setSpawnedResolverIds((current) => [...current, agentId]);
     return agentId;

--- a/packages/core/src/providers/role-models.test.ts
+++ b/packages/core/src/providers/role-models.test.ts
@@ -90,6 +90,43 @@ describe('resolveRoleRouting', () => {
     expect(resolved.isOverride).toBe(false);
   });
 
+  it('resolves the resolver role to its compiled default with no stored preference', () => {
+    expect(resolveRoleRouting({ role: 'resolver', prefs: null })).toEqual({
+      provider: ROLE_DEFAULTS.resolver.provider,
+      model: ROLE_DEFAULTS.resolver.model,
+      effort: ROLE_DEFAULTS.resolver.effort,
+      isOverride: false,
+    });
+  });
+
+  it('gives the resolver role its own pin and fallback, not the custom one', () => {
+    const prefs: RoleModelPreferences = {
+      custom: { providerId: 'anthropic', model: 'claude-haiku-4-5', effort: 'low' },
+      resolver: {
+        providerId: 'anthropic',
+        model: 'claude-opus-5',
+        effort: 'high',
+        fallback: { providerId: 'codex', model: 'gpt-5.6' },
+      },
+    };
+    const resolved = resolveRoleRouting({ role: 'resolver', prefs });
+
+    expect(resolved.model).toBe('opus-5');
+    expect(resolved.effort).toBe('high');
+    expect(resolved.isOverride).toBe(true);
+    expect(resolved.fallback).toEqual({ provider: 'codex', model: 'gpt-5.6', effort: 'high' });
+  });
+
+  it('leaves the resolver on its compiled default when only the custom role is pinned', () => {
+    const prefs: RoleModelPreferences = {
+      custom: { providerId: 'anthropic', model: 'claude-opus-5', effort: 'high' },
+    };
+    const resolved = resolveRoleRouting({ role: 'resolver', prefs });
+
+    expect(resolved.model).toBe(ROLE_DEFAULTS.resolver.model);
+    expect(resolved.isOverride).toBe(false);
+  });
+
   it('leaves the fallback absent when the role has no stored preference', () => {
     expect(resolveRoleRouting({ role: 'planner', prefs: null }).fallback).toBeUndefined();
   });

--- a/packages/core/src/roles.test.ts
+++ b/packages/core/src/roles.test.ts
@@ -11,6 +11,7 @@ describe('ROLE_DEFAULTS', () => {
       'reviewer',
       'investigator',
       'tester',
+      'resolver',
       'custom',
     ];
     for (const role of expected) {
@@ -48,6 +49,13 @@ describe('ROLE_DEFAULTS', () => {
   it('routes balanced roles to sonnet', () => {
     expect(ROLE_DEFAULTS.implementer.model).toMatch(/sonnet/);
     expect(ROLE_DEFAULTS.reviewer.model).toMatch(/sonnet/);
+    expect(ROLE_DEFAULTS.resolver.model).toMatch(/sonnet/);
+  });
+
+  it('keeps the resolver on the same routing the resolve UI spawned before it had a role', () => {
+    expect(ROLE_DEFAULTS.resolver.provider).toBe(ROLE_DEFAULTS.custom.provider);
+    expect(ROLE_DEFAULTS.resolver.model).toBe(ROLE_DEFAULTS.custom.model);
+    expect(ROLE_DEFAULTS.resolver.effort).toBe(ROLE_DEFAULTS.custom.effort);
   });
 
   it('every default uses anthropic provider for now', () => {
@@ -63,6 +71,7 @@ describe('ROLE_DEFAULTS', () => {
     expect(ROLE_DEFAULTS.investigator.fanOut.mode).toBe('conditional');
     expect(ROLE_DEFAULTS.planner.fanOut.mode).toBe('never');
     expect(ROLE_DEFAULTS.implementer.fanOut.mode).toBe('never');
+    expect(ROLE_DEFAULTS.resolver.fanOut.mode).toBe('never');
     expect(ROLE_DEFAULTS.custom.fanOut.mode).toBe('never');
   });
 });

--- a/packages/core/src/roles.ts
+++ b/packages/core/src/roles.ts
@@ -13,11 +13,7 @@ export type RoleDefaults = {
 export type RoleFanOutMode = 'natural' | 'conditional' | 'never';
 
 export type RoleFanOutPartitionKey =
-  | 'codebase-area'
-  | 'diff-aspect'
-  | 'module-under-test'
-  | 'top-stack-file'
-  | null;
+  'codebase-area' | 'diff-aspect' | 'module-under-test' | 'top-stack-file' | null;
 
 export type RoleFanOutCapability = {
   readonly mode: RoleFanOutMode;
@@ -91,6 +87,17 @@ export const ROLE_DEFAULTS = {
       partitionKey: 'module-under-test',
       condition:
         'only when at least two disjoint modules can be tested without shared fixtures or helpers',
+    },
+  },
+  resolver: {
+    provider: 'anthropic',
+    model: 'sonnet-5',
+    effort: 'medium',
+    description: 'address a review comment with one local commit',
+    fanOut: {
+      mode: 'never',
+      partitionKey: null,
+      condition: null,
     },
   },
   custom: {

--- a/packages/db/src/queries/session-workflow.ts
+++ b/packages/db/src/queries/session-workflow.ts
@@ -90,6 +90,7 @@ const ROLE_MODEL_ROLES = [
   'reviewer',
   'investigator',
   'tester',
+  'resolver',
   'custom',
 ] satisfies ReadonlyArray<AgentRole>;
 

--- a/packages/types/src/workflow.ts
+++ b/packages/types/src/workflow.ts
@@ -15,7 +15,14 @@ import type { VerbosityLevel } from './settings';
 export type AgentEffort = ModelEffort;
 
 export type AgentRole =
-  'scout' | 'planner' | 'implementer' | 'reviewer' | 'investigator' | 'tester' | 'custom';
+  | 'scout'
+  | 'planner'
+  | 'implementer'
+  | 'reviewer'
+  | 'investigator'
+  | 'tester'
+  | 'resolver'
+  | 'custom';
 
 export type AgentStatus = 'pending' | 'running' | 'completed' | 'failed' | 'skipped';
 


### PR DESCRIPTION
## Summary
- the resolver had no role of its own: `resolver` was absent from `AgentRole`, `KIND_TO_ROLE` mapped it to `custom`, and the comment-spawn builders resolved routing with no prefs at all, so Provider Studio could not steer Resolve agents and every spawn fell to the generic default
- `resolver` becomes a first-class role: `ROLE_DEFAULTS` entry (identical to the old effective default, so nothing changes without an override), a Resolver row in the Provider Studio defaults panel (auto-derived from the role keys), and `useResolverSpawner` as the single routing funnel: the popover's explicit choice wins, otherwise the role default plus its fallback apply
- routing fields dropped from `CommentAgentArgs` (dead once the spawner owns routing); no migration: workspace role prefs are a keyless json blob, additive
- deliberate exclusions: the workflow step role picker and run role models stay without resolver (workflow runs never spawn resolvers, the kind is resolve-UI only)
- behavior note: a pinned Custom role no longer steers resolvers; pin the new Resolver row instead

## Tests
- role resolution (compiled default, own pin + fallback, custom pin does not leak), panel row render + persist under the resolver key, spawner default-vs-override, full core (1245) + desktop (6508) + db (333) green on the builder pass; 66 targeted + typechecks green here

🤖 Generated with [Claude Code](https://claude.com/claude-code)