### PR TITLE
feat(ui): give the transcript handoff a stateful card

### DIFF
--- a/apps/desktop/src/features/chat/components/HandoffChip/index.test.tsx
+++ b/apps/desktop/src/features/chat/components/HandoffChip/index.test.tsx
@@ -2,6 +2,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { Agent, AgentId, SessionId } from '@goodboy/types';
 
 type ToastAction = { readonly label: string; readonly onClick: () => void };
 
@@ -13,8 +14,10 @@ const { extractHandoffMock, showToast, state } = vi.hoisted(() => ({
   state: {
     sessions: [{ id: 'sess-1', workflowRuns: [] as ReadonlyArray<string> }],
     sessionNudges: {} as Record<string, unknown>,
-    spawnAgent: vi.fn(async () => 'agent-impl'),
-    acceptSessionNudgeHandoff: vi.fn(async () => 'agent-accepted'),
+    sessionPhaseRuns: {} as Record<string, ReadonlyArray<Agent>>,
+    agentTurnState: {} as Record<string, unknown>,
+    spawnAgent: vi.fn(async () => 'agent-impl' as AgentId),
+    acceptSessionNudgeHandoff: vi.fn(async () => 'agent-accepted' as AgentId),
     selectAgent: vi.fn(async () => undefined),
     setCurrentSession: vi.fn(async () => undefined),
     setActiveLens: vi.fn(),
@@ -23,6 +26,7 @@ const { extractHandoffMock, showToast, state } = vi.hoisted(() => ({
 
 vi.mock('@goodboy/core', () => ({ extractHandoff: extractHandoffMock }));
 vi.mock('../../../../store', () => ({
+  EMPTY_ARRAY: [],
   useAppStore: <T,>(selector: (s: typeof state) => T) => selector(state),
 }));
 
@@ -32,14 +36,20 @@ vi.mock('../../../../app/components/Toast', () => ({
 
 import { HandoffChip } from './index';
 
+const SESSION_ID = 'sess-1' as SessionId;
+const SOURCE_AGENT_ID = 'agent-source' as AgentId;
+
 beforeEach(() => {
   extractHandoffMock.mockReset();
   showToast.mockClear();
   state.sessions = [{ id: 'sess-1', workflowRuns: [] }];
   state.sessionNudges = {};
-  state.spawnAgent = vi.fn(async () => 'agent-impl');
-  state.acceptSessionNudgeHandoff = vi.fn(async () => 'agent-accepted');
+  state.sessionPhaseRuns = {};
+  state.agentTurnState = {};
+  state.spawnAgent = vi.fn(async () => 'agent-impl' as AgentId);
+  state.acceptSessionNudgeHandoff = vi.fn(async () => 'agent-accepted' as AgentId);
   state.selectAgent = vi.fn(async () => undefined);
+  state.setCurrentSession = vi.fn(async () => undefined);
   state.setActiveLens = vi.fn();
 });
 afterEach(cleanup);
@@ -47,34 +57,96 @@ afterEach(cleanup);
 describe('HandoffChip', () => {
   it('renders nothing when no handoff is detected', () => {
     extractHandoffMock.mockReturnValue(null);
-    const { container } = render(<HandoffChip assistantText="x" sessionId={'sess-1' as never} />);
+    const { container } = render(
+      <HandoffChip assistantText="x" sessionId={SESSION_ID} sourceAgentId={SOURCE_AGENT_ID} />,
+    );
     expect(container.firstChild).toBeNull();
   });
 
   it('renders nothing when the session belongs to a workflow', () => {
     extractHandoffMock.mockReturnValue({ kind: 'implementer', reason: 'r' });
     state.sessions = [{ id: 'sess-1', workflowRuns: ['w'] }];
-    const { container } = render(<HandoffChip assistantText="x" sessionId={'sess-1' as never} />);
+    const { container } = render(
+      <HandoffChip assistantText="x" sessionId={SESSION_ID} sourceAgentId={SOURCE_AGENT_ID} />,
+    );
     expect(container.firstChild).toBeNull();
   });
 
-  it('spawns the suggested agent without stealing focus when the chip is clicked', () => {
+  it('links a directly spawned agent to the source without stealing focus', () => {
     extractHandoffMock.mockReturnValue({ kind: 'implementer', reason: null });
-    render(<HandoffChip assistantText="x" sessionId={'sess-1' as never} />);
-    fireEvent.click(screen.getByTestId('handoff-chip'));
+    render(
+      <HandoffChip assistantText="x" sessionId={SESSION_ID} sourceAgentId={SOURCE_AGENT_ID} />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Spawn implementer' }));
     expect(state.spawnAgent).toHaveBeenCalledWith('sess-1', {
       kindOverride: 'implementer',
+      parentAgentId: SOURCE_AGENT_ID,
       focus: 'none',
     });
+  });
+
+  it('shows a matching child live status and removes the spawn action', () => {
+    extractHandoffMock.mockReturnValue({ kind: 'implementer', reason: 'Build it' });
+    state.sessionPhaseRuns = {
+      'sess-1': [
+        {
+          id: 'agent-impl' as AgentId,
+          sessionId: SESSION_ID,
+          ordinal: 1,
+          name: 'Implement the handoff',
+          status: 'running',
+          kind: 'implementer',
+          parentAgentId: SOURCE_AGENT_ID,
+        } as Agent,
+      ],
+    };
+
+    render(
+      <HandoffChip assistantText="x" sessionId={SESSION_ID} sourceAgentId={SOURCE_AGENT_ID} />,
+    );
+
+    expect(screen.getByText('running')).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Go to chat' })).toBeDefined();
+    expect(screen.queryByRole('button', { name: 'Spawn implementer' })).toBeNull();
+  });
+
+  it('disables the action while the spawned child is waiting to enter the store', () => {
+    extractHandoffMock.mockReturnValue({ kind: 'implementer', reason: null });
+    state.spawnAgent = vi.fn(
+      () =>
+        new Promise<AgentId>(() => {
+          return undefined;
+        }),
+    );
+    render(
+      <HandoffChip assistantText="x" sessionId={SESSION_ID} sourceAgentId={SOURCE_AGENT_ID} />,
+    );
+    const action = screen.getByRole('button', { name: 'Spawn implementer' });
+
+    fireEvent.click(action);
+    fireEvent.click(action);
+
+    expect(screen.getByRole('button', { name: 'Spawning implementer' })).toHaveProperty(
+      'disabled',
+      true,
+    );
+    expect(state.spawnAgent).toHaveBeenCalledOnce();
   });
 
   it('accepts the live nudge, reports it started, and opens the agent only from the toast', async () => {
     extractHandoffMock.mockReturnValue({ kind: 'implementer', reason: null });
     state.sessionNudges = {
-      'sess-1': { id: 'nudge-1', kind: 'handoff-suggested', targetKind: 'implementer' },
+      'sess-1': {
+        id: 'nudge-1',
+        kind: 'handoff-suggested',
+        agentId: SOURCE_AGENT_ID,
+        targetKind: 'implementer',
+      },
     };
-    render(<HandoffChip assistantText="x" sessionId={'sess-1' as never} />);
-    fireEvent.click(screen.getByTestId('handoff-chip'));
+    render(
+      <HandoffChip assistantText="x" sessionId={SESSION_ID} sourceAgentId={SOURCE_AGENT_ID} />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Spawn implementer' }));
 
     await waitFor(() => expect(state.acceptSessionNudgeHandoff).toHaveBeenCalledWith('sess-1'));
     await waitFor(() => expect(showToast).toHaveBeenCalledOnce());

--- a/apps/desktop/src/features/chat/components/HandoffChip/index.tsx
+++ b/apps/desktop/src/features/chat/components/HandoffChip/index.tsx
@@ -1,29 +1,51 @@
-import { useMemo } from 'react';
-import { ArrowRight } from 'lucide-react';
-import type { PlanId, SessionId } from '@goodboy/types';
+import { useMemo, useRef, useState } from 'react';
+import { ArrowRight, LoaderCircle } from 'lucide-react';
+import { cn } from '@goodboy/ui';
+import type { AgentId, AgentStatus, PlanId, SessionId } from '@goodboy/types';
 import { extractHandoff } from '@goodboy/core';
-import { useAppStore } from '../../../../store';
+import { EMPTY_ARRAY, useAppStore } from '../../../../store';
 import { AGENT_KIND_META } from '../../../session/agent-kind';
+import { AgentStatusIcon } from '../../../session/components/AgentCard/AgentStatusIcon';
 import { TranscriptShell } from '../TranscriptShell';
 import { useAgentStartedToast } from '../../../../shared/hooks/useAgentStartedToast';
-import { tintClasses } from '@goodboy/ui';
-
-const accent = tintClasses('neutral');
+import { selectSpawnedChildren } from '../../../../shared/utils/spawnedChildren';
 
 type Props = {
   readonly assistantText: string;
   readonly sessionId: SessionId;
+  readonly sourceAgentId: AgentId | null;
 };
 
-export const HandoffChip = ({ assistantText, sessionId }: Props) => {
+const TERMINAL_LABELS: Partial<Record<AgentStatus, string>> = {
+  completed: 'done',
+  failed: 'failed',
+  skipped: 'skipped',
+};
+
+export const HandoffChip = ({ assistantText, sessionId, sourceAgentId }: Props) => {
+  const [isPending, setIsPending] = useState(false);
+  const pendingRef = useRef(false);
   const handoff = useMemo(() => extractHandoff(assistantText), [assistantText]);
   const session = useAppStore((s) => s.sessions.find((x) => x.id === sessionId) ?? null);
   const sessionNudge = useAppStore((s) => s.sessionNudges[sessionId] ?? null);
+  const runs = useAppStore((s) => s.sessionPhaseRuns[sessionId] ?? EMPTY_ARRAY);
+  const turnStates = useAppStore((s) => s.agentTurnState);
   const spawnAgent = useAppStore((s) => s.spawnAgent);
   const acceptHandoff = useAppStore((s) => s.acceptSessionNudgeHandoff);
+  const selectAgent = useAppStore((s) => s.selectAgent);
+  const setCurrentSession = useAppStore((s) => s.setCurrentSession);
+  const setActiveLens = useAppStore((s) => s.setActiveLens);
   const announceAgentStarted = useAgentStartedToast();
+  const spawnedChildren = useMemo(
+    () => selectSpawnedChildren({ runs, parentAgentId: sourceAgentId, turnStates }),
+    [runs, sourceAgentId, turnStates],
+  );
+  const spawnedChild =
+    handoff == null
+      ? null
+      : (spawnedChildren.find((child) => child.agent.kind === handoff.kind) ?? null);
 
-  if (!handoff || !session) {
+  if (handoff == null || session == null || sourceAgentId == null) {
     return null;
   }
   if (session.workflowRuns.length > 0) {
@@ -32,38 +54,101 @@ export const HandoffChip = ({ assistantText, sessionId }: Props) => {
 
   const meta = AGENT_KIND_META[handoff.kind];
   const isActiveNudge =
-    sessionNudge?.kind === 'handoff-suggested' && sessionNudge.targetKind === handoff.kind;
+    sessionNudge?.kind === 'handoff-suggested' &&
+    sessionNudge.agentId === sourceAgentId &&
+    sessionNudge.targetKind === handoff.kind;
 
-  const onClick = () => {
+  const onSpawn = () => {
+    if (pendingRef.current) {
+      return;
+    }
+    pendingRef.current = true;
+    setIsPending(true);
     void (async () => {
-      const agentId = isActiveNudge
-        ? await acceptHandoff(sessionId)
-        : await spawnAgent(sessionId, {
-            kindOverride: handoff.kind,
-            ...(handoff.planId ? { triggeredPlanId: handoff.planId as PlanId } : {}),
-            focus: 'none',
-          });
-      announceAgentStarted({
-        sessionId,
-        agentId,
-        title: `${meta.label} started`,
-        message: 'The agent is picking this up. You can keep working.',
-      });
+      try {
+        const agentId = isActiveNudge
+          ? await acceptHandoff(sessionId)
+          : await spawnAgent(sessionId, {
+              kindOverride: handoff.kind,
+              ...(handoff.planId != null ? { triggeredPlanId: handoff.planId as PlanId } : {}),
+              parentAgentId: sourceAgentId,
+              focus: 'none',
+            });
+        announceAgentStarted({
+          sessionId,
+          agentId,
+          title: `${meta.label} started`,
+          message: 'The agent is picking this up. You can keep working.',
+        });
+      } catch {
+        pendingRef.current = false;
+        setIsPending(false);
+      }
     })();
   };
+
+  const onOpen = () => {
+    if (spawnedChild == null) {
+      return;
+    }
+    void (async () => {
+      await setCurrentSession(sessionId);
+      setActiveLens(sessionId, 'agents');
+      await selectAgent(sessionId, spawnedChild.agent.id);
+      window.dispatchEvent(new CustomEvent('goodboy:reveal-chat'));
+    })();
+  };
+
+  const statusLabel =
+    spawnedChild == null ? null : (TERMINAL_LABELS[spawnedChild.status] ?? spawnedChild.status);
+
   return (
     <TranscriptShell
-      as="button"
-      type="button"
-      onClick={onClick}
-      data-testid="handoff-chip"
+      data-testid="handoff-card"
       tone="neutral"
-      variant="pill"
-      className={`inline-flex w-fit items-center gap-1.5 text-xs font-medium transition-opacity hover:opacity-80 ${accent.text}`}
+      variant="leftBorder"
+      className="flex w-full max-w-xl flex-col gap-1.5 text-xs"
     >
-      <ArrowRight size={12} aria-hidden />
-      <span>spawn {meta.label.toLowerCase()}</span>
-      {handoff.reason ? <span className="text-muted-foreground">· {handoff.reason}</span> : null}
+      <span className="font-medium text-foreground">spawn {handoff.kind}</span>
+      {handoff.reason != null && handoff.reason.length > 0 ? (
+        <span className="text-muted-foreground">{handoff.reason}</span>
+      ) : null}
+      <div className="flex min-h-5 items-center gap-1.5">
+        {spawnedChild == null ? (
+          <button
+            type="button"
+            disabled={isPending}
+            onClick={onSpawn}
+            className={cn(
+              'inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-2xs font-medium text-muted-foreground',
+              'hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--color-focus-ring)]',
+              'disabled:cursor-not-allowed disabled:opacity-60',
+            )}
+          >
+            {isPending ? (
+              <LoaderCircle size={10} className="animate-spin" aria-hidden />
+            ) : (
+              <ArrowRight size={10} aria-hidden />
+            )}
+            <span>{isPending ? `Spawning ${handoff.kind}` : `Spawn ${handoff.kind}`}</span>
+          </button>
+        ) : (
+          <>
+            <AgentStatusIcon status={spawnedChild.status} />
+            <span className="text-2xs text-muted-foreground">{statusLabel}</span>
+            <button
+              type="button"
+              onClick={onOpen}
+              className={cn(
+                'rounded px-1.5 py-0.5 text-2xs font-medium text-muted-foreground',
+                'hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--color-focus-ring)]',
+              )}
+            >
+              Go to chat
+            </button>
+          </>
+        )}
+      </div>
     </TranscriptShell>
   );
 };

--- a/apps/desktop/src/features/chat/components/HandoffChip/index.tsx
+++ b/apps/desktop/src/features/chat/components/HandoffChip/index.tsx
@@ -1,7 +1,8 @@
 import { useMemo, useRef, useState } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 import { ArrowRight, LoaderCircle } from 'lucide-react';
 import { cn } from '@goodboy/ui';
-import type { AgentId, AgentStatus, PlanId, SessionId } from '@goodboy/types';
+import type { AgentId, AgentStatus, PlanId, SessionId, TurnState } from '@goodboy/types';
 import { extractHandoff } from '@goodboy/core';
 import { EMPTY_ARRAY, useAppStore } from '../../../../store';
 import { AGENT_KIND_META } from '../../../session/agent-kind';
@@ -29,7 +30,19 @@ export const HandoffChip = ({ assistantText, sessionId, sourceAgentId }: Props) 
   const session = useAppStore((s) => s.sessions.find((x) => x.id === sessionId) ?? null);
   const sessionNudge = useAppStore((s) => s.sessionNudges[sessionId] ?? null);
   const runs = useAppStore((s) => s.sessionPhaseRuns[sessionId] ?? EMPTY_ARRAY);
-  const turnStates = useAppStore((s) => s.agentTurnState);
+  const turnStates = useAppStore(
+    useShallow((s) => {
+      const states: Record<string, TurnState> = {};
+      for (const run of runs) {
+        const turn = s.agentTurnState[run.id];
+        if (turn === undefined) {
+          continue;
+        }
+        states[run.id] = turn;
+      }
+      return states;
+    }),
+  );
   const spawnAgent = useAppStore((s) => s.spawnAgent);
   const acceptHandoff = useAppStore((s) => s.acceptSessionNudgeHandoff);
   const selectAgent = useAppStore((s) => s.selectAgent);

--- a/apps/desktop/src/features/chat/components/TranscriptCards/AssistantText.tsx
+++ b/apps/desktop/src/features/chat/components/TranscriptCards/AssistantText.tsx
@@ -27,7 +27,7 @@ export const AssistantText = ({ text, sessionId, agentId = null }: Props) => {
       {sessionId ? (
         <div className="flex flex-col items-start gap-2 empty:hidden">
           <PlanChip assistantText={text} sessionId={sessionId} />
-          <HandoffChip assistantText={text} sessionId={sessionId} />
+          <HandoffChip assistantText={text} sessionId={sessionId} sourceAgentId={agentId} />
           <ResolverThreadsCard assistantText={text} sessionId={sessionId} agentId={agentId} />
         </div>
       ) : null}

--- a/apps/desktop/src/store/slices/nudges/acceptSessionNudgeHandoff.test.ts
+++ b/apps/desktop/src/store/slices/nudges/acceptSessionNudgeHandoff.test.ts
@@ -12,6 +12,7 @@ import type { GetFn, SetFn } from './types';
 
 const SESSION_ID = 'sess-1' as SessionId;
 const PLAN_ID = 'plan-1' as PlanId;
+const SOURCE_AGENT_ID = 'agent-source' as AgentId;
 
 type FakeState = {
   sessionNudges: Record<string, unknown>;
@@ -37,25 +38,37 @@ beforeEach(() => {
 
 describe('acceptSessionNudgeHandoff, spawning does not steal focus', () => {
   it('spawns the plan implementer without focus and hands back the agent to open', async () => {
-    const state = buildState({ id: 'nudge-1', kind: 'plan-ready', planId: PLAN_ID });
+    const state = buildState({
+      id: 'nudge-1',
+      kind: 'plan-ready',
+      agentId: SOURCE_AGENT_ID,
+      planId: PLAN_ID,
+    });
 
     const agentId = await buildAccept(state)(SESSION_ID);
 
     expect(state.spawnAgent).toHaveBeenCalledWith(SESSION_ID, {
       triggeredPlanId: PLAN_ID,
       kindOverride: 'implementer',
+      parentAgentId: SOURCE_AGENT_ID,
       focus: 'none',
     });
     expect(agentId).toBe('agent-impl');
   });
 
   it('spawns a planless implementer without focus', async () => {
-    const state = buildState({ id: 'nudge-2', kind: 'plan-ready', planId: null });
+    const state = buildState({
+      id: 'nudge-2',
+      kind: 'plan-ready',
+      agentId: SOURCE_AGENT_ID,
+      planId: null,
+    });
 
     await buildAccept(state)(SESSION_ID);
 
     expect(state.spawnAgent).toHaveBeenCalledWith(SESSION_ID, {
       kindOverride: 'implementer',
+      parentAgentId: SOURCE_AGENT_ID,
       focus: 'none',
     });
   });
@@ -64,6 +77,7 @@ describe('acceptSessionNudgeHandoff, spawning does not steal focus', () => {
     const state = buildState({
       id: 'nudge-3',
       kind: 'handoff-suggested',
+      agentId: SOURCE_AGENT_ID,
       targetKind: 'reviewer',
       planId: null,
     });
@@ -72,6 +86,7 @@ describe('acceptSessionNudgeHandoff, spawning does not steal focus', () => {
 
     expect(state.spawnAgent).toHaveBeenCalledWith(SESSION_ID, {
       kindOverride: 'reviewer',
+      parentAgentId: SOURCE_AGENT_ID,
       focus: 'none',
     });
     expect(agentId).toBe('agent-impl');

--- a/apps/desktop/src/store/slices/nudges/acceptSessionNudgeHandoff.ts
+++ b/apps/desktop/src/store/slices/nudges/acceptSessionNudgeHandoff.ts
@@ -17,15 +17,21 @@ export const acceptSessionNudgeHandoff = (set: SetFn, get: GetFn) => {
         return await get().spawnAgent(sessionId, {
           triggeredPlanId: nudge.planId,
           kindOverride: 'implementer',
+          parentAgentId: nudge.agentId,
           focus: 'none',
         });
       }
-      return await get().spawnAgent(sessionId, { kindOverride: 'implementer', focus: 'none' });
+      return await get().spawnAgent(sessionId, {
+        kindOverride: 'implementer',
+        parentAgentId: nudge.agentId,
+        focus: 'none',
+      });
     }
     if (nudge.kind === 'handoff-suggested') {
       return await get().spawnAgent(sessionId, {
         kindOverride: nudge.targetKind,
         ...(nudge.planId !== null && { triggeredPlanId: nudge.planId }),
+        parentAgentId: nudge.agentId,
         focus: 'none',
       });
     }


### PR DESCRIPTION
The transcript handoff suggestion was a bare pill rebuilt from immutable assistant text: after the first spawn it stayed clickable and could spawn duplicates, with no link back to the source agent. It is now a left-border transcript card that passes parentAgentId on both spawn paths (direct and nudge accept), derives its state from the spawned child (running/done/failed + Go to chat, same vocabulary as AgentFollowUps), and guards the in-flight click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)