### PR TITLE
perf(desktop): take git and db commands off the main thread

### DIFF
--- a/apps/desktop/src-tauri/src/explore.rs
+++ b/apps/desktop/src-tauri/src/explore.rs
@@ -246,7 +246,16 @@ pub(crate) fn spawn_open(path: &Path, reveal: bool) -> std::io::Result<()> {
 }
 
 #[tauri::command]
-pub fn explore_list(
+pub async fn explore_list(
+    session_dir: String,
+    rel_path: String,
+) -> Result<Vec<ExploreEntry>, ExploreError> {
+    tauri::async_runtime::spawn_blocking(move || explore_list_blocking(session_dir, rel_path))
+        .await
+        .map_err(|error| ExploreError::Io(std::io::Error::other(error.to_string())))?
+}
+
+fn explore_list_blocking(
     session_dir: String,
     rel_path: String,
 ) -> Result<Vec<ExploreEntry>, ExploreError> {
@@ -293,7 +302,19 @@ pub fn explore_read(session_dir: String, rel_path: String) -> Result<ExploreCont
 }
 
 #[tauri::command]
-pub fn explore_open(
+pub async fn explore_open(
+    session_dir: String,
+    rel_path: String,
+    reveal: bool,
+) -> Result<(), ExploreError> {
+    tauri::async_runtime::spawn_blocking(move || {
+        explore_open_blocking(session_dir, rel_path, reveal)
+    })
+    .await
+    .map_err(|error| ExploreError::Io(std::io::Error::other(error.to_string())))?
+}
+
+fn explore_open_blocking(
     session_dir: String,
     rel_path: String,
     reveal: bool,
@@ -310,7 +331,9 @@ pub fn explore_open(
 mod tests {
     use std::fs;
 
-    use super::{explore_list, explore_read, ExploreContent, ExploreError, TEXT_MAX_BYTES};
+    use super::{
+        explore_list_blocking, explore_read, ExploreContent, ExploreError, TEXT_MAX_BYTES,
+    };
 
     fn test_root(name: &str) -> std::path::PathBuf {
         std::env::temp_dir().join(format!(
@@ -331,7 +354,8 @@ mod tests {
         fs::write(root.join("alpha.txt"), "alpha").unwrap();
         fs::write(root.join(".goodboy"), "marker").unwrap();
 
-        let entries = explore_list(root.to_string_lossy().into_owned(), String::new()).unwrap();
+        let entries =
+            explore_list_blocking(root.to_string_lossy().into_owned(), String::new()).unwrap();
 
         assert_eq!(
             entries
@@ -350,8 +374,8 @@ mod tests {
         let root = test_root("invalid-paths");
         fs::create_dir_all(&root).unwrap();
 
-        let parent = explore_list(root.to_string_lossy().into_owned(), "..".to_string());
-        let absolute = explore_list(
+        let parent = explore_list_blocking(root.to_string_lossy().into_owned(), "..".to_string());
+        let absolute = explore_list_blocking(
             root.to_string_lossy().into_owned(),
             root.to_string_lossy().into_owned(),
         );
@@ -407,7 +431,8 @@ mod tests {
         fs::write(root.join("file.txt"), "text").unwrap();
 
         let read = explore_read(root.to_string_lossy().into_owned(), String::new());
-        let list = explore_list(root.to_string_lossy().into_owned(), "file.txt".to_string());
+        let list =
+            explore_list_blocking(root.to_string_lossy().into_owned(), "file.txt".to_string());
 
         assert!(matches!(read, Err(ExploreError::NotFile)));
         assert!(matches!(list, Err(ExploreError::NotDirectory)));

--- a/apps/desktop/src-tauri/src/repo.rs
+++ b/apps/desktop/src-tauri/src/repo.rs
@@ -105,7 +105,21 @@ struct GitignoreSnapshot {
 }
 
 #[tauri::command]
-pub fn validate_git_repo(path: String) -> GitRepoCheck {
+pub async fn validate_git_repo(path: String) -> GitRepoCheck {
+    let fallback_path = path.clone();
+    tauri::async_runtime::spawn_blocking(move || validate_git_repo_blocking(path))
+        .await
+        .unwrap_or_else(|error| GitRepoCheck {
+            is_repo: false,
+            root_path: None,
+            resolved_path: None,
+            error: Some(format!(
+                "git repository check failed for {fallback_path}: {error}"
+            )),
+        })
+}
+
+fn validate_git_repo_blocking(path: String) -> GitRepoCheck {
     let candidate = Path::new(&path);
     if !candidate.is_dir() {
         return GitRepoCheck {
@@ -154,7 +168,7 @@ pub fn validate_git_repo(path: String) -> GitRepoCheck {
 }
 
 pub(crate) fn is_inside_repo(path: &Path) -> bool {
-    validate_git_repo(path.to_string_lossy().into_owned())
+    validate_git_repo_blocking(path.to_string_lossy().into_owned())
         .root_path
         .is_some_and(|found| !found.is_empty())
 }
@@ -166,7 +180,13 @@ pub struct ChildRepo {
 }
 
 #[tauri::command]
-pub fn scan_child_repos(path: String) -> Vec<ChildRepo> {
+pub async fn scan_child_repos(path: String) -> Vec<ChildRepo> {
+    tauri::async_runtime::spawn_blocking(move || scan_child_repos_blocking(path))
+        .await
+        .unwrap_or_default()
+}
+
+fn scan_child_repos_blocking(path: String) -> Vec<ChildRepo> {
     let parent = Path::new(path.trim());
     let Ok(entries) = std::fs::read_dir(parent) else {
         return Vec::new();
@@ -196,7 +216,13 @@ pub fn scan_child_repos(path: String) -> Vec<ChildRepo> {
 }
 
 #[tauri::command]
-pub fn project_git_status(project_path: String) -> WorkspaceGitStatus {
+pub async fn project_git_status(project_path: String) -> WorkspaceGitStatus {
+    tauri::async_runtime::spawn_blocking(move || project_git_status_blocking(project_path))
+        .await
+        .unwrap_or_else(|_| blank_status("missing"))
+}
+
+fn project_git_status_blocking(project_path: String) -> WorkspaceGitStatus {
     let root = Path::new(project_path.trim());
     if !root.is_dir() {
         return blank_status("missing");
@@ -253,7 +279,7 @@ fn blank_status(state: &'static str) -> WorkspaceGitStatus {
 }
 
 fn is_repo_root(root: &Path) -> bool {
-    let check = validate_git_repo(root.to_string_lossy().into_owned());
+    let check = validate_git_repo_blocking(root.to_string_lossy().into_owned());
     let Some(toplevel) = check.root_path.filter(|found| !found.is_empty()) else {
         return false;
     };
@@ -300,7 +326,13 @@ fn is_supported_authority(authority: &str) -> bool {
 }
 
 #[tauri::command]
-pub fn repo_init_with_remote(args: RepoInitArgs) -> Result<InitializedRepo, RepoInitError> {
+pub async fn repo_init_with_remote(args: RepoInitArgs) -> Result<InitializedRepo, RepoInitError> {
+    tauri::async_runtime::spawn_blocking(move || repo_init_with_remote_blocking(args))
+        .await
+        .map_err(|error| RepoInitError::Io(std::io::Error::other(error.to_string())))?
+}
+
+fn repo_init_with_remote_blocking(args: RepoInitArgs) -> Result<InitializedRepo, RepoInitError> {
     let remote_url = args.remote_url.trim().to_string();
     if !is_supported_remote_url(&remote_url) {
         return Err(RepoInitError::InvalidRemote(args.remote_url.clone()));
@@ -309,7 +341,13 @@ pub fn repo_init_with_remote(args: RepoInitArgs) -> Result<InitializedRepo, Repo
 }
 
 #[tauri::command]
-pub fn repo_init(path: String) -> Result<InitializedRepo, RepoInitError> {
+pub async fn repo_init(path: String) -> Result<InitializedRepo, RepoInitError> {
+    tauri::async_runtime::spawn_blocking(move || repo_init_blocking(path))
+        .await
+        .map_err(|error| RepoInitError::Io(std::io::Error::other(error.to_string())))?
+}
+
+fn repo_init_blocking(path: String) -> Result<InitializedRepo, RepoInitError> {
     init_repo_at(&path, None)
 }
 
@@ -328,7 +366,7 @@ fn init_repo_at(path: &str, remote_url: Option<&str>) -> Result<InitializedRepo,
 }
 
 fn repo_state(root: &Path) -> Result<RepoState, RepoInitError> {
-    let check = validate_git_repo(root.to_string_lossy().into_owned());
+    let check = validate_git_repo_blocking(root.to_string_lossy().into_owned());
     let Some(toplevel) = check.root_path.filter(|found| !found.is_empty()) else {
         if root.join(".git").exists() {
             return Err(RepoInitError::AlreadyRepo(
@@ -567,8 +605,8 @@ fn run_git(cwd: &Path, args: &[&str]) -> Result<String, RepoInitError> {
 #[cfg(test)]
 mod tests {
     use super::{
-        is_supported_remote_url, project_git_status, repo_init_with_remote, RepoInitArgs,
-        RepoInitError,
+        is_supported_remote_url, project_git_status_blocking, repo_init_with_remote_blocking,
+        RepoInitArgs, RepoInitError,
     };
     use crate::worktree::{GitDistance, GitWorkingTree};
 
@@ -608,7 +646,7 @@ mod tests {
         root: &std::path::Path,
         remote_url: &str,
     ) -> Result<super::InitializedRepo, RepoInitError> {
-        repo_init_with_remote(RepoInitArgs {
+        repo_init_with_remote_blocking(RepoInitArgs {
             path: root.to_string_lossy().into_owned(),
             remote_url: remote_url.to_string(),
         })
@@ -655,7 +693,7 @@ mod tests {
         let root = test_root("repo-init-plain");
         std::fs::write(root.join("notes.md"), "hello").unwrap();
 
-        let created = super::repo_init(root.to_string_lossy().into_owned()).unwrap();
+        let created = super::repo_init_blocking(root.to_string_lossy().into_owned()).unwrap();
 
         assert_eq!(created.branch, "main");
         assert_eq!(created.remote_url, "");
@@ -671,7 +709,7 @@ mod tests {
         let root = test_root("repo-init-plain-adopt");
         convert(&root, "https://github.com/acme/widgets.git").unwrap();
 
-        let adopted = super::repo_init(root.to_string_lossy().into_owned()).unwrap();
+        let adopted = super::repo_init_blocking(root.to_string_lossy().into_owned()).unwrap();
 
         assert_eq!(adopted.remote_url, "https://github.com/acme/widgets.git");
         assert_eq!(git_output(&root, &["rev-list", "--count", "HEAD"]), "1");
@@ -689,7 +727,7 @@ mod tests {
         let nested = root.join("notes");
         std::fs::create_dir_all(&nested).unwrap();
 
-        let err = super::repo_init(nested.to_string_lossy().into_owned()).unwrap_err();
+        let err = super::repo_init_blocking(nested.to_string_lossy().into_owned()).unwrap_err();
 
         assert!(matches!(err, RepoInitError::NestedRepo(_)));
         assert!(!nested.join(".git").exists());
@@ -816,7 +854,7 @@ mod tests {
     }
 
     fn status_of(root: &std::path::Path) -> super::WorkspaceGitStatus {
-        project_git_status(root.to_string_lossy().into_owned())
+        project_git_status_blocking(root.to_string_lossy().into_owned())
     }
 
     #[test]
@@ -825,7 +863,7 @@ mod tests {
         std::fs::write(root.join("notes.md"), "hello").unwrap();
 
         let absent = status_of(&root);
-        let missing = project_git_status(root.join("gone").to_string_lossy().into_owned());
+        let missing = project_git_status_blocking(root.join("gone").to_string_lossy().into_owned());
 
         assert_eq!(absent.state, "absent");
         assert_eq!(absent.branch, None);
@@ -949,7 +987,7 @@ mod tests {
         git_run(&hidden, &["init"]);
         std::fs::write(root.join("notes.md"), "hello").unwrap();
 
-        let found = super::scan_child_repos(root.to_string_lossy().into_owned());
+        let found = super::scan_child_repos_blocking(root.to_string_lossy().into_owned());
 
         let names: Vec<&str> = found.iter().map(|repo| repo.name.as_str()).collect();
         assert_eq!(names, vec!["alpha", "beta"]);
@@ -963,8 +1001,9 @@ mod tests {
         let root = test_root("scan-empty");
         std::fs::create_dir_all(root.join("plain")).unwrap();
 
-        let empty = super::scan_child_repos(root.to_string_lossy().into_owned());
-        let missing = super::scan_child_repos(root.join("gone").to_string_lossy().into_owned());
+        let empty = super::scan_child_repos_blocking(root.to_string_lossy().into_owned());
+        let missing =
+            super::scan_child_repos_blocking(root.join("gone").to_string_lossy().into_owned());
 
         assert!(empty.is_empty());
         assert!(missing.is_empty());
@@ -980,7 +1019,7 @@ mod tests {
         std::os::unix::fs::symlink(&target, root.join("linked")).unwrap();
         std::os::unix::fs::symlink(root.join("gone"), root.join("broken")).unwrap();
 
-        let found = super::scan_child_repos(root.to_string_lossy().into_owned());
+        let found = super::scan_child_repos_blocking(root.to_string_lossy().into_owned());
 
         assert_eq!(found.len(), 1);
         assert_eq!(found[0].name, "linked");

--- a/apps/desktop/src-tauri/src/workflows.rs
+++ b/apps/desktop/src-tauri/src/workflows.rs
@@ -364,7 +364,7 @@ fn row_to_template(
 // ---------------------------------------------------------------------------
 
 #[tauri::command]
-pub fn workflow_list(
+pub async fn workflow_list(
     state: State<'_, Db>,
     workspace_id: String,
 ) -> Result<Vec<WorkflowRow>, PhaseError> {
@@ -687,7 +687,7 @@ pub fn workflow_delete(state: State<'_, Db>, id: String) -> Result<(), PhaseErro
 /// started a workflow must keep seeing it even after it's deleted everywhere
 /// else, so this is loaded in addition to `workflow_list`.
 #[tauri::command]
-pub fn workflows_for_session(
+pub async fn workflows_for_session(
     state: State<'_, Db>,
     session_id: String,
 ) -> Result<Vec<WorkflowRow>, PhaseError> {
@@ -777,7 +777,7 @@ const STEP_DEF_COLS: &str = "id, workspace_id, role, name, prompt_prefix, provid
      model_default, effort_default, verbosity_default, created_at, updated_at";
 
 #[tauri::command]
-pub fn step_def_list(
+pub async fn step_def_list(
     state: State<'_, Db>,
     workspace_id: String,
 ) -> Result<Vec<StepDefRow>, PhaseError> {
@@ -920,7 +920,7 @@ fn session_row_from_row(row: &rusqlite::Row<'_>) -> Result<SessionRow, rusqlite:
 }
 
 #[tauri::command]
-pub fn agent_list_for_session(
+pub async fn agent_list_for_session(
     state: State<'_, Db>,
     session_id: String,
 ) -> Result<Vec<SessionRow>, PhaseError> {
@@ -1165,7 +1165,7 @@ pub fn agent_set_done(
 // workspace dot even for workspaces the user isn't currently on (their tasks
 // are not loaded in memory there).
 #[tauri::command]
-pub fn workspaces_with_unread(state: State<'_, Db>) -> Result<Vec<String>, PhaseError> {
+pub async fn workspaces_with_unread(state: State<'_, Db>) -> Result<Vec<String>, PhaseError> {
     let conn = state.0.lock().map_err(|_| PhaseError::Poisoned)?;
     let mut stmt = conn.prepare(
         "SELECT DISTINCT t.workspace_id

--- a/apps/desktop/src-tauri/src/worktree.rs
+++ b/apps/desktop/src-tauri/src/worktree.rs
@@ -132,7 +132,13 @@ pub fn sanitize_slug(input: &str) -> String {
 }
 
 #[tauri::command]
-pub fn worktree_create(args: CreateArgs) -> Result<CreatedWorktree, WorktreeError> {
+pub async fn worktree_create(args: CreateArgs) -> Result<CreatedWorktree, WorktreeError> {
+    tauri::async_runtime::spawn_blocking(move || worktree_create_blocking(args))
+        .await
+        .map_err(|e| WorktreeError::Io(std::io::Error::other(e.to_string())))?
+}
+
+fn worktree_create_blocking(args: CreateArgs) -> Result<CreatedWorktree, WorktreeError> {
     let repo_path = PathBuf::from(&args.repo_path);
     if !repo_path.exists() {
         return Err(WorktreeError::RepoNotFound(args.repo_path.clone()));
@@ -409,7 +415,13 @@ fn worktree_has_uncommitted(path: &str) -> bool {
 }
 
 #[tauri::command]
-pub fn worktree_change_branch(args: ChangeBranchArgs) -> Result<(), WorktreeError> {
+pub async fn worktree_change_branch(args: ChangeBranchArgs) -> Result<(), WorktreeError> {
+    tauri::async_runtime::spawn_blocking(move || worktree_change_branch_blocking(args))
+        .await
+        .map_err(|e| WorktreeError::Io(std::io::Error::other(e.to_string())))?
+}
+
+fn worktree_change_branch_blocking(args: ChangeBranchArgs) -> Result<(), WorktreeError> {
     let wt = Path::new(&args.worktree_path);
     if !wt.exists() {
         return Err(WorktreeError::RepoNotFound(args.worktree_path.clone()));
@@ -697,13 +709,25 @@ fn worktree_orphan_remove_blocking(repo_path: String, path: String) -> Result<()
 }
 
 #[tauri::command]
-pub fn worktree_list(repo_path: String) -> Result<Vec<WorktreeInfo>, WorktreeError> {
+pub async fn worktree_list(repo_path: String) -> Result<Vec<WorktreeInfo>, WorktreeError> {
+    tauri::async_runtime::spawn_blocking(move || worktree_list_blocking(repo_path))
+        .await
+        .map_err(|e| WorktreeError::Io(std::io::Error::other(e.to_string())))?
+}
+
+fn worktree_list_blocking(repo_path: String) -> Result<Vec<WorktreeInfo>, WorktreeError> {
     let stdout = git(Path::new(&repo_path), &["worktree", "list", "--porcelain"])?;
     Ok(parse_porcelain(&stdout))
 }
 
 #[tauri::command]
-pub fn worktree_remote_url(repo_path: String) -> Option<String> {
+pub async fn worktree_remote_url(repo_path: String) -> Option<String> {
+    tauri::async_runtime::spawn_blocking(move || worktree_remote_url_blocking(repo_path))
+        .await
+        .unwrap_or(None)
+}
+
+fn worktree_remote_url_blocking(repo_path: String) -> Option<String> {
     git(Path::new(&repo_path), &["remote", "get-url", "origin"])
         .ok()
         .map(|s| s.trim().to_string())
@@ -711,7 +735,16 @@ pub fn worktree_remote_url(repo_path: String) -> Option<String> {
 }
 
 #[tauri::command]
-pub fn worktree_diff(
+pub async fn worktree_diff(
+    worktree_path: String,
+    base_branch: Option<String>,
+) -> Result<String, WorktreeError> {
+    tauri::async_runtime::spawn_blocking(move || worktree_diff_blocking(worktree_path, base_branch))
+        .await
+        .map_err(|e| WorktreeError::Io(std::io::Error::other(e.to_string())))?
+}
+
+fn worktree_diff_blocking(
     worktree_path: String,
     base_branch: Option<String>,
 ) -> Result<String, WorktreeError> {
@@ -735,7 +768,19 @@ pub fn worktree_diff(
 /// outside the worktree root is refused. Untracked files fall back to the same
 /// synthetic new-file diff `worktree_diff` emits.
 #[tauri::command]
-pub fn worktree_diff_file(
+pub async fn worktree_diff_file(
+    worktree_path: String,
+    base_branch: Option<String>,
+    path: String,
+) -> Result<String, WorktreeError> {
+    tauri::async_runtime::spawn_blocking(move || {
+        worktree_diff_file_blocking(worktree_path, base_branch, path)
+    })
+    .await
+    .map_err(|e| WorktreeError::Io(std::io::Error::other(e.to_string())))?
+}
+
+fn worktree_diff_file_blocking(
     worktree_path: String,
     base_branch: Option<String>,
     path: String,
@@ -834,7 +879,18 @@ pub struct ChangedFilesSummary {
 /// count because we diff against the merge-base, not `HEAD`. Untracked files
 /// contribute their line count to additions.
 #[tauri::command]
-pub fn worktree_changed_files(
+pub async fn worktree_changed_files(
+    worktree_path: String,
+    base_branch: Option<String>,
+) -> Result<ChangedFilesSummary, WorktreeError> {
+    tauri::async_runtime::spawn_blocking(move || {
+        worktree_changed_files_blocking(worktree_path, base_branch)
+    })
+    .await
+    .map_err(|e| WorktreeError::Io(std::io::Error::other(e.to_string())))?
+}
+
+fn worktree_changed_files_blocking(
     worktree_path: String,
     base_branch: Option<String>,
 ) -> Result<ChangedFilesSummary, WorktreeError> {
@@ -983,7 +1039,13 @@ const COMMIT_LIMIT: usize = 100;
 const COMMIT_FORMAT: &str = "%H%x1f%h%x1f%s%x1f%an%x1f%at%x1f%P";
 
 #[tauri::command]
-pub fn worktree_commits(worktree_path: String) -> Result<Vec<BranchCommit>, WorktreeError> {
+pub async fn worktree_commits(worktree_path: String) -> Result<Vec<BranchCommit>, WorktreeError> {
+    tauri::async_runtime::spawn_blocking(move || worktree_commits_blocking(worktree_path))
+        .await
+        .map_err(|e| WorktreeError::Io(std::io::Error::other(e.to_string())))?
+}
+
+fn worktree_commits_blocking(worktree_path: String) -> Result<Vec<BranchCommit>, WorktreeError> {
     let p = Path::new(&worktree_path);
     if !p.exists() {
         return Err(WorktreeError::RepoNotFound(worktree_path));
@@ -1050,7 +1112,13 @@ pub struct RewrittenHead {
 }
 
 #[tauri::command]
-pub fn worktree_amend_commit(args: RewriteArgs) -> Result<RewrittenHead, WorktreeError> {
+pub async fn worktree_amend_commit(args: RewriteArgs) -> Result<RewrittenHead, WorktreeError> {
+    tauri::async_runtime::spawn_blocking(move || worktree_amend_commit_blocking(args))
+        .await
+        .map_err(|e| WorktreeError::Io(std::io::Error::other(e.to_string())))?
+}
+
+fn worktree_amend_commit_blocking(args: RewriteArgs) -> Result<RewrittenHead, WorktreeError> {
     let p = Path::new(&args.worktree_path);
     if !p.exists() {
         return Err(WorktreeError::RepoNotFound(args.worktree_path.clone()));
@@ -1073,7 +1141,13 @@ pub fn worktree_amend_commit(args: RewriteArgs) -> Result<RewrittenHead, Worktre
 }
 
 #[tauri::command]
-pub fn worktree_squash_commits(args: RewriteArgs) -> Result<RewrittenHead, WorktreeError> {
+pub async fn worktree_squash_commits(args: RewriteArgs) -> Result<RewrittenHead, WorktreeError> {
+    tauri::async_runtime::spawn_blocking(move || worktree_squash_commits_blocking(args))
+        .await
+        .map_err(|e| WorktreeError::Io(std::io::Error::other(e.to_string())))?
+}
+
+fn worktree_squash_commits_blocking(args: RewriteArgs) -> Result<RewrittenHead, WorktreeError> {
     let p = Path::new(&args.worktree_path);
     if !p.exists() {
         return Err(WorktreeError::RepoNotFound(args.worktree_path.clone()));
@@ -1211,7 +1285,19 @@ fn short_of(sha: &str) -> String {
 }
 
 #[tauri::command]
-pub fn worktree_diff_commit(worktree_path: String, sha: String) -> Result<String, WorktreeError> {
+pub async fn worktree_diff_commit(
+    worktree_path: String,
+    sha: String,
+) -> Result<String, WorktreeError> {
+    tauri::async_runtime::spawn_blocking(move || worktree_diff_commit_blocking(worktree_path, sha))
+        .await
+        .map_err(|e| WorktreeError::Io(std::io::Error::other(e.to_string())))?
+}
+
+fn worktree_diff_commit_blocking(
+    worktree_path: String,
+    sha: String,
+) -> Result<String, WorktreeError> {
     let p = Path::new(&worktree_path);
     if !p.exists() {
         return Err(WorktreeError::RepoNotFound(worktree_path));
@@ -1226,7 +1312,18 @@ pub fn worktree_diff_commit(worktree_path: String, sha: String) -> Result<String
 }
 
 #[tauri::command]
-pub fn worktree_diff_working(
+pub async fn worktree_diff_working(
+    worktree_path: String,
+    scope: String,
+) -> Result<String, WorktreeError> {
+    tauri::async_runtime::spawn_blocking(move || {
+        worktree_diff_working_blocking(worktree_path, scope)
+    })
+    .await
+    .map_err(|e| WorktreeError::Io(std::io::Error::other(e.to_string())))?
+}
+
+fn worktree_diff_working_blocking(
     worktree_path: String,
     scope: String,
 ) -> Result<String, WorktreeError> {
@@ -1248,7 +1345,18 @@ pub fn worktree_diff_working(
 }
 
 #[tauri::command]
-pub fn worktree_status(
+pub async fn worktree_status(
+    worktree_path: String,
+    base_branch: Option<String>,
+) -> Result<WorktreeStatus, WorktreeError> {
+    tauri::async_runtime::spawn_blocking(move || {
+        worktree_status_blocking(worktree_path, base_branch)
+    })
+    .await
+    .map_err(|e| WorktreeError::Io(std::io::Error::other(e.to_string())))?
+}
+
+fn worktree_status_blocking(
     worktree_path: String,
     base_branch: Option<String>,
 ) -> Result<WorktreeStatus, WorktreeError> {
@@ -1816,8 +1924,9 @@ fn parse_porcelain(stdout: &str) -> Vec<WorktreeInfo> {
 #[cfg(test)]
 mod rewrite_tests {
     use super::{
-        worktree_amend_commit, worktree_create, worktree_remove_blocking, worktree_squash_commits,
-        worktree_status, CreateArgs, GitDistance, GitUnknownReason, GitWorkingTree, RewriteArgs,
+        worktree_amend_commit_blocking, worktree_create_blocking, worktree_remove_blocking,
+        worktree_squash_commits_blocking, worktree_status_blocking, CreateArgs, GitDistance,
+        GitUnknownReason, GitWorkingTree, RewriteArgs,
     };
     use std::path::{Path, PathBuf};
 
@@ -1902,7 +2011,7 @@ mod rewrite_tests {
         git_ok(&root, &["push", "origin", "main"]);
         git_ok(&root, &["checkout", "feature"]);
 
-        let status = worktree_status(root.to_string_lossy().into_owned(), None).unwrap();
+        let status = worktree_status_blocking(root.to_string_lossy().into_owned(), None).unwrap();
 
         assert_eq!(
             status.main_distance,
@@ -1940,7 +2049,7 @@ mod rewrite_tests {
         git_ok(&root, &["config", "commit.gpgsign", "false"]);
         commit(&root, "base.txt", "base", "base");
 
-        let status = worktree_status(root.to_string_lossy().into_owned(), None).unwrap();
+        let status = worktree_status_blocking(root.to_string_lossy().into_owned(), None).unwrap();
 
         assert_eq!(super::resolve_base(&root, None), None);
         assert_eq!(
@@ -2010,7 +2119,7 @@ mod rewrite_tests {
         assert_eq!(main_ref, "master");
         assert_eq!(merge_base, base);
         assert_eq!(
-            worktree_status(root.to_string_lossy().into_owned(), None)
+            worktree_status_blocking(root.to_string_lossy().into_owned(), None)
                 .unwrap()
                 .main_distance,
             GitDistance::Known {
@@ -2175,7 +2284,7 @@ mod rewrite_tests {
     fn refuses_to_create_a_worktree_before_the_repository_exists() {
         let root = temp_root("create-without-git");
 
-        let plain = worktree_create(CreateArgs {
+        let plain = worktree_create_blocking(CreateArgs {
             repo_path: root.to_string_lossy().into_owned(),
             branch_prefix: "ak".to_string(),
             slug: "first".to_string(),
@@ -2196,7 +2305,7 @@ mod rewrite_tests {
     fn refuses_to_create_a_worktree_before_the_first_commit() {
         let root = init_repo("create-without-commit");
 
-        let unborn = worktree_create(CreateArgs {
+        let unborn = worktree_create_blocking(CreateArgs {
             repo_path: root.to_string_lossy().into_owned(),
             branch_prefix: "ak".to_string(),
             slug: "first".to_string(),
@@ -2219,7 +2328,8 @@ mod rewrite_tests {
         commit(&root, "a.txt", "a", "first");
         let head = commit(&root, "b.txt", "b", "second");
 
-        let result = worktree_amend_commit(args(&root, &head, "second, reworded")).unwrap();
+        let result =
+            worktree_amend_commit_blocking(args(&root, &head, "second, reworded")).unwrap();
 
         assert_eq!(result.sha, git_ok(&root, &["rev-parse", "HEAD"]));
         assert_eq!(result.replaced, vec![head]);
@@ -2233,7 +2343,7 @@ mod rewrite_tests {
         push_to_new_remote(&root);
         let head = git_ok(&root, &["rev-parse", "HEAD"]);
 
-        let err = worktree_amend_commit(args(&root, &head, "reworded")).unwrap_err();
+        let err = worktree_amend_commit_blocking(args(&root, &head, "reworded")).unwrap_err();
 
         assert!(err.to_string().contains("already pushed"), "{err}");
         assert_eq!(git_ok(&root, &["rev-parse", "HEAD"]), head);
@@ -2245,7 +2355,7 @@ mod rewrite_tests {
         let first = commit(&root, "a.txt", "a", "first");
         let head = commit(&root, "b.txt", "b", "second");
 
-        let err = worktree_amend_commit(args(&root, &first, "reworded")).unwrap_err();
+        let err = worktree_amend_commit_blocking(args(&root, &first, "reworded")).unwrap_err();
 
         assert!(err.to_string().contains("newest local commit"), "{err}");
         assert_eq!(git_ok(&root, &["rev-parse", "HEAD"]), head);
@@ -2258,7 +2368,8 @@ mod rewrite_tests {
         let second = commit(&root, "b.txt", "b", "second");
         let third = commit(&root, "c.txt", "c", "third");
 
-        let result = worktree_squash_commits(args(&root, &second, "second and third")).unwrap();
+        let result =
+            worktree_squash_commits_blocking(args(&root, &second, "second and third")).unwrap();
 
         assert_eq!(result.sha, git_ok(&root, &["rev-parse", "HEAD"]));
         assert_eq!(result.replaced, vec![third, second]);
@@ -2278,7 +2389,8 @@ mod rewrite_tests {
         commit(&root, "c.txt", "c", "third");
         let head = git_ok(&root, &["rev-parse", "HEAD"]);
 
-        let err = worktree_squash_commits(args(&root, &second, "second and third")).unwrap_err();
+        let err =
+            worktree_squash_commits_blocking(args(&root, &second, "second and third")).unwrap_err();
 
         assert!(err.to_string().contains("already pushed"), "{err}");
         assert_eq!(git_ok(&root, &["rev-parse", "HEAD"]), head);
@@ -2294,7 +2406,8 @@ mod rewrite_tests {
         git_ok(&root, &["add", "d.txt"]);
         let head = git_ok(&root, &["rev-parse", "HEAD"]);
 
-        let err = worktree_squash_commits(args(&root, &second, "second and third")).unwrap_err();
+        let err =
+            worktree_squash_commits_blocking(args(&root, &second, "second and third")).unwrap_err();
 
         assert!(err.to_string().contains("staged change"), "{err}");
         assert_eq!(git_ok(&root, &["rev-parse", "HEAD"]), head);
@@ -2307,7 +2420,7 @@ mod rewrite_tests {
         commit(&root, "b.txt", "b", "second");
         let head = git_ok(&root, &["rev-parse", "HEAD"]);
 
-        let err = worktree_squash_commits(args(&root, &first, "everything")).unwrap_err();
+        let err = worktree_squash_commits_blocking(args(&root, &first, "everything")).unwrap_err();
 
         assert!(err.to_string().contains("first commit"), "{err}");
         assert_eq!(git_ok(&root, &["rev-parse", "HEAD"]), head);
@@ -2329,7 +2442,8 @@ mod rewrite_tests {
             std::fs::set_permissions(&hook, std::fs::Permissions::from_mode(0o755)).unwrap();
         }
 
-        let err = worktree_squash_commits(args(&root, &second, "second and third")).unwrap_err();
+        let err =
+            worktree_squash_commits_blocking(args(&root, &second, "second and third")).unwrap_err();
 
         assert!(err.to_string().contains("git commit"), "{err}");
         assert_eq!(git_ok(&root, &["rev-parse", "HEAD"]), head);
@@ -2340,7 +2454,7 @@ mod rewrite_tests {
 
     fn create_session_mount(root: &Path, slug: &str) -> super::CreatedWorktree {
         let parent = root.join(".goodboy").join("worktrees");
-        worktree_create(CreateArgs {
+        worktree_create_blocking(CreateArgs {
             repo_path: root.to_string_lossy().into_owned(),
             branch_prefix: "goodboy".to_string(),
             slug: slug.to_string(),

--- a/apps/desktop/src/features/chat/components/ChatInput/hooks/useSuggestionCards.tsx
+++ b/apps/desktop/src/features/chat/components/ChatInput/hooks/useSuggestionCards.tsx
@@ -48,7 +48,7 @@ export const useSuggestionCards = ({
   acceptSessionNudgeHandoff,
 }: UseSuggestionCardsArgs): { readonly key: string; readonly node: ReactNode }[] => {
   const suggestions: { readonly key: string; readonly node: ReactNode }[] = [];
-  const sessionSuggestions = useSessionSuggestions({ session });
+  const sessionSuggestions = useSessionSuggestions({ session, withRebase: false });
   const planReady =
     sessionSuggestions.find((suggestion) => suggestion.kind === 'plan-ready') ?? null;
 

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/OverviewSuggestions.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/OverviewSuggestions.test.tsx
@@ -68,6 +68,7 @@ const { mocks, store } = vi.hoisted(() => {
 vi.mock('../../../../store', () => ({
   EMPTY_ARRAY: Object.freeze([]),
   useAppStore: <T,>(selector: (state: StoreState) => T) => selector(store),
+  useIsSessionCollectionLoaded: () => true,
 }));
 
 vi.mock('../../../suggestions', () => ({

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/OverviewSuggestions.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/OverviewSuggestions.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { Eyebrow, formatError } from '@goodboy/ui';
 import type { Agent, Session, SessionProjectMount } from '@goodboy/types';
-import { EMPTY_ARRAY, useAppStore } from '../../../../store';
+import { EMPTY_ARRAY, useAppStore, useIsSessionCollectionLoaded } from '../../../../store';
 import { useSessionRoleModels } from '../../../../shared/hooks/useSessionRoleModels';
 import { buildCommentAgentArgs, type ResolveModelChoice } from '../../../chat/spawn-from-comment';
 import { groupThreads } from '../../../github/comment-threads';
@@ -29,6 +29,7 @@ const OVERVIEW_KINDS: ReadonlySet<SessionSuggestion['kind']> = new Set<SessionSu
 
 export const OverviewSuggestions = ({ session, agents, onSelectQuestions }: Props) => {
   const sessionId = session.id;
+  const areAgentsLoaded = useIsSessionCollectionLoaded({ sessionId, collection: 'agents' });
   const suggestions = useSessionSuggestions({ session, agents });
   const github = useAppStore((state) => state.sessionGithub[sessionId] ?? null);
   const pendingResolutions = useAppStore(
@@ -90,7 +91,7 @@ export const OverviewSuggestions = ({ session, agents, onSelectQuestions }: Prop
   };
 
   const visible = suggestions.filter((suggestion) => OVERVIEW_KINDS.has(suggestion.kind));
-  if (visible.length === 0) {
+  if (!areAgentsLoaded || visible.length === 0) {
     return null;
   }
   return (

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectMountRow.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectMountRow.test.tsx
@@ -114,12 +114,14 @@ const renderRow = ({
   diffStat = null,
   pullRequest = null,
   worktreeStatus = null,
+  isStatusPending = false,
   rowMount = mount,
   rowProject = project,
 }: {
   readonly diffStat?: { additions: number; deletions: number } | null;
   readonly pullRequest?: PullRequestState | null;
   readonly worktreeStatus?: WorktreeStatus | null;
+  readonly isStatusPending?: boolean;
   readonly rowMount?: SessionProjectMount;
   readonly rowProject?: Project | null;
 }) =>
@@ -131,6 +133,7 @@ const renderRow = ({
       diffStat={diffStat}
       pullRequest={pullRequest ?? null}
       worktreeStatus={worktreeStatus}
+      isStatusPending={isStatusPending}
       onSelectLens={vi.fn()}
     />,
   );
@@ -315,7 +318,7 @@ describe('ProjectMountRow loading placeholders', () => {
   } as unknown as WorktreeStatus;
 
   it('holds a distance placeholder while the git status is still pending', () => {
-    renderRow({});
+    renderRow({ isStatusPending: true });
 
     expect(screen.getByTestId('project-distance-skeleton')).not.toBeNull();
     expect(screen.queryByTestId('sync-control')).toBeNull();
@@ -328,15 +331,23 @@ describe('ProjectMountRow loading placeholders', () => {
     expect(screen.getByTestId('sync-control')).not.toBeNull();
   });
 
+  it('drops the placeholder when the status fetch settled without a value', () => {
+    renderRow({ worktreeStatus: null, isStatusPending: false });
+
+    expect(screen.queryByTestId('project-distance-skeleton')).toBeNull();
+    expect(screen.queryByTestId('project-branch-skeleton')).toBeNull();
+    expect(screen.getByTestId('sync-control')).not.toBeNull();
+  });
+
   it('holds a branch placeholder instead of an empty branch cell', () => {
-    renderRow({ rowMount: { ...mount, branch: '' } as SessionProjectMount });
+    renderRow({ isStatusPending: true, rowMount: { ...mount, branch: '' } as SessionProjectMount });
 
     expect(screen.getByTestId('project-branch-skeleton')).not.toBeNull();
     expect(screen.queryByTestId('branch-chip')).toBeNull();
   });
 
   it('leaves a folder mount without any git placeholder', () => {
-    renderRow({ rowProject: { ...project, kind: 'folder' } as Project });
+    renderRow({ isStatusPending: true, rowProject: { ...project, kind: 'folder' } as Project });
 
     expect(screen.queryByTestId('project-distance-skeleton')).toBeNull();
     expect(screen.queryByTestId('project-branch-skeleton')).toBeNull();

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectMountRow.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectMountRow.test.tsx
@@ -4,7 +4,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import type { OverflowMenuItem } from '@goodboy/ui';
-import type { Project, PullRequestState, SessionId, SessionProjectMount } from '@goodboy/types';
+import type {
+  Project,
+  PullRequestState,
+  SessionId,
+  SessionProjectMount,
+  WorktreeStatus,
+} from '@goodboy/types';
 
 const { store, remoteKind } = vi.hoisted(() => ({
   remoteKind: { current: 'github' as string | null },
@@ -107,18 +113,24 @@ const mount = {
 const renderRow = ({
   diffStat = null,
   pullRequest = null,
+  worktreeStatus = null,
+  rowMount = mount,
+  rowProject = project,
 }: {
   readonly diffStat?: { additions: number; deletions: number } | null;
   readonly pullRequest?: PullRequestState | null;
+  readonly worktreeStatus?: WorktreeStatus | null;
+  readonly rowMount?: SessionProjectMount;
+  readonly rowProject?: Project | null;
 }) =>
   render(
     <ProjectMountRow
       sessionId={sessionId}
-      project={project}
-      mount={mount}
+      project={rowProject}
+      mount={rowMount}
       diffStat={diffStat}
       pullRequest={pullRequest ?? null}
-      worktreeStatus={null}
+      worktreeStatus={worktreeStatus}
       onSelectLens={vi.fn()}
     />,
   );
@@ -292,5 +304,41 @@ describe('ProjectMountRow activity dots', () => {
     expect(
       tooltipTextOf({ element: screen.getByRole('button', { name: 'Open scripts for API' }) }),
     ).toBe('Open scripts for API');
+  });
+});
+
+describe('ProjectMountRow loading placeholders', () => {
+  const status = {
+    branch: 'feat/api',
+    mainDistance: { kind: 'known', ahead: 0, behind: 0 },
+    upstreamDistance: { kind: 'known', ahead: 0, behind: 0 },
+  } as unknown as WorktreeStatus;
+
+  it('holds a distance placeholder while the git status is still pending', () => {
+    renderRow({});
+
+    expect(screen.getByTestId('project-distance-skeleton')).not.toBeNull();
+    expect(screen.queryByTestId('sync-control')).toBeNull();
+  });
+
+  it('swaps the placeholder for the sync control once the status lands', () => {
+    renderRow({ worktreeStatus: status });
+
+    expect(screen.queryByTestId('project-distance-skeleton')).toBeNull();
+    expect(screen.getByTestId('sync-control')).not.toBeNull();
+  });
+
+  it('holds a branch placeholder instead of an empty branch cell', () => {
+    renderRow({ rowMount: { ...mount, branch: '' } as SessionProjectMount });
+
+    expect(screen.getByTestId('project-branch-skeleton')).not.toBeNull();
+    expect(screen.queryByTestId('branch-chip')).toBeNull();
+  });
+
+  it('leaves a folder mount without any git placeholder', () => {
+    renderRow({ rowProject: { ...project, kind: 'folder' } as Project });
+
+    expect(screen.queryByTestId('project-distance-skeleton')).toBeNull();
+    expect(screen.queryByTestId('project-branch-skeleton')).toBeNull();
   });
 });

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectMountRow.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectMountRow.tsx
@@ -26,6 +26,7 @@ type Props = {
   readonly diffStat: MountDiffStat | null;
   readonly pullRequest: PullRequestState | null;
   readonly worktreeStatus: WorktreeStatus | null;
+  readonly isStatusPending?: boolean;
   readonly onSelectLens: (lens: LensKind) => void;
 };
 
@@ -47,6 +48,7 @@ export const ProjectMountRow = ({
   diffStat,
   pullRequest,
   worktreeStatus,
+  isStatusPending: isStatusPendingProp = false,
   onSelectLens,
 }: Props) => {
   const setSessionActiveProject = useAppStore((state) => state.setSessionActiveProject);
@@ -55,7 +57,7 @@ export const ProjectMountRow = ({
   const GlyphIcon = project?.kind === 'repo' ? FolderGit2 : Folder;
   const projectName = project?.name ?? mount.mountName;
   const changes = diffStat != null && (diffStat.additions > 0 || diffStat.deletions > 0);
-  const isStatusPending = worktreeStatus == null && project?.kind === 'repo';
+  const isStatusPending = isStatusPendingProp && worktreeStatus == null && project?.kind === 'repo';
   const remoteKind = useRemoteHostKind({ sessionId });
   const activity = useProjectActivity({
     sessionId,

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectMountRow.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectMountRow.tsx
@@ -1,5 +1,5 @@
 import { Folder, FolderGit2 } from 'lucide-react';
-import { Tooltip } from '@goodboy/ui';
+import { Skeleton, Tooltip } from '@goodboy/ui';
 import type {
   Project,
   PullRequestState,
@@ -55,6 +55,7 @@ export const ProjectMountRow = ({
   const GlyphIcon = project?.kind === 'repo' ? FolderGit2 : Folder;
   const projectName = project?.name ?? mount.mountName;
   const changes = diffStat != null && (diffStat.additions > 0 || diffStat.deletions > 0);
+  const isStatusPending = worktreeStatus == null && project?.kind === 'repo';
   const remoteKind = useRemoteHostKind({ sessionId });
   const activity = useProjectActivity({
     sessionId,
@@ -78,18 +79,30 @@ export const ProjectMountRow = ({
         <GlyphIcon size={14} aria-hidden className="shrink-0 text-muted-foreground" />
         <span className="truncate text-sm font-medium text-foreground">{projectName}</span>
       </div>
-      <ProjectBranchChip
-        sessionId={sessionId}
-        projectId={mount.projectId}
-        branch={mount.branch}
-        canSwitch={project?.kind === 'repo'}
-      />
-      {project?.kind === 'repo' ? (
-        <ProjectSyncControl
+      {isStatusPending && mount.branch === '' ? (
+        <span data-testid="project-branch-skeleton" className="shrink-0">
+          <Skeleton className="h-6 w-28 rounded-md" />
+        </span>
+      ) : (
+        <ProjectBranchChip
           sessionId={sessionId}
           projectId={mount.projectId}
-          status={worktreeStatus}
+          branch={mount.branch}
+          canSwitch={project?.kind === 'repo'}
         />
+      )}
+      {project?.kind === 'repo' ? (
+        isStatusPending ? (
+          <span data-testid="project-distance-skeleton" className="shrink-0">
+            <Skeleton className="size-7 rounded-md" />
+          </span>
+        ) : (
+          <ProjectSyncControl
+            sessionId={sessionId}
+            projectId={mount.projectId}
+            status={worktreeStatus}
+          />
+        )
       ) : null}
       {changes ? (
         <Tooltip content={`View changes in ${projectName}`}>

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/index.test.tsx
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, render, screen } from '@testing-library/react';
 import type { Session } from '@goodboy/types';
 
-const { store, useWorktreeStatuses } = vi.hoisted(() => ({
+const { store, useWorktreeStatuses, useWorktreeStatusPending } = vi.hoisted(() => ({
   store: {
     projects: [] as ReadonlyArray<{ id: string; workspaceId: string; name: string }>,
     sessionProjectMounts: {} as Record<
@@ -14,6 +14,7 @@ const { store, useWorktreeStatuses } = vi.hoisted(() => ({
     sessionProjectPrs: {},
   },
   useWorktreeStatuses: vi.fn(() => new Map()),
+  useWorktreeStatusPending: vi.fn(() => new Set()),
 }));
 
 vi.mock('../../../../../store', () => ({
@@ -26,7 +27,10 @@ vi.mock('./ProjectMountRow', () => ({
     <div data-testid="project-mount-row">{mount.mountName}</div>
   ),
 }));
-vi.mock('../../../hooks/useWorktreeStatuses', () => ({ useWorktreeStatuses }));
+vi.mock('../../../hooks/useWorktreeStatuses', () => ({
+  useWorktreeStatuses,
+  useWorktreeStatusPending,
+}));
 vi.mock('./MountProjectAction', () => ({
   MountProjectAction: () => <button>Mount project</button>,
 }));

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/index.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import type { Session, SessionProjectMount } from '@goodboy/types';
 import type { LensKind } from '../../../../../store';
@@ -65,4 +66,3 @@ export const ProjectMountRows = ({ session, onSelectLens }: Props) => {
     </section>
   );
 };
-import { useMemo } from 'react';

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/index.tsx
@@ -5,7 +5,7 @@ import type { LensKind } from '../../../../../store';
 import { EMPTY_ARRAY, useAppStore, useMountDiffStats } from '../../../../../store';
 import { MountProjectAction } from './MountProjectAction';
 import { ProjectMountRow } from './ProjectMountRow';
-import { useWorktreeStatuses } from '../../../hooks/useWorktreeStatuses';
+import { useWorktreeStatusPending, useWorktreeStatuses } from '../../../hooks/useWorktreeStatuses';
 
 type Props = {
   readonly session: Session;
@@ -34,6 +34,7 @@ export const ProjectMountRows = ({ session, onSelectLens }: Props) => {
     [mounts, projects],
   );
   const worktreeStatuses = useWorktreeStatuses({ targets: worktreeTargets });
+  const pendingWorktrees = useWorktreeStatusPending({ targets: worktreeTargets });
 
   return (
     <section
@@ -59,6 +60,7 @@ export const ProjectMountRows = ({ session, onSelectLens }: Props) => {
             diffStat={diffStats.get(mount.worktreePath) ?? null}
             pullRequest={projectPrs?.[mount.projectId]?.[0] ?? null}
             worktreeStatus={worktreeStatuses.get(mount.worktreePath) ?? null}
+            isStatusPending={pendingWorktrees.has(mount.worktreePath)}
             onSelectLens={onSelectLens}
           />
         ))

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineSkeleton.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineSkeleton.tsx
@@ -1,0 +1,21 @@
+import { Skeleton, cn } from '@goodboy/ui';
+import { TIMELINE_GUTTER } from './timelineLayout';
+
+const ROW_KEYS = ['first', 'second', 'third', 'fourth'] as const;
+
+export const TimelineSkeleton = () => (
+  <div className="flex flex-col" role="status" aria-label="Loading the timeline">
+    {ROW_KEYS.map((key) => (
+      <div key={key} className="flex min-w-0 items-center gap-2 py-1.5">
+        <span className={cn('shrink-0 pr-2', TIMELINE_GUTTER)}>
+          <Skeleton className="h-2.5 w-10" />
+        </span>
+        <Skeleton className="size-2.5 shrink-0 rounded-full" />
+        <span className="flex min-w-0 flex-1 flex-col gap-1.5 pl-2 pr-1.5">
+          <Skeleton className="h-3 w-2/5" />
+          <Skeleton className="h-2.5 w-3/5" />
+        </span>
+      </div>
+    ))}
+  </div>
+);

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/index.test.tsx
@@ -14,8 +14,9 @@ type Worktree = {
   readonly createdAt: number;
 };
 
-const { storeState, diffStats, unread, questions } = vi.hoisted(() => ({
+const { storeState, diffStats, unread, questions, agentsLoaded } = vi.hoisted(() => ({
   unread: { current: false },
+  agentsLoaded: { current: true },
   diffStats: { current: new Map<string, { additions: number; deletions: number }>() },
   questions: {
     open: [] as ReadonlyArray<unknown>,
@@ -49,6 +50,7 @@ vi.mock('../../../../../../store', () => {
     useSessionOpenQuestions: () => questions.open,
     useSessionAnsweredQuestions: () => questions.answered,
     useSessionDismissedQuestions: () => questions.dismissed,
+    useIsSessionCollectionLoaded: () => agentsLoaded.current,
   };
 });
 vi.mock('../../../../../workflows/useAttachedWorkflowRuns', () => ({
@@ -102,6 +104,7 @@ beforeEach(() => {
   questions.open = [];
   questions.answered = [];
   questions.dismissed = [];
+  agentsLoaded.current = true;
   localStorage.clear();
 });
 
@@ -159,6 +162,8 @@ describe('TimelinePane under a full filter', () => {
 
 describe('TimelinePane on an empty session', () => {
   it('keeps the header actions mounted above a quiet empty line', () => {
+    storeState.sessionEvents = { 'session-1': [] };
+
     render(
       <TimelinePane
         session={SESSION}
@@ -192,7 +197,7 @@ describe('TimelinePane kickoff', () => {
     expect(screen.queryByRole('button', { name: 'Filter' })).toBeNull();
   });
 
-  it('holds the quiet line until the session events resolve', () => {
+  it('holds a timeline skeleton until the session events resolve', () => {
     render(
       <TimelinePane
         session={SESSION}
@@ -203,7 +208,26 @@ describe('TimelinePane kickoff', () => {
     );
 
     expect(screen.queryByTestId('kickoff')).toBeNull();
+    expect(screen.queryByText(/Nothing yet/)).toBeNull();
+    expect(screen.getByRole('status', { name: 'Loading the timeline' })).not.toBeNull();
+  });
+
+  it('drops the skeleton once the events land', () => {
+    storeState.sessionEvents = { 'session-1': [] };
+
+    render(<TimelinePane session={SESSION} runs={RUNS} actions={null} />);
+
+    expect(screen.queryByRole('status', { name: 'Loading the timeline' })).toBeNull();
     expect(screen.getByText(/Nothing yet/)).toBeDefined();
+  });
+
+  it('holds a timeline skeleton until the agents collection loads', () => {
+    storeState.sessionEvents = { 'session-1': [] };
+    agentsLoaded.current = false;
+
+    render(<TimelinePane session={SESSION} runs={RUNS} actions={null} />);
+
+    expect(screen.getByRole('status', { name: 'Loading the timeline' })).not.toBeNull();
   });
 
   it('steps aside as soon as the timeline holds any activity', () => {

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/index.tsx
@@ -10,6 +10,7 @@ import {
   useMountDiffStats,
   useSessionAnsweredQuestions,
   useSessionDismissedQuestions,
+  useIsSessionCollectionLoaded,
   useSessionOpenQuestions,
   type MountDiffStat,
 } from '../../../../../../store';
@@ -31,6 +32,7 @@ import { ActivityFilterButton } from './ActivityFilterButton';
 import { TimelineDayRule } from './TimelineDayRule';
 import { TimelineNowRule } from './TimelineNowRule';
 import { TimelinePendingCluster } from './TimelinePendingCluster';
+import { TimelineSkeleton } from './TimelineSkeleton';
 import { TimelineStreamRow, type TimelineRowAction } from './TimelineStreamRow';
 import type { WorkspaceRuns } from '../../../../../orchestration/hooks/useWorkspaceRuns';
 
@@ -49,6 +51,7 @@ export const TimelinePane = ({ session, runs, actions, kickoff }: Props) => {
   const worktrees = useAppStore((s) => s.sessionWorktreeRecords?.[sessionId] ?? EMPTY_ARRAY);
   const events = useAppStore((s) => s.sessionEvents?.[sessionId] ?? EMPTY_ARRAY);
   const areEventsLoaded = useAppStore((s) => s.sessionEvents?.[sessionId] !== undefined);
+  const areAgentsLoaded = useIsSessionCollectionLoaded({ sessionId, collection: 'agents' });
   const loadSessionEvents = useAppStore((s) => s.loadSessionEvents);
   const agentKindOverride = useAppStore((s) => s.agentKindOverride);
   const orchestratingWorkflowRuns = useAppStore((s) => s.orchestratingWorkflowRuns);
@@ -296,8 +299,9 @@ export const TimelinePane = ({ session, runs, actions, kickoff }: Props) => {
   };
 
   const hasUnreadAgents = unreadAgentIds.size > 0;
+  const isLoading = (!areEventsLoaded || !areAgentsLoaded) && model.entries.length === 0;
 
-  if (model.entries.length === 0 && kickoff != null && areEventsLoaded) {
+  if (model.entries.length === 0 && kickoff != null && areEventsLoaded && areAgentsLoaded) {
     return <>{kickoff}</>;
   }
 
@@ -318,7 +322,9 @@ export const TimelinePane = ({ session, runs, actions, kickoff }: Props) => {
           </div>
         }
       />
-      {model.entries.length === 0 ? (
+      {isLoading ? (
+        <TimelineSkeleton />
+      ) : model.entries.length === 0 ? (
         <p className="px-0.5 py-2 text-xs text-muted-foreground">
           Nothing yet. Agents, workflows, and session facts land here as they happen.
         </p>

--- a/apps/desktop/src/features/session/hooks/useSessionBranchSync/index.test.ts
+++ b/apps/desktop/src/features/session/hooks/useSessionBranchSync/index.test.ts
@@ -29,6 +29,7 @@ vi.mock('../useIsBranchlessSession', () => ({
   useIsBranchlessSession: () => false,
 }));
 
+import { resetWorktreeStatusCache } from '../useWorktreeStatuses/cache';
 import { useSessionBranchSync } from './index';
 
 const session = {
@@ -38,6 +39,7 @@ const session = {
 
 afterEach(() => {
   cleanup();
+  resetWorktreeStatusCache();
   vi.clearAllMocks();
   h.lastTurnFinishedAt = null;
   h.worktreePath = '/sessions/one/api';

--- a/apps/desktop/src/features/session/hooks/useSessionBranchSync/index.ts
+++ b/apps/desktop/src/features/session/hooks/useSessionBranchSync/index.ts
@@ -1,10 +1,12 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import type { Session, SessionId } from '@goodboy/types';
 import { useAppStore, useSessionLastTurnFinishedAt } from '../../../../store';
 import { resolveSessionRepo } from '../../../../store/slices/worktrees/resolveSessionRepo';
-import { worktreeStatus } from '../../../worktree/worktree';
+import { ensure, worktreeStatusKey } from '../useWorktreeStatuses/cache';
 import { useIsBranchlessSession } from '../useIsBranchlessSession';
+
+const BRANCH_MAX_AGE_MS = 10_000;
 
 type Params = {
   readonly session: Session;
@@ -18,13 +20,21 @@ export const useSessionBranchSync = ({ session, isActive }: Params): void => {
   const projectWorktreePath = sessionRepo?.worktreePath ?? null;
   const reconcileSessionBranch = useAppStore((s) => s.reconcileSessionBranch);
   const lastTurnFinishedAt = useSessionLastTurnFinishedAt(sessionId);
+  const seenTurnRef = useRef<string | null | undefined>(undefined);
 
   useEffect(() => {
     if (!isActive || projectWorktreePath == null || isBranchless) return;
+    const isNewTurn =
+      seenTurnRef.current !== undefined && seenTurnRef.current !== lastTurnFinishedAt;
+    seenTurnRef.current = lastTurnFinishedAt;
     let cancelled = false;
-    worktreeStatus({ worktreePath: projectWorktreePath })
+    ensure({
+      key: worktreeStatusKey({ worktreePath: projectWorktreePath }),
+      worktreePath: projectWorktreePath,
+      maxAgeMs: isNewTurn ? 0 : BRANCH_MAX_AGE_MS,
+    })
       .then((status) => {
-        if (!cancelled && status.branch) {
+        if (!cancelled && status?.branch) {
           void reconcileSessionBranch(sessionId, status.branch);
         }
       })

--- a/apps/desktop/src/features/session/hooks/useWorktreeStatuses/cache.test.ts
+++ b/apps/desktop/src/features/session/hooks/useWorktreeStatuses/cache.test.ts
@@ -30,8 +30,20 @@ afterEach(() => {
 
 describe('worktree status cache', () => {
   it('keys an entry by worktree path and base branch', () => {
-    expect(worktreeStatusKey({ worktreePath: PATH, baseBranch: 'main' })).toBe(`${PATH} main`);
-    expect(worktreeStatusKey({ worktreePath: PATH })).toBe(`${PATH} `);
+    expect(worktreeStatusKey({ worktreePath: PATH, baseBranch: 'main' })).toBe(
+      JSON.stringify([PATH, 'main']),
+    );
+    expect(worktreeStatusKey({ worktreePath: PATH })).toBe(JSON.stringify([PATH, null]));
+  });
+
+  it('never collides on paths or branches that contain separators', () => {
+    const spaced = worktreeStatusKey({ worktreePath: '/wt/a b', baseBranch: 'c' });
+    const plain = worktreeStatusKey({ worktreePath: '/wt/a', baseBranch: 'b c' });
+    const piped = worktreeStatusKey({ worktreePath: '/wt/a|b', baseBranch: 'c' });
+    const emptyBranch = worktreeStatusKey({ worktreePath: PATH, baseBranch: '' });
+
+    expect(new Set([spaced, plain, piped]).size).toBe(3);
+    expect(emptyBranch).not.toBe(worktreeStatusKey({ worktreePath: PATH }));
   });
 
   it('runs one fetch for concurrent callers on the same key', async () => {

--- a/apps/desktop/src/features/session/hooks/useWorktreeStatuses/cache.test.ts
+++ b/apps/desktop/src/features/session/hooks/useWorktreeStatuses/cache.test.ts
@@ -1,0 +1,164 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const worktreeStatus = vi.hoisted(() => vi.fn());
+
+vi.mock('../../../worktree/worktree', () => ({ worktreeStatus }));
+
+import {
+  REFRESH_MS,
+  ensure,
+  readWorktreeStatus,
+  resetWorktreeStatusCache,
+  subscribe,
+  worktreeStatusKey,
+} from './cache';
+
+const PATH = '/worktrees/api';
+const KEY = worktreeStatusKey({ worktreePath: PATH, baseBranch: 'main' });
+
+beforeEach(() => {
+  worktreeStatus.mockReset();
+  worktreeStatus.mockResolvedValue({ branch: 'ak/feat' });
+});
+
+afterEach(() => {
+  resetWorktreeStatusCache();
+  vi.useRealTimers();
+});
+
+describe('worktree status cache', () => {
+  it('keys an entry by worktree path and base branch', () => {
+    expect(worktreeStatusKey({ worktreePath: PATH, baseBranch: 'main' })).toBe(`${PATH} main`);
+    expect(worktreeStatusKey({ worktreePath: PATH })).toBe(`${PATH} `);
+  });
+
+  it('runs one fetch for concurrent callers on the same key', async () => {
+    const [first, second] = await Promise.all([
+      ensure({ key: KEY, worktreePath: PATH, baseBranch: 'main', maxAgeMs: 30_000 }),
+      ensure({ key: KEY, worktreePath: PATH, baseBranch: 'main', maxAgeMs: 30_000 }),
+    ]);
+
+    expect(worktreeStatus).toHaveBeenCalledTimes(1);
+    expect(first).toEqual({ branch: 'ak/feat' });
+    expect(second).toBe(first);
+  });
+
+  it('serves a fresh entry without touching the backend again', async () => {
+    await ensure({ key: KEY, worktreePath: PATH, baseBranch: 'main', maxAgeMs: 30_000 });
+    await ensure({ key: KEY, worktreePath: PATH, baseBranch: 'main', maxAgeMs: 30_000 });
+
+    expect(worktreeStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it('refetches once the entry is older than the caller window', async () => {
+    await ensure({ key: KEY, worktreePath: PATH, baseBranch: 'main', maxAgeMs: 30_000 });
+    await ensure({ key: KEY, worktreePath: PATH, baseBranch: 'main', maxAgeMs: 0 });
+
+    expect(worktreeStatus).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps a failed fetch out of the cache without throwing', async () => {
+    worktreeStatus.mockRejectedValueOnce(new Error('no such worktree'));
+
+    const value = await ensure({
+      key: KEY,
+      worktreePath: PATH,
+      baseBranch: 'main',
+      maxAgeMs: 30_000,
+    });
+
+    expect(value).toBeNull();
+    expect(readWorktreeStatus(KEY)).toBeNull();
+  });
+
+  it('caps the fetches it runs at once', async () => {
+    let running = 0;
+    let peak = 0;
+    const gates: Array<() => void> = [];
+    worktreeStatus.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          running += 1;
+          peak = Math.max(peak, running);
+          gates.push(() => {
+            running -= 1;
+            resolve({ branch: 'ak/feat' });
+          });
+        }),
+    );
+
+    const all = Promise.all(
+      Array.from({ length: 10 }, (_, index) =>
+        ensure({
+          key: `/worktrees/${index} main`,
+          worktreePath: `/worktrees/${index}`,
+          baseBranch: 'main',
+          maxAgeMs: 30_000,
+        }),
+      ),
+    );
+
+    await vi.waitFor(() => expect(gates.length).toBe(4));
+    expect(worktreeStatus).toHaveBeenCalledTimes(4);
+    let settled = false;
+    void all.then(() => {
+      settled = true;
+    });
+    while (!settled) {
+      gates.splice(0, gates.length).forEach((release) => release());
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+    await all;
+
+    expect(peak).toBeLessThanOrEqual(4);
+    expect(worktreeStatus).toHaveBeenCalledTimes(10);
+  });
+
+  it('refreshes only the keys that still have a subscriber', async () => {
+    vi.useFakeTimers();
+    await ensure({ key: KEY, worktreePath: PATH, baseBranch: 'main', maxAgeMs: 30_000 });
+    const otherKey = worktreeStatusKey({ worktreePath: '/worktrees/web', baseBranch: 'main' });
+    await ensure({
+      key: otherKey,
+      worktreePath: '/worktrees/web',
+      baseBranch: 'main',
+      maxAgeMs: 30_000,
+    });
+    worktreeStatus.mockClear();
+    const unsubscribe = subscribe({ key: KEY, listener: () => undefined });
+
+    await vi.advanceTimersByTimeAsync(REFRESH_MS + 10);
+
+    expect(worktreeStatus).toHaveBeenCalledTimes(1);
+    expect(worktreeStatus).toHaveBeenCalledWith({ worktreePath: PATH, baseBranch: 'main' });
+
+    worktreeStatus.mockClear();
+    unsubscribe();
+    await vi.advanceTimersByTimeAsync(REFRESH_MS + 10);
+
+    expect(worktreeStatus).not.toHaveBeenCalled();
+  });
+
+  it('notifies the subscribers of a key when its value lands', async () => {
+    await ensure({ key: KEY, worktreePath: PATH, baseBranch: 'main', maxAgeMs: 30_000 });
+    const listener = vi.fn();
+    subscribe({ key: KEY, listener });
+
+    await ensure({ key: KEY, worktreePath: PATH, baseBranch: 'main', maxAgeMs: 0 });
+
+    expect(listener).toHaveBeenCalled();
+  });
+
+  it('forgets everything on reset', async () => {
+    await ensure({ key: KEY, worktreePath: PATH, baseBranch: 'main', maxAgeMs: 30_000 });
+    expect(readWorktreeStatus(KEY)).toEqual({ branch: 'ak/feat' });
+
+    resetWorktreeStatusCache();
+
+    expect(readWorktreeStatus(KEY)).toBeNull();
+    await ensure({ key: KEY, worktreePath: PATH, baseBranch: 'main', maxAgeMs: 30_000 });
+    expect(worktreeStatus).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/desktop/src/features/session/hooks/useWorktreeStatuses/cache.ts
+++ b/apps/desktop/src/features/session/hooks/useWorktreeStatuses/cache.ts
@@ -38,7 +38,7 @@ export const worktreeStatusKey = ({
 }: {
   readonly worktreePath: string;
   readonly baseBranch?: string;
-}): string => `${worktreePath} ${baseBranch ?? ''}`;
+}): string => JSON.stringify([worktreePath, baseBranch ?? null]);
 
 const entryFor = ({
   key,
@@ -157,6 +157,9 @@ export const subscribe = ({ key, listener }: SubscribeParams): (() => void) => {
 
 export const readWorktreeStatus = (key: string): WorktreeStatus | null =>
   entries.get(key)?.value ?? null;
+
+export const isWorktreeStatusSettled = (key: string): boolean =>
+  (entries.get(key)?.fetchedAt ?? 0) > 0;
 
 export const ensure = async ({
   key,

--- a/apps/desktop/src/features/session/hooks/useWorktreeStatuses/cache.ts
+++ b/apps/desktop/src/features/session/hooks/useWorktreeStatuses/cache.ts
@@ -1,0 +1,186 @@
+import type { WorktreeStatus } from '@goodboy/types';
+import { worktreeStatus } from '../../../worktree/worktree';
+
+type CacheEntry = {
+  value: WorktreeStatus | null;
+  fetchedAt: number;
+  inflight: Promise<void> | null;
+  worktreePath: string;
+  baseBranch?: string;
+  listeners: Set<() => void>;
+};
+
+type EnsureParams = {
+  readonly key: string;
+  readonly worktreePath: string;
+  readonly baseBranch?: string;
+  readonly maxAgeMs: number;
+};
+
+type SubscribeParams = {
+  readonly key: string;
+  readonly listener: () => void;
+};
+
+export const REFRESH_MS = 30_000;
+
+const MAX_CONCURRENT = 4;
+
+const entries = new Map<string, CacheEntry>();
+
+let running = 0;
+const queue: Array<() => void> = [];
+let timer: ReturnType<typeof setInterval> | null = null;
+
+export const worktreeStatusKey = ({
+  worktreePath,
+  baseBranch,
+}: {
+  readonly worktreePath: string;
+  readonly baseBranch?: string;
+}): string => `${worktreePath} ${baseBranch ?? ''}`;
+
+const entryFor = ({
+  key,
+  worktreePath,
+  baseBranch,
+}: {
+  readonly key: string;
+  readonly worktreePath: string;
+  readonly baseBranch?: string;
+}): CacheEntry => {
+  const existing = entries.get(key);
+  if (existing) {
+    return existing;
+  }
+  const created: CacheEntry = {
+    value: null,
+    fetchedAt: 0,
+    inflight: null,
+    worktreePath,
+    baseBranch,
+    listeners: new Set(),
+  };
+  entries.set(key, created);
+  return created;
+};
+
+const drain = () => {
+  while (running < MAX_CONCURRENT && queue.length > 0) {
+    const next = queue.shift();
+    if (next) {
+      running += 1;
+      next();
+    }
+  }
+};
+
+const schedule = <T>(task: () => Promise<T>): Promise<T> =>
+  new Promise<T>((resolve, reject) => {
+    queue.push(() => {
+      task()
+        .then(resolve, reject)
+        .finally(() => {
+          running -= 1;
+          drain();
+        });
+    });
+    drain();
+  });
+
+const notify = (entry: CacheEntry) => {
+  entry.listeners.forEach((listener) => listener());
+};
+
+const fetchInto = (entry: CacheEntry): Promise<void> => {
+  if (entry.inflight) {
+    return entry.inflight;
+  }
+  const inflight = schedule(() =>
+    worktreeStatus({ worktreePath: entry.worktreePath, baseBranch: entry.baseBranch }),
+  )
+    .then((status) => {
+      entry.value = status;
+    })
+    .catch(() => {
+      entry.value = null;
+    })
+    .finally(() => {
+      entry.fetchedAt = Date.now();
+      entry.inflight = null;
+      notify(entry);
+    });
+  entry.inflight = inflight;
+  return inflight;
+};
+
+const startTimer = () => {
+  if (timer !== null || typeof setInterval !== 'function') {
+    return;
+  }
+  timer = setInterval(() => {
+    if (typeof document !== 'undefined' && document.hidden) {
+      return;
+    }
+    entries.forEach((entry) => {
+      if (entry.listeners.size > 0) {
+        void fetchInto(entry);
+      }
+    });
+  }, REFRESH_MS);
+};
+
+const stopTimerWhenIdle = () => {
+  if (timer === null) {
+    return;
+  }
+  const hasListener = Array.from(entries.values()).some((entry) => entry.listeners.size > 0);
+  if (hasListener) {
+    return;
+  }
+  clearInterval(timer);
+  timer = null;
+};
+
+export const subscribe = ({ key, listener }: SubscribeParams): (() => void) => {
+  const entry = entries.get(key);
+  if (!entry) {
+    return () => {};
+  }
+  entry.listeners.add(listener);
+  startTimer();
+  return () => {
+    entry.listeners.delete(listener);
+    stopTimerWhenIdle();
+  };
+};
+
+export const readWorktreeStatus = (key: string): WorktreeStatus | null =>
+  entries.get(key)?.value ?? null;
+
+export const ensure = async ({
+  key,
+  worktreePath,
+  baseBranch,
+  maxAgeMs,
+}: EnsureParams): Promise<WorktreeStatus | null> => {
+  const entry = entryFor({ key, worktreePath, baseBranch });
+  entry.worktreePath = worktreePath;
+  entry.baseBranch = baseBranch;
+  const isFresh = entry.fetchedAt > 0 && Date.now() - entry.fetchedAt < maxAgeMs;
+  if (isFresh && !entry.inflight) {
+    return entry.value;
+  }
+  await fetchInto(entry);
+  return entry.value;
+};
+
+export const resetWorktreeStatusCache = () => {
+  entries.clear();
+  queue.length = 0;
+  running = 0;
+  if (timer !== null) {
+    clearInterval(timer);
+    timer = null;
+  }
+};

--- a/apps/desktop/src/features/session/hooks/useWorktreeStatuses/index.test.tsx
+++ b/apps/desktop/src/features/session/hooks/useWorktreeStatuses/index.test.tsx
@@ -1,15 +1,21 @@
 // @vitest-environment happy-dom
 
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
 
 const worktreeStatus = vi.hoisted(() => vi.fn());
 
 vi.mock('../../../worktree/worktree', () => ({ worktreeStatus }));
 
+import { resetWorktreeStatusCache } from './cache';
 import { useWorktreeStatuses } from '.';
 
+beforeEach(() => {
+  worktreeStatus.mockReset();
+});
+
 afterEach(() => {
+  resetWorktreeStatusCache();
   vi.restoreAllMocks();
   vi.useRealTimers();
 });
@@ -45,5 +51,44 @@ describe('useWorktreeStatuses', () => {
 
     expect(view.result.current).toBe(settledStatuses);
     expect(worktreeStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it('serves two independent hook instances from one fetch per key', async () => {
+    worktreeStatus.mockResolvedValue({ mainDistance: 2 });
+    const targets = [{ worktreePath: '/tmp/worktree', baseBranch: 'main' }];
+
+    const first = renderHook(() => useWorktreeStatuses({ targets }));
+    const second = renderHook(() => useWorktreeStatuses({ targets }));
+
+    await waitFor(() => expect(first.result.current.size).toBe(1));
+    await waitFor(() => expect(second.result.current.size).toBe(1));
+
+    expect(worktreeStatus).toHaveBeenCalledTimes(1);
+    expect(first.result.current.get('/tmp/worktree')).toBe(
+      second.result.current.get('/tmp/worktree'),
+    );
+  });
+
+  it('reads a key another consumer already filled without fetching again', async () => {
+    worktreeStatus.mockResolvedValue({ mainDistance: 2 });
+    const targets = [{ worktreePath: '/tmp/worktree', baseBranch: 'main' }];
+    const first = renderHook(() => useWorktreeStatuses({ targets }));
+    await waitFor(() => expect(first.result.current.size).toBe(1));
+    first.unmount();
+
+    const second = renderHook(() => useWorktreeStatuses({ targets }));
+
+    await waitFor(() => expect(second.result.current.size).toBe(1));
+    expect(worktreeStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves a failing worktree out of the map', async () => {
+    worktreeStatus.mockRejectedValue(new Error('gone'));
+    const targets = [{ worktreePath: '/tmp/gone', baseBranch: 'main' }];
+
+    const view = renderHook(() => useWorktreeStatuses({ targets }));
+
+    await waitFor(() => expect(worktreeStatus).toHaveBeenCalledTimes(1));
+    expect(view.result.current.size).toBe(0);
   });
 });

--- a/apps/desktop/src/features/session/hooks/useWorktreeStatuses/index.ts
+++ b/apps/desktop/src/features/session/hooks/useWorktreeStatuses/index.ts
@@ -1,6 +1,12 @@
 import { useEffect, useMemo, useState } from 'react';
 import type { WorktreeStatus } from '@goodboy/types';
-import { ensure, readWorktreeStatus, subscribe, worktreeStatusKey } from './cache';
+import {
+  ensure,
+  isWorktreeStatusSettled,
+  readWorktreeStatus,
+  subscribe,
+  worktreeStatusKey,
+} from './cache';
 
 type Params = {
   readonly targets: ReadonlyArray<{
@@ -9,19 +15,36 @@ type Params = {
   }>;
 };
 
+type Snapshot = {
+  readonly statuses: ReadonlyMap<string, WorktreeStatus>;
+  readonly pending: ReadonlySet<string>;
+};
+
 const MAX_AGE_MS = 10_000;
 const EMPTY_STATUSES: ReadonlyMap<string, WorktreeStatus> = new Map();
+const EMPTY_PENDING: ReadonlySet<string> = new Set();
+const EMPTY_SNAPSHOT: Snapshot = { statuses: EMPTY_STATUSES, pending: EMPTY_PENDING };
 
-export const useWorktreeStatuses = ({ targets }: Params): ReadonlyMap<string, WorktreeStatus> => {
-  const [statuses, setStatuses] = useState<ReadonlyMap<string, WorktreeStatus>>(EMPTY_STATUSES);
-  const targetsKey = targets
-    .map(({ worktreePath, baseBranch }) => `${worktreePath} ${baseBranch ?? ''}`)
-    .join('|');
+const sameStatuses = (
+  current: ReadonlyMap<string, WorktreeStatus>,
+  next: ReadonlyMap<string, WorktreeStatus>,
+): boolean =>
+  current.size === next.size &&
+  Array.from(next.entries()).every(([path, value]) => current.get(path) === value);
+
+const samePending = (current: ReadonlySet<string>, next: ReadonlySet<string>): boolean =>
+  current.size === next.size && Array.from(next).every((path) => current.has(path));
+
+const useWorktreeStatusSnapshot = ({ targets }: Params): Snapshot => {
+  const [snapshot, setSnapshot] = useState<Snapshot>(EMPTY_SNAPSHOT);
+  const targetsKey = JSON.stringify(
+    targets.map(({ worktreePath, baseBranch }) => [worktreePath, baseBranch ?? null]),
+  );
   const stableTargets = useMemo(() => targets, [targetsKey]);
 
   useEffect(() => {
     if (stableTargets.length === 0) {
-      setStatuses(EMPTY_STATUSES);
+      setSnapshot(EMPTY_SNAPSHOT);
       return;
     }
     let isStale = false;
@@ -34,21 +57,24 @@ export const useWorktreeStatuses = ({ targets }: Params): ReadonlyMap<string, Wo
       if (isStale) {
         return;
       }
-      const next = new Map<string, WorktreeStatus>();
+      const statuses = new Map<string, WorktreeStatus>();
+      const pending = new Set<string>();
       keyed.forEach(({ key, worktreePath }) => {
         const value = readWorktreeStatus(key);
         if (value) {
-          next.set(worktreePath, value);
+          statuses.set(worktreePath, value);
+        }
+        if (!isWorktreeStatusSettled(key)) {
+          pending.add(worktreePath);
         }
       });
-      setStatuses((current) => {
-        const isSame =
-          current.size === next.size &&
-          Array.from(next.entries()).every(([path, value]) => current.get(path) === value);
-        return isSame ? current : next;
-      });
+      setSnapshot((current) =>
+        sameStatuses(current.statuses, statuses) && samePending(current.pending, pending)
+          ? current
+          : { statuses, pending },
+      );
     };
-    setStatuses(EMPTY_STATUSES);
+    setSnapshot(EMPTY_SNAPSHOT);
     const unsubscribes = keyed.map(({ key, worktreePath, baseBranch }) => {
       const pending = ensure({ key, worktreePath, baseBranch, maxAgeMs: MAX_AGE_MS });
       const unsubscribe = subscribe({ key, listener: publish });
@@ -62,5 +88,11 @@ export const useWorktreeStatuses = ({ targets }: Params): ReadonlyMap<string, Wo
     };
   }, [stableTargets]);
 
-  return statuses;
+  return snapshot;
 };
+
+export const useWorktreeStatuses = ({ targets }: Params): ReadonlyMap<string, WorktreeStatus> =>
+  useWorktreeStatusSnapshot({ targets }).statuses;
+
+export const useWorktreeStatusPending = ({ targets }: Params): ReadonlySet<string> =>
+  useWorktreeStatusSnapshot({ targets }).pending;

--- a/apps/desktop/src/features/session/hooks/useWorktreeStatuses/index.ts
+++ b/apps/desktop/src/features/session/hooks/useWorktreeStatuses/index.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import type { WorktreeStatus } from '@goodboy/types';
-import { worktreeStatus } from '../../../worktree/worktree';
+import { ensure, readWorktreeStatus, subscribe, worktreeStatusKey } from './cache';
 
 type Params = {
   readonly targets: ReadonlyArray<{
@@ -9,16 +9,14 @@ type Params = {
   }>;
 };
 
-type StatusEntry = readonly [string, WorktreeStatus];
-
-const REFRESH_MS = 30_000;
+const MAX_AGE_MS = 10_000;
 const EMPTY_STATUSES: ReadonlyMap<string, WorktreeStatus> = new Map();
 
 export const useWorktreeStatuses = ({ targets }: Params): ReadonlyMap<string, WorktreeStatus> => {
   const [statuses, setStatuses] = useState<ReadonlyMap<string, WorktreeStatus>>(EMPTY_STATUSES);
   const targetsKey = targets
-    .map(({ worktreePath, baseBranch }) => `${worktreePath}\u0000${baseBranch ?? ''}`)
-    .join('\u0001');
+    .map(({ worktreePath, baseBranch }) => `${worktreePath} ${baseBranch ?? ''}`)
+    .join('|');
   const stableTargets = useMemo(() => targets, [targetsKey]);
 
   useEffect(() => {
@@ -27,32 +25,40 @@ export const useWorktreeStatuses = ({ targets }: Params): ReadonlyMap<string, Wo
       return;
     }
     let isStale = false;
-    const refresh = () => {
-      if (typeof document !== 'undefined' && document.hidden) {
+    const keyed = stableTargets.map((target) => ({
+      worktreePath: target.worktreePath,
+      baseBranch: target.baseBranch,
+      key: worktreeStatusKey(target),
+    }));
+    const publish = () => {
+      if (isStale) {
         return;
       }
-      void Promise.all(
-        stableTargets.map(async ({ worktreePath, baseBranch }) => {
-          try {
-            const status = await worktreeStatus({ worktreePath, baseBranch });
-            const entry: StatusEntry = [worktreePath, status];
-            return entry;
-          } catch {
-            return null;
-          }
-        }),
-      ).then((entries) => {
-        if (!isStale) {
-          setStatuses(new Map(entries.filter((entry): entry is StatusEntry => entry !== null)));
+      const next = new Map<string, WorktreeStatus>();
+      keyed.forEach(({ key, worktreePath }) => {
+        const value = readWorktreeStatus(key);
+        if (value) {
+          next.set(worktreePath, value);
         }
       });
+      setStatuses((current) => {
+        const isSame =
+          current.size === next.size &&
+          Array.from(next.entries()).every(([path, value]) => current.get(path) === value);
+        return isSame ? current : next;
+      });
     };
-    setStatuses(new Map());
-    refresh();
-    const timer = setInterval(refresh, REFRESH_MS);
+    setStatuses(EMPTY_STATUSES);
+    const unsubscribes = keyed.map(({ key, worktreePath, baseBranch }) => {
+      const pending = ensure({ key, worktreePath, baseBranch, maxAgeMs: MAX_AGE_MS });
+      const unsubscribe = subscribe({ key, listener: publish });
+      void pending.then(publish);
+      return unsubscribe;
+    });
+    publish();
     return () => {
       isStale = true;
-      clearInterval(timer);
+      unsubscribes.forEach((unsubscribe) => unsubscribe());
     };
   }, [stableTargets]);
 

--- a/apps/desktop/src/features/suggestions/useSessionSuggestions/index.test.tsx
+++ b/apps/desktop/src/features/suggestions/useSessionSuggestions/index.test.tsx
@@ -1,0 +1,86 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { Session } from '@goodboy/types';
+
+const { store, worktreeStatus } = vi.hoisted(() => ({
+  worktreeStatus: vi.fn(),
+  store: {
+    sessionPhaseRuns: {} as Record<string, ReadonlyArray<unknown>>,
+    planConsumptions: {} as Record<string, ReadonlyArray<unknown>>,
+    sessionGithub: {} as Record<string, unknown>,
+    sessionPendingResolutions: {} as Record<string, ReadonlyArray<unknown>>,
+    sessionProjectMounts: {
+      'session-1': [{ projectId: 'api', mountName: 'API', worktreePath: '/api', branch: 'feat' }],
+    } as Record<string, ReadonlyArray<Record<string, string>>>,
+    projects: [
+      { id: 'api', name: 'API', baseBranch: 'main', workspaceId: 'ws-1' },
+    ] as ReadonlyArray<Record<string, string>>,
+  },
+}));
+
+vi.mock('../../../store', () => ({
+  EMPTY_ARRAY: Object.freeze([]),
+  useAppStore: <T,>(selector: (state: typeof store) => T) => selector(store),
+  useSessionPlans: () => [],
+  useSessionOpenQuestions: () => [],
+}));
+
+vi.mock('../../workflows/useAttachedWorkflowRuns', () => ({
+  useAttachedWorkflowRuns: () => [],
+}));
+
+vi.mock('../../workflows/useWorkflowAdvanceStates', () => ({
+  useWorkflowAdvanceStates: () => new Map(),
+}));
+
+vi.mock('../../session/hooks/useResolverIndex', () => ({
+  useResolverIndex: () => ({
+    links: [],
+    byThreadId: new Map(),
+    byCommentUrl: new Map(),
+    byDiffAgentId: new Map(),
+  }),
+}));
+
+vi.mock('../../worktree/worktree', () => ({ worktreeStatus }));
+
+import { resetWorktreeStatusCache } from '../../session/hooks/useWorktreeStatuses/cache';
+import { useSessionSuggestions } from '.';
+
+const session = { id: 'session-1', workspaceId: 'ws-1' } as Session;
+
+beforeEach(() => {
+  worktreeStatus.mockReset();
+  worktreeStatus.mockResolvedValue({
+    branch: 'feat',
+    mainDistance: { kind: 'known', ahead: 0, behind: 4 },
+    upstreamDistance: { kind: 'known', ahead: 0, behind: 0 },
+  });
+});
+
+afterEach(() => {
+  resetWorktreeStatusCache();
+});
+
+describe('useSessionSuggestions rebase opt-out', () => {
+  it('reads the worktree and offers the rebase by default', async () => {
+    const view = renderHook(() => useSessionSuggestions({ session }));
+
+    await waitFor(() =>
+      expect(view.result.current.some((s) => s.kind === 'rebase-project')).toBe(true),
+    );
+    expect(worktreeStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it('runs no git work and offers no rebase when the caller opts out', async () => {
+    const view = renderHook(() => useSessionSuggestions({ session, withRebase: false }));
+
+    await waitFor(() => expect(view.result.current).toBeDefined());
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(worktreeStatus).not.toHaveBeenCalled();
+    expect(view.result.current.some((s) => s.kind === 'rebase-project')).toBe(false);
+  });
+});

--- a/apps/desktop/src/features/suggestions/useSessionSuggestions/index.ts
+++ b/apps/desktop/src/features/suggestions/useSessionSuggestions/index.ts
@@ -16,9 +16,13 @@ import { deriveSessionSuggestions } from '../deriveSessionSuggestions';
 type Params = {
   readonly session: Session;
   readonly agents?: ReadonlyArray<Agent>;
+  readonly withRebase?: boolean;
 };
 
-export const useSessionSuggestions = ({ session, agents }: Params) => {
+const NO_TARGETS: ReadonlyArray<{ readonly worktreePath: string; readonly baseBranch?: string }> =
+  [];
+
+export const useSessionSuggestions = ({ session, agents, withRebase = true }: Params) => {
   const sessionId = session.id;
   const storedAgents = useAppStore(
     (state) => state.sessionPhaseRuns[sessionId] ?? (EMPTY_ARRAY as ReadonlyArray<Agent>),
@@ -55,12 +59,14 @@ export const useSessionSuggestions = ({ session, agents }: Params) => {
   const resolverIndex = useResolverIndex(sessionId);
   const targets = useMemo(
     () =>
-      mounts.map((mount) => ({
-        worktreePath: mount.worktreePath,
-        baseBranch:
-          projects.find((project) => project.id === mount.projectId)?.baseBranch ?? undefined,
-      })),
-    [mounts, projects],
+      withRebase
+        ? mounts.map((mount) => ({
+            worktreePath: mount.worktreePath,
+            baseBranch:
+              projects.find((project) => project.id === mount.projectId)?.baseBranch ?? undefined,
+          }))
+        : NO_TARGETS,
+    [mounts, projects, withRebase],
   );
   const worktreeStatuses = useWorktreeStatuses({ targets });
 
@@ -131,17 +137,20 @@ export const useSessionSuggestions = ({ session, agents }: Params) => {
           resolverStatus: resolver?.status ?? null,
         };
       }),
-      projects: mounts.map((mount) => {
-        const project = projects.find((candidate) => candidate.id === mount.projectId) ?? null;
-        const status = worktreeStatuses.get(mount.worktreePath) ?? null;
-        return {
-          projectId: mount.projectId,
-          projectName: project?.name ?? mount.mountName,
-          worktreePath: mount.worktreePath,
-          baseBranch: project?.baseBranch ?? 'main',
-          mainDistance: status == null ? null : distanceBehind({ distance: status.mainDistance }),
-        };
-      }),
+      projects: withRebase
+        ? mounts.map((mount) => {
+            const project = projects.find((candidate) => candidate.id === mount.projectId) ?? null;
+            const status = worktreeStatuses.get(mount.worktreePath) ?? null;
+            return {
+              projectId: mount.projectId,
+              projectName: project?.name ?? mount.mountName,
+              worktreePath: mount.worktreePath,
+              baseBranch: project?.baseBranch ?? 'main',
+              mainDistance:
+                status == null ? null : distanceBehind({ distance: status.mainDistance }),
+            };
+          })
+        : [],
     });
   }, [
     active,
@@ -158,6 +167,7 @@ export const useSessionSuggestions = ({ session, agents }: Params) => {
     projects,
     resolverIndex,
     sessionId,
+    withRebase,
     worktreeStatuses,
   ]);
 };

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/PlanReadySuggestion.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/PlanReadySuggestion.tsx
@@ -10,7 +10,7 @@ type Props = {
 };
 
 export const PlanReadySuggestion = ({ task }: Props) => {
-  const suggestions = useSessionSuggestions({ session: task });
+  const suggestions = useSessionSuggestions({ session: task, withRebase: false });
   const runPlan = useAppStore((s) => s.runPlan);
   const announceAgentStarted = useAgentStartedToast();
   const [spawning, setSpawning] = useState(false);


### PR DESCRIPTION
Session switch froze the app for 3 to 4 seconds. Root cause: sync Tauri commands run on the macOS main thread (which also drives WKWebView), and the overview fired worktree_status (about 8 git processes per mount) from five independent hook instances plus the branch sync, each with its own poller: roughly 40N git bursts on the main thread for N mounts.

Rust
- Every command in worktree.rs and repo.rs, explore_list/explore_open, and the session/workspace read path in workflows.rs (workflow_list, workflows_for_session, step_def_list, agent_list_for_session, workspaces_with_unread) are async; process-spawning ones run through spawn_blocking with the original body kept as a private _blocking twin. Command names and JSON shapes unchanged.

Frontend
- One module-level worktree status cache: dedupe per key, freshness window, 4-slot concurrency queue, one shared 30 s poller that refreshes only subscribed keys and skips hidden documents. useWorktreeStatuses keeps its signature.
- useSessionSuggestions gains withRebase; the sidebar plan-ready row and the composer cards pass false, so they do no git work.
- useSessionBranchSync reads through the cache.
- Skeletons: timeline rows while events/agents load, branch and distance cells on repo mount rows, suggestions block waits for agents.

After: about 8N git processes per switch, off the main thread, at most 4 concurrent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)