### PR TITLE
chore(repo): bump version to 0.2.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,53 @@ version in the same PR that bumps the version numbers (see
 `docs/release-command.md`), before the tag is pushed: the release build fails
 if it can't find a matching `## Goodboy vX.Y.Z` heading.
 
+## Goodboy v0.2.21
+
+A session can hold several branches of the same project at once. Split a
+piece of work into three pull requests and each one gets its own row in
+the overview, its own worktree, its own branch and its own pull request,
+mounted and unmounted whenever you want. Checking out a branch by hand no
+longer erases what the session knew about the request it belonged to.
+
+### [#1700] Several branches and pull requests per project
+
+Until now a session could mount a project once, on one branch, with one
+pull request. That held right up to the moment a piece of work turned out
+too big and you wanted to ship it in parts. Then the only way through was
+to drive git by hand inside the single worktree, and every checkout
+silently rewrote what the session believed it was working on and threw
+away the pull request it had already found.
+
+Now a project can own as many mounts as the work needs. Each mount is a
+row under its project in the overview, carrying its own branch, its own
+request state and its own actions, and each one mounts and unmounts on
+its own without touching its siblings. Two branches of the same
+repository show two different pull requests, and a merge on one no longer
+stops the other from being followed.
+
+Goodboy does not do the splitting. Your agent already does that well from
+a plain description of what you want, so it keeps doing it, and Goodboy
+keeps the books instead. The one thing an agent cannot leave implicit is
+intent: cutting a new branch can mean this mount moves to it, or it can
+mean a second line of work starts while the first stays alive with its
+request. Nothing in the repository tells those apart, so the agent now
+says which it meant, through commands that fork, switch, attach, unmount
+and inspect a mount by name. A session with several mounts that does not
+name one gets a refusal listing the candidates, instead of a silent guess
+at the first.
+
+Pull requests that belong to one split can be declared as a series with a
+position, so a part carries `Part of` its ticket and its place in the run
+rather than a closing reference that would shut the ticket too early.
+
+Deleting a session is now thorough on disk and gentle in the database.
+The worktree goes, with the same refusals that protect a running agent, a
+bound terminal or a busy branch, and the folder is kept rather than lost
+when removal is not safe. What the session knew stays: its mounts, the
+requests they carried and the work you spent on them still show up in
+Impact. A worktree abandoned by a deleted session can finally be found
+and cleaned up, where before its row kept the path claimed forever.
+
 ## Goodboy v0.2.20
 
 Review is one surface. The conversation list stays on screen from Fix

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goodboy/desktop",
-  "version": "0.2.20",
+  "version": "0.2.21",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -1626,7 +1626,7 @@ dependencies = [
 
 [[package]]
 name = "goodboy-desktop"
-version = "0.2.20"
+version = "0.2.21"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goodboy-desktop"
-version = "0.2.20"
+version = "0.2.21"
 description = "Goodboy desktop app"
 authors = ["Amin Khayam"]
 license = "MIT"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Goodboy",
-  "version": "0.2.20",
+  "version": "0.2.21",
   "identifier": "com.goodboy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goodboy",
-  "version": "0.2.20",
+  "version": "0.2.21",
   "private": true,
   "description": "AI workspace orchestrator. Local-first, provider-agnostic.",
   "license": "MIT",

--- a/website/src/site.ts
+++ b/website/src/site.ts
@@ -1,5 +1,5 @@
 export const SITE = {
-  version: 'v0.2.20',
+  version: 'v0.2.21',
   repo: 'https://github.com/akhayam99/goodboy',
   releases: 'https://github.com/akhayam99/goodboy/releases',
   latest: 'https://github.com/akhayam99/goodboy/releases/latest',


### PR DESCRIPTION
Version bump across the six places plus the release notes for v0.2.21, which the release build reads verbatim from CHANGELOG.md.

One pull request landed since v0.2.20: #1700, several branches and pull requests per project in one session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)