### PR TITLE
feat(ui): show questions as lane artifacts in the timeline

### DIFF
--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRowLabel.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRowLabel.test.tsx
@@ -243,4 +243,30 @@ describe('TimelineRowLabel', () => {
 
     expect(screen.queryByText(AGENT_KIND_META.resolver.label)).toBeNull();
   });
+
+  it.each([
+    [['answered', 'answered'], '2 questions answered'],
+    [['dismissed', 'dismissed'], '2 questions dismissed'],
+    [['answered', 'dismissed'], '2 questions resolved'],
+  ] as const)('labels a consumed %s cluster as "%s"', (statuses, expected) => {
+    const entry = {
+      kind: 'question',
+      id: 'question:cluster',
+      at: '2026-08-17T09:04:00Z',
+      questions: statuses.map((status, index) => ({
+        id: `oq-${index}`,
+        sessionId: 'sess-1',
+        text: `q${index}`,
+        suggestedAnswers: [],
+        userAnswer: status === 'answered' ? 'yes' : null,
+        status,
+        createdAt: '2026-08-17T09:00:00Z',
+      })),
+      lane: null,
+    } as unknown as TimelineStreamEntry;
+
+    render(<TimelineRowLabel item={itemOf({ entry })} />);
+
+    expect(screen.queryByText(expected)).not.toBeNull();
+  });
 });

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRowLabel.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRowLabel.tsx
@@ -71,8 +71,9 @@ const segmentsOf = ({ entry }: EntryParams): ReadonlyArray<TimelineLabelSegment>
     return [{ kind: 'text', text: `${count} questions` }];
   }
   const allDismissed = entry.questions.every((question) => question.status === 'dismissed');
+  const allAnswered = entry.questions.every((question) => question.status === 'answered');
   const noun = count === 1 ? 'question' : 'questions';
-  const verb = allDismissed ? 'dismissed' : 'answered';
+  const verb = allDismissed ? 'dismissed' : allAnswered ? 'answered' : 'resolved';
   return [{ kind: 'text', text: `${count} ${noun} ${verb}` }];
 };
 

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRowLabel.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRowLabel.tsx
@@ -61,7 +61,19 @@ const segmentsOf = ({ entry }: EntryParams): ReadonlyArray<TimelineLabelSegment>
   if (entry.kind === 'event') {
     return sessionEventLabel({ event: entry.event });
   }
-  return [{ kind: 'text', text: entry.question.text }];
+  const isOpen = entry.questions.every((question) => question.status === 'open');
+  const count = entry.questions.length;
+  if (isOpen) {
+    const first = entry.questions[0];
+    if (count === 1 && first != null) {
+      return [{ kind: 'text', text: `Question: ${first.text}` }];
+    }
+    return [{ kind: 'text', text: `${count} questions` }];
+  }
+  const allDismissed = entry.questions.every((question) => question.status === 'dismissed');
+  const noun = count === 1 ? 'question' : 'questions';
+  const verb = allDismissed ? 'dismissed' : 'answered';
+  return [{ kind: 'text', text: `${count} ${noun} ${verb}` }];
 };
 
 type ChipParams = EntryParams & {
@@ -108,9 +120,6 @@ export const TimelineRowLabel = ({ item, diffStat = null }: Props) => {
         <span className="w-4 shrink-0 text-right text-3xs tabular-nums text-muted-foreground/60">
           {item.ordinal}
         </span>
-      ) : null}
-      {entry.kind === 'answer' ? (
-        <span className="shrink-0 text-2xs text-muted-foreground">You answered</span>
       ) : null}
       <span
         title={segmentsToText({ segments })}

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRowMarker.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRowMarker.tsx
@@ -1,4 +1,4 @@
-import { GitBranch, MessageSquare } from 'lucide-react';
+import { GitBranch, MessageSquareCheck } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import { tintClasses } from '@goodboy/ui';
 import type { Tone } from '@goodboy/ui';
@@ -21,9 +21,8 @@ type Glyph = {
   readonly label: string;
 };
 
-const ARTIFACT: Record<'branch' | 'answer', Glyph> = {
+const ARTIFACT: Record<'branch', Glyph> = {
   branch: { icon: GitBranch, tone: 'neutral', label: 'Branch' },
-  answer: { icon: MessageSquare, tone: 'warning', label: 'You answered' },
 };
 
 export const TimelineRowMarker = ({ item }: Props) => {
@@ -68,6 +67,29 @@ export const TimelineRowMarker = ({ item }: Props) => {
         label="Plan"
         grade={grade}
       />
+    );
+  }
+  if (entry.kind === 'question') {
+    const isOpen = entry.questions.every((question) => question.status === 'open');
+    if (isOpen) {
+      return (
+        <TimelineEmphasisMarker
+          icon={CONCEPT_ICONS.questions}
+          tone={CONCEPT_TONE.questions}
+          label="Question"
+          grade={grade}
+        />
+      );
+    }
+    const allDismissed = entry.questions.every((question) => question.status === 'dismissed');
+    return (
+      <TimelineGlyphMarker tone="neutral" grade={grade}>
+        <MessageSquareCheck
+          size={glyphSize}
+          aria-label={allDismissed ? 'Dismissed' : 'Answered'}
+          className={tintClasses('neutral').icon}
+        />
+      </TimelineGlyphMarker>
     );
   }
   const glyph = ARTIFACT[entry.kind];

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRowMarker.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRowMarker.tsx
@@ -82,11 +82,12 @@ export const TimelineRowMarker = ({ item }: Props) => {
       );
     }
     const allDismissed = entry.questions.every((question) => question.status === 'dismissed');
+    const allAnswered = entry.questions.every((question) => question.status === 'answered');
     return (
       <TimelineGlyphMarker tone="neutral" grade={grade}>
         <MessageSquareCheck
           size={glyphSize}
-          aria-label={allDismissed ? 'Dismissed' : 'Answered'}
+          aria-label={allDismissed ? 'Dismissed' : allAnswered ? 'Answered' : 'Resolved'}
           className={tintClasses('neutral').icon}
         />
       </TimelineGlyphMarker>

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/index.test.tsx
@@ -2,7 +2,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
-import type { Session } from '@goodboy/types';
+import type { OpenQuestion, Session } from '@goodboy/types';
 
 type Worktree = {
   readonly id: string;
@@ -14,9 +14,14 @@ type Worktree = {
   readonly createdAt: number;
 };
 
-const { storeState, diffStats, unread } = vi.hoisted(() => ({
+const { storeState, diffStats, unread, questions } = vi.hoisted(() => ({
   unread: { current: false },
   diffStats: { current: new Map<string, { additions: number; deletions: number }>() },
+  questions: {
+    open: [] as ReadonlyArray<unknown>,
+    answered: [] as ReadonlyArray<unknown>,
+    dismissed: [] as ReadonlyArray<unknown>,
+  },
   storeState: {
     sessionPhaseRuns: {},
     sessionPlans: {},
@@ -25,6 +30,8 @@ const { storeState, diffStats, unread } = vi.hoisted(() => ({
     sessionEvents: {},
     agentKindOverride: {},
     loadSessionEvents: vi.fn(async () => undefined),
+    loadSessionAnsweredQuestions: vi.fn(async () => undefined),
+    loadSessionDismissedQuestions: vi.fn(async () => undefined),
     markAllAgentsSeen: vi.fn(),
     setActiveLens: vi.fn(),
     openMountDiff: vi.fn(),
@@ -39,7 +46,9 @@ vi.mock('../../../../../../store', () => {
     agentHasUnread: () => unread.current,
     useAppStore,
     useMountDiffStats: () => diffStats.current,
-    useSessionOpenQuestions: () => [],
+    useSessionOpenQuestions: () => questions.open,
+    useSessionAnsweredQuestions: () => questions.answered,
+    useSessionDismissedQuestions: () => questions.dismissed,
   };
 });
 vi.mock('../../../../../workflows/useAttachedWorkflowRuns', () => ({
@@ -85,8 +94,14 @@ beforeEach(() => {
   storeState.sessionEvents = {};
   storeState.openMountDiff.mockReset();
   storeState.markAllAgentsSeen.mockReset();
+  storeState.setActiveLens.mockReset();
+  storeState.loadSessionAnsweredQuestions.mockClear();
+  storeState.loadSessionDismissedQuestions.mockClear();
   unread.current = false;
   diffStats.current = new Map();
+  questions.open = [];
+  questions.answered = [];
+  questions.dismissed = [];
   localStorage.clear();
 });
 
@@ -247,5 +262,55 @@ describe('TimelinePane unread affordance', () => {
     render(<TimelinePane session={SESSION} runs={RUNS} actions={null} />);
 
     expect(screen.queryByRole('button', { name: 'Mark all seen' })).toBeNull();
+  });
+});
+
+describe('TimelinePane questions', () => {
+  const OPEN_QUESTION = {
+    id: 'question-open',
+    sessionId: 'session-1',
+    text: 'Which database should we use?',
+    suggestedAnswers: [],
+    userAnswer: null,
+    status: 'open',
+    createdAt: '2026-08-20T09:00:00.000Z',
+  } as unknown as OpenQuestion;
+
+  const ANSWERED_QUESTION = {
+    id: 'question-answered',
+    sessionId: 'session-1',
+    text: 'Which cloud provider?',
+    suggestedAnswers: [],
+    userAnswer: 'aws',
+    status: 'answered',
+    createdAt: '2026-08-19T09:00:00.000Z',
+    answeredAt: '2026-08-19T10:00:00.000Z',
+  } as unknown as OpenQuestion;
+
+  it('loads the answered and dismissed caches on mount, alongside the open one', () => {
+    render(<TimelinePane session={SESSION} runs={RUNS} actions={null} />);
+
+    expect(storeState.loadSessionAnsweredQuestions).toHaveBeenCalledWith('session-1');
+    expect(storeState.loadSessionDismissedQuestions).toHaveBeenCalledWith('session-1');
+  });
+
+  it('feeds the builder the open and answered caches combined, as separate rows', () => {
+    questions.open = [OPEN_QUESTION];
+    questions.answered = [ANSWERED_QUESTION];
+
+    render(<TimelinePane session={SESSION} runs={RUNS} actions={null} />);
+
+    expect(screen.getByText(/Question: Which database should we use\?/)).toBeDefined();
+    expect(screen.getByText('1 question answered')).toBeDefined();
+  });
+
+  it('keeps the Answer action target on the open question artifact row', () => {
+    questions.open = [OPEN_QUESTION];
+
+    render(<TimelinePane session={SESSION} runs={RUNS} actions={null} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Answer' }));
+
+    expect(storeState.setActiveLens).toHaveBeenCalledWith('session-1', 'questions');
   });
 });

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/index.tsx
@@ -8,6 +8,8 @@ import {
   agentHasUnread,
   useAppStore,
   useMountDiffStats,
+  useSessionAnsweredQuestions,
+  useSessionDismissedQuestions,
   useSessionOpenQuestions,
   type MountDiffStat,
 } from '../../../../../../store';
@@ -53,7 +55,11 @@ export const TimelinePane = ({ session, runs, actions, kickoff }: Props) => {
   const markAllAgentsSeen = useAppStore((s) => s.markAllAgentsSeen);
   const setActiveLens = useAppStore((s) => s.setActiveLens);
   const openMountDiff = useAppStore((s) => s.openMountDiff);
-  const questions = useSessionOpenQuestions(sessionId);
+  const openQuestions = useSessionOpenQuestions(sessionId);
+  const answeredQuestions = useSessionAnsweredQuestions(sessionId);
+  const dismissedQuestions = useSessionDismissedQuestions(sessionId);
+  const loadSessionAnsweredQuestions = useAppStore((s) => s.loadSessionAnsweredQuestions);
+  const loadSessionDismissedQuestions = useAppStore((s) => s.loadSessionDismissedQuestions);
   const workflows = useAttachedWorkflowRuns({ session });
   const openTargetFor = useTimelineOpen({ sessionId });
   const advanceAgent = useAdvanceWorkflowAgent({ sessionId });
@@ -67,6 +73,11 @@ export const TimelinePane = ({ session, runs, actions, kickoff }: Props) => {
   }, [loadSessionEvents, sessionId]);
 
   useEffect(() => {
+    void loadSessionAnsweredQuestions(sessionId);
+    void loadSessionDismissedQuestions(sessionId);
+  }, [loadSessionAnsweredQuestions, loadSessionDismissedQuestions, sessionId]);
+
+  useEffect(() => {
     if (copied) {
       showToast('success', 'path copied');
     }
@@ -77,6 +88,11 @@ export const TimelinePane = ({ session, runs, actions, kickoff }: Props) => {
       showToast('error', 'copy failed');
     }
   }, [failed, showToast]);
+
+  const questions = useMemo(
+    () => [...openQuestions, ...answeredQuestions, ...dismissedQuestions],
+    [answeredQuestions, dismissedQuestions, openQuestions],
+  );
 
   const model = useMemo(
     () =>
@@ -235,6 +251,12 @@ export const TimelinePane = ({ session, runs, actions, kickoff }: Props) => {
       };
     }
     if (entry.kind === 'agent' && entry.openQuestions.length > 0) {
+      return { label: 'Answer', onAct: () => setActiveLens(sessionId, 'questions') };
+    }
+    if (
+      entry.kind === 'question' &&
+      entry.questions.every((question) => question.status === 'open')
+    ) {
       return { label: 'Answer', onAct: () => setActiveLens(sessionId, 'questions') };
     }
     if (entry.kind !== 'run') {

--- a/apps/desktop/src/features/session/timeline/buildTimelineGroups.ts
+++ b/apps/desktop/src/features/session/timeline/buildTimelineGroups.ts
@@ -73,6 +73,19 @@ export type TimelineAnswerEntry = {
   readonly question: OpenQuestion;
 };
 
+export type TimelineQuestionLane = {
+  readonly identity: RunIdentity;
+  readonly rootEntryId: string;
+};
+
+export type TimelineQuestionEntry = {
+  readonly kind: 'question';
+  readonly id: string;
+  readonly at: string;
+  readonly questions: ReadonlyArray<OpenQuestion>;
+  readonly lane: TimelineQuestionLane | null;
+};
+
 type TimelineRunChild = TimelineAgentEntry | TimelinePlanEntry;
 
 export type TimelineRunEntry = {
@@ -92,7 +105,8 @@ export type TimelineTopLevelEntry =
   | TimelineIssueEntry
   | TimelineBranchEntry
   | TimelineEventEntry
-  | TimelineRunEntry;
+  | TimelineRunEntry
+  | TimelineQuestionEntry;
 
 export type TimelineModel = {
   readonly entries: ReadonlyArray<TimelineTopLevelEntry>;
@@ -362,6 +376,56 @@ export const buildTimelineGroups = ({
           : {}),
       };
     });
+
+  const authorAgentIdByQuestionId = new Map<string, Agent['id']>();
+  for (const candidate of byOrdinal) {
+    for (const attached of attachedQuestionsFor({ questions, agent: candidate })) {
+      if (!authorAgentIdByQuestionId.has(attached.id)) {
+        authorAgentIdByQuestionId.set(attached.id, candidate.id);
+      }
+    }
+  }
+
+  const questionLaneFor = ({
+    authorAgentId,
+  }: {
+    readonly authorAgentId: Agent['id'] | undefined;
+  }): TimelineQuestionLane | null => {
+    if (authorAgentId == null) {
+      return null;
+    }
+    const rootId = chainRootIdByAgentId.get(authorAgentId) ?? authorAgentId;
+    const rootAgent = liveAgentById.get(rootId);
+    if (
+      rootAgent != null &&
+      rootAgent.workflowRunId != null &&
+      rootAgent.stepId != null &&
+      runIds.has(rootAgent.workflowRunId)
+    ) {
+      return {
+        identity: identityFor({ runId: rootAgent.workflowRunId }),
+        rootEntryId: `run:${rootAgent.workflowRunId}`,
+      };
+    }
+    if (chainRootIds.has(rootId)) {
+      return { identity: identityFor({ runId: rootId }), rootEntryId: `agent:${rootId}` };
+    }
+    return null;
+  };
+
+  const questionTimestamp = ({ question }: { readonly question: OpenQuestion }): string =>
+    question.status === 'open'
+      ? question.createdAt
+      : (question.answeredAt ?? question.dismissedAt ?? question.createdAt);
+
+  const questionEntries: ReadonlyArray<TimelineQuestionEntry> = questions.map((question) => ({
+    kind: 'question',
+    id: `question:${question.id}`,
+    at: questionTimestamp({ question }),
+    questions: [question],
+    lane: questionLaneFor({ authorAgentId: authorAgentIdByQuestionId.get(question.id) }),
+  }));
+
   const issues: ReadonlyArray<TimelineIssueEntry> = externalTasks.map((task) => ({
     kind: 'issue',
     id: `issue:${task.provider}:${task.externalId}`,
@@ -415,6 +479,7 @@ export const buildTimelineGroups = ({
     ...runEntries,
     ...standaloneAgents,
     ...standalonePlans,
+    ...questionEntries,
     ...visibleIssues,
     ...branches,
     ...eventEntries,

--- a/apps/desktop/src/features/session/timeline/buildTimelineStream.test.ts
+++ b/apps/desktop/src/features/session/timeline/buildTimelineStream.test.ts
@@ -1635,7 +1635,7 @@ describe('buildTimelineStream, plan visibility and family anchoring', () => {
   it('keeps an answered question in the stream by default', () => {
     const { items } = stream({ agents: ASKER_AGENTS, questions: [answeredQuestion] });
 
-    expect(items.map(labelOf)).toContain('step:answer:agent:asker:question-1');
+    expect(items.map(labelOf)).toContain('entry:question:question-1');
   });
 
   it('drops answered questions from the stream when questions are hidden', () => {
@@ -1645,7 +1645,7 @@ describe('buildTimelineStream, plan visibility and family anchoring', () => {
       showQuestions: false,
     });
 
-    expect(items.map(labelOf)).not.toContain('step:answer:agent:asker:question-1');
+    expect(items.map(labelOf)).not.toContain('entry:question:question-1');
     expect(items.map(labelOf)).toContain('entry:agent:asker');
   });
 
@@ -1698,5 +1698,251 @@ describe('buildTimelineStream, plan visibility and family anchoring', () => {
     const pendingChild = items.find((item) => item.id === 'agent:sub-3');
 
     expect(pendingChild?.kind === 'row' ? pendingChild.at : 'missing').toBeNull();
+  });
+});
+
+describe('buildTimelineStream, question artifact rows', () => {
+  type QuestionFixtureParams = {
+    readonly id: string;
+    readonly createdByAgentId?: string;
+    readonly createdAt: string;
+  };
+
+  const openQuestionFor = ({
+    id,
+    createdByAgentId,
+    createdAt,
+  }: QuestionFixtureParams): OpenQuestion => ({
+    id: typedString<OpenQuestionId>({ value: id }),
+    sessionId: SESSION_ID,
+    ...(createdByAgentId != null
+      ? { createdByAgentId: typedString<AgentId>({ value: createdByAgentId }) }
+      : {}),
+    text: id,
+    suggestedAnswers: [],
+    userAnswer: null,
+    status: 'open',
+    createdAt: typedString<IsoDateTime>({ value: createdAt }),
+  });
+
+  const answeredQuestionFor = ({
+    id,
+    createdByAgentId,
+    createdAt,
+    answeredAt,
+  }: QuestionFixtureParams & { readonly answeredAt: string }): OpenQuestion => ({
+    ...openQuestionFor({ id, createdByAgentId, createdAt }),
+    status: 'answered',
+    userAnswer: 'yes',
+    answeredAt: typedString<IsoDateTime>({ value: answeredAt }),
+  });
+
+  const CHAIN_AGENTS: ReadonlyArray<Agent> = [
+    agent({ id: 'planner', ordinal: 0, startedAt: localIso({ day: 18, hour: 9 }) }),
+    agent({
+      id: 'implementer',
+      ordinal: 1,
+      parentAgentId: 'planner',
+      startedAt: localIso({ day: 18, hour: 10 }),
+    }),
+  ];
+
+  it('lands a chain-root-authored question in the root lane, same as a plan artifact', () => {
+    const { items } = stream({
+      agents: CHAIN_AGENTS,
+      questions: [
+        openQuestionFor({
+          id: 'root-question',
+          createdByAgentId: 'planner',
+          createdAt: localIso({ day: 18, hour: 11 }),
+        }),
+      ],
+    });
+    const root = items.find((item) => item.kind === 'row' && item.id === 'agent:planner');
+    const questionRow = items.find(
+      (item) => item.kind === 'row' && item.id === 'question:root-question',
+    );
+
+    expect(questionRow?.groupId).toBe('lane:agent:planner');
+    expect(questionRow?.kind === 'row' ? questionRow.identity : null).toEqual(
+      root?.kind === 'row' ? root.identity : null,
+    );
+  });
+
+  it('bubbles a question authored by a descendant up to the chain root lane', () => {
+    const { items } = stream({
+      agents: CHAIN_AGENTS,
+      questions: [
+        openQuestionFor({
+          id: 'child-question',
+          createdByAgentId: 'implementer',
+          createdAt: localIso({ day: 18, hour: 11 }),
+        }),
+      ],
+    });
+    const questionRow = items.find(
+      (item) => item.kind === 'row' && item.id === 'question:child-question',
+    );
+
+    expect(questionRow?.groupId).toBe('lane:agent:planner');
+  });
+
+  it('lands a run-step-authored question in the run lane', () => {
+    const { items } = stream({
+      workflows: [attachedWorkflow({ createdAt: localIso({ day: 18, hour: 8 }) })],
+      agents: [
+        agent({
+          id: 'implement',
+          ordinal: 1,
+          startedAt: localIso({ day: 18, hour: 9 }),
+          workflowRunId: RUN_ID,
+        }),
+      ],
+      questions: [
+        answeredQuestionFor({
+          id: 'run-question',
+          createdByAgentId: 'implement',
+          createdAt: localIso({ day: 18, hour: 9, minute: 30 }),
+          answeredAt: localIso({ day: 18, hour: 9, minute: 45 }),
+        }),
+      ],
+    });
+    const run = items.find((item) => item.kind === 'row' && item.id === 'run:run-1');
+    const questionRow = items.find(
+      (item) => item.kind === 'row' && item.id === 'question:run-question',
+    );
+
+    expect(questionRow?.groupId).toBe('lane:run:run-1');
+    expect(questionRow?.kind === 'row' ? questionRow.identity : null).toEqual(
+      run?.kind === 'row' ? run.identity : null,
+    );
+  });
+
+  it('keeps a question with no resolvable author on the spine', () => {
+    const { items } = stream({
+      agents: [agent({ id: 'unrelated', ordinal: 0, startedAt: localIso({ day: 18, hour: 9 }) })],
+      questions: [
+        openQuestionFor({ id: 'orphan-question', createdAt: localIso({ day: 18, hour: 11 }) }),
+      ],
+    });
+    const questionRow = items.find(
+      (item) => item.kind === 'row' && item.id === 'question:orphan-question',
+    );
+
+    expect(questionRow?.groupId).toBeNull();
+    expect(questionRow?.kind === 'row' ? questionRow.identity : 'missing').toBeNull();
+  });
+
+  it('coalesces consecutive open questions from the same lane into one row', () => {
+    const { items } = stream({
+      agents: CHAIN_AGENTS,
+      questions: [
+        openQuestionFor({
+          id: 'first-question',
+          createdByAgentId: 'planner',
+          createdAt: localIso({ day: 18, hour: 11 }),
+        }),
+        openQuestionFor({
+          id: 'second-question',
+          createdByAgentId: 'planner',
+          createdAt: localIso({ day: 18, hour: 11, minute: 30 }),
+        }),
+      ],
+    });
+    const questionRows = items.filter(
+      (item) => item.kind === 'row' && item.entry.kind === 'question',
+    );
+    const [row] = questionRows;
+
+    expect(questionRows).toHaveLength(1);
+    expect(
+      row?.kind === 'row' && row.entry.kind === 'question' ? row.entry.questions.length : 0,
+    ).toBe(2);
+  });
+
+  it('keeps an open cluster and a consumed cluster from the same lane on separate rows', () => {
+    const { items } = stream({
+      agents: CHAIN_AGENTS,
+      questions: [
+        openQuestionFor({
+          id: 'open-question',
+          createdByAgentId: 'planner',
+          createdAt: localIso({ day: 18, hour: 11 }),
+        }),
+        answeredQuestionFor({
+          id: 'answered-question',
+          createdByAgentId: 'planner',
+          createdAt: localIso({ day: 18, hour: 11, minute: 15 }),
+          answeredAt: localIso({ day: 18, hour: 11, minute: 20 }),
+        }),
+      ],
+    });
+    const questionRows = items.filter(
+      (item) => item.kind === 'row' && item.entry.kind === 'question',
+    );
+
+    expect(questionRows).toHaveLength(2);
+  });
+
+  it('breaks the coalesced run when another row lands between two questions', () => {
+    const { items } = stream({
+      agents: [
+        agent({ id: 'planner', ordinal: 0, startedAt: localIso({ day: 18, hour: 9 }) }),
+        agent({
+          id: 'implementer',
+          ordinal: 1,
+          parentAgentId: 'planner',
+          startedAt: localIso({ day: 18, hour: 12 }),
+        }),
+      ],
+      questions: [
+        openQuestionFor({
+          id: 'first-question',
+          createdByAgentId: 'planner',
+          createdAt: localIso({ day: 18, hour: 11 }),
+        }),
+        openQuestionFor({
+          id: 'second-question',
+          createdByAgentId: 'planner',
+          createdAt: localIso({ day: 18, hour: 13 }),
+        }),
+      ],
+    });
+    const questionRows = items.filter(
+      (item) => item.kind === 'row' && item.entry.kind === 'question',
+    );
+
+    expect(questionRows).toHaveLength(2);
+  });
+
+  it('breaks the coalesced run across a day boundary', () => {
+    const { items } = stream({
+      agents: [
+        agent({ id: 'planner', ordinal: 0, startedAt: localIso({ day: 17, hour: 9 }) }),
+        agent({
+          id: 'implementer',
+          ordinal: 1,
+          parentAgentId: 'planner',
+          startedAt: localIso({ day: 17, hour: 10 }),
+        }),
+      ],
+      questions: [
+        openQuestionFor({
+          id: 'yesterday-question',
+          createdByAgentId: 'planner',
+          createdAt: localIso({ day: 17, hour: 23 }),
+        }),
+        openQuestionFor({
+          id: 'today-question',
+          createdByAgentId: 'planner',
+          createdAt: localIso({ day: 18, hour: 1 }),
+        }),
+      ],
+    });
+    const questionRows = items.filter(
+      (item) => item.kind === 'row' && item.entry.kind === 'question',
+    );
+
+    expect(questionRows).toHaveLength(2);
   });
 });

--- a/apps/desktop/src/features/session/timeline/buildTimelineStream.ts
+++ b/apps/desktop/src/features/session/timeline/buildTimelineStream.ts
@@ -1,12 +1,12 @@
-import type { Agent, SessionEventKind } from '@goodboy/types';
+import type { Agent, OpenQuestion, SessionEventKind } from '@goodboy/types';
 import { isWorkflowRunComplete } from '../../workflows/isWorkflowRunComplete';
 import type {
   TimelineAgentEntry,
-  TimelineAnswerEntry,
   TimelineBranchEntry,
   TimelineEventEntry,
   TimelineIssueEntry,
   TimelinePlanEntry,
+  TimelineQuestionEntry,
   TimelineRunEntry,
   TimelineTopLevelEntry,
 } from './buildTimelineGroups';
@@ -28,7 +28,7 @@ export type TimelineStreamEntry =
   | TimelineIssueEntry
   | TimelineBranchEntry
   | TimelineEventEntry
-  | TimelineAnswerEntry;
+  | TimelineQuestionEntry;
 
 type StreamRail = {
   readonly id: string;
@@ -233,6 +233,76 @@ const mergeConsecutiveDecisionRows = ({
   return merged;
 };
 
+const questionBucketOf = ({
+  entry,
+}: {
+  readonly entry: TimelineQuestionEntry;
+}): 'open' | 'consumed' =>
+  entry.questions.every((question) => question.status === 'open') ? 'open' : 'consumed';
+
+type MergeQuestionRowsParams = {
+  readonly drafts: ReadonlyArray<DraftRow>;
+};
+
+const mergeConsecutiveQuestionRows = ({
+  drafts,
+}: MergeQuestionRowsParams): ReadonlyArray<DraftRow> => {
+  const merged: DraftRow[] = [];
+  let index = 0;
+
+  while (index < drafts.length) {
+    const newest = drafts[index];
+    if (newest === undefined) {
+      break;
+    }
+    if (newest.entry.kind !== 'question' || newest.groupId == null) {
+      merged.push(newest);
+      index += 1;
+      continue;
+    }
+
+    const newestBucket = questionBucketOf({ entry: newest.entry });
+    const newestDayKey = newest.at === null ? null : dayKeyOf({ at: newest.at });
+    let runIndex = index;
+    const collected: OpenQuestion[] = [];
+    while (runIndex < drafts.length) {
+      const draft = drafts[runIndex];
+      if (draft === undefined || draft.entry.kind !== 'question') {
+        break;
+      }
+      if (draft.groupId !== newest.groupId) {
+        break;
+      }
+      if (questionBucketOf({ entry: draft.entry }) !== newestBucket) {
+        break;
+      }
+      const draftDayKey = draft.at === null ? null : dayKeyOf({ at: draft.at });
+      if (runIndex > index && draftDayKey !== newestDayKey) {
+        break;
+      }
+      collected.push(...draft.entry.questions);
+      runIndex += 1;
+    }
+
+    if (runIndex === index + 1) {
+      merged.push(newest);
+      index = runIndex;
+      continue;
+    }
+
+    merged.push({
+      ...newest,
+      entry: {
+        ...newest.entry,
+        questions: collected,
+      },
+    });
+    index = runIndex;
+  }
+
+  return merged;
+};
+
 const stepAgentsOf = ({ entry }: { readonly entry: TimelineRunEntry }): ReadonlyArray<Agent> =>
   entry.children.flatMap((child) => (child.kind === 'agent' ? [child.agent] : []));
 
@@ -322,26 +392,6 @@ const agentRows = ({
           context,
         }),
       );
-    }
-  }
-  if (context.showQuestions) {
-    for (const answer of entry.answers) {
-      const row: DraftRow = {
-        kind: 'row',
-        id: answer.id,
-        at: answer.at,
-        grade: 'step',
-        entry: answer,
-        identity,
-        familyId,
-        groupId,
-        ordinal: null,
-        sortOrdinal: 0,
-        markerState: 'done',
-        hasUnread: false,
-        isPending: false,
-      };
-      nested.push(row);
     }
   }
   const origin: DraftRow = {
@@ -632,6 +682,27 @@ export const buildTimelineStream = ({
       });
       continue;
     }
+    if (entry.kind === 'question') {
+      if (!context.showQuestions) {
+        continue;
+      }
+      rows.push({
+        kind: 'row',
+        id: entry.id,
+        at: entry.at,
+        grade: entry.lane != null ? 'step' : 'entry',
+        entry,
+        identity: entry.lane?.identity ?? null,
+        familyId: entry.lane?.rootEntryId ?? null,
+        groupId: entry.lane != null ? laneIdOf({ entryId: entry.lane.rootEntryId }) : null,
+        ordinal: null,
+        sortOrdinal: 0,
+        markerState: questionBucketOf({ entry }) === 'open' ? 'question' : 'done',
+        hasUnread: false,
+        isPending: false,
+      });
+      continue;
+    }
     const row: DraftRow = {
       kind: 'row',
       id: entry.id,
@@ -651,7 +722,9 @@ export const buildTimelineStream = ({
   }
 
   const sorted = [...rows].sort((first, second) => compareNewestFirst({ first, second }));
-  const merged = mergeConsecutiveDecisionRows({ drafts: sorted });
+  const merged = mergeConsecutiveQuestionRows({
+    drafts: mergeConsecutiveDecisionRows({ drafts: sorted }),
+  });
   const withDays = withDayBreaks({
     drafts: withPendingClusters({ drafts: withPendingAtFamilyHead({ drafts: merged }) }),
     dayLabelFor,

--- a/apps/desktop/src/store/index.ts
+++ b/apps/desktop/src/store/index.ts
@@ -8,6 +8,7 @@ export {
   useSessionLastTurnFinishedAt,
   useMountDiffStats,
   useSessionAnsweredQuestions,
+  useSessionDismissedQuestions,
   useSessionById,
   useSessionCost,
   useSessionLoading,

--- a/apps/desktop/src/store/selectors.ts
+++ b/apps/desktop/src/store/selectors.ts
@@ -609,6 +609,15 @@ export const useSessionAnsweredQuestions = (
       : EMPTY_OPEN_QUESTIONS,
   );
 
+export const useSessionDismissedQuestions = (
+  sessionId: SessionId | null,
+): ReadonlyArray<OpenQuestion> =>
+  useAppStore((s) =>
+    sessionId
+      ? (s.sessionDismissedQuestions[sessionId] ?? EMPTY_OPEN_QUESTIONS)
+      : EMPTY_OPEN_QUESTIONS,
+  );
+
 const IDLE_STATUS: SummarizerSessionStatus = {
   status: 'idle',
   lastUpdate: null,

--- a/apps/desktop/src/store/sessionEviction.ts
+++ b/apps/desktop/src/store/sessionEviction.ts
@@ -39,6 +39,7 @@ export const SESSION_EVICTION = [
   { key: 'sessionResolvedThreads', keyedBy: 'session', evictOn: 'archive' },
   { key: 'sessionPlans', keyedBy: 'session', evictOn: 'archive' },
   { key: 'sessionAnsweredQuestions', keyedBy: 'session', evictOn: 'archive' },
+  { key: 'sessionDismissedQuestions', keyedBy: 'session', evictOn: 'archive' },
   { key: 'sessionNudges', keyedBy: 'session', evictOn: 'archive' },
   { key: 'sessionAttachments', keyedBy: 'session', evictOn: 'archive' },
   { key: 'sessionOverrides', keyedBy: 'session', evictOn: 'archive' },

--- a/apps/desktop/src/store/slices/open-questions/dismissOpenQuestion.test.ts
+++ b/apps/desktop/src/store/slices/open-questions/dismissOpenQuestion.test.ts
@@ -30,6 +30,7 @@ import { restoreDismissedOpenQuestion } from './restoreDismissedOpenQuestion';
 type TestState = {
   sessionOpenQuestions: Record<string, ReadonlyArray<OpenQuestion>>;
   loadSessionSlots: (sessionId: SessionId) => Promise<void>;
+  loadSessionDismissedQuestions: (sessionId: SessionId) => Promise<void>;
   maybeAutoAdvanceWorkflow: (sessionId: SessionId) => Promise<void>;
 };
 
@@ -53,6 +54,7 @@ describe('dismissed open question restoration', () => {
     const store = createStore<TestState>(() => ({
       sessionOpenQuestions: { [sessionId]: [question] },
       loadSessionSlots: vi.fn(async () => undefined),
+      loadSessionDismissedQuestions: vi.fn(async () => undefined),
       maybeAutoAdvanceWorkflow: vi.fn(async () => undefined),
     }));
     const dismiss = dismissOpenQuestion(store.setState as never, store.getState as never);
@@ -61,10 +63,12 @@ describe('dismissed open question restoration', () => {
     await dismiss(sessionId, question);
     expect(store.getState().sessionOpenQuestions[sessionId]).toEqual([]);
     expect(markOpenQuestionDismissed).toHaveBeenCalledWith(expect.anything(), question.id);
+    expect(store.getState().loadSessionDismissedQuestions).toHaveBeenCalledWith(sessionId);
 
     await restore(sessionId, question);
     expect(store.getState().sessionOpenQuestions[sessionId]).toEqual([question]);
     expect(restoreOpenQuestion).toHaveBeenCalledWith(expect.anything(), question.id);
+    expect(store.getState().loadSessionDismissedQuestions).toHaveBeenCalledTimes(2);
     expect(store.getState().maybeAutoAdvanceWorkflow).toHaveBeenCalledWith(sessionId);
   });
 });

--- a/apps/desktop/src/store/slices/open-questions/dismissOpenQuestion.ts
+++ b/apps/desktop/src/store/slices/open-questions/dismissOpenQuestion.ts
@@ -15,6 +15,7 @@ export const dismissOpenQuestion = (set: SetFn, get: GetFn) => {
         ),
       },
     }));
+    await get().loadSessionDismissedQuestions(sessionId);
     const slotChanged = await removeQuestionsFromSlot(tauriDatabase, sessionId, [question.text]);
     if (slotChanged) {
       await get().loadSessionSlots(sessionId);

--- a/apps/desktop/src/store/slices/open-questions/index.ts
+++ b/apps/desktop/src/store/slices/open-questions/index.ts
@@ -2,6 +2,7 @@ import { answerOpenQuestions } from './answerOpenQuestions';
 import { clearOpenQuestionScroll } from './clearOpenQuestionScroll';
 import { dismissOpenQuestion } from './dismissOpenQuestion';
 import { loadSessionAnsweredQuestions } from './loadSessionAnsweredQuestions';
+import { loadSessionDismissedQuestions } from './loadSessionDismissedQuestions';
 import { loadSessionOpenQuestions } from './loadSessionOpenQuestions';
 import { requestOpenQuestionScroll } from './requestOpenQuestionScroll';
 import { restoreDismissedOpenQuestion } from './restoreDismissedOpenQuestion';
@@ -11,6 +12,7 @@ export const createOpenQuestionsSlice = (set: SetFn, get: GetFn) => {
   return {
     loadSessionOpenQuestions: loadSessionOpenQuestions(set),
     loadSessionAnsweredQuestions: loadSessionAnsweredQuestions(set),
+    loadSessionDismissedQuestions: loadSessionDismissedQuestions(set),
     requestOpenQuestionScroll: requestOpenQuestionScroll(set),
     clearOpenQuestionScroll: clearOpenQuestionScroll(set),
     answerOpenQuestions: answerOpenQuestions(get),

--- a/apps/desktop/src/store/slices/open-questions/loadSessionDismissedQuestions.ts
+++ b/apps/desktop/src/store/slices/open-questions/loadSessionDismissedQuestions.ts
@@ -1,0 +1,13 @@
+import type { SessionId } from '@goodboy/types';
+import { listOpenQuestionsForSession } from '@goodboy/db';
+import { tauriDatabase } from '../../../shared/lib/db';
+import type { SetFn } from './types';
+
+export const loadSessionDismissedQuestions = (set: SetFn) => {
+  return async (sessionId: SessionId) => {
+    const questions = await listOpenQuestionsForSession(tauriDatabase, sessionId, 'dismissed');
+    set((state) => ({
+      sessionDismissedQuestions: { ...state.sessionDismissedQuestions, [sessionId]: questions },
+    }));
+  };
+};

--- a/apps/desktop/src/store/slices/open-questions/restoreDismissedOpenQuestion.ts
+++ b/apps/desktop/src/store/slices/open-questions/restoreDismissedOpenQuestion.ts
@@ -19,6 +19,7 @@ export const restoreDismissedOpenQuestion = (set: SetFn, get: GetFn) => {
         sessionOpenQuestions: { ...state.sessionOpenQuestions, [sessionId]: next },
       };
     });
+    await get().loadSessionDismissedQuestions(sessionId);
     const slotChanged = await addQuestionsToSlot(tauriDatabase, sessionId, [question.text]);
     if (slotChanged) {
       await get().loadSessionSlots(sessionId);

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -828,6 +828,7 @@ type AppActions = {
   clearNotifications(): Promise<void>;
   loadSessionOpenQuestions(sessionId: SessionId): Promise<void>;
   loadSessionAnsweredQuestions(sessionId: SessionId): Promise<void>;
+  loadSessionDismissedQuestions(sessionId: SessionId): Promise<void>;
   requestOpenQuestionScroll(target: { agentId: AgentId; questionId: OpenQuestionId }): void;
   clearOpenQuestionScroll(): void;
   answerOpenQuestions(
@@ -1013,6 +1014,7 @@ export const initialState: AppState = {
   planConsumptions: {},
   sessionOpenQuestions: {},
   sessionAnsweredQuestions: {},
+  sessionDismissedQuestions: {},
   openQuestionScrollTarget: null,
   sessionLoading: {},
   boardReady: true,

--- a/apps/desktop/src/store/types.ts
+++ b/apps/desktop/src/store/types.ts
@@ -307,6 +307,7 @@ export type AppState = AppSliceState & {
   readonly planConsumptions: Readonly<Record<PlanId, ReadonlyArray<PlanConsumption>>>;
   readonly sessionOpenQuestions: Readonly<Record<SessionId, ReadonlyArray<OpenQuestion>>>;
   readonly sessionAnsweredQuestions: Readonly<Record<SessionId, ReadonlyArray<OpenQuestion>>>;
+  readonly sessionDismissedQuestions: Readonly<Record<SessionId, ReadonlyArray<OpenQuestion>>>;
   readonly openQuestionScrollTarget: {
     readonly agentId: AgentId;
     readonly questionId: OpenQuestionId;


### PR DESCRIPTION
## What

Questions now live in the session timeline like the plan artifact does: one row in the authoring agent's lane, visible while open and after consumption.

- Open and answered/dismissed questions render as artifact rows with the author chain root's groupId and identity color; spine fallback when the author is unresolvable.
- Consecutive same-lane, same-status question rows coalesce into one cluster (same merge rules as context/decision rows: same day, no intervening row). Open and consumed clusters never merge.
- Open clusters carry the attention marker and an Answer action into the Questions lens; consumed clusters show the answered/dismissed count with a done marker.
- New sessionDismissedQuestions cache + loader; dismiss and restore refresh it live.
- TimelinePane feeds the timeline builder open + answered + dismissed questions (previously only open, so consumed questions vanished).

## Tests

Timeline, TimelinePane, open-questions and regression suites green; full desktop suite 742 files / 6526 tests passed. Typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)