### PR TITLE
fix(core): honor providers studio task models at every runtime caller

### DIFF
--- a/apps/desktop/src/features/github/components/GitHubStudio/CreatePrPanel.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/CreatePrPanel.tsx
@@ -67,9 +67,10 @@ export const CreatePrPanel = ({
       taskModelAgentSpawnConfig({
         task: 'pr_draft',
         preferences: workspaceOverrides?.taskModels,
-        defaultProviderId: session?.providerPreference?.defaultProvider ?? 'anthropic',
+        workspaceDefaultProviderId: workspaceOverrides?.defaultProviderId,
+        sessionDefaultProviderId: session?.providerPreference?.defaultProvider ?? 'anthropic',
       }),
-    [workspaceOverrides?.taskModels, session?.providerPreference?.defaultProvider],
+    [workspaceOverrides, session?.providerPreference?.defaultProvider],
   );
 
   const [mode, setMode] = useState<CreateMode>('manual');

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel/CreateMrForm.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel/CreateMrForm.tsx
@@ -47,9 +47,10 @@ export const CreateMrForm = ({ sessionId, branch, error, onClose }: Props) => {
       taskModelAgentSpawnConfig({
         task: 'pr_draft',
         preferences: workspaceOverrides?.taskModels,
-        defaultProviderId: session?.providerPreference?.defaultProvider ?? 'anthropic',
+        workspaceDefaultProviderId: workspaceOverrides?.defaultProviderId,
+        sessionDefaultProviderId: session?.providerPreference?.defaultProvider ?? 'anthropic',
       }),
-    [workspaceOverrides?.taskModels, session?.providerPreference?.defaultProvider],
+    [workspaceOverrides, session?.providerPreference?.defaultProvider],
   );
 
   const [mode, setMode] = useState<CreateMode>('manual');

--- a/apps/desktop/src/features/notifications/components/NotificationCenter/index.tsx
+++ b/apps/desktop/src/features/notifications/components/NotificationCenter/index.tsx
@@ -418,10 +418,22 @@ const RetryWithPicker = ({ action, onDone }: RetryWithPickerProps) => {
   if (providerId == null) {
     return null;
   }
-  const recommendedModel = resolveTaskModel('summarizer', null, providerId).model;
+  const recommendedModel = resolveTaskModel({
+    task: 'summarizer',
+    preferences: null,
+    workspaceDefaultProviderId: providerId,
+    sessionDefaultProviderId: providerId,
+  }).model;
   const dispatch = () => {
     const taskModel =
-      model === '' ? resolveTaskModel('summarizer', null, providerId) : { providerId, model };
+      model === ''
+        ? resolveTaskModel({
+            task: 'summarizer',
+            preferences: null,
+            workspaceDefaultProviderId: providerId,
+            sessionDefaultProviderId: providerId,
+          })
+        : { providerId, model };
     const override: TaskModelPreference = { ...taskModel, effort };
     const store = useAppStore.getState();
     switch (action.kind) {

--- a/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/RoleModelRow/index.test.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/RoleModelRow/index.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
-import { resolveRoleRouting } from '@goodboy/core';
+import { resolveRoleRouting, resolveStoredModelSelection } from '@goodboy/core';
 import type { ProviderId, RoleModelPreference } from '@goodboy/types';
 import { RoleModelRow } from './index';
 
@@ -72,10 +72,11 @@ describe('RoleModelRow', () => {
     for (const [preference] of onChange.mock.calls) {
       expect(preference?.providerId).toBe('cursor');
     }
-    expect(onChange.mock.calls.at(-1)?.[0]).toMatchObject({
-      providerId: 'cursor',
-      model: 'opus-5',
-    });
+    const last = onChange.mock.calls.at(-1)?.[0];
+    expect(last?.providerId).toBe('cursor');
+    expect(
+      resolveStoredModelSelection({ provider: 'cursor', id: last?.model ?? '' }).selection.key,
+    ).toBe('opus-5');
   });
 
   it('pins a role running on its compiled default to the provider picked', () => {

--- a/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/TaskModelRow/index.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/TaskModelRow/index.tsx
@@ -32,7 +32,12 @@ export const TaskModelRow = ({
   disabled,
   onChange,
 }: Props) => {
-  const automatic = resolveTaskModel(task, null, defaultProviderId);
+  const automatic = resolveTaskModel({
+    task,
+    preferences: null,
+    workspaceDefaultProviderId: defaultProviderId,
+    sessionDefaultProviderId: defaultProviderId,
+  });
   const preferredProviderId = preference?.providerId ?? automatic.providerId;
   const [providerId, setProviderId] = useState(preferredProviderId);
   const pendingProvider = useRef(preferredProviderId);
@@ -40,7 +45,12 @@ export const TaskModelRow = ({
   const availableProviderIds = connectedProviderIds.filter(
     (candidate) => PROVIDER_CAPABILITIES[candidate].models.length > 0,
   );
-  const recommendedModel = resolveTaskModel(task, null, providerId).model;
+  const recommendedModel = resolveTaskModel({
+    task,
+    preferences: null,
+    workspaceDefaultProviderId: providerId,
+    sessionDefaultProviderId: defaultProviderId,
+  }).model;
   const effortModel = model === '' ? recommendedModel : model;
   const effortValue = preference?.effort ?? DEFAULT_EFFORT;
   const pendingModel = useRef(effortModel);
@@ -89,11 +99,23 @@ export const TaskModelRow = ({
               }
               setProviderId(next);
               pendingProvider.current = next;
-              pendingModel.current = resolveTaskModel(task, null, next).model;
+              pendingModel.current = resolveTaskModel({
+                task,
+                preferences: null,
+                workspaceDefaultProviderId: next,
+                sessionDefaultProviderId: defaultProviderId,
+              }).model;
               if (preference == null) {
                 return;
               }
-              onChange(resolveTaskModel(task, null, next));
+              onChange(
+                resolveTaskModel({
+                  task,
+                  preferences: null,
+                  workspaceDefaultProviderId: next,
+                  sessionDefaultProviderId: defaultProviderId,
+                }),
+              );
             }}
             onModel={(nextModel) => {
               if (nextModel === '') {

--- a/apps/desktop/src/features/session/components/AgentSpawnConfig/taskModelAgentSpawnConfig.test.ts
+++ b/apps/desktop/src/features/session/components/AgentSpawnConfig/taskModelAgentSpawnConfig.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { taskModelAgentSpawnConfig } from './taskModelAgentSpawnConfig';
+
+describe('taskModelAgentSpawnConfig', () => {
+  it('passes the configured task effort into the spawn config', () => {
+    const config = taskModelAgentSpawnConfig({
+      task: 'pr_draft',
+      preferences: {
+        pr_draft: {
+          providerId: 'codex',
+          model: 'gpt-5.6-luna',
+          effort: 'xhigh',
+        },
+      },
+      workspaceDefaultProviderId: 'codex',
+      sessionDefaultProviderId: 'anthropic',
+    });
+
+    expect(config).toMatchObject({
+      provider: 'codex',
+      model: 'gpt-5.6-luna',
+      effort: 'xhigh',
+    });
+  });
+});

--- a/apps/desktop/src/features/session/components/AgentSpawnConfig/taskModelAgentSpawnConfig.ts
+++ b/apps/desktop/src/features/session/components/AgentSpawnConfig/taskModelAgentSpawnConfig.ts
@@ -7,19 +7,26 @@ import { DEFAULT_AGENT_SPAWN_CONFIG } from './defaultAgentSpawnConfig';
 type Params = {
   readonly task: AuxTaskId;
   readonly preferences: TaskModelPreferences | null | undefined;
-  readonly defaultProviderId: ProviderId;
+  readonly workspaceDefaultProviderId: ProviderId | null | undefined;
+  readonly sessionDefaultProviderId: ProviderId;
 };
 
 export const taskModelAgentSpawnConfig = ({
   task,
   preferences,
-  defaultProviderId,
+  workspaceDefaultProviderId,
+  sessionDefaultProviderId,
 }: Params): AgentSpawnConfigValue => {
-  const taskModel = resolveTaskModel(task, preferences, defaultProviderId);
+  const taskModel = resolveTaskModel({
+    task,
+    preferences,
+    workspaceDefaultProviderId,
+    sessionDefaultProviderId,
+  });
   return {
     ...DEFAULT_AGENT_SPAWN_CONFIG,
     provider: taskModel.providerId,
     model: taskModel.model,
-    effort: clampEffort(taskModel.model, DEFAULT_AGENT_SPAWN_CONFIG.effort),
+    effort: clampEffort(taskModel.model, taskModel.effort ?? DEFAULT_AGENT_SPAWN_CONFIG.effort),
   };
 };

--- a/apps/desktop/src/features/session/components/WorkflowBuilderView/index.test.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowBuilderView/index.test.tsx
@@ -682,7 +682,7 @@ describe('WorkflowBuilderView (orchestrated mode)', () => {
     const orchestrator = orchestratorPicker();
     expect(
       within(orchestrator).getByRole('button', { name: /^model:auto$/i }).dataset.recommendedModel,
-    ).toBe('gpt-5.6');
+    ).toBe('gpt-5.6-sol');
     expect(within(orchestrator).getByRole('button', { name: /^effort:high$/i })).toBeDefined();
 
     fireEvent.click(within(orchestrator).getByRole('button', { name: /^effort:high$/i }));
@@ -693,7 +693,7 @@ describe('WorkflowBuilderView (orchestrated mode)', () => {
       'sess-1',
       expect.any(String),
       expect.objectContaining({
-        orchestratorRouting: { providerId: 'codex', model: 'gpt-5.6', effort: 'xhigh' },
+        orchestratorRouting: { providerId: 'codex', model: 'gpt-5.6-sol', effort: 'xhigh' },
       }),
     );
   });
@@ -1259,6 +1259,32 @@ describe('WorkflowBuilderView (planner model picker)', () => {
 
     expect(vi.mocked(PlannerClient)).toHaveBeenCalledWith(
       expect.objectContaining({ effort: 'xhigh' }),
+    );
+  });
+
+  it('PlannerClient receives the configured plan_generation effort', async () => {
+    storeState.workspaceOverrides = {
+      'ws-1': {
+        taskModels: {
+          plan_generation: {
+            providerId: 'anthropic',
+            model: 'claude-sonnet-5',
+            effort: 'medium',
+          },
+        },
+      },
+    };
+    mockPlan.mockResolvedValue({ output: PLAN_FIXTURE });
+    render(<WorkflowBuilderView session={session} onClose={vi.fn()} />);
+    setGoal();
+    fireEvent.change(screen.getByPlaceholderText(/describe the process/i), {
+      target: { value: 'do something' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /generate plan/i }));
+    await waitFor(() => screen.getByText('Ready'));
+
+    expect(vi.mocked(PlannerClient)).toHaveBeenCalledWith(
+      expect.objectContaining({ providerId: 'anthropic', model: 'sonnet-5', effort: 'medium' }),
     );
   });
 

--- a/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
@@ -288,7 +288,7 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
   const [confirmDeleteId, setConfirmDeleteId] = useState<WorkflowId | null>(null);
   const [plannerProviderOverride, setPlannerProviderOverride] = useState<ProviderId | ''>('');
   const [plannerModelOverride, setPlannerModelOverride] = useState('');
-  const [plannerEffortOverride, setPlannerEffortOverride] = useState<EffortLevel>(PLANNER_EFFORT);
+  const [plannerEffortOverride, setPlannerEffortOverride] = useState<EffortLevel | null>(null);
 
   const providerId =
     providers.find((p) => p.id === session.providerOverride)?.id ??
@@ -300,12 +300,24 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
   );
 
   const resolvedPlanTaskModel = useMemo(
-    () => resolveTaskModel('plan_generation', workspaceOverrides?.taskModels, providerId),
+    () =>
+      resolveTaskModel({
+        task: 'plan_generation',
+        preferences: workspaceOverrides?.taskModels,
+        workspaceDefaultProviderId: workspaceOverrides?.defaultProviderId,
+        sessionDefaultProviderId: providerId,
+      }),
     [workspaceOverrides, providerId],
   );
 
   const resolvedProsePolishTaskModel = useMemo(
-    () => resolveTaskModel('prose_polish', workspaceOverrides?.taskModels, providerId),
+    () =>
+      resolveTaskModel({
+        task: 'prose_polish',
+        preferences: workspaceOverrides?.taskModels,
+        workspaceDefaultProviderId: workspaceOverrides?.defaultProviderId,
+        sessionDefaultProviderId: providerId,
+      }),
     [workspaceOverrides, providerId],
   );
 
@@ -315,13 +327,26 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
   const plannerRecommendedModel = useMemo(
     () =>
       plannerProviderOverride !== ''
-        ? resolveTaskModel('plan_generation', null, plannerProviderOverride).model
+        ? resolveTaskModel({
+            task: 'plan_generation',
+            preferences: null,
+            workspaceDefaultProviderId: plannerProviderOverride,
+            sessionDefaultProviderId: providerId,
+          }).model
         : resolvedPlanTaskModel.model,
-    [plannerProviderOverride, resolvedPlanTaskModel],
+    [plannerProviderOverride, providerId, resolvedPlanTaskModel],
   );
 
+  const plannerEffort = plannerEffortOverride ?? resolvedPlanTaskModel.effort ?? PLANNER_EFFORT;
+
   const resolvedOrchestratorTaskModel = useMemo(
-    () => resolveTaskModel('workflow_orchestrator', workspaceOverrides?.taskModels, providerId),
+    () =>
+      resolveTaskModel({
+        task: 'workflow_orchestrator',
+        preferences: workspaceOverrides?.taskModels,
+        workspaceDefaultProviderId: workspaceOverrides?.defaultProviderId,
+        sessionDefaultProviderId: providerId,
+      }),
     [workspaceOverrides, providerId],
   );
 
@@ -339,7 +364,12 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
   const recommendedOrchestratorModel = useMemo(
     () =>
       orchestratorProviderOverride !== ''
-        ? resolveTaskModel('workflow_orchestrator', null, orchestratorProviderOverride).model
+        ? resolveTaskModel({
+            task: 'workflow_orchestrator',
+            preferences: null,
+            workspaceDefaultProviderId: orchestratorProviderOverride,
+            sessionDefaultProviderId: providerId,
+          }).model
         : resolvedOrchestratorTaskModel.model,
     [orchestratorProviderOverride, resolvedOrchestratorTaskModel],
   );
@@ -690,7 +720,7 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
       const taskModel = {
         providerId: plannerEffectiveProviderId,
         model: effectiveModel,
-        effort: plannerEffortOverride,
+        effort: plannerEffort,
       };
       const client = new PlannerClient({
         ...taskModel,
@@ -1219,7 +1249,7 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
                           model={plannerModelOverride}
                           effort={{
                             editable: true,
-                            value: plannerEffortOverride,
+                            value: plannerEffort,
                             onChange: setPlannerEffortOverride,
                           }}
                           recommendation={{

--- a/apps/desktop/src/features/session/hooks/useRebaseAgent/index.ts
+++ b/apps/desktop/src/features/session/hooks/useRebaseAgent/index.ts
@@ -94,9 +94,10 @@ export const useRebaseAgent = ({ sessionId, status, onError }: Params): Result =
       taskModelAgentSpawnConfig({
         task: 'rebase',
         preferences: workspaceOverrides?.taskModels,
-        defaultProviderId: session?.providerPreference.defaultProvider ?? 'anthropic',
+        workspaceDefaultProviderId: workspaceOverrides?.defaultProviderId,
+        sessionDefaultProviderId: session?.providerPreference.defaultProvider ?? 'anthropic',
       }),
-    [session?.providerPreference.defaultProvider, workspaceOverrides?.taskModels],
+    [session?.providerPreference.defaultProvider, workspaceOverrides],
   );
   const isAgentRunning =
     phaseRuns?.some(

--- a/apps/desktop/src/features/workflows/components/OrchestratorPanel/OrchestratorRoutingRow/index.test.tsx
+++ b/apps/desktop/src/features/workflows/components/OrchestratorPanel/OrchestratorRoutingRow/index.test.tsx
@@ -91,6 +91,18 @@ describe('OrchestratorRoutingRow', () => {
     }
   });
 
+  it('uses the workspace default provider, not the session provider, for the automatic routing', () => {
+    Object.assign(storeState, {
+      workspaceOverrides: {
+        'workspace-1': { defaultProviderId: 'cursor' },
+      },
+    });
+
+    renderRow(run());
+
+    expect(screen.getByRole('button', { name: /^Orchestrator routing: Cursor/ })).toBeTruthy();
+  });
+
   it('commits the provider just picked, not the one pinned before', () => {
     renderRow(run({ providerId: 'anthropic', model: 'claude-sonnet-4-6' }));
 

--- a/apps/desktop/src/features/workflows/components/OrchestratorPanel/OrchestratorRoutingRow/index.tsx
+++ b/apps/desktop/src/features/workflows/components/OrchestratorPanel/OrchestratorRoutingRow/index.tsx
@@ -30,6 +30,11 @@ export const OrchestratorRoutingRow = ({ sessionId, run, disabled }: Props) => {
   const taskModels = useAppStore((state) =>
     session == null ? undefined : state.workspaceOverrides?.[session.workspaceId]?.taskModels,
   );
+  const workspaceDefaultProviderId = useAppStore((state) =>
+    session == null
+      ? undefined
+      : state.workspaceOverrides?.[session.workspaceId]?.defaultProviderId,
+  );
   const setWorkflowOrchestratorRouting = useAppStore(
     (state) => state.setWorkflowOrchestratorRouting,
   );
@@ -39,7 +44,7 @@ export const OrchestratorRoutingRow = ({ sessionId, run, disabled }: Props) => {
   const automatic = resolveTaskModel({
     task: 'workflow_orchestrator',
     preferences: taskModels,
-    workspaceDefaultProviderId: defaultProvider,
+    workspaceDefaultProviderId,
     sessionDefaultProviderId: defaultProvider,
   });
   const pinned = run.orchestratorRouting ?? null;

--- a/apps/desktop/src/features/workflows/components/OrchestratorPanel/OrchestratorRoutingRow/index.tsx
+++ b/apps/desktop/src/features/workflows/components/OrchestratorPanel/OrchestratorRoutingRow/index.tsx
@@ -36,13 +36,23 @@ export const OrchestratorRoutingRow = ({ sessionId, run, disabled }: Props) => {
   const defaultProvider = (session?.providerOverride ??
     session?.providerPreference.defaultProvider ??
     'anthropic') as ProviderId;
-  const automatic = resolveTaskModel('workflow_orchestrator', taskModels, defaultProvider);
+  const automatic = resolveTaskModel({
+    task: 'workflow_orchestrator',
+    preferences: taskModels,
+    workspaceDefaultProviderId: defaultProvider,
+    sessionDefaultProviderId: defaultProvider,
+  });
   const pinned = run.orchestratorRouting ?? null;
   const preferredProviderId = pinned?.providerId ?? automatic.providerId;
   const [providerId, setProviderId] = useState<ProviderId>(preferredProviderId);
   const pendingProvider = useRef<ProviderId>(preferredProviderId);
   const model = pinned?.model ?? '';
-  const recommendedModel = resolveTaskModel('workflow_orchestrator', taskModels, providerId).model;
+  const recommendedModel = resolveTaskModel({
+    task: 'workflow_orchestrator',
+    preferences: taskModels,
+    workspaceDefaultProviderId: providerId,
+    sessionDefaultProviderId: defaultProvider,
+  }).model;
   const effortModel = model === '' ? recommendedModel : model;
   const effortValue = pinned?.effort ?? automatic.effort ?? DEFAULT_EFFORT;
   const connectedProviders = providers
@@ -100,7 +110,14 @@ export const OrchestratorRoutingRow = ({ sessionId, run, disabled }: Props) => {
           if (pinned == null) {
             return;
           }
-          apply(resolveTaskModel('workflow_orchestrator', taskModels, next));
+          apply(
+            resolveTaskModel({
+              task: 'workflow_orchestrator',
+              preferences: taskModels,
+              workspaceDefaultProviderId: next,
+              sessionDefaultProviderId: defaultProvider,
+            }),
+          );
         }}
         onModel={(nextModel) => {
           if (nextModel === '') {

--- a/apps/desktop/src/features/workflows/components/WorkflowsPanel/index.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowsPanel/index.tsx
@@ -257,8 +257,7 @@ export const WorkflowsPanel = ({ workspaceId }: Props) => {
   };
 
   const createWithAgent = async () => {
-    const providerId = connectedProviders[0];
-    if (providerId === undefined) {
+    if (connectedProviders.length === 0) {
       return;
     }
     const generationDescription =
@@ -272,7 +271,6 @@ export const WorkflowsPanel = ({ workspaceId }: Props) => {
     const workflow = editing !== null && editing !== 'new' ? editing : null;
     const accepted = await startWorkflowGeneration({
       workspaceId,
-      providerId,
       description: generationDescription,
       ...(workspaceRoot !== null && { workingDir: workspaceRoot }),
       workflow,

--- a/apps/desktop/src/store/slices/turn/applyHeuristicTitle/index.ts
+++ b/apps/desktop/src/store/slices/turn/applyHeuristicTitle/index.ts
@@ -110,11 +110,13 @@ export const applyHeuristicTitle = async ({
       return;
     }
 
-    const taskModel = resolveTaskModel(
-      'agent_naming',
-      get().workspaceOverrides?.[session.workspaceId]?.taskModels,
-      session.providerPreference.defaultProvider,
-    );
+    const taskModel = resolveTaskModel({
+      task: 'agent_naming',
+      preferences: get().workspaceOverrides?.[session.workspaceId]?.taskModels,
+      workspaceDefaultProviderId:
+        get().workspaceOverrides?.[session.workspaceId]?.defaultProviderId,
+      sessionDefaultProviderId: session.providerPreference.defaultProvider,
+    });
 
     let generatedTitle: string;
     try {

--- a/apps/desktop/src/store/slices/workflowStudio/startWorkflowGeneration.test.ts
+++ b/apps/desktop/src/store/slices/workflowStudio/startWorkflowGeneration.test.ts
@@ -7,9 +7,10 @@ const { formatWorkflowFromNLMock } = vi.hoisted(() => ({
 
 vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
 
-vi.mock('@goodboy/core', () => ({
-  formatWorkflowFromNL: formatWorkflowFromNLMock,
-}));
+vi.mock('@goodboy/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@goodboy/core')>();
+  return { ...actual, formatWorkflowFromNL: formatWorkflowFromNLMock };
+});
 
 import { startWorkflowGeneration } from './startWorkflowGeneration';
 
@@ -33,6 +34,22 @@ describe('startWorkflowGeneration', () => {
     const clearWorkflowStudioDraft = vi.fn();
     const state = {
       workflowGenerations: {},
+      providers: [
+        { id: 'anthropic', connection: 'connected' },
+        { id: 'codex', connection: 'connected' },
+      ],
+      workspaceOverrides: {
+        'ws-1': {
+          defaultProviderId: 'anthropic',
+          taskModels: {
+            plan_generation: {
+              providerId: 'codex',
+              model: 'gpt-5.6-terra',
+              effort: 'high',
+            },
+          },
+        },
+      },
       savePhaseTemplate,
       clearWorkflowStudioDraft,
     };
@@ -43,7 +60,6 @@ describe('startWorkflowGeneration', () => {
 
     const accepted = await generate({
       workspaceId: 'ws-1' as never,
-      providerId: 'anthropic',
       description: 'Review and ship this change',
       workflow: null,
       form: null,
@@ -52,6 +68,56 @@ describe('startWorkflowGeneration', () => {
     expect(accepted).toBe(true);
     expect(savePhaseTemplate).toHaveBeenCalledWith(
       expect.objectContaining({ isPreset: true, origin: 'custom' }),
+    );
+    expect(formatWorkflowFromNLMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        deps: expect.objectContaining({
+          providerId: 'codex',
+          model: 'gpt-5.6-terra',
+          effort: 'high',
+        }),
+      }),
+    );
+  });
+
+  it('falls back to a connected provider when the workspace default is not connected', async () => {
+    formatWorkflowFromNLMock.mockResolvedValue({
+      name: 'Review and ship',
+      description: 'Review the change, then ship it.',
+      goal: 'Ship the change',
+      steps: [
+        {
+          role: 'reviewer',
+          name: 'Review',
+          promptPrefix: 'Review the change',
+          expectedOutput: 'Review findings',
+        },
+      ],
+    });
+    const saved = { id: 'wf-2' as WorkflowId } satisfies Partial<Workflow>;
+    const state = {
+      workflowGenerations: {},
+      providers: [{ id: 'codex', connection: 'connected' }],
+      workspaceOverrides: {},
+      savePhaseTemplate: vi.fn(async () => saved),
+      clearWorkflowStudioDraft: vi.fn(),
+    };
+    const set = vi.fn((updater: (current: typeof state) => Partial<typeof state>) => {
+      Object.assign(state, updater(state));
+    });
+    const generate = startWorkflowGeneration(set as never, (() => state) as never);
+
+    await generate({
+      workspaceId: 'ws-1' as never,
+      description: 'Review and ship this change',
+      workflow: null,
+      form: null,
+    });
+
+    expect(formatWorkflowFromNLMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        deps: expect.objectContaining({ providerId: 'codex', model: 'gpt-5.4-mini' }),
+      }),
     );
   });
 });

--- a/apps/desktop/src/store/slices/workflowStudio/startWorkflowGeneration.test.ts
+++ b/apps/desktop/src/store/slices/workflowStudio/startWorkflowGeneration.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { getCheapModel } from '@goodboy/core';
 import type { Workflow, WorkflowId } from '@goodboy/types';
 
 const { formatWorkflowFromNLMock } = vi.hoisted(() => ({
@@ -80,7 +81,7 @@ describe('startWorkflowGeneration', () => {
     );
   });
 
-  it('falls back to a connected provider when the workspace default is not connected', async () => {
+  it('uses the first connected provider automatic model when no workspace default is set', async () => {
     formatWorkflowFromNLMock.mockResolvedValue({
       name: 'Review and ship',
       description: 'Review the change, then ship it.',
@@ -116,7 +117,105 @@ describe('startWorkflowGeneration', () => {
 
     expect(formatWorkflowFromNLMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        deps: expect.objectContaining({ providerId: 'codex', model: 'gpt-5.4-mini' }),
+        deps: expect.objectContaining({
+          providerId: 'codex',
+          model: getCheapModel('codex'),
+        }),
+      }),
+    );
+  });
+
+  it('uses the workspace default automatic model when it is set and connected', async () => {
+    formatWorkflowFromNLMock.mockResolvedValue({
+      name: 'Review and ship',
+      description: 'Review the change, then ship it.',
+      goal: 'Ship the change',
+      steps: [
+        {
+          role: 'reviewer',
+          name: 'Review',
+          promptPrefix: 'Review the change',
+          expectedOutput: 'Review findings',
+        },
+      ],
+    });
+    const saved = { id: 'wf-3' as WorkflowId } satisfies Partial<Workflow>;
+    const state = {
+      workflowGenerations: {},
+      providers: [
+        { id: 'codex', connection: 'connected' },
+        { id: 'anthropic', connection: 'connected' },
+      ],
+      workspaceOverrides: {
+        'ws-1': { defaultProviderId: 'anthropic' },
+      },
+      savePhaseTemplate: vi.fn(async () => saved),
+      clearWorkflowStudioDraft: vi.fn(),
+    };
+    const set = vi.fn((updater: (current: typeof state) => Partial<typeof state>) => {
+      Object.assign(state, updater(state));
+    });
+    const generate = startWorkflowGeneration(set as never, (() => state) as never);
+
+    await generate({
+      workspaceId: 'ws-1' as never,
+      description: 'Review and ship this change',
+      workflow: null,
+      form: null,
+    });
+
+    expect(formatWorkflowFromNLMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        deps: expect.objectContaining({
+          providerId: 'anthropic',
+          model: getCheapModel('anthropic'),
+        }),
+      }),
+    );
+  });
+
+  it('falls back to a connected provider when the workspace default is set but disconnected', async () => {
+    formatWorkflowFromNLMock.mockResolvedValue({
+      name: 'Review and ship',
+      description: 'Review the change, then ship it.',
+      goal: 'Ship the change',
+      steps: [
+        {
+          role: 'reviewer',
+          name: 'Review',
+          promptPrefix: 'Review the change',
+          expectedOutput: 'Review findings',
+        },
+      ],
+    });
+    const saved = { id: 'wf-4' as WorkflowId } satisfies Partial<Workflow>;
+    const state = {
+      workflowGenerations: {},
+      providers: [{ id: 'codex', connection: 'connected' }],
+      workspaceOverrides: {
+        'ws-1': { defaultProviderId: 'anthropic' },
+      },
+      savePhaseTemplate: vi.fn(async () => saved),
+      clearWorkflowStudioDraft: vi.fn(),
+    };
+    const set = vi.fn((updater: (current: typeof state) => Partial<typeof state>) => {
+      Object.assign(state, updater(state));
+    });
+    const generate = startWorkflowGeneration(set as never, (() => state) as never);
+
+    await generate({
+      workspaceId: 'ws-1' as never,
+      description: 'Review and ship this change',
+      workflow: null,
+      form: null,
+    });
+
+    expect(formatWorkflowFromNLMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        deps: expect.objectContaining({
+          providerId: 'codex',
+          model: getCheapModel('codex'),
+        }),
       }),
     );
   });

--- a/apps/desktop/src/store/slices/workflowStudio/startWorkflowGeneration.ts
+++ b/apps/desktop/src/store/slices/workflowStudio/startWorkflowGeneration.ts
@@ -16,16 +16,16 @@ const generationTaskModel = ({
   workspaceId,
 }: GenerationModelParams): TaskModelPreference => {
   const overrides = state.workspaceOverrides?.[workspaceId] ?? null;
-  const resolved = resolveTaskModel({
-    task: 'plan_generation',
-    preferences: overrides?.taskModels,
-    workspaceDefaultProviderId: overrides?.defaultProviderId,
-    sessionDefaultProviderId: DEFAULT_SESSION_PROVIDER_PREFERENCE.defaultProvider,
-  });
   const connected = state.providers
     .filter((provider) => provider.connection === 'connected')
     .map((provider) => provider.id);
   const firstConnected = connected[0];
+  const resolved = resolveTaskModel({
+    task: 'plan_generation',
+    preferences: overrides?.taskModels,
+    workspaceDefaultProviderId: overrides?.defaultProviderId,
+    sessionDefaultProviderId: firstConnected ?? DEFAULT_SESSION_PROVIDER_PREFERENCE.defaultProvider,
+  });
   if (firstConnected == null || connected.includes(resolved.providerId)) {
     return resolved;
   }

--- a/apps/desktop/src/store/slices/workflowStudio/startWorkflowGeneration.ts
+++ b/apps/desktop/src/store/slices/workflowStudio/startWorkflowGeneration.ts
@@ -1,13 +1,45 @@
-import { formatWorkflowFromNL } from '@goodboy/core';
+import { formatWorkflowFromNL, resolveTaskModel } from '@goodboy/core';
 import { invoke } from '@tauri-apps/api/core';
 import type { WorkflowUpsertArgs } from '../../../features/workflows/workflows';
 import { formatError } from '@goodboy/ui';
+import { DEFAULT_SESSION_PROVIDER_PREFERENCE } from '@goodboy/types';
+import type { TaskModelPreference, WorkspaceId } from '@goodboy/types';
 import type { GetFn, SetFn, StartWorkflowGenerationParams } from './types';
+
+type GenerationModelParams = {
+  readonly state: ReturnType<GetFn>;
+  readonly workspaceId: WorkspaceId;
+};
+
+const generationTaskModel = ({
+  state,
+  workspaceId,
+}: GenerationModelParams): TaskModelPreference => {
+  const overrides = state.workspaceOverrides?.[workspaceId] ?? null;
+  const resolved = resolveTaskModel({
+    task: 'plan_generation',
+    preferences: overrides?.taskModels,
+    workspaceDefaultProviderId: overrides?.defaultProviderId,
+    sessionDefaultProviderId: DEFAULT_SESSION_PROVIDER_PREFERENCE.defaultProvider,
+  });
+  const connected = state.providers
+    .filter((provider) => provider.connection === 'connected')
+    .map((provider) => provider.id);
+  const firstConnected = connected[0];
+  if (firstConnected == null || connected.includes(resolved.providerId)) {
+    return resolved;
+  }
+  return resolveTaskModel({
+    task: 'plan_generation',
+    preferences: null,
+    workspaceDefaultProviderId: firstConnected,
+    sessionDefaultProviderId: firstConnected,
+  });
+};
 
 export const startWorkflowGeneration = (set: SetFn, get: GetFn) => {
   return async ({
     workspaceId,
-    providerId,
     description,
     workingDir,
     workflow,
@@ -25,9 +57,14 @@ export const startWorkflowGeneration = (set: SetFn, get: GetFn) => {
       },
     }));
     try {
-      const formatted = await formatWorkflowFromNL(
-        { providerId, invokeFn: invoke, ...(workingDir !== undefined && { workingDir }) },
-        {
+      const taskModel = generationTaskModel({ state: get(), workspaceId });
+      const formatted = await formatWorkflowFromNL({
+        deps: {
+          ...taskModel,
+          invokeFn: invoke,
+          ...(workingDir !== undefined && { workingDir }),
+        },
+        input: {
           description: cleanDescription,
           ...(form !== null && {
             currentName: form.name,
@@ -37,7 +74,7 @@ export const startWorkflowGeneration = (set: SetFn, get: GetFn) => {
               .filter((name) => name.trim().length > 0),
           }),
         },
-      );
+      });
       if (formatted === null) {
         throw new Error(
           'The agent could not build a workflow from that description. Try adding the outcome and the steps you expect.',

--- a/apps/desktop/src/store/slices/workflowStudio/types.ts
+++ b/apps/desktop/src/store/slices/workflowStudio/types.ts
@@ -1,4 +1,4 @@
-import type { ProviderId, Workflow, WorkflowId, WorkspaceId } from '@goodboy/types';
+import type { Workflow, WorkflowId, WorkspaceId } from '@goodboy/types';
 import type { WorkflowDraft } from '../../../features/workflows/engine';
 
 export type { GetFn, SetFn } from '../../slice-types';
@@ -23,7 +23,6 @@ export type WorkflowGeneration =
 
 export type StartWorkflowGenerationParams = {
   readonly workspaceId: WorkspaceId;
-  readonly providerId: ProviderId;
   readonly description: string;
   readonly workingDir?: string;
   readonly workflow: Workflow | null;

--- a/apps/desktop/src/store/slices/workflows/generateWorkflowTitle.ts
+++ b/apps/desktop/src/store/slices/workflows/generateWorkflowTitle.ts
@@ -79,11 +79,12 @@ export const generateWorkflowTitle = (set: SetFn, get: GetFn) => {
       if (prompt.length === 0) {
         return;
       }
-      const taskModel = resolveTaskModel(
-        'agent_naming',
-        get().workspaceOverrides?.[workspaceId]?.taskModels,
-        session.providerPreference.defaultProvider,
-      );
+      const taskModel = resolveTaskModel({
+        task: 'agent_naming',
+        preferences: get().workspaceOverrides?.[workspaceId]?.taskModels,
+        workspaceDefaultProviderId: get().workspaceOverrides?.[workspaceId]?.defaultProviderId,
+        sessionDefaultProviderId: session.providerPreference.defaultProvider,
+      });
       const worktreePath = get().sessionWorktrees?.[sessionId]?.[0] ?? null;
 
       const generated = await generateTitleText({

--- a/apps/desktop/src/store/slices/workflows/orchestrateNextStep.ts
+++ b/apps/desktop/src/store/slices/workflows/orchestrateNextStep.ts
@@ -535,11 +535,13 @@ export const orchestrateNextStep = (set: SetFn, get: GetFn) => {
         workspace: workspaceRoleModels,
         run: run.roleModelOverrides,
       });
-      const taskModel = resolveTaskModel(
-        'workflow_orchestrator',
-        get().workspaceOverrides?.[session.workspaceId]?.taskModels,
-        defaultProvider,
-      );
+      const taskModel = resolveTaskModel({
+        task: 'workflow_orchestrator',
+        preferences: get().workspaceOverrides?.[session.workspaceId]?.taskModels,
+        workspaceDefaultProviderId:
+          get().workspaceOverrides?.[session.workspaceId]?.defaultProviderId,
+        sessionDefaultProviderId: defaultProvider,
+      });
       const routing = options?.routing ?? run.orchestratorRouting ?? taskModel;
       const profileBlock = buildProfileGuard({
         profile: get().workspaces.find((candidate) => candidate.id === session.workspaceId)

--- a/apps/desktop/src/store/slices/workflows/reprocessGoalForWorkflow.ts
+++ b/apps/desktop/src/store/slices/workflows/reprocessGoalForWorkflow.ts
@@ -39,11 +39,13 @@ export const reprocessGoalForWorkflow = (set: SetFn, get: GetFn) => {
 
       const worktreePath = getSessionRepo({ get, sessionId })?.worktreePath ?? null;
       const taskModel = routeTaskModel({
-        taskModel: resolveTaskModel(
-          'prose_polish',
-          state.workspaceOverrides?.[session.workspaceId]?.taskModels,
-          session.providerPreference.defaultProvider,
-        ),
+        taskModel: resolveTaskModel({
+          task: 'prose_polish',
+          preferences: state.workspaceOverrides?.[session.workspaceId]?.taskModels,
+          workspaceDefaultProviderId:
+            state.workspaceOverrides?.[session.workspaceId]?.defaultProviderId,
+          sessionDefaultProviderId: session.providerPreference.defaultProvider,
+        }),
         connectedProviders: state.providers
           .filter((provider) => provider.connection === 'connected')
           .map((provider) => provider.id),

--- a/apps/desktop/src/store/slices/workflows/retryStepSummary.ts
+++ b/apps/desktop/src/store/slices/workflows/retryStepSummary.ts
@@ -37,11 +37,13 @@ export const retryStepSummary = (set: SetFn, get: GetFn) => {
     const taskModel =
       taskModelOverride ??
       routeTaskModel({
-        taskModel: resolveTaskModel(
-          'summarizer',
-          get().workspaceOverrides?.[session.workspaceId]?.taskModels,
-          session.providerPreference.defaultProvider,
-        ),
+        taskModel: resolveTaskModel({
+          task: 'summarizer',
+          preferences: get().workspaceOverrides?.[session.workspaceId]?.taskModels,
+          workspaceDefaultProviderId:
+            get().workspaceOverrides?.[session.workspaceId]?.defaultProviderId,
+          sessionDefaultProviderId: session.providerPreference.defaultProvider,
+        }),
         connectedProviders: get()
           .providers.filter((provider) => provider.connection === 'connected')
           .map((provider) => provider.id),

--- a/apps/desktop/src/store/slices/workflows/summarizeWorkflowAgentOutput.test.ts
+++ b/apps/desktop/src/store/slices/workflows/summarizeWorkflowAgentOutput.test.ts
@@ -6,6 +6,7 @@ import type {
   ProviderId,
   Session,
   SessionId,
+  TaskModelPreferences,
   WorkspaceId,
 } from '@goodboy/types';
 
@@ -55,9 +56,11 @@ const session: Session = {
 type HarnessParams = {
   readonly connected: ReadonlyArray<ProviderId>;
   readonly cooldowns?: Readonly<Partial<Record<ProviderId, number>>>;
+  readonly defaultProviderId?: ProviderId;
+  readonly taskModels?: TaskModelPreferences;
 };
 
-const buildHarness = ({ connected, cooldowns }: HarnessParams) => {
+const buildHarness = ({ connected, cooldowns, defaultProviderId, taskModels }: HarnessParams) => {
   const emitNotification = vi.fn(async (..._args: ReadonlyArray<unknown>) => undefined);
   const state: Record<string, unknown> & {
     providerCooldowns: Readonly<Partial<Record<ProviderId, number>>>;
@@ -75,7 +78,15 @@ const buildHarness = ({ connected, cooldowns }: HarnessParams) => {
       identity: null,
     })),
     providerCooldowns: cooldowns ?? {},
-    workspaceOverrides: {},
+    workspaceOverrides:
+      defaultProviderId == null && taskModels == null
+        ? {}
+        : {
+            [WORKSPACE_ID]: {
+              defaultProviderId: defaultProviderId ?? null,
+              taskModels: taskModels ?? null,
+            },
+          },
     phaseTemplates: {},
     sessionWorkflows: {},
     emitNotification,
@@ -124,6 +135,36 @@ describe('summarizeWorkflowAgentOutput', () => {
       'codex',
     ]);
     expect(emitNotification).not.toHaveBeenCalled();
+  });
+
+  it('uses the current workspace provider for an automatic workflow summary', async () => {
+    summarizeStepOutputSpy.mockResolvedValueOnce('summary');
+    const { call } = buildHarness({
+      connected: ['anthropic', 'codex'],
+      defaultProviderId: 'codex',
+    });
+
+    await call();
+
+    expect(summarizeStepOutputSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ providerId: 'codex', model: 'gpt-5.4-mini' }),
+    );
+  });
+
+  it('preserves an explicit codex variant for a workflow summary', async () => {
+    summarizeStepOutputSpy.mockResolvedValueOnce('summary');
+    const { call } = buildHarness({
+      connected: ['anthropic', 'codex'],
+      taskModels: {
+        summarizer: { providerId: 'codex', model: 'gpt-5.6-luna', effort: 'xhigh' },
+      },
+    });
+
+    await call();
+
+    expect(summarizeStepOutputSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ providerId: 'codex', model: 'gpt-5.6-luna', effort: 'xhigh' }),
+    );
   });
 
   it('records a cooldown for the provider that ran out', async () => {

--- a/apps/desktop/src/store/slices/workflows/summarizeWorkflowAgentOutput.ts
+++ b/apps/desktop/src/store/slices/workflows/summarizeWorkflowAgentOutput.ts
@@ -66,11 +66,12 @@ export const summarizeWorkflowAgentOutput = async ({
     .providers.filter((provider) => provider.connection === 'connected')
     .map((provider) => provider.id);
   const enabledProviders = session.providerPreference.enabledProviders ?? null;
-  const resolved = resolveTaskModel(
-    'summarizer',
-    get().workspaceOverrides?.[session.workspaceId]?.taskModels,
-    session.providerPreference.defaultProvider,
-  );
+  const resolved = resolveTaskModel({
+    task: 'summarizer',
+    preferences: get().workspaceOverrides?.[session.workspaceId]?.taskModels,
+    workspaceDefaultProviderId: get().workspaceOverrides?.[session.workspaceId]?.defaultProviderId,
+    sessionDefaultProviderId: session.providerPreference.defaultProvider,
+  });
   const taskModel = routeTaskModel({
     taskModel: resolved,
     connectedProviders,

--- a/apps/desktop/src/store/store.summarizer-queue.test.ts
+++ b/apps/desktop/src/store/store.summarizer-queue.test.ts
@@ -384,6 +384,88 @@ describe('summarizer queue, coalescing and no-stack', () => {
     useAppStore.setState({ workspaceOverrides: {} });
   });
 
+  it('uses the current workspace provider instead of the captured session provider', async () => {
+    const { useAppStore } = await import('./store');
+    const { enqueueSummarizer, summarizerQueues: queues } = await import('./turn-helpers');
+    queues.clear();
+    useAppStore.setState({
+      sessions: [buildSession()],
+      sessionSlots: { [SESSION_ID]: [] },
+      summarizerStatus: {},
+      workspaceOverrides: {
+        [WORKSPACE_ID]: {
+          defaultProviderId: 'codex',
+          defaultWorkflowId: null,
+          defaultBranchPrefix: null,
+          parallelEnabled: null,
+          defaultVerbosity: null,
+          providerBindings: null,
+          taskModels: null,
+          roleModels: null,
+          parallelAgents: null,
+          providerPool: null,
+          attributionFooter: null,
+        },
+      },
+    });
+
+    enqueueSummarizer(
+      useAppStore.setState,
+      useAppStore.getState,
+      SESSION_ID,
+      'turn input',
+      'turn output',
+    );
+
+    await vi.waitFor(() => expect(queues.get(SESSION_ID)?.inFlight).toBe(false));
+    expect(summarizerConstructorCalls).toContainEqual(
+      expect.objectContaining({ providerId: 'codex', model: 'gpt-5.4-mini' }),
+    );
+    useAppStore.setState({ workspaceOverrides: {} });
+  });
+
+  it('preserves an explicit codex variant for session summaries', async () => {
+    const { useAppStore } = await import('./store');
+    const { enqueueSummarizer, summarizerQueues: queues } = await import('./turn-helpers');
+    queues.clear();
+    useAppStore.setState({
+      sessions: [buildSession()],
+      sessionSlots: { [SESSION_ID]: [] },
+      summarizerStatus: {},
+      workspaceOverrides: {
+        [WORKSPACE_ID]: {
+          defaultProviderId: 'codex',
+          defaultWorkflowId: null,
+          defaultBranchPrefix: null,
+          parallelEnabled: null,
+          defaultVerbosity: null,
+          providerBindings: null,
+          taskModels: {
+            summarizer: { providerId: 'codex', model: 'gpt-5.6-terra', effort: 'high' },
+          },
+          roleModels: null,
+          parallelAgents: null,
+          providerPool: null,
+          attributionFooter: null,
+        },
+      },
+    });
+
+    enqueueSummarizer(
+      useAppStore.setState,
+      useAppStore.getState,
+      SESSION_ID,
+      'turn input',
+      'turn output',
+    );
+
+    await vi.waitFor(() => expect(queues.get(SESSION_ID)?.inFlight).toBe(false));
+    expect(summarizerConstructorCalls).toContainEqual(
+      expect.objectContaining({ providerId: 'codex', model: 'gpt-5.6-terra', effort: 'high' }),
+    );
+    useAppStore.setState({ workspaceOverrides: {} });
+  });
+
   it('single trigger with nothing in-flight fires immediately and clears queue', async () => {
     let resolved = false;
     summarizeSpy.mockImplementation(async () => {

--- a/apps/desktop/src/store/turn-helpers.ts
+++ b/apps/desktop/src/store/turn-helpers.ts
@@ -246,11 +246,13 @@ const runSummarizer = async ({ set, get, sessionId, entry }: Params): Promise<vo
   const taskModel =
     entry.taskModelOverride ??
     routeTaskModel({
-      taskModel: resolveTaskModel(
-        'summarizer',
-        get().workspaceOverrides?.[session.workspaceId]?.taskModels,
-        session.providerPreference.defaultProvider,
-      ),
+      taskModel: resolveTaskModel({
+        task: 'summarizer',
+        preferences: get().workspaceOverrides?.[session.workspaceId]?.taskModels,
+        workspaceDefaultProviderId:
+          get().workspaceOverrides?.[session.workspaceId]?.defaultProviderId,
+        sessionDefaultProviderId: session.providerPreference.defaultProvider,
+      }),
       connectedProviders,
       enabledProviders,
       cooldowns: get().providerCooldowns,

--- a/packages/core/src/providers/resolvedStoredModelId.ts
+++ b/packages/core/src/providers/resolvedStoredModelId.ts
@@ -1,0 +1,14 @@
+import type { ModelSelection, ProviderId } from '@goodboy/types';
+import { modelIdForSelection } from './modelIdForSelection';
+
+type Params = {
+  readonly provider: ProviderId;
+  readonly selection: ModelSelection;
+};
+
+export const resolvedStoredModelId = ({ provider, selection }: Params): string => {
+  if (selection.variant == null && selection.toggles == null) {
+    return selection.key;
+  }
+  return modelIdForSelection({ provider, selection });
+};

--- a/packages/core/src/providers/role-models.test.ts
+++ b/packages/core/src/providers/role-models.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import type { ProviderId, RoleModelPreferences } from '@goodboy/types';
 import { ROLE_DEFAULTS } from '../roles';
 import { resolveRoleRouting } from './role-models';
@@ -272,5 +272,35 @@ describe('resolveRoleRouting', () => {
       effort: 'high',
       isOverride: true,
     });
+  });
+
+  it('preserves an explicit codex variant', () => {
+    const prefs: RoleModelPreferences = {
+      planner: { providerId: 'codex', model: 'gpt-5.6-luna', effort: 'high' },
+    };
+
+    expect(resolveRoleRouting({ role: 'planner', prefs })).toEqual({
+      provider: 'codex',
+      model: 'gpt-5.6-luna',
+      effort: 'high',
+      isOverride: true,
+    });
+  });
+
+  it('warns instead of silently dropping an invalid role preference', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const prefs: RoleModelPreferences = {
+      reviewer: { providerId: 'anthropic', model: 'claude-opus-99', effort: 'high' },
+    };
+
+    const resolved = resolveRoleRouting({ role: 'reviewer', prefs });
+
+    expect(resolved).toMatchObject({
+      provider: ROLE_DEFAULTS.reviewer.provider,
+      model: ROLE_DEFAULTS.reviewer.model,
+      isOverride: false,
+    });
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('invalid reviewer model'));
+    warn.mockRestore();
   });
 });

--- a/packages/core/src/providers/role-models.ts
+++ b/packages/core/src/providers/role-models.ts
@@ -4,9 +4,11 @@ import type {
   RoleModelFallback,
   RoleModelPreferences,
 } from '@goodboy/types';
+import { devWarn } from '../dev-log';
 import { PROVIDER_CAPABILITIES } from './capabilities';
 import { defaultsForRole, isAgentRole } from '../roles';
 import { resolveModelArgs } from './resolveModelArgs';
+import { resolvedStoredModelId } from './resolvedStoredModelId';
 import { resolveStoredModelSelection } from './resolveStoredModelSelection';
 
 export type ResolvedRoleFallback = Readonly<{
@@ -56,7 +58,10 @@ const resolveRoleFallback = ({ fallback, effort }: FallbackParams): ResolvedRole
   });
   return {
     provider: fallback.providerId,
-    model: stored.selection.key,
+    model: resolvedStoredModelId({
+      provider: fallback.providerId,
+      selection: stored.selection,
+    }),
     effort: resolved.clamped?.applied ?? requested,
   };
 };
@@ -75,6 +80,9 @@ export const resolveRoleRouting = ({ role, prefs }: Params): ResolvedRoleRouting
   }
   const capabilities = PROVIDER_CAPABILITIES[preference.providerId];
   if (capabilities == null) {
+    devWarn(
+      `[role-models] invalid ${role} provider ${preference.providerId}; using the ${compiled.provider} default model`,
+    );
     return compiled;
   }
   const stored = resolveStoredModelSelection({
@@ -83,6 +91,9 @@ export const resolveRoleRouting = ({ role, prefs }: Params): ResolvedRoleRouting
     effort: preference.effort,
   });
   if (stored.report?.kind === 'unknown') {
+    devWarn(
+      `[role-models] invalid ${role} model ${preference.model} for ${preference.providerId}; using the ${compiled.provider} default model`,
+    );
     return compiled;
   }
   const resolved = resolveModelArgs({
@@ -93,7 +104,10 @@ export const resolveRoleRouting = ({ role, prefs }: Params): ResolvedRoleRouting
   const fallback = resolveRoleFallback({ fallback: preference.fallback, effort });
   return {
     provider: preference.providerId,
-    model: stored.selection.key,
+    model: resolvedStoredModelId({
+      provider: preference.providerId,
+      selection: stored.selection,
+    }),
     effort,
     isOverride: true,
     ...(fallback != null && { fallback }),

--- a/packages/core/src/providers/task-models.test.ts
+++ b/packages/core/src/providers/task-models.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { PROVIDER_IDS, type TaskModelPreferences } from '@goodboy/types';
 import { PROVIDER_CAPABILITIES } from './capabilities';
 import { getCheapModel } from './cli-defaults';
@@ -10,7 +10,14 @@ describe('resolveTaskModel', () => {
       summarizer: { providerId: 'anthropic', model: 'claude-haiku-4-5' },
     };
 
-    expect(resolveTaskModel('summarizer', prefs, 'codex')).toEqual({
+    expect(
+      resolveTaskModel({
+        task: 'summarizer',
+        preferences: prefs,
+        workspaceDefaultProviderId: 'codex',
+        sessionDefaultProviderId: 'anthropic',
+      }),
+    ).toEqual({
       providerId: 'anthropic',
       model: 'haiku-4.5',
     });
@@ -25,7 +32,14 @@ describe('resolveTaskModel', () => {
       },
     };
 
-    expect(resolveTaskModel('workflow_orchestrator', prefs, 'anthropic')).toEqual({
+    expect(
+      resolveTaskModel({
+        task: 'workflow_orchestrator',
+        preferences: prefs,
+        workspaceDefaultProviderId: 'anthropic',
+        sessionDefaultProviderId: 'anthropic',
+      }),
+    ).toEqual({
       providerId: 'anthropic',
       model: 'sonnet-4.6',
       effort: 'high',
@@ -33,13 +47,21 @@ describe('resolveTaskModel', () => {
   });
 
   it('uses the default provider cheap model when no preference exists', () => {
-    expect(resolveTaskModel('branch_naming', null, 'anthropic')).toEqual({
+    expect(
+      resolveTaskModel({
+        task: 'branch_naming',
+        preferences: null,
+        workspaceDefaultProviderId: 'anthropic',
+        sessionDefaultProviderId: 'anthropic',
+      }),
+    ).toEqual({
       providerId: 'anthropic',
       model: 'haiku-4.5',
     });
   });
 
   it('falls back when the stored model does not belong to its provider', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     const prefs: TaskModelPreferences = {
       plan_generation: {
         providerId: 'anthropic',
@@ -47,29 +69,62 @@ describe('resolveTaskModel', () => {
       },
     };
 
-    expect(resolveTaskModel('plan_generation', prefs, 'anthropic')).toEqual({
-      providerId: 'anthropic',
-      model: 'haiku-4.5',
+    expect(
+      resolveTaskModel({
+        task: 'plan_generation',
+        preferences: prefs,
+        workspaceDefaultProviderId: 'codex',
+        sessionDefaultProviderId: 'anthropic',
+      }),
+    ).toEqual({
+      providerId: 'codex',
+      model: 'gpt-5.4-mini',
     });
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('invalid plan_generation model'));
+    warn.mockRestore();
   });
 
   it('uses a mid model for anthropic rebase tasks', () => {
-    expect(resolveTaskModel('rebase', null, 'anthropic')).toEqual({
+    expect(
+      resolveTaskModel({
+        task: 'rebase',
+        preferences: null,
+        workspaceDefaultProviderId: 'anthropic',
+        sessionDefaultProviderId: 'anthropic',
+      }),
+    ).toEqual({
       providerId: 'anthropic',
       model: 'sonnet-5',
     });
   });
 
   it('uses the first turn-tier model for other rebase providers', () => {
-    expect(resolveTaskModel('rebase', null, 'codex')).toEqual({
+    expect(
+      resolveTaskModel({
+        task: 'rebase',
+        preferences: null,
+        workspaceDefaultProviderId: 'codex',
+        sessionDefaultProviderId: 'anthropic',
+      }),
+    ).toEqual({
       providerId: 'codex',
       model: 'gpt-5.6',
     });
   });
 
   it('decides orchestration on a mid model, never on the cheap one', () => {
-    const anthropic = resolveTaskModel('workflow_orchestrator', null, 'anthropic');
-    const codex = resolveTaskModel('workflow_orchestrator', null, 'codex');
+    const anthropic = resolveTaskModel({
+      task: 'workflow_orchestrator',
+      preferences: null,
+      workspaceDefaultProviderId: 'anthropic',
+      sessionDefaultProviderId: 'anthropic',
+    });
+    const codex = resolveTaskModel({
+      task: 'workflow_orchestrator',
+      preferences: null,
+      workspaceDefaultProviderId: 'codex',
+      sessionDefaultProviderId: 'anthropic',
+    });
 
     expect(anthropic).toEqual({ providerId: 'anthropic', model: 'sonnet-5' });
     expect(codex).toEqual({ providerId: 'codex', model: 'gpt-5.4' });
@@ -79,12 +134,43 @@ describe('resolveTaskModel', () => {
 
   it('picks a mid model for every provider', () => {
     for (const providerId of PROVIDER_IDS) {
-      const resolved = resolveTaskModel('workflow_orchestrator', null, providerId);
+      const resolved = resolveTaskModel({
+        task: 'workflow_orchestrator',
+        preferences: null,
+        workspaceDefaultProviderId: providerId,
+        sessionDefaultProviderId: 'anthropic',
+      });
       const descriptor = PROVIDER_CAPABILITIES[providerId].models.find(
         (model) => model.id === resolved.model,
       );
 
       expect(descriptor?.costTier).toBe('mid');
     }
+  });
+
+  it('prefers the current workspace provider over a captured session provider', () => {
+    expect(
+      resolveTaskModel({
+        task: 'summarizer',
+        preferences: null,
+        workspaceDefaultProviderId: 'codex',
+        sessionDefaultProviderId: 'anthropic',
+      }),
+    ).toEqual({ providerId: 'codex', model: 'gpt-5.4-mini' });
+  });
+
+  it('preserves an explicit codex model variant', () => {
+    const preferences: TaskModelPreferences = {
+      summarizer: { providerId: 'codex', model: 'gpt-5.6-terra', effort: 'high' },
+    };
+
+    expect(
+      resolveTaskModel({
+        task: 'summarizer',
+        preferences,
+        workspaceDefaultProviderId: 'anthropic',
+        sessionDefaultProviderId: 'anthropic',
+      }),
+    ).toEqual({ providerId: 'codex', model: 'gpt-5.6-terra', effort: 'high' });
   });
 });

--- a/packages/core/src/providers/task-models.ts
+++ b/packages/core/src/providers/task-models.ts
@@ -4,11 +4,31 @@ import type {
   TaskModelPreference,
   TaskModelPreferences,
 } from '@goodboy/types';
+import { devWarn } from '../dev-log';
 import { PROVIDER_CAPABILITIES, getDefaultTurnModel } from './capabilities';
 import { getCheapModel, getMidModel } from './cli-defaults';
+import { resolvedStoredModelId } from './resolvedStoredModelId';
 import { resolveStoredModelSelection } from './resolveStoredModelSelection';
 
-const automaticModelForTask = (task: AuxTaskId, providerId: ProviderId): string => {
+type AutomaticParams = {
+  readonly task: AuxTaskId;
+  readonly providerId: ProviderId;
+};
+
+type PreferredParams = {
+  readonly task: AuxTaskId;
+  readonly preference: TaskModelPreference;
+  readonly defaultProviderId: ProviderId;
+};
+
+type Params = {
+  readonly task: AuxTaskId;
+  readonly preferences: TaskModelPreferences | null | undefined;
+  readonly workspaceDefaultProviderId: ProviderId | null | undefined;
+  readonly sessionDefaultProviderId: ProviderId;
+};
+
+const automaticModelForTask = ({ task, providerId }: AutomaticParams): string => {
   if (task === 'rebase') {
     return providerId === 'anthropic' ? 'sonnet-5' : getDefaultTurnModel({ id: providerId });
   }
@@ -18,27 +38,52 @@ const automaticModelForTask = (task: AuxTaskId, providerId: ProviderId): string 
   return getCheapModel(providerId);
 };
 
-export const resolveTaskModel = (
-  task: AuxTaskId,
-  prefs: TaskModelPreferences | null | undefined,
-  defaultProviderId: ProviderId,
-): TaskModelPreference => {
-  const preference = prefs?.[task];
-  if (preference != null && PROVIDER_CAPABILITIES[preference.providerId] != null) {
-    const stored = resolveStoredModelSelection({
+const preferredTaskModel = ({
+  task,
+  preference,
+  defaultProviderId,
+}: PreferredParams): TaskModelPreference | null => {
+  if (PROVIDER_CAPABILITIES[preference.providerId] == null) {
+    devWarn(
+      `[task-models] invalid ${task} provider ${preference.providerId}; using the ${defaultProviderId} automatic model`,
+    );
+    return null;
+  }
+  const stored = resolveStoredModelSelection({
+    provider: preference.providerId,
+    id: preference.model,
+  });
+  if (stored.report?.kind === 'unknown') {
+    devWarn(
+      `[task-models] invalid ${task} model ${preference.model} for ${preference.providerId}; using the ${defaultProviderId} automatic model`,
+    );
+    return null;
+  }
+  return {
+    providerId: preference.providerId,
+    model: resolvedStoredModelId({
       provider: preference.providerId,
-      id: preference.model,
-    });
-    if (stored.report?.kind !== 'unknown') {
-      return {
-        providerId: preference.providerId,
-        model: stored.selection.key,
-        ...(preference.effort != null && { effort: preference.effort }),
-      };
-    }
+      selection: stored.selection,
+    }),
+    ...(preference.effort != null && { effort: preference.effort }),
+  };
+};
+
+export const resolveTaskModel = ({
+  task,
+  preferences,
+  workspaceDefaultProviderId,
+  sessionDefaultProviderId,
+}: Params): TaskModelPreference => {
+  const defaultProviderId = workspaceDefaultProviderId ?? sessionDefaultProviderId;
+  const preference = preferences?.[task];
+  const preferred =
+    preference == null ? null : preferredTaskModel({ task, preference, defaultProviderId });
+  if (preferred != null) {
+    return preferred;
   }
   return {
     providerId: defaultProviderId,
-    model: automaticModelForTask(task, defaultProviderId),
+    model: automaticModelForTask({ task, providerId: defaultProviderId }),
   };
 };

--- a/packages/core/src/workflows/format.test.ts
+++ b/packages/core/src/workflows/format.test.ts
@@ -95,6 +95,7 @@ describe('formatWorkflowFromNL', () => {
   function makeDeps(overrides: Partial<WorkflowFormatDeps> = {}): WorkflowFormatDeps {
     return {
       providerId: 'gemini',
+      model: 'gemini-3.5-flash',
       invokeFn: vi.fn().mockResolvedValue({ stdout: validMarker, stderr: '', exitCode: 0 }),
       ...overrides,
     };
@@ -102,7 +103,7 @@ describe('formatWorkflowFromNL', () => {
 
   it('returns null for an empty description', async () => {
     const deps = makeDeps();
-    const result = await formatWorkflowFromNL(deps, { description: '   ' });
+    const result = await formatWorkflowFromNL({ deps, input: { description: '   ' } });
     expect(result).toBeNull();
     expect(deps.invokeFn).not.toHaveBeenCalled();
   });
@@ -111,12 +112,18 @@ describe('formatWorkflowFromNL', () => {
     const deps = makeDeps({
       invokeFn: vi.fn().mockResolvedValue({ stdout: '', stderr: 'err', exitCode: 1 }),
     });
-    const result = await formatWorkflowFromNL(deps, { description: 'plan and build' });
+    const result = await formatWorkflowFromNL({
+      deps,
+      input: { description: 'plan and build' },
+    });
     expect(result).toBeNull();
   });
 
   it('parses the workflow from a valid marker response', async () => {
-    const result = await formatWorkflowFromNL(makeDeps(), { description: 'plan and build' });
+    const result = await formatWorkflowFromNL({
+      deps: makeDeps(),
+      input: { description: 'plan and build' },
+    });
     expect(result?.name).toBe('plan-implement-review');
     expect(result?.steps).toHaveLength(2);
   });
@@ -127,7 +134,10 @@ describe('formatWorkflowFromNL', () => {
       providerId: 'anthropic',
       invokeFn: vi.fn().mockResolvedValue({ stdout: envelope, stderr: '', exitCode: 0 }),
     });
-    const result = await formatWorkflowFromNL(deps, { description: 'plan and build' });
+    const result = await formatWorkflowFromNL({
+      deps,
+      input: { description: 'plan and build' },
+    });
     expect(result?.steps).toHaveLength(2);
   });
 
@@ -137,8 +147,38 @@ describe('formatWorkflowFromNL', () => {
         .fn()
         .mockResolvedValue({ stdout: 'not json and no marker', stderr: '', exitCode: 0 }),
     });
-    const result = await formatWorkflowFromNL(deps, { description: 'plan and build' });
+    const result = await formatWorkflowFromNL({
+      deps,
+      input: { description: 'plan and build' },
+    });
     expect(result).toBeNull();
+  });
+
+  it('passes the configured model and effort to generation', async () => {
+    const invokeFn = vi.fn().mockResolvedValue({
+      stdout: validMarker,
+      stderr: '',
+      exitCode: 0,
+    });
+    const deps = makeDeps({
+      providerId: 'codex',
+      model: 'gpt-5.6-luna',
+      effort: 'high',
+      invokeFn,
+    });
+
+    await formatWorkflowFromNL({ deps, input: { description: 'plan and build' } });
+
+    expect(invokeFn).toHaveBeenCalledWith(
+      'summarize_session',
+      expect.objectContaining({
+        args: expect.objectContaining({
+          providerId: 'codex',
+          model: 'gpt-5.6-luna',
+          effort: 'high',
+        }),
+      }),
+    );
   });
 });
 

--- a/packages/core/src/workflows/format.ts
+++ b/packages/core/src/workflows/format.ts
@@ -1,7 +1,7 @@
-import type { AgentRole, ProviderId } from '@goodboy/types';
+import type { AgentRole, TaskModelPreference } from '@goodboy/types';
 import { extractAuxOutput } from '../providers/aux-output';
 import { runAuxOneShot } from '../providers/aux-spawn';
-import { getCheapModel, getDefaultBinary } from '../providers/cli-defaults';
+import { getDefaultBinary } from '../providers/cli-defaults';
 import { isAgentRole } from '../roles';
 
 const WORKFLOW_FORMAT_SYSTEM_PROMPT = `You design multi-step AI coding workflows. Each step runs as its own dedicated agent, in order, left to right.
@@ -48,11 +48,15 @@ export type WorkflowFormatInput = {
   readonly currentStepNames?: ReadonlyArray<string>;
 };
 
-export type WorkflowFormatDeps = {
-  readonly providerId: ProviderId;
+export type WorkflowFormatDeps = TaskModelPreference & {
   readonly binary?: string;
   readonly workingDir?: string;
   readonly invokeFn: <T>(cmd: string, args?: Record<string, unknown>) => Promise<T>;
+};
+
+type FormatParams = {
+  readonly deps: WorkflowFormatDeps;
+  readonly input: WorkflowFormatInput;
 };
 
 export const buildWorkflowFormatUserPrompt = (input: WorkflowFormatInput): string => {
@@ -80,10 +84,10 @@ export const buildWorkflowFormatUserPrompt = (input: WorkflowFormatInput): strin
   return lines.join('\n');
 };
 
-export const formatWorkflowFromNL = async (
-  deps: WorkflowFormatDeps,
-  input: WorkflowFormatInput,
-): Promise<FormattedWorkflow | null> => {
+export const formatWorkflowFromNL = async ({
+  deps,
+  input,
+}: FormatParams): Promise<FormattedWorkflow | null> => {
   const description = input.description.trim();
   if (description.length === 0) {
     return null;
@@ -91,7 +95,8 @@ export const formatWorkflowFromNL = async (
 
   const result = await runAuxOneShot({
     providerId: deps.providerId,
-    model: getCheapModel(deps.providerId),
+    model: deps.model,
+    ...(deps.effort != null && { effort: deps.effort }),
     binary: deps.binary ?? getDefaultBinary(deps.providerId),
     userMessage: buildWorkflowFormatUserPrompt(input),
     systemPrompt: WORKFLOW_FORMAT_SYSTEM_PROMPT,


### PR DESCRIPTION
## What

One workspace-aware task-model resolver is now the single runtime entry point for every configurable task. Auto resolves against the workspace default provider first and the session's captured provider only as a fallback, which is what Providers Studio previews. Callers updated: session summary, workflow step and handoff summary, summary retry, orchestrator, goal reprocessing, workflow and agent naming, PR and MR drafts, rebase, the planner picker and the routing rows.

Also in this PR:

- Workflow Studio generation goes through the `plan_generation` task instead of the first connected provider plus a hardcoded cheap model, with a fallback to the first connected provider only when the workspace default is unset or disconnected.
- Configured task effort flows through `taskModelAgentSpawnConfig` (pr_draft, rebase) and the planner picker starts from the `plan_generation` effort instead of the planner role default.
- The exact stored model id survives task and role resolution, so a configured `gpt-5.6-terra` no longer collapses to the first variant at CLI time.
- An invalid stored task preference warns through the dev logger instead of silently turning into the Anthropic default.

## Why

With everything configured on Codex, an older session created under Anthropic kept picking Haiku for summaries because the runtime read the session's captured provider while the Studio previewed the workspace default. The same gap existed in Workflow Studio generation and in the effort and variant handling of other tasks.

Closes #1621

Left out on purpose: `branch_naming` (no runtime caller yet), fan-out branch summaries and resolver output summaries (deterministic by design), and role preferences falling back to the workspace default provider (they warn and keep the compiled default; threading the workspace default through every spawn path is a separate change).

## Test plan

- `pnpm --filter @goodboy/core test`: 1276 passed, 4 skipped
- `pnpm --filter @goodboy/desktop test`: 7019 passed
- `pnpm --filter @goodboy/core run typecheck` and `pnpm --filter @goodboy/desktop run typecheck`: clean
- `pnpm knip`: clean
- New regression tests: Anthropic session with workspace default switched to Codex resolves the summarizer on Codex; explicit Codex GPT-5.6 pins honored for session and workflow summaries; Studio generation uses plan_generation; effort passthrough; variant preservation and invalid preference warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)