### PR TITLE
fix(ui): hide the overview suggestions block when nothing renders

### DIFF
--- a/apps/desktop/src/features/session/components/SessionOverviewPane/OverviewSuggestions.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/OverviewSuggestions.test.tsx
@@ -7,6 +7,7 @@ import type {
   Agent,
   AgentEffort,
   PendingResolution,
+  PlanId,
   PrComment,
   PrDetail,
   ProjectId,
@@ -380,6 +381,25 @@ describe('OverviewSuggestions', () => {
   });
 
   it('renders nothing when the engine has no suggestions', () => {
+    const { container } = render(
+      <OverviewSuggestions session={SESSION} agents={[]} onSelectQuestions={vi.fn()} />,
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing when the only suggestions belong to other surfaces', () => {
+    mocks.suggestions.mockReturnValue([
+      {
+        id: 'plan-ready:plan-1',
+        kind: 'plan-ready',
+        priority: 20,
+        title: 'Run the plan',
+        sessionId: SESSION.id,
+        payload: { planId: 'plan-1' as PlanId },
+      } satisfies SessionSuggestion,
+    ]);
+
     const { container } = render(
       <OverviewSuggestions session={SESSION} agents={[]} onSelectQuestions={vi.fn()} />,
     );

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/OverviewSuggestions.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/OverviewSuggestions.tsx
@@ -20,7 +20,7 @@ type Props = {
   readonly onSelectQuestions: () => void;
 };
 
-const OVERVIEW_KINDS: ReadonlySet<SessionSuggestion['kind']> = new Set([
+const OVERVIEW_KINDS: ReadonlySet<SessionSuggestion['kind']> = new Set<SessionSuggestion['kind']>([
   'workflow-next-step',
   'resolve-threads',
   'rebase-project',

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/OverviewSuggestions.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/OverviewSuggestions.tsx
@@ -6,7 +6,7 @@ import { useSessionRoleModels } from '../../../../shared/hooks/useSessionRoleMod
 import { buildCommentAgentArgs, type ResolveModelChoice } from '../../../chat/spawn-from-comment';
 import { groupThreads } from '../../../github/comment-threads';
 import { SuggestionRow } from '../../../suggestions/components/SuggestionRow';
-import { useSessionSuggestions } from '../../../suggestions';
+import { useSessionSuggestions, type SessionSuggestion } from '../../../suggestions';
 import { kindRouting } from '../../agent-kind';
 import { useResolverIndex } from '../../hooks/useResolverIndex';
 import { useResolverSpawner } from '../../hooks/useResolverSpawner';
@@ -19,6 +19,13 @@ type Props = {
   readonly agents: ReadonlyArray<Agent>;
   readonly onSelectQuestions: () => void;
 };
+
+const OVERVIEW_KINDS: ReadonlySet<SessionSuggestion['kind']> = new Set([
+  'workflow-next-step',
+  'resolve-threads',
+  'rebase-project',
+  'answer-questions',
+]);
 
 export const OverviewSuggestions = ({ session, agents, onSelectQuestions }: Props) => {
   const sessionId = session.id;
@@ -82,14 +89,15 @@ export const OverviewSuggestions = ({ session, agents, onSelectQuestions }: Prop
     });
   };
 
-  if (suggestions.length === 0) {
+  const visible = suggestions.filter((suggestion) => OVERVIEW_KINDS.has(suggestion.kind));
+  if (visible.length === 0) {
     return null;
   }
   return (
     <section aria-label="Suggestions" className="flex flex-col gap-2">
       <Eyebrow label="Suggestions" className="px-0.5" />
       <div className="flex flex-col gap-1.5">
-        {suggestions.map((suggestion) => {
+        {visible.map((suggestion) => {
           if (suggestion.kind === 'workflow-next-step') {
             const engineRun = suggestion.payload.runId;
             const runAgents = agents.filter((agent) => agent.workflowRunId === engineRun);


### PR DESCRIPTION
## What

The overview showed a Suggestions eyebrow with no rows whenever the engine only produced kinds the overview does not render (plan-ready lives in the composer and the sidebar). The block now filters to the kinds it renders and disappears when that list is empty.

## Tests

OverviewSuggestions spec for the plan-ready-only case; SessionOverviewPane suites 98 tests green, typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)