### PR TITLE
chore(repo): bump version to 0.2.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ version in the same PR that bumps the version numbers (see
 `docs/release-command.md`), before the tag is pushed: the release build fails
 if it can't find a matching `## Goodboy vX.Y.Z` heading.
 
+## Goodboy v0.2.12
+
+A fix for session overviews freezing the app, and one inbox reading
+work from every connected provider.
+
+### [#1632] Opening a session no longer freezes the app
+
+On v0.2.11, opening a session whose overview suggested a rebase could
+lock the whole app; the overview now stays responsive.
+
+### [#1629] One inbox for every integration
+
+The new Inbox, reachable from the footer, reads work items from every
+connected provider in one surface: GitHub, GitLab, Linear, Jira,
+Sentry, Slack and Bitbucket. The rail carries search, provider chips
+and a kind filter with counts (issues, PRs and MRs, threads, errors)
+over newest-first rows; the detail side keeps each provider's panel,
+so launching a session from a record works exactly as in the studios.
+
+The per-provider studios are untouched; they stop being destinations
+in a later phase.
+
 ## Goodboy v0.2.11
 
 Scripts you can actually read, one home for resolve work, questions that

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goodboy/desktop",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -1626,7 +1626,7 @@ dependencies = [
 
 [[package]]
 name = "goodboy-desktop"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goodboy-desktop"
-version = "0.2.11"
+version = "0.2.12"
 description = "Goodboy desktop app"
 authors = ["Amin Khayam"]
 license = "MIT"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Goodboy",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "identifier": "com.goodboy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goodboy",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "private": true,
   "description": "AI workspace orchestrator. Local-first, provider-agnostic.",
   "license": "MIT",

--- a/website/src/site.ts
+++ b/website/src/site.ts
@@ -1,5 +1,5 @@
 export const SITE = {
-  version: 'v0.2.11',
+  version: 'v0.2.12',
   repo: 'https://github.com/akhayam99/goodboy',
   releases: 'https://github.com/akhayam99/goodboy/releases',
   latest: 'https://github.com/akhayam99/goodboy/releases/latest',


### PR DESCRIPTION
Patch release: overview freeze fix (#1632) plus the unified integrations inbox (#1629). Changelog section added for the release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)