### PR TITLE
test(ui): await the post-turn advance in plan consumption specs

### DIFF
--- a/apps/desktop/src/store/store.plan-consumption-ordering.test.ts
+++ b/apps/desktop/src/store/store.plan-consumption-ordering.test.ts
@@ -437,7 +437,9 @@ describe('autorun plan consumption ordering', () => {
     expect(upsertPlanSpy).toHaveBeenCalledTimes(1);
     const persisted = planBacking.plans[0]!;
     expect(persisted.bodyMd).toBe('do the thing');
-    expect(addPlanConsumptionSpy).toHaveBeenCalledWith(persisted.id, IMPL_ID);
+    await vi.waitFor(() =>
+      expect(addPlanConsumptionSpy).toHaveBeenCalledWith(persisted.id, IMPL_ID),
+    );
     expect(planBacking.plans[0]!.status).toBe('consumed');
     expect(planBacking.consumptions[persisted.id]).toHaveLength(1);
 
@@ -484,8 +486,10 @@ describe('autorun plan consumption ordering', () => {
     expect(upsertPlanSpy).toHaveBeenCalledTimes(1);
     const persisted = planBacking.plans[0]!;
     expect(persisted.clusters).toHaveLength(2);
-    expect(addPlanConsumptionSpy).toHaveBeenCalledWith(persisted.id, IMPL_ID);
-    expect(fanOutClustersSpy).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() =>
+      expect(addPlanConsumptionSpy).toHaveBeenCalledWith(persisted.id, IMPL_ID),
+    );
+    await vi.waitFor(() => expect(fanOutClustersSpy).toHaveBeenCalledTimes(1));
   });
 
   it('persists the plan strictly before recording its consumption (race-fix invariant)', async () => {


### PR DESCRIPTION
#1615 made the post-turn workflow advance fire-and-forget (per review, so sendTurn callers are never held by the summarizer gate). Two specs in store.plan-consumption-ordering.test.ts still asserted the plan consumption and cluster fan-out synchronously right after awaiting sendTurn, which now races the detached advance: green locally when microtasks win, red on CI. The branch merged before this fix landed on it, so main carries the red.

Wraps the consumption and fan-out assertions in vi.waitFor. No production code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)