### PR TITLE
fix(desktop): keep the dirty block across a reload

### DIFF
--- a/apps/desktop/src-tauri/src/worktree_writer.rs
+++ b/apps/desktop/src-tauri/src/worktree_writer.rs
@@ -335,7 +335,7 @@ pub fn worktree_writer_abandon(
 ) -> WriterLeaseStatus {
     let (status, released) = abandon_in(&mut lock(&state.0), &path, &holder);
     if released {
-        emit_lease_event(&app, &path, &holder, "released");
+        emit_lease_event(&app, &path, &holder, "abandoned");
     }
     status
 }

--- a/apps/desktop/src/store/slices/resolve/drainResolveQueue.test.ts
+++ b/apps/desktop/src/store/slices/resolve/drainResolveQueue.test.ts
@@ -1,12 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createStore } from 'zustand/vanilla';
-import { migrate, type Database } from '@goodboy/db';
+import { migrate, upsertResolveThread, type Database } from '@goodboy/db';
 import { makeTestDatabase } from '@goodboy/db/test-helpers';
 import type { Agent, AgentId, IsoDateTime, ProjectId, SessionId } from '@goodboy/types';
 import type { GetFn, SetFn } from './types';
 import type { SendTurnResult } from '../turn/types';
 import { createResolveSlice } from './index';
-import { selectDirtyTreeThreads } from './selectDirtyTreeThreads';
+import { createResolveThread } from './createResolveThread';
+import { selectDirtyTreeThreads, withDirtyTreeReason } from './selectDirtyTreeThreads';
 import { resolveInitialState } from './state';
 
 type Lease = {
@@ -883,6 +884,38 @@ describe('resolve queue scheduler', () => {
     ).toEqual([]);
     expect(harness.sendTurn).toHaveBeenCalledTimes(2);
     expect(harness.sendTurn.mock.calls[1]?.[0]?.content).toBe('fix two');
+  });
+
+  it('keeps a persisted dirty block after a reload wiped the in-memory baseline', async () => {
+    const RELOAD_PATH = '/repo/reload';
+    const harness = createHarness({ worktreePathBySession: { [SESSION_A]: RELOAD_PATH } });
+    const dirtyRow = createResolveThread({
+      sessionId: SESSION_A,
+      threadId: 'PRRT_1',
+      projectId: PROJECT_ID,
+    });
+    await upsertResolveThread({
+      db,
+      row: { ...dirtyRow, stateReason: withDirtyTreeReason({ row: dirtyRow }) },
+      expectedRevision: null,
+    });
+    await queueRequest({
+      actions: harness.actions,
+      sessionId: SESSION_A,
+      agentId: AGENT_2,
+      instructions: 'fix two',
+    });
+    setTree({ unstaged: 2 });
+
+    await harness.actions.drainResolveQueue({ sessionId: SESSION_A });
+
+    expect(
+      selectDirtyTreeThreads({
+        sessionResolveThreads: harness.get().sessionResolveThreads,
+        sessionId: SESSION_A,
+      }),
+    ).toEqual(['PRRT_1']);
+    expect(harness.sendTurn).not.toHaveBeenCalled();
   });
 
   it('fails an interrupted running attempt on load and resumes the waiting one', async () => {

--- a/apps/desktop/src/store/slices/resolve/drainResolveQueue.ts
+++ b/apps/desktop/src/store/slices/resolve/drainResolveQueue.ts
@@ -60,8 +60,10 @@ const syncDirtyTree = async ({
     return CLEAN;
   }
   const baseline = startBaselines.get(worktreePath);
+  const currentChanges = trackedChanges({ status });
   const isAttemptDirt =
-    status.inProgress !== null || (baseline !== undefined && trackedChanges({ status }) > baseline);
+    status.inProgress !== null ||
+    (baseline === undefined ? currentChanges > 0 : currentChanges > baseline);
   if (!isAttemptDirt) {
     startBaselines.delete(worktreePath);
     for (const row of blocked) {

--- a/apps/desktop/src/store/slices/turn/sendTurn.ts
+++ b/apps/desktop/src/store/slices/turn/sendTurn.ts
@@ -515,7 +515,7 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
     const isResolverTurn = turnAgentKind === 'resolver';
     const agentRowForLease = isResolverTurn
       ? ((get().sessionPhaseRuns[sessionId] ?? []).find((row) => row.id === activeAgentId) ??
-        (await getAgentById(tauriDatabase, activeAgentId).catch(() => null)))
+        (await getAgentById(tauriDatabase, activeAgentId)))
       : null;
     const writerLeasePath = isResolverTurn ? await resolveWorktreePath({ get, sessionId }) : null;
     if (isResolverTurn && (writerLeasePath === null || agentRowForLease === null)) {

--- a/apps/desktop/src/store/store.sendturn-agent-routing.test.ts
+++ b/apps/desktop/src/store/store.sendturn-agent-routing.test.ts
@@ -2288,6 +2288,24 @@ describe('sendTurn, resolver config (provider pin + effort)', () => {
     expect(acquire).not.toHaveBeenCalled();
   });
 
+  it('lets a database failure looking up the resolver agent propagate instead of reporting it missing', async () => {
+    const useAppStore = await seedResolverTurn();
+    const worktreeMod = await import('../features/worktree/worktree');
+    const acquire = worktreeMod.acquireWorktreeWriter as ReturnType<typeof vi.fn>;
+    acquire.mockClear();
+    getAgentByIdSpy.mockRejectedValueOnce(new Error('db exploded'));
+    useAppStore.setState({ sessionPhaseRuns: { [SESSION_ID]: [] } });
+    runTurnSpy.mockReset();
+    runTurnSpy.mockImplementation(() => emptyStream());
+
+    await expect(
+      useAppStore.getState().sendTurn({ sessionId: SESSION_ID, agentId: AGENT_A, content: 'go' }),
+    ).rejects.toThrow('db exploded');
+
+    expect(runTurnSpy).not.toHaveBeenCalled();
+    expect(acquire).not.toHaveBeenCalled();
+  });
+
   it('acquires the writer lease for a resolver whose kind is only persisted, with no override in memory', async () => {
     const useAppStore = await seedResolverTurn();
     const worktreeMod = await import('../features/worktree/worktree');


### PR DESCRIPTION
## Summary
Follow-up to #1682, which merged before these review fixes landed on its branch.
- a reload wiped the in-memory baseline, so a persisted dirty_tree block was cleared on a worktree that still had tracked changes; without a baseline any tracked change now counts as dirt
- a database error while looking up the resolver agent propagates instead of reading as a missing agent
- an abandoned lease emits its own `abandoned` reason

## Test plan
- [x] desktop vitest `src/store` + `src/features/session` 3379 passed across 302 files
- [x] `cargo test --locked` 642 + 10 passed, `cargo fmt --check` clean
- [x] desktop `tsc --noEmit` exit 0, prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)