### PR TITLE
fix(core): lock the summarizer spawn out of builtin tools

### DIFF
--- a/apps/desktop/src-tauri/src/summarize.rs
+++ b/apps/desktop/src-tauri/src/summarize.rs
@@ -189,6 +189,8 @@ fn build_cli_args(args: &SummarizeArgs) -> Result<Vec<String>, SummarizeError> {
                 "--output-format".to_string(),
                 "json".to_string(),
                 "--no-session-persistence".to_string(),
+                "--tools".to_string(),
+                String::new(),
             ];
             crate::aux_spawn::push_claude_mcp_deny(&mut cli_args);
             crate::aux_spawn::push_effort_args("anthropic", args.effort.as_deref(), &mut cli_args);
@@ -286,6 +288,13 @@ mod tests {
             .expect("--setting-sources");
         assert_eq!(cli[idx + 1], "project,local");
         assert!(!cli.iter().any(|a| a == "--bare"));
+    }
+
+    #[test]
+    fn anthropic_args_disable_builtin_tools() {
+        let cli = build_cli_args(&make_args("anthropic")).expect("anthropic args");
+        let idx = cli.iter().position(|a| a == "--tools").expect("--tools");
+        assert_eq!(cli[idx + 1], "");
     }
 
     #[test]


### PR DESCRIPTION
The anthropic branch of the summarizer spawn never passed `--tools \"\"`, so `claude -p` ran with its default toolset inside the session worktree. On stronger models with high effort the summarizer went agentic and explored the repo before answering: production telemetry shows single summarizer runs reading 2.19M cached input tokens and emitting 40k output tokens, and one session accumulated $43.29 of summarizer spend over 169 runs. The planner already guards against this; the summarizer never got the same lockdown (same failure mode as the dynamic orchestrator incident fixed in v0.1.47).

The summarizer prompt is fully self-contained (slots + turn input + turn output, JSON out), so builtin tools are disabled unconditionally. Both the session summarizer and the step-output summarizer go through this spawn. New rust test pins the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)