### PR TITLE
refactor(desktop): let the stage board show work instead of chrome

### DIFF
--- a/apps/desktop/src/app/components/MockScene/index.tsx
+++ b/apps/desktop/src/app/components/MockScene/index.tsx
@@ -4,12 +4,14 @@ import { WorkspaceScene } from './scenes/WorkspaceScene';
 import { WorkflowScene } from './scenes/WorkflowScene';
 import { ShellScene } from './scenes/ShellScene';
 import { MountsScene } from './scenes/MountsScene';
+import { BoardScene } from './scenes/BoardScene';
 
 const SCENES = {
   workspace: WorkspaceScene,
   workflow: WorkflowScene,
   shell: ShellScene,
   mounts: MountsScene,
+  board: BoardScene,
 };
 
 export const MockScene = () => {

--- a/apps/desktop/src/app/components/MockScene/scenes/BoardScene.tsx
+++ b/apps/desktop/src/app/components/MockScene/scenes/BoardScene.tsx
@@ -1,0 +1,661 @@
+import { useEffect, useState } from 'react';
+import type {
+  Agent,
+  AgentId,
+  IsoDateTime,
+  OpenQuestion,
+  OpenQuestionId,
+  Project,
+  ProjectId,
+  ProviderRunId,
+  PullRequestState,
+  PullRequestStateKind,
+  Session,
+  SessionId,
+  SessionProjectMount,
+  TelemetryRecord,
+  TelemetryRecordId,
+  WorkflowRunId,
+  WorkflowId,
+  Workspace,
+  WorkspaceGitStatus,
+  WorkspaceId,
+} from '@goodboy/types';
+import { StageBoard } from '../../../../features/workspace/components/StageBoard';
+import { useAppStore, useSessions } from '../../../../store';
+
+const WORKSPACE_ID = 'mock-board-workspace-cascade' as WorkspaceId;
+const CORE_ID = 'mock-board-project-core-api' as ProjectId;
+const CONSOLE_ID = 'mock-board-project-web-console' as ProjectId;
+const LONG_ID = 'mock-board-project-reporting-warehouse' as ProjectId;
+const WORKFLOW_ID = 'mock-board-workflow-checkout-retry' as WorkflowId;
+const WORKFLOW_RUN_ID = 'mock-board-workflow-run-checkout-retry' as WorkflowRunId;
+const RUNNING_PROVIDER_RUN_ID = 'mock-board-provider-run-checkout-retry' as ProviderRunId;
+
+const MINUTE = 60_000;
+const HOUR = 3_600_000;
+const DAY = 86_400_000;
+
+const isoAgo = (offsetMs: number): IsoDateTime =>
+  new Date(Date.now() - offsetMs).toISOString() as IsoDateTime;
+
+const OVERRIDES = {
+  defaultProviderId: null,
+  defaultWorkflowId: null,
+  defaultBranchPrefix: null,
+  parallelEnabled: null,
+  defaultVerbosity: null,
+  providerBindings: null,
+  taskModels: null,
+  roleModels: null,
+  parallelAgents: null,
+  providerPool: null,
+  attributionFooter: null,
+};
+
+const WORKSPACE: Workspace = {
+  id: WORKSPACE_ID,
+  name: 'Cascade',
+  slug: 'cascade',
+  sessionsRoot: '/mock/cascade/sessions',
+  overrides: OVERRIDES,
+  createdAt: isoAgo(30 * DAY),
+  updatedAt: isoAgo(MINUTE),
+};
+
+const PROJECTS: ReadonlyArray<Project> = [
+  {
+    id: CORE_ID,
+    workspaceId: WORKSPACE_ID,
+    name: 'core-api',
+    rootPath: '/mock/cascade/core-api',
+    kind: 'repo',
+    overrides: OVERRIDES,
+    createdAt: isoAgo(30 * DAY),
+    updatedAt: isoAgo(MINUTE),
+  },
+  {
+    id: CONSOLE_ID,
+    workspaceId: WORKSPACE_ID,
+    name: 'web-console',
+    rootPath: '/mock/cascade/web-console',
+    kind: 'repo',
+    overrides: OVERRIDES,
+    createdAt: isoAgo(30 * DAY),
+    updatedAt: isoAgo(MINUTE),
+  },
+  {
+    id: LONG_ID,
+    workspaceId: WORKSPACE_ID,
+    name: 'reporting-analytics-data-warehouse-pipeline',
+    rootPath: '/mock/cascade/reporting-analytics-data-warehouse-pipeline',
+    kind: 'repo',
+    overrides: OVERRIDES,
+    createdAt: isoAgo(30 * DAY),
+    updatedAt: isoAgo(MINUTE),
+  },
+];
+
+const GIT_STATUSES: Readonly<Record<ProjectId, WorkspaceGitStatus>> = {
+  [CORE_ID]: {
+    state: 'ready',
+    branch: 'main',
+    headSubject: 'Bump the lockfile after the security patch',
+    upstreamDistance: { kind: 'known', ahead: 0, behind: 0 },
+    workingTree: { kind: 'known', staged: 0, unstaged: 0, untracked: 0, unmerged: 0, changed: 0 },
+    upstream: 'origin/main',
+    inProgress: null,
+  },
+  [CONSOLE_ID]: {
+    state: 'ready',
+    branch: 'main',
+    headSubject: 'Retire the legacy export cron job',
+    upstreamDistance: { kind: 'known', ahead: 2, behind: 0 },
+    workingTree: { kind: 'known', staged: 0, unstaged: 1, untracked: 0, unmerged: 0, changed: 1 },
+    upstream: 'origin/main',
+    inProgress: null,
+  },
+  [LONG_ID]: {
+    state: 'ready',
+    branch: 'main',
+    headSubject: 'Ship the reconciliation report exporter',
+    upstreamDistance: { kind: 'known', ahead: 0, behind: 1 },
+    workingTree: { kind: 'known', staged: 0, unstaged: 0, untracked: 3, unmerged: 0, changed: 3 },
+    upstream: 'origin/main',
+    inProgress: null,
+  },
+};
+
+const mount = (params: {
+  readonly projectId: ProjectId;
+  readonly mountName: string;
+  readonly branch: string;
+  readonly repoRoot: string;
+}): SessionProjectMount => ({
+  projectId: params.projectId,
+  mountName: params.mountName,
+  worktreePath: params.repoRoot,
+  repoRoot: params.repoRoot,
+  branch: params.branch,
+});
+
+const CORE_MOUNT = mount({
+  projectId: CORE_ID,
+  mountName: 'core-api',
+  branch: 'fix/api-gateway-rate-limits',
+  repoRoot: '/mock/cascade/core-api',
+});
+const CONSOLE_MOUNT = mount({
+  projectId: CONSOLE_ID,
+  mountName: 'web-console',
+  branch: 'feat/checkout-retry-dedupe',
+  repoRoot: '/mock/cascade/web-console',
+});
+const LONG_MOUNT = mount({
+  projectId: LONG_ID,
+  mountName: 'reporting-analytics-data-warehouse-pipeline',
+  branch: 'fix/settlement-export-rounding-drift',
+  repoRoot: '/mock/cascade/reporting-analytics-data-warehouse-pipeline',
+});
+
+type PrParams = {
+  readonly number: number;
+  readonly title: string;
+  readonly headBranch: string;
+  readonly state: PullRequestStateKind;
+  readonly isDraft?: boolean;
+  readonly checks?: PullRequestState['checks'];
+};
+
+const pullRequest = ({
+  number,
+  title,
+  headBranch,
+  state,
+  isDraft = false,
+  checks = 'success',
+}: PrParams): PullRequestState => ({
+  number,
+  title,
+  url: `https://example.invalid/cascade/pull/${number}`,
+  state,
+  mergeable: state === 'open' ? true : null,
+  checks,
+  baseBranch: 'main',
+  headBranch,
+  isDraft,
+  reviewDecision: 'review_required',
+  body: '',
+  updatedAt: isoAgo(HOUR),
+});
+
+const EMPTY_GITHUB = {
+  linkedIssues: [],
+  failedAt: null,
+  loading: false,
+  error: null,
+  detail: null,
+  detailFetchedAt: null,
+  detailLoading: false,
+  detailError: null,
+};
+
+const githubEntry = (pr: PullRequestState | null) => ({
+  ...EMPTY_GITHUB,
+  fetchedAt: isoAgo(HOUR),
+  pr,
+});
+
+const BUILDING_RATE_LIMIT = 'mock-board-session-rate-limit' as SessionId;
+const BUILDING_ONBOARDING = 'mock-board-session-onboarding-copy' as SessionId;
+const RUNNING_CHECKOUT_RETRY = 'mock-board-session-checkout-retry' as SessionId;
+const ATTENTION_BACKOFF = 'mock-board-session-notify-backoff' as SessionId;
+const ATTENTION_ERROR = 'mock-board-session-settlement-rounding' as SessionId;
+const REVIEW_PAGINATION = 'mock-board-session-admin-pagination' as SessionId;
+const REVIEW_RECONCILIATION = 'mock-board-session-reconciliation-export' as SessionId;
+const DONE_LOCKFILE = 'mock-board-session-lockfile-bump' as SessionId;
+const DONE_CRON = 'mock-board-session-retire-cron' as SessionId;
+const ARCHIVED_MACROS = 'mock-board-session-refund-macros' as SessionId;
+const ARCHIVED_FLAKY_TEST = 'mock-board-session-flaky-export-test' as SessionId;
+
+const SESSIONS: ReadonlyArray<Session> = [
+  {
+    id: BUILDING_RATE_LIMIT,
+    workspaceId: WORKSPACE_ID,
+    goal: 'Add per-tenant rate limiting to the public API gateway',
+    state: { kind: 'idle', lastActivityAt: isoAgo(2 * HOUR) },
+    contextSlots: [],
+    providerPreference: { defaultProvider: 'anthropic', allowTurnOverride: true },
+    permissionMode: 'default',
+    workflowRuns: [],
+    autoRun: false,
+    titleUserEdited: true,
+    activeProjectId: CORE_ID,
+    createdAt: isoAgo(2 * HOUR + 10 * MINUTE),
+    updatedAt: isoAgo(2 * HOUR),
+  },
+  {
+    id: BUILDING_ONBOARDING,
+    workspaceId: WORKSPACE_ID,
+    goal: 'Draft the first-run onboarding checklist copy',
+    state: { kind: 'idle', lastActivityAt: isoAgo(40 * MINUTE) },
+    contextSlots: [],
+    providerPreference: { defaultProvider: 'anthropic', allowTurnOverride: true },
+    permissionMode: 'default',
+    workflowRuns: [],
+    autoRun: false,
+    titleUserEdited: true,
+    activeProjectId: CONSOLE_ID,
+    createdAt: isoAgo(60 * MINUTE),
+    updatedAt: isoAgo(40 * MINUTE),
+  },
+  {
+    id: RUNNING_CHECKOUT_RETRY,
+    workspaceId: WORKSPACE_ID,
+    goal: 'Rewrite the checkout retry queue to dedupe webhook events',
+    state: { kind: 'running', runId: RUNNING_PROVIDER_RUN_ID, startedAt: isoAgo(25 * MINUTE) },
+    contextSlots: [],
+    providerPreference: { defaultProvider: 'anthropic', allowTurnOverride: true },
+    permissionMode: 'default',
+    workflowRuns: [
+      {
+        id: WORKFLOW_RUN_ID,
+        workflowId: WORKFLOW_ID,
+        ordinal: 0,
+        currentStep: 1,
+        autoRun: true,
+        triggerMode: 'immediate',
+        executionMode: 'dynamic',
+        goal: 'Rewrite the checkout retry queue to dedupe webhook events',
+        createdAt: isoAgo(30 * MINUTE),
+      },
+    ],
+    autoRun: true,
+    titleUserEdited: true,
+    activeProjectId: CORE_ID,
+    createdAt: isoAgo(30 * MINUTE),
+    updatedAt: isoAgo(25 * MINUTE),
+  },
+  {
+    id: ATTENTION_BACKOFF,
+    workspaceId: WORKSPACE_ID,
+    goal: 'Pick the retry backoff strategy for the notify relay',
+    state: { kind: 'idle', lastActivityAt: isoAgo(5 * HOUR) },
+    contextSlots: [],
+    providerPreference: { defaultProvider: 'anthropic', allowTurnOverride: true },
+    permissionMode: 'default',
+    workflowRuns: [],
+    autoRun: false,
+    titleUserEdited: true,
+    activeProjectId: CONSOLE_ID,
+    createdAt: isoAgo(5 * HOUR + 20 * MINUTE),
+    updatedAt: isoAgo(5 * HOUR),
+  },
+  {
+    id: ATTENTION_ERROR,
+    workspaceId: WORKSPACE_ID,
+    goal: 'Fix the rounding bug in the multi-currency settlement export',
+    state: {
+      kind: 'error',
+      message: 'Agent hit an unrecoverable git conflict',
+      failedAt: isoAgo(HOUR),
+    },
+    contextSlots: [],
+    providerPreference: { defaultProvider: 'anthropic', allowTurnOverride: true },
+    permissionMode: 'default',
+    workflowRuns: [],
+    autoRun: false,
+    titleUserEdited: true,
+    activeProjectId: LONG_ID,
+    createdAt: isoAgo(HOUR + 20 * MINUTE),
+    updatedAt: isoAgo(HOUR),
+  },
+  {
+    id: REVIEW_PAGINATION,
+    workspaceId: WORKSPACE_ID,
+    goal: 'Add pagination to the admin sessions table',
+    state: { kind: 'idle', lastActivityAt: isoAgo(6 * HOUR) },
+    contextSlots: [],
+    providerPreference: { defaultProvider: 'anthropic', allowTurnOverride: true },
+    permissionMode: 'default',
+    workflowRuns: [],
+    autoRun: false,
+    titleUserEdited: true,
+    activeProjectId: CONSOLE_ID,
+    createdAt: isoAgo(6 * HOUR + 30 * MINUTE),
+    updatedAt: isoAgo(6 * HOUR),
+  },
+  {
+    id: REVIEW_RECONCILIATION,
+    workspaceId: WORKSPACE_ID,
+    goal: "Reconcile the nightly settlement export against the ledger snapshot before the finance team's Monday close and stop the rounding drift from compounding",
+    state: { kind: 'idle', lastActivityAt: isoAgo(2 * DAY) },
+    contextSlots: [],
+    providerPreference: { defaultProvider: 'anthropic', allowTurnOverride: true },
+    permissionMode: 'default',
+    workflowRuns: [],
+    autoRun: false,
+    titleUserEdited: true,
+    activeProjectId: LONG_ID,
+    createdAt: isoAgo(2 * DAY + HOUR),
+    updatedAt: isoAgo(2 * DAY),
+  },
+  {
+    id: DONE_LOCKFILE,
+    workspaceId: WORKSPACE_ID,
+    goal: 'Bump the lockfile after the security patch',
+    state: { kind: 'idle', lastActivityAt: isoAgo(3 * DAY) },
+    contextSlots: [],
+    providerPreference: { defaultProvider: 'anthropic', allowTurnOverride: true },
+    permissionMode: 'default',
+    workflowRuns: [],
+    autoRun: false,
+    titleUserEdited: true,
+    activeProjectId: CORE_ID,
+    createdAt: isoAgo(3 * DAY + HOUR),
+    updatedAt: isoAgo(3 * DAY),
+  },
+  {
+    id: DONE_CRON,
+    workspaceId: WORKSPACE_ID,
+    goal: 'Retire the legacy export cron job',
+    state: { kind: 'idle', lastActivityAt: isoAgo(4 * DAY) },
+    contextSlots: [],
+    providerPreference: { defaultProvider: 'anthropic', allowTurnOverride: true },
+    permissionMode: 'default',
+    workflowRuns: [],
+    autoRun: false,
+    titleUserEdited: true,
+    activeProjectId: CONSOLE_ID,
+    createdAt: isoAgo(4 * DAY + HOUR),
+    updatedAt: isoAgo(4 * DAY),
+  },
+];
+
+const ARCHIVED_SESSIONS: ReadonlyArray<Session> = [
+  {
+    id: ARCHIVED_MACROS,
+    workspaceId: WORKSPACE_ID,
+    goal: 'Update support macro templates for the refund flow',
+    state: { kind: 'ended', endedAt: isoAgo(5 * DAY) },
+    contextSlots: [],
+    providerPreference: { defaultProvider: 'anthropic', allowTurnOverride: true },
+    permissionMode: 'default',
+    workflowRuns: [],
+    autoRun: false,
+    titleUserEdited: true,
+    activeProjectId: CORE_ID,
+    archivedAt: isoAgo(5 * DAY),
+    createdAt: isoAgo(6 * DAY),
+    updatedAt: isoAgo(5 * DAY),
+  },
+  {
+    id: ARCHIVED_FLAKY_TEST,
+    workspaceId: WORKSPACE_ID,
+    goal: 'Fix a flaky retry test in the export pipeline',
+    state: { kind: 'ended', endedAt: isoAgo(9 * DAY) },
+    contextSlots: [],
+    providerPreference: { defaultProvider: 'anthropic', allowTurnOverride: true },
+    permissionMode: 'default',
+    workflowRuns: [],
+    autoRun: false,
+    titleUserEdited: true,
+    activeProjectId: LONG_ID,
+    archivedAt: isoAgo(9 * DAY),
+    createdAt: isoAgo(10 * DAY),
+    updatedAt: isoAgo(9 * DAY),
+  },
+];
+
+const telemetry = (params: {
+  readonly id: string;
+  readonly sessionId: SessionId;
+  readonly costUsd: number;
+  readonly recordedAt: IsoDateTime;
+}): TelemetryRecord => ({
+  id: params.id as TelemetryRecordId,
+  runId: `${params.id}-run` as ProviderRunId,
+  sessionId: params.sessionId,
+  kind: 'turn',
+  provider: 'anthropic',
+  model: 'claude-sonnet-4-5',
+  inputTokens: 4_200,
+  outputTokens: 960,
+  estimatedCostUsd: params.costUsd,
+  recordedAt: params.recordedAt,
+});
+
+const agent = (params: {
+  readonly id: AgentId;
+  readonly sessionId: SessionId;
+  readonly ordinal: number;
+  readonly name: string;
+  readonly kind: string;
+  readonly status: Agent['status'];
+  readonly runId?: ProviderRunId;
+}): Agent => ({
+  id: params.id,
+  sessionId: params.sessionId,
+  ordinal: params.ordinal,
+  name: params.name,
+  kind: params.kind,
+  status: params.status,
+  runId: params.runId,
+  startedAt: isoAgo(20 * MINUTE),
+  completedAt: params.status === 'completed' ? isoAgo(10 * MINUTE) : undefined,
+});
+
+const OPEN_QUESTION: OpenQuestion = {
+  id: 'mock-board-question-relay-backoff' as OpenQuestionId,
+  sessionId: ATTENTION_BACKOFF,
+  text: 'Should the relay retry with a fixed delay or exponential backoff?',
+  suggestedAnswers: ['Fixed delay', 'Exponential backoff'],
+  recommendedAnswer: 'Exponential backoff',
+  userAnswer: null,
+  status: 'open',
+  createdAt: isoAgo(5 * HOUR + 10 * MINUTE),
+};
+
+export const BoardScene = () => {
+  const [isReady, setIsReady] = useState(false);
+
+  useEffect(() => {
+    useAppStore.setState({
+      workspaces: [WORKSPACE],
+      currentWorkspaceId: WORKSPACE_ID,
+      currentSessionId: null,
+      projects: PROJECTS,
+      sessions: SESSIONS,
+      archivedSessions: { [WORKSPACE_ID]: ARCHIVED_SESSIONS },
+      boardReady: true,
+      projectGitStatus: GIT_STATUSES,
+      sessionProjectMounts: {
+        [BUILDING_RATE_LIMIT]: [CORE_MOUNT],
+        [BUILDING_ONBOARDING]: [CONSOLE_MOUNT],
+        [RUNNING_CHECKOUT_RETRY]: [CORE_MOUNT, CONSOLE_MOUNT],
+        [ATTENTION_BACKOFF]: [CONSOLE_MOUNT],
+        [ATTENTION_ERROR]: [LONG_MOUNT],
+        [REVIEW_PAGINATION]: [CONSOLE_MOUNT],
+        [REVIEW_RECONCILIATION]: [LONG_MOUNT],
+        [DONE_LOCKFILE]: [CORE_MOUNT],
+        [DONE_CRON]: [CONSOLE_MOUNT],
+        [ARCHIVED_MACROS]: [CORE_MOUNT],
+        [ARCHIVED_FLAKY_TEST]: [LONG_MOUNT],
+      },
+      sessionGithub: {
+        [BUILDING_RATE_LIMIT]: githubEntry(null),
+        [BUILDING_ONBOARDING]: githubEntry(null),
+        [RUNNING_CHECKOUT_RETRY]: githubEntry(null),
+        [ATTENTION_BACKOFF]: githubEntry(null),
+        [ATTENTION_ERROR]: githubEntry(null),
+        [REVIEW_PAGINATION]: githubEntry(
+          pullRequest({
+            number: 231,
+            title: 'Add pagination to the admin sessions table',
+            headBranch: 'feat/admin-sessions-pagination',
+            state: 'open',
+            checks: 'success',
+          }),
+        ),
+        [REVIEW_RECONCILIATION]: githubEntry(
+          pullRequest({
+            number: 244,
+            title: 'Reconcile the settlement export against the ledger snapshot',
+            headBranch: LONG_MOUNT.branch,
+            state: 'open',
+            isDraft: true,
+            checks: 'pending',
+          }),
+        ),
+        [DONE_LOCKFILE]: githubEntry(
+          pullRequest({
+            number: 198,
+            title: 'Bump the lockfile after the security patch',
+            headBranch: 'chore/lockfile-security-bump',
+            state: 'merged',
+          }),
+        ),
+        [DONE_CRON]: githubEntry(
+          pullRequest({
+            number: 205,
+            title: 'Retire the legacy export cron job',
+            headBranch: 'chore/retire-export-cron',
+            state: 'closed',
+          }),
+        ),
+      },
+      sessionOpenQuestions: { [ATTENTION_BACKOFF]: [OPEN_QUESTION] },
+      sessionPhaseRuns: {
+        [RUNNING_CHECKOUT_RETRY]: [
+          agent({
+            id: 'mock-board-agent-retry-scout' as AgentId,
+            sessionId: RUNNING_CHECKOUT_RETRY,
+            ordinal: 0,
+            name: 'Trace the checkout retry path',
+            kind: 'scout',
+            status: 'completed',
+          }),
+          agent({
+            id: 'mock-board-agent-retry-implementer' as AgentId,
+            sessionId: RUNNING_CHECKOUT_RETRY,
+            ordinal: 1,
+            name: 'Dedupe webhook events in the retry queue',
+            kind: 'implementer',
+            status: 'running',
+            runId: RUNNING_PROVIDER_RUN_ID,
+          }),
+        ],
+        [REVIEW_PAGINATION]: [
+          agent({
+            id: 'mock-board-agent-pagination-implementer' as AgentId,
+            sessionId: REVIEW_PAGINATION,
+            ordinal: 0,
+            name: 'Add pagination to the admin sessions table',
+            kind: 'implementer',
+            status: 'completed',
+          }),
+        ],
+      },
+      sessionTelemetry: {
+        [BUILDING_RATE_LIMIT]: [
+          telemetry({
+            id: 'mock-board-telemetry-rate-limit',
+            sessionId: BUILDING_RATE_LIMIT,
+            costUsd: 0.34,
+            recordedAt: isoAgo(2 * HOUR),
+          }),
+        ],
+        [BUILDING_ONBOARDING]: [
+          telemetry({
+            id: 'mock-board-telemetry-onboarding',
+            sessionId: BUILDING_ONBOARDING,
+            costUsd: 1.2,
+            recordedAt: isoAgo(40 * MINUTE),
+          }),
+        ],
+        [RUNNING_CHECKOUT_RETRY]: [
+          telemetry({
+            id: 'mock-board-telemetry-checkout-retry',
+            sessionId: RUNNING_CHECKOUT_RETRY,
+            costUsd: 2.15,
+            recordedAt: isoAgo(25 * MINUTE),
+          }),
+        ],
+        [ATTENTION_BACKOFF]: [
+          telemetry({
+            id: 'mock-board-telemetry-notify-backoff',
+            sessionId: ATTENTION_BACKOFF,
+            costUsd: 0.02,
+            recordedAt: isoAgo(5 * HOUR),
+          }),
+        ],
+        [ATTENTION_ERROR]: [
+          telemetry({
+            id: 'mock-board-telemetry-settlement-rounding',
+            sessionId: ATTENTION_ERROR,
+            costUsd: 0.58,
+            recordedAt: isoAgo(HOUR),
+          }),
+        ],
+        [REVIEW_PAGINATION]: [
+          telemetry({
+            id: 'mock-board-telemetry-admin-pagination',
+            sessionId: REVIEW_PAGINATION,
+            costUsd: 0.75,
+            recordedAt: isoAgo(6 * HOUR),
+          }),
+        ],
+        [REVIEW_RECONCILIATION]: [
+          telemetry({
+            id: 'mock-board-telemetry-reconciliation-export',
+            sessionId: REVIEW_RECONCILIATION,
+            costUsd: 4.82,
+            recordedAt: isoAgo(2 * DAY),
+          }),
+        ],
+        [DONE_LOCKFILE]: [
+          telemetry({
+            id: 'mock-board-telemetry-lockfile-bump',
+            sessionId: DONE_LOCKFILE,
+            costUsd: 0.05,
+            recordedAt: isoAgo(3 * DAY),
+          }),
+        ],
+        [DONE_CRON]: [
+          telemetry({
+            id: 'mock-board-telemetry-retire-cron',
+            sessionId: DONE_CRON,
+            costUsd: 1.1,
+            recordedAt: isoAgo(4 * DAY),
+          }),
+        ],
+      },
+      sessionWorkflows: { [RUNNING_CHECKOUT_RETRY]: [] },
+      phaseTemplates: { [WORKSPACE_ID]: [] },
+      sessionExternalTasks: {},
+      activeLens: {},
+      workspaceIntegrations: { [WORKSPACE_ID]: [] },
+      sessionAttachments: {},
+      slotHistory: {},
+      slotHistoryCounts: {},
+      loadArchivedSessions: async () => undefined,
+      loadProjectGitStatus: async () => undefined,
+    });
+    setIsReady(true);
+  }, []);
+
+  if (!isReady) {
+    return null;
+  }
+
+  return <BoardSceneContent />;
+};
+
+const BoardSceneContent = () => {
+  const sessions = useSessions();
+  return (
+    <main className="h-screen overflow-hidden bg-background text-foreground">
+      <StageBoard workspaceId={WORKSPACE_ID} sessions={sessions} />
+    </main>
+  );
+};

--- a/apps/desktop/src/features/providers/components/CostBadge/index.test.tsx
+++ b/apps/desktop/src/features/providers/components/CostBadge/index.test.tsx
@@ -7,10 +7,10 @@ import { CostBadge } from './index';
 afterEach(cleanup);
 
 describe('CostBadge', () => {
-  it('renders a split dollars/cents formatted value', () => {
-    render(<CostBadge value={1.23} />);
-    expect(screen.getByText('$1')).toBeDefined();
-    expect(screen.getByText('.23')).toBeDefined();
+  it('renders the formatted value once', () => {
+    const { container } = render(<CostBadge value={1.23} />);
+    expect(screen.getByText('$1.23')).toBeDefined();
+    expect(container.querySelectorAll('span')).toHaveLength(1);
   });
 
   it('renders zero as $0', () => {

--- a/apps/desktop/src/features/providers/components/CostBadge/index.tsx
+++ b/apps/desktop/src/features/providers/components/CostBadge/index.tsx
@@ -6,27 +6,8 @@ export type Props = {
   readonly title?: string;
 };
 
-export const CostBadge = ({ value, className, title }: Props) => {
-  const formatted = formatUsd(value);
-  const split = splitDollarsCents(formatted);
-  return (
-    <span className={cn('inline-flex items-baseline tabular-nums', className)} title={title}>
-      {split ? (
-        <>
-          <span>{split.dollars}</span>
-          <span className="text-[0.78em] opacity-70">{split.cents}</span>
-        </>
-      ) : (
-        <span>{formatted}</span>
-      )}
-    </span>
-  );
-};
-
-function splitDollarsCents(formatted: string): { dollars: string; cents: string } | null {
-  const m = formatted.match(/^(\$\d+)(\.\d+)$/);
-  if (!m) {
-    return null;
-  }
-  return { dollars: m[1]!, cents: m[2]! };
-}
+export const CostBadge = ({ value, className, title }: Props) => (
+  <span className={cn('tabular-nums', className)} title={title}>
+    {formatUsd(value)}
+  </span>
+);

--- a/apps/desktop/src/features/session/agent-row-format.test.ts
+++ b/apps/desktop/src/features/session/agent-row-format.test.ts
@@ -43,9 +43,9 @@ describe('formatCost', () => {
     expect(formatCost(0.0099)).toBe('<$0.01');
   });
 
-  it('shows 3 decimals between 1 cent and 1 dollar', () => {
-    expect(formatCost(0.012)).toBe('$0.012');
-    expect(formatCost(0.999)).toBe('$0.999');
+  it('shows 2 decimals from a cent up', () => {
+    expect(formatCost(0.012)).toBe('$0.01');
+    expect(formatCost(0.999)).toBe('$1.00');
   });
 
   it('shows 2 decimals at or above 1 dollar', () => {

--- a/apps/desktop/src/features/session/components/sessionCardShell.test.ts
+++ b/apps/desktop/src/features/session/components/sessionCardShell.test.ts
@@ -4,14 +4,27 @@ import { sessionCardShell } from './sessionCardShell';
 describe('sessionCardShell', () => {
   it('tints the border by stage', () => {
     expect(sessionCardShell({ stage: 'running' })).toContain('border-info/50');
+    expect(sessionCardShell({ stage: 'running' })).toContain('spin-border spin-border-info');
     expect(sessionCardShell({ stage: 'attention' })).toContain('border-warning/50');
-    expect(sessionCardShell({ stage: 'done' })).toContain('border-transparent');
+    expect(sessionCardShell({ stage: 'attention' })).not.toContain('spin-border');
+    expect(sessionCardShell({ stage: 'done' })).toContain('border-border-soft');
+    expect(sessionCardShell({ stage: 'done' })).not.toContain('spin-border');
+  });
+
+  it('rests on the elevated surface without a shadow', () => {
+    const classes = sessionCardShell({ stage: 'building' });
+    expect(classes).toContain('bg-elevated');
+    expect(classes).toContain('text-foreground');
+    expect(classes).not.toContain('shadow-sm');
+    expect(classes).not.toContain('bg-muted/40');
+    expect(classes).not.toContain('text-foreground/70');
   });
 
   it('lets selection win over the stage tint', () => {
     const classes = sessionCardShell({ stage: 'running', selected: true });
     expect(classes).toContain('border-primary');
     expect(classes).not.toContain('border-info/50');
+    expect(classes).not.toContain('spin-border');
   });
 
   it('lifts the active card and neutralises its border', () => {

--- a/apps/desktop/src/features/session/components/sessionCardShell.ts
+++ b/apps/desktop/src/features/session/components/sessionCardShell.ts
@@ -8,19 +8,24 @@ type Params = {
   readonly dimmed?: boolean;
 };
 
+type RestBorderParams = Pick<Params, 'stage' | 'selected'>;
+
+const restBorder = ({ stage, selected }: RestBorderParams): string => {
+  if (selected === true) {
+    return 'border-primary bg-primary/5';
+  }
+  if (stage === 'running') {
+    return 'border-info/50 spin-border spin-border-info';
+  }
+  if (stage === 'attention') {
+    return 'border-warning/50';
+  }
+  return 'border-border-soft hover:border-border';
+};
+
 export const sessionCardShell = ({ stage, selected, active, dimmed }: Params): string =>
   cn(
-    'rounded-lg border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]',
-    active === true
-      ? 'bg-elevated text-foreground shadow-sm'
-      : 'bg-muted/40 text-foreground/70 hover:bg-muted/60 hover:text-foreground',
-    active === true
-      ? 'border-border'
-      : stage === 'running'
-        ? 'border-info/50'
-        : stage === 'attention'
-          ? 'border-warning/50'
-          : 'border-transparent',
-    selected === true && 'border-primary bg-primary/5 text-foreground',
+    'rounded-lg border bg-elevated text-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]',
+    active === true ? 'border-border shadow-sm' : restBorder({ stage, selected }),
     dimmed === true && 'opacity-50',
   );

--- a/apps/desktop/src/features/workspace/components/ProjectFilter/index.tsx
+++ b/apps/desktop/src/features/workspace/components/ProjectFilter/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef } from 'react';
 import { ListFilter, X } from 'lucide-react';
-import { AnchoredPopover, cn, Divider, Eyebrow, Tooltip, useDropdown } from '@goodboy/ui';
+import { AnchoredPopover, cn, Divider, Eyebrow, IconButton, useDropdown } from '@goodboy/ui';
 import type { Session, WorkspaceId } from '@goodboy/types';
 import {
   EMPTY_ARRAY,
@@ -8,6 +8,7 @@ import {
   useAppStore,
   useSelectedProjectIds,
 } from '../../../../store';
+import { ICON_SIZE } from '../../../../shared/components/conceptIcons';
 import { ProjectFilterOption } from './ProjectFilterOption';
 
 type Props = {
@@ -109,27 +110,24 @@ export const ProjectFilter = ({ workspaceId, sessions }: Props) => {
       className="py-1"
       hasBackdrop
       trigger={
-        <Tooltip content="Filter by project" side="bottom">
-          <button
-            ref={triggerRef}
-            type="button"
-            onClick={toggle}
-            aria-haspopup="dialog"
-            aria-expanded={open}
-            aria-label={
-              activeCount > 0 ? `Project filter, ${activeCount} active` : 'Project filter'
-            }
-            className={cn(
-              'inline-flex shrink-0 items-center gap-1 rounded px-1 py-0.5 text-2xs font-medium motion-safe:transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/40',
-              activeCount > 0 || open
-                ? 'bg-primary/10 text-primary'
-                : 'text-muted-foreground/70 hover:bg-foreground/10 hover:text-foreground',
-            )}
-          >
-            <ListFilter size={11} aria-hidden />
-            {activeCount > 0 ? <span className="tabular-nums">{activeCount}</span> : null}
-          </button>
-        </Tooltip>
+        <IconButton
+          ref={triggerRef}
+          variant="ghost"
+          icon={ListFilter}
+          iconSize={ICON_SIZE.row}
+          label={activeCount > 0 ? `Project filter, ${activeCount} active` : 'Project filter'}
+          tooltip={
+            activeCount > 0 ? `Filter by project, ${activeCount} active` : 'Filter by project'
+          }
+          onClick={toggle}
+          aria-haspopup="dialog"
+          aria-expanded={open}
+          className={cn(
+            'size-7 shrink-0',
+            (activeCount > 0 || open) &&
+              'bg-primary/10 text-primary hover:bg-primary/10 hover:text-primary',
+          )}
+        />
       }
     >
       <div className="flex items-center justify-between gap-2 px-3 py-2">

--- a/apps/desktop/src/features/workspace/components/ProjectGitPill/ProjectGitPill.test.tsx
+++ b/apps/desktop/src/features/workspace/components/ProjectGitPill/ProjectGitPill.test.tsx
@@ -63,9 +63,9 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe('ProjectGitPill', () => {
-  it('shows the total actionable count when behind and dirty', () => {
+  it('names what the count counts instead of showing a bare number', () => {
     renderPill({ status: statusOf({ behind: 2, changed: 3, unmerged: 1 }) });
-    expect(screen.getByTestId('project-git-count').textContent).toBe('6');
+    expect(screen.getByTestId('project-git-count').textContent).toBe('4 uncommitted');
   });
 
   it('shows no badge when the checkout is clean', () => {
@@ -130,7 +130,7 @@ describe('ProjectGitPills', () => {
     status,
   });
 
-  it('renders one aggregate trigger with the summed actionable count', () => {
+  it('renders one aggregate trigger naming the summed uncommitted files', () => {
     render(
       <ProjectGitPills
         entries={[
@@ -141,7 +141,7 @@ describe('ProjectGitPills', () => {
       />,
     );
     expect(screen.getByRole('button', { name: '3 repository git statuses' })).toBeDefined();
-    expect(screen.getByTestId('project-git-summary-count').textContent).toBe('6');
+    expect(screen.getByTestId('project-git-summary-count').textContent).toBe('4 uncommitted');
   });
 
   it('shows the aggregate warning instead of the count', () => {

--- a/apps/desktop/src/features/workspace/components/ProjectGitPill/ProjectGitPill.tsx
+++ b/apps/desktop/src/features/workspace/components/ProjectGitPill/ProjectGitPill.tsx
@@ -19,7 +19,9 @@ export const ProjectGitPill = ({ project, status, shouldShowProjectName }: Props
     expectedHeight: isSetup ? 520 : 260,
     align: 'end',
   });
-  const { actionableCount, branch, isWarning } = projectGitPresentationOf({ status });
+  const { actionableCount, uncommittedCount, branch, isWarning } = projectGitPresentationOf({
+    status,
+  });
   const label = shouldShowProjectName ? `${project.name} · ${branch}` : branch;
   return (
     <AnchoredPopover
@@ -47,12 +49,12 @@ export const ProjectGitPill = ({ project, status, shouldShowProjectName }: Props
             <span data-testid="project-git-warning" className="flex items-center text-warning">
               <AlertTriangle size={10} aria-hidden />
             </span>
-          ) : actionableCount > 0 ? (
+          ) : uncommittedCount > 0 ? (
             <span
               data-testid="project-git-count"
-              className="flex min-w-3.5 items-center justify-center rounded-full bg-warning px-1 text-3xs font-semibold leading-3.5 text-warning-foreground"
+              className="shrink-0 text-2xs tabular-nums text-warning"
             >
-              {actionableCount}
+              {uncommittedCount} uncommitted
             </span>
           ) : null}
         </button>

--- a/apps/desktop/src/features/workspace/components/ProjectGitPill/ProjectGitPill.tsx
+++ b/apps/desktop/src/features/workspace/components/ProjectGitPill/ProjectGitPill.tsx
@@ -50,7 +50,7 @@ export const ProjectGitPill = ({ project, status, shouldShowProjectName }: Props
           ) : actionableCount > 0 ? (
             <span
               data-testid="project-git-count"
-              className="flex min-w-3.5 items-center justify-center rounded-full bg-warning px-1 text-[9px] font-semibold leading-3.5 text-warning-foreground"
+              className="flex min-w-3.5 items-center justify-center rounded-full bg-warning px-1 text-3xs font-semibold leading-3.5 text-warning-foreground"
             >
               {actionableCount}
             </span>

--- a/apps/desktop/src/features/workspace/components/ProjectGitPill/ProjectGitSummaryPill.tsx
+++ b/apps/desktop/src/features/workspace/components/ProjectGitPill/ProjectGitSummaryPill.tsx
@@ -13,6 +13,7 @@ type Props = {
 
 type SummaryEntry = ProjectGitStatusEntry & {
   readonly actionableCount: number;
+  readonly uncommittedCount: number;
   readonly branch: string;
   readonly isWarning: boolean;
 };
@@ -44,6 +45,10 @@ export const ProjectGitSummaryPill = ({ entries }: Props) => {
     summaryEntries.find((entry) => entry.project.id === selectedProjectId) ?? null;
   const hasWarning = summaryEntries.some((entry) => entry.isWarning);
   const actionableCount = summaryEntries.reduce((total, entry) => total + entry.actionableCount, 0);
+  const uncommittedCount = summaryEntries.reduce(
+    (total, entry) => total + entry.uncommittedCount,
+    0,
+  );
 
   return (
     <AnchoredPopover
@@ -74,12 +79,12 @@ export const ProjectGitSummaryPill = ({ entries }: Props) => {
             >
               <AlertTriangle size={10} aria-hidden />
             </span>
-          ) : actionableCount > 0 ? (
+          ) : uncommittedCount > 0 ? (
             <span
               data-testid="project-git-summary-count"
-              className="flex min-w-3.5 items-center justify-center rounded-full bg-warning px-1 text-3xs font-semibold leading-3.5 text-warning-foreground"
+              className="shrink-0 text-2xs tabular-nums text-warning"
             >
-              {actionableCount}
+              {uncommittedCount} uncommitted
             </span>
           ) : null}
         </button>
@@ -100,12 +105,12 @@ export const ProjectGitSummaryPill = ({ entries }: Props) => {
               <span className="shrink-0 font-mono text-2xs text-muted-foreground">
                 {entry.branch}
               </span>
-              <span className="flex w-5 shrink-0 justify-end">
+              <span className="flex shrink-0 justify-end">
                 {entry.isWarning ? (
                   <AlertTriangle size={11} aria-label="Warning" className="text-warning" />
-                ) : entry.actionableCount > 0 ? (
-                  <span className="flex min-w-3.5 items-center justify-center rounded-full bg-warning px-1 text-3xs font-semibold leading-3.5 text-warning-foreground">
-                    {entry.actionableCount}
+                ) : entry.uncommittedCount > 0 ? (
+                  <span className="text-2xs tabular-nums text-warning">
+                    {entry.uncommittedCount} uncommitted
                   </span>
                 ) : null}
               </span>

--- a/apps/desktop/src/features/workspace/components/ProjectGitPill/ProjectGitSummaryPill.tsx
+++ b/apps/desktop/src/features/workspace/components/ProjectGitPill/ProjectGitSummaryPill.tsx
@@ -77,7 +77,7 @@ export const ProjectGitSummaryPill = ({ entries }: Props) => {
           ) : actionableCount > 0 ? (
             <span
               data-testid="project-git-summary-count"
-              className="flex min-w-3.5 items-center justify-center rounded-full bg-warning px-1 text-[9px] font-semibold leading-3.5 text-warning-foreground"
+              className="flex min-w-3.5 items-center justify-center rounded-full bg-warning px-1 text-3xs font-semibold leading-3.5 text-warning-foreground"
             >
               {actionableCount}
             </span>
@@ -104,7 +104,7 @@ export const ProjectGitSummaryPill = ({ entries }: Props) => {
                 {entry.isWarning ? (
                   <AlertTriangle size={11} aria-label="Warning" className="text-warning" />
                 ) : entry.actionableCount > 0 ? (
-                  <span className="flex min-w-3.5 items-center justify-center rounded-full bg-warning px-1 text-[9px] font-semibold leading-3.5 text-warning-foreground">
+                  <span className="flex min-w-3.5 items-center justify-center rounded-full bg-warning px-1 text-3xs font-semibold leading-3.5 text-warning-foreground">
                     {entry.actionableCount}
                   </span>
                 ) : null}

--- a/apps/desktop/src/features/workspace/components/ProjectGitPill/projectGitPresentationOf.ts
+++ b/apps/desktop/src/features/workspace/components/ProjectGitPill/projectGitPresentationOf.ts
@@ -7,6 +7,7 @@ type Params = {
 
 type Presentation = {
   readonly actionableCount: number;
+  readonly uncommittedCount: number;
   readonly branch: string;
   readonly isWarning: boolean;
 };
@@ -51,16 +52,19 @@ export const projectGitPresentationOf = ({ status }: Params): Presentation => {
   if (!isReady) {
     return {
       actionableCount: 0,
+      uncommittedCount: 0,
       branch,
       isWarning: status != null,
     };
   }
-  const actionableCount =
-    (distanceBehind({ distance: status.upstreamDistance }) ?? 0) +
+  const uncommittedCount =
     (changedCount({ workingTree: status.workingTree }) ?? 0) +
     (unmergedCount({ workingTree: status.workingTree }) ?? 0);
+  const actionableCount =
+    (distanceBehind({ distance: status.upstreamDistance }) ?? 0) + uncommittedCount;
   return {
     actionableCount,
+    uncommittedCount,
     branch,
     isWarning: hasReadFailure({ status }),
   };

--- a/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/ProjectMountChips.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/ProjectMountChips.tsx
@@ -1,4 +1,4 @@
-import { Chip, Tooltip } from '@goodboy/ui';
+import { Chip, Tooltip, cn } from '@goodboy/ui';
 import type { SessionProjectMount } from '@goodboy/types';
 
 const IDENTITY_SLOT = 'w-24 shrink-0';
@@ -15,31 +15,34 @@ export const ProjectMountChips = ({ mounts }: Props) => {
   if (mounts.length === 1) {
     return (
       <Tooltip content={first.mountName} side="top">
-        <Chip
-          tone="neutral"
-          size="xs"
-          bordered={false}
-          label={<span className="min-w-0 truncate">{first.mountName}</span>}
-          className={IDENTITY_SLOT}
-        />
+        <span className={cn('inline-flex min-w-0', IDENTITY_SLOT)}>
+          <Chip
+            tone="neutral"
+            size="xs"
+            bordered={false}
+            label={<span className="min-w-0 truncate">{first.mountName}</span>}
+            className="w-full"
+          />
+        </span>
       </Tooltip>
     );
   }
   const names = mounts.map((mount) => mount.mountName).join(', ');
   return (
     <Tooltip content={names} side="top">
-      <Chip
-        tone="neutral"
-        size="xs"
-        bordered={false}
-        ariaLabel={`${mounts.length} projects: ${names}`}
-        label={
-          <span className="min-w-0 truncate">
-            <span className="tabular-nums">{mounts.length}</span> projects
-          </span>
-        }
-        className="shrink-0"
-      />
+      <span className="inline-flex shrink-0">
+        <Chip
+          tone="neutral"
+          size="xs"
+          bordered={false}
+          ariaLabel={`${mounts.length} projects: ${names}`}
+          label={
+            <span className="min-w-0 truncate">
+              <span className="tabular-nums">{mounts.length}</span> projects
+            </span>
+          }
+        />
+      </span>
     </Tooltip>
   );
 };

--- a/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/ProjectMountChips.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/ProjectMountChips.tsx
@@ -1,7 +1,7 @@
 import { Chip, Tooltip } from '@goodboy/ui';
 import type { SessionProjectMount } from '@goodboy/types';
 
-const SLOT_WIDTH = 'w-20 shrink-0';
+const IDENTITY_SLOT = 'w-24 shrink-0';
 
 type Props = {
   readonly mounts: ReadonlyArray<SessionProjectMount>;
@@ -20,7 +20,7 @@ export const ProjectMountChips = ({ mounts }: Props) => {
           size="xs"
           bordered={false}
           label={<span className="min-w-0 truncate">{first.mountName}</span>}
-          className={SLOT_WIDTH}
+          className={IDENTITY_SLOT}
         />
       </Tooltip>
     );
@@ -38,7 +38,7 @@ export const ProjectMountChips = ({ mounts }: Props) => {
             <span className="tabular-nums">{mounts.length}</span> projects
           </span>
         }
-        className={SLOT_WIDTH}
+        className="shrink-0"
       />
     </Tooltip>
   );

--- a/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/ProjectMountChips.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/ProjectMountChips.tsx
@@ -1,0 +1,45 @@
+import { Chip, Tooltip } from '@goodboy/ui';
+import type { SessionProjectMount } from '@goodboy/types';
+
+const SLOT_WIDTH = 'w-20 shrink-0';
+
+type Props = {
+  readonly mounts: ReadonlyArray<SessionProjectMount>;
+};
+
+export const ProjectMountChips = ({ mounts }: Props) => {
+  const [first] = mounts;
+  if (first === undefined) {
+    return null;
+  }
+  if (mounts.length === 1) {
+    return (
+      <Tooltip content={first.mountName} side="top">
+        <Chip
+          tone="neutral"
+          size="xs"
+          bordered={false}
+          label={<span className="min-w-0 truncate">{first.mountName}</span>}
+          className={SLOT_WIDTH}
+        />
+      </Tooltip>
+    );
+  }
+  const names = mounts.map((mount) => mount.mountName).join(', ');
+  return (
+    <Tooltip content={names} side="top">
+      <Chip
+        tone="neutral"
+        size="xs"
+        bordered={false}
+        ariaLabel={`${mounts.length} projects: ${names}`}
+        label={
+          <span className="min-w-0 truncate">
+            <span className="tabular-nums">{mounts.length}</span> projects
+          </span>
+        }
+        className={SLOT_WIDTH}
+      />
+    </Tooltip>
+  );
+};

--- a/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.test.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.test.tsx
@@ -147,13 +147,17 @@ describe('StageBoardCard layout', () => {
     render(<StageBoardCard session={session} nav={nav} />);
     const card = screen.getAllByRole('button')[0];
     const title = screen.getByText(session.goal);
-    const metaRow = title.parentElement?.nextElementSibling?.nextElementSibling;
+    const metaRow = card?.children[2];
     expect(card?.className).toContain('h-28');
+    expect(card?.className).toContain('gap-y-1');
     expect(card?.className).not.toContain('h-[8.25rem]');
     expect(card?.className).not.toContain('shadow-sm');
     expect(title.className).toContain('line-clamp-2');
     expect(title.className).toContain('min-h-10');
     expect(title.className).toContain('leading-5');
+    expect(metaRow?.className).toContain('col-span-2');
+    expect(metaRow?.className).toContain('col-start-1');
+    expect(metaRow?.className).toContain('row-start-2');
     expect(metaRow?.className).toContain('h-5');
   });
 
@@ -162,6 +166,7 @@ describe('StageBoardCard layout', () => {
     expect(screen.getByText(session.goal).closest('[data-tooltip]')).toBeNull();
     expect(screen.queryByTestId('status-dot')).toBeNull();
     expect(screen.getByText('no PR yet').className).toContain('truncate');
+    expect(screen.getByText('no PR yet').parentElement?.children.length).toBe(2);
   });
 
   it('renders a backticked goal as inline code and keeps the tooltip plain', () => {
@@ -506,7 +511,31 @@ describe('StageBoardCard footer', () => {
     ]);
     expect(right?.firstElementChild).toBe(cost);
     expect(right?.children.length).toBe(1);
+    expect(right?.className).toContain('group-hover/session-card:opacity-0');
+    expect(right?.className).toContain('group-focus-within/session-card:opacity-0');
     expect(metaRow?.querySelector('.lucide-chevron-right')).toBeNull();
+  });
+
+  it('gives the project chip an ellipsis instead of a hard clip', () => {
+    state.projects = [{}, {}];
+    state.sessionProjectMounts = {
+      [SESSION_ID]: [{ projectId: 'project-1', mountName: 'gateway' }],
+    };
+    render(<StageBoardCard session={session} nav={nav} />);
+    const chipLabel = screen.getByText('gateway');
+    expect(chipLabel.className).toContain('truncate');
+    expect(chipLabel.closest('span.inline-flex')?.className).toContain('min-w-0');
+    expect(chipLabel.closest('span.inline-flex')?.className).not.toContain('shrink-0');
+  });
+
+  it('keeps the lifecycle slot bottom right over the trailing metadata', () => {
+    render(<StageBoardCard session={session} nav={nav} />);
+    const card = screen.getAllByRole('button')[0];
+    const group = screen.getByRole('group', { name: 'Session lifecycle actions' });
+    expect(group.className).toContain('col-start-2');
+    expect(group.className).toContain('row-start-2');
+    expect(group.className).toContain('justify-self-end');
+    expect(card?.lastElementChild).toBe(group);
   });
 
   it('keeps cost and age at the metadata grade', () => {

--- a/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.test.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.test.tsx
@@ -16,7 +16,7 @@ import type { BoardNavigation } from '../useBoardNavigation';
 type MockDynamicAction = {
   readonly key: string;
   readonly icon: LucideIcon;
-  readonly tone: 'primary' | 'warning';
+  readonly tone: 'primary' | 'warning' | 'danger';
   readonly label: string;
   readonly onClick: () => void;
 };
@@ -147,19 +147,19 @@ describe('StageBoardCard layout', () => {
     render(<StageBoardCard session={session} nav={nav} />);
     const card = screen.getAllByRole('button')[0];
     const title = screen.getByText(session.goal);
-    const footer =
-      title.closest('[data-tooltip]')?.parentElement?.nextElementSibling?.nextElementSibling;
-    expect(card?.className).toContain('h-[8.25rem]');
+    const metaRow = title.parentElement?.nextElementSibling?.nextElementSibling;
+    expect(card?.className).toContain('h-28');
+    expect(card?.className).not.toContain('h-[8.25rem]');
+    expect(card?.className).not.toContain('shadow-sm');
     expect(title.className).toContain('line-clamp-2');
     expect(title.className).toContain('min-h-10');
-    expect(footer?.className).toContain('flex-nowrap');
-    expect(footer?.className).toContain('min-h-5');
+    expect(title.className).toContain('leading-5');
+    expect(metaRow?.className).toContain('h-5');
   });
 
-  it('shows the reason under the goal and in the title tooltip without a status dot', () => {
+  it('shows the reason under the goal without a title tooltip or status dot', () => {
     render(<StageBoardCard session={session} nav={nav} />);
-    const tooltip = screen.getByText(session.goal).closest('[data-tooltip]');
-    expect(tooltip?.getAttribute('data-tooltip')).toBe(`${session.goal} · no PR yet`);
+    expect(screen.getByText(session.goal).closest('[data-tooltip]')).toBeNull();
     expect(screen.queryByTestId('status-dot')).toBeNull();
     expect(screen.getByText('no PR yet').className).toContain('truncate');
   });
@@ -170,14 +170,13 @@ describe('StageBoardCard layout', () => {
     const title = screen.getByText(/run/);
     expect(title.querySelector('code')?.textContent).toBe('/explore');
     expect(title.textContent).not.toContain('`');
-    expect(title.closest('[data-tooltip]')?.getAttribute('data-tooltip')).toBe(
-      'run /explore first · no PR yet',
-    );
+    expect(title.closest('[data-tooltip]')).toBeNull();
   });
 
   it('points at the session with a trailing chevron', () => {
     render(<StageBoardCard session={session} nav={nav} />);
     expect(document.querySelector('.lucide-chevron-right')).not.toBeNull();
+    expect(document.querySelector('.lucide-chevron-right')?.closest('[role="group"]')).toBeNull();
   });
 
   it('renders the last update age when the session carries a timestamp', () => {
@@ -349,18 +348,87 @@ describe('StageBoardCard actions visibility', () => {
     const nonAttention = screen.getByLabelText('run next step');
     expect(attention.className.includes(' bg-warning/5')).toBe(true);
     expect(attention.className).toContain('text-warning');
+    expect(attention.className).not.toContain('opacity-0');
     expect(nonAttention.className).not.toContain('bg-warning/5');
     expect(nonAttention.className.includes(' bg-primary/5')).toBe(false);
+    expect(nonAttention.className).toContain('opacity-0');
+    expect(nonAttention.className).toContain('group-hover/session-card:opacity-100');
   });
 
-  it('separates delete from archive with a divider in the lifecycle group', () => {
+  it('highlights a danger action', () => {
+    useDynamicActionsMock.mockReturnValue([
+      {
+        key: 'blocked',
+        icon: HelpCircle,
+        tone: 'danger',
+        label: 'Confirm skip and continue',
+        onClick: vi.fn(),
+      },
+    ]);
+    render(<StageBoardCard session={session} nav={nav} />);
+    const action = screen.getByLabelText('Confirm skip and continue');
+    expect(action.className).toContain('bg-danger/5');
+    expect(action.className).toContain('text-danger');
+  });
+
+  it('reveals editor and terminal on hover instead of showing them at rest', () => {
+    render(<StageBoardCard session={session} nav={nav} />);
+    for (const label of ['Open in editor', 'Open terminal']) {
+      const control = screen.getByLabelText(label);
+      expect(control.className).toContain('opacity-0');
+      expect(control.className).toContain('group-hover/session-card:opacity-100');
+      expect(control.className).toContain('group-focus-within/session-card:opacity-100');
+      expect(control.className).not.toContain('agent-card');
+    }
+  });
+
+  it('renders the revealed extras before the visible action', () => {
+    useDynamicActionsMock.mockReturnValue([
+      {
+        key: 'questions',
+        icon: HelpCircle,
+        tone: 'warning',
+        label: '1 open question',
+        onClick: vi.fn(),
+      },
+      {
+        key: 'run',
+        icon: Play,
+        tone: 'primary',
+        label: 'run next step',
+        onClick: vi.fn(),
+      },
+    ]);
+    render(<StageBoardCard session={session} nav={nav} />);
+    const group = screen.getByRole('group', { name: 'Session quick actions' });
+    expect(Array.from(group.children)).toEqual([
+      screen.getByLabelText('run next step').parentElement,
+      screen.getByLabelText('Open in editor').parentElement,
+      screen.getByLabelText('Open terminal').parentElement,
+      screen.getByLabelText('1 open question').parentElement,
+    ]);
+  });
+
+  it('reveals archive and delete with no divider', () => {
     render(<StageBoardCard session={session} nav={nav} />);
     const group = screen.getByRole('group', { name: 'Session lifecycle actions' });
-    const archive = screen.getByLabelText('Archive').parentElement;
-    const del = screen.getByLabelText('Delete').parentElement;
-    const divider = group.querySelector('[role="separator"]');
-    expect(divider).not.toBeNull();
-    expect(Array.from(group.children)).toEqual([archive, divider, del]);
+    const archive = screen.getByLabelText('Archive');
+    const del = screen.getByLabelText('Delete');
+    expect(group.querySelector('[role="separator"]')).toBeNull();
+    expect(Array.from(group.children)).toEqual([archive.parentElement, del.parentElement]);
+    expect(archive.className).toContain('opacity-0');
+    expect(del.className).toContain('opacity-0');
+  });
+
+  it('shows restore as the one visible action on an archived card', () => {
+    render(<StageBoardCard session={session} nav={nav} archived />);
+    const restore = screen.getByLabelText('Restore');
+    expect(restore.className).not.toContain('opacity-0');
+    const group = screen.getByRole('group', { name: 'Session quick actions' });
+    expect(group.contains(restore)).toBe(true);
+    expect(screen.queryByLabelText('Archive')).toBeNull();
+    expect(screen.queryByLabelText('Open in editor')).toBeNull();
+    expect(screen.getByLabelText('Delete').className).toContain('opacity-0');
   });
 });
 
@@ -421,20 +489,33 @@ describe('StageBoardCard footer', () => {
     const task = screen.getByLabelText('GB-123 from Linear');
     const cost = document.querySelector('[title="Session spend: $1.25 (excludes summarizer)"]');
     const auto = screen.getByText('Autorun');
-    const footer = agents.closest('[data-tooltip]')?.parentElement;
+    const metaRow = agents.closest('[data-tooltip]')?.parentElement?.parentElement;
+    const left = metaRow?.firstElementChild;
+    const right = metaRow?.lastElementChild;
     expect(agents.querySelector('.lucide-bot')).not.toBeNull();
     expect(screen.queryByText('GB-123')).toBeNull();
     expect(cost).not.toBeNull();
     expect(auto).toBeDefined();
     expect(auto.className).toContain('text-primary');
     expect(auto.className).not.toContain('text-danger');
-    expect(Array.from(footer?.children ?? []).slice(0, 4)).toEqual([
+    expect(auto.className).not.toContain('ring-1');
+    expect(Array.from(left?.children ?? [])).toEqual([
       agents.closest('[data-tooltip]'),
-      task,
-      cost,
       auto,
+      task,
     ]);
-    expect(footer?.lastElementChild?.classList.contains('lucide-chevron-right')).toBe(true);
+    expect(right?.firstElementChild).toBe(cost);
+    expect(right?.children.length).toBe(1);
+    expect(metaRow?.querySelector('.lucide-chevron-right')).toBeNull();
+  });
+
+  it('keeps cost and age at the metadata grade', () => {
+    hooks.cost = 1.25;
+    const updated = { ...session, updatedAt: new Date(Date.now() - 7_200_000).toISOString() };
+    render(<StageBoardCard session={updated as unknown as Session} nav={nav} />);
+    const cost = document.querySelector('[title="Session spend: $1.25 (excludes summarizer)"]');
+    expect(cost?.className).toContain('text-3xs');
+    expect(screen.getByText('2h ago').className).toContain('text-3xs');
   });
 
   it('singularizes the agent count label at one agent', () => {

--- a/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.test.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.test.tsx
@@ -526,11 +526,11 @@ describe('StageBoardCard footer', () => {
     };
     render(<StageBoardCard session={session} nav={nav} />);
     const chipLabel = screen.getByText('gateway');
-    const chip = chipLabel.closest('span.inline-flex');
+    const slot = chipLabel.closest('.w-24');
     expect(chipLabel.className).toContain('truncate');
-    expect(chip?.className).toContain('w-24');
-    expect(chip?.className).toContain('shrink-0');
-    expect(chip?.closest('[data-tooltip]')?.getAttribute('data-tooltip')).toBe('gateway');
+    expect(slot?.className).toContain('w-24');
+    expect(slot?.className).toContain('shrink-0');
+    expect(slot?.closest('[data-tooltip]')?.getAttribute('data-tooltip')).toBe('gateway');
   });
 
   it('collapses several projects into one count naming them', () => {

--- a/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.test.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.test.tsx
@@ -528,7 +528,7 @@ describe('StageBoardCard footer', () => {
     const chipLabel = screen.getByText('gateway');
     const chip = chipLabel.closest('span.inline-flex');
     expect(chipLabel.className).toContain('truncate');
-    expect(chip?.className).toContain('w-20');
+    expect(chip?.className).toContain('w-24');
     expect(chip?.className).toContain('shrink-0');
     expect(chip?.closest('[data-tooltip]')?.getAttribute('data-tooltip')).toBe('gateway');
   });
@@ -546,7 +546,7 @@ describe('StageBoardCard footer', () => {
     expect(screen.getByLabelText('2 projects: core-api, web-console')).toBeDefined();
     const chip = screen.getByLabelText('2 projects: core-api, web-console');
     expect(chip.textContent).toBe('2 projects');
-    expect(chip.className).toContain('w-20');
+    expect(chip.className).not.toContain('w-24');
     expect(chip.closest('[data-tooltip]')?.getAttribute('data-tooltip')).toBe(
       'core-api, web-console',
     );

--- a/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.test.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.test.tsx
@@ -159,6 +159,7 @@ describe('StageBoardCard layout', () => {
     expect(metaRow?.className).toContain('col-start-1');
     expect(metaRow?.className).toContain('row-start-2');
     expect(metaRow?.className).toContain('h-5');
+    expect(metaRow?.className).not.toContain('self-center');
   });
 
   it('shows the reason under the goal without a title tooltip or status dot', () => {
@@ -493,7 +494,7 @@ describe('StageBoardCard footer', () => {
     const agents = screen.getByLabelText('2 agents');
     const task = screen.getByLabelText('GB-123 from Linear');
     const cost = document.querySelector('[title="Session spend: $1.25 (excludes summarizer)"]');
-    const auto = screen.getByText('Autorun');
+    const auto = screen.getByLabelText('Autorun');
     const metaRow = agents.closest('[data-tooltip]')?.parentElement?.parentElement;
     const left = metaRow?.firstElementChild;
     const right = metaRow?.lastElementChild;
@@ -504,9 +505,11 @@ describe('StageBoardCard footer', () => {
     expect(auto.className).toContain('text-primary');
     expect(auto.className).not.toContain('text-danger');
     expect(auto.className).not.toContain('ring-1');
+    expect(screen.queryByText('Autorun')).toBeNull();
+    expect(auto.closest('[data-tooltip]')?.getAttribute('data-tooltip')).toBe('Autorun');
     expect(Array.from(left?.children ?? [])).toEqual([
       agents.closest('[data-tooltip]'),
-      auto,
+      auto.closest('[data-tooltip]'),
       task,
     ]);
     expect(right?.firstElementChild).toBe(cost);
@@ -535,6 +538,7 @@ describe('StageBoardCard footer', () => {
     expect(group.className).toContain('col-start-2');
     expect(group.className).toContain('row-start-2');
     expect(group.className).toContain('justify-self-end');
+    expect(group.className).toContain('h-5');
     expect(card?.lastElementChild).toBe(group);
   });
 

--- a/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.test.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.test.tsx
@@ -519,16 +519,37 @@ describe('StageBoardCard footer', () => {
     expect(metaRow?.querySelector('.lucide-chevron-right')).toBeNull();
   });
 
-  it('gives the project chip an ellipsis instead of a hard clip', () => {
+  it('holds the project slot at one width and truncates the name inside it', () => {
     state.projects = [{}, {}];
     state.sessionProjectMounts = {
       [SESSION_ID]: [{ projectId: 'project-1', mountName: 'gateway' }],
     };
     render(<StageBoardCard session={session} nav={nav} />);
     const chipLabel = screen.getByText('gateway');
+    const chip = chipLabel.closest('span.inline-flex');
     expect(chipLabel.className).toContain('truncate');
-    expect(chipLabel.closest('span.inline-flex')?.className).toContain('min-w-0');
-    expect(chipLabel.closest('span.inline-flex')?.className).not.toContain('shrink-0');
+    expect(chip?.className).toContain('w-20');
+    expect(chip?.className).toContain('shrink-0');
+    expect(chip?.closest('[data-tooltip]')?.getAttribute('data-tooltip')).toBe('gateway');
+  });
+
+  it('collapses several projects into one count naming them', () => {
+    state.projects = [{}, {}];
+    state.sessionProjectMounts = {
+      [SESSION_ID]: [
+        { projectId: 'project-1', mountName: 'core-api' },
+        { projectId: 'project-2', mountName: 'web-console' },
+      ],
+    };
+    render(<StageBoardCard session={session} nav={nav} />);
+    expect(screen.queryByText('core-api')).toBeNull();
+    expect(screen.getByLabelText('2 projects: core-api, web-console')).toBeDefined();
+    const chip = screen.getByLabelText('2 projects: core-api, web-console');
+    expect(chip.textContent).toBe('2 projects');
+    expect(chip.className).toContain('w-20');
+    expect(chip.closest('[data-tooltip]')?.getAttribute('data-tooltip')).toBe(
+      'core-api, web-console',
+    );
   });
 
   it('keeps the lifecycle slot bottom right over the trailing metadata', () => {

--- a/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.tsx
@@ -236,7 +236,7 @@ export const StageBoardCard = memo(function StageBoardCard({
         />
       </span>
 
-      <span className="col-span-2 col-start-1 row-start-2 flex h-5 min-w-0 items-center gap-2 self-center">
+      <span className="col-span-2 col-start-1 row-start-2 flex h-5 min-w-0 items-center gap-2">
         <span className="flex min-w-0 items-center gap-2 overflow-hidden">
           {agentCount > 0 && (
             <Tooltip content={agentCountLabel} side="top">
@@ -266,14 +266,16 @@ export const StageBoardCard = memo(function StageBoardCard({
             />
           )}
           {isAutoMode && (
-            <Chip
-              tone={CONCEPT_TONE.autorun}
-              size="xs"
-              bordered={false}
-              icon={<CONCEPT_ICONS.autorun size={10} aria-hidden />}
-              label="Autorun"
-              className="shrink-0"
-            />
+            <Tooltip content="Autorun" side="top">
+              <Chip
+                tone={CONCEPT_TONE.autorun}
+                size="xs"
+                bordered={false}
+                ariaLabel="Autorun"
+                icon={<CONCEPT_ICONS.autorun size={ICON_SIZE.row} aria-hidden />}
+                className="shrink-0"
+              />
+            </Tooltip>
           )}
           {showProjectChips
             ? mounts.map((mount) => (
@@ -316,7 +318,7 @@ export const StageBoardCard = memo(function StageBoardCard({
 
       <CardActionSlot
         label="Session lifecycle actions"
-        className="col-start-2 row-start-2 self-center justify-self-end"
+        className="col-start-2 row-start-2 h-5 self-center justify-self-end"
       >
         {!archived && (
           <CardAction

--- a/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.tsx
@@ -31,6 +31,9 @@ import { useDynamicActions, type DynamicAction } from './useDynamicActions';
 const SESSION_CARD_REVEAL =
   'group-hover/session-card:opacity-100 group-focus-within/session-card:opacity-100';
 
+const SESSION_CARD_META_HIDE =
+  'group-hover/session-card:opacity-0 group-focus-within/session-card:opacity-0';
+
 const isUrgent = ({ tone }: { readonly tone: DynamicAction['tone'] }): boolean =>
   tone === 'warning' || tone === 'danger';
 
@@ -152,11 +155,11 @@ export const StageBoardCard = memo(function StageBoardCard({
         nav.selectCard(session);
       }}
       className={cn(
-        'group/session-card grid h-28 shrink-0 cursor-pointer grid-cols-[minmax(0,1fr)_auto] grid-rows-[1fr_auto] gap-2 p-3 text-left',
+        'group/session-card grid h-28 shrink-0 cursor-pointer grid-cols-[minmax(0,1fr)_auto] grid-rows-[minmax(0,1fr)_auto] gap-x-2 gap-y-1 p-3 text-left',
         sessionCardShell({ stage, selected }),
       )}
     >
-      <span className="row-span-2 flex min-w-0 flex-col justify-between">
+      <span className="flex min-w-0 flex-col justify-between">
         <span className="flex min-h-10 items-start gap-2">
           <PrRequestSlot
             linkedRequest={linkedRequest}
@@ -171,79 +174,6 @@ export const StageBoardCard = memo(function StageBoardCard({
         </span>
 
         {reason && <span className="truncate text-2xs text-muted-foreground">{reason}</span>}
-
-        <span className="flex h-5 items-center gap-2">
-          <span className="flex min-w-0 items-center gap-2 overflow-hidden">
-            {agentCount > 0 && (
-              <Tooltip content={agentCountLabel} side="top">
-                <span
-                  aria-label={agentCountLabel}
-                  className="inline-flex shrink-0 items-center gap-1 text-3xs tabular-nums text-muted-foreground/70"
-                >
-                  <CONCEPT_ICONS.agents size={ICON_SIZE.row} aria-hidden />
-                  <span>{agentCount}</span>
-                </span>
-              </Tooltip>
-            )}
-            {reviewDraftCount > 0 && (
-              <Chip
-                tone="draft"
-                size="xs"
-                bordered={false}
-                ariaLabel={`Review ${reviewDraftCount} draft ${reviewDraftCount === 1 ? 'comment' : 'comments'}`}
-                onClick={(event) => {
-                  event.stopPropagation();
-                  openSession({ sessionId: id, lens: 'review' });
-                }}
-                icon={<MessageSquareDiff size={10} aria-hidden />}
-                label={<span className="tabular-nums">{reviewDraftCount}</span>}
-                trailing={<span>draft {reviewDraftCount === 1 ? 'comment' : 'comments'}</span>}
-                className="shrink-0"
-              />
-            )}
-            {isAutoMode && (
-              <Chip
-                tone={CONCEPT_TONE.autorun}
-                size="xs"
-                bordered={false}
-                icon={<CONCEPT_ICONS.autorun size={10} aria-hidden />}
-                label="Autorun"
-                className="shrink-0"
-              />
-            )}
-            {showProjectChips
-              ? mounts.map((mount) => (
-                  <Chip
-                    key={mount.mountId ?? mount.projectId}
-                    tone="neutral"
-                    size="xs"
-                    bordered={false}
-                    label={mount.mountName}
-                    className="shrink-0"
-                  />
-                ))
-              : null}
-            {externalTasks.map((task) => (
-              <ExternalTaskChip
-                key={`${task.provider}:${task.externalId}`}
-                task={task}
-                variant="icon"
-              />
-            ))}
-          </span>
-          <span className="ml-auto flex shrink-0 items-center gap-2">
-            {sessionCost > 0 && (
-              <CostBadge
-                value={sessionCost}
-                title={`Session spend: ${formatUsd(sessionCost)} (excludes summarizer)`}
-                className="shrink-0 text-3xs tabular-nums text-muted-foreground/70"
-              />
-            )}
-            {age && (
-              <span className="shrink-0 text-3xs tabular-nums text-muted-foreground/70">{age}</span>
-            )}
-          </span>
-        </span>
       </span>
 
       <span className="col-start-2 row-start-1 flex items-center gap-1 self-start">
@@ -306,9 +236,87 @@ export const StageBoardCard = memo(function StageBoardCard({
         />
       </span>
 
+      <span className="col-span-2 col-start-1 row-start-2 flex h-5 min-w-0 items-center gap-2 self-center">
+        <span className="flex min-w-0 items-center gap-2 overflow-hidden">
+          {agentCount > 0 && (
+            <Tooltip content={agentCountLabel} side="top">
+              <span
+                aria-label={agentCountLabel}
+                className="inline-flex shrink-0 items-center gap-1 text-3xs tabular-nums text-muted-foreground/70"
+              >
+                <CONCEPT_ICONS.agents size={ICON_SIZE.row} aria-hidden />
+                <span>{agentCount}</span>
+              </span>
+            </Tooltip>
+          )}
+          {reviewDraftCount > 0 && (
+            <Chip
+              tone="draft"
+              size="xs"
+              bordered={false}
+              ariaLabel={`Review ${reviewDraftCount} draft ${reviewDraftCount === 1 ? 'comment' : 'comments'}`}
+              onClick={(event) => {
+                event.stopPropagation();
+                openSession({ sessionId: id, lens: 'review' });
+              }}
+              icon={<MessageSquareDiff size={10} aria-hidden />}
+              label={<span className="tabular-nums">{reviewDraftCount}</span>}
+              trailing={<span>draft {reviewDraftCount === 1 ? 'comment' : 'comments'}</span>}
+              className="shrink-0"
+            />
+          )}
+          {isAutoMode && (
+            <Chip
+              tone={CONCEPT_TONE.autorun}
+              size="xs"
+              bordered={false}
+              icon={<CONCEPT_ICONS.autorun size={10} aria-hidden />}
+              label="Autorun"
+              className="shrink-0"
+            />
+          )}
+          {showProjectChips
+            ? mounts.map((mount) => (
+                <Chip
+                  key={mount.projectId}
+                  tone="neutral"
+                  size="xs"
+                  bordered={false}
+                  label={<span className="truncate">{mount.mountName}</span>}
+                  className="min-w-0"
+                />
+              ))
+            : null}
+          {externalTasks.map((task) => (
+            <ExternalTaskChip
+              key={`${task.provider}:${task.externalId}`}
+              task={task}
+              variant="icon"
+            />
+          ))}
+        </span>
+        <span
+          className={cn(
+            'ml-auto flex shrink-0 items-center gap-2 motion-safe:transition-opacity',
+            SESSION_CARD_META_HIDE,
+          )}
+        >
+          {sessionCost > 0 && (
+            <CostBadge
+              value={sessionCost}
+              title={`Session spend: ${formatUsd(sessionCost)} (excludes summarizer)`}
+              className="shrink-0 text-3xs tabular-nums text-muted-foreground/70"
+            />
+          )}
+          {age && (
+            <span className="shrink-0 text-3xs tabular-nums text-muted-foreground/70">{age}</span>
+          )}
+        </span>
+      </span>
+
       <CardActionSlot
         label="Session lifecycle actions"
-        className="col-start-2 row-start-2 self-end"
+        className="col-start-2 row-start-2 self-center justify-self-end"
       >
         {!archived && (
           <CardAction

--- a/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.tsx
@@ -26,6 +26,7 @@ import { useOpenSession } from '../../../../../shared/hooks/useOpenSession';
 import type { BoardNavigation } from '../useBoardNavigation';
 import { getLinkedRequest } from './getLinkedRequest';
 import { PrRequestSlot } from './PrRequestSlot';
+import { ProjectMountChips } from './ProjectMountChips';
 import { useDynamicActions, type DynamicAction } from './useDynamicActions';
 
 const SESSION_CARD_REVEAL =
@@ -277,18 +278,7 @@ export const StageBoardCard = memo(function StageBoardCard({
               />
             </Tooltip>
           )}
-          {showProjectChips
-            ? mounts.map((mount) => (
-                <Chip
-                  key={mount.projectId}
-                  tone="neutral"
-                  size="xs"
-                  bordered={false}
-                  label={<span className="truncate">{mount.mountName}</span>}
-                  className="min-w-0"
-                />
-              ))
-            : null}
+          {showProjectChips ? <ProjectMountChips mounts={mounts} /> : null}
           {externalTasks.map((task) => (
             <ExternalTaskChip
               key={`${task.provider}:${task.externalId}`}

--- a/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.tsx
@@ -268,14 +268,15 @@ export const StageBoardCard = memo(function StageBoardCard({
           )}
           {isAutoMode && (
             <Tooltip content="Autorun" side="top">
-              <Chip
-                tone={CONCEPT_TONE.autorun}
-                size="xs"
-                bordered={false}
-                ariaLabel="Autorun"
-                icon={<CONCEPT_ICONS.autorun size={ICON_SIZE.row} aria-hidden />}
-                className="shrink-0"
-              />
+              <span className="inline-flex shrink-0">
+                <Chip
+                  tone={CONCEPT_TONE.autorun}
+                  size="xs"
+                  bordered={false}
+                  ariaLabel="Autorun"
+                  icon={<CONCEPT_ICONS.autorun size={ICON_SIZE.row} aria-hidden />}
+                />
+              </span>
             </Tooltip>
           )}
           {showProjectChips ? <ProjectMountChips mounts={mounts} /> : null}

--- a/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.tsx
@@ -1,14 +1,6 @@
 import { memo, useEffect, useMemo } from 'react';
-import {
-  Archive,
-  Bot,
-  ChevronRight,
-  Code,
-  MessageSquareDiff,
-  RotateCcw,
-  Trash2,
-} from 'lucide-react';
-import { Chip, cn, Divider, formatUsd, Tooltip } from '@goodboy/ui';
+import { Archive, ChevronRight, Code, MessageSquareDiff, RotateCcw, Trash2 } from 'lucide-react';
+import { Chip, cn, formatUsd, Tooltip } from '@goodboy/ui';
 import type { Session, SessionId } from '@goodboy/types';
 import {
   EMPTY_ARRAY,
@@ -28,15 +20,19 @@ import {
   ICON_SIZE,
 } from '../../../../../shared/components/conceptIcons';
 import { InlineMarkdown } from '../../../../../shared/components/InlineMarkdown';
-import { stripInlineMarkdown } from '../../../../../shared/components/InlineMarkdown/stripInlineMarkdown';
-import { STAGE_TONE } from '../../../../session/session-stage';
 import { sessionCardShell } from '../../../../session/components/sessionCardShell';
 import { formatRelativeAge } from '../../../../../shared/utils/relativeDate';
 import { useOpenSession } from '../../../../../shared/hooks/useOpenSession';
 import type { BoardNavigation } from '../useBoardNavigation';
 import { getLinkedRequest } from './getLinkedRequest';
 import { PrRequestSlot } from './PrRequestSlot';
-import { useDynamicActions } from './useDynamicActions';
+import { useDynamicActions, type DynamicAction } from './useDynamicActions';
+
+const SESSION_CARD_REVEAL =
+  'group-hover/session-card:opacity-100 group-focus-within/session-card:opacity-100';
+
+const isUrgent = ({ tone }: { readonly tone: DynamicAction['tone'] }): boolean =>
+  tone === 'warning' || tone === 'danger';
 
 type CardSelectionEvent = {
   readonly shiftKey: boolean;
@@ -104,8 +100,8 @@ export const StageBoardCard = memo(function StageBoardCard({
     ? (reviewDrafts ?? []).filter((draft) => draft.status === 'draft').length
     : 0;
 
-  const plainGoal = stripInlineMarkdown({ text: session.goal });
   const age = formatRelativeAge({ fromIso: session.updatedAt });
+  const [visibleAction, ...revealedActions] = dynamicActions;
   const linkedRequest = getLinkedRequest({ pullRequest, mergeRequest });
   const isGitlab = mergeRequest != null && pullRequest == null;
 
@@ -156,155 +152,180 @@ export const StageBoardCard = memo(function StageBoardCard({
         nav.selectCard(session);
       }}
       className={cn(
-        'group/session-card grid h-[8.25rem] min-h-[8.25rem] shrink-0 cursor-pointer grid-cols-[minmax(0,1fr)_auto] grid-rows-[1fr_auto] gap-2 p-3 text-left shadow-sm',
+        'group/session-card grid h-28 shrink-0 cursor-pointer grid-cols-[minmax(0,1fr)_auto] grid-rows-[1fr_auto] gap-2 p-3 text-left',
         sessionCardShell({ stage, selected }),
       )}
     >
-      <span className="row-span-2 flex min-w-0 flex-col justify-between gap-2">
-        <span className="flex min-h-10 items-start gap-1.5">
+      <span className="row-span-2 flex min-w-0 flex-col justify-between">
+        <span className="flex min-h-10 items-start gap-2">
           <PrRequestSlot
             linkedRequest={linkedRequest}
             isGitlab={isGitlab}
             prFetchState={prFetchState}
             onOpen={handlePrClick}
           />
-          <Tooltip content={`${plainGoal}${reason ? ` · ${reason}` : ''}`} side="top">
-            <InlineMarkdown
-              text={session.goal}
-              className="line-clamp-2 min-h-10 min-w-0 flex-1 text-sm font-medium leading-snug"
-            />
-          </Tooltip>
+          <InlineMarkdown
+            text={session.goal}
+            className="line-clamp-2 min-h-10 min-w-0 flex-1 text-sm font-medium leading-5"
+          />
         </span>
 
-        {reason && (
-          <span className="truncate text-2xs leading-tight text-muted-foreground/60">{reason}</span>
-        )}
+        {reason && <span className="truncate text-2xs text-muted-foreground">{reason}</span>}
 
-        <span className="flex min-h-5 flex-nowrap items-center gap-1.5 overflow-hidden">
-          {agentCount > 0 && (
-            <Tooltip content={agentCountLabel} side="top">
-              <span
-                aria-label={agentCountLabel}
-                className="inline-flex shrink-0 items-center gap-1 text-2xs text-muted-foreground"
-              >
-                <Bot size={ICON_SIZE.control} aria-hidden />
-                <span className="tabular-nums">{agentCount}</span>
-              </span>
-            </Tooltip>
-          )}
-          {reviewDraftCount > 0 && (
-            <Chip
-              tone="draft"
-              size="3xs"
-              bordered={false}
-              ariaLabel={`Review ${reviewDraftCount} draft ${reviewDraftCount === 1 ? 'comment' : 'comments'}`}
-              onClick={(event) => {
-                event.stopPropagation();
-                openSession({ sessionId: id, lens: 'review' });
-              }}
-              icon={<MessageSquareDiff size={10} aria-hidden />}
-              label={<span className="tabular-nums">{reviewDraftCount}</span>}
-              trailing={<span>draft {reviewDraftCount === 1 ? 'comment' : 'comments'}</span>}
-              className="shrink-0"
-            />
-          )}
-          {externalTasks.map((task) => (
-            <ExternalTaskChip
-              key={`${task.provider}:${task.externalId}`}
-              task={task}
-              variant="icon"
-            />
-          ))}
-          {showProjectChips
-            ? mounts.map((mount) => (
-                <Chip
-                  key={mount.mountId ?? mount.projectId}
-                  tone="neutral"
-                  size="3xs"
-                  bordered={false}
-                  label={mount.mountName}
-                  className="shrink-0"
-                />
-              ))
-            : null}
-          {sessionCost > 0 && (
-            <CostBadge
-              value={sessionCost}
-              title={`Session spend: ${formatUsd(sessionCost)} (excludes summarizer)`}
-              className="shrink-0 text-2xs font-medium tabular-nums text-muted-foreground"
-            />
-          )}
-          {isAutoMode && (
-            <Chip
-              tone={CONCEPT_TONE.autorun}
-              size="sm"
-              icon={<CONCEPT_ICONS.autorun size={10} aria-hidden />}
-              label="Autorun"
-              className="shrink-0"
-            />
-          )}
-          {age && (
-            <span className="shrink-0 text-2xs tabular-nums text-muted-foreground/50">{age}</span>
-          )}
-          <ChevronRight
-            size={ICON_SIZE.row}
-            aria-hidden
-            className="ml-auto shrink-0 text-muted-foreground/40 group-hover/session-card:text-muted-foreground/70"
-          />
+        <span className="flex h-5 items-center gap-2">
+          <span className="flex min-w-0 items-center gap-2 overflow-hidden">
+            {agentCount > 0 && (
+              <Tooltip content={agentCountLabel} side="top">
+                <span
+                  aria-label={agentCountLabel}
+                  className="inline-flex shrink-0 items-center gap-1 text-3xs tabular-nums text-muted-foreground/70"
+                >
+                  <CONCEPT_ICONS.agents size={ICON_SIZE.row} aria-hidden />
+                  <span>{agentCount}</span>
+                </span>
+              </Tooltip>
+            )}
+            {reviewDraftCount > 0 && (
+              <Chip
+                tone="draft"
+                size="xs"
+                bordered={false}
+                ariaLabel={`Review ${reviewDraftCount} draft ${reviewDraftCount === 1 ? 'comment' : 'comments'}`}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  openSession({ sessionId: id, lens: 'review' });
+                }}
+                icon={<MessageSquareDiff size={10} aria-hidden />}
+                label={<span className="tabular-nums">{reviewDraftCount}</span>}
+                trailing={<span>draft {reviewDraftCount === 1 ? 'comment' : 'comments'}</span>}
+                className="shrink-0"
+              />
+            )}
+            {isAutoMode && (
+              <Chip
+                tone={CONCEPT_TONE.autorun}
+                size="xs"
+                bordered={false}
+                icon={<CONCEPT_ICONS.autorun size={10} aria-hidden />}
+                label="Autorun"
+                className="shrink-0"
+              />
+            )}
+            {showProjectChips
+              ? mounts.map((mount) => (
+                  <Chip
+                    key={mount.mountId ?? mount.projectId}
+                    tone="neutral"
+                    size="xs"
+                    bordered={false}
+                    label={mount.mountName}
+                    className="shrink-0"
+                  />
+                ))
+              : null}
+            {externalTasks.map((task) => (
+              <ExternalTaskChip
+                key={`${task.provider}:${task.externalId}`}
+                task={task}
+                variant="icon"
+              />
+            ))}
+          </span>
+          <span className="ml-auto flex shrink-0 items-center gap-2">
+            {sessionCost > 0 && (
+              <CostBadge
+                value={sessionCost}
+                title={`Session spend: ${formatUsd(sessionCost)} (excludes summarizer)`}
+                className="shrink-0 text-3xs tabular-nums text-muted-foreground/70"
+              />
+            )}
+            {age && (
+              <span className="shrink-0 text-3xs tabular-nums text-muted-foreground/70">{age}</span>
+            )}
+          </span>
         </span>
       </span>
 
-      <CardActionSlot
-        label="Session quick actions"
-        className="col-start-2 row-start-1 flex-col items-end self-start"
-      >
-        {!archived && (
-          <span className="flex flex-nowrap justify-end gap-1">
-            {dynamicActions.map((action) => (
+      <span className="col-start-2 row-start-1 flex items-center gap-1 self-start">
+        <CardActionSlot label="Session quick actions">
+          {!archived &&
+            revealedActions.map((action) => (
               <CardAction
                 key={action.key}
                 icon={action.icon}
                 tone={action.tone}
-                highlighted={action.tone === STAGE_TONE.attention}
+                highlighted={isUrgent({ tone: action.tone })}
                 label={action.label}
                 onClick={action.onClick}
+                reveal
+                revealGroup={SESSION_CARD_REVEAL}
               />
             ))}
+          {!archived && (
             <CardAction
               icon={Code}
               label="Open in editor"
               onClick={() => nav.openIDE(session)}
               disabled={worktreePath == null}
+              reveal
+              revealGroup={SESSION_CARD_REVEAL}
             />
+          )}
+          {!archived && (
             <CardAction
               icon={CONCEPT_ICONS.terminal}
               label="Open terminal"
               onClick={() => nav.openTerminal(session)}
+              reveal
+              revealGroup={SESSION_CARD_REVEAL}
             />
-          </span>
-        )}
-      </CardActionSlot>
+          )}
+          {!archived && visibleAction !== undefined && (
+            <CardAction
+              key={visibleAction.key}
+              icon={visibleAction.icon}
+              tone={visibleAction.tone}
+              highlighted={isUrgent({ tone: visibleAction.tone })}
+              label={visibleAction.label}
+              onClick={visibleAction.onClick}
+            />
+          )}
+          {archived === true && (
+            <CardAction
+              icon={RotateCcw}
+              tone="primary"
+              label="Restore"
+              onClick={() => onRestore?.(session)}
+            />
+          )}
+        </CardActionSlot>
+        <ChevronRight
+          size={ICON_SIZE.row}
+          aria-hidden
+          className="shrink-0 text-muted-foreground/40 group-hover/session-card:text-muted-foreground/70"
+        />
+      </span>
 
       <CardActionSlot
         label="Session lifecycle actions"
         className="col-start-2 row-start-2 self-end"
       >
-        {archived ? (
+        {!archived && (
           <CardAction
-            icon={RotateCcw}
-            tone="primary"
-            label="Restore"
-            onClick={() => onRestore?.(session)}
+            icon={Archive}
+            label="Archive"
+            onClick={() => onArchive?.(session)}
+            reveal
+            revealGroup={SESSION_CARD_REVEAL}
           />
-        ) : (
-          <CardAction icon={Archive} label="Archive" onClick={() => onArchive?.(session)} />
         )}
-        <Divider orientation="vertical" className="mx-0.5 h-4 shrink-0 self-center" />
         <CardAction
           icon={Trash2}
           tone="danger"
           label="Delete"
           onClick={() => onDelete?.(session)}
+          reveal
+          revealGroup={SESSION_CARD_REVEAL}
         />
       </CardActionSlot>
     </div>

--- a/apps/desktop/src/features/workspace/components/StageBoard/StageColumn/index.test.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/StageColumn/index.test.tsx
@@ -66,11 +66,48 @@ const renderColumn = (
 afterEach(cleanup);
 
 describe('StageColumn', () => {
-  it('uses the quiet empty state for an empty column', () => {
+  it('renders only the muted label for an empty column', () => {
     const { container } = renderColumn([]);
-    expect(screen.getByText('nothing building')).toBeDefined();
-    expect(container.querySelector('.size-12')).toBeNull();
-    expect(container.querySelector('.text-foreground')).toBeNull();
+    expect(screen.getByText('building').className).toContain('text-muted-foreground/60');
+    expect(screen.queryByText('nothing building')).toBeNull();
+    expect(container.querySelector('.tabular-nums')).toBeNull();
+  });
+
+  it('renders the count and the stage tint once the column has cards', () => {
+    renderColumn([makeSession('s-1', 'one')]);
+    expect(screen.getByText('1')).toBeDefined();
+    expect(screen.getByText('building').className).not.toContain('text-muted-foreground/60');
+
+    cleanup();
+    renderColumn([makeSession('s-1', 'one')], makeSelection(), {
+      kind: 'stage',
+      stage: 'running',
+    });
+    expect(screen.getByText('running').className).toContain('text-info');
+  });
+
+  it('starts collapsed for done and archived, open otherwise', () => {
+    renderColumn([makeSession('s-1', 'one')], makeSelection(), { kind: 'stage', stage: 'done' });
+    expect(screen.getByRole('button', { name: /done/ }).getAttribute('aria-expanded')).toBe(
+      'false',
+    );
+    expect(screen.queryByRole('button', { name: 'card one' })).toBeNull();
+
+    cleanup();
+    renderColumn([makeSession('s-1', 'one')], makeSelection(), { kind: 'archived' });
+    expect(screen.getByRole('button', { name: /archived/ }).getAttribute('aria-expanded')).toBe(
+      'false',
+    );
+    expect(screen.queryByRole('button', { name: 'card one' })).toBeNull();
+
+    cleanup();
+    renderColumn([makeSession('s-1', 'one')]);
+    expect(screen.getByRole('button', { name: 'card one' })).toBeDefined();
+  });
+
+  it('renders no native title on the collapse control', () => {
+    renderColumn([makeSession('s-1', 'one')], makeSelection(), { kind: 'stage', stage: 'done' });
+    expect(screen.getByRole('button', { name: /done/ }).hasAttribute('title')).toBe(false);
   });
 
   it('marks the cards the board selection owns', () => {
@@ -99,9 +136,11 @@ describe('StageColumn', () => {
   it('clears the archived selection when the archived column collapses', () => {
     const clear = vi.fn();
     renderColumn([makeSession('s-1', 'one')], makeSelection({ clear }), { kind: 'archived' });
-    clear.mockClear();
+    const header = screen.getByRole('button', { name: /archived/ });
 
-    fireEvent.click(screen.getByTitle('collapse archived'));
+    fireEvent.click(header);
+    clear.mockClear();
+    fireEvent.click(header);
 
     expect(clear).toHaveBeenCalled();
   });
@@ -112,9 +151,11 @@ describe('StageColumn', () => {
       kind: 'stage',
       stage: 'done',
     });
-    clear.mockClear();
+    const header = screen.getByRole('button', { name: /done/ });
 
-    fireEvent.click(screen.getByTitle('collapse done'));
+    fireEvent.click(header);
+    clear.mockClear();
+    fireEvent.click(header);
 
     expect(clear).not.toHaveBeenCalled();
   });

--- a/apps/desktop/src/features/workspace/components/StageBoard/StageColumn/index.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/StageColumn/index.tsx
@@ -1,22 +1,13 @@
 import { useEffect, useState } from 'react';
 import { ChevronDown } from 'lucide-react';
-import { cn, Eyebrow, ScrollFade, type Tone } from '@goodboy/ui';
+import { cn, Eyebrow, ScrollFade, tintClasses, type Tone } from '@goodboy/ui';
 import type { Session, SessionId, SessionStage } from '@goodboy/types';
 import { SESSION_STAGE_META, STAGE_TONE } from '../../../../session/session-stage';
 import type { MultiSelect } from '../../../../../shared/hooks/useMultiSelect';
 import { StageBoardCard } from '../StageBoardCard';
 import type { BoardNavigation } from '../useBoardNavigation';
-import { CONCEPT_ICONS, ICON_SIZE } from '../../../../../shared/components/conceptIcons';
+import { ICON_SIZE } from '../../../../../shared/components/conceptIcons';
 import { PANE_RHYTHM } from '@goodboy/ui';
-
-const ZERO_STATE: Record<SessionStage | 'archived', string> = {
-  attention: 'nothing needs you',
-  running: 'nothing running',
-  review: 'nothing in review',
-  building: 'nothing building',
-  done: 'nothing done yet',
-  archived: 'nothing archived',
-};
 
 export type ColumnSpec =
   { readonly kind: 'stage'; readonly stage: SessionStage } | { readonly kind: 'archived' };
@@ -68,7 +59,7 @@ export const StageColumn = ({
   onRestore,
 }: StageColumnProps) => {
   const view = viewFor(spec);
-  const [collapsed, setCollapsed] = useState(false);
+  const [collapsed, setCollapsed] = useState(view.collapsible);
   const empty = sessions.length === 0;
 
   const { clear: clearSelection, isSelected } = selection;
@@ -81,9 +72,15 @@ export const StageColumn = ({
   }, [collapsed, archivedColumn, clearSelection]);
 
   const header = (
-    <span className="flex items-center gap-1.5">
-      <Eyebrow label={view.label} tone={view.tone} badge muted={empty} />
-      <span className="text-2xs tabular-nums text-muted-foreground/60">{sessions.length}</span>
+    <span className="flex items-center gap-2">
+      <Eyebrow
+        label={view.label}
+        muted={empty}
+        className={cn(!empty && tintClasses(view.tone).text)}
+      />
+      {!empty && (
+        <span className="text-2xs tabular-nums text-muted-foreground/60">{sessions.length}</span>
+      )}
     </span>
   );
 
@@ -91,7 +88,7 @@ export const StageColumn = ({
     <div
       className={cn(
         'flex min-h-0 flex-col',
-        PANE_RHYTHM.board.colWidth,
+        collapsed ? 'w-auto' : PANE_RHYTHM.board.colWidth,
         PANE_RHYTHM.board.colStack,
       )}
     >
@@ -100,8 +97,7 @@ export const StageColumn = ({
           type="button"
           onClick={() => setCollapsed((v) => !v)}
           aria-expanded={!collapsed}
-          title={collapsed ? `expand ${view.label}` : `collapse ${view.label}`}
-          className="flex shrink-0 items-center gap-1 text-left"
+          className="flex shrink-0 items-center gap-2 text-left"
         >
           <ChevronDown
             size={ICON_SIZE.row}
@@ -117,33 +113,22 @@ export const StageColumn = ({
         <div className="shrink-0">{header}</div>
       )}
 
-      {!collapsed && (
+      {!collapsed && !empty && (
         <ScrollFade orientation="vertical" className="flex-1">
           <div className={cn('flex flex-col', PANE_RHYTHM.board.cardGap)}>
-            {empty ? (
-              <p className="flex items-center gap-2 px-1 py-2 text-xs text-muted-foreground/70">
-                <CONCEPT_ICONS.sessions
-                  size={ICON_SIZE.row}
-                  aria-hidden
-                  className="shrink-0 text-muted-foreground/40"
-                />
-                {ZERO_STATE[view.key]}
-              </p>
-            ) : (
-              sessions.map((session) => (
-                <StageBoardCard
-                  key={session.id}
-                  session={session}
-                  nav={nav}
-                  archived={view.archived}
-                  selected={isSelected(session.id as SessionId)}
-                  onModifierClick={selection.handleItemClick}
-                  onArchive={onArchive}
-                  onDelete={onDelete}
-                  onRestore={onRestore}
-                />
-              ))
-            )}
+            {sessions.map((session) => (
+              <StageBoardCard
+                key={session.id}
+                session={session}
+                nav={nav}
+                archived={view.archived}
+                selected={isSelected(session.id as SessionId)}
+                onModifierClick={selection.handleItemClick}
+                onArchive={onArchive}
+                onDelete={onDelete}
+                onRestore={onRestore}
+              />
+            ))}
           </div>
         </ScrollFade>
       )}

--- a/apps/desktop/src/features/workspace/components/StageBoard/index.test.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/index.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 
+import type { ReactElement } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import type { Project, Session, Workspace, WorkspaceGitStatus, WorkspaceId } from '@goodboy/types';
@@ -97,6 +98,16 @@ vi.mock('../../../session/components/DeleteSessionConfirm', () => ({
   DeleteSessionConfirm: () => null,
 }));
 vi.mock('../../../../shared/components/DogMascot', () => ({ DogMascot: () => <div /> }));
+
+vi.mock('@goodboy/ui', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@goodboy/ui')>();
+  return {
+    ...actual,
+    Tooltip: ({ content, children }: { content: string; children: ReactElement }) => (
+      <span data-tooltip={content}>{children}</span>
+    ),
+  };
+});
 
 import { StageBoard } from './index';
 
@@ -213,7 +224,9 @@ describe('StageBoard empty-projects gate', () => {
     render(<StageBoard workspaceId={wsId} sessions={[session]} />);
     const button = screen.getByRole('button', { name: 'New session' });
     expect(button.hasAttribute('disabled')).toBe(true);
-    expect(button.getAttribute('title')).toBe('Link a project first');
+    expect(button.closest('[data-tooltip]')?.getAttribute('data-tooltip')).toBe(
+      'Link a project first',
+    );
     expect(screen.queryByTestId('projects-step')).toBeNull();
   });
 
@@ -269,7 +282,7 @@ describe('StageBoard git gate', () => {
     render(<StageBoard workspaceId={wsId} sessions={[session]} />);
     const button = screen.getByRole('button', { name: 'New session' });
     expect(button.hasAttribute('disabled')).toBe(true);
-    expect(button.getAttribute('title')).toBe(
+    expect(button.closest('[data-tooltip]')?.getAttribute('data-tooltip')).toBe(
       'This project needs a git repository with one commit first',
     );
   });
@@ -278,9 +291,9 @@ describe('StageBoard git gate', () => {
     state.projects = [projectOf({ id: 'proj-1' }), projectOf({ id: 'proj-2' })];
     gitStatuses.current = { 'proj-1': statusOf('ready'), 'proj-2': statusOf('missing') };
     render(<StageBoard workspaceId={wsId} sessions={[session]} />);
-    expect(screen.getByRole('button', { name: 'New session' }).hasAttribute('disabled')).toBe(
-      false,
-    );
+    const button = screen.getByRole('button', { name: 'New session' });
+    expect(button.hasAttribute('disabled')).toBe(false);
+    expect(button.closest('[data-tooltip]')).toBeNull();
   });
 
   it('enables New session when a folder project is available', () => {
@@ -296,15 +309,20 @@ describe('StageBoard git gate', () => {
     render(<StageBoard workspaceId={wsId} sessions={[session]} />);
     const button = screen.getByRole('button', { name: 'New session' });
     expect(button.hasAttribute('disabled')).toBe(true);
-    expect(button.getAttribute('title')).toBe('Reading git status');
+    expect(button.closest('[data-tooltip]')?.getAttribute('data-tooltip')).toBe(
+      'Reading git status',
+    );
   });
 
   it('uses the unreachable reason when all repo projects are missing', () => {
     gitStatuses.current = { 'proj-1': statusOf('missing') };
     render(<StageBoard workspaceId={wsId} sessions={[session]} />);
-    expect(screen.getByRole('button', { name: 'New session' }).getAttribute('title')).toBe(
-      'The project folder is unreachable',
-    );
+    expect(
+      screen
+        .getByRole('button', { name: 'New session' })
+        .closest('[data-tooltip]')
+        ?.getAttribute('data-tooltip'),
+    ).toBe('The project folder is unreachable');
   });
 });
 
@@ -343,19 +361,13 @@ describe('StageBoard selection', () => {
   const other = { id: 's-2' } as Session;
   const shelved = { id: 's-9' } as Session;
 
-  it('offers the alt-click hint only once the board holds more than one session', () => {
+  it('never renders a standing selection hint', () => {
     groups.current = [{ key: 'building', sessions: [session] }];
     render(<StageBoard workspaceId={wsId} sessions={[session]} />);
     expect(screen.queryByText(/lasso/)).toBeNull();
 
     cleanup();
     groups.current = [{ key: 'building', sessions: [session, other] }];
-    render(<StageBoard workspaceId={wsId} sessions={[session, other]} />);
-    expect(screen.getByText('⌥click to select · drag to lasso')).toBeDefined();
-  });
-
-  it('hides the alt-click hint when the project filter leaves one visible session', () => {
-    groups.current = [{ key: 'building', sessions: [session] }];
     render(<StageBoard workspaceId={wsId} sessions={[session, other]} />);
     expect(screen.queryByText(/lasso/)).toBeNull();
   });

--- a/apps/desktop/src/features/workspace/components/StageBoard/index.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/index.tsx
@@ -1,7 +1,16 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { Plus } from 'lucide-react';
-import { Button, cn, Divider, EmptyState, Eyebrow, Skeleton } from '@goodboy/ui';
+import {
+  Button,
+  cn,
+  Divider,
+  EmptyState,
+  Eyebrow,
+  ScrollFade,
+  Skeleton,
+  Tooltip,
+} from '@goodboy/ui';
 import type { Session, SessionId, SessionStage, WorkspaceId } from '@goodboy/types';
 import {
   EMPTY_ARRAY,
@@ -56,7 +65,7 @@ const BoardSkeleton = () => (
         <Skeleton className="h-4 w-24 rounded-full" />
         <div className={cn('flex flex-col', PANE_RHYTHM.board.cardGap)}>
           {Array.from({ length: cards }).map((_, i) => (
-            <Skeleton key={i} className="h-[8.25rem] w-full rounded-lg" />
+            <Skeleton key={i} className="h-28 w-full rounded-lg" />
           ))}
         </div>
       </div>
@@ -141,64 +150,54 @@ export const StageBoard = ({ workspaceId, sessions }: Props) => {
         ? 'The project folder is unreachable'
         : 'This project needs a git repository with one commit first';
 
+  const newSessionButton = (
+    <Button
+      size="sm"
+      onClick={() => window.dispatchEvent(new CustomEvent('goodboy:new-session'))}
+      disabled={!hasUsableProject}
+    >
+      <Plus size={ICON_SIZE.control} aria-hidden />
+      New session
+    </Button>
+  );
+
   return (
-    <div className={cn('flex h-full w-full flex-col gap-5', PANE_RHYTHM.board.pad)}>
+    <div className={cn('flex h-full w-full', PANE_RHYTHM.stack, PANE_RHYTHM.board.pad)}>
       {pending || !empty || hasProjects ? (
         <>
           <div className="flex shrink-0 items-center justify-between gap-4">
             <span className="flex min-w-0 items-baseline gap-2">
               <Eyebrow label="Stage board" />
-              <span className="text-2xs tabular-nums text-muted-foreground/60">
-                {activeSessions.length}
-              </span>
-              {activeSessions.length > 1 && (
-                <span className="hidden text-3xs text-muted-foreground/50 sm:inline">
-                  ⌥click to select · drag to lasso
+              {activeSessions.length > 0 && (
+                <span className="text-2xs tabular-nums text-muted-foreground/60">
+                  {activeSessions.length}
                 </span>
               )}
             </span>
-            <span className="flex shrink-0 items-center gap-1.5">
+            <span className="flex shrink-0 items-center gap-2">
               <ProjectGitPills entries={projectGitStatuses} />
               <ProjectFilter workspaceId={workspaceId} sessions={filterSessions} />
-              <button
-                type="button"
-                onClick={() =>
-                  window.dispatchEvent(
-                    new CustomEvent('goodboy:open-settings', {
-                      detail: { scope: 'workspace', section: 'projects' },
-                    }),
-                  )
-                }
-                title="Manage the projects linked to this workspace"
-                className="rounded-md px-2 py-1 text-xs font-medium text-muted-foreground/70 transition-colors hover:bg-foreground/5 hover:text-foreground"
-              >
-                + Add project
-              </button>
-              <Button
-                size="sm"
-                onClick={() => window.dispatchEvent(new CustomEvent('goodboy:new-session'))}
-                disabled={!hasUsableProject}
-                title={hasUsableProject ? undefined : blockedReason}
-              >
-                <Plus size={ICON_SIZE.control} aria-hidden />
-                New session
-              </Button>
+              {hasUsableProject ? (
+                newSessionButton
+              ) : (
+                <Tooltip content={blockedReason} side="bottom">
+                  {newSessionButton}
+                </Tooltip>
+              )}
             </span>
           </div>
           <Divider />
         </>
       ) : null}
 
-      <div className="mx-auto w-full max-w-md shrink-0 empty:hidden"></div>
-
       {pending && <BoardSkeleton />}
 
       {!pending && empty && !hasProjects && workspace !== null && (
-        <div className="flex flex-1 items-center justify-center overflow-y-auto">
+        <ScrollFade className="min-h-0 flex-1" viewportClassName="flex items-center justify-center">
           <div className="w-full max-w-xl py-6">
             <ProjectsStep workspace={workspace} />
           </div>
-        </div>
+        </ScrollFade>
       )}
 
       {!pending && hasProjects && empty && hasUsableProject && (
@@ -224,12 +223,12 @@ export const StageBoard = ({ workspaceId, sessions }: Props) => {
       )}
 
       {!pending && !empty && (
-        <div className="flex min-h-0 flex-1 overflow-x-auto">
+        <ScrollFade orientation="horizontal" fadeSize="w-8" className="min-h-0 flex-1">
           <div
             ref={columnsRef}
             onPointerDown={lasso.onPointerDown}
             className={cn(
-              'relative mx-auto flex min-h-0 w-fit max-w-full',
+              'relative mx-auto flex h-full min-h-0 w-fit max-w-full',
               PANE_RHYTHM.board.colGap,
             )}
           >
@@ -268,7 +267,7 @@ export const StageBoard = ({ workspaceId, sessions }: Props) => {
               />
             )}
           </div>
-        </div>
+        </ScrollFade>
       )}
 
       {selection.selectedSessions.length > 0 && (

--- a/packages/ui/src/__tests__/Button.test.tsx
+++ b/packages/ui/src/__tests__/Button.test.tsx
@@ -13,7 +13,7 @@ describe('Button', () => {
 
     expect(button.getAttribute('aria-busy')).toBe('true');
     expect(container.querySelector('svg')).toBeNull();
-    expect(container.querySelector('.motion-safe\\:animate-pulse')).not.toBeNull();
+    expect(container.querySelector('.motion-safe\\:animate-soft-pulse')).not.toBeNull();
   });
 
   it('keeps the busy label instead of the children when given one', () => {

--- a/packages/ui/src/__tests__/CardAction.test.tsx
+++ b/packages/ui/src/__tests__/CardAction.test.tsx
@@ -24,6 +24,34 @@ describe('CardAction', () => {
     expect(button.className).toContain('group-focus-within/agent-card:opacity-100');
   });
 
+  it('keeps a disabled reveal action invisible at rest and dims it inside the group', () => {
+    render(
+      <CardAction
+        icon={Star}
+        label="Open in editor"
+        disabled
+        reveal
+        revealGroup="group-hover/agent-card:opacity-100 group-focus-within/agent-card:opacity-100"
+        onClick={vi.fn()}
+      />,
+    );
+    const button = screen.getByRole('button', { name: 'Open in editor' });
+
+    expect(button.className).toContain('opacity-0');
+    expect(button.className).not.toContain('opacity-40');
+    expect(button.className).toContain('group-hover/agent-card:opacity-100');
+    expect(button.querySelector('svg')?.getAttribute('class')).toContain('opacity-40');
+  });
+
+  it('dims a disabled action in place when it does not reveal', () => {
+    render(<CardAction icon={Star} label="Pin" disabled onClick={vi.fn()} />);
+    const button = screen.getByRole('button', { name: 'Pin' });
+
+    expect(button.className).toContain('opacity-40');
+    expect(button.className).not.toContain('opacity-0');
+    expect(button.querySelector('svg')?.getAttribute('class') ?? '').not.toContain('opacity-40');
+  });
+
   it('stays opaque when reveal is not set', () => {
     render(<CardAction icon={Star} label="Pin" onClick={vi.fn()} />);
     expect(screen.getByRole('button', { name: 'Pin' }).className).not.toContain('opacity-0');

--- a/packages/ui/src/__tests__/CountToggle.test.tsx
+++ b/packages/ui/src/__tests__/CountToggle.test.tsx
@@ -42,7 +42,7 @@ describe('CountToggle', () => {
     expect(onChange).toHaveBeenCalledWith(true);
   });
 
-  it('builds the title from the label and items noun', () => {
+  it('does not set a native title', () => {
     render(
       <CountToggle
         label="Answered"
@@ -54,6 +54,6 @@ describe('CountToggle', () => {
       />,
     );
 
-    expect(screen.getByRole('button').getAttribute('title')).toBe('hide answered questions');
+    expect(screen.getByRole('button').getAttribute('title')).toBeNull();
   });
 });

--- a/packages/ui/src/components/CardAction.tsx
+++ b/packages/ui/src/components/CardAction.tsx
@@ -31,33 +31,39 @@ export const CardAction = ({
   expanded,
   disabled = false,
   onClick,
-}: CardActionProps) => (
-  <Tooltip
-    content={tooltip ?? label}
-    side="top"
-    anchorClassName={cn('shrink-0', size === 'compact' ? 'size-6' : 'size-7')}
-  >
-    <button
-      type="button"
-      aria-label={label}
-      aria-pressed={pressed}
-      aria-expanded={expanded}
-      disabled={disabled}
-      onClick={(event) => {
-        event.stopPropagation();
-        onClick();
-      }}
-      className={cn(
-        'inline-flex size-full shrink-0 items-center justify-center rounded-md font-medium text-muted-foreground transition-[background-color,color,opacity] focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] disabled:opacity-40',
-        size === 'compact' ? 'text-3xs' : 'text-xs',
-        tintClasses(tone).hoverBgSoft,
-        tintClasses(tone).hoverText,
-        reveal && 'opacity-0',
-        reveal && revealGroup,
-        highlighted && cn(tintClasses(tone).bgSoft, tintClasses(tone).text),
-      )}
+}: CardActionProps) => {
+  const isDimmedInPlace = reveal && disabled;
+  return (
+    <Tooltip
+      content={tooltip ?? label}
+      side="top"
+      anchorClassName={cn('shrink-0', size === 'compact' ? 'size-6' : 'size-7')}
     >
-      <Icon size={size === 'compact' ? 12 : 14} aria-hidden />
-    </button>
-  </Tooltip>
-);
+      <button
+        type="button"
+        aria-label={label}
+        aria-pressed={pressed}
+        aria-expanded={expanded}
+        disabled={disabled}
+        onClick={(event) => {
+          event.stopPropagation();
+          onClick();
+        }}
+        className={cn(
+          'inline-flex size-full shrink-0 items-center justify-center rounded-md font-medium text-muted-foreground transition-[background-color,color,opacity] focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]',
+          size === 'compact' ? 'text-3xs' : 'text-xs',
+          tintClasses(tone).hoverBgSoft,
+          tintClasses(tone).hoverText,
+          reveal ? cn('opacity-0', revealGroup) : disabled && 'opacity-40',
+          highlighted && cn(tintClasses(tone).bgSoft, tintClasses(tone).text),
+        )}
+      >
+        <Icon
+          size={size === 'compact' ? 12 : 14}
+          aria-hidden
+          className={cn(isDimmedInPlace && 'opacity-40')}
+        />
+      </button>
+    </Tooltip>
+  );
+};

--- a/packages/ui/src/components/CountToggle.tsx
+++ b/packages/ui/src/components/CountToggle.tsx
@@ -10,7 +10,7 @@ export type Props = {
   readonly onChange: (isShown: boolean) => void;
 };
 
-export const CountToggle = ({ label, count, isShown, icon, itemsLabel, onChange }: Props) => {
+export const CountToggle = ({ label, count, isShown, icon, onChange }: Props) => {
   if (count === 0) {
     return null;
   }
@@ -22,7 +22,6 @@ export const CountToggle = ({ label, count, isShown, icon, itemsLabel, onChange 
       type="button"
       onClick={() => onChange(!isShown)}
       aria-pressed={isShown}
-      title={`${isShown ? 'hide' : 'show'} ${label.toLowerCase()} ${itemsLabel}`}
       className={cn(
         'flex h-7 items-center gap-1 rounded-md px-1.5 text-2xs font-medium transition-colors',
         isShown

--- a/packages/ui/src/components/IconButton.tsx
+++ b/packages/ui/src/components/IconButton.tsx
@@ -11,6 +11,7 @@ export type IconButtonProps = Omit<ComponentProps<'button'>, 'type' | 'children'
   iconSize?: number;
   busy?: boolean;
   tone?: Tone;
+  variant?: 'outline' | 'ghost';
   type?: 'button' | 'submit' | 'reset';
 };
 
@@ -26,6 +27,7 @@ export const IconButton = ({
   iconSize = 13,
   busy = false,
   tone = 'neutral',
+  variant = 'outline',
   type = 'button',
   className,
   ...rest
@@ -36,9 +38,12 @@ export const IconButton = ({
         type={type}
         aria-label={label}
         className={cn(
-          'inline-flex items-center justify-center rounded-md border border-border-soft p-1.5',
+          'inline-flex items-center justify-center rounded-md p-1.5',
           'text-muted-foreground motion-safe:transition-colors',
-          'hover:border-border hover:bg-muted/50 hover:text-foreground disabled:opacity-50',
+          variant === 'outline'
+            ? 'border border-border-soft hover:border-border hover:bg-muted/50'
+            : 'border border-transparent hover:bg-muted/60',
+          'hover:text-foreground disabled:opacity-50',
           'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]',
           tone !== 'neutral' && toneClasses(tone),
           busy && 'animate-border-pulse',

--- a/packages/ui/src/components/StatusDot.tsx
+++ b/packages/ui/src/components/StatusDot.tsx
@@ -62,7 +62,7 @@ export const StatusDot = ({
         'inline-block shrink-0 rounded-full',
         dim,
         dot,
-        pulsing ? 'motion-safe:animate-pulse' : '',
+        pulsing ? 'motion-safe:animate-soft-pulse' : '',
         className,
       )}
       {...ariaProps}

--- a/packages/ui/src/format-cost.test.ts
+++ b/packages/ui/src/format-cost.test.ts
@@ -14,7 +14,22 @@ describe('formatUsd', () => {
   it('formats values across precision boundaries', () => {
     expect(formatUsd(0)).toBe('$0');
     expect(formatUsd(0.005)).toBe('<$0.01');
-    expect(formatUsd(0.5)).toBe('$0.500');
+    expect(formatUsd(0.5)).toBe('$0.50');
     expect(formatUsd(12.3)).toBe('$12.30');
+  });
+
+  it('keeps a column of costs on one number of decimals', () => {
+    expect([0.02, 0.34, 0.75, 1.2, 4.82].map((usd) => formatUsd(usd))).toEqual([
+      '$0.02',
+      '$0.34',
+      '$0.75',
+      '$1.20',
+      '$4.82',
+    ]);
+  });
+
+  it('says a sub-cent amount is under a cent instead of rounding it away', () => {
+    expect(formatUsd(0.0001)).toBe('<$0.01');
+    expect(formatUsd(0.0099)).toBe('<$0.01');
   });
 });

--- a/packages/ui/src/format-cost.ts
+++ b/packages/ui/src/format-cost.ts
@@ -5,9 +5,6 @@ export const formatUsd = (usd: number): string => {
   if (usd < 0.01) {
     return '<$0.01';
   }
-  if (usd < 1) {
-    return `$${usd.toFixed(3)}`;
-  }
   return `$${usd.toFixed(2)}`;
 };
 


### PR DESCRIPTION
The stage board read as chrome rather than work: up to eleven always visible icon controls per card, a rail step fill wearing a floating step shadow with its title at 70 percent opacity, five filled badges heading the columns, and done and archived open by default pushing six columns into a raw horizontal scroller.

## What changed

- **One visible action plus the chevron at rest.** Everything else appears on hover and keyboard focus, in a slot that does not move.
- **The card leads.** Elevated surface, soft border, full strength title. A running session carries the registered moving border instead of a static one.
- **Terminal state hides behind a count.** Done and archived collapse to a label and a number, so all six columns fit 1440 pixels and the horizontal scroller is gone.
- **Column labels are tinted text, not filled badges.** The loudest thing on the board is the work.
- Off scale values removed: `text-[9px]` counts, `text-[0.78em]` cents, margins used as separation.

## Two fixes that reach past the board

- **`CardAction` reveal precedence.** `disabled:opacity-40` outranked the reveal's `opacity-0`, so a disabled revealed action stayed visible at rest. The one action per row rule was broken on every card in the product whenever an action was unavailable. `SummaryBlock` and `DecisionRowItem` carried the same bug and are fixed by the same change.
- **`formatUsd`** rendered three decimals under a dollar and two above, so a column of costs did not align. Sub cent values still say `<$0.01` rather than rounding to zero.

## Also

A `board` scene was added to the mock harness, which is how the two defects above were found: rendered pixels, not source review.

## Verification

`desktop test` 7062 passed, `ui test` 250 passed, typecheck clean.

Part of the 0.2.23 package. Merges after #1709.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
