### PR TITLE
fix(ui): let the inbox show nothing selected

### DIFF
--- a/apps/desktop/src/features/inbox/components/InboxStudio/InboxDetail.test.tsx
+++ b/apps/desktop/src/features/inbox/components/InboxStudio/InboxDetail.test.tsx
@@ -1,13 +1,22 @@
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { ReactNode } from 'react';
 import type { WorkspaceId } from '@goodboy/types';
 import type { InboxRecord } from '../../types';
 
 vi.mock('../../../github/GithubIssueDetail', () => ({
-  GithubIssueDetail: ({ issue, dock }: { issue: { title: string }; dock: ReactNode }) => (
+  GithubIssueDetail: ({
+    issue,
+    dock,
+    headerActions,
+  }: {
+    issue: { title: string };
+    dock: ReactNode;
+    headerActions: ReactNode;
+  }) => (
     <div data-testid="panel">
       github-issue:{issue.title}
+      {headerActions}
       {dock}
     </div>
   ),
@@ -110,11 +119,20 @@ const baseErrors = {
   bitbucket: null,
 };
 
-const renderDetail = (record: InboxRecord | null) =>
+const onDeselect = vi.fn();
+
+type RenderPaneParams = {
+  readonly record: InboxRecord | null;
+  readonly records?: ReadonlyArray<InboxRecord>;
+  readonly hasVisibleRecords?: boolean;
+};
+
+const renderPane = ({ record, records, hasVisibleRecords = false }: RenderPaneParams) =>
   render(
     <InboxDetail
       record={record}
-      records={record == null ? [] : [record]}
+      records={records ?? (record == null ? [] : [record])}
+      hasVisibleRecords={hasVisibleRecords}
       hasFiltersActive={false}
       workspaceId={workspaceId}
       rootPath="/repo"
@@ -122,13 +140,45 @@ const renderDetail = (record: InboxRecord | null) =>
       errors={baseErrors}
       onRefresh={vi.fn()}
       onClose={vi.fn()}
+      onDeselect={onDeselect}
       launchFocusRequest={0}
       onClearFilters={vi.fn()}
       onOpenIntegrations={vi.fn()}
     />,
   );
 
-afterEach(() => cleanup());
+const renderDetail = (record: InboxRecord | null) => renderPane({ record });
+
+const githubRecord: InboxRecord = {
+  key: 'github:issue:1',
+  provider: 'github',
+  kind: 'issue',
+  identifier: '#1',
+  title: 'github item',
+  state: 'open',
+  updatedAt: '2026-08-01T10:00:00Z',
+  url: '',
+  meta: 'GitHub',
+  payload: {
+    provider: 'github',
+    kind: 'issue',
+    issue: {
+      number: 1,
+      title: 'github item',
+      body: '',
+      url: '',
+      state: 'OPEN',
+      labels: [],
+      updatedAt: '',
+    },
+    sessionId: null,
+  },
+};
+
+afterEach(() => {
+  cleanup();
+  onDeselect.mockReset();
+});
 
 describe('InboxDetail', () => {
   it('summarises the inbox when nothing is selected', () => {
@@ -139,35 +189,27 @@ describe('InboxDetail', () => {
     expect(screen.queryByTestId('panel')).toBeNull();
   });
 
+  it('invites a pick when items are listed and none is selected', () => {
+    renderPane({ record: null, records: [], hasVisibleRecords: true });
+
+    expect(screen.getByText('Nothing selected')).toBeDefined();
+    expect(screen.queryByRole('button', { name: 'Open integrations' })).toBeNull();
+    expect(screen.queryByTestId('panel')).toBeNull();
+  });
+
   it('renders the github issue panel', () => {
-    renderDetail({
-      key: 'github:issue:1',
-      provider: 'github',
-      kind: 'issue',
-      identifier: '#1',
-      title: 'github item',
-      state: 'open',
-      updatedAt: '2026-08-01T10:00:00Z',
-      url: '',
-      meta: 'GitHub',
-      payload: {
-        provider: 'github',
-        kind: 'issue',
-        issue: {
-          number: 1,
-          title: 'github item',
-          body: '',
-          url: '',
-          state: 'OPEN',
-          labels: [],
-          updatedAt: '',
-        },
-        sessionId: null,
-      },
-    });
+    renderDetail(githubRecord);
 
     expect(screen.getByTestId('panel').textContent).toContain('github-issue:github item');
     expect(screen.getByTestId('dock')).toBeDefined();
+  });
+
+  it('closes the selected record from the detail header', () => {
+    renderDetail(githubRecord);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close the item' }));
+
+    expect(onDeselect).toHaveBeenCalledTimes(1);
   });
 
   it('renders the gitlab issue panel', () => {

--- a/apps/desktop/src/features/inbox/components/InboxStudio/InboxDetail.tsx
+++ b/apps/desktop/src/features/inbox/components/InboxStudio/InboxDetail.tsx
@@ -1,3 +1,5 @@
+import { IconButton } from '@goodboy/ui';
+import { X } from 'lucide-react';
 import type { WorkspaceId } from '@goodboy/types';
 import { GithubIssueDetail } from '../../../github/GithubIssueDetail';
 import { GitlabIssueDetail } from '../../../integrations/gitlab/GitlabIssueDetail';
@@ -15,6 +17,7 @@ import { InboxEmptySummary } from './InboxEmptySummary';
 type Props = {
   readonly record: InboxRecord | null;
   readonly records: ReadonlyArray<InboxRecord>;
+  readonly hasVisibleRecords: boolean;
   readonly hasFiltersActive: boolean;
   readonly workspaceId: WorkspaceId;
   readonly rootPath: string;
@@ -22,6 +25,7 @@ type Props = {
   readonly errors: Readonly<Record<InboxProvider, string | null>>;
   readonly onRefresh: () => void;
   readonly onClose: () => void;
+  readonly onDeselect: () => void;
   readonly onClearFilters: () => void;
   readonly onOpenIntegrations: () => void;
   readonly launchFocusRequest: number;
@@ -30,6 +34,7 @@ type Props = {
 export const InboxDetail = ({
   record,
   records,
+  hasVisibleRecords,
   hasFiltersActive,
   workspaceId,
   rootPath,
@@ -37,6 +42,7 @@ export const InboxDetail = ({
   errors,
   onRefresh,
   onClose,
+  onDeselect,
   onClearFilters,
   onOpenIntegrations,
   launchFocusRequest,
@@ -48,6 +54,7 @@ export const InboxDetail = ({
     return (
       <InboxEmptySummary
         records={records}
+        hasVisibleRecords={hasVisibleRecords}
         hasFiltersActive={hasFiltersActive}
         onClearFilters={onClearFilters}
         onOpenIntegrations={onOpenIntegrations}
@@ -56,6 +63,14 @@ export const InboxDetail = ({
   }
 
   const payload = record.payload;
+  const deselectAction = (
+    <IconButton
+      icon={X}
+      label="Close the item"
+      tooltip="Back to the inbox summary"
+      onClick={onDeselect}
+    />
+  );
 
   switch (payload.provider) {
     case 'github':
@@ -63,6 +78,7 @@ export const InboxDetail = ({
         <GithubIssueDetail
           issue={payload.issue}
           editContext={{ workspaceId, rootPath }}
+          headerActions={deselectAction}
           dock={
             <RecordLaunchDock
               record={record}
@@ -80,6 +96,7 @@ export const InboxDetail = ({
             <GitlabIssueDetail
               issue={payload.issue}
               workspaceId={workspaceId}
+              headerActions={deselectAction}
               dock={
                 <RecordLaunchDock
                   record={record}
@@ -98,6 +115,7 @@ export const InboxDetail = ({
               host={payload.host}
               onRefresh={onRefresh}
               onClose={onClose}
+              headerActions={deselectAction}
               dock={
                 <RecordLaunchDock
                   record={record}
@@ -118,6 +136,7 @@ export const InboxDetail = ({
         <LinearIssueDetail
           issue={payload.issue}
           workspaceId={workspaceId}
+          headerActions={deselectAction}
           dock={
             <RecordLaunchDock
               record={record}
@@ -134,6 +153,7 @@ export const InboxDetail = ({
           issue={payload.issue}
           workspaceId={workspaceId}
           onIssueWritten={onRefresh}
+          headerActions={deselectAction}
           dock={
             <RecordLaunchDock
               record={record}
@@ -163,6 +183,7 @@ export const InboxDetail = ({
           summaryIsLoading={false}
           summaryError={null}
           onRetrySummary={() => undefined}
+          headerActions={deselectAction}
           dock={
             <RecordLaunchDock
               record={record}
@@ -182,6 +203,7 @@ export const InboxDetail = ({
           fallbackChannelName={payload.channel.name}
           fallbackMessage={payload.head}
           fallbackUrl={record.url}
+          headerActions={deselectAction}
           dock={
             <RecordLaunchDock
               record={record}
@@ -203,6 +225,7 @@ export const InboxDetail = ({
           error={errors.bitbucket}
           onRefresh={onRefresh}
           onClose={onClose}
+          headerActions={deselectAction}
           dock={
             <RecordLaunchDock
               record={record}

--- a/apps/desktop/src/features/inbox/components/InboxStudio/InboxEmptySummary.tsx
+++ b/apps/desktop/src/features/inbox/components/InboxStudio/InboxEmptySummary.tsx
@@ -10,17 +10,48 @@ import { ICON_SIZE } from '../../../../shared/components/conceptIcons';
 
 type Props = {
   readonly records: ReadonlyArray<InboxRecord>;
+  readonly hasVisibleRecords: boolean;
   readonly hasFiltersActive: boolean;
   readonly onClearFilters: () => void;
   readonly onOpenIntegrations: () => void;
 };
 
+type Reason = 'nothing-connected' | 'no-matches' | 'no-selection';
+
+type ReasonCopy = {
+  readonly title: string;
+  readonly description: string;
+};
+
+const REASON_COPY: Record<Reason, ReasonCopy> = {
+  'nothing-connected': {
+    title: 'Inbox is empty',
+    description: 'Connect a provider to collect issues, reviews, threads and errors here.',
+  },
+  'no-matches': {
+    title: 'No matching items',
+    description: 'Adjust the filters to bring items back into the list.',
+  },
+  'no-selection': {
+    title: 'Nothing selected',
+    description: 'Pick an item from the list to open it here.',
+  },
+};
+
 export const InboxEmptySummary = ({
   records,
+  hasVisibleRecords,
   hasFiltersActive,
   onClearFilters,
   onOpenIntegrations,
 }: Props) => {
+  const reason: Reason = ((): Reason => {
+    if (hasVisibleRecords) {
+      return 'no-selection';
+    }
+    return records.length === 0 && !hasFiltersActive ? 'nothing-connected' : 'no-matches';
+  })();
+  const copy = REASON_COPY[reason];
   const counts = kindFilterCounts({ records });
   const providerCounts = INBOX_PROVIDERS.map((provider) => ({
     provider,
@@ -33,14 +64,8 @@ export const InboxEmptySummary = ({
         <div className={cn('flex flex-col gap-6', PANE_RHYTHM.body)}>
           <div className="flex flex-col gap-2">
             <Eyebrow label="Inbox summary" />
-            <h2 className="text-lg font-semibold text-foreground">
-              {hasFiltersActive ? 'No matching items' : 'Inbox is empty'}
-            </h2>
-            <p className="max-w-2xl text-sm text-muted-foreground">
-              {hasFiltersActive
-                ? 'Adjust the filters to bring items back into the list.'
-                : 'Connect a provider to collect issues, reviews, threads and errors here.'}
-            </p>
+            <h2 className="text-lg font-semibold text-foreground">{copy.title}</h2>
+            <p className="max-w-2xl text-sm text-muted-foreground">{copy.description}</p>
           </div>
 
           <div className="grid grid-cols-2 gap-4 xl:grid-cols-4">
@@ -91,17 +116,19 @@ export const InboxEmptySummary = ({
             </div>
           ) : null}
 
-          <div className="flex items-center gap-2">
-            {hasFiltersActive ? (
-              <Button variant="secondary" size="sm" onClick={onClearFilters}>
-                Clear filters
-              </Button>
-            ) : (
-              <Button variant="secondary" size="sm" onClick={onOpenIntegrations}>
-                Open integrations
-              </Button>
-            )}
-          </div>
+          {reason === 'no-selection' ? null : (
+            <div className="flex items-center gap-2">
+              {reason === 'no-matches' ? (
+                <Button variant="secondary" size="sm" onClick={onClearFilters}>
+                  Clear filters
+                </Button>
+              ) : (
+                <Button variant="secondary" size="sm" onClick={onOpenIntegrations}>
+                  Open integrations
+                </Button>
+              )}
+            </div>
+          )}
         </div>
       </ScrollFade>
     </div>

--- a/apps/desktop/src/features/inbox/components/InboxStudio/index.test.tsx
+++ b/apps/desktop/src/features/inbox/components/InboxStudio/index.test.tsx
@@ -55,24 +55,25 @@ vi.mock('./InboxDetail', () => ({
     record,
     hasFiltersActive,
     onClearFilters,
+    onDeselect,
     onOpenIntegrations,
   }: {
     record: InboxRecord | null;
     hasFiltersActive: boolean;
     onClearFilters: () => void;
+    onDeselect: () => void;
     onOpenIntegrations: () => void;
   }) => (
     <div data-testid="detail">
       {record?.identifier ?? 'none'}
+      {record == null ? null : (
+        <button type="button" data-testid="detail-deselect" onClick={onDeselect} />
+      )}
       {record == null && hasFiltersActive ? (
-        <button type="button" data-testid="detail-clear-filters" onClick={onClearFilters}>
-          clear
-        </button>
+        <button type="button" data-testid="detail-clear-filters" onClick={onClearFilters} />
       ) : null}
       {record == null && !hasFiltersActive ? (
-        <button type="button" data-testid="detail-open-integrations" onClick={onOpenIntegrations}>
-          integrations
-        </button>
+        <button type="button" data-testid="detail-open-integrations" onClick={onOpenIntegrations} />
       ) : null}
     </div>
   ),
@@ -304,12 +305,37 @@ describe('InboxStudio', () => {
     expect(screen.queryByText('Ship the inbox')).toBeNull();
   });
 
-  it('auto selects the first visible record and follows a click', () => {
+  it('opens with nothing selected and follows a click', () => {
     renderStudio();
+
+    expect(screen.getByTestId('detail').textContent).toBe('none');
+
+    fireEvent.click(screen.getByText('Ship the inbox'));
+
+    expect(screen.getByTestId('detail').textContent).toBe('ENG-1');
+  });
+
+  it('returns to the empty state when the record is closed', () => {
+    renderStudio();
+
+    fireEvent.click(screen.getByText('Ship the inbox'));
+    expect(screen.getByTestId('detail').textContent).toBe('ENG-1');
+
+    fireEvent.click(screen.getByTestId('detail-deselect'));
+
+    expect(screen.getByTestId('detail').textContent).toBe('none');
+    expect(screen.getByText('Ship the inbox')).toBeDefined();
+  });
+
+  it('selects with the arrow keys from the empty state', () => {
+    renderStudio();
+
+    const listbox = screen.getByRole('listbox', { name: 'Inbox items' });
+    fireEvent.keyDown(listbox, { key: 'ArrowDown' });
 
     expect(screen.getByTestId('detail').textContent).toBe('GBY-1');
 
-    fireEvent.click(screen.getByText('Ship the inbox'));
+    fireEvent.keyDown(listbox, { key: 'ArrowDown' });
 
     expect(screen.getByTestId('detail').textContent).toBe('ENG-1');
   });
@@ -317,12 +343,23 @@ describe('InboxStudio', () => {
   it('keeps the selected record in the detail when the filters hide it', () => {
     renderStudio();
 
+    fireEvent.click(screen.getByText('TypeError boom'));
+
     fireEvent.change(screen.getByLabelText('Search the inbox'), {
       target: { value: 'nothing matches this' },
     });
 
     expect(screen.getByText('No matching items')).toBeDefined();
     expect(screen.getByTestId('detail').textContent).toBe('GBY-1');
+  });
+
+  it('never forces a selection when the kind filter changes', () => {
+    renderStudio();
+
+    fireEvent.click(screen.getByRole('tab', { name: /Errors/ }));
+
+    expect(screen.getByText('TypeError boom')).toBeDefined();
+    expect(screen.getByTestId('detail').textContent).toBe('none');
   });
 
   it('shows a nothing-connected empty state when the inbox has no records', () => {
@@ -390,13 +427,22 @@ describe('InboxStudio', () => {
     expect(screen.getByTestId('detail').textContent).toBe('GBY-2');
   });
 
-  it('reselects the first scoped record when the seeded selection falls outside the session scope', () => {
+  it('shows the empty state when the seeded selection falls outside the session scope', () => {
     h.records = [linkedSentryError, sentryError, linearIssue, githubIssue];
 
     renderStudio({ initialSessionId: LINKED_SESSION_ID, initialRecordKey: sentryError.key });
 
     expect(screen.getByText('Session: Fix the crash')).toBeDefined();
-    expect(screen.getByTestId('detail').textContent).toBe('GBY-2');
+    expect(screen.getByTestId('detail').textContent).toBe('none');
+    expect(screen.getByText('RangeError boom')).toBeDefined();
+  });
+
+  it('keeps the session scope free of a forced selection', () => {
+    h.records = [linkedSentryError, sentryError, linearIssue, githubIssue];
+
+    renderStudio({ initialSessionId: LINKED_SESSION_ID });
+
+    expect(screen.getByTestId('detail').textContent).toBe('none');
     expect(screen.getByText('RangeError boom')).toBeDefined();
   });
 

--- a/apps/desktop/src/features/inbox/components/InboxStudio/index.tsx
+++ b/apps/desktop/src/features/inbox/components/InboxStudio/index.tsx
@@ -16,7 +16,6 @@ import {
   writeInboxKindFilter,
   writeInboxProviders,
 } from '../../kindFilterStorage';
-import { groupRecordsByAge } from '../../ageSections';
 import { InboxDetail } from './InboxDetail';
 import { InboxRail } from './InboxRail';
 
@@ -117,20 +116,6 @@ export const InboxStudio = ({
     [scopedRecords, query, kindFilter, selectedProviders],
   );
 
-  const visibleRecords = useMemo(
-    () => groupRecordsByAge({ records: filteredRecords }).flatMap((section) => section.records),
-    [filteredRecords],
-  );
-
-  useEffect(() => {
-    const isSelectedInScope = scopedRecords.some((record) => record.key === selectedKey);
-    if (selectedKey != null && isSelectedInScope) {
-      return;
-    }
-    const firstVisibleRecord = visibleRecords[0];
-    setSelectedKey(firstVisibleRecord == null ? null : firstVisibleRecord.key);
-  }, [scopedRecords, visibleRecords, selectedKey]);
-
   const selectedRecord = useMemo(
     () => scopedRecords.find((record) => record.key === selectedKey) ?? null,
     [scopedRecords, selectedKey],
@@ -140,6 +125,10 @@ export const InboxStudio = ({
 
   const onSelect = (record: InboxRecord): void => {
     setSelectedKey(record.key);
+  };
+
+  const onDeselect = (): void => {
+    setSelectedKey(null);
   };
 
   const onActivate = (record: InboxRecord): void => {
@@ -232,6 +221,7 @@ export const InboxStudio = ({
             <InboxDetail
               record={selectedRecord}
               records={scopedRecords}
+              hasVisibleRecords={filteredRecords.length > 0}
               hasFiltersActive={hasFiltersActive}
               workspaceId={workspaceId}
               rootPath={rootPath}
@@ -239,6 +229,7 @@ export const InboxStudio = ({
               errors={errors}
               onRefresh={refetch}
               onClose={requestClose}
+              onDeselect={onDeselect}
               onClearFilters={onClearFilters}
               onOpenIntegrations={onOpenIntegrations}
               launchFocusRequest={launchFocusRequest}

--- a/apps/desktop/src/features/integrations/bitbucket/BitbucketStudio/PrDetailPanel/index.tsx
+++ b/apps/desktop/src/features/integrations/bitbucket/BitbucketStudio/PrDetailPanel/index.tsx
@@ -40,6 +40,7 @@ type Props = {
   readonly error: string | null;
   readonly onRefresh: () => void;
   readonly onClose: () => void;
+  readonly headerActions?: ReactNode;
   readonly dock?: ReactNode;
 };
 
@@ -61,6 +62,7 @@ export const PrDetailPanel = ({
   isLoading,
   error,
   onRefresh,
+  headerActions,
   dock,
 }: Props) => {
   const [section, setSection] = useState<PrSection>('overview');
@@ -130,6 +132,7 @@ export const PrDetailPanel = ({
                     onRefresh();
                   }}
                 />
+                {headerActions}
               </>
             }
             externalRef={{ url: webUrl, label: 'pull request' }}

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel/index.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel/index.tsx
@@ -49,6 +49,7 @@ type Props = {
   readonly host?: string | null;
   readonly onRefresh?: () => void;
   readonly onClose: () => void;
+  readonly headerActions?: ReactNode;
   readonly dock?: ReactNode;
 };
 
@@ -64,6 +65,7 @@ export const MrDetailPanel = ({
   host,
   onRefresh,
   onClose,
+  headerActions,
   dock,
 }: Props) => {
   const session = useAppStore((s) =>
@@ -261,6 +263,7 @@ export const MrDetailPanel = ({
                       )}
                     </Button>
                   ) : null}
+                  {headerActions}
                 </>
               }
               externalRef={{ url: mr.webUrl, label: 'MR' }}

--- a/apps/desktop/src/features/integrations/slack/SlackThreadDetail/index.tsx
+++ b/apps/desktop/src/features/integrations/slack/SlackThreadDetail/index.tsx
@@ -20,6 +20,7 @@ type Props = {
   readonly fallbackMessage: SlackMessage | null;
   readonly fallbackUrl?: string | null;
   readonly fit?: Fit;
+  readonly headerActions?: ReactNode;
   readonly dock?: ReactNode;
 };
 
@@ -31,6 +32,7 @@ export const SlackThreadDetail = ({
   fallbackMessage,
   fallbackUrl = null,
   fit = 'fill',
+  headerActions,
   dock,
 }: Props) => {
   const [permalink, setPermalink] = useState<string | null>(fallbackUrl);
@@ -84,6 +86,7 @@ export const SlackThreadDetail = ({
           subtitle={
             <span className="font-mono text-2xs text-muted-foreground">#{channelName}</span>
           }
+          actions={headerActions}
           externalRef={
             permalink != null && permalink !== '' ? { url: permalink, label: 'thread' } : null
           }


### PR DESCRIPTION
## Summary
The inbox never showed its summary state: an effect re-seeded the first visible record on mount and after every scope change, so something was always selected and there was no way back.

- selection now comes only from a click, the keyboard, or a caller that asks for a specific record when opening the inbox, so the summary shows when nothing is chosen
- the detail header gained a close control that returns to the summary. Escape is already bound to close the whole studio, so it would have been ambiguous here
- the summary gained a third case for "nothing selected", alongside the existing empty and filtered cases
- three provider panes gained the header actions slot the others already had

## Test plan
- [x] desktop `src/features/inbox src/features/session src/__tests__` (2222 passed, 193 files)
- [x] `tsc --noEmit` on core and desktop (exit 0), prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)