### PR TITLE
feat(desktop): show the state of every worktree under its project

### DIFF
--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/MountChangeCell.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/MountChangeCell.tsx
@@ -1,0 +1,64 @@
+import { Tooltip, cn } from '@goodboy/ui';
+import type { SessionId } from '@goodboy/types';
+import type { MountDiffStat } from '../../../../../store';
+import { useAppStore } from '../../../../../store';
+import { CONCEPT_ICONS, ICON_SIZE } from '../../../../../shared/components/conceptIcons';
+import { DiffStat } from '../../DiffStat';
+import {
+  hasDiffCounts,
+  mountWorktreeStateLabel,
+  mountWorktreeStateTitle,
+  type MountWorktreeState,
+} from './mountRowState';
+
+type Props = {
+  readonly sessionId: SessionId;
+  readonly label: string;
+  readonly worktreePath: string | null;
+  readonly diffStat: MountDiffStat | null;
+  readonly state: MountWorktreeState;
+};
+
+const TEXT_TONE: Record<MountWorktreeState['kind'], string> = {
+  reading: 'text-muted-foreground/50',
+  unknown: 'text-warning/80',
+  clean: 'text-muted-foreground/50',
+  modified: 'text-muted-foreground',
+};
+
+export const MountChangeCell = ({ sessionId, label, worktreePath, diffStat, state }: Props) => {
+  const openMountDiff = useAppStore((store) => store.openMountDiff);
+  const hasCounts = hasDiffCounts({ diffStat });
+
+  if (hasCounts && diffStat !== null && worktreePath !== null) {
+    return (
+      <Tooltip content={`View changes in ${label}`}>
+        <button
+          type="button"
+          aria-label={`View the changes of ${label}`}
+          onClick={() => openMountDiff(sessionId, worktreePath)}
+          className="flex shrink-0 items-center gap-1.5 rounded-md px-1.5 py-1 text-xs tabular-nums hover:bg-muted/40"
+        >
+          <CONCEPT_ICONS.diff
+            size={ICON_SIZE.row}
+            aria-hidden
+            className="shrink-0 text-muted-foreground"
+          />
+          <DiffStat additions={diffStat.additions} deletions={diffStat.deletions} size="inherit" />
+        </button>
+      </Tooltip>
+    );
+  }
+
+  return (
+    <Tooltip content={mountWorktreeStateTitle({ state, label })}>
+      <span
+        data-testid="mount-change-state"
+        data-state={state.kind}
+        className={cn('truncate px-1.5 text-xs', TEXT_TONE[state.kind])}
+      >
+        {mountWorktreeStateLabel({ state })}
+      </span>
+    </Tooltip>
+  );
+};

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/MountKindGlyph.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/MountKindGlyph.tsx
@@ -1,0 +1,38 @@
+import { Tooltip, cn } from '@goodboy/ui';
+import { CONCEPT_ICONS, ICON_SIZE } from '../../../../../shared/components/conceptIcons';
+
+type Props = {
+  readonly projectKind: 'repo' | 'folder';
+  readonly isMainCheckout: boolean;
+  readonly label: string;
+};
+
+export const MountKindGlyph = ({ projectKind, isMainCheckout, label }: Props) => {
+  const isFolder = projectKind === 'folder';
+  const Glyph = isFolder
+    ? CONCEPT_ICONS.projectFolder
+    : isMainCheckout
+      ? CONCEPT_ICONS.projectRepo
+      : CONCEPT_ICONS.worktree;
+  const kind = isFolder ? 'folder' : isMainCheckout ? 'main checkout' : 'worktree';
+
+  return (
+    <Tooltip content={`${label} is the ${kind}`}>
+      <span
+        data-testid="mount-kind-glyph"
+        data-kind={kind}
+        aria-label={`${label} is the ${kind}`}
+        className="inline-flex shrink-0 items-center"
+      >
+        <Glyph
+          size={ICON_SIZE.row}
+          aria-hidden
+          className={cn(
+            'shrink-0',
+            isMainCheckout ? 'text-foreground/70' : 'text-muted-foreground',
+          )}
+        />
+      </span>
+    </Tooltip>
+  );
+};

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectBranchChip.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectBranchChip.tsx
@@ -80,7 +80,7 @@ export const ProjectBranchChip = ({ sessionId, projectId, mountId, branch, canSw
           role="dialog"
           ariaLabel="Switch branch"
           trigger={
-            <Tooltip content="Switch branch">
+            <Tooltip content="Switch branch. The next turns of this session write here.">
               <button
                 type="button"
                 aria-label="Switch branch"

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectMountRow.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectMountRow.test.tsx
@@ -96,6 +96,7 @@ const baseRow: MountRowView = {
   lastWorktreePath: '/api',
   repoRoot: '/repo/api',
   isAttached: true,
+  isMainCheckout: false,
   isOnDisk: true,
   revision: 0,
   parallelIndex: 0,
@@ -534,9 +535,14 @@ describe('ProjectMountRow activity dots', () => {
 describe('ProjectMountRow loading placeholders', () => {
   const status = {
     branch: 'feat/api',
+    head: null,
+    headSubject: null,
     mainDistance: { kind: 'known', ahead: 0, behind: 0 },
     upstreamDistance: { kind: 'known', ahead: 0, behind: 0 },
-  } as unknown as WorktreeStatus;
+    workingTree: { kind: 'known', staged: 0, unstaged: 0, untracked: 0, unmerged: 0, changed: 0 },
+    upstream: null,
+    inProgress: null,
+  } satisfies WorktreeStatus;
 
   it('holds a distance placeholder while the git status is still pending', () => {
     renderRow({ isStatusPending: true });
@@ -573,5 +579,90 @@ describe('ProjectMountRow loading placeholders', () => {
 
     expect(screen.queryByTestId('project-distance-skeleton')).toBeNull();
     expect(screen.queryByTestId('project-branch-skeleton')).toBeNull();
+  });
+});
+
+describe('ProjectMountRow worktree state', () => {
+  const cleanStatus = {
+    branch: 'feat/api',
+    head: null,
+    headSubject: null,
+    mainDistance: { kind: 'known', ahead: 0, behind: 0 },
+    upstreamDistance: { kind: 'known', ahead: 0, behind: 0 },
+    workingTree: { kind: 'known', staged: 0, unstaged: 0, untracked: 0, unmerged: 0, changed: 0 },
+    upstream: null,
+    inProgress: null,
+  } satisfies WorktreeStatus;
+
+  it('says the state is unknown when it has not been read, never that it is clean', () => {
+    renderRow({ worktreeStatus: null });
+
+    const cell = screen.getByTestId('mount-change-state');
+    expect(cell.dataset.state).toBe('unknown');
+    expect(cell.textContent).toBe('Unknown');
+    expect(tooltipTextOf({ element: cell })).toBe('The state of API has not been read.');
+  });
+
+  it('keeps unknown when git could not read the working tree', () => {
+    renderRow({
+      worktreeStatus: {
+        ...cleanStatus,
+        workingTree: { kind: 'unknown', reason: 'status-read-failed' },
+      },
+    });
+
+    const cell = screen.getByTestId('mount-change-state');
+    expect(cell.dataset.state).toBe('unknown');
+    expect(cell.textContent).toBe('Unknown');
+  });
+
+  it('calls a read worktree with no modifications clean', () => {
+    renderRow({ worktreeStatus: cleanStatus });
+
+    const cell = screen.getByTestId('mount-change-state');
+    expect(cell.dataset.state).toBe('clean');
+    expect(cell.textContent).toBe('No changes');
+  });
+
+  it('reports local modifications before the diff numbers land', () => {
+    renderRow({
+      worktreeStatus: {
+        ...cleanStatus,
+        workingTree: {
+          kind: 'known',
+          staged: 1,
+          unstaged: 1,
+          untracked: 0,
+          unmerged: 0,
+          changed: 2,
+        },
+      },
+    });
+
+    const cell = screen.getByTestId('mount-change-state');
+    expect(cell.dataset.state).toBe('modified');
+    expect(cell.textContent).toBe('Modified');
+    expect(tooltipTextOf({ element: cell })).toBe('API has 2 locally modified files.');
+  });
+
+  it('names the git operation in flight on the row', () => {
+    renderRow({ worktreeStatus: { ...cleanStatus, inProgress: 'rebase' } });
+
+    expect(screen.getByTitle('A rebase is in progress in API.').textContent).toBe('Rebasing');
+  });
+
+  it('leaves the row without an operation chip when nothing is running', () => {
+    renderRow({ worktreeStatus: cleanStatus });
+
+    expect(screen.queryByTitle('A rebase is in progress in API.')).toBeNull();
+  });
+
+  it('marks the main checkout apart from a worktree', () => {
+    renderRow({ row: { ...baseRow, isMainCheckout: true, worktreePath: '/repo/api' } });
+    expect(screen.getByTestId('mount-kind-glyph').dataset.kind).toBe('main checkout');
+
+    cleanup();
+    renderRow({ row: baseRow });
+    expect(screen.getByTestId('mount-kind-glyph').dataset.kind).toBe('worktree');
   });
 });

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectMountRow.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectMountRow.tsx
@@ -8,9 +8,10 @@ import { selectActiveMountId } from '../../../../../store/slices/project-mounts/
 import { CONCEPT_ICONS, ICON_SIZE } from '../../../../../shared/components/conceptIcons';
 import { useToast } from '../../../../../app/components/Toast';
 import { useMountRemoteHostKind } from '../../../../worktree/useMountRemoteHostKind';
-import { DiffStat } from '../../DiffStat';
 import { EditorMenu } from '../EditorMenu';
 import { MountBranchDecision } from './MountBranchDecision';
+import { MountChangeCell } from './MountChangeCell';
+import { MountKindGlyph } from './MountKindGlyph';
 import { MountRequestAction } from './MountRequestAction';
 import { MountRequestLink } from './MountRequestLink';
 import { ProjectBranchChip } from './ProjectBranchChip';
@@ -18,6 +19,7 @@ import { ProjectSyncControl } from './ProjectSyncControl';
 import { ProjectDetachMenu } from './ProjectDetachMenu';
 import { RemoveWorktreeAction } from './RemoveWorktreeAction';
 import { useProjectActivity } from './useProjectActivity';
+import { hasDiffCounts, mountOperationView, mountWorktreeState } from './mountRowState';
 
 type Props = {
   readonly sessionId: SessionId;
@@ -69,7 +71,6 @@ export const ProjectMountRow = ({
   onSelectLens,
 }: Props) => {
   const setScriptsLensScope = useAppStore((state) => state.setScriptsLensScope);
-  const openMountDiff = useAppStore((state) => state.openMountDiff);
   const openMountTerminal = useAppStore((state) => state.openMountTerminal);
   const attachMount = useAppStore((state) => state.attachMount);
   const activeMountId = useAppStore((state) => selectActiveMountId({ state, sessionId }));
@@ -77,7 +78,7 @@ export const ProjectMountRow = ({
   const [isAttaching, setIsAttaching] = useState(false);
   const isRepo = row.projectKind === 'repo';
   const worktreePath = row.worktreePath;
-  const changes = diffStat != null && (diffStat.additions > 0 || diffStat.deletions > 0);
+  const changes = hasDiffCounts({ diffStat });
   const isStatusPending = isStatusPendingProp && worktreeStatus == null && isRepo;
   const remoteKind = useMountRemoteHostKind({ sessionId, repoRoot: row.repoRoot });
   const activity = useProjectActivity({
@@ -88,6 +89,11 @@ export const ProjectMountRow = ({
   const observation = row.observation;
   const hasTools = row.isAttached && worktreePath !== null;
   const isWriteDestination = row.isAttached && row.mountId === activeMountId;
+  const worktreeState = mountWorktreeState({
+    status: worktreeStatus,
+    isPending: isStatusPendingProp,
+  });
+  const operation = mountOperationView({ status: worktreeStatus, label });
 
   const openLens = ({ lens }: OpenLensParams) => {
     if (lens === 'terminal') {
@@ -121,6 +127,11 @@ export const ProjectMountRow = ({
     >
       <div className="flex min-h-8 w-full items-center gap-2 rounded-md px-2 py-1 hover:bg-muted/40">
         <div className={SLOT_BRANCH}>
+          <MountKindGlyph
+            projectKind={row.projectKind}
+            isMainCheckout={row.isMainCheckout}
+            label={label}
+          />
           {isStatusPending && row.branch === '' ? (
             <span data-testid="project-branch-skeleton" className="shrink-0">
               <Skeleton className="h-6 w-28 rounded-md" />
@@ -144,6 +155,16 @@ export const ProjectMountRow = ({
               className="shrink-0"
             />
           ) : null}
+          {operation === null ? null : (
+            <Chip
+              tone="warning"
+              size="3xs"
+              bordered={false}
+              label={operation.label}
+              title={operation.title}
+              className="shrink-0"
+            />
+          )}
         </div>
         {hasSeriesColumn ? (
           <div className={SLOT_SERIES}>
@@ -173,28 +194,14 @@ export const ProjectMountRow = ({
           ) : null}
         </div>
         <div className={SLOT_DIFF}>
-          {!row.isAttached ? null : changes && worktreePath !== null ? (
-            <Tooltip content={`View changes in ${label}`}>
-              <button
-                type="button"
-                aria-label={`View the changes of ${label}`}
-                onClick={() => openMountDiff(sessionId, worktreePath)}
-                className="flex shrink-0 items-center gap-1.5 rounded-md px-1.5 py-1 text-xs tabular-nums hover:bg-muted/40"
-              >
-                <CONCEPT_ICONS.diff
-                  size={ICON_SIZE.row}
-                  aria-hidden
-                  className="shrink-0 text-muted-foreground"
-                />
-                <DiffStat
-                  additions={diffStat.additions}
-                  deletions={diffStat.deletions}
-                  size="inherit"
-                />
-              </button>
-            </Tooltip>
-          ) : (
-            <span className="px-1.5 text-xs text-muted-foreground/50">No changes</span>
+          {!row.isAttached || !isRepo ? null : (
+            <MountChangeCell
+              sessionId={sessionId}
+              label={label}
+              worktreePath={worktreePath}
+              diffStat={diffStat}
+              state={worktreeState}
+            />
           )}
         </div>
         <div className={SLOT_STATE}>

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/RemoveWorktreeAction.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/RemoveWorktreeAction.test.tsx
@@ -51,6 +51,7 @@ const ROW = {
   lastWorktreePath: '/worktrees/api',
   repoRoot: '/repos/api',
   isAttached: true,
+  isMainCheckout: false,
   isOnDisk: true,
   revision: 3,
   parallelIndex: 0,

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/mountRowState.ts
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/mountRowState.ts
@@ -1,0 +1,108 @@
+import type { GitOperation, GitUnknownReason, WorktreeStatus } from '@goodboy/types';
+import type { MountDiffStat } from '../../../../../store';
+import { operationLabel, unknownReasonLabel } from '../../../../../shared/lib/gitStatus';
+
+export const hasDiffCounts = ({ diffStat }: { readonly diffStat: MountDiffStat | null }): boolean =>
+  diffStat !== null && (diffStat.additions > 0 || diffStat.deletions > 0);
+
+export type MountWorktreeState =
+  | { readonly kind: 'reading' }
+  | { readonly kind: 'unknown'; readonly reason: GitUnknownReason | null }
+  | { readonly kind: 'clean' }
+  | { readonly kind: 'modified'; readonly changed: number };
+
+type StateParams = {
+  readonly status: WorktreeStatus | null;
+  readonly isPending: boolean;
+};
+
+type LabelParams = {
+  readonly state: MountWorktreeState;
+};
+
+type TitleParams = LabelParams & {
+  readonly label: string;
+};
+
+export const mountWorktreeState = ({ status, isPending }: StateParams): MountWorktreeState => {
+  if (status === null) {
+    return isPending ? { kind: 'reading' } : { kind: 'unknown', reason: null };
+  }
+  const workingTree = status.workingTree;
+  if (workingTree.kind === 'unknown') {
+    return { kind: 'unknown', reason: workingTree.reason };
+  }
+  if (workingTree.changed > 0) {
+    return { kind: 'modified', changed: workingTree.changed };
+  }
+  return { kind: 'clean' };
+};
+
+export const mountWorktreeStateLabel = ({ state }: LabelParams): string => {
+  switch (state.kind) {
+    case 'reading':
+      return 'Reading';
+    case 'unknown':
+      return 'Unknown';
+    case 'clean':
+      return 'No changes';
+    case 'modified':
+      return 'Modified';
+    default: {
+      const exhaustive: never = state;
+      return exhaustive;
+    }
+  }
+};
+
+export const mountWorktreeStateTitle = ({ state, label }: TitleParams): string => {
+  switch (state.kind) {
+    case 'reading':
+      return `Reading the state of ${label}.`;
+    case 'unknown':
+      return state.reason === null
+        ? `The state of ${label} has not been read.`
+        : `The state of ${label} is unknown: ${unknownReasonLabel({ reason: state.reason })}.`;
+    case 'clean':
+      return `${label} has no local modifications.`;
+    case 'modified':
+      return state.changed === 1
+        ? `${label} has 1 locally modified file.`
+        : `${label} has ${state.changed} locally modified files.`;
+    default: {
+      const exhaustive: never = state;
+      return exhaustive;
+    }
+  }
+};
+
+const OPERATION_LABEL = {
+  merge: 'Merging',
+  rebase: 'Rebasing',
+  'cherry-pick': 'Cherry-picking',
+  bisect: 'Bisecting',
+} satisfies Record<GitOperation, string>;
+
+export type MountOperationView = Readonly<{
+  label: string;
+  title: string;
+}>;
+
+type OperationParams = {
+  readonly status: WorktreeStatus | null;
+  readonly label: string;
+};
+
+export const mountOperationView = ({
+  status,
+  label,
+}: OperationParams): MountOperationView | null => {
+  const operation = status?.inProgress ?? null;
+  if (operation === null) {
+    return null;
+  }
+  return {
+    label: OPERATION_LABEL[operation],
+    title: `A ${operationLabel({ operation })} is in progress in ${label}.`,
+  };
+};

--- a/apps/desktop/src/store/slices/project-mounts/detachProject.test.ts
+++ b/apps/desktop/src/store/slices/project-mounts/detachProject.test.ts
@@ -624,6 +624,31 @@ describe('detachProject', () => {
     expect(store.sessions[0]?.activeMountId).toBeUndefined();
   });
 
+  it('leaves no write destination when the last project is detached', async () => {
+    const store = makeStore();
+    listSessionMounts.mockImplementation(async () => [VIEW_API, VIEW_API_2]);
+    store.sessionMounts['sess-1'] = [
+      { ...VIEW_API, repoRoot: '/repos/api' },
+      { ...VIEW_API_2, repoRoot: '/repos/api' },
+    ];
+    store.sessionProjectMounts['sess-1'] = store.sessionProjectMounts['sess-1'].filter(
+      (mount) => mount.projectId === 'project-api',
+    );
+    store.sessionWorktrees['sess-1'] = ['/container', '/container/api', '/container/api-2'];
+
+    await runDetach(store);
+
+    expect(store.sessionProjectMounts['sess-1']).toEqual([]);
+    expect(store.sessionActiveMount['sess-1']).toBeNull();
+    expect(store.sessionBranches['sess-1']).toBeUndefined();
+    expect(store.sessions[0]).not.toHaveProperty('activeMountId');
+    expect(updateSessionActiveMount).toHaveBeenCalledWith({
+      db: {},
+      sessionId: SESSION_ID,
+      mountId: null,
+    });
+  });
+
   it('clears the branch observations of the rows it deletes', async () => {
     const store = makeStore();
 

--- a/apps/desktop/src/store/slices/project-mounts/mountRowModel.test.ts
+++ b/apps/desktop/src/store/slices/project-mounts/mountRowModel.test.ts
@@ -218,3 +218,51 @@ describe('buildMountRows', () => {
     expect(row?.observedBranchHolder).toBeNull();
   });
 });
+
+describe('buildMountRows checkout kind', () => {
+  it('marks the row that lives in the repository root as the main checkout', () => {
+    const state = makeState();
+    const rebuilt: MountRowState = {
+      ...state,
+      sessionMounts: {
+        [SESSION_ID]: [
+          mountView({
+            id: FIRST,
+            branch: 'main',
+            worktreePath: '/repos/ledger-core',
+            parallelIndex: 0,
+          }),
+          mountView({
+            id: SECOND,
+            branch: 'ak/part-two',
+            worktreePath: '/wt/two',
+            parallelIndex: 1,
+          }),
+        ],
+      },
+    };
+
+    const [group] = buildMountRows({ state: rebuilt, sessionId: SESSION_ID });
+
+    expect(group?.rows.map((row) => [row.mountId, row.isMainCheckout])).toEqual([
+      [FIRST, true],
+      [SECOND, false],
+    ]);
+  });
+
+  it('never calls a detached row the main checkout', () => {
+    const state = makeState();
+    const rebuilt: MountRowState = {
+      ...state,
+      sessionMounts: {
+        [SESSION_ID]: [
+          mountView({ id: FIRST, branch: 'main', worktreePath: null, parallelIndex: 0 }),
+        ],
+      },
+    };
+
+    const [group] = buildMountRows({ state: rebuilt, sessionId: SESSION_ID });
+
+    expect(group?.rows[0]?.isMainCheckout).toBe(false);
+  });
+});

--- a/apps/desktop/src/store/slices/project-mounts/mountRowModel.ts
+++ b/apps/desktop/src/store/slices/project-mounts/mountRowModel.ts
@@ -56,6 +56,7 @@ export type MountRowView = Readonly<{
   lastWorktreePath: string | null;
   repoRoot: string;
   isAttached: boolean;
+  isMainCheckout: boolean;
   isOnDisk: boolean;
   revision: number;
   parallelIndex: number;
@@ -319,6 +320,7 @@ export const buildMountRows = ({
       lastWorktreePath: view.lastWorktreePath,
       repoRoot: view.repoRoot,
       isAttached: view.isAttached && view.worktreePath !== null,
+      isMainCheckout: view.worktreePath !== null && view.worktreePath === view.repoRoot,
       isOnDisk,
       revision: view.revision,
       parallelIndex: view.parallelIndex,


### PR DESCRIPTION
Makes a worktree row say what it actually knows.

This branch originally also fixed the detach itself. PR #1737 landed the same fix in parallel and went further, so that work was dropped rather than reapplied: main's `dropMountFromSession` deletes the rows outright instead of marking the views detached, `releaseMountSelection` already recomputes the write destination when the deleted rows held it, and the object-identity filter this branch fixed no longer exists as a code path. The recoverable-failure notice was dropped too: `mountCleanupBlockers` now gates before the attempt, so an agent-held mount never reaches a failure, and the popover stays open with a retry when a runtime failure does happen.

What is left is what main does not do.

## Unknown was drawn as clean

The row printed "No changes" whenever the diff stat was empty, which is also what it looks like before anyone has read the worktree. A worktree nobody had inspected and a worktree with nothing in it were the same row.

The state is now one of reading, unknown, clean or modified. Unknown says so in a warning tone and carries the git reason in its tooltip.

## A half-finished git operation is named

A merge, rebase, cherry-pick or bisect left in progress now shows as a chip on the row it belongs to, rather than being invisible until the next command fails.

## The main checkout is not a worktree

`isMainCheckout` compares the worktree path against the repository root and drives the glyph: a repository mark for the main checkout, a tree for a worktree, a folder for a project with no git.

## One test that is coverage, not a regression

`leaves no write destination when the last project is detached` passes against main unchanged. `releaseMountSelection` deletes `sessionBranches[sessionId]` and nulls the active mount when the released rows were the last ones, and nothing on main pinned that arm.

## Residual, on main's design not this branch

Main's detach failure toast is generic: the actual `decision.reason` never reaches the user, and nothing survives the popover closing. Worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
