### PR TITLE
feat(core): add claude fable 5.1 to the anthropic catalog

### DIFF
--- a/packages/core/src/providers/auto-model.test.ts
+++ b/packages/core/src/providers/auto-model.test.ts
@@ -104,16 +104,19 @@ describe('autoModelForRole', () => {
       };
       expect(autoModelForRole({ role: 'planner', providers: ['anthropic'], prefs })).toEqual({
         provider: 'anthropic',
-        model: 'fable-5',
+        model: 'fable-5.1',
       });
     });
 
-    it('leaves the thinker above Opus in raw strength', () => {
+    it('leaves the thinkers above Opus in raw strength', () => {
       const anthropic = PROVIDER_CAPABILITIES.anthropic.models;
       const fable = anthropic.find((model) => model.id === 'fable-5');
+      const fable51 = anthropic.find((model) => model.id === 'fable-5.1');
       const opus = anthropic.find((model) => model.id === 'opus-5');
+      expect(fable51?.weight ?? 0).toBeGreaterThan(fable?.weight ?? 0);
       expect(fable?.weight ?? 0).toBeGreaterThan(opus?.weight ?? 0);
       expect(fable?.thinkerOnly).toBe(true);
+      expect(fable51?.thinkerOnly).toBe(true);
       expect(opus?.thinkerOnly).toBe(false);
     });
   });

--- a/packages/core/src/providers/catalogDescriptor.ts
+++ b/packages/core/src/providers/catalogDescriptor.ts
@@ -4,10 +4,11 @@ type Params = {
   readonly model: CatalogModel;
 };
 
-const THINKER_ONLY_KEYS: ReadonlySet<string> = new Set(['fable-5']);
+const THINKER_ONLY_KEYS: ReadonlySet<string> = new Set(['fable-5', 'fable-5.1']);
 
 const WEIGHT_BY_KEY: Readonly<Record<string, number>> = {
   'opus-5': 85,
+  'fable-5.1': 95,
   'fable-5': 90,
   'opus-4.8': 80,
   'opus-4.7': 75,

--- a/packages/core/src/providers/claude/agent-model-ids.ts
+++ b/packages/core/src/providers/claude/agent-model-ids.ts
@@ -1,6 +1,7 @@
 export const ANTHROPIC_AGENT_MODEL_IDS = [
   'claude-opus-5',
   'claude-opus-4-8',
+  'claude-fable-5-1',
   'claude-fable-5',
   'claude-opus-4-7',
   'claude-opus-4-6',

--- a/packages/core/src/providers/claude/catalog.ts
+++ b/packages/core/src/providers/claude/catalog.ts
@@ -22,6 +22,23 @@ export const ANTHROPIC_CATALOG = [
     defaultEffort: 'high',
   },
   {
+    key: 'fable-5.1',
+    label: 'Fable 5.1',
+    tier: 'turn',
+    contextWindow: 1_000_000,
+    presentation: {
+      family: 'claude',
+      group: 'Fable',
+      version: '5.1',
+      order: 41,
+      costTier: 'expensive',
+    },
+    provider: 'anthropic',
+    cliId: 'claude-fable-5-1',
+    efforts: OPUS_EFFORTS,
+    defaultEffort: 'high',
+  },
+  {
     key: 'fable-5',
     label: 'Fable 5',
     tier: 'turn',

--- a/packages/core/src/providers/claude/cost.ts
+++ b/packages/core/src/providers/claude/cost.ts
@@ -11,6 +11,11 @@ const FABLE_PRICE: ModelPrice = {
   outputPerMtok: 50,
   cachedInputPerMtok: 1,
 };
+const FABLE_51_PRICE: ModelPrice = {
+  inputPerMtok: 10,
+  outputPerMtok: 50,
+  cachedInputPerMtok: 0.25,
+};
 const OPUS_PRICE: ModelPrice = {
   inputPerMtok: 5,
   outputPerMtok: 25,
@@ -23,6 +28,7 @@ const SONNET_PRICE: ModelPrice = {
 };
 
 export const CLAUDE_PRICES: Record<string, ModelPrice> = {
+  'claude-fable-5-1': FABLE_51_PRICE,
   'claude-fable-5': FABLE_PRICE,
   'claude-opus-5': OPUS_PRICE,
   'claude-opus-4-8': OPUS_PRICE,

--- a/packages/core/src/providers/parseLegacyId.ts
+++ b/packages/core/src/providers/parseLegacyId.ts
@@ -8,6 +8,7 @@ type Params = {
 
 const LEGACY_SELECTIONS: Readonly<Record<string, ModelSelection>> = {
   'anthropic:claude-opus-5': { key: 'opus-5' },
+  'anthropic:claude-fable-5-1': { key: 'fable-5.1' },
   'anthropic:claude-fable-5': { key: 'fable-5' },
   'anthropic:claude-opus-4-8': { key: 'opus-4.8' },
   'anthropic:claude-opus-4-7': { key: 'opus-4.7' },


### PR DESCRIPTION
## What

Support for Claude Fable 5.1 (owner request, ships in v0.2.12).

- Catalog entry fable-5.1 (cliId claude-fable-5-1, 1M context, full effort ladder, default high), presentation order above Fable 5.
- Pricing from the official model docs: $10/$50 per MTok, cache reads at 2.5% of input ($0.25/MTok, tighter than Fable 5's 10%).
- Routing weight 95 above Fable 5's 90, thinker-only like Fable 5, so it becomes the auto pick for thinking roles without touching code roles.
- Spawnable agent id list and legacy id parsing extended.
- Model id verified live: claude CLI updated to 2.1.259 (the model requires >=2.1.251) and claude -p --model claude-fable-5-1 answers.

## Tests

Core provider suites green (auto-model thinker expectation moved to 5.1), full desktop suite 753 files / 6596 tests green, typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)