### PR TITLE
perf(desktop): load xterm only when a terminal mounts

### DIFF
--- a/apps/desktop/src/features/providers/components/ProviderLifecycleTile/InlineTerminal.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderLifecycleTile/InlineTerminal.tsx
@@ -1,8 +1,8 @@
 import { useMemo } from 'react';
 import {
-  GenericTerminalPanel,
+  LazyGenericTerminalPanel,
   type TerminalDriver,
-} from '../../../../shared/components/GenericTerminalPanel';
+} from '../../../../shared/components/GenericTerminalPanel/LazyGenericTerminalPanel';
 import {
   invokeProviderLifecycleResize,
   invokeProviderLifecycleWrite,
@@ -65,7 +65,12 @@ export const InlineTerminal = ({ runId, isActive, heightClass = 'h-44' }: Props)
     <div
       className={`${heightClass} overflow-hidden rounded-md border border-border-soft bg-background`}
     >
-      <GenericTerminalPanel terminalId={runId} driver={driver} isActive={isActive} exitMessage="" />
+      <LazyGenericTerminalPanel
+        terminalId={runId}
+        driver={driver}
+        isActive={isActive}
+        exitMessage=""
+      />
     </div>
   );
 };

--- a/apps/desktop/src/features/terminal/closeTab.ts
+++ b/apps/desktop/src/features/terminal/closeTab.ts
@@ -1,4 +1,4 @@
-import { clearTerminalCache } from '../../shared/components/GenericTerminalPanel';
+import { clearTerminalCache } from '../../shared/components/GenericTerminalPanel/outputCache';
 import type { TerminalTabId } from '../../shared/types/terminal';
 import { invokeTerminalClose } from './terminal';
 

--- a/apps/desktop/src/features/terminal/components/TerminalDock/index.test.tsx
+++ b/apps/desktop/src/features/terminal/components/TerminalDock/index.test.tsx
@@ -28,8 +28,8 @@ vi.mock('../../../../store', () => ({
   useAppStore: <T,>(selector: (s: typeof state) => T) => selector(state),
 }));
 
-vi.mock('../../../../shared/components/GenericTerminalPanel', () => ({
-  GenericTerminalPanel: () => null,
+vi.mock('../../../../shared/components/GenericTerminalPanel/LazyGenericTerminalPanel', () => ({
+  LazyGenericTerminalPanel: () => null,
 }));
 
 vi.mock('../../terminal', () => ({

--- a/apps/desktop/src/features/terminal/components/TerminalDock/index.tsx
+++ b/apps/desktop/src/features/terminal/components/TerminalDock/index.tsx
@@ -6,9 +6,9 @@ import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../shared/components/conce
 import { LensEmptyState } from '@goodboy/ui';
 import { PaneShell } from '../../../../shared/components/PaneShell';
 import {
-  GenericTerminalPanel,
+  LazyGenericTerminalPanel,
   type TerminalDriver,
-} from '../../../../shared/components/GenericTerminalPanel';
+} from '../../../../shared/components/GenericTerminalPanel/LazyGenericTerminalPanel';
 import { currentPlatform } from '../../../../shared/platform';
 import type { TerminalTabId } from '../../../../shared/types/terminal';
 import {
@@ -159,7 +159,7 @@ export const TerminalDock = ({ sessionId, isActive, cwd }: Props) => {
       <Divider />
       <div className="relative min-h-0 flex-1">
         {activeTab ? (
-          <GenericTerminalPanel
+          <LazyGenericTerminalPanel
             key={activeTab.id}
             terminalId={activeTab.id}
             driver={driver}

--- a/apps/desktop/src/shared/components/GenericTerminalPanel/LazyGenericTerminalPanel.tsx
+++ b/apps/desktop/src/shared/components/GenericTerminalPanel/LazyGenericTerminalPanel.tsx
@@ -1,0 +1,17 @@
+import { Suspense, lazy } from 'react';
+import type { ComponentProps } from 'react';
+import type { GenericTerminalPanel } from './index';
+
+const Panel = lazy(() =>
+  import('./index').then((module) => ({ default: module.GenericTerminalPanel })),
+);
+
+type Props = ComponentProps<typeof GenericTerminalPanel>;
+
+export const LazyGenericTerminalPanel = (props: Props) => (
+  <Suspense fallback={<div className="h-full w-full bg-background" aria-hidden />}>
+    <Panel {...props} />
+  </Suspense>
+);
+
+export type { TerminalDriver } from './index';

--- a/apps/desktop/src/shared/components/GenericTerminalPanel/LazyGenericTerminalPanel.tsx
+++ b/apps/desktop/src/shared/components/GenericTerminalPanel/LazyGenericTerminalPanel.tsx
@@ -1,12 +1,11 @@
 import { Suspense, lazy } from 'react';
 import type { ComponentProps } from 'react';
-import type { GenericTerminalPanel } from './index';
 
 const Panel = lazy(() =>
   import('./index').then((module) => ({ default: module.GenericTerminalPanel })),
 );
 
-type Props = ComponentProps<typeof GenericTerminalPanel>;
+type Props = ComponentProps<typeof Panel>;
 
 export const LazyGenericTerminalPanel = (props: Props) => (
   <Suspense fallback={<div className="h-full w-full bg-background" aria-hidden />}>

--- a/apps/desktop/src/shared/components/GenericTerminalPanel/index.tsx
+++ b/apps/desktop/src/shared/components/GenericTerminalPanel/index.tsx
@@ -10,6 +10,7 @@ import { RotateCcw } from 'lucide-react';
 import { useThemeStore } from '../../lib/theme';
 import { openUrl } from '../../lib/editor';
 import { resolveTerminalTheme } from './terminal-theme';
+import { MAX_CACHE_CHUNKS, outputCache } from './outputCache';
 import { Tooltip } from '@goodboy/ui';
 
 export type TerminalDriver = {
@@ -17,14 +18,6 @@ export type TerminalDriver = {
   resize(cols: number, rows: number): void;
   onOutput(handler: (bytes: Uint8Array) => void): Promise<() => void>;
   onExit(handler: (exitCode: number) => void): Promise<() => void>;
-};
-
-const MAX_CACHE_CHUNKS = 500;
-
-const outputCache = new Map<string, Uint8Array[]>();
-
-export const clearTerminalCache = (terminalId: string): void => {
-  outputCache.delete(terminalId);
 };
 
 type Props = {

--- a/apps/desktop/src/shared/components/GenericTerminalPanel/outputCache.ts
+++ b/apps/desktop/src/shared/components/GenericTerminalPanel/outputCache.ts
@@ -1,0 +1,7 @@
+export const MAX_CACHE_CHUNKS = 500;
+
+export const outputCache = new Map<string, Uint8Array[]>();
+
+export const clearTerminalCache = (terminalId: string): void => {
+  outputCache.delete(terminalId);
+};

--- a/apps/desktop/src/store/slices/terminal/closeSessionTerminals.ts
+++ b/apps/desktop/src/store/slices/terminal/closeSessionTerminals.ts
@@ -1,6 +1,6 @@
 import type { SessionId } from '@goodboy/types';
 import { invokeTerminalClose } from '../../../features/terminal/terminal';
-import { clearTerminalCache } from '../../../shared/components/GenericTerminalPanel';
+import { clearTerminalCache } from '../../../shared/components/GenericTerminalPanel/outputCache';
 import type { SetFn, GetFn } from './types';
 
 export const closeSessionTerminals = (set: SetFn, get: GetFn) => {

--- a/apps/desktop/src/store/slices/terminal/closeTerminalTab.ts
+++ b/apps/desktop/src/store/slices/terminal/closeTerminalTab.ts
@@ -1,6 +1,6 @@
 import type { SessionId } from '@goodboy/types';
 import { invokeTerminalClose } from '../../../features/terminal/terminal';
-import { clearTerminalCache } from '../../../shared/components/GenericTerminalPanel';
+import { clearTerminalCache } from '../../../shared/components/GenericTerminalPanel/outputCache';
 import type { TerminalTabId } from '../../../shared/types/terminal';
 import type { GetFn, SetFn } from './types';
 

--- a/apps/desktop/src/store/slices/terminal/index.test.ts
+++ b/apps/desktop/src/store/slices/terminal/index.test.ts
@@ -349,7 +349,7 @@ vi.mock('../../../features/terminal/terminal', () => ({
   invokeTerminalResize: vi.fn(async () => undefined),
 }));
 
-vi.mock('../../../shared/components/GenericTerminalPanel', () => ({
+vi.mock('../../../shared/components/GenericTerminalPanel/outputCache', () => ({
   clearTerminalCache: vi.fn(() => undefined),
 }));
 


### PR DESCRIPTION
## Why
Round 5 foundations, follow-up to #1654. The Zustand store imported `clearTerminalCache` from `GenericTerminalPanel/index.tsx`, which imports `@xterm/xterm` and five addons, so the terminal (about 500 kB minified plus its css) shipped in the boot bundle for every window, terminal or not.

## What
- `GenericTerminalPanel/outputCache.ts` holds the output cache and `clearTerminalCache`; the store slices and `closeTab` import from there.
- `LazyGenericTerminalPanel` wraps the panel in `React.lazy` + `Suspense` (plain background fallback) and re-exports `TerminalDriver`; the terminal dock and the provider inline terminal render it.
- Test mocks follow the new module paths.

## Measured (vite build, main without #1654)
| chunk | before | after |
|---|---|---|
| boot `index-*.js` | 3092 kB (gzip 817) | 2591 kB (gzip 683) |
| `GenericTerminalPanel-*.js` (lazy) | – | 500 kB (gzip 134) |
| boot css | 140 kB | 136 kB, xterm css lazy (3.5 kB) |

Stacks with #1654 (studios lazy): together roughly 900 kB off the boot chunk.

## Verification
- typecheck clean, terminal + store + provider tests green, regression guards green, knip production clean, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)