### PR TITLE
feat(ui): rebuild the inbox as a triage list

### DIFF
--- a/apps/desktop/src/features/inbox/ageSections.test.ts
+++ b/apps/desktop/src/features/inbox/ageSections.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import type { InboxRecord } from './types';
+import { groupRecordsByAge } from './ageSections';
+
+type RecordParams = {
+  readonly key: string;
+  readonly updatedAt: string;
+  readonly state?: InboxRecord['state'];
+};
+
+const record = ({ key, updatedAt, state = 'open' }: RecordParams): InboxRecord => ({
+  key,
+  provider: 'github',
+  kind: 'issue',
+  identifier: key,
+  title: key,
+  state,
+  updatedAt,
+  url: '',
+  meta: '',
+  payload: {
+    provider: 'github',
+    kind: 'issue',
+    issue: {
+      number: 1,
+      title: key,
+      body: '',
+      url: '',
+      state: 'OPEN',
+      labels: [],
+      updatedAt,
+    },
+    sessionId: null,
+  },
+});
+
+describe('groupRecordsByAge', () => {
+  const now = new Date(2026, 8, 4, 12).getTime();
+
+  it('groups records by calendar age using the injected time', () => {
+    const sections = groupRecordsByAge({
+      now,
+      records: [
+        record({ key: 'today', updatedAt: new Date(2026, 8, 4, 8).toISOString() }),
+        record({ key: 'yesterday', updatedAt: new Date(2026, 8, 3, 8).toISOString() }),
+        record({ key: 'week', updatedAt: new Date(2026, 7, 31, 8).toISOString() }),
+        record({ key: 'older', updatedAt: new Date(2026, 7, 30, 8).toISOString() }),
+      ],
+    });
+
+    expect(sections.map((section) => section.label)).toEqual([
+      'Today',
+      'Yesterday',
+      'This week',
+      'Older',
+    ]);
+    expect(sections.map((section) => section.records[0]?.key)).toEqual([
+      'today',
+      'yesterday',
+      'week',
+      'older',
+    ]);
+  });
+
+  it('orders state priority before recency inside a section', () => {
+    const sections = groupRecordsByAge({
+      now,
+      records: [
+        record({ key: 'done', state: 'done', updatedAt: new Date(2026, 8, 4, 11).toISOString() }),
+        record({ key: 'open', state: 'open', updatedAt: new Date(2026, 8, 4, 10).toISOString() }),
+        record({
+          key: 'active',
+          state: 'active',
+          updatedAt: new Date(2026, 8, 4, 9).toISOString(),
+        }),
+        record({
+          key: 'alert-old',
+          state: 'alert',
+          updatedAt: new Date(2026, 8, 4, 7).toISOString(),
+        }),
+        record({
+          key: 'alert-new',
+          state: 'alert',
+          updatedAt: new Date(2026, 8, 4, 8).toISOString(),
+        }),
+      ],
+    });
+
+    expect(sections[0]?.records.map((item) => item.key)).toEqual([
+      'alert-new',
+      'alert-old',
+      'active',
+      'open',
+      'done',
+    ]);
+  });
+
+  it('does not depend on the current clock when now is injected', () => {
+    const sections = groupRecordsByAge({
+      now,
+      records: [record({ key: 'fixed', updatedAt: new Date(2026, 8, 4, 1).toISOString() })],
+    });
+
+    expect(sections[0]?.key).toBe('today');
+  });
+});

--- a/apps/desktop/src/features/inbox/ageSections.ts
+++ b/apps/desktop/src/features/inbox/ageSections.ts
@@ -1,0 +1,102 @@
+import type { InboxRecord, InboxState } from './types';
+
+type InboxAgeSectionKey = 'today' | 'yesterday' | 'this-week' | 'older';
+
+type InboxAgeSection = {
+  readonly key: InboxAgeSectionKey;
+  readonly label: string;
+  readonly records: ReadonlyArray<InboxRecord>;
+};
+
+type Params = {
+  readonly records: ReadonlyArray<InboxRecord>;
+  readonly now?: number;
+};
+
+type Boundaries = {
+  readonly today: number;
+  readonly yesterday: number;
+  readonly week: number;
+};
+
+const SECTION_ORDER = [
+  { key: 'today', label: 'Today' },
+  { key: 'yesterday', label: 'Yesterday' },
+  { key: 'this-week', label: 'This week' },
+  { key: 'older', label: 'Older' },
+] satisfies ReadonlyArray<{ readonly key: InboxAgeSectionKey; readonly label: string }>;
+
+const STATE_PRIORITY = {
+  alert: 0,
+  active: 1,
+  open: 2,
+  done: 3,
+} satisfies Record<InboxState, number>;
+
+type StartOfDayParams = {
+  readonly date: Date;
+};
+
+const startOfDay = ({ date }: StartOfDayParams): number =>
+  new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime();
+
+type BoundariesParams = {
+  readonly now: number;
+};
+
+const ageBoundaries = ({ now }: BoundariesParams): Boundaries => {
+  const date = new Date(now);
+  const today = startOfDay({ date });
+  const dayOfWeekFromMonday = (date.getDay() + 6) % 7;
+  return {
+    today,
+    yesterday: new Date(date.getFullYear(), date.getMonth(), date.getDate() - 1).getTime(),
+    week: new Date(
+      date.getFullYear(),
+      date.getMonth(),
+      date.getDate() - dayOfWeekFromMonday,
+    ).getTime(),
+  };
+};
+
+type SectionKeyParams = {
+  readonly record: InboxRecord;
+  readonly boundaries: Boundaries;
+};
+
+const sectionKeyForRecord = ({ record, boundaries }: SectionKeyParams): InboxAgeSectionKey => {
+  const updatedAt = Date.parse(record.updatedAt);
+  if (Number.isNaN(updatedAt)) {
+    return 'older';
+  }
+  if (updatedAt >= boundaries.today) {
+    return 'today';
+  }
+  if (updatedAt >= boundaries.yesterday) {
+    return 'yesterday';
+  }
+  if (updatedAt >= boundaries.week) {
+    return 'this-week';
+  }
+  return 'older';
+};
+
+export const groupRecordsByAge = ({
+  records,
+  now = Date.now(),
+}: Params): ReadonlyArray<InboxAgeSection> => {
+  const boundaries = ageBoundaries({ now });
+  return SECTION_ORDER.map(({ key, label }) => ({
+    key,
+    label,
+    records: records
+      .filter((record) => sectionKeyForRecord({ record, boundaries }) === key)
+      .sort((left, right) => {
+        const stateDifference = STATE_PRIORITY[left.state] - STATE_PRIORITY[right.state];
+        if (stateDifference !== 0) {
+          return stateDifference;
+        }
+        return Date.parse(right.updatedAt) - Date.parse(left.updatedAt);
+      }),
+  })).filter((section) => section.records.length > 0);
+};

--- a/apps/desktop/src/features/inbox/components/InboxStudio/InboxDetail.test.tsx
+++ b/apps/desktop/src/features/inbox/components/InboxStudio/InboxDetail.test.tsx
@@ -114,22 +114,27 @@ const renderDetail = (record: InboxRecord | null) =>
   render(
     <InboxDetail
       record={record}
+      records={record == null ? [] : [record]}
+      hasFiltersActive={false}
       workspaceId={workspaceId}
       rootPath="/repo"
       isLoading={false}
       errors={baseErrors}
       onRefresh={vi.fn()}
       onClose={vi.fn()}
+      onClearFilters={vi.fn()}
+      onOpenIntegrations={vi.fn()}
     />,
   );
 
 afterEach(() => cleanup());
 
 describe('InboxDetail', () => {
-  it('shows an empty state prompting selection when nothing is selected', () => {
+  it('summarises the inbox when nothing is selected', () => {
     renderDetail(null);
 
-    expect(screen.getByText('Nothing selected')).toBeDefined();
+    expect(screen.getByText('Inbox is empty')).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Open integrations' })).toBeDefined();
     expect(screen.queryByTestId('panel')).toBeNull();
   });
 

--- a/apps/desktop/src/features/inbox/components/InboxStudio/InboxDetail.tsx
+++ b/apps/desktop/src/features/inbox/components/InboxStudio/InboxDetail.tsx
@@ -1,6 +1,4 @@
-import { EmptyState } from '@goodboy/ui';
 import type { WorkspaceId } from '@goodboy/types';
-import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../shared/components/conceptIcons';
 import { GithubIssueDetail } from '../../../github/GithubIssueDetail';
 import { GitlabIssueDetail } from '../../../integrations/gitlab/GitlabIssueDetail';
 import { MrDetailPanel } from '../../../integrations/gitlab/GitlabStudio/MrDetailPanel';
@@ -12,42 +10,46 @@ import { SlackThreadDetail } from '../../../integrations/slack/SlackThreadDetail
 import { PrDetailPanel } from '../../../integrations/bitbucket/BitbucketStudio/PrDetailPanel';
 import type { InboxProvider, InboxRecord } from '../../types';
 import { RecordLaunchDock } from '../RecordLaunchDock';
+import { InboxEmptySummary } from './InboxEmptySummary';
 
 type Props = {
   readonly record: InboxRecord | null;
+  readonly records: ReadonlyArray<InboxRecord>;
+  readonly hasFiltersActive: boolean;
   readonly workspaceId: WorkspaceId;
   readonly rootPath: string;
   readonly isLoading: boolean;
   readonly errors: Readonly<Record<InboxProvider, string | null>>;
   readonly onRefresh: () => void;
   readonly onClose: () => void;
+  readonly onClearFilters: () => void;
+  readonly onOpenIntegrations: () => void;
 };
 
 export const InboxDetail = ({
   record,
+  records,
+  hasFiltersActive,
   workspaceId,
   rootPath,
   isLoading,
   errors,
   onRefresh,
   onClose,
+  onClearFilters,
+  onOpenIntegrations,
 }: Props) => {
   const sentryIssueId = record?.payload.provider === 'sentry' ? record.payload.issue.id : null;
   const sentryDetail = useSentryIssueDetail({ workspaceId, issueId: sentryIssueId });
 
   if (record == null) {
     return (
-      <div className="flex h-full items-center justify-center px-8">
-        <EmptyState
-          bordered
-          tone={CONCEPT_TONE.inbox}
-          icon={CONCEPT_ICONS.inbox}
-          title="Nothing selected"
-          description="Pick an item from the inbox to see its details and launch a session."
-          size="lg"
-          headingLevel={2}
-        />
-      </div>
+      <InboxEmptySummary
+        records={records}
+        hasFiltersActive={hasFiltersActive}
+        onClearFilters={onClearFilters}
+        onOpenIntegrations={onOpenIntegrations}
+      />
     );
   }
 

--- a/apps/desktop/src/features/inbox/components/InboxStudio/InboxEmptySummary.tsx
+++ b/apps/desktop/src/features/inbox/components/InboxStudio/InboxEmptySummary.tsx
@@ -1,0 +1,108 @@
+import { Bug, CircleDot, GitPullRequest, MessagesSquare } from 'lucide-react';
+import { Button, Chip, cn, Eyebrow, PANE_RHYTHM, ScrollFade, StatCard } from '@goodboy/ui';
+import {
+  IntegrationGlyph,
+  integrationLabel,
+} from '../../../integrations/components/IntegrationGlyph';
+import { kindFilterCounts } from '../../kindFilter';
+import { INBOX_PROVIDERS, type InboxRecord } from '../../types';
+
+type Props = {
+  readonly records: ReadonlyArray<InboxRecord>;
+  readonly hasFiltersActive: boolean;
+  readonly onClearFilters: () => void;
+  readonly onOpenIntegrations: () => void;
+};
+
+export const InboxEmptySummary = ({
+  records,
+  hasFiltersActive,
+  onClearFilters,
+  onOpenIntegrations,
+}: Props) => {
+  const counts = kindFilterCounts({ records });
+  const providerCounts = INBOX_PROVIDERS.map((provider) => ({
+    provider,
+    count: records.filter((record) => record.provider === provider).length,
+  })).filter(({ count }) => count > 0);
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      <ScrollFade className="min-h-0 flex-1">
+        <div className={cn('flex flex-col gap-6', PANE_RHYTHM.body)}>
+          <div className="flex flex-col gap-2">
+            <Eyebrow label="Inbox summary" />
+            <h2 className="text-lg font-semibold text-foreground">
+              {hasFiltersActive ? 'No matching items' : 'Inbox is empty'}
+            </h2>
+            <p className="max-w-2xl text-sm text-muted-foreground">
+              {hasFiltersActive
+                ? 'Adjust the filters to bring items back into the list.'
+                : 'Connect a provider to collect issues, reviews, threads and errors here.'}
+            </p>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4 xl:grid-cols-4">
+            <StatCard
+              label="Issues"
+              value={String(counts.issue)}
+              icon={<CircleDot size={16} aria-hidden />}
+              tone="info"
+              valueSize="lg"
+            />
+            <StatCard
+              label="PRs & MRs"
+              value={String(counts['pr-mr'])}
+              icon={<GitPullRequest size={16} aria-hidden />}
+              tone="merged"
+              valueSize="lg"
+            />
+            <StatCard
+              label="Threads"
+              value={String(counts.thread)}
+              icon={<MessagesSquare size={16} aria-hidden />}
+              tone="accent"
+              valueSize="lg"
+            />
+            <StatCard
+              label="Errors"
+              value={String(counts.error)}
+              icon={<Bug size={16} aria-hidden />}
+              tone="danger"
+              valueSize="lg"
+            />
+          </div>
+
+          {providerCounts.length > 0 ? (
+            <div className="flex flex-col gap-2">
+              <Eyebrow label="Providers" />
+              <div className="flex flex-wrap gap-2">
+                {providerCounts.map(({ provider, count }) => (
+                  <Chip
+                    key={provider}
+                    tone="neutral"
+                    icon={<IntegrationGlyph provider={provider} size="xs" useBrandColor />}
+                    label={integrationLabel({ provider })}
+                    trailing={<span className="font-mono tabular-nums">{count}</span>}
+                  />
+                ))}
+              </div>
+            </div>
+          ) : null}
+
+          <div className="flex items-center gap-2">
+            {hasFiltersActive ? (
+              <Button variant="secondary" size="sm" onClick={onClearFilters}>
+                Clear filters
+              </Button>
+            ) : (
+              <Button variant="secondary" size="sm" onClick={onOpenIntegrations}>
+                Open integrations
+              </Button>
+            )}
+          </div>
+        </div>
+      </ScrollFade>
+    </div>
+  );
+};

--- a/apps/desktop/src/features/inbox/components/InboxStudio/InboxRail.test.tsx
+++ b/apps/desktop/src/features/inbox/components/InboxStudio/InboxRail.test.tsx
@@ -112,14 +112,30 @@ describe('InboxRail', () => {
     const chips = within(group).getAllByRole('button');
 
     expect(chips.map((chip) => chip.textContent)).toEqual(['GitHub2', 'Linear1']);
+    expect(chips.map((chip) => chip.getAttribute('aria-label'))).toEqual([
+      'GitHub, 2 items',
+      'Linear, 1 item',
+    ]);
     expect(chips.every((chip) => chip.getAttribute('aria-pressed') === 'false')).toBe(true);
+  });
+
+  it('points aria-activedescendant at the selected option', () => {
+    renderRail({ selectedKey: 'b' });
+
+    const list = screen.getByRole('listbox', { name: 'Inbox items' });
+    const selected = within(list)
+      .getAllByRole('option')
+      .find((option) => option.getAttribute('aria-selected') === 'true');
+
+    expect(selected?.id).toBe('inbox-option-b');
+    expect(list.getAttribute('aria-activedescendant')).toBe('inbox-option-b');
   });
 
   it('renders a selected provider that has no records and can toggle it off', () => {
     const onToggleProvider = vi.fn();
     renderRail({ selectedProviders: new Set<InboxProvider>(['jira']), onToggleProvider });
 
-    const jiraChip = screen.getByRole('button', { name: 'Jira' });
+    const jiraChip = screen.getByRole('button', { name: /^Jira, / });
 
     expect(jiraChip.getAttribute('aria-pressed')).toBe('true');
     expect(jiraChip.textContent).toContain('0');

--- a/apps/desktop/src/features/inbox/components/InboxStudio/InboxRail.test.tsx
+++ b/apps/desktop/src/features/inbox/components/InboxStudio/InboxRail.test.tsx
@@ -1,0 +1,169 @@
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { InboxProvider, InboxRecord } from '../../types';
+import { InboxRail } from './InboxRail';
+
+const HOUR = 60 * 60 * 1000;
+
+type RecordParams = {
+  readonly key: string;
+  readonly provider?: InboxProvider;
+  readonly identifier: string;
+  readonly title: string;
+  readonly updatedAt: string;
+};
+
+const record = ({
+  key,
+  provider = 'github',
+  identifier,
+  title,
+  updatedAt,
+}: RecordParams): InboxRecord => ({
+  key,
+  provider,
+  kind: 'issue',
+  identifier,
+  title,
+  state: 'open',
+  updatedAt,
+  url: '',
+  meta: '',
+  payload: {
+    provider: 'github',
+    kind: 'issue',
+    issue: {
+      number: 1,
+      title,
+      body: '',
+      url: '',
+      state: 'OPEN',
+      labels: [],
+      updatedAt,
+    },
+    sessionId: null,
+  },
+});
+
+const now = Date.now();
+
+const todayRecord = record({
+  key: 'a',
+  identifier: '#1',
+  title: 'Today item',
+  updatedAt: new Date(now - 2 * HOUR).toISOString(),
+});
+
+const yesterdayRecord = record({
+  key: 'b',
+  provider: 'linear',
+  identifier: 'ENG-1',
+  title: 'Yesterday item',
+  updatedAt: new Date(now - 24 * HOUR).toISOString(),
+});
+
+const olderRecord = record({
+  key: 'c',
+  identifier: '#2',
+  title: 'Older item',
+  updatedAt: new Date(now - 30 * 24 * HOUR).toISOString(),
+});
+
+const records = [todayRecord, yesterdayRecord, olderRecord];
+
+type RenderParams = {
+  readonly selectedProviders?: ReadonlySet<InboxProvider>;
+  readonly selectedKey?: string | null;
+  readonly onSelect?: (record: InboxRecord) => void;
+  readonly onToggleProvider?: (provider: InboxProvider) => void;
+};
+
+const renderRail = ({
+  selectedProviders = new Set<InboxProvider>(),
+  selectedKey = null,
+  onSelect = vi.fn(),
+  onToggleProvider = vi.fn(),
+}: RenderParams = {}) =>
+  render(
+    <InboxRail
+      records={records}
+      allRecords={records}
+      selectedProviders={selectedProviders}
+      onToggleProvider={onToggleProvider}
+      query=""
+      onQueryChange={vi.fn()}
+      kindFilter="all"
+      onKindFilterChange={vi.fn()}
+      selectedKey={selectedKey}
+      onSelect={onSelect}
+      isLoading={false}
+      errors={[]}
+      onRefresh={vi.fn()}
+    />,
+  );
+
+afterEach(() => cleanup());
+
+describe('InboxRail', () => {
+  it('labels every provider chip with its count', () => {
+    renderRail();
+
+    const group = screen.getByRole('group', { name: 'Filter by provider' });
+    const chips = within(group).getAllByRole('button');
+
+    expect(chips.map((chip) => chip.textContent)).toEqual(['GitHub2', 'Linear1']);
+    expect(chips.every((chip) => chip.getAttribute('aria-pressed') === 'false')).toBe(true);
+  });
+
+  it('renders a selected provider that has no records and can toggle it off', () => {
+    const onToggleProvider = vi.fn();
+    renderRail({ selectedProviders: new Set<InboxProvider>(['jira']), onToggleProvider });
+
+    const jiraChip = screen.getByRole('button', { name: 'Jira' });
+
+    expect(jiraChip.getAttribute('aria-pressed')).toBe('true');
+    expect(jiraChip.textContent).toContain('0');
+
+    fireEvent.click(jiraChip);
+
+    expect(onToggleProvider).toHaveBeenCalledWith('jira');
+  });
+
+  it('separates the list into time sections', () => {
+    renderRail();
+
+    const list = screen.getByRole('listbox', { name: 'Inbox items' });
+
+    expect(within(list).getByText('Today')).toBeDefined();
+    expect(within(list).getByText('Yesterday')).toBeDefined();
+    expect(within(list).getByText('Older')).toBeDefined();
+    expect(within(list).queryByText('This week')).toBeNull();
+  });
+
+  it('moves the selection with the arrow keys, Home and End', () => {
+    const onSelect = vi.fn();
+    renderRail({ selectedKey: 'a', onSelect });
+
+    const list = screen.getByRole('listbox', { name: 'Inbox items' });
+
+    fireEvent.keyDown(list, { key: 'ArrowDown' });
+    expect(onSelect).toHaveBeenLastCalledWith(yesterdayRecord);
+
+    fireEvent.keyDown(list, { key: 'ArrowUp' });
+    expect(onSelect).toHaveBeenLastCalledWith(todayRecord);
+
+    fireEvent.keyDown(list, { key: 'End' });
+    expect(onSelect).toHaveBeenLastCalledWith(olderRecord);
+
+    fireEvent.keyDown(list, { key: 'Home' });
+    expect(onSelect).toHaveBeenLastCalledWith(todayRecord);
+  });
+
+  it('keeps the list focusable and hints at keyboard navigation', () => {
+    renderRail();
+
+    expect(screen.getByRole('listbox', { name: 'Inbox items' }).getAttribute('tabindex')).toBe('0');
+    expect(screen.getByText('navigate')).toBeDefined();
+    expect(screen.getByText('↑↓')).toBeDefined();
+  });
+});

--- a/apps/desktop/src/features/inbox/components/InboxStudio/InboxRail.tsx
+++ b/apps/desktop/src/features/inbox/components/InboxStudio/InboxRail.tsx
@@ -25,7 +25,7 @@ import {
   type InboxKindFilter,
 } from '../../kindFilter';
 import { INBOX_PROVIDERS, type InboxProvider, type InboxRecord } from '../../types';
-import { InboxRow } from './InboxRow';
+import { InboxRow, inboxOptionId } from './InboxRow';
 
 const KIND_LABEL: Record<InboxKindFilter, string> = {
   all: 'All',
@@ -197,7 +197,7 @@ export const InboxRail = ({
                   icon={<IntegrationGlyph provider={provider} size="xs" useBrandColor />}
                   label={label}
                   trailing={<span className="font-mono tabular-nums">{count}</span>}
-                  ariaLabel={label}
+                  ariaLabel={`${label}, ${count} ${count === 1 ? 'item' : 'items'}`}
                   ariaPressed={isActive}
                   onClick={() => onToggleProvider(provider)}
                 />
@@ -249,6 +249,11 @@ export const InboxRail = ({
               tabIndex={0}
               role="listbox"
               aria-label="Inbox items"
+              aria-activedescendant={
+                selectedKey == null || !orderedRecords.some((record) => record.key === selectedKey)
+                  ? undefined
+                  : inboxOptionId({ key: selectedKey })
+              }
               className="flex flex-col gap-0.5 rounded-md focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/40"
               onKeyDown={(event) =>
                 handleListKeyDown({ event, orderedRecords, selectedKey, onSelect })

--- a/apps/desktop/src/features/inbox/components/InboxStudio/InboxRail.tsx
+++ b/apps/desktop/src/features/inbox/components/InboxStudio/InboxRail.tsx
@@ -1,23 +1,30 @@
+import { Fragment, type KeyboardEvent } from 'react';
 import { Bug, CircleDot, GitPullRequest, MessagesSquare, Search } from 'lucide-react';
 import {
-  Button,
+  Chip,
   cn,
-  EmptyState,
   ErrorStrip,
+  Eyebrow,
+  KbdPill,
+  PANE_RHYTHM,
   ScrollFade,
   SegmentedTabs,
   Skeleton,
-  Tooltip,
-  PANE_RHYTHM,
   type SegmentedTabOption,
 } from '@goodboy/ui';
-import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../shared/components/conceptIcons';
+import { CONCEPT_ICONS } from '../../../../shared/components/conceptIcons';
 import {
   IntegrationGlyph,
   integrationLabel,
 } from '../../../integrations/components/IntegrationGlyph';
-import { INBOX_KIND_FILTERS, kindFilterCounts, type InboxKindFilter } from '../../kindFilter';
-import type { InboxProvider, InboxRecord } from '../../types';
+import { groupRecordsByAge } from '../../ageSections';
+import {
+  filterInboxRecords,
+  INBOX_KIND_FILTERS,
+  kindFilterCounts,
+  type InboxKindFilter,
+} from '../../kindFilter';
+import { INBOX_PROVIDERS, type InboxProvider, type InboxRecord } from '../../types';
 import { InboxRow } from './InboxRow';
 
 const KIND_LABEL: Record<InboxKindFilter, string> = {
@@ -36,6 +43,8 @@ const KIND_ICON: Record<InboxKindFilter, SegmentedTabOption<InboxKindFilter>['ic
   error: Bug,
 };
 
+const NO_PROVIDER_FILTER: ReadonlySet<InboxProvider> = new Set();
+
 type ErrorEntry = {
   readonly provider: InboxProvider;
   readonly message: string;
@@ -43,11 +52,9 @@ type ErrorEntry = {
 
 type Props = {
   readonly records: ReadonlyArray<InboxRecord>;
-  readonly totalCount: number;
-  readonly availableProviders: ReadonlyArray<InboxProvider>;
+  readonly allRecords: ReadonlyArray<InboxRecord>;
   readonly selectedProviders: ReadonlySet<InboxProvider>;
   readonly onToggleProvider: (provider: InboxProvider) => void;
-  readonly allRecords: ReadonlyArray<InboxRecord>;
   readonly query: string;
   readonly onQueryChange: (value: string) => void;
   readonly kindFilter: InboxKindFilter;
@@ -57,17 +64,57 @@ type Props = {
   readonly isLoading: boolean;
   readonly errors: ReadonlyArray<ErrorEntry>;
   readonly onRefresh: () => void;
-  readonly onOpenIntegrations: () => void;
-  readonly onClearFilters: () => void;
+};
+
+type ListKeyDownParams = {
+  readonly event: KeyboardEvent<HTMLUListElement>;
+  readonly orderedRecords: ReadonlyArray<InboxRecord>;
+  readonly selectedKey: string | null;
+  readonly onSelect: (record: InboxRecord) => void;
+};
+
+const handleListKeyDown = ({
+  event,
+  orderedRecords,
+  selectedKey,
+  onSelect,
+}: ListKeyDownParams): void => {
+  if (orderedRecords.length === 0) {
+    return;
+  }
+  const selectedIndex = orderedRecords.findIndex((record) => record.key === selectedKey);
+  const lastIndex = orderedRecords.length - 1;
+  const nextIndex = ((): number | null => {
+    if (event.key === 'ArrowDown') {
+      return selectedIndex < 0 ? 0 : Math.min(selectedIndex + 1, lastIndex);
+    }
+    if (event.key === 'ArrowUp') {
+      return selectedIndex < 0 ? lastIndex : Math.max(selectedIndex - 1, 0);
+    }
+    if (event.key === 'Home') {
+      return 0;
+    }
+    if (event.key === 'End') {
+      return lastIndex;
+    }
+    return null;
+  })();
+  if (nextIndex == null) {
+    return;
+  }
+  event.preventDefault();
+  const nextRecord = orderedRecords[nextIndex];
+  if (nextRecord == null) {
+    return;
+  }
+  onSelect(nextRecord);
 };
 
 export const InboxRail = ({
   records,
-  totalCount,
-  availableProviders,
+  allRecords,
   selectedProviders,
   onToggleProvider,
-  allRecords,
   query,
   onQueryChange,
   kindFilter,
@@ -77,8 +124,6 @@ export const InboxRail = ({
   isLoading,
   errors,
   onRefresh,
-  onOpenIntegrations,
-  onClearFilters,
 }: Props) => {
   const counts = kindFilterCounts({ records: allRecords });
   const kindOptions: ReadonlyArray<SegmentedTabOption<InboxKindFilter>> = INBOX_KIND_FILTERS.map(
@@ -89,20 +134,38 @@ export const InboxRail = ({
       badge: String(counts[filter]),
     }),
   );
+  const providerCountRecords = filterInboxRecords({
+    records: allRecords,
+    query,
+    kindFilter,
+    providers: NO_PROVIDER_FILTER,
+  });
+  const providers = INBOX_PROVIDERS.filter(
+    (provider) =>
+      selectedProviders.has(provider) || allRecords.some((record) => record.provider === provider),
+  );
+  const sections = groupRecordsByAge({ records });
+  const orderedRecords = sections.flatMap((section) => section.records);
+  const totalCount = allRecords.length;
   const hasFiltersActive =
     query.trim() !== '' || kindFilter !== 'all' || selectedProviders.size > 0;
   const isShowingSkeleton = isLoading && totalCount === 0;
 
   return (
-    <div className="flex h-full flex-col">
-      <div className={cn('shrink-0 flex flex-col gap-2.5', PANE_RHYTHM.rail.header)}>
+    <div className="flex h-full flex-col overflow-hidden">
+      <div
+        className={cn(
+          'sticky top-0 z-10 flex shrink-0 flex-col gap-2 border-b border-border-soft bg-background',
+          PANE_RHYTHM.rail.header,
+        )}
+      >
         <div className="flex h-9 items-center gap-2 rounded-md border border-border bg-background px-2.5 focus-within:border-primary">
           <Search size={13} aria-hidden className="shrink-0 text-muted-foreground/60" />
           <input
             type="text"
             value={query}
             onChange={(event) => onQueryChange(event.target.value)}
-            placeholder="Search the inbox…"
+            placeholder="Search the inbox"
             aria-label="Search the inbox"
             autoComplete="off"
             className="min-w-0 flex-1 bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground/50"
@@ -114,43 +177,48 @@ export const InboxRail = ({
           value={kindFilter}
           onChange={onKindFilterChange}
           size="sm"
+          fill
         />
-        {availableProviders.length > 0 ? (
-          <div role="group" aria-label="Filter by provider" className="flex flex-wrap gap-1">
-            {availableProviders.map((provider) => {
+        {providers.length > 0 ? (
+          <div role="group" aria-label="Filter by provider" className="flex flex-wrap gap-1.5">
+            {providers.map((provider) => {
               const label = integrationLabel({ provider });
               const isActive = selectedProviders.has(provider);
+              const count = providerCountRecords.filter(
+                (record) => record.provider === provider,
+              ).length;
               return (
-                <Tooltip key={provider} content={label}>
-                  <button
-                    type="button"
-                    onClick={() => onToggleProvider(provider)}
-                    aria-label={label}
-                    aria-pressed={isActive}
-                    className={cn(
-                      'flex items-center justify-center rounded-md border p-1.5 motion-safe:transition-colors',
-                      isActive
-                        ? 'border-primary/40 bg-primary/10'
-                        : 'border-border-soft hover:border-border hover:bg-muted/50',
-                    )}
-                  >
-                    <IntegrationGlyph provider={provider} size="xs" useBrandColor />
-                  </button>
-                </Tooltip>
+                <Chip
+                  key={provider}
+                  as="button"
+                  size="sm"
+                  tone={isActive ? 'primary' : 'neutral'}
+                  emphasis={isActive ? 'strong' : 'subtle'}
+                  icon={<IntegrationGlyph provider={provider} size="xs" useBrandColor />}
+                  label={label}
+                  trailing={<span className="font-mono tabular-nums">{count}</span>}
+                  ariaLabel={label}
+                  ariaPressed={isActive}
+                  onClick={() => onToggleProvider(provider)}
+                />
               );
             })}
           </div>
         ) : null}
+        <div className="flex items-center gap-1.5 text-3xs text-muted-foreground/60">
+          <KbdPill className="h-4 min-w-4 text-3xs">↑↓</KbdPill>
+          <span>navigate</span>
+        </div>
       </div>
 
       {isShowingSkeleton ? (
         <div
-          className="flex min-h-0 flex-1 flex-col gap-1.5 px-3 pb-3"
+          className={cn('flex min-h-0 flex-1 flex-col gap-1.5', PANE_RHYTHM.rail.body)}
           role="status"
           aria-label="Loading the inbox"
         >
           {Array.from({ length: 6 }).map((_, index) => (
-            <div key={index} className="flex flex-col gap-1 px-2.5 py-2">
+            <div key={index} className="flex flex-col gap-1 px-3 py-2">
               <div className="flex items-center gap-2">
                 <Skeleton className="size-3.5 shrink-0 rounded-full" />
                 <Skeleton className="h-3 flex-1 rounded" />
@@ -162,41 +230,11 @@ export const InboxRail = ({
             </div>
           ))}
         </div>
-      ) : totalCount === 0 ? (
-        <div className="flex min-h-0 flex-1 items-center justify-center px-3">
-          <EmptyState
-            icon={CONCEPT_ICONS.inbox}
-            tone={CONCEPT_TONE.inbox}
-            title="Nothing in your inbox yet"
-            description="Connect a provider to see issues, pull requests, merge requests, threads and errors here."
-            size="inline"
-            action={
-              <Button variant="ghost" size="sm" onClick={onOpenIntegrations}>
-                Open integrations
-              </Button>
-            }
-          />
-        </div>
-      ) : records.length === 0 ? (
-        <div className="flex min-h-0 flex-1 items-center justify-center px-3">
-          <EmptyState
-            icon={Search}
-            tone="neutral"
-            title="No matching items"
-            description="Your filters are hiding everything in the inbox."
-            size="inline"
-            action={
-              <Button variant="ghost" size="sm" onClick={onClearFilters}>
-                Clear filters
-              </Button>
-            }
-          />
-        </div>
       ) : (
         <ScrollFade className="min-h-0 flex-1" fadeSize={24}>
-          <div className={cn('flex flex-col gap-0.5', PANE_RHYTHM.rail.body)}>
+          <div className={cn('flex flex-col gap-2', PANE_RHYTHM.rail.body)}>
             {errors.length > 0 ? (
-              <div className="flex flex-col gap-1.5 pb-1.5">
+              <div className="flex flex-col gap-1.5">
                 {errors.map((entry) => (
                   <ErrorStrip
                     key={entry.provider}
@@ -207,19 +245,39 @@ export const InboxRail = ({
                 ))}
               </div>
             ) : null}
-            <ul className="flex flex-col gap-0.5">
-              {records.map((record) => (
-                <li key={record.key}>
-                  <InboxRow
-                    record={record}
-                    selected={record.key === selectedKey}
-                    onSelect={onSelect}
-                  />
-                </li>
+            <ul
+              tabIndex={0}
+              role="listbox"
+              aria-label="Inbox items"
+              className="flex flex-col gap-0.5 rounded-md focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/40"
+              onKeyDown={(event) =>
+                handleListKeyDown({ event, orderedRecords, selectedKey, onSelect })
+              }
+            >
+              {sections.map((section) => (
+                <Fragment key={section.key}>
+                  <li role="presentation" className="px-1 pb-0.5 pt-2.5 first:pt-0.5">
+                    <Eyebrow label={section.label} muted />
+                  </li>
+                  {section.records.map((record) => (
+                    <li key={record.key} role="presentation">
+                      <InboxRow
+                        record={record}
+                        selected={record.key === selectedKey}
+                        onSelect={onSelect}
+                      />
+                    </li>
+                  ))}
+                </Fragment>
               ))}
             </ul>
-            {hasFiltersActive ? (
-              <p className="px-1 pt-1 text-2xs text-muted-foreground/60">
+            {records.length === 0 ? (
+              <p className="px-1 py-1 text-xs text-muted-foreground">
+                {totalCount === 0 ? 'No inbox items' : 'No matching items'}
+              </p>
+            ) : null}
+            {hasFiltersActive && records.length > 0 ? (
+              <p className="px-1 text-2xs text-muted-foreground/60">
                 {records.length} of {totalCount} shown
               </p>
             ) : null}

--- a/apps/desktop/src/features/inbox/components/InboxStudio/InboxRow.test.tsx
+++ b/apps/desktop/src/features/inbox/components/InboxStudio/InboxRow.test.tsx
@@ -1,0 +1,64 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { InboxRecord } from '../../types';
+import { InboxRow } from './InboxRow';
+
+const record: InboxRecord = {
+  key: 'linear:issue:1',
+  provider: 'linear',
+  kind: 'issue',
+  identifier: 'ENG-42',
+  title: 'Ship the inbox',
+  state: 'active',
+  updatedAt: new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString(),
+  url: '',
+  meta: 'In Progress',
+  payload: {
+    provider: 'linear',
+    kind: 'issue',
+    issue: {
+      id: '1',
+      identifier: 'ENG-42',
+      title: 'Ship the inbox',
+      description: null,
+      url: '',
+      state: { name: 'In Progress', type: 'started' },
+      team: { key: 'ENG' },
+      updatedAt: '',
+    },
+    sessionId: null,
+  },
+};
+
+afterEach(() => cleanup());
+
+describe('InboxRow', () => {
+  it('renders the identifier, title, age, provider, state and meta', () => {
+    render(<InboxRow record={record} selected={false} onSelect={vi.fn()} />);
+
+    expect(screen.getByText('ENG-42')).toBeDefined();
+    expect(screen.getByText('Ship the inbox')).toBeDefined();
+    expect(screen.getByText('3h ago')).toBeDefined();
+    expect(screen.getByText('Linear')).toBeDefined();
+    expect(screen.getByText('Active')).toBeDefined();
+    expect(screen.getByText('In Progress')).toBeDefined();
+  });
+
+  it('exposes the row as a selectable option', () => {
+    render(<InboxRow record={record} selected onSelect={vi.fn()} />);
+
+    const option = screen.getByRole('option');
+
+    expect(option.getAttribute('aria-selected')).toBe('true');
+    expect(option.getAttribute('aria-current')).toBe('true');
+  });
+
+  it('reports the record when clicked', () => {
+    const onSelect = vi.fn();
+    render(<InboxRow record={record} selected={false} onSelect={onSelect} />);
+
+    fireEvent.click(screen.getByRole('option'));
+
+    expect(onSelect).toHaveBeenCalledWith(record);
+  });
+});

--- a/apps/desktop/src/features/inbox/components/InboxStudio/InboxRow.tsx
+++ b/apps/desktop/src/features/inbox/components/InboxStudio/InboxRow.tsx
@@ -36,6 +36,13 @@ type Props = {
   readonly onSelect: (record: InboxRecord) => void;
 };
 
+type OptionIdParams = {
+  readonly key: string;
+};
+
+export const inboxOptionId = ({ key }: OptionIdParams): string =>
+  `inbox-option-${key.replace(/[^a-zA-Z0-9_-]/g, '_')}`;
+
 export const InboxRow = ({ record, selected, onSelect }: Props) => {
   const relativeTime = formatRelativeAge({ fromIso: record.updatedAt });
   const stateTone = STATE_TONE[record.state];
@@ -48,6 +55,7 @@ export const InboxRow = ({ record, selected, onSelect }: Props) => {
       onClick={() => onSelect(record)}
       title={record.title}
       ariaCurrent={selected}
+      id={inboxOptionId({ key: record.key })}
       role="option"
       ariaSelected={selected}
       tabIndex={-1}

--- a/apps/desktop/src/features/inbox/components/InboxStudio/InboxRow.tsx
+++ b/apps/desktop/src/features/inbox/components/InboxStudio/InboxRow.tsx
@@ -1,13 +1,26 @@
-import { SelectableRow, StatusDot, type Tone } from '@goodboy/ui';
-import { IntegrationGlyph } from '../../../integrations/components/IntegrationGlyph';
+import type { LucideIcon } from 'lucide-react';
+import { Bug, CircleDot, GitPullRequest, MessagesSquare } from 'lucide-react';
+import { cn, SelectableRow, StateBadge, tintClasses, type StateTone } from '@goodboy/ui';
+import {
+  IntegrationGlyph,
+  integrationLabel,
+} from '../../../integrations/components/IntegrationGlyph';
 import { formatRelativeAge } from '../../../../shared/utils/relativeDate';
-import type { InboxRecord, InboxState } from '../../types';
+import type { InboxKind, InboxRecord, InboxState } from '../../types';
 
-const STATE_TONE: Record<InboxState, Tone> = {
+const STATE_TONE: Record<InboxState, StateTone> = {
   open: 'info',
   active: 'warning',
   done: 'neutral',
   alert: 'danger',
+};
+
+const KIND_ICON: Record<InboxKind, LucideIcon> = {
+  issue: CircleDot,
+  pr: GitPullRequest,
+  mr: GitPullRequest,
+  thread: MessagesSquare,
+  error: Bug,
 };
 
 const STATE_LABEL: Record<InboxState, string> = {
@@ -25,6 +38,9 @@ type Props = {
 
 export const InboxRow = ({ record, selected, onSelect }: Props) => {
   const relativeTime = formatRelativeAge({ fromIso: record.updatedAt });
+  const stateTone = STATE_TONE[record.state];
+  const KindIcon = KIND_ICON[record.kind];
+  const providerLabel = integrationLabel({ provider: record.provider });
 
   return (
     <SelectableRow
@@ -32,27 +48,31 @@ export const InboxRow = ({ record, selected, onSelect }: Props) => {
       onClick={() => onSelect(record)}
       title={record.title}
       ariaCurrent={selected}
-      className="flex-col items-stretch gap-1 px-2.5 py-2"
+      role="option"
+      ariaSelected={selected}
+      tabIndex={-1}
+      className="flex-col items-stretch gap-1 px-3 py-2"
     >
       <span className="flex items-center gap-2">
-        <IntegrationGlyph provider={record.provider} size="xs" useBrandColor />
+        <KindIcon size={14} aria-hidden className={cn('shrink-0', tintClasses(stateTone).icon)} />
         <span className="shrink-0 font-mono text-2xs tabular-nums text-muted-foreground">
           {record.identifier}
         </span>
         <span className="min-w-0 flex-1 truncate text-xs">{record.title}</span>
         {relativeTime !== '' ? (
-          <span className="shrink-0 text-2xs tabular-nums text-muted-foreground/50">
+          <span className="shrink-0 text-3xs tabular-nums text-muted-foreground/60">
             {relativeTime}
           </span>
         ) : null}
       </span>
-      <span className="flex items-center gap-1.5 pl-6">
-        <StatusDot
-          tone={STATE_TONE[record.state]}
-          size="sm"
-          ariaLabel={STATE_LABEL[record.state]}
-        />
-        <span className="min-w-0 flex-1 truncate text-2xs text-muted-foreground/70">
+      <span className="flex items-center gap-2 pl-6">
+        <IntegrationGlyph provider={record.provider} size="xs" useBrandColor />
+        <span className="shrink-0 text-2xs text-muted-foreground">{providerLabel}</span>
+        <StateBadge tone={stateTone}>{STATE_LABEL[record.state]}</StateBadge>
+        <span
+          className="min-w-0 flex-1 truncate text-2xs text-muted-foreground/70"
+          title={record.meta}
+        >
           {record.meta}
         </span>
       </span>

--- a/apps/desktop/src/features/inbox/components/InboxStudio/index.test.tsx
+++ b/apps/desktop/src/features/inbox/components/InboxStudio/index.test.tsx
@@ -262,7 +262,7 @@ describe('InboxStudio', () => {
   it('filters rows by provider chip', () => {
     renderStudio();
 
-    fireEvent.click(screen.getByRole('button', { name: 'GitHub' }));
+    fireEvent.click(screen.getByRole('button', { name: /^GitHub, / }));
 
     expect(screen.getByText('Fix the flaky test')).toBeDefined();
     expect(screen.queryByText('Ship the inbox')).toBeNull();
@@ -308,7 +308,7 @@ describe('InboxStudio', () => {
   it('renders a deep-linked provider that has no records and recovers with clear filters', () => {
     renderStudio({ initialProvider: 'jira' });
 
-    const jiraChip = screen.getByRole('button', { name: 'Jira' });
+    const jiraChip = screen.getByRole('button', { name: /^Jira, / });
     expect(jiraChip.getAttribute('aria-pressed')).toBe('true');
     expect(jiraChip.textContent).toContain('0');
     expect(screen.getByText('No matching items')).toBeDefined();
@@ -317,13 +317,13 @@ describe('InboxStudio', () => {
     fireEvent.click(screen.getByTestId('detail-clear-filters'));
 
     expect(screen.getByText('Fix the flaky test')).toBeDefined();
-    expect(screen.queryByRole('button', { name: 'Jira' })).toBeNull();
+    expect(screen.queryByRole('button', { name: /^Jira, / })).toBeNull();
   });
 
   it('toggles off a selected provider that has no records', () => {
     renderStudio({ initialProvider: 'jira' });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Jira' }));
+    fireEvent.click(screen.getByRole('button', { name: /^Jira, / }));
 
     expect(screen.getByText('Fix the flaky test')).toBeDefined();
   });
@@ -331,12 +331,12 @@ describe('InboxStudio', () => {
   it('persists the provider selection per workspace', () => {
     const first = renderStudio();
 
-    fireEvent.click(screen.getByRole('button', { name: 'GitHub' }));
+    fireEvent.click(screen.getByRole('button', { name: /^GitHub, / }));
     first.unmount();
 
     renderStudio();
 
-    expect(screen.getByRole('button', { name: 'GitHub' }).getAttribute('aria-pressed')).toBe(
+    expect(screen.getByRole('button', { name: /^GitHub, / }).getAttribute('aria-pressed')).toBe(
       'true',
     );
     expect(screen.queryByText('Ship the inbox')).toBeNull();

--- a/apps/desktop/src/features/inbox/components/InboxStudio/index.test.tsx
+++ b/apps/desktop/src/features/inbox/components/InboxStudio/index.test.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { WorkspaceId } from '@goodboy/types';
 import type { InboxRecord } from '../../types';
@@ -44,8 +44,30 @@ vi.mock('../../useInboxRecords', () => ({
 }));
 
 vi.mock('./InboxDetail', () => ({
-  InboxDetail: ({ record }: { record: InboxRecord | null }) => (
-    <div data-testid="detail">{record?.identifier ?? 'none'}</div>
+  InboxDetail: ({
+    record,
+    hasFiltersActive,
+    onClearFilters,
+    onOpenIntegrations,
+  }: {
+    record: InboxRecord | null;
+    hasFiltersActive: boolean;
+    onClearFilters: () => void;
+    onOpenIntegrations: () => void;
+  }) => (
+    <div data-testid="detail">
+      {record?.identifier ?? 'none'}
+      {record == null && hasFiltersActive ? (
+        <button type="button" data-testid="detail-clear-filters" onClick={onClearFilters}>
+          clear
+        </button>
+      ) : null}
+      {record == null && !hasFiltersActive ? (
+        <button type="button" data-testid="detail-open-integrations" onClick={onOpenIntegrations}>
+          integrations
+        </button>
+      ) : null}
+    </div>
   ),
 }));
 
@@ -204,10 +226,10 @@ afterEach(() => {
 });
 
 describe('InboxStudio', () => {
-  it('renders every row sorted newest first', () => {
+  it('renders every row with alerts first, then newest first', () => {
     renderStudio();
 
-    const identifiers = screen
+    const identifiers = within(screen.getByRole('listbox', { name: 'Inbox items' }))
       .getAllByText(/^(#1|ENG-1|#eng|GBY-1)$/)
       .map((node) => node.textContent);
 
@@ -246,14 +268,25 @@ describe('InboxStudio', () => {
     expect(screen.queryByText('Ship the inbox')).toBeNull();
   });
 
-  it('renders the matching detail once a row is selected', () => {
+  it('auto selects the first visible record and follows a click', () => {
     renderStudio();
 
-    expect(screen.getByTestId('detail').textContent).toBe('none');
+    expect(screen.getByTestId('detail').textContent).toBe('GBY-1');
 
     fireEvent.click(screen.getByText('Ship the inbox'));
 
     expect(screen.getByTestId('detail').textContent).toBe('ENG-1');
+  });
+
+  it('keeps the selected record in the detail when the filters hide it', () => {
+    renderStudio();
+
+    fireEvent.change(screen.getByLabelText('Search the inbox'), {
+      target: { value: 'nothing matches this' },
+    });
+
+    expect(screen.getByText('No matching items')).toBeDefined();
+    expect(screen.getByTestId('detail').textContent).toBe('GBY-1');
   });
 
   it('shows a nothing-connected empty state when the inbox has no records', () => {
@@ -262,9 +295,9 @@ describe('InboxStudio', () => {
 
     renderStudio();
 
-    expect(screen.getByText('Nothing in your inbox yet')).toBeDefined();
+    expect(screen.getByText('No inbox items')).toBeDefined();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Open integrations' }));
+    fireEvent.click(screen.getByTestId('detail-open-integrations'));
 
     expect(dispatchSpy).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'goodboy:open-settings' }),
@@ -272,18 +305,41 @@ describe('InboxStudio', () => {
     dispatchSpy.mockRestore();
   });
 
-  it('shows a filters-hide-everything empty state and clears filters', () => {
-    renderStudio();
+  it('renders a deep-linked provider that has no records and recovers with clear filters', () => {
+    renderStudio({ initialProvider: 'jira' });
 
-    fireEvent.change(screen.getByLabelText('Search the inbox'), {
-      target: { value: 'nothing matches this' },
-    });
-
+    const jiraChip = screen.getByRole('button', { name: 'Jira' });
+    expect(jiraChip.getAttribute('aria-pressed')).toBe('true');
+    expect(jiraChip.textContent).toContain('0');
     expect(screen.getByText('No matching items')).toBeDefined();
+    expect(screen.getByTestId('detail').textContent).toContain('none');
 
-    fireEvent.click(screen.getByRole('button', { name: 'Clear filters' }));
+    fireEvent.click(screen.getByTestId('detail-clear-filters'));
 
     expect(screen.getByText('Fix the flaky test')).toBeDefined();
+    expect(screen.queryByRole('button', { name: 'Jira' })).toBeNull();
+  });
+
+  it('toggles off a selected provider that has no records', () => {
+    renderStudio({ initialProvider: 'jira' });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Jira' }));
+
+    expect(screen.getByText('Fix the flaky test')).toBeDefined();
+  });
+
+  it('persists the provider selection per workspace', () => {
+    const first = renderStudio();
+
+    fireEvent.click(screen.getByRole('button', { name: 'GitHub' }));
+    first.unmount();
+
+    renderStudio();
+
+    expect(screen.getByRole('button', { name: 'GitHub' }).getAttribute('aria-pressed')).toBe(
+      'true',
+    );
+    expect(screen.queryByText('Ship the inbox')).toBeNull();
   });
 
   it('preselects the kind filter, provider and record from the open event props', () => {

--- a/apps/desktop/src/features/inbox/components/InboxStudio/index.tsx
+++ b/apps/desktop/src/features/inbox/components/InboxStudio/index.tsx
@@ -7,7 +7,13 @@ import { StudioShell } from '../../../../shared/components/StudioShell';
 import { useInboxRecords } from '../../useInboxRecords';
 import { INBOX_PROVIDERS, type InboxKind, type InboxProvider, type InboxRecord } from '../../types';
 import { filterInboxRecords, type InboxKindFilter } from '../../kindFilter';
-import { readInboxKindFilter, writeInboxKindFilter } from '../../kindFilterStorage';
+import {
+  readInboxKindFilter,
+  readInboxProviders,
+  writeInboxKindFilter,
+  writeInboxProviders,
+} from '../../kindFilterStorage';
+import { groupRecordsByAge } from '../../ageSections';
 import { InboxDetail } from './InboxDetail';
 import { InboxRail } from './InboxRail';
 
@@ -21,7 +27,11 @@ type Props = {
   readonly onClose: () => void;
 };
 
-const kindToFilter = (kind: InboxKind): InboxKindFilter => {
+type KindToFilterParams = {
+  readonly kind: InboxKind;
+};
+
+const kindToFilter = ({ kind }: KindToFilterParams): InboxKindFilter => {
   switch (kind) {
     case 'issue':
       return 'issue';
@@ -52,28 +62,46 @@ export const InboxStudio = ({
   const [query, setQuery] = useState('');
   const [kindFilter, setKindFilter] = useState<InboxKindFilter>(() => {
     if (initialKind != null) {
-      return kindToFilter(initialKind);
+      return kindToFilter({ kind: initialKind });
     }
     return readInboxKindFilter({ workspaceId }) ?? 'all';
   });
-  const [selectedProviders, setSelectedProviders] = useState<ReadonlySet<InboxProvider>>(() =>
-    initialProvider != null ? new Set([initialProvider]) : new Set(),
-  );
+  const [selectedProviders, setSelectedProviders] = useState<ReadonlySet<InboxProvider>>(() => {
+    if (initialProvider != null) {
+      return new Set([initialProvider]);
+    }
+    return new Set(readInboxProviders({ workspaceId }));
+  });
   const [selectedKey, setSelectedKey] = useState<string | null>(initialRecordKey);
 
   useEffect(() => {
     writeInboxKindFilter({ workspaceId, kindFilter });
   }, [workspaceId, kindFilter]);
 
-  const availableProviders = useMemo(() => {
-    const present = new Set(records.map((record) => record.provider));
-    return INBOX_PROVIDERS.filter((provider) => present.has(provider));
-  }, [records]);
+  useEffect(() => {
+    writeInboxProviders({ workspaceId, providers: selectedProviders });
+  }, [workspaceId, selectedProviders]);
 
   const filteredRecords = useMemo(
     () => filterInboxRecords({ records, query, kindFilter, providers: selectedProviders }),
     [records, query, kindFilter, selectedProviders],
   );
+
+  const visibleRecords = useMemo(
+    () => groupRecordsByAge({ records: filteredRecords }).flatMap((section) => section.records),
+    [filteredRecords],
+  );
+
+  useEffect(() => {
+    if (selectedKey != null) {
+      return;
+    }
+    const firstVisibleRecord = visibleRecords[0];
+    if (firstVisibleRecord == null) {
+      return;
+    }
+    setSelectedKey(firstVisibleRecord.key);
+  }, [visibleRecords, selectedKey]);
 
   const selectedRecord = useMemo(
     () => records.find((record) => record.key === selectedKey) ?? null,
@@ -102,6 +130,9 @@ export const InboxStudio = ({
     setSelectedProviders(new Set());
   };
 
+  const hasFiltersActive =
+    query.trim() !== '' || kindFilter !== 'all' || selectedProviders.size > 0;
+
   const onOpenIntegrations = (): void => {
     window.dispatchEvent(
       new CustomEvent('goodboy:open-settings', { detail: { scope: 'providers' } }),
@@ -129,13 +160,11 @@ export const InboxStudio = ({
       {(requestClose) => (
         <StudioRailLayout
           railLabel="Inbox"
-          railWidth="standard"
+          railWidth="xwide"
           rail={
             <InboxRail
               records={filteredRecords}
-              totalCount={records.length}
               allRecords={records}
-              availableProviders={availableProviders}
               selectedProviders={selectedProviders}
               onToggleProvider={onToggleProvider}
               query={query}
@@ -150,19 +179,21 @@ export const InboxStudio = ({
                 return message == null ? [] : [{ provider, message }];
               })}
               onRefresh={refetch}
-              onOpenIntegrations={onOpenIntegrations}
-              onClearFilters={onClearFilters}
             />
           }
           detail={
             <InboxDetail
               record={selectedRecord}
+              records={records}
+              hasFiltersActive={hasFiltersActive}
               workspaceId={workspaceId}
               rootPath={rootPath}
               isLoading={isLoading}
               errors={errors}
               onRefresh={refetch}
               onClose={requestClose}
+              onClearFilters={onClearFilters}
+              onOpenIntegrations={onOpenIntegrations}
             />
           }
         />

--- a/apps/desktop/src/features/inbox/kindFilterStorage.test.ts
+++ b/apps/desktop/src/features/inbox/kindFilterStorage.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import type { WorkspaceId } from '@goodboy/types';
-import { readInboxKindFilter, writeInboxKindFilter } from './kindFilterStorage';
+import type { InboxProvider } from './types';
+import {
+  readInboxKindFilter,
+  readInboxProviders,
+  writeInboxKindFilter,
+  writeInboxProviders,
+} from './kindFilterStorage';
 
 const workspaceId = 'workspace-1' as WorkspaceId;
 
@@ -30,5 +36,39 @@ describe('inbox kind filter storage', () => {
     localStorage.setItem('goodboy:inbox-kind-filter:workspace-1', 'not-a-real-filter');
 
     expect(readInboxKindFilter({ workspaceId })).toBeNull();
+  });
+
+  it('reads a legacy bare kind filter written before providers were persisted', () => {
+    localStorage.setItem('goodboy:inbox-kind-filter:workspace-1', 'issue');
+
+    expect(readInboxKindFilter({ workspaceId })).toBe('issue');
+    expect(readInboxProviders({ workspaceId })).toEqual([]);
+  });
+});
+
+describe('inbox provider filter storage', () => {
+  it('returns an empty selection when nothing was persisted yet', () => {
+    expect(readInboxProviders({ workspaceId })).toEqual([]);
+  });
+
+  it('round-trips a written provider selection', () => {
+    writeInboxProviders({ workspaceId, providers: new Set<InboxProvider>(['slack', 'github']) });
+
+    expect(readInboxProviders({ workspaceId })).toEqual(['github', 'slack']);
+  });
+
+  it('keeps the kind filter and the providers side by side', () => {
+    writeInboxKindFilter({ workspaceId, kindFilter: 'thread' });
+    writeInboxProviders({ workspaceId, providers: new Set<InboxProvider>(['slack']) });
+
+    expect(readInboxKindFilter({ workspaceId })).toBe('thread');
+    expect(readInboxProviders({ workspaceId })).toEqual(['slack']);
+  });
+
+  it('scopes the persisted providers per workspace', () => {
+    const other = 'workspace-2' as WorkspaceId;
+    writeInboxProviders({ workspaceId, providers: new Set<InboxProvider>(['jira']) });
+
+    expect(readInboxProviders({ workspaceId: other })).toEqual([]);
   });
 });

--- a/apps/desktop/src/features/inbox/kindFilterStorage.ts
+++ b/apps/desktop/src/features/inbox/kindFilterStorage.ts
@@ -39,21 +39,21 @@ const readStoredFilters = ({ workspaceId }: Params): StoredFilters | null => {
       return null;
     }
     const parsed: unknown = JSON.parse(raw);
-    if (typeof parsed !== 'object' || parsed == null) {
+    if (typeof parsed !== 'object' || parsed == null || Array.isArray(parsed)) {
       return null;
     }
-    if (!('kindFilter' in parsed) || !isInboxKindFilter(parsed.kindFilter)) {
+    const source = parsed as Readonly<Record<string, unknown>>;
+    const kindFilter = source['kindFilter'];
+    const providers = source['providers'];
+    if (!isInboxKindFilter(kindFilter) || !Array.isArray(providers)) {
       return null;
     }
-    if (!('providers' in parsed) || !Array.isArray(parsed.providers)) {
-      return null;
-    }
-    const stored: ReadonlyArray<unknown> = parsed.providers;
+    const stored: ReadonlyArray<unknown> = providers;
     if (!stored.every((provider) => isInboxProvider(provider))) {
       return null;
     }
     return {
-      kindFilter: parsed.kindFilter,
+      kindFilter,
       providers: INBOX_PROVIDERS.filter((provider) => stored.includes(provider)),
     };
   } catch {

--- a/apps/desktop/src/features/inbox/kindFilterStorage.ts
+++ b/apps/desktop/src/features/inbox/kindFilterStorage.ts
@@ -1,6 +1,7 @@
 import type { WorkspaceId } from '@goodboy/types';
 import { STORAGE_PREFIXES } from '../../shared/lib/storage-keys';
 import { INBOX_KIND_FILTERS, type InboxKindFilter } from './kindFilter';
+import { INBOX_PROVIDERS, type InboxProvider } from './types';
 
 type Params = {
   readonly workspaceId: WorkspaceId;
@@ -10,25 +11,84 @@ type WriteParams = Params & {
   readonly kindFilter: InboxKindFilter;
 };
 
+type WriteProvidersParams = Params & {
+  readonly providers: ReadonlySet<InboxProvider>;
+};
+
+type StoredFilters = {
+  readonly kindFilter: InboxKindFilter;
+  readonly providers: ReadonlyArray<InboxProvider>;
+};
+
 const storageKey = ({ workspaceId }: Params): string =>
   `${STORAGE_PREFIXES.inboxKindFilter}${workspaceId}`;
 
 const isInboxKindFilter = (value: unknown): value is InboxKindFilter =>
   typeof value === 'string' && INBOX_KIND_FILTERS.some((candidate) => candidate === value);
 
-export const readInboxKindFilter = ({ workspaceId }: Params): InboxKindFilter | null => {
+const isInboxProvider = (value: unknown): value is InboxProvider =>
+  typeof value === 'string' && INBOX_PROVIDERS.some((candidate) => candidate === value);
+
+const readStoredFilters = ({ workspaceId }: Params): StoredFilters | null => {
   try {
     const raw = localStorage.getItem(storageKey({ workspaceId }));
-    return isInboxKindFilter(raw) ? raw : null;
+    if (isInboxKindFilter(raw)) {
+      return { kindFilter: raw, providers: [] };
+    }
+    if (raw == null) {
+      return null;
+    }
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== 'object' || parsed == null) {
+      return null;
+    }
+    if (!('kindFilter' in parsed) || !isInboxKindFilter(parsed.kindFilter)) {
+      return null;
+    }
+    if (!('providers' in parsed) || !Array.isArray(parsed.providers)) {
+      return null;
+    }
+    const stored: ReadonlyArray<unknown> = parsed.providers;
+    if (!stored.every((provider) => isInboxProvider(provider))) {
+      return null;
+    }
+    return {
+      kindFilter: parsed.kindFilter,
+      providers: INBOX_PROVIDERS.filter((provider) => stored.includes(provider)),
+    };
   } catch {
     return null;
   }
 };
 
-export const writeInboxKindFilter = ({ workspaceId, kindFilter }: WriteParams): void => {
+type PersistParams = Params & StoredFilters;
+
+const persistFilters = ({ workspaceId, kindFilter, providers }: PersistParams): void => {
   try {
-    localStorage.setItem(storageKey({ workspaceId }), kindFilter);
+    localStorage.setItem(storageKey({ workspaceId }), JSON.stringify({ kindFilter, providers }));
   } catch {
     return;
   }
+};
+
+export const readInboxKindFilter = ({ workspaceId }: Params): InboxKindFilter | null => {
+  return readStoredFilters({ workspaceId })?.kindFilter ?? null;
+};
+
+export const writeInboxKindFilter = ({ workspaceId, kindFilter }: WriteParams): void => {
+  const stored = readStoredFilters({ workspaceId });
+  persistFilters({ workspaceId, kindFilter, providers: stored?.providers ?? [] });
+};
+
+export const readInboxProviders = ({ workspaceId }: Params): ReadonlyArray<InboxProvider> => {
+  return readStoredFilters({ workspaceId })?.providers ?? [];
+};
+
+export const writeInboxProviders = ({ workspaceId, providers }: WriteProvidersParams): void => {
+  const stored = readStoredFilters({ workspaceId });
+  persistFilters({
+    workspaceId,
+    kindFilter: stored?.kindFilter ?? 'all',
+    providers: INBOX_PROVIDERS.filter((provider) => providers.has(provider)),
+  });
 };

--- a/packages/ui/src/components/Chip.tsx
+++ b/packages/ui/src/components/Chip.tsx
@@ -19,6 +19,7 @@ export type ChipProps = {
   readonly as?: 'span' | 'button';
   readonly title?: string;
   readonly ariaLabel?: string;
+  readonly ariaPressed?: boolean;
   readonly testId?: string;
   readonly onClick?: (event: MouseEvent<HTMLButtonElement>) => void;
   readonly disabled?: boolean;
@@ -67,6 +68,7 @@ export const Chip = ({
   as = 'span',
   title,
   ariaLabel,
+  ariaPressed,
   testId,
   onClick,
   disabled = false,
@@ -102,6 +104,7 @@ export const Chip = ({
         type="button"
         title={title}
         aria-label={ariaLabel}
+        aria-pressed={ariaPressed}
         data-testid={testId}
         aria-expanded={expanded}
         aria-haspopup={hasPopup}

--- a/packages/ui/src/components/SelectableRow.tsx
+++ b/packages/ui/src/components/SelectableRow.tsx
@@ -7,6 +7,9 @@ export type SelectableRowProps = {
   readonly onClick?: () => void;
   readonly ariaCurrent?: AriaAttributes['aria-current'];
   readonly title?: string;
+  readonly role?: 'option';
+  readonly ariaSelected?: boolean;
+  readonly tabIndex?: number;
   readonly className?: string;
 };
 
@@ -19,6 +22,9 @@ export const SelectableRow = ({
   onClick,
   ariaCurrent,
   title,
+  role,
+  ariaSelected,
+  tabIndex,
   className,
 }: SelectableRowProps) => {
   return (
@@ -26,6 +32,9 @@ export const SelectableRow = ({
       type="button"
       data-selected={selected}
       aria-current={ariaCurrent}
+      role={role}
+      aria-selected={ariaSelected}
+      tabIndex={tabIndex}
       title={title}
       onClick={onClick}
       className={cn(ROW_CLASSES, className)}

--- a/packages/ui/src/components/SelectableRow.tsx
+++ b/packages/ui/src/components/SelectableRow.tsx
@@ -7,6 +7,7 @@ export type SelectableRowProps = {
   readonly onClick?: () => void;
   readonly ariaCurrent?: AriaAttributes['aria-current'];
   readonly title?: string;
+  readonly id?: string;
   readonly role?: 'option';
   readonly ariaSelected?: boolean;
   readonly tabIndex?: number;
@@ -22,6 +23,7 @@ export const SelectableRow = ({
   onClick,
   ariaCurrent,
   title,
+  id,
   role,
   ariaSelected,
   tabIndex,
@@ -30,6 +32,7 @@ export const SelectableRow = ({
   return (
     <button
       type="button"
+      id={id}
       data-selected={selected}
       aria-current={ariaCurrent}
       role={role}

--- a/packages/ui/src/components/StudioRailLayout.tsx
+++ b/packages/ui/src/components/StudioRailLayout.tsx
@@ -6,6 +6,7 @@ const RAIL_WIDTH_CLASSES = {
   narrow: 'w-64',
   standard: 'w-72',
   wide: 'w-80',
+  xwide: 'w-[26rem]',
 } satisfies Record<string, string>;
 
 type Props = {


### PR DESCRIPTION
Inbox rework after the owner review (list empty with "All 75", rail too narrow, giant placeholder).

- Bug: a deep-linked provider with zero records was an invisible filter. Provider chips now render every provider with records or currently selected, labeled with counts, toggleable.
- Wider list (xwide rail), sticky header with search, kind tabs, provider chips, keyboard hint.
- Flat list newest first with Today / Yesterday / This week / Older sections; alert > active > open > done inside a section.
- Two-line rows (kind icon tinted by state, identifier, title, age; provider, state, meta).
- First visible record auto-selected; ArrowUp/Down/Home/End move the selection.
- Detail empty state replaced by a compact summary (StatCards per kind, providers, actions).
- Provider selection persisted per workspace next to the kind filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)