### PR TITLE
fix(ui): connect tools from a settings scope

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -117,6 +117,15 @@ export const App = () => {
     openWorkflows,
     overlays,
   } = useAppOverlays({
+    connected: {
+      github: githubConnection.isAuthenticated,
+      linear: hasLinear,
+      sentry: hasSentry,
+      jira: hasJira,
+      gitlab: hasGitlab,
+      bitbucket: hasBitbucket,
+      slack: hasSlack,
+    },
     currentSession,
     currentWorkspace,
     workspaceProjectRoot,

--- a/apps/desktop/src/__tests__/footer-studio-reachability.test.tsx
+++ b/apps/desktop/src/__tests__/footer-studio-reachability.test.tsx
@@ -64,6 +64,8 @@ vi.mock('@goodboy/ui', async (importOriginal) => {
 });
 
 type FooterProps = {
+  readonly onOpenLinear: () => void;
+  readonly linearEnabled: boolean;
   readonly onOpenSlack: () => void;
   readonly slackEnabled: boolean;
   readonly onOpenBitbucket: () => void;
@@ -77,6 +79,8 @@ type FooterProps = {
 
 vi.mock('../app/components/AppFooter', () => ({
   AppFooter: ({
+    onOpenLinear,
+    linearEnabled,
     onOpenSlack,
     slackEnabled,
     onOpenBitbucket,
@@ -88,6 +92,9 @@ vi.mock('../app/components/AppFooter', () => ({
     onOpenChangelog,
   }: FooterProps) => (
     <>
+      <button type="button" onClick={onOpenLinear}>
+        {linearEnabled ? 'Open Linear' : 'Connect Linear'}
+      </button>
       <button type="button" onClick={onOpenSlack}>
         {slackEnabled ? 'Launch a session from a Slack thread' : 'Connect Slack'}
       </button>
@@ -165,8 +172,12 @@ vi.mock('../features/session/components/ArchiveSessionConfirm', () => ({
   ArchiveSessionConfirm: () => null,
 }));
 vi.mock('../features/settings/components/SettingsStudio', () => ({
-  SettingsStudio: ({ initialFocus }: { initialFocus: { scope: string } }) => (
-    <div data-testid="settings-studio" data-scope={initialFocus.scope} />
+  SettingsStudio: ({ initialFocus }: { initialFocus: { scope: string; tool?: string } }) => (
+    <div
+      data-testid="settings-studio"
+      data-scope={initialFocus.scope}
+      data-tool={initialFocus.tool}
+    />
   ),
 }));
 vi.mock('../features/settings/components/GuideStudio', () => ({ GuideStudio: () => null }));
@@ -286,12 +297,14 @@ describe('Slack studio reachability', () => {
     expect((await screen.findByTestId('inbox-studio')).textContent).toBe('Workspace:slack');
   });
 
-  it('still opens the studio when slack is not connected, so the connect form is reachable', () => {
+  it('opens Tools settings when slack is not connected', async () => {
     render(<App />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Connect Slack' }));
 
-    expect(screen.getByTestId('inbox-studio').textContent).toBe('Workspace:slack');
+    expect((await screen.findByTestId('settings-studio')).getAttribute('data-scope')).toBe('tools');
+    expect(screen.getByTestId('settings-studio').getAttribute('data-tool')).toBe('slack');
+    expect(screen.queryByTestId('inbox-studio')).toBeNull();
   });
 });
 
@@ -317,7 +330,9 @@ describe('GitHub footer state', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Connect GitHub' }));
 
-    expect(screen.getByTestId('inbox-studio').textContent).toBe('Workspace:github');
+    expect(screen.getByTestId('settings-studio').getAttribute('data-scope')).toBe('tools');
+    expect(screen.getByTestId('settings-studio').getAttribute('data-tool')).toBe('github');
+    expect(screen.queryByTestId('inbox-studio')).toBeNull();
   });
 });
 
@@ -391,7 +406,9 @@ describe('Bitbucket studio reachability', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Connect Bitbucket' }));
 
-    expect(screen.getByTestId('inbox-studio').textContent).toBe('Workspace:bitbucket');
+    expect(screen.getByTestId('settings-studio').getAttribute('data-scope')).toBe('tools');
+    expect(screen.getByTestId('settings-studio').getAttribute('data-tool')).toBe('bitbucket');
+    expect(screen.queryByTestId('inbox-studio')).toBeNull();
   });
 });
 
@@ -479,6 +496,24 @@ describe('Spend reachability through the impact studio', () => {
     );
 
     expect(screen.getByTestId('impact-studio').getAttribute('data-scope')).toBe('provider');
+    expect(screen.queryByTestId('settings-studio')).toBeNull();
+  });
+});
+
+describe('Linear connection routing', () => {
+  it('opens Tools settings focused on an unconnected Linear', () => {
+    render(<App />);
+    fireEvent.click(screen.getByRole('button', { name: 'Connect Linear' }));
+    expect(screen.getByTestId('settings-studio').getAttribute('data-scope')).toBe('tools');
+    expect(screen.getByTestId('settings-studio').getAttribute('data-tool')).toBe('linear');
+    expect(screen.queryByTestId('inbox-studio')).toBeNull();
+  });
+
+  it('opens the filtered inbox for connected Linear', () => {
+    state.workspaceIntegrations = { 'workspace-1': [{ provider: 'linear' }] };
+    render(<App />);
+    fireEvent.click(screen.getByRole('button', { name: 'Open Linear' }));
+    expect(screen.getByTestId('inbox-studio').textContent).toBe('Workspace:linear');
     expect(screen.queryByTestId('settings-studio')).toBeNull();
   });
 });

--- a/apps/desktop/src/app/components/AppFooter/IntegrationAddPopover.tsx
+++ b/apps/desktop/src/app/components/AppFooter/IntegrationAddPopover.tsx
@@ -1,3 +1,4 @@
+import { openToolSettings } from '../../../features/integrations/openToolSettings';
 import { AnchoredPopover, cn, ScrollFade, Tooltip, useDropdown } from '@goodboy/ui';
 import { Plus } from 'lucide-react';
 import type { IntegrationGlyphProvider } from '../../../features/integrations/components/IntegrationGlyph';
@@ -13,6 +14,8 @@ type Props = {
   readonly active: boolean;
 };
 
+type SelectParams = { readonly provider: IntegrationGlyphProvider };
+
 const PANEL_WIDTH = 224;
 const PANEL_MAX_HEIGHT = 240;
 
@@ -24,8 +27,12 @@ export const IntegrationAddPopover = ({ members, enabled, openers, isEmpty, acti
     expectedHeight: PANEL_MAX_HEIGHT,
   });
 
-  const select = (provider: IntegrationGlyphProvider) => {
+  const select = ({ provider }: SelectParams) => {
     dropdown.close();
+    if (!enabled[provider]) {
+      openToolSettings({ tool: provider });
+      return;
+    }
     openers[provider]();
   };
 
@@ -66,7 +73,7 @@ export const IntegrationAddPopover = ({ members, enabled, openers, isEmpty, acti
               key={member.provider}
               member={member}
               connected={enabled[member.provider]}
-              onSelect={() => select(member.provider)}
+              onSelect={() => select({ provider: member.provider })}
             />
           ))}
         </ul>

--- a/apps/desktop/src/app/components/AppFooter/index.test.tsx
+++ b/apps/desktop/src/app/components/AppFooter/index.test.tsx
@@ -333,6 +333,7 @@ describe('AppFooter', () => {
   });
 
   it('reaches every integration through the single link popover', () => {
+    const dispatch = vi.spyOn(window, 'dispatchEvent');
     const onOpenGitlab = vi.fn();
     render(<AppFooter {...footerProps({ overrides: { githubEnabled: true, onOpenGitlab } })} />);
 
@@ -346,7 +347,13 @@ describe('AppFooter', () => {
 
     fireEvent.click(within(panel).getByRole('button', { name: 'Connect GitLab' }));
 
-    expect(onOpenGitlab).toHaveBeenCalledOnce();
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'goodboy:open-settings',
+        detail: { scope: 'tools', tool: 'gitlab' },
+      }),
+    );
+    dispatch.mockRestore();
     expect(screen.queryByRole('dialog', { name: 'Integrations' })).toBeNull();
   });
 
@@ -386,21 +393,28 @@ describe('AppFooter', () => {
     });
   });
 
-  it('sends every popover row to its own studio and to no other', () => {
+  it('sends every unconnected popover row to its own Tools settings form', () => {
+    const dispatch = vi.spyOn(window, 'dispatchEvent');
     FOOTER_INTEGRATIONS.forEach((member) => {
+      dispatch.mockClear();
       const spies = openerSpies();
       render(<AppFooter {...routingProps({ spies, connected: false })} />);
-
       fireEvent.click(screen.getByRole('button', { name: 'Link your first integration' }));
       fireEvent.click(
         within(screen.getByRole('dialog', { name: 'Integrations' })).getByRole('button', {
           name: member.connectLabel,
         }),
       );
-
-      expectRoutedOnlyTo({ spies, provider: member.provider });
+      expect(dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'goodboy:open-settings',
+          detail: { scope: 'tools', tool: member.provider },
+        }),
+      );
+      expect(Object.values(spies).every((spy) => spy.mock.calls.length === 0)).toBe(true);
       cleanup();
     });
+    dispatch.mockRestore();
   });
 
   it('holds the active state on the link action for a disconnected open studio', () => {
@@ -438,6 +452,7 @@ describe('AppFooter', () => {
   });
 
   it('keeps Slack reachable whether or not it is connected', () => {
+    const dispatchSpy = vi.spyOn(window, 'dispatchEvent');
     const onOpenSlack = vi.fn();
     const { rerender } = render(<AppFooter {...footerProps({ overrides: { onOpenSlack } })} />);
 
@@ -447,12 +462,18 @@ describe('AppFooter', () => {
         name: 'Connect Slack',
       }),
     );
-    expect(onOpenSlack).toHaveBeenCalledOnce();
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'goodboy:open-settings',
+        detail: { scope: 'tools', tool: 'slack' },
+      }),
+    );
+    dispatchSpy.mockRestore();
 
     rerender(<AppFooter {...footerProps({ overrides: { slackEnabled: true, onOpenSlack } })} />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Slack' }));
 
-    expect(onOpenSlack).toHaveBeenCalledTimes(2);
+    expect(onOpenSlack).toHaveBeenCalledOnce();
   });
 });

--- a/apps/desktop/src/app/hooks/useAppOverlays/index.ts
+++ b/apps/desktop/src/app/hooks/useAppOverlays/index.ts
@@ -9,6 +9,8 @@ import {
   type Workspace,
   type WorkspaceId,
 } from '@goodboy/types';
+import { openToolSettings } from '../../../features/integrations/openToolSettings';
+import type { IntegrationGlyphProvider } from '../../../features/integrations/components/IntegrationGlyph';
 import { AppOverlayRouter } from '../../components/AppOverlayRouter';
 import type { ImpactScope } from '../../../features/impact/lib';
 import { IMPACT_STUDIO_EVENT } from '../../../features/impact/openImpactStudio';
@@ -34,6 +36,7 @@ import { resolveSessionRepo } from '../../../store/slices/worktrees/resolveSessi
 import { resolveOpenDiffViewerEvent } from '../../../store/slices/session-view/openDiffViewerEvent';
 
 type Params = {
+  readonly connected: Readonly<Record<IntegrationGlyphProvider, boolean>>;
   readonly currentSession: Session | null;
   readonly currentWorkspace: Workspace | null;
   readonly workspaceProjectRoot: string | null;
@@ -106,6 +109,7 @@ const isImpactScope = (value: unknown): value is ImpactScope => {
 };
 
 export const useAppOverlays = ({
+  connected,
   currentSession,
   currentWorkspace,
   workspaceProjectRoot,
@@ -205,46 +209,74 @@ export const useAppOverlays = ({
   }, [closeAllStudios]);
 
   const openGithub = useCallback(() => {
+    if (!connected.github) {
+      openToolSettings({ tool: 'github' });
+      return;
+    }
     closeAllStudios();
     setInboxStudioFocus({ provider: 'github', kind: null, recordKey: null, sessionId: null });
     setInboxStudioOpen(true);
-  }, [closeAllStudios]);
+  }, [closeAllStudios, connected.github]);
 
   const openLinear = useCallback(() => {
+    if (!connected.linear) {
+      openToolSettings({ tool: 'linear' });
+      return;
+    }
     closeAllStudios();
     setInboxStudioFocus({ provider: 'linear', kind: null, recordKey: null, sessionId: null });
     setInboxStudioOpen(true);
-  }, [closeAllStudios]);
+  }, [closeAllStudios, connected.linear]);
 
   const openJira = useCallback(() => {
+    if (!connected.jira) {
+      openToolSettings({ tool: 'jira' });
+      return;
+    }
     closeAllStudios();
     setInboxStudioFocus({ provider: 'jira', kind: null, recordKey: null, sessionId: null });
     setInboxStudioOpen(true);
-  }, [closeAllStudios]);
+  }, [closeAllStudios, connected.jira]);
 
   const openSentry = useCallback(() => {
+    if (!connected.sentry) {
+      openToolSettings({ tool: 'sentry' });
+      return;
+    }
     closeAllStudios();
     setInboxStudioFocus({ provider: 'sentry', kind: null, recordKey: null, sessionId: null });
     setInboxStudioOpen(true);
-  }, [closeAllStudios]);
+  }, [closeAllStudios, connected.sentry]);
 
   const openGitlab = useCallback(() => {
+    if (!connected.gitlab) {
+      openToolSettings({ tool: 'gitlab' });
+      return;
+    }
     closeAllStudios();
     setInboxStudioFocus({ provider: 'gitlab', kind: null, recordKey: null, sessionId: null });
     setInboxStudioOpen(true);
-  }, [closeAllStudios]);
+  }, [closeAllStudios, connected.gitlab]);
 
   const openBitbucket = useCallback(() => {
+    if (!connected.bitbucket) {
+      openToolSettings({ tool: 'bitbucket' });
+      return;
+    }
     closeAllStudios();
     setInboxStudioFocus({ provider: 'bitbucket', kind: null, recordKey: null, sessionId: null });
     setInboxStudioOpen(true);
-  }, [closeAllStudios]);
+  }, [closeAllStudios, connected.bitbucket]);
 
   const openSlack = useCallback(() => {
+    if (!connected.slack) {
+      openToolSettings({ tool: 'slack' });
+      return;
+    }
     closeAllStudios();
     setInboxStudioFocus({ provider: 'slack', kind: null, recordKey: null, sessionId: null });
     setInboxStudioOpen(true);
-  }, [closeAllStudios]);
+  }, [closeAllStudios, connected.slack]);
 
   const openInbox = useCallback(() => {
     closeAllStudios();
@@ -282,17 +314,22 @@ export const useAppOverlays = ({
   useEffect(() => {
     const openSettingsEvent = ({ event, fallbackScope }: OpenSettingsEventParams) => {
       const requestedScope = eventValue({ event, key: 'scope' });
+      const tool = eventValue({ event, key: 'tool' });
       const section = eventValue({ event, key: 'section' });
       const provider =
         eventValue({ event, key: 'provider' }) ?? eventValue({ event, key: 'providerId' });
       const action = eventValue({ event, key: 'action' });
       const scope: SettingsScope =
-        requestedScope === 'app' || requestedScope === 'workspace' || requestedScope === 'providers'
+        requestedScope === 'app' ||
+        requestedScope === 'workspace' ||
+        requestedScope === 'providers' ||
+        requestedScope === 'tools'
           ? requestedScope
           : fallbackScope;
       closeAllStudios();
       setSettingsFocus({
         scope,
+        tool: isInboxProvider(tool) ? tool : undefined,
         section: typeof section === 'string' ? section : undefined,
         provider: isProviderId(provider) ? provider : undefined,
         action: isProviderLifecycleAction(action) ? action : undefined,

--- a/apps/desktop/src/features/inbox/components/InboxStudio/InboxDetail.test.tsx
+++ b/apps/desktop/src/features/inbox/components/InboxStudio/InboxDetail.test.tsx
@@ -185,7 +185,7 @@ describe('InboxDetail', () => {
     renderDetail(null);
 
     expect(screen.getByText('Inbox is empty')).toBeDefined();
-    expect(screen.getByRole('button', { name: 'Open integrations' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Connect tools' })).toBeDefined();
     expect(screen.queryByTestId('panel')).toBeNull();
   });
 
@@ -193,7 +193,7 @@ describe('InboxDetail', () => {
     renderPane({ record: null, records: [], hasVisibleRecords: true });
 
     expect(screen.getByText('Nothing selected')).toBeDefined();
-    expect(screen.queryByRole('button', { name: 'Open integrations' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Connect tools' })).toBeNull();
     expect(screen.queryByTestId('panel')).toBeNull();
   });
 

--- a/apps/desktop/src/features/inbox/components/InboxStudio/InboxEmptySummary.tsx
+++ b/apps/desktop/src/features/inbox/components/InboxStudio/InboxEmptySummary.tsx
@@ -26,7 +26,7 @@ type ReasonCopy = {
 const REASON_COPY: Record<Reason, ReasonCopy> = {
   'nothing-connected': {
     title: 'Inbox is empty',
-    description: 'Connect a provider to collect issues, reviews, threads and errors here.',
+    description: 'Connect a tool to collect issues, reviews, threads and errors here.',
   },
   'no-matches': {
     title: 'No matching items',
@@ -101,7 +101,7 @@ export const InboxEmptySummary = ({
 
           {providerCounts.length > 0 ? (
             <div className="flex flex-col gap-2">
-              <Eyebrow label="Providers" />
+              <Eyebrow label="Tools" />
               <div className="flex flex-wrap gap-2">
                 {providerCounts.map(({ provider, count }) => (
                   <Chip
@@ -124,7 +124,7 @@ export const InboxEmptySummary = ({
                 </Button>
               ) : (
                 <Button variant="secondary" size="sm" onClick={onOpenIntegrations}>
-                  Open integrations
+                  Connect tools
                 </Button>
               )}
             </div>

--- a/apps/desktop/src/features/inbox/components/InboxStudio/index.test.tsx
+++ b/apps/desktop/src/features/inbox/components/InboxStudio/index.test.tsx
@@ -373,7 +373,7 @@ describe('InboxStudio', () => {
     fireEvent.click(screen.getByTestId('detail-open-integrations'));
 
     expect(dispatchSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ type: 'goodboy:open-settings' }),
+      expect.objectContaining({ type: 'goodboy:open-settings', detail: { scope: 'tools' } }),
     );
     dispatchSpy.mockRestore();
   });

--- a/apps/desktop/src/features/inbox/components/InboxStudio/index.tsx
+++ b/apps/desktop/src/features/inbox/components/InboxStudio/index.tsx
@@ -1,3 +1,4 @@
+import { openToolSettings } from '../../../integrations/openToolSettings';
 import { useEffect, useMemo, useState } from 'react';
 import { IconButton, StudioRailLayout } from '@goodboy/ui';
 import { RefreshCw } from 'lucide-react';
@@ -165,11 +166,7 @@ export const InboxStudio = ({
     selectedProviders.size > 0 ||
     sessionFilter != null;
 
-  const onOpenIntegrations = (): void => {
-    window.dispatchEvent(
-      new CustomEvent('goodboy:open-settings', { detail: { scope: 'providers' } }),
-    );
-  };
+  const onOpenIntegrations = () => openToolSettings({});
 
   return (
     <StudioShell

--- a/apps/desktop/src/features/integrations/ConnectIntegrationEmptyState.tsx
+++ b/apps/desktop/src/features/integrations/ConnectIntegrationEmptyState.tsx
@@ -1,12 +1,6 @@
-import type { ComponentType } from 'react';
 import type { WorkspaceId } from '@goodboy/types';
+import { FORM_BODIES } from './formBodies';
 import { IntegrationConnectPanel } from './components/IntegrationConnectPanel';
-import { BitbucketFormBody } from './bitbucket/BitbucketFormBody';
-import { GitlabFormBody } from './gitlab/GitlabFormBody';
-import { JiraFormBody } from './jira/JiraFormBody';
-import { LinearFormBody } from './linear/LinearFormBody';
-import { SentryFormBody } from './sentry/SentryFormBody';
-import { SlackFormBody } from './slack/SlackFormBody';
 
 type Provider = 'linear' | 'sentry' | 'gitlab' | 'jira' | 'bitbucket' | 'slack';
 
@@ -18,11 +12,6 @@ type Props = {
   readonly wrapped?: boolean;
 };
 
-type FormBodyProps = {
-  readonly workspaceId: WorkspaceId;
-  readonly shouldAutoFocus?: boolean;
-};
-
 const PROVIDER_DESCRIPTIONS: Record<Provider, string> = {
   linear: 'Connect Linear to review issues from this project',
   sentry: 'Connect Sentry to review errors from this project',
@@ -30,15 +19,6 @@ const PROVIDER_DESCRIPTIONS: Record<Provider, string> = {
   jira: 'Connect Jira to review issues from this project',
   bitbucket: 'Connect Bitbucket to review pull requests from this project',
   slack: 'Connect Slack to read the threads a task came out of',
-};
-
-const FORM_BODIES: Record<Provider, ComponentType<FormBodyProps>> = {
-  linear: LinearFormBody,
-  sentry: SentryFormBody,
-  gitlab: GitlabFormBody,
-  jira: JiraFormBody,
-  bitbucket: BitbucketFormBody,
-  slack: SlackFormBody,
 };
 
 export const ConnectIntegrationEmptyState = ({

--- a/apps/desktop/src/features/integrations/components/ToolSettingsScope/GithubToolConnection.tsx
+++ b/apps/desktop/src/features/integrations/components/ToolSettingsScope/GithubToolConnection.tsx
@@ -1,0 +1,44 @@
+import { Button, StatusDot } from '@goodboy/ui';
+import type { WorkspaceId } from '@goodboy/types';
+import type { useGithubConnection } from '../../github/useGithubConnection';
+import { GithubFormBody } from '../../github/GithubFormBody';
+
+type Props = {
+  readonly workspaceId: WorkspaceId;
+  readonly connection: ReturnType<typeof useGithubConnection>;
+};
+
+export const GithubToolConnection = ({ workspaceId, connection }: Props) => {
+  return (
+    <section className="flex flex-col gap-4">
+      {!connection.isScoped ? (
+        <p className="flex items-center gap-2 text-sm">
+          <StatusDot tone={connection.isAuthenticated ? 'success' : 'neutral'} size="md" />
+          {connection.isAuthenticated
+            ? `Connected as ${connection.user ?? '(unknown user)'} via ${connection.mode === 'gh-cli' ? 'the system gh CLI' : 'the global GitHub key'}`
+            : connection.isResolved
+              ? 'GitHub is not connected'
+              : 'Checking GitHub connection'}
+        </p>
+      ) : null}
+      {!connection.isAuthenticated ? (
+        <p className="text-sm text-muted-foreground">
+          Use a personal API key below, or run <code>gh auth login</code> in a terminal and check
+          the connection again.
+        </p>
+      ) : null}
+      {!connection.isAuthenticated || connection.isScoped ? (
+        <GithubFormBody
+          workspaceId={workspaceId}
+          connection={connection}
+          shouldAutoFocus={!connection.isAuthenticated}
+        />
+      ) : null}
+      <div className="flex items-center gap-2">
+        <Button variant="secondary" size="sm" onClick={connection.refresh}>
+          Check connection
+        </Button>
+      </div>
+    </section>
+  );
+};

--- a/apps/desktop/src/features/integrations/components/ToolSettingsScope/GithubToolConnection.tsx
+++ b/apps/desktop/src/features/integrations/components/ToolSettingsScope/GithubToolConnection.tsx
@@ -1,11 +1,11 @@
 import { Button, StatusDot } from '@goodboy/ui';
 import type { WorkspaceId } from '@goodboy/types';
-import type { useGithubConnection } from '../../github/useGithubConnection';
+import type { GithubConnection } from '../../github/useGithubConnection';
 import { GithubFormBody } from '../../github/GithubFormBody';
 
 type Props = {
   readonly workspaceId: WorkspaceId;
-  readonly connection: ReturnType<typeof useGithubConnection>;
+  readonly connection: GithubConnection;
 };
 
 export const GithubToolConnection = ({ workspaceId, connection }: Props) => {

--- a/apps/desktop/src/features/integrations/components/ToolSettingsScope/ToolDetailPanel.tsx
+++ b/apps/desktop/src/features/integrations/components/ToolSettingsScope/ToolDetailPanel.tsx
@@ -9,7 +9,7 @@ import {
 } from '../IntegrationGlyph';
 import { FORM_BODIES } from '../../formBodies';
 import { toolIdentity } from './toolIdentity';
-import type { useGithubConnection } from '../../github/useGithubConnection';
+import type { GithubConnection } from '../../github/useGithubConnection';
 import { GithubToolConnection } from './GithubToolConnection';
 
 type Props = {
@@ -17,7 +17,7 @@ type Props = {
   readonly provider: IntegrationGlyphProvider;
   readonly isConnected: boolean;
   readonly binding: IntegrationBinding | undefined;
-  readonly github: ReturnType<typeof useGithubConnection>;
+  readonly github: GithubConnection;
 };
 
 export const ToolDetailPanel = ({ workspaceId, provider, isConnected, binding, github }: Props) => {

--- a/apps/desktop/src/features/integrations/components/ToolSettingsScope/ToolDetailPanel.tsx
+++ b/apps/desktop/src/features/integrations/components/ToolSettingsScope/ToolDetailPanel.tsx
@@ -1,0 +1,60 @@
+import { Button, SectionHeader } from '@goodboy/ui';
+import type { IntegrationBinding, WorkspaceId } from '@goodboy/types';
+import { FOOTER_INTEGRATIONS } from '../../../../app/components/AppFooter/categories';
+import { StudioPanel } from '../../../../shared/components/StudioPanel';
+import {
+  IntegrationGlyph,
+  integrationLabel,
+  type IntegrationGlyphProvider,
+} from '../IntegrationGlyph';
+import { FORM_BODIES } from '../../formBodies';
+import { toolIdentity } from './toolIdentity';
+import type { useGithubConnection } from '../../github/useGithubConnection';
+import { GithubToolConnection } from './GithubToolConnection';
+
+type Props = {
+  readonly workspaceId: WorkspaceId;
+  readonly provider: IntegrationGlyphProvider;
+  readonly isConnected: boolean;
+  readonly binding: IntegrationBinding | undefined;
+  readonly github: ReturnType<typeof useGithubConnection>;
+};
+
+export const ToolDetailPanel = ({ workspaceId, provider, isConnected, binding, github }: Props) => {
+  const FormBody = provider === 'github' ? null : FORM_BODIES[provider];
+  const title = integrationLabel({ provider });
+  const subtitle = isConnected
+    ? provider === 'github'
+      ? (github.user ?? 'connected')
+      : toolIdentity({ binding })
+    : FOOTER_INTEGRATIONS.find((entry) => entry.provider === provider)?.connectLabel;
+  return (
+    <StudioPanel
+      title={title}
+      subtitle={subtitle}
+      icon={<IntegrationGlyph provider={provider} size={20} />}
+    >
+      <section className="flex flex-col gap-2">
+        <SectionHeader label="Account" />
+        {FormBody === null ? (
+          <GithubToolConnection workspaceId={workspaceId} connection={github} />
+        ) : (
+          <FormBody workspaceId={workspaceId} shouldAutoFocus={!isConnected} />
+        )}
+      </section>
+      {isConnected ? (
+        <div className="flex items-center gap-2">
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() =>
+              window.dispatchEvent(new CustomEvent('goodboy:open-inbox', { detail: { provider } }))
+            }
+          >
+            Open in inbox
+          </Button>
+        </div>
+      ) : null}
+    </StudioPanel>
+  );
+};

--- a/apps/desktop/src/features/integrations/components/ToolSettingsScope/ToolsRail.tsx
+++ b/apps/desktop/src/features/integrations/components/ToolSettingsScope/ToolsRail.tsx
@@ -1,0 +1,64 @@
+import { Eyebrow, SelectableRow, StatusDot } from '@goodboy/ui';
+import type { IntegrationBinding } from '@goodboy/types';
+import { FOOTER_INTEGRATIONS } from '../../../../app/components/AppFooter/categories';
+import { ICON_SIZE } from '../../../../shared/components/conceptIcons';
+import {
+  IntegrationGlyph,
+  integrationLabel,
+  type IntegrationGlyphProvider,
+} from '../IntegrationGlyph';
+import { toolIdentity } from './toolIdentity';
+
+type Props = {
+  readonly focusedId: IntegrationGlyphProvider | null;
+  readonly onSelect: (tool: IntegrationGlyphProvider) => void;
+  readonly integrations: ReadonlyArray<IntegrationBinding>;
+  readonly connected: Record<IntegrationGlyphProvider, boolean>;
+  readonly githubIdentity: string | null;
+};
+
+export const ToolsRail = ({
+  focusedId,
+  onSelect,
+  integrations,
+  connected,
+  githubIdentity,
+}: Props) => (
+  <div className="flex flex-col gap-4 p-2">
+    <section className="flex flex-col gap-1">
+      <Eyebrow label="Tools" className="px-2.5" />
+      <div className="flex flex-col gap-0.5">
+        {FOOTER_INTEGRATIONS.map(({ provider }) => {
+          const isActive = provider === focusedId;
+          const subtitle = !connected[provider]
+            ? 'not connected'
+            : provider === 'github'
+              ? (githubIdentity ?? 'connected')
+              : toolIdentity({
+                  binding: integrations.find((binding) => binding.provider === provider),
+                });
+          return (
+            <SelectableRow
+              key={provider}
+              selected={isActive}
+              ariaCurrent={isActive}
+              onClick={() => onSelect(provider)}
+              className="items-center gap-2.5 px-2.5 py-2"
+            >
+              <span aria-hidden className="shrink-0">
+                <IntegrationGlyph provider={provider} size={ICON_SIZE.control} useBrandColor />
+              </span>
+              <span className="flex min-w-0 flex-1 flex-col">
+                <span className="truncate text-sm font-medium text-foreground">
+                  {integrationLabel({ provider })}
+                </span>
+                <span className="truncate text-2xs text-muted-foreground">{subtitle}</span>
+              </span>
+              <StatusDot tone={connected[provider] ? 'success' : 'neutral'} size="md" />
+            </SelectableRow>
+          );
+        })}
+      </div>
+    </section>
+  </div>
+);

--- a/apps/desktop/src/features/integrations/components/ToolSettingsScope/index.test.tsx
+++ b/apps/desktop/src/features/integrations/components/ToolSettingsScope/index.test.tsx
@@ -1,0 +1,425 @@
+import { invoke } from '@tauri-apps/api/core';
+import userEvent from '@testing-library/user-event';
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { create } from 'zustand';
+import type {
+  IntegrationBinding,
+  IntegrationBindingId,
+  IntegrationCredentialId,
+  IsoDateTime,
+  WorkspaceId,
+} from '@goodboy/types';
+import { ToolSettingsScope } from '.';
+import { TrackerStudioLinks } from '../TrackerStudioLinks';
+
+const WORKSPACE_ID = 'workspace-1' as WorkspaceId;
+const LINEAR: IntegrationBinding = {
+  id: 'binding-1' as IntegrationBindingId,
+  workspaceId: WORKSPACE_ID,
+  projectId: null,
+  credentialId: 'credential-1' as IntegrationCredentialId,
+  createdAt: '2026-09-01' as IsoDateTime,
+  updatedAt: '2026-09-01' as IsoDateTime,
+  provider: 'linear',
+  config: { viewerName: 'Ada', viewerUserId: 'ada', workspaceUrlKey: 'acme' },
+};
+
+const BINDINGS = [
+  LINEAR,
+  {
+    ...LINEAR,
+    provider: 'gitlab',
+    config: { userName: 'Ada', userId: 'ada', host: 'https://gitlab.com' },
+  },
+  {
+    ...LINEAR,
+    provider: 'bitbucket',
+    config: { email: 'ada@example.com', displayName: 'Ada', workspaceSlug: 'acme' },
+  },
+  {
+    ...LINEAR,
+    provider: 'jira',
+    config: {
+      email: 'ada@example.com',
+      displayName: 'Ada',
+      siteUrl: 'https://acme.atlassian.net',
+      projectKey: 'ENG',
+    },
+  },
+  {
+    ...LINEAR,
+    provider: 'sentry',
+    config: { org: 'acme', project: 'desktop', projectName: 'Desktop' },
+  },
+  {
+    ...LINEAR,
+    provider: 'slack',
+    config: { teamName: 'Acme', teamId: 'acme', botUserId: 'ada', botUserName: 'Ada' },
+  },
+] satisfies ReadonlyArray<IntegrationBinding>;
+
+const github = vi.hoisted(() => ({ mode: 'absent', scoped: false, user: null as string | null }));
+
+const store = create(() => ({
+  currentWorkspaceId: WORKSPACE_ID,
+  workspaceIntegrations: {} as Record<string, ReadonlyArray<IntegrationBinding>>,
+  integrationCredentials: [],
+  integrationCredentialUsage: {},
+  forgetIntegrationCredential: vi.fn(),
+  disconnectIntegration: vi.fn(async () => undefined),
+  connectLinear: vi.fn(async () => undefined),
+}));
+
+vi.mock('../../../../store', () => ({
+  useAppStore: Object.assign(
+    <T,>(selector: (state: ReturnType<typeof store.getState>) => T) => store(selector),
+    {
+      getState: () => store.getState(),
+    },
+  ),
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(async (command: string) => (command === 'gh_status' ? { ...github } : true)),
+}));
+
+beforeEach(() => {
+  github.mode = 'absent';
+  github.scoped = false;
+  github.user = null;
+  vi.mocked(invoke).mockClear();
+  store.setState({ workspaceIntegrations: {} });
+  store.getState().connectLinear.mockReset();
+  store.getState().disconnectIntegration.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('ToolSettingsScope', () => {
+  it('renders every tool in footer order', async () => {
+    await act(async () => {
+      render(<ToolSettingsScope workspaceId={WORKSPACE_ID} />);
+    });
+    const rail = screen.getByRole('complementary', { name: 'Tools' });
+    expect(
+      within(rail)
+        .getAllByRole('button')
+        .map((row) => row.textContent),
+    ).toEqual([
+      'GitHubnot connected',
+      'GitLabnot connected',
+      'Bitbucketnot connected',
+      'Linearnot connected',
+      'Jiranot connected',
+      'Sentrynot connected',
+      'Slacknot connected',
+    ]);
+  });
+
+  it.each([
+    { tool: 'linear', label: 'Linear', field: 'Personal API key', id: 'linear-pat' },
+    { tool: 'jira', label: 'Jira', field: 'Personal API key', id: 'jira-token' },
+    { tool: 'gitlab', label: 'GitLab', field: 'Personal API key', id: 'gitlab-pat' },
+    { tool: 'bitbucket', label: 'Bitbucket', field: 'Personal API key', id: 'bitbucket-token' },
+    { tool: 'sentry', label: 'Sentry', field: 'Personal API key', id: 'sentry-token' },
+    { tool: 'slack', label: 'Slack', field: 'User token', id: 'slack-token' },
+  ])('focuses the $tool form from the rail', async ({ label, field, id }) => {
+    await act(async () => {
+      render(<ToolSettingsScope workspaceId={WORKSPACE_ID} />);
+    });
+    fireEvent.click(screen.getByRole('button', { name: `${label} not connected` }));
+    expect(screen.getByLabelText(field).id).toBe(id);
+    expect(screen.getByLabelText(field)).toBe(document.activeElement);
+    expect(screen.getAllByRole('heading').map((heading) => heading.textContent)).toEqual([label]);
+  });
+
+  it('lands initialFocus on the requested tool', async () => {
+    await act(async () => {
+      render(<ToolSettingsScope workspaceId={WORKSPACE_ID} initialFocus="slack" />);
+    });
+    expect(screen.getByLabelText('User token')).toBeDefined();
+    expect(
+      screen.getByRole('button', { name: 'Slack not connected' }).getAttribute('aria-current'),
+    ).toBe('true');
+  });
+
+  it('shows the connected identity and confirms disconnect', async () => {
+    store.setState({ workspaceIntegrations: { [WORKSPACE_ID]: [LINEAR] } });
+    await act(async () => {
+      render(<ToolSettingsScope workspaceId={WORKSPACE_ID} initialFocus="linear" />);
+    });
+    expect(screen.getByText('Connected as Ada')).toBeDefined();
+    expect(screen.getByText('linear.app/acme')).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: 'Disconnect Linear' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Disconnect Linear' }));
+    await waitFor(() =>
+      expect(store.getState().disconnectIntegration).toHaveBeenCalledWith({
+        workspaceId: WORKSPACE_ID,
+        provider: 'linear',
+      }),
+    );
+  });
+
+  it('flips the form to the connected view when connecting updates the binding', async () => {
+    store.getState().connectLinear.mockImplementation(async () => {
+      store.setState({ workspaceIntegrations: { [WORKSPACE_ID]: [LINEAR] } });
+    });
+    await act(async () => {
+      render(<ToolSettingsScope workspaceId={WORKSPACE_ID} initialFocus="linear" />);
+    });
+    fireEvent.change(screen.getByLabelText('Personal API key'), { target: { value: 'test-key' } });
+    await act(async () => fireEvent.click(screen.getByRole('button', { name: 'Connect' })));
+    expect(screen.getByText('Connected as Ada')).toBeDefined();
+    expect(screen.queryByLabelText('Personal API key')).toBeNull();
+    expect(screen.getByRole('button', { name: 'Open in inbox' })).toBeDefined();
+  });
+
+  it('opens connected tools in the inbox', async () => {
+    store.setState({ workspaceIntegrations: { [WORKSPACE_ID]: [LINEAR] } });
+    const dispatch = vi.spyOn(window, 'dispatchEvent');
+    await act(async () => {
+      render(<ToolSettingsScope workspaceId={WORKSPACE_ID} initialFocus="linear" />);
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Open in inbox' }));
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'goodboy:open-inbox', detail: { provider: 'linear' } }),
+    );
+  });
+
+  it.each([
+    {
+      provider: 'gitlab',
+      identity: 'Connected as Ada',
+      secondary: 'https://gitlab.com',
+      label: 'GitLab',
+    },
+    {
+      provider: 'bitbucket',
+      identity: 'Connected as Ada',
+      secondary: 'bitbucket.org/acme',
+      label: 'Bitbucket',
+    },
+    {
+      provider: 'jira',
+      identity: 'Connected as Ada',
+      secondary: 'https://acme.atlassian.net (ENG)',
+      label: 'Jira',
+    },
+    {
+      provider: 'sentry',
+      identity: 'Connected to Desktop',
+      secondary: 'acme/desktop',
+      label: 'Sentry',
+    },
+    { provider: 'slack', identity: 'Connected to Acme', secondary: 'as Ada', label: 'Slack' },
+  ] satisfies ReadonlyArray<{
+    provider: 'gitlab' | 'bitbucket' | 'jira' | 'sentry' | 'slack';
+    identity: string;
+    secondary: string;
+    label: string;
+  }>)(
+    'preserves $provider identity and disconnect behavior',
+    async ({ provider, identity, secondary, label }) => {
+      store.setState({ workspaceIntegrations: { [WORKSPACE_ID]: BINDINGS } });
+      await act(async () => {
+        render(<ToolSettingsScope workspaceId={WORKSPACE_ID} initialFocus={provider} />);
+      });
+      expect(screen.getAllByRole('heading').map((heading) => heading.textContent)).toEqual([label]);
+      expect(screen.getByText(identity)).toBeDefined();
+      expect(screen.getAllByText(secondary).length).toBeGreaterThan(0);
+      fireEvent.click(screen.getByRole('button', { name: `Disconnect ${label}` }));
+      fireEvent.click(screen.getByRole('button', { name: `Disconnect ${label}` }));
+      await waitFor(() =>
+        expect(store.getState().disconnectIntegration).toHaveBeenCalledWith({
+          workspaceId: WORKSPACE_ID,
+          provider,
+        }),
+      );
+    },
+  );
+
+  it('defaults to the first unconnected tool after GitHub resolves', async () => {
+    github.mode = 'gh-cli';
+    github.user = 'Ada';
+    await act(async () => {
+      render(<ToolSettingsScope workspaceId={WORKSPACE_ID} />);
+    });
+    await waitFor(() => expect(screen.getByLabelText('Personal API key').id).toBe('gitlab-pat'));
+    expect(
+      screen.getByRole('button', { name: 'GitLab not connected' }).getAttribute('aria-current'),
+    ).toBe('true');
+  });
+
+  it.each([undefined, 'linear'] satisfies ReadonlyArray<'linear' | undefined>)(
+    'holds the detail empty until GitHub resolves with initial focus %s',
+    async (initialFocus) => {
+      let resolveStatus: (status: unknown) => void = () => undefined;
+      vi.mocked(invoke).mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveStatus = resolve;
+          }),
+      );
+      render(<ToolSettingsScope workspaceId={WORKSPACE_ID} initialFocus={initialFocus} />);
+      expect(screen.queryByRole('heading')).toBeNull();
+      expect(screen.queryByLabelText('Personal API key')).toBeNull();
+      expect(
+        within(screen.getByRole('complementary', { name: 'Tools' }))
+          .getAllByRole('button')
+          .every((button) => button.getAttribute('aria-current') !== 'true'),
+      ).toBe(true);
+      await act(async () => resolveStatus({ mode: 'gh-cli', user: 'Ada', scoped: false }));
+      expect(screen.getByLabelText('Personal API key').id).toBe(
+        initialFocus === 'linear' ? 'linear-pat' : 'gitlab-pat',
+      );
+      expect(screen.getByLabelText('Personal API key')).toBe(document.activeElement);
+    },
+  );
+
+  it('keeps one title and switches its subtitle when the connection changes', async () => {
+    await act(async () => {
+      render(<ToolSettingsScope workspaceId={WORKSPACE_ID} initialFocus="linear" />);
+    });
+    const title = screen.getByRole('heading', { name: 'Linear' });
+    expect(title.parentElement?.textContent).toBe('LinearConnect Linear');
+    expect(screen.getAllByRole('heading')).toHaveLength(1);
+    act(() => store.setState({ workspaceIntegrations: { [WORKSPACE_ID]: [LINEAR] } }));
+    expect(title.parentElement?.textContent).toBe('LinearAda · acme');
+    expect(screen.getAllByRole('heading')).toHaveLength(1);
+  });
+
+  it('connects GitHub with a workspace key without requiring the CLI', async () => {
+    await act(async () => {
+      render(<ToolSettingsScope workspaceId={WORKSPACE_ID} initialFocus="github" />);
+    });
+    fireEvent.change(screen.getByLabelText('Personal API key'), { target: { value: 'test-key' } });
+    github.mode = 'pat';
+    github.user = 'Ada';
+    github.scoped = true;
+    fireEvent.click(screen.getByRole('button', { name: 'Connect' }));
+    expect(await screen.findByText('workspace key')).toBeDefined();
+    expect(invoke).toHaveBeenCalledWith('gh_set_token', {
+      token: 'test-key',
+      workspaceId: WORKSPACE_ID,
+    });
+    expect(screen.getByText('Connected as Ada')).toBeDefined();
+    expect(screen.queryByLabelText('Personal API key')).toBeNull();
+    expect(screen.getAllByRole('heading').map((heading) => heading.textContent)).toEqual([
+      'GitHub',
+    ]);
+  });
+
+  it('honors a global GitHub key and identifies its source', async () => {
+    github.mode = 'pat';
+    github.user = 'Ada';
+    await act(async () => {
+      render(<ToolSettingsScope workspaceId={WORKSPACE_ID} initialFocus="github" />);
+    });
+    expect(screen.getByText('Connected as Ada via the global GitHub key')).toBeDefined();
+    expect(screen.queryByLabelText('Personal API key')).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Disconnect GitHub' })).toBeNull();
+  });
+
+  it('defaults to the first tool when every tool is connected', async () => {
+    github.mode = 'gh-cli';
+    github.user = 'Ada';
+    store.setState({ workspaceIntegrations: { [WORKSPACE_ID]: BINDINGS } });
+    await act(async () => {
+      render(<ToolSettingsScope workspaceId={WORKSPACE_ID} />);
+    });
+    expect(await screen.findByText('Connected as Ada via the system gh CLI')).toBeDefined();
+    expect(screen.getByRole('button', { name: 'GitHub Ada' }).getAttribute('aria-current')).toBe(
+      'true',
+    );
+    expect(screen.queryByRole('button', { name: 'Disconnect GitHub' })).toBeNull();
+    expect(screen.queryByLabelText('Personal API key')).toBeNull();
+  });
+
+  it('offers CLI instructions and refreshes the GitHub connection', async () => {
+    await act(async () => {
+      render(<ToolSettingsScope workspaceId={WORKSPACE_ID} initialFocus="github" />);
+    });
+    expect(await screen.findByText('GitHub is not connected')).toBeDefined();
+    expect(screen.getByText('gh auth login')).toBeDefined();
+    expect(screen.getByLabelText('Personal API key').id).toBe('github-pat');
+    github.mode = 'gh-cli';
+    github.user = 'Ada';
+    fireEvent.click(screen.getByRole('button', { name: 'Check connection' }));
+    expect(await screen.findByText('Connected as Ada via the system gh CLI')).toBeDefined();
+  });
+
+  it('preserves the existing scoped GitHub disconnect action', async () => {
+    github.mode = 'pat';
+    github.scoped = true;
+    github.user = 'Ada';
+    await act(async () => {
+      render(<ToolSettingsScope workspaceId={WORKSPACE_ID} initialFocus="github" />);
+    });
+    expect(await screen.findByText('Connected as Ada')).toBeDefined();
+    expect(screen.getByText('workspace key')).toBeDefined();
+    expect(screen.getAllByRole('button', { name: 'Disconnect GitHub' })).toHaveLength(1);
+    fireEvent.click(screen.getByRole('button', { name: 'Disconnect GitHub' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Disconnect GitHub' }));
+    await waitFor(() =>
+      expect(invoke).toHaveBeenCalledWith('gh_clear_token', { workspaceId: WORKSPACE_ID }),
+    );
+  });
+
+  it('shares the resolved GitHub status with its token form', async () => {
+    await act(async () => {
+      render(<ToolSettingsScope workspaceId={WORKSPACE_ID} initialFocus="github" />);
+    });
+    expect(screen.getByLabelText('Personal API key')).toBeDefined();
+    expect(invoke).toHaveBeenCalledTimes(1);
+    expect(invoke).toHaveBeenCalledWith('gh_status', { workspaceId: WORKSPACE_ID });
+  });
+
+  it('reaches a connection form using the keyboard', async () => {
+    const user = userEvent.setup();
+    await act(async () => {
+      render(<ToolSettingsScope workspaceId={WORKSPACE_ID} initialFocus="github" />);
+    });
+    await screen.findByText('GitHub is not connected');
+    screen.getByRole('button', { name: 'GitHub not connected' }).focus();
+    await user.tab();
+    await user.keyboard('{Enter}');
+    expect(screen.getByLabelText('Personal API key').id).toBe('gitlab-pat');
+    expect(screen.getByLabelText('Personal API key')).toBe(document.activeElement);
+  });
+
+  it.each([false, true])('routes tracker links with connection state %s', async (isConnected) => {
+    store.setState({ workspaceIntegrations: { [WORKSPACE_ID]: isConnected ? [LINEAR] : [] } });
+    const dispatch = vi.spyOn(window, 'dispatchEvent');
+    render(
+      <TrackerStudioLinks
+        connected={{
+          linear: isConnected,
+          github: false,
+          gitlab: false,
+          jira: false,
+          sentry: false,
+        }}
+        links={[{ provider: 'linear', label: 'Linear', issueExternalId: 'issue-1' }]}
+      />,
+    );
+    const label = isConnected ? 'Open Linear in the inbox' : 'Connect Linear';
+    const button = screen.getByRole('button', { name: label });
+    fireEvent.mouseEnter(button);
+    expect((await screen.findByRole('tooltip')).textContent).toBe(label);
+    fireEvent.click(button);
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining(
+        isConnected
+          ? {
+              type: 'goodboy:open-inbox',
+              detail: { provider: 'linear', kind: 'issue', recordKey: 'linear:issue:issue-1' },
+            }
+          : { type: 'goodboy:open-settings', detail: { scope: 'tools', tool: 'linear' } },
+      ),
+    );
+  });
+});

--- a/apps/desktop/src/features/integrations/components/ToolSettingsScope/index.tsx
+++ b/apps/desktop/src/features/integrations/components/ToolSettingsScope/index.tsx
@@ -1,0 +1,62 @@
+import { useEffect, useState } from 'react';
+import { ScrollFade, StudioRailLayout } from '@goodboy/ui';
+import type { WorkspaceId } from '@goodboy/types';
+import { FOOTER_INTEGRATIONS } from '../../../../app/components/AppFooter/categories';
+import type { IntegrationGlyphProvider } from '../IntegrationGlyph';
+import { useToolConnections } from '../../useToolConnections';
+import { ToolsRail } from './ToolsRail';
+import { ToolDetailPanel } from './ToolDetailPanel';
+
+type Props = {
+  readonly workspaceId: WorkspaceId;
+  readonly initialFocus?: IntegrationGlyphProvider;
+};
+
+export const ToolSettingsScope = ({ workspaceId, initialFocus }: Props) => {
+  const { integrations, connected, github } = useToolConnections({ workspaceId });
+  const [focused, setFocused] = useState<IntegrationGlyphProvider | null>(initialFocus ?? null);
+  useEffect(() => setFocused(initialFocus ?? null), [initialFocus]);
+  const defaultSelection =
+    focused ??
+    FOOTER_INTEGRATIONS.find(({ provider }) => !connected[provider])?.provider ??
+    FOOTER_INTEGRATIONS[0]?.provider ??
+    'github';
+
+  const selected = github.isResolved ? defaultSelection : null;
+
+  useEffect(() => {
+    if (focused === null && selected !== null) {
+      setFocused(selected);
+    }
+  }, [focused, selected]);
+
+  return (
+    <StudioRailLayout
+      railLabel="Tools"
+      railWidth="standard"
+      rail={
+        <ScrollFade className="min-h-0 flex-1" fadeFrom="background">
+          <ToolsRail
+            focusedId={selected}
+            onSelect={setFocused}
+            integrations={integrations}
+            connected={connected}
+            githubIdentity={github.user}
+          />
+        </ScrollFade>
+      }
+      detail={
+        selected === null ? null : (
+          <ToolDetailPanel
+            key={selected}
+            workspaceId={workspaceId}
+            provider={selected}
+            isConnected={connected[selected]}
+            github={github}
+            binding={integrations.find((binding) => binding.provider === selected)}
+          />
+        )
+      }
+    />
+  );
+};

--- a/apps/desktop/src/features/integrations/components/ToolSettingsScope/toolIdentity.ts
+++ b/apps/desktop/src/features/integrations/components/ToolSettingsScope/toolIdentity.ts
@@ -1,0 +1,31 @@
+import type { IntegrationBinding } from '@goodboy/types';
+
+type Params = {
+  readonly binding: IntegrationBinding | undefined;
+};
+
+export const toolIdentity = ({ binding }: Params): string => {
+  if (binding === undefined) {
+    return 'not connected';
+  }
+  switch (binding.provider) {
+    case 'linear':
+      return `${binding.config.viewerName} · ${binding.config.workspaceUrlKey}`;
+    case 'gitlab':
+      return `${binding.config.userName} · ${binding.config.host}`;
+    case 'bitbucket':
+      return binding.config.workspaceName ?? binding.config.workspaceSlug;
+    case 'jira':
+      return `${binding.config.siteUrl} (${binding.config.projectKey})`;
+    case 'sentry':
+      return `${binding.config.org}/${binding.config.projectName ?? binding.config.project}`;
+    case 'slack':
+      return binding.config.teamName;
+    case 'github':
+      return 'connected';
+    default: {
+      const unreachable: never = binding;
+      return unreachable;
+    }
+  }
+};

--- a/apps/desktop/src/features/integrations/components/TrackerStudioLinks/index.tsx
+++ b/apps/desktop/src/features/integrations/components/TrackerStudioLinks/index.tsx
@@ -1,3 +1,4 @@
+import { openToolSettings } from '../../openToolSettings';
 import { Tooltip } from '@goodboy/ui';
 import { IntegrationGlyph } from '../IntegrationGlyph';
 
@@ -25,13 +26,12 @@ const INBOX_KIND: Record<TrackerProvider, 'issue' | 'error'> = {
   sentry: 'error',
 };
 
-const openTrackerStudio = ({
-  provider,
-  issueExternalId,
-}: {
+type OpenTrackerStudioParams = {
   readonly provider: TrackerProvider;
   readonly issueExternalId?: string;
-}): void => {
+};
+
+const openTrackerStudio = ({ provider, issueExternalId }: OpenTrackerStudioParams): void => {
   window.dispatchEvent(
     new CustomEvent('goodboy:open-inbox', {
       detail: {
@@ -47,24 +47,39 @@ const openTrackerStudio = ({
 };
 
 type Props = {
+  readonly connected: Readonly<Record<TrackerProvider, boolean>>;
   readonly links: ReadonlyArray<TrackerStudioLink>;
 };
 
-export const TrackerStudioLinks = ({ links }: Props) => (
-  <div className="flex items-center gap-1">
-    {links.map((link) => (
-      <Tooltip key={link.provider} content={`Open the ${link.label} studio`}>
-        <button
-          type="button"
-          aria-label={`Open the ${link.label} studio`}
-          className="inline-flex size-6 items-center justify-center rounded-md text-muted-foreground motion-safe:transition-colors hover:bg-muted/60"
-          onClick={() =>
-            openTrackerStudio({ provider: link.provider, issueExternalId: link.issueExternalId })
-          }
-        >
-          <IntegrationGlyph provider={link.provider} size="xs" />
-        </button>
-      </Tooltip>
-    ))}
-  </div>
-);
+export const TrackerStudioLinks = ({ links, connected }: Props) => {
+  return (
+    <div className="flex items-center gap-1">
+      {links.map((link) => {
+        const label = connected[link.provider]
+          ? `Open ${link.label} in the inbox`
+          : `Connect ${link.label}`;
+        return (
+          <Tooltip key={link.provider} content={label}>
+            <button
+              type="button"
+              aria-label={label}
+              className="inline-flex size-6 items-center justify-center rounded-md text-muted-foreground motion-safe:transition-colors hover:bg-muted/60"
+              onClick={() => {
+                if (!connected[link.provider]) {
+                  openToolSettings({ tool: link.provider });
+                  return;
+                }
+                openTrackerStudio({
+                  provider: link.provider,
+                  issueExternalId: link.issueExternalId,
+                });
+              }}
+            >
+              <IntegrationGlyph provider={link.provider} size="xs" />
+            </button>
+          </Tooltip>
+        );
+      })}
+    </div>
+  );
+};

--- a/apps/desktop/src/features/integrations/formBodies.ts
+++ b/apps/desktop/src/features/integrations/formBodies.ts
@@ -1,0 +1,26 @@
+import type { ComponentType } from 'react';
+import type { WorkspaceId } from '@goodboy/types';
+import type { IntegrationGlyphProvider } from './components/IntegrationGlyph';
+import { BitbucketFormBody } from './bitbucket/BitbucketFormBody';
+import { GitlabFormBody } from './gitlab/GitlabFormBody';
+import { JiraFormBody } from './jira/JiraFormBody';
+import { LinearFormBody } from './linear/LinearFormBody';
+import { SentryFormBody } from './sentry/SentryFormBody';
+import { SlackFormBody } from './slack/SlackFormBody';
+
+type FormBodyProps = {
+  readonly workspaceId: WorkspaceId;
+  readonly shouldAutoFocus?: boolean;
+};
+
+export const FORM_BODIES: Record<
+  Exclude<IntegrationGlyphProvider, 'github'>,
+  ComponentType<FormBodyProps>
+> = {
+  linear: LinearFormBody,
+  sentry: SentryFormBody,
+  gitlab: GitlabFormBody,
+  jira: JiraFormBody,
+  bitbucket: BitbucketFormBody,
+  slack: SlackFormBody,
+};

--- a/apps/desktop/src/features/integrations/github/GithubFormBody.tsx
+++ b/apps/desktop/src/features/integrations/github/GithubFormBody.tsx
@@ -4,10 +4,11 @@ import type { GhTokenStatus, WorkspaceId } from '@goodboy/types';
 import { ghClearToken, ghSetToken, ghStatus } from '../../github/github';
 import { ConnectForm } from '../components/ConnectForm';
 import { IntegrationConnectedRow } from '../components/IntegrationConnectedRow';
-import { notifyGithubConnectionChanged } from './useGithubConnection';
+import { notifyGithubConnectionChanged, type useGithubConnection } from './useGithubConnection';
 
 type Props = {
   workspaceId: WorkspaceId;
+  connection?: ReturnType<typeof useGithubConnection>;
   onConnected?: () => void;
   shouldAutoFocus?: boolean;
 };
@@ -15,16 +16,27 @@ type Props = {
 const TOKEN_CREATE_URL = 'https://github.com/settings/tokens/new?scopes=repo&description=Goodboy';
 const TOKEN_LIST_URL = 'https://github.com/settings/tokens';
 
-export const GithubFormBody = ({ workspaceId, onConnected, shouldAutoFocus = false }: Props) => {
-  const [status, setStatus] = useState<GhTokenStatus | null>(null);
+export const GithubFormBody = ({
+  workspaceId,
+  onConnected,
+  shouldAutoFocus = false,
+  connection,
+}: Props) => {
+  const [localStatus, setStatus] = useState<GhTokenStatus | null>(null);
+
+  const status = connection === undefined ? localStatus : connection.status;
+  const refreshConnection = connection?.refresh;
 
   const refresh = useCallback(async () => {
+    if (refreshConnection !== undefined) {
+      return;
+    }
     try {
       setStatus(await ghStatus(workspaceId));
     } catch {
       setStatus(null);
     }
-  }, [workspaceId]);
+  }, [workspaceId, refreshConnection]);
 
   useEffect(() => {
     void refresh();

--- a/apps/desktop/src/features/integrations/github/GithubFormBody.tsx
+++ b/apps/desktop/src/features/integrations/github/GithubFormBody.tsx
@@ -4,11 +4,11 @@ import type { GhTokenStatus, WorkspaceId } from '@goodboy/types';
 import { ghClearToken, ghSetToken, ghStatus } from '../../github/github';
 import { ConnectForm } from '../components/ConnectForm';
 import { IntegrationConnectedRow } from '../components/IntegrationConnectedRow';
-import { notifyGithubConnectionChanged, type useGithubConnection } from './useGithubConnection';
+import { notifyGithubConnectionChanged, type GithubConnection } from './useGithubConnection';
 
 type Props = {
   workspaceId: WorkspaceId;
-  connection?: ReturnType<typeof useGithubConnection>;
+  connection?: GithubConnection;
   onConnected?: () => void;
   shouldAutoFocus?: boolean;
 };

--- a/apps/desktop/src/features/integrations/github/useGithubConnection.ts
+++ b/apps/desktop/src/features/integrations/github/useGithubConnection.ts
@@ -63,3 +63,5 @@ export const useGithubConnection = ({ workspaceId }: Params) => {
     refresh,
   };
 };
+
+export type GithubConnection = ReturnType<typeof useGithubConnection>;

--- a/apps/desktop/src/features/integrations/github/useGithubConnection.ts
+++ b/apps/desktop/src/features/integrations/github/useGithubConnection.ts
@@ -54,6 +54,9 @@ export const useGithubConnection = ({ workspaceId }: Params) => {
   }, []);
 
   return {
+    status: connection.status,
+    user: connection.status?.user ?? null,
+    mode: connection.status?.mode ?? 'absent',
     isAuthenticated: connection.status?.mode !== 'absent' && connection.status != null,
     isResolved: connection.isResolved,
     isScoped: connection.status?.scoped === true,

--- a/apps/desktop/src/features/integrations/openToolSettings.ts
+++ b/apps/desktop/src/features/integrations/openToolSettings.ts
@@ -1,0 +1,11 @@
+import type { IntegrationGlyphProvider } from './components/IntegrationGlyph';
+
+type Params = {
+  readonly tool?: IntegrationGlyphProvider;
+};
+
+export const openToolSettings = ({ tool }: Params) => {
+  window.dispatchEvent(
+    new CustomEvent('goodboy:open-settings', { detail: { scope: 'tools', tool } }),
+  );
+};

--- a/apps/desktop/src/features/integrations/useToolConnections.ts
+++ b/apps/desktop/src/features/integrations/useToolConnections.ts
@@ -1,0 +1,29 @@
+import type { IntegrationBinding, WorkspaceId } from '@goodboy/types';
+import { useAppStore } from '../../store';
+import type { IntegrationGlyphProvider } from './components/IntegrationGlyph';
+import { useGithubConnection } from './github/useGithubConnection';
+
+type Params = {
+  readonly workspaceId: WorkspaceId | null;
+};
+
+const NO_INTEGRATIONS: ReadonlyArray<IntegrationBinding> = [];
+
+export const useToolConnections = ({ workspaceId }: Params) => {
+  const integrations = useAppStore((state) =>
+    workspaceId === null
+      ? NO_INTEGRATIONS
+      : (state.workspaceIntegrations[workspaceId] ?? NO_INTEGRATIONS),
+  );
+  const github = useGithubConnection({ workspaceId });
+  const connected: Record<IntegrationGlyphProvider, boolean> = {
+    github: github.isAuthenticated,
+    gitlab: integrations.some((binding) => binding.provider === 'gitlab'),
+    bitbucket: integrations.some((binding) => binding.provider === 'bitbucket'),
+    linear: integrations.some((binding) => binding.provider === 'linear'),
+    jira: integrations.some((binding) => binding.provider === 'jira'),
+    sentry: integrations.some((binding) => binding.provider === 'sentry'),
+    slack: integrations.some((binding) => binding.provider === 'slack'),
+  };
+  return { integrations, connected, github };
+};

--- a/apps/desktop/src/features/onboarding/OnboardingCard/StepRow.test.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingCard/StepRow.test.tsx
@@ -1,0 +1,28 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { StepRow } from './StepRow';
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('StepRow', () => {
+  it.each([
+    { id: 'tools', tool: 'linear' },
+    { id: 'codeHost', tool: 'github' },
+  ] satisfies ReadonlyArray<{ id: 'tools' | 'codeHost'; tool: string }>)(
+    'opens Tools settings for the $id step',
+    ({ id, tool }) => {
+      const dispatch = vi.spyOn(window, 'dispatchEvent');
+      render(<StepRow id={id} title="Tools" why="Connect your tools" done={false} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Set up Tools' }));
+      expect(dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'goodboy:open-settings',
+          detail: { scope: 'tools', tool },
+        }),
+      );
+    },
+  );
+});

--- a/apps/desktop/src/features/onboarding/OnboardingCard/StepRow.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingCard/StepRow.tsx
@@ -1,3 +1,4 @@
+import { openToolSettings } from '../../integrations/openToolSettings';
 import { Check } from 'lucide-react';
 import { cn } from '@goodboy/ui';
 import type { OnboardingStepId } from '../onboarding-store';
@@ -11,27 +12,15 @@ type Props = {
 };
 
 export const StepRow = ({ id, title, why, done }: Props) => {
-  const actionByStep: Readonly<
-    Partial<
-      Record<
-        OnboardingStepId,
-        { readonly event: string; readonly detail?: { readonly provider: 'github' | 'linear' } }
-      >
-    >
-  > = {
-    workspace: { event: 'goodboy:add-workspace' },
-    codeHost: { event: 'goodboy:open-inbox', detail: { provider: 'github' } },
-    tools: { event: 'goodboy:open-inbox', detail: { provider: 'linear' } },
-    session: { event: 'goodboy:new-session' },
-    palette: { event: OPEN_COMMAND_PALETTE_EVENT },
+  const actionByStep: Partial<Record<OnboardingStepId, () => void>> = {
+    workspace: () => window.dispatchEvent(new CustomEvent('goodboy:add-workspace')),
+    codeHost: () => openToolSettings({ tool: 'github' }),
+    tools: () => openToolSettings({ tool: 'linear' }),
+    session: () => window.dispatchEvent(new CustomEvent('goodboy:new-session')),
+    palette: () => window.dispatchEvent(new CustomEvent(OPEN_COMMAND_PALETTE_EVENT)),
   };
   const action = actionByStep[id];
-  const activate = () => {
-    if (action === undefined) {
-      return;
-    }
-    window.dispatchEvent(new CustomEvent(action.event, { detail: action.detail }));
-  };
+  const activate = () => action?.();
 
   return (
     <li title={why} className="rounded-md">

--- a/apps/desktop/src/features/session/components/SessionKickoff/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionKickoff/index.test.tsx
@@ -116,17 +116,32 @@ describe('SessionKickoff', () => {
     expect(spies.fetchIssueCandidates).not.toHaveBeenCalled();
   });
 
-  it('opens the inbox filtered to Linear from the no-tracker state', () => {
+  it('opens Tools settings focused on Linear from the no-tracker state', () => {
     const onOpenInbox = vi.fn();
-    window.addEventListener('goodboy:open-inbox', onOpenInbox);
+    window.addEventListener('goodboy:open-settings', onOpenInbox);
     render(<SessionKickoff session={session} onOpenWorkflowBuilder={vi.fn()} />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Open the Linear studio' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Connect Linear' }));
 
     expect(onOpenInbox).toHaveBeenCalledTimes(1);
     expect(onOpenInbox.mock.calls[0]?.[0]).toMatchObject({
-      detail: { provider: 'linear', kind: 'issue' },
+      detail: { scope: 'tools', tool: 'linear' },
     });
+    window.removeEventListener('goodboy:open-settings', onOpenInbox);
+  });
+
+  it('opens the inbox from a connected tracker shortcut', async () => {
+    store.workspaceIntegrations = { 'ws-1': [{ provider: 'linear' }] };
+    const onOpenInbox = vi.fn();
+    window.addEventListener('goodboy:open-inbox', onOpenInbox);
+    render(<SessionKickoff session={session} onOpenWorkflowBuilder={vi.fn()} />);
+    await screen.findByText('No open issues detected');
+    fireEvent.click(screen.getByRole('button', { name: 'Open Linear in the inbox' }));
+    expect(onOpenInbox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: { provider: 'linear', kind: 'issue', recordKey: undefined },
+      }),
+    );
     window.removeEventListener('goodboy:open-inbox', onOpenInbox);
   });
 

--- a/apps/desktop/src/features/session/components/SessionKickoff/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionKickoff/index.tsx
@@ -160,7 +160,7 @@ export const SessionKickoff = ({ session, onOpenWorkflowBuilder }: Props) => {
               {issues.hasSources ? 'No open issues detected' : 'No tracker connected yet'}
             </p>
             <div className="ml-auto">
-              <TrackerStudioLinks links={emptyStateLinks} />
+              <TrackerStudioLinks links={emptyStateLinks} connected={issues.connected} />
             </div>
           </div>
         ) : null}

--- a/apps/desktop/src/features/session/components/SessionKickoff/useKickoffIssues.ts
+++ b/apps/desktop/src/features/session/components/SessionKickoff/useKickoffIssues.ts
@@ -1,13 +1,14 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { GitlabIntegrationBinding, WorkspaceId } from '@goodboy/types';
-import { EMPTY_ARRAY, useAppStore } from '../../../../store';
+import { useAppStore } from '../../../../store';
 import { primaryProjectRoot } from '../../../workspace/primaryProjectRoot';
 import {
   fetchIssueCandidates,
   type IssueCandidate,
 } from '../../../integrations/fetchIssueCandidates';
 import { resolveIssueSources, type IssueSource } from '../../../integrations/issueSources';
-import { useGithubConnection } from '../../../integrations/github/useGithubConnection';
+import { useToolConnections } from '../../../integrations/useToolConnections';
+import type { TrackerProvider } from '../../../integrations/components/TrackerStudioLinks';
 import { useJiraConfig } from '../../../integrations/jira/useJiraConfig';
 
 const ROWS_PER_SOURCE = 5;
@@ -17,6 +18,7 @@ type Params = {
 };
 
 type Result = {
+  readonly connected: Readonly<Record<TrackerProvider, boolean>>;
   readonly hasSources: boolean;
   readonly rows: ReadonlyArray<IssueCandidate>;
   readonly isLoaded: boolean;
@@ -24,10 +26,7 @@ type Result = {
 };
 
 export const useKickoffIssues = ({ workspaceId }: Params): Result => {
-  const integrations = useAppStore(
-    (state) => state.workspaceIntegrations[workspaceId] ?? EMPTY_ARRAY,
-  );
-  const github = useGithubConnection({ workspaceId });
+  const { integrations, github, connected } = useToolConnections({ workspaceId });
   const rootPath = useAppStore((state) =>
     primaryProjectRoot({ projects: state.projects, workspaceId }),
   );
@@ -98,6 +97,7 @@ export const useKickoffIssues = ({ workspaceId }: Params): Result => {
   );
 
   return {
+    connected,
     hasSources: sources.length > 0,
     rows,
     isLoaded: sources.every((source) => settled.has(source.provider)),

--- a/apps/desktop/src/features/settings/components/SettingsStudio/SettingsRail.tsx
+++ b/apps/desktop/src/features/settings/components/SettingsStudio/SettingsRail.tsx
@@ -1,7 +1,7 @@
 import { PANE_RHYTHM, SelectableRow } from '@goodboy/ui';
 import { Boxes, Settings, Wrench } from 'lucide-react';
 import type { SettingsScope } from './types';
-import { ICON_SIZE } from '../../../../shared/components/conceptIcons';
+import { CONCEPT_ICONS, ICON_SIZE } from '../../../../shared/components/conceptIcons';
 
 type Props = {
   readonly scope: SettingsScope;
@@ -13,6 +13,7 @@ const ITEMS = [
   { scope: 'app', label: 'App', icon: Settings },
   { scope: 'workspace', label: 'Workspace', icon: Wrench },
   { scope: 'providers', label: 'Providers & models', icon: Boxes },
+  { scope: 'tools', label: 'Tools', icon: CONCEPT_ICONS.integrations },
 ] satisfies ReadonlyArray<{ scope: SettingsScope; label: string; icon: typeof Settings }>;
 
 export const SettingsRail = ({ scope, workspaceName, onSelect }: Props) => (

--- a/apps/desktop/src/features/settings/components/SettingsStudio/index.test.tsx
+++ b/apps/desktop/src/features/settings/components/SettingsStudio/index.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 
+import type { IsoDateTime, Workspace, WorkspaceId } from '@goodboy/types';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 
@@ -13,6 +14,13 @@ const { scrollIntoViewMock, state, toastMock } = vi.hoisted(() => ({
     wipeLocalDatabase: vi.fn(async () => undefined),
     loadDetectedEditors: vi.fn(async () => undefined),
     detectedEditors: [] as ReadonlyArray<{ binary: string; label: string }>,
+    workspaceIntegrations: {},
+    integrationCredentials: [],
+    integrationCredentialUsage: {},
+    forgetIntegrationCredential: vi.fn(),
+    connectLinear: vi.fn(),
+    disconnectIntegration: vi.fn(),
+    disconnectGithub: vi.fn(),
     storageStats: null,
     storageStatsLoading: false,
     loadStorageStats: vi.fn(async () => undefined),
@@ -20,6 +28,10 @@ const { scrollIntoViewMock, state, toastMock } = vi.hoisted(() => ({
     removeArchivedWorktrees: vi.fn(async () => ({ removed: 0, failed: 0 })),
   },
   toastMock: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(async () => ({ mode: 'absent', available: false, scoped: false })),
 }));
 
 vi.mock('../../../../store', () => ({
@@ -70,6 +82,39 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe('SettingsStudio', () => {
+  it('opens the actual tool form from a focused settings request', async () => {
+    const workspace: Workspace = {
+      id: 'workspace-1' as WorkspaceId,
+      name: 'Workspace',
+      slug: 'workspace',
+      sessionsRoot: null,
+      overrides: {
+        defaultProviderId: null,
+        defaultWorkflowId: null,
+        defaultBranchPrefix: null,
+        parallelEnabled: null,
+        defaultVerbosity: null,
+        providerBindings: null,
+        taskModels: null,
+        roleModels: null,
+        parallelAgents: null,
+        providerPool: null,
+        attributionFooter: null,
+      },
+      createdAt: '2026-09-01' as IsoDateTime,
+      updatedAt: '2026-09-01' as IsoDateTime,
+    };
+    render(
+      <SettingsStudio
+        currentWorkspace={workspace}
+        initialFocus={{ scope: 'tools', tool: 'linear' }}
+        onClose={vi.fn()}
+      />,
+    );
+    expect((await screen.findByLabelText('Personal API key')).id).toBe('linear-pat');
+    expect(screen.getByRole('button', { name: 'Tools' }).getAttribute('aria-current')).toBe('true');
+  });
+
   it('renders all settings scopes in a navigation rail', () => {
     render(
       <SettingsStudio currentWorkspace={null} initialFocus={{ scope: 'app' }} onClose={vi.fn()} />,

--- a/apps/desktop/src/features/settings/components/SettingsStudio/index.tsx
+++ b/apps/desktop/src/features/settings/components/SettingsStudio/index.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { ScrollFade, StudioRailLayout } from '@goodboy/ui';
 import type { Workspace } from '@goodboy/types';
+import { ToolSettingsScope } from '../../../integrations/components/ToolSettingsScope';
 import { ProviderSettingsScope } from '../../../providers/components/ProviderStudio';
 import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../shared/components/conceptIcons';
 import { StudioShell } from '../../../../shared/components/StudioShell';
@@ -58,6 +59,12 @@ export const SettingsStudio = ({ currentWorkspace, initialFocus, onClose }: Prop
                 workspaceId={currentWorkspace.id}
                 initialFocus={initialFocus.provider}
                 initialAction={initialFocus.action}
+              />
+            ) : availableScope === 'tools' && currentWorkspace !== null ? (
+              <ToolSettingsScope
+                key={currentWorkspace.id}
+                workspaceId={currentWorkspace.id}
+                initialFocus={initialFocus.tool}
               />
             ) : null
           }

--- a/apps/desktop/src/features/settings/components/SettingsStudio/types.ts
+++ b/apps/desktop/src/features/settings/components/SettingsStudio/types.ts
@@ -1,10 +1,13 @@
 import type { ProviderId, ProviderLifecycleAction } from '@goodboy/types';
 
-export type SettingsScope = 'app' | 'workspace' | 'providers';
+import type { IntegrationGlyphProvider } from '../../../integrations/components/IntegrationGlyph';
+
+export type SettingsScope = 'app' | 'workspace' | 'providers' | 'tools';
 
 export type SettingsFocus = {
   readonly scope: SettingsScope;
   readonly section?: string;
+  readonly tool?: IntegrationGlyphProvider;
   readonly provider?: ProviderId;
   readonly action?: ProviderLifecycleAction;
 };

--- a/apps/desktop/src/features/suggestions/index.ts
+++ b/apps/desktop/src/features/suggestions/index.ts
@@ -1,3 +1,2 @@
-export { deriveSessionSuggestions } from './deriveSessionSuggestions';
 export { useSessionSuggestions } from './useSessionSuggestions';
-export type { SessionSuggestion, SuggestionKind } from './types';
+export type { SessionSuggestion } from './types';

--- a/apps/desktop/src/features/workspace/components/ConvertWorkspaceDialog/index.test.tsx
+++ b/apps/desktop/src/features/workspace/components/ConvertWorkspaceDialog/index.test.tsx
@@ -169,9 +169,8 @@ describe('ConvertWorkspaceDialog', () => {
 
   it('keeps the draft when the user leaves to connect the host', () => {
     const onClose = vi.fn();
-    const dispatched: string[] = [];
-    const onOpenInbox = () => dispatched.push('github');
-    window.addEventListener('goodboy:open-inbox', onOpenInbox);
+    const onOpenSettings = vi.fn();
+    window.addEventListener('goodboy:open-settings', onOpenSettings);
     state.githubStatus = { available: false };
     render(<ConvertWorkspaceDialog open workspace={workspace} onClose={onClose} />);
 
@@ -180,10 +179,12 @@ describe('ConvertWorkspaceDialog', () => {
       target: { value: 'https://github.com/acme/widgets.git' },
     });
     fireEvent.click(screen.getByRole('button', { name: 'Connect GitHub' }));
-    window.removeEventListener('goodboy:open-inbox', onOpenInbox);
+    window.removeEventListener('goodboy:open-settings', onOpenSettings);
 
     expect(onClose).toHaveBeenCalledOnce();
-    expect(dispatched).toEqual(['github']);
+    expect(onOpenSettings).toHaveBeenCalledWith(
+      expect.objectContaining({ detail: { scope: 'tools', tool: 'github' } }),
+    );
     expect(
       (screen.getByPlaceholderText('https://github.com/owner/repo.git') as HTMLInputElement).value,
     ).toBe('https://github.com/acme/widgets.git');

--- a/apps/desktop/src/features/workspace/components/ConvertWorkspaceDialog/index.tsx
+++ b/apps/desktop/src/features/workspace/components/ConvertWorkspaceDialog/index.tsx
@@ -1,3 +1,4 @@
+import { openToolSettings } from '../../../integrations/openToolSettings';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Button, Dialog, formatError, Input, SegmentedTabs, Select, StatusDot } from '@goodboy/ui';
 import type { Workspace } from '@goodboy/types';
@@ -164,7 +165,7 @@ export const ConvertWorkspaceDialog = ({ open, workspace, onClose }: Props) => {
   const onConnect = useCallback(() => {
     keepDraftRef.current = true;
     onClose();
-    window.dispatchEvent(new CustomEvent('goodboy:open-inbox', { detail: { provider: host } }));
+    openToolSettings({ tool: host });
   }, [host, onClose]);
 
   const onConvert = useCallback(async () => {


### PR DESCRIPTION
## Summary
- restores the ability to connect Linear, Jira, GitLab, Bitbucket, Sentry, Slack and GitHub to a workspace, lost when #1629 deleted the per-integration studios that hosted the connect form
- new `Tools` scope in Settings, a sibling of `Providers & models`: rail with status and identity, detail with the setup form or the connected view and disconnect
- footer "Link integration", onboarding steps, convert dialog, tracker shortcuts and the inbox summary open the tools scope when unconnected and the inbox when connected
- GitHub keeps CLI auth and the existing key form; one connection read shared through App instead of three

## Test plan
- [x] desktop vitest full suite 6981 passed across 766 files
- [x] desktop `tsc --noEmit` exit 0, knip and prettier clean
- [x] new tests render the real scope: form present when unconnected, connected view after the store updates, routing events with the right detail

🤖 Generated with [Claude Code](https://claude.com/claude-code)