### PR TITLE
feat(ui): move the worktree menu onto the project row

### DIFF
--- a/apps/desktop/src/features/session/components/SessionOverviewPane/EditorMenu.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/EditorMenu.tsx
@@ -15,13 +15,26 @@ const FULL_TRIGGER_BUTTON =
 const COMPACT_TRIGGER_BUTTON =
   'inline-flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground motion-safe:transition-colors hover:bg-muted/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]';
 
+type FolderTarget = {
+  readonly name: string;
+  readonly worktreePath: string;
+};
+
 type Props = {
   readonly sessionId: SessionId;
   readonly density?: Density;
+  readonly target?: FolderTarget | null;
+  readonly triggerClassName?: string;
 };
 
-export const EditorMenu = ({ sessionId, density = 'full' }: Props) => {
-  const worktreePath = useAppStore((s) => s.sessionWorktrees[sessionId]?.[0] ?? null);
+export const EditorMenu = ({
+  sessionId,
+  density = 'full',
+  target = null,
+  triggerClassName,
+}: Props) => {
+  const sessionWorktreePath = useAppStore((s) => s.sessionWorktrees[sessionId]?.[0] ?? null);
+  const worktreePath = target === null ? sessionWorktreePath : target.worktreePath;
   const detectedEditors = useAppStore((s) => s.detectedEditors);
   const loadDetectedEditors = useAppStore((s) => s.loadDetectedEditors);
   const { showToast } = useToast();
@@ -95,15 +108,21 @@ export const EditorMenu = ({ sessionId, density = 'full' }: Props) => {
     ];
   }, [detectedEditors, worktreePath]);
 
-  const triggerClassName = density === 'compact' ? COMPACT_TRIGGER_BUTTON : FULL_TRIGGER_BUTTON;
+  const densityTriggerClassName =
+    density === 'compact' ? COMPACT_TRIGGER_BUTTON : FULL_TRIGGER_BUTTON;
+  const label = target === null ? 'Open worktree' : `Open the folder of ${target.name}`;
+  const tooltip =
+    target === null
+      ? 'Open the worktree in an editor, or copy its path'
+      : `Open ${target.name} in an editor, or copy its path`;
 
   return (
     <OverflowMenu
       items={items}
-      label="Open worktree"
-      tooltip="Open the worktree in an editor, or copy its path"
+      label={label}
+      tooltip={tooltip}
       align="left"
-      triggerClassName={triggerClassName}
+      triggerClassName={triggerClassName ?? densityTriggerClassName}
       trigger={
         <>
           <FolderOpen size={13} aria-hidden />

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/HeaderBand.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/HeaderBand.test.tsx
@@ -12,6 +12,8 @@ const { store } = vi.hoisted(() => ({
     sessionGithub: {},
     sessionExternalTasks: {},
     setScriptsLensScope: vi.fn(),
+    sessionProjectMounts: {} as Record<string, ReadonlyArray<{ projectId: string }>>,
+    projects: [] as ReadonlyArray<{ id: string; kind: string }>,
   },
 }));
 
@@ -69,6 +71,8 @@ describe('HeaderBand', () => {
     store.pendingTitleFocusSessionId = null;
     store.clearPendingTitleFocus.mockClear();
     store.setScriptsLensScope.mockClear();
+    store.sessionProjectMounts = {};
+    store.projects = [];
   });
 
   it('puts Scripts first in the title actions and opens it without scope', () => {
@@ -92,6 +96,29 @@ describe('HeaderBand', () => {
     const projects = screen.getByRole('region', { name: 'Mounted projects' });
     const goal = screen.getByText('Goal');
     expect(projects.compareDocumentPosition(goal) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('keeps the folder action for a session with no mount', () => {
+    render(<HeaderBand session={session} onSelectLens={vi.fn()} goal={<div>Goal</div>} />);
+
+    expect(screen.getByRole('button', { name: 'Open worktree' })).toBeDefined();
+  });
+
+  it('keeps the folder action when every mount is a plain folder', () => {
+    store.sessionProjectMounts = { 'session-1': [{ projectId: 'docs' }] };
+    store.projects = [{ id: 'docs', kind: 'folder' }];
+    render(<HeaderBand session={session} onSelectLens={vi.fn()} goal={<div>Goal</div>} />);
+
+    expect(screen.getByRole('button', { name: 'Open worktree' })).toBeDefined();
+  });
+
+  it('drops the folder action once a repo is mounted, since the row owns it', () => {
+    store.sessionProjectMounts = { 'session-1': [{ projectId: 'api' }] };
+    store.projects = [{ id: 'api', kind: 'repo' }];
+    render(<HeaderBand session={session} onSelectLens={vi.fn()} goal={<div>Goal</div>} />);
+
+    expect(screen.queryByRole('button', { name: 'Open worktree' })).toBeNull();
+    expect(screen.getByRole('button', { name: 'Mount a project' })).toBeDefined();
   });
 
   it('renders the session cost at the right edge of the context row', () => {

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/HeaderBand.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/HeaderBand.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
 import type { ReactNode } from 'react';
 import { Input, Tooltip } from '@goodboy/ui';
-import type { Session, SessionId } from '@goodboy/types';
+import type { Session, SessionId, SessionProjectMount } from '@goodboy/types';
 import { EMPTY_ARRAY, useAppStore } from '../../../../store';
 import type { LensKind } from '../../../../store';
 import { useSessionTitleRename } from '../../hooks/useSessionTitleRename';
@@ -34,6 +34,13 @@ export const HeaderBand = ({ session, onSelectLens, goal }: Props) => {
     const linkedIssues = s.sessionGithub[sessionId]?.linkedIssues ?? EMPTY_ARRAY;
     const externalTasks = s.sessionExternalTasks[sessionId] ?? EMPTY_ARRAY;
     return linkedIssues.length > 0 || externalTasks.length > 0;
+  });
+  const hasRepoMount = useAppStore((s) => {
+    const mounts =
+      s.sessionProjectMounts[sessionId] ?? (EMPTY_ARRAY as ReadonlyArray<SessionProjectMount>);
+    return mounts.some((mount) =>
+      s.projects.some((project) => project.id === mount.projectId && project.kind === 'repo'),
+    );
   });
   const titleFieldRef = useRef<HTMLDivElement | null>(null);
   const selectOnEditRef = useRef(false);
@@ -113,7 +120,7 @@ export const HeaderBand = ({ session, onSelectLens, goal }: Props) => {
               <CONCEPT_ICONS.scripts size={13} aria-hidden />
             </button>
           </Tooltip>
-          <EditorMenu sessionId={sessionId} density="compact" />
+          {hasRepoMount ? null : <EditorMenu sessionId={sessionId} density="compact" />}
           <MountProjectAction sessionId={sessionId} workspaceId={session.workspaceId} />
           <SessionDestructiveActions session={session} />
         </div>

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectMountRow.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectMountRow.test.tsx
@@ -2,6 +2,8 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import type { OverflowMenuItem } from '@goodboy/ui';
 import type { Project, PullRequestState, SessionId, SessionProjectMount } from '@goodboy/types';
 
 const { store, remoteKind } = vi.hoisted(() => ({
@@ -12,6 +14,9 @@ const { store, remoteKind } = vi.hoisted(() => ({
     openMountDiff: vi.fn(async () => undefined),
     projects: [] as ReadonlyArray<{ id: string; baseBranch?: string | null }>,
     emitNotification: vi.fn(),
+    sessionWorktrees: {} as Record<string, ReadonlyArray<string>>,
+    detectedEditors: [] as ReadonlyArray<{ binary: string; label: string }>,
+    loadDetectedEditors: vi.fn(async () => undefined),
     terminalTabs: {} as Record<
       string,
       ReadonlyArray<{ id: string; projectId?: string; status: string }>
@@ -36,8 +41,50 @@ vi.mock('./ProjectDetachMenu', () => ({
 vi.mock('../../../../worktree/useRemoteHostKind', () => ({
   useRemoteHostKind: () => remoteKind.current,
 }));
+vi.mock('../../../../../app/components/Toast', () => ({
+  useToast: () => ({ showToast: vi.fn() }),
+}));
+vi.mock('../../../../../shared/lib/editor', () => ({
+  openInEditor: vi.fn(async () => undefined),
+}));
+vi.mock('@goodboy/ui', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@goodboy/ui')>();
+  const { Tooltip } = actual;
+  return {
+    ...actual,
+    OverflowMenu: ({
+      items,
+      label,
+      tooltip,
+      triggerClassName,
+      trigger,
+    }: {
+      readonly items: ReadonlyArray<OverflowMenuItem>;
+      readonly label: string;
+      readonly tooltip: string;
+      readonly triggerClassName: string;
+      readonly trigger: ReactNode;
+    }) => (
+      <span>
+        <Tooltip content={tooltip}>
+          <button type="button" aria-label={label} className={triggerClassName}>
+            {trigger}
+          </button>
+        </Tooltip>
+        {items.map((item) =>
+          item.kind === 'item' ? (
+            <button key={item.key} type="button" onClick={item.onClick}>
+              {item.label}
+            </button>
+          ) : null,
+        )}
+      </span>
+    ),
+  };
+});
 
 import { tooltipTextOf } from '../../../../../__tests__/helpers/tooltip';
+import { openInEditor } from '../../../../../shared/lib/editor';
 import { ProjectMountRow } from './ProjectMountRow';
 
 const sessionId = 'session-1' as SessionId;
@@ -88,6 +135,9 @@ beforeEach(() => {
       { id: 'script-web', projectId: 'web' },
     ],
   };
+  store.sessionWorktrees = { [sessionId]: ['/session-root'] };
+  store.detectedEditors = [{ binary: 'code', label: 'VS Code' }];
+  vi.mocked(openInEditor).mockClear();
 });
 
 afterEach(cleanup);
@@ -134,6 +184,38 @@ describe('ProjectMountRow create pr action', () => {
     remoteKind.current = null;
     renderRow({ diffStat: { additions: 1, deletions: 0 } });
     expect(screen.queryByRole('button', { name: 'Create a PR for API' })).toBeNull();
+  });
+});
+
+describe('ProjectMountRow folder action', () => {
+  it('names the folder action after the project and reads it out in the tooltip', () => {
+    renderRow({});
+
+    const folder = screen.getByRole('button', { name: 'Open the folder of API' });
+    expect(tooltipTextOf({ element: folder })).toBe('Open API in an editor, or copy its path');
+  });
+
+  it('opens the worktree of the mount, not the first worktree of the session', () => {
+    renderRow({});
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open the folder of API' }));
+    fireEvent.click(screen.getByRole('button', { name: 'VS Code' }));
+
+    expect(openInEditor).toHaveBeenCalledWith('/api', 'code');
+  });
+
+  it('leads the trio folder, terminal, scripts', () => {
+    renderRow({});
+
+    const folder = screen.getByRole('button', { name: 'Open the folder of API' });
+    const terminal = screen.getByRole('button', { name: 'Open terminal for API' });
+    const scripts = screen.getByRole('button', { name: 'Open scripts for API' });
+    expect(
+      folder.compareDocumentPosition(terminal) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      terminal.compareDocumentPosition(scripts) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 });
 

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectMountRow.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectMountRow.tsx
@@ -13,6 +13,7 @@ import { CONCEPT_ICONS } from '../../../../../shared/components/conceptIcons';
 import { PullRequestChip } from '../../../../github/components/PullRequestChip';
 import { useRemoteHostKind } from '../../../../worktree/useRemoteHostKind';
 import { DiffStat } from '../../DiffStat';
+import { EditorMenu } from '../EditorMenu';
 import { ProjectBranchChip } from './ProjectBranchChip';
 import { ProjectSyncControl } from './ProjectSyncControl';
 import { ProjectDetachMenu } from './ProjectDetachMenu';
@@ -150,6 +151,12 @@ export const ProjectMountRow = ({
           <span className="font-mono">#{pullRequest.number}</span>
         </button>
       ) : null}
+      <EditorMenu
+        sessionId={sessionId}
+        density="compact"
+        target={{ name: projectName, worktreePath: mount.worktreePath }}
+        triggerClassName={ICON_BUTTON}
+      />
       <Tooltip
         content={`Open terminal in ${projectName}${runningSuffix({ count: activity.liveTerminals })}`}
       >


### PR DESCRIPTION
## Summary
- the header folder glyph was the EditorMenu pointed at the session's FIRST worktree: with multiple mounted projects it silently opened an arbitrary one
- the menu now lives on each project mount row (folder, then terminal, then scripts), targeting that mount's worktree with the same editor picker and copy-path actions; the header keeps it only for sessions with no repo mount, where the old behavior stays byte-identical
- copy stays honest: `Open <project> in an editor, or copy its path` (no Finder claim: no OS reveal exists in the codebase, and inventing a tauri command was out of scope)

## Tests
- row: naming, click routes the mount worktree and not the session root, icon order; header: shown mountless or folders-only, hidden once a repo mounts
- 100 tests green across the SessionOverviewPane sweep, typecheck green

🤖 Generated with [Claude Code](https://claude.com/claude-code)