### PR TITLE
test(ui): freeze the clock in the inbox rail sections test

### DIFF
--- a/apps/desktop/src/features/inbox/components/InboxStudio/InboxRail.test.tsx
+++ b/apps/desktop/src/features/inbox/components/InboxStudio/InboxRail.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { InboxProvider, InboxRecord } from '../../types';
 import { InboxRail } from './InboxRail';
 
@@ -45,7 +45,9 @@ const record = ({
   },
 });
 
-const now = Date.now();
+const FIXED_NOW = Date.UTC(2024, 0, 15, 12, 0, 0);
+
+const now = FIXED_NOW;
 
 const todayRecord = record({
   key: 'a',
@@ -114,7 +116,15 @@ const renderRail = ({
     />,
   );
 
-afterEach(() => cleanup());
+beforeEach(() => {
+  vi.useFakeTimers({ toFake: ['Date'] });
+  vi.setSystemTime(FIXED_NOW);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
 
 describe('InboxRail', () => {
   it('labels every provider chip with its count', () => {


### PR DESCRIPTION
## Summary
- `InboxRail.test.tsx` built its today/yesterday fixtures from the real `Date.now()`, and the component buckets by local calendar day: near UTC midnight the today record slid into yesterday and the Today section vanished (failed twice on CI at 00:2x UTC on #1671, passes in Europe/Rome)
- the test now freezes the clock at noon UTC with fake timers and derives every fixture from that instant; production helper `groupRecordsByAge` is unchanged and already unit-tested with an injected now

## Test plan
- [x] `TZ=UTC` and `TZ=Europe/Rome` runs of the file (10/10 each)
- [x] `pnpm vitest run src/features/inbox` (110 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)