### PR TITLE
fix(core): price claude-sonnet-5 at its own 2/10 rate

### DIFF
--- a/packages/core/src/providers/claude/cost.test.ts
+++ b/packages/core/src/providers/claude/cost.test.ts
@@ -34,6 +34,20 @@ describe('computeCostUsd', () => {
     expect(computeCostUsd({ usage, model: 'claude-sonnet-4-6' })).toBeCloseTo(3 + 15);
   });
 
+  it('sonnet-5 has its own price, cheaper than sonnet-4-6', () => {
+    expect(computeCostUsd({ usage, model: 'claude-sonnet-5' })).toBeCloseTo(2 + 10);
+  });
+
+  it('sonnet-5 cached tokens are billed at 10% of input', () => {
+    const partial: ProviderUsage = {
+      inputTokens: 0,
+      outputTokens: 0,
+      cachedInputTokens: 1_000_000,
+      estimatedCostUsd: 0,
+    };
+    expect(computeCostUsd({ usage: partial, model: 'claude-sonnet-5' })).toBeCloseTo(0.2);
+  });
+
   it('sonnet-4-5 is priced as sonnet', () => {
     expect(computeCostUsd({ usage, model: 'claude-sonnet-4-5' })).toBeCloseTo(3 + 15);
   });

--- a/packages/core/src/providers/claude/cost.ts
+++ b/packages/core/src/providers/claude/cost.ts
@@ -21,6 +21,11 @@ const SONNET_PRICE: ModelPrice = {
   outputPerMtok: 15,
   cachedInputPerMtok: 0.3,
 };
+const SONNET_5_PRICE: ModelPrice = {
+  inputPerMtok: 2,
+  outputPerMtok: 10,
+  cachedInputPerMtok: 0.2,
+};
 
 export const CLAUDE_PRICES: Record<string, ModelPrice> = {
   'claude-fable-5': FABLE_PRICE,
@@ -28,7 +33,7 @@ export const CLAUDE_PRICES: Record<string, ModelPrice> = {
   'claude-opus-4-8': OPUS_PRICE,
   'claude-opus-4-7': OPUS_PRICE,
   'claude-opus-4-6': OPUS_PRICE,
-  'claude-sonnet-5': SONNET_PRICE,
+  'claude-sonnet-5': SONNET_5_PRICE,
   'claude-sonnet-4-6': SONNET_PRICE,
   'claude-sonnet-4-5': SONNET_PRICE,
   'claude-haiku-4-5': {

--- a/packages/core/src/providers/model-price.test.ts
+++ b/packages/core/src/providers/model-price.test.ts
@@ -15,6 +15,10 @@ describe('getModelPrice', () => {
     expect(getModelPrice('claude-sonnet-4-6')).toEqual({ inputPerMtok: 3, outputPerMtok: 15 });
   });
 
+  it('returns dedicated claude sonnet-5 pricing', () => {
+    expect(getModelPrice('claude-sonnet-5')).toEqual({ inputPerMtok: 2, outputPerMtok: 10 });
+  });
+
   it('returns claude haiku pricing', () => {
     expect(getModelPrice('claude-haiku-4-5')).toEqual({ inputPerMtok: 1, outputPerMtok: 5 });
   });


### PR DESCRIPTION
## Summary
- `CLAUDE_PRICES` mapped `claude-sonnet-5` to `SONNET_PRICE` (3/15/0.3). official rate is $2/MTok input, $10/MTok output, cache reads at 10% of input.
- add `SONNET_5_PRICE` (2/10/0.2) and map `claude-sonnet-5` to it. sonnet-4-6 and sonnet-4-5 stay on `SONNET_PRICE`, so the unknown-model fallback is unchanged.
- tests: `cost.test.ts` covers base and cached rate, `model-price.test.ts` covers the spread into `getModelPrice`.

## Test plan
- [x] `pnpm exec vitest run src/providers` in packages/core (372 passed)
- [x] `pnpm typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)