### PR TITLE
fix(ui): set the attribution line in italics

### DIFF
--- a/apps/desktop/src-tauri/src/jira.rs
+++ b/apps/desktop/src-tauri/src/jira.rs
@@ -464,6 +464,23 @@ fn adf_field_to_markdown(value: Option<&Value>) -> String {
     }
 }
 
+fn emphasised_line(line: &str) -> Option<&str> {
+    let inner = line.strip_prefix('*')?.strip_suffix('*')?;
+    if inner.is_empty() || inner.contains('*') {
+        return None;
+    }
+    Some(inner)
+}
+
+fn paragraph_content(line: &str) -> Value {
+    match emphasised_line(line) {
+        Some(inner) => serde_json::json!([
+            { "type": "text", "text": inner, "marks": [{ "type": "em" }] }
+        ]),
+        None => serde_json::json!([{ "type": "text", "text": line }]),
+    }
+}
+
 fn text_to_adf(text: &str) -> Value {
     let paragraphs: Vec<Value> = text
         .lines()
@@ -472,7 +489,7 @@ fn text_to_adf(text: &str) -> Value {
         .map(|line| {
             serde_json::json!({
                 "type": "paragraph",
-                "content": [{ "type": "text", "text": line }]
+                "content": paragraph_content(line)
             })
         })
         .collect();
@@ -1354,6 +1371,34 @@ mod tests {
     #[test]
     fn adf_round_trips_a_multi_paragraph_body() {
         let text = "first line\n\nsecond line";
+        assert_eq!(adf_to_markdown(&text_to_adf(text)), text);
+    }
+
+    #[test]
+    fn adf_writer_marks_a_fully_emphasised_line_as_em() {
+        let document = text_to_adf("looks good\n\n*Written by Goodboy*");
+        let content = document["content"].as_array().unwrap();
+        assert_eq!(content.len(), 2);
+        assert_eq!(content[0]["content"][0]["text"], "looks good");
+        assert!(content[0]["content"][0].get("marks").is_none());
+        assert_eq!(content[1]["content"][0]["text"], "Written by Goodboy");
+        assert_eq!(content[1]["content"][0]["marks"][0]["type"], "em");
+    }
+
+    #[test]
+    fn adf_writer_keeps_asterisks_that_do_not_wrap_a_whole_line() {
+        let document = text_to_adf("**Valid.** shipped\n\n*partial emphasis* here\n\n**bold**");
+        let content = document["content"].as_array().unwrap();
+        assert_eq!(content.len(), 3);
+        assert_eq!(content[0]["content"][0]["text"], "**Valid.** shipped");
+        assert_eq!(content[1]["content"][0]["text"], "*partial emphasis* here");
+        assert_eq!(content[2]["content"][0]["text"], "**bold**");
+        assert!(content[2]["content"][0].get("marks").is_none());
+    }
+
+    #[test]
+    fn adf_round_trips_the_italic_attribution_line() {
+        let text = "looks good\n\n*Written by Goodboy*";
         assert_eq!(adf_to_markdown(&text_to_adf(text)), text);
     }
 

--- a/apps/desktop/src/features/github/GithubIssueDetail/index.test.tsx
+++ b/apps/desktop/src/features/github/GithubIssueDetail/index.test.tsx
@@ -14,7 +14,6 @@ vi.mock('../github', () => ({
   ghCreateIssueComment: h.ghCreateIssueComment,
 }));
 
-import { ATTRIBUTION_FOOTER } from '../../../shared/utils/attribution';
 import { GithubIssueDetail } from './index';
 
 const ISSUE: GithubIssue = {
@@ -95,7 +94,7 @@ describe('GithubIssueDetail', () => {
       expect(h.ghCreateIssueComment).toHaveBeenCalledWith({
         cwd: '/repo',
         issueNumber: 42,
-        body: `On it.\n\n${ATTRIBUTION_FOOTER}`,
+        body: `On it.\n\n*Written by Goodboy*`,
         workspaceId: 'workspace-1',
       }),
     );

--- a/apps/desktop/src/features/github/useGithubIssueComments/index.test.ts
+++ b/apps/desktop/src/features/github/useGithubIssueComments/index.test.ts
@@ -13,7 +13,6 @@ vi.mock('../github', () => ({
 }));
 
 import { overridesWithAttribution } from '../../../__tests__/helpers/attributionOverrides';
-import { ATTRIBUTION_FOOTER } from '../../../shared/utils/attribution';
 import { useAppStore } from '../../../store';
 import { useGithubIssueComments } from './index';
 
@@ -86,7 +85,7 @@ describe('useGithubIssueComments', () => {
     expect(h.ghCreateIssueComment).toHaveBeenCalledWith({
       cwd: '/repo',
       issueNumber: 42,
-      body: `Shipping this today.\n\n${ATTRIBUTION_FOOTER}`,
+      body: `Shipping this today.\n\n*Written by Goodboy*`,
       workspaceId: WORKSPACE_ID,
     });
     await waitFor(() => expect(result.current.comments).toEqual([COMMENT]));

--- a/apps/desktop/src/features/github/useGithubIssueComments/index.ts
+++ b/apps/desktop/src/features/github/useGithubIssueComments/index.ts
@@ -72,7 +72,7 @@ export const useGithubIssueComments = ({ workspaceId, rootPath, issueNumber }: P
       await ghCreateIssueComment({
         cwd: rootPath,
         issueNumber,
-        body: appendAttribution({ body, isEnabled: isAttributed }),
+        body: appendAttribution({ body, isEnabled: isAttributed, syntax: 'markdown' }),
         workspaceId,
       });
       setReloadToken((token) => token + 1);

--- a/apps/desktop/src/features/integrations/gitlab/GitlabIssueDetail/index.test.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabIssueDetail/index.test.tsx
@@ -7,7 +7,6 @@ import {
   gitlabUpdateIssueDescription,
   type GitlabIssue,
 } from '../client';
-import { ATTRIBUTION_FOOTER } from '../../../../shared/utils/attribution';
 import { GitlabIssueDetail } from './index';
 
 type StoreGitlabIntegration = { provider: string; config: { host: string } };
@@ -175,7 +174,7 @@ describe('GitlabIssueDetail', () => {
         host: 'https://gitlab.com',
         projectPath: 'acme/web',
         issueIid: 7,
-        body: `Reproduced on main\n\n${ATTRIBUTION_FOOTER}`,
+        body: `Reproduced on main\n\n*Written by Goodboy*`,
         projectId: undefined,
       }),
     );

--- a/apps/desktop/src/features/integrations/gitlab/useGitlabIssueNotes/index.test.ts
+++ b/apps/desktop/src/features/integrations/gitlab/useGitlabIssueNotes/index.test.ts
@@ -4,7 +4,6 @@ import type { WorkspaceId } from '@goodboy/types';
 import type { OverrideSettings } from '@goodboy/types';
 import type { GitlabIssue, GitlabIssueNote } from '../client';
 import { overridesWithAttribution } from '../../../../__tests__/helpers/attributionOverrides';
-import { ATTRIBUTION_FOOTER } from '../../../../shared/utils/attribution';
 
 type StoreGitlabIntegration = { provider: string; config: { host: string } };
 
@@ -115,7 +114,7 @@ describe('useGitlabIssueNotes', () => {
       host: 'https://gitlab.com',
       projectPath: 'acme/web',
       issueIid: 7,
-      body: `looks good\n\n${ATTRIBUTION_FOOTER}`,
+      body: `looks good\n\n*Written by Goodboy*`,
       projectId: undefined,
     });
     await waitFor(() => expect(h.list).toHaveBeenCalledTimes(2));

--- a/apps/desktop/src/features/integrations/gitlab/useGitlabIssueNotes/index.ts
+++ b/apps/desktop/src/features/integrations/gitlab/useGitlabIssueNotes/index.ts
@@ -92,7 +92,7 @@ export const useGitlabIssueNotes = ({ issue, workspaceId, projectId }: Params): 
         host,
         projectPath,
         issueIid,
-        body: appendAttribution({ body, isEnabled: isAttributed }),
+        body: appendAttribution({ body, isEnabled: isAttributed, syntax: 'markdown' }),
         projectId,
       });
       setReloadToken((token) => token + 1);

--- a/apps/desktop/src/features/integrations/gitlab/useGitlabMrDiscussions/index.test.ts
+++ b/apps/desktop/src/features/integrations/gitlab/useGitlabMrDiscussions/index.test.ts
@@ -18,7 +18,6 @@ vi.mock('../client', () => ({
 }));
 
 import { overridesWithAttribution } from '../../../../__tests__/helpers/attributionOverrides';
-import { ATTRIBUTION_FOOTER } from '../../../../shared/utils/attribution';
 import { useAppStore } from '../../../../store';
 import { useGitlabMrDiscussions } from './index';
 
@@ -84,7 +83,7 @@ describe('useGitlabMrDiscussions', () => {
       TARGET.host,
       TARGET.projectPath,
       TARGET.mrIid,
-      `looks good\n\n${ATTRIBUTION_FOOTER}`,
+      `looks good\n\n*Written by Goodboy*`,
     );
     await waitFor(() => expect(h.list).toHaveBeenCalledTimes(2));
   });
@@ -118,7 +117,7 @@ describe('useGitlabMrDiscussions', () => {
     expect(h.reply).toHaveBeenCalledWith({
       ...TARGET,
       discussionId: 'disc-1',
-      body: `fixed\n\n${ATTRIBUTION_FOOTER}`,
+      body: `fixed\n\n*Written by Goodboy*`,
     });
     await waitFor(() => expect(h.list).toHaveBeenCalledTimes(2));
   });

--- a/apps/desktop/src/features/integrations/gitlab/useGitlabMrDiscussions/index.ts
+++ b/apps/desktop/src/features/integrations/gitlab/useGitlabMrDiscussions/index.ts
@@ -119,7 +119,7 @@ export const useGitlabMrDiscussions = ({
         host,
         projectPath,
         mrIid,
-        appendAttribution({ body, isEnabled: isAttributed }),
+        appendAttribution({ body, isEnabled: isAttributed, syntax: 'markdown' }),
       );
       setReloadToken((token) => token + 1);
     },
@@ -137,7 +137,7 @@ export const useGitlabMrDiscussions = ({
         projectPath,
         mrIid,
         discussionId,
-        body: appendAttribution({ body, isEnabled: isAttributed }),
+        body: appendAttribution({ body, isEnabled: isAttributed, syntax: 'markdown' }),
       });
       setReloadToken((token) => token + 1);
     },

--- a/apps/desktop/src/features/integrations/jira/JiraIssueDetail/index.test.tsx
+++ b/apps/desktop/src/features/integrations/jira/JiraIssueDetail/index.test.tsx
@@ -38,7 +38,6 @@ vi.mock('../client', async (importOriginal) => ({
 }));
 
 import { overridesWithAttribution } from '../../../../__tests__/helpers/attributionOverrides';
-import { ATTRIBUTION_FOOTER } from '../../../../shared/utils/attribution';
 import { useAppStore } from '../../../../store';
 import { JiraIssueDetail } from './index';
 
@@ -166,7 +165,7 @@ describe('JiraIssueDetail', () => {
       expect(createComment).toHaveBeenCalledWith(
         expect.objectContaining({
           issueKey: 'ENG-142',
-          body: `Moving this to review\n\n${ATTRIBUTION_FOOTER}`,
+          body: `Moving this to review\n\n*Written by Goodboy*`,
         }),
       ),
     );

--- a/apps/desktop/src/features/integrations/jira/useJiraIssueComments/index.ts
+++ b/apps/desktop/src/features/integrations/jira/useJiraIssueComments/index.ts
@@ -83,7 +83,7 @@ export const useJiraIssueComments = ({ issue, workspaceId, projectId }: Params):
         siteUrl,
         email,
         issueKey,
-        body: appendAttribution({ body, isEnabled: isAttributed }),
+        body: appendAttribution({ body, isEnabled: isAttributed, syntax: 'markdown' }),
       });
       setComments((current) => [...current, created]);
     },

--- a/apps/desktop/src/features/integrations/linear/useLinearIssueComments.test.ts
+++ b/apps/desktop/src/features/integrations/linear/useLinearIssueComments.test.ts
@@ -4,7 +4,6 @@ import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { WorkspaceId } from '@goodboy/types';
 import { overridesWithAttribution } from '../../../__tests__/helpers/attributionOverrides';
-import { ATTRIBUTION_FOOTER } from '../../../shared/utils/attribution';
 import { useAppStore } from '../../../store';
 import { useLinearIssueComments } from './useLinearIssueComments';
 
@@ -80,7 +79,7 @@ describe('useLinearIssueComments', () => {
     expect(createComment).toHaveBeenCalledWith({
       workspaceId: WORKSPACE_ID,
       issueId: 'issue-1',
-      body: `Looks good\n\n${ATTRIBUTION_FOOTER}`,
+      body: `Looks good\n\n*Written by Goodboy*`,
       projectId: undefined,
     });
     expect(result.current.comments.map((comment) => comment.id)).toEqual([

--- a/apps/desktop/src/features/integrations/linear/useLinearIssueComments.ts
+++ b/apps/desktop/src/features/integrations/linear/useLinearIssueComments.ts
@@ -69,7 +69,7 @@ export const useLinearIssueComments = ({ workspaceId, issueId, projectId }: Para
       const created = await linearCreateComment({
         workspaceId,
         issueId,
-        body: appendAttribution({ body, isEnabled: isAttributed }),
+        body: appendAttribution({ body, isEnabled: isAttributed, syntax: 'markdown' }),
         projectId,
       });
       setComments((current) => [...current, created]);

--- a/apps/desktop/src/shared/utils/attribution.test.ts
+++ b/apps/desktop/src/shared/utils/attribution.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { OverrideSettings } from '@goodboy/types';
-import { appendAttribution, ATTRIBUTION_FOOTER, isAttributionEnabled } from './attribution';
+import { appendAttribution, ATTRIBUTION_TEXT, isAttributionEnabled } from './attribution';
 
 const overridesWith = (attributionFooter: boolean | null): OverrideSettings => ({
   defaultProviderId: null,
@@ -33,34 +33,78 @@ describe('isAttributionEnabled', () => {
 });
 
 describe('appendAttribution', () => {
-  it('appends the footer after a blank line when enabled', () => {
-    expect(appendAttribution({ body: 'looks good', isEnabled: true })).toBe(
-      `looks good\n\n${ATTRIBUTION_FOOTER}`,
+  it('appends the markdown italic footer after a blank line', () => {
+    expect(appendAttribution({ body: 'looks good', isEnabled: true, syntax: 'markdown' })).toBe(
+      'looks good\n\n*Written by Goodboy*',
+    );
+  });
+
+  it('appends the mrkdwn italic footer for slack', () => {
+    expect(appendAttribution({ body: 'looks good', isEnabled: true, syntax: 'mrkdwn' })).toBe(
+      'looks good\n\n_Written by Goodboy_',
     );
   });
 
   it('leaves the body untouched when disabled', () => {
-    expect(appendAttribution({ body: 'looks good', isEnabled: false })).toBe('looks good');
-  });
-
-  it('does not append twice', () => {
-    const once = appendAttribution({ body: 'looks good', isEnabled: true });
-    expect(appendAttribution({ body: once, isEnabled: true })).toBe(once);
-  });
-
-  it('treats a body that is already only the footer as done', () => {
-    expect(appendAttribution({ body: ATTRIBUTION_FOOTER, isEnabled: true })).toBe(
-      ATTRIBUTION_FOOTER,
+    expect(appendAttribution({ body: 'looks good', isEnabled: false, syntax: 'markdown' })).toBe(
+      'looks good',
+    );
+    expect(appendAttribution({ body: 'looks good', isEnabled: false, syntax: 'mrkdwn' })).toBe(
+      'looks good',
     );
   });
 
+  it('does not append twice for either syntax', () => {
+    const markdown = appendAttribution({ body: 'looks good', isEnabled: true, syntax: 'markdown' });
+    expect(appendAttribution({ body: markdown, isEnabled: true, syntax: 'markdown' })).toBe(
+      markdown,
+    );
+    const mrkdwn = appendAttribution({ body: 'looks good', isEnabled: true, syntax: 'mrkdwn' });
+    expect(appendAttribution({ body: mrkdwn, isEnabled: true, syntax: 'mrkdwn' })).toBe(mrkdwn);
+  });
+
+  it('recognizes a body already signed with the old plain line', () => {
+    const signed = `looks good\n\n${ATTRIBUTION_TEXT}`;
+    expect(appendAttribution({ body: signed, isEnabled: true, syntax: 'markdown' })).toBe(signed);
+    expect(appendAttribution({ body: signed, isEnabled: true, syntax: 'mrkdwn' })).toBe(signed);
+  });
+
+  it('recognizes a body already signed with the other italic syntax', () => {
+    const mrkdwnSigned = 'looks good\n\n_Written by Goodboy_';
+    expect(appendAttribution({ body: mrkdwnSigned, isEnabled: true, syntax: 'markdown' })).toBe(
+      mrkdwnSigned,
+    );
+    const markdownSigned = 'looks good\n\n*Written by Goodboy*';
+    expect(appendAttribution({ body: markdownSigned, isEnabled: true, syntax: 'mrkdwn' })).toBe(
+      markdownSigned,
+    );
+  });
+
+  it('treats a body that is already only the footer as done', () => {
+    expect(appendAttribution({ body: ATTRIBUTION_TEXT, isEnabled: true, syntax: 'markdown' })).toBe(
+      ATTRIBUTION_TEXT,
+    );
+    expect(
+      appendAttribution({
+        body: '*Written by Goodboy*',
+        isEnabled: true,
+        syntax: 'markdown',
+      }),
+    ).toBe('*Written by Goodboy*');
+  });
+
   it('normalizes trailing whitespace before appending', () => {
-    expect(appendAttribution({ body: 'looks good\n\n', isEnabled: true })).toBe(
-      `looks good\n\n${ATTRIBUTION_FOOTER}`,
+    expect(appendAttribution({ body: 'looks good\n\n', isEnabled: true, syntax: 'markdown' })).toBe(
+      'looks good\n\n*Written by Goodboy*',
     );
   });
 
   it('returns the footer alone for an empty body', () => {
-    expect(appendAttribution({ body: '   ', isEnabled: true })).toBe(ATTRIBUTION_FOOTER);
+    expect(appendAttribution({ body: '   ', isEnabled: true, syntax: 'markdown' })).toBe(
+      '*Written by Goodboy*',
+    );
+    expect(appendAttribution({ body: '   ', isEnabled: true, syntax: 'mrkdwn' })).toBe(
+      '_Written by Goodboy_',
+    );
   });
 });

--- a/apps/desktop/src/shared/utils/attribution.ts
+++ b/apps/desktop/src/shared/utils/attribution.ts
@@ -1,6 +1,19 @@
 import type { OverrideSettings } from '@goodboy/types';
 
-export const ATTRIBUTION_FOOTER = 'Written by Goodboy';
+export const ATTRIBUTION_TEXT = 'Written by Goodboy';
+
+export type AttributionSyntax = 'markdown' | 'mrkdwn';
+
+export const ATTRIBUTION_FOOTERS = {
+  markdown: `*${ATTRIBUTION_TEXT}*`,
+  mrkdwn: `_${ATTRIBUTION_TEXT}_`,
+} as const satisfies Record<AttributionSyntax, string>;
+
+const SIGNED_ENDINGS: ReadonlyArray<string> = [
+  ATTRIBUTION_TEXT,
+  ATTRIBUTION_FOOTERS.markdown,
+  ATTRIBUTION_FOOTERS.mrkdwn,
+];
 
 type IsAttributionEnabledParams = {
   readonly overrides: OverrideSettings | null | undefined;
@@ -9,21 +22,30 @@ type IsAttributionEnabledParams = {
 export const isAttributionEnabled = ({ overrides }: IsAttributionEnabledParams): boolean =>
   overrides?.attributionFooter !== false;
 
+type IsAlreadySignedParams = {
+  readonly body: string;
+};
+
+const isAlreadySigned = ({ body }: IsAlreadySignedParams): boolean =>
+  SIGNED_ENDINGS.some((ending) => body === ending || body.endsWith(`\n${ending}`));
+
 type AppendAttributionParams = {
   readonly body: string;
   readonly isEnabled: boolean;
+  readonly syntax: AttributionSyntax;
 };
 
-export const appendAttribution = ({ body, isEnabled }: AppendAttributionParams): string => {
+export const appendAttribution = ({ body, isEnabled, syntax }: AppendAttributionParams): string => {
   if (isEnabled === false) {
     return body;
   }
+  const footer = ATTRIBUTION_FOOTERS[syntax];
   const trimmed = body.replace(/\s+$/, '');
   if (trimmed === '') {
-    return ATTRIBUTION_FOOTER;
+    return footer;
   }
-  if (trimmed === ATTRIBUTION_FOOTER || trimmed.endsWith(`\n${ATTRIBUTION_FOOTER}`)) {
+  if (isAlreadySigned({ body: trimmed })) {
     return trimmed;
   }
-  return `${trimmed}\n\n${ATTRIBUTION_FOOTER}`;
+  return `${trimmed}\n\n${footer}`;
 };

--- a/apps/desktop/src/store/slices/bitbucket-pr/commentOnBitbucketPr.ts
+++ b/apps/desktop/src/store/slices/bitbucket-pr/commentOnBitbucketPr.ts
@@ -9,6 +9,7 @@ export const commentOnBitbucketPr = (set: SetFn, get: GetFn) => {
     const attributedBody = appendAttribution({
       body,
       isEnabled: isSessionAttributionEnabled({ get, sessionId }),
+      syntax: 'markdown',
     });
     await runBitbucketPrWrite({
       set,

--- a/apps/desktop/src/store/slices/bitbucket-pr/index.test.ts
+++ b/apps/desktop/src/store/slices/bitbucket-pr/index.test.ts
@@ -2,7 +2,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { OverrideSettings, SessionId, WorkspaceId } from '@goodboy/types';
 import type { AppStore } from '../../store';
 import { overridesWithAttribution } from '../../../__tests__/helpers/attributionOverrides';
-import { ATTRIBUTION_FOOTER } from '../../../shared/utils/attribution';
 import type { BitbucketPullRequest } from '../../../features/integrations/bitbucket/client';
 
 const pullRequestForBranchSpy = vi.fn();
@@ -253,7 +252,7 @@ describe('bitbucket-pr write verbs', () => {
     expect(writeSpies.comment).toHaveBeenCalledWith(
       expect.objectContaining({
         pullRequestId: 12,
-        body: `looks good\n\n${ATTRIBUTION_FOOTER}`,
+        body: `looks good\n\n*Written by Goodboy*`,
       }),
     );
     expect(writeSpies.comment.mock.calls[0]?.[0]).not.toHaveProperty('parentCommentId');
@@ -261,7 +260,7 @@ describe('bitbucket-pr write verbs', () => {
       expect.objectContaining({
         pullRequestId: 12,
         parentCommentId: 5,
-        body: `agreed\n\n${ATTRIBUTION_FOOTER}`,
+        body: `agreed\n\n*Written by Goodboy*`,
       }),
     );
   });

--- a/apps/desktop/src/store/slices/bitbucket-pr/replyToBitbucketPrComment.ts
+++ b/apps/desktop/src/store/slices/bitbucket-pr/replyToBitbucketPrComment.ts
@@ -15,6 +15,7 @@ export const replyToBitbucketPrComment = (set: SetFn, get: GetFn) => {
     const attributedBody = appendAttribution({
       body,
       isEnabled: isSessionAttributionEnabled({ get, sessionId }),
+      syntax: 'markdown',
     });
     await runBitbucketPrWrite({
       set,

--- a/apps/desktop/src/store/slices/github/buildResolutionReplyBody.test.ts
+++ b/apps/desktop/src/store/slices/github/buildResolutionReplyBody.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from 'vitest';
-import { ATTRIBUTION_FOOTER } from '../../../shared/utils/attribution';
 import { buildResolutionReplyBody } from './buildResolutionReplyBody';
 
 const PR_URL = 'https://github.com/o/r/pull/9';
@@ -84,7 +83,7 @@ describe('buildResolutionReplyBody', () => {
         prUrl: PR_URL,
         isAttributed: true,
       }),
-    ).toBe(`answered inline\n\n${ATTRIBUTION_FOOTER}`);
+    ).toBe(`answered inline\n\n*Written by Goodboy*`);
   });
 
   it('leaves a blank closure unsigned when attribution is enabled', () => {

--- a/apps/desktop/src/store/slices/github/buildResolutionReplyBody.ts
+++ b/apps/desktop/src/store/slices/github/buildResolutionReplyBody.ts
@@ -43,5 +43,7 @@ export const buildResolutionReplyBody = ({
     return reply.length > 0 ? reply : null;
   })();
 
-  return body === null ? null : appendAttribution({ body, isEnabled: isAttributed });
+  return body === null
+    ? null
+    : appendAttribution({ body, isEnabled: isAttributed, syntax: 'markdown' });
 };

--- a/apps/desktop/src/store/slices/github/index.test.ts
+++ b/apps/desktop/src/store/slices/github/index.test.ts
@@ -35,7 +35,6 @@ import type {
   ProjectScript,
   ProjectScriptId,
 } from '@goodboy/types';
-import { ATTRIBUTION_FOOTER } from '../../../shared/utils/attribution';
 
 vi.mock('@tauri-apps/api/core', () => ({
   invoke: vi.fn(async () => null),
@@ -1351,7 +1350,7 @@ describe('store contract', () => {
       expect(addReplySpy).toHaveBeenCalledWith(
         expect.anything(),
         persisted.threadId,
-        `${persisted.reply}\n\n${ATTRIBUTION_FOOTER}`,
+        `${persisted.reply}\n\n*Written by Goodboy*`,
         expect.anything(),
       );
     });
@@ -1497,7 +1496,7 @@ describe('store contract', () => {
       expect(addReplySpy).toHaveBeenCalledWith(
         expect.anything(),
         'PRRT_1',
-        `**Not applying.**\n\n**Resolution.** Closed without a change: the requested behavior is intentional\n\n${ATTRIBUTION_FOOTER}`,
+        `**Not applying.**\n\n**Resolution.** Closed without a change: the requested behavior is intentional\n\n*Written by Goodboy*`,
         expect.anything(),
       );
       expect(resolveThreadSpy).toHaveBeenCalledOnce();

--- a/apps/desktop/src/store/slices/review-drafts/index.test.ts
+++ b/apps/desktop/src/store/slices/review-drafts/index.test.ts
@@ -12,7 +12,6 @@ import type {
 import type { AppStore } from '../../store';
 import type { SetFn } from './types';
 import { overridesWithAttribution } from '../../../__tests__/helpers/attributionOverrides';
-import { ATTRIBUTION_FOOTER } from '../../../shared/utils/attribution';
 import { createReviewDraftsSlice } from './index';
 
 const {
@@ -244,13 +243,13 @@ describe('review-drafts slice', () => {
     const [, input] = addPullRequestReviewSpy.mock.calls[0]!;
     expect(input.pullRequestId).toBe('PR_node1');
     expect(input.event).toBe('APPROVE');
-    expect(input.body).toBe(`lgtm\n\n${ATTRIBUTION_FOOTER}`);
+    expect(input.body).toBe(`lgtm\n\n*Written by Goodboy*`);
     expect(input.threads).toHaveLength(2);
     expect(input.threads[0]).toEqual(
       expect.objectContaining({ path: 'src/a.ts', line: 2, side: 'RIGHT' }),
     );
     for (const thread of input.threads) {
-      expect(thread.body).not.toContain(ATTRIBUTION_FOOTER);
+      expect(thread.body).not.toContain('Written by Goodboy');
     }
     expect(markPublishedSpy).toHaveBeenCalledWith(
       expect.objectContaining({ ids: ['draft-1', 'draft-2'] }),
@@ -272,7 +271,7 @@ describe('review-drafts slice', () => {
     await slice.publishPrReview(SESSION_ID, { verdict: 'comment', body: 'a few notes' });
 
     const [, input] = addPullRequestReviewSpy.mock.calls[0]!;
-    expect(input.body).toBe(`a few notes\n\n${ATTRIBUTION_FOOTER}`);
+    expect(input.body).toBe(`a few notes\n\n*Written by Goodboy*`);
     expect(input.threads.map((thread: { body: string }) => thread.body)).toEqual([
       'guard the null case',
       'guard the null case',
@@ -367,7 +366,7 @@ describe('review-drafts slice', () => {
       'https://gitlab.com',
       'acme/web',
       10,
-      `Request changes: overall notes\n\n${ATTRIBUTION_FOOTER}`,
+      `Request changes: overall notes\n\n*Written by Goodboy*`,
     );
     expect(result.published).toBe(1);
     expect(result.failed).toHaveLength(1);

--- a/apps/desktop/src/store/slices/review-drafts/publishPrReview.ts
+++ b/apps/desktop/src/store/slices/review-drafts/publishPrReview.ts
@@ -244,6 +244,7 @@ export const publishPrReview = (set: SetFn, get: GetFn) => {
         : appendAttribution({
             body: opts.body,
             isEnabled: isAttributionEnabled({ overrides: get().workspaceOverrides[workspace.id] }),
+            syntax: 'markdown',
           });
 
     const outcome =

--- a/apps/desktop/src/store/slices/slack-threads/index.test.ts
+++ b/apps/desktop/src/store/slices/slack-threads/index.test.ts
@@ -2,7 +2,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { OverrideSettings, WorkspaceId } from '@goodboy/types';
 import type { AppStore } from '../../store';
 import { overridesWithAttribution } from '../../../__tests__/helpers/attributionOverrides';
-import { ATTRIBUTION_FOOTER } from '../../../shared/utils/attribution';
 
 const listChannelsSpy = vi.fn();
 const listUsersSpy = vi.fn();
@@ -159,7 +158,7 @@ describe('slack-threads slice', () => {
       workspaceId: WORKSPACE_ID,
       channelId: CHANNEL_ID,
       threadTs: THREAD_TS,
-      text: `on it\n\n${ATTRIBUTION_FOOTER}`,
+      text: `on it\n\n_Written by Goodboy_`,
     });
     expect(getThreadSpy).toHaveBeenCalledWith({
       workspaceId: WORKSPACE_ID,

--- a/apps/desktop/src/store/slices/slack-threads/replyToSlackThread.ts
+++ b/apps/desktop/src/store/slices/slack-threads/replyToSlackThread.ts
@@ -8,6 +8,7 @@ export const replyToSlackThread = (get: GetFn) => {
     const attributedText = appendAttribution({
       body: text,
       isEnabled: isAttributionEnabled({ overrides: get().workspaceOverrides[workspaceId] }),
+      syntax: 'mrkdwn',
     });
     await runSlackWrite({
       get,


### PR DESCRIPTION
## Summary
The attribution line shipped as plain text. It now renders in italics, using the syntax each destination actually understands rather than one hardcoded string.

- GitHub, GitLab, Bitbucket, Jira and Linear receive `*Written by Goodboy*`
- Slack receives `_Written by Goodboy_`, since it parses mrkdwn and not markdown
- the Jira converter had no mark support at all, so a single asterisk would have posted as a literal character. It now recognises a line that is entirely emphasised and converts it to an emphasis mark, leaving bold and partial spans byte identical
- the helper still refuses to sign twice, recognising the old plain line as well as both italic forms
- the workspace switch and the unsigned inline review comments are unchanged

## Test plan
- [x] `cargo test --locked` (614 passed) and `cargo fmt --check`
- [x] `pnpm -F @goodboy/db test` (351 passed)
- [x] desktop `src/store src/features/{integrations,github} src/shared` (2592 passed, 334 files)
- [x] `tsc --noEmit` on core and desktop (exit 0), prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)