### PR TITLE
fix(ui): studio rail layout owns its flex row

### DIFF
--- a/apps/desktop/src/features/providers/components/ProviderStudio/index.test.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/index.test.tsx
@@ -32,17 +32,10 @@ describe('ProviderSettingsScope', () => {
 
     const aside = screen.getByRole('complementary', { name: 'Providers' });
     const heading = screen.getByRole('heading', { name: 'Defaults' });
+    const wrapper = aside.parentElement;
 
-    const hasFlexClass = (element: Element) =>
-      element.className.toString().split(/\s+/).includes('flex');
-
-    let ancestor = heading.parentElement;
-    while (ancestor !== null && !hasFlexClass(ancestor)) {
-      ancestor = ancestor.parentElement;
-    }
-
-    expect(ancestor).not.toBeNull();
-    expect(ancestor?.contains(aside)).toBe(true);
-    expect(Array.from(ancestor?.children ?? []).includes(aside)).toBe(true);
+    expect(wrapper).not.toBeNull();
+    expect(wrapper?.classList.contains('flex')).toBe(true);
+    expect(Array.from(wrapper?.children ?? []).some((child) => child.contains(heading))).toBe(true);
   });
 });

--- a/apps/desktop/src/features/providers/components/ProviderStudio/index.test.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/index.test.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import type { WorkspaceId } from '@goodboy/types';
+
+const { state } = vi.hoisted(() => ({
+  state: {
+    providers: [] as ReadonlyArray<{ id: string; connection: string }>,
+    refreshProviders: vi.fn(async () => undefined),
+    providerConnect: {} as Record<string, { phase: string }>,
+  },
+}));
+
+vi.mock('../../../../store', () => ({
+  useAppStore: Object.assign(<T,>(selector: (store: typeof state) => T) => selector(state), {
+    getState: () => state,
+  }),
+}));
+
+vi.mock('./DefaultsPanel', () => ({
+  DefaultsPanel: () => <h1>Defaults</h1>,
+}));
+
+import { ProviderSettingsScope } from './index';
+
+afterEach(cleanup);
+
+describe('ProviderSettingsScope', () => {
+  it('keeps the providers rail and the Defaults panel side by side in a flex row', () => {
+    render(<ProviderSettingsScope workspaceId={'workspace-1' as WorkspaceId} />);
+
+    const aside = screen.getByRole('complementary', { name: 'Providers' });
+    const heading = screen.getByRole('heading', { name: 'Defaults' });
+
+    const hasFlexClass = (element: Element) =>
+      element.className.toString().split(/\s+/).includes('flex');
+
+    let ancestor = heading.parentElement;
+    while (ancestor !== null && !hasFlexClass(ancestor)) {
+      ancestor = ancestor.parentElement;
+    }
+
+    expect(ancestor).not.toBeNull();
+    expect(ancestor?.contains(aside)).toBe(true);
+    expect(Array.from(ancestor?.children ?? []).includes(aside)).toBe(true);
+  });
+});

--- a/packages/ui/src/__tests__/StudioRailLayout.test.tsx
+++ b/packages/ui/src/__tests__/StudioRailLayout.test.tsx
@@ -37,7 +37,7 @@ describe('StudioRailLayout', () => {
     const wrapper = aside.parentElement;
 
     expect(wrapper).not.toBeNull();
-    expect(wrapper?.className).toContain('flex');
+    expect(wrapper?.classList.contains('flex')).toBe(true);
     expect(Array.from(wrapper?.children ?? []).map((child) => child.tagName)).toEqual([
       'ASIDE',
       'DIV',

--- a/packages/ui/src/__tests__/StudioRailLayout.test.tsx
+++ b/packages/ui/src/__tests__/StudioRailLayout.test.tsx
@@ -36,15 +36,25 @@ describe('StudioRailLayout', () => {
     const aside = screen.getByRole('complementary', { name: 'Project navigation' });
     const wrapper = aside.parentElement;
 
-    expect(wrapper).not.toBeNull();
-    expect(wrapper?.classList.contains('flex')).toBe(true);
-    expect(Array.from(wrapper?.children ?? []).map((child) => child.tagName)).toEqual([
+    if (wrapper == null) {
+      throw new Error('wrapper not found');
+    }
+
+    expect(wrapper.classList.contains('flex')).toBe(true);
+    expect(Array.from(wrapper.children).map((child) => child.tagName)).toEqual([
       'ASIDE',
       'DIV',
       'DIV',
     ]);
-    expect(wrapper?.children[0]).toBe(aside);
-    expect(wrapper?.children[1]).toBe(screen.getByRole('separator'));
-    expect(wrapper?.children[2].textContent).toBe('Detail content');
+
+    const [asideChild, separatorChild, detailChild] = wrapper.children;
+
+    if (asideChild == null || separatorChild == null || detailChild == null) {
+      throw new Error('wrapper children not found');
+    }
+
+    expect(asideChild).toBe(aside);
+    expect(separatorChild).toBe(screen.getByRole('separator'));
+    expect(detailChild.textContent).toBe('Detail content');
   });
 });

--- a/packages/ui/src/__tests__/StudioRailLayout.test.tsx
+++ b/packages/ui/src/__tests__/StudioRailLayout.test.tsx
@@ -22,4 +22,29 @@ describe('StudioRailLayout', () => {
     expect(screen.getByText('Detail content')).toBeDefined();
     expect(screen.getByRole('separator').getAttribute('aria-orientation')).toBe('vertical');
   });
+
+  it('wraps aside, divider and detail in a flex row so hosts cannot break the layout', () => {
+    render(
+      <StudioRailLayout
+        rail={<p>Rail content</p>}
+        detail={<p>Detail content</p>}
+        railLabel="Project navigation"
+        railWidth="standard"
+      />,
+    );
+
+    const aside = screen.getByRole('complementary', { name: 'Project navigation' });
+    const wrapper = aside.parentElement;
+
+    expect(wrapper).not.toBeNull();
+    expect(wrapper?.className).toContain('flex');
+    expect(Array.from(wrapper?.children ?? []).map((child) => child.tagName)).toEqual([
+      'ASIDE',
+      'DIV',
+      'DIV',
+    ]);
+    expect(wrapper?.children[0]).toBe(aside);
+    expect(wrapper?.children[1]).toBe(screen.getByRole('separator'));
+    expect(wrapper?.children[2].textContent).toBe('Detail content');
+  });
 });

--- a/packages/ui/src/components/StudioRailLayout.tsx
+++ b/packages/ui/src/components/StudioRailLayout.tsx
@@ -18,7 +18,7 @@ type Props = {
 
 export const StudioRailLayout = ({ rail, detail, railLabel, railWidth }: Props) => {
   return (
-    <>
+    <div className="flex h-full min-h-0 flex-1">
       <aside
         aria-label={railLabel}
         className={cn('flex min-h-0 shrink-0 flex-col', RAIL_WIDTH_CLASSES[railWidth])}
@@ -27,6 +27,6 @@ export const StudioRailLayout = ({ rail, detail, railLabel, railWidth }: Props) 
       </aside>
       <Divider orientation="vertical" />
       <div className="min-h-0 flex-1">{detail}</div>
-    </>
+    </div>
   );
 };


### PR DESCRIPTION
## Why
Regression in v0.2.14: Settings > Providers & models renders its providers rail above the Defaults detail, pushed to the right, instead of side by side.

## Root cause
`StudioRailLayout` returned a fragment and relied on its host for the horizontal flex row. The provider scope lost that host (`StudioShell`) when every setting moved onto one settings surface, and the settings detail slot is a plain block.

## What
- `StudioRailLayout` wraps aside, divider and detail in its own `flex h-full min-h-0 flex-1` container. Every other host already placed it as the sole child of a flex row, so nothing else changes.
- Tests: the wrapper is flex with the three parts as direct children in order; the provider scope rendered inside settings shows the inner rail and the Defaults heading as siblings of one flex container.

## Verification
- `@goodboy/ui` suite 237 green; desktop settings, providers, inbox, budget, impact, changelog, workflows panel, bitbucket and regression suites 581 green; typecheck, knip production, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)