### PR TITLE
feat(ui): session titles render inline markdown

### DIFF
--- a/apps/desktop/src/app/components/AppBreadcrumb/index.tsx
+++ b/apps/desktop/src/app/components/AppBreadcrumb/index.tsx
@@ -1,6 +1,8 @@
 import { ChevronRight } from 'lucide-react';
 import type { BreadcrumbCrumb } from './buildBreadcrumb';
 import { ICON_SIZE } from '../../../shared/components/conceptIcons';
+import { InlineMarkdown } from '../../../shared/components/InlineMarkdown';
+import { stripInlineMarkdown } from '../../../shared/components/InlineMarkdown/stripInlineMarkdown';
 
 type Props = {
   readonly crumbs: BreadcrumbCrumb[];
@@ -12,6 +14,7 @@ export const AppBreadcrumb = ({ crumbs }: Props) => {
       {crumbs.map((crumb, index) => {
         const isLast = index === crumbs.length - 1;
         const Icon = crumb.icon;
+        const plainLabel = stripInlineMarkdown({ text: crumb.label });
         return (
           <span key={crumb.id} className="flex min-w-0 items-center gap-2">
             {index > 0 && (
@@ -20,7 +23,7 @@ export const AppBreadcrumb = ({ crumbs }: Props) => {
             {isLast ? (
               <span
                 className="inline-flex min-w-0 items-center gap-2 text-2xs font-medium text-foreground"
-                title={crumb.label}
+                title={plainLabel}
                 aria-current="page"
               >
                 {Icon == null ? null : (
@@ -30,7 +33,7 @@ export const AppBreadcrumb = ({ crumbs }: Props) => {
                     className="shrink-0 text-muted-foreground/70"
                   />
                 )}
-                <span className="min-w-0 truncate">{crumb.label}</span>
+                <InlineMarkdown text={crumb.label} className="min-w-0 truncate" />
                 {crumb.accessory}
               </span>
             ) : (
@@ -38,7 +41,7 @@ export const AppBreadcrumb = ({ crumbs }: Props) => {
                 type="button"
                 onClick={crumb.onClick}
                 className="inline-flex min-w-0 items-center gap-2 text-2xs text-muted-foreground transition-colors hover:text-foreground"
-                title={crumb.label}
+                title={plainLabel}
               >
                 {Icon == null ? null : (
                   <Icon
@@ -47,7 +50,7 @@ export const AppBreadcrumb = ({ crumbs }: Props) => {
                     className="shrink-0 text-muted-foreground/70"
                   />
                 )}
-                <span className="min-w-0 truncate">{crumb.label}</span>
+                <InlineMarkdown text={crumb.label} className="min-w-0 truncate" />
                 {crumb.accessory}
               </button>
             )}

--- a/apps/desktop/src/app/components/AppTopBar/NeedsYouSessionRow.tsx
+++ b/apps/desktop/src/app/components/AppTopBar/NeedsYouSessionRow.tsx
@@ -3,6 +3,8 @@ import type { Session, SessionId } from '@goodboy/types';
 import { useSessionStageInfo } from '../../../store';
 import { ATTENTION_REASON_META } from '../../../features/session/session-stage';
 import { CONCEPT_ICONS, ICON_SIZE } from '../../../shared/components/conceptIcons';
+import { InlineMarkdown } from '../../../shared/components/InlineMarkdown';
+import { stripInlineMarkdown } from '../../../shared/components/InlineMarkdown/stripInlineMarkdown';
 
 type Props = {
   readonly session: Session;
@@ -23,7 +25,7 @@ export const NeedsYouSessionRow = ({ session, onSelect }: Props) => {
       <button
         type="button"
         onClick={() => onSelect({ sessionId: session.id as SessionId })}
-        title={`${session.goal} · ${reason}`}
+        title={`${stripInlineMarkdown({ text: session.goal })} · ${reason}`}
         className="flex w-full items-start gap-2 px-3 py-2.5 text-left transition-colors hover:bg-muted/50"
       >
         <Icon
@@ -32,7 +34,10 @@ export const NeedsYouSessionRow = ({ session, onSelect }: Props) => {
           className={cn('mt-px shrink-0', tintClasses(meta?.tone ?? 'neutral').icon)}
         />
         <span className="flex min-w-0 flex-1 flex-col gap-0.5">
-          <span className="truncate text-xs font-medium text-foreground">{session.goal}</span>
+          <InlineMarkdown
+            text={session.goal}
+            className="truncate text-xs font-medium text-foreground"
+          />
           <span className="truncate text-2xs text-muted-foreground">{reason}</span>
         </span>
       </button>

--- a/apps/desktop/src/features/budget/components/BudgetStudio/ScopeRail.tsx
+++ b/apps/desktop/src/features/budget/components/BudgetStudio/ScopeRail.tsx
@@ -4,6 +4,8 @@ import type { ProviderSpendEntry } from '../../../../store';
 import { ProviderIcon } from '../../../providers/components/ProviderIcon';
 import { providerLabel, spendTone, type BudgetScope, type SessionSpend } from './lib';
 import { ICON_SIZE } from '../../../../shared/components/conceptIcons';
+import { InlineMarkdown } from '../../../../shared/components/InlineMarkdown';
+import { stripInlineMarkdown } from '../../../../shared/components/InlineMarkdown/stripInlineMarkdown';
 
 type Props = {
   readonly scope: BudgetScope;
@@ -83,7 +85,7 @@ export const ScopeRail = ({ scope, onSelect, providers, sessions }: Props) => {
                     selected={active}
                     onClick={() => onSelect({ kind: 'session', sessionId: s.sessionId })}
                     ariaCurrent={active}
-                    title={s.goal}
+                    title={stripInlineMarkdown({ text: s.goal })}
                     className="items-center gap-2 px-2.5 py-2"
                   >
                     {s.isCurrent ? (
@@ -94,7 +96,7 @@ export const ScopeRail = ({ scope, onSelect, providers, sessions }: Props) => {
                     ) : (
                       <span aria-hidden className="size-1.5 shrink-0 rounded-full bg-border-soft" />
                     )}
-                    <span className="min-w-0 flex-1 truncate text-sm">{s.goal}</span>
+                    <InlineMarkdown text={s.goal} className="min-w-0 flex-1 truncate text-sm" />
                     <span className="shrink-0 font-mono text-2xs tabular-nums text-muted-foreground">
                       {formatUsd(s.spentUsd)}
                     </span>

--- a/apps/desktop/src/features/budget/components/BudgetStudio/index.tsx
+++ b/apps/desktop/src/features/budget/components/BudgetStudio/index.tsx
@@ -9,6 +9,7 @@ import { OverviewPanel } from './OverviewPanel';
 import { ProviderPanel } from './ProviderPanel';
 import { ScopeRail } from './ScopeRail';
 import { SessionPanel } from './SessionPanel';
+import { stripInlineMarkdown } from '../../../../shared/components/InlineMarkdown/stripInlineMarkdown';
 import {
   BUDGET_WINDOW_DAYS,
   BUDGET_WINDOW_OPTIONS,
@@ -257,7 +258,7 @@ export const BudgetSettingsScope = ({ initialScope, requestClose }: Props) => {
             ) : selectedSession != null ? (
               <SessionPanel
                 sessionId={selectedSession.id}
-                goal={selectedSession.goal}
+                goal={stripInlineMarkdown({ text: selectedSession.goal })}
                 isCurrent={selectedSession.id === currentSessionId}
                 turns={turns.filter((t) => t.sessionId === selectedSession.id)}
                 softCapUsd={sessionBudgets[selectedSession.id]?.softCapUsd ?? null}

--- a/apps/desktop/src/features/chat/components/ChatBreadcrumb/index.tsx
+++ b/apps/desktop/src/features/chat/components/ChatBreadcrumb/index.tsx
@@ -10,6 +10,8 @@ import {
   type AgentKind,
 } from '../../../session/agent-kind';
 import { AgentAvatar } from '../../../../shared/components/AgentAvatar';
+import { InlineMarkdown } from '../../../../shared/components/InlineMarkdown';
+import { stripInlineMarkdown } from '../../../../shared/components/InlineMarkdown/stripInlineMarkdown';
 import { tintClasses } from '@goodboy/ui';
 
 const workflowAccent = tintClasses('primary');
@@ -133,8 +135,11 @@ export const ChatBreadcrumb = ({ session }: Props) => {
 
           <Separator />
 
-          <span className="min-w-0 truncate font-medium text-foreground/90" title={sessionLabel}>
-            {sessionLabel}
+          <span
+            className="min-w-0 truncate font-medium text-foreground/90"
+            title={stripInlineMarkdown({ text: sessionLabel })}
+          >
+            <InlineMarkdown text={sessionLabel} />
           </span>
 
           {workflowProgress ? (

--- a/apps/desktop/src/features/impact/components/ImpactStudio/SessionRows.tsx
+++ b/apps/desktop/src/features/impact/components/ImpactStudio/SessionRows.tsx
@@ -3,6 +3,7 @@ import type { SessionId } from '@goodboy/types';
 import { ArrowUpRight } from 'lucide-react';
 import { FilledEmptyState } from '@goodboy/ui';
 import { CONCEPT_ICONS, CONCEPT_TONE, ICON_SIZE } from '../../../../shared/components/conceptIcons';
+import { InlineMarkdown } from '../../../../shared/components/InlineMarkdown';
 
 type Props = {
   readonly sessions: ReadonlyArray<ImpactSession>;
@@ -30,7 +31,7 @@ export const SessionRows = ({ sessions, valueLabel, formatValue, onOpenSession }
           onClick={() => onOpenSession(session.sessionId)}
           className="flex items-center gap-3 rounded-md px-2 py-1.5 text-left text-xs transition-colors hover:bg-muted/60"
         >
-          <span className="min-w-0 flex-1 truncate text-foreground">{session.goal}</span>
+          <InlineMarkdown text={session.goal} className="min-w-0 flex-1 truncate text-foreground" />
           <span className="shrink-0 font-mono tabular-nums text-muted-foreground">
             {formatValue(session.value)} {valueLabel}
           </span>

--- a/apps/desktop/src/features/integrations/components/LaunchSessionPanel/index.tsx
+++ b/apps/desktop/src/features/integrations/components/LaunchSessionPanel/index.tsx
@@ -6,6 +6,7 @@ import { useAppStore } from '../../../../store';
 import { useToast } from '../../../../app/components/Toast';
 import { LaunchedNotice } from './LaunchedNotice';
 import { ICON_SIZE } from '../../../../shared/components/conceptIcons';
+import { stripInlineMarkdown } from '../../../../shared/components/InlineMarkdown/stripInlineMarkdown';
 
 type ExternalTask = {
   readonly provider: SessionExternalTaskProvider;
@@ -65,7 +66,7 @@ export const LaunchSessionPanel = ({
         goal,
         externalTasks: [externalTask],
       });
-      showToast('success', `Session created: ${session.goal}`);
+      showToast('success', `Session created: ${stripInlineMarkdown({ text: session.goal })}`);
       onClose();
     } catch (launchError) {
       setError(formatError(launchError));

--- a/apps/desktop/src/features/notifications/components/NotificationCenter/index.tsx
+++ b/apps/desktop/src/features/notifications/components/NotificationCenter/index.tsx
@@ -19,6 +19,7 @@ import { useAppStore } from '../../../../store';
 import { mapNotificationAction } from '../NotificationToastBridge';
 import { RoutingPicker } from '../../../../shared/components/RoutingPicker';
 import { CONCEPT_ICONS, CONCEPT_TONE, ICON_SIZE } from '../../../../shared/components/conceptIcons';
+import { stripInlineMarkdown } from '../../../../shared/components/InlineMarkdown/stripInlineMarkdown';
 import { formatRelativeAge } from '../../../../shared/utils/relativeDate';
 import { NOTIFICATIONS_STUDIO_EVENT } from '../../studioEvent';
 import { sendNotificationToDevelopers } from '../../../settings/sendNotificationToDevelopers';
@@ -211,8 +212,10 @@ const NotificationGroup = ({ notifications, onNavigated, onDismiss }: Notificati
   const canSendToDevelopers = n.severity === 'warning' || n.severity === 'error';
 
   const isUnread = notifications.some((notification) => !notification.read);
-  const source =
-    useAppStore((s) => s.sessions.find((session) => session.id === n.sessionId)?.goal) ?? 'Goodboy';
+  const sessionGoal = useAppStore(
+    (s) => s.sessions.find((session) => session.id === n.sessionId)?.goal,
+  );
+  const source = sessionGoal == null ? 'Goodboy' : stripInlineMarkdown({ text: sessionGoal });
   const border =
     n.severity === 'error'
       ? 'border-l-danger/40'

--- a/apps/desktop/src/features/notifications/components/NotificationToastBridge/index.tsx
+++ b/apps/desktop/src/features/notifications/components/NotificationToastBridge/index.tsx
@@ -3,6 +3,7 @@ import type { Notification, NotificationAction } from '@goodboy/db';
 import type { Session, Workspace } from '@goodboy/types';
 import { useAppStore } from '../../../../store';
 import { useToast, type ToastAction } from '../../../../app/components/Toast';
+import { stripInlineMarkdown } from '../../../../shared/components/InlineMarkdown/stripInlineMarkdown';
 import type { BudgetScope } from '../../../budget/components/BudgetStudio/lib';
 
 export const pickFreshFailures = (
@@ -39,7 +40,7 @@ export const notificationContext = (
   }
   const session = n.sessionId ? sessions.find((s) => s.id === n.sessionId) : undefined;
   if (session) {
-    parts.push(session.goal.trim() || 'untitled session');
+    parts.push(stripInlineMarkdown({ text: session.goal }).trim() || 'untitled session');
   }
   return parts.length > 0 ? parts.join(' · ') : undefined;
 };

--- a/apps/desktop/src/features/session/components/CommandPalette/index.tsx
+++ b/apps/desktop/src/features/session/components/CommandPalette/index.tsx
@@ -19,6 +19,7 @@ import { PREFIXES, parseQuery, type QuickActionGroup } from '../../../quick-acti
 import { REPORT_ISSUE_STUDIO_EVENT } from '../../../settings/reportIssueStudioEvent';
 import { useToast } from '../../../../app/components/Toast';
 import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../shared/components/conceptIcons';
+import { stripInlineMarkdown } from '../../../../shared/components/InlineMarkdown/stripInlineMarkdown';
 import { useThemeStore } from '../../../../shared/lib/theme';
 import { linkedProjectsLabel } from '../../../workspace/linkedProjectsLabel';
 import { shortcutGlyphs } from '../../../../shared/keyboard/registry';
@@ -140,7 +141,7 @@ export const CommandPalette = ({
       const ws = workspaces.find((w) => w.id === s.workspaceId);
       out.push({
         id: `session:${s.id}`,
-        label: s.goal || 'untitled session',
+        label: stripInlineMarkdown({ text: s.goal }) || 'untitled session',
         sublabel: ws?.name,
         group: 'session',
         onSelect: () => void setCurrentSession(s.id),

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/HeaderBand.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/HeaderBand.test.tsx
@@ -121,6 +121,15 @@ describe('HeaderBand', () => {
     expect(screen.getByRole('button', { name: 'Mount a project' })).toBeDefined();
   });
 
+  it('renders a backticked title as inline code without the backticks', () => {
+    const marked = { ...session, goal: 'run `/explore` first' } as Session;
+    render(<HeaderBand session={marked} onSelectLens={vi.fn()} goal={<div>Goal</div>} />);
+
+    const title = screen.getByRole('button', { name: /run/ });
+    expect(title.querySelector('code')?.textContent).toBe('/explore');
+    expect(title.textContent).not.toContain('`');
+  });
+
   it('renders the session cost at the right edge of the context row', () => {
     render(<HeaderBand session={session} onSelectLens={vi.fn()} goal={<div>Goal</div>} />);
 

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/HeaderBand.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/HeaderBand.tsx
@@ -12,6 +12,7 @@ import { ContextChip } from './ContextChip';
 import { LinkedWorkChips } from './LinkedWorkChips';
 import { MountProjectAction } from './ProjectMountRows/MountProjectAction';
 import { CONCEPT_ICONS, ICON_SIZE } from '../../../../shared/components/conceptIcons';
+import { InlineMarkdown } from '../../../../shared/components/InlineMarkdown';
 import { ProjectMountRows } from './ProjectMountRows';
 import { SessionCostChip } from './SessionCostChip';
 
@@ -105,7 +106,7 @@ export const HeaderBand = ({ session, onSelectLens, goal }: Props) => {
               }}
               className="min-w-0 flex-1 cursor-text truncate rounded-md text-xl font-semibold leading-snug text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
             >
-              {goalText}
+              <InlineMarkdown text={goalText} />
             </h1>
           </Tooltip>
         )}

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/SessionCostChip.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/SessionCostChip.tsx
@@ -15,6 +15,7 @@ import { openBudgetStudio as openBudgetStudioEvent } from '../../../budget/openB
 import { SessionBudgetContent } from '../../../budget/components/BudgetStudio/SessionBudgetContent';
 import type { WorkspaceTurn } from '../../../budget/components/BudgetStudio/lib';
 import { EMPTY_ARRAY, useAppStore, useSessionCost } from '../../../../store';
+import { InlineMarkdown } from '../../../../shared/components/InlineMarkdown';
 import { manageDialogFocus } from './manageDialogFocus';
 import { VITAL_CHIP_FOCUS, VITAL_CHIP_FRAME, VITAL_CHIP_HOVER } from './vitalChip';
 
@@ -152,9 +153,10 @@ export const SessionCostChip = ({ sessionId }: Props) => {
     >
       <div className="flex flex-col gap-0.5 px-4 py-3">
         <span className="text-sm font-semibold text-foreground">Session budget</span>
-        <span className="truncate text-2xs text-muted-foreground">
-          {session?.goal ?? 'Untitled session'}
-        </span>
+        <InlineMarkdown
+          text={session?.goal ?? 'Untitled session'}
+          className="truncate text-2xs text-muted-foreground"
+        />
       </div>
       <Divider />
       <ScrollFade className="min-h-0 flex-1" viewportClassName="p-4">

--- a/apps/desktop/src/features/workspace/components/SessionActivityBar/index.tsx
+++ b/apps/desktop/src/features/workspace/components/SessionActivityBar/index.tsx
@@ -371,6 +371,7 @@ const SessionActivityItem = memo(function SessionActivityItem({
 
   const sessionCost = useSessionCost(session.id as SessionId);
   const age = formatRelativeAge({ fromIso: session.updatedAt });
+  const plainGoal = useMemo(() => stripInlineMarkdown({ text: session.goal }), [session.goal]);
 
   return (
     <button
@@ -392,7 +393,7 @@ const SessionActivityItem = memo(function SessionActivityItem({
         event.preventDefault();
         onModifierClick(session.id as SessionId, event);
       }}
-      title={`${stripInlineMarkdown({ text: session.goal })} · ${reason}${prMeta ? ` · PR ${prMeta.label}` : ''}${externalTasks.length > 0 ? ` · ${externalTasks.map((task) => task.identifier).join(', ')}` : ''}`}
+      title={`${plainGoal} · ${reason}${prMeta ? ` · PR ${prMeta.label}` : ''}${externalTasks.length > 0 ? ` · ${externalTasks.map((task) => task.identifier).join(', ')}` : ''}`}
       className={cn(
         'flex w-full cursor-pointer items-center gap-2 px-2.5 py-2.5 text-left',
         sessionCardShell({ stage, selected, active: isActive, dimmed }),

--- a/apps/desktop/src/features/workspace/components/SessionActivityBar/index.tsx
+++ b/apps/desktop/src/features/workspace/components/SessionActivityBar/index.tsx
@@ -35,6 +35,8 @@ import { ExternalTaskChip } from '../../../../features/integrations/components/E
 import { useMultiSelect } from '../../../../shared/hooks/useMultiSelect';
 import { useDragLasso } from '../../../../shared/hooks/useDragLasso';
 import { CONCEPT_ICONS, CONCEPT_TONE, ICON_SIZE } from '../../../../shared/components/conceptIcons';
+import { InlineMarkdown } from '../../../../shared/components/InlineMarkdown';
+import { stripInlineMarkdown } from '../../../../shared/components/InlineMarkdown/stripInlineMarkdown';
 import { PANE_RHYTHM } from '@goodboy/ui';
 import { sessionCardShell } from '../../../session/components/sessionCardShell';
 import { formatRelativeAge } from '../../../../shared/utils/relativeDate';
@@ -390,7 +392,7 @@ const SessionActivityItem = memo(function SessionActivityItem({
         event.preventDefault();
         onModifierClick(session.id as SessionId, event);
       }}
-      title={`${session.goal} · ${reason}${prMeta ? ` · PR ${prMeta.label}` : ''}${externalTasks.length > 0 ? ` · ${externalTasks.map((task) => task.identifier).join(', ')}` : ''}`}
+      title={`${stripInlineMarkdown({ text: session.goal })} · ${reason}${prMeta ? ` · PR ${prMeta.label}` : ''}${externalTasks.length > 0 ? ` · ${externalTasks.map((task) => task.identifier).join(', ')}` : ''}`}
       className={cn(
         'flex w-full cursor-pointer items-center gap-2 px-2.5 py-2.5 text-left',
         sessionCardShell({ stage, selected, active: isActive, dimmed }),
@@ -405,9 +407,10 @@ const SessionActivityItem = memo(function SessionActivityItem({
               pulsing={stage === 'running'}
             />
           </span>
-          <span className="line-clamp-2 min-w-0 flex-1 text-sm font-medium leading-snug">
-            {session.goal}
-          </span>
+          <InlineMarkdown
+            text={session.goal}
+            className="line-clamp-2 min-w-0 flex-1 text-sm font-medium leading-snug"
+          />
           <ProjectChip projectNames={projectNames} />
           {externalTasks.map((task) => (
             <ExternalTaskChip

--- a/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.test.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.test.tsx
@@ -164,6 +164,17 @@ describe('StageBoardCard layout', () => {
     expect(screen.getByText('no PR yet').className).toContain('truncate');
   });
 
+  it('renders a backticked goal as inline code and keeps the tooltip plain', () => {
+    const marked = { ...session, goal: 'run `/explore` first' } as unknown as Session;
+    render(<StageBoardCard session={marked} nav={nav} />);
+    const title = screen.getByText(/run/);
+    expect(title.querySelector('code')?.textContent).toBe('/explore');
+    expect(title.textContent).not.toContain('`');
+    expect(title.closest('[data-tooltip]')?.getAttribute('data-tooltip')).toBe(
+      'run /explore first · no PR yet',
+    );
+  });
+
   it('points at the session with a trailing chevron', () => {
     render(<StageBoardCard session={session} nav={nav} />);
     expect(document.querySelector('.lucide-chevron-right')).not.toBeNull();

--- a/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.tsx
@@ -27,6 +27,8 @@ import {
   CONCEPT_TONE,
   ICON_SIZE,
 } from '../../../../../shared/components/conceptIcons';
+import { InlineMarkdown } from '../../../../../shared/components/InlineMarkdown';
+import { stripInlineMarkdown } from '../../../../../shared/components/InlineMarkdown/stripInlineMarkdown';
 import { STAGE_TONE } from '../../../../session/session-stage';
 import { sessionCardShell } from '../../../../session/components/sessionCardShell';
 import { formatRelativeAge } from '../../../../../shared/utils/relativeDate';
@@ -102,6 +104,7 @@ export const StageBoardCard = memo(function StageBoardCard({
     ? (reviewDrafts ?? []).filter((draft) => draft.status === 'draft').length
     : 0;
 
+  const plainGoal = stripInlineMarkdown({ text: session.goal });
   const age = formatRelativeAge({ fromIso: session.updatedAt });
   const linkedRequest = getLinkedRequest({ pullRequest, mergeRequest });
   const isGitlab = mergeRequest != null && pullRequest == null;
@@ -165,10 +168,11 @@ export const StageBoardCard = memo(function StageBoardCard({
             prFetchState={prFetchState}
             onOpen={handlePrClick}
           />
-          <Tooltip content={`${session.goal}${reason ? ` · ${reason}` : ''}`} side="top">
-            <span className="line-clamp-2 min-h-10 min-w-0 flex-1 text-sm font-medium leading-snug">
-              {session.goal}
-            </span>
+          <Tooltip content={`${plainGoal}${reason ? ` · ${reason}` : ''}`} side="top">
+            <InlineMarkdown
+              text={session.goal}
+              className="line-clamp-2 min-h-10 min-w-0 flex-1 text-sm font-medium leading-snug"
+            />
           </Tooltip>
         </span>
 

--- a/apps/desktop/src/shared/components/InlineMarkdown/index.test.tsx
+++ b/apps/desktop/src/shared/components/InlineMarkdown/index.test.tsx
@@ -54,6 +54,15 @@ describe('parseInlineMarkdown', () => {
     ]);
   });
 
+  it('treats a word-internal underscore as literal but a boundary-flanked one as emphasis', () => {
+    expect(parseInlineMarkdown({ text: 'foo_bar_baz' })).toEqual([
+      { kind: 'text', value: 'foo_bar_baz' },
+    ]);
+    expect(parseInlineMarkdown({ text: '_bar_' })).toEqual([
+      { kind: 'em', children: [{ kind: 'text', value: 'bar' }] },
+    ]);
+  });
+
   it('returns nothing for an empty string', () => {
     expect(parseInlineMarkdown({ text: '' })).toEqual([]);
   });

--- a/apps/desktop/src/shared/components/InlineMarkdown/index.test.tsx
+++ b/apps/desktop/src/shared/components/InlineMarkdown/index.test.tsx
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { InlineMarkdown } from './index';
+import { parseInlineMarkdown } from './parseInlineMarkdown';
+import { stripInlineMarkdown } from './stripInlineMarkdown';
+
+describe('parseInlineMarkdown', () => {
+  it('reads inline code between backticks', () => {
+    expect(parseInlineMarkdown({ text: 'run `/explore` now' })).toEqual([
+      { kind: 'text', value: 'run ' },
+      { kind: 'code', value: '/explore' },
+      { kind: 'text', value: ' now' },
+    ]);
+  });
+
+  it('reads bold with either delimiter', () => {
+    expect(parseInlineMarkdown({ text: '**ship** __it__' })).toEqual([
+      { kind: 'strong', children: [{ kind: 'text', value: 'ship' }] },
+      { kind: 'text', value: ' ' },
+      { kind: 'strong', children: [{ kind: 'text', value: 'it' }] },
+    ]);
+  });
+
+  it('reads italic with either delimiter', () => {
+    expect(parseInlineMarkdown({ text: '*soon* _later_' })).toEqual([
+      { kind: 'em', children: [{ kind: 'text', value: 'soon' }] },
+      { kind: 'text', value: ' ' },
+      { kind: 'em', children: [{ kind: 'text', value: 'later' }] },
+    ]);
+  });
+
+  it('keeps plain text nested inside emphasis', () => {
+    expect(parseInlineMarkdown({ text: '**fix `auth` bug**' })).toEqual([
+      {
+        kind: 'strong',
+        children: [
+          { kind: 'text', value: 'fix ' },
+          { kind: 'code', value: 'auth' },
+          { kind: 'text', value: ' bug' },
+        ],
+      },
+    ]);
+  });
+
+  it('leaves unbalanced markers literal', () => {
+    expect(parseInlineMarkdown({ text: 'a `b and **c and *d' })).toEqual([
+      { kind: 'text', value: 'a `b and **c and *d' },
+    ]);
+  });
+
+  it('leaves underscores inside a word literal', () => {
+    expect(parseInlineMarkdown({ text: 'rename foo_bar_baz' })).toEqual([
+      { kind: 'text', value: 'rename foo_bar_baz' },
+    ]);
+  });
+
+  it('returns nothing for an empty string', () => {
+    expect(parseInlineMarkdown({ text: '' })).toEqual([]);
+  });
+});
+
+describe('stripInlineMarkdown', () => {
+  it('drops the markers and keeps the content', () => {
+    expect(stripInlineMarkdown({ text: 'run `/explore` on **auth** _now_' })).toBe(
+      'run /explore on auth now',
+    );
+  });
+
+  it('keeps unbalanced markers', () => {
+    expect(stripInlineMarkdown({ text: 'a `b **c' })).toBe('a `b **c');
+  });
+
+  it('passes plain text through unchanged', () => {
+    expect(stripInlineMarkdown({ text: 'plain title' })).toBe('plain title');
+  });
+});
+
+describe('InlineMarkdown', () => {
+  it('renders backticked text as a code element without the backticks', () => {
+    render(<InlineMarkdown text="run `/explore` now" />);
+
+    const code = screen.getByText('/explore');
+    expect(code.tagName).toBe('CODE');
+    expect(screen.getByText(/run/).textContent).not.toContain('`');
+  });
+
+  it('renders bold and italic as strong and em', () => {
+    const { container } = render(<InlineMarkdown text="**ship** _it_" />);
+
+    expect(container.querySelector('strong')?.textContent).toBe('ship');
+    expect(container.querySelector('em')?.textContent).toBe('it');
+  });
+
+  it('applies the className to the wrapper', () => {
+    const { container } = render(<InlineMarkdown text="title" className="truncate" />);
+
+    expect(container.firstElementChild?.className).toBe('truncate');
+  });
+});

--- a/apps/desktop/src/shared/components/InlineMarkdown/index.tsx
+++ b/apps/desktop/src/shared/components/InlineMarkdown/index.tsx
@@ -1,0 +1,45 @@
+import { memo, type ReactNode } from 'react';
+import { parseInlineMarkdown, type InlineToken } from './parseInlineMarkdown';
+
+type Props = {
+  readonly text: string;
+  readonly className?: string;
+};
+
+const CODE_CLASS = 'rounded-md bg-muted/50 px-1 py-0 font-mono text-foreground/90';
+
+type RenderParams = {
+  readonly tokens: ReadonlyArray<InlineToken>;
+  readonly keyPrefix: string;
+};
+
+const renderTokens = ({ tokens, keyPrefix }: RenderParams): ReactNode =>
+  tokens.map((token, position) => {
+    const key = `${keyPrefix}-${position}`;
+    if (token.kind === 'text') {
+      return token.value;
+    }
+    if (token.kind === 'code') {
+      return (
+        <code key={key} className={CODE_CLASS}>
+          {token.value}
+        </code>
+      );
+    }
+    if (token.kind === 'strong') {
+      return (
+        <strong key={key} className="font-semibold">
+          {renderTokens({ tokens: token.children, keyPrefix: key })}
+        </strong>
+      );
+    }
+    return <em key={key}>{renderTokens({ tokens: token.children, keyPrefix: key })}</em>;
+  });
+
+const InlineMarkdownImpl = ({ text, className }: Props) => (
+  <span className={className}>
+    {renderTokens({ tokens: parseInlineMarkdown({ text }), keyPrefix: 'i' })}
+  </span>
+);
+
+export const InlineMarkdown = memo(InlineMarkdownImpl);

--- a/apps/desktop/src/shared/components/InlineMarkdown/parseInlineMarkdown.ts
+++ b/apps/desktop/src/shared/components/InlineMarkdown/parseInlineMarkdown.ts
@@ -8,14 +8,17 @@ type Params = {
   readonly text: string;
 };
 
-const EM_BOUNDARY_RE = /[\s(\[{,.!?:;'"]/;
+const EM_BOUNDARY_PUNCTUATION = new Set(['(', '[', '{', ',', '.', '!', '?', ':', ';', "'", '"']);
+
+const isEmBoundaryChar = (char: string): boolean =>
+  /\s/.test(char) || EM_BOUNDARY_PUNCTUATION.has(char);
 
 const isEmphasisStart = ({ text, index }: { readonly text: string; readonly index: number }) => {
   const previous = text[index - 1];
   if (previous === undefined) {
     return true;
   }
-  return EM_BOUNDARY_RE.test(previous);
+  return isEmBoundaryChar(previous);
 };
 
 export const parseInlineMarkdown = ({ text }: Params): ReadonlyArray<InlineToken> => {

--- a/apps/desktop/src/shared/components/InlineMarkdown/parseInlineMarkdown.ts
+++ b/apps/desktop/src/shared/components/InlineMarkdown/parseInlineMarkdown.ts
@@ -1,0 +1,82 @@
+export type InlineToken =
+  | { readonly kind: 'text'; readonly value: string }
+  | { readonly kind: 'code'; readonly value: string }
+  | { readonly kind: 'strong'; readonly children: ReadonlyArray<InlineToken> }
+  | { readonly kind: 'em'; readonly children: ReadonlyArray<InlineToken> };
+
+type Params = {
+  readonly text: string;
+};
+
+const EM_BOUNDARY_RE = /[\s(\[{,.!?:;'"]/;
+
+const isEmphasisStart = ({ text, index }: { readonly text: string; readonly index: number }) => {
+  const previous = text[index - 1];
+  if (previous === undefined) {
+    return true;
+  }
+  return EM_BOUNDARY_RE.test(previous);
+};
+
+export const parseInlineMarkdown = ({ text }: Params): ReadonlyArray<InlineToken> => {
+  const tokens: InlineToken[] = [];
+  let buffer = '';
+  let index = 0;
+
+  const flush = () => {
+    if (buffer.length === 0) {
+      return;
+    }
+    tokens.push({ kind: 'text', value: buffer });
+    buffer = '';
+  };
+
+  while (index < text.length) {
+    const char = text[index]!;
+
+    if (char === '`') {
+      const end = text.indexOf('`', index + 1);
+      if (end > index + 1) {
+        flush();
+        tokens.push({ kind: 'code', value: text.slice(index + 1, end) });
+        index = end + 1;
+        continue;
+      }
+    }
+
+    if ((char === '*' || char === '_') && text[index + 1] === char) {
+      const delimiter = `${char}${char}`;
+      const end = text.indexOf(delimiter, index + 2);
+      if (end > index + 2) {
+        flush();
+        tokens.push({
+          kind: 'strong',
+          children: parseInlineMarkdown({ text: text.slice(index + 2, end) }),
+        });
+        index = end + 2;
+        continue;
+      }
+    }
+
+    if ((char === '*' || char === '_') && text[index + 1] !== char) {
+      if (isEmphasisStart({ text, index })) {
+        const end = text.indexOf(char, index + 1);
+        if (end > index + 1 && text[end + 1] !== char) {
+          flush();
+          tokens.push({
+            kind: 'em',
+            children: parseInlineMarkdown({ text: text.slice(index + 1, end) }),
+          });
+          index = end + 1;
+          continue;
+        }
+      }
+    }
+
+    buffer += char;
+    index++;
+  }
+
+  flush();
+  return tokens;
+};

--- a/apps/desktop/src/shared/components/InlineMarkdown/stripInlineMarkdown.ts
+++ b/apps/desktop/src/shared/components/InlineMarkdown/stripInlineMarkdown.ts
@@ -1,0 +1,18 @@
+import { parseInlineMarkdown, type InlineToken } from './parseInlineMarkdown';
+
+type Params = {
+  readonly text: string;
+};
+
+const flatten = (tokens: ReadonlyArray<InlineToken>): string =>
+  tokens
+    .map((token) => {
+      if (token.kind === 'text' || token.kind === 'code') {
+        return token.value;
+      }
+      return flatten(token.children);
+    })
+    .join('');
+
+export const stripInlineMarkdown = ({ text }: Params): string =>
+  flatten(parseInlineMarkdown({ text }));


### PR DESCRIPTION
## Why
n-bro: titles should read as markdown, in the overview header and on the card. A goal like `` Move `/explore` in the new routing `` showed raw backticks everywhere.

## What
- `shared/components/InlineMarkdown`: a dependency-free inline tokenizer (inline code, bold, italic; unbalanced markers stay literal; `foo_bar_baz` stays literal like the chat rule), a memoized `InlineMarkdown` component using the chat inline-code tokens at the surrounding font size, and `stripInlineMarkdown` for string sinks.
- Rendered: overview header title, board card, sidebar session rows, top-bar needs-you rows, app breadcrumb, chat breadcrumb, impact and budget session rows, cost chip subtitle.
- Stripped: notification center and toasts, command palette label (search matches the plain text now), budget panel title, launch toast.
- Untouched on purpose: the goal editor (raw), archive/delete confirms (quoted mono block), outgoing PR/MR titles.

## Tests
- 13 parser/component cases; board card and overview header assert a `<code>` element and no literal backtick; workspace + session + app + regression suites green (2344), chat/budget/impact/notifications/integrations green (1061).

🤖 Generated with [Claude Code](https://claude.com/claude-code)