### PR TITLE
feat(desktop): import custom workflows from another workspace

### DIFF
--- a/apps/desktop/src/features/workflows/components/WorkflowStudio/WorkflowImportSection/WorkflowImportSkeleton.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowStudio/WorkflowImportSection/WorkflowImportSkeleton.tsx
@@ -1,0 +1,8 @@
+import { Skeleton } from '@goodboy/ui';
+
+export const WorkflowImportSkeleton = () => (
+  <div role="status" aria-label="Loading workflows" className="flex flex-col gap-1">
+    <Skeleton className="h-3 w-16 rounded" />
+    <Skeleton className="h-7 w-full rounded-md" />
+  </div>
+);

--- a/apps/desktop/src/features/workflows/components/WorkflowStudio/WorkflowImportSection/index.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowStudio/WorkflowImportSection/index.tsx
@@ -1,0 +1,160 @@
+import type { Project, ProjectId, Workflow, WorkflowId, Workspace } from '@goodboy/types';
+import { Button, LensEmptyState, SectionHeader, Select } from '@goodboy/ui';
+import { CONCEPT_ICONS, CONCEPT_TONE } from '../../../../../shared/components/conceptIcons';
+import { WorkflowImportSkeleton } from './WorkflowImportSkeleton';
+
+type Props = {
+  readonly projects: ReadonlyArray<Project>;
+  readonly workspaces: ReadonlyArray<Workspace>;
+  readonly sourceProjectId: ProjectId | null;
+  readonly workflows: ReadonlyArray<Workflow>;
+  readonly sourceWorkflowId: WorkflowId | null;
+  readonly isLoadingWorkflows: boolean;
+  readonly isImporting: boolean;
+  readonly loadError: string | null;
+  readonly importError: string | null;
+  readonly onSelectProject: (projectId: ProjectId) => void;
+  readonly onSelectWorkflow: (workflowId: WorkflowId) => void;
+  readonly onImport: () => void;
+};
+
+type ProjectLabelParams = {
+  readonly project: Project;
+  readonly workspaces: ReadonlyArray<Workspace>;
+};
+
+const projectLabel = ({ project, workspaces }: ProjectLabelParams): string => {
+  const workspace = workspaces.find((candidate) => candidate.id === project.workspaceId);
+  if (workspace === undefined) {
+    return project.name;
+  }
+  return `${project.name} · ${workspace.name}`;
+};
+
+export const WorkflowImportSection = ({
+  projects,
+  workspaces,
+  sourceProjectId,
+  workflows,
+  sourceWorkflowId,
+  isLoadingWorkflows,
+  isImporting,
+  loadError,
+  importError,
+  onSelectProject,
+  onSelectWorkflow,
+  onImport,
+}: Props) => {
+  if (projects.length === 0) {
+    return (
+      <div className="flex flex-col gap-2">
+        <SectionHeader label="Import from another workspace" />
+        <LensEmptyState
+          icon={CONCEPT_ICONS.workspace}
+          tone={CONCEPT_TONE.workspace}
+          title="No other workspaces"
+          description="Add a project in another workspace to import its workflows."
+        />
+      </div>
+    );
+  }
+
+  return (
+    <section className="flex flex-col gap-2" aria-label="Import from another workspace">
+      <SectionHeader label="Import from another workspace" />
+      <label className="flex flex-col gap-1 text-2xs font-medium text-muted-foreground">
+        Project
+        <Select
+          size="sm"
+          block
+          value={sourceProjectId ?? ''}
+          onChange={(event) => {
+            const project = projects.find((candidate) => candidate.id === event.target.value);
+            if (project === undefined) {
+              return;
+            }
+            onSelectProject(project.id);
+          }}
+        >
+          <option value="" disabled>
+            Select a project
+          </option>
+          {projects.map((project) => (
+            <option key={project.id} value={project.id}>
+              {projectLabel({ project, workspaces })}
+            </option>
+          ))}
+        </Select>
+      </label>
+
+      {isLoadingWorkflows ? <WorkflowImportSkeleton /> : null}
+
+      {!isLoadingWorkflows && loadError != null ? (
+        <LensEmptyState
+          icon={CONCEPT_ICONS.errors}
+          tone={CONCEPT_TONE.errors}
+          title="Couldn't load workflows"
+          description={loadError}
+        />
+      ) : null}
+
+      {!isLoadingWorkflows && loadError == null && sourceProjectId != null ? (
+        workflows.length === 0 ? (
+          <LensEmptyState
+            icon={CONCEPT_ICONS.workflows}
+            tone={CONCEPT_TONE.workflows}
+            title="No workflows to import"
+            description="This workspace has no custom workflow presets."
+          />
+        ) : (
+          <label className="flex flex-col gap-1 text-2xs font-medium text-muted-foreground">
+            Workflow
+            <Select
+              size="sm"
+              block
+              value={sourceWorkflowId ?? ''}
+              onChange={(event) => {
+                const workflow = workflows.find((candidate) => candidate.id === event.target.value);
+                if (workflow === undefined) {
+                  return;
+                }
+                onSelectWorkflow(workflow.id);
+              }}
+            >
+              <option value="" disabled>
+                Select a workflow
+              </option>
+              {workflows.map((workflow) => (
+                <option key={workflow.id} value={workflow.id}>
+                  {workflow.name}
+                </option>
+              ))}
+            </Select>
+          </label>
+        )
+      ) : null}
+
+      {importError != null ? (
+        <LensEmptyState
+          icon={CONCEPT_ICONS.errors}
+          tone={CONCEPT_TONE.errors}
+          title="Couldn't import workflow"
+          description={importError}
+        />
+      ) : null}
+
+      {workflows.length > 0 && loadError == null ? (
+        <Button
+          size="sm"
+          className="w-full"
+          disabled={sourceWorkflowId === null}
+          isBusy={isImporting}
+          busyLabel="Importing"
+          onClick={onImport}
+        >
+          Import
+        </Button>
+      ) : null}
+    </section>
+  );
+};

--- a/apps/desktop/src/features/workflows/components/WorkflowStudio/WorkflowsRail/index.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowStudio/WorkflowsRail/index.tsx
@@ -1,4 +1,5 @@
-import { EmptyState, ScrollFade, SectionHeader, Tooltip, cn } from '@goodboy/ui';
+import type { ReactNode } from 'react';
+import { Divider, EmptyState, ScrollFade, SectionHeader, Tooltip, cn } from '@goodboy/ui';
 import { Check, Plus, RotateCcw, X } from 'lucide-react';
 import type { Workflow, WorkflowId } from '@goodboy/types';
 import {
@@ -17,6 +18,7 @@ type Props = {
   readonly onSelect: (t: Workflow) => void;
   readonly onNew: () => void;
   readonly onReset: () => void;
+  readonly importSection: ReactNode;
 };
 
 export const WorkflowsRail = ({
@@ -28,6 +30,7 @@ export const WorkflowsRail = ({
   onSelect,
   onNew,
   onReset,
+  importSection,
 }: Props) => {
   return (
     <div className="flex h-full min-h-0 flex-col">
@@ -70,6 +73,10 @@ export const WorkflowsRail = ({
           </ul>
         )}
       </ScrollFade>
+
+      <Divider />
+      <div className="shrink-0 px-3 py-3">{importSection}</div>
+      <Divider />
 
       <div className="shrink-0 px-3 pb-3 pt-1">
         {confirmReset ? (

--- a/apps/desktop/src/features/workflows/components/WorkflowsPanel/index.test.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowsPanel/index.test.tsx
@@ -187,6 +187,31 @@ describe('WorkflowsPanel', () => {
     expect(await screen.findByText('No workflows to import')).toBeDefined();
   });
 
+  it('excludes a seeded library preset from the import list', async () => {
+    configureSourceWorkspace();
+    invokeMock.mockResolvedValueOnce([makeWorkflowRow({ origin: 'library' })]);
+    renderPanel();
+
+    fireEvent.change(screen.getByLabelText('Project'), {
+      target: { value: 'project-source' },
+    });
+
+    expect(await screen.findByText('No workflows to import')).toBeDefined();
+    expect(screen.queryByRole('option', { name: 'Source review' })).toBeNull();
+  });
+
+  it('includes a legacy workflow with no origin in the import list', async () => {
+    configureSourceWorkspace();
+    invokeMock.mockResolvedValueOnce([makeWorkflowRow({ origin: undefined })]);
+    renderPanel();
+
+    fireEvent.change(screen.getByLabelText('Project'), {
+      target: { value: 'project-source' },
+    });
+
+    expect(await screen.findByRole('option', { name: 'Source review' })).toBeDefined();
+  });
+
   it('selects a source workflow and opens the imported copy', async () => {
     configureSourceWorkspace();
     invokeMock.mockResolvedValueOnce([makeWorkflowRow()]);

--- a/apps/desktop/src/features/workflows/components/WorkflowsPanel/index.test.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowsPanel/index.test.tsx
@@ -3,16 +3,19 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 
-const { state } = vi.hoisted(() => ({
+const { invokeMock, state } = vi.hoisted(() => ({
+  invokeMock: vi.fn(async (_cmd: string, _args?: unknown): Promise<unknown> => undefined),
   state: {
     phaseTemplates: {} as Record<string, ReadonlyArray<unknown>>,
     stepLibrary: {} as Record<string, ReadonlyArray<unknown>>,
     providers: [] as ReadonlyArray<unknown>,
+    projects: [] as ReadonlyArray<unknown>,
     workspaces: [] as ReadonlyArray<unknown>,
     workflowStudioDrafts: {} as Record<string, unknown>,
     workflowGenerations: {} as Record<string, unknown>,
     loadPhaseTemplates: vi.fn(async () => undefined),
     loadStepLibrary: vi.fn(async () => undefined),
+    copyWorkflowFromWorkspace: vi.fn(async (_input: unknown): Promise<unknown> => undefined),
     savePhaseTemplate: vi.fn(async (_input: unknown): Promise<unknown> => undefined),
     deleteWorkflow: vi.fn(async () => undefined),
     saveStepDef: vi.fn(async () => undefined),
@@ -25,7 +28,7 @@ const { state } = vi.hoisted(() => ({
   },
 }));
 
-vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn(async () => undefined) }));
+vi.mock('@tauri-apps/api/core', () => ({ invoke: invokeMock }));
 
 vi.mock('@goodboy/core', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@goodboy/core')>();
@@ -51,16 +54,20 @@ beforeEach(() => {
   state.phaseTemplates = {};
   state.stepLibrary = {};
   state.providers = [];
+  state.projects = [];
   state.workspaces = [];
   state.workflowStudioDrafts = {};
   state.workflowGenerations = {};
   state.loadPhaseTemplates = vi.fn(async () => undefined);
   state.loadStepLibrary = vi.fn(async () => undefined);
+  state.copyWorkflowFromWorkspace = vi.fn(async (_input: unknown): Promise<unknown> => undefined);
   state.savePhaseTemplate = vi.fn(async (_input: unknown): Promise<unknown> => undefined);
   state.deleteWorkflow = vi.fn(async () => undefined);
   state.saveStepDef = vi.fn(async () => undefined);
   state.deleteStepDef = vi.fn(async () => undefined);
   state.resetWorkflows = vi.fn(async () => undefined);
+  invokeMock.mockReset();
+  invokeMock.mockResolvedValue(undefined);
 });
 afterEach(cleanup);
 
@@ -86,6 +93,56 @@ const makeWorkflow = (overrides: Record<string, unknown> = {}) => ({
   ...overrides,
 });
 
+const sourceProject = {
+  id: 'project-source',
+  workspaceId: 'ws-source',
+  name: 'Source project',
+  rootPath: '/source',
+  kind: 'repo',
+};
+
+const sourceWorkspace = {
+  id: 'ws-source',
+  name: 'Source workspace',
+};
+
+const makeWorkflowRow = (overrides: Record<string, unknown> = {}) => ({
+  id: 'wf-source',
+  workspaceId: 'ws-source',
+  name: 'Source review',
+  description: 'Review a change',
+  goal: 'Find regressions',
+  processText: 'Inspect the change and report findings.',
+  steps: [
+    {
+      id: 'step-source',
+      workflowId: 'wf-source',
+      libraryStepId: null,
+      role: 'reviewer',
+      ordinal: 0,
+      name: 'Review',
+      promptPrefix: 'Review the change.',
+      expectedOutput: 'Findings',
+      providerOverride: null,
+      modelOverride: null,
+      effort: 'high',
+      verbosity: 'verbose',
+      orchestratorReason: null,
+    },
+  ],
+  createdAt: '2026-09-07T12:00:00.000Z',
+  updatedAt: '2026-09-07T12:00:00.000Z',
+  deletedAt: null,
+  isPreset: true,
+  origin: 'custom',
+  ...overrides,
+});
+
+const configureSourceWorkspace = () => {
+  state.projects = [sourceProject];
+  state.workspaces = [sourceWorkspace];
+};
+
 describe('WorkflowsPanel', () => {
   it('renders the empty-state copy when no workflows exist', () => {
     renderPanel();
@@ -95,6 +152,106 @@ describe('WorkflowsPanel', () => {
   it('renders a New workflow button', () => {
     renderPanel();
     expect(screen.getByRole('button', { name: /new workflow/i })).toBeDefined();
+  });
+
+  it('shows the empty import state without another workspace', () => {
+    renderPanel();
+
+    expect(screen.getByText('No other workspaces')).toBeDefined();
+  });
+
+  it('loads workflows after selecting a source project', async () => {
+    configureSourceWorkspace();
+    invokeMock.mockResolvedValueOnce([makeWorkflowRow()]);
+    renderPanel();
+
+    expect(screen.getByRole('option', { name: 'Source project · Source workspace' })).toBeDefined();
+    fireEvent.change(screen.getByLabelText('Project'), {
+      target: { value: 'project-source' },
+    });
+
+    expect(screen.getByRole('status', { name: 'Loading workflows' })).toBeDefined();
+    expect(await screen.findByRole('option', { name: 'Source review' })).toBeDefined();
+    expect(invokeMock).toHaveBeenCalledWith('workflow_list', { workspaceId: 'ws-source' });
+  });
+
+  it('shows the empty import state when the source has no custom presets', async () => {
+    configureSourceWorkspace();
+    invokeMock.mockResolvedValueOnce([]);
+    renderPanel();
+
+    fireEvent.change(screen.getByLabelText('Project'), {
+      target: { value: 'project-source' },
+    });
+
+    expect(await screen.findByText('No workflows to import')).toBeDefined();
+  });
+
+  it('selects a source workflow and opens the imported copy', async () => {
+    configureSourceWorkspace();
+    invokeMock.mockResolvedValueOnce([makeWorkflowRow()]);
+    const imported = makeWorkflow({
+      id: 'wf-imported',
+      name: 'Source review 2',
+      workspaceId: 'ws-1',
+      origin: 'custom',
+    });
+    state.copyWorkflowFromWorkspace = vi.fn(async () => imported);
+    renderPanel();
+
+    fireEvent.change(screen.getByLabelText('Project'), {
+      target: { value: 'project-source' },
+    });
+    await screen.findByRole('option', { name: 'Source review' });
+    fireEvent.change(screen.getByLabelText('Workflow'), {
+      target: { value: 'wf-source' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Import' }));
+
+    await waitFor(() =>
+      expect(state.copyWorkflowFromWorkspace).toHaveBeenCalledWith({
+        sourceWorkspaceId: 'ws-source',
+        sourceWorkflowId: 'wf-source',
+        targetWorkspaceId: 'ws-1',
+      }),
+    );
+    const name = screen.getByRole('textbox', { name: 'Workflow name' }) as HTMLInputElement;
+    expect(name.value).toBe('Source review 2');
+  });
+
+  it('keeps the source selection visible when import fails', async () => {
+    configureSourceWorkspace();
+    invokeMock.mockResolvedValueOnce([makeWorkflowRow()]);
+    state.copyWorkflowFromWorkspace = vi.fn(async () => {
+      throw new Error('target database unavailable');
+    });
+    renderPanel();
+
+    fireEvent.change(screen.getByLabelText('Project'), {
+      target: { value: 'project-source' },
+    });
+    await screen.findByRole('option', { name: 'Source review' });
+    fireEvent.change(screen.getByLabelText('Workflow'), {
+      target: { value: 'wf-source' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Import' }));
+
+    expect(await screen.findByText("Couldn't import workflow")).toBeDefined();
+    expect(screen.getByText('target database unavailable')).toBeDefined();
+    expect(screen.getByLabelText('Workflow')).toBeDefined();
+  });
+
+  it('shows a source loading failure inline', async () => {
+    configureSourceWorkspace();
+    invokeMock.mockRejectedValueOnce(new Error('source database unavailable'));
+    renderPanel();
+
+    fireEvent.change(screen.getByLabelText('Project'), {
+      target: { value: 'project-source' },
+    });
+
+    expect(await screen.findByText("Couldn't load workflows")).toBeDefined();
+    expect(screen.getByText('source database unavailable')).toBeDefined();
   });
 
   it('loads phase templates and step library on mount', () => {

--- a/apps/desktop/src/features/workflows/components/WorkflowsPanel/index.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowsPanel/index.tsx
@@ -20,6 +20,7 @@ import {
 } from '../../engine';
 import { useWorkflowDraft } from '../../engine/useWorkflowDraft';
 import { useWorkflowDrag } from '../../hooks/useWorkflowDrag';
+import { isImportableWorkflow } from '../../isImportableWorkflow';
 import { DragGhost } from '../WorkflowStudio/DragGhost';
 import { WorkflowComposer } from '../WorkflowStudio/WorkflowComposer';
 import { WorkflowImportSection } from '../WorkflowStudio/WorkflowImportSection';
@@ -267,14 +268,7 @@ export const WorkflowsPanel = ({ workspaceId }: Props) => {
       if (sourceLoadRequest.current !== requestId) {
         return;
       }
-      setSourceWorkflows(
-        loaded.filter(
-          (workflow) =>
-            workflow.deletedAt == null &&
-            workflow.isPreset !== false &&
-            workflow.origin !== 'orchestrated',
-        ),
-      );
+      setSourceWorkflows(loaded.filter(isImportableWorkflow));
     } catch (error) {
       if (sourceLoadRequest.current !== requestId) {
         return;

--- a/apps/desktop/src/features/workflows/components/WorkflowsPanel/index.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowsPanel/index.tsx
@@ -1,5 +1,12 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import type { ProviderId, StepDef, Workflow, WorkflowId, WorkspaceId } from '@goodboy/types';
+import type {
+  ProjectId,
+  ProviderId,
+  StepDef,
+  Workflow,
+  WorkflowId,
+  WorkspaceId,
+} from '@goodboy/types';
 import { formatError, StudioRailLayout } from '@goodboy/ui';
 import { EMPTY_ARRAY, useAppStore } from '../../../../store';
 import { primaryProjectRoot } from '../../../workspace/primaryProjectRoot';
@@ -15,8 +22,10 @@ import { useWorkflowDraft } from '../../engine/useWorkflowDraft';
 import { useWorkflowDrag } from '../../hooks/useWorkflowDrag';
 import { DragGhost } from '../WorkflowStudio/DragGhost';
 import { WorkflowComposer } from '../WorkflowStudio/WorkflowComposer';
+import { WorkflowImportSection } from '../WorkflowStudio/WorkflowImportSection';
 import { WorkflowStarter } from '../WorkflowStudio/WorkflowStarter';
 import { WorkflowsRail } from '../WorkflowStudio/WorkflowsRail';
+import { invokeWorkflowList } from '../../workflows';
 
 type Props = { readonly workspaceId: WorkspaceId };
 
@@ -35,6 +44,8 @@ export const WorkflowsPanel = ({ workspaceId }: Props) => {
     (state) => state.stepLibrary[workspaceId] ?? (EMPTY_ARRAY as ReadonlyArray<StepDef>),
   );
   const providers = useAppStore((state) => state.providers);
+  const projects = useAppStore((state) => state.projects);
+  const workspaces = useAppStore((state) => state.workspaces);
   const workspaceRoot = useAppStore((state) =>
     primaryProjectRoot({ projects: state.projects, workspaceId }),
   );
@@ -42,6 +53,7 @@ export const WorkflowsPanel = ({ workspaceId }: Props) => {
   const generation = useAppStore((state) => state.workflowGenerations[workspaceId]);
   const loadPhaseTemplates = useAppStore((state) => state.loadPhaseTemplates);
   const loadStepLibrary = useAppStore((state) => state.loadStepLibrary);
+  const copyWorkflowFromWorkspace = useAppStore((state) => state.copyWorkflowFromWorkspace);
   const savePhaseTemplate = useAppStore((state) => state.savePhaseTemplate);
   const deleteWorkflow = useAppStore((state) => state.deleteWorkflow);
   const saveStepDef = useAppStore((state) => state.saveStepDef);
@@ -78,8 +90,16 @@ export const WorkflowsPanel = ({ workspaceId }: Props) => {
   const [formError, setFormError] = useState<string | null>(null);
   const [confirmDefaults, setConfirmDefaults] = useState(false);
   const [resetting, setResetting] = useState(false);
+  const [sourceProjectId, setSourceProjectId] = useState<ProjectId | null>(null);
+  const [sourceWorkflows, setSourceWorkflows] = useState<ReadonlyArray<Workflow>>([]);
+  const [sourceWorkflowId, setSourceWorkflowId] = useState<WorkflowId | null>(null);
+  const [isLoadingSource, setIsLoadingSource] = useState(false);
+  const [isImporting, setIsImporting] = useState(false);
+  const [sourceLoadError, setSourceLoadError] = useState<string | null>(null);
+  const [importError, setImportError] = useState<string | null>(null);
   const editingIdRef = useRef<WorkflowId | null>(restoredWorkflow?.id ?? null);
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const sourceLoadRequest = useRef(0);
   const formRef = useRef(form);
   const savedFormRef = useRef(
     restoredWorkflow === null
@@ -87,6 +107,10 @@ export const WorkflowsPanel = ({ workspaceId }: Props) => {
       : JSON.stringify(draftFromWorkflow({ workflow: restoredWorkflow })),
   );
   formRef.current = form;
+  const sourceProjects = useMemo(
+    () => projects.filter((project) => project.workspaceId !== workspaceId),
+    [projects, workspaceId],
+  );
 
   useEffect(() => {
     void loadPhaseTemplates(workspaceId);
@@ -221,6 +245,69 @@ export const WorkflowsPanel = ({ workspaceId }: Props) => {
     setFormError(null);
   };
 
+  type SelectSourceProjectParams = {
+    readonly projectId: ProjectId;
+  };
+
+  const selectSourceProject = async ({ projectId }: SelectSourceProjectParams) => {
+    const project = sourceProjects.find((candidate) => candidate.id === projectId);
+    if (project === undefined) {
+      return;
+    }
+    const requestId = sourceLoadRequest.current + 1;
+    sourceLoadRequest.current = requestId;
+    setSourceProjectId(project.id);
+    setSourceWorkflowId(null);
+    setSourceWorkflows([]);
+    setSourceLoadError(null);
+    setImportError(null);
+    setIsLoadingSource(true);
+    try {
+      const loaded = await invokeWorkflowList(project.workspaceId);
+      if (sourceLoadRequest.current !== requestId) {
+        return;
+      }
+      setSourceWorkflows(
+        loaded.filter(
+          (workflow) =>
+            workflow.deletedAt == null &&
+            workflow.isPreset !== false &&
+            workflow.origin !== 'orchestrated',
+        ),
+      );
+    } catch (error) {
+      if (sourceLoadRequest.current !== requestId) {
+        return;
+      }
+      setSourceLoadError(formatError(error));
+    } finally {
+      if (sourceLoadRequest.current === requestId) {
+        setIsLoadingSource(false);
+      }
+    }
+  };
+
+  const importSelectedWorkflow = async () => {
+    const sourceProject = sourceProjects.find((project) => project.id === sourceProjectId);
+    if (sourceProject === undefined || sourceWorkflowId === null) {
+      return;
+    }
+    setIsImporting(true);
+    setImportError(null);
+    try {
+      const saved = await copyWorkflowFromWorkspace({
+        sourceWorkspaceId: sourceProject.workspaceId,
+        sourceWorkflowId,
+        targetWorkspaceId: workspaceId,
+      });
+      openEdit(saved);
+    } catch (error) {
+      setImportError(formatError(error));
+    } finally {
+      setIsImporting(false);
+    }
+  };
+
   const duplicate = async (workflow: Workflow) => {
     const source = draftFromWorkflow({ workflow });
     const saved = await savePhaseTemplate(
@@ -341,6 +428,22 @@ export const WorkflowsPanel = ({ workspaceId }: Props) => {
                 setConfirmDefaults(false);
               });
             }}
+            importSection={
+              <WorkflowImportSection
+                projects={sourceProjects}
+                workspaces={workspaces}
+                sourceProjectId={sourceProjectId}
+                workflows={sourceWorkflows}
+                sourceWorkflowId={sourceWorkflowId}
+                isLoadingWorkflows={isLoadingSource}
+                isImporting={isImporting}
+                loadError={sourceLoadError}
+                importError={importError}
+                onSelectProject={(projectId) => void selectSourceProject({ projectId })}
+                onSelectWorkflow={setSourceWorkflowId}
+                onImport={() => void importSelectedWorkflow()}
+              />
+            }
           />
         }
         detail={

--- a/apps/desktop/src/features/workflows/isImportableWorkflow.ts
+++ b/apps/desktop/src/features/workflows/isImportableWorkflow.ts
@@ -1,0 +1,9 @@
+import type { Workflow } from '@goodboy/types';
+
+export const isImportableWorkflow = (workflow: Workflow): boolean => {
+  return (
+    workflow.deletedAt == null &&
+    workflow.isPreset !== false &&
+    (workflow.origin == null || workflow.origin === 'custom')
+  );
+};

--- a/apps/desktop/src/store/slices/workflows/copyWorkflowFromWorkspace.test.ts
+++ b/apps/desktop/src/store/slices/workflows/copyWorkflowFromWorkspace.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  IsoDateTime,
+  Step,
+  StepDefId,
+  StepId,
+  Workflow,
+  WorkflowId,
+  WorkspaceId,
+} from '@goodboy/types';
+import type { AppStore } from '../../store';
+import type { SetFn } from './types';
+
+const { invokeWorkflowListSpy, invokeWorkflowUpsertSpy } = vi.hoisted(() => ({
+  invokeWorkflowListSpy: vi.fn(),
+  invokeWorkflowUpsertSpy: vi.fn(),
+}));
+
+vi.mock('../../../features/workflows/workflows', () => ({
+  invokeWorkflowList: invokeWorkflowListSpy,
+  invokeWorkflowUpsert: invokeWorkflowUpsertSpy,
+}));
+
+import { copyWorkflowFromWorkspace } from './copyWorkflowFromWorkspace';
+
+const SOURCE_WORKSPACE_ID = 'workspace-source' as WorkspaceId;
+const TARGET_WORKSPACE_ID = 'workspace-target' as WorkspaceId;
+const SOURCE_WORKFLOW_ID = 'workflow-source' as WorkflowId;
+const SOURCE_STEP_ID = 'step-source' as StepId;
+const LIBRARY_STEP_ID = 'library-step-source' as StepDefId;
+const IMPORTED_WORKFLOW_ID = 'workflow-imported' as WorkflowId;
+const IMPORTED_STEP_ID = 'step-imported' as StepId;
+const NOW = '2026-09-07T12:00:00.000Z' as IsoDateTime;
+
+const sourceStep: Step = {
+  id: SOURCE_STEP_ID,
+  workflowId: SOURCE_WORKFLOW_ID,
+  libraryStepId: LIBRARY_STEP_ID,
+  role: 'reviewer',
+  ordinal: 3,
+  name: 'Review',
+  promptPrefix: 'Review the implementation.',
+  expectedOutput: 'A prioritized findings list.',
+  providerOverride: 'codex',
+  modelOverride: 'gpt-5.4',
+  effort: 'high',
+  verbosity: 'verbose',
+  orchestratorReason: 'The implementation is ready for review.',
+};
+
+const sourceWorkflow: Workflow = {
+  id: SOURCE_WORKFLOW_ID,
+  workspaceId: SOURCE_WORKSPACE_ID,
+  name: 'Review and resolve',
+  description: 'Review changes and resolve findings.',
+  goal: 'Land a reviewed change',
+  processText: 'Review first, then resolve every finding.',
+  isPreset: true,
+  origin: 'custom',
+  steps: [sourceStep],
+  createdAt: NOW,
+  updatedAt: NOW,
+};
+
+const importedWorkflow: Workflow = {
+  ...sourceWorkflow,
+  id: IMPORTED_WORKFLOW_ID,
+  workspaceId: TARGET_WORKSPACE_ID,
+  name: 'Review and resolve 2',
+  origin: 'custom',
+  steps: [
+    {
+      ...sourceStep,
+      id: IMPORTED_STEP_ID,
+      workflowId: IMPORTED_WORKFLOW_ID,
+      libraryStepId: undefined,
+    },
+  ],
+};
+
+const buildHarness = () => {
+  let state = {
+    phaseTemplates: { [TARGET_WORKSPACE_ID]: [] },
+  } as unknown as AppStore;
+  const set: SetFn = (update) => {
+    const patch = typeof update === 'function' ? update(state) : update;
+    state = { ...state, ...patch };
+  };
+  return {
+    copy: copyWorkflowFromWorkspace({ set }),
+    getState: () => state,
+  };
+};
+
+describe('copyWorkflowFromWorkspace', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('copies a preset into the target workspace without source links', async () => {
+    invokeWorkflowListSpy
+      .mockResolvedValueOnce([sourceWorkflow])
+      .mockResolvedValueOnce([importedWorkflow]);
+    invokeWorkflowUpsertSpy.mockResolvedValue(importedWorkflow);
+    vi.spyOn(globalThis.crypto, 'randomUUID')
+      .mockReturnValueOnce('00000000-0000-4000-8000-000000000001')
+      .mockReturnValueOnce('00000000-0000-4000-8000-000000000002');
+    const { copy, getState } = buildHarness();
+
+    const result = await copy({
+      sourceWorkspaceId: SOURCE_WORKSPACE_ID,
+      sourceWorkflowId: SOURCE_WORKFLOW_ID,
+      targetWorkspaceId: TARGET_WORKSPACE_ID,
+    });
+
+    expect(invokeWorkflowUpsertSpy).toHaveBeenCalledWith({
+      id: '00000000-0000-4000-8000-000000000001',
+      workspaceId: TARGET_WORKSPACE_ID,
+      name: 'Review and resolve',
+      description: 'Review changes and resolve findings.',
+      goal: 'Land a reviewed change',
+      processText: 'Review first, then resolve every finding.',
+      isPreset: true,
+      origin: 'custom',
+      steps: [
+        {
+          id: '00000000-0000-4000-8000-000000000002',
+          role: 'reviewer',
+          ordinal: 3,
+          name: 'Review',
+          promptPrefix: 'Review the implementation.',
+          expectedOutput: 'A prioritized findings list.',
+          providerOverride: 'codex',
+          modelOverride: 'gpt-5.4',
+          effort: 'high',
+          verbosity: 'verbose',
+          orchestratorReason: 'The implementation is ready for review.',
+        },
+      ],
+    });
+    expect(invokeWorkflowUpsertSpy.mock.calls[0]?.[0].steps[0]).not.toHaveProperty('libraryStepId');
+    expect(result).toBe(importedWorkflow);
+    expect(getState().phaseTemplates[TARGET_WORKSPACE_ID]).toEqual([importedWorkflow]);
+  });
+});

--- a/apps/desktop/src/store/slices/workflows/copyWorkflowFromWorkspace.test.ts
+++ b/apps/desktop/src/store/slices/workflows/copyWorkflowFromWorkspace.test.ts
@@ -146,4 +146,52 @@ describe('copyWorkflowFromWorkspace', () => {
     expect(result).toBe(importedWorkflow);
     expect(getState().phaseTemplates[TARGET_WORKSPACE_ID]).toEqual([importedWorkflow]);
   });
+
+  it('rejects a library preset workflow', async () => {
+    invokeWorkflowListSpy.mockResolvedValueOnce([{ ...sourceWorkflow, origin: 'library' }]);
+    const { copy } = buildHarness();
+
+    await expect(
+      copy({
+        sourceWorkspaceId: SOURCE_WORKSPACE_ID,
+        sourceWorkflowId: SOURCE_WORKFLOW_ID,
+        targetWorkspaceId: TARGET_WORKSPACE_ID,
+      }),
+    ).rejects.toThrow('workflow not found in source workspace');
+    expect(invokeWorkflowUpsertSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects an orchestrated workflow', async () => {
+    invokeWorkflowListSpy.mockResolvedValueOnce([{ ...sourceWorkflow, origin: 'orchestrated' }]);
+    const { copy } = buildHarness();
+
+    await expect(
+      copy({
+        sourceWorkspaceId: SOURCE_WORKSPACE_ID,
+        sourceWorkflowId: SOURCE_WORKFLOW_ID,
+        targetWorkspaceId: TARGET_WORKSPACE_ID,
+      }),
+    ).rejects.toThrow('workflow not found in source workspace');
+    expect(invokeWorkflowUpsertSpy).not.toHaveBeenCalled();
+  });
+
+  it('accepts a legacy workflow with no origin', async () => {
+    const legacyWorkflow = { ...sourceWorkflow, origin: undefined };
+    invokeWorkflowListSpy
+      .mockResolvedValueOnce([legacyWorkflow])
+      .mockResolvedValueOnce([importedWorkflow]);
+    invokeWorkflowUpsertSpy.mockResolvedValue(importedWorkflow);
+    vi.spyOn(globalThis.crypto, 'randomUUID')
+      .mockReturnValueOnce('00000000-0000-4000-8000-000000000003')
+      .mockReturnValueOnce('00000000-0000-4000-8000-000000000004');
+    const { copy } = buildHarness();
+
+    const result = await copy({
+      sourceWorkspaceId: SOURCE_WORKSPACE_ID,
+      sourceWorkflowId: SOURCE_WORKFLOW_ID,
+      targetWorkspaceId: TARGET_WORKSPACE_ID,
+    });
+
+    expect(result).toBe(importedWorkflow);
+  });
 });

--- a/apps/desktop/src/store/slices/workflows/copyWorkflowFromWorkspace.ts
+++ b/apps/desktop/src/store/slices/workflows/copyWorkflowFromWorkspace.ts
@@ -1,4 +1,5 @@
 import type { StepId, Workflow, WorkflowId, WorkspaceId } from '@goodboy/types';
+import { isImportableWorkflow } from '../../../features/workflows/isImportableWorkflow';
 import { invokeWorkflowList, invokeWorkflowUpsert } from '../../../features/workflows/workflows';
 import type { SetFn } from './types';
 
@@ -20,11 +21,7 @@ export const copyWorkflowFromWorkspace = ({ set }: FactoryParams) => {
   }: CopyWorkflowFromWorkspaceParams): Promise<Workflow> => {
     const sourceWorkflows = await invokeWorkflowList(sourceWorkspaceId);
     const sourceWorkflow = sourceWorkflows.find(
-      (workflow) =>
-        workflow.id === sourceWorkflowId &&
-        workflow.deletedAt == null &&
-        workflow.isPreset !== false &&
-        workflow.origin !== 'orchestrated',
+      (workflow) => workflow.id === sourceWorkflowId && isImportableWorkflow(workflow),
     );
     if (sourceWorkflow === undefined) {
       throw new Error('workflow not found in source workspace');

--- a/apps/desktop/src/store/slices/workflows/copyWorkflowFromWorkspace.ts
+++ b/apps/desktop/src/store/slices/workflows/copyWorkflowFromWorkspace.ts
@@ -1,0 +1,80 @@
+import type { StepId, Workflow, WorkflowId, WorkspaceId } from '@goodboy/types';
+import { invokeWorkflowList, invokeWorkflowUpsert } from '../../../features/workflows/workflows';
+import type { SetFn } from './types';
+
+export type CopyWorkflowFromWorkspaceParams = {
+  readonly sourceWorkspaceId: WorkspaceId;
+  readonly sourceWorkflowId: WorkflowId;
+  readonly targetWorkspaceId: WorkspaceId;
+};
+
+type FactoryParams = {
+  readonly set: SetFn;
+};
+
+export const copyWorkflowFromWorkspace = ({ set }: FactoryParams) => {
+  return async ({
+    sourceWorkspaceId,
+    sourceWorkflowId,
+    targetWorkspaceId,
+  }: CopyWorkflowFromWorkspaceParams): Promise<Workflow> => {
+    const sourceWorkflows = await invokeWorkflowList(sourceWorkspaceId);
+    const sourceWorkflow = sourceWorkflows.find(
+      (workflow) =>
+        workflow.id === sourceWorkflowId &&
+        workflow.deletedAt == null &&
+        workflow.isPreset !== false &&
+        workflow.origin !== 'orchestrated',
+    );
+    if (sourceWorkflow === undefined) {
+      throw new Error('workflow not found in source workspace');
+    }
+
+    const saved = await invokeWorkflowUpsert({
+      id: crypto.randomUUID() as WorkflowId,
+      workspaceId: targetWorkspaceId,
+      name: sourceWorkflow.name,
+      description: sourceWorkflow.description,
+      ...(sourceWorkflow.goal != null && { goal: sourceWorkflow.goal }),
+      ...(sourceWorkflow.processText != null && { processText: sourceWorkflow.processText }),
+      isPreset: true,
+      origin: 'custom',
+      steps: sourceWorkflow.steps.map((step) => ({
+        id: crypto.randomUUID() as StepId,
+        ...(step.role != null && { role: step.role }),
+        ordinal: step.ordinal,
+        name: step.name,
+        promptPrefix: step.promptPrefix,
+        ...(step.expectedOutput != null && { expectedOutput: step.expectedOutput }),
+        ...(step.providerOverride != null && { providerOverride: step.providerOverride }),
+        ...(step.modelOverride != null && { modelOverride: step.modelOverride }),
+        ...(step.effort != null && { effort: step.effort }),
+        ...(step.verbosity != null && { verbosity: step.verbosity }),
+        ...(step.orchestratorReason != null && {
+          orchestratorReason: step.orchestratorReason,
+        }),
+      })),
+    });
+    const presets = await invokeWorkflowList(targetWorkspaceId);
+
+    set((state) => {
+      const refreshedIds = new Set([...presets.map((workflow) => workflow.id), saved.id]);
+      const retained = (state.phaseTemplates[targetWorkspaceId] ?? []).filter(
+        (workflow) =>
+          !refreshedIds.has(workflow.id) &&
+          (workflow.deletedAt != null || workflow.isPreset === false),
+      );
+      const refreshed = presets.some((workflow) => workflow.id === saved.id)
+        ? [...presets, ...retained]
+        : [...presets, saved, ...retained];
+      return {
+        phaseTemplates: {
+          ...state.phaseTemplates,
+          [targetWorkspaceId]: refreshed,
+        },
+      };
+    });
+
+    return saved;
+  };
+};

--- a/apps/desktop/src/store/slices/workflows/index.ts
+++ b/apps/desktop/src/store/slices/workflows/index.ts
@@ -14,6 +14,7 @@ import { loadPhaseTemplates } from './loadPhaseTemplates';
 import { loadStepLibrary } from './loadStepLibrary';
 import { maybeAutoAdvanceWorkflow } from './maybeAutoAdvanceWorkflow';
 import { continueWorkflowRun } from './continueWorkflowRun';
+import { copyWorkflowFromWorkspace } from './copyWorkflowFromWorkspace';
 import { orchestrateNextStep } from './orchestrateNextStep';
 import { setWorkflowOrchestratorHints } from './setWorkflowOrchestratorHints';
 import { setWorkflowOrchestratorRouting } from './setWorkflowOrchestratorRouting';
@@ -38,6 +39,7 @@ import type { GetFn, SetFn } from './types';
 export const createWorkflowsSlice = (set: SetFn, get: GetFn) => {
   return {
     loadPhaseTemplates: loadPhaseTemplates(set),
+    copyWorkflowFromWorkspace: copyWorkflowFromWorkspace({ set }),
     savePhaseTemplate: savePhaseTemplate(set),
     deleteWorkflow: deleteWorkflow(set, get),
     renameWorkflow: renameWorkflow(set, get),

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -158,6 +158,7 @@ import { createSlotsSlice } from './slices/slots';
 import { createOverridesSlice } from './slices/overrides';
 import { createCredentialsSlice } from './slices/credentials';
 import { createWorkflowsSlice } from './slices/workflows';
+import type { CopyWorkflowFromWorkspaceParams } from './slices/workflows/copyWorkflowFromWorkspace';
 import type { OrchestrateOptions } from './slices/workflows/orchestrateNextStep';
 import type { ActivateWorkflowAgentParams } from './slices/workflows/activateWorkflowAgent';
 import { createSettingsSlice } from './slices/settings';
@@ -552,6 +553,7 @@ type AppActions = {
   reattachScriptRuns(): Promise<void>;
   cancelScript(sessionId: SessionId, scriptId: string): Promise<void>;
   loadPhaseTemplates(workspaceId: WorkspaceId): Promise<void>;
+  copyWorkflowFromWorkspace(params: CopyWorkflowFromWorkspaceParams): Promise<Workflow>;
   savePhaseTemplate(template: WorkflowUpsertArgs): Promise<Workflow>;
   deleteWorkflow(id: WorkflowId, workspaceId: WorkspaceId): Promise<void>;
   renameWorkflow(workspaceId: WorkspaceId, workflowId: WorkflowId, name: string): Promise<void>;


### PR DESCRIPTION
## What

Workflow Studio gains an inline "Import from another workspace" section in the workflows rail. Pick a source project (only projects living in a different workspace), pick one of that workspace's custom preset workflows, import. The workflow is copied into the current workspace through the existing upsert path with a fresh workflow id and fresh step ids, `isPreset: true`, `origin: 'custom'`, `libraryStepId` cleared, and every step field preserved (role, ordinal, name, prompt, expected output, provider, model, effort, verbosity, orchestrator reason). After import the list refreshes and the copied workflow is selected. Loading, empty and error states are inline.

## Why

Workflows are scoped per workspace and the only reuse path was an in-workspace Duplicate. Users with several workspaces had to rebuild the same custom workflow by hand.

Closes #1622

A global default workflow is left as a follow-up.

## Test plan

- `pnpm --filter @goodboy/desktop exec vitest run src/store/slices/workflows/copyWorkflowFromWorkspace.test.ts src/features/workflows/components/WorkflowsPanel/index.test.tsx`: 20 passed
- `pnpm --filter @goodboy/desktop typecheck`: clean
- `pnpm knip`: clean
- Manual: open Workflow Studio in a workspace, import a workflow from a project of another workspace, confirm it appears selected with all step routing intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)