### PR TITLE
fix(core): pick the newest version when switching model group

### DIFF
--- a/apps/desktop/src/features/explore/components/ExplorePane/index.test.tsx
+++ b/apps/desktop/src/features/explore/components/ExplorePane/index.test.tsx
@@ -282,7 +282,7 @@ describe('ExplorePane', () => {
       | { readonly model: string; readonly initialPrompt: string; readonly focus: string }
       | undefined;
     expect(spawnArgs?.focus).toBe('none');
-    expect(spawnArgs?.model).toBe('claude-opus-4-6');
+    expect(spawnArgs?.model).toBe('claude-opus-5');
     expect(spawnArgs?.initialPrompt).toContain('Analyze this spreadsheet and summarize trends.');
     expect(spawnArgs?.initialPrompt).toContain('- budget.xlsx');
     expect(

--- a/apps/desktop/src/features/session/resolve/ResolveConfigPopover/index.test.tsx
+++ b/apps/desktop/src/features/session/resolve/ResolveConfigPopover/index.test.tsx
@@ -80,7 +80,7 @@ describe('ResolveConfigPopover', () => {
     open();
     fireEvent.click(screen.getByRole('button', { name: 'Opus' }));
     expect(onChange).toHaveBeenCalledWith(
-      expect.objectContaining({ provider: 'anthropic', model: 'claude-opus-4-6' }),
+      expect.objectContaining({ provider: 'anthropic', model: 'claude-opus-5' }),
     );
   });
 });

--- a/packages/core/src/providers/modelAxes.test.ts
+++ b/packages/core/src/providers/modelAxes.test.ts
@@ -100,9 +100,19 @@ describe('modelAxes', () => {
       throw new Error('missing anthropic sonnet-4.6');
     }
     const options = modelAxes({ model, selection: { key: model.key } }).model.options;
-    expect(options.find((option) => option.id === 'Opus')?.modelKey).toBe('opus-5');
-    expect(options.find((option) => option.id === 'Fable')?.modelKey).toBe('fable-5.1');
-    expect(options.find((option) => option.id === 'Sonnet')?.modelKey).toBe('sonnet-5');
+    const newestByGroup = new Map<string, string>();
+    for (const candidate of ANTHROPIC_CATALOG) {
+      const group = candidate.presentation.group ?? candidate.presentation.version;
+      const current = ANTHROPIC_CATALOG.find((entry) => entry.key === newestByGroup.get(group));
+      if (current == null || candidate.presentation.order > current.presentation.order) {
+        newestByGroup.set(group, candidate.key);
+      }
+    }
+    expect(options.length).toBe(newestByGroup.size);
+    for (const option of options) {
+      expect(option.modelKey).toBe(newestByGroup.get(option.id));
+    }
+    expect(options.find((option) => option.id === 'Opus')?.modelKey).not.toBe('opus-4.6');
   });
 
   it('omits the version axis when the catalog declares no model group', () => {

--- a/packages/core/src/providers/modelAxes.test.ts
+++ b/packages/core/src/providers/modelAxes.test.ts
@@ -94,6 +94,17 @@ describe('modelAxes', () => {
     expect(axes.variant).toBeNull();
   });
 
+  it('represents each model group by its newest version', () => {
+    const model = ANTHROPIC_CATALOG.find((candidate) => candidate.key === 'sonnet-4.6');
+    if (model == null) {
+      throw new Error('missing anthropic sonnet-4.6');
+    }
+    const options = modelAxes({ model, selection: { key: model.key } }).model.options;
+    expect(options.find((option) => option.id === 'Opus')?.modelKey).toBe('opus-5');
+    expect(options.find((option) => option.id === 'Fable')?.modelKey).toBe('fable-5.1');
+    expect(options.find((option) => option.id === 'Sonnet')?.modelKey).toBe('sonnet-5');
+  });
+
   it('omits the version axis when the catalog declares no model group', () => {
     const model = CURSOR_CATALOG.find((candidate) => candidate.key === 'auto');
     if (model == null) {

--- a/packages/core/src/providers/modelAxes.ts
+++ b/packages/core/src/providers/modelAxes.ts
@@ -69,9 +69,7 @@ const selectionAxes = ({ model }: SelectionAxesParams) => {
   const groupModels = new Map<string, CatalogModel>();
   for (const candidate of catalog) {
     const group = candidate.presentation.group ?? candidate.presentation.version;
-    if (groupModels.has(group) === false) {
-      groupModels.set(group, candidate);
-    }
+    groupModels.set(group, candidate);
   }
   const activeGroup = model.presentation.group ?? model.presentation.version;
   return {


### PR DESCRIPTION
Switching the model group in the picker (Opus, Sonnet, Fable, ...) now lands on the newest version of that group instead of the oldest: Opus -> 5, Sonnet -> 5, Fable -> 5.1. The version axis still lists every version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)