### PR TITLE
fix(ui): name the fan-out group after its children

### DIFF
--- a/apps/desktop/src/features/session/agent-kind.ts
+++ b/apps/desktop/src/features/session/agent-kind.ts
@@ -91,64 +91,80 @@ export const kindWritesFiles = (kind: AgentKind): boolean => {
 
 export const AGENT_KIND_META: Record<
   AgentKind,
-  { label: string; hint: string; persona: string; expectedOutput: string | null }
+  {
+    label: string;
+    pluralLabel: string;
+    hint: string;
+    persona: string;
+    expectedOutput: string | null;
+  }
 > = {
   generic: {
     label: 'Generalist',
+    pluralLabel: 'generalists',
     hint: 'Plans, investigates, edits, and verifies without a narrow role',
     persona: 'max',
     expectedOutput: null,
   },
   scout: {
     label: 'Scout',
+    pluralLabel: 'scouts',
     hint: 'Reads and searches codebase. Never edits files',
     persona: 'scout',
     expectedOutput: 'a findings summary carried forward',
   },
   planner: {
     label: 'Plan',
+    pluralLabel: 'planners',
     hint: 'Analyzes goals, produces a plan. No code, no edits',
     persona: 'drafty',
     expectedOutput: 'a plan artifact, ready to consume',
   },
   implementer: {
     label: 'Implement',
+    pluralLabel: 'implementers',
     hint: 'Writes code based on active plan. No re-planning',
     persona: 'hammer',
     expectedOutput: 'commits on the session branch',
   },
   debugger: {
     label: 'Debug',
+    pluralLabel: 'debuggers',
     hint: 'Reproduces and fixes bugs. No refactoring, no planning',
     persona: 'sherlock',
     expectedOutput: 'a diagnosis and the fix, committed',
   },
   tester: {
     label: 'Test',
+    pluralLabel: 'testers',
     hint: 'Writes tests. No production code changes',
     persona: 'beaker',
     expectedOutput: 'a test run outcome',
   },
   reviewer: {
     label: 'Review',
+    pluralLabel: 'reviewers',
     hint: 'Reviews diffs, suggests fixes. Read-only',
     persona: 'specs',
     expectedOutput: 'review findings',
   },
   'pr-reviewer': {
     label: 'PR reviewer',
+    pluralLabel: 'PR reviewers',
     hint: 'Reviews an external pull request checked out locally. Read-only',
     persona: 'monocle',
     expectedOutput: 'a verdict per review thread',
   },
   docs: {
     label: 'Docs',
+    pluralLabel: 'docs',
     hint: 'Writes documentation. No production logic',
     persona: 'scribble',
     expectedOutput: 'documentation changes, committed',
   },
   resolver: {
     label: 'Resolve',
+    pluralLabel: 'resolvers',
     hint: 'Addresses one comment with a local commit. Spawned by the resolve UI',
     persona: 'patches',
     expectedOutput: 'one local commit answering the comment',

--- a/apps/desktop/src/features/session/components/AgentMetrics/index.tsx
+++ b/apps/desktop/src/features/session/components/AgentMetrics/index.tsx
@@ -25,6 +25,8 @@ type Props = {
   readonly contextUsage: ReadonlyArray<ProviderContextUsage>;
   readonly turns: number;
   readonly turnsLoading: boolean;
+  readonly delegatedChildCount?: number;
+  readonly activeDelegatedChildCount?: number;
   readonly density: 'compact' | 'full' | 'lane';
   readonly plannedModel?: string | null;
   readonly plannedProvider?: ProviderId | null;
@@ -38,6 +40,8 @@ export const AgentMetrics = ({
   contextUsage,
   turns,
   turnsLoading,
+  delegatedChildCount = 0,
+  activeDelegatedChildCount = 0,
   density,
   plannedModel = null,
   plannedProvider = null,
@@ -71,14 +75,16 @@ export const AgentMetrics = ({
             !isLane && 'flex-nowrap whitespace-nowrap',
           )}
           items={[
-            <RoutingBadge
-              key="model"
-              provider={provider ?? null}
-              model={model ?? null}
-              planned={planned}
-              muted={muted}
-              missingLabel="no model yet"
-            />,
+            model != null || delegatedChildCount === 0 ? (
+              <RoutingBadge
+                key="model"
+                provider={provider ?? null}
+                model={model ?? null}
+                planned={planned}
+                muted={muted}
+                missingLabel="no model yet"
+              />
+            ) : null,
             <CostBadge
               key="cost"
               value={aggregate?.estimatedCostUsd ?? 0}
@@ -114,7 +120,14 @@ export const AgentMetrics = ({
               </span>
             ),
             isLane && run.startedAt != null ? <AgentDuration key="duration" run={run} /> : null,
-            isLane ? <AgentLastUpdate key="updated" agent={run} /> : null,
+            isLane ? (
+              <AgentLastUpdate
+                key="updated"
+                agent={run}
+                delegatedChildCount={delegatedChildCount}
+                activeDelegatedChildCount={activeDelegatedChildCount}
+              />
+            ) : null,
           ]}
         />
       </div>

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AdHocRow.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AdHocRow.test.tsx
@@ -1,0 +1,106 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import type { Agent, AgentId, SessionId } from '@goodboy/types';
+
+vi.mock('../../../../../store', () => {
+  const useAppStore = Object.assign(() => undefined, {
+    getState: () => ({ markAgentSeen: vi.fn(async () => undefined) }),
+  });
+  return {
+    EMPTY_ARRAY: [] satisfies never[],
+    agentHasUnread: () => false,
+    useAppStore,
+  };
+});
+
+import { AdHocRow } from './AdHocRow';
+
+const SESSION_ID = 'session-1' as SessionId;
+const PARENT_ID = 'parent-1' as AgentId;
+
+type RenderRowParams = {
+  readonly children?: ReadonlyArray<Agent>;
+};
+
+type BuildAgentParams = {
+  readonly id: AgentId;
+  readonly status: Agent['status'];
+};
+
+const buildAgent = ({ id, status }: BuildAgentParams): Agent => ({
+  id,
+  sessionId: SESSION_ID,
+  ordinal: 0,
+  name: id,
+  status,
+  kind: 'implementer',
+});
+
+const renderRow = ({ children = [] }: RenderRowParams = {}) => {
+  const childrenByParentId = new Map<string, Agent[]>();
+  if (children.length > 0) {
+    childrenByParentId.set(PARENT_ID, [...children]);
+  }
+  return render(
+    <ul>
+      <AdHocRow
+        run={buildAgent({ id: PARENT_ID, status: 'running' })}
+        firstUserTextByAgentId={new Map()}
+        agentKindOverride={{}}
+        childrenByParentId={childrenByParentId}
+        latestTelemetryByAgentId={new Map()}
+        aggregatesByAgentId={new Map()}
+        providerUsageByAgentId={new Map()}
+        turnsByAgentId={new Map()}
+        selectedAgentId={null}
+        isTranscriptLoading={false}
+        isTaskActive
+        editingId={null}
+        setEditingId={vi.fn()}
+        clusterExpand={new Map()}
+        toggleClusterExpand={vi.fn()}
+        onPickAgent={vi.fn()}
+        onRenameCommit={vi.fn(async () => undefined)}
+        onDeleteAgent={vi.fn(async () => undefined)}
+        onMarkDone={vi.fn()}
+      />
+    </ul>,
+  );
+};
+
+afterEach(cleanup);
+
+describe('AdHocRow delegation state', () => {
+  it('shows active delegated children and hides the missing model fallback', () => {
+    renderRow({
+      children: [
+        buildAgent({ id: 'child-1' as AgentId, status: 'pending' }),
+        buildAgent({ id: 'child-2' as AgentId, status: 'running' }),
+        buildAgent({ id: 'child-3' as AgentId, status: 'completed' }),
+      ],
+    });
+
+    expect(screen.getByText('delegated · 2/3 running')).toBeDefined();
+    expect(screen.queryByText('no model yet')).toBeNull();
+  });
+
+  it('shows delegated done when every child is terminal', () => {
+    renderRow({
+      children: [
+        buildAgent({ id: 'child-1' as AgentId, status: 'completed' }),
+        buildAgent({ id: 'child-2' as AgentId, status: 'failed' }),
+      ],
+    });
+
+    expect(screen.getByText('delegated · done')).toBeDefined();
+  });
+
+  it('keeps not started and the missing model fallback for a childless parent', () => {
+    renderRow();
+
+    expect(screen.getByText('not started')).toBeDefined();
+    expect(screen.getByText('no model yet')).toBeDefined();
+  });
+});

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AdHocRow.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AdHocRow.tsx
@@ -67,6 +67,9 @@ export const AdHocRow = ({
     agentKindOverride[run.id] ?? null,
   );
   const scoutChildren = childrenByParentId.get(run.id) ?? EMPTY_ARRAY;
+  const activeDelegatedChildCount = scoutChildren.filter(
+    (child) => child.status === 'pending' || child.status === 'running',
+  ).length;
   return (
     <Fragment key={run.id}>
       <AgentRow
@@ -77,6 +80,8 @@ export const AdHocRow = ({
         contextUsage={providerUsageByAgentId.get(run.id) ?? EMPTY_ARRAY}
         turns={turnsByAgentId.get(run.id) ?? 0}
         turnsLoading={run.id === selectedAgentId && isTranscriptLoading}
+        delegatedChildCount={scoutChildren.length}
+        activeDelegatedChildCount={activeDelegatedChildCount}
         isSelected={run.id === selectedAgentId}
         isTaskActive={isTaskActive}
         isEditing={editingId === run.id}

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentRow.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentRow.tsx
@@ -29,6 +29,8 @@ type Props = {
   readonly contextUsage: ReadonlyArray<ProviderContextUsage>;
   readonly turns: number;
   readonly turnsLoading: boolean;
+  readonly delegatedChildCount?: number;
+  readonly activeDelegatedChildCount?: number;
   readonly isSelected: boolean;
   readonly isTaskActive: boolean;
   readonly isEditing: boolean;
@@ -53,6 +55,8 @@ export const AgentRow = ({
   contextUsage,
   turns,
   turnsLoading,
+  delegatedChildCount = 0,
+  activeDelegatedChildCount = 0,
   isSelected,
   isTaskActive,
   isEditing,
@@ -199,6 +203,8 @@ export const AgentRow = ({
           contextUsage={contextUsage}
           turns={turns}
           turnsLoading={turnsLoading}
+          delegatedChildCount={delegatedChildCount}
+          activeDelegatedChildCount={activeDelegatedChildCount}
           density="lane"
         />
       }

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/ScoutSubtree.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/ScoutSubtree.test.tsx
@@ -191,4 +191,38 @@ describe('ScoutSubtree unread badge', () => {
     expect(container.querySelector('.ml-3')).not.toBeNull();
     expect(container.querySelector('.border-l')).not.toBeNull();
   });
+
+  it('labels a group of implementer children as implementers', () => {
+    const map = new Map<string, Agent[]>([
+      [
+        CONTAINER,
+        [
+          buildAgent({ id: 'i1' as AgentId, kind: 'implementer' }),
+          buildAgent({ id: 'i2' as AgentId, kind: 'implementer', status: 'running' }),
+        ],
+      ],
+    ]);
+    renderTree(map);
+
+    expect(screen.getByRole('button', { name: 'expand implementers' }).textContent).toContain(
+      'implementers 1/2',
+    );
+  });
+
+  it('labels a mixed-kind group as agents', () => {
+    const map = new Map<string, Agent[]>([
+      [
+        CONTAINER,
+        [
+          buildAgent({ id: 's1' as AgentId, kind: 'scout' }),
+          buildAgent({ id: 'i1' as AgentId, kind: 'implementer' }),
+        ],
+      ],
+    ]);
+    renderTree(map);
+
+    expect(screen.getByRole('button', { name: 'expand agents' }).textContent).toContain(
+      'agents 2/2',
+    );
+  });
 });

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/ScoutSubtree.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/ScoutSubtree.tsx
@@ -2,6 +2,7 @@ import { Fragment, type ReactNode } from 'react';
 import { ChevronDown, ChevronRight } from 'lucide-react';
 import type { Agent, AgentId } from '@goodboy/types';
 import { EMPTY_ARRAY, agentHasUnread } from '../../../../../store';
+import { AGENT_KIND_META, classifyAgent } from '../../../../../features/session/agent-kind';
 import type { AgentAggregate } from '../../../../../features/session/components/AgentMetrics';
 import { ClusterChildRow } from './ClusterChildRow';
 
@@ -36,6 +37,9 @@ export const ScoutSubtree = ({
   const doneCount = children.filter(
     (c) => c.status === 'completed' || c.status === 'skipped',
   ).length;
+  const childKinds = new Set(children.map((child) => classifyAgent(child, null)));
+  const childKind = childKinds.size === 1 ? childKinds.values().next().value : undefined;
+  const groupLabel = childKind === undefined ? 'agents' : AGENT_KIND_META[childKind].pluralLabel;
   const unreadCount = (() => {
     let n = 0;
     const visit = (id: AgentId) => {
@@ -55,7 +59,7 @@ export const ScoutSubtree = ({
         type="button"
         onClick={() => onToggle(containerId)}
         aria-expanded={expanded}
-        aria-label={`${expanded ? 'collapse' : 'expand'} scouts`}
+        aria-label={`${expanded ? 'collapse' : 'expand'} ${groupLabel}`}
         className="flex items-center gap-1 px-2 py-0.5 text-2xs uppercase tracking-wide text-info/70 transition-colors hover:text-info"
       >
         {expanded ? (
@@ -63,7 +67,7 @@ export const ScoutSubtree = ({
         ) : (
           <ChevronRight size={10} aria-hidden className="shrink-0" />
         )}
-        scouts {doneCount}/{children.length}
+        {groupLabel} {doneCount}/{children.length}
         {!expanded && unreadCount > 0 ? (
           <span
             className="inline-flex shrink-0 items-center gap-1 rounded bg-warning/15 px-1 py-0.5 text-3xs font-medium text-warning"

--- a/apps/desktop/src/shared/components/AgentLastUpdate/index.tsx
+++ b/apps/desktop/src/shared/components/AgentLastUpdate/index.tsx
@@ -5,12 +5,27 @@ import { formatRelativeAge } from '../../utils/relativeDate';
 
 type Props = {
   readonly agent: Agent;
+  readonly delegatedChildCount?: number;
+  readonly activeDelegatedChildCount?: number;
 };
 
-export const AgentLastUpdate = ({ agent }: Props) => {
+export const AgentLastUpdate = ({
+  agent,
+  delegatedChildCount = 0,
+  activeDelegatedChildCount = 0,
+}: Props) => {
   const lastUpdate = agentLastUpdate({ agent });
   const nowMs = useNow(60_000, lastUpdate !== null);
   if (lastUpdate === null) {
+    if (delegatedChildCount > 0) {
+      const delegatedState =
+        activeDelegatedChildCount > 0
+          ? `${activeDelegatedChildCount}/${delegatedChildCount} running`
+          : 'done';
+      return (
+        <span className="text-2xs text-muted-foreground/60">delegated · {delegatedState}</span>
+      );
+    }
     return <span className="text-2xs text-muted-foreground/60">not started</span>;
   }
   return (


### PR DESCRIPTION
The fan-out subtree header was hardcoded to "scouts n/m" even when an implement agent split into implementation slices; it now derives its label from the direct children's kind (implementers, scouts, agents when mixed). A delegating parent with no own timestamps used to read "not started - no model yet" while its children ran: it now says "delegated · n/m running" (or "delegated · done") and hides the routing fallback, keeping the aggregated cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)