### PR TITLE
feat(desktop): say why a merge cannot happen, and hold one write

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -26,6 +26,7 @@ import { listenBridgeCommands } from './features/companion/commandExecutor';
 import { listenProjectMaterializeRequests } from './features/session/projectMaterializeBridge';
 import { listenMountCommands } from './features/session/mountQueryBridge';
 import { startWorktreeWriterBridge } from './features/session/resolve/worktreeWriterBridge';
+import { startPrWriteBridge } from './features/review/prWriteBridge';
 import { useProviderRefreshOnFocus } from './shared/hooks/useProviderRefreshOnFocus';
 import { useZoomShortcuts } from './shared/hooks/useZoomShortcuts';
 import { useUnhandledRejectionNotice } from './shared/hooks/useUnhandledRejectionNotice';
@@ -209,6 +210,22 @@ export const App = () => {
     let off: (() => void) | undefined;
     let cancelled = false;
     void startWorktreeWriterBridge().then((fn) => {
+      if (cancelled) {
+        fn();
+        return;
+      }
+      off = fn;
+    });
+    return () => {
+      cancelled = true;
+      off?.();
+    };
+  }, []);
+
+  useEffect(() => {
+    let off: (() => void) | undefined;
+    let cancelled = false;
+    void startPrWriteBridge().then((fn) => {
       if (cancelled) {
         fn();
         return;

--- a/apps/desktop/src/features/review/components/ReviewPane/MergeReadinessNote.tsx
+++ b/apps/desktop/src/features/review/components/ReviewPane/MergeReadinessNote.tsx
@@ -1,0 +1,28 @@
+import { AlertTriangle } from 'lucide-react';
+import { ICON_SIZE } from '../../../../shared/components/conceptIcons';
+import type { PrMergeReadiness } from '../../prMergeReadiness';
+
+type Props = {
+  readonly readiness: PrMergeReadiness;
+};
+
+export const MergeReadinessNote = ({ readiness }: Props) => {
+  if (readiness.status === 'ready' && readiness.caveats.length === 0) {
+    return null;
+  }
+  return (
+    <div className="flex min-w-0 flex-col gap-1 rounded-md border border-border p-2">
+      <p className="flex min-w-0 items-start gap-1 font-semibold text-foreground">
+        <AlertTriangle size={ICON_SIZE.row} aria-hidden className="mt-px shrink-0" />
+        {readiness.reason}
+      </p>
+      {readiness.caveats.length > 0 && (
+        <ul className="flex min-w-0 flex-col gap-0.5 text-muted-foreground">
+          {readiness.caveats.map((caveat) => (
+            <li key={caveat}>{caveat}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};

--- a/apps/desktop/src/features/review/components/ReviewPane/PrActionsMenu.tsx
+++ b/apps/desktop/src/features/review/components/ReviewPane/PrActionsMenu.tsx
@@ -12,6 +12,8 @@ import { InlineConfirm, OverflowMenu, type ConfirmRole, type OverflowMenuItem } 
 import type { PullRequestState } from '@goodboy/types';
 import { ICON_SIZE } from '../../../../shared/components/conceptIcons';
 import type { PrLifecycleBusy } from '../../prLifecycle';
+import type { PrMergeReadiness } from '../../prMergeReadiness';
+import { MergeReadinessNote } from './MergeReadinessNote';
 
 type PendingAction = 'merge' | 'ready' | 'close';
 
@@ -20,6 +22,7 @@ type ConfirmSpec = {
   readonly icon: ReactNode;
   readonly title: string;
   readonly description: string;
+  readonly note?: ReactNode;
   readonly confirmLabel: string;
   readonly isConfirmDisabled: boolean;
   readonly onConfirm: () => void | Promise<void>;
@@ -28,8 +31,8 @@ type ConfirmSpec = {
 type Props = {
   readonly pr: PullRequestState;
   readonly busy: PrLifecycleBusy;
-  readonly canMerge: boolean;
-  readonly mergeReason: string;
+  readonly mergeReadiness: PrMergeReadiness;
+  readonly writeInFlight: string | null;
   readonly canCreateNew: boolean;
   readonly onMarkReady: () => void;
   readonly onConvertDraft: () => void;
@@ -42,8 +45,8 @@ type Props = {
 export const PrActionsMenu = ({
   pr,
   busy,
-  canMerge,
-  mergeReason,
+  mergeReadiness,
+  writeInFlight,
   canCreateNew,
   onMarkReady,
   onConvertDraft,
@@ -56,7 +59,8 @@ export const PrActionsMenu = ({
   const isTerminal = pr.state === 'merged' || pr.state === 'closed';
   const isClosed = pr.state === 'closed';
   const isQueued = pr.state === 'queued';
-  const isBusy = busy !== null;
+  const isBusy = busy !== null || writeInFlight !== null;
+  const isMergeBlocked = mergeReadiness.status === 'blocked';
 
   const confirms: Record<PendingAction, ConfirmSpec> = {
     merge: {
@@ -64,8 +68,9 @@ export const PrActionsMenu = ({
       icon: <GitMerge size={ICON_SIZE.row} aria-hidden />,
       title: `Squash merge #${pr.number}?`,
       description: `Every commit on ${pr.headBranch} lands on ${pr.baseBranch} as one, and GitHub closes the pull request. The branch is not deleted.`,
+      note: <MergeReadinessNote readiness={mergeReadiness} />,
       confirmLabel: busy === 'merge' ? 'Merging' : 'Confirm merge',
-      isConfirmDisabled: canMerge === false || isBusy,
+      isConfirmDisabled: isMergeBlocked || isBusy,
       onConfirm: async () => {
         await onMerge();
         setPending(null);
@@ -107,6 +112,7 @@ export const PrActionsMenu = ({
         icon={spec.icon}
         title={spec.title}
         description={spec.description}
+        note={spec.note}
         confirmLabel={spec.confirmLabel}
         onConfirm={spec.onConfirm}
         onCancel={() => setPending(null)}
@@ -124,8 +130,8 @@ export const PrActionsMenu = ({
       key: 'merge',
       label: 'Merge',
       icon: GitMerge,
-      disabled: canMerge === false || isBusy,
-      hint: mergeReason,
+      disabled: isMergeBlocked || isBusy,
+      hint: writeInFlight ?? mergeReadiness.reason,
       onClick: () => setPending('merge'),
     });
   }
@@ -136,6 +142,7 @@ export const PrActionsMenu = ({
       label: 'Mark ready',
       icon: Send,
       disabled: isBusy,
+      ...(writeInFlight !== null && { hint: writeInFlight }),
       onClick: () => setPending('ready'),
     });
   }
@@ -146,6 +153,7 @@ export const PrActionsMenu = ({
       label: 'Convert to draft',
       icon: GitPullRequestDraft,
       disabled: isBusy,
+      ...(writeInFlight !== null && { hint: writeInFlight }),
       onClick: onConvertDraft,
     });
   }
@@ -157,6 +165,7 @@ export const PrActionsMenu = ({
       icon: XCircle,
       destructive: true,
       disabled: isBusy,
+      ...(writeInFlight !== null && { hint: writeInFlight }),
       onClick: () => setPending('close'),
     });
   }
@@ -167,6 +176,7 @@ export const PrActionsMenu = ({
       label: 'Reopen',
       icon: RotateCcw,
       disabled: isBusy,
+      ...(writeInFlight !== null && { hint: writeInFlight }),
       onClick: onReopen,
     });
   }

--- a/apps/desktop/src/features/review/components/ReviewPane/PrActionsMenu.tsx
+++ b/apps/desktop/src/features/review/components/ReviewPane/PrActionsMenu.tsx
@@ -58,7 +58,6 @@ export const PrActionsMenu = ({
   const [pending, setPending] = useState<PendingAction | null>(null);
   const isTerminal = pr.state === 'merged' || pr.state === 'closed';
   const isClosed = pr.state === 'closed';
-  const isQueued = pr.state === 'queued';
   const isBusy = busy !== null || writeInFlight !== null;
   const isMergeBlocked = mergeReadiness.status === 'blocked';
 
@@ -123,9 +122,8 @@ export const PrActionsMenu = ({
     );
   }
 
-  const items: Array<OverflowMenuItem> = [];
-  if (!isTerminal && !isQueued) {
-    items.push({
+  const items: Array<OverflowMenuItem> = [
+    {
       kind: 'item',
       key: 'merge',
       label: 'Merge',
@@ -133,8 +131,8 @@ export const PrActionsMenu = ({
       disabled: isMergeBlocked || isBusy,
       hint: writeInFlight ?? mergeReadiness.reason,
       onClick: () => setPending('merge'),
-    });
-  }
+    },
+  ];
   if (!isTerminal && pr.isDraft) {
     items.push({
       kind: 'item',

--- a/apps/desktop/src/features/review/components/ReviewPane/index.test.tsx
+++ b/apps/desktop/src/features/review/components/ReviewPane/index.test.tsx
@@ -21,6 +21,7 @@ const h = vi.hoisted(() => {
     activePublicationPreview: {} as Record<string, unknown>,
     reviewDrafts: {} as Record<string, ReadonlyArray<unknown>>,
     diffComments: {} as Record<string, ReadonlyArray<unknown>>,
+    prWriteClaims: {} as Record<string, unknown>,
     reviewTargets: {} as Record<
       string,
       {
@@ -93,6 +94,7 @@ vi.mock('../../../../store/slices/worktrees/useSessionRepo', () => ({
     worktreePath: '/tmp/work',
     repoRoot: 'acme/web',
     branch: 'feature/retry',
+    projectId: 'project-1',
   }),
 }));
 vi.mock('../../../../shared/hooks/useSessionRoleModels', () => ({
@@ -227,6 +229,15 @@ const seed = () => {
   h.state.sessionSelectedPrNumber = {};
   h.state.sessionExternalTasks = {};
   h.state.branchPrs = [];
+  h.state.prWriteClaims = {};
+};
+
+const patchPr = (patch: Record<string, unknown>) => {
+  const github = h.state.sessionGithub[SESSION_ID] as { readonly pr: Record<string, unknown> };
+  h.state.sessionGithub = {
+    ...h.state.sessionGithub,
+    [SESSION_ID]: { ...github, pr: { ...github.pr, ...patch } },
+  };
 };
 
 beforeEach(() => {
@@ -378,13 +389,7 @@ describe('ReviewPane', () => {
   });
 
   it('names the branch pair the merge squashes, and what it leaves alone', () => {
-    const github = h.state.sessionGithub[SESSION_ID] as {
-      readonly pr: Record<string, unknown>;
-    };
-    h.state.sessionGithub = {
-      ...h.state.sessionGithub,
-      [SESSION_ID]: { ...github, pr: { ...github.pr, isDraft: false } },
-    };
+    patchPr({ isDraft: false });
     render(<ReviewPane session={SESSION} />);
 
     fireEvent.click(screen.getByRole('button', { name: 'PR actions' }));
@@ -397,6 +402,70 @@ describe('ReviewPane', () => {
         /Every commit on feature\/retry lands on main as one.*The branch is not deleted\./,
       ),
     ).toBeDefined();
+  });
+
+  it('refuses the merge before the press when the branch conflicts', () => {
+    patchPr({ isDraft: false, mergeable: false });
+    render(<ReviewPane session={SESSION} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'PR actions' }));
+    const merge = screen.getByRole('menuitem', { name: /^Merge/ }) as HTMLButtonElement;
+
+    expect(merge.disabled).toBe(true);
+    expect(merge.textContent).toContain('Resolve the conflicts with main first');
+
+    fireEvent.click(merge);
+    expect(screen.queryByRole('group', { name: 'Squash merge #248?' })).toBeNull();
+  });
+
+  it('draws an uncomputed mergeable as unknown rather than as the good case', () => {
+    patchPr({ isDraft: false, mergeable: null, checks: 'pending' });
+    render(<ReviewPane session={SESSION} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'PR actions' }));
+    const merge = screen.getByRole('menuitem', { name: /^Merge/ }) as HTMLButtonElement;
+
+    expect(merge.disabled).toBe(false);
+    fireEvent.click(merge);
+
+    const confirm = screen.getByRole('group', { name: 'Squash merge #248?' });
+    expect(
+      within(confirm).getByText('GitHub has not finished checking whether this branch merges'),
+    ).toBeDefined();
+    expect(within(confirm).getByText('Checks are still running')).toBeDefined();
+  });
+
+  it('names what GitHub may still refuse on a mergeable pull request', () => {
+    patchPr({ isDraft: false, mergeable: true, reviewDecision: 'review_required' });
+    render(<ReviewPane session={SESSION} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'PR actions' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: /^Merge/ }));
+
+    const confirm = screen.getByRole('group', { name: 'Squash merge #248?' });
+    expect(within(confirm).getByText('GitHub can still refuse this merge')).toBeDefined();
+    expect(within(confirm).getByText('A review is still requested')).toBeDefined();
+  });
+
+  it('holds back every write while another surface is already writing this pull request', () => {
+    patchPr({ isDraft: false });
+    h.state.prWriteClaims = {
+      'project-1#248': {
+        key: 'project-1#248',
+        windowLabel: 'win-other',
+        action: 'merge',
+        startedAt: Date.now(),
+      },
+    };
+    render(<ReviewPane session={SESSION} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'PR actions' }));
+    const merge = screen.getByRole('menuitem', { name: /^Merge/ }) as HTMLButtonElement;
+    const close = screen.getByRole('menuitem', { name: /^Close/ }) as HTMLButtonElement;
+
+    expect(merge.disabled).toBe(true);
+    expect(close.disabled).toBe(true);
+    expect(merge.textContent).toContain('Goodboy is already merging #248');
   });
 
   it('backs out of a confirm without touching GitHub', () => {

--- a/apps/desktop/src/features/review/components/ReviewPane/index.test.tsx
+++ b/apps/desktop/src/features/review/components/ReviewPane/index.test.tsx
@@ -468,6 +468,39 @@ describe('ReviewPane', () => {
     expect(merge.textContent).toContain('Goodboy is already merging #248');
   });
 
+  it('says why a merged pull request cannot merge again', () => {
+    patchPr({ state: 'merged', isDraft: false });
+    render(<ReviewPane session={SESSION} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'PR actions' }));
+    const merge = screen.getByRole('menuitem', { name: /^Merge/ }) as HTMLButtonElement;
+
+    expect(merge.disabled).toBe(true);
+    expect(merge.textContent).toContain('This pull request is already merged');
+  });
+
+  it('says a closed pull request has to come back before it merges', () => {
+    patchPr({ state: 'closed', isDraft: false });
+    render(<ReviewPane session={SESSION} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'PR actions' }));
+    const merge = screen.getByRole('menuitem', { name: /^Merge/ }) as HTMLButtonElement;
+
+    expect(merge.disabled).toBe(true);
+    expect(merge.textContent).toContain('Reopen this pull request before merging');
+  });
+
+  it('says GitHub already owns the merge once it is set to go', () => {
+    patchPr({ state: 'queued', isDraft: false });
+    render(<ReviewPane session={SESSION} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'PR actions' }));
+    const merge = screen.getByRole('menuitem', { name: /^Merge/ }) as HTMLButtonElement;
+
+    expect(merge.disabled).toBe(true);
+    expect(merge.textContent).toContain('GitHub is already set to merge this pull request');
+  });
+
   it('backs out of a confirm without touching GitHub', () => {
     render(<ReviewPane session={SESSION} />);
 

--- a/apps/desktop/src/features/review/components/ReviewPane/index.tsx
+++ b/apps/desktop/src/features/review/components/ReviewPane/index.tsx
@@ -11,6 +11,7 @@ import type {
 import { EMPTY_ARRAY, useAppStore, useDiffComments } from '../../../../store';
 import { reviewThreadId } from '../../../../store/slices/review-navigation';
 import { selectActiveProjectPrs } from '../../../../store/slices/github/activeProjectPrs';
+import { selectPrWrite } from '../../../../store/slices/pr-writes/selectPrWrite';
 import { useSessionRepo } from '../../../../store/slices/worktrees/useSessionRepo';
 import { useToast } from '../../../../app/components/Toast';
 import { StudioDetailLayout } from '../../../../shared/components/StudioDetail';
@@ -20,7 +21,12 @@ import { openUrl } from '../../../../shared/lib/editor';
 import { GithubConnectionEmptyState } from '../../../github/components/GithubConnectionEmptyState';
 import { useGithubConnection } from '../../../integrations/github/useGithubConnection';
 import { usePrDraftAgentRunning } from '../../../github/usePrDraftAgentRunning';
-import { PR_LIFECYCLE_FAILURE_LABEL, type PrLifecycleBusy } from '../../prLifecycle';
+import {
+  PR_LIFECYCLE_FAILURE_LABEL,
+  describePrWriteInFlight,
+  type PrLifecycleBusy,
+} from '../../prLifecycle';
+import { evaluatePrMergeReadiness } from '../../prMergeReadiness';
 import { buildCommentAgentArgs } from '../../../chat/spawn-from-comment';
 import { kindRouting } from '../../../session/agent-kind';
 import { useSessionRoleModels } from '../../../../shared/hooks/useSessionRoleModels';
@@ -98,6 +104,9 @@ export const ReviewPane = ({ session, eyebrow }: Props) => {
   }, [branchPrs, canonicalPr]);
   const pr =
     prOptions.find((candidate) => candidate.number === selectedPrNumber) ?? canonicalPr ?? null;
+  const prWriteTarget =
+    pr === null || repo === null ? null : { projectId: repo.projectId, prNumber: pr.number };
+  const prWriteClaim = useAppStore((s) => selectPrWrite({ state: s, target: prWriteTarget }));
 
   useEffect(() => {
     void loadResolveSession({ sessionId });
@@ -243,14 +252,12 @@ export const ReviewPane = ({ session, eyebrow }: Props) => {
     );
   }
 
-  const isTerminal = pr.state === 'merged' || pr.state === 'closed';
   const isClosed = pr.state === 'closed';
-  const canMerge = !isTerminal && !pr.isDraft && pr.mergeable !== false;
-  const mergeReason = pr.isDraft
-    ? 'mark the PR ready before merging'
-    : pr.mergeable === false
-      ? 'PR has conflicts, resolve them first'
-      : 'squash merge this PR';
+  const mergeReadiness = evaluatePrMergeReadiness({ pr });
+  const writeInFlight =
+    prWriteClaim === null
+      ? null
+      : describePrWriteInFlight({ action: prWriteClaim.action, prNumber: pr.number });
 
   const header = (
     <PrContextRow
@@ -263,8 +270,8 @@ export const ReviewPane = ({ session, eyebrow }: Props) => {
         <PrActionsMenu
           pr={pr}
           busy={lifecycleBusy}
-          canMerge={canMerge}
-          mergeReason={mergeReason}
+          mergeReadiness={mergeReadiness}
+          writeInFlight={writeInFlight}
           canCreateNew={!isDraftAgentRunning}
           onMarkReady={() => void runLifecycle('ready', () => markPrReady(sessionId, pr.number))}
           onConvertDraft={() =>

--- a/apps/desktop/src/features/review/prLifecycle.ts
+++ b/apps/desktop/src/features/review/prLifecycle.ts
@@ -9,3 +9,19 @@ export const PR_LIFECYCLE_FAILURE_LABEL: Record<PrLifecycleAction, string> = {
   close: 'Close failed',
   reopen: 'Reopen failed',
 };
+
+const PR_LIFECYCLE_GERUND: Record<PrLifecycleAction, string> = {
+  ready: 'marking ready',
+  undraft: 'converting to draft',
+  merge: 'merging',
+  close: 'closing',
+  reopen: 'reopening',
+};
+
+export const describePrWriteInFlight = ({
+  action,
+  prNumber,
+}: {
+  readonly action: PrLifecycleAction;
+  readonly prNumber: number;
+}): string => `Goodboy is already ${PR_LIFECYCLE_GERUND[action]} #${prNumber}`;

--- a/apps/desktop/src/features/review/prMergeReadiness.test.ts
+++ b/apps/desktop/src/features/review/prMergeReadiness.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import type { PullRequestState } from '@goodboy/types';
+import { evaluatePrMergeReadiness } from './prMergeReadiness';
+
+const pullRequest = (patch: Partial<PullRequestState> = {}): PullRequestState => ({
+  number: 248,
+  title: 'Retry failed requests',
+  url: 'https://github.com/acme/web/pull/248',
+  state: 'open',
+  mergeable: true,
+  checks: 'success',
+  baseBranch: 'main',
+  headBranch: 'feature/retry',
+  isDraft: false,
+  reviewDecision: 'approved',
+  body: '',
+  updatedAt: '2026-01-01T00:00:00Z',
+  ...patch,
+});
+
+describe('evaluatePrMergeReadiness', () => {
+  it('clears a mergeable pull request with nothing outstanding', () => {
+    const readiness = evaluatePrMergeReadiness({ pr: pullRequest() });
+
+    expect(readiness.status).toBe('ready');
+    expect(readiness.caveats).toEqual([]);
+  });
+
+  it('names the base branch when the head conflicts', () => {
+    const readiness = evaluatePrMergeReadiness({ pr: pullRequest({ mergeable: false }) });
+
+    expect(readiness.status).toBe('blocked');
+    expect(readiness.reason).toBe('Resolve the conflicts with main first');
+  });
+
+  it('blocks a draft, a closed, a merged and a queued pull request', () => {
+    expect(evaluatePrMergeReadiness({ pr: pullRequest({ isDraft: true }) }).reason).toBe(
+      'Mark this pull request ready before merging',
+    );
+    expect(evaluatePrMergeReadiness({ pr: pullRequest({ state: 'closed' }) }).reason).toBe(
+      'Reopen this pull request before merging',
+    );
+    expect(evaluatePrMergeReadiness({ pr: pullRequest({ state: 'merged' }) }).reason).toBe(
+      'This pull request is already merged',
+    );
+    expect(evaluatePrMergeReadiness({ pr: pullRequest({ state: 'queued' }) }).reason).toBe(
+      'GitHub is already set to merge this pull request',
+    );
+  });
+
+  it('reads an uncomputed mergeable as unknown, never as ready and never as blocked', () => {
+    const readiness = evaluatePrMergeReadiness({ pr: pullRequest({ mergeable: null }) });
+
+    expect(readiness.status).toBe('unknown');
+    expect(readiness.reason).toBe('GitHub has not finished checking whether this branch merges');
+  });
+
+  it('keeps the caveats of an unknown pull request', () => {
+    const readiness = evaluatePrMergeReadiness({
+      pr: pullRequest({ mergeable: null, checks: 'failure', reviewDecision: 'review_required' }),
+    });
+
+    expect(readiness.status).toBe('unknown');
+    expect(readiness.caveats).toEqual(['A review is still requested', 'Checks are failing']);
+  });
+
+  it('lets a mergeable pull request through while naming what GitHub may refuse', () => {
+    const readiness = evaluatePrMergeReadiness({
+      pr: pullRequest({ checks: 'pending', reviewDecision: 'changes_requested' }),
+    });
+
+    expect(readiness.status).toBe('ready');
+    expect(readiness.reason).toBe('GitHub can still refuse this merge');
+    expect(readiness.caveats).toEqual(['A reviewer asked for changes', 'Checks are still running']);
+  });
+
+  it('says nothing about checks a repository does not run', () => {
+    const readiness = evaluatePrMergeReadiness({ pr: pullRequest({ checks: null }) });
+
+    expect(readiness.caveats).toEqual([]);
+  });
+});

--- a/apps/desktop/src/features/review/prMergeReadiness.ts
+++ b/apps/desktop/src/features/review/prMergeReadiness.ts
@@ -1,0 +1,68 @@
+import type { PullRequestState } from '@goodboy/types';
+
+export type PrMergeReadiness = {
+  readonly status: 'ready' | 'unknown' | 'blocked';
+  readonly reason: string;
+  readonly caveats: ReadonlyArray<string>;
+};
+
+const NO_CAVEATS: ReadonlyArray<string> = [];
+
+const READY_REASON = 'Squash merge this pull request';
+const UNKNOWN_REASON = 'GitHub has not finished checking whether this branch merges';
+const CAVEAT_REASON = 'GitHub can still refuse this merge';
+
+const blockingReason = ({ pr }: { readonly pr: PullRequestState }): string | null => {
+  if (pr.state === 'merged') {
+    return 'This pull request is already merged';
+  }
+  if (pr.state === 'closed') {
+    return 'Reopen this pull request before merging';
+  }
+  if (pr.state === 'queued') {
+    return 'GitHub is already set to merge this pull request';
+  }
+  if (pr.isDraft) {
+    return 'Mark this pull request ready before merging';
+  }
+  if (pr.mergeable === false) {
+    return `Resolve the conflicts with ${pr.baseBranch} first`;
+  }
+  return null;
+};
+
+const mergeCaveats = ({ pr }: { readonly pr: PullRequestState }): ReadonlyArray<string> => {
+  const caveats: Array<string> = [];
+  if (pr.reviewDecision === 'changes_requested') {
+    caveats.push('A reviewer asked for changes');
+  }
+  if (pr.reviewDecision === 'review_required') {
+    caveats.push('A review is still requested');
+  }
+  if (pr.checks === 'failure') {
+    caveats.push('Checks are failing');
+  }
+  if (pr.checks === 'pending') {
+    caveats.push('Checks are still running');
+  }
+  return caveats;
+};
+
+export const evaluatePrMergeReadiness = ({
+  pr,
+}: {
+  readonly pr: PullRequestState;
+}): PrMergeReadiness => {
+  const blocked = blockingReason({ pr });
+  if (blocked !== null) {
+    return { status: 'blocked', reason: blocked, caveats: NO_CAVEATS };
+  }
+  const caveats = mergeCaveats({ pr });
+  if (pr.mergeable === null) {
+    return { status: 'unknown', reason: UNKNOWN_REASON, caveats };
+  }
+  if (caveats.length > 0) {
+    return { status: 'ready', reason: CAVEAT_REASON, caveats };
+  }
+  return { status: 'ready', reason: READY_REASON, caveats: NO_CAVEATS };
+};

--- a/apps/desktop/src/features/review/prWriteBridge.ts
+++ b/apps/desktop/src/features/review/prWriteBridge.ts
@@ -1,0 +1,18 @@
+import type { UnlistenFn } from '@tauri-apps/api/event';
+import { useAppStore } from '../../store/store';
+import { listenPrWrites } from './prWriteBus';
+
+const SWEEP_INTERVAL_MS = 30_000;
+
+export const startPrWriteBridge = async (): Promise<UnlistenFn> => {
+  const unlisten = await listenPrWrites((announcement) => {
+    useAppStore.getState().notePrWrite(announcement);
+  });
+  const timer = setInterval(() => {
+    useAppStore.getState().sweepPrWriteClaims();
+  }, SWEEP_INTERVAL_MS);
+  return () => {
+    clearInterval(timer);
+    unlisten();
+  };
+};

--- a/apps/desktop/src/features/review/prWriteBus.ts
+++ b/apps/desktop/src/features/review/prWriteBus.ts
@@ -1,0 +1,30 @@
+import { emit, listen, type UnlistenFn } from '@tauri-apps/api/event';
+import type { PrLifecycleAction } from './prLifecycle';
+
+const PR_WRITE_EVENT = 'goodboy:pr-write';
+
+export type PrWriteAnnouncement = {
+  readonly kind: 'claimed' | 'released';
+  readonly key: string;
+  readonly windowLabel: string;
+  readonly action: PrLifecycleAction;
+  readonly startedAt: number;
+};
+
+const inTauri = (): boolean => typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window;
+
+export const announcePrWrite = async (announcement: PrWriteAnnouncement): Promise<void> => {
+  if (!inTauri()) {
+    return;
+  }
+  await emit(PR_WRITE_EVENT, announcement).catch(() => undefined);
+};
+
+export const listenPrWrites = async (
+  onAnnouncement: (announcement: PrWriteAnnouncement) => void,
+): Promise<UnlistenFn> => {
+  if (!inTauri()) {
+    return () => undefined;
+  }
+  return listen<PrWriteAnnouncement>(PR_WRITE_EVENT, (event) => onAnnouncement(event.payload));
+};

--- a/apps/desktop/src/features/review/prWriteBus.ts
+++ b/apps/desktop/src/features/review/prWriteBus.ts
@@ -6,6 +6,7 @@ const PR_WRITE_EVENT = 'goodboy:pr-write';
 export type PrWriteAnnouncement = {
   readonly kind: 'claimed' | 'released';
   readonly key: string;
+  readonly token: string;
   readonly windowLabel: string;
   readonly action: PrLifecycleAction;
   readonly startedAt: number;

--- a/apps/desktop/src/store/sessionEviction.ts
+++ b/apps/desktop/src/store/sessionEviction.ts
@@ -183,6 +183,7 @@ export const NON_SESSION_STATE_KEYS = [
   'slackThreadHeads',
   'slackThreads',
   'retainedWorktreePaths',
+  'prWriteClaims',
 ] as const satisfies ReadonlyArray<keyof AppState>;
 
 type RegisteredKey =

--- a/apps/desktop/src/store/slices/github/closePr.ts
+++ b/apps/desktop/src/store/slices/github/closePr.ts
@@ -2,6 +2,7 @@ import type { SessionId } from '@goodboy/types';
 import { tauriGhRunner } from '../../../features/github/github';
 import { getSessionRepo } from '../worktrees/getSessionRepo';
 import { prEventPayload } from './prEventPayload';
+import { withPrWriteClaim } from './withPrWriteClaim';
 import type { GetFn, SetFn } from './types';
 
 export const closePr = (_set: SetFn, get: GetFn) => {
@@ -19,24 +20,32 @@ export const closePr = (_set: SetFn, get: GetFn) => {
     if (repo == null) {
       return;
     }
-    const res = await tauriGhRunner.run(['pr', 'close', String(num)], {
-      cwd: repo.repoRoot,
-      workspaceId: session.workspaceId,
+    await withPrWriteClaim({
+      get,
       projectId: repo.projectId,
-    });
-    if (res.exitCode !== 0) {
-      const errMsg = res.stderr.trim() || `gh pr close exited with ${res.exitCode}`;
-      void get().emitNotification('error', 'error', `Close of #${num} failed`, errMsg, {
-        sessionId,
-        workspaceId: workspace.id,
-      });
-      throw new Error(errMsg);
-    }
-    await get().refreshSessionPr(sessionId, { force: true });
-    await get().recordSessionEventOnce({
-      sessionId,
-      kind: 'pr_closed',
-      payload: prEventPayload({ number: num, pr: get().sessionGithub[sessionId]?.pr ?? null }),
+      prNumber: num,
+      action: 'close',
+      run: async () => {
+        const res = await tauriGhRunner.run(['pr', 'close', String(num)], {
+          cwd: repo.repoRoot,
+          workspaceId: session.workspaceId,
+          projectId: repo.projectId,
+        });
+        if (res.exitCode !== 0) {
+          const errMsg = res.stderr.trim() || `gh pr close exited with ${res.exitCode}`;
+          void get().emitNotification('error', 'error', `Close of #${num} failed`, errMsg, {
+            sessionId,
+            workspaceId: workspace.id,
+          });
+          throw new Error(errMsg);
+        }
+        await get().refreshSessionPr(sessionId, { force: true });
+        await get().recordSessionEventOnce({
+          sessionId,
+          kind: 'pr_closed',
+          payload: prEventPayload({ number: num, pr: get().sessionGithub[sessionId]?.pr ?? null }),
+        });
+      },
     });
   };
 };

--- a/apps/desktop/src/store/slices/github/convertPrToDraft.ts
+++ b/apps/desktop/src/store/slices/github/convertPrToDraft.ts
@@ -1,6 +1,7 @@
 import type { SessionId } from '@goodboy/types';
 import { tauriGhRunner } from '../../../features/github/github';
 import { getSessionRepo } from '../worktrees/getSessionRepo';
+import { withPrWriteClaim } from './withPrWriteClaim';
 import type { GetFn, SetFn } from './types';
 
 export const convertPrToDraft = (_set: SetFn, get: GetFn) => {
@@ -18,19 +19,27 @@ export const convertPrToDraft = (_set: SetFn, get: GetFn) => {
     if (repo == null) {
       return;
     }
-    const res = await tauriGhRunner.run(['pr', 'ready', String(num), '--undo'], {
-      cwd: repo.repoRoot,
-      workspaceId: session.workspaceId,
+    await withPrWriteClaim({
+      get,
       projectId: repo.projectId,
+      prNumber: num,
+      action: 'undraft',
+      run: async () => {
+        const res = await tauriGhRunner.run(['pr', 'ready', String(num), '--undo'], {
+          cwd: repo.repoRoot,
+          workspaceId: session.workspaceId,
+          projectId: repo.projectId,
+        });
+        if (res.exitCode !== 0) {
+          const errMsg = res.stderr.trim() || `gh pr ready --undo exited with ${res.exitCode}`;
+          void get().emitNotification('error', 'error', 'Convert to draft failed', errMsg, {
+            sessionId,
+            workspaceId: workspace.id,
+          });
+          throw new Error(errMsg);
+        }
+        await get().refreshSessionPr(sessionId, { force: true });
+      },
     });
-    if (res.exitCode !== 0) {
-      const errMsg = res.stderr.trim() || `gh pr ready --undo exited with ${res.exitCode}`;
-      void get().emitNotification('error', 'error', 'Convert to draft failed', errMsg, {
-        sessionId,
-        workspaceId: workspace.id,
-      });
-      throw new Error(errMsg);
-    }
-    await get().refreshSessionPr(sessionId, { force: true });
   };
 };

--- a/apps/desktop/src/store/slices/github/markPrReady.ts
+++ b/apps/desktop/src/store/slices/github/markPrReady.ts
@@ -2,6 +2,7 @@ import type { SessionId } from '@goodboy/types';
 import { tauriGhRunner } from '../../../features/github/github';
 import { getSessionRepo } from '../worktrees/getSessionRepo';
 import { prEventPayload } from './prEventPayload';
+import { withPrWriteClaim } from './withPrWriteClaim';
 import type { GetFn, SetFn } from './types';
 
 export const markPrReady = (_set: SetFn, get: GetFn) => {
@@ -19,24 +20,32 @@ export const markPrReady = (_set: SetFn, get: GetFn) => {
     if (repo == null) {
       return;
     }
-    const res = await tauriGhRunner.run(['pr', 'ready', String(num)], {
-      cwd: repo.repoRoot,
-      workspaceId: session.workspaceId,
+    await withPrWriteClaim({
+      get,
       projectId: repo.projectId,
-    });
-    if (res.exitCode !== 0) {
-      const errMsg = res.stderr.trim() || `gh pr ready exited with ${res.exitCode}`;
-      void get().emitNotification('error', 'error', 'Mark ready failed', errMsg, {
-        sessionId,
-        workspaceId: workspace.id,
-      });
-      throw new Error(errMsg);
-    }
-    await get().refreshSessionPr(sessionId, { force: true });
-    await get().recordSessionEventOnce({
-      sessionId,
-      kind: 'pr_ready',
-      payload: prEventPayload({ number: num, pr: get().sessionGithub[sessionId]?.pr ?? null }),
+      prNumber: num,
+      action: 'ready',
+      run: async () => {
+        const res = await tauriGhRunner.run(['pr', 'ready', String(num)], {
+          cwd: repo.repoRoot,
+          workspaceId: session.workspaceId,
+          projectId: repo.projectId,
+        });
+        if (res.exitCode !== 0) {
+          const errMsg = res.stderr.trim() || `gh pr ready exited with ${res.exitCode}`;
+          void get().emitNotification('error', 'error', 'Mark ready failed', errMsg, {
+            sessionId,
+            workspaceId: workspace.id,
+          });
+          throw new Error(errMsg);
+        }
+        await get().refreshSessionPr(sessionId, { force: true });
+        await get().recordSessionEventOnce({
+          sessionId,
+          kind: 'pr_ready',
+          payload: prEventPayload({ number: num, pr: get().sessionGithub[sessionId]?.pr ?? null }),
+        });
+      },
     });
   };
 };

--- a/apps/desktop/src/store/slices/github/mergePr.ts
+++ b/apps/desktop/src/store/slices/github/mergePr.ts
@@ -2,10 +2,9 @@ import type { PrMergeMethod, SessionId } from '@goodboy/types';
 import { tauriGhRunner } from '../../../features/github/github';
 import { getSessionRepo } from '../worktrees/getSessionRepo';
 import { prEventPayload } from './prEventPayload';
+import { withPrWriteClaim } from './withPrWriteClaim';
 import type { GetFn, SetFn } from './types';
 
-// `gh pr merge` takes exactly one strategy flag. Squash is the desktop default
-// (unchanged from before the method param existed).
 const MERGE_FLAG: Record<PrMergeMethod, string> = {
   squash: '--squash',
   merge: '--merge',
@@ -27,24 +26,32 @@ export const mergePr = (_set: SetFn, get: GetFn) => {
     if (repo == null) {
       return;
     }
-    const res = await tauriGhRunner.run(['pr', 'merge', String(num), MERGE_FLAG[method]], {
-      cwd: repo.repoRoot,
-      workspaceId: session.workspaceId,
+    await withPrWriteClaim({
+      get,
       projectId: repo.projectId,
-    });
-    if (res.exitCode !== 0) {
-      const errMsg = res.stderr.trim() || `gh pr merge exited with ${res.exitCode}`;
-      void get().emitNotification('error', 'error', `Merge of #${num} failed`, errMsg, {
-        sessionId,
-        workspaceId: workspace.id,
-      });
-      throw new Error(errMsg);
-    }
-    await get().refreshSessionPr(sessionId, { force: true });
-    await get().recordSessionEventOnce({
-      sessionId,
-      kind: 'pr_merged',
-      payload: prEventPayload({ number: num, pr: get().sessionGithub[sessionId]?.pr ?? null }),
+      prNumber: num,
+      action: 'merge',
+      run: async () => {
+        const res = await tauriGhRunner.run(['pr', 'merge', String(num), MERGE_FLAG[method]], {
+          cwd: repo.repoRoot,
+          workspaceId: session.workspaceId,
+          projectId: repo.projectId,
+        });
+        if (res.exitCode !== 0) {
+          const errMsg = res.stderr.trim() || `gh pr merge exited with ${res.exitCode}`;
+          void get().emitNotification('error', 'error', `Merge of #${num} failed`, errMsg, {
+            sessionId,
+            workspaceId: workspace.id,
+          });
+          throw new Error(errMsg);
+        }
+        await get().refreshSessionPr(sessionId, { force: true });
+        await get().recordSessionEventOnce({
+          sessionId,
+          kind: 'pr_merged',
+          payload: prEventPayload({ number: num, pr: get().sessionGithub[sessionId]?.pr ?? null }),
+        });
+      },
     });
   };
 };

--- a/apps/desktop/src/store/slices/github/reopenPr.ts
+++ b/apps/desktop/src/store/slices/github/reopenPr.ts
@@ -1,6 +1,7 @@
 import type { SessionId } from '@goodboy/types';
 import { tauriGhRunner } from '../../../features/github/github';
 import { getSessionRepo } from '../worktrees/getSessionRepo';
+import { withPrWriteClaim } from './withPrWriteClaim';
 import type { GetFn, SetFn } from './types';
 
 export const reopenPr = (_set: SetFn, get: GetFn) => {
@@ -18,19 +19,27 @@ export const reopenPr = (_set: SetFn, get: GetFn) => {
     if (repo == null) {
       return;
     }
-    const res = await tauriGhRunner.run(['pr', 'reopen', String(num)], {
-      cwd: repo.repoRoot,
-      workspaceId: session.workspaceId,
+    await withPrWriteClaim({
+      get,
       projectId: repo.projectId,
+      prNumber: num,
+      action: 'reopen',
+      run: async () => {
+        const res = await tauriGhRunner.run(['pr', 'reopen', String(num)], {
+          cwd: repo.repoRoot,
+          workspaceId: session.workspaceId,
+          projectId: repo.projectId,
+        });
+        if (res.exitCode !== 0) {
+          const errMsg = res.stderr.trim() || `gh pr reopen exited with ${res.exitCode}`;
+          void get().emitNotification('error', 'error', `Reopen of #${num} failed`, errMsg, {
+            sessionId,
+            workspaceId: workspace.id,
+          });
+          throw new Error(errMsg);
+        }
+        await get().refreshSessionPr(sessionId, { force: true });
+      },
     });
-    if (res.exitCode !== 0) {
-      const errMsg = res.stderr.trim() || `gh pr reopen exited with ${res.exitCode}`;
-      void get().emitNotification('error', 'error', `Reopen of #${num} failed`, errMsg, {
-        sessionId,
-        workspaceId: workspace.id,
-      });
-      throw new Error(errMsg);
-    }
-    await get().refreshSessionPr(sessionId, { force: true });
   };
 };

--- a/apps/desktop/src/store/slices/github/withPrWriteClaim.test.ts
+++ b/apps/desktop/src/store/slices/github/withPrWriteClaim.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ProjectId } from '@goodboy/types';
+
+const hoisted = vi.hoisted(() => ({
+  announcePrWrite: vi.fn<(announcement: unknown) => Promise<void>>(async () => undefined),
+  currentWindowLabel: vi.fn(() => 'win-here'),
+}));
+
+vi.mock('../../../features/review/prWriteBus', () => ({
+  announcePrWrite: hoisted.announcePrWrite,
+}));
+vi.mock('../../../features/workspace/window', () => ({
+  currentWindowLabel: hoisted.currentWindowLabel,
+}));
+
+import { createPrWritesSlice } from '../pr-writes';
+import { PR_WRITE_CLAIM_TTL_MS, prWritesInitialState } from '../pr-writes/state';
+import { withPrWriteClaim } from './withPrWriteClaim';
+import type { GetFn, SetFn } from './types';
+
+const PROJECT_ID = 'project-1' as ProjectId;
+const TARGET = { projectId: PROJECT_ID, prNumber: 248 };
+
+const harness = () => {
+  let state: Record<string, unknown> = { ...prWritesInitialState };
+  const set = ((patch: unknown) => {
+    const next =
+      typeof patch === 'function'
+        ? (patch as (s: Record<string, unknown>) => object)(state)
+        : patch;
+    state = { ...state, ...(next as object) };
+  }) as unknown as SetFn;
+  const get = (() => state) as unknown as GetFn;
+  state = { ...state, ...createPrWritesSlice(set, get) };
+  return { get };
+};
+
+type PendingRun = {
+  readonly run: () => Promise<void>;
+  readonly settle: () => void;
+};
+
+const pendingRun = (): PendingRun => {
+  let release: (() => void) | null = null;
+  const promise = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  return {
+    run: () => promise,
+    settle: () => release?.(),
+  };
+};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-09-11T10:00:00.000Z'));
+  hoisted.announcePrWrite.mockClear();
+  hoisted.currentWindowLabel.mockReturnValue('win-here');
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('withPrWriteClaim', () => {
+  it('refuses a second write while the first is still running', async () => {
+    const { get } = harness();
+    const first = pendingRun();
+    const running = withPrWriteClaim({ get, ...TARGET, action: 'merge', run: first.run });
+    await Promise.resolve();
+
+    await expect(
+      withPrWriteClaim({ get, ...TARGET, action: 'close', run: async () => undefined }),
+    ).rejects.toThrow('Goodboy is already merging #248');
+
+    first.settle();
+    await running;
+  });
+
+  it('frees the pull request once the write settles', async () => {
+    const { get } = harness();
+    await withPrWriteClaim({ get, ...TARGET, action: 'merge', run: async () => undefined });
+
+    await expect(
+      withPrWriteClaim({ get, ...TARGET, action: 'close', run: async () => undefined }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('frees the pull request when the write fails', async () => {
+    const { get } = harness();
+    await expect(
+      withPrWriteClaim({
+        get,
+        ...TARGET,
+        action: 'merge',
+        run: async () => {
+          throw new Error('gh pr merge exited with 1');
+        },
+      }),
+    ).rejects.toThrow('gh pr merge exited with 1');
+
+    await expect(
+      withPrWriteClaim({ get, ...TARGET, action: 'close', run: async () => undefined }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('keeps the second write protected when the first one outlives the ttl', async () => {
+    const { get } = harness();
+    const first = pendingRun();
+    const second = pendingRun();
+
+    const merging = withPrWriteClaim({ get, ...TARGET, action: 'merge', run: first.run });
+    await Promise.resolve();
+
+    vi.advanceTimersByTime(PR_WRITE_CLAIM_TTL_MS);
+
+    const closing = withPrWriteClaim({ get, ...TARGET, action: 'close', run: second.run });
+    await Promise.resolve();
+
+    first.settle();
+    await merging;
+
+    await expect(
+      withPrWriteClaim({ get, ...TARGET, action: 'ready', run: async () => undefined }),
+    ).rejects.toThrow('Goodboy is already closing #248');
+
+    second.settle();
+    await closing;
+  });
+});

--- a/apps/desktop/src/store/slices/github/withPrWriteClaim.ts
+++ b/apps/desktop/src/store/slices/github/withPrWriteClaim.ts
@@ -25,6 +25,6 @@ export const withPrWriteClaim = async ({
   try {
     await run();
   } finally {
-    get().releasePrWrite({ projectId, prNumber });
+    get().releasePrWrite({ projectId, prNumber, token: claimed.token });
   }
 };

--- a/apps/desktop/src/store/slices/github/withPrWriteClaim.ts
+++ b/apps/desktop/src/store/slices/github/withPrWriteClaim.ts
@@ -1,0 +1,30 @@
+import {
+  describePrWriteInFlight,
+  type PrLifecycleAction,
+} from '../../../features/review/prLifecycle';
+import type { PrWriteTarget } from '../pr-writes/types';
+import type { GetFn } from './types';
+
+type Params = PrWriteTarget & {
+  readonly get: GetFn;
+  readonly action: PrLifecycleAction;
+  readonly run: () => Promise<void>;
+};
+
+export const withPrWriteClaim = async ({
+  get,
+  projectId,
+  prNumber,
+  action,
+  run,
+}: Params): Promise<void> => {
+  const claimed = get().claimPrWrite({ projectId, prNumber, action });
+  if (!claimed.ok) {
+    throw new Error(describePrWriteInFlight({ action: claimed.claim.action, prNumber }));
+  }
+  try {
+    await run();
+  } finally {
+    get().releasePrWrite({ projectId, prNumber });
+  }
+};

--- a/apps/desktop/src/store/slices/pr-writes/claimPrWrite.ts
+++ b/apps/desktop/src/store/slices/pr-writes/claimPrWrite.ts
@@ -1,0 +1,20 @@
+import { announcePrWrite } from '../../../features/review/prWriteBus';
+import { currentWindowLabel } from '../../../features/workspace/window';
+import { liveClaim } from './liveClaim';
+import { prWriteKey } from './prWriteKey';
+import type { ClaimPrWriteParams, GetFn, PrWriteClaimResult, SetFn } from './types';
+
+export const claimPrWrite = (set: SetFn, get: GetFn) => {
+  return ({ projectId, prNumber, action }: ClaimPrWriteParams): PrWriteClaimResult => {
+    const key = prWriteKey({ projectId, prNumber });
+    const now = Date.now();
+    const held = liveClaim({ claim: get().prWriteClaims[key], now });
+    if (held !== null) {
+      return { ok: false, claim: held };
+    }
+    const claim = { key, windowLabel: currentWindowLabel(), action, startedAt: now };
+    set((state) => ({ prWriteClaims: { ...state.prWriteClaims, [key]: claim } }));
+    void announcePrWrite({ kind: 'claimed', ...claim });
+    return { ok: true };
+  };
+};

--- a/apps/desktop/src/store/slices/pr-writes/claimPrWrite.ts
+++ b/apps/desktop/src/store/slices/pr-writes/claimPrWrite.ts
@@ -4,6 +4,19 @@ import { liveClaim } from './liveClaim';
 import { prWriteKey } from './prWriteKey';
 import type { ClaimPrWriteParams, GetFn, PrWriteClaimResult, SetFn } from './types';
 
+let nextSequence = 0;
+
+const freshToken = ({
+  windowLabel,
+  now,
+}: {
+  readonly windowLabel: string;
+  readonly now: number;
+}): string => {
+  nextSequence += 1;
+  return `${windowLabel}-${now}-${nextSequence}`;
+};
+
 export const claimPrWrite = (set: SetFn, get: GetFn) => {
   return ({ projectId, prNumber, action }: ClaimPrWriteParams): PrWriteClaimResult => {
     const key = prWriteKey({ projectId, prNumber });
@@ -12,9 +25,16 @@ export const claimPrWrite = (set: SetFn, get: GetFn) => {
     if (held !== null) {
       return { ok: false, claim: held };
     }
-    const claim = { key, windowLabel: currentWindowLabel(), action, startedAt: now };
+    const windowLabel = currentWindowLabel();
+    const claim = {
+      key,
+      token: freshToken({ windowLabel, now }),
+      windowLabel,
+      action,
+      startedAt: now,
+    };
     set((state) => ({ prWriteClaims: { ...state.prWriteClaims, [key]: claim } }));
     void announcePrWrite({ kind: 'claimed', ...claim });
-    return { ok: true };
+    return { ok: true, token: claim.token };
   };
 };

--- a/apps/desktop/src/store/slices/pr-writes/index.test.ts
+++ b/apps/desktop/src/store/slices/pr-writes/index.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ProjectId } from '@goodboy/types';
+import type { PrWriteAnnouncement } from '../../../features/review/prWriteBus';
+
+const hoisted = vi.hoisted(() => ({
+  announcePrWrite: vi.fn<(announcement: unknown) => Promise<void>>(async () => undefined),
+  currentWindowLabel: vi.fn(() => 'win-here'),
+}));
+
+vi.mock('../../../features/review/prWriteBus', () => ({
+  announcePrWrite: hoisted.announcePrWrite,
+}));
+vi.mock('../../../features/workspace/window', () => ({
+  currentWindowLabel: hoisted.currentWindowLabel,
+}));
+
+import { createPrWritesSlice } from './index';
+import { PR_WRITE_CLAIM_TTL_MS, prWritesInitialState, type PrWritesState } from './state';
+import { selectPrWrite } from './selectPrWrite';
+import type { GetFn, SetFn } from './types';
+
+const PROJECT_ID = 'project-1' as ProjectId;
+const TARGET = { projectId: PROJECT_ID, prNumber: 248 };
+
+const harness = () => {
+  let state: Record<string, unknown> = { ...prWritesInitialState };
+  const set = ((patch: unknown) => {
+    const next =
+      typeof patch === 'function'
+        ? (patch as (s: Record<string, unknown>) => object)(state)
+        : patch;
+    state = { ...state, ...(next as object) };
+  }) as unknown as SetFn;
+  const get = (() => state) as unknown as GetFn;
+  const slice = createPrWritesSlice(set, get);
+  state = { ...state, ...slice };
+  return {
+    slice,
+    read: (): PrWritesState => state as unknown as PrWritesState,
+  };
+};
+
+const announcementFrom = (call: number): PrWriteAnnouncement =>
+  hoisted.announcePrWrite.mock.calls[call]?.[0] as PrWriteAnnouncement;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-09-11T10:00:00.000Z'));
+  hoisted.announcePrWrite.mockClear();
+  hoisted.currentWindowLabel.mockReturnValue('win-here');
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('pr writes slice', () => {
+  it('grants a free pull request and tells the other windows', () => {
+    const { slice, read } = harness();
+
+    expect(slice.claimPrWrite({ ...TARGET, action: 'merge' })).toEqual({ ok: true });
+    expect(read().prWriteClaims['project-1#248']?.action).toBe('merge');
+    expect(announcementFrom(0).kind).toBe('claimed');
+    expect(announcementFrom(0).key).toBe('project-1#248');
+  });
+
+  it('refuses a second write on the same pull request and names the one in flight', () => {
+    const { slice } = harness();
+    slice.claimPrWrite({ ...TARGET, action: 'merge' });
+
+    const second = slice.claimPrWrite({ ...TARGET, action: 'close' });
+
+    expect(second.ok).toBe(false);
+    expect(second.ok === false && second.claim.action).toBe('merge');
+  });
+
+  it('leaves a different pull request of the same project alone', () => {
+    const { slice } = harness();
+    slice.claimPrWrite({ ...TARGET, action: 'merge' });
+
+    expect(slice.claimPrWrite({ projectId: PROJECT_ID, prNumber: 249, action: 'merge' })).toEqual({
+      ok: true,
+    });
+  });
+
+  it('frees the pull request on release and announces it', () => {
+    const { slice, read } = harness();
+    slice.claimPrWrite({ ...TARGET, action: 'merge' });
+
+    slice.releasePrWrite(TARGET);
+
+    expect(read().prWriteClaims['project-1#248']).toBeUndefined();
+    expect(announcementFrom(1).kind).toBe('released');
+    expect(slice.claimPrWrite({ ...TARGET, action: 'close' })).toEqual({ ok: true });
+  });
+
+  it('never releases a claim another window holds', () => {
+    const { slice, read } = harness();
+    slice.notePrWrite({
+      kind: 'claimed',
+      key: 'project-1#248',
+      windowLabel: 'win-other',
+      action: 'merge',
+      startedAt: Date.now(),
+    });
+
+    slice.releasePrWrite(TARGET);
+
+    expect(read().prWriteClaims['project-1#248']?.windowLabel).toBe('win-other');
+  });
+
+  it('refuses a write another window announced', () => {
+    const { slice } = harness();
+    slice.notePrWrite({
+      kind: 'claimed',
+      key: 'project-1#248',
+      windowLabel: 'win-other',
+      action: 'close',
+      startedAt: Date.now(),
+    });
+
+    expect(slice.claimPrWrite({ ...TARGET, action: 'merge' }).ok).toBe(false);
+  });
+
+  it('ignores a release announced by a window that does not hold the claim', () => {
+    const { slice, read } = harness();
+    slice.claimPrWrite({ ...TARGET, action: 'merge' });
+
+    slice.notePrWrite({
+      kind: 'released',
+      key: 'project-1#248',
+      windowLabel: 'win-other',
+      action: 'merge',
+      startedAt: Date.now(),
+    });
+
+    expect(read().prWriteClaims['project-1#248']?.windowLabel).toBe('win-here');
+  });
+
+  it('lets a claim expire so a dead window cannot wedge the pull request', () => {
+    const { slice, read } = harness();
+    slice.claimPrWrite({ ...TARGET, action: 'merge' });
+
+    vi.advanceTimersByTime(PR_WRITE_CLAIM_TTL_MS);
+    expect(slice.claimPrWrite({ ...TARGET, action: 'close' })).toEqual({ ok: true });
+
+    slice.releasePrWrite(TARGET);
+    slice.notePrWrite({
+      kind: 'claimed',
+      key: 'project-1#249',
+      windowLabel: 'win-other',
+      action: 'merge',
+      startedAt: Date.now(),
+    });
+    vi.advanceTimersByTime(PR_WRITE_CLAIM_TTL_MS);
+    slice.sweepPrWriteClaims();
+
+    expect(read().prWriteClaims).toEqual({});
+  });
+
+  it('reads back the claim a surface should show, and nothing without a target', () => {
+    const { slice, read } = harness();
+    slice.claimPrWrite({ ...TARGET, action: 'merge' });
+
+    expect(selectPrWrite({ state: read(), target: TARGET })?.action).toBe('merge');
+    expect(selectPrWrite({ state: read(), target: null })).toBeNull();
+  });
+});

--- a/apps/desktop/src/store/slices/pr-writes/index.test.ts
+++ b/apps/desktop/src/store/slices/pr-writes/index.test.ts
@@ -58,7 +58,7 @@ describe('pr writes slice', () => {
   it('grants a free pull request and tells the other windows', () => {
     const { slice, read } = harness();
 
-    expect(slice.claimPrWrite({ ...TARGET, action: 'merge' })).toEqual({ ok: true });
+    expect(slice.claimPrWrite({ ...TARGET, action: 'merge' }).ok).toBe(true);
     expect(read().prWriteClaims['project-1#248']?.action).toBe('merge');
     expect(announcementFrom(0).kind).toBe('claimed');
     expect(announcementFrom(0).key).toBe('project-1#248');
@@ -78,20 +78,29 @@ describe('pr writes slice', () => {
     const { slice } = harness();
     slice.claimPrWrite({ ...TARGET, action: 'merge' });
 
-    expect(slice.claimPrWrite({ projectId: PROJECT_ID, prNumber: 249, action: 'merge' })).toEqual({
-      ok: true,
-    });
+    expect(slice.claimPrWrite({ projectId: PROJECT_ID, prNumber: 249, action: 'merge' }).ok).toBe(
+      true,
+    );
   });
 
   it('frees the pull request on release and announces it', () => {
     const { slice, read } = harness();
-    slice.claimPrWrite({ ...TARGET, action: 'merge' });
+    const claimed = slice.claimPrWrite({ ...TARGET, action: 'merge' });
 
-    slice.releasePrWrite(TARGET);
+    slice.releasePrWrite({ ...TARGET, token: claimed.ok ? claimed.token : '' });
 
     expect(read().prWriteClaims['project-1#248']).toBeUndefined();
     expect(announcementFrom(1).kind).toBe('released');
-    expect(slice.claimPrWrite({ ...TARGET, action: 'close' })).toEqual({ ok: true });
+    expect(slice.claimPrWrite({ ...TARGET, action: 'close' }).ok).toBe(true);
+  });
+
+  it('never frees a claim the caller does not hold', () => {
+    const { slice, read } = harness();
+    slice.claimPrWrite({ ...TARGET, action: 'merge' });
+
+    slice.releasePrWrite({ ...TARGET, token: 'win-here-0-0' });
+
+    expect(read().prWriteClaims['project-1#248']?.action).toBe('merge');
   });
 
   it('never releases a claim another window holds', () => {
@@ -99,12 +108,13 @@ describe('pr writes slice', () => {
     slice.notePrWrite({
       kind: 'claimed',
       key: 'project-1#248',
+      token: 'win-other-1',
       windowLabel: 'win-other',
       action: 'merge',
       startedAt: Date.now(),
     });
 
-    slice.releasePrWrite(TARGET);
+    slice.releasePrWrite({ ...TARGET, token: 'win-here-1' });
 
     expect(read().prWriteClaims['project-1#248']?.windowLabel).toBe('win-other');
   });
@@ -114,6 +124,7 @@ describe('pr writes slice', () => {
     slice.notePrWrite({
       kind: 'claimed',
       key: 'project-1#248',
+      token: 'win-other-1',
       windowLabel: 'win-other',
       action: 'close',
       startedAt: Date.now(),
@@ -122,13 +133,14 @@ describe('pr writes slice', () => {
     expect(slice.claimPrWrite({ ...TARGET, action: 'merge' }).ok).toBe(false);
   });
 
-  it('ignores a release announced by a window that does not hold the claim', () => {
+  it('ignores a release announced against a claim that is no longer the one held', () => {
     const { slice, read } = harness();
     slice.claimPrWrite({ ...TARGET, action: 'merge' });
 
     slice.notePrWrite({
       kind: 'released',
       key: 'project-1#248',
+      token: 'win-other-1',
       windowLabel: 'win-other',
       action: 'merge',
       startedAt: Date.now(),
@@ -142,12 +154,14 @@ describe('pr writes slice', () => {
     slice.claimPrWrite({ ...TARGET, action: 'merge' });
 
     vi.advanceTimersByTime(PR_WRITE_CLAIM_TTL_MS);
-    expect(slice.claimPrWrite({ ...TARGET, action: 'close' })).toEqual({ ok: true });
+    const second = slice.claimPrWrite({ ...TARGET, action: 'close' });
+    expect(second.ok).toBe(true);
 
-    slice.releasePrWrite(TARGET);
+    slice.releasePrWrite({ ...TARGET, token: second.ok ? second.token : '' });
     slice.notePrWrite({
       kind: 'claimed',
       key: 'project-1#249',
+      token: 'win-other-1',
       windowLabel: 'win-other',
       action: 'merge',
       startedAt: Date.now(),

--- a/apps/desktop/src/store/slices/pr-writes/index.ts
+++ b/apps/desktop/src/store/slices/pr-writes/index.ts
@@ -1,0 +1,14 @@
+import { claimPrWrite } from './claimPrWrite';
+import { notePrWrite } from './notePrWrite';
+import { releasePrWrite } from './releasePrWrite';
+import { prWritesInitialState } from './state';
+import { sweepPrWriteClaims } from './sweepPrWriteClaims';
+import type { GetFn, PrWritesSlice, SetFn } from './types';
+
+export const createPrWritesSlice = (set: SetFn, get: GetFn): PrWritesSlice => ({
+  ...prWritesInitialState,
+  claimPrWrite: claimPrWrite(set, get),
+  releasePrWrite: releasePrWrite(set, get),
+  notePrWrite: notePrWrite(set),
+  sweepPrWriteClaims: sweepPrWriteClaims(set),
+});

--- a/apps/desktop/src/store/slices/pr-writes/liveClaim.ts
+++ b/apps/desktop/src/store/slices/pr-writes/liveClaim.ts
@@ -1,0 +1,18 @@
+import { PR_WRITE_CLAIM_TTL_MS } from './state';
+import type { PrWriteClaim } from './types';
+
+export const liveClaim = ({
+  claim,
+  now,
+}: {
+  readonly claim: PrWriteClaim | undefined;
+  readonly now: number;
+}): PrWriteClaim | null => {
+  if (claim === undefined) {
+    return null;
+  }
+  if (now - claim.startedAt >= PR_WRITE_CLAIM_TTL_MS) {
+    return null;
+  }
+  return claim;
+};

--- a/apps/desktop/src/store/slices/pr-writes/notePrWrite.ts
+++ b/apps/desktop/src/store/slices/pr-writes/notePrWrite.ts
@@ -6,18 +6,14 @@ export const notePrWrite = (set: SetFn) => {
     set((state) => {
       const current = state.prWriteClaims[announcement.key];
       if (announcement.kind === 'released') {
-        if (current === undefined || current.windowLabel !== announcement.windowLabel) {
+        if (current === undefined || current.token !== announcement.token) {
           return {};
         }
         const next = { ...state.prWriteClaims };
         delete next[announcement.key];
         return { prWriteClaims: next };
       }
-      if (
-        current !== undefined &&
-        current.windowLabel === announcement.windowLabel &&
-        current.startedAt === announcement.startedAt
-      ) {
+      if (current !== undefined && current.token === announcement.token) {
         return {};
       }
       return {
@@ -25,6 +21,7 @@ export const notePrWrite = (set: SetFn) => {
           ...state.prWriteClaims,
           [announcement.key]: {
             key: announcement.key,
+            token: announcement.token,
             windowLabel: announcement.windowLabel,
             action: announcement.action,
             startedAt: announcement.startedAt,

--- a/apps/desktop/src/store/slices/pr-writes/notePrWrite.ts
+++ b/apps/desktop/src/store/slices/pr-writes/notePrWrite.ts
@@ -1,0 +1,36 @@
+import type { PrWriteAnnouncement } from '../../../features/review/prWriteBus';
+import type { SetFn } from './types';
+
+export const notePrWrite = (set: SetFn) => {
+  return (announcement: PrWriteAnnouncement): void => {
+    set((state) => {
+      const current = state.prWriteClaims[announcement.key];
+      if (announcement.kind === 'released') {
+        if (current === undefined || current.windowLabel !== announcement.windowLabel) {
+          return {};
+        }
+        const next = { ...state.prWriteClaims };
+        delete next[announcement.key];
+        return { prWriteClaims: next };
+      }
+      if (
+        current !== undefined &&
+        current.windowLabel === announcement.windowLabel &&
+        current.startedAt === announcement.startedAt
+      ) {
+        return {};
+      }
+      return {
+        prWriteClaims: {
+          ...state.prWriteClaims,
+          [announcement.key]: {
+            key: announcement.key,
+            windowLabel: announcement.windowLabel,
+            action: announcement.action,
+            startedAt: announcement.startedAt,
+          },
+        },
+      };
+    });
+  };
+};

--- a/apps/desktop/src/store/slices/pr-writes/prWriteKey.ts
+++ b/apps/desktop/src/store/slices/pr-writes/prWriteKey.ts
@@ -1,0 +1,4 @@
+import type { PrWriteTarget } from './types';
+
+export const prWriteKey = ({ projectId, prNumber }: PrWriteTarget): string =>
+  `${projectId}#${prNumber}`;

--- a/apps/desktop/src/store/slices/pr-writes/releasePrWrite.ts
+++ b/apps/desktop/src/store/slices/pr-writes/releasePrWrite.ts
@@ -1,0 +1,20 @@
+import { announcePrWrite } from '../../../features/review/prWriteBus';
+import { currentWindowLabel } from '../../../features/workspace/window';
+import { prWriteKey } from './prWriteKey';
+import type { GetFn, PrWriteTarget, SetFn } from './types';
+
+export const releasePrWrite = (set: SetFn, get: GetFn) => {
+  return ({ projectId, prNumber }: PrWriteTarget): void => {
+    const key = prWriteKey({ projectId, prNumber });
+    const claim = get().prWriteClaims[key];
+    if (claim === undefined || claim.windowLabel !== currentWindowLabel()) {
+      return;
+    }
+    set((state) => {
+      const next = { ...state.prWriteClaims };
+      delete next[key];
+      return { prWriteClaims: next };
+    });
+    void announcePrWrite({ kind: 'released', ...claim });
+  };
+};

--- a/apps/desktop/src/store/slices/pr-writes/releasePrWrite.ts
+++ b/apps/desktop/src/store/slices/pr-writes/releasePrWrite.ts
@@ -1,13 +1,12 @@
 import { announcePrWrite } from '../../../features/review/prWriteBus';
-import { currentWindowLabel } from '../../../features/workspace/window';
 import { prWriteKey } from './prWriteKey';
-import type { GetFn, PrWriteTarget, SetFn } from './types';
+import type { GetFn, ReleasePrWriteParams, SetFn } from './types';
 
 export const releasePrWrite = (set: SetFn, get: GetFn) => {
-  return ({ projectId, prNumber }: PrWriteTarget): void => {
+  return ({ projectId, prNumber, token }: ReleasePrWriteParams): void => {
     const key = prWriteKey({ projectId, prNumber });
     const claim = get().prWriteClaims[key];
-    if (claim === undefined || claim.windowLabel !== currentWindowLabel()) {
+    if (claim === undefined || claim.token !== token) {
       return;
     }
     set((state) => {

--- a/apps/desktop/src/store/slices/pr-writes/selectPrWrite.ts
+++ b/apps/desktop/src/store/slices/pr-writes/selectPrWrite.ts
@@ -1,0 +1,16 @@
+import type { AppState } from '../../types';
+import { prWriteKey } from './prWriteKey';
+import type { PrWriteClaim, PrWriteTarget } from './types';
+
+export const selectPrWrite = ({
+  state,
+  target,
+}: {
+  readonly state: Pick<AppState, 'prWriteClaims'>;
+  readonly target: PrWriteTarget | null;
+}): PrWriteClaim | null => {
+  if (target === null) {
+    return null;
+  }
+  return state.prWriteClaims[prWriteKey(target)] ?? null;
+};

--- a/apps/desktop/src/store/slices/pr-writes/state.ts
+++ b/apps/desktop/src/store/slices/pr-writes/state.ts
@@ -1,0 +1,11 @@
+import type { PrWriteClaim } from './types';
+
+export const PR_WRITE_CLAIM_TTL_MS = 120_000;
+
+export type PrWritesState = {
+  readonly prWriteClaims: Readonly<Record<string, PrWriteClaim>>;
+};
+
+export const prWritesInitialState: PrWritesState = {
+  prWriteClaims: {},
+};

--- a/apps/desktop/src/store/slices/pr-writes/sweepPrWriteClaims.ts
+++ b/apps/desktop/src/store/slices/pr-writes/sweepPrWriteClaims.ts
@@ -1,0 +1,16 @@
+import { liveClaim } from './liveClaim';
+import type { SetFn } from './types';
+
+export const sweepPrWriteClaims = (set: SetFn) => {
+  return (): void => {
+    const now = Date.now();
+    set((state) => {
+      const entries = Object.entries(state.prWriteClaims);
+      const live = entries.filter(([, claim]) => liveClaim({ claim, now }) !== null);
+      if (live.length === entries.length) {
+        return {};
+      }
+      return { prWriteClaims: Object.fromEntries(live) };
+    });
+  };
+};

--- a/apps/desktop/src/store/slices/pr-writes/types.ts
+++ b/apps/desktop/src/store/slices/pr-writes/types.ts
@@ -7,6 +7,7 @@ export type { GetFn, SetFn } from '../../slice-types';
 
 export type PrWriteClaim = {
   readonly key: string;
+  readonly token: string;
   readonly windowLabel: string;
   readonly action: PrLifecycleAction;
   readonly startedAt: number;
@@ -21,12 +22,17 @@ export type ClaimPrWriteParams = PrWriteTarget & {
   readonly action: PrLifecycleAction;
 };
 
+export type ReleasePrWriteParams = PrWriteTarget & {
+  readonly token: string;
+};
+
 export type PrWriteClaimResult =
-  { readonly ok: true } | { readonly ok: false; readonly claim: PrWriteClaim };
+  | { readonly ok: true; readonly token: string }
+  | { readonly ok: false; readonly claim: PrWriteClaim };
 
 export type PrWritesSlice = PrWritesState & {
   claimPrWrite(params: ClaimPrWriteParams): PrWriteClaimResult;
-  releasePrWrite(params: PrWriteTarget): void;
+  releasePrWrite(params: ReleasePrWriteParams): void;
   notePrWrite(announcement: PrWriteAnnouncement): void;
   sweepPrWriteClaims(): void;
 };

--- a/apps/desktop/src/store/slices/pr-writes/types.ts
+++ b/apps/desktop/src/store/slices/pr-writes/types.ts
@@ -1,0 +1,32 @@
+import type { ProjectId } from '@goodboy/types';
+import type { PrLifecycleAction } from '../../../features/review/prLifecycle';
+import type { PrWriteAnnouncement } from '../../../features/review/prWriteBus';
+import type { PrWritesState } from './state';
+
+export type { GetFn, SetFn } from '../../slice-types';
+
+export type PrWriteClaim = {
+  readonly key: string;
+  readonly windowLabel: string;
+  readonly action: PrLifecycleAction;
+  readonly startedAt: number;
+};
+
+export type PrWriteTarget = {
+  readonly projectId: ProjectId;
+  readonly prNumber: number;
+};
+
+export type ClaimPrWriteParams = PrWriteTarget & {
+  readonly action: PrLifecycleAction;
+};
+
+export type PrWriteClaimResult =
+  { readonly ok: true } | { readonly ok: false; readonly claim: PrWriteClaim };
+
+export type PrWritesSlice = PrWritesState & {
+  claimPrWrite(params: ClaimPrWriteParams): PrWriteClaimResult;
+  releasePrWrite(params: PrWriteTarget): void;
+  notePrWrite(announcement: PrWriteAnnouncement): void;
+  sweepPrWriteClaims(): void;
+};

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -187,6 +187,8 @@ import { createProjectMountsSlice } from './slices/project-mounts';
 import { projectMountsInitialState } from './slices/project-mounts/state';
 import { createMountCleanupSlice, mountCleanupInitialState } from './slices/mount-cleanup';
 import { createPrSeriesSlice, prSeriesInitialState } from './slices/pr-series';
+import { createPrWritesSlice } from './slices/pr-writes';
+import { prWritesInitialState } from './slices/pr-writes/state';
 import type {
   CreatePrSeriesInput,
   LoadPrSeriesInput,
@@ -954,7 +956,8 @@ type AppActions = {
 export type AppStore = AppState &
   AppActions &
   ReturnType<typeof createResolveSlice> &
-  ReturnType<typeof createReviewNavigationSlice>;
+  ReturnType<typeof createReviewNavigationSlice> &
+  ReturnType<typeof createPrWritesSlice>;
 
 export const initialState: AppState = {
   ...initialUpdaterState,
@@ -1010,6 +1013,7 @@ export const initialState: AppState = {
   ...projectMountsInitialState,
   ...mountCleanupInitialState,
   ...prSeriesInitialState,
+  ...prWritesInitialState,
   sessionLanguageAnchor: {},
   sessionActiveProject: {},
   sessionBranches: {},
@@ -1139,6 +1143,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
   ...createProjectMountsSlice(set, get),
   ...createMountCleanupSlice(set, get),
   ...createPrSeriesSlice(set, get),
+  ...createPrWritesSlice(set, get),
   ...createPresenceSlice(set, get),
   ...createTurnSlice(set, get),
   ...createWorktreesSlice(set, get),

--- a/apps/desktop/src/store/types.ts
+++ b/apps/desktop/src/store/types.ts
@@ -4,6 +4,7 @@ import type { OrphanWorktree } from '../features/worktree/worktree';
 import type { StorageStats } from './slices/storage';
 import type { MountCleanupState } from './slices/mount-cleanup/state';
 import type { PrSeriesState } from './slices/pr-series/state';
+import type { PrWritesState } from './slices/pr-writes/state';
 import type { Notification, NotificationCounts, TelemetrySummary } from '@goodboy/db';
 import type {
   Agent,
@@ -220,6 +221,7 @@ export type PendingOrchestration = {
 
 type AppSliceState = ResolveState &
   ReviewNavigationState &
+  PrWritesState &
   UpdaterState &
   ChangelogState &
   SlackThreadsSliceState &


### PR DESCRIPTION
Two problems under one intervention: a merge control that could not say why it would fail, and pull request writes that nothing serialized across windows.

## Why a merge cannot happen, before you press it

`prMergeReadiness` derives the answer once and passes it down, rather than each surface recomputing it.

**Blocked**, control disabled with the reason in the hint: already merged, closed, queued with GitHub's merge queue, still a draft, or `mergeable === false`, which names the base branch.

**Caveats**, which do not block and are named in the confirm instead: a review requested, changes requested, checks failing, checks pending. These are deliberately not blocks. GitHub decides which checks and reviews branch protection actually requires, and `PullRequestState` cannot see protection rules. Presenting them as blocks would be inventing a product fact we do not have.

**Unknown** when `mergeable` is null, which is what GitHub returns while it is still computing. The item stays enabled, because disabling it would be a lie in the other direction, and the confirm says GitHub has not finished checking. Unknown is never rendered as either the good case or the bad one.

## One write at a time per pull request

What existed: `runLifecycle` guarded one component instance in one window. The five store actions had no guard at all. And the companion calls `store.mergePr` directly, bypassing `runLifecycle` entirely, so a merge from the phone and a merge from the desktop had no mutual exclusion whatsoever.

A claim keyed `${projectId}#${prNumber}` is announced on the Tauri global bus that presence already uses, and applied in every window. It lives in `withPrWriteClaim` inside the store actions, not in the UI, so the companion is covered too. Review disables every write while a claim stands and names it: "Goodboy is already merging #248".

Per pull request, not per session: a session can hold several pull requests, and per-session would block closing one while merging another.

## Why there is no Rust lock

`spawnWorkspaceWindow` uses `new WebviewWindow`, so every window is a webview of one Tauri process. A Rust registry and the Tauri event bus therefore have exactly the same scope, and the only thing a lock would add is atomicity: it closes a race of a few milliseconds between two clicks on one machine with one keyboard.

The existing `worktree_writer` lease is the wrong instrument at every level. Its key is a canonicalized filesystem path, which a pull request does not have. Its steal rule fires on exactly the shape a pull request write would take. And taking it would queue a merge behind a running agent turn, or stop an agent from starting.

The cost is asymmetric. A duplicated `gh pr merge` returns "already merged" through the failure path that already exists. A stuck lock leaves a control nothing can unstick, which is the class of defect an earlier investigation this cycle already had to rule out once.

**Residual race, stated rather than hidden:** two windows claiming inside the event round trip both proceed, and the loser gets GitHub's own refusal through the existing error path. A window opened during an in-flight write does not learn about it. A window killed mid-write leaves a claim that expires after 120 seconds and is swept; bounded and visible, never permanent. None of this protects against a second operating system process.

Error handling is untouched: a refused claim throws into `PR_LIFECYCLE_FAILURE_LABEL`, so it reads "Merge failed: Goodboy is already merging #248".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
