### PR TITLE
feat(ui): turn base branch inputs into a lazy branch select

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -232,6 +232,7 @@ pub fn run() {
             worktree::worktree_status,
             worktree::checkout_fast_forward,
             worktree::worktree_list_local_branches,
+            worktree::worktree_list_branch_names,
             worktree::worktree_change_branch,
             providers::get_provider_status,
             providers::refresh_provider_status,

--- a/apps/desktop/src-tauri/src/worktree.rs
+++ b/apps/desktop/src-tauri/src/worktree.rs
@@ -308,6 +308,48 @@ pub async fn worktree_list_local_branches(
         .map_err(|e| WorktreeError::Io(std::io::Error::other(e.to_string())))?
 }
 
+#[tauri::command]
+pub async fn worktree_list_branch_names(
+    repo_path: String,
+) -> Result<Vec<String>, WorktreeError> {
+    tauri::async_runtime::spawn_blocking(move || list_branch_names_blocking(repo_path))
+        .await
+        .map_err(|e| WorktreeError::Io(std::io::Error::other(e.to_string())))?
+}
+
+fn list_branch_names_blocking(repo_path: String) -> Result<Vec<String>, WorktreeError> {
+    let p = Path::new(&repo_path);
+    if !p.exists() {
+        return Err(WorktreeError::RepoNotFound(repo_path));
+    }
+    let raw = git(
+        p,
+        &[
+            "for-each-ref",
+            "--format=%(refname:short)",
+            "refs/heads",
+            "refs/remotes",
+        ],
+    )?;
+    Ok(normalize_branch_names(&raw))
+}
+
+fn normalize_branch_names(raw: &str) -> Vec<String> {
+    let mut seen = std::collections::HashSet::new();
+    let mut names = Vec::new();
+    for line in raw.lines() {
+        let name = line.trim();
+        if name.is_empty() || name == "origin" || name.ends_with("/HEAD") {
+            continue;
+        }
+        let normalized = name.strip_prefix("origin/").unwrap_or(name);
+        if seen.insert(normalized.to_string()) {
+            names.push(normalized.to_string());
+        }
+    }
+    names
+}
+
 fn list_local_branches_blocking(repo_path: String) -> Result<Vec<BranchInfo>, WorktreeError> {
     let p = Path::new(&repo_path);
     if !p.exists() {
@@ -1793,6 +1835,16 @@ mod rewrite_tests {
             .lines()
             .map(|l| l.trim().to_string())
             .collect()
+    }
+
+    #[test]
+    fn branch_names_strip_origin_and_preserve_the_first_occurrence() {
+        let raw = "main\nfeature/search\norigin\norigin/HEAD\norigin/main\norigin/release\nupstream/HEAD\nupstream/release\n";
+
+        assert_eq!(
+            super::normalize_branch_names(raw),
+            vec!["main", "feature/search", "release", "upstream/release"]
+        );
     }
 
     fn args(root: &Path, sha: &str, message: &str) -> RewriteArgs {

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectSyncControl.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectSyncControl.test.tsx
@@ -9,7 +9,7 @@ const { store } = vi.hoisted(() => ({
     setSessionActiveProject: vi.fn(async () => undefined),
     emitNotification: vi.fn(),
     updateProjectBaseBranch: vi.fn(async () => undefined),
-    projects: [] as ReadonlyArray<{ id: string; baseBranch?: string | null }>,
+    projects: [] as ReadonlyArray<{ id: string; rootPath: string; baseBranch?: string | null }>,
   },
 }));
 
@@ -21,6 +21,9 @@ vi.mock('../../../hooks/useRebaseAgent', () => ({
 }));
 vi.mock('../../../hooks/usePushBranch', () => ({
   usePushBranch: () => ({ isBusy: false, error: null, run: vi.fn() }),
+}));
+vi.mock('../../../../worktree/worktree', () => ({
+  listBranchNames: vi.fn(async () => ['main', 'develop', 'release']),
 }));
 
 import { ProjectSyncControl } from './ProjectSyncControl';
@@ -55,7 +58,7 @@ const renderControl = ({ status }: { readonly status: WorktreeStatus | null }) =
 describe('ProjectSyncControl', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    store.projects = [{ id: 'project-1', baseBranch: 'develop' }];
+    store.projects = [{ id: 'project-1', rootPath: '/repo', baseBranch: 'develop' }];
   });
   afterEach(cleanup);
 
@@ -80,8 +83,8 @@ describe('ProjectSyncControl', () => {
   it('commits a trimmed base branch on Enter', async () => {
     renderControl({ status: null });
     fireEvent.click(screen.getByRole('button', { name: 'Branch sync actions' }));
-    fireEvent.click(screen.getByRole('button', { name: /Compared with develop/ }));
-    const input = screen.getByRole('textbox', { name: 'Base branch' });
+    fireEvent.click(screen.getByRole('button', { name: 'Base branch: develop' }));
+    const input = screen.getByRole('combobox', { name: 'Base branch' });
     fireEvent.change(input, { target: { value: '  release  ' } });
     fireEvent.keyDown(input, { key: 'Enter' });
 
@@ -96,8 +99,8 @@ describe('ProjectSyncControl', () => {
   it('clears an empty base branch to null', async () => {
     renderControl({ status: null });
     fireEvent.click(screen.getByRole('button', { name: 'Branch sync actions' }));
-    fireEvent.click(screen.getByRole('button', { name: /Compared with develop/ }));
-    const input = screen.getByRole('textbox', { name: 'Base branch' });
+    fireEvent.click(screen.getByRole('button', { name: 'Base branch: develop' }));
+    const input = screen.getByRole('combobox', { name: 'Base branch' });
     fireEvent.change(input, { target: { value: '   ' } });
     fireEvent.keyDown(input, { key: 'Enter' });
 
@@ -112,12 +115,13 @@ describe('ProjectSyncControl', () => {
   it('reverts the base branch edit on Escape', () => {
     renderControl({ status: null });
     fireEvent.click(screen.getByRole('button', { name: 'Branch sync actions' }));
-    fireEvent.click(screen.getByRole('button', { name: /Compared with develop/ }));
-    const input = screen.getByRole('textbox', { name: 'Base branch' });
+    fireEvent.click(screen.getByRole('button', { name: 'Base branch: develop' }));
+    const input = screen.getByRole('combobox', { name: 'Base branch' });
     fireEvent.change(input, { target: { value: 'release' } });
     fireEvent.keyDown(input, { key: 'Escape' });
 
     expect(store.updateProjectBaseBranch).not.toHaveBeenCalled();
-    expect(screen.getByRole('button', { name: /Compared with develop/ })).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: 'Branch sync actions' }));
+    expect(screen.getByRole('button', { name: 'Base branch: develop' })).toBeDefined();
   });
 });

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectSyncControl.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectSyncControl.tsx
@@ -1,9 +1,10 @@
 import { useState } from 'react';
-import { ArrowDown, ArrowUp, GitBranch, Pencil, RefreshCw, Upload } from 'lucide-react';
-import { AnchoredPopover, Input, cn, formatError, useDropdown } from '@goodboy/ui';
+import { ArrowDown, ArrowUp, GitBranch, RefreshCw, Upload } from 'lucide-react';
+import { AnchoredPopover, cn, formatError, useDropdown } from '@goodboy/ui';
 import type { ProjectId, SessionId, WorktreeStatus } from '@goodboy/types';
 import { useAppStore } from '../../../../../store';
 import { distanceAhead } from '../../../../../shared/lib/gitStatus';
+import { BaseBranchSelect } from '../../../../worktree/BaseBranchSelect';
 import { useRebaseAgent } from '../../../hooks/useRebaseAgent';
 import { usePushBranch } from '../../../hooks/usePushBranch';
 
@@ -13,6 +14,10 @@ type Props = {
   readonly status: WorktreeStatus | null;
 };
 
+type CommitBaseBranchParams = {
+  readonly candidate: string | null;
+};
+
 export const ProjectSyncControl = ({ sessionId, projectId, status }: Props) => {
   const dropdown = useDropdown({ width: 'w-64', expectedHeight: 160 });
   const setSessionActiveProject = useAppStore((state) => state.setSessionActiveProject);
@@ -20,9 +25,10 @@ export const ProjectSyncControl = ({ sessionId, projectId, status }: Props) => {
   const configuredBaseBranch = useAppStore(
     (state) => state.projects.find((project) => project.id === projectId)?.baseBranch ?? null,
   );
+  const repoPath = useAppStore(
+    (state) => state.projects.find((project) => project.id === projectId)?.rootPath ?? '',
+  );
   const updateProjectBaseBranch = useAppStore((state) => state.updateProjectBaseBranch);
-  const [isEditingBase, setIsEditingBase] = useState(false);
-  const [baseDraft, setBaseDraft] = useState('');
   const [baseError, setBaseError] = useState<string | null>(null);
   const baseBranch = configuredBaseBranch ?? 'main';
   const notify = ({ title, message }: { readonly title: string; readonly message: string }) => {
@@ -46,28 +52,16 @@ export const ProjectSyncControl = ({ sessionId, projectId, status }: Props) => {
     await setSessionActiveProject({ sessionId, projectId });
     await action();
   };
-  const startBaseEdit = () => {
-    setBaseDraft(configuredBaseBranch ?? '');
-    setBaseError(null);
-    setIsEditingBase(true);
-  };
-  const cancelBaseEdit = () => {
-    setBaseDraft(configuredBaseBranch ?? '');
-    setBaseError(null);
-    setIsEditingBase(false);
-  };
-  const commitBaseEdit = async () => {
-    const value = baseDraft.trim();
+  const commitBaseBranch = async ({ candidate }: CommitBaseBranchParams) => {
+    const value = candidate?.trim() ?? '';
     const next = value === '' ? null : value;
     if (next === (configuredBaseBranch ?? null)) {
       setBaseError(null);
-      setIsEditingBase(false);
       return;
     }
     try {
       await updateProjectBaseBranch({ projectId, baseBranch: next });
       setBaseError(null);
-      setIsEditingBase(false);
     } catch (error) {
       setBaseError(formatError(error));
     }
@@ -101,45 +95,14 @@ export const ProjectSyncControl = ({ sessionId, projectId, status }: Props) => {
     >
       <div className="flex flex-col py-1">
         <div className="flex flex-col gap-1 border-b border-border-soft px-3 py-2 text-xs tabular-nums text-muted-foreground">
-          <div className="group flex items-center gap-3">
-            {isEditingBase ? (
-              <Input
-                autoFocus
-                aria-label="Base branch"
-                placeholder="main"
-                value={baseDraft}
-                onChange={(event) => setBaseDraft(event.target.value)}
-                onBlur={() => void commitBaseEdit()}
-                onKeyDown={(event) => {
-                  if (event.key === 'Escape') {
-                    event.preventDefault();
-                    event.stopPropagation();
-                    cancelBaseEdit();
-                    return;
-                  }
-                  if (event.key !== 'Enter') {
-                    return;
-                  }
-                  event.preventDefault();
-                  event.currentTarget.blur();
-                }}
-                className="h-7 font-mono text-xs"
-              />
-            ) : (
-              <button
-                type="button"
-                onClick={startBaseEdit}
-                className="flex items-center gap-1 font-medium text-foreground"
-              >
-                <span>Compared with</span>
-                <span className="rounded px-1 font-mono hover:bg-muted/60">{baseBranch}</span>
-                <Pencil
-                  size={10}
-                  aria-hidden
-                  className="opacity-0 transition-opacity group-hover:opacity-100"
-                />
-              </button>
-            )}
+          <div className="flex items-center gap-3">
+            <span className="font-medium text-foreground">Compared with</span>
+            <BaseBranchSelect
+              repoPath={repoPath}
+              value={configuredBaseBranch}
+              disabled={repoPath === ''}
+              onCommit={(candidate) => commitBaseBranch({ candidate })}
+            />
             <span className="ml-auto flex items-center gap-1">
               <ArrowDown size={11} aria-hidden />
               {distance?.behind ?? '--'}

--- a/apps/desktop/src/features/settings/components/SettingsStudio/ProjectBaseBranchInput.tsx
+++ b/apps/desktop/src/features/settings/components/SettingsStudio/ProjectBaseBranchInput.tsx
@@ -2,26 +2,29 @@ import { useState } from 'react';
 import type { Project } from '@goodboy/types';
 import { formatError } from '@goodboy/ui';
 import { useAppStore } from '../../../../store';
+import { BaseBranchSelect } from '../../../worktree/BaseBranchSelect';
 
 type Props = {
   readonly project: Project;
 };
 
+type CommitParams = {
+  readonly candidate: string | null;
+};
+
 export const ProjectBaseBranchInput = ({ project }: Props) => {
-  const [value, setValue] = useState(project.baseBranch ?? '');
   const [error, setError] = useState<string | null>(null);
   const updateProjectBaseBranch = useAppStore((state) => state.updateProjectBaseBranch);
 
-  const commit = async () => {
-    const baseBranch = value.trim() || null;
-    if (baseBranch === project.baseBranch) {
-      setValue(project.baseBranch ?? '');
+  const commit = async ({ candidate }: CommitParams) => {
+    const trimmed = candidate?.trim() ?? '';
+    const baseBranch = trimmed === '' ? null : trimmed;
+    if (baseBranch === (project.baseBranch ?? null)) {
       return;
     }
     setError(null);
     try {
       await updateProjectBaseBranch({ projectId: project.id, baseBranch });
-      setValue(baseBranch ?? '');
     } catch (failure) {
       setError(formatError(failure));
     }
@@ -29,24 +32,14 @@ export const ProjectBaseBranchInput = ({ project }: Props) => {
 
   return (
     <span className="flex min-w-36 flex-col gap-1">
-      <label className="flex items-center gap-2 text-2xs text-muted-foreground">
+      <span className="flex items-center gap-2 text-2xs text-muted-foreground">
         <span className="shrink-0">Base branch</span>
-        <input
-          type="text"
-          value={value}
-          placeholder="main"
-          aria-label={`${project.name} base branch`}
-          onChange={(event) => setValue(event.target.value)}
-          onBlur={() => void commit()}
-          onKeyDown={(event) => {
-            if (event.key === 'Enter') {
-              event.preventDefault();
-              event.currentTarget.blur();
-            }
-          }}
-          className="h-7 min-w-0 flex-1 rounded-md border border-border bg-background px-2 font-mono text-xs text-foreground placeholder:text-muted-foreground/40 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+        <BaseBranchSelect
+          repoPath={project.rootPath}
+          value={project.baseBranch ?? null}
+          onCommit={(candidate) => commit({ candidate })}
         />
-      </label>
+      </span>
       {error != null ? (
         <span role="alert" className="text-2xs text-danger">
           {error}

--- a/apps/desktop/src/features/workspace/components/ProjectGitPill/ProjectGitDetail.tsx
+++ b/apps/desktop/src/features/workspace/components/ProjectGitPill/ProjectGitDetail.tsx
@@ -12,6 +12,7 @@ import { Button, formatError } from '@goodboy/ui';
 import type { GitUnknownReason, Project, WorkspaceGitStatus } from '@goodboy/types';
 import { useAppStore } from '../../../../store';
 import { openInEditor } from '../../../../shared/lib/editor';
+import { BaseBranchSelect } from '../../../worktree/BaseBranchSelect';
 import {
   changedCount,
   distanceAhead,
@@ -44,6 +45,10 @@ type StatusParams = {
 
 type CapitalizeParams = {
   readonly value: string;
+};
+
+type CommitBaseBranchParams = {
+  readonly candidate: string | null;
 };
 
 const isReadFailureReason = ({ reason }: ReasonParams): boolean => {
@@ -137,7 +142,6 @@ const capitalize = ({ value }: CapitalizeParams): string =>
 export const ProjectGitDetail = ({ project, status }: Props) => {
   const [openError, setOpenError] = useState<string | null>(null);
   const [pullError, setPullError] = useState<string | null>(null);
-  const [baseBranch, setBaseBranch] = useState(project.baseBranch ?? '');
   const [baseBranchError, setBaseBranchError] = useState<string | null>(null);
   const pulling = useAppStore((state) => state.projectCheckoutPulling[project.id] === true);
   const fastForwardProjectCheckout = useAppStore((state) => state.fastForwardProjectCheckout);
@@ -171,17 +175,15 @@ export const ProjectGitDetail = ({ project, status }: Props) => {
       setPullError(formatError(error));
     }
   };
-  const commitBaseBranch = async () => {
-    const trimmedBaseBranch = baseBranch.trim();
+  const commitBaseBranch = async ({ candidate }: CommitBaseBranchParams) => {
+    const trimmedBaseBranch = candidate?.trim() ?? '';
     const nextBaseBranch = trimmedBaseBranch === '' ? null : trimmedBaseBranch;
-    if (nextBaseBranch === project.baseBranch) {
-      setBaseBranch(project.baseBranch ?? '');
+    if (nextBaseBranch === (project.baseBranch ?? null)) {
       return;
     }
     setBaseBranchError(null);
     try {
       await updateProjectBaseBranch({ projectId: project.id, baseBranch: nextBaseBranch });
-      setBaseBranch(nextBaseBranch ?? '');
     } catch (error) {
       setBaseBranchError(formatError(error));
     }
@@ -232,24 +234,14 @@ export const ProjectGitDetail = ({ project, status }: Props) => {
             ))}
           </div>
           <div className="flex flex-col gap-1 border-t border-border-soft pt-2">
-            <label className="flex items-center gap-2 text-2xs text-muted-foreground">
+            <span className="flex items-center gap-2 text-2xs text-muted-foreground">
               <span className="shrink-0">Base branch</span>
-              <input
-                type="text"
-                value={baseBranch}
-                placeholder="main"
-                aria-label={`${project.name} base branch`}
-                onChange={(event) => setBaseBranch(event.target.value)}
-                onBlur={() => void commitBaseBranch()}
-                onKeyDown={(event) => {
-                  if (event.key === 'Enter') {
-                    event.preventDefault();
-                    event.currentTarget.blur();
-                  }
-                }}
-                className="h-7 min-w-0 flex-1 rounded-md border border-border bg-background px-2 font-mono text-xs text-foreground placeholder:text-muted-foreground/40 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+              <BaseBranchSelect
+                repoPath={project.rootPath}
+                value={project.baseBranch ?? null}
+                onCommit={(candidate) => commitBaseBranch({ candidate })}
               />
-            </label>
+            </span>
             {baseBranchError != null ? (
               <span role="alert" className="text-2xs text-danger">
                 {baseBranchError}

--- a/apps/desktop/src/features/worktree/BaseBranchSelect.test.tsx
+++ b/apps/desktop/src/features/worktree/BaseBranchSelect.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+const { listBranchNames } = vi.hoisted(() => ({ listBranchNames: vi.fn() }));
+
+vi.mock('./worktree', () => ({ listBranchNames }));
+
+import { BaseBranchSelect } from './BaseBranchSelect';
+
+describe('BaseBranchSelect', () => {
+  beforeEach(() => {
+    listBranchNames.mockReset();
+    listBranchNames.mockResolvedValue(['main', 'develop', 'release']);
+  });
+  afterEach(cleanup);
+
+  it('fetches branches only after the popover opens', async () => {
+    render(<BaseBranchSelect repoPath="/repo" value={null} onCommit={vi.fn()} />);
+
+    expect(listBranchNames).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: 'Base branch: main' }));
+
+    await waitFor(() => expect(listBranchNames).toHaveBeenCalledWith({ repoPath: '/repo' }));
+  });
+
+  it('filters the fetched branch list', async () => {
+    render(<BaseBranchSelect repoPath="/repo" value={null} onCommit={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Base branch: main' }));
+    const input = screen.getByRole('combobox', { name: 'Base branch' });
+    await screen.findByRole('button', { name: 'develop' });
+
+    fireEvent.change(input, { target: { value: 'rel' } });
+
+    expect(screen.getByRole('button', { name: 'release' })).toBeDefined();
+    expect(screen.queryByRole('button', { name: 'develop' })).toBeNull();
+  });
+
+  it('commits an unlisted trimmed branch on Enter', async () => {
+    const onCommit = vi.fn();
+    render(<BaseBranchSelect repoPath="/repo" value={null} onCommit={onCommit} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Base branch: main' }));
+    const input = screen.getByRole('combobox', { name: 'Base branch' });
+
+    fireEvent.change(input, { target: { value: '  topic/new  ' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onCommit).toHaveBeenCalledWith('topic/new');
+  });
+
+  it('clears an explicit branch to null', () => {
+    const onCommit = vi.fn();
+    render(<BaseBranchSelect repoPath="/repo" value="develop" onCommit={onCommit} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Base branch: develop' }));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Use default' }));
+
+    expect(onCommit).toHaveBeenCalledWith(null);
+  });
+});

--- a/apps/desktop/src/features/worktree/BaseBranchSelect.tsx
+++ b/apps/desktop/src/features/worktree/BaseBranchSelect.tsx
@@ -1,0 +1,57 @@
+import { AnchoredPopover, cn, useDropdown } from '@goodboy/ui';
+import { ChevronDown } from 'lucide-react';
+import { BaseBranchSelectContent } from './BaseBranchSelectContent';
+
+type Props = {
+  readonly repoPath: string;
+  readonly value: string | null;
+  readonly placeholder?: string;
+  readonly disabled?: boolean;
+  readonly onCommit: (next: string | null) => void | Promise<void>;
+};
+
+export const BaseBranchSelect = ({
+  repoPath,
+  value,
+  placeholder = 'main',
+  disabled = false,
+  onCommit,
+}: Props) => {
+  const dropdown = useDropdown({ disabled, width: 'w-64', expectedHeight: 248 });
+  const displayValue = value ?? placeholder;
+
+  return (
+    <AnchoredPopover
+      dropdown={dropdown}
+      className="border-border-soft bg-subtle shadow-lg"
+      trigger={
+        <button
+          type="button"
+          disabled={disabled}
+          aria-label={`Base branch: ${displayValue}`}
+          aria-haspopup="listbox"
+          aria-expanded={dropdown.open}
+          onClick={dropdown.toggle}
+          className={cn(
+            'flex h-7 min-w-0 items-center gap-1 rounded-md border border-border-soft bg-background/70 px-2 font-mono text-xs text-foreground hover:border-border-strong hover:bg-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] disabled:cursor-not-allowed disabled:opacity-50',
+            value == null && 'text-muted-foreground',
+          )}
+        >
+          <span className="min-w-0 flex-1 truncate text-left">{displayValue}</span>
+          <ChevronDown
+            size={11}
+            aria-hidden
+            className={cn('shrink-0 transition-transform', dropdown.open && 'rotate-180')}
+          />
+        </button>
+      }
+    >
+      <BaseBranchSelectContent
+        repoPath={repoPath}
+        value={value}
+        onCommit={onCommit}
+        onClose={dropdown.close}
+      />
+    </AnchoredPopover>
+  );
+};

--- a/apps/desktop/src/features/worktree/BaseBranchSelectContent.tsx
+++ b/apps/desktop/src/features/worktree/BaseBranchSelectContent.tsx
@@ -1,0 +1,144 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { cn, ScrollFade } from '@goodboy/ui';
+import { listBranchNames } from './worktree';
+
+type Props = {
+  readonly repoPath: string;
+  readonly value: string | null;
+  readonly onCommit: (next: string | null) => void | Promise<void>;
+  readonly onClose: () => void;
+};
+
+type CommitParams = {
+  readonly candidate: string;
+};
+
+export const BaseBranchSelectContent = ({ repoPath, value, onCommit, onClose }: Props) => {
+  const [query, setQuery] = useState(value ?? '');
+  const [branches, setBranches] = useState<ReadonlyArray<string>>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [hasError, setHasError] = useState(false);
+  const [highlightIndex, setHighlightIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+    let isCancelled = false;
+    listBranchNames({ repoPath })
+      .then((nextBranches) => {
+        if (!isCancelled) {
+          setBranches(nextBranches);
+        }
+      })
+      .catch(() => {
+        if (!isCancelled) {
+          setHasError(true);
+        }
+      })
+      .finally(() => {
+        if (!isCancelled) {
+          setIsLoading(false);
+        }
+      });
+    return () => {
+      isCancelled = true;
+    };
+  }, [repoPath]);
+
+  const filteredBranches = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+    if (normalizedQuery === '') {
+      return branches;
+    }
+    return branches.filter((branch) => branch.toLowerCase().includes(normalizedQuery));
+  }, [branches, query]);
+
+  useEffect(() => {
+    setHighlightIndex(0);
+  }, [query]);
+
+  const commit = ({ candidate }: CommitParams) => {
+    const trimmed = candidate.trim();
+    void onCommit(trimmed === '' ? null : trimmed);
+    onClose();
+  };
+
+  return (
+    <div className="flex w-64 flex-col gap-1.5 p-2">
+      <input
+        ref={inputRef}
+        type="text"
+        role="combobox"
+        aria-label="Base branch"
+        aria-expanded="true"
+        aria-controls="base-branch-options"
+        aria-autocomplete="list"
+        autoComplete="off"
+        value={query}
+        placeholder="Search or enter a branch"
+        onChange={(event) => setQuery(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key === 'ArrowDown') {
+            event.preventDefault();
+            setHighlightIndex((current) =>
+              Math.min(current + 1, Math.max(filteredBranches.length - 1, 0)),
+            );
+            return;
+          }
+          if (event.key === 'ArrowUp') {
+            event.preventDefault();
+            setHighlightIndex((current) => Math.max(current - 1, 0));
+            return;
+          }
+          if (event.key !== 'Enter') {
+            return;
+          }
+          event.preventDefault();
+          commit({ candidate: query });
+        }}
+        className="h-8 rounded-md border border-border bg-background px-2 font-mono text-xs text-foreground outline-none placeholder:text-muted-foreground/50 focus:border-primary focus:ring-1 focus:ring-primary"
+      />
+      {isLoading ? (
+        <span className="px-1 text-2xs text-muted-foreground">Loading branches</span>
+      ) : null}
+      {hasError ? (
+        <span className="px-1 text-2xs text-muted-foreground">Could not load branches</span>
+      ) : null}
+      {!isLoading && filteredBranches.length === 0 ? (
+        <span className="px-1 text-2xs text-muted-foreground">No matching branches</span>
+      ) : null}
+      {filteredBranches.length > 0 ? (
+        <ScrollFade className="max-h-44" viewportClassName="py-0.5" fadeFrom="subtle">
+          <ul id="base-branch-options" role="listbox">
+            {filteredBranches.map((branch, index) => (
+              <li key={branch} role="option" aria-selected={index === highlightIndex}>
+                <button
+                  type="button"
+                  onMouseEnter={() => setHighlightIndex(index)}
+                  onClick={() => commit({ candidate: branch })}
+                  className={cn(
+                    'flex w-full rounded px-2 py-1.5 text-left font-mono text-xs',
+                    index === highlightIndex
+                      ? 'bg-primary/10 text-foreground'
+                      : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground',
+                  )}
+                >
+                  <span className="truncate">{branch}</span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        </ScrollFade>
+      ) : null}
+      {value != null ? (
+        <button
+          type="button"
+          onClick={() => commit({ candidate: '' })}
+          className="rounded px-2 py-1.5 text-left text-2xs text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+        >
+          Use default
+        </button>
+      ) : null}
+    </div>
+  );
+};

--- a/apps/desktop/src/features/worktree/worktree.ts
+++ b/apps/desktop/src/features/worktree/worktree.ts
@@ -273,6 +273,16 @@ export const listLocalBranches = async (
   return branches;
 };
 
+type ListBranchNamesParams = {
+  readonly repoPath: string;
+};
+
+export const listBranchNames = async ({
+  repoPath,
+}: ListBranchNamesParams): Promise<ReadonlyArray<string>> => {
+  return invoke<ReadonlyArray<string>>('worktree_list_branch_names', { repoPath });
+};
+
 export type ChangeBranchArgs = {
   readonly repoPath: string;
   readonly worktreePath: string;


### PR DESCRIPTION
The three free-text Base branch inputs (overview mount row, project git pill, settings) become a searchable select. Branches are fetched only when the popover opens, via a new worktree_list_branch_names command that merges local and origin refs (origin/ prefix stripped, HEAD refs dropped, deduped). Free text still commits unlisted branches, empty or "Use default" resets to null.

🤖 Generated with [Claude Code](https://claude.com/claude-code)