### PR TITLE
feat(desktop): reach mount from the projects block, tighten its rows

### DIFF
--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/MountProjectAction.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/MountProjectAction.test.tsx
@@ -1,0 +1,106 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { Project, SessionId, WorkspaceId } from '@goodboy/types';
+
+const { store } = vi.hoisted(() => ({
+  store: {
+    projects: [] as ReadonlyArray<Record<string, unknown>>,
+    sessionProjectMounts: {} as Record<string, ReadonlyArray<Record<string, unknown>>>,
+    materializeProject: vi.fn(async () => undefined),
+    emitNotification: vi.fn(),
+  },
+}));
+
+vi.mock('../../../../../store', () => ({
+  useAppStore: <T,>(selector: (state: typeof store) => T) => selector(store),
+}));
+
+import { MountProjectAction } from './MountProjectAction';
+
+const typedString = <Value extends string>({ value }: { readonly value: string }): Value =>
+  JSON.parse(JSON.stringify(value));
+
+const SESSION_ID = typedString<SessionId>({ value: 'session-1' });
+const WORKSPACE_ID = typedString<WorkspaceId>({ value: 'workspace-1' });
+
+const project = ({ id, name }: { readonly id: string; readonly name: string }): Project =>
+  ({
+    id: typedString({ value: id }),
+    workspaceId: WORKSPACE_ID,
+    name,
+    kind: 'repo',
+    rootPath: `/repo/${id}`,
+  }) as Project;
+
+const openPicker = () => {
+  fireEvent.click(screen.getByRole('button', { name: 'Mount project' }));
+};
+
+describe('MountProjectAction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    store.projects = [];
+    store.sessionProjectMounts = {};
+  });
+  afterEach(cleanup);
+
+  it('renders a single labelled action regardless of mount state', () => {
+    render(
+      <MountProjectAction
+        sessionId={SESSION_ID}
+        workspaceId={WORKSPACE_ID}
+        presentation="button"
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Mount project' })).toBeDefined();
+  });
+
+  it('tells the workspace has no projects at all', () => {
+    store.projects = [];
+    render(
+      <MountProjectAction
+        sessionId={SESSION_ID}
+        workspaceId={WORKSPACE_ID}
+        presentation="button"
+      />,
+    );
+    openPicker();
+
+    expect(screen.getByText('Add a project in workspace settings to mount it here.')).toBeDefined();
+  });
+
+  it('distinguishes an all-mounted workspace from an empty one', () => {
+    store.projects = [project({ id: 'api', name: 'API' })];
+    store.sessionProjectMounts = {
+      'session-1': [{ mountId: 'mount-1', projectId: 'api' }],
+    };
+    render(
+      <MountProjectAction
+        sessionId={SESSION_ID}
+        workspaceId={WORKSPACE_ID}
+        presentation="button"
+      />,
+    );
+    openPicker();
+
+    expect(screen.getByText('Every workspace project is already mounted.')).toBeDefined();
+    expect(screen.queryByText('Add a project in workspace settings to mount it here.')).toBeNull();
+  });
+
+  it('lists an unmounted project for mounting', () => {
+    store.projects = [project({ id: 'api', name: 'API' })];
+    render(
+      <MountProjectAction
+        sessionId={SESSION_ID}
+        workspaceId={WORKSPACE_ID}
+        presentation="button"
+      />,
+    );
+    openPicker();
+
+    expect(screen.getByRole('button', { name: 'Mount API' })).toBeDefined();
+  });
+});

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/MountProjectAction.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/MountProjectAction.test.tsx
@@ -2,7 +2,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
-import type { Project, SessionId, WorkspaceId } from '@goodboy/types';
+import type { SessionId, WorkspaceId } from '@goodboy/types';
 
 const { store } = vi.hoisted(() => ({
   store: {
@@ -25,14 +25,13 @@ const typedString = <Value extends string>({ value }: { readonly value: string }
 const SESSION_ID = typedString<SessionId>({ value: 'session-1' });
 const WORKSPACE_ID = typedString<WorkspaceId>({ value: 'workspace-1' });
 
-const project = ({ id, name }: { readonly id: string; readonly name: string }): Project =>
-  ({
-    id: typedString({ value: id }),
-    workspaceId: WORKSPACE_ID,
-    name,
-    kind: 'repo',
-    rootPath: `/repo/${id}`,
-  }) as Project;
+const project = ({ id, name }: { readonly id: string; readonly name: string }) => ({
+  id,
+  workspaceId: WORKSPACE_ID,
+  name,
+  kind: 'repo',
+  rootPath: `/repo/${id}`,
+});
 
 const openPicker = () => {
   fireEvent.click(screen.getByRole('button', { name: 'Mount project' }));

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/MountProjectAction.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/MountProjectAction.tsx
@@ -13,10 +13,19 @@ type Props = {
   readonly presentation?: 'icon' | 'button';
 };
 
+const emptyPickerMessage = ({
+  hasWorkspaceProjects,
+}: {
+  readonly hasWorkspaceProjects: boolean;
+}): string =>
+  hasWorkspaceProjects
+    ? 'Every workspace project is already mounted.'
+    : 'Add a project in workspace settings to mount it here.';
+
 export const MountProjectAction = ({ sessionId, workspaceId, presentation = 'icon' }: Props) => {
   const dropdown = useDropdown({ width: 'w-80', expectedHeight: 320 });
   const [isComplete, setIsComplete] = useState(false);
-  const projects = useAppStore(
+  const availableProjects = useAppStore(
     useShallow((state) => {
       const mounts = state.sessionProjectMounts[sessionId] ?? [];
       return state.projects.filter(
@@ -26,13 +35,16 @@ export const MountProjectAction = ({ sessionId, workspaceId, presentation = 'ico
       );
     }),
   );
-  const label = presentation === 'icon' ? 'Mount a project' : 'Mount project';
+  const hasWorkspaceProjects = useAppStore((state) =>
+    state.projects.some((project) => project.workspaceId === workspaceId),
+  );
+  const label = 'Mount project';
 
   return (
     <AnchoredPopover
       dropdown={dropdown}
       role="dialog"
-      ariaLabel="Mount a project"
+      ariaLabel={label}
       anchorClassName="shrink-0"
       trigger={
         presentation === 'icon' ? (
@@ -67,14 +79,14 @@ export const MountProjectAction = ({ sessionId, workspaceId, presentation = 'ico
         )
       }
     >
-      {projects.length === 0 || isComplete ? (
+      {availableProjects.length === 0 || isComplete ? (
         <p className="px-3 py-2 text-xs text-muted-foreground">
-          Every workspace project is already mounted
+          {emptyPickerMessage({ hasWorkspaceProjects })}
         </p>
       ) : (
         <MountProjectList
           sessionId={sessionId}
-          projects={projects}
+          projects={availableProjects}
           onDone={() => {
             setIsComplete(true);
             dropdown.close();

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/MountProjectList.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/MountProjectList.tsx
@@ -21,7 +21,8 @@ export const MountProjectList = ({ sessionId, projects, onDone }: Props) => {
   const materializeProject = useAppStore((state) => state.materializeProject);
   const emitNotification = useAppStore((state) => state.emitNotification);
   const [query, setQuery] = useState('');
-  const [isBusy, setIsBusy] = useState(false);
+  const [mountingProjectId, setMountingProjectId] = useState<Project['id'] | null>(null);
+  const isBusy = mountingProjectId !== null;
   const isSearchable = projects.length > SEARCH_THRESHOLD;
   const filtered = useMemo(
     () => projects.filter((project) => project.name.toLowerCase().includes(query.toLowerCase())),
@@ -29,7 +30,7 @@ export const MountProjectList = ({ sessionId, projects, onDone }: Props) => {
   );
 
   const mountProject = async ({ project }: MountParams) => {
-    setIsBusy(true);
+    setMountingProjectId(project.id);
     try {
       await materializeProject({ sessionId, projectId: project.id, reason: MANUAL_REASON });
       setQuery('');
@@ -40,7 +41,7 @@ export const MountProjectList = ({ sessionId, projects, onDone }: Props) => {
         workspaceId: project.workspaceId,
       });
     } finally {
-      setIsBusy(false);
+      setMountingProjectId(null);
     }
   };
 
@@ -64,16 +65,19 @@ export const MountProjectList = ({ sessionId, projects, onDone }: Props) => {
           <ul>
             {filtered.map((project) => {
               const GlyphIcon = projectGlyph({ kind: project.kind });
+              const isMounting = mountingProjectId === project.id;
               return (
                 <li key={project.id}>
                   <button
                     type="button"
                     disabled={isBusy}
                     aria-label={`Mount ${project.name}`}
+                    aria-busy={isMounting}
                     onClick={() => void mountProject({ project })}
                     className={cn(
-                      'flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm text-foreground motion-safe:transition-colors hover:bg-muted/40',
-                      isBusy && 'pointer-events-none opacity-50',
+                      'flex w-full items-center gap-2 rounded-md px-3 py-1.5 text-left text-sm text-foreground motion-safe:transition-colors hover:bg-muted/40',
+                      isBusy && !isMounting && 'pointer-events-none opacity-50',
+                      isMounting && 'spin-border spin-border-info',
                     )}
                   >
                     <GlyphIcon

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectMountRow.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectMountRow.tsx
@@ -110,7 +110,7 @@ export const ProjectMountRow = ({
       aria-label={label}
       className="group/mount-row flex w-full flex-col"
     >
-      <div className="flex min-h-10 w-full items-center gap-2 rounded-md px-2 py-1.5 hover:bg-muted/40">
+      <div className="flex min-h-8 w-full items-center gap-2 rounded-md px-2 py-1 hover:bg-muted/40">
         <div className={SLOT_BRANCH}>
           {isStatusPending && row.branch === '' ? (
             <span data-testid="project-branch-skeleton" className="shrink-0">

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/index.test.tsx
@@ -215,7 +215,7 @@ describe('ProjectMountRows', () => {
       expect((block as HTMLElement).className).not.toContain('border');
       expect(within(block as HTMLElement).getAllByTestId('project-mount-row')).toHaveLength(1);
     }
-    expect(blocks[0]?.parentElement?.className).toContain('gap-4');
+    expect(blocks[0]?.parentElement?.className).toContain('gap-6');
   });
 
   it('renders one row per branch mount of the same project', () => {
@@ -379,6 +379,9 @@ describe('ProjectMountRows', () => {
     expect(screen.getByText('Projects')).toBeDefined();
     expect(screen.queryByText('No project mounted yet')).toBeNull();
     expect(screen.getByRole('button', { name: 'Mount project' })).toBeDefined();
+    expect(
+      screen.getByText('Mount a workspace project to make it available in this session.'),
+    ).toBeDefined();
   });
 
   it('keeps the mount action in the section header when mounts exist', () => {
@@ -398,5 +401,8 @@ describe('ProjectMountRows', () => {
 
     expect(screen.getByRole('button', { name: 'Mount project' })).toBeDefined();
     expect(screen.getByTestId('project-mount-row')).toBeDefined();
+    expect(
+      screen.queryByText('Mount a workspace project to make it available in this session.'),
+    ).toBeNull();
   });
 });

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/index.tsx
@@ -42,10 +42,21 @@ export const ProjectMountRows = ({ session, onSelectLens }: Props) => {
     <section aria-label="Mounted projects" className="flex min-w-0 flex-col gap-2">
       <SectionHeader
         label="Projects"
-        action={<MountProjectAction sessionId={session.id} workspaceId={session.workspaceId} />}
+        action={
+          <MountProjectAction
+            sessionId={session.id}
+            workspaceId={session.workspaceId}
+            presentation="button"
+          />
+        }
+        hint={
+          groups.length === 0
+            ? 'Mount a workspace project to make it available in this session.'
+            : undefined
+        }
       />
       {groups.length === 0 ? null : (
-        <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-6">
           {groups.map((group) => (
             <ProjectMountGroup
               key={group.projectId}

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -88,12 +88,13 @@ grid, so no column resize, no hide animation and no overlay can move it.
 **The pane** is the work: the only surface that scrolls its own body, mounts
 editors and takes a title.
 
-**The scope bar states which projects a session has materialized.** It sits
-above the session pane, lists the mounted projects, and carries the
-**+ project** chip that materializes another one. It renders only when there
-is a choice to state: one mount in a one-project workspace needs no bar.
-Sessions are created lazily on the workspace ([concepts.md](concepts.md) →
-Lazy sessions), so the bar is also where a session's footprint grows.
+**The projects section states which projects a session has materialized.** It
+lives in the session overview and always carries the Mount project action,
+including before the first mount. Mounted projects appear as dense rows; the
+empty section is one quiet action row with a short explanation. Sessions are
+created lazily on the workspace ([concepts.md](concepts.md) → Lazy sessions),
+and this section is where a session's footprint grows. The session header
+does not carry a second mount control.
 
 **Inside a session the sidebar stays the sessions list.** There is no second
 mode: the sidebar lists the workspace's sessions grouped by stage, and the open


### PR DESCRIPTION
Issue #1714 says the projects block has no way to mount a project, and that the only route the reporter found was a suggestion that happened to appear. It was there, but as an unlabelled icon: `MountProjectAction` defaults to `presentation='icon'` and the projects section header used that default. It now renders as a labelled `Mount project` control, always, including before the first mount.

The zero-mount case is a quiet action row carrying one sentence instead of an empty section. The picker now distinguishes a workspace with no projects from one where everything is already mounted, and the row being mounted carries a moving border rather than dimming the whole list.

Density: the owner asked for less space between a project and its own branches and a little more between one project and the next. Measured in a live render rather than read off the classes, the coded gaps were already 4px within a group and 16px between groups; the visual gap came from the row's own padding, which added about 8px above and below each row. The row keeps a 36px rendered height, above the 32px hit target floor, and groups are now 24px apart.

`docs/navigation.md` loses the stale scope-bar paragraph.

One bug caught only because the change was checked against pixels: returning `{ availableProjects, hasWorkspaceProjects }` from a single `useShallow` selector loops forever, since the nested array is a fresh reference each render and shallow comparison only goes one level. The mocked store in unit tests does not go through `useSyncExternalStore`, so the tests passed while the app did not render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)