### PR TITLE
fix(ui): review board shows an empty state without a pull request

### DIFF
--- a/apps/desktop/src/features/review/components/ReviewBoardPane/index.test.tsx
+++ b/apps/desktop/src/features/review/components/ReviewBoardPane/index.test.tsx
@@ -24,6 +24,7 @@ const h = vi.hoisted(() => {
     publishPrReview: vi.fn(async () => ({ published: 1, stale: [], failed: [], mismatched: [] })),
     setAgentDraft: vi.fn(),
     selectAgent: vi.fn(async () => undefined),
+    setActiveLens: vi.fn(),
   };
   const useAppStore = Object.assign(<T,>(selector: (s: typeof state) => T) => selector(state), {
     getState: () => state,
@@ -148,6 +149,7 @@ beforeEach(() => {
     mismatched: [],
   });
   h.state.setAgentDraft.mockClear();
+  h.state.setActiveLens.mockClear();
   h.showToast.mockClear();
   h.diff.refresh.mockClear();
   localStorage.clear();
@@ -301,6 +303,53 @@ describe('ReviewBoardPane', () => {
     const retry = screen.getByRole('button', { name: 'Retry' });
     fireEvent.click(retry);
     expect(h.diff.refresh).toHaveBeenCalled();
+  });
+
+  it('points at the pull request lens when the session has no pull request linked', () => {
+    h.diff.target = null;
+    h.diff.files = [];
+    h.diff.loading = false;
+    render(<ReviewBoardPane session={SESSION} />);
+
+    expect(screen.getByText('No pull request to review')).toBeDefined();
+    expect(
+      screen.getByText(
+        "The review board reviews the diff of this session's pull request, and none is linked yet. The GitHub lens opens or creates one.",
+      ),
+    ).toBeDefined();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open GitHub' }));
+    expect(h.state.setActiveLens).toHaveBeenCalledWith('session-1', 'pr');
+
+    expect(screen.queryByRole('tab', { name: 'Unified' })).toBeNull();
+    expect(screen.queryByRole('tab', { name: 'Split' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Refresh diff' })).toBeNull();
+    expect(screen.queryByRole('button', { name: /Publish review/ })).toBeNull();
+    expect(screen.queryByText('0 files')).toBeNull();
+    expect(screen.queryByText(/Could not load/)).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Retry' })).toBeNull();
+  });
+
+  it('keeps the threads and resolvers sections reachable without a pull request', () => {
+    h.diff.target = null;
+    h.diff.files = [];
+    render(<ReviewBoardPane session={SESSION} />);
+
+    fireEvent.click(screen.getByRole('tab', { name: /Threads/ }));
+    expect(screen.getByTestId('threads-section')).toBeDefined();
+
+    fireEvent.click(screen.getByRole('tab', { name: /Resolvers/ }));
+    expect(screen.getByTestId('resolvers-section')).toBeDefined();
+  });
+
+  it('waits on the skeleton while the pull request link is still loading', () => {
+    h.diff.target = null;
+    h.diff.files = [];
+    h.diff.loading = true;
+    render(<ReviewBoardPane session={SESSION} />);
+
+    expect(screen.getByRole('status', { name: 'Loading diff' })).toBeDefined();
+    expect(screen.queryByText('No pull request to review')).toBeNull();
   });
 
   it('switches between review, threads, and resolver sections', () => {

--- a/apps/desktop/src/features/review/components/ReviewBoardPane/index.test.tsx
+++ b/apps/desktop/src/features/review/components/ReviewBoardPane/index.test.tsx
@@ -380,6 +380,10 @@ describe('ReviewBoardPane', () => {
 
     expect(screen.getByRole('status', { name: 'Loading diff' })).toBeDefined();
     expect(screen.queryByText('No pull request to review')).toBeNull();
+    expect(screen.queryByText(/files$/)).toBeNull();
+    expect(screen.queryByRole('tab', { name: 'Unified' })).toBeNull();
+    expect(screen.queryByRole('tab', { name: 'Split' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Refresh diff' })).toBeNull();
   });
 
   it('switches between review, threads, and resolver sections', () => {

--- a/apps/desktop/src/features/review/components/ReviewBoardPane/index.test.tsx
+++ b/apps/desktop/src/features/review/components/ReviewBoardPane/index.test.tsx
@@ -2,7 +2,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import type { FileDiff, IsoDateTime, PrReviewDraft, Session } from '@goodboy/types';
+import type { FileDiff, IsoDateTime, PrReviewDraft, Session, SessionId } from '@goodboy/types';
 
 const h = vi.hoisted(() => {
   const state = {
@@ -78,8 +78,28 @@ vi.mock('@goodboy/ui', async (importOriginal) => {
 });
 
 import { ReviewBoardPane } from './index';
+import {
+  resolveReviewTarget,
+  type ReviewTargetState,
+} from '../../../../store/slices/review-drafts/resolveReviewTarget';
 
 const SESSION = { id: 'session-1', workspaceId: 'workspace-1' } as unknown as Session;
+const SESSION_ID = SESSION.id as SessionId;
+
+const OWN_PR_STATE = {
+  sessionExternalTasks: { [SESSION_ID]: [] },
+  sessions: [],
+  projects: [],
+  sessionProjectMounts: {},
+  sessionActiveProject: {},
+  sessionProjectPrs: {},
+  sessionGithub: {
+    [SESSION_ID]: {
+      pr: { number: 1631, url: 'https://github.com/acme/web/pull/1631' },
+    },
+  },
+  sessionGitlabMr: {},
+} as unknown as ReviewTargetState;
 
 const FILE: FileDiff = {
   path: 'src/auth.ts',
@@ -303,6 +323,16 @@ describe('ReviewBoardPane', () => {
     const retry = screen.getByRole('button', { name: 'Retry' });
     fireEvent.click(retry);
     expect(h.diff.refresh).toHaveBeenCalled();
+  });
+
+  it('reviews the diff of the pull request this session opened', () => {
+    h.diff.target = resolveReviewTarget({ state: OWN_PR_STATE, sessionId: SESSION_ID });
+    render(<ReviewBoardPane session={SESSION} />);
+
+    expect(screen.queryByText('No pull request to review')).toBeNull();
+    expect(screen.getByText('acme/web #1631')).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Draft a comment on line 3' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Publish review (1)' })).toBeDefined();
   });
 
   it('points at the pull request lens when the session has no pull request linked', () => {

--- a/apps/desktop/src/features/review/components/ReviewBoardPane/index.tsx
+++ b/apps/desktop/src/features/review/components/ReviewBoardPane/index.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import {
+  Button,
   cn,
   DiffLayoutToggle,
   formatError,
@@ -52,6 +53,7 @@ export const ReviewBoardPane = ({ session }: Props) => {
   const updateReviewDraft = useAppStore((s) => s.updateReviewDraft);
   const discardReviewDraft = useAppStore((s) => s.discardReviewDraft);
   const publishPrReview = useAppStore((s) => s.publishPrReview);
+  const setActiveLens = useAppStore((s) => s.setActiveLens);
   const setAgentDraft = useAppStore((s) => s.setAgentDraft);
   const selectAgent = useAppStore((s) => s.selectAgent);
   const phaseRuns = useAppStore((s) => s.sessionPhaseRuns[sessionId] ?? EMPTY_ARRAY);
@@ -62,6 +64,7 @@ export const ReviewBoardPane = ({ session }: Props) => {
   const diffComments = useDiffComments(sessionId);
   const resolverIndex = useResolverIndex(sessionId);
   const { files, loading, error, target, refresh } = useReviewDiff({ session });
+  const hasNoTarget = target == null && !loading;
   const [layoutMode, setLayoutMode] = useDiffLayoutMode();
   const { showToast } = useToast();
   const [publishing, setPublishing] = useState(false);
@@ -189,13 +192,15 @@ export const ReviewBoardPane = ({ session }: Props) => {
               {`${target.repo} ${target.provider === 'gitlab' ? '!' : '#'}${target.prNumber}`}
             </span>
           ) : null}
-          <span className="text-2xs tabular-nums text-muted-foreground/60">
-            {loading ? '' : `${files.length} files`}
-          </span>
+          {hasNoTarget ? null : (
+            <span className="text-2xs tabular-nums text-muted-foreground/60">
+              {loading ? '' : `${files.length} files`}
+            </span>
+          )}
         </>
       }
       actions={
-        section === 'review' ? (
+        section === 'review' && !hasNoTarget ? (
           <>
             <DiffLayoutToggle mode={layoutMode} onChange={setLayoutMode} />
             <RefreshIconButton
@@ -224,7 +229,7 @@ export const ReviewBoardPane = ({ session }: Props) => {
       }
       fit="bleed"
       dock={
-        section === 'review' ? (
+        section === 'review' && !hasNoTarget ? (
           <PublishBar
             provider={target?.provider ?? 'github'}
             draftCount={openDrafts.length}
@@ -242,6 +247,20 @@ export const ReviewBoardPane = ({ session }: Props) => {
           inspectedResolverId={inspectedResolverId}
           onInspectResolver={openResolver}
         />
+      ) : hasNoTarget ? (
+        <div className={cn('flex min-h-0 flex-1 flex-col', PANE_RHYTHM.body)}>
+          <LensEmptyState
+            tone={CONCEPT_TONE.pr}
+            icon={CONCEPT_ICONS.pr}
+            title="No pull request to review"
+            description="The review board reviews the diff of this session's pull request, and none is linked yet. The GitHub lens opens or creates one."
+            action={
+              <Button size="sm" variant="secondary" onClick={() => setActiveLens(sessionId, 'pr')}>
+                Open GitHub
+              </Button>
+            }
+          />
+        </div>
       ) : (
         <div className="flex min-h-0 flex-1">
           <div className="flex min-w-0 flex-1 flex-col">

--- a/apps/desktop/src/features/review/components/ReviewBoardPane/index.tsx
+++ b/apps/desktop/src/features/review/components/ReviewBoardPane/index.tsx
@@ -64,6 +64,7 @@ export const ReviewBoardPane = ({ session }: Props) => {
   const diffComments = useDiffComments(sessionId);
   const resolverIndex = useResolverIndex(sessionId);
   const { files, loading, error, target, refresh } = useReviewDiff({ session });
+  const hasTarget = target != null;
   const hasNoTarget = target == null && !loading;
   const [layoutMode, setLayoutMode] = useDiffLayoutMode();
   const { showToast } = useToast();
@@ -192,15 +193,15 @@ export const ReviewBoardPane = ({ session }: Props) => {
               {`${target.repo} ${target.provider === 'gitlab' ? '!' : '#'}${target.prNumber}`}
             </span>
           ) : null}
-          {hasNoTarget ? null : (
+          {hasTarget ? (
             <span className="text-2xs tabular-nums text-muted-foreground/60">
               {loading ? '' : `${files.length} files`}
             </span>
-          )}
+          ) : null}
         </>
       }
       actions={
-        section === 'review' && !hasNoTarget ? (
+        section === 'review' && hasTarget ? (
           <>
             <DiffLayoutToggle mode={layoutMode} onChange={setLayoutMode} />
             <RefreshIconButton

--- a/apps/desktop/src/features/review/components/ReviewBoardPane/useReviewDiff.test.ts
+++ b/apps/desktop/src/features/review/components/ReviewBoardPane/useReviewDiff.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, renderHook, waitFor } from '@testing-library/react';
 import type {
   IsoDateTime,
+  PullRequestState,
   Session,
   SessionExternalTask,
   SessionId,
@@ -97,6 +98,36 @@ const mergeRequest: GitlabMergeRequest = {
   updatedAt: NOW,
 };
 
+const pullRequest: PullRequestState = {
+  number: 1631,
+  title: 'PR',
+  url: 'https://github.com/acme/web/pull/1631',
+  state: 'open',
+  mergeable: true,
+  checks: 'success',
+  baseBranch: 'main',
+  headBranch: 'ak/feature',
+  isDraft: false,
+  reviewDecision: null,
+  body: '',
+  updatedAt: NOW,
+};
+
+const githubState = (pr: PullRequestState | null): MockStore['sessionGithub'] => ({
+  [SESSION_ID]: {
+    pr,
+    linkedIssues: [],
+    fetchedAt: NOW,
+    failedAt: null,
+    loading: false,
+    error: null,
+    detail: null,
+    detailFetchedAt: null,
+    detailLoading: false,
+    detailError: null,
+  },
+});
+
 const BASE_STATE: MockStore = {
   sessionExternalTasks: { [SESSION_ID]: [githubTask, gitlabTask] },
   sessions: [],
@@ -104,6 +135,7 @@ const BASE_STATE: MockStore = {
   sessionProjectMounts: {},
   sessionActiveProject: {},
   sessionProjectPrs: { [SESSION_ID]: {} },
+  sessionGithub: githubState(null),
   sessionGitlabMr: {
     [SESSION_ID]: { mr: mergeRequest, fetchedAt: NOW, loading: false, error: null },
   },
@@ -138,7 +170,7 @@ describe('useReviewDiff', () => {
     expect(result.current.target).toEqual(resolveReviewTarget({ state, sessionId: SESSION_ID }));
   });
 
-  it('fetches the diff of the discovered merge request, not the priority-first candidate', async () => {
+  it('fetches the diff of the merge request this session opened, not a linked candidate', async () => {
     renderHook(() => useReviewDiff({ session }));
 
     await waitFor(() => expect(h.gitlabMrDiff).toHaveBeenCalledOnce());
@@ -147,8 +179,33 @@ describe('useReviewDiff', () => {
     expect(h.ghPrDiff).not.toHaveBeenCalled();
   });
 
+  it('fetches the diff of the pull request this session opened with nothing linked', async () => {
+    state = {
+      ...BASE_STATE,
+      sessionExternalTasks: { [SESSION_ID]: [] },
+      sessionGithub: githubState(pullRequest),
+      sessionGitlabMr: { [SESSION_ID]: { mr: null, fetchedAt: NOW, loading: false, error: null } },
+    };
+
+    const { result } = renderHook(() => useReviewDiff({ session }));
+
+    await waitFor(() => expect(h.ghPrDiff).toHaveBeenCalledOnce());
+
+    expect(result.current.target).toEqual({
+      provider: 'github',
+      repo: 'acme/web',
+      prNumber: 1631,
+    });
+    expect(h.ghPrDiff).toHaveBeenCalledWith('acme/web', 1631, '/repo', WORKSPACE_ID, undefined);
+    expect(h.gitlabMrDiff).not.toHaveBeenCalled();
+  });
+
   it('reports no target and no error once the links loaded without a pull request', async () => {
-    state = { ...BASE_STATE, sessionExternalTasks: { [SESSION_ID]: [] } };
+    state = {
+      ...BASE_STATE,
+      sessionExternalTasks: { [SESSION_ID]: [] },
+      sessionGitlabMr: { [SESSION_ID]: { mr: null, fetchedAt: NOW, loading: false, error: null } },
+    };
 
     const { result } = renderHook(() => useReviewDiff({ session }));
 
@@ -162,7 +219,11 @@ describe('useReviewDiff', () => {
   });
 
   it('stays loading while the session links are not loaded yet', () => {
-    state = { ...BASE_STATE, sessionExternalTasks: {} };
+    state = {
+      ...BASE_STATE,
+      sessionExternalTasks: {},
+      sessionGitlabMr: { [SESSION_ID]: { mr: null, fetchedAt: NOW, loading: false, error: null } },
+    };
 
     const { result } = renderHook(() => useReviewDiff({ session }));
 

--- a/apps/desktop/src/features/review/components/ReviewBoardPane/useReviewDiff.test.ts
+++ b/apps/desktop/src/features/review/components/ReviewBoardPane/useReviewDiff.test.ts
@@ -97,7 +97,7 @@ const mergeRequest: GitlabMergeRequest = {
   updatedAt: NOW,
 };
 
-const state: MockStore = {
+const BASE_STATE: MockStore = {
   sessionExternalTasks: { [SESSION_ID]: [githubTask, gitlabTask] },
   sessions: [],
   projects: [],
@@ -113,10 +113,13 @@ const state: MockStore = {
   },
 };
 
+let state: MockStore = BASE_STATE;
+
 import { useReviewDiff } from './useReviewDiff';
 
 afterEach(() => {
   cleanup();
+  state = BASE_STATE;
   h.ghPrDiff.mockClear();
   h.gitlabMrDiff.mockClear();
 });
@@ -142,5 +145,29 @@ describe('useReviewDiff', () => {
 
     expect(h.gitlabMrDiff).toHaveBeenCalledWith(WORKSPACE_ID, 'https://gitlab.com', 'acme/web', 10);
     expect(h.ghPrDiff).not.toHaveBeenCalled();
+  });
+
+  it('reports no target and no error once the links loaded without a pull request', async () => {
+    state = { ...BASE_STATE, sessionExternalTasks: { [SESSION_ID]: [] } };
+
+    const { result } = renderHook(() => useReviewDiff({ session }));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.target).toBeNull();
+    expect(result.current.error).toBeNull();
+    expect(result.current.files).toEqual([]);
+    expect(h.ghPrDiff).not.toHaveBeenCalled();
+    expect(h.gitlabMrDiff).not.toHaveBeenCalled();
+  });
+
+  it('stays loading while the session links are not loaded yet', () => {
+    state = { ...BASE_STATE, sessionExternalTasks: {} };
+
+    const { result } = renderHook(() => useReviewDiff({ session }));
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.target).toBeNull();
+    expect(result.current.error).toBeNull();
   });
 });

--- a/apps/desktop/src/features/review/components/ReviewBoardPane/useReviewDiff.ts
+++ b/apps/desktop/src/features/review/components/ReviewBoardPane/useReviewDiff.ts
@@ -27,6 +27,7 @@ type Result = {
 export const useReviewDiff = ({ session }: Params): Result => {
   const sessionId = session.id as SessionId;
   const target = useAppStore(useShallow((state) => resolveReviewTarget({ state, sessionId })));
+  const isTargetLoaded = useAppStore((s) => s.sessionExternalTasks[sessionId] !== undefined);
   const workspace = useAppStore(
     (s) => s.workspaces.find((candidate) => candidate.id === session.workspaceId) ?? null,
   );
@@ -43,10 +44,16 @@ export const useReviewDiff = ({ session }: Params): Result => {
   const [tick, setTick] = useState(0);
 
   useEffect(() => {
-    if (target == null || workspace == null || repo == null) {
+    if (target == null) {
+      setFiles([]);
+      setLoading(!isTargetLoaded);
+      setError(null);
+      return;
+    }
+    if (workspace == null || repo == null) {
       setFiles([]);
       setLoading(false);
-      setError('No linked pull request or merge request for this session.');
+      setError('No repository is mounted for this session.');
       return;
     }
     const fetchDiff =
@@ -82,7 +89,7 @@ export const useReviewDiff = ({ session }: Params): Result => {
     return () => {
       cancelled = true;
     };
-  }, [gitlabHost, repo, target, tick, workspace]);
+  }, [gitlabHost, isTargetLoaded, repo, target, tick, workspace]);
 
   const refresh = useCallback(() => setTick((value) => value + 1), []);
 

--- a/apps/desktop/src/store/slices/review-drafts/index.test.ts
+++ b/apps/desktop/src/store/slices/review-drafts/index.test.ts
@@ -150,6 +150,7 @@ const buildHarness = (initial: Record<string, unknown>): Harness => {
     workspaceIntegrations: {},
     sessionExternalTasks: { [SESSION_ID]: [githubTask] },
     sessionProjectPrs: {},
+    sessionGithub: {},
     sessionGitlabMr: {},
     sessionWorktrees: { [SESSION_ID]: ['/tmp/repo/.goodboy/worktrees/review'] },
     sessionBranches: { [SESSION_ID]: 'review' },

--- a/apps/desktop/src/store/slices/review-drafts/resolveReviewTarget.test.ts
+++ b/apps/desktop/src/store/slices/review-drafts/resolveReviewTarget.test.ts
@@ -10,7 +10,7 @@ import type {
   SessionProjectMount,
 } from '@goodboy/types';
 import type { GitlabMergeRequest } from '../../../features/integrations/gitlab/client';
-import { reviewPrKey, resolveReviewTarget, type ReviewTargetState } from './resolveReviewTarget';
+import { resolveReviewTarget, type ReviewTargetState } from './resolveReviewTarget';
 
 const SESSION_ID = 'session-1' as SessionId;
 const PROJECT_ID = 'project-1' as ProjectId;
@@ -23,6 +23,26 @@ const githubTask: SessionExternalTask = {
   identifier: '#42',
   url: 'https://github.com/acme/web/pull/42',
   title: 'PR',
+  createdAt: NOW,
+};
+
+const githubIssueTask: SessionExternalTask = {
+  sessionId: SESSION_ID,
+  provider: 'github',
+  externalId: '1600',
+  identifier: '#1600',
+  url: 'https://github.com/acme/web/issues/1600',
+  title: 'Issue',
+  createdAt: NOW,
+};
+
+const gitlabIssueTask: SessionExternalTask = {
+  sessionId: SESSION_ID,
+  provider: 'gitlab',
+  externalId: '77',
+  identifier: '#77',
+  url: 'https://gitlab.com/acme/web/-/issues/77',
+  title: 'Issue',
   createdAt: NOW,
 };
 
@@ -77,13 +97,25 @@ const pullRequest: PullRequestState = {
   updatedAt: NOW,
 };
 
+const ownPullRequest: PullRequestState = {
+  ...pullRequest,
+  number: 1631,
+  url: 'https://github.com/acme/web/pull/1631',
+};
+
 type StateParams = {
   readonly tasks: ReadonlyArray<SessionExternalTask>;
+  readonly ownPr?: PullRequestState | null;
   readonly prs?: ReadonlyArray<PullRequestState>;
   readonly mr?: GitlabMergeRequest | null;
 };
 
-const buildState = ({ tasks, prs = [], mr = null }: StateParams): ReviewTargetState => ({
+const buildState = ({
+  tasks,
+  ownPr = null,
+  prs = [],
+  mr = null,
+}: StateParams): ReviewTargetState => ({
   sessionExternalTasks: { [SESSION_ID]: tasks },
   sessions: [{ id: SESSION_ID, activeProjectId: PROJECT_ID } as Session],
   projects: [{ id: PROJECT_ID, kind: 'repo' } as Project],
@@ -100,13 +132,67 @@ const buildState = ({ tasks, prs = [], mr = null }: StateParams): ReviewTargetSt
   },
   sessionActiveProject: { [SESSION_ID]: PROJECT_ID },
   sessionProjectPrs: { [SESSION_ID]: { [PROJECT_ID]: prs } },
+  sessionGithub: {
+    [SESSION_ID]: {
+      pr: ownPr,
+      linkedIssues: [],
+      fetchedAt: NOW,
+      failedAt: null,
+      loading: false,
+      error: null,
+      detail: null,
+      detailFetchedAt: null,
+      detailLoading: false,
+      detailError: null,
+    },
+  },
   sessionGitlabMr: {
     [SESSION_ID]: { mr, fetchedAt: NOW, loading: false, error: null },
   },
 });
 
 describe('resolveReviewTarget', () => {
-  it('picks the same target whatever order the candidates arrive in', () => {
+  it('reviews the pull request this session opened when nothing else is linked', () => {
+    const state = buildState({ tasks: [], ownPr: ownPullRequest });
+
+    expect(resolveReviewTarget({ state, sessionId: SESSION_ID })).toEqual({
+      provider: 'github',
+      repo: 'acme/web',
+      prNumber: 1631,
+    });
+  });
+
+  it('reviews the merge request this session opened when nothing else is linked', () => {
+    const state = buildState({ tasks: [], mr: mergeRequest });
+
+    expect(resolveReviewTarget({ state, sessionId: SESSION_ID })).toEqual({
+      provider: 'gitlab',
+      repo: 'acme/web',
+      prNumber: 10,
+    });
+  });
+
+  it('puts the pull request of this session ahead of a linked one', () => {
+    const state = buildState({ tasks: [githubTask], ownPr: ownPullRequest });
+
+    expect(resolveReviewTarget({ state, sessionId: SESSION_ID })).toEqual({
+      provider: 'github',
+      repo: 'acme/web',
+      prNumber: 1631,
+    });
+  });
+
+  it('reviews the linked pull request of a session that opened none of its own', () => {
+    const state = buildState({ tasks: [githubTask] });
+
+    expect(resolveReviewTarget({ state, sessionId: SESSION_ID })).toEqual({
+      provider: 'github',
+      repo: 'acme/web',
+      prNumber: 42,
+    });
+  });
+
+  it('picks the same linked target whatever order the candidates arrive in', () => {
     const forward = resolveReviewTarget({
       state: buildState({ tasks: [gitlabTask, githubTask] }),
       sessionId: SESSION_ID,
@@ -120,28 +206,39 @@ describe('resolveReviewTarget', () => {
     expect(reversed).toEqual(forward);
   });
 
-  it('prefers the candidate matching a pull request the store already discovered', () => {
-    const state = buildState({ tasks: [githubTask, gitlabTask], mr: mergeRequest });
-
-    expect(resolveReviewTarget({ state, sessionId: SESSION_ID })).toEqual({
-      provider: 'gitlab',
-      repo: 'acme/web',
-      prNumber: 10,
-    });
-  });
-
-  it('falls back to the priority order when both hosts discovered something', () => {
-    const state = buildState({
-      tasks: [gitlabTask, githubTask],
-      prs: [pullRequest],
-      mr: mergeRequest,
-    });
+  it('falls back to the priority order when this session opened work on both hosts', () => {
+    const state = buildState({ tasks: [], prs: [pullRequest], mr: mergeRequest });
 
     expect(resolveReviewTarget({ state, sessionId: SESSION_ID })).toEqual({
       provider: 'github',
       repo: 'acme/web',
       prNumber: 42,
     });
+  });
+
+  it('reads the pull request of the active project when the session slice holds none', () => {
+    const state = buildState({ tasks: [], prs: [pullRequest] });
+
+    expect(resolveReviewTarget({ state, sessionId: SESSION_ID })).toEqual({
+      provider: 'github',
+      repo: 'acme/web',
+      prNumber: 42,
+    });
+  });
+
+  it('never reviews a linked issue as if it were a pull request', () => {
+    expect(
+      resolveReviewTarget({
+        state: buildState({ tasks: [githubIssueTask, gitlabIssueTask] }),
+        sessionId: SESSION_ID,
+      }),
+    ).toBeNull();
+    expect(
+      resolveReviewTarget({
+        state: buildState({ tasks: [githubIssueTask, githubTask] }),
+        sessionId: SESSION_ID,
+      }),
+    ).toEqual({ provider: 'github', repo: 'acme/web', prNumber: 42 });
   });
 
   it('never routes a bitbucket task through the reviewable providers', () => {
@@ -168,9 +265,9 @@ describe('resolveReviewTarget', () => {
     });
   });
 
-  it('keys a discovered pull request by provider so numbers cannot collide', () => {
-    expect(reviewPrKey({ provider: 'github', prNumber: 10 })).not.toBe(
-      reviewPrKey({ provider: 'gitlab', prNumber: 10 }),
-    );
+  it('reports no target for a session with neither its own work nor a linked one', () => {
+    expect(
+      resolveReviewTarget({ state: buildState({ tasks: [] }), sessionId: SESSION_ID }),
+    ).toBeNull();
   });
 });

--- a/apps/desktop/src/store/slices/review-drafts/resolveReviewTarget.ts
+++ b/apps/desktop/src/store/slices/review-drafts/resolveReviewTarget.ts
@@ -14,51 +14,67 @@ type ReviewableTask = SessionExternalTask & { readonly provider: ReviewablePrPro
 const isReviewableTask = (task: SessionExternalTask): task is ReviewableTask =>
   task.provider === 'github' || task.provider === 'gitlab';
 
-type RepoFromTaskParams = {
-  readonly task: ReviewableTask;
+const GITLAB_MR_PATH = '/-/merge_requests/';
+
+type PathParams = {
+  readonly pathname: string;
 };
 
-const repoFromTask = ({ task }: RepoFromTaskParams): string | null => {
+const gitlabRepoFromPath = ({ pathname }: PathParams): string | null => {
+  const [projectPart, mrPart] = pathname.split(GITLAB_MR_PATH);
+  if (mrPart === undefined) {
+    return null;
+  }
+  const trimmed = (projectPart ?? '').replace(/^\/+|\/+$/g, '');
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+const githubRepoFromPath = ({ pathname }: PathParams): string | null => {
+  const segments = pathname.split('/').filter((segment) => segment.length > 0);
+  const [owner, name, kind] = segments;
+  if (owner === undefined || name === undefined || kind !== 'pull') {
+    return null;
+  }
+  return `${owner}/${name}`;
+};
+
+type UrlParams = {
+  readonly provider: ReviewablePrProvider;
+  readonly url: string;
+  readonly prNumber: number;
+};
+
+const pathnameOf = ({ url }: { readonly url: string }): string | null => {
   try {
-    const pathname = new URL(task.url).pathname;
-    if (task.provider === 'github') {
-      const segments = pathname.split('/').filter((segment) => segment.length > 0);
-      if (segments.length < 2) {
-        return null;
-      }
-      return `${segments[0]}/${segments[1]}`;
-    }
-    const projectPart = pathname.split('/-/')[0] ?? '';
-    const trimmed = projectPart.replace(/^\/+|\/+$/g, '');
-    return trimmed.length > 0 ? trimmed : null;
+    return new URL(url).pathname;
   } catch {
     return null;
   }
+};
+
+const targetFromUrl = ({ provider, url, prNumber }: UrlParams): ReviewTarget | null => {
+  if (!Number.isInteger(prNumber) || prNumber <= 0) {
+    return null;
+  }
+  const pathname = pathnameOf({ url });
+  if (pathname == null) {
+    return null;
+  }
+  const repo =
+    provider === 'gitlab' ? gitlabRepoFromPath({ pathname }) : githubRepoFromPath({ pathname });
+  return repo == null ? null : { provider, repo, prNumber };
 };
 
 type TargetFromTaskParams = {
   readonly task: ReviewableTask;
 };
 
-const targetFromTask = ({ task }: TargetFromTaskParams): ReviewTarget | null => {
-  const prNumber = Number.parseInt(task.externalId, 10);
-  if (!Number.isInteger(prNumber) || prNumber <= 0) {
-    return null;
-  }
-  const repo = repoFromTask({ task });
-  if (repo == null) {
-    return null;
-  }
-  return { provider: task.provider, repo, prNumber };
-};
-
-type PrKeyParams = {
-  readonly provider: ReviewablePrProvider;
-  readonly prNumber: number;
-};
-
-export const reviewPrKey = ({ provider, prNumber }: PrKeyParams): string =>
-  `${provider}#${prNumber}`;
+const targetFromTask = ({ task }: TargetFromTaskParams): ReviewTarget | null =>
+  targetFromUrl({
+    provider: task.provider,
+    url: task.url,
+    prNumber: Number.parseInt(task.externalId, 10),
+  });
 
 const byProviderThenNumber = (left: ReviewTarget, right: ReviewTarget): number => {
   const rank = PROVIDER_PRIORITY.indexOf(left.provider) - PROVIDER_PRIORITY.indexOf(right.provider);
@@ -68,29 +84,10 @@ const byProviderThenNumber = (left: ReviewTarget, right: ReviewTarget): number =
   return left.prNumber - right.prNumber;
 };
 
-type FromTasksParams = {
-  readonly tasks: ReadonlyArray<SessionExternalTask>;
-  readonly discoveredPrKeys: ReadonlySet<string>;
-};
-
-const reviewTargetFromTasks = ({
-  tasks,
-  discoveredPrKeys,
-}: FromTasksParams): ReviewTarget | null => {
-  const candidates = tasks
-    .filter(isReviewableTask)
-    .flatMap((task) => {
-      const target = targetFromTask({ task });
-      return target == null ? [] : [target];
-    })
-    .sort(byProviderThenNumber);
-  const discovered = candidates.find((candidate) => discoveredPrKeys.has(reviewPrKey(candidate)));
-  return discovered ?? candidates[0] ?? null;
-};
-
 export type ReviewTargetState = Pick<
   AppState,
   | 'sessionExternalTasks'
+  | 'sessionGithub'
   | 'sessionGitlabMr'
   | 'sessions'
   | 'projects'
@@ -104,20 +101,31 @@ type Params = {
   readonly sessionId: SessionId;
 };
 
-const discoveredPrKeysForSession = ({ state, sessionId }: Params): ReadonlySet<string> => {
-  const keys = new Set<string>();
-  for (const pr of selectActiveProjectPrs({ state, sessionId })) {
-    keys.add(reviewPrKey({ provider: 'github', prNumber: pr.number }));
-  }
+const ownReviewTargets = ({ state, sessionId }: Params): ReadonlyArray<ReviewTarget> => {
+  const pullRequest =
+    state.sessionGithub[sessionId]?.pr ?? selectActiveProjectPrs({ state, sessionId })[0] ?? null;
   const mergeRequest = state.sessionGitlabMr[sessionId]?.mr ?? null;
-  if (mergeRequest != null) {
-    keys.add(reviewPrKey({ provider: 'gitlab', prNumber: mergeRequest.iid }));
-  }
-  return keys;
+  const candidates = [
+    pullRequest == null
+      ? null
+      : targetFromUrl({ provider: 'github', url: pullRequest.url, prNumber: pullRequest.number }),
+    mergeRequest == null
+      ? null
+      : targetFromUrl({ provider: 'gitlab', url: mergeRequest.webUrl, prNumber: mergeRequest.iid }),
+  ];
+  return candidates
+    .filter((candidate): candidate is ReviewTarget => candidate != null)
+    .sort(byProviderThenNumber);
 };
 
+const linkedReviewTargets = ({ state, sessionId }: Params): ReadonlyArray<ReviewTarget> =>
+  (state.sessionExternalTasks[sessionId] ?? [])
+    .filter(isReviewableTask)
+    .flatMap((task) => {
+      const target = targetFromTask({ task });
+      return target == null ? [] : [target];
+    })
+    .sort(byProviderThenNumber);
+
 export const resolveReviewTarget = ({ state, sessionId }: Params): ReviewTarget | null =>
-  reviewTargetFromTasks({
-    tasks: state.sessionExternalTasks[sessionId] ?? [],
-    discoveredPrKeys: discoveredPrKeysForSession({ state, sessionId }),
-  });
+  ownReviewTargets({ state, sessionId })[0] ?? linkedReviewTargets({ state, sessionId })[0] ?? null;


### PR DESCRIPTION
## Why
Regression seen in v0.2.14: opening the Review board on a session without a review target showed "Could not load the diff: No linked pull request or merge request" next to the Unified/Split toggle, a files count, an empty drafts rail and the Publish review footer.

## How you get there
Closing a resolver agent overlay, the breadcrumb of a resolver child, the timeline "Open review" row, the resolver threads card, the resolver lane, the diff viewer, the board draft-comments chip, the review inbox row, and the two lens shortcuts all land on the review board. None removed.

## What
- `useReviewDiff`: no target is not an error. It reports loading until the session's external tasks are loaded, then no error and no fetch. A real error stays for a target whose workspace or repository cannot be resolved.
- `ReviewBoardPane`: without a target the Review section is a `LensEmptyState` ("No pull request to review", action opens the GitHub lens); toggle, refresh, files count, drafts rail and publish footer are hidden. Threads and Resolvers tabs keep working. Skeleton while loading.

## Found on the way (follow-up on this branch)
The board only builds review targets from external tasks with GitHub/GitLab URLs, never from the session's own `sessionGithub.pr` or GitLab MR, so an ordinary build session with an open PR still lands on the empty state. A linked issue URL can also be mistaken for a PR number. Next commit addresses both.

## Tests
- 3 board cases (empty state and action, tabs without a PR, skeleton while loading), 2 hook cases; review + session + notifications + board + regression suites green (2084).

🤖 Generated with [Claude Code](https://claude.com/claude-code)