### PR TITLE
feat(ui): redesign scripts pane with grouping, search, collapse

### DIFF
--- a/apps/desktop/src/features/scripts/components/RunningScriptsIndicator/useRunningScripts.test.ts
+++ b/apps/desktop/src/features/scripts/components/RunningScriptsIndicator/useRunningScripts.test.ts
@@ -13,6 +13,7 @@ import type { ScriptRunRecord } from '../../scripts';
 type StoreState = {
   readonly scriptRuns: Readonly<Record<string, Readonly<Record<string, ScriptRunRecord>>>>;
   readonly sessions: ReadonlyArray<Session>;
+  readonly archivedSessions: Readonly<Record<string, ReadonlyArray<Session>>>;
   readonly projectScripts: Readonly<Record<string, ReadonlyArray<ProjectScript>>>;
 };
 
@@ -21,6 +22,7 @@ const { store } = vi.hoisted(() => ({
     state: {
       scriptRuns: {},
       sessions: [],
+      archivedSessions: {},
       projectScripts: {},
     } as StoreState,
   },
@@ -44,6 +46,7 @@ beforeEach(() => {
   store.state = {
     scriptRuns: {},
     sessions: [],
+    archivedSessions: {},
     projectScripts: {},
   };
 });
@@ -54,6 +57,38 @@ afterEach(() => {
 });
 
 describe('useRunningScripts', () => {
+  it('counts a pending run from an archived session', () => {
+    store.state = {
+      sessions: [],
+      archivedSessions: {
+        [WORKSPACE_A]: [
+          { id: SESSION_A, workspaceId: WORKSPACE_A, goal: 'archived goal' } as Session,
+        ],
+      },
+      projectScripts: {
+        [WORKSPACE_A]: [
+          { id: SHARED_SCRIPT, projectId: PROJECT_A, name: 'archived setup' } as ProjectScript,
+        ],
+      },
+      scriptRuns: {
+        [SESSION_A]: {
+          [SHARED_SCRIPT]: {
+            status: 'pending',
+            result: null,
+            runId: 'run-archived',
+            startedAt: 10,
+          },
+        },
+      },
+    };
+
+    const { result } = renderHook(() => useRunningScripts());
+
+    expect(result.current).toEqual([
+      expect.objectContaining({ sessionId: SESSION_A, scriptName: 'archived setup' }),
+    ]);
+  });
+
   it('resolves each running script name from its session workspace', () => {
     store.state = {
       sessions: [
@@ -68,6 +103,7 @@ describe('useRunningScripts', () => {
           goal: 'beta goal',
         } as Session,
       ],
+      archivedSessions: {},
       projectScripts: {
         [WORKSPACE_A]: [
           {
@@ -121,6 +157,7 @@ describe('useRunningScripts', () => {
           goal: 'alpha goal',
         } as Session,
       ],
+      archivedSessions: {},
       projectScripts: {
         [WORKSPACE_A]: [],
         [WORKSPACE_B]: [
@@ -160,6 +197,7 @@ describe('useRunningScripts', () => {
           goal: 'alpha goal',
         } as Session,
       ],
+      archivedSessions: {},
       projectScripts: {
         [WORKSPACE_A]: [
           {

--- a/apps/desktop/src/features/scripts/components/RunningScriptsIndicator/useRunningScripts.ts
+++ b/apps/desktop/src/features/scripts/components/RunningScriptsIndicator/useRunningScripts.ts
@@ -13,11 +13,20 @@ export type RunningScript = {
 export const useRunningScripts = (): ReadonlyArray<RunningScript> => {
   const scriptRuns = useAppStore((state) => state.scriptRuns);
   const sessions = useAppStore((state) => state.sessions);
+  const archivedSessions = useAppStore((state) => state.archivedSessions);
   const projectScripts = useAppStore((state) => state.projectScripts);
 
   return useMemo(() => {
     const running: RunningScript[] = [];
+    const sessionById = new Map(
+      Object.values(archivedSessions ?? {})
+        .flat()
+        .map((session) => [session.id, session] as const),
+    );
     for (const session of sessions) {
+      sessionById.set(session.id, session);
+    }
+    for (const session of sessionById.values()) {
       const sessionId = session.id as SessionId;
       const runs = scriptRuns[sessionId];
       if (runs === undefined) {
@@ -42,5 +51,5 @@ export const useRunningScripts = (): ReadonlyArray<RunningScript> => {
       }
     }
     return running.sort((a, b) => a.startedAt - b.startedAt);
-  }, [scriptRuns, projectScripts, sessions]);
+  }, [archivedSessions, scriptRuns, projectScripts, sessions]);
 };

--- a/apps/desktop/src/features/scripts/components/ScriptsPanel/DiscoveredScriptGroup.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsPanel/DiscoveredScriptGroup.tsx
@@ -48,7 +48,13 @@ export const DiscoveredScriptGroup = ({
         className="border border-border-soft"
         trigger={
           <span className="flex min-w-0 items-center gap-2">
-            <h3 className="truncate text-sm font-medium text-foreground">{group.packageName}</h3>
+            <span
+              role="heading"
+              aria-level={3}
+              className="truncate text-sm font-medium text-foreground"
+            >
+              {group.packageName}
+            </span>
             {group.relDir !== '' ? (
               <span className="truncate font-mono text-3xs text-muted-foreground">
                 {group.relDir}

--- a/apps/desktop/src/features/scripts/components/ScriptsPanel/DiscoveredScriptGroup.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsPanel/DiscoveredScriptGroup.tsx
@@ -1,3 +1,4 @@
+import { Collapsible } from '@goodboy/ui';
 import type { ScriptGroup, ScriptRunRecord } from '../../scripts';
 import { discoveredScriptCwd, discoveredScriptId } from '../../scripts';
 import { DiscoveredScriptRow } from './DiscoveredScriptRow';
@@ -18,6 +19,8 @@ type Props = {
   readonly worktreePath: string;
   readonly runs: Readonly<Record<string, ScriptRunRecord>> | undefined;
   readonly completedAt: Readonly<Record<string, number>>;
+  readonly open: boolean;
+  readonly onOpenChange: (open: boolean) => void;
   readonly onRun: (params: RunParams) => void;
   readonly onCancel: (params: CancelParams) => void;
 };
@@ -27,6 +30,8 @@ export const DiscoveredScriptGroup = ({
   worktreePath,
   runs,
   completedAt,
+  open,
+  onOpenChange,
   onRun,
   onCancel,
 }: Props) => {
@@ -36,49 +41,61 @@ export const DiscoveredScriptGroup = ({
   );
 
   return (
-    <section className="flex flex-col gap-2" aria-label={`${group.packageName} scripts`}>
-      <div className="flex min-w-0 items-baseline gap-2 px-0.5">
-        <h3 className="truncate text-sm font-medium text-foreground">{group.packageName}</h3>
-        {group.relDir !== '' ? (
-          <span className="truncate font-mono text-3xs text-muted-foreground">{group.relDir}</span>
-        ) : null}
-        <span className="shrink-0 text-3xs tabular-nums text-muted-foreground/70">
-          {scripts.length}
-        </span>
-        <span className="h-px flex-1 bg-border/40" aria-hidden />
-      </div>
-      <ul className="flex flex-col gap-2">
-        {scripts.map((script) => {
-          const scriptId = discoveredScriptId({
-            worktreePath,
-            source: group.source,
-            relDir: group.relDir,
-            name: script.name,
-          });
-          const run = runs?.[scriptId] ?? null;
-          return (
-            <li key={scriptId}>
-              <DiscoveredScriptRow
-                scriptId={scriptId}
-                name={script.name}
-                command={script.command}
-                cwd={cwd}
-                run={run}
-                completedAt={run == null ? undefined : completedAt[run.runId]}
-                onRun={() =>
-                  onRun({
-                    scriptId,
-                    name: script.name,
-                    command: script.command,
-                    cwd,
-                  })
-                }
-                onCancel={() => onCancel({ scriptId })}
-              />
-            </li>
-          );
-        })}
-      </ul>
+    <section aria-label={`${group.packageName} scripts`}>
+      <Collapsible
+        open={open}
+        onOpenChange={onOpenChange}
+        className="border border-border-soft"
+        trigger={
+          <span className="flex min-w-0 items-center gap-2">
+            <h3 className="truncate text-sm font-medium text-foreground">{group.packageName}</h3>
+            {group.relDir !== '' ? (
+              <span className="truncate font-mono text-3xs text-muted-foreground">
+                {group.relDir}
+              </span>
+            ) : null}
+            <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-3xs font-semibold uppercase text-muted-foreground">
+              {group.manager}
+            </span>
+            <span className="shrink-0 rounded-full bg-muted px-1.5 py-0.5 text-3xs tabular-nums text-muted-foreground">
+              {scripts.length}
+            </span>
+          </span>
+        }
+      >
+        <ul className="flex flex-col gap-1.5 pt-1.5">
+          {scripts.map((script) => {
+            const scriptId = discoveredScriptId({
+              worktreePath,
+              source: group.source,
+              relDir: group.relDir,
+              name: script.name,
+            });
+            const run = runs?.[scriptId] ?? null;
+            return (
+              <li key={scriptId}>
+                <DiscoveredScriptRow
+                  scriptId={scriptId}
+                  name={script.name}
+                  command={script.command}
+                  cwd={cwd}
+                  run={run}
+                  completedAt={run == null ? undefined : completedAt[run.runId]}
+                  onRun={() =>
+                    onRun({
+                      scriptId,
+                      name: script.name,
+                      command: script.command,
+                      cwd,
+                    })
+                  }
+                  onCancel={() => onCancel({ scriptId })}
+                />
+              </li>
+            );
+          })}
+        </ul>
+      </Collapsible>
     </section>
   );
 };

--- a/apps/desktop/src/features/scripts/components/ScriptsPanel/DiscoveredScriptRow.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsPanel/DiscoveredScriptRow.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { ChevronDown, ChevronRight, Play, Square } from 'lucide-react';
-import { CardAction, CardActionSlot, cn } from '@goodboy/ui';
+import { CardAction, CardActionSlot, StatusDot, cn } from '@goodboy/ui';
 import type { ScriptRunRecord } from '../../scripts';
 import { ScriptRunOutput } from './ScriptRunOutput';
 import { SCRIPT_RUN_PRESENTATION } from './scriptRunPresentation';
@@ -53,6 +53,9 @@ export const DiscoveredScriptRow = ({
         </button>
 
         <div className="col-start-2 row-start-1 flex items-start gap-1">
+          {status === 'pending' ? (
+            <StatusDot tone="info" pulsing ariaLabel="Running" className="mt-2" />
+          ) : null}
           <CardActionSlot label="Script lifecycle actions">
             {status === 'pending' ? (
               <CardAction

--- a/apps/desktop/src/features/scripts/components/ScriptsPanel/ManifestSearchInput.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsPanel/ManifestSearchInput.tsx
@@ -1,0 +1,40 @@
+import { Search, X } from 'lucide-react';
+import { Tooltip } from '@goodboy/ui';
+
+type Props = {
+  readonly value: string;
+  readonly onChange: (value: string) => void;
+};
+
+export const ManifestSearchInput = ({ value, onChange }: Props) => (
+  <div className="flex items-center gap-2 rounded-md border border-border-soft bg-muted/30 px-2.5 py-1.5 focus-within:ring-2 focus-within:ring-[var(--color-focus-ring)]">
+    <Search size={14} className="shrink-0 text-muted-foreground" aria-hidden />
+    <input
+      type="search"
+      aria-label="Search scripts"
+      placeholder="Search scripts"
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+      onKeyDown={(event) => {
+        if (event.key !== 'Escape') {
+          return;
+        }
+        event.preventDefault();
+        onChange('');
+      }}
+      className="min-w-0 flex-1 bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground"
+    />
+    {value !== '' ? (
+      <Tooltip content="Clear search">
+        <button
+          type="button"
+          aria-label="Clear search"
+          onClick={() => onChange('')}
+          className="rounded-sm text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
+        >
+          <X size={14} aria-hidden />
+        </button>
+      </Tooltip>
+    ) : null}
+  </div>
+);

--- a/apps/desktop/src/features/scripts/components/ScriptsPanel/ProjectScopeTabs.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsPanel/ProjectScopeTabs.tsx
@@ -1,0 +1,27 @@
+import { ScrollFade, SegmentedTabs, type SegmentedTabOption } from '@goodboy/ui';
+import type { ProjectId } from '@goodboy/types';
+
+export type ProjectFilter = 'all' | ProjectId;
+
+type Props = {
+  readonly options: ReadonlyArray<SegmentedTabOption<ProjectFilter>>;
+  readonly value: ProjectFilter;
+  readonly onChange: (value: ProjectFilter) => void;
+};
+
+export const ProjectScopeTabs = ({ options, value, onChange }: Props) => (
+  <ScrollFade
+    className="w-full"
+    viewportClassName="overflow-x-auto overflow-y-hidden"
+    fadeSize={24}
+  >
+    <SegmentedTabs
+      ariaLabel="Filter scripts by project"
+      options={options}
+      value={value}
+      onChange={onChange}
+      size="sm"
+      className="whitespace-nowrap"
+    />
+  </ScrollFade>
+);

--- a/apps/desktop/src/features/scripts/components/ScriptsPanel/ScriptRow.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsPanel/ScriptRow.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Check, ChevronDown, ChevronRight, Copy, Pencil, Play, Square, Trash2 } from 'lucide-react';
-import { InlineConfirm, Textarea, cn } from '@goodboy/ui';
+import { InlineConfirm, StatusDot, Textarea, cn } from '@goodboy/ui';
 import type { Project, ProjectId, ProjectScript } from '@goodboy/types';
 import { CardAction } from '@goodboy/ui';
 import { CardActionSlot } from '@goodboy/ui';
@@ -213,6 +213,9 @@ export const ScriptRow = ({
         </div>
 
         <div className="col-start-2 row-start-1 flex items-start gap-1">
+          {status === 'pending' ? (
+            <StatusDot tone="info" pulsing ariaLabel="Running" className="mt-2" />
+          ) : null}
           <CardActionSlot label="Script lifecycle actions">
             {runnable && status === 'pending' ? (
               <CardAction

--- a/apps/desktop/src/features/scripts/components/ScriptsPanel/UserScriptGroup.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsPanel/UserScriptGroup.tsx
@@ -1,0 +1,28 @@
+import type { ReactNode } from 'react';
+import { Collapsible } from '@goodboy/ui';
+
+type Props = {
+  readonly label: string;
+  readonly count: number;
+  readonly open: boolean;
+  readonly onOpenChange: (open: boolean) => void;
+  readonly children: ReactNode;
+};
+
+export const UserScriptGroup = ({ label, count, open, onOpenChange, children }: Props) => (
+  <Collapsible
+    open={open}
+    onOpenChange={onOpenChange}
+    className="border border-border-soft"
+    trigger={
+      <span className="flex min-w-0 items-center gap-2">
+        <span className="truncate font-medium">{label}</span>
+        <span className="rounded-full bg-muted px-1.5 py-0.5 text-3xs tabular-nums text-muted-foreground">
+          {count}
+        </span>
+      </span>
+    }
+  >
+    {children}
+  </Collapsible>
+);

--- a/apps/desktop/src/features/scripts/components/ScriptsPanel/index.test.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsPanel/index.test.tsx
@@ -148,6 +148,10 @@ describe('ScriptsPanel', () => {
     expect(
       screen.getAllByRole('heading', { level: 3 }).map((heading) => heading.textContent),
     ).toEqual(['root', '@acme/web', 'acme/api']);
+    expect(screen.getByRole('button', { name: /@acme\/web/ }).getAttribute('aria-expanded')).toBe(
+      'false',
+    );
+    fireEvent.click(screen.getByRole('button', { name: /@acme\/web/ }));
     fireEvent.click(screen.getByRole('button', { name: 'Run dev' }));
     expect(state.runDiscoveredScript).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -156,6 +160,48 @@ describe('ScriptsPanel', () => {
         command: 'pnpm run dev',
         cwd: '/tmp/api/apps/web',
       }),
+    );
+  });
+
+  it('filters every section and auto-expands matching manifest groups', () => {
+    state.scripts = [
+      { id: 's1', projectId: 'project-1', name: 'deploy user', body: 'ship production' },
+      { id: 's2', projectId: 'project-1', name: 'lint user', body: 'eslint .' },
+    ];
+    state.discoveredScripts = {
+      'session-1': {
+        '/tmp/api': [
+          {
+            source: 'package-json',
+            packageName: '@acme/web',
+            relDir: 'apps/web',
+            manager: 'pnpm',
+            scripts: [{ name: 'deploy manifest', command: 'ship preview' }],
+          },
+        ],
+      },
+    };
+    state.discoveredScriptScans = {
+      'session-1': { '/tmp/api': { status: 'ready', error: null } },
+    };
+
+    render(<ScriptsPanel workspaceId={'ws-1' as never} sessionId={'session-1' as never} />);
+
+    fireEvent.change(screen.getByRole('searchbox', { name: 'Search scripts' }), {
+      target: { value: 'deploy' },
+    });
+    expect(screen.getByText('deploy user')).toBeDefined();
+    expect(screen.queryByText('lint user')).toBeNull();
+    expect(screen.getByRole('button', { name: /@acme\/web/ }).getAttribute('aria-expanded')).toBe(
+      'true',
+    );
+    expect(screen.getByText('deploy manifest')).toBeDefined();
+
+    fireEvent.keyDown(screen.getByRole('searchbox', { name: 'Search scripts' }), {
+      key: 'Escape',
+    });
+    expect(screen.getByRole('button', { name: /@acme\/web/ }).getAttribute('aria-expanded')).toBe(
+      'false',
     );
   });
 
@@ -225,7 +271,7 @@ describe('ScriptsPanel', () => {
 
     render(<ScriptsPanel workspaceId={'ws-1' as never} sessionId={'session-1' as never} />);
 
-    expect(screen.getByRole('tab', { name: 'Web' }).getAttribute('aria-selected')).toBe('true');
+    expect(screen.getByRole('tab', { name: /Web/ }).getAttribute('aria-selected')).toBe('true');
     expect(screen.getByText('deploy web')).toBeDefined();
     expect(screen.queryByText('setup api')).toBeNull();
     expect(state.setScriptsLensScope).toHaveBeenCalledWith({ scope: null });
@@ -243,7 +289,7 @@ describe('ScriptsPanel', () => {
 
     render(<ScriptsPanel workspaceId={'ws-1' as never} />);
 
-    expect(screen.getByRole('tab', { name: 'All' }).getAttribute('aria-selected')).toBe('true');
+    expect(screen.getByRole('tab', { name: /All/ }).getAttribute('aria-selected')).toBe('true');
     expect(screen.getByText('setup api')).toBeDefined();
     expect(screen.getByText('deploy web')).toBeDefined();
   });
@@ -261,7 +307,11 @@ describe('ScriptsPanel', () => {
 
     render(<ScriptsPanel workspaceId={'ws-1' as never} />);
 
-    expect(screen.getAllByRole('tab').map((tab) => tab.textContent)).toEqual(['All', 'API', 'Web']);
+    expect(screen.getAllByRole('tab').map((tab) => tab.textContent)).toEqual([
+      'All3',
+      'API2',
+      'Web1',
+    ]);
     expect(screen.getAllByRole('listitem').map((item) => item.textContent)).toEqual([
       expect.stringContaining('Alpha'),
       expect.stringContaining('zebra'),
@@ -447,7 +497,7 @@ describe('ScriptsPanel', () => {
     expect(row.className).not.toContain('border-info/50');
     expect(row.className).not.toContain('border-success/40');
     expect(row.className).not.toContain('border-danger/40');
-    expect(row.querySelector('[role="img"]')).toBeNull();
+    expect(row.querySelector('[aria-label="Running"]')).toBeNull();
   });
 
   it.each([
@@ -473,7 +523,11 @@ describe('ScriptsPanel', () => {
     if (pulseClass !== null) {
       expect(row.className).toContain(pulseClass);
     }
-    expect(row.querySelector('[role="img"]')).toBeNull();
+    if (status === 'pending') {
+      expect(row.querySelector('[aria-label="Running"]')).not.toBeNull();
+      return;
+    }
+    expect(row.querySelector('[aria-label="Running"]')).toBeNull();
   });
 
   it('groups the All view, filters by project, and explains an unmounted project', () => {
@@ -487,7 +541,7 @@ describe('ScriptsPanel', () => {
     ];
     render(<ScriptsPanel workspaceId={'ws-1' as never} sessionId={'session-1' as never} />);
 
-    expect(screen.getByRole('tab', { name: 'All' })).toBeDefined();
+    expect(screen.getByRole('tab', { name: /All/ })).toBeDefined();
     expect(screen.getAllByText('API').length).toBeGreaterThan(1);
     expect(screen.getAllByText('Web').length).toBeGreaterThan(1);
 
@@ -497,7 +551,7 @@ describe('ScriptsPanel', () => {
       (screen.getAllByRole('button', { name: 'Run script' })[1] as HTMLButtonElement).disabled,
     ).toBe(true);
 
-    fireEvent.click(screen.getByRole('tab', { name: 'API' }));
+    fireEvent.click(screen.getByRole('tab', { name: /API/ }));
     expect(screen.getByText('setup api')).toBeDefined();
     expect(screen.queryByText('deploy web')).toBeNull();
   });

--- a/apps/desktop/src/features/scripts/components/ScriptsPanel/index.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsPanel/index.tsx
@@ -4,8 +4,9 @@ import {
   formatError,
   RefreshIconButton,
   SectionHeader,
-  SegmentedTabs,
+  PANE_RHYTHM,
   type SegmentedTabOption,
+  cn,
 } from '@goodboy/ui';
 import type {
   Project,
@@ -24,6 +25,9 @@ import { DiscardDraftConfirm } from './DiscardDraftConfirm';
 import { NewScriptCard } from './NewScriptCard';
 import { ScriptRow } from './ScriptRow';
 import { DiscoveredScriptGroup } from './DiscoveredScriptGroup';
+import { ManifestSearchInput } from './ManifestSearchInput';
+import { ProjectScopeTabs, type ProjectFilter } from './ProjectScopeTabs';
+import { UserScriptGroup as UserScriptGroupView } from './UserScriptGroup';
 import type { ScriptGroup as ManifestScriptGroup } from '../../scripts';
 
 type Props = {
@@ -78,8 +82,6 @@ type SaveExistingParams = {
   readonly body: string;
   readonly projectId: ProjectId;
 };
-
-type ProjectFilter = 'all' | ProjectId;
 
 type UserScriptGroup = {
   readonly key: string;
@@ -144,6 +146,9 @@ export const ScriptsPanel = ({ workspaceId, sessionId, hasHostHeading = false }:
   const [error, setError] = useState<string | null>(null);
   const [copiedId, setCopiedId] = useState<ProjectScriptId | null>(null);
   const [completedAt, setCompletedAt] = useState<Record<string, number>>({});
+  const [searchQuery, setSearchQuery] = useState('');
+  const [userGroupOpen, setUserGroupOpen] = useState<Record<string, boolean>>({});
+  const [manifestGroupOpen, setManifestGroupOpen] = useState<Record<string, boolean>>({});
   const [projectFilter, setProjectFilter] = useState<ProjectFilter>(() => {
     const scoped = scriptsLensScope?.projectId;
     if (scoped == null) {
@@ -171,14 +176,33 @@ export const ScriptsPanel = ({ workspaceId, sessionId, hasHostHeading = false }:
   );
   const isMultiProject = projects.length > 1;
   const defaultProjectId = activeProjectId ?? projects[0]?.id ?? null;
-  const projectFilterOptions = useMemo<ReadonlyArray<SegmentedTabOption<ProjectFilter>>>(
-    () => [
-      { value: 'all', label: 'All' },
-      ...[...projects]
+  const projectFilterOptions = useMemo<ReadonlyArray<SegmentedTabOption<ProjectFilter>>>(() => {
+    const scriptCountByProject = new Map<ProjectId, number>();
+    for (const script of list) {
+      scriptCountByProject.set(
+        script.projectId,
+        (scriptCountByProject.get(script.projectId) ?? 0) + 1,
+      );
+    }
+    return [
+      { value: 'all', label: 'All', badge: list.length },
+      ...projects
+        .filter((project) => (scriptCountByProject.get(project.id) ?? 0) > 0)
         .sort((left, right) => left.name.localeCompare(right.name))
-        .map((project) => ({ value: project.id, label: project.name })),
-    ],
-    [projects],
+        .map((project) => ({
+          value: project.id,
+          label: project.name,
+          badge: scriptCountByProject.get(project.id) ?? 0,
+        })),
+    ];
+  }, [list, projects]);
+  const normalizedQuery = searchQuery.trim().toLocaleLowerCase();
+  const matchesSearch = useCallback(
+    ({ name, command }: { readonly name: string; readonly command: string }) =>
+      normalizedQuery === '' ||
+      name.toLocaleLowerCase().includes(normalizedQuery) ||
+      command.toLocaleLowerCase().includes(normalizedQuery),
+    [normalizedQuery],
   );
   const groups = useMemo<ReadonlyArray<UserScriptGroup>>(() => {
     const sortScripts = (groupScripts: ReadonlyArray<ProjectScript>) =>
@@ -186,14 +210,28 @@ export const ScriptsPanel = ({ workspaceId, sessionId, hasHostHeading = false }:
         left.name.localeCompare(right.name, undefined, { sensitivity: 'base' }),
       );
     if (!isMultiProject) {
-      return [{ key: 'all', label: null, scripts: sortScripts(list) }];
+      return [
+        {
+          key: 'all',
+          label: null,
+          scripts: sortScripts(
+            list.filter((script) => matchesSearch({ name: script.name, command: script.body })),
+          ),
+        },
+      ];
     }
     if (projectFilter !== 'all') {
       return [
         {
           key: projectFilter,
           label: null,
-          scripts: sortScripts(list.filter((script) => script.projectId === projectFilter)),
+          scripts: sortScripts(
+            list.filter(
+              (script) =>
+                script.projectId === projectFilter &&
+                matchesSearch({ name: script.name, command: script.body }),
+            ),
+          ),
         },
       ];
     }
@@ -201,13 +239,17 @@ export const ScriptsPanel = ({ workspaceId, sessionId, hasHostHeading = false }:
       .sort((left, right) => left.name.localeCompare(right.name))
       .flatMap((project) => {
         const projectScripts = sortScripts(
-          list.filter((script) => script.projectId === project.id),
+          list.filter(
+            (script) =>
+              script.projectId === project.id &&
+              matchesSearch({ name: script.name, command: script.body }),
+          ),
         );
         return projectScripts.length === 0
           ? []
           : [{ key: project.id, label: project.name, scripts: projectScripts }];
       });
-  }, [isMultiProject, list, projectFilter, projects]);
+  }, [isMultiProject, list, matchesSearch, projectFilter, projects]);
   const visibleMounts = useMemo(
     () =>
       [...sessionMounts]
@@ -234,12 +276,18 @@ export const ScriptsPanel = ({ workspaceId, sessionId, hasHostHeading = false }:
           return left.relDir.localeCompare(right.relDir);
         },
       );
-      return mountGroups.map((group) => ({
-        group,
-        worktreePath: mount.worktreePath,
-      }));
+      return mountGroups.flatMap((group) => {
+        const matchingScripts = group.scripts.filter((script) =>
+          matchesSearch({ name: script.name, command: script.command }),
+        );
+        return matchingScripts.length === 0
+          ? []
+          : [{ group: { ...group, scripts: matchingScripts }, worktreePath: mount.worktreePath }];
+      });
     });
-  }, [discoveredScripts, visibleMounts]);
+  }, [discoveredScripts, matchesSearch, visibleMounts]);
+  const hasSearchResults =
+    groups.some((group) => group.scripts.length > 0) || discoveredGroups.length > 0;
   const isDiscoveryLoading = visibleMounts.some((mount) => {
     const scan = discoveredScriptScans?.[mount.worktreePath];
     return scan === undefined || scan.status === 'loading';
@@ -500,7 +548,7 @@ export const ScriptsPanel = ({ workspaceId, sessionId, hasHostHeading = false }:
   );
 
   return (
-    <div className="flex h-full min-h-0 flex-col gap-3">
+    <div className={cn('flex h-full min-h-0 flex-col', PANE_RHYTHM.stack)}>
       {hasHostHeading ? (
         <div className="flex items-start justify-between gap-2">
           <p className="text-2xs text-muted-foreground/70">{SCRIPTS_HINT}</p>
@@ -517,7 +565,7 @@ export const ScriptsPanel = ({ workspaceId, sessionId, hasHostHeading = false }:
 
       {error !== null && newDraft === null ? <p className="text-xs text-danger">{error}</p> : null}
 
-      <div className="flex min-h-0 flex-1 flex-col gap-6">
+      <div className={cn('flex min-h-0 flex-1 flex-col', PANE_RHYTHM.stack)}>
         <section className="flex flex-col gap-2" aria-label="User scripts">
           {sessionId != null ? (
             <div className="flex items-baseline gap-2 px-0.5">
@@ -529,13 +577,10 @@ export const ScriptsPanel = ({ workspaceId, sessionId, hasHostHeading = false }:
             </div>
           ) : null}
           {isMultiProject ? (
-            <SegmentedTabs
-              ariaLabel="Filter scripts by project"
+            <ProjectScopeTabs
               options={projectFilterOptions}
               value={projectFilter}
               onChange={setProjectFilter}
-              size="sm"
-              className="max-w-full flex-wrap self-start"
             />
           ) : null}
           {newDraft != null && newDraft.projectId != null ? (
@@ -568,19 +613,8 @@ export const ScriptsPanel = ({ workspaceId, sessionId, hasHostHeading = false }:
             />
           ) : (
             <div className="flex flex-col gap-4">
-              {groups.map((group) => (
-                <div key={group.key} className="flex flex-col gap-1.5">
-                  {group.label != null ? (
-                    <div className="flex items-center gap-2 px-0.5">
-                      <span className="text-2xs font-semibold uppercase tracking-wider text-muted-foreground/80">
-                        {group.label}
-                      </span>
-                      <span className="text-2xs tabular-nums text-muted-foreground/50">
-                        {group.scripts.length}
-                      </span>
-                      <span className="h-px flex-1 bg-border/40" aria-hidden />
-                    </div>
-                  ) : null}
+              {groups.map((group) => {
+                const listView = (
                   <ul className="flex flex-col gap-2">
                     {group.scripts.map((script) => {
                       const run = runs?.[script.id] ?? null;
@@ -618,8 +652,24 @@ export const ScriptsPanel = ({ workspaceId, sessionId, hasHostHeading = false }:
                       );
                     })}
                   </ul>
-                </div>
-              ))}
+                );
+                if (group.label == null) {
+                  return <div key={group.key}>{listView}</div>;
+                }
+                return (
+                  <UserScriptGroupView
+                    key={group.key}
+                    label={group.label}
+                    count={group.scripts.length}
+                    open={userGroupOpen[group.key] ?? true}
+                    onOpenChange={(open) =>
+                      setUserGroupOpen((current) => ({ ...current, [group.key]: open }))
+                    }
+                  >
+                    {listView}
+                  </UserScriptGroupView>
+                );
+              })}
             </div>
           )}
         </section>
@@ -644,6 +694,7 @@ export const ScriptsPanel = ({ workspaceId, sessionId, hasHostHeading = false }:
                 />
               ) : null}
             </div>
+            <ManifestSearchInput value={searchQuery} onChange={setSearchQuery} />
             {isDiscoveryLoading ? (
               <p className="text-xs text-muted-foreground">Scanning project manifests…</p>
             ) : null}
@@ -655,17 +706,39 @@ export const ScriptsPanel = ({ workspaceId, sessionId, hasHostHeading = false }:
             discoveredGroups.length === 0 ? (
               <p className="text-xs text-muted-foreground">No manifest scripts found.</p>
             ) : null}
-            {discoveredGroups.map((entry) => (
-              <DiscoveredScriptGroup
-                key={`${entry.worktreePath}:${entry.group.source}:${entry.group.relDir}`}
-                group={entry.group}
-                worktreePath={entry.worktreePath}
-                runs={runs}
-                completedAt={completedAt}
-                onRun={onRunDiscovered}
-                onCancel={onCancelDiscovered}
-              />
-            ))}
+            {searchQuery !== '' && !hasSearchResults ? (
+              <div className="flex items-center gap-2 rounded-md bg-muted/30 px-2.5 py-2 text-xs text-muted-foreground">
+                <span>No scripts match</span>
+                <button
+                  type="button"
+                  onClick={() => setSearchQuery('')}
+                  className="text-foreground"
+                >
+                  Clear
+                </button>
+              </div>
+            ) : null}
+            {discoveredGroups.map((entry) => {
+              const groupKey = `${entry.worktreePath}:${entry.group.source}:${entry.group.relDir}`;
+              return (
+                <DiscoveredScriptGroup
+                  key={groupKey}
+                  group={entry.group}
+                  worktreePath={entry.worktreePath}
+                  runs={runs}
+                  completedAt={completedAt}
+                  open={
+                    normalizedQuery !== '' ||
+                    (manifestGroupOpen[groupKey] ?? entry.group.relDir === '')
+                  }
+                  onOpenChange={(open) =>
+                    setManifestGroupOpen((current) => ({ ...current, [groupKey]: open }))
+                  }
+                  onRun={onRunDiscovered}
+                  onCancel={onCancelDiscovered}
+                />
+              );
+            })}
           </section>
         ) : null}
       </div>

--- a/apps/desktop/src/features/scripts/components/ScriptsPanel/index.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsPanel/index.tsx
@@ -185,14 +185,14 @@ export const ScriptsPanel = ({ workspaceId, sessionId, hasHostHeading = false }:
       );
     }
     return [
-      { value: 'all', label: 'All', badge: list.length },
+      { value: 'all', label: 'All', badge: String(list.length) },
       ...projects
         .filter((project) => (scriptCountByProject.get(project.id) ?? 0) > 0)
         .sort((left, right) => left.name.localeCompare(right.name))
         .map((project) => ({
           value: project.id,
           label: project.name,
-          badge: scriptCountByProject.get(project.id) ?? 0,
+          badge: String(scriptCountByProject.get(project.id) ?? 0),
         })),
     ];
   }, [list, projects]);
@@ -661,10 +661,13 @@ export const ScriptsPanel = ({ workspaceId, sessionId, hasHostHeading = false }:
                     key={group.key}
                     label={group.label}
                     count={group.scripts.length}
-                    open={userGroupOpen[group.key] ?? true}
-                    onOpenChange={(open) =>
-                      setUserGroupOpen((current) => ({ ...current, [group.key]: open }))
-                    }
+                    open={normalizedQuery !== '' || (userGroupOpen[group.key] ?? true)}
+                    onOpenChange={(open) => {
+                      if (normalizedQuery !== '') {
+                        return;
+                      }
+                      setUserGroupOpen((current) => ({ ...current, [group.key]: open }));
+                    }}
                   >
                     {listView}
                   </UserScriptGroupView>
@@ -731,9 +734,12 @@ export const ScriptsPanel = ({ workspaceId, sessionId, hasHostHeading = false }:
                     normalizedQuery !== '' ||
                     (manifestGroupOpen[groupKey] ?? entry.group.relDir === '')
                   }
-                  onOpenChange={(open) =>
-                    setManifestGroupOpen((current) => ({ ...current, [groupKey]: open }))
-                  }
+                  onOpenChange={(open) => {
+                    if (normalizedQuery !== '') {
+                      return;
+                    }
+                    setManifestGroupOpen((current) => ({ ...current, [groupKey]: open }));
+                  }}
                   onRun={onRunDiscovered}
                   onCancel={onCancelDiscovered}
                 />


### PR DESCRIPTION
## What

Rewrites the Scripts pane for comprehension and hierarchy, and fixes the topbar running-scripts counter.

- Project scope: the wrapping chip wall becomes a single-line, horizontally scrollable tab row with per-project count badges.
- User scripts: grouped per project under collapsible headers, aligned rows, hover actions.
- Manifest scripts: per-package collapsible groups, default collapsed except the root package, manager badge and count on each header.
- Search across user and manifest scripts: matching groups auto-expand, non-matching hide, Escape clears, prior collapse state restored.
- Running rows show a pulsing status dot.
- Fix: the topbar running-scripts indicator now counts pending runs owned by archived sessions (previously only active sessions were scanned).

## Tests

Scripts suites plus the unstable-selector and icon-only tooltip guards: 47 passed. Typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)