### PR TITLE
chore(repo): bump version to 0.2.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ version in the same PR that bumps the version numbers (see
 `docs/release-command.md`), before the tag is pushed: the release build fails
 if it can't find a matching `## Goodboy vX.Y.Z` heading.
 
+## Goodboy v0.2.13
+
+The inbox becomes the only door to your integrations, with one detail
+shell behind it, and Claude Fable 5.1 joins the catalog.
+
+### [#1630] Integration studios retire behind the inbox
+
+Tracker chips, the board's merge request click, the footer glyphs and
+the onboarding links all open the Inbox now, preselected on the right
+provider, kind or record. The old per-provider studio events keep
+working and land in the same place. The workspace studio shells for
+GitHub issues, GitLab, Linear, Sentry, Jira, Slack and Bitbucket are
+gone; session-scoped surfaces (a session's PR panel, the review hub)
+are untouched.
+
+### [#1635] One detail shell for every record
+
+The eight provider detail panels share a single header (provider
+glyph, identifier, title, state, external link, provider actions) and
+a single launch dock, so starting a session from an issue, a merge
+request, a thread or an error looks and behaves the same everywhere.
+GitLab merge requests gain the launch affordance; Sentry's two detail
+implementations become one.
+
+### [#1631] Claude Fable 5.1
+
+Fable 5.1 is in the Anthropic catalog with its own pricing and sits
+above Fable 5 for the thinking roles; code roles keep their Opus
+defaults. It needs Claude Code 2.1.251 or newer on your machine.
+
 ## Goodboy v0.2.12
 
 A fix for session overviews freezing the app, and one inbox reading

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goodboy/desktop",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -1626,7 +1626,7 @@ dependencies = [
 
 [[package]]
 name = "goodboy-desktop"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goodboy-desktop"
-version = "0.2.12"
+version = "0.2.13"
 description = "Goodboy desktop app"
 authors = ["Amin Khayam"]
 license = "MIT"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Goodboy",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "identifier": "com.goodboy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goodboy",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "private": true,
   "description": "AI workspace orchestrator. Local-first, provider-agnostic.",
   "license": "MIT",

--- a/website/src/site.ts
+++ b/website/src/site.ts
@@ -1,5 +1,5 @@
 export const SITE = {
-  version: 'v0.2.12',
+  version: 'v0.2.13',
   repo: 'https://github.com/akhayam99/goodboy',
   releases: 'https://github.com/akhayam99/goodboy/releases',
   latest: 'https://github.com/akhayam99/goodboy/releases/latest',


### PR DESCRIPTION
Version 0.2.13 in the six version sites plus the CHANGELOG section: [#1630] studios retire behind the inbox, [#1635] one detail shell and launch dock, [#1631] Claude Fable 5.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)