### PR TITLE
chore(repo): bump version to 0.2.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,54 @@ version in the same PR that bumps the version numbers (see
 `docs/release-command.md`), before the tag is pushed: the release build fails
 if it can't find a matching `## Goodboy vX.Y.Z` heading.
 
+## Goodboy v0.2.9
+
+Your project's own scripts show up by themselves, the breadcrumb earns
+its place, and the app stops freezing on heavy git work.
+
+### [#1611] Manifest scripts appear on their own
+
+The Scripts surface now lists every script your project already defines:
+the root package.json, every workspace package in a monorepo (pnpm or npm
+workspaces), and composer.json, grouped per package with the package
+manager detected from the lockfile. Nothing is imported or duplicated;
+the list is scanned fresh when you open the lens, and discovered scripts
+run, stop and survive a reload exactly like the ones you write by hand.
+
+### [#1609] Deleting and fast-forwarding no longer freeze the app
+
+Deleting a session or worktree and fast-forwarding a project ran their
+git and filesystem work on the thread the interface depends on, so the
+whole window locked until they finished. That work now runs off the main
+thread; the app stays responsive throughout.
+
+### [#1610] The breadcrumb earns its place
+
+The session breadcrumb now carries section icons, the live status of the
+selected agent, and the pending count on the resolve crumb, with a
+clearly readable current step. Scripts and terminal also stop sharing
+near-identical icons everywhere they appear.
+
+### [#1607] Every detail page lines up with the overview
+
+Agent, resolver, pull request and integration detail pages used to put
+secondary chips above a smaller title at a different height than the
+overview. Every detail surface now leads with its title at the same size
+and offset as the overview, with the chips below.
+
+### [#1608] Split work is labeled for what it is
+
+An agent that fans its work out to children showed them as "scouts" no
+matter what they were, while the parent claimed it had not started. The
+group is now named after its children, and the parent says it delegated
+and how many children are still running.
+
+### Under the hood
+
+Knip gains a production pass in CI, funding a sweep of dead exports and
+test-only modules [#1606]; the sweep orphaned one unused rust command,
+removed in [#1612].
+
 ## Goodboy v0.2.8
 
 Base branches become a real picker, suggested next steps stop spawning

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goodboy/desktop",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -1626,7 +1626,7 @@ dependencies = [
 
 [[package]]
 name = "goodboy-desktop"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goodboy-desktop"
-version = "0.2.8"
+version = "0.2.9"
 description = "Goodboy desktop app"
 authors = ["Amin Khayam"]
 license = "MIT"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Goodboy",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "identifier": "com.goodboy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goodboy",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "private": true,
   "description": "AI workspace orchestrator. Local-first, provider-agnostic.",
   "license": "MIT",

--- a/website/src/site.ts
+++ b/website/src/site.ts
@@ -1,5 +1,5 @@
 export const SITE = {
-  version: 'v0.2.8',
+  version: 'v0.2.9',
   repo: 'https://github.com/akhayam99/goodboy',
   releases: 'https://github.com/akhayam99/goodboy/releases',
   latest: 'https://github.com/akhayam99/goodboy/releases/latest',


### PR DESCRIPTION
Version bump to 0.2.9 across the six version locations plus the CHANGELOG section release.yml reads for the v0.2.9 tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)