### PR TITLE
refactor(desktop): predictable agent, mount and workflow starts

### DIFF
--- a/apps/desktop/src-tauri/src/worktree.rs
+++ b/apps/desktop/src-tauri/src/worktree.rs
@@ -427,6 +427,44 @@ pub fn sanitize_slug(input: &str) -> String {
     }
 }
 
+#[cfg(test)]
+mod sanitize_slug_tests {
+    use super::{sanitize_slug, MAX_SLUG_LEN};
+
+    #[test]
+    fn replaces_a_branch_separator_so_the_directory_never_nests() {
+        assert_eq!(sanitize_slug("alice/fix-parser"), "alice-fix-parser");
+    }
+
+    #[test]
+    fn truncates_at_the_slug_budget_without_a_trailing_dash() {
+        let sanitized = sanitize_slug(&format!("{}-tail", "a".repeat(MAX_SLUG_LEN - 1)));
+
+        assert_eq!(sanitized, "a".repeat(MAX_SLUG_LEN - 1));
+    }
+
+    #[test]
+    fn lowercases_ascii_only() {
+        assert_eq!(sanitize_slug("Fix-Parser"), "fix-parser");
+        assert_eq!(sanitize_slug("caff\u{c8}"), "caff");
+    }
+
+    #[test]
+    fn leaves_an_already_sanitized_name_untouched() {
+        let once = sanitize_slug("Alice/Fix   Parser/../weird");
+
+        assert_eq!(sanitize_slug(&once), once);
+    }
+
+    #[test]
+    fn leaves_a_mount_directory_name_untouched() {
+        let name = "alice-fix-p-9f1c2d3e-4a5b-6c7d-8e9f-0a1b2c3d4e5f";
+
+        assert_eq!(name.len(), MAX_SLUG_LEN);
+        assert_eq!(sanitize_slug(name), name);
+    }
+}
+
 #[tauri::command]
 pub async fn worktree_create(args: CreateArgs) -> Result<CreatedWorktree, WorktreeError> {
     tauri::async_runtime::spawn_blocking(move || worktree_create_blocking(args))

--- a/apps/desktop/src-tauri/src/worktree.rs
+++ b/apps/desktop/src-tauri/src/worktree.rs
@@ -543,8 +543,8 @@ fn worktree_create_blocking(args: CreateArgs) -> Result<CreatedWorktree, Worktre
                 .as_deref()
                 .map(str::trim)
                 .filter(|s| !s.is_empty());
-            let fetched = git(&repo_path, &["fetch", "origin", name]).is_ok();
-            let remote_exists = fetched
+            let fetch_failure = try_fetch_origin(&repo_path, name);
+            let remote_exists = fetch_failure.is_none()
                 && git(
                     &repo_path,
                     &[
@@ -560,7 +560,8 @@ fn worktree_create_blocking(args: CreateArgs) -> Result<CreatedWorktree, Worktre
                     git(
                         &repo_path,
                         &["fetch", "origin", &format!("{fallback}:{name}")],
-                    )?;
+                    )
+                    .map_err(|error| with_fetch_cause(error, fetch_failure.as_deref()))?;
                     git(
                         &repo_path,
                         &[
@@ -583,7 +584,8 @@ fn worktree_create_blocking(args: CreateArgs) -> Result<CreatedWorktree, Worktre
                             worktree_path.to_string_lossy().as_ref(),
                             &format!("origin/{name}"),
                         ],
-                    )?;
+                    )
+                    .map_err(|error| with_fetch_cause(error, fetch_failure.as_deref()))?;
                 }
             }
         }
@@ -596,10 +598,11 @@ fn worktree_create_blocking(args: CreateArgs) -> Result<CreatedWorktree, Worktre
         let detected_base = configured_base
             .map(str::to_string)
             .or_else(|| resolve_origin_head(&repo_path));
-        if let Some(base) = detected_base.as_deref() {
-            try_fetch_origin(&repo_path, base);
-        }
-        let base_ref = resolve_origin_base(&repo_path, configured_base)?;
+        let fetch_failure = detected_base
+            .as_deref()
+            .and_then(|base| try_fetch_origin(&repo_path, base));
+        let base_ref = resolve_origin_base(&repo_path, configured_base)
+            .map_err(|error| with_fetch_cause(error, fetch_failure.as_deref()))?;
         git(
             &repo_path,
             &[
@@ -2888,12 +2891,26 @@ fn find_existing(
         .find(|w| Path::new(&w.path) == worktree_path))
 }
 
-/// Best-effort fetch of `origin/<base>`. Silently swallows errors so that
-/// offline sessions or repos without an `origin` remote still let the user
-/// create a worktree — they just fall back to whatever `origin/<base>` already
-/// points at locally (or to the local branch as a last resort).
-fn try_fetch_origin(repo_path: &Path, base: &str) {
-    let _ = git(repo_path, &["fetch", "origin", base]);
+/// Best-effort fetch of `origin/<base>`. Returns the failure message instead of
+/// dropping it, so that offline sessions or repos without an `origin` remote
+/// still let the user create a worktree while a later failure can still name
+/// the fetch as the first thing that went wrong.
+fn try_fetch_origin(repo_path: &Path, base: &str) -> Option<String> {
+    git(repo_path, &["fetch", "origin", base])
+        .err()
+        .map(|error| error.to_string())
+}
+
+fn with_fetch_cause(error: WorktreeError, fetch_failure: Option<&str>) -> WorktreeError {
+    let Some(cause) = fetch_failure else {
+        return error;
+    };
+    let WorktreeError::Git { message } = error else {
+        return error;
+    };
+    WorktreeError::Git {
+        message: format!("{message}. fetching from origin failed first: {cause}"),
+    }
 }
 
 /// Resolve the ref to cut a new branch from. Prefers `origin/<base>` so the
@@ -3800,6 +3817,49 @@ mod rewrite_tests {
             None
         );
         std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn names_the_failed_fetch_when_the_base_ref_cannot_be_found() {
+        let root = init_repo("create-fetch-cause");
+        commit(&root, "base.txt", "base", "base");
+
+        let error = worktree_create_blocking(CreateArgs {
+            repo_path: root.to_string_lossy().into_owned(),
+            branch_prefix: "ak".to_string(),
+            slug: "first".to_string(),
+            existing_branch: None,
+            fallback_ref: None,
+            base_branch: Some("release-42".to_string()),
+            parent_dir: None,
+            dir_name: None,
+        })
+        .unwrap_err();
+
+        let super::WorktreeError::Git { message } = error else {
+            panic!("expected a git error, found {error:?}");
+        };
+        assert!(
+            message.contains("cannot find base ref"),
+            "missing the base ref cause: {message}"
+        );
+        assert!(
+            message.contains("fetching from origin failed first"),
+            "the fetch cause was dropped: {message}"
+        );
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn keeps_the_error_untouched_when_the_fetch_succeeded() {
+        let plain = super::WorktreeError::Git {
+            message: "cannot find base ref: tried origin/main".to_string(),
+        };
+
+        let super::WorktreeError::Git { message } = super::with_fetch_cause(plain, None) else {
+            panic!("expected a git error");
+        };
+        assert_eq!(message, "cannot find base ref: tried origin/main");
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/worktree.rs
+++ b/apps/desktop/src-tauri/src/worktree.rs
@@ -2891,10 +2891,6 @@ fn find_existing(
         .find(|w| Path::new(&w.path) == worktree_path))
 }
 
-/// Best-effort fetch of `origin/<base>`. Returns the failure message instead of
-/// dropping it, so that offline sessions or repos without an `origin` remote
-/// still let the user create a worktree while a later failure can still name
-/// the fetch as the first thing that went wrong.
 fn try_fetch_origin(repo_path: &Path, base: &str) -> Option<String> {
     git(repo_path, &["fetch", "origin", base])
         .err()

--- a/apps/desktop/src/features/explore/components/ExplorePane/ExploreSpawnPopover.tsx
+++ b/apps/desktop/src/features/explore/components/ExplorePane/ExploreSpawnPopover.tsx
@@ -5,6 +5,7 @@ import { useAppStore } from '../../../../store';
 import { useToast } from '../../../../app/components/Toast';
 import { clampEffort } from '../../../chat/utils/chat-constants';
 import { AgentSpawnConfig } from '../../../session/components/AgentSpawnConfig';
+import { AGENT_KIND_META } from '../../../session/agent-kind';
 import { resolveSpawnRouting } from '../../../session/spawn-routing';
 import { useSessionRoleModels } from '../../../../shared/hooks/useSessionRoleModels';
 import type { AgentSpawnConfigValue } from '../../../session/components/AgentSpawnConfig/AgentSpawnConfigValue';
@@ -138,6 +139,7 @@ export const ExploreSpawnPopover = ({ sessionId, entry }: Props) => {
           onChange={setConfig}
           disabled={isSpawning}
           className="gap-1.5"
+          role={{ label: AGENT_KIND_META.generic.label, hint: 'Fixed by the explore panel' }}
         />
         {spawnError != null ? <p className="text-xs text-danger">{spawnError}</p> : null}
       </div>

--- a/apps/desktop/src/features/explore/components/ExplorePane/index.test.tsx
+++ b/apps/desktop/src/features/explore/components/ExplorePane/index.test.tsx
@@ -273,7 +273,7 @@ describe('ExplorePane', () => {
         target: { value: 'Analyze this spreadsheet and summarize trends.' },
       },
     );
-    fireEvent.click(screen.getByRole('button', { name: /^Agent settings:/ }));
+    fireEvent.click(screen.getByRole('button', { name: /^Agent routing:/ }));
     fireEvent.click(screen.getByRole('button', { name: 'Opus' }));
     fireEvent.click(screen.getByRole('button', { name: 'Spawn agent' }));
 

--- a/apps/desktop/src/features/github/components/GitHubStudio/CreatePrPanel.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/CreatePrPanel.tsx
@@ -295,6 +295,7 @@ export const CreatePrPanel = ({
                     setAgentConfig(value);
                   }}
                   disabled={busy !== null}
+                  role={{ label: 'Pull request author', hint: 'Fixed by this panel' }}
                 />
               </FieldRow>
             )}

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel/CreateMrForm.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel/CreateMrForm.tsx
@@ -214,6 +214,7 @@ export const CreateMrForm = ({ sessionId, branch, error, onClose }: Props) => {
                     setAgentConfig(value);
                   }}
                   disabled={busy !== null}
+                  role={{ label: 'Merge request author', hint: 'Fixed by this panel' }}
                 />
               </FieldRow>
             )}

--- a/apps/desktop/src/features/scripts/components/ScriptsPanel/NewScriptCard.test.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsPanel/NewScriptCard.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import type { Project, ProjectId, WorkspaceId } from '@goodboy/types';
+import { NewScriptCard } from './NewScriptCard';
+
+const project = ({ id, name }: { readonly id: string; readonly name: string }) =>
+  ({
+    id: id as ProjectId,
+    workspaceId: 'workspace-1' as WorkspaceId,
+    name,
+    kind: 'repo',
+    rootPath: `/repos/${id}`,
+  }) as unknown as Project;
+
+const renderCard = ({
+  projects,
+  mountPath,
+}: {
+  readonly projects: ReadonlyArray<Project>;
+  readonly mountPath: string | null;
+}) =>
+  render(
+    <NewScriptCard
+      name=""
+      body=""
+      projects={projects}
+      projectId={'api' as ProjectId}
+      mountPath={mountPath}
+      error={null}
+      onNameChange={vi.fn()}
+      onBodyChange={vi.fn()}
+      onProjectChange={vi.fn()}
+      onSave={vi.fn()}
+      onCancel={vi.fn()}
+    />,
+  );
+
+afterEach(cleanup);
+
+describe('NewScriptCard', () => {
+  it('names the project and the path a single-project script will run in', () => {
+    renderCard({ projects: [project({ id: 'api', name: 'API' })], mountPath: '/work/api' });
+
+    expect(screen.getByText('Project')).toBeTruthy();
+    expect(screen.getByText('API')).toBeTruthy();
+    expect(screen.getByText('Runs in API at /work/api.')).toBeTruthy();
+    expect(screen.queryByRole('combobox', { name: 'New script project' })).toBeNull();
+  });
+
+  it('keeps the project selectable when the workspace has more than one', () => {
+    renderCard({
+      projects: [project({ id: 'api', name: 'API' }), project({ id: 'web', name: 'Web' })],
+      mountPath: '/work/api',
+    });
+
+    expect(screen.getByRole('combobox', { name: 'New script project' })).toBeTruthy();
+    expect(screen.getByText('Runs in API at /work/api.')).toBeTruthy();
+  });
+
+  it('says the script has nowhere to run when the project is not mounted', () => {
+    renderCard({ projects: [project({ id: 'api', name: 'API' })], mountPath: null });
+
+    expect(
+      screen.getByText(
+        'API is not mounted in this session yet, so this script has nowhere to run until it is.',
+      ),
+    ).toBeTruthy();
+  });
+});

--- a/apps/desktop/src/features/scripts/components/ScriptsPanel/NewScriptCard.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsPanel/NewScriptCard.tsx
@@ -9,6 +9,7 @@ type Props = {
   readonly body: string;
   readonly projects: ReadonlyArray<Project>;
   readonly projectId: ProjectId;
+  readonly mountPath: string | null;
   readonly error: string | null;
   readonly onNameChange: (value: string) => void;
   readonly onBodyChange: (value: string) => void;
@@ -17,74 +18,89 @@ type Props = {
   readonly onCancel: () => void;
 };
 
+type ScopeParams = {
+  readonly projectName: string;
+  readonly mountPath: string | null;
+};
+
+const scopeHelp = ({ projectName, mountPath }: ScopeParams): string =>
+  mountPath === null
+    ? `${projectName} is not mounted in this session yet, so this script has nowhere to run until it is.`
+    : `Runs in ${projectName} at ${mountPath}.`;
+
 export const NewScriptCard = ({
   name,
   body,
   projects,
   projectId,
+  mountPath,
   error,
   onNameChange,
   onBodyChange,
   onProjectChange,
   onSave,
   onCancel,
-}: Props) => (
-  <section className="flex flex-col gap-6">
-    <section className="flex flex-col">
-      <FieldRow label="Name">
-        <Input
-          value={name}
-          onChange={(event) => onNameChange(event.target.value)}
-          placeholder="Script name (e.g. copy environments)"
-          autoFocus
-          className="w-full sm:w-72"
-        />
-      </FieldRow>
-      <Divider />
-      {projects.length > 1 ? (
-        <>
-          <FieldRow label="Project">
+}: Props) => {
+  const projectName = projects.find((project) => project.id === projectId)?.name ?? 'this project';
+
+  return (
+    <section className="flex flex-col gap-6">
+      <section className="flex flex-col">
+        <FieldRow label="Name">
+          <Input
+            value={name}
+            onChange={(event) => onNameChange(event.target.value)}
+            placeholder="Script name (e.g. copy environments)"
+            autoFocus
+            className="w-full sm:w-72"
+          />
+        </FieldRow>
+        <Divider />
+        <FieldRow label="Project" help={scopeHelp({ projectName, mountPath })}>
+          {projects.length > 1 ? (
             <ProjectSelect
               projects={projects}
               projectId={projectId}
               ariaLabel="New script project"
               onChange={onProjectChange}
             />
-          </FieldRow>
-          <Divider />
-        </>
-      ) : null}
-      <FieldRow label="Command" help="Runs from this project's worktree for the session.">
-        <Textarea
-          value={body}
-          onChange={(event) => onBodyChange(event.target.value)}
-          placeholder={'#!/bin/bash\ncp ../main/.env .env'}
-          className="w-full font-mono text-xs sm:w-96"
-          autoGrow
-          minRows={5}
-          maxRows={24}
-          spellCheck={false}
-          autoCorrect="off"
-          autoCapitalize="off"
-        />
-      </FieldRow>
+          ) : (
+            <span className="text-xs text-foreground">{projectName}</span>
+          )}
+        </FieldRow>
+        <Divider />
+        <FieldRow label="Command" help="Saved for every session of this workspace.">
+          <Textarea
+            value={body}
+            onChange={(event) => onBodyChange(event.target.value)}
+            placeholder={'#!/bin/bash\ncp ../main/.env .env'}
+            className="w-full font-mono text-xs sm:w-96"
+            autoGrow
+            minRows={5}
+            maxRows={24}
+            spellCheck={false}
+            autoCorrect="off"
+            autoCapitalize="off"
+          />
+        </FieldRow>
+      </section>
+      <Divider />
+      <footer className="flex shrink-0 items-center gap-3">
+        <div className="min-w-0 flex-1">
+          {error !== null ? (
+            <span role="alert" className="inline-flex items-center gap-1 text-xs text-danger">
+              <AlertTriangle size={ICON_SIZE.row} aria-hidden />
+              {error}
+            </span>
+          ) : null}
+        </div>
+        <Button variant="ghost" size="sm" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button size="sm" onClick={onSave}>
+          Save
+        </Button>
+      </footer>
     </section>
-    <Divider />
-    <footer className="flex shrink-0 items-center gap-3">
-      <div className="min-w-0 flex-1">
-        {error !== null ? (
-          <span role="alert" className="inline-flex items-center gap-1 text-xs text-danger">
-            <AlertTriangle size={ICON_SIZE.row} aria-hidden />
-            {error}
-          </span>
-        ) : null}
-      </div>
-      <Button variant="ghost" size="sm" onClick={onCancel}>
-        Cancel
-      </Button>
-      <Button size="sm" onClick={onSave}>
-        Save
-      </Button>
-    </footer>
-  </section>
-);
+  );
+};

--- a/apps/desktop/src/features/scripts/components/ScriptsPanel/index.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsPanel/index.tsx
@@ -742,6 +742,7 @@ export const ScriptsPanel = ({ workspaceId, sessionId, hasHostHeading = false }:
             body={newDraft.body}
             projects={workspaceProjects}
             projectId={newDraft.projectId}
+            mountPath={mountByProjectId.get(newDraft.projectId)?.worktreePath ?? null}
             error={error}
             onNameChange={(name) =>
               setNewDraft((current) => (current == null ? null : { ...current, name }))
@@ -810,6 +811,7 @@ export const ScriptsPanel = ({ workspaceId, sessionId, hasHostHeading = false }:
                   body={newDraft.body}
                   projects={workspaceProjects}
                   projectId={newDraft.projectId}
+                  mountPath={mountByProjectId.get(newDraft.projectId)?.worktreePath ?? null}
                   error={error}
                   onNameChange={(name) =>
                     setNewDraft((current) => (current == null ? null : { ...current, name }))

--- a/apps/desktop/src/features/session/agent-form-grammar.ts
+++ b/apps/desktop/src/features/session/agent-form-grammar.ts
@@ -1,0 +1,21 @@
+export type AgentFormRole = {
+  readonly label: string;
+  readonly hint?: string;
+};
+
+export const AGENT_FORM_GRAMMAR = {
+  role: {
+    label: 'Role',
+    fixedHint: 'Fixed by where you started this agent',
+  },
+  instructions: {
+    label: 'Instructions',
+    optional: 'optional',
+    ariaLabel: 'Agent instructions',
+    placeholder: 'What to emphasize, what to avoid. Leave empty and the agent decides.',
+  },
+  routing: {
+    label: 'Routing',
+    ariaLabel: 'Agent routing',
+  },
+} as const;

--- a/apps/desktop/src/features/session/components/AgentInstructionsField/index.tsx
+++ b/apps/desktop/src/features/session/components/AgentInstructionsField/index.tsx
@@ -1,0 +1,33 @@
+import { Textarea, cn } from '@goodboy/ui';
+import { AGENT_FORM_GRAMMAR } from '../../agent-form-grammar';
+
+type Props = {
+  readonly value: string;
+  readonly onChange: (value: string) => void;
+  readonly disabled: boolean;
+  readonly className?: string;
+};
+
+export const AgentInstructionsField = ({ value, onChange, disabled, className }: Props) => (
+  <div className={cn('flex flex-col gap-1', className)}>
+    <span className="flex items-baseline gap-1.5">
+      <span className="text-2xs font-semibold uppercase tracking-wide text-muted-foreground/80">
+        {AGENT_FORM_GRAMMAR.instructions.label}
+      </span>
+      <span className="text-2xs lowercase tracking-normal text-muted-foreground/60">
+        {AGENT_FORM_GRAMMAR.instructions.optional}
+      </span>
+    </span>
+    <Textarea
+      aria-label={AGENT_FORM_GRAMMAR.instructions.ariaLabel}
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+      disabled={disabled}
+      placeholder={AGENT_FORM_GRAMMAR.instructions.placeholder}
+      minRows={2}
+      maxRows={8}
+      autoGrow
+      className="text-xs"
+    />
+  </div>
+);

--- a/apps/desktop/src/features/session/components/AgentRoleField/index.tsx
+++ b/apps/desktop/src/features/session/components/AgentRoleField/index.tsx
@@ -1,0 +1,19 @@
+import { cn } from '@goodboy/ui';
+import { AGENT_FORM_GRAMMAR, type AgentFormRole } from '../../agent-form-grammar';
+
+type Props = {
+  readonly role: AgentFormRole;
+  readonly className?: string;
+};
+
+export const AgentRoleField = ({ role, className }: Props) => (
+  <div className={cn('flex flex-col gap-0.5', className)}>
+    <span className="text-2xs font-semibold uppercase tracking-wide text-muted-foreground/80">
+      {AGENT_FORM_GRAMMAR.role.label}
+    </span>
+    <span className="text-xs font-medium text-foreground">{role.label}</span>
+    <span className="text-2xs leading-tight text-muted-foreground/60">
+      {role.hint ?? AGENT_FORM_GRAMMAR.role.fixedHint}
+    </span>
+  </div>
+);

--- a/apps/desktop/src/features/session/components/AgentSpawnConfig/index.test.tsx
+++ b/apps/desktop/src/features/session/components/AgentSpawnConfig/index.test.tsx
@@ -33,7 +33,7 @@ describe('AgentSpawnConfig', () => {
       <AgentSpawnConfig value={DEFAULT_AGENT_SPAWN_CONFIG} onChange={onChange} disabled={false} />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: /^Agent settings:/ }));
+    fireEvent.click(screen.getByRole('button', { name: /^Agent routing:/ }));
     fireEvent.click(screen.getByRole('button', { name: /^Codex/ }));
     const providerValue = onChange.mock.calls[0]![0];
     expect(providerValue.provider).toBe('codex');
@@ -42,7 +42,7 @@ describe('AgentSpawnConfig', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Mini' }));
     expect(onChange.mock.calls[1]![0].model).toBe('gpt-5.4-mini');
 
-    fireEvent.change(screen.getByRole('textbox', { name: 'Agent hint' }), {
+    fireEvent.change(screen.getByRole('textbox', { name: 'Agent instructions' }), {
       target: { value: 'Emphasize the migration path.' },
     });
     expect(onChange.mock.calls.at(-1)?.[0].hint).toBe('Emphasize the migration path.');
@@ -56,6 +56,42 @@ describe('AgentSpawnConfig', () => {
         disabled={false}
       />,
     );
-    expect(screen.getByRole('button', { name: /^Agent settings:/ }).textContent).toContain('High');
+    expect(screen.getByRole('button', { name: /^Agent routing:/ }).textContent).toContain('High');
+  });
+  it('fixes the role read-only when the caller imposes one', () => {
+    render(
+      <AgentSpawnConfig
+        value={DEFAULT_AGENT_SPAWN_CONFIG}
+        onChange={vi.fn()}
+        disabled={false}
+        role={{ label: 'Pull request author' }}
+      />,
+    );
+
+    expect(screen.getByText('Role')).toBeTruthy();
+    expect(screen.getByText('Pull request author')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Pull request author' })).toBeNull();
+  });
+
+  it('orders role, then optional instructions, then routing', () => {
+    const { container } = render(
+      <AgentSpawnConfig
+        value={DEFAULT_AGENT_SPAWN_CONFIG}
+        onChange={vi.fn()}
+        disabled={false}
+        role={{ label: 'Pull request author' }}
+      />,
+    );
+
+    const instructions = screen.getByRole('textbox', { name: 'Agent instructions' });
+    const routing = screen.getByRole('button', { name: /^Agent routing:/ });
+    const order = instructions.compareDocumentPosition(routing);
+
+    expect(container.textContent).toContain('optional');
+    expect(order & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(
+      screen.getByText('Role').compareDocumentPosition(instructions) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 });

--- a/apps/desktop/src/features/session/components/AgentSpawnConfig/index.tsx
+++ b/apps/desktop/src/features/session/components/AgentSpawnConfig/index.tsx
@@ -5,6 +5,9 @@ import { cn } from '@goodboy/ui';
 import { clampEffort } from '../../../chat/utils/chat-constants';
 import { RoutingPicker } from '../../../../shared/components/RoutingPicker';
 import { useAppStore } from '../../../../store';
+import { AGENT_FORM_GRAMMAR, type AgentFormRole } from '../../agent-form-grammar';
+import { AgentInstructionsField } from '../AgentInstructionsField';
+import { AgentRoleField } from '../AgentRoleField';
 import type { AgentSpawnConfigValue } from './AgentSpawnConfigValue';
 import { DEFAULT_AGENT_SPAWN_CONFIG } from './defaultAgentSpawnConfig';
 
@@ -13,9 +16,10 @@ type Props = {
   readonly onChange: (value: AgentSpawnConfigValue) => void;
   readonly disabled: boolean;
   readonly className?: string;
+  readonly role?: AgentFormRole;
 };
 
-export const AgentSpawnConfig = ({ value, onChange, disabled, className }: Props) => {
+export const AgentSpawnConfig = ({ value, onChange, disabled, className, role }: Props) => {
   const connectedProviders = useAppStore(
     useShallow((state) =>
       state.providers.filter((provider) => provider.connection === 'connected').map(({ id }) => id),
@@ -42,8 +46,14 @@ export const AgentSpawnConfig = ({ value, onChange, disabled, className }: Props
 
   return (
     <div className={cn('flex flex-col gap-2', className)}>
+      {role != null && <AgentRoleField role={role} />}
+      <AgentInstructionsField
+        value={value.hint}
+        onChange={(hint) => onChange({ ...value, hint })}
+        disabled={disabled}
+      />
       <RoutingPicker
-        ariaLabel="Agent settings"
+        ariaLabel={AGENT_FORM_GRAMMAR.routing.ariaLabel}
         connectedProviders={connectedProviders}
         provider={value.provider}
         model={value.model}
@@ -55,15 +65,6 @@ export const AgentSpawnConfig = ({ value, onChange, disabled, className }: Props
         disabled={disabled}
         onProvider={onProvider}
         onModel={(model) => onChange({ ...value, model, effort: clampEffort(model, value.effort) })}
-      />
-      <textarea
-        aria-label="Agent hint"
-        value={value.hint}
-        onChange={(event) => onChange({ ...value, hint: event.target.value })}
-        rows={2}
-        disabled={disabled}
-        placeholder="Optional notes for the agent: what to emphasize, what to avoid..."
-        className="w-full resize-none rounded-md border border-border-soft bg-subtle px-2 py-1.5 text-xs text-foreground placeholder:text-muted-foreground/60 focus:border-primary focus:outline-none disabled:opacity-50"
       />
     </div>
   );

--- a/apps/desktop/src/features/session/components/CreateAgentPopover/index.test.tsx
+++ b/apps/desktop/src/features/session/components/CreateAgentPopover/index.test.tsx
@@ -88,6 +88,10 @@ const confirm = () => {
   fireEvent.click(screen.getByRole('button', { name: /^Spawn / }));
 };
 
+const expandRouting = () => {
+  fireEvent.click(screen.getByRole('button', { name: /^Agent routing:/ }));
+};
+
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
@@ -174,6 +178,7 @@ describe('CreateAgentPopover', () => {
     renderControl();
     openPopover();
     fireEvent.click(screen.getByRole('button', { name: 'Scout' }));
+    expandRouting();
 
     expect(screen.getByRole('button', { name: 'Haiku' }).getAttribute('aria-pressed')).toBe('true');
 
@@ -190,6 +195,7 @@ describe('CreateAgentPopover', () => {
   it('selects a model family and version as separate ladder levels', () => {
     renderControl();
     openPopover();
+    expandRouting();
     fireEvent.click(screen.getByRole('button', { name: 'Opus' }));
     fireEvent.click(screen.getByRole('button', { name: '5' }));
     expect(screen.getByRole('button', { name: 'Opus' }).getAttribute('aria-pressed')).toBe('true');
@@ -199,6 +205,7 @@ describe('CreateAgentPopover', () => {
   it('spawns exactly the pinned model the picker shows', () => {
     renderControl();
     openPopover();
+    expandRouting();
     fireEvent.click(screen.getByRole('button', { name: 'Opus' }));
     fireEvent.click(screen.getByRole('button', { name: '5' }));
 
@@ -281,6 +288,7 @@ describe('CreateAgentPopover', () => {
     ];
     const { container } = renderControl();
     openPopover();
+    expandRouting();
 
     expect(container.querySelector('select')).toBeNull();
     expect(screen.getByRole('button', { name: 'Sol' })).toBeTruthy();
@@ -309,6 +317,7 @@ describe('CreateAgentPopover', () => {
     ];
     renderControl();
     openPopover();
+    expandRouting();
 
     fireEvent.click(screen.getByRole('button', { name: 'Thinking' }));
 
@@ -322,6 +331,7 @@ describe('CreateAgentPopover', () => {
     ];
     renderControl();
     openPopover();
+    expandRouting();
     expect(screen.getByRole('button', { name: 'Claude' })).toBeDefined();
     expect(screen.queryByRole('button', { name: 'Codex' })).toBeNull();
   });
@@ -330,6 +340,7 @@ describe('CreateAgentPopover', () => {
     h.providers = [];
     renderControl();
     openPopover();
+    expandRouting();
     const openProviders = screen.getByRole('button', { name: 'Open providers' });
     const onOpenProviderStudio = vi.fn();
     window.addEventListener('goodboy:open-settings', onOpenProviderStudio);
@@ -339,11 +350,11 @@ describe('CreateAgentPopover', () => {
     expect(screen.queryByRole('dialog', { name: 'Create agent' })).toBeNull();
   });
 
-  it('keeps the type section available for a folder project', () => {
+  it('keeps the role section available for a folder project', () => {
     renderControl();
     openPopover();
 
-    expect(screen.getByText('Agent type')).toBeDefined();
+    expect(screen.getByText('Role')).toBeDefined();
     confirm();
     expect(h.spawnAgent).toHaveBeenCalledWith(SID, {
       kindOverride: 'generic',
@@ -370,5 +381,51 @@ describe('CreateAgentPopover', () => {
     const footer = action.closest('footer');
     expect(footer?.className).toContain('shrink-0');
     expect(footer?.previousElementSibling?.getAttribute('role')).toBe('separator');
+  });
+  it('keeps routing collapsed until the user asks for it', () => {
+    renderControl();
+    openPopover();
+
+    const routing = screen.getByRole('button', { name: /^Agent routing:/ });
+    expect(routing.getAttribute('aria-expanded')).toBe('false');
+    expect(routing.textContent).toContain('Claude');
+    expect(screen.queryByRole('button', { name: 'Opus' })).toBeNull();
+
+    expandRouting();
+    expect(screen.getByRole('button', { name: 'Opus' })).toBeTruthy();
+  });
+
+  it('sends optional instructions as the first prompt and omits them when empty', () => {
+    renderControl();
+    openPopover();
+
+    const instructions = screen.getByRole('textbox', { name: 'Agent instructions' });
+    fireEvent.change(instructions, { target: { value: '  keep the diff small  ' } });
+    confirm();
+
+    expect(h.spawnAgent).toHaveBeenCalledWith(SID, {
+      kindOverride: 'generic',
+      provider: 'anthropic',
+      model: 'haiku-4.5',
+      effort: 'low',
+      initialPrompt: 'keep the diff small',
+      focus: 'agent',
+    });
+  });
+
+  it('places the role before the instructions and the instructions before routing', () => {
+    renderControl();
+    openPopover();
+
+    const role = screen.getByText('Role');
+    const instructions = screen.getByRole('textbox', { name: 'Agent instructions' });
+    const routing = screen.getByRole('button', { name: /^Agent routing:/ });
+
+    expect(
+      role.compareDocumentPosition(instructions) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      instructions.compareDocumentPosition(routing) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 });

--- a/apps/desktop/src/features/session/components/CreateAgentPopover/index.tsx
+++ b/apps/desktop/src/features/session/components/CreateAgentPopover/index.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { ChevronDown } from 'lucide-react';
 import { useShallow } from 'zustand/react/shallow';
 import { getDefaultTurnModel } from '@goodboy/core';
 import {
@@ -12,8 +13,13 @@ import {
   useDropdown,
 } from '@goodboy/ui';
 import type { ProviderId, SessionId } from '@goodboy/types';
-import { useAppStore, useCurrentWorkspace } from '../../../../store';
-import { clampEffort } from '../../../chat/utils/chat-constants';
+import { useAppStore } from '../../../../store';
+import {
+  EFFORT_LABEL,
+  PROVIDER_LABEL,
+  clampEffort,
+  modelLabel,
+} from '../../../chat/utils/chat-constants';
 import { PickerSection } from '../../../../shared/components/RoutingPicker/PickerSection';
 import { useSessionRoleModels } from '../../../../shared/hooks/useSessionRoleModels';
 import {
@@ -22,10 +28,15 @@ import {
   type AgentKind,
   type AgentKindRouting,
 } from '../../agent-kind';
+import { AGENT_FORM_GRAMMAR } from '../../agent-form-grammar';
 import { resolveSpawnRouting } from '../../spawn-routing';
+import { AgentInstructionsField } from '../AgentInstructionsField';
+import { AgentRoleField } from '../AgentRoleField';
 import { AgentKindGrid } from './AgentKindGrid';
 import { AgentRoutingSections } from './AgentRoutingSections';
 import { CreateAgentTrigger, type CreateAgentTriggerVariant } from './CreateAgentTrigger';
+
+const ROUTING_PANEL_ID = 'create-agent-routing';
 
 type Props = {
   readonly sessionId: SessionId;
@@ -51,6 +62,8 @@ export const CreateAgentPopover = ({
   const { open, close, toggle } = dropdown;
   const [kind, setKind] = useState<AgentKind>('generic');
   const [routing, setRouting] = useState<AgentKindRouting | null>(null);
+  const [instructions, setInstructions] = useState('');
+  const [isRoutingOpen, setIsRoutingOpen] = useState(false);
   const [isSpawning, setIsSpawning] = useState(false);
   const [spawnError, setSpawnError] = useState<string | null>(null);
   const isSpawningRef = useRef(false);
@@ -69,6 +82,9 @@ export const CreateAgentPopover = ({
   const spawnDefault = resolveSpawnRouting({ kind: selectedKind, roleModels, session });
   const effective: AgentKindRouting = routing ?? spawnDefault;
   const [viewProvider, setViewProvider] = useState<ProviderId>(spawnDefault.provider);
+  const routingSummary = `${PROVIDER_LABEL[effective.provider]} · ${modelLabel(effective.model)} · ${
+    EFFORT_LABEL[effective.effort]
+  }`;
 
   useEffect(() => {
     setViewProvider(routing?.provider ?? spawnDefault.provider);
@@ -81,16 +97,20 @@ export const CreateAgentPopover = ({
     isSpawningRef.current = true;
     setIsSpawning(true);
     setSpawnError(null);
+    const trimmedInstructions = instructions.trim();
     try {
       await spawnAgent(sessionId, {
         kindOverride: selectedKind,
         provider: effective.provider,
         model: effective.model,
         effort: effective.effort,
+        ...(trimmedInstructions !== '' && { initialPrompt: trimmedInstructions }),
         focus: 'agent',
       });
       setKind('generic');
       setRouting(null);
+      setInstructions('');
+      setIsRoutingOpen(false);
       close();
       if (onSpawned != null) {
         onSpawned();
@@ -122,36 +142,76 @@ export const CreateAgentPopover = ({
       }
     >
       <PopoverBody>
-        {agentKinds.length > 1 && (
-          <>
-            <PickerSection label="Agent type">
-              <AgentKindGrid kinds={agentKinds} value={selectedKind} onChange={setKind} />
-            </PickerSection>
-            <Divider />
-          </>
+        {agentKinds.length > 1 ? (
+          <PickerSection label={AGENT_FORM_GRAMMAR.role.label}>
+            <AgentKindGrid kinds={agentKinds} value={selectedKind} onChange={setKind} />
+          </PickerSection>
+        ) : (
+          <AgentRoleField
+            role={{
+              label: AGENT_KIND_META[selectedKind].label,
+              hint: AGENT_KIND_META[selectedKind].hint,
+            }}
+            className="px-2.5 py-1.5"
+          />
         )}
-        <AgentRoutingSections
-          connectedProviders={connectedProviders}
-          effective={effective}
-          viewProvider={viewProvider}
-          onViewProvider={setViewProvider}
-          onNavigateProviders={close}
-          onPickProvider={(provider) => {
-            const model = getDefaultTurnModel({ id: provider });
-            setRouting({
-              provider,
-              model,
-              effort: clampEffort(model, effective.effort),
-            });
-          }}
-          onPickModel={(model, effort) => {
-            setRouting({
-              provider: viewProvider,
-              model,
-              effort,
-            });
-          }}
+        <Divider />
+        <AgentInstructionsField
+          value={instructions}
+          onChange={setInstructions}
+          disabled={isSpawning}
+          className="px-2.5 py-1.5"
         />
+        <Divider />
+        <PickerSection label={AGENT_FORM_GRAMMAR.routing.label}>
+          <div className="px-2.5">
+            <button
+              type="button"
+              onClick={() => setIsRoutingOpen((current) => !current)}
+              aria-expanded={isRoutingOpen}
+              aria-controls={ROUTING_PANEL_ID}
+              aria-label={`${AGENT_FORM_GRAMMAR.routing.ariaLabel}: ${routingSummary}`}
+              className="flex w-full items-center gap-1.5 rounded-md border border-border-soft bg-subtle px-2 py-1.5 text-left text-xs text-foreground motion-safe:transition-colors hover:border-border hover:bg-muted/50"
+            >
+              <span className="min-w-0 flex-1 truncate">{routingSummary}</span>
+              <ChevronDown
+                size={11}
+                aria-hidden
+                className={cn(
+                  'shrink-0 text-muted-foreground motion-safe:transition-transform',
+                  isRoutingOpen && 'rotate-180',
+                )}
+              />
+            </button>
+          </div>
+        </PickerSection>
+        {isRoutingOpen && (
+          <div id={ROUTING_PANEL_ID}>
+            <Divider />
+            <AgentRoutingSections
+              connectedProviders={connectedProviders}
+              effective={effective}
+              viewProvider={viewProvider}
+              onViewProvider={setViewProvider}
+              onNavigateProviders={close}
+              onPickProvider={(provider) => {
+                const model = getDefaultTurnModel({ id: provider });
+                setRouting({
+                  provider,
+                  model,
+                  effort: clampEffort(model, effective.effort),
+                });
+              }}
+              onPickModel={(model, effort) => {
+                setRouting({
+                  provider: viewProvider,
+                  model,
+                  effort,
+                });
+              }}
+            />
+          </div>
+        )}
       </PopoverBody>
       <Divider />
       <PopoverFooter className="flex items-center justify-end gap-2 px-2.5 py-2">

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/MountPreflightCard.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/MountPreflightCard.tsx
@@ -1,0 +1,87 @@
+import { Button, cn } from '@goodboy/ui';
+import type { Project } from '@goodboy/types';
+import { ICON_SIZE, projectGlyph } from '../../../../../shared/components/conceptIcons';
+import type { MountPreflightState } from './useMountPreflight';
+
+type Props = {
+  readonly project: Project;
+  readonly state: MountPreflightState;
+  readonly isBusy: boolean;
+  readonly onConfirm: () => void;
+  readonly onCancel: () => void;
+};
+
+type RowProps = {
+  readonly label: string;
+  readonly value: string;
+  readonly isPending: boolean;
+};
+
+const PreflightRow = ({ label, value, isPending }: RowProps) => (
+  <div className="flex min-w-0 items-baseline gap-2">
+    <dt className="w-12 shrink-0 text-2xs uppercase tracking-wide text-muted-foreground/70">
+      {label}
+    </dt>
+    <dd
+      className={cn(
+        'min-w-0 flex-1 truncate font-mono text-2xs text-foreground',
+        isPending && 'text-muted-foreground',
+      )}
+      title={value}
+    >
+      {value}
+    </dd>
+  </div>
+);
+
+export const MountPreflightCard = ({ project, state, isBusy, onConfirm, onCancel }: Props) => {
+  const GlyphIcon = projectGlyph({ kind: project.kind });
+  const { preflight } = state;
+  const isPending = state.status === 'checking';
+
+  return (
+    <section aria-label={`Add ${project.name}`} className="flex flex-col gap-2 px-3 py-2">
+      <header className="flex min-w-0 items-center gap-2">
+        <GlyphIcon size={ICON_SIZE.row} aria-hidden className="shrink-0 text-muted-foreground" />
+        <span className="min-w-0 truncate text-sm text-foreground">{project.name}</span>
+      </header>
+      {preflight === null ? (
+        <p className="text-xs text-muted-foreground">Preparing the plan…</p>
+      ) : (
+        <dl className="flex flex-col gap-1">
+          {preflight.branch === null ? null : (
+            <PreflightRow
+              label="Base"
+              value={preflight.baseBranch ?? 'repository default'}
+              isPending={isPending}
+            />
+          )}
+          {preflight.branch === null ? null : (
+            <PreflightRow label="Branch" value={preflight.branch} isPending={isPending} />
+          )}
+          <PreflightRow label="Path" value={preflight.targetPath} isPending={isPending} />
+        </dl>
+      )}
+      {preflight?.renamedFrom == null ? null : (
+        <p role="status" className="text-2xs text-warning">
+          {preflight.renamedFrom} already exists in this repository, using {preflight.branch}{' '}
+          instead.
+        </p>
+      )}
+      {state.branchScanError === null ? null : (
+        <p className="text-2xs text-muted-foreground">
+          Could not read the existing branches, so a name clash was not ruled out:{' '}
+          {state.branchScanError}
+        </p>
+      )}
+      <footer className="flex items-center justify-end gap-2">
+        <Button variant="ghost" size="sm" onClick={onCancel} disabled={isBusy}>
+          Back
+        </Button>
+        <Button size="sm" onClick={onConfirm} disabled={isBusy || preflight === null}>
+          Add project
+        </Button>
+      </footer>
+    </section>
+  );
+};

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/MountPreflightCard.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/MountPreflightCard.tsx
@@ -1,12 +1,15 @@
+import { AlertTriangle } from 'lucide-react';
 import { Button, cn } from '@goodboy/ui';
 import type { Project } from '@goodboy/types';
 import { ICON_SIZE, projectGlyph } from '../../../../../shared/components/conceptIcons';
+import type { MountFailure } from './mountFailure';
 import type { MountPreflightState } from './useMountPreflight';
 
 type Props = {
   readonly project: Project;
   readonly state: MountPreflightState;
   readonly isBusy: boolean;
+  readonly failure: MountFailure | null;
   readonly onConfirm: () => void;
   readonly onCancel: () => void;
 };
@@ -34,10 +37,34 @@ const PreflightRow = ({ label, value, isPending }: RowProps) => (
   </div>
 );
 
-export const MountPreflightCard = ({ project, state, isBusy, onConfirm, onCancel }: Props) => {
+type ActivityParams = {
+  readonly project: Project;
+  readonly status: MountPreflightState['status'];
+  readonly isBusy: boolean;
+};
+
+const activityLabel = ({ project, status, isBusy }: ActivityParams): string | null => {
+  if (isBusy) {
+    return project.kind === 'repo' ? 'Creating the worktree…' : 'Creating the folder…';
+  }
+  if (status === 'checking') {
+    return 'Reading the branches already in the repository…';
+  }
+  return null;
+};
+
+export const MountPreflightCard = ({
+  project,
+  state,
+  isBusy,
+  failure,
+  onConfirm,
+  onCancel,
+}: Props) => {
   const GlyphIcon = projectGlyph({ kind: project.kind });
   const { preflight } = state;
   const isPending = state.status === 'checking';
+  const activity = activityLabel({ project, status: state.status, isBusy });
 
   return (
     <section aria-label={`Add ${project.name}`} className="flex flex-col gap-2 px-3 py-2">
@@ -74,12 +101,36 @@ export const MountPreflightCard = ({ project, state, isBusy, onConfirm, onCancel
           {state.branchScanError}
         </p>
       )}
+      {activity === null ? null : (
+        <p role="status" className="text-2xs text-muted-foreground">
+          {activity}
+        </p>
+      )}
+      {failure === null ? null : (
+        <div role="alert" className="flex flex-col gap-1">
+          <p className="flex items-start gap-1 text-2xs text-danger">
+            <AlertTriangle size={ICON_SIZE.row} aria-hidden className="mt-px shrink-0" />
+            <span className="min-w-0 flex-1">{failure.cause}</span>
+          </p>
+          <details className="text-2xs text-muted-foreground">
+            <summary className="cursor-pointer select-none">Technical detail</summary>
+            <pre className="mt-1 max-h-32 overflow-auto whitespace-pre-wrap break-all rounded-md bg-muted/40 p-1.5 font-mono text-2xs">
+              {failure.detail}
+            </pre>
+          </details>
+        </div>
+      )}
       <footer className="flex items-center justify-end gap-2">
         <Button variant="ghost" size="sm" onClick={onCancel} disabled={isBusy}>
           Back
         </Button>
-        <Button size="sm" onClick={onConfirm} disabled={isBusy || preflight === null}>
-          Add project
+        <Button
+          size="sm"
+          onClick={onConfirm}
+          disabled={isBusy || preflight === null}
+          isBusy={isBusy}
+        >
+          {failure === null ? 'Add project' : 'Try again'}
         </Button>
       </footer>
     </section>

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/MountProjectList.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/MountProjectList.test.tsx
@@ -1,0 +1,113 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { MountId, Project, ProjectId, SessionId, WorkspaceId } from '@goodboy/types';
+import { emptyOverrides } from '../../../../../store/storyHarness';
+
+const SID = 'session-1' as SessionId;
+const WID = 'workspace-1' as WorkspaceId;
+const PID = 'project-1' as ProjectId;
+const MID = 'mount-1' as MountId;
+
+const repoProject = {
+  id: PID,
+  workspaceId: WID,
+  name: 'goodboy',
+  kind: 'repo',
+  rootPath: '/repos/goodboy',
+  baseBranch: 'main',
+  overrides: emptyOverrides,
+  createdAt: '2026-07-27T00:00:00.000Z',
+  updatedAt: '2026-07-27T00:00:00.000Z',
+} as unknown as Project;
+
+const h = vi.hoisted(() => ({
+  materializeProject: vi.fn(async () => undefined),
+  emitNotification: vi.fn(),
+  preflight: {
+    status: 'ready',
+    preflight: {
+      mountId: 'mount-1',
+      slug: 'ship-it',
+      branch: 'ak/ship-it',
+      baseBranch: 'main',
+      targetPath: '/repos/goodboy/.goodboy/worktrees/ship-it-mount-1',
+      renamedFrom: null as string | null,
+    },
+    branchScanError: null as string | null,
+  },
+}));
+
+vi.mock('../../../../../store', () => ({
+  useAppStore: <T,>(
+    selector: (state: {
+      readonly materializeProject: typeof h.materializeProject;
+      readonly emitNotification: typeof h.emitNotification;
+    }) => T,
+  ) =>
+    selector({
+      materializeProject: h.materializeProject,
+      emitNotification: h.emitNotification,
+    }),
+}));
+
+vi.mock('./useMountPreflight', () => ({ useMountPreflight: () => h.preflight }));
+
+import { MountProjectList } from './MountProjectList';
+
+const renderList = () =>
+  render(<MountProjectList sessionId={SID} projects={[repoProject]} onDone={vi.fn()} />);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.preflight.preflight.renamedFrom = null;
+  h.preflight.branchScanError = null;
+});
+
+afterEach(cleanup);
+
+describe('MountProjectList', () => {
+  it('shows base, branch and target path before creating anything', () => {
+    renderList();
+    fireEvent.click(screen.getByRole('button', { name: 'Mount goodboy' }));
+
+    expect(h.materializeProject).not.toHaveBeenCalled();
+    expect(screen.getByText('main')).toBeTruthy();
+    expect(screen.getByText('ak/ship-it')).toBeTruthy();
+    expect(screen.getByText('/repos/goodboy/.goodboy/worktrees/ship-it-mount-1')).toBeTruthy();
+  });
+
+  it('creates with exactly the branch and the mount the preview showed', async () => {
+    renderList();
+    fireEvent.click(screen.getByRole('button', { name: 'Mount goodboy' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Add project' }));
+
+    await waitFor(() =>
+      expect(h.materializeProject).toHaveBeenCalledWith({
+        sessionId: SID,
+        projectId: PID,
+        reason: 'added manually by the user',
+        mountId: MID,
+        slug: 'ship-it',
+      }),
+    );
+  });
+
+  it('names the branch it had to step around', () => {
+    h.preflight.preflight.renamedFrom = 'ak/taken';
+    renderList();
+    fireEvent.click(screen.getByRole('button', { name: 'Mount goodboy' }));
+
+    expect(screen.getByRole('status').textContent).toContain('ak/taken already exists');
+  });
+
+  it('goes back to the list without creating anything', () => {
+    renderList();
+    fireEvent.click(screen.getByRole('button', { name: 'Mount goodboy' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+
+    expect(screen.getByRole('button', { name: 'Mount goodboy' })).toBeTruthy();
+    expect(h.materializeProject).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/MountProjectList.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/MountProjectList.test.tsx
@@ -26,7 +26,7 @@ const h = vi.hoisted(() => ({
   materializeProject: vi.fn(async () => undefined),
   emitNotification: vi.fn(),
   preflight: {
-    status: 'ready',
+    status: 'ready' as 'ready' | 'checking',
     preflight: {
       mountId: 'mount-1',
       slug: 'ship-it',
@@ -63,6 +63,8 @@ beforeEach(() => {
   vi.clearAllMocks();
   h.preflight.preflight.renamedFrom = null;
   h.preflight.branchScanError = null;
+  h.preflight.status = 'ready';
+  h.materializeProject.mockResolvedValue(undefined);
 });
 
 afterEach(cleanup);
@@ -109,5 +111,42 @@ describe('MountProjectList', () => {
 
     expect(screen.getByRole('button', { name: 'Mount goodboy' })).toBeTruthy();
     expect(h.materializeProject).not.toHaveBeenCalled();
+  });
+  it('names what is running while the branches are read and while it creates', async () => {
+    h.preflight.status = 'checking';
+    renderList();
+    fireEvent.click(screen.getByRole('button', { name: 'Mount goodboy' }));
+
+    expect(screen.getByText('Reading the branches already in the repository…')).toBeTruthy();
+
+    h.preflight.status = 'ready';
+    const deferred: { resolve: () => void } = { resolve: () => undefined };
+    h.materializeProject.mockReturnValueOnce(
+      new Promise<undefined>((resolve) => {
+        deferred.resolve = () => resolve(undefined);
+      }),
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Add project' }));
+
+    await waitFor(() => expect(screen.getByText('Creating the worktree…')).toBeTruthy());
+    deferred.resolve();
+  });
+
+  it('shows the cause, the technical detail and a retry after a failure', async () => {
+    h.materializeProject.mockRejectedValueOnce(
+      new Error('cannot find base ref: tried origin/main'),
+    );
+    renderList();
+    fireEvent.click(screen.getByRole('button', { name: 'Mount goodboy' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Add project' }));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toContain('cannot find base ref: tried origin/main');
+    expect(screen.getByText('Technical detail')).toBeTruthy();
+    expect(alert.parentElement?.textContent).toContain('path: /repos/goodboy');
+
+    const retry = screen.getByRole('button', { name: 'Try again' });
+    fireEvent.click(retry);
+    await waitFor(() => expect(h.materializeProject).toHaveBeenCalledTimes(2));
   });
 });

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/MountProjectList.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/MountProjectList.tsx
@@ -3,6 +3,8 @@ import { ScrollFade, cn, formatError } from '@goodboy/ui';
 import type { Project, SessionId } from '@goodboy/types';
 import { useAppStore } from '../../../../../store';
 import { ICON_SIZE, projectGlyph } from '../../../../../shared/components/conceptIcons';
+import { MountPreflightCard } from './MountPreflightCard';
+import { useMountPreflight } from './useMountPreflight';
 
 const MANUAL_REASON = 'added manually by the user';
 const SEARCH_THRESHOLD = 8;
@@ -13,27 +15,32 @@ type Props = {
   readonly onDone: () => void;
 };
 
-type MountParams = {
-  readonly project: Project;
-};
-
 export const MountProjectList = ({ sessionId, projects, onDone }: Props) => {
   const materializeProject = useAppStore((state) => state.materializeProject);
   const emitNotification = useAppStore((state) => state.emitNotification);
   const [query, setQuery] = useState('');
-  const [mountingProjectId, setMountingProjectId] = useState<Project['id'] | null>(null);
-  const isBusy = mountingProjectId !== null;
+  const [selectedProjectId, setSelectedProjectId] = useState<Project['id'] | null>(null);
+  const [isMounting, setIsMounting] = useState(false);
   const isSearchable = projects.length > SEARCH_THRESHOLD;
   const filtered = useMemo(
     () => projects.filter((project) => project.name.toLowerCase().includes(query.toLowerCase())),
     [projects, query],
   );
+  const selectedProject = projects.find((project) => project.id === selectedProjectId) ?? null;
+  const preflightState = useMountPreflight({ sessionId, project: selectedProject });
 
-  const mountProject = async ({ project }: MountParams) => {
-    setMountingProjectId(project.id);
+  const mountProject = async ({ project }: { readonly project: Project }) => {
+    const { preflight } = preflightState;
+    setIsMounting(true);
     try {
-      await materializeProject({ sessionId, projectId: project.id, reason: MANUAL_REASON });
+      await materializeProject({
+        sessionId,
+        projectId: project.id,
+        reason: MANUAL_REASON,
+        ...(preflight === null ? {} : { mountId: preflight.mountId, slug: preflight.slug }),
+      });
       setQuery('');
+      setSelectedProjectId(null);
       onDone();
     } catch (error) {
       void emitNotification('error', 'warning', 'could not add the project', formatError(error), {
@@ -41,9 +48,21 @@ export const MountProjectList = ({ sessionId, projects, onDone }: Props) => {
         workspaceId: project.workspaceId,
       });
     } finally {
-      setMountingProjectId(null);
+      setIsMounting(false);
     }
   };
+
+  if (selectedProject !== null) {
+    return (
+      <MountPreflightCard
+        project={selectedProject}
+        state={preflightState}
+        isBusy={isMounting}
+        onConfirm={() => void mountProject({ project: selectedProject })}
+        onCancel={() => setSelectedProjectId(null)}
+      />
+    );
+  }
 
   return (
     <div className="flex flex-col">
@@ -65,19 +84,14 @@ export const MountProjectList = ({ sessionId, projects, onDone }: Props) => {
           <ul>
             {filtered.map((project) => {
               const GlyphIcon = projectGlyph({ kind: project.kind });
-              const isMounting = mountingProjectId === project.id;
               return (
                 <li key={project.id}>
                   <button
                     type="button"
-                    disabled={isBusy}
                     aria-label={`Mount ${project.name}`}
-                    aria-busy={isMounting}
-                    onClick={() => void mountProject({ project })}
+                    onClick={() => setSelectedProjectId(project.id)}
                     className={cn(
                       'flex w-full items-center gap-2 rounded-md px-3 py-1.5 text-left text-sm text-foreground motion-safe:transition-colors hover:bg-muted/40',
-                      isBusy && !isMounting && 'pointer-events-none opacity-50',
-                      isMounting && 'spin-border spin-border-info',
                     )}
                   >
                     <GlyphIcon

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/MountProjectList.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/MountProjectList.tsx
@@ -4,6 +4,7 @@ import type { Project, SessionId } from '@goodboy/types';
 import { useAppStore } from '../../../../../store';
 import { ICON_SIZE, projectGlyph } from '../../../../../shared/components/conceptIcons';
 import { MountPreflightCard } from './MountPreflightCard';
+import { mountFailure, type MountFailure } from './mountFailure';
 import { useMountPreflight } from './useMountPreflight';
 
 const MANUAL_REASON = 'added manually by the user';
@@ -21,6 +22,7 @@ export const MountProjectList = ({ sessionId, projects, onDone }: Props) => {
   const [query, setQuery] = useState('');
   const [selectedProjectId, setSelectedProjectId] = useState<Project['id'] | null>(null);
   const [isMounting, setIsMounting] = useState(false);
+  const [failure, setFailure] = useState<MountFailure | null>(null);
   const isSearchable = projects.length > SEARCH_THRESHOLD;
   const filtered = useMemo(
     () => projects.filter((project) => project.name.toLowerCase().includes(query.toLowerCase())),
@@ -32,6 +34,7 @@ export const MountProjectList = ({ sessionId, projects, onDone }: Props) => {
   const mountProject = async ({ project }: { readonly project: Project }) => {
     const { preflight } = preflightState;
     setIsMounting(true);
+    setFailure(null);
     try {
       await materializeProject({
         sessionId,
@@ -43,6 +46,7 @@ export const MountProjectList = ({ sessionId, projects, onDone }: Props) => {
       setSelectedProjectId(null);
       onDone();
     } catch (error) {
+      setFailure(mountFailure({ error, project, preflight }));
       void emitNotification('error', 'warning', 'could not add the project', formatError(error), {
         sessionId,
         workspaceId: project.workspaceId,
@@ -58,8 +62,12 @@ export const MountProjectList = ({ sessionId, projects, onDone }: Props) => {
         project={selectedProject}
         state={preflightState}
         isBusy={isMounting}
+        failure={failure}
         onConfirm={() => void mountProject({ project: selectedProject })}
-        onCancel={() => setSelectedProjectId(null)}
+        onCancel={() => {
+          setFailure(null);
+          setSelectedProjectId(null);
+        }}
       />
     );
   }
@@ -89,7 +97,10 @@ export const MountProjectList = ({ sessionId, projects, onDone }: Props) => {
                   <button
                     type="button"
                     aria-label={`Mount ${project.name}`}
-                    onClick={() => setSelectedProjectId(project.id)}
+                    onClick={() => {
+                      setFailure(null);
+                      setSelectedProjectId(project.id);
+                    }}
                     className={cn(
                       'flex w-full items-center gap-2 rounded-md px-3 py-1.5 text-left text-sm text-foreground motion-safe:transition-colors hover:bg-muted/40',
                     )}

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/mountFailure.test.ts
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/mountFailure.test.ts
@@ -50,6 +50,12 @@ describe('mountFailure', () => {
     expect(failure.detail).toContain('kind: branch_in_use');
   });
 
+  it('keeps a technical detail for an error json cannot serialize', () => {
+    const failure = mountFailure({ error: () => 'boom', project, preflight });
+
+    expect(failure.detail.split('\n').at(-1)).toContain('boom');
+  });
+
   it('survives a plan that never resolved', () => {
     const failure = mountFailure({ error: 'boom', project, preflight: null });
 

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/mountFailure.test.ts
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/mountFailure.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import type { Project, ProjectId, WorkspaceId } from '@goodboy/types';
+import { emptyOverrides } from '../../../../../store/storyHarness';
+import { mountFailure } from './mountFailure';
+import type { MountPreflight } from './useMountPreflight/resolveMountPreflight';
+
+const project = {
+  id: 'project-1' as ProjectId,
+  workspaceId: 'workspace-1' as WorkspaceId,
+  name: 'goodboy',
+  kind: 'repo',
+  rootPath: '/repos/goodboy',
+  baseBranch: 'main',
+  overrides: emptyOverrides,
+  createdAt: '2026-07-27T00:00:00.000Z',
+  updatedAt: '2026-07-27T00:00:00.000Z',
+} as unknown as Project;
+
+const preflight = {
+  mountId: 'mount-1',
+  slug: 'ship-it',
+  branch: 'ak/ship-it',
+  baseBranch: 'main',
+  targetPath: '/repos/goodboy/.goodboy/worktrees/ship-it-mount-1',
+  renamedFrom: null,
+} as unknown as MountPreflight;
+
+describe('mountFailure', () => {
+  it('keeps the message as the cause and the plan as the detail', () => {
+    const failure = mountFailure({
+      error: new Error('cannot find base ref: tried origin/main'),
+      project,
+      preflight,
+    });
+
+    expect(failure.cause).toBe('cannot find base ref: tried origin/main');
+    expect(failure.detail).toContain('branch: ak/ship-it');
+    expect(failure.detail).toContain('base: main');
+    expect(failure.detail).toContain('path: /repos/goodboy/.goodboy/worktrees/ship-it-mount-1');
+  });
+
+  it('records the tauri error kind when the backend sends one', () => {
+    const failure = mountFailure({
+      error: { kind: 'branch_in_use', message: 'branch is checked out elsewhere' },
+      project,
+      preflight,
+    });
+
+    expect(failure.cause).toBe('branch is checked out elsewhere');
+    expect(failure.detail).toContain('kind: branch_in_use');
+  });
+
+  it('survives a plan that never resolved', () => {
+    const failure = mountFailure({ error: 'boom', project, preflight: null });
+
+    expect(failure.cause).toBe('boom');
+    expect(failure.detail).toContain('project: goodboy (/repos/goodboy)');
+    expect(failure.detail).not.toContain('branch:');
+  });
+});

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/mountFailure.ts
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/mountFailure.ts
@@ -1,0 +1,39 @@
+import { formatError } from '@goodboy/ui';
+import type { Project } from '@goodboy/types';
+import { worktreeErrorKind } from '../../../../../store/slices/project-mounts/mountErrors';
+import type { MountPreflight } from './useMountPreflight/resolveMountPreflight';
+
+export type MountFailure = {
+  readonly cause: string;
+  readonly detail: string;
+};
+
+type Params = {
+  readonly error: unknown;
+  readonly project: Project;
+  readonly preflight: MountPreflight | null;
+};
+
+const rawError = ({ error }: { readonly error: unknown }): string => {
+  if (error instanceof Error && error.stack != null) {
+    return error.stack;
+  }
+  try {
+    return JSON.stringify(error, null, 2);
+  } catch {
+    return String(error);
+  }
+};
+
+export const mountFailure = ({ error, project, preflight }: Params): MountFailure => {
+  const kind = worktreeErrorKind({ error });
+  const lines = [
+    `project: ${project.name} (${project.rootPath})`,
+    ...(preflight?.branch == null ? [] : [`branch: ${preflight.branch}`]),
+    ...(preflight?.baseBranch == null ? [] : [`base: ${preflight.baseBranch}`]),
+    ...(preflight == null ? [] : [`path: ${preflight.targetPath}`]),
+    ...(kind === null ? [] : [`kind: ${kind}`]),
+    rawError({ error }),
+  ];
+  return { cause: formatError(error), detail: lines.join('\n') };
+};

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/mountFailure.ts
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/mountFailure.ts
@@ -19,7 +19,7 @@ const rawError = ({ error }: { readonly error: unknown }): string => {
     return error.stack;
   }
   try {
-    return JSON.stringify(error, null, 2);
+    return JSON.stringify(error, null, 2) ?? String(error);
   } catch {
     return String(error);
   }

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/useMountPreflight/index.test.ts
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/useMountPreflight/index.test.ts
@@ -1,0 +1,180 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, renderHook, waitFor } from '@testing-library/react';
+import type {
+  IsoDateTime,
+  MountId,
+  Project,
+  ProjectId,
+  Session,
+  SessionId,
+  WorkspaceId,
+} from '@goodboy/types';
+import { DEFAULT_BRANCH_PREFIX } from '../../../../../settings/settings';
+import { emptyOverrides } from '../../../../../../store/storyHarness';
+import type { MountPlan } from '../../../../../../store/slices/sessions/mountPlan';
+
+const NOW = '2026-07-27T00:00:00.000Z' as IsoDateTime;
+const SID = 'ab12cd34-ef56-7890' as SessionId;
+const PID = 'project-1' as ProjectId;
+const WID = 'workspace-1' as WorkspaceId;
+const MID = 'mount-1' as MountId;
+
+const repoProject = {
+  id: PID,
+  workspaceId: WID,
+  name: 'goodboy',
+  kind: 'repo',
+  rootPath: '/repos/goodboy',
+  baseBranch: 'main',
+  overrides: emptyOverrides,
+  createdAt: NOW,
+  updatedAt: NOW,
+} satisfies Project;
+
+const session = {
+  id: SID,
+  workspaceId: WID,
+  goal: 'Ship the rebase row',
+  state: { kind: 'idle', lastActivityAt: NOW },
+  contextSlots: [],
+  providerPreference: { defaultProvider: 'anthropic', allowTurnOverride: true },
+  permissionMode: 'default',
+  workflowRuns: [],
+  autoRun: false,
+  titleUserEdited: false,
+  createdAt: NOW,
+  updatedAt: NOW,
+} satisfies Session;
+
+const h = vi.hoisted(() => ({
+  listBranchNames: vi.fn<(params: { readonly repoPath: string }) => Promise<Array<string>>>(),
+  state: {} as Record<string, unknown>,
+}));
+
+vi.mock('../../../../../worktree/worktree', () => ({ listBranchNames: h.listBranchNames }));
+vi.mock('../../../../../../store', () => ({ useAppStore: { getState: () => h.state } }));
+
+import { useMountPreflight } from './index';
+import { resolveMountPreflight } from './resolveMountPreflight';
+
+const planFor = (overrides: Partial<MountPlan> = {}): MountPlan => ({
+  project: repoProject,
+  mountId: MID,
+  prefix: 'ak',
+  slug: 'ship-it',
+  branch: 'ak/ship-it',
+  adoptedBranch: null,
+  baseBranch: 'main',
+  targetPath: '/repos/goodboy/.goodboy/worktrees/ship-it-mount-1',
+  takenBranches: [],
+  ...overrides,
+});
+
+beforeEach(() => {
+  h.listBranchNames.mockReset();
+  h.state = {
+    sessions: [session],
+    archivedSessions: {},
+    projects: [repoProject],
+    workspaceOverrides: {},
+    sessionWorktreeRecords: {},
+    sessionProjectMounts: {},
+    sessionExternalTasks: {},
+  };
+});
+
+afterEach(cleanup);
+
+describe('resolveMountPreflight', () => {
+  it('keeps the proposed branch when nothing in the repository claims it', () => {
+    const resolved = resolveMountPreflight({ plan: planFor(), repoBranches: ['main', 'ak/other'] });
+
+    expect(resolved.branch).toBe('ak/ship-it');
+    expect(resolved.renamedFrom).toBeNull();
+    expect(resolved.targetPath).toBe('/repos/goodboy/.goodboy/worktrees/ship-it-mount-1');
+  });
+
+  it('proposes an alternative and a matching path when the branch already exists', () => {
+    const resolved = resolveMountPreflight({
+      plan: planFor(),
+      repoBranches: ['main', 'ak/ship-it'],
+    });
+
+    expect(resolved.renamedFrom).toBe('ak/ship-it');
+    expect(resolved.branch).toBe('ak/ship-it-2');
+    expect(resolved.slug).toBe('ship-it-2');
+    expect(resolved.targetPath).toBe('/repos/goodboy/.goodboy/worktrees/ship-it-2-mount-1');
+  });
+
+  it('never renames a branch the session is adopting on purpose', () => {
+    const resolved = resolveMountPreflight({
+      plan: planFor({ adoptedBranch: 'ak/existing' }),
+      repoBranches: ['ak/existing', 'ak/ship-it'],
+    });
+
+    expect(resolved.branch).toBe('ak/existing');
+    expect(resolved.renamedFrom).toBeNull();
+  });
+
+  it('leaves a folder project without a branch or a base', () => {
+    const resolved = resolveMountPreflight({
+      plan: planFor({ branch: null, baseBranch: null, targetPath: '/notes/sessions/ship-it' }),
+      repoBranches: ['main'],
+    });
+
+    expect(resolved.branch).toBeNull();
+    expect(resolved.baseBranch).toBeNull();
+    expect(resolved.renamedFrom).toBeNull();
+  });
+});
+
+describe('useMountPreflight', () => {
+  it('stays idle with no project selected', () => {
+    const { result } = renderHook(() => useMountPreflight({ sessionId: SID, project: null }));
+
+    expect(result.current.status).toBe('idle');
+    expect(result.current.preflight).toBeNull();
+    expect(h.listBranchNames).not.toHaveBeenCalled();
+  });
+
+  it('shows the plan while checking, then the repository verdict', async () => {
+    const derived = `${DEFAULT_BRANCH_PREFIX}/ship-the-rebase-row-ab12cd34`;
+    h.listBranchNames.mockResolvedValue(['main', derived]);
+    const { result } = renderHook(() =>
+      useMountPreflight({ sessionId: SID, project: repoProject }),
+    );
+
+    expect(result.current.status).toBe('checking');
+    expect(result.current.preflight?.branch).toBe(derived);
+
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+    expect(h.listBranchNames).toHaveBeenCalledWith({ repoPath: '/repos/goodboy' });
+    expect(result.current.preflight?.renamedFrom).toBe(derived);
+    expect(result.current.preflight?.branch).toBe(`${derived}-2`);
+  });
+
+  it('keeps the plan and reports the cause when the branch scan fails', async () => {
+    h.listBranchNames.mockRejectedValue(new Error('not a git repository'));
+    const { result } = renderHook(() =>
+      useMountPreflight({ sessionId: SID, project: repoProject }),
+    );
+
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+    expect(result.current.branchScanError).toContain('not a git repository');
+    expect(result.current.preflight?.branch).toBe(
+      `${DEFAULT_BRANCH_PREFIX}/ship-the-rebase-row-ab12cd34`,
+    );
+  });
+
+  it('skips the branch scan for a folder project', async () => {
+    const folder = { ...repoProject, kind: 'folder' } satisfies Project;
+    h.state = { ...h.state, projects: [folder] };
+    const { result } = renderHook(() => useMountPreflight({ sessionId: SID, project: folder }));
+
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+    expect(h.listBranchNames).not.toHaveBeenCalled();
+    expect(result.current.preflight?.branch).toBeNull();
+  });
+});

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/useMountPreflight/index.ts
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/useMountPreflight/index.ts
@@ -1,0 +1,86 @@
+import { useEffect, useState } from 'react';
+import { formatError } from '@goodboy/ui';
+import type { MountId, Project, SessionId } from '@goodboy/types';
+import { listBranchNames } from '../../../../../worktree/worktree';
+import { useAppStore } from '../../../../../../store';
+import { mountPlan } from '../../../../../../store/slices/sessions/mountPlan';
+import { resolveMountPreflight, type MountPreflight } from './resolveMountPreflight';
+
+export type MountPreflightState = {
+  readonly status: 'idle' | 'checking' | 'ready';
+  readonly preflight: MountPreflight | null;
+  readonly branchScanError: string | null;
+};
+
+type Params = {
+  readonly sessionId: SessionId;
+  readonly project: Project | null;
+};
+
+const IDLE = {
+  status: 'idle',
+  preflight: null,
+  branchScanError: null,
+} satisfies MountPreflightState;
+
+export const useMountPreflight = ({ sessionId, project }: Params): MountPreflightState => {
+  const [state, setState] = useState<MountPreflightState>(IDLE);
+  const projectId = project?.id ?? null;
+
+  useEffect(() => {
+    if (project === null || projectId === null) {
+      setState(IDLE);
+      return;
+    }
+    let isCurrent = true;
+    const plan = mountPlan({
+      state: useAppStore.getState(),
+      sessionId,
+      projectId,
+      mountId: crypto.randomUUID() as MountId,
+    });
+    if (plan === null) {
+      setState(IDLE);
+      return;
+    }
+    if (project.kind !== 'repo') {
+      setState({
+        status: 'ready',
+        preflight: resolveMountPreflight({ plan, repoBranches: [] }),
+        branchScanError: null,
+      });
+      return;
+    }
+    setState({
+      status: 'checking',
+      preflight: resolveMountPreflight({ plan, repoBranches: [] }),
+      branchScanError: null,
+    });
+    listBranchNames({ repoPath: project.rootPath })
+      .then((repoBranches) => {
+        if (!isCurrent) {
+          return;
+        }
+        setState({
+          status: 'ready',
+          preflight: resolveMountPreflight({ plan, repoBranches }),
+          branchScanError: null,
+        });
+      })
+      .catch((error: unknown) => {
+        if (!isCurrent) {
+          return;
+        }
+        setState({
+          status: 'ready',
+          preflight: resolveMountPreflight({ plan, repoBranches: [] }),
+          branchScanError: formatError(error),
+        });
+      });
+    return () => {
+      isCurrent = false;
+    };
+  }, [projectId, project, sessionId]);
+
+  return state;
+};

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/useMountPreflight/resolveMountPreflight.ts
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/useMountPreflight/resolveMountPreflight.ts
@@ -1,0 +1,48 @@
+import type { MountId } from '@goodboy/types';
+import { mountDirName } from '../../../../../../store/slices/project-mounts/mountDirName';
+import { nextAvailableSlug } from '../../../../../../store/slices/sessions/deriveBranchName';
+import type { MountPlan } from '../../../../../../store/slices/sessions/mountPlan';
+
+export type MountPreflight = {
+  readonly mountId: MountId;
+  readonly slug: string;
+  readonly branch: string | null;
+  readonly baseBranch: string | null;
+  readonly targetPath: string;
+  readonly renamedFrom: string | null;
+};
+
+type Params = {
+  readonly plan: MountPlan;
+  readonly repoBranches: ReadonlyArray<string>;
+};
+
+export const resolveMountPreflight = ({ plan, repoBranches }: Params): MountPreflight => {
+  const proposed = {
+    mountId: plan.mountId,
+    slug: plan.slug,
+    branch: plan.adoptedBranch ?? plan.branch,
+    baseBranch: plan.baseBranch,
+    targetPath: plan.targetPath,
+    renamedFrom: null,
+  } satisfies MountPreflight;
+  if (plan.branch === null || plan.adoptedBranch !== null) {
+    return proposed;
+  }
+  const taken = [...plan.takenBranches, ...repoBranches];
+  if (!taken.includes(plan.branch)) {
+    return proposed;
+  }
+  const slug = nextAvailableSlug({ base: plan.slug, prefix: plan.prefix, taken });
+  return {
+    mountId: plan.mountId,
+    slug,
+    branch: `${plan.prefix}/${slug}`,
+    baseBranch: plan.baseBranch,
+    targetPath: `${plan.project.rootPath}/.goodboy/worktrees/${mountDirName({
+      sessionSlug: slug,
+      mountId: plan.mountId,
+    })}`,
+    renamedFrom: plan.branch,
+  };
+};

--- a/apps/desktop/src/features/session/components/WorkflowBuilderView/index.test.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowBuilderView/index.test.tsx
@@ -493,6 +493,37 @@ describe('WorkflowBuilderView (orchestrated mode)', () => {
     );
   });
 
+  it('keeps the reason visible whenever start is disabled', () => {
+    render(<WorkflowBuilderView session={session} onClose={vi.fn()} />);
+
+    const start = startBtn();
+    expect(start.hasAttribute('disabled')).toBe(true);
+    const described = start.getAttribute('aria-describedby');
+    expect(described).not.toBeNull();
+    expect(document.getElementById(described ?? '')?.textContent).toBe('Set a goal to start');
+
+    setGoal();
+    const afterGoal = startBtn().getAttribute('aria-describedby');
+    expect(afterGoal).not.toBeNull();
+    expect(document.getElementById(afterGoal ?? '')?.textContent).toMatch(/ to start$/);
+  });
+
+  it('says why an unparsable spend limit blocks start instead of going mute', () => {
+    render(<WorkflowBuilderView session={session} onClose={vi.fn()} />);
+    setGoal();
+    fireEvent.click(screen.getByRole('tab', { name: /orchestrated/i }));
+    fireEvent.change(screen.getByPlaceholderText(/describe the intent/i), {
+      target: { value: 'Inspect each result and stop after tests pass.' },
+    });
+    fireEvent.click(screen.getByRole('switch', { name: /spend limit/i }));
+    fireEvent.change(screen.getByLabelText('Spend limit in dollars'), {
+      target: { value: 'not a number' },
+    });
+
+    expect(startBtn().hasAttribute('disabled')).toBe(true);
+    expect(screen.getByText('Enter a valid spend limit to start')).toBeDefined();
+  });
+
   it('keeps spend limit collapsed until enabled and reveals the outcome after an amount', async () => {
     render(<WorkflowBuilderView session={session} onClose={vi.fn()} />);
     setGoal();

--- a/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
@@ -62,6 +62,7 @@ import type {
 } from '@goodboy/types';
 import { EMPTY_ARRAY, useAppStore, useCurrentWorkspace, useSessionSlots } from '../../../../store';
 import { buildProfileGuard } from '../../../../store/profileGuard';
+import { workflowStartGate } from './workflowStartGate';
 import type { Mode, WorkflowBuilderDraft } from '../../../../store/slices/workflowDrafts/types';
 import type { StepDraft, WorkflowDraft } from '../../../workflows/engine';
 import {
@@ -99,6 +100,8 @@ import { LaunchToggleRow } from './parts/LaunchToggleRow';
 import { ApproachSummary } from './ApproachSummary';
 import { DynamicWorkflowComposer } from './DynamicWorkflowComposer';
 import { SpendLimitDisclosure } from './SpendLimitDisclosure';
+
+const START_REASON_ID = 'workflow-start-reason';
 
 type Props = {
   readonly session: Session;
@@ -852,19 +855,15 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
   const spendLimitInvalid =
     mode === 'dynamic' && isSpendLimitEnabled && parseSpendLimit(spendLimitDraft) == null;
   const dynamicNameMissing = mode === 'dynamic' && dynamicName.trim().length === 0;
-  const startDisabled =
-    blocked || goalMissing || approachMissing || spendLimitInvalid || dynamicNameMissing;
-  const startHint = goalMissing
-    ? 'Set a goal to start'
-    : approachMissing
-      ? mode === 'preset'
-        ? 'Select a preset to start'
-        : mode === 'dynamic'
-          ? 'Describe the intent and constraints to start'
-          : 'Generate a plan to start'
-      : dynamicNameMissing
-        ? 'Name the workflow to start'
-        : null;
+  const startGate = workflowStartGate({
+    mode,
+    isStarting: busy,
+    isPlanning: planning,
+    hasGoal: !goalMissing,
+    hasApproach: !approachMissing,
+    hasName: !dynamicNameMissing,
+    isSpendLimitValid: !spendLimitInvalid,
+  });
   const onModeChange = (next: Mode) => {
     setMode(next);
   };
@@ -1527,36 +1526,42 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
                 PANE_RHYTHM.dock,
               )}
             >
-              <div className="flex min-w-0 items-center gap-2">
-                {!draftEmpty ? (
-                  <Button
-                    variant="ghost"
-                    size="md"
-                    onClick={resetDraft}
-                    disabled={busy}
-                    aria-label="Discard workflow draft"
-                    className="gap-1.5 text-muted-foreground"
-                  >
-                    <RotateCcw size={ICON_SIZE.control} aria-hidden />
-                    Discard changes
-                  </Button>
-                ) : null}
-                {error ? (
-                  <span
-                    role="alert"
-                    className="inline-flex min-w-0 items-center gap-1 truncate text-xs text-danger"
-                  >
-                    <AlertTriangle size={ICON_SIZE.row} className="shrink-0" aria-hidden />
-                    {error}
+              <div className="flex min-w-0 flex-col gap-1">
+                <div className="flex min-w-0 items-center gap-2">
+                  {!draftEmpty ? (
+                    <Button
+                      variant="ghost"
+                      size="md"
+                      onClick={resetDraft}
+                      disabled={busy}
+                      aria-label="Discard workflow draft"
+                      className="gap-1.5 text-muted-foreground"
+                    >
+                      <RotateCcw size={ICON_SIZE.control} aria-hidden />
+                      Discard changes
+                    </Button>
+                  ) : null}
+                  {error ? (
+                    <span
+                      role="alert"
+                      className="inline-flex min-w-0 items-start gap-1 text-xs text-danger"
+                    >
+                      <AlertTriangle size={ICON_SIZE.row} className="mt-0.5 shrink-0" aria-hidden />
+                      {error}
+                    </span>
+                  ) : null}
+                </div>
+                {startGate.reason === null ? null : (
+                  <span id={START_REASON_ID} className="text-2xs text-muted-foreground">
+                    {startGate.reason}
                   </span>
-                ) : startHint ? (
-                  <span className="truncate text-2xs text-muted-foreground/60">{startHint}</span>
-                ) : null}
+                )}
               </div>
               <Button
                 size="md"
                 onClick={() => void onStart()}
-                disabled={startDisabled}
+                disabled={startGate.isDisabled}
+                {...(startGate.reason === null ? {} : { 'aria-describedby': START_REASON_ID })}
                 className={cn('shrink-0', busy && 'animate-border-pulse')}
               >
                 {busy ? 'Starting…' : 'Start workflow'}

--- a/apps/desktop/src/features/session/components/WorkflowBuilderView/workflowStartGate.test.ts
+++ b/apps/desktop/src/features/session/components/WorkflowBuilderView/workflowStartGate.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { workflowStartGate } from './workflowStartGate';
+
+const ready = {
+  mode: 'preset',
+  isStarting: false,
+  isPlanning: false,
+  hasGoal: true,
+  hasApproach: true,
+  hasName: true,
+  isSpendLimitValid: true,
+} as const;
+
+describe('workflowStartGate', () => {
+  it('enables start with no reason left to show', () => {
+    expect(workflowStartGate(ready)).toEqual({ isDisabled: false, reason: null });
+  });
+
+  it('names the reason for every blocker, never leaving start mute', () => {
+    const blockers = [
+      { ...ready, isStarting: true },
+      { ...ready, isPlanning: true },
+      { ...ready, hasGoal: false },
+      { ...ready, hasApproach: false },
+      { ...ready, hasName: false },
+      { ...ready, isSpendLimitValid: false },
+    ];
+
+    for (const params of blockers) {
+      const gate = workflowStartGate(params);
+      expect(gate.isDisabled).toBe(true);
+      expect(gate.reason).not.toBeNull();
+    }
+  });
+
+  it('speaks the approach language of the selected mode', () => {
+    expect(workflowStartGate({ ...ready, mode: 'preset', hasApproach: false }).reason).toBe(
+      'Select a preset to start',
+    );
+    expect(workflowStartGate({ ...ready, mode: 'custom', hasApproach: false }).reason).toBe(
+      'Generate a plan to start',
+    );
+    expect(workflowStartGate({ ...ready, mode: 'dynamic', hasApproach: false }).reason).toBe(
+      'Describe the intent and constraints to start',
+    );
+  });
+
+  it('keeps an invalid spend limit from starting a run in silence', () => {
+    expect(workflowStartGate({ ...ready, mode: 'dynamic', isSpendLimitValid: false })).toEqual({
+      isDisabled: true,
+      reason: 'Enter a valid spend limit to start',
+    });
+  });
+
+  it('puts work in flight ahead of the fields still to fill', () => {
+    expect(workflowStartGate({ ...ready, isStarting: true, hasGoal: false }).reason).toBe(
+      'This workflow is already starting',
+    );
+  });
+});

--- a/apps/desktop/src/features/session/components/WorkflowBuilderView/workflowStartGate.ts
+++ b/apps/desktop/src/features/session/components/WorkflowBuilderView/workflowStartGate.ts
@@ -1,0 +1,52 @@
+import type { Mode } from '../../../../store/slices/workflowDrafts/types';
+
+export type WorkflowStartGate = {
+  readonly isDisabled: boolean;
+  readonly reason: string | null;
+};
+
+type Params = {
+  readonly mode: Mode;
+  readonly isStarting: boolean;
+  readonly isPlanning: boolean;
+  readonly hasGoal: boolean;
+  readonly hasApproach: boolean;
+  readonly hasName: boolean;
+  readonly isSpendLimitValid: boolean;
+};
+
+const APPROACH_REASON: Record<Mode, string> = {
+  preset: 'Select a preset to start',
+  custom: 'Generate a plan to start',
+  dynamic: 'Describe the intent and constraints to start',
+};
+
+export const workflowStartGate = ({
+  mode,
+  isStarting,
+  isPlanning,
+  hasGoal,
+  hasApproach,
+  hasName,
+  isSpendLimitValid,
+}: Params): WorkflowStartGate => {
+  if (isStarting) {
+    return { isDisabled: true, reason: 'This workflow is already starting' };
+  }
+  if (isPlanning) {
+    return { isDisabled: true, reason: 'Wait for the plan to come back to start' };
+  }
+  if (!hasGoal) {
+    return { isDisabled: true, reason: 'Set a goal to start' };
+  }
+  if (!hasApproach) {
+    return { isDisabled: true, reason: APPROACH_REASON[mode] };
+  }
+  if (!hasName) {
+    return { isDisabled: true, reason: 'Name the workflow to start' };
+  }
+  if (!isSpendLimitValid) {
+    return { isDisabled: true, reason: 'Enter a valid spend limit to start' };
+  }
+  return { isDisabled: false, reason: null };
+};

--- a/apps/desktop/src/store/slices/github/createPrForSession.test.ts
+++ b/apps/desktop/src/store/slices/github/createPrForSession.test.ts
@@ -259,6 +259,23 @@ describe('createPrForSession, issue references', () => {
     });
   });
 
+  it('names the cause when the reference patch fails instead of dropping it', async () => {
+    const created = { number: 7, body: 'Generated from the commits.' } as PullRequestState;
+    const state = buildState({
+      sessionExternalTasks: { [SESSION_ID]: [githubIssue()] },
+      mountGithub: { [MOUNT_ID]: { pr: created } },
+    });
+    state.editPr.mockRejectedValueOnce(new Error('gh: pull request is locked'));
+
+    await buildCreate(state)({ sessionId: SESSION_ID });
+
+    const warning = state.emitNotification.mock.calls.find(
+      (call: ReadonlyArray<unknown>) => call[2] === 'PR opened without its issue links',
+    );
+    expect(warning?.[3]).toContain('Closes #41');
+    expect(warning?.[3]).toContain('gh: pull request is locked');
+  });
+
   it('does not patch a filled body that already closes the issue', async () => {
     const created = { number: 7, body: 'fix #41' } as PullRequestState;
     const state = buildState({

--- a/apps/desktop/src/store/slices/github/createPrForSession.ts
+++ b/apps/desktop/src/store/slices/github/createPrForSession.ts
@@ -1,4 +1,5 @@
 import { detectRepoSlug } from '@goodboy/core';
+import { formatError } from '@goodboy/ui';
 import { findPrSeriesMembership, upsertMountPullRequestLink } from '@goodboy/db';
 import type {
   IsoDateTime,
@@ -219,7 +220,17 @@ export const createPrForSession = (_set: SetFn, get: GetFn) => {
           .editPr(sessionId, created.number, {
             body: appendClosingReferences({ body: created.body, references: filledReferences }),
           })
-          .catch(() => undefined);
+          .catch((error: unknown) => {
+            void get().emitNotification(
+              'error',
+              'warning',
+              'PR opened without its issue links',
+              `${filledReferences
+                .map((reference) => reference.line)
+                .join(', ')} could not be appended to the description: ${formatError(error)}`,
+              { sessionId, workspaceId: workspace.id },
+            );
+          });
       }
     }
     void get().emitNotification(

--- a/apps/desktop/src/store/slices/project-mounts/mountDirName.test.ts
+++ b/apps/desktop/src/store/slices/project-mounts/mountDirName.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import type { MountId } from '@goodboy/types';
+import { mountDirName } from './mountDirName';
+import { sanitizeSlug } from './sanitizeSlug';
+
+const MID = '9f1c2d3e-4a5b-6c7d-8e9f-0a1b2c3d4e5f' as MountId;
+
+describe('mountDirName', () => {
+  it('keeps a slash out of the directory name', () => {
+    expect(mountDirName({ sessionSlug: 'alice/fix-parser', mountId: MID })).toBe(
+      `alice-fix-p-${MID}`,
+    );
+  });
+
+  it('returns a name the backend sanitizer leaves untouched', () => {
+    const name = mountDirName({ sessionSlug: 'Alice/Fix   Parser', mountId: MID });
+
+    expect(sanitizeSlug(name)).toBe(name);
+  });
+
+  it('falls back to the mount id when the slug has nothing usable', () => {
+    expect(mountDirName({ sessionSlug: '***', mountId: MID })).toBe(MID);
+  });
+
+  it('stays within the backend directory-name budget', () => {
+    const name = mountDirName({ sessionSlug: 'a'.repeat(80), mountId: MID });
+
+    expect(name.length).toBeLessThanOrEqual(48);
+  });
+});

--- a/apps/desktop/src/store/slices/project-mounts/mountDirName.ts
+++ b/apps/desktop/src/store/slices/project-mounts/mountDirName.ts
@@ -1,4 +1,5 @@
 import type { MountId } from '@goodboy/types';
+import { sanitizeSlug } from './sanitizeSlug';
 
 const MAX_DIR_NAME_LENGTH = 48;
 
@@ -8,13 +9,14 @@ type Params = {
 };
 
 export const mountDirName = ({ sessionSlug, mountId }: Params): string => {
-  const budget = MAX_DIR_NAME_LENGTH - mountId.length - 1;
-  if (budget <= 0) {
-    return mountId;
-  }
-  const head = sessionSlug.slice(0, budget).replace(/-+$/g, '');
+  const id = sanitizeSlug(mountId);
+  const budget = MAX_DIR_NAME_LENGTH - id.length - 1;
+  const head = budget <= 0 ? '' : sanitizeSlug(sessionSlug).slice(0, budget).replace(/-+$/g, '');
   if (head === '') {
-    return mountId;
+    return id;
   }
-  return `${head}-${mountId}`;
+  if (id === '') {
+    return head;
+  }
+  return `${head}-${id}`;
 };

--- a/apps/desktop/src/store/slices/project-mounts/sanitizeSlug.test.ts
+++ b/apps/desktop/src/store/slices/project-mounts/sanitizeSlug.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { sanitizeSlug } from './sanitizeSlug';
+
+describe('sanitizeSlug', () => {
+  it('mirrors the backend sanitizer on a branch-shaped slug', () => {
+    expect(sanitizeSlug('alice/fix-parser')).toBe('alice-fix-parser');
+  });
+
+  it('lowercases only ascii letters, the way the backend does', () => {
+    expect(sanitizeSlug('Fix-Parser')).toBe('fix-parser');
+    expect(sanitizeSlug('caffÈ')).toBe('caff');
+  });
+
+  it('collapses runs and drops edge dashes', () => {
+    expect(sanitizeSlug('  my   feature  ')).toBe('my-feature');
+  });
+
+  it('truncates at 48 characters, not 40', () => {
+    const raw = 'a'.repeat(60);
+
+    expect(sanitizeSlug(raw)).toHaveLength(48);
+  });
+
+  it('never leaves a trailing dash after truncation', () => {
+    const raw = `${'a'.repeat(47)}-tail`;
+
+    expect(sanitizeSlug(raw)).toBe('a'.repeat(47));
+  });
+
+  it('is idempotent, so a sanitized name survives a second pass', () => {
+    const once = sanitizeSlug('Alice/Fix   Parser/../weird');
+
+    expect(sanitizeSlug(once)).toBe(once);
+  });
+
+  it('returns an empty string when nothing survives', () => {
+    expect(sanitizeSlug('***')).toBe('');
+  });
+});

--- a/apps/desktop/src/store/slices/project-mounts/sanitizeSlug.ts
+++ b/apps/desktop/src/store/slices/project-mounts/sanitizeSlug.ts
@@ -1,0 +1,10 @@
+const MAX_SLUG_LENGTH = 48;
+
+export const sanitizeSlug = (raw: string): string =>
+  raw
+    .replace(/[A-Z]/g, (letter) => letter.toLowerCase())
+    .replace(/[^a-z0-9-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, MAX_SLUG_LENGTH)
+    .replace(/-+$/g, '');

--- a/apps/desktop/src/store/slices/sessions/index.test.ts
+++ b/apps/desktop/src/store/slices/sessions/index.test.ts
@@ -1552,7 +1552,7 @@ describe('store contract', () => {
       );
     });
 
-    it('keeps an explicit branch slug untouched', async () => {
+    it('sends an explicit branch slug already sanitized the way the backend would', async () => {
       const store = await getStore();
       store.setState({ currentWorkspaceId: WS_ID });
 
@@ -1564,11 +1564,11 @@ describe('store contract', () => {
       });
 
       expect(createWorktreeSpy).toHaveBeenCalledWith(
-        expect.objectContaining({ slug: 'Foreign_Feature/Exact' }),
+        expect.objectContaining({ slug: 'foreign-feature-exact' }),
       );
     });
 
-    it('pins a foreign prefix and verbatim slug for existing branch adoption', async () => {
+    it('pins a foreign prefix and keeps the adopted branch verbatim', async () => {
       const store = await getStore();
       store.setState({ currentWorkspaceId: WS_ID });
 
@@ -1582,10 +1582,27 @@ describe('store contract', () => {
       expect(createWorktreeSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           branchPrefix: 'alice',
-          slug: 'alice/fix-parser',
+          slug: 'alice-fix-parser',
           existingBranch: 'alice/fix-parser',
         }),
       );
+    });
+
+    it('never asks the backend for a nested worktree directory', async () => {
+      const store = await getStore();
+      store.setState({ currentWorkspaceId: WS_ID });
+
+      await store.getState().createSession({
+        workspaceId: WS_ID,
+        projectId: PROJECT_ID,
+        goal: 'Review parser fix',
+        existingBranch: 'alice/fix-parser',
+      });
+
+      const [args] = createWorktreeSpy.mock.calls[0] ?? [];
+
+      expect(args?.dirName).not.toContain('/');
+      expect(args?.dirName).toMatch(/^alice-fix-p-/);
     });
   });
 

--- a/apps/desktop/src/store/slices/sessions/materializeProject.test.ts
+++ b/apps/desktop/src/store/slices/sessions/materializeProject.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import type { MountId, ProjectId, SessionId } from '@goodboy/types';
+import type { AppStore } from '../../store';
+
+type StoreInput = Parameters<AppStore['materializeProject']>[0];
+
+describe('materializeProject store contract', () => {
+  it('accepts the planned mount id and slug the mount preflight passes', () => {
+    const input = {
+      sessionId: 'session-1' as SessionId,
+      projectId: 'project-1' as ProjectId,
+      reason: 'added manually by the user',
+      mountId: 'mount-1' as MountId,
+      slug: 'ship-it',
+    } satisfies StoreInput;
+
+    expect(input.slug).toBe('ship-it');
+  });
+});

--- a/apps/desktop/src/store/slices/sessions/materializeProject.ts
+++ b/apps/desktop/src/store/slices/sessions/materializeProject.ts
@@ -186,7 +186,10 @@ export const materializeProject = (set: SetFn, get: GetFn) => {
         kind: 'project_materialization_refused',
         payload: { projectId, projectName: project.name, reason: formatError(error) },
       });
-      const branchInUse = branchInUseError({ error });
+      const branchInUse = branchInUseError({
+        error,
+        branch: adoptedBranch ?? `${prefix}/${sessionSlug}`,
+      });
       if (branchInUse !== null) {
         throw branchInUse;
       }

--- a/apps/desktop/src/store/slices/sessions/materializeProject.ts
+++ b/apps/desktop/src/store/slices/sessions/materializeProject.ts
@@ -186,10 +186,7 @@ export const materializeProject = (set: SetFn, get: GetFn) => {
         kind: 'project_materialization_refused',
         payload: { projectId, projectName: project.name, reason: formatError(error) },
       });
-      const branchInUse = branchInUseError({
-        error,
-        branch: adoptedBranch ?? `${prefix}/${sessionSlug}`,
-      });
+      const branchInUse = branchInUseError({ error });
       if (branchInUse !== null) {
         throw branchInUse;
       }

--- a/apps/desktop/src/store/slices/sessions/materializeProject.ts
+++ b/apps/desktop/src/store/slices/sessions/materializeProject.ts
@@ -7,15 +7,14 @@ import {
   type SessionWorktree,
 } from '@goodboy/db';
 import { formatError } from '@goodboy/ui';
-import { detectRepoSlug, resolveSettings } from '@goodboy/core';
+import { detectRepoSlug } from '@goodboy/core';
 import { tauriDatabase } from '../../../shared/lib/db';
 import { tauriGhRunner } from '../../../features/github/github';
 import { createSessionDir, createWorktree } from '../../../features/worktree/worktree';
-import { DEFAULT_BRANCH_PREFIX } from '../../../features/settings/settings';
 import { consumeAdoptionSeed, materializationSeedFor } from './materializationSeeds';
 import { branchInUseError } from '../project-mounts/mountErrors';
 import { mountDirName } from '../project-mounts/mountDirName';
-import { deriveBranchName } from './deriveBranchName';
+import { mountPlan } from './mountPlan';
 import type { GetFn, SetFn } from './types';
 
 export type MaterializeProjectInput = {
@@ -23,6 +22,8 @@ export type MaterializeProjectInput = {
   readonly projectId: ProjectId;
   readonly reason: string;
   readonly taskIdentifiers?: ReadonlyArray<string>;
+  readonly mountId?: MountId;
+  readonly slug?: string;
 };
 
 type StampRepoSlugParams = {
@@ -82,6 +83,8 @@ export const materializeProject = (set: SetFn, get: GetFn) => {
     projectId,
     reason,
     taskIdentifiers,
+    mountId: plannedMountId,
+    slug: plannedSlug,
   }: MaterializeProjectInput): Promise<SessionProjectMount> => {
     const trimmedReason = reason.trim();
     if (trimmedReason === '') {
@@ -140,49 +143,22 @@ export const materializeProject = (set: SetFn, get: GetFn) => {
       return persistedMount;
     }
     const seed = materializationSeedFor({ sessionId });
-    const resolved = resolveSettings({
-      global: {
-        defaultProviderId: session.providerPreference.defaultProvider,
-        defaultWorkflowId: null,
-        defaultBranchPrefix: DEFAULT_BRANCH_PREFIX,
-        parallelEnabled: false,
-        defaultVerbosity: 'normal',
-      },
-      workspaceOverride: get().workspaceOverrides[session.workspaceId] ?? null,
-      projectOverride: project.overrides,
-    });
-    const prefix = seed?.branchPrefix ?? resolved.defaultBranchPrefix;
-    const liveSessionIds: ReadonlySet<string> = new Set(
-      get()
-        .sessions.filter(
-          (candidate) =>
-            candidate.workspaceId === session.workspaceId && candidate.id !== sessionId,
-        )
-        .map((candidate) => candidate.id),
-    );
-    const recordBranches = Object.entries(get().sessionWorktreeRecords ?? {}).flatMap(
-      ([candidateId, records]) =>
-        liveSessionIds.has(candidateId) ? records.map((record) => record.branch) : [],
-    );
-    const mountBranches = Object.entries(get().sessionProjectMounts).flatMap(
-      ([candidateId, mounts]) =>
-        liveSessionIds.has(candidateId) ? mounts.map((mount) => mount.branch) : [],
-    );
-    const storedIdentifiers = (get().sessionExternalTasks[sessionId] ?? []).map(
-      (task) => task.identifier,
-    );
-    const sessionSlug = deriveBranchName({
-      prefix,
+    const mountId = plannedMountId ?? (crypto.randomUUID() as MountId);
+    const plan = mountPlan({
+      state: get(),
       sessionId,
-      goal: session.goal,
-      ...(seed?.sessionSlug !== undefined ? { explicitSlug: seed.sessionSlug } : {}),
-      taskIdentifiers: storedIdentifiers.length > 0 ? storedIdentifiers : taskIdentifiers,
-      existingBranches: [...recordBranches, ...mountBranches],
+      projectId,
+      mountId,
+      ...(taskIdentifiers === undefined ? {} : { taskIdentifiers }),
     });
+    if (plan === null) {
+      throw new Error(`project not found in this workspace: ${projectId}`);
+    }
+    const prefix = plan.prefix;
+    const sessionSlug = plannedSlug ?? plan.slug;
     const hasRepoMount = rows.some((row) => row.projectId !== undefined && row.branch !== '');
     const adoptedBranch = hasRepoMount ? undefined : seed?.existingBranch;
     const adoptedFallbackRef = adoptedBranch === undefined ? undefined : seed?.fallbackRef;
-    const mountId = crypto.randomUUID() as MountId;
     let created;
     try {
       created =

--- a/apps/desktop/src/store/slices/sessions/mountPlan.test.ts
+++ b/apps/desktop/src/store/slices/sessions/mountPlan.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import type {
   IsoDateTime,
   MountId,
@@ -9,6 +9,7 @@ import type {
   WorkspaceId,
 } from '@goodboy/types';
 import { emptyOverrides } from '../../storyHarness';
+import { forgetMaterializationSeed, rememberMaterializationSeed } from './materializationSeeds';
 import { mountPlan, type MountPlanState } from './mountPlan';
 
 const NOW = '2026-07-27T00:00:00.000Z' as IsoDateTime;
@@ -57,6 +58,10 @@ const stateWith = (overrides: Partial<MountPlanState> = {}): MountPlanState =>
   }) as MountPlanState;
 
 describe('mountPlan', () => {
+  afterEach(() => {
+    forgetMaterializationSeed({ sessionId: SID });
+  });
+
   it('derives the branch, the base and the target path before anything is created', () => {
     const plan = mountPlan({ state: stateWith(), sessionId: SID, projectId: PID, mountId: MID });
 
@@ -97,6 +102,41 @@ describe('mountPlan', () => {
     });
 
     expect(plan?.takenBranches).toContain('ak/taken-branch');
+  });
+
+  it('keeps an adopted branch slug out of the worktree path', () => {
+    rememberMaterializationSeed({
+      sessionId: SID,
+      seed: { sessionSlug: 'alice/fix-parser', existingBranch: 'alice/fix-parser' },
+    });
+
+    const plan = mountPlan({ state: stateWith(), sessionId: SID, projectId: PID, mountId: MID });
+
+    expect(plan?.slug).toBe('alice-fix-parser');
+    expect(plan?.targetPath).toBe('/repos/goodboy/.goodboy/worktrees/alice-fix-parser-mount-1');
+  });
+
+  it('truncates a folder path at the backend budget, not at forty characters', () => {
+    const folder = { ...repoProject, kind: 'folder', rootPath: '/notes' } satisfies Project;
+    rememberMaterializationSeed({ sessionId: SID, seed: { sessionSlug: 'a'.repeat(45) } });
+
+    const plan = mountPlan({
+      state: stateWith({ projects: [folder] }),
+      sessionId: SID,
+      projectId: PID,
+      mountId: MID,
+    });
+
+    expect(plan?.targetPath).toBe(`/notes/sessions/${'a'.repeat(45)}`);
+  });
+
+  it('falls back to a session slug the backend would not rewrite', () => {
+    rememberMaterializationSeed({ sessionId: SID, seed: { sessionSlug: '***' } });
+
+    const plan = mountPlan({ state: stateWith(), sessionId: SID, projectId: PID, mountId: MID });
+
+    expect(plan?.slug).toBe('session-ab12cd34');
+    expect(plan?.targetPath).toBe('/repos/goodboy/.goodboy/worktrees/session-ab12cd34-mount-1');
   });
 
   it('returns null when the project does not belong to the session workspace', () => {

--- a/apps/desktop/src/store/slices/sessions/mountPlan.test.ts
+++ b/apps/desktop/src/store/slices/sessions/mountPlan.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  IsoDateTime,
+  MountId,
+  Project,
+  ProjectId,
+  Session,
+  SessionId,
+  WorkspaceId,
+} from '@goodboy/types';
+import { emptyOverrides } from '../../storyHarness';
+import { mountPlan, type MountPlanState } from './mountPlan';
+
+const NOW = '2026-07-27T00:00:00.000Z' as IsoDateTime;
+const SID = 'ab12cd34-ef56-7890' as SessionId;
+const PID = 'project-1' as ProjectId;
+const WID = 'workspace-1' as WorkspaceId;
+const MID = 'mount-1' as MountId;
+
+const session = {
+  id: SID,
+  workspaceId: WID,
+  goal: 'Ship the rebase row',
+  state: { kind: 'idle', lastActivityAt: NOW },
+  contextSlots: [],
+  providerPreference: { defaultProvider: 'anthropic', allowTurnOverride: true },
+  permissionMode: 'default',
+  workflowRuns: [],
+  autoRun: false,
+  titleUserEdited: false,
+  createdAt: NOW,
+  updatedAt: NOW,
+} satisfies Session;
+
+const repoProject = {
+  id: PID,
+  workspaceId: WID,
+  name: 'goodboy',
+  kind: 'repo',
+  rootPath: '/repos/goodboy',
+  baseBranch: 'main',
+  overrides: emptyOverrides,
+  createdAt: NOW,
+  updatedAt: NOW,
+} satisfies Project;
+
+const stateWith = (overrides: Partial<MountPlanState> = {}): MountPlanState =>
+  ({
+    sessions: [session],
+    archivedSessions: {},
+    projects: [repoProject],
+    workspaceOverrides: {},
+    sessionWorktreeRecords: {},
+    sessionProjectMounts: {},
+    sessionExternalTasks: {},
+    ...overrides,
+  }) as MountPlanState;
+
+describe('mountPlan', () => {
+  it('derives the branch, the base and the target path before anything is created', () => {
+    const plan = mountPlan({ state: stateWith(), sessionId: SID, projectId: PID, mountId: MID });
+
+    expect(plan?.baseBranch).toBe('main');
+    expect(plan?.branch).toBe(`${plan?.prefix}/${plan?.slug}`);
+    expect(plan?.slug).toBe('ship-the-rebase-row-ab12cd34');
+    expect(plan?.targetPath).toBe(
+      '/repos/goodboy/.goodboy/worktrees/ship-the-rebase-row-ab12cd34-mount-1',
+    );
+  });
+
+  it('leaves branch and base empty for a folder project and targets the sessions dir', () => {
+    const folder = { ...repoProject, kind: 'folder', rootPath: '/notes' } satisfies Project;
+    const plan = mountPlan({
+      state: stateWith({ projects: [folder] }),
+      sessionId: SID,
+      projectId: PID,
+      mountId: MID,
+    });
+
+    expect(plan?.branch).toBeNull();
+    expect(plan?.baseBranch).toBeNull();
+    expect(plan?.targetPath).toBe('/notes/sessions/ship-the-rebase-row-ab12cd34');
+  });
+
+  it('reports the branches already taken by other live sessions', () => {
+    const other = { ...session, id: 'session-other' as SessionId };
+    const plan = mountPlan({
+      state: stateWith({
+        sessions: [session, other],
+        sessionProjectMounts: {
+          'session-other': [{ branch: 'ak/taken-branch' }],
+        } as unknown as MountPlanState['sessionProjectMounts'],
+      }),
+      sessionId: SID,
+      projectId: PID,
+      mountId: MID,
+    });
+
+    expect(plan?.takenBranches).toContain('ak/taken-branch');
+  });
+
+  it('returns null when the project does not belong to the session workspace', () => {
+    const foreign = { ...repoProject, workspaceId: 'workspace-2' as WorkspaceId } satisfies Project;
+    expect(
+      mountPlan({
+        state: stateWith({ projects: [foreign] }),
+        sessionId: SID,
+        projectId: PID,
+        mountId: MID,
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/desktop/src/store/slices/sessions/mountPlan.ts
+++ b/apps/desktop/src/store/slices/sessions/mountPlan.ts
@@ -1,0 +1,126 @@
+import { resolveSettings } from '@goodboy/core';
+import type { MountId, Project, ProjectId, SessionId } from '@goodboy/types';
+import { DEFAULT_BRANCH_PREFIX } from '../../../features/settings/settings';
+import { mountDirName } from '../project-mounts/mountDirName';
+import { deriveBranchName } from './deriveBranchName';
+import { materializationSeedFor } from './materializationSeeds';
+import { slugifyDir } from './slugifyDir';
+import type { AppStore } from '../../store';
+
+export type MountPlanState = Pick<
+  AppStore,
+  | 'sessions'
+  | 'archivedSessions'
+  | 'projects'
+  | 'workspaceOverrides'
+  | 'sessionWorktreeRecords'
+  | 'sessionProjectMounts'
+  | 'sessionExternalTasks'
+>;
+
+export type MountPlan = {
+  readonly project: Project;
+  readonly mountId: MountId;
+  readonly prefix: string;
+  readonly slug: string;
+  readonly branch: string | null;
+  readonly adoptedBranch: string | null;
+  readonly baseBranch: string | null;
+  readonly targetPath: string;
+  readonly takenBranches: ReadonlyArray<string>;
+};
+
+type Params = {
+  readonly state: MountPlanState;
+  readonly sessionId: SessionId;
+  readonly projectId: ProjectId;
+  readonly mountId: MountId;
+  readonly taskIdentifiers?: ReadonlyArray<string>;
+};
+
+type PathParams = {
+  readonly project: Project;
+  readonly slug: string;
+  readonly mountId: MountId;
+  readonly folderName: string | undefined;
+};
+
+const targetPathFor = ({ project, slug, mountId, folderName }: PathParams): string => {
+  if (project.kind !== 'repo') {
+    return `${project.rootPath}/sessions/${folderName ?? slugifyDir(slug)}`;
+  }
+  return `${project.rootPath}/.goodboy/worktrees/${mountDirName({ sessionSlug: slug, mountId })}`;
+};
+
+export const mountPlan = ({
+  state,
+  sessionId,
+  projectId,
+  mountId,
+  taskIdentifiers,
+}: Params): MountPlan | null => {
+  const session =
+    state.sessions.find((candidate) => candidate.id === sessionId) ??
+    Object.values(state.archivedSessions)
+      .flat()
+      .find((candidate) => candidate.id === sessionId);
+  if (session === undefined) {
+    return null;
+  }
+  const project = state.projects.find((candidate) => candidate.id === projectId);
+  if (project === undefined || project.workspaceId !== session.workspaceId) {
+    return null;
+  }
+  const seed = materializationSeedFor({ sessionId });
+  const resolved = resolveSettings({
+    global: {
+      defaultProviderId: session.providerPreference.defaultProvider,
+      defaultWorkflowId: null,
+      defaultBranchPrefix: DEFAULT_BRANCH_PREFIX,
+      parallelEnabled: false,
+      defaultVerbosity: 'normal',
+    },
+    workspaceOverride: state.workspaceOverrides[session.workspaceId] ?? null,
+    projectOverride: project.overrides,
+  });
+  const prefix = seed?.branchPrefix ?? resolved.defaultBranchPrefix;
+  const liveSessionIds: ReadonlySet<string> = new Set(
+    state.sessions
+      .filter(
+        (candidate) => candidate.workspaceId === session.workspaceId && candidate.id !== sessionId,
+      )
+      .map((candidate) => candidate.id),
+  );
+  const recordBranches = Object.entries(state.sessionWorktreeRecords ?? {}).flatMap(
+    ([candidateId, records]) =>
+      liveSessionIds.has(candidateId) ? records.map((record) => record.branch) : [],
+  );
+  const mountBranches = Object.entries(state.sessionProjectMounts).flatMap(
+    ([candidateId, mounts]) =>
+      liveSessionIds.has(candidateId) ? mounts.map((mount) => mount.branch) : [],
+  );
+  const takenBranches = [...recordBranches, ...mountBranches].filter((branch) => branch !== '');
+  const storedIdentifiers = (state.sessionExternalTasks[sessionId] ?? []).map(
+    (task) => task.identifier,
+  );
+  const slug = deriveBranchName({
+    prefix,
+    sessionId,
+    goal: session.goal,
+    ...(seed?.sessionSlug !== undefined ? { explicitSlug: seed.sessionSlug } : {}),
+    taskIdentifiers: storedIdentifiers.length > 0 ? storedIdentifiers : taskIdentifiers,
+    existingBranches: takenBranches,
+  });
+  const adoptedBranch = seed?.existingBranch ?? null;
+  return {
+    project,
+    mountId,
+    prefix,
+    slug,
+    branch: project.kind === 'repo' ? `${prefix}/${slug}` : null,
+    adoptedBranch: project.kind === 'repo' ? adoptedBranch : null,
+    baseBranch: project.kind === 'repo' ? (project.baseBranch ?? null) : null,
+    targetPath: targetPathFor({ project, slug, mountId, folderName: seed?.folderName }),
+    takenBranches,
+  };
+};

--- a/apps/desktop/src/store/slices/sessions/mountPlan.ts
+++ b/apps/desktop/src/store/slices/sessions/mountPlan.ts
@@ -2,9 +2,9 @@ import { resolveSettings } from '@goodboy/core';
 import type { MountId, Project, ProjectId, SessionId } from '@goodboy/types';
 import { DEFAULT_BRANCH_PREFIX } from '../../../features/settings/settings';
 import { mountDirName } from '../project-mounts/mountDirName';
+import { sanitizeSlug } from '../project-mounts/sanitizeSlug';
 import { deriveBranchName } from './deriveBranchName';
 import { materializationSeedFor } from './materializationSeeds';
-import { slugifyDir } from './slugifyDir';
 import type { AppStore } from '../../store';
 
 export type MountPlanState = Pick<
@@ -47,7 +47,7 @@ type PathParams = {
 
 const targetPathFor = ({ project, slug, mountId, folderName }: PathParams): string => {
   if (project.kind !== 'repo') {
-    return `${project.rootPath}/sessions/${folderName ?? slugifyDir(slug)}`;
+    return `${project.rootPath}/sessions/${folderName ?? slug}`;
   }
   return `${project.rootPath}/.goodboy/worktrees/${mountDirName({ sessionSlug: slug, mountId })}`;
 };
@@ -103,7 +103,7 @@ export const mountPlan = ({
   const storedIdentifiers = (state.sessionExternalTasks[sessionId] ?? []).map(
     (task) => task.identifier,
   );
-  const slug = deriveBranchName({
+  const derivedSlug = deriveBranchName({
     prefix,
     sessionId,
     goal: session.goal,
@@ -111,6 +111,8 @@ export const mountPlan = ({
     taskIdentifiers: storedIdentifiers.length > 0 ? storedIdentifiers : taskIdentifiers,
     existingBranches: takenBranches,
   });
+  const sanitizedSlug = sanitizeSlug(derivedSlug);
+  const slug = sanitizedSlug === '' ? `session-${sessionId.slice(0, 8)}` : sanitizedSlug;
   const adoptedBranch = seed?.existingBranch ?? null;
   return {
     project,

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -191,6 +191,7 @@ import type {
   SetPrSeriesMemberInput,
 } from './slices/pr-series';
 import type { ArchiveTaskOptions } from './slices/sessions/types';
+import type { MaterializeProjectInput } from './slices/sessions/materializeProject';
 import type {
   CleanupSessionMountsInput,
   ProposeMountCleanupInput,
@@ -437,12 +438,7 @@ type AppActions = {
   }): Promise<{ session: Session }>;
   createUntitledSession(input: { workspaceId: WorkspaceId }): Promise<{ session: Session }>;
   clearPendingTitleFocus(): void;
-  materializeProject(input: {
-    sessionId: SessionId;
-    projectId: ProjectId;
-    reason: string;
-    taskIdentifiers?: ReadonlyArray<string>;
-  }): Promise<SessionProjectMount>;
+  materializeProject(input: MaterializeProjectInput): Promise<SessionProjectMount>;
   detachProject(input: DetachProjectInput): Promise<ReadonlyArray<DetachProjectOutcome>>;
   loadSessionMounts(input: SessionKeyInput): Promise<ReadonlyArray<SessionMountView>>;
   forkMount(input: ForkMountInput): Promise<SessionMountView>;


### PR DESCRIPTION
Cantiere c3 of the UX elevation plan: making the start of work predictable. Five interventions.

## The two agent forms now teach each other

`CreateAgentPopover` was a role grid, then provider, then always-expanded model axes, with no instructions field at all. `AgentSpawnConfig` was routing first, then a textarea labelled "Agent hint". Learning one taught you nothing about the other.

Both are now Role, then Instructions marked optional, then Routing collapsed behind a summary. The shared copy lives in one module so the two cannot drift again. The role row is read-only when the context already fixes it.

## Base, branch and path are shown before the worktree is created

Clicking a project mounted it instantly, and the branch name was derived inline inside `materializeProject` where no surface could read it. The derivation is now a module that both the preview and the creation call, so the plan you see is the plan that runs. On a branch-name collision the preflight proposes an alternative and recomputes the path to match. A branch the session is deliberately adopting is never renamed.

## A failed mount now says what actually failed first

`try_fetch_origin` was `let _ = git(...)`. Offline, or on a repo with no `origin`, you got `cannot find base ref: tried origin/main, main` and no hint that a failed fetch was the real first cause. The cause is now appended to the error on both the new-branch and existing-branch paths.

The card names the running phase while it waits, with no percentage and no ETA since neither is observable. A failure stays inline with the cause, an expandable technical detail and a retry.

`createPrForSession` had `.catch(() => undefined)` around `editPr`, silently dropping the reason closing references never landed. It now warns with the reference lines and the cause.

## Workflows keep their reason for not starting

Progressive disclosure was already there and was left alone. What was missing: `startHint` did not cover an unparsable spend limit or a plan still running, so start went dead with no explanation, and an error replaced the reason instead of sitting beside it. One gate module now owns every blocker with an explicit precedence, and the disabled button points at the reason with `aria-describedby`.

## A new script says where it will run

The plan claimed scripts were hard to reach from a session. They are not: there is a lens, a shortcut, a sidebar section, a mount row action and the `$` quick action, and the panel already had a scope selector and an explicit re-read. No entry points were manufactured.

The real gap was in the file the plan named: `NewScriptCard` hid the project row entirely on a single-project workspace, so a new script's scope was implicit. The row now always renders, read-only when the context imposes it, and names the target path, or says the project is not mounted in this session yet.

## Not done

The skills half of c3.7 is blocked on a product decision: `SkillsPanel` renders only inside Settings, gated on `WORKSPACE_FEATURES.skills`, hardcoded `false`. The flag is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
