### PR TITLE
chore(repo): bump version to 0.2.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ version in the same PR that bumps the version numbers (see
 `docs/release-command.md`), before the tag is pushed: the release build fails
 if it can't find a matching `## Goodboy vX.Y.Z` heading.
 
+## Goodboy v0.2.16
+
+The website's landing page rewrites around what Goodboy does for you,
+most tauri commands move off the desktop app's main thread, the
+sentry lens retires into the inbox, and budget merges into impact
+studio.
+
+### [#1665] Website: the landing page rewrites around what the app does
+
+The public website, not the app itself, rewrites its landing page
+around what Goodboy does for you rather than how it's built, answers
+a review right on the scrolling provider belt, and updates the
+structured data to match.
+
+### [#1666] 72 tauri commands move off the main thread
+
+Of 86 tauri commands that used to run synchronously on the desktop
+app's main thread, 72 now run off it; only terminal and provider
+write and resize, and db_path, stay sync on purpose. Skill upsert,
+delete and rescan no longer hold the database lock while they touch
+disk, so a slow scan can't stall everything else waiting on it.
+
+### [#1667] The sentry lens retires into the inbox
+
+The sentry lens is gone. Sentry issues now open in the inbox with the
+record focused, the way every other integration already works. The
+inbox gains a session scope chip and an unlink action on sentry
+records, five orphaned goodboy:open-*-studio listeners are deleted,
+and cmd+alt+3 is unbound.
+
+### [#1668] Budget merges into impact studio
+
+Budget is no longer its own surface: it merges into impact studio as
+one rail alongside the four impact sections, plus spend by provider
+and by session, behind a single window picker. A spend section sits
+under overview, and budget leaves settings and the more popover.
+goodboy:open-budget-studio stays as an alias so old links keep
+working.
+
 ## Goodboy v0.2.15
 
 Every lens and detail page now names the session you're in, its title

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goodboy/desktop",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -1626,7 +1626,7 @@ dependencies = [
 
 [[package]]
 name = "goodboy-desktop"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goodboy-desktop"
-version = "0.2.15"
+version = "0.2.16"
 description = "Goodboy desktop app"
 authors = ["Amin Khayam"]
 license = "MIT"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Goodboy",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "identifier": "com.goodboy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goodboy",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "private": true,
   "description": "AI workspace orchestrator. Local-first, provider-agnostic.",
   "license": "MIT",

--- a/website/src/site.ts
+++ b/website/src/site.ts
@@ -1,5 +1,5 @@
 export const SITE = {
-  version: 'v0.2.15',
+  version: 'v0.2.16',
   repo: 'https://github.com/akhayam99/goodboy',
   releases: 'https://github.com/akhayam99/goodboy/releases',
   latest: 'https://github.com/akhayam99/goodboy/releases/latest',


### PR DESCRIPTION
## What

- version 0.2.15 -> 0.2.16 in package.json, apps/desktop/package.json, tauri.conf.json, Cargo.toml, Cargo.lock (desktop crate only), website/src/site.ts
- CHANGELOG.md gains the v0.2.16 section covering #1665, #1666, #1667, #1668

## Why

release v0.2.16, merges last after the full gate on origin/main is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)