### PR TITLE
fix(desktop): follow the pr drafting agent from the overview

### DIFF
--- a/apps/desktop/src/features/github/components/GitHubStudio/CreatePrPanel.test.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/CreatePrPanel.test.tsx
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type {
+  Agent,
+  AgentId,
   IsoDateTime,
   SessionExternalTask,
   SessionId,
@@ -27,7 +29,9 @@ type Store = {
   readonly createPrForSession: ReturnType<typeof vi.fn<CreatePr>>;
   readonly spawnAgent: ReturnType<typeof vi.fn<SpawnAgent>>;
   readonly selectAgent: ReturnType<typeof vi.fn>;
+  readonly setActiveLens: ReturnType<typeof vi.fn>;
   readonly setCurrentSession: ReturnType<typeof vi.fn>;
+  sessionPhaseRuns: Record<string, ReadonlyArray<Agent>>;
   readonly sessionBranches: Record<string, string>;
   readonly sessionProjectMounts: Record<string, ReadonlyArray<never>>;
   readonly sessionActiveProject: Record<string, string>;
@@ -68,7 +72,9 @@ const h = vi.hoisted(() => ({
     createPrForSession: vi.fn<CreatePr>(async () => undefined),
     spawnAgent: vi.fn<SpawnAgent>(async () => 'agent-2'),
     selectAgent: vi.fn(async () => undefined),
+    setActiveLens: vi.fn(),
     setCurrentSession: vi.fn(async () => undefined),
+    sessionPhaseRuns: {} as Record<string, ReadonlyArray<Agent>>,
     sessionBranches: { 'session-2': 'ak/card-config' },
     sessionProjectMounts: {},
     sessionActiveProject: {},
@@ -140,13 +146,16 @@ const linkedIssue = (overrides: Partial<SessionExternalTask>): SessionExternalTa
 
 const renderPanel = () =>
   render(
-    <CreatePrPanel
-      sessionId={SESSION_ID}
-      defaultTitle="Refactor PR cards"
-      onCreated={vi.fn()}
-      onStudioClose={vi.fn()}
-    />,
+    <CreatePrPanel sessionId={SESSION_ID} defaultTitle="Refactor PR cards" onCreated={vi.fn()} />,
   );
+
+const draftingAgent = (): Agent => ({
+  id: 'agent-1' as AgentId,
+  sessionId: SESSION_ID,
+  ordinal: 1,
+  name: 'open pull request',
+  status: 'running',
+});
 
 const switchToAgentMode = () => {
   fireEvent.click(screen.getByRole('tab', { name: 'With an agent' }));
@@ -157,7 +166,9 @@ beforeEach(() => {
   h.store.createPrForSession.mockImplementation(async () => undefined);
   h.store.spawnAgent.mockClear();
   h.store.selectAgent.mockClear();
+  h.store.setActiveLens.mockClear();
   h.store.setCurrentSession.mockClear();
+  h.store.sessionPhaseRuns = {};
   h.showToast.mockClear();
   h.store.workspaceOverrides = {};
   h.store.sessionExternalTasks = {};
@@ -238,15 +249,7 @@ describe('CreatePrPanel', () => {
   });
 
   it('spawns a PR agent with the chosen config and operator notes', async () => {
-    const onStudioClose = vi.fn();
-    render(
-      <CreatePrPanel
-        sessionId={SESSION_ID}
-        defaultTitle="Refactor PR cards"
-        onCreated={vi.fn()}
-        onStudioClose={onStudioClose}
-      />,
-    );
+    renderPanel();
     switchToAgentMode();
     fireEvent.click(screen.getByRole('button', { name: 'Choose agent config' }));
     fireEvent.click(screen.getByRole('button', { name: 'Draft with agent' }));
@@ -262,23 +265,16 @@ describe('CreatePrPanel', () => {
       '\n\nOperator notes:\n---\nKeep the public API stable.\n---',
     );
     expect(args).toMatchObject({ focus: 'none' });
-    expect(onStudioClose).not.toHaveBeenCalled();
   });
 
-  it('keeps the panel in place after the spawn and opens the agent only from the toast action', async () => {
-    const onStudioClose = vi.fn();
-    render(
-      <CreatePrPanel
-        sessionId={SESSION_ID}
-        defaultTitle="Refactor PR cards"
-        onCreated={vi.fn()}
-        onStudioClose={onStudioClose}
-      />,
-    );
+  it('sends the operator back to the overview and follows the agent from the toast action', async () => {
+    renderPanel();
     switchToAgentMode();
     fireEvent.click(screen.getByRole('button', { name: 'Draft with agent' }));
 
     await waitFor(() => expect(h.showToast).toHaveBeenCalledOnce());
+    expect(h.store.setCurrentSession).toHaveBeenCalledWith(SESSION_ID);
+    expect(h.store.setActiveLens).toHaveBeenCalledWith(SESSION_ID, null);
     expect(h.store.selectAgent).not.toHaveBeenCalled();
     const action = h.showToast.mock.calls[0]![2]?.action;
     expect(action?.label).toBe('Open the agent');
@@ -286,7 +282,22 @@ describe('CreatePrPanel', () => {
     action?.onClick();
 
     await waitFor(() => expect(h.store.selectAgent).toHaveBeenCalledWith(SESSION_ID, 'agent-2'));
-    await waitFor(() => expect(onStudioClose).toHaveBeenCalledOnce());
+    expect(h.store.setActiveLens).toHaveBeenCalledWith(SESSION_ID, 'agents');
+  });
+
+  it('blocks both create actions while a drafting agent runs', async () => {
+    h.store.sessionPhaseRuns = { 'session-2': [draftingAgent()] };
+    renderPanel();
+    await screen.findByRole('combobox', { name: 'Branch' });
+
+    expect(screen.getByRole('button', { name: 'Create PR' }).hasAttribute('disabled')).toBe(true);
+    expect(
+      screen.getByText('An agent is already opening a pull request for this session.'),
+    ).toBeDefined();
+    switchToAgentMode();
+    fireEvent.click(screen.getByRole('button', { name: 'Draft with agent' }));
+
+    expect(h.store.spawnAgent).not.toHaveBeenCalled();
   });
 
   it('preserves the prompt for a whitespace-only hint', async () => {
@@ -316,12 +327,7 @@ describe('CreatePrPanel', () => {
 
   it('uses a workspace task model loaded after mount', async () => {
     const { rerender } = render(
-      <CreatePrPanel
-        sessionId={SESSION_ID}
-        defaultTitle="Refactor PR cards"
-        onCreated={vi.fn()}
-        onStudioClose={vi.fn()}
-      />,
+      <CreatePrPanel sessionId={SESSION_ID} defaultTitle="Refactor PR cards" onCreated={vi.fn()} />,
     );
     h.store.workspaceOverrides = {
       'workspace-1': {
@@ -329,12 +335,7 @@ describe('CreatePrPanel', () => {
       },
     };
     rerender(
-      <CreatePrPanel
-        sessionId={SESSION_ID}
-        defaultTitle="Refactor PR cards"
-        onCreated={vi.fn()}
-        onStudioClose={vi.fn()}
-      />,
+      <CreatePrPanel sessionId={SESSION_ID} defaultTitle="Refactor PR cards" onCreated={vi.fn()} />,
     );
     switchToAgentMode();
     fireEvent.click(screen.getByRole('button', { name: 'Draft with agent' }));

--- a/apps/desktop/src/features/github/components/GitHubStudio/CreatePrPanel.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/CreatePrPanel.tsx
@@ -15,6 +15,8 @@ import {
 } from '@goodboy/ui';
 import { AlertTriangle, ArrowRight, GitBranch, PenLine } from 'lucide-react';
 import { ghBaseBranches } from '../../github';
+import { PR_DRAFT_AGENT_NAME } from '../../prDraftAgent';
+import { usePrDraftAgentRunning } from '../../usePrDraftAgentRunning';
 import { closingIssueReferences } from '../../closingIssueReferences';
 import { appendOperatorNotes } from '../../../session/utils/appendOperatorNotes';
 import { AgentSpawnConfig } from '../../../session/components/AgentSpawnConfig';
@@ -23,7 +25,7 @@ import { taskModelAgentSpawnConfig } from '../../../session/components/AgentSpaw
 import { BranchCombobox } from '../../../worktree/BranchCombobox';
 import type { LocalBranchInfo } from '../../../worktree/worktree';
 import { EMPTY_ARRAY, useAppStore } from '../../../../store';
-import { useToast } from '../../../../app/components/Toast';
+import { useAgentStartedToast } from '../../../../shared/hooks/useAgentStartedToast';
 import { useSessionRepo } from '../../../../store/slices/worktrees/useSessionRepo';
 import { openUrl } from '../../../../shared/lib/editor';
 import { CONCEPT_ICONS, ICON_SIZE } from '../../../../shared/components/conceptIcons';
@@ -36,7 +38,6 @@ type Props = {
   readonly defaultTitle: string;
   readonly closedPr?: { number: number; url: string };
   readonly onCreated: () => void;
-  readonly onStudioClose: () => void;
   readonly onCancel?: () => void;
 };
 
@@ -45,14 +46,14 @@ export const CreatePrPanel = ({
   defaultTitle,
   closedPr,
   onCreated,
-  onStudioClose,
   onCancel,
 }: Props) => {
   const createPrForSession = useAppStore((s) => s.createPrForSession);
   const spawnAgent = useAppStore((s) => s.spawnAgent);
-  const selectAgent = useAppStore((s) => s.selectAgent);
+  const setActiveLens = useAppStore((s) => s.setActiveLens);
   const setCurrentSession = useAppStore((s) => s.setCurrentSession);
-  const { showToast } = useToast();
+  const announceAgentStarted = useAgentStartedToast();
+  const isDraftAgentRunning = usePrDraftAgentRunning({ sessionId });
   const repo = useSessionRepo({ sessionId });
   const branch = repo?.branch ?? null;
   const projectRoot = repo?.repoRoot ?? null;
@@ -135,7 +136,7 @@ export const CreatePrPanel = ({
   }, [projectId, projectRoot, workspaceId]);
 
   const onCreate = async () => {
-    if (busy || title.trim().length === 0) {
+    if (busy || isDraftAgentRunning || title.trim().length === 0) {
       return;
     }
     setBusy('create');
@@ -151,7 +152,7 @@ export const CreatePrPanel = ({
   };
 
   const onCreateWithAi = async () => {
-    if (busy) {
+    if (busy || isDraftAgentRunning) {
       return;
     }
     setBusy('ai');
@@ -176,25 +177,20 @@ export const CreatePrPanel = ({
         `Then run \`gh pr create\` to open it and report the PR URL.`,
       ].join('\n');
       const agentId = await spawnAgent(sessionId, {
-        name: 'open pull request',
+        name: PR_DRAFT_AGENT_NAME,
         initialPrompt: appendOperatorNotes({ prompt, hint: agentConfig.hint }),
         model: agentConfig.model,
         ...(agentConfig.provider !== '' && { provider: agentConfig.provider }),
         effort: agentConfig.effort,
         focus: 'none',
       });
-      showToast('success', 'An agent is drafting the pull request. You can keep working.', {
+      await setCurrentSession(sessionId);
+      setActiveLens(sessionId, null);
+      announceAgentStarted({
+        sessionId,
+        agentId,
         title: 'Agent started',
-        action: {
-          label: 'Open the agent',
-          onClick: () => {
-            void (async () => {
-              await setCurrentSession(sessionId);
-              await selectAgent(sessionId, agentId);
-              onStudioClose();
-            })();
-          },
-        },
+        message: 'An agent is drafting the pull request. You can keep working.',
       });
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
@@ -338,6 +334,12 @@ export const CreatePrPanel = ({
       <footer className="shrink-0 px-6 py-3">
         <div className="mx-auto flex w-full max-w-2xl items-center gap-3">
           <div className="flex min-w-0 flex-1 items-center gap-3">
+            {error == null && isDraftAgentRunning && (
+              <span className="inline-flex min-w-0 items-center gap-1.5 truncate text-xs text-muted-foreground">
+                <CONCEPT_ICONS.agents size={ICON_SIZE.row} aria-hidden className="shrink-0" />
+                An agent is already opening a pull request for this session.
+              </span>
+            )}
             {error != null && (
               <span
                 role="alert"
@@ -357,7 +359,7 @@ export const CreatePrPanel = ({
           {mode === 'manual' ? (
             <Button
               onClick={() => void onCreate()}
-              disabled={busy !== null || title.trim().length === 0}
+              disabled={busy !== null || isDraftAgentRunning || title.trim().length === 0}
               className={cn(busy === 'create' && 'animate-border-pulse')}
             >
               {busy === 'create' ? (
@@ -372,7 +374,7 @@ export const CreatePrPanel = ({
           ) : (
             <Button
               onClick={() => void onCreateWithAi()}
-              disabled={busy !== null}
+              disabled={busy !== null || isDraftAgentRunning}
               className={cn(busy === 'ai' && 'animate-border-pulse')}
             >
               {busy === 'ai' ? (

--- a/apps/desktop/src/features/github/components/GitHubStudio/CreatePrPanel.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/CreatePrPanel.tsx
@@ -136,7 +136,7 @@ export const CreatePrPanel = ({
   }, [projectId, projectRoot, workspaceId]);
 
   const onCreate = async () => {
-    if (busy || isDraftAgentRunning || title.trim().length === 0) {
+    if (busy !== null || isDraftAgentRunning || title.trim().length === 0) {
       return;
     }
     setBusy('create');
@@ -152,7 +152,7 @@ export const CreatePrPanel = ({
   };
 
   const onCreateWithAi = async () => {
-    if (busy || isDraftAgentRunning) {
+    if (busy !== null || isDraftAgentRunning) {
       return;
     }
     setBusy('ai');

--- a/apps/desktop/src/features/github/components/GitHubStudio/PrActionBar.test.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/PrActionBar.test.tsx
@@ -9,6 +9,7 @@ type Params = {
   readonly canMerge?: boolean;
   readonly canReview?: boolean;
   readonly busy?: ActionBusy;
+  readonly canCreateNew?: boolean;
   readonly onMerge?: () => Promise<void>;
   readonly onSubmitVerdict?: (submission: PrVerdictSubmission) => void;
 };
@@ -35,6 +36,7 @@ const renderActionBar = ({
   canMerge = true,
   canReview = true,
   busy = null,
+  canCreateNew = true,
   onMerge = vi.fn(async () => undefined),
   onSubmitVerdict = vi.fn(),
 }: Params = {}) =>
@@ -50,6 +52,7 @@ const renderActionBar = ({
       onConvertDraft={vi.fn()}
       onClose={vi.fn()}
       onReopen={vi.fn()}
+      canCreateNew={canCreateNew}
       onCreateNew={vi.fn()}
       onMerge={onMerge}
     />,
@@ -137,5 +140,18 @@ describe('PrActionBar', () => {
 
     expect(screen.getByText('Auto-merge on')).toBeDefined();
     expect(screen.queryByText('In merge queue')).toBeNull();
+  });
+});
+
+describe('PrActionBar create new', () => {
+  it('blocks a second pull request while a drafting agent runs', () => {
+    renderActionBar({
+      pr: { ...PR, state: 'closed' },
+      canCreateNew: false,
+    });
+
+    expect(screen.getByRole('button', { name: 'Create new PR' }).hasAttribute('disabled')).toBe(
+      true,
+    );
   });
 });

--- a/apps/desktop/src/features/github/components/GitHubStudio/PrActionBar.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/PrActionBar.tsx
@@ -160,7 +160,7 @@ export const PrActionBar = ({
             emphasis="outline"
             size="sm"
             onClick={onCreateNew}
-            disabled={canCreateNew === false}
+            disabled={canCreateNew === false || busy !== null}
             title={
               canCreateNew
                 ? 'Open a new pull request for this branch'

--- a/apps/desktop/src/features/github/components/GitHubStudio/PrActionBar.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/PrActionBar.tsx
@@ -18,6 +18,7 @@ type Props = {
   readonly onConvertDraft: () => void;
   readonly onClose: () => void;
   readonly onReopen: () => void;
+  readonly canCreateNew: boolean;
   readonly onCreateNew: () => void;
   readonly onMerge: () => Promise<void>;
 };
@@ -33,6 +34,7 @@ export const PrActionBar = ({
   onConvertDraft,
   onClose,
   onReopen,
+  canCreateNew,
   onCreateNew,
   onMerge,
 }: Props) => {
@@ -153,7 +155,18 @@ export const PrActionBar = ({
             <RotateCcw size={ICON_SIZE.row} aria-hidden />
             Reopen
           </Button>
-          <Button variant="primary" emphasis="outline" size="sm" onClick={onCreateNew}>
+          <Button
+            variant="primary"
+            emphasis="outline"
+            size="sm"
+            onClick={onCreateNew}
+            disabled={canCreateNew === false}
+            title={
+              canCreateNew
+                ? 'Open a new pull request for this branch'
+                : 'An agent is already opening a pull request for this session'
+            }
+          >
             <Plus size={ICON_SIZE.row} aria-hidden />
             Create new PR
           </Button>

--- a/apps/desktop/src/features/github/components/GitHubStudio/PrDetailPanel.test.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/PrDetailPanel.test.tsx
@@ -39,6 +39,10 @@ type Store = {
     Readonly<Record<string, ReadonlyArray<PullRequestState>>>
   >;
   readonly sessionSelectedPrNumber: Record<string, number | null>;
+  readonly sessionPhaseRuns: Record<
+    string,
+    ReadonlyArray<{ readonly name: string; readonly status: string }>
+  >;
   readonly sessionBranches: Record<string, string>;
   readonly refreshSessionPrDetail: ReturnType<typeof vi.fn>;
   readonly refreshSessionPr: ReturnType<typeof vi.fn>;
@@ -145,6 +149,7 @@ const h = vi.hoisted(() => {
       },
       sessionProjectPrs: { [sessionId]: { 'project-1': [pr] } },
       sessionSelectedPrNumber: {},
+      sessionPhaseRuns: {},
       sessionBranches: { [sessionId]: pr.headBranch },
       refreshSessionPrDetail: vi.fn(async () => undefined),
       refreshSessionPr: vi.fn(async () => undefined),

--- a/apps/desktop/src/features/github/components/GitHubStudio/PrDetailPanel.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/PrDetailPanel.tsx
@@ -17,6 +17,7 @@ import { selectActiveProjectPrs } from '../../../../store/slices/github/activePr
 import type { CommentThread } from '../../comment-threads';
 import { PullRequestChip } from '../PullRequestChip';
 import { CreatePrPanel } from './CreatePrPanel';
+import { usePrDraftAgentRunning } from '../../usePrDraftAgentRunning';
 import { PrActionBar, type ActionBusy } from './PrActionBar';
 import type { PrVerdictSubmission } from './PrVerdictAction';
 import { PrChecks } from './PrChecks';
@@ -83,6 +84,7 @@ export const PrDetailPanel = ({
   );
 
   const { showToast } = useToast();
+  const isDraftAgentRunning = usePrDraftAgentRunning({ sessionId });
   const [busy, setBusy] = useState<ActionBusy>(null);
   const [createOpen, setCreateOpen] = useState(false);
   const [section, setSection] = useState<PrSection>('overview');
@@ -213,12 +215,7 @@ export const PrDetailPanel = ({
   if (activePr == null) {
     return (
       <div className="flex h-full flex-col">
-        <CreatePrPanel
-          sessionId={sessionId}
-          defaultTitle={session.goal}
-          onCreated={onMutated}
-          onStudioClose={onClose}
-        />
+        <CreatePrPanel sessionId={sessionId} defaultTitle={session.goal} onCreated={onMutated} />
       </div>
     );
   }
@@ -311,6 +308,7 @@ export const PrDetailPanel = ({
           onConvertDraft={() => void run('undraft', () => convertPrToDraft(sessionId, num))}
           onClose={() => void run('close', () => closePr(sessionId, num))}
           onReopen={() => void run('reopen', () => reopenPr(sessionId, num))}
+          canCreateNew={!isDraftAgentRunning}
           onCreateNew={() => setCreateOpen(true)}
           onMerge={() => run('merge', () => mergePr(sessionId, num))}
         />
@@ -330,7 +328,6 @@ export const PrDetailPanel = ({
             onMutated();
           }}
           onCancel={() => setCreateOpen(false)}
-          onStudioClose={onClose}
         />
       </StudioDetailLayout>
     );

--- a/apps/desktop/src/features/github/prDraftAgent.test.ts
+++ b/apps/desktop/src/features/github/prDraftAgent.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import type { Agent, AgentId, AgentStatus, IsoDateTime, SessionId } from '@goodboy/types';
+import { isPrDraftAgentRunning, PR_DRAFT_AGENT_NAME } from './prDraftAgent';
+
+const agent = ({
+  name,
+  status,
+  deletedAt,
+}: {
+  readonly name: string;
+  readonly status: AgentStatus;
+  readonly deletedAt?: IsoDateTime;
+}): Agent => ({
+  id: `${name}-${status}` as AgentId,
+  sessionId: 'session-1' as SessionId,
+  ordinal: 1,
+  name,
+  status,
+  ...(deletedAt == null ? {} : { deletedAt }),
+});
+
+describe('isPrDraftAgentRunning', () => {
+  it('reports a pending or running pr draft agent', () => {
+    expect(
+      isPrDraftAgentRunning({
+        agents: [agent({ name: PR_DRAFT_AGENT_NAME, status: 'pending' })],
+      }),
+    ).toBe(true);
+    expect(
+      isPrDraftAgentRunning({
+        agents: [agent({ name: PR_DRAFT_AGENT_NAME, status: 'running' })],
+      }),
+    ).toBe(true);
+  });
+
+  it('ignores a settled or deleted pr draft agent', () => {
+    expect(
+      isPrDraftAgentRunning({
+        agents: [
+          agent({ name: PR_DRAFT_AGENT_NAME, status: 'completed' }),
+          agent({ name: PR_DRAFT_AGENT_NAME, status: 'failed' }),
+          agent({
+            name: PR_DRAFT_AGENT_NAME,
+            status: 'running',
+            deletedAt: '2026-09-07T00:00:00.000Z' as IsoDateTime,
+          }),
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it('ignores other running agents', () => {
+    expect(
+      isPrDraftAgentRunning({ agents: [agent({ name: 'implementer', status: 'running' })] }),
+    ).toBe(false);
+  });
+});

--- a/apps/desktop/src/features/github/prDraftAgent.ts
+++ b/apps/desktop/src/features/github/prDraftAgent.ts
@@ -1,0 +1,15 @@
+import type { Agent } from '@goodboy/types';
+
+export const PR_DRAFT_AGENT_NAME = 'open pull request';
+
+export const isPrDraftAgentRunning = ({
+  agents,
+}: {
+  readonly agents: ReadonlyArray<Agent>;
+}): boolean =>
+  agents.some(
+    (agent) =>
+      agent.name === PR_DRAFT_AGENT_NAME &&
+      agent.deletedAt == null &&
+      (agent.status === 'pending' || agent.status === 'running'),
+  );

--- a/apps/desktop/src/features/github/usePrDraftAgentRunning.ts
+++ b/apps/desktop/src/features/github/usePrDraftAgentRunning.ts
@@ -1,0 +1,13 @@
+import type { SessionId } from '@goodboy/types';
+import { useAppStore } from '../../store';
+import { isPrDraftAgentRunning } from './prDraftAgent';
+
+export const usePrDraftAgentRunning = ({
+  sessionId,
+}: {
+  readonly sessionId: SessionId | null;
+}): boolean =>
+  useAppStore((state) => {
+    const agents = sessionId == null ? null : (state.sessionPhaseRuns[sessionId] ?? null);
+    return agents == null ? false : isPrDraftAgentRunning({ agents });
+  });

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectMountRow.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectMountRow.test.tsx
@@ -28,6 +28,7 @@ const { store, remoteKind } = vi.hoisted(() => ({
       ReadonlyArray<{ id: string; projectId?: string; status: string }>
     >,
     scriptRuns: {} as Record<string, Record<string, { status: string }>>,
+    sessionPhaseRuns: {} as Record<string, ReadonlyArray<{ name: string; status: string }>>,
     projectScripts: {} as Record<string, ReadonlyArray<{ id: string; projectId: string }>>,
   },
 }));
@@ -151,6 +152,7 @@ beforeEach(() => {
     ],
   };
   store.sessionWorktrees = { [sessionId]: ['/session-root'] };
+  store.sessionPhaseRuns = {};
   store.detectedEditors = [{ binary: 'code', label: 'VS Code' }];
   vi.mocked(openInEditor).mockClear();
 });
@@ -171,6 +173,17 @@ describe('ProjectMountRow create pr action', () => {
     expect(event.detail).toEqual({ sessionId });
     expect(store.setSessionActiveProject).toHaveBeenCalledWith({ sessionId, projectId: 'api' });
     window.removeEventListener('goodboy:open-github-session', listener);
+  });
+
+  it('blocks create pr while an agent is opening one', () => {
+    store.sessionPhaseRuns = {
+      [sessionId]: [{ name: 'open pull request', status: 'running' }],
+    };
+    renderRow({ diffStat: { additions: 3, deletions: 1 } });
+
+    const action = screen.getByRole('button', { name: 'An agent is opening a PR for API' });
+    expect(action.hasAttribute('disabled')).toBe(true);
+    expect(action.textContent).toBe('Opening PR…');
   });
 
   it('hides create pr without changes', () => {

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectMountRow.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectMountRow.tsx
@@ -1,4 +1,4 @@
-import { Skeleton, Tooltip } from '@goodboy/ui';
+import { cn, Skeleton, Tooltip } from '@goodboy/ui';
 import type {
   Project,
   PullRequestState,
@@ -14,6 +14,7 @@ import {
   projectGlyph,
 } from '../../../../../shared/components/conceptIcons';
 import { PullRequestChip } from '../../../../github/components/PullRequestChip';
+import { usePrDraftAgentRunning } from '../../../../github/usePrDraftAgentRunning';
 import { useRemoteHostKind } from '../../../../worktree/useRemoteHostKind';
 import { DiffStat } from '../../DiffStat';
 import { EditorMenu } from '../EditorMenu';
@@ -62,6 +63,8 @@ export const ProjectMountRow = ({
   const changes = diffStat != null && (diffStat.additions > 0 || diffStat.deletions > 0);
   const isStatusPending = isStatusPendingProp && worktreeStatus == null && project?.kind === 'repo';
   const remoteKind = useRemoteHostKind({ sessionId });
+  const isDraftAgentRunning = usePrDraftAgentRunning({ sessionId });
+  const isCreateBlocked = remoteKind !== 'gitlab' && isDraftAgentRunning;
   const activity = useProjectActivity({
     sessionId,
     projectId: mount.projectId,
@@ -139,7 +142,12 @@ export const ProjectMountRow = ({
       {pullRequest == null && changes && remoteKind != null ? (
         <button
           type="button"
-          aria-label={`Create a PR for ${projectName}`}
+          disabled={isCreateBlocked}
+          aria-label={
+            isCreateBlocked
+              ? `An agent is opening a PR for ${projectName}`
+              : `Create a PR for ${projectName}`
+          }
           onClick={() => {
             void setSessionActiveProject({ sessionId, projectId: mount.projectId }).then(() => {
               window.dispatchEvent(
@@ -152,9 +160,12 @@ export const ProjectMountRow = ({
               );
             });
           }}
-          className="rounded-md px-1.5 py-1 text-xs text-muted-foreground/70 hover:bg-muted/40 hover:text-foreground"
+          className={cn(
+            'rounded-md px-1.5 py-1 text-xs text-muted-foreground/70 hover:bg-muted/40 hover:text-foreground',
+            'disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent',
+          )}
         >
-          {remoteKind === 'gitlab' ? 'Create MR' : 'Create PR'}
+          {remoteKind === 'gitlab' ? 'Create MR' : isCreateBlocked ? 'Opening PR…' : 'Create PR'}
         </button>
       ) : null}
       {pullRequest != null ? (

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.tsx
@@ -22,6 +22,7 @@ import { useGithubConnection } from '../../../../integrations/github/useGithubCo
 import { useRemoteHostKind } from '../../../../worktree/useRemoteHostKind';
 import { gitlabMrStateKind } from '../../../../integrations/gitlab/gitlabMrStateKind';
 import { closingIssueReferences } from '../../../../github/closingIssueReferences';
+import { usePrDraftAgentRunning } from '../../../../github/usePrDraftAgentRunning';
 import { closingReferenceLines } from '../../../../github/closingReferenceLines';
 import { removeClosingReference } from '../../../../github/removeClosingReference';
 import { RefreshIconButton } from '@goodboy/ui';
@@ -329,6 +330,7 @@ const GithubPrCard = ({
   );
   const projects = useAppStore((state) => state.projects);
   const githubConnection = useGithubConnection({ workspaceId: session.workspaceId });
+  const isDraftAgentRunning = usePrDraftAgentRunning({ sessionId });
   const isGithubConnected = resolveIntegrationConnection({
     provider: 'github',
     integrations: workspaceIntegrations,
@@ -463,12 +465,20 @@ const GithubPrCard = ({
 
   if (!pr) {
     const hasLinkedWork = linkedIssues.length > 0 || codeHostTasks.length > 0;
-    const openAction = (
+    const openAction = isDraftAgentRunning ? (
+      <Button size="sm" variant="ghost" onClick={() => onSelectLens('agents')}>
+        <CONCEPT_ICONS.agents size={ICON_SIZE.row} aria-hidden className="shrink-0" />
+        Follow the drafting agent
+      </Button>
+    ) : (
       <Button size="sm" onClick={onOpenStudio}>
         Draft a pull request
         <ArrowRight size={ICON_SIZE.row} aria-hidden className="shrink-0 opacity-70" />
       </Button>
     );
+    const emptyDescription = isDraftAgentRunning
+      ? 'An agent is already opening a pull request for this session. Follow it instead of starting a second one.'
+      : null;
     if (!hasLinkedWork) {
       return shell({
         children: (
@@ -476,7 +486,10 @@ const GithubPrCard = ({
             tone={CONCEPT_TONE.pr}
             icon={CONCEPT_ICONS.pr}
             title="Open a pull or merge request"
-            description="No issues or external tasks are linked to this session yet. Turn its work into a pull or merge request, or hand it to an agent that writes one from your commits."
+            description={
+              emptyDescription ??
+              'No issues or external tasks are linked to this session yet. Turn its work into a pull or merge request, or hand it to an agent that writes one from your commits.'
+            }
             action={openAction}
           />
         ),
@@ -496,7 +509,10 @@ const GithubPrCard = ({
             tone={CONCEPT_TONE.pr}
             icon={CONCEPT_ICONS.pr}
             title="No pull or merge request yet"
-            description="Turn this session's work into a pull or merge request when it is ready."
+            description={
+              emptyDescription ??
+              "Turn this session's work into a pull or merge request when it is ready."
+            }
             action={openAction}
           />
         </>


### PR DESCRIPTION
## What

Handing pull request creation to an agent now moves the operator to the session overview with the shared agent started toast, and every create entry is gated while that agent is pending or running.

- `CreatePrPanel`: after the spawn it calls `setCurrentSession` + `setActiveLens(sessionId, null)` and announces through `useAgentStartedToast`, replacing the local toast. The now dead `onStudioClose` prop is gone.
- New `prDraftAgent.ts` (`PR_DRAFT_AGENT_NAME`, `isPrDraftAgentRunning`) and `usePrDraftAgentRunning` hook read `sessionPhaseRuns`.
- Gated entries: project mount row (github remotes only, label becomes `Opening PR…`), PR lens empty state (offers `Follow the drafting agent` instead), `PrActionBar` create new PR via the new `canCreateNew` prop, and both actions inside the create panel with a footer note.

## Why

The panel stayed parked in a pending-looking state after the spawn, with nothing to watch, and every create affordance stayed live, so a second agent could open a duplicate pull request on the same branch.

## Test plan

- `pnpm typecheck` green
- `pnpm test` green (8915 tests)
- `pnpm knip --include files,duplicates,unlisted`, `pnpm knip:production`, `pnpm check:tauri-commands` green
- New coverage: `prDraftAgent.test.ts`, blocked-state cases in `CreatePrPanel.test.tsx`, `PrActionBar.test.tsx`, `ProjectMountRow.test.tsx`

Note: the GitLab `CreateMrForm` has the same stay-in-place behaviour and was left untouched, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)