### PR TITLE
fix(ui): wait out the summarizer before a static autorun advance

### DIFF
--- a/apps/desktop/src/store/slices/turn/sendTurn.ts
+++ b/apps/desktop/src/store/slices/turn/sendTurn.ts
@@ -1318,7 +1318,7 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
     }
 
     if (!lastError && shouldAutoAdvanceWorkflow) {
-      await get().maybeAutoAdvanceWorkflow(sessionId);
+      void get().maybeAutoAdvanceWorkflow(sessionId);
     }
 
     if (lastError) {

--- a/apps/desktop/src/store/slices/workflows/maybeAutoAdvanceWorkflow.test.ts
+++ b/apps/desktop/src/store/slices/workflows/maybeAutoAdvanceWorkflow.test.ts
@@ -371,22 +371,50 @@ describe('maybeAutoAdvanceWorkflow', () => {
     });
   });
 
-  it('holds while the summarizer runs and advances once it finishes', async () => {
-    const state = baseState(['s0'], [makeAgent('s0', 'pending', 0)]);
-    state['summarizerStatus'] = { [SESSION_ID]: { status: 'running' } };
-    const { set, get } = harness(state);
-    const advance = maybeAutoAdvanceWorkflow(set, get);
+  it('waits out a running summarizer and advances in the same call', async () => {
+    vi.useFakeTimers();
+    try {
+      const state = baseState(['s0'], [makeAgent('s0', 'pending', 0)]);
+      state['summarizerStatus'] = { [SESSION_ID]: { status: 'running' } };
+      const { set, get } = harness(state);
+      const advance = maybeAutoAdvanceWorkflow(set, get);
 
-    await advance(SESSION_ID);
-    expect(state['activateWorkflowAgent']).not.toHaveBeenCalled();
+      const pending = advance(SESSION_ID);
+      await vi.advanceTimersByTimeAsync(300);
+      expect(state['activateWorkflowAgent']).not.toHaveBeenCalled();
 
-    state['summarizerStatus'] = { [SESSION_ID]: { status: 'idle' } };
-    await advance(SESSION_ID);
-    expect(state['activateWorkflowAgent']).toHaveBeenCalledWith({
-      sessionId: SESSION_ID,
-      agentId: `${RUN_ID}-s0`,
-      focus: 'announce',
-    });
+      state['summarizerStatus'] = { [SESSION_ID]: { status: 'idle' } };
+      await vi.advanceTimersByTimeAsync(300);
+      await pending;
+      expect(state['activateWorkflowAgent']).toHaveBeenCalledWith({
+        sessionId: SESSION_ID,
+        agentId: `${RUN_ID}-s0`,
+        focus: 'announce',
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('gives up on a stuck summarizer after the gate timeout and advances anyway', async () => {
+    vi.useFakeTimers();
+    try {
+      const state = baseState(['s0'], [makeAgent('s0', 'pending', 0)]);
+      state['summarizerStatus'] = { [SESSION_ID]: { status: 'running' } };
+      const { set, get } = harness(state);
+      const advance = maybeAutoAdvanceWorkflow(set, get);
+
+      const pending = advance(SESSION_ID);
+      await vi.advanceTimersByTimeAsync(61_000);
+      await pending;
+      expect(state['activateWorkflowAgent']).toHaveBeenCalledWith({
+        sessionId: SESSION_ID,
+        agentId: `${RUN_ID}-s0`,
+        focus: 'announce',
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('orchestrates a dynamic run when no pending agent exists', async () => {
@@ -556,9 +584,6 @@ describe('maybeAutoAdvanceWorkflow', () => {
     const { set, get } = harness(state);
     const advance = maybeAutoAdvanceWorkflow(set, get);
 
-    state['summarizerStatus'] = { [SESSION_ID]: { status: 'running' } };
-    await advance(SESSION_ID);
-    state['summarizerStatus'] = {};
     state['budgetAlerts'] = [{ kind: 'provider-exceeded' }];
     await advance(SESSION_ID);
     expect(updateOrchestrationStopSpy).toHaveBeenCalledWith({}, RUN_ID, {

--- a/apps/desktop/src/store/slices/workflows/maybeAutoAdvanceWorkflow.ts
+++ b/apps/desktop/src/store/slices/workflows/maybeAutoAdvanceWorkflow.ts
@@ -13,6 +13,7 @@ import {
 import { persistOrchestrationStop } from './orchestrateNextStep';
 import { activateWorkflowAgentOrNotify } from './activateWorkflowAgentOrNotify';
 import { resumeClusterChildren, unsettledClusterChildren } from './clusterImplementation';
+import { waitForSessionSummarizer } from './summarizerGate';
 import type { GetFn, SetFn } from './types';
 
 const advanceInFlight = new Set<SessionId>();
@@ -64,6 +65,7 @@ const startChainedRuns = async ({ get, sessionId }: Params): Promise<void> => {
 
 const runAdvance = async ({ set, get, sessionId }: Params): Promise<void> => {
   await startChainedRuns({ set, get, sessionId });
+  await waitForSessionSummarizer({ get, sessionId });
 
   const state = get();
   const session = state.sessions.find((s) => s.id === sessionId);
@@ -74,9 +76,6 @@ const runAdvance = async ({ set, get, sessionId }: Params): Promise<void> => {
     .filter((r) => r.autoRun && r.discardedAt == null && r.triggerMode === 'immediate')
     .sort((a, b) => a.ordinal - b.ordinal);
   if (activeRuns.length === 0) {
-    return;
-  }
-  if (state.summarizerStatus[sessionId]?.status === 'running') {
     return;
   }
   const sessionBlocked = isBudgetBlocked({ alerts: state.budgetAlerts, sessionId });

--- a/apps/desktop/src/store/slices/workflows/orchestrateNextStep.ts
+++ b/apps/desktop/src/store/slices/workflows/orchestrateNextStep.ts
@@ -54,6 +54,7 @@ import { preSpawnWorkflowAgents } from './preSpawnWorkflowAgents';
 import { patchWorkflowRun, withoutKeys } from './patchWorkflowRun';
 import { recordOrchestratorUsage } from './recordOrchestratorUsage';
 import { findWorkflowActivationBlock } from './workflowActivationGate';
+import { waitForSessionSummarizer } from './summarizerGate';
 import { WORKFLOW_BLOCK_COPY } from '../../../features/workflows/blockCopy';
 import type { GetFn, SetFn } from './types';
 
@@ -64,29 +65,6 @@ export type OrchestrateOptions = {
 };
 
 const orchestrationInFlight = new Set<WorkflowRunId>();
-
-const SUMMARIZER_GATE_POLL_MS = 100;
-const SUMMARIZER_GATE_TIMEOUT_MS = 60_000;
-
-type SummarizerGateParams = {
-  readonly get: GetFn;
-  readonly sessionId: SessionId;
-};
-
-const waitForSessionSummarizer = async ({
-  get,
-  sessionId,
-}: SummarizerGateParams): Promise<void> => {
-  const deadline = Date.now() + SUMMARIZER_GATE_TIMEOUT_MS;
-  while (get().summarizerStatus[sessionId]?.status === 'running') {
-    if (Date.now() >= deadline) {
-      return;
-    }
-    await new Promise<void>((resolve) => {
-      setTimeout(resolve, SUMMARIZER_GATE_POLL_MS);
-    });
-  }
-};
 
 type DecidingParams = {
   readonly set: SetFn;

--- a/apps/desktop/src/store/slices/workflows/summarizerGate.ts
+++ b/apps/desktop/src/store/slices/workflows/summarizerGate.ts
@@ -1,0 +1,25 @@
+import type { SessionId } from '@goodboy/types';
+import type { GetFn } from './types';
+
+const SUMMARIZER_GATE_POLL_MS = 100;
+const SUMMARIZER_GATE_TIMEOUT_MS = 60_000;
+
+type SummarizerGateParams = {
+  readonly get: GetFn;
+  readonly sessionId: SessionId;
+};
+
+export const waitForSessionSummarizer = async ({
+  get,
+  sessionId,
+}: SummarizerGateParams): Promise<void> => {
+  const deadline = Date.now() + SUMMARIZER_GATE_TIMEOUT_MS;
+  while (get().summarizerStatus[sessionId]?.status === 'running') {
+    if (Date.now() >= deadline) {
+      return;
+    }
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, SUMMARIZER_GATE_POLL_MS);
+    });
+  }
+};


### PR DESCRIPTION
Autorun advanced orchestrated (dynamic) workflows but silently parked custom and preset (static) ones. The dynamic path got a bounded summarizer wait in #1304 (poll, 60s cap, proceed anyway) inside orchestrateNextStep, while the static path kept the bare early-return in maybeAutoAdvanceWorkflow and depended on a single deferred wake from the summarizer queue's finally, which a stuck or racing summarizer never delivers. The gate is now the same bounded wait for both paths, extracted to summarizerGate.ts: an advance tick waits for the summarizer in the same call and gives up after 60 seconds instead of returning silently. Tests pin both the wait-then-advance and the timeout-then-advance behavior with fake timers; the whole workflows area is green (498 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)