### PR TITLE
fix(core): drop the orphaned bridge_stop command

### DIFF
--- a/apps/desktop/src-tauri/src/bridge/mod.rs
+++ b/apps/desktop/src-tauri/src/bridge/mod.rs
@@ -211,12 +211,6 @@ pub async fn bridge_start(
     })
 }
 
-#[tauri::command]
-pub async fn bridge_stop(state: State<'_, BridgeState>) -> Result<(), BridgeError> {
-    state.stop().await;
-    Ok(())
-}
-
 /// Desktop-initiated disconnect ("forget device"): clears the enrolled-phone
 /// allow-list and tears the bridge down, dropping any live connection. The phone
 /// must scan a fresh QR to reconnect — re-pairing is a deliberate act here on the

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -204,7 +204,6 @@ pub fn run() {
             db::db_select,
             db::db_wipe,
             bridge::bridge_start,
-            bridge::bridge_stop,
             bridge::bridge_status,
             bridge::bridge_command_result,
             bridge::bridge_revoke,


### PR DESCRIPTION
Main's tauri-command parity step went red after #1606: the knip cut removed the dead bridgeStop frontend export, which was the only invoker of the rust bridge_stop command, leaving it registered with no caller. The command was a thin wrapper over BridgeState::stop, which bridge_revoke still exercises, so it goes away entirely. Parity back to 230/230, bridge module tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)