### PR TITLE
feat(desktop): stop reading clean as merged before a removal

### DIFF
--- a/apps/desktop/src-tauri/src/worktree.rs
+++ b/apps/desktop/src-tauri/src/worktree.rs
@@ -129,6 +129,14 @@ pub enum WorktreeRemovalMode {
 
 #[derive(Debug, Serialize, PartialEq, Eq)]
 #[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum BranchIntegration {
+    Unknown,
+    Merged { base: String },
+    Unmerged { base: String, ahead: u32 },
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
 pub enum WorktreeDetachAssessment {
     Missing {
         path: String,
@@ -150,6 +158,7 @@ pub enum WorktreeDetachAssessment {
         ignored_files: u32,
         #[serde(rename = "ignoredFileSamples")]
         ignored_file_samples: Vec<String>,
+        integration: BranchIntegration,
     },
 }
 
@@ -1211,16 +1220,95 @@ pub async fn worktree_remove_checked(
 #[tauri::command]
 pub async fn worktree_detach_assessment(
     worktree_path: String,
+    base_branch: Option<String>,
 ) -> Result<WorktreeDetachAssessment, WorktreeError> {
-    tauri::async_runtime::spawn_blocking(move || worktree_detach_assessment_blocking(worktree_path))
-        .await
-        .map_err(|e| WorktreeError::Io(std::io::Error::other(e.to_string())))?
+    tauri::async_runtime::spawn_blocking(move || {
+        worktree_detach_assessment_blocking(worktree_path, base_branch)
+    })
+    .await
+    .map_err(|e| WorktreeError::Io(std::io::Error::other(e.to_string())))?
 }
 
 fn local_only_commit_count(cwd: &Path) -> Option<u32> {
     git(cwd, &["rev-list", "--count", "HEAD", "--not", "--remotes"])
         .ok()
         .and_then(|raw| raw.trim().parse::<u32>().ok())
+}
+
+fn commit_ref_exists(cwd: &Path, reference: &str) -> bool {
+    git(
+        cwd,
+        &[
+            "rev-parse",
+            "--verify",
+            "--quiet",
+            &format!("{reference}^{{commit}}"),
+        ],
+    )
+    .is_ok_and(|raw| !raw.trim().is_empty())
+}
+
+fn default_base_ref(cwd: &Path) -> Option<String> {
+    let raw = git(
+        cwd,
+        &["symbolic-ref", "--quiet", "refs/remotes/origin/HEAD"],
+    )
+    .ok()?;
+    let trimmed = raw.trim();
+    match trimmed.is_empty() {
+        true => None,
+        false => Some(trimmed.to_string()),
+    }
+}
+
+fn resolve_base_ref(cwd: &Path, base_branch: Option<&str>) -> Option<String> {
+    let named = base_branch
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .map(str::to_string);
+    let Some(name) = named else {
+        return default_base_ref(cwd);
+    };
+    let stripped = name
+        .strip_prefix("refs/heads/")
+        .or_else(|| name.strip_prefix("refs/remotes/"))
+        .unwrap_or(name.as_str())
+        .to_string();
+    [
+        format!("refs/remotes/origin/{stripped}"),
+        format!("refs/heads/{stripped}"),
+        stripped.clone(),
+    ]
+    .into_iter()
+    .find(|candidate| commit_ref_exists(cwd, candidate))
+}
+
+fn base_label(base_ref: &str) -> String {
+    base_ref
+        .strip_prefix("refs/remotes/")
+        .or_else(|| base_ref.strip_prefix("refs/heads/"))
+        .unwrap_or(base_ref)
+        .to_string()
+}
+
+fn branch_integration(cwd: &Path, base_branch: Option<&str>, has_head: bool) -> BranchIntegration {
+    let Some(base_ref) = resolve_base_ref(cwd, base_branch) else {
+        return BranchIntegration::Unknown;
+    };
+    let base = base_label(&base_ref);
+    if !has_head {
+        return BranchIntegration::Merged { base };
+    }
+    let Ok(raw) = git(cwd, &["rev-list", "--count", &format!("{base_ref}..HEAD")]) else {
+        return BranchIntegration::Unknown;
+    };
+    let Ok(ahead) = raw.trim().parse::<u32>() else {
+        return BranchIntegration::Unknown;
+    };
+    match ahead {
+        0 => BranchIntegration::Merged { base },
+        _ => BranchIntegration::Unmerged { base, ahead },
+    }
 }
 
 const REPRODUCIBLE_IGNORED_DIRS: [&str; 11] = [
@@ -1274,6 +1362,7 @@ fn ignored_files_at_risk(worktree_path: &Path) -> Option<IgnoredFilesAtRisk> {
 
 fn worktree_detach_assessment_blocking(
     worktree_path: String,
+    base_branch: Option<String>,
 ) -> Result<WorktreeDetachAssessment, WorktreeError> {
     let p = Path::new(&worktree_path);
     if !p.exists() {
@@ -1311,6 +1400,7 @@ fn worktree_detach_assessment_blocking(
             branch,
         });
     };
+    let integration = branch_integration(p, base_branch.as_deref(), snapshot.head.is_some());
     Ok(WorktreeDetachAssessment::Assessed {
         path: worktree_path,
         branch,
@@ -1319,6 +1409,7 @@ fn worktree_detach_assessment_blocking(
         local_only_commits,
         ignored_files: ignored.count,
         ignored_file_samples: ignored.samples,
+        integration,
     })
 }
 
@@ -4268,7 +4359,7 @@ mod teardown_tests {
     use super::{
         collect_orphans, inspect_worktree_with, remove_worktree_checked_leased,
         remove_worktree_checked_with, worktree_detach_assessment_blocking,
-        worktree_directory_size_blocking, worktree_orphan_remove_blocking,
+        worktree_directory_size_blocking, worktree_orphan_remove_blocking, BranchIntegration,
         WorktreeDetachAssessment, WorktreeError, WorktreeInspection, WorktreeRemovalMode,
         WorktreeRemovalReason, WorktreeRemovalResult, REPRODUCIBLE_IGNORED_DIRS,
     };
@@ -4783,10 +4874,26 @@ mod teardown_tests {
         git_ok(root, &["init", "--bare", bare.to_str().unwrap()]);
         git_ok(root, &["remote", "add", "origin", bare.to_str().unwrap()]);
         git_ok(root, &["push", "-u", "origin", "main"]);
+        git_ok(root, &["remote", "set-head", "origin", "main"]);
     }
 
     fn assess(target: &Path) -> WorktreeDetachAssessment {
-        worktree_detach_assessment_blocking(target.to_string_lossy().into_owned()).unwrap()
+        worktree_detach_assessment_blocking(target.to_string_lossy().into_owned(), None).unwrap()
+    }
+
+    fn assess_against(target: &Path, base_branch: &str) -> WorktreeDetachAssessment {
+        worktree_detach_assessment_blocking(
+            target.to_string_lossy().into_owned(),
+            Some(base_branch.to_string()),
+        )
+        .unwrap()
+    }
+
+    fn integration_of(assessment: &WorktreeDetachAssessment) -> &BranchIntegration {
+        match assessment {
+            WorktreeDetachAssessment::Assessed { integration, .. } => integration,
+            _ => panic!("expected an assessed worktree"),
+        }
     }
 
     #[test]
@@ -4870,6 +4977,9 @@ mod teardown_tests {
                 local_only_commits: 0,
                 ignored_files: 0,
                 ignored_file_samples: Vec::new(),
+                integration: BranchIntegration::Merged {
+                    base: "origin/main".to_string()
+                },
             }
         );
     }
@@ -5115,6 +5225,107 @@ mod teardown_tests {
             assess(&target),
             WorktreeDetachAssessment::Missing {
                 path: target.to_string_lossy().into_owned()
+            }
+        );
+    }
+
+    #[test]
+    fn assessment_reports_a_branch_merged_into_the_configured_base() {
+        let root = init_repo("assess-merged-base");
+        publish_repo(&root);
+        let target = add_worktree(&root, "merged-base");
+        git_ok(&target, &["push", "-u", "origin", "test/merged-base"]);
+
+        assert_eq!(
+            integration_of(&assess_against(&target, "main")),
+            &BranchIntegration::Merged {
+                base: "origin/main".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn assessment_counts_commits_missing_from_the_configured_base() {
+        let root = init_repo("assess-unmerged-base");
+        publish_repo(&root);
+        let target = add_worktree(&root, "unmerged-base");
+        std::fs::write(target.join("first.txt"), "one\n").unwrap();
+        git_ok(&target, &["add", "first.txt"]);
+        git_ok(&target, &["commit", "-m", "first"]);
+        std::fs::write(target.join("second.txt"), "two\n").unwrap();
+        git_ok(&target, &["add", "second.txt"]);
+        git_ok(&target, &["commit", "-m", "second"]);
+        git_ok(&target, &["push", "-u", "origin", "test/unmerged-base"]);
+
+        assert_eq!(
+            integration_of(&assess_against(&target, "main")),
+            &BranchIntegration::Unmerged {
+                base: "origin/main".to_string(),
+                ahead: 2
+            }
+        );
+    }
+
+    #[test]
+    fn assessment_reads_integration_against_the_project_base_not_main() {
+        let root = init_repo("assess-project-base");
+        publish_repo(&root);
+        let target = add_worktree(&root, "project-base");
+        std::fs::write(target.join("feature.txt"), "work\n").unwrap();
+        git_ok(&target, &["add", "feature.txt"]);
+        git_ok(&target, &["commit", "-m", "feature"]);
+        git_ok(&target, &["push", "-u", "origin", "test/project-base"]);
+        git_ok(&target, &["push", "origin", "HEAD:refs/heads/develop"]);
+        git_ok(&target, &["fetch", "origin"]);
+
+        assert_eq!(
+            integration_of(&assess_against(&target, "develop")),
+            &BranchIntegration::Merged {
+                base: "origin/develop".to_string()
+            }
+        );
+        assert_eq!(
+            integration_of(&assess_against(&target, "main")),
+            &BranchIntegration::Unmerged {
+                base: "origin/main".to_string(),
+                ahead: 1
+            }
+        );
+    }
+
+    #[test]
+    fn assessment_reports_unknown_integration_when_the_base_does_not_resolve() {
+        let root = init_repo("assess-base-missing");
+        publish_repo(&root);
+        let target = add_worktree(&root, "base-missing");
+        git_ok(&target, &["push", "-u", "origin", "test/base-missing"]);
+
+        assert_eq!(
+            integration_of(&assess_against(&target, "release/never-cut")),
+            &BranchIntegration::Unknown
+        );
+    }
+
+    #[test]
+    fn assessment_reports_unknown_integration_when_no_base_is_configured_and_none_is_published() {
+        let root = init_repo("assess-base-absent");
+        let target = add_worktree(&root, "base-absent");
+
+        assert_eq!(
+            integration_of(&assess(&target)),
+            &BranchIntegration::Unknown
+        );
+    }
+
+    #[test]
+    fn assessment_falls_back_to_a_local_base_branch_without_a_remote() {
+        let root = init_repo("assess-local-base");
+        let target = add_worktree(&root, "local-base");
+
+        assert_eq!(
+            integration_of(&assess_against(&target, "main")),
+            &BranchIntegration::Merged {
+                base: "main".to_string()
             }
         );
     }

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/DetachConfirm.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/DetachConfirm.tsx
@@ -69,9 +69,12 @@ export const DetachConfirm = ({
   }
   const isRisky = plan.kind === 'risky';
   const details =
-    plan.kind === 'risky' || plan.kind === 'keep' ? plan.details : { totals: [], worktrees: [] };
+    plan.kind === 'risky' || plan.kind === 'keep' || plan.kind === 'safe'
+      ? plan.details
+      : { totals: [], worktrees: [] };
   const hasDetails = details.totals.length > 0 || details.worktrees.length > 0;
-  const isUnavailable = plan.kind === 'keep' && plan.reason === 'unavailable';
+  const isUnread =
+    plan.kind === 'keep' && (plan.reason === 'unavailable' || plan.reason === 'unverified');
 
   return (
     <div className="flex flex-col p-2">
@@ -83,7 +86,7 @@ export const DetachConfirm = ({
         isBusy={isBusy}
         onConfirm={() => onConfirm({ disposition: action.disposition })}
         onCancel={onCancel}
-        {...(isUnavailable
+        {...(isUnread
           ? { altAction: { label: 'Check again', onClick: onRecheck, disabled: isBusy } }
           : {})}
       >

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectDetachMenu.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectDetachMenu.test.tsx
@@ -2,7 +2,13 @@
 
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { MountId, ProjectId, SessionId, WorktreeDetachAssessment } from '@goodboy/types';
+import type {
+  BranchIntegration,
+  MountId,
+  ProjectId,
+  SessionId,
+  WorktreeDetachAssessment,
+} from '@goodboy/types';
 
 const { state, showToast, worktreeDetachAssessment } = vi.hoisted(() => ({
   state: {
@@ -10,7 +16,7 @@ const { state, showToast, worktreeDetachAssessment } = vi.hoisted(() => ({
     unmountMount: vi.fn(async () => ({ kept: false })),
     forgetMount: vi.fn(async () => ({ keptPath: null as string | null })),
     emitNotification: vi.fn(),
-    projects: [{ id: 'project-1', kind: 'repo' }],
+    projects: [{ id: 'project-1', kind: 'repo', baseBranch: 'develop' as string | null }],
     sessions: [{ id: 'session-1', state: { kind: 'idle' } }],
     terminalTabs: {},
     sessionProjectMounts: {
@@ -31,6 +37,7 @@ const { state, showToast, worktreeDetachAssessment } = vi.hoisted(() => ({
           worktreePath: '/worktrees/api' as string | null,
           lastWorktreePath: null as string | null,
           branch: 'ak/feat',
+          baseBranch: 'main' as string | null,
           isAttached: true,
           diskState: 'present' as string,
         },
@@ -58,18 +65,22 @@ import { ProjectDetachMenu } from './ProjectDetachMenu';
 const typedString = <Value extends string>({ value }: { readonly value: string }): Value =>
   JSON.parse(JSON.stringify(value));
 
+const MERGED = { kind: 'merged', base: 'origin/main' } satisfies BranchIntegration;
+
 const assessed = ({
   affectedFiles,
   localOnlyCommits,
   hasUpstream,
   ignoredFiles = 0,
   ignoredFileSamples = [],
+  integration = MERGED,
 }: {
   readonly affectedFiles: number;
   readonly localOnlyCommits: number;
   readonly hasUpstream: boolean;
   readonly ignoredFiles?: number;
   readonly ignoredFileSamples?: ReadonlyArray<string>;
+  readonly integration?: BranchIntegration;
 }): WorktreeDetachAssessment => ({
   kind: 'assessed',
   path: '/worktrees/api',
@@ -79,6 +90,7 @@ const assessed = ({
   localOnlyCommits,
   ignoredFiles,
   ignoredFileSamples,
+  integration,
 });
 
 const renderMenu = () =>
@@ -120,7 +132,7 @@ const openConfirm = () => {
 afterEach(cleanup);
 beforeEach(() => {
   vi.clearAllMocks();
-  state.projects = [{ id: 'project-1', kind: 'repo' }];
+  state.projects = [{ id: 'project-1', kind: 'repo', baseBranch: 'develop' }];
   state.sessions = [{ id: 'session-1', state: { kind: 'idle' } }];
   state.terminalTabs = {};
   state.sessionProjectMounts = {
@@ -141,6 +153,7 @@ beforeEach(() => {
         worktreePath: '/worktrees/api',
         lastWorktreePath: null,
         branch: 'ak/feat',
+        baseBranch: 'main',
         isAttached: true,
         diskState: 'present',
       },
@@ -189,7 +202,7 @@ describe('ProjectDetachMenu', () => {
     await waitFor(() => expect(screen.getByRole('button', { name: 'Detach and remove' })));
     expect(
       screen.getByText(
-        'Remove the clean worktree at /worktrees/api; ak/feat is published, with 0 uncommitted files and 0 unpushed commits, and the branch will remain.',
+        'Remove the clean worktree at /worktrees/api: 0 uncommitted files, 0 unpushed commits, and ak/feat is merged into origin/main.',
       ),
     ).toBeDefined();
     fireEvent.click(screen.getByRole('button', { name: 'Detach and remove' }));
@@ -229,6 +242,7 @@ describe('ProjectDetachMenu', () => {
           worktreePath: '/worktrees/api-one',
           lastWorktreePath: null,
           branch: 'ak/one',
+          baseBranch: null,
           isAttached: true,
           diskState: 'present',
         },
@@ -238,6 +252,7 @@ describe('ProjectDetachMenu', () => {
           worktreePath: '/worktrees/api-two',
           lastWorktreePath: null,
           branch: 'ak/two',
+          baseBranch: null,
           isAttached: true,
           diskState: 'present',
         },
@@ -247,6 +262,7 @@ describe('ProjectDetachMenu', () => {
           worktreePath: '/worktrees/web',
           lastWorktreePath: null,
           branch: 'ak/web',
+          baseBranch: null,
           isAttached: true,
           diskState: 'present',
         },
@@ -286,6 +302,7 @@ describe('ProjectDetachMenu', () => {
               localOnlyCommits: 0,
               ignoredFiles: 0,
               ignoredFileSamples: [],
+              integration: MERGED,
             }
           : {
               kind: 'assessed',
@@ -296,6 +313,7 @@ describe('ProjectDetachMenu', () => {
               localOnlyCommits: 3,
               ignoredFiles: 0,
               ignoredFileSamples: [],
+              integration: MERGED,
             },
     );
     renderMenu();
@@ -312,10 +330,14 @@ describe('ProjectDetachMenu', () => {
     expect(screen.getByText('3 uncommitted files will be deleted.')).toBeDefined();
     fireEvent.click(screen.getByRole('button', { name: 'Detach details for api' }));
     expect(
-      screen.getByText('ak/one at /worktrees/api-one: 2 uncommitted files, 0 unpushed commits'),
+      screen.getByText(
+        'ak/one at /worktrees/api-one: 2 uncommitted files, 0 unpushed commits, merged into origin/main',
+      ),
     ).toBeDefined();
     expect(
-      screen.getByText('ak/two at /worktrees/api-two: 1 uncommitted file, 3 local-only commits'),
+      screen.getByText(
+        'ak/two at /worktrees/api-two: 1 uncommitted file, 3 local-only commits, merged into origin/main',
+      ),
     ).toBeDefined();
   });
 
@@ -357,7 +379,7 @@ describe('ProjectDetachMenu', () => {
   });
 
   it('keeps the directory of a folder project without assessing it', () => {
-    state.projects = [{ id: 'project-1', kind: 'folder' }];
+    state.projects = [{ id: 'project-1', kind: 'folder', baseBranch: null }];
     renderMenu();
     openConfirm();
 
@@ -382,6 +404,90 @@ describe('ProjectDetachMenu', () => {
       ),
     ).toBeDefined();
     expect(screen.getByRole('button', { name: 'Check again' })).toBeDefined();
+  });
+
+  it('asks for integration against the base the mount carries', async () => {
+    renderMenu();
+    openConfirm();
+
+    await waitFor(() =>
+      expect(worktreeDetachAssessment).toHaveBeenCalledWith({
+        worktreePath: '/worktrees/api',
+        baseBranch: 'main',
+      }),
+    );
+  });
+
+  it('falls back to the base branch of the project when the mount carries none', async () => {
+    state.sessionMounts = {
+      'session-1': [
+        {
+          id: 'mount-1',
+          projectId: 'project-1',
+          worktreePath: '/worktrees/api',
+          lastWorktreePath: null,
+          branch: 'ak/feat',
+          baseBranch: null,
+          isAttached: true,
+          diskState: 'present',
+        },
+      ],
+    };
+    renderMenu();
+    openConfirm();
+
+    await waitFor(() =>
+      expect(worktreeDetachAssessment).toHaveBeenCalledWith({
+        worktreePath: '/worktrees/api',
+        baseBranch: 'develop',
+      }),
+    );
+  });
+
+  it('never offers removal when the merge state of the branch is unknown', async () => {
+    worktreeDetachAssessment.mockResolvedValue(
+      assessed({
+        affectedFiles: 0,
+        localOnlyCommits: 0,
+        hasUpstream: true,
+        integration: { kind: 'unknown' },
+      }),
+    );
+    renderMenu();
+    openConfirm();
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Detach and keep files' })));
+    expect(
+      screen.getByText(
+        'Whether ak/feat is merged into its base branch is unknown; detach will keep its files at /worktrees/api.',
+      ),
+    ).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Check again' })).toBeDefined();
+    expect(screen.queryByRole('button', { name: 'Detach and remove' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Detach and delete files' })).toBeNull();
+  });
+
+  it('says a clean branch has not reached its base instead of implying it landed', async () => {
+    worktreeDetachAssessment.mockResolvedValue(
+      assessed({
+        affectedFiles: 0,
+        localOnlyCommits: 0,
+        hasUpstream: true,
+        integration: { kind: 'unmerged', base: 'origin/develop', ahead: 4 },
+      }),
+    );
+    renderMenu();
+    openConfirm();
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Detach and remove' })));
+    expect(
+      screen.getByText(
+        'Remove the clean worktree at /worktrees/api: 0 uncommitted files, 0 unpushed commits, and ak/feat is not merged into origin/develop yet.',
+      ),
+    ).toBeDefined();
+    expect(screen.getByText('The branch and its commits stay in the repository.')).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: 'Detach details for api' }));
+    expect(screen.getByText('Branches not merged into the base (1)')).toBeDefined();
   });
 
   it('reports an already absent directory', async () => {
@@ -471,6 +577,7 @@ describe('ProjectDetachMenu', () => {
           worktreePath: null,
           lastWorktreePath: '/worktrees/api',
           branch: 'ak/feat',
+          baseBranch: null,
           isAttached: false,
           diskState: 'removed',
         },
@@ -501,6 +608,7 @@ describe('ProjectDetachMenu', () => {
           worktreePath: null,
           lastWorktreePath: '/worktrees/api',
           branch: 'ak/feat',
+          baseBranch: null,
           isAttached: false,
           diskState: 'present',
         },
@@ -531,6 +639,7 @@ describe('ProjectDetachMenu', () => {
           worktreePath: null,
           lastWorktreePath: '/worktrees/api',
           branch: 'ak/feat',
+          baseBranch: null,
           isAttached: false,
           diskState: 'present',
         },
@@ -561,6 +670,7 @@ describe('ProjectDetachMenu', () => {
           worktreePath: null,
           lastWorktreePath: '/worktrees/api',
           branch: 'ak/feat',
+          baseBranch: null,
           isAttached: false,
           diskState: 'removed',
         },

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectDetachMenu.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/ProjectDetachMenu.tsx
@@ -50,6 +50,7 @@ type DetachTarget = {
   readonly mountId: MountId | null;
   readonly path: string;
   readonly branch: string;
+  readonly baseBranch: string | null;
   readonly isOnDisk: boolean;
 };
 
@@ -94,6 +95,9 @@ export const ProjectDetachMenu = ({
   const isRepoProject = useAppStore(
     (state) => state.projects.find((candidate) => candidate.id === projectId)?.kind === 'repo',
   );
+  const projectBaseBranch = useAppStore(
+    (state) => state.projects.find((candidate) => candidate.id === projectId)?.baseBranch ?? null,
+  );
   const forgetMount = useAppStore((state) => state.forgetMount);
   const mountViews = useAppStore(
     useShallow((state) =>
@@ -114,12 +118,14 @@ export const ProjectDetachMenu = ({
             mountId: view.id,
             path: view.worktreePath ?? view.lastWorktreePath ?? '',
             branch: view.branch,
+            baseBranch: view.baseBranch,
             isOnDisk: view.diskState !== 'missing' && view.diskState !== 'removed',
           }))
         : projectMounts.map((mount) => ({
             mountId: mount.mountId ?? null,
             path: mount.worktreePath,
             branch: mount.branch,
+            baseBranch: mount.baseBranch ?? null,
             isOnDisk: true,
           })),
     [mountViews, projectMounts],
@@ -191,7 +197,15 @@ export const ProjectDetachMenu = ({
     const targets: ReadonlyArray<DetachTarget> =
       detachTargets.length > 0
         ? detachTargets
-        : [{ mountId: mountId ?? null, path: worktreePath, branch, isOnDisk: true }];
+        : [
+            {
+              mountId: mountId ?? null,
+              path: worktreePath,
+              branch,
+              baseBranch: projectBaseBranch,
+              isOnDisk: true,
+            },
+          ];
     void Promise.all(
       targets.map(async (target): Promise<MountAssessment> => {
         const unavailable = {
@@ -210,7 +224,10 @@ export const ProjectDetachMenu = ({
           return {
             worktreePath: target.path,
             branch: target.branch,
-            assessment: await worktreeDetachAssessment({ worktreePath: target.path }),
+            assessment: await worktreeDetachAssessment({
+              worktreePath: target.path,
+              baseBranch: target.baseBranch ?? projectBaseBranch,
+            }),
           };
         } catch {
           return unavailable;

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/RemoveWorktreeAction.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/RemoveWorktreeAction.test.tsx
@@ -2,7 +2,13 @@
 
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { MountId, ProjectId, SessionId, WorktreeDetachAssessment } from '@goodboy/types';
+import type {
+  BranchIntegration,
+  MountId,
+  ProjectId,
+  SessionId,
+  WorktreeDetachAssessment,
+} from '@goodboy/types';
 import type { MountRowView } from '../../../../../store/slices/project-mounts/mountRowModel';
 
 const { removeMountWorktree, showToast, state, worktreeDetachAssessment } = vi.hoisted(() => ({
@@ -12,6 +18,7 @@ const { removeMountWorktree, showToast, state, worktreeDetachAssessment } = vi.h
     removeMountWorktree: vi.fn(async () => ({ kind: 'removed', reason: null })),
     sessions: [{ id: 'session-1', state: { kind: 'idle' } }],
     terminalTabs: {},
+    projects: [{ id: 'project-1', kind: 'repo', baseBranch: 'develop' }],
   },
   worktreeDetachAssessment: vi.fn(),
 }));
@@ -62,14 +69,18 @@ const ROW = {
   isCompleted: true,
 } satisfies MountRowView;
 
+const MERGED = { kind: 'merged', base: 'origin/main' } satisfies BranchIntegration;
+
 type AssessmentParams = {
   readonly ignoredFiles: number;
   readonly ignoredFileSamples: ReadonlyArray<string>;
+  readonly integration?: BranchIntegration;
 };
 
 const assessment = ({
   ignoredFiles,
   ignoredFileSamples,
+  integration = MERGED,
 }: AssessmentParams): WorktreeDetachAssessment => ({
   kind: 'assessed',
   path: '/worktrees/api',
@@ -79,6 +90,7 @@ const assessment = ({
   localOnlyCommits: 0,
   ignoredFiles,
   ignoredFileSamples,
+  integration,
 });
 
 const renderAction = () =>
@@ -88,6 +100,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   state.sessions = [{ id: 'session-1', state: { kind: 'idle' } }];
   state.terminalTabs = {};
+  state.projects = [{ id: 'project-1', kind: 'repo', baseBranch: 'develop' }];
   removeMountWorktree.mockResolvedValue({ kind: 'removed', reason: null });
 });
 
@@ -125,5 +138,83 @@ describe('RemoveWorktreeAction', () => {
       }),
     );
     expect(screen.queryByText('Remove worktree?')).toBeNull();
+  });
+
+  it('asks the base the mount carries rather than assuming main', async () => {
+    worktreeDetachAssessment.mockResolvedValue(
+      assessment({ ignoredFiles: 0, ignoredFileSamples: [] }),
+    );
+    renderAction();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove the worktree for API' }));
+
+    await waitFor(() =>
+      expect(worktreeDetachAssessment).toHaveBeenCalledWith({
+        worktreePath: '/worktrees/api',
+        baseBranch: 'main',
+      }),
+    );
+  });
+
+  it('falls back to the base branch of the project when the mount carries none', async () => {
+    worktreeDetachAssessment.mockResolvedValue(
+      assessment({ ignoredFiles: 0, ignoredFileSamples: [] }),
+    );
+    render(
+      <RemoveWorktreeAction
+        sessionId={SESSION_ID}
+        row={{ ...ROW, baseBranch: null }}
+        label="API"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove the worktree for API' }));
+
+    await waitFor(() =>
+      expect(worktreeDetachAssessment).toHaveBeenCalledWith({
+        worktreePath: '/worktrees/api',
+        baseBranch: 'develop',
+      }),
+    );
+  });
+
+  it('asks before removing a clean worktree that never reached its base', async () => {
+    worktreeDetachAssessment.mockResolvedValue(
+      assessment({
+        ignoredFiles: 0,
+        ignoredFileSamples: [],
+        integration: { kind: 'unmerged', base: 'origin/main', ahead: 2 },
+      }),
+    );
+    renderAction();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove the worktree for API' }));
+
+    await waitFor(() => expect(screen.getByText('Remove worktree?')).toBeDefined());
+    expect(screen.getByText('ak/feat is not merged into origin/main yet.')).toBeDefined();
+    expect(removeMountWorktree).not.toHaveBeenCalled();
+  });
+
+  it('keeps the worktree when the merge state cannot be read', async () => {
+    worktreeDetachAssessment.mockResolvedValue(
+      assessment({
+        ignoredFiles: 0,
+        ignoredFileSamples: [],
+        integration: { kind: 'unknown' },
+      }),
+    );
+    renderAction();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove the worktree for API' }));
+
+    await waitFor(() => expect(screen.getByText('Remove worktree?')).toBeDefined());
+    expect(
+      screen.getByText(
+        'Whether ak/feat is merged into its base branch is unknown; the worktree stays until that can be read.',
+      ),
+    ).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Check again' })).toBeDefined();
+    expect(screen.queryByRole('button', { name: 'Remove worktree' })).toBeNull();
+    expect(removeMountWorktree).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/RemoveWorktreeAction.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/RemoveWorktreeAction.tsx
@@ -14,6 +14,7 @@ import {
   BLOCKER_SENTENCE,
   countLabel,
   ignoredFilesLine,
+  integrationLine,
   isMountRisky,
   measure,
 } from './detachPlan';
@@ -27,7 +28,8 @@ type Props = {
 
 type Confirm =
   | { readonly kind: 'blocked'; readonly lines: ReadonlyArray<string> }
-  | { readonly kind: 'unavailable' }
+  | { readonly kind: 'unread'; readonly lines: ReadonlyArray<string> }
+  | { readonly kind: 'unmerged'; readonly lines: ReadonlyArray<string> }
   | { readonly kind: 'risky'; readonly lines: ReadonlyArray<string> };
 
 type RemoveParams = {
@@ -35,6 +37,12 @@ type RemoveParams = {
 };
 
 const AlertIcon = CONCEPT_ICONS.errors;
+const WorktreeIcon = CONCEPT_ICONS.worktree;
+const CONFIRM_ROLE = {
+  blocked: 'alert',
+  unmerged: 'primary',
+  risky: 'danger',
+} satisfies Record<'blocked' | 'unmerged' | 'risky', 'alert' | 'primary' | 'danger'>;
 const BLOCKER_CODES = [
   'agent-running',
   'terminal-open',
@@ -42,6 +50,10 @@ const BLOCKER_CODES = [
 
 export const RemoveWorktreeAction = ({ sessionId, row, label, triggerClassName }: Props) => {
   const removeMountWorktree = useAppStore((state) => state.removeMountWorktree);
+  const projectBaseBranch = useAppStore(
+    (state) =>
+      state.projects.find((candidate) => candidate.id === row.projectId)?.baseBranch ?? null,
+  );
   const { showToast } = useToast();
   const dropdown = useDropdown({ align: 'end', width: 'w-80', expectedHeight: 170 });
   const [isChecking, setIsChecking] = useState(false);
@@ -61,6 +73,12 @@ export const RemoveWorktreeAction = ({ sessionId, row, label, triggerClassName }
   const cancel = () => {
     setConfirm(null);
     dropdown.close();
+  };
+
+  const reveal = () => {
+    if (!dropdown.open) {
+      dropdown.toggle();
+    }
   };
 
   const remove = async ({ mode }: RemoveParams) => {
@@ -97,24 +115,54 @@ export const RemoveWorktreeAction = ({ sessionId, row, label, triggerClassName }
         kind: 'blocked',
         lines: blockers.map((blocker) => BLOCKER_SENTENCE[blocker]({ projectName: label })),
       });
-      if (!dropdown.open) {
-        dropdown.toggle();
-      }
+      reveal();
       return;
     }
     setIsChecking(true);
     try {
-      const assessment = await worktreeDetachAssessment({ worktreePath });
+      const assessment = await worktreeDetachAssessment({
+        worktreePath,
+        baseBranch: row.baseBranch ?? projectBaseBranch,
+      });
       const measured = measure({ worktreePath, branch: row.branch, assessment });
       if (measured === null) {
-        setConfirm({ kind: 'unavailable' });
-        if (!dropdown.open) {
-          dropdown.toggle();
-        }
+        setConfirm({
+          kind: 'unread',
+          lines: [`The safety of the worktree at ${worktreePath} could not be verified.`],
+        });
+        reveal();
         return;
       }
-      if (measured.isAbsent || !isMountRisky({ measured })) {
+      if (measured.isAbsent) {
         await remove({ mode: 'safe' });
+        return;
+      }
+      const integration = measured.integration;
+      if (integration.kind === 'unknown') {
+        setConfirm({
+          kind: 'unread',
+          lines: [
+            `Whether ${measured.branch} is merged into its base branch is unknown; the worktree stays until that can be read.`,
+            'Check again, or set the base branch for this project in Settings.',
+          ],
+        });
+        reveal();
+        return;
+      }
+      if (!isMountRisky({ measured })) {
+        if (integration.kind === 'merged') {
+          await remove({ mode: 'safe' });
+          return;
+        }
+        setConfirm({
+          kind: 'unmerged',
+          lines: [
+            `The worktree at ${worktreePath} is clean: 0 uncommitted files and 0 unpushed commits.`,
+            `${measured.branch} is not merged into ${integration.base} yet.`,
+            'Removing the worktree deletes its directory. The branch and its commits stay in the repository.',
+          ],
+        });
+        reveal();
         return;
       }
       const files = countLabel({ count: measured.affectedFiles, singular: 'uncommitted file' });
@@ -123,17 +171,17 @@ export const RemoveWorktreeAction = ({ sessionId, row, label, triggerClassName }
         singular: measured.hasUpstream ? 'unpushed commit' : 'local-only commit',
       });
       const ignored = ignoredFilesLine({ measured: [measured] });
+      const merge = integrationLine({ measured: [measured] });
       setConfirm({
         kind: 'risky',
         lines: [
           `Removing this worktree will lose ${files} and ${commits}.`,
           ...(ignored === null ? [] : [ignored]),
+          ...(merge === null ? [] : [merge]),
           'The branch and its commits stay in the repository.',
         ],
       });
-      if (!dropdown.open) {
-        dropdown.toggle();
-      }
+      reveal();
     } catch (error) {
       showToast('error', formatError(error));
     } finally {
@@ -169,12 +217,16 @@ export const RemoveWorktreeAction = ({ sessionId, row, label, triggerClassName }
         </button>
       }
     >
-      {confirm === null ? null : confirm.kind === 'unavailable' ? (
+      {confirm === null ? null : confirm.kind === 'unread' ? (
         <div className="flex flex-col gap-2 p-3">
           <span className="text-xs font-medium">Remove worktree?</span>
-          <span className="text-2xs text-muted-foreground">
-            {`The safety of the worktree at ${worktreePath ?? label} could not be verified.`}
-          </span>
+          <div className="flex min-w-0 flex-col gap-1 text-2xs text-muted-foreground">
+            {confirm.lines.map((line) => (
+              <p key={line} className="break-words">
+                {line}
+              </p>
+            ))}
+          </div>
           <div className="flex items-center gap-1">
             <button
               type="button"
@@ -196,13 +248,21 @@ export const RemoveWorktreeAction = ({ sessionId, row, label, triggerClassName }
       ) : (
         <div className="flex flex-col p-2">
           <InlineConfirm
-            role={confirm.kind === 'blocked' ? 'alert' : 'danger'}
-            icon={<AlertIcon size={ICON_SIZE.row} />}
+            role={CONFIRM_ROLE[confirm.kind]}
+            icon={
+              confirm.kind === 'unmerged' ? (
+                <WorktreeIcon size={ICON_SIZE.row} />
+              ) : (
+                <AlertIcon size={ICON_SIZE.row} />
+              )
+            }
             title="Remove worktree?"
             confirmLabel="Remove worktree"
             isBusy={isBusy}
             isConfirmDisabled={confirm.kind === 'blocked'}
-            onConfirm={() => void remove({ mode: 'confirmed' })}
+            onConfirm={() =>
+              void remove({ mode: confirm.kind === 'unmerged' ? 'safe' : 'confirmed' })
+            }
             onCancel={() => cancel()}
           >
             <div className="flex min-w-0 flex-col gap-1 text-muted-foreground">

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/detachPlan.test.ts
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/detachPlan.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { WorktreeDetachAssessment } from '@goodboy/types';
+import type { BranchIntegration, WorktreeDetachAssessment } from '@goodboy/types';
 import {
   buildDetachPlan,
   detachActionFor,
@@ -25,6 +25,8 @@ const plan = ({
     assessments,
   });
 
+const MERGED = { kind: 'merged', base: 'origin/main' } satisfies BranchIntegration;
+
 const mount = ({
   path = '/worktrees/api',
   branch = 'ak/feat',
@@ -33,6 +35,7 @@ const mount = ({
   hasUpstream,
   ignoredFiles = 0,
   ignoredFileSamples = [],
+  integration = MERGED,
 }: {
   readonly path?: string;
   readonly branch?: string;
@@ -41,6 +44,7 @@ const mount = ({
   readonly hasUpstream: boolean;
   readonly ignoredFiles?: number;
   readonly ignoredFileSamples?: ReadonlyArray<string>;
+  readonly integration?: BranchIntegration;
 }): MountAssessment => ({
   worktreePath: path,
   branch,
@@ -53,6 +57,7 @@ const mount = ({
     localOnlyCommits,
     ignoredFiles,
     ignoredFileSamples,
+    integration,
   } satisfies WorktreeDetachAssessment,
 });
 
@@ -116,11 +121,14 @@ describe('buildDetachPlan', () => {
       lines: [
         'Remove the worktree at /worktrees/api for ak/feat, which has 1 unpushed commit.',
         '1 uncommitted file will be deleted.',
+        'ak/feat is merged into origin/main.',
         'The branch and its commits stay in the repository.',
       ],
       details: {
         totals: ['Files affected (1)', 'Unpushed commits (1)'],
-        worktrees: ['ak/feat at /worktrees/api: 1 uncommitted file, 1 unpushed commit'],
+        worktrees: [
+          'ak/feat at /worktrees/api: 1 uncommitted file, 1 unpushed commit, merged into origin/main',
+        ],
       },
     });
   });
@@ -132,11 +140,14 @@ describe('buildDetachPlan', () => {
       lines: [
         'Remove the worktree at /worktrees/api for ak/feat, which has no upstream.',
         'No uncommitted files will be deleted.',
+        'ak/feat is merged into origin/main.',
         'The branch and its commits stay in the repository.',
       ],
       details: {
         totals: ['Files affected (0)', 'Local-only commits (0)'],
-        worktrees: ['ak/feat at /worktrees/api: 0 uncommitted files, 0 local-only commits'],
+        worktrees: [
+          'ak/feat at /worktrees/api: 0 uncommitted files, 0 local-only commits, merged into origin/main',
+        ],
       },
     });
   });
@@ -160,6 +171,7 @@ describe('buildDetachPlan', () => {
         'Remove the worktree at /worktrees/api for ak/feat.',
         'No uncommitted files will be deleted.',
         '2 ignored files at risk, not tracked by git: .env.local, scratch/data.db.',
+        'ak/feat is merged into origin/main.',
         'The branch and its commits stay in the repository.',
       ],
     });
@@ -190,13 +202,14 @@ describe('buildDetachPlan', () => {
       lines: [
         'Remove 2 worktrees for api, which have 3 local-only commits and 1 branch without an upstream.',
         '3 uncommitted files will be deleted.',
+        'Every branch is merged into its base branch.',
         'The branches and their commits stay in the repository.',
       ],
       details: {
         totals: ['Files affected (3)', 'Local-only commits (3)'],
         worktrees: [
-          'ak/one at /worktrees/api-one: 2 uncommitted files, 0 unpushed commits',
-          'ak/two at /worktrees/api-two: 1 uncommitted file, 3 local-only commits',
+          'ak/one at /worktrees/api-one: 2 uncommitted files, 0 unpushed commits, merged into origin/main',
+          'ak/two at /worktrees/api-two: 1 uncommitted file, 3 local-only commits, merged into origin/main',
         ],
       },
     });
@@ -227,6 +240,7 @@ describe('buildDetachPlan', () => {
       lines: [
         'Remove 2 worktrees for api, which have 2 unpushed commits.',
         'No uncommitted files will be deleted.',
+        'Every branch is merged into its base branch.',
         'The branches and their commits stay in the repository.',
       ],
     });
@@ -257,6 +271,7 @@ describe('buildDetachPlan', () => {
       lines: [
         'Remove 2 worktrees for api, of which 2 branches have no upstream.',
         'No uncommitted files will be deleted.',
+        'Every branch is merged into its base branch.',
         'The branches and their commits stay in the repository.',
       ],
     });
@@ -285,8 +300,10 @@ describe('buildDetachPlan', () => {
     ).toEqual({
       kind: 'safe',
       lines: [
-        'Remove 2 clean worktrees for api; every branch is published, with 0 uncommitted files and 0 unpushed commits, and every branch will remain.',
+        'Remove 2 clean worktrees for api: 0 uncommitted files, 0 unpushed commits, and every branch is merged into its base branch.',
+        'The branches stay in the repository.',
       ],
+      details: { totals: [], worktrees: [] },
     });
   });
 
@@ -363,13 +380,172 @@ describe('buildDetachPlan', () => {
       lines: [
         'Remove 2 worktrees for api.',
         '2 uncommitted files will be deleted.',
+        'ak/b is merged into origin/main.',
         'The branches and their commits stay in the repository.',
       ],
       details: {
         totals: ['Files affected (2)', 'Unpushed commits (0)'],
         worktrees: [
           'ak/gone at /gone: directory already absent',
-          'ak/b at /b: 2 uncommitted files, 0 unpushed commits',
+          'ak/b at /b: 2 uncommitted files, 0 unpushed commits, merged into origin/main',
+        ],
+      },
+    });
+  });
+
+  it('keeps the files when the merge state of the only branch is unknown', () => {
+    const result = plan({
+      assessments: [
+        mount({
+          affectedFiles: 0,
+          localOnlyCommits: 0,
+          hasUpstream: true,
+          integration: { kind: 'unknown' },
+        }),
+      ],
+    });
+
+    expect(result).toEqual({
+      kind: 'keep',
+      reason: 'unverified',
+      lines: [
+        'Whether ak/feat is merged into its base branch is unknown; detach will keep its files at /worktrees/api.',
+        'Check again, or set the base branch for this project in Settings.',
+      ],
+      details: { totals: [], worktrees: [] },
+    });
+    expect(detachActionFor({ plan: result })).toMatchObject({ disposition: 'keep-files' });
+  });
+
+  it('keeps the files on an unknown merge state even when the tree is dirty', () => {
+    const result = plan({
+      assessments: [
+        mount({
+          affectedFiles: 4,
+          localOnlyCommits: 2,
+          hasUpstream: false,
+          integration: { kind: 'unknown' },
+        }),
+      ],
+    });
+
+    expect(result).toMatchObject({ kind: 'keep', reason: 'unverified' });
+    expect(detachActionFor({ plan: result })).toMatchObject({ disposition: 'keep-files' });
+  });
+
+  it('keeps every directory when one branch of several cannot be read against its base', () => {
+    expect(
+      plan({
+        assessments: [
+          mount({
+            path: '/a',
+            branch: 'ak/a',
+            affectedFiles: 0,
+            localOnlyCommits: 0,
+            hasUpstream: true,
+          }),
+          mount({
+            path: '/b',
+            branch: 'ak/b',
+            affectedFiles: 0,
+            localOnlyCommits: 0,
+            hasUpstream: true,
+            integration: { kind: 'unknown' },
+          }),
+        ],
+      }),
+    ).toEqual({
+      kind: 'keep',
+      reason: 'unverified',
+      lines: [
+        'Whether 1 branch in api reached the base branch is unknown; detach will keep every directory.',
+        'Check again, or set the base branch for this project in Settings.',
+      ],
+      details: { totals: [], worktrees: ['ak/b at /b: merge state unknown'] },
+    });
+  });
+
+  it('says a clean branch is not merged instead of calling it done', () => {
+    expect(
+      plan({
+        assessments: [
+          mount({
+            affectedFiles: 0,
+            localOnlyCommits: 0,
+            hasUpstream: true,
+            integration: { kind: 'unmerged', base: 'origin/main', ahead: 3 },
+          }),
+        ],
+      }),
+    ).toEqual({
+      kind: 'safe',
+      lines: [
+        'Remove the clean worktree at /worktrees/api: 0 uncommitted files, 0 unpushed commits, and ak/feat is not merged into origin/main yet.',
+        'The branch and its commits stay in the repository.',
+      ],
+      details: {
+        totals: ['Branches not merged into the base (1)'],
+        worktrees: ['ak/feat at /worktrees/api: not merged into origin/main'],
+      },
+    });
+  });
+
+  it('names the base the project carries rather than assuming main', () => {
+    expect(
+      plan({
+        assessments: [
+          mount({
+            affectedFiles: 0,
+            localOnlyCommits: 0,
+            hasUpstream: true,
+            integration: { kind: 'merged', base: 'origin/develop' },
+          }),
+        ],
+      }),
+    ).toEqual({
+      kind: 'safe',
+      lines: [
+        'Remove the clean worktree at /worktrees/api: 0 uncommitted files, 0 unpushed commits, and ak/feat is merged into origin/develop.',
+        'The branch stays in the repository.',
+      ],
+      details: { totals: [], worktrees: [] },
+    });
+  });
+
+  it('counts the unmerged branches in the details of a risky detach', () => {
+    expect(
+      plan({
+        assessments: [
+          mount({
+            path: '/a',
+            branch: 'ak/a',
+            affectedFiles: 1,
+            localOnlyCommits: 0,
+            hasUpstream: true,
+            integration: { kind: 'unmerged', base: 'origin/main', ahead: 2 },
+          }),
+          mount({
+            path: '/b',
+            branch: 'ak/b',
+            affectedFiles: 0,
+            localOnlyCommits: 0,
+            hasUpstream: true,
+          }),
+        ],
+      }),
+    ).toMatchObject({
+      kind: 'risky',
+      lines: [
+        'Remove 2 worktrees for api.',
+        '1 uncommitted file will be deleted.',
+        '1 branch is not merged into the base branch yet.',
+        'The branches and their commits stay in the repository.',
+      ],
+      details: {
+        totals: [
+          'Files affected (1)',
+          'Unpushed commits (0)',
+          'Branches not merged into the base (1)',
         ],
       },
     });

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/detachPlan.ts
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/detachPlan.ts
@@ -1,4 +1,4 @@
-import type { WorktreeDetachAssessment } from '@goodboy/types';
+import type { BranchIntegration, WorktreeDetachAssessment } from '@goodboy/types';
 import type { MountCleanupBlocker } from '../../../../../store/slices/mount-cleanup/cleanupPolicy';
 import type { DetachDisposition } from '../../../../../store/slices/project-mounts/detachProject';
 
@@ -17,12 +17,16 @@ export type DetachPlan =
   | { readonly kind: 'checking' }
   | {
       readonly kind: 'keep';
-      readonly reason: 'folder' | 'blocked' | 'unavailable';
+      readonly reason: 'folder' | 'blocked' | 'unavailable' | 'unverified';
       readonly lines: ReadonlyArray<string>;
       readonly details: DetachDetails;
     }
   | { readonly kind: 'missing'; readonly lines: ReadonlyArray<string> }
-  | { readonly kind: 'safe'; readonly lines: ReadonlyArray<string> }
+  | {
+      readonly kind: 'safe';
+      readonly lines: ReadonlyArray<string>;
+      readonly details: DetachDetails;
+    }
   | {
       readonly kind: 'risky';
       readonly lines: ReadonlyArray<string>;
@@ -105,13 +109,14 @@ export type Measured = {
   readonly localOnlyCommits: number;
   readonly ignoredFiles: number;
   readonly ignoredFileSamples: ReadonlyArray<string>;
+  readonly integration: BranchIntegration;
 };
 
 type MountRiskParams = {
   readonly measured: Measured;
 };
 
-type IgnoredFilesLineParams = {
+type MeasuredListParams = {
   readonly measured: ReadonlyArray<Measured>;
 };
 
@@ -129,6 +134,7 @@ export const measure = ({ branch, assessment }: MountAssessment): Measured | nul
         localOnlyCommits: 0,
         ignoredFiles: 0,
         ignoredFileSamples: [],
+        integration: { kind: 'unknown' },
       };
     case 'assessed':
       return {
@@ -140,6 +146,7 @@ export const measure = ({ branch, assessment }: MountAssessment): Measured | nul
         localOnlyCommits: assessment.localOnlyCommits,
         ignoredFiles: assessment.ignoredFiles,
         ignoredFileSamples: assessment.ignoredFileSamples,
+        integration: assessment.integration,
       };
   }
 };
@@ -151,7 +158,7 @@ export const isMountRisky = ({ measured }: MountRiskParams): boolean =>
     !measured.hasUpstream ||
     measured.ignoredFiles > 0);
 
-export const ignoredFilesLine = ({ measured }: IgnoredFilesLineParams): string | null => {
+export const ignoredFilesLine = ({ measured }: MeasuredListParams): string | null => {
   const count = measured.reduce((total, entry) => total + entry.ignoredFiles, 0);
   if (count === 0) {
     return null;
@@ -159,6 +166,92 @@ export const ignoredFilesLine = ({ measured }: IgnoredFilesLineParams): string |
   const samples = measured.flatMap((entry) => entry.ignoredFileSamples).slice(0, 5);
   const noun = countLabel({ count, singular: 'ignored file' });
   return `${noun} at risk, not tracked by git: ${samples.join(', ')}.`;
+};
+
+export const isIntegrationUnknown = ({ measured }: MountRiskParams): boolean =>
+  !measured.isAbsent && measured.integration.kind === 'unknown';
+
+const presentOf = ({ measured }: MeasuredListParams): ReadonlyArray<Measured> =>
+  measured.filter((entry) => !entry.isAbsent);
+
+const unmergedOf = ({ measured }: MeasuredListParams): ReadonlyArray<Measured> =>
+  measured.filter((entry) => entry.integration.kind === 'unmerged');
+
+const baseName = ({ base }: { readonly base: string | null }): string =>
+  base === null ? 'its base branch' : base;
+
+const baseOf = ({ measured }: MountRiskParams): string | null =>
+  measured.integration.kind === 'unknown' ? null : measured.integration.base;
+
+const integrationDetailOf = ({ measured }: MountRiskParams): string => {
+  switch (measured.integration.kind) {
+    case 'unknown':
+      return 'merge state unknown';
+    case 'merged':
+      return `merged into ${measured.integration.base}`;
+    case 'unmerged':
+      return `not merged into ${measured.integration.base}`;
+  }
+};
+
+export const integrationLine = ({ measured }: MeasuredListParams): string | null => {
+  const present = presentOf({ measured });
+  const only = present[0];
+  if (only === undefined) {
+    return null;
+  }
+  const unmerged = unmergedOf({ measured: present });
+  if (present.length === 1) {
+    const base = baseName({ base: baseOf({ measured: only }) });
+    return unmerged.length === 0
+      ? `${only.branch} is merged into ${base}.`
+      : `${only.branch} is not merged into ${base} yet.`;
+  }
+  if (unmerged.length === 0) {
+    return 'Every branch is merged into its base branch.';
+  }
+  const verb = unmerged.length === 1 ? 'is' : 'are';
+  return `${countLabel({ count: unmerged.length, singular: 'branch' })} ${verb} not merged into the base branch yet.`;
+};
+
+export const integrationDetails = ({ measured }: MeasuredListParams): DetachDetails => {
+  const present = presentOf({ measured });
+  const unmerged = unmergedOf({ measured: present });
+  if (unmerged.length === 0) {
+    return NO_DETAILS;
+  }
+  return {
+    totals: [`Branches not merged into the base (${unmerged.length})`],
+    worktrees: present.map(
+      (entry) => `${entry.branch} at ${entry.path}: ${integrationDetailOf({ measured: entry })}`,
+    ),
+  };
+};
+
+const CHECK_AGAIN_SENTENCE = 'Check again, or set the base branch for this project in Settings.';
+
+type UnverifiedParams = {
+  readonly unknown: ReadonlyArray<Measured>;
+  readonly total: number;
+  readonly projectName: string;
+};
+
+const unverifiedLines = ({
+  unknown,
+  total,
+  projectName,
+}: UnverifiedParams): ReadonlyArray<string> => {
+  const only = unknown[0];
+  if (total === 1 && only !== undefined) {
+    return [
+      `Whether ${only.branch} is merged into its base branch is unknown; detach will keep its files at ${only.path}.`,
+      CHECK_AGAIN_SENTENCE,
+    ];
+  }
+  return [
+    `Whether ${countLabel({ count: unknown.length, singular: 'branch' })} in ${projectName} reached the base branch is unknown; detach will keep every directory.`,
+    CHECK_AGAIN_SENTENCE,
+  ];
 };
 
 type CommitSingularParams = {
@@ -177,7 +270,7 @@ const perWorktreeDetail = ({ measured }: { readonly measured: Measured }): strin
     count: measured.localOnlyCommits,
     singular: commitSingular({ hasUpstream: measured.hasUpstream }),
   });
-  return `${measured.branch} at ${measured.path}: ${files}, ${commits}`;
+  return `${measured.branch} at ${measured.path}: ${files}, ${commits}, ${integrationDetailOf({ measured })}`;
 };
 
 const removalLine = ({
@@ -231,18 +324,39 @@ const retentionLine = ({ measured }: { readonly measured: ReadonlyArray<Measured
     ? 'The branch and its commits stay in the repository.'
     : 'The branches and their commits stay in the repository.';
 
-const safeLine = ({
+const safeLines = ({
   measured,
   projectName,
 }: {
   readonly measured: ReadonlyArray<Measured>;
   readonly projectName: string;
-}): string => {
-  const only = measured[0];
-  if (measured.length === 1 && only !== undefined) {
-    return `Remove the clean worktree at ${only.path}; ${only.branch} is published, with 0 uncommitted files and 0 unpushed commits, and the branch will remain.`;
+}): ReadonlyArray<string> => {
+  const present = presentOf({ measured });
+  const unmerged = unmergedOf({ measured: present });
+  const only = present[0];
+  if (present.length === 1 && only !== undefined) {
+    const base = baseName({ base: baseOf({ measured: only }) });
+    const head = `Remove the clean worktree at ${only.path}: 0 uncommitted files, 0 unpushed commits`;
+    return unmerged.length === 0
+      ? [
+          `${head}, and ${only.branch} is merged into ${base}.`,
+          'The branch stays in the repository.',
+        ]
+      : [
+          `${head}, and ${only.branch} is not merged into ${base} yet.`,
+          'The branch and its commits stay in the repository.',
+        ];
   }
-  return `Remove ${countLabel({ count: measured.length, singular: 'clean worktree' })} for ${projectName}; every branch is published, with 0 uncommitted files and 0 unpushed commits, and every branch will remain.`;
+  const head = `Remove ${countLabel({ count: present.length, singular: 'clean worktree' })} for ${projectName}: 0 uncommitted files, 0 unpushed commits`;
+  return unmerged.length === 0
+    ? [
+        `${head}, and every branch is merged into its base branch.`,
+        'The branches stay in the repository.',
+      ]
+    : [
+        `${head}, and ${countLabel({ count: unmerged.length, singular: 'branch' })} not merged into the base branch yet.`,
+        'The branches and their commits stay in the repository.',
+      ];
 };
 
 const missingLine = ({
@@ -325,26 +439,51 @@ export const buildDetachPlan = ({
   if (measured.every((entry) => entry.isAbsent)) {
     return { kind: 'missing', lines: [missingLine({ measured, projectName })] };
   }
+  const unknown = measured.filter((entry) => isIntegrationUnknown({ measured: entry }));
+  if (unknown.length > 0) {
+    return {
+      kind: 'keep',
+      reason: 'unverified',
+      lines: unverifiedLines({ unknown, total: measured.length, projectName }),
+      details: {
+        totals: [],
+        worktrees:
+          measured.length === 1
+            ? []
+            : unknown.map((entry) => `${entry.branch} at ${entry.path}: merge state unknown`),
+      },
+    };
+  }
   const isRisky = measured.some((entry) => isMountRisky({ measured: entry }));
   if (!isRisky) {
-    return { kind: 'safe', lines: [safeLine({ measured, projectName })] };
+    return {
+      kind: 'safe',
+      lines: safeLines({ measured, projectName }),
+      details: integrationDetails({ measured }),
+    };
   }
   const files = measured.reduce((total, entry) => total + entry.affectedFiles, 0);
   const commits = measured.reduce((total, entry) => total + entry.localOnlyCommits, 0);
   const hasUpstream = measured.every((entry) => entry.hasUpstream);
   const ignoredLine = ignoredFilesLine({ measured });
+  const integration = integrationLine({ measured });
+  const unmerged = unmergedOf({ measured: presentOf({ measured }) });
   return {
     kind: 'risky',
     lines: [
       removalLine({ measured, projectName }),
       lossLine({ measured }),
       ...(ignoredLine === null ? [] : [ignoredLine]),
+      ...(integration === null ? [] : [integration]),
       retentionLine({ measured }),
     ],
     details: {
       totals: [
         `Files affected (${files})`,
         hasUpstream ? `Unpushed commits (${commits})` : `Local-only commits (${commits})`,
+        ...(unmerged.length === 0
+          ? []
+          : [`Branches not merged into the base (${unmerged.length})`]),
       ],
       worktrees: measured.map((entry) => perWorktreeDetail({ measured: entry })),
     },

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/detachPlan.ts
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/ProjectMountRows/detachPlan.ts
@@ -194,6 +194,9 @@ const integrationDetailOf = ({ measured }: MountRiskParams): string => {
   }
 };
 
+const unmergedVerb = ({ count }: { readonly count: number }): string =>
+  count === 1 ? 'is' : 'are';
+
 export const integrationLine = ({ measured }: MeasuredListParams): string | null => {
   const present = presentOf({ measured });
   const only = present[0];
@@ -210,8 +213,7 @@ export const integrationLine = ({ measured }: MeasuredListParams): string | null
   if (unmerged.length === 0) {
     return 'Every branch is merged into its base branch.';
   }
-  const verb = unmerged.length === 1 ? 'is' : 'are';
-  return `${countLabel({ count: unmerged.length, singular: 'branch' })} ${verb} not merged into the base branch yet.`;
+  return `${countLabel({ count: unmerged.length, singular: 'branch' })} ${unmergedVerb({ count: unmerged.length })} not merged into the base branch yet.`;
 };
 
 export const integrationDetails = ({ measured }: MeasuredListParams): DetachDetails => {
@@ -354,7 +356,7 @@ const safeLines = ({
         'The branches stay in the repository.',
       ]
     : [
-        `${head}, and ${countLabel({ count: unmerged.length, singular: 'branch' })} not merged into the base branch yet.`,
+        `${head}, and ${countLabel({ count: unmerged.length, singular: 'branch' })} ${unmergedVerb({ count: unmerged.length })} not merged into the base branch yet.`,
         'The branches and their commits stay in the repository.',
       ];
 };

--- a/apps/desktop/src/features/worktree/worktree.ts
+++ b/apps/desktop/src/features/worktree/worktree.ts
@@ -257,12 +257,17 @@ export const removeWorktreeChecked = async ({
 
 type DetachAssessmentParams = {
   readonly worktreePath: string;
+  readonly baseBranch: string | null;
 };
 
 export const worktreeDetachAssessment = async ({
   worktreePath,
+  baseBranch,
 }: DetachAssessmentParams): Promise<WorktreeDetachAssessment> => {
-  return invoke<WorktreeDetachAssessment>('worktree_detach_assessment', { worktreePath });
+  return invoke<WorktreeDetachAssessment>('worktree_detach_assessment', {
+    worktreePath,
+    baseBranch,
+  });
 };
 
 export const gitCommonDirectory = async ({

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -234,6 +234,7 @@ export type {
 export { TASKS } from './settings';
 export type {
   BranchCommit,
+  BranchIntegration,
   DiffView,
   FastForwardResult,
   GitDistance,

--- a/packages/types/src/worktree.ts
+++ b/packages/types/src/worktree.ts
@@ -88,6 +88,11 @@ export type WorktreeRemovalResult =
 
 export type WorktreeRemovalMode = 'safe' | 'confirmed';
 
+export type BranchIntegration =
+  | { readonly kind: 'unknown' }
+  | { readonly kind: 'merged'; readonly base: string }
+  | { readonly kind: 'unmerged'; readonly base: string; readonly ahead: number };
+
 export type WorktreeDetachAssessment =
   | { readonly kind: 'missing'; readonly path: string }
   | { readonly kind: 'unavailable'; readonly path: string; readonly branch: string | null }
@@ -100,6 +105,7 @@ export type WorktreeDetachAssessment =
       readonly localOnlyCommits: number;
       readonly ignoredFiles: number;
       readonly ignoredFileSamples: ReadonlyArray<string>;
+      readonly integration: BranchIntegration;
     };
 
 export type WorktreeDirectorySize = {


### PR DESCRIPTION
"Clean" was standing in for "landed". They are not the same thing, and one of them was being used to delete a directory without asking.

## What was already there

Two of the three facts were already read by `worktree_detach_assessment`: uncommitted changes through `git status --porcelain=v2`, and committed-but-unpushed work through `rev-list --count HEAD --not --remotes`, along with at-risk ignored files. That part of the plan was already satisfied and was left alone.

## What was missing

Nothing anywhere resolved a base ref or compared the branch against it. The gap showed up in two shapes:

- `RemoveWorktreeAction` removed the directory **with no confirmation at all** when the tree was clean and published.
- `detachPlan`'s copy read "is published, with 0 uncommitted files and 0 unpushed commits, and the branch will remain". Every word true, and the sentence as a whole invited the reader to conclude the work had landed.

A branch can be clean, fully pushed, and still not merged anywhere.

## Integration against the base the project actually uses

New `BranchIntegration` in the Rust assessment: `unknown`, `merged { base }`, `unmerged { base, ahead }`. Resolution order is the base the caller passes, as `refs/remotes/origin/<b>`, then `refs/heads/<b>`, then the raw ref, and otherwise `symbolic-ref refs/remotes/origin/HEAD`.

There is no `main` fallback anywhere. If nothing resolves, the answer is unknown.

`SessionMount.baseBranch` and `Project.baseBranch` already existed and `ProjectBaseBranchInput` already wrote the latter. It needed no change: it is now the input to a check that consumes it. The copy names the base rather than implying one: "merged into origin/main", "not merged into origin/develop yet".

## Unknown is a variant, not a zero

The unknown guard runs before the risky and safe split, so it cannot fall through into either. It wins even over a dirty tree, and its only offer is to keep the files, plus a way to check again. In `RemoveWorktreeAction`, unknown renders no remove button at all, so the silent removal path is unreachable on an unknown.

A clean but unmerged branch no longer removes itself either. It asks first.

## Fit with what exists

`mountCleanupBlockers` was deliberately not extended. A blocker refuses the attempt; these facts do not refuse anything, they decide which disposition is offered. They sit alongside blockers in `buildDetachPlan`, which already consumes blockers first.

`unmountMount` was checked and left alone: it runs `git worktree remove` without `--force`, so it already refuses a dirty tree and can never force-delete.

## Tests

Seven Rust tests against throwaway repositories, including one that proves the check reads the project's base and not `main`: the same branch is merged into `develop` and one commit ahead of `main`. Fourteen TypeScript tests across the plan and the two surfaces.

`cargo fmt` was run and reverted: it reformats four pre-existing unrelated sites. Only the hunks covering these lines were applied by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
