### PR TITLE
perf(desktop): move 72 sync tauri commands off the main thread

### DIFF
--- a/apps/desktop/src-tauri/src/attachment.rs
+++ b/apps/desktop/src-tauri/src/attachment.rs
@@ -119,7 +119,20 @@ fn is_allowed_mime(mime: &str) -> bool {
 /// returns the worktree-relative path. The stored name is `<id>-<file_name>`,
 /// both sanitized — `id` keeps names unique without a uuid crate.
 #[tauri::command]
-pub fn attachment_write(
+pub async fn attachment_write(
+    worktree_dir: String,
+    attachment_id: String,
+    file_name: String,
+    data_base64: String,
+) -> Result<String, AttachmentError> {
+    tauri::async_runtime::spawn_blocking(move || {
+        attachment_write_blocking(worktree_dir, attachment_id, file_name, data_base64)
+    })
+    .await
+    .map_err(|e| AttachmentError::Io(std::io::Error::other(e.to_string())))?
+}
+
+fn attachment_write_blocking(
     worktree_dir: String,
     attachment_id: String,
     file_name: String,
@@ -160,7 +173,17 @@ pub struct DroppedAttachment {
 /// Accepts the same whitelist as the composer picker, mirroring its `accept`
 /// filter — the second guard exists because OS drag-drop bypasses the picker.
 #[tauri::command]
-pub fn attachment_read_dropped(abs_path: String) -> Result<DroppedAttachment, AttachmentError> {
+pub async fn attachment_read_dropped(
+    abs_path: String,
+) -> Result<DroppedAttachment, AttachmentError> {
+    tauri::async_runtime::spawn_blocking(move || attachment_read_dropped_blocking(abs_path))
+        .await
+        .map_err(|e| AttachmentError::Io(std::io::Error::other(e.to_string())))?
+}
+
+fn attachment_read_dropped_blocking(
+    abs_path: String,
+) -> Result<DroppedAttachment, AttachmentError> {
     let path = Path::new(&abs_path);
     let meta = fs::metadata(path)?;
     if !meta.is_file() {
@@ -197,7 +220,19 @@ pub fn attachment_read_dropped(abs_path: String) -> Result<DroppedAttachment, At
 /// the webview. `rel_path` must be the worktree-relative path produced by
 /// `attachment_write`; anything pointing outside the attachment dir is rejected.
 #[tauri::command]
-pub fn attachment_read(worktree_dir: String, rel_path: String) -> Result<String, AttachmentError> {
+pub async fn attachment_read(
+    worktree_dir: String,
+    rel_path: String,
+) -> Result<String, AttachmentError> {
+    tauri::async_runtime::spawn_blocking(move || attachment_read_blocking(worktree_dir, rel_path))
+        .await
+        .map_err(|e| AttachmentError::Io(std::io::Error::other(e.to_string())))?
+}
+
+fn attachment_read_blocking(
+    worktree_dir: String,
+    rel_path: String,
+) -> Result<String, AttachmentError> {
     if rel_path.contains("..") || !rel_path.starts_with(ATTACH_SUBDIR) {
         return Err(AttachmentError::InvalidPath);
     }
@@ -216,7 +251,19 @@ pub fn attachment_read(worktree_dir: String, rel_path: String) -> Result<String,
 }
 
 #[tauri::command]
-pub fn attachment_delete(worktree_dir: String, rel_path: String) -> Result<(), AttachmentError> {
+pub async fn attachment_delete(
+    worktree_dir: String,
+    rel_path: String,
+) -> Result<(), AttachmentError> {
+    tauri::async_runtime::spawn_blocking(move || attachment_delete_blocking(worktree_dir, rel_path))
+        .await
+        .map_err(|e| AttachmentError::Io(std::io::Error::other(e.to_string())))?
+}
+
+fn attachment_delete_blocking(
+    worktree_dir: String,
+    rel_path: String,
+) -> Result<(), AttachmentError> {
     if rel_path.contains("..") || !rel_path.starts_with(ATTACH_SUBDIR) {
         return Err(AttachmentError::InvalidPath);
     }
@@ -356,7 +403,15 @@ fn write_bug_report_images(
 }
 
 #[tauri::command]
-pub fn bug_report_stage_images(
+pub async fn bug_report_stage_images(
+    images: Vec<BugReportImageInput>,
+) -> Result<StagedBugReport, AttachmentError> {
+    tauri::async_runtime::spawn_blocking(move || bug_report_stage_images_blocking(images))
+        .await
+        .map_err(|e| AttachmentError::Io(std::io::Error::other(e.to_string())))?
+}
+
+fn bug_report_stage_images_blocking(
     images: Vec<BugReportImageInput>,
 ) -> Result<StagedBugReport, AttachmentError> {
     let dir = std::env::temp_dir().join(bug_report_dir_name());
@@ -384,14 +439,26 @@ fn resolve_bug_report_dir(dir: &str) -> Result<std::path::PathBuf, AttachmentErr
 }
 
 #[tauri::command]
-pub fn bug_report_reveal_images(dir: String) -> Result<(), AttachmentError> {
+pub async fn bug_report_reveal_images(dir: String) -> Result<(), AttachmentError> {
+    tauri::async_runtime::spawn_blocking(move || bug_report_reveal_images_blocking(dir))
+        .await
+        .map_err(|e| AttachmentError::Io(std::io::Error::other(e.to_string())))?
+}
+
+fn bug_report_reveal_images_blocking(dir: String) -> Result<(), AttachmentError> {
     let canonical_dir = resolve_bug_report_dir(&dir)?;
     crate::explore::spawn_open(&canonical_dir, false)?;
     Ok(())
 }
 
 #[tauri::command]
-pub fn bug_report_discard_images(dir: String) -> Result<(), AttachmentError> {
+pub async fn bug_report_discard_images(dir: String) -> Result<(), AttachmentError> {
+    tauri::async_runtime::spawn_blocking(move || bug_report_discard_images_blocking(dir))
+        .await
+        .map_err(|e| AttachmentError::Io(std::io::Error::other(e.to_string())))?
+}
+
+fn bug_report_discard_images_blocking(dir: String) -> Result<(), AttachmentError> {
     let canonical_dir = resolve_bug_report_dir(&dir)?;
     match fs::remove_dir_all(&canonical_dir) {
         Ok(()) => Ok(()),
@@ -443,7 +510,7 @@ mod tests {
         fs::create_dir_all(&dir).unwrap();
         fs::write(dir.join(".goodboy"), b"{\"sessionId\":\"s\"}").unwrap();
         let png_b64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=";
-        let rel = attachment_write(
+        let rel = attachment_write_blocking(
             dir.to_string_lossy().to_string(),
             "att-1".to_string(),
             "shot.png".to_string(),
@@ -467,7 +534,7 @@ mod tests {
 
         // 1x1 transparent PNG.
         let png_b64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=";
-        let rel = attachment_write(
+        let rel = attachment_write_blocking(
             dir.to_string_lossy().to_string(),
             "att-1".to_string(),
             "shot.png".to_string(),
@@ -476,7 +543,7 @@ mod tests {
         .unwrap();
         assert_eq!(rel, ".goodboy/attachments/att-1-shot.png");
 
-        let data_url = attachment_read(dir.to_string_lossy().to_string(), rel).unwrap();
+        let data_url = attachment_read_blocking(dir.to_string_lossy().to_string(), rel).unwrap();
         assert!(data_url.starts_with("data:image/png;base64,"));
 
         let _ = fs::remove_dir_all(&dir);
@@ -489,7 +556,7 @@ mod tests {
         fs::create_dir_all(&dir).unwrap();
 
         let png_b64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=";
-        let rel = attachment_write(
+        let rel = attachment_write_blocking(
             dir.to_string_lossy().to_string(),
             "att-del".to_string(),
             "shot.png".to_string(),
@@ -499,14 +566,14 @@ mod tests {
         let full = Path::new(&dir).join(&rel);
         assert!(full.exists());
 
-        attachment_delete(dir.to_string_lossy().to_string(), rel.clone()).unwrap();
+        attachment_delete_blocking(dir.to_string_lossy().to_string(), rel.clone()).unwrap();
         assert!(!full.exists());
 
-        attachment_delete(dir.to_string_lossy().to_string(), rel).unwrap();
+        attachment_delete_blocking(dir.to_string_lossy().to_string(), rel).unwrap();
 
-        let err = attachment_delete("/tmp".to_string(), "../../etc/passwd".to_string());
+        let err = attachment_delete_blocking("/tmp".to_string(), "../../etc/passwd".to_string());
         assert!(matches!(err, Err(AttachmentError::InvalidPath)));
-        let err = attachment_delete("/tmp".to_string(), "etc/passwd".to_string());
+        let err = attachment_delete_blocking("/tmp".to_string(), "etc/passwd".to_string());
         assert!(matches!(err, Err(AttachmentError::InvalidPath)));
 
         let _ = fs::remove_dir_all(&dir);
@@ -533,9 +600,9 @@ mod tests {
 
     #[test]
     fn read_rejects_traversal() {
-        let err = attachment_read("/tmp".to_string(), "../../etc/passwd".to_string());
+        let err = attachment_read_blocking("/tmp".to_string(), "../../etc/passwd".to_string());
         assert!(matches!(err, Err(AttachmentError::InvalidPath)));
-        let err = attachment_read("/tmp".to_string(), "etc/passwd".to_string());
+        let err = attachment_read_blocking("/tmp".to_string(), "etc/passwd".to_string());
         assert!(matches!(err, Err(AttachmentError::InvalidPath)));
     }
 
@@ -546,7 +613,7 @@ mod tests {
         fs::create_dir_all(&dir).unwrap();
         let blob = dir.join("payload.bin");
         fs::write(&blob, b"\x00\x01\x02").unwrap();
-        let err = attachment_read_dropped(blob.to_string_lossy().to_string());
+        let err = attachment_read_dropped_blocking(blob.to_string_lossy().to_string());
         assert!(matches!(err, Err(AttachmentError::UnsupportedMime(_))));
         let _ = fs::remove_dir_all(&dir);
     }
@@ -558,13 +625,13 @@ mod tests {
         fs::create_dir_all(&dir).unwrap();
         let csv = dir.join("data.csv");
         fs::write(&csv, b"a,b\n1,2\n").unwrap();
-        let out = attachment_read_dropped(csv.to_string_lossy().to_string()).unwrap();
+        let out = attachment_read_dropped_blocking(csv.to_string_lossy().to_string()).unwrap();
         assert_eq!(out.file_name, "data.csv");
         assert_eq!(out.mime_type, "text/csv");
 
         let pdf = dir.join("doc.pdf");
         fs::write(&pdf, b"%PDF-1.4\n").unwrap();
-        let out = attachment_read_dropped(pdf.to_string_lossy().to_string()).unwrap();
+        let out = attachment_read_dropped_blocking(pdf.to_string_lossy().to_string()).unwrap();
         assert_eq!(out.mime_type, "application/pdf");
         let _ = fs::remove_dir_all(&dir);
     }
@@ -634,13 +701,13 @@ mod tests {
         fs::create_dir_all(&dir).unwrap();
         fs::write(dir.join("01-shot.png"), b"bytes").unwrap();
 
-        bug_report_discard_images(dir.to_string_lossy().to_string()).unwrap();
+        bug_report_discard_images_blocking(dir.to_string_lossy().to_string()).unwrap();
         assert!(!dir.exists());
 
         let other = std::env::temp_dir().join(format!("goodboy-keep-{}", std::process::id()));
         let _ = fs::remove_dir_all(&other);
         fs::create_dir_all(&other).unwrap();
-        let err = bug_report_discard_images(other.to_string_lossy().to_string());
+        let err = bug_report_discard_images_blocking(other.to_string_lossy().to_string());
         assert!(matches!(err, Err(AttachmentError::InvalidPath)));
         assert!(other.exists());
 
@@ -653,7 +720,7 @@ mod tests {
         let _ = fs::remove_dir_all(&dir);
         fs::create_dir_all(&dir).unwrap();
 
-        let result = bug_report_reveal_images(dir.to_string_lossy().to_string());
+        let result = bug_report_reveal_images_blocking(dir.to_string_lossy().to_string());
 
         assert!(matches!(result, Err(AttachmentError::InvalidPath)));
         let _ = fs::remove_dir_all(&dir);
@@ -668,7 +735,7 @@ mod tests {
         // 1x1 transparent PNG.
         let png_b64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=";
         fs::write(&png, STANDARD.decode(png_b64).unwrap()).unwrap();
-        let out = attachment_read_dropped(png.to_string_lossy().to_string()).unwrap();
+        let out = attachment_read_dropped_blocking(png.to_string_lossy().to_string()).unwrap();
         assert_eq!(out.file_name, "shot.png");
         assert_eq!(out.mime_type, "image/png");
         assert_eq!(out.data_base64, png_b64);

--- a/apps/desktop/src-tauri/src/budget.rs
+++ b/apps/desktop/src-tauri/src/budget.rs
@@ -44,7 +44,7 @@ pub struct BudgetAlert {
 }
 
 #[tauri::command]
-pub fn budget_rule_upsert(state: State<'_, Db>, rule: BudgetRule) -> Result<(), DbError> {
+pub async fn budget_rule_upsert(state: State<'_, Db>, rule: BudgetRule) -> Result<(), DbError> {
     let conn = state.0.lock().map_err(|_| DbError::Poisoned)?;
     conn.execute(
         "INSERT INTO budget_rules (id, provider, period, cap_usd, alert_threshold_pct, extra_tokens_budget, created_at)
@@ -69,7 +69,7 @@ pub fn budget_rule_upsert(state: State<'_, Db>, rule: BudgetRule) -> Result<(), 
 }
 
 #[tauri::command]
-pub fn budget_rule_list(state: State<'_, Db>) -> Result<Vec<BudgetRule>, DbError> {
+pub async fn budget_rule_list(state: State<'_, Db>) -> Result<Vec<BudgetRule>, DbError> {
     let conn = state.0.lock().map_err(|_| DbError::Poisoned)?;
     let mut stmt = conn.prepare(
         "SELECT id, provider, period, cap_usd, alert_threshold_pct, extra_tokens_budget, created_at FROM budget_rules",
@@ -89,7 +89,7 @@ pub fn budget_rule_list(state: State<'_, Db>) -> Result<Vec<BudgetRule>, DbError
 }
 
 #[tauri::command]
-pub fn budget_rule_delete(state: State<'_, Db>, id: String) -> Result<(), DbError> {
+pub async fn budget_rule_delete(state: State<'_, Db>, id: String) -> Result<(), DbError> {
     let conn = state.0.lock().map_err(|_| DbError::Poisoned)?;
     conn.execute(
         "DELETE FROM budget_rules WHERE id = ?1",
@@ -99,7 +99,7 @@ pub fn budget_rule_delete(state: State<'_, Db>, id: String) -> Result<(), DbErro
 }
 
 #[tauri::command]
-pub fn session_budget_set(
+pub async fn session_budget_set(
     state: State<'_, Db>,
     session_id: String,
     soft_cap_usd: f64,
@@ -115,7 +115,7 @@ pub fn session_budget_set(
 }
 
 #[tauri::command]
-pub fn session_budget_get(
+pub async fn session_budget_get(
     state: State<'_, Db>,
     session_id: String,
 ) -> Result<Option<SessionBudget>, DbError> {
@@ -135,7 +135,7 @@ pub fn session_budget_get(
 }
 
 #[tauri::command]
-pub fn budget_alerts_list(state: State<'_, Db>) -> Result<Vec<BudgetAlert>, DbError> {
+pub async fn budget_alerts_list(state: State<'_, Db>) -> Result<Vec<BudgetAlert>, DbError> {
     let conn = state.0.lock().map_err(|_| DbError::Poisoned)?;
     let mut stmt = conn.prepare(
         "SELECT id, kind, provider, session_id, current_usd, cap_usd, created_at, dismissed_at
@@ -158,7 +158,7 @@ pub fn budget_alerts_list(state: State<'_, Db>) -> Result<Vec<BudgetAlert>, DbEr
 }
 
 #[tauri::command]
-pub fn budget_alert_dismiss(state: State<'_, Db>, id: String) -> Result<(), DbError> {
+pub async fn budget_alert_dismiss(state: State<'_, Db>, id: String) -> Result<(), DbError> {
     let conn = state.0.lock().map_err(|_| DbError::Poisoned)?;
     conn.execute(
         "UPDATE budget_alerts SET dismissed_at = ?2 WHERE id = ?1",
@@ -210,7 +210,7 @@ pub struct EmitAlertsInput {
 }
 
 #[tauri::command]
-pub fn budget_emit_alerts(
+pub async fn budget_emit_alerts(
     state: State<'_, Db>,
     input: EmitAlertsInput,
 ) -> Result<Vec<BudgetAlert>, DbError> {
@@ -407,7 +407,7 @@ fn provider_budget_status(
 }
 
 #[tauri::command]
-pub fn check_provider_budget(
+pub async fn check_provider_budget(
     state: State<'_, Db>,
     provider: String,
     period: String,

--- a/apps/desktop/src-tauri/src/config_export.rs
+++ b/apps/desktop/src-tauri/src/config_export.rs
@@ -811,7 +811,10 @@ fn normalized_kind(kind: &str) -> String {
 // ---------------------------------------------------------------------------
 
 #[tauri::command]
-pub fn export_config_to_file(state: State<'_, Db>, path: String) -> Result<(), ConfigExportError> {
+pub async fn export_config_to_file(
+    state: State<'_, Db>,
+    path: String,
+) -> Result<(), ConfigExportError> {
     let bundle = export_config(state)?;
     let json = serde_json::to_string_pretty(&bundle)?;
     std::fs::write(&path, json).map_err(|e| ConfigExportError::Validation(e.to_string()))?;
@@ -819,7 +822,7 @@ pub fn export_config_to_file(state: State<'_, Db>, path: String) -> Result<(), C
 }
 
 #[tauri::command]
-pub fn import_config_from_file(
+pub async fn import_config_from_file(
     state: State<'_, Db>,
     path: String,
 ) -> Result<ImportResult, ConfigExportError> {

--- a/apps/desktop/src-tauri/src/db.rs
+++ b/apps/desktop/src-tauri/src/db.rs
@@ -68,11 +68,18 @@ fn migration_snapshot_prefix(path: &std::path::Path) -> String {
 }
 
 #[tauri::command]
-pub fn db_list_migration_snapshots(state: State<'_, Db>) -> Result<Vec<String>, DbError> {
-    let Some(parent) = state.1.parent() else {
+pub async fn db_list_migration_snapshots(state: State<'_, Db>) -> Result<Vec<String>, DbError> {
+    let db_path = state.1.clone();
+    tauri::async_runtime::spawn_blocking(move || db_list_migration_snapshots_blocking(db_path))
+        .await
+        .map_err(|e| DbError::MigrationSnapshotFilesystem(e.to_string()))?
+}
+
+fn db_list_migration_snapshots_blocking(db_path: PathBuf) -> Result<Vec<String>, DbError> {
+    let Some(parent) = db_path.parent() else {
         return Ok(Vec::new());
     };
-    let prefix = migration_snapshot_prefix(&state.1);
+    let prefix = migration_snapshot_prefix(&db_path);
     let mut snapshots = Vec::new();
     let entries = std::fs::read_dir(parent)
         .map_err(|error| DbError::MigrationSnapshotFilesystem(error.to_string()))?;
@@ -89,15 +96,27 @@ pub fn db_list_migration_snapshots(state: State<'_, Db>) -> Result<Vec<String>, 
 }
 
 #[tauri::command]
-pub fn db_remove_migration_snapshot(state: State<'_, Db>, path: String) -> Result<(), DbError> {
+pub async fn db_remove_migration_snapshot(
+    state: State<'_, Db>,
+    path: String,
+) -> Result<(), DbError> {
+    let db_path = state.1.clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        db_remove_migration_snapshot_blocking(db_path, path)
+    })
+    .await
+    .map_err(|e| DbError::MigrationSnapshotFilesystem(e.to_string()))?
+}
+
+fn db_remove_migration_snapshot_blocking(db_path: PathBuf, path: String) -> Result<(), DbError> {
     let snapshot_path = PathBuf::from(path);
     let name = snapshot_path
         .file_name()
         .unwrap_or_default()
         .to_string_lossy();
-    let is_same_parent = snapshot_path.parent() == state.1.parent();
+    let is_same_parent = snapshot_path.parent() == db_path.parent();
     let is_snapshot =
-        name.starts_with(&migration_snapshot_prefix(&state.1)) && name.ends_with(".bak");
+        name.starts_with(&migration_snapshot_prefix(&db_path)) && name.ends_with(".bak");
     if !is_same_parent || !is_snapshot {
         return Err(DbError::InvalidSnapshotPath);
     }

--- a/apps/desktop/src-tauri/src/editor.rs
+++ b/apps/desktop/src-tauri/src/editor.rs
@@ -48,7 +48,7 @@ fn which_binary(binary: &str) -> Option<()> {
     }
 }
 
-#[tauri::command]
+#[tauri::command(async)]
 pub fn detect_editors() -> Vec<DetectedEditor> {
     DETECTED_EDITORS.get_or_init(detect_editors_inner).clone()
 }
@@ -63,6 +63,8 @@ pub enum EditorError {
         #[source]
         source: std::io::Error,
     },
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
 }
 
 impl serde::Serialize for EditorError {
@@ -72,7 +74,13 @@ impl serde::Serialize for EditorError {
 }
 
 #[tauri::command]
-pub fn open_in_editor(path: String, editor: Option<String>) -> Result<(), EditorError> {
+pub async fn open_in_editor(path: String, editor: Option<String>) -> Result<(), EditorError> {
+    tauri::async_runtime::spawn_blocking(move || open_in_editor_blocking(path, editor))
+        .await
+        .map_err(|e| EditorError::Io(std::io::Error::other(e.to_string())))?
+}
+
+fn open_in_editor_blocking(path: String, editor: Option<String>) -> Result<(), EditorError> {
     let binary = editor.unwrap_or_else(|| DEFAULT_EDITOR.to_string());
 
     // Resolve to absolute canonical path so editors load it as a workspace folder
@@ -103,7 +111,19 @@ pub fn open_in_editor(path: String, editor: Option<String>) -> Result<(), Editor
 /// avoiding the "new standalone window per file" behavior of `open_in_editor`,
 /// which forces `--new-window`.
 #[tauri::command]
-pub fn open_file_in_workspace(
+pub async fn open_file_in_workspace(
+    workspace_path: String,
+    file_path: String,
+    editor: Option<String>,
+) -> Result<(), EditorError> {
+    tauri::async_runtime::spawn_blocking(move || {
+        open_file_in_workspace_blocking(workspace_path, file_path, editor)
+    })
+    .await
+    .map_err(|e| EditorError::Io(std::io::Error::other(e.to_string())))?
+}
+
+fn open_file_in_workspace_blocking(
     workspace_path: String,
     file_path: String,
     editor: Option<String>,
@@ -144,7 +164,13 @@ fn is_openable_url(url: &str) -> bool {
 }
 
 #[tauri::command]
-pub fn open_url(url: String) -> Result<(), String> {
+pub async fn open_url(url: String) -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(move || open_url_blocking(url))
+        .await
+        .map_err(|e| e.to_string())?
+}
+
+fn open_url_blocking(url: String) -> Result<(), String> {
     if !is_openable_url(&url) {
         return Err("refused to open a url that is not a plain http(s) address".to_string());
     }

--- a/apps/desktop/src-tauri/src/file_versions.rs
+++ b/apps/desktop/src-tauri/src/file_versions.rs
@@ -199,44 +199,68 @@ pub struct PurgeSessionArgs {
 }
 
 #[tauri::command]
-pub fn file_versions_begin_snapshot(
+pub async fn file_versions_begin_snapshot(
     args: BeginSnapshotArgs,
 ) -> Result<BeginSnapshotResult, FileVersionsError> {
-    let root = file_versions_root()?;
-    begin_snapshot_with_root(&root, args)
+    tauri::async_runtime::spawn_blocking(move || {
+        let root = file_versions_root()?;
+        begin_snapshot_with_root(&root, args)
+    })
+    .await
+    .map_err(|e| FileVersionsError::Io(std::io::Error::other(e.to_string())))?
 }
 
 #[tauri::command]
-pub fn file_versions_finalize_snapshot(
+pub async fn file_versions_finalize_snapshot(
     args: FinalizeSnapshotArgs,
 ) -> Result<FinalizeSnapshotResult, FileVersionsError> {
-    let root = file_versions_root()?;
-    finalize_snapshot_with_root(&root, args)
+    tauri::async_runtime::spawn_blocking(move || {
+        let root = file_versions_root()?;
+        finalize_snapshot_with_root(&root, args)
+    })
+    .await
+    .map_err(|e| FileVersionsError::Io(std::io::Error::other(e.to_string())))?
 }
 
 #[tauri::command]
-pub fn file_versions_list_staged_snapshots() -> Result<ListStagedSnapshotsResult, FileVersionsError>
-{
-    let root = file_versions_root()?;
-    list_staged_snapshots_with_root(&root)
+pub async fn file_versions_list_staged_snapshots(
+) -> Result<ListStagedSnapshotsResult, FileVersionsError> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let root = file_versions_root()?;
+        list_staged_snapshots_with_root(&root)
+    })
+    .await
+    .map_err(|e| FileVersionsError::Io(std::io::Error::other(e.to_string())))?
 }
 
 #[tauri::command]
-pub fn file_versions_restore(args: RestoreVersionArgs) -> Result<(), FileVersionsError> {
-    let root = file_versions_root()?;
-    restore_version_with_root(&root, args)
+pub async fn file_versions_restore(args: RestoreVersionArgs) -> Result<(), FileVersionsError> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let root = file_versions_root()?;
+        restore_version_with_root(&root, args)
+    })
+    .await
+    .map_err(|e| FileVersionsError::Io(std::io::Error::other(e.to_string())))?
 }
 
 #[tauri::command]
-pub fn file_versions_delete(args: DeleteVersionArgs) -> Result<(), FileVersionsError> {
-    let root = file_versions_root()?;
-    delete_version_with_root(&root, args)
+pub async fn file_versions_delete(args: DeleteVersionArgs) -> Result<(), FileVersionsError> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let root = file_versions_root()?;
+        delete_version_with_root(&root, args)
+    })
+    .await
+    .map_err(|e| FileVersionsError::Io(std::io::Error::other(e.to_string())))?
 }
 
 #[tauri::command]
-pub fn file_versions_purge_session(args: PurgeSessionArgs) -> Result<(), FileVersionsError> {
-    let root = file_versions_root()?;
-    purge_session_with_root(&root, args)
+pub async fn file_versions_purge_session(args: PurgeSessionArgs) -> Result<(), FileVersionsError> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let root = file_versions_root()?;
+        purge_session_with_root(&root, args)
+    })
+    .await
+    .map_err(|e| FileVersionsError::Io(std::io::Error::other(e.to_string())))?
 }
 
 fn begin_snapshot_with_root(

--- a/apps/desktop/src-tauri/src/integration_credentials.rs
+++ b/apps/desktop/src-tauri/src/integration_credentials.rs
@@ -27,6 +27,8 @@ pub enum IntegrationCredentialError {
     Store(String),
     #[error("secret store error: {0}")]
     Secret(#[from] secrets::SecretError),
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
 }
 
 crate::util::impl_error_serialize!(IntegrationCredentialError);
@@ -40,6 +42,7 @@ impl IntegrationCredentialError {
             IntegrationCredentialError::MissingSecret { .. } => "missing_secret",
             IntegrationCredentialError::Store(_) => "store",
             IntegrationCredentialError::Secret(_) => "secret",
+            IntegrationCredentialError::Io(_) => "io",
         }
     }
 }
@@ -643,7 +646,17 @@ where
 /// Whether the keychain still holds the secret a credential claims to own.
 /// A binding whose credential answers false is connected on paper only.
 #[tauri::command]
-pub fn integration_credential_has_secret(
+pub async fn integration_credential_has_secret(
+    credential_id: String,
+) -> Result<bool, IntegrationCredentialError> {
+    tauri::async_runtime::spawn_blocking(move || {
+        integration_credential_has_secret_blocking(credential_id)
+    })
+    .await
+    .map_err(|e| IntegrationCredentialError::Io(std::io::Error::other(e.to_string())))?
+}
+
+fn integration_credential_has_secret_blocking(
     credential_id: String,
 ) -> Result<bool, IntegrationCredentialError> {
     if credential_id.is_empty() {
@@ -655,7 +668,17 @@ pub fn integration_credential_has_secret(
 /// Removes the secret itself. The row is deleted first on the database side,
 /// where a foreign key refuses while any binding still references it.
 #[tauri::command]
-pub fn integration_credential_forget(
+pub async fn integration_credential_forget(
+    credential_id: String,
+) -> Result<(), IntegrationCredentialError> {
+    tauri::async_runtime::spawn_blocking(move || {
+        integration_credential_forget_blocking(credential_id)
+    })
+    .await
+    .map_err(|e| IntegrationCredentialError::Io(std::io::Error::other(e.to_string())))?
+}
+
+fn integration_credential_forget_blocking(
     credential_id: String,
 ) -> Result<(), IntegrationCredentialError> {
     if credential_id.is_empty() {

--- a/apps/desktop/src-tauri/src/permissions.rs
+++ b/apps/desktop/src-tauri/src/permissions.rs
@@ -145,7 +145,7 @@ impl From<DbError> for PermissionError {
 // ---------------------------------------------------------------------------
 
 #[tauri::command]
-pub fn permission_rule_list(
+pub async fn permission_rule_list(
     state: State<'_, Db>,
     scope: String,
     workspace_id: Option<String>,
@@ -205,7 +205,7 @@ pub fn permission_rule_list(
 }
 
 #[tauri::command]
-pub fn permission_rule_upsert(
+pub async fn permission_rule_upsert(
     state: State<'_, Db>,
     input: PermissionRuleUpsertInput,
 ) -> Result<PermissionRuleRow, PermissionError> {
@@ -306,7 +306,7 @@ pub fn permission_rule_upsert(
 // ---------------------------------------------------------------------------
 
 #[tauri::command]
-pub fn permission_audit_insert(
+pub async fn permission_audit_insert(
     state: State<'_, Db>,
     input: PermissionAuditInsertInput,
 ) -> Result<PermissionAuditRow, PermissionError> {
@@ -374,7 +374,7 @@ pub struct AuditRetryEnqueueInput {
 }
 
 #[tauri::command]
-pub fn permission_audit_retry_enqueue(
+pub async fn permission_audit_retry_enqueue(
     state: State<'_, Db>,
     input: AuditRetryEnqueueInput,
 ) -> Result<(), PermissionError> {
@@ -394,7 +394,7 @@ pub fn permission_audit_retry_enqueue(
 }
 
 #[tauri::command]
-pub fn permission_audit_retry_drain(
+pub async fn permission_audit_retry_drain(
     state: State<'_, Db>,
     limit: i64,
 ) -> Result<Vec<AuditRetryRow>, PermissionError> {
@@ -420,7 +420,7 @@ pub fn permission_audit_retry_drain(
 }
 
 #[tauri::command]
-pub fn permission_audit_retry_update(
+pub async fn permission_audit_retry_update(
     state: State<'_, Db>,
     id: String,
     attempts: i64,
@@ -440,7 +440,7 @@ pub fn permission_audit_retry_update(
 }
 
 #[tauri::command]
-pub fn permission_audit_retry_delete(
+pub async fn permission_audit_retry_delete(
     state: State<'_, Db>,
     id: String,
 ) -> Result<(), PermissionError> {

--- a/apps/desktop/src-tauri/src/provider_lifecycle.rs
+++ b/apps/desktop/src-tauri/src/provider_lifecycle.rs
@@ -446,7 +446,7 @@ pub fn provider_lifecycle_resize(
 /// group. Exit handler still runs and refreshes detection, so UI reflects the
 /// real (possibly half-installed) state.
 #[tauri::command]
-pub fn provider_lifecycle_cancel(
+pub async fn provider_lifecycle_cancel(
     registry: State<'_, ProviderLifecycleRegistry>,
     run_id: String,
 ) -> Result<(), LifecycleError> {

--- a/apps/desktop/src-tauri/src/scripts.rs
+++ b/apps/desktop/src-tauri/src/scripts.rs
@@ -352,7 +352,7 @@ pub async fn workspace_script_run_adhoc(
 }
 
 #[tauri::command]
-pub fn workspace_script_list_live(
+pub async fn workspace_script_list_live(
     registry: State<'_, ScriptRegistry>,
 ) -> Result<Vec<LiveScriptRun>, ScriptError> {
     registry.list_live()
@@ -365,7 +365,7 @@ pub fn workspace_script_list_live(
 /// Removes the run from the registry and kills the pty child. Dropping the
 /// master sends SIGHUP to the entire process group, cleaning up descendants.
 #[tauri::command]
-pub fn workspace_script_cancel(
+pub async fn workspace_script_cancel(
     registry: State<'_, ScriptRegistry>,
     run_id: String,
 ) -> Result<(), ScriptError> {

--- a/apps/desktop/src-tauri/src/secrets.rs
+++ b/apps/desktop/src-tauri/src/secrets.rs
@@ -19,6 +19,8 @@ const SERVICE: &str = "com.goodboy.desktop";
 pub enum SecretError {
     #[error("keyring backend error: {0}")]
     Backend(#[from] keyring::Error),
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
 }
 
 impl serde::Serialize for SecretError {
@@ -53,13 +55,17 @@ pub fn clear(key: &str) -> Result<(), SecretError> {
 }
 
 #[tauri::command]
-pub fn secret_set(key: String, value: String) -> Result<(), SecretError> {
-    set(&key, &value)
+pub async fn secret_set(key: String, value: String) -> Result<(), SecretError> {
+    tauri::async_runtime::spawn_blocking(move || set(&key, &value))
+        .await
+        .map_err(|e| SecretError::Io(std::io::Error::other(e.to_string())))?
 }
 
 #[tauri::command]
-pub fn secret_delete(key: String) -> Result<(), SecretError> {
-    clear(&key)
+pub async fn secret_delete(key: String) -> Result<(), SecretError> {
+    tauri::async_runtime::spawn_blocking(move || clear(&key))
+        .await
+        .map_err(|e| SecretError::Io(std::io::Error::other(e.to_string())))?
 }
 
 #[cfg(test)]

--- a/apps/desktop/src-tauri/src/session_dir.rs
+++ b/apps/desktop/src-tauri/src/session_dir.rs
@@ -191,7 +191,13 @@ fn resolve_directory_name(args: &CreateArgs) -> Result<String, SessionDirError> 
 }
 
 #[tauri::command]
-pub fn session_dir_create(args: CreateArgs) -> Result<CreatedSessionDir, SessionDirError> {
+pub async fn session_dir_create(args: CreateArgs) -> Result<CreatedSessionDir, SessionDirError> {
+    tauri::async_runtime::spawn_blocking(move || session_dir_create_blocking(args))
+        .await
+        .map_err(|e| SessionDirError::Io(std::io::Error::other(e.to_string())))?
+}
+
+fn session_dir_create_blocking(args: CreateArgs) -> Result<CreatedSessionDir, SessionDirError> {
     let base = expand_home(&args.base_path)?;
     let slug = resolve_directory_name(&args)?;
     let target = absolute_path(base)?.join("sessions").join(&slug);
@@ -256,7 +262,13 @@ fn session_dir_remove_blocking(args: RemoveArgs) -> Result<(), SessionDirError> 
 }
 
 #[tauri::command]
-pub fn session_dir_exists(path: String) -> Result<bool, SessionDirError> {
+pub async fn session_dir_exists(path: String) -> Result<bool, SessionDirError> {
+    tauri::async_runtime::spawn_blocking(move || session_dir_exists_blocking(path))
+        .await
+        .map_err(|e| SessionDirError::Io(std::io::Error::other(e.to_string())))?
+}
+
+fn session_dir_exists_blocking(path: String) -> Result<bool, SessionDirError> {
     Ok(absolute_path(expand_home(&path)?)?.is_dir())
 }
 
@@ -264,7 +276,7 @@ pub fn session_dir_exists(path: String) -> Result<bool, SessionDirError> {
 mod tests {
     use std::path::Path;
 
-    use super::{session_dir_create, CreateArgs, SessionDirError, SessionMarker};
+    use super::{session_dir_create_blocking, CreateArgs, SessionDirError, SessionMarker};
 
     fn test_root(name: &str) -> std::path::PathBuf {
         std::env::temp_dir().join(format!(
@@ -287,7 +299,7 @@ mod tests {
             session_id: "session-1".to_string(),
             workspace_id: "workspace-1".to_string(),
         };
-        let created = session_dir_create(args()).unwrap();
+        let created = session_dir_create_blocking(args()).unwrap();
         assert_eq!(created.branch_name, "");
         assert_eq!(created.slug, "study-plan");
         assert!(!created.reused);
@@ -303,7 +315,7 @@ mod tests {
         assert_eq!(marker.workspace_id, "workspace-1");
         assert!(!marker.created_at.is_empty());
         let first_created_at = marker.created_at.clone();
-        let reused = session_dir_create(args()).unwrap();
+        let reused = session_dir_create_blocking(args()).unwrap();
         assert!(reused.reused);
         let marker_after_reuse = std::fs::read(
             Path::new(&created.worktree_path)
@@ -328,7 +340,7 @@ mod tests {
             br#"{"sessionId":"session-1","workspaceId":"workspace-1","createdAt":"2026-01-01T00:00:00Z"}"#,
         )
         .unwrap();
-        let created = session_dir_create(CreateArgs {
+        let created = session_dir_create_blocking(CreateArgs {
             base_path: root.to_string_lossy().into_owned(),
             slug: "Study Plan".to_string(),
             directory_name: None,
@@ -343,7 +355,7 @@ mod tests {
     #[test]
     fn removes_a_nested_session_directory_and_refuses_anything_else() {
         let root = test_root("simple-session-remove");
-        let created = session_dir_create(CreateArgs {
+        let created = session_dir_create_blocking(CreateArgs {
             base_path: root.to_string_lossy().into_owned(),
             slug: "Study Plan".to_string(),
             directory_name: None,
@@ -382,7 +394,7 @@ mod tests {
         let sessions = root.join("sessions");
         std::fs::create_dir_all(sessions.join("study-plan")).unwrap();
 
-        let result = session_dir_create(CreateArgs {
+        let result = session_dir_create_blocking(CreateArgs {
             base_path: root.to_string_lossy().into_owned(),
             slug: "Study Plan".to_string(),
             directory_name: None,
@@ -400,7 +412,7 @@ mod tests {
     #[test]
     fn rejects_reusing_a_directory_owned_by_another_session() {
         let root = test_root("simple-session-session-conflict");
-        let created = session_dir_create(CreateArgs {
+        let created = session_dir_create_blocking(CreateArgs {
             base_path: root.to_string_lossy().into_owned(),
             slug: "Study Plan".to_string(),
             directory_name: None,
@@ -409,7 +421,7 @@ mod tests {
         })
         .unwrap();
 
-        let result = session_dir_create(CreateArgs {
+        let result = session_dir_create_blocking(CreateArgs {
             base_path: root.to_string_lossy().into_owned(),
             slug: "Study Plan".to_string(),
             directory_name: None,
@@ -428,7 +440,7 @@ mod tests {
     #[test]
     fn creates_a_directory_from_an_explicit_name() {
         let root = test_root("simple-session-explicit-name");
-        let created = session_dir_create(CreateArgs {
+        let created = session_dir_create_blocking(CreateArgs {
             base_path: root.to_string_lossy().into_owned(),
             slug: "ignored".to_string(),
             directory_name: Some("MatchAnalysis_20260514".to_string()),
@@ -460,7 +472,7 @@ mod tests {
         ];
 
         for name in invalid_names {
-            let result = session_dir_create(CreateArgs {
+            let result = session_dir_create_blocking(CreateArgs {
                 base_path: root.to_string_lossy().into_owned(),
                 slug: "ignored".to_string(),
                 directory_name: Some(name.to_string()),
@@ -470,7 +482,7 @@ mod tests {
             assert!(matches!(result, Err(SessionDirError::InvalidDirectoryName)));
         }
 
-        let control_result = session_dir_create(CreateArgs {
+        let control_result = session_dir_create_blocking(CreateArgs {
             base_path: root.to_string_lossy().into_owned(),
             slug: "ignored".to_string(),
             directory_name: Some("name\u{0007}part".to_string()),

--- a/apps/desktop/src-tauri/src/settings_overrides.rs
+++ b/apps/desktop/src-tauri/src/settings_overrides.rs
@@ -49,7 +49,7 @@ fn string_array_from_text(raw: Option<String>) -> Option<Vec<String>> {
 }
 
 #[tauri::command]
-pub fn get_workspace_overrides(
+pub async fn get_workspace_overrides(
     state: State<'_, Db>,
     workspace_id: String,
 ) -> Result<Option<SettingsOverrides>, DbError> {
@@ -81,7 +81,7 @@ pub fn get_workspace_overrides(
 }
 
 #[tauri::command]
-pub fn set_workspace_overrides(
+pub async fn set_workspace_overrides(
     state: State<'_, Db>,
     workspace_id: String,
     overrides: SettingsOverrides,
@@ -123,7 +123,7 @@ pub fn set_workspace_overrides(
 }
 
 #[tauri::command]
-pub fn get_session_overrides(
+pub async fn get_session_overrides(
     state: State<'_, Db>,
     session_id: String,
 ) -> Result<Option<SettingsOverrides>, DbError> {
@@ -154,7 +154,7 @@ pub fn get_session_overrides(
 }
 
 #[tauri::command]
-pub fn set_session_overrides(
+pub async fn set_session_overrides(
     state: State<'_, Db>,
     session_id: String,
     overrides: SettingsOverrides,

--- a/apps/desktop/src-tauri/src/skills.rs
+++ b/apps/desktop/src-tauri/src/skills.rs
@@ -157,7 +157,10 @@ impl From<DbError> for SkillError {
 // ---------------------------------------------------------------------------
 
 #[tauri::command]
-pub fn skill_list(state: State<'_, Db>, workspace_id: String) -> Result<Vec<SkillRow>, SkillError> {
+pub async fn skill_list(
+    state: State<'_, Db>,
+    workspace_id: String,
+) -> Result<Vec<SkillRow>, SkillError> {
     let conn = state.0.lock().map_err(|_| SkillError::Poisoned)?;
     let mut stmt = conn.prepare(
         "SELECT id, workspace_id, name, description, file_path, body, frontmatter_json,
@@ -183,7 +186,10 @@ pub fn skill_list(state: State<'_, Db>, workspace_id: String) -> Result<Vec<Skil
 }
 
 #[tauri::command]
-pub fn skill_get(state: State<'_, Db>, skill_id: String) -> Result<Option<SkillRow>, SkillError> {
+pub async fn skill_get(
+    state: State<'_, Db>,
+    skill_id: String,
+) -> Result<Option<SkillRow>, SkillError> {
     let conn = state.0.lock().map_err(|_| SkillError::Poisoned)?;
     let mut stmt = conn.prepare(
         "SELECT id, workspace_id, name, description, file_path, body, frontmatter_json,
@@ -212,7 +218,10 @@ pub fn skill_get(state: State<'_, Db>, skill_id: String) -> Result<Option<SkillR
 }
 
 #[tauri::command]
-pub fn skill_upsert(state: State<'_, Db>, input: SkillUpsertInput) -> Result<SkillRow, SkillError> {
+pub async fn skill_upsert(
+    state: State<'_, Db>,
+    input: SkillUpsertInput,
+) -> Result<SkillRow, SkillError> {
     let conn = state.0.lock().map_err(|_| SkillError::Poisoned)?;
 
     let roots = workspace_roots(&conn, &input.workspace_id)?;
@@ -307,7 +316,7 @@ pub fn skill_upsert(state: State<'_, Db>, input: SkillUpsertInput) -> Result<Ski
 }
 
 #[tauri::command]
-pub fn skill_delete(state: State<'_, Db>, skill_id: String) -> Result<(), SkillError> {
+pub async fn skill_delete(state: State<'_, Db>, skill_id: String) -> Result<(), SkillError> {
     let conn = state.0.lock().map_err(|_| SkillError::Poisoned)?;
 
     // Look up the row first to get file_path + workspace root for path guard.
@@ -365,7 +374,7 @@ pub fn skill_delete(state: State<'_, Db>, skill_id: String) -> Result<(), SkillE
 }
 
 #[tauri::command]
-pub fn skill_rescan(
+pub async fn skill_rescan(
     state: State<'_, Db>,
     workspace_id: String,
 ) -> Result<Vec<SkillRow>, SkillError> {
@@ -528,7 +537,17 @@ pub struct SkillRunScriptInput {
 }
 
 #[tauri::command]
-pub fn skill_run_script(input: SkillRunScriptInput) -> Result<SkillRunScriptResult, SkillError> {
+pub async fn skill_run_script(
+    input: SkillRunScriptInput,
+) -> Result<SkillRunScriptResult, SkillError> {
+    tauri::async_runtime::spawn_blocking(move || skill_run_script_blocking(input))
+        .await
+        .map_err(|e| SkillError::Io(e.to_string()))?
+}
+
+fn skill_run_script_blocking(
+    input: SkillRunScriptInput,
+) -> Result<SkillRunScriptResult, SkillError> {
     let allowed_prefix = PathBuf::from(&input.project_root)
         .join(".kay")
         .join("skills");

--- a/apps/desktop/src-tauri/src/skills.rs
+++ b/apps/desktop/src-tauri/src/skills.rs
@@ -222,9 +222,11 @@ pub async fn skill_upsert(
     state: State<'_, Db>,
     input: SkillUpsertInput,
 ) -> Result<SkillRow, SkillError> {
-    let conn = state.0.lock().map_err(|_| SkillError::Poisoned)?;
+    let roots = {
+        let conn = state.0.lock().map_err(|_| SkillError::Poisoned)?;
+        workspace_roots(&conn, &input.workspace_id)?
+    };
 
-    let roots = workspace_roots(&conn, &input.workspace_id)?;
     let skills_dirs = roots
         .iter()
         .map(|root| root.join(".kay").join("skills"))
@@ -233,7 +235,6 @@ pub async fn skill_upsert(
         .first()
         .ok_or_else(|| SkillError::WorkspaceNotFound(input.workspace_id.clone()))?;
 
-    // Derive file path if not provided.
     let raw_path = match &input.file_path {
         Some(fp) => PathBuf::from(fp),
         None => default_skills_dir.join(format!("{}.md", &input.name)),
@@ -246,14 +247,14 @@ pub async fn skill_upsert(
     std::fs::create_dir_all(skills_dir).map_err(|e| SkillError::Io(e.to_string()))?;
     let canonical = guard_path(&raw_path, skills_dir)?;
 
-    // Write pre-serialized markdown to disk.
     std::fs::write(&canonical, &input.markdown).map_err(|e| SkillError::Io(e.to_string()))?;
 
     let file_path_str = canonical.to_string_lossy().to_string();
     let now_ms = crate::util::now_ms();
     let now = crate::util::ms_to_iso(now_ms);
 
-    // Upsert by (workspace_id, name); generate id if new.
+    let conn = state.0.lock().map_err(|_| SkillError::Poisoned)?;
+
     let existing_id: Option<String> = {
         let mut stmt =
             conn.prepare("SELECT id FROM skills WHERE workspace_id = ?1 AND name = ?2 LIMIT 1")?;
@@ -317,55 +318,58 @@ pub async fn skill_upsert(
 
 #[tauri::command]
 pub async fn skill_delete(state: State<'_, Db>, skill_id: String) -> Result<(), SkillError> {
-    let conn = state.0.lock().map_err(|_| SkillError::Poisoned)?;
-
-    // Look up the row first to get file_path + workspace root for path guard.
-    let row: Option<(String, String)> = {
-        let mut stmt = conn.prepare(
-            "SELECT s.file_path, s.workspace_id
-             FROM skills s
-             WHERE s.id = ?1
-             LIMIT 1",
-        )?;
-        let mut rows = stmt.query_map(rusqlite::params![skill_id], |row| {
-            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
-        })?;
-        match rows.next() {
-            Some(r) => Some(r.map_err(SkillError::Db)?),
-            None => None,
+    let (file_path, roots) = {
+        let conn = state.0.lock().map_err(|_| SkillError::Poisoned)?;
+        let row: Option<(String, String)> = {
+            let mut stmt = conn.prepare(
+                "SELECT s.file_path, s.workspace_id
+                 FROM skills s
+                 WHERE s.id = ?1
+                 LIMIT 1",
+            )?;
+            let mut rows = stmt.query_map(rusqlite::params![skill_id], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })?;
+            match rows.next() {
+                Some(r) => Some(r.map_err(SkillError::Db)?),
+                None => None,
+            }
+        };
+        match row {
+            Some((file_path, workspace_id)) => {
+                let roots = workspace_roots(&conn, &workspace_id)?;
+                (file_path, roots)
+            }
+            None => return Err(SkillError::NotFound(skill_id)),
         }
     };
 
-    if let Some((file_path, workspace_id)) = row {
-        let roots = workspace_roots(&conn, &workspace_id)?;
-        let path = PathBuf::from(&file_path);
-        let allowed_dirs = roots.iter().flat_map(|root| {
-            [
-                root.join(".kay").join("skills"),
-                root.join(".claude").join("skills"),
-            ]
-        });
-        let mut guarded_path = None;
-        for directory in allowed_dirs {
-            if !directory.exists() {
-                continue;
-            }
-            if let Ok(canonical) = guard_path(&path, &directory) {
-                guarded_path = Some(canonical);
-                break;
-            }
+    let path = PathBuf::from(&file_path);
+    let allowed_dirs = roots.iter().flat_map(|root| {
+        [
+            root.join(".kay").join("skills"),
+            root.join(".claude").join("skills"),
+        ]
+    });
+    let mut guarded_path = None;
+    for directory in allowed_dirs {
+        if !directory.exists() {
+            continue;
         }
-        if let Some(canonical) = guarded_path {
-            if canonical.exists() {
-                std::fs::remove_file(canonical).map_err(|e| SkillError::Io(e.to_string()))?;
-            }
-        } else if path.exists() {
-            return Err(SkillError::PathTraversal(file_path));
+        if let Ok(canonical) = guard_path(&path, &directory) {
+            guarded_path = Some(canonical);
+            break;
         }
-    } else {
-        return Err(SkillError::NotFound(skill_id));
+    }
+    if let Some(canonical) = guarded_path {
+        if canonical.exists() {
+            std::fs::remove_file(canonical).map_err(|e| SkillError::Io(e.to_string()))?;
+        }
+    } else if path.exists() {
+        return Err(SkillError::PathTraversal(file_path));
     }
 
+    let conn = state.0.lock().map_err(|_| SkillError::Poisoned)?;
     conn.execute(
         "DELETE FROM skills WHERE id = ?1",
         rusqlite::params![skill_id],
@@ -378,12 +382,11 @@ pub async fn skill_rescan(
     state: State<'_, Db>,
     workspace_id: String,
 ) -> Result<Vec<SkillRow>, SkillError> {
-    let conn = state.0.lock().map_err(|_| SkillError::Poisoned)?;
-    let roots = workspace_roots(&conn, &workspace_id)?;
+    let roots = {
+        let conn = state.0.lock().map_err(|_| SkillError::Poisoned)?;
+        workspace_roots(&conn, &workspace_id)?
+    };
 
-    // Discover skill files from both layouts:
-    //   - <root>/.kay/skills/*.md            (Goodboy native)
-    //   - <root>/.claude/skills/<name>/SKILL.md  (claude-code convention)
     let mut md_files: Vec<PathBuf> = Vec::new();
 
     for root in roots {
@@ -418,8 +421,8 @@ pub async fn skill_rescan(
 
     let now_ms = crate::util::now_ms();
 
-    // Existing skills in DB for this workspace.
     let existing: Vec<(String, String)> = {
+        let conn = state.0.lock().map_err(|_| SkillError::Poisoned)?;
         let mut stmt = conn.prepare("SELECT id, file_path FROM skills WHERE workspace_id = ?1")?;
         let rows = stmt.query_map(rusqlite::params![workspace_id], |row| {
             Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
@@ -434,6 +437,7 @@ pub async fn skill_rescan(
         .collect();
 
     let mut scanned_paths = std::collections::HashSet::new();
+    let mut parsed_entries: Vec<(String, String, String, String, String, String)> = Vec::new();
 
     for file_path in &md_files {
         let canonical = match file_path.canonicalize() {
@@ -446,7 +450,6 @@ pub async fn skill_rescan(
         let content =
             std::fs::read_to_string(&canonical).map_err(|e| SkillError::Io(e.to_string()))?;
 
-        // Extract name/description from frontmatter naively (no TS parser available).
         let (name, description, body, frontmatter_json) = parse_skill_markdown_rust(&content)?;
 
         let id = existing_by_path
@@ -454,6 +457,12 @@ pub async fn skill_rescan(
             .cloned()
             .unwrap_or_else(crate::util::uuid_v4);
 
+        parsed_entries.push((id, fp_str, name, description, body, frontmatter_json));
+    }
+
+    let conn = state.0.lock().map_err(|_| SkillError::Poisoned)?;
+
+    for (id, fp_str, name, description, body, frontmatter_json) in &parsed_entries {
         let created_at_ms: i64 = {
             let mut stmt = conn.prepare("SELECT created_at FROM skills WHERE id = ?1 LIMIT 1")?;
             let mut rows = stmt.query_map(rusqlite::params![id], |row| row.get(0))?;
@@ -489,14 +498,12 @@ pub async fn skill_rescan(
         )?;
     }
 
-    // Delete DB rows whose files are no longer on disk.
     for (id, fp) in &existing {
         if !scanned_paths.contains(fp) {
             conn.execute("DELETE FROM skills WHERE id = ?1", rusqlite::params![id])?;
         }
     }
 
-    // Return updated list.
     let mut stmt = conn.prepare(
         "SELECT id, workspace_id, name, description, file_path, body, frontmatter_json,
                 created_at, updated_at

--- a/apps/desktop/src-tauri/src/terminal.rs
+++ b/apps/desktop/src-tauri/src/terminal.rs
@@ -302,7 +302,7 @@ pub async fn terminal_open(
 }
 
 #[tauri::command]
-pub fn terminal_list_live(
+pub async fn terminal_list_live(
     registry: State<'_, TerminalRegistry>,
 ) -> Result<Vec<LiveTerminal>, TerminalError> {
     registry.list_live()
@@ -361,7 +361,7 @@ pub fn terminal_resize(
 }
 
 #[tauri::command]
-pub fn terminal_close(
+pub async fn terminal_close(
     registry: State<'_, TerminalRegistry>,
     session_id: String,
 ) -> Result<(), TerminalError> {

--- a/apps/desktop/src-tauri/src/turn.rs
+++ b/apps/desktop/src-tauri/src/turn.rs
@@ -387,7 +387,7 @@ fn spawn_one(
 }
 
 #[tauri::command]
-pub fn turn_spawn(
+pub async fn turn_spawn(
     app: AppHandle,
     state: State<'_, TurnRegistry>,
     args: SpawnArgs,
@@ -430,13 +430,13 @@ pub fn turn_spawn(
 }
 
 #[tauri::command]
-pub fn turn_list_live(state: State<'_, TurnRegistry>) -> Result<Vec<String>, TurnError> {
+pub async fn turn_list_live(state: State<'_, TurnRegistry>) -> Result<Vec<String>, TurnError> {
     let map = state.0.lock().map_err(|_| TurnError::Poisoned)?;
     Ok(map.keys().cloned().collect())
 }
 
 #[tauri::command]
-pub fn turn_cancel(state: State<'_, TurnRegistry>, run_id: String) -> Result<(), TurnError> {
+pub async fn turn_cancel(state: State<'_, TurnRegistry>, run_id: String) -> Result<(), TurnError> {
     let map = state.0.lock().map_err(|_| TurnError::Poisoned)?;
     let slot = map
         .get(&run_id)

--- a/apps/desktop/src-tauri/src/workflows.rs
+++ b/apps/desktop/src-tauri/src/workflows.rs
@@ -465,7 +465,7 @@ fn resolve_live_name(
 }
 
 #[tauri::command]
-pub fn workflow_upsert(
+pub async fn workflow_upsert(
     state: State<'_, Db>,
     input: PhaseTemplateUpsertInput,
 ) -> Result<WorkflowRow, PhaseError> {
@@ -636,7 +636,7 @@ pub fn workflow_upsert(
 }
 
 #[tauri::command]
-pub fn workflow_delete(state: State<'_, Db>, id: String) -> Result<(), PhaseError> {
+pub async fn workflow_delete(state: State<'_, Db>, id: String) -> Result<(), PhaseError> {
     let conn = state.0.lock().map_err(|_| PhaseError::Poisoned)?;
 
     let exists: bool = {
@@ -795,7 +795,7 @@ pub async fn step_def_list(
 }
 
 #[tauri::command]
-pub fn step_def_upsert(
+pub async fn step_def_upsert(
     state: State<'_, Db>,
     input: StepDefUpsertInput,
 ) -> Result<StepDefRow, PhaseError> {
@@ -863,7 +863,7 @@ pub fn step_def_upsert(
 /// `steps` rows (the instance carries its own copy), so existing presets are
 /// unaffected; the def just stops appearing in the library picker.
 #[tauri::command]
-pub fn step_def_delete(state: State<'_, Db>, id: String) -> Result<(), PhaseError> {
+pub async fn step_def_delete(state: State<'_, Db>, id: String) -> Result<(), PhaseError> {
     let conn = state.0.lock().map_err(|_| PhaseError::Poisoned)?;
     let affected = conn.execute(
         "UPDATE step_library SET deleted_at = ?2 WHERE id = ?1",
@@ -943,7 +943,7 @@ const AGENT_INSERT_SQL: &str = "INSERT INTO agents
  VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22)";
 
 #[tauri::command]
-pub fn agent_insert(
+pub async fn agent_insert(
     state: State<'_, Db>,
     input: PhaseRunInsertInput,
 ) -> Result<SessionRow, PhaseError> {
@@ -1015,7 +1015,7 @@ pub fn agent_insert(
 }
 
 #[tauri::command]
-pub fn agent_update_status(
+pub async fn agent_update_status(
     state: State<'_, Db>,
     input: PhaseRunUpdateInput,
 ) -> Result<SessionRow, PhaseError> {
@@ -1068,7 +1068,7 @@ pub fn agent_update_status(
 // chip survives an app restart. agentKindOverride in the store mirrors
 // this column; both are kept in sync via this command.
 #[tauri::command]
-pub fn agent_set_kind(
+pub async fn agent_set_kind(
     state: State<'_, Db>,
     id: String,
     kind: Option<String>,
@@ -1086,7 +1086,7 @@ pub fn agent_set_kind(
 
 // Persists the agent-level verbosity override. NULL = inherit from workspace.
 #[tauri::command]
-pub fn agent_set_verbosity(
+pub async fn agent_set_verbosity(
     state: State<'_, Db>,
     id: String,
     verbosity: Option<String>,
@@ -1103,7 +1103,7 @@ pub fn agent_set_verbosity(
 }
 
 #[tauri::command]
-pub fn agent_set_provider_session_id(
+pub async fn agent_set_provider_session_id(
     state: State<'_, Db>,
     id: String,
     provider_session_id: String,
@@ -1123,7 +1123,11 @@ pub fn agent_set_provider_session_id(
 // Stamps `last_viewed_at` when the user selects/views an agent in the sidebar.
 // Compared against `last_finished_at` to derive the unread indicator.
 #[tauri::command]
-pub fn agent_mark_viewed(state: State<'_, Db>, id: String, at: String) -> Result<(), PhaseError> {
+pub async fn agent_mark_viewed(
+    state: State<'_, Db>,
+    id: String,
+    at: String,
+) -> Result<(), PhaseError> {
     let conn = state.0.lock().map_err(|_| PhaseError::Poisoned)?;
     let affected = conn.execute(
         "UPDATE agents SET last_viewed_at = ?2 WHERE id = ?1",
@@ -1139,7 +1143,7 @@ pub fn agent_mark_viewed(state: State<'_, Db>, id: String, at: String) -> Result
 }
 
 #[tauri::command]
-pub fn agent_set_done(
+pub async fn agent_set_done(
     state: State<'_, Db>,
     id: String,
     done: bool,


### PR DESCRIPTION
## Why
A sync `#[tauri::command]` runs on the macOS main thread, the one that drives the WKWebView; any filesystem, sqlite or process work inside it stalls the UI (the v0.2.14 session-switch freeze was this). 86 of 225 commands were still sync.

## What
- 72 commands across 17 files are async: `spawn_blocking` twins where arguments are owned (attachment, editor, skills, session_dir, integration_credentials, db snapshots), plain `pub async fn` where a `State` is borrowed (`Db` wraps a `Mutex<Connection>` directly, it cannot move into a `'static` closure; `workflow_list` already used this form). No guard is held across an await.
- `Io` variants added to `EditorError`, `SecretError`, `IntegrationCredentialError`.
- Kept sync on purpose (5): `db_path` (pure getter) and `terminal_write`, `terminal_resize`, `provider_lifecycle_write`, `provider_lifecycle_resize`: fired unawaited once per keystroke, their IPC order on the main thread is what keeps keystrokes ordered into the PTY; the async runtime would not guarantee it and there is no main-thread time to reclaim there.
- 14 sync remain (9 in files outside this batch: explore, external_terminal, github, profile_file, qa_preview, scratch_dir, summarize, query_bridge).

## Verification
- `cargo test --locked` 601 green, `cargo fmt` clean, clippy 25 warnings before and after (zero new), `pnpm run check:tauri-commands` 232/232.

🤖 Generated with [Claude Code](https://claude.com/claude-code)