### PR TITLE
feat(ui): session eyebrow above every lens title

### DIFF
--- a/apps/desktop/src/features/explore/components/ExplorePane/index.tsx
+++ b/apps/desktop/src/features/explore/components/ExplorePane/index.tsx
@@ -36,6 +36,7 @@ const KNOWN_UNSUPPORTED_PREVIEW_EXTENSIONS = new Set([
 type Props = {
   readonly sessionId: SessionId;
   readonly sessionDir: string | null;
+  readonly eyebrow?: ReactNode;
 };
 
 type RenderEntriesParams = {
@@ -112,7 +113,7 @@ const isKnownUnsupportedPreviewExtension = ({
   return KNOWN_UNSUPPORTED_PREVIEW_EXTENSIONS.has(extensionOf({ fileName }));
 };
 
-export const ExplorePane = ({ sessionId, sessionDir }: Props) => {
+export const ExplorePane = ({ sessionId, sessionDir, eyebrow }: Props) => {
   const [entriesByPath, setEntriesByPath] = useState<
     Readonly<Record<string, ReadonlyArray<ExploreEntry>>>
   >({});
@@ -412,7 +413,7 @@ export const ExplorePane = ({ sessionId, sessionDir }: Props) => {
         ) : null
       }
     >
-      <PaneShell title="Explore" description="Browse the files for this session.">
+      <PaneShell title="Explore" description="Browse the files for this session." eyebrow={eyebrow}>
         <div className="flex flex-col gap-3">
           {rootLoading ? (
             <>

--- a/apps/desktop/src/features/github/GithubIssueDetail/index.tsx
+++ b/apps/desktop/src/features/github/GithubIssueDetail/index.tsx
@@ -23,6 +23,7 @@ type Props = {
   readonly dock?: ReactNode;
   readonly fit?: Fit;
   readonly editContext?: GithubIssueEditContext | null;
+  readonly eyebrow?: ReactNode;
 };
 
 export const GithubIssueDetail = ({
@@ -31,6 +32,7 @@ export const GithubIssueDetail = ({
   dock,
   fit = 'fill',
   editContext,
+  eyebrow,
 }: Props) => {
   const [section, setSection] = useState<IssueSection>('overview');
   const { description, save } = useGithubIssueDescription({ issue, editContext });
@@ -61,6 +63,7 @@ export const GithubIssueDetail = ({
   return (
     <StudioDetailLayout
       fit={fit}
+      eyebrow={eyebrow}
       header={
         <RecordDetailHeader
           provider="github"

--- a/apps/desktop/src/features/permissions/components/DiffViewerDialog/DiffViewerContent.tsx
+++ b/apps/desktop/src/features/permissions/components/DiffViewerDialog/DiffViewerContent.tsx
@@ -78,6 +78,7 @@ type Props = {
   presentation?: 'dialog' | 'pane';
   onContentEmptyChange?: (isEmpty: boolean) => void;
   headerActions?: ReactNode;
+  eyebrow?: ReactNode;
   branchRevision?: number;
 };
 
@@ -256,6 +257,7 @@ export const DiffViewerContent = ({
   presentation = 'dialog',
   onContentEmptyChange,
   headerActions,
+  eyebrow,
   branchRevision = 0,
 }: Props) => {
   const [files, setFiles] = useState<ReadonlyArray<FileDiff>>([]);
@@ -762,6 +764,7 @@ export const DiffViewerContent = ({
           )}
         >
           <div className="flex min-w-0 flex-col gap-1">
+            {eyebrow}
             <div className="flex flex-wrap items-baseline gap-2">
               <h1 className="text-xl font-semibold leading-snug text-foreground">
                 {DIFF_VIEWER_PANE_COPY.title}

--- a/apps/desktop/src/features/permissions/components/DiffViewerDialog/index.test.tsx
+++ b/apps/desktop/src/features/permissions/components/DiffViewerDialog/index.test.tsx
@@ -235,6 +235,16 @@ describe('DiffViewerPane', () => {
     expect(container.firstElementChild?.className).toContain('motion-safe:animate-studio-in');
   });
 
+  it('renders the session eyebrow above the pane title', () => {
+    render(<DiffViewerPane onClose={vi.fn()} eyebrow={<span>Ship the lens eyebrow</span>} />);
+
+    const eyebrow = screen.getByText('Ship the lens eyebrow');
+    const heading = screen.getByRole('heading', { name: /^diff$/i });
+    expect(
+      eyebrow.compareDocumentPosition(heading) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
   it('lets the pane content span the full lens width', () => {
     const { container } = render(<DiffViewerPane onClose={vi.fn()} />);
     const shell = container.firstElementChild as HTMLElement;

--- a/apps/desktop/src/features/permissions/components/DiffViewerDialog/index.tsx
+++ b/apps/desktop/src/features/permissions/components/DiffViewerDialog/index.tsx
@@ -20,6 +20,7 @@ type DiffViewerContentProps = {
   showToolbarClose?: boolean;
   onContentEmptyChange?: (isEmpty: boolean) => void;
   headerActions?: ReactNode;
+  eyebrow?: ReactNode;
   branchRevision?: number;
 };
 

--- a/apps/desktop/src/features/plans/components/PlanStudio/index.tsx
+++ b/apps/desktop/src/features/plans/components/PlanStudio/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, type ReactNode } from 'react';
 import { ArchiveRestore, Eye, Pencil, Play, RotateCw, Trash2 } from 'lucide-react';
 import {
   Button,
@@ -28,9 +28,10 @@ import { FinishedRegister } from '../../../../shared/components/FinishedRegister
 
 type Props = {
   readonly sessionId: SessionId;
+  readonly eyebrow?: ReactNode;
 };
 
-export const PlanStudio = ({ sessionId }: Props) => {
+export const PlanStudio = ({ sessionId, eyebrow }: Props) => {
   const plans = useSessionPlans(sessionId);
   const agents = useAppStore(
     (s) => s.sessionPhaseRuns[sessionId] ?? (EMPTY_ARRAY as ReadonlyArray<Agent>),
@@ -129,7 +130,7 @@ export const PlanStudio = ({ sessionId }: Props) => {
 
   if (selected != null) {
     return (
-      <FocusedPane lens="Plans" count={plans.length}>
+      <FocusedPane lens="Plans" count={plans.length} eyebrow={eyebrow}>
         <div className="flex min-h-0 min-w-0 flex-1 flex-col">
           <div className={cn('flex shrink-0 flex-col gap-2', PANE_RHYTHM.body)}>
             <HeaderBand
@@ -311,6 +312,7 @@ export const PlanStudio = ({ sessionId }: Props) => {
       title="Plans"
       description="Plans agents drafted for this session. Run one to spawn an executor."
       meta={plans.length > 0 ? plans.length : undefined}
+      eyebrow={eyebrow}
     >
       {plans.length === 0 ? (
         <LensEmptyState

--- a/apps/desktop/src/features/review/components/ReviewBoardPane/index.test.tsx
+++ b/apps/desktop/src/features/review/components/ReviewBoardPane/index.test.tsx
@@ -285,6 +285,14 @@ describe('ReviewBoardPane', () => {
     expect(title.compareDocumentPosition(record) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
+  it('renders the session eyebrow above its section title', () => {
+    render(<ReviewBoardPane session={SESSION} eyebrow={<span>Ship the lens eyebrow</span>} />);
+
+    const eyebrow = screen.getByText('Ship the lens eyebrow');
+    const title = screen.getByRole('heading', { level: 2, name: 'Review board' });
+    expect(eyebrow.compareDocumentPosition(title) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
   it('states its section title with no reviewed record', () => {
     h.diff.target = null;
     render(<ReviewBoardPane session={SESSION} />);

--- a/apps/desktop/src/features/review/components/ReviewBoardPane/index.tsx
+++ b/apps/desktop/src/features/review/components/ReviewBoardPane/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
 import {
   cn,
   DiffLayoutToggle,
@@ -37,9 +37,10 @@ type Section = 'review' | 'threads' | 'resolvers';
 
 type Props = {
   readonly session: Session;
+  readonly eyebrow?: ReactNode;
 };
 
-export const ReviewBoardPane = ({ session }: Props) => {
+export const ReviewBoardPane = ({ session, eyebrow }: Props) => {
   const sessionId = session.id as SessionId;
   const [section, setSection] = useState<Section>('review');
   const [inspectedResolverId, setInspectedResolverId] = useState<AgentId | null>(null);
@@ -214,6 +215,7 @@ export const ReviewBoardPane = ({ session }: Props) => {
   return (
     <StudioDetailLayout
       header={header}
+      eyebrow={eyebrow}
       tabs={
         <StudioDetailTabs
           ariaLabel="Resolve hub sections"

--- a/apps/desktop/src/features/session/components/AgentDetailPane/index.test.tsx
+++ b/apps/desktop/src/features/session/components/AgentDetailPane/index.test.tsx
@@ -115,6 +115,22 @@ describe('AgentDetailPane', () => {
     expect(screen.getByRole('tab', { name: 'Brief' })).toBeDefined();
   });
 
+  it('renders the session eyebrow above the agent title', () => {
+    render(
+      <AgentDetailPane
+        session={session}
+        agent={agent}
+        isChatActive
+        onBack={() => undefined}
+        eyebrow={<span>Ship the lens eyebrow</span>}
+      />,
+    );
+
+    const eyebrow = screen.getByText('Ship the lens eyebrow');
+    const title = screen.getByRole('heading', { level: 2 });
+    expect(eyebrow.compareDocumentPosition(title) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
   it('shows the planned model in the header while the agent has not run', () => {
     Object.assign(state, { agentModelOverride: { [agentId]: 'claude-haiku-4-5' } });
 

--- a/apps/desktop/src/features/session/components/AgentDetailPane/index.tsx
+++ b/apps/desktop/src/features/session/components/AgentDetailPane/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
 import { HeaderBand, StudioDetailTabs } from '@goodboy/ui';
 import type { Agent, Session } from '@goodboy/types';
 import { ChatView } from '../../../chat/components/ChatView';
@@ -19,6 +19,7 @@ type Props = {
   readonly agent: Agent;
   readonly isChatActive: boolean;
   readonly onBack: () => void;
+  readonly eyebrow?: ReactNode;
 };
 
 type Tab = 'brief' | 'transcript';
@@ -28,7 +29,7 @@ const TABS = [
   { value: 'transcript', label: 'Transcript' },
 ] satisfies ReadonlyArray<{ readonly value: Tab; readonly label: string }>;
 
-export const AgentDetailPane = ({ session, agent, isChatActive, onBack }: Props) => {
+export const AgentDetailPane = ({ session, agent, isChatActive, onBack, eyebrow }: Props) => {
   const [tab, setTab] = useState<Tab>('brief');
   const kindOverride = useAppStore((state) => state.agentKindOverride[agent.id] ?? null);
   const providerOverride = useAppStore(
@@ -66,6 +67,7 @@ export const AgentDetailPane = ({ session, agent, isChatActive, onBack }: Props)
         agent={agent}
         isChatActive={isChatActive}
         onBack={onBack}
+        eyebrow={eyebrow}
       />
     );
   }
@@ -79,6 +81,7 @@ export const AgentDetailPane = ({ session, agent, isChatActive, onBack }: Props)
   return (
     <StudioDetailLayout
       fit={tab === 'transcript' ? 'bleed' : 'fill'}
+      eyebrow={eyebrow}
       header={
         <HeaderBand
           title={<AgentTitle agent={agent} sessionId={session.id} />}

--- a/apps/desktop/src/features/session/components/ResolverDetailPane/index.tsx
+++ b/apps/desktop/src/features/session/components/ResolverDetailPane/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
 import type { Agent, PendingResolution, PrComment, Session, SessionId } from '@goodboy/types';
 import { ChatView } from '../../../chat/components/ChatView';
 import { EMPTY_ARRAY, useAppStore, useDiffComments } from '../../../../store';
@@ -41,6 +41,7 @@ type Props = {
   readonly agent: Agent;
   readonly isChatActive: boolean;
   readonly onBack: () => void;
+  readonly eyebrow?: ReactNode;
 };
 
 type Tab = 'brief' | 'transcript';
@@ -53,7 +54,7 @@ const TABS = [
 const EMPTY_PENDING: ReadonlyArray<PendingResolution> = [];
 const EMPTY_OUTCOMES: Readonly<Record<string, ResolverThreadOutcome>> = {};
 
-export const ResolverDetailPane = ({ session, agent, isChatActive, onBack }: Props) => {
+export const ResolverDetailPane = ({ session, agent, isChatActive, onBack, eyebrow }: Props) => {
   const sessionId = session.id as SessionId;
   const agentId = agent.id;
   const [tab, setTab] = useState<Tab>('brief');
@@ -192,6 +193,7 @@ export const ResolverDetailPane = ({ session, agent, isChatActive, onBack }: Pro
   return (
     <StudioDetailLayout
       fit={tab === 'transcript' ? 'bleed' : 'fill'}
+      eyebrow={eyebrow}
       header={
         <HeaderBand
           title={agent.name}

--- a/apps/desktop/src/features/session/components/SessionEyebrow/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionEyebrow/index.test.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { Session, SessionId } from '@goodboy/types';
+
+const SESSION_ID = 'ses-1' as SessionId;
+
+const setActiveLens = vi.fn();
+
+vi.mock('../../../../store', () => ({
+  useAppStore: <T,>(selector: (state: { setActiveLens: typeof setActiveLens }) => T) =>
+    selector({ setActiveLens }),
+}));
+
+const { SessionEyebrow } = await import('.');
+
+const sessionWith = ({ goal }: { readonly goal: string }): Session =>
+  ({ id: SESSION_ID, goal }) as unknown as Session;
+
+beforeEach(() => {
+  setActiveLens.mockClear();
+});
+
+afterEach(cleanup);
+
+describe('SessionEyebrow', () => {
+  it('renders the session title with the full text on the tooltip', () => {
+    render(<SessionEyebrow session={sessionWith({ goal: 'Ship the lens eyebrow' })} />);
+
+    const button = screen.getByRole('button', { name: 'Ship the lens eyebrow' });
+    expect(button.getAttribute('title')).toBe('Ship the lens eyebrow');
+  });
+
+  it('falls back to the untitled label when the session has no goal', () => {
+    render(<SessionEyebrow session={sessionWith({ goal: '' })} />);
+
+    expect(screen.getByRole('button', { name: 'Untitled session' })).toBeDefined();
+  });
+
+  it('navigates back to the session overview on click', () => {
+    render(<SessionEyebrow session={sessionWith({ goal: 'Ship the lens eyebrow' })} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Ship the lens eyebrow' }));
+
+    expect(setActiveLens).toHaveBeenCalledWith(SESSION_ID, null);
+  });
+});

--- a/apps/desktop/src/features/session/components/SessionEyebrow/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionEyebrow/index.tsx
@@ -1,0 +1,26 @@
+import type { Session, SessionId } from '@goodboy/types';
+import { useAppStore } from '../../../../store';
+import { CONCEPT_ICONS, ICON_SIZE } from '../../../../shared/components/conceptIcons';
+
+type Props = {
+  readonly session: Session;
+};
+
+export const SessionEyebrow = ({ session }: Props) => {
+  const setActiveLens = useAppStore((s) => s.setActiveLens);
+  const sessionId = session.id as SessionId;
+  const title = session.goal === '' ? 'Untitled session' : session.goal;
+  const Icon = CONCEPT_ICONS.sessions;
+
+  return (
+    <button
+      type="button"
+      title={title}
+      onClick={() => setActiveLens(sessionId, null)}
+      className="inline-flex min-w-0 max-w-full items-center gap-1.5 self-start text-2xs text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--color-focus-ring)]"
+    >
+      <Icon size={ICON_SIZE.row} aria-hidden className="shrink-0 text-muted-foreground/70" />
+      <span className="min-w-0 truncate">{title}</span>
+    </button>
+  );
+};

--- a/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
@@ -14,6 +14,7 @@ import {
 import type { LensKind } from '../../../../store';
 import { SessionOverviewPane } from '../SessionOverviewPane';
 import { SessionCrumbBar } from '../SessionCrumbBar';
+import { SessionEyebrow } from '../SessionEyebrow';
 import { AgentOverlay } from './parts/AgentOverlay';
 import { AgentsPane } from './parts/AgentsPane';
 import { Pane } from './parts/Pane';
@@ -127,6 +128,7 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
   const onSelectOverview = () => {
     setActiveLens(sessionId, null);
   };
+  const sessionEyebrow = <SessionEyebrow session={session} />;
   const showStudio = studio != null;
   const showAgentOverlay = selectedAgentId != null && !showStudio;
   const showLens = selectedAgentId == null && !showStudio;
@@ -193,13 +195,18 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
               />
             )
           ) : null}
-          {lens === 'questions' ? <QuestionsPane session={session} /> : null}
-          {lens === 'plans' ? <PlanStudio sessionId={sessionId} /> : null}
-          {lens === 'workflows' ? <WorkflowsPane session={session} /> : null}
+          {lens === 'questions' ? (
+            <QuestionsPane session={session} eyebrow={sessionEyebrow} />
+          ) : null}
+          {lens === 'plans' ? <PlanStudio sessionId={sessionId} eyebrow={sessionEyebrow} /> : null}
+          {lens === 'workflows' ? (
+            <WorkflowsPane session={session} eyebrow={sessionEyebrow} />
+          ) : null}
           {lens === 'scripts' ? (
             <PaneShell
               title="Scripts"
               description="Shell commands you run by hand from this session, no agent involved."
+              eyebrow={sessionEyebrow}
             >
               <ScriptsPanel
                 workspaceId={session.workspaceId}
@@ -209,7 +216,11 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
             </PaneShell>
           ) : null}
           {surface === 'context' ? (
-            <ContextPane session={session} initialRegion={contextRegionFor({ lens })} />
+            <ContextPane
+              session={session}
+              initialRegion={contextRegionFor({ lens })}
+              eyebrow={sessionEyebrow}
+            />
           ) : null}
           {lens === 'pr' ? <PrPane session={session} onSelectLens={onSelectLens} /> : null}
           {lens === 'review' ? <ReviewBoardPane session={session} /> : null}
@@ -218,6 +229,7 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
               sessionId={sessionId}
               workspaceId={session.workspaceId}
               provider="linear"
+              eyebrow={sessionEyebrow}
             />
           ) : null}
           {lens === 'sentry' ? (
@@ -225,6 +237,7 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
               sessionId={sessionId}
               workspaceId={session.workspaceId}
               provider="sentry"
+              eyebrow={sessionEyebrow}
             />
           ) : null}
           {lens === 'gitlab_issues' ? (
@@ -232,6 +245,7 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
               sessionId={sessionId}
               workspaceId={session.workspaceId}
               provider="gitlab"
+              eyebrow={sessionEyebrow}
             />
           ) : null}
           {lens === 'jira_issues' ? (
@@ -239,6 +253,7 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
               sessionId={sessionId}
               workspaceId={session.workspaceId}
               provider="jira"
+              eyebrow={sessionEyebrow}
             />
           ) : null}
           {lens === 'slack_threads' ? (
@@ -246,6 +261,7 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
               sessionId={sessionId}
               workspaceId={session.workspaceId}
               provider="slack"
+              eyebrow={sessionEyebrow}
             />
           ) : null}
           {lens === 'github_issue' ? (
@@ -260,6 +276,7 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
               <PaneShell
                 title="GitHub issue"
                 description="The GitHub issue linked to this session."
+                eyebrow={sessionEyebrow}
               >
                 <LensEmptyState
                   icon={CONCEPT_ICONS.github}
@@ -288,13 +305,14 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
               worktreePath={diffWorktreePath}
               isBranchless={isBranchless}
               onClose={onSelectOverview}
+              eyebrow={sessionEyebrow}
             />
           ) : null}
           {lens === 'explore' ? (
-            <ExplorePane sessionId={sessionId} sessionDir={workingDir} />
+            <ExplorePane sessionId={sessionId} sessionDir={workingDir} eyebrow={sessionEyebrow} />
           ) : null}
           <Pane visible={lens === 'agents'}>
-            <AgentsPane session={session} meta={agentsMeta} />
+            <AgentsPane session={session} meta={agentsMeta} eyebrow={sessionEyebrow} />
           </Pane>
         </div>
 
@@ -319,6 +337,7 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
               sessionId={sessionId}
               isActive={isActive && lens === 'terminal' && showLens}
               cwd={workingDir}
+              eyebrow={sessionEyebrow}
             />
           </div>
         ) : null}

--- a/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
@@ -222,8 +222,12 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
               eyebrow={sessionEyebrow}
             />
           ) : null}
-          {lens === 'pr' ? <PrPane session={session} onSelectLens={onSelectLens} /> : null}
-          {lens === 'review' ? <ReviewBoardPane session={session} /> : null}
+          {lens === 'pr' ? (
+            <PrPane session={session} onSelectLens={onSelectLens} eyebrow={sessionEyebrow} />
+          ) : null}
+          {lens === 'review' ? (
+            <ReviewBoardPane session={session} eyebrow={sessionEyebrow} />
+          ) : null}
           {lens === 'linear' ? (
             <IntegrationPane
               sessionId={sessionId}
@@ -271,6 +275,7 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
                 rootPath={projectWorktreePath}
                 {...(githubTask != null && { task: githubTask })}
                 issueNumber={githubIssueNumber}
+                eyebrow={sessionEyebrow}
               />
             ) : (
               <PaneShell
@@ -323,6 +328,7 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
             isChatActive={isActive && selectedAgentId != null}
             selectedAgentId={selectedAgentId}
             onBack={() => setActiveLens(sessionId, overlayHome)}
+            eyebrow={sessionEyebrow}
           />
         ) : null}
 

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/AgentOverlay.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/AgentOverlay.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import { PANE_RHYTHM, Skeleton, SkeletonText, cn } from '@goodboy/ui';
 import type { Agent, AgentId, Session, SessionId } from '@goodboy/types';
 import { AgentDetailPane } from '../../AgentDetailPane';
@@ -9,6 +10,7 @@ type Props = {
   readonly isChatActive: boolean;
   readonly selectedAgentId: AgentId | null;
   readonly onBack: () => void;
+  readonly eyebrow?: ReactNode;
 };
 
 export const AgentOverlay = ({
@@ -17,6 +19,7 @@ export const AgentOverlay = ({
   isChatActive,
   selectedAgentId,
   onBack,
+  eyebrow,
 }: Props) => {
   const selectedAgent = useAppStore(
     (state) =>
@@ -30,6 +33,7 @@ export const AgentOverlay = ({
       <div className="flex min-h-0 min-w-0 flex-1 flex-col">
         {selectedAgent === null ? (
           <div className={cn('flex flex-col gap-4', PANE_RHYTHM.body)}>
+            {eyebrow}
             <Skeleton className="h-6 w-48" />
             <SkeletonText lines={3} />
           </div>
@@ -39,6 +43,7 @@ export const AgentOverlay = ({
             agent={selectedAgent}
             isChatActive={isChatActive}
             onBack={onBack}
+            eyebrow={eyebrow}
           />
         )}
       </div>

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/AgentsPane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/AgentsPane.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import type { Session, SessionId } from '@goodboy/types';
 import { CreateAgentPopover } from '../../CreateAgentPopover';
 import { StandaloneAgentsLane } from '../../StandaloneAgentsLane';
@@ -6,9 +7,10 @@ import { PaneShell } from '../../../../../shared/components/PaneShell';
 type Props = {
   readonly session: Session;
   readonly meta: string | undefined;
+  readonly eyebrow?: ReactNode;
 };
 
-export const AgentsPane = ({ session, meta }: Props) => {
+export const AgentsPane = ({ session, meta, eyebrow }: Props) => {
   const sessionId = session.id as SessionId;
 
   return (
@@ -16,6 +18,7 @@ export const AgentsPane = ({ session, meta }: Props) => {
       title="Agents"
       description="Agents you spawn by hand to work this session."
       meta={meta}
+      eyebrow={eyebrow}
       actions={<CreateAgentPopover sessionId={sessionId} variant="compact" />}
     >
       <StandaloneAgentsLane session={session} variant="lens" showCompleted />

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/ContextPane/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/ContextPane/index.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useEffect, useMemo, useState } from 'react';
+import { Fragment, useEffect, useMemo, useState, type ReactNode } from 'react';
 import { CopyButton, Divider, GhostActionButton } from '@goodboy/ui';
 import { Code, History } from 'lucide-react';
 import type { Session, SessionId } from '@goodboy/types';
@@ -46,6 +46,7 @@ const REGION_CONCEPT = {
 type Props = {
   readonly session: Session;
   readonly initialRegion?: ContextLens;
+  readonly eyebrow?: ReactNode;
 };
 
 type ValueParams = {
@@ -56,7 +57,7 @@ type ValueParams = {
 const valueFor = ({ slots, slotKey }: ValueParams): string =>
   slots.find((slot) => slot.key === slotKey)?.value ?? '';
 
-export const ContextPane = ({ session, initialRegion }: Props) => {
+export const ContextPane = ({ session, initialRegion, eyebrow }: Props) => {
   const sessionId = session.id as SessionId;
   const slots = useSessionSlots(sessionId);
   const loading = useSessionLoading(sessionId);
@@ -137,7 +138,12 @@ export const ContextPane = ({ session, initialRegion }: Props) => {
         )
       }
     >
-      <PaneShell title="Context" icon={CONCEPT_ICONS.context} tone={CONCEPT_TONE.context}>
+      <PaneShell
+        title="Context"
+        icon={CONCEPT_ICONS.context}
+        tone={CONCEPT_TONE.context}
+        eyebrow={eyebrow}
+      >
         {REGION_ORDER.map((slotKey, index) => {
           const value = valueFor({ slots, slotKey });
           const title = REGION_TITLE[slotKey];

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/FileVersionsPane/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/FileVersionsPane/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
 import { Trash2 } from 'lucide-react';
 import { Divider, formatError } from '@goodboy/ui';
 import { useShallow } from 'zustand/react/shallow';
@@ -19,11 +19,12 @@ type Props = {
   sessionId: SessionId;
   sessionDir: string;
   onClose: () => void;
+  eyebrow?: ReactNode;
 };
 
 const EMPTY_VERSIONS: ReadonlyArray<FileVersion> = [];
 
-export const FileVersionsPane = ({ sessionId, sessionDir, onClose }: Props) => {
+export const FileVersionsPane = ({ sessionId, sessionDir, onClose, eyebrow }: Props) => {
   const versions = useAppStore(
     useShallow((state) => state.sessionFileVersions[sessionId] ?? EMPTY_VERSIONS),
   );
@@ -94,6 +95,7 @@ export const FileVersionsPane = ({ sessionId, sessionDir, onClose }: Props) => {
       title="File versions"
       description="Before an agent changes a file in this session, Goodboy stores the previous copy here so you can bring it back."
       measure={loading || groups.length > 0 ? 'full' : 'pane'}
+      eyebrow={eyebrow}
       actions={
         <>
           {deleteAllArmed ? (

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/FilesPane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/FilesPane.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, type ReactNode } from 'react';
 import type { BranchCommit, SessionId, SessionProjectMount } from '@goodboy/types';
 import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../../shared/components/conceptIcons';
 import { LensEmptyState } from '@goodboy/ui';
@@ -20,6 +20,7 @@ type Props = {
   readonly worktreePath: string | null;
   readonly isBranchless: boolean;
   readonly onClose: () => void;
+  readonly eyebrow?: ReactNode;
 };
 
 export const FilesPane = ({
@@ -28,6 +29,7 @@ export const FilesPane = ({
   worktreePath,
   isBranchless,
   onClose,
+  eyebrow,
 }: Props) => {
   const diffFocus = useAppStore((s) => s.diffFocus[sessionId] ?? null);
   const mounts = useAppStore((s) => s.sessionProjectMounts?.[sessionId] ?? EMPTY_MOUNTS);
@@ -66,6 +68,7 @@ export const FilesPane = ({
         <PaneShell
           title="File versions"
           description="View and restore saved file copies for this session."
+          eyebrow={eyebrow}
         >
           <LensEmptyState
             tone={CONCEPT_TONE.diff}
@@ -76,13 +79,21 @@ export const FilesPane = ({
         </PaneShell>
       );
     }
-    return <FileVersionsPane sessionId={sessionId} sessionDir={sessionDir} onClose={onClose} />;
+    return (
+      <FileVersionsPane
+        sessionId={sessionId}
+        sessionDir={sessionDir}
+        onClose={onClose}
+        eyebrow={eyebrow}
+      />
+    );
   }
   if (worktreePath == null) {
     return (
       <PaneShell
         title={DIFF_VIEWER_PANE_COPY.title}
         description={DIFF_VIEWER_PANE_COPY.description}
+        eyebrow={eyebrow}
       >
         <LensEmptyState
           tone={CONCEPT_TONE.diff}

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/FilesPane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/FilesPane.tsx
@@ -121,6 +121,7 @@ export const FilesPane = ({
           workingDir={sessionDir ?? undefined}
           worktreePath={worktreePath}
           diffFocus={diffFocus}
+          eyebrow={eyebrow}
           onClose={onClose}
           onContentEmptyChange={setIsDiffEmpty}
           branchRevision={branchRevision}

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/GithubTaskDetail.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/GithubTaskDetail.test.tsx
@@ -88,6 +88,28 @@ describe('GithubTaskDetail', () => {
     expect(screen.getByText('feature')).toBeDefined();
   });
 
+  it('renders the session eyebrow above the loaded issue title', () => {
+    useGithubIssueMock.mockReturnValue({
+      issue: ISSUE,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(
+      <GithubTaskDetail
+        workspaceId={WORKSPACE_ID}
+        rootPath="/repo"
+        task={TASK}
+        eyebrow={<span>Ship the lens eyebrow</span>}
+      />,
+    );
+
+    const eyebrow = screen.getByText('Ship the lens eyebrow');
+    const title = screen.getByRole('heading', { level: 2, name: 'Add issue dashboard' });
+    expect(eyebrow.compareDocumentPosition(title) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
   it('falls back to the linked task number when no issue number is given', () => {
     useGithubIssueMock.mockReturnValue({
       issue: null,

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/GithubTaskDetail.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/GithubTaskDetail.tsx
@@ -1,5 +1,6 @@
 import { StudioDetailLayout } from '../../../../../../shared/components/StudioDetail';
 import { Skeleton } from '@goodboy/ui';
+import type { ReactNode } from 'react';
 import type { SessionExternalTask, WorkspaceId } from '@goodboy/types';
 import { ErrorStrip } from '@goodboy/ui';
 import { HeaderBand } from '@goodboy/ui';
@@ -11,9 +12,10 @@ type Props = {
   readonly rootPath: string | null;
   readonly task?: SessionExternalTask;
   readonly issueNumber?: number;
+  readonly eyebrow?: ReactNode;
 };
 
-export const GithubTaskDetail = ({ workspaceId, rootPath, task, issueNumber }: Props) => {
+export const GithubTaskDetail = ({ workspaceId, rootPath, task, issueNumber, eyebrow }: Props) => {
   const resolvedIssueNumber = issueNumber ?? Number(task?.externalId);
   const { issue, isLoading, error, refetch } = useGithubIssue({
     workspaceId,
@@ -26,6 +28,7 @@ export const GithubTaskDetail = ({ workspaceId, rootPath, task, issueNumber }: P
       <GithubIssueDetail
         issue={issue}
         fit="fill"
+        eyebrow={eyebrow}
         {...(rootPath != null && { editContext: { workspaceId, rootPath } })}
       />
     );
@@ -34,6 +37,7 @@ export const GithubTaskDetail = ({ workspaceId, rootPath, task, issueNumber }: P
   return (
     <StudioDetailLayout
       fit="fill"
+      eyebrow={eyebrow}
       header={
         <HeaderBand
           title={task?.title ?? `#${resolvedIssueNumber}`}

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
 import { ArrowLeft, Check, Unlink } from 'lucide-react';
 import type {
   SessionExternalTask,
@@ -35,6 +35,7 @@ type Props = {
   readonly sessionId: SessionId;
   readonly workspaceId: WorkspaceId;
   readonly provider: Exclude<SessionExternalTaskProvider, 'github'>;
+  readonly eyebrow?: ReactNode;
 };
 
 type ProviderMeta = Readonly<{
@@ -101,7 +102,7 @@ const PROVIDER_META: Record<SessionExternalTaskProvider, ProviderMeta> = {
   },
 };
 
-export const IntegrationPane = ({ sessionId, workspaceId, provider }: Props) => {
+export const IntegrationPane = ({ sessionId, workspaceId, provider, eyebrow }: Props) => {
   const [unlinkError, setUnlinkError] = useState<string | null>(null);
   const [isUnlinking, setIsUnlinking] = useState(false);
   const [isUnlinkArmed, setIsUnlinkArmed] = useState(false);
@@ -183,6 +184,7 @@ export const IntegrationPane = ({ sessionId, workspaceId, provider }: Props) => 
       <FocusedPane
         lens={meta.label}
         count={tasks.length}
+        eyebrow={eyebrow}
         actions={
           isUnlinkArmed ? (
             <InlineConfirm
@@ -241,6 +243,7 @@ export const IntegrationPane = ({ sessionId, workspaceId, provider }: Props) => 
       title={meta.label}
       description={`External ${meta.label} ${meta.nounPlural} linked to this session.`}
       meta={hasTasks ? tasks.length : undefined}
+      eyebrow={eyebrow}
       actions={connection.isConnected && hasTasks ? linkAction : undefined}
     >
       {!connection.isConnected ? (

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.test.tsx
@@ -300,6 +300,20 @@ describe('PrPane', () => {
     expect(screen.queryByText('Open a pull or merge request')).toBeNull();
   });
 
+  it('renders the session eyebrow above the host title', () => {
+    render(
+      <PrPane
+        session={session}
+        onSelectLens={h.onSelectLens}
+        eyebrow={<span>Ship the lens eyebrow</span>}
+      />,
+    );
+
+    const eyebrow = screen.getByText('Ship the lens eyebrow');
+    const title = screen.getByRole('heading', { level: 2 });
+    expect(eyebrow.compareDocumentPosition(title) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
   it('names the host it is actually pointed at', () => {
     h.remoteKind = 'gitlab';
 

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.tsx
@@ -66,6 +66,7 @@ const PROVIDER_TAB_OPTIONS: ReadonlyArray<{
 type Props = {
   readonly session: Session;
   readonly onSelectLens: (lens: LensKind) => void;
+  readonly eyebrow?: ReactNode;
 };
 
 type HostTitleParams = {
@@ -134,7 +135,7 @@ const resolveSessionStudioOpenEvent = ({
   }
 };
 
-export const PrPane = ({ session, onSelectLens }: Props) => {
+export const PrPane = ({ session, onSelectLens, eyebrow }: Props) => {
   const sessionId = session.id as SessionId;
   const remoteKind = useRemoteHostKind({ sessionId });
   const sessionBranch = useSessionRepo({ sessionId })?.branch ?? null;
@@ -209,6 +210,7 @@ export const PrPane = ({ session, onSelectLens }: Props) => {
     return (
       <StudioDetailLayout
         fit="fill"
+        eyebrow={eyebrow}
         header={
           <HeaderBand
             title={bitbucketPr?.title ?? hostTitle({ remoteKind, providerCount, activeProvider })}
@@ -241,6 +243,7 @@ export const PrPane = ({ session, onSelectLens }: Props) => {
     return (
       <StudioDetailLayout
         fit="fill"
+        eyebrow={eyebrow}
         header={
           <HeaderBand
             title={mergeRequest?.title ?? hostTitle({ remoteKind, providerCount, activeProvider })}
@@ -278,6 +281,7 @@ export const PrPane = ({ session, onSelectLens }: Props) => {
       onOpenStudio={openStudio}
       providerCount={providerCount}
       activeProvider={activeProvider}
+      eyebrow={eyebrow}
       {...(providerTabs != null && { tabs: providerTabs })}
     />
   );
@@ -292,6 +296,7 @@ const GithubPrCard = ({
   providerCount,
   activeProvider,
   tabs,
+  eyebrow,
 }: {
   session: Session;
   isPrReview: boolean;
@@ -301,6 +306,7 @@ const GithubPrCard = ({
   providerCount: number;
   activeProvider: PullRequestProvider;
   tabs?: ReactNode;
+  eyebrow?: ReactNode;
 }) => {
   const sessionId = session.id as SessionId;
   const [unlinkingIssueNumber, setUnlinkingIssueNumber] = useState<number | null>(null);
@@ -413,6 +419,7 @@ const GithubPrCard = ({
   const shell = ({ children }: { readonly children: ReactNode }) => (
     <StudioDetailLayout
       fit="fill"
+      eyebrow={eyebrow}
       header={
         <HeaderBand
           title={hostTitle({ remoteKind, providerCount, activeProvider })}
@@ -500,6 +507,7 @@ const GithubPrCard = ({
   return (
     <StudioDetailLayout
       fit="fill"
+      eyebrow={eyebrow}
       header={
         <HeaderBand
           title={pr.title}

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/QuestionsPane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/QuestionsPane.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, type ReactNode } from 'react';
 import { Bot } from 'lucide-react';
 import { Skeleton } from '@goodboy/ui';
 import { LensEmptyState } from '@goodboy/ui';
@@ -44,6 +44,7 @@ type AnswerPair = { id: OpenQuestionId; text: string; answer: string };
 
 type QuestionsPaneProps = {
   readonly session: Session;
+  readonly eyebrow?: ReactNode;
 };
 
 type ClusterSectionProps = {
@@ -241,7 +242,7 @@ const AnsweredHistory = ({ clusters, sessionId }: AnsweredHistoryProps) => {
   );
 };
 
-export const QuestionsPane = ({ session }: QuestionsPaneProps) => {
+export const QuestionsPane = ({ session, eyebrow }: QuestionsPaneProps) => {
   const sessionId = session.id as SessionId;
   const open = selectOpenQuestions(useSessionOpenQuestions(sessionId));
   const answered = useSessionAnsweredQuestions(sessionId);
@@ -329,7 +330,11 @@ export const QuestionsPane = ({ session }: QuestionsPaneProps) => {
 
   if (!openLoaded || !answeredLoaded) {
     return (
-      <PaneShell title="Questions" description="Decisions agents need from you to keep going.">
+      <PaneShell
+        title="Questions"
+        description="Decisions agents need from you to keep going."
+        eyebrow={eyebrow}
+      >
         <div className="flex flex-col gap-2" role="status" aria-label="Loading questions">
           {Array.from({ length: 3 }).map((_, i) => (
             <div key={i} className="flex flex-col gap-1.5 rounded-md border border-border-soft p-3">
@@ -345,7 +350,11 @@ export const QuestionsPane = ({ session }: QuestionsPaneProps) => {
 
   if (open.length === 0 && answeredClusters.length === 0 && pendingUndoQuestion === null) {
     return (
-      <PaneShell title="Questions" description="Decisions agents need from you to keep going.">
+      <PaneShell
+        title="Questions"
+        description="Decisions agents need from you to keep going."
+        eyebrow={eyebrow}
+      >
         <LensEmptyState
           tone={CONCEPT_TONE.questions}
           icon={CONCEPT_ICONS.questions}
@@ -358,7 +367,11 @@ export const QuestionsPane = ({ session }: QuestionsPaneProps) => {
 
   if (open.length === 0 && pendingUndoQuestion === null) {
     return (
-      <PaneShell title="Questions" description="Decisions agents need from you to keep going.">
+      <PaneShell
+        title="Questions"
+        description="Decisions agents need from you to keep going."
+        eyebrow={eyebrow}
+      >
         <LensEmptyState
           tone={CONCEPT_TONE.questions}
           icon={CONCEPT_ICONS.questions}
@@ -377,6 +390,7 @@ export const QuestionsPane = ({ session }: QuestionsPaneProps) => {
   return (
     <PaneShell
       title="Questions"
+      eyebrow={eyebrow}
       description={
         open.length > 0
           ? `${open.length} open ${open.length === 1 ? 'question' : 'questions'} waiting on you.`

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowsPane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowsPane.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import { BookmarkPlus } from 'lucide-react';
 import type { Agent, Session, SessionId, Workflow, WorkflowRun } from '@goodboy/types';
 import { EMPTY_ARRAY, useAppStore } from '../../../../../store';
@@ -20,9 +21,10 @@ const VISIBLE_FINISHED_COUNT = 30;
 
 type Props = {
   readonly session: Session;
+  readonly eyebrow?: ReactNode;
 };
 
-export const WorkflowsPane = ({ session }: Props) => {
+export const WorkflowsPane = ({ session, eyebrow }: Props) => {
   const sessionId = session.id as SessionId;
   const attachedRuns = useAttachedWorkflowRuns({ session });
   const makeWorkflowPreset = useAppStore((s) => s.makeWorkflowPreset);
@@ -82,6 +84,7 @@ export const WorkflowsPane = ({ session }: Props) => {
       <FocusedPane
         lens="Workflows"
         count={attachedRuns.length}
+        eyebrow={eyebrow}
         actions={
           <>
             {focusedRun.workflow != null && focusedRun.workflow.isPreset === false ? (
@@ -110,6 +113,7 @@ export const WorkflowsPane = ({ session }: Props) => {
       title="Workflows"
       description="Sequences of agents this session runs toward its goal."
       meta={hasRuns ? attachedRuns.length : undefined}
+      eyebrow={eyebrow}
       actions={
         shouldShowHeaderAttach ? (
           <WorkflowAttachButton sessionId={sessionId} placement="header" />

--- a/apps/desktop/src/features/terminal/components/TerminalDock/index.test.tsx
+++ b/apps/desktop/src/features/terminal/components/TerminalDock/index.test.tsx
@@ -72,6 +72,23 @@ afterEach(() => {
   platform.current = 'darwin';
 });
 
+describe('TerminalDock eyebrow', () => {
+  it('renders the session eyebrow above the tab strip', () => {
+    render(
+      <TerminalDock
+        sessionId={SESSION_ID}
+        isActive
+        cwd="/repo"
+        eyebrow={<span>Ship the lens eyebrow</span>}
+      />,
+    );
+
+    const eyebrow = screen.getByText('Ship the lens eyebrow');
+    const strip = screen.getByRole('tab');
+    expect(eyebrow.compareDocumentPosition(strip) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+});
+
 describe('TerminalDock new tab shortcut', () => {
   it('spawns a tab on the command combo on darwin', () => {
     platform.current = 'darwin';

--- a/apps/desktop/src/features/terminal/components/TerminalDock/index.tsx
+++ b/apps/desktop/src/features/terminal/components/TerminalDock/index.tsx
@@ -160,6 +160,9 @@ export const TerminalDock = ({ sessionId, isActive, cwd, eyebrow }: Props) => {
 
   return (
     <div className="flex min-h-0 flex-1 flex-col" onKeyDown={handleKeyDown}>
+      {eyebrow != null ? (
+        <div className="flex min-w-0 flex-col gap-1 px-3 pt-2">{eyebrow}</div>
+      ) : null}
       <TerminalTabStrip
         tabs={tabs}
         activeId={activeId}

--- a/apps/desktop/src/features/terminal/components/TerminalDock/index.tsx
+++ b/apps/desktop/src/features/terminal/components/TerminalDock/index.tsx
@@ -1,4 +1,10 @@
-import { useCallback, useEffect, useMemo, type KeyboardEvent as ReactKeyboardEvent } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type ReactNode,
+} from 'react';
 import { Button, Divider } from '@goodboy/ui';
 import type { SessionId } from '@goodboy/types';
 import { useAppStore } from '../../../../store';
@@ -45,9 +51,10 @@ type Props = {
   readonly sessionId: SessionId;
   readonly isActive: boolean;
   readonly cwd: string | null;
+  readonly eyebrow?: ReactNode;
 };
 
-export const TerminalDock = ({ sessionId, isActive, cwd }: Props) => {
+export const TerminalDock = ({ sessionId, isActive, cwd, eyebrow }: Props) => {
   const tabs = useAppStore((s) => s.terminalTabs[sessionId] ?? EMPTY_TABS);
   const activeId = useAppStore((s) => s.activeTerminalTab[sessionId] ?? null);
   const addTerminalTab = useAppStore((s) => s.addTerminalTab);
@@ -131,7 +138,11 @@ export const TerminalDock = ({ sessionId, isActive, cwd }: Props) => {
 
   if (tabs.length === 0) {
     return (
-      <PaneShell title="Terminal" description="Run commands in this session's worktree.">
+      <PaneShell
+        title="Terminal"
+        description="Run commands in this session's worktree."
+        eyebrow={eyebrow}
+      >
         <LensEmptyState
           tone={CONCEPT_TONE.terminal}
           icon={CONCEPT_ICONS.terminal}

--- a/apps/desktop/src/shared/components/PaneShell/FocusedPane.tsx
+++ b/apps/desktop/src/shared/components/PaneShell/FocusedPane.tsx
@@ -12,10 +12,10 @@ type Props = {
 
 export const FocusedPane = ({ lens, count, actions, eyebrow, children }: Props) => (
   <div className="flex h-full min-h-0 flex-col bg-background">
-    <div className={cn('flex shrink-0 items-center justify-between gap-3', PANE_RHYTHM.header)}>
-      <div className="flex min-w-0 flex-col gap-1">
-        {eyebrow}
-        <div className="flex items-baseline gap-2">
+    <div className={cn('flex shrink-0 flex-col gap-1', PANE_RHYTHM.header)}>
+      {eyebrow}
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex min-w-0 items-baseline gap-2">
           <h1 className="text-2xs font-semibold uppercase tracking-wide text-muted-foreground/70">
             {lens}
           </h1>
@@ -23,8 +23,8 @@ export const FocusedPane = ({ lens, count, actions, eyebrow, children }: Props) 
             <span className="text-2xs tabular-nums text-muted-foreground/70">{count}</span>
           ) : null}
         </div>
+        {actions}
       </div>
-      {actions}
     </div>
     <Divider />
     <div className="flex min-h-0 flex-1">{children}</div>

--- a/apps/desktop/src/shared/components/PaneShell/FocusedPane.tsx
+++ b/apps/desktop/src/shared/components/PaneShell/FocusedPane.tsx
@@ -6,19 +6,23 @@ type Props = {
   readonly lens: string;
   readonly count?: ReactNode;
   readonly actions?: ReactNode;
+  readonly eyebrow?: ReactNode;
   readonly children: ReactNode;
 };
 
-export const FocusedPane = ({ lens, count, actions, children }: Props) => (
+export const FocusedPane = ({ lens, count, actions, eyebrow, children }: Props) => (
   <div className="flex h-full min-h-0 flex-col bg-background">
     <div className={cn('flex shrink-0 items-center justify-between gap-3', PANE_RHYTHM.header)}>
-      <div className="flex items-baseline gap-2">
-        <h1 className="text-2xs font-semibold uppercase tracking-wide text-muted-foreground/70">
-          {lens}
-        </h1>
-        {count != null ? (
-          <span className="text-2xs tabular-nums text-muted-foreground/70">{count}</span>
-        ) : null}
+      <div className="flex min-w-0 flex-col gap-1">
+        {eyebrow}
+        <div className="flex items-baseline gap-2">
+          <h1 className="text-2xs font-semibold uppercase tracking-wide text-muted-foreground/70">
+            {lens}
+          </h1>
+          {count != null ? (
+            <span className="text-2xs tabular-nums text-muted-foreground/70">{count}</span>
+          ) : null}
+        </div>
       </div>
       {actions}
     </div>

--- a/apps/desktop/src/shared/components/PaneShell/index.test.tsx
+++ b/apps/desktop/src/shared/components/PaneShell/index.test.tsx
@@ -89,6 +89,30 @@ describe('PaneShell', () => {
     expect(screen.getByText('Body copy')).toBeDefined();
   });
 
+  it('renders the eyebrow above the title', () => {
+    render(
+      <PaneShell title="Workflows" eyebrow={<span>Ship the lens eyebrow</span>}>
+        <p>Body copy</p>
+      </PaneShell>,
+    );
+
+    const eyebrow = screen.getByText('Ship the lens eyebrow');
+    const title = screen.getByRole('heading', { name: 'Workflows' });
+    expect(eyebrow.compareDocumentPosition(title) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('renders the eyebrow above a custom header', () => {
+    render(
+      <PaneShell header={<h1>Custom header</h1>} eyebrow={<span>Ship the lens eyebrow</span>}>
+        <p>Body copy</p>
+      </PaneShell>,
+    );
+
+    const eyebrow = screen.getByText('Ship the lens eyebrow');
+    const header = screen.getByRole('heading', { name: 'Custom header' });
+    expect(eyebrow.compareDocumentPosition(header) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
   it('mounts with the studio-in animation by default', () => {
     render(
       <PaneShell title="Linear">
@@ -132,6 +156,18 @@ describe('FocusedPane', () => {
     expect(screen.getByText('2')).toBeDefined();
     expect(screen.getByRole('button', { name: 'Close' })).toBeDefined();
     expect(screen.getByText('Body copy')).toBeDefined();
+  });
+
+  it('renders the eyebrow above the lens label', () => {
+    render(
+      <FocusedPane lens="Workflows" eyebrow={<span>Ship the lens eyebrow</span>}>
+        <p>Body copy</p>
+      </FocusedPane>,
+    );
+
+    const eyebrow = screen.getByText('Ship the lens eyebrow');
+    const lens = screen.getByRole('heading', { name: 'Workflows' });
+    expect(eyebrow.compareDocumentPosition(lens) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
   it('insets its header on the shared rhythm', () => {

--- a/apps/desktop/src/shared/components/PaneShell/index.tsx
+++ b/apps/desktop/src/shared/components/PaneShell/index.tsx
@@ -7,6 +7,7 @@ import { PANE_RHYTHM } from '@goodboy/ui';
 type BaseProps = {
   readonly measure?: keyof typeof PANE_RHYTHM.measure;
   readonly animationClassName?: string;
+  readonly eyebrow?: ReactNode;
   readonly children: ReactNode;
 };
 
@@ -36,6 +37,7 @@ export const PaneShell = (props: Props) => {
   const {
     measure = 'pane',
     animationClassName = 'motion-safe:animate-studio-in',
+    eyebrow,
     children,
   } = props;
 
@@ -49,40 +51,43 @@ export const PaneShell = (props: Props) => {
           PANE_RHYTHM.measure[measure],
         )}
       >
-        {props.header !== undefined ? (
-          props.header
-        ) : (
-          <div className="flex flex-wrap items-start justify-between gap-3">
-            <div className="flex min-w-0 flex-col gap-1">
-              <div className="flex items-baseline gap-2">
-                {props.icon != null ? (
-                  <props.icon
-                    size={16}
-                    aria-hidden
-                    className={cn(
-                      'shrink-0 translate-y-0.5',
-                      tintClasses(props.tone ?? 'neutral').icon,
-                    )}
-                  />
-                ) : null}
-                <h1 className="text-xl font-semibold leading-snug text-foreground">
-                  {props.title}
-                </h1>
-                {props.meta ? (
-                  <span className="text-xs tabular-nums text-muted-foreground">{props.meta}</span>
+        <div className="flex min-w-0 flex-col gap-1">
+          {eyebrow}
+          {props.header !== undefined ? (
+            props.header
+          ) : (
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div className="flex min-w-0 flex-col gap-1">
+                <div className="flex items-baseline gap-2">
+                  {props.icon != null ? (
+                    <props.icon
+                      size={16}
+                      aria-hidden
+                      className={cn(
+                        'shrink-0 translate-y-0.5',
+                        tintClasses(props.tone ?? 'neutral').icon,
+                      )}
+                    />
+                  ) : null}
+                  <h1 className="text-xl font-semibold leading-snug text-foreground">
+                    {props.title}
+                  </h1>
+                  {props.meta ? (
+                    <span className="text-xs tabular-nums text-muted-foreground">{props.meta}</span>
+                  ) : null}
+                </div>
+                {props.description ? (
+                  <p className="text-sm text-muted-foreground">{props.description}</p>
                 ) : null}
               </div>
-              {props.description ? (
-                <p className="text-sm text-muted-foreground">{props.description}</p>
+              {props.actions ? (
+                <div className="flex min-w-0 flex-wrap items-center justify-end gap-1.5 pt-0.5">
+                  {props.actions}
+                </div>
               ) : null}
             </div>
-            {props.actions ? (
-              <div className="flex min-w-0 flex-wrap items-center justify-end gap-1.5 pt-0.5">
-                {props.actions}
-              </div>
-            ) : null}
-          </div>
-        )}
+          )}
+        </div>
         {children}
       </div>
     </ScrollFade>

--- a/apps/desktop/src/shared/components/StudioDetail/StudioDetailLayout.tsx
+++ b/apps/desktop/src/shared/components/StudioDetail/StudioDetailLayout.tsx
@@ -8,6 +8,7 @@ type Fit = 'fill' | 'bleed' | 'flow';
 
 type Props = {
   readonly header: ReactNode;
+  readonly eyebrow?: ReactNode;
   readonly rail?: ReactNode;
   readonly dock?: ReactNode;
   readonly properties?: ResolvedDetailFields;
@@ -18,6 +19,7 @@ type Props = {
 
 export const StudioDetailLayout = ({
   header,
+  eyebrow,
   rail,
   dock,
   properties,
@@ -39,7 +41,14 @@ export const StudioDetailLayout = ({
       >
         <div className={cn('flex flex-col', !isFlow && PANE_RHYTHM.body)}>
           <div className={cn('flex flex-col gap-3', PANE_RHYTHM.column, headerMeasure)}>
-            {header}
+            {eyebrow != null ? (
+              <div className="flex min-w-0 flex-col gap-1">
+                {eyebrow}
+                {header}
+              </div>
+            ) : (
+              header
+            )}
             {hasMeta ? (
               <div data-testid="detail-meta" className="flex min-w-0 flex-col gap-3">
                 {hasProperties ? <DetailProperties entries={properties} /> : null}

--- a/apps/desktop/src/shared/components/StudioDetail/index.test.tsx
+++ b/apps/desktop/src/shared/components/StudioDetail/index.test.tsx
@@ -62,6 +62,21 @@ describe('StudioDetailLayout', () => {
     expect(screen.getByText('Rail slot')).toBeDefined();
   });
 
+  it('renders the eyebrow above the header band', () => {
+    render(
+      <StudioDetailLayout
+        header={<h2>Header slot</h2>}
+        eyebrow={<span>Ship the lens eyebrow</span>}
+      >
+        <span>Main slot</span>
+      </StudioDetailLayout>,
+    );
+
+    const eyebrow = screen.getByText('Ship the lens eyebrow');
+    const header = screen.getByRole('heading', { name: 'Header slot' });
+    expect(eyebrow.compareDocumentPosition(header) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
   it('renders the optional tab bar between the header and the body', () => {
     render(
       <StudioDetailLayout


### PR DESCRIPTION
## Why
n-bro: inside a sub-page you lose sight of which session you are in. Chosen option: the session title small above the section title.

## What
- `SessionEyebrow`: session glyph + goal (fallback "Untitled session"), truncated with the full text in `title`, click returns to the overview through the same store action the breadcrumb uses.
- `PaneShell` and `FocusedPane` gain an `eyebrow` slot rendered above the title row (and above a custom header).
- `SessionWorkspace` passes one eyebrow to every lens and focused page: Questions, Plans, Workflows (list and run), Scripts, Context/Decisions/Summary, Linear/Sentry/GitLab/Jira/Slack, GitHub issue empty state, Files (branchless and no-worktree states), File versions, Explore, Agents, Terminal empty state. The overview has none.

## Not covered yet (own headers, follow-up on this branch)
PR and Review panes (`StudioDetailLayout`), GitHub task detail, Files with a diff open (`DiffViewerPane`), Terminal with tabs, the agent focused page.

## Tests
- eyebrow (title, fallback, click), shell order assertions; session + workflows + scripts + regression suites green (2213).

🤖 Generated with [Claude Code](https://claude.com/claude-code)