### PR TITLE
feat(ui): surface every manifest script grouped per package

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -20,6 +20,7 @@ mod path_env;
 mod permissions;
 mod planner;
 mod profile_file;
+mod project_scripts;
 mod provider_credentials;
 mod provider_lifecycle;
 mod providers;
@@ -297,7 +298,9 @@ pub fn run() {
             skills::skill_delete,
             skills::skill_rescan,
             skills::skill_run_script,
+            project_scripts::project_scripts_scan,
             scripts::workspace_script_run,
+            scripts::workspace_script_run_adhoc,
             scripts::workspace_script_list_live,
             scripts::workspace_script_cancel,
             terminal::terminal_open,

--- a/apps/desktop/src-tauri/src/project_scripts.rs
+++ b/apps/desktop/src-tauri/src/project_scripts.rs
@@ -1,0 +1,511 @@
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+
+use serde::Serialize;
+use serde_json::Value;
+
+const MAX_PACKAGES: usize = 50;
+const EXCLUDED_DIRS: [&str; 3] = ["node_modules", ".git", "vendor"];
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ScriptSource {
+    PackageJson,
+    Composer,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DiscoveredScript {
+    name: String,
+    command: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScriptGroup {
+    source: ScriptSource,
+    package_name: String,
+    rel_dir: String,
+    manager: String,
+    scripts: Vec<DiscoveredScript>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ScriptScanError {
+    #[error("io error: {0}")]
+    Io(String),
+}
+
+crate::util::impl_error_serialize!(ScriptScanError);
+
+impl ScriptScanError {
+    fn kind(&self) -> &'static str {
+        match self {
+            ScriptScanError::Io(_) => "io",
+        }
+    }
+}
+
+fn fallback_package_name(path: &Path) -> String {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .unwrap_or("package")
+        .to_string()
+}
+
+fn package_scripts(value: &Value, manager: &str) -> Vec<DiscoveredScript> {
+    let Some(scripts) = value.get("scripts").and_then(Value::as_object) else {
+        return Vec::new();
+    };
+    scripts
+        .keys()
+        .map(|name| DiscoveredScript {
+            name: name.clone(),
+            command: format!("{manager} run {name}"),
+        })
+        .collect()
+}
+
+fn composer_scripts(value: &Value) -> Vec<DiscoveredScript> {
+    let Some(scripts) = value.get("scripts").and_then(Value::as_object) else {
+        return Vec::new();
+    };
+    scripts
+        .keys()
+        .map(|name| DiscoveredScript {
+            name: name.clone(),
+            command: format!("composer run-script {name}"),
+        })
+        .collect()
+}
+
+fn read_json(path: &Path) -> Option<Value> {
+    let content = fs::read_to_string(path).ok()?;
+    serde_json::from_str(&content).ok()
+}
+
+fn workspace_patterns(value: &Value) -> Vec<String> {
+    let Some(workspaces) = value.get("workspaces") else {
+        return Vec::new();
+    };
+    let values = match workspaces {
+        Value::Array(values) => Some(values),
+        Value::Object(object) => object.get("packages").and_then(Value::as_array),
+        _ => None,
+    };
+    values
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .map(str::to_string)
+        .collect()
+}
+
+fn clean_yaml_value(value: &str) -> Option<String> {
+    let without_comment = value.split('#').next().unwrap_or("").trim();
+    let cleaned = without_comment
+        .trim_end_matches(',')
+        .trim()
+        .trim_matches(|character| character == '\'' || character == '"')
+        .trim();
+    if cleaned.is_empty() {
+        return None;
+    }
+    Some(cleaned.to_string())
+}
+
+fn pnpm_workspace_patterns(root: &Path) -> Vec<String> {
+    let Ok(content) = fs::read_to_string(root.join("pnpm-workspace.yaml")) else {
+        return Vec::new();
+    };
+    let mut patterns = Vec::new();
+    let mut is_packages = false;
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("packages:") {
+            is_packages = true;
+            let inline = trimmed.trim_start_matches("packages:").trim();
+            if inline.starts_with('[') && inline.ends_with(']') {
+                patterns.extend(
+                    inline[1..inline.len() - 1]
+                        .split(',')
+                        .filter_map(clean_yaml_value),
+                );
+            }
+            continue;
+        }
+        if !is_packages {
+            continue;
+        }
+        if !line.starts_with(char::is_whitespace) && !trimmed.is_empty() {
+            break;
+        }
+        let Some(value) = trimmed.strip_prefix('-') else {
+            continue;
+        };
+        if let Some(pattern) = clean_yaml_value(value) {
+            patterns.push(pattern);
+        }
+    }
+    patterns
+}
+
+fn normalized_relative_path(value: &str) -> Option<PathBuf> {
+    let path = Path::new(value.trim().trim_end_matches('/'));
+    if path.as_os_str().is_empty() {
+        return None;
+    }
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Normal(segment) => {
+                let segment = segment.to_str()?;
+                if EXCLUDED_DIRS.contains(&segment) {
+                    return None;
+                }
+                normalized.push(segment);
+            }
+            Component::CurDir => {}
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => return None,
+        }
+    }
+    Some(normalized)
+}
+
+fn relative_display(path: &Path) -> String {
+    path.components()
+        .filter_map(|component| match component {
+            Component::Normal(segment) => segment.to_str().map(str::to_string),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+fn add_candidate(root: &Path, relative: &Path, candidates: &mut BTreeSet<String>) {
+    if candidates.len() >= MAX_PACKAGES.saturating_sub(1) {
+        return;
+    }
+    let candidate = root.join(relative);
+    let Ok(canonical) = candidate.canonicalize() else {
+        return;
+    };
+    if !canonical.starts_with(root) || !canonical.join("package.json").is_file() {
+        return;
+    }
+    candidates.insert(relative_display(relative));
+}
+
+fn expand_pattern(root: &Path, pattern: &str, candidates: &mut BTreeSet<String>) {
+    if candidates.len() >= MAX_PACKAGES.saturating_sub(1) {
+        return;
+    }
+    if let Some(base) = pattern.strip_suffix("/*") {
+        let Some(base_path) = normalized_relative_path(base) else {
+            return;
+        };
+        let Ok(entries) = fs::read_dir(root.join(&base_path)) else {
+            return;
+        };
+        let mut children = entries.flatten().collect::<Vec<_>>();
+        children.sort_by_key(|entry| entry.file_name());
+        for entry in children {
+            if candidates.len() >= MAX_PACKAGES.saturating_sub(1) {
+                break;
+            }
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if !file_type.is_dir() {
+                continue;
+            }
+            let Some(name) = entry.file_name().to_str().map(str::to_string) else {
+                continue;
+            };
+            if EXCLUDED_DIRS.contains(&name.as_str()) {
+                continue;
+            }
+            add_candidate(root, &base_path.join(name), candidates);
+        }
+        return;
+    }
+    if pattern.contains('*') {
+        return;
+    }
+    let Some(relative) = normalized_relative_path(pattern) else {
+        return;
+    };
+    add_candidate(root, &relative, candidates);
+}
+
+fn detect_manager(root: &Path) -> &'static str {
+    if root.join("pnpm-lock.yaml").is_file() {
+        return "pnpm";
+    }
+    if root.join("yarn.lock").is_file() {
+        return "yarn";
+    }
+    if root.join("bun.lockb").is_file() || root.join("bun.lock").is_file() {
+        return "bun";
+    }
+    "npm"
+}
+
+fn package_group(path: &Path, rel_dir: &str, manager: &str) -> Option<ScriptGroup> {
+    let value = read_json(&path.join("package.json"))?;
+    let scripts = package_scripts(&value, manager);
+    if scripts.is_empty() {
+        return None;
+    }
+    let package_name = value
+        .get("name")
+        .and_then(Value::as_str)
+        .filter(|name| !name.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| fallback_package_name(path));
+    Some(ScriptGroup {
+        source: ScriptSource::PackageJson,
+        package_name,
+        rel_dir: rel_dir.to_string(),
+        manager: manager.to_string(),
+        scripts,
+    })
+}
+
+fn scan(root: &Path) -> Result<Vec<ScriptGroup>, ScriptScanError> {
+    let root = root
+        .canonicalize()
+        .map_err(|error| ScriptScanError::Io(error.to_string()))?;
+    let manager = detect_manager(&root);
+    let root_manifest = read_json(&root.join("package.json"));
+    let mut patterns = root_manifest
+        .as_ref()
+        .map(workspace_patterns)
+        .unwrap_or_default();
+    patterns.extend(pnpm_workspace_patterns(&root));
+    let mut candidates = BTreeSet::new();
+    for pattern in patterns {
+        expand_pattern(&root, &pattern, &mut candidates);
+    }
+
+    let mut groups = Vec::new();
+    if let Some(group) = package_group(&root, "", manager) {
+        groups.push(group);
+    }
+    for rel_dir in candidates.into_iter().take(MAX_PACKAGES.saturating_sub(1)) {
+        if let Some(group) = package_group(&root.join(&rel_dir), &rel_dir, manager) {
+            groups.push(group);
+        }
+    }
+    if let Some(value) = read_json(&root.join("composer.json")) {
+        let scripts = composer_scripts(&value);
+        if !scripts.is_empty() {
+            let package_name = value
+                .get("name")
+                .and_then(Value::as_str)
+                .filter(|name| !name.is_empty())
+                .map(str::to_string)
+                .unwrap_or_else(|| fallback_package_name(&root));
+            groups.push(ScriptGroup {
+                source: ScriptSource::Composer,
+                package_name,
+                rel_dir: String::new(),
+                manager: "composer".to_string(),
+                scripts,
+            });
+        }
+    }
+    Ok(groups)
+}
+
+#[tauri::command]
+pub async fn project_scripts_scan(
+    worktree_path: String,
+) -> Result<Vec<ScriptGroup>, ScriptScanError> {
+    tauri::async_runtime::spawn_blocking(move || scan(Path::new(&worktree_path)))
+        .await
+        .map_err(|error| ScriptScanError::Io(error.to_string()))?
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    use super::*;
+
+    static NEXT_DIR: AtomicU64 = AtomicU64::new(0);
+
+    struct TestDir(PathBuf);
+
+    impl TestDir {
+        fn new(name: &str) -> Self {
+            let ordinal = NEXT_DIR.fetch_add(1, Ordering::Relaxed);
+            let path = std::env::temp_dir().join(format!(
+                "goodboy-project-scripts-{}-{}-{}",
+                std::process::id(),
+                ordinal,
+                name
+            ));
+            fs::create_dir_all(&path).unwrap();
+            Self(path)
+        }
+
+        fn write(&self, relative: &str, content: &str) {
+            let path = self.0.join(relative);
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent).unwrap();
+            }
+            fs::write(path, content).unwrap();
+        }
+    }
+
+    impl Drop for TestDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn scans_plain_package() {
+        let dir = TestDir::new("plain");
+        dir.write(
+            "package.json",
+            r#"{"name":"plain-app","scripts":{"build":"vite build","dev":"vite"}}"#,
+        );
+
+        let groups = scan(&dir.0).unwrap();
+
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].package_name, "plain-app");
+        assert_eq!(groups[0].rel_dir, "");
+        assert_eq!(groups[0].manager, "npm");
+        assert_eq!(groups[0].scripts[0].command, "npm run build");
+    }
+
+    #[test]
+    fn scans_pnpm_monorepo_globs() {
+        let dir = TestDir::new("pnpm");
+        dir.write(
+            "package.json",
+            r#"{"name":"root","scripts":{"dev":"vite"}}"#,
+        );
+        dir.write("pnpm-lock.yaml", "lockfileVersion: '9.0'");
+        dir.write("pnpm-workspace.yaml", "packages:\n  - 'packages/*'\n");
+        dir.write(
+            "packages/api/package.json",
+            r#"{"name":"api","scripts":{"test":"vitest"}}"#,
+        );
+        dir.write(
+            "packages/web/package.json",
+            r#"{"name":"web","scripts":{"build":"vite build"}}"#,
+        );
+
+        let groups = scan(&dir.0).unwrap();
+
+        assert_eq!(groups.len(), 3);
+        assert_eq!(groups[1].rel_dir, "packages/api");
+        assert_eq!(groups[2].rel_dir, "packages/web");
+        assert!(groups.iter().all(|group| group.manager == "pnpm"));
+    }
+
+    #[test]
+    fn scans_package_workspaces_array_and_explicit_paths() {
+        let dir = TestDir::new("workspaces");
+        dir.write(
+            "package.json",
+            r#"{"workspaces":["apps/*","tools/cli"],"scripts":{"root":"true"}}"#,
+        );
+        dir.write("apps/site/package.json", r#"{"scripts":{"dev":"vite"}}"#);
+        dir.write(
+            "tools/cli/package.json",
+            r#"{"name":"cli","scripts":{"check":"cargo check"}}"#,
+        );
+
+        let groups = scan(&dir.0).unwrap();
+
+        assert_eq!(groups.len(), 3);
+        assert_eq!(groups[1].package_name, "site");
+        assert_eq!(groups[2].package_name, "cli");
+    }
+
+    #[test]
+    fn scans_composer_scripts_last() {
+        let dir = TestDir::new("composer");
+        dir.write(
+            "package.json",
+            r#"{"name":"web","scripts":{"build":"vite build"}}"#,
+        );
+        dir.write(
+            "composer.json",
+            r#"{"name":"acme/server","scripts":{"post-install-cmd":"@php artisan","test":"phpunit"}}"#,
+        );
+
+        let groups = scan(&dir.0).unwrap();
+
+        assert_eq!(groups.len(), 2);
+        assert_eq!(groups[1].source, ScriptSource::Composer);
+        assert_eq!(groups[1].scripts.len(), 2);
+        assert_eq!(groups[1].scripts[1].command, "composer run-script test");
+    }
+
+    #[test]
+    fn skips_malformed_manifests() {
+        let dir = TestDir::new("malformed");
+        dir.write(
+            "package.json",
+            r#"{"workspaces":["packages/*"],"scripts":{"root":"true"}}"#,
+        );
+        dir.write("packages/bad/package.json", "{");
+        dir.write(
+            "packages/good/package.json",
+            r#"{"name":"good","scripts":{"test":"vitest"}}"#,
+        );
+
+        let groups = scan(&dir.0).unwrap();
+
+        assert_eq!(groups.len(), 2);
+        assert_eq!(groups[1].package_name, "good");
+    }
+
+    #[test]
+    fn excludes_dependency_directories() {
+        let dir = TestDir::new("excluded");
+        dir.write(
+            "package.json",
+            r#"{"workspaces":["node_modules/*","vendor/*","packages/*"],"scripts":{"root":"true"}}"#,
+        );
+        dir.write(
+            "node_modules/dependency/package.json",
+            r#"{"name":"dependency","scripts":{"postinstall":"bad"}}"#,
+        );
+        dir.write(
+            "vendor/dependency/package.json",
+            r#"{"name":"vendor-dependency","scripts":{"test":"bad"}}"#,
+        );
+        dir.write(
+            "packages/app/package.json",
+            r#"{"name":"app","scripts":{"test":"vitest"}}"#,
+        );
+
+        let groups = scan(&dir.0).unwrap();
+
+        assert_eq!(groups.len(), 2);
+        assert_eq!(groups[1].package_name, "app");
+    }
+
+    #[test]
+    fn detects_yarn_and_bun_managers() {
+        let yarn = TestDir::new("yarn");
+        yarn.write("package.json", r#"{"scripts":{"test":"vitest"}}"#);
+        yarn.write("yarn.lock", "");
+        let bun = TestDir::new("bun");
+        bun.write("package.json", r#"{"scripts":{"test":"bun test"}}"#);
+        bun.write("bun.lock", "");
+
+        assert_eq!(scan(&yarn.0).unwrap()[0].manager, "yarn");
+        assert_eq!(scan(&bun.0).unwrap()[0].manager, "bun");
+    }
+}

--- a/apps/desktop/src-tauri/src/scripts.rs
+++ b/apps/desktop/src-tauri/src/scripts.rs
@@ -53,6 +53,7 @@ struct ScriptSlot {
 pub struct LiveScriptRun {
     run_id: String,
     script_id: String,
+    name: String,
     session_id: String,
     started_at: u64,
 }
@@ -148,6 +149,139 @@ fn build_script_command(body: &str, cwd: &str, login_env: &[(String, String)]) -
     cmd
 }
 
+struct ScriptSpawnRequest {
+    app: AppHandle,
+    registry: Arc<Mutex<HashMap<String, ScriptSlot>>>,
+    script_id: String,
+    name: String,
+    body: String,
+    run_id: String,
+    session_id: String,
+    cwd: String,
+    cols: u16,
+    rows: u16,
+}
+
+fn spawn_script(request: ScriptSpawnRequest) -> Result<(), ScriptError> {
+    let pty_system = native_pty_system();
+    let pair = pty_system
+        .openpty(PtySize {
+            rows: request.rows,
+            cols: request.cols,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .map_err(|error| ScriptError::Io(error.to_string()))?;
+
+    let cmd = build_script_command(&request.body, &request.cwd, crate::path_env::resolved_env());
+    let child = pair
+        .slave
+        .spawn_command(cmd)
+        .map_err(|error| ScriptError::Io(error.to_string()))?;
+    drop(pair.slave);
+
+    let reader = pair
+        .master
+        .try_clone_reader()
+        .map_err(|error| ScriptError::Io(error.to_string()))?;
+    let writer = pair
+        .master
+        .take_writer()
+        .map_err(|error| ScriptError::Io(error.to_string()))?;
+    let slot: PtySlot = Arc::new(Mutex::new(Some(PtyRun {
+        _writer: writer,
+        _master: pair.master,
+        child,
+    })));
+    let started_at = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|error| ScriptError::Io(error.to_string()))?
+        .as_millis() as u64;
+    let metadata = LiveScriptRun {
+        run_id: request.run_id.clone(),
+        script_id: request.script_id,
+        name: request.name,
+        session_id: request.session_id,
+        started_at,
+    };
+
+    request
+        .registry
+        .lock()
+        .map_err(|_| ScriptError::Poisoned)?
+        .insert(
+            request.run_id.clone(),
+            ScriptSlot {
+                run: Arc::clone(&slot),
+                metadata,
+            },
+        );
+
+    let run_id = request.run_id;
+    let app = request.app;
+    let registry = request.registry;
+    thread::spawn(move || {
+        let mut reader = reader;
+        let mut buf = [0u8; 4096];
+        loop {
+            match reader.read(&mut buf) {
+                Ok(0) | Err(_) => break,
+                Ok(count) => {
+                    let encoded = STANDARD.encode(&buf[..count]);
+                    let _ = app.emit(
+                        "script-output",
+                        ScriptOutputPayload {
+                            run_id: run_id.clone(),
+                            data: encoded,
+                        },
+                    );
+                }
+            }
+        }
+
+        let exit_code = {
+            let slot = {
+                let guard = registry.lock().ok();
+                guard
+                    .as_ref()
+                    .and_then(|map| map.get(&run_id).map(|entry| Arc::clone(&entry.run)))
+            };
+            if let Some(slot) = slot {
+                let mut guard = slot.lock().unwrap_or_else(|error| error.into_inner());
+                guard
+                    .as_mut()
+                    .and_then(|run| run.child.wait().ok())
+                    .map(|status| match status.success() {
+                        true => 0_i32,
+                        false => 1_i32,
+                    })
+                    .unwrap_or(-1)
+            } else {
+                -1
+            }
+        };
+
+        let _ = app.emit(
+            "script-exit",
+            ScriptExitPayload {
+                run_id: run_id.clone(),
+                exit_code,
+            },
+        );
+        if let Ok(mut map) = registry.lock() {
+            map.remove(&run_id);
+        }
+    });
+
+    Ok(())
+}
+
+async fn spawn_script_blocking(request: ScriptSpawnRequest) -> Result<(), ScriptError> {
+    tauri::async_runtime::spawn_blocking(move || spawn_script(request))
+        .await
+        .map_err(|error| ScriptError::Io(error.to_string()))?
+}
+
 /// Spawns `bash -c <body>` inside a pty, registers the run under `run_id`, and
 /// returns immediately. Output is streamed as `script-output` events (base64
 /// chunks). A `script-exit` event fires when the process exits or is killed.
@@ -163,132 +297,58 @@ pub async fn workspace_script_run(
     cols: u16,
     rows: u16,
 ) -> Result<(), ScriptError> {
-    let body = {
+    let (name, body) = {
         let conn = state.0.lock().map_err(|_| ScriptError::Poisoned)?;
         conn.query_row(
-            "SELECT body FROM project_scripts WHERE id = ?1 LIMIT 1",
+            "SELECT name, body FROM project_scripts WHERE id = ?1 LIMIT 1",
             rusqlite::params![script_id],
-            |row| row.get::<_, String>(0),
+            |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
         )
         .map_err(|_| ScriptError::NotFound(script_id.clone()))?
     };
-
-    let registry_arc = Arc::clone(&registry.0);
-
-    tauri::async_runtime::spawn_blocking(move || {
-        let pty_system = native_pty_system();
-        let pair = pty_system
-            .openpty(PtySize {
-                rows,
-                cols,
-                pixel_width: 0,
-                pixel_height: 0,
-            })
-            .map_err(|e| ScriptError::Io(e.to_string()))?;
-
-        let cmd = build_script_command(&body, &cwd, crate::path_env::resolved_env());
-
-        let child = pair
-            .slave
-            .spawn_command(cmd)
-            .map_err(|e| ScriptError::Io(e.to_string()))?;
-        drop(pair.slave);
-
-        let reader = pair
-            .master
-            .try_clone_reader()
-            .map_err(|e| ScriptError::Io(e.to_string()))?;
-        let writer = pair
-            .master
-            .take_writer()
-            .map_err(|e| ScriptError::Io(e.to_string()))?;
-
-        let slot: PtySlot = Arc::new(Mutex::new(Some(PtyRun {
-            _writer: writer,
-            _master: pair.master,
-            child,
-        })));
-
-        let started_at = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map_err(|e| ScriptError::Io(e.to_string()))?
-            .as_millis() as u64;
-        let metadata = LiveScriptRun {
-            run_id: run_id.clone(),
-            script_id: script_id.clone(),
-            session_id,
-            started_at,
-        };
-
-        registry_arc
-            .lock()
-            .map_err(|_| ScriptError::Poisoned)?
-            .insert(
-                run_id.clone(),
-                ScriptSlot {
-                    run: Arc::clone(&slot),
-                    metadata,
-                },
-            );
-
-        let run_id_r = run_id.clone();
-        let app_r = app.clone();
-        let registry_r = Arc::clone(&registry_arc);
-
-        thread::spawn(move || {
-            let mut reader = reader;
-            let mut buf = [0u8; 4096];
-            loop {
-                match reader.read(&mut buf) {
-                    Ok(0) | Err(_) => break,
-                    Ok(n) => {
-                        let encoded = STANDARD.encode(&buf[..n]);
-                        let _ = app_r.emit(
-                            "script-output",
-                            ScriptOutputPayload {
-                                run_id: run_id_r.clone(),
-                                data: encoded,
-                            },
-                        );
-                    }
-                }
-            }
-
-            let exit_code = {
-                let slot = {
-                    let guard = registry_r.lock().ok();
-                    guard
-                        .as_ref()
-                        .and_then(|m| m.get(&run_id_r).map(|slot| Arc::clone(&slot.run)))
-                };
-                if let Some(slot) = slot {
-                    let mut g = slot.lock().unwrap_or_else(|e| e.into_inner());
-                    g.as_mut()
-                        .and_then(|r| r.child.wait().ok())
-                        .map(|s| if s.success() { 0_i32 } else { 1_i32 })
-                        .unwrap_or(-1)
-                } else {
-                    -1
-                }
-            };
-
-            let _ = app_r.emit(
-                "script-exit",
-                ScriptExitPayload {
-                    run_id: run_id_r.clone(),
-                    exit_code,
-                },
-            );
-
-            if let Ok(mut map) = registry_r.lock() {
-                map.remove(&run_id_r);
-            }
-        });
-
-        Ok(())
+    spawn_script_blocking(ScriptSpawnRequest {
+        app,
+        registry: Arc::clone(&registry.0),
+        script_id,
+        name,
+        body,
+        run_id,
+        session_id,
+        cwd,
+        cols,
+        rows,
     })
     .await
-    .map_err(|e| ScriptError::Io(e.to_string()))?
+}
+
+#[tauri::command]
+pub async fn workspace_script_run_adhoc(
+    app: AppHandle,
+    registry: State<'_, ScriptRegistry>,
+    script_id: String,
+    name: String,
+    body: String,
+    run_id: Option<String>,
+    session_id: String,
+    cwd: String,
+    cols: u16,
+    rows: u16,
+) -> Result<String, ScriptError> {
+    let run_id = run_id.unwrap_or_else(|| format!("adhoc-{:032x}", rand::random::<u128>()));
+    spawn_script_blocking(ScriptSpawnRequest {
+        app,
+        registry: Arc::clone(&registry.0),
+        script_id,
+        name,
+        body,
+        run_id: run_id.clone(),
+        session_id,
+        cwd,
+        cols,
+        rows,
+    })
+    .await?;
+    Ok(run_id)
 }
 
 #[tauri::command]
@@ -390,6 +450,7 @@ mod tests {
         let metadata = LiveScriptRun {
             run_id: "run-1".to_string(),
             script_id: "script-1".to_string(),
+            name: "Script one".to_string(),
             session_id: "session-1".to_string(),
             started_at: 1234,
         };

--- a/apps/desktop/src-tauri/src/worktree.rs
+++ b/apps/desktop/src-tauri/src/worktree.rs
@@ -309,9 +309,7 @@ pub async fn worktree_list_local_branches(
 }
 
 #[tauri::command]
-pub async fn worktree_list_branch_names(
-    repo_path: String,
-) -> Result<Vec<String>, WorktreeError> {
+pub async fn worktree_list_branch_names(repo_path: String) -> Result<Vec<String>, WorktreeError> {
     tauri::async_runtime::spawn_blocking(move || list_branch_names_blocking(repo_path))
         .await
         .map_err(|e| WorktreeError::Io(std::io::Error::other(e.to_string())))?
@@ -1413,14 +1411,19 @@ fn resolve_branch_range(cwd: &Path) -> String {
 }
 
 fn normalized_base(base: Option<&str>) -> Option<&str> {
-    base.map(str::trim).filter(|candidate| !candidate.is_empty())
+    base.map(str::trim)
+        .filter(|candidate| !candidate.is_empty())
 }
 
 fn resolve_origin_head(cwd: &Path) -> Option<String> {
     git(cwd, &["symbolic-ref", "refs/remotes/origin/HEAD"])
         .ok()
         .map(|output| output.trim().to_string())
-        .and_then(|reference| reference.strip_prefix("refs/remotes/origin/").map(str::to_string))
+        .and_then(|reference| {
+            reference
+                .strip_prefix("refs/remotes/origin/")
+                .map(str::to_string)
+        })
         .filter(|branch| !branch.is_empty())
 }
 

--- a/apps/desktop/src/features/scripts/components/RunningScriptsIndicator/useRunningScripts.ts
+++ b/apps/desktop/src/features/scripts/components/RunningScriptsIndicator/useRunningScripts.ts
@@ -1,11 +1,11 @@
 import { useMemo } from 'react';
-import type { SessionId, ProjectScriptId } from '@goodboy/types';
+import type { SessionId } from '@goodboy/types';
 import { useAppStore } from '../../../../store';
 
 export type RunningScript = {
   readonly sessionId: SessionId;
   readonly sessionGoal: string;
-  readonly scriptId: ProjectScriptId;
+  readonly scriptId: string;
   readonly scriptName: string;
   readonly startedAt: number;
 };
@@ -23,7 +23,7 @@ export const useRunningScripts = (): ReadonlyArray<RunningScript> => {
       if (runs === undefined) {
         continue;
       }
-      const names = new Map(
+      const names = new Map<string, string>(
         (projectScripts[session.workspaceId] ?? []).map(
           (script) => [script.id, script.name] as const,
         ),
@@ -32,12 +32,11 @@ export const useRunningScripts = (): ReadonlyArray<RunningScript> => {
         if (record.status !== 'pending') {
           continue;
         }
-        const id = scriptId as ProjectScriptId;
         running.push({
           sessionId,
           sessionGoal: session.goal,
-          scriptId: id,
-          scriptName: names.get(id) ?? 'script',
+          scriptId,
+          scriptName: record.name ?? names.get(scriptId) ?? 'script',
           startedAt: record.startedAt,
         });
       }

--- a/apps/desktop/src/features/scripts/components/ScriptsPanel/DiscoveredScriptGroup.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsPanel/DiscoveredScriptGroup.tsx
@@ -1,0 +1,84 @@
+import type { ScriptGroup, ScriptRunRecord } from '../../scripts';
+import { discoveredScriptCwd, discoveredScriptId } from '../../scripts';
+import { DiscoveredScriptRow } from './DiscoveredScriptRow';
+
+type RunParams = {
+  readonly scriptId: string;
+  readonly name: string;
+  readonly command: string;
+  readonly cwd: string;
+};
+
+type CancelParams = {
+  readonly scriptId: string;
+};
+
+type Props = {
+  readonly group: ScriptGroup;
+  readonly worktreePath: string;
+  readonly runs: Readonly<Record<string, ScriptRunRecord>> | undefined;
+  readonly completedAt: Readonly<Record<string, number>>;
+  readonly onRun: (params: RunParams) => void;
+  readonly onCancel: (params: CancelParams) => void;
+};
+
+export const DiscoveredScriptGroup = ({
+  group,
+  worktreePath,
+  runs,
+  completedAt,
+  onRun,
+  onCancel,
+}: Props) => {
+  const cwd = discoveredScriptCwd({ worktreePath, relDir: group.relDir });
+  const scripts = [...group.scripts].sort((left, right) =>
+    left.name.localeCompare(right.name, undefined, { sensitivity: 'base' }),
+  );
+
+  return (
+    <section className="flex flex-col gap-2" aria-label={`${group.packageName} scripts`}>
+      <div className="flex min-w-0 items-baseline gap-2 px-0.5">
+        <h3 className="truncate text-sm font-medium text-foreground">{group.packageName}</h3>
+        {group.relDir !== '' ? (
+          <span className="truncate font-mono text-3xs text-muted-foreground">{group.relDir}</span>
+        ) : null}
+        <span className="shrink-0 text-3xs tabular-nums text-muted-foreground/70">
+          {scripts.length}
+        </span>
+        <span className="h-px flex-1 bg-border/40" aria-hidden />
+      </div>
+      <ul className="flex flex-col gap-2">
+        {scripts.map((script) => {
+          const scriptId = discoveredScriptId({
+            worktreePath,
+            source: group.source,
+            relDir: group.relDir,
+            name: script.name,
+          });
+          const run = runs?.[scriptId] ?? null;
+          return (
+            <li key={scriptId}>
+              <DiscoveredScriptRow
+                scriptId={scriptId}
+                name={script.name}
+                command={script.command}
+                cwd={cwd}
+                run={run}
+                completedAt={run == null ? undefined : completedAt[run.runId]}
+                onRun={() =>
+                  onRun({
+                    scriptId,
+                    name: script.name,
+                    command: script.command,
+                    cwd,
+                  })
+                }
+                onCancel={() => onCancel({ scriptId })}
+              />
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+};

--- a/apps/desktop/src/features/scripts/components/ScriptsPanel/DiscoveredScriptRow.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsPanel/DiscoveredScriptRow.tsx
@@ -1,0 +1,96 @@
+import { useState } from 'react';
+import { ChevronDown, ChevronRight, Play, Square } from 'lucide-react';
+import { CardAction, CardActionSlot, cn } from '@goodboy/ui';
+import type { ScriptRunRecord } from '../../scripts';
+import { ScriptRunOutput } from './ScriptRunOutput';
+import { SCRIPT_RUN_PRESENTATION } from './scriptRunPresentation';
+
+type Props = {
+  readonly scriptId: string;
+  readonly name: string;
+  readonly command: string;
+  readonly cwd: string;
+  readonly run: ScriptRunRecord | null;
+  readonly completedAt: number | undefined;
+  readonly onRun: () => void;
+  readonly onCancel: () => void;
+};
+
+export const DiscoveredScriptRow = ({
+  scriptId,
+  name,
+  command,
+  cwd,
+  run,
+  completedAt,
+  onRun,
+  onCancel,
+}: Props) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const status = run?.status ?? 'idle';
+  const presentation = SCRIPT_RUN_PRESENTATION[status];
+
+  return (
+    <div className="flex flex-col gap-1">
+      <div
+        data-testid={`discovered-script-${scriptId}`}
+        data-status={status}
+        className={cn(
+          'grid grid-cols-[minmax(0,1fr)_auto] gap-x-2 rounded-md border px-2.5 py-2 motion-safe:transition-colors hover:bg-muted/50',
+          isExpanded ? 'grid-rows-[auto_auto] gap-y-2' : 'grid-rows-[auto]',
+          presentation.borderClass,
+          presentation.pulseClass,
+          isExpanded ? 'bg-muted/20' : 'bg-card/40',
+        )}
+      >
+        <button
+          type="button"
+          onClick={() => setIsExpanded((current) => !current)}
+          className="col-start-1 row-start-1 flex min-w-0 flex-col gap-0.5 text-left"
+        >
+          <span className="truncate text-sm font-medium text-foreground">{name}</span>
+          <span className="truncate font-mono text-2xs text-muted-foreground">{command}</span>
+        </button>
+
+        <div className="col-start-2 row-start-1 flex items-start gap-1">
+          <CardActionSlot label="Script lifecycle actions">
+            {status === 'pending' ? (
+              <CardAction
+                icon={Square}
+                label={`Stop ${name}`}
+                tone="danger"
+                size="default"
+                onClick={onCancel}
+              />
+            ) : (
+              <CardAction icon={Play} label={`Run ${name}`} size="default" onClick={onRun} />
+            )}
+          </CardActionSlot>
+          <CardActionSlot label="Script navigation actions">
+            <CardAction
+              icon={isExpanded ? ChevronDown : ChevronRight}
+              label={`${isExpanded ? 'Collapse' : 'Expand'} ${name}`}
+              size="default"
+              expanded={isExpanded}
+              onClick={() => setIsExpanded((current) => !current)}
+            />
+          </CardActionSlot>
+        </div>
+
+        {isExpanded ? (
+          <div className="col-span-2 flex flex-col gap-2">
+            <p className="truncate font-mono text-2xs text-muted-foreground" title={cwd}>
+              {cwd}
+            </p>
+            <div className="rounded-lg bg-subtle/40 p-3">
+              <pre className="whitespace-pre-wrap break-words font-mono text-xs leading-relaxed text-foreground/80">
+                {command}
+              </pre>
+            </div>
+            {run !== null ? <ScriptRunOutput run={run} completedAt={completedAt} /> : null}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+};

--- a/apps/desktop/src/features/scripts/components/ScriptsPanel/index.test.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsPanel/index.test.tsx
@@ -16,6 +16,14 @@ type RunRecord = {
   readonly runId: string;
 };
 
+type ManifestGroup = {
+  readonly source: 'package-json' | 'composer';
+  readonly packageName: string;
+  readonly relDir: string;
+  readonly manager: string;
+  readonly scripts: ReadonlyArray<{ readonly name: string; readonly command: string }>;
+};
+
 const { state } = vi.hoisted(() => ({
   state: {
     scripts: [] as ReadonlyArray<Script>,
@@ -26,11 +34,19 @@ const { state } = vi.hoisted(() => ({
       'session-1': [{ projectId: 'project-1', worktreePath: '/tmp/api' }],
     } as Record<string, ReadonlyArray<{ projectId: string; worktreePath: string }>>,
     scriptRuns: {} as Record<string, Record<string, RunRecord>>,
+    discoveredScripts: {} as Record<string, Record<string, ReadonlyArray<ManifestGroup>>>,
+    discoveredScriptScans: {} as Record<
+      string,
+      Record<string, { status: 'loading' | 'ready' | 'error'; error: string | null }>
+    >,
     loadScripts: vi.fn(async () => undefined),
     saveScript: vi.fn(async () => undefined),
     deleteScript: vi.fn(async () => undefined),
     runScript: vi.fn(async () => undefined),
     cancelScript: vi.fn(async () => undefined),
+    loadDiscoveredScripts: vi.fn(async () => undefined),
+    refreshDiscoveredScripts: vi.fn(async () => undefined),
+    runDiscoveredScript: vi.fn(async () => undefined),
     scriptsLensScope: null as { readonly projectId: string } | null,
     setScriptsLensScope: vi.fn(),
   },
@@ -44,11 +60,16 @@ vi.mock('../../../../store', () => {
     sessionActiveProject: state.sessionActiveProject,
     sessionProjectMounts: state.sessionProjectMounts,
     scriptRuns: { 'session-1': state.scriptRuns['session-1'] ?? {} },
+    discoveredScripts: state.discoveredScripts,
+    discoveredScriptScans: state.discoveredScriptScans,
     loadScripts: state.loadScripts,
     saveScript: state.saveScript,
     deleteScript: state.deleteScript,
     runScript: state.runScript,
     cancelScript: state.cancelScript,
+    loadDiscoveredScripts: state.loadDiscoveredScripts,
+    refreshDiscoveredScripts: state.refreshDiscoveredScripts,
+    runDiscoveredScript: state.runDiscoveredScript,
     scriptsLensScope: state.scriptsLensScope,
     setScriptsLensScope: state.setScriptsLensScope,
   });
@@ -69,11 +90,16 @@ beforeEach(() => {
     'session-1': [{ projectId: 'project-1', worktreePath: '/tmp/api' }],
   };
   state.scriptRuns = {};
+  state.discoveredScripts = {};
+  state.discoveredScriptScans = {};
   state.loadScripts = vi.fn(async () => undefined);
   state.saveScript = vi.fn(async () => undefined);
   state.deleteScript = vi.fn(async () => undefined);
   state.runScript = vi.fn(async () => undefined);
   state.cancelScript = vi.fn(async () => undefined);
+  state.loadDiscoveredScripts = vi.fn(async () => undefined);
+  state.refreshDiscoveredScripts = vi.fn(async () => undefined);
+  state.runDiscoveredScript = vi.fn(async () => undefined);
   state.scriptsLensScope = null;
   state.setScriptsLensScope = vi.fn();
 });
@@ -81,6 +107,111 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe('ScriptsPanel', () => {
+  it('loads, groups, sorts, and runs scripts discovered from the mounted project', () => {
+    state.discoveredScripts = {
+      'session-1': {
+        '/tmp/api': [
+          {
+            source: 'composer',
+            packageName: 'acme/api',
+            relDir: '',
+            manager: 'composer',
+            scripts: [{ name: 'test-php', command: 'composer run-script test-php' }],
+          },
+          {
+            source: 'package-json',
+            packageName: '@acme/web',
+            relDir: 'apps/web',
+            manager: 'pnpm',
+            scripts: [{ name: 'dev', command: 'pnpm run dev' }],
+          },
+          {
+            source: 'package-json',
+            packageName: 'root',
+            relDir: '',
+            manager: 'pnpm',
+            scripts: [{ name: 'build', command: 'pnpm run build' }],
+          },
+        ],
+      },
+    };
+    state.discoveredScriptScans = {
+      'session-1': { '/tmp/api': { status: 'ready', error: null } },
+    };
+
+    render(<ScriptsPanel workspaceId={'ws-1' as never} sessionId={'session-1' as never} />);
+
+    expect(state.loadDiscoveredScripts).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      worktreePath: '/tmp/api',
+    });
+    expect(
+      screen.getAllByRole('heading', { level: 3 }).map((heading) => heading.textContent),
+    ).toEqual(['root', '@acme/web', 'acme/api']);
+    fireEvent.click(screen.getByRole('button', { name: 'Run dev' }));
+    expect(state.runDiscoveredScript).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'session-1',
+        name: 'dev',
+        command: 'pnpm run dev',
+        cwd: '/tmp/api/apps/web',
+      }),
+    );
+  });
+
+  it('shows manifest scan loading, empty, and error states quietly', () => {
+    state.discoveredScriptScans = {
+      'session-1': { '/tmp/api': { status: 'loading', error: null } },
+    };
+    const { rerender } = render(
+      <ScriptsPanel workspaceId={'ws-1' as never} sessionId={'session-1' as never} />,
+    );
+    expect(screen.getByText('Scanning project manifests…')).toBeDefined();
+
+    state.discoveredScriptScans = {
+      'session-1': { '/tmp/api': { status: 'ready', error: null } },
+    };
+    rerender(<ScriptsPanel workspaceId={'ws-1' as never} sessionId={'session-1' as never} />);
+    expect(screen.getByText('No manifest scripts found.')).toBeDefined();
+
+    state.discoveredScriptScans = {
+      'session-1': { '/tmp/api': { status: 'error', error: 'manifest scan failed' } },
+    };
+    rerender(<ScriptsPanel workspaceId={'ws-1' as never} sessionId={'session-1' as never} />);
+    expect(screen.getByText('manifest scan failed')).toBeDefined();
+  });
+
+  it('reattaches a discovered run to its manifest row and stops it through the shared registry', () => {
+    const scriptId = JSON.stringify(['/tmp/api', 'package-json', '', 'dev']);
+    state.discoveredScripts = {
+      'session-1': {
+        '/tmp/api': [
+          {
+            source: 'package-json',
+            packageName: 'api',
+            relDir: '',
+            manager: 'pnpm',
+            scripts: [{ name: 'dev', command: 'pnpm run dev' }],
+          },
+        ],
+      },
+    };
+    state.discoveredScriptScans = {
+      'session-1': { '/tmp/api': { status: 'ready', error: null } },
+    };
+    state.scriptRuns = {
+      'session-1': {
+        [scriptId]: { status: 'pending', result: null, runId: 'run-live' },
+      },
+    };
+
+    render(<ScriptsPanel workspaceId={'ws-1' as never} sessionId={'session-1' as never} />);
+
+    expect(screen.getByTestId(`discovered-script-${scriptId}`).dataset.status).toBe('pending');
+    fireEvent.click(screen.getByRole('button', { name: 'Stop dev' }));
+    expect(state.cancelScript).toHaveBeenCalledWith('session-1', scriptId);
+  });
+
   it('consumes a scoped open and preselects its project tab', () => {
     state.projects = [
       { id: 'project-1', workspaceId: 'ws-1', name: 'API' },

--- a/apps/desktop/src/features/scripts/components/ScriptsPanel/index.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsPanel/index.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   Button,
   formatError,
+  RefreshIconButton,
   SectionHeader,
   SegmentedTabs,
   type SegmentedTabOption,
@@ -22,6 +23,8 @@ import { useAppStore } from '../../../../store';
 import { DiscardDraftConfirm } from './DiscardDraftConfirm';
 import { NewScriptCard } from './NewScriptCard';
 import { ScriptRow } from './ScriptRow';
+import { DiscoveredScriptGroup } from './DiscoveredScriptGroup';
+import type { ScriptGroup as ManifestScriptGroup } from '../../scripts';
 
 type Props = {
   readonly workspaceId: WorkspaceId;
@@ -78,10 +81,26 @@ type SaveExistingParams = {
 
 type ProjectFilter = 'all' | ProjectId;
 
-type ScriptGroup = {
+type UserScriptGroup = {
   readonly key: string;
   readonly label: string | null;
   readonly scripts: ReadonlyArray<ProjectScript>;
+};
+
+type DiscoveredGroupEntry = {
+  readonly group: ManifestScriptGroup;
+  readonly worktreePath: string;
+};
+
+type RunDiscoveredParams = {
+  readonly scriptId: string;
+  readonly name: string;
+  readonly command: string;
+  readonly cwd: string;
+};
+
+type CancelDiscoveredParams = {
+  readonly scriptId: string;
 };
 
 const EMPTY_MOUNTS: ReadonlyArray<SessionProjectMount> = [];
@@ -106,6 +125,15 @@ export const ScriptsPanel = ({ workspaceId, sessionId, hasHostHeading = false }:
   const cancelScript = useAppStore((state) => state.cancelScript);
   const scriptsLensScope = useAppStore((state) => state.scriptsLensScope);
   const setScriptsLensScope = useAppStore((state) => state.setScriptsLensScope);
+  const loadDiscoveredScripts = useAppStore((state) => state.loadDiscoveredScripts);
+  const refreshDiscoveredScripts = useAppStore((state) => state.refreshDiscoveredScripts);
+  const runDiscoveredScript = useAppStore((state) => state.runDiscoveredScript);
+  const discoveredScripts = useAppStore((state) =>
+    sessionId == null ? undefined : state.discoveredScripts[sessionId],
+  );
+  const discoveredScriptScans = useAppStore((state) =>
+    sessionId == null ? undefined : state.discoveredScriptScans[sessionId],
+  );
   const runs = useAppStore((state) =>
     sessionId != null ? state.scriptRuns[sessionId] : undefined,
   );
@@ -152,7 +180,7 @@ export const ScriptsPanel = ({ workspaceId, sessionId, hasHostHeading = false }:
     ],
     [projects],
   );
-  const groups = useMemo<ReadonlyArray<ScriptGroup>>(() => {
+  const groups = useMemo<ReadonlyArray<UserScriptGroup>>(() => {
     const sortScripts = (groupScripts: ReadonlyArray<ProjectScript>) =>
       [...groupScripts].sort((left, right) =>
         left.name.localeCompare(right.name, undefined, { sensitivity: 'base' }),
@@ -180,12 +208,64 @@ export const ScriptsPanel = ({ workspaceId, sessionId, hasHostHeading = false }:
           : [{ key: project.id, label: project.name, scripts: projectScripts }];
       });
   }, [isMultiProject, list, projectFilter, projects]);
+  const visibleMounts = useMemo(
+    () =>
+      [...sessionMounts]
+        .filter((mount) => projectFilter === 'all' || mount.projectId === projectFilter)
+        .sort((left, right) => {
+          const leftName = projectById.get(left.projectId)?.name ?? '';
+          const rightName = projectById.get(right.projectId)?.name ?? '';
+          return leftName.localeCompare(rightName);
+        }),
+    [projectById, projectFilter, sessionMounts],
+  );
+  const discoveredGroups = useMemo<ReadonlyArray<DiscoveredGroupEntry>>(() => {
+    return visibleMounts.flatMap((mount) => {
+      const mountGroups = [...(discoveredScripts?.[mount.worktreePath] ?? [])].sort(
+        (left, right) => {
+          if (left.source !== right.source) {
+            return left.source === 'composer' ? 1 : -1;
+          }
+          const leftRoot = left.relDir === '';
+          const rightRoot = right.relDir === '';
+          if (leftRoot !== rightRoot) {
+            return leftRoot ? -1 : 1;
+          }
+          return left.relDir.localeCompare(right.relDir);
+        },
+      );
+      return mountGroups.map((group) => ({
+        group,
+        worktreePath: mount.worktreePath,
+      }));
+    });
+  }, [discoveredScripts, visibleMounts]);
+  const isDiscoveryLoading = visibleMounts.some((mount) => {
+    const scan = discoveredScriptScans?.[mount.worktreePath];
+    return scan === undefined || scan.status === 'loading';
+  });
+  const discoveryErrors = visibleMounts.flatMap((mount) => {
+    const scan = discoveredScriptScans?.[mount.worktreePath];
+    if (scan?.status !== 'error' || scan.error === null) {
+      return [];
+    }
+    return [scan.error];
+  });
   const newDraftDirty =
     newDraft != null && (newDraft.name.trim() !== '' || newDraft.body.trim() !== '');
 
   useEffect(() => {
     void loadScripts(workspaceId);
   }, [workspaceId, loadScripts]);
+
+  useEffect(() => {
+    if (sessionId == null) {
+      return;
+    }
+    for (const mount of sessionMounts) {
+      void loadDiscoveredScripts({ sessionId, worktreePath: mount.worktreePath });
+    }
+  }, [loadDiscoveredScripts, sessionId, sessionMounts]);
 
   useEffect(() => {
     setScriptsLensScope({ scope: null });
@@ -383,6 +463,35 @@ export const ScriptsPanel = ({ workspaceId, sessionId, hasHostHeading = false }:
     [cancelScript, sessionId],
   );
 
+  const onRunDiscovered = useCallback(
+    ({ scriptId, name, command, cwd }: RunDiscoveredParams) => {
+      if (sessionId == null) {
+        return;
+      }
+      void runDiscoveredScript({ sessionId, scriptId, name, command, cwd });
+    },
+    [runDiscoveredScript, sessionId],
+  );
+
+  const onCancelDiscovered = useCallback(
+    ({ scriptId }: CancelDiscoveredParams) => {
+      if (sessionId == null) {
+        return;
+      }
+      void cancelScript(sessionId, scriptId);
+    },
+    [cancelScript, sessionId],
+  );
+
+  const onRefreshDiscovered = useCallback(() => {
+    if (sessionId == null) {
+      return;
+    }
+    for (const mount of visibleMounts) {
+      void refreshDiscoveredScripts({ sessionId, worktreePath: mount.worktreePath });
+    }
+  }, [refreshDiscoveredScripts, sessionId, visibleMounts]);
+
   const newScriptAction = (
     <Button variant="ghost" size="sm" onClick={onOpenNew}>
       <Plus size={13} aria-hidden />
@@ -395,32 +504,41 @@ export const ScriptsPanel = ({ workspaceId, sessionId, hasHostHeading = false }:
       {hasHostHeading ? (
         <div className="flex items-start justify-between gap-2">
           <p className="text-2xs text-muted-foreground/70">{SCRIPTS_HINT}</p>
-          {list.length > 0 ? newScriptAction : null}
+          {list.length > 0 || sessionId != null ? newScriptAction : null}
         </div>
       ) : (
         <SectionHeader
           label="Scripts"
           icon={<CONCEPT_ICONS.scripts size={13} aria-hidden />}
           hint={SCRIPTS_HINT}
-          action={list.length > 0 ? newScriptAction : null}
+          action={list.length > 0 || sessionId != null ? newScriptAction : null}
         />
       )}
 
       {error !== null && newDraft === null ? <p className="text-xs text-danger">{error}</p> : null}
 
-      <div className="flex min-h-0 flex-1 flex-col gap-2">
-        {isMultiProject ? (
-          <SegmentedTabs
-            ariaLabel="Filter scripts by project"
-            options={projectFilterOptions}
-            value={projectFilter}
-            onChange={setProjectFilter}
-            size="sm"
-            className="max-w-full flex-wrap self-start"
-          />
-        ) : null}
-        {newDraft != null ? (
-          newDraft.projectId != null ? (
+      <div className="flex min-h-0 flex-1 flex-col gap-6">
+        <section className="flex flex-col gap-2" aria-label="User scripts">
+          {sessionId != null ? (
+            <div className="flex items-baseline gap-2 px-0.5">
+              <h2 className="text-2xs font-semibold uppercase tracking-wider text-muted-foreground/80">
+                User scripts
+              </h2>
+              <span className="text-2xs tabular-nums text-muted-foreground/50">{list.length}</span>
+              <span className="h-px flex-1 bg-border/40" aria-hidden />
+            </div>
+          ) : null}
+          {isMultiProject ? (
+            <SegmentedTabs
+              ariaLabel="Filter scripts by project"
+              options={projectFilterOptions}
+              value={projectFilter}
+              onChange={setProjectFilter}
+              size="sm"
+              className="max-w-full flex-wrap self-start"
+            />
+          ) : null}
+          {newDraft != null && newDraft.projectId != null ? (
             <NewScriptCard
               name={newDraft.name}
               body={newDraft.body}
@@ -439,72 +557,117 @@ export const ScriptsPanel = ({ workspaceId, sessionId, hasHostHeading = false }:
               onSave={onSaveNew}
               onCancel={onCancelNew}
             />
-          ) : null
-        ) : null}
-        {list.length === 0 && newDraft == null ? (
-          <LensEmptyState
-            tone={CONCEPT_TONE.scripts}
-            icon={CONCEPT_ICONS.scripts}
-            title="No scripts yet"
-            description="Each script belongs to a project and runs in that project's worktree for this session. Scripts are shared across every session of the workspace."
-            action={newScriptAction}
-          />
-        ) : (
-          <div className="flex flex-col gap-4">
-            {groups.map((group) => (
-              <div key={group.key} className="flex flex-col gap-1.5">
-                {group.label != null ? (
-                  <div className="flex items-center gap-2 px-0.5">
-                    <span className="text-2xs font-semibold uppercase tracking-wider text-muted-foreground/80">
-                      {group.label}
-                    </span>
-                    <span className="text-2xs tabular-nums text-muted-foreground/50">
-                      {group.scripts.length}
-                    </span>
-                    <span className="h-px flex-1 bg-border/40" aria-hidden />
-                  </div>
-                ) : null}
-                <ul className="flex flex-col gap-2">
-                  {group.scripts.map((script) => {
-                    const run = runs?.[script.id] ?? null;
-                    const project = projectById.get(script.projectId) ?? null;
-                    const projectName = project?.name ?? 'Project';
-                    const mountPath = mountPathByProjectId.get(script.projectId) ?? null;
-                    const runDisabledReason =
-                      runnable && mountPath == null
-                        ? `${projectName} is not mounted in this session`
-                        : null;
-                    return (
-                      <li key={script.id}>
-                        <ScriptRow
-                          script={script}
-                          projects={projects}
-                          projectName={projectName}
-                          mountPath={mountPath}
-                          run={run}
-                          completedAt={run == null ? undefined : completedAt[run.runId]}
-                          expanded={expandedId === script.id}
-                          runnable={runnable}
-                          canRun={mountPath != null}
-                          runDisabledReason={runDisabledReason}
-                          copied={copiedId === script.id}
-                          onToggle={() => onToggle({ id: script.id })}
-                          onSave={(name, body, projectId) =>
-                            onSaveExisting({ script, name, body, projectId })
-                          }
-                          onRun={() => onRun({ script })}
-                          onCancel={() => onCancel({ id: script.id })}
-                          onCopy={() => onCopy({ id: script.id, body: script.body })}
-                          onDelete={() => onDelete({ id: script.id })}
-                        />
-                      </li>
-                    );
-                  })}
-                </ul>
+          ) : null}
+          {list.length === 0 && newDraft == null && sessionId == null ? (
+            <LensEmptyState
+              tone={CONCEPT_TONE.scripts}
+              icon={CONCEPT_ICONS.scripts}
+              title="No scripts yet"
+              description="Each script belongs to a project and runs in that project's worktree for this session. Scripts are shared across every session of the workspace."
+              action={newScriptAction}
+            />
+          ) : (
+            <div className="flex flex-col gap-4">
+              {groups.map((group) => (
+                <div key={group.key} className="flex flex-col gap-1.5">
+                  {group.label != null ? (
+                    <div className="flex items-center gap-2 px-0.5">
+                      <span className="text-2xs font-semibold uppercase tracking-wider text-muted-foreground/80">
+                        {group.label}
+                      </span>
+                      <span className="text-2xs tabular-nums text-muted-foreground/50">
+                        {group.scripts.length}
+                      </span>
+                      <span className="h-px flex-1 bg-border/40" aria-hidden />
+                    </div>
+                  ) : null}
+                  <ul className="flex flex-col gap-2">
+                    {group.scripts.map((script) => {
+                      const run = runs?.[script.id] ?? null;
+                      const project = projectById.get(script.projectId) ?? null;
+                      const projectName = project?.name ?? 'Project';
+                      const mountPath = mountPathByProjectId.get(script.projectId) ?? null;
+                      const runDisabledReason =
+                        runnable && mountPath == null
+                          ? `${projectName} is not mounted in this session`
+                          : null;
+                      return (
+                        <li key={script.id}>
+                          <ScriptRow
+                            script={script}
+                            projects={projects}
+                            projectName={projectName}
+                            mountPath={mountPath}
+                            run={run}
+                            completedAt={run == null ? undefined : completedAt[run.runId]}
+                            expanded={expandedId === script.id}
+                            runnable={runnable}
+                            canRun={mountPath != null}
+                            runDisabledReason={runDisabledReason}
+                            copied={copiedId === script.id}
+                            onToggle={() => onToggle({ id: script.id })}
+                            onSave={(name, body, projectId) =>
+                              onSaveExisting({ script, name, body, projectId })
+                            }
+                            onRun={() => onRun({ script })}
+                            onCancel={() => onCancel({ id: script.id })}
+                            onCopy={() => onCopy({ id: script.id, body: script.body })}
+                            onDelete={() => onDelete({ id: script.id })}
+                          />
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+
+        {sessionId != null ? (
+          <section className="flex flex-col gap-4" aria-label="Manifest scripts">
+            <div className="flex items-center gap-2">
+              <div className="flex min-w-0 flex-1 items-baseline gap-2 px-0.5">
+                <h2 className="text-2xs font-semibold uppercase tracking-wider text-muted-foreground/80">
+                  Manifest scripts
+                </h2>
+                <span className="text-2xs tabular-nums text-muted-foreground/50">
+                  {discoveredGroups.reduce((total, entry) => total + entry.group.scripts.length, 0)}
+                </span>
+                <span className="h-px flex-1 bg-border/40" aria-hidden />
               </div>
+              {visibleMounts.length > 0 ? (
+                <RefreshIconButton
+                  label="Refresh manifest scripts"
+                  isLoading={isDiscoveryLoading}
+                  onClick={onRefreshDiscovered}
+                />
+              ) : null}
+            </div>
+            {isDiscoveryLoading ? (
+              <p className="text-xs text-muted-foreground">Scanning project manifests…</p>
+            ) : null}
+            {discoveryErrors.length > 0 ? (
+              <p className="text-xs text-muted-foreground">{discoveryErrors.join(' ')}</p>
+            ) : null}
+            {!isDiscoveryLoading &&
+            discoveryErrors.length === 0 &&
+            discoveredGroups.length === 0 ? (
+              <p className="text-xs text-muted-foreground">No manifest scripts found.</p>
+            ) : null}
+            {discoveredGroups.map((entry) => (
+              <DiscoveredScriptGroup
+                key={`${entry.worktreePath}:${entry.group.source}:${entry.group.relDir}`}
+                group={entry.group}
+                worktreePath={entry.worktreePath}
+                runs={runs}
+                completedAt={completedAt}
+                onRun={onRunDiscovered}
+                onCancel={onCancelDiscovered}
+              />
             ))}
-          </div>
-        )}
+          </section>
+        ) : null}
       </div>
 
       {pendingNewAction !== null ? (

--- a/apps/desktop/src/features/scripts/scripts.ts
+++ b/apps/desktop/src/features/scripts/scripts.ts
@@ -15,6 +15,22 @@ export type ScriptRunRecord = {
   readonly result: ScriptRunResult | null;
   readonly runId: string;
   readonly startedAt: number;
+  readonly name?: string;
+};
+
+export type ScriptSource = 'package-json' | 'composer';
+
+export type DiscoveredScript = {
+  readonly name: string;
+  readonly command: string;
+};
+
+export type ScriptGroup = {
+  readonly source: ScriptSource;
+  readonly packageName: string;
+  readonly relDir: string;
+  readonly manager: string;
+  readonly scripts: ReadonlyArray<DiscoveredScript>;
 };
 
 export type ScriptOutputPayload = {
@@ -29,9 +45,37 @@ export type ScriptExitPayload = {
 
 export type LiveScriptRun = {
   readonly runId: string;
-  readonly scriptId: ProjectScriptId;
+  readonly scriptId: string;
+  readonly name: string;
   readonly sessionId: SessionId;
   readonly startedAt: number;
+};
+
+type ScanProjectScriptsParams = {
+  readonly worktreePath: string;
+};
+
+type RunAdhocScriptParams = {
+  readonly scriptId: string;
+  readonly name: string;
+  readonly body: string;
+  readonly runId?: string;
+  readonly sessionId: SessionId;
+  readonly cwd: string;
+  readonly cols?: number;
+  readonly rows?: number;
+};
+
+type DiscoveredScriptIdParams = {
+  readonly worktreePath: string;
+  readonly source: ScriptSource;
+  readonly relDir: string;
+  readonly name: string;
+};
+
+type DiscoveredScriptCwdParams = {
+  readonly worktreePath: string;
+  readonly relDir: string;
 };
 
 type InvokeScriptRunParams = {
@@ -52,6 +96,53 @@ export const invokeScriptRun = ({
   rows,
 }: InvokeScriptRunParams): Promise<void> => {
   return invoke<void>('workspace_script_run', { scriptId, runId, sessionId, cwd, cols, rows });
+};
+
+export const scanProjectScripts = ({
+  worktreePath,
+}: ScanProjectScriptsParams): Promise<ReadonlyArray<ScriptGroup>> => {
+  return invoke<ReadonlyArray<ScriptGroup>>('project_scripts_scan', { worktreePath });
+};
+
+export const runAdhocScript = ({
+  scriptId,
+  name,
+  body,
+  runId,
+  sessionId,
+  cwd,
+  cols = 220,
+  rows = 50,
+}: RunAdhocScriptParams): Promise<string> => {
+  return invoke<string>('workspace_script_run_adhoc', {
+    scriptId,
+    name,
+    body,
+    runId,
+    sessionId,
+    cwd,
+    cols,
+    rows,
+  });
+};
+
+export const discoveredScriptId = ({
+  worktreePath,
+  source,
+  relDir,
+  name,
+}: DiscoveredScriptIdParams): string => {
+  return JSON.stringify([worktreePath, source, relDir, name]);
+};
+
+export const discoveredScriptCwd = ({
+  worktreePath,
+  relDir,
+}: DiscoveredScriptCwdParams): string => {
+  if (relDir === '') {
+    return worktreePath;
+  }
+  return `${worktreePath.replace(/[\\/]+$/, '')}/${relDir}`;
 };
 
 export const invokeScriptListLive = (): Promise<ReadonlyArray<LiveScriptRun>> => {

--- a/apps/desktop/src/store/sessionEviction.ts
+++ b/apps/desktop/src/store/sessionEviction.ts
@@ -43,6 +43,8 @@ export const SESSION_EVICTION = [
   { key: 'sessionAttachments', keyedBy: 'session', evictOn: 'archive' },
   { key: 'sessionOverrides', keyedBy: 'session', evictOn: 'archive' },
   { key: 'scriptRuns', keyedBy: 'session', evictOn: 'archive' },
+  { key: 'discoveredScripts', keyedBy: 'session', evictOn: 'archive' },
+  { key: 'discoveredScriptScans', keyedBy: 'session', evictOn: 'archive' },
   { key: 'sessionPanelExpanded', keyedBy: 'session', evictOn: 'archive' },
   { key: 'activeLens', keyedBy: 'session', evictOn: 'archive' },
   { key: 'lensHistory', keyedBy: 'session', evictOn: 'archive' },

--- a/apps/desktop/src/store/slices/scripts/cancelScript.ts
+++ b/apps/desktop/src/store/slices/scripts/cancelScript.ts
@@ -1,9 +1,9 @@
-import type { SessionId, ProjectScriptId } from '@goodboy/types';
+import type { SessionId } from '@goodboy/types';
 import { invokeScriptCancel, type ScriptRunRecord } from '../../../features/scripts/scripts';
 import type { GetFn, SetFn } from './types';
 
 export const cancelScript = (set: SetFn, get: GetFn) => {
-  return async (sessionId: SessionId, scriptId: ProjectScriptId) => {
+  return async (sessionId: SessionId, scriptId: string) => {
     const curr = get().scriptRuns[sessionId]?.[scriptId];
     if (!curr || curr.status !== 'pending') {
       return;

--- a/apps/desktop/src/store/slices/scripts/index.test.ts
+++ b/apps/desktop/src/store/slices/scripts/index.test.ts
@@ -65,6 +65,17 @@ const listProjectScriptsSpy = vi.fn(async () => [] as ReadonlyArray<ProjectScrip
 const upsertProjectScriptSpy = vi.fn(async () => undefined);
 const deleteProjectScriptSpy = vi.fn(async () => undefined);
 const invokeScriptRunSpy: ReturnType<typeof vi.fn> = vi.fn(async () => undefined);
+const scanProjectScriptsSpy = vi.fn(
+  async () =>
+    [] as ReadonlyArray<{
+      source: 'package-json' | 'composer';
+      packageName: string;
+      relDir: string;
+      manager: string;
+      scripts: ReadonlyArray<{ name: string; command: string }>;
+    }>,
+);
+const runAdhocScriptSpy: ReturnType<typeof vi.fn> = vi.fn(async () => 'run-adhoc');
 const invokeScriptListLiveSpy = vi.fn<
   () => Promise<
     ReadonlyArray<{
@@ -351,6 +362,8 @@ vi.mock('@goodboy/core', async (importOriginal) => {
 
 vi.mock('../../../features/scripts/scripts', () => ({
   invokeScriptRun: invokeScriptRunSpy,
+  scanProjectScripts: scanProjectScriptsSpy,
+  runAdhocScript: runAdhocScriptSpy,
   invokeScriptListLive: invokeScriptListLiveSpy,
   invokeScriptCancel: vi.fn(async () => undefined),
   listenScriptOutput: vi.fn(async () => () => undefined),
@@ -533,6 +546,8 @@ describe('store contract', () => {
         skills: {},
         projectScripts: {},
         scriptRuns: {},
+        discoveredScripts: {},
+        discoveredScriptScans: {},
         phaseTemplates: {},
         sessionWorkflows: {},
         sessionPhaseRuns: {},
@@ -572,6 +587,66 @@ describe('store contract', () => {
   });
 
   describe('scripts', () => {
+    it('loads discovered scripts once and refreshes them on demand', async () => {
+      const store = await getStore();
+      const group = {
+        source: 'package-json' as const,
+        packageName: 'desktop',
+        relDir: '',
+        manager: 'pnpm',
+        scripts: [{ name: 'dev', command: 'pnpm run dev' }],
+      };
+      scanProjectScriptsSpy.mockResolvedValue([group]);
+
+      await store
+        .getState()
+        .loadDiscoveredScripts({ sessionId: SESSION_ID, worktreePath: '/sessions/one/api' });
+      await store
+        .getState()
+        .loadDiscoveredScripts({ sessionId: SESSION_ID, worktreePath: '/sessions/one/api' });
+      await store
+        .getState()
+        .refreshDiscoveredScripts({ sessionId: SESSION_ID, worktreePath: '/sessions/one/api' });
+
+      expect(scanProjectScriptsSpy).toHaveBeenCalledTimes(2);
+      expect(store.getState().discoveredScripts[SESSION_ID]?.['/sessions/one/api']).toEqual([
+        group,
+      ]);
+      expect(store.getState().discoveredScriptScans[SESSION_ID]?.['/sessions/one/api']).toEqual({
+        status: 'ready',
+        error: null,
+      });
+    });
+
+    it('runs a discovered script through the ad hoc bridge and shared listeners', async () => {
+      const store = await getStore();
+      const resultPromise = store.getState().runDiscoveredScript({
+        sessionId: SESSION_ID,
+        scriptId: 'manifest-script',
+        name: 'dev',
+        command: 'pnpm run dev',
+        cwd: '/sessions/one/api/apps/web',
+      });
+      await vi.waitFor(() => expect(runAdhocScriptSpy).toHaveBeenCalledOnce());
+      const invocation = runAdhocScriptSpy.mock.calls[0]?.[0];
+      if (invocation?.runId === undefined || scriptExitHandler === null) {
+        throw new Error('discovered script listeners were not ready');
+      }
+      scriptExitHandler({ runId: invocation.runId, exitCode: 0 });
+      await resultPromise;
+
+      expect(invocation).toEqual(
+        expect.objectContaining({
+          scriptId: 'manifest-script',
+          name: 'dev',
+          body: 'pnpm run dev',
+          sessionId: SESSION_ID,
+          cwd: '/sessions/one/api/apps/web',
+        }),
+      );
+      expect(store.getState().scriptRuns[SESSION_ID]?.['manifest-script']?.status).toBe('ok');
+    });
+
     it('loadScripts caches workspace scripts', async () => {
       const store = await getStore();
       const script: ProjectScript = {

--- a/apps/desktop/src/store/slices/scripts/index.ts
+++ b/apps/desktop/src/store/slices/scripts/index.ts
@@ -1,8 +1,11 @@
 import { cancelScript } from './cancelScript';
 import { deleteScript } from './deleteScript';
+import { loadDiscoveredScripts } from './loadDiscoveredScripts';
 import { loadScripts } from './loadScripts';
-import { runScript } from './runScript';
 import { reattachScriptRuns } from './reattachScriptRuns';
+import { refreshDiscoveredScripts } from './refreshDiscoveredScripts';
+import { runDiscoveredScript } from './runDiscoveredScript';
+import { runScript } from './runScript';
 import { saveScript } from './saveScript';
 import type { GetFn, SetFn } from './types';
 
@@ -11,7 +14,10 @@ export const createScriptsSlice = (set: SetFn, get: GetFn) => {
     loadScripts: loadScripts(set, get),
     saveScript: saveScript(get),
     deleteScript: deleteScript(set),
+    loadDiscoveredScripts: loadDiscoveredScripts(set, get),
+    refreshDiscoveredScripts: refreshDiscoveredScripts(set, get),
     runScript: runScript(set, get),
+    runDiscoveredScript: runDiscoveredScript(set, get),
     reattachScriptRuns: reattachScriptRuns(set, get),
     cancelScript: cancelScript(set, get),
   };

--- a/apps/desktop/src/store/slices/scripts/loadDiscoveredScripts.ts
+++ b/apps/desktop/src/store/slices/scripts/loadDiscoveredScripts.ts
@@ -1,0 +1,14 @@
+import type { SessionId } from '@goodboy/types';
+import { scanDiscoveredScripts } from './scanDiscoveredScripts';
+import type { GetFn, SetFn } from './types';
+
+type Params = {
+  readonly sessionId: SessionId;
+  readonly worktreePath: string;
+};
+
+export const loadDiscoveredScripts = (set: SetFn, get: GetFn) => {
+  return async ({ sessionId, worktreePath }: Params): Promise<void> => {
+    await scanDiscoveredScripts({ set, get, sessionId, worktreePath, force: false });
+  };
+};

--- a/apps/desktop/src/store/slices/scripts/reattachScriptRuns.ts
+++ b/apps/desktop/src/store/slices/scripts/reattachScriptRuns.ts
@@ -13,6 +13,7 @@ export const reattachScriptRuns = (set: SetFn, get: GetFn) => {
           result: null,
           runId: live.runId,
           startedAt: live.startedAt,
+          ...(live.name === undefined ? {} : { name: live.name }),
         };
         scriptRuns[live.sessionId] = {
           ...scriptRuns[live.sessionId],

--- a/apps/desktop/src/store/slices/scripts/refreshDiscoveredScripts.ts
+++ b/apps/desktop/src/store/slices/scripts/refreshDiscoveredScripts.ts
@@ -1,0 +1,14 @@
+import type { SessionId } from '@goodboy/types';
+import { scanDiscoveredScripts } from './scanDiscoveredScripts';
+import type { GetFn, SetFn } from './types';
+
+type Params = {
+  readonly sessionId: SessionId;
+  readonly worktreePath: string;
+};
+
+export const refreshDiscoveredScripts = (set: SetFn, get: GetFn) => {
+  return async ({ sessionId, worktreePath }: Params): Promise<void> => {
+    await scanDiscoveredScripts({ set, get, sessionId, worktreePath, force: true });
+  };
+};

--- a/apps/desktop/src/store/slices/scripts/registerScriptRunListeners.ts
+++ b/apps/desktop/src/store/slices/scripts/registerScriptRunListeners.ts
@@ -1,4 +1,4 @@
-import type { ProjectScriptId, SessionId } from '@goodboy/types';
+import type { SessionId } from '@goodboy/types';
 import {
   listenScriptExit,
   listenScriptOutput,
@@ -11,9 +11,10 @@ type Params = {
   readonly set: SetFn;
   readonly get: GetFn;
   readonly sessionId: SessionId;
-  readonly scriptId: ProjectScriptId;
+  readonly scriptId: string;
   readonly runId: string;
   readonly startedAt: number;
+  readonly name?: string;
 };
 
 type WriteRunParams = {
@@ -32,6 +33,7 @@ export const registerScriptRunListeners = async ({
   scriptId,
   runId,
   startedAt,
+  name,
 }: Params): Promise<RegisteredScriptRun> => {
   const writeRun = ({ record }: WriteRunParams): void => {
     set((state) => ({
@@ -84,6 +86,7 @@ export const registerScriptRunListeners = async ({
         result: completed,
         runId,
         startedAt,
+        ...(name === undefined ? {} : { name }),
       },
     });
     resolveResult?.(completed);

--- a/apps/desktop/src/store/slices/scripts/runDiscoveredScript.ts
+++ b/apps/desktop/src/store/slices/scripts/runDiscoveredScript.ts
@@ -1,0 +1,78 @@
+import type { SessionId } from '@goodboy/types';
+import { formatError } from '@goodboy/ui';
+import {
+  runAdhocScript,
+  type ScriptRunRecord,
+  type ScriptRunResult,
+} from '../../../features/scripts/scripts';
+import { registerScriptRunListeners } from './registerScriptRunListeners';
+import type { GetFn, SetFn } from './types';
+
+type Params = {
+  readonly sessionId: SessionId;
+  readonly scriptId: string;
+  readonly name: string;
+  readonly command: string;
+  readonly cwd: string;
+  readonly cols?: number;
+  readonly rows?: number;
+};
+
+type WriteRunParams = {
+  readonly record: ScriptRunRecord;
+};
+
+export const runDiscoveredScript = (set: SetFn, get: GetFn) => {
+  return async ({
+    sessionId,
+    scriptId,
+    name,
+    command,
+    cwd,
+    cols = 220,
+    rows = 50,
+  }: Params): Promise<ScriptRunResult> => {
+    const runId = crypto.randomUUID();
+    const startedAt = Date.now();
+    const writeRun = ({ record }: WriteRunParams): void => {
+      set((state) => ({
+        scriptRuns: {
+          ...state.scriptRuns,
+          [sessionId]: { ...state.scriptRuns[sessionId], [scriptId]: record },
+        },
+      }));
+    };
+    writeRun({ record: { status: 'pending', result: null, runId, startedAt, name } });
+    const registered = await registerScriptRunListeners({
+      set,
+      get,
+      sessionId,
+      scriptId,
+      runId,
+      startedAt,
+      name,
+    });
+    try {
+      await runAdhocScript({
+        scriptId,
+        name,
+        body: command,
+        runId,
+        sessionId,
+        cwd,
+        cols,
+        rows,
+      });
+    } catch (caughtError) {
+      registered.dispose();
+      const result: ScriptRunResult = {
+        stdout: '',
+        stderr: formatError(caughtError),
+        exitCode: -1,
+      };
+      writeRun({ record: { status: 'error', result, runId, startedAt, name } });
+      return result;
+    }
+    return registered.result;
+  };
+};

--- a/apps/desktop/src/store/slices/scripts/runScript.ts
+++ b/apps/desktop/src/store/slices/scripts/runScript.ts
@@ -68,6 +68,7 @@ export const runScript = (set: SetFn, get: GetFn) => {
       scriptId,
       runId,
       startedAt,
+      name: script.name,
     });
 
     try {

--- a/apps/desktop/src/store/slices/scripts/scanDiscoveredScripts.ts
+++ b/apps/desktop/src/store/slices/scripts/scanDiscoveredScripts.ts
@@ -1,0 +1,61 @@
+import type { SessionId } from '@goodboy/types';
+import { formatError } from '@goodboy/ui';
+import { scanProjectScripts } from '../../../features/scripts/scripts';
+import type { GetFn, SetFn } from './types';
+
+type Params = {
+  readonly set: SetFn;
+  readonly get: GetFn;
+  readonly sessionId: SessionId;
+  readonly worktreePath: string;
+  readonly force: boolean;
+};
+
+export const scanDiscoveredScripts = async ({
+  set,
+  get,
+  sessionId,
+  worktreePath,
+  force,
+}: Params): Promise<void> => {
+  const current = get().discoveredScriptScans[sessionId]?.[worktreePath];
+  const cached = get().discoveredScripts[sessionId]?.[worktreePath];
+  if (current?.status === 'loading' || (!force && cached !== undefined)) {
+    return;
+  }
+  set((state) => ({
+    discoveredScriptScans: {
+      ...state.discoveredScriptScans,
+      [sessionId]: {
+        ...state.discoveredScriptScans[sessionId],
+        [worktreePath]: { status: 'loading', error: null },
+      },
+    },
+  }));
+  try {
+    const groups = await scanProjectScripts({ worktreePath });
+    set((state) => ({
+      discoveredScripts: {
+        ...state.discoveredScripts,
+        [sessionId]: { ...state.discoveredScripts[sessionId], [worktreePath]: groups },
+      },
+      discoveredScriptScans: {
+        ...state.discoveredScriptScans,
+        [sessionId]: {
+          ...state.discoveredScriptScans[sessionId],
+          [worktreePath]: { status: 'ready', error: null },
+        },
+      },
+    }));
+  } catch (caughtError) {
+    set((state) => ({
+      discoveredScriptScans: {
+        ...state.discoveredScriptScans,
+        [sessionId]: {
+          ...state.discoveredScriptScans[sessionId],
+          [worktreePath]: { status: 'error', error: formatError(caughtError) },
+        },
+      },
+    }));
+  }
+};

--- a/apps/desktop/src/store/slices/scripts/state.ts
+++ b/apps/desktop/src/store/slices/scripts/state.ts
@@ -1,0 +1,25 @@
+import type { ProjectScript, SessionId, WorkspaceId } from '@goodboy/types';
+import type { ScriptGroup, ScriptRunRecord } from '../../../features/scripts/scripts';
+
+export type DiscoveredScriptScan = {
+  readonly status: 'loading' | 'ready' | 'error';
+  readonly error: string | null;
+};
+
+export type ScriptsSliceState = {
+  readonly projectScripts: Readonly<Record<WorkspaceId, ReadonlyArray<ProjectScript>>>;
+  readonly scriptRuns: Readonly<Record<SessionId, Readonly<Record<string, ScriptRunRecord>>>>;
+  readonly discoveredScripts: Readonly<
+    Record<SessionId, Readonly<Record<string, ReadonlyArray<ScriptGroup>>>>
+  >;
+  readonly discoveredScriptScans: Readonly<
+    Record<SessionId, Readonly<Record<string, DiscoveredScriptScan>>>
+  >;
+};
+
+export const initialScriptsState: ScriptsSliceState = {
+  projectScripts: {},
+  scriptRuns: {},
+  discoveredScripts: {},
+  discoveredScriptScans: {},
+};

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -134,6 +134,7 @@ import type {
 import type { SpawnFocus } from './slices/session-view/spawnFocus';
 import { createTerminalSlice } from './slices/terminal';
 import { createScriptsSlice } from './slices/scripts';
+import { initialScriptsState } from './slices/scripts/state';
 import { createPermissionsSlice } from './slices/permissions';
 import {
   createProvidersSlice,
@@ -214,6 +215,21 @@ type SaveScriptParams = {
 type RunScriptParams = {
   readonly sessionId: SessionId;
   readonly scriptId: ProjectScriptId;
+  readonly cols?: number;
+  readonly rows?: number;
+};
+
+type DiscoveredScriptsParams = {
+  readonly sessionId: SessionId;
+  readonly worktreePath: string;
+};
+
+type RunDiscoveredScriptParams = {
+  readonly sessionId: SessionId;
+  readonly scriptId: string;
+  readonly name: string;
+  readonly command: string;
+  readonly cwd: string;
   readonly cols?: number;
   readonly rows?: number;
 };
@@ -527,9 +543,12 @@ type AppActions = {
   loadScripts(workspaceId: WorkspaceId): Promise<void>;
   saveScript(input: SaveScriptParams): Promise<void>;
   deleteScript(scriptId: ProjectScriptId, workspaceId: WorkspaceId): Promise<void>;
+  loadDiscoveredScripts(input: DiscoveredScriptsParams): Promise<void>;
+  refreshDiscoveredScripts(input: DiscoveredScriptsParams): Promise<void>;
   runScript(input: RunScriptParams): Promise<ScriptRunResult>;
+  runDiscoveredScript(input: RunDiscoveredScriptParams): Promise<ScriptRunResult>;
   reattachScriptRuns(): Promise<void>;
-  cancelScript(sessionId: SessionId, scriptId: ProjectScriptId): Promise<void>;
+  cancelScript(sessionId: SessionId, scriptId: string): Promise<void>;
   loadPhaseTemplates(workspaceId: WorkspaceId): Promise<void>;
   savePhaseTemplate(template: WorkflowUpsertArgs): Promise<Workflow>;
   deleteWorkflow(id: WorkflowId, workspaceId: WorkspaceId): Promise<void>;
@@ -873,6 +892,7 @@ export const initialState: AppState = {
   ...initialUpdaterState,
   ...initialChangelogState,
   ...initialBugReportDraftState,
+  ...initialScriptsState,
   ...createInitialSessionViewState({}),
   selectedProjectIds: {},
   workspaces: [],
@@ -936,8 +956,6 @@ export const initialState: AppState = {
   providerSpendBreakdown: [],
   budgetAlerts: [],
   skills: {},
-  projectScripts: {},
-  scriptRuns: {},
   phaseTemplates: {},
   stepLibrary: {},
   sessionWorkflows: {},

--- a/apps/desktop/src/store/types.ts
+++ b/apps/desktop/src/store/types.ts
@@ -52,7 +52,6 @@ import type {
   WorkspaceId,
   IntegrationBinding,
   ProjectScript,
-  ProjectScriptId,
 } from '@goodboy/types';
 import type { SessionWorktree } from '@goodboy/db';
 import type { AgentKind } from '../features/session/agent-kind';
@@ -67,7 +66,8 @@ import type {
   ProviderStatus,
 } from '../features/providers/providers';
 import type { ProviderCooldowns } from '../features/providers/routing';
-import type { ScriptRunRecord } from '../features/scripts/scripts';
+import type { ScriptGroup, ScriptRunRecord } from '../features/scripts/scripts';
+import type { DiscoveredScriptScan } from './slices/scripts/state';
 import type { DetectedEditor } from '../shared/lib/editor';
 import type { TerminalTab, TerminalTabId } from '../shared/types/terminal';
 import type { DraftAttachment } from './slices/agents/setAgentAttachments';
@@ -235,8 +235,12 @@ export type AppState = AppSliceState & {
   readonly budgetAlerts: ReadonlyArray<BudgetAlert>;
   readonly skills: Readonly<Record<WorkspaceId, ReadonlyArray<Skill>>>;
   readonly projectScripts: Readonly<Record<WorkspaceId, ReadonlyArray<ProjectScript>>>;
-  readonly scriptRuns: Readonly<
-    Record<SessionId, Readonly<Record<ProjectScriptId, ScriptRunRecord>>>
+  readonly scriptRuns: Readonly<Record<SessionId, Readonly<Record<string, ScriptRunRecord>>>>;
+  readonly discoveredScripts: Readonly<
+    Record<SessionId, Readonly<Record<string, ReadonlyArray<ScriptGroup>>>>
+  >;
+  readonly discoveredScriptScans: Readonly<
+    Record<SessionId, Readonly<Record<string, DiscoveredScriptScan>>>
   >;
   readonly phaseTemplates: Readonly<Record<WorkspaceId, ReadonlyArray<Workflow>>>;
   readonly stepLibrary: Readonly<Record<WorkspaceId, ReadonlyArray<StepDef>>>;


### PR DESCRIPTION
The Scripts surface now shows every script the mounted project defines, without importing anything: a new project_scripts_scan command (async, spawn_blocking) reads the root package.json, expands workspaces/pnpm-workspace globs (node_modules/.git/vendor excluded, 50-package cap, lenient parsing), detects the package manager from the lockfile and lists composer.json scripts last. Discovered scripts are virtual per-session state (lazy scan on lens open, cached, refreshable, evicted with the session), grouped per package in the panel with the same run affordance as user scripts; runs go through a new workspace_script_run_adhoc that shares the PTY machinery and live-run registry, so stop, dots and reload reattach behave identically. Full desktop suite (6501 tests) and cargo (594 tests) green.

Note: the tauri-command parity step is red on main independently of this branch (bridge_stop orphaned by #1606); hotfix incoming, this PR's check gets rerun after it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)