### PR TITLE
fix(desktop): keep detached mounts detached after a reload

### DIFF
--- a/apps/desktop/src/store/slices/project-mounts/detachProject.test.ts
+++ b/apps/desktop/src/store/slices/project-mounts/detachProject.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const {
   removeWorktreeChecked,
   worktreeWriterStatus,
+  getSessionMount,
   markSessionMountRemoved,
   markSessionMountRemovedByPath,
   updateSessionActiveProject,
@@ -25,6 +26,7 @@ const {
     hasExited: false,
     waiting: [],
   })),
+  getSessionMount: vi.fn(async (_args: { mountId: string }) => null as { revision: number } | null),
   markSessionMountRemoved: vi.fn(async (_args: { mountId: string }) => true),
   markSessionMountRemovedByPath: vi.fn(async () => true),
   updateSessionActiveProject: vi.fn(async () => undefined),
@@ -32,6 +34,7 @@ const {
 }));
 
 vi.mock('@goodboy/db', () => ({
+  getSessionMount,
   markSessionMountRemoved,
   markSessionMountRemovedByPath,
   updateSessionActiveProject,
@@ -128,6 +131,7 @@ const runDetach = async (store: Store, disposition?: string) => {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  getSessionMount.mockImplementation(async () => null);
   markSessionMountRemoved.mockImplementation(async () => true);
   markSessionMountRemovedByPath.mockImplementation(async () => true);
   removeWorktreeChecked.mockImplementation(async ({ worktreePath }: { worktreePath: string }) => ({
@@ -205,6 +209,62 @@ describe('detachProject', () => {
       kind: 'project_detached',
       payload: expect.objectContaining({ kept: true, reason: 'unstaged-changes' }),
     });
+    expect(store.sessionProjectMounts['sess-1'].map((m) => m.projectId)).toEqual(['project-web']);
+  });
+
+  it('fetches the live revision and still marks a kept mount detached when the seeded mount has none', async () => {
+    const store = makeStore();
+    store.sessionProjectMounts['sess-1'] = store.sessionProjectMounts['sess-1'].map((m) =>
+      m.mountId === 'mount-api' ? ({ ...m, revision: undefined } as never) : m,
+    );
+    getSessionMount.mockImplementation(async ({ mountId }: { mountId: string }) =>
+      mountId === 'mount-api' ? { revision: 9 } : null,
+    );
+    removeWorktreeChecked.mockResolvedValue({
+      kind: 'kept',
+      path: '/container/api',
+      reasons: ['unstaged-changes'],
+    });
+
+    await runDetach(store);
+
+    expect(getSessionMount).toHaveBeenCalledWith({
+      db: {},
+      sessionId: SESSION_ID,
+      mountId: 'mount-api',
+    });
+    expect(updateSessionMountLifecycle).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mountId: 'mount-api',
+        isAttached: false,
+        expectedRevision: 9,
+      }),
+    );
+    expect(store.sessionProjectMounts['sess-1'].map((m) => m.projectId)).toEqual(['project-web']);
+  });
+
+  it('skips the DB write but still drops the mount when no revision can be found anywhere', async () => {
+    const store = makeStore();
+    store.sessionProjectMounts['sess-1'] = store.sessionProjectMounts['sess-1'].map((m) =>
+      m.mountId === 'mount-api' ? ({ ...m, revision: undefined } as never) : m,
+    );
+    getSessionMount.mockImplementation(async () => null);
+    removeWorktreeChecked.mockResolvedValue({
+      kind: 'kept',
+      path: '/container/api',
+      reasons: ['unstaged-changes'],
+    });
+
+    await runDetach(store);
+
+    expect(updateSessionMountLifecycle).not.toHaveBeenCalledWith(
+      expect.objectContaining({ mountId: 'mount-api' }),
+    );
+    expect(store.recordSessionEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({ worktreePath: '/container/api', kept: true }),
+      }),
+    );
     expect(store.sessionProjectMounts['sess-1'].map((m) => m.projectId)).toEqual(['project-web']);
   });
 

--- a/apps/desktop/src/store/slices/project-mounts/detachProject.ts
+++ b/apps/desktop/src/store/slices/project-mounts/detachProject.ts
@@ -6,6 +6,7 @@ import type {
   SessionProjectMount,
 } from '@goodboy/types';
 import {
+  getSessionMount,
   markSessionMountRemoved,
   markSessionMountRemovedByPath,
   updateSessionActiveProject,
@@ -130,18 +131,24 @@ export const detachProject = (set: SetFn, get: GetFn) => {
         }
       }
       const mountId = mount.mountId;
-      const revision = mount.revision;
-      if (kept && mountId !== undefined && revision !== undefined) {
-        await updateSessionMountLifecycle({
-          db: tauriDatabase,
-          sessionId,
-          mountId,
-          worktreePath: mount.worktreePath,
-          isAttached: false,
-          diskState: result.diskState,
-          expectedRevision: revision,
-          updatedAt: new Date().toISOString() as IsoDateTime,
-        });
+      if (kept && mountId !== undefined) {
+        const revision =
+          mount.revision ??
+          (await getSessionMount({ db: tauriDatabase, sessionId, mountId }).catch(() => null))
+            ?.revision ??
+          null;
+        if (revision !== null) {
+          await updateSessionMountLifecycle({
+            db: tauriDatabase,
+            sessionId,
+            mountId,
+            worktreePath: mount.worktreePath,
+            isAttached: false,
+            diskState: result.diskState,
+            expectedRevision: revision,
+            updatedAt: new Date().toISOString() as IsoDateTime,
+          });
+        }
       }
       if (!kept && mountId !== undefined) {
         await markSessionMountRemoved({ db: tauriDatabase, sessionId, mountId });

--- a/apps/desktop/src/store/slices/sessions/index.test.ts
+++ b/apps/desktop/src/store/slices/sessions/index.test.ts
@@ -929,6 +929,60 @@ describe('store contract', () => {
       );
     });
 
+    it('unarchiveTask carries the stored revision into the seeded project mount', async () => {
+      const store = await getStore();
+      const db = await import('@goodboy/db');
+      const archived: Session = { ...buildSession(), archivedAt: NOW } as Session;
+      vi.mocked(db.listWorktreesForSession).mockResolvedValueOnce([
+        {
+          id: 'mount-live',
+          sessionId: SESSION_ID,
+          projectId: PROJECT_ID,
+          worktreePath: '/tmp/repo/.goodboy/worktrees/live',
+          branch: 'ak/live',
+          parallelIndex: 0,
+          mountName: 'repo',
+          revision: 5,
+          createdAt: Date.now(),
+        },
+      ] as never);
+      store.setState({
+        workspaces: [buildWorkspace()],
+        projects: [buildProject()],
+        currentWorkspaceId: WS_ID,
+        archivedSessions: { [WS_ID]: [archived] },
+      });
+
+      await store.getState().unarchiveTask(SESSION_ID);
+
+      expect(store.getState().sessionProjectMounts[SESSION_ID]?.[0]?.revision).toBe(5);
+    });
+
+    it('unarchiveTask restores the session and reports when the secondary refresh fails', async () => {
+      const store = await getStore();
+      const archived: Session = { ...buildSession(), archivedAt: NOW } as Session;
+      invokeAgentListSpy.mockRejectedValueOnce(new Error('agent list unavailable'));
+      store.setState({
+        workspaces: [buildWorkspace()],
+        currentWorkspaceId: WS_ID,
+        archivedSessions: { [WS_ID]: [archived] },
+      });
+
+      await store.getState().unarchiveTask(SESSION_ID);
+
+      const s = store.getState();
+      expect(s.sessions.find((x) => x.id === SESSION_ID)).toBeDefined();
+      expect(s.archivedSessions[WS_ID]).toEqual([]);
+      expect(insertNotificationSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          kind: 'error',
+          severity: 'warning',
+          sessionId: SESSION_ID,
+        }),
+      );
+    });
+
     it('archiveTask keeps the worktrees unless the user asks to clean them', async () => {
       const store = await getStore();
       const cleanupSessionMounts = vi.fn(async () => []);

--- a/apps/desktop/src/store/slices/sessions/index.test.ts
+++ b/apps/desktop/src/store/slices/sessions/index.test.ts
@@ -1652,6 +1652,13 @@ describe('store contract', () => {
       ).toEqual([WEB_PROJECT_ID, API_PROJECT_ID]);
       expect(store.getState().sessionActiveProject[session.id]).toBe(WEB_PROJECT_ID);
       expect(mount.worktreePath).toBe(mountPath);
+      expect(mount.revision).toBe(0);
+      expect(
+        store
+          .getState()
+          .sessionWorktreeRecords?.[session.id]?.find((row) => row.worktreePath === mountPath)
+          ?.revision,
+      ).toBe(0);
       const materialized = vi
         .mocked(db.insertSessionEvent)
         .mock.calls.map(([{ event }]) => event)
@@ -1719,6 +1726,7 @@ describe('store contract', () => {
           branch: 'goodboy/persisted',
           parallelIndex: 2,
           mountName: 'api',
+          revision: 6,
           createdAt: Date.now(),
         },
       ]);
@@ -1731,6 +1739,13 @@ describe('store contract', () => {
 
       expect(createWorktreeSpy).not.toHaveBeenCalled();
       expect(mount.worktreePath).toBe('/tmp/api/.goodboy/worktrees/persisted');
+      expect(mount.revision).toBe(6);
+      expect(
+        store
+          .getState()
+          .sessionProjectMounts[session.id]?.find((entry) => entry.projectId === API_PROJECT_ID)
+          ?.revision,
+      ).toBe(6);
       expect(vi.mocked(db.insertSessionEvent)).not.toHaveBeenCalled();
     });
 

--- a/apps/desktop/src/store/slices/sessions/materializeProject.ts
+++ b/apps/desktop/src/store/slices/sessions/materializeProject.ts
@@ -124,6 +124,7 @@ export const materializeProject = (set: SetFn, get: GetFn) => {
         baseBranch: project.baseBranch ?? null,
         parallelIndex: persistedRow.parallelIndex,
         isAttached: true,
+        revision: persistedRow.revision,
       };
       set((state) => ({
         sessionProjectMounts: {
@@ -227,6 +228,7 @@ export const materializeProject = (set: SetFn, get: GetFn) => {
       parallelIndex: nextParallelIndex,
       projectId,
       mountName: project.name,
+      revision: 0,
       createdAt: Date.now(),
     };
     await insertSessionWorktree(tauriDatabase, record);

--- a/apps/desktop/src/store/slices/sessions/unarchiveTask.ts
+++ b/apps/desktop/src/store/slices/sessions/unarchiveTask.ts
@@ -4,6 +4,7 @@ import {
   unarchiveSession as unarchiveSessionInDb,
   updateSessionActiveProject,
 } from '@goodboy/db';
+import { formatError } from '@goodboy/ui';
 import { tauriDatabase } from '../../../shared/lib/db';
 import { invokeAgentList, invokeWorkflowsForSession } from '../../../features/workflows/workflows';
 import { buildSessionProjectMounts } from '../worktrees/buildSessionProjectMounts';
@@ -116,7 +117,15 @@ export const unarchiveTask = (set: SetFn, get: GetFn) => {
           sessionWorkflows: { ...state.sessionWorkflows, [sessionId]: attachedWorkflows },
         };
       });
-    } catch {}
+    } catch (error) {
+      void get().emitNotification(
+        'error',
+        'warning',
+        'session restored, but some data failed to load',
+        formatError(error),
+        { sessionId },
+      );
+    }
     void get()
       .reconcileOrphanWorktrees()
       .catch(() => undefined);

--- a/apps/desktop/src/store/slices/worktrees/buildSessionProjectMounts.ts
+++ b/apps/desktop/src/store/slices/worktrees/buildSessionProjectMounts.ts
@@ -31,6 +31,7 @@ export const buildSessionProjectMounts = ({
         baseBranch: project.baseBranch ?? null,
         parallelIndex: row.parallelIndex,
         isAttached: true,
+        revision: row.revision,
       },
     ];
   });

--- a/packages/db/src/queries/session-worktree.ts
+++ b/packages/db/src/queries/session-worktree.ts
@@ -38,6 +38,7 @@ export type SessionWorktree = {
   readonly projectId?: ProjectId;
   readonly mountName?: string;
   readonly repoSlug?: string;
+  readonly revision?: number;
   readonly createdAt: number;
 };
 
@@ -108,6 +109,7 @@ const toPresentWorktree = (row: SessionWorktreeRow): SessionWorktree | null => {
     ...(row.project_id !== null ? { projectId: row.project_id as ProjectId } : {}),
     ...(row.mount_name !== null ? { mountName: row.mount_name } : {}),
     ...(row.repo_slug !== null ? { repoSlug: row.repo_slug } : {}),
+    revision: row.revision,
     createdAt: row.created_at,
   };
 };


### PR DESCRIPTION
Detaching a project whose worktree is kept, because it is dirty or held by a terminal or agent, updated the client state but never wrote `isAttached: false` to the database. On the next hydration the mount came back, which reads as "I detached it and it returned".

## Root cause, one level down from the symptom

The write in `detachProject.ts` was gated on `mount.revision`, and only one of the two builders supplied it:

- `mountViews.ts:toProjectMount` set it correctly
- `buildSessionProjectMounts.ts`, the seed used by `setCurrentWorkspace` and `unarchiveTask`, never did

Not an oversight in the builder: `SessionWorktree` did not expose `revision` at all, even though `session_worktrees.revision` has always been a NOT NULL DEFAULT 0 column. Every mount seeded that way arrived without it, so a detach in the window between a workspace switch and the first mount views load silently skipped the write.

## Fix

Both ends, deliberately:

1. `SessionWorktree` now carries `revision`, populated from the real row value, and `buildSessionProjectMounts` propagates it. This removes the asymmetry between the two builders.
2. `detachProject` refetches the real revision via `getSessionMount` when it is still missing, the same idiom `verifyAvailableWorktrees` already uses in this slice, instead of skipping the write. No invented default: if the refetch also fails, the write is still skipped, which is the old behaviour for a case that is now close to unreachable.

Fixing only the builder would have left the gate fragile for future seeds; fixing only the gate would have left the asymmetry.

## Also here

`unarchiveTask` had an empty catch around the secondary refresh, after the database restore was already committed. A single failing call left the session looking empty, with no branch and no agents, and said nothing. It now keeps the session restored and tells the user that part of the data did not load, using the same notification pattern as `setCurrentSession` and `bulkUnarchiveTask`.

## Noted, not touched

`mountRequests.ts:126` and `mountRowModel.ts:284` use `mount.revision ?? 0`, an invented default rather than a gate. They do not write to the database, only staleness checks and the row model, but in the same seed window they can reason with a fake revision 0. Worth its own look.

## Tests

4 added: 2 in `detachProject.test.ts` for the refetch fallback, 2 in `sessions/index.test.ts` for revision propagation through unarchive and the failed refresh notification. `apps/desktop`: 802 files, 7267 tests green. `packages/db`: 405 green. Typecheck clean on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)