### PR TITLE
fix(desktop): round-trip the provider pool override

### DIFF
--- a/apps/desktop/src-tauri/src/settings_overrides.rs
+++ b/apps/desktop/src-tauri/src/settings_overrides.rs
@@ -23,8 +23,8 @@ pub struct SettingsOverrides {
     pub role_models: Option<serde_json::Value>,
     #[serde(rename = "parallelAgents")]
     pub parallel_agents: Option<bool>,
-    #[serde(rename = "enabledProviders")]
-    pub enabled_providers: Option<Vec<String>>,
+    #[serde(rename = "providerPool")]
+    pub provider_pool: Option<Vec<String>>,
     #[serde(rename = "attributionFooter")]
     pub attribution_footer: Option<bool>,
 }
@@ -74,7 +74,7 @@ pub async fn get_workspace_overrides(
             task_models: json_from_text(row.get(6)?),
             role_models: json_from_text(row.get(7)?),
             parallel_agents: parallel_agents_raw.map(|v| v != 0),
-            enabled_providers: string_array_from_text(row.get(9)?),
+            provider_pool: string_array_from_text(row.get(9)?),
             attribution_footer: attribution_footer_raw.map(|v| v != 0),
         })
     })?;
@@ -121,7 +121,7 @@ pub async fn set_workspace_overrides(
             json_to_text(&overrides.task_models),
             json_to_text(&overrides.role_models),
             parallel_agents_val,
-            string_array_to_text(&overrides.enabled_providers),
+            string_array_to_text(&overrides.provider_pool),
             attribution_footer_val,
             now,
             workspace_id,
@@ -152,7 +152,7 @@ pub async fn get_session_overrides(
             task_models: None,
             role_models: None,
             parallel_agents: None,
-            enabled_providers: None,
+            provider_pool: None,
             attribution_footer: None,
         })
     })?;
@@ -191,4 +191,59 @@ pub async fn set_session_overrides(
         ],
     )?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_provider_pool_survives_the_wire_names_the_frontend_sends() {
+        let payload = serde_json::json!({
+            "defaultProviderId": "anthropic",
+            "defaultWorkflowId": null,
+            "defaultBranchPrefix": null,
+            "parallelEnabled": null,
+            "defaultVerbosity": null,
+            "providerBindings": null,
+            "taskModels": null,
+            "roleModels": null,
+            "parallelAgents": null,
+            "providerPool": ["anthropic", "codex"],
+            "attributionFooter": null,
+        });
+
+        let overrides: SettingsOverrides =
+            serde_json::from_value(payload).expect("deserialize overrides");
+
+        assert_eq!(
+            overrides.provider_pool,
+            Some(vec!["anthropic".to_string(), "codex".to_string()])
+        );
+
+        let encoded = serde_json::to_value(&overrides).expect("serialize overrides");
+        assert_eq!(
+            encoded.get("providerPool"),
+            Some(&serde_json::json!(["anthropic", "codex"]))
+        );
+        assert!(encoded.get("enabledProviders").is_none());
+    }
+
+    #[test]
+    fn an_absent_provider_pool_reads_back_as_none() {
+        let overrides: SettingsOverrides =
+            serde_json::from_value(serde_json::json!({})).expect("deserialize overrides");
+
+        assert_eq!(overrides.provider_pool, None);
+        assert_eq!(string_array_to_text(&overrides.provider_pool), None);
+    }
+
+    #[test]
+    fn the_provider_pool_column_text_round_trips() {
+        let pool = Some(vec!["anthropic".to_string(), "codex".to_string()]);
+        let text = string_array_to_text(&pool);
+
+        assert_eq!(text.as_deref(), Some(r#"["anthropic","codex"]"#));
+        assert_eq!(string_array_from_text(text), pool);
+    }
 }

--- a/apps/desktop/src/store/slices/overrides/index.test.ts
+++ b/apps/desktop/src/store/slices/overrides/index.test.ts
@@ -549,6 +549,11 @@ describe('store contract', () => {
         workspaceId: WS_ID,
         overrides,
       });
+      const payload = vi.mocked(invoke).mock.calls[0]?.[1] as {
+        readonly overrides: Record<string, unknown>;
+      };
+      expect(payload.overrides).toHaveProperty('providerPool', ['anthropic', 'codex']);
+      expect(payload.overrides).not.toHaveProperty('enabledProviders');
     });
 
     it('setTaskOverrides caches the override map keyed by session', async () => {

--- a/packages/db/src/queries/settings-overrides.test.ts
+++ b/packages/db/src/queries/settings-overrides.test.ts
@@ -1,11 +1,18 @@
 import { describe, expect, it } from 'vitest';
-import type { IsoDateTime, OverrideSettings, WorkspaceId } from '@goodboy/types';
+import type { IsoDateTime, OverrideSettings, ProjectId, WorkspaceId } from '@goodboy/types';
 import { makeTestDatabase } from '../test-helpers/test-db';
 import { migrate } from '../migrations/runner';
 import { insertWorkspace } from './workspace';
-import { getWorkspaceOverrides, setWorkspaceOverrides } from './settings-overrides';
+import { insertProject } from './project';
+import {
+  getProjectOverrides,
+  getWorkspaceOverrides,
+  setProjectOverrides,
+  setWorkspaceOverrides,
+} from './settings-overrides';
 
 const WS_ID = 'w1' as WorkspaceId;
+const PROJECT_ID = 'p1' as ProjectId;
 
 const EMPTY: OverrideSettings = {
   defaultProviderId: null,
@@ -79,5 +86,37 @@ describe('workspace overrides', () => {
     await setWorkspaceOverrides(db, WS_ID, { ...EMPTY, roleModels: {} });
 
     expect((await getWorkspaceOverrides(db, WS_ID))?.roleModels).toBeNull();
+  });
+});
+
+describe('project overrides', () => {
+  it('round-trips the routing pool', async () => {
+    const db = await makeDb();
+    const now = new Date().toISOString() as IsoDateTime;
+    await insertProject({
+      db,
+      project: {
+        id: PROJECT_ID,
+        workspaceId: WS_ID,
+        name: 'my-repo',
+        rootPath: '/tmp/my-repo',
+        kind: 'repo',
+        baseBranch: null,
+        overrides: EMPTY,
+        createdAt: now,
+        updatedAt: now,
+      },
+    });
+
+    expect((await getProjectOverrides(db, PROJECT_ID))?.providerPool).toBeNull();
+
+    await setProjectOverrides(db, PROJECT_ID, { ...EMPTY, providerPool: ['anthropic', 'codex'] });
+    expect((await getProjectOverrides(db, PROJECT_ID))?.providerPool).toEqual([
+      'anthropic',
+      'codex',
+    ]);
+
+    await setProjectOverrides(db, PROJECT_ID, { ...EMPTY, providerPool: null });
+    expect((await getProjectOverrides(db, PROJECT_ID))?.providerPool).toBeNull();
   });
 });


### PR DESCRIPTION
## Problem

`SettingsOverrides` in `apps/desktop/src-tauri/src/settings_overrides.rs` serde-renamed `provider_pool` as `enabledProviders`, while the frontend sends and reads `providerPool` (`OverrideSettings.providerPool`, store action `setWorkspaceOverrides`).

Serde resolves a missing `Option<T>` to `None`, so the mismatch was silent:

- `set_workspace_overrides` never saw the pool and wrote `NULL` into `provider_pool`
- `get_workspace_overrides` returned the value under a key nothing reads

Because the store overwrites the whole override row on any save, a pool set at workspace insert time was wiped by the next unrelated override save.

Scope is workspace-only. There is no `set_project_overrides` / `get_project_overrides` Tauri command, and the TS `setProjectOverrides` has no runtime caller, so project pools go through `insertProject` and were never affected. Session overrides never carry the pool.

## Fix

Rename the wire name to `providerPool` and the field to `provider_pool` to match the column. `enabledProviders` stays a legitimate name elsewhere (session `provider_enabled`), which is likely how the copy-paste happened.

No data fix is needed: both sides write a JSON string array into the same column, only the JSON key was wrong. Stored rows are either `NULL` (correct "no pool restriction") or a valid array, and lost values were never written.

## Tests

- Rust: deserialize the exact store payload, assert the pool survives and `enabledProviders` is absent from the encoded form, plus absent-field and column-text round trips
- Store: assert the `invoke` payload carries `providerPool` and not `enabledProviders`
- DB: added the project-scope pool round trip, the suite was workspace-only

`cargo test --locked` 614 passed, `cargo fmt --check` clean, `pnpm -F @goodboy/db test` 352 passed, desktop `src/store` 1519 passed, settings and ProviderStudio 176 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)