### PR TITLE
perf(repo): rebuild landing page motion grammar and load path

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -8,12 +8,38 @@
       (function (w, d, s, l, i) {
         w[l] = w[l] || [];
         w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
-        var f = d.getElementsByTagName(s)[0],
-          j = d.createElement(s),
-          dl = l != 'dataLayer' ? '&l=' + l : '';
-        j.async = true;
-        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
-        f.parentNode.insertBefore(j, f);
+        var done = false;
+        var load = function () {
+          if (done) return;
+          done = true;
+          try {
+            var f = d.getElementsByTagName(s)[0],
+              j = d.createElement(s),
+              dl = l != 'dataLayer' ? '&l=' + l : '';
+            j.async = true;
+            j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+            f.parentNode.insertBefore(j, f);
+          } catch (e) {}
+        };
+        var schedule = function () {
+          if (w.requestIdleCallback) w.requestIdleCallback(load, { timeout: 4000 });
+          else w.setTimeout(load, 2000);
+        };
+        var opts = { once: true, passive: true };
+        var events = ['pointerdown', 'keydown', 'scroll'];
+        if (typeof w.addEventListener === 'function') {
+          for (var k = 0; k < events.length; k++) {
+            try {
+              w.addEventListener(events[k], load, opts);
+            } catch (e) {
+              w.addEventListener(events[k], load, false);
+            }
+          }
+          if (d.readyState === 'complete') schedule();
+          else w.addEventListener('load', schedule, false);
+        } else {
+          schedule();
+        }
       })(window, document, 'script', 'dataLayer', 'GTM-5NM3VX7Q');
     </script>
     <!-- End Google Tag Manager -->

--- a/website/index.html
+++ b/website/index.html
@@ -11,7 +11,6 @@
         var done = false;
         var load = function () {
           if (done) return;
-          done = true;
           try {
             var f = d.getElementsByTagName(s)[0],
               j = d.createElement(s),
@@ -19,6 +18,7 @@
             j.async = true;
             j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
             f.parentNode.insertBefore(j, f);
+            done = true;
           } catch (e) {}
         };
         var schedule = function () {

--- a/website/src/sections/Activity.css
+++ b/website/src/sections/Activity.css
@@ -57,22 +57,7 @@
 }
 
 .ac-slot {
-  display: grid;
-  grid-template-rows: 0fr;
-  margin-top: 0;
-  transition:
-    grid-template-rows 0.46s cubic-bezier(0.2, 0.7, 0.3, 1),
-    margin-top 0.46s cubic-bezier(0.2, 0.7, 0.3, 1);
-}
-
-.ac-slot.ac-on {
-  grid-template-rows: 1fr;
   margin-top: var(--gap);
-}
-
-.ac-clip {
-  min-height: 0;
-  overflow: hidden;
 }
 
 .ac-row {
@@ -80,16 +65,18 @@
   grid-template-columns: var(--ac-gut) 32px minmax(0, 1fr);
   align-items: center;
   min-height: var(--bh);
-  opacity: 0;
-  transform: translateY(-5px);
-  transition:
-    opacity 0.34s ease 0.1s,
-    transform 0.44s cubic-bezier(0.2, 0.7, 0.3, 1) 0.06s;
 }
 
-.ac-slot.ac-on .ac-row {
-  opacity: 1;
-  transform: none;
+.ac-row,
+.ac-row * {
+  transition:
+    color 0.58s cubic-bezier(0.2, 0.7, 0.3, 1),
+    background-color 0.58s cubic-bezier(0.2, 0.7, 0.3, 1),
+    border-color 0.58s cubic-bezier(0.2, 0.7, 0.3, 1);
+}
+
+.ac-slot:not(.ac-on) {
+  --ac-run: var(--gray3);
 }
 
 .ac-gut {
@@ -100,6 +87,10 @@
   font-size: 10px;
   font-variant-numeric: tabular-nums;
   color: var(--gray5);
+}
+
+.ac-slot:not(.ac-on) .ac-gut {
+  color: color-mix(in oklab, var(--gray5) 62%, #fff);
 }
 
 .ac-nowlabel {
@@ -150,8 +141,13 @@
 }
 
 .ac-dash {
-  background-image: linear-gradient(to bottom, var(--ac-run) 0 3px, transparent 3px 6px);
-  background-size: 2px 6px;
+  background: var(--ac-run);
+  mask-image: linear-gradient(to bottom, #000 0 3px, transparent 3px 6px);
+  mask-size: 2px 6px;
+}
+
+.ac-lane.ac-pend {
+  --ac-run: var(--gray3);
 }
 
 .ac-join {
@@ -232,11 +228,21 @@
   color: oklch(0.71 0.14 277);
 }
 
+.ac-slot:not(.ac-on) .ac-mk {
+  background: #fff;
+  box-shadow: inset 0 0 0 1px var(--gray3);
+  color: var(--gray5);
+}
+
 .ac-live {
   width: 4px;
   height: 4px;
   border-radius: 50%;
   background: var(--info);
+}
+
+.ac-slot:not(.ac-on) .ac-live {
+  background: var(--gray5);
 }
 
 .ac-body {
@@ -249,7 +255,7 @@
   padding: 0 6px 0 8px;
 }
 
-.ac-body.ac-wash {
+.ac-slot.ac-on .ac-body.ac-wash {
   background: color-mix(in oklab, var(--warn) 6%, transparent);
 }
 
@@ -257,6 +263,11 @@
   margin-top: 0;
   margin-left: 12px;
   flex-shrink: 0;
+}
+
+.ac-slot:not(.ac-on) .ac-body .mockbtn {
+  background: var(--gray1);
+  color: var(--gray5);
 }
 
 .ac-label {
@@ -275,6 +286,10 @@
 
 .ac-label.ac-ok {
   color: var(--ok-text);
+}
+
+.ac-slot:not(.ac-on) .ac-label {
+  color: var(--gray5);
 }
 
 .ac-val {
@@ -304,6 +319,15 @@
   color: var(--gray5);
   white-space: nowrap;
   flex-shrink: 0;
+}
+
+.ac-slot:not(.ac-on) .ac-val {
+  background: var(--gray0);
+}
+
+.ac-slot:not(.ac-on) .ac-sec,
+.ac-slot:not(.ac-on) .ac-hint {
+  color: color-mix(in oklab, var(--gray5) 62%, #fff);
 }
 
 .ac-runchip {
@@ -337,6 +361,20 @@
 .kb.ac-k-tester {
   background: oklch(0.94 0.05 65);
   color: oklch(0.48 0.13 55);
+}
+
+.ac-slot:not(.ac-on) .kb,
+.ac-slot:not(.ac-on) .ac-runchip {
+  background: var(--gray1);
+  box-shadow: none;
+  color: var(--gray5);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ac-row,
+  .ac-row * {
+    transition: none;
+  }
 }
 
 @media (max-width: 768px) {

--- a/website/src/sections/Activity.css
+++ b/website/src/sections/Activity.css
@@ -142,7 +142,9 @@
 
 .ac-dash {
   background: var(--ac-run);
+  -webkit-mask-image: linear-gradient(to bottom, #000 0 3px, transparent 3px 6px);
   mask-image: linear-gradient(to bottom, #000 0 3px, transparent 3px 6px);
+  -webkit-mask-size: 2px 6px;
   mask-size: 2px 6px;
 }
 

--- a/website/src/sections/Activity.tsx
+++ b/website/src/sections/Activity.tsx
@@ -25,7 +25,7 @@ type Ev = {
 };
 
 const BEATS = [
-  400, 1300, 2200, 3100, 4000, 4900, 5900, 6900, 7900, 8900, 9900, 11600, 12600, 13600, 14600,
+  240, 590, 890, 1180, 1540, 1920, 2210, 2520, 2860, 3170, 3510, 4490, 4840, 5150, 5490,
 ];
 
 const AT_WORKFLOW = 2;
@@ -213,27 +213,25 @@ const Rail = ({
 
 const FeedRow = ({ ev, stage }: { readonly ev: Ev; readonly stage: number }) => (
   <div className={`ac-slot${stage >= ev.at ? ' ac-on' : ''}`} style={rowStyle(ev.gap, ev.bh)}>
-    <div className="ac-clip">
-      <div className="ac-row">
-        <div className="ac-gut">
-          <span>{ev.time}</span>
-        </div>
-        <div className="ac-rc">
-          <Rail
-            up={laneUp(ev.run, ev.at, stage)}
-            down={laneDown(ev.run)}
-            join={ev.run === 'anchor'}
-          />
-          <span
-            className={`ac-mk ac-${ev.grade} ac-t-${ev.tone}${ev.run === 'step' ? ' ac-onlane' : ''}`}
-          >
-            {ev.glyph}
-          </span>
-        </div>
-        <div className={`ac-body ac-${ev.grade}${ev.wash === true ? ' ac-wash' : ''}`}>
-          {ev.body}
-          {ev.action}
-        </div>
+    <div className="ac-row">
+      <div className="ac-gut">
+        <span>{ev.time}</span>
+      </div>
+      <div className="ac-rc">
+        <Rail
+          up={laneUp(ev.run, ev.at, stage)}
+          down={laneDown(ev.run)}
+          join={ev.run === 'anchor'}
+        />
+        <span
+          className={`ac-mk ac-${ev.grade} ac-t-${ev.tone}${ev.run === 'step' ? ' ac-onlane' : ''}`}
+        >
+          {ev.glyph}
+        </span>
+      </div>
+      <div className={`ac-body ac-${ev.grade}${ev.wash === true ? ' ac-wash' : ''}`}>
+        {ev.body}
+        {ev.action}
       </div>
     </div>
   </div>
@@ -532,17 +530,17 @@ export const Activity = () => {
             <p className="ac-eyebrow">Activity</p>
             <div className="ac-stream">
               <div className="ac-slot ac-on" style={rowStyle(0, 26)}>
-                <div className="ac-clip">
-                  <div className="ac-row">
-                    <div className="ac-gut">
-                      <span className="ac-nowlabel">Now</span>
-                    </div>
-                    <div className="ac-rc">
-                      {stage >= AT_WORKFLOW && <span className="ac-lane ac-down ac-dash" />}
-                      <span className="ac-nowdot" />
-                    </div>
-                    <div className="ac-body" />
+                <div className="ac-row">
+                  <div className="ac-gut">
+                    <span className="ac-nowlabel">Now</span>
                   </div>
+                  <div className="ac-rc">
+                    <span
+                      className={`ac-lane ac-down ac-dash${stage >= AT_WORKFLOW ? '' : ' ac-pend'}`}
+                    />
+                    <span className="ac-nowdot" />
+                  </div>
+                  <div className="ac-body" />
                 </div>
               </div>
 

--- a/website/src/sections/Artifacts.css
+++ b/website/src/sections/Artifacts.css
@@ -1,25 +1,121 @@
-.ar-panes {
+.ar-fig {
   display: grid;
-  grid-template-columns: minmax(0, 1.02fr) minmax(0, 0.98fr);
+  grid-template-columns: minmax(0, 1fr);
+  gap: 26px;
+  margin-top: 48px;
+  align-items: stretch;
 }
 
-.ar-pane {
+@media (min-width: 901px) {
+  .ar-fig {
+    grid-template-columns: minmax(0, 1.04fr) minmax(0, 0.96fr);
+    gap: 20px;
+  }
+}
+
+.ar-side {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
   min-width: 0;
-  padding: 16px 18px 18px;
-}
-
-.ar-kept {
-  border-left: 1px solid var(--gray1);
-  background: var(--gray0);
-  overflow: hidden;
 }
 
 .ar-eyebrow {
+  padding-left: 2px;
   font-size: 11px;
   font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--gray6);
+}
+
+.ar-term {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+  background: #fff;
+  border: 1px solid var(--gray3);
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 1px 3px rgba(16, 17, 19, 0.05);
+}
+
+.ar-termbar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  height: 42px;
+  padding: 0 14px;
+  border-bottom: 1px solid var(--gray1);
+  background: var(--gray0);
+}
+
+.ar-tapp {
+  flex-shrink: 0;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--gray6);
+  background: var(--gray1);
+  border-radius: 6px;
+  padding: 2px 7px;
+}
+
+.ar-tpath {
+  flex-shrink: 0;
+  font-size: 12px;
+  color: var(--gray7);
+}
+
+.ar-tbranch {
+  min-width: 0;
+  padding-left: 10px;
+  border-left: 1px solid var(--gray3);
+  font-size: 12px;
+  color: var(--gray6);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.ar-termbody {
+  flex: 1;
+  min-width: 0;
+  padding: 13px 16px 18px;
+}
+
+.ar-prompt {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  min-width: 0;
+  padding-bottom: 11px;
+  border-bottom: 1px solid var(--gray1);
+  font-size: 12px;
+  color: var(--gray7);
+}
+
+.ar-caret {
+  color: var(--accent);
+  font-weight: 700;
+}
+
+.ar-fig .ar-app {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+  margin: 0;
+}
+
+.ar-kept {
+  flex: 1;
+  padding: 16px 18px 18px;
+  background: var(--gray0);
+  overflow: hidden;
 }
 
 .ar-chat {
@@ -52,7 +148,7 @@
 
 .ar-chat[data-play='run'] .ar-track {
   transform: translateY(calc(-1 * var(--ar-scroll)));
-  transition: transform 9000ms linear;
+  transition: transform 5600ms linear;
 }
 
 .ar-chat[data-play='still'] .ar-track {
@@ -60,14 +156,21 @@
 }
 
 .ar-line {
+  position: relative;
   flex: 0 0 var(--ar-row);
   height: var(--ar-row);
   line-height: var(--ar-row);
   padding: 0 6px 0 10px;
   border-left: 2px solid transparent;
   border-radius: 0 6px 6px 0;
-  font-size: 12px;
+  font-family: var(--mono);
+  font-size: 11.5px;
   color: var(--gray6);
+}
+
+.ar-ltext {
+  display: block;
+  min-width: 0;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -97,11 +200,41 @@
   color: var(--info-text);
 }
 
+.ar-cue:after {
+  content: '';
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: -2px;
+  border-radius: inherit;
+  box-shadow:
+    inset 0 0 0 1px color-mix(in oklab, currentColor 26%, transparent),
+    0 0 0 3px color-mix(in oklab, currentColor 10%, transparent);
+  opacity: 0;
+}
+
+.ar-chat[data-play='run'] .ar-cue:after {
+  animation: arCue 660ms ease-out both;
+  animation-delay: var(--ar-cue, 0ms);
+}
+
+@keyframes arCue {
+  from {
+    opacity: 0;
+  }
+  30% {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
 .ar-cards {
   display: flex;
   flex-direction: column;
   gap: 10px;
-  margin-top: 10px;
 }
 
 .ar-card {
@@ -115,15 +248,11 @@
   padding: 12px 14px;
   box-shadow: 0 1px 3px rgba(16, 17, 19, 0.05);
   opacity: 0;
-  transform: translateX(-16px);
-  transition:
-    opacity 0.4s ease,
-    transform 0.4s cubic-bezier(0.2, 0.7, 0.3, 1);
+  transition: opacity 0.58s cubic-bezier(0.2, 0.7, 0.3, 1);
 }
 
 .ar-card.ar-in {
   opacity: 1;
-  transform: none;
 }
 
 .ar-accent {
@@ -260,7 +389,7 @@
   grid-area: 1 / 1;
   display: flex;
   opacity: 0;
-  transition: opacity 0.35s ease;
+  transition: opacity 0.58s cubic-bezier(0.2, 0.7, 0.3, 1);
 }
 
 .ar-sw.ar-on {
@@ -288,28 +417,37 @@
 @media (prefers-reduced-motion: reduce) {
   .ar-card {
     opacity: 1;
-    transform: none;
+    transition: none;
+  }
+
+  .ar-cue:after {
+    animation: none;
+    opacity: 0;
   }
 }
 
 @media (max-width: 720px) {
-  .ar-panes {
-    grid-template-columns: minmax(0, 1fr);
-  }
-
-  .ar-kept {
-    border-left: 0;
-    border-top: 1px solid var(--gray1);
-  }
-
   .ar-chat {
-    height: calc(var(--ar-row) * 6.5);
+    height: calc(var(--ar-row) * 7);
   }
 }
 
 @media (max-width: 480px) {
-  .ar-pane {
+  .ar-termbody {
+    padding: 12px 14px 16px;
+  }
+
+  .ar-kept {
     padding: 14px;
+  }
+
+  .ar-tpath {
+    display: none;
+  }
+
+  .ar-tbranch {
+    padding-left: 0;
+    border-left: 0;
   }
 
   .ar-step {

--- a/website/src/sections/Artifacts.tsx
+++ b/website/src/sections/Artifacts.tsx
@@ -1,5 +1,5 @@
 import './Artifacts.css';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type CSSProperties } from 'react';
 import { delay, prefersReducedMotion, useInViewOnce } from '../components/Reveal';
 import { SITE } from '../site';
 
@@ -18,7 +18,18 @@ type Step = {
   readonly edited?: boolean;
 };
 
-const BEATS = [1180, 1570, 6260, 7260];
+const PLAN_MS = 730;
+const DECISION_MS = 975;
+const QUESTION_MS = 3895;
+const ANSWER_MS = 4695;
+
+const BEATS = [PLAN_MS, DECISION_MS, QUESTION_MS, ANSWER_MS];
+
+const CUE: Readonly<Record<Tone, number>> = {
+  plan: PLAN_MS,
+  decision: DECISION_MS,
+  question: QUESTION_MS,
+};
 
 const AT_PLAN = 1;
 const AT_DECISION = 2;
@@ -88,6 +99,8 @@ const playState = (reduced: boolean, seen: boolean) => {
   return seen ? 'run' : 'idle';
 };
 
+const cueStyle = (tone: Tone) => ({ '--ar-cue': `${CUE[tone]}ms` }) as CSSProperties;
+
 export const Artifacts = () => {
   const { ref, inView } = useInViewOnce<HTMLDivElement>();
   const [stage, setStage] = useState(() => (prefersReducedMotion() ? AT_LAST : 0));
@@ -113,75 +126,97 @@ export const Artifacts = () => {
             The plan does not scroll away
           </h2>
           <p className="sub rv" style={delay(80)}>
-            A chat buries the plan under the next hundred lines. Here the plan, the open question and
-            the decision are <b>objects that stay where you left them</b>, and you can edit, answer
-            or reread them any time.
+            A chat buries the plan under the next hundred lines. Here the plan, the open question
+            and the decision are <b>objects that stay where you left them</b>, and you can edit,
+            answer or reread them any time.
           </p>
         </div>
 
-        <div className="appframe rv" style={delay(160)} ref={ref} aria-hidden="true">
-          <div className="tbar">
-            <span className="tl r" />
-            <span className="tl y" />
-            <span className="tl g" />
-            <span className="tname">goodboy, acme / Ship LIN-241</span>
-          </div>
+        <div className="ar-fig rv" style={delay(160)} ref={ref} aria-hidden="true">
+          <div className="ar-side">
+            <p className="ar-eyebrow">In a chat</p>
 
-          <div className="ar-panes">
-            <div className="ar-pane">
-              <p className="ar-eyebrow">Chat</p>
-              <div className="ar-chat" data-play={play}>
-                <div className="ar-track">
-                  {LINES.map((line, i) => (
-                    <p
-                      className={`ar-line${line.tone === undefined ? '' : ` ar-${line.tone}`}`}
-                      key={`${line.text}-${i}`}
-                    >
-                      {line.text}
-                    </p>
-                  ))}
-                </div>
+            <div className="ar-term">
+              <div className="ar-termbar">
+                <span className="ar-tapp mono">zsh</span>
+                <span className="ar-tpath mono">~/acme/api</span>
+                <span className="ar-tbranch mono">gb/lin-241-bulk-archive</span>
               </div>
-            </div>
 
-            <div className="ar-pane ar-kept">
-              <p className="ar-eyebrow">Kept</p>
-              <div className="ar-cards">
-                <div className={`ar-card ar-accent${stage >= AT_PLAN ? ' ar-in' : ''}`}>
-                  <p className="ar-ckind">Plan</p>
-                  <p className="ar-ctitle">Ship LIN-241, bulk archive for notifications</p>
-                  <div className="ar-steps">
-                    {STEPS.map((step) => (
-                      <div className="ar-step" key={step.title}>
-                        <span className={`kb ${step.tone}`}>{step.role}</span>
-                        <span className="ar-stitle">{step.title}</span>
-                        {step.edited === true && <span className="ar-edit">edited by you</span>}
-                        <span className={`ar-dot ar-d-${step.dot}`} />
-                      </div>
+              <div className="ar-termbody">
+                <p className="ar-prompt mono">
+                  <span className="ar-caret">&gt;</span>
+                  Ship LIN-241, bulk archive for notifications
+                </p>
+
+                <div className="ar-chat" data-play={play}>
+                  <div className="ar-track">
+                    {LINES.map((line, i) => (
+                      <p
+                        className={
+                          line.tone === undefined ? 'ar-line' : `ar-line ar-cue ar-${line.tone}`
+                        }
+                        key={`${line.text}-${i}`}
+                        style={line.tone === undefined ? undefined : cueStyle(line.tone)}
+                      >
+                        <span className="ar-ltext">{line.text}</span>
+                      </p>
                     ))}
                   </div>
                 </div>
+              </div>
+            </div>
+          </div>
 
-                <div className={`ar-card ar-info${stage >= AT_DECISION ? ' ar-in' : ''}`}>
-                  <p className="ar-ckind">Decision</p>
-                  <p className="ar-ctitle">Soft delete only. Batches of 500.</p>
-                  <span className="ar-cctx">Recorded by the planner at 11:21</span>
-                </div>
+          <div className="ar-side">
+            <p className="ar-eyebrow">In Goodboy</p>
 
-                <div className={`ar-card ar-warn${stage >= AT_QUESTION ? ' ar-in' : ''}`}>
-                  <p className="ar-ckind">Open question</p>
-                  <p className="ar-ctitle">Archive read notifications too, or only unread?</p>
-                  <span className="ar-crow">
-                    <span className="ar-cctx">Asked by the implementer at 12:11</span>
-                    <span className="ar-swap">
-                      <span className={`ar-sw${answered ? '' : ' ar-on'}`}>
-                        <span className="mockbtn">Answer</span>
-                      </span>
-                      <span className={`ar-sw${answered ? ' ar-on' : ''}`}>
-                        <span className="ar-ans">✓ Only unread</span>
+            <div className="appframe ar-app">
+              <div className="tbar">
+                <span className="tl r" />
+                <span className="tl y" />
+                <span className="tl g" />
+                <span className="tname">goodboy, acme / Ship LIN-241</span>
+              </div>
+
+              <div className="ar-kept">
+                <div className="ar-cards">
+                  <div className={`ar-card ar-accent${stage >= AT_PLAN ? ' ar-in' : ''}`}>
+                    <p className="ar-ckind">Plan</p>
+                    <p className="ar-ctitle">Ship LIN-241, bulk archive for notifications</p>
+                    <div className="ar-steps">
+                      {STEPS.map((step) => (
+                        <div className="ar-step" key={step.title}>
+                          <span className={`kb ${step.tone}`}>{step.role}</span>
+                          <span className="ar-stitle">{step.title}</span>
+                          {step.edited === true && <span className="ar-edit">edited by you</span>}
+                          <span className={`ar-dot ar-d-${step.dot}`} />
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+
+                  <div className={`ar-card ar-info${stage >= AT_DECISION ? ' ar-in' : ''}`}>
+                    <p className="ar-ckind">Decision</p>
+                    <p className="ar-ctitle">Soft delete only. Batches of 500.</p>
+                    <span className="ar-cctx">Recorded by the planner at 11:21</span>
+                  </div>
+
+                  <div className={`ar-card ar-warn${stage >= AT_QUESTION ? ' ar-in' : ''}`}>
+                    <p className="ar-ckind">Open question</p>
+                    <p className="ar-ctitle">Archive read notifications too, or only unread?</p>
+                    <span className="ar-crow">
+                      <span className="ar-cctx">Asked by the implementer at 12:11</span>
+                      <span className="ar-swap">
+                        <span className={`ar-sw${answered ? '' : ' ar-on'}`}>
+                          <span className="mockbtn">Answer</span>
+                        </span>
+                        <span className={`ar-sw${answered ? ' ar-on' : ''}`}>
+                          <span className="ar-ans">✓ Only unread</span>
+                        </span>
                       </span>
                     </span>
-                  </span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -189,7 +224,7 @@ export const Artifacts = () => {
         </div>
 
         <p className="caption rv" style={delay(200)}>
-          The chat keeps moving. These three do not.
+          Same agent, same run. On the left those three lines scroll past, on the right they stay.
         </p>
         <a className="more rv" style={delay(220)} href={`${SITE.concepts}#plans`}>
           How plans work <span className="arr">→</span>

--- a/website/src/sections/Briefing.css
+++ b/website/src/sections/Briefing.css
@@ -37,16 +37,15 @@
   border: 1px solid var(--gray3);
   border-radius: 12px;
   padding: 12px 14px;
+  box-shadow: 0 0 0 3px color-mix(in oklch, var(--accent-bright) 12%, transparent);
   transition:
-    background 0.4s ease,
-    border-color 0.4s ease,
-    box-shadow 0.4s ease;
+    background 0.58s cubic-bezier(0.2, 0.7, 0.3, 1),
+    border-color 0.58s cubic-bezier(0.2, 0.7, 0.3, 1);
 }
 
 .br-card[data-lit] {
   background: color-mix(in oklch, var(--accent-soft) 46%, #fff);
   border-color: color-mix(in oklch, var(--accent-bright) 60%, var(--gray3));
-  box-shadow: 0 0 0 3px color-mix(in oklch, var(--accent-bright) 12%, transparent);
 }
 
 .br-cardtitle {
@@ -56,7 +55,7 @@
   text-transform: uppercase;
   color: var(--gray6);
   margin-bottom: 5px;
-  transition: color 0.4s ease;
+  transition: color 0.58s cubic-bezier(0.2, 0.7, 0.3, 1);
 }
 
 .br-card[data-lit] .br-cardtitle {
@@ -83,42 +82,12 @@
   fill: none;
   stroke: color-mix(in oklch, var(--accent-bright) 55%, var(--gray3));
   stroke-width: 1;
-  stroke-dasharray: var(--len);
-  stroke-dashoffset: var(--len);
   opacity: 0;
+  transition: opacity 0.58s cubic-bezier(0.2, 0.7, 0.3, 1);
 }
 
 .br-lit .br-track {
   opacity: 1;
-  stroke-dashoffset: 0;
-  animation: br-draw 420ms cubic-bezier(0.2, 0.7, 0.3, 1) both;
-}
-
-@keyframes br-draw {
-  from {
-    stroke-dashoffset: var(--len);
-  }
-  to {
-    stroke-dashoffset: 0;
-  }
-}
-
-.br-trav {
-  fill: none;
-  stroke: var(--accent);
-  stroke-width: 3.5;
-  stroke-linecap: round;
-  stroke-dasharray: 0.5px var(--len);
-  animation: br-travel 560ms cubic-bezier(0.4, 0, 0.4, 1) 140ms both;
-}
-
-@keyframes br-travel {
-  from {
-    stroke-dashoffset: 0;
-  }
-  to {
-    stroke-dashoffset: calc(var(--len) * -1);
-  }
 }
 
 .br-pane {
@@ -164,7 +133,7 @@
   gap: 8px;
   white-space: nowrap;
   opacity: 0;
-  transition: opacity 320ms ease;
+  transition: opacity 0.58s cubic-bezier(0.2, 0.7, 0.3, 1);
 }
 
 .br-popt.br-on {
@@ -188,18 +157,12 @@
   color: var(--accent-deep);
   background: color-mix(in oklch, var(--accent-bright) 14%, #fff);
   box-shadow: inset 0 0 0 1px color-mix(in oklch, var(--accent-bright) 42%, transparent);
-  animation: br-tag-in 380ms cubic-bezier(0.2, 0.7, 0.3, 1) both;
+  opacity: 0;
+  transition: opacity 0.58s cubic-bezier(0.2, 0.7, 0.3, 1);
 }
 
-@keyframes br-tag-in {
-  from {
-    opacity: 0;
-    transform: translateX(6px);
-  }
-  to {
-    opacity: 1;
-    transform: none;
-  }
+.br-tag.br-show {
+  opacity: 1;
 }
 
 .br-msgs {
@@ -249,19 +212,13 @@
   color: var(--accent-deep);
 }
 
-.br-new {
-  animation: br-slide 420ms cubic-bezier(0.2, 0.7, 0.3, 1) both;
+.br-reply {
+  opacity: 0;
+  transition: opacity 0.58s cubic-bezier(0.2, 0.7, 0.3, 1);
 }
 
-@keyframes br-slide {
-  from {
-    opacity: 0;
-    transform: translateY(8px);
-  }
-  to {
-    opacity: 1;
-    transform: none;
-  }
+.br-reply.br-show {
+  opacity: 1;
 }
 
 .br-event {
@@ -269,15 +226,11 @@
   gap: 8px;
   margin: 2px 0;
   opacity: 0;
-  transform: translateY(6px);
-  transition:
-    opacity 0.4s ease,
-    transform 0.4s ease;
+  transition: opacity 0.58s cubic-bezier(0.2, 0.7, 0.3, 1);
 }
 
 .br-event.br-show {
   opacity: 1;
-  transform: none;
 }
 
 .br-eventtext {
@@ -326,5 +279,10 @@
 
   .br-msg {
     max-width: 100%;
+  }
+
+  .br-phead {
+    flex-wrap: wrap;
+    row-gap: 6px;
   }
 }

--- a/website/src/sections/Briefing.tsx
+++ b/website/src/sections/Briefing.tsx
@@ -1,12 +1,12 @@
 import './Briefing.css';
-import { useEffect, useRef, useState, type CSSProperties } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { BrandMark } from '../components/BrandIcons';
 import { delay, prefersReducedMotion, useInViewOnce } from '../components/Reveal';
 import { SITE } from '../site';
 
 type Slot = { readonly title: string; readonly text: string };
 
-type Wire = { readonly d: string; readonly len: number };
+type Wire = { readonly d: string };
 
 const SLOTS: readonly Slot[] = [
   { title: 'Goal', text: 'Ship LIN-241, bulk archive for notifications.' },
@@ -14,7 +14,7 @@ const SLOTS: readonly Slot[] = [
   { title: 'Summary', text: 'Archive endpoint done, list view wired, empty-state copy still ahead.' },
 ];
 
-const BEATS: readonly number[] = [700, 1300, 1520, 1740, 2300, 2600];
+const BEATS: readonly number[] = [560, 1200, 1800, 2400, 3120, 3840];
 
 const AT_SWITCH = 1;
 const AT_FIRST_CARD = 2;
@@ -25,8 +25,6 @@ const AT_LAST = BEATS.length;
 const WIDE_AT = 760;
 const MIN_RUN = 40;
 
-const lenStyle = (len: number) => ({ '--len': `${len.toFixed(1)}px` }) as CSSProperties;
-
 const round = (value: number) => value.toFixed(1);
 
 const wireOf = (x0: number, y0: number, x1: number, y1: number, at: number): Wire => {
@@ -35,7 +33,7 @@ const wireOf = (x0: number, y0: number, x1: number, y1: number, at: number): Wir
   const dir = dy < 0 ? -1 : 1;
   const r = Math.min(9, Math.abs(dy) / 2, (xm - x0) / 2, (x1 - xm) / 2);
   if (r < 1) {
-    return { d: `M${round(x0)} ${round(y0)}L${round(x1)} ${round(y1)}`, len: Math.hypot(x1 - x0, dy) };
+    return { d: `M${round(x0)} ${round(y0)}L${round(x1)} ${round(y1)}` };
   }
   const d = [
     `M${round(x0)} ${round(y0)}`,
@@ -45,8 +43,7 @@ const wireOf = (x0: number, y0: number, x1: number, y1: number, at: number): Wir
     `Q${round(xm)} ${round(y1)} ${round(xm + r)} ${round(y1)}`,
     `L${round(x1)} ${round(y1)}`,
   ].join('');
-  const len = xm - r - x0 + (Math.abs(dy) - 2 * r) + (x1 - xm - r) + 3 * r;
-  return { d, len };
+  return { d };
 };
 
 export const Briefing = () => {
@@ -54,7 +51,6 @@ export const Briefing = () => {
   const gridRef = useRef<HTMLDivElement | null>(null);
   const headRef = useRef<HTMLDivElement | null>(null);
   const cardRefs = useRef<(HTMLDivElement | null)[]>([]);
-  const [reduced] = useState(prefersReducedMotion);
   const [stage, setStage] = useState(() => (prefersReducedMotion() ? AT_LAST : 0));
   const [wires, setWires] = useState<readonly Wire[]>([]);
 
@@ -68,7 +64,7 @@ export const Briefing = () => {
     return () => timers.forEach(window.clearTimeout);
   }, [inView]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const grid = gridRef.current;
     if (grid == null) {
       return;
@@ -118,13 +114,13 @@ export const Briefing = () => {
           <h2 className="rv" id="h2-brief">
             The briefing belongs to the task, not the chat
           </h2>
-          <p className="sub rv" style={delay(80)}>
+          <p className="sub rv" style={delay(40)}>
             Write the goal once and <b>every agent that touches the task starts informed</b>. Swap
             models mid-task or step away for a day, and nothing needs re&#8209;explaining.
           </p>
         </div>
 
-        <div className="appframe br-frame rv" style={delay(160)} ref={ref} aria-hidden="true">
+        <div className="appframe br-frame rv" style={delay(80)} ref={ref} aria-hidden="true">
           <div className="tbar">
             <span className="tl r" />
             <span className="tl y" />
@@ -135,11 +131,8 @@ export const Briefing = () => {
           <div className="br-grid" ref={gridRef}>
             <svg className="br-wires" aria-hidden="true" focusable="false">
               {wires.map((w, i) => (
-                <g className={stage >= AT_FIRST_CARD + i ? 'br-lit' : undefined} key={w.d}>
-                  <path className="br-track" d={w.d} style={lenStyle(w.len)} />
-                  {!reduced && stage >= AT_FIRST_CARD + i ? (
-                    <path className="br-trav" d={w.d} style={lenStyle(w.len)} />
-                  ) : null}
+                <g className={stage >= AT_FIRST_CARD + i ? 'br-lit' : undefined} key={SLOTS[i].title}>
+                  <path className="br-track" d={w.d} />
                 </g>
               ))}
             </svg>
@@ -180,7 +173,9 @@ export const Briefing = () => {
                     </span>
                   </span>
                   <span className="br-tagslot">
-                    {stage >= AT_TAG ? <span className="br-tag">briefed from the task</span> : null}
+                    <span className={`br-tag${stage >= AT_TAG ? ' br-show' : ''}`}>
+                      briefed from the task
+                    </span>
                   </span>
                 </div>
 
@@ -208,27 +203,25 @@ export const Briefing = () => {
                     <span className="hairline" />
                   </div>
 
-                  {stage >= AT_REPLY ? (
-                    <div className="br-agent br-new">
-                      <span className="br-av">
-                        <BrandMark brand="codex" size={13} />
-                      </span>
-                      <p className="br-msg">
-                        Flag honoured in the empty state, 12 tests green. Summary updated for whoever
-                        comes next.
-                      </p>
-                    </div>
-                  ) : null}
+                  <div className={`br-agent br-reply${stage >= AT_REPLY ? ' br-show' : ''}`}>
+                    <span className="br-av">
+                      <BrandMark brand="codex" size={13} />
+                    </span>
+                    <p className="br-msg">
+                      Flag honoured in the empty state, 12 tests green. Summary updated for whoever
+                      comes next.
+                    </p>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
 
-        <p className="caption rv" style={delay(200)}>
+        <p className="caption rv" style={delay(110)}>
           A chat tool loses the thread when you switch, and Goodboy keeps it with the task.
         </p>
-        <a className="more rv" style={delay(220)} href={`${SITE.concepts}#shared-context`}>
+        <a className="more rv" style={delay(130)} href={`${SITE.concepts}#shared-context`}>
           How shared context works <span className="arr">→</span>
         </a>
       </div>

--- a/website/src/sections/Extras.css
+++ b/website/src/sections/Extras.css
@@ -17,45 +17,53 @@
   margin-bottom: 10px;
 }
 
-.ex-rail {
+.ex-list {
   display: flex;
   flex-direction: column;
+  gap: 8px;
 }
 
-.ex-rail > :last-child {
-  margin-bottom: 0;
-}
-
-.ex-step {
+.ex-row {
   display: flex;
   align-items: center;
-  gap: 10px;
-  margin-bottom: 8px;
+  gap: 11px;
+  min-height: 52px;
   background: #fff;
   border: 1px solid var(--gray3);
   border-radius: 12px;
   padding: 9px 12px;
-  min-height: 46px;
+  opacity: 0.34;
+  transition: opacity 0.55s cubic-bezier(0.2, 0.7, 0.3, 1);
 }
 
-.ex-step.ex-new {
-  animation: ex-rowin 320ms cubic-bezier(0.2, 0.7, 0.3, 1) both;
+.ex-row.ex-lit {
+  opacity: 1;
 }
 
-@keyframes ex-rowin {
-  from {
-    opacity: 0;
-    transform: translateY(-6px);
-  }
-  to {
-    opacity: 1;
-    transform: none;
-  }
+.ex-ico {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  color: var(--gray5);
 }
 
-.ex-name {
+.ex-ico svg {
+  width: 16px;
+  height: 16px;
+}
+
+.ex-rt {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
   flex: 1;
   min-width: 0;
+}
+
+.ex-title {
   font-size: 13.5px;
   color: var(--gray7);
   overflow: hidden;
@@ -63,147 +71,42 @@
   white-space: nowrap;
 }
 
-.ex-st {
-  flex-shrink: 0;
-  font-size: 11px;
-  font-weight: 700;
-  border-radius: 999px;
-  padding: 2px 9px;
-}
-
-.ex-st-done {
-  background: oklch(0.94 0.04 148);
-  color: var(--ok-text);
-}
-
-.ex-st-queued {
-  background: var(--gray1);
-  color: var(--gray6);
-}
-
-.ex-prov {
-  flex-shrink: 0;
-  font-size: 11px;
-  color: var(--gray6);
-  white-space: nowrap;
-}
-
-.ex-sug {
-  max-height: 0;
-  opacity: 0;
-  overflow: hidden;
-  transition:
-    max-height 0.3s cubic-bezier(0.2, 0.7, 0.3, 1),
-    opacity 0.3s ease;
-}
-
-.ex-sug.ex-open {
-  max-height: 220px;
-  opacity: 1;
-}
-
-.ex-sugcard {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 10px;
-  margin-bottom: 8px;
-  border-radius: 10px;
-  border-left: 2px solid var(--accent);
-  background: color-mix(in oklch, var(--accent-soft) 62%, #fff);
-  padding: 10px 12px;
-  opacity: 0;
-  transform: translateY(6px);
-  transition:
-    opacity 0.32s ease,
-    transform 0.32s cubic-bezier(0.2, 0.7, 0.3, 1);
-}
-
-.ex-sug.ex-open .ex-sugcard {
-  opacity: 1;
-  transform: none;
-}
-
-.ex-sugglyph {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  width: 20px;
-  height: 20px;
-  color: var(--accent);
-}
-
-.ex-sugglyph svg {
-  width: 15px;
-  height: 15px;
-}
-
-.ex-sugtext {
-  flex: 1 1 220px;
-  min-width: 0;
-  font-size: 13px;
-  line-height: 1.45;
-  color: var(--accent-deep);
-}
-
-.ex-sugbtns {
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  flex-shrink: 0;
-  margin-left: auto;
-}
-
-.ex-accept {
-  margin-top: 0;
-  transition:
-    transform 0.12s ease,
-    background 0.12s ease;
-}
-
-.ex-accept.ex-press {
-  transform: translateY(1px);
-  background: var(--accent);
-  color: #fff;
-}
-
-.ex-quiet {
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--gray6);
-  white-space: nowrap;
-}
-
-.ex-trace {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  margin-bottom: 8px;
-  padding-left: 2px;
+.ex-detail {
   font-size: 11.5px;
-  color: var(--gray5);
-  animation: ex-fade 380ms ease 180ms both;
+  color: var(--gray6);
 }
 
-.ex-traceglyph {
-  display: inline-flex;
+.ex-row .mockbtn {
+  margin-top: 0;
   flex-shrink: 0;
-  color: var(--gray5);
 }
 
-.ex-traceglyph svg {
-  width: 11px;
-  height: 11px;
+.ex-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  flex-shrink: 0;
+  font-size: 12px;
+  font-weight: 700;
+  border-radius: 8px;
+  padding: 5px 11px;
+  color: var(--accent-deep);
+  background: color-mix(in oklch, var(--accent-soft) 58%, #fff);
+  border: 1px solid color-mix(in oklch, var(--accent) 22%, #fff);
 }
 
-@keyframes ex-fade {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
+.ex-cta svg {
+  width: 12px;
+  height: 12px;
+  flex-shrink: 0;
+}
+
+.ex-badge {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--accent-deep);
+  opacity: 0.7;
+  white-space: nowrap;
 }
 
 .ex-composer {
@@ -218,11 +121,95 @@
   font-size: 14px;
   line-height: 1.5;
   color: var(--ink);
+  opacity: 0.34;
+  transition: opacity 0.55s cubic-bezier(0.2, 0.7, 0.3, 1);
 }
 
-.ex-composer .ex-sugcard,
-.ex-composer .ex-trace {
+.ex-typed.ex-lit {
+  opacity: 1;
+}
+
+.ex-card {
+  display: flex;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  gap: 10px;
   margin: 0 12px 12px;
+  border-radius: 10px;
+  border-left: 2px solid var(--accent);
+  background: color-mix(in oklch, var(--accent-soft) 62%, #fff);
+  padding: 10px 12px;
+  opacity: 0.26;
+  transition: opacity 0.55s cubic-bezier(0.2, 0.7, 0.3, 1);
+}
+
+.ex-card.ex-lit {
+  opacity: 1;
+}
+
+.ex-cardglyph {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 20px;
+  height: 20px;
+  margin-top: 1px;
+  color: var(--accent);
+}
+
+.ex-cardglyph svg {
+  width: 15px;
+  height: 15px;
+}
+
+.ex-cardtext {
+  flex: 1 1 240px;
+  min-width: 0;
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--accent-deep);
+}
+
+.ex-cardtext b {
+  font-weight: 700;
+}
+
+.ex-cardsub {
+  display: block;
+  margin-top: 2px;
+  font-size: 12px;
+  opacity: 0.72;
+}
+
+.ex-cardbtns {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+  margin-left: auto;
+}
+
+.ex-cardbtns .mockbtn {
+  margin-top: 0;
+}
+
+.ex-accept {
+  transition:
+    background 0.18s ease,
+    color 0.18s ease;
+}
+
+.ex-accept.ex-press {
+  background: var(--accent);
+  color: #fff;
+}
+
+.ex-quiet {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--gray6);
+  white-space: nowrap;
 }
 
 .ex-cfoot {
@@ -247,28 +234,23 @@
   padding: 4px 11px;
 }
 
-.ex-chip span {
+.ex-chipslot {
+  display: grid;
+  min-width: 0;
+}
+
+.ex-chipslot > span {
+  grid-area: 1 / 1;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  opacity: 0;
+  transition: opacity 0.55s cubic-bezier(0.2, 0.7, 0.3, 1);
 }
 
-.ex-chip.ex-swapped {
-  animation: ex-flash 600ms ease both;
-}
-
-@keyframes ex-flash {
-  0% {
-    background: var(--accent-soft);
-    border-color: var(--accent-bright);
-    box-shadow: 0 0 0 4px color-mix(in oklch, var(--accent-bright) 18%, transparent);
-  }
-  100% {
-    background: #fff;
-    border-color: var(--gray3);
-    box-shadow: 0 0 0 0 transparent;
-  }
+.ex-chipslot > span.ex-on {
+  opacity: 1;
 }
 
 .ex-send {
@@ -289,40 +271,39 @@
   height: 15px;
 }
 
+@media (max-width: 700px) {
+  .ex-row {
+    flex-wrap: wrap;
+    row-gap: 8px;
+  }
+
+  .ex-rt {
+    flex: 1 1 calc(100% - 27px);
+  }
+
+  .ex-cta {
+    flex-basis: 100%;
+    justify-content: flex-start;
+  }
+}
+
 @media (max-width: 560px) {
   .ex-sec {
     padding: 14px 12px;
   }
 
-  .ex-step {
-    flex-wrap: wrap;
-    row-gap: 8px;
-  }
-
-  .ex-step .kb {
-    order: 1;
-  }
-
-  .ex-st {
-    order: 2;
-  }
-
-  .ex-prov {
-    order: 3;
-  }
-
-  .ex-name {
-    order: 4;
-    flex: 1 1 100%;
+  .ex-title {
     white-space: normal;
   }
 
-  .ex-sugbtns {
+  .ex-cardbtns {
     margin-left: 0;
     flex-basis: 100%;
+    flex-wrap: wrap;
+    gap: 8px;
   }
 
-  .ex-sug.ex-open {
-    max-height: 300px;
+  .ex-cardbtns .mockbtn {
+    white-space: nowrap;
   }
 }

--- a/website/src/sections/Extras.tsx
+++ b/website/src/sections/Extras.tsx
@@ -3,43 +3,68 @@ import { useEffect, useState, type ReactNode } from 'react';
 import { BrandMark } from '../components/BrandIcons';
 import { delay, prefersReducedMotion, useInViewOnce } from '../components/Reveal';
 
-type SuggestionProps = {
-  readonly open: boolean;
-  readonly pressed: boolean;
-  readonly text: string;
-  readonly accept: string;
-  readonly dismiss: string;
+type Offer = {
+  readonly at: number;
+  readonly key: string;
+  readonly glyph: ReactNode;
+  readonly title: string;
+  readonly detail: string | null;
+  readonly action: ReactNode;
 };
 
-type TraceProps = {
-  readonly children: ReactNode;
-};
+const BEATS: readonly number[] = [320, 700, 1080, 1500, 1900, 2280, 2640];
 
-const BEATS: readonly number[] = [600, 1900, 2060, 3000, 4300, 4460];
-
-const AT_SUGGEST_A = 1;
-const AT_PRESS_A = 2;
-const AT_ACCEPT_A = 3;
-const AT_SUGGEST_B = 4;
-const AT_PRESS_B = 5;
-const AT_ACCEPT_B = 6;
+const AT_TYPED = 4;
+const AT_HELD = 5;
+const AT_PRESS = 6;
+const AT_SWAP = 7;
 const AT_LAST = BEATS.length;
 
-const LampGlyph = () => (
+const Stroke = ({ children }: { readonly children: ReactNode }) => (
   <svg
     viewBox="0 0 24 24"
     fill="none"
     stroke="currentColor"
-    strokeWidth="1.9"
+    strokeWidth="2"
     strokeLinecap="round"
     strokeLinejoin="round"
     aria-hidden="true"
     focusable="false"
   >
-    <path d="M12 3.2a5.8 5.8 0 0 0-3.5 10.4c.6.5 1 1.1 1.1 1.8h4.8c.1-.7.5-1.3 1.1-1.8A5.8 5.8 0 0 0 12 3.2Z" />
-    <path d="M9.8 18.3h4.4" />
-    <path d="M10.7 21h2.6" />
+    {children}
   </svg>
+);
+
+const PlayGlyph = () => (
+  <Stroke>
+    <path d="M7.5 5.2 18.5 12 7.5 18.8Z" />
+  </Stroke>
+);
+
+const ReplyGlyph = () => (
+  <Stroke>
+    <path d="M4 5.5h16v10H10l-5 3.5v-3.5H4Z" />
+    <path d="M12.4 8.4 9.6 10.9l2.8 2.5" />
+    <path d="M9.6 10.9h4a2.4 2.4 0 0 1 2.4 2.4" />
+  </Stroke>
+);
+
+const RebaseGlyph = () => (
+  <Stroke>
+    <circle cx="6" cy="18" r="2.6" />
+    <circle cx="18" cy="7.4" r="2.6" />
+    <path d="M6 15.4V6.6" />
+    <path d="m3.4 9.2 2.6-2.6 2.6 2.6" />
+    <path d="M18 10v3.4a4 4 0 0 1-4 4h-2" />
+  </Stroke>
+);
+
+const LampGlyph = () => (
+  <Stroke>
+    <path d="M12 3.4a5.7 5.7 0 0 0-3.4 10.2c.6.5 1 1.1 1 1.8h4.8c0-.7.4-1.3 1-1.8A5.7 5.7 0 0 0 12 3.4Z" />
+    <path d="M9.9 18.3h4.2" />
+    <path d="M10.8 20.9h2.4" />
+  </Stroke>
 );
 
 const SendGlyph = () => (
@@ -58,29 +83,38 @@ const SendGlyph = () => (
   </svg>
 );
 
-const Suggestion = ({ open, pressed, text, accept, dismiss }: SuggestionProps) => (
-  <div className={`ex-sug${open ? ' ex-open' : ''}`}>
-    <div className="ex-sugcard">
-      <span className="ex-sugglyph">
-        <LampGlyph />
+const OFFERS: readonly Offer[] = [
+  {
+    at: 1,
+    key: 'workflow',
+    glyph: <PlayGlyph />,
+    title: 'Continue Ship a feature',
+    detail: null,
+    action: (
+      <span className="ex-cta">
+        <PlayGlyph />
+        Run next step: Archive endpoint
+        <span className="ex-badge">GPT-5.6 Sol</span>
       </span>
-      <p className="ex-sugtext">{text}</p>
-      <span className="ex-sugbtns">
-        <span className={`mockbtn ex-accept${pressed ? ' ex-press' : ''}`}>{accept}</span>
-        <span className="ex-quiet">{dismiss}</span>
-      </span>
-    </div>
-  </div>
-);
-
-const Trace = ({ children }: TraceProps) => (
-  <p className="ex-trace">
-    <span className="ex-traceglyph">
-      <LampGlyph />
-    </span>
-    {children}
-  </p>
-);
+    ),
+  },
+  {
+    at: 2,
+    key: 'threads',
+    glyph: <ReplyGlyph />,
+    title: 'Resolve review comments',
+    detail: '2 comments',
+    action: <span className="mockbtn ghost">Resolve</span>,
+  },
+  {
+    at: 3,
+    key: 'rebase',
+    glyph: <RebaseGlyph />,
+    title: 'Rebase api on main',
+    detail: '3 behind',
+    action: <span className="mockbtn ghost">Rebase</span>,
+  },
+];
 
 export const Extras = () => {
   const { ref, inView } = useInViewOnce<HTMLDivElement>();
@@ -96,85 +130,80 @@ export const Extras = () => {
     return () => timers.forEach(window.clearTimeout);
   }, [inView]);
 
-  const openA = stage >= AT_SUGGEST_A && stage < AT_ACCEPT_A;
-  const acceptedA = stage >= AT_ACCEPT_A;
-  const openB = stage >= AT_SUGGEST_B && stage < AT_ACCEPT_B;
-  const acceptedB = stage >= AT_ACCEPT_B;
+  const swapped = stage >= AT_SWAP;
 
   return (
     <section className="block" id="extras" aria-labelledby="h2-extras">
       <div className="wrap">
         <div className="blockHead">
           <h2 className="rv" id="h2-extras">
-            Goodboy has opinions
+            It notices the next step and waits
           </h2>
-          <p className="sub rv" style={delay(80)}>
-            Finish a plan with nothing attached to it and it offers to spawn the implementer.
-            Point the biggest model at a one-line rename and it asks whether a lighter one will
-            do. One click either way, and it never decides for you.
+          <p className="sub rv" style={delay(40)}>
+            Goodboy reads the state of a task and offers what comes next: the workflow step waiting
+            to run, the review comments nobody answered, the branch that fell behind main. Finish a
+            plan on its own and it offers to spawn the implementer. Send a one-line rename to the
+            biggest model and it holds the message to ask whether a smaller one will do. Each of
+            those is one button, and none of them fires itself.
           </p>
         </div>
 
-        <div className="appframe ex-frame rv" style={delay(160)} ref={ref} aria-hidden="true">
+        <div className="appframe ex-frame rv" style={delay(80)} ref={ref} aria-hidden="true">
           <div className="tbar">
             <span className="tl r" />
             <span className="tl y" />
             <span className="tl g" />
-            <span className="tname">goodboy, acme / Ship LIN-241</span>
+            <span className="tname">goodboy, acme / api / Ship LIN-241</span>
           </div>
 
           <div className="ex-sec">
-            <p className="ex-eyebrow">Plan</p>
-            <div className="ex-rail">
-              <div className="ex-step">
-                <span className="kb planner">planner</span>
-                <span className="ex-name">Draft the archive steps</span>
-                <span className="ex-st ex-st-done">done</span>
-                <span className="ex-prov">Claude Opus</span>
-              </div>
-
-              <Suggestion
-                open={openA}
-                pressed={stage === AT_PRESS_A}
-                text="Plan looks ready: Ship LIN-241, bulk archive for notifications. Spawn an implementer to execute it?"
-                accept="Spawn implementer"
-                dismiss="Not now"
-              />
-
-              {acceptedA && <Trace>Implementer spawned from the plan</Trace>}
-
-              {acceptedA && (
-                <div className="ex-step ex-new">
-                  <span className="kb implementer">implementer</span>
-                  <span className="ex-name">Archive endpoint, batches of 500</span>
-                  <span className="ex-st ex-st-queued">queued</span>
-                  <span className="ex-prov">Codex GPT-5.6 Sol</span>
+            <p className="ex-eyebrow">Suggestions</p>
+            <div className="ex-list">
+              {OFFERS.map((offer) => (
+                <div className={`ex-row${stage >= offer.at ? ' ex-lit' : ''}`} key={offer.key}>
+                  <span className="ex-ico">{offer.glyph}</span>
+                  <span className="ex-rt">
+                    <span className="ex-title">{offer.title}</span>
+                    {offer.detail !== null && <span className="ex-detail">{offer.detail}</span>}
+                  </span>
+                  {offer.action}
                 </div>
-              )}
+              ))}
             </div>
           </div>
 
           <div className="hairline" />
 
           <div className="ex-sec">
-            <p className="ex-eyebrow">Message</p>
             <div className="ex-composer">
-              <p className="ex-typed">Rename the Archive button to Archive all</p>
+              <p className={`ex-typed${stage >= AT_TYPED ? ' ex-lit' : ''}`}>
+                Rename the Archive button to Archive all
+              </p>
 
-              <Suggestion
-                open={openB}
-                pressed={stage === AT_PRESS_B}
-                text="Claude Opus for a one-line rename? Claude Haiku 4.5 does this for about a tenth of the price."
-                accept="Use Haiku"
-                dismiss="Keep Opus"
-              />
-
-              {acceptedB && <Trace>Switched to Haiku 4.5 from a suggestion</Trace>}
+              <div className={`ex-card${stage >= AT_HELD ? ' ex-lit' : ''}`}>
+                <span className="ex-cardglyph">
+                  <LampGlyph />
+                </span>
+                <p className="ex-cardtext">
+                  This looks light. Run with <b>Claude Sonnet</b> instead of <b>Claude Opus</b>?
+                  <span className="ex-cardsub">About 1.7x cheaper.</span>
+                </p>
+                <span className="ex-cardbtns">
+                  <span className={`mockbtn ex-accept${stage >= AT_PRESS ? ' ex-press' : ''}`}>
+                    Use Sonnet
+                  </span>
+                  <span className="mockbtn ghost">Keep Opus</span>
+                  <span className="ex-quiet">Change model…</span>
+                </span>
+              </div>
 
               <div className="ex-cfoot">
-                <span className={`ex-chip${acceptedB ? ' ex-swapped' : ''}`}>
+                <span className="ex-chip">
                   <BrandMark brand="anthropic" size={13} />
-                  <span>{acceptedB ? 'Claude Haiku 4.5 · Low' : 'Claude Opus · High'}</span>
+                  <span className="ex-chipslot">
+                    <span className={swapped ? '' : 'ex-on'}>Claude Opus · High</span>
+                    <span className={swapped ? 'ex-on' : ''}>Claude Sonnet · High</span>
+                  </span>
                 </span>
                 <span className="ex-send">
                   <SendGlyph />
@@ -184,8 +213,9 @@ export const Extras = () => {
           </div>
         </div>
 
-        <p className="caption rv" style={delay(200)}>
-          Two nudges, both easy to ignore. You stop ignoring them by day two.
+        <p className="caption rv" style={delay(110)}>
+          Three offers sitting on the task, one holding the message you just typed. Ignore all four
+          and nothing changes.
         </p>
       </div>
     </section>

--- a/website/src/sections/Hero.tsx
+++ b/website/src/sections/Hero.tsx
@@ -93,14 +93,14 @@ export const Hero = () => (
   <section id="hero" aria-labelledby="h2-hero">
     <div className="wrap heroGrid hr-grid">
       <div className="heroCopy">
-        <h1 className="rv" id="h2-hero">
+        <h1 className="rvi-lead" id="h2-hero">
           Stop <span className="hl">re&#8209;explaining yourself.</span>
         </h1>
-        <p className="sub rv" style={delay(80)}>
+        <p className="sub rvi-lead" style={delay(80)}>
           Goodboy is a free desktop app that runs a team of coding agents on your work. You describe
           it once, and Goodboy decides which agent goes next.
         </p>
-        <div className="ctaRow hr-cta rv" style={delay(160)}>
+        <div className="ctaRow hr-cta rvi" style={delay(160)}>
           <a className="btn" href="#install">
             Install
           </a>
@@ -108,19 +108,19 @@ export const Hero = () => (
             Star on GitHub
           </a>
         </div>
-        <p className="reassure rv" style={delay(240)}>
+        <p className="reassure rvi" style={delay(240)}>
           <b>Free and open source (MIT), every feature included.</b> It lives on your computer, no
           account.
         </p>
-        <p className="reassure rv" style={delay(300)}>
+        <p className="reassure rvi" style={delay(300)}>
           <b>No new bill.</b> It runs on the Claude, ChatGPT or Cursor plan you already pay for.
         </p>
-        <p className="reassure rv" style={delay(360)}>
+        <p className="reassure rvi" style={delay(360)}>
           <b>Switch model mid-task and nothing resets.</b> The goal, the decisions and the summary
           belong to the task, so the next agent already has them.
         </p>
       </div>
-      <div className="wall rv" style={delay(200)} aria-hidden="true">
+      <div className="wall rvi" style={delay(200)} aria-hidden="true">
         <div className="wallCol">
           {[...WALL, ...WALL].map((card, i) => (
             <SessionCard key={`${card.goal}-${i}`} {...card} />

--- a/website/src/sections/Integrations.css
+++ b/website/src/sections/Integrations.css
@@ -50,15 +50,11 @@
   display: flex;
   flex-direction: column;
   opacity: 0;
-  transform: translateX(-10px);
-  transition:
-    opacity 0.42s cubic-bezier(0.2, 0.7, 0.3, 1),
-    transform 0.42s cubic-bezier(0.2, 0.7, 0.3, 1);
+  transition: opacity 0.58s cubic-bezier(0.2, 0.7, 0.3, 1);
 }
 
 .ig-st.on {
   opacity: 1;
-  transform: none;
 }
 
 .ig-step {
@@ -134,16 +130,11 @@
   width: 28px;
   height: 12px;
   opacity: 0;
-  transform: scaleX(0.15);
-  transform-origin: left center;
-  transition:
-    opacity 0.3s ease,
-    transform 0.4s cubic-bezier(0.2, 0.7, 0.3, 1);
+  transition: opacity 0.58s cubic-bezier(0.2, 0.7, 0.3, 1);
 }
 
 .ig-arr.on svg {
   opacity: 1;
-  transform: none;
 }
 
 .ig-res {
@@ -190,7 +181,7 @@
   font-weight: 500;
   color: var(--gray6);
   opacity: 0;
-  transition: opacity 0.3s ease;
+  transition: opacity 0.58s cubic-bezier(0.2, 0.7, 0.3, 1);
 }
 
 .ig-ro.on {
@@ -215,7 +206,7 @@
   height: 6px;
   border-radius: 50%;
   background: var(--accent-bright);
-  animation: ig-pulse 1.1s ease-in-out infinite;
+  animation: ig-pulse 0.7s ease-in-out infinite;
 }
 
 @keyframes ig-pulse {
@@ -362,7 +353,7 @@
   align-items: center;
   gap: 8px;
   opacity: 0;
-  transition: opacity 0.42s ease;
+  transition: opacity 0.58s cubic-bezier(0.2, 0.7, 0.3, 1);
 }
 
 .ig-return.on {
@@ -401,7 +392,7 @@
   line-height: 1.5;
   color: var(--gray7);
   opacity: 0;
-  transition: opacity 0.42s ease;
+  transition: opacity 0.58s cubic-bezier(0.2, 0.7, 0.3, 1);
 }
 
 .ig-note.on {
@@ -443,11 +434,6 @@
   }
 
   .ig-arr svg {
-    transform: rotate(90deg) scaleX(0.15);
-    transform-origin: center;
-  }
-
-  .ig-arr.on svg {
     transform: rotate(90deg);
   }
 

--- a/website/src/sections/Integrations.tsx
+++ b/website/src/sections/Integrations.tsx
@@ -57,7 +57,7 @@ const UploadGlyph = () => (
   </svg>
 );
 
-const STAGE_MS = [180, 820, 1460, 2060, 2660, 3400, 4120, 4780] as const;
+const STAGE_MS = [180, 840, 1500, 2000, 2470, 3160, 3820, 4360] as const;
 const MAX_STAGE = 8;
 
 const IntegrationsFlow = () => {
@@ -216,19 +216,19 @@ export const Integrations = () => (
         <h2 className="rv" id="h2-integrations">
           The cards write themselves
         </h2>
-        <p className="sub rv" style={delay(80)}>
+        <p className="sub rv" style={delay(40)}>
           Most tasks start somewhere else, in an issue or a crash report. <b>One click</b> makes it
           a card with the goal already written for you, and whatever those tools send back lands in
           one inbox.
         </p>
       </div>
 
-      <ul className="ig-strip rv" style={delay(60)} aria-label="Connected tools">
+      <ul className="ig-strip rv" style={delay(30)} aria-label="Connected tools">
         {CARDS.map((card, index) => (
           <li
             key={card.brand}
             className="ig-chip"
-            style={{ ...delay(60 + index * 40), '--brand': BRAND_COLOR[card.brand] } as CSSProperties}
+            style={{ ...delay(30 + index * 20), '--brand': BRAND_COLOR[card.brand] } as CSSProperties}
           >
             <BrandMark brand={card.brand} size={16} />
             <span>{card.name}</span>
@@ -236,21 +236,21 @@ export const Integrations = () => (
         ))}
       </ul>
 
-      <h3 className="rv" id="h3-resolve" style={delay(160)}>
+      <h3 className="rv" id="h3-resolve" style={delay(80)}>
         From a review comment to a commit
       </h3>
 
-      <div className="ig-resolve rv" style={delay(200)}>
+      <div className="ig-resolve rv" style={delay(100)}>
         <IntegrationsFlow />
       </div>
 
-      <p className="caption rv" style={delay(240)}>
+      <p className="caption rv" style={delay(120)}>
         You stay in the app and the thread stays answered.
       </p>
 
       <a
         className="more rv"
-        style={delay(280)}
+        style={delay(140)}
         href={`${SITE.concepts}#integration-surface`}
       >
         See where each integration stands <span className="arr">→</span>

--- a/website/src/sections/Orchestrator.css
+++ b/website/src/sections/Orchestrator.css
@@ -33,62 +33,39 @@
   font-family: var(--sans);
 }
 
-.or-wire {
-  fill: none;
-  stroke: var(--gray3);
-  stroke-width: 1.5;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-}
-
 .or-spoke {
   fill: none;
   stroke: var(--gray3);
   stroke-width: 1.5;
   stroke-linecap: round;
   stroke-linejoin: round;
-  stroke-dasharray: 100;
-  stroke-dashoffset: 100;
-  animation: or-draw 620ms cubic-bezier(0.3, 0.7, 0.3, 1) forwards;
+  opacity: 0.5;
+  transition:
+    opacity 0.58s cubic-bezier(0.2, 0.7, 0.3, 1),
+    stroke 0.58s cubic-bezier(0.2, 0.7, 0.3, 1);
 }
 
-@keyframes or-draw {
-  to {
-    stroke-dashoffset: 0;
+.or-rail {
+  stroke-width: 3;
+  opacity: 0.85;
+}
+
+.or-spoke.or-live {
+  stroke: var(--c);
+  opacity: 1;
+}
+
+.or-outspoke,
+.or-lead {
+  --c: var(--accent);
+}
+
+@keyframes or-fade {
+  from {
+    opacity: 0;
   }
-}
-
-.or-pulse {
-  fill: none;
-  stroke: var(--accent);
-  stroke-width: 2.5;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-  stroke-dasharray: 9 200;
-  stroke-dashoffset: 9;
-  animation: or-run 900ms linear forwards;
-}
-
-@keyframes or-run {
   to {
-    stroke-dashoffset: -100;
-  }
-}
-
-.or-back {
-  fill: none;
-  stroke: var(--accent);
-  stroke-width: 5;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-  stroke-dasharray: 1 400;
-  stroke-dashoffset: 1;
-  animation: or-back-run 820ms cubic-bezier(0.4, 0, 0.4, 1) forwards;
-}
-
-@keyframes or-back-run {
-  to {
-    stroke-dashoffset: -100;
+    opacity: 1;
   }
 }
 
@@ -136,7 +113,27 @@
 }
 
 .or-tall .or-hubname {
-  font-size: 15px;
+  font-size: 13.5px;
+}
+
+.or-tall .or-lab {
+  font-size: 11px;
+}
+
+.or-tall .or-msg {
+  font-size: 12px;
+}
+
+.or-tall .or-role {
+  font-size: 13.5px;
+}
+
+.or-tall .or-model {
+  font-size: 11.5px;
+}
+
+.or-tall .or-eff {
+  font-size: 10.5px;
 }
 
 .or-readout {
@@ -147,26 +144,18 @@
 }
 
 .or-tall .or-readout {
-  font-size: 9.5px;
+  font-size: 8.5px;
 }
 
 .or-read {
-  animation: or-in 420ms ease both;
-}
-
-@keyframes or-in {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
+  animation: or-fade 580ms cubic-bezier(0.2, 0.7, 0.3, 1) both;
 }
 
 .or-role {
   font-size: 14.5px;
   font-weight: 600;
   fill: var(--c);
+  transition: fill 0.58s cubic-bezier(0.2, 0.7, 0.3, 1);
 }
 
 .or-model {
@@ -192,7 +181,11 @@
 }
 
 .or-tall .or-out-t {
-  font-size: 15.5px;
+  font-size: 15px;
+}
+
+.or-tall .or-out-s {
+  font-size: 11.5px;
 }
 
 .or-out-s {
@@ -201,6 +194,11 @@
 }
 
 .or-prglyph {
+  color: var(--gray5);
+  transition: color 0.58s cubic-bezier(0.2, 0.7, 0.3, 1);
+}
+
+.or-outcome.or-live .or-prglyph {
   color: var(--accent-deep);
 }
 
@@ -222,64 +220,70 @@
 
 .or-bubble {
   opacity: 0;
-  transition: opacity 0.5s ease;
+  transition: opacity 0.58s cubic-bezier(0.2, 0.7, 0.3, 1);
 }
 
 .or-bubble.or-on {
   opacity: 1;
 }
 
-.or-node {
-  opacity: 0;
-  transform: translate(-14px, 0) scale(0.9);
-  transform-box: fill-box;
-  transform-origin: 0 50%;
-  transition:
-    opacity 0.4s ease,
-    transform 0.4s cubic-bezier(0.2, 0.7, 0.3, 1);
+.or-node,
+.or-outcome {
+  transition: opacity 0.58s cubic-bezier(0.2, 0.7, 0.3, 1);
+}
+
+.or-node.or-off {
+  --c: var(--gray5);
+  opacity: 0.58;
+}
+
+.or-node.or-off .or-role {
+  fill: var(--gray7);
 }
 
 .or-node.or-live {
   opacity: 1;
-  transform: none;
-}
-
-.or-node.or-done {
-  opacity: 0.46;
-  transform: none;
 }
 
 .or-nrect {
-  fill: color-mix(in oklab, var(--c) 7%, #fff);
+  fill: #fff;
   stroke: var(--c);
   stroke-width: 1.5;
+  transition:
+    fill 0.58s cubic-bezier(0.2, 0.7, 0.3, 1),
+    stroke 0.58s cubic-bezier(0.2, 0.7, 0.3, 1);
+}
+
+.or-node.or-live .or-nrect {
+  fill: color-mix(in oklab, var(--c) 16%, #fff);
 }
 
 .or-nbar {
   fill: var(--c);
+  transition: fill 0.58s cubic-bezier(0.2, 0.7, 0.3, 1);
 }
 
 .or-orect {
-  fill: color-mix(in oklab, var(--accent) 7%, #fff);
-  stroke: var(--accent);
+  fill: #fff;
+  stroke: var(--c);
   stroke-width: 1.5;
+  transition:
+    fill 0.58s cubic-bezier(0.2, 0.7, 0.3, 1),
+    stroke 0.58s cubic-bezier(0.2, 0.7, 0.3, 1);
 }
 
 .or-outcome {
-  transform-box: fill-box;
-  transform-origin: 0 50%;
-  animation: or-grow 460ms cubic-bezier(0.2, 0.7, 0.3, 1) both;
+  --c: var(--gray5);
+  opacity: 0.58;
 }
 
-@keyframes or-grow {
-  from {
-    opacity: 0;
-    transform: translate(-14px, 0) scale(0.9);
-  }
-  to {
-    opacity: 1;
-    transform: none;
-  }
+.or-outcome.or-live {
+  --c: var(--accent);
+  opacity: 1;
+}
+
+.or-outcome.or-live .or-orect {
+  fill: color-mix(in oklab, var(--c) 16%, #fff);
 }
 
 .or-num circle {
@@ -299,14 +303,14 @@
   .or-fig .or-bubble,
   .or-fig .or-node,
   .or-fig .or-outcome,
-  .or-fig .or-read {
-    opacity: 1;
-    transform: none;
+  .or-fig .or-read,
+  .or-fig .or-spoke,
+  .or-fig .or-nrect,
+  .or-fig .or-nbar,
+  .or-fig .or-orect,
+  .or-fig .or-role,
+  .or-fig .or-prglyph {
     transition: none;
-    animation: none;
-  }
-  .or-fig .or-spoke {
-    stroke-dashoffset: 0;
     animation: none;
   }
 }

--- a/website/src/sections/Orchestrator.tsx
+++ b/website/src/sections/Orchestrator.tsx
@@ -18,10 +18,9 @@ const AGENTS: readonly Agent[] = [
     name: 'scout',
     brand: 'anthropic',
     model: 'Claude Haiku 4.5',
-    effort: 'Low',
-    ew: 40,
+    ew: 0,
     y: 62,
-    ty: 330,
+    ty: 278,
   },
   {
     name: 'planner',
@@ -30,7 +29,7 @@ const AGENTS: readonly Agent[] = [
     effort: 'High',
     ew: 44,
     y: 152,
-    ty: 418,
+    ty: 350,
   },
   {
     name: 'implementer',
@@ -38,16 +37,15 @@ const AGENTS: readonly Agent[] = [
     model: 'GPT-5.6 Sol',
     ew: 0,
     y: 242,
-    ty: 506,
+    ty: 422,
   },
   {
     name: 'reviewer',
     brand: 'cursor',
     model: 'Composer',
-    effort: 'Medium',
-    ew: 60,
+    ew: 0,
     y: 332,
-    ty: 594,
+    ty: 494,
   },
 ];
 
@@ -57,7 +55,7 @@ const WAYS: readonly (readonly [string, string])[] = [
 ];
 
 const DUR: readonly number[] = [
-  900, 1300, 850, 950, 400, 850, 950, 400, 850, 950, 400, 850, 950, 400, 640,
+  330, 440, 380, 440, 100, 380, 440, 100, 380, 440, 100, 380, 440, 100, 360,
 ];
 
 const LAST = DUR.length;
@@ -65,15 +63,13 @@ const LAST = DUR.length;
 const OUT_STEP = 14;
 
 const FIG_LABEL =
-  'A workflow spawns one agent per step. You send a goal, the workflow comes from a preset or from a plan the orchestrator builds, then an agent is created for each step: scout on Claude Haiku 4.5 at low effort, planner on Claude Opus at high effort, implementer on Codex GPT-5.6 Sol, reviewer on Cursor Composer at medium effort. Each one reports back to the workflow and is let go, and the run ends with draft pull request 1045 waiting for you to merge.';
+  'A workflow spawns one agent per step. You send a goal, the workflow comes from a preset or from a plan the orchestrator builds, then an agent is created for each step: scout on Claude Haiku 4.5, planner on Claude Opus at high effort, implementer on Codex GPT-5.6 Sol, reviewer on Cursor Composer. Each one reports back to the workflow and is let go, and the run ends with draft pull request 1045 waiting for you to merge.';
 
 type Scene = {
   readonly phase: (i: number) => string;
-  readonly born: (i: number) => boolean;
-  readonly backOn: (i: number) => boolean;
-  readonly inPulse: boolean;
-  readonly outWire: boolean;
-  readonly outOn: boolean;
+  readonly lead: string;
+  readonly wire: string;
+  readonly out: string;
   readonly bubbleOn: boolean;
   readonly readOn: boolean;
   readonly way: readonly [string, string];
@@ -82,8 +78,6 @@ type Scene = {
 };
 
 const outSpoke = (y: number) => `M390,198 C 480,198 600,${y} 740,${y}`;
-
-const backSpoke = (y: number) => `M740,${y} C 600,${y} 480,198 390,198`;
 
 const PrGlyph = ({ size }: { readonly size: number }) => (
   <svg
@@ -107,28 +101,20 @@ const PrGlyph = ({ size }: { readonly size: number }) => (
 
 const Wide = ({ s }: { readonly s: Scene }) => (
   <svg className="or-wide" viewBox="0 0 1120 520" role="img" aria-label={FIG_LABEL}>
-    <path className="or-wire" d="M202,198 L246,198" />
-    {s.inPulse ? <path className="or-pulse" pathLength={100} d="M202,198 L246,198" /> : null}
+    <path className={`or-spoke or-lead ${s.lead}`} d="M202,198 L246,198" />
 
-    {AGENTS.map((a, i) =>
-      s.born(i) ? (
-        <path className="or-spoke" key={`spoke-${a.name}`} pathLength={100} d={outSpoke(a.y)} />
-      ) : null,
-    )}
-
-    {AGENTS.map((a, i) =>
-      s.backOn(i) ? (
-        <path className="or-back" key={`back-${a.name}`} pathLength={100} d={backSpoke(a.y)} />
-      ) : null,
-    )}
-
-    {s.outWire ? (
+    {AGENTS.map((a, i) => (
       <path
-        className="or-spoke"
-        pathLength={100}
-        d="M348,275 C 420,400 540,447 680,447 L 740,447"
+        className={`or-spoke or-n${i + 1} ${s.phase(i)}`}
+        key={`spoke-${a.name}`}
+        d={outSpoke(a.y)}
       />
-    ) : null}
+    ))}
+
+    <path
+      className={`or-spoke or-outspoke ${s.wire}`}
+      d="M348,275 C 420,400 540,447 680,447 L 740,447"
+    />
 
     <g>
       <text className="or-lab" x={10} y={142}>
@@ -193,20 +179,18 @@ const Wide = ({ s }: { readonly s: Scene }) => (
       </g>
     ))}
 
-    {s.outOn ? (
-      <g className="or-outcome">
-        <rect className="or-orect" x={740} y={400} width={230} height={94} rx={16} />
-        <g className="or-prglyph" transform="translate(764,434)">
-          <PrGlyph size={26} />
-        </g>
-        <text className="or-out-t" x={808} y={442}>
-          Draft PR #1045
-        </text>
-        <text className="or-out-s" x={808} y={468}>
-          merging waits for you
-        </text>
+    <g className={`or-outcome ${s.out}`}>
+      <rect className="or-orect" x={740} y={400} width={230} height={94} rx={16} />
+      <g className="or-prglyph" transform="translate(764,434)">
+        <PrGlyph size={26} />
       </g>
-    ) : null}
+      <text className="or-out-t" x={808} y={442}>
+        Draft PR #1045
+      </text>
+      <text className="or-out-s" x={808} y={468}>
+        merging waits for you
+      </text>
+    </g>
 
     {s.still ? (
       <g className="or-nums">
@@ -224,66 +208,50 @@ const Wide = ({ s }: { readonly s: Scene }) => (
 );
 
 const Tall = ({ s }: { readonly s: Scene }) => (
-  <svg className="or-tall" viewBox="0 0 360 748" role="img" aria-label={FIG_LABEL}>
-    <path className="or-wire" d="M180,110 L180,136" />
-    <path className="or-wire" d="M180,272 L180,290 L26,290 L26,700" />
-    {s.inPulse ? <path className="or-pulse" pathLength={100} d="M180,110 L180,136" /> : null}
+  <svg className="or-tall" viewBox="0 0 360 612" role="img" aria-label={FIG_LABEL}>
+    <path className={`or-spoke or-rail or-lead ${s.lead}`} d="M180,82 L180,96" />
 
-    {AGENTS.map((a, i) =>
-      s.born(i) ? (
-        <path
-          className="or-spoke"
-          key={`tspoke-${a.name}`}
-          pathLength={100}
-          d={`M26,${a.ty} L48,${a.ty}`}
-        />
-      ) : null,
-    )}
+    {AGENTS.map((a, i) => (
+      <path
+        className={`or-spoke or-rail or-n${i + 1} ${s.phase(i)}`}
+        key={`trail-${a.name}`}
+        d={`M180,${a.ty - 46} L180,${a.ty - 26}`}
+      />
+    ))}
 
-    {AGENTS.map((a, i) =>
-      s.backOn(i) ? (
-        <path
-          className="or-back"
-          key={`tback-${a.name}`}
-          pathLength={100}
-          d={`M48,${a.ty} L26,${a.ty} L26,290 L180,290 L180,272`}
-        />
-      ) : null,
-    )}
-
-    {s.outWire ? <path className="or-spoke" pathLength={100} d="M26,700 L48,700" /> : null}
+    <path className={`or-spoke or-rail or-outspoke ${s.wire}`} d="M180,520 L180,540" />
 
     <g>
-      <text className="or-lab" x={52} y={16}>
+      <text className="or-lab" x={10} y={12}>
         you
       </text>
-      <circle className="or-halo" cx={180} cy={204} r={76} />
-      <circle className="or-hub" cx={180} cy={204} r={68} />
-      <text className="or-hubname" x={180} y={198}>
+      <circle className="or-halo" cx={180} cy={164} r={68} />
+      <circle className="or-hub" cx={180} cy={164} r={62} />
+      <text className="or-hubname" x={180} y={159}>
         workflow
       </text>
-      <line className="or-hr" x1={146} y1={207} x2={214} y2={207} />
+      <line className="or-hr" x1={148} y1={167} x2={212} y2={167} />
     </g>
 
     <g className={s.bubbleOn ? 'or-bubble or-on' : 'or-bubble'}>
       <path
         className="or-card"
-        d="M64,26 H296 A14,14 0 0 1 310,40 V80 A14,14 0 0 1 296,94 H190 L180,108 L170,94 H64 A14,14 0 0 1 50,80 V40 A14,14 0 0 1 64,26 Z"
+        d="M20,18 H340 A12,12 0 0 1 352,30 V60 A12,12 0 0 1 340,72 H190 L180,82 L170,72 H20 A12,12 0 0 1 8,60 V30 A12,12 0 0 1 20,18 Z"
       />
-      <text className="or-msg" x={66} y={56}>
+      <text className="or-msg" x={24} y={41}>
         Ship LIN-241, bulk archive
       </text>
-      <text className="or-msg" x={66} y={76}>
+      <text className="or-msg" x={24} y={59}>
         for notifications
       </text>
     </g>
 
     {s.readOn ? (
       <g className="or-read" key={s.wayKey}>
-        <text className="or-readout" x={180} y={221}>
+        <text className="or-readout" x={180} y={177}>
           {s.way[0]}
         </text>
-        <text className="or-readout" x={180} y={235}>
+        <text className="or-readout" x={180} y={189}>
           {s.way[1]}
         </text>
       </g>
@@ -291,21 +259,21 @@ const Tall = ({ s }: { readonly s: Scene }) => (
 
     {AGENTS.map((a, i) => (
       <g className={`or-node or-n${i + 1} ${s.phase(i)}`} key={`tnode-${a.name}`}>
-        <rect className="or-nrect" x={48} y={a.ty - 35} width={304} height={70} rx={14} />
-        <rect className="or-nbar" x={64} y={a.ty - 18} width={4} height={36} rx={2} />
-        <text className="or-role" x={80} y={a.ty - 8}>
+        <rect className="or-nrect" x={8} y={a.ty - 26} width={344} height={52} rx={12} />
+        <rect className="or-nbar" x={24} y={a.ty - 14} width={4} height={28} rx={2} />
+        <text className="or-role" x={40} y={a.ty - 5}>
           {a.name}
         </text>
-        <g transform={`translate(80,${a.ty + 2})`}>
-          <BrandMark brand={a.brand} size={13} />
+        <g transform={`translate(40,${a.ty + 3})`}>
+          <BrandMark brand={a.brand} size={12} />
         </g>
-        <text className="or-model" x={100} y={a.ty + 13}>
+        <text className="or-model" x={58} y={a.ty + 13}>
           {a.model}
         </text>
         {a.effort ? (
           <>
-            <rect className="or-effbg" x={336 - a.ew} y={a.ty} width={a.ew} height={18} rx={9} />
-            <text className="or-eff" x={336 - a.ew / 2} y={a.ty + 13}>
+            <rect className="or-effbg" x={336 - a.ew} y={a.ty - 9} width={a.ew} height={18} rx={9} />
+            <text className="or-eff" x={336 - a.ew / 2} y={a.ty + 4}>
               {a.effort}
             </text>
           </>
@@ -313,33 +281,18 @@ const Tall = ({ s }: { readonly s: Scene }) => (
       </g>
     ))}
 
-    {s.outOn ? (
-      <g className="or-outcome">
-        <rect className="or-orect" x={48} y={660} width={304} height={80} rx={16} />
-        <g className="or-prglyph" transform="translate(72,687)">
-          <PrGlyph size={24} />
-        </g>
-        <text className="or-out-t" x={110} y={694}>
-          Draft PR #1045
-        </text>
-        <text className="or-out-s" x={110} y={718}>
-          merging waits for you
-        </text>
+    <g className={`or-outcome ${s.out}`}>
+      <rect className="or-orect" x={8} y={540} width={344} height={64} rx={14} />
+      <g className="or-prglyph" transform="translate(32,561)">
+        <PrGlyph size={22} />
       </g>
-    ) : null}
-
-    {s.still ? (
-      <g className="or-nums">
-        {AGENTS.map((a, i) => (
-          <g className="or-num" key={`tnum-${a.name}`}>
-            <circle cx={37} cy={a.ty} r={9} />
-            <text x={37} y={a.ty + 3.5}>
-              {i + 1}
-            </text>
-          </g>
-        ))}
-      </g>
-    ) : null}
+      <text className="or-out-t" x={68} y={567}>
+        Draft PR #1045
+      </text>
+      <text className="or-out-s" x={68} y={587}>
+        merging waits for you
+      </text>
+    </g>
   </svg>
 );
 
@@ -365,15 +318,11 @@ export const Orchestrator = () => {
     phase: (i) => {
       if (still) return 'or-live';
       const base = 2 + i * 3;
-      if (step < base) return 'or-off';
-      if (step < base + 2) return 'or-live';
-      return 'or-done';
+      return step < base ? 'or-off' : 'or-live';
     },
-    born: (i) => still || step >= 2 + i * 3,
-    backOn: (i) => !still && step === 3 + i * 3,
-    inPulse: !still && step === 1,
-    outWire: still || step >= OUT_STEP,
-    outOn: still || step > OUT_STEP,
+    lead: still || step >= 1 ? 'or-live' : 'or-off',
+    wire: still || step >= OUT_STEP ? 'or-live' : 'or-off',
+    out: still || step > OUT_STEP ? 'or-live' : 'or-off',
     bubbleOn: still || inView,
     readOn: still || step >= 1,
     way: WAYS[still ? 0 : way],
@@ -389,8 +338,8 @@ export const Orchestrator = () => {
             How it works
           </h2>
           <p className="sub rv" style={delay(80)}>
-            Pick a workflow, or describe the goal and let the orchestrator build one. Every step gets
-            its own agent, on the model that fits the effort.
+            Pick a workflow, or describe the goal and let the orchestrator build one. Every step
+            gets its own agent, on the model that fits the effort.
           </p>
         </div>
 

--- a/website/src/sections/Providers.tsx
+++ b/website/src/sections/Providers.tsx
@@ -9,7 +9,7 @@ type Chip = {
   readonly plan: string;
 };
 
-const CHIPS: readonly Chip[] = [
+const PROVIDER_CHIPS: readonly Chip[] = [
   { brand: 'anthropic', name: 'Claude', plan: 'Claude Max or Pro' },
   { brand: 'codex', name: 'Codex', plan: 'ChatGPT Plus or Pro' },
   { brand: 'cursor', name: 'Cursor', plan: 'Cursor Pro' },
@@ -19,39 +19,66 @@ const CHIPS: readonly Chip[] = [
   { brand: 'moonshot', name: 'Moonshot', plan: 'Kimi, from Moonshot' },
 ];
 
+const TOOL_CHIPS: readonly Chip[] = [
+  { brand: 'github', name: 'GitHub', plan: 'Issues & pull requests' },
+  { brand: 'gitlab', name: 'GitLab', plan: 'Issues & merge requests' },
+  { brand: 'bitbucket', name: 'Bitbucket', plan: 'Pull requests' },
+  { brand: 'linear', name: 'Linear', plan: 'Issues' },
+  { brand: 'jira', name: 'Jira', plan: 'Issues' },
+  { brand: 'sentry', name: 'Sentry', plan: 'Crash reports, read-only' },
+  { brand: 'slack', name: 'Slack', plan: 'Notifications' },
+];
+
+const BELT_COPIES = 4;
+
+const BeltChip = ({ chip }: { chip: Chip }) => (
+  <div className="bchip">
+    <BrandMark brand={chip.brand} size={20} />
+    <span>
+      <span className="bname">{chip.name}</span>
+      <br />
+      <span className="bplan">{chip.plan}</span>
+    </span>
+  </div>
+);
+
+const BeltCopy = ({ chips }: { chips: readonly Chip[] }) => (
+  <>
+    {chips.map((chip) => (
+      <BeltChip chip={chip} key={chip.brand} />
+    ))}
+  </>
+);
+
+const renderBelt = (chips: readonly Chip[]) => (
+  <>
+    <BeltCopy chips={chips} />
+    {Array.from({ length: BELT_COPIES - 1 }, (_, copyIndex) => (
+      <div className="pv-loop" aria-hidden="true" key={`loop-${copyIndex}`}>
+        <BeltCopy chips={chips} />
+      </div>
+    ))}
+  </>
+);
+
 export const Providers = () => (
   <section id="providers" aria-label="Providers">
     <p className="beltEyebrow rv">Runs on the plans you already pay for</p>
     <p className="vh">Claude, Codex, Cursor, Gemini, OpenCode, OpenRouter and Moonshot.</p>
     <div className="belt rv" style={delay(80)} aria-hidden="true">
-      <div className="beltTrack">
-        {CHIPS.map((chip) => (
-          <div className="bchip" key={chip.brand}>
-            <BrandMark brand={chip.brand} size={20} />
-            <span>
-              <span className="bname">{chip.name}</span>
-              <br />
-              <span className="bplan">{chip.plan}</span>
-            </span>
-          </div>
-        ))}
-        <div className="pv-loop">
-          {CHIPS.map((chip) => (
-            <div className="bchip" key={chip.brand}>
-              <BrandMark brand={chip.brand} size={20} />
-              <span>
-                <span className="bname">{chip.name}</span>
-                <br />
-                <span className="bplan">{chip.plan}</span>
-              </span>
-            </div>
-          ))}
-        </div>
-      </div>
+      <div className="beltTrack">{renderBelt(PROVIDER_CHIPS)}</div>
     </div>
     <p className="beltMore rv" style={delay(140)}>
       Seven providers, one session. Your logins stay where they already are.{' '}
       <a href={SITE.providersDoc}>Set up a provider →</a>
     </p>
+
+    <p className="beltEyebrow rv" style={{ ...delay(160), marginTop: 36 }}>
+      Works with the tools you already use
+    </p>
+    <p className="vh">GitHub, GitLab, Bitbucket, Linear, Jira, Sentry and Slack.</p>
+    <div className="belt rv" style={delay(180)} aria-hidden="true">
+      <div className="beltTrack beltTrackReverse">{renderBelt(TOOL_CHIPS)}</div>
+    </div>
   </section>
 );

--- a/website/src/sections/Roles.css
+++ b/website/src/sections/Roles.css
@@ -1,8 +1,9 @@
 .rl-frame {
-  --rl-prov: 118px;
-  --rl-model: 130px;
-  --rl-seg: 150px;
-  --rl-slot: 190px;
+  --rl-prov: 108px;
+  --rl-model: 108px;
+  --rl-seg: 232px;
+  --rl-slot: 166px;
+  --rl-ease: cubic-bezier(0.2, 0.7, 0.3, 1);
 }
 
 .rl-legend {
@@ -126,49 +127,69 @@
   color: var(--gray5);
 }
 
-.rl-seg {
-  position: relative;
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
+.rl-dialslot {
+  display: flex;
+  align-items: center;
   width: var(--rl-seg);
   flex-shrink: 0;
+}
+
+.rl-seg {
+  display: inline-flex;
+  align-items: stretch;
   background: var(--gray1);
   border-radius: 999px;
   padding: 2px;
 }
 
-.rl-thumb {
-  position: absolute;
-  top: 2px;
-  bottom: 2px;
-  left: 2px;
-  width: calc((100% - 4px) / 3);
-  border-radius: 999px;
-  background: var(--accent-soft);
-  box-shadow: inset 0 0 0 1px color-mix(in oklch, var(--accent-bright) 45%, transparent);
-  transform: translateX(calc(var(--i) * 100%));
-  opacity: 0;
-  transition:
-    transform 0.46s cubic-bezier(0.2, 0.7, 0.3, 1),
-    opacity 0.28s ease;
-}
-
-.rl-seg[data-set] .rl-thumb {
-  opacity: 1;
-}
-
 .rl-sv {
   position: relative;
+  isolation: isolate;
+  padding: 0 7px;
   text-align: center;
   font-size: 11px;
   font-weight: 600;
   line-height: 1.7;
+  white-space: nowrap;
   color: var(--gray6);
-  transition: color 0.3s ease;
+  transition: color 0.58s var(--rl-ease);
+}
+
+.rl-sv::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  box-shadow: inset 0 0 0 1px color-mix(in oklch, var(--accent-bright) 45%, transparent);
+  opacity: 0;
+  transition: opacity 0.58s var(--rl-ease);
 }
 
 .rl-sv[data-on] {
   color: var(--accent-deep);
+}
+
+.rl-sv[data-on]::before {
+  opacity: 1;
+}
+
+.rl-nodial {
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1.7;
+  white-space: nowrap;
+  color: var(--gray5);
+  border: 1px dashed var(--gray3);
+  border-radius: 999px;
+  padding: 1px 11px;
+  opacity: 0;
+  transition: opacity 0.58s var(--rl-ease);
+}
+
+.rl-nodial[data-in] {
+  opacity: 1;
 }
 
 .rl-slot {
@@ -183,17 +204,12 @@
   line-height: 1.4;
   color: var(--gray6);
   text-align: right;
-  white-space: nowrap;
   opacity: 0;
-  transform: translateX(6px);
-  transition:
-    opacity 0.36s ease,
-    transform 0.36s cubic-bezier(0.2, 0.7, 0.3, 1);
+  transition: opacity 0.58s var(--rl-ease);
 }
 
 .rl-why[data-in] {
   opacity: 1;
-  transform: none;
 }
 
 .rl-foot {
@@ -212,31 +228,15 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .rl-thumb,
   .rl-sv,
+  .rl-sv::before,
+  .rl-nodial,
   .rl-why {
     transition: none;
   }
 }
 
 @media (max-width: 1020px) {
-  .rl-frame {
-    --rl-prov: 110px;
-    --rl-model: 122px;
-    --rl-seg: 140px;
-    --rl-slot: 176px;
-  }
-
-  .rl-row {
-    gap: 10px;
-  }
-
-  .rl-ctrls {
-    gap: 8px;
-  }
-}
-
-@media (max-width: 900px) {
   .rl-row {
     grid-template-columns: 18px 96px minmax(0, 1fr);
     row-gap: 10px;
@@ -252,6 +252,10 @@
     gap: 8px;
   }
 
+  .rl-dialslot {
+    width: auto;
+  }
+
   .rl-slot {
     width: 100%;
     justify-content: flex-start;
@@ -259,7 +263,6 @@
 
   .rl-why {
     text-align: left;
-    white-space: normal;
   }
 }
 

--- a/website/src/sections/Roles.tsx
+++ b/website/src/sections/Roles.tsx
@@ -1,10 +1,13 @@
 import './Roles.css';
-import { useEffect, useState, type CSSProperties } from 'react';
+import { useEffect, useState } from 'react';
 import { BrandMark, type BrandId } from '../components/BrandIcons';
 import { delay, prefersReducedMotion, useInViewOnce } from '../components/Reveal';
 import { SITE } from '../site';
 
-type EffortValue = 'Low' | 'Medium' | 'High' | 'Luna' | 'Terra' | 'Sol';
+type Dial = {
+  readonly options: readonly string[];
+  readonly pick: string;
+};
 
 type Step = {
   readonly n: number;
@@ -13,15 +16,20 @@ type Step = {
   readonly brand: BrandId;
   readonly provider: string;
   readonly model: string;
-  readonly effort: EffortValue;
-  readonly options: readonly EffortValue[];
+  readonly dial: Dial | null;
   readonly task: string;
   readonly why: string;
 };
 
-const EFFORTS: readonly EffortValue[] = ['Low', 'Medium', 'High'];
+const OPUS_EFFORTS: readonly string[] = ['Low', 'Medium', 'High', 'Very high', 'Max'];
 
-const VARIANTS: readonly EffortValue[] = ['Luna', 'Terra', 'Sol'];
+const SONNET_EFFORTS: readonly string[] = ['Low', 'Medium', 'High'];
+
+const CODEX_VARIANTS: readonly string[] = ['Luna', 'Terra', 'Sol'];
+
+const COMPOSER_MODES: readonly string[] = ['Standard', 'Fast'];
+
+const NO_DIAL = 'no tuning';
 
 const LEGEND: readonly (readonly [string, string])[] = [
   ['scout', 'scout'],
@@ -41,8 +49,7 @@ const STEPS: readonly Step[] = [
     brand: 'anthropic',
     provider: 'Claude',
     model: 'Haiku 4.5',
-    effort: 'Low',
-    options: EFFORTS,
+    dial: null,
     task: 'Read how notifications are stored',
     why: 'reads a lot, decides nothing',
   },
@@ -53,8 +60,7 @@ const STEPS: readonly Step[] = [
     brand: 'anthropic',
     provider: 'Claude',
     model: 'Opus',
-    effort: 'High',
-    options: EFFORTS,
+    dial: { options: OPUS_EFFORTS, pick: 'High' },
     task: 'Draft the archive steps',
     why: 'the one that has to think',
   },
@@ -64,9 +70,8 @@ const STEPS: readonly Step[] = [
     tone: 'implementer',
     brand: 'codex',
     provider: 'Codex',
-    model: 'GPT-5.6 Sol',
-    effort: 'Sol',
-    options: VARIANTS,
+    model: 'GPT-5.6',
+    dial: { options: CODEX_VARIANTS, pick: 'Sol' },
     task: 'Archive endpoint, batches of 500',
     why: 'writes most of the code',
   },
@@ -76,11 +81,10 @@ const STEPS: readonly Step[] = [
     tone: 'rl-tester',
     brand: 'codex',
     provider: 'Codex',
-    model: 'GPT-5.6 Terra',
-    effort: 'Terra',
-    options: VARIANTS,
+    model: 'GPT-5.6',
+    dial: { options: CODEX_VARIANTS, pick: 'Terra' },
     task: 'Run the suite, fix the reds',
-    why: 'runs the suite, fixes the reds',
+    why: 'the tests do the judging',
   },
   {
     n: 5,
@@ -89,8 +93,7 @@ const STEPS: readonly Step[] = [
     brand: 'cursor',
     provider: 'Cursor',
     model: 'Composer',
-    effort: 'Medium',
-    options: EFFORTS,
+    dial: { options: COMPOSER_MODES, pick: 'Standard' },
     task: 'Read the diff before the PR',
     why: 'reads the diff, not the repo',
   },
@@ -101,18 +104,15 @@ const STEPS: readonly Step[] = [
     brand: 'anthropic',
     provider: 'Claude',
     model: 'Sonnet',
-    effort: 'Low',
-    options: EFFORTS,
+    dial: { options: SONNET_EFFORTS, pick: 'Low' },
     task: 'Answer review comments',
     why: 'small edits, one at a time',
   },
 ];
 
-const FIRST_BEAT = 500;
+const FIRST_BEAT = 480;
 
-const BEAT_GAP = 420;
-
-const segStyle = (i: number) => ({ '--i': `${i}` }) as CSSProperties;
+const BEAT_GAP = 700;
 
 const Caret = () => (
   <svg
@@ -130,28 +130,28 @@ const Caret = () => (
   </svg>
 );
 
-const Effortometer = ({
-  effort,
-  options,
-  set,
-}: {
-  readonly effort: EffortValue;
-  readonly options: readonly EffortValue[];
-  readonly set: boolean;
-}) => (
-  <span
-    className="rl-seg"
-    data-set={set ? 'y' : undefined}
-    style={segStyle(set ? options.indexOf(effort) : 0)}
-  >
-    <span className="rl-thumb" />
-    {options.map((value) => (
-      <span className="rl-sv" key={value} data-on={set && value === effort ? 'y' : undefined}>
-        {value}
+const DialControl = ({ dial, set }: { readonly dial: Dial | null; readonly set: boolean }) => {
+  if (dial == null) {
+    return (
+      <span className="rl-dialslot">
+        <span className="rl-nodial" data-in={set ? 'y' : undefined}>
+          {NO_DIAL}
+        </span>
       </span>
-    ))}
-  </span>
-);
+    );
+  }
+  return (
+    <span className="rl-dialslot">
+      <span className="rl-seg">
+        {dial.options.map((value) => (
+          <span className="rl-sv" key={value} data-on={set && value === dial.pick ? 'y' : undefined}>
+            {value}
+          </span>
+        ))}
+      </span>
+    </span>
+  );
+};
 
 export const Roles = () => {
   const { ref, inView } = useInViewOnce<HTMLDivElement>();
@@ -177,14 +177,15 @@ export const Roles = () => {
           <h2 className="rv" id="h2-roles">
             The right model for each step
           </h2>
-          <p className="sub rv" style={delay(80)}>
+          <p className="sub rv" style={delay(40)}>
             Seven roles come in the box: scout, planner, implementer, tester, reviewer, investigator
-            and resolver. Each step in a workflow picks its own provider, model and effort, and any
-            of them is one click from being changed.
+            and resolver. Each step picks its own provider and model, then whatever that model lets
+            you tune: how hard it thinks, which variant, standard or fast. Any of it is one click
+            from being changed.
           </p>
         </div>
 
-        <div className="appframe rl-frame rv" style={delay(160)} ref={ref} aria-hidden="true">
+        <div className="appframe rl-frame rv" style={delay(80)} ref={ref} aria-hidden="true">
           <div className="tbar">
             <span className="tl r" />
             <span className="tl y" />
@@ -223,7 +224,7 @@ export const Roles = () => {
                       <span className="rl-cv">{step.model}</span>
                       <Caret />
                     </span>
-                    <Effortometer effort={step.effort} options={step.options} set={set} />
+                    <DialControl dial={step.dial} set={set} />
                     <span className="rl-slot">
                       <span className="rl-why" data-in={set ? 'y' : undefined}>
                         {step.why}
@@ -240,11 +241,11 @@ export const Roles = () => {
           </div>
         </div>
 
-        <p className="caption rv" style={delay(200)}>
-          The scout reads the codebase for two cents. The planner thinks, and that is the one that
-          costs real money.
+        <p className="caption rv" style={delay(110)}>
+          The scout reads the codebase for two cents and has nothing to tune. The planner thinks at
+          high effort, and that is the one that costs real money.
         </p>
-        <a className="more rv" style={delay(220)} href={`${SITE.concepts}#workflows`}>
+        <a className="more rv" style={delay(130)} href={`${SITE.concepts}#workflows`}>
           How workflows work <span className="arr">→</span>
         </a>
       </div>

--- a/website/src/sections/Routing.css
+++ b/website/src/sections/Routing.css
@@ -187,7 +187,6 @@
   height: 12px;
   border-radius: 2px;
   background: color-mix(in oklab, var(--warn) 45%, white);
-  transform-origin: bottom center;
 }
 
 .ro-worst .ro-blk {
@@ -209,7 +208,6 @@
   height: 100%;
   min-width: 3px;
   border-radius: 99px;
-  transform-origin: left center;
 }
 
 .ro-cap-label {
@@ -242,6 +240,10 @@
   opacity: 0.85;
 }
 
+.ro-note.ro-calm {
+  color: var(--gray6);
+}
+
 .ro-reroute {
   display: flex;
   align-items: center;
@@ -254,7 +256,7 @@
   line-height: 1.4;
   color: var(--warn-text);
   opacity: 0;
-  transition: opacity 0.3s ease;
+  transition: opacity 0.58s cubic-bezier(0.2, 0.7, 0.3, 1);
 }
 
 .ro-reroute.ro-on {
@@ -283,50 +285,19 @@
   color: oklch(0.5 0.16 130);
 }
 
-@keyframes ro-rowin {
+@keyframes ro-fadein {
   from {
     opacity: 0;
-    transform: translateY(6px);
   }
   to {
     opacity: 1;
-    transform: none;
   }
 }
 
-@keyframes ro-barin {
-  from {
-    transform: scaleX(0);
-  }
-  to {
-    transform: scaleX(1);
-  }
-}
-
-@keyframes ro-blkin {
-  from {
-    opacity: 0;
-    transform: scaleY(0.15);
-  }
-  to {
-    opacity: 1;
-    transform: none;
-  }
-}
-
-.ro-fig[data-stage='play'] .ro-row {
-  opacity: 0;
-  animation: ro-rowin 420ms cubic-bezier(0.2, 0.7, 0.3, 1) var(--d, 0ms) forwards;
-}
-
-.ro-fig[data-stage='play'] .ro-fill {
-  transform: scaleX(0);
-  animation: ro-barin 1100ms cubic-bezier(0.4, 0, 0.2, 1) var(--d, 0ms) forwards;
-}
-
+.ro-fig[data-stage='play'] .ro-row,
 .ro-fig[data-stage='play'] .ro-blk {
   opacity: 0;
-  animation: ro-blkin 260ms cubic-bezier(0.2, 0.7, 0.3, 1) var(--d, 0ms) forwards;
+  animation: ro-fadein 0.58s cubic-bezier(0.2, 0.7, 0.3, 1) var(--d, 0ms) forwards;
 }
 
 @media (max-width: 900px) {

--- a/website/src/sections/Routing.tsx
+++ b/website/src/sections/Routing.tsx
@@ -12,7 +12,7 @@ type Turn = Priced & {
   readonly key: string;
   readonly ask: string;
   readonly model: string;
-  readonly effort: string;
+  readonly effort?: string;
   readonly carries: string;
   readonly blocks: number;
   readonly run: number;
@@ -91,7 +91,6 @@ const TURNS: readonly Turn[] = [
     key: 'label',
     ask: 'rename one label',
     model: 'Claude Haiku 4.5',
-    effort: 'Low',
     carries: 'carries turns 1 to 5',
     blocks: 5,
     delta: 2.1,
@@ -106,12 +105,12 @@ const STEPS: readonly Step[] = [
     role: 'scout',
     tone: 'scout',
     ask: 'read the code',
-    brand: 'anthropic',
-    model: 'Claude Haiku 4.5',
-    effort: 'Low',
+    brand: 'gemini',
+    model: 'Gemini 3.1 Pro',
+    effort: 'High',
     brief: 'brief 2k',
-    delta: 0.02,
-    run: 0.02,
+    delta: 0.05,
+    run: 0.05,
   },
   {
     key: 'planner',
@@ -119,11 +118,11 @@ const STEPS: readonly Step[] = [
     tone: 'planner',
     ask: 'plan it',
     brand: 'anthropic',
-    model: 'Claude Opus',
+    model: 'Claude Opus 5',
     effort: 'High',
     brief: 'brief 6k',
-    delta: 0.48,
-    run: 0.5,
+    delta: 0.43,
+    run: 0.48,
   },
   {
     key: 'implementer',
@@ -133,31 +132,32 @@ const STEPS: readonly Step[] = [
     brand: 'codex',
     model: 'GPT-5.6 Sol',
     brief: 'brief 9k',
-    delta: 0.91,
-    run: 1.41,
+    delta: 0.77,
+    run: 1.25,
   },
   {
     key: 'tester',
     role: 'tester',
     tone: 'ro-tester',
     ask: 'fix the tests',
-    brand: 'codex',
-    model: 'GPT-5.6 Terra',
+    brand: 'cursor',
+    model: 'Cursor Opus 5',
+    effort: 'High',
     brief: 'brief 5k',
-    delta: 0.1,
-    run: 1.51,
+    delta: 0.25,
+    run: 1.5,
   },
   {
     key: 'reviewer',
     role: 'reviewer',
     tone: 'reviewer',
     ask: 'review the diff',
-    brand: 'cursor',
-    model: 'Cursor Composer',
-    effort: 'Medium',
+    brand: 'codex',
+    model: 'GPT-5.5',
+    effort: 'High',
     brief: 'brief 7k',
-    delta: 0.14,
-    run: 1.65,
+    delta: 0.28,
+    run: 1.78,
   },
   {
     key: 'resolver',
@@ -165,26 +165,25 @@ const STEPS: readonly Step[] = [
     tone: 'ro-resolver',
     ask: 'rename one label',
     brand: 'anthropic',
-    model: 'Claude Sonnet',
-    effort: 'Low',
+    model: 'Claude Haiku 4.5',
     brief: 'brief 3k',
-    delta: 0.05,
-    run: 1.7,
+    delta: 0.01,
+    run: 1.79,
   },
 ];
 
 const BUDGET_CAP = 3;
 
-const BASE = 600;
-const STEP_MS = 1400;
-const FILL = 1100;
+const BASE = 300;
+const STEP_MS = 660;
+const FILL = 680;
 const MAX = 6.6;
 const FALLBACK_AT = BASE + STEP_MS + FILL;
 const END = BASE + 5 * STEP_MS + FILL;
 
 const rowDelay = (index: number) => BASE + index * STEP_MS;
 
-const blockDelay = (index: number, slot: number) => rowDelay(index) + 140 + slot * 90;
+const blockDelay = (index: number, slot: number) => rowDelay(index) + 110 + slot * 65;
 
 const barWidth = (run: number) => `${Math.max((run / MAX) * 100, 2)}%`;
 
@@ -287,6 +286,9 @@ const RoStep = ({ step, index, rerouted }: StepProps) => (
         Claude hit its limit, GPT-5.6 Sol finished the step
       </span>
     )}
+    {step.key === 'resolver' && (
+      <span className="ro-note ro-calm">Same model as the turn on the left, one short brief</span>
+    )}
   </div>
 );
 
@@ -341,17 +343,18 @@ export const Routing = () => {
           <h2 className="rv" id="h2-routing">
             The same task, two very different bills
           </h2>
-          <p className="sub rv" style={delay(80)}>
+          <p className="sub rv" style={delay(40)}>
             One chat carries every earlier turn into the next, so the last small change costs the
-            most, whatever model does it. A fresh agent per step reads a short brief instead, on the
-            model the step deserves.
+            most, whatever model does it. A fresh agent per step reads a short brief instead. Both
+            columns run the same six tasks on models of comparable weight, so what changes is how
+            much context each agent has to read.
           </p>
         </div>
 
         <div
           className="contrast ro-fig rv"
           data-stage={stage}
-          style={delay(160)}
+          style={delay(80)}
           ref={ref}
           aria-hidden="true"
         >
@@ -388,18 +391,18 @@ export const Routing = () => {
               total
               <span className="ro-cap-label mono">cap {money(BUDGET_CAP)}</span>
               <span className="tot mono" ref={fitRef}>
-                $1.70
+                $1.79
               </span>
             </div>
           </div>
         </div>
-        <p className="caption rv" style={delay(200)}>
+        <p className="caption rv" style={delay(110)}>
           <span className="ro-ill">Illustrative figures.</span> Set a budget and Goodboy taps you on
           the shoulder before you cross it, not after.
         </p>
         <a
           className="more rv"
-          style={delay(220)}
+          style={delay(130)}
           href={`${SITE.concepts}#provider-routing--balance`}
         >
           See how routing works <span className="arr">→</span>

--- a/website/src/sections/Workspace.css
+++ b/website/src/sections/Workspace.css
@@ -49,7 +49,7 @@
   padding: 3px 10px;
   white-space: nowrap;
   opacity: 0;
-  transition: opacity 0.4s ease;
+  transition: opacity 0.58s cubic-bezier(0.2, 0.7, 0.3, 1);
 }
 
 .ws-touched.ws-in {
@@ -67,15 +67,11 @@
   background: color-mix(in oklch, var(--accent-bright) 8%, white);
   border-radius: 14px;
   opacity: 0;
-  transform: translateY(6px);
-  transition:
-    opacity 0.45s ease,
-    transform 0.45s ease;
+  transition: opacity 0.58s cubic-bezier(0.2, 0.7, 0.3, 1);
 }
 
 .ws-goal.ws-in {
   opacity: 1;
-  transform: none;
 }
 
 .ws-goal-label {
@@ -143,11 +139,11 @@
   overflow: hidden;
   text-overflow: ellipsis;
   transition:
-    opacity 0.5s ease,
-    border-color 0.4s ease,
-    color 0.4s ease,
-    background 0.4s ease,
-    box-shadow 0.4s ease;
+    opacity 0.58s cubic-bezier(0.2, 0.7, 0.3, 1),
+    border-color 0.58s cubic-bezier(0.2, 0.7, 0.3, 1),
+    color 0.58s cubic-bezier(0.2, 0.7, 0.3, 1),
+    background 0.58s cubic-bezier(0.2, 0.7, 0.3, 1),
+    box-shadow 0.58s cubic-bezier(0.2, 0.7, 0.3, 1);
 }
 
 .ws-chip.ws-off {
@@ -184,16 +180,12 @@
   color: var(--gray7);
   overflow-wrap: anywhere;
   opacity: 0;
-  transform: translateY(5px);
-  transition:
-    opacity 0.4s ease,
-    transform 0.4s ease;
+  transition: opacity 0.58s cubic-bezier(0.2, 0.7, 0.3, 1);
   transition-delay: var(--d, 0ms);
 }
 
 .ws-row.ws-in {
   opacity: 1;
-  transform: none;
 }
 
 .ws-row.ws-branch {
@@ -259,6 +251,14 @@
 
   .ws-goal-text {
     font-size: 13.5px;
+  }
+
+  .ws-rk {
+    font-size: 10.5px;
+  }
+
+  .ws-row.ws-branch .ws-rv {
+    font-size: 11.5px;
   }
 }
 

--- a/website/src/sections/Workspace.tsx
+++ b/website/src/sections/Workspace.tsx
@@ -21,7 +21,7 @@ const PROJECTS: readonly Project[] = [
 
 const LAST_STEP = 6;
 
-const STEP_AT: readonly number[] = [400, 1400, 2100, 3000, 4300, 5700];
+const STEP_AT: readonly number[] = [380, 1330, 1800, 2220, 2840, 3740];
 
 const CheckGlyph = () => (
   <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.6" aria-hidden="true">
@@ -55,14 +55,14 @@ export const Workspace = () => {
           <h2 className="rv" id="h2-workspace">
             Eight repos, one goal
           </h2>
-          <p className="sub rv" style={delay(80)}>
+          <p className="sub rv" style={delay(40)}>
             Put every repo you work on in one workspace. Describe the goal and{' '}
             <b>Goodboy figures out which projects it touches</b>, opens a branch in each, and comes
             back with a pull request per repo.
           </p>
         </div>
 
-        <div className="ws-frame rv" style={delay(160)} ref={ref} aria-hidden="true">
+        <div className="ws-frame rv" style={delay(80)} ref={ref} aria-hidden="true">
           <div className="ws-body">
             <div className="ws-head">
               <span className="ws-hl">
@@ -88,7 +88,7 @@ export const Workspace = () => {
                   return (
                     <div className="ws-tile" key={project.name}>
                       <span className={cx('ws-chip', lit && 'ws-lit')}>{project.name}</span>
-                      <div className="ws-stack" style={delay(i * 240)}>
+                      <div className="ws-stack" style={delay(i * 160)}>
                         <span className={cx('ws-row', 'ws-branch', step >= 5 && 'ws-in')}>
                           <span className="ws-rk">branch</span>
                           <span className="ws-rv">gb/lin-241-bulk-archive</span>
@@ -113,10 +113,10 @@ export const Workspace = () => {
           </div>
         </div>
 
-        <p className="caption rv" style={delay(200)}>
+        <p className="caption rv" style={delay(110)}>
           The other six stay exactly as they were.
         </p>
-        <a className="more rv" style={delay(220)} href={SITE.concepts}>
+        <a className="more rv" style={delay(130)} href={SITE.concepts}>
           How workspaces work <span className="arr">→</span>
         </a>
       </div>

--- a/website/src/styles.css
+++ b/website/src/styles.css
@@ -168,26 +168,58 @@ h2 {
 
 .rv {
   opacity: 0;
-  transform: translateY(14px);
-  transition:
-    opacity 0.5s cubic-bezier(0.2, 0.7, 0.3, 1),
-    transform 0.5s cubic-bezier(0.2, 0.7, 0.3, 1);
+  transition: opacity 0.58s cubic-bezier(0.2, 0.7, 0.3, 1);
   transition-delay: var(--d, 0ms);
 }
 
 .rv.in {
   opacity: 1;
-  transform: none;
+}
+
+.rvi,
+.rvi-lead {
+  animation-duration: 0.58s;
+  animation-timing-function: cubic-bezier(0.2, 0.7, 0.3, 1);
+  animation-delay: var(--d, 0ms);
+  animation-fill-mode: both;
+}
+
+.rvi {
+  animation-name: rvReveal;
+}
+
+.rvi-lead {
+  animation-name: rvLead;
+}
+
+@keyframes rvReveal {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes rvLead {
+  from {
+    opacity: 0.55;
+  }
+  to {
+    opacity: 1;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
   html {
     scroll-behavior: auto;
   }
-  .rv {
+  .rv,
+  .rvi,
+  .rvi-lead {
     opacity: 1 !important;
-    transform: none !important;
     transition: none !important;
+    animation: none !important;
   }
   * {
     animation: none !important;
@@ -234,15 +266,6 @@ h2 {
   justify-content: center;
   flex-shrink: 0;
   background: var(--brand-tile);
-}
-
-.vtag {
-  font-size: 12px;
-  font-weight: 600;
-  border: 1px solid var(--gray3);
-  border-radius: 8px;
-  padding: 3px 9px;
-  color: var(--gray7);
 }
 
 #top nav {
@@ -301,11 +324,15 @@ h2 {
   #top nav .hidesm {
     display: none;
   }
-  .vtag {
-    display: none;
-  }
   #top nav {
     gap: 16px;
+  }
+  #top nav a {
+    padding-top: 12px;
+    padding-bottom: 12px;
+  }
+  #top nav .btn.small {
+    padding: 13px 18px;
   }
 }
 
@@ -386,7 +413,7 @@ h2 {
 .wallCol {
   display: flex;
   flex-direction: column;
-  animation: wallScroll 60s linear infinite;
+  animation: wallScroll 40s linear infinite;
 }
 
 .wallCol .scard {
@@ -506,19 +533,6 @@ h2 {
   background: oklch(0.95 0.05 78);
   color: var(--warn-text);
 }
-.pill.stage-rev {
-  background: oklch(0.95 0.03 305);
-  color: var(--merged-text);
-}
-.pill.stage-build {
-  background: oklch(0.95 0.03 238);
-  color: var(--info-text);
-}
-.pill.stage-done {
-  background: oklch(0.94 0.04 148);
-  color: var(--ok-text);
-}
-
 .pill.proj {
   font-size: 11px;
   background: var(--gray1);
@@ -602,16 +616,20 @@ h2 {
   display: flex;
   width: max-content;
   padding: 2px 0;
-  animation: beltScroll 46s linear infinite;
+  animation: beltScroll 30s linear infinite;
 }
 
 .belt:hover .beltTrack {
   animation-play-state: paused;
 }
 
+.beltTrackReverse {
+  animation-direction: reverse;
+}
+
 @keyframes beltScroll {
   to {
-    transform: translateX(-50%);
+    transform: translateX(-25%);
   }
 }
 
@@ -722,6 +740,22 @@ section.block.alt {
   font-weight: 500;
   color: var(--gray7);
   pointer-events: none;
+}
+
+@media (max-width: 480px) {
+  .tbar .tl {
+    display: none;
+  }
+
+  .tbar .tname {
+    position: static;
+    flex: 1;
+    min-width: 0;
+    text-align: left;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
 }
 
 .ovmeta {
@@ -846,13 +880,6 @@ section.block.alt {
   color: var(--ok-text);
 }
 
-.pickrow {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  flex-wrap: wrap;
-}
-
 .pick {
   display: inline-flex;
   align-items: center;
@@ -871,12 +898,6 @@ section.block.alt {
   color: var(--gray6);
 }
 
-.pickrow .note {
-  font-size: 12px;
-  color: var(--gray6);
-  font-style: italic;
-}
-
 .gb {
   border-radius: 12px;
   padding: 10px 14px;
@@ -890,93 +911,6 @@ section.block.alt {
   align-self: flex-end;
   background: #e9ecef;
   color: var(--gray7);
-}
-
-.gbrow {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.gbrow.right {
-  align-items: flex-end;
-}
-
-.turncost {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.turncost .tc {
-  margin-left: auto;
-  font-size: 12px;
-  font-variant-numeric: tabular-nums;
-  color: var(--gray6);
-}
-
-.ctxbar {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-}
-
-.ctxbar .track {
-  flex: 1;
-  height: 6px;
-  border-radius: 99px;
-  background: var(--gray1);
-  overflow: hidden;
-}
-
-.ctxbar .cb {
-  display: block;
-  height: 100%;
-  width: 0;
-  border-radius: 99px;
-  background: var(--gray5);
-  transition: width 1s cubic-bezier(0.4, 0, 0.2, 1);
-  transition-delay: var(--d, 0ms);
-}
-
-.ctxbar .cb.warm {
-  background: var(--warn);
-}
-
-.ctxbar .cb.bad {
-  background: var(--danger);
-}
-
-.ctxbar .cl {
-  font-size: 11px;
-  color: var(--gray6);
-  font-variant-numeric: tabular-nums;
-  white-space: nowrap;
-}
-
-.briefrow {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  flex-wrap: wrap;
-}
-
-.briefchip {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  border: 1px solid color-mix(in oklch, var(--accent-bright) 45%, var(--gray3));
-  background: color-mix(in oklch, var(--accent-bright) 7%, white);
-  border-radius: 999px;
-  padding: 5px 13px;
-  font-size: 12px;
-  font-weight: 700;
-  color: var(--accent-deep);
-}
-
-.briefrow .note {
-  font-size: 12px;
-  color: var(--gray6);
 }
 
 .rail {
@@ -994,52 +928,6 @@ section.block.alt {
   bottom: 10px;
   width: 2px;
   background: color-mix(in oklch, var(--accent-bright) 45%, white);
-}
-
-.steprow {
-  position: relative;
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  background: #fff;
-  border: 1px solid var(--gray3);
-  border-radius: 12px;
-  padding: 10px 14px;
-  min-height: 48px;
-}
-
-.steprow.star {
-  border-color: var(--accent-bright);
-}
-
-.steprow .model {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 13px;
-  font-weight: 500;
-  color: var(--gray7);
-  min-width: 0;
-  overflow: hidden;
-}
-
-.steprow .model span:last-child {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.steprow .c {
-  margin-left: auto;
-  font-size: 13px;
-  font-weight: 500;
-  font-variant-numeric: tabular-nums;
-  color: var(--gray6);
-}
-
-.steprow .c.hi {
-  color: var(--warn-text);
-  font-weight: 600;
 }
 
 .eff {
@@ -1105,78 +993,6 @@ section.block.alt {
   font-size: 13px;
   color: var(--gray6);
   max-width: 680px;
-}
-
-.igrid {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 18px;
-  margin-top: 48px;
-  align-items: stretch;
-}
-
-@media (max-width: 900px) {
-  .igrid {
-    grid-template-columns: 1fr 1fr;
-  }
-}
-
-@media (max-width: 560px) {
-  .igrid {
-    grid-template-columns: 1fr;
-  }
-}
-
-.icard.wide {
-  grid-column: span 2;
-}
-
-@media (max-width: 900px) {
-  .icard.wide {
-    grid-column: span 1;
-  }
-}
-
-.icard {
-  background: #fff;
-  border: 1px solid var(--gray3);
-  border-top: 3px solid var(--brand, var(--gray3));
-  border-radius: 16px;
-  padding: 24px;
-  min-height: 200px;
-  display: flex;
-  flex-direction: column;
-}
-
-.icard .ihead {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-}
-
-.icard .ihead svg {
-  color: var(--brand);
-}
-
-.icard h3 {
-  font-family: var(--display);
-  font-weight: 600;
-  font-size: 19px;
-}
-
-.icard p {
-  font-size: 14px;
-  color: var(--gray7);
-  margin-top: 10px;
-}
-
-.icard .flow {
-  margin-top: auto;
-  padding-top: 18px;
-  font-size: 12px;
-  font-weight: 600;
-  font-family: var(--mono);
-  color: var(--gray6);
 }
 
 .dbcard {
@@ -1325,9 +1141,16 @@ section.block.alt {
 
 @media (max-width: 480px) {
   .cmd {
+    align-items: flex-start;
     font-size: 13px;
     padding: 13px 14px;
     gap: 10px;
+  }
+  .cmd > span:not(.p) {
+    white-space: normal;
+    overflow-x: visible;
+    overflow-wrap: anywhere;
+    line-height: 1.5;
   }
   .kb {
     min-width: auto;
@@ -1354,151 +1177,6 @@ section.block.alt {
   display: flex;
   align-items: center;
   justify-content: center;
-}
-
-.hgrid {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 18px;
-  margin-top: 48px;
-  align-items: stretch;
-}
-
-@media (max-width: 980px) {
-  .hgrid {
-    grid-template-columns: 1fr 1fr;
-  }
-}
-
-@media (max-width: 560px) {
-  .hgrid {
-    grid-template-columns: 1fr;
-  }
-}
-
-.hcard {
-  background: #fff;
-  border: 1px solid var(--gray3);
-  border-radius: 16px;
-  padding: 22px;
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-}
-
-.hcard.star {
-  border-color: var(--accent-bright);
-  box-shadow: 0 0 0 4px color-mix(in oklch, var(--accent-bright) 12%, transparent);
-}
-
-.hn {
-  display: flex;
-  gap: 10px;
-  align-items: center;
-}
-
-.hn h3 {
-  font-family: var(--display);
-  font-weight: 600;
-  font-size: 18px;
-  line-height: 1.25;
-}
-
-.hmock {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  gap: 7px;
-}
-
-.hcard .cap {
-  font-size: 13px;
-  color: var(--gray6);
-  line-height: 1.5;
-}
-
-.composeBox {
-  border: 1px solid var(--gray3);
-  border-radius: 12px;
-  padding: 11px 13px;
-  font-size: 13px;
-  display: flex;
-  gap: 10px;
-  align-items: center;
-  background: #fff;
-  box-shadow: 0 1px 3px rgba(16, 17, 19, 0.05);
-}
-
-.composeBox span:first-child {
-  flex: 1;
-  min-width: 0;
-}
-
-.composeHint {
-  font-size: 11px;
-  color: var(--gray6);
-  padding-left: 2px;
-}
-
-.planHead {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 12px;
-  color: var(--gray6);
-  margin-bottom: 2px;
-}
-
-.planRow {
-  display: flex;
-  gap: 9px;
-  align-items: center;
-  font-size: 12.5px;
-  color: var(--gray7);
-  border: 1px solid var(--gray1);
-  border-radius: 9px;
-  padding: 6px 10px;
-  background: #fff;
-}
-
-.planRow .pn {
-  color: var(--accent-deep);
-  font-weight: 700;
-  font-size: 11px;
-  min-width: 54px;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
-
-.mrow {
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
-  font-weight: 600;
-}
-
-.hterm {
-  background: var(--ink);
-  border-radius: 12px;
-  padding: 13px 15px;
-  font-family: var(--mono);
-  font-size: 12px;
-  line-height: 1.85;
-  color: #dee2e6;
-  overflow-x: auto;
-}
-
-.hterm .dim {
-  color: #868e96;
-}
-
-.hterm .tp {
-  color: var(--accent-bright);
-}
-
-.hterm .good {
-  color: oklch(0.8 0.14 148);
 }
 
 footer {


### PR DESCRIPTION
## Why

Lighthouse on the production build scored 68. The score was not the animations: it was third-party JavaScript on the critical path and a hero whose LCP element waited for React to reveal it. Separately, the scripted plays ran 8 to 14 seconds each and several mock claims did not match the product.

## What

**Load path**
- GTM bootstrap deferred to `load` then idle (or first interaction), `dataLayer` and `gtm.start` stay synchronous. TBT 610ms to ~230ms.
- Hero reveal is CSS-only; the LCP paragraph paints from the first frame. LCP 4.6s to 2.0s.
- Score 68 to 94-96 (run variance is the third parties).

**Motion grammar, uniform across the page**
- Every element is present from the first frame in a recessed state and lights on its beat. Only opacity and colour animate. No transforms, size or `grid-template-rows` animations, no stroke-dash draws. CLS stays 0.
- Lit means done: nothing dims after it lights. State is carried by hue (grey vs role accent), not brightness.
- Plays retimed from 8-14s to 3.7-5.5s, one shared 0.58s fade that overlaps the beats.
- Orchestrator mobile variant redesigned around one centre rail; spoke pulses removed.

**Truth against the product**
- `haiku-4.5` has `efforts: []` and `composer-2.5` has `effort: null` in the catalogues, so neither carries an effort pill anywhere any more.
- `suggestLighterModel` skips `costTier: 'cheap'`, so the right-size nudge proposes Sonnet, not Haiku, with the ratio from the real price table.
- Roles shows the tuning axis each model really exposes (Opus five levels, Sonnet three, GPT-5.6 variants, Composer standard/fast, Haiku none).
- Extras rebuilt on the real overview suggestions (`deriveSessionSuggestions`) plus the `RightSizeCard`.
- Routing right column is a cross-provider comparison on models of comparable weight.

**Sections**
- Artifacts split into two distinct frames (terminal vs Goodboy) so the contrast is structural.
- Providers marquee made seamless (four copies, one-sequence translate) with a second tools belt.
- Mobile pass at 360/390/768: titlebar overlap, clipped install command, wrapped chips, tap targets. No horizontal overflow.
- 27 orphan classes from deleted sections removed.

## Verification

- `pnpm build` green. Lighthouse on `vite preview`: 94/91/96 across three runs, LCP 2.0s, CLS 0.
- Codex pre-merge review: five findings fixed (copy claim in Routing, `box-shadow` in two transition lists, Briefing wires mounted after measurement, GTM listener fallback).
- Known gap: the IntersectionObserver-gated parts of Routing (fallback badge, running counter) cannot be exercised headless; verified on the dev server by eye.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
