### PR TITLE
feat(desktop): remove the worktree of a completed mount

### DIFF
--- a/apps/desktop/src-tauri/src/worktree.rs
+++ b/apps/desktop/src-tauri/src/worktree.rs
@@ -146,6 +146,10 @@ pub enum WorktreeDetachAssessment {
         affected_files: u32,
         #[serde(rename = "localOnlyCommits")]
         local_only_commits: u32,
+        #[serde(rename = "ignoredFiles")]
+        ignored_files: u32,
+        #[serde(rename = "ignoredFileSamples")]
+        ignored_file_samples: Vec<String>,
     },
 }
 
@@ -1178,6 +1182,55 @@ fn local_only_commit_count(cwd: &Path) -> Option<u32> {
         .and_then(|raw| raw.trim().parse::<u32>().ok())
 }
 
+const REPRODUCIBLE_IGNORED_DIRS: [&str; 11] = [
+    "node_modules",
+    "target",
+    "dist",
+    "build",
+    ".next",
+    ".venv",
+    "__pycache__",
+    ".turbo",
+    "coverage",
+    ".gradle",
+    "Pods",
+];
+
+fn is_reproducible_ignored_path(relative: &str) -> bool {
+    let top_level = relative.split('/').next().unwrap_or(relative);
+    REPRODUCIBLE_IGNORED_DIRS.contains(&top_level)
+}
+
+struct IgnoredFilesAtRisk {
+    count: u32,
+    samples: Vec<String>,
+}
+
+fn ignored_files_at_risk(worktree_path: &Path) -> Option<IgnoredFilesAtRisk> {
+    let raw = git(
+        worktree_path,
+        &[
+            "ls-files",
+            "--others",
+            "--ignored",
+            "--exclude-standard",
+            "--directory",
+            "-z",
+        ],
+    )
+    .ok()?;
+    let mut at_risk: Vec<String> = raw
+        .split_terminator('\0')
+        .filter(|line| !line.is_empty())
+        .filter(|line| !is_reproducible_ignored_path(line))
+        .map(|line| line.to_string())
+        .collect();
+    at_risk.sort_by(|a, b| a.len().cmp(&b.len()).then_with(|| a.cmp(b)));
+    let count = u32::try_from(at_risk.len()).ok()?;
+    let samples = at_risk.into_iter().take(5).collect();
+    Some(IgnoredFilesAtRisk { count, samples })
+}
+
 fn worktree_detach_assessment_blocking(
     worktree_path: String,
 ) -> Result<WorktreeDetachAssessment, WorktreeError> {
@@ -1211,12 +1264,20 @@ fn worktree_detach_assessment_blocking(
             branch,
         });
     };
+    let Some(ignored) = ignored_files_at_risk(p) else {
+        return Ok(WorktreeDetachAssessment::Unavailable {
+            path: worktree_path,
+            branch,
+        });
+    };
     Ok(WorktreeDetachAssessment::Assessed {
         path: worktree_path,
         branch,
         has_upstream: snapshot.upstream.is_some(),
         affected_files: changed,
         local_only_commits,
+        ignored_files: ignored.count,
+        ignored_file_samples: ignored.samples,
     })
 }
 
@@ -4115,7 +4176,7 @@ mod teardown_tests {
         remove_worktree_checked_with, worktree_detach_assessment_blocking,
         worktree_directory_size_blocking, worktree_orphan_remove_blocking,
         WorktreeDetachAssessment, WorktreeError, WorktreeInspection, WorktreeRemovalMode,
-        WorktreeRemovalReason, WorktreeRemovalResult,
+        WorktreeRemovalReason, WorktreeRemovalResult, REPRODUCIBLE_IGNORED_DIRS,
     };
     use std::path::{Path, PathBuf};
 
@@ -4713,8 +4774,166 @@ mod teardown_tests {
                 has_upstream: true,
                 affected_files: 0,
                 local_only_commits: 0,
+                ignored_files: 0,
+                ignored_file_samples: Vec::new(),
             }
         );
+    }
+
+    #[test]
+    fn assessment_treats_reproducible_ignored_directories_as_no_risk() {
+        let root = init_repo("assess-ignored-reproducible");
+        publish_repo(&root);
+        let target = add_worktree(&root, "ignored-reproducible");
+        git_ok(
+            &target,
+            &["push", "-u", "origin", "test/ignored-reproducible"],
+        );
+        let ignores = REPRODUCIBLE_IGNORED_DIRS
+            .iter()
+            .map(|directory| format!("{directory}/\n"))
+            .collect::<String>();
+        std::fs::write(target.join(".gitignore"), ignores).unwrap();
+        for directory in REPRODUCIBLE_IGNORED_DIRS {
+            let nested = target.join(directory).join("nested");
+            std::fs::create_dir_all(&nested).unwrap();
+            std::fs::write(nested.join("artifact.bin"), "x").unwrap();
+        }
+
+        let WorktreeDetachAssessment::Assessed {
+            ignored_files,
+            ignored_file_samples,
+            ..
+        } = assess(&target)
+        else {
+            panic!("expected an assessed worktree");
+        };
+
+        assert_eq!(ignored_files, 0);
+        assert!(ignored_file_samples.is_empty());
+    }
+
+    #[test]
+    fn assessment_reports_and_names_a_non_reproducible_ignored_file() {
+        let root = init_repo("assess-ignored-env");
+        publish_repo(&root);
+        let target = add_worktree(&root, "ignored-env");
+        git_ok(&target, &["push", "-u", "origin", "test/ignored-env"]);
+        std::fs::write(target.join(".gitignore"), "node_modules/\n.env.local\n").unwrap();
+        std::fs::write(target.join(".env.local"), "SECRET=1\n").unwrap();
+
+        let WorktreeDetachAssessment::Assessed {
+            ignored_files,
+            ignored_file_samples,
+            ..
+        } = assess(&target)
+        else {
+            panic!("expected an assessed worktree");
+        };
+
+        assert_eq!(ignored_files, 1);
+        assert_eq!(ignored_file_samples, vec![".env.local".to_string()]);
+    }
+
+    #[test]
+    fn assessment_excludes_reproducible_names_only_at_the_top_level() {
+        let root = init_repo("assess-ignored-top-level");
+        publish_repo(&root);
+        let target = add_worktree(&root, "ignored-top-level");
+        git_ok(&target, &["push", "-u", "origin", "test/ignored-top-level"]);
+        std::fs::write(target.join(".gitignore"), "**/node_modules/\n").unwrap();
+        let nested = target.join("scratch").join("node_modules");
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::write(nested.join("local.bin"), "x").unwrap();
+        std::fs::create_dir_all(target.join("node_modules")).unwrap();
+        std::fs::write(target.join("node_modules").join("dep.js"), "x").unwrap();
+
+        let WorktreeDetachAssessment::Assessed {
+            ignored_files,
+            ignored_file_samples,
+            ..
+        } = assess(&target)
+        else {
+            panic!("expected an assessed worktree");
+        };
+
+        assert_eq!(ignored_files, 2);
+        assert_eq!(
+            ignored_file_samples,
+            vec!["scratch/".to_string(), "scratch/node_modules/".to_string()]
+        );
+    }
+
+    #[test]
+    fn assessment_limits_relative_samples_and_orders_shortest_first() {
+        let root = init_repo("assess-ignored-samples");
+        publish_repo(&root);
+        let target = add_worktree(&root, "ignored-samples");
+        git_ok(&target, &["push", "-u", "origin", "test/ignored-samples"]);
+        let paths = [
+            ".a",
+            ".env",
+            "local.db",
+            "notes.txt",
+            "settings.json",
+            "space file.txt",
+        ];
+        std::fs::write(target.join(".gitignore"), paths.join("\n")).unwrap();
+        for relative in paths {
+            let path = target.join(relative);
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent).unwrap();
+            }
+            std::fs::write(path, "x").unwrap();
+        }
+
+        let WorktreeDetachAssessment::Assessed {
+            ignored_files,
+            ignored_file_samples,
+            ..
+        } = assess(&target)
+        else {
+            panic!("expected an assessed worktree");
+        };
+
+        assert_eq!(ignored_files, 6);
+        assert_eq!(
+            ignored_file_samples,
+            vec![
+                ".a".to_string(),
+                ".env".to_string(),
+                "local.db".to_string(),
+                "notes.txt".to_string(),
+                "settings.json".to_string(),
+            ]
+        );
+        assert!(ignored_file_samples
+            .iter()
+            .all(|sample| !Path::new(sample).is_absolute()));
+    }
+
+    #[test]
+    fn assessment_counts_only_the_non_reproducible_ignored_file_when_both_are_present() {
+        let root = init_repo("assess-ignored-mixed");
+        publish_repo(&root);
+        let target = add_worktree(&root, "ignored-mixed");
+        git_ok(&target, &["push", "-u", "origin", "test/ignored-mixed"]);
+        std::fs::write(target.join(".gitignore"), "node_modules/\n.env.local\n").unwrap();
+        std::fs::write(target.join(".env.local"), "SECRET=1\n").unwrap();
+        std::fs::create_dir_all(target.join("node_modules")).unwrap();
+        std::fs::write(target.join("node_modules").join("dep.js"), "x").unwrap();
+
+        let WorktreeDetachAssessment::Assessed {
+            ignored_files,
+            ignored_file_samples,
+            ..
+        } = assess(&target)
+        else {
+            panic!("expected an assessed worktree");
+        };
+
+        assert_eq!(ignored_files, 1);
+        assert_eq!(ignored_file_samples, vec![".env.local".to_string()]);
     }
 
     #[test]

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectDetachMenu.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectDetachMenu.test.tsx
@@ -48,10 +48,14 @@ const assessed = ({
   affectedFiles,
   localOnlyCommits,
   hasUpstream,
+  ignoredFiles = 0,
+  ignoredFileSamples = [],
 }: {
   readonly affectedFiles: number;
   readonly localOnlyCommits: number;
   readonly hasUpstream: boolean;
+  readonly ignoredFiles?: number;
+  readonly ignoredFileSamples?: ReadonlyArray<string>;
 }): WorktreeDetachAssessment => ({
   kind: 'assessed',
   path: '/worktrees/api',
@@ -59,6 +63,8 @@ const assessed = ({
   hasUpstream,
   affectedFiles,
   localOnlyCommits,
+  ignoredFiles,
+  ignoredFileSamples,
 });
 
 const renderMenu = () =>
@@ -202,6 +208,8 @@ describe('ProjectDetachMenu', () => {
               hasUpstream: true,
               affectedFiles: 2,
               localOnlyCommits: 0,
+              ignoredFiles: 0,
+              ignoredFileSamples: [],
             }
           : {
               kind: 'assessed',
@@ -210,6 +218,8 @@ describe('ProjectDetachMenu', () => {
               hasUpstream: false,
               affectedFiles: 1,
               localOnlyCommits: 3,
+              ignoredFiles: 0,
+              ignoredFileSamples: [],
             },
     );
     renderMenu();

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectMountRow.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectMountRow.test.tsx
@@ -12,6 +12,10 @@ import type {
 } from '@goodboy/types';
 import type { MountRowView } from '../../../../../store/slices/project-mounts/mountRowModel';
 
+type RemoveWorktreeProps = {
+  readonly label: string;
+};
+
 const { store, remoteKind } = vi.hoisted(() => ({
   remoteKind: { current: 'github' as string | null },
   store: {
@@ -47,6 +51,13 @@ vi.mock('./ProjectSyncControl', () => ({
 vi.mock('./ProjectDetachMenu', () => ({
   ProjectDetachMenu: ({ menuLabel }: { readonly menuLabel?: string }) => (
     <span data-testid="detach-menu">{menuLabel}</span>
+  ),
+}));
+vi.mock('./RemoveWorktreeAction', () => ({
+  RemoveWorktreeAction: ({ label }: RemoveWorktreeProps) => (
+    <button type="button" aria-label={`Remove the worktree for ${label}`}>
+      Remove worktree
+    </button>
   ),
 }));
 vi.mock('./MountBranchDecision', () => ({
@@ -269,6 +280,15 @@ describe('ProjectMountRow availability', () => {
     });
 
     expect(screen.getByTestId('branch-decision')).toBeDefined();
+  });
+
+  it('offers worktree removal only for a completed attached row', () => {
+    renderRow({ row: { ...baseRow, isCompleted: true } });
+
+    expect(screen.getByRole('button', { name: 'Remove the worktree for API' })).toBeDefined();
+    cleanup();
+    renderRow({});
+    expect(screen.queryByRole('button', { name: 'Remove the worktree for API' })).toBeNull();
   });
 });
 

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectMountRow.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectMountRow.tsx
@@ -15,6 +15,7 @@ import { MountRequestLink } from './MountRequestLink';
 import { ProjectBranchChip } from './ProjectBranchChip';
 import { ProjectSyncControl } from './ProjectSyncControl';
 import { ProjectDetachMenu } from './ProjectDetachMenu';
+import { RemoveWorktreeAction } from './RemoveWorktreeAction';
 import { useProjectActivity } from './useProjectActivity';
 
 type Props = {
@@ -199,7 +200,9 @@ export const ProjectMountRow = ({
           )}
         </div>
         <div className={SLOT_ACTION}>
-          {row.isAttached ? (
+          {row.isAttached && row.isCompleted && isRepo && worktreePath !== null ? (
+            <RemoveWorktreeAction sessionId={sessionId} row={row} label={label} />
+          ) : row.isAttached ? (
             <MountRequestAction
               sessionId={sessionId}
               row={row}

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/RemoveWorktreeAction.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/RemoveWorktreeAction.test.tsx
@@ -1,0 +1,128 @@
+// @vitest-environment happy-dom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MountId, ProjectId, SessionId, WorktreeDetachAssessment } from '@goodboy/types';
+import type { MountRowView } from '../../../../../store/slices/project-mounts/mountRowModel';
+
+const { removeMountWorktree, showToast, state, worktreeDetachAssessment } = vi.hoisted(() => ({
+  removeMountWorktree: vi.fn(async () => ({ kind: 'removed', reason: null })),
+  showToast: vi.fn(),
+  state: {
+    removeMountWorktree: vi.fn(async () => ({ kind: 'removed', reason: null })),
+    sessions: [{ id: 'session-1', state: { kind: 'idle' } }],
+    terminalTabs: {},
+  },
+  worktreeDetachAssessment: vi.fn(),
+}));
+
+state.removeMountWorktree = removeMountWorktree;
+
+vi.mock('../../../../../store', () => ({
+  useAppStore: <Value,>(selector: (store: typeof state) => Value) => selector(state),
+}));
+
+vi.mock('../../../../../app/components/Toast', () => ({
+  useToast: () => ({ showToast }),
+}));
+
+vi.mock('../../../../worktree/worktree', () => ({ worktreeDetachAssessment }));
+
+import { RemoveWorktreeAction } from './RemoveWorktreeAction';
+
+type TypedStringParams = {
+  readonly value: string;
+};
+
+const typedString = <Value extends string>({ value }: TypedStringParams): Value =>
+  JSON.parse(JSON.stringify(value));
+
+const SESSION_ID = typedString<SessionId>({ value: 'session-1' });
+
+const ROW = {
+  mountId: typedString<MountId>({ value: 'mount-1' }),
+  projectId: typedString<ProjectId>({ value: 'project-1' }),
+  projectName: 'API',
+  projectKind: 'repo',
+  mountName: 'API',
+  branch: 'ak/feat',
+  baseBranch: 'main',
+  worktreePath: '/worktrees/api',
+  lastWorktreePath: '/worktrees/api',
+  repoRoot: '/repos/api',
+  isAttached: true,
+  isOnDisk: true,
+  revision: 3,
+  parallelIndex: 0,
+  request: null,
+  series: null,
+  observation: null,
+  observedBranchHolder: null,
+  isCompleted: true,
+} satisfies MountRowView;
+
+type AssessmentParams = {
+  readonly ignoredFiles: number;
+  readonly ignoredFileSamples: ReadonlyArray<string>;
+};
+
+const assessment = ({
+  ignoredFiles,
+  ignoredFileSamples,
+}: AssessmentParams): WorktreeDetachAssessment => ({
+  kind: 'assessed',
+  path: '/worktrees/api',
+  branch: 'ak/feat',
+  hasUpstream: true,
+  affectedFiles: 0,
+  localOnlyCommits: 0,
+  ignoredFiles,
+  ignoredFileSamples,
+});
+
+const renderAction = () =>
+  render(<RemoveWorktreeAction sessionId={SESSION_ID} row={ROW} label="API" />);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.sessions = [{ id: 'session-1', state: { kind: 'idle' } }];
+  state.terminalTabs = {};
+  removeMountWorktree.mockResolvedValue({ kind: 'removed', reason: null });
+});
+
+afterEach(cleanup);
+
+describe('RemoveWorktreeAction', () => {
+  it('shows confirmation when ignored data is at risk', async () => {
+    worktreeDetachAssessment.mockResolvedValue(
+      assessment({ ignoredFiles: 1, ignoredFileSamples: ['.env.local'] }),
+    );
+    renderAction();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove the worktree for API' }));
+
+    await waitFor(() => expect(screen.getByText('Remove worktree?')).toBeDefined());
+    expect(
+      screen.getByText('1 ignored file at risk, not tracked by git: .env.local.'),
+    ).toBeDefined();
+    expect(removeMountWorktree).not.toHaveBeenCalled();
+  });
+
+  it('removes immediately without confirmation when no data is at risk', async () => {
+    worktreeDetachAssessment.mockResolvedValue(
+      assessment({ ignoredFiles: 0, ignoredFileSamples: [] }),
+    );
+    renderAction();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove the worktree for API' }));
+
+    await waitFor(() =>
+      expect(removeMountWorktree).toHaveBeenCalledWith({
+        sessionId: SESSION_ID,
+        mountId: ROW.mountId,
+        mode: 'safe',
+      }),
+    );
+    expect(screen.queryByText('Remove worktree?')).toBeNull();
+  });
+});

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/RemoveWorktreeAction.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/RemoveWorktreeAction.tsx
@@ -1,0 +1,220 @@
+import { useState } from 'react';
+import { AnchoredPopover, InlineConfirm, cn, formatError, useDropdown } from '@goodboy/ui';
+import type { SessionId } from '@goodboy/types';
+import { useAppStore } from '../../../../../store';
+import type { MountRowView } from '../../../../../store/slices/project-mounts/mountRowModel';
+import { useToast } from '../../../../../app/components/Toast';
+import { worktreeDetachAssessment } from '../../../../worktree/worktree';
+import {
+  mountCleanupBlockers,
+  type MountCleanupBlocker,
+} from '../../../../../store/slices/mount-cleanup/cleanupPolicy';
+import { CONCEPT_ICONS, ICON_SIZE } from '../../../../../shared/components/conceptIcons';
+import {
+  BLOCKER_SENTENCE,
+  countLabel,
+  ignoredFilesLine,
+  isMountRisky,
+  measure,
+} from './detachPlan';
+
+type Props = {
+  readonly sessionId: SessionId;
+  readonly row: MountRowView;
+  readonly label: string;
+  readonly triggerClassName?: string;
+};
+
+type Confirm =
+  | { readonly kind: 'blocked'; readonly lines: ReadonlyArray<string> }
+  | { readonly kind: 'unavailable' }
+  | { readonly kind: 'risky'; readonly lines: ReadonlyArray<string> };
+
+type RemoveParams = {
+  readonly mode: 'safe' | 'confirmed';
+};
+
+const AlertIcon = CONCEPT_ICONS.errors;
+const BLOCKER_CODES = [
+  'agent-running',
+  'terminal-open',
+] satisfies ReadonlyArray<MountCleanupBlocker>;
+
+export const RemoveWorktreeAction = ({ sessionId, row, label, triggerClassName }: Props) => {
+  const removeMountWorktree = useAppStore((state) => state.removeMountWorktree);
+  const { showToast } = useToast();
+  const dropdown = useDropdown({ align: 'end', width: 'w-80', expectedHeight: 170 });
+  const [isChecking, setIsChecking] = useState(false);
+  const [isBusy, setIsBusy] = useState(false);
+  const [confirm, setConfirm] = useState<Confirm | null>(null);
+  const worktreePath = row.worktreePath;
+  const blockerKey = useAppStore((state) =>
+    worktreePath === null
+      ? ''
+      : mountCleanupBlockers({ state, sessionId, mountId: row.mountId, worktreePath })
+          .slice()
+          .sort()
+          .join(','),
+  );
+  const blockers = BLOCKER_CODES.filter((code) => blockerKey.split(',').includes(code));
+
+  const cancel = () => {
+    setConfirm(null);
+    dropdown.close();
+  };
+
+  const remove = async ({ mode }: RemoveParams) => {
+    setIsBusy(true);
+    try {
+      const result = await removeMountWorktree({ sessionId, mountId: row.mountId, mode });
+      switch (result.kind) {
+        case 'removed':
+          showToast('info', `Removed the worktree for ${label}.`);
+          break;
+        case 'missing':
+          showToast('info', `The worktree for ${label} was already gone.`);
+          break;
+        case 'kept':
+        case 'failed':
+          showToast('error', result.reason ?? `Could not remove the worktree for ${label}.`);
+          break;
+      }
+      setConfirm(null);
+      dropdown.close();
+    } catch (error) {
+      showToast('error', formatError(error));
+    } finally {
+      setIsBusy(false);
+    }
+  };
+
+  const check = async () => {
+    if (worktreePath === null || isChecking) {
+      return;
+    }
+    if (blockers.length > 0) {
+      setConfirm({
+        kind: 'blocked',
+        lines: blockers.map((blocker) => BLOCKER_SENTENCE[blocker]({ projectName: label })),
+      });
+      if (!dropdown.open) {
+        dropdown.toggle();
+      }
+      return;
+    }
+    setIsChecking(true);
+    try {
+      const assessment = await worktreeDetachAssessment({ worktreePath });
+      const measured = measure({ worktreePath, branch: row.branch, assessment });
+      if (measured === null) {
+        setConfirm({ kind: 'unavailable' });
+        if (!dropdown.open) {
+          dropdown.toggle();
+        }
+        return;
+      }
+      if (measured.isAbsent || !isMountRisky({ measured })) {
+        await remove({ mode: 'safe' });
+        return;
+      }
+      const files = countLabel({ count: measured.affectedFiles, singular: 'uncommitted file' });
+      const commits = countLabel({
+        count: measured.localOnlyCommits,
+        singular: measured.hasUpstream ? 'unpushed commit' : 'local-only commit',
+      });
+      const ignored = ignoredFilesLine({ measured: [measured] });
+      setConfirm({
+        kind: 'risky',
+        lines: [
+          `Removing this worktree will lose ${files} and ${commits}.`,
+          ...(ignored === null ? [] : [ignored]),
+          'The branch and its commits stay in the repository.',
+        ],
+      });
+      if (!dropdown.open) {
+        dropdown.toggle();
+      }
+    } catch (error) {
+      showToast('error', formatError(error));
+    } finally {
+      setIsChecking(false);
+    }
+  };
+
+  return (
+    <AnchoredPopover
+      dropdown={dropdown}
+      role="dialog"
+      ariaLabel={`Remove the worktree for ${label}`}
+      anchorClassName="shrink-0"
+      trigger={
+        <button
+          type="button"
+          disabled={isChecking || isBusy}
+          aria-label={`Remove the worktree for ${label}`}
+          onClick={() => {
+            if (dropdown.open) {
+              cancel();
+              return;
+            }
+            void check();
+          }}
+          className={cn(
+            'shrink-0 rounded-md px-1.5 py-1 text-xs text-muted-foreground/70 hover:bg-muted/40 hover:text-danger',
+            'disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent disabled:hover:text-muted-foreground/70',
+            triggerClassName,
+          )}
+        >
+          {isChecking ? 'Checking' : 'Remove worktree'}
+        </button>
+      }
+    >
+      {confirm === null ? null : confirm.kind === 'unavailable' ? (
+        <div className="flex flex-col gap-2 p-3">
+          <span className="text-xs font-medium">Remove worktree?</span>
+          <span className="text-2xs text-muted-foreground">
+            {`The safety of the worktree at ${worktreePath ?? label} could not be verified.`}
+          </span>
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              disabled={isChecking}
+              onClick={() => void check()}
+              className="rounded-md px-2 py-0.5 text-2xs font-semibold hover:bg-muted"
+            >
+              Check again
+            </button>
+            <button
+              type="button"
+              onClick={() => cancel()}
+              className="rounded-md px-2 py-0.5 text-2xs font-semibold hover:bg-muted"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div className="flex flex-col p-2">
+          <InlineConfirm
+            role={confirm.kind === 'blocked' ? 'alert' : 'danger'}
+            icon={<AlertIcon size={ICON_SIZE.row} />}
+            title="Remove worktree?"
+            confirmLabel="Remove worktree"
+            isBusy={isBusy}
+            isConfirmDisabled={confirm.kind === 'blocked'}
+            onConfirm={() => void remove({ mode: 'confirmed' })}
+            onCancel={() => cancel()}
+          >
+            <div className="flex min-w-0 flex-col gap-1 text-muted-foreground">
+              {confirm.lines.map((line) => (
+                <p key={line} className="break-words">
+                  {line}
+                </p>
+              ))}
+            </div>
+          </InlineConfirm>
+        </div>
+      )}
+    </AnchoredPopover>
+  );
+};

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/detachPlan.test.ts
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/detachPlan.test.ts
@@ -31,12 +31,16 @@ const mount = ({
   affectedFiles,
   localOnlyCommits,
   hasUpstream,
+  ignoredFiles = 0,
+  ignoredFileSamples = [],
 }: {
   readonly path?: string;
   readonly branch?: string;
   readonly affectedFiles: number;
   readonly localOnlyCommits: number;
   readonly hasUpstream: boolean;
+  readonly ignoredFiles?: number;
+  readonly ignoredFileSamples?: ReadonlyArray<string>;
 }): MountAssessment => ({
   worktreePath: path,
   branch,
@@ -47,6 +51,8 @@ const mount = ({
     hasUpstream,
     affectedFiles,
     localOnlyCommits,
+    ignoredFiles,
+    ignoredFileSamples,
   } satisfies WorktreeDetachAssessment,
 });
 
@@ -108,6 +114,30 @@ describe('buildDetachPlan', () => {
         totals: ['Files affected (0)', 'Local-only commits (0)'],
         worktrees: ['ak/feat at /worktrees/api: 0 uncommitted files, 0 local-only commits'],
       },
+    });
+  });
+
+  it('names ignored files at risk before promising branch retention', () => {
+    expect(
+      plan({
+        assessments: [
+          mount({
+            affectedFiles: 0,
+            localOnlyCommits: 0,
+            hasUpstream: true,
+            ignoredFiles: 2,
+            ignoredFileSamples: ['.env.local', 'scratch/data.db'],
+          }),
+        ],
+      }),
+    ).toMatchObject({
+      kind: 'risky',
+      lines: [
+        'Remove the worktree at /worktrees/api for ak/feat.',
+        'No uncommitted files will be deleted.',
+        '2 ignored files at risk, not tracked by git: .env.local, scratch/data.db.',
+        'The branch and its commits stay in the repository.',
+      ],
     });
   });
 

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/detachPlan.ts
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/detachPlan.ts
@@ -42,16 +42,21 @@ export type BuildDetachPlanParams = {
 export const CHECKING_STATUS = 'Checking files and commits';
 export const REMOVAL_STAGE = 'Removing worktree';
 
-const BLOCKER_SENTENCE = {
-  'agent-running': ({ projectName }: { readonly projectName: string }) =>
+type ProjectNameParams = {
+  readonly projectName: string;
+};
+
+export const BLOCKER_SENTENCE = {
+  'agent-running': ({ projectName }: ProjectNameParams) =>
     `Work is still running in ${projectName}; stop it before removing this worktree.`,
-  'terminal-open': ({ projectName }: { readonly projectName: string }) =>
+  'terminal-open': ({ projectName }: ProjectNameParams) =>
     `A terminal is open in ${projectName}; close it before removing this worktree.`,
-} satisfies Record<MountCleanupBlocker, (input: { readonly projectName: string }) => string>;
+} satisfies Record<MountCleanupBlocker, (input: ProjectNameParams) => string>;
 
 type CountNoun =
   | 'branch'
   | 'clean worktree'
+  | 'ignored file'
   | 'local-only commit'
   | 'uncommitted file'
   | 'unpushed commit'
@@ -60,6 +65,7 @@ type CountNoun =
 const PLURAL_LABEL = {
   branch: 'branches',
   'clean worktree': 'clean worktrees',
+  'ignored file': 'ignored files',
   'local-only commit': 'local-only commits',
   'uncommitted file': 'uncommitted files',
   'unpushed commit': 'unpushed commits',
@@ -71,7 +77,7 @@ type CountLabelParams = {
   readonly singular: CountNoun;
 };
 
-const countLabel = ({ count, singular }: CountLabelParams): string =>
+export const countLabel = ({ count, singular }: CountLabelParams): string =>
   count === 1 ? `1 ${singular}` : `${count} ${PLURAL_LABEL[singular]}`;
 
 const branchLabelFor = ({
@@ -90,16 +96,26 @@ const branchLabelFor = ({
   return 'this worktree';
 };
 
-type Measured = {
+export type Measured = {
   readonly branch: string;
   readonly path: string;
   readonly isAbsent: boolean;
   readonly hasUpstream: boolean;
   readonly affectedFiles: number;
   readonly localOnlyCommits: number;
+  readonly ignoredFiles: number;
+  readonly ignoredFileSamples: ReadonlyArray<string>;
 };
 
-const measure = ({ branch, assessment }: MountAssessment): Measured | null => {
+type MountRiskParams = {
+  readonly measured: Measured;
+};
+
+type IgnoredFilesLineParams = {
+  readonly measured: ReadonlyArray<Measured>;
+};
+
+export const measure = ({ branch, assessment }: MountAssessment): Measured | null => {
   switch (assessment.kind) {
     case 'unavailable':
       return null;
@@ -111,6 +127,8 @@ const measure = ({ branch, assessment }: MountAssessment): Measured | null => {
         hasUpstream: true,
         affectedFiles: 0,
         localOnlyCommits: 0,
+        ignoredFiles: 0,
+        ignoredFileSamples: [],
       };
     case 'assessed':
       return {
@@ -120,8 +138,27 @@ const measure = ({ branch, assessment }: MountAssessment): Measured | null => {
         hasUpstream: assessment.hasUpstream,
         affectedFiles: assessment.affectedFiles,
         localOnlyCommits: assessment.localOnlyCommits,
+        ignoredFiles: assessment.ignoredFiles,
+        ignoredFileSamples: assessment.ignoredFileSamples,
       };
   }
+};
+
+export const isMountRisky = ({ measured }: MountRiskParams): boolean =>
+  !measured.isAbsent &&
+  (measured.affectedFiles > 0 ||
+    measured.localOnlyCommits > 0 ||
+    !measured.hasUpstream ||
+    measured.ignoredFiles > 0);
+
+export const ignoredFilesLine = ({ measured }: IgnoredFilesLineParams): string | null => {
+  const count = measured.reduce((total, entry) => total + entry.ignoredFiles, 0);
+  if (count === 0) {
+    return null;
+  }
+  const samples = measured.flatMap((entry) => entry.ignoredFileSamples).slice(0, 5);
+  const noun = countLabel({ count, singular: 'ignored file' });
+  return `${noun} at risk, not tracked by git: ${samples.join(', ')}.`;
 };
 
 type CommitSingularParams = {
@@ -288,22 +325,20 @@ export const buildDetachPlan = ({
   if (measured.every((entry) => entry.isAbsent)) {
     return { kind: 'missing', lines: [missingLine({ measured, projectName })] };
   }
-  const isRisky = measured.some(
-    (entry) =>
-      !entry.isAbsent &&
-      (entry.affectedFiles > 0 || entry.localOnlyCommits > 0 || !entry.hasUpstream),
-  );
+  const isRisky = measured.some((entry) => isMountRisky({ measured: entry }));
   if (!isRisky) {
     return { kind: 'safe', lines: [safeLine({ measured, projectName })] };
   }
   const files = measured.reduce((total, entry) => total + entry.affectedFiles, 0);
   const commits = measured.reduce((total, entry) => total + entry.localOnlyCommits, 0);
   const hasUpstream = measured.every((entry) => entry.hasUpstream);
+  const ignoredLine = ignoredFilesLine({ measured });
   return {
     kind: 'risky',
     lines: [
       removalLine({ measured, projectName }),
       lossLine({ measured }),
+      ...(ignoredLine === null ? [] : [ignoredLine]),
       retentionLine({ measured }),
     ],
     details: {

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/index.test.tsx
@@ -61,6 +61,7 @@ vi.mock('./ProjectBranchChip', () => ({
 }));
 vi.mock('./ProjectSyncControl', () => ({ ProjectSyncControl: () => null }));
 vi.mock('./ProjectDetachMenu', () => ({ ProjectDetachMenu: () => null }));
+vi.mock('./RemoveWorktreeAction', () => ({ RemoveWorktreeAction: () => null }));
 vi.mock('./NewBranchMountAction', () => ({
   NewBranchMountAction: () => <button>New branch mount</button>,
 }));

--- a/apps/desktop/src/store/slices/project-mounts/index.ts
+++ b/apps/desktop/src/store/slices/project-mounts/index.ts
@@ -4,6 +4,7 @@ import { forkMount } from './forkMount';
 import { inspectMount } from './inspectMount';
 import { loadSessionMounts } from './loadSessionMounts';
 import { openMountRequest } from './openMountRequest';
+import { removeMountWorktree } from './removeMountWorktree';
 import { resolveMountBranchMismatch } from './resolveMountBranchMismatch';
 import { setSessionActiveMount } from './setSessionActiveMount';
 import { switchMount } from './switchMount';
@@ -19,6 +20,7 @@ export const createProjectMountsSlice = (set: SetFn, get: GetFn) => {
     switchMount: switchMount(set, get),
     attachMount: attachMount(set, get),
     unmountMount: unmountMount(set, get),
+    removeMountWorktree: removeMountWorktree({ set, get }),
     inspectMount: inspectMount(set, get),
     resolveMountBranchMismatch: resolveMountBranchMismatch(set, get),
     setSessionActiveMount: setSessionActiveMount(set, get),

--- a/apps/desktop/src/store/slices/project-mounts/removeMountWorktree.test.ts
+++ b/apps/desktop/src/store/slices/project-mounts/removeMountWorktree.test.ts
@@ -1,0 +1,212 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  IsoDateTime,
+  MountDiskState,
+  MountId,
+  ProjectId,
+  SessionId,
+  SessionMountView,
+  SessionProjectMount,
+} from '@goodboy/types';
+import type { AppStore } from '../../store';
+import type { GetFn, SetFn } from './types';
+
+type CleanupParams = {
+  readonly target: {
+    readonly worktreePath: string;
+  };
+};
+
+type LifecycleParams = {
+  readonly mountId: MountId;
+  readonly worktreePath: string | null;
+  readonly isAttached: boolean;
+  readonly diskState: MountDiskState;
+  readonly expectedRevision: number;
+};
+
+type ListParams = {
+  readonly sessionId: SessionId;
+};
+
+type LockParams = {
+  readonly run: () => Promise<unknown>;
+};
+
+const h = vi.hoisted(() => ({
+  cleanupMountDirectory: vi.fn(async ({ target }: CleanupParams) => ({
+    decision: { kind: 'removed', path: target.worktreePath },
+    diskState: 'removed',
+  })),
+  rows: new Map<MountId, SessionMountView>(),
+  updateSessionMountLifecycle: vi.fn(async ({}: LifecycleParams) => true),
+  withRepositoryAndMountLock: vi.fn(async ({ run }: LockParams) => run()),
+}));
+
+vi.mock('@goodboy/db', () => ({
+  listSessionMounts: vi.fn(async ({ sessionId }: ListParams) =>
+    [...h.rows.values()].filter((row) => row.sessionId === sessionId),
+  ),
+  updateSessionMountLifecycle: h.updateSessionMountLifecycle,
+}));
+
+vi.mock('../../../shared/lib/db', () => ({ tauriDatabase: {} }));
+
+vi.mock('../mount-cleanup', () => ({
+  cleanupMountDirectory: h.cleanupMountDirectory,
+}));
+
+vi.mock('./mountLocks', () => ({
+  withRepositoryAndMountLock: h.withRepositoryAndMountLock,
+}));
+
+import { removeMountWorktree } from './removeMountWorktree';
+
+type TypedStringParams = {
+  readonly value: string;
+};
+
+const typedString = <Value extends string>({ value }: TypedStringParams): Value =>
+  JSON.parse(JSON.stringify(value));
+
+const SESSION_ID = typedString<SessionId>({ value: 'session-1' });
+const PROJECT_ID = typedString<ProjectId>({ value: 'project-1' });
+const TARGET_ID = typedString<MountId>({ value: 'mount-target' });
+const SIBLING_ID = typedString<MountId>({ value: 'mount-sibling' });
+const AT = typedString<IsoDateTime>({ value: '2026-09-10T10:00:00.000Z' });
+
+type ViewParams = {
+  readonly id: MountId;
+  readonly branch: string;
+  readonly worktreePath: string;
+};
+
+const view = ({ id, branch, worktreePath }: ViewParams): SessionMountView => ({
+  id,
+  sessionId: SESSION_ID,
+  projectId: PROJECT_ID,
+  worktreePath,
+  lastWorktreePath: worktreePath,
+  branch,
+  baseBranch: 'main',
+  parallelIndex: id === TARGET_ID ? 1 : 2,
+  mountName: 'API',
+  repoSlug: null,
+  repoRoot: '/repos/api',
+  isAttached: true,
+  diskState: 'present',
+  revision: 2,
+  createdAt: AT,
+  updatedAt: AT,
+});
+
+type ProjectMountParams = {
+  readonly source: SessionMountView;
+};
+
+const projectMount = ({ source }: ProjectMountParams): SessionProjectMount => ({
+  mountId: source.id,
+  sessionId: source.sessionId,
+  projectId: source.projectId,
+  mountName: source.mountName,
+  worktreePath: source.worktreePath ?? source.lastWorktreePath ?? '',
+  lastWorktreePath: source.lastWorktreePath,
+  repoRoot: source.repoRoot,
+  branch: source.branch,
+  baseBranch: source.baseBranch,
+  parallelIndex: source.parallelIndex,
+  isAttached: true,
+  diskState: source.diskState,
+  revision: source.revision,
+});
+
+type StateParams = {
+  readonly views: ReadonlyArray<SessionMountView>;
+};
+
+const stateWith = ({ views }: StateParams): AppStore =>
+  Object.assign(Object.create(null), {
+    sessions: [{ id: SESSION_ID, workspaceId: 'workspace-1', state: { kind: 'idle' } }],
+    archivedSessions: {},
+    projects: [
+      {
+        id: PROJECT_ID,
+        workspaceId: 'workspace-1',
+        kind: 'repo',
+        name: 'API',
+        rootPath: '/repos/api',
+      },
+    ],
+    sessionMounts: { [SESSION_ID]: views },
+    sessionProjectMounts: { [SESSION_ID]: views.map((source) => projectMount({ source })) },
+    sessionActiveMount: { [SESSION_ID]: TARGET_ID },
+    sessionActiveProject: { [SESSION_ID]: PROJECT_ID },
+    sessionBranches: { [SESSION_ID]: 'ak/target' },
+    sessionWorktrees: { [SESSION_ID]: views.flatMap((entry) => entry.worktreePath ?? []) },
+    reconcileOrphanWorktrees: vi.fn(async () => undefined),
+  });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  const target = view({ id: TARGET_ID, branch: 'ak/target', worktreePath: '/worktrees/target' });
+  const sibling = view({
+    id: SIBLING_ID,
+    branch: 'ak/sibling',
+    worktreePath: '/worktrees/sibling',
+  });
+  h.rows.clear();
+  h.rows.set(TARGET_ID, target);
+  h.rows.set(SIBLING_ID, sibling);
+  h.updateSessionMountLifecycle.mockImplementation(async (params: LifecycleParams) => {
+    const current = h.rows.get(params.mountId);
+    if (current === undefined || current.revision !== params.expectedRevision) {
+      return false;
+    }
+    h.rows.set(params.mountId, {
+      ...current,
+      worktreePath: params.worktreePath,
+      lastWorktreePath: params.worktreePath ?? current.worktreePath ?? current.lastWorktreePath,
+      isAttached: params.isAttached,
+      diskState: params.diskState,
+      revision: current.revision + 1,
+    });
+    return true;
+  });
+});
+
+describe('removeMountWorktree', () => {
+  it('removes one mount worktree and leaves its same-project sibling untouched', async () => {
+    const initialViews = [...h.rows.values()];
+    const state = stateWith({ views: initialViews });
+    const set: SetFn = (update) => {
+      const patch = typeof update === 'function' ? update(state) : update;
+      Object.assign(state, patch);
+    };
+    const get: GetFn = () => state;
+    const remove = removeMountWorktree({ set, get });
+
+    const result = await remove({ sessionId: SESSION_ID, mountId: TARGET_ID, mode: 'safe' });
+
+    expect(result).toEqual({ kind: 'removed', reason: null });
+    expect(h.cleanupMountDirectory).toHaveBeenCalledTimes(1);
+    expect(h.cleanupMountDirectory).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: 'safe',
+        target: expect.objectContaining({
+          mountId: TARGET_ID,
+          worktreePath: '/worktrees/target',
+        }),
+      }),
+    );
+    expect(h.updateSessionMountLifecycle).toHaveBeenCalledTimes(1);
+    expect(state.sessionMounts[SESSION_ID]).toEqual([
+      expect.objectContaining({ id: TARGET_ID, worktreePath: null, isAttached: false }),
+      expect.objectContaining({
+        id: SIBLING_ID,
+        worktreePath: '/worktrees/sibling',
+        isAttached: true,
+        revision: 2,
+      }),
+    ]);
+  });
+});

--- a/apps/desktop/src/store/slices/project-mounts/removeMountWorktree.ts
+++ b/apps/desktop/src/store/slices/project-mounts/removeMountWorktree.ts
@@ -1,0 +1,103 @@
+import { updateSessionMountLifecycle } from '@goodboy/db';
+import type {
+  IsoDateTime,
+  MountCleanupDecision,
+  MountId,
+  SessionId,
+  WorktreeRemovalMode,
+} from '@goodboy/types';
+import { tauriDatabase } from '../../../shared/lib/db';
+import { cleanupMountDirectory } from '../mount-cleanup';
+import { mountError } from './mountErrors';
+import { withRepositoryAndMountLock } from './mountLocks';
+import { applyMountViews, loadMountViews, requireMountView } from './mountViews';
+import { requireMountContext } from './requireMountContext';
+import type { GetFn, SetFn } from './types';
+
+export type RemoveMountWorktreeInput = {
+  readonly sessionId: SessionId;
+  readonly mountId: MountId;
+  readonly mode: WorktreeRemovalMode;
+};
+
+export type RemoveMountWorktreeResult = {
+  readonly kind: MountCleanupDecision['kind'];
+  readonly reason: string | null;
+};
+
+type Params = {
+  readonly set: SetFn;
+  readonly get: GetFn;
+};
+
+export const removeMountWorktree = ({ set, get }: Params) => {
+  return async ({
+    sessionId,
+    mountId,
+    mode,
+  }: RemoveMountWorktreeInput): Promise<RemoveMountWorktreeResult> => {
+    const views = await loadMountViews({ get, sessionId });
+    const view = requireMountView({ views, mountId });
+    const { project } = requireMountContext({ get, sessionId, projectId: view.projectId });
+    const worktreePath = view.worktreePath;
+    if (worktreePath === null) {
+      return { kind: 'missing', reason: null };
+    }
+    return withRepositoryAndMountLock({
+      repoRoot: view.repoRoot,
+      mountKey: `${sessionId}:${mountId}`,
+      run: async () => {
+        const cleanup = await cleanupMountDirectory({
+          get,
+          mode,
+          target: {
+            sessionId,
+            mountId,
+            projectId: view.projectId,
+            repoRoot: view.repoRoot,
+            worktreePath,
+            branch: view.branch,
+            diskState: view.diskState,
+            isRepoProject: project.kind === 'repo',
+          },
+        });
+        const decision = cleanup.decision;
+        switch (decision.kind) {
+          case 'failed':
+          case 'kept':
+            return { kind: decision.kind, reason: decision.reason };
+          case 'removed':
+          case 'missing':
+            break;
+          default: {
+            const exhaustive: never = decision;
+            throw exhaustive;
+          }
+        }
+        const written = await updateSessionMountLifecycle({
+          db: tauriDatabase,
+          sessionId,
+          mountId,
+          worktreePath: null,
+          isAttached: false,
+          diskState: cleanup.diskState,
+          expectedRevision: view.revision,
+          updatedAt: new Date().toISOString() as IsoDateTime,
+        });
+        if (!written) {
+          throw mountError({
+            code: 'revision-conflict',
+            message: 'the mount changed while removing its worktree',
+            mountId,
+          });
+        }
+        const nextViews = await loadMountViews({ get, sessionId });
+        applyMountViews({ set, sessionId, views: nextViews });
+        void get()
+          .reconcileOrphanWorktrees()
+          .catch(() => undefined);
+        return { kind: decision.kind, reason: null };
+      },
+    });
+  };
+};

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -214,6 +214,10 @@ import type {
   DetachProjectInput,
   DetachProjectOutcome,
 } from './slices/project-mounts/detachProject';
+import type {
+  RemoveMountWorktreeInput,
+  RemoveMountWorktreeResult,
+} from './slices/project-mounts/removeMountWorktree';
 import { createPresenceSlice } from './slices/presence';
 import { createTurnSlice } from './slices/turn';
 import type { SendTurnResult } from './slices/turn/types';
@@ -445,6 +449,7 @@ type AppActions = {
   switchMount(input: SwitchMountInput): Promise<SessionMountView>;
   attachMount(input: AttachMountInput): Promise<SessionMountView>;
   unmountMount(input: UnmountMountInput): Promise<UnmountMountResult>;
+  removeMountWorktree(input: RemoveMountWorktreeInput): Promise<RemoveMountWorktreeResult>;
   inspectMount(input: MountKeyInput): Promise<InspectMountResult>;
   resolveMountBranchMismatch(input: ResolveMountBranchInput): Promise<SessionMountView>;
   setSessionActiveMount(input: MountKeyInput): Promise<void>;

--- a/packages/types/src/worktree.ts
+++ b/packages/types/src/worktree.ts
@@ -98,6 +98,8 @@ export type WorktreeDetachAssessment =
       readonly hasUpstream: boolean;
       readonly affectedFiles: number;
       readonly localOnlyCommits: number;
+      readonly ignoredFiles: number;
+      readonly ignoredFileSamples: ReadonlyArray<string>;
     };
 
 export type WorktreeDirectorySize = {


### PR DESCRIPTION
Stacked on #1722, merge that first.

A mount whose pull request is merged keeps its directory on disk. The only way to reclaim it was the project-wide detach, which loops over every mount of that project and would take the unfinished siblings of the same stack with it.

- `removeMountWorktree` is scoped to one `mountId`. It keeps the branch and its commits, keeps the row, the request link and the session history. The row becomes detached with its files gone, and its existing `Mount` control is what recreates the checkout, so there is no second recreate path.
- `Remove worktree` sits in the action slot of a completed row. With nothing at risk it removes in one step; otherwise it opens the inline confirmation that already exists, never a Dialog.

The assessment behind that confirmation counted only tracked and untracked files. Its own test asserted that `node_modules/dep.js` was invisible to it, which is right for build output and wrong for a local env file, a development sqlite database or ignored scratch work: the confirmation could say nothing was at risk while erasing all three. It now also counts the ignored paths that are not obviously reproducible, excluding eleven build directories by top level segment, and names up to five of them, shortest path first.

Rust: 109 tests pass. Desktop: 802 files, 7263 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)