### PR TITLE
fix(desktop): make permissions, budget and pr actions truthful

### DIFF
--- a/apps/desktop/src/features/budget/hooks/useWorkspaceSpend/index.test.ts
+++ b/apps/desktop/src/features/budget/hooks/useWorkspaceSpend/index.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, renderHook } from '@testing-library/react';
+import type { BudgetRule, IsoDateTime } from '@goodboy/types';
+
+const typedString = <Value extends string>({ value }: { readonly value: string }): Value =>
+  JSON.parse(JSON.stringify(value));
+
+const CREATED_AT = typedString<IsoDateTime>({ value: '2026-09-11T10:00:00.000Z' });
+
+const h = vi.hoisted(() => ({
+  store: {
+    currentSessionId: null,
+    currentWorkspaceId: null,
+    sessionTelemetry: {},
+    providerSpendBreakdown: [],
+    budgetAlerts: [],
+    budgetRules: [] as ReadonlyArray<BudgetRule>,
+    sessionBudgets: {},
+    dismissBudgetAlert: vi.fn(async () => undefined),
+    saveBudgetRule: vi.fn(async () => undefined),
+    deleteBudgetRule: vi.fn(async () => undefined),
+    setSessionBudget: vi.fn(async () => undefined),
+    refreshProviderSpendBreakdown: vi.fn(async () => undefined),
+  },
+}));
+
+vi.mock('../../../../store', () => ({
+  EMPTY_ARRAY: [],
+  useSessions: () => [],
+  useAppStore: <T>(selector: (state: typeof h.store) => T) => selector(h.store),
+}));
+
+vi.mock('../useBudgetData', () => ({
+  useBudgetData: () => ({}),
+}));
+
+import { useWorkspaceSpend } from './index';
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  h.store.budgetRules = [];
+});
+
+describe('useWorkspaceSpend', () => {
+  it('updates a provider cap without deleting or replacing its rule', async () => {
+    const existing: BudgetRule = {
+      id: 'rule-1',
+      provider: 'anthropic',
+      period: 'monthly',
+      capUsd: 50,
+      alertThresholdPct: 0.8,
+      extraTokensBudget: null,
+      createdAt: CREATED_AT,
+    };
+    h.store.budgetRules = [existing];
+    const { result } = renderHook(() => useWorkspaceSpend({ sinceMs: null }));
+
+    await act(async () => {
+      await result.current.saveProviderCap({ provider: 'anthropic', capUsd: 75 });
+    });
+
+    expect(h.store.saveBudgetRule).toHaveBeenCalledWith({ ...existing, capUsd: 75 });
+    expect(h.store.deleteBudgetRule).not.toHaveBeenCalled();
+  });
+
+  it('updates a threshold under the existing identity', async () => {
+    const existing: BudgetRule = {
+      id: 'rule-1',
+      provider: 'anthropic',
+      period: 'monthly',
+      capUsd: 50,
+      alertThresholdPct: 0.8,
+      extraTokensBudget: null,
+      createdAt: CREATED_AT,
+    };
+    h.store.budgetRules = [existing];
+    const { result } = renderHook(() => useWorkspaceSpend({ sinceMs: null }));
+
+    await act(async () => {
+      await result.current.saveProviderThreshold({ provider: 'anthropic', thresholdPct: 0.9 });
+    });
+
+    expect(h.store.saveBudgetRule).toHaveBeenCalledWith({
+      ...existing,
+      alertThresholdPct: 0.9,
+    });
+    expect(h.store.deleteBudgetRule).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/features/budget/hooks/useWorkspaceSpend/index.ts
+++ b/apps/desktop/src/features/budget/hooks/useWorkspaceSpend/index.ts
@@ -80,20 +80,20 @@ export const useWorkspaceSpend = ({ sinceMs }: Params): WorkspaceSpend => {
   const saveProviderCap = useCallback(
     async ({ provider, capUsd }: SaveProviderCapParams) => {
       const existing = rules.find((rule) => rule.provider === provider) ?? null;
-      if (existing) {
-        await deleteBudgetRule(existing.id);
-      }
-      const next: Omit<BudgetRule, 'id' | 'createdAt'> = {
-        provider,
-        period: existing?.period ?? 'monthly',
-        capUsd,
-        alertThresholdPct: existing?.alertThresholdPct ?? 80,
-        extraTokensBudget: existing?.extraTokensBudget ?? null,
-      };
+      const next: BudgetRule | Omit<BudgetRule, 'id' | 'createdAt'> =
+        existing === null
+          ? {
+              provider,
+              period: 'monthly',
+              capUsd,
+              alertThresholdPct: 80,
+              extraTokensBudget: null,
+            }
+          : { ...existing, capUsd };
       await saveBudgetRule(next);
       await refreshBreakdown();
     },
-    [deleteBudgetRule, refreshBreakdown, rules, saveBudgetRule],
+    [refreshBreakdown, rules, saveBudgetRule],
   );
 
   const saveProviderThreshold = useCallback(
@@ -102,18 +102,11 @@ export const useWorkspaceSpend = ({ sinceMs }: Params): WorkspaceSpend => {
       if (existing === null) {
         return;
       }
-      await deleteBudgetRule(existing.id);
-      const next: Omit<BudgetRule, 'id' | 'createdAt'> = {
-        provider,
-        period: existing.period,
-        capUsd: existing.capUsd,
-        alertThresholdPct: thresholdPct,
-        extraTokensBudget: existing.extraTokensBudget,
-      };
+      const next: BudgetRule = { ...existing, alertThresholdPct: thresholdPct };
       await saveBudgetRule(next);
       await refreshBreakdown();
     },
-    [deleteBudgetRule, refreshBreakdown, rules, saveBudgetRule],
+    [refreshBreakdown, rules, saveBudgetRule],
   );
 
   const removeProviderCap = useCallback(

--- a/apps/desktop/src/features/github/components/GitHubStudio/PrDetailPanel.test.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/PrDetailPanel.test.tsx
@@ -202,8 +202,10 @@ vi.mock('../../../../app/components/Toast', () => ({
 vi.mock('./PrActionBar', () => ({
   PrActionBar: ({
     onSubmitVerdict,
+    onMerge,
   }: {
     readonly onSubmitVerdict: (submission: { verdict: string; body: string }) => void;
+    readonly onMerge: () => Promise<void>;
   }) => (
     <div>
       Pull request actions
@@ -212,6 +214,9 @@ vi.mock('./PrActionBar', () => ({
         onClick={() => onSubmitVerdict({ verdict: 'approve', body: 'ship it' })}
       >
         Approve pull request
+      </button>
+      <button type="button" onClick={() => void onMerge()}>
+        Merge pull request action
       </button>
     </div>
   ),
@@ -244,6 +249,7 @@ beforeEach(() => {
   h.store.sessionSelectedPrNumber = {};
   h.store.selectSessionPr.mockClear();
   h.store.publishPrReview.mockClear();
+  h.store.mergePr.mockClear();
   h.showToast.mockClear();
 });
 
@@ -363,6 +369,20 @@ describe('PrDetailPanel', () => {
       ),
     );
     expect(h.showToast).not.toHaveBeenCalledWith('success', expect.anything());
+  });
+
+  it('shows the cause when a pull request action fails', async () => {
+    h.store.mergePr.mockRejectedValueOnce(new Error('branch protection rejected the merge'));
+
+    renderPanel();
+    fireEvent.click(screen.getByRole('button', { name: 'Merge pull request action' }));
+
+    await waitFor(() =>
+      expect(h.showToast).toHaveBeenCalledWith(
+        'error',
+        'Merge failed: branch protection rejected the merge',
+      ),
+    );
   });
 
   it('drives the active pr and switcher selection through store state', () => {

--- a/apps/desktop/src/features/github/components/GitHubStudio/PrDetailPanel.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/PrDetailPanel.tsx
@@ -36,10 +36,23 @@ const VERDICT_TOAST = {
   request_changes: 'Changes requested on the pull request',
 } satisfies Record<PublishPrReviewVerdict, string>;
 
+const ACTION_FAILURE_LABEL: Record<Exclude<ActionBusy, 'review' | null>, string> = {
+  ready: 'Mark ready failed',
+  undraft: 'Convert to draft failed',
+  merge: 'Merge failed',
+  close: 'Close failed',
+  reopen: 'Reopen failed',
+};
+
 type Props = {
   readonly sessionId: SessionId | null;
   readonly initialPrNumber?: number | null;
   readonly onClose: () => void;
+};
+
+type RunParams = {
+  readonly kind: Exclude<ActionBusy, 'review' | null>;
+  readonly action: () => Promise<void>;
 };
 
 export const PrDetailPanel = ({ sessionId, initialPrNumber = null, onClose }: Props) => {
@@ -159,16 +172,16 @@ export const PrDetailPanel = ({ sessionId, initialPrNumber = null, onClose }: Pr
 
   const onMutated = refreshActive;
 
-  const run = async (kind: Exclude<ActionBusy, null>, fn: () => Promise<void>) => {
+  const run = async ({ kind, action }: RunParams) => {
     if (busy != null) {
       return;
     }
     setBusy(kind);
     try {
-      await fn();
+      await action();
       onMutated();
-    } catch {
-      void 0;
+    } catch (err) {
+      showToast('error', `${ACTION_FAILURE_LABEL[kind]}: ${formatError(err)}`);
     } finally {
       setBusy(null);
     }
@@ -181,8 +194,9 @@ export const PrDetailPanel = ({ sessionId, initialPrNumber = null, onClose }: Pr
     void (async () => {
       try {
         await requestReview(sessionId, activePr.number, logins);
-      } catch {
-        void 0;
+      } catch (err) {
+        showToast('error', `Reviewers not requested: ${formatError(err)}`);
+        return;
       }
       onMutated();
     })();
@@ -280,13 +294,15 @@ export const PrDetailPanel = ({ sessionId, initialPrNumber = null, onClose }: Pr
           canReview={verdictTarget != null}
           mergeReason={mergeReason}
           onSubmitVerdict={(submission) => void submitVerdict(submission)}
-          onMarkReady={() => void run('ready', () => markPrReady(sessionId, num))}
-          onConvertDraft={() => void run('undraft', () => convertPrToDraft(sessionId, num))}
-          onClose={() => void run('close', () => closePr(sessionId, num))}
-          onReopen={() => void run('reopen', () => reopenPr(sessionId, num))}
+          onMarkReady={() => void run({ kind: 'ready', action: () => markPrReady(sessionId, num) })}
+          onConvertDraft={() =>
+            void run({ kind: 'undraft', action: () => convertPrToDraft(sessionId, num) })
+          }
+          onClose={() => void run({ kind: 'close', action: () => closePr(sessionId, num) })}
+          onReopen={() => void run({ kind: 'reopen', action: () => reopenPr(sessionId, num) })}
           canCreateNew={!isDraftAgentRunning}
           onCreateNew={() => setCreateOpen(true)}
-          onMerge={() => run('merge', () => mergePr(sessionId, num))}
+          onMerge={() => run({ kind: 'merge', action: () => mergePr(sessionId, num) })}
         />
       )}
     </>

--- a/apps/desktop/src/features/impact/components/ImpactStudio/spend.test.tsx
+++ b/apps/desktop/src/features/impact/components/ImpactStudio/spend.test.tsx
@@ -190,7 +190,7 @@ describe('Impact studio spend scopes', () => {
     expect(state.deleteBudgetRule).not.toHaveBeenCalled();
   });
 
-  it('edits an existing provider cap as delete then save', async () => {
+  it('edits an existing provider cap under the same rule identity', async () => {
     state.budgetRules = [
       {
         id: 'rule-1',
@@ -207,17 +207,19 @@ describe('Impact studio spend scopes', () => {
     fireEvent.change(screen.getByLabelText(/monthly cap/i), { target: { value: '25' } });
     fireEvent.click(screen.getByRole('button', { name: /update cap/i }));
     await Promise.resolve();
-    expect(state.deleteBudgetRule).toHaveBeenCalledWith('rule-1');
+    expect(state.deleteBudgetRule).not.toHaveBeenCalled();
     expect(state.saveBudgetRule).toHaveBeenCalledWith({
+      id: 'rule-1',
       provider: 'anthropic',
       period: 'monthly',
       capUsd: 25,
       alertThresholdPct: 90,
       extraTokensBudget: 5,
+      createdAt: '2026-06-01T00:00:00.000Z',
     });
   });
 
-  it('edits the threshold as delete then save, keeping the cap intact', async () => {
+  it('edits the threshold under the same rule identity', async () => {
     state.budgetRules = [
       {
         id: 'rule-1',
@@ -236,13 +238,15 @@ describe('Impact studio spend scopes', () => {
     });
     fireEvent.click(screen.getByRole('button', { name: /update threshold/i }));
     await Promise.resolve();
-    expect(state.deleteBudgetRule).toHaveBeenCalledWith('rule-1');
+    expect(state.deleteBudgetRule).not.toHaveBeenCalled();
     expect(state.saveBudgetRule).toHaveBeenCalledWith({
+      id: 'rule-1',
       provider: 'anthropic',
       period: 'monthly',
       capUsd: 10,
       alertThresholdPct: 60,
       extraTokensBudget: 5,
+      createdAt: '2026-06-01T00:00:00.000Z',
     });
   });
 

--- a/apps/desktop/src/features/permissions/components/PermissionModePicker/index.test.tsx
+++ b/apps/desktop/src/features/permissions/components/PermissionModePicker/index.test.tsx
@@ -15,9 +15,9 @@ vi.mock('../../../../store', () => ({
 
 import { PermissionModePicker, permissionModeMeta } from './index';
 
-function makeSession(): Session {
+const makeSession = (): Session => {
   return { id: 'sess-1', permissionMode: 'default' } as Session;
-}
+};
 
 beforeEach(() => {
   setModeMock.mockReset();
@@ -30,12 +30,13 @@ describe('PermissionModePicker', () => {
     expect(screen.getByText('Default')).toBeDefined();
   });
 
-  it('opens a dialog with all 4 mode options when clicked', () => {
+  it('opens a dialog with all 5 mode options when clicked', () => {
     render(<PermissionModePicker session={makeSession()} activeProvider="anthropic" />);
     fireEvent.click(screen.getByRole('button', { name: /default/i }));
     expect(screen.getByRole('dialog', { name: /permission mode/i })).toBeDefined();
     expect(screen.getByText('Bypass')).toBeDefined();
     expect(screen.getByText('Edits')).toBeDefined();
+    expect(screen.getByText("Don't ask")).toBeDefined();
     expect(screen.getByText('Plan')).toBeDefined();
   });
 
@@ -97,5 +98,12 @@ describe('PermissionModePicker', () => {
 describe('permissionModeMeta', () => {
   it('returns the meta for a known mode', () => {
     expect(permissionModeMeta('plan').label).toBe('Plan');
+  });
+
+  it('represents dontAsk as restrictive instead of bypass', () => {
+    const meta = permissionModeMeta('dontAsk');
+
+    expect(meta.label).toBe("Don't ask");
+    expect(meta.tone).toBe('neutral');
   });
 });

--- a/apps/desktop/src/features/permissions/components/PermissionModePicker/index.tsx
+++ b/apps/desktop/src/features/permissions/components/PermissionModePicker/index.tsx
@@ -13,39 +13,54 @@ type ModeMeta = {
   readonly text: string;
 };
 
-const PERMISSION_MODES: ReadonlyArray<ModeMeta> = [
-  {
+const PERMISSION_MODE_META: Record<ClaudePermissionMode, ModeMeta> = {
+  bypassPermissions: {
     value: 'bypassPermissions',
     label: 'Bypass',
     description: 'Agent uses all tools freely, no prompts',
     tone: 'danger',
     text: 'text-danger',
   },
-  {
+  acceptEdits: {
     value: 'acceptEdits',
     label: 'Edits',
     description: 'File edits allowed, asks before bash',
     tone: 'warning',
     text: 'text-warning',
   },
-  {
+  default: {
     value: 'default',
     label: 'Default',
     description: 'Asks before writes and runs',
     tone: 'info',
     text: 'text-info',
   },
-  {
+  dontAsk: {
+    value: 'dontAsk',
+    label: "Don't ask",
+    description: 'Requests that need approval are denied, no prompts',
+    tone: 'neutral',
+    text: 'text-muted-foreground',
+  },
+  plan: {
     value: 'plan',
     label: 'Plan',
     description: 'No tool calls executed, read-only',
     tone: 'neutral',
     text: 'text-muted-foreground',
   },
+};
+
+const PERMISSION_MODES: ReadonlyArray<ModeMeta> = [
+  PERMISSION_MODE_META.bypassPermissions,
+  PERMISSION_MODE_META.acceptEdits,
+  PERMISSION_MODE_META.default,
+  PERMISSION_MODE_META.dontAsk,
+  PERMISSION_MODE_META.plan,
 ];
 
 export const permissionModeMeta = (mode: ClaudePermissionMode): ModeMeta => {
-  return PERMISSION_MODES.find((m) => m.value === mode) ?? PERMISSION_MODES[0]!;
+  return PERMISSION_MODE_META[mode] ?? PERMISSION_MODE_META.plan;
 };
 
 type Props = {
@@ -56,7 +71,7 @@ type Props = {
 export const PermissionModePicker = ({ session, activeProvider }: Props) => {
   const dropdown = useDropdown({
     width: 'w-64',
-    expectedHeight: 240,
+    expectedHeight: 280,
     openEvent: 'goodboy:open-permission-picker',
   });
   const { open, close, toggle } = dropdown;

--- a/apps/desktop/src/features/session/components/CommandPalette/index.tsx
+++ b/apps/desktop/src/features/session/components/CommandPalette/index.tsx
@@ -24,7 +24,7 @@ import { useThemeStore } from '../../../../shared/lib/theme';
 import { linkedProjectsLabel } from '../../../workspace/linkedProjectsLabel';
 import { shortcutGlyphs } from '../../../../shared/keyboard/registry';
 
-type PaletteGroup = Exclude<QuickActionGroup, 'skill' | 'workflow'> | 'recents';
+type PaletteGroup = Exclude<QuickActionGroup, 'skill' | 'workflow'>;
 
 type PaletteItem = {
   readonly id: string;
@@ -37,7 +37,6 @@ type PaletteItem = {
 };
 
 const GROUP_LABELS: Record<PaletteGroup, string> = {
-  recents: 'Recents',
   workspace: 'Workspaces',
   session: 'Sessions',
   agent: 'Agents',
@@ -49,7 +48,6 @@ const GROUP_LABELS: Record<PaletteGroup, string> = {
 const PALETTE_PREFIXES = PREFIXES.filter((p) => p.group !== 'skill' && p.group !== 'workflow');
 
 const GROUP_ORDER: ReadonlyArray<PaletteGroup> = [
-  'recents',
   'agent',
   'session',
   'workspace',

--- a/apps/desktop/src/features/session/components/CreateAgentPopover/index.test.tsx
+++ b/apps/desktop/src/features/session/components/CreateAgentPopover/index.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { IsoDateTime, ProviderId, Session, SessionId, WorkspaceId } from '@goodboy/types';
 
 type Store = {
@@ -205,6 +205,44 @@ describe('CreateAgentPopover', () => {
       effort: 'low',
       focus: 'agent',
     });
+  });
+
+  it('blocks repeated spawn gestures while creation is pending', async () => {
+    let finishSpawn: (() => void) | null = null;
+    const pendingSpawn = new Promise<string>((resolve) => {
+      finishSpawn = () => resolve('a1');
+    });
+    h.spawnAgent.mockReturnValueOnce(pendingSpawn);
+    renderControl();
+    openPopover();
+
+    confirm();
+    const action = screen.getByRole('button', { name: 'Spawning Generalist' });
+    fireEvent.click(action);
+
+    expect(h.spawnAgent).toHaveBeenCalledOnce();
+    expect(action.getAttribute('aria-busy')).toBe('true');
+
+    await act(async () => {
+      finishSpawn?.();
+      await pendingSpawn;
+    });
+  });
+
+  it('keeps the control open and shows a spawn failure', async () => {
+    h.spawnAgent.mockRejectedValueOnce(new Error('provider is unavailable'));
+    renderControl();
+    openPopover();
+
+    confirm();
+
+    expect((await screen.findByRole('alert')).textContent).toContain('provider is unavailable');
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: 'Spawn Generalist' }).hasAttribute('disabled'),
+      ).toBe(false),
+    );
+    expect(screen.getByRole('dialog', { name: 'Create agent' })).toBeDefined();
   });
 
   it('renders codex variants as chips without a native select', () => {

--- a/apps/desktop/src/features/session/components/CreateAgentPopover/index.test.tsx
+++ b/apps/desktop/src/features/session/components/CreateAgentPopover/index.test.tsx
@@ -71,8 +71,13 @@ vi.mock('../../../../store', () => ({
 
 import { CreateAgentPopover } from './index';
 
-const renderControl = (variant?: 'tile' | 'compact') => {
-  return render(<CreateAgentPopover sessionId={SID} variant={variant} onSpawned={vi.fn()} />);
+type RenderControlParams = {
+  readonly variant?: 'tile' | 'compact';
+  readonly onSpawned?: () => void;
+};
+
+const renderControl = ({ variant, onSpawned = vi.fn() }: RenderControlParams = {}) => {
+  return render(<CreateAgentPopover sessionId={SID} variant={variant} onSpawned={onSpawned} />);
 };
 
 const openPopover = () => {
@@ -229,6 +234,23 @@ describe('CreateAgentPopover', () => {
     });
   });
 
+  it('notifies the caller and reveals chat after a successful spawn', async () => {
+    const onSpawned = vi.fn();
+    const onRevealChat = vi.fn();
+    window.addEventListener('goodboy:reveal-chat', onRevealChat);
+
+    try {
+      renderControl({ onSpawned });
+      openPopover();
+      confirm();
+
+      await waitFor(() => expect(onSpawned).toHaveBeenCalledOnce());
+      expect(onRevealChat).toHaveBeenCalledOnce();
+    } finally {
+      window.removeEventListener('goodboy:reveal-chat', onRevealChat);
+    }
+  });
+
   it('keeps the control open and shows a spawn failure', async () => {
     h.spawnAgent.mockRejectedValueOnce(new Error('provider is unavailable'));
     renderControl();
@@ -333,7 +355,7 @@ describe('CreateAgentPopover', () => {
   });
 
   it('renders a compact header control without its own edge inset', () => {
-    renderControl('compact');
+    renderControl({ variant: 'compact' });
     const trigger = screen.getByRole('button', { name: 'Create agent' });
 
     expect(trigger.className).toContain('h-7');

--- a/apps/desktop/src/features/session/components/CreateAgentPopover/index.tsx
+++ b/apps/desktop/src/features/session/components/CreateAgentPopover/index.tsx
@@ -94,7 +94,6 @@ export const CreateAgentPopover = ({
       close();
       if (onSpawned != null) {
         onSpawned();
-        return;
       }
       window.dispatchEvent(new CustomEvent('goodboy:reveal-chat'));
     } catch (err) {

--- a/apps/desktop/src/features/session/components/CreateAgentPopover/index.tsx
+++ b/apps/desktop/src/features/session/components/CreateAgentPopover/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { getDefaultTurnModel } from '@goodboy/core';
 import {
@@ -8,6 +8,7 @@ import {
   Divider,
   PopoverBody,
   PopoverFooter,
+  formatError,
   useDropdown,
 } from '@goodboy/ui';
 import type { ProviderId, SessionId } from '@goodboy/types';
@@ -50,6 +51,9 @@ export const CreateAgentPopover = ({
   const { open, close, toggle } = dropdown;
   const [kind, setKind] = useState<AgentKind>('generic');
   const [routing, setRouting] = useState<AgentKindRouting | null>(null);
+  const [isSpawning, setIsSpawning] = useState(false);
+  const [spawnError, setSpawnError] = useState<string | null>(null);
+  const isSpawningRef = useRef(false);
   const spawnAgent = useAppStore((state) => state.spawnAgent);
   const agentKinds = visibleAgentKinds();
   const selectedKind = agentKinds.includes(kind) ? kind : (agentKinds[0] ?? 'generic');
@@ -71,21 +75,34 @@ export const CreateAgentPopover = ({
   }, [open, selectedKind, routing, spawnDefault.provider]);
 
   const onCreate = async () => {
-    await spawnAgent(sessionId, {
-      kindOverride: selectedKind,
-      provider: effective.provider,
-      model: effective.model,
-      effort: effective.effort,
-      focus: 'agent',
-    });
-    setKind('generic');
-    setRouting(null);
-    close();
-    if (onSpawned != null) {
-      onSpawned();
+    if (isSpawningRef.current) {
       return;
     }
-    window.dispatchEvent(new CustomEvent('goodboy:reveal-chat'));
+    isSpawningRef.current = true;
+    setIsSpawning(true);
+    setSpawnError(null);
+    try {
+      await spawnAgent(sessionId, {
+        kindOverride: selectedKind,
+        provider: effective.provider,
+        model: effective.model,
+        effort: effective.effort,
+        focus: 'agent',
+      });
+      setKind('generic');
+      setRouting(null);
+      close();
+      if (onSpawned != null) {
+        onSpawned();
+        return;
+      }
+      window.dispatchEvent(new CustomEvent('goodboy:reveal-chat'));
+    } catch (err) {
+      setSpawnError(formatError(err));
+    } finally {
+      isSpawningRef.current = false;
+      setIsSpawning(false);
+    }
   };
 
   return (
@@ -138,8 +155,19 @@ export const CreateAgentPopover = ({
         />
       </PopoverBody>
       <Divider />
-      <PopoverFooter className="flex items-center justify-end px-2.5 py-2">
-        <Button size="sm" onClick={() => void onCreate()}>
+      <PopoverFooter className="flex items-center justify-end gap-2 px-2.5 py-2">
+        {spawnError === null ? null : (
+          <span role="alert" className="min-w-0 flex-1 text-2xs text-danger">
+            {spawnError}
+          </span>
+        )}
+        <Button
+          size="sm"
+          onClick={() => void onCreate()}
+          disabled={isSpawning}
+          isBusy={isSpawning}
+          busyLabel={`Spawning ${AGENT_KIND_META[selectedKind].label}`}
+        >
           Spawn {AGENT_KIND_META[selectedKind].label}
         </Button>
       </PopoverFooter>

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/MountProjectAction.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/MountProjectAction.test.tsx
@@ -58,6 +58,14 @@ describe('MountProjectAction', () => {
   });
 
   it('tells the workspace has no projects at all', () => {
+    let settingsDetail: unknown = null;
+    const onOpenWorkspaceSettings = vi.fn((event: Event) => {
+      if (!(event instanceof CustomEvent)) {
+        return;
+      }
+      settingsDetail = event.detail;
+    });
+    window.addEventListener('goodboy:open-workspace-settings', onOpenWorkspaceSettings);
     store.projects = [];
     render(
       <MountProjectAction
@@ -69,6 +77,10 @@ describe('MountProjectAction', () => {
     openPicker();
 
     expect(screen.getByText('Add a project in workspace settings to mount it here.')).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: 'Add workspace project' }));
+    expect(onOpenWorkspaceSettings).toHaveBeenCalledOnce();
+    expect(settingsDetail).toEqual({ section: 'projects' });
+    window.removeEventListener('goodboy:open-workspace-settings', onOpenWorkspaceSettings);
   });
 
   it('distinguishes an all-mounted workspace from an empty one', () => {
@@ -87,6 +99,7 @@ describe('MountProjectAction', () => {
 
     expect(screen.getByText('Every workspace project is already mounted.')).toBeDefined();
     expect(screen.queryByText('Add a project in workspace settings to mount it here.')).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Add workspace project' })).toBeNull();
   });
 
   it('lists an unmounted project for mounting', () => {

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/MountProjectAction.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/MountProjectAction.tsx
@@ -80,9 +80,27 @@ export const MountProjectAction = ({ sessionId, workspaceId, presentation = 'ico
       }
     >
       {availableProjects.length === 0 || isComplete ? (
-        <p className="px-3 py-2 text-xs text-muted-foreground">
-          {emptyPickerMessage({ hasWorkspaceProjects })}
-        </p>
+        <div className="flex flex-col gap-2 px-3 py-2">
+          <p className="text-xs text-muted-foreground">
+            {emptyPickerMessage({ hasWorkspaceProjects })}
+          </p>
+          {hasWorkspaceProjects ? null : (
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => {
+                dropdown.close();
+                window.dispatchEvent(
+                  new CustomEvent('goodboy:open-workspace-settings', {
+                    detail: { section: 'projects' },
+                  }),
+                );
+              }}
+            >
+              Add workspace project
+            </Button>
+          )}
+        </div>
       ) : (
         <MountProjectList
           sessionId={sessionId}

--- a/apps/desktop/src/store/slices/budget/index.test.ts
+++ b/apps/desktop/src/store/slices/budget/index.test.ts
@@ -565,6 +565,25 @@ describe('store contract', () => {
       expect(arg.provider).toBe('anthropic');
     });
 
+    it('saveBudgetRule preserves identity when updating an existing rule', async () => {
+      const store = await getStore();
+      const existing: BudgetRule = {
+        id: 'rule-existing',
+        provider: 'anthropic',
+        period: 'monthly',
+        capUsd: 50,
+        alertThresholdPct: 0.8,
+        extraTokensBudget: null,
+        createdAt: NOW,
+      };
+      invokeBudgetRuleListSpy.mockResolvedValueOnce([{ ...existing, capUsd: 75 }]);
+
+      await store.getState().saveBudgetRule({ ...existing, capUsd: 75 });
+
+      expect(invokeBudgetRuleUpsertSpy).toHaveBeenCalledWith({ ...existing, capUsd: 75 });
+      expect(invokeBudgetRuleDeleteSpy).not.toHaveBeenCalled();
+    });
+
     it('deleteBudgetRule filters by id in memory', async () => {
       const store = await getStore();
       const ruleA: BudgetRule = {

--- a/apps/desktop/src/store/slices/budget/saveBudgetRule.ts
+++ b/apps/desktop/src/store/slices/budget/saveBudgetRule.ts
@@ -2,14 +2,18 @@ import type { BudgetRule, IsoDateTime } from '@goodboy/types';
 import { invokeBudgetRuleList, invokeBudgetRuleUpsert } from '../../../features/budget/budget';
 import type { SetFn } from './types';
 
+type SaveBudgetRuleInput = BudgetRule | Omit<BudgetRule, 'id' | 'createdAt'>;
+
 export const saveBudgetRule = (set: SetFn) => {
-  return async (partial: Omit<BudgetRule, 'id' | 'createdAt'>) => {
-    const now = new Date().toISOString() as IsoDateTime;
-    const rule: BudgetRule = {
-      id: crypto.randomUUID(),
-      createdAt: now,
-      ...partial,
-    };
+  return async (input: SaveBudgetRuleInput) => {
+    const rule: BudgetRule =
+      'id' in input
+        ? input
+        : {
+            id: crypto.randomUUID(),
+            createdAt: new Date().toISOString() as IsoDateTime,
+            ...input,
+          };
     await invokeBudgetRuleUpsert(rule);
     const rules = await invokeBudgetRuleList();
     set({ budgetRules: rules });

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -606,7 +606,7 @@ type AppActions = {
   pruneArchivedTranscripts(): Promise<number>;
   removeArchivedWorktrees(): Promise<{ removed: number; failed: number }>;
   loadBudgetRules(): Promise<void>;
-  saveBudgetRule(rule: Omit<BudgetRule, 'id' | 'createdAt'>): Promise<void>;
+  saveBudgetRule(rule: BudgetRule | Omit<BudgetRule, 'id' | 'createdAt'>): Promise<void>;
   deleteBudgetRule(id: string): Promise<void>;
   loadSessionBudget(sessionId: SessionId): Promise<void>;
   setSessionBudget(sessionId: SessionId, softCapUsd: number): Promise<void>;


### PR DESCRIPTION
Six defects from the ux audit, each verified against `origin/main` before being touched rather than patched from the older report.

## The permission picker mislabelled a whole mode

`PERMISSION_MODES` listed four entries while `ClaudePermissionMode` has five. A session in `dontAsk` fell through to `PERMISSION_MODES[0]` and rendered as **Bypass** in danger red: the most permissive label in the set, on a session that was actually denying every request that needed approval.

The modes are now a `Record` keyed by the mode type, so adding a mode without its presentation is a compile error, and the fallback is `plan`, the most restrictive entry, rather than the first one in an array.

## Editing a budget rule removed its protection first

`saveBudgetRule` always minted a fresh uuid, so every edit was a delete followed by a save: a real window with no budget rule in force, and the rule's history lost. It is now an upsert that keeps the id and the original creation date.

## Failed pull request actions said nothing

The shared `run()` wrapper swallowed its error. Merge, close, reopen and mark ready failed with nothing but a button that stopped spinning, indistinguishable from success. Each now reports a readable cause through the notification path already used beside it.

## Two taps, two agents

`CreateAgentPopover` did not block repeat submits during a spawn. It now blocks repeats and carries its own busy and error state on the control.

## An empty state that named a place instead of going there

The zero projects case now opens workspace settings on the projects section.

## Already fixed upstream, verified not repatched

The duplicate `cmd+opt+R` / `cmd+opt+B` shortcut and the ambiguous empty state copy were both already corrected between 0.2.19 and 0.2.24. The phantom `recents` palette group, which had no producer anywhere, is removed here.

## Tests

`@goodboy/desktop`: 803 files, 7270 tests, all green. Typecheck clean, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)