### PR TITLE
perf(desktop): load studios and the diff viewer on first open

### DIFF
--- a/apps/desktop/src/__tests__/footer-studio-reachability.test.tsx
+++ b/apps/desktop/src/__tests__/footer-studio-reachability.test.tsx
@@ -254,14 +254,14 @@ afterEach(() => {
 });
 
 describe('Slack studio reachability', () => {
-  it('opens the workspace slack studio from the app footer', () => {
+  it('opens the workspace slack studio from the app footer', async () => {
     state.workspaceIntegrations = { 'workspace-1': [{ provider: 'slack' }] };
     render(<App />);
 
     expect(screen.queryByTestId('inbox-studio')).toBeNull();
     fireEvent.click(screen.getByRole('button', { name: 'Launch a session from a Slack thread' }));
 
-    expect(screen.getByTestId('inbox-studio').textContent).toBe('Workspace:slack');
+    expect((await screen.findByTestId('inbox-studio')).textContent).toBe('Workspace:slack');
   });
 
   it('still opens the studio when slack is not connected, so the connect form is reachable', () => {
@@ -312,19 +312,21 @@ describe('Provider studio reachability from the command palette', () => {
     expect(screen.getByRole('button', { name: 'Connect a provider' })).toBeDefined();
   });
 
-  it('opens the provider studio when the palette entry is chosen', () => {
+  it('opens the provider studio when the palette entry is chosen', async () => {
     render(<App />);
     openPalette();
 
     expect(screen.queryByTestId('settings-studio')).toBeNull();
     fireEvent.click(screen.getByRole('button', { name: 'Connect a provider' }));
 
-    expect(screen.getByTestId('settings-studio').getAttribute('data-scope')).toBe('providers');
+    expect((await screen.findByTestId('settings-studio')).getAttribute('data-scope')).toBe(
+      'providers',
+    );
   });
 });
 
 describe('Report issue studio reachability', () => {
-  it('mounts the studio when the shared open event fires', () => {
+  it('mounts the studio when the shared open event fires', async () => {
     render(<App />);
 
     expect(screen.queryByTestId('report-issue-studio')).toBeNull();
@@ -332,7 +334,7 @@ describe('Report issue studio reachability', () => {
       window.dispatchEvent(new CustomEvent(REPORT_ISSUE_STUDIO_EVENT));
     });
 
-    expect(screen.getByTestId('report-issue-studio')).toBeDefined();
+    expect(await screen.findByTestId('report-issue-studio')).toBeDefined();
   });
 
   it('closes the settings studio when the report studio takes over', () => {
@@ -390,22 +392,22 @@ describe('Footer to settings and more-popover reachability', () => {
     expect(screen.getByTestId('settings-studio').getAttribute('data-scope')).toBe('budget');
   });
 
-  it('opens impact from the footer more popover', () => {
+  it('opens impact from the footer more popover', async () => {
     render(<App />);
 
     expect(screen.queryByTestId('impact-studio')).toBeNull();
     fireEvent.click(screen.getByRole('button', { name: 'Open impact' }));
 
-    expect(screen.getByTestId('impact-studio').textContent).toBe('Workspace');
+    expect((await screen.findByTestId('impact-studio')).textContent).toBe('Workspace');
   });
 
-  it('opens changelog from the footer more popover', () => {
+  it('opens changelog from the footer more popover', async () => {
     render(<App />);
 
     expect(screen.queryByTestId('changelog-studio')).toBeNull();
     fireEvent.click(screen.getByRole('button', { name: 'Open changelog' }));
 
-    expect(screen.getByTestId('changelog-studio').textContent).toBe('Workspace');
+    expect((await screen.findByTestId('changelog-studio')).textContent).toBe('Workspace');
   });
 });
 

--- a/apps/desktop/src/app/components/AppOverlayRouter/index.tsx
+++ b/apps/desktop/src/app/components/AppOverlayRouter/index.tsx
@@ -1,24 +1,70 @@
+import { Suspense, lazy } from 'react';
 import type { Session, SessionId, Workspace } from '@goodboy/types';
 import type { InboxKind, InboxProvider } from '../../../features/inbox/types';
 import { ArchiveSessionConfirm } from '../../../features/session/components/ArchiveSessionConfirm';
 import { CommandPalette } from '../../../features/session/components/CommandPalette';
 import { DeleteSessionConfirm } from '../../../features/session/components/DeleteSessionConfirm';
-import { SettingsStudio } from '../../../features/settings/components/SettingsStudio';
-import { GuideStudio } from '../../../features/settings/components/GuideStudio';
-import { ReportIssueStudio } from '../../../features/settings/components/ReportIssueStudio';
-import { WorkspaceLinkStudio } from '../../../features/workspace/components/WorkspaceLinkStudio';
 import { ConvertWorkspaceDialog } from '../../../features/workspace/components/ConvertWorkspaceDialog';
 import { WorkspaceLauncher } from '../../../features/workspace/components/WorkspaceLauncher';
-import { WorkflowStudio } from '../../../features/workflows/components/WorkflowStudio';
-import { InboxStudio } from '../../../features/inbox/components/InboxStudio';
 import type { SettingsFocus } from '../../../features/settings/components/SettingsStudio/types';
-import { ImpactStudio } from '../../../features/impact/components/ImpactStudio';
-import { ChangelogStudio } from '../../../features/changelog/components/ChangelogStudio';
-import { NotificationsStudio } from '../../../features/notifications/components/NotificationsStudio';
-import { DiffViewerDialog } from '../../../features/permissions/components/DiffViewerDialog';
 import { OnboardingWizard } from '../../../features/onboarding/OnboardingWizard';
-import { CompanionStudio } from '../../../features/companion/CompanionStudio';
 import type { CommitDiffTarget } from '../../../shared/hooks/useCommitLinkInterceptor';
+
+const SettingsStudio = lazy(() =>
+  import('../../../features/settings/components/SettingsStudio').then((module) => ({
+    default: module.SettingsStudio,
+  })),
+);
+const GuideStudio = lazy(() =>
+  import('../../../features/settings/components/GuideStudio').then((module) => ({
+    default: module.GuideStudio,
+  })),
+);
+const ReportIssueStudio = lazy(() =>
+  import('../../../features/settings/components/ReportIssueStudio').then((module) => ({
+    default: module.ReportIssueStudio,
+  })),
+);
+const WorkspaceLinkStudio = lazy(() =>
+  import('../../../features/workspace/components/WorkspaceLinkStudio').then((module) => ({
+    default: module.WorkspaceLinkStudio,
+  })),
+);
+const WorkflowStudio = lazy(() =>
+  import('../../../features/workflows/components/WorkflowStudio').then((module) => ({
+    default: module.WorkflowStudio,
+  })),
+);
+const InboxStudio = lazy(() =>
+  import('../../../features/inbox/components/InboxStudio').then((module) => ({
+    default: module.InboxStudio,
+  })),
+);
+const ImpactStudio = lazy(() =>
+  import('../../../features/impact/components/ImpactStudio').then((module) => ({
+    default: module.ImpactStudio,
+  })),
+);
+const ChangelogStudio = lazy(() =>
+  import('../../../features/changelog/components/ChangelogStudio').then((module) => ({
+    default: module.ChangelogStudio,
+  })),
+);
+const NotificationsStudio = lazy(() =>
+  import('../../../features/notifications/components/NotificationsStudio').then((module) => ({
+    default: module.NotificationsStudio,
+  })),
+);
+const DiffViewerDialog = lazy(() =>
+  import('../../../features/permissions/components/DiffViewerDialog').then((module) => ({
+    default: module.DiffViewerDialog,
+  })),
+);
+const CompanionStudio = lazy(() =>
+  import('../../../features/companion/CompanionStudio').then((module) => ({
+    default: module.CompanionStudio,
+  })),
+);
 
 type Props = {
   readonly currentWorkspace: Workspace | null;
@@ -122,11 +168,11 @@ export const AppOverlayRouter = ({
   ) : null;
 
   if (isWorkspaceLauncherBranch) {
-    return addWorkspaceSurface ?? <WorkspaceLauncher />;
+    return <Suspense fallback={null}>{addWorkspaceSurface ?? <WorkspaceLauncher />}</Suspense>;
   }
 
   return (
-    <>
+    <Suspense fallback={null}>
       {settingsOpen ? (
         <SettingsStudio
           currentWorkspace={currentWorkspace}
@@ -208,6 +254,6 @@ export const AppOverlayRouter = ({
       ) : null}
       {companionOpen ? <CompanionStudio onClose={closeCompanion} /> : null}
       <OnboardingWizard />
-    </>
+    </Suspense>
   );
 };


### PR DESCRIPTION
## Why
Round 5 foundations: code splitting. `AppOverlayRouter` imported ten full-page studios plus the diff viewer eagerly, so they all sat in the single 3 MB boot chunk although most sessions never open half of them.

## What
- `SettingsStudio`, `GuideStudio`, `ReportIssueStudio`, `WorkspaceLinkStudio`, `WorkflowStudio`, `InboxStudio`, `ImpactStudio`, `ChangelogStudio`, `NotificationsStudio`, `CompanionStudio` and `DiffViewerDialog` are `React.lazy` in the router, both return paths wrapped in `Suspense` with a null fallback (chunks are local files inside the Tauri bundle, the gap is a few ms).
- The single-entrance guard for the notifications studio still sees `<NotificationsStudio` only in the router.

## Measured (vite build)
| | boot chunk(s) | chunks |
|---|---|---|
| before | 3019 kB | 1 |
| after | 1282 kB store + 1091 kB index + 130 kB + 107 kB ≈ 2610 kB | 46 |

Largest lazy chunks: SettingsStudio 83 kB, DiffViewerDialog 51 kB, ImpactStudio 34 kB, InboxStudio 28 kB, WorkflowStudio 28 kB. The 1.28 MB store chunk is the next target.

## Verification
- typecheck clean, regression guards + app tests green, knip production clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)