### PR TITLE
chore(repo): bump version to 0.2.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,69 @@ version in the same PR that bumps the version numbers (see
 `docs/release-command.md`), before the tag is pushed: the release build fails
 if it can't find a matching `## Goodboy vX.Y.Z` heading.
 
+## Goodboy v0.2.26
+
+The resolve queue splits the outcomes it used to lump together, pull request
+state reads the same on every surface, and detaching a project takes it out of
+the session.
+
+### [#1732] Five resolve outcomes instead of one bucket
+
+"Needs review" covered three different situations, and a run that crashed sat
+under the same label as one you stopped on purpose. There are five outcomes
+now: fix ready, reply ready, nothing to change, run failed, run stopped. Each
+carries its next step in words and its own icon, so none of them rests on
+color. A fix that exists only on your machine is labelled that way, and an
+approved change that has not gone out reads `Approved, not published`, so
+neither can be mistaken for closed on the provider.
+
+The queue counts what is in it, queued, working, question, failed and
+published, and hides the buckets that are empty. A `retryable` filter narrows
+it to the three states a retry can actually move.
+
+`Publish` now commits to one of three things before you press it: send the fix
+out, close the threads without one, or post replies. Closing without a fix is
+the only one that asks you to confirm, restating the counts and the pull
+request number.
+
+### [#1733] One reading of pull request state everywhere
+
+Merged, closed and approved each had their own color per provider: a merged
+GitLab or Linear item wore a plain notice tone, an abandoned pull request wore
+the merged one, and the board and the sidebar disagreed over which pull
+requests counted as approved. All of it now comes from one grammar.
+
+Approval and error no longer share a dot either. Plan and agent status show a
+written label and a reason instead of a bare keyword, and every status dot
+carries both, so nothing rests on color alone.
+
+### [#1737] Detaching a project removes it from the session
+
+Detaching a project left it in the Projects list with a `Mount` button beside
+it, detaching it a second time did nothing at all, and the row menu of the one
+it left behind opened an empty popover. Detach now takes the project out of
+the session, which is what the word says; `Unmount branch` still covers the
+narrower case.
+
+A mount an agent or a terminal is still holding is refused instead of deleted,
+and while a blocker stands the confirmation offers no button to press past it.
+A row left over from before can leave on its own through `Remove from session`.
+A directory still on disk is handed to the orphan sweep, so it turns up in
+workspace settings instead of disappearing quietly.
+
+### Fixes
+
+- The command palette offered a skills filter the workspace has turned off,
+  and typing it led nowhere; three surfaces that still advertised skills are
+  now gated. (#1733)
+- The composer's placeholder named a slash command it did not accept. (#1733)
+- The palette listed four of seventeen lens destinations, leaving thirteen
+  bound to shortcuts nobody was told about; all seventeen are listed with
+  their shortcut, and the context chip and the permission picker teach theirs
+  in place. The routing picker still does not show its own. (#1733)
+- `Fix all` promised more than it did, since it started one shared run on the
+  default resolver routing; it is now `Start resolve run`. (#1732)
+
 ## Goodboy v0.2.25
 
 The chat shows where a session is about to write, model lists match what

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goodboy/desktop",
-  "version": "0.2.25",
+  "version": "0.2.26",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -1626,7 +1626,7 @@ dependencies = [
 
 [[package]]
 name = "goodboy-desktop"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goodboy-desktop"
-version = "0.2.25"
+version = "0.2.26"
 description = "Goodboy desktop app"
 authors = ["Amin Khayam"]
 license = "MIT"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Goodboy",
-  "version": "0.2.25",
+  "version": "0.2.26",
   "identifier": "com.goodboy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goodboy",
-  "version": "0.2.25",
+  "version": "0.2.26",
   "private": true,
   "description": "AI workspace orchestrator. Local-first, provider-agnostic.",
   "license": "MIT",

--- a/website/src/site.ts
+++ b/website/src/site.ts
@@ -1,5 +1,5 @@
 export const SITE = {
-  version: 'v0.2.25',
+  version: 'v0.2.26',
   repo: 'https://github.com/akhayam99/goodboy',
   releases: 'https://github.com/akhayam99/goodboy/releases',
   latest: 'https://github.com/akhayam99/goodboy/releases/latest',


### PR DESCRIPTION
Version bump to 0.2.26 across the six places that carry it, plus the `## Goodboy v0.2.26` section the release build reads its notes from.

Three PRs merged since v0.2.25, all desktop scope: #1732 (resolve outcomes, counts, publish intent), #1733 (one state grammar, commands that exist), #1737 (detach removes a project from the session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)