### PR TITLE
feat(core): add gpt-6 astra to the codex catalog

### DIFF
--- a/apps/desktop/src/features/chat/utils/chat-constants.test.ts
+++ b/apps/desktop/src/features/chat/utils/chat-constants.test.ts
@@ -2,6 +2,15 @@ import { describe, expect, it } from 'vitest';
 import { modelLabel } from './chat-constants';
 
 describe('modelLabel', () => {
+  it('uses the authored Astra label for its catalog key and cli id', () => {
+    expect(modelLabel('gpt-6')).toBe('Astra');
+    expect(modelLabel('gpt-6-astra')).toBe('Astra');
+  });
+
+  it('formats an unrecognized Astra effort suffix as an unknown id', () => {
+    expect(modelLabel('gpt-6-astra-high')).toBe('GPT 6 Astra High');
+  });
+
   it('keeps the version number intact for gpt effort variants', () => {
     expect(modelLabel('gpt-5.6-high')).toBe('GPT 5.6 High');
   });

--- a/apps/desktop/src/features/providers/pricing.json
+++ b/apps/desktop/src/features/providers/pricing.json
@@ -11,6 +11,7 @@
     "claude-haiku-4-5": { "inputPerMtok": 1, "outputPerMtok": 5, "cachedInputPerMtok": 0.1 }
   },
   "codex": {
+    "gpt-6-astra": { "inputPerMtok": 10, "outputPerMtok": 50, "cachedInputPerMtok": 1 },
     "gpt-5.6-sol": { "inputPerMtok": 5, "outputPerMtok": 30, "cachedInputPerMtok": 0.5 },
     "gpt-5.6-terra": { "inputPerMtok": 2.5, "outputPerMtok": 15, "cachedInputPerMtok": 0.25 },
     "gpt-5.6-luna": { "inputPerMtok": 1, "outputPerMtok": 6, "cachedInputPerMtok": 0.1 },

--- a/apps/desktop/src/features/providers/provider-pricing.test.ts
+++ b/apps/desktop/src/features/providers/provider-pricing.test.ts
@@ -34,6 +34,14 @@ describe('getActivePricingTable', () => {
 });
 
 describe('getCodexPriceOverride', () => {
+  it('returns the standard Astra rates', () => {
+    expect(getCodexPriceOverride(null, 'gpt-6-astra')).toEqual({
+      inputPerMtok: 10,
+      outputPerMtok: 50,
+      cachedInputPerMtok: 1,
+    });
+  });
+
   it('returns null for unknown model', () => {
     expect(getCodexPriceOverride(null, 'unknown-model-xyz')).toBeNull();
   });

--- a/apps/desktop/src/shared/components/RoutingPicker/index.test.tsx
+++ b/apps/desktop/src/shared/components/RoutingPicker/index.test.tsx
@@ -317,6 +317,28 @@ describe('RoutingPicker', () => {
     expect(onModel).toHaveBeenCalledWith('gpt-5.6-luna');
   });
 
+  it('selects Astra from Sol and emits its cli id and requested effort', () => {
+    const onModel = vi.fn();
+    const onChange = vi.fn();
+    render(
+      <RoutingPicker
+        {...baseProps}
+        provider="codex"
+        model="gpt-5.6-sol"
+        onModel={onModel}
+        effort={{ editable: true, value: 'low', onChange }}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /routing/i }));
+    fireEvent.click(screen.getByRole('button', { name: '6' }));
+    expect(onModel).toHaveBeenCalledWith('gpt-6-astra');
+    expect(screen.getByRole('contentinfo').textContent).toBe(
+      '-m gpt-6-astra -c model_reasoning_effort="low"',
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Max' }));
+    expect(onChange).toHaveBeenCalledWith('max');
+  });
+
   it('shows the Codex variant row only for a family with sibling checkpoints', () => {
     const view = render(<RoutingPicker {...baseProps} provider="codex" model="gpt-5.6-sol" />);
     fireEvent.click(screen.getByRole('button', { name: /routing/i }));

--- a/docs/mock-screenshots.md
+++ b/docs/mock-screenshots.md
@@ -97,7 +97,7 @@ component instead of a gap in the mock.
   `run.providerOverride` on the `Agent` object when the
   `agentModelOverride`/`agentProviderOverride` prop maps are empty. Use real
   ids from `packages/core/src/providers/*/catalog.ts` (e.g. cursor's
-  `composer-2.5-fast`, codex's `gpt-5.6-sol`), not invented strings; the
+  `composer-2.5-fast`, codex's `gpt-6-astra` or `gpt-5.6-sol`), not invented strings; the
   catalog is what `RoutingBadge` and the model picker resolve labels from.
 - **Fan-out / sub-agents** render via `WorkflowStepGraph`'s
   `childrenByParentId: ReadonlyMap<string, ReadonlyArray<Agent>>` prop, keyed

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -133,7 +133,7 @@ is `providers/claude/catalog.ts`.
 
 What the catalogs do not tell you:
 
-- Cursor's accepted slugs are recorded in `providers/cursor/agent-model-ids.ts`; the curated subset
+- Cursor's accepted slugs are recorded in `packages/core/src/providers/cursor/agent-model-ids.ts`; the curated subset
   is pinned against that list by
   `packages/core/src/providers/cursor/agent-model-ids.test.ts`. Cursor bakes
   effort into the slug, so it never receives an effort flag and its reachable

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -133,7 +133,7 @@ is `providers/claude/catalog.ts`.
 
 What the catalogs do not tell you:
 
-- Cursor surfaces 193 slugs via `cursor-agent --list-models`; the curated subset
+- Cursor's accepted slugs are recorded in `providers/cursor/agent-model-ids.ts`; the curated subset
   is pinned against that list by
   `packages/core/src/providers/cursor/agent-model-ids.test.ts`. Cursor bakes
   effort into the slug, so it never receives an effort flag and its reachable

--- a/packages/core/src/providers/auto-model.test.ts
+++ b/packages/core/src/providers/auto-model.test.ts
@@ -56,7 +56,7 @@ describe('autoModelForRole', () => {
     it('picks the expensive codex model for a high-tier role', () => {
       expect(autoModelForRole({ role: 'planner', providers: ['codex'] })).toEqual({
         provider: 'codex',
-        model: 'gpt-5.6',
+        model: 'gpt-6',
       });
     });
 

--- a/packages/core/src/providers/catalog.test.ts
+++ b/packages/core/src/providers/catalog.test.ts
@@ -165,8 +165,21 @@ describe('model catalogs', () => {
   it('keeps a bare Codex family id unrepresentable', () => {
     const emitted = codexCatalogIds({});
     expect(emitted).not.toContain('gpt-5.6');
+    expect(emitted).not.toContain('gpt-6');
     expect(emitted).toEqual(CODEX_AGENT_MODEL_IDS);
   });
+
+  it.each(['low', 'medium', 'high', 'xhigh', 'max'] satisfies ReadonlyArray<EffortLevel>)(
+    'emits the Astra cli id with %s effort',
+    (effort) => {
+      expect(
+        resolveModelArgs({
+          provider: 'codex',
+          selection: { key: 'gpt-6', variant: 'astra', effort },
+        }),
+      ).toEqual({ args: ['-m', 'gpt-6-astra', '-c', `model_reasoning_effort="${effort}"`] });
+    },
+  );
 
   it('throws when a provider cannot recognize a model key', () => {
     expect(() =>

--- a/packages/core/src/providers/catalogDescriptor.test.ts
+++ b/packages/core/src/providers/catalogDescriptor.test.ts
@@ -6,6 +6,18 @@ import { catalogDescriptor } from './catalogDescriptor';
 const NON_ANTHROPIC_WEIGHT_CEILING = 30;
 
 describe('catalogDescriptor weights', () => {
+  it('ranks Astra one notch above Sol and below Fable 5.1', () => {
+    const astra = MODEL_CATALOGS.codex.find((model) => model.key === 'gpt-6');
+    const sol = MODEL_CATALOGS.codex.find((model) => model.key === 'gpt-5.6');
+    const fable = MODEL_CATALOGS.anthropic.find((model) => model.key === 'fable-5.1');
+    if (astra == null || sol == null || fable == null) {
+      throw new Error('missing routing weight models');
+    }
+    expect(catalogDescriptor({ model: astra }).weight).toBe(29);
+    expect(catalogDescriptor({ model: sol }).weight).toBe(28);
+    expect(catalogDescriptor({ model: fable }).weight).toBe(95);
+  });
+
   it('keeps every non-anthropic model below the implementer band', () => {
     for (const provider of PROVIDER_IDS) {
       for (const model of MODEL_CATALOGS[provider]) {

--- a/packages/core/src/providers/catalogDescriptor.ts
+++ b/packages/core/src/providers/catalogDescriptor.ts
@@ -17,6 +17,7 @@ const WEIGHT_BY_KEY: Readonly<Record<string, number>> = {
   'sonnet-4.6': 15,
   'sonnet-4.5': 14,
   'haiku-4.5': 5,
+  'gpt-6': 29,
   'gpt-5.6': 28,
   'gpt-5.5': 25,
   'gpt-5.4': 22,

--- a/packages/core/src/providers/codex/agent-model-ids.ts
+++ b/packages/core/src/providers/codex/agent-model-ids.ts
@@ -2,6 +2,7 @@ export const CODEX_AGENT_MODEL_IDS = [
   'gpt-5.6-sol',
   'gpt-5.6-terra',
   'gpt-5.6-luna',
+  'gpt-6-astra',
   'gpt-5.5',
   'gpt-5.4',
   'gpt-5.4-mini',

--- a/packages/core/src/providers/codex/catalog.ts
+++ b/packages/core/src/providers/codex/catalog.ts
@@ -26,6 +26,23 @@ export const CODEX_CATALOG = [
     defaultEffort: 'low',
   },
   {
+    key: 'gpt-6',
+    label: 'Astra',
+    tier: 'turn',
+    contextWindow: 1_000_000,
+    presentation: {
+      family: 'gpt',
+      group: 'GPT',
+      version: '6',
+      order: 23,
+      costTier: 'expensive',
+    },
+    provider: 'codex',
+    variants: [{ id: 'astra', label: 'Astra', cliId: 'gpt-6-astra' }],
+    efforts: FULL_EFFORTS,
+    defaultEffort: 'low',
+  },
+  {
     key: 'gpt-5.5',
     label: 'GPT-5.5',
     tier: 'turn',

--- a/packages/core/src/providers/codex/cost.test.ts
+++ b/packages/core/src/providers/codex/cost.test.ts
@@ -11,6 +11,33 @@ const usage: ProviderUsage = {
 };
 
 describe('computeCodexCostUsd', () => {
+  it('prices Astra input and output at the standard rates', () => {
+    expect(CODEX_PRICES['gpt-6-astra']).toEqual({
+      inputPerMtok: 10,
+      outputPerMtok: 50,
+      cachedInputPerMtok: 1,
+    });
+    expect(computeCodexCostUsd({ usage, model: 'gpt-6-astra' })).toBeCloseTo(60);
+  });
+
+  it('bills Astra cache reads separately from uncached input', () => {
+    expect(
+      computeCodexCostUsd({
+        usage: { ...usage, inputTokens: 2_000_000, cachedInputTokens: 1_000_000, outputTokens: 0 },
+        model: 'gpt-6-astra',
+      }),
+    ).toBeCloseTo(11);
+  });
+
+  it('bills Astra cache writes at 12.50 per million tokens', () => {
+    expect(
+      computeCodexCostUsd({
+        usage: { ...usage, inputTokens: 0, outputTokens: 0, cacheCreationInputTokens: 1_000_000 },
+        model: 'gpt-6-astra',
+      }),
+    ).toBeCloseTo(12.5);
+  });
+
   it('prices every catalog cli id', () => {
     const modelIds = CODEX_CATALOG.flatMap((model) =>
       model.variants.map((variant) => variant.cliId),

--- a/packages/core/src/providers/codex/cost.ts
+++ b/packages/core/src/providers/codex/cost.ts
@@ -7,6 +7,11 @@ export type CodexModelPriceOverride = {
 };
 
 export const CODEX_PRICES: Readonly<Record<string, CodexModelPriceOverride>> = {
+  'gpt-6-astra': {
+    inputPerMtok: 10,
+    outputPerMtok: 50,
+    cachedInputPerMtok: 1,
+  },
   'gpt-5.6-sol': {
     inputPerMtok: 5,
     outputPerMtok: 30,

--- a/packages/core/src/providers/cost-coverage.test.ts
+++ b/packages/core/src/providers/cost-coverage.test.ts
@@ -27,6 +27,7 @@ describe('costCoverage', () => {
   });
 
   it('reports codex as measured for a priced model and unpriced otherwise', () => {
+    expect(costCoverage({ provider: 'codex', model: 'gpt-6-astra' })).toBe('measured');
     expect(costCoverage({ provider: 'codex', model: 'gpt-5.6-sol' })).toBe('measured');
     expect(costCoverage({ provider: 'codex', model: 'unknown-codex-model' })).toBe('unpriced');
   });

--- a/packages/core/src/providers/model-display.test.ts
+++ b/packages/core/src/providers/model-display.test.ts
@@ -2,6 +2,18 @@ import { describe, expect, it } from 'vitest';
 import { getModelDescriptor, getModelProvider } from './model-display';
 
 describe('provider model display', () => {
+  it('resolves Astra presentation from its cli id', () => {
+    expect(getModelProvider('gpt-6-astra')).toBe('codex');
+    expect(getModelDescriptor('gpt-6-astra')).toMatchObject({
+      id: 'gpt-6',
+      label: 'Astra',
+      family: 'gpt',
+      variantLabel: '6',
+      contextWindow: 1_000_000,
+      costTier: 'expensive',
+    });
+  });
+
   it('resolves OpenCode models', () => {
     expect(getModelProvider('opencode/big-pickle')).toBe('opencode');
     expect(getModelDescriptor('opencode/big-pickle')?.id).toBe('big-pickle');

--- a/packages/core/src/providers/model-price.test.ts
+++ b/packages/core/src/providers/model-price.test.ts
@@ -33,6 +33,7 @@ describe('getModelPrice', () => {
   });
 
   it('returns codex pricing for catalog cli ids', () => {
+    expect(getModelPrice('gpt-6-astra')).toEqual({ inputPerMtok: 10, outputPerMtok: 50 });
     expect(getModelPrice('gpt-5.5')).toEqual({ inputPerMtok: 5, outputPerMtok: 30 });
     expect(getModelPrice('gpt-5.4-mini')).toEqual({ inputPerMtok: 0.75, outputPerMtok: 4.5 });
   });
@@ -65,6 +66,7 @@ describe('getModelPrice', () => {
   });
 
   it.each([
+    ['gpt-6', 'gpt-6-astra'],
     ['gpt-5.6', 'gpt-5.6-sol'],
     ['opus-5', 'claude-opus-5'],
     ['sonnet-4.6', 'claude-sonnet-4-6'],

--- a/packages/core/src/providers/modelAxes.test.ts
+++ b/packages/core/src/providers/modelAxes.test.ts
@@ -9,6 +9,24 @@ import { OPENROUTER_CATALOG } from './openrouter/catalog';
 import { selectionRequiresMaxMode } from './selectionRequiresMaxMode';
 
 describe('modelAxes', () => {
+  it('offers Astra as the newest GPT version with the full Codex effort ladder', () => {
+    const model = CODEX_CATALOG.find((candidate) => candidate.key === 'gpt-6');
+    if (model == null) {
+      throw new Error('missing codex Astra');
+    }
+    const axes = modelAxes({ model, selection: { key: model.key, variant: 'astra' } });
+    expect(axes.model.options).toContainEqual({ id: 'GPT', label: 'GPT', modelKey: 'gpt-6' });
+    expect(axes.version?.options).toContainEqual({ id: 'gpt-6', label: '6', modelKey: 'gpt-6' });
+    expect(axes.effort?.levels).toEqual([
+      { level: 'low', available: true },
+      { level: 'medium', available: true },
+      { level: 'high', available: true },
+      { level: 'xhigh', available: true },
+      { level: 'max', available: true },
+    ]);
+    expect(axes.variant).toBeNull();
+  });
+
   it('changes cursor effort availability with the thinking toggle', () => {
     const model = CURSOR_CATALOG.find((candidate) => candidate.key === 'opus-5');
     if (model == null) {

--- a/packages/core/src/providers/parseLegacyId.test.ts
+++ b/packages/core/src/providers/parseLegacyId.test.ts
@@ -3,6 +3,23 @@ import { parseLegacyId } from './parseLegacyId';
 import { resolveStoredModelSelection } from './resolveStoredModelSelection';
 
 describe('parseLegacyId', () => {
+  it('maps the bare Astra family id with its requested effort', () => {
+    expect(parseLegacyId({ provider: 'codex', id: 'gpt-6', effort: 'max' })).toEqual({
+      key: 'gpt-6',
+      variant: 'astra',
+      effort: 'max',
+    });
+  });
+
+  it('recognizes stored Astra cli ids without falling back to Sol', () => {
+    expect(
+      resolveStoredModelSelection({ provider: 'codex', id: 'gpt-6-astra', effort: 'max' }),
+    ).toEqual({
+      selection: { key: 'gpt-6', variant: 'astra', effort: 'max' },
+      report: null,
+    });
+  });
+
   it('maps shipped legacy ids to structured selections', () => {
     expect(parseLegacyId({ provider: 'anthropic', id: 'claude-sonnet-4-6' })).toEqual({
       key: 'sonnet-4.6',

--- a/packages/core/src/providers/parseLegacyId.ts
+++ b/packages/core/src/providers/parseLegacyId.ts
@@ -55,6 +55,7 @@ const LEGACY_SELECTIONS: Readonly<Record<string, ModelSelection>> = {
     key: 'gpt-5.3-codex',
     toggles: { thinking: false, fast: false },
   },
+  'codex:gpt-6': { key: 'gpt-6', variant: 'astra' },
   'codex:gpt-5.6': { key: 'gpt-5.6', variant: 'sol' },
   'codex:gpt-5.5': { key: 'gpt-5.5', variant: 'default' },
   'codex:gpt-5.4': { key: 'gpt-5.4', variant: 'default' },

--- a/packages/core/src/providers/planTurnFallback.test.ts
+++ b/packages/core/src/providers/planTurnFallback.test.ts
@@ -22,7 +22,7 @@ const ROWS: ReadonlyArray<Row> = [
     model: 'opus-5',
     attempt: 0,
     connectedProviders: CONNECTED,
-    expected: { provider: 'codex', model: 'gpt-5.6' },
+    expected: { provider: 'codex', model: 'gpt-6' },
   },
   {
     name: 'authentication gives up when no other provider is connected',
@@ -58,7 +58,7 @@ const ROWS: ReadonlyArray<Row> = [
     model: 'opus-5',
     attempt: 1,
     connectedProviders: CONNECTED,
-    expected: { provider: 'codex', model: 'gpt-5.6' },
+    expected: { provider: 'codex', model: 'gpt-6' },
   },
   {
     name: 'an account usage limit crosses to another provider on the first attempt',
@@ -67,7 +67,7 @@ const ROWS: ReadonlyArray<Row> = [
     model: 'opus-5',
     attempt: 0,
     connectedProviders: CONNECTED,
-    expected: { provider: 'codex', model: 'gpt-5.6' },
+    expected: { provider: 'codex', model: 'gpt-6' },
   },
   {
     name: 'an account usage limit gives up when no other provider is connected',
@@ -94,7 +94,7 @@ const ROWS: ReadonlyArray<Row> = [
     model: 'opus-5',
     attempt: 1,
     connectedProviders: CONNECTED,
-    expected: { provider: 'codex', model: 'gpt-5.6' },
+    expected: { provider: 'codex', model: 'gpt-6' },
   },
   {
     name: 'model not available swaps to the nearest sibling on the same provider',
@@ -104,6 +104,15 @@ const ROWS: ReadonlyArray<Row> = [
     attempt: 0,
     connectedProviders: CONNECTED,
     expected: { provider: 'anthropic', model: 'fable-5' },
+  },
+  {
+    name: 'model not available falls back from Astra to Sol on the same provider',
+    failure: 'model_not_available',
+    provider: 'codex',
+    model: 'gpt-6',
+    attempt: 0,
+    connectedProviders: CONNECTED,
+    expected: { provider: 'codex', model: 'gpt-5.6' },
   },
   {
     name: 'model not available crosses providers on the second attempt',
@@ -192,7 +201,7 @@ describe('planTurnFallback', () => {
         connectedProviders: CONNECTED,
         preferred: { provider: 'codex', model: 'gpt-5.4-mini' },
       }),
-    ).toEqual({ provider: 'codex', model: 'gpt-5.6' });
+    ).toEqual({ provider: 'codex', model: 'gpt-6' });
   });
 
   it('degrades to the heuristic when the role fallback provider is not connected', () => {
@@ -244,7 +253,7 @@ describe('planTurnFallback', () => {
         connectedProviders: CONNECTED,
         preferred: { provider: 'anthropic', model: 'haiku-4.5' },
       }),
-    ).toEqual({ provider: 'codex', model: 'gpt-5.6' });
+    ).toEqual({ provider: 'codex', model: 'gpt-6' });
   });
 
   it('keeps a role fallback on another provider for an account usage limit', () => {


### PR DESCRIPTION
## Summary
- adds OpenAI GPT-6 Astra (`gpt-6-astra`, codex CLI >= 0.153) to the codex catalog mirroring Sol: descriptor with effort variants, agent model ids, legacy id parsing
- pricing 10 / 50 per M tokens, cached input 1; routing weight 29 (one notch above Sol) so high-tier codex roles pick Astra with Sol as next fallback
- desktop pricing table and provider docs updated; `CODEX_DEFAULT_MODEL` unchanged; Cursor catalog untouched

## Test plan
- [x] `pnpm vitest run` in packages/core (1264 passed)
- [x] desktop suites referencing codex ids (226 passed)
- [x] `tsc --noEmit` on packages/core

🤖 Generated with [Claude Code](https://claude.com/claude-code)