### PR TITLE
fix(ui): group consecutive project mounts in the timeline

### DIFF
--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRowLabel.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRowLabel.test.tsx
@@ -82,6 +82,26 @@ const mountEntry = (): TimelineStreamEntry =>
     },
   }) as unknown as TimelineStreamEntry;
 
+type ProjectRunParams = {
+  readonly mounted: ReadonlyArray<string>;
+  readonly detached: ReadonlyArray<string>;
+};
+
+const projectRunEntry = ({ mounted, detached }: ProjectRunParams): TimelineStreamEntry =>
+  ({
+    kind: 'event',
+    id: 'event:ev-9',
+    at: '2026-08-17T09:04:00Z',
+    event: {
+      id: 'ev-9',
+      sessionId: 'session-1',
+      kind: mounted.length > 0 ? 'project_materialized' : 'project_detached',
+      payload: { projectName: 'api', kept: true },
+      createdAt: '2026-08-17T09:04:00Z',
+    },
+    projectRun: { mounted, detached },
+  }) as unknown as TimelineStreamEntry;
+
 const branchEntry = (): TimelineStreamEntry =>
   ({
     kind: 'branch',
@@ -229,6 +249,44 @@ describe('TimelineRowLabel', () => {
     const { container } = render(<TimelineRowLabel item={itemOf({ entry: mountEntry() })} />);
 
     expect(container.querySelector('[data-testid="diff-stat"]')).toBeNull();
+  });
+
+  it('keeps every project of a collapsed run a chip, on one row', () => {
+    render(
+      <TimelineRowLabel
+        item={itemOf({
+          entry: projectRunEntry({ mounted: ['api'], detached: ['app-web', 'infra'] }),
+        })}
+      />,
+    );
+
+    for (const value of ['api', 'app-web', 'infra']) {
+      expect(screen.getByText(value).className).toContain('font-mono');
+    }
+    expect(screen.getByText('Mounted').className).not.toContain('font-mono');
+    expect(screen.getByText(', detached')).toBeDefined();
+  });
+
+  it('names every project in the tooltip, even the ones the row counts', () => {
+    const detached = ['api', 'app-web', 'infra', 'db', 'edge'];
+    const { container } = render(
+      <TimelineRowLabel item={itemOf({ entry: projectRunEntry({ mounted: [], detached }) })} />,
+    );
+
+    expect(container.querySelector('[title]')?.getAttribute('title')).toBe(
+      'Detached api, app-web, infra, db and edge',
+    );
+    expect(screen.getByText('and 2 more')).toBeDefined();
+  });
+
+  it('drops the single detach note from a collapsed run, which no longer speaks for one', () => {
+    render(
+      <TimelineRowLabel
+        item={itemOf({ entry: projectRunEntry({ mounted: [], detached: ['api', 'app-web'] }) })}
+      />,
+    );
+
+    expect(screen.queryByText('worktree kept on disk')).toBeNull();
   });
 
   it('keeps the chip off a step row, where the run already names the role', () => {

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRowLabel.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineRowLabel.tsx
@@ -7,6 +7,7 @@ import {
   segmentsToText,
   sessionEventEmphasis,
   sessionEventLabel,
+  sessionEventProjectRunLabel,
   sessionEventSecondary,
   type TimelineLabelSegment,
 } from '../../../../timeline/sessionEventPresentation';
@@ -59,6 +60,13 @@ const segmentsOf = ({ entry }: EntryParams): ReadonlyArray<TimelineLabelSegment>
     ];
   }
   if (entry.kind === 'event') {
+    const { projectRun } = entry;
+    if (projectRun != null) {
+      return sessionEventProjectRunLabel({
+        mounted: projectRun.mounted,
+        detached: projectRun.detached,
+      });
+    }
     return sessionEventLabel({ event: entry.event });
   }
   const isOpen = entry.questions.every((question) => question.status === 'open');
@@ -75,6 +83,24 @@ const segmentsOf = ({ entry }: EntryParams): ReadonlyArray<TimelineLabelSegment>
   const noun = count === 1 ? 'question' : 'questions';
   const verb = allDismissed ? 'dismissed' : allAnswered ? 'answered' : 'resolved';
   return [{ kind: 'text', text: `${count} ${noun} ${verb}` }];
+};
+
+type TitleParams = EntryParams & {
+  readonly segments: ReadonlyArray<TimelineLabelSegment>;
+};
+
+const titleOf = ({ entry, segments }: TitleParams): string => {
+  if (entry.kind === 'event' && entry.projectRun != null) {
+    const { mounted, detached } = entry.projectRun;
+    return segmentsToText({
+      segments: sessionEventProjectRunLabel({
+        mounted,
+        detached,
+        limit: mounted.length + detached.length,
+      }),
+    });
+  }
+  return segmentsToText({ segments });
 };
 
 type ChipParams = EntryParams & {
@@ -112,7 +138,10 @@ export const TimelineRowLabel = ({ item, diffStat = null }: Props) => {
   const isStep = grade === 'step';
   const emphasis =
     entry.kind === 'event' ? sessionEventEmphasis({ kind: entry.event.kind }) : 'plain';
-  const secondary = entry.kind === 'event' ? sessionEventSecondary({ event: entry.event }) : null;
+  const secondary =
+    entry.kind === 'event' && entry.projectRun == null
+      ? sessionEventSecondary({ event: entry.event })
+      : null;
   const segments = segmentsOf({ entry });
   return (
     <>
@@ -123,7 +152,7 @@ export const TimelineRowLabel = ({ item, diffStat = null }: Props) => {
         </span>
       ) : null}
       <span
-        title={segmentsToText({ segments })}
+        title={titleOf({ entry, segments })}
         className={cn(
           'flex min-w-0 items-center overflow-hidden',
           isStep ? 'text-xs leading-4' : 'text-sm leading-5',

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/index.tsx
@@ -232,6 +232,9 @@ export const TimelinePane = ({ session, runs, actions, kickoff }: Props) => {
     if (entry.kind !== 'event' || entry.event.kind !== 'project_materialized') {
       return null;
     }
+    if (entry.projectRun != null) {
+      return null;
+    }
     const projectId = entry.event.payload?.projectId ?? null;
     if (projectId == null) {
       return null;

--- a/apps/desktop/src/features/session/timeline/buildTimelineGroups.ts
+++ b/apps/desktop/src/features/session/timeline/buildTimelineGroups.ts
@@ -59,11 +59,17 @@ export type TimelineBranchEntry = {
   readonly worktree: SessionWorktree;
 };
 
+export type TimelineProjectRun = {
+  readonly mounted: ReadonlyArray<string>;
+  readonly detached: ReadonlyArray<string>;
+};
+
 export type TimelineEventEntry = {
   readonly kind: 'event';
   readonly id: string;
   readonly at: string;
   readonly event: SessionEvent;
+  readonly projectRun?: TimelineProjectRun;
 };
 
 export type TimelineAnswerEntry = {

--- a/apps/desktop/src/features/session/timeline/buildTimelineStream.test.ts
+++ b/apps/desktop/src/features/session/timeline/buildTimelineStream.test.ts
@@ -1946,3 +1946,234 @@ describe('buildTimelineStream, question artifact rows', () => {
     expect(questionRows).toHaveLength(2);
   });
 });
+
+describe('buildTimelineStream, project mount runs', () => {
+  const projectRunOf = (item: TimelineStreamItem | undefined) => {
+    if (item === undefined || item.kind !== 'row' || item.entry.kind !== 'event') {
+      return null;
+    }
+    return item.entry.projectRun ?? null;
+  };
+
+  const rowsOf = (items: ReadonlyArray<TimelineStreamItem>) =>
+    items.flatMap((item) => (item.kind === 'row' ? [item] : []));
+
+  it('collapses a run of detachments into one row that keeps every name', () => {
+    const { items } = stream({
+      agents: [],
+      events: ['api', 'app-web', 'infra'].map((projectName, index) =>
+        sessionEvent({
+          id: `ev-${projectName}`,
+          kind: 'project_detached',
+          at: localIso({ day: 18, hour: 10, minute: index }),
+          payload: { projectName },
+        }),
+      ),
+    });
+    const rows = rowsOf(items);
+
+    expect(rows).toHaveLength(1);
+    expect(projectRunOf(rows[0])).toEqual({
+      mounted: [],
+      detached: ['infra', 'app-web', 'api'],
+    });
+  });
+
+  it('carries both verbs on one row when a run mixes them', () => {
+    const { items } = stream({
+      agents: [],
+      events: [
+        sessionEvent({
+          id: 'ev-api',
+          kind: 'project_materialized',
+          at: localIso({ day: 18, hour: 10, minute: 1 }),
+          payload: { projectName: 'api' },
+        }),
+        sessionEvent({
+          id: 'ev-app-web',
+          kind: 'project_detached',
+          at: localIso({ day: 18, hour: 10, minute: 2 }),
+          payload: { projectName: 'app-web' },
+        }),
+        sessionEvent({
+          id: 'ev-infra',
+          kind: 'project_detached',
+          at: localIso({ day: 18, hour: 10, minute: 3 }),
+          payload: { projectName: 'infra' },
+        }),
+      ],
+    });
+    const rows = rowsOf(items);
+
+    expect(rows).toHaveLength(1);
+    expect(projectRunOf(rows[0])).toEqual({
+      mounted: ['api'],
+      detached: ['infra', 'app-web'],
+    });
+  });
+
+  it('reads a mixed run as a mount, so it opens the files lens like a mount does', () => {
+    const { items } = stream({
+      agents: [],
+      events: [
+        sessionEvent({
+          id: 'ev-api',
+          kind: 'project_materialized',
+          at: localIso({ day: 18, hour: 10, minute: 1 }),
+          payload: { projectName: 'api' },
+        }),
+        sessionEvent({
+          id: 'ev-app-web',
+          kind: 'project_detached',
+          at: localIso({ day: 18, hour: 10, minute: 2 }),
+          payload: { projectName: 'app-web' },
+        }),
+      ],
+    });
+    const row = rowsOf(items)[0];
+
+    expect(row?.entry.kind === 'event' ? row.entry.event.kind : null).toBe('project_materialized');
+  });
+
+  it('leaves a run of detachments a detachment, which navigates nowhere', () => {
+    const { items } = stream({
+      agents: [],
+      events: ['api', 'app-web'].map((projectName, index) =>
+        sessionEvent({
+          id: `ev-${projectName}`,
+          kind: 'project_detached',
+          at: localIso({ day: 18, hour: 10, minute: index }),
+          payload: { projectName },
+        }),
+      ),
+    });
+    const row = rowsOf(items)[0];
+
+    expect(row?.entry.kind === 'event' ? row.entry.event.kind : null).toBe('project_detached');
+  });
+
+  it('stamps the collapsed row with the newest event in the run', () => {
+    const newestAt = localIso({ day: 18, hour: 11, minute: 30 });
+    const { items } = stream({
+      agents: [],
+      events: [
+        sessionEvent({
+          id: 'ev-api',
+          kind: 'project_detached',
+          at: localIso({ day: 18, hour: 10 }),
+          payload: { projectName: 'api' },
+        }),
+        sessionEvent({
+          id: 'ev-app-web',
+          kind: 'project_detached',
+          at: newestAt,
+          payload: { projectName: 'app-web' },
+        }),
+      ],
+    });
+    const row = rowsOf(items)[0];
+
+    expect(row?.at).toBe(newestAt);
+    expect(row?.id).toBe('event:ev-app-web');
+  });
+
+  it('keeps two mounts apart when another kind of event sits between them', () => {
+    const { items } = stream({
+      agents: [],
+      events: [
+        sessionEvent({
+          id: 'ev-api',
+          kind: 'project_materialized',
+          at: localIso({ day: 18, hour: 10 }),
+          payload: { projectName: 'api' },
+        }),
+        sessionEvent({
+          id: 'ev-pr',
+          kind: 'pr_created',
+          at: localIso({ day: 18, hour: 11 }),
+          payload: { number: 42 },
+        }),
+        sessionEvent({
+          id: 'ev-app-web',
+          kind: 'project_materialized',
+          at: localIso({ day: 18, hour: 12 }),
+          payload: { projectName: 'app-web' },
+        }),
+      ],
+    });
+    const rows = rowsOf(items);
+
+    expect(rows.map((row) => row.id)).toEqual(['event:ev-app-web', 'event:ev-pr', 'event:ev-api']);
+    expect(rows.every((row) => projectRunOf(row) == null)).toBe(true);
+  });
+
+  it('keeps mount runs apart across a day boundary', () => {
+    const { items } = stream({
+      agents: [],
+      events: [
+        sessionEvent({
+          id: 'ev-api',
+          kind: 'project_detached',
+          at: localIso({ day: 17, hour: 23 }),
+          payload: { projectName: 'api' },
+        }),
+        sessionEvent({
+          id: 'ev-app-web',
+          kind: 'project_detached',
+          at: localIso({ day: 18, hour: 1 }),
+          payload: { projectName: 'app-web' },
+        }),
+      ],
+    });
+    const rows = rowsOf(items);
+
+    expect(rows).toHaveLength(2);
+    expect(rows.every((row) => projectRunOf(row) == null)).toBe(true);
+  });
+
+  it('leaves a single mount exactly as it was', () => {
+    const { items } = stream({
+      agents: [],
+      events: [
+        sessionEvent({
+          id: 'ev-api',
+          kind: 'project_materialized',
+          at: localIso({ day: 18, hour: 10 }),
+          payload: { projectName: 'api', branch: 'goodboy/untitled' },
+        }),
+      ],
+    });
+    const rows = rowsOf(items);
+    const row = rows[0];
+
+    expect(rows).toHaveLength(1);
+    expect(projectRunOf(row)).toBeNull();
+    expect(row?.entry.kind === 'event' ? row.entry.event.payload : null).toEqual({
+      projectName: 'api',
+      branch: 'goodboy/untitled',
+    });
+  });
+
+  it('leaves a nameless detachment on its own row, where the old copy still fits', () => {
+    const { items } = stream({
+      agents: [],
+      events: [
+        sessionEvent({
+          id: 'ev-api',
+          kind: 'project_detached',
+          at: localIso({ day: 18, hour: 10 }),
+          payload: { projectName: 'api' },
+        }),
+        sessionEvent({
+          id: 'ev-nameless',
+          kind: 'project_detached',
+          at: localIso({ day: 18, hour: 11 }),
+        }),
+      ],
+    });
+    const rows = rowsOf(items);
+
+    expect(rows.map((row) => row.id)).toEqual(['event:ev-nameless', 'event:ev-api']);
+    expect(rows.every((row) => projectRunOf(row) == null)).toBe(true);
+  });
+});

--- a/apps/desktop/src/features/session/timeline/buildTimelineStream.ts
+++ b/apps/desktop/src/features/session/timeline/buildTimelineStream.ts
@@ -233,6 +233,99 @@ const mergeConsecutiveDecisionRows = ({
   return merged;
 };
 
+type ProjectRunPart = {
+  readonly verb: 'mounted' | 'detached';
+  readonly name: string;
+};
+
+const projectRunPartOf = ({ draft }: { readonly draft: DraftRow }): ProjectRunPart | null => {
+  if (draft.groupId != null || draft.entry.kind !== 'event') {
+    return null;
+  }
+  const { event } = draft.entry;
+  const name = event.payload?.projectName ?? null;
+  if (name == null) {
+    return null;
+  }
+  if (event.kind === 'project_materialized') {
+    return { verb: 'mounted', name };
+  }
+  if (event.kind === 'project_detached') {
+    return { verb: 'detached', name };
+  }
+  return null;
+};
+
+type MergeProjectRowsParams = {
+  readonly drafts: ReadonlyArray<DraftRow>;
+};
+
+const mergeConsecutiveProjectRows = ({
+  drafts,
+}: MergeProjectRowsParams): ReadonlyArray<DraftRow> => {
+  const merged: DraftRow[] = [];
+  let index = 0;
+
+  while (index < drafts.length) {
+    const newest = drafts[index];
+    if (newest === undefined) {
+      break;
+    }
+    if (projectRunPartOf({ draft: newest }) == null || newest.entry.kind !== 'event') {
+      merged.push(newest);
+      index += 1;
+      continue;
+    }
+
+    const mounted: string[] = [];
+    const detached: string[] = [];
+    let runIndex = index;
+    const newestDayKey = newest.at === null ? null : dayKeyOf({ at: newest.at });
+    while (runIndex < drafts.length) {
+      const draft = drafts[runIndex];
+      if (draft === undefined) {
+        break;
+      }
+      const part = projectRunPartOf({ draft });
+      if (part == null) {
+        break;
+      }
+      const draftDayKey = draft.at === null ? null : dayKeyOf({ at: draft.at });
+      if (runIndex > index && draftDayKey !== newestDayKey) {
+        break;
+      }
+      if (part.verb === 'mounted') {
+        mounted.push(part.name);
+      }
+      if (part.verb === 'detached') {
+        detached.push(part.name);
+      }
+      runIndex += 1;
+    }
+
+    if (runIndex === index + 1) {
+      merged.push(newest);
+      index = runIndex;
+      continue;
+    }
+
+    merged.push({
+      ...newest,
+      entry: {
+        ...newest.entry,
+        event: {
+          ...newest.entry.event,
+          kind: mounted.length > 0 ? 'project_materialized' : 'project_detached',
+        },
+        projectRun: { mounted, detached },
+      },
+    });
+    index = runIndex;
+  }
+
+  return merged;
+};
+
 const questionBucketOf = ({
   entry,
 }: {
@@ -723,7 +816,9 @@ export const buildTimelineStream = ({
 
   const sorted = [...rows].sort((first, second) => compareNewestFirst({ first, second }));
   const merged = mergeConsecutiveQuestionRows({
-    drafts: mergeConsecutiveDecisionRows({ drafts: sorted }),
+    drafts: mergeConsecutiveProjectRows({
+      drafts: mergeConsecutiveDecisionRows({ drafts: sorted }),
+    }),
   });
   const withDays = withDayBreaks({
     drafts: withPendingClusters({ drafts: withPendingAtFamilyHead({ drafts: merged }) }),

--- a/apps/desktop/src/features/session/timeline/sessionEventPresentation.test.ts
+++ b/apps/desktop/src/features/session/timeline/sessionEventPresentation.test.ts
@@ -4,9 +4,12 @@ import { SESSION_EVENT_KINDS } from '@goodboy/types';
 import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../shared/components/conceptIcons';
 import { PULL_REQUEST_PRESENTATION } from '../../../shared/pullRequestPresentation';
 import {
+  TIMELINE_PROJECT_NAME_LIMIT,
+  segmentsToText,
   sessionEventEmphasis,
   sessionEventGlyph,
   sessionEventLabel,
+  sessionEventProjectRunLabel,
   sessionEventSecondary,
   sessionEventTitle,
 } from './sessionEventPresentation';
@@ -290,5 +293,96 @@ describe('sessionEventGlyph', () => {
       expect(glyph.icon).toBe(presentation.icon);
       expect(glyph.tone).toBe(presentation.tone);
     }
+  });
+});
+
+describe('sessionEventProjectRunLabel', () => {
+  it('reads a run of detachments as one sentence with a serial list', () => {
+    expect(
+      segmentsToText({
+        segments: sessionEventProjectRunLabel({
+          mounted: [],
+          detached: ['api', 'app-web', 'infra'],
+        }),
+      }),
+    ).toBe('Detached api, app-web and infra');
+  });
+
+  it('says both verbs in one sentence, mounted first', () => {
+    expect(
+      segmentsToText({
+        segments: sessionEventProjectRunLabel({
+          mounted: ['api'],
+          detached: ['app-web', 'infra'],
+        }),
+      }),
+    ).toBe('Mounted api, detached app-web and infra');
+  });
+
+  it('keeps each list readable when both verbs name more than one project', () => {
+    expect(
+      segmentsToText({
+        segments: sessionEventProjectRunLabel({
+          mounted: ['api', 'app-web'],
+          detached: ['infra'],
+        }),
+      }),
+    ).toBe('Mounted api and app-web, detached infra');
+  });
+
+  it('keeps every project name a chip, never prose', () => {
+    expect(sessionEventProjectRunLabel({ mounted: ['api'], detached: ['app-web'] })).toEqual([
+      { kind: 'text', text: 'Mounted ' },
+      { kind: 'value', text: 'api', variant: 'project' },
+      { kind: 'text', text: ', detached ' },
+      { kind: 'value', text: 'app-web', variant: 'project' },
+    ]);
+  });
+
+  it(`names ${TIMELINE_PROJECT_NAME_LIMIT} projects and counts the rest`, () => {
+    expect(
+      segmentsToText({
+        segments: sessionEventProjectRunLabel({
+          mounted: [],
+          detached: ['api', 'app-web', 'infra', 'db', 'edge', 'docs', 'cli'],
+        }),
+      }),
+    ).toBe('Detached api, app-web, infra and 4 more');
+  });
+
+  it('names the last project rather than counting one hidden name', () => {
+    expect(
+      segmentsToText({
+        segments: sessionEventProjectRunLabel({
+          mounted: [],
+          detached: ['api', 'app-web', 'infra', 'db'],
+        }),
+      }),
+    ).toBe('Detached api, app-web, infra and db');
+  });
+
+  it('truncates each verb on its own so neither disappears', () => {
+    expect(
+      segmentsToText({
+        segments: sessionEventProjectRunLabel({
+          mounted: ['api', 'app-web', 'infra', 'db', 'edge'],
+          detached: ['docs', 'cli', 'agents', 'ui', 'core'],
+        }),
+      }),
+    ).toBe('Mounted api, app-web, infra and 2 more, detached docs, cli, agents and 2 more');
+  });
+
+  it('names every project when the caller lifts the limit, as a tooltip does', () => {
+    const names = ['api', 'app-web', 'infra', 'db', 'edge'];
+
+    expect(
+      segmentsToText({
+        segments: sessionEventProjectRunLabel({
+          mounted: [],
+          detached: names,
+          limit: names.length,
+        }),
+      }),
+    ).toBe('Detached api, app-web, infra, db and edge');
   });
 });

--- a/apps/desktop/src/features/session/timeline/sessionEventPresentation.ts
+++ b/apps/desktop/src/features/session/timeline/sessionEventPresentation.ts
@@ -273,6 +273,58 @@ export const sessionEventLabel = ({ event }: TitleParams): ReadonlyArray<Timelin
   }
 };
 
+export const TIMELINE_PROJECT_NAME_LIMIT = 3;
+
+type ProjectListParams = {
+  readonly names: ReadonlyArray<string>;
+  readonly limit: number;
+};
+
+const projectListSegments = ({
+  names,
+  limit,
+}: ProjectListParams): ReadonlyArray<TimelineLabelSegment> => {
+  const shown = names.length > limit + 1 ? names.slice(0, limit) : names;
+  const hidden = names.length - shown.length;
+  const segments: TimelineLabelSegment[] = [];
+  for (const [index, name] of shown.entries()) {
+    if (index > 0) {
+      const isLast = index === shown.length - 1 && hidden === 0;
+      segments.push({ kind: 'text', text: isLast ? ' and ' : ', ' });
+    }
+    segments.push({ kind: 'value', text: name, variant: 'project' });
+  }
+  if (hidden > 0) {
+    segments.push({ kind: 'text', text: ` and ${hidden} more` });
+  }
+  return segments;
+};
+
+type ProjectRunParams = {
+  readonly mounted: ReadonlyArray<string>;
+  readonly detached: ReadonlyArray<string>;
+  readonly limit?: number;
+};
+
+export const sessionEventProjectRunLabel = ({
+  mounted,
+  detached,
+  limit = TIMELINE_PROJECT_NAME_LIMIT,
+}: ProjectRunParams): ReadonlyArray<TimelineLabelSegment> => {
+  const mountedSegments: ReadonlyArray<TimelineLabelSegment> =
+    mounted.length === 0
+      ? []
+      : [{ kind: 'text', text: 'Mounted ' }, ...projectListSegments({ names: mounted, limit })];
+  const detachedSegments: ReadonlyArray<TimelineLabelSegment> =
+    detached.length === 0
+      ? []
+      : [
+          { kind: 'text', text: mounted.length === 0 ? 'Detached ' : ', detached ' },
+          ...projectListSegments({ names: detached, limit }),
+        ];
+  return [...mountedSegments, ...detachedSegments];
+};
+
 export const segmentsToText = ({
   segments,
 }: {


### PR DESCRIPTION
## Summary
Detaching several projects at once filled the timeline with one row per project, all sharing the same minute.

- a run of adjacent project mount and detach rows now renders as one row that names the projects, and both verbs share one sentence when the run mixes them, for example "Mounted api, detached infra and app-web"
- any other event between two of them ends the run, as does a day boundary, so nothing unrelated is swallowed
- three names per verb, then a count, except when a single name would be hidden, in which case it is named
- the row carries the newest event's time and keeps the click target, tooltip and filtering the single rows had. The two affordances that cannot describe a group, the diff shortcut and the worktree note, are dropped for grouped rows only
- nothing changes in what is stored: the events stay one per project

## Test plan
- [x] desktop `src/features/session src/store` (3348 passed, 300 files), 21 new tests
- [x] `tsc --noEmit` on core and desktop (exit 0), prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)