### PR TITLE
feat(ui): inbox enter opens the launch dock, clear filters in the rail

### DIFF
--- a/apps/desktop/src/features/inbox/components/InboxStudio/InboxDetail.test.tsx
+++ b/apps/desktop/src/features/inbox/components/InboxStudio/InboxDetail.test.tsx
@@ -122,6 +122,7 @@ const renderDetail = (record: InboxRecord | null) =>
       errors={baseErrors}
       onRefresh={vi.fn()}
       onClose={vi.fn()}
+      launchFocusRequest={0}
       onClearFilters={vi.fn()}
       onOpenIntegrations={vi.fn()}
     />,

--- a/apps/desktop/src/features/inbox/components/InboxStudio/InboxDetail.tsx
+++ b/apps/desktop/src/features/inbox/components/InboxStudio/InboxDetail.tsx
@@ -24,6 +24,7 @@ type Props = {
   readonly onClose: () => void;
   readonly onClearFilters: () => void;
   readonly onOpenIntegrations: () => void;
+  readonly launchFocusRequest: number;
 };
 
 export const InboxDetail = ({
@@ -38,6 +39,7 @@ export const InboxDetail = ({
   onClose,
   onClearFilters,
   onOpenIntegrations,
+  launchFocusRequest,
 }: Props) => {
   const sentryIssueId = record?.payload.provider === 'sentry' ? record.payload.issue.id : null;
   const sentryDetail = useSentryIssueDetail({ workspaceId, issueId: sentryIssueId });
@@ -61,7 +63,14 @@ export const InboxDetail = ({
         <GithubIssueDetail
           issue={payload.issue}
           editContext={{ workspaceId, rootPath }}
-          dock={<RecordLaunchDock record={record} workspaceId={workspaceId} onClose={onClose} />}
+          dock={
+            <RecordLaunchDock
+              record={record}
+              workspaceId={workspaceId}
+              onClose={onClose}
+              focusRequest={launchFocusRequest}
+            />
+          }
         />
       );
     case 'gitlab':
@@ -72,7 +81,12 @@ export const InboxDetail = ({
               issue={payload.issue}
               workspaceId={workspaceId}
               dock={
-                <RecordLaunchDock record={record} workspaceId={workspaceId} onClose={onClose} />
+                <RecordLaunchDock
+                  record={record}
+                  workspaceId={workspaceId}
+                  onClose={onClose}
+                  focusRequest={launchFocusRequest}
+                />
               }
             />
           );
@@ -85,7 +99,12 @@ export const InboxDetail = ({
               onRefresh={onRefresh}
               onClose={onClose}
               dock={
-                <RecordLaunchDock record={record} workspaceId={workspaceId} onClose={onClose} />
+                <RecordLaunchDock
+                  record={record}
+                  workspaceId={workspaceId}
+                  onClose={onClose}
+                  focusRequest={launchFocusRequest}
+                />
               }
             />
           );
@@ -99,7 +118,14 @@ export const InboxDetail = ({
         <LinearIssueDetail
           issue={payload.issue}
           workspaceId={workspaceId}
-          dock={<RecordLaunchDock record={record} workspaceId={workspaceId} onClose={onClose} />}
+          dock={
+            <RecordLaunchDock
+              record={record}
+              workspaceId={workspaceId}
+              onClose={onClose}
+              focusRequest={launchFocusRequest}
+            />
+          }
         />
       );
     case 'jira':
@@ -108,7 +134,14 @@ export const InboxDetail = ({
           issue={payload.issue}
           workspaceId={workspaceId}
           onIssueWritten={onRefresh}
-          dock={<RecordLaunchDock record={record} workspaceId={workspaceId} onClose={onClose} />}
+          dock={
+            <RecordLaunchDock
+              record={record}
+              workspaceId={workspaceId}
+              onClose={onClose}
+              focusRequest={launchFocusRequest}
+            />
+          }
         />
       );
     case 'sentry':
@@ -130,7 +163,14 @@ export const InboxDetail = ({
           summaryIsLoading={false}
           summaryError={null}
           onRetrySummary={() => undefined}
-          dock={<RecordLaunchDock record={record} workspaceId={workspaceId} onClose={onClose} />}
+          dock={
+            <RecordLaunchDock
+              record={record}
+              workspaceId={workspaceId}
+              onClose={onClose}
+              focusRequest={launchFocusRequest}
+            />
+          }
         />
       );
     case 'slack':
@@ -142,7 +182,14 @@ export const InboxDetail = ({
           fallbackChannelName={payload.channel.name}
           fallbackMessage={payload.head}
           fallbackUrl={record.url}
-          dock={<RecordLaunchDock record={record} workspaceId={workspaceId} onClose={onClose} />}
+          dock={
+            <RecordLaunchDock
+              record={record}
+              workspaceId={workspaceId}
+              onClose={onClose}
+              focusRequest={launchFocusRequest}
+            />
+          }
         />
       );
     case 'bitbucket':
@@ -156,7 +203,14 @@ export const InboxDetail = ({
           error={errors.bitbucket}
           onRefresh={onRefresh}
           onClose={onClose}
-          dock={<RecordLaunchDock record={record} workspaceId={workspaceId} onClose={onClose} />}
+          dock={
+            <RecordLaunchDock
+              record={record}
+              workspaceId={workspaceId}
+              onClose={onClose}
+              focusRequest={launchFocusRequest}
+            />
+          }
         />
       );
     default: {

--- a/apps/desktop/src/features/inbox/components/InboxStudio/InboxRail.test.tsx
+++ b/apps/desktop/src/features/inbox/components/InboxStudio/InboxRail.test.tsx
@@ -202,11 +202,13 @@ describe('InboxRail', () => {
     expect(onActivate).not.toHaveBeenCalled();
   });
 
-  it('offers to clear filters from the rail once a provider is selected', () => {
+  it('offers to clear filters from the rail only once a filter is active', () => {
     const onClearFilters = vi.fn();
+    const view = renderRail({ onClearFilters });
     expect(screen.queryByRole('button', { name: 'Clear filters' })).toBeNull();
-    renderRail({ selectedProviders: new Set<InboxProvider>(['github']), onClearFilters });
+    view.unmount();
 
+    renderRail({ selectedProviders: new Set<InboxProvider>(['github']), onClearFilters });
     fireEvent.click(screen.getByRole('button', { name: 'Clear filters' }));
 
     expect(onClearFilters).toHaveBeenCalledTimes(1);

--- a/apps/desktop/src/features/inbox/components/InboxStudio/InboxRail.test.tsx
+++ b/apps/desktop/src/features/inbox/components/InboxStudio/InboxRail.test.tsx
@@ -75,6 +75,8 @@ type RenderParams = {
   readonly selectedProviders?: ReadonlySet<InboxProvider>;
   readonly selectedKey?: string | null;
   readonly onSelect?: (record: InboxRecord) => void;
+  readonly onActivate?: (record: InboxRecord) => void;
+  readonly onClearFilters?: () => void;
   readonly onToggleProvider?: (provider: InboxProvider) => void;
 };
 
@@ -82,6 +84,8 @@ const renderRail = ({
   selectedProviders = new Set<InboxProvider>(),
   selectedKey = null,
   onSelect = vi.fn(),
+  onActivate = vi.fn(),
+  onClearFilters = vi.fn(),
   onToggleProvider = vi.fn(),
 }: RenderParams = {}) =>
   render(
@@ -96,6 +100,8 @@ const renderRail = ({
       onKindFilterChange={vi.fn()}
       selectedKey={selectedKey}
       onSelect={onSelect}
+      onActivate={onActivate}
+      onClearFilters={onClearFilters}
       isLoading={false}
       errors={[]}
       onRefresh={vi.fn()}
@@ -173,6 +179,37 @@ describe('InboxRail', () => {
 
     fireEvent.keyDown(list, { key: 'Home' });
     expect(onSelect).toHaveBeenLastCalledWith(todayRecord);
+  });
+
+  it('activates the selected record on Enter', () => {
+    const onActivate = vi.fn();
+    const onSelect = vi.fn();
+    renderRail({ selectedKey: 'b', onActivate, onSelect });
+
+    fireEvent.keyDown(screen.getByRole('listbox', { name: 'Inbox items' }), { key: 'Enter' });
+
+    expect(onActivate).toHaveBeenCalledTimes(1);
+    expect(onActivate.mock.calls[0]?.[0]?.key).toBe('b');
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('ignores Enter when nothing is selected', () => {
+    const onActivate = vi.fn();
+    renderRail({ selectedKey: null, onActivate });
+
+    fireEvent.keyDown(screen.getByRole('listbox', { name: 'Inbox items' }), { key: 'Enter' });
+
+    expect(onActivate).not.toHaveBeenCalled();
+  });
+
+  it('offers to clear filters from the rail once a provider is selected', () => {
+    const onClearFilters = vi.fn();
+    expect(screen.queryByRole('button', { name: 'Clear filters' })).toBeNull();
+    renderRail({ selectedProviders: new Set<InboxProvider>(['github']), onClearFilters });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear filters' }));
+
+    expect(onClearFilters).toHaveBeenCalledTimes(1);
   });
 
   it('keeps the list focusable and hints at keyboard navigation', () => {

--- a/apps/desktop/src/features/inbox/components/InboxStudio/InboxRail.tsx
+++ b/apps/desktop/src/features/inbox/components/InboxStudio/InboxRail.tsx
@@ -61,6 +61,8 @@ type Props = {
   readonly onKindFilterChange: (value: InboxKindFilter) => void;
   readonly selectedKey: string | null;
   readonly onSelect: (record: InboxRecord) => void;
+  readonly onActivate: (record: InboxRecord) => void;
+  readonly onClearFilters: () => void;
   readonly isLoading: boolean;
   readonly errors: ReadonlyArray<ErrorEntry>;
   readonly onRefresh: () => void;
@@ -71,6 +73,7 @@ type ListKeyDownParams = {
   readonly orderedRecords: ReadonlyArray<InboxRecord>;
   readonly selectedKey: string | null;
   readonly onSelect: (record: InboxRecord) => void;
+  readonly onActivate: (record: InboxRecord) => void;
 };
 
 const handleListKeyDown = ({
@@ -78,11 +81,21 @@ const handleListKeyDown = ({
   orderedRecords,
   selectedKey,
   onSelect,
+  onActivate,
 }: ListKeyDownParams): void => {
   if (orderedRecords.length === 0) {
     return;
   }
   const selectedIndex = orderedRecords.findIndex((record) => record.key === selectedKey);
+  if (event.key === 'Enter') {
+    const selectedRecord = selectedIndex < 0 ? null : (orderedRecords[selectedIndex] ?? null);
+    if (selectedRecord == null) {
+      return;
+    }
+    event.preventDefault();
+    onActivate(selectedRecord);
+    return;
+  }
   const lastIndex = orderedRecords.length - 1;
   const nextIndex = ((): number | null => {
     if (event.key === 'ArrowDown') {
@@ -121,6 +134,8 @@ export const InboxRail = ({
   onKindFilterChange,
   selectedKey,
   onSelect,
+  onActivate,
+  onClearFilters,
   isLoading,
   errors,
   onRefresh,
@@ -208,6 +223,17 @@ export const InboxRail = ({
         <div className="flex items-center gap-1.5 text-3xs text-muted-foreground/60">
           <KbdPill className="h-4 min-w-4 text-3xs">↑↓</KbdPill>
           <span>navigate</span>
+          <KbdPill className="h-4 min-w-4 text-3xs">↵</KbdPill>
+          <span>launch</span>
+          {hasFiltersActive ? (
+            <button
+              type="button"
+              onClick={onClearFilters}
+              className="ml-auto text-2xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--color-focus-ring)]"
+            >
+              Clear filters
+            </button>
+          ) : null}
         </div>
       </div>
 
@@ -256,7 +282,7 @@ export const InboxRail = ({
               }
               className="flex flex-col gap-0.5 rounded-md focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/40"
               onKeyDown={(event) =>
-                handleListKeyDown({ event, orderedRecords, selectedKey, onSelect })
+                handleListKeyDown({ event, orderedRecords, selectedKey, onSelect, onActivate })
               }
             >
               {sections.map((section) => (

--- a/apps/desktop/src/features/inbox/components/InboxStudio/InboxRail.tsx
+++ b/apps/desktop/src/features/inbox/components/InboxStudio/InboxRail.tsx
@@ -220,16 +220,18 @@ export const InboxRail = ({
             })}
           </div>
         ) : null}
-        <div className="flex items-center gap-1.5 text-3xs text-muted-foreground/60">
-          <KbdPill className="h-4 min-w-4 text-3xs">↑↓</KbdPill>
-          <span>navigate</span>
-          <KbdPill className="h-4 min-w-4 text-3xs">↵</KbdPill>
-          <span>launch</span>
+        <div className="flex items-center justify-between gap-2 text-3xs text-muted-foreground/60">
+          <span className="flex items-center gap-1.5">
+            <KbdPill className="h-4 min-w-4 text-3xs">↑↓</KbdPill>
+            <span>navigate</span>
+            <KbdPill className="h-4 min-w-4 text-3xs">↵</KbdPill>
+            <span>launch</span>
+          </span>
           {hasFiltersActive ? (
             <button
               type="button"
               onClick={onClearFilters}
-              className="ml-auto text-2xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--color-focus-ring)]"
+              className="text-2xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--color-focus-ring)]"
             >
               Clear filters
             </button>

--- a/apps/desktop/src/features/inbox/components/InboxStudio/index.tsx
+++ b/apps/desktop/src/features/inbox/components/InboxStudio/index.tsx
@@ -108,8 +108,15 @@ export const InboxStudio = ({
     [records, selectedKey],
   );
 
+  const [launchFocusRequest, setLaunchFocusRequest] = useState(0);
+
   const onSelect = (record: InboxRecord): void => {
     setSelectedKey(record.key);
+  };
+
+  const onActivate = (record: InboxRecord): void => {
+    setSelectedKey(record.key);
+    setLaunchFocusRequest((current) => current + 1);
   };
 
   const onToggleProvider = (provider: InboxProvider): void => {
@@ -173,6 +180,8 @@ export const InboxStudio = ({
               onKindFilterChange={setKindFilter}
               selectedKey={selectedKey}
               onSelect={onSelect}
+              onActivate={onActivate}
+              onClearFilters={onClearFilters}
               isLoading={isLoading}
               errors={INBOX_PROVIDERS.flatMap((provider) => {
                 const message = errors[provider];
@@ -194,6 +203,7 @@ export const InboxStudio = ({
               onClose={requestClose}
               onClearFilters={onClearFilters}
               onOpenIntegrations={onOpenIntegrations}
+              launchFocusRequest={launchFocusRequest}
             />
           }
         />

--- a/apps/desktop/src/features/inbox/components/RecordLaunchDock/index.tsx
+++ b/apps/desktop/src/features/inbox/components/RecordLaunchDock/index.tsx
@@ -22,9 +22,10 @@ type Props = {
   readonly record: InboxRecord;
   readonly workspaceId: WorkspaceId;
   readonly onClose: () => void;
+  readonly focusRequest?: number;
 };
 
-export const RecordLaunchDock = ({ record, workspaceId, onClose }: Props) => {
+export const RecordLaunchDock = ({ record, workspaceId, onClose, focusRequest }: Props) => {
   const payload = record.payload;
 
   switch (payload.provider) {
@@ -42,6 +43,7 @@ export const RecordLaunchDock = ({ record, workspaceId, onClose }: Props) => {
             title: payload.issue.title,
           }}
           onClose={onClose}
+          focusRequest={focusRequest}
         />
       );
     case 'gitlab':
@@ -60,6 +62,7 @@ export const RecordLaunchDock = ({ record, workspaceId, onClose }: Props) => {
                 title: payload.issue.title,
               }}
               onClose={onClose}
+              focusRequest={focusRequest}
             />
           );
         case 'mr':
@@ -76,6 +79,7 @@ export const RecordLaunchDock = ({ record, workspaceId, onClose }: Props) => {
                 title: payload.mr.title,
               }}
               onClose={onClose}
+              focusRequest={focusRequest}
             />
           );
         default: {
@@ -97,6 +101,7 @@ export const RecordLaunchDock = ({ record, workspaceId, onClose }: Props) => {
             title: payload.issue.title,
           }}
           onClose={onClose}
+          focusRequest={focusRequest}
         />
       );
     case 'jira':
@@ -113,6 +118,7 @@ export const RecordLaunchDock = ({ record, workspaceId, onClose }: Props) => {
             title: payload.issue.summary,
           }}
           onClose={onClose}
+          focusRequest={focusRequest}
         />
       );
     case 'sentry':
@@ -129,6 +135,7 @@ export const RecordLaunchDock = ({ record, workspaceId, onClose }: Props) => {
             title: payload.issue.title,
           }}
           onClose={onClose}
+          focusRequest={focusRequest}
         />
       );
     case 'slack': {
@@ -149,6 +156,7 @@ export const RecordLaunchDock = ({ record, workspaceId, onClose }: Props) => {
             title: slackThreadTitle({ text: payload.head.text }),
           }}
           onClose={onClose}
+          focusRequest={focusRequest}
         />
       );
     }
@@ -173,6 +181,7 @@ export const RecordLaunchDock = ({ record, workspaceId, onClose }: Props) => {
             title: payload.pullRequest.title,
           }}
           onClose={onClose}
+          focusRequest={focusRequest}
         />
       );
     }

--- a/apps/desktop/src/features/integrations/components/LaunchSessionPanel/index.tsx
+++ b/apps/desktop/src/features/integrations/components/LaunchSessionPanel/index.tsx
@@ -20,6 +20,7 @@ type Props = {
   readonly goalSeed: string;
   readonly externalTask: ExternalTask;
   readonly onClose: () => void;
+  readonly focusRequest?: number;
 };
 
 export const LaunchSessionPanel = ({
@@ -28,6 +29,7 @@ export const LaunchSessionPanel = ({
   goalSeed,
   externalTask,
   onClose,
+  focusRequest = 0,
 }: Props) => {
   const createSession = useAppStore((state) => state.createSession);
   const { showToast } = useToast();
@@ -35,6 +37,15 @@ export const LaunchSessionPanel = ({
   const [isBusy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const goalSeedRef = useRef(goalSeed);
+  const sectionRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (focusRequest === 0) {
+      return;
+    }
+    const goalField = sectionRef.current?.querySelector('textarea') ?? null;
+    goalField?.focus();
+  }, [focusRequest]);
 
   useEffect(() => {
     const previousSeed = goalSeedRef.current;
@@ -79,6 +90,7 @@ export const LaunchSessionPanel = ({
 
   return (
     <section
+      ref={sectionRef}
       aria-label="Launch session"
       className="flex flex-col gap-1 rounded-md bg-subtle/80 p-2 ring-1 ring-border-soft motion-safe:transition-shadow focus-within:ring-2 focus-within:ring-primary/40"
     >


### PR DESCRIPTION
## Why
Two leftovers from the inbox rework (#1642): the list had no keyboard path into the launch dock, and Clear filters only existed in the empty detail summary.

## What
- Enter on the selected row activates it: the studio bumps a `launchFocusRequest` counter that `LaunchSessionPanel` turns into focus on its goal field. Cmd/Ctrl+Enter there still creates the session. Benchmark: Linear and Gmail lists open the item on Enter and keep the committing action behind its own shortcut.
- Keyboard hint reads `↑↓ navigate ↵ launch`.
- `Clear filters` sits at the end of the hint row whenever a query, kind or provider filter is active.

## Tests
- rail: Enter activates the selected record, no-op with nothing selected, Clear filters appears with an active provider filter and calls back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)