### PR TITLE
feat(ui): navigate monorepo manifests from a side rail in scripts

### DIFF
--- a/apps/desktop/src/features/scripts/components/ScriptsPanel/DiscoveredScriptGroup.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsPanel/DiscoveredScriptGroup.tsx
@@ -1,4 +1,4 @@
-import { Chip, Collapsible, Eyebrow, Tooltip, cn, tintClasses } from '@goodboy/ui';
+import { Chip, Eyebrow, Tooltip, cn, tintClasses } from '@goodboy/ui';
 import type { DiscoveredScript, ScriptGroup, ScriptRunRecord } from '../../scripts';
 import { discoveredScriptCwd, discoveredScriptId } from '../../scripts';
 import {
@@ -24,8 +24,7 @@ type Props = {
   readonly worktreePath: string;
   readonly runs: Readonly<Record<string, ScriptRunRecord>> | undefined;
   readonly completedAt: Readonly<Record<string, number>>;
-  readonly open: boolean;
-  readonly onOpenChange: (open: boolean) => void;
+  readonly emptyLabel: string | null;
   readonly onRun: (params: RunParams) => void;
   readonly onCancel: (params: CancelParams) => void;
 };
@@ -35,8 +34,7 @@ export const DiscoveredScriptGroup = ({
   worktreePath,
   runs,
   completedAt,
-  open,
-  onOpenChange,
+  emptyLabel,
   onRun,
   onCancel,
 }: Props) => {
@@ -52,114 +50,112 @@ export const DiscoveredScriptGroup = ({
     scriptsByCategory.get(category) ?? [];
 
   return (
-    <section aria-label={`${group.packageName} scripts`}>
-      <Collapsible
-        open={open}
-        onOpenChange={onOpenChange}
-        className="border border-border-soft"
-        trigger={
-          <span className="flex min-w-0 flex-1 flex-col gap-1.5">
-            <span className="flex min-w-0 items-center gap-2">
-              <span
-                role="heading"
-                aria-level={3}
-                className="truncate text-sm font-medium text-foreground"
-              >
-                {group.packageName}
-              </span>
-              {group.relDir !== '' ? (
-                <span className="truncate font-mono text-3xs text-muted-foreground">
-                  {group.relDir}
-                </span>
-              ) : null}
-              <Chip tone="neutral" label={group.manager} size="3xs" shape="badge" uppercase />
-              <Chip tone="neutral" label={String(scripts.length)} size="3xs" />
-            </span>
-            <span className="flex flex-wrap items-center gap-1" aria-label="Script categories">
-              {presentCategories.map((category) => {
-                const Icon = category.icon;
-                const tint = tintClasses(category.tone);
-                return (
-                  <Tooltip
-                    key={category.id}
-                    content={`${category.label}: ${scriptsFor(category.id).length}`}
-                  >
-                    <span
-                      className={cn(
-                        'inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-3xs tabular-nums ring-1',
-                        tint.bgSoft,
-                        tint.ring,
-                        tint.text,
-                      )}
-                      data-testid={`category-strip-${category.id}`}
-                    >
-                      <Icon size={10} aria-hidden />
-                      {scriptsFor(category.id).length}
-                    </span>
-                  </Tooltip>
-                );
-              })}
-            </span>
+    <section
+      aria-label={`${group.packageName} scripts`}
+      className="flex min-w-0 flex-1 flex-col gap-3"
+    >
+      <header className="flex min-w-0 flex-col gap-1.5">
+        <span className="flex min-w-0 items-center gap-2">
+          <span
+            role="heading"
+            aria-level={3}
+            className="truncate text-sm font-medium text-foreground"
+          >
+            {group.packageName}
           </span>
-        }
-      >
-        <div className="flex flex-col gap-3 pt-2">
-          {presentCategories.map((category) => {
-            const Icon = category.icon;
-            const tint = tintClasses(category.tone);
-            const categoryScripts = scriptsFor(category.id);
-            return (
-              <section key={category.id} aria-label={`${category.label} scripts`}>
-                <div className="flex flex-col gap-1.5">
-                  <Eyebrow
-                    label={
-                      <span className="flex items-center gap-1.5">
-                        <span>{category.label}</span>
-                        <span className="tabular-nums text-muted-foreground/60">
-                          {categoryScripts.length}
-                        </span>
-                      </span>
-                    }
-                    icon={<Icon size={11} aria-hidden className={tint.icon} />}
-                  />
-                  <ul className="flex flex-col gap-1.5">
-                    {categoryScripts.map((script) => {
-                      const scriptId = discoveredScriptId({
-                        worktreePath,
-                        source: group.source,
-                        relDir: group.relDir,
-                        name: script.name,
-                      });
-                      const run = runs?.[scriptId] ?? null;
-                      return (
-                        <li key={scriptId}>
-                          <DiscoveredScriptRow
-                            scriptId={scriptId}
-                            name={script.name}
-                            command={script.command}
-                            cwd={cwd}
-                            run={run}
-                            completedAt={run == null ? undefined : completedAt[run.runId]}
-                            onRun={() =>
-                              onRun({
-                                scriptId,
-                                name: script.name,
-                                command: script.command,
-                                cwd,
-                              })
-                            }
-                            onCancel={() => onCancel({ scriptId })}
-                          />
-                        </li>
-                      );
-                    })}
-                  </ul>
-                </div>
-              </section>
-            );
-          })}
-        </div>
-      </Collapsible>
+          {group.relDir !== '' ? (
+            <span className="truncate font-mono text-3xs text-muted-foreground">
+              {group.relDir}
+            </span>
+          ) : null}
+          <Chip tone="neutral" label={group.manager} size="3xs" shape="badge" uppercase />
+          <Chip tone="neutral" label={String(scripts.length)} size="3xs" />
+        </span>
+        {presentCategories.length > 0 ? (
+          <span className="flex flex-wrap items-center gap-1" aria-label="Script categories">
+            {presentCategories.map((category) => {
+              const Icon = category.icon;
+              const tint = tintClasses(category.tone);
+              return (
+                <Tooltip
+                  key={category.id}
+                  content={`${category.label}: ${scriptsFor(category.id).length}`}
+                >
+                  <span
+                    className={cn(
+                      'inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-3xs tabular-nums ring-1',
+                      tint.bgSoft,
+                      tint.ring,
+                      tint.text,
+                    )}
+                    data-testid={`category-strip-${category.id}`}
+                  >
+                    <Icon size={10} aria-hidden />
+                    {scriptsFor(category.id).length}
+                  </span>
+                </Tooltip>
+              );
+            })}
+          </span>
+        ) : null}
+      </header>
+      {scripts.length === 0 && emptyLabel != null ? (
+        <p className="text-xs text-muted-foreground">{emptyLabel}</p>
+      ) : null}
+      {presentCategories.map((category) => {
+        const Icon = category.icon;
+        const tint = tintClasses(category.tone);
+        const categoryScripts = scriptsFor(category.id);
+        return (
+          <section key={category.id} aria-label={`${category.label} scripts`}>
+            <div className="flex flex-col gap-1.5">
+              <Eyebrow
+                label={
+                  <span className="flex items-center gap-1.5">
+                    <span>{category.label}</span>
+                    <span className="tabular-nums text-muted-foreground/60">
+                      {categoryScripts.length}
+                    </span>
+                  </span>
+                }
+                icon={<Icon size={11} aria-hidden className={tint.icon} />}
+              />
+              <ul className="flex flex-col gap-1.5">
+                {categoryScripts.map((script) => {
+                  const scriptId = discoveredScriptId({
+                    worktreePath,
+                    source: group.source,
+                    relDir: group.relDir,
+                    name: script.name,
+                  });
+                  const run = runs?.[scriptId] ?? null;
+                  return (
+                    <li key={scriptId}>
+                      <DiscoveredScriptRow
+                        scriptId={scriptId}
+                        name={script.name}
+                        command={script.command}
+                        cwd={cwd}
+                        run={run}
+                        completedAt={run == null ? undefined : completedAt[run.runId]}
+                        onRun={() =>
+                          onRun({
+                            scriptId,
+                            name: script.name,
+                            command: script.command,
+                            cwd,
+                          })
+                        }
+                        onCancel={() => onCancel({ scriptId })}
+                      />
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          </section>
+        );
+      })}
     </section>
   );
 };

--- a/apps/desktop/src/features/scripts/components/ScriptsPanel/ManifestRail.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsPanel/ManifestRail.tsx
@@ -24,11 +24,11 @@ type Bucket = {
   readonly entries: ReadonlyArray<ManifestRailEntry>;
 };
 
-const ROOT_LABEL = 'root';
+const ROOT_KEY = '';
 
-const bucketLabel = ({ relDir }: { readonly relDir: string }): string => {
+const bucketKey = ({ relDir }: { readonly relDir: string }): string => {
   const [head] = relDir.split(/[\\/]/).filter((part) => part !== '');
-  return head ?? ROOT_LABEL;
+  return head ?? ROOT_KEY;
 };
 
 const bucketEntries = ({
@@ -38,20 +38,20 @@ const bucketEntries = ({
 }): ReadonlyArray<Bucket> => {
   const buckets = new Map<string, Array<ManifestRailEntry>>();
   for (const entry of entries) {
-    const label = bucketLabel({ relDir: entry.relDir });
-    const bucket = buckets.get(label);
+    const key = bucketKey({ relDir: entry.relDir });
+    const bucket = buckets.get(key);
     if (bucket === undefined) {
-      buckets.set(label, [entry]);
+      buckets.set(key, [entry]);
     } else {
       bucket.push(entry);
     }
   }
-  const labeled = [...buckets.keys()].filter((label) => label !== ROOT_LABEL);
+  const labeled = [...buckets.keys()].filter((key) => key !== ROOT_KEY);
   if (labeled.length < 2) {
     return [{ label: null, entries }];
   }
-  return [...buckets.entries()].map(([label, bucket]) => ({
-    label: label === ROOT_LABEL ? null : label,
+  return [...buckets.entries()].map(([key, bucket]) => ({
+    label: key === ROOT_KEY ? null : key,
     entries: bucket,
   }));
 };
@@ -62,11 +62,14 @@ export const ManifestRail = ({ entries, selectedKey, hasSearch, onSelect }: Prop
     className="sticky top-0 flex w-48 shrink-0 flex-col gap-2 self-start"
   >
     {bucketEntries({ entries }).map((bucket) => (
-      <div key={bucket.label ?? ROOT_LABEL} className="flex flex-col gap-1">
+      <div
+        key={bucket.label == null ? ROOT_KEY : `dir:${bucket.label}`}
+        className="flex flex-col gap-1"
+      >
         {bucket.label == null ? null : <Eyebrow label={bucket.label} />}
         {bucket.entries.map((entry) => {
           const selected = entry.key === selectedKey;
-          const showMatches = hasSearch && !selected;
+          const showMatches = hasSearch;
           return (
             <SelectableRow
               key={entry.key}

--- a/apps/desktop/src/features/scripts/components/ScriptsPanel/ManifestRail.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsPanel/ManifestRail.tsx
@@ -1,0 +1,113 @@
+import { Chip, Eyebrow, SelectableRow, StatusDot, cn } from '@goodboy/ui';
+import type { ScriptSource } from '../../scripts';
+
+export type ManifestRailEntry = {
+  readonly key: string;
+  readonly source: ScriptSource;
+  readonly packageName: string;
+  readonly relDir: string;
+  readonly manager: string;
+  readonly scriptCount: number;
+  readonly matchCount: number;
+  readonly isRunning: boolean;
+};
+
+type Props = {
+  readonly entries: ReadonlyArray<ManifestRailEntry>;
+  readonly selectedKey: string;
+  readonly hasSearch: boolean;
+  readonly onSelect: (key: string) => void;
+};
+
+type Bucket = {
+  readonly label: string | null;
+  readonly entries: ReadonlyArray<ManifestRailEntry>;
+};
+
+const ROOT_LABEL = 'root';
+
+const bucketLabel = ({ relDir }: { readonly relDir: string }): string => {
+  const [head] = relDir.split(/[\\/]/).filter((part) => part !== '');
+  return head ?? ROOT_LABEL;
+};
+
+const bucketEntries = ({
+  entries,
+}: {
+  readonly entries: ReadonlyArray<ManifestRailEntry>;
+}): ReadonlyArray<Bucket> => {
+  const buckets = new Map<string, Array<ManifestRailEntry>>();
+  for (const entry of entries) {
+    const label = bucketLabel({ relDir: entry.relDir });
+    const bucket = buckets.get(label);
+    if (bucket === undefined) {
+      buckets.set(label, [entry]);
+    } else {
+      bucket.push(entry);
+    }
+  }
+  const labeled = [...buckets.keys()].filter((label) => label !== ROOT_LABEL);
+  if (labeled.length < 2) {
+    return [{ label: null, entries }];
+  }
+  return [...buckets.entries()].map(([label, bucket]) => ({
+    label: label === ROOT_LABEL ? null : label,
+    entries: bucket,
+  }));
+};
+
+export const ManifestRail = ({ entries, selectedKey, hasSearch, onSelect }: Props) => (
+  <nav
+    aria-label="Manifest packages"
+    className="sticky top-0 flex w-48 shrink-0 flex-col gap-2 self-start"
+  >
+    {bucketEntries({ entries }).map((bucket) => (
+      <div key={bucket.label ?? ROOT_LABEL} className="flex flex-col gap-1">
+        {bucket.label == null ? null : <Eyebrow label={bucket.label} />}
+        {bucket.entries.map((entry) => {
+          const selected = entry.key === selectedKey;
+          const showMatches = hasSearch && !selected;
+          return (
+            <SelectableRow
+              key={entry.key}
+              selected={selected}
+              ariaCurrent={selected}
+              onClick={() => onSelect(entry.key)}
+              className="flex-col items-stretch gap-0.5 px-2 py-1.5"
+            >
+              <span className="flex min-w-0 items-center gap-1.5">
+                <span className="min-w-0 flex-1 truncate text-xs font-medium">
+                  {entry.packageName}
+                </span>
+                {entry.isRunning ? (
+                  <StatusDot
+                    tone="info"
+                    pulsing
+                    size="sm"
+                    ariaLabel={`Running script in ${entry.packageName}`}
+                  />
+                ) : null}
+                <Chip
+                  tone="neutral"
+                  label={String(showMatches ? entry.matchCount : entry.scriptCount)}
+                  size="3xs"
+                  className={cn(showMatches && entry.matchCount === 0 && 'opacity-40')}
+                />
+              </span>
+              <span className="flex min-w-0 items-center gap-1.5 text-3xs text-muted-foreground/70">
+                <span className="truncate font-mono">
+                  {entry.relDir === '' ? entry.manager : entry.relDir}
+                </span>
+                {showMatches ? (
+                  <span className="ml-auto shrink-0 tabular-nums">
+                    {entry.matchCount === 1 ? '1 match' : `${entry.matchCount} matches`}
+                  </span>
+                ) : null}
+              </span>
+            </SelectableRow>
+          );
+        })}
+      </div>
+    ))}
+  </nav>
+);

--- a/apps/desktop/src/features/scripts/components/ScriptsPanel/index.test.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsPanel/index.test.tsx
@@ -601,6 +601,12 @@ describe('ScriptsPanel', () => {
     expect(headings()).toEqual(['@acme/web']);
     expect(screen.getByText('deploy manifest')).toBeDefined();
     expect(within(manifestRail()).getByText('1 match')).toBeDefined();
+    expect(within(manifestRail()).getByText('0 matches')).toBeDefined();
+    expect(
+      within(manifestRail())
+        .getByRole('button', { name: /@acme\/web/ })
+        .getAttribute('aria-current'),
+    ).toBe('true');
     expect(within(rail()).getByText('1 match')).toBeDefined();
 
     fireEvent.keyDown(searchBox(), { key: 'Escape' });

--- a/apps/desktop/src/features/scripts/components/ScriptsPanel/index.test.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsPanel/index.test.tsx
@@ -109,6 +109,13 @@ const rail = () => screen.getByRole('navigation', { name: 'Script projects' });
 
 const manifestSection = () => screen.getByRole('region', { name: 'Manifest scripts' });
 
+const manifestRail = () => screen.getByRole('navigation', { name: 'Manifest packages' });
+
+const headings = () =>
+  Array.from(manifestSection().querySelectorAll('span[role="heading"]')).map(
+    (heading) => heading.textContent,
+  );
+
 const searchBox = () => screen.getByRole('searchbox', { name: 'Search scripts' });
 
 beforeEach(() => {
@@ -287,7 +294,7 @@ describe('ScriptsPanel', () => {
     expect(within(rail()).queryByRole('img', { name: 'Running script in API' })).toBeNull();
   });
 
-  it('keeps the root package open and workspace packages collapsed', () => {
+  it('lists manifests in a rail, root first, and shows the selected one', () => {
     state.discoveredScripts = {
       'session-1': {
         '/tmp/api': [
@@ -318,20 +325,78 @@ describe('ScriptsPanel', () => {
 
     renderPanel();
 
-    const packages = Array.from(manifestSection().querySelectorAll('span[role="heading"]'));
-    expect(packages.map((heading) => heading.textContent)).toEqual([
-      'root',
-      '@acme/web',
-      'acme/api',
+    const packages = within(manifestRail()).getAllByRole('button');
+    expect(packages.map((row) => row.textContent)).toEqual([
+      expect.stringContaining('root'),
+      expect.stringContaining('@acme/web'),
+      expect.stringContaining('acme/api'),
     ]);
+    expect(packages[0]?.getAttribute('aria-current')).toBe('true');
+    expect(headings()).toEqual(['root']);
+
+    fireEvent.click(within(manifestRail()).getByRole('button', { name: /@acme\/web/ }));
+
+    expect(headings()).toEqual(['@acme/web']);
     expect(
-      within(manifestSection()).getByRole('button', { name: /root/ }).getAttribute('aria-expanded'),
-    ).toBe('true');
-    expect(
-      within(manifestSection())
+      within(manifestRail())
         .getByRole('button', { name: /@acme\/web/ })
-        .getAttribute('aria-expanded'),
-    ).toBe('false');
+        .getAttribute('aria-current'),
+    ).toBe('true');
+  });
+
+  it('remembers the manifest picked for each project', () => {
+    withTwoProjects();
+    state.discoveredScripts = {
+      'session-1': {
+        '/tmp/api': [
+          {
+            source: 'package-json',
+            packageName: 'root',
+            relDir: '',
+            manager: 'pnpm',
+            scripts: [{ name: 'build', command: 'pnpm run build' }],
+          },
+          {
+            source: 'package-json',
+            packageName: '@acme/web',
+            relDir: 'apps/web',
+            manager: 'pnpm',
+            scripts: [{ name: 'dev', command: 'pnpm run dev' }],
+          },
+        ],
+      },
+    };
+
+    renderPanel();
+
+    fireEvent.click(within(manifestRail()).getByRole('button', { name: /@acme\/web/ }));
+    expect(headings()).toEqual(['@acme/web']);
+
+    fireEvent.click(within(rail()).getByRole('button', { name: /Web/ }));
+    fireEvent.click(within(rail()).getByRole('button', { name: /API/ }));
+
+    expect(headings()).toEqual(['@acme/web']);
+  });
+
+  it('hides the manifest rail when a project has a single manifest', () => {
+    state.discoveredScripts = {
+      'session-1': {
+        '/tmp/api': [
+          {
+            source: 'package-json',
+            packageName: 'api',
+            relDir: '',
+            manager: 'pnpm',
+            scripts: [{ name: 'dev', command: 'pnpm run dev' }],
+          },
+        ],
+      },
+    };
+
+    renderPanel();
+
+    expect(screen.queryByRole('navigation', { name: 'Manifest packages' })).toBeNull();
+    expect(headings()).toEqual(['api']);
   });
 
   it('summarises a package with a category strip and groups its scripts by category', () => {
@@ -399,7 +464,6 @@ describe('ScriptsPanel', () => {
       sessionId: 'session-1',
       worktreePath: '/tmp/api',
     });
-    fireEvent.click(within(manifestSection()).getByRole('button', { name: /@acme\/web/ }));
     fireEvent.click(screen.getByRole('button', { name: 'Run dev' }));
 
     expect(state.runDiscoveredScript).toHaveBeenCalledWith(
@@ -511,6 +575,13 @@ describe('ScriptsPanel', () => {
         '/tmp/api': [
           {
             source: 'package-json',
+            packageName: 'root',
+            relDir: '',
+            manager: 'pnpm',
+            scripts: [{ name: 'build', command: 'pnpm run build' }],
+          },
+          {
+            source: 'package-json',
             packageName: '@acme/web',
             relDir: 'apps/web',
             manager: 'pnpm',
@@ -522,24 +593,18 @@ describe('ScriptsPanel', () => {
 
     renderPanel();
 
+    expect(headings()).toEqual(['root']);
     fireEvent.change(searchBox(), { target: { value: 'deploy' } });
 
     expect(screen.getByText('deploy user')).toBeDefined();
     expect(screen.queryByText('lint user')).toBeNull();
-    expect(
-      within(manifestSection())
-        .getByRole('button', { name: /@acme\/web/ })
-        .getAttribute('aria-expanded'),
-    ).toBe('true');
+    expect(headings()).toEqual(['@acme/web']);
     expect(screen.getByText('deploy manifest')).toBeDefined();
+    expect(within(manifestRail()).getByText('1 match')).toBeDefined();
     expect(within(rail()).getByText('1 match')).toBeDefined();
 
     fireEvent.keyDown(searchBox(), { key: 'Escape' });
-    expect(
-      within(manifestSection())
-        .getByRole('button', { name: /@acme\/web/ })
-        .getAttribute('aria-expanded'),
-    ).toBe('false');
+    expect(headings()).toEqual(['root']);
     expect(screen.getByText('lint user')).toBeDefined();
   });
 

--- a/apps/desktop/src/features/scripts/components/ScriptsPanel/index.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsPanel/index.tsx
@@ -27,6 +27,7 @@ import { readScriptsProject, writeScriptsProject } from '../../projectSelectionS
 import { discoveredScriptId, type ScriptGroup as ManifestScriptGroup } from '../../scripts';
 import { DiscardDraftConfirm } from './DiscardDraftConfirm';
 import { DiscoveredScriptGroup } from './DiscoveredScriptGroup';
+import { ManifestRail, type ManifestRailEntry } from './ManifestRail';
 import { ManifestSearchInput } from './ManifestSearchInput';
 import { NewScriptCard } from './NewScriptCard';
 import { ProjectRail, type ProjectRailEntry } from './ProjectRail';
@@ -109,6 +110,10 @@ type SelectProjectParams = {
   readonly projectId: ProjectId;
 };
 
+type SelectManifestParams = {
+  readonly key: string;
+};
+
 type SearchTarget = {
   readonly name: string;
   readonly command: string;
@@ -155,6 +160,9 @@ const initialProject = ({
   }
   return projects[0]?.id ?? null;
 };
+
+const manifestKey = ({ group }: { readonly group: ManifestScriptGroup }): string =>
+  `${group.source}:${group.relDir}`;
 
 const shortenPath = ({ path }: ShortenPathParams): string => {
   const parts = path.split(/[\\/]/).filter((part) => part !== '');
@@ -239,7 +247,9 @@ export const ScriptsPanel = ({ workspaceId, sessionId, hasHostHeading = false }:
   const [copiedId, setCopiedId] = useState<ProjectScriptId | null>(null);
   const [completedAt, setCompletedAt] = useState<Record<string, number>>({});
   const [searchQuery, setSearchQuery] = useState('');
-  const [manifestGroupOpen, setManifestGroupOpen] = useState<Record<string, boolean>>({});
+  const [manifestKeyByProject, setManifestKeyByProject] = useState<
+    Readonly<Partial<Record<ProjectId, string>>>
+  >({});
 
   const selectedProject =
     selectedProjectId == null ? null : (projectById.get(selectedProjectId) ?? null);
@@ -264,36 +274,31 @@ export const ScriptsPanel = ({ workspaceId, sessionId, hasHostHeading = false }:
       }),
     [list, matchesSearch, selectedProjectId],
   );
-  const selectedDiscoveredGroups = useMemo<ReadonlyArray<DiscoveredGroupEntry>>(() => {
+  const manifestGroups = useMemo<ReadonlyArray<ManifestScriptGroup>>(() => {
     if (selectedMount === null) {
       return [];
     }
-    const groups = [...(discoveredScripts?.[selectedMount.worktreePath] ?? [])].sort(
-      (left, right) => {
-        if (left.source !== right.source) {
-          return left.source === 'composer' ? 1 : -1;
-        }
-        const leftRoot = left.relDir === '';
-        const rightRoot = right.relDir === '';
-        if (leftRoot !== rightRoot) {
-          return leftRoot ? -1 : 1;
-        }
-        return left.relDir.localeCompare(right.relDir);
-      },
-    );
-    return groups.flatMap((group) => {
-      const matchingScripts = group.scripts.filter((script) => matchesSearch(script));
-      if (matchingScripts.length === 0) {
-        return [];
+    return [...(discoveredScripts?.[selectedMount.worktreePath] ?? [])].sort((left, right) => {
+      if (left.source !== right.source) {
+        return left.source === 'composer' ? 1 : -1;
       }
-      return [
-        {
-          group: { ...group, scripts: matchingScripts },
-          worktreePath: selectedMount.worktreePath,
-        },
-      ];
+      const leftRoot = left.relDir === '';
+      const rightRoot = right.relDir === '';
+      if (leftRoot !== rightRoot) {
+        return leftRoot ? -1 : 1;
+      }
+      return left.relDir.localeCompare(right.relDir);
     });
-  }, [discoveredScripts, matchesSearch, selectedMount]);
+  }, [discoveredScripts, selectedMount]);
+  const filteredManifestGroups = useMemo<ReadonlyArray<DiscoveredGroupEntry>>(() => {
+    if (selectedMount === null) {
+      return [];
+    }
+    return manifestGroups.map((group) => ({
+      group: { ...group, scripts: group.scripts.filter((script) => matchesSearch(script)) },
+      worktreePath: selectedMount.worktreePath,
+    }));
+  }, [manifestGroups, matchesSearch, selectedMount]);
   const userScriptsByProjectId = useMemo(() => {
     const index = new Map<ProjectId, Array<ProjectScript>>();
     for (const script of list) {
@@ -371,10 +376,46 @@ export const ScriptsPanel = ({ workspaceId, sessionId, hasHostHeading = false }:
       userScriptsByProjectId,
     ],
   );
-  const selectedManifestCount = selectedDiscoveredGroups.reduce(
+  const manifestEntries = useMemo<ReadonlyArray<ManifestRailEntry>>(() => {
+    if (selectedMount === null) {
+      return [];
+    }
+    return manifestGroups.map((group, index) => ({
+      key: manifestKey({ group }),
+      source: group.source,
+      packageName: group.packageName,
+      relDir: group.relDir,
+      manager: group.manager,
+      scriptCount: group.scripts.length,
+      matchCount: filteredManifestGroups[index]?.group.scripts.length ?? 0,
+      isRunning:
+        pendingScriptIds.size > 0 &&
+        group.scripts.some((script) =>
+          pendingScriptIds.has(
+            discoveredScriptId({
+              worktreePath: selectedMount.worktreePath,
+              source: group.source,
+              relDir: group.relDir,
+              name: script.name,
+            }),
+          ),
+        ),
+    }));
+  }, [filteredManifestGroups, manifestGroups, pendingScriptIds, selectedMount]);
+  const storedManifestKey = manifestKeyByProject[selectedProjectId ?? ('' as ProjectId)] ?? null;
+  const selectedManifestKey =
+    storedManifestKey !== null && manifestEntries.some((entry) => entry.key === storedManifestKey)
+      ? storedManifestKey
+      : (manifestEntries[0]?.key ?? null);
+  const visibleManifestGroups =
+    normalizedQuery === ''
+      ? filteredManifestGroups.filter((entry) => manifestKey(entry) === selectedManifestKey)
+      : filteredManifestGroups.filter((entry) => entry.group.scripts.length > 0);
+  const selectedManifestCount = filteredManifestGroups.reduce(
     (total, entry) => total + entry.group.scripts.length,
     0,
   );
+  const hasManifestRail = manifestEntries.length > 1;
   const selectedScan =
     selectedMount === null ? undefined : discoveredScriptScans?.[selectedMount.worktreePath];
   const isDiscoveryLoading =
@@ -650,6 +691,16 @@ export const ScriptsPanel = ({ workspaceId, sessionId, hasHostHeading = false }:
     setError(null);
   }, []);
 
+  const onSelectManifest = useCallback(
+    ({ key }: SelectManifestParams) => {
+      if (selectedProjectId === null) {
+        return;
+      }
+      setManifestKeyByProject((current) => ({ ...current, [selectedProjectId]: key }));
+    },
+    [selectedProjectId],
+  );
+
   const newScriptAction =
     workspaceProjects.length === 0 ? null : (
       <Button variant="ghost" size="sm" onClick={onOpenNew}>
@@ -849,7 +900,7 @@ export const ScriptsPanel = ({ workspaceId, sessionId, hasHostHeading = false }:
                 {!isDiscoveryLoading &&
                 discoveryError === null &&
                 selectedMount !== null &&
-                selectedDiscoveredGroups.length === 0 &&
+                manifestGroups.length === 0 &&
                 normalizedQuery === '' ? (
                   <p className="text-xs text-muted-foreground">No manifest scripts found.</p>
                 ) : null}
@@ -865,30 +916,34 @@ export const ScriptsPanel = ({ workspaceId, sessionId, hasHostHeading = false }:
                     </button>
                   </div>
                 ) : null}
-                {selectedDiscoveredGroups.map((entry) => {
-                  const groupKey = `${entry.worktreePath}:${entry.group.source}:${entry.group.relDir}`;
-                  const isRoot = entry.group.relDir === '';
-                  return (
-                    <DiscoveredScriptGroup
-                      key={groupKey}
-                      group={entry.group}
-                      worktreePath={entry.worktreePath}
-                      runs={runs}
-                      completedAt={completedAt}
-                      open={
-                        isRoot || normalizedQuery !== '' || (manifestGroupOpen[groupKey] ?? false)
-                      }
-                      onOpenChange={(open) => {
-                        if (isRoot || normalizedQuery !== '') {
-                          return;
-                        }
-                        setManifestGroupOpen((current) => ({ ...current, [groupKey]: open }));
-                      }}
-                      onRun={onRunDiscovered}
-                      onCancel={onCancelDiscovered}
-                    />
-                  );
-                })}
+                {visibleManifestGroups.length > 0 ? (
+                  <div className="flex min-w-0 items-start gap-4">
+                    {hasManifestRail && selectedManifestKey !== null ? (
+                      <ManifestRail
+                        entries={manifestEntries}
+                        selectedKey={selectedManifestKey}
+                        hasSearch={normalizedQuery !== ''}
+                        onSelect={(key) => onSelectManifest({ key })}
+                      />
+                    ) : null}
+                    <div className="flex min-w-0 flex-1 flex-col gap-5">
+                      {visibleManifestGroups.map((entry) => (
+                        <DiscoveredScriptGroup
+                          key={manifestKey(entry)}
+                          group={entry.group}
+                          worktreePath={entry.worktreePath}
+                          runs={runs}
+                          completedAt={completedAt}
+                          emptyLabel={
+                            normalizedQuery === '' ? 'No scripts in this manifest.' : null
+                          }
+                          onRun={onRunDiscovered}
+                          onCancel={onCancelDiscovered}
+                        />
+                      ))}
+                    </div>
+                  </div>
+                ) : null}
               </section>
             ) : null}
           </div>

--- a/apps/desktop/src/features/scripts/components/ScriptsPanel/index.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsPanel/index.tsx
@@ -402,7 +402,8 @@ export const ScriptsPanel = ({ workspaceId, sessionId, hasHostHeading = false }:
         ),
     }));
   }, [filteredManifestGroups, manifestGroups, pendingScriptIds, selectedMount]);
-  const storedManifestKey = manifestKeyByProject[selectedProjectId ?? ('' as ProjectId)] ?? null;
+  const storedManifestKey =
+    selectedProjectId === null ? null : (manifestKeyByProject[selectedProjectId] ?? null);
   const selectedManifestKey =
     storedManifestKey !== null && manifestEntries.some((entry) => entry.key === storedManifestKey)
       ? storedManifestKey
@@ -411,6 +412,11 @@ export const ScriptsPanel = ({ workspaceId, sessionId, hasHostHeading = false }:
     normalizedQuery === ''
       ? filteredManifestGroups.filter((entry) => manifestKey(entry) === selectedManifestKey)
       : filteredManifestGroups.filter((entry) => entry.group.scripts.length > 0);
+  const firstVisibleManifest = visibleManifestGroups[0] ?? null;
+  const railManifestKey =
+    normalizedQuery === '' || firstVisibleManifest === null
+      ? selectedManifestKey
+      : manifestKey(firstVisibleManifest);
   const selectedManifestCount = filteredManifestGroups.reduce(
     (total, entry) => total + entry.group.scripts.length,
     0,
@@ -918,10 +924,10 @@ export const ScriptsPanel = ({ workspaceId, sessionId, hasHostHeading = false }:
                 ) : null}
                 {visibleManifestGroups.length > 0 ? (
                   <div className="flex min-w-0 items-start gap-4">
-                    {hasManifestRail && selectedManifestKey !== null ? (
+                    {hasManifestRail && railManifestKey !== null ? (
                       <ManifestRail
                         entries={manifestEntries}
-                        selectedKey={selectedManifestKey}
+                        selectedKey={railManifestKey}
                         hasSearch={normalizedQuery !== ''}
                         onSelect={(key) => onSelectManifest({ key })}
                       />


### PR DESCRIPTION
## Why
With several `package.json` in a monorepo the Manifest scripts section became a stack of collapsibles: only the root open, every workspace package a fold to expand and scroll past. n-bro asked for a lateral, navigable selection.

## What
- `ManifestRail`: a second rail inside the Manifest scripts section, root first, bucketed by top-level folder (`apps`, `packages`) when there are two or more, each row with package name, folder or manager, script count, running dot. Hidden when the project has a single manifest.
- `DiscoveredScriptGroup` is now static (header + category groups), no collapsible.
- The selected manifest is remembered per project for the pane's lifetime.
- Search: every manifest with matches is listed; the rail shows match counts per manifest.

## Tests
- rail order and selection, per-project memory, single-manifest layout, search across manifests with counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)