### PR TITLE
feat(ui): give every detail page the overview header rhythm

### DIFF
--- a/apps/desktop/src/features/github/GithubIssueDetail/index.tsx
+++ b/apps/desktop/src/features/github/GithubIssueDetail/index.tsx
@@ -64,6 +64,7 @@ export const GithubIssueDetail = ({
       fit={fit}
       header={
         <HeaderBand
+          title={issue.title}
           meta={
             <>
               <span className="font-mono text-2xs tabular-nums text-muted-foreground">
@@ -72,7 +73,6 @@ export const GithubIssueDetail = ({
               <StateBadge>{issue.state.toLowerCase()}</StateBadge>
             </>
           }
-          title={issue.title}
           actions={
             <>
               {headerActions}

--- a/apps/desktop/src/features/github/components/GitHubStudio/PrDetailPanel.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/PrDetailPanel.tsx
@@ -372,6 +372,7 @@ export const PrDetailPanel = ({
   const header = (
     <>
       <HeaderBand
+        title={activePr.title}
         meta={
           options.length > 1 ? (
             <PrSwitcher
@@ -388,7 +389,6 @@ export const PrDetailPanel = ({
             />
           )
         }
-        title={activePr.title}
         subtitle={<BranchPair headBranch={activePr.headBranch} baseBranch={activePr.baseBranch} />}
         actions={
           <>

--- a/apps/desktop/src/features/integrations/bitbucket/BitbucketStudio/PrDetailPanel/index.tsx
+++ b/apps/desktop/src/features/integrations/bitbucket/BitbucketStudio/PrDetailPanel/index.tsx
@@ -109,12 +109,12 @@ export const PrDetailPanel = ({
       header={
         <>
           <HeaderBand
+            title={pullRequest.title}
             meta={
               <StateBadge tone={pullRequestStateTone({ state: pullRequest.state })}>
                 #{pullRequest.id} · {pullRequest.state.toLowerCase()}
               </StateBadge>
             }
-            title={pullRequest.title}
             subtitle={
               <BranchPair
                 headBranch={pullRequest.sourceBranch}

--- a/apps/desktop/src/features/integrations/gitlab/GitlabIssueDetail/index.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabIssueDetail/index.tsx
@@ -45,6 +45,7 @@ export const GitlabIssueDetail = ({
       fit={fit}
       header={
         <HeaderBand
+          title={issue.title}
           meta={
             <>
               <span className="font-mono text-2xs tabular-nums text-muted-foreground">
@@ -53,7 +54,6 @@ export const GitlabIssueDetail = ({
               <StateBadge>{issue.state}</StateBadge>
             </>
           }
-          title={issue.title}
           actions={
             <>
               {headerActions}

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/IssueDetailPanel.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/IssueDetailPanel.tsx
@@ -73,6 +73,7 @@ export const IssueDetailPanel = ({ issue, sessionId, workspaceId, onClose }: Pro
     <StudioDetailLayout
       header={
         <HeaderBand
+          title={issue.title}
           meta={
             <>
               <span className="font-mono text-2xs tabular-nums text-muted-foreground">
@@ -81,7 +82,6 @@ export const IssueDetailPanel = ({ issue, sessionId, workspaceId, onClose }: Pro
               <StateBadge>{issue.state}</StateBadge>
             </>
           }
-          title={issue.title}
           actions={<ExternalRefActions url={issue.webUrl} label="issue" hostLabel="GitLab" />}
         />
       }

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel/index.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel/index.tsx
@@ -232,6 +232,7 @@ export const MrDetailPanel = ({
         header={
           <>
             <HeaderBand
+              title={mr.title}
               meta={
                 <>
                   <StateBadge tone={mergeRequestStateTone({ state: mr.state })}>
@@ -240,7 +241,6 @@ export const MrDetailPanel = ({
                   {mr.draft ? <StateBadge tone="warning">draft</StateBadge> : null}
                 </>
               }
-              title={mr.title}
               subtitle={<BranchPair headBranch={mr.sourceBranch} baseBranch={mr.targetBranch} />}
               actions={
                 <>
@@ -356,13 +356,13 @@ export const MrDetailPanel = ({
     <StudioDetailLayout
       header={
         <HeaderBand
+          title="New merge request"
           meta={
             <span className="inline-flex items-center gap-1.5 font-mono text-2xs text-muted-foreground">
               <GitBranch size={11} aria-hidden />
               {branch ?? 'no branch'}
             </span>
           }
-          title="New merge request"
           actions={refreshButton}
         />
       }

--- a/apps/desktop/src/features/integrations/jira/JiraIssueDetail/index.tsx
+++ b/apps/desktop/src/features/integrations/jira/JiraIssueDetail/index.tsx
@@ -54,6 +54,7 @@ export const JiraIssueDetail = ({
       dock={dock}
       header={
         <HeaderBand
+          title={live.summary}
           meta={
             <>
               <span className="font-mono text-2xs tabular-nums text-muted-foreground">
@@ -64,7 +65,6 @@ export const JiraIssueDetail = ({
               </StateBadge>
             </>
           }
-          title={live.summary}
           actions={
             <>
               {actions.assign != null && (

--- a/apps/desktop/src/features/integrations/linear/LinearIssueDetail/index.tsx
+++ b/apps/desktop/src/features/integrations/linear/LinearIssueDetail/index.tsx
@@ -45,6 +45,7 @@ export const LinearIssueDetail = ({
       fit={fit}
       header={
         <HeaderBand
+          title={issue.title}
           meta={
             <>
               <span className="font-mono text-2xs tabular-nums text-muted-foreground">
@@ -53,7 +54,6 @@ export const LinearIssueDetail = ({
               <StateBadge>{issue.state.name}</StateBadge>
             </>
           }
-          title={issue.title}
           actions={
             <>
               {headerActions}

--- a/apps/desktop/src/features/integrations/sentry/SentryIssueDetail/index.tsx
+++ b/apps/desktop/src/features/integrations/sentry/SentryIssueDetail/index.tsx
@@ -93,6 +93,7 @@ export const SentryIssueDetail = ({
       fit={fit}
       header={
         <HeaderBand
+          title={view.title}
           meta={
             <>
               <SentryLevelBadge level={view.level} />
@@ -101,7 +102,6 @@ export const SentryIssueDetail = ({
               </span>
             </>
           }
-          title={view.title}
           actions={
             <>
               {headerActions}

--- a/apps/desktop/src/features/integrations/sentry/SentryStudio/IssueDetailPanel.tsx
+++ b/apps/desktop/src/features/integrations/sentry/SentryStudio/IssueDetailPanel.tsx
@@ -116,6 +116,7 @@ export const IssueDetailPanel = ({ issue, sessionId, workspaceId, onClose }: Pro
       fit="fill"
       header={
         <HeaderBand
+          title={view.title}
           meta={
             <>
               <SentryLevelBadge level={view.level} />
@@ -124,7 +125,6 @@ export const IssueDetailPanel = ({ issue, sessionId, workspaceId, onClose }: Pro
               </span>
             </>
           }
-          title={view.title}
           actions={
             view.permalink != null && view.permalink !== '' ? (
               <ExternalRefActions url={view.permalink} label="issue" hostLabel="Sentry" />

--- a/apps/desktop/src/features/integrations/slack/SlackThreadDetail/index.tsx
+++ b/apps/desktop/src/features/integrations/slack/SlackThreadDetail/index.tsx
@@ -58,10 +58,10 @@ export const SlackThreadDetail = ({
       dock={dock}
       header={
         <HeaderBand
+          title={title !== '' ? title : `#${channelName}`}
           meta={
             <span className="font-mono text-2xs text-muted-foreground">{`#${channelName}`}</span>
           }
-          title={title !== '' ? title : `#${channelName}`}
           actions={
             url != null && url !== '' ? (
               <ExternalRefActions url={url} label="thread" hostLabel="Slack" />

--- a/apps/desktop/src/features/plans/components/PlanStudio/index.test.tsx
+++ b/apps/desktop/src/features/plans/components/PlanStudio/index.test.tsx
@@ -277,8 +277,14 @@ describe('PlanStudio subpage', () => {
     ];
     state.focusedPlanId = { 'sess-1': 'plan-2' };
     const { container } = render(<PlanStudio sessionId={'sess-1' as never} />);
+    const title = screen.getByRole('heading', { level: 2, name: 'Second plan' });
+    const status = screen.getByText('active');
+
     expect(screen.getByText('body two')).toBeDefined();
     expect(container.querySelector('.max-w-5xl')).not.toBeNull();
+    expect(title.className).toContain('text-xl');
+    expect(title.compareDocumentPosition(status) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(title.closest('.px-6')?.className).toContain('py-5');
   });
 
   it('re-renders as the list when focusedPlanId transitions to null while mounted', () => {

--- a/apps/desktop/src/features/plans/components/PlanStudio/index.tsx
+++ b/apps/desktop/src/features/plans/components/PlanStudio/index.tsx
@@ -3,6 +3,7 @@ import { ArchiveRestore, Eye, Pencil, Play, RotateCw, Trash2 } from 'lucide-reac
 import {
   Button,
   Divider,
+  HeaderBand,
   InlineConfirm,
   Markdown,
   ScrollFade,
@@ -130,15 +131,11 @@ export const PlanStudio = ({ sessionId }: Props) => {
     return (
       <FocusedPane lens="Plans" count={plans.length}>
         <div className="flex min-h-0 min-w-0 flex-1 flex-col">
-          <div className={cn('flex shrink-0 flex-col gap-2', PANE_RHYTHM.header)}>
-            <div className="flex shrink-0 items-start gap-3">
-              <div className="flex min-w-0 flex-1 flex-col gap-1 text-2xs text-muted-foreground">
-                <div className="flex min-w-0 items-center gap-2">
-                  <h2 className="min-w-0 truncate text-sm font-medium text-foreground">
-                    {selected.title}
-                  </h2>
-                  <PlanStatusChip status={selected.status} />
-                </div>
+          <div className={cn('flex shrink-0 flex-col gap-2', PANE_RHYTHM.body)}>
+            <HeaderBand
+              title={selected.title}
+              meta={<PlanStatusChip status={selected.status} />}
+              subtitle={
                 <PlanProvenance
                   creatorName={selectedAgentName}
                   creatorAgentId={selected.agentId}
@@ -148,136 +145,138 @@ export const PlanStudio = ({ sessionId }: Props) => {
                   agents={agents}
                   onAgentClick={handleAgentClick}
                 />
-              </div>
-              <div className="flex shrink-0 flex-col items-end gap-1.5">
-                {deleteArmed ? (
-                  <InlineConfirm
-                    role="danger"
-                    icon={<Trash2 size={12} aria-hidden />}
-                    title={`Delete "${selected.title}"?`}
-                    description="Moves this plan to discarded plans, where it can still be restored."
-                    confirmLabel={`Delete ${selected.title}`}
-                    autoDisarmMs={4000}
-                    onConfirm={() => {
-                      handleDiscard(selected);
-                      setDeleteArmed(false);
-                    }}
-                    onCancel={() => setDeleteArmed(false)}
-                    className="shrink-0"
-                  />
-                ) : replayArmed ? (
-                  <InlineConfirm
-                    role="alert"
-                    icon={<RotateCw size={12} aria-hidden />}
-                    title="Replay this plan?"
-                    description="It already ran once. Replaying spawns a new agent to execute it again."
-                    confirmLabel="Replay"
-                    autoDisarmMs={4000}
-                    isBusy={spawning}
-                    onConfirm={async () => {
-                      await handleTrigger();
-                      setReplayArmed(false);
-                    }}
-                    onCancel={() => setReplayArmed(false)}
-                    className="shrink-0"
-                  />
-                ) : (
-                  <div className="flex items-center gap-2">
-                    {selected.status !== 'discarded' ? (
-                      selected.status === 'consumed' ? (
-                        <Button
-                          variant="warning"
-                          emphasis="outline"
-                          size="sm"
-                          onClick={() => setReplayArmed(true)}
-                          disabled={spawning}
-                          title="Plan already ran, click to replay and confirm"
-                          className={cn(spawning && 'cursor-not-allowed animate-border-pulse')}
-                        >
-                          <RotateCw size={12} aria-hidden />
-                          Replay
-                        </Button>
-                      ) : (
-                        <Button
-                          variant="primary"
-                          size="sm"
-                          onClick={() => void handleTrigger()}
-                          disabled={spawning}
-                          className={cn(spawning && 'cursor-not-allowed animate-border-pulse')}
-                          title={
-                            selected.status === 'active'
-                              ? 'Spawn new agent to execute this plan'
-                              : 'Replay this plan'
-                          }
-                        >
-                          {selected.status === 'active' ? (
-                            <Play size={12} aria-hidden className="fill-current" />
-                          ) : (
+              }
+              actions={
+                <div className="flex shrink-0 flex-col items-end gap-1.5">
+                  {deleteArmed ? (
+                    <InlineConfirm
+                      role="danger"
+                      icon={<Trash2 size={12} aria-hidden />}
+                      title={`Delete "${selected.title}"?`}
+                      description="Moves this plan to discarded plans, where it can still be restored."
+                      confirmLabel={`Delete ${selected.title}`}
+                      autoDisarmMs={4000}
+                      onConfirm={() => {
+                        handleDiscard(selected);
+                        setDeleteArmed(false);
+                      }}
+                      onCancel={() => setDeleteArmed(false)}
+                      className="shrink-0"
+                    />
+                  ) : replayArmed ? (
+                    <InlineConfirm
+                      role="alert"
+                      icon={<RotateCw size={12} aria-hidden />}
+                      title="Replay this plan?"
+                      description="It already ran once. Replaying spawns a new agent to execute it again."
+                      confirmLabel="Replay"
+                      autoDisarmMs={4000}
+                      isBusy={spawning}
+                      onConfirm={async () => {
+                        await handleTrigger();
+                        setReplayArmed(false);
+                      }}
+                      onCancel={() => setReplayArmed(false)}
+                      className="shrink-0"
+                    />
+                  ) : (
+                    <div className="flex items-center gap-2">
+                      {selected.status !== 'discarded' ? (
+                        selected.status === 'consumed' ? (
+                          <Button
+                            variant="warning"
+                            emphasis="outline"
+                            size="sm"
+                            onClick={() => setReplayArmed(true)}
+                            disabled={spawning}
+                            title="Plan already ran, click to replay and confirm"
+                            className={cn(spawning && 'cursor-not-allowed animate-border-pulse')}
+                          >
                             <RotateCw size={12} aria-hidden />
-                          )}
-                          {selected.status === 'active' ? 'Start' : 'Replay'}
-                        </Button>
-                      )
-                    ) : null}
-                    {selected.status === 'consumed' ? (
-                      <Tooltip content="Consumed plans cannot be deleted">
-                        <span
-                          className="inline-flex cursor-not-allowed items-center justify-center rounded-md border border-border-soft p-1.5 text-danger/30"
-                          aria-label="Consumed plans cannot be deleted"
-                        >
-                          <Trash2 size={13} aria-hidden />
-                        </span>
-                      </Tooltip>
-                    ) : selected.status === 'discarded' ? (
-                      <Tooltip content="Restore plan">
-                        <button
-                          type="button"
-                          onClick={() => handleRestore(selected)}
-                          aria-label="Restore plan"
-                          className="inline-flex items-center justify-center rounded-md border border-info/20 p-1.5 text-info transition hover:border-info/40 hover:bg-info/10"
-                        >
-                          <ArchiveRestore size={13} aria-hidden />
-                        </button>
-                      </Tooltip>
-                    ) : (
-                      <Tooltip content="Delete plan (soft delete, click restore to recover)">
-                        <button
-                          type="button"
-                          onClick={() => setDeleteArmed(true)}
-                          aria-label="Delete plan"
-                          className="inline-flex items-center justify-center rounded-md border border-danger/20 p-1.5 text-danger transition hover:border-danger/40 hover:bg-danger/10"
-                        >
-                          <Trash2 size={13} aria-hidden />
-                        </button>
-                      </Tooltip>
-                    )}
-                  </div>
-                )}
-                <SegmentedTabs
-                  ariaLabel="Content mode"
-                  options={[
-                    { value: 'preview', label: 'Preview', icon: Eye },
-                    {
-                      value: 'edit',
-                      label: 'Edit',
-                      icon: Pencil,
-                      ...(selected.status === 'discarded' && {
-                        hint: 'Restore the plan to edit it',
-                      }),
-                      disabled: selected.status === 'discarded',
-                    },
-                  ]}
-                  value={mode}
-                  onChange={(nextMode) => {
-                    if (nextMode === 'preview' && mode === 'edit') {
-                      commitEdit();
-                    }
-                    setMode(nextMode);
-                  }}
-                  size="sm"
-                />
-              </div>
-            </div>
+                            Replay
+                          </Button>
+                        ) : (
+                          <Button
+                            variant="primary"
+                            size="sm"
+                            onClick={() => void handleTrigger()}
+                            disabled={spawning}
+                            className={cn(spawning && 'cursor-not-allowed animate-border-pulse')}
+                            title={
+                              selected.status === 'active'
+                                ? 'Spawn new agent to execute this plan'
+                                : 'Replay this plan'
+                            }
+                          >
+                            {selected.status === 'active' ? (
+                              <Play size={12} aria-hidden className="fill-current" />
+                            ) : (
+                              <RotateCw size={12} aria-hidden />
+                            )}
+                            {selected.status === 'active' ? 'Start' : 'Replay'}
+                          </Button>
+                        )
+                      ) : null}
+                      {selected.status === 'consumed' ? (
+                        <Tooltip content="Consumed plans cannot be deleted">
+                          <span
+                            className="inline-flex cursor-not-allowed items-center justify-center rounded-md border border-border-soft p-1.5 text-danger/30"
+                            aria-label="Consumed plans cannot be deleted"
+                          >
+                            <Trash2 size={13} aria-hidden />
+                          </span>
+                        </Tooltip>
+                      ) : selected.status === 'discarded' ? (
+                        <Tooltip content="Restore plan">
+                          <button
+                            type="button"
+                            onClick={() => handleRestore(selected)}
+                            aria-label="Restore plan"
+                            className="inline-flex items-center justify-center rounded-md border border-info/20 p-1.5 text-info transition hover:border-info/40 hover:bg-info/10"
+                          >
+                            <ArchiveRestore size={13} aria-hidden />
+                          </button>
+                        </Tooltip>
+                      ) : (
+                        <Tooltip content="Delete plan (soft delete, click restore to recover)">
+                          <button
+                            type="button"
+                            onClick={() => setDeleteArmed(true)}
+                            aria-label="Delete plan"
+                            className="inline-flex items-center justify-center rounded-md border border-danger/20 p-1.5 text-danger transition hover:border-danger/40 hover:bg-danger/10"
+                          >
+                            <Trash2 size={13} aria-hidden />
+                          </button>
+                        </Tooltip>
+                      )}
+                    </div>
+                  )}
+                  <SegmentedTabs
+                    ariaLabel="Content mode"
+                    options={[
+                      { value: 'preview', label: 'Preview', icon: Eye },
+                      {
+                        value: 'edit',
+                        label: 'Edit',
+                        icon: Pencil,
+                        ...(selected.status === 'discarded' && {
+                          hint: 'Restore the plan to edit it',
+                        }),
+                        disabled: selected.status === 'discarded',
+                      },
+                    ]}
+                    value={mode}
+                    onChange={(nextMode) => {
+                      if (nextMode === 'preview' && mode === 'edit') {
+                        commitEdit();
+                      }
+                      setMode(nextMode);
+                    }}
+                    size="sm"
+                  />
+                </div>
+              }
+            />
           </div>
           <Divider />
           <ScrollFade className="min-h-0 flex-1" viewportClassName={PANE_RHYTHM.body} fadeSize={24}>

--- a/apps/desktop/src/features/review/components/ReviewBoardPane/index.test.tsx
+++ b/apps/desktop/src/features/review/components/ReviewBoardPane/index.test.tsx
@@ -251,8 +251,13 @@ describe('ReviewBoardPane', () => {
   it('states its section title with the reviewed record below it', () => {
     render(<ReviewBoardPane session={SESSION} />);
 
-    expect(screen.getByRole('heading', { name: 'Review board' })).toBeDefined();
-    expect(screen.getByText('acme/web #41')).toBeDefined();
+    const title = screen.getByRole('heading', { level: 2, name: 'Review board' });
+    const record = screen.getByText('acme/web #41');
+    const layoutControl = screen.getByRole('tab', { name: 'Unified' });
+
+    expect(title.className).toContain('text-xl');
+    expect(title.parentElement?.contains(layoutControl)).toBe(true);
+    expect(title.compareDocumentPosition(record) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
   it('states its section title with no reviewed record', () => {

--- a/apps/desktop/src/features/review/components/ReviewBoardPane/index.tsx
+++ b/apps/desktop/src/features/review/components/ReviewBoardPane/index.tsx
@@ -1,5 +1,13 @@
 import { useEffect, useMemo, useState } from 'react';
-import { cn, DiffLayoutToggle, formatError, ResizeHandle, ScrollFade, Skeleton } from '@goodboy/ui';
+import {
+  cn,
+  DiffLayoutToggle,
+  formatError,
+  HeaderBand,
+  ResizeHandle,
+  ScrollFade,
+  Skeleton,
+} from '@goodboy/ui';
 import type { PrReviewDraft, Session, SessionId } from '@goodboy/types';
 import { EMPTY_ARRAY, useAppStore } from '../../../../store';
 import type { PublishPrReviewVerdict } from '../../../../store/slices/review-drafts/types';
@@ -121,26 +129,33 @@ export const ReviewBoardPane = ({ session }: Props) => {
   };
 
   const header = (
-    <div className="flex items-center gap-2">
-      <h2 className="min-w-0 truncate text-sm font-medium text-foreground">Review board</h2>
-      {target != null ? (
-        <span className="min-w-0 truncate font-mono text-2xs text-muted-foreground">
-          {`${target.repo} ${target.provider === 'gitlab' ? '!' : '#'}${target.prNumber}`}
-        </span>
-      ) : null}
-      <span className="text-2xs tabular-nums text-muted-foreground/60">
-        {loading ? '' : `${files.length} files`}
-      </span>
-      <span className="flex-1" />
-      <DiffLayoutToggle mode={layoutMode} onChange={setLayoutMode} />
-      <RefreshIconButton
-        label="Refresh diff"
-        isLoading={loading}
-        onClick={refresh}
-        iconSize={12}
-        className="size-6 border-transparent p-0"
-      />
-    </div>
+    <HeaderBand
+      title="Review board"
+      meta={
+        <>
+          {target != null ? (
+            <span className="min-w-0 truncate font-mono text-2xs text-muted-foreground">
+              {`${target.repo} ${target.provider === 'gitlab' ? '!' : '#'}${target.prNumber}`}
+            </span>
+          ) : null}
+          <span className="text-2xs tabular-nums text-muted-foreground/60">
+            {loading ? '' : `${files.length} files`}
+          </span>
+        </>
+      }
+      actions={
+        <>
+          <DiffLayoutToggle mode={layoutMode} onChange={setLayoutMode} />
+          <RefreshIconButton
+            label="Refresh diff"
+            isLoading={loading}
+            onClick={refresh}
+            iconSize={12}
+            className="size-6 border-transparent p-0"
+          />
+        </>
+      }
+    />
   );
 
   return (

--- a/apps/desktop/src/features/review/components/ReviewPrDetailPanel/index.tsx
+++ b/apps/desktop/src/features/review/components/ReviewPrDetailPanel/index.tsx
@@ -89,6 +89,7 @@ export const ReviewPrDetailPanel = ({ pr, workspaceId, onClose }: Props) => {
     <StudioDetailLayout
       header={
         <HeaderBand
+          title={pr.title}
           meta={
             <>
               <span className="font-mono text-2xs tabular-nums text-muted-foreground">
@@ -102,7 +103,6 @@ export const ReviewPrDetailPanel = ({ pr, workspaceId, onClose }: Props) => {
               </span>
             </>
           }
-          title={pr.title}
           subtitle={<BranchPair headBranch={pr.headBranch} baseBranch={pr.baseBranch} />}
           actions={
             <ExternalRefActions url={pr.url} label={`PR #${pr.number}`} hostLabel={hostLabel} />

--- a/apps/desktop/src/features/session/components/AgentDetailPane/index.test.tsx
+++ b/apps/desktop/src/features/session/components/AgentDetailPane/index.test.tsx
@@ -65,6 +65,19 @@ beforeEach(() => {
 });
 
 describe('AgentDetailPane', () => {
+  it('places the title at the shared detail inset above agent metadata', () => {
+    render(
+      <AgentDetailPane session={session} agent={agent} isChatActive onBack={() => undefined} />,
+    );
+
+    const title = screen.getByRole('heading', { level: 2, name: 'Implement chat' });
+    const status = screen.getByText('running');
+
+    expect(title.className).toContain('text-xl');
+    expect(title.closest('.px-6')?.className).toContain('py-5');
+    expect(title.compareDocumentPosition(status) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
   it('opens on the brief and keeps transcript one tab away', () => {
     render(
       <AgentDetailPane session={session} agent={agent} isChatActive onBack={() => undefined} />,

--- a/apps/desktop/src/features/session/components/ResolverDetailPane/index.tsx
+++ b/apps/desktop/src/features/session/components/ResolverDetailPane/index.tsx
@@ -196,6 +196,7 @@ export const ResolverDetailPane = ({ session, agent, isChatActive, onBack }: Pro
       fit={tab === 'transcript' ? 'bleed' : 'fill'}
       header={
         <HeaderBand
+          title={agent.name}
           meta={
             <>
               <ResolverStateBadge state={resolverBadgeState(status)} />
@@ -209,7 +210,6 @@ export const ResolverDetailPane = ({ session, agent, isChatActive, onBack }: Pro
               )}
             </>
           }
-          title={agent.name}
           subtitle={
             tallySentence !== null && (
               <span className="text-2xs tabular-nums text-muted-foreground/80">

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/FocusedTaskBody.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/FocusedTaskBody.tsx
@@ -67,12 +67,12 @@ export const FocusedTaskBody = ({
       fit="fill"
       header={
         <HeaderBand
+          title={task.title}
           meta={
             <span className="font-mono text-2xs tabular-nums text-muted-foreground">
               {task.identifier}
             </span>
           }
-          title={task.title}
         />
       }
     >

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/GithubTaskDetail.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/GithubTaskDetail.test.tsx
@@ -115,4 +115,17 @@ describe('GithubTaskDetail', () => {
 
     expect(useGithubIssueMock).toHaveBeenCalledWith(expect.objectContaining({ issueNumber: 7 }));
   });
+
+  it('uses the issue identifier as the title when no linked task supplies one', () => {
+    useGithubIssueMock.mockReturnValue({
+      issue: null,
+      isLoading: true,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(<GithubTaskDetail workspaceId={WORKSPACE_ID} rootPath="/repo" issueNumber={7} />);
+
+    expect(screen.getByRole('heading', { level: 2, name: '#7' })).toBeDefined();
+  });
 });

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/GithubTaskDetail.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/GithubTaskDetail.tsx
@@ -36,12 +36,12 @@ export const GithubTaskDetail = ({ workspaceId, rootPath, task, issueNumber }: P
       fit="fill"
       header={
         <HeaderBand
+          title={task?.title ?? `#${resolvedIssueNumber}`}
           meta={
             <span className="font-mono text-2xs tabular-nums text-muted-foreground">
               {task?.identifier ?? `#${resolvedIssueNumber}`}
             </span>
           }
-          title={task?.title ?? 'GitHub issue'}
         />
       }
     >

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/GitlabTaskDetail.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/GitlabTaskDetail.tsx
@@ -30,12 +30,12 @@ export const GitlabTaskDetail = ({ workspaceId, projectId, task }: Props) => {
       fit="fill"
       header={
         <HeaderBand
+          title={task.title}
           meta={
             <span className="font-mono text-2xs tabular-nums text-muted-foreground">
               {task.identifier}
             </span>
           }
-          title={task.title}
         />
       }
     >

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/JiraTaskDetail.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/JiraTaskDetail.tsx
@@ -30,12 +30,12 @@ export const JiraTaskDetail = ({ workspaceId, projectId, task }: Props) => {
       fit="fill"
       header={
         <HeaderBand
+          title={task.title}
           meta={
             <span className="font-mono text-2xs tabular-nums text-muted-foreground">
               {task.identifier}
             </span>
           }
-          title={task.title}
         />
       }
     >

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/LinearTaskDetail.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/LinearTaskDetail.tsx
@@ -30,12 +30,12 @@ export const LinearTaskDetail = ({ workspaceId, projectId, task }: Props) => {
       fit="fill"
       header={
         <HeaderBand
+          title={task.title}
           meta={
             <span className="font-mono text-2xs tabular-nums text-muted-foreground">
               {task.identifier}
             </span>
           }
-          title={task.title}
         />
       }
     >

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/SlackTaskDetail.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/SlackTaskDetail.tsx
@@ -34,10 +34,10 @@ export const SlackTaskDetail = ({ workspaceId, task }: Props) => {
         fit="fill"
         header={
           <HeaderBand
+            title={task.title}
             meta={
               <span className="font-mono text-2xs text-muted-foreground">{task.identifier}</span>
             }
-            title={task.title}
           />
         }
       >

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.test.tsx
@@ -309,7 +309,7 @@ describe('PrPane', () => {
     expect(screen.queryByText('GitHub')).toBeNull();
   });
 
-  it('keeps naming GitLab with a merge request linked below the title', () => {
+  it('promotes the GitLab merge request title and keeps the host below it', () => {
     h.remoteKind = 'gitlab';
     h.store.sessionGitlabMr = {
       [SESSION_ID]: {
@@ -319,9 +319,11 @@ describe('PrPane', () => {
 
     render(<PrPane session={session} onSelectLens={h.onSelectLens} />);
 
-    expect(screen.getByRole('heading', { name: 'GitLab', level: 2 })).toBeDefined();
+    const title = screen.getByRole('heading', { name: 'Refactor authentication', level: 2 });
+    const host = screen.getByText('GitLab');
+
+    expect(title.compareDocumentPosition(host) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(screen.getByText('!7')).toBeDefined();
-    expect(screen.getByText('Refactor authentication')).toBeDefined();
   });
 
   it('names GitHub when that is the host', () => {
@@ -348,8 +350,8 @@ describe('PrPane', () => {
 
     render(<PrPane session={session} onSelectLens={h.onSelectLens} />);
 
-    expect(screen.getByRole('heading', { name: 'Code host work' })).toBeDefined();
-    expect(screen.getAllByText('Refactor authentication').length).toBeGreaterThan(0);
+    expect(screen.getByRole('heading', { name: 'Refactor authentication' })).toBeDefined();
+    expect(screen.getByText('Code host work')).toBeDefined();
     expect(screen.getByRole('tab', { name: 'GitHub' })).toBeDefined();
     expect(screen.getByRole('tab', { name: 'GitLab' })).toBeDefined();
   });
@@ -389,7 +391,8 @@ describe('PrPane', () => {
 
     render(<PrPane session={session} onSelectLens={h.onSelectLens} />);
 
-    expect(screen.getByRole('heading', { name: 'Bitbucket' })).toBeDefined();
+    expect(screen.getByRole('heading', { name: 'Raise the fuel constant' })).toBeDefined();
+    expect(screen.getByText('Bitbucket')).toBeDefined();
     expect(screen.getByText('Bitbucket pull request detail')).toBeDefined();
     expect(screen.queryByRole('tab', { name: 'Bitbucket' })).toBeNull();
   });
@@ -435,7 +438,8 @@ describe('PrPane', () => {
 
     render(<PrPane session={session} onSelectLens={h.onSelectLens} />);
 
-    expect(screen.getByRole('heading', { name: 'Code host work' })).toBeDefined();
+    expect(screen.getByRole('heading', { name: 'Refactor authentication' })).toBeDefined();
+    expect(screen.getByText('Code host work')).toBeDefined();
     expect(screen.getByRole('tab', { name: 'GitHub' })).toBeDefined();
     expect(screen.getByRole('tab', { name: 'GitLab' })).toBeDefined();
     expect(screen.getByRole('tab', { name: 'Bitbucket' })).toBeDefined();
@@ -478,8 +482,8 @@ describe('PrPane', () => {
 
     render(<PrPane session={session} onSelectLens={h.onSelectLens} />);
 
-    expect(screen.getByRole('heading', { name: 'GitHub', level: 2 })).toBeDefined();
-    expect(screen.queryByRole('heading', { name: PULL_REQUEST.title })).toBeNull();
+    const expectedTitle = count === 0 ? 'GitHub' : PULL_REQUEST.title;
+    expect(screen.getByRole('heading', { name: expectedTitle, level: 2 })).toBeDefined();
   });
 
   it('scopes the pull request list to the branch it reads', () => {
@@ -587,7 +591,7 @@ describe('PrPane', () => {
 
     render(<PrPane session={session} onSelectLens={h.onSelectLens} />);
 
-    expect(screen.getByRole('heading', { name: 'GitHub', level: 2 })).toBeDefined();
+    expect(screen.getByRole('heading', { name: PULL_REQUEST.title, level: 2 })).toBeDefined();
     expect(screen.getByText('Pull request on ak/refactor-auth')).toBeDefined();
     expect(screen.getByRole('button', { name: 'Open pull request #42' })).toBeDefined();
     expect(screen.getByText('No CI')).toBeDefined();
@@ -663,6 +667,7 @@ describe('PrPane', () => {
     render(<PrPane session={session} onSelectLens={h.onSelectLens} />);
 
     expect(screen.getAllByText(closedPr.title).length).toBeGreaterThan(0);
+    expect(screen.getByRole('heading', { name: closedPr.title, level: 2 })).toBeDefined();
     expect(screen.queryByRole('heading', { name: PULL_REQUEST.title })).toBeNull();
     const selectedRow = screen
       .getByRole('button', { name: `Open pull request #${closedPr.number}` })

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.tsx
@@ -207,20 +207,22 @@ export const PrPane = ({ session, onSelectLens }: Props) => {
         fit="fill"
         header={
           <HeaderBand
-            meta={<SessionBranchTag branch={sessionBranch} />}
-            title={hostTitle({ remoteKind, providerCount, activeProvider })}
-            subtitle={
-              bitbucketPr != null ? (
-                <div className="flex min-w-0 flex-wrap items-center gap-2">
+            title={bitbucketPr?.title ?? hostTitle({ remoteKind, providerCount, activeProvider })}
+            meta={
+              <>
+                <span className="text-2xs font-medium text-muted-foreground">
+                  {hostTitle({ remoteKind, providerCount, activeProvider })}
+                </span>
+                <SessionBranchTag branch={sessionBranch} />
+                {bitbucketPr != null ? (
                   <span className="font-mono text-2xs tabular-nums text-muted-foreground">
                     #{bitbucketPr.id}
                   </span>
+                ) : null}
+                {bitbucketPr != null ? (
                   <StateBadge>{bitbucketPr.state.toLowerCase()}</StateBadge>
-                  <span className="min-w-0 truncate text-sm text-muted-foreground">
-                    {bitbucketPr.title}
-                  </span>
-                </div>
-              ) : null
+                ) : null}
+              </>
             }
           />
         }
@@ -237,20 +239,22 @@ export const PrPane = ({ session, onSelectLens }: Props) => {
         fit="fill"
         header={
           <HeaderBand
-            meta={<SessionBranchTag branch={sessionBranch} />}
-            title={hostTitle({ remoteKind, providerCount, activeProvider })}
-            subtitle={
-              mergeRequest != null && mergeRequestState != null ? (
-                <div className="flex min-w-0 flex-wrap items-center gap-2">
+            title={mergeRequest?.title ?? hostTitle({ remoteKind, providerCount, activeProvider })}
+            meta={
+              <>
+                <span className="text-2xs font-medium text-muted-foreground">
+                  {hostTitle({ remoteKind, providerCount, activeProvider })}
+                </span>
+                <SessionBranchTag branch={sessionBranch} />
+                {mergeRequest != null ? (
                   <span className="font-mono text-2xs tabular-nums text-muted-foreground">
                     !{mergeRequest.iid}
                   </span>
+                ) : null}
+                {mergeRequestState != null ? (
                   <StateBadge>{pullRequestMeta({ state: mergeRequestState }).label}</StateBadge>
-                  <span className="min-w-0 truncate text-sm text-muted-foreground">
-                    {mergeRequest.title}
-                  </span>
-                </div>
-              ) : null
+                ) : null}
+              </>
             }
           />
         }
@@ -407,8 +411,8 @@ const GithubPrCard = ({
       fit="fill"
       header={
         <HeaderBand
-          meta={<SessionBranchTag branch={branch} />}
           title={hostTitle({ remoteKind, providerCount, activeProvider })}
+          meta={<SessionBranchTag branch={branch} />}
         />
       }
       {...(tabs != null && { tabs })}
@@ -494,13 +498,15 @@ const GithubPrCard = ({
       fit="fill"
       header={
         <HeaderBand
-          meta={<SessionBranchTag branch={branch} />}
-          title={hostTitle({ remoteKind, providerCount, activeProvider })}
-          subtitle={
-            <div className="flex min-w-0 flex-wrap items-center gap-2">
+          title={pr.title}
+          meta={
+            <>
+              <span className="text-2xs font-medium text-muted-foreground">
+                {hostTitle({ remoteKind, providerCount, activeProvider })}
+              </span>
+              <SessionBranchTag branch={branch} />
               <PullRequestChip state={pr.state} variant="badge" number={pr.number} iconSize={12} />
-              <span className="min-w-0 truncate text-sm text-muted-foreground">{pr.title}</span>
-            </div>
+            </>
           }
           actions={
             <>

--- a/apps/desktop/src/shared/components/StudioDetail/StudioDetailLayout.tsx
+++ b/apps/desktop/src/shared/components/StudioDetail/StudioDetailLayout.tsx
@@ -37,7 +37,7 @@ export const StudioDetailLayout = ({
         data-testid="detail-header-band"
         className={cn('flex shrink-0 flex-col', isFlow && 'sticky top-0 z-10 gap-4 bg-background')}
       >
-        <div className={cn('flex flex-col', !isFlow && PANE_RHYTHM.header)}>
+        <div className={cn('flex flex-col', !isFlow && PANE_RHYTHM.body)}>
           <div className={cn('flex flex-col gap-3', PANE_RHYTHM.column, headerMeasure)}>
             {header}
             {hasMeta ? (

--- a/apps/desktop/src/shared/components/StudioDetail/index.test.tsx
+++ b/apps/desktop/src/shared/components/StudioDetail/index.test.tsx
@@ -101,6 +101,19 @@ describe('StudioDetailLayout', () => {
     expect(screen.getByText('Main slot').closest('[class*="max-w-"]')).toBeNull();
   });
 
+  it('uses the same 20px inset as pane bodies', () => {
+    render(
+      <StudioDetailLayout header={<span>Header slot</span>}>
+        <span>Main slot</span>
+      </StudioDetailLayout>,
+    );
+
+    const headerInset = screen.getByText('Header slot').closest(`.${PANE_RHYTHM.inset}`);
+
+    expect(headerInset?.className).toContain(PANE_RHYTHM.body);
+    expect(headerInset?.className).not.toContain('py-4');
+  });
+
   it('drops the rail and the scroll region for a full-bleed body', () => {
     render(
       <StudioDetailLayout
@@ -344,19 +357,23 @@ describe('RailBlock', () => {
 });
 
 describe('HeaderBand', () => {
-  it('renders meta chips, title, subtitle, and actions', () => {
+  it('renders title and actions before the meta chips and subtitle', () => {
     render(
       <HeaderBand
-        meta={<span>GB-42</span>}
         title="Improve detail layout"
+        meta={<span>GB-42</span>}
         subtitle={<span>api/items</span>}
         actions={<a href="https://example.com">Open</a>}
       />,
     );
 
-    expect(screen.getByText('GB-42')).toBeDefined();
-    expect(screen.getByRole('heading', { name: 'Improve detail layout' })).toBeDefined();
-    expect(screen.getByText('api/items')).toBeDefined();
-    expect(screen.getByRole('link', { name: 'Open' })).toBeDefined();
+    const title = screen.getByRole('heading', { level: 2, name: 'Improve detail layout' });
+    const meta = screen.getByText('GB-42');
+    const subtitle = screen.getByText('api/items');
+    const action = screen.getByRole('link', { name: 'Open' });
+
+    expect(title.parentElement?.contains(action)).toBe(true);
+    expect(title.compareDocumentPosition(meta) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(meta.compareDocumentPosition(subtitle) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 });

--- a/packages/ui/src/__tests__/HeaderBand.test.tsx
+++ b/packages/ui/src/__tests__/HeaderBand.test.tsx
@@ -1,0 +1,32 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { HeaderBand } from '../components/HeaderBand';
+
+afterEach(cleanup);
+
+describe('HeaderBand', () => {
+  it('renders the title and actions above the meta and subtitle', () => {
+    render(
+      <HeaderBand
+        title="Improve detail layout"
+        meta={<span>GB-42</span>}
+        subtitle={<span>api/items</span>}
+        actions={<a href="https://example.com">Open</a>}
+      />,
+    );
+
+    const title = screen.getByRole('heading', { level: 2, name: 'Improve detail layout' });
+    const meta = screen.getByText('GB-42');
+    const subtitle = screen.getByText('api/items');
+    const action = screen.getByRole('link', { name: 'Open' });
+
+    expect(title.className).toContain('text-xl');
+    expect(title.className).toContain('font-semibold');
+    expect(title.className).toContain('leading-snug');
+    expect(title.parentElement?.contains(action)).toBe(true);
+    expect(title.compareDocumentPosition(meta) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(meta.compareDocumentPosition(subtitle) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+});

--- a/packages/ui/src/components/HeaderBand.tsx
+++ b/packages/ui/src/components/HeaderBand.tsx
@@ -9,15 +9,17 @@ type Props = {
 
 export const HeaderBand = ({ meta, title, subtitle, actions }: Props) => {
   return (
-    <div className="flex items-start gap-4">
-      <div className="flex min-w-0 flex-1 flex-col gap-1.5">
-        <div className="flex flex-wrap items-center gap-2">{meta}</div>
-        <h2 className="text-lg font-semibold leading-snug text-foreground">{title}</h2>
-        {subtitle ?? null}
+    <div className="flex min-w-0 flex-col gap-1.5">
+      <div className="flex items-start gap-4">
+        <h2 className="min-w-0 flex-1 text-xl font-semibold leading-snug text-foreground">
+          {title}
+        </h2>
+        {actions != null ? (
+          <div className="flex shrink-0 items-center gap-2 pt-0.5">{actions}</div>
+        ) : null}
       </div>
-      {actions != null ? (
-        <div className="flex shrink-0 items-center gap-2 pt-0.5">{actions}</div>
-      ) : null}
+      <div className="flex flex-wrap items-center gap-2">{meta}</div>
+      {subtitle ?? null}
     </div>
   );
 };

--- a/packages/ui/src/paneRhythm.ts
+++ b/packages/ui/src/paneRhythm.ts
@@ -1,6 +1,6 @@
 export const PANE_RHYTHM = {
   inset: 'px-6',
-  header: 'px-6 py-4',
+  header: 'px-6 py-5',
   body: 'px-6 py-5',
   dock: 'px-6 py-4',
   stack: 'flex flex-col gap-5',


### PR DESCRIPTION
The shared HeaderBand rendered meta above the title with a smaller face and a tighter top inset than the overview, which made every subsection (agent, resolver, PR, integration issues, Slack threads) read lower and messier than the overview it sits next to. The primitive now renders title and actions first, meta chips below, subtitle last, at the overview's text-xl and 20px inset; the PANE_RHYTHM header token moves the whole shell family (studio detail, panels, focused strips) to the same inset so the pane-rhythm contract test keeps guarding one number. Review board's custom row and the focused plan header adopt the same structure. No chip or action was dropped, order only. Full desktop suite green (6509 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)