### PR TITLE
feat(ui): add the resolve queue home

### DIFF
--- a/apps/desktop/src/features/permissions/components/DiffViewerDialog/DiffToolbar.tsx
+++ b/apps/desktop/src/features/permissions/components/DiffViewerDialog/DiffToolbar.tsx
@@ -18,6 +18,7 @@ type Props = {
   onClose: () => void;
   viewSelector?: React.ReactNode;
   layoutToggle?: React.ReactNode;
+  resolveAction?: React.ReactNode;
   presentation?: 'bar' | 'actions';
 };
 
@@ -34,6 +35,7 @@ export const DiffToolbar = ({
   onClose,
   viewSelector,
   layoutToggle,
+  resolveAction,
   presentation = 'bar',
 }: Props) => {
   const titleText = title ?? (prNumber !== undefined ? `PR #${prNumber} diff` : 'Diff');
@@ -93,6 +95,7 @@ export const DiffToolbar = ({
         ) : null}
 
         {layoutToggle}
+        {resolveAction}
 
         <div className="flex shrink-0 items-center gap-0.5">
           {onRefresh ? (

--- a/apps/desktop/src/features/permissions/components/DiffViewerDialog/DiffViewerContent.tsx
+++ b/apps/desktop/src/features/permissions/components/DiffViewerDialog/DiffViewerContent.tsx
@@ -54,6 +54,7 @@ import {
   worktreeStatus,
 } from '../../../../features/worktree/worktree';
 import { DiffViewSelector } from '../DiffViewSelector';
+import { ResolveOverviewAction } from '../../../resolve/components/ResolveOverviewAction';
 import { DIFF_CAPPED_COLUMN_CLASS, TOOLBAR_ICON_BTN, type ReviewState } from './lib';
 import { FileRail } from './FileTree/FileRail';
 import { FileDiffCard } from './FileDiffCard';
@@ -825,6 +826,7 @@ export const DiffViewerContent = ({
                 onClose={onClose}
                 presentation="actions"
                 layoutToggle={<DiffLayoutToggle mode={layoutMode} onChange={setLayoutMode} />}
+                resolveAction={sessionId ? <ResolveOverviewAction sessionId={sessionId} /> : null}
                 viewSelector={
                   isGitAware ? (
                     <DiffViewSelector
@@ -928,6 +930,7 @@ export const DiffViewerContent = ({
               showClose={showToolbarClose}
               onClose={onClose}
               layoutToggle={<DiffLayoutToggle mode={layoutMode} onChange={setLayoutMode} />}
+              resolveAction={sessionId ? <ResolveOverviewAction sessionId={sessionId} /> : null}
               viewSelector={
                 isGitAware ? (
                   <DiffViewSelector

--- a/apps/desktop/src/features/permissions/components/DiffViewerDialog/index.test.tsx
+++ b/apps/desktop/src/features/permissions/components/DiffViewerDialog/index.test.tsx
@@ -18,6 +18,8 @@ const { showToast, state, fixtures } = vi.hoisted(() => ({
   showToast: vi.fn<(kind: string, message: string, opts?: ToastOptions) => void>(),
   state: {
     settings: {} as Record<string, string>,
+    sessionGithub: {} as Record<string, { pr: unknown } | undefined>,
+    sessionResolveAttempts: {} as Record<string, ReadonlyArray<unknown>>,
     sessionPhaseRuns: {} as Record<string, ReadonlyArray<unknown>>,
     sessionProjectMounts: {} as Record<string, ReadonlyArray<{ projectId: string }>>,
     projects: [] as ReadonlyArray<{ id: string; baseBranch?: string | null }>,
@@ -41,6 +43,7 @@ const { showToast, state, fixtures } = vi.hoisted(() => ({
     beginSessionCreation: vi.fn(() => 'creation-1'),
     endSessionCreation: vi.fn(),
     spawnAgent: vi.fn(async () => 'a1'),
+    setAgentConfig: vi.fn(async () => undefined),
     sendTurn: vi.fn(async () => undefined),
     recordSessionEvent: vi.fn(async () => undefined),
   },

--- a/apps/desktop/src/features/resolve/buildResolveQueueRows.test.ts
+++ b/apps/desktop/src/features/resolve/buildResolveQueueRows.test.ts
@@ -27,6 +27,7 @@ const item = ({
   approvalState,
   approvedRevision: null,
   approvedReplyHash: null,
+  integratedSha: null,
   deferredAt: null,
   deliveredAt: null,
   supersededAt: null,

--- a/apps/desktop/src/features/resolve/buildResolveQueueRows.test.ts
+++ b/apps/desktop/src/features/resolve/buildResolveQueueRows.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  PrComment,
+  ResolveAttempt,
+  ResolveQueueItem,
+  ResolveQueueItemWithThread,
+  ResolveThread,
+  SessionId,
+} from '@goodboy/types';
+import { buildResolveQueueRows } from './buildResolveQueueRows';
+
+const sessionId = 'session' as SessionId;
+
+const item = ({
+  threadId,
+  approvalState = 'none',
+}: {
+  readonly threadId: string;
+  readonly approvalState?: ResolveQueueItem['approvalState'];
+}): ResolveQueueItem => ({
+  id: `item-${threadId}`,
+  sessionId,
+  threadId,
+  generation: 0,
+  reopenedFromItemId: null,
+  candidateRevision: 1,
+  approvalState,
+  approvedRevision: null,
+  approvedReplyHash: null,
+  deferredAt: null,
+  deliveredAt: null,
+  supersededAt: null,
+  createdAt: 1,
+  updatedAt: 1,
+});
+
+const thread = ({
+  threadId,
+  activeAttemptId = null,
+  replyDraft = null,
+}: {
+  readonly threadId: string;
+  readonly activeAttemptId?: string | null;
+  readonly replyDraft?: string | null;
+}): ResolveThread => ({
+  id: `row-${threadId}`,
+  sessionId,
+  projectId: null,
+  prNumber: 1,
+  threadId,
+  originKind: 'review_comment',
+  state: 'open',
+  stateReason: null,
+  revision: 1,
+  activeAttemptId,
+  disposition: null,
+  replyDraft,
+  commitShas: null,
+  question: null,
+  replyPostedAt: null,
+  replyId: null,
+  githubResolved: null,
+  closedAt: null,
+  closedSource: null,
+  createdAt: 1,
+  updatedAt: 1,
+});
+
+const comment = ({
+  threadId,
+  createdAt,
+  body,
+}: {
+  readonly threadId: string;
+  readonly createdAt: string;
+  readonly body: string;
+}): PrComment => ({
+  id: `comment-${threadId}`,
+  author: 'reviewer',
+  authorAvatarUrl: null,
+  body,
+  createdAt,
+  url: `https://example.com/${threadId}`,
+  source: 'review',
+  path: 'src/index.ts',
+  line: 12,
+  threadId,
+});
+
+const attempt: ResolveAttempt = {
+  id: 'attempt-1',
+  sessionId,
+  agentId: 'agent-1' as ResolveAttempt['agentId'],
+  prNumber: 1,
+  threadIds: ['t1', 't2'],
+  provider: 'anthropic',
+  model: 'sonnet-5',
+  effort: 'high',
+  instructions: null,
+  phase: 'running',
+  startedAt: 1,
+  endedAt: null,
+  error: null,
+  createdAt: 1,
+};
+
+describe('buildResolveQueueRows', () => {
+  it('attaches the reviewer note, status and active attempt for each entry', () => {
+    const entries: ReadonlyArray<ResolveQueueItemWithThread> = [
+      { item: item({ threadId: 't1' }), thread: thread({ threadId: 't1' }) },
+    ];
+    const rows = buildResolveQueueRows({
+      entries,
+      attempts: [],
+      deliveryReceipts: [],
+      comments: [comment({ threadId: 't1', createdAt: '2026-01-01T00:00:00.000Z', body: 'Fix this' })],
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.status).toBe('for_you');
+    expect(rows[0]?.attempt).toBeNull();
+    expect(rows[0]?.reviewerNote).toMatchObject({
+      body: 'Fix this',
+      location: 'src/index.ts:12',
+      path: 'src/index.ts',
+    });
+  });
+
+  it('marks threads that share an active attempt as covered by each other', () => {
+    const entries: ReadonlyArray<ResolveQueueItemWithThread> = [
+      { item: item({ threadId: 't1' }), thread: thread({ threadId: 't1', activeAttemptId: attempt.id }) },
+      { item: item({ threadId: 't2' }), thread: thread({ threadId: 't2', activeAttemptId: attempt.id }) },
+    ];
+    const rows = buildResolveQueueRows({
+      entries,
+      attempts: [attempt],
+      deliveryReceipts: [],
+      comments: [],
+    });
+    expect(rows[0]?.coveredThreadIds).toEqual(['t2']);
+    expect(rows[1]?.coveredThreadIds).toEqual(['t1']);
+    expect(rows[0]?.attempt).toBe(attempt);
+  });
+
+  it('leaves the reviewer note null when no matching comment exists', () => {
+    const entries: ReadonlyArray<ResolveQueueItemWithThread> = [
+      { item: item({ threadId: 't1' }), thread: thread({ threadId: 't1' }) },
+    ];
+    const rows = buildResolveQueueRows({ entries, attempts: [], deliveryReceipts: [], comments: [] });
+    expect(rows[0]?.reviewerNote).toBeNull();
+  });
+});

--- a/apps/desktop/src/features/resolve/buildResolveQueueRows.ts
+++ b/apps/desktop/src/features/resolve/buildResolveQueueRows.ts
@@ -1,0 +1,111 @@
+import type {
+  PrComment,
+  ResolveAttempt,
+  ResolvePublicationThread,
+  ResolveQueueItem,
+  ResolveQueueItemWithThread,
+  ResolveThread,
+} from '@goodboy/types';
+import { groupThreads } from '../github/comment-threads';
+import { prCommentLocation } from '../session/pr-comment-location';
+import {
+  deriveResolveQueueStatus,
+  type ResolveQueueStatus,
+} from '../../store/slices/resolve/deriveResolveQueueStatus';
+
+export type ResolveQueueReviewerNote = {
+  readonly body: string;
+  readonly author: string;
+  readonly createdAtMs: number;
+  readonly location: string | null;
+  readonly path: string | null;
+};
+
+export type ResolveQueueRow = {
+  readonly item: ResolveQueueItem;
+  readonly thread: ResolveThread;
+  readonly status: ResolveQueueStatus;
+  readonly attempt: ResolveAttempt | null;
+  readonly reviewerNote: ResolveQueueReviewerNote | null;
+  readonly proposal: string | null;
+  readonly coveredThreadIds: ReadonlyArray<string>;
+};
+
+type Params = {
+  readonly entries: ReadonlyArray<ResolveQueueItemWithThread>;
+  readonly attempts: ReadonlyArray<ResolveAttempt>;
+  readonly deliveryReceipts: ReadonlyArray<ResolvePublicationThread>;
+  readonly comments: ReadonlyArray<PrComment>;
+};
+
+const reviewerNoteByThreadId = ({
+  comments,
+}: {
+  readonly comments: ReadonlyArray<PrComment>;
+}): ReadonlyMap<string, ResolveQueueReviewerNote> => {
+  const map = new Map<string, ResolveQueueReviewerNote>();
+  const threads = groupThreads(comments.filter((comment) => comment.source === 'review'));
+  for (const thread of threads) {
+    const threadId = thread.head.threadId;
+    if (threadId == null || threadId === '') {
+      continue;
+    }
+    map.set(threadId, {
+      body: thread.head.body,
+      author: thread.head.author,
+      createdAtMs: Date.parse(thread.head.createdAt),
+      location: prCommentLocation({ comment: thread.head }),
+      path: thread.head.path ?? null,
+    });
+  }
+  return map;
+};
+
+const coveredThreadIdsFor = ({
+  thread,
+  entries,
+}: {
+  readonly thread: ResolveThread;
+  readonly entries: ReadonlyArray<ResolveQueueItemWithThread>;
+}): ReadonlyArray<string> => {
+  if (thread.activeAttemptId === null) {
+    return [];
+  }
+  return entries
+    .filter(
+      (entry) =>
+        entry.thread.activeAttemptId === thread.activeAttemptId &&
+        entry.thread.threadId !== thread.threadId,
+    )
+    .map((entry) => entry.thread.threadId);
+};
+
+export const buildResolveQueueRows = ({
+  entries,
+  attempts,
+  deliveryReceipts,
+  comments,
+}: Params): ReadonlyArray<ResolveQueueRow> => {
+  const notes = reviewerNoteByThreadId({ comments });
+  return entries.map(({ item, thread }) => {
+    const attempt =
+      thread.activeAttemptId === null
+        ? null
+        : (attempts.find((candidate) => candidate.id === thread.activeAttemptId) ?? null);
+    const status = deriveResolveQueueStatus({
+      item,
+      thread,
+      activeAttempt: attempt,
+      deliveryReceipts,
+    });
+    return {
+      item,
+      thread,
+      status,
+      attempt,
+      reviewerNote: notes.get(thread.threadId) ?? null,
+      proposal: thread.replyDraft,
+      coveredThreadIds: coveredThreadIdsFor({ thread, entries }),
+    };
+  });
+};

--- a/apps/desktop/src/features/resolve/components/ResolveOverviewAction/index.tsx
+++ b/apps/desktop/src/features/resolve/components/ResolveOverviewAction/index.tsx
@@ -1,0 +1,62 @@
+import { useState } from 'react';
+import { Button } from '@goodboy/ui';
+import type { ResolveAttempt, SessionId } from '@goodboy/types';
+import { useAppStore } from '../../../../store';
+import { openReview } from '../../../review/openReview';
+import { DEFAULT_AGENT_SPAWN_CONFIG } from '../../../session/components/AgentSpawnConfig/defaultAgentSpawnConfig';
+import type { AgentSpawnConfigValue } from '../../../session/components/AgentSpawnConfig/AgentSpawnConfigValue';
+import { hasActiveResolveRun } from '../../hasActiveResolveRun';
+import { startResolveRun } from '../../startResolveRun';
+import { ResolveSpawnSheet } from '../ResolveSpawnSheet';
+
+type Props = {
+  readonly sessionId: SessionId;
+};
+
+const EMPTY_ATTEMPTS: ReadonlyArray<ResolveAttempt> = [];
+
+export const ResolveOverviewAction = ({ sessionId }: Props) => {
+  const pr = useAppStore((s) => s.sessionGithub[sessionId]?.pr ?? null);
+  const attempts = useAppStore((s) => s.sessionResolveAttempts[sessionId] ?? EMPTY_ATTEMPTS);
+  const spawnAgent = useAppStore((s) => s.spawnAgent);
+  const setAgentConfig = useAppStore((s) => s.setAgentConfig);
+  const [spawnConfig, setSpawnConfig] = useState<AgentSpawnConfigValue>(DEFAULT_AGENT_SPAWN_CONFIG);
+  const [isSpawning, setIsSpawning] = useState(false);
+
+  if (pr === null) {
+    return null;
+  }
+
+  if (hasActiveResolveRun({ attempts })) {
+    return (
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() => openReview({ sessionId, mode: 'queue' })}
+      >
+        For you
+      </Button>
+    );
+  }
+
+  const onStart = async (): Promise<void> => {
+    setIsSpawning(true);
+    try {
+      await startResolveRun({ sessionId, pr, spawnConfig, spawnAgent, setAgentConfig });
+      openReview({ sessionId, mode: 'queue' });
+    } finally {
+      setIsSpawning(false);
+    }
+  };
+
+  return (
+    <ResolveSpawnSheet
+      value={spawnConfig}
+      onChange={setSpawnConfig}
+      disabled={false}
+      isBusy={isSpawning}
+      startLabel="Start a resolve run"
+      onStart={() => void onStart()}
+    />
+  );
+};

--- a/apps/desktop/src/features/resolve/components/ResolveQueueHome/ResolveQueueEmptyState.tsx
+++ b/apps/desktop/src/features/resolve/components/ResolveQueueHome/ResolveQueueEmptyState.tsx
@@ -1,0 +1,56 @@
+import { AlertTriangle, CheckCheck, Inbox } from 'lucide-react';
+import { Button, EmptyState } from '@goodboy/ui';
+
+type NothingWaitingProps = {
+  readonly onOpenSpawn: () => void;
+};
+
+export const NothingWaitingState = ({ onOpenSpawn }: NothingWaitingProps) => (
+  <EmptyState
+    icon={CheckCheck}
+    tone="success"
+    title="Nothing is waiting on you"
+    description="Every review comment on this pull request has an answer."
+    action={
+      <Button size="sm" variant="secondary" onClick={onOpenSpawn}>
+        Start a resolve run
+      </Button>
+    }
+  />
+);
+
+type NoPullRequestProps = {
+  readonly onOpenReview: () => void;
+};
+
+export const NoResolveTargetState = ({ onOpenReview }: NoPullRequestProps) => (
+  <EmptyState
+    icon={Inbox}
+    title="No pull request to resolve yet"
+    description="Open a pull request or leave a note on a diff to see what is for you."
+    action={
+      <Button size="sm" variant="secondary" onClick={onOpenReview}>
+        Open review
+      </Button>
+    }
+  />
+);
+
+type ErrorProps = {
+  readonly message: string;
+  readonly onRetry: () => void;
+};
+
+export const ResolveQueueErrorState = ({ message, onRetry }: ErrorProps) => (
+  <EmptyState
+    icon={AlertTriangle}
+    tone="danger"
+    title="Could not load what is for you"
+    description={message}
+    action={
+      <Button size="sm" variant="secondary" onClick={onRetry}>
+        Retry
+      </Button>
+    }
+  />
+);

--- a/apps/desktop/src/features/resolve/components/ResolveQueueHome/ResolveQueueFooter.tsx
+++ b/apps/desktop/src/features/resolve/components/ResolveQueueHome/ResolveQueueFooter.tsx
@@ -1,0 +1,76 @@
+import { useState } from 'react';
+import { Button, Collapsible } from '@goodboy/ui';
+import { RESOLVE_QUEUE_ACTION_LABEL, RESOLVE_QUEUE_STATUS_LABEL } from '../../resolveQueueCopy';
+import type { ResolveQueueRow } from '../../buildResolveQueueRows';
+
+type Props = {
+  readonly pushed: ReadonlyArray<ResolveQueueRow>;
+  readonly later: ReadonlyArray<ResolveQueueRow>;
+  readonly onOpen: (params: { readonly threadId: string }) => void;
+  readonly onTakeUp: (params: { readonly threadId: string; readonly itemId: string }) => void;
+};
+
+export const ResolveQueueFooter = ({ pushed, later, onOpen, onTakeUp }: Props) => {
+  const [isOpen, setIsOpen] = useState(false);
+  if (pushed.length === 0 && later.length === 0) {
+    return null;
+  }
+  return (
+    <Collapsible
+      open={isOpen}
+      onOpenChange={setIsOpen}
+      trigger={`${RESOLVE_QUEUE_STATUS_LABEL.pushed} (${pushed.length}) · ${RESOLVE_QUEUE_STATUS_LABEL.later} (${later.length})`}
+      className="mt-2 border-t border-border-soft pt-2"
+    >
+      <div className="flex flex-col gap-3">
+        {later.length > 0 && (
+          <div className="flex flex-col gap-1">
+            <p className="text-2xs font-medium uppercase tracking-wide text-muted-foreground">
+              {RESOLVE_QUEUE_STATUS_LABEL.later}
+            </p>
+            <ul className="flex flex-col gap-1">
+              {later.map((row) => (
+                <li key={row.thread.threadId} className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => onOpen({ threadId: row.thread.threadId })}
+                    className="min-w-0 flex-1 truncate text-left text-xs text-muted-foreground hover:text-foreground hover:underline"
+                  >
+                    {row.reviewerNote?.body ?? row.thread.threadId}
+                  </button>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => onTakeUp({ threadId: row.thread.threadId, itemId: row.item.id })}
+                  >
+                    {RESOLVE_QUEUE_ACTION_LABEL.takeUp}
+                  </Button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+        {pushed.length > 0 && (
+          <div className="flex flex-col gap-1">
+            <p className="text-2xs font-medium uppercase tracking-wide text-muted-foreground">
+              {RESOLVE_QUEUE_STATUS_LABEL.pushed}
+            </p>
+            <ul className="flex flex-col gap-1">
+              {pushed.map((row) => (
+                <li key={row.thread.threadId}>
+                  <button
+                    type="button"
+                    onClick={() => onOpen({ threadId: row.thread.threadId })}
+                    className="min-w-0 truncate text-left text-xs text-muted-foreground hover:text-foreground hover:underline"
+                  >
+                    {row.reviewerNote?.body ?? row.thread.threadId}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </Collapsible>
+  );
+};

--- a/apps/desktop/src/features/resolve/components/ResolveQueueHome/ResolveQueueRow.tsx
+++ b/apps/desktop/src/features/resolve/components/ResolveQueueHome/ResolveQueueRow.tsx
@@ -1,0 +1,77 @@
+import { Button, Chip, SelectableRow, tintClasses } from '@goodboy/ui';
+import { RESOLVE_QUEUE_STATUS_LABEL, acceptFixLabel, coversSeveralSentence } from '../../resolveQueueCopy';
+import type { ResolveQueueRow as QueueRow } from '../../buildResolveQueueRows';
+import { BADGE_TONE_BY_STATUS } from './statusTone';
+
+type Props = {
+  readonly row: QueueRow;
+  readonly isAcceptEligible: boolean;
+  readonly acceptSummary: string | null;
+  readonly onOpen: () => void;
+  readonly onAcceptFix: () => void;
+};
+
+export const ResolveQueueRow = ({
+  row,
+  isAcceptEligible,
+  acceptSummary,
+  onOpen,
+  onAcceptFix,
+}: Props) => {
+  const { status, reviewerNote, proposal, coveredThreadIds } = row;
+  const tone = BADGE_TONE_BY_STATUS[status];
+  const coveredCount = coveredThreadIds.length + 1;
+  const coversSeveral = coversSeveralSentence({ coveredCount });
+  return (
+    <li className="list-none">
+      <SelectableRow
+        id={`resolve-queue-row-${row.thread.threadId}`}
+        selected={false}
+        onClick={onOpen}
+        title={reviewerNote?.body ?? 'No reviewer comment'}
+        className="flex min-w-0 flex-col gap-1 px-3 py-2.5"
+      >
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="min-w-0 flex-1 truncate text-sm text-foreground">
+            {reviewerNote?.body ?? 'No reviewer comment on this thread'}
+          </span>
+          <Chip size="3xs" bordered={false} tone={tone} label={RESOLVE_QUEUE_STATUS_LABEL[status]} />
+        </div>
+        <div className="flex min-w-0 items-center gap-1.5 text-2xs text-muted-foreground">
+          {reviewerNote?.author != null && <span className="truncate">{reviewerNote.author}</span>}
+          {reviewerNote?.location != null && (
+            <>
+              <span aria-hidden className="opacity-50">
+                ·
+              </span>
+              <span className="truncate font-mono">{reviewerNote.location}</span>
+            </>
+          )}
+        </div>
+        {proposal != null && proposal.trim() !== '' && (
+          <p className="min-w-0 truncate text-2xs text-muted-foreground/80">{proposal}</p>
+        )}
+        {coversSeveral != null && (
+          <p className="min-w-0 truncate text-2xs text-muted-foreground/70">{coversSeveral}</p>
+        )}
+      </SelectableRow>
+      {isAcceptEligible && (
+        <div className="flex items-center gap-2 px-3 pb-2">
+          <Button
+            size="sm"
+            variant="success"
+            onClick={(event) => {
+              event.stopPropagation();
+              onAcceptFix();
+            }}
+          >
+            {acceptFixLabel({ coveredCount })}
+          </Button>
+          {acceptSummary != null && (
+            <span className={`truncate text-2xs ${tintClasses('success').text}`}>{acceptSummary}</span>
+          )}
+        </div>
+      )}
+    </li>
+  );
+};

--- a/apps/desktop/src/features/resolve/components/ResolveQueueHome/index.tsx
+++ b/apps/desktop/src/features/resolve/components/ResolveQueueHome/index.tsx
@@ -1,0 +1,222 @@
+import { useEffect, useMemo, useState } from 'react';
+import type {
+  PrCheckRun,
+  PrComment,
+  ResolveAttempt,
+  ResolvePublication,
+  ResolveQueueItemWithThread,
+  Session,
+  SessionId,
+} from '@goodboy/types';
+import { PANE_RHYTHM } from '@goodboy/ui';
+import { EMPTY_ARRAY, useAppStore } from '../../../../store';
+import { PaneShell } from '../../../../shared/components/PaneShell';
+import { openReview } from '../../../review/openReview';
+import { useReviewDiff } from '../../../review/components/ReviewPane/WriteReview/useReviewDiff';
+import { DEFAULT_AGENT_SPAWN_CONFIG } from '../../../session/components/AgentSpawnConfig/defaultAgentSpawnConfig';
+import type { AgentSpawnConfigValue } from '../../../session/components/AgentSpawnConfig/AgentSpawnConfigValue';
+import { useResolveDeliveryReceipts } from '../../hooks/useResolveDeliveryReceipts';
+import { buildResolveQueueRows } from '../../buildResolveQueueRows';
+import { groupResolveQueue } from '../../groupResolveQueue';
+import { buildResolveQueueChecksByThreadId } from '../../resolveQueueChecksSummary';
+import { isInlineAcceptEligible } from '../../isInlineAcceptEligible';
+import { forYouHeading, secondaryStatusLine } from '../../resolveQueueCopy';
+import { ResolveSpawnSheet } from '../ResolveSpawnSheet';
+import { ResolveQueueRow } from './ResolveQueueRow';
+import { ResolveQueueFooter } from './ResolveQueueFooter';
+import { NoResolveTargetState, NothingWaitingState, ResolveQueueErrorState } from './ResolveQueueEmptyState';
+
+type Props = {
+  readonly session: Session;
+};
+
+const EMPTY_QUEUE_ITEMS: ReadonlyArray<ResolveQueueItemWithThread> = [];
+const EMPTY_ATTEMPTS: ReadonlyArray<ResolveAttempt> = [];
+const EMPTY_PUBLICATIONS: ReadonlyArray<ResolvePublication> = [];
+const EMPTY_CHECKS: ReadonlyArray<PrCheckRun> = [];
+
+export const ResolveQueueHome = ({ session }: Props) => {
+  const sessionId = session.id as SessionId;
+  const github = useAppStore((s) => s.sessionGithub[sessionId] ?? null);
+  const comments = useAppStore(
+    (s) =>
+      s.sessionGithub[sessionId]?.detail?.comments ?? (EMPTY_ARRAY as ReadonlyArray<PrComment>),
+  );
+  const checks = useAppStore((s) => s.sessionGithub[sessionId]?.detail?.checks ?? EMPTY_CHECKS);
+  const queueItems = useAppStore(
+    (s) => s.sessionResolveQueueItems[sessionId] ?? EMPTY_QUEUE_ITEMS,
+  );
+  const attempts = useAppStore((s) => s.sessionResolveAttempts[sessionId] ?? EMPTY_ATTEMPTS);
+  const publications = useAppStore(
+    (s) => s.sessionResolvePublications[sessionId] ?? EMPTY_PUBLICATIONS,
+  );
+  const loadResolveSession = useAppStore((s) => s.loadResolveSession);
+  const acceptResolveQueueItem = useAppStore((s) => s.acceptResolveQueueItem);
+  const takeUpResolveQueueItem = useAppStore((s) => s.takeUpResolveQueueItem);
+  const refreshSessionPrDetail = useAppStore((s) => s.refreshSessionPrDetail);
+  const spawnAgent = useAppStore((s) => s.spawnAgent);
+  const setAgentConfig = useAppStore((s) => s.setAgentConfig);
+
+  const deliveryReceipts = useResolveDeliveryReceipts({ publications });
+  const diff = useReviewDiff({ session });
+  const [spawnConfig, setSpawnConfig] = useState<AgentSpawnConfigValue>(DEFAULT_AGENT_SPAWN_CONFIG);
+  const [isSpawning, setIsSpawning] = useState(false);
+
+  useEffect(() => {
+    void loadResolveSession({ sessionId });
+  }, [loadResolveSession, sessionId]);
+
+  const rows = useMemo(
+    () =>
+      buildResolveQueueRows({
+        entries: queueItems,
+        attempts,
+        deliveryReceipts,
+        comments,
+      }),
+    [attempts, comments, deliveryReceipts, queueItems],
+  );
+
+  const groups = useMemo(() => groupResolveQueue({ rows }), [rows]);
+
+  const checksByThreadId = useMemo(
+    () =>
+      buildResolveQueueChecksByThreadId({
+        threadPaths: new Map(rows.map((row) => [row.thread.threadId, row.reviewerNote?.path ?? null])),
+        checks,
+        files: diff.files,
+      }),
+    [checks, diff.files, rows],
+  );
+
+  const onOpen = ({ threadId }: { readonly threadId: string }): void => {
+    openReview({ sessionId, threadId });
+  };
+
+  const onAcceptFix = ({
+    threadIds,
+  }: {
+    readonly threadIds: ReadonlyArray<string>;
+  }): void => {
+    for (const threadId of threadIds) {
+      const row = rows.find((candidate) => candidate.thread.threadId === threadId);
+      if (row === undefined) {
+        continue;
+      }
+      void acceptResolveQueueItem({
+        sessionId,
+        itemId: row.item.id,
+        revision: row.thread.revision,
+        reply: row.proposal ?? '',
+      });
+    }
+  };
+
+  const onTakeUp = ({ threadId, itemId }: { readonly threadId: string; readonly itemId: string }): void => {
+    void takeUpResolveQueueItem({ sessionId, itemId });
+    onOpen({ threadId });
+  };
+
+  const onStartResolveRun = async (): Promise<void> => {
+    const pr = github?.pr;
+    if (pr == null) {
+      return;
+    }
+    setIsSpawning(true);
+    try {
+      const agentId = await spawnAgent(sessionId, {
+        name: `Resolve PR #${pr.number}`,
+        ...(spawnConfig.provider !== '' && { provider: spawnConfig.provider }),
+        model: spawnConfig.model,
+        effort: spawnConfig.effort,
+        initialPrompt:
+          `Resolve the outstanding review comments on PR #${pr.number} (${pr.title}). ` +
+          `Check each unresolved thread and propose a fix or a reply.${
+            spawnConfig.hint.trim() === '' ? '' : ` ${spawnConfig.hint.trim()}`
+          }`,
+        kindOverride: 'resolver',
+        sourceCommentUrl: pr.url,
+        sourceKind: 'review_comment',
+        focus: 'none',
+      });
+      await setAgentConfig(sessionId, agentId, {
+        ...(spawnConfig.provider !== '' && { providerOverride: spawnConfig.provider }),
+        modelOverride: spawnConfig.model,
+        effort: spawnConfig.effort,
+      });
+    } finally {
+      setIsSpawning(false);
+    }
+  };
+
+  if (github?.pr == null) {
+    return (
+      <PaneShell title="For you" description="No pull request is open on this session.">
+        <NoResolveTargetState onOpenReview={() => openReview({ sessionId })} />
+      </PaneShell>
+    );
+  }
+
+  if (github.detailError != null) {
+    return (
+      <PaneShell title="For you">
+        <ResolveQueueErrorState
+          message={github.detailError}
+          onRetry={() => void refreshSessionPrDetail(sessionId, { force: true })}
+        />
+      </PaneShell>
+    );
+  }
+
+  return (
+    <PaneShell
+      title={forYouHeading({ count: groups.forYou.length })}
+      description={secondaryStatusLine({
+        workingCount: groups.workingCount,
+        readyToPushCount: groups.readyToPushCount,
+      })}
+    >
+      <div className={PANE_RHYTHM.stack}>
+        <ResolveSpawnSheet
+          value={spawnConfig}
+          onChange={setSpawnConfig}
+          disabled={false}
+          isBusy={isSpawning}
+          startLabel="Start a resolve run"
+          onStart={() => void onStartResolveRun()}
+        />
+        {groups.forYou.length === 0 ? (
+          <NothingWaitingState onOpenSpawn={() => void onStartResolveRun()} />
+        ) : (
+          <ol className="flex flex-col gap-1.5">
+            {groups.forYou.map((row) => {
+              const checksSummary = checksByThreadId.get(row.thread.threadId) ?? null;
+              const isEligible = isInlineAcceptEligible({ status: row.status, checks: checksSummary });
+              const acceptSummary = isEligible && checksSummary !== null
+                ? `+${checksSummary.additions} -${checksSummary.deletions} · ${checksSummary.passCount} pass · reply drafted`
+                : null;
+              return (
+                <ResolveQueueRow
+                  key={row.thread.threadId}
+                  row={row}
+                  isAcceptEligible={isEligible}
+                  acceptSummary={acceptSummary}
+                  onOpen={() => onOpen({ threadId: row.thread.threadId })}
+                  onAcceptFix={() =>
+                    onAcceptFix({ threadIds: [row.thread.threadId, ...row.coveredThreadIds] })
+                  }
+                />
+              );
+            })}
+          </ol>
+        )}
+        <ResolveQueueFooter
+          pushed={groups.pushed}
+          later={groups.later}
+          onOpen={onOpen}
+          onTakeUp={onTakeUp}
+        />
+      </div>
+    </PaneShell>
+  );
+};

--- a/apps/desktop/src/features/resolve/components/ResolveQueueHome/index.tsx
+++ b/apps/desktop/src/features/resolve/components/ResolveQueueHome/index.tsx
@@ -16,6 +16,7 @@ import { useReviewDiff } from '../../../review/components/ReviewPane/WriteReview
 import { DEFAULT_AGENT_SPAWN_CONFIG } from '../../../session/components/AgentSpawnConfig/defaultAgentSpawnConfig';
 import type { AgentSpawnConfigValue } from '../../../session/components/AgentSpawnConfig/AgentSpawnConfigValue';
 import { useResolveDeliveryReceipts } from '../../hooks/useResolveDeliveryReceipts';
+import { startResolveRun } from '../../startResolveRun';
 import { buildResolveQueueRows } from '../../buildResolveQueueRows';
 import { groupResolveQueue } from '../../groupResolveQueue';
 import { buildResolveQueueChecksByThreadId } from '../../resolveQueueChecksSummary';
@@ -124,26 +125,7 @@ export const ResolveQueueHome = ({ session }: Props) => {
     }
     setIsSpawning(true);
     try {
-      const agentId = await spawnAgent(sessionId, {
-        name: `Resolve PR #${pr.number}`,
-        ...(spawnConfig.provider !== '' && { provider: spawnConfig.provider }),
-        model: spawnConfig.model,
-        effort: spawnConfig.effort,
-        initialPrompt:
-          `Resolve the outstanding review comments on PR #${pr.number} (${pr.title}). ` +
-          `Check each unresolved thread and propose a fix or a reply.${
-            spawnConfig.hint.trim() === '' ? '' : ` ${spawnConfig.hint.trim()}`
-          }`,
-        kindOverride: 'resolver',
-        sourceCommentUrl: pr.url,
-        sourceKind: 'review_comment',
-        focus: 'none',
-      });
-      await setAgentConfig(sessionId, agentId, {
-        ...(spawnConfig.provider !== '' && { providerOverride: spawnConfig.provider }),
-        modelOverride: spawnConfig.model,
-        effort: spawnConfig.effort,
-      });
+      await startResolveRun({ sessionId, pr, spawnConfig, spawnAgent, setAgentConfig });
     } finally {
       setIsSpawning(false);
     }

--- a/apps/desktop/src/features/resolve/components/ResolveQueueHome/statusTone.ts
+++ b/apps/desktop/src/features/resolve/components/ResolveQueueHome/statusTone.ts
@@ -1,0 +1,12 @@
+import type { Tone } from '@goodboy/ui';
+import type { ResolveQueueStatus } from '../../../../store/slices/resolve/deriveResolveQueueStatus';
+
+export const BADGE_TONE_BY_STATUS: Record<ResolveQueueStatus, Tone> = {
+  for_you: 'warning',
+  agent_asked: 'warning',
+  working: 'info',
+  ready_to_push: 'success',
+  pushed: 'merged',
+  later: 'neutral',
+  changed_since_accepted: 'warning',
+};

--- a/apps/desktop/src/features/resolve/components/ResolveSpawnSheet/index.tsx
+++ b/apps/desktop/src/features/resolve/components/ResolveSpawnSheet/index.tsx
@@ -1,0 +1,69 @@
+import { useState } from 'react';
+import { getModelProvider } from '@goodboy/core';
+import { Button } from '@goodboy/ui';
+import { EFFORT_LABEL, PROVIDER_LABEL, modelLabel } from '../../../chat/utils/chat-constants';
+import { AgentSpawnConfig } from '../../../session/components/AgentSpawnConfig';
+import type { AgentSpawnConfigValue } from '../../../session/components/AgentSpawnConfig/AgentSpawnConfigValue';
+
+type Props = {
+  readonly value: AgentSpawnConfigValue;
+  readonly onChange: (value: AgentSpawnConfigValue) => void;
+  readonly disabled: boolean;
+  readonly isBusy: boolean;
+  readonly startLabel: string;
+  readonly onStart: () => void;
+  readonly onCancel?: () => void;
+};
+
+export const ResolveSpawnSheet = ({
+  value,
+  onChange,
+  disabled,
+  isBusy,
+  startLabel,
+  onStart,
+  onCancel,
+}: Props) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const provider = value.provider === '' ? (getModelProvider(value.model) ?? 'anthropic') : value.provider;
+  const summary = `${PROVIDER_LABEL[provider]} ${modelLabel(value.model)} ${EFFORT_LABEL[value.effort]}`;
+
+  if (!isExpanded) {
+    return (
+      <button
+        type="button"
+        onClick={() => setIsExpanded(true)}
+        disabled={disabled}
+        className="flex items-center gap-1.5 rounded-md border border-border-soft bg-subtle px-2.5 py-1.5 text-xs text-muted-foreground motion-safe:transition-colors hover:border-border hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        <span className="font-mono">{summary}</span>
+        <span aria-hidden className="opacity-50">
+          ·
+        </span>
+        <span className="underline-offset-2">change</span>
+      </button>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-2 rounded-md border border-border-soft bg-subtle p-2.5">
+      <AgentSpawnConfig value={value} onChange={onChange} disabled={disabled || isBusy} />
+      <div className="flex items-center justify-end gap-2">
+        <Button
+          size="sm"
+          variant="ghost"
+          disabled={isBusy}
+          onClick={() => {
+            setIsExpanded(false);
+            onCancel?.();
+          }}
+        >
+          Cancel
+        </Button>
+        <Button size="sm" variant="primary" disabled={disabled} isBusy={isBusy} onClick={onStart}>
+          {startLabel}
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/apps/desktop/src/features/resolve/groupResolveQueue.test.ts
+++ b/apps/desktop/src/features/resolve/groupResolveQueue.test.ts
@@ -16,6 +16,7 @@ const baseItem: ResolveQueueItem = {
   approvalState: 'none',
   approvedRevision: null,
   approvedReplyHash: null,
+  integratedSha: null,
   deferredAt: null,
   deliveredAt: null,
   supersededAt: null,
@@ -51,12 +52,14 @@ const row = ({
   threadId,
   status,
   reviewerCreatedAtMs,
+  integratedSha = null,
 }: {
   readonly threadId: string;
   readonly status: ResolveQueueStatus;
   readonly reviewerCreatedAtMs: number;
+  readonly integratedSha?: string | null;
 }): ResolveQueueRow => ({
-  item: { ...baseItem, id: `item-${threadId}`, threadId },
+  item: { ...baseItem, id: `item-${threadId}`, threadId, integratedSha },
   thread: { ...baseThread, id: `row-${threadId}`, threadId },
   status,
   attempt: null,
@@ -76,7 +79,12 @@ describe('groupResolveQueue', () => {
     const rows = [
       row({ threadId: 'newest', status: 'for_you', reviewerCreatedAtMs: 300 }),
       row({ threadId: 'oldest', status: 'agent_asked', reviewerCreatedAtMs: 100 }),
-      row({ threadId: 'middle', status: 'changed_since_accepted', reviewerCreatedAtMs: 200 }),
+      row({
+        threadId: 'middle',
+        status: 'changed_since_accepted',
+        reviewerCreatedAtMs: 200,
+        integratedSha: 'a1b2c3d4e5f60718293a4b5c6d7e8f9012345678',
+      }),
     ];
     const groups = groupResolveQueue({ rows });
     expect(groups.forYou.map((entry) => entry.thread.threadId)).toEqual([
@@ -89,8 +97,18 @@ describe('groupResolveQueue', () => {
   it('excludes working, ready_to_push, pushed and later from the for-you bucket', () => {
     const rows = [
       row({ threadId: 'w', status: 'working', reviewerCreatedAtMs: 1 }),
-      row({ threadId: 'r', status: 'ready_to_push', reviewerCreatedAtMs: 2 }),
-      row({ threadId: 'p', status: 'pushed', reviewerCreatedAtMs: 3 }),
+      row({
+        threadId: 'r',
+        status: 'ready_to_push',
+        reviewerCreatedAtMs: 2,
+        integratedSha: 'b2c3d4e5f60718293a4b5c6d7e8f90123456789a',
+      }),
+      row({
+        threadId: 'p',
+        status: 'pushed',
+        reviewerCreatedAtMs: 3,
+        integratedSha: 'c3d4e5f60718293a4b5c6d7e8f90123456789ab2',
+      }),
       row({ threadId: 'l', status: 'later', reviewerCreatedAtMs: 4 }),
     ];
     const groups = groupResolveQueue({ rows });

--- a/apps/desktop/src/features/resolve/groupResolveQueue.test.ts
+++ b/apps/desktop/src/features/resolve/groupResolveQueue.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import type { ResolveQueueItem, ResolveThread, SessionId } from '@goodboy/types';
+import type { ResolveQueueStatus } from '../../store/slices/resolve/deriveResolveQueueStatus';
+import { groupResolveQueue } from './groupResolveQueue';
+import type { ResolveQueueRow } from './buildResolveQueueRows';
+
+const sessionId = 'session' as SessionId;
+
+const baseItem: ResolveQueueItem = {
+  id: 'item',
+  sessionId,
+  threadId: 'thread',
+  generation: 0,
+  reopenedFromItemId: null,
+  candidateRevision: 1,
+  approvalState: 'none',
+  approvedRevision: null,
+  approvedReplyHash: null,
+  deferredAt: null,
+  deliveredAt: null,
+  supersededAt: null,
+  createdAt: 1,
+  updatedAt: 1,
+};
+
+const baseThread: ResolveThread = {
+  id: 'row',
+  sessionId,
+  projectId: null,
+  prNumber: 1,
+  threadId: 'thread',
+  originKind: 'review_comment',
+  state: 'open',
+  stateReason: null,
+  revision: 1,
+  activeAttemptId: null,
+  disposition: null,
+  replyDraft: null,
+  commitShas: null,
+  question: null,
+  replyPostedAt: null,
+  replyId: null,
+  githubResolved: null,
+  closedAt: null,
+  closedSource: null,
+  createdAt: 1,
+  updatedAt: 1,
+};
+
+const row = ({
+  threadId,
+  status,
+  reviewerCreatedAtMs,
+}: {
+  readonly threadId: string;
+  readonly status: ResolveQueueStatus;
+  readonly reviewerCreatedAtMs: number;
+}): ResolveQueueRow => ({
+  item: { ...baseItem, id: `item-${threadId}`, threadId },
+  thread: { ...baseThread, id: `row-${threadId}`, threadId },
+  status,
+  attempt: null,
+  reviewerNote: {
+    body: `body-${threadId}`,
+    author: 'reviewer',
+    createdAtMs: reviewerCreatedAtMs,
+    location: null,
+    path: null,
+  },
+  proposal: null,
+  coveredThreadIds: [],
+});
+
+describe('groupResolveQueue', () => {
+  it('buckets for_you, agent_asked and changed_since_accepted together, ordered oldest first', () => {
+    const rows = [
+      row({ threadId: 'newest', status: 'for_you', reviewerCreatedAtMs: 300 }),
+      row({ threadId: 'oldest', status: 'agent_asked', reviewerCreatedAtMs: 100 }),
+      row({ threadId: 'middle', status: 'changed_since_accepted', reviewerCreatedAtMs: 200 }),
+    ];
+    const groups = groupResolveQueue({ rows });
+    expect(groups.forYou.map((entry) => entry.thread.threadId)).toEqual([
+      'oldest',
+      'middle',
+      'newest',
+    ]);
+  });
+
+  it('excludes working, ready_to_push, pushed and later from the for-you bucket', () => {
+    const rows = [
+      row({ threadId: 'w', status: 'working', reviewerCreatedAtMs: 1 }),
+      row({ threadId: 'r', status: 'ready_to_push', reviewerCreatedAtMs: 2 }),
+      row({ threadId: 'p', status: 'pushed', reviewerCreatedAtMs: 3 }),
+      row({ threadId: 'l', status: 'later', reviewerCreatedAtMs: 4 }),
+    ];
+    const groups = groupResolveQueue({ rows });
+    expect(groups.forYou).toHaveLength(0);
+    expect(groups.workingCount).toBe(1);
+    expect(groups.readyToPushCount).toBe(1);
+    expect(groups.pushed.map((entry) => entry.thread.threadId)).toEqual(['p']);
+    expect(groups.later.map((entry) => entry.thread.threadId)).toEqual(['l']);
+  });
+
+  it('never counts a later item as pushed or resolved', () => {
+    const rows = [row({ threadId: 'l', status: 'later', reviewerCreatedAtMs: 1 })];
+    const groups = groupResolveQueue({ rows });
+    expect(groups.pushed).toHaveLength(0);
+    expect(groups.later).toHaveLength(1);
+  });
+});

--- a/apps/desktop/src/features/resolve/groupResolveQueue.ts
+++ b/apps/desktop/src/features/resolve/groupResolveQueue.ts
@@ -1,0 +1,37 @@
+import type { ResolveQueueStatus } from '../../store/slices/resolve/deriveResolveQueueStatus';
+import type { ResolveQueueRow } from './buildResolveQueueRows';
+
+export type ResolveQueueGroups = {
+  readonly forYou: ReadonlyArray<ResolveQueueRow>;
+  readonly workingCount: number;
+  readonly readyToPushCount: number;
+  readonly pushed: ReadonlyArray<ResolveQueueRow>;
+  readonly later: ReadonlyArray<ResolveQueueRow>;
+};
+
+const FOR_YOU_STATUSES: ReadonlySet<ResolveQueueStatus> = new Set([
+  'for_you',
+  'agent_asked',
+  'changed_since_accepted',
+]);
+
+const reviewerTimeOf = ({ row }: { readonly row: ResolveQueueRow }): number =>
+  row.reviewerNote?.createdAtMs ?? row.thread.createdAt;
+
+export const groupResolveQueue = ({
+  rows,
+}: {
+  readonly rows: ReadonlyArray<ResolveQueueRow>;
+}): ResolveQueueGroups => {
+  const forYou = rows
+    .filter((row) => FOR_YOU_STATUSES.has(row.status))
+    .slice()
+    .sort((a, b) => reviewerTimeOf({ row: a }) - reviewerTimeOf({ row: b }));
+  return {
+    forYou,
+    workingCount: rows.filter((row) => row.status === 'working').length,
+    readyToPushCount: rows.filter((row) => row.status === 'ready_to_push').length,
+    pushed: rows.filter((row) => row.status === 'pushed'),
+    later: rows.filter((row) => row.status === 'later'),
+  };
+};

--- a/apps/desktop/src/features/resolve/hasActiveResolveRun.test.ts
+++ b/apps/desktop/src/features/resolve/hasActiveResolveRun.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import type { ResolveAttempt, SessionId } from '@goodboy/types';
+import { hasActiveResolveRun } from './hasActiveResolveRun';
+
+const sessionId = 'session' as SessionId;
+
+const attempt = ({ phase }: { readonly phase: ResolveAttempt['phase'] }): ResolveAttempt => ({
+  id: `attempt-${phase}`,
+  sessionId,
+  agentId: 'agent' as ResolveAttempt['agentId'],
+  prNumber: 1,
+  threadIds: ['t1'],
+  provider: 'anthropic',
+  model: 'sonnet-5',
+  effort: 'high',
+  instructions: null,
+  phase,
+  startedAt: 1,
+  endedAt: null,
+  error: null,
+  createdAt: 1,
+});
+
+describe('hasActiveResolveRun', () => {
+  it('is true when an attempt is queued, running or waiting', () => {
+    expect(hasActiveResolveRun({ attempts: [attempt({ phase: 'queued' })] })).toBe(true);
+    expect(hasActiveResolveRun({ attempts: [attempt({ phase: 'running' })] })).toBe(true);
+    expect(hasActiveResolveRun({ attempts: [attempt({ phase: 'waiting' })] })).toBe(true);
+  });
+
+  it('is false when every attempt is finished, failed or cancelled', () => {
+    expect(
+      hasActiveResolveRun({
+        attempts: [attempt({ phase: 'finished' }), attempt({ phase: 'failed' })],
+      }),
+    ).toBe(false);
+    expect(hasActiveResolveRun({ attempts: [] })).toBe(false);
+  });
+});

--- a/apps/desktop/src/features/resolve/hasActiveResolveRun.ts
+++ b/apps/desktop/src/features/resolve/hasActiveResolveRun.ts
@@ -1,0 +1,9 @@
+import type { ResolveAttempt } from '@goodboy/types';
+
+const LIVE_PHASES: ReadonlyArray<ResolveAttempt['phase']> = ['queued', 'running', 'waiting'];
+
+export const hasActiveResolveRun = ({
+  attempts,
+}: {
+  readonly attempts: ReadonlyArray<ResolveAttempt>;
+}): boolean => attempts.some((attempt) => LIVE_PHASES.includes(attempt.phase));

--- a/apps/desktop/src/features/resolve/hooks/useResolveDeliveryReceipts/index.ts
+++ b/apps/desktop/src/features/resolve/hooks/useResolveDeliveryReceipts/index.ts
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+import { listResolvePublicationThreads } from '@goodboy/db';
+import type { ResolvePublication, ResolvePublicationThread } from '@goodboy/types';
+import { tauriDatabase } from '../../../../shared/lib/db';
+
+const EMPTY_RECEIPTS: ReadonlyArray<ResolvePublicationThread> = [];
+
+type Params = {
+  readonly publications: ReadonlyArray<ResolvePublication>;
+};
+
+export const useResolveDeliveryReceipts = ({
+  publications,
+}: Params): ReadonlyArray<ResolvePublicationThread> => {
+  const [receipts, setReceipts] = useState<ReadonlyArray<ResolvePublicationThread>>(EMPTY_RECEIPTS);
+  const publicationIds = publications.map((publication) => publication.id).join(',');
+
+  useEffect(() => {
+    if (publicationIds === '') {
+      setReceipts(EMPTY_RECEIPTS);
+      return;
+    }
+    let cancelled = false;
+    Promise.all(
+      publicationIds
+        .split(',')
+        .map((publicationId) =>
+          listResolvePublicationThreads({ db: tauriDatabase, publicationId }).catch(() => []),
+        ),
+    )
+      .then((groups) => {
+        if (!cancelled) {
+          setReceipts(groups.flat());
+        }
+      })
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, [publicationIds]);
+
+  return receipts;
+};

--- a/apps/desktop/src/features/resolve/isInlineAcceptEligible.test.ts
+++ b/apps/desktop/src/features/resolve/isInlineAcceptEligible.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest';
+import type { ResolveQueueItem, ResolveThread, SessionId } from '@goodboy/types';
+import {
+  isAcceptAllEligible,
+  isInlineAcceptEligible,
+  type ResolveQueueChecksSummary,
+} from './isInlineAcceptEligible';
+import type { ResolveQueueRow } from './buildResolveQueueRows';
+
+const sessionId = 'session' as SessionId;
+
+const greenChecks: ResolveQueueChecksSummary = {
+  additions: 3,
+  deletions: 1,
+  passCount: 12,
+  totalCount: 12,
+};
+
+const baseItem: ResolveQueueItem = {
+  id: 'item',
+  sessionId,
+  threadId: 'thread',
+  generation: 0,
+  reopenedFromItemId: null,
+  candidateRevision: 1,
+  approvalState: 'none',
+  approvedRevision: null,
+  approvedReplyHash: null,
+  deferredAt: null,
+  deliveredAt: null,
+  supersededAt: null,
+  createdAt: 1,
+  updatedAt: 1,
+};
+
+const baseThread: ResolveThread = {
+  id: 'row',
+  sessionId,
+  projectId: null,
+  prNumber: 1,
+  threadId: 'thread',
+  originKind: 'review_comment',
+  state: 'open',
+  stateReason: null,
+  revision: 1,
+  activeAttemptId: null,
+  disposition: null,
+  replyDraft: null,
+  commitShas: null,
+  question: null,
+  replyPostedAt: null,
+  replyId: null,
+  githubResolved: null,
+  closedAt: null,
+  closedSource: null,
+  createdAt: 1,
+  updatedAt: 1,
+};
+
+const row = ({
+  threadId,
+  coveredThreadIds = [],
+}: {
+  readonly threadId: string;
+  readonly coveredThreadIds?: ReadonlyArray<string>;
+}): ResolveQueueRow => ({
+  item: { ...baseItem, id: `item-${threadId}`, threadId },
+  thread: { ...baseThread, id: `row-${threadId}`, threadId },
+  status: 'for_you',
+  attempt: null,
+  reviewerNote: null,
+  proposal: null,
+  coveredThreadIds,
+});
+
+describe('isInlineAcceptEligible', () => {
+  it('is eligible when for_you, checks are all green and the change is small', () => {
+    expect(isInlineAcceptEligible({ status: 'for_you', checks: greenChecks })).toBe(true);
+  });
+
+  it('is not eligible for any status other than for_you', () => {
+    expect(isInlineAcceptEligible({ status: 'agent_asked', checks: greenChecks })).toBe(false);
+    expect(isInlineAcceptEligible({ status: 'ready_to_push', checks: greenChecks })).toBe(false);
+  });
+
+  it('is not eligible when checks are missing or not all green', () => {
+    expect(isInlineAcceptEligible({ status: 'for_you', checks: null })).toBe(false);
+    expect(
+      isInlineAcceptEligible({
+        status: 'for_you',
+        checks: { ...greenChecks, passCount: 11 },
+      }),
+    ).toBe(false);
+    expect(
+      isInlineAcceptEligible({
+        status: 'for_you',
+        checks: { ...greenChecks, totalCount: 0, passCount: 0 },
+      }),
+    ).toBe(false);
+  });
+
+  it('is not eligible when the change is large', () => {
+    expect(
+      isInlineAcceptEligible({
+        status: 'for_you',
+        checks: { ...greenChecks, additions: 40, deletions: 10 },
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('isAcceptAllEligible', () => {
+  it('is eligible only when every for_you row is green and none covers several comments', () => {
+    const rows = [row({ threadId: 't1' }), row({ threadId: 't2' })];
+    const checksByThreadId = new Map([
+      ['t1', greenChecks],
+      ['t2', greenChecks],
+    ]);
+    expect(isAcceptAllEligible({ rows, checksByThreadId })).toBe(true);
+  });
+
+  it('is not eligible when a row covers several comments', () => {
+    const rows = [row({ threadId: 't1', coveredThreadIds: ['t2'] }), row({ threadId: 't2' })];
+    const checksByThreadId = new Map([
+      ['t1', greenChecks],
+      ['t2', greenChecks],
+    ]);
+    expect(isAcceptAllEligible({ rows, checksByThreadId })).toBe(false);
+  });
+
+  it('is not eligible when any row is not green', () => {
+    const rows = [row({ threadId: 't1' }), row({ threadId: 't2' })];
+    const checksByThreadId = new Map<string, ResolveQueueChecksSummary | null>([
+      ['t1', greenChecks],
+      ['t2', null],
+    ]);
+    expect(isAcceptAllEligible({ rows, checksByThreadId })).toBe(false);
+  });
+
+  it('is not eligible when there are no for_you rows', () => {
+    expect(isAcceptAllEligible({ rows: [], checksByThreadId: new Map() })).toBe(false);
+  });
+});

--- a/apps/desktop/src/features/resolve/isInlineAcceptEligible.test.ts
+++ b/apps/desktop/src/features/resolve/isInlineAcceptEligible.test.ts
@@ -26,6 +26,7 @@ const baseItem: ResolveQueueItem = {
   approvalState: 'none',
   approvedRevision: null,
   approvedReplyHash: null,
+  integratedSha: null,
   deferredAt: null,
   deliveredAt: null,
   supersededAt: null,

--- a/apps/desktop/src/features/resolve/isInlineAcceptEligible.ts
+++ b/apps/desktop/src/features/resolve/isInlineAcceptEligible.ts
@@ -1,0 +1,56 @@
+import type { ResolveQueueStatus } from '../../store/slices/resolve/deriveResolveQueueStatus';
+import type { ResolveQueueRow } from './buildResolveQueueRows';
+
+export type ResolveQueueChecksSummary = {
+  readonly additions: number;
+  readonly deletions: number;
+  readonly passCount: number;
+  readonly totalCount: number;
+};
+
+const SMALL_CHANGE_LINE_LIMIT = 20;
+
+export const isInlineAcceptEligible = ({
+  status,
+  checks,
+}: {
+  readonly status: ResolveQueueStatus;
+  readonly checks: ResolveQueueChecksSummary | null;
+}): boolean => {
+  if (status !== 'for_you') {
+    return false;
+  }
+  if (checks === null) {
+    return false;
+  }
+  if (checks.totalCount === 0) {
+    return false;
+  }
+  if (checks.passCount !== checks.totalCount) {
+    return false;
+  }
+  if (checks.additions + checks.deletions > SMALL_CHANGE_LINE_LIMIT) {
+    return false;
+  }
+  return true;
+};
+
+export const isAcceptAllEligible = ({
+  rows,
+  checksByThreadId,
+}: {
+  readonly rows: ReadonlyArray<ResolveQueueRow>;
+  readonly checksByThreadId: ReadonlyMap<string, ResolveQueueChecksSummary | null>;
+}): boolean => {
+  const candidates = rows.filter((row) => row.status === 'for_you');
+  if (candidates.length === 0) {
+    return false;
+  }
+  return candidates.every((row) => {
+    if (row.coveredThreadIds.length > 0) {
+      return false;
+    }
+    const checks = checksByThreadId.get(row.thread.threadId) ?? null;
+    return isInlineAcceptEligible({ status: row.status, checks });
+  });
+};

--- a/apps/desktop/src/features/resolve/resolveQueueChecksSummary.test.ts
+++ b/apps/desktop/src/features/resolve/resolveQueueChecksSummary.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import type { FileDiff, PrCheckRun } from '@goodboy/types';
+import { buildResolveQueueChecksByThreadId, resolveQueueChecksSummary } from './resolveQueueChecksSummary';
+
+const checks: ReadonlyArray<PrCheckRun> = [
+  { name: 'build', conclusion: 'success', detailsUrl: null, durationMs: null },
+  { name: 'lint', conclusion: 'success', detailsUrl: null, durationMs: null },
+  { name: 'test', conclusion: 'failure', detailsUrl: null, durationMs: null },
+];
+
+const fileDiff: FileDiff = {
+  path: 'src/index.ts',
+  status: 'modified',
+  additions: 3,
+  deletions: 1,
+  binary: false,
+  hunks: [],
+};
+
+describe('resolveQueueChecksSummary', () => {
+  it('counts passing checks and reads the file diff stat', () => {
+    expect(resolveQueueChecksSummary({ checks, fileDiff })).toEqual({
+      totalCount: 3,
+      passCount: 2,
+      additions: 3,
+      deletions: 1,
+    });
+  });
+
+  it('reports a zero-size change when there is no file diff', () => {
+    expect(resolveQueueChecksSummary({ checks, fileDiff: null })).toEqual({
+      totalCount: 3,
+      passCount: 2,
+      additions: 0,
+      deletions: 0,
+    });
+  });
+});
+
+describe('buildResolveQueueChecksByThreadId', () => {
+  it('maps a thread to its checks summary only when the file diff is found', () => {
+    const map = buildResolveQueueChecksByThreadId({
+      threadPaths: new Map([
+        ['t1', 'src/index.ts'],
+        ['t2', 'src/missing.ts'],
+        ['t3', null],
+      ]),
+      checks,
+      files: [fileDiff],
+    });
+    expect(map.get('t1')).toEqual({ totalCount: 3, passCount: 2, additions: 3, deletions: 1 });
+    expect(map.get('t2')).toBeNull();
+    expect(map.get('t3')).toBeNull();
+  });
+});

--- a/apps/desktop/src/features/resolve/resolveQueueChecksSummary.ts
+++ b/apps/desktop/src/features/resolve/resolveQueueChecksSummary.ts
@@ -1,0 +1,33 @@
+import type { FileDiff, PrCheckRun } from '@goodboy/types';
+import type { ResolveQueueChecksSummary } from './isInlineAcceptEligible';
+
+export const resolveQueueChecksSummary = ({
+  checks,
+  fileDiff,
+}: {
+  readonly checks: ReadonlyArray<PrCheckRun>;
+  readonly fileDiff: FileDiff | null;
+}): ResolveQueueChecksSummary => ({
+  totalCount: checks.length,
+  passCount: checks.filter((check) => check.conclusion === 'success').length,
+  additions: fileDiff?.additions ?? 0,
+  deletions: fileDiff?.deletions ?? 0,
+});
+
+export const buildResolveQueueChecksByThreadId = ({
+  threadPaths,
+  checks,
+  files,
+}: {
+  readonly threadPaths: ReadonlyMap<string, string | null>;
+  readonly checks: ReadonlyArray<PrCheckRun>;
+  readonly files: ReadonlyArray<FileDiff>;
+}): ReadonlyMap<string, ResolveQueueChecksSummary | null> => {
+  const fileByPath = new Map(files.map((file) => [file.path, file]));
+  const map = new Map<string, ResolveQueueChecksSummary | null>();
+  for (const [threadId, path] of threadPaths) {
+    const fileDiff = path === null ? null : (fileByPath.get(path) ?? null);
+    map.set(threadId, fileDiff === null ? null : resolveQueueChecksSummary({ checks, fileDiff }));
+  }
+  return map;
+};

--- a/apps/desktop/src/features/resolve/resolveQueueCopy.ts
+++ b/apps/desktop/src/features/resolve/resolveQueueCopy.ts
@@ -1,0 +1,42 @@
+import type { ResolveQueueStatus } from '../../store/slices/resolve/deriveResolveQueueStatus';
+
+export const RESOLVE_QUEUE_STATUS_LABEL: Record<ResolveQueueStatus, string> = {
+  for_you: 'For you',
+  agent_asked: 'Agent asked you',
+  working: 'Working',
+  ready_to_push: 'Ready to push',
+  pushed: 'Pushed and posted',
+  later: 'Later',
+  changed_since_accepted: 'Changed since you accepted',
+};
+
+export const RESOLVE_QUEUE_ACTION_LABEL = {
+  treatAsOneFix: 'Treat as one fix',
+  takeUp: 'Take up',
+  later: 'Later',
+  askForChanges: 'Ask for changes',
+  send: 'Send',
+  acceptAll: 'Accept all',
+} as const;
+
+export const forYouHeading = ({ count }: { readonly count: number }): string =>
+  `${count} for you`;
+
+export const acceptFixLabel = ({ coveredCount }: { readonly coveredCount: number }): string =>
+  coveredCount > 1 ? `Accept fix (${coveredCount})` : 'Accept fix';
+
+export const secondaryStatusLine = ({
+  workingCount,
+  readyToPushCount,
+}: {
+  readonly workingCount: number;
+  readonly readyToPushCount: number;
+}): string =>
+  `${workingCount} working · ${readyToPushCount} ready to push`;
+
+export const coversSeveralSentence = ({
+  coveredCount,
+}: {
+  readonly coveredCount: number;
+}): string | null =>
+  coveredCount > 1 ? `This proposal also covers ${coveredCount - 1} other comment${coveredCount - 1 === 1 ? '' : 's'}.` : null;

--- a/apps/desktop/src/features/resolve/resolveQueueCopyGuard.test.ts
+++ b/apps/desktop/src/features/resolve/resolveQueueCopyGuard.test.ts
@@ -1,0 +1,60 @@
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const GUARD_FILE_NAME = 'resolveQueueCopyGuard.test.ts';
+
+const FORBIDDEN_STRINGS: ReadonlyArray<string> = [
+  'Needs decision',
+  'Needs answer',
+  'Accepted, not yet delivered',
+  'Confirm group',
+  'Acceptance cleared',
+  'Accept group',
+];
+
+const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx']);
+
+const collectSourceFiles = ({ root }: { readonly root: string }): ReadonlyArray<string> => {
+  const files: Array<string> = [];
+  const walk = ({ dir }: { readonly dir: string }): void => {
+    for (const entry of readdirSync(dir)) {
+      const full = join(dir, entry);
+      const stats = statSync(full);
+      if (stats.isDirectory()) {
+        walk({ dir: full });
+        continue;
+      }
+      if (entry === GUARD_FILE_NAME) {
+        continue;
+      }
+      const dot = entry.lastIndexOf('.');
+      const ext = dot === -1 ? '' : entry.slice(dot);
+      if (SOURCE_EXTENSIONS.has(ext)) {
+        files.push(full);
+      }
+    }
+  };
+  walk({ dir: root });
+  return files;
+};
+
+describe('resolve queue copy guard', () => {
+  it('never reintroduces the legacy wizard copy in the resolve or review feature folders', () => {
+    const roots = [HERE, join(HERE, '..', 'review')];
+    const offenders: Array<string> = [];
+    for (const root of roots) {
+      for (const file of collectSourceFiles({ root })) {
+        const contents = readFileSync(file, 'utf8');
+        for (const forbidden of FORBIDDEN_STRINGS) {
+          if (contents.includes(forbidden)) {
+            offenders.push(`${file}: "${forbidden}"`);
+          }
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/apps/desktop/src/features/resolve/startResolveRun.ts
+++ b/apps/desktop/src/features/resolve/startResolveRun.ts
@@ -1,0 +1,64 @@
+import type { AgentId, ProviderId, PullRequestState, SessionId } from '@goodboy/types';
+import type { EffortLevel } from '../chat/utils/chat-constants';
+import type { AgentSpawnConfigValue } from '../session/components/AgentSpawnConfig/AgentSpawnConfigValue';
+
+type SpawnAgentArgs = {
+  readonly name: string;
+  readonly model?: string;
+  readonly provider?: ProviderId;
+  readonly effort?: EffortLevel;
+  readonly initialPrompt: string;
+  readonly kindOverride: 'resolver';
+  readonly sourceCommentUrl: string;
+  readonly sourceKind: 'review_comment';
+  readonly focus: 'none';
+};
+
+export type SpawnAgentFn = (sessionId: SessionId, args: SpawnAgentArgs) => Promise<AgentId>;
+
+export type SetAgentConfigFn = (
+  sessionId: SessionId,
+  agentId: AgentId,
+  fields: {
+    readonly providerOverride?: ProviderId;
+    readonly modelOverride?: string;
+    readonly effort?: EffortLevel;
+  },
+) => Promise<void>;
+
+type Params = {
+  readonly sessionId: SessionId;
+  readonly pr: PullRequestState;
+  readonly spawnConfig: AgentSpawnConfigValue;
+  readonly spawnAgent: SpawnAgentFn;
+  readonly setAgentConfig: SetAgentConfigFn;
+};
+
+export const startResolveRun = async ({
+  sessionId,
+  pr,
+  spawnConfig,
+  spawnAgent,
+  setAgentConfig,
+}: Params): Promise<AgentId> => {
+  const hint = spawnConfig.hint.trim();
+  const agentId = await spawnAgent(sessionId, {
+    name: `Resolve PR #${pr.number}`,
+    ...(spawnConfig.provider !== '' && { provider: spawnConfig.provider }),
+    model: spawnConfig.model,
+    effort: spawnConfig.effort,
+    initialPrompt:
+      `Resolve the outstanding review comments on PR #${pr.number} (${pr.title}). ` +
+      `Check each unresolved thread and propose a fix or a reply.${hint === '' ? '' : ` ${hint}`}`,
+    kindOverride: 'resolver',
+    sourceCommentUrl: pr.url,
+    sourceKind: 'review_comment',
+    focus: 'none',
+  });
+  await setAgentConfig(sessionId, agentId, {
+    ...(spawnConfig.provider !== '' && { providerOverride: spawnConfig.provider }),
+    modelOverride: spawnConfig.model,
+    effort: spawnConfig.effort,
+  });
+  return agentId;
+};

--- a/apps/desktop/src/features/review/components/ReviewPane/PrContextRow.tsx
+++ b/apps/desktop/src/features/review/components/ReviewPane/PrContextRow.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { ExternalLink } from 'lucide-react';
+import { ExternalLink, ListChecks } from 'lucide-react';
 import {
   BranchPair,
   Chip,
@@ -23,6 +23,7 @@ type Props = {
   readonly onSelectPr: (prNumber: number) => void;
   readonly onRefresh: () => void;
   readonly onOpenChecks: () => void;
+  readonly onOpenQueue: () => void;
   readonly onOpenOnGithub: () => void;
 };
 
@@ -36,6 +37,7 @@ export const PrContextRow = ({
   onSelectPr,
   onRefresh,
   onOpenChecks,
+  onOpenQueue,
   onOpenOnGithub,
 }: Props) => {
   const rollup = checksRollup({ checks });
@@ -76,6 +78,7 @@ export const PrContextRow = ({
       }
       actions={
         <>
+          <GhostActionButton icon={ListChecks} label="For you" onClick={onOpenQueue} />
           <RefreshIconButton
             label="Refresh the pull request"
             isLoading={isRefreshing}

--- a/apps/desktop/src/features/review/components/ReviewPane/index.tsx
+++ b/apps/desktop/src/features/review/components/ReviewPane/index.tsx
@@ -45,6 +45,7 @@ import { PublishConversationsBar, type PublishScope } from './PublishConversatio
 import type { PreviewBlockerAction } from './PublishConversationsBar/PublicationPreview';
 import { NoPullRequestState, NothingToFixState } from './ReviewEmptyStates';
 import { openDiffComments } from '../../../session/resolve/openDiffComments';
+import { ResolveQueueHome } from '../../../resolve/components/ResolveQueueHome';
 import { ChecksMode } from './modes/ChecksMode';
 import { CreatePrMode } from './modes/CreatePrMode';
 import { PrActivityMode } from './modes/PrActivityMode';
@@ -743,6 +744,7 @@ export const ReviewPane = ({ session, eyebrow }: Props) => {
       onSelectPr={(prNumber) => void selectSessionPr(sessionId, prNumber)}
       onRefresh={() => void refreshSessionPrDetail(sessionId, { force: true })}
       onOpenChecks={() => setMode('checks')}
+      onOpenQueue={() => setMode(mode === 'queue' ? 'conversations' : 'queue')}
       onOpenOnGithub={() => void openUrl(pr.url)}
     />
   );
@@ -875,7 +877,7 @@ export const ReviewPane = ({ session, eyebrow }: Props) => {
             publishing={isBusy}
             onPublish={(opts) => void onWriteReviewPublish(opts)}
           />
-        ) : (
+        ) : mode === 'queue' ? null : (
           <PublishConversationsBar
             readyCount={selection.readyIds.length}
             selectedCount={selection.selected.size}
@@ -916,6 +918,8 @@ export const ReviewPane = ({ session, eyebrow }: Props) => {
             listWidth={listWidth}
             onBack={() => setMode('conversations')}
           />
+        ) : mode === 'queue' ? (
+          <ResolveQueueHome session={session} />
         ) : isNarrow ? (
           isListHidden ? (
             detail

--- a/apps/desktop/src/features/review/reviewMode.ts
+++ b/apps/desktop/src/features/review/reviewMode.ts
@@ -1,2 +1,2 @@
 export type ReviewMode =
-  'conversations' | 'pr_details' | 'pr_activity' | 'checks' | 'create_pr' | 'write_review';
+  'conversations' | 'pr_details' | 'pr_activity' | 'checks' | 'create_pr' | 'write_review' | 'queue';

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/OverviewActions/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/OverviewActions/index.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@goodboy/ui';
 import type { SessionId } from '@goodboy/types';
 import { CONCEPT_ICONS, ICON_SIZE } from '../../../../../shared/components/conceptIcons';
+import { ResolveOverviewAction } from '../../../../resolve/components/ResolveOverviewAction';
 import { CreateAgentPopover } from '../../CreateAgentPopover';
 
 type Props = {
@@ -15,6 +16,7 @@ export const OverviewActions = ({ sessionId, onOpenWorkflowBuilder }: Props) => 
         <CONCEPT_ICONS.workflows size={ICON_SIZE.row} aria-hidden />
         Add workflow
       </Button>
+      <ResolveOverviewAction sessionId={sessionId} />
       <CreateAgentPopover sessionId={sessionId} variant="compact" />
     </div>
   );


### PR DESCRIPTION
Third of five stacked PRs rebuilding Resolve. Stacked on #1699.

The old surface answered "what is the state of the machine" in three places and "what do I do now" in none. This replaces it with a persistent queue.

- One `For you` block holding every item waiting on a person, oldest reviewer comment first, with one secondary line for working and ready to push. Archived states sit behind a footer disclosure rather than a count strip.
- Rows lead with the reviewer's own words and the anchor, then the agent's proposal underneath.
- Inline `Accept fix` on the row when the item is waiting on you, checks are green and the change is at most 20 lines. `Accept all` appears only when every listed item qualifies, and is never preselected.
- The spawn surface is an inline sheet reusing the existing routing picker, never a modal.
- Same centered shell as the session overview (`PaneShell`, max-w-5xl, no side rail).

Delivery receipts are now in global state, so `pushed` reflects a real receipt rather than an assumption.

Not in this PR: the expanded item view with hunks and checks, the push strip, split, conflict detection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)