### PR TITLE
fix(desktop): fork mounts without hijacking the source mount

### DIFF
--- a/apps/desktop/src-tauri/src/query_bridge/mount.rs
+++ b/apps/desktop/src-tauri/src/query_bridge/mount.rs
@@ -445,6 +445,14 @@ fn operation_kind(verb: &str) -> &'static str {
     }
 }
 
+fn journalled_mount<'a>(kind: &str, mount_id: &'a str) -> Option<&'a str> {
+    if kind == "fork" {
+        None
+    } else {
+        Some(mount_id)
+    }
+}
+
 fn intent_of(raw: &str) -> Result<&'static str, BridgeError> {
     match raw {
         "switch" => Ok("switch"),
@@ -561,7 +569,7 @@ pub(super) async fn dispatch(
         scope.session,
         &request_id,
         kind,
-        Some(&mount.id),
+        journalled_mount(kind, &mount.id),
         &input,
     )?;
     handoff(
@@ -797,6 +805,13 @@ mod tests {
             );
         }
         assert_eq!(operation_kind("resolve"), "switch");
+    }
+
+    #[test]
+    fn a_fork_journals_no_mount_id_because_its_mount_does_not_exist_yet() {
+        assert_eq!(journalled_mount("fork", "mount-1"), None);
+        assert_eq!(journalled_mount("switch", "mount-1"), Some("mount-1"));
+        assert_eq!(journalled_mount("attach", "mount-1"), Some("mount-1"));
     }
 
     #[test]

--- a/apps/desktop/src/__tests__/mount-operations.persistence.test.ts
+++ b/apps/desktop/src/__tests__/mount-operations.persistence.test.ts
@@ -1,0 +1,264 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Database } from '@goodboy/db';
+import type { MountId } from '@goodboy/types';
+
+const h = vi.hoisted(() => ({
+  db: null as unknown as {
+    exec: (sql: string) => Promise<void>;
+    execute: (sql: string, params?: ReadonlyArray<unknown>) => Promise<{ rowsAffected: number }>;
+    select: <T>(sql: string, params?: ReadonlyArray<unknown>) => Promise<ReadonlyArray<T>>;
+  },
+  branchNames: ['ak/base'] as Array<string>,
+  createWorktree: vi.fn(),
+  inspectWorktree: vi.fn(async () => ({ kind: 'registered' }) as { kind: string }),
+}));
+
+vi.mock('@goodboy/ui', () => ({ formatError: (error: unknown) => String(error) }));
+
+vi.mock('../features/settings/settings', () => ({ DEFAULT_BRANCH_PREFIX: 'ak' }));
+
+vi.mock('../shared/lib/db', () => ({
+  tauriDatabase: {
+    exec: (sql: string) => h.db.exec(sql),
+    execute: (sql: string, params?: ReadonlyArray<unknown>) => h.db.execute(sql, params),
+    select: <T>(sql: string, params?: ReadonlyArray<unknown>) => h.db.select<T>(sql, params),
+  },
+}));
+
+vi.mock('../features/worktree/worktree', () => ({
+  createWorktree: h.createWorktree,
+  changeWorktreeBranch: vi.fn(async () => undefined),
+  invalidateLocalBranchesCache: vi.fn(),
+  listBranchNames: vi.fn(async () => h.branchNames),
+  inspectWorktree: h.inspectWorktree,
+  removeWorktreeChecked: vi.fn(async () => ({ kind: 'removed', path: '' })),
+  worktreeWriterStatus: vi.fn(async ({ path }: { path: string }) => ({
+    path,
+    holder: null,
+    token: null,
+    runId: null,
+    isGranted: false,
+    hasExited: false,
+    waiting: [],
+  })),
+  removeWorktree: vi.fn(async () => undefined),
+  removeSessionDirectory: vi.fn(async () => undefined),
+  sessionDirExists: vi.fn(async () => true),
+  worktreeStatus: vi.fn(async () => ({
+    workingTree: { kind: 'known', staged: 0, unstaged: 0, untracked: 0, unmerged: 0, changed: 0 },
+    inProgress: null,
+  })),
+}));
+
+import { insertSessionMount, listMountOperations, listSessionMounts } from '@goodboy/db';
+import { createProjectMountsSlice } from '../store/slices/project-mounts/index';
+import {
+  createMountRecoveryDatabase,
+  mountRecoveryFixture,
+  RECOVERY_PROJECT_ID,
+  RECOVERY_SESSION_ID,
+  RECOVERY_WORKSPACE_ID,
+} from './helpers/mountRecoveryDatabase';
+
+type State = Record<string, unknown>;
+
+const makeSlice = () => {
+  const state: State = {
+    sessions: [
+      {
+        id: RECOVERY_SESSION_ID,
+        workspaceId: RECOVERY_WORKSPACE_ID,
+        goal: 'Split the big pull request',
+        providerPreference: { defaultProvider: 'claude' },
+      },
+    ],
+    archivedSessions: {},
+    projects: [
+      {
+        id: RECOVERY_PROJECT_ID,
+        workspaceId: RECOVERY_WORKSPACE_ID,
+        kind: 'repo',
+        name: 'API',
+        rootPath: '/repo/api',
+        baseBranch: 'main',
+        overrides: {},
+      },
+    ],
+    workspaceOverrides: {},
+    sessionExternalTasks: {},
+    sessionProjectMounts: {},
+    sessionMounts: {},
+    mountBranchObservations: {},
+    sessionWorktrees: {},
+    sessionBranches: {},
+    sessionActiveProject: {},
+    sessionActiveMount: {},
+    sessionGithub: {},
+    sessionProjectPrs: {},
+    sessionSelectedPrNumber: {},
+    terminalTabs: {},
+    recordSessionEvent: vi.fn(async () => undefined),
+    reconcileOrphanWorktrees: vi.fn(async () => undefined),
+  };
+  const set = vi.fn((updater: Partial<State> | ((current: State) => Partial<State>)) => {
+    const patch = typeof updater === 'function' ? updater(state) : updater;
+    Object.assign(state, patch);
+  });
+  return { state, slice: createProjectMountsSlice(set as never, (() => state) as never) };
+};
+
+let db: Database;
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  db = await createMountRecoveryDatabase();
+  h.db = db as never;
+  h.branchNames = ['ak/base'];
+  h.inspectWorktree.mockResolvedValue({ kind: 'registered' });
+  h.createWorktree.mockImplementation(
+    async (args: {
+      branchPrefix: string;
+      slug: string;
+      parentDir: string;
+      dirName: string;
+      existingBranch?: string;
+    }) => ({
+      worktreePath: `${args.parentDir}/${args.dirName}`,
+      branchName: args.existingBranch ?? `${args.branchPrefix}/${args.slug}`,
+      slug: args.slug,
+      reused: false,
+    }),
+  );
+});
+
+const journal = async () => listMountOperations({ db, sessionId: RECOVERY_SESSION_ID });
+
+describe('mount operations against a real database', () => {
+  it('forks a new mount without claiming a mount id the journal cannot see yet', async () => {
+    const { slice } = makeSlice();
+
+    const mount = await slice.forkMount({
+      sessionId: RECOVERY_SESSION_ID,
+      projectId: RECOVERY_PROJECT_ID,
+      branch: 'ak/first',
+    });
+
+    const rows = await listSessionMounts({ db, sessionId: RECOVERY_SESSION_ID });
+    const operations = await journal();
+    expect(rows.map((row) => row.id)).toEqual([mount.id]);
+    expect(operations).toHaveLength(1);
+    expect(operations[0]?.status).toBe('succeeded');
+    expect(operations[0]?.mountId).toBe(mount.id);
+  });
+
+  it('forks two branches of one project into two mounts', async () => {
+    const { slice } = makeSlice();
+
+    const first = await slice.forkMount({
+      sessionId: RECOVERY_SESSION_ID,
+      projectId: RECOVERY_PROJECT_ID,
+      branch: 'ak/first',
+    });
+    const second = await slice.forkMount({
+      sessionId: RECOVERY_SESSION_ID,
+      projectId: RECOVERY_PROJECT_ID,
+      branch: 'ak/second',
+    });
+
+    expect(second.id).not.toBe(first.id);
+    expect(second.branch).toBe('ak/second');
+    expect(second.worktreePath).not.toBe(first.worktreePath);
+    const rows = await listSessionMounts({ db, sessionId: RECOVERY_SESSION_ID });
+    expect(rows).toHaveLength(2);
+  });
+
+  it('replays one request id into the same mount without cutting a second worktree', async () => {
+    const { slice } = makeSlice();
+
+    const first = await slice.forkMount({
+      sessionId: RECOVERY_SESSION_ID,
+      projectId: RECOVERY_PROJECT_ID,
+      branch: 'ak/first',
+      requestId: 'request-1',
+    });
+    const replayed = await slice.forkMount({
+      sessionId: RECOVERY_SESSION_ID,
+      projectId: RECOVERY_PROJECT_ID,
+      branch: 'ak/first',
+      requestId: 'request-1',
+    });
+
+    expect(replayed.id).toBe(first.id);
+    expect(h.createWorktree).toHaveBeenCalledTimes(1);
+    const rows = await listSessionMounts({ db, sessionId: RECOVERY_SESSION_ID });
+    expect(rows).toHaveLength(1);
+  });
+
+  it('never replays a settled request onto a fork of another branch', async () => {
+    const { slice } = makeSlice();
+
+    const first = await slice.forkMount({
+      sessionId: RECOVERY_SESSION_ID,
+      projectId: RECOVERY_PROJECT_ID,
+      branch: 'ak/first',
+      requestId: 'request-1',
+    });
+    const second = await slice.forkMount({
+      sessionId: RECOVERY_SESSION_ID,
+      projectId: RECOVERY_PROJECT_ID,
+      branch: 'ak/second',
+      requestId: 'request-1',
+    });
+
+    expect(second.id).not.toBe(first.id);
+    expect(second.branch).toBe('ak/second');
+    expect(h.createWorktree).toHaveBeenCalledTimes(2);
+  });
+
+  it('journals an attach against the mount row it already has', async () => {
+    const mount = mountRecoveryFixture({
+      id: 'mount-detached',
+      branch: 'ak/base',
+      position: 1,
+      path: null,
+      isAttached: false,
+      diskState: 'removed',
+    });
+    await insertSessionMount({
+      db,
+      mount: { ...mount, lastWorktreePath: '/repo/api/.goodboy/worktrees/mount-detached' },
+    });
+    const { slice } = makeSlice();
+
+    const attached = await slice.attachMount({
+      sessionId: RECOVERY_SESSION_ID,
+      mountId: 'mount-detached' as MountId,
+      requestId: 'attach-1',
+    });
+
+    expect(attached.isAttached).toBe(true);
+    const operations = await journal();
+    expect(operations).toHaveLength(1);
+    expect(operations[0]?.mountId).toBe('mount-detached');
+    expect(operations[0]?.status).toBe('succeeded');
+  });
+
+  it('keeps the journal honest when the fork is refused before any mount exists', async () => {
+    h.createWorktree.mockRejectedValueOnce(new Error('git worktree add failed'));
+    const { slice } = makeSlice();
+
+    await expect(
+      slice.forkMount({
+        sessionId: RECOVERY_SESSION_ID,
+        projectId: RECOVERY_PROJECT_ID,
+        branch: 'ak/first',
+      }),
+    ).rejects.toThrow('git worktree add failed');
+
+    const operations = await journal();
+    expect(operations[0]?.status).toBe('failed');
+    expect(operations[0]?.mountId).toBeNull();
+    const rows = await listSessionMounts({ db, sessionId: RECOVERY_SESSION_ID });
+    expect(rows).toHaveLength(0);
+  });
+});

--- a/apps/desktop/src/features/session/mountQueryBridge/index.test.ts
+++ b/apps/desktop/src/features/session/mountQueryBridge/index.test.ts
@@ -6,6 +6,7 @@ const { state, links } = vi.hoisted(() => ({
   state: {
     sessions: [{ id: 'session-1', workspaceId: 'ws-1', goal: 'split the pull request' }],
     terminalTabs: {} as Record<string, ReadonlyArray<unknown>>,
+    sessionActiveMount: {} as Record<string, string | null>,
     views: [] as Array<Record<string, unknown>>,
     loadSessionMounts: vi.fn(async () => state.views),
     forkMount: vi.fn(async () => state.views[1]),
@@ -103,6 +104,7 @@ beforeEach(() => {
     view({ id: 'mount-2', branch: 'goodboy/two' }) as unknown as Record<string, unknown>,
   ];
   links.length = 0;
+  state.sessionActiveMount = {};
   clearMountContinuations();
   for (const call of Object.values(state)) {
     if (typeof call === 'function' && 'mockClear' in call) {
@@ -146,6 +148,40 @@ describe('executeMountRequest', () => {
       worktreePath: '/wt/mount-2',
       origin: 'fork',
     });
+  });
+
+  it('refuses a fork that came back with the mount it forked from', async () => {
+    state.forkMount.mockResolvedValueOnce(state.views[0]);
+
+    const outcome = await executeMountRequest(
+      request({ verb: 'fork', args: { branch: 'goodboy/two' } }),
+    );
+
+    expect(outcome.ok).toBe(false);
+    expect(outcome.code).toBe('fork_unsatisfied');
+    expect(pendingMountContinuations({ sessionId: 'session-1' as SessionId })).toHaveLength(0);
+  });
+
+  it('refuses a fork that landed on a branch nobody asked for', async () => {
+    const outcome = await executeMountRequest(
+      request({ verb: 'fork', args: { branch: 'goodboy/elsewhere' } }),
+    );
+
+    expect(outcome.ok).toBe(false);
+    expect(outcome.code).toBe('fork_unsatisfied');
+    expect(pendingMountContinuations({ sessionId: 'session-1' as SessionId })).toHaveLength(0);
+  });
+
+  it('starts no continuation into the mount the turn already runs in', async () => {
+    state.sessionActiveMount = { 'session-1': 'mount-2' };
+
+    const outcome = await executeMountRequest(
+      request({ verb: 'fork', args: { branch: 'goodboy/two' } }),
+    );
+
+    expect(outcome.ok).toBe(true);
+    expect(outcome.data).toMatchObject({ requiresNewTurn: false });
+    expect(pendingMountContinuations({ sessionId: 'session-1' as SessionId })).toHaveLength(0);
   });
 
   it('leaves a mount activation without any continuation of its own', async () => {

--- a/apps/desktop/src/features/session/mountQueryBridge/index.ts
+++ b/apps/desktop/src/features/session/mountQueryBridge/index.ts
@@ -15,7 +15,10 @@ import {
   worktreeWriterStatus,
 } from '../../worktree/worktree';
 import { mountCleanupBlockers } from '../../../store/slices/mount-cleanup/cleanupPolicy';
-import { queueMountContinuation } from '../../../store/slices/turn/mountContinuations';
+import {
+  mountContinuationRefusal,
+  queueMountContinuation,
+} from '../../../store/slices/turn/mountContinuations';
 import { tauriDatabase } from '../../../shared/lib/db';
 import { useAppStore } from '../../../store/store';
 import { isMainWindow } from '../../workspace/window';
@@ -87,18 +90,44 @@ type ContinuationParams = {
   readonly origin: 'fork' | 'attach';
 };
 
-const requestContinuation = ({ request, mount, origin }: ContinuationParams): string => {
+type Continuation = {
+  readonly operationId: string;
+  readonly requiresNewTurn: boolean;
+  readonly note?: string;
+};
+
+const boundMountId = ({ sessionId }: { readonly sessionId: SessionId }): MountId | null => {
+  const state = useAppStore.getState();
+  const selected = state.sessionActiveMount?.[sessionId] ?? null;
+  if (selected !== null) {
+    return selected;
+  }
+  const session = state.sessions?.find((candidate) => candidate.id === sessionId);
+  return session?.activeMountId ?? null;
+};
+
+const requestContinuation = ({ request, mount, origin }: ContinuationParams): Continuation => {
   const operationId = request.requestId ?? `${origin}:${mount.id}:${mount.revision}`;
-  queueMountContinuation({
-    operationId,
-    sessionId: request.sessionId,
-    mountId: mount.id,
-    mountName: mount.mountName,
-    branch: mount.branch,
-    worktreePath: mount.worktreePath ?? '',
-    origin,
+  const outcome = queueMountContinuation({
+    continuation: {
+      operationId,
+      sessionId: request.sessionId,
+      mountId: mount.id,
+      mountName: mount.mountName,
+      branch: mount.branch,
+      worktreePath: mount.worktreePath ?? '',
+      origin,
+    },
+    boundMountId: boundMountId({ sessionId: request.sessionId }),
   });
-  return operationId;
+  if (outcome.queued) {
+    return { operationId, requiresNewTurn: true };
+  }
+  return {
+    operationId,
+    requiresNewTurn: false,
+    note: mountContinuationRefusal({ refusal: outcome.refusal }),
+  };
 };
 
 const bridgeErrorCode = (error: unknown): string | undefined => {
@@ -162,6 +191,14 @@ const loadedMount = async (request: MountBridgeRequest): Promise<SessionMountVie
   return views.find((candidate) => candidate.id === request.mountId);
 };
 
+const satisfiesBranch = ({
+  requested,
+  branch,
+}: {
+  readonly requested: string;
+  readonly branch: string;
+}): boolean => requested === '' || branch === requested || branch.endsWith(`/${requested}`);
+
 const forkFrom = async ({ request }: InspectParams): Promise<MountBridgeOutcome> => {
   const get = useAppStore.getState;
   const source = await loadedMount(request);
@@ -169,22 +206,38 @@ const forkFrom = async ({ request }: InspectParams): Promise<MountBridgeOutcome>
     return { ok: false, error: 'the source mount is not loaded', code: 'mount_unavailable' };
   }
   const base = text({ args: request.args, key: 'base' });
+  const requested = text({ args: request.args, key: 'branch' });
   const mount = await get().forkMount({
     sessionId: request.sessionId,
     projectId: source.projectId,
-    branch: text({ args: request.args, key: 'branch' }),
+    branch: requested,
     adoptExistingBranch: truthy({ args: request.args, key: 'existing' }),
     ...(request.requestId === undefined ? {} : { requestId: request.requestId }),
     ...(base === '' ? {} : { baseBranch: base }),
   });
-  const operationId = requestContinuation({ request, mount, origin: 'fork' });
+  if (mount.id === source.id) {
+    return {
+      ok: false,
+      error: `the fork returned the mount it forked from (${source.id}) instead of a new one`,
+      code: 'fork_unsatisfied',
+    };
+  }
+  if (!satisfiesBranch({ requested, branch: mount.branch })) {
+    return {
+      ok: false,
+      error: `the fork asked for ${requested} but the new mount sits on ${mount.branch}`,
+      code: 'fork_unsatisfied',
+    };
+  }
+  const continuation = requestContinuation({ request, mount, origin: 'fork' });
   return {
     ok: true,
     data: {
-      operationId,
+      operationId: continuation.operationId,
       sourceMountId: request.mountId,
       mount: mountResult(mount),
-      requiresNewTurn: true,
+      requiresNewTurn: continuation.requiresNewTurn,
+      ...(continuation.note === undefined ? {} : { note: continuation.note }),
     },
   };
 };
@@ -231,13 +284,14 @@ const attach = async ({ request }: InspectParams): Promise<MountBridgeOutcome> =
     mountId: request.mountId,
     ...(request.requestId === undefined ? {} : { requestId: request.requestId }),
   });
-  const operationId = requestContinuation({ request, mount, origin: 'attach' });
+  const continuation = requestContinuation({ request, mount, origin: 'attach' });
   return {
     ok: true,
     data: {
-      operationId,
+      operationId: continuation.operationId,
       mount: mountResult(mount),
-      requiresNewTurn: true,
+      requiresNewTurn: continuation.requiresNewTurn,
+      ...(continuation.note === undefined ? {} : { note: continuation.note }),
     },
   };
 };

--- a/apps/desktop/src/store/slices/project-mounts/forkMount.ts
+++ b/apps/desktop/src/store/slices/project-mounts/forkMount.ts
@@ -11,6 +11,8 @@ import {
   beginMountOperation,
   failMountOperation,
   markMountOperationUncertain,
+  mountOperationInputMatches,
+  plannedMountId,
   reusableMountOperationResult,
   succeedMountOperation,
 } from './mountOperations';
@@ -40,45 +42,71 @@ export const forkMount = (set: SetFn, get: GetFn) => {
       mountKey: `${sessionId}:${requestId}`,
       run: async () => {
         const views = await loadMountViews({ get, sessionId });
+        const requested = input.branch?.trim() ?? '';
+        const adopt = input.adoptExistingBranch === true;
+        const recordedBase = input.baseBranch ?? project.baseBranch ?? null;
+        const identity = {
+          projectId,
+          repoRoot: project.rootPath,
+          baseBranch: recordedBase,
+          branch: requested,
+          adoptExistingBranch: adopt,
+        };
         const operation = await beginMountOperation({
           sessionId,
           requestId,
           kind: 'fork',
-          mountId: generatedMountId,
+          mountId: null,
+          plannedMountId: generatedMountId,
           expectedRevision: 0,
-          input: {
-            projectId,
-            repoRoot: project.rootPath,
-            baseBranch: input.baseBranch ?? project.baseBranch ?? null,
-            mountName: input.mountName ?? project.name,
-          },
+          input: { ...identity, mountName: input.mountName ?? project.name },
         });
         const reused = reusableMountOperationResult({
           operation,
           expected: { repoRoot: project.rootPath },
+          input: identity,
         });
         if (reused !== null) {
-          const existing = views.find((candidate) => candidate.id === reused.mountId);
+          const existing = views.find(
+            (candidate) => candidate.id === reused.mountId && candidate.branch === reused.branch,
+          );
           if (existing !== undefined) {
             applyMountViews({ set, sessionId, views });
             return existing;
           }
         }
-        const mountId = (operation.mountId ?? generatedMountId) as MountId;
+        const planned = plannedMountId({ operation });
+        const sameRequest =
+          planned !== null && mountOperationInputMatches({ operation, expected: identity });
+        const landed = sameRequest
+          ? views.find((candidate) => candidate.id === planned && candidate.worktreePath !== null)
+          : undefined;
+        if (landed !== undefined) {
+          await succeedMountOperation({
+            operation,
+            result: {
+              mountId: landed.id,
+              worktreePath: landed.worktreePath ?? '',
+              branch: landed.branch,
+              repoRoot: project.rootPath,
+            },
+          });
+          applyMountViews({ set, sessionId, views });
+          return landed;
+        }
+        const mountId = (sameRequest ? planned : generatedMountId) as MountId;
         const prefix = resolveMountBranchPrefix({ get, session, project });
         const sessionSlug = resolveSessionSlug({ get, session, prefix });
         const remoteBranches = await listBranchNames({ repoPath: project.rootPath }).catch(
           () => [] as ReadonlyArray<string>,
         );
         const taken = [...remoteBranches, ...views.map((candidate) => candidate.branch)];
-        const requested = input.branch?.trim() ?? '';
         const split = splitBranchName({ branch: requested });
         const branchPrefix = split.branchPrefix === '' ? prefix : split.branchPrefix;
         const branchSlug =
           requested === ''
             ? nextAvailableSlug({ base: sessionSlug, prefix, taken })
             : split.branchSlug;
-        const adopt = input.adoptExistingBranch === true;
         if (!adopt && requested !== '' && taken.includes(`${branchPrefix}/${branchSlug}`)) {
           await failMountOperation({ operation, errorCode: 'branch-taken' });
           throw mountError({
@@ -106,6 +134,17 @@ export const forkMount = (set: SetFn, get: GetFn) => {
             payload: { projectId, projectName: project.name, reason: formatError(error) },
           });
           throw error;
+        }
+        const occupant = views.find(
+          (candidate) =>
+            candidate.id !== mountId && candidate.worktreePath === created.worktreePath,
+        );
+        if (occupant !== undefined) {
+          await failMountOperation({ operation, errorCode: 'directory-occupied' });
+          throw mountError({
+            code: 'directory-occupied',
+            message: `that worktree already belongs to mount ${occupant.id}: ${created.worktreePath}`,
+          });
         }
         const result = {
           mountId,

--- a/apps/desktop/src/store/slices/project-mounts/index.test.ts
+++ b/apps/desktop/src/store/slices/project-mounts/index.test.ts
@@ -152,6 +152,10 @@ vi.mock('@goodboy/db', () => ({
       h.operations.get(`${sessionId}:${requestId}`) ?? null,
   ),
   upsertMountOperation: vi.fn(async ({ operation }: { operation: Record<string, unknown> }) => {
+    const mountId = operation['mountId'];
+    if (typeof mountId === 'string' && !h.rows.has(mountId)) {
+      throw new Error('Sqlite error: FOREIGN KEY constraint failed');
+    }
     h.operations.set(`${operation['sessionId']}:${operation['requestId']}`, { ...operation });
   }),
   listMountOperations: vi.fn(async ({ sessionId }: { sessionId: string }) =>
@@ -376,12 +380,24 @@ describe('project mount lifecycle', () => {
 
   it('keeps the created directory when the mount row cannot be written', async () => {
     const { slice } = makeSlice();
-    await slice.forkMount({
-      sessionId: SESSION_ID,
+    const collidingPath = `${REPO_ROOT}/.goodboy/worktrees/foreign`;
+    h.rows.set('mount-foreign', {
+      id: 'mount-foreign',
+      sessionId: 'session-elsewhere',
       projectId: PROJECT_ID,
-      requestId: 'request-3',
+      worktreePath: collidingPath,
+      lastWorktreePath: collidingPath,
+      branch: 'ak/foreign',
+      baseBranch: 'main',
+      parallelIndex: 1,
+      mountName: 'goodboy',
+      repoSlug: null,
+      isAttached: true,
+      diskState: 'present',
+      revision: 0,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
     });
-    const collidingPath = [...h.rows.values()][0]?.worktreePath;
     h.createWorktree.mockResolvedValue({
       worktreePath: collidingPath,
       branchName: 'ak/second',
@@ -393,6 +409,57 @@ describe('project mount lifecycle', () => {
       slice.forkMount({ sessionId: SESSION_ID, projectId: PROJECT_ID, requestId: 'request-4' }),
     ).rejects.toMatchObject({ code: 'directory-occupied' });
     expect(h.operations.get(`${SESSION_ID}:request-4`)).toMatchObject({ status: 'uncertain' });
+  });
+
+  it('refuses a fork that lands in the directory of another mount of this session', async () => {
+    const { slice } = makeSlice();
+    const first = await slice.forkMount({
+      sessionId: SESSION_ID,
+      projectId: PROJECT_ID,
+      requestId: 'request-3',
+    });
+    h.createWorktree.mockResolvedValue({
+      worktreePath: first.worktreePath,
+      branchName: 'ak/second',
+      slug: 'second',
+      reused: true,
+    });
+
+    await expect(
+      slice.forkMount({ sessionId: SESSION_ID, projectId: PROJECT_ID, requestId: 'request-4' }),
+    ).rejects.toMatchObject({ code: 'directory-occupied' });
+    expect(h.operations.get(`${SESSION_ID}:request-4`)).toMatchObject({ status: 'failed' });
+    expect([...h.rows.values()]).toHaveLength(1);
+  });
+
+  it('forks a different branch under a reused request id instead of replaying it', async () => {
+    const { slice } = makeSlice();
+
+    const first = await slice.forkMount({
+      sessionId: SESSION_ID,
+      projectId: PROJECT_ID,
+      branch: 'ak/first',
+      requestId: 'request-5',
+    });
+    const second = await slice.forkMount({
+      sessionId: SESSION_ID,
+      projectId: PROJECT_ID,
+      branch: 'ak/second',
+      requestId: 'request-5',
+    });
+
+    expect(second.id).not.toBe(first.id);
+    expect(second.branch).toBe('ak/second');
+  });
+
+  it('stamps the journal with the mount id only once the mount row exists', async () => {
+    const { slice } = makeSlice();
+
+    const mount = await slice.forkMount({ sessionId: SESSION_ID, projectId: PROJECT_ID });
+
+    const operation = [...h.operations.values()][0];
+    expect(operation).toMatchObject({ status: 'succeeded', mountId: mount.id });
+    expect(h.rows.get(mount.id)).toBeDefined();
   });
 
   it('switches a mount in place and keeps its identity and directory', async () => {

--- a/apps/desktop/src/store/slices/project-mounts/mountOperations.ts
+++ b/apps/desktop/src/store/slices/project-mounts/mountOperations.ts
@@ -20,6 +20,7 @@ type BeginParams = {
   readonly requestId: string;
   readonly kind: MountOperationKind;
   readonly mountId: MountId | null;
+  readonly plannedMountId?: MountId;
   readonly expectedRevision: number;
   readonly input: unknown;
 };
@@ -32,11 +33,28 @@ type SettleParams = {
 
 const nowIso = (): IsoDateTime => new Date().toISOString() as IsoDateTime;
 
+const PLANNED_MOUNT_KEY = 'plannedMountId';
+
+const readPlanned = ({ input }: { readonly input: unknown }): MountId | null => {
+  if (input === null || typeof input !== 'object') {
+    return null;
+  }
+  const value = (input as Readonly<Record<string, unknown>>)[PLANNED_MOUNT_KEY];
+  return typeof value === 'string' ? (value as MountId) : null;
+};
+
+export const plannedMountId = ({
+  operation,
+}: {
+  readonly operation: MountOperation;
+}): MountId | null => readPlanned({ input: operation.input });
+
 export const beginMountOperation = async ({
   sessionId,
   requestId,
   kind,
   mountId,
+  plannedMountId: planned,
   expectedRevision,
   input,
 }: BeginParams): Promise<MountOperation> => {
@@ -45,15 +63,32 @@ export const beginMountOperation = async ({
     return existing;
   }
   const timestamp = nowIso();
+  const carried =
+    (existing === null ? null : readPlanned({ input: existing.input })) ?? planned ?? null;
+  const merged =
+    existing === null ||
+    existing.input === null ||
+    typeof existing.input !== 'object' ||
+    input === null ||
+    typeof input !== 'object'
+      ? input
+      : {
+          ...(existing.input as Readonly<Record<string, unknown>>),
+          ...(input as Readonly<Record<string, unknown>>),
+        };
+  const recorded =
+    carried === null || merged === null || typeof merged !== 'object'
+      ? merged
+      : { ...(merged as Readonly<Record<string, unknown>>), [PLANNED_MOUNT_KEY]: carried };
   const operation: MountOperation = {
     id: existing?.id ?? crypto.randomUUID(),
     sessionId,
-    mountId: existing?.mountId ?? mountId,
+    mountId,
     requestId,
     kind,
     status: 'running',
     expectedRevision,
-    input,
+    input: recorded,
     result: null,
     errorCode: null,
     createdAt: existing?.createdAt ?? timestamp,
@@ -110,13 +145,33 @@ type MatchParams = {
   readonly operation: MountOperation;
   readonly expected: Pick<MountOperationResult, 'repoRoot'> &
     Partial<Pick<MountOperationResult, 'mountId' | 'worktreePath' | 'branch'>>;
+  readonly input?: Readonly<Record<string, unknown>>;
+};
+
+export const mountOperationInputMatches = ({
+  operation,
+  expected,
+}: {
+  readonly operation: MountOperation;
+  readonly expected: Readonly<Record<string, unknown>>;
+}): boolean => {
+  const recorded = operation.input;
+  if (recorded === null || typeof recorded !== 'object') {
+    return false;
+  }
+  const fields = recorded as Readonly<Record<string, unknown>>;
+  return Object.entries(expected).every(([key, value]) => fields[key] === value);
 };
 
 export const reusableMountOperationResult = ({
   operation,
   expected,
+  input,
 }: MatchParams): MountOperationResult | null => {
   if (operation.status !== 'succeeded') {
+    return null;
+  }
+  if (input !== undefined && !mountOperationInputMatches({ operation, expected: input })) {
     return null;
   }
   const result = operation.result;

--- a/apps/desktop/src/store/slices/project-mounts/recoverMountOperations.ts
+++ b/apps/desktop/src/store/slices/project-mounts/recoverMountOperations.ts
@@ -5,6 +5,7 @@ import { inspectWorktree } from '../../../features/worktree/worktree';
 import {
   failMountOperation,
   markMountOperationUncertain,
+  plannedMountId,
   succeedMountOperation,
 } from './mountOperations';
 import { applyMountViews, loadMountViews } from './mountViews';
@@ -53,7 +54,10 @@ type RecoverForkParams = {
 };
 
 const recoverFork = async ({ get, operation, views }: RecoverForkParams): Promise<boolean> => {
-  const mountId = operation.mountId;
+  const mountId =
+    operation.mountId ??
+    (readString({ source: operation.result, key: 'mountId' }) as MountId | null) ??
+    plannedMountId({ operation });
   const worktreePath = readPath({ operation });
   const repoRoot = readRepoRoot({ operation });
   const branch = readString({ source: operation.result, key: 'branch' });

--- a/apps/desktop/src/store/slices/turn/mountContinuations.test.ts
+++ b/apps/desktop/src/store/slices/turn/mountContinuations.test.ts
@@ -1,10 +1,12 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import type { MountId, SessionId } from '@goodboy/types';
 import {
+  MAX_MOUNT_CONTINUATIONS,
   clearMountContinuations,
   mountContinuationPrompt,
   pendingMountContinuations,
   queueMountContinuation,
+  resetMountContinuationChain,
   takeMountContinuation,
 } from './mountContinuations';
 
@@ -28,30 +30,92 @@ beforeEach(() => {
 
 describe('mount continuations', () => {
   it('keeps one entry per operation id however often the same fork is retried', () => {
-    expect(queueMountContinuation(continuation())).toBe(true);
-    expect(queueMountContinuation(continuation({ mountName: 'renamed' }))).toBe(false);
+    expect(queueMountContinuation({ continuation: continuation() }).queued).toBe(true);
+    expect(
+      queueMountContinuation({ continuation: continuation({ mountName: 'renamed' }) }).queued,
+    ).toBe(false);
 
     expect(pendingMountContinuations({ sessionId: SESSION })).toHaveLength(1);
   });
 
   it('refuses an operation it already handed out, so one fork continues once', () => {
-    queueMountContinuation(continuation());
+    queueMountContinuation({ continuation: continuation() });
     takeMountContinuation({ sessionId: SESSION });
 
-    expect(queueMountContinuation(continuation())).toBe(false);
+    expect(queueMountContinuation({ continuation: continuation() })).toEqual({
+      queued: false,
+      refusal: 'already-queued',
+    });
     expect(takeMountContinuation({ sessionId: SESSION })).toBeNull();
   });
 
+  it('refuses to continue into the mount the turn already runs in', () => {
+    const outcome = queueMountContinuation({
+      continuation: continuation(),
+      boundMountId: 'mount-2' as MountId,
+    });
+
+    expect(outcome).toEqual({ queued: false, refusal: 'same-mount' });
+    expect(pendingMountContinuations({ sessionId: SESSION })).toHaveLength(0);
+  });
+
+  it('stops the chain at the cap so a broken mount cannot spend turns forever', () => {
+    for (let index = 0; index < MAX_MOUNT_CONTINUATIONS; index += 1) {
+      const queued = queueMountContinuation({
+        continuation: continuation({
+          operationId: `req-${index}`,
+          mountId: `mount-${index}` as MountId,
+        }),
+      });
+      expect(queued.queued).toBe(true);
+      expect(takeMountContinuation({ sessionId: SESSION })).not.toBeNull();
+    }
+
+    expect(
+      queueMountContinuation({
+        continuation: continuation({ operationId: 'req-last', mountId: 'mount-last' as MountId }),
+      }),
+    ).toEqual({ queued: false, refusal: 'chain-exhausted' });
+  });
+
+  it('counts the chain per session and forgets it when the operator speaks again', () => {
+    for (let index = 0; index < MAX_MOUNT_CONTINUATIONS; index += 1) {
+      queueMountContinuation({
+        continuation: continuation({
+          operationId: `req-${index}`,
+          mountId: `mount-${index}` as MountId,
+        }),
+      });
+      takeMountContinuation({ sessionId: SESSION });
+    }
+
+    expect(
+      queueMountContinuation({
+        continuation: continuation({ operationId: 'other', sessionId: OTHER_SESSION }),
+      }).queued,
+    ).toBe(true);
+
+    resetMountContinuationChain({ sessionId: SESSION });
+
+    expect(
+      queueMountContinuation({
+        continuation: continuation({ operationId: 'req-after', mountId: 'mount-after' as MountId }),
+      }).queued,
+    ).toBe(true);
+  });
+
   it('hands the session its latest target once and leaves nothing behind', () => {
-    queueMountContinuation(continuation());
-    queueMountContinuation(continuation({ operationId: 'req-2', mountId: 'mount-3' as MountId }));
+    queueMountContinuation({ continuation: continuation() });
+    queueMountContinuation({
+      continuation: continuation({ operationId: 'req-2', mountId: 'mount-3' as MountId }),
+    });
 
     expect(takeMountContinuation({ sessionId: SESSION })?.mountId).toBe('mount-3');
     expect(takeMountContinuation({ sessionId: SESSION })).toBeNull();
   });
 
   it('never hands one session the continuation another session asked for', () => {
-    queueMountContinuation(continuation({ sessionId: OTHER_SESSION }));
+    queueMountContinuation({ continuation: continuation({ sessionId: OTHER_SESSION }) });
 
     expect(takeMountContinuation({ sessionId: SESSION })).toBeNull();
     expect(takeMountContinuation({ sessionId: OTHER_SESSION })?.operationId).toBe('req-1');

--- a/apps/desktop/src/store/slices/turn/mountContinuations.ts
+++ b/apps/desktop/src/store/slices/turn/mountContinuations.ts
@@ -10,15 +10,60 @@ export type MountContinuation = Readonly<{
   origin: 'fork' | 'attach';
 }>;
 
+export const MAX_MOUNT_CONTINUATIONS = 3;
+
+export type MountContinuationRefusal = 'already-queued' | 'same-mount' | 'chain-exhausted';
+
+export type MountContinuationOutcome =
+  | { readonly queued: true }
+  | { readonly queued: false; readonly refusal: MountContinuationRefusal };
+
 const queued = new Map<string, MountContinuation>();
 const consumed = new Set<string>();
+const chained = new Map<SessionId, number>();
 
-export const queueMountContinuation = (continuation: MountContinuation): boolean => {
+type QueueParams = {
+  readonly continuation: MountContinuation;
+  readonly boundMountId?: MountId | null;
+};
+
+export const queueMountContinuation = ({
+  continuation,
+  boundMountId,
+}: QueueParams): MountContinuationOutcome => {
   if (queued.has(continuation.operationId) || consumed.has(continuation.operationId)) {
-    return false;
+    return { queued: false, refusal: 'already-queued' };
+  }
+  if (boundMountId != null && boundMountId === continuation.mountId) {
+    return { queued: false, refusal: 'same-mount' };
+  }
+  if ((chained.get(continuation.sessionId) ?? 0) >= MAX_MOUNT_CONTINUATIONS) {
+    return { queued: false, refusal: 'chain-exhausted' };
   }
   queued.set(continuation.operationId, continuation);
-  return true;
+  return { queued: true };
+};
+
+export const mountContinuationRefusal = ({
+  refusal,
+}: {
+  readonly refusal: MountContinuationRefusal;
+}): string => {
+  if (refusal === 'same-mount') {
+    return 'this turn already runs in that mount, so no new turn was started';
+  }
+  if (refusal === 'chain-exhausted') {
+    return `this session already chained ${MAX_MOUNT_CONTINUATIONS} mount turns: finish the work here or ask the operator, no new turn was started`;
+  }
+  return 'that mount request already started a turn, so no new turn was started';
+};
+
+export const resetMountContinuationChain = ({
+  sessionId,
+}: {
+  readonly sessionId: SessionId;
+}): void => {
+  chained.delete(sessionId);
 };
 
 export const pendingMountContinuations = ({
@@ -38,12 +83,17 @@ export const takeMountContinuation = ({
     queued.delete(entry.operationId);
     consumed.add(entry.operationId);
   }
-  return owned[owned.length - 1] ?? null;
+  const next = owned[owned.length - 1] ?? null;
+  if (next !== null) {
+    chained.set(sessionId, (chained.get(sessionId) ?? 0) + 1);
+  }
+  return next;
 };
 
 export const clearMountContinuations = (): void => {
   queued.clear();
   consumed.clear();
+  chained.clear();
 };
 
 export const mountContinuationPrompt = ({

--- a/apps/desktop/src/store/slices/turn/sendTurn.ts
+++ b/apps/desktop/src/store/slices/turn/sendTurn.ts
@@ -110,7 +110,11 @@ import {
   selectMountById,
   selectWritableMounts,
 } from '../project-mounts/selectors';
-import { mountContinuationPrompt, takeMountContinuation } from './mountContinuations';
+import {
+  mountContinuationPrompt,
+  resetMountContinuationChain,
+  takeMountContinuation,
+} from './mountContinuations';
 import {
   buildTurnWritableRoots,
   repoRootsForTurn,
@@ -1501,6 +1505,9 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
     });
   };
   const run = async (input: Input): Promise<SendTurnResult> => {
+    if (input.origin !== 'mount-continuation') {
+      resetMountContinuationChain({ sessionId: input.sessionId });
+    }
     const lease: TurnLease = { path: null, holder: null, token: null, attemptId: undefined };
     try {
       return await runOnce(input, lease);

--- a/apps/desktop/src/store/store.story-materialize-on-demand.test.ts
+++ b/apps/desktop/src/store/store.story-materialize-on-demand.test.ts
@@ -265,13 +265,15 @@ describe('story: an agent works from its own project and reads the others', () =
     } as never);
     storySpies.runTurn.mockImplementation(() => {
       queueMountContinuation({
-        operationId: 'req-fork',
-        sessionId: SESSION_ID,
-        mountId: 'mount-b' as never,
-        mountName: 'app 2',
-        branch: 'goodboy/second',
-        worktreePath: SECOND_MOUNT_PATH,
-        origin: 'fork',
+        continuation: {
+          operationId: 'req-fork',
+          sessionId: SESSION_ID,
+          mountId: 'mount-b' as never,
+          mountName: 'app 2',
+          branch: 'goodboy/second',
+          worktreePath: SECOND_MOUNT_PATH,
+          origin: 'fork',
+        },
       });
       return emptyTurnStream();
     });

--- a/docs/query-bridge.md
+++ b/docs/query-bridge.md
@@ -103,7 +103,9 @@ answer does not open a duplicate.
 
 A refusal may carry a machine-readable code beside its sentence:
 `ambiguous_mount`, `mount_unavailable`, `branch_mismatch`, `branch_in_use`,
-`unsafe_cleanup`, `operation_pending`, `request_conflict`. Codes are additive;
+`unsafe_cleanup`, `operation_pending`, `request_conflict`, `fork_unsatisfied`.
+`fork_unsatisfied` says the fork came back with the mount it forked from, or on
+a branch other than the one asked for, so no new turn starts. Codes are additive;
 the envelope stays `{ok, data, error}`.
 
 ## No verb writes an event


### PR DESCRIPTION
## What broke

v0.2.21 shipped mount forking with a defect that made every new mount fail, and made an agent that asked for one loop.

`beginMountOperation` wrote `mount_id` into `mount_operations` at the **start** of the operation, as `existing?.mountId ?? mountId`. Two faces of the same line:

- **From the UI**, no prior row existed, so it wrote a mount id that `session_worktrees` did not have yet. `mount_operations.mount_id` references that table and the app opens the database with `PRAGMA foreign_keys = ON`, so creating a mount failed outright with `FOREIGN KEY constraint failed`.
- **From the query bridge**, Rust `record_pending` had already journalled the row with the **source** mount of `mount fork --mount X`. That row exists, so no constraint error: `existing?.mountId` won, the fork adopted the source mount id, `mountDirName` produced the source directory, `find_existing` returned it with the source branch, the insert was skipped, and the caller got the source mount back. `forkFrom` trusted it and queued a continuation turn into it, so the agent woke up in the directory it had just left, found its branch still missing, and forked again. About ten turns of full context before anyone noticed.

A second defect kept it quiet: `beginMountOperation` **overwrote** `input_json`, destroying the `{verb, mountId, args}` the Rust side had recorded, so `conflicting_input` found none of its keys and never raised `request_conflict`. A repeated request id with a different branch replayed silently instead of being refused.

## What changed

- The journal no longer claims a mount id that does not exist. `beginMountOperation` takes an existing `mountId` or `null`, plus a `plannedMountId` carried inside `input_json` where no foreign key applies, so a resumed fork still reuses its directory. `succeedMountOperation` stamps `mount_id` once the row is written.
- Recorded input is merged, not clobbered, so `request_conflict` can see a reused id carrying different arguments.
- `forkMount` replays only on complete request identity: repository root, requested branch, adopt flag and base branch. It refuses with `directory-occupied` when the created worktree already belongs to another mount.
- The bridge refuses with a new `fork_unsatisfied` code when the mount it gets back is the source, or is not on the branch that was asked for.
- Continuation turns are bounded: `MAX_MOUNT_CONTINUATIONS = 3` per session, no continuation into the mount the turn already runs in, and the chain resets on any ordinary turn. A refusal comes back in the same turn with a note saying why, instead of stalling in silence.

## Why the suite did not catch it

The desktop store tests mock `@goodboy/db` wholesale, so no insert ever reached SQLite; the `@goodboy/db` tests exercise queries against rows built by hand. The seam between them, a journal write ordered before the mount insert, belonged to neither.

`apps/desktop/src/__tests__/mount-operations.persistence.test.ts` now drives the store slice against the real database with foreign keys on and only the git layer mocked. Reinstating the old line makes five of its six cases fail with `FOREIGN KEY constraint failed`, verified. The mocked `@goodboy/db` also now throws when a journal write names an unknown mount, so the invariant holds across the mocked suite too.

## Verification

`pnpm typecheck` 5/5, `@goodboy/db` 383 passed, desktop 774 files / 7035 tests, `cargo test --locked` 689, Tauri command parity 244/244.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
