### PR TITLE
fix(desktop): rework rebase suggestion and completed mounts

### DIFF
--- a/apps/desktop/src/features/session/components/CreateAgentPopover/CreateAgentTrigger.tsx
+++ b/apps/desktop/src/features/session/components/CreateAgentPopover/CreateAgentTrigger.tsx
@@ -20,7 +20,7 @@ export const CreateAgentTrigger = ({ variant, isOpen, className, description, on
   if (variant === 'compact') {
     return (
       <Button
-        variant="ghost"
+        variant="primary"
         size="sm"
         onClick={onClick}
         aria-haspopup="dialog"

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/OverviewActions/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/OverviewActions/index.tsx
@@ -11,7 +11,7 @@ type Props = {
 export const OverviewActions = ({ sessionId, onOpenWorkflowBuilder }: Props) => {
   return (
     <div className="flex shrink-0 flex-wrap items-center gap-1">
-      <Button variant="ghost" size="sm" onClick={onOpenWorkflowBuilder}>
+      <Button variant="secondary" size="sm" onClick={onOpenWorkflowBuilder}>
         <CONCEPT_ICONS.workflows size={ICON_SIZE.row} aria-hidden />
         Add workflow
       </Button>

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectMountRow.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectMountRow.test.tsx
@@ -470,6 +470,15 @@ describe('ProjectMountRow loading placeholders', () => {
     expect(screen.getByTestId('sync-control')).not.toBeNull();
   });
 
+  it('hides the sync control only for a completed row', () => {
+    renderRow({ worktreeStatus: status, row: { ...baseRow, isCompleted: true } });
+    expect(screen.queryByTestId('sync-control')).toBeNull();
+    cleanup();
+
+    renderRow({ worktreeStatus: status });
+    expect(screen.getByTestId('sync-control')).not.toBeNull();
+  });
+
   it('holds a branch placeholder instead of an empty branch cell', () => {
     renderRow({ isStatusPending: true, row: { ...baseRow, branch: '' } });
 

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectMountRow.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectMountRow.tsx
@@ -138,7 +138,7 @@ export const ProjectMountRow = ({
           </div>
         ) : null}
         <div className={SLOT_SYNC}>
-          {isRepo && row.isAttached ? (
+          {isRepo && row.isAttached && !row.isCompleted ? (
             isStatusPending ? (
               <span data-testid="project-distance-skeleton" className="shrink-0">
                 <Skeleton className="size-7 rounded-md" />

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineSuggestionRow.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/TimelinePane/TimelineSuggestionRow.tsx
@@ -1,6 +1,7 @@
 import { X } from 'lucide-react';
-import { Button, Tooltip, cn, tintClasses } from '@goodboy/ui';
+import { Tooltip, cn, tintClasses } from '@goodboy/ui';
 import { ICON_SIZE } from '../../../../../../shared/components/conceptIcons';
+import { SuggestionActionButton } from '../../../../../suggestions/components/SuggestionActionButton';
 import { SUGGESTION_ICONS } from '../../../../../suggestions/suggestionIcons';
 import type { SessionSuggestion } from '../../../../../suggestions';
 import type { SuggestionActions } from '../../../../../suggestions/useSuggestionActions';
@@ -47,15 +48,7 @@ export const TimelineSuggestionRow = ({ suggestion, railWidth, actions }: Props)
         )}
         <span className="ml-auto flex shrink-0 items-center gap-0.5">
           {actions.primary == null ? null : (
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-6"
-              disabled={actions.primary.isDisabled}
-              onClick={actions.primary.onAct}
-            >
-              {actions.primary.label}
-            </Button>
+            <SuggestionActionButton action={actions.primary} appearance="ghost" />
           )}
           {actions.onDismiss == null ? null : (
             <Tooltip content="Dismiss this suggestion">

--- a/apps/desktop/src/features/session/hooks/useRebaseAgent/index.test.ts
+++ b/apps/desktop/src/features/session/hooks/useRebaseAgent/index.test.ts
@@ -27,7 +27,12 @@ const { showToast, state } = vi.hoisted(() => ({
     },
     sessionProjectMounts: {} as Record<
       string,
-      ReadonlyArray<{ projectId: string; worktreePath?: string; mountName?: string }>
+      ReadonlyArray<{
+        mountId?: string;
+        projectId: string;
+        worktreePath?: string;
+        mountName?: string;
+      }>
     >,
     projects: [] as ReadonlyArray<{ id: string; baseBranch?: string | null; name?: string }>,
     sessionPhaseRuns: {} as Record<
@@ -248,6 +253,39 @@ describe('useRebaseAgent', () => {
 
     expect(prompt).toContain('This rebase belongs to mount mount-a at /wt/app.');
     expect(prompt).toContain('query github push --mount mount-a --force-with-lease');
+  });
+
+  it('records the selected mount and its per-run distance', async () => {
+    state.projects = [{ id: 'project-web', baseBranch: 'main', name: 'web' }];
+    state.sessionProjectMounts = {
+      [sessionId]: [
+        {
+          mountId: 'mount-first',
+          projectId: 'project-web',
+          worktreePath: '/wt/web-first',
+          mountName: 'web first',
+        },
+        {
+          mountId: 'mount-second',
+          projectId: 'project-web',
+          worktreePath: '/wt/web-second',
+          mountName: 'web second',
+        },
+      ],
+    };
+    const { result } = renderHook(() => useRebaseAgent({ sessionId, status: status(0) }));
+
+    await act(() => result.current.run({ mountId: 'mount-second' as never, behind: 3 }));
+
+    expect(state.recordSessionEvent).toHaveBeenCalledWith({
+      sessionId,
+      kind: 'rebase_requested',
+      payload: expect.objectContaining({ mountId: 'mount-second', behind: 3 }),
+    });
+    expect(state.spawnAgent).toHaveBeenCalledWith(
+      sessionId,
+      expect.objectContaining({ initialPrompt: expect.stringContaining('mount mount-second') }),
+    );
   });
 
   it('leaves the push command unscoped when the session has no mount to name', () => {

--- a/apps/desktop/src/features/session/hooks/useRebaseAgent/index.ts
+++ b/apps/desktop/src/features/session/hooks/useRebaseAgent/index.ts
@@ -24,6 +24,7 @@ type Params = {
 type RunParams = {
   readonly projectId?: ProjectId;
   readonly mountId?: MountId;
+  readonly behind?: number;
 };
 
 type Result = {
@@ -209,10 +210,13 @@ export const useRebaseAgent = ({ sessionId, status, onError }: Params): Result =
   ]);
 
   const run = async (params?: RunParams): Promise<void> => {
-    if (!canRebase || isRunning || sessionId == null || config.provider === '') {
+    const runParams = params ?? {};
+    const runBehind = runParams.behind ?? behindMain;
+    const canRunRebase = sessionId != null && runBehind != null && runBehind > 0;
+    if (!canRunRebase || isRunning || sessionId == null || config.provider === '') {
       return;
     }
-    const target = targetFor(params ?? {});
+    const target = targetFor(runParams);
     setError(null);
     setIsStarting(true);
     const creationId = beginSessionCreation(sessionId, {
@@ -241,7 +245,7 @@ export const useRebaseAgent = ({ sessionId, status, onError }: Params): Result =
           ...(target.projectId == null ? {} : { projectId: target.projectId }),
           ...(target.projectName == null ? {} : { projectName: target.projectName }),
           ...(target.worktreePath == null ? {} : { worktreePath: target.worktreePath }),
-          ...(behindMain == null ? {} : { behind: behindMain }),
+          behind: runBehind,
           branch: target.baseBranch,
           agentId,
         },

--- a/apps/desktop/src/features/suggestions/components/SuggestionActionButton.test.tsx
+++ b/apps/desktop/src/features/suggestions/components/SuggestionActionButton.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment happy-dom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { SuggestionAction } from '../useSuggestionActions';
+import { SuggestionActionButton } from './SuggestionActionButton';
+
+afterEach(cleanup);
+
+describe('SuggestionActionButton', () => {
+  it('opens target choices and runs the selected entry', () => {
+    const runFirst = vi.fn();
+    const runSecond = vi.fn();
+    const action = {
+      label: 'Rebase',
+      isDisabled: false,
+      onAct: runFirst,
+      choices: [
+        {
+          id: 'mount-first',
+          label: 'web',
+          description: 'web-first',
+          detail: '7 behind',
+          onAct: runFirst,
+        },
+        {
+          id: 'mount-second',
+          label: 'web',
+          description: 'web-second',
+          detail: '3 behind',
+          onAct: runSecond,
+        },
+      ],
+    } satisfies SuggestionAction;
+
+    render(<SuggestionActionButton action={action} appearance="ghost" />);
+    fireEvent.click(screen.getByRole('button', { name: 'Rebase' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: 'web web-second 3 behind' }));
+
+    expect(runFirst).not.toHaveBeenCalled();
+    expect(runSecond).toHaveBeenCalledOnce();
+    expect(screen.queryByRole('menu')).toBeNull();
+  });
+});

--- a/apps/desktop/src/features/suggestions/components/SuggestionActionButton.tsx
+++ b/apps/desktop/src/features/suggestions/components/SuggestionActionButton.tsx
@@ -1,0 +1,91 @@
+import { ChevronDown } from 'lucide-react';
+import { AnchoredPopover, Button, cn, useDropdown } from '@goodboy/ui';
+import { ICON_SIZE } from '../../../shared/components/conceptIcons';
+import type { SuggestionAction, SuggestionActionChoice } from '../useSuggestionActions';
+
+type Props = {
+  readonly action: SuggestionAction;
+  readonly appearance: 'outline' | 'ghost';
+};
+
+type ChooseParams = {
+  readonly choice: SuggestionActionChoice;
+  readonly close: () => void;
+};
+
+const choose = ({ choice, close }: ChooseParams) => {
+  close();
+  choice.onAct();
+};
+
+export const SuggestionActionButton = ({ action, appearance }: Props) => {
+  const choices = action.choices ?? [];
+  const dropdown = useDropdown({
+    align: 'end',
+    width: 'w-72',
+    expectedHeight: Math.min(320, 16 + choices.length * 44),
+  });
+  const buttonClassName = appearance === 'ghost' ? 'h-6' : undefined;
+
+  if (choices.length <= 1) {
+    return (
+      <Button
+        variant={appearance === 'ghost' ? 'ghost' : 'secondary'}
+        emphasis={appearance === 'ghost' ? 'solid' : 'outline'}
+        size="sm"
+        className={buttonClassName}
+        disabled={action.isDisabled}
+        onClick={action.onAct}
+      >
+        {action.label}
+      </Button>
+    );
+  }
+
+  return (
+    <AnchoredPopover
+      dropdown={dropdown}
+      role="menu"
+      ariaLabel="Choose rebase target"
+      trigger={
+        <Button
+          variant={appearance === 'ghost' ? 'ghost' : 'secondary'}
+          emphasis={appearance === 'ghost' ? 'solid' : 'outline'}
+          size="sm"
+          className={buttonClassName}
+          disabled={action.isDisabled}
+          onClick={dropdown.toggle}
+          aria-haspopup="menu"
+          aria-expanded={dropdown.open}
+        >
+          {action.label}
+          <ChevronDown
+            size={ICON_SIZE.row}
+            aria-hidden
+            className={cn('motion-safe:transition-transform', dropdown.open && 'rotate-180')}
+          />
+        </Button>
+      }
+    >
+      <div className="flex flex-col py-1">
+        {choices.map((choice) => (
+          <button
+            key={choice.id}
+            type="button"
+            role="menuitem"
+            onClick={() => choose({ choice, close: dropdown.close })}
+            className="flex w-full items-center gap-2 px-3 py-2 text-left text-foreground motion-safe:transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--color-focus-ring)]"
+          >
+            <span className="flex min-w-0 flex-1 items-baseline gap-2">
+              <span className="truncate text-xs font-medium">{choice.label}</span>
+              <span className="truncate text-2xs text-muted-foreground">{choice.description}</span>
+            </span>
+            <span className="shrink-0 text-2xs tabular-nums text-muted-foreground">
+              {choice.detail}
+            </span>
+          </button>
+        ))}
+      </div>
+    </AnchoredPopover>
+  );
+};

--- a/apps/desktop/src/features/suggestions/deriveSessionSuggestions.test.ts
+++ b/apps/desktop/src/features/suggestions/deriveSessionSuggestions.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type {
   AgentId,
+  MountId,
   PlanId,
   ProjectId,
   SessionEventId,
@@ -14,6 +15,7 @@ import type { SuggestionMountEvent, SuggestionMountEventKind } from './mountProp
 const sessionId = 'session-1' as SessionId;
 const planId = 'plan-1' as PlanId;
 const webId = 'project-web' as ProjectId;
+const webMountId = 'mount-web' as MountId;
 
 const mountEvent = ({
   id,
@@ -72,8 +74,11 @@ const derive = ({
     mountEvents,
     projects: [
       {
+        id: 'mount:mount-1',
+        mountId: 'mount-1' as MountId,
         projectId: 'project-1' as ProjectId,
         projectName: 'Goodboy',
+        branch: 'feature/goodboy',
         worktreePath: '/tmp/goodboy',
         baseBranch: 'main',
         mainDistance,
@@ -185,8 +190,11 @@ describe('deriveSessionSuggestions', () => {
 
   it('hides the rebase once a request covers the same distance and its agent did not fail', () => {
     const project = {
+      id: 'mount:mount-web',
+      mountId: webMountId,
       projectId: webId,
       projectName: 'web',
+      branch: 'feature/web',
       worktreePath: '/tmp/web',
       baseBranch: 'main',
       mainDistance: 126,
@@ -227,17 +235,17 @@ describe('deriveSessionSuggestions', () => {
       rebaseIds({ rebaseRequest: { behind: 126, baseBranch: null, agentStatus: 'running' } }),
     ).toEqual([]);
     expect(rebaseIds({ rebaseRequest: { behind: 126, agentStatus: 'failed' } })).toEqual([
-      'rebase-project:project-web',
+      'rebase-project:session-1',
     ]);
     expect(
       rebaseIds({ rebaseRequest: { behind: 126, agentStatus: 'completed' }, mainDistance: 129 }),
-    ).toEqual(['rebase-project:project-web']);
+    ).toEqual(['rebase-project:session-1']);
     expect(
       rebaseIds({ rebaseRequest: { behind: 126, baseBranch: 'develop', agentStatus: 'running' } }),
-    ).toEqual(['rebase-project:project-web']);
+    ).toEqual(['rebase-project:session-1']);
   });
 
-  it('orders equal-priority suggestions by id', () => {
+  it('collapses two mounts of one project into one ordered rebase suggestion', () => {
     const suggestions = deriveSessionSuggestions({
       sessionId,
       workflowRuns: [],
@@ -249,25 +257,102 @@ describe('deriveSessionSuggestions', () => {
       mountEvents: [],
       projects: [
         {
-          projectId: 'project-z' as ProjectId,
-          projectName: 'Zulu',
-          worktreePath: '/tmp/zulu',
+          id: 'mount:mount-second',
+          mountId: 'mount-second' as MountId,
+          projectId: webId,
+          projectName: 'web',
+          branch: 'feature/second',
+          worktreePath: '/tmp/web-second',
           baseBranch: 'main',
-          mainDistance: 1,
+          mainDistance: 2,
         },
         {
-          projectId: 'project-a' as ProjectId,
-          projectName: 'Alpha',
-          worktreePath: '/tmp/alpha',
+          id: 'mount:mount-first',
+          mountId: 'mount-first' as MountId,
+          projectId: webId,
+          projectName: 'web',
+          branch: 'feature/first',
+          worktreePath: '/tmp/web-first',
           baseBranch: 'main',
-          mainDistance: 1,
+          mainDistance: 7,
         },
       ],
     });
 
-    expect(suggestions.map((suggestion) => suggestion.id)).toEqual([
-      'rebase-project:project-a',
-      'rebase-project:project-z',
+    const rebase = suggestions.find((suggestion) => suggestion.kind === 'rebase-project');
+    expect(suggestions.filter((suggestion) => suggestion.kind === 'rebase-project')).toHaveLength(
+      1,
+    );
+    expect(rebase?.title).toBe('Rebase web');
+    expect(rebase?.detail).toBe('2 branches behind');
+    expect(rebase?.payload.targets.map((target) => target.mountId)).toEqual([
+      'mount-first',
+      'mount-second',
+    ]);
+  });
+
+  it('sorts several projects by distance and then project name without reordering ties', () => {
+    const suggestions = deriveSessionSuggestions({
+      sessionId,
+      workflowRuns: [],
+      plans: [],
+      consumedPlanIds: new Set<PlanId>(),
+      openQuestionCount: 0,
+      hasPullRequest: false,
+      eligibleThreadCount: 0,
+      mountEvents: [],
+      projects: [
+        {
+          id: 'mount:mount-zulu',
+          mountId: 'mount-zulu' as MountId,
+          projectId: 'project-zulu' as ProjectId,
+          projectName: 'Zulu',
+          branch: 'feature/zulu',
+          worktreePath: '/tmp/zulu',
+          baseBranch: 'main',
+          mainDistance: 3,
+        },
+        {
+          id: 'mount:mount-alpha-first',
+          mountId: 'mount-alpha-first' as MountId,
+          projectId: 'project-alpha' as ProjectId,
+          projectName: 'Alpha',
+          branch: 'feature/alpha-first',
+          worktreePath: '/tmp/alpha-first',
+          baseBranch: 'main',
+          mainDistance: 3,
+        },
+        {
+          id: 'mount:mount-alpha-second',
+          mountId: 'mount-alpha-second' as MountId,
+          projectId: 'project-alpha' as ProjectId,
+          projectName: 'Alpha',
+          branch: 'feature/alpha-second',
+          worktreePath: '/tmp/alpha-second',
+          baseBranch: 'main',
+          mainDistance: 3,
+        },
+        {
+          id: 'mount:mount-far',
+          mountId: 'mount-far' as MountId,
+          projectId: 'project-far' as ProjectId,
+          projectName: 'Far',
+          branch: 'feature/far',
+          worktreePath: '/tmp/far',
+          baseBranch: 'develop',
+          mainDistance: 8,
+        },
+      ],
+    });
+
+    const rebase = suggestions.find((suggestion) => suggestion.kind === 'rebase-project');
+    expect(rebase?.title).toBe('Rebase 4 branches');
+    expect(rebase?.detail).toBe('3 projects behind');
+    expect(rebase?.payload.targets.map((target) => target.mountId)).toEqual([
+      'mount-far',
+      'mount-alpha-first',
+      'mount-alpha-second',
+      'mount-zulu',
     ]);
   });
 });

--- a/apps/desktop/src/features/suggestions/deriveSessionSuggestions.ts
+++ b/apps/desktop/src/features/suggestions/deriveSessionSuggestions.ts
@@ -1,6 +1,6 @@
-import type { PlanId, ProjectId, SessionId, StepId, WorkflowRunId } from '@goodboy/types';
+import type { MountId, PlanId, ProjectId, SessionId, StepId, WorkflowRunId } from '@goodboy/types';
 import { pendingMountEvents, type SuggestionMountEvent } from './mountProposals';
-import type { SessionSuggestion } from './types';
+import type { RebaseSuggestionTarget, SessionSuggestion } from './types';
 
 export type SuggestionWorkflowRun = {
   readonly id: WorkflowRunId;
@@ -23,8 +23,11 @@ export type SuggestionRebaseRequest = {
 };
 
 export type SuggestionProject = {
+  readonly id: string;
+  readonly mountId: MountId | null;
   readonly projectId: ProjectId;
   readonly projectName: string;
+  readonly branch: string;
   readonly worktreePath: string;
   readonly baseBranch: string;
   readonly mainDistance: number | null;
@@ -136,6 +139,8 @@ export const deriveSessionSuggestions = ({
       payload: { eligibleThreadCount },
     });
   }
+  const rebaseTargets: RebaseSuggestionTarget[] = [];
+  const rebaseTargetIds = new Set<string>();
   for (const project of projects) {
     if (project.mainDistance == null || project.mainDistance <= 0) {
       continue;
@@ -143,19 +148,46 @@ export const deriveSessionSuggestions = ({
     if (isRebaseConsumed({ project })) {
       continue;
     }
+    if (rebaseTargetIds.has(project.id)) {
+      continue;
+    }
+    rebaseTargetIds.add(project.id);
+    rebaseTargets.push({
+      id: project.id,
+      mountId: project.mountId,
+      projectId: project.projectId,
+      projectName: project.projectName,
+      branch: project.branch,
+      worktreePath: project.worktreePath,
+      baseBranch: project.baseBranch,
+      behind: project.mainDistance,
+    });
+  }
+  rebaseTargets.sort(
+    (first, second) =>
+      second.behind - first.behind || first.projectName.localeCompare(second.projectName),
+  );
+  const firstRebaseTarget = rebaseTargets[0];
+  if (firstRebaseTarget != null) {
+    const projectCount = new Set(rebaseTargets.map((target) => target.projectId)).size;
+    const isSingleTarget = rebaseTargets.length === 1;
+    const isSingleProject = projectCount === 1;
     suggestions.push({
-      id: `rebase-project:${project.projectId}`,
+      id: `rebase-project:${sessionId}`,
       kind: 'rebase-project',
       priority: 40,
-      title: `Rebase ${project.projectName} on ${project.baseBranch}`,
-      detail: `${project.mainDistance} behind`,
+      title: isSingleTarget
+        ? `Rebase ${firstRebaseTarget.projectName} on ${firstRebaseTarget.baseBranch}`
+        : isSingleProject
+          ? `Rebase ${firstRebaseTarget.projectName}`
+          : `Rebase ${rebaseTargets.length} branches`,
+      detail: isSingleTarget
+        ? `${firstRebaseTarget.behind} behind`
+        : isSingleProject
+          ? `${rebaseTargets.length} branches behind`
+          : `${projectCount} projects behind`,
       sessionId,
-      payload: {
-        projectId: project.projectId,
-        worktreePath: project.worktreePath,
-        baseBranch: project.baseBranch,
-        behind: project.mainDistance,
-      },
+      payload: { targets: rebaseTargets },
     });
   }
   return suggestions.sort(

--- a/apps/desktop/src/features/suggestions/types.ts
+++ b/apps/desktop/src/features/suggestions/types.ts
@@ -1,5 +1,6 @@
 import type {
   AgentId,
+  MountId,
   PlanId,
   ProjectId,
   SessionEventId,
@@ -24,6 +25,17 @@ type SuggestionBase = {
   readonly sessionId: SessionId;
 };
 
+export type RebaseSuggestionTarget = {
+  readonly id: string;
+  readonly mountId: MountId | null;
+  readonly projectId: ProjectId;
+  readonly projectName: string;
+  readonly branch: string;
+  readonly worktreePath: string;
+  readonly baseBranch: string;
+  readonly behind: number;
+};
+
 export type SessionSuggestion =
   | (SuggestionBase & {
       readonly kind: 'workflow-next-step';
@@ -40,10 +52,7 @@ export type SessionSuggestion =
   | (SuggestionBase & {
       readonly kind: 'rebase-project';
       readonly payload: {
-        readonly projectId: ProjectId;
-        readonly worktreePath: string;
-        readonly baseBranch: string;
-        readonly behind: number;
+        readonly targets: ReadonlyArray<RebaseSuggestionTarget>;
       };
     })
   | (SuggestionBase & {

--- a/apps/desktop/src/features/suggestions/useSessionSuggestions/index.test.tsx
+++ b/apps/desktop/src/features/suggestions/useSessionSuggestions/index.test.tsx
@@ -11,8 +11,19 @@ const { store, worktreeStatus } = vi.hoisted(() => ({
     planConsumptions: {} as Record<string, ReadonlyArray<unknown>>,
     sessionGithub: {} as Record<string, unknown>,
     sessionResolveThreads: {} as Record<string, ReadonlyArray<unknown>>,
+    mountGithub: {} as Record<string, unknown>,
+    mountGitlabMr: {} as Record<string, unknown>,
+    mountBitbucketPr: {} as Record<string, unknown>,
     sessionProjectMounts: {
-      'session-1': [{ projectId: 'api', mountName: 'API', worktreePath: '/api', branch: 'feat' }],
+      'session-1': [
+        {
+          mountId: 'mount-api',
+          projectId: 'api',
+          mountName: 'API',
+          worktreePath: '/api',
+          branch: 'feat',
+        },
+      ],
     } as Record<string, ReadonlyArray<Record<string, string>>>,
     projects: [
       { id: 'api', name: 'API', baseBranch: 'main', workspaceId: 'ws-1' },
@@ -44,6 +55,21 @@ import { useSessionSuggestions } from '.';
 const session = { id: 'session-1', workspaceId: 'ws-1' } as Session;
 
 beforeEach(() => {
+  store.sessionProjectMounts = {
+    'session-1': [
+      {
+        mountId: 'mount-api',
+        projectId: 'api',
+        mountName: 'API',
+        worktreePath: '/api',
+        branch: 'feat',
+      },
+    ],
+  };
+  store.projects = [{ id: 'api', name: 'API', baseBranch: 'main', workspaceId: 'ws-1' }];
+  store.mountGithub = {};
+  store.mountGitlabMr = {};
+  store.mountBitbucketPr = {};
   worktreeStatus.mockReset();
   worktreeStatus.mockResolvedValue({
     branch: 'feat',
@@ -62,19 +88,68 @@ const rebaseRequested = ({
   behind,
   agentId,
   branch = 'main',
+  mountId,
 }: {
   behind: number;
   agentId: string;
   branch?: string;
+  mountId?: string;
 }) => ({
   id: `ev-${agentId}`,
   sessionId: 'session-1',
   kind: 'rebase_requested',
-  payload: { projectId: 'api', projectName: 'API', branch, behind, agentId },
+  payload: {
+    projectId: 'api',
+    projectName: 'API',
+    branch,
+    behind,
+    agentId,
+    ...(mountId === undefined ? {} : { mountId }),
+  },
   createdAt: '2026-09-04T09:11:00.000Z',
 });
 
 describe('useSessionSuggestions rebase consumption', () => {
+  it('skips a merged mount while its unfinished sibling still produces a rebase', async () => {
+    store.sessionProjectMounts = {
+      'session-1': [
+        {
+          mountId: 'mount-api',
+          projectId: 'api',
+          mountName: 'API merged',
+          worktreePath: '/api-merged',
+          branch: 'feat-merged',
+        },
+        {
+          mountId: 'mount-api-open',
+          projectId: 'api',
+          mountName: 'API open',
+          worktreePath: '/api-open',
+          branch: 'feat-open',
+        },
+      ],
+    };
+    store.mountGithub = {
+      'mount-api': {
+        pr: {
+          number: 12,
+          state: 'merged',
+          title: 'Merged request',
+          url: 'https://github.com/acme/api/pull/12',
+          isDraft: false,
+        },
+      },
+    };
+    const view = renderHook(() => useSessionSuggestions({ session }));
+
+    await waitFor(() => {
+      const rebase = view.result.current.find((candidate) => candidate.kind === 'rebase-project');
+      expect(rebase?.payload.targets.map((target) => target.mountId)).toEqual(['mount-api-open']);
+    });
+    expect(worktreeStatus).toHaveBeenCalledTimes(1);
+    expect(worktreeStatus).toHaveBeenCalledWith({ worktreePath: '/api-open', baseBranch: 'main' });
+  });
+
   it('hides the rebase after a request while the distance is unchanged', async () => {
     store.sessionEvents = { 'session-1': [rebaseRequested({ behind: 4, agentId: 'agent-1' })] };
     store.sessionPhaseRuns = { 'session-1': [{ id: 'agent-1', status: 'running' }] };
@@ -117,6 +192,38 @@ describe('useSessionSuggestions rebase consumption', () => {
       expect(view.result.current.some((s) => s.kind === 'rebase-project')).toBe(true),
     );
   });
+
+  it('consumes only the mount named by a new rebase request', async () => {
+    store.sessionProjectMounts = {
+      'session-1': [
+        {
+          mountId: 'mount-api',
+          projectId: 'api',
+          mountName: 'API first',
+          worktreePath: '/api-first',
+          branch: 'feat-first',
+        },
+        {
+          mountId: 'mount-api-second',
+          projectId: 'api',
+          mountName: 'API second',
+          worktreePath: '/api-second',
+          branch: 'feat-second',
+        },
+      ],
+    };
+    store.sessionEvents = {
+      'session-1': [rebaseRequested({ behind: 4, agentId: 'agent-1', mountId: 'mount-api' })],
+    };
+    store.sessionPhaseRuns = { 'session-1': [{ id: 'agent-1', status: 'running' }] };
+    const view = renderHook(() => useSessionSuggestions({ session }));
+
+    await waitFor(() => expect(worktreeStatus).toHaveBeenCalledTimes(2));
+    await waitFor(() => {
+      const rebase = view.result.current.find((candidate) => candidate.kind === 'rebase-project');
+      expect(rebase?.payload.targets.map((target) => target.mountId)).toEqual(['mount-api-second']);
+    });
+  });
 });
 
 describe('useSessionSuggestions rebase opt-out', () => {
@@ -127,6 +234,64 @@ describe('useSessionSuggestions rebase opt-out', () => {
       expect(view.result.current.some((s) => s.kind === 'rebase-project')).toBe(true),
     );
     expect(worktreeStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps a mountless worktree as a rebase target', async () => {
+    store.sessionProjectMounts = {
+      'session-1': [
+        {
+          projectId: 'api',
+          mountName: 'API',
+          worktreePath: '/api',
+          branch: 'feature/api',
+        },
+      ],
+    };
+    const view = renderHook(() => useSessionSuggestions({ session }));
+
+    await waitFor(() => {
+      const rebase = view.result.current.find((candidate) => candidate.kind === 'rebase-project');
+      expect(rebase?.payload.targets).toEqual([
+        expect.objectContaining({
+          id: 'worktree:/api',
+          mountId: null,
+          projectId: 'api',
+          branch: 'feature/api',
+          worktreePath: '/api',
+        }),
+      ]);
+    });
+  });
+
+  it('collapses two mounts of the same project into one suggestion', async () => {
+    store.sessionProjectMounts = {
+      'session-1': [
+        {
+          mountId: 'mount-api',
+          projectId: 'api',
+          mountName: 'API first',
+          worktreePath: '/api-first',
+          branch: 'feat-first',
+        },
+        {
+          mountId: 'mount-api-second',
+          projectId: 'api',
+          mountName: 'API second',
+          worktreePath: '/api-second',
+          branch: 'feat-second',
+        },
+      ],
+    };
+    const view = renderHook(() => useSessionSuggestions({ session }));
+
+    await waitFor(() => expect(worktreeStatus).toHaveBeenCalledTimes(2));
+    await waitFor(() => {
+      const rebases = view.result.current.filter(
+        (suggestion) => suggestion.kind === 'rebase-project',
+      );
+      expect(rebases).toHaveLength(1);
+      expect(rebases[0]?.payload.targets).toHaveLength(2);
+    });
   });
 
   it('runs no git work and offers no rebase when the caller opts out', async () => {

--- a/apps/desktop/src/features/suggestions/useSessionSuggestions/index.ts
+++ b/apps/desktop/src/features/suggestions/useSessionSuggestions/index.ts
@@ -1,14 +1,8 @@
 import { useMemo } from 'react';
 import { useShallow } from 'zustand/react/shallow';
-import type {
-  Agent,
-  PlanId,
-  ProjectId,
-  Session,
-  SessionEvent,
-  SessionProjectMount,
-} from '@goodboy/types';
+import type { Agent, PlanId, Session, SessionEvent, SessionProjectMount } from '@goodboy/types';
 import { EMPTY_ARRAY, useAppStore, useSessionOpenQuestions, useSessionPlans } from '../../../store';
+import { isMountCompleted } from '../../../store/slices/project-mounts/mountRowModel';
 import { distanceBehind } from '../../../shared/lib/gitStatus';
 import { workflowHasOpenQuestions } from '../../context/openQuestionsGate';
 import { splitWorkflowRuns } from '../../workflows/activeWorkflowRuns';
@@ -28,18 +22,36 @@ type Params = {
   readonly withRebase?: boolean;
 };
 
+type LatestRebaseRequestsParams = {
+  readonly events: ReadonlyArray<SessionEvent>;
+  readonly agents: ReadonlyArray<Agent>;
+};
+
+type RebaseRequestKeyParams = {
+  readonly mountId: string | null;
+  readonly projectId: string;
+};
+
+type RebaseTargetIdParams = {
+  readonly mountId: string | null;
+  readonly worktreePath: string;
+};
+
 const NO_TARGETS: ReadonlyArray<{ readonly worktreePath: string; readonly baseBranch?: string }> =
   [];
+
+const rebaseRequestKey = ({ mountId, projectId }: RebaseRequestKeyParams): string =>
+  mountId == null ? `project:${projectId}` : `mount:${mountId}`;
+
+const rebaseTargetId = ({ mountId, worktreePath }: RebaseTargetIdParams): string =>
+  mountId == null ? `worktree:${worktreePath}` : `mount:${mountId}`;
 
 const latestRebaseRequests = ({
   events,
   agents,
-}: {
-  readonly events: ReadonlyArray<SessionEvent>;
-  readonly agents: ReadonlyArray<Agent>;
-}): ReadonlyMap<ProjectId, SuggestionRebaseRequest> => {
-  const requests = new Map<ProjectId, SuggestionRebaseRequest>();
-  const agentsById = new Map(agents.map((agent) => [agent.id as string, agent]));
+}: LatestRebaseRequestsParams): ReadonlyMap<string, SuggestionRebaseRequest> => {
+  const requests = new Map<string, SuggestionRebaseRequest>();
+  const agentsById = new Map<string, Agent>(agents.map((agent) => [agent.id, agent]));
   for (const event of events) {
     const projectId = event.payload?.projectId;
     if (event.kind !== 'rebase_requested' || projectId == null) {
@@ -47,7 +59,7 @@ const latestRebaseRequests = ({
     }
     const agentId = event.payload?.agentId ?? null;
     const agent = agentId == null ? null : (agentsById.get(agentId) ?? null);
-    requests.set(projectId as ProjectId, {
+    requests.set(rebaseRequestKey({ mountId: event.payload?.mountId ?? null, projectId }), {
       behind: event.payload?.behind ?? null,
       baseBranch: event.payload?.branch ?? null,
       agentStatus: agent?.status ?? null,
@@ -83,6 +95,28 @@ export const useSessionSuggestions = ({ session, agents, withRebase = true }: Pa
     (state) =>
       state.sessionProjectMounts[sessionId] ?? (EMPTY_ARRAY as ReadonlyArray<SessionProjectMount>),
   );
+  const completedMountIds = useAppStore(
+    useShallow((state) =>
+      mounts.flatMap((mount) => {
+        const mountId = mount.mountId;
+        if (mountId === undefined || !isMountCompleted({ state, mountId })) {
+          return [];
+        }
+        return [mountId];
+      }),
+    ),
+  );
+  const rebaseMounts = useMemo(
+    () =>
+      mounts.filter((mount) => {
+        const mountId = mount.mountId;
+        if (mountId === undefined) {
+          return true;
+        }
+        return !completedMountIds.includes(mountId);
+      }),
+    [completedMountIds, mounts],
+  );
   const projects = useAppStore(
     useShallow((state) =>
       state.projects.filter((project) => mounts.some((mount) => mount.projectId === project.id)),
@@ -94,13 +128,15 @@ export const useSessionSuggestions = ({ session, agents, withRebase = true }: Pa
   const targets = useMemo(
     () =>
       withRebase
-        ? mounts.map((mount) => ({
+        ? rebaseMounts.map((mount) => ({
             worktreePath: mount.worktreePath,
             baseBranch:
-              projects.find((project) => project.id === mount.projectId)?.baseBranch ?? undefined,
+              mount.baseBranch ??
+              projects.find((project) => project.id === mount.projectId)?.baseBranch ??
+              undefined,
           }))
         : NO_TARGETS,
-    [mounts, projects, withRebase],
+    [projects, rebaseMounts, withRebase],
   );
   const worktreeStatuses = useWorktreeStatuses({ targets });
 
@@ -161,17 +197,27 @@ export const useSessionSuggestions = ({ session, agents, withRebase = true }: Pa
       eligibleThreadCount: eligibleReviewThreadCount({ github, rows: resolveRows }),
       mountEvents: toMountEvents({ events }),
       projects: withRebase
-        ? mounts.map((mount) => {
+        ? rebaseMounts.map((mount) => {
             const project = projects.find((candidate) => candidate.id === mount.projectId) ?? null;
             const status = worktreeStatuses.get(mount.worktreePath) ?? null;
+            const mountId = mount.mountId ?? null;
+            const mountRequest = rebaseRequests.get(
+              rebaseRequestKey({ mountId, projectId: mount.projectId }),
+            );
+            const projectRequest = rebaseRequests.get(
+              rebaseRequestKey({ mountId: null, projectId: mount.projectId }),
+            );
             return {
+              id: rebaseTargetId({ mountId, worktreePath: mount.worktreePath }),
+              mountId,
               projectId: mount.projectId,
               projectName: project?.name ?? mount.mountName,
+              branch: mount.branch,
               worktreePath: mount.worktreePath,
-              baseBranch: project?.baseBranch ?? 'main',
+              baseBranch: mount.baseBranch ?? project?.baseBranch ?? 'main',
               mainDistance:
                 status == null ? null : distanceBehind({ distance: status.mainDistance }),
-              rebaseRequest: rebaseRequests.get(mount.projectId) ?? null,
+              rebaseRequest: mountRequest ?? projectRequest ?? null,
             };
           })
         : [],
@@ -184,11 +230,11 @@ export const useSessionSuggestions = ({ session, agents, withRebase = true }: Pa
     effectiveAgents,
     events,
     github,
-    mounts,
     openQuestions,
     planConsumptions,
     plans,
     projects,
+    rebaseMounts,
     resolveRows,
     sessionId,
     withRebase,

--- a/apps/desktop/src/features/suggestions/useSuggestionActions/index.test.ts
+++ b/apps/desktop/src/features/suggestions/useSuggestionActions/index.test.ts
@@ -3,6 +3,7 @@ import { renderHook } from '@testing-library/react';
 import type {
   Agent,
   AgentId,
+  MountId,
   ProjectId,
   Session,
   SessionEventId,
@@ -33,6 +34,7 @@ const { storeState, spies } = vi.hoisted(() => {
     void fields;
   });
   const setActiveLens = vi.fn();
+  const rebaseRun = vi.fn(async () => undefined);
   return {
     spies: {
       materializeProject,
@@ -43,12 +45,22 @@ const { storeState, spies } = vi.hoisted(() => {
       spawnAgent,
       setAgentConfig,
       setActiveLens,
-      rebaseRun: vi.fn(async () => undefined),
+      rebaseRun,
+      worktreeStatuses: vi.fn(() => new Map<string, unknown>()),
+      useRebaseAgent: vi.fn((_params: unknown) => ({
+        canRebase: false,
+        isRunning: false,
+        error: null,
+        run: rebaseRun,
+      })),
     },
     storeState: {
       sessionGithub: {} as Record<string, unknown>,
       sessionResolveThreads: {} as Record<string, ReadonlyArray<unknown>>,
       sessionProjectMounts: {} as Record<string, ReadonlyArray<unknown>>,
+      mountGithub: {} as Record<string, unknown>,
+      mountGitlabMr: {} as Record<string, unknown>,
+      mountBitbucketPr: {} as Record<string, unknown>,
       projects: [] as ReadonlyArray<unknown>,
       materializeProject,
       recordSessionEvent,
@@ -72,10 +84,10 @@ vi.mock('../../session/agent-kind', () => ({
   kindRouting: () => ({ provider: 'anthropic', model: 'claude', effort: 'medium' }),
 }));
 vi.mock('../../session/hooks/useWorktreeStatuses', () => ({
-  useWorktreeStatuses: () => new Map(),
+  useWorktreeStatuses: spies.worktreeStatuses,
 }));
 vi.mock('../../session/hooks/useRebaseAgent', () => ({
-  useRebaseAgent: () => ({ canRebase: true, isRunning: false, error: null, run: spies.rebaseRun }),
+  useRebaseAgent: spies.useRebaseAgent,
 }));
 vi.mock('../../workflows/useAdvanceWorkflowAgent', () => ({
   useAdvanceWorkflowAgent: () => spies.advanceAgent,
@@ -92,6 +104,8 @@ const SESSION_ID = 'session-1' as SessionId;
 const RUN_ID = 'run-1' as WorkflowRunId;
 const STEP_ID = 'step-1' as StepId;
 const WEB_ID = 'project-web' as ProjectId;
+const WEB_MOUNT_ID = 'mount-web' as MountId;
+const WEB_SECOND_MOUNT_ID = 'mount-web-second' as MountId;
 const AGENT_ID = 'agent-1' as AgentId;
 
 const SESSION = { id: SESSION_ID, workspaceId: 'workspace-1' } as Session;
@@ -119,7 +133,11 @@ beforeEach(() => {
   storeState.sessionGithub = {};
   storeState.sessionResolveThreads = {};
   storeState.sessionProjectMounts = {};
+  storeState.mountGithub = {};
+  storeState.mountGitlabMr = {};
+  storeState.mountBitbucketPr = {};
   storeState.projects = [];
+  spies.worktreeStatuses.mockReturnValue(new Map());
   onSelectQuestions.mockReset();
   for (const spy of Object.values(spies)) {
     spy.mockClear();
@@ -248,13 +266,106 @@ describe('useSuggestionActions', () => {
     const actions = actionsFor({
       suggestion: {
         ...suggestionBase,
-        id: 'rebase-project:project-web',
+        id: 'rebase-project:session-1',
         kind: 'rebase-project',
-        payload: { projectId: WEB_ID, worktreePath: '/tmp/web', baseBranch: 'main', behind: 2 },
+        payload: {
+          targets: [
+            {
+              id: 'mount:mount-web',
+              mountId: WEB_MOUNT_ID,
+              projectId: WEB_ID,
+              projectName: 'web',
+              branch: 'feature/web',
+              worktreePath: '/tmp/web',
+              baseBranch: 'main',
+              behind: 2,
+            },
+          ],
+        },
       },
     });
 
     expect(actions.primary?.label).toBe('Rebase');
+    expect(actions.primary?.isDisabled).toBe(false);
+    actions.primary?.onAct();
+
+    await vi.waitFor(() => expect(spies.rebaseRun).toHaveBeenCalledTimes(1));
+    expect(spies.setSessionActiveProject).toHaveBeenCalledWith({
+      sessionId: SESSION_ID,
+      projectId: WEB_ID,
+      mountId: WEB_MOUNT_ID,
+    });
+    expect(spies.rebaseRun).toHaveBeenCalledWith({ mountId: WEB_MOUNT_ID, behind: 2 });
+  });
+
+  it('runs the second rebase choice with that mount and distance', async () => {
+    const actions = actionsFor({
+      suggestion: {
+        ...suggestionBase,
+        id: 'rebase-project:session-1',
+        kind: 'rebase-project',
+        payload: {
+          targets: [
+            {
+              id: 'mount:mount-web',
+              mountId: WEB_MOUNT_ID,
+              projectId: WEB_ID,
+              projectName: 'web',
+              branch: 'feature/web-first',
+              worktreePath: '/tmp/web-first',
+              baseBranch: 'main',
+              behind: 7,
+            },
+            {
+              id: 'mount:mount-web-second',
+              mountId: WEB_SECOND_MOUNT_ID,
+              projectId: WEB_ID,
+              projectName: 'web',
+              branch: 'feature/web-second',
+              worktreePath: '/tmp/web-second',
+              baseBranch: 'main',
+              behind: 3,
+            },
+          ],
+        },
+      },
+    });
+
+    expect(actions.primary?.choices?.[1]?.description).toBe('feature/web-second');
+    actions.primary?.choices?.[1]?.onAct();
+
+    await vi.waitFor(() => expect(spies.rebaseRun).toHaveBeenCalledTimes(1));
+    expect(spies.setSessionActiveProject).toHaveBeenCalledWith({
+      sessionId: SESSION_ID,
+      projectId: WEB_ID,
+      mountId: WEB_SECOND_MOUNT_ID,
+    });
+    expect(spies.rebaseRun).toHaveBeenCalledWith({ mountId: WEB_SECOND_MOUNT_ID, behind: 3 });
+  });
+
+  it('starts a mountless target by project id', async () => {
+    const actions = actionsFor({
+      suggestion: {
+        ...suggestionBase,
+        id: 'rebase-project:session-1',
+        kind: 'rebase-project',
+        payload: {
+          targets: [
+            {
+              id: 'worktree:/tmp/web',
+              mountId: null,
+              projectId: WEB_ID,
+              projectName: 'web',
+              branch: 'feature/web',
+              worktreePath: '/tmp/web',
+              baseBranch: 'main',
+              behind: 2,
+            },
+          ],
+        },
+      },
+    });
+
     actions.primary?.onAct();
 
     await vi.waitFor(() => expect(spies.rebaseRun).toHaveBeenCalledTimes(1));
@@ -262,6 +373,72 @@ describe('useSuggestionActions', () => {
       sessionId: SESSION_ID,
       projectId: WEB_ID,
     });
+    expect(spies.rebaseRun).toHaveBeenCalledWith({ projectId: WEB_ID, behind: 2 });
+  });
+
+  it('ignores completed mounts when polling and choosing the behind status', () => {
+    const completedStatus = {
+      branch: 'feature/web-merged',
+      mainDistance: { kind: 'known', ahead: 0, behind: 9 },
+      upstreamDistance: { kind: 'known', ahead: 0, behind: 0 },
+    };
+    const activeStatus = {
+      branch: 'feature/web-open',
+      mainDistance: { kind: 'known', ahead: 0, behind: 2 },
+      upstreamDistance: { kind: 'known', ahead: 0, behind: 0 },
+    };
+    storeState.sessionProjectMounts = {
+      [SESSION_ID]: [
+        {
+          mountId: WEB_MOUNT_ID,
+          projectId: WEB_ID,
+          mountName: 'web merged',
+          worktreePath: '/tmp/web-merged',
+          branch: 'feature/web-merged',
+        },
+        {
+          mountId: WEB_SECOND_MOUNT_ID,
+          projectId: WEB_ID,
+          mountName: 'web open',
+          worktreePath: '/tmp/web-open',
+          branch: 'feature/web-open',
+        },
+      ],
+    };
+    storeState.projects = [{ id: WEB_ID, baseBranch: 'main' }];
+    storeState.mountGithub = {
+      [WEB_MOUNT_ID]: {
+        pr: {
+          number: 12,
+          state: 'merged',
+          title: 'Merged request',
+          url: 'https://github.com/acme/web/pull/12',
+          isDraft: false,
+        },
+      },
+    };
+    spies.worktreeStatuses.mockReturnValue(
+      new Map([
+        ['/tmp/web-merged', completedStatus],
+        ['/tmp/web-open', activeStatus],
+      ]),
+    );
+
+    actionsFor({
+      suggestion: {
+        ...suggestionBase,
+        id: 'workflow-next-step:run-1',
+        kind: 'workflow-next-step',
+        payload: { runId: RUN_ID, stepId: STEP_ID },
+      },
+    });
+
+    expect(spies.worktreeStatuses).toHaveBeenLastCalledWith({
+      targets: [{ worktreePath: '/tmp/web-open', baseBranch: 'main' }],
+    });
+    expect(spies.useRebaseAgent).toHaveBeenLastCalledWith(
+      expect.objectContaining({ status: activeStatus }),
+    );
   });
 
   it('hands the questions lens the answer action', () => {

--- a/apps/desktop/src/features/suggestions/useSuggestionActions/index.ts
+++ b/apps/desktop/src/features/suggestions/useSuggestionActions/index.ts
@@ -1,7 +1,9 @@
 import { useMemo } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 import { formatError } from '@goodboy/ui';
 import type { Agent, ResolveThread, Session, SessionProjectMount } from '@goodboy/types';
 import { EMPTY_ARRAY, useAppStore } from '../../../store';
+import { isMountCompleted } from '../../../store/slices/project-mounts/mountRowModel';
 import { distanceBehind } from '../../../shared/lib/gitStatus';
 import { useSessionRoleModels } from '../../../shared/hooks/useSessionRoleModels';
 import type { ResolveModelChoice } from '../../chat/spawn-from-comment';
@@ -13,7 +15,7 @@ import { useWorktreeStatuses } from '../../session/hooks/useWorktreeStatuses';
 import { useAdvanceWorkflowAgent } from '../../workflows/useAdvanceWorkflowAgent';
 import { eligibleReviewThreads } from '../eligibleThreads';
 import { useMountProposalActions } from '../useMountProposalActions';
-import type { SessionSuggestion } from '../types';
+import type { RebaseSuggestionTarget, SessionSuggestion } from '../types';
 
 type Params = {
   readonly session: Session;
@@ -24,6 +26,15 @@ type Params = {
 export type SuggestionAction = {
   readonly label: string;
   readonly isDisabled: boolean;
+  readonly onAct: () => void;
+  readonly choices?: ReadonlyArray<SuggestionActionChoice>;
+};
+
+export type SuggestionActionChoice = {
+  readonly id: string;
+  readonly label: string;
+  readonly description: string;
+  readonly detail: string;
   readonly onAct: () => void;
 };
 
@@ -39,6 +50,10 @@ export type SuggestionActionResolver = (params: {
 const NO_ACTIONS: SuggestionActions = { primary: null, onDismiss: null };
 const EMPTY_ROWS: ReadonlyArray<ResolveThread> = [];
 
+type StartRebaseParams = {
+  readonly target: RebaseSuggestionTarget;
+};
+
 export const useSuggestionActions = ({
   session,
   agents,
@@ -51,6 +66,17 @@ export const useSuggestionActions = ({
       state.sessionProjectMounts[sessionId] ?? (EMPTY_ARRAY as ReadonlyArray<SessionProjectMount>),
   );
   const projects = useAppStore((state) => state.projects);
+  const completedMountIds = useAppStore(
+    useShallow((state) =>
+      mounts.flatMap((mount) => {
+        const mountId = mount.mountId;
+        if (mountId === undefined || !isMountCompleted({ state, mountId })) {
+          return [];
+        }
+        return [mountId];
+      }),
+    ),
+  );
   const emitNotification = useAppStore((state) => state.emitNotification);
   const setSessionActiveProject = useAppStore((state) => state.setSessionActiveProject);
   const roleModels = useSessionRoleModels({ sessionId });
@@ -65,18 +91,30 @@ export const useSuggestionActions = ({
     void emitNotification('error', 'error', title, formatError(message), { sessionId });
   };
 
+  const rebaseMounts = useMemo(
+    () =>
+      mounts.filter((mount) => {
+        const mountId = mount.mountId;
+        if (mountId === undefined) {
+          return true;
+        }
+        return !completedMountIds.includes(mountId);
+      }),
+    [completedMountIds, mounts],
+  );
+
   const targets = useMemo(
     () =>
-      mounts.map((mount) => ({
+      rebaseMounts.map((mount) => ({
         worktreePath: mount.worktreePath,
         baseBranch:
           projects.find((project) => project.id === mount.projectId)?.baseBranch ?? undefined,
       })),
-    [projects, mounts],
+    [projects, rebaseMounts],
   );
   const statuses = useWorktreeStatuses({ targets });
   const behindStatus = useMemo(() => {
-    for (const mount of mounts) {
+    for (const mount of rebaseMounts) {
       const status = statuses.get(mount.worktreePath) ?? null;
       const behind = status == null ? null : distanceBehind({ distance: status.mainDistance });
       if (behind != null && behind > 0) {
@@ -84,7 +122,7 @@ export const useSuggestionActions = ({
       }
     }
     return null;
-  }, [mounts, statuses]);
+  }, [rebaseMounts, statuses]);
   const rebase = useRebaseAgent({
     sessionId,
     status: behindStatus,
@@ -120,17 +158,18 @@ export const useSuggestionActions = ({
       });
   };
 
-  const startRebase = ({
-    suggestion,
-  }: {
-    readonly suggestion: Extract<SessionSuggestion, { readonly kind: 'rebase-project' }>;
-  }) => {
+  const startRebase = ({ target }: StartRebaseParams) => {
     void (async () => {
       await setSessionActiveProject({
         sessionId,
-        projectId: suggestion.payload.projectId,
+        projectId: target.projectId,
+        ...(target.mountId == null ? {} : { mountId: target.mountId }),
       });
-      await rebase.run({ projectId: suggestion.payload.projectId });
+      await rebase.run(
+        target.mountId == null
+          ? { projectId: target.projectId, behind: target.behind }
+          : { mountId: target.mountId, behind: target.behind },
+      );
     })().catch((error: unknown) => {
       reportError('Rebase failed')(formatError(error));
     });
@@ -179,11 +218,27 @@ export const useSuggestionActions = ({
       };
     }
     if (suggestion.kind === 'rebase-project') {
+      const firstTarget = suggestion.payload.targets[0] ?? null;
       return {
         primary: {
           label: rebase.isRunning ? 'Rebasing' : 'Rebase',
-          isDisabled: !rebase.canRebase || rebase.isRunning,
-          onAct: () => startRebase({ suggestion }),
+          isDisabled: firstTarget == null || rebase.isRunning,
+          onAct: () => {
+            if (firstTarget == null) {
+              return;
+            }
+            startRebase({ target: firstTarget });
+          },
+          choices:
+            suggestion.payload.targets.length > 1
+              ? suggestion.payload.targets.map((target) => ({
+                  id: target.id,
+                  label: target.projectName,
+                  description: target.branch,
+                  detail: `${target.behind} behind`,
+                  onAct: () => startRebase({ target }),
+                }))
+              : undefined,
         },
         onDismiss: null,
       };

--- a/apps/desktop/src/store/slices/project-mounts/mountRowModel.test.ts
+++ b/apps/desktop/src/store/slices/project-mounts/mountRowModel.test.ts
@@ -4,16 +4,19 @@ import type {
   MountId,
   Project,
   ProjectId,
+  PullRequestStateKind,
   SessionId,
   SessionMountView,
   WorkspaceId,
 } from '@goodboy/types';
-import { buildMountRows, type MountRowState } from './mountRowModel';
+import type { MountGithubState } from '../../types';
+import { buildMountRows, isMountCompleted, type MountRowState } from './mountRowModel';
 
 const SESSION_ID = 'session-1' as SessionId;
 const PROJECT_ID = 'project-1' as ProjectId;
 const FIRST = 'mount-1' as MountId;
 const SECOND = 'mount-2' as MountId;
+const THIRD = 'mount-3' as MountId;
 const NOW = '2026-01-01T00:00:00.000Z' as IsoDateTime;
 
 type ViewParams = {
@@ -65,6 +68,48 @@ const PROJECT: Project = {
   updatedAt: NOW,
 };
 
+type GithubStateParams = {
+  readonly mountId: MountId;
+  readonly state: PullRequestStateKind;
+};
+
+const githubState = ({ mountId, state }: GithubStateParams): MountGithubState => {
+  const pr = {
+    number: mountId === FIRST ? 11 : mountId === SECOND ? 12 : 13,
+    title: `Request for ${mountId}`,
+    url: `https://github.com/acme/ledger-core/pull/${mountId}`,
+    state,
+    mergeable: true,
+    checks: 'success',
+    baseBranch: 'main',
+    headBranch: `ak/${mountId}`,
+    isDraft: false,
+    reviewDecision: 'approved',
+    body: '',
+    updatedAt: NOW,
+  } satisfies NonNullable<MountGithubState['pr']>;
+  return {
+    mountId,
+    projectId: PROJECT_ID,
+    revision: 1,
+    repository: 'acme/ledger-core',
+    host: 'github.com',
+    branch: pr.headBranch,
+    prs: [pr],
+    links: [],
+    pr,
+    linkedIssues: [],
+    fetchedAt: NOW,
+    failedAt: null,
+    loading: false,
+    error: null,
+    detail: null,
+    detailFetchedAt: null,
+    detailLoading: false,
+    detailError: null,
+  };
+};
+
 const makeState = (): MountRowState => ({
   projects: [PROJECT],
   sessionMounts: {
@@ -94,6 +139,53 @@ const makeState = (): MountRowState => ({
 });
 
 describe('buildMountRows', () => {
+  it('uses the shared completion predicate for merged, closed, and open requests', () => {
+    const state: MountRowState = {
+      ...makeState(),
+      sessionMounts: {
+        [SESSION_ID]: [
+          mountView({
+            id: FIRST,
+            branch: 'ak/part-one',
+            worktreePath: '/wt/one',
+            parallelIndex: 0,
+          }),
+          mountView({
+            id: SECOND,
+            branch: 'ak/part-two',
+            worktreePath: '/wt/two',
+            parallelIndex: 1,
+          }),
+          mountView({
+            id: THIRD,
+            branch: 'ak/part-three',
+            worktreePath: '/wt/three',
+            parallelIndex: 2,
+          }),
+        ],
+      },
+      mountGithub: {
+        [FIRST]: githubState({ mountId: FIRST, state: 'merged' }),
+        [SECOND]: githubState({ mountId: SECOND, state: 'closed' }),
+        [THIRD]: githubState({ mountId: THIRD, state: 'open' }),
+      },
+    };
+    const [group] = buildMountRows({ state, sessionId: SESSION_ID });
+    const rows = [...(group?.rows ?? []), ...(group?.completedRows ?? [])];
+
+    expect(
+      [FIRST, SECOND, THIRD].map((mountId) => ({
+        mountId,
+        predicate: isMountCompleted({ state, mountId }),
+        row: rows.find((candidate) => candidate.mountId === mountId)?.isCompleted,
+      })),
+    ).toEqual([
+      { mountId: FIRST, predicate: true, row: true },
+      { mountId: SECOND, predicate: true, row: true },
+      { mountId: THIRD, predicate: false, row: false },
+    ]);
+  });
+
   it('names the mount that already holds the observed branch', () => {
     const [group] = buildMountRows({ state: makeState(), sessionId: SESSION_ID });
     const row = group?.rows.find((candidate) => candidate.mountId === FIRST);

--- a/apps/desktop/src/store/slices/project-mounts/mountRowModel.ts
+++ b/apps/desktop/src/store/slices/project-mounts/mountRowModel.ts
@@ -95,6 +95,10 @@ type TerminalParams = {
   readonly state: PullRequestStateKind;
 };
 
+type CompletedParams = {
+  readonly request: MountRequestView | null;
+};
+
 type SeriesParams = {
   readonly series: ReadonlyArray<PrSeriesView>;
   readonly mountId: MountId;
@@ -180,10 +184,11 @@ export const mountRequestOf = ({ state, mountId }: RequestParams): MountRequestV
   };
 };
 
-export const isMountCompleted = ({ state, mountId }: RequestParams): boolean => {
-  const request = mountRequestOf({ state, mountId });
-  return request !== null && isTerminal({ state: request.state });
-};
+const isCompletedRequest = ({ request }: CompletedParams): boolean =>
+  request !== null && isTerminal({ state: request.state });
+
+export const isMountCompleted = ({ state, mountId }: RequestParams): boolean =>
+  isCompletedRequest({ request: mountRequestOf({ state, mountId }) });
 
 const seriesPositionOf = ({
   series,
@@ -321,7 +326,7 @@ export const buildMountRows = ({
       series: seriesPositionOf({ series, mountId: view.id, branch: view.branch }),
       observation: observations.find((candidate) => candidate.mountId === view.id) ?? null,
       observedBranchHolder: null,
-      isCompleted: isMountCompleted({ state, mountId: view.id }),
+      isCompleted: isCompletedRequest({ request }),
     };
     if (!grouped.has(view.projectId)) {
       order.push(view.projectId);

--- a/apps/desktop/src/store/slices/project-mounts/mountRowModel.ts
+++ b/apps/desktop/src/store/slices/project-mounts/mountRowModel.ts
@@ -91,6 +91,10 @@ type RequestParams = {
   readonly mountId: MountId;
 };
 
+type TerminalParams = {
+  readonly state: PullRequestStateKind;
+};
+
 type SeriesParams = {
   readonly series: ReadonlyArray<PrSeriesView>;
   readonly mountId: MountId;
@@ -104,8 +108,7 @@ const BITBUCKET_STATE: Readonly<Record<string, PullRequestStateKind>> = {
   SUPERSEDED: 'closed',
 };
 
-const isTerminal = (state: PullRequestStateKind): boolean =>
-  state === 'merged' || state === 'closed';
+const isTerminal = ({ state }: TerminalParams): boolean => state === 'merged' || state === 'closed';
 
 export const mountRequestOf = ({ state, mountId }: RequestParams): MountRequestView | null => {
   const github = (state.mountGithub ?? {})[mountId];
@@ -175,6 +178,11 @@ export const mountRequestOf = ({ state, mountId }: RequestParams): MountRequestV
     title: bitbucketPr.title,
     label: `PR #${bitbucketPr.id}`,
   };
+};
+
+export const isMountCompleted = ({ state, mountId }: RequestParams): boolean => {
+  const request = mountRequestOf({ state, mountId });
+  return request !== null && isTerminal({ state: request.state });
 };
 
 const seriesPositionOf = ({
@@ -313,7 +321,7 @@ export const buildMountRows = ({
       series: seriesPositionOf({ series, mountId: view.id, branch: view.branch }),
       observation: observations.find((candidate) => candidate.mountId === view.id) ?? null,
       observedBranchHolder: null,
-      isCompleted: request !== null && isTerminal(request.state),
+      isCompleted: isMountCompleted({ state, mountId: view.id }),
     };
     if (!grouped.has(view.projectId)) {
       order.push(view.projectId);


### PR DESCRIPTION
The Activity timeline showed one "Rebase internal-tools on main" row per mount, thirteen of them stacked, all carrying the same React key. Clicking Rebase on any of them started the first behind mount and recorded that mount's distance, so the dedup then silenced a row the owner had not acted on.

- One rebase suggestion per session. With a single branch behind the button acts directly; with several it opens a popover listing project, branch and distance, and each entry rebases its own mount.
- The target carries a nullable `mountId`, because `SessionProjectMount.mountId` is optional and mounts without one are a real case (`detachProject.ts`, `forkMount.ts`). Those still get a target and still rebase, by project id.
- Consumption is keyed by mount, falling back to project for events recorded before this change, so rebasing one branch of a stack no longer silences its siblings.

A mount whose pull request is merged or closed is history. It produces no rebase target, is not polled for git distance, and does not render the sync control. The rule has one definition now, `isMountCompleted`, shared by the row model and the suggestions. Everything else on the row stays: branch chip, diff, request link, detach.

Create agent is the single primary of the activity header, Add workflow its secondary companion.

Desktop suite green: 800 files, 7257 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)