### PR TITLE
fix(desktop): say each branch once in the mismatch note

### DIFF
--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/MountBranchDecision.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/MountBranchDecision.test.tsx
@@ -43,7 +43,7 @@ const renderDecision = ({ next = {}, holder = null }: RenderParams = {}) =>
     <MountBranchDecision
       sessionId={sessionId}
       mountId={mountId}
-      mountLabel="ledger-core on ak/part-one"
+      projectName="ledger-core"
       repoRoot="/repos/ledger-core"
       worktreePath="/worktrees/part-one"
       observation={{ ...observation, ...next }}
@@ -61,11 +61,9 @@ describe('MountBranchDecision', () => {
   it('names the mount, the recorded branch and the one found', () => {
     renderDecision();
 
-    expect(screen.getByText('ledger-core on ak/part-one has a different branch')).toBeDefined();
+    expect(screen.getByText('ledger-core is not on the branch it was left on')).toBeDefined();
     expect(
-      screen.getByText(
-        'ledger-core on ak/part-one was expected on ak/part-one, but Goodboy found ak/part-two. Nothing was changed.',
-      ),
+      screen.getByText('Expected ak/part-one, found ak/part-two. Nothing was changed.'),
     ).toBeDefined();
   });
 
@@ -106,10 +104,10 @@ describe('MountBranchDecision', () => {
   it('turns off adopting a branch another mount already holds', () => {
     renderDecision({ holder: { mountId: 'mount-2' as MountId, label: 'PR #418' } });
 
-    expect(screen.getByText('ledger-core on ak/part-one has a different branch')).toBeDefined();
+    expect(screen.getByText('ledger-core is not on the branch it was left on')).toBeDefined();
     expect(
       screen.getByText(
-        'ledger-core on ak/part-one was expected on ak/part-one, but Goodboy found ak/part-two. ak/part-two is already mounted as PR #418 in this session. Git keeps one branch in one worktree, so using it here would fail.',
+        'Expected ak/part-one, found ak/part-two. That branch is already mounted as PR #418 in this session. Git keeps one branch in one worktree, so using it here would fail.',
       ),
     ).toBeDefined();
     expect(
@@ -137,7 +135,10 @@ describe('MountBranchDecision', () => {
   it('puts a detached mount back on its recorded branch', async () => {
     renderDecision({ next: { state: 'detached', observedBranch: null } });
 
-    expect(screen.getByText('ledger-core on ak/part-one is not on a branch')).toBeDefined();
+    expect(screen.getByText('ledger-core is not on a branch')).toBeDefined();
+    expect(
+      screen.getByText('Expected ak/part-one, found a commit with no branch. Nothing was changed.'),
+    ).toBeDefined();
     await waitFor(() =>
       expect(
         screen.getByRole('button', { name: 'Put it back on ak/part-one' }).hasAttribute('disabled'),
@@ -157,7 +158,12 @@ describe('MountBranchDecision', () => {
   it('offers a reread when the directory could not be read', () => {
     renderDecision({ next: { state: 'unavailable', observedBranch: null } });
 
-    expect(screen.getByText('ledger-core on ak/part-one could not be read')).toBeDefined();
+    expect(screen.getByText("ledger-core's branch could not be read")).toBeDefined();
+    expect(
+      screen.getByText(
+        'Expected ak/part-one, but the directory could not be read. Nothing was changed.',
+      ),
+    ).toBeDefined();
     expect(
       screen.getByRole('button', { name: 'Check this mount again' }).hasAttribute('disabled'),
     ).toBe(false);
@@ -179,7 +185,7 @@ describe('MountBranchDecision', () => {
     await waitFor(() =>
       expect(
         screen.getByText(
-          'ledger-core on ak/part-one was expected on ak/part-one, but Goodboy found ak/part-two. ak/part-two is already mounted in another worktree of this project. Git keeps one branch in one worktree, so using it here would fail.',
+          'Expected ak/part-one, found ak/part-two. That branch is already mounted in another worktree of this project. Git keeps one branch in one worktree, so using it here would fail.',
         ),
       ).toBeDefined(),
     );

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/MountBranchDecision.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/MountBranchDecision.tsx
@@ -17,7 +17,7 @@ import { buildBranchDecision } from './branchDecision';
 type Props = {
   readonly sessionId: SessionId;
   readonly mountId: MountId;
-  readonly mountLabel: string;
+  readonly projectName: string;
   readonly repoRoot: string;
   readonly worktreePath: string | null;
   readonly observation: MountBranchObservation;
@@ -31,7 +31,7 @@ type ResolveParams = {
 export const MountBranchDecision = ({
   sessionId,
   mountId,
-  mountLabel,
+  projectName,
   repoRoot,
   worktreePath,
   observation,
@@ -79,7 +79,7 @@ export const MountBranchDecision = ({
     };
   }, [holder, observation.state, repoRoot, targetBranch, worktreePath]);
 
-  const decision = buildBranchDecision({ observation, mountLabel, holder: resolvedHolder });
+  const decision = buildBranchDecision({ observation, projectName, holder: resolvedHolder });
 
   if (isDismissed || decision === null) {
     return null;

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectMountRow.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectMountRow.tsx
@@ -291,7 +291,7 @@ export const ProjectMountRow = ({
           <MountBranchDecision
             sessionId={sessionId}
             mountId={row.mountId}
-            mountLabel={label}
+            projectName={row.projectName}
             repoRoot={row.repoRoot}
             worktreePath={row.worktreePath}
             observation={observation}

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/branchDecision.ts
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/branchDecision.ts
@@ -3,7 +3,7 @@ import type { MountBranchHolder } from '../../../../../store/slices/project-moun
 
 type Params = {
   readonly observation: MountBranchObservation;
-  readonly mountLabel: string;
+  readonly projectName: string;
   readonly holder: MountBranchHolder | 'checking' | null;
 };
 
@@ -36,7 +36,7 @@ const recheck = ({ isDisabled }: RecheckParams): BranchDecisionAction => ({
 
 export const buildBranchDecision = ({
   observation,
-  mountLabel,
+  projectName,
   holder,
 }: Params): BranchDecision | null => {
   const recorded = observation.recordedBranch;
@@ -46,8 +46,8 @@ export const buildBranchDecision = ({
       return null;
     case 'unavailable':
       return {
-        title: `${mountLabel} could not be read`,
-        description: `${mountLabel} was expected on ${recorded}, but Goodboy could not read its directory. Nothing was changed.`,
+        title: `${projectName}'s branch could not be read`,
+        description: `Expected ${recorded}, but the directory could not be read. Nothing was changed.`,
         notes: [RECHECK_NOTE, NOT_NOW_NOTE],
         confirm: recheck({ isDisabled: false }),
         alt: null,
@@ -56,8 +56,8 @@ export const buildBranchDecision = ({
       const isChecking = holder === 'checking';
       const isHeld = holder !== null && holder !== 'checking';
       return {
-        title: `${mountLabel} is not on a branch`,
-        description: `${mountLabel} was expected on ${recorded}, but Goodboy found a commit with no branch. Nothing was changed.`,
+        title: `${projectName} is not on a branch`,
+        description: `Expected ${recorded}, found a commit with no branch. Nothing was changed.`,
         notes: [
           ...(isChecking
             ? [
@@ -87,8 +87,8 @@ export const buildBranchDecision = ({
       const found = observed ?? 'another branch';
       if (holder === 'checking') {
         return {
-          title: `${mountLabel} has a different branch`,
-          description: `${mountLabel} was expected on ${recorded}, but Goodboy found ${found}. Nothing was changed.`,
+          title: `${projectName} is not on the branch it was left on`,
+          description: `Expected ${recorded}, found ${found}. Nothing was changed.`,
           notes: [
             `Goodboy is checking whether ${found} is mounted in another worktree.`,
             RECHECK_NOTE,
@@ -110,8 +110,8 @@ export const buildBranchDecision = ({
               ? 'in another mount of this session'
               : `as ${holder.label} in this session`;
         return {
-          title: `${mountLabel} has a different branch`,
-          description: `${mountLabel} was expected on ${recorded}, but Goodboy found ${found}. ${found} is already mounted ${location}. Git keeps one branch in one worktree, so using it here would fail.`,
+          title: `${projectName} is not on the branch it was left on`,
+          description: `Expected ${recorded}, found ${found}. That branch is already mounted ${location}. Git keeps one branch in one worktree, so using it here would fail.`,
           notes: [
             `Use this branch here is turned off because ${found} is mounted elsewhere.`,
             RECHECK_NOTE,
@@ -126,8 +126,8 @@ export const buildBranchDecision = ({
         };
       }
       return {
-        title: `${mountLabel} has a different branch`,
-        description: `${mountLabel} was expected on ${recorded}, but Goodboy found ${found}. Nothing was changed.`,
+        title: `${projectName} is not on the branch it was left on`,
+        description: `Expected ${recorded}, found ${found}. Nothing was changed.`,
         notes: [
           `Use this branch here records ${found} as this mount's branch and leaves the directory alone.`,
           `Keep both branches records ${found} here, then mounts ${recorded} again in a row of its own.`,


### PR DESCRIPTION
The banner shipped in #1719 reads correctly and says too much. `mountLabel` already expands to `<project> on <recorded branch>`, so the title and the description repeated the project name twice and the recorded branch three times, twice inside one sentence. With real branch names that is four near-identical lines, and the one fact that matters, the branch actually found, sat at the end of them.

Each fact is now stated once. Only the wording changes: same states, same controls, same disabled logic.

| State | Title | Description |
| --- | --- | --- |
| Mismatch | `ledger-core is not on the branch it was left on` | `Expected ak/part-one, found ak/part-two. Nothing was changed.` |
| Mismatch, branch mounted elsewhere | `ledger-core is not on the branch it was left on` | `Expected ak/part-one, found ak/part-two. That branch is already mounted as PR #418 in this session. Git keeps one branch in one worktree, so using it here would fail.` |
| Detached head | `ledger-core is not on a branch` | `Expected ak/part-one, found a commit with no branch. Nothing was changed.` |
| Unreadable | `ledger-core's branch could not be read` | `Expected ak/part-one, but the directory could not be read. Nothing was changed.` |

Verified by rendering the scene and reading it, not only by the tests: `?scene=mount-mismatch` at 1440x900. Typecheck clean on desktop and ui, 799 test files and 7245 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)