### PR TITLE
fix(ui): let the brief follow-up implementer fan out on the plan

### DIFF
--- a/apps/desktop/src/features/session/components/AgentDetailPane/AgentBrief.tsx
+++ b/apps/desktop/src/features/session/components/AgentDetailPane/AgentBrief.tsx
@@ -129,6 +129,10 @@ export const AgentBrief = ({ session, agent }: Props) => {
         summary={summary}
         sessionId={session.id}
         followUps={followUps}
+        activePlanId={
+          [...plans].reverse().find((plan) => plan.agentId === agent.id && plan.status === 'active')
+            ?.id ?? null
+        }
       />
       <AgentBriefChildren session={session} kind={kind} children={laneChildren} />
       <AgentMetaLine

--- a/apps/desktop/src/features/session/components/AgentDetailPane/AgentFollowUps.test.tsx
+++ b/apps/desktop/src/features/session/components/AgentDetailPane/AgentFollowUps.test.tsx
@@ -126,7 +126,10 @@ describe('AgentFollowUps suggestions', () => {
     screen.getByText('Fix these review findings').click();
     await vi.waitFor(() => expect(state.spawnAgent).toHaveBeenCalledTimes(1));
 
-    const options = state.spawnAgent.mock.calls[0]?.[1] as Record<string, unknown>;
+    const options = (state.spawnAgent.mock.calls[0] as ReadonlyArray<unknown>)[1] as Record<
+      string,
+      unknown
+    >;
     expect(options.kindOverride).toBe('implementer');
     expect(options.triggeredPlanId).toBe('plan-1');
     expect(options.initialPrompt).toBeUndefined();
@@ -148,7 +151,10 @@ describe('AgentFollowUps suggestions', () => {
     screen.getByText('Fix these review findings').click();
     await vi.waitFor(() => expect(state.spawnAgent).toHaveBeenCalledTimes(1));
 
-    const options = state.spawnAgent.mock.calls[0]?.[1] as Record<string, unknown>;
+    const options = (state.spawnAgent.mock.calls[0] as ReadonlyArray<unknown>)[1] as Record<
+      string,
+      unknown
+    >;
     expect(options.triggeredPlanId).toBeUndefined();
     expect(typeof options.initialPrompt).toBe('string');
     expect((options.initialPrompt as string).length).toBeGreaterThan(0);

--- a/apps/desktop/src/features/session/components/AgentDetailPane/AgentFollowUps.test.tsx
+++ b/apps/desktop/src/features/session/components/AgentDetailPane/AgentFollowUps.test.tsx
@@ -2,7 +2,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, render, screen } from '@testing-library/react';
-import type { Agent, AgentId, OpenQuestion, SessionId } from '@goodboy/types';
+import type { Agent, AgentId, OpenQuestion, PlanId, SessionId } from '@goodboy/types';
 import type { SpawnedChild } from '../../../../shared/utils/spawnedChildren';
 
 const state = vi.hoisted(() => ({
@@ -81,6 +81,7 @@ describe('AgentFollowUps suggestions', () => {
         summary="two findings"
         sessionId={sessionId}
         followUps={[]}
+        activePlanId={null}
       />,
     );
 
@@ -97,6 +98,7 @@ describe('AgentFollowUps suggestions', () => {
         summary="two findings"
         sessionId={sessionId}
         followUps={[]}
+        activePlanId={null}
       />,
     );
 
@@ -107,6 +109,49 @@ describe('AgentFollowUps suggestions', () => {
       sessionId,
       expect.objectContaining({ kindOverride: 'planner', parentAgentId: sourceId }),
     );
+  });
+
+  it('hands the active plan to an implementer instead of a seed so it can fan out', async () => {
+    render(
+      <AgentFollowUps
+        sourceAgent={source}
+        sourceKind="reviewer"
+        summary="two findings"
+        sessionId={sessionId}
+        followUps={[]}
+        activePlanId={'plan-1' as PlanId}
+      />,
+    );
+
+    screen.getByText('Fix these review findings').click();
+    await vi.waitFor(() => expect(state.spawnAgent).toHaveBeenCalledTimes(1));
+
+    const options = state.spawnAgent.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(options.kindOverride).toBe('implementer');
+    expect(options.triggeredPlanId).toBe('plan-1');
+    expect(options.initialPrompt).toBeUndefined();
+    expect(options.parentAgentId).toBe(sourceId);
+  });
+
+  it('keeps the seed on an implementer when no plan exists', async () => {
+    render(
+      <AgentFollowUps
+        sourceAgent={source}
+        sourceKind="reviewer"
+        summary="two findings"
+        sessionId={sessionId}
+        followUps={[]}
+        activePlanId={null}
+      />,
+    );
+
+    screen.getByText('Fix these review findings').click();
+    await vi.waitFor(() => expect(state.spawnAgent).toHaveBeenCalledTimes(1));
+
+    const options = state.spawnAgent.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(options.triggeredPlanId).toBeUndefined();
+    expect(typeof options.initialPrompt).toBe('string');
+    expect((options.initialPrompt as string).length).toBeGreaterThan(0);
   });
 });
 
@@ -119,6 +164,7 @@ describe('AgentFollowUps after a spawn', () => {
         summary="two findings"
         sessionId={sessionId}
         followUps={[makeChild({})]}
+        activePlanId={null}
       />,
     );
 
@@ -135,6 +181,7 @@ describe('AgentFollowUps after a spawn', () => {
         summary="two findings"
         sessionId={sessionId}
         followUps={[makeChild({ status: 'completed' })]}
+        activePlanId={null}
       />,
     );
 
@@ -159,6 +206,7 @@ describe('AgentFollowUps after a spawn', () => {
         summary="two findings"
         sessionId={sessionId}
         followUps={[makeChild({})]}
+        activePlanId={null}
       />,
     );
 
@@ -173,6 +221,7 @@ describe('AgentFollowUps after a spawn', () => {
         summary="two findings"
         sessionId={sessionId}
         followUps={[makeChild({})]}
+        activePlanId={null}
       />,
     );
 

--- a/apps/desktop/src/features/session/components/AgentDetailPane/AgentFollowUps.tsx
+++ b/apps/desktop/src/features/session/components/AgentDetailPane/AgentFollowUps.tsx
@@ -1,6 +1,6 @@
 import { ArrowRight } from 'lucide-react';
 import { SectionSurface, cn } from '@goodboy/ui';
-import type { Agent, SessionId } from '@goodboy/types';
+import type { Agent, PlanId, SessionId } from '@goodboy/types';
 import { useAppStore } from '../../../../store';
 import { useAgentStartedToast } from '../../../../shared/hooks/useAgentStartedToast';
 import type { AgentKind } from '../../agent-kind';
@@ -16,6 +16,7 @@ type Props = {
   readonly summary: string;
   readonly sessionId: SessionId;
   readonly followUps: ReadonlyArray<FollowUpChild>;
+  readonly activePlanId: PlanId | null;
 };
 
 export const AgentFollowUps = ({
@@ -24,6 +25,7 @@ export const AgentFollowUps = ({
   summary,
   sessionId,
   followUps,
+  activePlanId,
 }: Props) => {
   const spawnAgent = useAppStore((state) => state.spawnAgent);
   const announceAgentStarted = useAgentStartedToast();
@@ -43,11 +45,13 @@ export const AgentFollowUps = ({
   const pending = moves.filter((move) => !spawnedKinds.has(move.kind));
 
   const onSpawn = (nextKind: AgentKind) => {
-    const seed = composeFollowUpSeed({ sourceAgent, summary });
+    const planDriven = nextKind === 'implementer' && activePlanId != null;
     void (async () => {
       const agentId = await spawnAgent(sessionId, {
         kindOverride: nextKind,
-        initialPrompt: seed,
+        ...(planDriven
+          ? { triggeredPlanId: activePlanId }
+          : { initialPrompt: composeFollowUpSeed({ sourceAgent, summary }) }),
         parentAgentId: sourceAgent.id,
         focus: 'agent',
       });


### PR DESCRIPTION
Spawning an implementer from the plan surface fans out into cluster children; the same spawn from the planner's brief did not. Root cause: fan-out is gated on an empty initialPrompt, and the brief follow-up always sent its non-empty seed, silently disabling clustering even though the plan existed. The brief now resolves the source agent's most recent active plan and, when spawning an implementer with one, passes triggeredPlanId with no seed (the attached plan is the context); every other follow-up keeps the seed. The spawnAgent contract is untouched: explicit initialPrompt still means no fan-out for callers that author their own kickoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)